### PR TITLE
Fail-closed on empty capability final_text, extend bound-capability timeout, add live verification scripts and tests

### DIFF
--- a/scripts/locate-bound-capability-live-path.sh
+++ b/scripts/locate-bound-capability-live-path.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+require_match() {
+  local label="$1"
+  local file="$2"
+  local pattern="$3"
+  local out
+  out="$(rg -n "$pattern" "$file" || true)"
+  if [[ -z "$out" ]]; then
+    echo "MISSING: ${label} (${file} :: ${pattern})"
+    return 1
+  fi
+  echo "=== ${label} ==="
+  echo "$out"
+  echo
+}
+
+status=0
+
+require_match "Ingress HTTP endpoint" "services/orion-hub/scripts/api_routes.py" "@router.post\(\"/api/chat\"\)|async def api_chat|async def handle_chat_request" || status=1
+require_match "Hub bus egress to gateway" "services/orion-hub/scripts/bus_clients/cortex_client.py" "cortex\.gateway\.chat\.request|CORTEX_GATEWAY_REQUEST_CHANNEL|send_chat_request" || status=1
+require_match "Gateway intake + orch handoff" "services/orion-cortex-gateway/app/bus_client.py" "async def handle_gateway_request|rpc_call_cortex_orch|cortex\.orch\.request" || status=1
+require_match "Orch handle + verb runtime handoff" "services/orion-cortex-orch/app/main.py" "async def handle\(|call_verb_runtime\(" || status=1
+require_match "Orch->Exec publish/wait" "services/orion-cortex-orch/app/orchestrator.py" "async def call_verb_runtime|orion:verb:request|orch_publish_verb_runtime|orch_wait_verb_runtime" || status=1
+require_match "Exec verb request entry" "services/orion-cortex-exec/app/main.py" "async def handle_verb_request|verb_runtime_intake|verb_runtime_result" || status=1
+require_match "Exec supervisor path + AgentChainService" "services/orion-cortex-exec/app/supervisor.py" "bound_capability_request_received|dispatch_action.*AgentChainService|selected_verb_preserved" || status=1
+require_match "Agent-chain bound execution + preserved selected_verb" "services/orion-agent-chain/app/api.py" "bound_capability_direct_execute=1|selected_verb_preserved=1|bound_capability_execution_timeout" || status=1
+require_match "Agent-chain concrete skills.runtime invocation" "services/orion-agent-chain/app/tool_executor.py" "_execute_capability_backed_verb|decision\.selected_skill|orion:cortex:request|skills\.runtime" || status=1
+require_match "Concrete runtime skill implementation" "services/orion-cortex-exec/app/verb_adapters.py" "@verb\(\"skills\.runtime\.docker_prune_stopped_containers\.v1\"\)" || status=1
+
+echo "=== Most likely live trigger command ==="
+cat <<'CMD'
+curl -sS -X POST "http://127.0.0.1:${HUB_PORT:-8000}/api/chat" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "mode": "agent",
+    "messages": [{"role": "user", "content": "Dry-run cleanup of stopped containers."}],
+    "use_recall": false,
+    "no_write": true
+  }'
+CMD
+
+echo
+if [[ $status -ne 0 ]]; then
+  echo "PATH_PROOF=FAIL"
+  exit 1
+fi
+
+echo "PATH_PROOF=PASS"

--- a/scripts/verify-bound-capability-live.sh
+++ b/scripts/verify-bound-capability-live.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REQUEST_TEXT='Dry-run cleanup of stopped containers.'
+SERVICES=(
+  orion-athena-cortex-orch
+  orion-athena-cortex-exec
+  orion-athena-agent-chain
+  orion-athena-planner-react
+)
+
+TMP_DIR="${TMP_DIR:-$(mktemp -d /tmp/orion-live-verify.XXXXXX)}"
+START_TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+fail() {
+  echo "FAIL: $*"
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+need_cmd docker
+need_cmd curl
+need_cmd python3
+
+for svc in "${SERVICES[@]}"; do
+  docker inspect "$svc" >/dev/null 2>&1 || fail "required container not found: $svc"
+done
+
+HUB_CONTAINER="${HUB_CONTAINER:-orion-athena-hub}"
+docker inspect "$HUB_CONTAINER" >/dev/null 2>&1 || fail "hub container not found: $HUB_CONTAINER"
+
+HUB_PORT="$({ docker inspect "$HUB_CONTAINER" --format '{{range .Config.Env}}{{println .}}{{end}}' || true; } | awk -F= '/^HUB_PORT=/{print $2; exit}')"
+HUB_PORT="${HUB_PORT:-8000}"
+HUB_URL="${HUB_URL:-http://127.0.0.1:${HUB_PORT}/api/chat}"
+
+REQ_JSON="${TMP_DIR}/request.json"
+cat >"$REQ_JSON" <<JSON
+{
+  "mode": "agent",
+  "messages": [
+    {"role": "user", "content": "${REQUEST_TEXT}"}
+  ],
+  "use_recall": false,
+  "no_write": true
+}
+JSON
+
+echo "Triggering live ingress via ${HUB_URL}"
+RESP_JSON="${TMP_DIR}/response.json"
+HTTP_CODE="$(curl -sS -o "$RESP_JSON" -w '%{http_code}' -H 'Content-Type: application/json' -X POST "$HUB_URL" --data-binary "@$REQ_JSON")"
+[[ "$HTTP_CODE" == "200" ]] || fail "hub request failed, HTTP ${HTTP_CODE}, body=$(cat "$RESP_JSON")"
+CORR_ID="$(python3 - <<'PY' "$RESP_JSON"
+import json,sys
+p=json.load(open(sys.argv[1]))
+print(p.get('correlation_id') or '')
+PY
+)"
+[[ -n "$CORR_ID" ]] || fail "missing correlation_id in hub response: $(cat "$RESP_JSON")"
+
+echo "correlation_id=${CORR_ID}"
+
+# Give services a small window to flush async logs.
+sleep 4
+
+for svc in "${SERVICES[@]}"; do
+  docker logs --since "$START_TS" --timestamps "$svc" >"${TMP_DIR}/${svc}.log" 2>&1 || true
+  grep -F "$CORR_ID" "${TMP_DIR}/${svc}.log" >"${TMP_DIR}/${svc}.corr.log" || true
+  if [[ ! -s "${TMP_DIR}/${svc}.corr.log" ]]; then
+    cp "${TMP_DIR}/${svc}.log" "${TMP_DIR}/${svc}.corr.log"
+  fi
+
+done
+
+find_line() {
+  local file="$1"; shift
+  local pattern="$1"
+  grep -E "$pattern" "$file" | head -n 1 || true
+}
+
+E1="$(find_line "${TMP_DIR}/orion-athena-cortex-exec.corr.log" 'bound_capability_request_received.*selected_verb=housekeep_runtime')"
+[[ -n "$E1" ]] || fail "missing evidence #1 (supervisor selected housekeep_runtime)"
+
+E2="$(find_line "${TMP_DIR}/orion-athena-agent-chain.corr.log" 'bound_capability_direct_execute=1.*selected_verb=housekeep_runtime.*selected_verb_preserved=1')"
+[[ -n "$E2" ]] || fail "missing evidence #2 (selected_verb preserved into agent-chain)"
+
+E3="$(find_line "${TMP_DIR}/orion-athena-cortex-orch.corr.log" 'orch_publish_verb_runtime.*skills\.runtime\.')"
+[[ -n "$E3" ]] || fail "missing evidence #3 (downstream concrete skills.runtime.* invocation)"
+
+E4="$(find_line "${TMP_DIR}/orion-athena-cortex-exec.corr.log" 'final_text_assembly .*verb=skills\.runtime\..*final_len=[1-9]')"
+[[ -n "$E4" ]] || fail "missing evidence #4 (non-empty terminal output for concrete runtime skill)"
+
+if grep -E 'bound_capability_execution_timeout' "${TMP_DIR}/orion-athena-agent-chain.corr.log" >/dev/null 2>&1; then
+  fail "evidence #5 failed (bound_capability_execution_timeout present)"
+fi
+
+TIMINGS_JSON="${TMP_DIR}/timings.json"
+python3 - <<'PY' "${TMP_DIR}/orion-athena-cortex-exec.corr.log" "$TIMINGS_JSON"
+import json,re,sys
+from datetime import datetime
+
+log = open(sys.argv[1], encoding='utf-8', errors='ignore').read().splitlines()
+out = {}
+
+def first_ts(pattern):
+    rx = re.compile(pattern)
+    for line in log:
+        if rx.search(line):
+            ts = line.split(' ', 1)[0]
+            try:
+                return datetime.fromisoformat(ts.replace('Z', '+00:00')).timestamp(), line
+            except Exception:
+                continue
+    return None, None
+
+pairs = {
+  'planner_react': (r'rpc -> PlannerReactService', r'ok <- PlannerReactService'),
+  'agent_chain': (r'rpc -> AgentChainService', r'ok <- AgentChainService'),
+  'concrete_skill': (r'verb_runtime_intake .*trigger=legacy\.plan', r'final_text_assembly .*verb=skills\.runtime\.'),
+}
+for k,(s,e) in pairs.items():
+    s_ts,s_line = first_ts(s)
+    e_ts,e_line = first_ts(e)
+    if s_ts is None or e_ts is None or e_ts < s_ts:
+        print(f"MISSING:{k}")
+        sys.exit(2)
+    out[k] = {
+        'duration_sec': round(e_ts - s_ts, 3),
+        'start_line': s_line,
+        'end_line': e_line,
+    }
+json.dump(out, open(sys.argv[2], 'w'), indent=2)
+PY
+
+echo "PASS: live bound capability verification"
+echo "Evidence #1: $E1"
+echo "Evidence #2: $E2"
+echo "Evidence #3: $E3"
+echo "Evidence #4: $E4"
+echo "Evidence #5: no bound_capability_execution_timeout in agent-chain logs"
+echo "Evidence #6 timings: $(cat "$TIMINGS_JSON")"

--- a/services/orion-agent-chain/app/api.py
+++ b/services/orion-agent-chain/app/api.py
@@ -456,9 +456,11 @@ def _bound_execution_timeout_seconds() -> float:
     the parent RPC time out first.
     """
     default_timeout = float(settings.default_timeout_seconds or 90)
-    # Keep under the parent hop budget while allowing capability-backed verbs
-    # with 30s runtimes (e.g. runtime housekeeping) to complete under nominal load.
-    return max(8.0, min(45.0, default_timeout * 0.75))
+    # Bound execution wraps ToolExecutor.execute_llm_verb(), which for capability-backed
+    # verbs performs a nested cortex-orch RPC using settings.default_timeout_seconds.
+    # The guardrail here must exceed that inner timeout so we don't fail closed early
+    # while the concrete skill invocation is still legitimately in flight.
+    return max(12.0, min(180.0, default_timeout + 15.0))
 
 
 async def _execute_bound_capability_request(

--- a/services/orion-agent-chain/app/tool_executor.py
+++ b/services/orion-agent-chain/app/tool_executor.py
@@ -236,6 +236,20 @@ class ToolExecutor:
             raise RuntimeError(f"Capability bridge decode failed: {decoded.error}")
         payload = decoded.envelope.payload if isinstance(decoded.envelope.payload, dict) else {}
         result = CortexClientResult.model_validate(payload)
+        final_text = str(result.final_text or "").strip()
+        if result.ok and not final_text:
+            fail_closed_decision = decision.model_copy(update={"selected_skill": None})
+            return normalize_capability_observation(
+                decision=fail_closed_decision,
+                execution_summary=(
+                    f"Execution failed closed: {decision.selected_skill} returned empty terminal output."
+                ),
+                raw_payload={
+                    "status": "empty_terminal_output",
+                    "ok": False,
+                    "final_text": "",
+                },
+            )
         summary = f"Executed {decision.selected_skill}: status={result.status} ok={result.ok}"
         return normalize_capability_observation(
             decision=decision,

--- a/services/orion-agent-chain/tests/test_bound_capability_contract.py
+++ b/services/orion-agent-chain/tests/test_bound_capability_contract.py
@@ -290,7 +290,7 @@ def test_bound_capability_timeout_terminal_reply(monkeypatch):
     assert bound["observation"]["reply_emitted"] is True
 
 
-def test_bound_execution_timeout_budget_is_below_parent_hop_budget():
+def test_bound_execution_timeout_budget_exceeds_nested_capability_rpc_budget():
     timeout_sec = agent_api._bound_execution_timeout_seconds()
     assert timeout_sec > 25.0
-    assert timeout_sec < float(agent_api.settings.default_timeout_seconds)
+    assert timeout_sec > float(agent_api.settings.default_timeout_seconds)

--- a/services/orion-agent-chain/tests/test_tool_executor_capability.py
+++ b/services/orion-agent-chain/tests/test_tool_executor_capability.py
@@ -46,6 +46,33 @@ class _FakeBus:
         }
 
 
+class _FakeBusEmptyFinalText(_FakeBus):
+    async def rpc_request(self, channel, env, *, reply_channel, timeout_sec):
+        self.calls.append(
+            (
+                channel,
+                env.kind,
+                env.payload.get("verb"),
+                env.payload.get("context", {}).get("metadata", {}),
+                reply_channel,
+                env.reply_to,
+            )
+        )
+        return {
+            "data": {
+                "ok": True,
+                "mode": "brain",
+                "verb": "skills.runtime.docker_prune_stopped_containers.v1",
+                "status": "success",
+                "final_text": "",
+                "memory_used": False,
+                "steps": [],
+                "recall_debug": {},
+                "metadata": {},
+            }
+        }
+
+
 def test_capability_backed_tool_exec_normalizes_observation():
     bus = _FakeBus()
     executor = ToolExecutor(bus, base_dir="/workspace/Orion-Sapienform/orion/cognition")
@@ -66,6 +93,22 @@ def test_capability_backed_tool_exec_normalizes_observation():
     assert "risk_class" in metadata
     assert bus.calls[0][4].startswith("orion:cortex:result:")
     assert bus.calls[0][5] == bus.calls[0][4]
+
+
+def test_capability_backed_tool_exec_fail_closes_on_empty_terminal_text():
+    bus = _FakeBusEmptyFinalText()
+    executor = ToolExecutor(bus, base_dir="/workspace/Orion-Sapienform/orion/cognition")
+    result = asyncio.run(
+        executor.execute_llm_verb(
+            "housekeep_runtime",
+            {"text": "dry-run cleanup of stopped containers"},
+            parent_correlation_id="corr-empty",
+        )
+    )
+    assert result["selected_verb"] == "housekeep_runtime"
+    assert result["selected_skill"] is None
+    assert result["raw_payload_ref"]["status"] == "empty_terminal_output"
+    assert "failed closed" in result["execution_summary"].lower()
 
 
 def test_capability_backed_tool_reply_channel_is_catalog_valid():

--- a/services/orion-cortex-exec/tests/test_bound_capability_full_path.py
+++ b/services/orion-cortex-exec/tests/test_bound_capability_full_path.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.schemas.agents.schemas import AgentChainRequest, PlannerRequest, PlannerResponse
+from orion.schemas.cortex.contracts import CortexClientResult
+from orion.schemas.cortex.schemas import ExecutionPlan
+
+from app.supervisor import Supervisor
+
+
+@dataclass
+class CapabilityHop:
+    selected_verb: str
+    selected_skill: str
+    final_text: str
+
+
+class _CapabilityBridgeBus:
+    def __init__(self, hops: list[CapabilityHop]):
+        self.hops = hops
+
+    async def rpc_request(self, channel: str, env: BaseEnvelope, *, reply_channel: str, timeout_sec: float = 60.0):
+        assert channel == "orion:cortex:request"
+        payload = env.payload if isinstance(env.payload, dict) else {}
+        metadata = payload.get("context", {}).get("metadata", {}) if isinstance(payload, dict) else {}
+        selected_verb = str(metadata.get("requested_verb") or "")
+        selected_skill = str(payload.get("verb") or "")
+        assert selected_skill.startswith("skills.runtime.")
+
+        concrete_final_text = "dry-run cleanup of stopped containers completed"
+        self.hops.append(
+            CapabilityHop(
+                selected_verb=selected_verb,
+                selected_skill=selected_skill,
+                final_text=concrete_final_text,
+            )
+        )
+        result = CortexClientResult(
+            ok=True,
+            mode="brain",
+            verb=selected_skill,
+            status="success",
+            final_text=concrete_final_text,
+            memory_used=False,
+            recall_debug={},
+            steps=[],
+            metadata={"concrete_skill": selected_skill},
+        )
+        response = BaseEnvelope(
+            kind="cortex.orch.result",
+            source=ServiceRef(name="cortex-orch", version="test", node="test"),
+            correlation_id=env.correlation_id,
+            payload=result.model_dump(mode="json"),
+        )
+        return {"type": "message", "channel": reply_channel, "data": env.model_copy(update={"payload": response.payload})}
+
+
+class _Codec:
+    def decode(self, data: Any):
+        return type("D", (), {"ok": True, "envelope": BaseEnvelope(kind="cortex.orch.result", source=ServiceRef(name="cortex-orch"), correlation_id=str(uuid4()), payload=data), "error": None})
+
+
+class _HarnessBus:
+    def __init__(self):
+        self.codec = _Codec()
+        self.handlers: dict[str, Any] = {}
+        self.capability_hops: list[CapabilityHop] = []
+
+    async def connect(self):
+        return
+
+    async def close(self):
+        return
+
+    def register(self, channel: str, handler):
+        self.handlers[channel] = handler
+
+    async def publish(self, channel: str, msg: BaseEnvelope | dict[str, Any]):
+        return
+
+    async def rpc_request(self, request_channel: str, envelope: BaseEnvelope, *, reply_channel: str, timeout_sec: float = 60.0):
+        response_env = await self.handlers[request_channel](envelope)
+        return {"type": "message", "channel": reply_channel, "data": response_env.payload}
+
+
+async def _agent_handler(env: BaseEnvelope, *, capability_hops: list[CapabilityHop]) -> BaseEnvelope:
+    req = AgentChainRequest.model_validate(env.payload)
+    selected_verb = req.bound_capability_execution.selected_verb if req.bound_capability_execution else "housekeep_runtime"
+    rpc_bus = _CapabilityBridgeBus(capability_hops)
+    bridge_env = BaseEnvelope(
+        kind="cortex.orch.request",
+        source=ServiceRef(name="agent-chain", version="test", node="test"),
+        correlation_id=env.correlation_id,
+        payload={
+            "verb": "skills.runtime.docker_prune_stopped_containers.v1",
+            "context": {"metadata": {"requested_verb": selected_verb}},
+        },
+    )
+    bridge_msg = await rpc_bus.rpc_request("orion:cortex:request", bridge_env, reply_channel=f"orion:cortex:result:{env.correlation_id}")
+    bridge_payload = bridge_msg["data"].payload if isinstance(bridge_msg["data"], BaseEnvelope) else {}
+    concrete_text = str((bridge_payload or {}).get("final_text") or "")
+    result_payload = {
+        "mode": req.mode,
+        "text": concrete_text,
+        "structured": {
+            "finalization_reason": "bound_capability_execution",
+            "bound_capability": {
+                "selected_verb": selected_verb,
+                "selected_skill": "skills.runtime.docker_prune_stopped_containers.v1",
+                "execution_path": "direct_execute",
+            },
+        },
+        "planner_raw": {"status": "ok"},
+        "runtime_debug": {"bound_capability_terminal_path": "bound_direct_success"},
+    }
+    return BaseEnvelope(
+        kind="agent.chain.result",
+        source=ServiceRef(name="agent-chain", version="test", node="test"),
+        correlation_id=env.correlation_id,
+        payload=result_payload,
+    )
+
+
+def test_bound_capability_full_runtime_path_emits_non_empty_result_without_timeout():
+    bus = _HarnessBus()
+
+    async def planner_handler(env: BaseEnvelope) -> BaseEnvelope:
+        req = PlannerRequest.model_validate(env.payload)
+        planner_resp = PlannerResponse(
+            request_id=req.request_id,
+            status="ok",
+            stop_reason="delegate",
+            trace=[
+                {
+                    "step_index": 0,
+                    "thought": "select semantic runtime tool",
+                    "action": {"tool_id": "housekeep_runtime", "input": {"text": req.goal}},
+                    "observation": {"selected_semantic_tool": "housekeep_runtime"},
+                }
+            ],
+            usage={"steps": 1, "tokens_reason": 0, "tokens_answer": 0, "tools_called": ["housekeep_runtime"], "duration_ms": 1},
+        )
+        return BaseEnvelope(kind="agent.planner.result", source=ServiceRef(name="planner-react", version="test", node="test"), correlation_id=env.correlation_id, payload=planner_resp.model_dump(mode="json"))
+
+    async def agent_handler(env: BaseEnvelope) -> BaseEnvelope:
+        return await _agent_handler(env, capability_hops=bus.capability_hops)
+
+    bus.register("orion:exec:request:PlannerReactService", planner_handler)
+    bus.register("orion:exec:request:AgentChainService", agent_handler)
+
+    supervisor = Supervisor(bus)
+
+    corr = str(uuid4())
+    req = ExecutionPlan(verb_name="chat_general", steps=[], metadata={"mode": "agent"})
+    ctx = {
+        "mode": "agent",
+        "messages": [{"role": "user", "content": "Dry-run cleanup of stopped containers."}],
+        "output_mode": "direct_answer",
+        "response_profile": "direct_answer",
+        "packs": ["executive_pack"],
+        "options": {},
+        "trace_id": corr,
+        "session_id": "harness",
+        "user_id": "harness",
+    }
+
+    result = asyncio.run(
+        supervisor.execute(
+            source=ServiceRef(name="cortex-orch", version="0", node="n"),
+            req=req,
+            correlation_id=corr,
+            ctx=ctx,
+            recall_cfg={"enabled": False, "required": False},
+        )
+    )
+
+    agent_step = next(step for step in result.steps if step.step_name == "agent_chain")
+    agent_payload = agent_step.result["AgentChainService"]
+    bound = agent_payload["structured"]["bound_capability"]
+
+    assert bound["selected_verb"] == "housekeep_runtime"
+    assert bound["selected_skill"].startswith("skills.runtime.")
+    assert bus.capability_hops
+    assert bus.capability_hops[0].selected_verb == "housekeep_runtime"
+    assert bus.capability_hops[0].selected_skill == bound["selected_skill"]
+    assert bus.capability_hops[0].final_text
+    assert (agent_payload.get("text") or "").strip()
+    assert agent_payload["runtime_debug"]["bound_capability_terminal_path"] == "bound_direct_success"
+    assert "timeout" not in (result.final_text or "").lower()


### PR DESCRIPTION
### Motivation
- Ensure bound-capability direct execution does not incorrectly succeed when the downstream concrete skill returns an empty terminal output by treating that as a fail-closed observation. 
- Prevent premature agent-chain termination by making the bound-capability guardrail timeout exceed the nested capability RPC budget. 
- Provide developer tooling to locate and verify the live bound-capability execution path across services. 

### Description
- Add two helper scripts `scripts/locate-bound-capability-live-path.sh` and `scripts/verify-bound-capability-live.sh` to locate key handoff points in the codebase and to trigger/verify a live end-to-end bound-capability execution path. 
- Change the bound-capability guard in `AgentChain` by updating `_bound_execution_timeout_seconds` to return `max(12.0, min(180.0, default_timeout + 15.0))` and add comments explaining the need to exceed nested RPC timeouts. 
- Update `ToolExecutor.execute_llm_verb` in `services/orion-agent-chain/app/tool_executor.py` to detect an empty `final_text` from the cortex-orch bridge and return a fail-closed normalized observation with `selected_skill=None` and `raw_payload` containing `status: empty_terminal_output`. 
- Add and adjust unit tests: rename/adjust the timeout budget test to `test_bound_execution_timeout_budget_exceeds_nested_capability_rpc_budget`, add `test_capability_backed_tool_exec_fail_closes_on_empty_terminal_text` in `test_tool_executor_capability.py`, and add a comprehensive harness test `services/orion-cortex-exec/tests/test_bound_capability_full_path.py` that simulates the full runtime hop. 

### Testing
- Ran the modified unit tests under `services/orion-agent-chain/tests` including `test_tool_executor_capability.py` and `test_bound_capability_contract.py`, and they passed. 
- Ran the new end-to-end harness test `services/orion-cortex-exec/tests/test_bound_capability_full_path.py` under `pytest`, and it passed. 
- The added verification scripts are present and executable for manual or CI-driven live verification steps, and no automated script failures were observed during the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87fe83da8832abc48db0e4b451c3d)