### PR TITLE
Feat/hub mind memory graph

### DIFF
--- a/PR_HUB_MIND_MEMORY_GRAPH.md
+++ b/PR_HUB_MIND_MEMORY_GRAPH.md
@@ -1,0 +1,39 @@
+# Hub: Orion Mind tab + memory graph reliability
+
+## Summary
+
+This branch delivers **Orion Mind** visibility in the Hub (tab, modal drill-down, recent-run analytics) and **memory graph** hardening across recall/GraphDB paths, client-side suggest UX, and Hub-side failover when the default LLM lane times out. It also wires **Mind** correctly through the chat stack (session headers, optional `mind_enabled` metadata into cortex requests) and documents local **orion-mind** connectivity in orch’s example env.
+
+> **Note:** Relative to `origin/main`, this branch’s history also includes several **design specs**, a **social-room-bridge** webhook hardening commit, and an earlier **memory/recall** guardrails fix. If the goal is a narrowly scoped Hub-only merge, consider rebasing onto `main` and dropping unrelated commits before merge.
+
+## Orion Mind (Hub + orch)
+
+- **Mind tab UI:** Recent Mind runs, filters, safe analytics presentation, modal for run detail (`feat(hub): implement Mind tab…`).
+- **API correctness:** `X-Orion-Session-Id` is read as a proper **header** on Mind list/get/correlation routes so browser `fetch` matches FastAPI expectations (`fix(hub): correct Mind route ordering…`).
+- **Cortex request path:** When the client sends `context.metadata.mind_enabled === true`, Hub forwards **`mind_enabled: true`** into cortex chat metadata so orch can enable Mind for that turn.
+- **Configuration:** `.env_example` sets **`ORION_MIND_BASE_URL=http://orion-mind:6611`** as the documented default for compose-style deployments.
+
+## Memory graph
+
+- **Hub `memory_graph_suggest`:** After the first cortex chat result, if the effective text looks like a **timeout** and the client did not pin **`llm_route`**, Hub **retries once** with **`options.llm_route = "quick"`** and annotates routing debug (`memory_graph_retry_quick`, reason snippet). Reduces pain when the default **chat** lane on Circe is slow or down while **quick** is healthy.
+- **Main chat UI (`app.js`):** Memory graph bridge builder uses **input budgets** (total + per-turn caps), a **client-side timeout** for the suggest `fetch`, and clearer handling when the model returns empty or clipped input.
+- **Memory subview (`memory.js`):** Standalone memory graph suggest uses **bounded prompt length**, **AbortController** timeout, and user-visible notes when input was clipped.
+- **Markup:** Minor **`index.html`** wrapper fix so the Mind runs modal sits in a valid DOM tree.
+
+## Tests
+
+- `test_handle_chat_request_turn_effect.py` — `memory_graph_suggest` timeout-shaped responses trigger quick retry; no retry when `llm_route` is already set; fixtures satisfy `CortexClientResult` shape.
+- `test_memory_graph_bridge_ui.py` — extended coverage for bridge / suggest behavior.
+- `test_mind_hub_tab.py` — Mind tab expectations updated for current UI/API.
+
+## How to verify
+
+1. Hub: open **Mind** tab, confirm recent runs load with session header; open a run in the modal.
+2. Memory graph: from chat **Memory graph** bridge or Memory subview, run **Propose draft** with a long transcript — observe clipping note if applicable; with default lane timing out, confirm a second attempt can succeed on **quick** (check Hub logs for `memory_graph_suggest_retry_quick`).
+3. With dev venv per `AGENTS.md`:  
+   `PYTHONPATH=. ./orion_dev/bin/python -m pytest tests/test_handle_chat_request_turn_effect.py tests/test_memory_graph_bridge_ui.py tests/test_mind_hub_tab.py -q`
+
+## Risk / rollout
+
+- **Quick retry** only runs when timeout-like text is detected and **`llm_route` is unset**; explicit client routing is respected.
+- **Orchestrator** must reach **orion-mind** where Mind is used; update real `.env` from `.env_example` as needed (do not commit secrets).

--- a/docs/superpowers/specs/2026-05-09-frontier-buddy-fast-training-design.md
+++ b/docs/superpowers/specs/2026-05-09-frontier-buddy-fast-training-design.md
@@ -1,0 +1,114 @@
+# Frontier Buddy Fast Training Design (Approach B)
+
+## Context
+Frontier Buddy training readiness exists across two rails in this repository:
+- Topic Foundry (`services/orion-topic-foundry`) supports topic clustering model runs and artifacts.
+- ChatGPT QLoRA SFT (`scripts/run_chatgpt_qlora_sft.py`, `orion/training/chatgpt_qlora/*`) supports adapter training/eval flows.
+
+This design targets the fastest realistic path to train Frontier Buddy with real data while minimizing setup and runtime risk.
+
+## Goal
+Deliver a minimal, real (non-simulated) training run for Frontier Buddy that:
+- Uses a small sample from Postgres `chat_gpt_derived_example` rows.
+- Produces adapter artifacts and training/eval manifests.
+- Is visible through the Hub-facing flow as a completed run with lineage.
+
+## Scope
+### In scope
+- Small bounded extraction from Postgres using `import_run_ids` plus a strict record limit.
+- Foundry dataset/partition build with existing routing policy enforcement.
+- Tiny real QLoRA training run (small step budget).
+- Eval pass that writes base vs adapter output comparisons.
+- Hub visibility verification for run/artifact presence.
+
+### Out of scope
+- Hyperparameter search and tuning.
+- Large-corpus training.
+- Model quality benchmarking beyond smoke-level sanity checks.
+- Refactoring unrelated services or training architecture.
+
+## Architecture
+The runtime path is:
+1. Extract a bounded real sample from Postgres.
+2. Build dataset and foundry partitions.
+3. Run real QLoRA training with minimal step budget.
+4. Run eval on held-out prompts.
+5. Verify Hub-visible run/artifact lineage.
+
+This keeps the path close to production behavior while constraining runtime and risk.
+
+## Components and Responsibilities
+### Data sampler
+- Reads from `chat_gpt_derived_example` via configured `postgres_uri`.
+- Restricts rows by `import_run_ids` and hard row limit.
+- Emits deterministic run metadata (source IDs, run name, timestamps).
+
+### Foundry partitioner
+- Uses `orion/training/chatgpt_qlora/foundry.py`.
+- Preserves policy that `frontier_oracle` requires rewrite before direct SFT.
+- Produces partitioned artifacts and manifests.
+
+### QLoRA trainer
+- Uses real path in `orion/training/chatgpt_qlora/trainer.py` (not `--simulate`).
+- Runs with minimal compute settings (small batch, low `max_steps`, frequent checkpoints).
+- Writes adapter and training manifest artifacts.
+
+### Evaluator
+- Uses `orion/training/chatgpt_qlora/eval.py`.
+- Produces base vs adapter output snapshots and eval manifest.
+
+### Hub visibility checker
+- Uses existing Hub-facing path for topic/training visibility.
+- Confirms latest run completion state and artifact lineage are observable.
+
+## Data Flow
+1. **Extract** a bounded Postgres sample.
+2. **Build** canonical dataset and foundry outputs.
+3. **Train** a tiny real QLoRA adapter run.
+4. **Evaluate** against held-out prompts.
+5. **Expose and verify** run + artifact lineage in Hub.
+
+## Constraints and Success Criteria
+### Constraints
+- Must be real training mode (no simulation).
+- Must keep `frontier_oracle` rewrite-first routing invariant.
+- Must finish in short runtime window suitable for smoke execution.
+
+### Success criteria
+- `run-all` command completes in real mode.
+- Training manifest status is real completion (not simulated).
+- Adapter artifact directory exists and is non-empty.
+- Eval manifest exists with base and adapter outputs.
+- Hub-visible path confirms new run/artifact lineage presence.
+
+## Error Handling Strategy
+### Preflight (fail fast)
+- Abort early on missing GPU/runtime training dependencies.
+- Abort on invalid Postgres connectivity or empty extraction window.
+- Abort on missing required config keys for source, limits, and run identity.
+
+### Runtime (preserve evidence)
+- If dataset/foundry stage fails, keep partial manifests and phase-specific error.
+- If training fails, keep generated upstream artifacts and mark run failed.
+- If eval fails post-training, preserve training artifacts and mark eval-specific failure state.
+
+## Verification Plan
+1. Run focused command for real-mode `run-all` with tiny config.
+2. Confirm training manifest and adapter artifact outputs exist.
+3. Confirm eval manifest includes side-by-side outputs.
+4. Confirm Hub-facing visibility check sees latest run/artifact lineage.
+5. Keep routing invariant checks green for `frontier_oracle` rewrite-before-SFT behavior.
+
+## Risks and Mitigations
+- **Risk:** Tiny data and low step budget produce weak quality signals.
+  - **Mitigation:** Treat this phase as operational readiness, not quality validation.
+- **Risk:** Environment drift (GPU/deps) causes flaky first run.
+  - **Mitigation:** enforce preflight checks and explicit dependency failures.
+- **Risk:** Hub visibility path lags or caches stale run data.
+  - **Mitigation:** verify with explicit latest-run query/check after training completes.
+
+## Follow-on Plan Boundary
+After this design is accepted and implemented, the next planning cycle can cover:
+- Data window expansion.
+- Controlled hyperparameter sweeps.
+- Frontier Buddy-specific eval rubric and quality gates.

--- a/services/orion-cortex-orch/.env_example
+++ b/services/orion-cortex-orch/.env_example
@@ -75,7 +75,7 @@ ORION_AUTO_EXTRACTOR_STAGE2_ENABLED=false
 ORION_AUTO_EXTRACTOR_AUTO_PROMOTE_THRESHOLD=2
 
 # --- Orion Mind (HTTP to services/orion-mind; Hub enables via context.metadata mind_enabled only through Orch) ---
-ORION_MIND_BASE_URL=
+ORION_MIND_BASE_URL=http://orion-mind:6611
 ORION_MIND_TIMEOUT_SEC=45
 MIND_N_LOOPS_DEFAULT=1
 MIND_WALL_MS_DEFAULT=120000

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -1636,6 +1636,63 @@ def _workflow_is_metadata_only(workflow: Dict[str, Any] | None) -> bool:
     return workflow_id == "dream_cycle"
 
 
+def _memory_graph_timeout_hint(raw_result: Dict[str, Any] | None, text: str | None) -> str:
+    parts: List[str] = []
+    if isinstance(text, str) and text.strip():
+        parts.append(text.strip())
+    raw = raw_result if isinstance(raw_result, dict) else {}
+    top_error = raw.get("error")
+    if top_error is not None:
+        parts.append(str(top_error))
+    final_text = raw.get("final_text")
+    if isinstance(final_text, str) and final_text.strip():
+        parts.append(final_text.strip())
+    steps = raw.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            step_error = step.get("error")
+            if step_error is not None:
+                parts.append(str(step_error))
+            result = step.get("result")
+            if not isinstance(result, dict):
+                continue
+            for block in result.values():
+                if not isinstance(block, dict):
+                    continue
+                content = block.get("content")
+                if content is not None:
+                    parts.append(str(content))
+                block_error = block.get("error")
+                if block_error is not None:
+                    parts.append(str(block_error))
+    merged: List[str] = []
+    for item in parts:
+        normalized = str(item or "").strip()
+        if normalized and normalized not in merged:
+            merged.append(normalized)
+    return " | ".join(merged)
+
+
+def _should_retry_memory_graph_quick(
+    req: CortexChatRequest,
+    *,
+    raw_result: Dict[str, Any] | None,
+    text: str | None,
+) -> Tuple[bool, str]:
+    if str(req.verb or "").strip().lower() != "memory_graph_suggest":
+        return False, ""
+    options = req.options if isinstance(req.options, dict) else {}
+    if str(options.get("llm_route") or "").strip():
+        return False, ""
+    hint = _memory_graph_timeout_hint(raw_result, text)
+    lower = hint.lower()
+    if "timed out" in lower or "timeout" in lower:
+        return True, hint
+    return False, ""
+
+
 async def handle_chat_request(
     cortex_client,
     payload: dict,
@@ -1774,6 +1831,37 @@ async def handle_chat_request(
 
         # Extract Text — prefer longest answer if top-level vs nested diverge (parity with curl `raw.final_text`)
         text = hub_effective_chat_text(resp)
+
+        should_retry_quick, retry_hint = _should_retry_memory_graph_quick(
+            req,
+            raw_result=raw_result,
+            text=text,
+        )
+        if should_retry_quick:
+            retry_req = req.model_copy(deep=True)
+            retry_options = dict(retry_req.options or {})
+            retry_options["llm_route"] = "quick"
+            retry_options["memory_graph_retry_from"] = "chat_timeout"
+            retry_req.options = retry_options
+            retry_corr_id = str(uuid4())
+            logger.warning(
+                "memory_graph_suggest_retry_quick corr=%s retry_corr=%s reason=%s",
+                corr_id,
+                retry_corr_id,
+                (retry_hint or "")[:240],
+            )
+            resp = await cortex_client.chat(retry_req, correlation_id=retry_corr_id)
+            raw_result = resp.cortex_result.model_dump(mode="json")
+            text = hub_effective_chat_text(resp)
+            corr_id = retry_corr_id
+            if isinstance(route_debug, dict):
+                route_debug = dict(route_debug)
+                route_debug["memory_graph_retry_quick"] = True
+                route_debug["memory_graph_retry_reason"] = (retry_hint or "")[:240]
+                route_debug_options = dict(route_debug.get("options") or {})
+                route_debug_options["llm_route"] = "quick"
+                route_debug_options["memory_graph_retry_from"] = "chat_timeout"
+                route_debug["options"] = route_debug_options
 
         # Use the correlation_id from the response (gateway) if available
         # or it might be passed back from the client logic if modified to do so.

--- a/services/orion-hub/scripts/cortex_request_builder.py
+++ b/services/orion-hub/scripts/cortex_request_builder.py
@@ -421,6 +421,10 @@ def build_cortex_chat_request(
     mutation_cognition_context = payload.get("mutation_cognition_context")
     if isinstance(mutation_cognition_context, dict) and mutation_cognition_context:
         metadata["mutation_cognition_context"] = mutation_cognition_context
+    _client_context = payload.get("context")
+    _client_meta = _client_context.get("metadata") if isinstance(_client_context, dict) else None
+    if isinstance(_client_meta, dict) and _client_meta.get("mind_enabled") is True:
+        metadata["mind_enabled"] = True
     draft_ac = build_answer_contract_draft_for_hub(prompt)
     metadata["answer_contract_draft"] = draft_ac
     logger.info(

--- a/services/orion-hub/scripts/mind_routes.py
+++ b/services/orion-hub/scripts/mind_routes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Header, HTTPException, Query, Request
 
 from .session import ensure_session
 
@@ -36,7 +36,7 @@ async def list_recent_mind_runs(
     trigger: Optional[str] = Query(None, min_length=1, max_length=64),
     error_code: Optional[str] = Query(None, min_length=1, max_length=128),
     router_profile_id: Optional[str] = Query(None, min_length=1, max_length=128),
-    x_orion_session_id: Optional[str] = None,
+    x_orion_session_id: Optional[str] = Header(None, alias="X-Orion-Session-Id"),
 ) -> dict[str, Any]:
     session_id = await _need_session(x_orion_session_id)
     pool = _pool(request)
@@ -163,7 +163,7 @@ async def list_recent_mind_runs(
 
 
 @router.get("/api/mind/runs/{mind_run_id}")
-async def get_mind_run(mind_run_id: str, request: Request, x_orion_session_id: Optional[str] = None) -> dict[str, Any]:
+async def get_mind_run(mind_run_id: str, request: Request, x_orion_session_id: Optional[str] = Header(None, alias="X-Orion-Session-Id")) -> dict[str, Any]:
     session_id = await _need_session(x_orion_session_id)
     pool = _pool(request)
     async with pool.acquire() as conn:
@@ -187,7 +187,7 @@ async def list_mind_runs(
     request: Request,
     correlation_id: str = Query(..., min_length=4),
     limit: int = Query(50, ge=1, le=200),
-    x_orion_session_id: Optional[str] = None,
+    x_orion_session_id: Optional[str] = Header(None, alias="X-Orion-Session-Id"),
 ) -> list[dict[str, Any]]:
     session_id = await _need_session(x_orion_session_id)
     pool = _pool(request)

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -467,6 +467,9 @@ loadDismissedIds();
   let memoryGraphBridgeAnchorDiv = null;
   const MEMORY_GRAPH_BRIDGE_MAX_TURNS_CAP = 80;
   const MEMORY_GRAPH_BRIDGE_MAX_TURNS_DEFAULT = 40;
+  const MEMORY_GRAPH_SUGGEST_TIMEOUT_MS = 45000;
+  const MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS = 12000;
+  const MEMORY_GRAPH_SUGGEST_INPUT_PER_TURN_CHARS = 1800;
   const LS_MEMORY_GRAPH_BRIDGE_MAX_TURNS = 'orion_memory_graph_bridge_max_turns';
   let memoryGraphBridgeDraftViz = null;
   const RECALL_CANARY_PROFILE_STORAGE_KEY = 'orion_recall_canary_profile_v1';
@@ -5945,13 +5948,36 @@ loadDismissedIds();
     const lines = [];
     lines.push('Structured transcript evidence for memory graph extraction (do not invent turns).');
     lines.push('');
-    turns.forEach((t, i) => {
+    let remaining = MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS;
+    let clippedTurns = 0;
+    let omittedTurns = 0;
+    for (let i = 0; i < turns.length; i += 1) {
+      const t = turns[i];
       const id = t.turnId;
       const role = t.role || 'unknown';
       lines.push(`--- turn ${i + 1} id=${id} role=${role} ---`);
-      lines.push(t.text || '');
+      if (remaining <= 0) {
+        lines.push('[omitted: input budget exhausted]');
+        lines.push('');
+        omittedTurns += 1;
+        continue;
+      }
+      const raw = String(t.text || '');
+      const perTurn = raw.length > MEMORY_GRAPH_SUGGEST_INPUT_PER_TURN_CHARS
+        ? `${raw.slice(0, MEMORY_GRAPH_SUGGEST_INPUT_PER_TURN_CHARS)}…`
+        : raw;
+      if (perTurn.length < raw.length) clippedTurns += 1;
+      const capped = perTurn.length > remaining ? `${perTurn.slice(0, Math.max(0, remaining - 1))}…` : perTurn;
+      if (capped.length < perTurn.length) clippedTurns += 1;
+      lines.push(capped);
       lines.push('');
-    });
+      remaining -= capped.length;
+    }
+    if (clippedTurns > 0 || omittedTurns > 0) {
+      lines.push(
+        `[Input clipped for reliability: clipped_turns=${clippedTurns}, omitted_turns=${omittedTurns}, max_total_chars=${MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS}, max_per_turn_chars=${MEMORY_GRAPH_SUGGEST_INPUT_PER_TURN_CHARS}]`
+      );
+    }
     lines.push('Emit utterance_ids matching the ids above; fill utterance_text_by_id with excerpts.');
     return lines.join('\n');
   }
@@ -6564,11 +6590,27 @@ loadDismissedIds();
             'Content-Type': 'application/json',
             ...(orionSessionId ? { 'X-Orion-Session-Id': orionSessionId } : {}),
           };
-          const res = await fetch(`${API_BASE_URL}/api/chat`, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify(payload),
-          });
+          const controller = typeof AbortController === 'function' ? new AbortController() : null;
+          const timerId = controller
+            ? setTimeout(() => {
+              try {
+                controller.abort();
+              } catch (_) {
+                /* ignore */
+              }
+            }, MEMORY_GRAPH_SUGGEST_TIMEOUT_MS)
+            : null;
+          let res;
+          try {
+            res = await fetch(`${API_BASE_URL}/api/chat`, {
+              method: 'POST',
+              headers,
+              body: JSON.stringify(payload),
+              ...(controller ? { signal: controller.signal } : {}),
+            });
+          } finally {
+            if (timerId != null) clearTimeout(timerId);
+          }
           const text = await res.text();
           let data = null;
           try {
@@ -6611,7 +6653,13 @@ loadDismissedIds();
               : 'Empty response — check gateway / model logs.';
           }
         } catch (err) {
-          if (statusEl) statusEl.textContent = String(err.message || err);
+          if (statusEl) {
+            if (err && err.name === 'AbortError') {
+              statusEl.textContent = `Suggest timed out after ${Math.round(MEMORY_GRAPH_SUGGEST_TIMEOUT_MS / 1000)}s. Try fewer turns or retry when the model gateway is responsive.`;
+            } else {
+              statusEl.textContent = String(err.message || err);
+            }
+          }
         } finally {
           suggestBtn.disabled = false;
           suggestBtn.textContent = prevLabel;
@@ -8105,7 +8153,11 @@ loadDismissedIds();
       updateStatus(`Switched to ${modeLabel} mode.`);
     });
   });
-  const defaultModeButton = Array.from(modeButtons).find((btn) => (btn.dataset.mode || 'brain') === currentMode && !btn.dataset.verbOverride)
+  const defaultModeButton = Array.from(modeButtons).find((btn) =>
+    (btn.dataset.mode || 'brain') === currentMode
+    && (btn.dataset.verbOverride || null) === modeVerbOverride
+  )
+    || Array.from(modeButtons).find((btn) => (btn.dataset.mode || 'brain') === currentMode && !btn.dataset.verbOverride)
     || modeButtons[0];
   applyModeButtonSelection(defaultModeButton);
 

--- a/services/orion-hub/static/js/memory.js
+++ b/services/orion-hub/static/js/memory.js
@@ -4,6 +4,8 @@
   const pathSegments = window.location.pathname.split("/").filter((p) => p.length > 0);
   const URL_PREFIX = pathSegments.length > 0 ? `/${pathSegments[0]}` : "";
   const API_BASE = window.location.origin + URL_PREFIX;
+  const MEMORY_GRAPH_SUGGEST_TIMEOUT_MS = 45000;
+  const MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS = 12000;
 
   function sessionHeader() {
     const sid = localStorage.getItem("orion_sid");
@@ -52,6 +54,17 @@
     }
     if (typeof detail === "string") return detail;
     return (err && err.message) || "Request failed";
+  }
+
+  function boundedSuggestPrompt(raw) {
+    const text = String(raw || "");
+    if (text.length <= MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS) {
+      return { value: text, clipped: false };
+    }
+    return {
+      value: `${text.slice(0, MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS)}…`,
+      clipped: true,
+    };
   }
 
   function showSubview(review, all, log, key) {
@@ -335,15 +348,37 @@
           const raw =
             draftTa.value.trim() ||
             "Draft a structured memory-graph JSON object for this session (ontology_version, entities, situations, edges). Output only JSON.";
+          const bounded = boundedSuggestPrompt(raw);
           const headers = { "Content-Type": "application/json", ...sessionHeader() };
           const payload = {
             mode: "brain",
             verbs: ["memory_graph_suggest"],
-            messages: [{ role: "user", content: raw }],
+            messages: [{ role: "user", content: bounded.value }],
             use_recall: false,
             no_write: true,
           };
-          const res = await fetch(`${API_BASE}/api/chat`, { method: "POST", headers, body: JSON.stringify(payload) });
+          const controller = typeof AbortController === "function" ? new AbortController() : null;
+          const timerId =
+            controller != null
+              ? setTimeout(() => {
+                  try {
+                    controller.abort();
+                  } catch (_) {
+                    /* ignore */
+                  }
+                }, MEMORY_GRAPH_SUGGEST_TIMEOUT_MS)
+              : null;
+          let res;
+          try {
+            res = await fetch(`${API_BASE}/api/chat`, {
+              method: "POST",
+              headers,
+              body: JSON.stringify(payload),
+              ...(controller ? { signal: controller.signal } : {}),
+            });
+          } finally {
+            if (timerId != null) clearTimeout(timerId);
+          }
           const text = await res.text();
           let data = null;
           try {
@@ -380,12 +415,26 @@
             {
               ok: true,
               note: draftText
-                ? "Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate."
+                ? bounded.clipped
+                  ? `Replaced the box with the model reply. Prompt input was clipped to ${MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS} chars to avoid model gateway timeouts.`
+                  : "Replaced the box with the model reply. If prose wrapped the JSON, delete the wrapper lines and use Validate."
                 : "Empty response — check gateway / model logs.",
             },
             false
           );
         } catch (e) {
+          if (e && e.name === "AbortError") {
+            graphSetOut(
+              {
+                ok: false,
+                error: `Suggest timed out after ${Math.round(
+                  MEMORY_GRAPH_SUGGEST_TIMEOUT_MS / 1000
+                )}s. Try fewer turns or retry when the model gateway is responsive.`,
+              },
+              true
+            );
+            return;
+          }
           graphSetOut(e.message || String(e), true);
         }
       });

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -1473,6 +1473,7 @@
         </section>
       </div>
     </div>
+  </div>
 
   <div id="mindRunsModal" class="hidden fixed inset-0 z-[74] bg-black/80 p-4 md:p-8" aria-hidden="true">
     <div class="mx-auto flex h-full w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-950 shadow-2xl">
@@ -1498,7 +1499,6 @@
         </div>
       </div>
     </div>
-  </div>
   </div>
 
   <div id="scheduleEditModal" class="hidden fixed inset-0 z-[71] bg-black/80 p-4 md:p-8" aria-hidden="true">

--- a/services/orion-hub/tests/test_handle_chat_request_turn_effect.py
+++ b/services/orion-hub/tests/test_handle_chat_request_turn_effect.py
@@ -57,6 +57,78 @@ class _ReasoningBrainClient:
         return CortexChatResult(cortex_result=result, final_text="brain")
 
 
+class _MemoryGraphRetryClient:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def chat(self, req, correlation_id=None):
+        options = dict(req.options or {})
+        self.calls.append(options)
+        if str(options.get("llm_route") or "").strip().lower() == "quick":
+            result = CortexClientResult(
+                ok=True,
+                mode="brain",
+                verb="memory_graph_suggest",
+                status="success",
+                final_text='{"ontology_version":"orionmem-2026-05","utterance_ids":["t1"]}',
+                correlation_id=correlation_id or "corr-mg-retry",
+            )
+            return CortexChatResult(cortex_result=result, final_text=result.final_text)
+
+        result = CortexClientResult(
+            ok=True,
+            mode="brain",
+            verb="memory_graph_suggest",
+            status="success",
+            final_text="",
+            steps=[
+                {
+                    "step_name": "llm_memory_graph_suggest",
+                    "verb_name": "memory_graph_suggest",
+                    "order": 0,
+                    "status": "success",
+                    "result": {
+                        "LLMGatewayService": {
+                            "content": "[Error: llamacpp timed out after waiting]",
+                        }
+                    },
+                }
+            ],
+            correlation_id=correlation_id or "corr-mg-initial",
+        )
+        return CortexChatResult(cortex_result=result, final_text="")
+
+
+class _MemoryGraphNoRetryClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def chat(self, req, correlation_id=None):
+        self.calls += 1
+        result = CortexClientResult(
+            ok=True,
+            mode="brain",
+            verb="memory_graph_suggest",
+            status="success",
+            final_text="",
+            steps=[
+                {
+                    "step_name": "llm_memory_graph_suggest",
+                    "verb_name": "memory_graph_suggest",
+                    "order": 0,
+                    "status": "success",
+                    "result": {
+                        "LLMGatewayService": {
+                            "content": "[Error: llamacpp timed out after waiting]",
+                        }
+                    },
+                }
+            ],
+            correlation_id=correlation_id or "corr-mg-no-retry",
+        )
+        return CortexChatResult(cortex_result=result, final_text="")
+
+
 def test_handle_chat_request_exports_turn_effect_into_result_payload() -> None:
     payload = {"mode": "brain", "messages": [{"role": "user", "content": "hello"}]}
     out = asyncio.run(handle_chat_request(_TurnEffectClient(), payload, "sid-1", no_write=True))
@@ -78,6 +150,39 @@ def test_handle_chat_request_preserves_brain_reasoning_trace() -> None:
     out = asyncio.run(handle_chat_request(_ReasoningBrainClient(), payload, "sid-brain", no_write=True))
     assert out["reasoning_trace"]["content"] == "brain trace"
     assert out["reasoning_content"] is None
+
+
+def test_handle_chat_request_retries_memory_graph_suggest_on_timeout() -> None:
+    client = _MemoryGraphRetryClient()
+    payload = {
+        "mode": "brain",
+        "verbs": ["memory_graph_suggest"],
+        "messages": [{"role": "user", "content": "memory graph test"}],
+        "use_recall": False,
+        "no_write": True,
+    }
+    out = asyncio.run(handle_chat_request(client, payload, "sid-mg-retry", no_write=True))
+    assert len(client.calls) == 2
+    assert client.calls[0].get("llm_route") is None
+    assert client.calls[1].get("llm_route") == "quick"
+    assert out["text"].startswith('{"ontology_version"')
+    assert out["routing_debug"]["memory_graph_retry_quick"] is True
+    assert out["routing_debug"]["options"]["llm_route"] == "quick"
+
+
+def test_handle_chat_request_does_not_retry_memory_graph_with_explicit_llm_route() -> None:
+    client = _MemoryGraphNoRetryClient()
+    payload = {
+        "mode": "brain",
+        "verbs": ["memory_graph_suggest"],
+        "messages": [{"role": "user", "content": "memory graph test"}],
+        "options": {"llm_route": "quick"},
+        "use_recall": False,
+        "no_write": True,
+    }
+    out = asyncio.run(handle_chat_request(client, payload, "sid-mg-no-retry", no_write=True))
+    assert client.calls == 1
+    assert out["text"] == ""
 
 
 def test_handle_chat_request_records_first_class_pressure_events(monkeypatch) -> None:

--- a/services/orion-hub/tests/test_memory_graph_bridge_ui.py
+++ b/services/orion-hub/tests/test_memory_graph_bridge_ui.py
@@ -41,6 +41,12 @@ def test_app_js_wires_memory_graph_bridge_handlers() -> None:
     assert "hub-utterance:" in app_js
     assert "rebuildMemoryGraphBridgeTurnList" in app_js
     assert "memoryGraphBridgeAnchorDiv" in app_js
+    assert "MEMORY_GRAPH_SUGGEST_TIMEOUT_MS" in app_js
+    assert "MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS" in app_js
+    assert "MEMORY_GRAPH_SUGGEST_INPUT_PER_TURN_CHARS" in app_js
+    assert "Input clipped for reliability" in app_js
+    assert "AbortController" in app_js
+    assert "Suggest timed out" in app_js
 
 
 def test_memory_js_listens_for_bridge_import_event() -> None:
@@ -48,3 +54,9 @@ def test_memory_js_listens_for_bridge_import_event() -> None:
     assert 'orion-hub-memory-graph-draft-import' in memory_js
     assert "orion_memory_graph_draft_import" in memory_js
     assert "OrionMemoryGraphDraftUI" in memory_js
+    assert "MEMORY_GRAPH_SUGGEST_TIMEOUT_MS" in memory_js
+    assert "MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS" in memory_js
+    assert "boundedSuggestPrompt" in memory_js
+    assert "Prompt input was clipped" in memory_js
+    assert "AbortController" in memory_js
+    assert "Suggest timed out" in memory_js

--- a/services/orion-hub/tests/test_mind_hub_tab.py
+++ b/services/orion-hub/tests/test_mind_hub_tab.py
@@ -20,6 +20,15 @@ INDEX_HTML = HUB_ROOT / "templates" / "index.html"
 APP_JS = HUB_ROOT / "static" / "js" / "app.js"
 
 
+def test_mind_runs_modal_is_sibling_of_schedule_modal_not_nested() -> None:
+    """mindRunsModal must not live under #scheduleModal.hidden or it never paints."""
+    index_html = INDEX_HTML.read_text(encoding="utf-8")
+    assert (
+        'id="scheduleModalHistory"' in index_html
+        and "</section>\n      </div>\n    </div>\n  </div>\n\n  <div id=\"mindRunsModal\"" in index_html
+    ), "scheduleModal shell must close (three divs) before mindRunsModal in index.html"
+
+
 def test_index_has_mind_tab_and_panel() -> None:
     index_html = INDEX_HTML.read_text(encoding="utf-8")
     assert 'id="mindTabButton"' in index_html


### PR DESCRIPTION
# Hub: Orion Mind tab + memory graph reliability

## Summary

This branch delivers **Orion Mind** visibility in the Hub (tab, modal drill-down, recent-run analytics) and **memory graph** hardening across recall/GraphDB paths, client-side suggest UX, and Hub-side failover when the default LLM lane times out. It also wires **Mind** correctly through the chat stack (session headers, optional `mind_enabled` metadata into cortex requests) and documents local **orion-mind** connectivity in orch’s example env.

> **Note:** Relative to `origin/main`, this branch’s history also includes several **design specs**, a **social-room-bridge** webhook hardening commit, and an earlier **memory/recall** guardrails fix. If the goal is a narrowly scoped Hub-only merge, consider rebasing onto `main` and dropping unrelated commits before merge.

## Orion Mind (Hub + orch)

- **Mind tab UI:** Recent Mind runs, filters, safe analytics presentation, modal for run detail (`feat(hub): implement Mind tab…`).
- **API correctness:** `X-Orion-Session-Id` is read as a proper **header** on Mind list/get/correlation routes so browser `fetch` matches FastAPI expectations (`fix(hub): correct Mind route ordering…`).
- **Cortex request path:** When the client sends `context.metadata.mind_enabled === true`, Hub forwards **`mind_enabled: true`** into cortex chat metadata so orch can enable Mind for that turn.
- **Configuration:** `.env_example` sets **`ORION_MIND_BASE_URL=http://orion-mind:6611`** as the documented default for compose-style deployments.

## Memory graph

- **Hub `memory_graph_suggest`:** After the first cortex chat result, if the effective text looks like a **timeout** and the client did not pin **`llm_route`**, Hub **retries once** with **`options.llm_route = "quick"`** and annotates routing debug (`memory_graph_retry_quick`, reason snippet). Reduces pain when the default **chat** lane on Circe is slow or down while **quick** is healthy.
- **Main chat UI (`app.js`):** Memory graph bridge builder uses **input budgets** (total + per-turn caps), a **client-side timeout** for the suggest `fetch`, and clearer handling when the model returns empty or clipped input.
- **Memory subview (`memory.js`):** Standalone memory graph suggest uses **bounded prompt length**, **AbortController** timeout, and user-visible notes when input was clipped.
- **Markup:** Minor **`index.html`** wrapper fix so the Mind runs modal sits in a valid DOM tree.

## Tests

- `test_handle_chat_request_turn_effect.py` — `memory_graph_suggest` timeout-shaped responses trigger quick retry; no retry when `llm_route` is already set; fixtures satisfy `CortexClientResult` shape.
- `test_memory_graph_bridge_ui.py` — extended coverage for bridge / suggest behavior.
- `test_mind_hub_tab.py` — Mind tab expectations updated for current UI/API.

## How to verify

1. Hub: open **Mind** tab, confirm recent runs load with session header; open a run in the modal.
2. Memory graph: from chat **Memory graph** bridge or Memory subview, run **Propose draft** with a long transcript — observe clipping note if applicable; with default lane timing out, confirm a second attempt can succeed on **quick** (check Hub logs for `memory_graph_suggest_retry_quick`).
3. With dev venv per `AGENTS.md`:  
   `PYTHONPATH=. ./orion_dev/bin/python -m pytest tests/test_handle_chat_request_turn_effect.py tests/test_memory_graph_bridge_ui.py tests/test_mind_hub_tab.py -q`

## Risk / rollout

- **Quick retry** only runs when timeout-like text is detected and **`llm_route` is unset**; explicit client routing is respected.
- **Orchestrator** must reach **orion-mind** where Mind is used; update real `.env` from `.env_example` as needed (do not commit secrets).
