### PR TITLE
Add operator-invoked bootstrap for substrate review queue and refresh-on-access durability hardening

### DIFF
--- a/orion/substrate/review_bootstrap.py
+++ b/orion/substrate/review_bootstrap.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from orion.core.schemas.substrate_consolidation import GraphConsolidationDecisionV1, GraphConsolidationResultV1
+from orion.substrate.review_schedule import GraphReviewScheduler
+from orion.substrate.store import SubstrateGraphStore, SubstrateQueryResultV1
+
+
+@dataclass(frozen=True)
+class GraphReviewBootstrapExecutionV1:
+    items_before: int
+    items_after: int
+    items_enqueued: int
+    due_after: int
+    scheduled_decision_count: int
+    semantic_source: str
+    semantic_degraded: bool
+    notes: list[str]
+
+
+class GraphReviewBootstrapper:
+    """Explicit operator-invoked bootstrap for initial review frontier seeding."""
+
+    def __init__(self, *, scheduler: GraphReviewScheduler, semantic_store: SubstrateGraphStore) -> None:
+        self._scheduler = scheduler
+        self._store = semantic_store
+
+    def bootstrap(self, *, now: datetime | None = None, query_limit: int = 12) -> GraphReviewBootstrapExecutionV1:
+        t = now or datetime.now(timezone.utc)
+        scheduling_now = t - timedelta(days=1)
+        limit_nodes = max(1, min(32, int(query_limit)))
+        limit_edges = max(4, min(64, int(limit_nodes * 2)))
+
+        queue_before = self._scheduler.queue.snapshot(limit=200).queue_items
+        before_ids = {item.queue_item_id for item in queue_before}
+
+        contradiction = self._store.query_contradiction_region(limit_nodes=limit_nodes, limit_edges=limit_edges)
+        hotspot = self._store.query_hotspot_region(limit_nodes=limit_nodes, limit_edges=limit_edges)
+        concept = self._store.query_concept_region(limit_nodes=limit_nodes, limit_edges=limit_edges)
+
+        seed_specs = [
+            ("contradiction_region", contradiction, "concept_graph"),
+            ("hotspot_region", hotspot, "autonomy_graph"),
+            ("concept_region", concept, "world_ontology"),
+        ]
+
+        scheduled_decision_count = 0
+        notes: list[str] = []
+
+        for query_kind, query_result, target_zone in seed_specs:
+            decision = self._build_decision(query_kind=query_kind, query_result=query_result, target_zone=target_zone)
+            if decision is None:
+                notes.append(f"seed_skipped:{query_kind}")
+                continue
+
+            anchor_scope, subject_ref = self._anchor_subject(query_result)
+            if anchor_scope is None:
+                notes.append(f"seed_skipped:{query_kind}:missing_anchor_scope")
+                continue
+
+            request_id = f"graph-review-bootstrap-{query_kind}-{uuid4()}"
+            consolidation_result = GraphConsolidationResultV1(
+                request_id=request_id,
+                decisions=[decision],
+                outcome_counts={decision.outcome: 1},
+                regions_reviewed=[query_kind, f"nodes:{len(query_result.slice.nodes)}", f"edges:{len(query_result.slice.edges)}"],
+                unresolved_regions=[query_kind] if decision.outcome in {"requeue_review", "maintain_priority"} else [],
+                confidence=decision.confidence,
+                degraded=bool(query_result.degraded),
+                notes=["operator_bootstrap_seed", f"query_kind:{query_kind}", f"source:{query_result.source_kind}"],
+            )
+            scheduled = self._scheduler.apply_consolidation_result(
+                consolidation_result=consolidation_result,
+                anchor_scope=anchor_scope,
+                subject_ref=subject_ref,
+                now=scheduling_now,
+                invocation_surface="operator_review",
+            )
+            scheduled_decision_count += len(scheduled.schedule_decisions)
+
+        queue_after = self._scheduler.queue.snapshot(limit=200).queue_items
+        after_ids = {item.queue_item_id for item in queue_after}
+        due_after = len(self._scheduler.queue.list_eligible(now=t, limit=200))
+
+        semantic_source = "mixed"
+        semantic_sources = {contradiction.source_kind, hotspot.source_kind, concept.source_kind}
+        if len(semantic_sources) == 1:
+            semantic_source = next(iter(semantic_sources))
+        semantic_degraded = bool(contradiction.degraded or hotspot.degraded or concept.degraded)
+
+        if not notes:
+            notes.append("bootstrap_seeded")
+
+        return GraphReviewBootstrapExecutionV1(
+            items_before=len(queue_before),
+            items_after=len(queue_after),
+            items_enqueued=len(after_ids - before_ids),
+            due_after=due_after,
+            scheduled_decision_count=scheduled_decision_count,
+            semantic_source=semantic_source,
+            semantic_degraded=semantic_degraded,
+            notes=notes[:16],
+        )
+
+    def _build_decision(
+        self,
+        *,
+        query_kind: str,
+        query_result: SubstrateQueryResultV1,
+        target_zone: str,
+    ) -> GraphConsolidationDecisionV1 | None:
+        nodes = query_result.slice.nodes
+        if not nodes:
+            return None
+
+        node_ids = sorted({node.node_id for node in nodes if node.node_id})[:8]
+        if not node_ids:
+            return None
+
+        if query_kind == "contradiction_region":
+            max_pressure = max(float(node.metadata.get("dynamic_pressure") or 0.0) for node in nodes)
+            unresolved = any(not bool(node.metadata.get("resolved", False)) for node in nodes)
+            high_pressure = max_pressure >= 0.6
+            outcome = "maintain_priority" if unresolved and high_pressure else "requeue_review"
+            reason = "bootstrap contradiction frontier"
+            priority = 90 if outcome == "maintain_priority" else 76
+            evidence = f"contradictions:{len(nodes)} pressure:{max_pressure:.3f}"
+            notes = ["bootstrap_seed", "contradiction_frontier"]
+        elif query_kind == "hotspot_region":
+            outcome = "requeue_review"
+            reason = "bootstrap hotspot frontier"
+            priority = 72
+            evidence = f"hotspots:{len(nodes)}"
+            notes = ["bootstrap_seed", "hotspot_frontier"]
+        else:
+            outcome = "requeue_review"
+            reason = "bootstrap concept frontier"
+            priority = 68
+            evidence = f"concepts:{len(nodes)}"
+            notes = ["bootstrap_seed", "concept_frontier"]
+
+        return GraphConsolidationDecisionV1(
+            target_refs=node_ids,
+            outcome=outcome,
+            reason=reason,
+            confidence=0.72,
+            zone=target_zone,
+            priority=priority,
+            notes=notes,
+            evidence_summary=evidence,
+        )
+
+    @staticmethod
+    def _anchor_subject(query_result: SubstrateQueryResultV1) -> tuple[str | None, str | None]:
+        for node in query_result.slice.nodes:
+            if node.anchor_scope:
+                return node.anchor_scope, node.subject_ref
+        return None, None

--- a/orion/substrate/review_queue.py
+++ b/orion/substrate/review_queue.py
@@ -47,6 +47,7 @@ class GraphReviewQueue:
         return self._last_error
 
     def upsert(self, item: GraphReviewQueueItemV1) -> None:
+        self.refresh_from_storage()
         region_key = self._region_key(item.focal_node_refs, item.target_zone)
         existing_id = None
         for item_id, existing in self._items.items():
@@ -74,6 +75,7 @@ class GraphReviewQueue:
         self._persist()
 
     def mark_reviewed(self, queue_item_id: str, *, reviewed_at: datetime | None = None) -> GraphReviewQueueItemV1 | None:
+        self.refresh_from_storage()
         item = self._items.get(queue_item_id)
         if item is None:
             return None
@@ -97,6 +99,7 @@ class GraphReviewQueue:
         return updated
 
     def apply_cycle_feedback(self, queue_item_id: str, *, no_change: bool) -> GraphReviewQueueItemV1 | None:
+        self.refresh_from_storage()
         item = self._items.get(queue_item_id)
         if item is None:
             return None
@@ -115,6 +118,7 @@ class GraphReviewQueue:
         return updated
 
     def list_eligible(self, *, now: datetime | None = None, limit: int = 10) -> list[GraphReviewQueueItemV1]:
+        self.refresh_from_storage()
         t = now or datetime.now(timezone.utc)
         eligible = [
             item
@@ -128,6 +132,7 @@ class GraphReviewQueue:
         return eligible[:limit]
 
     def snapshot(self, *, limit: int = 200) -> GraphReviewQueueSnapshotV1:
+        self.refresh_from_storage()
         items = sorted(self._items.values(), key=lambda item: (-item.priority, item.next_review_at, item.created_at))
         truncated = len(items) > limit
         items = items[:limit]
@@ -143,6 +148,26 @@ class GraphReviewQueue:
             top_priorities=[item.priority for item in items[:10]],
             truncated=truncated,
         )
+
+
+    def refresh_from_storage(self) -> None:
+        if self.postgres_url:
+            try:
+                self._load_from_postgres()
+                self._source_kind = "postgres"
+                self._last_error = None
+                return
+            except Exception as exc:
+                self._source_kind = "fallback"
+                self._last_error = str(exc)
+        if self.sql_db_path:
+            try:
+                self._load_from_sql()
+                self._source_kind = "sqlite"
+                self._last_error = None
+            except Exception as exc:
+                self._source_kind = "fallback"
+                self._last_error = str(exc)
 
     @staticmethod
     def _region_key(node_refs: list[str], zone: str) -> str:

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -54,6 +54,7 @@ from orion.substrate import build_substrate_policy_store_from_env, build_substra
 from orion.substrate.consolidation import GraphConsolidationEvaluator
 from orion.substrate.policy_comparison import SubstratePolicyComparisonService
 from orion.substrate.review_queue import GraphReviewQueue
+from orion.substrate.review_bootstrap import GraphReviewBootstrapper
 from orion.substrate.review_runtime import GraphReviewRuntimeExecutor
 from orion.substrate.review_schedule import GraphReviewScheduler
 from orion.substrate.review_telemetry import GraphReviewCalibrationAnalyzer, GraphReviewTelemetryRecorder
@@ -131,6 +132,10 @@ SUBSTRATE_REVIEW_RUNTIME_EXECUTOR = GraphReviewRuntimeExecutor(
     telemetry_recorder=SUBSTRATE_REVIEW_TELEMETRY_STORE,
     policy_profiles=SUBSTRATE_POLICY_STORE,
 )
+SUBSTRATE_REVIEW_BOOTSTRAPPER = GraphReviewBootstrapper(
+    scheduler=SUBSTRATE_REVIEW_RUNTIME_EXECUTOR.scheduler,
+    semantic_store=SUBSTRATE_SEMANTIC_STORE,
+)
 
 
 def _thought_debug_enabled() -> bool:
@@ -180,6 +185,10 @@ class SubstrateReviewExecuteRequest(BaseModel):
 
 class SubstrateReviewSmokeCheckRequest(BaseModel):
     limit: int = Field(default=10, ge=1, le=100)
+
+
+class SubstrateReviewBootstrapRequest(BaseModel):
+    limit: int = Field(default=12, ge=1, le=32)
 
 
 async def _execute_workflow_schedule_management(*, session_id: str, user_id: Optional[str], request: WorkflowScheduleManageRequestV1) -> Dict[str, Any]:
@@ -1585,6 +1594,7 @@ def _substrate_runtime_status_payload(*, queue_limit: int = 20, telemetry_limit:
 
 def _execute_substrate_review_cycle(*, allow_followup: bool, explicit_queue_item_id: str | None = None) -> Dict[str, Any]:
     now = datetime.now(timezone.utc)
+    SUBSTRATE_REVIEW_QUEUE_STORE.refresh_from_storage()
     before_due = len(SUBSTRATE_REVIEW_QUEUE_STORE.list_eligible(now=now, limit=200))
     before_count = len(SUBSTRATE_REVIEW_QUEUE_STORE.snapshot(limit=200).queue_items)
     request = GraphReviewRuntimeRequestV1(
@@ -1609,6 +1619,26 @@ def _execute_substrate_review_cycle(*, allow_followup: bool, explicit_queue_item
         "queue_before": {"count": before_count, "due_count": before_due},
         "queue_after": {"count": after_count, "due_count": after_due},
         "source": _substrate_source_posture(),
+    }
+
+
+def _bootstrap_substrate_review_frontier(*, limit: int = 12) -> Dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    SUBSTRATE_REVIEW_QUEUE_STORE.refresh_from_storage()
+    execution = SUBSTRATE_REVIEW_BOOTSTRAPPER.bootstrap(now=now, query_limit=limit)
+    return {
+        "generated_at": now.isoformat(),
+        "items_before": execution.items_before,
+        "items_enqueued": execution.items_enqueued,
+        "items_after": execution.items_after,
+        "due_after": execution.due_after,
+        "source_posture": _substrate_source_posture(),
+        "audit_summary": {
+            "scheduled_decision_count": execution.scheduled_decision_count,
+            "semantic_source": execution.semantic_source,
+            "semantic_degraded": execution.semantic_degraded,
+        },
+        "notes": execution.notes,
     }
 
 
@@ -1700,6 +1730,12 @@ def api_substrate_review_runtime_execute_once_followup(request: SubstrateReviewE
         allow_followup=True,
         explicit_queue_item_id=req.explicit_queue_item_id,
     )
+
+
+@router.post("/api/substrate/review-runtime/bootstrap")
+def api_substrate_review_runtime_bootstrap(request: SubstrateReviewBootstrapRequest | None = None) -> Dict[str, Any]:
+    req = request or SubstrateReviewBootstrapRequest()
+    return _bootstrap_substrate_review_frontier(limit=req.limit)
 
 
 @router.post("/api/substrate/review-runtime/smoke-check")

--- a/tests/test_cognitive_substrate_phase12_review_bootstrap.py
+++ b/tests/test_cognitive_substrate_phase12_review_bootstrap.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    ContradictionNodeV1,
+    GoalNodeV1,
+    NodeRefV1,
+    SubstrateEdgeV1,
+    SubstrateGraphRecordV1,
+    SubstrateProvenanceV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.core.schemas.substrate_review_runtime import GraphReviewRuntimeRequestV1
+from orion.substrate.consolidation import GraphConsolidationEvaluator
+from orion.substrate.materializer import SubstrateGraphMaterializer
+from orion.substrate.review_bootstrap import GraphReviewBootstrapper
+from orion.substrate.review_queue import GraphReviewQueue
+from orion.substrate.review_runtime import GraphReviewRuntimeExecutor
+from orion.substrate.review_schedule import GraphReviewScheduler
+from orion.substrate.store import InMemorySubstrateGraphStore
+
+
+def _temporal() -> SubstrateTemporalWindowV1:
+    return SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc))
+
+
+def _prov() -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="local_inferred",
+        source_kind="test",
+        source_channel="orion:test",
+        producer="pytest",
+    )
+
+
+def _edge(source: str, source_kind: str, target: str, target_kind: str) -> SubstrateEdgeV1:
+    return SubstrateEdgeV1(
+        source=NodeRefV1(node_id=source, node_kind=source_kind),
+        target=NodeRefV1(node_id=target, node_kind=target_kind),
+        predicate="supports",
+        temporal=_temporal(),
+        confidence=1.0,
+        salience=0.7,
+        provenance=_prov(),
+    )
+
+
+def _healthy_store() -> InMemorySubstrateGraphStore:
+    store = InMemorySubstrateGraphStore()
+    mat = SubstrateGraphMaterializer(store=store)
+    concept = ConceptNodeV1(
+        node_id="concept-1",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="C1",
+        temporal=_temporal(),
+        provenance=_prov(),
+        signals={"activation": {"activation": 0.8}, "salience": 0.81},
+        metadata={"dynamic_pressure": 0.75},
+    )
+    goal = GoalNodeV1(
+        node_id="goal-1",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        goal_text="G1",
+        temporal=_temporal(),
+        provenance=_prov(),
+        signals={"activation": {"activation": 0.73}, "salience": 0.77},
+        metadata={"dynamic_pressure": 0.7},
+    )
+    contradiction = ContradictionNodeV1(
+        node_id="contra-1",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        summary="conflict",
+        involved_node_ids=["concept-1", "goal-1"],
+        temporal=_temporal(),
+        provenance=_prov(),
+        signals={"activation": {"activation": 0.82}, "salience": 0.84},
+        metadata={"severity": 0.8, "dynamic_pressure": 0.86},
+    )
+    record = SubstrateGraphRecordV1(
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        nodes=[concept, goal, contradiction],
+        edges=[
+            _edge("concept-1", "concept", "goal-1", "goal"),
+            _edge("concept-1", "concept", "contra-1", "contradiction"),
+        ],
+    )
+    mat.apply_record(record)
+    return store
+
+
+def test_bootstrap_enqueues_on_meaningful_substrate_and_execute_once_runs() -> None:
+    store = _healthy_store()
+    queue = GraphReviewQueue(max_items=20)
+    scheduler = GraphReviewScheduler(queue=queue)
+    bootstrapper = GraphReviewBootstrapper(scheduler=scheduler, semantic_store=store)
+
+    seeded = bootstrapper.bootstrap(query_limit=12)
+    assert seeded.items_before == 0
+    assert seeded.items_enqueued >= 1
+    assert seeded.due_after >= 1
+
+    runtime = GraphReviewRuntimeExecutor(
+        queue=queue,
+        consolidation_evaluator=GraphConsolidationEvaluator(store=store),
+        scheduler=scheduler,
+    )
+    result = runtime.execute_once(
+        request=GraphReviewRuntimeRequestV1(invocation_surface="operator_review"),
+        now=datetime.now(timezone.utc),
+    )
+    assert result.outcome == "executed"
+
+
+def test_bootstrap_is_noop_on_empty_semantic_state() -> None:
+    store = InMemorySubstrateGraphStore()
+    queue = GraphReviewQueue(max_items=20)
+    scheduler = GraphReviewScheduler(queue=queue)
+    bootstrapper = GraphReviewBootstrapper(scheduler=scheduler, semantic_store=store)
+
+    seeded = bootstrapper.bootstrap(query_limit=12)
+    assert seeded.items_enqueued == 0
+    assert seeded.due_after == 0
+    assert any(note.startswith("seed_skipped:") for note in seeded.notes)
+
+
+def test_bootstrap_is_dedup_safe_on_repeat_runs() -> None:
+    store = _healthy_store()
+    queue = GraphReviewQueue(max_items=20)
+    scheduler = GraphReviewScheduler(queue=queue)
+    bootstrapper = GraphReviewBootstrapper(scheduler=scheduler, semantic_store=store)
+
+    first = bootstrapper.bootstrap(query_limit=12)
+    second = bootstrapper.bootstrap(query_limit=12)
+
+    assert first.items_enqueued >= 1
+    assert second.items_enqueued == 0
+
+
+def test_sqlite_refresh_sees_cross_process_queue_updates(tmp_path) -> None:
+    db_path = str(tmp_path / "review-queue.db")
+    q1 = GraphReviewQueue(max_items=20, sql_db_path=db_path)
+    q2 = GraphReviewQueue(max_items=20, sql_db_path=db_path)
+    scheduler = GraphReviewScheduler(queue=q1)
+    store = _healthy_store()
+    bootstrapper = GraphReviewBootstrapper(scheduler=scheduler, semantic_store=store)
+
+    seeded = bootstrapper.bootstrap(now=datetime.now(timezone.utc) - timedelta(hours=1), query_limit=12)
+    assert seeded.items_enqueued >= 1
+
+    q2.refresh_from_storage()
+    assert len(q2.snapshot(limit=50).queue_items) >= 1


### PR DESCRIPTION
### Motivation
- The review runtime could only reschedule after selecting an existing queue item, so an empty queue produced persistent no-ops with no operator path to seed the first work item. 
- Introduce an explicit, operator-invoked bootstrap action to deterministically seed initial review items from bounded semantic regions without adding background daemons. 
- Harden queue cross-process visibility so operator actions and runtime reads see recent durable state when Postgres/SQLite is configured.

### Description
- Added `GraphReviewBootstrapper` (`orion/substrate/review_bootstrap.py`) which queries bounded semantic regions (`contradiction`, `hotspot`, `concept`), builds deterministic consolidation-style seed decisions, and enqueues via the existing `GraphReviewScheduler.apply_consolidation_result(...)` contract. 
- Wired a production operator endpoint `POST /api/substrate/review-runtime/bootstrap` and a singleton bootstrapper in `services/orion-hub/scripts/api_routes.py` that returns a structured payload (`items_before`, `items_enqueued`, `items_after`, `due_after`, `source_posture`, `audit_summary`, `notes`). 
- Added tactical durability hardening to the control-plane queue: `GraphReviewQueue.refresh_from_storage()` and calls to refresh before reads/mutations (`upsert`, `mark_reviewed`, `apply_cycle_feedback`, `list_eligible`, `snapshot`) in `orion/substrate/review_queue.py`, and invoked a refresh before runtime execution in `api_routes.py`. 
- Preserved existing semantics and dedup behavior; documented that full multi-writer correctness is still a follow-on because persistence remains a full-table rewrite (recommend row-level UPSERT or optimistic locking for full safety). 

### Testing
- Added unit tests `tests/test_cognitive_substrate_phase12_review_bootstrap.py` that validate: bootstrap enqueues on a healthy substrate and enables `execute_once`, bootstrap is noop on empty substrate, bootstrap dedup-safety on repeated runs, and sqlite-backed queue refresh semantics. 
- Ran targeted test suite: `pytest -q tests/test_cognitive_substrate_phase10_review_scheduling.py tests/test_cognitive_substrate_phase11_review_runtime.py tests/test_cognitive_substrate_phase12_review_bootstrap.py orion/substrate/tests/test_phase15_reanchoring.py` and all tests passed (`20 passed`). 
- No integration or background-daemon behavior was added; operator bootstrap is explicit and idempotent by design.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86390ce98832aa05adeb7c3e48e50)