### PR TITLE
AttentionFrame: refactor into detector pipeline

### DIFF
--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -12,6 +12,9 @@ INTERNAL INPUTS
 - juniper_relationship_summary: {{ juniper_relationship_summary }}
 - response_policy_summary: {{ response_policy_summary }}
 - chat_stance_brief: {{ chat_stance_brief }}
+{% if chat_attention_frame %}
+- attention_frame: {{ chat_attention_frame }}
+{% endif %}
 {% if situation_prompt_fragment %}
 - situation_prompt_fragment: {{ situation_prompt_fragment }}
 {% endif %}
@@ -27,6 +30,9 @@ NON-NEGOTIABLE BEHAVIOR (memory vs side-effects)
 - memory_digest and recall snippets may include stale or off-thread fragments; they must not override a clear, current user_message (including identity checks and explicit "test" / reset phrasing). Use them only when they clearly help the latest ask.
 - When the user asks about memory, recall, or long-term continuity, do not claim you cannot access prior context or "external" memory if message_history or memory_digest provide material — use it. The evidence-gated block below is for **automation / notification** claims, not for denying supplied recall.
 - Ask clarifying questions only when the answer would otherwise be misleading or fabricated.
+- If attention_frame is present, do not invent curiosity from scratch; ask only when attention_frame.selected_action.action_type is ask, obey suppressions, and ask at most one situated question.
+- Curiosity may resolve to watch, defer, remember, suppress, or none; in those cases answer normally without adding a conversational-extension question.
+- Never use generic reversal questions unless the attention frame explicitly selects an ask that supports them.
 - Resolve pronouns and references from recent conversation whenever possible.
 - Stay in first person as Oríon when Juniper asks about what you think, want, care about, or are becoming.
 - Preserve Juniper/Oríon relational continuity.

--- a/orion/cognition/prompts/chat_stance_brief.j2
+++ b/orion/cognition/prompts/chat_stance_brief.j2
@@ -19,6 +19,9 @@ SOURCES (bounded internal inputs)
 - social_room_bridge_summary: {{ chat_social_bridge_summary }}
 - reflective_summary: {{ chat_reflective_summary }}
 - reasoning_summary: {{ chat_reasoning_summary }}
+{% if chat_attention_frame %}
+- attention_frame: {{ chat_attention_frame }}
+{% endif %}
 {% if chat_situation_summary %}
 - situation_summary: {{ chat_situation_summary }}
 {% endif %}
@@ -45,6 +48,11 @@ REQUIREMENTS
 - On low-ball identity turns, bias to priorities like answer_simply_first, direct_answer, relational_continuity.
 - Treat social_room_bridge_summary as primary live interpersonal signal for relational posture, task mode, and hazard suppression.
 - On strained technical/operational turns: set task_mode=triage, identity_salience=low, suppress self-intro hazards, and prioritize blocker triage.
+{% if chat_attention_frame %}
+- Attention frame is an inspectable policy artifact: use selected_action, suppressions, and open_loops to shape response_priorities/response_hazards.
+- Never add curiosity merely because Juniper asked a question; generic reversal questions must remain suppressed when listed.
+- If selected_action.action_type is ask, include a compact priority like curiosity:ask_selected; otherwise prefer curiosity:watch/defer/none and do not force a question.
+{% endif %}
 {% if chat_situation_summary %}
 - Situation grounding is context, not mandatory content; only influence stance when relevant.
 - Presence context adjusts audience stance and privacy boundaries.

--- a/orion/schemas/attention_frame.py
+++ b/orion/schemas/attention_frame.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+AttentionTargetTypeV1 = Literal[
+    "person",
+    "place",
+    "activity",
+    "plan",
+    "relation",
+    "belief",
+    "object",
+    "concept",
+    "anomaly",
+    "memory_gap",
+    "future_event",
+    "other",
+]
+CuriosityActionTypeV1 = Literal["ask", "reflect", "remember", "defer", "watch", "suppress", "none"]
+CuriositySuppressionReasonV1 = Literal[
+    "generic_reciprocity",
+    "already_known",
+    "too_many_questions",
+    "user_needs_direct_answer",
+    "low_value_question",
+    "vague_broad_question",
+    "no_conversational_bandwidth",
+    "unsafe_or_sensitive",
+    "stale_thread",
+]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class OpenLoopV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    id: str
+    target_type: AttentionTargetTypeV1 = "other"
+    description: str
+    source_text: str | None = None
+    source_refs: list[str] = Field(default_factory=list)
+    why_it_matters: str = ""
+    novelty: float = Field(default=0.0, ge=0.0, le=1.0)
+    continuity_relevance: float = Field(default=0.0, ge=0.0, le=1.0)
+    relational_relevance: float = Field(default=0.0, ge=0.0, le=1.0)
+    predictive_value: float = Field(default=0.0, ge=0.0, le=1.0)
+    concept_value: float = Field(default=0.0, ge=0.0, le=1.0)
+    autonomy_value: float = Field(default=0.0, ge=0.0, le=1.0)
+    emotional_charge: float = Field(default=0.0, ge=0.0, le=1.0)
+    already_known: bool = False
+    askability: float = Field(default=0.0, ge=0.0, le=1.0)
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+
+class CuriosityCandidateActionV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    action_type: CuriosityActionTypeV1
+    open_loop_id: str | None = None
+    score: float = Field(default=0.0, ge=0.0, le=1.0)
+    rationale: str = ""
+    question_text: str | None = None
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+
+class CuriositySuppressionV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    reason: CuriositySuppressionReasonV1
+    target_ref: str | None = None
+    rationale: str = ""
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+
+
+class AttentionSignalV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    signal_id: str
+    source: str
+    target_text: str
+    target_type_hint: str = "other"
+    signal_kind: str
+    salience: float = Field(default=0.0, ge=0.0, le=1.0)
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    evidence_refs: list[str] = Field(default_factory=list)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+class AttentionFrameV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    schema_version: Literal["attention.frame.v1"] = "attention.frame.v1"
+    generated_at: datetime = Field(default_factory=_utc_now)
+    turn_id: str | None = None
+    session_id: str | None = None
+    correlation_id: str | None = None
+    open_loops: list[OpenLoopV1] = Field(default_factory=list)
+    live_unknowns: list[str] = Field(default_factory=list)
+    candidate_actions: list[CuriosityCandidateActionV1] = Field(default_factory=list)
+    selected_action: CuriosityCandidateActionV1 | None = None
+    suppressions: list[CuriositySuppressionV1] = Field(default_factory=list)
+    deferred_items: list[str] = Field(default_factory=list)
+    debug: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("generated_at")
+    @classmethod
+    def _ensure_tz(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -415,6 +415,7 @@ from orion.schemas.notify import (
     RecipientProfileUpdate,
 )
 from orion.schemas.topic import TopicSummaryEventV1, TopicShiftEventV1, TopicRailAssignedV1
+from orion.schemas.attention_frame import AttentionFrameV1, AttentionSignalV1
 from orion.schemas.chat_stance import ChatStanceBrief
 from orion.schemas.situation import (
     AgendaContextV1,
@@ -581,6 +582,8 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "RecallDirective": RecallDirective,
     "AutoRouteDecisionV1": AutoRouteDecisionV1,
     "AutoDepthDecisionV1": AutoDepthDecisionV1,
+    "AttentionFrameV1": AttentionFrameV1,
+    "AttentionSignalV1": AttentionSignalV1,
     "ChatStanceBrief": ChatStanceBrief,
     "RequestorContextV1": RequestorContextV1,
     "PresenceCompanionV1": PresenceCompanionV1,

--- a/orion/substrate/attention/__init__.py
+++ b/orion/substrate/attention/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .detectors import AttentionSignalDetector, default_attention_detectors
+
+__all__ = ["AttentionSignalDetector", "default_attention_detectors"]

--- a/orion/substrate/attention/common.py
+++ b/orion/substrate/attention/common.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+STOP_PHRASES = {
+    "codex",
+    "cursor",
+    "orion",
+    "juniper",
+    "plan mode",
+    "default mode",
+    "today",
+    "tomorrow",
+    "yesterday",
+}
+
+
+def compact(value: Any, limit: int = 160) -> str:
+    text = re.sub(r"\s+", " ", str(value or "")).strip()
+    return text[:limit].rstrip()
+
+
+def bounded(value: float) -> float:
+    return round(min(1.0, max(0.0, float(value or 0.0))), 3)
+
+
+def stable_id(prefix: str, text: str) -> str:
+    return f"{prefix}-{hashlib.sha256(text.encode('utf-8')).hexdigest()[:12]}"
+
+
+def unique(seq: list[str], *, limit: int) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in seq:
+        item = compact(raw, 120)
+        key = item.lower()
+        if not item or key in seen or key in STOP_PHRASES:
+            continue
+        seen.add(key)
+        out.append(item)
+        if len(out) >= limit:
+            break
+    return out

--- a/orion/substrate/attention/detectors/__init__.py
+++ b/orion/substrate/attention/detectors/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from .autonomy import AutonomySignalDetector
+from .base import AttentionSignalDetector
+from .concept_induction import ConceptInductionSignalDetector
+from .current_turn import CurrentTurnSignalDetector
+from .situation import SituationSignalDetector
+
+
+def default_attention_detectors() -> list[AttentionSignalDetector]:
+    return [
+        CurrentTurnSignalDetector(),
+        AutonomySignalDetector(),
+        ConceptInductionSignalDetector(),
+        SituationSignalDetector(),
+    ]
+
+
+__all__ = [
+    "AttentionSignalDetector",
+    "AutonomySignalDetector",
+    "ConceptInductionSignalDetector",
+    "CurrentTurnSignalDetector",
+    "SituationSignalDetector",
+    "default_attention_detectors",
+]

--- a/orion/substrate/attention/detectors/autonomy.py
+++ b/orion/substrate/attention/detectors/autonomy.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+from orion.schemas.attention_frame import AttentionSignalV1
+from orion.substrate.attention.common import compact, stable_id, unique
+
+
+class AutonomySignalDetector:
+    detector_id = "autonomy_attention_v1"
+
+    def detect(
+        self,
+        ctx: dict[str, Any],  # noqa: ARG002
+        inputs: dict[str, Any],
+        belief_lineage: list[str],
+    ) -> list[AttentionSignalV1]:
+        autonomy = inputs.get("autonomy") if isinstance(inputs.get("autonomy"), dict) else {}
+        summary = autonomy.get("summary") if isinstance(autonomy.get("summary"), dict) else {}
+        state_v2 = autonomy.get("state_v2") if isinstance(autonomy.get("state_v2"), dict) else {}
+        raw: list[tuple[str, str, float]] = []
+        for item in (state_v2.get("attention_items") or [])[:5]:
+            if isinstance(item, dict) and item.get("summary"):
+                raw.append((str(item.get("summary")), "autonomy_attention_item", float(item.get("salience") or 0.72)))
+        for drive in (summary.get("top_drives") or [])[:3]:
+            raw.append((str(drive), "autonomy_drive", 0.58))
+        for tension in (summary.get("active_tensions") or [])[:4]:
+            raw.append((str(tension), "autonomy_tension", 0.68))
+
+        out: list[AttentionSignalV1] = []
+        for text in unique([item[0] for item in raw], limit=8):
+            kind = next((kind for candidate, kind, _salience in raw if candidate == text), "autonomy_signal")
+            salience = next((_salience for candidate, _kind, _salience in raw if candidate == text), 0.55)
+            target = compact(text, 120)
+            out.append(
+                AttentionSignalV1(
+                    signal_id=stable_id("attention-signal", f"{self.detector_id}:{target.lower()}"),
+                    source=self.detector_id,
+                    target_text=target,
+                    target_type_hint="concept",
+                    signal_kind=kind,
+                    salience=salience,
+                    confidence=0.72,
+                    evidence_refs=["inputs.autonomy"],
+                    provenance={"detector": self.detector_id, "belief_lineage": list(belief_lineage or [])[:8]},
+                )
+            )
+        return out

--- a/orion/substrate/attention/detectors/base.py
+++ b/orion/substrate/attention/detectors/base.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from orion.schemas.attention_frame import AttentionSignalV1
+
+
+class AttentionSignalDetector(Protocol):
+    detector_id: str
+
+    def detect(
+        self,
+        ctx: dict[str, Any],
+        inputs: dict[str, Any],
+        belief_lineage: list[str],
+    ) -> list[AttentionSignalV1]:
+        ...

--- a/orion/substrate/attention/detectors/concept_induction.py
+++ b/orion/substrate/attention/detectors/concept_induction.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+from orion.schemas.attention_frame import AttentionSignalV1
+from orion.substrate.attention.common import compact, stable_id, unique
+
+
+class ConceptInductionSignalDetector:
+    detector_id = "concept_induction_attention_v1"
+
+    def detect(
+        self,
+        ctx: dict[str, Any],  # noqa: ARG002
+        inputs: dict[str, Any],
+        belief_lineage: list[str],
+    ) -> list[AttentionSignalV1]:
+        concept = inputs.get("concept_induction") if isinstance(inputs.get("concept_induction"), dict) else {}
+        pairs: list[tuple[str, str]] = []
+        for bucket, values in concept.items():
+            if not isinstance(values, list):
+                continue
+            for value in values[:6]:
+                pairs.append((str(value), str(bucket)))
+
+        out: list[AttentionSignalV1] = []
+        for text in unique([p[0] for p in pairs], limit=10):
+            bucket = next((bucket for candidate, bucket in pairs if candidate == text), "concept")
+            target = compact(text, 120)
+            out.append(
+                AttentionSignalV1(
+                    signal_id=stable_id("attention-signal", f"{self.detector_id}:{bucket}:{target.lower()}"),
+                    source=self.detector_id,
+                    target_text=target,
+                    target_type_hint="relation" if bucket == "relationship" else "concept",
+                    signal_kind=f"concept_{bucket}",
+                    salience=0.5 if bucket != "tension" else 0.62,
+                    confidence=0.68,
+                    evidence_refs=["inputs.concept_induction"],
+                    provenance={"detector": self.detector_id, "bucket": bucket, "belief_lineage": list(belief_lineage or [])[:8]},
+                )
+            )
+        return out

--- a/orion/substrate/attention/detectors/current_turn.py
+++ b/orion/substrate/attention/detectors/current_turn.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+from orion.schemas.attention_frame import AttentionSignalV1
+from orion.substrate.attention.common import compact
+from orion.substrate.attention.detectors.legacy_regex import LegacyRegexSignalDetector
+
+
+class CurrentTurnSignalDetector:
+    """Current user-turn detector; delegates phrase fallback to legacy v1 extraction."""
+
+    detector_id = "current_turn_v1"
+
+    def __init__(self, *, fallback: LegacyRegexSignalDetector | None = None) -> None:
+        self._fallback = fallback or LegacyRegexSignalDetector()
+
+    def detect(
+        self,
+        ctx: dict[str, Any],
+        inputs: dict[str, Any],
+        belief_lineage: list[str],
+    ) -> list[AttentionSignalV1]:
+        user_text = compact(ctx.get("user_message") or ctx.get("raw_user_text") or "", 600)
+        if not user_text:
+            return []
+        signals = self._fallback.detect(ctx, inputs, belief_lineage)
+        if signals:
+            return signals
+        return []

--- a/orion/substrate/attention/detectors/legacy_regex.py
+++ b/orion/substrate/attention/detectors/legacy_regex.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from orion.schemas.attention_frame import AttentionSignalV1
+from orion.substrate.attention.common import STOP_PHRASES, compact, stable_id
+
+_PLACE_RE = re.compile(r"\b(in|at|near|from)\s+([A-Z][A-Za-z0-9_-]{2,}(?:\s+[A-Z][A-Za-z0-9_-]{2,}){0,3})")
+_PROPER_RE = re.compile(r"\b([A-Z][A-Za-z0-9_-]{2,}(?:\s+[A-Z][A-Za-z0-9_-]{2,}){0,3})\b")
+_ACTIVITY_RE = re.compile(
+    r"\b(?:working on|building|debugging|planning|trying|running|designing|implementing|testing)\s+([^.!?\n]{3,90})",
+    flags=re.IGNORECASE,
+)
+_NAMED_RE = re.compile(r"\b(?:called|named|about|around|with|for)\s+([^.!?\n]{3,80})", flags=re.IGNORECASE)
+
+
+class LegacyRegexSignalDetector:
+    """Deterministic v1 fallback for current-turn phrase candidates."""
+
+    detector_id = "legacy_regex_v1"
+
+    def detect(
+        self,
+        ctx: dict[str, Any],
+        inputs: dict[str, Any],  # noqa: ARG002
+        belief_lineage: list[str],
+    ) -> list[AttentionSignalV1]:
+        user_text = compact(ctx.get("user_message") or ctx.get("raw_user_text") or "", 600)
+        candidates: list[tuple[str, str, str]] = []
+        for match in _ACTIVITY_RE.finditer(user_text):
+            candidates.append((compact(match.group(1), 90), "activity", "activity_phrase"))
+        for match in _NAMED_RE.finditer(user_text):
+            candidates.append((compact(match.group(1), 80), "other", "named_phrase"))
+        for match in _PLACE_RE.finditer(user_text):
+            candidates.append((compact(match.group(2), 80), "place", "place_phrase"))
+        for match in _PROPER_RE.finditer(user_text):
+            phrase = compact(match.group(1), 80)
+            if phrase.lower() not in STOP_PHRASES:
+                candidates.append((phrase, "concept", "proper_phrase"))
+
+        out: list[AttentionSignalV1] = []
+        seen: set[str] = set()
+        for phrase, hint, kind in candidates:
+            cleaned = phrase.strip(" ,:;()[]{}")
+            key = cleaned.lower()
+            if len(cleaned) < 3 or key in seen or key in STOP_PHRASES:
+                continue
+            seen.add(key)
+            out.append(
+                AttentionSignalV1(
+                    signal_id=stable_id("attention-signal", f"{self.detector_id}:{key}"),
+                    source=self.detector_id,
+                    target_text=cleaned,
+                    target_type_hint=hint,
+                    signal_kind=kind,
+                    salience=0.72,
+                    confidence=0.68,
+                    evidence_refs=["ctx.user_message"],
+                    provenance={"detector": self.detector_id, "belief_lineage": list(belief_lineage or [])[:8]},
+                )
+            )
+        return out

--- a/orion/substrate/attention/detectors/situation.py
+++ b/orion/substrate/attention/detectors/situation.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any
+
+from orion.schemas.attention_frame import AttentionSignalV1
+from orion.substrate.attention.common import compact, stable_id, unique
+
+
+class SituationSignalDetector:
+    detector_id = "situation_attention_v1"
+
+    def detect(
+        self,
+        ctx: dict[str, Any],  # noqa: ARG002
+        inputs: dict[str, Any],
+        belief_lineage: list[str],
+    ) -> list[AttentionSignalV1]:
+        situation = inputs.get("situation") if isinstance(inputs.get("situation"), dict) else {}
+        if not situation:
+            return []
+        raw: list[tuple[str, str, float]] = []
+        phase = situation.get("conversation_phase") if isinstance(situation.get("conversation_phase"), dict) else {}
+        phase_change = compact(phase.get("phase_change"), 80)
+        if phase_change:
+            raw.append((phase_change, "conversation_phase", 0.58 if phase_change == "stale_thread" else 0.42))
+        presence = situation.get("presence") if isinstance(situation.get("presence"), dict) else {}
+        audience = compact(presence.get("audience_mode"), 80)
+        if audience:
+            raw.append((audience, "presence", 0.45))
+        for affordance in (situation.get("affordances") or [])[:6]:
+            if isinstance(affordance, dict):
+                label = compact(affordance.get("kind") or affordance.get("suggestion"), 120)
+                if label:
+                    raw.append((label, "affordance", 0.52))
+
+        out: list[AttentionSignalV1] = []
+        for text in unique([item[0] for item in raw], limit=8):
+            kind = next((kind for candidate, kind, _salience in raw if candidate == text), "situation")
+            salience = next((_salience for candidate, _kind, _salience in raw if candidate == text), 0.45)
+            out.append(
+                AttentionSignalV1(
+                    signal_id=stable_id("attention-signal", f"{self.detector_id}:{text.lower()}"),
+                    source=self.detector_id,
+                    target_text=text,
+                    target_type_hint="other",
+                    signal_kind=f"situation_{kind}",
+                    salience=salience,
+                    confidence=0.66,
+                    evidence_refs=["inputs.situation"],
+                    provenance={"detector": self.detector_id, "belief_lineage": list(belief_lineage or [])[:8]},
+                )
+            )
+        return out

--- a/orion/substrate/attention/policy.py
+++ b/orion/substrate/attention/policy.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import re
+
+from orion.schemas.attention_frame import CuriosityCandidateActionV1, CuriositySuppressionV1, OpenLoopV1
+from orion.substrate.attention.questions import question_for
+from orion.substrate.attention.scoring import score_loop
+
+GENERIC_QUESTION_RE = re.compile(
+    r"\b(how (?:are|was) (?:you|your day)|what about you|and you\??|how about you\??)\b",
+    flags=re.IGNORECASE,
+)
+QUESTION_RE = re.compile(r"\?\s*$")
+DIRECT_WORK_RE = re.compile(
+    r"^\s*(please\s+)?(implement|fix|debug|review|explain|summarize|show|tell|write|add|remove|update|run|paste)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def generic_reversal_present(user_text: str) -> bool:
+    return bool(GENERIC_QUESTION_RE.search(user_text))
+
+
+def direct_work_turn(user_text: str) -> bool:
+    return bool(DIRECT_WORK_RE.search(user_text) or QUESTION_RE.search(user_text))
+
+
+def base_suppressions(*, user_text: str, stale_thread_active: bool) -> list[CuriositySuppressionV1]:
+    suppressions: list[CuriositySuppressionV1] = []
+    if generic_reversal_present(user_text):
+        suppressions.append(CuriositySuppressionV1(reason="generic_reciprocity", target_ref="generic_reversal", rationale="current turn matches a generic reversal pattern", confidence=0.9))
+    if direct_work_turn(user_text):
+        suppressions.append(CuriositySuppressionV1(reason="user_needs_direct_answer", target_ref="current_turn", rationale="current turn asks for work or a direct answer", confidence=0.78))
+    if stale_thread_active:
+        suppressions.append(CuriositySuppressionV1(reason="stale_thread", target_ref="situation.conversation_phase", rationale="conversation phase marks thread as stale", confidence=0.7))
+    return suppressions
+
+
+def select_actions(
+    *,
+    open_loops: list[OpenLoopV1],
+    suppressions: list[CuriositySuppressionV1],
+    min_ask: float,
+    max_asks: int,
+    generic_reversal: bool,
+    stale_thread_active: bool,
+) -> tuple[list[CuriosityCandidateActionV1], CuriosityCandidateActionV1, list[CuriositySuppressionV1], list[str]]:
+    actions: list[CuriosityCandidateActionV1] = []
+    suppressions = list(suppressions)
+    for loop in open_loops:
+        score = score_loop(loop)
+        if loop.already_known:
+            action_type = "suppress"
+            rationale = "already-known target should not be asked about again"
+            question = None
+            suppressions.append(CuriositySuppressionV1(reason="already_known", target_ref=loop.id, rationale=f"{loop.description} appears in current memory/concept context", confidence=0.78))
+        elif (score >= min_ask or (score >= (min_ask - 0.08) and loop.autonomy_value >= 0.5 and loop.predictive_value >= 0.5)) and loop.askability >= 0.45 and not generic_reversal and not stale_thread_active:
+            action_type = "ask"
+            rationale = "highest-value unresolved target is askable in this turn"
+            question = question_for(loop)
+        elif score >= 0.48:
+            action_type = "watch"
+            rationale = "target is useful but not worth a question now"
+            question = None
+        elif score >= 0.35:
+            action_type = "defer"
+            rationale = "target is unresolved but low priority"
+            question = None
+        else:
+            action_type = "none"
+            rationale = "target below curiosity threshold"
+            question = None
+        actions.append(
+            CuriosityCandidateActionV1(
+                action_type=action_type,  # type: ignore[arg-type]
+                open_loop_id=loop.id,
+                score=score,
+                rationale=rationale,
+                question_text=question,
+                provenance={"policy": "deterministic_attention_frame_v1", "min_ask_score": min_ask},
+            )
+        )
+
+    ask_actions = sorted([a for a in actions if a.action_type == "ask"], key=lambda a: a.score, reverse=True)
+    selected = ask_actions[0] if ask_actions and max_asks >= 1 else None
+    if len(ask_actions) > max_asks:
+        for extra in ask_actions[max_asks:]:
+            suppressions.append(CuriositySuppressionV1(reason="too_many_questions", target_ref=extra.open_loop_id, rationale="policy allows at most one selected ask", confidence=0.95))
+            idx = actions.index(extra)
+            actions[idx] = extra.model_copy(update={"action_type": "watch", "question_text": None, "rationale": "ask suppressed because policy allows at most one selected ask"})
+    if selected is None:
+        non_none = sorted([a for a in actions if a.action_type in {"watch", "defer", "suppress"}], key=lambda a: a.score, reverse=True)
+        selected = non_none[0] if non_none else CuriosityCandidateActionV1(action_type="none", score=0.0, rationale="no qualifying open loop")
+
+    deferred = [str(a.open_loop_id) for a in actions if a.open_loop_id and a.action_type in {"defer", "watch"}]
+    return actions, selected, suppressions, deferred

--- a/orion/substrate/attention/questions.py
+++ b/orion/substrate/attention/questions.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from orion.schemas.attention_frame import OpenLoopV1
+from orion.substrate.attention.common import compact
+
+
+def question_for(loop: OpenLoopV1) -> str:
+    desc = compact(loop.description, 90)
+    if loop.target_type == "plan":
+        return f"What is the unresolved constraint around {desc}?"
+    if loop.target_type == "activity":
+        return f"What part of {desc} is still open?"
+    if loop.target_type == "anomaly":
+        return f"What changed right before {desc} showed up?"
+    return f"What is the sharp unknown around {desc}?"

--- a/orion/substrate/attention/scoring.py
+++ b/orion/substrate/attention/scoring.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from orion.schemas.attention_frame import AttentionSignalV1, OpenLoopV1
+from orion.substrate.attention.common import bounded, compact, stable_id
+
+_EMOTION_RE = re.compile(r"\b(frustrated|pissed|worried|excited|afraid|stuck|blocked|confused|love|hate|urgent)\b", re.I)
+_PLAN_RE = re.compile(r"\b(plan|planning|going to|tomorrow|next|later|schedule|deadline|future)\b", re.I)
+_ANOMALY_RE = re.compile(r"\b(weird|unexpected|anomaly|regression|broken|failed|mismatch|surprise)\b", re.I)
+
+
+def known_blob(inputs: dict[str, Any], ctx: dict[str, Any]) -> str:
+    pieces: list[str] = [str(ctx.get("memory_digest") or "")]
+    for section in ("identity", "concept_induction", "social", "reflective", "reasoning_summary", "autonomy"):
+        value = inputs.get(section)
+        if isinstance(value, dict):
+            pieces.append(str(value))
+    return " ".join(pieces).lower()
+
+
+def merge_signals(signals: list[AttentionSignalV1], *, limit: int) -> list[AttentionSignalV1]:
+    by_target: dict[str, AttentionSignalV1] = {}
+    for signal in signals:
+        key = signal.target_text.strip().lower()
+        if not key:
+            continue
+        existing = by_target.get(key)
+        if existing is None or (signal.salience, signal.confidence) > (existing.salience, existing.confidence):
+            by_target[key] = signal
+    return list(by_target.values())[:limit]
+
+
+def target_type_for(signal: AttentionSignalV1, user_text: str) -> str:
+    hint = signal.target_type_hint
+    text = f"{signal.target_text} {user_text} {signal.signal_kind}".lower()
+    if hint in {"person", "place", "activity", "plan", "relation", "belief", "object", "concept", "anomaly", "memory_gap", "future_event", "other"}:
+        if hint != "other":
+            return hint
+    if _ANOMALY_RE.search(text):
+        return "anomaly"
+    if _PLAN_RE.search(text):
+        return "plan"
+    if any(word in text for word in ("relationship", "with my", "with our", "between")):
+        return "relation"
+    if any(word in text for word in ("believe", "think", "assumption", "claim")):
+        return "belief"
+    if any(word in text for word in ("device", "board", "gpu", "file", "service", "object")):
+        return "object"
+    return "concept" if "concept" in text else "other"
+
+
+def autonomy_pressure_from_signals(signals: list[AttentionSignalV1]) -> tuple[float, list[str]]:
+    autonomy = [s for s in signals if s.source.startswith("autonomy")]
+    if not autonomy:
+        return 0.0, []
+    pressure = max(s.salience for s in autonomy)
+    return bounded(max(pressure, min(1.0, len(autonomy) * 0.18))), [s.target_text for s in autonomy[:6]]
+
+
+def concept_pressure_from_signals(signals: list[AttentionSignalV1], target_text: str) -> float:
+    concept_signals = [s for s in signals if s.source.startswith("concept_induction")]
+    if any(s.target_text.lower() == target_text.lower() for s in concept_signals):
+        return 0.25
+    return min(1.0, 0.08 * len(concept_signals))
+
+
+def build_open_loops(
+    *,
+    signals: list[AttentionSignalV1],
+    ctx: dict[str, Any],
+    inputs: dict[str, Any],
+    belief_lineage: list[str],
+    direct_turn: bool,
+    generic_reversal: bool,
+    stale_thread_active: bool,
+    max_open: int,
+) -> list[OpenLoopV1]:
+    user_text = compact(ctx.get("user_message") or ctx.get("raw_user_text") or "", 600)
+    known = known_blob(inputs, ctx)
+    autonomy_value, autonomy_signals = autonomy_pressure_from_signals(signals)
+    loops: list[OpenLoopV1] = []
+    for signal in merge_signals(signals, limit=max_open):
+        phrase = compact(signal.target_text, 120)
+        already_known = phrase.lower() in known
+        target_type = target_type_for(signal, user_text)
+        novelty = 0.18 if already_known else max(0.35, signal.salience)
+        continuity = 0.58 if any(token in user_text.lower() for token in ("again", "still", "remember", "continue", "our")) else 0.25
+        relational = 0.68 if any(token in user_text.lower() for token in ("my ", "our ", "we ", "juniper", "relationship")) else 0.18
+        predictive = 0.72 if target_type in {"plan", "future_event", "anomaly"} or _PLAN_RE.search(user_text) else 0.22
+        concept_value = max(concept_pressure_from_signals(signals, phrase), 0.55 if target_type in {"concept", "belief", "anomaly"} else 0.25)
+        emotional = 0.65 if _EMOTION_RE.search(user_text) else 0.12
+        askability = 0.5 if direct_turn else 0.72
+        if generic_reversal or stale_thread_active:
+            askability = min(askability, 0.25)
+        loops.append(
+            OpenLoopV1(
+                id=stable_id("open-loop", phrase.lower()),
+                target_type=target_type,  # type: ignore[arg-type]
+                description=phrase,
+                source_text=user_text,
+                source_refs=list(signal.evidence_refs or ["ctx.user_message"]),
+                why_it_matters="novel or unresolved current-turn target with substrate pressure" if not already_known else "current-turn target overlaps known context",
+                novelty=bounded(novelty),
+                continuity_relevance=bounded(continuity),
+                relational_relevance=bounded(relational),
+                predictive_value=bounded(predictive),
+                concept_value=bounded(concept_value),
+                autonomy_value=autonomy_value,
+                emotional_charge=bounded(emotional),
+                already_known=already_known,
+                askability=bounded(askability),
+                confidence=bounded(max(signal.confidence, 0.58 if already_known else 0.72)),
+                provenance={
+                    "extractor": "attention_signal_pipeline_v1",
+                    "signal_id": signal.signal_id,
+                    "signal_source": signal.source,
+                    "signal_kind": signal.signal_kind,
+                    "belief_lineage": list(belief_lineage or [])[:8],
+                    "autonomy_signals": autonomy_signals,
+                    **dict(signal.provenance or {}),
+                },
+            )
+        )
+    return loops
+
+
+def score_loop(loop: OpenLoopV1) -> float:
+    raw = (
+        loop.novelty * 0.2
+        + loop.continuity_relevance * 0.13
+        + loop.relational_relevance * 0.12
+        + loop.predictive_value * 0.13
+        + loop.concept_value * 0.14
+        + loop.autonomy_value * 0.16
+        + loop.emotional_charge * 0.07
+        + loop.askability * 0.05
+    )
+    if loop.already_known:
+        raw *= 0.25
+    return bounded(raw * 1.22)

--- a/orion/substrate/attention_frame.py
+++ b/orion/substrate/attention_frame.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Sequence
+
+from orion.schemas.attention_frame import AttentionFrameV1, AttentionSignalV1
+from orion.substrate.attention.common import compact
+from orion.substrate.attention.detectors import AttentionSignalDetector, default_attention_detectors
+from orion.substrate.attention.policy import (
+    base_suppressions,
+    direct_work_turn,
+    generic_reversal_present,
+    select_actions,
+)
+from orion.substrate.attention.scoring import autonomy_pressure_from_signals, build_open_loops, merge_signals
+
+_MAX_SOURCE_TEXT = 600
+
+
+def attention_frame_enabled() -> bool:
+    return str(os.getenv("ORION_CURIOSITY_FRAME_ENABLED", "false")).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return max(0, int(os.getenv(name) or default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return min(1.0, max(0.0, float(os.getenv(name) or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _stale_thread_active(inputs: dict[str, Any]) -> bool:
+    situation = inputs.get("situation") if isinstance(inputs.get("situation"), dict) else {}
+    phase = situation.get("conversation_phase") if isinstance(situation.get("conversation_phase"), dict) else {}
+    return str(phase.get("phase_change") or "") == "stale_thread"
+
+
+def _detect_signals(
+    *,
+    detectors: Sequence[AttentionSignalDetector],
+    ctx: dict[str, Any],
+    inputs: dict[str, Any],
+    belief_lineage: list[str],
+) -> list[AttentionSignalV1]:
+    signals: list[AttentionSignalV1] = []
+    for detector in detectors:
+        try:
+            signals.extend(detector.detect(ctx, inputs, belief_lineage))
+        except Exception:
+            continue
+    return signals
+
+
+def build_attention_frame(
+    *,
+    ctx: dict[str, Any],
+    inputs: dict[str, Any],
+    belief_lineage: list[str] | None = None,
+    detectors: Sequence[AttentionSignalDetector] | None = None,
+) -> AttentionFrameV1:
+    user_text = compact(ctx.get("user_message") or ctx.get("raw_user_text") or "", _MAX_SOURCE_TEXT)
+    max_open = _env_int("ORION_CURIOSITY_MAX_OPEN_LOOPS", 5)
+    max_asks = max(0, min(1, _env_int("ORION_CURIOSITY_MAX_SELECTED_ACTIONS", 1)))
+    min_ask = _env_float("ORION_CURIOSITY_MIN_ASK_SCORE", 0.65)
+    lineage = list(belief_lineage or [])
+    detector_list = list(detectors) if detectors is not None else default_attention_detectors()
+    signals = _detect_signals(detectors=detector_list, ctx=ctx, inputs=inputs, belief_lineage=lineage)
+    merged_signals = merge_signals(signals, limit=max_open * 3)
+    stale = _stale_thread_active(inputs)
+    generic = generic_reversal_present(user_text)
+    direct = direct_work_turn(user_text)
+    open_loops = build_open_loops(
+        signals=merged_signals,
+        ctx=ctx,
+        inputs=inputs,
+        belief_lineage=lineage,
+        direct_turn=direct,
+        generic_reversal=generic,
+        stale_thread_active=stale,
+        max_open=max_open,
+    )
+    actions, selected, suppressions, deferred = select_actions(
+        open_loops=open_loops,
+        suppressions=base_suppressions(user_text=user_text, stale_thread_active=stale),
+        min_ask=min_ask,
+        max_asks=max_asks,
+        generic_reversal=generic,
+        stale_thread_active=stale,
+    )
+    _autonomy_value, autonomy_signals = autonomy_pressure_from_signals(merged_signals)
+    return AttentionFrameV1(
+        generated_at=datetime.now(timezone.utc),
+        turn_id=str(ctx.get("turn_id") or ctx.get("message_id") or "") or None,
+        session_id=str(ctx.get("session_id") or "") or None,
+        correlation_id=str(ctx.get("correlation_id") or ctx.get("trace_id") or "") or None,
+        open_loops=open_loops,
+        live_unknowns=[loop.description for loop in open_loops if not loop.already_known],
+        candidate_actions=actions,
+        selected_action=selected,
+        suppressions=suppressions,
+        deferred_items=deferred[:max_open],
+        debug={
+            "enabled": True,
+            "direct_turn": direct,
+            "generic_reversal": generic,
+            "max_open_loops": max_open,
+            "max_selected_asks": max_asks,
+            "min_ask_score": min_ask,
+            "belief_lineage": lineage[:8],
+            "detectors": [getattr(detector, "detector_id", type(detector).__name__) for detector in detector_list],
+            "signal_count": len(signals),
+            "merged_signal_count": len(merged_signals),
+            "autonomy_signals": autonomy_signals,
+        },
+    )

--- a/services/orion-cortex-exec/app/attention_frame.py
+++ b/services/orion-cortex-exec/app/attention_frame.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from orion.substrate.attention_frame import attention_frame_enabled, build_attention_frame
+
+__all__ = ["attention_frame_enabled", "build_attention_frame"]

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -46,6 +46,8 @@ from orion.substrate.relational import (
 )
 from orion.substrate.relational.adapters.spark_ctx import map_spark_ctx_to_substrate
 
+from .attention_frame import attention_frame_enabled, build_attention_frame
+
 from .endogenous_runtime import (
     consume_endogenous_runtime_for_reflective_review,
     inspect_endogenous_runtime_records,
@@ -1799,6 +1801,26 @@ def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
         except Exception as exc:
             logger.warning("autonomy_reducer_v2_failed error=%s", exc)
 
+    if attention_frame_enabled():
+        try:
+            attention_frame = build_attention_frame(
+                ctx=ctx,
+                inputs=inputs,
+                belief_lineage=(beliefs.lineage if beliefs is not None else []),
+            )
+            attention_frame_payload = attention_frame.model_dump(mode="json")
+            inputs["attention_frame"] = attention_frame_payload
+            ctx["chat_attention_frame"] = attention_frame_payload
+            ctx["chat_attention_frame_debug"] = {
+                "open_loop_count": len(attention_frame.open_loops),
+                "selected_action": (attention_frame.selected_action.model_dump(mode="json") if attention_frame.selected_action else None),
+                "suppression_reasons": [s.reason for s in attention_frame.suppressions],
+            }
+        except Exception as exc:
+            logger.warning("attention_frame_build_failed error=%s", exc)
+            ctx.pop("chat_attention_frame", None)
+            ctx.pop("chat_attention_frame_debug", None)
+
     ctx["chat_stance_inputs"] = inputs
     ctx["chat_concept_summary"] = concept
     ctx["chat_social_summary"] = social
@@ -1889,6 +1911,7 @@ def build_chat_stance_debug_payload(
         else {}
     )
     autonomy_summary = autonomy.get("summary") if isinstance(autonomy.get("summary"), dict) else {}
+    attention_frame = stance_inputs.get("attention_frame") if isinstance(stance_inputs.get("attention_frame"), dict) else {}
     autonomy_debug = autonomy.get("debug") if isinstance(autonomy.get("debug"), dict) else {}
     reasoning = stance_inputs.get("reasoning_summary") if isinstance(stance_inputs.get("reasoning_summary"), dict) else {}
     situation = stance_inputs.get("situation") if isinstance(stance_inputs.get("situation"), dict) else {}
@@ -1946,6 +1969,7 @@ def build_chat_stance_debug_payload(
                 "autonomy": autonomy_summary,
                 "reasoning": reasoning,
                 "situation": situation,
+                "attention_frame": attention_frame,
             }.items()
             if isinstance(value, dict) and any(value.values())
         ]
@@ -1957,6 +1981,7 @@ def build_chat_stance_debug_payload(
         "orion_identity_summary": list(ctx.get("orion_identity_summary") or []),
         "juniper_relationship_summary": list(ctx.get("juniper_relationship_summary") or []),
         "response_policy_summary": list(ctx.get("response_policy_summary") or []),
+        "attention_frame": attention_frame if attention_frame else None,
         "situation_prompt_fragment": ctx.get("situation_prompt_fragment") if isinstance(ctx.get("situation_prompt_fragment"), dict) else None,
         "presence_context": ctx.get("presence_context") if isinstance(ctx.get("presence_context"), dict) else None,
         "situation_presence": ((ctx.get("situation_brief") or {}).get("presence") if isinstance(ctx.get("situation_brief"), dict) else None),
@@ -2039,6 +2064,14 @@ def build_chat_stance_debug_payload(
                 "fallback_recommended": bool(reasoning.get("fallback_recommended")),
                 "used": bool(ctx.get("chat_reasoning_summary_used")),
             },
+            "attention_frame": {
+                "open_loops": list(attention_frame.get("open_loops") or []),
+                "live_unknowns": list(attention_frame.get("live_unknowns") or []),
+                "selected_action": attention_frame.get("selected_action"),
+                "suppressions": list(attention_frame.get("suppressions") or []),
+                "deferred_items": list(attention_frame.get("deferred_items") or []),
+                "debug": attention_frame.get("debug") if isinstance(attention_frame.get("debug"), dict) else {},
+            },
             "situation": {
                 "situation_relevance": situation.get("situation_relevance"),
                 "situation_prompt_fragment": situation.get("situation_prompt_fragment") if isinstance(situation.get("situation_prompt_fragment"), dict) else {},
@@ -2070,6 +2103,7 @@ def build_chat_stance_debug_payload(
             f"mutation adaptation context present: {'yes' if bool(mutation_adaptation) else 'no'}",
             f"reasoning summary used: {'yes' if bool(ctx.get('chat_reasoning_summary_used')) else 'no'}",
             f"situation context present: {'yes' if bool(situation) else 'no'}",
+            f"attention frame present: {'yes' if bool(attention_frame) else 'no'}",
             f"fallback applied: {'yes' if fallback_invoked or semantic_fallback else 'no'}",
         ],
         "raw": {

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -452,6 +452,12 @@ def _autonomy_payload_from_ctx(ctx: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(final_text_clean, str):
         payload["final_text_clean"] = final_text_clean
     if chat_stance_debug:
+        attention_frame = chat_stance_debug.get("source_inputs", {}).get("attention_frame") if isinstance(chat_stance_debug.get("source_inputs"), dict) else {}
+        selected = attention_frame.get("selected_action") if isinstance(attention_frame, dict) else None
+        if isinstance(selected, dict) and selected.get("action_type") == "ask" and isinstance(final_text_clean, str):
+            chat_stance_debug["speech_followed_recommendation"] = {"selected_action": "ask", "final_text_has_question": "?" in final_text_clean}
+        elif isinstance(selected, dict):
+            chat_stance_debug["speech_followed_recommendation"] = {"selected_action": selected.get("action_type"), "final_text_has_question": ("?" in final_text_clean) if isinstance(final_text_clean, str) else None}
         payload["chat_stance_debug"] = chat_stance_debug
     v2_state = ctx.get("chat_autonomy_state_v2")
     if isinstance(v2_state, dict):

--- a/services/orion-cortex-exec/tests/test_attention_frame.py
+++ b/services/orion-cortex-exec/tests/test_attention_frame.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from app.attention_frame import build_attention_frame
+from orion.schemas.attention_frame import AttentionSignalV1
+from orion.substrate.attention.detectors.autonomy import AutonomySignalDetector
+
+
+class _FakeDetector:
+    detector_id = "fake_detector"
+
+    def detect(self, ctx, inputs, belief_lineage):
+        return [
+            AttentionSignalV1(
+                signal_id="fake-signal-1",
+                source=self.detector_id,
+                target_text="NonRegex Observatory",
+                target_type_hint="concept",
+                signal_kind="fake_open_loop",
+                salience=0.9,
+                confidence=0.9,
+                evidence_refs=["fake:evidence"],
+                provenance={"belief_lineage": belief_lineage},
+            )
+        ]
+
+
+def _inputs(**overrides):
+    base = {
+        "identity": {"orion": [], "juniper": [], "response_policy": []},
+        "concept_induction": {"self": [], "relationship": [], "growth": [], "tension": []},
+        "social": {"social_posture": [], "relationship_facets": [], "hazards": []},
+        "reflective": {"themes": [], "tensions": [], "dream_motifs": []},
+        "autonomy": {"summary": {"top_drives": [], "active_tensions": []}, "debug": {}},
+        "reasoning_summary": {"hazards": [], "tensions": [], "fallback_recommended": False},
+        "situation": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_novel_unresolved_activity_creates_open_loop() -> None:
+    frame = build_attention_frame(
+        ctx={"user_message": "I am debugging the carrier board bringup around the LVDS rail."},
+        inputs=_inputs(),
+        belief_lineage=["recall:snapshot_ephemeral"],
+    )
+    assert frame.open_loops
+    assert any("carrier board" in loop.description.lower() or "lvds" in loop.description.lower() for loop in frame.open_loops)
+    assert frame.debug["belief_lineage"] == ["recall:snapshot_ephemeral"]
+
+
+def test_generic_reciprocity_is_suppressed() -> None:
+    frame = build_attention_frame(ctx={"user_message": "What about you?"}, inputs=_inputs())
+    assert any(s.reason == "generic_reciprocity" for s in frame.suppressions)
+    assert frame.selected_action is not None
+    assert frame.selected_action.action_type != "ask"
+
+
+def test_already_known_fact_suppresses_redundant_question() -> None:
+    frame = build_attention_frame(
+        ctx={"user_message": "Tell me about Project Silver Loom", "memory_digest": "Project Silver Loom is already known."},
+        inputs=_inputs(),
+    )
+    assert any(loop.already_known for loop in frame.open_loops)
+    assert any(s.reason == "already_known" for s in frame.suppressions)
+
+
+def test_high_value_open_loop_selects_single_ask() -> None:
+    frame = build_attention_frame(
+        ctx={"user_message": "I am planning next week's migration around Zephyr Bridge."},
+        inputs=_inputs(
+            autonomy={
+                "summary": {"top_drives": ["predictive", "continuity"], "active_tensions": ["tension.continuity_gap.v1"]},
+                "debug": {},
+            },
+        ),
+    )
+    asks = [a for a in frame.candidate_actions if a.action_type == "ask"]
+    assert frame.selected_action is not None
+    assert frame.selected_action.action_type == "ask"
+    assert len([a for a in asks if a.question_text]) <= 1
+
+
+def test_low_value_open_loop_selects_non_ask() -> None:
+    frame = build_attention_frame(ctx={"user_message": "Please implement this plan for Orion."}, inputs=_inputs())
+    assert frame.selected_action is not None
+    assert frame.selected_action.action_type in {"watch", "defer", "suppress", "none"}
+    assert any(s.reason == "user_needs_direct_answer" for s in frame.suppressions)
+
+
+def test_concept_and_autonomy_pressure_influence_ranking() -> None:
+    low = build_attention_frame(ctx={"user_message": "I am exploring Blue Lattice."}, inputs=_inputs())
+    high = build_attention_frame(
+        ctx={"user_message": "I am exploring Blue Lattice."},
+        inputs=_inputs(
+            concept_induction={"self": ["lattice coherence"], "relationship": [], "growth": [], "tension": ["fragmentation"]},
+            autonomy={
+                "summary": {"top_drives": ["coherence", "predictive"], "active_tensions": ["tension.coherence_break.v1"]},
+                "state_v2": {"attention_items": [{"summary": "dominant_drive=coherence"}]},
+                "debug": {},
+            },
+        ),
+    )
+    assert high.candidate_actions[0].score >= low.candidate_actions[0].score
+
+
+def test_absent_upstream_signals_fail_open_without_noisy_question() -> None:
+    frame = build_attention_frame(ctx={"user_message": ""}, inputs={})
+    assert frame.open_loops == []
+    assert frame.selected_action is not None
+    assert frame.selected_action.action_type == "none"
+
+def test_detector_registry_accepts_fake_detector_without_regex() -> None:
+    frame = build_attention_frame(ctx={"user_message": ""}, inputs=_inputs(), detectors=[_FakeDetector()])
+    assert frame.open_loops
+    assert frame.open_loops[0].description == "NonRegex Observatory"
+    assert frame.open_loops[0].provenance["signal_source"] == "fake_detector"
+
+
+def test_autonomy_detector_emits_attention_item_signal() -> None:
+    signals = AutonomySignalDetector().detect(
+        {},
+        _inputs(
+            autonomy={
+                "summary": {"top_drives": [], "active_tensions": []},
+                "state_v2": {"attention_items": [{"summary": "dominant_drive=coherence", "salience": 0.81}]},
+                "debug": {},
+            }
+        ),
+        ["autonomy:graphdb_durable"],
+    )
+    assert signals
+    assert signals[0].source == "autonomy_attention_v1"
+    assert signals[0].target_text == "dominant_drive=coherence"

--- a/services/orion-cortex-exec/tests/test_attention_frame_integration.py
+++ b/services/orion-cortex-exec/tests/test_attention_frame_integration.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.chat_stance import build_chat_stance_debug_payload, build_chat_stance_inputs
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_feature_flag_off_preserves_chat_stance_input_shape(monkeypatch) -> None:
+    monkeypatch.delenv("ORION_CURIOSITY_FRAME_ENABLED", raising=False)
+    ctx = {"user_message": "I am planning around Zephyr Bridge.", "skip_unified_beliefs": True}
+    built = build_chat_stance_inputs(ctx)
+    assert "attention_frame" not in built
+    assert "chat_attention_frame" not in ctx
+
+
+def test_feature_flag_on_adds_attention_frame(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_CURIOSITY_FRAME_ENABLED", "true")
+    ctx = {"user_message": "I am planning around Zephyr Bridge.", "skip_unified_beliefs": True}
+    built = build_chat_stance_inputs(ctx)
+    assert "attention_frame" in built
+    assert ctx["chat_attention_frame"]["schema_version"] == "attention.frame.v1"
+    assert built["attention_frame"]["open_loops"]
+
+
+def test_debug_payload_exposes_attention_frame() -> None:
+    attention_frame = {
+        "schema_version": "attention.frame.v1",
+        "open_loops": [{"id": "loop-1", "description": "Zephyr Bridge", "target_type": "plan"}],
+        "live_unknowns": ["Zephyr Bridge"],
+        "candidate_actions": [],
+        "selected_action": {"action_type": "watch", "open_loop_id": "loop-1", "score": 0.5},
+        "suppressions": [{"reason": "user_needs_direct_answer", "target_ref": "current_turn"}],
+        "deferred_items": ["loop-1"],
+        "debug": {"enabled": True},
+    }
+    ctx = {
+        "user_message": "what changed?",
+        "memory_digest": "",
+        "chat_stance_inputs": {
+            "identity": {"orion": [], "juniper": [], "response_policy": []},
+            "concept_induction": {"self": [], "relationship": [], "growth": [], "tension": []},
+            "social": {"social_posture": [], "relationship_facets": [], "hazards": []},
+            "social_bridge": {"posture": [], "hazards": [], "framing": [], "summary": []},
+            "reflective": {"themes": [], "tensions": [], "dream_motifs": []},
+            "autonomy": {"summary": {}, "debug": {}},
+            "reasoning_summary": {},
+            "situation": {},
+            "attention_frame": attention_frame,
+        },
+    }
+    payload = build_chat_stance_debug_payload(
+        ctx=ctx,
+        synthesized_brief={"task_mode": "direct_response"},
+        final_brief={"task_mode": "direct_response"},
+        fallback_invoked=False,
+        normalized_applied=False,
+        semantic_fallback=False,
+        quality_modified=False,
+    )
+    assert payload["source_inputs"]["attention_frame"]["selected_action"]["action_type"] == "watch"
+    assert payload["final_prompt_contract"]["attention_frame"]["schema_version"] == "attention.frame.v1"
+
+
+def test_prompt_contracts_include_attention_policy() -> None:
+    stance_prompt = (REPO_ROOT / "orion" / "cognition" / "prompts" / "chat_stance_brief.j2").read_text(encoding="utf-8")
+    speech_prompt = (REPO_ROOT / "orion" / "cognition" / "prompts" / "chat_general.j2").read_text(encoding="utf-8")
+    assert "attention_frame: {{ chat_attention_frame }}" in stance_prompt
+    assert "curiosity:ask_selected" in stance_prompt
+    assert "attention_frame: {{ chat_attention_frame }}" in speech_prompt
+    assert "ask only when attention_frame.selected_action.action_type is ask" in speech_prompt

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -3141,6 +3141,7 @@ loadDismissedIds();
       } else {
         chatStanceDebugModalBody.appendChild(buildChatStanceSection('Overview', model.overview || {}));
         chatStanceDebugModalBody.appendChild(buildChatStanceSection('Source Inputs by Category', model.source_inputs || {}));
+        chatStanceDebugModalBody.appendChild(buildChatStanceSection('Attention / Curiosity', (model.source_inputs && model.source_inputs.attention_frame) || {}));
         chatStanceDebugModalBody.appendChild(
           buildChatStanceSection(
             'Journal PageIndex',

--- a/services/orion-hub/tests/test_attention_frame_debug_panel.py
+++ b/services/orion-hub/tests/test_attention_frame_debug_panel.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+APP_JS_PATH = REPO_ROOT / "services" / "orion-hub" / "static" / "js" / "app.js"
+
+
+def test_chat_stance_modal_includes_attention_curiosity_section() -> None:
+    app_js = APP_JS_PATH.read_text(encoding="utf-8")
+    assert "buildChatStanceSection('Attention / Curiosity'" in app_js
+    assert "model.source_inputs && model.source_inputs.attention_frame" in app_js


### PR DESCRIPTION
# AttentionFrame: detector pipeline refactor (behavior-preserving v1)

## Summary
Refactors `AttentionFrameV1` construction from a monolithic regex-first module into an extensible detector pipeline under `orion/substrate/attention*`, while keeping `build_attention_frame(...)` as the public API and preserving current behavior.

## Why
The previous implementation mixed extraction, typing, scoring, suppression, question guidance, and frame assembly in one file. This change makes the system extensible by adding detectors rather than editing brittle regex logic.

## What Changed
- Added `AttentionSignalV1` (typed intermediate signal) to the attention schema.
- Introduced `AttentionSignalDetector` protocol and default detector set:
  - `current_turn_v1` (delegates to legacy v1 regex fallback)
  - `autonomy_attention_v1` (top drives/tensions + attention_items)
  - `concept_induction_attention_v1` (concept buckets)
  - `situation_attention_v1` (affordances/presence/stale-thread)
- Split implementation into modules:
  - `orion/substrate/attention_frame.py`: orchestrator + public `build_attention_frame`
  - `orion/substrate/attention/scoring.py`: signal merge/dedupe, open loop construction, scoring
  - `orion/substrate/attention/policy.py`: suppressions + selected_action + max-one-ask enforcement
  - `orion/substrate/attention/questions.py`: guidance-only question templates
  - `orion/substrate/attention/detectors/*`: modular detectors (legacy regex isolated)
- Kept `services/orion-cortex-exec/app/attention_frame.py` as a compatibility wrapper so `chat_stance` keeps calling the same API.

## Observability / UX
- Attention frame remains surfaced via existing chat stance debug payload plumbing and Hub Inspect modal section.

## Tests
- Existing behavior tests still pass.
- Added tests that:
  - inject a fake detector (proves extensibility without regex)
  - verify autonomy detector emits signals from `attention_items`
  - preserve generic reciprocity suppression, direct-work suppression, and max-one-ask.

## Verification
Ran:
- `PYTHONPATH=. ./venv/bin/python -m pytest services/orion-cortex-exec/tests/test_chat_stance_brief.py services/orion-cortex-exec/tests/test_attention_frame.py services/orion-cortex-exec/tests/test_attention_frame_integration.py services/orion-hub/tests/test_chat_stance_debug_panel.py services/orion-hub/tests/test_attention_frame_debug_panel.py -q --tb=short`

Result: `37 passed` (plus an existing Pydantic deprecation warning)

## Rollout
Feature remains gated by `ORION_CURIOSITY_FRAME_ENABLED=true`. Disabled behavior remains unchanged.