### PR TITLE
Restore SMTP delivery attempts in orion-notify stateless router

### DIFF
--- a/services/orion-notify/app/main.py
+++ b/services/orion-notify/app/main.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, Header, HTTPException, Query, Request
 
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.notify.transport import EmailTransport
 from orion.schemas.cortex.contracts import AgentTraceSummaryV1
 from orion.schemas.notify import (
     ChatAttentionAck,
@@ -53,9 +54,9 @@ CHAT_MESSAGE_ESCALATION_EVENT_KIND = "orion.chat.message.escalation"
 async def on_startup() -> None:
     app.state.env_lookup = dict(os.environ)
     app.state.bus = await _init_bus()
+    app.state.email_transport = _build_email_transport()
     # No DB init
     # No policy load (stateless)
-    # No email transport (stateless router only)
     # No escalation loop (stateless)
 
 
@@ -125,6 +126,44 @@ async def notify(
     # Fill defaults
     if not payload.created_at:
         payload.created_at = datetime.utcnow()
+
+    email_transport: EmailTransport | None = getattr(request.app.state, "email_transport", None)
+    should_send_email, send_reason = _should_send_email(payload)
+    if should_send_email:
+        logger.info(
+            "[NOTIFY] email_send_eligible notification_id=%s event_kind=%s reason=%s",
+            payload.notification_id,
+            payload.event_kind,
+            send_reason,
+        )
+        if email_transport is None:
+            logger.info(
+                "[NOTIFY] email_send_unavailable notification_id=%s event_kind=%s reason=smtp_transport_unconfigured",
+                payload.notification_id,
+                payload.event_kind,
+            )
+        else:
+            logger.info(
+                "[NOTIFY] email_send_attempted notification_id=%s event_kind=%s",
+                payload.notification_id,
+                payload.event_kind,
+            )
+            try:
+                email_transport.send(payload)
+            except Exception as exc:
+                logger.error(
+                    "[NOTIFY] email_send_failed notification_id=%s event_kind=%s error_class=%s error=%s",
+                    payload.notification_id,
+                    payload.event_kind,
+                    exc.__class__.__name__,
+                    str(exc),
+                )
+            else:
+                logger.info(
+                    "[NOTIFY] email_send_succeeded notification_id=%s event_kind=%s",
+                    payload.notification_id,
+                    payload.event_kind,
+                )
 
     # 1. Publish In-App (if enabled)
     # We do this blindly as a router. Policy logic is stripped for statelessness or should be in the consumer.
@@ -719,3 +758,52 @@ def _resolve_notification_type(event_kind: str) -> Optional[str]:
 
 def _check_presence():
     return False # Stateless stub
+
+
+def _build_email_transport() -> EmailTransport | None:
+    missing = []
+    if not settings.NOTIFY_EMAIL_SMTP_HOST:
+        missing.append("smtp_host")
+    if not settings.NOTIFY_EMAIL_FROM:
+        missing.append("from")
+    if not settings.notify_email_to:
+        missing.append("to")
+
+    if missing:
+        logger.info(
+            "[NOTIFY] smtp_transport_not_configured missing=%s",
+            ",".join(missing),
+        )
+        return None
+
+    transport = EmailTransport(
+        smtp_host=settings.NOTIFY_EMAIL_SMTP_HOST,
+        smtp_port=settings.NOTIFY_EMAIL_SMTP_PORT,
+        smtp_username=settings.NOTIFY_EMAIL_SMTP_USERNAME,
+        smtp_password=settings.NOTIFY_EMAIL_SMTP_PASSWORD,
+        use_tls=settings.NOTIFY_EMAIL_USE_TLS,
+        default_from=settings.NOTIFY_EMAIL_FROM,
+        default_to=settings.notify_email_to,
+    )
+    logger.info(
+        "[NOTIFY] smtp_transport_configured smtp_host=%s smtp_port=%s use_tls=%s default_to_count=%s",
+        settings.NOTIFY_EMAIL_SMTP_HOST,
+        settings.NOTIFY_EMAIL_SMTP_PORT,
+        settings.NOTIFY_EMAIL_USE_TLS,
+        len(settings.notify_email_to),
+    )
+    return transport
+
+
+def _should_send_email(payload: NotificationRequest) -> tuple[bool, Optional[str]]:
+    channels = payload.channels_requested or []
+    if any(channel.lower() == "email" for channel in channels):
+        return True, "channels_requested=email"
+
+    severity = (payload.severity or "").lower()
+    if severity == "error":
+        return True, "severity=error"
+    if severity == "critical":
+        return True, "severity=critical"
+
+    return False, None

--- a/services/orion-notify/tests/test_notify_email_delivery.py
+++ b/services/orion-notify/tests/test_notify_email_delivery.py
@@ -1,0 +1,178 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from app import main
+from orion.schemas.notify import NotificationRequest
+
+
+class DummyTransport:
+    def __init__(self, should_raise: bool = False) -> None:
+        self.calls = []
+        self.should_raise = should_raise
+
+    def send(self, payload: NotificationRequest) -> None:
+        self.calls.append(payload)
+        if self.should_raise:
+            raise RuntimeError("smtp down")
+
+
+class DummyBus:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_startup_creates_email_transport_when_configured(monkeypatch):
+    async def fake_init_bus():
+        return None
+
+    monkeypatch.setattr(main, "_init_bus", fake_init_bus)
+    monkeypatch.setattr(main.settings, "NOTIFY_EMAIL_SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(main.settings, "NOTIFY_EMAIL_SMTP_PORT", 587)
+    monkeypatch.setattr(main.settings, "NOTIFY_EMAIL_SMTP_USERNAME", "user")
+    monkeypatch.setattr(main.settings, "NOTIFY_EMAIL_SMTP_PASSWORD", "pass")
+    monkeypatch.setattr(main.settings, "NOTIFY_EMAIL_USE_TLS", True)
+    monkeypatch.setattr(main.settings, "NOTIFY_EMAIL_FROM", "from@example.com")
+    monkeypatch.setattr(main.settings, "NOTIFY_EMAIL_TO", "to1@example.com,to2@example.com")
+
+    await main.on_startup()
+
+    transport = main.app.state.email_transport
+    assert transport is not None
+    assert transport.smtp_host == "smtp.example.com"
+    assert transport.default_to == ["to1@example.com", "to2@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_notify_sends_email_when_channel_requested(monkeypatch):
+    sent = DummyTransport()
+    published = {"in_app": 0, "persistence": 0}
+
+    async def fake_in_app(*args, **kwargs):
+        published["in_app"] += 1
+
+    async def fake_persist(*args, **kwargs):
+        published["persistence"] += 1
+
+    monkeypatch.setattr(main.settings, "NOTIFY_IN_APP_ENABLED", True)
+    monkeypatch.setattr(main, "_publish_in_app_event", fake_in_app)
+    monkeypatch.setattr(main, "_publish_persistence_event", fake_persist)
+    monkeypatch.setattr(main.asyncio, "create_task", lambda coro: asyncio.create_task(coro))
+
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(bus=DummyBus(), email_transport=sent)))
+    payload = NotificationRequest(
+        source_service="svc",
+        event_kind="evt",
+        severity="info",
+        title="hello",
+        channels_requested=["email"],
+    )
+
+    result = await main.notify(payload, request)
+    await asyncio.sleep(0)
+
+    assert result.status == "queued"
+    assert len(sent.calls) == 1
+    assert published["in_app"] == 1
+    assert published["persistence"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("severity", ["error", "critical"])
+async def test_notify_sends_email_for_error_and_critical(monkeypatch, severity):
+    sent = DummyTransport()
+
+    async def fake_in_app(*args, **kwargs):
+        return None
+
+    async def fake_persist(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(main.settings, "NOTIFY_IN_APP_ENABLED", True)
+    monkeypatch.setattr(main, "_publish_in_app_event", fake_in_app)
+    monkeypatch.setattr(main, "_publish_persistence_event", fake_persist)
+    monkeypatch.setattr(main.asyncio, "create_task", lambda coro: asyncio.create_task(coro))
+
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(bus=DummyBus(), email_transport=sent)))
+    payload = NotificationRequest(
+        source_service="svc",
+        event_kind="evt",
+        severity=severity,
+        title="hello",
+    )
+
+    await main.notify(payload, request)
+    await asyncio.sleep(0)
+
+    assert len(sent.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_notify_does_not_send_email_for_info_without_email_channel(monkeypatch):
+    sent = DummyTransport()
+
+    async def fake_in_app(*args, **kwargs):
+        return None
+
+    async def fake_persist(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(main.settings, "NOTIFY_IN_APP_ENABLED", True)
+    monkeypatch.setattr(main, "_publish_in_app_event", fake_in_app)
+    monkeypatch.setattr(main, "_publish_persistence_event", fake_persist)
+    monkeypatch.setattr(main.asyncio, "create_task", lambda coro: asyncio.create_task(coro))
+
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(bus=DummyBus(), email_transport=sent)))
+    payload = NotificationRequest(
+        source_service="svc",
+        event_kind="evt",
+        severity="info",
+        title="hello",
+    )
+
+    await main.notify(payload, request)
+    await asyncio.sleep(0)
+
+    assert sent.calls == []
+
+
+@pytest.mark.asyncio
+async def test_notify_publishes_even_if_smtp_send_fails(monkeypatch):
+    sent = DummyTransport(should_raise=True)
+    published = {"in_app": 0, "persistence": 0}
+
+    async def fake_in_app(*args, **kwargs):
+        published["in_app"] += 1
+
+    async def fake_persist(*args, **kwargs):
+        published["persistence"] += 1
+
+    monkeypatch.setattr(main.settings, "NOTIFY_IN_APP_ENABLED", True)
+    monkeypatch.setattr(main, "_publish_in_app_event", fake_in_app)
+    monkeypatch.setattr(main, "_publish_persistence_event", fake_persist)
+    monkeypatch.setattr(main.asyncio, "create_task", lambda coro: asyncio.create_task(coro))
+
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(bus=DummyBus(), email_transport=sent)))
+    payload = NotificationRequest(
+        source_service="svc",
+        event_kind="evt",
+        severity="critical",
+        title="hello",
+        notification_id=uuid4(),
+    )
+
+    result = await main.notify(payload, request)
+    await asyncio.sleep(0)
+
+    assert result.status == "queued"
+    assert len(sent.calls) == 1
+    assert published["in_app"] == 1
+    assert published["persistence"] == 1


### PR DESCRIPTION
### Motivation
- Reintroduce minimal, safe SMTP delivery from the stateless notify router so live `/notify` posts can attempt email delivery without reintroducing policy/state or breaking existing in-app and persistence behavior.  
- Keep the change narrowly focused and auditable: only wire up the existing `EmailTransport` and add a small send-decision rule while preserving the queued response and non-blocking bus publishes.

### Description
- Import and instantiate the existing `EmailTransport` from `orion.notify.transport` at startup when SMTP `host/from/to` are present, and store the transport on `app.state.email_transport` via a new helper ` _build_email_transport()` in `services/orion-notify/app/main.py`.  
- Add `_should_send_email(payload)` helper implementing the stopgap delivery rule: send if `channels_requested` contains `email` OR `severity` is `error` or `critical`.  
- In the `/notify` handler call, detect send eligibility and, if configured, attempt `email_transport.send(payload)` while logging structured `[NOTIFY]` lines for configured/unconfigured, attempted, succeeded, and failed sends; SMTP failures are logged but do not prevent in-app or persistence publishes or the queued response.  
- Add focused tests in `services/orion-notify/tests/test_notify_email_delivery.py` that assert transport creation on startup, send behavior for `channels_requested=email` and severities `error`/`critical`, no-send for `info` without email channel, and that persistence/in-app publishes still occur when SMTP send raises.

### Testing
- Added unit tests `services/orion-notify/tests/test_notify_email_delivery.py` (startup transport, eligibility rules, non-blocking publish behavior).  
- Ran `python -m compileall services/orion-notify/app/main.py services/orion-notify/tests/test_notify_email_delivery.py` which succeeded (exit code `0`).  
- Ran `pytest -q services/orion-notify/tests/test_notify_email_delivery.py`, which failed at import time (exit code `2`) due to an environment dependency issue: `ImportError: cannot import name 'Sentinel' from 'typing_extensions'` originating from the installed `pydantic`/`pydantic_core` stack; this prevented automated test execution in the current environment.  
- Manual smoke guidance: POST to `POST /notify` with either `channels_requested:[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59c0cd2b4832aa9d40728c41858c3)