### PR TITLE
Add non-authoritative Mind shadow synthesis

### DIFF
--- a/orion/mind/v1.py
+++ b/orion/mind/v1.py
@@ -12,7 +12,7 @@ TrustLevelV1 = Literal["low", "med", "high"]
 HypothesisTagV1 = Literal["assumption", "hypothesis", "simulation_result"]
 MergePolicyV1 = Literal["deterministic_merge"]
 BindingV1 = Literal["advisory", "mandatory"]
-MindQualityV1 = Literal["meaningful_synthesis", "fallback_contract_only", "empty", "error"]
+MindQualityV1 = Literal["meaningful_synthesis", "shadow_synthesis", "fallback_contract_only", "empty", "error"]
 
 
 class MindRunPolicyV1(BaseModel):
@@ -74,6 +74,26 @@ class MindStanceTrajectoryV1(BaseModel):
     merge_policy: MergePolicyV1 = "deterministic_merge"
 
 
+class MindShadowSynthesisV1(BaseModel):
+    """Non-authoritative Mind stance candidate for comparison/debug.
+
+    Shadow synthesis may inform inspection and later evaluation, but it is not
+    allowed to replace ChatStanceBrief or skip stance synthesis.
+    """
+
+    schema_version: Literal["mind.shadow_synthesis.v1"] = "mind.shadow_synthesis.v1"
+    present: bool = False
+    authorized_for_stance_skip: bool = False
+    stance_candidate: dict[str, Any] = Field(default_factory=dict)
+    attention_focus: list[str] = Field(default_factory=list)
+    curiosity_candidate: list[str] = Field(default_factory=list)
+    relationship_frame: str | None = None
+    projection_refs_used: list[str] = Field(default_factory=list)
+    hazards: list[str] = Field(default_factory=list)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    rationale: str | None = None
+
+
 class MindControlDecisionV1(BaseModel):
     route_kind: str = "no_chat"
     allowed_verbs: list[str] = Field(default_factory=list)
@@ -91,6 +111,8 @@ class MindHandoffBriefV1(BaseModel):
     advisory_keys: list[str] = Field(default_factory=list)
     stance_payload: dict[str, Any] = Field(default_factory=dict)
     mind_quality: MindQualityV1 = "empty"
+    shadow_synthesis: MindShadowSynthesisV1 | None = None
+    mind_authorized_for_stance_skip: bool = False
 
 
 class MindRunResultV1(BaseModel):

--- a/services/orion-cortex-orch/app/mind_runtime.py
+++ b/services/orion-cortex-orch/app/mind_runtime.py
@@ -230,10 +230,22 @@ def merge_mind_brief_into_plan_metadata(plan_request: PlanExecutionRequest, resu
         meta[str(k)] = v
     meta["mind_handoff"] = result.brief.model_dump(mode="json")
     meta["mind_quality"] = _mind_result_quality(result)
+    shadow = result.brief.shadow_synthesis
+    if shadow is not None:
+        meta["mind_shadow_synthesis"] = shadow.model_dump(mode="json")
+        meta["mind_shadow_synthesis_present"] = bool(shadow.present)
+        meta["mind_authorized_for_stance_skip"] = bool(shadow.authorized_for_stance_skip)
+    else:
+        meta["mind_shadow_synthesis_present"] = False
+        meta["mind_authorized_for_stance_skip"] = False
     skip_llm_stance = False
     if result.ok:
         meta["mind_run_ok"] = True
-        if _mind_result_quality(result) == "meaningful_synthesis" and not _mind_result_is_deterministic_contract_only(result):
+        if (
+            _mind_result_quality(result) == "meaningful_synthesis"
+            and bool(getattr(result.brief, "mind_authorized_for_stance_skip", False))
+            and not _mind_result_is_deterministic_contract_only(result)
+        ):
             sp = result.brief.stance_payload if isinstance(result.brief.stance_payload, dict) else {}
             try:
                 ChatStanceBrief.model_validate(sp)
@@ -242,7 +254,7 @@ def merge_mind_brief_into_plan_metadata(plan_request: PlanExecutionRequest, resu
                 meta["mind_stance_payload_invalid"] = True
                 skip_llm_stance = False
         else:
-            meta["mind_contract_only"] = True
+            meta["mind_contract_only"] = _mind_result_quality(result) in {"fallback_contract_only", "shadow_synthesis"}
         meta["mind_skip_stance_synthesis"] = skip_llm_stance
     else:
         meta["mind_skip_stance_synthesis"] = False

--- a/services/orion-cortex-orch/tests/test_mind_orch.py
+++ b/services/orion-cortex-orch/tests/test_mind_orch.py
@@ -23,7 +23,14 @@ def _orch_prep() -> None:
     _guard_mod.ensure_orion_cortex_orch_app()
 
 
-from orion.mind.v1 import MindHandoffBriefV1, MindRunResultV1, MindStancePatchV1, MindStanceTrajectoryV1, MindProvenanceV1
+from orion.mind.v1 import (
+    MindHandoffBriefV1,
+    MindProvenanceV1,
+    MindRunResultV1,
+    MindShadowSynthesisV1,
+    MindStancePatchV1,
+    MindStanceTrajectoryV1,
+)
 from orion.schemas.cortex.contracts import CortexClientContext, CortexClientRequest, LLMMessage
 from orion.schemas.cortex.schemas import ExecutionPlan, ExecutionStep, PlanExecutionRequest
 
@@ -73,6 +80,7 @@ def test_meaningful_mind_synthesis_may_skip_stance_synthesis() -> None:
         mind_quality="meaningful_synthesis",
         brief=MindHandoffBriefV1(
             mind_quality="meaningful_synthesis",
+            mind_authorized_for_stance_skip=True,
             machine_contract={"mind.route_kind": "brain"},
             stance_payload=dict(_VALID_STANCE),
         ),
@@ -83,6 +91,66 @@ def test_meaningful_mind_synthesis_may_skip_stance_synthesis() -> None:
     assert meta.get("mind_skip_stance_synthesis") is True
     assert meta.get("mind_quality") == "meaningful_synthesis"
     assert meta.get("mind.route_kind") == "brain"
+
+
+def test_meaningful_mind_synthesis_without_authorization_does_not_skip_stance_synthesis() -> None:
+    _orch_prep()
+    from app.mind_runtime import merge_mind_brief_into_plan_metadata
+
+    pr = _plan_request()
+    result = MindRunResultV1(
+        mind_run_id=uuid4(),
+        ok=True,
+        mind_quality="meaningful_synthesis",
+        brief=MindHandoffBriefV1(
+            mind_quality="meaningful_synthesis",
+            mind_authorized_for_stance_skip=False,
+            machine_contract={"mind.route_kind": "brain"},
+            stance_payload=dict(_VALID_STANCE),
+        ),
+    )
+
+    merge_mind_brief_into_plan_metadata(pr, result)
+    meta = pr.context["metadata"]
+    assert meta.get("mind_skip_stance_synthesis") is False
+
+
+def test_shadow_synthesis_is_preserved_but_never_skips_stance_synthesis() -> None:
+    _orch_prep()
+    from app.mind_runtime import merge_mind_brief_into_plan_metadata
+
+    pr = _plan_request()
+    shadow = MindShadowSynthesisV1(
+        present=True,
+        authorized_for_stance_skip=False,
+        stance_candidate=dict(_VALID_STANCE),
+        attention_focus=["projection item"],
+        projection_refs_used=["node-1"],
+        confidence=0.5,
+        rationale="test shadow",
+    )
+    result = MindRunResultV1(
+        mind_run_id=uuid4(),
+        ok=True,
+        mind_quality="shadow_synthesis",
+        brief=MindHandoffBriefV1(
+            mind_quality="shadow_synthesis",
+            shadow_synthesis=shadow,
+            mind_authorized_for_stance_skip=False,
+            machine_contract={"mind.route_kind": "brain", "mind.shadow_synthesis_present": True},
+            stance_payload=dict(_VALID_STANCE),
+        ),
+    )
+
+    merge_mind_brief_into_plan_metadata(pr, result)
+    meta = pr.context["metadata"]
+    assert meta.get("mind_quality") == "shadow_synthesis"
+    assert meta.get("mind_shadow_synthesis_present") is True
+    assert meta.get("mind_shadow_synthesis", {}).get("schema_version") == "mind.shadow_synthesis.v1"
+    assert meta.get("mind_shadow_synthesis", {}).get("projection_refs_used") == ["node-1"]
+    assert meta.get("mind_authorized_for_stance_skip") is False
+    assert meta.get("mind_skip_stance_synthesis") is False
+    assert meta.get("mind_contract_only") is True
 
 
 def test_fallback_contract_only_mind_never_skips_stance_synthesis() -> None:
@@ -152,6 +220,7 @@ def test_meaningful_mind_with_invalid_payload_does_not_skip_stance_synthesis() -
         mind_quality="meaningful_synthesis",
         brief=MindHandoffBriefV1(
             mind_quality="meaningful_synthesis",
+            mind_authorized_for_stance_skip=True,
             machine_contract={"mind.route_kind": "brain"},
             stance_payload={"conversation_frame": "___invalid___"},
         ),

--- a/services/orion-mind/app/engine.py
+++ b/services/orion-mind/app/engine.py
@@ -18,6 +18,7 @@ from orion.mind.v1 import (
     MindHandoffBriefV1,
     MindRunRequestV1,
     MindRunResultV1,
+    MindShadowSynthesisV1,
     MindStancePatchV1,
     MindStanceTrajectoryV1,
     MindProvenanceV1,
@@ -184,8 +185,13 @@ def _snapshot_facets(snapshot: dict[str, Any]) -> dict[str, Any]:
     return dict(facets)
 
 
-def _cognitive_projection_debug(snapshot: dict[str, Any]) -> dict[str, Any]:
+def _cognitive_projection(snapshot: dict[str, Any]) -> dict[str, Any] | None:
     projection = _snapshot_facets(snapshot).get("cognitive_projection")
+    return projection if isinstance(projection, dict) else None
+
+
+def _cognitive_projection_debug(snapshot: dict[str, Any]) -> dict[str, Any]:
+    projection = _cognitive_projection(snapshot)
     if not isinstance(projection, dict):
         return {"present": False}
     anchors = projection.get("anchors") if isinstance(projection.get("anchors"), dict) else {}
@@ -200,6 +206,86 @@ def _cognitive_projection_debug(snapshot: dict[str, Any]) -> dict[str, Any]:
         "degraded_producers": projection.get("degraded_producers") if isinstance(projection.get("degraded_producers"), list) else [],
         "notes": projection.get("notes") if isinstance(projection.get("notes"), list) else [],
     }
+
+
+def _projection_items(projection: dict[str, Any] | None, *, limit: int = 8) -> list[dict[str, Any]]:
+    if not isinstance(projection, dict):
+        return []
+    anchors = projection.get("anchors") if isinstance(projection.get("anchors"), dict) else {}
+    items: list[dict[str, Any]] = []
+    for anchor, anchor_payload in anchors.items():
+        if not isinstance(anchor_payload, dict):
+            continue
+        for item in anchor_payload.get("items") or []:
+            if not isinstance(item, dict):
+                continue
+            enriched = dict(item)
+            enriched.setdefault("anchor", anchor)
+            items.append(enriched)
+    return sorted(
+        items,
+        key=lambda item: (float(item.get("salience") or 0.0), float(item.get("confidence") or 0.0), str(item.get("label") or "")),
+        reverse=True,
+    )[:limit]
+
+
+def _label_for_projection_item(item: dict[str, Any]) -> str:
+    for key in ("label", "summary", "node_id"):
+        value = item.get(key)
+        if value:
+            return str(value).strip()[:160]
+    return "projection item"
+
+
+def _build_shadow_synthesis(snapshot: dict[str, Any], base_stance: dict[str, Any]) -> MindShadowSynthesisV1 | None:
+    projection = _cognitive_projection(snapshot)
+    items = _projection_items(projection)
+    if not projection or not items:
+        return None
+
+    focus_items = items[:4]
+    labels = [_label_for_projection_item(item) for item in focus_items]
+    refs = [str(item.get("node_id") or item.get("item_id") or label) for item, label in zip(focus_items, labels)]
+    relationship_labels = [
+        _label_for_projection_item(item)
+        for item in focus_items
+        if str(item.get("anchor") or "").lower() == "relationship" or "relationship" in str(item.get("bucket") or "").lower()
+    ]
+    curiosity = []
+    if labels:
+        curiosity.append(f"Notice whether the turn connects to: {labels[0]}")
+    if len(labels) > 1:
+        curiosity.append(f"Consider a light follow-up around: {labels[1]}")
+
+    stance_candidate = dict(base_stance)
+    stance_candidate.update(
+        {
+            "stance_summary": "Shadow synthesis candidate from CognitiveProjectionV1; non-authoritative.",
+            "response_priorities": [
+                "use cognitive projection as context, not as truth",
+                "preserve current user turn",
+                "prefer concise, situated response",
+            ],
+            "active_relationship_facets": relationship_labels[:3],
+            "reflective_themes": labels[:4],
+        }
+    )
+    return MindShadowSynthesisV1(
+        present=True,
+        authorized_for_stance_skip=False,
+        stance_candidate=stance_candidate,
+        attention_focus=labels,
+        curiosity_candidate=curiosity,
+        relationship_frame=relationship_labels[0] if relationship_labels else None,
+        projection_refs_used=refs,
+        hazards=[
+            "shadow synthesis is non-authoritative",
+            "do not skip legacy chat stance from this candidate",
+            "do not invent facts beyond projection/source text",
+        ],
+        confidence=min(0.75, 0.35 + 0.05 * len(items)),
+        rationale="Deterministic shadow candidate extracted from top CognitiveProjectionV1 items for operator comparison.",
+    )
 
 
 def _elapsed_ms_wall_clock(t_run_start: float) -> float:
@@ -277,6 +363,7 @@ def run_mind_deterministic(
     layers: list[dict[str, Any]] = []
     t_loop = time.perf_counter()
     base = _default_stance_from_user_text(user_text)
+    shadow_synthesis = _build_shadow_synthesis(bounded, base)
     for i in range(n_loops):
         if _elapsed_ms_wall_clock(t_run_start) > wall_budget_ms:
             logger.info(
@@ -302,6 +389,9 @@ def run_mind_deterministic(
                 delta["cognitive_projection_seen"] = True
                 delta["cognitive_projection_id"] = cognitive_projection_debug.get("projection_id")
                 delta["cognitive_projection_item_count"] = cognitive_projection_debug.get("item_count")
+            if shadow_synthesis is not None:
+                delta["mind_shadow_synthesis_present"] = True
+                delta["mind_shadow_projection_refs_used"] = list(shadow_synthesis.projection_refs_used)
         else:
             delta["user_intent"] = base["user_intent"]
         layers.append(delta)
@@ -365,32 +455,46 @@ def run_mind_deterministic(
         mode_binding=mode_binding,  # type: ignore[arg-type]
         budgets={"wall_ms_remaining": float(req.policy.wall_time_ms_max), "truncated": _truncated},
     )
+    quality = "shadow_synthesis" if shadow_synthesis is not None else "fallback_contract_only"
     machine = {
         "mind.route_kind": decision.route_kind,
         "mind.allowed_verbs": decision.allowed_verbs,
         "mind.mode_suggestion": decision.mode_suggestion,
         "mind.mode_binding": decision.mode_binding,
-        "mind.quality": "fallback_contract_only",
+        "mind.quality": quality,
         "mind.cognitive_projection_seen": bool(cognitive_projection_debug.get("present")),
+        "mind.shadow_synthesis_present": shadow_synthesis is not None,
+        "mind.authorized_for_stance_skip": False,
     }
     if cognitive_projection_debug.get("present"):
         machine["mind.cognitive_projection_id"] = cognitive_projection_debug.get("projection_id")
         machine["mind.cognitive_projection_item_count"] = cognitive_projection_debug.get("item_count")
+    if shadow_synthesis is not None:
+        machine["mind.shadow_projection_refs_used"] = list(shadow_synthesis.projection_refs_used)
+        machine["mind.shadow_confidence"] = shadow_synthesis.confidence
     brief = MindHandoffBriefV1(
-        summary_one_paragraph="Fallback contract only — no meaningful Mind synthesis produced.",
+        summary_one_paragraph=(
+            "Shadow synthesis candidate produced from CognitiveProjectionV1; not authorized for stance skip."
+            if shadow_synthesis is not None
+            else "Fallback contract only — no meaningful Mind synthesis produced."
+        ),
         machine_contract=machine,
         mandatory_keys=["mind.route_kind", "mind.allowed_verbs"],
-        advisory_keys=["mind.mode_suggestion", "mind.quality", "mind.cognitive_projection_seen"],
+        advisory_keys=["mind.mode_suggestion", "mind.quality", "mind.cognitive_projection_seen", "mind.shadow_synthesis_present"],
         stance_payload=valid.model_dump(mode="json"),
-        mind_quality="fallback_contract_only",
+        mind_quality=quality,  # type: ignore[arg-type]
+        shadow_synthesis=shadow_synthesis,
+        mind_authorized_for_stance_skip=False,
     )
 
     phases["total_ms"] = _elapsed_ms_wall_clock(t_run_start)
     logger.info(
-        "mind_run_end mind_run_id=%s ok=True snapshot_hash=%s quality=fallback_contract_only cognitive_projection_seen=%s",
+        "mind_run_end mind_run_id=%s ok=True snapshot_hash=%s quality=%s cognitive_projection_seen=%s shadow_synthesis_present=%s",
         mind_run_id,
         snap_hash,
+        quality,
         bool(cognitive_projection_debug.get("present")),
+        shadow_synthesis is not None,
     )
 
     return MindRunResultV1(
@@ -404,6 +508,6 @@ def run_mind_deterministic(
         ),
         decision=decision,
         brief=brief,
-        mind_quality="fallback_contract_only",
+        mind_quality=quality,  # type: ignore[arg-type]
         timing_ms_by_phase=phases,
     )

--- a/services/orion-mind/tests/test_http_contract.py
+++ b/services/orion-mind/tests/test_http_contract.py
@@ -34,6 +34,34 @@ def client() -> TestClient:
     return TestClient(main_mod.app)
 
 
+def _projection_with_item() -> dict:
+    return {
+        "schema_version": "cognitive.projection.v1",
+        "projection_id": "cog-proj-http-test",
+        "generated_at": "2026-05-16T04:00:00+00:00",
+        "source": "cognitive_unification_layer",
+        "anchors": {
+            "orion": {
+                "anchor": "orion",
+                "items": [
+                    {
+                        "item_id": "item-1",
+                        "node_id": "node-1",
+                        "bucket": "concept",
+                        "node_kind": "concept",
+                        "label": "curiosity about Juniper life moment",
+                        "summary": "A candidate concept for noticing Juniper's shared life context.",
+                        "salience": 0.9,
+                        "confidence": 0.8,
+                    }
+                ],
+            }
+        },
+        "item_count": 1,
+        "notes": ["test_projection"],
+    }
+
+
 def test_health_ok(client: TestClient) -> None:
     r = client.get("/health")
     assert r.status_code == 200
@@ -56,16 +84,18 @@ def test_mind_run_deterministic_ok(client: TestClient) -> None:
     assert body.get("mind_run_id")
     assert body.get("mind_quality") == "fallback_contract_only"
     assert body.get("brief", {}).get("stance_payload")
+    assert body.get("brief", {}).get("shadow_synthesis") is None
+    assert body.get("brief", {}).get("mind_authorized_for_stance_skip") is False
 
 
-def test_mind_run_surfaces_cognitive_projection_seen_without_claiming_synthesis(client: TestClient) -> None:
+def test_mind_run_surfaces_cognitive_projection_seen_without_shadow_when_no_items(client: TestClient) -> None:
     projection = {
         "schema_version": "cognitive.projection.v1",
-        "projection_id": "cog-proj-http-test",
+        "projection_id": "cog-proj-empty-test",
         "generated_at": "2026-05-16T04:00:00+00:00",
         "source": "cognitive_unification_layer",
         "anchors": {"orion": {"anchor": "orion", "items": []}},
-        "item_count": 7,
+        "item_count": 0,
         "notes": ["test_projection"],
     }
     r = client.post(
@@ -84,6 +114,40 @@ def test_mind_run_surfaces_cognitive_projection_seen_without_claiming_synthesis(
     assert body.get("mind_quality") == "fallback_contract_only"
     machine = body.get("brief", {}).get("machine_contract") or {}
     assert machine.get("mind.cognitive_projection_seen") is True
-    assert machine.get("mind.cognitive_projection_id") == "cog-proj-http-test"
-    assert machine.get("mind.cognitive_projection_item_count") == 7
-    assert body.get("brief", {}).get("mind_quality") == "fallback_contract_only"
+    assert machine.get("mind.cognitive_projection_id") == "cog-proj-empty-test"
+    assert machine.get("mind.cognitive_projection_item_count") == 0
+    assert machine.get("mind.shadow_synthesis_present") is False
+    assert body.get("brief", {}).get("shadow_synthesis") is None
+    assert body.get("brief", {}).get("mind_authorized_for_stance_skip") is False
+
+
+def test_mind_run_emits_shadow_synthesis_from_projection_items_without_authority(client: TestClient) -> None:
+    r = client.post(
+        "/v1/mind/run",
+        json={
+            "correlation_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "snapshot_inputs": {
+                "user_text": "thanks, I'm going to watch a crazy show with Amanda, my wife :) ",
+                "facets": {"cognitive_projection": _projection_with_item()},
+            },
+            "policy": {"n_loops_max": 1, "wall_time_ms_max": 60000, "router_profile_id": "default"},
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("mind_quality") == "shadow_synthesis"
+    brief = body.get("brief") or {}
+    assert brief.get("mind_quality") == "shadow_synthesis"
+    assert brief.get("mind_authorized_for_stance_skip") is False
+    shadow = brief.get("shadow_synthesis") or {}
+    assert shadow.get("schema_version") == "mind.shadow_synthesis.v1"
+    assert shadow.get("present") is True
+    assert shadow.get("authorized_for_stance_skip") is False
+    assert shadow.get("confidence") > 0
+    assert "node-1" in shadow.get("projection_refs_used", [])
+    assert shadow.get("stance_candidate", {}).get("conversation_frame") == "playful_relational"
+    assert shadow.get("attention_focus")
+    assert shadow.get("hazards")
+    machine = brief.get("machine_contract") or {}
+    assert machine.get("mind.shadow_synthesis_present") is True
+    assert machine.get("mind.authorized_for_stance_skip") is False


### PR DESCRIPTION
## Summary

First safe **Mind shadow synthesis** slice.

Mind can now produce a structured stance candidate from `CognitiveProjectionV1`, but the candidate is explicitly non-authoritative and cannot skip legacy chat stance.

## What changed

### Contracts

Updates `orion/mind/v1.py`:

- adds `MindShadowSynthesisV1`
- adds `shadow_synthesis` to `MindHandoffBriefV1`
- adds `mind_authorized_for_stance_skip: bool = False`
- extends `MindQualityV1` with `shadow_synthesis`

### Mind engine

Updates `services/orion-mind/app/engine.py`:

- detects `snapshot_inputs.facets.cognitive_projection`
- extracts top projection items
- emits a deterministic `MindShadowSynthesisV1` candidate when projection items exist
- keeps `authorized_for_stance_skip=False`
- sets `mind_quality="shadow_synthesis"` only for comparison/debug
- preserves fallback behavior when no projection items exist

Shadow candidate includes:

- `stance_candidate`
- `attention_focus`
- `curiosity_candidate`
- `relationship_frame`
- `projection_refs_used`
- `hazards`
- `confidence`
- `rationale`

### Orch preservation / gate hardening

Updates `services/orion-cortex-orch/app/mind_runtime.py`:

- preserves `mind_shadow_synthesis` in plan metadata
- exposes `mind_shadow_synthesis_present`
- exposes `mind_authorized_for_stance_skip`
- hardens skip gate so `meaningful_synthesis` must also explicitly set `mind_authorized_for_stance_skip=True`
- `shadow_synthesis` never skips stance synthesis

## Tests

Adds/updates tests for:

- Mind HTTP fallback still emits no shadow and no authority
- empty projection is seen but does not produce shadow synthesis
- projection with items emits `mind_quality="shadow_synthesis"`
- shadow synthesis has refs/focus/hazards and `authorized_for_stance_skip=false`
- Orch preserves shadow synthesis metadata
- shadow synthesis never skips stance
- meaningful synthesis without explicit authorization does not skip stance

## Authority boundary

This PR does **not** promote Mind.

- No final LLM replacement
- No routing change
- No legacy ChatStanceBrief replacement
- No skip-gate relaxation
- `mind_authorized_for_stance_skip` remains false for shadow synthesis

Mind can propose. Mind cannot drive.

## Next phase

Expose `mind_shadow_synthesis` in the Hub Cognitive Comparison card as a fourth column beside:

- shared cognitive projection
- legacy ChatStanceBrief
- Mind handoff / quality
- Mind shadow synthesis candidate