### PR TITLE
Fix nested agent-chain capability reply channel to use canonical cortex result family

### DIFF
--- a/services/orion-agent-chain/app/tool_executor.py
+++ b/services/orion-agent-chain/app/tool_executor.py
@@ -186,7 +186,10 @@ class ToolExecutor:
             )
 
         corr = str(uuid4())
-        reply_channel = f"orion:agent-chain:capability:reply:{corr}"
+        # Nested capability execution is a cortex-orch RPC and should use the
+        # canonical cortex result reply family so bus catalog enforcement and
+        # schema validation remain aligned.
+        reply_channel = f"orion:cortex:result:{corr}"
         normalized_input = self._normalize_inputs(tool_id, tool_input)
         req = CortexClientRequest(
             mode="brain",

--- a/services/orion-agent-chain/tests/test_tool_executor_capability.py
+++ b/services/orion-agent-chain/tests/test_tool_executor_capability.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from pathlib import Path
+
+import yaml
 
 from app.tool_executor import ToolExecutor
+from orion.core.bus.enforce import ChannelCatalogEnforcer
 
 
 class _FakeCodec:
@@ -17,7 +21,16 @@ class _FakeBus:
         self.calls = []
 
     async def rpc_request(self, channel, env, *, reply_channel, timeout_sec):
-        self.calls.append((channel, env.kind, env.payload.get("verb"), env.payload.get("context", {}).get("metadata", {})))
+        self.calls.append(
+            (
+                channel,
+                env.kind,
+                env.payload.get("verb"),
+                env.payload.get("context", {}).get("metadata", {}),
+                reply_channel,
+                env.reply_to,
+            )
+        )
         return {
             "data": {
                 "ok": True,
@@ -51,3 +64,29 @@ def test_capability_backed_tool_exec_normalizes_observation():
     metadata = bus.calls[0][3]
     assert metadata["requested_verb"] == "assess_runtime_state"
     assert "risk_class" in metadata
+    assert bus.calls[0][4].startswith("orion:cortex:result:")
+    assert bus.calls[0][5] == bus.calls[0][4]
+
+
+def test_capability_backed_tool_reply_channel_is_catalog_valid():
+    bus = _FakeBus()
+    executor = ToolExecutor(bus, base_dir="/workspace/Orion-Sapienform/orion/cognition")
+    asyncio.run(
+        executor.execute_llm_verb(
+            "housekeep_runtime",
+            {"text": "dry-run cleanup of stopped containers"},
+            parent_correlation_id="corr-2",
+        )
+    )
+    reply_channel = bus.calls[0][4]
+    assert reply_channel.startswith("orion:cortex:result:")
+
+    channels_yaml = Path("/workspace/Orion-Sapienform/orion/bus/channels.yaml")
+    raw = yaml.safe_load(channels_yaml.read_text(encoding="utf-8")) or {}
+    channels = raw.get("channels", [])
+    catalog = {entry["name"]: entry for entry in channels if isinstance(entry, dict) and entry.get("name")}
+    enforcer = ChannelCatalogEnforcer(enforce=True, catalog=catalog)
+
+    entry = enforcer.entry_for(reply_channel)
+    assert entry is not None
+    assert entry["schema_id"] == "CortexClientResult"

--- a/tests/test_exec_result_channel_catalog_specificity.py
+++ b/tests/test_exec_result_channel_catalog_specificity.py
@@ -37,3 +37,29 @@ def test_channel_enforcer_accepts_dedicated_verb_result_reply_channel() -> None:
 
     assert entry is not None
     assert entry["schema_id"] == "VerbResultV1"
+
+
+def test_channel_enforcer_accepts_cortex_result_reply_channel() -> None:
+    raw = yaml.safe_load(CHANNELS_YAML.read_text()) or {}
+    channels = raw.get("channels", [])
+    catalog = {entry["name"]: entry for entry in channels if isinstance(entry, dict) and entry.get("name")}
+    enforcer = ChannelCatalogEnforcer(enforce=True, catalog=catalog)
+
+    entry = enforcer.entry_for("orion:cortex:result:corr-123")
+
+    assert entry is not None
+    assert entry["schema_id"] == "CortexClientResult"
+
+
+def test_channel_enforcer_rejects_uncataloged_agent_chain_capability_reply_channel() -> None:
+    raw = yaml.safe_load(CHANNELS_YAML.read_text()) or {}
+    channels = raw.get("channels", [])
+    catalog = {entry["name"]: entry for entry in channels if isinstance(entry, dict) and entry.get("name")}
+    enforcer = ChannelCatalogEnforcer(enforce=True, catalog=catalog)
+
+    try:
+        enforcer.validate("orion:agent-chain:capability:reply:corr-123")
+    except ValueError as exc:
+        assert "Channel not found in catalog" in str(exc)
+    else:
+        raise AssertionError("Expected uncataloged nested capability reply channel to be rejected")


### PR DESCRIPTION
### Motivation
- Nested capability-backed RPCs from agent-chain used an uncataloged reply channel (`orion:agent-chain:capability:reply:<corr>`) which caused `orion-cortex-orch` to fail publishing replies under catalog enforcement and led to bound capability timeouts. 
- The repository already exposes a canonical cortex RPC result family (`orion:cortex:result*`) with `CortexClientResult` schema, so reusing that family preserves contract coherence and prevents enforcement failures.

### Description
- Changed nested capability reply channel in `services/orion-agent-chain/app/tool_executor.py` from `orion:agent-chain:capability:reply:{corr}` to the canonical `orion:cortex:result:{corr}` so Cortex orch replies validate against the catalog and schema. 
- Extended `services/orion-agent-chain/tests/test_tool_executor_capability.py` to assert the nested RPC uses the `orion:cortex:result:` prefix and to validate the chosen reply channel against the catalog returning `CortexClientResult`. 
- Extended `tests/test_exec_result_channel_catalog_specificity.py` to assert `orion:cortex:result:<corr>` resolves to `CortexClientResult` and to assert that the uncataloged `orion:agent-chain:capability:reply:<corr>` is rejected by the `ChannelCatalogEnforcer` in enforce mode.

### Testing
- Ran the new/related unit tests: `pytest -q tests/test_exec_result_channel_catalog_specificity.py` which passed. 
- Ran agent-chain unit tests with module path: `PYTHONPATH=.:services/orion-agent-chain pytest -q services/orion-agent-chain/tests/test_tool_executor_capability.py` which passed and confirmed the nested reply channel is `orion:cortex:result:*`. 
- Ran related cortex tests `PYTHONPATH=.:services/orion-cortex-orch pytest -q services/orion-cortex-orch/tests/test_verb_runtime_rpc.py` and `PYTHONPATH=.:services/orion-cortex-exec pytest -q services/orion-cortex-exec/tests/test_verb_runtime_reply_channel.py` which passed, providing end-to-end confidence that `CortexClientResult` reply family is honored and that the prior uncataloged channel would have been rejected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d863a1a140832a8856b91e253cd2b3)