### PR TITLE
fix(spark-introspect): skip unified beliefs and autonomy GraphDB on s…

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-14-spark-introspect-skip-unified-beliefs-autonomy-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-14-spark-introspect-skip-unified-beliefs-autonomy-pr.md
@@ -1,0 +1,87 @@
+# PR: Spark introspection — skip unified beliefs & autonomy GraphDB
+
+## Branch
+
+- **Head:** `feat/spark-introspect-skip-unified-beliefs-autonomy`
+- **Base:** Prefer **`main`** (or your integration branch). This branch was created from **`feat/hub-deterministic-skill-runner-and-stash-tooling`** at the time of the commit; rebase onto `main` before merge if that parent is not the desired base.
+
+Create PR: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/spark-introspect-skip-unified-beliefs-autonomy
+
+---
+
+## Summary
+
+`introspect_spark` was still paying **Cognitive Unification** and **`autonomy_ctx_adapter`** cost because **`prepare_brain_reply_context` ran from `PlanRunner`** (router) for brain-mode verbs, independent of the executor `_should_prepare_brain_reply_context` gate. This change adds **adapter- and layer-level hard skips**, **router skip** for brain prep on spark introspection, **explicit cortex `options` flags** from the spark-introspector worker, and **tests** so GraphDB / `list_latest` autonomy fan-out does not run on the spark introspection path.
+
+---
+
+## What changed
+
+| Area | Change |
+|------|--------|
+| **`orion/substrate/relational/adapters/autonomy_ctx.py`** | `map_autonomy_ctx_to_substrate`: early return for `introspect_spark`, `execution_lane`/`llm_lane` == `spark`, `skip_unified_beliefs` / `skip_autonomy_context` (ctx or `options`). |
+| **`orion/substrate/relational/layer.py`** | `_skip_unified_beliefs_ctx`, `_lightweight_belief_set`; `beliefs_for_stance` returns empty slices + lineage marker before any producer fan-out. |
+| **`services/orion-cortex-exec/app/chat_stance.py`** | `_unified_beliefs_for_stance` short-circuits using layer skip helpers before `_get_unification_layer()`. |
+| **`services/orion-cortex-exec/app/router.py`** | Skip `prepare_brain_reply_context` when `skip_brain_reply_context` or `verb == introspect_spark`. |
+| **`services/orion-cortex-exec/app/executor.py`** | `_should_prepare_brain_reply_context`: skip `introspect_spark` (brain prep per exec step). |
+| **`services/orion-cortex-exec/tests/test_executor_runtime_context_skip.py`** | Assert introspect spark skips brain reply context prep. |
+| **`services/orion-spark-introspector/app/worker.py`** | Cortex request `options`: `skip_brain_reply_context`, `skip_unified_beliefs`, `skip_autonomy_context`, `skip_chat_stance_inputs`. |
+| **`orion/substrate/relational/tests/test_adapters.py`** | `TestAutonomyCtxAdapterSkip`. |
+| **`orion/substrate/relational/tests/test_layer.py`** | `test_beliefs_for_stance_skips_producers_for_introspect_spark`. |
+
+---
+
+## Verification (ran locally)
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+PYTHONPATH=. ./venv/bin/python -m pytest \
+  orion/substrate/relational/tests/test_adapters.py \
+  orion/substrate/relational/tests/test_layer.py \
+  orion/substrate/relational/tests/test_golden_path.py \
+  services/orion-cortex-exec/tests/test_executor_runtime_context_skip.py \
+  services/orion-cortex-exec/tests/test_chat_stance_brief.py \
+  -q --tb=short
+# 77 passed (subset run during development); re-run full suite if your CI scope differs.
+```
+
+---
+
+## Risk / follow-up
+
+- **`execution_lane == "spark"`** in `_skip_unified_beliefs_ctx` skips unified beliefs for **any** verb on that lane, not only `introspect_spark`. If a future verb needs full beliefs on the spark exec lane, tighten the predicate (e.g. require `verb == "introspect_spark"` in addition to lane).
+
+---
+
+## Suggested PR title
+
+**fix(spark-introspect): skip unified beliefs and autonomy GraphDB on spark path**
+
+---
+
+## Suggested PR description (copy-paste)
+
+### What & why
+
+Spark heavy introspection (`introspect_spark`) only needs `metadata` for `introspect_spark.j2`, but **router-level `prepare_brain_reply_context`** still invoked **`build_chat_stance_inputs` → unified layer → `map_autonomy_ctx_to_substrate`**, producing duplicate autonomy consumers (`chat_stance` + `autonomy_ctx_adapter`) and GraphDB fan-out. This PR blocks that at the **router**, **unification layer**, **autonomy adapter**, **chat_stance** early exit, **executor** brain-prep gate, and **spark-introspector** cortex `options`.
+
+### Key behavior
+
+- **Autonomy adapter:** no repository / `list_latest` when spark introspection, spark lane, or skip flags are set.
+- **CognitiveUnificationLayer:** returns a lightweight `UnifiedRelationalBeliefSetV1` with lineage `skipped:introspect_spark_or_unified_beliefs_disabled` without running producers.
+- **PlanRunner:** does not call `prepare_brain_reply_context` for `introspect_spark` or when `skip_brain_reply_context` is true after options merge.
+- **Spark introspector:** sets explicit `skip_*` options on the cortex request for downstream consistency.
+
+### How to test
+
+```bash
+PYTHONPATH=. ./venv/bin/python -m pytest orion/substrate/relational/tests/test_adapters.py \
+  orion/substrate/relational/tests/test_layer.py orion/substrate/relational/tests/test_golden_path.py \
+  services/orion-cortex-exec/tests/test_executor_runtime_context_skip.py \
+  services/orion-cortex-exec/tests/test_chat_stance_brief.py -q --tb=short
+```
+
+### Checklist
+
+- [ ] Rebase onto correct base (`main` vs parent feature branch) before merge.
+- [ ] Confirm no other verb legitimately needs full unified beliefs on `execution_lane=spark`.

--- a/orion/substrate/relational/adapters/autonomy_ctx.py
+++ b/orion/substrate/relational/adapters/autonomy_ctx.py
@@ -151,6 +151,31 @@ def _map_autonomy_state_to_nodes(state: Any, *, anchor: str) -> list[Any]:
 
 def map_autonomy_ctx_to_substrate(ctx: dict[str, Any]) -> SubstrateGraphRecordV1 | None:
     """Fetch autonomy state for all subjects and map to substrate nodes (graphdb_durable)."""
+    verb = str(ctx.get("verb") or ctx.get("requested_verb") or "").strip().lower()
+    opts = ctx.get("options") if isinstance(ctx.get("options"), dict) else {}
+    lane = str(
+        ctx.get("execution_lane")
+        or ctx.get("llm_lane")
+        or opts.get("execution_lane")
+        or opts.get("llm_lane")
+        or ""
+    ).strip().lower()
+    if (
+        verb == "introspect_spark"
+        or lane == "spark"
+        or bool(ctx.get("skip_unified_beliefs"))
+        or bool(ctx.get("skip_autonomy_context"))
+        or bool(opts.get("skip_unified_beliefs"))
+        or bool(opts.get("skip_autonomy_context"))
+    ):
+        logger.info(
+            "autonomy_ctx_adapter_skip reason=spark_or_unified_beliefs_disabled verb=%s lane=%s correlation_id=%s",
+            verb,
+            lane,
+            ctx.get("correlation_id") or ctx.get("trace_id"),
+        )
+        return None
+
     try:
         from orion.autonomy.repository import build_autonomy_repository  # noqa: PLC0415 — lazy to avoid spacy at import time
     except ImportError as exc:

--- a/orion/substrate/relational/layer.py
+++ b/orion/substrate/relational/layer.py
@@ -24,6 +24,36 @@ logger = logging.getLogger("orion.substrate.relational.layer")
 _DEFAULT_ANCHORS: tuple[str, ...] = ("orion", "relationship", "juniper")
 
 
+def _skip_unified_beliefs_ctx(ctx: dict[str, Any]) -> bool:
+    """Heavy substrate / GraphDB work must not run for spark introspection or explicit skips."""
+    if bool(ctx.get("skip_unified_beliefs")):
+        return True
+    opts = ctx.get("options") if isinstance(ctx.get("options"), dict) else {}
+    if bool(opts.get("skip_unified_beliefs")):
+        return True
+    verb = str(ctx.get("verb") or ctx.get("requested_verb") or "").strip().lower()
+    if verb == "introspect_spark":
+        return True
+    lane = str(
+        ctx.get("execution_lane")
+        or ctx.get("llm_lane")
+        or opts.get("execution_lane")
+        or opts.get("llm_lane")
+        or ""
+    ).strip().lower()
+    return lane == "spark"
+
+
+def _lightweight_belief_set(anchors: Sequence[str]) -> UnifiedRelationalBeliefSetV1:
+    slices = {a: AnchorBeliefSliceV1(anchor=a) for a in anchors}
+    return UnifiedRelationalBeliefSetV1(
+        anchors=slices,
+        cold_anchors=[],
+        degraded_producers=[],
+        lineage=["skipped:introspect_spark_or_unified_beliefs_disabled"],
+    )
+
+
 def _aggregate_tier_outcomes(
     results: list[MaterializationResultV1],
     node_id_to_anchor: dict[str, str],
@@ -97,6 +127,15 @@ class CognitiveUnificationLayer:
         is marked ``degraded=True``.
         """
         ctx = ctx if isinstance(ctx, dict) else {}
+
+        if _skip_unified_beliefs_ctx(ctx):
+            anchors_resolved = tuple(anchors) if anchors else _DEFAULT_ANCHORS
+            logger.info(
+                "cognitive_unification_layer_skip reason=spark_or_unified_beliefs_disabled verb=%s correlation_id=%s",
+                ctx.get("verb"),
+                ctx.get("correlation_id") or ctx.get("trace_id"),
+            )
+            return _lightweight_belief_set(anchors_resolved)
 
         # Fresh ephemeral store per call (snapshot_ephemeral nodes are never cached)
         ephemeral_store = InMemorySubstrateGraphStore()

--- a/orion/substrate/relational/tests/test_adapters.py
+++ b/orion/substrate/relational/tests/test_adapters.py
@@ -155,6 +155,29 @@ class TestSocialAdapter:
 
 
 # ---------------------------------------------------------------------------
+# autonomy_ctx adapter — hard skip for spark introspection (no GraphDB)
+# ---------------------------------------------------------------------------
+
+
+class TestAutonomyCtxAdapterSkip:
+    def test_skips_for_introspect_spark_verb(self):
+        from orion.substrate.relational.adapters.autonomy_ctx import map_autonomy_ctx_to_substrate
+
+        assert map_autonomy_ctx_to_substrate({"verb": "introspect_spark", "correlation_id": "c1"}) is None
+
+    def test_skips_for_spark_lane(self):
+        from orion.substrate.relational.adapters.autonomy_ctx import map_autonomy_ctx_to_substrate
+
+        assert map_autonomy_ctx_to_substrate({"verb": "chat_general", "execution_lane": "spark"}) is None
+
+    def test_skips_for_flags(self):
+        from orion.substrate.relational.adapters.autonomy_ctx import map_autonomy_ctx_to_substrate
+
+        assert map_autonomy_ctx_to_substrate({"verb": "x", "skip_autonomy_context": True}) is None
+        assert map_autonomy_ctx_to_substrate({"verb": "x", "options": {"skip_unified_beliefs": True}}) is None
+
+
+# ---------------------------------------------------------------------------
 # Existing adapter smoke tests (registered, unchanged)
 # ---------------------------------------------------------------------------
 

--- a/orion/substrate/relational/tests/test_layer.py
+++ b/orion/substrate/relational/tests/test_layer.py
@@ -373,3 +373,22 @@ class TestTtlStaleness:
         call_count["n"] = 0
         layer.beliefs_for_stance(anchors=["orion"])
         assert call_count["n"] == 1
+
+
+def test_beliefs_for_stance_skips_producers_for_introspect_spark():
+    def boom(ctx: dict[str, Any]) -> SubstrateGraphRecordV1 | None:
+        raise AssertionError("producer must not run when skipping unified beliefs")
+
+    layer, _ = _make_layer([
+        ProducerEntryV1(
+            producer_id="ephemeral_only",
+            trust_tier=SNAPSHOT_EPHEMERAL,
+            anchor_scopes=("orion",),
+            freshness_ttl_sec=0,
+            pull_on_cold=False,
+            adapter_fn=boom,
+        ),
+    ])
+    beliefs = layer.beliefs_for_stance(anchors=["orion"], ctx={"verb": "introspect_spark"})
+    assert beliefs.lineage == ["skipped:introspect_spark_or_unified_beliefs_disabled"]
+    assert not beliefs.anchors["orion"].concepts

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -202,6 +202,11 @@ def _unified_beliefs_for_stance(ctx: Dict[str, Any]) -> UnifiedRelationalBeliefS
     and the affected anchor slice ``degraded`` flag.
     """
     try:
+        from orion.substrate.relational.layer import _lightweight_belief_set, _skip_unified_beliefs_ctx
+
+        if _skip_unified_beliefs_ctx(ctx):
+            return _lightweight_belief_set(("orion", "relationship", "juniper"))
+
         layer = _get_unification_layer()
         beliefs = layer.beliefs_for_stance(
             anchors=("orion", "relationship", "juniper"),

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -3576,6 +3576,12 @@ def _should_prepare_brain_reply_context(*, step: ExecutionStep, ctx: Dict[str, A
     verb_name = str(step.verb_name or "").strip().lower()
     if verb_name == "chat_quick":
         return False
+    # Spark introspection uses mode=brain but only renders introspect_spark.j2 from
+    # context.metadata (prompt/response/spark_meta). Full brain stance + unified
+    # beliefs (GraphDB/recall/social) is wasted work and dominated latency after the
+    # 2026-05-09 cognitive unification layer landed in build_chat_stance_inputs.
+    if verb_name == "introspect_spark":
+        return False
     if verb_name.startswith("skills.runtime."):
         return False
     return True

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -764,6 +764,12 @@ class PlanRunner:
                     prepare_brain_reply_context(ctx)
                 else:
                     prepare_chat_quick_reply_context(ctx)
+            elif ctx.get("skip_brain_reply_context") or str(plan.verb_name or "").strip().lower() == "introspect_spark":
+                logger.info(
+                    "router_skip_prepare_brain_reply_context corr=%s verb=%s reason=spark_or_skip_flag",
+                    correlation_id,
+                    plan.verb_name,
+                )
             else:
                 prepare_brain_reply_context(ctx)
         existing_scope = str(ctx.get("_run_scope_corr_id") or "")

--- a/services/orion-cortex-exec/tests/test_executor_runtime_context_skip.py
+++ b/services/orion-cortex-exec/tests/test_executor_runtime_context_skip.py
@@ -30,3 +30,13 @@ def test_chat_quick_skips_heavy_brain_reply_context_prep():
         services=["LLMGatewayService"],
     )
     assert _should_prepare_brain_reply_context(step=step, ctx={"mode": "brain"}) is False
+
+
+def test_introspect_spark_skips_heavy_brain_reply_context_prep():
+    step = ExecutionStep(
+        verb_name="introspect_spark",
+        step_name="generate_introspection",
+        order=0,
+        services=["LLMGatewayService"],
+    )
+    assert _should_prepare_brain_reply_context(step=step, ctx={"mode": "brain"}) is False

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -1547,6 +1547,10 @@ async def run_heavy_spark_introspection(
                 "allow_chat_fallback": allow_chat_fallback_opt,
                 "max_tokens": max_tokens_opt,
                 "timeout_sec": timeout_opt,
+                "skip_brain_reply_context": True,
+                "skip_unified_beliefs": True,
+                "skip_autonomy_context": True,
+                "skip_chat_stance_inputs": True,
             },
             recall={"enabled": False, "required": False},
         )


### PR DESCRIPTION
# PR: Spark introspection — skip unified beliefs & autonomy GraphDB

## Branch

- **Head:** `feat/spark-introspect-skip-unified-beliefs-autonomy`
- **Base:** Prefer **`main`** (or your integration branch). This branch was created from **`feat/hub-deterministic-skill-runner-and-stash-tooling`** at the time of the commit; rebase onto `main` before merge if that parent is not the desired base.

Create PR: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/spark-introspect-skip-unified-beliefs-autonomy

---

## Summary

`introspect_spark` was still paying **Cognitive Unification** and **`autonomy_ctx_adapter`** cost because **`prepare_brain_reply_context` ran from `PlanRunner`** (router) for brain-mode verbs, independent of the executor `_should_prepare_brain_reply_context` gate. This change adds **adapter- and layer-level hard skips**, **router skip** for brain prep on spark introspection, **explicit cortex `options` flags** from the spark-introspector worker, and **tests** so GraphDB / `list_latest` autonomy fan-out does not run on the spark introspection path.

---

## What changed

| Area | Change |
|------|--------|
| **`orion/substrate/relational/adapters/autonomy_ctx.py`** | `map_autonomy_ctx_to_substrate`: early return for `introspect_spark`, `execution_lane`/`llm_lane` == `spark`, `skip_unified_beliefs` / `skip_autonomy_context` (ctx or `options`). |
| **`orion/substrate/relational/layer.py`** | `_skip_unified_beliefs_ctx`, `_lightweight_belief_set`; `beliefs_for_stance` returns empty slices + lineage marker before any producer fan-out. |
| **`services/orion-cortex-exec/app/chat_stance.py`** | `_unified_beliefs_for_stance` short-circuits using layer skip helpers before `_get_unification_layer()`. |
| **`services/orion-cortex-exec/app/router.py`** | Skip `prepare_brain_reply_context` when `skip_brain_reply_context` or `verb == introspect_spark`. |
| **`services/orion-cortex-exec/app/executor.py`** | `_should_prepare_brain_reply_context`: skip `introspect_spark` (brain prep per exec step). |
| **`services/orion-cortex-exec/tests/test_executor_runtime_context_skip.py`** | Assert introspect spark skips brain reply context prep. |
| **`services/orion-spark-introspector/app/worker.py`** | Cortex request `options`: `skip_brain_reply_context`, `skip_unified_beliefs`, `skip_autonomy_context`, `skip_chat_stance_inputs`. |
| **`orion/substrate/relational/tests/test_adapters.py`** | `TestAutonomyCtxAdapterSkip`. |
| **`orion/substrate/relational/tests/test_layer.py`** | `test_beliefs_for_stance_skips_producers_for_introspect_spark`. |

---

## Verification (ran locally)

```bash
cd /mnt/scripts/Orion-Sapienform
PYTHONPATH=. ./venv/bin/python -m pytest \
  orion/substrate/relational/tests/test_adapters.py \
  orion/substrate/relational/tests/test_layer.py \
  orion/substrate/relational/tests/test_golden_path.py \
  services/orion-cortex-exec/tests/test_executor_runtime_context_skip.py \
  services/orion-cortex-exec/tests/test_chat_stance_brief.py \
  -q --tb=short
# 77 passed (subset run during development); re-run full suite if your CI scope differs.
```

---

## Risk / follow-up

- **`execution_lane == "spark"`** in `_skip_unified_beliefs_ctx` skips unified beliefs for **any** verb on that lane, not only `introspect_spark`. If a future verb needs full beliefs on the spark exec lane, tighten the predicate (e.g. require `verb == "introspect_spark"` in addition to lane).

---

## Suggested PR title

**fix(spark-introspect): skip unified beliefs and autonomy GraphDB on spark path**

---

## Suggested PR description (copy-paste)

### What & why

Spark heavy introspection (`introspect_spark`) only needs `metadata` for `introspect_spark.j2`, but **router-level `prepare_brain_reply_context`** still invoked **`build_chat_stance_inputs` → unified layer → `map_autonomy_ctx_to_substrate`**, producing duplicate autonomy consumers (`chat_stance` + `autonomy_ctx_adapter`) and GraphDB fan-out. This PR blocks that at the **router**, **unification layer**, **autonomy adapter**, **chat_stance** early exit, **executor** brain-prep gate, and **spark-introspector** cortex `options`.

### Key behavior

- **Autonomy adapter:** no repository / `list_latest` when spark introspection, spark lane, or skip flags are set.
- **CognitiveUnificationLayer:** returns a lightweight `UnifiedRelationalBeliefSetV1` with lineage `skipped:introspect_spark_or_unified_beliefs_disabled` without running producers.
- **PlanRunner:** does not call `prepare_brain_reply_context` for `introspect_spark` or when `skip_brain_reply_context` is true after options merge.
- **Spark introspector:** sets explicit `skip_*` options on the cortex request for downstream consistency.

### How to test

```bash
PYTHONPATH=. ./venv/bin/python -m pytest orion/substrate/relational/tests/test_adapters.py \
  orion/substrate/relational/tests/test_layer.py orion/substrate/relational/tests/test_golden_path.py \
  services/orion-cortex-exec/tests/test_executor_runtime_context_skip.py \
  services/orion-cortex-exec/tests/test_chat_stance_brief.py -q --tb=short
```

### Checklist

- [ ] Rebase onto correct base (`main` vs parent feature branch) before merge.
- [ ] Confirm no other verb legitimately needs full unified beliefs on `execution_lane=spark`.
