### PR TITLE
Harden RDF store v1 cutover safety

### DIFF
--- a/docs/architecture/rdf_store_v1_cutover.md
+++ b/docs/architecture/rdf_store_v1_cutover.md
@@ -1,0 +1,60 @@
+# RDF Store V1 Cutover
+
+Practical operator notes for the **V1 safety cutover**: one canonical bus-driven RDF write sink, explicit legacy quarantine, and narrowed blast radius for out-of-scope GraphDB special cases.
+
+## Canonical writer
+
+- **Service:** `services/orion-rdf-writer`
+- **Role:** Only service that should perform **general** RDF materialization writes from the Orion bus (collapse/tags/chat/cortex/… → triples → store).
+- **Implementation:** `app/rdf_store.py` (`GraphDbRdfStoreClient`, `FusekiRdfStoreClient`, `GenericSparqlRdfStoreClient`; `rdf4j` → generic), factory `build_rdf_store_client()`, queue in `app/service.py`.
+
+## Backend environment (`orion-rdf-writer`)
+
+| Variable | Purpose |
+|----------|---------|
+| `RDF_STORE_BACKEND` | `graphdb` \| `fuseki` \| `generic` \| `rdf4j` (alias of generic with URL requirements). |
+| `RDF_STORE_BASE_URL` | Fuseki base (e.g. `http://orion-athena-fuseki:3030`). |
+| `RDF_STORE_DATASET` | Fuseki dataset name (default `orion`). |
+| `RDF_STORE_GRAPH_STORE_URL` | Graph Store HTTP POST target (Fuseki data URL or generic). |
+| `RDF_STORE_QUERY_URL` | SPARQL query endpoint (optional for writes; used in health metadata). |
+| `RDF_STORE_UPDATE_URL` | SPARQL UPDATE endpoint (generic adapter fallback). |
+| `GRAPHDB_URL` / `GRAPHDB_REPO` / `GRAPHDB_USER` / `GRAPHDB_PASS` | Required when `RDF_STORE_BACKEND=graphdb` only. |
+
+Copy from `services/orion-rdf-writer/.env_example` (including the **RDF Store V1 Cutover** block).
+
+## Producer channels (unchanged)
+
+- Default enqueue list: **`orion:rdf:enqueue`** (override with `CHANNEL_RDF_ENQUEUE`).
+- Payload kind: **`rdf.write.request`** (`RdfWriteRequest` and related build kinds).
+- The writer also subscribes to other catalog channels; see `Settings.get_all_subscribe_channels()` in `app/settings.py`.
+
+## Legacy writer (quarantined)
+
+- **Service:** `services/orion-gdb-client`
+- **Default:** `GDB_CLIENT_ENABLED=false` — no GraphDB wait, no repository bootstrap, **no** bus listener, `/health` includes `"enabled": false`.
+- **Enable:** `GDB_CLIENT_ENABLED=true` only for backfill or legacy tests. **Do not** run beside `orion-rdf-writer` for the same logical writes without understanding duplicate-write risk.
+
+## Explicitly out of scope for V1 (still GraphDB or in-memory)
+
+1. **Memory graph approval** — `orion/memory_graph/approve.py` + Hub `POST /api/memory/graph/approve`. GraphDB statements API + Postgres with RDF compensation. Hub returns **`503`** with detail **`memory_graph_approval_requires_graphdb`** when `GRAPHDB_URL` is unset.
+2. **Substrate semantic store** — `orion/substrate/graphdb_store.py` `build_substrate_store_from_env()`. **GraphDB is used only when `SUBSTRATE_STORE_BACKEND=graphdb`**. Unset backend → **in-memory** even if `GRAPHDB_URL` is set (V1 blast-radius guard).
+
+## Operator cutover checklist
+
+1. Set `orion-rdf-writer` env: `RDF_STORE_BACKEND=fuseki` (or `generic`) and the matching `RDF_STORE_*` URLs (see `.env_example`).
+2. Set `GDB_CLIENT_ENABLED=false` for `orion-gdb-client` (default) or remove the service from the running stack.
+3. Set `SUBSTRATE_STORE_BACKEND=in_memory` unless you explicitly need durable substrate in GraphDB (`graphdb` + endpoint envs).
+4. Confirm Hub / recall GraphDB vars still satisfy **memory graph approval** if you use that API.
+5. Hit `orion-rdf-writer` **`GET /health`** — expect `rdf_store_backend`, queue snapshot fields, **no** secrets in URLs (credentials stripped).
+6. Publish a test `rdf.write.request` on `orion:rdf:enqueue` and confirm `rdf_write_enqueued` / `rdf_write_committed` log lines and stable dead-letter file size.
+
+## Rollback
+
+1. Point `RDF_STORE_BACKEND=graphdb` and restore `GRAPHDB_URL` / `GRAPHDB_REPO` on `orion-rdf-writer`.
+2. If you must restore the legacy parallel writer, set `GDB_CLIENT_ENABLED=true` on `orion-gdb-client` and ensure GraphDB is reachable (see service README). Prefer **not** duplicating producers indefinitely.
+
+## Remaining V2 work (do not track as V1 deliverables)
+
+- Backend-neutral memory graph approval store.
+- Backend-neutral substrate graph store.
+- Self-study / concept profile **read** cutover and GraphDB retirement once all direct read/write paths are migrated.

--- a/docs/superpowers/pr-reports/2026-05-15-rdf-store-v1-cutover-pr-body.md
+++ b/docs/superpowers/pr-reports/2026-05-15-rdf-store-v1-cutover-pr-body.md
@@ -1,0 +1,57 @@
+# PR: RDF Store V1 cutover safety
+
+## Summary
+
+- **Canonical general RDF writes:** `services/orion-rdf-writer` only (backend-neutral `RDF_STORE_*`; bus producers unchanged).
+- **Legacy writer quarantined:** `services/orion-gdb-client` defaults `GDB_CLIENT_ENABLED=false` — no GraphDB wait, repo bootstrap, listener, or heartbeat unless explicitly enabled.
+- **Substrate blast-radius:** `build_substrate_store_from_env()` uses in-memory when `SUBSTRATE_STORE_BACKEND` is unset; GraphDB substrate requires explicit `SUBSTRATE_STORE_BACKEND=graphdb` (global `GRAPHDB_URL` alone no longer auto-selects).
+- **Memory graph approval:** remains GraphDB-only; Hub returns `503` with `memory_graph_approval_requires_graphdb` when GraphDB is not configured (no silent migration to Fuseki/generic).
+- **Operator doc:** `docs/architecture/rdf_store_v1_cutover.md` (checklist, env, rollback).
+
+## V1 operator env (reference)
+
+```env
+RDF_STORE_BACKEND=fuseki
+RDF_STORE_BASE_URL=http://orion-athena-fuseki:3030
+RDF_STORE_DATASET=orion
+RDF_STORE_GRAPH_STORE_URL=http://orion-athena-fuseki:3030/orion/data
+RDF_STORE_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
+RDF_STORE_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
+GDB_CLIENT_ENABLED=false
+SUBSTRATE_STORE_BACKEND=in_memory
+```
+
+Hub deployments that need durable substrate may keep `SUBSTRATE_STORE_BACKEND=graphdb` in Hub `.env` / compose (explicit, not auto from `GRAPHDB_URL` alone).
+
+## Test plan
+
+- [x] `PYTHONPYCACHEPREFIX=/tmp/orion_pycache_$$ ./venv/bin/python -m compileall services/orion-rdf-writer services/orion-gdb-client orion/substrate orion/memory_graph -q`
+- [x] `PYTHONPATH=. ./venv/bin/python -m pytest services/orion-rdf-writer/tests -q` — **37 passed**
+- [x] `PYTHONPATH=. ./venv/bin/python -m pytest orion/substrate/tests -q` — **87 passed**
+- [x] `PYTHONPATH=. ./venv/bin/python -m pytest services/orion-gdb-client/tests -q` — **3 passed**
+- [x] `PYTHONPATH=. ./venv/bin/python -m pytest tests/test_memory_graph_graphdb_mocked.py tests/test_memory_graph_approve.py -q` — **2 passed**
+- [ ] Runtime: `orion-rdf-writer` `/health` shows `rdf_store_backend` + queue fields (no credentials in URLs)
+- [ ] Runtime: `orion-gdb-client` `/health` shows `"enabled": false` with default env
+- [ ] Runtime: publish `rdf.write.request` on `orion:rdf:enqueue` → `rdf_write_enqueued` / `rdf_write_committed` logs
+
+## Out of scope (V2)
+
+- Backend-neutral memory graph approval store
+- Backend-neutral substrate graph store
+- Concept profile / self-study read cutover
+- GraphDB retirement
+
+## Files touched
+
+| Area | Change |
+|------|--------|
+| `services/orion-rdf-writer/` | Startup `rdf_store_backend_selected` log; `.env_example` V1 block; compose comment; factory tests |
+| `services/orion-gdb-client/` | `GDB_CLIENT_ENABLED` gate; compose default false; tests; README |
+| `orion/substrate/graphdb_store.py` | Explicit GraphDB backend only; V1 default in-memory |
+| `orion/memory_graph/`, Hub routes | GraphDB-only doc + `memory_graph_approval_requires_graphdb` |
+| `docs/architecture/rdf_store_v1_cutover.md` | Operator cutover / rollback |
+
+## Risk notes
+
+- **gdb-client compose:** `depends_on: graphdb` removed; with `GDB_CLIENT_ENABLED=true`, operators must ensure GraphDB is reachable separately.
+- **Hub compose** still defaults `SUBSTRATE_STORE_BACKEND=graphdb` at compose level — intentional for durable Hub stacks; code default for unset env is in-memory.

--- a/orion/memory_graph/approve.py
+++ b/orion/memory_graph/approve.py
@@ -33,7 +33,10 @@ async def approve_memory_graph_draft(
     graphdb_pass: str = "",
     named_graph_iri: str,
 ) -> ApproveOutcome:
-    """validate → GraphDB (named graph + revision batch) → Postgres cards/edges; compensate RDF if PG fails."""
+    """validate → GraphDB (named graph + revision batch) → Postgres cards/edges; compensate RDF if PG fails.
+
+    **RDF Store V1:** GraphDB-only transactional path; not routed through ``orion-rdf-writer`` (no silent migration).
+    """
     batch_id = str(uuid4())
     g2 = draft_to_graph(draft, revision_batch=batch_id)
     violations = validate_graph(g2)

--- a/orion/substrate/graphdb_store.py
+++ b/orion/substrate/graphdb_store.py
@@ -6,6 +6,7 @@ import os
 from dataclasses import dataclass
 from hashlib import sha256
 from typing import Any, Optional
+from urllib.parse import urlparse, urlunparse
 
 import requests
 
@@ -564,9 +565,6 @@ WHERE {{ OPTIONAL {{ GRAPH <{self._cfg.graph_uri}> {{ {iri} ?p ?o . }} }} }}
         return f"{edge.source.node_id}|{edge.predicate}|{edge.target.node_id}"
 
 
-DEFAULT_SUBSTRATE_STORE_BACKEND = "in_memory"
-
-
 def _resolve_substrate_graphdb_endpoint() -> str:
     endpoint = str(os.getenv("SUBSTRATE_GRAPHDB_ENDPOINT", "")).strip()
     if endpoint:
@@ -578,29 +576,49 @@ def _resolve_substrate_graphdb_endpoint() -> str:
     return ""
 
 
-def build_substrate_store_from_env() -> SubstrateGraphStore:
-    """Return GraphDB-backed store when configured; otherwise in-memory.
+def _redact_endpoint_for_log(endpoint: str) -> str:
+    """Log-safe endpoint (host + path only; strips userinfo)."""
+    p = urlparse(endpoint)
+    netloc = p.hostname or ""
+    if p.port:
+        netloc = f"{netloc}:{p.port}"
+    return urlunparse((p.scheme, netloc, p.path, p.params, p.query, p.fragment))
 
-    Resolution order:
-    - ``SUBSTRATE_STORE_BACKEND=in_memory`` (or ``memory`` / ``mem``) → always in-memory.
-    - ``SUBSTRATE_STORE_BACKEND=graphdb`` (aliases) → GraphDB if endpoint resolvable, else in-memory with warning.
-    - Backend unset / empty → GraphDB when ``SUBSTRATE_GRAPHDB_ENDPOINT`` or ``GRAPHDB_URL``+``GRAPHDB_REPO``
-      resolves; otherwise in-memory (preserves dev default when no GraphDB env).
-    - Any other explicit backend string → in-memory.
+
+def build_substrate_store_from_env() -> SubstrateGraphStore:
+    """Select substrate semantic store.
+
+    **RDF Store V1 safety:** GraphDB is used only when ``SUBSTRATE_STORE_BACKEND`` is set to
+    ``graphdb`` (or aliases). Global ``GRAPHDB_URL`` alone must **not** activate this store;
+    that avoids accidental duplicate RDF surfaces during backend-neutral RDF writer cutover.
+
+    Resolution:
+    - ``SUBSTRATE_STORE_BACKEND`` unset / empty → in-memory (default).
+    - ``in_memory`` / ``memory`` / ``mem`` / ``local`` → in-memory.
+    - ``graphdb`` / ``graph_db`` / ``rdf`` → ``GraphDBSubstrateStore`` when
+      ``SUBSTRATE_GRAPHDB_ENDPOINT`` or ``GRAPHDB_URL``+``GRAPHDB_REPO`` resolves; else in-memory + warning.
+    - Any other backend string → in-memory + warning.
     """
     backend = str(os.getenv("SUBSTRATE_STORE_BACKEND", "")).strip().lower()
     endpoint = _resolve_substrate_graphdb_endpoint()
 
     if backend in {"in_memory", "memory", "mem", "local"}:
+        logger.info("substrate_store_backend_selected backend=in_memory reason=explicit_backend")
         return InMemorySubstrateGraphStore()
 
-    use_graphdb = backend in {"graphdb", "graph_db", "rdf"} or (backend == "" and bool(endpoint))
+    if not backend:
+        logger.info("substrate_store_backend_selected backend=in_memory reason=default_v1_safety")
+        return InMemorySubstrateGraphStore()
 
-    if use_graphdb:
+    if backend in {"graphdb", "graph_db", "rdf"}:
         if not endpoint:
-            if backend in {"graphdb", "graph_db", "rdf"}:
-                logger.warning("SUBSTRATE_STORE_BACKEND=graphdb but endpoint missing; falling back to in-memory store")
+            logger.warning("SUBSTRATE_STORE_BACKEND=graphdb but endpoint missing; falling back to in-memory store")
+            logger.info("substrate_store_backend_selected backend=in_memory reason=graphdb_endpoint_missing")
             return InMemorySubstrateGraphStore()
+        logger.info(
+            "substrate_store_backend_selected backend=graphdb endpoint=%s",
+            _redact_endpoint_for_log(endpoint),
+        )
         cfg = GraphDBSubstrateStoreConfig(
             endpoint=endpoint,
             graph_uri=str(os.getenv("SUBSTRATE_GRAPHDB_GRAPH_URI", DEFAULT_SUBSTRATE_GRAPH_URI)).strip() or DEFAULT_SUBSTRATE_GRAPH_URI,
@@ -610,8 +628,6 @@ def build_substrate_store_from_env() -> SubstrateGraphStore:
         )
         return GraphDBSubstrateStore(cfg)
 
-    if backend == DEFAULT_SUBSTRATE_STORE_BACKEND or backend == "":
-        return InMemorySubstrateGraphStore()
-
     logger.warning("Unknown SUBSTRATE_STORE_BACKEND=%r; using in-memory store", backend)
+    logger.info("substrate_store_backend_selected backend=in_memory reason=unknown_backend")
     return InMemorySubstrateGraphStore()

--- a/orion/substrate/tests/test_graphdb_store.py
+++ b/orion/substrate/tests/test_graphdb_store.py
@@ -265,8 +265,19 @@ def test_materializer_falls_back_to_in_memory_when_graphdb_not_configured(monkey
     assert isinstance(store, InMemorySubstrateGraphStore)
 
 
-def test_build_substrate_store_auto_graphdb_when_url_and_repo_without_backend(monkeypatch):
+def test_build_substrate_store_unset_backend_with_graphdb_env_stays_in_memory(monkeypatch):
+    """V1: GRAPHDB_URL alone must not select GraphDB substrate."""
     monkeypatch.delenv("SUBSTRATE_STORE_BACKEND", raising=False)
+    monkeypatch.delenv("SUBSTRATE_GRAPHDB_ENDPOINT", raising=False)
+    monkeypatch.setenv("GRAPHDB_URL", "http://graphdb.test")
+    monkeypatch.setenv("GRAPHDB_REPO", "collapse")
+
+    store = build_substrate_store_from_env()
+    assert isinstance(store, InMemorySubstrateGraphStore)
+
+
+def test_build_substrate_store_graphdb_backend_uses_graphdb_from_url_and_repo(monkeypatch):
+    monkeypatch.setenv("SUBSTRATE_STORE_BACKEND", "graphdb")
     monkeypatch.delenv("SUBSTRATE_GRAPHDB_ENDPOINT", raising=False)
     monkeypatch.setenv("GRAPHDB_URL", "http://graphdb.test")
     monkeypatch.setenv("GRAPHDB_REPO", "collapse")

--- a/services/orion-gdb-client/.env_example
+++ b/services/orion-gdb-client/.env_example
@@ -33,3 +33,8 @@ GDB_JAVA_OPTS=-Xmx8g -Dgraphdb.workbench.importDirectory=/var/graphdb/import
 
 # === Runtime ===
 LOG_LEVEL=INFO
+
+# === RDF Store V1 (legacy writer gate) ===
+# false: no GraphDB wait, no bus listener (default; use orion-rdf-writer for RDF writes).
+# true: legacy direct GraphDB writer — duplicate risk if orion-rdf-writer is also consuming the same events.
+GDB_CLIENT_ENABLED=false

--- a/services/orion-gdb-client/README.md
+++ b/services/orion-gdb-client/README.md
@@ -1,6 +1,6 @@
 # Orion GraphDB Service
 
-This service integrates **GraphDB** into the Orion-Sapienform mesh for storing, reasoning, and querying collapse events in RDF.
+**RDF Store V1:** `orion-gdb-client` is a **legacy GraphDB-native writer** (direct `/repositories/{repo}/statements` posts). It is **disabled by default** (`GDB_CLIENT_ENABLED=false`) so general RDF writes do not duplicate `orion-rdf-writer`. Enable only for intentional backfill or legacy testing; do not run beside `orion-rdf-writer` unless you understand duplicate-write risk.
 
 ---
 

--- a/services/orion-gdb-client/app/main.py
+++ b/services/orion-gdb-client/app/main.py
@@ -18,10 +18,21 @@ BOOT_ID = str(uuid.uuid4())
 @app.on_event("startup")
 def startup_event():
     """
-    Waits for GraphDB to be ready, ensures the repository exists,
-    and starts the bus listener in a background thread.
+    When ``GDB_CLIENT_ENABLED`` is true: wait for GraphDB, ensure the repository exists,
+    and start the bus listener in a background thread.
+
+    Default (V1 cutover): disabled — no GraphDB waits and no listener (canonical RDF writes
+    go through ``orion-rdf-writer``).
     """
     logger.info("🚀 Starting %s (%s)", settings.SERVICE_NAME, settings.SERVICE_VERSION)
+
+    if not settings.GDB_CLIENT_ENABLED:
+        logger.info(
+            "gdb_client_disabled reason=rdf_store_v1_cutover enable_with=GDB_CLIENT_ENABLED=true",
+        )
+        return
+
+    logger.warning("gdb_client_legacy_enabled warning=direct_graphdb_writer_duplicate_risk")
 
     wait_for_graphdb()
     ensure_repo_exists()
@@ -92,6 +103,7 @@ def health():
     return {
         "service": settings.SERVICE_NAME,
         "version": settings.SERVICE_VERSION,
+        "enabled": settings.GDB_CLIENT_ENABLED,
         "graphdb_repo": settings.GRAPHDB_REPO,
         "bus_enabled": settings.ORION_BUS_ENABLED,
         "bus_channels": [

--- a/services/orion-gdb-client/app/settings.py
+++ b/services/orion-gdb-client/app/settings.py
@@ -1,4 +1,4 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field, field_validator
 
 
@@ -7,6 +7,8 @@ class Settings(BaseSettings):
     Orion GDB Client configuration.
     Handles GraphDB connectivity, Redis bus, and runtime metadata.
     """
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     # === Core Identity ===
     SERVICE_NAME: str = Field(default="gdb-client", env="SERVICE_NAME")
@@ -36,16 +38,20 @@ class Settings(BaseSettings):
     # === Runtime ===
     LOG_LEVEL: str = Field(default="INFO", env="LOG_LEVEL")
 
+    # RDF Store V1: keep this service inert unless intentionally enabling the legacy GraphDB writer.
+    GDB_CLIENT_ENABLED: bool = Field(default=False, env="GDB_CLIENT_ENABLED")
+
     @field_validator("ORION_BUS_ENABLED", mode="before")
     def parse_bool(cls, v):
         if isinstance(v, str):
             return v.lower() in ("true", "1", "yes", "on")
         return bool(v)
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    @field_validator("GDB_CLIENT_ENABLED", mode="before")
+    def parse_gdb_client_enabled(cls, v):
+        if isinstance(v, str):
+            return v.lower() in ("true", "1", "yes", "on")
+        return bool(v)
 
 
 settings = Settings()
-

--- a/services/orion-gdb-client/docker-compose.yml
+++ b/services/orion-gdb-client/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     ports:
       - "${PORT}:8000"
     environment:
+      - GDB_CLIENT_ENABLED=${GDB_CLIENT_ENABLED:-false}
       - PROJECT=${PROJECT}
       - SERVICE_NAME=${SERVICE_NAME}
       - SERVICE_VERSION=${SERVICE_VERSION}
@@ -59,9 +60,7 @@ services:
       - GRAPHDB_REPO=${GRAPHDB_REPO}
       - LOG_LEVEL=${LOG_LEVEL}
       - PORT=${PORT}
-    depends_on:
-      graphdb:
-        condition: service_healthy
+    # When GDB_CLIENT_ENABLED=true, start GraphDB (or point GRAPHDB_URL at a reachable repo) before this service.
     healthcheck:
       test: ["CMD", "curl", "-fs", "http://localhost:${PORT}/health"]
       interval: 15s

--- a/services/orion-gdb-client/tests/test_disabled_by_default.py
+++ b/services/orion-gdb-client/tests/test_disabled_by_default.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+sys.path[:0] = [str(REPO_ROOT), str(SERVICE_ROOT)]
+
+
+def _reload_app(monkeypatch: pytest.MonkeyPatch) -> object:
+    monkeypatch.setenv("ORION_BUS_URL", os.environ.get("ORION_BUS_URL", "redis://bus.test/0"))
+    import app.settings as settings_mod
+    import app.main as main_mod
+
+    importlib.reload(settings_mod)
+    importlib.reload(main_mod)
+    return main_mod
+
+
+def test_default_settings_gdb_client_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GDB_CLIENT_ENABLED", raising=False)
+    main_mod = _reload_app(monkeypatch)
+    assert main_mod.settings.GDB_CLIENT_ENABLED is False
+
+
+def test_disabled_startup_skips_graphdb_and_listener(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GDB_CLIENT_ENABLED", "false")
+    monkeypatch.setenv("ORION_BUS_ENABLED", "true")
+    main_mod = _reload_app(monkeypatch)
+    with (
+        patch.object(main_mod, "wait_for_graphdb") as w,
+        patch.object(main_mod, "ensure_repo_exists") as e,
+        patch.object(main_mod, "listener_worker") as lw,
+        patch.object(main_mod.threading, "Thread") as th,
+    ):
+        with TestClient(main_mod.app):
+            pass
+    w.assert_not_called()
+    e.assert_not_called()
+    lw.assert_not_called()
+    th.assert_not_called()
+
+
+def test_health_reports_enabled_false_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GDB_CLIENT_ENABLED", "false")
+    main_mod = _reload_app(monkeypatch)
+    with TestClient(main_mod.app) as client:
+        r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("enabled") is False

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -206,13 +206,14 @@ SUBSTRATE_MUTATION_CONTROL_SQL_DB_PATH=
 SUBSTRATE_MUTATION_OPERATOR_TOKEN=
 
 # --- Substrate semantic graph (GraphDB) ---
-# Code default is in_memory unless backend is graphdb (aliases: graph_db, rdf).
+# RDF Store V1: default is in-memory unless SUBSTRATE_STORE_BACKEND=graphdb (aliases: graph_db, rdf).
+# GRAPHDB_URL alone does not activate GraphDB; set the backend explicitly when you intend durable substrate.
 # With HUB_DOCKER_NETWORK_MODE=host, GraphDB must be a host-reachable URL (e.g. 127.0.0.1:7200),
 # not a Docker Compose service hostname.
 SUBSTRATE_STORE_BACKEND=graphdb
 # Full SPARQL endpoint; preferred when set. Example matches published GraphDB + collapse repo:
 SUBSTRATE_GRAPHDB_ENDPOINT=http://127.0.0.1:7200/repositories/collapse
-# If SUBSTRATE_GRAPHDB_ENDPOINT is empty, build_substrate_store_from_env() can build from:
+# When SUBSTRATE_GRAPHDB_ENDPOINT is empty but backend is graphdb, the store can build the endpoint from:
 # GRAPHDB_URL=http://127.0.0.1:7200
 # GRAPHDB_REPO=collapse
 SUBSTRATE_GRAPHDB_GRAPH_URI=http://conjourney.net/graph/orion/substrate

--- a/services/orion-hub/scripts/memory_graph_routes.py
+++ b/services/orion-hub/scripts/memory_graph_routes.py
@@ -53,7 +53,8 @@ async def memory_graph_approve(
 
     await ensure_session(x_orion_session_id, bus)
     if not getattr(settings, "GRAPHDB_URL", "").strip():
-        raise HTTPException(status_code=503, detail="graphdb_unconfigured")
+        # Memory graph approval is GraphDB-specific (transaction + compensation); not covered by RDF Store V1.
+        raise HTTPException(status_code=503, detail="memory_graph_approval_requires_graphdb")
     try:
         draft = SuggestDraftV1.model_validate(body.get("draft") or body)
     except ValidationError as e:

--- a/services/orion-rdf-writer/.env_example
+++ b/services/orion-rdf-writer/.env_example
@@ -40,6 +40,19 @@ CHANNEL_WORLD_PULSE_GRAPH=orion:world_pulse:graph:upsert
 CHANNEL_RDF_CONFIRM=orion:rdf:confirm
 CHANNEL_RDF_ERROR=orion:rdf:error
 
+# === RDF Store V1 Cutover ===
+# Canonical general RDF write sink: ``orion-rdf-writer`` (this service). Backend-neutral envs:
+# RDF_STORE_BACKEND=fuseki
+# RDF_STORE_BASE_URL=http://orion-athena-fuseki:3030
+# RDF_STORE_DATASET=orion
+# RDF_STORE_GRAPH_STORE_URL=http://orion-athena-fuseki:3030/orion/data
+# RDF_STORE_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
+# RDF_STORE_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
+# RDF_STORE_TIMEOUT_SEC=10.0
+# Optional: reduce duplicate chat graph volume during V1 cutover
+# RDF_SKIP_KINDS=chat.history.message.v1
+# Legacy GraphDB for this service only when RDF_STORE_BACKEND=graphdb (see below).
+
 # --- GraphDB Configuration ---
 GRAPHDB_URL=http://${PROJECT}-graphdb:7200
 GRAPHDB_REPO=collapse

--- a/services/orion-rdf-writer/app/service.py
+++ b/services/orion-rdf-writer/app/service.py
@@ -227,6 +227,24 @@ async def init_rdf_write_pipeline() -> None:
         _write_queue = None
         _inflight_sem = None
 
+    assert _store is not None
+    try:
+        h = await _store.health()
+        graph_url = h.get("graph_store_url") or h.get("endpoint")
+        logger.info(
+            "rdf_store_backend_selected backend=%s graph_store_url=%s dataset=%s",
+            (settings.RDF_STORE_BACKEND or "").strip().lower(),
+            _strip_credentials(str(graph_url)) if graph_url else "",
+            settings.RDF_STORE_DATASET,
+        )
+    except Exception as exc:
+        logger.warning(
+            "rdf_store_backend_selected backend=%s dataset=%s (health snapshot failed: %s)",
+            (settings.RDF_STORE_BACKEND or "").strip().lower(),
+            settings.RDF_STORE_DATASET,
+            exc,
+        )
+
 
 async def shutdown_rdf_write_pipeline(*, drain_timeout_sec: float = 8.0) -> None:
     global _http_client, _store, _write_queue, _worker_tasks, _inflight_sem

--- a/services/orion-rdf-writer/docker-compose.yml
+++ b/services/orion-rdf-writer/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - GRAPHDB_PASS=${GRAPHDB_PASS}
 
       # --- RDF store (GraphDB, Fuseki, or generic SPARQL) ---
+      # V1: prefer fuseki/generic via .env; graphdb here is legacy compatibility when unset.
       - RDF_STORE_BACKEND=${RDF_STORE_BACKEND:-graphdb}
       - RDF_STORE_BASE_URL=${RDF_STORE_BASE_URL:-}
       - RDF_STORE_DATASET=${RDF_STORE_DATASET:-orion}

--- a/services/orion-rdf-writer/tests/test_rdf_store.py
+++ b/services/orion-rdf-writer/tests/test_rdf_store.py
@@ -16,6 +16,7 @@ sys.path[:0] = [str(ROOT), str(SERVICE_ROOT)]
 
 from app.rdf_store import (
     FusekiRdfStoreClient,
+    GenericSparqlRdfStoreClient,
     GraphDbRdfStoreClient,
     build_rdf_store_client,
     normalize_graph_name,
@@ -209,6 +210,49 @@ def test_fuseki_write_graph_query_uses_normalized_uri() -> None:
     asyncio.run(_run())
     assert len(captured) == 1
     assert captured[0].url.params.get("graph") == "http://conjourney.net/graph/orion/chat"
+
+
+def test_factory_generic_builds_generic_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RDF_STORE_BACKEND", "generic")
+    monkeypatch.delenv("GRAPHDB_URL", raising=False)
+    monkeypatch.setenv("RDF_STORE_GRAPH_STORE_URL", "http://rdf-store.example/orion/data")
+    s = Settings(ORION_BUS_URL="redis://example/0")
+
+    async def _call():
+        async with httpx.AsyncClient() as client:
+            return build_rdf_store_client(s, client)
+
+    c = asyncio.run(_call())
+    assert isinstance(c, GenericSparqlRdfStoreClient)
+
+
+def test_factory_rdf4j_aliases_generic(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RDF_STORE_BACKEND", "rdf4j")
+    monkeypatch.delenv("GRAPHDB_URL", raising=False)
+    monkeypatch.setenv("RDF_STORE_GRAPH_STORE_URL", "http://rdf4j.example/rdf4j-server/repositories/orion/rdf-graphs/service")
+    s = Settings(ORION_BUS_URL="redis://example/0")
+
+    async def _call():
+        async with httpx.AsyncClient() as client:
+            return build_rdf_store_client(s, client)
+
+    c = asyncio.run(_call())
+    assert isinstance(c, GenericSparqlRdfStoreClient)
+    assert c.backend == "generic"
+
+
+def test_factory_graphdb_builds_graphdb_when_url_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RDF_STORE_BACKEND", "graphdb")
+    monkeypatch.setenv("GRAPHDB_URL", "http://gdb.example:7200")
+    monkeypatch.setenv("GRAPHDB_REPO", "collapse")
+    s = Settings(ORION_BUS_URL="redis://example/0")
+
+    async def _call():
+        async with httpx.AsyncClient() as client:
+            return build_rdf_store_client(s, client)
+
+    c = asyncio.run(_call())
+    assert isinstance(c, GraphDbRdfStoreClient)
 
 
 def test_limits_helper_smoke() -> None:


### PR DESCRIPTION
# PR: RDF Store V1 cutover safety

## Summary

- **Canonical general RDF writes:** `services/orion-rdf-writer` only (backend-neutral `RDF_STORE_*`; bus producers unchanged).
- **Legacy writer quarantined:** `services/orion-gdb-client` defaults `GDB_CLIENT_ENABLED=false` — no GraphDB wait, repo bootstrap, listener, or heartbeat unless explicitly enabled.
- **Substrate blast-radius:** `build_substrate_store_from_env()` uses in-memory when `SUBSTRATE_STORE_BACKEND` is unset; GraphDB substrate requires explicit `SUBSTRATE_STORE_BACKEND=graphdb` (global `GRAPHDB_URL` alone no longer auto-selects).
- **Memory graph approval:** remains GraphDB-only; Hub returns `503` with `memory_graph_approval_requires_graphdb` when GraphDB is not configured (no silent migration to Fuseki/generic).
- **Operator doc:** `docs/architecture/rdf_store_v1_cutover.md` (checklist, env, rollback).

## V1 operator env (reference)

```env
RDF_STORE_BACKEND=fuseki
RDF_STORE_BASE_URL=http://orion-athena-fuseki:3030
RDF_STORE_DATASET=orion
RDF_STORE_GRAPH_STORE_URL=http://orion-athena-fuseki:3030/orion/data
RDF_STORE_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
RDF_STORE_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
GDB_CLIENT_ENABLED=false
SUBSTRATE_STORE_BACKEND=in_memory
```

Hub deployments that need durable substrate may keep `SUBSTRATE_STORE_BACKEND=graphdb` in Hub `.env` / compose (explicit, not auto from `GRAPHDB_URL` alone).

## Test plan

- [x] `PYTHONPYCACHEPREFIX=/tmp/orion_pycache_$$ ./venv/bin/python -m compileall services/orion-rdf-writer services/orion-gdb-client orion/substrate orion/memory_graph -q`
- [x] `PYTHONPATH=. ./venv/bin/python -m pytest services/orion-rdf-writer/tests -q` — **37 passed**
- [x] `PYTHONPATH=. ./venv/bin/python -m pytest orion/substrate/tests -q` — **87 passed**
- [x] `PYTHONPATH=. ./venv/bin/python -m pytest services/orion-gdb-client/tests -q` — **3 passed**
- [x] `PYTHONPATH=. ./venv/bin/python -m pytest tests/test_memory_graph_graphdb_mocked.py tests/test_memory_graph_approve.py -q` — **2 passed**
- [ ] Runtime: `orion-rdf-writer` `/health` shows `rdf_store_backend` + queue fields (no credentials in URLs)
- [ ] Runtime: `orion-gdb-client` `/health` shows `"enabled": false` with default env
- [ ] Runtime: publish `rdf.write.request` on `orion:rdf:enqueue` → `rdf_write_enqueued` / `rdf_write_committed` logs

## Out of scope (V2)

- Backend-neutral memory graph approval store
- Backend-neutral substrate graph store
- Concept profile / self-study read cutover
- GraphDB retirement

## Files touched

| Area | Change |
|------|--------|
| `services/orion-rdf-writer/` | Startup `rdf_store_backend_selected` log; `.env_example` V1 block; compose comment; factory tests |
| `services/orion-gdb-client/` | `GDB_CLIENT_ENABLED` gate; compose default false; tests; README |
| `orion/substrate/graphdb_store.py` | Explicit GraphDB backend only; V1 default in-memory |
| `orion/memory_graph/`, Hub routes | GraphDB-only doc + `memory_graph_approval_requires_graphdb` |
| `docs/architecture/rdf_store_v1_cutover.md` | Operator cutover / rollback |

## Risk notes

- **gdb-client compose:** `depends_on: graphdb` removed; with `GDB_CLIENT_ENABLED=true`, operators must ensure GraphDB is reachable separately.
- **Hub compose** still defaults `SUBSTRATE_STORE_BACKEND=graphdb` at compose level — intentional for durable Hub stacks; code default for unset env is in-memory.
