### PR TITLE
Unify planner-selected capability verbs with bound execution and guarantee terminal agent-chain results

### DIFF
--- a/services/orion-agent-chain/app/api.py
+++ b/services/orion-agent-chain/app/api.py
@@ -461,6 +461,180 @@ def _bound_execution_timeout_seconds() -> float:
     return max(8.0, min(45.0, default_timeout * 0.75))
 
 
+async def _execute_bound_capability_request(
+    *,
+    body: AgentChainRequest,
+    dbg: dict[str, Any],
+    tools: List[ToolDef],
+    tool_executor: ToolExecutor,
+    parent_corr_id: str,
+    bound_contract: BoundCapabilityExecutionRequestV1,
+    action_input: dict[str, Any],
+) -> AgentChainResult | None:
+    selected_verb = str(bound_contract.selected_verb or "").strip()
+    semantic_mismatch, mismatch_reasons = _is_semantic_mismatch(
+        selected_verb=selected_verb,
+        user_text=body.text,
+        action_input=action_input,
+    )
+    if semantic_mismatch:
+        logger.warning(
+            "[agent-chain] bound_capability_semantic_mismatch selected_verb=%s reasons=%s",
+            selected_verb,
+            mismatch_reasons,
+        )
+        return _bound_terminal_failure(
+            body=body,
+            dbg=dbg,
+            selected_verb=selected_verb,
+            reason=CapabilityRecoveryReasonV1.policy_blocked,
+            detail=f"semantic mismatch: {','.join(mismatch_reasons)}",
+            path="bound_direct_semantic_mismatch",
+            failure_category="semantic_mismatch",
+            observation={"mismatch_reasons": mismatch_reasons, "capability_resolution_status": "skipped"},
+        )
+    policy_state = _bound_policy_state(bound_contract)
+    dbg["bound_capability_policy_state"] = dict(policy_state)
+    logger.info(
+        "[agent-chain] bound_capability_policy_state selected_verb=%s no_write_active=%s tool_execution_policy=%s action_execution_policy=%s execution_forbidden=%s",
+        selected_verb,
+        policy_state.get("no_write_active"),
+        policy_state.get("tool_execution_policy"),
+        policy_state.get("action_execution_policy"),
+        policy_state.get("execution_forbidden"),
+    )
+    if policy_state.get("execution_forbidden"):
+        return _bound_policy_blocked_result(body=body, contract=bound_contract, dbg=dbg)
+
+    candidate = next((t for t in tools if t.tool_id == selected_verb), None)
+    is_capability = bool(
+        candidate
+        and (
+            str(candidate.execution_mode or "").strip().lower() == "capability_backed"
+            or bool(candidate.requires_capability_selector)
+        )
+    )
+    if not is_capability:
+        return _bound_terminal_failure(
+            body=body,
+            dbg=dbg,
+            selected_verb=selected_verb,
+            reason=CapabilityRecoveryReasonV1.policy_blocked,
+            detail=f"selected verb '{selected_verb}' is not capability-backed.",
+            path="bound_direct_no_compatible_capability",
+            failure_category="no_compatible_capability",
+            observation={"capability_resolution_status": "selected_verb_not_capability"},
+        )
+    try:
+        execution_timeout = _bound_execution_timeout_seconds()
+        observation = await asyncio.wait_for(
+            tool_executor.execute_llm_verb(
+                selected_verb,
+                action_input,
+                parent_correlation_id=parent_corr_id,
+            ),
+            timeout=execution_timeout,
+        )
+    except asyncio.TimeoutError:
+        logger.error(
+            "[agent-chain] bound_capability_execution_timeout selected_verb=%s timeout_sec=%.2f",
+            selected_verb,
+            execution_timeout,
+        )
+        return _bound_terminal_failure(
+            body=body,
+            dbg=dbg,
+            selected_verb=selected_verb,
+            reason=CapabilityRecoveryReasonV1.capability_executor_unavailable,
+            detail=f"capability execution timed out after {execution_timeout:.2f}s",
+            path="bound_direct_timeout",
+            failure_category="execution_timeout",
+            observation={"capability_resolution_status": "executor_timeout"},
+        )
+    except FileNotFoundError:
+        reason = CapabilityRecoveryReasonV1.selected_verb_missing
+        dbg["bound_execution_recovery_reason"] = reason.value
+        if _replan_allowed_for_bound_recovery(bound_contract, reason):
+            logger.warning("[agent-chain] bound_capability_recovery_replan=1 reason=%s", reason.value)
+            dbg["bound_execution_replanned"] = True
+            bound_contract.recovery.reason = reason
+            bound_contract.recovery.replanned = True
+            return None
+        return _bound_terminal_failure(
+            body=body,
+            dbg=dbg,
+            selected_verb=selected_verb,
+            reason=reason,
+            detail=f"verb '{selected_verb}' no longer exists.",
+            path="bound_direct_resolution_failed",
+            failure_category="resolution_failed",
+            observation={"capability_resolution_status": "selected_verb_missing"},
+        )
+    except Exception as e:
+        logger.exception("[agent-chain] bound_capability_resolution_failed selected_verb=%s", selected_verb)
+        return _bound_terminal_failure(
+            body=body,
+            dbg=dbg,
+            selected_verb=selected_verb,
+            reason=CapabilityRecoveryReasonV1.capability_executor_unavailable,
+            detail=str(e),
+            path="bound_direct_internal_error",
+            failure_category="internal_error",
+            observation={"capability_resolution_status": "executor_exception"},
+        )
+
+    selected_skill = observation.get("selected_skill") if isinstance(observation, dict) else None
+    if not selected_skill:
+        logger.error("[agent-chain] bound_capability_no_compatible_capability selected_verb=%s", selected_verb)
+        return _bound_terminal_failure(
+            body=body,
+            dbg=dbg,
+            selected_verb=selected_verb,
+            reason=CapabilityRecoveryReasonV1.no_compatible_capability,
+            detail="no compatible capability skill was resolved.",
+            path="bound_direct_no_compatible_capability",
+            failure_category="no_compatible_capability",
+            capability_decision=(observation or {}).get("capability_decision", {}) if isinstance(observation, dict) else {},
+            observation={
+                "capability_resolution_status": "no_skill",
+                "selected_tool_would_have_been": selected_verb,
+            },
+        )
+    dbg["bound_execution_completed"] = True
+    logger.info(
+        "[agent-chain] bound_capability_direct_execute=1 selected_verb=%s selected_skill=%s selected_verb_preserved=1",
+        selected_verb,
+        selected_skill,
+    )
+    result_obj = BoundCapabilityExecutionResultV1(
+        selected_verb=selected_verb,
+        normalized_action_input=action_input,
+        selected_skill_family=(observation or {}).get("selected_skill_family") if isinstance(observation, dict) else None,
+        selected_skill=selected_skill,
+        policy_metadata=bound_contract.policy_metadata,
+        capability_decision=(observation or {}).get("capability_decision", {}) if isinstance(observation, dict) else {},
+        structured_skill_output=observation if isinstance(observation, dict) else {},
+        execution_path="direct_execute",
+        recovery=CapabilityRecoveryDecisionV1(
+            reason=CapabilityRecoveryReasonV1.internal_contract_error,
+            allow_replan=False,
+            replanned=False,
+            detail="not_used",
+        ),
+    )
+    logger.info(
+        "[agent-chain] bound_capability_terminal_reply_emitted selected_verb=%s path=bound_direct_success",
+        selected_verb,
+    )
+    return AgentChainResult(
+        mode=body.mode,
+        text=str(observation.get("execution_summary") or "Capability executed."),
+        structured={"finalization_reason": "bound_capability_execution", "bound_capability": result_obj.model_dump(mode="json")},
+        planner_raw={"runtime_debug": dbg, "trace": []},
+        runtime_debug={**dbg, "bound_capability_reply_emitted": True, "bound_capability_terminal_path": "bound_direct_success"},
+    )
+
+
 async def execute_agent_chain(
     body: AgentChainRequest,
     *,
@@ -604,167 +778,17 @@ async def execute_agent_chain(
                         failure_category="selected_verb_missing",
                     )
             else:
-                semantic_mismatch, mismatch_reasons = _is_semantic_mismatch(
-                    selected_verb=selected_verb,
-                    user_text=body.text,
+                bound_result = await _execute_bound_capability_request(
+                    body=body,
+                    dbg=dbg,
+                    tools=tools,
+                    tool_executor=tool_executor,
+                    parent_corr_id=parent_corr_id,
+                    bound_contract=bound_contract,
                     action_input=action_input,
                 )
-                if semantic_mismatch:
-                    logger.warning(
-                        "[agent-chain] bound_capability_semantic_mismatch selected_verb=%s reasons=%s",
-                        selected_verb,
-                        mismatch_reasons,
-                    )
-                    return _bound_terminal_failure(
-                        body=body,
-                        dbg=dbg,
-                        selected_verb=selected_verb,
-                        reason=CapabilityRecoveryReasonV1.policy_blocked,
-                        detail=f"semantic mismatch: {','.join(mismatch_reasons)}",
-                        path="bound_direct_semantic_mismatch",
-                        failure_category="semantic_mismatch",
-                        observation={"mismatch_reasons": mismatch_reasons, "capability_resolution_status": "skipped"},
-                    )
-                policy_state = _bound_policy_state(bound_contract)
-                dbg["bound_capability_policy_state"] = dict(policy_state)
-                logger.info(
-                    "[agent-chain] bound_capability_policy_state selected_verb=%s no_write_active=%s tool_execution_policy=%s action_execution_policy=%s execution_forbidden=%s",
-                    selected_verb,
-                    policy_state.get("no_write_active"),
-                    policy_state.get("tool_execution_policy"),
-                    policy_state.get("action_execution_policy"),
-                    policy_state.get("execution_forbidden"),
-                )
-                if policy_state.get("execution_forbidden"):
-                    return _bound_policy_blocked_result(body=body, contract=bound_contract, dbg=dbg)
-                candidate = next((t for t in tools if t.tool_id == selected_verb), None)
-                is_capability = bool(
-                    candidate
-                    and (
-                        str(candidate.execution_mode or "").strip().lower() == "capability_backed"
-                        or bool(candidate.requires_capability_selector)
-                    )
-                )
-                if not is_capability:
-                    return _bound_terminal_failure(
-                        body=body,
-                        dbg=dbg,
-                        selected_verb=selected_verb,
-                        reason=CapabilityRecoveryReasonV1.policy_blocked,
-                        detail=f"selected verb '{selected_verb}' is not capability-backed.",
-                        path="bound_direct_no_compatible_capability",
-                        failure_category="no_compatible_capability",
-                        observation={"capability_resolution_status": "selected_verb_not_capability"},
-                    )
-                try:
-                    execution_timeout = _bound_execution_timeout_seconds()
-                    observation = await asyncio.wait_for(
-                        tool_executor.execute_llm_verb(
-                            selected_verb,
-                            action_input,
-                            parent_correlation_id=parent_corr_id,
-                        ),
-                        timeout=execution_timeout,
-                    )
-                except asyncio.TimeoutError:
-                    logger.error(
-                        "[agent-chain] bound_capability_execution_timeout selected_verb=%s timeout_sec=%.2f",
-                        selected_verb,
-                        execution_timeout,
-                    )
-                    return _bound_terminal_failure(
-                        body=body,
-                        dbg=dbg,
-                        selected_verb=selected_verb,
-                        reason=CapabilityRecoveryReasonV1.capability_executor_unavailable,
-                        detail=f"capability execution timed out after {execution_timeout:.2f}s",
-                        path="bound_direct_timeout",
-                        failure_category="execution_timeout",
-                        observation={"capability_resolution_status": "executor_timeout"},
-                    )
-                except FileNotFoundError:
-                    reason = CapabilityRecoveryReasonV1.selected_verb_missing
-                    dbg["bound_execution_recovery_reason"] = reason.value
-                    if _replan_allowed_for_bound_recovery(bound_contract, reason):
-                        logger.warning("[agent-chain] bound_capability_recovery_replan=1 reason=%s", reason.value)
-                        dbg["bound_execution_replanned"] = True
-                        bound_contract.recovery.reason = reason
-                        bound_contract.recovery.replanned = True
-                    else:
-                        return _bound_terminal_failure(
-                            body=body,
-                            dbg=dbg,
-                            selected_verb=selected_verb,
-                            reason=reason,
-                            detail=f"verb '{selected_verb}' no longer exists.",
-                            path="bound_direct_resolution_failed",
-                            failure_category="resolution_failed",
-                            observation={"capability_resolution_status": "selected_verb_missing"},
-                        )
-                except Exception as e:
-                    logger.exception("[agent-chain] bound_capability_resolution_failed selected_verb=%s", selected_verb)
-                    return _bound_terminal_failure(
-                        body=body,
-                        dbg=dbg,
-                        selected_verb=selected_verb,
-                        reason=CapabilityRecoveryReasonV1.capability_executor_unavailable,
-                        detail=str(e),
-                        path="bound_direct_internal_error",
-                        failure_category="internal_error",
-                        observation={"capability_resolution_status": "executor_exception"},
-                    )
-                else:
-                    if not dbg.get("bound_execution_replanned"):
-                        selected_skill = observation.get("selected_skill") if isinstance(observation, dict) else None
-                        if not selected_skill:
-                            logger.error("[agent-chain] bound_capability_no_compatible_capability selected_verb=%s", selected_verb)
-                            return _bound_terminal_failure(
-                                body=body,
-                                dbg=dbg,
-                                selected_verb=selected_verb,
-                                reason=CapabilityRecoveryReasonV1.no_compatible_capability,
-                                detail="no compatible capability skill was resolved.",
-                                path="bound_direct_no_compatible_capability",
-                                failure_category="no_compatible_capability",
-                                capability_decision=(observation or {}).get("capability_decision", {}) if isinstance(observation, dict) else {},
-                                observation={
-                                    "capability_resolution_status": "no_skill",
-                                    "selected_tool_would_have_been": selected_verb,
-                                },
-                            )
-                        dbg["bound_execution_completed"] = True
-                        logger.info(
-                            "[agent-chain] bound_capability_direct_execute=1 selected_verb=%s selected_skill=%s selected_verb_preserved=1",
-                            selected_verb,
-                            selected_skill,
-                        )
-                        result_obj = BoundCapabilityExecutionResultV1(
-                            selected_verb=selected_verb,
-                            normalized_action_input=action_input,
-                            selected_skill_family=(observation or {}).get("selected_skill_family") if isinstance(observation, dict) else None,
-                            selected_skill=selected_skill,
-                            policy_metadata=bound_contract.policy_metadata,
-                            capability_decision=(observation or {}).get("capability_decision", {}) if isinstance(observation, dict) else {},
-                            structured_skill_output=observation if isinstance(observation, dict) else {},
-                            execution_path="direct_execute",
-                            recovery=CapabilityRecoveryDecisionV1(
-                                reason=CapabilityRecoveryReasonV1.internal_contract_error,
-                                allow_replan=False,
-                                replanned=False,
-                                detail="not_used",
-                            ),
-                        )
-                        logger.info(
-                            "[agent-chain] bound_capability_terminal_reply_emitted selected_verb=%s path=bound_direct_success",
-                            selected_verb,
-                        )
-                        return AgentChainResult(
-                            mode=body.mode,
-                            text=str(observation.get("execution_summary") or "Capability executed."),
-                            structured={"finalization_reason": "bound_capability_execution", "bound_capability": result_obj.model_dump(mode="json")},
-                            planner_raw={"runtime_debug": dbg, "trace": []},
-                            runtime_debug={**dbg, "bound_capability_reply_emitted": True, "bound_capability_terminal_path": "bound_direct_success"},
-                        )
+                if bound_result is not None:
+                    return bound_result
 
 
         for step_idx in range(settings.default_max_steps):
@@ -1021,6 +1045,59 @@ async def execute_agent_chain(
                     "[agent-chain] finalization_source_trace_used=1 tool_id=%s output_mode=%s",
                     tool_id,
                     output_mode,
+                )
+
+            chosen_tool = next((t for t in tools if t.tool_id == str(tool_id)), None)
+            is_capability_selected = bool(
+                chosen_tool
+                and (
+                    str(chosen_tool.execution_mode or "").strip().lower() == "capability_backed"
+                    or bool(chosen_tool.requires_capability_selector)
+                )
+            )
+            if is_capability_selected:
+                logger.info("[agent-chain] planner_selected_capability_handoff tool_id=%s", tool_id)
+                synthetic_bound = BoundCapabilityExecutionRequestV1(
+                    selected_verb=str(tool_id),
+                    normalized_action_input=tool_input if isinstance(tool_input, dict) else {},
+                    planner_correlation_id=parent_corr_id,
+                    planner_metadata={"source": "planner_action", "step_index": step_idx},
+                    selected_tool_metadata={
+                        "tool_id": str(tool_id),
+                        "execution_mode": str(chosen_tool.execution_mode or ""),
+                        "requires_capability_selector": bool(chosen_tool.requires_capability_selector),
+                    },
+                    policy_metadata={},
+                    recovery=CapabilityRecoveryDecisionV1(
+                        reason=CapabilityRecoveryReasonV1.internal_contract_error,
+                        allow_replan=False,
+                        replanned=False,
+                        detail="planner_selected_capability_fail_closed",
+                    ),
+                )
+                logger.info("[agent-chain] planner_selected_capability_bound_entry tool_id=%s", tool_id)
+                bound_result = await _execute_bound_capability_request(
+                    body=body,
+                    dbg=dbg,
+                    tools=tools,
+                    tool_executor=tool_executor,
+                    parent_corr_id=parent_corr_id,
+                    bound_contract=synthetic_bound,
+                    action_input=synthetic_bound.normalized_action_input,
+                )
+                if bound_result is not None:
+                    logger.info("[agent-chain] planner_selected_capability_terminal_reply_emitted tool_id=%s", tool_id)
+                    return bound_result
+                logger.error("[agent-chain] planner_selected_capability_fail_closed tool_id=%s", tool_id)
+                return _bound_terminal_failure(
+                    body=body,
+                    dbg=dbg,
+                    selected_verb=str(tool_id),
+                    reason=CapabilityRecoveryReasonV1.internal_contract_error,
+                    detail="planner-selected capability execution did not terminalize.",
+                    path="planner_selected_non_terminal",
+                    failure_category="internal_error",
+                    observation={"capability_resolution_status": "non_terminal"},
                 )
 
             observation = await tool_executor.execute_llm_verb(

--- a/services/orion-agent-chain/tests/test_planner_selected_capability_terminalization.py
+++ b/services/orion-agent-chain/tests/test_planner_selected_capability_terminalization.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+from app import api as agent_api
+from orion.schemas.agents.bound_capability import (
+    BoundCapabilityExecutionRequestV1,
+    CapabilityRecoveryDecisionV1,
+    CapabilityRecoveryReasonV1,
+)
+from orion.schemas.agents.schemas import AgentChainRequest, ToolDef
+
+
+class _FakeCapabilityExecutor:
+    def __init__(self, *_args, **_kwargs):
+        self.calls: list[tuple[str, dict, str | None]] = []
+        self._result = {
+            "selected_skill": "skills.docker.prune_stopped_containers.v1",
+            "selected_skill_family": "runtime_housekeeping",
+            "execution_summary": "Dry-run cleanup completed",
+            "capability_decision": {"selected_skill": "skills.docker.prune_stopped_containers.v1"},
+        }
+
+    async def execute_llm_verb(self, tool_id, tool_input, *, parent_correlation_id=None):
+        self.calls.append((tool_id, tool_input, parent_correlation_id))
+        return dict(self._result)
+
+
+class _FakeCapabilityExecutorNoSkill(_FakeCapabilityExecutor):
+    def __init__(self, *_args, **_kwargs):
+        super().__init__()
+        self._result = {
+            "selected_skill": None,
+            "selected_skill_family": "runtime_housekeeping",
+            "execution_summary": "No skill",
+            "capability_decision": {"selected_skill": None},
+        }
+
+
+async def _planner_returns_housekeep(_payload, *, parent_correlation_id=None, rpc_bus=None):
+    return {
+        "status": "ok",
+        "trace": [
+            {
+                "step_index": 0,
+                "thought": "execute runtime cleanup",
+                "action": {"tool_id": "housekeep_runtime", "input": {"text": "dry-run cleanup"}},
+                "observation": None,
+            }
+        ],
+    }
+
+
+def _tools():
+    return [
+        ToolDef(
+            tool_id="housekeep_runtime",
+            description="Runtime housekeeping",
+            input_schema={},
+            output_schema={},
+            execution_mode="capability_backed",
+            requires_capability_selector=True,
+        ),
+        ToolDef(tool_id="finalize_response", description="Finalize", input_schema={}, output_schema={}),
+    ]
+
+
+def test_planner_selected_capability_routes_to_bound_terminal_success(monkeypatch):
+    fake_exec = _FakeCapabilityExecutor()
+    monkeypatch.setattr(agent_api, "ToolExecutor", lambda *_a, **_k: fake_exec)
+    monkeypatch.setattr(agent_api, "call_planner_react", _planner_returns_housekeep)
+    monkeypatch.setattr(agent_api, "_resolve_tools", lambda body, output_mode=None: (_tools(), ["executive_pack"]))
+
+    req = AgentChainRequest(text="dry-run cleanup of stopped containers", mode="agent", messages=[{"role": "user", "content": "cleanup"}])
+    out = asyncio.run(agent_api.execute_agent_chain(req, correlation_id=str(uuid4()), rpc_bus=object()))
+
+    assert fake_exec.calls and fake_exec.calls[0][0] == "housekeep_runtime"
+    assert out.structured["finalization_reason"] == "bound_capability_execution"
+    assert out.runtime_debug["bound_capability_terminal_path"] == "bound_direct_success"
+
+
+def test_planner_selected_capability_fail_closed_terminal_reply(monkeypatch):
+    fake_exec = _FakeCapabilityExecutorNoSkill()
+    monkeypatch.setattr(agent_api, "ToolExecutor", lambda *_a, **_k: fake_exec)
+    monkeypatch.setattr(agent_api, "call_planner_react", _planner_returns_housekeep)
+    monkeypatch.setattr(agent_api, "_resolve_tools", lambda body, output_mode=None: (_tools(), ["executive_pack"]))
+
+    req = AgentChainRequest(text="dry-run cleanup of stopped containers", mode="agent", messages=[{"role": "user", "content": "cleanup"}])
+    out = asyncio.run(agent_api.execute_agent_chain(req, correlation_id=str(uuid4()), rpc_bus=object()))
+
+    assert out.structured["finalization_reason"] == "bound_capability_fail_closed"
+    assert out.runtime_debug["bound_capability_terminal_path"] == "bound_direct_no_compatible_capability"
+
+
+def test_bound_and_planner_selected_paths_have_terminalization_parity(monkeypatch):
+    fake_exec = _FakeCapabilityExecutor()
+    monkeypatch.setattr(agent_api, "ToolExecutor", lambda *_a, **_k: fake_exec)
+    monkeypatch.setattr(agent_api, "call_planner_react", _planner_returns_housekeep)
+    monkeypatch.setattr(agent_api, "_resolve_tools", lambda body, output_mode=None: (_tools(), ["executive_pack"]))
+
+    bound_req = AgentChainRequest(
+        text="dry-run cleanup",
+        mode="agent",
+        tools=[t.model_dump() for t in _tools()],
+        bound_capability_execution=BoundCapabilityExecutionRequestV1(
+            selected_verb="housekeep_runtime",
+            normalized_action_input={"text": "dry-run cleanup"},
+            recovery=CapabilityRecoveryDecisionV1(
+                reason=CapabilityRecoveryReasonV1.internal_contract_error,
+                allow_replan=False,
+                replanned=False,
+            ),
+        ),
+    )
+    planner_req = AgentChainRequest(text="dry-run cleanup", mode="agent", messages=[{"role": "user", "content": "cleanup"}])
+
+    out_bound = asyncio.run(agent_api.execute_agent_chain(bound_req, correlation_id=str(uuid4()), rpc_bus=object()))
+    out_planner = asyncio.run(agent_api.execute_agent_chain(planner_req, correlation_id=str(uuid4()), rpc_bus=object()))
+
+    assert out_bound.structured["finalization_reason"] == "bound_capability_execution"
+    assert out_planner.structured["finalization_reason"] == "bound_capability_execution"
+    assert out_bound.runtime_debug["bound_capability_terminal_path"] == "bound_direct_success"
+    assert out_planner.runtime_debug["bound_capability_terminal_path"] == "bound_direct_success"


### PR DESCRIPTION
### Motivation
- Fix a choke point where planner-selected capability-backed actions (e.g. `housekeep_runtime`) could run via a non-terminal path and cause the outer orchestrator to wait until hub timeout. 
- Ensure planner-selected capability verbs get the same policy/timeout/fail-closed guarantees as explicit bound capability requests so agent-chain always returns a terminal `AgentChainResult`.

### Description
- Added a shared helper `_execute_bound_capability_request(...)` that centralizes policy checks, timeout guarding, capability resolution, and structured terminal replies for capability-backed verbs. 
- When `body.bound_capability_execution` is present the code now delegates to the shared helper rather than duplicating logic. 
- Intercepted planner-selected capability actions inside the planner loop to synthesize a `BoundCapabilityExecutionRequestV1` and route them into the canonical helper, with explicit lifecycle logs (`planner_selected_capability_handoff`, `planner_selected_capability_bound_entry`, `planner_selected_capability_terminal_reply_emitted`, `planner_selected_capability_fail_closed`). 
- Added a fail-closed fallback that returns a structured `bound_capability_fail_closed` `AgentChainResult` if planner-selected capability handoff does not terminalize. 
- Added unit tests `services/orion-agent-chain/tests/test_planner_selected_capability_terminalization.py` covering planner-selected success, planner-selected fail-closed, and parity between bound vs planner-selected paths. 

### Testing
- Ran `PYTHONPATH=.:services/orion-agent-chain pytest -q services/orion-agent-chain/tests/test_planner_selected_capability_terminalization.py services/orion-agent-chain/tests/test_bound_capability_contract.py` and the command completed successfully with all tests passing. 
- Ran `PYTHONPATH=.:services/orion-cortex-exec pytest -q services/orion-cortex-exec/tests/test_supervisor_planner_delegate.py -k "planner_action_only_continues_and_runs_agent_chain or operational_semantic_override_wins_over_lower_scored_planner_action"` and the targeted tests passed. 
- The new tests exercise both success and failure terminalization for planner-selected capability verbs and confirm parity with the explicit bound path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86ef9b150832aa7e911677767fd30)