### PR TITLE
Build cognitive projection before Mind handoff

### DIFF
--- a/orion/cognition/projection_builder.py
+++ b/orion/cognition/projection_builder.py
@@ -1,0 +1,219 @@
+"""Shared CognitiveUnificationLayer → CognitiveProjection builder.
+
+Phase-3 seam: move the substrate/projection spine out of the chat stance
+service module so both Exec and Orch can build the same pre-LLM cognitive
+projection before Mind is allowed to claim synthesis authority.
+
+This module owns no chat prompt text and no final-response behavior. It only:
+
+1. wires the known substrate producer registry,
+2. runs ``CognitiveUnificationLayer`` for a bounded anchor set,
+3. optionally publishes cold-path tier telemetry, and
+4. projects unified beliefs into ``CognitiveProjectionV1``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Sequence
+
+from orion.cognition.projection import CognitiveProjectionV1, project_unified_beliefs_for_mind
+from orion.substrate import build_substrate_store_from_env
+from orion.substrate.relational import (
+    CONCEPT_INDUCED,
+    GRAPHDB_DURABLE,
+    OPERATOR_STATIC,
+    SNAPSHOT_EPHEMERAL,
+    CognitiveUnificationLayer,
+    ProducerEntryV1,
+    ProducerRegistryV1,
+    UnifiedRelationalBeliefSetV1,
+    map_autonomy_ctx_to_substrate,
+    map_concept_induction_ctx_to_substrate,
+    map_identity_yaml_to_substrate,
+    map_orionmem_to_substrate,
+    map_recall_bundle_to_substrate,
+    map_self_study_to_substrate,
+    map_social_ctx_to_substrate,
+)
+from orion.substrate.relational.layer import _lightweight_belief_set, _skip_unified_beliefs_ctx
+from orion.substrate.relational.adapters.spark_ctx import map_spark_ctx_to_substrate
+
+logger = logging.getLogger("orion.cognition.projection_builder")
+
+DEFAULT_PROJECTION_ANCHORS: tuple[str, ...] = ("orion", "relationship", "juniper")
+
+_UNIFICATION_LAYER: CognitiveUnificationLayer | None = None
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def build_projection_unification_registry() -> ProducerRegistryV1:
+    """Construct the shared producer registry for cognitive projection reads."""
+    return ProducerRegistryV1(
+        producers=[
+            ProducerEntryV1(
+                producer_id="identity_yaml",
+                trust_tier=OPERATOR_STATIC,
+                anchor_scopes=("orion",),
+                freshness_ttl_sec=86400,
+                pull_on_cold=True,
+                adapter_fn=map_identity_yaml_to_substrate,
+            ),
+            ProducerEntryV1(
+                producer_id="self_study",
+                trust_tier=GRAPHDB_DURABLE,
+                anchor_scopes=("orion",),
+                freshness_ttl_sec=300,
+                pull_on_cold=True,
+                adapter_fn=map_self_study_to_substrate,
+            ),
+            ProducerEntryV1(
+                producer_id="autonomy",
+                trust_tier=GRAPHDB_DURABLE,
+                anchor_scopes=("orion", "relationship", "juniper"),
+                freshness_ttl_sec=300,
+                pull_on_cold=True,
+                adapter_fn=map_autonomy_ctx_to_substrate,
+            ),
+            ProducerEntryV1(
+                producer_id="concept_induction",
+                trust_tier=CONCEPT_INDUCED,
+                anchor_scopes=("orion", "relationship", "juniper"),
+                freshness_ttl_sec=300,
+                pull_on_cold=True,
+                adapter_fn=map_concept_induction_ctx_to_substrate,
+            ),
+            ProducerEntryV1(
+                producer_id="spark",
+                trust_tier=CONCEPT_INDUCED,
+                anchor_scopes=("orion",),
+                freshness_ttl_sec=300,
+                pull_on_cold=True,
+                adapter_fn=map_spark_ctx_to_substrate,
+            ),
+            ProducerEntryV1(
+                producer_id="orionmem",
+                trust_tier=SNAPSHOT_EPHEMERAL,
+                anchor_scopes=("orion", "relationship"),
+                freshness_ttl_sec=120,
+                pull_on_cold=True,
+                adapter_fn=map_orionmem_to_substrate,
+            ),
+            ProducerEntryV1(
+                producer_id="recall",
+                trust_tier=SNAPSHOT_EPHEMERAL,
+                anchor_scopes=("orion", "relationship", "juniper"),
+                freshness_ttl_sec=0,
+                pull_on_cold=False,
+                adapter_fn=map_recall_bundle_to_substrate,
+            ),
+            ProducerEntryV1(
+                producer_id="social",
+                trust_tier=SNAPSHOT_EPHEMERAL,
+                anchor_scopes=("relationship",),
+                freshness_ttl_sec=0,
+                pull_on_cold=False,
+                adapter_fn=map_social_ctx_to_substrate,
+            ),
+        ]
+    )
+
+
+def get_projection_unification_layer() -> CognitiveUnificationLayer:
+    """Return the process-level CognitiveUnificationLayer used by projection builders."""
+    global _UNIFICATION_LAYER
+    if _UNIFICATION_LAYER is None:
+        registry = build_projection_unification_registry()
+        store = build_substrate_store_from_env()
+        _UNIFICATION_LAYER = CognitiveUnificationLayer(registry=registry, store=store)
+    return _UNIFICATION_LAYER
+
+
+def _publish_tier_outcomes_if_needed(*, beliefs: UnifiedRelationalBeliefSetV1, ctx: dict[str, Any]) -> None:
+    if not beliefs.cold_anchors:
+        return
+    try:
+        from orion.substrate.tier_outcomes_bus import publish_substrate_tier_outcomes_sync
+
+        tier_map = {a: s.tier_outcomes for a, s in beliefs.anchors.items() if s.tier_outcomes}
+        publish_substrate_tier_outcomes_sync(
+            generated_at=beliefs.generated_at,
+            cold_anchors=list(beliefs.cold_anchors),
+            tier_outcomes=tier_map,
+            degraded_producers=list(beliefs.degraded_producers),
+            ctx=ctx,
+        )
+        logger.debug(
+            "substrate_tier_outcomes_bus cold_anchors=%s degraded=%s",
+            beliefs.cold_anchors,
+            beliefs.degraded_producers,
+        )
+    except Exception as exc:
+        logger.warning("substrate_tier_outcomes_publish_failed error=%s", exc)
+
+
+def unified_beliefs_for_context(
+    ctx: dict[str, Any] | None,
+    *,
+    anchors: Sequence[str] = DEFAULT_PROJECTION_ANCHORS,
+    timeout_sec: float | None = None,
+    publish_tier_outcomes: bool = False,
+) -> UnifiedRelationalBeliefSetV1 | None:
+    """Build unified beliefs for a request context."""
+    ctx = ctx if isinstance(ctx, dict) else {}
+    anchors_resolved = tuple(anchors) if anchors else DEFAULT_PROJECTION_ANCHORS
+    try:
+        if _skip_unified_beliefs_ctx(ctx):
+            logger.info(
+                "cognitive_projection_builder_skip reason=spark_or_unified_beliefs_disabled verb=%s correlation_id=%s",
+                ctx.get("verb"),
+                ctx.get("correlation_id") or ctx.get("trace_id"),
+            )
+            return _lightweight_belief_set(anchors_resolved)
+
+        layer = get_projection_unification_layer()
+        beliefs = layer.beliefs_for_stance(
+            anchors=anchors_resolved,
+            ctx=ctx,
+            timeout_sec=float(timeout_sec if timeout_sec is not None else _env_float("UNIFIED_BELIEFS_TIMEOUT_SEC", 5.0)),
+        )
+    except Exception as exc:
+        logger.warning("unified_beliefs_for_context_failed error=%s", exc)
+        return None
+
+    if beliefs is not None and publish_tier_outcomes:
+        _publish_tier_outcomes_if_needed(beliefs=beliefs, ctx=ctx)
+    return beliefs
+
+
+def build_cognitive_projection_for_context(
+    ctx: dict[str, Any] | None,
+    *,
+    anchors: Sequence[str] = DEFAULT_PROJECTION_ANCHORS,
+    timeout_sec: float | None = None,
+    max_items_per_bucket: int = 6,
+    max_total_items: int = 48,
+    publish_tier_outcomes: bool = False,
+) -> CognitiveProjectionV1 | None:
+    """Build a bounded ``CognitiveProjectionV1`` for Mind/LLM pre-context."""
+    beliefs = unified_beliefs_for_context(
+        ctx,
+        anchors=anchors,
+        timeout_sec=timeout_sec,
+        publish_tier_outcomes=publish_tier_outcomes,
+    )
+    return project_unified_beliefs_for_mind(
+        beliefs,
+        max_items_per_bucket=max_items_per_bucket,
+        max_total_items=max_total_items,
+    )

--- a/services/orion-cortex-orch/app/mind_runtime.py
+++ b/services/orion-cortex-orch/app/mind_runtime.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 
+from orion.cognition.projection_builder import build_cognitive_projection_for_context
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.mind.v1 import MindRunRequestV1, MindRunResultV1, MindRunPolicyV1
 from orion.schemas.chat_stance import ChatStanceBrief
@@ -116,18 +117,51 @@ async def fetch_substrate_telemetry_facet_for_mind(correlation_id: str) -> dict[
 
 
 def _inline_cognitive_projection_facet(metadata: dict[str, Any]) -> dict[str, Any] | None:
-    """Return caller-supplied cognitive projection for Mind shadow mode.
-
-    This is intentionally inline-only for now. Same-turn Orch cannot see the Exec
-    chat-stance projection until after execution; later phases can add a persisted
-    projection read path. For now this creates the stable snapshot seam without
-    moving authority.
-    """
+    """Return caller-supplied cognitive projection for Mind shadow mode."""
     for key in ("cognitive_projection_facet", "cognitive_projection"):
         value = metadata.get(key)
         if isinstance(value, dict):
             return value
     return None
+
+
+def _plan_projection_context(client_request: CortexClientRequest, plan_request: PlanExecutionRequest, correlation_id: str) -> dict[str, Any]:
+    ctx = dict(plan_request.context or {}) if isinstance(plan_request.context, dict) else {}
+    metadata = ctx.get("metadata") if isinstance(ctx.get("metadata"), dict) else {}
+    ctx["metadata"] = dict(metadata)
+    ctx["correlation_id"] = correlation_id
+    ctx["requested_verb"] = client_request.verb or plan_request.plan.verb_name
+    ctx["verb"] = client_request.verb or plan_request.plan.verb_name
+    ctx["mode"] = client_request.mode
+    ctx["messages"] = [m.model_dump(mode="json") if hasattr(m, "model_dump") else m for m in (client_request.context.messages or [])]
+    ctx["raw_user_text"] = client_request.context.raw_user_text or None
+    ctx["user_message"] = client_request.context.user_message or None
+    ctx["session_id"] = client_request.context.session_id
+    ctx["trace_id"] = client_request.context.trace_id
+    ctx["user_id"] = client_request.context.user_id
+    return ctx
+
+
+def _build_cognitive_projection_facet(
+    client_request: CortexClientRequest,
+    plan_request: PlanExecutionRequest,
+    correlation_id: str,
+) -> dict[str, Any] | None:
+    meta = client_request.context.metadata if isinstance(client_request.context.metadata, dict) else {}
+    inline = _inline_cognitive_projection_facet(meta)
+    if inline is not None:
+        return inline
+    try:
+        projection = build_cognitive_projection_for_context(
+            _plan_projection_context(client_request, plan_request, correlation_id),
+            publish_tier_outcomes=False,
+        )
+    except Exception as exc:
+        logger.warning("mind_cognitive_projection_build_failed corr=%s err=%s", correlation_id, exc)
+        return None
+    if projection is None:
+        return None
+    return projection.model_dump(mode="json")
 
 
 def build_mind_run_request(
@@ -169,7 +203,11 @@ def build_mind_run_request(
     facets: dict[str, Any] = {}
     if substrate_telemetry_facet is not None:
         facets["substrate_telemetry"] = substrate_telemetry_facet
-    cognitive_projection = cognitive_projection_facet or _inline_cognitive_projection_facet(meta)
+    cognitive_projection = cognitive_projection_facet or _build_cognitive_projection_facet(
+        client_request,
+        plan_request,
+        correlation_id,
+    )
     if cognitive_projection is not None:
         facets["cognitive_projection"] = cognitive_projection
     if facets:

--- a/services/orion-cortex-orch/tests/test_mind_orch.py
+++ b/services/orion-cortex-orch/tests/test_mind_orch.py
@@ -44,7 +44,7 @@ def _plan_request() -> PlanExecutionRequest:
             verb_name="chat_general",
             steps=[ExecutionStep(verb_name="chat_general", step_name="noop", order=0, services=[])],
         ),
-        context={"metadata": {}},
+        context={"metadata": {"orion_state": {"ok": True, "status": "present"}}},
     )
 
 
@@ -172,6 +172,7 @@ def test_build_mind_run_request_merges_substrate_telemetry_facet() -> None:
         _plan_request(),
         "550e8400-e29b-41d4-a716-446655440000",
         substrate_telemetry_facet={"status": "absent"},
+        cognitive_projection_facet={"schema_version": "cognitive.projection.v1", "projection_id": "explicit"},
     )
     facets = (req.snapshot_inputs or {}).get("facets") or {}
     assert facets.get("substrate_telemetry") == {"status": "absent"}
@@ -218,3 +219,41 @@ def test_build_mind_run_request_accepts_inline_metadata_cognitive_projection_fac
     )
     facets = (req.snapshot_inputs or {}).get("facets") or {}
     assert facets.get("cognitive_projection") == projection
+
+
+def test_build_mind_run_request_auto_builds_cognitive_projection(monkeypatch) -> None:
+    _orch_prep()
+    import app.mind_runtime as mind_runtime
+    from app.mind_runtime import build_mind_run_request
+
+    calls: list[dict] = []
+
+    class _Projection:
+        def model_dump(self, mode: str = "json") -> dict:
+            return {
+                "schema_version": "cognitive.projection.v1",
+                "projection_id": "cog-proj-auto",
+                "generated_at": "2026-05-16T04:00:00+00:00",
+                "source": "cognitive_unification_layer",
+                "anchors": {},
+                "item_count": 0,
+            }
+
+    def fake_build_projection(ctx, **kwargs):
+        calls.append({"ctx": ctx, "kwargs": kwargs})
+        return _Projection()
+
+    monkeypatch.setattr(mind_runtime, "build_cognitive_projection_for_context", fake_build_projection)
+    req = build_mind_run_request(
+        _client_request(),
+        _plan_request(),
+        "550e8400-e29b-41d4-a716-446655440000",
+    )
+
+    facets = (req.snapshot_inputs or {}).get("facets") or {}
+    assert facets.get("cognitive_projection", {}).get("projection_id") == "cog-proj-auto"
+    assert calls
+    assert calls[0]["ctx"].get("correlation_id") == "550e8400-e29b-41d4-a716-446655440000"
+    assert calls[0]["ctx"].get("user_message") == "hi"
+    assert calls[0]["ctx"].get("metadata", {}).get("orion_state") == {"ok": True, "status": "present"}
+    assert calls[0]["kwargs"].get("publish_tier_outcomes") is False


### PR DESCRIPTION
## Summary

Phase 3 of the Mind/substrate unification path.

This PR adds the shared projection builder that Mind can use before the final LLM path, without moving authority to Mind yet.

### What changed

- Adds `orion/cognition/projection_builder.py`
  - shared producer registry wiring for the existing `CognitiveUnificationLayer`
  - `unified_beliefs_for_context(...)`
  - `build_cognitive_projection_for_context(...)`
  - optional cold-path substrate tier telemetry publication
- Updates `services/orion-cortex-orch/app/mind_runtime.py`
  - `build_mind_run_request(...)` now auto-builds `CognitiveProjectionV1` when no inline projection facet is supplied
  - the projection is placed at `snapshot_inputs.facets.cognitive_projection`
  - projection build failures are non-fatal and logged as `mind_cognitive_projection_build_failed`
- Keeps inline override support for tests/operators:
  - `cognitive_projection_facet`
  - `cognitive_projection`
- Adds test coverage proving `build_mind_run_request(...)` now calls the shared builder and passes correlation/user/state context.

## Why

Previously Mind could only receive a projection when one was explicitly supplied inline. This PR gives Orch’s Mind handoff a same-turn projection build seam, while keeping the actual substrate implementation shared and outside `chat_stance.py`.

## Authority boundary

Mind still stays `fallback_contract_only` unless a future real synthesis layer earns `mind_quality == meaningful_synthesis`.

This PR does **not** let deterministic Mind skip chat stance.

## Important note

I intentionally did **not** rewrite `orchestrator.py` in this PR. The first pass tried that and had too much blast radius. The clean branch only touches:

- `orion/cognition/projection_builder.py`
- `services/orion-cortex-orch/app/mind_runtime.py`
- `services/orion-cortex-orch/tests/test_mind_orch.py`

## Next phase

Convert `services/orion-cortex-exec/app/chat_stance.py` to call the shared projection builder wrapper for its unified belief reads, then start comparing:

- projection-built stance context
- legacy chat stance synthesis
- Mind shadow output

That is the safe path toward removing on-the-fly cognition from the final LLM prompt.