### PR TITLE
Gate Mind handoff on meaningful synthesis

### DIFF
--- a/orion/mind/v1.py
+++ b/orion/mind/v1.py
@@ -12,6 +12,7 @@ TrustLevelV1 = Literal["low", "med", "high"]
 HypothesisTagV1 = Literal["assumption", "hypothesis", "simulation_result"]
 MergePolicyV1 = Literal["deterministic_merge"]
 BindingV1 = Literal["advisory", "mandatory"]
+MindQualityV1 = Literal["meaningful_synthesis", "fallback_contract_only", "empty", "error"]
 
 
 class MindRunPolicyV1(BaseModel):
@@ -89,6 +90,7 @@ class MindHandoffBriefV1(BaseModel):
     mandatory_keys: list[str] = Field(default_factory=list)
     advisory_keys: list[str] = Field(default_factory=list)
     stance_payload: dict[str, Any] = Field(default_factory=dict)
+    mind_quality: MindQualityV1 = "empty"
 
 
 class MindRunResultV1(BaseModel):
@@ -100,4 +102,5 @@ class MindRunResultV1(BaseModel):
     trajectory: MindStanceTrajectoryV1 = Field(default_factory=MindStanceTrajectoryV1)
     decision: MindControlDecisionV1 = Field(default_factory=MindControlDecisionV1)
     brief: MindHandoffBriefV1 = Field(default_factory=MindHandoffBriefV1)
+    mind_quality: MindQualityV1 = "empty"
     timing_ms_by_phase: dict[str, float] = Field(default_factory=dict)

--- a/services/orion-cortex-exec/tests/test_mind_handoff_shortcut.py
+++ b/services/orion-cortex-exec/tests/test_mind_handoff_shortcut.py
@@ -25,39 +25,44 @@ def _exec_prep() -> None:
 from orion.schemas.cortex.schemas import ExecutionStep
 
 
-def test_shortcut_returns_result_when_handoff_valid() -> None:
+_VALID_STANCE = {
+    "conversation_frame": "technical",
+    "user_intent": "u",
+    "self_relevance": "s",
+    "juniper_relevance": "j",
+    "answer_strategy": "DirectAnswer",
+    "stance_summary": "st",
+}
+
+
+def _step() -> ExecutionStep:
+    return ExecutionStep(
+        verb_name="chat_general",
+        step_name="synthesize_chat_stance_brief",
+        order=1,
+        services=["LLMGatewayService"],
+    )
+
+
+def test_shortcut_returns_result_when_orch_authorized_meaningful_handoff() -> None:
     _exec_prep()
     from app.executor import _attempt_mind_handoff_chat_stance_shortcut
 
     ctx = {
         "metadata": {
             "mind_skip_stance_synthesis": True,
+            "mind_quality": "meaningful_synthesis",
             "mind_handoff": {
-                "stance_payload": {
-                    "conversation_frame": "technical",
-                    "user_intent": "u",
-                    "self_relevance": "s",
-                    "juniper_relevance": "j",
-                    "answer_strategy": "DirectAnswer",
-                    "stance_summary": "st",
-                }
+                "mind_quality": "meaningful_synthesis",
+                "stance_payload": dict(_VALID_STANCE),
             },
         }
     }
     merged: dict = {}
     logs: list[str] = []
 
-    def record(*args, **kwargs):
-        pass
-
-    step = ExecutionStep(
-        verb_name="chat_general",
-        step_name="synthesize_chat_stance_brief",
-        order=1,
-        services=["LLMGatewayService"],
-    )
     out = _attempt_mind_handoff_chat_stance_shortcut(
-        step=step,
+        step=_step(),
         service="LLMGatewayService",
         ctx=ctx,
         merged_result=merged,
@@ -65,12 +70,43 @@ def test_shortcut_returns_result_when_handoff_valid() -> None:
         correlation_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         spark_vector=None,
         t0=0.0,
-        record_scoped_step=record,
+        record_scoped_step=lambda *args, **kwargs: None,
         node_name="test-node",
     )
     assert out is not None
     assert out.status == "success"
     assert merged.get("ChatStanceBrief")
+
+
+def test_shortcut_returns_none_when_orch_did_not_authorize_skip() -> None:
+    _exec_prep()
+    from app.executor import _attempt_mind_handoff_chat_stance_shortcut
+
+    ctx = {
+        "metadata": {
+            "mind_skip_stance_synthesis": False,
+            "mind_quality": "fallback_contract_only",
+            "mind_handoff": {
+                "mind_quality": "fallback_contract_only",
+                "stance_payload": dict(_VALID_STANCE),
+            },
+        }
+    }
+    merged = {}
+    out = _attempt_mind_handoff_chat_stance_shortcut(
+        step=_step(),
+        service="LLMGatewayService",
+        ctx=ctx,
+        merged_result=merged,
+        logs=[],
+        correlation_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        spark_vector=None,
+        t0=0.0,
+        record_scoped_step=lambda *a, **k: None,
+        node_name="n",
+    )
+    assert out is None
+    assert merged == {}
 
 
 def test_shortcut_returns_none_when_payload_invalid() -> None:
@@ -80,18 +116,13 @@ def test_shortcut_returns_none_when_payload_invalid() -> None:
     ctx = {
         "metadata": {
             "mind_skip_stance_synthesis": True,
-            "mind_handoff": {"stance_payload": {"conversation_frame": "not-a-valid-frame"}},
+            "mind_quality": "meaningful_synthesis",
+            "mind_handoff": {"mind_quality": "meaningful_synthesis", "stance_payload": {"conversation_frame": "not-a-valid-frame"}},
         }
     }
     merged = {}
-    step = ExecutionStep(
-        verb_name="chat_general",
-        step_name="synthesize_chat_stance_brief",
-        order=1,
-        services=["LLMGatewayService"],
-    )
     out = _attempt_mind_handoff_chat_stance_shortcut(
-        step=step,
+        step=_step(),
         service="LLMGatewayService",
         ctx=ctx,
         merged_result=merged,

--- a/services/orion-cortex-orch/app/mind_runtime.py
+++ b/services/orion-cortex-orch/app/mind_runtime.py
@@ -27,6 +27,35 @@ def _mind_enabled_exact(metadata: dict[str, Any] | None) -> bool:
     return metadata is not None and metadata.get("mind_enabled") is True
 
 
+def _mind_result_quality(result: MindRunResultV1) -> str:
+    brief_quality = getattr(result.brief, "mind_quality", None)
+    if isinstance(brief_quality, str) and brief_quality:
+        return brief_quality
+    result_quality = getattr(result, "mind_quality", None)
+    if isinstance(result_quality, str) and result_quality:
+        return result_quality
+    summary = (result.brief.summary_one_paragraph or "").strip().lower()
+    if summary in {
+        "deterministic mind run (v1).",
+        "fallback contract only — no meaningful mind synthesis produced.",
+    }:
+        return "fallback_contract_only"
+    if not result.ok:
+        return "error"
+    return "empty"
+
+
+def _mind_result_is_deterministic_contract_only(result: MindRunResultV1) -> bool:
+    quality = _mind_result_quality(result)
+    if quality == "fallback_contract_only":
+        return True
+    patches = list(result.trajectory.patches or [])
+    if patches and all(getattr(p.provenance, "model_id", "") == "deterministic" for p in patches):
+        return True
+    summary = (result.brief.summary_one_paragraph or "").strip()
+    return summary == "Deterministic mind run (v1)."
+
+
 async def fetch_substrate_telemetry_facet_for_mind(correlation_id: str) -> dict[str, Any] | None:
     """GET latest row from telemetry service.
 
@@ -143,16 +172,20 @@ def merge_mind_brief_into_plan_metadata(plan_request: PlanExecutionRequest, resu
     for k, v in (result.brief.machine_contract or {}).items():
         meta[str(k)] = v
     meta["mind_handoff"] = result.brief.model_dump(mode="json")
+    meta["mind_quality"] = _mind_result_quality(result)
     skip_llm_stance = False
     if result.ok:
         meta["mind_run_ok"] = True
-        sp = result.brief.stance_payload if isinstance(result.brief.stance_payload, dict) else {}
-        try:
-            ChatStanceBrief.model_validate(sp)
-            skip_llm_stance = True
-        except Exception:
-            meta["mind_stance_payload_invalid"] = True
-            skip_llm_stance = False
+        if _mind_result_quality(result) == "meaningful_synthesis" and not _mind_result_is_deterministic_contract_only(result):
+            sp = result.brief.stance_payload if isinstance(result.brief.stance_payload, dict) else {}
+            try:
+                ChatStanceBrief.model_validate(sp)
+                skip_llm_stance = True
+            except Exception:
+                meta["mind_stance_payload_invalid"] = True
+                skip_llm_stance = False
+        else:
+            meta["mind_contract_only"] = True
         meta["mind_skip_stance_synthesis"] = skip_llm_stance
     else:
         meta["mind_skip_stance_synthesis"] = False

--- a/services/orion-cortex-orch/tests/test_mind_orch.py
+++ b/services/orion-cortex-orch/tests/test_mind_orch.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 from uuid import uuid4
 
 _guard = Path(__file__).resolve().parent / "_orch_import_guard.py"
@@ -11,8 +10,6 @@ _spec = importlib.util.spec_from_file_location("_orch_guard_boot", _guard)
 assert _spec and _spec.loader
 _guard_mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_guard_mod)
-
-import asyncio
 
 ROOT = Path(__file__).resolve().parents[3]
 APP_ROOT = Path(__file__).resolve().parents[1]
@@ -26,328 +23,128 @@ def _orch_prep() -> None:
     _guard_mod.ensure_orion_cortex_orch_app()
 
 
-from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
-from orion.core.verbs.models import VerbResultV1
-from orion.mind.v1 import MindHandoffBriefV1, MindRunResultV1
-from orion.schemas.cortex.contracts import CortexClientContext, CortexClientRequest, LLMMessage, RecallDirective
+from orion.mind.v1 import MindHandoffBriefV1, MindRunResultV1, MindStancePatchV1, MindStanceTrajectoryV1, MindProvenanceV1
+from orion.schemas.cortex.contracts import CortexClientContext, CortexClientRequest, LLMMessage
+from orion.schemas.cortex.schemas import ExecutionPlan, ExecutionStep, PlanExecutionRequest
 
 
-def test_mind_enabled_calls_http_and_merges_metadata(monkeypatch) -> None:
+_VALID_STANCE = {
+    "conversation_frame": "technical",
+    "user_intent": "u",
+    "self_relevance": "s",
+    "juniper_relevance": "j",
+    "answer_strategy": "a",
+    "stance_summary": "st",
+}
+
+
+def _plan_request() -> PlanExecutionRequest:
+    return PlanExecutionRequest(
+        plan=ExecutionPlan(
+            verb_name="chat_general",
+            steps=[ExecutionStep(verb_name="chat_general", step_name="noop", order=0, services=[])],
+        ),
+        context={"metadata": {}},
+    )
+
+
+def test_meaningful_mind_synthesis_may_skip_stance_synthesis() -> None:
     _orch_prep()
-    import app.orchestrator as orchestrator
-    from app.orchestrator import call_verb_runtime
+    from app.mind_runtime import merge_mind_brief_into_plan_metadata
 
-    async def fake_maybe_fetch_state(*args, **kwargs):
-        return None
-
-    mr = MindRunResultV1(
+    pr = _plan_request()
+    result = MindRunResultV1(
         mind_run_id=uuid4(),
         ok=True,
+        mind_quality="meaningful_synthesis",
         brief=MindHandoffBriefV1(
+            mind_quality="meaningful_synthesis",
             machine_contract={"mind.route_kind": "brain"},
-            stance_payload={
-                "conversation_frame": "technical",
-                "user_intent": "u",
-                "self_relevance": "s",
-                "juniper_relevance": "j",
-                "answer_strategy": "a",
-                "stance_summary": "st",
-            },
-        ),
-    )
-    called: dict = {}
-
-    async def fake_call_mind(req):
-        called["req"] = req
-        return mr
-
-    async def fake_publish(*args, **kwargs):
-        called["publish"] = True
-
-    monkeypatch.setattr(orchestrator, "_maybe_fetch_state", fake_maybe_fetch_state)
-    monkeypatch.setattr(orchestrator, "call_orion_mind_http", fake_call_mind)
-    monkeypatch.setattr(orchestrator, "publish_mind_run_artifact", fake_publish)
-
-    class _PubSub:
-        def __init__(self, channel: str) -> None:
-            self.channel = channel
-
-    class _SubCtx:
-        def __init__(self, channel: str) -> None:
-            self.pubsub = _PubSub(channel)
-
-        async def __aenter__(self):
-            return self.pubsub
-
-        async def __aexit__(self, *a):
-            return False
-
-    class _FakeBus:
-        def __init__(self) -> None:
-            self.published: list = []
-            self.codec = SimpleNamespace(decode=lambda d: SimpleNamespace(ok=True, envelope=d, error=None))
-
-        def subscribe(self, channel: str):
-            return _SubCtx(channel)
-
-        async def publish(self, channel: str, env: BaseEnvelope) -> None:
-            self.published.append((channel, env))
-
-        async def iter_messages(self, pubsub: _PubSub):
-            _ch, env = self.published[0]
-            yield {"data": BaseEnvelope(
-                kind="verb.result",
-                source=ServiceRef(name="cortex-exec", version="0", node="n"),
-                correlation_id=env.correlation_id,
-                payload=VerbResultV1(
-                    verb="legacy.plan",
-                    ok=True,
-                    output={"result": {"status": "success", "steps": [], "final_text": "ok", "metadata": {}}},
-                    request_id=env.payload["request_id"],
-                ).model_dump(mode="json"),
-            )}
-
-    req = CortexClientRequest(
-        mode="brain",
-        route_intent="none",
-        verb="chat_general",
-        packs=[],
-        options={},
-        recall=RecallDirective(enabled=False, required=False, mode="hybrid", profile=None),
-        context=CortexClientContext(
-            messages=[LLMMessage(role="user", content="hi")],
-            raw_user_text="hi",
-            user_message="hi",
-            session_id="s1",
-            user_id="u1",
-            trace_id="t1",
-            metadata={"mind_enabled": True},
+            stance_payload=dict(_VALID_STANCE),
         ),
     )
 
-    bus = _FakeBus()
-    source = ServiceRef(name="cortex-orch", version="0", node="n")
-    captured: dict = {}
-    _orig_build = orchestrator.build_verb_request
-
-    def _capture_build_verb(**kwargs):
-        plan_request = kwargs["plan_request"]
-        captured["metadata"] = dict((plan_request.context or {}).get("metadata") or {})
-        return _orig_build(**kwargs)
-
-    monkeypatch.setattr(orchestrator, "build_verb_request", _capture_build_verb)
-    asyncio.run(
-        call_verb_runtime(
-            bus,
-            source=source,
-            client_request=req,
-            correlation_id="11111111-1111-1111-1111-111111111111",
-            timeout_sec=30.0,
-        )
-    )
-    assert "req" in called
-    assert called.get("publish") is True
-    assert called["req"].policy.n_loops_max >= 1
-    meta = captured.get("metadata") or {}
+    merge_mind_brief_into_plan_metadata(pr, result)
+    meta = pr.context["metadata"]
     assert meta.get("mind_skip_stance_synthesis") is True
-    assert meta.get("mind_run_ok") is True
+    assert meta.get("mind_quality") == "meaningful_synthesis"
     assert meta.get("mind.route_kind") == "brain"
-    assert isinstance(meta.get("mind_handoff"), dict)
 
 
-def test_mind_disabled_skips_http(monkeypatch) -> None:
+def test_fallback_contract_only_mind_never_skips_stance_synthesis() -> None:
     _orch_prep()
-    import app.orchestrator as orchestrator
-    from app.orchestrator import call_verb_runtime
+    from app.mind_runtime import merge_mind_brief_into_plan_metadata
 
-    async def fake_maybe_fetch_state(*args, **kwargs):
-        return None
-
-    called: dict = {}
-
-    async def fake_call_mind(req):
-        called["mind"] = True
-        raise AssertionError("mind HTTP should not be called")
-
-    monkeypatch.setattr(orchestrator, "_maybe_fetch_state", fake_maybe_fetch_state)
-    monkeypatch.setattr(orchestrator, "call_orion_mind_http", fake_call_mind)
-
-    class _PubSub:
-        def __init__(self, channel: str) -> None:
-            self.channel = channel
-
-    class _SubCtx:
-        def __init__(self, channel: str) -> None:
-            self.pubsub = _PubSub(channel)
-
-        async def __aenter__(self):
-            return self.pubsub
-
-        async def __aexit__(self, *a):
-            return False
-
-    class _FakeBus:
-        def __init__(self) -> None:
-            self.published: list = []
-            self.codec = SimpleNamespace(decode=lambda d: SimpleNamespace(ok=True, envelope=d, error=None))
-
-        def subscribe(self, channel: str):
-            return _SubCtx(channel)
-
-        async def publish(self, channel: str, env: BaseEnvelope) -> None:
-            self.published.append((channel, env))
-
-        async def iter_messages(self, pubsub: _PubSub):
-            _ch, env = self.published[0]
-            yield {"data": BaseEnvelope(
-                kind="verb.result",
-                source=ServiceRef(name="cortex-exec", version="0", node="n"),
-                correlation_id=env.correlation_id,
-                payload=VerbResultV1(
-                    verb="legacy.plan",
-                    ok=True,
-                    output={"result": {"status": "success", "steps": [], "final_text": "ok", "metadata": {}}},
-                    request_id=env.payload["request_id"],
-                ).model_dump(mode="json"),
-            )}
-
-    req = CortexClientRequest(
-        mode="brain",
-        route_intent="none",
-        verb="chat_general",
-        packs=[],
-        options={},
-        recall=RecallDirective(enabled=False, required=False, mode="hybrid", profile=None),
-        context=CortexClientContext(
-            messages=[LLMMessage(role="user", content="hi")],
-            raw_user_text="hi",
-            user_message="hi",
-            session_id="s1",
-            user_id="u1",
-            trace_id="t1",
-            metadata={"mind_enabled": False},
+    pr = _plan_request()
+    result = MindRunResultV1(
+        mind_run_id=uuid4(),
+        ok=True,
+        mind_quality="fallback_contract_only",
+        trajectory=MindStanceTrajectoryV1(
+            patches=[
+                MindStancePatchV1(
+                    loop_index=0,
+                    structured=dict(_VALID_STANCE),
+                    provenance=MindProvenanceV1(model_id="deterministic"),
+                )
+            ],
+            merged_stance_brief=dict(_VALID_STANCE),
+        ),
+        brief=MindHandoffBriefV1(
+            mind_quality="fallback_contract_only",
+            summary_one_paragraph="Fallback contract only — no meaningful Mind synthesis produced.",
+            machine_contract={"mind.route_kind": "brain"},
+            stance_payload=dict(_VALID_STANCE),
         ),
     )
 
-    bus = _FakeBus()
-    source = ServiceRef(name="cortex-orch", version="0", node="n")
-    asyncio.run(
-        call_verb_runtime(
-            bus,
-            source=source,
-            client_request=req,
-            correlation_id="22222222-2222-2222-2222-222222222222",
-            timeout_sec=30.0,
-        )
-    )
-    assert "mind" not in called
+    merge_mind_brief_into_plan_metadata(pr, result)
+    meta = pr.context["metadata"]
+    assert meta.get("mind_skip_stance_synthesis") is False
+    assert meta.get("mind_contract_only") is True
+    assert meta.get("mind_quality") == "fallback_contract_only"
 
 
-def test_merge_skips_stance_when_payload_invalid(monkeypatch) -> None:
+def test_legacy_deterministic_summary_is_treated_as_contract_only() -> None:
     _orch_prep()
-    import app.orchestrator as orchestrator
-    from app.orchestrator import call_verb_runtime
+    from app.mind_runtime import merge_mind_brief_into_plan_metadata
 
-    mr = MindRunResultV1(
+    pr = _plan_request()
+    result = MindRunResultV1(
         mind_run_id=uuid4(),
         ok=True,
         brief=MindHandoffBriefV1(
+            summary_one_paragraph="Deterministic mind run (v1).",
+            machine_contract={"mind.route_kind": "brain"},
+            stance_payload=dict(_VALID_STANCE),
+        ),
+    )
+
+    merge_mind_brief_into_plan_metadata(pr, result)
+    meta = pr.context["metadata"]
+    assert meta.get("mind_skip_stance_synthesis") is False
+    assert meta.get("mind_contract_only") is True
+    assert meta.get("mind_quality") == "fallback_contract_only"
+
+
+def test_meaningful_mind_with_invalid_payload_does_not_skip_stance_synthesis() -> None:
+    _orch_prep()
+    from app.mind_runtime import merge_mind_brief_into_plan_metadata
+
+    pr = _plan_request()
+    result = MindRunResultV1(
+        mind_run_id=uuid4(),
+        ok=True,
+        mind_quality="meaningful_synthesis",
+        brief=MindHandoffBriefV1(
+            mind_quality="meaningful_synthesis",
             machine_contract={"mind.route_kind": "brain"},
             stance_payload={"conversation_frame": "___invalid___"},
         ),
     )
 
-    async def fake_maybe_fetch_state(*args, **kwargs):
-        return None
-
-    async def fake_call_mind(req):
-        return mr
-
-    async def fake_publish(*args, **kwargs):
-        pass
-
-    monkeypatch.setattr(orchestrator, "_maybe_fetch_state", fake_maybe_fetch_state)
-    monkeypatch.setattr(orchestrator, "call_orion_mind_http", fake_call_mind)
-    monkeypatch.setattr(orchestrator, "publish_mind_run_artifact", fake_publish)
-
-    class _PubSub:
-        def __init__(self, channel: str) -> None:
-            self.channel = channel
-
-    class _SubCtx:
-        def __init__(self, channel: str) -> None:
-            self.pubsub = _PubSub(channel)
-
-        async def __aenter__(self):
-            return self.pubsub
-
-        async def __aexit__(self, *a):
-            return False
-
-    class _FakeBus:
-        def __init__(self) -> None:
-            self.published: list = []
-            self.codec = SimpleNamespace(decode=lambda d: SimpleNamespace(ok=True, envelope=d, error=None))
-
-        def subscribe(self, channel: str):
-            return _SubCtx(channel)
-
-        async def publish(self, channel: str, env: BaseEnvelope) -> None:
-            self.published.append((channel, env))
-
-        async def iter_messages(self, pubsub: _PubSub):
-            _ch, env = self.published[0]
-            yield {"data": BaseEnvelope(
-                kind="verb.result",
-                source=ServiceRef(name="cortex-exec", version="0", node="n"),
-                correlation_id=env.correlation_id,
-                payload=VerbResultV1(
-                    verb="legacy.plan",
-                    ok=True,
-                    output={"result": {"status": "success", "steps": [], "final_text": "ok", "metadata": {}}},
-                    request_id=env.payload["request_id"],
-                ).model_dump(mode="json"),
-            )}
-
-    req = CortexClientRequest(
-        mode="brain",
-        route_intent="none",
-        verb="chat_general",
-        packs=[],
-        options={},
-        recall=RecallDirective(enabled=False, required=False, mode="hybrid", profile=None),
-        context=CortexClientContext(
-            messages=[LLMMessage(role="user", content="hi")],
-            raw_user_text="hi",
-            user_message="hi",
-            session_id="s1",
-            user_id="u1",
-            trace_id="t1",
-            metadata={"mind_enabled": True},
-        ),
-    )
-
-    bus = _FakeBus()
-    source = ServiceRef(name="cortex-orch", version="0", node="n")
-    captured: dict = {}
-    _orig_build = orchestrator.build_verb_request
-
-    def _capture_build_verb(**kwargs):
-        plan_request = kwargs["plan_request"]
-        captured["metadata"] = dict((plan_request.context or {}).get("metadata") or {})
-        return _orig_build(**kwargs)
-
-    monkeypatch.setattr(orchestrator, "build_verb_request", _capture_build_verb)
-    asyncio.run(
-        call_verb_runtime(
-            bus,
-            source=source,
-            client_request=req,
-            correlation_id="33333333-3333-3333-3333-333333333333",
-            timeout_sec=30.0,
-        )
-    )
-    meta = captured.get("metadata") or {}
+    merge_mind_brief_into_plan_metadata(pr, result)
+    meta = pr.context["metadata"]
     assert meta.get("mind_stance_payload_invalid") is True
     assert meta.get("mind_skip_stance_synthesis") is False
 
@@ -355,12 +152,9 @@ def test_merge_skips_stance_when_payload_invalid(monkeypatch) -> None:
 def test_build_mind_run_request_merges_substrate_telemetry_facet() -> None:
     _orch_prep()
     from app.mind_runtime import build_mind_run_request
-    from orion.schemas.cortex.contracts import CortexClientRequest, CortexClientContext
-    from orion.schemas.cortex.schemas import ExecutionPlan, PlanExecutionRequest
-    from orion.schemas.cortex.types import ExecutionStep
 
     cr = CortexClientRequest(
-        verb="chat",
+        verb="chat_general",
         mode="brain",
         context=CortexClientContext(
             messages=[LLMMessage(role="user", content="hi")],
@@ -370,18 +164,7 @@ def test_build_mind_run_request_merges_substrate_telemetry_facet() -> None:
             metadata={"mind_enabled": True},
         ),
     )
-    plan = ExecutionPlan(
-        verb_name="chat",
-        steps=[
-            ExecutionStep(
-                verb_name="chat",
-                step_name="noop",
-                order=0,
-                services=[],
-            )
-        ],
-    )
-    pr = PlanExecutionRequest(plan=plan, context={})
+    pr = _plan_request()
     req = build_mind_run_request(
         cr,
         pr,
@@ -390,120 +173,3 @@ def test_build_mind_run_request_merges_substrate_telemetry_facet() -> None:
     )
     facets = (req.snapshot_inputs or {}).get("facets") or {}
     assert facets.get("substrate_telemetry") == {"status": "absent"}
-
-
-def test_orch_inline_substrate_telemetry_facet_skips_http_fetch(monkeypatch) -> None:
-    _orch_prep()
-    import app.orchestrator as orchestrator
-    from app.orchestrator import call_verb_runtime
-
-    async def fake_maybe_fetch_state(*args, **kwargs):
-        return None
-
-    mr = MindRunResultV1(
-        mind_run_id=uuid4(),
-        ok=True,
-        brief=MindHandoffBriefV1(
-            machine_contract={"mind.route_kind": "brain"},
-            stance_payload={
-                "conversation_frame": "technical",
-                "user_intent": "u",
-                "self_relevance": "s",
-                "juniper_relevance": "j",
-                "answer_strategy": "a",
-                "stance_summary": "st",
-            },
-        ),
-    )
-    called: dict = {}
-    fetch_calls: list[str] = []
-
-    async def fake_call_mind(req):
-        called["req"] = req
-        return mr
-
-    async def fake_publish(*args, **kwargs):
-        called["publish"] = True
-
-    async def fake_fetch_substrate_telemetry(_cid: str):
-        fetch_calls.append(_cid)
-        raise AssertionError("fetch_substrate_telemetry_facet_for_mind must not run when inline facet is set")
-
-    monkeypatch.setattr(orchestrator, "_maybe_fetch_state", fake_maybe_fetch_state)
-    monkeypatch.setattr(orchestrator, "call_orion_mind_http", fake_call_mind)
-    monkeypatch.setattr(orchestrator, "publish_mind_run_artifact", fake_publish)
-    monkeypatch.setattr(orchestrator, "fetch_substrate_telemetry_facet_for_mind", fake_fetch_substrate_telemetry)
-
-    class _PubSub:
-        def __init__(self, channel: str) -> None:
-            self.channel = channel
-
-    class _SubCtx:
-        def __init__(self, channel: str) -> None:
-            self.pubsub = _PubSub(channel)
-
-        async def __aenter__(self):
-            return self.pubsub
-
-        async def __aexit__(self, *a):
-            return False
-
-    class _FakeBus:
-        def __init__(self) -> None:
-            self.published: list = []
-            self.codec = SimpleNamespace(decode=lambda d: SimpleNamespace(ok=True, envelope=d, error=None))
-
-        def subscribe(self, channel: str):
-            return _SubCtx(channel)
-
-        async def publish(self, channel: str, env: BaseEnvelope) -> None:
-            self.published.append((channel, env))
-
-        async def iter_messages(self, pubsub: _PubSub):
-            _ch, env = self.published[0]
-            yield {"data": BaseEnvelope(
-                kind="verb.result",
-                source=ServiceRef(name="cortex-exec", version="0", node="n"),
-                correlation_id=env.correlation_id,
-                payload=VerbResultV1(
-                    verb="legacy.plan",
-                    ok=True,
-                    output={"result": {"status": "success", "steps": [], "final_text": "ok", "metadata": {}}},
-                    request_id=env.payload["request_id"],
-                ).model_dump(mode="json"),
-            )}
-
-    inline_facet = {"status": "inline", "tier_outcomes": {"x": ["y"]}}
-    req = CortexClientRequest(
-        mode="brain",
-        route_intent="none",
-        verb="chat_general",
-        packs=[],
-        options={},
-        recall=RecallDirective(enabled=False, required=False, mode="hybrid", profile=None),
-        context=CortexClientContext(
-            messages=[LLMMessage(role="user", content="hi")],
-            raw_user_text="hi",
-            user_message="hi",
-            session_id="s1",
-            user_id="u1",
-            trace_id="t1",
-            metadata={"mind_enabled": True, "substrate_telemetry_facet": inline_facet},
-        ),
-    )
-
-    bus = _FakeBus()
-    source = ServiceRef(name="cortex-orch", version="0", node="n")
-    asyncio.run(
-        call_verb_runtime(
-            bus,
-            source=source,
-            client_request=req,
-            correlation_id="22222222-2222-2222-2222-222222222222",
-            timeout_sec=30.0,
-        )
-    )
-    assert fetch_calls == []
-    assert "req" in called
-    facets = (called["req"].snapshot_inputs or {}).get("facets") or {}
-    assert facets.get("substrate_telemetry") == inline_facet

--- a/services/orion-mind/app/engine.py
+++ b/services/orion-mind/app/engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -34,6 +35,60 @@ _FACET_ORDER = (
     "metacog",
     "tool_outcomes",
     "misc",
+)
+
+_TECHNICAL_PATTERNS = (
+    r"\bapi\b",
+    r"\bbug\b",
+    r"\bcode\b",
+    r"\bcursor\b",
+    r"\bdebug\b",
+    r"\bdeploy\b",
+    r"\bdocker\b",
+    r"\berror\b",
+    r"\bgraphdb\b",
+    r"\blog(s)?\b",
+    r"\bpython\b",
+    r"\bschema\b",
+    r"\bservice\b",
+    r"\bsql\b",
+    r"\bstack\b",
+    r"\btimeout\b",
+)
+_PLANNING_PATTERNS = (
+    r"\bbuild\b",
+    r"\bdesign\b",
+    r"\bimplement\b",
+    r"\bnext step\b",
+    r"\bplan\b",
+    r"\bprompt\b",
+    r"\broadmap\b",
+)
+_REFLECTIVE_PATTERNS = (
+    r"\bautonomy\b",
+    r"\bcognition\b",
+    r"\bdream\b",
+    r"\bfeel\b",
+    r"\bidentity\b",
+    r"\bmeaning\b",
+    r"\bmind\b",
+    r"\borion\b",
+    r"\brelationship\b",
+)
+_RELATIONAL_PATTERNS = (
+    r"\bamanda\b",
+    r"\bbike(s)?\b",
+    r"\bfamily\b",
+    r"\bfriend\b",
+    r"\bgoing to\b",
+    r"\bhusband\b",
+    r"\bkid(s)?\b",
+    r"\blol\b",
+    r"\bshow\b",
+    r"\bthanks\b",
+    r"\bwatch\b",
+    r"\bwife\b",
+    r"[:;]-?\)",
 )
 
 
@@ -83,22 +138,71 @@ def deterministic_merge_stance(patch_structured_layers: list[dict[str, Any]]) ->
     return merged
 
 
+def _matches_any(text: str, patterns: tuple[str, ...]) -> bool:
+    return any(re.search(pattern, text) for pattern in patterns)
+
+
+def _deterministic_frame_from_user_text(user_text: str) -> tuple[str, str]:
+    """Tiny safe fallback classifier for contract-only Mind runs.
+
+    This is not meaningful synthesis. It exists only to avoid actively wrong
+    boilerplate such as marking every casual turn as technical.
+    """
+    lowered = (user_text or "").strip().lower()
+    if not lowered:
+        return "mixed", "direct_response"
+    if _matches_any(lowered, _TECHNICAL_PATTERNS):
+        return "technical", "technical_collaboration"
+    if _matches_any(lowered, _PLANNING_PATTERNS):
+        return "planning", "direct_response"
+    if _matches_any(lowered, _REFLECTIVE_PATTERNS):
+        return "reflective", "reflective_dialogue"
+    if _matches_any(lowered, _RELATIONAL_PATTERNS):
+        return "playful_relational", "playful_exchange"
+    return "mixed", "direct_response"
+
+
 def _default_stance_from_user_text(user_text: str) -> dict[str, Any]:
     ut = (user_text or "").strip()[:2000]
+    conversation_frame, task_mode = _deterministic_frame_from_user_text(ut)
     return {
-        "conversation_frame": "technical",
-        "task_mode": "direct_response",
+        "conversation_frame": conversation_frame,
+        "task_mode": task_mode,
         "identity_salience": "medium",
         "user_intent": ut or "(empty turn)",
-        "self_relevance": "Maintain coherence with Orion continuity.",
-        "juniper_relevance": "Collaborate with Juniper on the active thread.",
+        "self_relevance": "contract_only: no meaningful Mind synthesis produced.",
+        "juniper_relevance": "contract_only: preserve latest user turn without adding invented context.",
         "answer_strategy": "DirectAnswer",
-        "stance_summary": f"Deterministic stance seed ({len(ut)} chars).",
+        "stance_summary": f"Deterministic contract-only stance seed ({len(ut)} chars).",
     }
 
 
 def _elapsed_ms_wall_clock(t_run_start: float) -> float:
     return (time.perf_counter() - t_run_start) * 1000
+
+
+def _error_result(
+    *,
+    mind_run_id,
+    error_code: str,
+    diagnostics: list[str],
+    snapshot_hash: str,
+    trajectory: MindStanceTrajectoryV1 | None = None,
+    brief: MindHandoffBriefV1 | None = None,
+    timing_ms_by_phase: dict[str, float] | None = None,
+) -> MindRunResultV1:
+    return MindRunResultV1(
+        mind_run_id=mind_run_id,
+        ok=False,
+        error_code=error_code,
+        diagnostics=diagnostics,
+        snapshot_hash=snapshot_hash,
+        trajectory=trajectory or MindStanceTrajectoryV1(patches=[], merged_stance_brief={}, merge_policy="deterministic_merge"),
+        decision=MindControlDecisionV1(route_kind="no_chat", refusals=[{"code": error_code}]),
+        brief=brief or MindHandoffBriefV1(mind_quality="error"),
+        mind_quality="error",
+        timing_ms_by_phase=timing_ms_by_phase or {},
+    )
 
 
 def run_mind_deterministic(
@@ -125,15 +229,11 @@ def run_mind_deterministic(
 
     if _elapsed_ms_wall_clock(t_run_start) > wall_budget_ms:
         logger.info("mind_run_end mind_run_id=%s ok=False error=loop_budget_exceeded phase=snapshot", mind_run_id)
-        return MindRunResultV1(
+        return _error_result(
             mind_run_id=mind_run_id,
-            ok=False,
             error_code="loop_budget_exceeded",
             diagnostics=["wall_time_exceeded_after_snapshot"],
             snapshot_hash=snap_hash,
-            trajectory=MindStanceTrajectoryV1(patches=[], merged_stance_brief={}, merge_policy="deterministic_merge"),
-            decision=MindControlDecisionV1(route_kind="no_chat", refusals=[{"code": "loop_budget_exceeded"}]),
-            brief=MindHandoffBriefV1(),
             timing_ms_by_phase=phases,
         )
 
@@ -158,15 +258,12 @@ def run_mind_deterministic(
                 mind_run_id,
                 i,
             )
-            return MindRunResultV1(
+            return _error_result(
                 mind_run_id=mind_run_id,
-                ok=False,
                 error_code="loop_budget_exceeded",
                 diagnostics=[f"wall_time_exceeded_during_loop_at_index_{i}"],
                 snapshot_hash=snap_hash,
                 trajectory=MindStanceTrajectoryV1(patches=patches, merged_stance_brief={}, merge_policy="deterministic_merge"),
-                decision=MindControlDecisionV1(route_kind="no_chat", refusals=[{"code": "loop_budget_exceeded"}]),
-                brief=MindHandoffBriefV1(),
                 timing_ms_by_phase={**phases, "loops_partial_ms": (time.perf_counter() - t_loop) * 1000},
             )
         # llm_flags[i] True means LLM would run — v1 is deterministic only; no extra merge keys (avoid polluting ChatStanceBrief).
@@ -193,9 +290,8 @@ def run_mind_deterministic(
     if _elapsed_ms_wall_clock(t_run_start) > wall_budget_ms:
         logger.info("mind_run_end mind_run_id=%s ok=False error=loop_budget_exceeded phase=post_loops", mind_run_id)
         merged_partial = deterministic_merge_stance(layers)
-        return MindRunResultV1(
+        return _error_result(
             mind_run_id=mind_run_id,
-            ok=False,
             error_code="loop_budget_exceeded",
             diagnostics=["wall_time_exceeded_after_loops_before_merge"],
             snapshot_hash=snap_hash,
@@ -204,8 +300,6 @@ def run_mind_deterministic(
                 merged_stance_brief=merged_partial,
                 merge_policy="deterministic_merge",
             ),
-            decision=MindControlDecisionV1(route_kind="no_chat", refusals=[{"code": "loop_budget_exceeded"}]),
-            brief=MindHandoffBriefV1(),
             timing_ms_by_phase=phases,
         )
 
@@ -216,15 +310,13 @@ def run_mind_deterministic(
 
     if valid is None:
         logger.info("mind_run_end mind_run_id=%s ok=False error=stance_merge_invalid", mind_run_id)
-        return MindRunResultV1(
+        return _error_result(
             mind_run_id=mind_run_id,
-            ok=False,
             error_code="stance_merge_invalid",
             diagnostics=[err or "stance_merge_invalid", f"merged_keys={list(merged.keys())}"],
             snapshot_hash=snap_hash,
             trajectory=MindStanceTrajectoryV1(patches=patches, merged_stance_brief=merged, merge_policy="deterministic_merge"),
-            decision=MindControlDecisionV1(route_kind="no_chat", refusals=[{"code": "stance_merge_invalid", "detail": str(err)}]),
-            brief=MindHandoffBriefV1(),
+            brief=MindHandoffBriefV1(mind_quality="error"),
             timing_ms_by_phase=phases,
         )
 
@@ -248,17 +340,19 @@ def run_mind_deterministic(
         "mind.allowed_verbs": decision.allowed_verbs,
         "mind.mode_suggestion": decision.mode_suggestion,
         "mind.mode_binding": decision.mode_binding,
+        "mind.quality": "fallback_contract_only",
     }
     brief = MindHandoffBriefV1(
-        summary_one_paragraph="Deterministic mind run (v1).",
+        summary_one_paragraph="Fallback contract only — no meaningful Mind synthesis produced.",
         machine_contract=machine,
         mandatory_keys=["mind.route_kind", "mind.allowed_verbs"],
-        advisory_keys=["mind.mode_suggestion"],
+        advisory_keys=["mind.mode_suggestion", "mind.quality"],
         stance_payload=valid.model_dump(mode="json"),
+        mind_quality="fallback_contract_only",
     )
 
     phases["total_ms"] = _elapsed_ms_wall_clock(t_run_start)
-    logger.info("mind_run_end mind_run_id=%s ok=True snapshot_hash=%s", mind_run_id, snap_hash)
+    logger.info("mind_run_end mind_run_id=%s ok=True snapshot_hash=%s quality=fallback_contract_only", mind_run_id, snap_hash)
 
     return MindRunResultV1(
         mind_run_id=mind_run_id,
@@ -271,5 +365,6 @@ def run_mind_deterministic(
         ),
         decision=decision,
         brief=brief,
+        mind_quality="fallback_contract_only",
         timing_ms_by_phase=phases,
     )


### PR DESCRIPTION
## Summary

This is the arsonist safety cut for Mind:

- adds explicit `MindQualityV1` to Mind run and handoff contracts
- marks deterministic `orion-mind` runs as `fallback_contract_only`
- changes deterministic Mind summary to honest contract-only language
- adds a tiny deterministic frame fallback so casual turns are not blindly stamped `technical`
- gates Orch `mind_skip_stance_synthesis` so only `mind_quality == meaningful_synthesis` can skip the real chat stance synthesis path
- preserves deterministic Mind artifacts/metadata but prevents them from replacing rich stance synthesis
- tightens Exec shortcut tests and Orch merge tests around the new authority boundary

## Why

Current Mind is deterministic-only, but its schema-valid `ChatStanceBrief` can cause Exec to skip `chat_stance_brief.j2`. That lets contract-shaped filler suppress the richer CognitiveUnification/chat stance path. This PR removes that authority until Mind actually owns meaningful substrate synthesis.

## Notes

This does **not** complete the full Mind/substrate unification. It is the prerequisite safety gate: deterministic Mind may observe and report, but it cannot wear the crown.

## Follow-up

Next PR should extract the current chat stance substrate projection into a shared `CognitiveProjectionV1` builder that Mind can consume in shadow mode.