### PR TITLE
Route chat stance through shared cognitive projection builder

### DIFF
--- a/services/orion-cortex-exec/app/__init__.py
+++ b/services/orion-cortex-exec/app/__init__.py
@@ -1,0 +1,9 @@
+"""orion-cortex-exec application package."""
+
+from __future__ import annotations
+
+# Phase-5 Mind/substrate convergence: install the shared cognitive projection
+# spine before modules such as ``executor.py`` import chat stance helpers.
+from .chat_stance_shared_spine import install_chat_stance_shared_spine
+
+install_chat_stance_shared_spine()

--- a/services/orion-cortex-exec/app/chat_stance_shared_spine.py
+++ b/services/orion-cortex-exec/app/chat_stance_shared_spine.py
@@ -1,0 +1,81 @@
+"""Runtime installer for the shared chat stance cognitive spine.
+
+This is the safe Phase-5 cut: make ``app.chat_stance`` use the shared
+``orion.cognition.projection_builder`` unified-beliefs path without rewriting the
+large service module through a full-file GitHub update.
+
+The local duplicated registry in ``chat_stance.py`` remains in the file for now,
+but it is no longer the runtime path when this installer is active.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from orion.cognition.projection_builder import unified_beliefs_for_chat_stance
+from orion.substrate.relational import UnifiedRelationalBeliefSetV1
+
+logger = logging.getLogger("orion.cortex.exec.chat_stance_shared_spine")
+
+_INSTALLED = False
+_ORIGINAL = None
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def shared_unified_beliefs_for_stance(ctx: dict[str, Any]) -> UnifiedRelationalBeliefSetV1 | None:
+    """Exec chat-stance adapter into the shared cognitive projection builder."""
+    return unified_beliefs_for_chat_stance(
+        ctx,
+        timeout_sec=_env_float("UNIFIED_BELIEFS_TIMEOUT_SEC", 5.0),
+    )
+
+
+def install_chat_stance_shared_spine(*, force: bool = False) -> bool:
+    """Patch ``app.chat_stance`` to use the shared unified-beliefs builder.
+
+    Returns True when the shared spine is installed or already installed.
+    Returns False only when explicitly disabled by env.
+    """
+    global _INSTALLED, _ORIGINAL
+
+    disabled = (os.getenv("CHAT_STANCE_SHARED_PROJECTION_SPINE_DISABLED") or "").strip().lower()
+    if disabled in {"1", "true", "yes", "on"} and not force:
+        logger.info("chat_stance_shared_projection_spine_disabled")
+        return False
+    if _INSTALLED and not force:
+        return True
+
+    from . import chat_stance
+
+    current = getattr(chat_stance, "_unified_beliefs_for_stance", None)
+    if current is not shared_unified_beliefs_for_stance:
+        _ORIGINAL = current
+        setattr(chat_stance, "_unified_beliefs_for_stance", shared_unified_beliefs_for_stance)
+    setattr(chat_stance, "_CHAT_STANCE_SHARED_PROJECTION_SPINE", True)
+    _INSTALLED = True
+    logger.info("chat_stance_shared_projection_spine_installed")
+    return True
+
+
+def restore_chat_stance_shared_spine_for_tests() -> None:
+    """Restore the original local path in tests only."""
+    global _INSTALLED, _ORIGINAL
+    if _ORIGINAL is None:
+        _INSTALLED = False
+        return
+    from . import chat_stance
+
+    setattr(chat_stance, "_unified_beliefs_for_stance", _ORIGINAL)
+    setattr(chat_stance, "_CHAT_STANCE_SHARED_PROJECTION_SPINE", False)
+    _INSTALLED = False

--- a/services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_guard = Path(__file__).resolve().parent / "_exec_import_guard.py"
+_spec = importlib.util.spec_from_file_location("_exec_guard_boot_shared_spine", _guard)
+assert _spec and _spec.loader
+_guard_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guard_mod)
+
+ROOT = Path(__file__).resolve().parents[3]
+APP_ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+
+def test_exec_app_import_installs_shared_chat_stance_spine(monkeypatch) -> None:
+    monkeypatch.delenv("CHAT_STANCE_SHARED_PROJECTION_SPINE_DISABLED", raising=False)
+    _guard_mod.ensure_orion_cortex_exec_app()
+
+    import app
+    from app import chat_stance
+    from app import chat_stance_shared_spine
+
+    assert app is not None
+    assert getattr(chat_stance, "_CHAT_STANCE_SHARED_PROJECTION_SPINE") is True
+    assert chat_stance._unified_beliefs_for_stance is chat_stance_shared_spine.shared_unified_beliefs_for_stance
+
+
+def test_shared_chat_stance_spine_can_be_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("CHAT_STANCE_SHARED_PROJECTION_SPINE_DISABLED", "true")
+    _guard_mod.ensure_orion_cortex_exec_app()
+
+    import app
+    from app import chat_stance
+    from app import chat_stance_shared_spine
+
+    assert app is not None
+    assert chat_stance._unified_beliefs_for_stance is not chat_stance_shared_spine.shared_unified_beliefs_for_stance


### PR DESCRIPTION
## Summary

Phase 5 of the Mind/substrate convergence path.

This PR makes Exec chat stance use the shared cognitive projection/unified-beliefs spine at runtime, without doing a risky full-file rewrite of the 2,000+ line `chat_stance.py` module.

### What changed

- Adds `services/orion-cortex-exec/app/chat_stance_shared_spine.py`
  - defines `shared_unified_beliefs_for_stance(ctx)`
  - calls `orion.cognition.projection_builder.unified_beliefs_for_chat_stance(...)`
  - preserves `UNIFIED_BELIEFS_TIMEOUT_SEC`
  - adds `install_chat_stance_shared_spine(...)`
  - includes `restore_chat_stance_shared_spine_for_tests(...)`
- Updates `services/orion-cortex-exec/app/__init__.py`
  - installs the shared spine on package import, before `executor.py` imports functions from `chat_stance.py`
- Adds tests proving:
  - importing `app` installs the shared chat stance spine
  - `app.chat_stance._unified_beliefs_for_stance` points to the shared adapter
  - env kill switch disables the installer

## Why this shape

The true desired cleanup is to replace the local `_unified_beliefs_for_stance(...)` internals in `chat_stance.py` and then delete the duplicated local registry/singleton. But the available GitHub connector here only supports full-file replacement, and `chat_stance.py` is very large. A blind full-file rewrite would be too risky.

This PR makes the runtime cut safely:

```python
app.chat_stance._unified_beliefs_for_stance = shared_unified_beliefs_for_stance
```

So `build_chat_stance_inputs(...)` now goes through the shared projection builder path when the Exec app package imports normally.

## Kill switch

Set:

```bash
CHAT_STANCE_SHARED_PROJECTION_SPINE_DISABLED=true
```

to preserve the old local path at import time.

## Authority boundary

This still does not promote Mind to `meaningful_synthesis` and does not let deterministic Mind skip chat stance. It only makes chat stance and Mind share the same substrate/projection spine.

## Next phase

After this merges and runtime validates:

1. Use Cursor/Codex line patching to replace the body of `chat_stance.py::_unified_beliefs_for_stance(...)` directly.
2. Delete the local duplicated registry/singleton/imports from `chat_stance.py`.
3. Add a side-by-side debug panel comparison:
   - shared projection
   - legacy stance synthesis
   - Mind shadow handoff
4. Then start building true `meaningful_synthesis` inside Mind.