### PR TITLE
Add shared spine observability for chat stance

### DIFF
--- a/services/orion-cortex-exec/app/chat_stance_shared_spine.py
+++ b/services/orion-cortex-exec/app/chat_stance_shared_spine.py
@@ -14,6 +14,7 @@ import logging
 import os
 from typing import Any
 
+from orion.cognition.projection import project_unified_beliefs_for_mind
 from orion.cognition.projection_builder import unified_beliefs_for_chat_stance
 from orion.substrate.relational import UnifiedRelationalBeliefSetV1
 
@@ -33,12 +34,88 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _record_shared_spine_marker(
+    ctx: dict[str, Any],
+    *,
+    beliefs: UnifiedRelationalBeliefSetV1 | None,
+    error: str | None = None,
+) -> None:
+    marker = {
+        "enabled": True,
+        "adapter": "services/orion-cortex-exec/app/chat_stance_shared_spine.py",
+        "builder": "orion.cognition.projection_builder.unified_beliefs_for_chat_stance",
+        "beliefs_present": beliefs is not None,
+        "cold_anchors": list(getattr(beliefs, "cold_anchors", []) or []) if beliefs is not None else [],
+        "degraded_producers": list(getattr(beliefs, "degraded_producers", []) or []) if beliefs is not None else [],
+        "lineage": list(getattr(beliefs, "lineage", []) or []) if beliefs is not None else [],
+        "error": error,
+    }
+    ctx["chat_stance_shared_projection_spine"] = marker
+    metadata = ctx.setdefault("metadata", {})
+    if isinstance(metadata, dict):
+        metadata["chat_stance_shared_projection_spine"] = marker
+
+
+def _record_projection_snapshot(ctx: dict[str, Any], beliefs: UnifiedRelationalBeliefSetV1 | None) -> None:
+    if beliefs is None:
+        ctx["chat_cognitive_projection"] = None
+        ctx["chat_cognitive_projection_debug"] = {"present": False, "reason": "beliefs_absent"}
+        return
+    try:
+        projection = project_unified_beliefs_for_mind(beliefs)
+    except Exception as exc:
+        logger.warning("chat_stance_projection_snapshot_failed error=%s", exc)
+        ctx["chat_cognitive_projection"] = None
+        ctx["chat_cognitive_projection_debug"] = {
+            "present": False,
+            "reason": "projection_failed",
+            "error": str(exc),
+        }
+        return
+    if projection is None:
+        ctx["chat_cognitive_projection"] = None
+        ctx["chat_cognitive_projection_debug"] = {"present": False, "reason": "projection_none"}
+        return
+    payload = projection.model_dump(mode="json")
+    ctx["chat_cognitive_projection"] = payload
+    ctx["chat_cognitive_projection_debug"] = {
+        "present": True,
+        "projection_id": payload.get("projection_id"),
+        "item_count": payload.get("item_count"),
+        "anchor_count": len(payload.get("anchors") or {}),
+        "cold_anchors": list(payload.get("cold_anchors") or []),
+        "degraded_producers": list(payload.get("degraded_producers") or []),
+        "notes": list(payload.get("notes") or []),
+    }
+
+
 def shared_unified_beliefs_for_stance(ctx: dict[str, Any]) -> UnifiedRelationalBeliefSetV1 | None:
-    """Exec chat-stance adapter into the shared cognitive projection builder."""
-    return unified_beliefs_for_chat_stance(
-        ctx,
-        timeout_sec=_env_float("UNIFIED_BELIEFS_TIMEOUT_SEC", 5.0),
+    """Exec chat-stance adapter into the shared cognitive projection builder.
+
+    Besides returning beliefs to legacy chat stance, this records a compact marker
+    and projection snapshot in ``ctx`` so Inspect/debug surfaces can prove which
+    cognitive spine served the turn.
+    """
+    try:
+        beliefs = unified_beliefs_for_chat_stance(
+            ctx,
+            timeout_sec=_env_float("UNIFIED_BELIEFS_TIMEOUT_SEC", 5.0),
+        )
+    except Exception as exc:
+        _record_shared_spine_marker(ctx, beliefs=None, error=str(exc))
+        logger.warning("chat_stance_shared_projection_spine_failed error=%s", exc)
+        raise
+    _record_shared_spine_marker(ctx, beliefs=beliefs)
+    _record_projection_snapshot(ctx, beliefs)
+    logger.info(
+        "chat_stance_shared_projection_spine_used beliefs_present=%s projection_present=%s item_count=%s cold_anchors=%s degraded=%s",
+        beliefs is not None,
+        bool((ctx.get("chat_cognitive_projection_debug") or {}).get("present")) if isinstance(ctx.get("chat_cognitive_projection_debug"), dict) else False,
+        (ctx.get("chat_cognitive_projection_debug") or {}).get("item_count") if isinstance(ctx.get("chat_cognitive_projection_debug"), dict) else None,
+        list(getattr(beliefs, "cold_anchors", []) or []) if beliefs is not None else [],
+        list(getattr(beliefs, "degraded_producers", []) or []) if beliefs is not None else [],
     )
+    return beliefs
 
 
 def install_chat_stance_shared_spine(*, force: bool = False) -> bool:

--- a/services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 _guard = Path(__file__).resolve().parent / "_exec_import_guard.py"
@@ -16,6 +17,39 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 if str(APP_ROOT) not in sys.path:
     sys.path.insert(0, str(APP_ROOT))
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+    SubstrateTemporalWindowV1,
+)
+from orion.substrate.relational.beliefs import AnchorBeliefSliceV1, UnifiedRelationalBeliefSetV1
+
+
+def _beliefs() -> UnifiedRelationalBeliefSetV1:
+    concept = ConceptNodeV1(
+        node_kind="concept",
+        anchor_scope="orion",
+        label="shared spine test concept",
+        definition="A compact concept proving the shared stance spine produced projection data.",
+        temporal=SubstrateTemporalWindowV1(observed_at=datetime.now(timezone.utc)),
+        signals=SubstrateSignalBundleV1(salience=0.9, confidence=0.8),
+        provenance=SubstrateProvenanceV1(
+            authority="local_inferred",
+            source_kind="test",
+            source_channel="unit",
+            producer="test_chat_stance_shared_spine",
+            tier_rank=3,
+            evidence_refs=["ev-shared-spine"],
+        ),
+    )
+    return UnifiedRelationalBeliefSetV1(
+        anchors={"orion": AnchorBeliefSliceV1(anchor="orion", concepts=[concept])},
+        cold_anchors=["orion"],
+        degraded_producers=["producer-x"],
+        lineage=["test:shared_spine"],
+    )
 
 
 def test_exec_app_import_installs_shared_chat_stance_spine(monkeypatch) -> None:
@@ -41,3 +75,52 @@ def test_shared_chat_stance_spine_can_be_disabled(monkeypatch) -> None:
 
     assert app is not None
     assert chat_stance._unified_beliefs_for_stance is not chat_stance_shared_spine.shared_unified_beliefs_for_stance
+
+
+def test_shared_spine_records_context_marker_and_projection(monkeypatch) -> None:
+    monkeypatch.delenv("CHAT_STANCE_SHARED_PROJECTION_SPINE_DISABLED", raising=False)
+    _guard_mod.ensure_orion_cortex_exec_app()
+
+    from app import chat_stance_shared_spine
+
+    monkeypatch.setattr(chat_stance_shared_spine, "unified_beliefs_for_chat_stance", lambda ctx, **kwargs: _beliefs())
+
+    ctx = {"metadata": {}, "verb": "chat_general", "correlation_id": "corr-shared"}
+    result = chat_stance_shared_spine.shared_unified_beliefs_for_stance(ctx)
+
+    assert result is not None
+    marker = ctx.get("chat_stance_shared_projection_spine")
+    assert marker["enabled"] is True
+    assert marker["beliefs_present"] is True
+    assert marker["cold_anchors"] == ["orion"]
+    assert marker["degraded_producers"] == ["producer-x"]
+    assert marker["lineage"] == ["test:shared_spine"]
+    assert ctx["metadata"]["chat_stance_shared_projection_spine"] == marker
+
+    projection = ctx.get("chat_cognitive_projection")
+    debug = ctx.get("chat_cognitive_projection_debug")
+    assert projection["schema_version"] == "cognitive.projection.v1"
+    assert projection["item_count"] == 1
+    assert debug["present"] is True
+    assert debug["item_count"] == 1
+    assert debug["cold_anchors"] == ["orion"]
+    assert debug["degraded_producers"] == ["producer-x"]
+
+
+def test_shared_spine_records_absent_beliefs(monkeypatch) -> None:
+    monkeypatch.delenv("CHAT_STANCE_SHARED_PROJECTION_SPINE_DISABLED", raising=False)
+    _guard_mod.ensure_orion_cortex_exec_app()
+
+    from app import chat_stance_shared_spine
+
+    monkeypatch.setattr(chat_stance_shared_spine, "unified_beliefs_for_chat_stance", lambda ctx, **kwargs: None)
+
+    ctx = {"metadata": {}, "verb": "chat_general", "correlation_id": "corr-empty"}
+    result = chat_stance_shared_spine.shared_unified_beliefs_for_stance(ctx)
+
+    assert result is None
+    marker = ctx.get("chat_stance_shared_projection_spine")
+    assert marker["enabled"] is True
+    assert marker["beliefs_present"] is False
+    assert ctx.get("chat_cognitive_projection") is None
+    assert ctx.get("chat_cognitive_projection_debug") == {"present": False, "reason": "beliefs_absent"}


### PR DESCRIPTION
## Summary

Next phase after routing chat stance through the shared cognitive projection builder.

This PR adds runtime observability proving whether the shared chat-stance cognitive spine served a turn, and captures a compact `CognitiveProjectionV1` snapshot for Inspect/debug surfaces.

### What changed

- Updates `services/orion-cortex-exec/app/chat_stance_shared_spine.py`
  - records `ctx["chat_stance_shared_projection_spine"]`
  - mirrors that marker into `ctx["metadata"]["chat_stance_shared_projection_spine"]`
  - records `ctx["chat_cognitive_projection"]`
  - records `ctx["chat_cognitive_projection_debug"]`
  - logs `chat_stance_shared_projection_spine_used` with projection/belief counts
- Updates `services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py`
  - tests shared-spine installation still works
  - tests kill switch still works
  - tests positive marker/projection population
  - tests absent-beliefs marker behavior

## Runtime markers

Successful shared spine path now leaves:

```python
ctx["chat_stance_shared_projection_spine"] = {
    "enabled": True,
    "adapter": "services/orion-cortex-exec/app/chat_stance_shared_spine.py",
    "builder": "orion.cognition.projection_builder.unified_beliefs_for_chat_stance",
    "beliefs_present": True,
    "cold_anchors": [...],
    "degraded_producers": [...],
    "lineage": [...],
    "error": None,
}
```

and:

```python
ctx["chat_cognitive_projection_debug"] = {
    "present": True,
    "projection_id": "...",
    "item_count": 12,
    "anchor_count": 3,
    "cold_anchors": [...],
    "degraded_producers": [...],
    "notes": [...],
}
```

## Authority boundary

No Mind promotion here.
No `meaningful_synthesis` promotion.
No change to the Mind skip gate.
No routing change.

This is observability and proof-of-path only.

## Next phase

Expose these markers in Hub/Inspect, then build the side-by-side comparison surface:

- shared cognitive projection
- legacy chat stance synthesis
- Mind shadow handoff

That gives us the dashboard needed before building real Mind synthesis.