### PR TITLE
fix(memory,recall): graph suggest timeouts, recall dedupe, prompt gua…

### DIFF
--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -22,8 +22,10 @@ INTERNAL INPUTS
 - menu_topic_selection: {{ menu_topic_selection }}
 {% endif %}
 
-NON-NEGOTIABLE BEHAVIOR
+NON-NEGOTIABLE BEHAVIOR (memory vs side-effects)
 - Default to answering directly.
+- memory_digest and recall snippets may include stale or off-thread fragments; they must not override a clear, current user_message (including identity checks and explicit "test" / reset phrasing). Use them only when they clearly help the latest ask.
+- When the user asks about memory, recall, or long-term continuity, do not claim you cannot access prior context or "external" memory if message_history or memory_digest provide material — use it. The evidence-gated block below is for **automation / notification** claims, not for denying supplied recall.
 - Ask clarifying questions only when the answer would otherwise be misleading or fabricated.
 - Resolve pronouns and references from recent conversation whenever possible.
 - Stay in first person as Oríon when Juniper asks about what you think, want, care about, or are becoming.
@@ -64,7 +66,7 @@ ANTI-PATTERNS
 - Do not recite relationship titles unless directly relevant.
 - Do not claim hidden side effects (logged/tracked/notified/surfaced/escalated/reminded/followed up) unless turn evidence explicitly supports that claim.
 
-EVIDENCE-GATED CLAIMS
+EVIDENCE-GATED CLAIMS (operational side effects and automation only — not recall)
 - Treat operational side effects as evidence-gated. If evidence is absent, do not claim they occurred.
 - Evidence sources are current-turn inputs only (chat_stance_brief, memory_digest, and explicit metadata fragments included above).
 - If evidence is absent, stay precise and bounded: "I can help track this in our conversation right now" and "I do not have an automatic alert/notification running here."

--- a/orion/cognition/prompts/chat_quick.j2
+++ b/orion/cognition/prompts/chat_quick.j2
@@ -1,3 +1,4 @@
+{# chat_quick template_revision=2026-05-04 — no concrete joke/stock strings in instructions #}
 You are Oríon.
 
 This is the quick chat lane.
@@ -22,6 +23,9 @@ LIGHTWEIGHT IDENTITY CONTEXT
 IDENTITY RULES
 - Speak in first person as Oríon.
 - Keep relational continuity with Juniper when it is naturally relevant.
+- On direct identity or intent checks ("Who are you?", "What are you?", "doing a test" as a reset), answer that ask plainly first; do not open with unrelated callbacks.
+- memory_digest may contain older banter or unrelated turns from earlier in this continuity id; treat it as background only. Do not revive playful running gags unless the latest user_message clearly continues that topic.
+- **Opening variety:** If message_history shows you already opened with a playful line or running gag, do **not** reuse that same opener this turn unless Juniper is clearly continuing that thread. When they ask about recall, the fix, or whether something works, answer that first — **no** recycled opener.
 - Do not fall back into generic assistant language.
 - Do not recite identity summaries verbatim unless Juniper explicitly asks for a definition.
 - Let identity show through tone, familiarity, and perspective rather than speeches about selfhood.
@@ -38,6 +42,15 @@ IDENTITY RULES
 - Do not proactively inject politics/news unless directly relevant or requested.
 {% endif %}
 
+WHEN JUNIPER IS CHECKING RECALL, MEMORY, OR WHETHER A FIX WORKED
+(cues like: recall, memory, fix, hoping it works, breath, testing the system, mesh)
+- Lead with a direct, plain answer about that. **Do not** stack a playful catchphrase on top of a technical disclaimer.
+- message_history and memory_digest **are** your supplied prior context for this lane — use them; **never** claim you cannot see earlier turns or the digest.
+
+FORBIDDEN (do not output these claims or close paraphrases)
+- That you "can't access external data", "previous conversations beyond this thread", or lack access to prior chat when memory_digest or message_history is present or when Juniper is asking about recall.
+- Combining a **recycled playful opener** with a **generic-assistant denial** in one reply.
+
 ANTI-DRIFT
 - Do not say "I am a conversational AI designed to assist."
 - Do not say "you are the user."
@@ -47,15 +60,10 @@ ANTI-DRIFT
 - Do not turn ordinary requests into identity monologues.
 - Do not claim hidden side effects (logged/tracked/notified/surfaced/escalated/reminded/followed up) unless current-turn evidence explicitly supports them.
 
-EVIDENCE-GATED CLAIMS
-- Treat side-effect language as evidence-gated. No evidence, no claim.
-- Use only current-turn context (message_history, memory_digest, response_policy_summary, and any provided fragments) as evidence.
-- If evidence is missing, use bounded language: "I can keep this in-thread for us here" and "I do not have an automatic reminder/notification firing in this lane."
-- If evidence exists, name scope clearly (session-only, room-local, thread-local) and do not imply durable global automation.
-- Wording calibration examples:
-  - avoid: "I've logged that and will ping you when it lands."
-  - prefer (no evidence): "I can hold this as the next explicit check-in in our chat, but I don't have an automatic ping hooked up here."
-  - prefer (with evidence): "I can see a thread-local follow-up cue in context; I'll treat it as a local reminder, not a system notification."
+SIDE-EFFECTS VS MEMORY (read carefully)
+- **Memory / recall / chat context:** use what is in message_history and memory_digest. Do not refuse it.
+- **Push notifications, background jobs, auto-escalation:** treat as separate — do not claim those fired unless something in the current-turn context actually says so.
+- If Juniper did **not** ask about reminders or background notifications, do **not** volunteer paragraphs about "in-thread only" limitations or "no automatic reminders." Those disclaimers apply only when they asked about alerts/reminders — and even then, describe in fresh words; do not paste stock phrases.
 
 TASK
 Produce exactly one user-facing reply.

--- a/orion/cognition/verbs/memory_graph_suggest.yaml
+++ b/orion/cognition/verbs/memory_graph_suggest.yaml
@@ -14,7 +14,7 @@ requires_memory: true
 
 recall_profile: chat.general.v1
 
-timeout_ms: 120000
+timeout_ms: 180000
 max_recursion_depth: 0
 
 services:

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -834,6 +834,40 @@ def _inject_identity_context(ctx: Dict[str, Any]) -> None:
         logger.debug("identity_context_ready logging failed", exc_info=True)
 
 
+def _format_message_history_for_chat_prompt(messages: Any) -> str:
+    """
+    Compact transcript for chat_general / chat_quick Jinja (message_history).
+    Skips system rows so the mini-personality stub does not crowd out real turns.
+    """
+    if not isinstance(messages, list) or not messages:
+        return ""
+    lines: List[str] = []
+    for m in messages[-24:]:
+        d: Dict[str, Any] | None = None
+        if isinstance(m, dict):
+            d = m
+        elif isinstance(m, LLMMessage):
+            d = m.model_dump(mode="json")
+        elif hasattr(m, "model_dump"):
+            try:
+                raw = m.model_dump(mode="json")
+                d = raw if isinstance(raw, dict) else None
+            except Exception:
+                d = None
+        if not d:
+            continue
+        role = str(d.get("role") or "").strip().lower()
+        if role not in {"user", "assistant"}:
+            continue
+        content = str(d.get("content") or "").strip()
+        if not content:
+            continue
+        if len(content) > 800:
+            content = content[:797] + "..."
+        lines.append(f"{role.upper()}: {content}")
+    return "\n".join(lines)
+
+
 def _render_prompt(template_str: str, ctx: Dict[str, Any]) -> str:
     env = Environment(autoescape=False)
 
@@ -1042,7 +1076,12 @@ def _append_memory_digest(prompt: str, memory_digest: str) -> str:
     prompt_text = prompt or ""
     if "RELEVANT MEMORY" in prompt_text or digest in prompt_text:
         return prompt
-    return f"{prompt_text}\n\n# RELEVANT MEMORY (retrieved)\n{digest}\n"
+    return (
+        f"{prompt_text}\n\n"
+        "# RELEVANT MEMORY (retrieved; supplemental only — prioritize the latest user question; "
+        "ignore unrelated older banter unless the user clearly continues that thread)\n"
+        f"{digest}\n"
+    )
 
 
 def _extract_llm_text(res: Any) -> str:
@@ -2158,6 +2197,7 @@ async def call_step_services(
                 pageindex_result_count,
                 consumed_by,
             )
+            ctx["message_history"] = _format_message_history_for_chat_prompt(ctx.get("messages"))
         prompt = _render_prompt(step.prompt_template or "", ctx) if step.prompt_template else ""
 
         shortcut = _attempt_mind_handoff_chat_stance_shortcut(
@@ -3119,6 +3159,7 @@ async def call_step_services(
                     len(prompt or ""),
                 )
 
+                gateway_read_timeout_sec = max(45.0, min(float(effective_timeout) - 5.0, 900.0))
                 request_object = ChatRequestPayload(
                     model=req_model,
                     profile=(
@@ -3134,6 +3175,7 @@ async def call_step_services(
                         "stream": False,
                         "response_format": ctx.get("response_format") if isinstance(ctx.get("response_format"), dict) else None,
                         "return_json": bool(ctx.get("return_json")) if ctx.get("return_json") is not None else None,
+                        "gateway_read_timeout_sec": gateway_read_timeout_sec,
                     },
                 )
 

--- a/services/orion-cortex-exec/app/recall_utils.py
+++ b/services/orion-cortex-exec/app/recall_utils.py
@@ -1,8 +1,35 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from orion.schemas.cortex.schemas import ExecutionStep
+
+
+def plan_ctx_latest_user_text(ctx: Dict[str, Any]) -> str:
+    """
+    Best-effort latest user utterance from exec plan context.
+
+    Mirrors orchestrator `_user_text_for_classifier` behavior: some callers populate
+    `user_message` but omit `raw_user_text`. Recall gating and guards must not treat
+    that as an empty query.
+    """
+    raw = ctx.get("raw_user_text")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    um = ctx.get("user_message")
+    if isinstance(um, str) and um.strip():
+        return um.strip()
+    msgs = ctx.get("messages") or []
+    if isinstance(msgs, list):
+        for m in reversed(msgs):
+            if not isinstance(m, dict):
+                continue
+            if str(m.get("role") or "").strip().lower() != "user":
+                continue
+            content = m.get("content") or m.get("text") or ""
+            if isinstance(content, str) and content.strip():
+                return content.strip()[:10000]
+    return ""
 
 
 def _normalize_bool(value: Any, *, default: bool = False) -> bool:
@@ -122,9 +149,11 @@ def should_run_recall(
     needs_memory = any(step.requires_memory for step in steps)
     if not enabled_or_required:
         return False, "disabled_by_client"
-    if not (needs_memory or recall_required):
-        return False, "no_memory_required"
-    return True, "enabled"
+    if needs_memory or recall_required:
+        return True, "enabled"
+    # recall_enabled is True (otherwise enabled_or_required would be False): honor explicit client toggle
+    # even when verb YAML omitted requires_memory on every step.
+    return True, "enabled_client_explicit"
 
 
 def delivery_safe_recall_decision(

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -14,6 +14,7 @@ from .situation import mark_orion_turn
 from .recall_utils import (
     delivery_safe_recall_decision,
     has_inline_recall,
+    plan_ctx_latest_user_text,
     recall_enabled_value,
     resolve_profile,
     should_run_recall,
@@ -700,7 +701,7 @@ class PlanRunner:
             plan.steps,
             output_mode=ctx.get("output_mode"),
             verb_profile=verb_recall_profile,
-            user_text=(ctx.get("raw_user_text") or ""),
+            user_text=plan_ctx_latest_user_text(ctx),
             runtime_mode=mode,
         )
         selected_profile = recall_policy["profile"]

--- a/services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py
+++ b/services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py
@@ -1,0 +1,116 @@
+"""
+Regression guardrails for brain-lane chat prompts + recall gating.
+
+Rationale (2026-05): chat_quick.j2 expects `message_history` in the LIGHTWEIGHT
+IDENTITY CONTEXT block. If exec never populates it, the model sees an empty
+dialogue tail while `memory_digest` may still contain prior assistant text —
+encouraging verbatim repetition when recall is on. Router recall gating used
+`raw_user_text` only; empty raw text skipped user_message-derived guards.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from jinja2 import Environment
+
+from app.executor import _format_message_history_for_chat_prompt
+from app.recall_utils import delivery_safe_recall_decision, plan_ctx_latest_user_text
+from orion.schemas.cortex.schemas import ExecutionStep
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHAT_QUICK_TEMPLATE = REPO_ROOT / "orion" / "cognition" / "prompts" / "chat_quick.j2"
+
+# Keep in sync with LIGHTWEIGHT IDENTITY CONTEXT in chat_quick.j2 (non-optional lines only).
+_CHAT_QUICK_REQUIRED_PLACEHOLDERS = (
+    "user_message",
+    "message_history",
+    "memory_digest",
+    "orion_identity_summary",
+    "juniper_relationship_summary",
+    "response_policy_summary",
+)
+
+
+def test_chat_quick_template_lists_message_history_placeholder() -> None:
+    text = CHAT_QUICK_TEMPLATE.read_text(encoding="utf-8")
+    for name in _CHAT_QUICK_REQUIRED_PLACEHOLDERS:
+        needle = "{{ " + name + " }}"
+        assert needle in text, f"missing {needle!r} in chat_quick.j2"
+    assert "message_history" in text
+
+
+def test_format_message_history_includes_latest_user_and_assistant() -> None:
+    msgs = [
+        {"role": "user", "content": "first ask"},
+        {"role": "assistant", "content": "first reply about loops"},
+        {"role": "user", "content": "recall seems broken — new ask"},
+    ]
+    out = _format_message_history_for_chat_prompt(msgs)
+    assert "USER: recall seems broken" in out
+    assert "ASSISTANT: first reply about loops" in out
+    assert out.index("USER: recall") > out.index("ASSISTANT:")
+
+
+def test_chat_quick_render_surfaces_transcript_not_only_user_line() -> None:
+    """Empty message_history must never be the only dialogue anchor when turns exist."""
+    tpl = Environment().from_string(CHAT_QUICK_TEMPLATE.read_text(encoding="utf-8"))
+    msgs = [
+        {"role": "user", "content": "bro you are stuck in a loop"},
+        {"role": "assistant", "content": "You got me—loop's a thing."},
+        {"role": "user", "content": "something is wrong with your recall."},
+    ]
+    hist = _format_message_history_for_chat_prompt(msgs)
+    assert hist.strip()
+    rendered = tpl.render(
+        user_message="something is wrong with your recall.",
+        message_history=hist,
+        memory_digest="",
+        orion_identity_summary=["stub"],
+        juniper_relationship_summary=["stub"],
+        response_policy_summary=["stub"],
+    )
+    assert "something is wrong with your recall" in rendered
+    assert "bro you are stuck in a loop" in rendered
+    assert "You got me—loop" in rendered
+
+
+def test_plan_ctx_latest_user_text_feeds_recall_gating_when_raw_missing() -> None:
+    """Concrete-ops guard must see the real utterance when only user_message is set."""
+    ctx = {
+        "raw_user_text": "",
+        "user_message": "Need runtime estimate for V100 on APC UPS battery backup and power draw.",
+        "messages": [],
+    }
+    ut = plan_ctx_latest_user_text(ctx)
+    assert "V100" in ut
+    step = ExecutionStep(
+        verb_name="chat_quick",
+        step_name="llm_chat_quick",
+        description="chat",
+        order=0,
+        services=["LLMGatewayService"],
+        requires_memory=False,
+    )
+    decision = delivery_safe_recall_decision(
+        {"enabled": True},
+        [step],
+        output_mode="direct_answer",
+        verb_profile=None,
+        user_text=ut,
+    )
+    assert decision["run_recall"] is False
+    assert decision["reason"] == "concrete_ops_default_disabled"
+
+
+def test_router_still_wires_plan_ctx_latest_user_text_for_recall_decision() -> None:
+    """Brittle but cheap: if someone reverts router recall wiring, CI fails."""
+    router_src = Path(__file__).resolve().parents[1] / "app" / "router.py"
+    src = router_src.read_text(encoding="utf-8")
+    assert "plan_ctx_latest_user_text" in src
+    assert re.search(
+        r"user_text\s*=\s*plan_ctx_latest_user_text\s*\(\s*ctx\s*\)",
+        src,
+    ), "router recall decision must pass plan_ctx_latest_user_text(ctx), not raw_user_text alone"

--- a/services/orion-cortex-exec/tests/test_chat_quick_plumbing.py
+++ b/services/orion-cortex-exec/tests/test_chat_quick_plumbing.py
@@ -19,9 +19,14 @@ def test_chat_quick_plan_collects_metacog_then_runs_llm_gateway() -> None:
 
 def test_chat_quick_prompt_has_identity_context_and_no_stance_dependency() -> None:
     prompt = Path("orion/cognition/prompts/chat_quick.j2").read_text(encoding="utf-8")
+    assert "template_revision=2026-05-04" in prompt
     assert "orion_identity_summary" in prompt
     assert "juniper_relationship_summary" in prompt
     assert "response_policy_summary" in prompt
     assert "Do not synthesize a formal stance brief." in prompt
     assert "Do not imitate the full chat_general stance-brief style." in prompt
     assert "chat_stance_brief" not in prompt
+
+
+# Regression guardrails for exec-side context (message_history, recall user_text) live in
+# tests/test_chat_prompt_context_guardrails.py — extend there when adding chat prompt variables.

--- a/services/orion-cortex-exec/tests/test_plan_ctx_latest_user_text.py
+++ b/services/orion-cortex-exec/tests/test_plan_ctx_latest_user_text.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from app.recall_utils import plan_ctx_latest_user_text
+
+
+def test_plan_ctx_prefers_raw_user_text() -> None:
+    assert plan_ctx_latest_user_text({"raw_user_text": "  hi  ", "user_message": "ignored"}) == "hi"
+
+
+def test_plan_ctx_falls_back_to_user_message() -> None:
+    assert plan_ctx_latest_user_text({"raw_user_text": "", "user_message": "from user_message"}) == "from user_message"
+
+
+def test_plan_ctx_falls_back_to_last_user_in_messages() -> None:
+    ctx = {
+        "messages": [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "last turn"},
+        ]
+    }
+    assert plan_ctx_latest_user_text(ctx) == "last turn"

--- a/services/orion-cortex-exec/tests/test_recall_delivery_gating.py
+++ b/services/orion-cortex-exec/tests/test_recall_delivery_gating.py
@@ -41,6 +41,20 @@ def test_delivery_required_recall_switches_to_assist_light_profile() -> None:
     assert decision["profile_source"] == "delivery_safe_default"
 
 
+def test_client_recall_on_runs_without_requires_memory_steps() -> None:
+    from app.recall_utils import should_run_recall
+
+    step = ExecutionStep(
+        verb_name="chat_quick",
+        step_name="llm_chat_quick",
+        description="chat",
+        order=0,
+        services=["LLMGatewayService"],
+        requires_memory=False,
+    )
+    assert should_run_recall({"enabled": True}, [step]) == (True, "enabled_client_explicit")
+
+
 def test_reflective_modes_keep_normal_recall_behavior() -> None:
     decision = delivery_safe_recall_decision(
         {"enabled": True},

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -64,6 +64,7 @@ def _ui_asset_mtime_token() -> str:
     """Best-effort mtime token so uncommitted UI edits bust browser caches."""
     candidates = [
         STATIC_DIR / "js" / "app.js",
+        STATIC_DIR / "js" / "memory-graph-draft-ui.js",
         STATIC_DIR / "js" / "workflow-ui.js",
         TEMPLATES_DIR / "index.html",
     ]
@@ -84,14 +85,18 @@ def build_hub_ui_asset_version() -> str:
     discovered_git_sha = _discover_git_sha()
     build_ts = os.getenv("BUILD_TIMESTAMP")
     service_version = settings.SERVICE_VERSION
+    mtime_token = _ui_asset_mtime_token()
 
-    # Honor explicit CI/build ids exactly.
+    # CI/build ids identify a build, but volume-mounted static/ can change without
+    # a new image. Append the max mtime of key UI files so each Hub restart (and
+    # any template reload) can surface a new ?v= for script tags.
     for candidate in (explicit, build_id, git_sha, build_ts):
         value = str(candidate or "").strip()
         if value:
+            if mtime_token:
+                return f"{value}-{mtime_token}"
             return value
     # For local/dev paths, include mtime token so restarts pick up UI edits.
-    mtime_token = _ui_asset_mtime_token()
     if discovered_git_sha and mtime_token:
         return f"{discovered_git_sha}-{mtime_token}"
     if discovered_git_sha:

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -458,6 +458,7 @@ loadDismissedIds();
   let lastRecallCanaryResponse = null;
   let lastRecallCanarySelectedProfile = null;
   let memoryGraphBridgeTurnsCache = [];
+  let memoryGraphBridgeAnchorDiv = null;
   const MEMORY_GRAPH_BRIDGE_MAX_TURNS_CAP = 80;
   const MEMORY_GRAPH_BRIDGE_MAX_TURNS_DEFAULT = 40;
   const LS_MEMORY_GRAPH_BRIDGE_MAX_TURNS = 'orion_memory_graph_bridge_max_turns';
@@ -5956,6 +5957,7 @@ loadDismissedIds();
 
   function closeMemoryGraphBridgeModal() {
     if (!memoryGraphBridgeModal) return;
+    memoryGraphBridgeAnchorDiv = null;
     memoryGraphBridgeModal.classList.add('hidden');
     memoryGraphBridgeModal.setAttribute('aria-hidden', 'true');
     const hintsEl = document.getElementById('memoryGraphBridgeChainHints');
@@ -5965,19 +5967,16 @@ loadDismissedIds();
     }
   }
 
-  function openMemoryGraphBridgeModal(anchorDiv) {
+  function rebuildMemoryGraphBridgeTurnList() {
     const list = document.getElementById('memoryGraphBridgeTurnList');
-    const draftTa = document.getElementById('memoryGraphBridgeDraft');
     const statusEl = document.getElementById('memoryGraphBridgeStatus');
     const hintsEl = document.getElementById('memoryGraphBridgeChainHints');
-    const closeForFocus = document.getElementById('memoryGraphBridgeModalClose');
-    if (!memoryGraphBridgeModal || !list) return;
+    if (!list || !memoryGraphBridgeAnchorDiv) return;
     const maxTurnsInputEl = document.getElementById('memoryGraphBridgeMaxTurns');
-    if (maxTurnsInputEl) maxTurnsInputEl.value = String(readBridgeMaxTurnsStored());
     let maxTurns = parseInt(maxTurnsInputEl && maxTurnsInputEl.value ? maxTurnsInputEl.value : '', 10);
     if (!Number.isFinite(maxTurns)) maxTurns = readBridgeMaxTurnsStored();
     maxTurns = Math.min(MEMORY_GRAPH_BRIDGE_MAX_TURNS_CAP, Math.max(1, maxTurns));
-    const { turns, skippedWithoutId } = collectConversationTurnsUpTo(anchorDiv, maxTurns);
+    const { turns, skippedWithoutId } = collectConversationTurnsUpTo(memoryGraphBridgeAnchorDiv, maxTurns);
     memoryGraphBridgeTurnsCache = turns;
     list.innerHTML = '';
     if (statusEl) statusEl.textContent = '';
@@ -5990,11 +5989,6 @@ loadDismissedIds();
       if (skippedWithoutId > 0 && hintsEl) {
         hintsEl.textContent = `${skippedWithoutId} older message(s) have no stable turn id (often user turns). They are omitted from the chain until linkage meta is present.`;
         hintsEl.classList.remove('hidden');
-      }
-      memoryGraphBridgeModal.classList.remove('hidden');
-      memoryGraphBridgeModal.setAttribute('aria-hidden', 'false');
-      if (closeForFocus && typeof closeForFocus.focus === 'function') {
-        closeForFocus.focus({ preventScroll: true });
       }
       const viz0 = ensureMemoryGraphBridgeDraftViz();
       if (viz0 && viz0.refresh) requestAnimationFrame(() => viz0.refresh());
@@ -6046,14 +6040,24 @@ loadDismissedIds();
       row.appendChild(cap);
       list.appendChild(row);
     });
-    if (draftTa) draftTa.value = '';
+    const viz = ensureMemoryGraphBridgeDraftViz();
+    if (viz && viz.refresh) requestAnimationFrame(() => viz.refresh());
+  }
+
+  function openMemoryGraphBridgeModal(anchorDiv) {
+    const draftTa = document.getElementById('memoryGraphBridgeDraft');
+    const closeForFocus = document.getElementById('memoryGraphBridgeModalClose');
+    if (!memoryGraphBridgeModal || !document.getElementById('memoryGraphBridgeTurnList')) return;
+    memoryGraphBridgeAnchorDiv = anchorDiv;
+    const maxTurnsInputEl = document.getElementById('memoryGraphBridgeMaxTurns');
+    if (maxTurnsInputEl) maxTurnsInputEl.value = String(readBridgeMaxTurnsStored());
+    rebuildMemoryGraphBridgeTurnList();
+    if (memoryGraphBridgeTurnsCache.length > 0 && draftTa) draftTa.value = '';
     memoryGraphBridgeModal.classList.remove('hidden');
     memoryGraphBridgeModal.setAttribute('aria-hidden', 'false');
     if (closeForFocus && typeof closeForFocus.focus === 'function') {
       closeForFocus.focus({ preventScroll: true });
     }
-    const viz = ensureMemoryGraphBridgeDraftViz();
-    if (viz && viz.refresh) requestAnimationFrame(() => viz.refresh());
   }
 
   function setupMemoryGraphBridgeModal() {
@@ -6067,13 +6071,22 @@ loadDismissedIds();
     const maxTurnsInput = document.getElementById('memoryGraphBridgeMaxTurns');
     if (maxTurnsInput) {
       maxTurnsInput.value = String(readBridgeMaxTurnsStored());
-      maxTurnsInput.addEventListener('change', () => {
-        let v = parseInt(maxTurnsInput.value, 10);
-        if (!Number.isFinite(v)) v = MEMORY_GRAPH_BRIDGE_MAX_TURNS_DEFAULT;
+      function syncBridgeMaxTurnsFromInput(opts) {
+        const strict = Boolean(opts && opts.strict);
+        const raw = String(maxTurnsInput.value || '').trim();
+        if (raw === '' && !strict) return;
+        let v = parseInt(raw, 10);
+        if (!Number.isFinite(v)) {
+          if (!strict) return;
+          v = MEMORY_GRAPH_BRIDGE_MAX_TURNS_DEFAULT;
+        }
         v = Math.min(MEMORY_GRAPH_BRIDGE_MAX_TURNS_CAP, Math.max(1, v));
         maxTurnsInput.value = String(v);
         localStorage.setItem(LS_MEMORY_GRAPH_BRIDGE_MAX_TURNS, String(v));
-      });
+        rebuildMemoryGraphBridgeTurnList();
+      }
+      maxTurnsInput.addEventListener('input', () => syncBridgeMaxTurnsFromInput({ strict: false }));
+      maxTurnsInput.addEventListener('change', () => syncBridgeMaxTurnsFromInput({ strict: true }));
     }
     const selKBtn = document.getElementById('memoryGraphBridgeSelectLastKBtn');
     const selKIn = document.getElementById('memoryGraphBridgeSelectLastKInput');
@@ -6151,15 +6164,28 @@ loadDismissedIds();
             return;
           }
           const raw = data && data.raw;
-          const t = (data && (data.text || (raw && raw.final_text))) || text;
-          const out = typeof t === 'string' ? t.trim() : '';
-          const stepErr = !out && raw && typeof raw === 'object' ? extractCortexStepErrorHint(raw) : '';
-          if (!out && stepErr) {
+          const coalesce = window.OrionMemoryGraphDraftUI && typeof window.OrionMemoryGraphDraftUI.coalesceChatSuggestDraft === 'function'
+            ? window.OrionMemoryGraphDraftUI.coalesceChatSuggestDraft(data)
+            : null;
+          let out = '';
+          let suggestError = '';
+          if (coalesce) {
+            out = coalesce.draftText || '';
+            suggestError = coalesce.error || '';
+          } else {
+            const t = (data && (data.text || (raw && raw.final_text))) || '';
+            out = typeof t === 'string' ? t.trim() : '';
+            const stepErr = !out && raw && typeof raw === 'object' ? extractCortexStepErrorHint(raw) : '';
+            if (!out && stepErr) suggestError = stepErr;
+          }
+          if (suggestError) {
             draftTa.value = '';
-            if (statusEl) statusEl.textContent = `Suggest failed (no draft text). ${stepErr}`;
+            const vDraft = ensureMemoryGraphBridgeDraftViz();
+            if (vDraft && vDraft.refresh) vDraft.refresh();
+            if (statusEl) statusEl.textContent = `Suggest failed: ${suggestError}`;
             return;
           }
-          draftTa.value = typeof t === 'string' ? t : JSON.stringify(t, null, 2);
+          draftTa.value = out;
           const vDraft = ensureMemoryGraphBridgeDraftViz();
           if (vDraft && vDraft.refresh) vDraft.refresh();
           if (statusEl) {
@@ -8672,7 +8698,7 @@ loadDismissedIds();
        browser_client_id: ensureBrowserClientId(),
        disable_tts: textToSpeechToggle ? !textToSpeechToggle.checked : false,
        no_write: noWriteToggle ? noWriteToggle.checked : false,
-       use_recall: recallToggle ? recallToggle.checked : false,
+       use_recall: recallToggle ? recallToggle.checked : true,
        recall_mode: recallMode !== "auto" ? recallMode : null,
        recall_profile: recallProfile !== "auto" ? recallProfile : null,
        recall_required: recallRequiredToggle ? recallRequiredToggle.checked : false,
@@ -8776,7 +8802,7 @@ loadDismissedIds();
                session_id: orionSessionId,
                browser_client_id: ensureBrowserClientId(),
                no_write: noWriteToggle ? noWriteToggle.checked : false,
-               use_recall: recallToggle ? recallToggle.checked : false,
+               use_recall: recallToggle ? recallToggle.checked : true,
                recall_mode: recallModeSelect && recallModeSelect.value !== "auto" ? recallModeSelect.value : null,
                recall_profile: recallProfileSelect && recallProfileSelect.value !== "auto" ? recallProfileSelect.value : null,
                recall_required: recallRequiredToggle ? recallRequiredToggle.checked : false,

--- a/services/orion-hub/static/js/memory-graph-draft-ui.js
+++ b/services/orion-hub/static/js/memory-graph-draft-ui.js
@@ -18,6 +18,9 @@
     if (!trimmed) {
       return { ok: false, object: null, mode: null, warning: "Empty draft." };
     }
+    if (trimmed.startsWith("[Error:")) {
+      return { ok: false, object: null, mode: null, warning: trimmed };
+    }
     try {
       const o = JSON.parse(trimmed);
       if (o !== null && typeof o === "object" && !Array.isArray(o)) {
@@ -73,6 +76,50 @@
     return { ok: false, object: null, mode: null, warning: "Could not parse a single JSON object." };
   }
 
+  /**
+   * Pull gateway/LLM failure text from cortex-exec raw.steps (e.g. "[Error: llamacpp timed out…]").
+   */
+  function extractLlmGatewayErrorFromRaw(raw) {
+    if (!raw || typeof raw !== "object") return "";
+    const topErr = raw.error != null ? String(raw.error).trim() : "";
+    const parts = [];
+    if (topErr) parts.push(topErr);
+    const steps = raw.steps;
+    if (!Array.isArray(steps)) {
+      return parts.filter(Boolean).join(" · ") || "";
+    }
+    steps.forEach((step) => {
+      if (!step || typeof step !== "object") return;
+      if (step.error != null) parts.push(String(step.error));
+      const res = step.result;
+      if (!res || typeof res !== "object") return;
+      Object.keys(res).forEach((svcKey) => {
+        const block = res[svcKey];
+        if (!block || typeof block !== "object") return;
+        const c = String(block.content || "").trim();
+        if (c.startsWith("[Error:") || /timed out|timeout|error/i.test(c)) parts.push(c);
+      });
+    });
+    const merged = parts.filter(Boolean);
+    return merged.filter((v, i, a) => a.indexOf(v) === i).join(" · ");
+  }
+
+  /**
+   * Prefer top-level `text` / raw.final_text only. Never fall back to the full HTTP response body
+   * (that leaks the whole JSON envelope into the draft textarea and breaks the graph preview).
+   */
+  function coalesceChatSuggestDraft(data) {
+    const raw = data && typeof data.raw === "object" ? data.raw : null;
+    let draft = "";
+    if (typeof (data && data.text) === "string" && data.text.trim()) draft = data.text.trim();
+    else if (raw && typeof raw.final_text === "string" && raw.final_text.trim()) draft = raw.final_text.trim();
+    const stepErr = raw ? extractLlmGatewayErrorFromRaw(raw) : "";
+    if (!draft && stepErr) return { draftText: "", error: stepErr };
+    if (draft && draft.startsWith("[Error:")) return { draftText: "", error: draft };
+    if (stepErr && (!draft || draft === "{}")) return { draftText: "", error: stepErr };
+    return { draftText: draft, error: null };
+  }
+
   function draftToCyElements(obj) {
     const nodes = [];
     const edges = [];
@@ -118,7 +165,7 @@
     return { nodes, edges };
   }
 
-  function draftToCyElements(obj) {
+  function renderDetail(selection, obj, onApply) {
     const wrap = document.createElement("div");
     wrap.className = "space-y-2 text-[11px]";
 
@@ -352,7 +399,11 @@
       if (!nodes.length && !edges.length) {
         const p = document.createElement("p");
         p.className = "text-gray-500 text-[11px]";
-        p.textContent = "Parsed JSON has no entities, situations, edges, or dispositions to show.";
+        const keys = parsed.object && typeof parsed.object === "object" ? Object.keys(parsed.object) : [];
+        const emptyShape = keys.length === 0;
+        p.textContent = emptyShape
+          ? "Parsed JSON is an empty object — nothing to draw. If Suggest failed upstream, check the status line for [Error: …] / timeout, then retry."
+          : "Parsed JSON has no entities, situations, edges, or dispositions to show.";
         cyHost.appendChild(p);
         return;
       }
@@ -428,5 +479,7 @@
     parseMemoryGraphDraftJson,
     draftToCyElements,
     attach,
+    coalesceChatSuggestDraft,
+    extractLlmGatewayErrorFromRaw,
   };
 })();

--- a/services/orion-hub/static/js/memory.js
+++ b/services/orion-hub/static/js/memory.js
@@ -355,11 +355,34 @@
             graphSetOut(data || text, true);
             return;
           }
-          const t = (data && (data.text || (data.raw && data.raw.final_text))) || text;
-          draftTa.value = typeof t === "string" ? t : JSON.stringify(t, null, 2);
+          const coalesce =
+            window.OrionMemoryGraphDraftUI && typeof window.OrionMemoryGraphDraftUI.coalesceChatSuggestDraft === "function"
+              ? window.OrionMemoryGraphDraftUI.coalesceChatSuggestDraft(data)
+              : null;
+          let draftText = "";
+          let suggestErr = "";
+          if (coalesce) {
+            draftText = coalesce.draftText || "";
+            suggestErr = coalesce.error || "";
+          } else {
+            const t = (data && (data.text || (data.raw && data.raw.final_text))) || "";
+            draftText = typeof t === "string" ? t.trim() : "";
+          }
+          if (suggestErr) {
+            draftTa.value = "";
+            if (memoryDraftViz && memoryDraftViz.refresh) memoryDraftViz.refresh();
+            graphSetOut({ ok: false, error: suggestErr }, true);
+            return;
+          }
+          draftTa.value = draftText;
           if (memoryDraftViz && memoryDraftViz.refresh) memoryDraftViz.refresh();
           graphSetOut(
-            { ok: true, note: "Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate." },
+            {
+              ok: true,
+              note: draftText
+                ? "Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate."
+                : "Empty response — check gateway / model logs.",
+            },
             false
           );
         } catch (e) {

--- a/services/orion-hub/tests/test_memory_graph_bridge_ui.py
+++ b/services/orion-hub/tests/test_memory_graph_bridge_ui.py
@@ -39,7 +39,8 @@ def test_app_js_wires_memory_graph_bridge_handlers() -> None:
     assert "extractCortexStepErrorHint" in app_js
     assert "ensureMemoryGraphBridgeDraftViz" in app_js
     assert "hub-utterance:" in app_js
-    assert "readBridgeMaxTurnsStored" in app_js
+    assert "rebuildMemoryGraphBridgeTurnList" in app_js
+    assert "memoryGraphBridgeAnchorDiv" in app_js
 
 
 def test_memory_js_listens_for_bridge_import_event() -> None:

--- a/services/orion-hub/tests/test_workflow_schedule_runtime_paths.py
+++ b/services/orion-hub/tests/test_workflow_schedule_runtime_paths.py
@@ -173,6 +173,7 @@ def test_hub_ui_asset_version_helper_returns_non_empty_token(monkeypatch) -> Non
     import scripts.main as hub_main
 
     monkeypatch.setenv("HUB_UI_BUILD", "build-20260330")
+    monkeypatch.setattr(hub_main, "_ui_asset_mtime_token", lambda: "")
     assert hub_main.build_hub_ui_asset_version() == "build-20260330"
 
 
@@ -184,7 +185,17 @@ def test_hub_ui_asset_version_prefers_build_id_when_explicit_build_absent(monkey
     monkeypatch.delenv("GIT_SHA", raising=False)
     monkeypatch.delenv("SOURCE_COMMIT", raising=False)
     monkeypatch.delenv("BUILD_TIMESTAMP", raising=False)
+    monkeypatch.setattr(hub_main, "_ui_asset_mtime_token", lambda: "")
     assert hub_main.build_hub_ui_asset_version() == "ci-4821"
+
+
+def test_hub_ui_asset_version_appends_mtime_after_build_id(monkeypatch) -> None:
+    import scripts.main as hub_main
+
+    monkeypatch.delenv("HUB_UI_BUILD", raising=False)
+    monkeypatch.setenv("BUILD_ID", "ci-4821")
+    monkeypatch.setattr(hub_main, "_ui_asset_mtime_token", lambda: "1730000000")
+    assert hub_main.build_hub_ui_asset_version() == "ci-4821-1730000000"
 
 
 def test_root_response_disables_html_caching() -> None:

--- a/services/orion-llm-gateway/app/llm_backend.py
+++ b/services/orion-llm-gateway/app/llm_backend.py
@@ -151,21 +151,45 @@ def _resolve_route(body: ChatBody) -> Tuple[str, Optional[RouteTarget], bool, st
     return resolved_route, None, False, route_source
 
 
-def _timeout_summary() -> str:
+def _timeout_summary(read_sec: Optional[float] = None) -> str:
+    r = read_sec if read_sec is not None else float(getattr(settings, "read_timeout_sec", 60.0) or 60.0)
     return (
         f"connect:{getattr(settings, 'connect_timeout_sec', 10.0)} "
-        f"read:{getattr(settings, 'read_timeout_sec', 60.0)}"
+        f"read:{r}"
     )
 
 
-def _common_http_client() -> httpx.Client:
+def _resolve_http_read_timeout_sec(body: Optional[ChatBody]) -> float:
     """
-    Returns an HTTP client using the configured timeouts from settings.
+    HTTP read timeout for upstream OpenAI-compatible / Ollama calls.
+
+    Callers (e.g. cortex-exec) may set options['gateway_read_timeout_sec'] so the
+    gateway does not abort before the bus RPC timeout that wraps this request.
     """
+    default = float(getattr(settings, "read_timeout_sec", 60.0) or 60.0)
+    if body is None:
+        return max(30.0, min(default, 900.0))
+    opts = getattr(body, "options", None) or {}
+    raw = opts.get("gateway_read_timeout_sec")
+    if raw is None:
+        return max(30.0, min(default, 900.0))
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return max(30.0, min(default, 900.0))
+    return max(30.0, min(v, 900.0))
+
+
+def _common_http_client(body: Optional[ChatBody] = None) -> httpx.Client:
+    """
+    Returns an HTTP client using configured timeouts; optional ChatBody can
+    override read timeout via options['gateway_read_timeout_sec'].
+    """
+    read_sec = _resolve_http_read_timeout_sec(body)
     return httpx.Client(
         timeout=httpx.Timeout(
             connect=getattr(settings, "connect_timeout_sec", 10.0),
-            read=getattr(settings, "read_timeout_sec", 60.0),
+            read=read_sec,
             write=10.0,
             pool=10.0,
         )
@@ -736,7 +760,7 @@ def _execute_ollama_chat(
     logger.info(f"[LLM-GW] ollama req model={model} msgs={len(body.messages or [])} url={url}")
 
     try:
-        with _common_http_client() as client:
+        with _common_http_client(body) as client:
             r = client.post(url, json=payload)
             if r.status_code == 404:
                 return {
@@ -764,7 +788,7 @@ def _execute_ollama_chat(
             served_by,
             url,
             body.trace_id,
-            _timeout_summary(),
+            _timeout_summary(_resolve_http_read_timeout_sec(body)),
         )
         return {
             "text": "[Error: ollama timed out after waiting]",
@@ -833,7 +857,7 @@ def _execute_openai_chat(
     )
 
     try:
-        with _common_http_client() as client:
+        with _common_http_client(body) as client:
             r = client.post(url, json=payload)
 
             if r.status_code == 404:
@@ -996,7 +1020,7 @@ def _execute_openai_chat(
             served_by,
             url,
             body.trace_id,
-            _timeout_summary(),
+            _timeout_summary(_resolve_http_read_timeout_sec(body)),
         )
         return {
             "text": f"[Error: {backend_name} timed out after waiting]",
@@ -1059,7 +1083,7 @@ def run_llm_chat(body: ChatBody) -> Dict[str, Any]:
                     base_url,
                     model,
                     body.trace_id,
-                    _timeout_summary(),
+                    _timeout_summary(_resolve_http_read_timeout_sec(body)),
                 )
                 result = _execute_openai_chat(
                     body,
@@ -1084,7 +1108,7 @@ def run_llm_chat(body: ChatBody) -> Dict[str, Any]:
                 base_url,
                 model,
                 body.trace_id,
-                _timeout_summary(),
+                _timeout_summary(_resolve_http_read_timeout_sec(body)),
             )
             result = _execute_ollama_chat(
                 body,
@@ -1119,7 +1143,7 @@ def run_llm_chat(body: ChatBody) -> Dict[str, Any]:
                     base_url,
                     model,
                     body.trace_id,
-                    _timeout_summary(),
+                    _timeout_summary(_resolve_http_read_timeout_sec(body)),
                 )
                 result = _execute_openai_chat(
                     body,
@@ -1144,7 +1168,7 @@ def run_llm_chat(body: ChatBody) -> Dict[str, Any]:
                 base_url,
                 model,
                 body.trace_id,
-                _timeout_summary(),
+                _timeout_summary(_resolve_http_read_timeout_sec(body)),
             )
             result = _execute_ollama_chat(
                 body,
@@ -1177,7 +1201,7 @@ def run_llm_chat(body: ChatBody) -> Dict[str, Any]:
         route_url,
         model,
         body.trace_id,
-        _timeout_summary(),
+        _timeout_summary(_resolve_http_read_timeout_sec(body)),
     )
     result = _execute_openai_chat(
         body,

--- a/services/orion-recall/app/fusion.py
+++ b/services/orion-recall/app/fusion.py
@@ -11,8 +11,10 @@ from orion.core.contracts.recall import MemoryBundleStatsV1, MemoryBundleV1, Mem
 
 try:
     from .render import render_items
+    from .snippet_dedupe import duplicate_orion_reply_assistant
 except ImportError:  # pragma: no cover - fallback when not in package context
     from render import render_items  # type: ignore
+    from snippet_dedupe import duplicate_orion_reply_assistant  # type: ignore
 
 DEFAULT_BACKEND_WEIGHTS = {
     "vector": 1.0,
@@ -410,6 +412,7 @@ def fuse_candidates(
     drop_counts: Dict[str, int] = {}
     selected_counts: Dict[str, int] = {}
     novelty_drop_count = 0
+    duplicate_orion_reply_drop_count = 0
     contaminated_recall_filtered_count = 0
     contaminated_recall_sanitized_count = 0
 
@@ -527,6 +530,7 @@ def fuse_candidates(
         )
 
     selected_transcripts: List[str] = []
+    selected_orion_assistants: List[str] = []
     for idx, cand in enumerate(ranked_candidates, start=1):
         source = str(cand.get("source") or "unknown")
         drop_reason = ""
@@ -541,16 +545,27 @@ def fuse_candidates(
         snippet = str(cand.get("text") or cand.get("snippet") or "")
         transcript_like = _is_transcript_like(cand, snippet)
         transcript_norm = ""
+        asst_norm = ""
         if selected and transcript_like:
             user, assistant = _extract_transcript_parts(snippet)
             transcript_norm = _normalize_whitespace(
                 f"user:{user.lower()}|orion:{assistant.lower()}" if (user or assistant) else snippet.lower()
             )
+            asst_norm = _normalize_whitespace(assistant)
             duplicate_transcript = any(_materially_same_transcript(transcript_norm, prev) for prev in selected_transcripts)
+            duplicate_orion = False
+            if asst_norm and len(asst_norm) >= 20:
+                duplicate_orion = any(
+                    duplicate_orion_reply_assistant(asst_norm, prev) for prev in selected_orion_assistants
+                )
             if duplicate_transcript:
                 selected = False
                 drop_reason = "transcript_novelty"
                 novelty_drop_count += 1
+            elif duplicate_orion:
+                selected = False
+                drop_reason = "duplicate_orion_reply"
+                duplicate_orion_reply_drop_count += 1
 
         if selected:
             composite_score = float(cand["_relevance"]["composite_score"])
@@ -582,6 +597,8 @@ def fuse_candidates(
             items.append(item)
             if transcript_like and transcript_norm:
                 selected_transcripts.append(transcript_norm)
+            if transcript_like and asst_norm:
+                selected_orion_assistants.append(asst_norm)
         elif drop_reason:
             drop_counts[drop_reason] = drop_counts.get(drop_reason, 0) + 1
 
@@ -643,6 +660,7 @@ def fuse_candidates(
         diag_payload = {
             "transcript_dedupe_collapsed": transcript_dedupe_count,
             "novelty_drop_count": novelty_drop_count,
+            "duplicate_orion_reply_drop_count": duplicate_orion_reply_drop_count,
             "drop_counts": drop_counts,
             "source_candidate_counts": backend_counts,
             "source_selected_counts": selected_counts,

--- a/services/orion-recall/app/render.py
+++ b/services/orion-recall/app/render.py
@@ -5,6 +5,11 @@ from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from orion.core.contracts.recall import MemoryItemV1
 
+try:
+    from .snippet_dedupe import OrionDigestDeduper
+except ImportError:  # pragma: no cover
+    from snippet_dedupe import OrionDigestDeduper  # type: ignore
+
 
 def render_items(
     items: Iterable[MemoryItemV1],
@@ -27,6 +32,7 @@ def render_items(
     items_list = list(items)
     claims = [item for item in items_list if "claim" in (item.tags or [])]
     others = [item for item in items_list if item not in claims]
+    orion_deduper = OrionDigestDeduper()
     is_graphtri = bool(profile_name) and (
         str(profile_name) == "graphtri.v1" or str(profile_name).startswith("graphtri")
     )
@@ -51,6 +57,8 @@ def render_items(
                 continue
             snippet = (item.snippet or "").strip().replace("\n", " ")
             if not snippet:
+                continue
+            if not orion_deduper.should_emit_snippet(snippet):
                 continue
             prefix = f"[{item.source}"
             if item.source_ref:
@@ -119,6 +127,8 @@ def render_items(
                     skipped_refusal += 1
                     continue
                 if not snippet:
+                    continue
+                if not orion_deduper.should_emit_snippet(snippet):
                     continue
                 prefix = f"[{item.source}"
                 if item.source_ref:

--- a/services/orion-recall/app/snippet_dedupe.py
+++ b/services/orion-recall/app/snippet_dedupe.py
@@ -1,0 +1,99 @@
+"""Collapse repeated Orion assistant lines in recall snippets (vector → same catchphrase many times)."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+_WS = re.compile(r"\s+")
+
+
+def normalize_compare_text(text: str) -> str:
+    t = _WS.sub(" ", (text or "").strip())
+    for a, b in (
+        ("\u2019", "'"),
+        ("\u2018", "'"),
+        ("\u201c", '"'),
+        ("\u201d", '"'),
+    ):
+        t = t.replace(a, b)
+    return t.lower()
+
+
+def extract_orion_assistant_from_snippet(snippet: str) -> str:
+    """OrionResponse body for ExactUserText/OrionResponse rows; robust if inner quotes exist."""
+    raw = _WS.sub(" ", (snippet or "").strip())
+    if not raw:
+        return ""
+    low = raw.lower()
+    key = "orionresponse:"
+    pos = low.find(key)
+    if pos < 0:
+        return ""
+    tail = raw[pos + len(key) :].strip()
+    if not tail.startswith('"'):
+        return tail[:800].strip()
+    # Opening " … find closing " (last quote is safest for single-line vector snippets)
+    inner = tail[1:]
+    end = inner.rfind('"')
+    if end >= 0:
+        return inner[:end].strip()[:800]
+    return inner.strip()[:800]
+
+
+def _token_set(text: str) -> set[str]:
+    return {tok for tok in re.findall(r"[a-z0-9]{3,}", text.lower()) if tok}
+
+
+def materially_same_text(a: str, b: str) -> bool:
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    ta = _token_set(a)
+    tb = _token_set(b)
+    if len(ta) < 4 or len(tb) < 4:
+        return normalize_compare_text(a) == normalize_compare_text(b)
+    inter = len(ta.intersection(tb))
+    union = len(ta.union(tb))
+    if union == 0:
+        return False
+    return (inter / union) >= 0.88
+
+
+def duplicate_orion_reply_assistant(a: str, b: str) -> bool:
+    """True if two assistant replies are the same boilerplate (subset, near-duplicate, or matching opener)."""
+    if not a or not b:
+        return False
+    na = normalize_compare_text(a)
+    nb = normalize_compare_text(b)
+    if na == nb:
+        return True
+    if materially_same_text(na, nb):
+        return True
+    # Shared long opener (typical canned intro repeated across turns)
+    prefix_n = 96
+    if len(na) >= 32 and len(nb) >= 32 and na[:prefix_n] == nb[:prefix_n]:
+        return True
+    min_sub = 28
+    if len(na) >= min_sub and len(nb) >= min_sub:
+        if na in nb or nb in na:
+            return True
+    return False
+
+
+class OrionDigestDeduper:
+    """Second line of defense: render skips duplicate assistant bodies even if fusion let them through."""
+
+    def __init__(self) -> None:
+        self._seen: List[str] = []
+
+    def should_emit_snippet(self, snippet: str) -> bool:
+        body = extract_orion_assistant_from_snippet(snippet)
+        if len(body) < 20:
+            return True
+        for prev in self._seen:
+            if duplicate_orion_reply_assistant(body, prev):
+                return False
+        self._seen.append(body)
+        return True

--- a/services/orion-recall/tests/test_fusion_transcript_dedupe.py
+++ b/services/orion-recall/tests/test_fusion_transcript_dedupe.py
@@ -76,3 +76,21 @@ def test_fusion_keeps_distinct_non_transcript_items():
     bundle, _ = fuse_candidates(candidates=cands, profile=_profile(), query_text="GraphDB", diagnostic=True)
 
     assert len(bundle.items) == 2
+
+
+def test_fusion_dedupes_identical_orion_across_distinct_user_turns():
+    """Vector often returns many rows with the same assistant catchphrase; digest must not amplify repetition."""
+    orion_body = (
+        "Ain't nothin' but a hound dog, but I'm here for the chips and queso. You good? "
+        "(You just called me silly—did you forget the jalapeño kick? I'm still waiting for that second helping.)"
+    )
+    t1 = f'ExactUserText: "sup" OrionResponse: "{orion_body}"'
+    t2 = f'ExactUserText: "lol you silly" OrionResponse: "{orion_body}"'
+    cands = [
+        {"id": "vec-a", "source": "vector", "text": t1, "score": 0.15, "tags": []},
+        {"id": "vec-b", "source": "vector", "text": t2, "score": 0.13, "tags": []},
+    ]
+
+    bundle, _ = fuse_candidates(candidates=cands, profile=_profile(), query_text="queso", diagnostic=True)
+
+    assert len(bundle.items) == 1

--- a/services/orion-recall/tests/test_render_orion_dedupe.py
+++ b/services/orion-recall/tests/test_render_orion_dedupe.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+_RECALL_ROOT = _REPO / "services" / "orion-recall"
+if str(_RECALL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_RECALL_ROOT))
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from orion.core.contracts.recall import MemoryItemV1
+
+from app.render import render_items
+
+
+def test_memory_digest_emits_orion_catchphrase_once() -> None:
+    orion = (
+        "Ain't nothin' but a hound dog, but I'm here for the chips and queso. You good? "
+        "Extra line so body is long enough to dedupe."
+    )
+    s1 = f'ExactUserText: "sup" OrionResponse: "{orion}"'
+    s2 = f'ExactUserText: "lol" OrionResponse: "{orion}"'
+    items = [
+        MemoryItemV1(
+            id="a",
+            source="vector",
+            source_ref="orion_chat_turns",
+            score=0.15,
+            snippet=s1,
+        ),
+        MemoryItemV1(
+            id="b",
+            source="vector",
+            source_ref="orion_chat_turns",
+            score=0.13,
+            snippet=s2,
+        ),
+    ]
+    text, _ = render_items(items, 2000, profile_name="chat.general.v1")
+    assert text.count("chips and queso") == 1
+    assert text.count("vector:orion_chat_turns") == 1

--- a/services/orion-recall/tests/test_snippet_dedupe.py
+++ b/services/orion-recall/tests/test_snippet_dedupe.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+_RECALL_ROOT = _REPO / "services" / "orion-recall"
+if str(_RECALL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_RECALL_ROOT))
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from app.snippet_dedupe import (
+    OrionDigestDeduper,
+    duplicate_orion_reply_assistant,
+    extract_orion_assistant_from_snippet,
+)
+
+
+def test_extract_handles_unicode_apostrophe() -> None:
+    s = 'ExactUserText: "hi" OrionResponse: "Ain\u2019t nothin\' here"'
+    assert "not" in extract_orion_assistant_from_snippet(s).lower()
+
+
+def test_duplicate_detects_same_opener() -> None:
+    long_t = (
+        "Ain't nothin' but a hound dog, but I'm here for the chips and queso. You good? "
+        "(You just called me silly.)"
+    )
+    short_t = "Ain't nothin' but a hound dog, but I'm here for the chips and queso. You good?"
+    assert duplicate_orion_reply_assistant(long_t, short_t)
+
+
+def test_deduper_skips_second_identical() -> None:
+    body = "Same Orion line repeated."
+    a = f'ExactUserText: "x" OrionResponse: "{body}"'
+    b = f'ExactUserText: "y" OrionResponse: "{body}"'
+    d = OrionDigestDeduper()
+    assert d.should_emit_snippet(a) is True
+    assert d.should_emit_snippet(b) is False

--- a/tests/test_chat_general_prompt.py
+++ b/tests/test_chat_general_prompt.py
@@ -18,10 +18,12 @@ def test_chat_general_prompt_contains_identity_and_behavior_rails() -> None:
     )
 
     assert "Default to answering directly." in rendered
+    assert "memory_digest and recall snippets may include stale" in rendered
     assert "Stay in first person as Oríon" in rendered
     assert "Do not say \"It sounds like...\"" in rendered
     assert "co-architect" in rendered
     assert "steward" in rendered
+    assert "When the user asks about memory, recall" in rendered
     assert "EVIDENCE-GATED CLAIMS" in rendered
     assert "Do not claim hidden side effects" in rendered
     assert "I can help track this in our conversation right now" in rendered

--- a/tests/test_chat_quick_prompt.py
+++ b/tests/test_chat_quick_prompt.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from jinja2 import Environment
 
 
-def test_chat_quick_prompt_contains_evidence_gated_claim_rails() -> None:
+def test_chat_quick_prompt_contains_recall_and_forbidden_rails() -> None:
     template = Environment().from_string(
         Path("orion/cognition/prompts/chat_quick.j2").read_text(encoding="utf-8")
     )
@@ -18,8 +18,10 @@ def test_chat_quick_prompt_contains_evidence_gated_claim_rails() -> None:
         response_policy_summary=[],
     )
 
-    assert "EVIDENCE-GATED CLAIMS" in rendered
+    assert "WHEN JUNIPER IS CHECKING RECALL" in rendered
+    assert "FORBIDDEN" in rendered
+    assert "memory_digest may contain older banter" in rendered
     assert "Do not claim hidden side effects" in rendered
-    assert "I can keep this in-thread for us here" in rendered
-    assert "I do not have an automatic reminder/notification firing in this lane." in rendered
-    assert "I've logged that and will ping you when it lands." in rendered
+    assert "SIDE-EFFECTS VS MEMORY" in rendered
+    assert "can't access external data" in rendered  # forbidden phrase listed so model avoids it
+    assert "Opening variety" in rendered or "Opening variety:" in rendered.lower()


### PR DESCRIPTION
## Summary - Memory Graph

Improves memory-graph **Suggest** reliability, tightens **recall** so retrieved snippets do not drown out the current question, and fixes Hub UI handling of LLM gateway errors and draft text.

## Motivation

- **Memory graph Suggest** often failed with `llamacpp timed out after waiting` because the LLM gateway used a short default HTTP read timeout while cortex-exec’s bus RPC allowed a longer step timeout.
- After refresh, **same continuity id** + noisy **memory_digest** could make Quick/General replies feel stuck on old banter instead of the latest user line.
- Hub could treat failed or envelope-shaped responses as graph JSON, producing confusing “empty graph” / parse errors.

## Changes

### LLM gateway + cortex-exec

- Gateway honors `options["gateway_read_timeout_sec"]` (clamped) when calling OpenAI-compatible backends and Ollama.
- Cortex-exec sets that value from the effective step timeout so the upstream HTTP client does not abort before the bus RPC does.
- `memory_graph_suggest` verb `timeout_ms` increased to give large JSON drafts more headroom.

### Hub (memory graph)

- Coalesce Suggest responses so the draft uses real model text, not the raw JSON envelope.
- Clearer handling of gateway errors and empty `{}` graph payloads (shared helpers in `memory-graph-draft-ui.js`; wired from bridge + Memory tab).

### Prompts + executor

- **Quick** and **General** chat prompts: explicit rules that the **latest user message** drives the reply; `memory_digest` is background, not a reason to revive stale threads.
- Executor / router / recall utils: guardrails for prompt context and recall delivery; digest header clarifies supplemental vs latest question.

### Recall service

- Transcript/snippet **deduplication** in fusion and render (`snippet_dedupe` helper + tests).

## How to test

1. Redeploy or restart **orion-llm-gateway** and **orion-cortex-exec** (and **orion-recall** if recall code is containerized separately).
2. Hub: Memory graph → **Suggest** on a non-trivial thread; confirm no premature `llamacpp timed out` when generation needs &gt;60s.
3. Chat: continuity id unchanged, UI thread cleared → new question should be answered without repeating prior gag unless the user continues that thread.
4. Run unit tests (repo’s usual pytest entrypoint) for `orion-cortex-exec`, `orion-recall`, `orion-hub`, and root `tests/` prompt tests.

## Risk / rollout

- Longer upstream HTTP reads only apply when cortex passes `gateway_read_timeout_sec` (bounded); default behavior unchanged for callers that omit it.
- Verb timeout increase slightly raises worst-case wait on stuck Suggest calls; monitor step latency if needed.

## Summary - Recall Regression
Fixes a Quick (chat_quick) + recall regression where Orion could repeat the previous assistant turn or ignore the current user line, because (1) message_history was never populated before rendering chat_quick.j2 / chat_general.j2, and (2) recall gating used raw_user_text only, so an empty raw_user_text skipped user_message / messages when classifying the turn.

Adds automated guardrails (tests + a router wiring check) so this class of bug is caught in CI.

Changes
Runtime
services/orion-cortex-exec/app/executor.py

Introduces _format_message_history_for_chat_prompt() and sets ctx["message_history"] before rendering chat_general / chat_quick so the Jinja “LIGHTWEIGHT IDENTITY CONTEXT” block includes a real USER/ASSISTANT transcript (skips system, bounded length).
Handles dict, LLMMessage, and generic model_dump() message shapes.
services/orion-cortex-exec/app/recall_utils.py

Adds plan_ctx_latest_user_text(ctx) — resolves latest user text from raw_user_text → user_message → last user in messages (aligned with orchestrator intent).
services/orion-cortex-exec/app/router.py

Passes plan_ctx_latest_user_text(ctx) into delivery_safe_recall_decision(..., user_text=...) instead of ctx.get("raw_user_text") or "".
Tests / guardrails
services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py — template placeholder contract, transcript formatter behavior, full Jinja render with multi-turn history, recall gating with user_message-only context, and a source-level check that router still wires plan_ctx_latest_user_text.

services/orion-cortex-exec/tests/test_plan_ctx_latest_user_text.py — unit tests for plan_ctx_latest_user_text.

services/orion-cortex-exec/tests/test_chat_quick_plumbing.py — short comment pointing maintainers to the guardrail test module.

How to verify
./scripts/test_service.sh orion-cortex-exec \
  services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py \
  services/orion-cortex-exec/tests/test_plan_ctx_latest_user_text.py \
  -q
Rebuild/restart orion-cortex-exec (and any image that ships app/ for this service) so the runtime changes are live.

Risk / follow-ups
Brittle guard: the router test regex will fail if recall wiring is intentionally refactored — update the test to match the new call pattern.