### PR TITLE
Feat/hub chat kids story wiring

### DIFF
--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -41,7 +41,7 @@ Hub supports three modes via the `mode` field in the request:
 
 #### Kids story lane (verb override)
 
-Send a single explicit verb: `verbs: ["chat_kids_story"]` with normal `messages` / recall options.
+In the main chat UI, use the **Story** mode button (bounded fast lane, `chat_kids_story`) next to **Quick**, or send a single explicit verb: `verbs: ["chat_kids_story"]` with normal `messages` / recall options.
 Verb must be active on the hub node (`orion/cognition/verbs/active.yaml`). Default recall profile is
 `chat.story.kids.v1` (vector-off; SQL + timeline + optional cards) unless the client sets `profile_explicit`.
 

--- a/services/orion-hub/scripts/cortex_request_builder.py
+++ b/services/orion-hub/scripts/cortex_request_builder.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from orion.cognition.fast_chat_verbs import FAST_SINGLE_PASS_CHAT_VERBS
 from orion.cognition.verb_activation import is_active
 from orion.cognition.workflows import (
     derive_workflow_execution_policy,
@@ -127,6 +128,8 @@ def _normalize_skill_runner_lane(
         return "brain", selected_verbs
     if lane == "quick":
         if len(selected_verbs) == 1 and str(selected_verbs[0]).strip().startswith("skills."):
+            return "brain", selected_verbs
+        if len(selected_verbs) == 1 and str(selected_verbs[0]).strip().lower() in FAST_SINGLE_PASS_CHAT_VERBS:
             return "brain", selected_verbs
         return "brain", ["chat_quick"]
     if lane == "agent":

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -8114,6 +8114,14 @@ loadDismissedIds();
         options: { chat_quick_full_stance: chatQuickVariant === 'stance' },
       };
     }
+    if (verbOverride === 'chat_kids_story') {
+      return {
+        mode: 'brain',
+        verbs: ['chat_kids_story'],
+        skillRunnerOrigin: true,
+        skillRunnerLane: 'quick',
+      };
+    }
     if (laneMode === 'agent') {
       return {
         mode: 'agent',
@@ -9488,6 +9496,12 @@ loadDismissedIds();
               if (audioIsChatQuick) {
                 audioPayload.verbs = ['chat_quick'];
                 audioPayload.options = { chat_quick_full_stance: chatQuickVariant === 'stance' };
+              } else if (
+                Array.isArray(audioLaneVerbs) &&
+                audioLaneVerbs.length === 1 &&
+                String(audioLaneVerbs[0] || '').trim().toLowerCase() === 'chat_kids_story'
+              ) {
+                audioPayload.verbs = ['chat_kids_story'];
               }
               socket.send(JSON.stringify(audioPayload));
              updateStatus('Audio sent.');

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -8104,7 +8104,8 @@ loadDismissedIds();
       };
     }
     const laneMode = String(currentMode || 'brain').toLowerCase();
-    const verbOverride = modeVerbOverride ? String(modeVerbOverride).trim() : '';
+    const verbOverrideRaw = modeVerbOverride ? String(modeVerbOverride).trim() : '';
+    const verbOverride = verbOverrideRaw.toLowerCase();
     if (verbOverride === 'chat_quick') {
       return {
         mode: 'brain',

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -211,6 +211,7 @@
                   <button type="button" class="quick-variant-item block w-full px-3 py-2 text-left text-[11px] text-indigo-100 hover:bg-indigo-600/35" data-quick-variant="stance" role="menuitem">Quick + stance</button>
                 </div>
               </div>
+              <button type="button" class="mode-btn px-2 py-1 rounded border border-teal-500/40 bg-teal-500/15 text-teal-100 hover:bg-teal-500/25 transition-colors" data-mode="brain" data-verb-override="chat_kids_story" id="kidsStoryModeBtn" title="Kids story (bounded fast lane)">Story</button>
               <button class="mode-btn px-2 py-1 rounded bg-gray-700 text-gray-200 hover:bg-gray-600 transition-colors" data-mode="agent">Agent</button>
               <button class="mode-btn px-2 py-1 rounded bg-gray-700 text-gray-200 hover:bg-gray-600 transition-colors" data-mode="council">Council</button>
             </div>

--- a/services/orion-hub/tests/test_cortex_request_builder.py
+++ b/services/orion-hub/tests/test_cortex_request_builder.py
@@ -243,6 +243,28 @@ def test_quick_chat_selection_uses_chat_quick_verb_without_changing_brain_mode_c
     assert debug["verb"] == "chat_quick"
 
 
+def test_chat_kids_story_single_verb_maps_to_cortex_verb() -> None:
+    req, debug, _ = hub_builder.build_chat_request(
+        payload={
+            "mode": "brain",
+            "verbs": ["chat_kids_story"],
+        },
+        session_id="sid-kids",
+        user_id="user-kids",
+        trace_id="trace-kids",
+        default_mode="brain",
+        auto_default_enabled=False,
+        source_label="hub_http",
+        prompt="Tell a short cozy story.",
+    )
+
+    assert req.mode == "brain"
+    assert req.verb == "chat_kids_story"
+    assert req.route_intent == "none"
+    assert req.options.get("chat_quick_full_stance") is None
+    assert debug["verb"] == "chat_kids_story"
+
+
 def test_chat_quick_full_stance_option_passes_to_cortex_request() -> None:
     req, _, _ = hub_builder.build_chat_request(
         payload={

--- a/services/orion-hub/tests/test_workflow_request_builder.py
+++ b/services/orion-hub/tests/test_workflow_request_builder.py
@@ -339,6 +339,31 @@ def test_skill_runner_quick_lane_normalizes_to_brain_chat_quick() -> None:
     assert req.route_intent == 'none'
     assert debug['selected_ui_route'] == 'brain'
 
+
+def test_skill_runner_quick_lane_preserves_chat_kids_story_verb() -> None:
+    req, debug, _ = hub_builder.build_chat_request(
+        payload={
+            'mode': 'agent',
+            'skill_runner_origin': True,
+            'skill_runner_lane': 'quick',
+            'verbs': ['chat_kids_story'],
+        },
+        session_id='sid-skill-runner-kids',
+        user_id='user-1',
+        trace_id='trace-skill-runner-kids',
+        default_mode='brain',
+        auto_default_enabled=False,
+        source_label='hub_http',
+        prompt='Run this Orion skill now',
+    )
+
+    assert req.mode == 'brain'
+    assert req.verb == 'chat_kids_story'
+    assert req.route_intent == 'none'
+    assert req.options.get('chat_quick_full_stance') is None
+    assert debug['selected_ui_route'] == 'brain'
+
+
 def test_skill_runner_quick_lane_catalogue_gpu_uses_direct_skill_verb() -> None:
     req, debug, _ = hub_builder.build_chat_request(
         payload={


### PR DESCRIPTION
## Summary

- Adds a **Story** hub mode control (`chat_kids_story`) next to **Quick**, using the same `mode-btn` + `data-verb-override` pattern so typed chat and normal sends emit `verbs: ["chat_kids_story"]` without `chat_quick_full_stance`.
- **Skill runner** workflow runs with **quick** lane now preserve `chat_kids_story` instead of normalizing every non-`skills.*` verb to `chat_quick` (Python uses `FAST_SINGLE_PASS_CHAT_VERBS` for a single source of truth).
- **WebSocket audio** includes `verbs: ["chat_kids_story"]` when Story override is active (mirrors quick-lane audio behavior for `chat_quick`).
- README: documents the Story button under the kids story lane section.
- Tests: direct `chat_kids_story` request mapping + skill-runner quick lane preservation.

## Test plan

- [x] `PYTHONPATH=. <repo>/venv/bin/python -m pytest services/orion-hub/tests/test_cortex_request_builder.py services/orion-hub/tests/test_workflow_request_builder.py -q`
- [x] `PYTHONPATH=. …/venv/bin/python -m pytest services/orion-hub/tests/test_skill_runner_catalogue.py -q`
- [ ] Manual: Hub UI — select **Story**, send a message; confirm routing / recall behavior matches bounded fast lane for `chat_kids_story`.
- [ ] Manual (optional): Skill runner with a workflow + Story selected + Run; confirm cortex receives `chat_kids_story`.
- [ ] Manual (optional): Story + mic — confirm WS payload includes `verbs: ["chat_kids_story"]`.

## Notes

- No `.env` / `docker-compose` / `settings.py` changes (no new configuration).
- Full `services/orion-hub/tests/` suite may require a populated hub `.env` for settings-backed tests; targeted modules above pass without it.