### PR TITLE
Enforce bus contracts for cortex pipeline

### DIFF
--- a/orion/core/bus/CONTRACT_MAP.md
+++ b/orion/core/bus/CONTRACT_MAP.md
@@ -1,0 +1,54 @@
+# Orion Cognitive Bus Contract (Authoritative)
+
+This file is the single source of truth for cognitive bus contracts. All services **must** use the channel and kind constants defined in [`contracts.py`](./contracts.py).
+
+## Channels
+
+| Flow | Channel (intake) | Reply prefix |
+| ---- | ---------------- | ------------ |
+| Client → Cortex-Orch | `orion-cortex:request` | `orion-cortex:reply:` |
+| Orch → Cortex-Exec | `orion-cortex-exec:request` | `orion-cortex-exec:reply:` |
+| Exec → LLM Gateway | `orion-exec:request:LLMGatewayService` | caller-provided |
+| Exec → Recall | `orion-exec:request:RecallService` | caller-provided |
+| Exec → Agent Chain | `orion-exec:request:AgentChainService` | caller-provided |
+| Exec → Planner React | `orion-exec:request:PlannerReactService` | caller-provided |
+| Exec → Agent Council | `orion-exec:request:AgentCouncilService` | caller-provided |
+
+Reply channels **must** be `reply_prefix + correlation_id`.
+
+## Envelope kinds
+
+| Kind | Purpose |
+| ---- | ------- |
+| `cortex.orch.request` / `cortex.orch.result` | Client ↔ Orch RPC |
+| `cortex.exec.request` / `cortex.exec.result` | Orch ↔ Exec RPC |
+| `llm.chat.request` / `llm.chat.result` | Exec ↔ LLM Gateway |
+| `recall.query.request` / `recall.query.result` | Exec ↔ Recall |
+| `agent.chain.request` / `agent.chain.result` | Exec ↔ Agent Chain |
+| `agent.planner.request` / `agent.planner.result` | Exec ↔ Planner React |
+| `agent.council.request` / `agent.council.result` | Exec ↔ Council |
+
+## Correlation + reply rules
+
+- Every envelope carries `id`, `correlation_id`, `reply_to`, and `causality_chain`.
+- Callers **must** set `reply_to` on the ingress envelope. Services publish responses to that channel; they **must not** invent new reply destinations.
+- Services derive child envelopes by preserving the parent `correlation_id` and extending `causality_chain`.
+
+## Payload contracts (high level)
+
+- **LLM Gateway** (`llm.chat.request`): `ChatRequestPayload` (model/messages/options/user_id/session_id). Response: `ChatResultPayload`.
+- **Recall** (`recall.query.request`): `RecallRequestPayload` (query_text, max_items, time_window_days, mode, tags, user_id, session_id, trace_id). Response: `RecallResultPayload` (`ok`, `error`, `fragments`, `debug`).
+- **Agent Chain** (`agent.chain.request`): `AgentChainRequest` / `AgentChainResult`.
+- **Planner React** (`agent.planner.request`): `PlannerRequest` / `PlannerResponse`.
+- **Council** (`agent.council.request`): opaque dict for now; maintain `correlation_id` + reply channel discipline.
+
+## Logging / observability expectations
+
+- Every hop logs `channel`, `kind`, `correlation_id`, `reply_to`, and `source`.
+- Exec returns per-step `StepExecutionResult` (status, soft_fail flag, latency, logs, error).
+
+## Acceptance harness (manual)
+
+- Use `scripts/bus_harness.py` to publish `brain` or `agent` requests with proper envelopes.
+- Use `redis-cli psubscribe orion:*` to observe traffic end-to-end (correlation ids should align with harness output).
+

--- a/orion/core/bus/bus_schemas.py
+++ b/orion/core/bus/bus_schemas.py
@@ -223,20 +223,31 @@ class ChatResultPayload(BaseModel):
 
 
 class RecallRequestPayload(BaseModel):
+    """
+    Canonical recall request payload.
+    """
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    text: str
+    query_text: str
     max_items: int = 8
     time_window_days: int = 90
-    mode: str = "hybrid"
+    mode: Literal["hybrid", "deep", "short_term"] = "hybrid"
     tags: List[str] = Field(default_factory=list)
+    user_id: Optional[str] = None
+    session_id: Optional[str] = None
     trace_id: Optional[str] = None
 
 
 class RecallResultPayload(BaseModel):
+    """
+    Canonical recall response payload.
+    """
     model_config = ConfigDict(extra="forbid", frozen=True)
-    items: List[Dict[str, Any]] = Field(default_factory=list)
-    meta: Dict[str, Any] = Field(default_factory=dict)
+
+    ok: bool = True
+    error: Optional[str] = None
+    fragments: List[Dict[str, Any]] = Field(default_factory=list)
+    debug: Dict[str, Any] = Field(default_factory=dict)
 
 
 class CollapseMirrorPayload(BaseModel):

--- a/orion/core/bus/bus_service_chassis.py
+++ b/orion/core/bus/bus_service_chassis.py
@@ -209,7 +209,14 @@ class Rabbit(BaseChassis):
 
                 env = decoded.envelope
                 # [FIX] LOG RECEIPT TO PROVE WE HIT CORTEX
-                logger.info(f"Rabbit request received: kind={env.kind} source={env.source}")
+                logger.info(
+                    "Rabbit request received: channel=%s kind=%s corr=%s reply_to=%s source=%s",
+                    msg.get("channel"),
+                    env.kind,
+                    env.correlation_id,
+                    env.reply_to,
+                    env.source,
+                )
                 try:
                     out = await self.handler(env)
                     if out is not None and env.reply_to:

--- a/orion/core/bus/contracts.py
+++ b/orion/core/bus/contracts.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""
+Authoritative contract + channel map for the Orion cognitive bus.
+
+These constants are the single source of truth for:
+• Bus channels (intake + reply prefixes) used by every cognitive service.
+• Envelope kinds used on those channels.
+• Reply-channel construction rules.
+"""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class BusChannels:
+    """Canonical bus channels used across the cognitive pipeline."""
+
+    # Client/Hub -> Cortex-Orch
+    cortex_request: str = "orion-cortex:request"
+    cortex_reply_prefix: str = "orion-cortex:reply:"
+
+    # Orch -> Cortex-Exec
+    exec_request: str = "orion-cortex-exec:request"
+    exec_reply_prefix: str = "orion-cortex-exec:reply:"
+
+    # Exec -> Workers (all workers live under the exec namespace)
+    llm_intake: str = "orion-exec:request:LLMGatewayService"
+    recall_intake: str = "orion-exec:request:RecallService"
+    agent_chain_intake: str = "orion-exec:request:AgentChainService"
+    planner_intake: str = "orion-exec:request:PlannerReactService"
+    council_intake: str = "orion-exec:request:AgentCouncilService"
+
+
+@dataclass(frozen=True)
+class EnvelopeKinds:
+    """Canonical envelope kinds (use these exact strings)."""
+
+    cortex_orch_request: str = "cortex.orch.request"
+    cortex_orch_result: str = "cortex.orch.result"
+
+    cortex_exec_request: str = "cortex.exec.request"
+    cortex_exec_result: str = "cortex.exec.result"
+
+    llm_chat_request: str = "llm.chat.request"
+    llm_chat_result: str = "llm.chat.result"
+
+    recall_query_request: str = "recall.query.request"
+    recall_query_result: str = "recall.query.result"
+
+    agent_chain_request: str = "agent.chain.request"
+    agent_chain_result: str = "agent.chain.result"
+
+    planner_request: str = "agent.planner.request"
+    planner_result: str = "agent.planner.result"
+
+    council_request: str = "agent.council.request"
+    council_result: str = "agent.council.result"
+
+
+CHANNELS = BusChannels()
+KINDS = EnvelopeKinds()
+
+
+def reply_channel(prefix: str, correlation_id: UUID | str) -> str:
+    """Construct a reply channel using the canonical prefix + correlation id."""
+    return f"{prefix}{correlation_id}"
+

--- a/orion/schemas/cortex/schemas.py
+++ b/orion/schemas/cortex/schemas.py
@@ -81,7 +81,7 @@ class PlanExecutionRequest(BaseModel):
 # ─────────────────────────────────────────────────────────────
 
 class StepExecutionResult(BaseModel):
-    status: str  # "success" | "fail" | "retry"
+    status: str  # "success" | "fail" | "retry" | "error" | "soft_fail"
     verb_name: str
     step_name: str
     order: int
@@ -91,6 +91,7 @@ class StepExecutionResult(BaseModel):
     node: Optional[str] = None
     logs: List[str] = Field(default_factory=list)
     error: Optional[str] = None
+    soft_fail: bool = False
 
 
 class PlanExecutionResult(BaseModel):

--- a/scripts/bus_harness.py
+++ b/scripts/bus_harness.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from uuid import uuid4
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.bus.contracts import CHANNELS, KINDS, reply_channel
+
+
+def _default_messages(text: str):
+    return [{"role": "user", "content": text}]
+
+
+async def run_once(*, mode: str, text: str, bus_url: str, timeout: float):
+    bus = OrionBusAsync(url=bus_url)
+    await bus.connect()
+
+    corr = uuid4()
+    reply = reply_channel(CHANNELS.cortex_reply_prefix, corr)
+
+    env = BaseEnvelope(
+        kind=KINDS.cortex_orch_request,
+        source=ServiceRef(name="bus-harness", version="dev", node="cli"),
+        correlation_id=corr,
+        reply_to=reply,
+        payload={
+            "verb_name": mode,
+            "args": {"request_id": str(corr), "mode": mode},
+            "context": {"messages": _default_messages(text), "mode": mode},
+        },
+    )
+
+    msg = await bus.rpc_request(
+        CHANNELS.cortex_request,
+        env,
+        reply_channel=reply,
+        timeout_sec=timeout,
+    )
+    decoded = bus.codec.decode(msg.get("data"))
+    if not decoded.ok:
+        raise RuntimeError(f"Decode failed: {decoded.error}")
+    return decoded.envelope.payload
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Minimal bus harness for cortex pipeline.")
+    parser.add_argument("--mode", default="brain", choices=["brain", "agent", "council", "chat_general"])
+    parser.add_argument("--text", required=True, help="User message to send.")
+    parser.add_argument("--bus-url", default="redis://orion-redis:6379/0")
+    parser.add_argument("--timeout", type=float, default=60.0)
+    args = parser.parse_args()
+
+    payload = asyncio.run(
+        run_once(mode=args.mode, text=args.text, bus_url=args.bus_url, timeout=args.timeout)
+    )
+    print(json.dumps(payload, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/services/orion-agent-chain/app/settings.py
+++ b/services/orion-agent-chain/app/settings.py
@@ -6,6 +6,8 @@ import logging
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from orion.core.bus.contracts import CHANNELS
+
 logger = logging.getLogger("orion-agent-chain.settings")
 
 
@@ -30,7 +32,7 @@ class AgentChainSettings(BaseSettings):
     # --- Orion bus / Redis ---
     orion_bus_enabled: bool = Field(True, alias="ORION_BUS_ENABLED")
     orion_bus_url: str = Field(
-        "redis://100.92.216.81/0",
+        "redis://orion-redis:6379/0",
         alias="ORION_BUS_URL",
     )
 
@@ -50,7 +52,7 @@ class AgentChainSettings(BaseSettings):
     # ─────────────────────────────────────────────────────────────
     # The UI will publish here, and we will listen (once we add the listener)
     agent_chain_request_channel: str = Field(
-        "orion-agent-chain:request",
+        CHANNELS.agent_chain_intake,
         alias="AGENT_CHAIN_REQUEST_CHANNEL"
     )
 

--- a/services/orion-cortex-exec/app/clients.py
+++ b/services/orion-cortex-exec/app/clients.py
@@ -1,57 +1,186 @@
-# services/orion-cortex-exec/app/clients.py
 from __future__ import annotations
+
 import logging
 from typing import Any, Dict, Optional
 
 from pydantic import ValidationError
+
 from orion.core.bus.async_service import OrionBusAsync
-from orion.core.bus.bus_schemas import BaseEnvelope, ChatRequestPayload, ChatResponsePayload, ServiceRef
+from orion.core.bus.bus_schemas import (
+    BaseEnvelope,
+    ChatRequestPayload,
+    ChatResponsePayload,
+    RecallRequestPayload,
+    RecallResultPayload,
+    ServiceRef,
+)
+from orion.core.bus.contracts import KINDS
+from orion.schemas.agents.schemas import AgentChainRequest, AgentChainResult, PlannerRequest, PlannerResponse
 from .settings import settings
 
 logger = logging.getLogger("orion.cortex.exec.clients")
 
-class LLMGatewayClient:
+
+class _BaseClient:
+    def __init__(self, bus: OrionBusAsync, channel: str, timeout_ms: int):
+        self.bus = bus
+        self.channel = channel
+        self.timeout_sec = float(timeout_ms) / 1000.0
+
+    async def _rpc(self, env: BaseEnvelope, *, reply_channel: str, timeout_sec: Optional[float] = None) -> dict:
+        rpc_timeout = timeout_sec if timeout_sec is not None else self.timeout_sec
+        msg = await self.bus.rpc_request(self.channel, env, reply_channel=reply_channel, timeout_sec=rpc_timeout)
+        return msg
+
+
+class LLMGatewayClient(_BaseClient):
     """
     Strict, typed client for the LLM Gateway.
     Prevents 'dict soup' by enforcing Pydantic models on both ends.
     """
     def __init__(self, bus: OrionBusAsync):
-        self.bus = bus
-        self.channel = settings.channel_llm_intake
-        self.timeout = float(settings.step_timeout_ms) / 1000.0
+        super().__init__(bus, settings.channel_llm_intake, settings.step_timeout_ms)
 
     async def chat(
         self,
+        *,
         source: ServiceRef,
         req: ChatRequestPayload,
         correlation_id: str,
         reply_to: str,
-        timeout_sec: Optional[float] = None,  # <--- ADDED ARGUMENT
+        timeout_sec: Optional[float] = None,
     ) -> ChatResponsePayload:
-        """
-        Sends a typed request, returns typed response.
-        """
-
         env = BaseEnvelope(
-            kind="llm.chat.request",
+            kind=KINDS.llm_chat_request,
             source=source,
             correlation_id=correlation_id,
             reply_to=reply_to,
             payload=req.model_dump(mode="json"),
         )
 
-        # Use passed timeout, or fall back to global default
-        rpc_timeout = timeout_sec if timeout_sec is not None else self.timeout
-
-        msg = await self.bus.rpc_request(
-            self.channel,
-            env,
-            reply_channel=reply_to,
-            timeout_sec=rpc_timeout  # <--- PASSED HERE
-        )
-
+        msg = await self._rpc(env, reply_channel=reply_to, timeout_sec=timeout_sec)
         decoded = self.bus.codec.decode(msg.get("data"))
         if not decoded.ok:
             raise RuntimeError(f"Decode failed: {decoded.error}")
-
         return ChatResponsePayload.model_validate(decoded.envelope.payload)
+
+
+class RecallClient(_BaseClient):
+    def __init__(self, bus: OrionBusAsync):
+        super().__init__(bus, settings.channel_recall_intake, settings.step_timeout_ms)
+
+    async def query(
+        self,
+        *,
+        source: ServiceRef,
+        req: RecallRequestPayload,
+        correlation_id: str,
+        reply_to: str,
+        timeout_sec: Optional[float] = None,
+    ) -> RecallResultPayload:
+        env = BaseEnvelope(
+            kind=KINDS.recall_query_request,
+            source=source,
+            correlation_id=correlation_id,
+            reply_to=reply_to,
+            payload=req.model_dump(mode="json"),
+        )
+        msg = await self._rpc(env, reply_channel=reply_to, timeout_sec=timeout_sec)
+        decoded = self.bus.codec.decode(msg.get("data"))
+        if not decoded.ok:
+            raise RuntimeError(f"Decode failed: {decoded.error}")
+        try:
+            return RecallResultPayload.model_validate(decoded.envelope.payload)
+        except ValidationError as ve:
+            raise RuntimeError(f"Invalid recall payload: {ve}") from ve
+
+
+class AgentChainClient(_BaseClient):
+    def __init__(self, bus: OrionBusAsync):
+        super().__init__(bus, settings.channel_agent_chain_intake, settings.step_timeout_ms)
+
+    async def run(
+        self,
+        *,
+        source: ServiceRef,
+        req: AgentChainRequest,
+        correlation_id: str,
+        reply_to: str,
+    ) -> AgentChainResult:
+        env = BaseEnvelope(
+            kind=KINDS.agent_chain_request,
+            source=source,
+            correlation_id=correlation_id,
+            reply_to=reply_to,
+            payload=req.model_dump(mode="json"),
+        )
+        msg = await self._rpc(env, reply_channel=reply_to)
+        decoded = self.bus.codec.decode(msg.get("data"))
+        if not decoded.ok:
+            raise RuntimeError(f"Decode failed: {decoded.error}")
+        payload = decoded.envelope.payload
+        if isinstance(payload, dict):
+            return AgentChainResult(**payload)
+        raise RuntimeError("AgentChain returned non-dict payload")
+
+
+class PlannerReactClient(_BaseClient):
+    def __init__(self, bus: OrionBusAsync):
+        super().__init__(bus, settings.channel_planner_intake, settings.step_timeout_ms)
+
+    async def run(
+        self,
+        *,
+        source: ServiceRef,
+        req: PlannerRequest,
+        correlation_id: str,
+        reply_to: str,
+    ) -> PlannerResponse:
+        env = BaseEnvelope(
+            kind=KINDS.planner_request,
+            source=source,
+            correlation_id=correlation_id,
+            reply_to=reply_to,
+            payload=req.model_dump(mode="json"),
+        )
+        msg = await self._rpc(env, reply_channel=reply_to)
+        decoded = self.bus.codec.decode(msg.get("data"))
+        if not decoded.ok:
+            raise RuntimeError(f"Decode failed: {decoded.error}")
+        payload = decoded.envelope.payload
+        if isinstance(payload, dict):
+            return PlannerResponse(**payload)
+        raise RuntimeError("PlannerReact returned non-dict payload")
+
+
+class CouncilClient(_BaseClient):
+    """
+    Stubbed council worker to keep the pipeline contract intact.
+    """
+    def __init__(self, bus: OrionBusAsync):
+        super().__init__(bus, settings.channel_council_intake, settings.step_timeout_ms)
+
+    async def deliberate(
+        self,
+        *,
+        source: ServiceRef,
+        req: Dict[str, Any],
+        correlation_id: str,
+        reply_to: str,
+    ) -> Dict[str, Any]:
+        env = BaseEnvelope(
+            kind=KINDS.council_request,
+            source=source,
+            correlation_id=correlation_id,
+            reply_to=reply_to,
+            payload=req,
+        )
+        msg = await self._rpc(env, reply_channel=reply_to)
+        decoded = self.bus.codec.decode(msg.get("data"))
+        if not decoded.ok:
+            raise RuntimeError(f"Decode failed: {decoded.error}")
+        payload = decoded.envelope.payload
+        if isinstance(payload, dict):
+            return payload
+        raise RuntimeError("Council returned non-dict payload")
+

--- a/services/orion-cortex-exec/app/main.py
+++ b/services/orion-cortex-exec/app/main.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.core.bus.bus_service_chassis import ChassisConfig, Rabbit
+from orion.core.bus.contracts import KINDS
 
 from orion.schemas.cortex.schemas import PlanExecutionRequest
 from .router import PlanRouter
@@ -23,7 +24,7 @@ logger = logging.getLogger("orion.cortex.exec.main")
 
 
 class CortexExecRequest(BaseEnvelope):
-    kind: str = Field("cortex.exec.request", frozen=True)
+    kind: str = Field(KINDS.cortex_exec_request, frozen=True)
     payload: PlanExecutionRequest
 
 
@@ -33,7 +34,7 @@ class CortexExecResultPayload(BaseModel):
 
 
 class CortexExecResult(BaseEnvelope):
-    kind: str = Field("cortex.exec.result", frozen=True)
+    kind: str = Field(KINDS.cortex_exec_result, frozen=True)
     payload: CortexExecResultPayload
 
 
@@ -85,6 +86,7 @@ async def handle(env: BaseEnvelope) -> BaseEnvelope:
         **(req_env.payload.args.extra or {}),
         "user_id": req_env.payload.args.user_id,
         "trigger_source": req_env.payload.args.trigger_source,
+        "mode": (req_env.payload.plan.metadata.get("mode") if req_env.payload.plan.metadata else None) or req_env.payload.plan.verb_name,
     }
     
     logger.debug(f"Context loaded with {len(ctx.get('messages', []))} history messages.")

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -37,9 +37,11 @@ class PlanRunner:
             )
             step_results.append(step_res)
 
-            if step_res.status != "success":
+            if step_res.status != "success" and not step_res.soft_fail:
                 overall_status = "partial" if len(step_results) > 1 else "fail"
                 break
+            if step_res.soft_fail and overall_status == "success":
+                overall_status = "partial"
 
         return PlanExecutionResult(
             verb_name=plan.verb_name,

--- a/services/orion-cortex-exec/app/settings.py
+++ b/services/orion-cortex-exec/app/settings.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
+from orion.core.bus.contracts import CHANNELS
+
 
 class Settings(BaseSettings):
     # Identity
@@ -11,12 +13,12 @@ class Settings(BaseSettings):
     node_name: str = Field("athena", alias="NODE_NAME")
 
     # Bus
-    orion_bus_url: str = Field("redis://100.92.216.81:6379/0", alias="ORION_BUS_URL")
+    orion_bus_url: str = Field("redis://orion-redis:6379/0", alias="ORION_BUS_URL")
     orion_bus_enabled: bool = Field(True, alias="ORION_BUS_ENABLED")
     heartbeat_interval_sec: float = Field(10.0, alias="HEARTBEAT_INTERVAL_SEC")
 
     # Intake channel (hub or orch -> exec)
-    channel_exec_request: str = Field("orion-cortex-exec:request", alias="CHANNEL_EXEC_REQUEST")
+    channel_exec_request: str = Field(CHANNELS.exec_request, alias="CHANNEL_EXEC_REQUEST")
 
     # Downstream routing (exec -> step services)
     exec_request_prefix: str = Field("orion-exec:request", alias="EXEC_REQUEST_PREFIX")
@@ -24,8 +26,12 @@ class Settings(BaseSettings):
     # CHANGED: 8000 -> 60000 (60s). LLMs need time.
     step_timeout_ms: int = Field(60000, alias="STEP_TIMEOUT_MS")
 
-    # CHANGED: "orion-llm:intake" -> "orion-exec:request:LLMGatewayService"
-    channel_llm_intake: str = Field("orion-exec:request:LLMGatewayService", alias="CHANNEL_LLM_INTAKE")
+    # Worker intake channels (canonical, enforced)
+    channel_llm_intake: str = Field(CHANNELS.llm_intake, alias="CHANNEL_LLM_INTAKE")
+    channel_recall_intake: str = Field(CHANNELS.recall_intake, alias="CHANNEL_RECALL_INTAKE")
+    channel_agent_chain_intake: str = Field(CHANNELS.agent_chain_intake, alias="CHANNEL_AGENT_CHAIN_INTAKE")
+    channel_planner_intake: str = Field(CHANNELS.planner_intake, alias="CHANNEL_PLANNER_INTAKE")
+    channel_council_intake: str = Field(CHANNELS.council_intake, alias="CHANNEL_COUNCIL_INTAKE")
 
     class Config:
         env_file = ".env"

--- a/services/orion-cortex-orch/app/main.py
+++ b/services/orion-cortex-orch/app/main.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import traceback
-
 from pydantic import BaseModel, Field, ValidationError
 
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.core.bus.bus_service_chassis import ChassisConfig, Rabbit
+from orion.core.bus.contracts import KINDS
 
 from .orchestrator import call_cortex_exec
 from .models import CortexOrchInput  # CHANGED: Import from models
@@ -18,7 +17,7 @@ logger = logging.getLogger("orion.cortex.orch")
 
 
 class CortexOrchRequest(BaseEnvelope):
-    kind: str = Field("cortex.orch.request", frozen=True)
+    kind: str = Field(KINDS.cortex_orch_request, frozen=True)
     payload: CortexOrchInput
 
 
@@ -28,7 +27,7 @@ class CortexOrchResultPayload(BaseModel):
 
 
 class CortexOrchResult(BaseEnvelope):
-    kind: str = Field("cortex.orch.result", frozen=True)
+    kind: str = Field(KINDS.cortex_orch_result, frozen=True)
     payload: CortexOrchResultPayload
 
 

--- a/services/orion-cortex-orch/app/settings.py
+++ b/services/orion-cortex-orch/app/settings.py
@@ -4,6 +4,8 @@ from functools import lru_cache
 from pydantic import Field, AliasChoices
 from pydantic_settings import BaseSettings
 
+from orion.core.bus.contracts import CHANNELS
+
 
 class Settings(BaseSettings):
     # Service identity
@@ -12,7 +14,7 @@ class Settings(BaseSettings):
     node_name: str = Field("athena", alias="NODE_NAME")
 
     # Bus config
-    orion_bus_url: str = Field("redis://100.92.216.81:6379/0", alias="ORION_BUS_URL")
+    orion_bus_url: str = Field("redis://orion-redis:6379/0", alias="ORION_BUS_URL")
     orion_bus_enabled: bool = Field(True, alias="ORION_BUS_ENABLED")
 
     # Chassis
@@ -20,13 +22,13 @@ class Settings(BaseSettings):
 
     # RPC intake channel (hub -> cortex-orch)
     channel_cortex_request: str = Field(
-        "orion-cortex:request",
+        CHANNELS.cortex_request,
         validation_alias=AliasChoices("CORTEX_REQUEST_CHANNEL", "ORCH_REQUEST_CHANNEL"),
     )
 
     # RPC out to cortex-exec
     channel_exec_request: str = Field(
-        "orion-cortex-exec:request",
+        CHANNELS.exec_request,
         validation_alias=AliasChoices("CORTEX_EXEC_REQUEST_CHANNEL", "CHANNEL_EXEC_REQUEST"),
     )
 

--- a/services/orion-hub/scripts/recall_rpc.py
+++ b/services/orion-hub/scripts/recall_rpc.py
@@ -65,7 +65,7 @@ class RecallRPC:
             correlation_id=corr,
             reply_to=reply,
             payload=RecallRequestPayload(
-                text=text,
+                query_text=text,
                 max_items=max_items,
                 time_window_days=time_window_days,
                 mode=mode,

--- a/services/orion-llm-gateway/app/settings.py
+++ b/services/orion-llm-gateway/app/settings.py
@@ -7,6 +7,7 @@ import yaml
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
+from orion.core.bus.contracts import CHANNELS
 from .profiles import LLMProfile, LLMProfileRegistry
 
 
@@ -17,12 +18,12 @@ class Settings(BaseSettings):
     node_name: Optional[str] = Field(None, alias="NODE_NAME")
 
     # Bus config
-    orion_bus_url: str = Field("redis://100.92.216.81:6379/0", alias="ORION_BUS_URL")
+    orion_bus_url: str = Field("redis://orion-redis:6379/0", alias="ORION_BUS_URL")
     orion_bus_enabled: bool = Field(True, alias="ORION_BUS_ENABLED")
     heartbeat_interval_sec: float = Field(10.0, alias="HEARTBEAT_INTERVAL_SEC")
 
     # Intake from other services
-    channel_llm_intake: str = Field("orion-exec:request:LLMGatewayService", alias="CHANNEL_LLM_INTAKE")
+    channel_llm_intake: str = Field(CHANNELS.llm_intake, alias="CHANNEL_LLM_INTAKE")
 
     # Spark
     channel_spark_introspect_candidate: str = Field(

--- a/services/orion-planner-react/app/settings.py
+++ b/services/orion-planner-react/app/settings.py
@@ -5,6 +5,8 @@ from typing import Optional
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from orion.core.bus.contracts import CHANNELS
+
 
 class Settings(BaseSettings):
     # Core identity
@@ -50,7 +52,7 @@ class Settings(BaseSettings):
 
     # Service Request Channels
     planner_request_channel: str = Field(
-        "orion-planner:request",
+        CHANNELS.planner_intake,
         alias="PLANNER_REQUEST_CHANNEL",
     )
     planner_result_prefix: str = Field(

--- a/services/orion-recall/app/http_models.py
+++ b/services/orion-recall/app/http_models.py
@@ -8,7 +8,9 @@ from pydantic import BaseModel, Field
 class RecallRequestBody(BaseModel):
     """HTTP API request model (backwards compatibility)."""
 
-    text: str
+    model_config = {"populate_by_name": True}
+
+    query_text: str = Field(alias="text")
     max_items: int = 8
     time_window_days: int = 90
     mode: str = "hybrid"

--- a/services/orion-recall/app/main.py
+++ b/services/orion-recall/app/main.py
@@ -30,7 +30,7 @@ app = FastAPI(title="Orion Recall", version=settings.SERVICE_VERSION, lifespan=l
 @app.post("/recall", response_model=RecallResponseBody)
 async def recall_endpoint(body: RecallRequestBody):
     q = RecallQuery(
-        text=body.text,
+        text=body.query_text,
         max_items=body.max_items,
         time_window_days=body.time_window_days,
         mode=body.mode,

--- a/services/orion-recall/app/settings.py
+++ b/services/orion-recall/app/settings.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from orion.core.bus.contracts import CHANNELS
+
 
 class Settings(BaseSettings):
     # Pydantic / Settings config
@@ -19,8 +21,8 @@ class Settings(BaseSettings):
 
     # ── Orion Bus ─────────────────────────────────────────────────────
     ORION_BUS_ENABLED: bool = True
-    ORION_BUS_URL: str = "redis://100.92.216.81:6379/0"
-    RECALL_BUS_INTAKE: str = "orion-recall:request"
+    ORION_BUS_URL: str = "redis://orion-redis:6379/0"
+    RECALL_BUS_INTAKE: str = CHANNELS.recall_intake
 
     # ── Chassis / Runtime ─────────────────────────────────────────────
     HEARTBEAT_INTERVAL_SEC: float = 10.0
@@ -28,8 +30,8 @@ class Settings(BaseSettings):
     ERROR_CHANNEL: str = "system.error"
     SHUTDOWN_GRACE_SEC: float = 10.0
 
-    CHANNEL_RECALL_REQUEST: str = "orion:recall:request"
-    CHANNEL_RECALL_DEFAULT_REPLY_PREFIX: str = "orion:recall:reply"
+    CHANNEL_RECALL_REQUEST: str = CHANNELS.recall_intake
+    CHANNEL_RECALL_DEFAULT_REPLY_PREFIX: str = "orion:recall:reply:"
 
     # ── Default Recall Behavior ───────────────────────────────────────
     RECALL_DEFAULT_MAX_ITEMS: int = 16


### PR DESCRIPTION
## Summary
- establish canonical bus channel/kind map and export constants for all cognitive services
- rebuild cortex orch/exec plans around brain/agent/council modes with typed clients for recall, LLM, agent-chain, planner, and council
- normalize recall contract (query_text, ok/error/fragments/debug), update services/settings to the canonical channels, and add a bus harness for end-to-end RPC checks

## Testing
- python -m compileall orion/core/bus services/orion-cortex-exec/app services/orion-cortex-orch/app services/orion-recall/app scripts/bus_harness.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a83c09ac832a8d4515d2589ce426)