### PR TITLE
Hub: memory graph draft Cytoscape preview, bridge depth/K, hub-uttera…

### DIFF
--- a/docs/superpowers/specs/2026-05-02-memory-graph-chat-entry-bridge-design.md
+++ b/docs/superpowers/specs/2026-05-02-memory-graph-chat-entry-bridge-design.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-05-02  
 **Status:** Draft — operator review  
-**Related:** [Memory graph annotator (Hub) + dual-write GraphDB](./2026-05-02-memory-graph-annotator-hub-design.md)  
-**Decision:** Smallest change that removes paste-as-primary workflow (**option C**): optimize for minimal surface area; Approve location unconstrained.
+**Related:** [Memory graph annotator (Hub) + dual-write GraphDB](./2026-05-02-memory-graph-annotator-hub-design.md), [Draft viz + bridge turn depth / ids (2026-05-03)](./2026-05-03-memory-graph-draft-viz-and-bridge-turns-design.md)  
+**Decision:** Smallest change that removes paste-as-primary workflow (**option C**): optimize for minimal surface area; Approve location unconstrained. **Normative depth, cap, persistence, “Select last K”, and user-bubble `hub-utterance:*` ids** are defined in the 2026-05-03 spec; the “e.g. 5 turns” below is a **default token target**, not the hard maximum.
 
 ---
 
@@ -38,7 +38,7 @@ The backend shape **`SuggestDraftV1`** already includes **`utterance_ids`** and 
 
 - On **assistant** bubbles (same row as existing feedback / inspect affordances where layout fits), add **“Memory graph…”** (or shorter **“Graph…”**).
 - Click opens a **modal** that shows:
-  - **Chain selector:** Default = clicked assistant turn + optional **previous N user/assistant turns** (checkboxes or “include prior user message”) capped (e.g. 5 turns) to control tokens.
+  - **Chain selector:** Default = clicked assistant turn + optional **previous N user/assistant turns** (checkboxes or “include prior user message”). **Default N ≈ 5** for token control on first visit; operators may raise **N** up to a **hard cap** with persistence — see [2026-05-03 spec §5](./2026-05-03-memory-graph-draft-viz-and-bridge-turns-design.md#5-bridge-configurable-depth-and-selection).
   - **Evidence preview:** Read-only concatenation of turn texts with **stable ids** displayed monospaced (`message_id` / `turnId` / `correlationId` — whatever `resolveFeedbackLinkage` and message meta already expose for feedback).
 
 ### 3.2 Suggest from modal
@@ -74,7 +74,7 @@ Hub DOM (turn meta) → modal selection
   → Validate / Approve unchanged (memory_graph_routes.py)
 ```
 
-**Provenance:** Turn ids must match what **approve** / **json_to_rdf** can attach as `prov:wasDerivedFrom` — if meta only has correlation ids, document the **canonical id choice** in the implementation plan (single rule: prefer `message_id` when present, else `turnId`, else synthetic session-scoped index with warning banner).
+**Provenance:** Turn ids must match what **approve** / **json_to_rdf** can attach as `prov:wasDerivedFrom` — if meta only has correlation ids, document the **canonical id choice** in the implementation plan (single rule: prefer `message_id` when present, else `turnId`, else synthetic session-scoped index with warning banner). **User bubbles without server meta:** use `hub-utterance:<uuid>` and session-local semantics per [2026-05-03 spec §3](./2026-05-03-memory-graph-draft-viz-and-bridge-turns-design.md#3-id-strategy-for-user-and-assistant-turns-decision).
 
 ---
 

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -458,6 +458,10 @@ loadDismissedIds();
   let lastRecallCanaryResponse = null;
   let lastRecallCanarySelectedProfile = null;
   let memoryGraphBridgeTurnsCache = [];
+  const MEMORY_GRAPH_BRIDGE_MAX_TURNS_CAP = 80;
+  const MEMORY_GRAPH_BRIDGE_MAX_TURNS_DEFAULT = 40;
+  const LS_MEMORY_GRAPH_BRIDGE_MAX_TURNS = 'orion_memory_graph_bridge_max_turns';
+  let memoryGraphBridgeDraftViz = null;
   const RECALL_CANARY_PROFILE_STORAGE_KEY = 'orion_recall_canary_profile_v1';
 
   // Controls
@@ -5743,6 +5747,12 @@ loadDismissedIds();
     const color = sender === 'You' ? 'text-blue-300' : 'text-green-300';
     const turnIdForGraph = canonicalTurnIdForMemoryGraph(meta);
     if (turnIdForGraph) div.dataset.turnId = turnIdForGraph;
+    else if (sender === 'You') {
+      const uuid = (window.crypto && typeof window.crypto.randomUUID === 'function')
+        ? window.crypto.randomUUID()
+        : `u${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+      div.dataset.turnId = `hub-utterance:${uuid}`;
+    }
     div.dataset.role = sender === 'Orion' ? 'assistant' : (sender === 'You' ? 'user' : 'system');
     const displayText = sender === 'Orion' ? hubCoalesceAssistantText(text, meta) : (text || '');
     const workflowOnlyTurn = Boolean(
@@ -5920,6 +5930,30 @@ loadDismissedIds();
     return { turns: out.reverse(), skippedWithoutId };
   }
 
+  function readBridgeMaxTurnsStored() {
+    const raw = localStorage.getItem(LS_MEMORY_GRAPH_BRIDGE_MAX_TURNS);
+    let n = raw ? parseInt(raw, 10) : MEMORY_GRAPH_BRIDGE_MAX_TURNS_DEFAULT;
+    if (!Number.isFinite(n)) n = MEMORY_GRAPH_BRIDGE_MAX_TURNS_DEFAULT;
+    return Math.min(MEMORY_GRAPH_BRIDGE_MAX_TURNS_CAP, Math.max(1, n));
+  }
+
+  function ensureMemoryGraphBridgeDraftViz() {
+    if (!window.OrionMemoryGraphDraftUI) return null;
+    if (memoryGraphBridgeDraftViz) return memoryGraphBridgeDraftViz;
+    const ta = document.getElementById('memoryGraphBridgeDraft');
+    const cy = document.getElementById('memoryGraphBridgeCyHost');
+    const det = document.getElementById('memoryGraphBridgeDetail');
+    const ban = document.getElementById('memoryGraphBridgeParseBanner');
+    if (!ta || !cy || !det) return null;
+    memoryGraphBridgeDraftViz = window.OrionMemoryGraphDraftUI.attach({
+      draftTextarea: ta,
+      cyHost: cy,
+      detailHost: det,
+      bannerEl: ban,
+    });
+    return memoryGraphBridgeDraftViz;
+  }
+
   function closeMemoryGraphBridgeModal() {
     if (!memoryGraphBridgeModal) return;
     memoryGraphBridgeModal.classList.add('hidden');
@@ -5938,7 +5972,12 @@ loadDismissedIds();
     const hintsEl = document.getElementById('memoryGraphBridgeChainHints');
     const closeForFocus = document.getElementById('memoryGraphBridgeModalClose');
     if (!memoryGraphBridgeModal || !list) return;
-    const { turns, skippedWithoutId } = collectConversationTurnsUpTo(anchorDiv, 40);
+    const maxTurnsInputEl = document.getElementById('memoryGraphBridgeMaxTurns');
+    if (maxTurnsInputEl) maxTurnsInputEl.value = String(readBridgeMaxTurnsStored());
+    let maxTurns = parseInt(maxTurnsInputEl && maxTurnsInputEl.value ? maxTurnsInputEl.value : '', 10);
+    if (!Number.isFinite(maxTurns)) maxTurns = readBridgeMaxTurnsStored();
+    maxTurns = Math.min(MEMORY_GRAPH_BRIDGE_MAX_TURNS_CAP, Math.max(1, maxTurns));
+    const { turns, skippedWithoutId } = collectConversationTurnsUpTo(anchorDiv, maxTurns);
     memoryGraphBridgeTurnsCache = turns;
     list.innerHTML = '';
     if (statusEl) statusEl.textContent = '';
@@ -5957,6 +5996,8 @@ loadDismissedIds();
       if (closeForFocus && typeof closeForFocus.focus === 'function') {
         closeForFocus.focus({ preventScroll: true });
       }
+      const viz0 = ensureMemoryGraphBridgeDraftViz();
+      if (viz0 && viz0.refresh) requestAnimationFrame(() => viz0.refresh());
       return;
     }
     const lastIdx = turns.length - 1;
@@ -6011,6 +6052,8 @@ loadDismissedIds();
     if (closeForFocus && typeof closeForFocus.focus === 'function') {
       closeForFocus.focus({ preventScroll: true });
     }
+    const viz = ensureMemoryGraphBridgeDraftViz();
+    if (viz && viz.refresh) requestAnimationFrame(() => viz.refresh());
   }
 
   function setupMemoryGraphBridgeModal() {
@@ -6021,6 +6064,35 @@ loadDismissedIds();
     const statusEl = document.getElementById('memoryGraphBridgeStatus');
     const list = document.getElementById('memoryGraphBridgeTurnList');
     if (!memoryGraphBridgeModal || !closeBtn) return;
+    const maxTurnsInput = document.getElementById('memoryGraphBridgeMaxTurns');
+    if (maxTurnsInput) {
+      maxTurnsInput.value = String(readBridgeMaxTurnsStored());
+      maxTurnsInput.addEventListener('change', () => {
+        let v = parseInt(maxTurnsInput.value, 10);
+        if (!Number.isFinite(v)) v = MEMORY_GRAPH_BRIDGE_MAX_TURNS_DEFAULT;
+        v = Math.min(MEMORY_GRAPH_BRIDGE_MAX_TURNS_CAP, Math.max(1, v));
+        maxTurnsInput.value = String(v);
+        localStorage.setItem(LS_MEMORY_GRAPH_BRIDGE_MAX_TURNS, String(v));
+      });
+    }
+    const selKBtn = document.getElementById('memoryGraphBridgeSelectLastKBtn');
+    const selKIn = document.getElementById('memoryGraphBridgeSelectLastKInput');
+    if (selKBtn && selKIn) {
+      selKBtn.addEventListener('click', () => {
+        const turnList = document.getElementById('memoryGraphBridgeTurnList');
+        if (!turnList) return;
+        let k = parseInt(selKIn.value, 10);
+        const boxes = turnList.querySelectorAll('input[type="checkbox"][data-turn-index]');
+        const n = boxes.length;
+        if (!n) return;
+        if (!Number.isFinite(k) || k < 1) k = n;
+        k = Math.min(k, n);
+        boxes.forEach((cb, i) => {
+          cb.checked = i >= n - k;
+        });
+      });
+    }
+    ensureMemoryGraphBridgeDraftViz();
     function close() {
       closeMemoryGraphBridgeModal();
     }
@@ -6037,11 +6109,12 @@ loadDismissedIds();
         boxes.forEach((cb) => {
           if (cb.checked) {
             const idx = Number(cb.dataset.turnIndex);
-            if (memoryGraphBridgeTurnsCache[idx]) selected.push(memoryGraphBridgeTurnsCache[idx]);
+            const row = memoryGraphBridgeTurnsCache[idx];
+            if (row && row.turnId && String(row.turnId).trim()) selected.push(row);
           }
         });
         if (!selected.length) {
-          if (statusEl) statusEl.textContent = 'Select at least one turn.';
+          if (statusEl) statusEl.textContent = 'Select at least one turn with a stable id.';
           return;
         }
         const prevLabel = suggestBtn.textContent;
@@ -6087,6 +6160,8 @@ loadDismissedIds();
             return;
           }
           draftTa.value = typeof t === 'string' ? t : JSON.stringify(t, null, 2);
+          const vDraft = ensureMemoryGraphBridgeDraftViz();
+          if (vDraft && vDraft.refresh) vDraft.refresh();
           if (statusEl) {
             statusEl.textContent = out
               ? 'Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate.'

--- a/services/orion-hub/static/js/memory-graph-draft-ui.js
+++ b/services/orion-hub/static/js/memory-graph-draft-ui.js
@@ -1,0 +1,432 @@
+/* Orion Hub — shared Memory graph SuggestDraftV1 draft preview (parse + Cytoscape + detail panel). */
+(function () {
+  function debounce(fn, ms) {
+    let t = null;
+    return function debounced() {
+      const args = arguments;
+      const self = this;
+      clearTimeout(t);
+      t = setTimeout(() => fn.apply(self, args), ms);
+    };
+  }
+
+  /**
+   * One successfully parsed JSON object; salvage modes show explicit warning (no silent graph).
+   */
+  function parseMemoryGraphDraftJson(text) {
+    const trimmed = String(text || "").trim();
+    if (!trimmed) {
+      return { ok: false, object: null, mode: null, warning: "Empty draft." };
+    }
+    try {
+      const o = JSON.parse(trimmed);
+      if (o !== null && typeof o === "object" && !Array.isArray(o)) {
+        return { ok: true, object: o, mode: "strict", warning: null };
+      }
+    } catch (_) {
+      /* try salvage */
+    }
+    const fence = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+    if (fence) {
+      try {
+        const o = JSON.parse(fence[1].trim());
+        if (o !== null && typeof o === "object" && !Array.isArray(o)) {
+          return {
+            ok: true,
+            object: o,
+            mode: "fenced",
+            warning: "Parsed JSON from a fenced code block (textarea had extra wrapping).",
+          };
+        }
+      } catch (_) {
+        /* continue */
+      }
+    }
+    const start = trimmed.indexOf("{");
+    if (start >= 0) {
+      let depth = 0;
+      for (let i = start; i < trimmed.length; i += 1) {
+        const c = trimmed[i];
+        if (c === "{") depth += 1;
+        else if (c === "}") {
+          depth -= 1;
+          if (depth === 0) {
+            const slice = trimmed.slice(start, i + 1);
+            try {
+              const o = JSON.parse(slice);
+              if (o !== null && typeof o === "object" && !Array.isArray(o)) {
+                return {
+                  ok: true,
+                  object: o,
+                  mode: "salvage",
+                  warning: "Parsed the first top-level { … } object; leading/trailing text was ignored.",
+                };
+              }
+            } catch (_) {
+              /* fall through */
+            }
+            break;
+          }
+        }
+      }
+    }
+    return { ok: false, object: null, mode: null, warning: "Could not parse a single JSON object." };
+  }
+
+  function draftToCyElements(obj) {
+    const nodes = [];
+    const edges = [];
+    const seen = new Set();
+    function addNode(id, label, kind) {
+      const sid = String(id);
+      if (seen.has(sid)) return;
+      seen.add(sid);
+      nodes.push({ data: { id: sid, label: String(label || sid), kind } });
+    }
+
+    const ents = Array.isArray(obj.entities) ? obj.entities : [];
+    ents.forEach((e) => {
+      if (e && e.id) addNode(e.id, e.label || e.id, "entity");
+    });
+    const sits = Array.isArray(obj.situations) ? obj.situations : [];
+    sits.forEach((s) => {
+      if (s && s.id) addNode(s.id, s.label || s.id, "situation");
+    });
+    const disps = Array.isArray(obj.dispositions) ? obj.dispositions : [];
+    disps.forEach((d) => {
+      if (d && d.id) addNode(d.id, (d.description && String(d.description).slice(0, 40)) || String(d.id), "disposition");
+    });
+
+    const edgs = Array.isArray(obj.edges) ? obj.edges : [];
+    edgs.forEach((e, i) => {
+      if (!e || e.s == null || e.o == null) return;
+      const sid = String(e.s);
+      const oid = String(e.o);
+      if (!seen.has(sid)) addNode(sid, sid, "ref");
+      if (!seen.has(oid)) addNode(oid, oid, "ref");
+      edges.push({
+        data: {
+          id: `draft-edge-${i}`,
+          source: sid,
+          target: oid,
+          label: String(e.p || ""),
+          edgeIndex: i,
+        },
+      });
+    });
+
+    return { nodes, edges };
+  }
+
+  function draftToCyElements(obj) {
+    const wrap = document.createElement("div");
+    wrap.className = "space-y-2 text-[11px]";
+
+    if (!selection) {
+      wrap.innerHTML = '<p class="text-gray-500">Select a node or edge in the graph.</p>';
+      return wrap;
+    }
+
+    if (selection.type === "edge") {
+      const e = selection.edge;
+      const idx = selection.index;
+      const head = document.createElement("div");
+      head.className = "text-gray-400 font-mono text-[10px] break-all";
+      head.textContent = `edge[${idx}] ${e.s} —${e.p}→ ${e.o}`;
+      wrap.appendChild(head);
+      ["s", "p", "o"].forEach((field) => {
+        const lab = document.createElement("label");
+        lab.className = "block text-gray-500";
+        lab.textContent = field;
+        const inp = document.createElement("input");
+        inp.type = "text";
+        inp.className = "w-full bg-gray-950 border border-gray-700 rounded px-2 py-1 text-gray-100";
+        inp.value = e[field] != null ? String(e[field]) : "";
+        inp.dataset.field = field;
+        lab.appendChild(inp);
+        wrap.appendChild(lab);
+      });
+      if (idx >= 0 && Array.isArray(obj.edges) && obj.edges[idx]) {
+        const applyBtn = document.createElement("button");
+        applyBtn.type = "button";
+        applyBtn.className = "mt-2 px-2 py-1 rounded border border-violet-600 bg-violet-900/30 text-violet-100";
+        applyBtn.textContent = "Apply to draft JSON";
+        applyBtn.addEventListener("click", () => {
+          const edges = [...obj.edges];
+          const cur = { ...(edges[idx] || {}) };
+          wrap.querySelectorAll("input[data-field]").forEach((inp) => {
+            const f = inp.dataset.field;
+            if (f) cur[f] = inp.value;
+          });
+          edges[idx] = cur;
+          onApply({ ...obj, edges });
+        });
+        wrap.appendChild(applyBtn);
+      } else {
+        const note = document.createElement("p");
+        note.className = "text-amber-200/90 text-[10px]";
+        note.textContent = "This edge is not indexed in draft.edges — edit JSON or fix the draft.";
+        wrap.appendChild(note);
+      }
+      return wrap;
+    }
+
+    const arrName = selection.arrayName;
+    const idx = selection.index;
+    const arr = Array.isArray(obj[arrName]) ? obj[arrName] : [];
+    const row = arr[idx];
+    if (!row || typeof row !== "object") {
+      wrap.innerHTML = '<p class="text-gray-500">Missing row in draft.</p>';
+      return wrap;
+    }
+
+    const title = document.createElement("div");
+    title.className = "text-gray-300 font-semibold capitalize";
+    title.textContent = `${arrName.slice(0, -1)} ${row.id != null ? String(row.id) : `#${idx}`}`;
+    wrap.appendChild(title);
+
+    const keys = Object.keys(row);
+    keys.forEach((k) => {
+      const val = row[k];
+      if (val != null && typeof val === "object") return;
+      const lab = document.createElement("label");
+      lab.className = "block text-gray-500";
+      lab.textContent = k;
+      const inp = document.createElement("input");
+      inp.type = "text";
+      inp.className = "w-full bg-gray-950 border border-gray-700 rounded px-2 py-1 text-gray-100";
+      inp.value = val != null ? String(val) : "";
+      inp.dataset.key = k;
+      lab.appendChild(inp);
+      wrap.appendChild(lab);
+    });
+
+    const applyBtn = document.createElement("button");
+    applyBtn.type = "button";
+    applyBtn.className = "mt-2 px-2 py-1 rounded border border-violet-600 bg-violet-900/30 text-violet-100";
+    applyBtn.textContent = "Apply to draft JSON";
+    applyBtn.addEventListener("click", () => {
+      const copy = { ...row };
+      wrap.querySelectorAll("input[data-key]").forEach((inp) => {
+        const k = inp.dataset.key;
+        if (k) copy[k] = inp.value;
+      });
+      const narr = [...arr];
+      narr[idx] = copy;
+      const next = { ...obj, [arrName]: narr };
+      onApply(next);
+    });
+    wrap.appendChild(applyBtn);
+    return wrap;
+  }
+
+  function findNodeSelection(obj, targetId) {
+    const id = String(targetId);
+    const ents = Array.isArray(obj.entities) ? obj.entities : [];
+    for (let i = 0; i < ents.length; i += 1) {
+      if (ents[i] && String(ents[i].id) === id) return { type: "node", arrayName: "entities", index: i };
+    }
+    const sits = Array.isArray(obj.situations) ? obj.situations : [];
+    for (let i = 0; i < sits.length; i += 1) {
+      if (sits[i] && String(sits[i].id) === id) return { type: "node", arrayName: "situations", index: i };
+    }
+    const disps = Array.isArray(obj.dispositions) ? obj.dispositions : [];
+    for (let i = 0; i < disps.length; i += 1) {
+      if (disps[i] && String(disps[i].id) === id) return { type: "node", arrayName: "dispositions", index: i };
+    }
+    return null;
+  }
+
+  /**
+   * @param {object} options
+   * @param {HTMLTextAreaElement|null} options.draftTextarea
+   * @param {HTMLElement|null} options.cyHost
+   * @param {HTMLElement|null} options.detailHost
+   * @param {HTMLElement|null} [options.bannerEl]
+   * @param {() => void} [options.onDraftJsonChange]
+   */
+  function attach(options) {
+    const draftTextarea = options.draftTextarea;
+    const cyHost = options.cyHost;
+    const detailHost = options.detailHost;
+    const bannerEl = options.bannerEl || null;
+    const onDraftJsonChange = options.onDraftJsonChange || function () {};
+
+    if (!window.cytoscape || !cyHost) {
+      return { refresh: function () {}, destroy: function () {}, getParsed: function () { return null; } };
+    }
+
+    let cy = null;
+    let lastParsed = null;
+    let lastObj = null;
+
+    function destroyCy() {
+      if (cy) {
+        try {
+          cy.destroy();
+        } catch (_) {
+          /* ignore */
+        }
+        cy = null;
+      }
+    }
+
+    function renderDetailFor(evt) {
+      if (!detailHost || !lastObj) return;
+      detailHost.innerHTML = "";
+      const t = evt && evt.target;
+      if (!t || typeof t !== "object") return;
+      if (t.isEdge && t.isEdge()) {
+        const ed = t.data();
+        const edges = Array.isArray(lastObj.edges) ? lastObj.edges : [];
+        const idx = typeof ed.edgeIndex === "number" ? ed.edgeIndex : -1;
+        const edge = idx >= 0 && edges[idx] ? edges[idx] : { s: ed.source, p: ed.label, o: ed.target };
+        const panel = renderDetail(
+          { type: "edge", edge, index: idx >= 0 ? idx : 0 },
+          lastObj,
+          applyObj,
+        );
+        detailHost.appendChild(panel);
+        return;
+      }
+      if (t.isNode && t.isNode()) {
+        const nid = t.id();
+        const sel = findNodeSelection(lastObj, nid);
+        if (sel && sel.type === "node") {
+          detailHost.appendChild(renderDetail(sel, lastObj, applyObj));
+        } else {
+          const el = document.createElement("div");
+          el.className = "text-gray-500 text-[11px]";
+          el.textContent = `Node "${nid}" is not listed under entities / situations / dispositions (edge endpoint or ref).`;
+          detailHost.appendChild(el);
+        }
+      }
+    }
+
+    function applyObj(nextObj) {
+      lastObj = nextObj;
+      const json = JSON.stringify(nextObj, null, 2);
+      if (draftTextarea) draftTextarea.value = json;
+      onDraftJsonChange();
+      refresh();
+    }
+
+    function refresh() {
+      if (!draftTextarea) return;
+      const raw = draftTextarea.value;
+      const parsed = parseMemoryGraphDraftJson(raw);
+      lastParsed = parsed;
+
+      if (bannerEl) {
+        bannerEl.textContent = "";
+        bannerEl.className =
+          "text-[11px] rounded border px-2 py-1 whitespace-pre-wrap hidden border-gray-700 text-gray-400 bg-gray-950/60";
+        if (!parsed.ok) {
+          bannerEl.classList.remove("hidden");
+          bannerEl.classList.add("border-amber-700", "text-amber-100", "bg-amber-950/50");
+          bannerEl.textContent = parsed.warning || "Invalid JSON.";
+        } else if (parsed.warning) {
+          bannerEl.classList.remove("hidden");
+          bannerEl.classList.add("border-amber-700", "text-amber-100", "bg-amber-950/50");
+          bannerEl.textContent = parsed.warning;
+        }
+      }
+
+      destroyCy();
+      cyHost.innerHTML = "";
+      detailHost.innerHTML = "";
+
+      if (!parsed.ok || !parsed.object) {
+        lastObj = null;
+        if (detailHost) {
+          const p = document.createElement("p");
+          p.className = "text-gray-500 text-[11px]";
+          p.textContent = "No graph preview until JSON parses.";
+          detailHost.appendChild(p);
+        }
+        return;
+      }
+
+      lastObj = parsed.object;
+      const { nodes, edges } = draftToCyElements(parsed.object);
+      if (!nodes.length && !edges.length) {
+        const p = document.createElement("p");
+        p.className = "text-gray-500 text-[11px]";
+        p.textContent = "Parsed JSON has no entities, situations, edges, or dispositions to show.";
+        cyHost.appendChild(p);
+        return;
+      }
+
+      cy = window.cytoscape({
+        container: cyHost,
+        elements: [...nodes, ...edges],
+        style: [
+          {
+            selector: "node",
+            style: {
+              label: "data(label)",
+              "font-size": 10,
+              color: "#e2e8f0",
+              "background-color": "#475569",
+              width: 28,
+              height: 28,
+            },
+          },
+          { selector: 'node[kind = "entity"]', style: { "background-color": "#4f46e5" } },
+          { selector: 'node[kind = "situation"]', style: { "background-color": "#059669" } },
+          { selector: 'node[kind = "disposition"]', style: { "background-color": "#c026d3" } },
+          { selector: 'node[kind = "ref"]', style: { "background-color": "#64748b" } },
+          {
+            selector: "edge",
+            style: {
+              width: 2,
+              "line-color": "#64748b",
+              "target-arrow-color": "#64748b",
+              "target-arrow-shape": "triangle",
+              "curve-style": "bezier",
+              label: "data(label)",
+              "font-size": 8,
+              color: "#94a3b8",
+            },
+          },
+        ],
+        layout: { name: "cose", animate: false },
+        wheelSensitivity: 0.35,
+      });
+      cy.on("tap", "node", renderDetailFor);
+      cy.on("tap", "edge", renderDetailFor);
+      cy.userPanningEnabled(true);
+      cy.boxSelectionEnabled(false);
+      requestAnimationFrame(() => {
+        try {
+          cy.resize();
+          cy.fit(undefined, 24);
+        } catch (_) {
+          /* ignore */
+        }
+      });
+    }
+
+    const debounced = debounce(refresh, 120);
+    if (draftTextarea) {
+      draftTextarea.addEventListener("input", debounced);
+    }
+
+    return {
+      refresh,
+      destroy: function () {
+        if (draftTextarea) draftTextarea.removeEventListener("input", debounced);
+        destroyCy();
+      },
+      getParsed: function () {
+        return lastParsed;
+      },
+    };
+  }
+
+  window.OrionMemoryGraphDraftUI = {
+    parseMemoryGraphDraftJson,
+    draftToCyElements,
+    attach,
+  };
+})();

--- a/services/orion-hub/static/js/memory.js
+++ b/services/orion-hub/static/js/memory.js
@@ -282,6 +282,20 @@
     const vBtn = document.getElementById("memoryGraphValidateBtn");
     const aBtn = document.getElementById("memoryGraphApproveBtn");
     const sBtn = document.getElementById("memoryGraphSuggestBtn");
+    let memoryDraftViz = null;
+    if (window.OrionMemoryGraphDraftUI && draftTa) {
+      const cyH = document.getElementById("memoryGraphDraftCyHost");
+      const det = document.getElementById("memoryGraphDraftDetail");
+      const ban = document.getElementById("memoryGraphDraftParseBanner");
+      if (cyH && det) {
+        memoryDraftViz = window.OrionMemoryGraphDraftUI.attach({
+          draftTextarea: draftTa,
+          cyHost: cyH,
+          detailHost: det,
+          bannerEl: ban,
+        });
+      }
+    }
     function graphSetOut(obj, isErr) {
       if (!graphOut) return;
       graphOut.textContent = typeof obj === "string" ? obj : JSON.stringify(obj, null, 2);
@@ -343,6 +357,7 @@
           }
           const t = (data && (data.text || (data.raw && data.raw.final_text))) || text;
           draftTa.value = typeof t === "string" ? t : JSON.stringify(t, null, 2);
+          if (memoryDraftViz && memoryDraftViz.refresh) memoryDraftViz.refresh();
           graphSetOut(
             { ok: true, note: "Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate." },
             false
@@ -367,6 +382,7 @@
       const v = sessionStorage.getItem("orion_memory_graph_draft_import");
       if (v && draftTa) draftTa.value = v;
       sessionStorage.removeItem("orion_memory_graph_draft_import");
+      if (memoryDraftViz && memoryDraftViz.refresh) memoryDraftViz.refresh();
       graphSetOut(
         { ok: true, note: "Draft loaded from chat bridge. Review JSON then Validate." },
         false

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -897,17 +897,28 @@
           <button type="button" id="memorySubviewAll" class="px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200">All Cards</button>
           <button type="button" id="memorySubviewLog" class="px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200">Activity Log</button>
         </div>
-        <div id="memoryGraphAnnotator" class="border border-gray-700 rounded-lg p-3 space-y-2 text-xs">
+        <div id="memoryGraphAnnotator" class="border border-gray-700 rounded-lg p-3 space-y-3 text-xs">
           <div class="font-semibold text-gray-200">Memory graph (optional)</div>
           <p class="text-[10px] text-gray-500"><span class="text-gray-400">Suggest</span> — type plain language or paste a chat snippet (or leave empty). The model drafts JSON here; trim any prose around it, then Validate.</p>
           <p class="text-[10px] text-gray-500"><span class="text-gray-400">Validate / Approve</span> — need structured JSON the API accepts. Approve needs GraphDB on this Hub.</p>
-          <textarea id="memoryGraphDraftJson" class="w-full h-40 bg-gray-950 border border-gray-700 rounded p-2 font-mono text-[10px]" placeholder="Plain text for Suggest, or JSON for Validate / Approve…"></textarea>
-          <div class="flex flex-wrap gap-2">
-            <button type="button" id="memoryGraphValidateBtn" class="px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200">Validate</button>
-            <button type="button" id="memoryGraphApproveBtn" class="px-2 py-1 rounded border border-emerald-800 bg-emerald-900/40 text-emerald-100">Approve</button>
-            <button type="button" id="memoryGraphSuggestBtn" class="px-2 py-1 rounded border border-indigo-700 bg-indigo-900/30 text-indigo-100">Suggest</button>
+          <div id="memoryGraphDraftParseBanner" class="hidden text-[11px] rounded border px-2 py-1 whitespace-pre-wrap border-gray-700 text-gray-400 bg-gray-950/60" role="status"></div>
+          <div class="grid grid-cols-1 xl:grid-cols-2 gap-3 items-start">
+            <div class="space-y-2 min-w-0">
+              <div class="text-[10px] uppercase tracking-wide text-gray-500">Draft</div>
+              <textarea id="memoryGraphDraftJson" class="w-full min-h-[11rem] bg-gray-950 border border-gray-700 rounded p-2 font-mono text-xs leading-relaxed" placeholder="Plain text for Suggest, or JSON for Validate / Approve…"></textarea>
+              <div class="flex flex-wrap gap-2">
+                <button type="button" id="memoryGraphValidateBtn" class="px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200">Validate</button>
+                <button type="button" id="memoryGraphApproveBtn" class="px-2 py-1 rounded border border-emerald-800 bg-emerald-900/40 text-emerald-100">Approve</button>
+                <button type="button" id="memoryGraphSuggestBtn" class="px-2 py-1 rounded border border-indigo-700 bg-indigo-900/30 text-indigo-100">Suggest</button>
+              </div>
+              <pre id="memoryGraphAnnotatorOut" class="text-xs text-gray-400 whitespace-pre-wrap max-h-48 overflow-auto border border-gray-800 rounded p-2 bg-gray-950/30"></pre>
+            </div>
+            <div class="space-y-2 min-w-0">
+              <div class="text-[10px] uppercase tracking-wide text-gray-500">Graph preview</div>
+              <div id="memoryGraphDraftCyHost" class="h-56 w-full border border-gray-800 rounded-lg bg-black/40"></div>
+              <div id="memoryGraphDraftDetail" class="min-h-[7rem] border border-gray-800 rounded-lg p-2 bg-gray-950/50 text-gray-200"></div>
+            </div>
           </div>
-          <pre id="memoryGraphAnnotatorOut" class="text-[10px] text-gray-400 whitespace-pre-wrap max-h-48 overflow-auto"></pre>
         </div>
         <div id="memoryStatus" class="text-xs text-gray-400 min-h-[1.25rem]"></div>
         <div id="memoryReviewPanel" class="memory-subview flex flex-col gap-2 text-sm"></div>
@@ -2865,7 +2876,7 @@
 
   <div id="memoryGraphBridgeModal" class="hidden fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-4" aria-hidden="true">
     <div
-      class="bg-gray-900 border border-gray-700 rounded-xl max-w-lg w-full max-h-[90vh] overflow-hidden flex flex-col shadow-xl"
+      class="bg-gray-900 border border-gray-700 rounded-xl max-w-5xl w-full max-h-[92vh] overflow-hidden flex flex-col shadow-xl"
       role="dialog"
       aria-modal="true"
       aria-labelledby="memoryGraphBridgeModalTitle"
@@ -2875,10 +2886,35 @@
         <button type="button" id="memoryGraphBridgeModalClose" class="text-gray-400 hover:text-white text-lg leading-none" aria-label="Close">&times;</button>
       </div>
       <div class="p-4 overflow-y-auto flex-1 space-y-3 text-xs text-gray-300">
+        <div class="flex flex-wrap items-end gap-3 text-[11px]">
+          <label class="flex flex-col gap-1 text-gray-400">
+            Max turns in chain (≤80)
+            <input id="memoryGraphBridgeMaxTurns" type="number" min="1" max="80" step="1"
+              class="w-24 bg-gray-950 border border-gray-700 rounded px-2 py-1 text-gray-100 font-mono" />
+          </label>
+          <label class="flex flex-col gap-1 text-gray-400">
+            Select last K turns
+            <input id="memoryGraphBridgeSelectLastKInput" type="number" min="1" step="1"
+              class="w-24 bg-gray-950 border border-gray-700 rounded px-2 py-1 text-gray-100 font-mono" placeholder="K" />
+          </label>
+          <button type="button" id="memoryGraphBridgeSelectLastKBtn"
+            class="px-3 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200">Apply K</button>
+        </div>
         <p id="memoryGraphBridgeChainHints" class="hidden text-[10px] text-amber-200/90 whitespace-pre-wrap" role="status"></p>
-        <div id="memoryGraphBridgeTurnList" class="space-y-2"></div>
-        <textarea id="memoryGraphBridgeDraft" class="w-full h-36 bg-gray-950 border border-gray-700 rounded p-2 font-mono text-[10px]" placeholder="Draft JSON appears here after Suggest…"></textarea>
-        <pre id="memoryGraphBridgeStatus" class="text-[10px] text-gray-500 whitespace-pre-wrap"></pre>
+        <div id="memoryGraphBridgeTurnList" class="space-y-2 max-h-48 overflow-y-auto border border-gray-800 rounded-lg p-2"></div>
+        <div id="memoryGraphBridgeParseBanner" class="hidden text-[11px] rounded border px-2 py-1 whitespace-pre-wrap border-gray-700 text-gray-400 bg-gray-950/60" role="status"></div>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3 items-start">
+          <div class="space-y-2 min-w-0">
+            <div class="text-[10px] uppercase tracking-wide text-gray-500">Draft JSON</div>
+            <textarea id="memoryGraphBridgeDraft" class="w-full min-h-[11rem] bg-gray-950 border border-gray-700 rounded p-2 font-mono text-xs leading-relaxed" placeholder="Draft JSON appears here after Suggest…"></textarea>
+          </div>
+          <div class="space-y-2 min-w-0">
+            <div class="text-[10px] uppercase tracking-wide text-gray-500">Preview graph &amp; selection</div>
+            <div id="memoryGraphBridgeCyHost" class="h-52 w-full border border-gray-800 rounded-lg bg-black/40"></div>
+            <div id="memoryGraphBridgeDetail" class="min-h-[7rem] border border-gray-800 rounded-lg p-2 bg-gray-950/50 text-gray-200"></div>
+          </div>
+        </div>
+        <pre id="memoryGraphBridgeStatus" class="text-xs text-gray-500 whitespace-pre-wrap"></pre>
       </div>
       <div class="flex flex-wrap gap-2 px-4 py-3 border-t border-gray-800">
         <button type="button" id="memoryGraphBridgeSuggest" class="px-3 py-1 rounded border border-indigo-700 bg-indigo-900/40 text-indigo-100 text-xs">Suggest draft</button>
@@ -2898,6 +2934,7 @@
   <script src="/static/js/service-logs-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/thought-process.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="/static/js/memory-graph-draft-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/memory.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/app.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
 </body>

--- a/services/orion-hub/tests/test_memory_graph_bridge_ui.py
+++ b/services/orion-hub/tests/test_memory_graph_bridge_ui.py
@@ -16,6 +16,11 @@ def test_template_includes_memory_graph_bridge_modal_and_a11y() -> None:
     assert 'id="memoryGraphBridgeToMemory"' in html
     assert 'id="memoryGraphBridgeChainHints"' in html
     assert 'id="memoryGraphBridgeModalTitle"' in html
+    assert 'id="memoryGraphBridgeMaxTurns"' in html
+    assert 'id="memoryGraphBridgeSelectLastKBtn"' in html
+    assert 'id="memoryGraphBridgeCyHost"' in html
+    assert 'id="memoryGraphDraftCyHost"' in html
+    assert "/static/js/memory-graph-draft-ui.js" in html
     assert 'role="dialog"' in html
     assert "aria-modal=\"true\"" in html
     assert "aria-labelledby=\"memoryGraphBridgeModalTitle\"" in html
@@ -32,9 +37,13 @@ def test_app_js_wires_memory_graph_bridge_handlers() -> None:
     assert "CustomEvent('orion-hub-memory-graph-draft-import'" in app_js
     assert "backfillLatestUserTurnIdForGraph" in app_js
     assert "extractCortexStepErrorHint" in app_js
+    assert "ensureMemoryGraphBridgeDraftViz" in app_js
+    assert "hub-utterance:" in app_js
+    assert "readBridgeMaxTurnsStored" in app_js
 
 
 def test_memory_js_listens_for_bridge_import_event() -> None:
     memory_js = MEMORY_JS_PATH.read_text(encoding="utf-8")
     assert 'orion-hub-memory-graph-draft-import' in memory_js
     assert "orion_memory_graph_draft_import" in memory_js
+    assert "OrionMemoryGraphDraftUI" in memory_js


### PR DESCRIPTION
## Summary

Delivers the Hub-side memory graph draft UX from the 2026-05-03 spec: Cytoscape preview of parsed `SuggestDraftV1`-shaped JSON (with explicit banners when salvage parsing is used), a detail panel with minimal Apply-back-to-draft, stable `hub-utterance:<uuid>` ids on user bubbles when server meta is absent, and a configurable bridge turn chain (max 1–80, persisted) plus **Select last K**. The Memory tab reuses the same shared script and a two-column draft / preview layout.

## Changes

- **`services/orion-hub/static/js/memory-graph-draft-ui.js`** (new): parse + salvage semantics + graph elements + Cytoscape + detail/apply.
- **`services/orion-hub/static/js/app.js`**: `hub-utterance:*` assignment; bridge depth/K controls; draft viz wiring; suggest payload uses turns with non-empty ids only.
- **`services/orion-hub/static/js/memory.js`** + **`services/orion-hub/templates/index.html`**: Memory annotator layout, preview hosts, script include order.
- **`services/orion-hub/tests/test_memory_graph_bridge_ui.py`**: IDs and wiring assertions.
- **`docs/superpowers/specs/2026-05-02-memory-graph-chat-entry-bridge-design.md`**: cross-links and alignment notes vs the 2026-05-03 spec.

## Verification

```bash
./scripts/test_service.sh orion-hub services/orion-hub/tests/test_memory_graph_bridge_ui.py -q --tb=short
node --check services/orion-hub/static/js/memory-graph-draft-ui.js