### PR TITLE
Expose Mind shadow synthesis in Hub comparison card

### DIFF
--- a/services/orion-hub/static/js/thought-process.js
+++ b/services/orion-hub/static/js/thought-process.js
@@ -320,6 +320,56 @@
     };
   }
 
+  function normalizeMindShadowSynthesis(payload) {
+    const root = asObject(payload) || {};
+    const raw = asObject(root.raw) || {};
+    const sourceInputs = asObject(root.source_inputs) || asObject(raw.source_inputs) || {};
+    const finalPromptContract = asObject(root.final_prompt_contract) || asObject(raw.final_prompt_contract) || {};
+    const rootHandoff = asObject(root.mind_handoff) || {};
+    const rawHandoff = asObject(raw.mind_handoff) || {};
+    const sourceHandoff = asObject(sourceInputs.mind_handoff) || asObject(sourceInputs.mind) || {};
+    const contractHandoff = asObject(finalPromptContract.mind_handoff) || {};
+    const shadow = firstPresent([
+      root.mind_shadow_synthesis,
+      raw.mind_shadow_synthesis,
+      sourceInputs.mind_shadow_synthesis,
+      finalPromptContract.mind_shadow_synthesis,
+      rootHandoff.shadow_synthesis,
+      rawHandoff.shadow_synthesis,
+      sourceHandoff.shadow_synthesis,
+      contractHandoff.shadow_synthesis,
+    ]);
+    const shadowObject = asObject(shadow) || {};
+    const presentFlag = firstPresent([
+      root.mind_shadow_synthesis_present,
+      raw.mind_shadow_synthesis_present,
+      sourceInputs.mind_shadow_synthesis_present,
+      finalPromptContract.mind_shadow_synthesis_present,
+      shadowObject.present,
+    ]);
+    const authorizedForStanceSkip = firstPresent([
+      root.mind_authorized_for_stance_skip,
+      raw.mind_authorized_for_stance_skip,
+      sourceInputs.mind_authorized_for_stance_skip,
+      finalPromptContract.mind_authorized_for_stance_skip,
+      shadowObject.authorized_for_stance_skip,
+    ]);
+    return {
+      present: Boolean(shadow || presentFlag),
+      schemaVersion: shadowObject.schema_version || '--',
+      authorizedForStanceSkip,
+      confidence: shadowObject.confidence,
+      attentionFocus: asList(shadowObject.attention_focus),
+      curiosityCandidate: asList(shadowObject.curiosity_candidate),
+      relationshipFrame: shadowObject.relationship_frame,
+      projectionRefsUsed: asList(shadowObject.projection_refs_used),
+      hazards: asList(shadowObject.hazards),
+      rationale: shadowObject.rationale,
+      stanceCandidate: asObject(shadowObject.stance_candidate),
+      shadow: shadowObject,
+    };
+  }
+
   function renderProjectionCard(model, opts = {}) {
     const card = makeEl('section', 'rounded-xl border border-cyan-500/30 bg-cyan-500/5 p-3 space-y-3');
     card.id = opts.modal ? MODAL_CARD_ID : INLINE_CARD_ID;
@@ -397,6 +447,7 @@
     const projection = bundle ? normalizeProjectionBundle(bundle) : null;
     const legacy = normalizeLegacyChatStance(payload);
     const mind = normalizeMindHandoff(payload);
+    const shadow = normalizeMindShadowSynthesis(payload);
     const card = makeEl('section', 'rounded-xl border border-fuchsia-500/30 bg-fuchsia-500/5 p-3 space-y-3');
     card.id = opts.modal ? MODAL_COMPARE_ID : INLINE_COMPARE_ID;
 
@@ -405,7 +456,7 @@
     header.appendChild(makeEl('div', 'text-[10px] text-gray-400', 'read-only · no promotion'));
     card.appendChild(header);
 
-    const grid = makeEl('div', 'grid grid-cols-1 gap-3 xl:grid-cols-3');
+    const grid = makeEl('div', 'grid grid-cols-1 gap-3 xl:grid-cols-4');
     grid.appendChild(comparisonColumn(
       'Shared projection',
       projection ? (projection.used ? 'active' : 'present / inactive') : 'absent',
@@ -439,6 +490,20 @@
       ],
       { border: 'border-emerald-500/25', bg: 'bg-emerald-500/5', title: 'text-emerald-200' },
     ));
+    grid.appendChild(comparisonColumn(
+      'Mind shadow synthesis',
+      shadow.present ? 'present' : 'absent',
+      [
+        ['schema', shadow.schemaVersion || '--'],
+        ['authorized for skip', shadow.authorizedForStanceSkip === null || shadow.authorizedForStanceSkip === undefined ? '--' : String(shadow.authorizedForStanceSkip)],
+        ['confidence', shadow.confidence === null || shadow.confidence === undefined ? '--' : shadow.confidence],
+        ['attention focus', shadow.attentionFocus.length ? shadow.attentionFocus.slice(0, 3).join(' · ') : '--'],
+        ['curiosity candidate', shadow.curiosityCandidate.length ? shadow.curiosityCandidate.slice(0, 2).join(' · ') : '--'],
+        ['projection refs', shadow.projectionRefsUsed.length ? shadow.projectionRefsUsed.slice(0, 4).join(' · ') : '--'],
+        ['hazards', shadow.hazards.length ? shadow.hazards.slice(0, 3).join(' · ') : '--'],
+      ],
+      { border: 'border-amber-500/25', bg: 'bg-amber-500/5', title: 'text-amber-200' },
+    ));
     card.appendChild(grid);
 
     if (opts.modal) {
@@ -458,6 +523,19 @@
           skip_stance_synthesis: mind.skipStance,
           summary: mind.summary || null,
           handoff: mind.handoff || null,
+        },
+        mind_shadow_synthesis: {
+          present: shadow.present,
+          authorized_for_stance_skip: shadow.authorizedForStanceSkip,
+          confidence: shadow.confidence,
+          attention_focus: shadow.attentionFocus,
+          curiosity_candidate: shadow.curiosityCandidate,
+          relationship_frame: shadow.relationshipFrame,
+          projection_refs_used: shadow.projectionRefsUsed,
+          hazards: shadow.hazards,
+          rationale: shadow.rationale,
+          stance_candidate: shadow.stanceCandidate || null,
+          raw: shadow.shadow || null,
         },
       }, null, 2);
       raw.appendChild(pre);
@@ -519,7 +597,7 @@
     refresh();
   }
 
-  const api = { attach, refresh, normalizeProjectionBundle, normalizeLegacyChatStance, normalizeMindHandoff, renderFromPayload };
+  const api = { attach, refresh, normalizeProjectionBundle, normalizeLegacyChatStance, normalizeMindHandoff, normalizeMindShadowSynthesis, renderFromPayload };
   global.OrionChatStanceProjectionInspect = api;
   if (typeof document !== 'undefined') {
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', attach);

--- a/services/orion-hub/tests/test_chat_stance_debug_panel.py
+++ b/services/orion-hub/tests/test_chat_stance_debug_panel.py
@@ -86,7 +86,9 @@ def test_thought_process_js_renders_read_only_cognitive_comparison_surface() -> 
     assert "Shared projection" in thought_js
     assert "Legacy ChatStanceBrief" in thought_js
     assert "Mind handoff / quality" in thought_js
+    assert "Mind shadow synthesis" in thought_js
     assert "Raw comparison sources" in thought_js
+    assert "xl:grid-cols-4" in thought_js
 
 
 def test_thought_process_js_comparison_extracts_legacy_and_mind_fields() -> None:
@@ -102,11 +104,30 @@ def test_thought_process_js_comparison_extracts_legacy_and_mind_fields() -> None
     assert "mind_skip_stance_synthesis" in thought_js
 
 
+def test_thought_process_js_comparison_extracts_mind_shadow_synthesis_fields() -> None:
+    thought_js = THOUGHT_PROCESS_JS_PATH.read_text(encoding="utf-8")
+    assert "function normalizeMindShadowSynthesis" in thought_js
+    assert "mind_shadow_synthesis" in thought_js
+    assert "mind_shadow_synthesis_present" in thought_js
+    assert "mind_authorized_for_stance_skip" in thought_js
+    assert "authorized_for_stance_skip" in thought_js
+    assert "attention_focus" in thought_js
+    assert "curiosity_candidate" in thought_js
+    assert "relationship_frame" in thought_js
+    assert "projection_refs_used" in thought_js
+    assert "hazards" in thought_js
+    assert "stance_candidate" in thought_js
+
+
 def test_thought_process_js_comparison_does_not_promote_mind_or_change_routing() -> None:
     thought_js = THOUGHT_PROCESS_JS_PATH.read_text(encoding="utf-8")
     forbidden_mutations = [
         "mind_skip_stance_synthesis = true",
         "mind_skip_stance_synthesis=true",
+        "mind_authorized_for_stance_skip = true",
+        "mind_authorized_for_stance_skip=true",
+        "authorized_for_stance_skip = true",
+        "authorized_for_stance_skip=true",
         "meaningful_synthesis' &&",
         'meaningful_synthesis" &&',
         "fetch(`${API_BASE_URL}/api/chat`",


### PR DESCRIPTION
## Summary

Adds a fourth read-only column to the Hub Cognitive Comparison card for `mind_shadow_synthesis`.

The comparison card now shows:

- shared cognitive projection
- legacy ChatStanceBrief
- Mind handoff / quality
- Mind shadow synthesis

The shadow synthesis column displays compact fields from the non-authoritative Mind candidate, including schema, authorization flag, confidence, attention focus, curiosity candidate, projection refs, and hazards. The modal raw comparison sources now also include the normalized shadow synthesis payload.

## Authority boundary

This PR is display-only.

- No routing changes
- No final LLM replacement
- No legacy ChatStanceBrief replacement
- No skip-gate relaxation
- Mind shadow synthesis remains non-authoritative
- Mind can propose. Mind cannot drive.

## Tests

- Extends Hub chat stance debug panel tests for the fourth comparison column
- Asserts shadow synthesis fields are rendered/exposed
- Preserves no-promotion / no-routing-mutation guardrails

## Notes

I could not run the pytest command locally from this chat environment because the container cannot reach GitHub to clone the repo. The branch diff is limited to:

- `services/orion-hub/static/js/thought-process.js`
- `services/orion-hub/tests/test_chat_stance_debug_panel.py`

Suggested verification:

```bash
pytest services/orion-hub/tests/test_chat_stance_debug_panel.py -q
```