### PR TITLE
Force terminal bound-capability reply on executor timeout

### DIFF
--- a/services/orion-agent-chain/app/api.py
+++ b/services/orion-agent-chain/app/api.py
@@ -447,6 +447,18 @@ def _bound_terminal_failure(
         runtime_debug=dbg,
     )
 
+
+def _bound_execution_timeout_seconds() -> float:
+    """
+    Bound-capability direct execution guardrail.
+    Keep this strictly below the broader agent-chain / exec hop timeout so
+    we can always emit a terminal bound-capability reply instead of letting
+    the parent RPC time out first.
+    """
+    default_timeout = float(settings.default_timeout_seconds or 90)
+    return max(5.0, min(25.0, default_timeout * 0.5))
+
+
 async def execute_agent_chain(
     body: AgentChainRequest,
     *,
@@ -643,13 +655,30 @@ async def execute_agent_chain(
                         observation={"capability_resolution_status": "selected_verb_not_capability"},
                     )
                 try:
+                    execution_timeout = _bound_execution_timeout_seconds()
                     observation = await asyncio.wait_for(
                         tool_executor.execute_llm_verb(
                             selected_verb,
                             action_input,
                             parent_correlation_id=parent_corr_id,
                         ),
-                        timeout=float(settings.default_timeout_seconds),
+                        timeout=execution_timeout,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "[agent-chain] bound_capability_execution_timeout selected_verb=%s timeout_sec=%.2f",
+                        selected_verb,
+                        execution_timeout,
+                    )
+                    return _bound_terminal_failure(
+                        body=body,
+                        dbg=dbg,
+                        selected_verb=selected_verb,
+                        reason=CapabilityRecoveryReasonV1.capability_executor_unavailable,
+                        detail=f"capability execution timed out after {execution_timeout:.2f}s",
+                        path="bound_direct_timeout",
+                        failure_category="execution_timeout",
+                        observation={"capability_resolution_status": "executor_timeout"},
                     )
                 except FileNotFoundError:
                     reason = CapabilityRecoveryReasonV1.selected_verb_missing

--- a/services/orion-agent-chain/tests/test_bound_capability_contract.py
+++ b/services/orion-agent-chain/tests/test_bound_capability_contract.py
@@ -266,3 +266,25 @@ def test_bound_capability_internal_error_terminal_reply(monkeypatch):
     assert bound["reason"] == "capability_executor_unavailable"
     assert bound["observation"]["path"] == "bound_direct_internal_error"
     assert bound["observation"]["reply_emitted"] is True
+
+
+def test_bound_capability_timeout_terminal_reply(monkeypatch):
+    class _HangingExecutor(_FakeToolExecutor):
+        async def execute_llm_verb(self, tool_id, tool_input, *, parent_correlation_id=None):
+            await asyncio.sleep(0.25)
+            return {"selected_verb": tool_id, "selected_skill": "never-returned"}
+
+    fake_exec = _HangingExecutor()
+
+    async def _fake_planner(*_args, **_kwargs):
+        raise AssertionError("planner should not be called on bound direct path")
+
+    monkeypatch.setattr(agent_api, "call_planner_react", _fake_planner)
+    monkeypatch.setattr(agent_api, "ToolExecutor", lambda *_a, **_k: fake_exec)
+    monkeypatch.setattr(agent_api, "_bound_execution_timeout_seconds", lambda: 0.05)
+
+    out = asyncio.run(agent_api.execute_agent_chain(_bound_request(), correlation_id=str(uuid4()), rpc_bus=object()))
+    bound = out.structured["bound_capability"]
+    assert bound["reason"] == "capability_executor_unavailable"
+    assert bound["observation"]["path"] == "bound_direct_timeout"
+    assert bound["observation"]["reply_emitted"] is True

--- a/services/orion-agent-chain/tests/test_bus_listener_rpc.py
+++ b/services/orion-agent-chain/tests/test_bus_listener_rpc.py
@@ -141,7 +141,7 @@ def test_nested_planner_child_corr_still_replies_to_exec_parent(monkeypatch):
     reply_to = f"orion:exec:result:AgentChainService:{parent_corr}"
     env = _request_env(corr=parent_corr, reply_to=reply_to)
     bus = _FakeBus(env)
-    monkeypatch.setattr(agent_api, "_resolve_tools", lambda _body: [])
+    monkeypatch.setattr(agent_api, "_resolve_tools", lambda _body, **_kwargs: ([], []))
     monkeypatch.setattr(bus_listener, "execute_agent_chain", agent_api.execute_agent_chain)
 
     asyncio.run(bus_listener._handle_request(bus, {"data": b"ignored"}))


### PR DESCRIPTION
### Motivation
- Investigation found the allowed bound-capability path blocks in `execute_agent_chain` while awaiting `tool_executor.execute_llm_verb(...)`, allowing downstream nested RPC latency to exhaust the parent RPC timeout and leave no terminal reply published.  
- The goal is to guarantee that the allowed direct-bound path always emits a terminal `AgentChainResult` on both success and failure, turning indefinite waits into structured failures.  
- The fix must be minimal and focused at the choke point (bound direct execution) without changing planner prompts or verb semantics.  

### Description
- Add a dedicated bound-capability guard ` _bound_execution_timeout_seconds()` and apply it to the direct bound execution await in `execute_agent_chain`, ensuring a shorter, local timeout is used instead of relying on the outer default timeout (`services/orion-agent-chain/app/api.py`).  
- Handle `asyncio.TimeoutError` from the bound-capability execution by returning a structured fail-closed `AgentChainResult` whose `structured.bound_capability` reports `path="bound_direct_timeout"`, `reason=capability_executor_unavailable`, and `observation.reply_emitted=True`.  
- Add `test_bound_capability_timeout_terminal_reply` to prove the terminal reply on hanging executors and adjust a test helper signature in `test_bus_listener_rpc.py` to match the `_resolve_tools` contract (`services/orion-agent-chain/tests/*`).  

### Testing
- Executed the agent-chain test subset with the service code on PYTHONPATH: `PYTHONPATH=/workspace/Orion-Sapienform:/workspace/Orion-Sapienform/services/orion-agent-chain pytest -q services/orion-agent-chain/tests/test_bound_capability_contract.py services/orion-agent-chain/tests/test_bus_listener_rpc.py services/orion-agent-chain/tests/test_agent_chain_rpc_fork.py`.  
- Result: all tests passed (`16 passed`, `4 warnings`).  
- Tests added/updated: added `test_bound_capability_timeout_terminal_reply` (verifies terminal reply on executor timeout) and updated `test_bus_listener_rpc.py` helper to match current `_resolve_tools` signature; existing bound-capability contract tests still pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71deaf440832a823b481cb4363583)