### PR TITLE
fix(hub): backfill user turn ids for memory graph bridge

### DIFF
--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -5677,14 +5677,73 @@ loadDismissedIds();
     return a || b;
   }
 
+  function memoryGraphCorrelationBase(meta) {
+    if (!meta || typeof meta !== 'object') return '';
+    const raw = meta.raw;
+    return String(
+      meta.correlationId
+      || meta.correlation_id
+      || meta.turnId
+      || meta.turn_id
+      || (raw && typeof raw === 'object' ? raw.correlation_id : null)
+      || '',
+    ).trim();
+  }
+
+  /** Pair the latest You-line with this Orion turn (WS/HTTP never sent user meta). */
+  function backfillLatestUserTurnIdForGraph(threadRoot, correlationId) {
+    const base = String(correlationId || '').trim();
+    if (!threadRoot || !base) return;
+    let el = threadRoot.lastElementChild;
+    while (el) {
+      const role = el.dataset && el.dataset.role;
+      if (role === 'user') {
+        if (!el.dataset.turnId) el.dataset.turnId = `${base}:user`;
+        return;
+      }
+      if (role === 'assistant' && el.dataset.turnId) return;
+      el = el.previousElementSibling;
+    }
+  }
+
+  function extractCortexStepErrorHint(raw) {
+    if (!raw || typeof raw !== 'object') return '';
+    const topErr = raw.error != null ? String(raw.error).trim() : '';
+    const steps = raw.steps;
+    const parts = [];
+    if (topErr) parts.push(topErr);
+    if (!Array.isArray(steps)) {
+      return parts.filter(Boolean).join(' · ') || '';
+    }
+    steps.forEach((step) => {
+      if (!step || typeof step !== 'object') return;
+      if (step.error != null) parts.push(String(step.error));
+      const res = step.result;
+      if (!res || typeof res !== 'object') return;
+      Object.keys(res).forEach((svcKey) => {
+        const block = res[svcKey];
+        if (!block || typeof block !== 'object') return;
+        const c = String(block.content || '').trim();
+        if (c.startsWith('[Error:') || /timed out|timeout|error/i.test(c)) parts.push(c);
+      });
+    });
+    const merged = parts.filter(Boolean);
+    if (!merged.length) return '';
+    return merged.filter((v, i, a) => a.indexOf(v) === i).join(' · ');
+  }
+
   function appendMessage(sender, text, colorClass = 'text-white') {
     if (!conversationDiv) return;
+    const meta = arguments.length > 3 && arguments[3] && typeof arguments[3] === 'object' ? arguments[3] : {};
+    if (sender === 'Orion') {
+      const corr = memoryGraphCorrelationBase(meta);
+      if (corr) backfillLatestUserTurnIdForGraph(conversationDiv, corr);
+    }
     const div = document.createElement('div');
     const color = sender === 'You' ? 'text-blue-300' : 'text-green-300';
-    const meta = arguments.length > 3 && arguments[3] && typeof arguments[3] === 'object' ? arguments[3] : {};
     const turnIdForGraph = canonicalTurnIdForMemoryGraph(meta);
     if (turnIdForGraph) div.dataset.turnId = turnIdForGraph;
-    div.dataset.role = sender === 'Orion' ? 'assistant' : 'user';
+    div.dataset.role = sender === 'Orion' ? 'assistant' : (sender === 'You' ? 'user' : 'system');
     const displayText = sender === 'Orion' ? hubCoalesceAssistantText(text, meta) : (text || '');
     const workflowOnlyTurn = Boolean(
       sender === 'Orion'
@@ -6018,10 +6077,20 @@ loadDismissedIds();
             if (statusEl) statusEl.textContent = typeof data === 'object' && data ? JSON.stringify(data) : text;
             return;
           }
-          const t = (data && (data.text || (data.raw && data.raw.final_text))) || text;
+          const raw = data && data.raw;
+          const t = (data && (data.text || (raw && raw.final_text))) || text;
+          const out = typeof t === 'string' ? t.trim() : '';
+          const stepErr = !out && raw && typeof raw === 'object' ? extractCortexStepErrorHint(raw) : '';
+          if (!out && stepErr) {
+            draftTa.value = '';
+            if (statusEl) statusEl.textContent = `Suggest failed (no draft text). ${stepErr}`;
+            return;
+          }
           draftTa.value = typeof t === 'string' ? t : JSON.stringify(t, null, 2);
           if (statusEl) {
-            statusEl.textContent = 'Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate.';
+            statusEl.textContent = out
+              ? 'Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate.'
+              : 'Empty response — check gateway / model logs.';
           }
         } catch (err) {
           if (statusEl) statusEl.textContent = String(err.message || err);

--- a/services/orion-hub/tests/test_memory_graph_bridge_ui.py
+++ b/services/orion-hub/tests/test_memory_graph_bridge_ui.py
@@ -30,6 +30,8 @@ def test_app_js_wires_memory_graph_bridge_handlers() -> None:
     assert "setupMemoryGraphBridgeModal();" in app_js
     assert "closeMemoryGraphBridgeModal();" in app_js
     assert "CustomEvent('orion-hub-memory-graph-draft-import'" in app_js
+    assert "backfillLatestUserTurnIdForGraph" in app_js
+    assert "extractCortexStepErrorHint" in app_js
 
 
 def test_memory_js_listens_for_bridge_import_event() -> None:


### PR DESCRIPTION
## Summary
Improves the Hub **Memory graph** chat bridge so turn chains include stable user utterance ids, and so **Suggest draft** failures are visible when the API returns success but the model step errors (e.g. llama.cpp timeout).

## Changes
- When an **Orion** message is appended, backfill the latest **`You`** row with `data-turn-id="<correlation>:user"` if it had no id (WebSocket/HTTP never attach user meta today).
- Resolve correlation from `correlationId` / `turnId` / `raw.correlation_id`.
- Set **`data-role="system"`** for System lines so they are not mistaken for user turns during chain walk.
- If `text` / `final_text` are empty, scan `raw.steps` (and nested gateway `content`) for errors and show them in the modal status line.
- Extend `test_memory_graph_bridge_ui.py` to assert the new helper names are present.

## Testing
- `pytest services/orion-hub/tests/test_memory_graph_bridge_ui.py -v`

## Notes
Graph submission remains **Memory tab → Validate → Approve** after **Continue on Memory tab**; this PR does not add in-modal approve.