### PR TITLE
Add substrate inspector operator controls and review-runtime debug-run orchestration

### DIFF
--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -1642,6 +1642,160 @@ def _bootstrap_substrate_review_frontier(*, limit: int = 12) -> Dict[str, Any]:
     }
 
 
+def _queue_count(payload: Dict[str, Any]) -> int:
+    data = payload.get("data")
+    if isinstance(data, dict):
+        items = data.get("queue_items")
+        if isinstance(items, list):
+            return len(items)
+    return 0
+
+
+def _classify_substrate_debug_diagnosis(
+    *,
+    source_posture: Dict[str, Any],
+    bootstrap_payload: Dict[str, Any],
+    baseline_queue_payload: Dict[str, Any],
+    post_bootstrap_queue_payload: Dict[str, Any],
+    execute_payload: Dict[str, Any],
+    final_queue_payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    categories: list[str] = []
+    highlights: list[str] = []
+    severity = "ok"
+
+    control_plane = source_posture.get("control_plane") if isinstance(source_posture, dict) else {}
+    semantic = source_posture.get("semantic") if isinstance(source_posture, dict) else {}
+
+    control_degraded = bool(control_plane.get("degraded")) if isinstance(control_plane, dict) else False
+    semantic_degraded = bool(semantic.get("degraded")) if isinstance(semantic, dict) else False
+
+    if control_degraded:
+        categories.append("control plane degraded")
+        highlights.append("Control-plane storage/reporting is degraded.")
+        severity = "degraded"
+
+    if semantic_degraded:
+        categories.append("semantic substrate degraded")
+        highlights.append("Semantic substrate queries are degraded.")
+        severity = "degraded"
+
+    bootstrap_items_enqueued = int(bootstrap_payload.get("items_enqueued") or 0)
+    bootstrap_notes = bootstrap_payload.get("notes")
+    if isinstance(bootstrap_notes, list) and any("seed_skipped" in str(note) for note in bootstrap_notes):
+        categories.append("likely weak seed heuristics for current graph shape")
+        highlights.append("Bootstrap skipped one or more seed regions.")
+        severity = "warning" if severity != "degraded" else severity
+
+    if "items_enqueued" not in bootstrap_payload and "error" in bootstrap_payload:
+        categories.append("bootstrap route/path unavailable")
+        highlights.append("Bootstrap path could not be invoked.")
+        severity = "degraded"
+    elif bootstrap_items_enqueued <= 0:
+        categories.append("bootstrap produced zero items")
+        highlights.append("Bootstrap completed without queue growth.")
+        severity = "warning" if severity != "degraded" else severity
+
+    baseline_queue_count = _queue_count(baseline_queue_payload)
+    post_bootstrap_queue_count = _queue_count(post_bootstrap_queue_payload)
+    final_queue_count = _queue_count(final_queue_payload)
+
+    if bootstrap_items_enqueued > 0 and post_bootstrap_queue_count <= baseline_queue_count:
+        categories.append("bootstrap claimed to enqueue but queue remained empty")
+        highlights.append("Bootstrap reported enqueues, but queue did not increase.")
+        severity = "degraded"
+
+    execute_result = execute_payload.get("result") if isinstance(execute_payload, dict) else {}
+    execute_outcome = execute_result.get("outcome") if isinstance(execute_result, dict) else None
+    execute_reason = ""
+    execute_audit = execute_result.get("audit_summary") if isinstance(execute_result, dict) else {}
+    if isinstance(execute_audit, dict):
+        execute_reason = str(execute_audit.get("selection_reason") or "").strip().lower()
+    execute_notes = execute_result.get("notes") if isinstance(execute_result, dict) else []
+    execute_notes_lower = " ".join(str(note).lower() for note in execute_notes) if isinstance(execute_notes, list) else ""
+
+    if post_bootstrap_queue_count > 0 and execute_outcome == "noop" and (
+        "no eligible queue items" in execute_reason or "not due yet" in execute_reason
+    ):
+        categories.append("queue nonempty but execute-once still noop due to no eligible items")
+        highlights.append("Queue has items, but none were eligible for this cycle.")
+        severity = "warning" if severity == "ok" else severity
+
+    if bootstrap_items_enqueued > 0 and execute_outcome == "executed":
+        categories.append("bootstrap produced items and execute-once succeeded")
+        highlights.append("Bootstrap seeded the queue and one cycle executed successfully.")
+
+    if "seed_skipped" in execute_notes_lower and "likely weak seed heuristics for current graph shape" not in categories:
+        categories.append("likely weak seed heuristics for current graph shape")
+        highlights.append("Execution notes indicate weak substrate seed coverage.")
+        severity = "warning" if severity == "ok" else severity
+
+    summary = " | ".join(highlights) if highlights else "Debug pass completed."
+    return {
+        "severity": severity,
+        "categories": categories,
+        "summary": summary,
+        "facts": {
+            "baseline_queue_count": baseline_queue_count,
+            "post_bootstrap_queue_count": post_bootstrap_queue_count,
+            "final_queue_count": final_queue_count,
+            "bootstrap_items_enqueued": bootstrap_items_enqueued,
+            "execute_outcome": execute_outcome,
+        },
+    }
+
+
+def _run_substrate_review_debug_pass(*, bootstrap_limit: int = 12) -> Dict[str, Any]:
+    generated_at = datetime.now(timezone.utc).isoformat()
+    baseline_status = _substrate_runtime_status_payload(queue_limit=50, telemetry_limit=20)
+    baseline_queue = _sql_review_queue_payload(limit=50)
+    baseline_overview = _graphdb_overview_payload(limit=10)
+    baseline_hotspots = _graphdb_hotspots_payload(limit=20)
+    baseline_executions = _sql_review_executions_payload(limit=20)
+
+    bootstrap = _bootstrap_substrate_review_frontier(limit=bootstrap_limit)
+    post_bootstrap_queue = _sql_review_queue_payload(limit=50)
+    post_bootstrap_status = _substrate_runtime_status_payload(queue_limit=50, telemetry_limit=20)
+
+    execute_once = _execute_substrate_review_cycle(allow_followup=False)
+    final_queue = _sql_review_queue_payload(limit=50)
+    final_status = _substrate_runtime_status_payload(queue_limit=50, telemetry_limit=20)
+    final_executions = _sql_review_executions_payload(limit=20)
+    source_posture = _substrate_source_posture()
+    diagnosis = _classify_substrate_debug_diagnosis(
+        source_posture=source_posture,
+        bootstrap_payload=bootstrap,
+        baseline_queue_payload=baseline_queue,
+        post_bootstrap_queue_payload=post_bootstrap_queue,
+        execute_payload=execute_once,
+        final_queue_payload=final_queue,
+    )
+
+    return {
+        "generated_at": generated_at,
+        "baseline": {
+            "runtime_status": baseline_status,
+            "review_queue": baseline_queue,
+            "overview": baseline_overview,
+            "hotspots": baseline_hotspots,
+            "recent_executions": baseline_executions,
+        },
+        "bootstrap": bootstrap,
+        "post_bootstrap": {
+            "review_queue": post_bootstrap_queue,
+            "runtime_status": post_bootstrap_status,
+        },
+        "execute_once": execute_once,
+        "final": {
+            "review_queue": final_queue,
+            "runtime_status": final_status,
+            "recent_executions": final_executions,
+        },
+        "diagnosis": diagnosis,
+        "source_posture": source_posture,
+    }
+
+
 @router.get("/substrate")
 async def substrate_page() -> HTMLResponse:
     from .main import TEMPLATES_DIR, build_hub_ui_asset_version
@@ -1736,6 +1890,12 @@ def api_substrate_review_runtime_execute_once_followup(request: SubstrateReviewE
 def api_substrate_review_runtime_bootstrap(request: SubstrateReviewBootstrapRequest | None = None) -> Dict[str, Any]:
     req = request or SubstrateReviewBootstrapRequest()
     return _bootstrap_substrate_review_frontier(limit=req.limit)
+
+
+@router.post("/api/substrate/review-runtime/debug-run")
+def api_substrate_review_runtime_debug_run(request: SubstrateReviewBootstrapRequest | None = None) -> Dict[str, Any]:
+    req = request or SubstrateReviewBootstrapRequest()
+    return _run_substrate_review_debug_pass(bootstrap_limit=req.limit)
 
 
 @router.post("/api/substrate/review-runtime/smoke-check")

--- a/services/orion-hub/static/js/substrate.js
+++ b/services/orion-hub/static/js/substrate.js
@@ -1,5 +1,8 @@
 (() => {
   const sections = {
+    runtimeStatus: document.getElementById('substrateRuntimeStatus'),
+    debugResult: document.getElementById('substrateDebugRunResult'),
+    diagnosisSummary: document.getElementById('substrateDiagnosisSummary'),
     overview: document.getElementById('substrateOverview'),
     hotspots: document.getElementById('substrateHotspots'),
     queue: document.getElementById('substrateReviewQueue'),
@@ -9,7 +12,11 @@
     policyComparison: document.getElementById('substratePolicyComparison'),
   };
   const sourceMeta = document.getElementById('substrateSourceMeta');
+  const actionError = document.getElementById('substrateActionError');
   const refreshButton = document.getElementById('substrateRefreshButton');
+  const bootstrapButton = document.getElementById('substrateBootstrapButton');
+  const executeOnceButton = document.getElementById('substrateExecuteOnceButton');
+  const debugRunButton = document.getElementById('substrateDebugRunButton');
 
   async function fetchSection(path) {
     const res = await fetch(path, { headers: { 'Accept': 'application/json' } });
@@ -29,9 +36,62 @@
     target.textContent = JSON.stringify({ degraded: true, error: String(error) }, null, 2);
   }
 
+  function setActionError(error) {
+    if (!actionError) return;
+    if (!error) {
+      actionError.classList.add('hidden');
+      actionError.textContent = '';
+      return;
+    }
+    actionError.classList.remove('hidden');
+    actionError.textContent = `Action failed: ${String(error)}`;
+  }
+
+  function setButtonBusy(button, label, busy) {
+    if (!button) return;
+    if (!button.dataset.defaultLabel) {
+      button.dataset.defaultLabel = button.textContent || '';
+    }
+    button.disabled = busy;
+    button.textContent = busy ? `${label}…` : button.dataset.defaultLabel;
+    button.classList.toggle('opacity-60', busy);
+    button.classList.toggle('cursor-not-allowed', busy);
+  }
+
+  async function postAction(path, body = {}) {
+    const res = await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const payload = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const detail = payload?.detail ? JSON.stringify(payload.detail) : `HTTP ${res.status}`;
+      throw new Error(`${path}: ${detail}`);
+    }
+    return payload;
+  }
+
+  function renderDiagnosis(payload) {
+    if (!sections.diagnosisSummary) return;
+    const diagnosis = payload?.diagnosis || {};
+    const severity = diagnosis.severity || 'unknown';
+    const summary = diagnosis.summary || 'No diagnosis summary available.';
+    const categories = Array.isArray(diagnosis.categories) ? diagnosis.categories : [];
+    const severityClass =
+      severity === 'degraded'
+        ? 'border-red-700 bg-red-950/40 text-red-200'
+        : severity === 'warning'
+          ? 'border-amber-700 bg-amber-950/40 text-amber-200'
+          : 'border-emerald-700 bg-emerald-950/40 text-emerald-200';
+    sections.diagnosisSummary.className = `text-sm rounded border p-3 ${severityClass}`;
+    sections.diagnosisSummary.textContent = `${summary}${categories.length ? `\nCategories: ${categories.join(' | ')}` : ''}`;
+  }
+
   async function refresh() {
     const startedAt = new Date().toISOString();
     const endpoints = [
+      ['runtimeStatus', '/api/substrate/review-runtime/status'],
       ['overview', '/api/substrate/overview?limit=10'],
       ['hotspots', '/api/substrate/hotspots?limit=20'],
       ['queue', '/api/substrate/review-queue?limit=50'],
@@ -61,7 +121,56 @@
 
   if (refreshButton) {
     refreshButton.addEventListener('click', () => {
+      setActionError(null);
       void refresh();
+    });
+  }
+
+  if (bootstrapButton) {
+    bootstrapButton.addEventListener('click', async () => {
+      setActionError(null);
+      setButtonBusy(bootstrapButton, 'Bootstrapping', true);
+      try {
+        await postAction('/api/substrate/review-runtime/bootstrap', {});
+        await refresh();
+      } catch (error) {
+        setActionError(error);
+      } finally {
+        setButtonBusy(bootstrapButton, 'Bootstrapping', false);
+      }
+    });
+  }
+
+  if (executeOnceButton) {
+    executeOnceButton.addEventListener('click', async () => {
+      setActionError(null);
+      setButtonBusy(executeOnceButton, 'Executing', true);
+      try {
+        await postAction('/api/substrate/review-runtime/execute-once', {});
+        await refresh();
+      } catch (error) {
+        setActionError(error);
+      } finally {
+        setButtonBusy(executeOnceButton, 'Executing', false);
+      }
+    });
+  }
+
+  if (debugRunButton) {
+    debugRunButton.addEventListener('click', async () => {
+      setActionError(null);
+      setButtonBusy(debugRunButton, 'Running Debug Pass', true);
+      try {
+        const payload = await postAction('/api/substrate/review-runtime/debug-run', {});
+        renderSection(sections.debugResult, payload);
+        renderDiagnosis(payload);
+        await refresh();
+      } catch (error) {
+        setActionError(error);
+        renderError(sections.debugResult, error);
+      } finally {
+        setButtonBusy(debugRunButton, 'Running Debug Pass', false);
+      }
     });
   }
 

--- a/services/orion-hub/templates/substrate.html
+++ b/services/orion-hub/templates/substrate.html
@@ -13,11 +13,30 @@
       <h1 class="text-xl font-semibold">Substrate Inspector</h1>
       <div class="flex gap-2">
         <button id="substrateRefreshButton" class="px-3 py-2 text-xs rounded border border-gray-700 bg-gray-900 hover:bg-gray-800">Refresh</button>
+        <button id="substrateBootstrapButton" class="px-3 py-2 text-xs rounded border border-indigo-700 bg-indigo-900/40 hover:bg-indigo-800/60">Bootstrap Frontier</button>
+        <button id="substrateExecuteOnceButton" class="px-3 py-2 text-xs rounded border border-emerald-700 bg-emerald-900/40 hover:bg-emerald-800/60">Execute Once</button>
+        <button id="substrateDebugRunButton" class="px-3 py-2 text-xs rounded border border-purple-700 bg-purple-900/40 hover:bg-purple-800/60">Run Debug Pass</button>
         <a href="/" class="px-3 py-2 text-xs rounded border border-gray-700 bg-gray-900 hover:bg-gray-800">Back to Hub</a>
       </div>
     </div>
 
+    <div id="substrateActionError" class="hidden text-xs text-red-300 bg-red-950/40 border border-red-800 rounded p-2"></div>
     <div id="substrateSourceMeta" class="text-xs text-gray-400"></div>
+
+    <section class="bg-gray-900 border border-gray-800 rounded p-4">
+      <h2 class="font-medium mb-2">Diagnosis Summary</h2>
+      <div id="substrateDiagnosisSummary" class="text-sm rounded border border-gray-700 bg-gray-950 p-3 text-gray-200">Run Debug Pass to generate a diagnosis.</div>
+    </section>
+
+    <section class="bg-gray-900 border border-gray-800 rounded p-4">
+      <h2 class="font-medium mb-2">Runtime Status</h2>
+      <pre id="substrateRuntimeStatus" class="text-xs bg-gray-950 border border-gray-800 rounded p-3 overflow-auto">Loading…</pre>
+    </section>
+
+    <section class="bg-gray-900 border border-gray-800 rounded p-4">
+      <h2 class="font-medium mb-2">Debug Pass Result</h2>
+      <pre id="substrateDebugRunResult" class="text-xs bg-gray-950 border border-gray-800 rounded p-3 overflow-auto">No debug pass run yet.</pre>
+    </section>
 
     <section class="bg-gray-900 border border-gray-800 rounded p-4">
       <h2 class="font-medium mb-2">Substrate Overview (GraphDB)</h2>

--- a/services/orion-hub/tests/test_substrate_review_runtime_hub_debug.py
+++ b/services/orion-hub/tests/test_substrate_review_runtime_hub_debug.py
@@ -156,6 +156,106 @@ def test_smoke_check_is_bounded_and_returns_source_and_checks() -> None:
     assert "control_plane" in payload["source"]
 
 
+def test_debug_run_route_returns_structured_payload(monkeypatch) -> None:
+    monkeypatch.setattr(api_routes, "_substrate_runtime_status_payload", lambda **kwargs: {"summary": {"queue_count": 1, "due_count": 1}})
+    monkeypatch.setattr(api_routes, "_sql_review_queue_payload", lambda **kwargs: {"data": {"queue_items": [{"queue_item_id": "q-1"}]}})
+    monkeypatch.setattr(api_routes, "_graphdb_overview_payload", lambda **kwargs: {"data": {"nodes": 3}})
+    monkeypatch.setattr(api_routes, "_graphdb_hotspots_payload", lambda **kwargs: {"data": {"hotspots": ["h1"]}})
+    monkeypatch.setattr(api_routes, "_sql_review_executions_payload", lambda **kwargs: {"data": {"executions": []}})
+    monkeypatch.setattr(api_routes, "_bootstrap_substrate_review_frontier", lambda **kwargs: {"items_enqueued": 2, "notes": ["bootstrap_seeded"]})
+    monkeypatch.setattr(
+        api_routes,
+        "_execute_substrate_review_cycle",
+        lambda **kwargs: {"result": {"outcome": "executed", "audit_summary": {"selection_reason": "eligible_item_selected"}}},
+    )
+    monkeypatch.setattr(api_routes, "_substrate_source_posture", lambda: {"control_plane": {"degraded": False}, "semantic": {"degraded": False}})
+
+    payload = api_routes.api_substrate_review_runtime_debug_run()
+    assert "generated_at" in payload
+    assert "baseline" in payload
+    assert "bootstrap" in payload
+    assert "post_bootstrap" in payload
+    assert "execute_once" in payload
+    assert "final" in payload
+    assert "diagnosis" in payload
+    assert "source_posture" in payload
+
+
+def test_debug_diagnosis_classification_cases() -> None:
+    base_source = {"control_plane": {"degraded": False}, "semantic": {"degraded": False}}
+
+    unavailable = api_routes._classify_substrate_debug_diagnosis(
+        source_posture=base_source,
+        bootstrap_payload={"error": "route down"},
+        baseline_queue_payload={"data": {"queue_items": []}},
+        post_bootstrap_queue_payload={"data": {"queue_items": []}},
+        execute_payload={"result": {"outcome": "noop", "audit_summary": {"selection_reason": "no eligible queue items"}}},
+        final_queue_payload={"data": {"queue_items": []}},
+    )
+    assert "bootstrap route/path unavailable" in unavailable["categories"]
+
+    zero_items = api_routes._classify_substrate_debug_diagnosis(
+        source_posture=base_source,
+        bootstrap_payload={"items_enqueued": 0, "notes": ["seed_skipped:hotspot_region"]},
+        baseline_queue_payload={"data": {"queue_items": []}},
+        post_bootstrap_queue_payload={"data": {"queue_items": []}},
+        execute_payload={"result": {"outcome": "noop", "audit_summary": {"selection_reason": "no eligible queue items"}}},
+        final_queue_payload={"data": {"queue_items": []}},
+    )
+    assert "bootstrap produced zero items" in zero_items["categories"]
+    assert "likely weak seed heuristics for current graph shape" in zero_items["categories"]
+
+    success = api_routes._classify_substrate_debug_diagnosis(
+        source_posture=base_source,
+        bootstrap_payload={"items_enqueued": 2, "notes": ["bootstrap_seeded"]},
+        baseline_queue_payload={"data": {"queue_items": []}},
+        post_bootstrap_queue_payload={"data": {"queue_items": [{"id": 1}]}},
+        execute_payload={"result": {"outcome": "executed", "audit_summary": {"selection_reason": "eligible_item_selected"}}},
+        final_queue_payload={"data": {"queue_items": []}},
+    )
+    assert "bootstrap produced items and execute-once succeeded" in success["categories"]
+
+    enqueue_but_empty = api_routes._classify_substrate_debug_diagnosis(
+        source_posture=base_source,
+        bootstrap_payload={"items_enqueued": 1, "notes": ["bootstrap_seeded"]},
+        baseline_queue_payload={"data": {"queue_items": []}},
+        post_bootstrap_queue_payload={"data": {"queue_items": []}},
+        execute_payload={"result": {"outcome": "noop", "audit_summary": {"selection_reason": "no eligible queue items"}}},
+        final_queue_payload={"data": {"queue_items": []}},
+    )
+    assert "bootstrap claimed to enqueue but queue remained empty" in enqueue_but_empty["categories"]
+
+    queue_nonempty_noop = api_routes._classify_substrate_debug_diagnosis(
+        source_posture=base_source,
+        bootstrap_payload={"items_enqueued": 1, "notes": ["bootstrap_seeded"]},
+        baseline_queue_payload={"data": {"queue_items": []}},
+        post_bootstrap_queue_payload={"data": {"queue_items": [{"id": 1}]}},
+        execute_payload={"result": {"outcome": "noop", "audit_summary": {"selection_reason": "no eligible queue items"}}},
+        final_queue_payload={"data": {"queue_items": [{"id": 1}]}},
+    )
+    assert "queue nonempty but execute-once still noop due to no eligible items" in queue_nonempty_noop["categories"]
+
+    control_degraded = api_routes._classify_substrate_debug_diagnosis(
+        source_posture={"control_plane": {"degraded": True}, "semantic": {"degraded": False}},
+        bootstrap_payload={"items_enqueued": 0, "notes": []},
+        baseline_queue_payload={"data": {"queue_items": []}},
+        post_bootstrap_queue_payload={"data": {"queue_items": []}},
+        execute_payload={"result": {"outcome": "noop", "audit_summary": {"selection_reason": "no eligible queue items"}}},
+        final_queue_payload={"data": {"queue_items": []}},
+    )
+    assert "control plane degraded" in control_degraded["categories"]
+
+    semantic_degraded = api_routes._classify_substrate_debug_diagnosis(
+        source_posture={"control_plane": {"degraded": False}, "semantic": {"degraded": True}},
+        bootstrap_payload={"items_enqueued": 0, "notes": ["seed_skipped:concept_region"]},
+        baseline_queue_payload={"data": {"queue_items": []}},
+        post_bootstrap_queue_payload={"data": {"queue_items": []}},
+        execute_payload={"result": {"outcome": "noop", "audit_summary": {"selection_reason": "no eligible queue items"}}},
+        final_queue_payload={"data": {"queue_items": []}},
+    )
+    assert "semantic substrate degraded" in semantic_degraded["categories"]
+
+
 def test_hub_substrate_debug_surface_does_not_embed_standalone_page() -> None:
     index_html = TEMPLATE_PATH.read_text(encoding="utf-8")
     app_js = APP_JS_PATH.read_text(encoding="utf-8")

--- a/services/orion-hub/tests/test_substrate_standalone_page.py
+++ b/services/orion-hub/tests/test_substrate_standalone_page.py
@@ -36,9 +36,19 @@ def test_substrate_route_and_template_and_bundle_are_standalone() -> None:
 
     assert "Substrate Inspector" in template
     assert "substratePolicyComparison" in template
+    assert 'id="substrateBootstrapButton"' in template
+    assert 'id="substrateExecuteOnceButton"' in template
+    assert 'id="substrateDebugRunButton"' in template
+    assert 'id="substrateRuntimeStatus"' in template
+    assert 'id="substrateDebugRunResult"' in template
+    assert 'id="substrateDiagnosisSummary"' in template
     assert "/static/js/substrate.js?v={{HUB_UI_ASSET_VERSION}}" in template
     assert "window.OrionHub" not in script
     assert "\'/api/substrate/overview?limit=10\'" in script
+    assert "\'/api/substrate/review-runtime/status\'" in script
+    assert "\'/api/substrate/review-runtime/bootstrap\'" in script
+    assert "\'/api/substrate/review-runtime/execute-once\'" in script
+    assert "\'/api/substrate/review-runtime/debug-run\'" in script
     assert "policy-comparison?pair_mode=baseline_vs_active" in script
 
     route_paths = {route.path for route in api_routes.router.routes}


### PR DESCRIPTION
### Motivation
- Operators needed an integrated, operator-grade workflow in the Substrate Inspector to bootstrap the frontier, run a single review cycle, run an end-to-end debug pass, and get a plain-language diagnosis without using curl or correlating multiple endpoints. 

### Description
- Add a new orchestration endpoint `POST /api/substrate/review-runtime/debug-run` that collects baseline snapshots (runtime status/queue/overview/hotspots/executions), invokes the existing `bootstrap` and `execute-once` flows, then collects final snapshots and returns a single structured payload containing `generated_at`, `baseline`, `bootstrap`, `post_bootstrap`, `execute_once`, `final`, `diagnosis`, and `source_posture`. 
- Implement a deterministic, fact-based diagnosis classifier that derives categories from payload facts (queue deltas, bootstrap notes, execute outcome, and source posture) including the requested classes such as control-plane degraded, semantic degraded, bootstrap route unavailable, zero items, enqueue-but-empty, queue-nonempty-but-no-eligible-items, and likely weak seed heuristics. 
- Update the Substrate Inspector UI to expose operator controls at the top: `Refresh`, `Bootstrap Frontier`, `Execute Once`, and `Run Debug Pass`, and add visible panels for `Runtime Status`, `Debug Pass Result`, and a prominent `Diagnosis Summary`. 
- Wire client behaviors in `static/js/substrate.js` to call the real POST routes (`bootstrap`, `execute-once`, and `debug-run`), show in-progress button states, surface in-panel errors, auto-refresh dependent sections after bootstrap/execute, and render both the full debug JSON and an extracted human-readable diagnosis after a debug-run. 
- Add unit tests validating the debug-run response shape and multiple diagnosis classification scenarios, and update standalone/template tests to check for the new UI controls and routes. 

### Testing
- Ran `pytest -q services/orion-hub/tests/test_substrate_standalone_page.py services/orion-hub/tests/test_substrate_review_runtime_hub_debug.py tests/test_cognitive_substrate_phase12_review_bootstrap.py` and all tests passed (`21 passed`).
- New tests exercise the `debug-run` route shape and multiple diagnosis classification cases and were included in the above run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d874fb2e30832aacf260b987b72bba)