### PR TITLE
fix(hub): harden memory graph bridge after review

### DIFF
--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -5521,6 +5521,7 @@ loadDismissedIds();
     return { targetTurnId, targetMessageId, targetCorrelationId, linkageStrategy };
   }
 
+  // Single id string for data-turn-id and suggest evidence: prefers assistant message id from linkage, then meta fields, then turn id.
   function canonicalTurnIdForMemoryGraph(meta = {}) {
     const linkage = resolveFeedbackLinkage(meta);
     const id =
@@ -5838,42 +5839,65 @@ loadDismissedIds();
   }
 
   function collectConversationTurnsUpTo(anchorEl, maxTurns) {
-    if (!conversationDiv || !anchorEl) return [];
+    if (!conversationDiv || !anchorEl) return { turns: [], skippedWithoutId: 0 };
     const out = [];
+    let skippedWithoutId = 0;
     let el = anchorEl;
     while (el && out.length < maxTurns) {
-      if (el.parentElement === conversationDiv && el.dataset && el.dataset.turnId) {
-        const body = el.querySelector('p.whitespace-pre-wrap');
-        out.push({
-          turnId: el.dataset.turnId,
-          role: el.dataset.role || 'unknown',
-          text: body ? body.textContent : '',
-        });
+      if (el.parentElement === conversationDiv) {
+        if (el.dataset && el.dataset.turnId) {
+          const body = el.querySelector('p.whitespace-pre-wrap');
+          out.push({
+            turnId: el.dataset.turnId,
+            role: el.dataset.role || 'unknown',
+            text: body ? body.textContent : '',
+          });
+        } else {
+          skippedWithoutId += 1;
+        }
       }
       el = el.previousElementSibling;
     }
-    return out.reverse();
+    return { turns: out.reverse(), skippedWithoutId };
   }
 
   function closeMemoryGraphBridgeModal() {
     if (!memoryGraphBridgeModal) return;
     memoryGraphBridgeModal.classList.add('hidden');
     memoryGraphBridgeModal.setAttribute('aria-hidden', 'true');
+    const hintsEl = document.getElementById('memoryGraphBridgeChainHints');
+    if (hintsEl) {
+      hintsEl.textContent = '';
+      hintsEl.classList.add('hidden');
+    }
   }
 
   function openMemoryGraphBridgeModal(anchorDiv) {
     const list = document.getElementById('memoryGraphBridgeTurnList');
     const draftTa = document.getElementById('memoryGraphBridgeDraft');
     const statusEl = document.getElementById('memoryGraphBridgeStatus');
+    const hintsEl = document.getElementById('memoryGraphBridgeChainHints');
+    const closeForFocus = document.getElementById('memoryGraphBridgeModalClose');
     if (!memoryGraphBridgeModal || !list) return;
-    const turns = collectConversationTurnsUpTo(anchorDiv, 40);
+    const { turns, skippedWithoutId } = collectConversationTurnsUpTo(anchorDiv, 40);
     memoryGraphBridgeTurnsCache = turns;
     list.innerHTML = '';
     if (statusEl) statusEl.textContent = '';
+    if (hintsEl) {
+      hintsEl.textContent = '';
+      hintsEl.classList.add('hidden');
+    }
     if (!turns.length) {
       if (statusEl) statusEl.textContent = 'No turns with stable ids found in this thread yet.';
+      if (skippedWithoutId > 0 && hintsEl) {
+        hintsEl.textContent = `${skippedWithoutId} older message(s) have no stable turn id (often user turns). They are omitted from the chain until linkage meta is present.`;
+        hintsEl.classList.remove('hidden');
+      }
       memoryGraphBridgeModal.classList.remove('hidden');
       memoryGraphBridgeModal.setAttribute('aria-hidden', 'false');
+      if (closeForFocus && typeof closeForFocus.focus === 'function') {
+        closeForFocus.focus({ preventScroll: true });
+      }
       return;
     }
     const lastIdx = turns.length - 1;
@@ -5882,6 +5906,22 @@ loadDismissedIds();
       if (turns[j].role === 'user') {
         priorUserIdx = j;
         break;
+      }
+    }
+    const hasUserTurnInChain = turns.some((t) => t.role === 'user');
+    if (hintsEl) {
+      const hintParts = [];
+      if (skippedWithoutId > 0) {
+        hintParts.push(`${skippedWithoutId} older message(s) have no stable turn id and were skipped when building this chain.`);
+      }
+      if (!hasUserTurnInChain) {
+        hintParts.push('No user turn with a stable id appears in this chain — select turns manually, or ensure chat passes turn ids for user messages.');
+      } else if (priorUserIdx < 0) {
+        hintParts.push('No user turn directly before this reply appears in the chain (ids may start mid-thread). Adjust checkboxes as needed.');
+      }
+      if (hintParts.length) {
+        hintsEl.textContent = hintParts.join(' ');
+        hintsEl.classList.remove('hidden');
       }
     }
     turns.forEach((t, i) => {
@@ -5909,6 +5949,9 @@ loadDismissedIds();
     if (draftTa) draftTa.value = '';
     memoryGraphBridgeModal.classList.remove('hidden');
     memoryGraphBridgeModal.setAttribute('aria-hidden', 'false');
+    if (closeForFocus && typeof closeForFocus.focus === 'function') {
+      closeForFocus.focus({ preventScroll: true });
+    }
   }
 
   function setupMemoryGraphBridgeModal() {
@@ -5929,6 +5972,7 @@ loadDismissedIds();
     if (suggestBtn) {
       suggestBtn.addEventListener('click', async () => {
         if (!list || !draftTa) return;
+        if (suggestBtn.disabled) return;
         const boxes = list.querySelectorAll('input[type="checkbox"][data-turn-index]');
         const selected = [];
         boxes.forEach((cb) => {
@@ -5941,6 +5985,9 @@ loadDismissedIds();
           if (statusEl) statusEl.textContent = 'Select at least one turn.';
           return;
         }
+        const prevLabel = suggestBtn.textContent;
+        suggestBtn.disabled = true;
+        suggestBtn.textContent = 'Working…';
         if (statusEl) statusEl.textContent = 'Requesting draft…';
         const content = buildMemoryGraphSuggestUserContent(selected);
         const payload = {
@@ -5974,16 +6021,23 @@ loadDismissedIds();
           const t = (data && (data.text || (data.raw && data.raw.final_text))) || text;
           draftTa.value = typeof t === 'string' ? t : JSON.stringify(t, null, 2);
           if (statusEl) {
-            statusEl.textContent = 'Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate on the Memory tab.';
+            statusEl.textContent = 'Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate.';
           }
         } catch (err) {
           if (statusEl) statusEl.textContent = String(err.message || err);
+        } finally {
+          suggestBtn.disabled = false;
+          suggestBtn.textContent = prevLabel;
         }
       });
     }
     if (toMemBtn) {
       toMemBtn.addEventListener('click', () => {
         const raw = document.getElementById('memoryGraphBridgeDraft')?.value || '';
+        if (!String(raw).trim()) {
+          showToast('Add or generate a draft first (run Suggest draft), then continue.');
+          return;
+        }
         sessionStorage.setItem('orion_memory_graph_draft_import', raw);
         if (memoryTabButton) {
           memoryTabButton.click();

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -2864,22 +2864,28 @@
   </div>
 
   <div id="memoryGraphBridgeModal" class="hidden fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-4" aria-hidden="true">
-  <div class="bg-gray-900 border border-gray-700 rounded-xl max-w-lg w-full max-h-[90vh] overflow-hidden flex flex-col shadow-xl">
-    <div class="flex items-center justify-between px-4 py-2 border-b border-gray-800">
-      <div class="text-sm font-semibold text-white">Memory graph from chat</div>
-      <button type="button" id="memoryGraphBridgeModalClose" class="text-gray-400 hover:text-white text-lg leading-none">&times;</button>
-    </div>
-    <div class="p-4 overflow-y-auto flex-1 space-y-3 text-xs text-gray-300">
-      <div id="memoryGraphBridgeTurnList" class="space-y-2"></div>
-      <textarea id="memoryGraphBridgeDraft" class="w-full h-36 bg-gray-950 border border-gray-700 rounded p-2 font-mono text-[10px]" placeholder="Draft JSON appears here after Suggest…"></textarea>
-      <pre id="memoryGraphBridgeStatus" class="text-[10px] text-gray-500 whitespace-pre-wrap"></pre>
-    </div>
-    <div class="flex flex-wrap gap-2 px-4 py-3 border-t border-gray-800">
-      <button type="button" id="memoryGraphBridgeSuggest" class="px-3 py-1 rounded border border-indigo-700 bg-indigo-900/40 text-indigo-100 text-xs">Suggest draft</button>
-      <button type="button" id="memoryGraphBridgeToMemory" class="px-3 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 text-xs">Continue on Memory tab</button>
+    <div
+      class="bg-gray-900 border border-gray-700 rounded-xl max-w-lg w-full max-h-[90vh] overflow-hidden flex flex-col shadow-xl"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="memoryGraphBridgeModalTitle"
+    >
+      <div class="flex items-center justify-between px-4 py-2 border-b border-gray-800">
+        <div id="memoryGraphBridgeModalTitle" class="text-sm font-semibold text-white">Memory graph from chat</div>
+        <button type="button" id="memoryGraphBridgeModalClose" class="text-gray-400 hover:text-white text-lg leading-none" aria-label="Close">&times;</button>
+      </div>
+      <div class="p-4 overflow-y-auto flex-1 space-y-3 text-xs text-gray-300">
+        <p id="memoryGraphBridgeChainHints" class="hidden text-[10px] text-amber-200/90 whitespace-pre-wrap" role="status"></p>
+        <div id="memoryGraphBridgeTurnList" class="space-y-2"></div>
+        <textarea id="memoryGraphBridgeDraft" class="w-full h-36 bg-gray-950 border border-gray-700 rounded p-2 font-mono text-[10px]" placeholder="Draft JSON appears here after Suggest…"></textarea>
+        <pre id="memoryGraphBridgeStatus" class="text-[10px] text-gray-500 whitespace-pre-wrap"></pre>
+      </div>
+      <div class="flex flex-wrap gap-2 px-4 py-3 border-t border-gray-800">
+        <button type="button" id="memoryGraphBridgeSuggest" class="px-3 py-1 rounded border border-indigo-700 bg-indigo-900/40 text-indigo-100 text-xs">Suggest draft</button>
+        <button type="button" id="memoryGraphBridgeToMemory" class="px-3 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 text-xs">Continue on Memory tab</button>
+      </div>
     </div>
   </div>
-</div>
 
   <script>
     window.__HUB_CFG__ = {{HUB_CFG}};

--- a/services/orion-hub/tests/test_memory_graph_bridge_ui.py
+++ b/services/orion-hub/tests/test_memory_graph_bridge_ui.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+APP_JS_PATH = REPO_ROOT / "services" / "orion-hub" / "static" / "js" / "app.js"
+MEMORY_JS_PATH = REPO_ROOT / "services" / "orion-hub" / "static" / "js" / "memory.js"
+TEMPLATE_PATH = REPO_ROOT / "services" / "orion-hub" / "templates" / "index.html"
+
+
+def test_template_includes_memory_graph_bridge_modal_and_a11y() -> None:
+    html = TEMPLATE_PATH.read_text(encoding="utf-8")
+    assert 'id="memoryGraphBridgeModal"' in html
+    assert 'id="memoryGraphBridgeSuggest"' in html
+    assert 'id="memoryGraphBridgeToMemory"' in html
+    assert 'id="memoryGraphBridgeChainHints"' in html
+    assert 'id="memoryGraphBridgeModalTitle"' in html
+    assert 'role="dialog"' in html
+    assert "aria-modal=\"true\"" in html
+    assert "aria-labelledby=\"memoryGraphBridgeModalTitle\"" in html
+
+
+def test_app_js_wires_memory_graph_bridge_handlers() -> None:
+    app_js = APP_JS_PATH.read_text(encoding="utf-8")
+    assert "function collectConversationTurnsUpTo" in app_js
+    assert "skippedWithoutId" in app_js
+    assert "memoryGraphBridgeTurnsCache" in app_js
+    assert "verbs: ['memory_graph_suggest']" in app_js
+    assert "setupMemoryGraphBridgeModal();" in app_js
+    assert "closeMemoryGraphBridgeModal();" in app_js
+    assert "CustomEvent('orion-hub-memory-graph-draft-import'" in app_js
+
+
+def test_memory_js_listens_for_bridge_import_event() -> None:
+    memory_js = MEMORY_JS_PATH.read_text(encoding="utf-8")
+    assert 'orion-hub-memory-graph-draft-import' in memory_js
+    assert "orion_memory_graph_draft_import" in memory_js


### PR DESCRIPTION
## Summary

Hardens the Hub **memory graph chat bridge** (post–code-review) and adds **static regression checks** so the modal markup and JS wiring do not drift.

`origin/main` already contains the initial bridge feature; this PR is the **follow-up fix** commit only.

## Changes

- **Suggest draft:** disable the button during the in-flight `/api/chat` request, show a short working state, and always re-enable in `finally` (avoids duplicate requests).
- **Turn chain transparency:** `collectConversationTurnsUpTo` now returns `skippedWithoutId` and the UI shows **amber hints** when messages lack stable turn ids or the default “prior user + anchor” selection is ambiguous.
- **Continue on Memory tab:** require non-empty draft (toast if user tries to hand off with no JSON).
- **A11y / UX:** dialog `role` / `aria-*`, labelled title, hints region with `role="status"`, focus close control when the modal opens; clear hints when the modal closes.
- **Copy alignment:** success status matches the Memory tab **Suggest** flow (`memory.js`).
- **Tests:** `services/orion-hub/tests/test_memory_graph_bridge_ui.py` — asserts critical template IDs, dialog attributes, and `app.js` / `memory.js` wiring.

## Test plan

- [ ] `node --check services/orion-hub/static/js/app.js`
- [ ] `pytest services/orion-hub/tests/test_memory_graph_bridge_ui.py -q`
- [ ] Manual: Hub chat → **Memory graph** on an assistant reply → **Suggest draft** (button disables briefly) → **Continue on Memory tab** with empty draft (toast) → with draft (Memory annotator prefilled)

## Risk / notes

- Full modal focus trap is still out of scope; keyboard users get labelled dialog + initial focus on close.