### PR TITLE
Share populated Mind projection with Chat Stance

### DIFF
--- a/services/orion-cortex-exec/app/chat_stance_shared_spine.py
+++ b/services/orion-cortex-exec/app/chat_stance_shared_spine.py
@@ -35,29 +35,69 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _projection_item_count(projection: dict[str, Any] | None) -> int:
+    if not isinstance(projection, dict):
+        return 0
+    try:
+        return int(projection.get("item_count") or 0)
+    except Exception:
+        return 0
+
+
+def _inline_projection_from_metadata(ctx: dict[str, Any]) -> dict[str, Any] | None:
+    metadata = ctx.get("metadata") if isinstance(ctx.get("metadata"), dict) else {}
+    for key in ("cognitive_projection_facet", "cognitive_projection"):
+        value = metadata.get(key) if isinstance(metadata, dict) else None
+        if isinstance(value, dict):
+            return value
+    return None
+
+
 def _record_shared_spine_marker(
     ctx: dict[str, Any],
     *,
     beliefs: UnifiedRelationalBeliefSetV1 | None,
     error: str | None = None,
+    inline_projection: dict[str, Any] | None = None,
 ) -> None:
     marker = {
         "enabled": True,
         "adapter": "services/orion-cortex-exec/app/chat_stance_shared_spine.py",
         "builder": "orion.cognition.projection_builder.unified_beliefs_for_chat_stance",
-        "beliefs_present": beliefs is not None,
-        "cold_anchors": list(getattr(beliefs, "cold_anchors", []) or []) if beliefs is not None else [],
-        "degraded_producers": list(getattr(beliefs, "degraded_producers", []) or []) if beliefs is not None else [],
-        "lineage": list(getattr(beliefs, "lineage", []) or []) if beliefs is not None else [],
+        "beliefs_present": beliefs is not None or isinstance(inline_projection, dict),
+        "cold_anchors": list(getattr(beliefs, "cold_anchors", []) or []) if beliefs is not None else list((inline_projection or {}).get("cold_anchors") or []),
+        "degraded_producers": list(getattr(beliefs, "degraded_producers", []) or []) if beliefs is not None else list((inline_projection or {}).get("degraded_producers") or []),
+        "lineage": list(getattr(beliefs, "lineage", []) or []) if beliefs is not None else list((inline_projection or {}).get("lineage") or []),
         "error": error,
     }
+    if isinstance(inline_projection, dict):
+        marker["projection_source"] = "orion_cortex_orch_mind_runtime"
+        marker["projection_reused_from_metadata"] = True
     ctx["chat_stance_shared_projection_spine"] = marker
     metadata = ctx.setdefault("metadata", {})
     if isinstance(metadata, dict):
         metadata["chat_stance_shared_projection_spine"] = marker
 
 
+def _record_projection_payload(ctx: dict[str, Any], payload: dict[str, Any], *, source_label: str) -> None:
+    ctx["chat_cognitive_projection"] = payload
+    ctx["chat_cognitive_projection_debug"] = {
+        "present": True,
+        "projection_id": payload.get("projection_id"),
+        "item_count": payload.get("item_count"),
+        "anchor_count": len(payload.get("anchors") or {}),
+        "cold_anchors": list(payload.get("cold_anchors") or []),
+        "degraded_producers": list(payload.get("degraded_producers") or []),
+        "notes": list(payload.get("notes") or []),
+        "source": source_label,
+    }
+
+
 def _record_projection_snapshot(ctx: dict[str, Any], beliefs: UnifiedRelationalBeliefSetV1 | None) -> None:
+    inline_projection = _inline_projection_from_metadata(ctx)
+    if isinstance(inline_projection, dict) and _projection_item_count(inline_projection) > 0:
+        _record_projection_payload(ctx, inline_projection, source_label="orion_cortex_orch_mind_runtime")
+        return
     if beliefs is None:
         ctx["chat_cognitive_projection"] = None
         ctx["chat_cognitive_projection_debug"] = {"present": False, "reason": "beliefs_absent"}
@@ -77,17 +117,7 @@ def _record_projection_snapshot(ctx: dict[str, Any], beliefs: UnifiedRelationalB
         ctx["chat_cognitive_projection"] = None
         ctx["chat_cognitive_projection_debug"] = {"present": False, "reason": "projection_none"}
         return
-    payload = projection.model_dump(mode="json")
-    ctx["chat_cognitive_projection"] = payload
-    ctx["chat_cognitive_projection_debug"] = {
-        "present": True,
-        "projection_id": payload.get("projection_id"),
-        "item_count": payload.get("item_count"),
-        "anchor_count": len(payload.get("anchors") or {}),
-        "cold_anchors": list(payload.get("cold_anchors") or []),
-        "degraded_producers": list(payload.get("degraded_producers") or []),
-        "notes": list(payload.get("notes") or []),
-    }
+    _record_projection_payload(ctx, projection.model_dump(mode="json"), source_label="exec_shared_spine")
 
 
 def _projection_debug_bundle(ctx: dict[str, Any]) -> dict[str, Any]:
@@ -147,6 +177,16 @@ def shared_unified_beliefs_for_stance(ctx: dict[str, Any]) -> UnifiedRelationalB
     and projection snapshot in ``ctx`` so Inspect/debug surfaces can prove which
     cognitive spine served the turn.
     """
+    inline_projection = _inline_projection_from_metadata(ctx)
+    if isinstance(inline_projection, dict) and _projection_item_count(inline_projection) > 0:
+        _record_shared_spine_marker(ctx, beliefs=None, inline_projection=inline_projection)
+        _record_projection_snapshot(ctx, None)
+        logger.info(
+            "chat_stance_shared_projection_spine_reused projection_id=%s item_count=%s",
+            inline_projection.get("projection_id"),
+            inline_projection.get("item_count"),
+        )
+        return None
     try:
         beliefs = unified_beliefs_for_chat_stance(
             ctx,

--- a/services/orion-cortex-orch/app/mind_runtime.py
+++ b/services/orion-cortex-orch/app/mind_runtime.py
@@ -8,13 +8,19 @@ from typing import Any
 
 import httpx
 
-from orion.cognition.projection_builder import build_cognitive_projection_for_context
+from orion.cognition.projection import project_unified_beliefs_for_mind
+from orion.cognition.projection_builder import (
+    build_cognitive_projection_for_context,
+    build_projection_unification_registry,
+)
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.mind.v1 import MindRunRequestV1, MindRunResultV1, MindRunPolicyV1
 from orion.schemas.chat_stance import ChatStanceBrief
 from orion.schemas.cortex.contracts import CortexClientRequest
 from orion.schemas.cortex.schemas import PlanExecutionRequest
 from orion.schemas.mind.artifact import MindRunArtifactV1
+from orion.substrate.relational import CognitiveUnificationLayer
+from orion.substrate.store import InMemorySubstrateGraphStore
 
 from .settings import get_settings
 
@@ -125,6 +131,15 @@ def _inline_cognitive_projection_facet(metadata: dict[str, Any]) -> dict[str, An
     return None
 
 
+def _projection_item_count(projection: dict[str, Any] | None) -> int:
+    if not isinstance(projection, dict):
+        return 0
+    try:
+        return int(projection.get("item_count") or 0)
+    except Exception:
+        return 0
+
+
 def _plan_projection_context(client_request: CortexClientRequest, plan_request: PlanExecutionRequest, correlation_id: str) -> dict[str, Any]:
     ctx = dict(plan_request.context or {}) if isinstance(plan_request.context, dict) else {}
     metadata = ctx.get("metadata") if isinstance(ctx.get("metadata"), dict) else {}
@@ -142,6 +157,37 @@ def _plan_projection_context(client_request: CortexClientRequest, plan_request: 
     return ctx
 
 
+def _build_cold_cognitive_projection_facet(ctx: dict[str, Any], correlation_id: str) -> dict[str, Any] | None:
+    """Build a fresh cold-path projection for Mind when Orch's warm path is empty.
+
+    Orch and Exec run in different processes. The default Orch projection can hit an
+    empty warm store while Exec later cold-materializes a populated projection for
+    ChatStanceDebug. For Mind shadow synthesis, prefer a fresh in-memory layer so
+    cold producers run for this turn and the resulting projection can be passed to
+    Exec as the shared per-turn object.
+    """
+    try:
+        registry = build_projection_unification_registry()
+        layer = CognitiveUnificationLayer(registry=registry, store=InMemorySubstrateGraphStore())
+        beliefs = layer.beliefs_for_stance(ctx=ctx, timeout_sec=5.0)
+        projection = project_unified_beliefs_for_mind(beliefs)
+    except Exception as exc:
+        logger.warning("mind_cognitive_projection_cold_build_failed corr=%s err=%s", correlation_id, exc)
+        return None
+    if projection is None:
+        return None
+    payload = projection.model_dump(mode="json")
+    logger.info(
+        "mind_cognitive_projection_cold_build corr=%s projection_id=%s item_count=%s cold_anchors=%s degraded=%s",
+        correlation_id,
+        payload.get("projection_id"),
+        payload.get("item_count"),
+        payload.get("cold_anchors"),
+        payload.get("degraded_producers"),
+    )
+    return payload
+
+
 def _build_cognitive_projection_facet(
     client_request: CortexClientRequest,
     plan_request: PlanExecutionRequest,
@@ -151,17 +197,34 @@ def _build_cognitive_projection_facet(
     inline = _inline_cognitive_projection_facet(meta)
     if inline is not None:
         return inline
+    ctx = _plan_projection_context(client_request, plan_request, correlation_id)
+    projection_payload: dict[str, Any] | None = None
     try:
         projection = build_cognitive_projection_for_context(
-            _plan_projection_context(client_request, plan_request, correlation_id),
+            ctx,
             publish_tier_outcomes=False,
         )
+        if projection is not None:
+            projection_payload = projection.model_dump(mode="json")
     except Exception as exc:
         logger.warning("mind_cognitive_projection_build_failed corr=%s err=%s", correlation_id, exc)
-        return None
-    if projection is None:
-        return None
-    return projection.model_dump(mode="json")
+
+    if _projection_item_count(projection_payload) <= 0:
+        cold_payload = _build_cold_cognitive_projection_facet(ctx, correlation_id)
+        if _projection_item_count(cold_payload) > _projection_item_count(projection_payload):
+            projection_payload = cold_payload
+
+    return projection_payload
+
+
+def _share_cognitive_projection_with_plan(plan_request: PlanExecutionRequest, projection: dict[str, Any]) -> None:
+    ctx = plan_request.context if isinstance(plan_request.context, dict) else {}
+    metadata = ctx.setdefault("metadata", {})
+    if not isinstance(metadata, dict):
+        return
+    metadata["cognitive_projection_facet"] = projection
+    metadata["cognitive_projection"] = projection
+    metadata["cognitive_projection_source"] = "orion_cortex_orch_mind_runtime"
 
 
 def build_mind_run_request(
@@ -210,6 +273,7 @@ def build_mind_run_request(
     )
     if cognitive_projection is not None:
         facets["cognitive_projection"] = cognitive_projection
+        _share_cognitive_projection_with_plan(plan_request, cognitive_projection)
     if facets:
         snapshot["facets"] = facets
     return MindRunRequestV1(

--- a/services/orion-hub/tests/test_chat_stance_debug_panel.py
+++ b/services/orion-hub/tests/test_chat_stance_debug_panel.py
@@ -7,6 +7,8 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 TEMPLATE_PATH = REPO_ROOT / "services" / "orion-hub" / "templates" / "index.html"
 APP_JS_PATH = REPO_ROOT / "services" / "orion-hub" / "static" / "js" / "app.js"
 THOUGHT_PROCESS_JS_PATH = REPO_ROOT / "services" / "orion-hub" / "static" / "js" / "thought-process.js"
+ORCH_MIND_RUNTIME_PATH = REPO_ROOT / "services" / "orion-cortex-orch" / "app" / "mind_runtime.py"
+EXEC_SHARED_SPINE_PATH = REPO_ROOT / "services" / "orion-cortex-exec" / "app" / "chat_stance_shared_spine.py"
 
 
 def test_template_includes_chat_stance_panel_and_outer_modal_button() -> None:
@@ -147,6 +149,22 @@ def test_thought_process_js_registers_grounded_small_lane_contract() -> None:
     assert "hub_chat_lane" in thought_js
     assert "patchWebSocketSend" in thought_js
     assert "patchFetch" in thought_js
+
+
+def test_mind_projection_handoff_reuses_one_populated_projection() -> None:
+    mind_runtime = ORCH_MIND_RUNTIME_PATH.read_text(encoding="utf-8")
+    shared_spine = EXEC_SHARED_SPINE_PATH.read_text(encoding="utf-8")
+
+    assert "_build_cold_cognitive_projection_facet" in mind_runtime
+    assert "InMemorySubstrateGraphStore" in mind_runtime
+    assert "metadata[\"cognitive_projection_facet\"] = projection" in mind_runtime
+    assert "metadata[\"cognitive_projection\"] = projection" in mind_runtime
+    assert "_share_cognitive_projection_with_plan(plan_request, cognitive_projection)" in mind_runtime
+
+    assert "_inline_projection_from_metadata" in shared_spine
+    assert "projection_reused_from_metadata" in shared_spine
+    assert "orion_cortex_orch_mind_runtime" in shared_spine
+    assert "chat_stance_shared_projection_spine_reused" in shared_spine
 
 
 def test_thought_process_js_comparison_does_not_promote_mind_or_change_routing() -> None:


### PR DESCRIPTION
## Summary

Fixes the projection mismatch found during Grounded Small validation.

Before this change, Mind could receive an empty CognitiveProjectionV1 while Chat Stance Debug later rendered a different populated projection for the same turn/correlation.

This PR makes Orch build a populated cold-path projection for Mind when the normal pre-Mind projection is empty, then passes that same projection through plan metadata so Exec Chat Stance Debug reuses it instead of rebuilding a second different projection.

## Expected result

For the same correlation:

- Mind `mind.cognitive_projection_id` should match Chat Stance Debug projection id
- Mind `mind.cognitive_projection_item_count` should match Chat Stance Debug item count
- If Chat Stance projection has items, Mind should no longer report item_count=0
- Shadow synthesis may become present when there are usable projection items

## Authority boundary

This does not promote Mind output, change routing, replace ChatStanceBrief, or relax stance skip gates. It only makes the projection handoff consistent.

## Tests

Adds guard assertions for the Orch -> Mind -> Exec shared projection handoff wiring.

Suggested verification:

```bash
pytest services/orion-hub/tests/test_chat_stance_debug_panel.py -q
```

I could not run pytest locally from this chat environment.