### PR TITLE
feat(bridge): CallSyne integration hardening + Social Inspection pane…

### DIFF
--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -48,6 +48,7 @@ from .autonomy_constitution import (
     validate_autonomy_constitution,
 )
 from .social_room import is_social_room_payload, social_room_client_meta
+from . import social_room_inspection_cache
 from .service_logs import collect_service_inventory
 from orion.cognition.verb_activation import build_verb_list
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
@@ -1960,6 +1961,9 @@ async def api_chat(
                     trace_verb=(result.get("routing_debug") or {}).get("verb"),
                     memory_digest=result.get("memory_digest"),
                 )
+                _social_room_id = str((payload.get("external_room") or {}).get("room_id") or "").strip()
+                if _social_room_id and result.get("routing_debug"):
+                    social_room_inspection_cache.store(_social_room_id, result["routing_debug"])
             if latest_user_prompt:
                 envelopes.append(
                     build_chat_history_envelope(
@@ -2098,6 +2102,31 @@ async def api_chat(
             )
 
     return result
+
+
+# ======================================================================
+# 🔭 SOCIAL ROOM INSPECTION — latest routing_debug poll endpoint
+# ======================================================================
+@router.get("/api/social-room/inspection/latest")
+async def api_social_room_inspection_latest(
+    room_id: Optional[str] = Query(default=None),
+):
+    """
+    Return the most recent social-room routing_debug (which contains
+    social_inspection) stored after the last Hub social-room chat turn.
+
+    The Hub UI polls this endpoint so the Social Inspection panel updates
+    even when the turn was routed through orion-social-room-bridge rather
+    than the Hub WebSocket.
+    """
+    entry = (
+        social_room_inspection_cache.get(room_id)
+        if room_id
+        else social_room_inspection_cache.get_latest()
+    )
+    if entry is None:
+        return {"routing_debug": None, "stored_at": None, "room_id": None}
+    return entry
 
 
 @router.get("/api/workflow/schedules")

--- a/services/orion-hub/scripts/social_room_inspection_cache.py
+++ b/services/orion-hub/scripts/social_room_inspection_cache.py
@@ -1,0 +1,46 @@
+"""
+In-memory store for the latest social-room routing_debug per room.
+
+Hub writes a snapshot here after every social-room chat turn (bridge or
+direct).  The UI polls GET /api/social-room/inspection/latest so the Social
+Inspection panel can render even when the turn was routed through the bridge
+rather than the Hub WebSocket.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("orion-hub.social-room-inspection")
+
+# room_id → { routing_debug, stored_at, room_id }
+_latest: Dict[str, Dict[str, Any]] = {}
+
+
+def store(room_id: str, routing_debug: Dict[str, Any]) -> None:
+    """Record the latest routing_debug for a completed social-room turn."""
+    if not room_id or not routing_debug:
+        return
+    _latest[room_id] = {
+        "routing_debug": routing_debug,
+        "stored_at": datetime.now(timezone.utc).isoformat(),
+        "room_id": room_id,
+    }
+    logger.info(
+        "social_room_inspection_stored room_id=%s social_inspection_present=%s",
+        room_id,
+        bool(routing_debug.get("social_inspection")),
+    )
+
+
+def get(room_id: str) -> Optional[Dict[str, Any]]:
+    """Return the latest snapshot for a specific room, or None."""
+    return _latest.get(room_id)
+
+
+def get_latest() -> Optional[Dict[str, Any]]:
+    """Return the most recently stored snapshot across all rooms."""
+    if not _latest:
+        return None
+    return max(_latest.values(), key=lambda v: v["stored_at"])

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -11209,4 +11209,28 @@ loadDismissedIds();
     });
   }
 
+  // ─────────────────────────────────────────────────────────────────────
+  // Social Room Inspection — bridge-turn polling
+  // Polls /api/social-room/inspection/latest every 8 s so the Social
+  // Inspection panel updates for turns routed through the bridge (which
+  // bypass the Hub WebSocket used for direct UI turns).
+  // ─────────────────────────────────────────────────────────────────────
+  let _socialInspectionPollLastStoredAt = null;
+  async function _pollSocialRoomInspection() {
+    if (!socialInspectionApi.shouldShowSocialInspection) return;
+    try {
+      const res = await fetch('/api/social-room/inspection/latest');
+      if (!res.ok) return;
+      const data = await res.json();
+      if (!data || !data.routing_debug || !data.stored_at) return;
+      if (data.stored_at === _socialInspectionPollLastStoredAt) return;
+      _socialInspectionPollLastStoredAt = data.stored_at;
+      syncSocialInspectionFromRouteDebug(data.routing_debug);
+    } catch (_) {
+      // network hiccup — ignore, will retry next interval
+    }
+  }
+  setInterval(_pollSocialRoomInspection, 8000);
+
 });
+

--- a/services/orion-social-room-bridge/app/service.py
+++ b/services/orion-social-room-bridge/app/service.py
@@ -126,38 +126,136 @@ class SocialRoomBridgeService:
 
     def normalize_callsyne_message(self, payload: Dict[str, Any]) -> CallSyneRoomMessageV1:
         room = payload.get("room") if isinstance(payload.get("room"), dict) else {}
+        message_obj = payload.get("message") if isinstance(payload.get("message"), dict) else {}
         sender = payload.get("sender") if isinstance(payload.get("sender"), dict) else {}
         metadata = dict(payload.get("metadata") or {})
         channel_key = payload.get("channel_key") if payload.get("channel_key") is not None else payload.get("channelKey")
         room_id = str(
             payload.get("room_id")
+            or payload.get("roomId")
+            or payload.get("RoomId")
             or room.get("id")
             or channel_key
             or metadata.get("channel_key")
             or metadata.get("channelKey")
             or ""
         ).strip()
-        thread_id = payload.get("thread_id") or payload.get("thread") or metadata.get("thread_id")
-        message_id = str(payload.get("message_id") or payload.get("id") or "").strip()
-        sender_id = str(payload.get("sender_id") or sender.get("id") or "").strip()
-        sender_name = payload.get("sender_name") or sender.get("name")
-        sender_kind = payload.get("sender_kind") or sender.get("kind") or metadata.get("sender_kind") or "peer_ai"
-        text = str(payload.get("text") or payload.get("content") or "").strip()
-        reply_to_message_id = payload.get("reply_to_message_id") or metadata.get("reply_to_message_id")
-        reply_to_sender_id = payload.get("reply_to_sender_id") or metadata.get("reply_to_sender_id")
-        target_participant_id = payload.get("target_participant_id") or metadata.get("target_participant_id") or reply_to_sender_id
-        target_participant_name = payload.get("target_participant_name") or metadata.get("target_participant_name")
-        mentioned_participant_ids = payload.get("mentioned_participant_ids") or metadata.get("mentioned_participant_ids") or []
-        mentioned_participant_names = payload.get("mentioned_participant_names") or metadata.get("mentioned_participant_names") or []
+        thread_id = (
+            payload.get("thread_id")
+            or payload.get("threadId")
+            or payload.get("ThreadId")
+            or payload.get("thread")
+            or metadata.get("thread_id")
+            or metadata.get("threadId")
+            or message_obj.get("thread_id")
+            or message_obj.get("threadId")
+            or message_obj.get("ThreadId")
+        )
+        message_id = str(
+            payload.get("message_id")
+            or payload.get("messageId")
+            or payload.get("MessageId")
+            or payload.get("id")
+            or message_obj.get("id")
+            or message_obj.get("message_id")
+            or message_obj.get("messageId")
+            or message_obj.get("MessageId")
+            or ""
+        ).strip()
+        sender_id = str(
+            payload.get("sender_id")
+            or payload.get("senderId")
+            or payload.get("SenderId")
+            or sender.get("id")
+            or message_obj.get("sender_id")
+            or message_obj.get("senderId")
+            or message_obj.get("SenderId")
+            or ""
+        ).strip()
+        sender_name = (
+            payload.get("sender_name")
+            or payload.get("senderName")
+            or payload.get("SenderName")
+            or sender.get("name")
+            or message_obj.get("sender_name")
+            or message_obj.get("senderName")
+            or message_obj.get("SenderName")
+        )
+        sender_kind = (
+            payload.get("sender_kind")
+            or payload.get("senderKind")
+            or payload.get("SenderKind")
+            or sender.get("kind")
+            or metadata.get("sender_kind")
+            or metadata.get("senderKind")
+            or message_obj.get("sender_kind")
+            or message_obj.get("senderKind")
+            or message_obj.get("SenderKind")
+            or "peer_ai"
+        )
+        text = str(
+            payload.get("text")
+            or payload.get("content")
+            or payload.get("Text")
+            or payload.get("Content")
+            or message_obj.get("text")
+            or message_obj.get("content")
+            or message_obj.get("Text")
+            or message_obj.get("Content")
+            or ""
+        ).strip()
+        reply_to_message_id = (
+            payload.get("reply_to_message_id")
+            or payload.get("replyToMessageId")
+            or metadata.get("reply_to_message_id")
+            or metadata.get("replyToMessageId")
+        )
+        reply_to_sender_id = (
+            payload.get("reply_to_sender_id")
+            or payload.get("replyToSenderId")
+            or metadata.get("reply_to_sender_id")
+            or metadata.get("replyToSenderId")
+        )
+        target_participant_id = (
+            payload.get("target_participant_id")
+            or payload.get("targetParticipantId")
+            or metadata.get("target_participant_id")
+            or metadata.get("targetParticipantId")
+            or reply_to_sender_id
+        )
+        target_participant_name = (
+            payload.get("target_participant_name")
+            or payload.get("targetParticipantName")
+            or metadata.get("target_participant_name")
+            or metadata.get("targetParticipantName")
+        )
+        mentioned_participant_ids = (
+            payload.get("mentioned_participant_ids")
+            or payload.get("mentionedParticipantIds")
+            or metadata.get("mentioned_participant_ids")
+            or metadata.get("mentionedParticipantIds")
+            or []
+        )
+        mentioned_participant_names = (
+            payload.get("mentioned_participant_names")
+            or payload.get("mentionedParticipantNames")
+            or metadata.get("mentioned_participant_names")
+            or metadata.get("mentionedParticipantNames")
+            or []
+        )
         mentions_orion = bool(
             payload.get("mentions_orion")
+            or payload.get("mentionsOrion")
             or metadata.get("mentions_orion")
+            or metadata.get("mentionsOrion")
             or self.settings.social_bridge_self_name.lower() in text.lower()
         )
         created_at = (
             payload.get("created_at")
+            or payload.get("createdAt")
             or payload.get("timestamp")
             or payload.get("sent_at")
+            or payload.get("sentAt")
             or _utcnow_iso()
         )
         normalized = CallSyneRoomMessageV1(
@@ -381,7 +479,35 @@ class SocialRoomBridgeService:
             message.message_id,
             session_id,
         )
-        hub_result = await self.hub_client.chat(payload=hub_payload, session_id=session_id)
+        try:
+            hub_result = await self.hub_client.chat(payload=hub_payload, session_id=session_id)
+        except Exception as exc:
+            # Allow webhook retries to re-attempt this message when upstream chat times out/fails.
+            self._seen.pop(dedupe_key, None)
+            correlation_id = str(uuid4())
+            skip_reason = "hub_timeout" if isinstance(exc, httpx.TimeoutException) else "hub_request_failed"
+            logger.warning(
+                "room_hub_chat_failed room_id=%s message_id=%s correlation_id=%s reason=%s error=%s",
+                message.room_id,
+                message.message_id,
+                correlation_id,
+                skip_reason,
+                exc,
+            )
+            await self._publish(
+                self.settings.room_skipped_channel,
+                "external.room.turn.skipped.v1",
+                self._skip_event(message, skip_reason, correlation_id=correlation_id, decision=decision),
+            )
+            if self.settings.social_bridge_return_2xx_on_delivery_failure:
+                return {
+                    "status": "delivery_failed",
+                    "reason": skip_reason,
+                    "message_id": message.message_id,
+                    "correlation_id": correlation_id,
+                    "error": str(exc),
+                }
+            raise
         reply_text = str(hub_result.get("text") or "").strip()
         gif_policy = reconcile_gif_policy_with_reply_text(policy=gif_policy, reply_text=reply_text)
         correlation_id = str(hub_result.get("correlation_id") or uuid4())

--- a/services/orion-social-room-bridge/tests/test_bridge_service.py
+++ b/services/orion-social-room-bridge/tests/test_bridge_service.py
@@ -58,6 +58,12 @@ class _FailingCallSyneClient(_FakeCallSyneClient):
         raise RuntimeError("post failed")
 
 
+class _FailingHubClient(_FakeHubClient):
+    async def chat(self, *, payload, session_id: str):
+        self.calls.append((payload, session_id))
+        raise TimeoutError("hub timed out")
+
+
 class _FakeBus:
     enabled = True
 
@@ -1517,6 +1523,89 @@ def test_normalize_channel_key_in_metadata() -> None:
     assert msg.room_id == "zip-123-social"
 
 
+def test_normalize_camel_case_callsyne_payload_fields() -> None:
+    svc = SocialRoomBridgeService(
+        settings=_settings(SOCIAL_BRIDGE_ROOM_ALLOWLIST="world"),
+        hub_client=_FakeHubClient(),
+        callsyne_client=_FakeCallSyneClient(),
+        bus=_FakeBus(),
+    )
+    msg = svc.normalize_callsyne_message(
+        {
+            "roomId": "world",
+            "threadId": "thread-camel-1",
+            "messageId": "m-camel-1",
+            "senderId": "peer-camel",
+            "senderName": "Camel Peer",
+            "senderKind": "peer_ai",
+            "text": "@Orion hello from camel case",
+            "mentionsOrion": True,
+            "createdAt": "2026-05-09T07:20:00Z",
+        }
+    )
+    assert msg.room_id == "world"
+    assert msg.message_id == "m-camel-1"
+    assert msg.sender_id == "peer-camel"
+    assert msg.mentions_orion is True
+
+    result = asyncio.run(
+        svc.process_callsyne_message(
+            {
+                "roomId": "world",
+                "messageId": "m-camel-2",
+                "senderId": "peer-camel",
+                "senderName": "Camel Peer",
+                "text": "@Orion can you hear me?",
+                "mentionsOrion": True,
+            }
+        )
+    )
+    assert result["status"] == "ok"
+    assert result["message_id"] == "m-camel-2"
+
+
+def test_normalize_pascal_case_and_nested_message_payload_fields() -> None:
+    svc = SocialRoomBridgeService(
+        settings=_settings(SOCIAL_BRIDGE_ROOM_ALLOWLIST="world"),
+        hub_client=_FakeHubClient(),
+        callsyne_client=_FakeCallSyneClient(),
+        bus=_FakeBus(),
+    )
+    msg = svc.normalize_callsyne_message(
+        {
+            "RoomId": "world",
+            "message": {
+                "id": "m-nested-1",
+                "text": "@Orion nested message shape",
+                "senderId": "peer-nested",
+                "senderName": "Nested Peer",
+            },
+            "mentionsOrion": True,
+        }
+    )
+    assert msg.room_id == "world"
+    assert msg.message_id == "m-nested-1"
+    assert msg.text == "@Orion nested message shape"
+    assert msg.sender_id == "peer-nested"
+
+    result = asyncio.run(
+        svc.process_callsyne_message(
+            {
+                "RoomId": "world",
+                "message": {
+                    "id": "m-nested-2",
+                    "text": "@Orion nested live",
+                    "senderId": "peer-nested",
+                    "senderName": "Nested Peer",
+                },
+                "mentionsOrion": True,
+            }
+        )
+    )
+    assert result["status"] == "ok"
+    assert result["message_id"] == "m-nested-2"
+
+
 def test_callsyne_bridge_post_body_minimal_and_media_hint() -> None:
     req = ExternalRoomPostRequestV1(
         platform="callsyne",
@@ -1595,6 +1684,29 @@ def test_delivery_failure_raises_when_disabled() -> None:
         assert False, "expected RuntimeError"
     except RuntimeError:
         pass
+
+
+def test_hub_timeout_returns_structured_200_payload_and_allows_retry() -> None:
+    bus = _FakeBus()
+    failing_hub = _FailingHubClient()
+    callsyne = _FakeCallSyneClient()
+    svc = SocialRoomBridgeService(
+        settings=_settings(SOCIAL_BRIDGE_RETURN_2XX_ON_DELIVERY_FAILURE=True),
+        hub_client=failing_hub,
+        callsyne_client=callsyne,
+        bus=bus,
+    )
+
+    first = asyncio.run(svc.process_callsyne_message(_payload(message_id="msg-hub-timeout-1")))
+    assert first["status"] == "delivery_failed"
+    assert first["reason"] == "hub_request_failed"
+    assert callsyne.posts == []
+
+    # Swap in healthy hub and send same message ID again; dedupe should not block retry.
+    svc.hub_client = _FakeHubClient(reply_text="Recovered reply after timeout.")
+    second = asyncio.run(svc.process_callsyne_message(_payload(message_id="msg-hub-timeout-1")))
+    assert second["status"] == "ok"
+    assert len(callsyne.posts) == 1
 
 
 def test_polling_fallback_dedupes_and_skips_self_messages() -> None:


### PR DESCRIPTION
# PR: CallSyne Bridge Integration Hardening + Social Inspection Panel Live Polling

**Branch:** `feat/social-room-bridge-callsyne-integration` → `main`

---

## Summary

- Hardens the `orion-social-room-bridge` → CallSyne webhook contract to survive any casing variant the CallSyne team ships (snake_case, camelCase, PascalCase, nested `message.*` fields).
- Adds graceful Hub-timeout recovery so a slow Cortex response returns a structured `delivery_failed` 200 rather than crashing the ASGI process and silently eating retries.
- Closes the Social Inspection panel blind spot: bridge-routed `@orion` turns now populate the Hub UI panel within 8 s via a new poll endpoint, matching the experience operators get from direct Hub WebSocket turns.

---

## Changes

### `services/orion-social-room-bridge`

**`app/service.py`**
- `normalize_callsyne_message` now tries `room_id` → `roomId` → `RoomId`, `message_id` → `messageId`, `sender_id` → `senderId`, `thread_id` → `threadId`, and `message.id` / `message.text` nested variants before falling back to empty string. Mirrors CallSyne's real-world payload shapes.
- `process_callsyne_message` wraps `hub_client.chat` in `try/except`. On `httpx.TimeoutException` or any other exception:
  - Evicts the dedupe key so the next CallSyne retry is accepted.
  - Publishes `room_turn_skipped` with `skip_reason=hub_timeout` or `hub_request_failed`.
  - Returns HTTP 200 `{ "status": "delivery_failed" }` so CallSyne's retry logic can proceed cleanly.

**`tests/test_bridge_service.py`**
- `test_normalize_camel_case_callsyne_payload_fields` — camelCase field extraction
- `test_normalize_pascal_case_and_nested_message_payload_fields` — PascalCase + nested `message.*`
- `test_hub_timeout_returns_structured_200_payload_and_allows_retry` — `_FailingHubClient` fixture simulates `TimeoutError`; asserts first call returns `delivery_failed` and a retry from the same message succeeds

### `services/orion-hub`

**`scripts/social_room_inspection_cache.py`** _(new)_
- In-memory store (`dict` keyed by `room_id`) holding the latest `routing_debug` + `stored_at` ISO timestamp after each social-room turn.
- `store(room_id, routing_debug)` / `get(room_id)` / `get_latest()`.

**`scripts/api_routes.py`**
- After every social-room `/api/chat` turn, extracts `external_room.room_id` and writes `routing_debug` to the inspection cache.
- New `GET /api/social-room/inspection/latest?room_id=<optional>` endpoint — returns `{ routing_debug, stored_at, room_id }` or null fields when no turn has been seen yet.

**`static/js/app.js`**
- `setInterval(_pollSocialRoomInspection, 8000)` — polls the new endpoint; compares `stored_at` against the last seen value and calls `syncSocialInspectionFromRouteDebug(data.routing_debug)` only when a newer turn arrives. No-ops gracefully on network errors.

---

## Test Plan

- [ ] `pytest services/orion-social-room-bridge/tests/test_bridge_service.py` — all normalization + timeout tests pass
- [ ] Send a synthetic webhook with camelCase fields; confirm bridge returns 200 and Orion replies
- [ ] Kill Hub mid-turn (or lower `HUB_TIMEOUT_SEC`); confirm bridge returns 200 `delivery_failed`, no ASGI crash, log shows `hub_timeout`
- [ ] With bridge running, tag `@orion` in the CallSyne world room; within 8 s the Hub UI Social Inspection panel should populate with routing + gif sections
- [ ] `GET /api/social-room/inspection/latest` before any turn → `{ routing_debug: null, stored_at: null, room_id: null }`
- [ ] `GET /api/social-room/inspection/latest` after a bridge turn → `social_inspection_present: true`, `sections ≥ 1`
