### PR TITLE
Fix Orion Hub Postgres URL handling for host network mode

### DIFF
--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -101,9 +101,19 @@ HUB_SOCIAL_STYLE_CONFIDENCE_FLOOR=0.35
 HUB_DEFAULT_NO_WRITE=false
 HUB_AUTO_DEFAULT_ENABLED=false
 
+# --- Hub Docker networking posture ---
+# Hub docker-compose uses network_mode: "host" by default.
+# In host mode, Docker service DNS names (for example "orion-athena-sql-db") do NOT resolve.
+# Use a host-reachable Postgres host instead: 127.0.0.1, LAN IP, Tailscale IP, etc.
+HUB_DOCKER_NETWORK_MODE=host
+
 # --- Substrate control-plane SQL source (Phase 20c parity) ---
+# Precedence for Hub control-plane reads:
+# 1) SUBSTRATE_CONTROL_PLANE_POSTGRES_URL
+# 2) SUBSTRATE_POLICY_POSTGRES_URL
+# 3) DATABASE_URL
 # Prefer shared operational Postgres over local sqlite seams.
-DATABASE_URL=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/conjourney
 SUBSTRATE_CONTROL_PLANE_POSTGRES_URL=
 SUBSTRATE_POLICY_POSTGRES_URL=
 SUBSTRATE_REVIEW_QUEUE_SQL_DB_PATH=

--- a/services/orion-hub/docker-compose.yml
+++ b/services/orion-hub/docker-compose.yml
@@ -6,7 +6,11 @@ services:
       dockerfile: services/orion-hub/Dockerfile
     container_name: ${PROJECT}-hub
 
-    # use when on atlas:
+    # Default deployment posture for Hub:
+    # network_mode: "host" means this container resolves hosts through the host network stack.
+    # In this mode, Docker service DNS names (e.g. "orion-athena-sql-db") are not valid DB hosts.
+    # Use a host-reachable Postgres host in *_POSTGRES_URL / DATABASE_URL
+    # (127.0.0.1, LAN IP, Tailscale IP, etc.).
     network_mode: "host"
 
     # use when on athena:
@@ -112,6 +116,9 @@ services:
       - HUB_SOCIAL_STYLE_CONFIDENCE_FLOOR=${HUB_SOCIAL_STYLE_CONFIDENCE_FLOOR}
       - HUB_DEFAULT_NO_WRITE=${HUB_DEFAULT_NO_WRITE}
       - HUB_AUTO_DEFAULT_ENABLED=${HUB_AUTO_DEFAULT_ENABLED}
+      - HUB_DOCKER_NETWORK_MODE=${HUB_DOCKER_NETWORK_MODE:-host}
+      # Control-plane Postgres precedence in Hub:
+      # SUBSTRATE_CONTROL_PLANE_POSTGRES_URL -> SUBSTRATE_POLICY_POSTGRES_URL -> DATABASE_URL
       - DATABASE_URL=${DATABASE_URL}
       - SUBSTRATE_CONTROL_PLANE_POSTGRES_URL=${SUBSTRATE_CONTROL_PLANE_POSTGRES_URL}
       - SUBSTRATE_POLICY_POSTGRES_URL=${SUBSTRATE_POLICY_POSTGRES_URL}

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+import ipaddress
 from datetime import datetime, timezone
 from uuid import uuid4
 from typing import Optional, Any, List, Dict, Tuple
+from urllib.parse import urlparse
 import aiohttp
 
 from fastapi import APIRouter, Header, HTTPException, Query, Request
@@ -61,15 +63,57 @@ PROCESS_STARTED_AT_UTC = datetime.now(timezone.utc)
 
 router = APIRouter()
 
+
+def _hub_uses_host_network_mode() -> bool:
+    mode = str(os.getenv("HUB_DOCKER_NETWORK_MODE", "")).strip().lower()
+    return mode == "host"
+
+
+def _postgres_url_host(postgres_url: str) -> str:
+    try:
+        return str(urlparse(postgres_url).hostname or "").strip()
+    except Exception:
+        return ""
+
+
+def _looks_like_docker_service_hostname(postgres_url: str) -> bool:
+    host = _postgres_url_host(postgres_url)
+    if not host:
+        return False
+    if host in {"localhost", "host.docker.internal"}:
+        return False
+    try:
+        ipaddress.ip_address(host)
+        return False
+    except ValueError:
+        pass
+    return "." not in host
+
+
+def _resolve_control_plane_postgres_url() -> Optional[str]:
+    control_plane_url = str(os.getenv("SUBSTRATE_CONTROL_PLANE_POSTGRES_URL", "")).strip()
+    policy_url = str(os.getenv("SUBSTRATE_POLICY_POSTGRES_URL", "")).strip()
+    database_url = str(os.getenv("DATABASE_URL", "")).strip()
+    resolved = control_plane_url or policy_url or database_url or None
+    if resolved and _hub_uses_host_network_mode() and _looks_like_docker_service_hostname(resolved):
+        logger.warning(
+            "Hub is configured for host networking (HUB_DOCKER_NETWORK_MODE=host), "
+            "but the resolved Postgres hostname '%s' looks like a Docker service name. "
+            "Use a host-reachable address (for example 127.0.0.1, LAN IP, or Tailscale IP).",
+            _postgres_url_host(resolved),
+        )
+    return resolved
+
+
 SUBSTRATE_REVIEW_QUEUE_STORE = GraphReviewQueue(
     max_items=200,
     sql_db_path=str(os.getenv("SUBSTRATE_REVIEW_QUEUE_SQL_DB_PATH", "")).strip() or None,
-    postgres_url=str(os.getenv("SUBSTRATE_CONTROL_PLANE_POSTGRES_URL", "")).strip() or str(os.getenv("DATABASE_URL", "")).strip() or None,
+    postgres_url=_resolve_control_plane_postgres_url(),
 )
 SUBSTRATE_REVIEW_TELEMETRY_STORE = GraphReviewTelemetryRecorder(
     max_records=2000,
     sql_db_path=str(os.getenv("SUBSTRATE_REVIEW_TELEMETRY_SQL_DB_PATH", "")).strip() or None,
-    postgres_url=str(os.getenv("SUBSTRATE_CONTROL_PLANE_POSTGRES_URL", "")).strip() or str(os.getenv("DATABASE_URL", "")).strip() or None,
+    postgres_url=_resolve_control_plane_postgres_url(),
 )
 SUBSTRATE_SEMANTIC_STORE = build_substrate_store_from_env()
 SUBSTRATE_POLICY_STORE = build_substrate_policy_store_from_env()

--- a/services/orion-hub/tests/test_postgres_env_resolution.py
+++ b/services/orion-hub/tests/test_postgres_env_resolution.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("CHANNEL_VOICE_TRANSCRIPT", "orion:voice:transcript")
+os.environ.setdefault("CHANNEL_VOICE_LLM", "orion:voice:llm")
+os.environ.setdefault("CHANNEL_VOICE_TTS", "orion:voice:tts")
+os.environ.setdefault("CHANNEL_COLLAPSE_INTAKE", "orion:collapse:intake")
+os.environ.setdefault("CHANNEL_COLLAPSE_TRIAGE", "orion:collapse:triage")
+
+HUB_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+for candidate in (str(REPO_ROOT), str(HUB_ROOT)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+from scripts import api_routes
+
+
+def test_control_plane_postgres_resolution_precedence(monkeypatch) -> None:
+    monkeypatch.setenv("SUBSTRATE_CONTROL_PLANE_POSTGRES_URL", "postgresql://cp:pw@10.0.0.8:5432/control")
+    monkeypatch.setenv("SUBSTRATE_POLICY_POSTGRES_URL", "postgresql://policy:pw@10.0.0.9:5432/policy")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://db:pw@10.0.0.10:5432/default")
+
+    assert api_routes._resolve_control_plane_postgres_url() == "postgresql://cp:pw@10.0.0.8:5432/control"
+
+
+def test_control_plane_postgres_resolution_falls_back_to_policy_then_database(monkeypatch) -> None:
+    monkeypatch.delenv("SUBSTRATE_CONTROL_PLANE_POSTGRES_URL", raising=False)
+    monkeypatch.setenv("SUBSTRATE_POLICY_POSTGRES_URL", "postgresql://policy:pw@10.0.0.9:5432/policy")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://db:pw@10.0.0.10:5432/default")
+
+    assert api_routes._resolve_control_plane_postgres_url() == "postgresql://policy:pw@10.0.0.9:5432/policy"
+
+    monkeypatch.delenv("SUBSTRATE_POLICY_POSTGRES_URL", raising=False)
+
+    assert api_routes._resolve_control_plane_postgres_url() == "postgresql://db:pw@10.0.0.10:5432/default"
+
+
+def test_host_network_mode_warns_on_docker_service_hostname(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("HUB_DOCKER_NETWORK_MODE", "host")
+    monkeypatch.setenv("SUBSTRATE_CONTROL_PLANE_POSTGRES_URL", "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney")
+
+    with caplog.at_level(logging.WARNING, logger="orion-hub.api"):
+        resolved = api_routes._resolve_control_plane_postgres_url()
+
+    assert resolved == "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+    assert "looks like a Docker service name" in caplog.text


### PR DESCRIPTION
### Motivation
- Hub running with `network_mode: "host"` was inheriting Docker-style service hostnames (e.g. `orion-athena-sql-db`) which do not resolve from host-networked containers causing control-plane Postgres connectivity failures. 
- The intent is to make Postgres connectivity explicit and operator-friendly for host-network deployments without altering control-plane architecture or precedence semantics. 
- Make precedence, documentation, and a minimal runtime guard explicit so operators get actionable warnings when misconfigured.

### Description
- Introduced a small resolver helper in `services/orion-hub/scripts/api_routes.py` that enforces explicit precedence: `SUBSTRATE_CONTROL_PLANE_POSTGRES_URL` → `SUBSTRATE_POLICY_POSTGRES_URL` → `DATABASE_URL`, and returns the resolved URL. 
- Added host-network detection (`HUB_DOCKER_NETWORK_MODE`) and a lightweight heuristic that warns when the resolved Postgres host looks like a single-label Docker service name while Hub is running in host mode. 
- Updated `services/orion-hub/.env_example` to document host-network posture, add `HUB_DOCKER_NETWORK_MODE=host`, and replace the Docker-service DB example with a host-reachable example (`127.0.0.1`). 
- Added clarifying comments and passthrough of `HUB_DOCKER_NETWORK_MODE` plus precedence notes to `services/orion-hub/docker-compose.yml`. 
- Added focused unit tests at `services/orion-hub/tests/test_postgres_env_resolution.py` to cover precedence and the host-mode warning behavior.

### Testing
- Ran the new feature tests with `pytest -q services/orion-hub/tests/test_postgres_env_resolution.py` and they all passed (`3 passed`).
- Ran related substrate UI tests with `pytest -q services/orion-hub/tests/test_substrate_standalone_page.py` to ensure no regressions and they passed (`6 passed`).
- No other automated tests were changed and no failures were observed while validating the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d728516d30832a9d33fe2bc3e36aeb)