### PR TITLE
Add shared chat stance projection builder seam

### DIFF
--- a/orion/cognition/projection_builder.py
+++ b/orion/cognition/projection_builder.py
@@ -196,6 +196,27 @@ def unified_beliefs_for_context(
     return beliefs
 
 
+def unified_beliefs_for_chat_stance(
+    ctx: dict[str, Any] | None,
+    *,
+    timeout_sec: float | None = None,
+) -> UnifiedRelationalBeliefSetV1 | None:
+    """Compatibility seam for Exec chat stance unified-belief reads.
+
+    This is the Phase-4 convergence target for
+    ``services/orion-cortex-exec/app/chat_stance.py::_unified_beliefs_for_stance``.
+    It preserves chat stance's historical anchors and cold-path telemetry behavior
+    while ensuring the registry/store/build logic is owned here rather than in the
+    service module.
+    """
+    return unified_beliefs_for_context(
+        ctx,
+        anchors=DEFAULT_PROJECTION_ANCHORS,
+        timeout_sec=timeout_sec,
+        publish_tier_outcomes=True,
+    )
+
+
 def build_cognitive_projection_for_context(
     ctx: dict[str, Any] | None,
     *,

--- a/orion/cognition/tests/test_projection_builder.py
+++ b/orion/cognition/tests/test_projection_builder.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from orion.cognition import projection_builder
+from orion.cognition.projection_builder import (
+    DEFAULT_PROJECTION_ANCHORS,
+    build_projection_unification_registry,
+    unified_beliefs_for_chat_stance,
+)
+from orion.substrate.relational.beliefs import AnchorBeliefSliceV1, UnifiedRelationalBeliefSetV1
+
+
+def test_projection_registry_matches_expected_chat_stance_producers() -> None:
+    registry = build_projection_unification_registry()
+    producer_ids = [producer.producer_id for producer in registry.producers]
+
+    assert producer_ids == [
+        "identity_yaml",
+        "self_study",
+        "autonomy",
+        "concept_induction",
+        "spark",
+        "orionmem",
+        "recall",
+        "social",
+    ]
+
+
+def test_unified_beliefs_for_chat_stance_uses_shared_context_path(monkeypatch) -> None:
+    calls: list[dict] = []
+    expected = UnifiedRelationalBeliefSetV1(
+        anchors={anchor: AnchorBeliefSliceV1(anchor=anchor) for anchor in DEFAULT_PROJECTION_ANCHORS},
+        lineage=["test:shared_projection_builder"],
+    )
+
+    def fake_unified_beliefs_for_context(ctx, **kwargs):
+        calls.append({"ctx": ctx, "kwargs": kwargs})
+        return expected
+
+    monkeypatch.setattr(projection_builder, "unified_beliefs_for_context", fake_unified_beliefs_for_context)
+
+    result = unified_beliefs_for_chat_stance({"verb": "chat_general", "correlation_id": "corr-1"}, timeout_sec=1.25)
+
+    assert result is expected
+    assert calls
+    assert tuple(calls[0]["kwargs"]["anchors"]) == DEFAULT_PROJECTION_ANCHORS
+    assert calls[0]["kwargs"]["timeout_sec"] == 1.25
+    assert calls[0]["kwargs"]["publish_tier_outcomes"] is True
+    assert calls[0]["ctx"]["correlation_id"] == "corr-1"


### PR DESCRIPTION
## Summary

Phase 4 seam-first cut for Mind/substrate convergence.

This PR does **not** rewrite the 2,000+ line `chat_stance.py` file. The GitHub connector available here only supports full-file replacements, so a direct service-file rewrite would be a high-risk blind edit. Instead, this PR lands the safe convergence seam that `chat_stance.py` should call next.

### What changed

- Extends `orion/cognition/projection_builder.py` with:
  - `unified_beliefs_for_chat_stance(...)`
- This wrapper preserves the historical chat stance behavior:
  - anchors: `("orion", "relationship", "juniper")`
  - `publish_tier_outcomes=True`
  - same shared `CognitiveUnificationLayer` / producer registry path used by Mind projection building
- Adds `orion/cognition/tests/test_projection_builder.py`
  - verifies the shared registry producer order/IDs
  - verifies `unified_beliefs_for_chat_stance(...)` delegates through `unified_beliefs_for_context(...)` with the correct anchors, timeout, and telemetry behavior

## Why

Phase 3 let Orch/Mind build same-turn `CognitiveProjectionV1`. Phase 4 needs Exec chat stance to converge on the same shared substrate/projection spine.

This PR creates the explicit, test-covered function that should replace this local service-module logic in `services/orion-cortex-exec/app/chat_stance.py`:

```python
beliefs = _unified_beliefs_for_stance(ctx)
```

with a thin wrapper around:

```python
from orion.cognition.projection_builder import unified_beliefs_for_chat_stance
```

## Boundary

This is intentionally a seam PR, not a giant-file rewrite. The next patch should be made in Cursor/Codex with a proper line-based patch to change `chat_stance.py` safely:

```python
# inside _unified_beliefs_for_stance(ctx)
return unified_beliefs_for_chat_stance(
    ctx,
    timeout_sec=_env_float("UNIFIED_BELIEFS_TIMEOUT_SEC", 5.0),
)
```

and then delete the local duplicated registry/singleton helpers once tests pass.

## Next phase

After this merges:

1. Replace `chat_stance.py::_unified_beliefs_for_stance` internals with the shared wrapper.
2. Remove the duplicated local registry/singleton/imports from `chat_stance.py`.
3. Add a focused Exec test proving `build_chat_stance_inputs(...)` receives beliefs through `unified_beliefs_for_chat_stance(...)`.
4. Then start comparing Mind shadow projection vs legacy stance synthesis output.