### PR TITLE
Supervisor: enforce semantic override for operational asks and preserve bound-capability failures in finalization/trace

### DIFF
--- a/orion/normalizers/agent_trace.py
+++ b/orion/normalizers/agent_trace.py
@@ -215,6 +215,14 @@ def _step_summary(step: StepExecutionResult, tool_id: str | None) -> str:
         return "Recall retrieved memory context."
     if service_key == "AgentChainService":
         agent_payload = step.result.get("AgentChainService") if isinstance(step.result, dict) else {}
+        bound_payload = agent_payload.get("bound_capability") if isinstance(agent_payload, dict) else {}
+        if isinstance(bound_payload, dict):
+            bound_status = str(bound_payload.get("status") or "").strip().lower()
+            bound_reason = str(bound_payload.get("reason") or "").strip()
+            bound_detail = str(bound_payload.get("detail") or "").strip()
+            if bound_status == "fail" or bound_reason:
+                message = bound_detail or bound_reason or "bound capability failure"
+                return f"Bound capability execution failed: {_coerce_text(message, limit=140)}."
         nested = []
         if isinstance(agent_payload, dict):
             planner_raw = agent_payload.get("planner_raw") if isinstance(agent_payload.get("planner_raw"), dict) else {}
@@ -380,7 +388,14 @@ def _join_phrases(items: List[str]) -> str:
     return ", ".join(filtered[:-1]) + f", and {filtered[-1]}"
 
 
-def _deterministic_summary(*, tools: List[AgentTraceToolStatV1], action_counts: Dict[str, int], effect_counts: Dict[str, int], final_text: str | None) -> str:
+def _deterministic_summary(
+    *,
+    tools: List[AgentTraceToolStatV1],
+    action_counts: Dict[str, int],
+    effect_counts: Dict[str, int],
+    final_text: str | None,
+    failed_step_count: int,
+) -> str:
     families = []
     seen = set()
     for tool in tools:
@@ -425,6 +440,8 @@ def _deterministic_summary(*, tools: List[AgentTraceToolStatV1], action_counts: 
         sentence += f" with {_join_phrases(effect_notes)}"
     else:
         sentence += " without write or side-effect actions"
+    if failed_step_count > 0:
+        sentence += f", and encountered {failed_step_count} failed {_pluralize('step', failed_step_count)}"
     return sentence + "."
 
 
@@ -453,11 +470,15 @@ def build_agent_trace_summary(
     unique_families.sort(key=lambda value: TOOL_FAMILY_ORDER.index(value) if value in TOOL_FAMILY_ORDER else 999)
     action_counts = _counts_with_order(action_counter, ACTION_ORDER)
     effect_counts = _counts_with_order(effect_counter, EFFECT_ORDER)
+    failed_step_count = sum(1 for step in normalized_steps if str(step.status or "").lower() not in {"success"})
+    if failed_step_count == 0 and str(status or "").lower() not in {"success", "unknown"}:
+        failed_step_count = 1
     summary_text = _deterministic_summary(
         tools=tool_stats,
         action_counts=action_counts,
         effect_counts=effect_counts,
         final_text=final_text,
+        failed_step_count=failed_step_count,
     )
     raw_steps = [step.model_dump(mode="json") if hasattr(step, "model_dump") else step for step in (steps or [])]
     raw_metadata = metadata if isinstance(metadata, dict) else {}

--- a/services/orion-cortex-exec/app/supervisor.py
+++ b/services/orion-cortex-exec/app/supervisor.py
@@ -268,6 +268,61 @@ def _select_preferred_operational_tool(
     return best, scored
 
 
+def _should_override_planner_operational_action(
+    *,
+    planner_tool_id: str | None,
+    preferred_tool_id: str | None,
+    override_scores: List[Dict[str, Any]],
+    minimum_score_gap: int = 10,
+) -> tuple[bool, Dict[str, Any]]:
+    planner_id = str(planner_tool_id or "").strip()
+    preferred_id = str(preferred_tool_id or "").strip()
+    score_map = {
+        str(item.get("tool_id") or ""): int(item.get("score") or 0)
+        for item in (override_scores or [])
+        if str(item.get("tool_id") or "").strip()
+    }
+    planner_score = score_map.get(planner_id)
+    preferred_score = score_map.get(preferred_id)
+    diagnostics = {
+        "planner_tool_id": planner_id or None,
+        "preferred_tool_id": preferred_id or None,
+        "planner_score": planner_score,
+        "preferred_score": preferred_score,
+        "minimum_score_gap": minimum_score_gap,
+        "score_gap": (preferred_score - planner_score) if isinstance(preferred_score, int) and isinstance(planner_score, int) else None,
+    }
+    if not planner_id or not preferred_id or planner_id == preferred_id:
+        return False, diagnostics
+    if planner_score is None or preferred_score is None:
+        return False, diagnostics
+    should_override = (preferred_score - planner_score) >= int(minimum_score_gap)
+    return should_override, diagnostics
+
+
+def _extract_bound_failure_signal(step_results: List[StepExecutionResult]) -> Dict[str, Any] | None:
+    for step in reversed(step_results or []):
+        payload = (step.result or {}).get("AgentChainService") if isinstance(step.result, dict) else None
+        if not isinstance(payload, dict):
+            continue
+        bound = payload.get("bound_capability")
+        if not isinstance(bound, dict):
+            continue
+        status_value = str(bound.get("status") or "").strip().lower()
+        reason = str(bound.get("reason") or "").strip()
+        path = str(bound.get("path") or "").strip()
+        if status_value == "fail" or reason or path.startswith("bound_direct_"):
+            return {
+                "step_name": step.step_name,
+                "verb_name": step.verb_name,
+                "reason": reason or None,
+                "path": path or None,
+                "status": status_value or None,
+                "detail": str(bound.get("detail") or "").strip() or None,
+            }
+    return None
+
+
 def _sanitize_operational_history(messages: List[LLMMessage], *, user_text: str) -> Tuple[List[LLMMessage], Dict[str, Any]]:
     lowered = str(user_text or "").lower()
     safety_sensitive = any(token in lowered for token in ("dry-run", "dry run", "preview", "safe"))
@@ -1298,6 +1353,28 @@ class Supervisor:
 
             tool_id = (action or {}).get("tool_id") if isinstance(action, dict) else None
             logger.info("planner_action corr_id=%s tool_id=%s lane=%s", correlation_id, tool_id, "depth2")
+            if operational_intent_detected and preferred_operational_tool and mode in {"agent", "council"}:
+                should_override, override_diag = _should_override_planner_operational_action(
+                    planner_tool_id=str(tool_id or ""),
+                    preferred_tool_id=preferred_operational_tool.tool_id,
+                    override_scores=override_scores,
+                )
+                ctx.setdefault("debug", {})["semantic_override_decision"] = override_diag
+                if should_override and action:
+                    logger.info(
+                        "semantic_tool_override_applied corr_id=%s planner_tool=%s planner_score=%s preferred_tool=%s preferred_score=%s score_gap=%s",
+                        correlation_id,
+                        override_diag.get("planner_tool_id"),
+                        override_diag.get("planner_score"),
+                        override_diag.get("preferred_tool_id"),
+                        override_diag.get("preferred_score"),
+                        override_diag.get("score_gap"),
+                    )
+                    action = {
+                        **action,
+                        "tool_id": preferred_operational_tool.tool_id,
+                    }
+                    tool_id = preferred_operational_tool.tool_id
 
             if decision["stop_reason"] == "final_answer" and not decision["action_present"]:
                 forced_delegate = False
@@ -1638,7 +1715,9 @@ class Supervisor:
             verdict["scaffolding_markers"],
         )
         explanation_downgrade = bool((ctx.get("debug") or {}).get("downgraded_to_explanation"))
-        if not verdict["anchored"] and not recent_followup_continuity and not explanation_downgrade:
+        bound_failure_signal = _extract_bound_failure_signal(step_results)
+        preserve_operational_failure_text = bound_failure_signal is not None
+        if not verdict["anchored"] and not recent_followup_continuity and not explanation_downgrade and not preserve_operational_failure_text:
             logger.warning(
                 "grounding_guardrail_triggered corr_id=%s ask_head=%r answer_head=%r",
                 correlation_id,
@@ -1649,6 +1728,13 @@ class Supervisor:
                 f"I may have drifted from your request. You asked: {user_text}\n\n"
                 "Could you restate the key constraint and I will answer directly from that prompt?"
             )
+        elif preserve_operational_failure_text:
+            logger.info(
+                "grounding_guardrail_bypassed_for_operational_failure corr_id=%s reason=%s path=%s",
+                correlation_id,
+                bound_failure_signal.get("reason"),
+                bound_failure_signal.get("path"),
+            )
 
         runtime_policy_meta = {
             "no_write_active": no_write_active,
@@ -1657,6 +1743,7 @@ class Supervisor:
             "semantic_tool_preferred": bool(operational_intent_detected and preferred_operational_tool),
             "downgraded_to_explanation": bool((ctx.get("debug") or {}).get("downgraded_to_explanation")),
             "selected_tool_would_have_been": selected_tool_would_have_been,
+            "bound_failure_signal": bound_failure_signal,
         }
         logger.info(
             "blocked_execution_explanation_emitted corr_id=%s emitted=%s selected_tool=%s",
@@ -1666,6 +1753,16 @@ class Supervisor:
         )
 
         overall_status = "success" if step_results and all(s.status == "success" for s in step_results if s) else "partial"
+        overall_error: str | None = None
+        if bound_failure_signal is not None:
+            overall_status = "fail"
+            overall_error = (
+                bound_failure_signal.get("detail")
+                or bound_failure_signal.get("reason")
+                or "bound_capability_failed"
+            )
+        elif overall_status != "success":
+            overall_error = step_results[-1].error if step_results else None
         return PlanExecutionResult(
             verb_name=req.verb_name,
             request_id=correlation_id,
@@ -1678,5 +1775,5 @@ class Supervisor:
             memory_used=memory_used,
             recall_debug=recall_debug,
             metadata={"runtime_policy": runtime_policy_meta},
-            error=None,
+            error=overall_error,
         )

--- a/services/orion-cortex-exec/tests/test_supervisor_planner_delegate.py
+++ b/services/orion-cortex-exec/tests/test_supervisor_planner_delegate.py
@@ -199,6 +199,116 @@ class OperationalPreferenceSupervisor(Supervisor):
         )
 
 
+class PlannerConflictOperationalSupervisor(Supervisor):
+    def __init__(self):
+        super().__init__(MagicMock())
+        self.executed_tool_ids = []
+
+    def _toolset(self, packs=None, tags=None):
+        return [
+            ToolDef(
+                tool_id="housekeep_runtime",
+                description="Runtime housekeeping and container cleanup",
+                input_schema={},
+                output_schema={},
+                execution_mode="capability_backed",
+                preferred_skill_families=["runtime_housekeeping"],
+                side_effect_level="low",
+            ),
+            ToolDef(
+                tool_id="assess_runtime_state",
+                description="Assess runtime status and health",
+                input_schema={},
+                output_schema={},
+                execution_mode="capability_backed",
+                preferred_skill_families=["runtime_health"],
+                side_effect_level="none",
+            ),
+        ]
+
+    async def _planner_step(self, **kwargs):
+        step = StepExecutionResult(
+            status="success",
+            verb_name="planner",
+            step_name="planner_react",
+            order=0,
+            result={
+                "PlannerReactService": {
+                    "status": "ok",
+                    "trace": [{"thought": "delegate", "action": {"tool_id": "assess_runtime_state", "input": {"text": "list stopped containers"}}}],
+                    "stop_reason": "delegate",
+                }
+            },
+            latency_ms=1,
+            node="test",
+            logs=["ok"],
+            error=None,
+        )
+        return None, step, None, {"tool_id": "assess_runtime_state", "input": {"text": "list stopped containers"}}
+
+    async def _execute_action(self, **kwargs):
+        action = kwargs.get("action") or {}
+        tool_id = action.get("tool_id")
+        self.executed_tool_ids.append(tool_id)
+        return StepExecutionResult(
+            status="success",
+            verb_name=str(tool_id),
+            step_name="agent_chain",
+            order=1,
+            result={"AgentChainService": {"text": "dry-run cleanup of stopped containers completed"}},
+            latency_ms=1,
+            node="test",
+            logs=["ok"],
+            error=None,
+        )
+
+
+class BoundFailureSupervisor(Supervisor):
+    def __init__(self):
+        super().__init__(MagicMock())
+
+    def _toolset(self, packs=None, tags=None):
+        return [ToolDef(tool_id="agent_chain", description="delegate", input_schema={}, output_schema={})]
+
+    async def _planner_step(self, **kwargs):
+        step = StepExecutionResult(
+            status="success",
+            verb_name="planner",
+            step_name="planner_react",
+            order=0,
+            result={"PlannerReactService": {"status": "ok", "trace": [{"thought": "delegate", "action": {"tool_id": "agent_chain", "input": {}}}], "stop_reason": "delegate"}},
+            latency_ms=1,
+            node="test",
+            logs=["ok"],
+            error=None,
+        )
+        return None, step, None, {"tool_id": "agent_chain", "input": {}}
+
+    async def _execute_action(self, **kwargs):
+        return StepExecutionResult(
+            status="success",
+            verb_name="agent_chain",
+            step_name="agent_chain",
+            order=100,
+            result={
+                "AgentChainService": {
+                    "text": "Bound capability execution failed: capability execution timed out after 25.00s",
+                    "bound_capability": {
+                        "status": "fail",
+                        "reason": "capability_executor_unavailable",
+                        "path": "bound_direct_timeout",
+                        "detail": "capability execution timed out after 25.00s",
+                    },
+                    "runtime_debug": {"bound_capability_terminal_path": "bound_direct_timeout"},
+                }
+            },
+            latency_ms=1,
+            node="test",
+            logs=["ok"],
+            error=None,
+        )
+
+
 class TestSupervisorPlannerDelegate(unittest.TestCase):
     def _run(self, planner_outputs, action_step_output=None, action_outputs=None):
         supervisor = StubSupervisor(planner_outputs, action_step_output=action_step_output, action_outputs=action_outputs)
@@ -435,6 +545,56 @@ class TestSupervisorPlannerDelegate(unittest.TestCase):
         self.assertIn("Execution is disabled in this session", result.final_text or "")
         self.assertTrue(result.metadata["runtime_policy"]["no_write_active"])
         self.assertTrue(result.metadata["runtime_policy"]["downgraded_to_explanation"])
+
+    def test_operational_semantic_override_wins_over_lower_scored_planner_action(self):
+        supervisor = PlannerConflictOperationalSupervisor()
+        source = ServiceRef(name="test", node="test", version="1.0")
+        req = ExecutionPlan(verb_name="chat", steps=[], metadata={"mode": "agent"})
+        ctx = {
+            "mode": "agent",
+            "messages": [{"role": "user", "content": "dry-run cleanup of stopped containers"}],
+            "max_steps": 1,
+        }
+        result = asyncio.run(
+            supervisor.execute(
+                source=source,
+                req=req,
+                correlation_id="corr-override",
+                ctx=ctx,
+                recall_cfg={"enabled": False},
+            )
+        )
+        self.assertIn("housekeep_runtime", supervisor.executed_tool_ids)
+        self.assertNotIn("assess_runtime_state", supervisor.executed_tool_ids)
+        self.assertIn("cleanup", result.final_text or "")
+        override_diag = (ctx.get("debug") or {}).get("semantic_override_decision", {})
+        self.assertEqual(override_diag.get("planner_tool_id"), "assess_runtime_state")
+        self.assertEqual(override_diag.get("preferred_tool_id"), "housekeep_runtime")
+
+    def test_bound_failure_passthrough_not_rewritten_by_grounding_guardrail(self):
+        supervisor = BoundFailureSupervisor()
+        source = ServiceRef(name="test", node="test", version="1.0")
+        req = ExecutionPlan(verb_name="chat", steps=[], metadata={"mode": "agent"})
+        ctx = {
+            "mode": "agent",
+            "messages": [{"role": "user", "content": "list stopped containers"}],
+            "max_steps": 1,
+        }
+        result = asyncio.run(
+            supervisor.execute(
+                source=source,
+                req=req,
+                correlation_id="corr-bound-failure",
+                ctx=ctx,
+                recall_cfg={"enabled": False},
+            )
+        )
+        assert result.final_text is not None
+        self.assertIn("Bound capability execution failed", result.final_text)
+        self.assertNotIn("I may have drifted from your request", result.final_text)
+        self.assertEqual(result.status, "fail")
+        self.assertIn("runtime_policy", result.metadata)
+        self.assertEqual(result.metadata["runtime_policy"]["bound_failure_signal"]["path"], "bound_direct_timeout")
 
     def test_operational_guidance_blocked_without_validated_semantic_execution(self):
         supervisor = StubSupervisor(

--- a/services/orion-cortex-orch/tests/test_agent_trace_bound_failure_summary.py
+++ b/services/orion-cortex-orch/tests/test_agent_trace_bound_failure_summary.py
@@ -1,0 +1,56 @@
+from orion.normalizers.agent_trace import build_agent_trace_summary
+from orion.schemas.cortex.schemas import StepExecutionResult
+
+
+def test_agent_trace_summary_surfaces_bound_failure_details():
+    steps = [
+        StepExecutionResult(
+            status="success",
+            verb_name="planner",
+            step_name="planner_react",
+            order=0,
+            result={"PlannerReactService": {"trace": [{"action": {"tool_id": "assess_runtime_state"}}]}},
+            latency_ms=2,
+            node="test",
+            logs=[],
+            error=None,
+        ),
+        StepExecutionResult(
+            status="success",
+            verb_name="agent_chain",
+            step_name="agent_chain",
+            order=1,
+            result={
+                "AgentChainService": {
+                    "text": "Bound capability execution failed: capability execution timed out after 25.00s",
+                    "bound_capability": {
+                        "status": "fail",
+                        "reason": "capability_executor_unavailable",
+                        "path": "bound_direct_timeout",
+                        "detail": "capability execution timed out after 25.00s",
+                    },
+                }
+            },
+            latency_ms=25,
+            node="test",
+            logs=[],
+            error=None,
+        ),
+    ]
+
+    summary = build_agent_trace_summary(
+        correlation_id="corr-1",
+        message_id="corr-1",
+        mode="agent",
+        status="fail",
+        final_text="Bound capability execution failed: capability execution timed out after 25.00s",
+        steps=steps,
+        metadata={},
+    )
+
+    assert summary is not None
+    assert summary.status == "fail"
+    assert "encountered 1 failed step" in summary.summary_text
+    step_summaries = [s.summary for s in summary.steps if s.tool_id == "agent_chain"]
+    assert step_summaries
+    assert "Bound capability execution failed" in step_summaries[0]


### PR DESCRIPTION
### Motivation

- Clarify authority for operational asks so supervisor can override a lower-fit planner action when a semantically stronger operational tool is available. 
- Preserve truthful, structured bound-capability failure information (e.g., 25s executor timeout) instead of letting grounding/finalization rewrite it into a generic "I may have drifted" message. 
- Ensure top-level plan status and agent trace summaries honestly reflect nested operational/tool failures.

### Description

- Added a score-gap based arbitration helper `_should_override_planner_operational_action` and applied it in the Supervisor loop to replace planner-selected operational actions when the supervisor's semantic candidate is materially stronger (default gap threshold). 
- Added `_extract_bound_failure_signal` to detect structured bound-capability failure payloads returned by Agent Chain and used that signal to: bypass the grounding guardrail that would replace authoritative failure text, include a `bound_failure_signal` entry in runtime metadata, and force top-level `status="fail"` with a propagated `error` detail. 
- Updated finalization logic so the grounding guardrail no longer rewrites explicit bound-capability failure replies into generic drift/restatement prompts. 
- Enhanced agent-trace normalization and deterministic summary generation to surface bound-capability failure phrasing in step summaries and to include failed-step counts in the summary text. 
- Added and updated unit tests exercising: supervisor authority override (planner vs supervisor), bound-capability timeout passthrough (no drift rewrite), and agent-trace failure summarization. Files changed: `services/orion-cortex-exec/app/supervisor.py`, `orion/normalizers/agent_trace.py`, test updates in `services/orion-cortex-exec/tests/test_supervisor_planner_delegate.py`, and a new test `services/orion-cortex-orch/tests/test_agent_trace_bound_failure_summary.py`.

### Testing

- Ran targeted pytest slices: `pytest -q services/orion-cortex-exec/tests/test_supervisor_planner_delegate.py services/orion-cortex-orch/tests/test_agent_trace_bound_failure_summary.py` and `PYTHONPATH=.:services/orion-agent-chain pytest -q services/orion-agent-chain/tests/test_bound_capability_contract.py::test_bound_capability_timeout_terminal_reply`. All exercised tests passed locally (final run: 22 passed for the supervisor/test-suite slice; agent-chain bound timeout test passed). 
- The tests added/updated are: `TestSupervisorPlannerDelegate::test_operational_semantic_override_wins_over_lower_scored_planner_action`, `TestSupervisorPlannerDelegate::test_bound_failure_passthrough_not_rewritten_by_grounding_guardrail`, and `test_agent_trace_summary_surfaces_bound_failure_details`.
- No schema, bus channel or environment var contracts were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72980f970832a855731651b65bee1)