### PR TITLE
Feat/llamacpp qwen3 thinking b8740

### DIFF
--- a/docs/2026-05-09-orion-llamacpp-host-rebuild-design.md
+++ b/docs/2026-05-09-orion-llamacpp-host-rebuild-design.md
@@ -99,3 +99,11 @@ Run against the **same Docker image** intended for production and a **reference 
 ---
 
 **Next step after you approve this file:** invoke **writing-plans** to produce an implementation plan with file-level tasks and verification commands.
+
+---
+
+## Appendix (implementation, 2026-05-10)
+
+- Default CUDA pin raised to **`ghcr.io/ggml-org/llama.cpp:server-cuda-b8740`** (`Dockerfile` / compose / `.env_example`).
+- **`orion-llm-gateway`** forwards **`options.chat_template_kwargs`** on `ChatRequestPayload` to **`llamacpp`** and **`llama-cola`** `/v1/chat/completions` payloads for **per-request** thinking control (no host restart).
+- **Atlas live check:** `services/orion-llamacpp-host/scripts/verify_atlas_quick_llamacpp_thinking_off.sh` with `ATLAS_LLAMACPP_QUICK_URL` + `ATLAS_QUICK_CHAT_MODEL` hits the quick worker’s HTTP API directly.

--- a/services/orion-llamacpp-host/.env_example
+++ b/services/orion-llamacpp-host/.env_example
@@ -10,6 +10,12 @@ SERVICE_VERSION=0.1.1
 
 # Pinned upstream llama.cpp CUDA image tag used at build time.
 LLAMACPP_IMAGE_TAG=server-cuda-b8740
+
+# Optional: Atlas quick-lane llama-server base URL for live thinking checks (no trailing slash).
+# Example: ATLAS_LLAMACPP_QUICK_URL=http://100.121.214.30:8013
+# ATLAS_QUICK_CHAT_MODEL=Qwen_Qwen3-8B-Q4_K_M.gguf
+#ATLAS_LLAMACPP_QUICK_URL=
+#ATLAS_QUICK_CHAT_MODEL=
 ORION_BUS_URL=redis://100.92.216.81:6379/0
 
 # Which profile this single worker service should boot

--- a/services/orion-llamacpp-host/.env_example
+++ b/services/orion-llamacpp-host/.env_example
@@ -9,7 +9,7 @@ SERVICE_NAME=orion-llamacpp-host
 SERVICE_VERSION=0.1.1
 
 # Pinned upstream llama.cpp CUDA image tag used at build time.
-LLAMACPP_IMAGE_TAG=server-cuda-b8660
+LLAMACPP_IMAGE_TAG=server-cuda-b8740
 ORION_BUS_URL=redis://100.92.216.81:6379/0
 
 # Which profile this single worker service should boot

--- a/services/orion-llamacpp-host/Dockerfile
+++ b/services/orion-llamacpp-host/Dockerfile
@@ -1,10 +1,10 @@
 # services/orion-llamacpp-host/Dockerfile
 
 # Pinned target for Qwen3 GGUF support + CUDA image stability.
-# Default pin: server-cuda-b8660 from ghcr.io/ggml-org/llama.cpp (see LLAMACPP_IMAGE_TAG).
+# Default pin: server-cuda-b8740 from ghcr.io/ggml-org/llama.cpp (see LLAMACPP_IMAGE_TAG).
 # Qwen3 capability floor (e.g. --reasoning-budget, --chat-template-kwargs) tracks upstream
 # llama.cpp PRs/changelog, not a single misleading "build number" here—see README + design doc.
-ARG LLAMACPP_IMAGE_TAG=server-cuda-b8660
+ARG LLAMACPP_IMAGE_TAG=server-cuda-b8740
 FROM ghcr.io/ggml-org/llama.cpp:${LLAMACPP_IMAGE_TAG}
 
 # Install Python + pip (base image is minimal)

--- a/services/orion-llamacpp-host/Dockerfile
+++ b/services/orion-llamacpp-host/Dockerfile
@@ -1,8 +1,9 @@
 # services/orion-llamacpp-host/Dockerfile
 
 # Pinned target for Qwen3 GGUF support + CUDA image stability.
-# Qwen docs indicate llama.cpp b5092 as minimum for Qwen3/Qwen3MoE support.
-# We pin above that floor (b5401) rather than tracking HEAD.
+# Default pin: server-cuda-b8660 from ghcr.io/ggml-org/llama.cpp (see LLAMACPP_IMAGE_TAG).
+# Qwen3 capability floor (e.g. --reasoning-budget, --chat-template-kwargs) tracks upstream
+# llama.cpp PRs/changelog, not a single misleading "build number" here—see README + design doc.
 ARG LLAMACPP_IMAGE_TAG=server-cuda-b8660
 FROM ghcr.io/ggml-org/llama.cpp:${LLAMACPP_IMAGE_TAG}
 

--- a/services/orion-llamacpp-host/README.md
+++ b/services/orion-llamacpp-host/README.md
@@ -427,12 +427,12 @@ watch -n 1 nvidia-smi
 
 `services/orion-llamacpp-host/Dockerfile` pins the base to:
 
-- `ghcr.io/ggml-org/llama.cpp:server-cuda-b8660` by default (override with `LLAMACPP_IMAGE_TAG` at build time)
+- `ghcr.io/ggml-org/llama.cpp:server-cuda-b8740` by default (override with `LLAMACPP_IMAGE_TAG` at build time)
 
 Why this pin:
 
 - Qwen3-related flags such as `--reasoning-budget` and `--chat-template-kwargs` follow upstream llama.cpp PRs and release notes; treat the design doc as the narrative source of truth instead of stale single “build number” claims.
-- `server-cuda-b8660` is a fixed non-HEAD CUDA server image tag aligned with the Dockerfile default.
+- `server-cuda-b8740` is a fixed non-HEAD CUDA server image tag aligned with the Dockerfile default (newer than `b8660` on GHCR for Qwen3 thinking / `--reasoning-budget` / `--chat-template-kwargs` fixes).
 - Existing Qwen2/Qwen2.5 GGUF workflows remain in the same llama.cpp runtime family and OpenAI-compatible `llama-server` surface.
 
 After `docker build`, record the exact server binary in ops notes (output varies by image tag):
@@ -455,7 +455,7 @@ docker compose \
 ### Optional explicit build tag override
 
 ```bash
-LLAMACPP_IMAGE_TAG=server-cuda-b8660 docker compose \
+LLAMACPP_IMAGE_TAG=server-cuda-b8740 docker compose \
   --env-file services/orion-llamacpp-host/.env_example \
   -f services/orion-llamacpp-host/docker-compose.yml \
   build orion-llamacpp-host

--- a/services/orion-llamacpp-host/README.md
+++ b/services/orion-llamacpp-host/README.md
@@ -425,15 +425,23 @@ watch -n 1 nvidia-smi
 
 ## Pinned llama.cpp CUDA base image
 
-`services/orion-llamacpp-host/Dockerfile` now pins to:
+`services/orion-llamacpp-host/Dockerfile` pins the base to:
 
-- `ghcr.io/ggerganov/llama.cpp:server-cuda-b5401` (via `LLAMACPP_IMAGE_TAG` build arg)
+- `ghcr.io/ggml-org/llama.cpp:server-cuda-b8660` by default (override with `LLAMACPP_IMAGE_TAG` at build time)
 
 Why this pin:
 
-- Qwen docs list `b5092` as the minimum for Qwen3/Qwen3MoE support.
-- `b5401` is above that floor while remaining a fixed non-HEAD build.
+- Qwen3-related flags such as `--reasoning-budget` and `--chat-template-kwargs` follow upstream llama.cpp PRs and release notes; treat the design doc as the narrative source of truth instead of stale single “build number” claims.
+- `server-cuda-b8660` is a fixed non-HEAD CUDA server image tag aligned with the Dockerfile default.
 - Existing Qwen2/Qwen2.5 GGUF workflows remain in the same llama.cpp runtime family and OpenAI-compatible `llama-server` surface.
+
+After `docker build`, record the exact server binary in ops notes (output varies by image tag):
+
+```bash
+docker run --rm <image> /app/llama-server --version
+```
+
+Replace `<image>` with the tag you built (for example `orion-llamacpp-host:0.1.0`). Paste the printed version into your runbook; do not copy a version string from this README unless you have just run the command and captured real output.
 
 ### Build with the pinned target
 
@@ -447,7 +455,7 @@ docker compose \
 ### Optional explicit build tag override
 
 ```bash
-LLAMACPP_IMAGE_TAG=server-cuda-b5401 docker compose \
+LLAMACPP_IMAGE_TAG=server-cuda-b8660 docker compose \
   --env-file services/orion-llamacpp-host/.env_example \
   -f services/orion-llamacpp-host/docker-compose.yml \
   build orion-llamacpp-host
@@ -455,7 +463,7 @@ LLAMACPP_IMAGE_TAG=server-cuda-b5401 docker compose \
 
 ### Rollback
 
-If regression appears, rollback to prior known-good image tag:
+If regression appears, rollback to your organization’s last known-good base tag. Legacy example (older pin only—replace with the tag you actually used):
 
 ```bash
 LLAMACPP_IMAGE_TAG=server-cuda-b4719 docker compose \
@@ -474,3 +482,26 @@ MODEL_QWEN3_PATH=/mnt/telemetry/llm-cache/gguf/Qwen3-30B-A3B-Q4_K_M.gguf \
 IMAGE=orion-llamacpp-host:0.1.0 \
 services/orion-llamacpp-host/scripts/validate_llamacpp_upgrade.sh
 ```
+
+### Verifying thinking off after upgrade
+
+Design background: [docs/2026-05-09-orion-llamacpp-host-rebuild-design.md](../../docs/2026-05-09-orion-llamacpp-host-rebuild-design.md).
+
+Fast checks (no live GPU endpoint required beyond what the tests already expect):
+
+```bash
+./scripts/test_service.sh orion-llamacpp-host services/orion-llamacpp-host/tests/ -q --tb=short
+```
+
+Live verification against a running container and GGUF on disk (script added in a follow-up task; env vars below are the intended contract):
+
+```bash
+IMAGE=orion-llamacpp-host:0.1.0 \
+MODEL_QWEN3_PATH=/path/to/your/Qwen3.gguf \
+CUDA_VISIBLE_DEVICES=0 \
+bash services/orion-llamacpp-host/scripts/verify_qwen3_thinking_off_live.sh
+```
+
+- `IMAGE` defaults to `orion-llamacpp-host:0.1.0` if unset.
+- `MODEL_QWEN3_PATH` must point at the Qwen3 GGUF you are validating.
+- `CUDA_VISIBLE_DEVICES` selects the GPU visible inside the check (adjust per host).

--- a/services/orion-llamacpp-host/README.md
+++ b/services/orion-llamacpp-host/README.md
@@ -493,7 +493,7 @@ Fast checks (no live GPU endpoint required beyond what the tests already expect)
 ./scripts/test_service.sh orion-llamacpp-host services/orion-llamacpp-host/tests/ -q --tb=short
 ```
 
-Live verification against a running container and GGUF on disk (script added in a follow-up task; env vars below are the intended contract):
+Live verification against a **local Docker** build and GGUF on disk:
 
 ```bash
 IMAGE=orion-llamacpp-host:0.1.0 \
@@ -505,3 +505,13 @@ bash services/orion-llamacpp-host/scripts/verify_qwen3_thinking_off_live.sh
 - `IMAGE` defaults to `orion-llamacpp-host:0.1.0` if unset.
 - `MODEL_QWEN3_PATH` must point at the Qwen3 GGUF you are validating.
 - `CUDA_VISIBLE_DEVICES` selects the GPU visible inside the check (adjust per host).
+
+**Atlas quick lane (live, no Docker):** hit the **running** `llama-server` on the Hub/quick worker (Tailscale or host IP, port from `ATLAS_FAST_HOST_PORT`, usually `8013`). Per-request `chat_template_kwargs` is sent in the JSON body so thinking can be forced off **without** restarting the worker (requires `server-cuda-b8740`+ class binary and Qwen3-capable profile).
+
+```bash
+export ATLAS_LLAMACPP_QUICK_URL=http://<atlas-host>:8013
+export ATLAS_QUICK_CHAT_MODEL=<exact-model-id-the-server-uses>
+bash services/orion-llamacpp-host/scripts/verify_atlas_quick_llamacpp_thinking_off.sh
+```
+
+**Via `orion-llm-gateway` (bus):** callers may pass `options.chat_template_kwargs` (e.g. `{"enable_thinking": false}`) on `ChatRequestPayload`; the gateway forwards that field to `llamacpp` / `llama-cola` OpenAI-compatible backends on each request.

--- a/services/orion-llamacpp-host/docker-compose.atlas-workers.yml
+++ b/services/orion-llamacpp-host/docker-compose.atlas-workers.yml
@@ -9,7 +9,7 @@ services:
       context: ../..
       dockerfile: services/orion-llamacpp-host/Dockerfile
       args:
-        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b8660}
+        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b8740}
     image: orion-llamacpp-host:0.1.0
     container_name: ${PROJECT:-orion}-atlas-llamacpp-chat
     restart: unless-stopped
@@ -49,7 +49,7 @@ services:
       context: ../..
       dockerfile: services/orion-llamacpp-host/Dockerfile
       args:
-        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b8660}
+        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b8740}
     image: orion-llamacpp-host:0.1.0
     container_name: ${PROJECT:-orion}-atlas-llamacpp-metacog
     restart: unless-stopped
@@ -88,7 +88,7 @@ services:
       context: ../..
       dockerfile: services/orion-llamacpp-host/Dockerfile
       args:
-        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b8660}
+        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b8740}
     image: orion-llamacpp-host:0.1.0
     container_name: ${PROJECT:-orion}-atlas-llamacpp-fast
     restart: unless-stopped
@@ -128,7 +128,7 @@ services:
       context: ../..
       dockerfile: services/orion-llamacpp-host/Dockerfile
       args:
-        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b8660}
+        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b8740}
     image: orion-llamacpp-host:0.1.0
     container_name: ${PROJECT:-orion}-atlas-llamacpp-agent
     restart: unless-stopped

--- a/services/orion-llamacpp-host/docker-compose.yml
+++ b/services/orion-llamacpp-host/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: ../..
       dockerfile: services/orion-llamacpp-host/Dockerfile
       args:
-        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b5401}
+        - LLAMACPP_IMAGE_TAG=${LLAMACPP_IMAGE_TAG:-server-cuda-b8740}
     env_file:
       - .env
     image: orion-llamacpp-host:0.1.0

--- a/services/orion-llamacpp-host/scripts/goldens/README.md
+++ b/services/orion-llamacpp-host/scripts/goldens/README.md
@@ -1,0 +1,30 @@
+# Goldens and forbidden markers
+
+This directory holds small, checked-in artifacts used by `verify_qwen3_thinking_off_live.sh`.
+
+## `forbidden_thinking_markers.txt`
+
+Case-sensitive substrings that must **not** appear in the assistant `content` when the server is started with thinking disabled (`--reasoning-budget 0`, `--chat-template-kwargs '{"enable_thinking":false}'`, and matching per-request `chat_template_kwargs` where applicable). The list is intentionally short and conservative: it targets delimiter strings that commonly appear when a Qwen3-class model emits a **thinking** trace (see upstream discussion around [PR #13196](https://github.com/ggml-org/llama.cpp/pull/13196) and Qwen3 templates), not vague English substrings (avoid bare `think`, which matches normal prose).
+
+If you change any of the following, re-run the live script on a GPU host and **review** whether this file still matches real failure modes (or causes false positives):
+
+- **`LLAMACPP_IMAGE_TAG` / rebuilt `orion-llamacpp-host` image** — template or tokenizer behavior can shift delimiters.
+- **Reference Qwen3 GGUF** — different quant or checkpoint may change how thinking leaks into `content`.
+
+## How to refresh or extend markers
+
+1. Run the live verifier (from repo root or any cwd; use absolute `MODEL_QWEN3_PATH`):
+
+   ```bash
+   export MODEL_QWEN3_PATH=/absolute/path/to/your/Qwen3.gguf
+   export IMAGE=orion-llamacpp-host:0.1.0   # optional
+   bash services/orion-llamacpp-host/scripts/verify_qwen3_thinking_off_live.sh
+   ```
+
+2. If Gate B fails because a **new** thinking delimiter appears in `content`, add a **single literal substring** per line to `forbidden_thinking_markers.txt` (document the source: upstream issue, PR, or a one-line paste from your capture). Prefer tags or reserved tokens over vague words.
+
+3. If a marker causes **false positives** on your pin/GGUF (legitimate text contains the substring), remove or narrow that line and re-run until the script passes.
+
+4. Commit updated `forbidden_thinking_markers.txt` together with any README tweaks.
+
+Optional future golden files (e.g. `qwen3-*_thinking_off_completion.json`) can live here following the same refresh discipline.

--- a/services/orion-llamacpp-host/scripts/goldens/forbidden_thinking_markers.txt
+++ b/services/orion-llamacpp-host/scripts/goldens/forbidden_thinking_markers.txt
@@ -1,0 +1,3 @@
+redacted_thinking
+<think>
+</think>

--- a/services/orion-llamacpp-host/scripts/validate_llamacpp_upgrade.sh
+++ b/services/orion-llamacpp-host/scripts/validate_llamacpp_upgrade.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Validates a built orion-llamacpp-host image for:
 # 1) pinned build tag/version visibility
 # 2) CUDA availability
@@ -92,4 +94,11 @@ echo "[6/7] llama-server startup (Qwen3)"
 run_server_boot "${MODEL_QWEN3_PATH}" "qwen3"
 
 echo "[7/7] Basic inference checks complete for both model families."
-echo "Done. Review output for any changed warnings/flags." 
+
+if [[ "${VERIFY_QWEN3_THINKING_OFF:-}" == "1" && -n "${MODEL_QWEN3_PATH:-}" ]]; then
+  echo "[optional] Qwen3 thinking-off live gates (VERIFY_QWEN3_THINKING_OFF=1)"
+  IMAGE="${IMAGE}" MODEL_QWEN3_PATH="${MODEL_QWEN3_PATH}" CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES}" \
+    bash "${SCRIPT_DIR}/verify_qwen3_thinking_off_live.sh"
+fi
+
+echo "Done. Review output for any changed warnings/flags."

--- a/services/orion-llamacpp-host/scripts/verify_atlas_quick_llamacpp_thinking_off.sh
+++ b/services/orion-llamacpp-host/scripts/verify_atlas_quick_llamacpp_thinking_off.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Live check: Atlas quick-lane (or any) llama-server — chat completion with per-request
+# chat_template_kwargs.enable_thinking=false must not leak thinking delimiter substrings.
+#
+# Requires: curl, jq. No Docker.
+#
+#   export ATLAS_LLAMACPP_QUICK_URL=http://<tailscale-or-host>:8013   # no trailing slash
+#   export ATLAS_QUICK_CHAT_MODEL=Qwen_Qwen3-8B-Q4_K_M.gguf         # must match server model id
+#   bash services/orion-llamacpp-host/scripts/verify_atlas_quick_llamacpp_thinking_off.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE="${ATLAS_LLAMACPP_QUICK_URL:?ERROR: set ATLAS_LLAMACPP_QUICK_URL (e.g. http://100.x.x.x:8013)}"
+MODEL="${ATLAS_QUICK_CHAT_MODEL:?ERROR: set ATLAS_QUICK_CHAT_MODEL (GGUF filename as known to llama-server)}"
+
+BASE="${BASE%/}"
+MARKER="LIVE-ATLAS-QUICK-NO-THINK-OK"
+
+echo "POST ${BASE}/v1/chat/completions model=${MODEL}"
+
+resp="$(jq -n \
+  --arg model "$MODEL" \
+  --arg marker "$MARKER" \
+  '{
+    model: $model,
+    messages: [{role: "user", content: ("Reply with exactly: " + $marker)}],
+    max_tokens: 96,
+    temperature: 0.2,
+    chat_template_kwargs: {enable_thinking: false}
+  }' | curl -fsS -X POST "${BASE}/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d @-)"
+
+content="$(printf '%s' "$resp" | jq -r '.choices[0].message.content // empty')"
+if [[ "$content" != *"$MARKER"* ]]; then
+  echo "ERROR: expected marker in assistant content" >&2
+  printf '%s\n' "$resp" >&2
+  exit 1
+fi
+
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  [[ -z "${line}" || "${line}" == \#* ]] && continue
+  if printf '%s' "$content" | grep -Fq -- "$line"; then
+    echo "ERROR: forbidden thinking marker in content: ${line}" >&2
+    printf '%s\n' "$resp" >&2
+    exit 1
+  fi
+done < "${SCRIPT_DIR}/goldens/forbidden_thinking_markers.txt"
+
+echo "verify_atlas_quick_llamacpp_thinking_off.sh: OK"

--- a/services/orion-llamacpp-host/scripts/verify_qwen3_thinking_off_live.sh
+++ b/services/orion-llamacpp-host/scripts/verify_qwen3_thinking_off_live.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Live Gates A/B: Qwen3 with thinking disabled (argv + per-request kwargs).
+# Requires Docker, GPU (--gpus all), jq, curl. MODEL_QWEN3_PATH must point to a Qwen3 GGUF on the host.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE="${IMAGE:-orion-llamacpp-host:0.1.0}"
+CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+PORT="${PORT:-18081}"
+MODEL_QWEN3_PATH="${MODEL_QWEN3_PATH:-}"
+
+if [[ -z "${MODEL_QWEN3_PATH}" ]]; then
+  echo "ERROR: MODEL_QWEN3_PATH must be set to an absolute path to a Qwen3 GGUF on the host." >&2
+  exit 1
+fi
+if [[ ! -f "${MODEL_QWEN3_PATH}" ]]; then
+  echo "ERROR: MODEL_QWEN3_PATH not found: ${MODEL_QWEN3_PATH}" >&2
+  exit 1
+fi
+
+model_dir="$(dirname "${MODEL_QWEN3_PATH}")"
+model_file="$(basename "${MODEL_QWEN3_PATH}")"
+
+echo "Gate A: POST /apply-template (PR #13196-style body, enable_thinking false)"
+echo "Gate B: POST /v1/chat/completions (marker + forbidden substrings from goldens/)"
+echo "IMAGE=${IMAGE} PORT=${PORT} MODEL_FILE=${model_file}"
+
+docker run --rm --gpus all \
+  -e CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES}" \
+  -p "${PORT}:8080" \
+  -v "${model_dir}:/models-ro:ro" \
+  -v "${SCRIPT_DIR}/goldens:/goldens-ro:ro" \
+  --entrypoint /bin/bash "${IMAGE}" -lc "\
+set -euo pipefail; \
+/app/llama-server -m /models-ro/${model_file} --host 0.0.0.0 --port 8080 --n-gpu-layers 99 --ctx-size 1024 \
+  --jinja --reasoning-budget 0 --chat-template-kwargs '{\"enable_thinking\":false}' \
+  > /tmp/qwen3-thinking-off-server.log 2>&1 & \
+pid=\$!; \
+for _ in \$(seq 1 60); do \
+  if curl -fsS http://127.0.0.1:8080/health >/dev/null 2>&1; then break; fi; \
+  sleep 1; \
+done; \
+curl -fsS http://127.0.0.1:8080/health >/dev/null; \
+jq -n --arg model \"${model_file}\" --arg msg 'Give me a short introduction to large language models.' \
+'{model: \$model, messages: [{role: \"user\", content: \$msg}], temperature: 0.7, top_p: 0.8, top_k: 20, max_tokens: 8192, presence_penalty: 1.5, chat_template_kwargs: {enable_thinking: false}}' \
+| curl -fsS -X POST http://127.0.0.1:8080/apply-template -H 'Content-Type: application/json' -d @- \
+| jq -e '.prompt != null and (.prompt|length) > 20' >/dev/null; \
+resp=\$(jq -n --arg model \"${model_file}\" \
+'{model: \$model, messages: [{role: \"user\", content: \"Reply with exactly: LIVE-GATE-B-OK\"}], max_tokens: 64, temperature: 0.2, chat_template_kwargs: {enable_thinking: false}}' \
+| curl -fsS -X POST http://127.0.0.1:8080/v1/chat/completions -H 'Content-Type: application/json' -d @-); \
+content=\$(printf '%s' \"\${resp}\" | jq -r '.choices[0].message.content // empty'); \
+if [[ \"\${content}\" != *\"LIVE-GATE-B-OK\"* ]]; then echo 'Gate B: expected LIVE-GATE-B-OK in assistant content' >&2; printf '%s\n' \"\${resp}\" >&2; kill \${pid} 2>/dev/null || true; wait \${pid} 2>/dev/null || true; exit 1; fi; \
+while IFS= read -r line || [[ -n \"\${line}\" ]]; do \
+  [[ -z \"\${line}\" || \"\${line}\" == \\#* ]] && continue; \
+  if printf '%s' \"\${content}\" | grep -Fq -- \"\${line}\"; then echo \"Gate B: forbidden thinking marker in content: \${line}\" >&2; printf '%s\n' \"\${resp}\" >&2; kill \${pid} 2>/dev/null || true; wait \${pid} 2>/dev/null || true; exit 1; fi; \
+done < /goldens-ro/forbidden_thinking_markers.txt; \
+kill \${pid}; wait \${pid} || true"
+
+echo "verify_qwen3_thinking_off_live.sh: OK"

--- a/services/orion-llm-gateway/README.md
+++ b/services/orion-llm-gateway/README.md
@@ -4,6 +4,8 @@ The **LLM Gateway** provides a unified interface to various LLM backends (OpenAI
 
 It now supports **latent vector emission** for vLLM/llama-cola responses (when the backend returns a spark vector), publishing those latents to the vector writer while leaving semantic embeddings to orion-vector-host.
 
+For **llama.cpp** and **llama-cola** backends, `ChatRequestPayload.options` may include **`chat_template_kwargs`** (e.g. `{"enable_thinking": false}`). The gateway forwards that object to `/v1/chat/completions` so Qwen3-style thinking can be toggled **per request** without restarting the model host.
+
 ## Contracts
 
 ### Consumed Channels

--- a/services/orion-llm-gateway/app/llm_backend.py
+++ b/services/orion-llm-gateway/app/llm_backend.py
@@ -843,6 +843,11 @@ def _execute_openai_chat(
         payload["response_format"] = response_format
     elif opts.get("return_json") and backend_name in ("vllm", "llamacpp", "llama-cola"):
         payload["response_format"] = {"type": "json_object"}
+    # llama.cpp OpenAI server: per-request template kwargs (Qwen3 enable_thinking, etc.) — no worker restart.
+    if backend_name in ("llamacpp", "llama-cola"):
+        ctk = opts.get("chat_template_kwargs")
+        if isinstance(ctk, dict) and ctk:
+            payload["chat_template_kwargs"] = ctk
     # Clean None values
     payload = {k: v for k, v in payload.items() if v is not None}
 

--- a/services/orion-llm-gateway/tests/test_llm_backend.py
+++ b/services/orion-llm-gateway/tests/test_llm_backend.py
@@ -116,6 +116,30 @@ class TestLLMBackendExecution(unittest.TestCase):
         self.assertEqual(payload["response_format"], {"type": "json_object"})
 
     @patch("app.llm_backend._common_http_client")
+    def test_execute_openai_chat_forwards_chat_template_kwargs_for_llamacpp(self, mock_client_factory):
+        mock_client = MagicMock()
+        mock_client_factory.return_value.__enter__.return_value = mock_client
+        mock_client.post.return_value.status_code = 200
+        mock_client.post.return_value.json.return_value = {
+            "choices": [{"message": {"content": "LIVE-GATE-B-OK"}}]
+        }
+
+        body = ChatBody(
+            messages=[ChatMessage(role="user", content="Reply with exactly: LIVE-GATE-B-OK")],
+            options={"chat_template_kwargs": {"enable_thinking": False}, "max_tokens": 64, "temperature": 0.2},
+        )
+        _execute_openai_chat(
+            body=body,
+            model="Qwen_Qwen3-8B-Q4_K_M.gguf",
+            base_url="http://localhost",
+            backend_name="llamacpp",
+        )
+        mock_client.post.assert_called_once()
+        _args, kwargs = mock_client.post.call_args
+        payload = kwargs["json"]
+        self.assertEqual(payload.get("chat_template_kwargs"), {"enable_thinking": False})
+
+    @patch("app.llm_backend._common_http_client")
     def test_execute_openai_chat_passes_response_format_for_llama_cola(self, mock_client_factory):
         # Setup mock
         mock_client = MagicMock()


### PR DESCRIPTION
Problem
Memory graph Suggest draft from the chat bridge could finish with an empty draft and no clear failure: the button returned from “Working…” while the textarea stayed blank. That showed up when /api/chat returned HTTP 200 with only Hub-style errors (error / message, no raw), when the model’s JSON legitimately contained the substring error (the old step scanner treated the whole body as a gateway error), or when text / raw.final_text were empty but the draft still lived under raw.steps.

Changes
memory-graph-draft-ui.js: Narrow gateway-failure detection (no broad /error/ on full LLM content), add raw.steps fallback to recover memory-graph JSON, and treat top-level error + message responses as explicit failures when there is no cortex envelope to parse.
app.js: Apply the same gateway-failure heuristics in extractCortexStepErrorHint so the bridge’s non-coalesce fallback path stays consistent.
Verification
PYTHONPATH=. ./orion_dev/bin/python -m pytest services/orion-hub/tests/test_memory_graph_bridge_ui.py -q --tb=short → 3 passed