### PR TITLE
Fix/recall vector policy sql timeline substrate

### DIFF
--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -633,6 +633,8 @@ channels:
     stability: "experimental"
     since: "2026-01-08"
 
+  # RecallDecisionV1.recall_debug documented keys: RecallDebugV1 (vector_policy, source_gating).
+  # Substrate recall adapter diagnostics: RecallAdapterDiagnosticsV1 on mapped node metadata.
   - name: "orion:recall:telemetry"
     kind: "telemetry"
     schema_id: "RecallDecisionV1"

--- a/orion/cognition/tests/test_recall_sql_timeline_projection.py
+++ b/orion/cognition/tests/test_recall_sql_timeline_projection.py
@@ -1,0 +1,42 @@
+"""Mind projection integration — sql_timeline recall fragments enrich projection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orion.cognition.projection_builder import build_cognitive_projection_for_mind_with_diagnostics
+from orion.cognition.projection_context import enrich_projection_context
+
+
+def test_sql_timeline_recall_enriches_mind_projection_beyond_identity() -> None:
+    ctx: dict[str, Any] = {
+        "verb": "chat_general",
+        "orion_identity_summary": ["Oríon."],
+        "juniper_relationship_summary": ["Juniper."],
+        "response_policy_summary": ["Policy."],
+        "recall_bundle": {
+            "fragments": [
+                {
+                    "source": "sql_timeline",
+                    "source_ref": "chat_history_log",
+                    "tags": ["chat_timeline"],
+                    "snippet": "User: What is the Teddy launch plan?\nOrion: We agreed on phased rollout.",
+                },
+            ],
+            "citations": [],
+        },
+    }
+    enrich_projection_context(ctx)
+    projection, diag = build_cognitive_projection_for_mind_with_diagnostics(
+        ctx,
+        publish_tier_outcomes=False,
+        build_path="test.sql_timeline_projection",
+    )
+    assert projection is not None
+    assert int(projection.item_count or 0) >= 2
+    assert "recall" in (diag.get("projection_sources_returned") or [])
+    source_counts = diag.get("source_counts") or {}
+    assert source_counts.get("orion", 0) >= 1
+    categories = diag.get("category_counts") or {}
+    assert categories.get("event", 0) >= 1 or categories.get("concept", 0) >= 0
+    assert diag.get("input_summary", {}).get("recall_bundle_present") is True

--- a/orion/core/contracts/__init__.py
+++ b/orion/core/contracts/__init__.py
@@ -1,6 +1,18 @@
 """Shared contracts for bus message payloads."""
 
-from .recall import MemoryBundleV1, MemoryItemV1, MemoryBundleStatsV1, RecallQueryV1, RecallReplyV1, RecallDecisionV1  # noqa: F401
+from .recall import (  # noqa: F401
+    MemoryBundleV1,
+    MemoryBundleStatsV1,
+    MemoryItemV1,
+    RecallAdapterDiagnosticsV1,
+    RecallDebugV1,
+    RecallDecisionV1,
+    RecallQueryV1,
+    RecallReplyV1,
+    RecallSourceGatingV1,
+    RecallVectorPolicyPathV1,
+    RecallVectorPolicyV1,
+)
 from .memory_cards import (  # noqa: F401
     MemoryCardCreateV1,
     MemoryCardEdgeCreateV1,

--- a/orion/core/contracts/recall.py
+++ b/orion/core/contracts/recall.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
 class MemoryItemV1(BaseModel):
@@ -74,6 +74,81 @@ class RecallReplyV1(BaseModel):
     debug: Optional[Dict[str, Any]] = None
 
 
+RecallVectorPolicyReasonV1 = Literal[
+    "enabled",
+    "disabled_global",
+    "disabled_profile_vector_top_k_zero",
+    "disabled_profile_enable_vector_false",
+]
+
+
+class RecallVectorPolicyPathV1(BaseModel):
+    """Per-fetch-path vector gating outcome (see ``source_policy.recall_vector_allowed``)."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    allowed: bool
+    reason: RecallVectorPolicyReasonV1
+    profile: str = ""
+    vector_top_k: int = 0
+    recall_enable_vector: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("RECALL_ENABLE_VECTOR", "recall_enable_vector"),
+        serialization_alias="RECALL_ENABLE_VECTOR",
+    )
+    path: str = ""
+
+
+class RecallVectorPolicyV1(BaseModel):
+    """Path-keyed vector policy diagnostics attached under ``recall_debug.vector_policy``."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    main: Optional[RecallVectorPolicyPathV1] = None
+    anchor: Optional[RecallVectorPolicyPathV1] = None
+    graphtri: Optional[RecallVectorPolicyPathV1] = None
+    collectors: Optional[RecallVectorPolicyPathV1] = None
+    v2_shadow_exact: Optional[RecallVectorPolicyPathV1] = None
+    v2_shadow_semantic: Optional[RecallVectorPolicyPathV1] = None
+
+
+class RecallSourceGatingV1(BaseModel):
+    """Coarse source enablement labels under ``recall_debug.source_gating``."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    vector: Optional[str] = None
+    sql_timeline: Optional[str] = None
+    sql_chat: Optional[str] = None
+    rdf: Optional[str] = None
+
+
+class RecallAdapterDiagnosticsV1(BaseModel):
+    """Substrate recall adapter map/drop counters (``metadata.recall_adapter`` on first mapped node)."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    recall_fragments_seen: int = 0
+    recall_fragments_mapped: int = 0
+    recall_fragments_dropped: int = 0
+    dropped_counts_by_reason: Dict[str, int] = Field(default_factory=dict)
+    mapped_counts_by_source: Dict[str, int] = Field(default_factory=dict)
+    mapped_counts_by_node_type: Dict[str, int] = Field(default_factory=dict)
+    original_sources_seen: List[str] = Field(default_factory=list)
+
+
+class RecallDebugV1(BaseModel):
+    """Documented keys for ``RecallDecisionV1.recall_debug`` / v2 shadow debug payloads."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    vector_policy: Optional[RecallVectorPolicyV1] = None
+    source_gating: Optional[RecallSourceGatingV1] = None
+    compare_summary: Optional[Dict[str, Any]] = None
+    selected_evidence_cards: Optional[List[Dict[str, Any]]] = None
+    pressure_events: Optional[List[Dict[str, Any]]] = None
+
+
 class RecallDecisionV1(BaseModel):
     """Telemetry for recall decisions."""
 
@@ -92,7 +167,10 @@ class RecallDecisionV1(BaseModel):
     latency_ms: int = 0
     recall_debug: Dict[str, Any] = Field(
         default_factory=dict,
-        description="Bounded, structured diagnostics for recall decision explainability.",
+        description=(
+            "Bounded diagnostics for recall explainability. Documented shape: RecallDebugV1 "
+            "(vector_policy, source_gating, pressure_events, selected_evidence_cards)."
+        ),
     )
     ranking_debug: List[Dict[str, Optional[float | int | str | bool]]] = Field(
         default_factory=list,

--- a/orion/recall/profiles/assist.light.v1.yaml
+++ b/orion/recall/profiles/assist.light.v1.yaml
@@ -1,5 +1,5 @@
 profile: assist.light.v1
-# Low-latency lane: vector_top_k=0 disables all vector/Chroma recall (see worker._vector_enabled_for_profile).
+# Low-latency lane: vector_top_k=0 disables all vector/Chroma recall (see source_policy.recall_vector_allowed).
 # render_transcript_user_only still applies to transcript-shaped sql_chat rows if that backend is enabled.
 render_transcript_user_only: true
 vector_top_k: 0

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -10,7 +10,16 @@ from orion.core.bus.bus_schemas import (
     RecallRequestPayload,
     RecallResultPayload,
 )
-from orion.core.contracts.recall import RecallDecisionV1, RecallReplyV1, RecallQueryV1
+from orion.core.contracts.recall import (
+    RecallAdapterDiagnosticsV1,
+    RecallDebugV1,
+    RecallDecisionV1,
+    RecallQueryV1,
+    RecallReplyV1,
+    RecallSourceGatingV1,
+    RecallVectorPolicyPathV1,
+    RecallVectorPolicyV1,
+)
 from orion.core.verbs.models import VerbEffectV1, VerbRequestV1, VerbResultV1
 from orion.schemas.actions.daily import DailyMetacogV1, DailyPulseV1
 from orion.schemas.actions.mesh_ops import (
@@ -506,6 +515,11 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "RecallDecisionV1": RecallDecisionV1,
     "RecallReplyV1": RecallReplyV1,
     "RecallQueryV1": RecallQueryV1,
+    "RecallDebugV1": RecallDebugV1,
+    "RecallVectorPolicyV1": RecallVectorPolicyV1,
+    "RecallVectorPolicyPathV1": RecallVectorPolicyPathV1,
+    "RecallSourceGatingV1": RecallSourceGatingV1,
+    "RecallAdapterDiagnosticsV1": RecallAdapterDiagnosticsV1,
     "MindRunArtifactV1": MindRunArtifactV1,
     "SubstrateTierOutcomesPayloadV1": SubstrateTierOutcomesPayloadV1,
     "CortexClientRequest": CortexClientRequest,

--- a/orion/substrate/relational/adapters/recall.py
+++ b/orion/substrate/relational/adapters/recall.py
@@ -7,6 +7,7 @@ Fragment source tags:
   journal / metacog → ConceptNodeV1  (label = snippet)
   tension            → TensionNodeV1
   dream              → EventNodeV1
+  sql_timeline       → EventNodeV1 (conservative episodic mapping)
 """
 
 from __future__ import annotations
@@ -39,13 +40,133 @@ def _make_prov(*, source_tag: str) -> SubstrateProvenanceV1:
     )
 
 
-def _anchor_for_fragment(frag: dict[str, Any]) -> str:
-    subject = str(frag.get("subject") or frag.get("anchor") or "").lower()
-    if "relationship" in subject:
+def _tag_list(frag: dict[str, Any]) -> list[str]:
+    raw = frag.get("tags")
+    if isinstance(raw, list):
+        return [str(t).lower() for t in raw if t]
+    return []
+
+
+def _meta_dict(frag: dict[str, Any]) -> dict[str, Any]:
+    for key in ("metadata", "meta"):
+        val = frag.get(key)
+        if isinstance(val, dict):
+            return val
+    return {}
+
+
+def _anchor_hint(*parts: str) -> str:
+    joined = " ".join(p for p in parts if p).lower()
+    if "relationship" in joined:
         return "relationship"
-    if "juniper" in subject:
+    if "juniper" in joined or joined.strip() in {"user", "human"}:
         return "juniper"
     return _ANCHOR_DEFAULT
+
+
+def _anchor_for_fragment(frag: dict[str, Any]) -> str:
+    tags = _tag_list(frag)
+    meta = _meta_dict(frag)
+    return _anchor_hint(
+        str(frag.get("subject") or ""),
+        str(frag.get("anchor") or ""),
+        str(meta.get("subject") or ""),
+        str(meta.get("anchor") or ""),
+        " ".join(tags),
+        str(frag.get("source_ref") or ""),
+    )
+
+
+def _fragment_metadata(frag: dict[str, Any], *, source: str, snippet: str) -> dict[str, Any]:
+    meta = _meta_dict(frag)
+    out: dict[str, Any] = {
+        "recall_source": source,
+        "original_source": source,
+        "snippet": snippet,
+    }
+    if frag.get("source_ref"):
+        out["source_ref"] = frag.get("source_ref")
+    if tags := _tag_list(frag):
+        out["tags"] = tags
+    if frag.get("session_id"):
+        out["session_id"] = frag.get("session_id")
+    if frag.get("node_id"):
+        out["node_id"] = frag.get("node_id")
+    if meta.get("turn_effect_delta") is not None:
+        out["turn_effect_delta"] = meta.get("turn_effect_delta")
+    elif frag.get("turn_effect_delta") is not None:
+        out["turn_effect_delta"] = frag.get("turn_effect_delta")
+    return out
+
+
+def _map_sql_timeline_fragment(
+    frag: dict[str, Any],
+    *,
+    snippet: str,
+    temporal: Any,
+) -> tuple[Any | None, str]:
+    """Map sql_timeline fragment → conservative substrate node."""
+    source = "sql_timeline"
+    tags = _tag_list(frag)
+    source_ref = str(frag.get("source_ref") or "").lower()
+    anchor = _anchor_for_fragment(frag)
+    metadata = _fragment_metadata(frag, source=source, snippet=snippet)
+
+    tension_explicit = any(t in tags for t in ("tension", "pressure")) or "tension" in source_ref
+    if tension_explicit and any(t in tags for t in ("tension", "pressure", "turn_effect")):
+        return (
+            TensionNodeV1(
+                anchor_scope=anchor,
+                tension_kind="recall_timeline",
+                intensity=0.5,
+                temporal=temporal,
+                provenance=_make_prov(source_tag="sql_timeline.tension"),
+                signals=SubstrateSignalBundleV1(confidence=0.55, salience=0.45),
+                metadata={**metadata, "label": snippet},
+            ),
+            "tension",
+        )
+
+    if "chat_timeline" in tags or source_ref in ("chat_history_log", "chat_history"):
+        return (
+            EventNodeV1(
+                anchor_scope=anchor,
+                event_type="chat_timeline",
+                summary=snippet,
+                temporal=temporal,
+                provenance=_make_prov(source_tag="sql_timeline.chat"),
+                signals=SubstrateSignalBundleV1(confidence=0.5, salience=0.32),
+                metadata=metadata,
+            ),
+            "event.chat_timeline",
+        )
+
+    if source_ref == "collapse_mirror" or "collapse_mirror" in tags:
+        return (
+            EventNodeV1(
+                anchor_scope=anchor,
+                event_type="collapse_mirror",
+                summary=snippet,
+                temporal=temporal,
+                provenance=_make_prov(source_tag="sql_timeline.collapse_mirror"),
+                signals=SubstrateSignalBundleV1(confidence=0.55, salience=0.4),
+                metadata=metadata,
+            ),
+            "event.collapse_mirror",
+        )
+
+    return (
+        EventNodeV1(
+            anchor_scope=anchor,
+            event_type="timeline_memory",
+            summary=snippet,
+            temporal=temporal,
+            provenance=_make_prov(source_tag="sql_timeline"),
+            signals=SubstrateSignalBundleV1(confidence=0.48, salience=0.3),
+            metadata=metadata,
+        ),
+        "event.timeline_memory",
+    )
 
 
 def map_recall_bundle_to_substrate(ctx: dict[str, Any]) -> SubstrateGraphRecordV1 | None:
@@ -60,51 +181,91 @@ def map_recall_bundle_to_substrate(ctx: dict[str, Any]) -> SubstrateGraphRecordV
     now = datetime.now(timezone.utc)
     temporal = make_temporal(observed_at=now)
     nodes: list[Any] = []
+    dropped_counts: dict[str, int] = {}
+    mapped_counts_by_source: dict[str, int] = {}
+    mapped_counts_by_node_type: dict[str, int] = {}
+    original_sources_seen: set[str] = set()
+    recall_fragments_seen = 0
+    recall_fragments_mapped = 0
 
     for frag in fragments[:24]:
+        recall_fragments_seen += 1
         if not isinstance(frag, dict):
+            dropped_counts["non_dict_fragment"] = dropped_counts.get("non_dict_fragment", 0) + 1
             continue
         source = str(frag.get("source") or "").lower()
-        snippet = str(frag.get("snippet") or "").strip()[:200]
+        original_sources_seen.add(source or "unknown")
+        snippet = str(frag.get("snippet") or frag.get("text") or "").strip()[:200]
         if not snippet:
+            dropped_counts["missing_snippet"] = dropped_counts.get("missing_snippet", 0) + 1
             continue
 
         anchor = _anchor_for_fragment(frag)
+        mapped_node: Any | None = None
+        node_type_key = ""
 
         if "journal" in source or "metacog" in source:
-            nodes.append(
-                ConceptNodeV1(
-                    anchor_scope=anchor,
-                    label=snippet,
-                    temporal=temporal,
-                    provenance=_make_prov(source_tag="journal" if "journal" in source else "metacog"),
-                    signals=SubstrateSignalBundleV1(confidence=0.6, salience=0.4),
-                    metadata={"recall_source": source, "snippet": snippet},
-                )
+            mapped_node = ConceptNodeV1(
+                anchor_scope=anchor,
+                label=snippet,
+                temporal=temporal,
+                provenance=_make_prov(source_tag="journal" if "journal" in source else "metacog"),
+                signals=SubstrateSignalBundleV1(confidence=0.6, salience=0.4),
+                metadata=_fragment_metadata(frag, source=source, snippet=snippet),
             )
-        elif "tension" in source:
-            nodes.append(
-                TensionNodeV1(
-                    anchor_scope=anchor,
-                    tension_kind="recall",
-                    intensity=0.5,
-                    temporal=temporal,
-                    provenance=_make_prov(source_tag="tension"),
-                    signals=SubstrateSignalBundleV1(confidence=0.6, salience=0.5),
-                    metadata={"recall_source": source, "label": snippet, "snippet": snippet},
-                )
+            node_type_key = "concept"
+        elif "tension" in source and "sql_timeline" not in source:
+            mapped_node = TensionNodeV1(
+                anchor_scope=anchor,
+                tension_kind="recall",
+                intensity=0.5,
+                temporal=temporal,
+                provenance=_make_prov(source_tag="tension"),
+                signals=SubstrateSignalBundleV1(confidence=0.6, salience=0.5),
+                metadata={**_fragment_metadata(frag, source=source, snippet=snippet), "label": snippet},
             )
+            node_type_key = "tension"
         elif "dream" in source:
-            nodes.append(
-                EventNodeV1(
-                    anchor_scope=anchor,
-                    event_type="dream",
-                    summary=snippet,
-                    temporal=temporal,
-                    provenance=_make_prov(source_tag="dream"),
-                    signals=SubstrateSignalBundleV1(confidence=0.5, salience=0.3),
-                    metadata={"recall_source": source},
-                )
+            mapped_node = EventNodeV1(
+                anchor_scope=anchor,
+                event_type="dream",
+                summary=snippet,
+                temporal=temporal,
+                provenance=_make_prov(source_tag="dream"),
+                signals=SubstrateSignalBundleV1(confidence=0.5, salience=0.3),
+                metadata=_fragment_metadata(frag, source=source, snippet=snippet),
             )
+            node_type_key = "event.dream"
+        elif source == "sql_timeline" or "sql_timeline" in source:
+            mapped_node, node_type_key = _map_sql_timeline_fragment(frag, snippet=snippet, temporal=temporal)
+        else:
+            dropped_counts["unsupported_source"] = dropped_counts.get("unsupported_source", 0) + 1
+            continue
 
-    return SubstrateGraphRecordV1(anchor_scope=_ANCHOR_DEFAULT, nodes=nodes) if nodes else None
+        if mapped_node is None:
+            dropped_counts["map_failed"] = dropped_counts.get("map_failed", 0) + 1
+            continue
+
+        nodes.append(mapped_node)
+        recall_fragments_mapped += 1
+        mapped_counts_by_source[source or "unknown"] = mapped_counts_by_source.get(source or "unknown", 0) + 1
+        mapped_counts_by_node_type[node_type_key] = mapped_counts_by_node_type.get(node_type_key, 0) + 1
+
+    if not nodes:
+        return None
+
+    adapter_diag = {
+        "recall_fragments_seen": recall_fragments_seen,
+        "recall_fragments_mapped": recall_fragments_mapped,
+        "recall_fragments_dropped": recall_fragments_seen - recall_fragments_mapped,
+        "dropped_counts_by_reason": dropped_counts,
+        "mapped_counts_by_source": mapped_counts_by_source,
+        "mapped_counts_by_node_type": mapped_counts_by_node_type,
+        "original_sources_seen": sorted(original_sources_seen),
+    }
+    if nodes and hasattr(nodes[0], "metadata"):
+        first_meta = dict(getattr(nodes[0], "metadata", None) or {})
+        first_meta["recall_adapter"] = adapter_diag
+        nodes[0] = nodes[0].model_copy(update={"metadata": first_meta})
+
+    return SubstrateGraphRecordV1(anchor_scope=_ANCHOR_DEFAULT, nodes=nodes)

--- a/orion/substrate/relational/tests/test_adapters.py
+++ b/orion/substrate/relational/tests/test_adapters.py
@@ -257,6 +257,10 @@ class TestRecallAnchorRouting:
         from orion.substrate.relational.adapters.recall import _anchor_for_fragment
         assert _anchor_for_fragment({"subject": "juniper recall"}) == "juniper"
 
+    def test_juniper_from_tags(self):
+        from orion.substrate.relational.adapters.recall import _anchor_for_fragment
+        assert _anchor_for_fragment({"tags": ["juniper", "chat_timeline"]}) == "juniper"
+
     def test_relationship_routes_to_relationship(self):
         from orion.substrate.relational.adapters.recall import _anchor_for_fragment
         assert _anchor_for_fragment({"subject": "relationship memory"}) == "relationship"
@@ -265,6 +269,88 @@ class TestRecallAnchorRouting:
         from orion.substrate.relational.adapters.recall import _anchor_for_fragment
         assert _anchor_for_fragment({"subject": "orion self"}) == "orion"
         assert _anchor_for_fragment({}) == "orion"
+
+
+class TestRecallSqlTimelineMapping:
+    def test_chat_timeline_maps_to_event(self):
+        ctx = {
+            "recall_bundle": {
+                "fragments": [
+                    {
+                        "source": "sql_timeline",
+                        "source_ref": "chat_history_log",
+                        "tags": ["chat_timeline"],
+                        "snippet": "User: hi\nOrion: hello",
+                    }
+                ]
+            }
+        }
+        record = map_recall_bundle_to_substrate(ctx)
+        assert record is not None
+        events = [n for n in record.nodes if n.node_kind == "event"]
+        assert len(events) == 1
+        assert events[0].event_type == "chat_timeline"
+        assert events[0].metadata.get("source_ref") == "chat_history_log"
+        assert events[0].metadata.get("tags") == ["chat_timeline"]
+        assert events[0].metadata.get("snippet") == "User: hi\nOrion: hello"
+
+    def test_collapse_mirror_maps(self):
+        ctx = {
+            "recall_bundle": {
+                "fragments": [
+                    {
+                        "source": "sql_timeline",
+                        "source_ref": "collapse_mirror",
+                        "snippet": "mirror row text",
+                    }
+                ]
+            }
+        }
+        record = map_recall_bundle_to_substrate(ctx)
+        assert record is not None
+        events = [n for n in record.nodes if n.node_kind == "event"]
+        assert events[0].event_type == "collapse_mirror"
+
+    def test_explicit_tension_tags_map_conservatively(self):
+        ctx = {
+            "recall_bundle": {
+                "fragments": [
+                    {
+                        "source": "sql_timeline",
+                        "tags": ["tension", "turn_effect"],
+                        "snippet": "pressure noted explicitly",
+                    }
+                ]
+            }
+        }
+        record = map_recall_bundle_to_substrate(ctx)
+        assert record is not None
+        tensions = [n for n in record.nodes if n.node_kind == "tension"]
+        assert len(tensions) == 1
+
+    def test_empty_snippet_dropped_with_reason(self):
+        ctx = {"recall_bundle": {"fragments": [{"source": "sql_timeline", "snippet": ""}]}}
+        assert map_recall_bundle_to_substrate(ctx) is None
+
+    def test_unsupported_source_dropped(self):
+        ctx = {"recall_bundle": {"fragments": [{"source": "vector", "snippet": "should not map"}]}}
+        assert map_recall_bundle_to_substrate(ctx) is None
+
+    def test_adapter_diagnostics_on_first_node(self):
+        ctx = {
+            "recall_bundle": {
+                "fragments": [
+                    {"source": "journal", "snippet": "a"},
+                    {"source": "sql_timeline", "tags": ["chat_timeline"], "snippet": "b"},
+                ]
+            }
+        }
+        record = map_recall_bundle_to_substrate(ctx)
+        assert record is not None
+        diag = record.nodes[0].metadata.get("recall_adapter") or {}
+        assert diag.get("recall_fragments_seen") == 2
+        assert diag.get("recall_fragments_mapped") == 2
+        assert "sql_timeline" in (diag.get("original_sources_seen") or [])
 
 
 # ---------------------------------------------------------------------------

--- a/services/orion-recall/app/collectors.py
+++ b/services/orion-recall/app/collectors.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from typing import List
 
+from .profiles import get_profile
 from .settings import settings
+from .source_policy import recall_vector_allowed
 from .types import Fragment, RecallQuery
 from .storage.sql_adapter import fetch_sql_fragments
 from .storage.vector_adapter import fetch_vector_fragments
@@ -29,7 +31,9 @@ def collect_fragments(q: RecallQuery) -> List[Fragment]:
         )
 
     # Vector neighbors (Chroma / orion-vector-db)
-    if settings.RECALL_ENABLE_VECTOR and settings.RECALL_VECTOR_BASE_URL:
+    profile = get_profile(getattr(q, "profile", None) or settings.RECALL_DEFAULT_PROFILE)
+    vec_allowed, _ = recall_vector_allowed(profile, settings, path="collectors")
+    if vec_allowed and settings.RECALL_VECTOR_BASE_URL:
         fragments.extend(
             fetch_vector_fragments(
                 query_text=q.query_text,

--- a/services/orion-recall/app/recall_v2.py
+++ b/services/orion-recall/app/recall_v2.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 import time
 from dataclasses import dataclass
@@ -10,11 +11,15 @@ import requests
 
 from orion.core.contracts.recall import MemoryBundleStatsV1, MemoryBundleV1, MemoryItemV1, RecallQueryV1
 
+from .profiles import get_profile
 from .render import render_items
 from .settings import settings
+from .source_policy import build_vector_policy, log_vector_skipped, recall_vector_allowed
 from .sql_timeline import fetch_exact_fragments, fetch_recent_fragments
 from .storage.rdf_adapter import fetch_rdf_chatturn_exact_matches, fetch_rdf_fragments
 from .storage.vector_adapter import fetch_vector_exact_matches, fetch_vector_fragments
+
+logger = logging.getLogger("orion-recall.recall_v2")
 
 
 @dataclass(frozen=True)
@@ -124,9 +129,15 @@ def _pageindex_candidates(plan: RecallV2Plan, *, top_k: int = 8) -> List[Dict[st
     return out
 
 
-async def run_recall_v2_shadow(query: RecallQueryV1) -> tuple[MemoryBundleV1, Dict[str, Any]]:
+async def run_recall_v2_shadow(
+    query: RecallQueryV1,
+    *,
+    profile: Dict[str, Any] | None = None,
+) -> tuple[MemoryBundleV1, Dict[str, Any]]:
     started = time.time()
     plan = build_recall_v2_plan(query)
+    profile = profile if isinstance(profile, dict) else get_profile(str(query.profile or settings.RECALL_DEFAULT_PROFILE))
+    vector_policy = build_vector_policy(profile, settings)
     candidates: List[Dict[str, Any]] = []
     backend_counts: Dict[str, int] = {}
     filter_debug: Dict[str, Any] = {
@@ -158,21 +169,27 @@ async def run_recall_v2_shadow(query: RecallQueryV1) -> tuple[MemoryBundleV1, Di
                     "explain": {"exact_anchor": True, "backend": "sql_timeline"},
                 }
             )
-        vector_exact = fetch_vector_exact_matches(
-            tokens=list(plan.exact_anchor_tokens),
-            max_items=8,
-            session_id=query.session_id,
-            profile_name="recall.v2.shadow",
-            node_id=query.node_id,
-        )
-        backend_counts["vector_exact_anchor"] = len(vector_exact)
-        for row in vector_exact:
-            row = dict(row)
-            row["source"] = "vector"
-            row["score"] = max(0.7, float(row.get("score") or 0.0))
-            row["tags"] = list(row.get("tags") or []) + ["exact_anchor"]
-            row["explain"] = {"exact_anchor": True, "backend": "vector"}
-            candidates.append(row)
+        exact_allowed, exact_policy = recall_vector_allowed(profile, settings, path="v2_shadow_exact")
+        if exact_allowed:
+            vector_exact = fetch_vector_exact_matches(
+                tokens=list(plan.exact_anchor_tokens),
+                max_items=8,
+                session_id=query.session_id,
+                profile_name=profile.get("profile"),
+                node_id=query.node_id,
+            )
+            backend_counts["vector_exact_anchor"] = len(vector_exact)
+            for row in vector_exact:
+                row = dict(row)
+                row["source"] = "vector"
+                row["score"] = max(0.7, float(row.get("score") or 0.0))
+                row["tags"] = list(row.get("tags") or []) + ["exact_anchor"]
+                row["explain"] = {"exact_anchor": True, "backend": "vector"}
+                candidates.append(row)
+        else:
+            backend_counts["vector_exact_anchor"] = 0
+            log_vector_skipped("v2_shadow_exact", exact_policy, logger)
+
         rdf_exact = fetch_rdf_chatturn_exact_matches(tokens=list(plan.exact_anchor_tokens), session_id=query.session_id, max_items=8)
         backend_counts["rdf_exact_anchor"] = len(rdf_exact)
         for row in rdf_exact:
@@ -187,20 +204,25 @@ async def run_recall_v2_shadow(query: RecallQueryV1) -> tuple[MemoryBundleV1, Di
     backend_counts["pageindex_lexical"] = len(pageindex)
     candidates.extend(pageindex)
 
-    vector = fetch_vector_fragments(
-        query_text=plan.query_text,
-        time_window_days=plan.time_window_days,
-        max_items=10,
-        session_id=query.session_id,
-        profile_name="recall.v2.shadow",
-        node_id=query.node_id,
-    )
-    backend_counts["vector"] = len(vector)
-    for row in vector:
-        item = dict(row)
-        item["source"] = "vector"
-        item["explain"] = {"backend": "vector", "semantic_signal": float(item.get("score") or 0.0)}
-        candidates.append(item)
+    semantic_allowed, semantic_policy = recall_vector_allowed(profile, settings, path="v2_shadow_semantic")
+    if semantic_allowed:
+        vector = fetch_vector_fragments(
+            query_text=plan.query_text,
+            time_window_days=plan.time_window_days,
+            max_items=10,
+            session_id=query.session_id,
+            profile_name=profile.get("profile"),
+            node_id=query.node_id,
+        )
+        backend_counts["vector"] = len(vector)
+        for row in vector:
+            item = dict(row)
+            item["source"] = "vector"
+            item["explain"] = {"backend": "vector", "semantic_signal": float(item.get("score") or 0.0)}
+            candidates.append(item)
+    else:
+        backend_counts["vector"] = 0
+        log_vector_skipped("v2_shadow_semantic", semantic_policy, logger)
 
     rdf = fetch_rdf_fragments(query_text=plan.query_text, max_items=8)
     backend_counts["rdf"] = len(rdf)
@@ -277,15 +299,16 @@ async def run_recall_v2_shadow(query: RecallQueryV1) -> tuple[MemoryBundleV1, Di
     ]
     latency_ms = int((time.time() - started) * 1000)
     bundle = MemoryBundleV1(
-        rendered=render_items(items, 320, profile_name="recall.v2.shadow")[0],
+        rendered=render_items(items, 320, profile_name=str(profile.get("profile") or "recall.v2.shadow"))[0],
         items=items,
         stats=MemoryBundleStatsV1(
             backend_counts=backend_counts,
             latency_ms=latency_ms,
-            profile="recall.v2.shadow",
+            profile=str(profile.get("profile") or "recall.v2.shadow"),
             diagnostic={
                 "anchors": filter_debug,
                 "ranked_cards": top_cards,
+                "vector_policy": vector_policy,
             },
         ),
     )
@@ -301,6 +324,7 @@ async def run_recall_v2_shadow(query: RecallQueryV1) -> tuple[MemoryBundleV1, Di
         "filters": filter_debug,
         "backend_counts": backend_counts,
         "ranked_cards": top_cards,
+        "vector_policy": vector_policy,
         "latency_ms": latency_ms,
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }

--- a/services/orion-recall/app/source_policy.py
+++ b/services/orion-recall/app/source_policy.py
@@ -70,6 +70,7 @@ def build_vector_policy(
         "main",
         "anchor",
         "graphtri",
+        "collectors",
         "v2_shadow_exact",
         "v2_shadow_semantic",
     ),

--- a/services/orion-recall/app/source_policy.py
+++ b/services/orion-recall/app/source_policy.py
@@ -1,0 +1,99 @@
+"""Shared recall source policy — vector gating with path-specific diagnostics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .settings import settings
+
+
+def _profile_vector_top_k(profile: dict[str, Any]) -> int:
+    try:
+        return int(profile.get("vector_top_k", settings.RECALL_DEFAULT_MAX_ITEMS))
+    except Exception:
+        return 0
+
+
+def recall_vector_allowed(
+    profile: dict[str, Any],
+    settings_obj: Any | None = None,
+    *,
+    path: str,
+) -> tuple[bool, dict[str, Any]]:
+    """Return whether vector fetch is allowed for this profile/path and why."""
+    s = settings_obj or settings
+    profile_name = str(profile.get("profile") or "")
+    vector_top_k = _profile_vector_top_k(profile)
+    enable_vector = profile.get("enable_vector")
+    if enable_vector is False:
+        return False, {
+            "allowed": False,
+            "reason": "disabled_profile_enable_vector_false",
+            "profile": profile_name,
+            "vector_top_k": vector_top_k,
+            "RECALL_ENABLE_VECTOR": bool(getattr(s, "RECALL_ENABLE_VECTOR", True)),
+            "path": path,
+        }
+    if not bool(getattr(s, "RECALL_ENABLE_VECTOR", True)):
+        return False, {
+            "allowed": False,
+            "reason": "disabled_global",
+            "profile": profile_name,
+            "vector_top_k": vector_top_k,
+            "RECALL_ENABLE_VECTOR": False,
+            "path": path,
+        }
+    if vector_top_k <= 0:
+        return False, {
+            "allowed": False,
+            "reason": "disabled_profile_vector_top_k_zero",
+            "profile": profile_name,
+            "vector_top_k": vector_top_k,
+            "RECALL_ENABLE_VECTOR": bool(getattr(s, "RECALL_ENABLE_VECTOR", True)),
+            "path": path,
+        }
+    return True, {
+        "allowed": True,
+        "reason": "enabled",
+        "profile": profile_name,
+        "vector_top_k": vector_top_k,
+        "RECALL_ENABLE_VECTOR": bool(getattr(s, "RECALL_ENABLE_VECTOR", True)),
+        "path": path,
+    }
+
+
+def build_vector_policy(
+    profile: dict[str, Any],
+    settings_obj: Any | None = None,
+    *,
+    paths: tuple[str, ...] = (
+        "main",
+        "anchor",
+        "graphtri",
+        "v2_shadow_exact",
+        "v2_shadow_semantic",
+    ),
+) -> dict[str, dict[str, Any]]:
+    """Build path-keyed vector policy diagnostics for recall_debug."""
+    out: dict[str, dict[str, Any]] = {}
+    for path in paths:
+        allowed, detail = recall_vector_allowed(profile, settings_obj, path=path)
+        out[path] = {
+            "allowed": allowed,
+            "reason": detail["reason"],
+            "profile": detail["profile"],
+            "vector_top_k": detail["vector_top_k"],
+            "RECALL_ENABLE_VECTOR": detail["RECALL_ENABLE_VECTOR"],
+        }
+    return out
+
+
+def log_vector_skipped(path: str, detail: dict[str, Any], logger: Any) -> None:
+    logger.info(
+        "recall vector skipped path=%s reason=%s profile=%s vector_top_k=%s global_vector_enabled=%s",
+        path,
+        detail.get("reason"),
+        detail.get("profile"),
+        detail.get("vector_top_k"),
+        detail.get("RECALL_ENABLE_VECTOR"),
+    )

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -510,11 +510,6 @@ def _rdf_enabled(profile: Dict[str, Any]) -> bool:
     ) and int(profile.get("rdf_top_k", 0)) > 0
 
 
-def _vector_enabled_for_profile(profile: Dict[str, Any]) -> bool:
-    allowed, _ = recall_vector_allowed(profile, settings, path="main")
-    return allowed
-
-
 def _sql_timeline_enabled_for_profile(profile: Dict[str, Any]) -> bool:
     if not settings.RECALL_ENABLE_SQL_TIMELINE:
         return False

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -25,6 +25,7 @@ try:
     from .fusion import fuse_candidates
     from .profiles import get_profile
     from .settings import settings
+    from .source_policy import build_vector_policy, log_vector_skipped, recall_vector_allowed
     from .storage.rdf_adapter import (
         fetch_rdf_fragments,
         fetch_rdf_expansion_terms,
@@ -47,6 +48,7 @@ except ImportError as _e:  # pragma: no cover - fallback for runtime pathing
         from app.fusion import fuse_candidates  # type: ignore
         from app.profiles import get_profile  # type: ignore
         from app.settings import settings  # type: ignore
+        from app.source_policy import build_vector_policy, log_vector_skipped, recall_vector_allowed  # type: ignore
         from app.storage.rdf_adapter import (  # type: ignore
             fetch_rdf_fragments,
             fetch_rdf_expansion_terms,
@@ -509,12 +511,8 @@ def _rdf_enabled(profile: Dict[str, Any]) -> bool:
 
 
 def _vector_enabled_for_profile(profile: Dict[str, Any]) -> bool:
-    if not settings.RECALL_ENABLE_VECTOR:
-        return False
-    try:
-        return int(profile.get("vector_top_k", settings.RECALL_DEFAULT_MAX_ITEMS)) > 0
-    except Exception:
-        return False
+    allowed, _ = recall_vector_allowed(profile, settings, path="main")
+    return allowed
 
 
 def _sql_timeline_enabled_for_profile(profile: Dict[str, Any]) -> bool:
@@ -576,7 +574,8 @@ async def _fetch_anchor_candidates(
     except Exception as exc:
         logger.debug(f"sql anchor fetch skipped: {exc}")
 
-    if _vector_enabled_for_profile(profile):
+    vec_allowed, vec_policy = recall_vector_allowed(profile, settings, path="anchor")
+    if vec_allowed:
         try:
             vec = fetch_vector_exact_matches(
                 tokens=tokens,
@@ -595,14 +594,8 @@ async def _fetch_anchor_candidates(
                 candidates.append(item)
         except Exception as exc:
             logger.debug(f"vector anchor fetch skipped: {exc}")
-
     elif diagnostic:
-        logger.info(
-            "anchor rail vector skipped profile=%s vector_top_k=%s global_vector_enabled=%s",
-            profile.get("profile"),
-            profile.get("vector_top_k"),
-            settings.RECALL_ENABLE_VECTOR,
-        )
+        log_vector_skipped("anchor", vec_policy, logger)
 
     if _rdf_enabled(profile) and settings.RECALL_RDF_ENDPOINT_URL:
         try:
@@ -707,7 +700,8 @@ async def _query_backends(
             logger.debug(f"rdf backend skipped: {exc}")
 
 
-    if _vector_enabled_for_profile(profile):
+    vec_allowed, vec_policy = recall_vector_allowed(profile, settings, path="main")
+    if vec_allowed:
         seeds = [fragment, *entities]
         expansions = expansion_terms[:6]
         vector_queries: List[str] = []
@@ -754,14 +748,8 @@ async def _query_backends(
                 vector_queries,
                 vec_count,
             )
-
     elif diagnostic:
-        logger.info(
-            "recall vector skipped profile=%s vector_top_k=%s global_vector_enabled=%s",
-            profile.get("profile"),
-            profile.get("vector_top_k"),
-            settings.RECALL_ENABLE_VECTOR,
-        )
+        log_vector_skipped("main", vec_policy, logger)
 
     if diagnostic:
         logger.info(
@@ -1065,7 +1053,8 @@ async def process_recall(
     effective_session_id: str | None = None
     exclusion = _parse_exclusion(q)
     source_gating: Dict[str, str] = {}
-    source_gating["vector"] = "enabled" if _vector_enabled_for_profile(profile) else "disabled_by_profile_or_global"
+    vector_policy = build_vector_policy(profile, settings)
+    source_gating["vector"] = "enabled" if vector_policy.get("main", {}).get("allowed") else "disabled_by_profile_or_global"
     source_gating["sql_timeline"] = "enabled" if _sql_timeline_enabled_for_profile(profile) else "disabled_by_profile_or_global"
     source_gating["sql_chat"] = "enabled" if _sql_chat_enabled_for_profile(profile) else "disabled_by_profile_or_global"
     source_gating["rdf"] = "enabled" if _rdf_enabled(profile) else "disabled_by_profile_or_global"
@@ -1153,6 +1142,7 @@ async def process_recall(
                         "raw_fragment": q.fragment,
                     },
                     "source_gating": source_gating,
+                    "vector_policy": vector_policy,
                     "active_turn": {
                         "ids_count": len(list(exclusion.get("active_turn_ids") or [])),
                         "text_present": bool(str(exclusion.get("active_turn_text") or "").strip()),
@@ -1245,7 +1235,8 @@ async def process_recall(
                     candidates.extend(rdf_connected)
             except Exception as exc:
                 logger.debug(f"rdf backend skipped: {exc}")
-        if _vector_enabled_for_profile(profile):
+        graphtri_vec_allowed, graphtri_vec_policy = recall_vector_allowed(profile, settings, path="graphtri")
+        if graphtri_vec_allowed:
             source_gating["vector"] = "enabled"
             vector_top_k = int(profile.get("vector_top_k", settings.RECALL_DEFAULT_MAX_ITEMS))
             per_query = max(1, vector_top_k // max(1, len(vector_queries)))
@@ -1311,12 +1302,7 @@ async def process_recall(
 
         elif diagnostic:
             source_gating["vector"] = "disabled_by_profile_or_global"
-            logger.info(
-                "graphtri vector skipped profile=%s vector_top_k=%s global_vector_enabled=%s",
-                profile.get("profile"),
-                profile.get("vector_top_k"),
-                settings.RECALL_ENABLE_VECTOR,
-            )
+            log_vector_skipped("graphtri", graphtri_vec_policy, logger)
 
         sql_attempted = False
         sql_session_id = effective_session_id
@@ -1470,6 +1456,7 @@ async def process_recall(
                     "raw_fragment": q.fragment,
                 },
                 "source_gating": source_gating,
+                "vector_policy": vector_policy,
                 "active_turn": {
                     "ids_count": len(list(exclusion.get("active_turn_ids") or [])),
                     "text_present": bool(str(exclusion.get("active_turn_text") or "").strip()),
@@ -1495,7 +1482,7 @@ async def process_recall(
         try:
             from .recall_v2 import run_recall_v2_shadow
 
-            shadow_bundle, shadow_debug = await run_recall_v2_shadow(q)
+            shadow_bundle, shadow_debug = await run_recall_v2_shadow(q, profile=profile)
             compare_summary = {
                 "v1_latency_ms": decision.latency_ms,
                 "v2_latency_ms": int(shadow_debug.get("latency_ms") or 0),

--- a/services/orion-recall/tests/test_source_policy_vector.py
+++ b/services/orion-recall/tests/test_source_policy_vector.py
@@ -1,0 +1,156 @@
+"""Vector source policy — starvation and v2 shadow regression tests."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_RECALL_ROOT = _REPO / "services" / "orion-recall"
+if str(_RECALL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_RECALL_ROOT))
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from app import worker
+from app.profiles import get_profile, load_profiles
+from app.recall_v2 import run_recall_v2_shadow
+from app.source_policy import build_vector_policy, recall_vector_allowed
+from orion.core.contracts.recall import RecallQueryV1
+
+
+def test_recall_vector_allowed_global_off() -> None:
+    profile = {"profile": "reflect.v1", "vector_top_k": 8}
+    allowed, detail = recall_vector_allowed(profile, MagicMock(RECALL_ENABLE_VECTOR=False), path="main")
+    assert allowed is False
+    assert detail["reason"] == "disabled_global"
+
+
+def test_recall_vector_allowed_profile_top_k_zero() -> None:
+    load_profiles.cache_clear()
+    profile = get_profile("assist.light.v1")
+    allowed, detail = recall_vector_allowed(profile, MagicMock(RECALL_ENABLE_VECTOR=True), path="main")
+    assert allowed is False
+    assert detail["reason"] == "disabled_profile_vector_top_k_zero"
+
+
+def test_build_vector_policy_all_paths_disabled() -> None:
+    load_profiles.cache_clear()
+    profile = get_profile("assist.light.v1")
+    policy = build_vector_policy(profile, MagicMock(RECALL_ENABLE_VECTOR=True))
+    for path in ("main", "anchor", "graphtri", "v2_shadow_exact", "v2_shadow_semantic"):
+        assert policy[path]["allowed"] is False
+        assert policy[path]["reason"] == "disabled_profile_vector_top_k_zero"
+
+
+@pytest.mark.parametrize("global_on,vector_top_k", [(False, 8), (True, 0)])
+def test_query_backends_never_calls_vector_when_disabled(monkeypatch, global_on: bool, vector_top_k: int) -> None:
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_VECTOR", global_on)
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_SQL_CHAT", False)
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_SQL_TIMELINE", False)
+
+    def _fail_vector(**kwargs):
+        raise AssertionError("fetch_vector_fragments must not be called when vector disabled")
+
+    monkeypatch.setattr(worker, "fetch_vector_fragments", _fail_vector)
+
+    profile = {"profile": "reflect.v1", "vector_top_k": vector_top_k, "enable_sql_timeline": False, "rdf_top_k": 0}
+    candidates, counts = asyncio.run(
+        worker._query_backends(
+            "hello",
+            profile,
+            session_id=None,
+            node_id=None,
+            entities=[],
+            diagnostic=True,
+            exclusion={},
+        )
+    )
+    assert counts.get("vector", 0) == 0
+    assert not any(c.get("source") == "vector" for c in candidates)
+
+
+@pytest.mark.asyncio
+async def test_v2_shadow_no_vector_when_global_off(monkeypatch) -> None:
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_VECTOR", False)
+    monkeypatch.setattr("app.recall_v2.settings", worker.settings)
+
+    vec_frag_called = False
+    vec_exact_called = False
+
+    def _fail_frag(**kwargs):
+        nonlocal vec_frag_called
+        vec_frag_called = True
+        raise AssertionError("fetch_vector_fragments must not run")
+
+    def _fail_exact(**kwargs):
+        nonlocal vec_exact_called
+        vec_exact_called = True
+        raise AssertionError("fetch_vector_exact_matches must not run")
+
+    monkeypatch.setattr("app.recall_v2.fetch_vector_fragments", _fail_frag)
+    monkeypatch.setattr("app.recall_v2.fetch_vector_exact_matches", _fail_exact)
+
+    async def _empty_exact(**kw):
+        return []
+
+    async def _empty_recent(*a, **k):
+        return []
+
+    monkeypatch.setattr("app.recall_v2.fetch_exact_fragments", _empty_exact)
+    monkeypatch.setattr("app.recall_v2.fetch_recent_fragments", _empty_recent)
+    monkeypatch.setattr("app.recall_v2.fetch_rdf_chatturn_exact_matches", lambda **kw: [])
+    monkeypatch.setattr("app.recall_v2.fetch_rdf_fragments", lambda **kw: [])
+    monkeypatch.setattr("app.recall_v2._pageindex_candidates", lambda *a, **k: [])
+
+    q = RecallQueryV1(fragment="session abc123 token", profile="reflect.v1", verb="chat_general")
+    profile = get_profile("reflect.v1")
+    bundle, debug = await run_recall_v2_shadow(q, profile=profile)
+
+    assert not vec_frag_called
+    assert not vec_exact_called
+    assert not any(str(i.source) == "vector" for i in bundle.items)
+    assert debug["backend_counts"].get("vector", 0) == 0
+    assert debug["backend_counts"].get("vector_exact_anchor", 0) == 0
+    for path in ("v2_shadow_exact", "v2_shadow_semantic"):
+        assert debug["vector_policy"][path]["allowed"] is False
+
+
+@pytest.mark.asyncio
+async def test_v2_shadow_assist_light_no_vector(monkeypatch) -> None:
+    load_profiles.cache_clear()
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_VECTOR", True)
+    monkeypatch.setattr("app.recall_v2.settings", worker.settings)
+
+    monkeypatch.setattr("app.recall_v2.fetch_vector_fragments", lambda **kw: (_ for _ in ()).throw(AssertionError("vector")))
+    monkeypatch.setattr("app.recall_v2.fetch_vector_exact_matches", lambda **kw: (_ for _ in ()).throw(AssertionError("vector")))
+    async def _empty_exact(**kw):
+        return []
+
+    async def _empty_recent(*a, **k):
+        return []
+
+    monkeypatch.setattr("app.recall_v2.fetch_exact_fragments", _empty_exact)
+    monkeypatch.setattr("app.recall_v2.fetch_recent_fragments", _empty_recent)
+    monkeypatch.setattr("app.recall_v2.fetch_rdf_chatturn_exact_matches", lambda **kw: [])
+    monkeypatch.setattr("app.recall_v2.fetch_rdf_fragments", lambda **kw: [])
+    monkeypatch.setattr("app.recall_v2._pageindex_candidates", lambda *a, **k: [])
+
+    profile = get_profile("assist.light.v1")
+    q = RecallQueryV1(fragment="hello", profile="assist.light.v1", verb="chat_general")
+    bundle, debug = await run_recall_v2_shadow(q, profile=profile)
+
+    assert not any(str(i.source) == "vector" for i in bundle.items)
+    assert all(not debug["vector_policy"][p]["allowed"] for p in debug["vector_policy"])
+
+
+def test_vector_enabled_sanity(monkeypatch) -> None:
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_VECTOR", True)
+    profile = {"profile": "reflect.v1", "vector_top_k": 4}
+    allowed, detail = recall_vector_allowed(profile, worker.settings, path="main")
+    assert allowed is True
+    assert detail["reason"] == "enabled"

--- a/tests/test_recall_diagnostic_schema_registry.py
+++ b/tests/test_recall_diagnostic_schema_registry.py
@@ -1,0 +1,88 @@
+"""Recall diagnostic schemas are registered and validate production shapes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from orion.core.contracts.recall import (
+    RecallAdapterDiagnosticsV1,
+    RecallDebugV1,
+    RecallVectorPolicyPathV1,
+    RecallVectorPolicyV1,
+)
+from orion.schemas.registry import _REGISTRY, resolve
+
+ROOT = Path(__file__).resolve().parents[1]
+CHANNELS_YAML = ROOT / "orion" / "bus" / "channels.yaml"
+
+
+def test_recall_diagnostic_schemas_in_registry() -> None:
+    for schema_id in (
+        "RecallDebugV1",
+        "RecallVectorPolicyV1",
+        "RecallVectorPolicyPathV1",
+        "RecallSourceGatingV1",
+        "RecallAdapterDiagnosticsV1",
+    ):
+        assert schema_id in _REGISTRY
+        assert resolve(schema_id) is _REGISTRY[schema_id]
+
+
+def test_vector_policy_path_roundtrip() -> None:
+    raw = {
+        "allowed": False,
+        "reason": "disabled_profile_vector_top_k_zero",
+        "profile": "assist.light.v1",
+        "vector_top_k": 0,
+        "RECALL_ENABLE_VECTOR": True,
+        "path": "main",
+    }
+    model = RecallVectorPolicyPathV1.model_validate(raw)
+    dumped = model.model_dump(by_alias=True)
+    assert dumped["RECALL_ENABLE_VECTOR"] is True
+    assert dumped["reason"] == "disabled_profile_vector_top_k_zero"
+
+
+def test_recall_debug_validates_vector_policy_subset() -> None:
+    debug = RecallDebugV1.model_validate(
+        {
+            "vector_policy": {
+                "main": {
+                    "allowed": False,
+                    "reason": "disabled_global",
+                    "profile": "reflect.v1",
+                    "vector_top_k": 8,
+                    "RECALL_ENABLE_VECTOR": False,
+                    "path": "main",
+                }
+            },
+            "source_gating": {"vector": "disabled_by_profile_or_global", "sql_timeline": "enabled"},
+        }
+    )
+    assert debug.vector_policy is not None
+    assert debug.vector_policy.main is not None
+    assert debug.vector_policy.main.allowed is False
+
+
+def test_recall_telemetry_channel_still_recall_decision_v1() -> None:
+    doc = yaml.safe_load(CHANNELS_YAML.read_text(encoding="utf-8"))
+    channels = doc.get("channels") or []
+    entry = next(c for c in channels if c.get("name") == "orion:recall:telemetry")
+    assert entry["schema_id"] == "RecallDecisionV1"
+    assert "RecallDecisionV1" in _REGISTRY
+
+
+def test_adapter_diagnostics_shape() -> None:
+    RecallAdapterDiagnosticsV1.model_validate(
+        {
+            "recall_fragments_seen": 2,
+            "recall_fragments_mapped": 1,
+            "recall_fragments_dropped": 1,
+            "dropped_counts_by_reason": {"unsupported_source": 1},
+            "mapped_counts_by_source": {"sql_timeline": 1},
+            "mapped_counts_by_node_type": {"event.chat_timeline": 1},
+            "original_sources_seen": ["sql_timeline", "vector"],
+        }
+    )


### PR DESCRIPTION
# PR: Recall vector policy + SQL timeline Mind substrate mapping

## Branch

- **Head:** `fix/recall-vector-policy-sql-timeline-substrate`
- **Base:** `main` (or integration branch)
- **Worktree:** `.worktrees/recall-vector-sql-timeline`

---

## Summary

Two recall/Mind convergence fixes in one pass, kept as separate concerns:

1. **Problem A — vector leakage:** Centralized `recall_vector_allowed()` gates every vector fetch path (worker anchor/main/graphtri, v2 shadow exact/semantic, collectors). When vector is disabled globally or by profile, fetch functions are not called; diagnostics expose per-path `vector_policy`.
2. **Problem B — SQL timeline substrate:** `map_recall_bundle_to_substrate()` now maps `source=sql_timeline` fragments into conservative `EventNodeV1` / `TensionNodeV1` nodes so Mind projection is no longer identity-only when recall_bundle carries episodic timeline material.

**Arsonist constraint:** Vector is sealed; SQL timeline is opened for Mind projection.

---

## Vector entrypoint inventory (file:line)

| Path | Location | Gated by |
|------|----------|----------|
| Main semantic vector | `worker.py` `_query_backends` ~710–746 | `recall_vector_allowed(..., path="main")` |
| Exact-anchor vector | `worker.py` `_fetch_anchor_candidates` ~579–597 | `path="anchor"` |
| Graphtri vector rerank | `worker.py` `process_recall` graphtri block ~1248–1310 | `path="graphtri"` |
| V2 shadow exact vector | `recall_v2.py` ~168–186 | `path="v2_shadow_exact"` |
| V2 shadow semantic vector | `recall_v2.py` ~206–221 | `path="v2_shadow_semantic"` |
| Legacy collectors | `collectors.py` ~32–39 | `path="collectors"` |
| Vector adapter (low-level) | `storage/vector_adapter.py` `fetch_vector_fragments` / `fetch_vector_exact_matches` | Only reached via gated callers |
| Debug pressure / selected_evidence_cards | `worker.py` ~1496–1527 | Fed from v2 shadow output (no vector when policy disabled) |
| Render/fusion sort bias | `render.py`, `fusion.py` | Post-fetch only; no new vector fetch |

**Not changed (by design):** fusion/render may still *prefer* vector in ranking if vector candidates exist from an enabled profile — policy prevents fetch, not post-hoc normalization into fake journal sources.

---

## Source policy helper

`services/orion-recall/app/source_policy.py`:

```python
recall_vector_allowed(profile, settings, *, path: str) -> tuple[bool, dict]
```

**Reasons:** `enabled` | `disabled_global` | `disabled_profile_vector_top_k_zero` | `disabled_profile_enable_vector_false`

**Diagnostics shape** (in `recall_debug.vector_policy`):

```yaml
vector_policy:
  main: { allowed: false, reason: disabled_profile_vector_top_k_zero, ... }
  anchor: { ... }
  graphtri: { ... }
  collectors: { ... }
  v2_shadow_exact: { ... }
  v2_shadow_semantic: { ... }
```

**Logs:** `recall vector skipped path=<path> reason=... profile=... vector_top_k=... global_vector_enabled=...`

---

## SQL timeline substrate mapping

`orion/substrate/relational/adapters/recall.py`:

| Fragment signal | Node | event_type / kind |
|-----------------|------|-------------------|
| `sql_timeline` + `chat_timeline` tag / `chat_history_log` ref | `EventNodeV1` | `chat_timeline` |
| `source_ref=collapse_mirror` | `EventNodeV1` | `collapse_mirror` |
| tags `tension`/`pressure` + `turn_effect` (explicit) | `TensionNodeV1` | `recall_timeline` |
| otherwise | `EventNodeV1` | `timeline_memory` |

**Preserved metadata:** `recall_source`, `original_source`, `source_ref`, `tags`, `session_id`, `node_id`, `turn_effect_delta`, `snippet`

**Adapter diagnostics** (on first mapped node `metadata.recall_adapter`): `recall_fragments_seen/mapped/dropped`, `dropped_counts_by_reason`, `mapped_counts_by_source`, `mapped_counts_by_node_type`, `original_sources_seen`

**Anchor routing:** Uses `subject`, `anchor`, `tags`, `metadata.subject/anchor`, `source_ref` — no free-text vibe inference.

---

## Files changed

| File | Change |
|------|--------|
| `services/orion-recall/app/source_policy.py` | **new** shared vector policy |
| `services/orion-recall/app/worker.py` | Gate all vector paths; `vector_policy` in recall_debug; pass profile to v2 shadow |
| `services/orion-recall/app/recall_v2.py` | Profile-aware shadow; vector gates; `vector_policy` in debug |
| `services/orion-recall/app/collectors.py` | Policy-gated vector collect |
| `services/orion-recall/tests/test_source_policy_vector.py` | **new** tests A–D |
| `orion/substrate/relational/adapters/recall.py` | SQL timeline mapping + diagnostics |
| `orion/substrate/relational/tests/test_adapters.py` | Tests E–H |
| `orion/cognition/tests/test_recall_sql_timeline_projection.py` | **new** test I |
| `orion/recall/profiles/assist.light.v1.yaml` | Comment points to source_policy |

**Env / settings:** No new env keys; existing `RECALL_ENABLE_VECTOR`, profile `vector_top_k`, `enable_vector` honored.

**Schema registry / bus:** New documented diagnostic types in `orion/core/contracts/recall.py` — `RecallDebugV1`, `RecallVectorPolicyV1`, `RecallVectorPolicyPathV1`, `RecallSourceGatingV1`, `RecallAdapterDiagnosticsV1` — registered in `orion/schemas/registry.py`; `orion:recall:telemetry` channel comment in `orion/bus/channels.yaml`.

---

## Verification

```bash
cd /mnt/scripts/Orion-Sapienform/.worktrees/recall-vector-sql-timeline
PYTHONPATH=. /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest \
  services/orion-recall/tests/test_source_policy_vector.py \
  services/orion-recall/tests/test_profile_runtime_knobs.py \
  orion/substrate/relational/tests/test_adapters.py \
  orion/cognition/tests/test_recall_sql_timeline_projection.py \
  orion/cognition/tests/test_recall_prefetch.py::test_projection_producer_emits_recall_derived_items \
  -q --tb=short
```

- **Exit code:** 0
- **Result:** 58 passed

---

## Live verification (operator)

After redeploy recall, orch, exec, mind, hub, gateway:

1. `RECALL_ENABLE_VECTOR=false`, profile `reflect.v1`, `mind_enabled=true`, diagnostic on  
   - Expect: `recall_bundle_present=true`, no `source=vector` in bundle or v2 `selected_evidence_cards`, all `vector_policy.*.allowed=false`, `sql_timeline` may appear, Mind `item_count` > identity-only when timeline fragments exist, `projection_starved=false`.

2. `RECALL_ENABLE_VECTOR=true`, profile `assist.light.v1` (`vector_top_k=0`)  
   - Expect: same vector starvation via profile; SQL timeline per profile `enable_sql_timeline`.

**Live stack:** UNVERIFIED in this session (no redeploy/run).

---

## Test plan

- [x] A. Global vector off — no fetch, no vector in bundle/shadow/pressure, vector_policy disabled all paths
- [x] B. Profile vector off (`assist.light.v1`, `vector_top_k=0`)
- [x] C. V2 shadow regression with vector disabled
- [x] D. Vector enabled sanity (`reflect.v1`, `vector_top_k>0`)
- [x] E. SQL timeline chat maps to `EventNodeV1` `chat_timeline`
- [x] F. Collapse mirror maps
- [x] G. Explicit tension tags → `TensionNodeV1`
- [x] H. Empty/unsupported fragments dropped with diagnostics
- [x] I. Mind projection integration with sql_timeline recall_bundle
- [ ] Live gateway chat with recall prefetch + Mind parity

---

## Remaining gaps

| Gap | Notes |
|-----|-------|
| `sql_chat` fragments | Still `unsupported_source` in substrate adapter; separate change if Mind should surface chat-pair recall |
| Anchor/graphtri fail-fast tests | Only `main` + v2 have AssertionError mocks; policy logic is shared |
| `enable_vector: false` profile YAML | Supported in policy; no dedicated profile regression test yet |
| Live E2E | Requires redeploy + `RECALL_ENABLE_VECTOR` / profile matrix |

---

## Out of scope

- Mind LLM loops, prompt tuning, ontology, second projection builder
- Normalizing vector into fake journal/dream sources
- Removing SQL timeline because vector is bad
