### PR TITLE
Add operational semantic harness and enforce canonical operational rail

### DIFF
--- a/services/orion-cortex-exec/app/supervisor.py
+++ b/services/orion-cortex-exec/app/supervisor.py
@@ -195,6 +195,12 @@ def _available_operational_semantic_tools(toolset: List[ToolDef]) -> List[ToolDe
 _RUNTIME_CLEANUP_TERMS = {"docker", "container", "cleanup", "stopped", "prune", "runtime", "housekeep", "housekeeping", "dry", "run"}
 _CHANGE_SUMMARY_TERMS = {"summarize", "summary", "recent", "changes", "change", "changelog", "intel"}
 _UNSAFE_ASSISTANT_COMMAND_PATTERN = re.compile(r"(docker\s+(rm|rmi|system\s+prune|container\s+prune|volume\s+rm|network\s+rm)|rm\s+-rf|kubectl\s+delete)", re.IGNORECASE)
+_OPERATIONAL_VERB_RULES: list[tuple[str, tuple[str, ...]]] = [
+    ("assess_mesh_presence", ("node", "nodes", "mesh", "up", "online", "alive", "status")),
+    ("assess_storage_health", ("disk", "storage", "health", "filesystem", "volume")),
+    ("summarize_recent_changes", ("summarize", "summary", "recent", "changes", "prs", "pull request", "commits")),
+    ("housekeep_runtime", ("cleanup", "clean up", "stopped", "container", "containers", "runtime", "prune", "dry-run", "dry run")),
+]
 
 
 def _tool_semantic_haystack(tool: ToolDef) -> str:
@@ -266,6 +272,34 @@ def _select_preferred_operational_tool(
     scored = _semantic_override_scores(user_text=user_text, normalized_action_input=normalized_action_input, tools=tools)
     best = scored[0]["tool"] if scored else None
     return best, scored
+
+
+def _select_canonical_operational_tool(user_text: str, tools: List[ToolDef]) -> Optional[ToolDef]:
+    if not tools:
+        return None
+    hay = str(user_text or "").lower()
+    tool_map = {str(t.tool_id or ""): t for t in tools}
+    priority_rules = [
+        ("assess_storage_health", ("disk", "storage")),
+        ("summarize_recent_changes", ("recent pr", "recent pull request", "recent changes", "summarize recent")),
+        ("housekeep_runtime", ("cleanup", "dry-run", "dry run", "stopped containers", "prune")),
+        ("assess_mesh_presence", ("nodes are up", "which nodes", "mesh presence", "nodes up")),
+    ]
+    for tool_id, phrases in priority_rules:
+        if tool_id not in tool_map:
+            continue
+        if any(phrase in hay for phrase in phrases):
+            return tool_map[tool_id]
+    best_tool: Optional[ToolDef] = None
+    best_hits = 0
+    for tool_id, terms in _OPERATIONAL_VERB_RULES:
+        if tool_id not in tool_map:
+            continue
+        hits = sum(1 for term in terms if term in hay)
+        if hits > best_hits:
+            best_hits = hits
+            best_tool = tool_map[tool_id]
+    return best_tool if best_hits >= 2 else None
 
 
 def _should_override_planner_operational_action(
@@ -1227,10 +1261,16 @@ class Supervisor:
             operational_tools,
             normalized_action_input=ctx.get("normalized_action_input") if isinstance(ctx.get("normalized_action_input"), dict) else None,
         )
+        canonical_operational_tool = _select_canonical_operational_tool(user_text, operational_tools)
+        if canonical_operational_tool is not None:
+            operational_intent_detected = True
+            preferred_operational_tool = canonical_operational_tool
         ctx["no_write_active"] = no_write_active
         ctx["execution_blocked_reason"] = execution_blocked_reason
         ctx["operational_intent_detected"] = operational_intent_detected
         ctx["available_operational_tools"] = offered_operational_tool_ids
+        if canonical_operational_tool is not None:
+            ctx.setdefault("debug", {})["canonical_operational_tool"] = canonical_operational_tool.tool_id
         allowed_verbs = [str(v).strip() for v in (options.get("allowed_verbs") or []) if str(v).strip()]
         if operational_intent_detected:
             logger.info(
@@ -1368,6 +1408,13 @@ class Supervisor:
                     preferred_tool_id=preferred_operational_tool.tool_id,
                     override_scores=override_scores,
                 )
+                if canonical_operational_tool is not None and str(tool_id or "") != canonical_operational_tool.tool_id:
+                    should_override = True
+                    override_diag = {
+                        **override_diag,
+                        "forced_by": "canonical_operational_rail",
+                        "preferred_tool_id": canonical_operational_tool.tool_id,
+                    }
                 ctx.setdefault("debug", {})["semantic_override_decision"] = override_diag
                 if should_override and action:
                     logger.info(

--- a/services/orion-cortex-exec/tests/test_operational_semantic_harness.py
+++ b/services/orion-cortex-exec/tests/test_operational_semantic_harness.py
@@ -1,0 +1,137 @@
+import asyncio
+import unittest
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.bus.codec import OrionCodec
+from orion.core.bus.enforce import enforcer
+from orion.schemas.agents.schemas import AgentChainRequest, AgentChainResult, PlannerRequest, PlannerResponse
+from orion.schemas.cortex.schemas import ExecutionPlan
+
+from app.supervisor import Supervisor
+
+
+@dataclass
+class HarnessEvent:
+    channel: str
+    kind: str
+    correlation_id: str
+    payload: dict[str, Any] | Any
+
+
+class HarnessBus:
+    def __init__(self):
+        self.codec = OrionCodec()
+        self.handlers: dict[str, Any] = {}
+        self.events: list[HarnessEvent] = []
+
+    async def connect(self):
+        return
+
+    async def close(self):
+        return
+
+    def register(self, channel: str, handler):
+        self.handlers[channel] = handler
+
+    async def publish(self, channel: str, msg: BaseEnvelope | dict[str, Any]):
+        enforcer.validate(channel)
+        env = msg if isinstance(msg, BaseEnvelope) else BaseEnvelope.model_validate(msg)
+        self.events.append(HarnessEvent(channel=channel, kind=env.kind, correlation_id=str(env.correlation_id), payload=env.payload))
+
+    async def rpc_request(self, request_channel: str, envelope: BaseEnvelope, *, reply_channel: str, timeout_sec: float = 60.0):
+        enforcer.validate(request_channel)
+        response_env = await self.handlers[request_channel](envelope)
+        return {"type": "message", "channel": reply_channel, "data": self.codec.encode(response_env)}
+
+
+class OperationalSemanticHarnessTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        enforcer.enforce = True
+        self.bus = HarnessBus()
+        self.supervisor = Supervisor(self.bus)
+
+        async def planner_handler(env: BaseEnvelope) -> BaseEnvelope:
+            req = PlannerRequest.model_validate(env.payload)
+            planner_resp = PlannerResponse(
+                request_id=req.request_id,
+                status="ok",
+                stop_reason="delegate",
+                trace=[{"step_index": 0, "thought": "generic-first", "action": {"tool_id": "generate_code_scaffold", "input": {"request": req.goal}}, "observation": {}}],
+                usage={"steps": 1, "tokens_reason": 0, "tokens_answer": 0, "tools_called": ["generate_code_scaffold"], "duration_ms": 1},
+            )
+            return BaseEnvelope(kind="agent.planner.result", source=ServiceRef(name="planner-react", version="test", node="test"), correlation_id=env.correlation_id, payload=planner_resp.model_dump(mode="json"))
+
+        async def agent_handler(env: BaseEnvelope) -> BaseEnvelope:
+            req = AgentChainRequest.model_validate(env.payload)
+            selected = req.bound_capability_execution.selected_verb if req.bound_capability_execution else "unknown"
+            result = AgentChainResult(
+                mode=req.mode,
+                text=f"executed:{selected}",
+                structured={"bound_capability": {"selected_verb": selected, "path": "bound_direct_success"}},
+                planner_raw={"status": "ok"},
+                runtime_debug={"bound_capability_terminal_path": "bound_direct_success"},
+            )
+            return BaseEnvelope(kind="agent.chain.result", source=ServiceRef(name="agent-chain", version="test", node="test"), correlation_id=env.correlation_id, payload=result.model_dump(mode="json"))
+
+        self.bus.register("orion:exec:request:PlannerReactService", planner_handler)
+        self.bus.register("orion:exec:request:AgentChainService", agent_handler)
+
+    async def _run(self, ask: str):
+        corr = str(uuid4())
+        req = ExecutionPlan(verb_name="chat_general", steps=[], metadata={"mode": "agent"})
+        ctx = {
+            "mode": "agent",
+            "messages": [{"role": "user", "content": ask}],
+            "output_mode": "direct_answer",
+            "response_profile": "direct_answer",
+            "packs": ["executive_pack"],
+            "options": {},
+            "trace_id": corr,
+            "session_id": "harness",
+            "user_id": "harness",
+        }
+        recall_cfg = {"enabled": False, "required": False}
+        return await self.supervisor.execute(
+            source=ServiceRef(name="test", version="0", node="n"),
+            req=req,
+            correlation_id=corr,
+            ctx=ctx,
+            recall_cfg=recall_cfg,
+        )
+
+    async def test_operational_asks_commit_to_canonical_verbs(self):
+        cases = {
+            "Which nodes are up right now?": "assess_mesh_presence",
+            "Check disk health across active nodes.": "assess_storage_health",
+            "Summarize recent PR changes.": "summarize_recent_changes",
+            "Dry-run cleanup of stopped containers.": "housekeep_runtime",
+        }
+        for ask, expected in cases.items():
+            res = await self._run(ask)
+            agent_step = next(step for step in res.steps if step.step_name == "agent_chain")
+            selected = agent_step.result["AgentChainService"]["structured"]["bound_capability"]["selected_verb"]
+            self.assertEqual(selected, expected)
+
+    async def test_truthful_failure_is_preserved(self):
+        async def failing_agent(env: BaseEnvelope) -> BaseEnvelope:
+            req = AgentChainRequest.model_validate(env.payload)
+            selected = req.bound_capability_execution.selected_verb if req.bound_capability_execution else "unknown"
+            result = AgentChainResult(
+                mode=req.mode,
+                text="Bound capability execution failed: induced timeout",
+                structured={"bound_capability": {"selected_verb": selected, "path": "bound_direct_timeout", "reason": "capability_executor_unavailable"}},
+                planner_raw={"status": "error"},
+                runtime_debug={"bound_capability_terminal_path": "bound_direct_timeout"},
+            )
+            return BaseEnvelope(kind="agent.chain.result", source=ServiceRef(name="agent-chain", version="test", node="test"), correlation_id=env.correlation_id, payload=result.model_dump(mode="json"))
+
+        self.bus.register("orion:exec:request:AgentChainService", failing_agent)
+        res = await self._run("Dry-run cleanup of stopped containers.")
+        self.assertIn("Bound capability execution failed", res.final_text or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Prevent regressions where generic LLM tools (e.g. `generate_code_scaffold`) run before committing to operational verbs by building a deterministic harness that exercises the real supervisor/planner/agent RPC wiring. 
- Reproduce the live failure class where planner output can diverge from the intended operational verb and agent-chain fails to terminalize. 
- Provide a single canonical, testable operational rail for the four target asks so capability-backed verbs always follow a unified, terminal execution path.

### Description

- Add a canonical operational selector with explicit phrase-priority rules and a lexical fallback: `_OPERATIONAL_VERB_RULES` and `_select_canonical_operational_tool` in `services/orion-cortex-exec/app/supervisor.py`. 
- Wire canonical selection into the supervisor decision flow so a matched canonical operational tool promotes `operational_intent_detected`, becomes `preferred_operational_tool`, and forces planner-action override when needed. 
- Keep the execution path unified: forced operational verbs still route via the existing bound-capability escalation (`AgentChainService`) to preserve the canonical capability execution helper and terminalization semantics. 
- Add an end-to-end deterministic harness test `services/orion-cortex-exec/tests/test_operational_semantic_harness.py` that drives requests through supervisor with real bus channel names and schema enforcement while stubbing planner and agent-chain responses deterministically for the four target asks.

### Testing

- Ran the harness and existing supervisor planner delegate tests: `pytest -q services/orion-cortex-exec/tests/test_operational_semantic_harness.py services/orion-cortex-exec/tests/test_supervisor_planner_delegate.py -q`; the combined suite passed on the final run. 
- The harness asserts that the four asks map to the canonical verbs `assess_mesh_presence`, `assess_storage_health`, `summarize_recent_changes`, and `housekeep_runtime`, and that induced capability failures are preserved and terminalized as structured fail-closed results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d875596bf0832abbd85518fdb70037)