### PR TITLE
Preserve structured bound-capability failures and relax bound-execution timeout

### DIFF
--- a/orion/normalizers/agent_trace.py
+++ b/orion/normalizers/agent_trace.py
@@ -215,7 +215,15 @@ def _step_summary(step: StepExecutionResult, tool_id: str | None) -> str:
         return "Recall retrieved memory context."
     if service_key == "AgentChainService":
         agent_payload = step.result.get("AgentChainService") if isinstance(step.result, dict) else {}
-        bound_payload = agent_payload.get("bound_capability") if isinstance(agent_payload, dict) else {}
+        bound_payload = {}
+        if isinstance(agent_payload, dict):
+            direct_bound = agent_payload.get("bound_capability")
+            if isinstance(direct_bound, dict):
+                bound_payload = direct_bound
+            else:
+                structured = agent_payload.get("structured")
+                if isinstance(structured, dict) and isinstance(structured.get("bound_capability"), dict):
+                    bound_payload = structured.get("bound_capability") or {}
         if isinstance(bound_payload, dict):
             bound_status = str(bound_payload.get("status") or "").strip().lower()
             bound_reason = str(bound_payload.get("reason") or "").strip()

--- a/services/orion-agent-chain/app/api.py
+++ b/services/orion-agent-chain/app/api.py
@@ -456,7 +456,9 @@ def _bound_execution_timeout_seconds() -> float:
     the parent RPC time out first.
     """
     default_timeout = float(settings.default_timeout_seconds or 90)
-    return max(5.0, min(25.0, default_timeout * 0.5))
+    # Keep under the parent hop budget while allowing capability-backed verbs
+    # with 30s runtimes (e.g. runtime housekeeping) to complete under nominal load.
+    return max(8.0, min(45.0, default_timeout * 0.75))
 
 
 async def execute_agent_chain(

--- a/services/orion-agent-chain/tests/test_bound_capability_contract.py
+++ b/services/orion-agent-chain/tests/test_bound_capability_contract.py
@@ -288,3 +288,9 @@ def test_bound_capability_timeout_terminal_reply(monkeypatch):
     assert bound["reason"] == "capability_executor_unavailable"
     assert bound["observation"]["path"] == "bound_direct_timeout"
     assert bound["observation"]["reply_emitted"] is True
+
+
+def test_bound_execution_timeout_budget_is_below_parent_hop_budget():
+    timeout_sec = agent_api._bound_execution_timeout_seconds()
+    assert timeout_sec > 25.0
+    assert timeout_sec < float(agent_api.settings.default_timeout_seconds)

--- a/services/orion-cortex-exec/app/supervisor.py
+++ b/services/orion-cortex-exec/app/supervisor.py
@@ -301,11 +301,20 @@ def _should_override_planner_operational_action(
 
 
 def _extract_bound_failure_signal(step_results: List[StepExecutionResult]) -> Dict[str, Any] | None:
+    def _bound_payload(agent_payload: Dict[str, Any]) -> Dict[str, Any]:
+        direct = agent_payload.get("bound_capability")
+        if isinstance(direct, dict):
+            return direct
+        structured = agent_payload.get("structured")
+        if isinstance(structured, dict) and isinstance(structured.get("bound_capability"), dict):
+            return structured.get("bound_capability") or {}
+        return {}
+
     for step in reversed(step_results or []):
         payload = (step.result or {}).get("AgentChainService") if isinstance(step.result, dict) else None
         if not isinstance(payload, dict):
             continue
-        bound = payload.get("bound_capability")
+        bound = _bound_payload(payload)
         if not isinstance(bound, dict):
             continue
         status_value = str(bound.get("status") or "").strip().lower()
@@ -1499,6 +1508,10 @@ class Supervisor:
                 agent_payload = (action_step.result or {}).get("AgentChainService", {})
                 if isinstance(agent_payload, dict):
                     bound_payload = agent_payload.get("bound_capability")
+                    if not isinstance(bound_payload, dict):
+                        structured_payload = agent_payload.get("structured")
+                        if isinstance(structured_payload, dict):
+                            bound_payload = structured_payload.get("bound_capability")
                     if isinstance(bound_payload, dict) and str(bound_payload.get("path") or "").startswith("blocked_"):
                         ctx.setdefault("debug", {})["downgraded_to_explanation"] = True
                         ctx.setdefault("debug", {})["no_write_downgrade"] = True

--- a/services/orion-cortex-exec/tests/test_supervisor_planner_delegate.py
+++ b/services/orion-cortex-exec/tests/test_supervisor_planner_delegate.py
@@ -309,6 +309,35 @@ class BoundFailureSupervisor(Supervisor):
         )
 
 
+class StructuredBoundFailureSupervisor(BoundFailureSupervisor):
+    async def _execute_action(self, **kwargs):
+        return StepExecutionResult(
+            status="success",
+            verb_name="agent_chain",
+            step_name="agent_chain",
+            order=100,
+            result={
+                "AgentChainService": {
+                    "text": "Bound capability execution failed: capability execution timed out after 25.00s",
+                    "structured": {
+                        "finalization_reason": "bound_capability_fail_closed",
+                        "bound_capability": {
+                            "status": "fail",
+                            "reason": "capability_executor_unavailable",
+                            "path": "bound_direct_timeout",
+                            "detail": "capability execution timed out after 25.00s",
+                        },
+                    },
+                    "runtime_debug": {"bound_capability_terminal_path": "bound_direct_timeout"},
+                }
+            },
+            latency_ms=1,
+            node="test",
+            logs=["ok"],
+            error=None,
+        )
+
+
 class TestSupervisorPlannerDelegate(unittest.TestCase):
     def _run(self, planner_outputs, action_step_output=None, action_outputs=None):
         supervisor = StubSupervisor(planner_outputs, action_step_output=action_step_output, action_outputs=action_outputs)
@@ -594,6 +623,30 @@ class TestSupervisorPlannerDelegate(unittest.TestCase):
         self.assertNotIn("I may have drifted from your request", result.final_text)
         self.assertEqual(result.status, "fail")
         self.assertIn("runtime_policy", result.metadata)
+        self.assertEqual(result.metadata["runtime_policy"]["bound_failure_signal"]["path"], "bound_direct_timeout")
+
+    def test_structured_bound_failure_passthrough_not_rewritten_by_grounding_guardrail(self):
+        supervisor = StructuredBoundFailureSupervisor()
+        source = ServiceRef(name="test", node="test", version="1.0")
+        req = ExecutionPlan(verb_name="chat", steps=[], metadata={"mode": "agent"})
+        ctx = {
+            "mode": "agent",
+            "messages": [{"role": "user", "content": "cleanup stopped containers"}],
+            "max_steps": 1,
+        }
+        result = asyncio.run(
+            supervisor.execute(
+                source=source,
+                req=req,
+                correlation_id="corr-structured-bound-failure",
+                ctx=ctx,
+                recall_cfg={"enabled": False},
+            )
+        )
+        assert result.final_text is not None
+        self.assertIn("Bound capability execution failed", result.final_text)
+        self.assertNotIn("I may have drifted from your request", result.final_text)
+        self.assertEqual(result.status, "fail")
         self.assertEqual(result.metadata["runtime_policy"]["bound_failure_signal"]["path"], "bound_direct_timeout")
 
     def test_operational_guidance_blocked_without_validated_semantic_execution(self):

--- a/services/orion-cortex-orch/tests/test_agent_trace_bound_failure_summary.py
+++ b/services/orion-cortex-orch/tests/test_agent_trace_bound_failure_summary.py
@@ -54,3 +54,48 @@ def test_agent_trace_summary_surfaces_bound_failure_details():
     step_summaries = [s.summary for s in summary.steps if s.tool_id == "agent_chain"]
     assert step_summaries
     assert "Bound capability execution failed" in step_summaries[0]
+
+
+def test_agent_trace_summary_surfaces_structured_bound_failure_details():
+    steps = [
+        StepExecutionResult(
+            status="success",
+            verb_name="agent_chain",
+            step_name="agent_chain",
+            order=1,
+            result={
+                "AgentChainService": {
+                    "text": "Bound capability execution failed: capability execution timed out after 25.00s",
+                    "structured": {
+                        "finalization_reason": "bound_capability_fail_closed",
+                        "bound_capability": {
+                            "status": "fail",
+                            "reason": "capability_executor_unavailable",
+                            "path": "bound_direct_timeout",
+                            "detail": "capability execution timed out after 25.00s",
+                        },
+                    },
+                }
+            },
+            latency_ms=25,
+            node="test",
+            logs=[],
+            error=None,
+        ),
+    ]
+
+    summary = build_agent_trace_summary(
+        correlation_id="corr-structured",
+        message_id="corr-structured",
+        mode="agent",
+        status="fail",
+        final_text="Bound capability execution failed: capability execution timed out after 25.00s",
+        steps=steps,
+        metadata={},
+    )
+
+    assert summary is not None
+    assert summary.status == "fail"
+    step_summaries = [s.summary for s in summary.steps if s.tool_id == "agent_chain"]
+    assert step_summaries
+    assert "Bound capability execution failed" in step_summaries[0]


### PR DESCRIPTION
### Motivation
- Bound-capability timeout failures (e.g. `bound_direct_timeout`) were being emitted by Agent Chain but sometimes lost or rewritten by Exec finalization/grounding logic because only the legacy `AgentChainService.bound_capability` shape was inspected.  
- `housekeep_runtime` verbs have a `timeout_ms=30000` and can deterministically hit the agent-chain direct-execution budget; the guardrail budget was too tight relative to nested RPC/service overhead.  
- The goal is to ensure truthful operational failures are preserved end-to-end (user text, trace, and top-level status) while reducing spurious timeouts for genuine capability-backed verbs.

### Description
- Preserve structured bound failures: `services/orion-cortex-exec/app/supervisor.py` now recognizes both `AgentChainService.bound_capability` and `AgentChainService.structured.bound_capability` when extracting bound-failure signals and when deciding runtime-policy downgrade flags, so structured terminal failure payloads are treated as authoritative.  
- Surface structured failures in trace summaries: `orion/normalizers/agent_trace.py` updated `_step_summary()` to read the new structured payload shape, keeping agent-trace summaries operationally truthful.  
- Relax bound direct timeout budget: `services/orion-agent-chain/app/api.py` adjusted `_bound_execution_timeout_seconds()` from the restrictive ~25s cap to `max(8.0, min(45.0, default_timeout * 0.75))` so capability-backed verbs with ~30s runtimes have a better chance to complete while still remaining below the parent hop budget.  
- Tests and coverage: added regression tests exercising structured bound-failure passthrough and trace rendering and a guardrail-budget assertion in the bound-capability contract tests.

### Testing
- Added test cases: `test_structured_bound_failure_passthrough_not_rewritten_by_grounding_guardrail` (exec supervisor), `test_agent_trace_summary_surfaces_structured_bound_failure_details` (orch agent-trace summary), and `test_bound_execution_timeout_budget_is_below_parent_hop_budget` (agent-chain contract).  
- Ran targeted suites:  
  - `pytest -q services/orion-cortex-exec/tests/test_supervisor_planner_delegate.py services/orion-cortex-orch/tests/test_agent_trace_bound_failure_summary.py` — all tests passed.  
  - `PYTHONPATH=../../:. pytest -q tests/test_bound_capability_contract.py` (run from `services/orion-agent-chain`) — passed.  
- Result: new tests and updated suites validate that structured bound failures are preserved through finalization/grounding and that the timeout budget is less likely to cause deterministic failures while remaining below parent RPC timeouts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8588f2f5c832aaab387da5dd66695)