### PR TITLE
feat(hub): deterministic Skill Runner lane + stash tooling

### DIFF
--- a/.verify-run/hub_quick_playwright_live.py
+++ b/.verify-run/hub_quick_playwright_live.py
@@ -9,6 +9,74 @@ import time
 from playwright.sync_api import sync_playwright
 
 
+def _run_fast_two_turns(
+    *,
+    base_url: str,
+    headless: bool,
+    timeout_ms: int,
+    probe1: str | None,
+    probe2: str | None,
+) -> int:
+    """Quick (fast) only: send probe1, wait for reply, immediately send probe2, wait again. Prints per-turn wall ms."""
+    ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    p1 = (probe1 or "").strip() or f"pw-2turn-a-{ts}-{time.time():.0f}"
+    p2 = (probe2 or "").strip() or f"pw-2turn-b-{ts}-{time.time():.0f}"
+    print(f"TRACE_PROBE_TURN1={p1}", flush=True)
+    print(f"TRACE_PROBE_TURN2={p2}", flush=True)
+
+    wait_js = """(probe) => {
+      const root = document.getElementById('conversation');
+      if (!root) return false;
+      const kids = [...root.children];
+      let userIdx = -1;
+      for (let i = 0; i < kids.length; i++) {
+        const el = kids[i];
+        if (el.getAttribute('data-role') === 'user' && (el.innerText || '').includes(probe)) {
+          userIdx = i;
+          break;
+        }
+      }
+      if (userIdx < 0) return false;
+      for (let j = userIdx + 1; j < kids.length; j++) {
+        const el = kids[j];
+        if (el.getAttribute('data-role') === 'assistant') {
+          const body = el.querySelector('p.whitespace-pre-wrap');
+          const txt = (body && body.textContent) ? body.textContent.trim() : (el.innerText || '').trim();
+          return txt.length > 15;
+        }
+      }
+      return false;
+    }"""
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=headless)
+        page = browser.new_page(viewport={"width": 1280, "height": 900})
+        page.goto(f"{base_url.rstrip('/')}/", wait_until="domcontentloaded", timeout=timeout_ms)
+        page.wait_for_selector("#quickModeBtn", state="visible", timeout=timeout_ms)
+        page.wait_for_selector("#chatInput", state="visible", timeout=timeout_ms)
+        page.click("#quickModeBtn")
+        page.wait_for_timeout(300)
+
+        for turn, probe in ((1, p1), (2, p2)):
+            t0 = time.perf_counter()
+            page.fill("#chatInput", probe)
+            page.click("#sendButton")
+            try:
+                page.wait_for_function(wait_js, arg=probe, timeout=timeout_ms)
+            except Exception as exc:
+                print(f"TURN{turn}_FAIL", repr(exc))
+                print("--- #status ---")
+                print(page.inner_text("#status")[:2000])
+                browser.close()
+                return 1
+            elapsed_ms = (time.perf_counter() - t0) * 1000.0
+            print(f"TURN{turn}_WALL_MS", round(elapsed_ms, 1), "PROBE", probe, flush=True)
+
+        print("--- #status ---", page.inner_text("#status")[:400], flush=True)
+        browser.close()
+    return 0
+
+
 def _run_one(
     *,
     base_url: str,
@@ -200,10 +268,33 @@ def main() -> int:
         default="",
         help="Exact user text to send (for log correlation). Default: auto-generated.",
     )
+    ap.add_argument(
+        "--two-fast-turns",
+        action="store_true",
+        help="Quick (fast) only: two back-to-back user messages; prints TURN1_WALL_MS / TURN2_WALL_MS (second often slower).",
+    )
+    ap.add_argument(
+        "--probe2",
+        default="",
+        help="Second user message (with --two-fast-turns). Default: auto-generated.",
+    )
     args = ap.parse_args()
 
     headless = not args.headed
     probe_opt = args.probe.strip() or None
+    probe2_opt = args.probe2.strip() or None
+
+    if args.two_fast_turns:
+        if args.variant not in ("fast", "both"):
+            print("--two-fast-turns requires --variant fast (ignoring stance).", flush=True)
+        return _run_fast_two_turns(
+            base_url=args.base_url,
+            headless=headless,
+            timeout_ms=args.timeout_ms,
+            probe1=probe_opt,
+            probe2=probe2_opt,
+        )
+
     if args.variant == "both":
         a = _run_one(
             base_url=args.base_url,

--- a/scripts/git-stash-table.sh
+++ b/scripts/git-stash-table.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Print git stashes as a table with commit timestamps (UTC from git object).
+#
+# Usage:
+#   ./scripts/git-stash-table.sh           # markdown table (default)
+#   ./scripts/git-stash-table.sh --tsv     # tab-separated
+#   ./scripts/git-stash-table.sh --plain # column-aligned (no markdown)
+#
+# Run from any directory inside a git work tree.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: git-stash-table.sh [--tsv|--plain|-h|--help]
+
+  (default)   Markdown table: Stash | When (UTC) | Branch | Message
+  --tsv       Tab-separated values
+  --plain     column(1)-aligned text
+EOF
+}
+
+MODE=markdown
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tsv) MODE=tsv ;;
+    --plain) MODE=plain ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "error: not inside a git repository" >&2
+  exit 1
+fi
+cd "$REPO_ROOT"
+
+# Args: full subject from "git log -1 --format=%s" on stash ref
+# Prints: branch<TAB>message_tail (branch may be empty)
+parse_stash_subject() {
+  local subj="$1"
+  if [[ "$subj" == "On "* ]]; then
+    local rest="${subj#On }"
+    printf '%s\t%s' "${rest%%: *}" "${rest#*: }"
+  elif [[ "$subj" == "WIP on "* ]]; then
+    local rest="${subj#WIP on }"
+    printf '%s\t%s' "${rest%%: *}" "${rest#*: }"
+  else
+    printf '\t%s' "$subj"
+  fi
+}
+
+md_escape() {
+  local s="$1"
+  s="${s//|/\\|}"
+  s="${s//\`/\\\`}"
+  printf '%s' "$s"
+}
+
+i=0
+rows=0
+plain_tmp=""
+if [[ "$MODE" == "plain" ]]; then
+  plain_tmp="$(mktemp)"
+  trap 'rm -f "${plain_tmp:-}"' EXIT
+fi
+
+if [[ "$MODE" == "markdown" ]]; then
+  echo "| Stash | When (UTC) | Branch | Message |"
+  echo "|-------|------------|--------|---------|"
+elif [[ "$MODE" == "tsv" ]]; then
+  printf '%s\t%s\t%s\t%s\n' "stash" "when_utc" "branch" "message"
+fi
+
+while git rev-parse "stash@{$i}" &>/dev/null; do
+  ref="stash@{$i}"
+  when="$(git log -1 --format='%ci' "$ref")"
+  subj="$(git log -1 --format='%s' "$ref")"
+  IFS=$'\t' read -r branch msg <<<"$(parse_stash_subject "$subj")"
+
+  case "$MODE" in
+    markdown)
+      echo "| \`$ref\` | $when | \`$(md_escape "$branch")\` | $(md_escape "$msg") |"
+      ;;
+    tsv)
+      # single-line message: tabs in subject become spaces
+      msg1="${subj//	/ }"
+      printf '%s\t%s\t%s\t%s\n' "$ref" "$when" "$branch" "$msg1"
+      ;;
+    plain)
+      msg1="${subj//	/ }"
+      printf '%s\t%s\t%s\t%s\n' "$ref" "$when" "$branch" "$msg1" >>"$plain_tmp"
+      ;;
+  esac
+
+  rows=$((rows + 1))
+  i=$((i + 1))
+done
+
+if [[ "$MODE" == "plain" && "$rows" -gt 0 ]]; then
+  column -t -s $'\t' "$plain_tmp"
+fi
+
+if [[ "$rows" -eq 0 ]]; then
+  echo "(no stashes)" >&2
+fi

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -37,7 +37,12 @@ from .trace_payloads import extract_agent_trace_payload
 from .autonomy_payloads import extract_autonomy_payload
 from .workflow_payloads import extract_workflow_payload
 from .cortex_chat_display import hub_effective_chat_text
-from .cortex_request_builder import build_chat_request, build_continuity_messages, validate_single_verb_override
+from .cortex_request_builder import (
+    HubRequestValidationError,
+    build_chat_request,
+    build_continuity_messages,
+    validate_single_verb_override,
+)
 from .mutation_cognition_context import build_mutation_cognition_context
 from .autonomy_constitution import (
     COGNITIVE_LIVE_APPLY_ENABLED,
@@ -734,6 +739,21 @@ def api_debug_build():
             "notify_base_url": settings.NOTIFY_BASE_URL,
             "landing_pad_url": settings.LANDING_PAD_URL,
         },
+    }
+
+
+@router.get("/api/debug/skill-runner-deterministic")
+def api_debug_skill_runner_deterministic(prompt: str = Query(default="", description="Exact Skill Runner catalogue prompt value")) -> Dict[str, Any]:
+    """Resolve prompt to catalogue verb (no cortex). Use to verify deterministic-lane eligibility."""
+    from scripts.skill_runner_catalogue import resolve_skill_runner_catalogue_verb
+
+    p = str(prompt or "").strip()
+    verb = resolve_skill_runner_catalogue_verb(prompt=p, skill_runner_origin=True)
+    ok = bool(verb and str(verb).strip().startswith("skills."))
+    return {
+        "prompt": p,
+        "catalogue_verb": verb,
+        "deterministic_eligible": ok,
     }
 
 
@@ -1746,17 +1766,20 @@ async def handle_chat_request(
         except Exception:
             pass
     routed_payload["mutation_cognition_context"] = build_mutation_cognition_context(store=SUBSTRATE_MUTATION_STORE)
-    req, route_debug, _ = build_chat_request(
-        payload=routed_payload,
-        session_id=session_id,
-        user_id=payload.get("user_id"),
-        trace_id=None,
-        default_mode="brain",
-        auto_default_enabled=bool(settings.HUB_AUTO_DEFAULT_ENABLED),
-        source_label="hub_http",
-        prompt=user_prompt,
-        messages=continuity_messages,
-    )
+    try:
+        req, route_debug, _ = build_chat_request(
+            payload=routed_payload,
+            session_id=session_id,
+            user_id=payload.get("user_id"),
+            trace_id=None,
+            default_mode="brain",
+            auto_default_enabled=bool(settings.HUB_AUTO_DEFAULT_ENABLED),
+            source_label="hub_http",
+            prompt=user_prompt,
+            messages=continuity_messages,
+        )
+    except HubRequestValidationError as exc:
+        return {"error": str(exc), "error_code": exc.code}
     workflow_request = req.metadata.get("workflow_request") if isinstance(req.metadata, dict) else None
     execution_policy = workflow_request.get("execution_policy") if isinstance(workflow_request, dict) else None
     logger.info(

--- a/services/orion-hub/scripts/cortex_request_builder.py
+++ b/services/orion-hub/scripts/cortex_request_builder.py
@@ -37,6 +37,15 @@ from orion.schemas.social_gif import (
 
 logger = logging.getLogger("orion-hub.request-builder")
 
+
+class HubRequestValidationError(ValueError):
+    """Hub refused to build a CortexChatRequest (client can fix payload and retry)."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(message)
+
+
 try:
     from scripts.social_room import (
         SOCIAL_ROOM_PROFILE,
@@ -113,6 +122,9 @@ def _normalize_skill_runner_lane(
     if not _normalize_flag(payload.get("skill_runner_origin"), default=False):
         return selected_ui_route, selected_verbs
     lane = str(payload.get("skill_runner_lane") or "").strip().lower()
+    # Deterministic lane: exact catalogue -> single skills.* verb, brain only (never chat_quick / agent).
+    if lane == "deterministic":
+        return "brain", selected_verbs
     if lane == "quick":
         if len(selected_verbs) == 1 and str(selected_verbs[0]).strip().startswith("skills."):
             return "brain", selected_verbs
@@ -405,6 +417,29 @@ def build_cortex_chat_request(
         route_intent = "none"
         options.pop("route_intent", None)
 
+    skill_runner_lane_raw = str(payload.get("skill_runner_lane") or "").strip().lower()
+    deterministic_requested = _normalize_flag(payload.get("skill_runner_origin"), default=False) and (
+        skill_runner_lane_raw == "deterministic"
+    )
+    if deterministic_requested:
+        if workflow_request_override is not None or workflow_match is not None or workflow_management is not None:
+            raise HubRequestValidationError(
+                "skill_runner_deterministic_no_workflow",
+                "Skill Runner deterministic lane only supports catalogue skills (not workflows or schedule ops).",
+            )
+        if not verb_override or not str(verb_override).strip().startswith("skills."):
+            raise HubRequestValidationError(
+                "skill_runner_deterministic_requires_skill_verb",
+                "Skill Runner deterministic lane requires a catalogue prompt that resolves to exactly one skills.* verb.",
+            )
+        if mode != "brain":
+            raise HubRequestValidationError(
+                "skill_runner_deterministic_requires_brain_mode",
+                "Skill Runner deterministic lane only runs in brain mode.",
+            )
+        options["force_agent_chain"] = False
+        options.pop("supervised", None)
+
     metadata: Dict[str, Any] = {
         "source": source_label,
         "hub_route": {
@@ -620,6 +655,12 @@ def build_cortex_chat_request(
         "workflow_requested": bool(workflow_match is not None or workflow_management is not None),
         "fallback_route": "workflow_lane" if (workflow_match is not None or workflow_management is not None) else "chat_or_auto_route",
         "skill_runner_catalogue_verb": skill_runner_catalogue_verb,
+        "skill_runner_lane_requested": (
+            (skill_runner_lane_raw or None)
+            if _normalize_flag(payload.get("skill_runner_origin"), default=False)
+            else None
+        ),
+        "skill_runner_deterministic": bool(deterministic_requested),
     }
     if social_room:
         debug["social_skill_allowlist"] = metadata.get("social_skill_request", {}).get("allowlist") or []

--- a/services/orion-hub/scripts/skill_runner_catalogue.py
+++ b/services/orion-hub/scripts/skill_runner_catalogue.py
@@ -2,6 +2,9 @@
 
 Keys MUST match option ``value=`` strings in ``services/orion-hub/templates/index.html``.
 See ``docs/operator_skill_prompt_catalogue.md`` (kept in sync with the Hub Skill Runner dropdown).
+
+Operator **deterministic** lane (``skill_runner_lane=deterministic``): same catalogue map, brain-only,
+single ``skills.*`` verb — no ``chat_quick``, no agent chain, no workflow payloads.
 """
 
 from __future__ import annotations

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -11,7 +11,12 @@ from typing import Any, Dict, List, Optional
 from fastapi import WebSocket, WebSocketDisconnect
 
 from scripts.settings import settings
-from scripts.cortex_request_builder import build_chat_request, build_continuity_messages, validate_single_verb_override
+from scripts.cortex_request_builder import (
+    HubRequestValidationError,
+    build_chat_request,
+    build_continuity_messages,
+    validate_single_verb_override,
+)
 from scripts.biometrics_cache import BiometricsCache
 from scripts.chat_history import (
     build_chat_history_envelope,
@@ -551,17 +556,26 @@ async def websocket_endpoint(websocket: WebSocket):
                 if stored_presence:
                     data["presence_context"] = stored_presence
             data["mutation_cognition_context"] = build_mutation_cognition_context()
-            chat_req, route_debug, use_recall = build_chat_request(
-                payload=data,
-                session_id=session_id,
-                user_id=data.get("user_id"),
-                trace_id=trace_id,
-                default_mode="brain",
-                auto_default_enabled=bool(settings.HUB_AUTO_DEFAULT_ENABLED),
-                source_label="hub_ws",
-                prompt=prompt_with_ctx,
-                messages=continuity_messages,
-            )
+            try:
+                chat_req, route_debug, use_recall = build_chat_request(
+                    payload=data,
+                    session_id=session_id,
+                    user_id=data.get("user_id"),
+                    trace_id=trace_id,
+                    default_mode="brain",
+                    auto_default_enabled=bool(settings.HUB_AUTO_DEFAULT_ENABLED),
+                    source_label="hub_ws",
+                    prompt=prompt_with_ctx,
+                    messages=continuity_messages,
+                )
+            except HubRequestValidationError as exc:
+                await websocket.send_json(
+                    await _with_biometrics(
+                        {"error": str(exc), "error_code": exc.code},
+                        cache=biometrics_cache,
+                    )
+                )
+                continue
             workflow_request = chat_req.metadata.get("workflow_request") if isinstance(chat_req.metadata, dict) else None
             execution_policy = workflow_request.get("execution_policy") if isinstance(workflow_request, dict) else None
             logger.info(

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -113,6 +113,7 @@ loadDismissedIds();
   const skillRunnerSelect = document.getElementById('skillRunnerSelect');
   const skillRunnerRunBtn = document.getElementById('skillRunnerRunBtn');
   const skillRunnerInsertBtn = document.getElementById('skillRunnerInsertBtn');
+  const skillRunnerDeterministicOnly = document.getElementById('skillRunnerDeterministicOnly');
   const textToSpeechToggle = document.getElementById('textToSpeechToggle');
   const recallToggle = document.getElementById('recallToggle');
   const recallRequiredToggle = document.getElementById('recallRequiredToggle');
@@ -8094,6 +8095,14 @@ loadDismissedIds();
     };
   }
   function getSkillRunnerLaneOptions() {
+    if (skillRunnerDeterministicOnly && skillRunnerDeterministicOnly.checked) {
+      return {
+        mode: 'brain',
+        verbs: [],
+        skillRunnerOrigin: true,
+        skillRunnerLane: 'deterministic',
+      };
+    }
     const laneMode = String(currentMode || 'brain').toLowerCase();
     const verbOverride = modeVerbOverride ? String(modeVerbOverride).trim() : '';
     if (verbOverride === 'chat_quick') {
@@ -8132,6 +8141,14 @@ loadDismissedIds();
     skillRunnerRunBtn.addEventListener('click', async () => {
       const { prompt: promptText, workflowId } = getSkillRunnerSelection();
       if (!promptText) return;
+      if (workflowId && skillRunnerDeterministicOnly && skillRunnerDeterministicOnly.checked) {
+        appendMessage(
+          'System',
+          'Deterministic Skill Runner cannot run cognitive workflows. Uncheck "Deterministic lane" or pick a catalogue skill (non-workflow) row.',
+          'text-amber-400',
+        );
+        return;
+      }
       const runOptions = getSkillRunnerLaneOptions();
       if (workflowId) {
         runOptions.workflowRequestOverride = { workflow_id: workflowId };

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -340,6 +340,15 @@
           >
             Run
           </button>
+          <label class="flex items-start gap-1.5 text-[10px] text-gray-400 max-w-sm leading-tight cursor-pointer select-none">
+            <input
+              type="checkbox"
+              id="skillRunnerDeterministicOnly"
+              class="rounded border-gray-600 bg-gray-800 shrink-0 mt-0.5"
+            />
+            <span>Deterministic lane: catalogue <code class="text-indigo-300">skills.*</code> only (no workflows,
+              quick, or agent).</span>
+          </label>
         </div>
 
         <div id="runtimeDebugPanel" class="bg-gray-800/40 border border-gray-700 rounded-xl p-3 space-y-2">

--- a/services/orion-hub/tests/test_cortex_request_builder.py
+++ b/services/orion-hub/tests/test_cortex_request_builder.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "cortex_request_builder.py"
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -892,3 +894,65 @@ def test_social_room_artifact_dialogue_can_confirm_pending_proposal() -> None:
     assert req.metadata["social_skill_selection"]["selected_skill"] == "social_artifact_dialogue"
     assert "carry forward" in req.metadata["social_skill_result"]["summary"].lower()
     assert debug["social_artifact_confirmation"]["decision_state"] == "accepted"
+
+
+def test_skill_runner_deterministic_lane_catalogue_success() -> None:
+    prompt = "What time is it right now?"
+    req, debug, _ = hub_builder.build_chat_request(
+        payload={
+            "mode": "brain",
+            "skill_runner_origin": True,
+            "skill_runner_lane": "deterministic",
+        },
+        session_id="sid-sr-det",
+        user_id="user-1",
+        trace_id="trace-sr-det",
+        default_mode="brain",
+        auto_default_enabled=False,
+        source_label="hub_http",
+        prompt=prompt,
+    )
+    assert req.mode == "brain"
+    assert req.verb == "skills.system.time_now.v1"
+    assert req.options.get("force_agent_chain") is False
+    assert "supervised" not in req.options
+    assert debug["skill_runner_deterministic"] is True
+    assert debug["skill_runner_lane_requested"] == "deterministic"
+
+
+def test_skill_runner_deterministic_lane_rejects_workflow_prompt() -> None:
+    with pytest.raises(hub_builder.HubRequestValidationError) as exc:
+        hub_builder.build_chat_request(
+            payload={
+                "mode": "brain",
+                "skill_runner_origin": True,
+                "skill_runner_lane": "deterministic",
+            },
+            session_id="sid-sr-det-wf",
+            user_id="user-1",
+            trace_id="trace-sr-det-wf",
+            default_mode="brain",
+            auto_default_enabled=False,
+            source_label="hub_http",
+            prompt="Run through your concept induction graphs",
+        )
+    assert exc.value.code == "skill_runner_deterministic_no_workflow"
+
+
+def test_skill_runner_deterministic_lane_requires_catalogue_match() -> None:
+    with pytest.raises(hub_builder.HubRequestValidationError) as exc:
+        hub_builder.build_chat_request(
+            payload={
+                "mode": "brain",
+                "skill_runner_origin": True,
+                "skill_runner_lane": "deterministic",
+            },
+            session_id="sid-sr-det-miss",
+            user_id="user-1",
+            trace_id="trace-sr-det-miss",
+            default_mode="brain",
+            auto_default_enabled=False,
+            source_label="hub_http",
+            prompt="Not a catalogue skill runner prompt.",
+        )
+    assert exc.value.code == "skill_runner_deterministic_requires_skill_verb"

--- a/services/orion-signal-gateway/app/processor.py
+++ b/services/orion-signal-gateway/app/processor.py
@@ -201,6 +201,7 @@ class SignalProcessor:
 
     async def _emit_passthrough(self, signal: OrionSignalV1) -> None:
         """Self-hardened signal: re-emit without adapting (spec §2); keep existing OTEL fields."""
+        # Dedupe key recorded in handle_envelope before this call when suppress mode is on.
         await self._publish(signal)
 
     async def _emit_traced(self, signal: OrionSignalV1, *, prior: dict[str, OrionSignalV1]) -> None:

--- a/services/orion-signal-gateway/app/settings.py
+++ b/services/orion-signal-gateway/app/settings.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
     SIGNALS_OUTPUT_CHANNEL: str = "orion:signals"
     SIGNALS_PASSTHROUGH_PATTERN: str = "orion:signals:*"
     SIGNAL_WINDOW_SEC: float = 30.0
+    # When True, skip adapter emit if a recent passthrough for the same (organ_id, source_event_id) exists.
     SUPPRESS_ADAPTED_WHEN_PASSTHROUGH: bool = False
     PASSTHROUGH_DEDUPE_WINDOW_SEC: float = 30.0
 

--- a/services/orion-spark-introspector/.env_example
+++ b/services/orion-spark-introspector/.env_example
@@ -116,3 +116,26 @@ SPARK_INTROSPECTION_QUEUE_DEBUG_ENABLE=false
 #SPARK_INTROSPECTION_QUEUE_DEBUG_TOKEN=
 # How long to wait for orchestrator reply
 CORTEX_TIMEOUT_SEC=300
+
+# --- Spark introspection pressure (Phase 1) ---
+# When false: still run validation, cache gates, candidate telemetry, and tissue update; then skip cortex RPC (emergency kill switch).
+SPARK_INTROSPECTION_ENABLE_HEAVY=true
+# Max concurrent heavy introspection RPCs (semaphore permits).
+SPARK_INTROSPECTION_MAX_INFLIGHT=1
+# Timeout (seconds) for the cortex RPC inside heavy introspection.
+SPARK_INTROSPECTION_TIMEOUT_SEC=45
+# Skip heavy introspection when envelope created_at is older than this (seconds).
+SPARK_INTROSPECTION_QUEUE_MAX_AGE_SEC=180
+# When true with SPARK_INTROSPECTION_ACQUIRE_TIMEOUT_SEC<=0, do not block waiting for a semaphore slot (immediate drop if busy).
+SPARK_INTROSPECTION_DROP_ON_PRESSURE=true
+# Max wait (seconds) to acquire semaphore; <=0 with DROP_ON_PRESSURE=true means immediate drop; with DROP_ON_PRESSURE=false, <=0 means unbounded wait (operators may prefer a positive timeout).
+SPARK_INTROSPECTION_ACQUIRE_TIMEOUT_SEC=0
+# Minimum wall time (seconds) between successful heavy completions (global throttle).
+SPARK_INTROSPECTION_MIN_INTERVAL_SEC=0
+# Use Redis (same URL as ORION_BUS_URL unless SPARK_INTROSPECTION_REDIS_URL is set) for inflight SETNX and done markers.
+SPARK_INTROSPECTION_IDEMPOTENCY_ENABLE=true
+# Optional override for idempotency Redis; if unset, ORION_BUS_URL is used.
+#SPARK_INTROSPECTION_REDIS_URL=redis://orion-redis:6379/0
+SPARK_INTROSPECTION_KEY_PREFIX=spark:introspection
+SPARK_INTROSPECTION_INFLIGHT_TTL_SEC=300
+SPARK_INTROSPECTION_DONE_TTL_SEC=86400


### PR DESCRIPTION
This PR combines several previously stashed pieces of work onto the spark introspector queue branch.

Orion Hub — deterministic Skill Runner

Adds a deterministic Skill Runner lane: catalogue prompts resolve to a single skills.* verb, brain mode only, with validation that rejects workflows, non-catalogue prompts, and invalid option combinations.
Surfaces validation failures over HTTP and WebSocket as structured error / error_code responses.
UI: checkbox to send skill_runner_lane: deterministic with skill_runner_origin; blocks running a workflow row while deterministic is enabled (client-side guard + server-side validation).
Debug: GET /api/debug/skill-runner-deterministic?prompt=... returns catalogue resolution without hitting Cortex.
Tests: test_cortex_request_builder.py covers success, workflow rejection, and unknown-prompt rejection for the deterministic lane.
Tooling / ops

Adds scripts/git-stash-table.sh to list stashes with timestamps (Markdown / plain / TSV).
Other

.verify-run/hub_quick_playwright_live.py: helper for a fast two-turn Hub quick-mode probe.
orion-spark-introspector: .env_example updates (aligned with existing queue-backed compose on this branch).
orion-signal-gateway: short comments clarifying passthrough suppress / dedupe settings (no behaviour change intended).
Verification

pytest services/orion-hub/tests/test_cortex_request_builder.py::test_skill_runner_deterministic_lane_* (3 tests) passed locally.
Base branch note

PR targets the branch you were on: feat/spark-introspector-queue-backed-heavy-introspection (or change base in GitHub if you prefer main).