### PR TITLE
Add supervisor routing for agentic verbs and council checkpoints

### DIFF
--- a/orion/cognition/planner/models.py
+++ b/orion/cognition/planner/models.py
@@ -1,14 +1,18 @@
 # orion/cognition/planner/models.py
-from typing import Optional
-from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
 
 
 class VerbConfig(BaseModel):
     name: str
     description: Optional[str] = None
     group: Optional[str] = None
-    # maybe:
-    # input_schema: Optional[dict] = None
-    # output_schema: Optional[dict] = None
-    # examples: Optional[List[str]] = None
-    # tags: Optional[List[str]] = None
+    category: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    input_schema: Dict[str, Any] = Field(default_factory=dict)
+    output_schema: Dict[str, Any] = Field(default_factory=dict)
+    services: List[str] = Field(default_factory=list)
+    prompt_template: Optional[str] = None
+    timeout_ms: Optional[int] = None
+    requires_gpu: Optional[bool] = None
+    requires_memory: Optional[bool] = None

--- a/orion/schemas/agents/schemas.py
+++ b/orion/schemas/agents/schemas.py
@@ -77,24 +77,9 @@ class Preferences(BaseModel):
     style: str = "neutral"
     allow_internal_thought_logging: bool = True
     return_trace: bool = True
+    plan_only: bool = False
+    delegate_tool_execution: bool = False
 
-
-class PlannerRequest(BaseModel):
-    """Low-level request to the ReAct Planner."""
-    model_config = ConfigDict(extra="ignore")
-
-    request_id: Optional[str] = None
-    caller: str = "hub"
-    goal: Goal
-    context: ContextBlock = Field(default_factory=ContextBlock)
-    toolset: List[ToolDef] = Field(default_factory=list)
-    limits: Limits = Field(default_factory=Limits)
-    preferences: Preferences = Field(default_factory=Preferences)
-
-
-# ─────────────────────────────────────────────
-# Planner Outputs
-# ─────────────────────────────────────────────
 
 class TraceStep(BaseModel):
     step_index: int
@@ -115,6 +100,24 @@ class FinalAnswer(BaseModel):
     content: str
     structured: Dict[str, Any] = Field(default_factory=dict)
 
+
+class PlannerRequest(BaseModel):
+    """Low-level request to the ReAct Planner."""
+    model_config = ConfigDict(extra="ignore")
+
+    request_id: Optional[str] = None
+    caller: str = "hub"
+    goal: Goal
+    context: ContextBlock = Field(default_factory=ContextBlock)
+    toolset: List[ToolDef] = Field(default_factory=list)
+    trace: List[TraceStep] = Field(default_factory=list)
+    limits: Limits = Field(default_factory=Limits)
+    preferences: Preferences = Field(default_factory=Preferences)
+
+
+# ─────────────────────────────────────────────
+# Planner Outputs
+# ─────────────────────────────────────────────
 
 class PlannerResponse(BaseModel):
     model_config = ConfigDict(extra="ignore")

--- a/scripts/smoke_supervisor.py
+++ b/scripts/smoke_supervisor.py
@@ -1,0 +1,90 @@
+"""
+Quick smoke scripts for the supervisor path.
+
+Usage:
+    python scripts/smoke_supervisor.py react
+    python scripts/smoke_supervisor.py escalate
+"""
+
+import asyncio
+import os
+import sys
+from uuid import uuid4
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef, LLMMessage
+from orion.schemas.cortex.contracts import CortexClientContext, CortexClientRequest, RecallDirective
+
+ORCH_CHANNEL = os.getenv("CORTEX_ORCH_REQUEST_CHANNEL", "orion-cortex:request")
+ORCH_RESULT_PREFIX = os.getenv("CORTEX_ORCH_RESULT_PREFIX", "orion-cortex:result")
+
+
+def _source() -> ServiceRef:
+    return ServiceRef(name="smoke-supervisor", node="local", version="0.0.1")
+
+
+async def _rpc(bus: OrionBusAsync, payload: CortexClientRequest, *, timeout_sec: float = 120.0) -> dict:
+    corr = str(uuid4())
+    reply_channel = f"{ORCH_RESULT_PREFIX}:{corr}"
+    env = BaseEnvelope(
+        kind="cortex.orch.request",
+        source=_source(),
+        correlation_id=corr,
+        reply_to=reply_channel,
+        payload=payload.model_dump(mode="json"),
+    )
+    msg = await bus.rpc_request(ORCH_CHANNEL, env, reply_channel=reply_channel, timeout_sec=timeout_sec)
+    decoded = bus.codec.decode(msg.get("data"))
+    if not decoded.ok:
+        raise RuntimeError(decoded.error)
+    return decoded.envelope.payload if isinstance(decoded.envelope.payload, dict) else decoded.envelope.payload.model_dump(mode="json")
+
+
+async def run_react_smoke() -> None:
+    bus = OrionBusAsync(url=os.getenv("ORION_BUS_URL", "redis://localhost:6379/0"))
+    await bus.connect()
+
+    ctx = CortexClientContext(
+        messages=[LLMMessage(role="user", content="Summarize this phrase: Orion supervisor demo.")],
+        session_id="smoke-react",
+    )
+    payload = CortexClientRequest(
+        mode="agent",
+        verb_name="analyze_text",
+        packs=["executive_pack"],
+        options={"max_steps": 1},
+        recall=RecallDirective(enabled=False),
+        context=ctx,
+    )
+    res = await _rpc(bus, payload)
+    print("React smoke result:", res)
+    await bus.close()
+
+
+async def run_escalation_smoke() -> None:
+    bus = OrionBusAsync(url=os.getenv("ORION_BUS_URL", "redis://localhost:6379/0"))
+    await bus.connect()
+
+    ctx = CortexClientContext(
+        messages=[LLMMessage(role="user", content="Plan a small research outline and have council review it.")],
+        session_id="smoke-escalate",
+    )
+    payload = CortexClientRequest(
+        mode="agent",
+        verb_name="plan_action",
+        packs=["executive_pack"],
+        options={"force_agent_chain": True},
+        recall=RecallDirective(enabled=False),
+        context=ctx,
+    )
+    res = await _rpc(bus, payload, timeout_sec=180.0)
+    print("Escalation smoke result:", res)
+    await bus.close()
+
+
+if __name__ == "__main__":
+    action = sys.argv[1] if len(sys.argv) > 1 else "react"
+    if action == "escalate":
+        asyncio.run(run_escalation_smoke())
+    else:
+        asyncio.run(run_react_smoke())

--- a/services/orion-agent-chain/app/tool_registry.py
+++ b/services/orion-agent-chain/app/tool_registry.py
@@ -51,7 +51,7 @@ class ToolRegistry:
 
                 verb_cfg = self._verb_registry.get(verb_name)
 
-                input_schema = {
+                input_schema = verb_cfg.input_schema or {
                     "type": "object",
                     "properties": {
                         "text": {"type": "string"},
@@ -59,7 +59,7 @@ class ToolRegistry:
                     },
                     "required": ["text"],
                 }
-                output_schema = {
+                output_schema = verb_cfg.output_schema or {
                     "type": "object",
                     "properties": {
                         "llm_output": {"type": "string"},

--- a/services/orion-cortex-exec/app/settings.py
+++ b/services/orion-cortex-exec/app/settings.py
@@ -30,7 +30,8 @@ class Settings(BaseSettings):
     channel_recall_intake: str = Field("orion-exec:request:RecallService", alias="CHANNEL_RECALL_INTAKE")
     channel_agent_chain_intake: str = Field("orion-exec:request:AgentChainService", alias="CHANNEL_AGENT_CHAIN_INTAKE")
     channel_planner_intake: str = Field("orion-exec:request:PlannerReactService", alias="CHANNEL_PLANNER_INTAKE")
-    channel_council_intake: str = Field("orion-exec:request:CouncilService", alias="CHANNEL_COUNCIL_INTAKE")
+    channel_council_intake: str = Field("orion:council:intake", alias="CHANNEL_COUNCIL_INTAKE")
+    channel_council_reply_prefix: str = Field("orion:council:reply", alias="CHANNEL_COUNCIL_REPLY_PREFIX")
 
     diagnostic_mode: bool = Field(False, alias="DIAGNOSTIC_MODE")
     diagnostic_recall_timeout_sec: float = Field(5.0, alias="DIAGNOSTIC_RECALL_TIMEOUT_SEC")

--- a/services/orion-cortex-exec/app/supervisor.py
+++ b/services/orion-cortex-exec/app/supervisor.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import orion
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import LLMMessage, ServiceRef
+from orion.cognition.packs_loader import PackManager
+from orion.cognition.planner.loader import VerbRegistry
+from orion.schemas.agents.schemas import (
+    ContextBlock,
+    DeliberationRequest,
+    FinalAnswer,
+    Goal,
+    Limits,
+    PlannerRequest,
+    Preferences,
+    ToolDef,
+    TraceStep,
+    AgentChainRequest,
+)
+from orion.schemas.cortex.schemas import ExecutionPlan, ExecutionStep, PlanExecutionResult, StepExecutionResult
+
+from .clients import AgentChainClient, CouncilClient, LLMGatewayClient, PlannerReactClient
+from .executor import _last_user_message, call_step_services, run_recall_step
+from .settings import settings
+
+logger = logging.getLogger("orion.cortex.exec.supervisor")
+
+ORION_PKG_DIR = Path(orion.__file__).resolve().parent
+PROMPTS_DIR = ORION_PKG_DIR / "cognition" / "prompts"
+VERBS_DIR = ORION_PKG_DIR / "cognition" / "verbs"
+
+
+def _load_prompt_content(template_ref: Optional[str]) -> Optional[str]:
+    if not template_ref:
+        return None
+    ref = template_ref.strip()
+    if not ref.endswith(".j2"):
+        return ref
+    path = PROMPTS_DIR / ref
+    if path.exists():
+        return path.read_text(encoding="utf-8")
+    logger.warning("Prompt template not found: %s", path)
+    return ref
+
+
+def _verb_to_step(cfg) -> ExecutionStep:
+    prompt_text = _load_prompt_content(cfg.prompt_template)
+    services = cfg.services or ["LLMGatewayService"]
+    return ExecutionStep(
+        verb_name=cfg.name,
+        step_name=cfg.name,
+        description=cfg.description or "",
+        order=0,
+        services=services,
+        prompt_template=prompt_text,
+        requires_gpu=bool(cfg.requires_gpu),
+        requires_memory=bool(cfg.requires_memory),
+        timeout_ms=int(cfg.timeout_ms or settings.step_timeout_ms),
+    )
+
+
+def _extract_observation(step_res: StepExecutionResult) -> Dict[str, Any]:
+    for payload in (step_res.result or {}).values():
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("llm_output"):
+            return {"llm_output": payload.get("llm_output"), "raw": payload}
+        if payload.get("content"):
+            return {"llm_output": payload.get("content"), "raw": payload}
+        if payload.get("text"):
+            return {"llm_output": payload.get("text"), "raw": payload}
+    return {"raw": step_res.result}
+
+
+class Supervisor:
+    """
+    Hierarchical controller that can pick reasoning paths, run ReAct with verbs, checkpoint with Council,
+    and escalate to Agent Chain.
+    """
+
+    def __init__(self, bus: OrionBusAsync):
+        self.bus = bus
+        self.registry = VerbRegistry(VERBS_DIR)
+        self.pack_manager = PackManager(ORION_PKG_DIR / "cognition")
+        self.llm_client = LLMGatewayClient(bus)
+        self.planner_client = PlannerReactClient(bus)
+        self.agent_client = AgentChainClient(bus)
+        self.council_client = CouncilClient(bus)
+
+    def _toolset(self, packs: List[str] | None = None, tags: List[str] | None = None) -> List[ToolDef]:
+        try:
+            names: List[str] = []
+            if packs:
+                self.pack_manager.load_packs()
+                names = self.pack_manager.load_verb_set(packs)
+            verbs = self.registry.filter(names=names or None, tags=tags)
+        except Exception as exc:
+            logger.warning("Verb registry load failed, falling back to all verbs: %s", exc)
+            verbs = self.registry.list()
+
+        tools: List[ToolDef] = []
+        for v in verbs:
+            tools.append(
+                ToolDef(
+                    tool_id=v.name,
+                    description=v.description or f"Orion verb: {v.name}",
+                    input_schema=v.input_schema or {},
+                    output_schema=v.output_schema or {},
+                )
+            )
+        return tools
+
+    def _should_use_react(self, mode: str, tools: List[ToolDef]) -> bool:
+        if mode == "agent":
+            return True
+        return bool(tools)
+
+    async def _planner_step(
+        self,
+        *,
+        source: ServiceRef,
+        goal_text: str,
+        toolset: List[ToolDef],
+        trace: List[TraceStep],
+        ctx: Dict[str, Any],
+        correlation_id: str,
+    ) -> Tuple[PlannerRequest, StepExecutionResult, FinalAnswer | None, Dict[str, Any] | None]:
+        planner_req = PlannerRequest(
+            request_id=correlation_id,
+            caller="cortex-exec",
+            goal=Goal(description=goal_text, metadata={"verb": ctx.get("verb")}),
+            context=ContextBlock(
+                conversation_history=[LLMMessage(**m) if not isinstance(m, LLMMessage) else m for m in (ctx.get("messages") or [])],
+                external_facts={"text": ctx.get("memory_digest", "")},
+            ),
+            toolset=toolset,
+            trace=trace,
+            limits=Limits(max_steps=1, timeout_seconds=int(settings.step_timeout_ms / 1000)),
+            preferences=Preferences(plan_only=True, return_trace=True, delegate_tool_execution=True),
+        )
+        reply_channel = f"{settings.exec_result_prefix}:PlannerReactService:{correlation_id}"
+        t0 = time.time()
+        logs = [f"rpc -> PlannerReactService (plan_only) reply={reply_channel}"]
+        planner_res = await self.planner_client.plan(
+            source=source,
+            req=planner_req,
+            correlation_id=correlation_id,
+            reply_to=reply_channel,
+            timeout_sec=float(settings.diagnostic_agent_timeout_sec),
+        )
+        logs.append(f"ok <- PlannerReactService status={planner_res.status}")
+
+        step_res = StepExecutionResult(
+            status="success" if planner_res.status == "ok" else "fail",
+            verb_name=ctx.get("verb") or "unknown",
+            step_name="planner_react",
+            order=-1,
+            result={"PlannerReactService": planner_res.model_dump(mode="json")},
+            latency_ms=int((time.time() - t0) * 1000),
+            node=settings.node_name,
+            logs=logs,
+            error=None if planner_res.status == "ok" else (planner_res.error or {}).get("message"),
+        )
+        final = planner_res.final_answer
+        action: Dict[str, Any] | None = None
+        if planner_res.trace:
+            last = planner_res.trace[-1]
+            action = last.action
+        return planner_req, step_res, final, action
+
+    async def _execute_action(
+        self,
+        *,
+        source: ServiceRef,
+        action: Dict[str, Any],
+        ctx: Dict[str, Any],
+        correlation_id: str,
+    ) -> StepExecutionResult:
+        tool_id = action.get("tool_id")
+        tool_input = action.get("input") or {}
+        verb_cfg = self.registry.get(tool_id)
+        step = _verb_to_step(verb_cfg)
+
+        exec_ctx = {**ctx, **tool_input}
+        exec_ctx.setdefault("verb", tool_id)
+
+        step_res = await call_step_services(
+            self.bus,
+            source=source,
+            step=step,
+            ctx=exec_ctx,
+            correlation_id=correlation_id,
+            diagnostic=bool(ctx.get("diagnostic")),
+        )
+        return step_res
+
+    async def _council_checkpoint(
+        self,
+        *,
+        source: ServiceRef,
+        correlation_id: str,
+        prompt: str,
+        history: List[Dict[str, Any]],
+    ) -> StepExecutionResult:
+        deliberation = DeliberationRequest(
+            prompt=prompt,
+            history=history,
+            event="council_deliberation",
+            trace_id=correlation_id,
+        )
+        reply_channel = f"{settings.channel_council_reply_prefix}:{correlation_id}"
+        t0 = time.time()
+        logs = [f"rpc -> CouncilService reply={reply_channel}"]
+        council_res = await self.council_client.deliberate(
+            source=source,
+            req=deliberation,
+            correlation_id=correlation_id,
+            reply_to=reply_channel,
+            timeout_sec=float(settings.diagnostic_agent_timeout_sec),
+        )
+        logs.append("ok <- CouncilService")
+        return StepExecutionResult(
+            status="success",
+            verb_name="council_checkpoint",
+            step_name="council_checkpoint",
+            order=99,
+            result={"CouncilService": council_res.model_dump(mode="json")},
+            latency_ms=int((time.time() - t0) * 1000),
+            node=settings.node_name,
+            logs=logs,
+        )
+
+    async def _agent_chain_escalation(
+        self,
+        *,
+        source: ServiceRef,
+        correlation_id: str,
+        ctx: Dict[str, Any],
+        packs: List[str],
+    ) -> StepExecutionResult:
+        agent_req = {
+            "text": _last_user_message(ctx),
+            "mode": ctx.get("mode") or "agent",
+            "session_id": ctx.get("session_id"),
+            "user_id": ctx.get("user_id"),
+            "messages": ctx.get("messages") or [],
+            "packs": packs,
+        }
+        reply_channel = f"{settings.exec_result_prefix}:AgentChainService:{correlation_id}"
+        t0 = time.time()
+        logs = [f"rpc -> AgentChainService reply={reply_channel}"]
+        agent_res = await self.agent_client.run_chain(
+            source=source,
+            req=AgentChainRequest(**agent_req),
+            correlation_id=correlation_id,
+            reply_to=reply_channel,
+            timeout_sec=float(settings.step_timeout_ms) / 1000.0,
+        )
+        logs.append("ok <- AgentChainService")
+        return StepExecutionResult(
+            status="success",
+            verb_name="agent_chain",
+            step_name="agent_chain",
+            order=100,
+            result={"AgentChainService": agent_res.model_dump(mode="json")},
+            latency_ms=int((time.time() - t0) * 1000),
+            node=settings.node_name,
+            logs=logs,
+        )
+
+    async def execute(
+        self,
+        *,
+        source: ServiceRef,
+        req: ExecutionPlan,
+        correlation_id: str,
+        ctx: Dict[str, Any],
+        recall_cfg: Dict[str, Any],
+    ) -> PlanExecutionResult:
+        step_results: List[StepExecutionResult] = []
+        memory_used = False
+        recall_debug: Dict[str, Any] = {}
+
+        # Recall
+        raw_enabled = recall_cfg.get("enabled", True)
+        recall_enabled = str(raw_enabled).lower() not in {"false", "0", "no", "off"} if isinstance(raw_enabled, str) else bool(raw_enabled)
+        if recall_enabled:
+            recall_step, recall_debug, _ = await run_recall_step(
+                self.bus,
+                source=source,
+                ctx=ctx,
+                correlation_id=correlation_id,
+                recall_cfg=recall_cfg,
+                diagnostic=bool(ctx.get("diagnostic")),
+            )
+            step_results.append(recall_step)
+            memory_used = recall_step.status == "success"
+
+        packs = ctx.get("packs") or []
+        tags = ctx.get("verb_tags") or []
+        tools = self._toolset(packs=packs, tags=tags)
+        mode = ctx.get("mode") or req.metadata.get("mode") or "agent"
+
+        if not self._should_use_react(mode, tools):
+            logger.info("Supervisor: using direct LLM path")
+            direct_cfg = self.registry.get(req.verb_name)
+            step = _verb_to_step(direct_cfg)
+            direct_step = await call_step_services(
+                self.bus,
+                source=source,
+                step=step,
+                ctx=ctx,
+                correlation_id=correlation_id,
+                diagnostic=bool(ctx.get("diagnostic")),
+            )
+            step_results.append(direct_step)
+            final_obs = _extract_observation(direct_step)
+            return PlanExecutionResult(
+                verb_name=req.verb_name,
+                request_id=correlation_id,
+                status="success" if direct_step.status == "success" else "fail",
+                blocked=False,
+                blocked_reason=None,
+                steps=step_results,
+                mode=mode,
+                final_text=final_obs.get("llm_output"),
+                memory_used=memory_used,
+                recall_debug=recall_debug,
+                error=direct_step.error,
+            )
+
+        trace: List[TraceStep] = []
+        max_steps = int(ctx.get("max_steps") or 3)
+        final_text: Optional[str] = None
+
+        for _ in range(max_steps):
+            goal_text = _last_user_message(ctx)
+            planner_req, planner_step, planner_final, action = await self._planner_step(
+                source=source,
+                goal_text=goal_text,
+                toolset=tools,
+                trace=trace,
+                ctx=ctx,
+                correlation_id=correlation_id,
+            )
+            step_results.append(planner_step)
+            if planner_final and planner_final.content:
+                final_text = planner_final.content
+                break
+            if planner_step.status != "success" or not action:
+                break
+
+            action_step = await self._execute_action(
+                source=source,
+                action=action,
+                ctx=ctx,
+                correlation_id=correlation_id,
+            )
+            step_results.append(action_step)
+            obs = _extract_observation(action_step)
+            trace.append(
+                TraceStep(
+                    step_index=len(trace),
+                    thought=None,
+                    action=action,
+                    observation=obs,
+                )
+            )
+            if obs.get("llm_output"):
+                final_text = obs.get("llm_output")
+
+        # Council checkpoint if we have trace
+        council_step: Optional[StepExecutionResult] = None
+        if trace:
+            prompt_lines = [f"Goal: { _last_user_message(ctx)}", "Trace:"]
+            for step in trace:
+                prompt_lines.append(f"- action: {step.action} obs: {step.observation}")
+            council_prompt = "\n".join(prompt_lines)
+            council_step = await self._council_checkpoint(
+                source=source,
+                correlation_id=correlation_id,
+                prompt=council_prompt,
+                history=ctx.get("messages") or [],
+            )
+            step_results.append(council_step)
+            try:
+                council_payload = council_step.result.get("CouncilService", {})
+                if isinstance(council_payload, dict):
+                    final_text = council_payload.get("final_text") or final_text
+            except Exception:
+                pass
+
+        if ctx.get("force_agent_chain"):
+            final_text = None
+
+        # Escalate to agent chain if still no final text
+        if not final_text:
+            agent_step = await self._agent_chain_escalation(
+                source=source,
+                correlation_id=correlation_id,
+                ctx=ctx,
+                packs=packs or [],
+            )
+            step_results.append(agent_step)
+            try:
+                agent_payload = agent_step.result.get("AgentChainService", {})
+                if isinstance(agent_payload, dict):
+                    final_text = agent_payload.get("text") or final_text
+            except Exception:
+                pass
+
+        overall_status = "success" if step_results and all(s.status == "success" for s in step_results if s) else "partial"
+        return PlanExecutionResult(
+            verb_name=req.verb_name,
+            request_id=correlation_id,
+            status=overall_status,
+            blocked=False,
+            blocked_reason=None,
+            steps=step_results,
+            mode=mode,
+            final_text=final_text,
+            memory_used=memory_used,
+            recall_debug=recall_debug,
+            error=None,
+        )


### PR DESCRIPTION
## Summary
- add a supervisor loop inside cortex-exec to orchestrate agentic requests with verb registry tooling, planner-react planning, council checkpoints, and agent-chain escalation
- extend the verb registry and shared schemas so tools carry schemas/tags and planner-react can run in a delegate planning-only mode
- align downstream clients/settings for council/agent chain and provide smoke scripts to exercise react and escalation flows

## Testing
- python -m compileall services/orion-cortex-exec/app services/orion-planner-react/app scripts/smoke_supervisor.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954f6b830f8832a977c262b28951025)