### PR TITLE
Expose shared cognitive projection in ChatStanceDebug

### DIFF
--- a/services/orion-cortex-exec/app/chat_stance_shared_spine.py
+++ b/services/orion-cortex-exec/app/chat_stance_shared_spine.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any
+from typing import Any, Callable
 
 from orion.cognition.projection import project_unified_beliefs_for_mind
 from orion.cognition.projection_builder import unified_beliefs_for_chat_stance
@@ -22,6 +22,7 @@ logger = logging.getLogger("orion.cortex.exec.chat_stance_shared_spine")
 
 _INSTALLED = False
 _ORIGINAL = None
+_ORIGINAL_DEBUG_BUILDER: Callable[..., dict[str, Any]] | None = None
 
 
 def _env_float(name: str, default: float) -> float:
@@ -89,6 +90,56 @@ def _record_projection_snapshot(ctx: dict[str, Any], beliefs: UnifiedRelationalB
     }
 
 
+def _projection_debug_bundle(ctx: dict[str, Any]) -> dict[str, Any]:
+    marker = ctx.get("chat_stance_shared_projection_spine")
+    if not isinstance(marker, dict):
+        metadata = ctx.get("metadata") if isinstance(ctx.get("metadata"), dict) else {}
+        marker = metadata.get("chat_stance_shared_projection_spine") if isinstance(metadata, dict) else None
+    projection_debug = ctx.get("chat_cognitive_projection_debug")
+    projection = ctx.get("chat_cognitive_projection")
+    return {
+        "shared_spine": marker if isinstance(marker, dict) else {"enabled": False, "reason": "marker_absent"},
+        "projection_debug": projection_debug if isinstance(projection_debug, dict) else {"present": False, "reason": "debug_absent"},
+        "projection": projection if isinstance(projection, dict) else None,
+    }
+
+
+def _inject_projection_debug(debug_payload: dict[str, Any], ctx: dict[str, Any]) -> dict[str, Any]:
+    bundle = _projection_debug_bundle(ctx)
+    debug_payload["cognitive_projection"] = bundle
+
+    lineage = debug_payload.get("lineage_summary")
+    if isinstance(lineage, list):
+        projection_debug = bundle.get("projection_debug") if isinstance(bundle.get("projection_debug"), dict) else {}
+        shared_spine = bundle.get("shared_spine") if isinstance(bundle.get("shared_spine"), dict) else {}
+        lineage.append(
+            "shared projection spine used: "
+            + ("yes" if bool(shared_spine.get("enabled")) and bool(shared_spine.get("beliefs_present")) else "no")
+        )
+        lineage.append(
+            f"cognitive projection items: {projection_debug.get('item_count') if projection_debug.get('present') else 0}"
+        )
+
+    raw = debug_payload.setdefault("raw", {})
+    if isinstance(raw, dict):
+        raw["cognitive_projection"] = bundle
+    return debug_payload
+
+
+def shared_build_chat_stance_debug_payload(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    """Decorate legacy ChatStanceDebug with shared-spine/projection details."""
+    if _ORIGINAL_DEBUG_BUILDER is None:
+        raise RuntimeError("chat_stance_debug_builder_not_installed")
+    debug_payload = _ORIGINAL_DEBUG_BUILDER(*args, **kwargs)
+    ctx = kwargs.get("ctx")
+    if not isinstance(ctx, dict) and args:
+        maybe_ctx = args[0]
+        ctx = maybe_ctx if isinstance(maybe_ctx, dict) else None
+    if isinstance(debug_payload, dict) and isinstance(ctx, dict):
+        return _inject_projection_debug(debug_payload, ctx)
+    return debug_payload
+
+
 def shared_unified_beliefs_for_stance(ctx: dict[str, Any]) -> UnifiedRelationalBeliefSetV1 | None:
     """Exec chat-stance adapter into the shared cognitive projection builder.
 
@@ -119,12 +170,12 @@ def shared_unified_beliefs_for_stance(ctx: dict[str, Any]) -> UnifiedRelationalB
 
 
 def install_chat_stance_shared_spine(*, force: bool = False) -> bool:
-    """Patch ``app.chat_stance`` to use the shared unified-beliefs builder.
+    """Patch ``app.chat_stance`` to use the shared unified-beliefs/debug builders.
 
     Returns True when the shared spine is installed or already installed.
     Returns False only when explicitly disabled by env.
     """
-    global _INSTALLED, _ORIGINAL
+    global _INSTALLED, _ORIGINAL, _ORIGINAL_DEBUG_BUILDER
 
     disabled = (os.getenv("CHAT_STANCE_SHARED_PROJECTION_SPINE_DISABLED") or "").strip().lower()
     if disabled in {"1", "true", "yes", "on"} and not force:
@@ -139,6 +190,12 @@ def install_chat_stance_shared_spine(*, force: bool = False) -> bool:
     if current is not shared_unified_beliefs_for_stance:
         _ORIGINAL = current
         setattr(chat_stance, "_unified_beliefs_for_stance", shared_unified_beliefs_for_stance)
+
+    current_debug = getattr(chat_stance, "build_chat_stance_debug_payload", None)
+    if current_debug is not shared_build_chat_stance_debug_payload:
+        _ORIGINAL_DEBUG_BUILDER = current_debug
+        setattr(chat_stance, "build_chat_stance_debug_payload", shared_build_chat_stance_debug_payload)
+
     setattr(chat_stance, "_CHAT_STANCE_SHARED_PROJECTION_SPINE", True)
     _INSTALLED = True
     logger.info("chat_stance_shared_projection_spine_installed")
@@ -147,12 +204,15 @@ def install_chat_stance_shared_spine(*, force: bool = False) -> bool:
 
 def restore_chat_stance_shared_spine_for_tests() -> None:
     """Restore the original local path in tests only."""
-    global _INSTALLED, _ORIGINAL
-    if _ORIGINAL is None:
+    global _INSTALLED, _ORIGINAL, _ORIGINAL_DEBUG_BUILDER
+    if _ORIGINAL is None and _ORIGINAL_DEBUG_BUILDER is None:
         _INSTALLED = False
         return
     from . import chat_stance
 
-    setattr(chat_stance, "_unified_beliefs_for_stance", _ORIGINAL)
+    if _ORIGINAL is not None:
+        setattr(chat_stance, "_unified_beliefs_for_stance", _ORIGINAL)
+    if _ORIGINAL_DEBUG_BUILDER is not None:
+        setattr(chat_stance, "build_chat_stance_debug_payload", _ORIGINAL_DEBUG_BUILDER)
     setattr(chat_stance, "_CHAT_STANCE_SHARED_PROJECTION_SPINE", False)
     _INSTALLED = False

--- a/services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py
@@ -63,6 +63,7 @@ def test_exec_app_import_installs_shared_chat_stance_spine(monkeypatch) -> None:
     assert app is not None
     assert getattr(chat_stance, "_CHAT_STANCE_SHARED_PROJECTION_SPINE") is True
     assert chat_stance._unified_beliefs_for_stance is chat_stance_shared_spine.shared_unified_beliefs_for_stance
+    assert chat_stance.build_chat_stance_debug_payload is chat_stance_shared_spine.shared_build_chat_stance_debug_payload
 
 
 def test_shared_chat_stance_spine_can_be_disabled(monkeypatch) -> None:
@@ -75,6 +76,7 @@ def test_shared_chat_stance_spine_can_be_disabled(monkeypatch) -> None:
 
     assert app is not None
     assert chat_stance._unified_beliefs_for_stance is not chat_stance_shared_spine.shared_unified_beliefs_for_stance
+    assert chat_stance.build_chat_stance_debug_payload is not chat_stance_shared_spine.shared_build_chat_stance_debug_payload
 
 
 def test_shared_spine_records_context_marker_and_projection(monkeypatch) -> None:
@@ -124,3 +126,49 @@ def test_shared_spine_records_absent_beliefs(monkeypatch) -> None:
     assert marker["beliefs_present"] is False
     assert ctx.get("chat_cognitive_projection") is None
     assert ctx.get("chat_cognitive_projection_debug") == {"present": False, "reason": "beliefs_absent"}
+
+
+def test_shared_debug_builder_injects_projection_bundle(monkeypatch) -> None:
+    monkeypatch.delenv("CHAT_STANCE_SHARED_PROJECTION_SPINE_DISABLED", raising=False)
+    _guard_mod.ensure_orion_cortex_exec_app()
+
+    from app import chat_stance_shared_spine
+
+    def fake_legacy_builder(*args, **kwargs):
+        return {
+            "overview": {},
+            "lineage_summary": [],
+            "raw": {},
+        }
+
+    monkeypatch.setattr(chat_stance_shared_spine, "_ORIGINAL_DEBUG_BUILDER", fake_legacy_builder)
+
+    ctx = {
+        "chat_stance_shared_projection_spine": {"enabled": True, "beliefs_present": True, "lineage": ["test"]},
+        "chat_cognitive_projection_debug": {"present": True, "projection_id": "proj-1", "item_count": 3, "anchor_count": 2},
+        "chat_cognitive_projection": {"schema_version": "cognitive.projection.v1", "projection_id": "proj-1", "item_count": 3},
+    }
+    debug = chat_stance_shared_spine.shared_build_chat_stance_debug_payload(ctx=ctx)
+
+    assert debug["cognitive_projection"]["shared_spine"]["enabled"] is True
+    assert debug["cognitive_projection"]["projection_debug"]["item_count"] == 3
+    assert debug["cognitive_projection"]["projection"]["projection_id"] == "proj-1"
+    assert debug["raw"]["cognitive_projection"]["projection_debug"]["projection_id"] == "proj-1"
+    assert "shared projection spine used: yes" in debug["lineage_summary"]
+    assert "cognitive projection items: 3" in debug["lineage_summary"]
+
+
+def test_shared_debug_builder_records_absent_projection(monkeypatch) -> None:
+    monkeypatch.delenv("CHAT_STANCE_SHARED_PROJECTION_SPINE_DISABLED", raising=False)
+    _guard_mod.ensure_orion_cortex_exec_app()
+
+    from app import chat_stance_shared_spine
+
+    monkeypatch.setattr(chat_stance_shared_spine, "_ORIGINAL_DEBUG_BUILDER", lambda *args, **kwargs: {"lineage_summary": [], "raw": {}})
+
+    debug = chat_stance_shared_spine.shared_build_chat_stance_debug_payload(ctx={})
+
+    assert debug["cognitive_projection"]["shared_spine"] == {"enabled": False, "reason": "marker_absent"}
+    assert debug["cognitive_projection"]["projection_debug"] == {"present": False, "reason": "debug_absent"}
+    assert "shared projection spine used: no" in debug["lineage_summary"]
+    assert "cognitive projection items: 0" in debug["lineage_summary"]


### PR DESCRIPTION
## Summary

Next phase after shared-spine observability: surface the shared cognitive projection markers inside the existing `ChatStanceDebug` payload so Hub/Inspect has something concrete to render.

This keeps the no-giant-file-rewrite constraint: `chat_stance.py` remains untouched. The import-time installer now wraps both:

- `_unified_beliefs_for_stance`
- `build_chat_stance_debug_payload`

### What changed

- Updates `services/orion-cortex-exec/app/chat_stance_shared_spine.py`
  - adds `shared_build_chat_stance_debug_payload(...)`
  - preserves/delegates to the original legacy debug builder
  - injects a new top-level debug section:

```python
ChatStanceDebug["cognitive_projection"] = {
    "shared_spine": {...},
    "projection_debug": {...},
    "projection": {...} | None,
}
```

  - also mirrors the same bundle into:

```python
ChatStanceDebug["raw"]["cognitive_projection"]
```

  - appends lineage summary rows:

```text
shared projection spine used: yes/no
cognitive projection items: N
```

- Updates `services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py`
  - asserts the debug builder wrapper is installed on `app` import
  - asserts kill switch disables both wrappers
  - tests projection-bundle injection
  - tests absent-marker/absent-projection behavior

## Why

The previous PR recorded the markers in runtime `ctx`, but Hub/Inspect typically sees the step result/debug payloads. This PR pushes the shared spine/projection data into the existing `ChatStanceDebug` surface without changing routing, Mind authority, or the large stance module directly.

## Authority boundary

No Mind promotion.
No `meaningful_synthesis` promotion.
No skip-gate change.
No routing change.

This is display/debug surfacing only.

## Next phase

Expose `ChatStanceDebug.cognitive_projection` in Hub UI and build the side-by-side panel:

- shared cognitive projection
- legacy chat stance synthesis
- Mind shadow handoff