### PR TITLE
fix(cortex-exec): skip orion-hub in mesh script skills

### DIFF
--- a/services/orion-cortex-exec/app/verb_adapters.py
+++ b/services/orion-cortex-exec/app/verb_adapters.py
@@ -674,7 +674,13 @@ class SafeCommandRunner:
         self.allowed_commands = set(allowed_commands)
         self.timeout_sec = float(timeout_sec)
 
-    def run(self, command: list[str], *, cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    def run(
+        self,
+        command: list[str],
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         if not command:
             raise PermissionError("empty_command")
         binary = str(command[0]).strip()
@@ -687,14 +693,16 @@ class SafeCommandRunner:
             resolved = shutil.which(base)
         if not resolved:
             raise FileNotFoundError(base)
-        return subprocess.run(
-            [resolved, *command[1:]],
-            capture_output=True,
-            text=True,
-            timeout=self.timeout_sec,
-            check=False,
-            cwd=cwd,
-        )
+        run_kw: dict[str, Any] = {
+            "capture_output": True,
+            "text": True,
+            "timeout": self.timeout_sec,
+            "check": False,
+            "cwd": cwd,
+        }
+        if env is not None:
+            run_kw["env"] = env
+        return subprocess.run([resolved, *command[1:]], **run_kw)
 
 
 def _skill_args(payload: PlanExecutionRequest) -> Dict[str, Any]:
@@ -1972,6 +1980,20 @@ class DockerPruneStoppedContainersVerb(BaseVerb[PlanExecutionRequest, SkillVerbO
         ), []
 
 
+def _mesh_service_scripts_child_env() -> dict[str, str]:
+    """Child env for mesh-utilities scripts invoked from cortex-exec skills.
+
+    Appends ``orion-hub`` to ``EXCLUDE_SERVICES_ADD`` so shared helper scripts
+    stay unchanged while the skills runner skips Hub bring-up and env refresh.
+    """
+    out = os.environ.copy()
+    parts = (out.get("EXCLUDE_SERVICES_ADD") or "").split()
+    if "orion-hub" not in parts:
+        parts.append("orion-hub")
+    out["EXCLUDE_SERVICES_ADD"] = " ".join(parts)
+    return out
+
+
 def _allowlisted_mesh_service_script_paths() -> set[Path]:
     root = self_study_module.REPO_ROOT.resolve()
     return {
@@ -2073,7 +2095,11 @@ async def _run_mesh_util_shell_skill(
     runner = SafeCommandRunner(allowed_commands={"bash"}, timeout_sec=timeout_sec)
 
     def _invoke() -> subprocess.CompletedProcess[str]:
-        return runner.run([bash_bin, str(script_path)], cwd=str(repo_root))
+        return runner.run(
+            [bash_bin, str(script_path)],
+            cwd=str(repo_root),
+            env=_mesh_service_scripts_child_env(),
+        )
 
     try:
         proc = await asyncio.to_thread(_invoke)

--- a/services/orion-cortex-exec/tests/test_skill_verbs.py
+++ b/services/orion-cortex-exec/tests/test_skill_verbs.py
@@ -452,7 +452,10 @@ def test_mesh_up_all_services_runs_allowlisted_script(monkeypatch, tmp_path):
     script_dir = tmp_path / "mesh-utilities" / "common"
     script_dir.mkdir(parents=True)
     script = script_dir / "up_all_services.sh"
-    script.write_text("#!/usr/bin/env bash\necho mesh_up_ok\n", encoding="utf-8")
+    script.write_text(
+        "#!/usr/bin/env bash\nset -u\necho \"EXCLUDE_SERVICES_ADD=${EXCLUDE_SERVICES_ADD:-}\"\necho mesh_up_ok\n",
+        encoding="utf-8",
+    )
     script.chmod(0o755)
     monkeypatch.setattr(verb_adapters.self_study_module, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(verb_adapters.settings, "skills_allow_mesh_service_scripts", True)
@@ -463,14 +466,19 @@ def test_mesh_up_all_services_runs_allowlisted_script(monkeypatch, tmp_path):
     data = json.loads(out.final_text)
     assert out.ok is True
     assert data["status"] == "success"
-    assert "mesh_up_ok" in (data.get("stdout_stderr_tail") or "")
+    tail = data.get("stdout_stderr_tail") or ""
+    assert "orion-hub" in tail
+    assert "mesh_up_ok" in tail
 
 
 def test_mesh_refresh_service_envs_runs_allowlisted_script(monkeypatch, tmp_path):
     script_dir = tmp_path / "mesh-utilities" / "common"
     script_dir.mkdir(parents=True)
     script = script_dir / "refresh_service_envs.sh"
-    script.write_text("#!/usr/bin/env bash\necho env_refresh_ok\n", encoding="utf-8")
+    script.write_text(
+        "#!/usr/bin/env bash\nset -u\necho \"EXCLUDE_SERVICES_ADD=${EXCLUDE_SERVICES_ADD:-}\"\necho env_refresh_ok\n",
+        encoding="utf-8",
+    )
     script.chmod(0o755)
     monkeypatch.setattr(verb_adapters.self_study_module, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(verb_adapters.settings, "skills_allow_mesh_service_scripts", True)
@@ -481,4 +489,6 @@ def test_mesh_refresh_service_envs_runs_allowlisted_script(monkeypatch, tmp_path
     data = json.loads(out.final_text)
     assert out.ok is True
     assert data["status"] == "success"
-    assert "env_refresh_ok" in (data.get("stdout_stderr_tail") or "")
+    tail = data.get("stdout_stderr_tail") or ""
+    assert "orion-hub" in tail
+    assert "env_refresh_ok" in tail


### PR DESCRIPTION
## Summary

Mesh utility skills (`skills.mesh.up_all_services.v1`, `skills.mesh.refresh_service_envs.v1`) run **inside `orion-cortex-exec`**, not in Hub. This change ensures those subprocesses always append **`orion-hub`** to `EXCLUDE_SERVICES_ADD`, so shared `mesh-utilities/common/*.sh` behavior stays the same for manual runs while the **Hub skill runner** path does not rebuild or refresh the Hub stack.

## Changes

- Add `_mesh_service_scripts_child_env()` and pass its merged `env` into the allowlisted bash invocations.
- Extend `SafeCommandRunner.run(..., env=...)` so mesh skills can pass a full child environment without affecting other callers.
- Assert `EXCLUDE_SERVICES_ADD` contains `orion-hub` in the existing mesh skill verb tests.

## Test plan

- [x] `PYTHONPATH=. ./venv/bin/python -m pytest services/orion-cortex-exec/tests/test_skill_verbs.py::test_mesh_up_all_services_runs_allowlisted_script services/orion-cortex-exec/tests/test_skill_verbs.py::test_mesh_refresh_service_envs_runs_allowlisted_script services/orion-cortex-exec/tests/test_skill_verbs.py::test_mesh_up_all_services_policy_blocked -q --tb=short` (3 passed)

## Notes / risks

- If `EXCLUDE_SERVICES` (replace mode) is set on the cortex-exec process, the shell scripts can still replace the full exclude list; this patch only guarantees the **additive** `EXCLUDE_SERVICES_ADD` path.
- Manual CLI runs of the mesh scripts are unchanged unless the operator sets env themselves.