### PR TITLE
feat(bus): Redis Streams work queue and QueueRabbit chassis (Phase 4)

### DIFF
--- a/docs/superpowers/plans/2026-05-13-redis-streams-workqueue-queuerabbit-phase4-implementation.md
+++ b/docs/superpowers/plans/2026-05-13-redis-streams-workqueue-queuerabbit-phase4-implementation.md
@@ -1,0 +1,38 @@
+# 2026-05-13 — Redis Streams WorkQueue + QueueRabbit (Phase 4A/4B)
+
+## Goal
+
+Add **Redis Streams + consumer groups** beside existing **OrionBusAsync PubSub** so one-worker workloads are assigned to exactly one consumer per delivery, with retry, DLQ, pending recovery, and service-level idempotency hooks. PubSub remains for broadcasts and reply channels.
+
+## Doctrine
+
+- **PubSub** tells everyone something happened.
+- **Streams** assign one worker to do the work.
+- Streams are **at-least-once**; exactly-once is not claimed.
+
+## Deliverables
+
+| Artifact | Path |
+|----------|------|
+| Work queue + RPC helper | `orion/core/bus/work_queue.py` |
+| Queue chassis | `orion/core/bus/queue_service_chassis.py` |
+| Unit tests | `tests/test_work_queue.py`, `tests/test_queue_service_chassis.py` |
+
+## Constraints (non-negotiable)
+
+- Do **not** migrate chat, recall, spark, exec, LLM, RDF, or vector traffic in this phase.
+- Do **not** replace `OrionBusAsync` or change its public API.
+- `BaseEnvelope` is frozen — copy envelopes when updating work/retry metadata.
+- `QueueRabbit` subclasses `BaseChassis` (heartbeat, errors, identity, shutdown).
+- `QueueRabbit` uses `OrionBusAsync` for PubSub replies (optional `reply_bus` override for reply publishes only); stream I/O uses a **separate** `RedisStreamWorkQueue` client.
+- `queue_rpc_request`: **subscribe to `reply_channel` before enqueue** (avoid fast-reply races).
+- Decode failures: DLQ + ack if DLQ configured; else leave pending + loud logs.
+- Optional live Redis test gated by `ORION_REDIS_STREAM_TEST_URL`.
+
+## Acceptance
+
+Foundation complete when items 1–12 in the originating task specification are satisfied (unchanged PubSub/Rabbit/Hunter, stream ops, chassis behavior, tests, optional two-consumer integration).
+
+## Execution note
+
+Implemented in-repo per `/executing-plans` request; full step-by-step spec is preserved in the task transcript / agent log.

--- a/docs/superpowers/pr-reports/2026-05-13-phase4-redis-streams-workqueue-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-13-phase4-redis-streams-workqueue-pr.md
@@ -1,0 +1,58 @@
+# PR: Phase 4A/4B — Redis Streams work queue + QueueRabbit chassis
+
+## Branch
+
+- **Head:** `feat/bus-redis-streams-workqueue-phase4` (push to `origin`)
+- **Base:** `main`
+
+Create PR: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/bus-redis-streams-workqueue-phase4
+
+---
+
+## Summary
+
+Adds a **foundation-only** substrate for safe work assignment: **Redis Streams + consumer groups** beside the existing **OrionBusAsync** PubSub bus. PubSub remains the nervous system for broadcasts, telemetry, and reply channels; streams carry **“exactly one consumer should do this job”** workloads with retry, optional DLQ, pending recovery (`XAUTOCLAIM`), and `queue_rpc_request` (subscribe to `reply_to` **before** enqueue to avoid fast-reply races). **No** migration of chat, recall, spark, exec, LLM, RDF, or vector traffic; **no** change to `OrionBusAsync`, Rabbit, or Hunter APIs.
+
+---
+
+## What changed
+
+| Area | Change |
+|------|--------|
+| **`orion/core/bus/work_queue.py`** | `RedisStreamWorkQueue`: `XADD` / `XREADGROUP` / `XACK` / `XPENDING` / `XAUTOCLAIM`, `enqueue`, `requeue`, `send_to_dlq`, `send_malformed_to_dlq`, optional XINFO helpers. **`ReadGroupBatch`**: per-entry decode so one bad envelope in a batch does not strand earlier valid messages. `queue_rpc_request`: subscribe then enqueue; `reply_to` vs `reply_channel` mismatch warning. Owned Redis client closed on `close()`; injected client left open. |
+| **`orion/core/bus/queue_service_chassis.py`** | **`QueueRabbit(BaseChassis)`**: consumer-group loop, handler → optional PubSub reply → ack; retry/requeue and DLQ after `max_attempts`; `not_before` / `expires_at` + `stale_policy`; decode-error path; reply publish failures routed through same retry/DLQ path as handler errors; concurrent mode with **bounded** reads (wait for in-flight capacity); `work_queue.close()` in `_run` `finally`. |
+| **Tests** | `tests/test_work_queue.py`, `tests/test_queue_service_chassis.py`: mocked Redis; batch decode + malformed DLQ coverage; live two-consumer test **skipped** unless `ORION_REDIS_STREAM_TEST_URL` is set. |
+| **Plan** | `docs/superpowers/plans/2026-05-13-redis-streams-workqueue-queuerabbit-phase4-implementation.md` |
+
+---
+
+## API note (callers)
+
+- `RedisStreamWorkQueue.read_group` and `autoclaim` return **`ReadGroupBatch`** (`messages`, `decode_errors`), not a bare `list[StreamMessage]`.
+
+---
+
+## Verification (ran locally)
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+PYTHONPATH=. ./venv/bin/python -m pytest tests/test_work_queue.py tests/test_queue_service_chassis.py -q --tb=short
+# 29 passed, 1 skipped (live Redis test without ORION_REDIS_STREAM_TEST_URL)
+
+PYTHONPATH=. ./venv/bin/python -m compileall -q orion/core/bus/work_queue.py orion/core/bus/queue_service_chassis.py
+```
+
+**Optional live test:** set `ORION_REDIS_STREAM_TEST_URL=redis://localhost:6379/15` and re-run pytest to exercise two consumers, one message.
+
+---
+
+## Risk / follow-up
+
+- **Adoption:** Wire services to `QueueRabbit` + `RedisStreamWorkQueue` in later PRs; this PR does not enable any production queue by default.
+- **Stash:** Local `orion-hub` edits and `scripts/git-stash-table.sh` were stashed before branching from `main` (`git stash list` — pops when you are ready).
+
+---
+
+## Suggested PR title
+
+**feat(bus): Redis Streams work queue + QueueRabbit chassis (Phase 4 foundation)**

--- a/orion/core/bus/queue_service_chassis.py
+++ b/orion/core/bus/queue_service_chassis.py
@@ -1,0 +1,448 @@
+# orion/core/bus/queue_service_chassis.py
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+import traceback
+from datetime import datetime, timezone
+from time import perf_counter
+from typing import Awaitable, Callable
+from uuid import uuid4
+
+from .async_service import OrionBusAsync
+from .bus_schemas import BaseEnvelope
+from .bus_service_chassis import BaseChassis, ChassisConfig
+from .work_queue import (
+    RedisStreamWorkQueue,
+    StreamMessage,
+    extract_work_metadata,
+    _parse_ts,
+)
+
+logger = logging.getLogger("orion.bus.queue_rabbit")
+
+Handler = Callable[[BaseEnvelope], Awaitable[BaseEnvelope | None]]
+
+
+def _consumer_suffix() -> str:
+    return f"{os.getpid()}:{uuid4().hex[:8]}"
+
+
+def _attempt_from_envelope(env: BaseEnvelope) -> int:
+    w = extract_work_metadata(env)
+    raw = w.get("attempt", 1)
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _reply_optional(env: BaseEnvelope) -> bool:
+    w = extract_work_metadata(env)
+    return bool(w.get("reply_optional"))
+
+
+def _not_before_ms(env: BaseEnvelope) -> int | None:
+    w = extract_work_metadata(env)
+    v = w.get("not_before_ms")
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _expires_at(env: BaseEnvelope) -> datetime | None:
+    w = extract_work_metadata(env)
+    if "expires_at_ms" in w:
+        try:
+            ms = int(w["expires_at_ms"])
+            return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+        except (TypeError, ValueError):
+            pass
+    return _parse_ts(w.get("expires_at"))
+
+
+class QueueRabbit(BaseChassis):
+    """
+    Stream consumer chassis: one worker per delivery (Redis consumer group),
+    replies on existing PubSub (OrionBusAsync) reply_to channels.
+    """
+
+    def __init__(
+        self,
+        cfg: ChassisConfig,
+        *,
+        stream: str,
+        group: str,
+        consumer: str | None = None,
+        handler: Handler,
+        reply_bus: OrionBusAsync | None = None,
+        work_queue: RedisStreamWorkQueue | None = None,
+        concurrent_handlers: bool = False,
+        max_inflight: int = 1,
+        read_count: int = 1,
+        block_ms: int = 5000,
+        max_attempts: int = 3,
+        dlq_stream: str | None = None,
+        reclaim_pending: bool = True,
+        reclaim_min_idle_ms: int = 120_000,
+        stale_policy: str = "drop",
+        heartbeat_enabled: bool = True,
+        reclaim_every_loops: int = 5,
+        reclaim_every_sec: float = 30.0,
+    ) -> None:
+        super().__init__(cfg)
+        self.stream = stream
+        self.group = group
+        self.consumer = consumer or f"{cfg.service_name}:{cfg.node_name or 'node'}:{_consumer_suffix()}"
+        self.handler = handler
+        self._reply_bus = reply_bus or self.bus
+        if work_queue is None:
+            raise ValueError("QueueRabbit requires work_queue=RedisStreamWorkQueue(...)")
+        self.work_queue = work_queue
+        self.concurrent_handlers = bool(concurrent_handlers)
+        self.max_inflight = max(1, int(max_inflight))
+        self.read_count = max(1, int(read_count))
+        self.block_ms = int(block_ms)
+        self.max_attempts = int(max_attempts)
+        self.dlq_stream = dlq_stream
+        self.reclaim_pending = bool(reclaim_pending)
+        self.reclaim_min_idle_ms = int(reclaim_min_idle_ms)
+        self.stale_policy = stale_policy
+        self.heartbeat_enabled = bool(heartbeat_enabled)
+        self.reclaim_every_loops = max(1, int(reclaim_every_loops))
+        self.reclaim_every_sec = float(reclaim_every_sec)
+        self._inflight: set[asyncio.Task] = set()
+        self._sem = asyncio.Semaphore(self.max_inflight)
+        self._loop_iter = 0
+        self._last_reclaim = perf_counter()
+
+    async def _heartbeat_loop(self) -> None:
+        if not self.heartbeat_enabled:
+            await self._stop.wait()
+            return
+        await super()._heartbeat_loop()
+
+    def _log_ctx(self, env: BaseEnvelope | None, sm: StreamMessage | None) -> str:
+        parts: list[str] = [
+            f"stream={self.stream}",
+            f"group={self.group}",
+            f"consumer={self.consumer}",
+        ]
+        if sm:
+            parts.append(f"message_id={sm.message_id}")
+        if env:
+            wm = extract_work_metadata(env)
+            parts.extend(
+                [
+                    f"corr={env.correlation_id}",
+                    f"trace_id={(env.trace or {}).get('trace_id', '')}",
+                    f"job_id={wm.get('job_id', '')}",
+                    f"idempotency_key={wm.get('idempotency_key', '')}",
+                    f"lane={wm.get('lane', '')}",
+                    f"attempt={_attempt_from_envelope(env)}",
+                ]
+            )
+        return " ".join(parts)
+
+    async def _publish_reply(self, env: BaseEnvelope, out: BaseEnvelope) -> None:
+        if not env.reply_to:
+            return
+        await self._reply_bus.publish(env.reply_to, out)
+        ctx = self._log_ctx(env, None)
+        logger.info(
+            f"queue_rabbit_reply_publish {ctx} reply_to={env.reply_to} kind_out={out.kind}",
+        )
+
+    async def _handle_decode_error(self, err: WorkQueueDecodeError) -> None:
+        logger.error(
+            f"queue_rabbit_decode_error stream={err.stream} group={self.group} consumer={self.consumer} "
+            f"message_id={err.message_id} error={err.error}",
+        )
+        if self.dlq_stream:
+            try:
+                await self.work_queue.send_malformed_to_dlq(
+                    self.dlq_stream,
+                    original_stream=err.stream,
+                    original_message_id=err.message_id,
+                    raw_fields=err.raw_fields,
+                    error=err.error,
+                    reason="decode_failed",
+                )
+                await self.work_queue.ack(err.stream, self.group, err.message_id)
+            except Exception as e:
+                logger.error(f"queue_rabbit_dlq decode_dlq_failed error={e}")
+        else:
+            logger.error(
+                f"queue_rabbit_decode_error_no_dlq_pending stream={err.stream} message_id={err.message_id} "
+                "(message stays pending)",
+            )
+
+    async def _expire_or_dlq(self, sm: StreamMessage, *, action: str, expires_at: str) -> bool:
+        """Returns True if message should be acked without handler."""
+        if action == "drop":
+            logger.info(
+                f"queue_rabbit_expired stream={self.stream} message_id={sm.message_id} "
+                f"action=drop expires_at={expires_at}",
+            )
+            return True
+        if action == "dlq" and self.dlq_stream:
+            logger.info(
+                f"queue_rabbit_expired stream={self.stream} message_id={sm.message_id} "
+                f"action=dlq expires_at={expires_at}",
+            )
+            await self.work_queue.send_to_dlq(
+                self.dlq_stream,
+                sm,
+                error="expired",
+                reason="expires_at_elapsed",
+                attempt=_attempt_from_envelope(sm.envelope),
+            )
+            return True
+        if action == "run":
+            logger.info(
+                f"queue_rabbit_expired stream={self.stream} message_id={sm.message_id} "
+                f"action=run expires_at={expires_at}",
+            )
+            return False
+        logger.warning(
+            f"queue_rabbit_expired stream={self.stream} message_id={sm.message_id} "
+            f"action={action} expires_at={expires_at} (fallback no-op)",
+        )
+        return False
+
+    async def _process_one(self, sm: StreamMessage) -> None:
+        env = sm.envelope
+        t0 = perf_counter()
+        logger.info(f"queue_rabbit_handler_start {self._log_ctx(env, sm)}")
+
+        exp = _expires_at(env)
+        if exp is not None:
+            now = time.time()
+            if exp.timestamp() < now:
+                pol = self.stale_policy
+                if pol == "dlq" and not self.dlq_stream:
+                    pol = "drop"
+                should_ack_only = await self._expire_or_dlq(
+                    sm,
+                    action=pol,
+                    expires_at=exp.isoformat(),
+                )
+                if should_ack_only:
+                    await self.work_queue.ack(self.stream, self.group, sm.message_id)
+                    return
+                if pol != "run":
+                    return
+
+        nb = _not_before_ms(env)
+        if nb is not None and nb > int(time.time() * 1000):
+            await self.work_queue.requeue(
+                self.stream,
+                sm,
+                _attempt_from_envelope(env),
+                delay_ms=0,
+                reason="not_before",
+            )
+            await self.work_queue.ack(self.stream, self.group, sm.message_id)
+            logger.info(f"queue_rabbit_retry {self._log_ctx(env, sm)} reason=not_before")
+            return
+
+        out: BaseEnvelope | None
+        try:
+            out = await self.handler(env)
+        except Exception as e:
+            await self._on_handler_exception(sm, env, e)
+            return
+
+        if out is None and env.reply_to and not _reply_optional(env):
+            await self._on_handler_exception(
+                sm,
+                env,
+                RuntimeError("handler_returned_none_with_reply_to"),
+            )
+            return
+
+        if out is not None and env.reply_to:
+            try:
+                await self._publish_reply(env, out)
+            except Exception as e:
+                logger.error(
+                    f"queue_rabbit_handler_error {self._log_ctx(env, sm)} reason=reply_publish_failed error={e}",
+                )
+                await self._on_handler_exception(
+                    sm,
+                    env,
+                    RuntimeError(f"reply_publish_failed: {e}"),
+                )
+                return
+
+        await self.work_queue.ack(self.stream, self.group, sm.message_id)
+        ms = (perf_counter() - t0) * 1000.0
+        logger.info(f"queue_rabbit_handler_complete {self._log_ctx(env, sm)} runtime_ms={ms:.1f}")
+
+    async def _on_handler_exception(self, sm: StreamMessage, env: BaseEnvelope, err: BaseException) -> None:
+        logger.error(
+            f"queue_rabbit_handler_error {self._log_ctx(env, sm)} error={err}\n{traceback.format_exc()}",
+        )
+        current = _attempt_from_envelope(env)
+        if current < self.max_attempts:
+            try:
+                await self.work_queue.requeue(
+                    self.stream,
+                    sm,
+                    current + 1,
+                    delay_ms=0,
+                    reason=type(err).__name__,
+                )
+                await self.work_queue.ack(self.stream, self.group, sm.message_id)
+                logger.info(
+                    f"queue_rabbit_retry {self._log_ctx(env, sm)} reason={type(err).__name__} "
+                    f"next_attempt={current + 1}",
+                )
+            except Exception as re:
+                logger.error(
+                    f"queue_rabbit_handler_error {self._log_ctx(env, sm)} reason=requeue_failed error={re}",
+                )
+            return
+
+        if self.dlq_stream:
+            try:
+                await self.work_queue.send_to_dlq(
+                    self.dlq_stream,
+                    sm,
+                    error=str(err),
+                    reason=type(err).__name__,
+                    attempt=current,
+                )
+                await self.work_queue.ack(self.stream, self.group, sm.message_id)
+                logger.info(f"queue_rabbit_dlq {self._log_ctx(env, sm)} reason=max_attempts")
+            except Exception as de:
+                logger.error(
+                    f"queue_rabbit_handler_error {self._log_ctx(env, sm)} reason=dlq_write_failed error={de}",
+                )
+        else:
+            logger.error(
+                f"queue_rabbit_handler_error {self._log_ctx(env, sm)} reason=max_attempts_no_dlq "
+                "(message stays pending)",
+            )
+
+    async def _reclaim_tick(self) -> None:
+        if not self.reclaim_pending:
+            return
+        now = perf_counter()
+        self._loop_iter += 1
+        due = (self._loop_iter % self.reclaim_every_loops == 0) or (now - self._last_reclaim >= self.reclaim_every_sec)
+        if not due:
+            return
+        self._last_reclaim = now
+        try:
+            _next, batch = await self.work_queue.autoclaim(
+                self.stream,
+                self.group,
+                self.consumer,
+                self.reclaim_min_idle_ms,
+                start_id="0-0",
+                count=self.read_count,
+            )
+            for err in batch.decode_errors:
+                await self._handle_decode_error(err)
+            claimed = batch.messages
+            if claimed:
+                logger.info(
+                    f"queue_rabbit_claim stream={self.stream} group={self.group} consumer={self.consumer} "
+                    f"count={len(claimed)} next_start={_next}",
+                )
+            for sm in claimed:
+                await self._dispatch_sm(sm)
+        except Exception:
+            logger.exception("queue_rabbit_claim unexpected_error")
+
+    def _active_inflight_count(self) -> int:
+        return sum(1 for t in self._inflight if not t.done())
+
+    def _capacity_count(self) -> int:
+        if not self.concurrent_handlers:
+            return 1
+        free = self.max_inflight - self._active_inflight_count()
+        return max(0, min(self.read_count, free))
+
+    async def _dispatch_sm(self, sm: StreamMessage) -> None:
+        if self.concurrent_handlers:
+            async def _wrapped() -> None:
+                async with self._sem:
+                    await self._process_one(sm)
+
+            t = asyncio.create_task(_wrapped())
+            self._inflight.add(t)
+
+            def _done(tk: asyncio.Task) -> None:
+                self._inflight.discard(tk)
+
+            t.add_done_callback(_done)
+            return
+        await self._process_one(sm)
+
+    async def _run(self) -> None:
+        await self.work_queue.connect()
+        await self.work_queue.ensure_group(self.stream, self.group)
+        logger.info(
+            f"queue_rabbit_start service={self.cfg.service_name} stream={self.stream} group={self.group} "
+            f"consumer={self.consumer} max_inflight={self.max_inflight}",
+        )
+        try:
+            while not self._stop.is_set():
+                await self._reclaim_tick()
+                if self.concurrent_handlers:
+                    while (
+                        self._active_inflight_count() >= self.max_inflight
+                        and self._inflight
+                        and not self._stop.is_set()
+                    ):
+                        await asyncio.wait(
+                            self._inflight,
+                            return_when=asyncio.FIRST_COMPLETED,
+                            timeout=1.0,
+                        )
+                cap = self._capacity_count()
+                if cap <= 0:
+                    await asyncio.sleep(0.02)
+                    continue
+                batch = await self.work_queue.read_group(
+                    self.stream,
+                    self.group,
+                    self.consumer,
+                    count=cap,
+                    block_ms=self.block_ms,
+                )
+                for err in batch.decode_errors:
+                    await self._handle_decode_error(err)
+                msgs = batch.messages
+
+                if not msgs:
+                    continue
+
+                for sm in msgs:
+                    if self._stop.is_set():
+                        break
+                    await self._dispatch_sm(sm)
+
+                if self.concurrent_handlers and self._inflight:
+                    await asyncio.sleep(0)
+
+            if self._inflight:
+                for t in list(self._inflight):
+                    if not t.done():
+                        t.cancel()
+                await asyncio.gather(*self._inflight, return_exceptions=True)
+        finally:
+            try:
+                await self.work_queue.close()
+            except Exception:
+                logger.exception("queue_rabbit_work_queue_close_failed")
+            logger.info(
+                f"queue_rabbit_stop service={self.cfg.service_name} stream={self.stream} inflight={len(self._inflight)}",
+            )

--- a/orion/core/bus/work_queue.py
+++ b/orion/core/bus/work_queue.py
@@ -1,0 +1,675 @@
+# orion/core/bus/work_queue.py
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from redis import asyncio as aioredis
+from redis.exceptions import ResponseError
+
+from .async_service import OrionBusAsync
+from .bus_schemas import BaseEnvelope
+from .codec import OrionCodec
+
+logger = logging.getLogger("orion.bus.work_queue")
+
+SCHEMA_ENTRY = "work_queue.entry.v1"
+SCHEMA_DLQ = "work_queue.dlq.v1"
+SCHEMA_DLQ_MALFORMED = "work_queue.dlq_malformed.v1"
+
+
+def _decode_any(v: Any) -> str:
+    if isinstance(v, (bytes, bytearray)):
+        return v.decode("utf-8", "ignore")
+    return str(v)
+
+
+def _field(fields: Mapping[Any, Any], name: str) -> Any:
+    if name in fields:
+        return fields[name]
+    nb = name.encode("utf-8")
+    if nb in fields:
+        return fields[nb]
+    return None
+
+
+def _normalize_stream_fields(raw: Any) -> dict[Any, Any]:
+    if isinstance(raw, dict):
+        return dict(raw)
+    if isinstance(raw, (list, tuple)):
+        out: dict[Any, Any] = {}
+        it = iter(raw)
+        for k in it:
+            out[k] = next(it, None)
+        return out
+    return {}
+
+
+def _stream_value_for_xadd(v: Any) -> bytes | str:
+    if isinstance(v, (bytes, bytearray)):
+        return bytes(v)
+    if isinstance(v, bool):
+        return b"true" if v else b"false"
+    if isinstance(v, int):
+        return str(v).encode("utf-8")
+    if isinstance(v, float):
+        return str(v).encode("utf-8")
+    if isinstance(v, str):
+        return v.encode("utf-8")
+    return json.dumps(v, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _merge_extra_fields(base: dict[bytes, bytes], extra: Mapping[str, Any] | None) -> None:
+    if not extra:
+        return
+    for k, v in extra.items():
+        key = k.encode("utf-8") if isinstance(k, str) else bytes(k)
+        base[key] = _stream_value_for_xadd(v)
+
+
+def extract_work_metadata(envelope: BaseEnvelope) -> dict[str, Any]:
+    """
+    Read optional work metadata from trace['work'] or payload['work'] (dict only).
+    Payload wins for overlapping keys after trace.
+    """
+    out: dict[str, Any] = {}
+    tr = envelope.trace or {}
+    tw = tr.get("work")
+    if isinstance(tw, dict):
+        out.update(tw)
+    pw = (envelope.payload or {}).get("work")
+    if isinstance(pw, dict):
+        out.update(pw)
+    return out
+
+
+def copy_envelope_with_work(
+    envelope: BaseEnvelope,
+    *,
+    work_updates: Mapping[str, Any],
+) -> BaseEnvelope:
+    """
+    Shallow-merge work dict into trace['work'] without mutating the original envelope.
+
+    Reads merge trace['work'] then payload['work'] (see extract_work_metadata); updates
+    here only modify trace['work'] so payload-based work keys are unchanged on disk.
+    """
+    tr = dict(envelope.trace or {})
+    cur = tr.get("work")
+    merged_work: dict[str, Any] = dict(cur) if isinstance(cur, dict) else {}
+    merged_work.update(dict(work_updates))
+    tr["work"] = merged_work
+    return envelope.model_copy(update={"trace": tr})
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, (int, float)):
+        v = float(value)
+        if v > 1e12:
+            return datetime.fromtimestamp(v / 1000.0, tz=timezone.utc)
+        return datetime.fromtimestamp(v, tz=timezone.utc)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+@dataclass(frozen=True)
+class StreamMessage:
+    stream: str
+    message_id: str
+    envelope: BaseEnvelope
+    raw_fields: Mapping[str, Any]
+    enqueued_at_ms: int | None
+    delivery_count: int | None
+
+
+@dataclass(frozen=True)
+class PendingMessage:
+    stream: str
+    message_id: str
+    consumer: str | None
+    idle_ms: int | None
+    deliveries: int | None
+
+
+@dataclass(frozen=True)
+class RetryDecision:
+    action: str  # retry | dlq | drop
+    reason: str
+    attempt: int
+    max_attempts: int
+    delay_ms: int = 0
+    dlq_stream: str | None = None
+
+
+class WorkQueueError(Exception):
+    pass
+
+
+class WorkQueueDecodeError(WorkQueueError):
+    def __init__(
+        self,
+        *,
+        stream: str,
+        message_id: str,
+        error: str,
+        raw_fields: Mapping[str, Any],
+    ) -> None:
+        super().__init__(f"decode_failed stream={stream} id={message_id} error={error}")
+        self.stream = stream
+        self.message_id = message_id
+        self.error = error
+        self.raw_fields = raw_fields
+
+
+@dataclass(frozen=True)
+class ReadGroupBatch:
+    """Result of XREADGROUP / XAUTOCLAIM: decoded messages plus per-entry decode failures."""
+
+    messages: list[StreamMessage] = field(default_factory=list)
+    decode_errors: list[WorkQueueDecodeError] = field(default_factory=list)
+
+
+class WorkQueueGroupError(WorkQueueError):
+    pass
+
+
+class WorkQueueRetryExhausted(WorkQueueError):
+    pass
+
+
+class RedisStreamWorkQueue:
+    """
+    Redis Streams consumer-group primitive using OrionCodec-compatible envelope bytes.
+
+    ``read_group`` / ``autoclaim`` return :class:`ReadGroupBatch` so each stream entry is
+    decoded independently; malformed entries do not prevent delivery of other messages
+    in the same Redis batch.
+    """
+
+    def __init__(
+        self,
+        redis_url: str,
+        *,
+        codec: OrionCodec | None = None,
+        client: aioredis.Redis | None = None,
+        default_maxlen: int | None = None,
+        logger_: logging.Logger | None = None,
+    ) -> None:
+        self._redis_url = redis_url
+        self.codec = codec or OrionCodec()
+        self._client: aioredis.Redis | None = client
+        self._owns_client = client is None
+        self.default_maxlen = default_maxlen
+        self.log = logger_ or logger
+
+    @property
+    def client(self) -> aioredis.Redis:
+        if self._client is None:
+            raise RuntimeError("RedisStreamWorkQueue not connected. Call await connect().")
+        return self._client
+
+    async def connect(self) -> None:
+        if self._client is not None:
+            await self._client.ping()
+            return
+        self._client = aioredis.from_url(self._redis_url, decode_responses=False)
+        await self._client.ping()
+
+    async def close(self) -> None:
+        if self._client is None:
+            return
+        if self._owns_client:
+            await self._client.close()
+            self._client = None
+
+    async def ensure_group(self, stream: str, group: str, start_id: str = "$", mkstream: bool = True) -> None:
+        try:
+            await self.client.xgroup_create(stream, group, id=start_id, mkstream=mkstream)
+            self.log.info(
+                "work_queue_group_ready stream=%s group=%s status=created",
+                stream,
+                group,
+            )
+        except ResponseError as e:
+            if "BUSYGROUP" in str(e):
+                self.log.info(
+                    "work_queue_group_ready stream=%s group=%s status=exists",
+                    stream,
+                    group,
+                )
+                return
+            raise WorkQueueGroupError(str(e)) from e
+
+    def _envelope_bytes(self, envelope: BaseEnvelope) -> bytes:
+        return self.codec.encode(envelope)
+
+    def _decode_envelope_field(self, raw: Any, *, stream: str, message_id: str, raw_fields: Mapping[str, Any]) -> BaseEnvelope:
+        data = raw
+        if isinstance(raw, str):
+            data = raw.encode("utf-8")
+        if not isinstance(data, (bytes, bytearray)):
+            raise WorkQueueDecodeError(
+                stream=stream,
+                message_id=message_id,
+                error="envelope_field_not_bytes",
+                raw_fields=raw_fields,
+            )
+        res = self.codec.decode(bytes(data))
+        if not res.ok or res.envelope is None:
+            raise WorkQueueDecodeError(
+                stream=stream,
+                message_id=message_id,
+                error=res.error or "decode_failed",
+                raw_fields=raw_fields,
+            )
+        return res.envelope
+
+    async def enqueue(
+        self,
+        stream: str,
+        envelope: BaseEnvelope,
+        maxlen: int | None = None,
+        approximate: bool = True,
+        extra_fields: dict[str, str] | None = None,
+    ) -> str:
+        await self.connect()
+        enc = self._envelope_bytes(envelope)
+        now_ms = int(time.time() * 1000)
+        fields: dict[bytes, bytes] = {
+            b"schema_version": SCHEMA_ENTRY.encode("utf-8"),
+            b"envelope": enc,
+            b"enqueued_at_ms": str(now_ms).encode("utf-8"),
+            b"kind": envelope.kind.encode("utf-8"),
+            b"correlation_id": str(envelope.correlation_id).encode("utf-8"),
+            b"reply_to": (envelope.reply_to or "").encode("utf-8"),
+            b"source": json.dumps(envelope.source.model_dump(mode="json"), ensure_ascii=False).encode("utf-8"),
+        }
+        _merge_extra_fields(fields, extra_fields)
+        trim = maxlen if maxlen is not None else self.default_maxlen
+        xadd_kw: dict[str, Any] = {}
+        if trim is not None:
+            xadd_kw["maxlen"] = int(trim)
+            xadd_kw["approximate"] = bool(approximate)
+        msg_id = await self.client.xadd(stream, fields, **xadd_kw)
+        mid = _decode_any(msg_id)
+        wm = extract_work_metadata(envelope)
+        self.log.info(
+            "work_queue_enqueue stream=%s message_id=%s kind=%s corr=%s job_id=%s lane=%s",
+            stream,
+            mid,
+            envelope.kind,
+            envelope.correlation_id,
+            wm.get("job_id", ""),
+            wm.get("lane", ""),
+        )
+        return mid
+
+    def _normalize_xread_entries(self, entries: Any) -> list[tuple[str, dict[Any, Any]]]:
+        out: list[tuple[str, dict[Any, Any]]] = []
+        if not entries:
+            return out
+        for entry in entries:
+            if not entry or len(entry) < 2:
+                continue
+            mid, raw_fields = entry[0], entry[1]
+            fields = _normalize_stream_fields(raw_fields)
+            out.append((_decode_any(mid), fields))
+        return out
+
+    async def read_group(
+        self,
+        stream: str,
+        group: str,
+        consumer: str,
+        count: int = 1,
+        block_ms: int = 5000,
+    ) -> ReadGroupBatch:
+        """
+        XREADGROUP for new messages. Each stream entry is decoded independently; malformed
+        entries appear in ``decode_errors`` so earlier valid messages in the same batch
+        are still returned and are not stranded in the PEL.
+        """
+        await self.connect()
+        reply = await self.client.xreadgroup(
+            groupname=group,
+            consumername=consumer,
+            streams={stream: ">"},
+            count=count,
+            block=block_ms,
+        )
+        messages: list[StreamMessage] = []
+        decode_errors: list[WorkQueueDecodeError] = []
+        if not reply:
+            return ReadGroupBatch(messages=messages, decode_errors=decode_errors)
+        for item in reply:
+            if not item or len(item) < 2:
+                continue
+            _sname, entries = item[0], item[1]
+            for mid, fields in self._normalize_xread_entries(entries):
+                env_raw = _field(fields, "envelope")
+                try:
+                    env = self._decode_envelope_field(env_raw, stream=stream, message_id=mid, raw_fields=fields)
+                except WorkQueueDecodeError as e:
+                    decode_errors.append(e)
+                    continue
+                enq_raw = _field(fields, "enqueued_at_ms")
+                enq_ms: int | None = None
+                if enq_raw is not None:
+                    try:
+                        enq_ms = int(_decode_any(enq_raw))
+                    except ValueError:
+                        enq_ms = None
+                messages.append(
+                    StreamMessage(
+                        stream=stream,
+                        message_id=mid,
+                        envelope=env,
+                        raw_fields=fields,
+                        enqueued_at_ms=enq_ms,
+                        delivery_count=None,
+                    )
+                )
+        if messages:
+            self.log.info(
+                "work_queue_read stream=%s group=%s consumer=%s count=%s",
+                stream,
+                group,
+                consumer,
+                len(messages),
+            )
+        if decode_errors:
+            self.log.warning(
+                "work_queue_read_decode_errors stream=%s group=%s consumer=%s n=%s",
+                stream,
+                group,
+                consumer,
+                len(decode_errors),
+            )
+        return ReadGroupBatch(messages=messages, decode_errors=decode_errors)
+
+    async def ack(self, stream: str, group: str, message_id: str) -> int:
+        await self.connect()
+        n = int(await self.client.xack(stream, group, message_id))
+        self.log.info(
+            "work_queue_ack stream=%s group=%s message_id=%s acked=%s",
+            stream,
+            group,
+            message_id,
+            n,
+        )
+        return n
+
+    def _normalize_pending_summary(self, raw: Any) -> dict[str, Any]:
+        if raw is None:
+            return {"count": 0, "min_id": None, "max_id": None, "consumers": []}
+        if isinstance(raw, dict):
+            count = int(raw.get(b"pending", raw.get("pending", 0)))
+            min_id = raw.get(b"min", raw.get("min"))
+            max_id = raw.get(b"max", raw.get("max"))
+            consumers = raw.get(b"consumers", raw.get("consumers", []))
+            return {
+                "count": count,
+                "min_id": None if min_id is None else _decode_any(min_id),
+                "max_id": None if max_id is None else _decode_any(max_id),
+                "consumers": list(consumers) if isinstance(consumers, (list, tuple)) else [],
+            }
+        if isinstance(raw, (list, tuple)) and len(raw) >= 4:
+            pending, min_id, max_id, consumers = raw[0], raw[1], raw[2], raw[3]
+            return {
+                "count": int(pending),
+                "min_id": None if min_id is None else _decode_any(min_id),
+                "max_id": None if max_id is None else _decode_any(max_id),
+                "consumers": list(consumers) if isinstance(consumers, (list, tuple)) else [],
+            }
+        return {"count": 0, "min_id": None, "max_id": None, "consumers": []}
+
+    async def pending_summary(self, stream: str, group: str) -> dict[str, Any]:
+        await self.connect()
+        raw = await self.client.xpending(stream, group)
+        return self._normalize_pending_summary(raw)
+
+    def _normalize_pending_range_row(self, stream: str, row: Any) -> PendingMessage | None:
+        if row is None:
+            return None
+        if isinstance(row, dict):
+            mid = row.get("message_id") or row.get(b"message_id")
+            cons = row.get("consumer") or row.get(b"consumer")
+            idle = row.get("time_since_delivered") or row.get("idle") or row.get(b"time_since_delivered")
+            deliv = row.get("times_delivered") or row.get(b"times_delivered")
+            return PendingMessage(
+                stream=stream,
+                message_id=_decode_any(mid) if mid is not None else "",
+                consumer=None if cons is None else _decode_any(cons),
+                idle_ms=int(idle) if idle is not None else None,
+                deliveries=int(deliv) if deliv is not None else None,
+            )
+        if isinstance(row, (list, tuple)) and len(row) >= 4:
+            mid, cons, ms_since, times = row[0], row[1], row[2], row[3]
+            return PendingMessage(
+                stream=stream,
+                message_id=_decode_any(mid),
+                consumer=None if cons is None else _decode_any(cons),
+                idle_ms=int(ms_since) if ms_since is not None else None,
+                deliveries=int(times) if times is not None else None,
+            )
+        return None
+
+    async def pending_range(
+        self,
+        stream: str,
+        group: str,
+        start: str = "-",
+        end: str = "+",
+        count: int = 10,
+        consumer: str | None = None,
+    ) -> list[PendingMessage]:
+        await self.connect()
+        rows = await self.client.xpending_range(stream, group, min=start, max=end, count=count, consumername=consumer)
+        out: list[PendingMessage] = []
+        for row in rows or []:
+            pm = self._normalize_pending_range_row(stream, row)
+            if pm:
+                out.append(pm)
+        return out
+
+    async def autoclaim(
+        self,
+        stream: str,
+        group: str,
+        consumer: str,
+        min_idle_ms: int,
+        start_id: str = "0-0",
+        count: int = 10,
+    ) -> tuple[str, ReadGroupBatch]:
+        await self.connect()
+        res = await self.client.xautoclaim(
+            stream,
+            group,
+            consumer,
+            min_idle_time=int(min_idle_ms),
+            start_id=start_id,
+            count=count,
+        )
+        if not res or len(res) < 2:
+            return start_id, ReadGroupBatch()
+        next_start = _decode_any(res[0])
+        raw_entries = res[1]
+        messages: list[StreamMessage] = []
+        decode_errors: list[WorkQueueDecodeError] = []
+        for entry in raw_entries or []:
+            if not entry or len(entry) < 2:
+                continue
+            mid, raw_fields = entry[0], entry[1]
+            fields = _normalize_stream_fields(raw_fields)
+            mid_s = _decode_any(mid)
+            env_raw = _field(fields, "envelope")
+            try:
+                env = self._decode_envelope_field(env_raw, stream=stream, message_id=mid_s, raw_fields=fields)
+            except WorkQueueDecodeError as e:
+                decode_errors.append(e)
+                continue
+            enq_raw = _field(fields, "enqueued_at_ms")
+            enq_ms: int | None = None
+            if enq_raw is not None:
+                try:
+                    enq_ms = int(_decode_any(enq_raw))
+                except ValueError:
+                    enq_ms = None
+            messages.append(
+                StreamMessage(
+                    stream=stream,
+                    message_id=mid_s,
+                    envelope=env,
+                    raw_fields=fields,
+                    enqueued_at_ms=enq_ms,
+                    delivery_count=None,
+                )
+            )
+        return next_start, ReadGroupBatch(messages=messages, decode_errors=decode_errors)
+
+    async def send_to_dlq(
+        self,
+        dlq_stream: str,
+        message: StreamMessage,
+        error: str,
+        reason: str,
+        attempt: int,
+    ) -> str:
+        await self.connect()
+        fields: dict[bytes, bytes] = {
+            b"schema_version": SCHEMA_DLQ.encode("utf-8"),
+            b"original_stream": message.stream.encode("utf-8"),
+            b"original_message_id": message.message_id.encode("utf-8"),
+            b"error": error.encode("utf-8"),
+            b"reason": reason.encode("utf-8"),
+            b"attempt": str(attempt).encode("utf-8"),
+            b"failed_at_ms": str(int(time.time() * 1000)).encode("utf-8"),
+            b"envelope": self._envelope_bytes(message.envelope),
+        }
+        msg_id = await self.client.xadd(dlq_stream, fields)
+        mid = _decode_any(msg_id)
+        self.log.info(
+            "work_queue_dlq stream=%s dlq_stream=%s message_id=%s reason=%s attempt=%s",
+            message.stream,
+            dlq_stream,
+            message.message_id,
+            reason,
+            attempt,
+        )
+        return mid
+
+    async def send_malformed_to_dlq(
+        self,
+        dlq_stream: str,
+        *,
+        original_stream: str,
+        original_message_id: str,
+        raw_fields: Mapping[str, Any],
+        error: str,
+        reason: str,
+    ) -> str:
+        """DLQ path for decode failures: preserve raw stream fields (esp. envelope bytes)."""
+        await self.connect()
+        enc_raw = _field(raw_fields, "envelope")
+        if isinstance(enc_raw, (bytes, bytearray)):
+            enc_bytes = bytes(enc_raw)
+        elif enc_raw is None:
+            enc_bytes = b""
+        else:
+            enc_bytes = repr(enc_raw).encode("utf-8", errors="replace")
+        fields: dict[bytes, bytes] = {
+            b"schema_version": SCHEMA_DLQ_MALFORMED.encode("utf-8"),
+            b"original_stream": original_stream.encode("utf-8"),
+            b"original_message_id": original_message_id.encode("utf-8"),
+            b"error": error.encode("utf-8"),
+            b"reason": reason.encode("utf-8"),
+            b"failed_at_ms": str(int(time.time() * 1000)).encode("utf-8"),
+            b"envelope": enc_bytes,
+        }
+        msg_id = await self.client.xadd(dlq_stream, fields)
+        return _decode_any(msg_id)
+
+    async def requeue(
+        self,
+        stream: str,
+        message: StreamMessage,
+        attempt: int,
+        delay_ms: int = 0,
+        *,
+        reason: str,
+    ) -> str:
+        await self.connect()
+        work_updates: dict[str, Any] = {"attempt": attempt}
+        if delay_ms > 0:
+            nb = int(time.time() * 1000) + int(delay_ms)
+            work_updates["not_before_ms"] = nb
+        new_env = copy_envelope_with_work(message.envelope, work_updates=work_updates)
+        old_id = message.message_id
+        new_id = await self.enqueue(stream, new_env)
+        self.log.info(
+            "work_queue_requeue stream=%s message_id=%s new_message_id=%s attempt=%s reason=%s",
+            stream,
+            old_id,
+            new_id,
+            attempt,
+            reason,
+        )
+        return new_id
+
+    async def stream_info(self, stream: str) -> Any:
+        await self.connect()
+        return await self.client.xinfo_stream(stream)
+
+    async def group_info(self, stream: str) -> Any:
+        await self.connect()
+        return await self.client.xinfo_groups(stream)
+
+    async def consumer_info(self, stream: str, group: str) -> Any:
+        await self.connect()
+        return await self.client.xinfo_consumers(stream, group)
+
+
+async def queue_rpc_request(
+    *,
+    queue: RedisStreamWorkQueue,
+    reply_bus: OrionBusAsync,
+    stream: str,
+    envelope: BaseEnvelope,
+    reply_channel: str,
+    timeout_sec: float,
+    maxlen: int | None = None,
+    extra_fields: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """
+    Subscribe to PubSub reply_channel first, then enqueue to the stream, then await the reply.
+    Mirrors OrionBusAsync.rpc_request enough for later adopters (returns raw redis message dict).
+    """
+    if envelope.reply_to and envelope.reply_to != reply_channel:
+        logger.warning(
+            "queue_rpc_request reply_channel_mismatch corr=%s envelope.reply_to=%s reply_channel=%s",
+            envelope.correlation_id,
+            envelope.reply_to,
+            reply_channel,
+        )
+    corr = str(envelope.correlation_id)
+    async with reply_bus.subscribe(reply_channel) as pubsub:
+        await queue.enqueue(stream, envelope, maxlen=maxlen, extra_fields=extra_fields)
+
+        async def _wait_one() -> dict:
+            async for msg in reply_bus.iter_messages(pubsub):
+                return msg
+
+        return await asyncio.wait_for(_wait_one(), timeout=timeout_sec)

--- a/tests/test_queue_service_chassis.py
+++ b/tests/test_queue_service_chassis.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from contextlib import suppress
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.bus.bus_service_chassis import ChassisConfig
+from orion.core.bus.codec import OrionCodec
+from orion.core.bus.queue_service_chassis import QueueRabbit
+from orion.core.bus.work_queue import StreamMessage, WorkQueueDecodeError
+
+
+async def _noop_handler(_e: BaseEnvelope) -> None:
+    return None
+
+
+def _cfg() -> ChassisConfig:
+    return ChassisConfig(
+        service_name="test-svc",
+        service_version="0",
+        node_name="node-a",
+        bus_url="redis://localhost:6379/0",
+        bus_enabled=False,
+    )
+
+
+def _env(**kwargs) -> BaseEnvelope:
+    base = dict(
+        kind="q.test",
+        source=ServiceRef(name="svc", node="n1"),
+        payload={},
+        trace={},
+    )
+    base.update(kwargs)
+    return BaseEnvelope.model_validate(base)
+
+
+def _sm(env: BaseEnvelope, mid: str = "1-0") -> StreamMessage:
+    return StreamMessage(
+        stream="jobs",
+        message_id=mid,
+        envelope=env,
+        raw_fields={},
+        enqueued_at_ms=None,
+        delivery_count=None,
+    )
+
+
+def _qr(
+    *,
+    handler,
+    wq: AsyncMock | None = None,
+    reply_bus=None,
+    max_attempts: int = 3,
+    dlq_stream: str | None = None,
+    stale_policy: str = "drop",
+    concurrent_handlers: bool = False,
+    max_inflight: int = 1,
+) -> QueueRabbit:
+    wq_supplied = wq is not None
+    wq = wq or AsyncMock()
+    if not wq_supplied:
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock(return_value="2-0")
+        wq.send_to_dlq = AsyncMock(return_value="d-0")
+        wq.send_malformed_to_dlq = AsyncMock(return_value="m-0")
+    bus_supplied = reply_bus is not None
+    rb = reply_bus or MagicMock()
+    if not bus_supplied:
+        rb.publish = AsyncMock()
+    return QueueRabbit(
+        _cfg(),
+        stream="jobs",
+        group="g1",
+        consumer="c-fixed",
+        handler=handler,
+        reply_bus=rb,
+        work_queue=wq,  # type: ignore[arg-type]
+        max_attempts=max_attempts,
+        dlq_stream=dlq_stream,
+        stale_policy=stale_policy,
+        concurrent_handlers=concurrent_handlers,
+        max_inflight=max_inflight,
+        heartbeat_enabled=False,
+        reclaim_pending=False,
+    )
+
+
+def test_handler_success_no_reply_acks() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        env = _env()
+        calls = []
+
+        async def h(e):
+            calls.append("h")
+            return None
+
+        qr = _qr(handler=h, wq=wq)
+        await qr._process_one(_sm(env))
+        wq.ack.assert_awaited_once_with("jobs", "g1", "1-0")
+        assert calls == ["h"]
+
+    asyncio.run(_())
+
+
+def test_handler_success_with_reply_publishes_then_acks() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        rb = MagicMock()
+        rb.publish = AsyncMock()
+        env = _env(reply_to="rep:x")
+        out = _env(kind="q.resp", reply_to=None)
+
+        async def h(e):
+            return out
+
+        qr = _qr(handler=h, wq=wq, reply_bus=rb)
+        await qr._process_one(_sm(env))
+        rb.publish.assert_awaited_once_with("rep:x", out)
+        wq.ack.assert_awaited_once_with("jobs", "g1", "1-0")
+
+    asyncio.run(_())
+
+
+def test_reply_publish_failure_triggers_retry() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock(return_value="2-0")
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        rb = MagicMock()
+        rb.publish = AsyncMock(side_effect=RuntimeError("pubfail"))
+        env = _env(reply_to="rep:x")
+
+        async def h(e):
+            return _env(kind="out")
+
+        qr = _qr(handler=h, wq=wq, reply_bus=rb)
+        await qr._process_one(_sm(env))
+        wq.requeue.assert_awaited()
+        wq.ack.assert_awaited_once_with("jobs", "g1", "1-0")
+
+    asyncio.run(_())
+
+
+def test_handler_returns_none_with_reply_to_is_error() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock(return_value="2-0")
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        env = _env(reply_to="rep:x")
+
+        async def h(e):
+            return None
+
+        qr = _qr(handler=h, wq=wq, max_attempts=3)
+        await qr._process_one(_sm(env))
+        wq.requeue.assert_awaited()
+        wq.ack.assert_awaited()
+
+    asyncio.run(_())
+
+
+def test_handler_failure_requeues_before_ack() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock(return_value="2-0")
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        env = _env()
+
+        async def h(e):
+            raise ValueError("nope")
+
+        qr = _qr(handler=h, wq=wq)
+        await qr._process_one(_sm(env))
+        wq.requeue.assert_awaited()
+        wq.ack.assert_awaited_once_with("jobs", "g1", "1-0")
+
+    asyncio.run(_())
+
+
+def test_handler_failure_dlq_after_max_attempts() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock(return_value="d-0")
+        wq.send_malformed_to_dlq = AsyncMock()
+        env = _env(trace={"work": {"attempt": 3}})
+
+        async def h(e):
+            raise ValueError("nope")
+
+        qr = _qr(handler=h, wq=wq, max_attempts=3, dlq_stream="dlq")
+        await qr._process_one(_sm(env))
+        wq.send_to_dlq.assert_awaited()
+        wq.requeue.assert_not_called()
+        wq.ack.assert_awaited_once_with("jobs", "g1", "1-0")
+
+    asyncio.run(_())
+
+
+def test_dlq_failure_does_not_ack_original() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock(side_effect=RuntimeError("dlqfail"))
+        wq.send_malformed_to_dlq = AsyncMock()
+        env = _env(trace={"work": {"attempt": 3}})
+
+        async def h(e):
+            raise ValueError("nope")
+
+        qr = _qr(handler=h, wq=wq, max_attempts=3, dlq_stream="dlq")
+        await qr._process_one(_sm(env))
+        wq.ack.assert_not_called()
+
+    asyncio.run(_())
+
+
+def test_expired_drop_acks_without_handler() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        env = _env(trace={"work": {"expires_at": past}})
+        ran = []
+
+        async def h(e):
+            ran.append(1)
+            return None
+
+        qr = _qr(handler=h, wq=wq, stale_policy="drop")
+        await qr._process_one(_sm(env))
+        assert ran == []
+        wq.ack.assert_awaited_once_with("jobs", "g1", "1-0")
+
+    asyncio.run(_())
+
+
+def test_expired_dlq_acks_after_dlq() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        env = _env(trace={"work": {"expires_at": past}})
+        ran = []
+
+        async def h(e):
+            ran.append(1)
+            return None
+
+        qr = _qr(handler=h, wq=wq, stale_policy="dlq", dlq_stream="dlq")
+        await qr._process_one(_sm(env))
+        assert ran == []
+        wq.send_to_dlq.assert_awaited()
+        wq.ack.assert_awaited_once_with("jobs", "g1", "1-0")
+
+    asyncio.run(_())
+
+
+def test_not_before_requeues_and_acks_original() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock(return_value="2-0")
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        nb = int(time.time() * 1000) + 3600_000
+        env = _env(trace={"work": {"attempt": 2, "not_before_ms": nb}})
+        ran = []
+
+        async def h(e):
+            ran.append(1)
+            return None
+
+        qr = _qr(handler=h, wq=wq)
+        await qr._process_one(_sm(env))
+        assert ran == []
+        wq.requeue.assert_awaited()
+        wq.ack.assert_awaited_once_with("jobs", "g1", "1-0")
+
+    asyncio.run(_())
+
+
+def test_concurrent_max_inflight() -> None:
+    async def _() -> None:
+        qr = _qr(handler=_noop_handler, concurrent_handlers=True, max_inflight=3)
+        t1 = asyncio.create_task(asyncio.sleep(60))
+        t2 = asyncio.create_task(asyncio.sleep(60))
+        qr._inflight.update({t1, t2})
+        assert qr._active_inflight_count() == 2
+        assert qr._capacity_count() == 1
+        t1.cancel()
+        t2.cancel()
+        with suppress(asyncio.CancelledError):
+            await t1
+        with suppress(asyncio.CancelledError):
+            await t2
+
+    asyncio.run(_())
+
+
+def test_shutdown_does_not_ack_cancelled_task() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        env = _env()
+
+        async def h(e):
+            await asyncio.Event().wait()
+
+        qr = _qr(handler=h, wq=wq)
+        t = asyncio.create_task(qr._process_one(_sm(env)))
+        await asyncio.sleep(0.05)
+        t.cancel()
+        with suppress(asyncio.CancelledError):
+            await t
+        wq.ack.assert_not_called()
+
+    asyncio.run(_())
+
+
+def test_decode_failure_dlq_and_ack_when_dlq_configured() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock(return_value="m-1")
+        err = WorkQueueDecodeError(
+            stream="jobs",
+            message_id="9-0",
+            error="bad",
+            raw_fields={b"envelope": b"x"},
+        )
+        qr = _qr(handler=_noop_handler, wq=wq, dlq_stream="dlq")
+        await qr._handle_decode_error(err)
+        wq.send_malformed_to_dlq.assert_awaited()
+        wq.ack.assert_awaited_once_with("jobs", "g1", "9-0")
+
+    asyncio.run(_())
+
+
+def test_decode_failure_no_dlq_leaves_pending() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        err = WorkQueueDecodeError(
+            stream="jobs",
+            message_id="9-0",
+            error="bad",
+            raw_fields={b"envelope": b"x"},
+        )
+        qr = _qr(handler=_noop_handler, wq=wq, dlq_stream=None)
+        await qr._handle_decode_error(err)
+        wq.send_malformed_to_dlq.assert_not_called()
+        wq.ack.assert_not_called()
+
+    asyncio.run(_())
+
+
+def test_reply_optional_none_with_reply_does_not_error() -> None:
+    async def _() -> None:
+        wq = AsyncMock()
+        wq.connect = AsyncMock()
+        wq.ensure_group = AsyncMock()
+        wq.ack = AsyncMock(return_value=1)
+        wq.requeue = AsyncMock()
+        wq.send_to_dlq = AsyncMock()
+        wq.send_malformed_to_dlq = AsyncMock()
+        rb = MagicMock()
+        rb.publish = AsyncMock()
+        env = _env(reply_to="rep:x", trace={"work": {"reply_optional": True}})
+
+        async def h(e):
+            return None
+
+        qr = _qr(handler=h, wq=wq, reply_bus=rb)
+        await qr._process_one(_sm(env))
+        rb.publish.assert_not_called()
+        wq.ack.assert_awaited_once_with("jobs", "g1", "1-0")
+
+    asyncio.run(_())
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ORION_REDIS_STREAM_TEST_URL"),
+    reason="ORION_REDIS_STREAM_TEST_URL not set",
+)
+def test_live_two_consumers_one_message() -> None:
+    async def _() -> None:
+        import os
+
+        from redis import asyncio as aioredis
+
+        from orion.core.bus.work_queue import RedisStreamWorkQueue
+
+        url = os.environ["ORION_REDIS_STREAM_TEST_URL"]
+        stream = f"orion:test:stream:{os.getpid()}"
+        group = "g"
+        codec = OrionCodec()
+        client = aioredis.from_url(url, decode_responses=False)
+        wq = RedisStreamWorkQueue(url, client=client, codec=codec)
+        await wq.connect()
+        try:
+            await client.delete(stream)
+        except Exception:
+            pass
+        await wq.ensure_group(stream, group, start_id="0", mkstream=True)
+        env = _env()
+        await wq.enqueue(stream, env)
+        got: list[str] = []
+
+        async def read_once(name: str) -> int:
+            batch = await wq.read_group(stream, group, name, count=1, block_ms=2000)
+            got.extend([name] * len(batch.messages))
+            for m in batch.messages:
+                await wq.ack(stream, group, m.message_id)
+            return len(batch.messages)
+
+        n1, n2 = await asyncio.gather(read_once("c1"), read_once("c2"))
+        assert n1 + n2 == 1
+        assert len(got) == 1
+        pend = await wq.pending_summary(stream, group)
+        assert pend.get("count", 0) == 0
+        await client.delete(stream)
+        await client.aclose()
+
+    asyncio.run(_())

--- a/tests/test_work_queue.py
+++ b/tests/test_work_queue.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+from redis.exceptions import ResponseError
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.bus.codec import OrionCodec
+from orion.core.bus.work_queue import (
+    RedisStreamWorkQueue,
+    StreamMessage,
+    copy_envelope_with_work,
+    extract_work_metadata,
+    queue_rpc_request,
+)
+
+
+def _env(**kwargs) -> BaseEnvelope:
+    base = dict(
+        kind="test.kind",
+        source=ServiceRef(name="svc", node="n1"),
+        payload={},
+        trace={},
+    )
+    base.update(kwargs)
+    return BaseEnvelope.model_validate(base)
+
+
+def test_group_create_busygroup_ok() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        r.xgroup_create = AsyncMock(
+            side_effect=ResponseError("BUSYGROUP Consumer Group name already exists")
+        )
+        wq = RedisStreamWorkQueue("redis://x", client=r)
+        await wq.ensure_group("s1", "g1")
+        r.xgroup_create.assert_awaited_once()
+
+    asyncio.run(_())
+
+
+def test_enqueue_encodes_base_envelope() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        r.xadd = AsyncMock(return_value=b"1-0")
+        codec = OrionCodec()
+        env = _env()
+        wq = RedisStreamWorkQueue("redis://x", client=r, codec=codec)
+        mid = await wq.enqueue("jobs", env)
+        assert mid == "1-0"
+        args, _kwargs = r.xadd.call_args
+        assert args[0] == "jobs"
+        fields = args[1]
+        assert fields[b"schema_version"] == b"work_queue.entry.v1"
+        dec = codec.decode(fields[b"envelope"])
+        assert dec.ok and dec.envelope and dec.envelope.kind == "test.kind"
+
+    asyncio.run(_())
+
+
+def test_read_group_decodes_base_envelope() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        codec = OrionCodec()
+        env = _env()
+        raw = codec.encode(env)
+        r.xreadgroup = AsyncMock(
+            return_value=[
+                [
+                    "jobs",
+                    [[b"1-0", {b"envelope": raw, b"enqueued_at_ms": b"123"}]],
+                ]
+            ]
+        )
+        wq = RedisStreamWorkQueue("redis://x", client=r, codec=codec)
+        batch = await wq.read_group("jobs", "g", "c1", count=1, block_ms=1)
+        assert len(batch.messages) == 1
+        assert batch.messages[0].message_id == "1-0"
+        assert batch.messages[0].envelope.kind == "test.kind"
+        assert batch.decode_errors == []
+
+    asyncio.run(_())
+
+
+def test_read_group_decode_error_collected() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        codec = OrionCodec()
+        r.xreadgroup = AsyncMock(
+            return_value=[
+                [
+                    "jobs",
+                    [[b"9-0", {b"envelope": b"not-json"}]],
+                ]
+            ]
+        )
+        wq = RedisStreamWorkQueue("redis://x", client=r, codec=codec)
+        batch = await wq.read_group("jobs", "g", "c1", count=1, block_ms=1)
+        assert batch.messages == []
+        assert len(batch.decode_errors) == 1
+        assert batch.decode_errors[0].message_id == "9-0"
+        assert batch.decode_errors[0].stream == "jobs"
+
+    asyncio.run(_())
+
+
+def test_read_group_batch_decodes_valid_before_invalid() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        codec = OrionCodec()
+        good = _env(kind="a.ok")
+        raw_ok = codec.encode(good)
+        r.xreadgroup = AsyncMock(
+            return_value=[
+                [
+                    "jobs",
+                    [
+                        [b"1-0", {b"envelope": raw_ok}],
+                        [b"2-0", {b"envelope": b"not-json"}],
+                    ],
+                ]
+            ]
+        )
+        wq = RedisStreamWorkQueue("redis://x", client=r, codec=codec)
+        batch = await wq.read_group("jobs", "g", "c1", count=2, block_ms=1)
+        assert len(batch.messages) == 1
+        assert batch.messages[0].message_id == "1-0"
+        assert len(batch.decode_errors) == 1
+        assert batch.decode_errors[0].message_id == "2-0"
+
+    asyncio.run(_())
+
+
+def test_ack_calls_xack() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        r.xack = AsyncMock(return_value=1)
+        wq = RedisStreamWorkQueue("redis://x", client=r)
+        n = await wq.ack("jobs", "g", "1-0")
+        assert n == 1
+        r.xack.assert_awaited_once_with("jobs", "g", "1-0")
+
+    asyncio.run(_())
+
+
+def test_pending_summary_normalizes_response() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        r.xpending = AsyncMock(return_value={b"pending": 3, b"min": b"1-0", b"max": b"2-0", b"consumers": []})
+        wq = RedisStreamWorkQueue("redis://x", client=r)
+        s = await wq.pending_summary("jobs", "g")
+        assert s["count"] == 3
+        assert s["min_id"] == "1-0"
+        assert s["max_id"] == "2-0"
+
+    asyncio.run(_())
+
+
+def test_pending_range_normalizes_response() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        r.xpending_range = AsyncMock(
+            return_value=[[b"1-0", b"c1", 5000, 2]],
+        )
+        wq = RedisStreamWorkQueue("redis://x", client=r)
+        rows = await wq.pending_range("jobs", "g", count=5)
+        assert len(rows) == 1
+        assert rows[0].message_id == "1-0"
+        assert rows[0].consumer == "c1"
+        assert rows[0].idle_ms == 5000
+        assert rows[0].deliveries == 2
+
+    asyncio.run(_())
+
+
+def test_autoclaim_decodes_messages() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        codec = OrionCodec()
+        env = _env()
+        raw = codec.encode(env)
+        r.xautoclaim = AsyncMock(return_value=[b"0-0", [[b"2-0", {b"envelope": raw}]]])
+        wq = RedisStreamWorkQueue("redis://x", client=r, codec=codec)
+        nxt, batch = await wq.autoclaim("jobs", "g", "c1", 1000, count=2)
+        assert nxt == "0-0"
+        assert len(batch.messages) == 1
+        assert batch.messages[0].message_id == "2-0"
+        assert batch.decode_errors == []
+
+    asyncio.run(_())
+
+
+def test_requeue_copies_envelope_and_increments_attempt() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        r.xadd = AsyncMock(return_value=b"2-0")
+        codec = OrionCodec()
+        env = _env(trace={"work": {"attempt": 1}})
+        wq = RedisStreamWorkQueue("redis://x", client=r, codec=codec)
+        sm = StreamMessage(
+            stream="jobs",
+            message_id="1-0",
+            envelope=env,
+            raw_fields={},
+            enqueued_at_ms=None,
+            delivery_count=None,
+        )
+        new_id = await wq.requeue("jobs", sm, 2, reason="retry")
+        assert new_id == "2-0"
+        fields = r.xadd.call_args[0][1]
+        dec = codec.decode(fields[b"envelope"])
+        assert dec.ok and dec.envelope
+        assert extract_work_metadata(dec.envelope).get("attempt") == 2
+
+    asyncio.run(_())
+
+
+def test_dlq_writes_original_envelope_and_error_metadata() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        r.xadd = AsyncMock(return_value=b"99-0")
+        codec = OrionCodec()
+        env = _env()
+        wq = RedisStreamWorkQueue("redis://x", client=r, codec=codec)
+        sm = StreamMessage(
+            stream="jobs",
+            message_id="1-0",
+            envelope=env,
+            raw_fields={},
+            enqueued_at_ms=None,
+            delivery_count=None,
+        )
+        mid = await wq.send_to_dlq("dlq", sm, error="boom", reason="TestErr", attempt=3)
+        assert mid == "99-0"
+        fields = r.xadd.call_args[0][1]
+        assert fields[b"schema_version"] == b"work_queue.dlq.v1"
+        assert fields[b"original_message_id"] == b"1-0"
+        dec = codec.decode(fields[b"envelope"])
+        assert dec.ok and dec.envelope.kind == "test.kind"
+
+    asyncio.run(_())
+
+
+def test_send_malformed_to_dlq_preserves_non_bytes_envelope() -> None:
+    async def _() -> None:
+        r = AsyncMock()
+        r.ping = AsyncMock()
+        r.xadd = AsyncMock(return_value=b"m-1")
+        wq = RedisStreamWorkQueue("redis://x", client=r)
+        await wq.send_malformed_to_dlq(
+            "dlq",
+            original_stream="jobs",
+            original_message_id="1-0",
+            raw_fields={b"envelope": 12345},
+            error="bad",
+            reason="decode",
+        )
+        fields = r.xadd.call_args[0][1]
+        assert fields[b"envelope"] == repr(12345).encode("utf-8", errors="replace")
+
+    asyncio.run(_())
+
+
+def test_queue_rpc_request_subscribe_before_enqueue_order() -> None:
+    async def _() -> None:
+        order: list[str] = []
+
+        class Q:
+            async def enqueue(self, *a, **k):
+                order.append("enqueue")
+                return "1-0"
+
+        q = Q()
+        pubsub = MagicMock()
+
+        @asynccontextmanager
+        async def sub_cm(*ch, **kw):
+            order.append("subscribe_ctx")
+            yield pubsub
+
+        reply_bus = MagicMock()
+        reply_bus.subscribe = sub_cm
+
+        async def it_messages(_p):
+            order.append("iter")
+            yield {"type": "message", "data": b"{}"}
+
+        reply_bus.iter_messages = it_messages
+        env = _env()
+        await queue_rpc_request(
+            queue=q,  # type: ignore[arg-type]
+            reply_bus=reply_bus,  # type: ignore[arg-type]
+            stream="jobs",
+            envelope=env,
+            reply_channel="rep:1",
+            timeout_sec=2.0,
+        )
+        assert order[0] == "subscribe_ctx"
+        assert order.index("subscribe_ctx") < order.index("enqueue")
+
+    asyncio.run(_())
+
+
+def test_copy_envelope_with_work_no_mutation() -> None:
+    env = _env(trace={"work": {"attempt": 1}, "x": 1})
+    e2 = copy_envelope_with_work(env, work_updates={"attempt": 2})
+    assert extract_work_metadata(env).get("attempt") == 1
+    assert extract_work_metadata(e2).get("attempt") == 2
+    assert env.trace["x"] == 1


### PR DESCRIPTION
# PR: Phase 4A/4B — Redis Streams work queue + QueueRabbit chassis

## Branch

- **Head:** `feat/bus-redis-streams-workqueue-phase4` (push to `origin`)
- **Base:** `main`

Create PR: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/bus-redis-streams-workqueue-phase4

---

## Summary

Adds a **foundation-only** substrate for safe work assignment: **Redis Streams + consumer groups** beside the existing **OrionBusAsync** PubSub bus. PubSub remains the nervous system for broadcasts, telemetry, and reply channels; streams carry **“exactly one consumer should do this job”** workloads with retry, optional DLQ, pending recovery (`XAUTOCLAIM`), and `queue_rpc_request` (subscribe to `reply_to` **before** enqueue to avoid fast-reply races). **No** migration of chat, recall, spark, exec, LLM, RDF, or vector traffic; **no** change to `OrionBusAsync`, Rabbit, or Hunter APIs.

---

## What changed

| Area | Change |
|------|--------|
| **`orion/core/bus/work_queue.py`** | `RedisStreamWorkQueue`: `XADD` / `XREADGROUP` / `XACK` / `XPENDING` / `XAUTOCLAIM`, `enqueue`, `requeue`, `send_to_dlq`, `send_malformed_to_dlq`, optional XINFO helpers. **`ReadGroupBatch`**: per-entry decode so one bad envelope in a batch does not strand earlier valid messages. `queue_rpc_request`: subscribe then enqueue; `reply_to` vs `reply_channel` mismatch warning. Owned Redis client closed on `close()`; injected client left open. |
| **`orion/core/bus/queue_service_chassis.py`** | **`QueueRabbit(BaseChassis)`**: consumer-group loop, handler → optional PubSub reply → ack; retry/requeue and DLQ after `max_attempts`; `not_before` / `expires_at` + `stale_policy`; decode-error path; reply publish failures routed through same retry/DLQ path as handler errors; concurrent mode with **bounded** reads (wait for in-flight capacity); `work_queue.close()` in `_run` `finally`. |
| **Tests** | `tests/test_work_queue.py`, `tests/test_queue_service_chassis.py`: mocked Redis; batch decode + malformed DLQ coverage; live two-consumer test **skipped** unless `ORION_REDIS_STREAM_TEST_URL` is set. |
| **Plan** | `docs/superpowers/plans/2026-05-13-redis-streams-workqueue-queuerabbit-phase4-implementation.md` |

---

## API note (callers)

- `RedisStreamWorkQueue.read_group` and `autoclaim` return **`ReadGroupBatch`** (`messages`, `decode_errors`), not a bare `list[StreamMessage]`.

---

## Verification (ran locally)

```bash
cd /mnt/scripts/Orion-Sapienform
PYTHONPATH=. ./venv/bin/python -m pytest tests/test_work_queue.py tests/test_queue_service_chassis.py -q --tb=short
# 29 passed, 1 skipped (live Redis test without ORION_REDIS_STREAM_TEST_URL)

PYTHONPATH=. ./venv/bin/python -m compileall -q orion/core/bus/work_queue.py orion/core/bus/queue_service_chassis.py
```

**Optional live test:** set `ORION_REDIS_STREAM_TEST_URL=redis://localhost:6379/15` and re-run pytest to exercise two consumers, one message.

---

## Risk / follow-up

- **Adoption:** Wire services to `QueueRabbit` + `RedisStreamWorkQueue` in later PRs; this PR does not enable any production queue by default.
- **Stash:** Local `orion-hub` edits and `scripts/git-stash-table.sh` were stashed before branching from `main` (`git stash list` — pops when you are ready).

---

## Suggested PR title

**feat(bus): Redis Streams work queue + QueueRabbit chassis (Phase 4 foundation)**
