### PR TITLE
Expose cognitive projection in Hub Chat Stance inspect

### DIFF
--- a/services/orion-hub/static/js/thought-process.js
+++ b/services/orion-hub/static/js/thought-process.js
@@ -129,3 +129,200 @@
     module.exports = api;
   }
 })(typeof window !== 'undefined' ? window : globalThis);
+
+(function (global) {
+  const INLINE_CARD_ID = 'chatStanceCognitiveProjectionInspectCard';
+  const MODAL_CARD_ID = 'chatStanceCognitiveProjectionInspectModalCard';
+
+  function asObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+  }
+
+  function asList(value) {
+    return Array.isArray(value) ? value : [];
+  }
+
+  function short(value, fallback = '--') {
+    const text = String(value === null || value === undefined ? '' : value).trim();
+    return text || fallback;
+  }
+
+  function parseJson(text) {
+    const raw = String(text || '').trim();
+    if (!raw || raw === '--' || raw.startsWith('No chat stance debug')) return null;
+    try {
+      const parsed = JSON.parse(raw);
+      return asObject(parsed);
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  function projectionBundle(payload) {
+    const root = asObject(payload) || {};
+    return asObject(root.cognitive_projection) || asObject(asObject(root.raw)?.cognitive_projection) || null;
+  }
+
+  function normalizeProjectionBundle(bundle) {
+    const b = asObject(bundle) || {};
+    const sharedSpine = asObject(b.shared_spine) || {};
+    const projectionDebug = asObject(b.projection_debug) || {};
+    const projection = asObject(b.projection) || null;
+    const anchors = asObject(projection && projection.anchors) || {};
+    const anchorNames = Object.keys(anchors);
+    const notes = asList(projectionDebug.notes).length ? asList(projectionDebug.notes) : asList(projection && projection.notes);
+    const coldAnchors = asList(projectionDebug.cold_anchors).length ? asList(projectionDebug.cold_anchors) : asList(sharedSpine.cold_anchors);
+    const degraded = asList(projectionDebug.degraded_producers).length ? asList(projectionDebug.degraded_producers) : asList(sharedSpine.degraded_producers);
+    return {
+      sharedSpine,
+      projectionDebug,
+      projection,
+      anchors,
+      anchorNames,
+      notes,
+      coldAnchors,
+      degraded,
+      used: Boolean(sharedSpine.enabled && sharedSpine.beliefs_present),
+      present: Boolean(projectionDebug.present),
+      projectionId: projectionDebug.projection_id || (projection && projection.projection_id),
+      itemCount: projectionDebug.item_count ?? (projection && projection.item_count) ?? 0,
+      anchorCount: projectionDebug.anchor_count ?? anchorNames.length,
+      lineage: asList(sharedSpine.lineage),
+    };
+  }
+
+  function makeEl(tag, className, text) {
+    const el = document.createElement(tag);
+    if (className) el.className = className;
+    if (text !== undefined && text !== null) el.textContent = String(text);
+    return el;
+  }
+
+  function metric(label, value) {
+    const card = makeEl('div', 'rounded-lg border border-gray-800 bg-gray-950/60 px-3 py-2');
+    card.appendChild(makeEl('div', 'text-[10px] uppercase tracking-wide text-gray-500', label));
+    card.appendChild(makeEl('div', 'mt-1 text-[11px] text-gray-100 break-words', short(value)));
+    return card;
+  }
+
+  function compactProjectionItems(model, limit = 8) {
+    const out = [];
+    const anchors = asObject(model.anchors) || {};
+    Object.keys(anchors).forEach((anchor) => {
+      const items = asList(asObject(anchors[anchor])?.items);
+      items.forEach((item) => {
+        if (!asObject(item)) return;
+        out.push({ anchor, ...item });
+      });
+    });
+    return out.slice(0, limit);
+  }
+
+  function renderProjectionCard(model, opts = {}) {
+    const card = makeEl('section', 'rounded-xl border border-cyan-500/30 bg-cyan-500/5 p-3 space-y-3');
+    card.id = opts.modal ? MODAL_CARD_ID : INLINE_CARD_ID;
+
+    const header = makeEl('div', 'flex items-center justify-between gap-2');
+    header.appendChild(makeEl('div', 'text-[10px] uppercase tracking-wide text-cyan-200', 'Cognitive Projection'));
+    const status = model.used ? 'shared spine used' : 'not active';
+    header.appendChild(makeEl('div', model.used ? 'text-[10px] text-emerald-200' : 'text-[10px] text-amber-200', status));
+    card.appendChild(header);
+
+    const grid = makeEl('div', 'grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4');
+    grid.appendChild(metric('Shared spine', model.used ? 'yes' : 'no'));
+    grid.appendChild(metric('Projection id', model.projectionId || '--'));
+    grid.appendChild(metric('Items', model.itemCount));
+    grid.appendChild(metric('Anchors', model.anchorCount));
+    grid.appendChild(metric('Cold anchors', model.coldAnchors.length ? model.coldAnchors.join(', ') : '--'));
+    grid.appendChild(metric('Degraded producers', model.degraded.length ? model.degraded.join(', ') : '--'));
+    grid.appendChild(metric('Lineage', model.lineage.length ? model.lineage.slice(0, 3).join(' · ') : '--'));
+    grid.appendChild(metric('Notes', model.notes.length ? model.notes.join(', ') : '--'));
+    card.appendChild(grid);
+
+    if (opts.modal && model.projection) {
+      const items = compactProjectionItems(model.projection, 10);
+      const detail = makeEl('details', 'rounded-lg border border-cyan-500/20 bg-gray-950/50 p-2');
+      detail.open = true;
+      const summary = makeEl('summary', 'cursor-pointer text-[11px] text-cyan-100', `Top projection items (${items.length})`);
+      detail.appendChild(summary);
+      if (!items.length) {
+        detail.appendChild(makeEl('div', 'mt-2 text-[11px] text-gray-400', 'No compact projection items were present.'));
+      } else {
+        const list = makeEl('div', 'mt-2 space-y-2');
+        items.forEach((item) => {
+          const row = makeEl('div', 'rounded border border-gray-800 bg-gray-900/50 px-2 py-1 text-[11px] text-gray-200');
+          const label = short(item.label || item.summary || item.node_id, 'projection item');
+          const meta = [item.anchor, item.bucket, item.node_kind, item.salience !== undefined ? `sal=${item.salience}` : null, item.confidence !== undefined ? `conf=${item.confidence}` : null]
+            .filter(Boolean)
+            .join(' · ');
+          row.appendChild(makeEl('div', 'text-gray-100', label));
+          row.appendChild(makeEl('div', 'text-[10px] text-gray-500', meta));
+          list.appendChild(row);
+        });
+        detail.appendChild(list);
+      }
+      card.appendChild(detail);
+    }
+
+    if (opts.modal) {
+      const raw = makeEl('details', 'rounded-lg border border-gray-800 bg-gray-950/50 p-2');
+      raw.appendChild(makeEl('summary', 'cursor-pointer text-[10px] uppercase tracking-wide text-gray-500', 'Raw cognitive projection'));
+      const pre = makeEl('pre', 'mt-2 max-h-80 overflow-y-auto whitespace-pre-wrap break-words text-[10px] text-gray-300');
+      pre.textContent = JSON.stringify(model.projection || model.projectionDebug || {}, null, 2);
+      raw.appendChild(pre);
+      card.appendChild(raw);
+    }
+    return card;
+  }
+
+  function payloadFromRawPre() {
+    const rawPre = document.getElementById('chatStanceDebugRaw');
+    return parseJson(rawPre ? rawPre.textContent : '');
+  }
+
+  function renderFromPayload(payload) {
+    const bundle = projectionBundle(payload);
+    const existingInline = document.getElementById(INLINE_CARD_ID);
+    const existingModal = document.getElementById(MODAL_CARD_ID);
+    if (existingInline) existingInline.remove();
+    if (existingModal) existingModal.remove();
+    if (!bundle) return false;
+    const model = normalizeProjectionBundle(bundle);
+    const overview = document.getElementById('chatStanceDebugOverview');
+    if (overview) {
+      overview.appendChild(renderProjectionCard(model, { modal: false }));
+    }
+    const modalBody = document.getElementById('chatStanceDebugModalBody');
+    if (modalBody) {
+      modalBody.insertBefore(renderProjectionCard(model, { modal: true }), modalBody.firstChild || null);
+    }
+    return true;
+  }
+
+  function refresh() {
+    return renderFromPayload(payloadFromRawPre());
+  }
+
+  function attach() {
+    const rawPre = document.getElementById('chatStanceDebugRaw');
+    if (rawPre && typeof MutationObserver !== 'undefined') {
+      const observer = new MutationObserver(() => refresh());
+      observer.observe(rawPre, { childList: true, characterData: true, subtree: true });
+    }
+    const modalButton = document.getElementById('chatStanceDebugOpenModal');
+    if (modalButton) {
+      modalButton.addEventListener('click', () => {
+        setTimeout(() => refresh(), 0);
+        setTimeout(() => refresh(), 50);
+      });
+    }
+    refresh();
+  }
+
+  const api = { attach, refresh, normalizeProjectionBundle, renderFromPayload };
+  global.OrionChatStanceProjectionInspect = api;
+  if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', attach);
+    else attach();
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/services/orion-hub/tests/test_chat_stance_debug_panel.py
+++ b/services/orion-hub/tests/test_chat_stance_debug_panel.py
@@ -6,6 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 TEMPLATE_PATH = REPO_ROOT / "services" / "orion-hub" / "templates" / "index.html"
 APP_JS_PATH = REPO_ROOT / "services" / "orion-hub" / "static" / "js" / "app.js"
+THOUGHT_PROCESS_JS_PATH = REPO_ROOT / "services" / "orion-hub" / "static" / "js" / "thought-process.js"
 
 
 def test_template_includes_chat_stance_panel_and_outer_modal_button() -> None:
@@ -45,3 +46,32 @@ def test_app_js_wires_chat_stance_modal_and_payload_plumbing() -> None:
     assert "chatStanceDebugToggle.addEventListener('click', toggleChatStanceDebugPanel);" in app_js
     assert "chatStanceDebugOpenModal.addEventListener('click', (event) => {" in app_js
     assert "openChatStanceDebugModal();" in app_js
+
+
+def test_thought_process_js_registers_cognitive_projection_inspect_renderer() -> None:
+    thought_js = THOUGHT_PROCESS_JS_PATH.read_text(encoding="utf-8")
+    assert "global.OrionChatStanceProjectionInspect = api;" in thought_js
+    assert "function renderProjectionCard" in thought_js
+    assert "function normalizeProjectionBundle" in thought_js
+    assert "function renderFromPayload" in thought_js
+    assert "function attach" in thought_js
+    assert "MutationObserver" in thought_js
+    assert "chatStanceDebugRaw" in thought_js
+    assert "chatStanceDebugOpenModal" in thought_js
+
+
+def test_thought_process_js_renders_cognitive_projection_cards_and_fields() -> None:
+    thought_js = THOUGHT_PROCESS_JS_PATH.read_text(encoding="utf-8")
+    assert "chatStanceCognitiveProjectionInspectCard" in thought_js
+    assert "chatStanceCognitiveProjectionInspectModalCard" in thought_js
+    assert "payload.cognitive_projection" in thought_js
+    assert "root.raw" in thought_js
+    assert "raw.cognitive_projection" in thought_js
+    assert "Cognitive Projection" in thought_js
+    assert "Top projection items" in thought_js
+    assert "Raw cognitive projection" in thought_js
+    assert "shared spine used" in thought_js
+    assert "Projection id" in thought_js
+    assert "Degraded producers" in thought_js
+    assert "Cold anchors" in thought_js
+    assert "Lineage" in thought_js


### PR DESCRIPTION
## Summary

Actual Hub UI rendering pass after #561.

#561 pushed `ChatStanceDebug.cognitive_projection` into the backend/debug payload. This PR makes that visible in Hub without rewriting the large `app.js` or `index.html` files.

### What changed

- Updates `services/orion-hub/static/js/thought-process.js`
  - keeps existing `OrionThoughtProcess` behavior intact
  - adds `window.OrionChatStanceProjectionInspect`
  - watches `#chatStanceDebugRaw` with a `MutationObserver`
  - parses the existing Chat Stance raw JSON
  - reads either:
    - `payload.cognitive_projection`
    - `payload.raw.cognitive_projection`
  - injects a **Cognitive Projection** card into:
    - inline Chat Stance panel: `#chatStanceDebugOverview`
    - Chat Stance modal: `#chatStanceDebugModalBody`

### Rendered fields

The card shows:

- shared spine used: yes/no
- projection id
- item count
- anchor count
- cold anchors
- degraded producers
- lineage
- notes

The modal version also shows:

- top compact projection items
- raw cognitive projection JSON

### Why this shape

The available connector only supports full-file replacements, and `app.js` is large. Instead of a risky blind rewrite, this PR uses a small already-loaded module (`thought-process.js`) as a safe UI hook. The card reacts to the existing `ChatStanceDebug` raw JSON rendered by `app.js`.

## Tests

Updates `services/orion-hub/tests/test_chat_stance_debug_panel.py` to assert:

- `OrionChatStanceProjectionInspect` is registered
- renderer functions exist
- the MutationObserver / DOM hook targets exist
- the expected projection card IDs and field labels are present

## Authority boundary

No Mind promotion.
No `meaningful_synthesis` promotion.
No routing change.
No skip-gate change.

This only exposes the shared cognitive projection in Hub Inspect.

## Next phase

Add side-by-side comparison:

- shared cognitive projection
- legacy ChatStanceBrief
- Mind handoff / Mind quality

Then build true Mind shadow synthesis against that comparison surface.