### PR TITLE
Chore/graphdb cutover review fixes

### DIFF
--- a/orion/graph/backend_config.py
+++ b/orion/graph/backend_config.py
@@ -170,6 +170,23 @@ def resolve_graph_backend(environ: Mapping[str, str] | None = None) -> GraphBack
             source="RDF_STORE_QUERY_URL",
         )
 
+    if rdf_b == "fuseki":
+        base = _fuseki_base()
+        ds = _fuseki_dataset()
+        if base:
+            q, u, g, src = _derive_fuseki_urls(base, ds)
+            return GraphBackendConfig(
+                backend="fuseki",
+                query_url=_strip(env.get("RDF_STORE_QUERY_URL")) or q,
+                update_url=_strip(env.get("RDF_STORE_UPDATE_URL")) or u,
+                graph_store_url=_strip(env.get("RDF_STORE_GRAPH_STORE_URL")) or g,
+                dataset=ds,
+                user=_strip(env.get("RDF_STORE_USER")) or None,
+                password=_strip(env.get("RDF_STORE_PASS")) or None,
+                legacy_graphdb=False,
+                source=f"auto:{src}",
+            )
+
     return GraphBackendConfig(
         backend="disabled",
         query_url=None,

--- a/orion/graph/tests/test_backend_config.py
+++ b/orion/graph/tests/test_backend_config.py
@@ -37,6 +37,19 @@ def test_only_graphdb_url_auto_does_not_select_graphdb(monkeypatch: pytest.Monke
     assert cfg.backend == "disabled"
 
 
+def test_auto_rdf_store_fuseki_derives_urls_without_explicit_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GRAPH_BACKEND", raising=False)
+    monkeypatch.delenv("RDF_STORE_QUERY_URL", raising=False)
+    monkeypatch.setenv("RDF_STORE_BACKEND", "fuseki")
+    monkeypatch.setenv("RDF_STORE_BASE_URL", "http://orion-athena-fuseki:3030")
+    monkeypatch.setenv("RDF_STORE_DATASET", "orion")
+    monkeypatch.delenv("GRAPHDB_URL", raising=False)
+    cfg = resolve_graph_backend()
+    assert cfg.backend == "fuseki"
+    assert cfg.query_url == "http://orion-athena-fuseki:3030/orion/query"
+    assert cfg.legacy_graphdb is False
+
+
 def test_explicit_graphdb_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GRAPH_BACKEND", "graphdb")
     monkeypatch.setenv("GRAPHDB_URL", "http://gdb:7200")

--- a/orion/memory_graph/approve.py
+++ b/orion/memory_graph/approve.py
@@ -13,7 +13,6 @@ from orion.memory_graph.graphdb import compensate_batch, insert_batch
 from orion.memory_graph.json_to_rdf import draft_to_graph
 from orion.memory_graph.project import project_graph_to_cards
 from orion.memory_graph.rdf_target import (
-    MemoryGraphGraphDbTarget,
     MemoryGraphSparqlTarget,
     resolve_memory_graph_rdf_target,
 )
@@ -93,8 +92,9 @@ async def approve_memory_graph_draft(
     """validate → RDF graph store (Fuseki graph-store HTTP + SPARQL update, or legacy GraphDB) → Postgres.
 
     When ``RDF_STORE_GRAPH_STORE_URL`` and ``RDF_STORE_UPDATE_URL`` are set (``MEMORY_GRAPH_APPROVAL_BACKEND=auto``),
-    writes go to Fuseki. Legacy GraphDB requires ``MEMORY_GRAPH_APPROVAL_BACKEND=graphdb`` or Hub-supplied
-    ``GRAPHDB_URL`` fallback when no RDF graph-store URLs are configured.
+    writes go to Fuseki. Legacy GraphDB is used only when ``MEMORY_GRAPH_APPROVAL_BACKEND=graphdb`` and
+    ``GRAPHDB_URL`` is set in the environment (see ``resolve_memory_graph_rdf_target``). Hub must not
+    implicitly select GraphDB from stale ``GRAPHDB_URL`` while ``MEMORY_GRAPH_APPROVAL_BACKEND=auto``.
     """
     batch_id = str(uuid4())
     g2 = draft_to_graph(draft, revision_batch=batch_id)
@@ -103,14 +103,6 @@ async def approve_memory_graph_draft(
         return ApproveOutcome(ok=False, card_ids=[], violations=violations)
 
     target = resolve_memory_graph_rdf_target()
-    if target is None and graphdb_url.strip():
-        target = MemoryGraphGraphDbTarget(
-            kind="graphdb",
-            graphdb_url=graphdb_url.rstrip("/"),
-            repo=graphdb_repo,
-            user=graphdb_user,
-            password=graphdb_pass,
-        )
     if target is None:
         raise ValueError("graph_backend_unconfigured")
 

--- a/orion/memory_graph/rdf_target.py
+++ b/orion/memory_graph/rdf_target.py
@@ -26,7 +26,7 @@ class MemoryGraphSparqlTarget:
 
 
 def resolve_memory_graph_rdf_target() -> MemoryGraphGraphDbTarget | MemoryGraphSparqlTarget | None:
-    """Prefer RDF store graph HTTP when configured; legacy GraphDB only when explicitly forced."""
+    """Prefer RDF store graph HTTP when configured; legacy GraphDB only when ``MEMORY_GRAPH_APPROVAL_BACKEND=graphdb``."""
     mode = (os.getenv("MEMORY_GRAPH_APPROVAL_BACKEND") or "auto").strip().lower()
     gs = (os.getenv("RDF_STORE_GRAPH_STORE_URL") or "").strip()
     up = (os.getenv("RDF_STORE_UPDATE_URL") or "").strip()

--- a/orion/substrate/graphdb_store.py
+++ b/orion/substrate/graphdb_store.py
@@ -49,6 +49,7 @@ class GraphDBSubstrateStore(SubstrateGraphStore):
     def __init__(self, cfg: GraphDBSubstrateStoreConfig) -> None:
         self._cfg = cfg
         self._cache = InMemorySubstrateGraphStore()
+        self._result_source_kind = "graphdb"
 
     def _sparql_update_endpoint(self) -> str:
         """GraphDB accepts SPARQL UPDATE only on the RDF4J statements endpoint, not the repo root."""
@@ -219,7 +220,7 @@ WHERE {{ OPTIONAL {{ GRAPH <{self._cfg.graph_uri}> {{ {edge_iri} ?p ?o . }} }} }
         if not node_ids:
             return SubstrateQueryResultV1(
                 query_kind="focal_slice",
-                source_kind="graphdb",
+                source_kind=self._result_source_kind,
                 slice=SubstrateNeighborhoodSliceV1(nodes=[], edges=[]),
                 limits={"max_edges": edges_limit, "node_ids": 0},
             )
@@ -230,7 +231,7 @@ WHERE {{ OPTIONAL {{ GRAPH <{self._cfg.graph_uri}> {{ {edge_iri} ?p ?o . }} }} }
             self._refresh_cache(nodes=nodes, edges=edges)
             return SubstrateQueryResultV1(
                 query_kind="focal_slice",
-                source_kind="graphdb",
+                source_kind=self._result_source_kind,
                 slice=SubstrateNeighborhoodSliceV1(nodes=nodes, edges=edges),
                 truncated=nodes_truncated or edges_truncated,
                 limits={"max_edges": edges_limit, "node_ids": len(node_ids)},
@@ -250,7 +251,7 @@ WHERE {{ OPTIONAL {{ GRAPH <{self._cfg.graph_uri}> {{ {edge_iri} ?p ?o . }} }} }
             self._refresh_cache(nodes=nodes, edges=edges)
             return SubstrateQueryResultV1(
                 query_kind="hotspot_region",
-                source_kind="graphdb",
+                source_kind=self._result_source_kind,
                 slice=SubstrateNeighborhoodSliceV1(nodes=nodes, edges=edges),
                 truncated=nodes_truncated or edges_truncated,
                 limits={"limit_nodes": nodes_limit, "limit_edges": edges_limit},
@@ -273,7 +274,7 @@ WHERE {{ OPTIONAL {{ GRAPH <{self._cfg.graph_uri}> {{ {edge_iri} ?p ?o . }} }} }
         if not needle:
             return SubstrateQueryResultV1(
                 query_kind="provenance_neighborhood",
-                source_kind="graphdb",
+                source_kind=self._result_source_kind,
                 slice=SubstrateNeighborhoodSliceV1(nodes=[], edges=[]),
                 limits={"limit_nodes": nodes_limit, "limit_edges": edges_limit},
                 details={"evidence_ref": ""},
@@ -285,7 +286,7 @@ WHERE {{ OPTIONAL {{ GRAPH <{self._cfg.graph_uri}> {{ {edge_iri} ?p ?o . }} }} }
             self._refresh_cache(nodes=nodes, edges=edges)
             return SubstrateQueryResultV1(
                 query_kind="provenance_neighborhood",
-                source_kind="graphdb",
+                source_kind=self._result_source_kind,
                 slice=SubstrateNeighborhoodSliceV1(nodes=nodes, edges=edges),
                 truncated=nodes_truncated or edges_truncated,
                 limits={"limit_nodes": nodes_limit, "limit_edges": edges_limit},
@@ -322,7 +323,7 @@ WHERE {{ OPTIONAL {{ GRAPH <{self._cfg.graph_uri}> {{ {edge_iri} ?p ?o . }} }} }
             self._refresh_cache(nodes=nodes, edges=edges)
             return SubstrateQueryResultV1(
                 query_kind=query_kind,
-                source_kind="graphdb",
+                source_kind=self._result_source_kind,
                 slice=SubstrateNeighborhoodSliceV1(nodes=nodes, edges=edges),
                 truncated=nodes_truncated or edges_truncated,
                 limits={"limit_nodes": nodes_limit, "limit_edges": edges_limit},
@@ -588,6 +589,7 @@ class SparqlSubstrateStore(GraphDBSubstrateStore):
                 password=cfg.password,
             )
         )
+        self._result_source_kind = "sparql"
         self._sparql_update_url = cfg.update_url.rstrip("/")
 
     def _sparql_update_endpoint(self) -> str:

--- a/orion/substrate/tests/test_graphdb_store.py
+++ b/orion/substrate/tests/test_graphdb_store.py
@@ -292,11 +292,17 @@ def test_build_substrate_store_graphdb_backend_uses_graphdb_from_url_and_repo(mo
 
 
 def test_build_substrate_store_sparql_backend(monkeypatch):
+    fake = _FakeGraphDB()
+    monkeypatch.setattr("orion.substrate.graphdb_store.requests.post", fake.post)
     monkeypatch.setenv("SUBSTRATE_STORE_BACKEND", "sparql")
     monkeypatch.setenv("SUBSTRATE_GRAPH_QUERY_URL", "http://fuseki:3030/orion/query")
     monkeypatch.setenv("SUBSTRATE_GRAPH_UPDATE_URL", "http://fuseki:3030/orion/update")
     store = build_substrate_store_from_env()
     assert isinstance(store, SparqlSubstrateStore)
+    materializer = SubstrateGraphMaterializer(store=store)
+    materializer.apply_record(_sample_record())
+    hotspot = store.query_hotspot_region(min_salience=0.65, limit_nodes=2, limit_edges=1)
+    assert hotspot.source_kind == "sparql"
 
 
 def test_build_substrate_store_explicit_in_memory_overrides_graphdb_env(monkeypatch):

--- a/services/orion-hub/scripts/memory_graph_routes.py
+++ b/services/orion-hub/scripts/memory_graph_routes.py
@@ -55,7 +55,7 @@ async def memory_graph_approve(
     from orion.memory_graph.rdf_target import resolve_memory_graph_rdf_target
 
     target = resolve_memory_graph_rdf_target()
-    if target is None and not str(getattr(settings, "GRAPHDB_URL", "") or "").strip():
+    if target is None:
         raise HTTPException(status_code=503, detail="graph_backend_unconfigured")
     try:
         draft = SuggestDraftV1.model_validate(body.get("draft") or body)
@@ -90,7 +90,7 @@ async def memory_graph_approve(
         logger.warning("memory_graph_approve_failed postgres error=%s", exc)
         raise HTTPException(status_code=503, detail="memory_store_error") from exc
     except requests.RequestException as exc:
-        logger.warning("memory_graph_approve_failed graphdb error=%s", exc)
+        logger.warning("memory_graph_approve_failed rdf_http error=%s", exc)
         raise HTTPException(status_code=503, detail="rdf_graph_unavailable") from exc
 
     if not result.ok:

--- a/tests/test_memory_graph_approve.py
+++ b/tests/test_memory_graph_approve.py
@@ -11,10 +11,15 @@ from orion.memory_graph.approve import approve_memory_graph_draft
 from orion.memory_graph.dto import SuggestDraftV1
 
 
-def test_compensate_batch_on_postgres_failure() -> None:
+def test_compensate_batch_on_postgres_failure(monkeypatch) -> None:
     raw = json.loads(Path("tests/fixtures/memory_graph/joey_cats_draft.json").read_text(encoding="utf-8"))
     draft = SuggestDraftV1.model_validate(raw)
     pool = MagicMock()
+    monkeypatch.setenv("MEMORY_GRAPH_APPROVAL_BACKEND", "graphdb")
+    monkeypatch.setenv("GRAPHDB_URL", "http://g")
+    monkeypatch.setenv("GRAPHDB_REPO", "r")
+    monkeypatch.delenv("RDF_STORE_GRAPH_STORE_URL", raising=False)
+    monkeypatch.delenv("RDF_STORE_UPDATE_URL", raising=False)
 
     async def boom(*args, **kwargs):
         raise RuntimeError("pg down")


### PR DESCRIPTION
## Title
Post–GraphDB cutover: code-review fixes (memory graph, resolver auto, substrate telemetry)

## Summary
Addresses follow-ups from an internal **code-reviewer** pass on the merged Fuseki/SPARQL graph cutover:

1. **Memory graph approval** no longer falls back to GraphDB from Hub-injected `GRAPHDB_URL` when `MEMORY_GRAPH_APPROVAL_BACKEND=auto` and RDF graph-store URLs are missing. Approve uses **only** `resolve_memory_graph_rdf_target()`; Hub preflight is strict; RDF HTTP errors are logged as **`rdf_http`**, not “graphdb”.
2. **`resolve_graph_backend()`** in **auto/unset** mode now derives Fuseki query/update/data URLs when **`RDF_STORE_BACKEND=fuseki`** and **`RDF_STORE_BASE_URL`** are set, even if **`RDF_STORE_QUERY_URL`** is omitted (aligned with module intent).
3. **`SparqlSubstrateStore`** substrate query results report **`source_kind=sparql`** instead of inheriting **`graphdb`**.

## Commits
- `bc58bb30` — `fix(memory-graph): drop implicit GraphDB approve when backend is auto.`
- `88c0eb24` — `fix(graph,substrate): align auto fuseki derivation and SPARQL telemetry.`

## Test plan
- [x] `PYTHONPATH=. ./venv/bin/python -m pytest orion/graph/tests/test_backend_config.py orion/substrate/tests/test_graphdb_store.py tests/test_memory_graph_approve.py services/orion-hub/tests/test_memory_graph_routes.py -q --tb=short` (17 passed)
- [ ] Staging: Hub `POST /api/memory/graph/approve` with `MEMORY_GRAPH_APPROVAL_BACKEND=auto`, Fuseki URLs set, legacy `GRAPHDB_URL` still present → must **not** hit GraphDB
- [ ] Optional: substrate query payloads show `source_kind=sparql` for `SUBSTRATE_STORE_BACKEND=sparql`

## Base / branch
- **Branch:** `chore/graphdb-cutover-review-fixes` (from `origin/main` after merge of prior cutover PR)
- **PR link (create):** https://github.com/junebug-junie/Orion-Sapienform/pull/new/chore/graphdb-cutover-review-fixes