### PR TITLE
Add Mind cognitive projection shadow seam

### DIFF
--- a/orion/cognition/projection.py
+++ b/orion/cognition/projection.py
@@ -1,0 +1,205 @@
+"""Compact cognitive projection artifacts for Mind shadow wiring.
+
+This module deliberately sits *above* the CognitiveUnificationLayer read model:
+``UnifiedRelationalBeliefSetV1`` remains the substrate/unification output, while
+``CognitiveProjectionV1`` is the bounded, LLM/Mind-friendly active frontier.
+
+Do not put service clients or chat prompt logic here. This file is a pure adapter
+from substrate beliefs to a portable projection contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1
+from orion.substrate.relational.beliefs import AnchorBeliefSliceV1, UnifiedRelationalBeliefSetV1
+
+ProjectionBucketV1 = Literal["concept", "tension", "goal", "drive", "snapshot", "event"]
+
+
+class CognitiveProjectionItemV1(BaseModel):
+    """One compact, source-linked item in the active cognitive frontier."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    item_id: str = Field(default_factory=lambda: f"cog-proj-item-{uuid4()}")
+    anchor: str
+    bucket: ProjectionBucketV1
+    node_id: str
+    node_kind: str
+    label: str = ""
+    summary: str = ""
+    salience: float = Field(default=0.0, ge=0.0, le=1.0)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    producer: str | None = None
+    authority: str | None = None
+    tier_rank: int | None = None
+    evidence_refs: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class CognitiveProjectionAnchorV1(BaseModel):
+    """Bounded projection for one anchor scope."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    anchor: str
+    degraded: bool = False
+    tier_outcomes: list[str] = Field(default_factory=list)
+    items: list[CognitiveProjectionItemV1] = Field(default_factory=list)
+
+
+class CognitiveProjectionV1(BaseModel):
+    """Portable pre-LLM cognitive projection for Mind shadow consumption."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["cognitive.projection.v1"] = "cognitive.projection.v1"
+    projection_id: str = Field(default_factory=lambda: f"cog-proj-{uuid4()}")
+    generated_at: str
+    source: Literal["cognitive_unification_layer"] = "cognitive_unification_layer"
+    anchors: dict[str, CognitiveProjectionAnchorV1] = Field(default_factory=dict)
+    cold_anchors: list[str] = Field(default_factory=list)
+    degraded_producers: list[str] = Field(default_factory=list)
+    lineage: list[str] = Field(default_factory=list)
+    item_count: int = 0
+    notes: list[str] = Field(default_factory=list)
+
+
+def _compact(value: Any, *, limit: int = 180) -> str:
+    text = " ".join(str(value or "").split()).strip()
+    return text[:limit]
+
+
+def _node_label(node: BaseSubstrateNodeV1) -> str:
+    for attr in ("label", "summary", "goal_text", "hypothesis_text", "target_state", "drive_kind", "tension_kind", "event_type", "snapshot_source"):
+        value = getattr(node, attr, None)
+        if value:
+            return _compact(value, limit=120)
+    subject_ref = getattr(node, "subject_ref", None)
+    if subject_ref:
+        return _compact(subject_ref, limit=120)
+    return _compact(node.node_id, limit=120)
+
+
+def _node_summary(node: BaseSubstrateNodeV1) -> str:
+    if hasattr(node, "definition") and getattr(node, "definition"):
+        return _compact(getattr(node, "definition"), limit=240)
+    if hasattr(node, "target_state") and getattr(node, "target_state"):
+        return _compact(getattr(node, "target_state"), limit=240)
+    if hasattr(node, "dimensions") and getattr(node, "dimensions"):
+        return _compact(getattr(node, "dimensions"), limit=240)
+    meta = getattr(node, "metadata", {}) or {}
+    for key in ("summary", "description", "excerpt", "text"):
+        if isinstance(meta, dict) and meta.get(key):
+            return _compact(meta.get(key), limit=240)
+    return _node_label(node)
+
+
+def _item_from_node(anchor: str, bucket: ProjectionBucketV1, node: BaseSubstrateNodeV1) -> CognitiveProjectionItemV1:
+    provenance = node.provenance
+    signals = node.signals
+    return CognitiveProjectionItemV1(
+        anchor=anchor,
+        bucket=bucket,
+        node_id=node.node_id,
+        node_kind=str(node.node_kind),
+        label=_node_label(node),
+        summary=_node_summary(node),
+        salience=float(signals.salience or 0.0),
+        confidence=float(signals.confidence or 0.0),
+        producer=provenance.producer,
+        authority=provenance.authority,
+        tier_rank=provenance.tier_rank,
+        evidence_refs=list(provenance.evidence_refs or [])[:8],
+        metadata={
+            "promotion_state": node.promotion_state,
+            "risk_tier": node.risk_tier,
+            "observed_at": node.temporal.observed_at.isoformat(),
+        },
+    )
+
+
+def _rank_items(items: list[CognitiveProjectionItemV1]) -> list[CognitiveProjectionItemV1]:
+    return sorted(
+        items,
+        key=lambda item: (
+            float(item.salience or 0.0),
+            float(item.confidence or 0.0),
+            -float(item.tier_rank or 99),
+            item.label,
+        ),
+        reverse=True,
+    )
+
+
+def _items_for_anchor(anchor_slice: AnchorBeliefSliceV1, *, max_items_per_bucket: int) -> list[CognitiveProjectionItemV1]:
+    bucket_nodes: list[tuple[ProjectionBucketV1, list[BaseSubstrateNodeV1]]] = [
+        ("concept", list(anchor_slice.concepts or [])),
+        ("tension", list(anchor_slice.tensions or [])),
+        ("goal", list(anchor_slice.goals or [])),
+        ("drive", list(anchor_slice.drives or [])),
+        ("snapshot", list(anchor_slice.snapshots or [])),
+        ("event", list(anchor_slice.events or [])),
+    ]
+    out: list[CognitiveProjectionItemV1] = []
+    for bucket, nodes in bucket_nodes:
+        ranked = _rank_items([_item_from_node(anchor_slice.anchor, bucket, node) for node in nodes])
+        out.extend(ranked[:max_items_per_bucket])
+    return _rank_items(out)
+
+
+def project_unified_beliefs_for_mind(
+    beliefs: UnifiedRelationalBeliefSetV1 | None,
+    *,
+    max_items_per_bucket: int = 6,
+    max_total_items: int = 48,
+) -> CognitiveProjectionV1 | None:
+    """Compress unified beliefs into a bounded Mind/LLM-facing projection.
+
+    Returns ``None`` only when there is no belief set at all. Empty/skipped belief
+    sets still produce a projection with lineage/degradation information so Mind
+    and Hub can distinguish "no signal" from "not run".
+    """
+    if beliefs is None:
+        return None
+
+    anchors: dict[str, CognitiveProjectionAnchorV1] = {}
+    total_items = 0
+    for anchor_name, anchor_slice in (beliefs.anchors or {}).items():
+        items = _items_for_anchor(anchor_slice, max_items_per_bucket=max(1, int(max_items_per_bucket)))
+        remaining = max(0, int(max_total_items) - total_items)
+        items = items[:remaining]
+        total_items += len(items)
+        anchors[anchor_name] = CognitiveProjectionAnchorV1(
+            anchor=anchor_name,
+            degraded=bool(anchor_slice.degraded),
+            tier_outcomes=list(anchor_slice.tier_outcomes or [])[:12],
+            items=items,
+        )
+        if total_items >= int(max_total_items):
+            break
+
+    notes: list[str] = []
+    if not anchors:
+        notes.append("no_anchors")
+    if total_items == 0:
+        notes.append("no_active_projection_items")
+    if beliefs.cold_anchors:
+        notes.append("cold_path_materialized")
+    if beliefs.degraded_producers:
+        notes.append("degraded_producers_present")
+
+    return CognitiveProjectionV1(
+        generated_at=beliefs.generated_at,
+        anchors=anchors,
+        cold_anchors=list(beliefs.cold_anchors or []),
+        degraded_producers=list(beliefs.degraded_producers or []),
+        lineage=list(beliefs.lineage or []),
+        item_count=total_items,
+        notes=notes,
+    )

--- a/orion/cognition/tests/test_projection.py
+++ b/orion/cognition/tests/test_projection.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.cognition.projection import project_unified_beliefs_for_mind
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.substrate.relational.beliefs import AnchorBeliefSliceV1, UnifiedRelationalBeliefSetV1
+
+
+def _concept(label: str, salience: float, confidence: float) -> ConceptNodeV1:
+    return ConceptNodeV1(
+        node_kind="concept",
+        anchor_scope="orion",
+        label=label,
+        definition=f"Definition for {label}",
+        temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
+        signals=SubstrateSignalBundleV1(salience=salience, confidence=confidence),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="test",
+            source_channel="unit",
+            producer="test_projection",
+            tier_rank=3,
+            evidence_refs=["ev1"],
+        ),
+    )
+
+
+def test_project_unified_beliefs_for_mind_compacts_items_and_lineage() -> None:
+    beliefs = UnifiedRelationalBeliefSetV1(
+        anchors={
+            "orion": AnchorBeliefSliceV1(
+                anchor="orion",
+                concepts=[
+                    _concept("low", salience=0.1, confidence=0.9),
+                    _concept("high", salience=0.9, confidence=0.8),
+                ],
+                tier_outcomes=["concept_induced_accepted:2"],
+            )
+        },
+        cold_anchors=["orion"],
+        degraded_producers=["producer_x"],
+        lineage=["test_projection:concept_induced"],
+    )
+
+    projection = project_unified_beliefs_for_mind(beliefs, max_items_per_bucket=2, max_total_items=4)
+
+    assert projection is not None
+    assert projection.schema_version == "cognitive.projection.v1"
+    assert projection.source == "cognitive_unification_layer"
+    assert projection.item_count == 2
+    assert projection.cold_anchors == ["orion"]
+    assert projection.degraded_producers == ["producer_x"]
+    assert "cold_path_materialized" in projection.notes
+    assert "degraded_producers_present" in projection.notes
+    assert projection.anchors["orion"].tier_outcomes == ["concept_induced_accepted:2"]
+    assert projection.anchors["orion"].items[0].label == "high"
+    assert projection.anchors["orion"].items[0].producer == "test_projection"
+    assert projection.anchors["orion"].items[0].evidence_refs == ["ev1"]
+
+
+def test_project_unified_beliefs_for_mind_empty_beliefs_is_still_signal() -> None:
+    beliefs = UnifiedRelationalBeliefSetV1(
+        anchors={},
+        lineage=["skipped:introspect_spark_or_unified_beliefs_disabled"],
+    )
+
+    projection = project_unified_beliefs_for_mind(beliefs)
+
+    assert projection is not None
+    assert projection.item_count == 0
+    assert "no_anchors" in projection.notes
+    assert "no_active_projection_items" in projection.notes
+    assert projection.lineage == ["skipped:introspect_spark_or_unified_beliefs_disabled"]

--- a/services/orion-cortex-orch/app/mind_runtime.py
+++ b/services/orion-cortex-orch/app/mind_runtime.py
@@ -115,12 +115,28 @@ async def fetch_substrate_telemetry_facet_for_mind(correlation_id: str) -> dict[
     }
 
 
+def _inline_cognitive_projection_facet(metadata: dict[str, Any]) -> dict[str, Any] | None:
+    """Return caller-supplied cognitive projection for Mind shadow mode.
+
+    This is intentionally inline-only for now. Same-turn Orch cannot see the Exec
+    chat-stance projection until after execution; later phases can add a persisted
+    projection read path. For now this creates the stable snapshot seam without
+    moving authority.
+    """
+    for key in ("cognitive_projection_facet", "cognitive_projection"):
+        value = metadata.get(key)
+        if isinstance(value, dict):
+            return value
+    return None
+
+
 def build_mind_run_request(
     client_request: CortexClientRequest,
     plan_request: PlanExecutionRequest,
     correlation_id: str,
     *,
     substrate_telemetry_facet: dict[str, Any] | None = None,
+    cognitive_projection_facet: dict[str, Any] | None = None,
 ) -> MindRunRequestV1:
     """Construct a bounded v1 request; snapshot is inline JSON only (v1)."""
     meta = client_request.context.metadata if isinstance(client_request.context.metadata, dict) else {}
@@ -150,10 +166,13 @@ def build_mind_run_request(
         llm_enabled_per_loop=list(extra_policy.get("llm_enabled_per_loop") or []),
         router_profile_id=router_profile,
     )
+    facets: dict[str, Any] = {}
     if substrate_telemetry_facet is not None:
-        existing = snapshot.get("facets")
-        facets: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
         facets["substrate_telemetry"] = substrate_telemetry_facet
+    cognitive_projection = cognitive_projection_facet or _inline_cognitive_projection_facet(meta)
+    if cognitive_projection is not None:
+        facets["cognitive_projection"] = cognitive_projection
+    if facets:
         snapshot["facets"] = facets
     return MindRunRequestV1(
         correlation_id=correlation_id,

--- a/services/orion-cortex-orch/tests/test_mind_orch.py
+++ b/services/orion-cortex-orch/tests/test_mind_orch.py
@@ -48,6 +48,20 @@ def _plan_request() -> PlanExecutionRequest:
     )
 
 
+def _client_request(metadata: dict | None = None) -> CortexClientRequest:
+    return CortexClientRequest(
+        verb="chat_general",
+        mode="brain",
+        context=CortexClientContext(
+            messages=[LLMMessage(role="user", content="hi")],
+            session_id="s",
+            trace_id="t",
+            user_message="hi",
+            metadata=metadata or {"mind_enabled": True},
+        ),
+    )
+
+
 def test_meaningful_mind_synthesis_may_skip_stance_synthesis() -> None:
     _orch_prep()
     from app.mind_runtime import merge_mind_brief_into_plan_metadata
@@ -153,23 +167,54 @@ def test_build_mind_run_request_merges_substrate_telemetry_facet() -> None:
     _orch_prep()
     from app.mind_runtime import build_mind_run_request
 
-    cr = CortexClientRequest(
-        verb="chat_general",
-        mode="brain",
-        context=CortexClientContext(
-            messages=[LLMMessage(role="user", content="hi")],
-            session_id="s",
-            trace_id="t",
-            user_message="hi",
-            metadata={"mind_enabled": True},
-        ),
-    )
-    pr = _plan_request()
     req = build_mind_run_request(
-        cr,
-        pr,
+        _client_request(),
+        _plan_request(),
         "550e8400-e29b-41d4-a716-446655440000",
         substrate_telemetry_facet={"status": "absent"},
     )
     facets = (req.snapshot_inputs or {}).get("facets") or {}
     assert facets.get("substrate_telemetry") == {"status": "absent"}
+
+
+def test_build_mind_run_request_accepts_explicit_cognitive_projection_facet() -> None:
+    _orch_prep()
+    from app.mind_runtime import build_mind_run_request
+
+    projection = {
+        "schema_version": "cognitive.projection.v1",
+        "projection_id": "cog-proj-test",
+        "generated_at": "2026-05-16T04:00:00+00:00",
+        "source": "cognitive_unification_layer",
+        "anchors": {},
+        "item_count": 0,
+    }
+    req = build_mind_run_request(
+        _client_request(),
+        _plan_request(),
+        "550e8400-e29b-41d4-a716-446655440000",
+        cognitive_projection_facet=projection,
+    )
+    facets = (req.snapshot_inputs or {}).get("facets") or {}
+    assert facets.get("cognitive_projection") == projection
+
+
+def test_build_mind_run_request_accepts_inline_metadata_cognitive_projection_facet() -> None:
+    _orch_prep()
+    from app.mind_runtime import build_mind_run_request
+
+    projection = {
+        "schema_version": "cognitive.projection.v1",
+        "projection_id": "cog-proj-inline",
+        "generated_at": "2026-05-16T04:00:00+00:00",
+        "source": "cognitive_unification_layer",
+        "anchors": {},
+        "item_count": 0,
+    }
+    req = build_mind_run_request(
+        _client_request(metadata={"mind_enabled": True, "cognitive_projection_facet": projection}),
+        _plan_request(),
+        "550e8400-e29b-41d4-a716-446655440000",
+    )
+    facets = (req.snapshot_inputs or {}).get("facets") or {}
+    assert facets.get("cognitive_projection") == projection

--- a/services/orion-mind/app/engine.py
+++ b/services/orion-mind/app/engine.py
@@ -26,8 +26,10 @@ from orion.mind.v1 import (
 logger = logging.getLogger("orion-mind.engine")
 
 _FACET_ORDER = (
+    "cognitive_projection",
     "autonomy",
     "substrate",
+    "substrate_telemetry",
     "collapse",
     "concept_induction",
     "recall_digest",
@@ -177,6 +179,29 @@ def _default_stance_from_user_text(user_text: str) -> dict[str, Any]:
     }
 
 
+def _snapshot_facets(snapshot: dict[str, Any]) -> dict[str, Any]:
+    facets = snapshot.get("facets") if isinstance(snapshot.get("facets"), dict) else {}
+    return dict(facets)
+
+
+def _cognitive_projection_debug(snapshot: dict[str, Any]) -> dict[str, Any]:
+    projection = _snapshot_facets(snapshot).get("cognitive_projection")
+    if not isinstance(projection, dict):
+        return {"present": False}
+    anchors = projection.get("anchors") if isinstance(projection.get("anchors"), dict) else {}
+    return {
+        "present": True,
+        "schema_version": projection.get("schema_version"),
+        "projection_id": projection.get("projection_id"),
+        "generated_at": projection.get("generated_at"),
+        "item_count": projection.get("item_count"),
+        "anchor_count": len(anchors),
+        "cold_anchors": projection.get("cold_anchors") if isinstance(projection.get("cold_anchors"), list) else [],
+        "degraded_producers": projection.get("degraded_producers") if isinstance(projection.get("degraded_producers"), list) else [],
+        "notes": projection.get("notes") if isinstance(projection.get("notes"), list) else [],
+    }
+
+
 def _elapsed_ms_wall_clock(t_run_start: float) -> float:
     return (time.perf_counter() - t_run_start) * 1000
 
@@ -224,6 +249,7 @@ def run_mind_deterministic(
     )
 
     bounded, _truncated = build_bounded_snapshot_inputs(dict(req.snapshot_inputs or {}), snapshot_max_bytes)
+    cognitive_projection_debug = _cognitive_projection_debug(bounded)
     snap_hash = hash_snapshot_inputs(bounded)
     phases["snapshot_ms"] = _elapsed_ms_wall_clock(t_run_start)
 
@@ -272,6 +298,10 @@ def run_mind_deterministic(
         }
         if i == 0:
             delta.update(base)
+            if cognitive_projection_debug.get("present"):
+                delta["cognitive_projection_seen"] = True
+                delta["cognitive_projection_id"] = cognitive_projection_debug.get("projection_id")
+                delta["cognitive_projection_item_count"] = cognitive_projection_debug.get("item_count")
         else:
             delta["user_intent"] = base["user_intent"]
         layers.append(delta)
@@ -341,18 +371,27 @@ def run_mind_deterministic(
         "mind.mode_suggestion": decision.mode_suggestion,
         "mind.mode_binding": decision.mode_binding,
         "mind.quality": "fallback_contract_only",
+        "mind.cognitive_projection_seen": bool(cognitive_projection_debug.get("present")),
     }
+    if cognitive_projection_debug.get("present"):
+        machine["mind.cognitive_projection_id"] = cognitive_projection_debug.get("projection_id")
+        machine["mind.cognitive_projection_item_count"] = cognitive_projection_debug.get("item_count")
     brief = MindHandoffBriefV1(
         summary_one_paragraph="Fallback contract only — no meaningful Mind synthesis produced.",
         machine_contract=machine,
         mandatory_keys=["mind.route_kind", "mind.allowed_verbs"],
-        advisory_keys=["mind.mode_suggestion", "mind.quality"],
+        advisory_keys=["mind.mode_suggestion", "mind.quality", "mind.cognitive_projection_seen"],
         stance_payload=valid.model_dump(mode="json"),
         mind_quality="fallback_contract_only",
     )
 
     phases["total_ms"] = _elapsed_ms_wall_clock(t_run_start)
-    logger.info("mind_run_end mind_run_id=%s ok=True snapshot_hash=%s quality=fallback_contract_only", mind_run_id, snap_hash)
+    logger.info(
+        "mind_run_end mind_run_id=%s ok=True snapshot_hash=%s quality=fallback_contract_only cognitive_projection_seen=%s",
+        mind_run_id,
+        snap_hash,
+        bool(cognitive_projection_debug.get("present")),
+    )
 
     return MindRunResultV1(
         mind_run_id=mind_run_id,

--- a/services/orion-mind/tests/test_http_contract.py
+++ b/services/orion-mind/tests/test_http_contract.py
@@ -54,4 +54,36 @@ def test_mind_run_deterministic_ok(client: TestClient) -> None:
     body = r.json()
     assert body.get("ok") is True
     assert body.get("mind_run_id")
+    assert body.get("mind_quality") == "fallback_contract_only"
     assert body.get("brief", {}).get("stance_payload")
+
+
+def test_mind_run_surfaces_cognitive_projection_seen_without_claiming_synthesis(client: TestClient) -> None:
+    projection = {
+        "schema_version": "cognitive.projection.v1",
+        "projection_id": "cog-proj-http-test",
+        "generated_at": "2026-05-16T04:00:00+00:00",
+        "source": "cognitive_unification_layer",
+        "anchors": {"orion": {"anchor": "orion", "items": []}},
+        "item_count": 7,
+        "notes": ["test_projection"],
+    }
+    r = client.post(
+        "/v1/mind/run",
+        json={
+            "correlation_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "snapshot_inputs": {
+                "user_text": "hello",
+                "facets": {"cognitive_projection": projection},
+            },
+            "policy": {"n_loops_max": 1, "wall_time_ms_max": 60000, "router_profile_id": "default"},
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("mind_quality") == "fallback_contract_only"
+    machine = body.get("brief", {}).get("machine_contract") or {}
+    assert machine.get("mind.cognitive_projection_seen") is True
+    assert machine.get("mind.cognitive_projection_id") == "cog-proj-http-test"
+    assert machine.get("mind.cognitive_projection_item_count") == 7
+    assert body.get("brief", {}).get("mind_quality") == "fallback_contract_only"


### PR DESCRIPTION
## Summary

Phase 2 of the Mind/substrate unification path.

This PR adds a portable, bounded cognitive projection artifact above the existing CognitiveUnificationLayer without moving authority to Mind yet.

### What changed

- Adds `orion/cognition/projection.py`
  - `CognitiveProjectionV1`
  - `CognitiveProjectionAnchorV1`
  - `CognitiveProjectionItemV1`
  - `project_unified_beliefs_for_mind(...)`
- Keeps `UnifiedRelationalBeliefSetV1` as the substrate/unification read model.
- Adds a Mind snapshot seam:
  - `build_mind_run_request(..., cognitive_projection_facet=...)`
  - inline metadata keys: `cognitive_projection_facet` or `cognitive_projection`
  - snapshot facet: `snapshot_inputs.facets.cognitive_projection`
- Deterministic Mind now reports whether it saw a cognitive projection:
  - `mind.cognitive_projection_seen`
  - `mind.cognitive_projection_id`
  - `mind.cognitive_projection_item_count`
- Mind still stays `fallback_contract_only`; this PR does **not** let Mind skip stance synthesis or claim meaningful synthesis.

## Why

The current rich substrate still lives in the chat-stance/CognitiveUnification path. This creates the first portable pre-LLM artifact that Mind can consume in shadow mode, without recreating another substrate or handing authority back to deterministic Mind.

## Important architecture note

Same-turn Orch currently calls Mind before Exec builds `chat_stance_inputs`, so this PR does not pretend to feed the exact same-turn Exec projection into pre-Exec Mind. It creates the stable artifact and inline carrier seam. The next phase should either:

1. move projection building earlier into Orch/shared request preparation, or
2. persist/publish projections from Exec so future Mind runs can read them by correlation/session.

## Tests

Added/updated tests for:

- projection compaction and lineage preservation
- empty/skipped projection as explicit signal
- Mind request projection facet handoff
- deterministic Mind projection visibility while remaining fallback contract-only

## Next phase

Extract the producer registry / projection builder out of `chat_stance.py` into a shared substrate projection service so Orch can build `CognitiveProjectionV1` before calling Mind.