### PR TITLE
Fix/ground small mind enabled

### DIFF
--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -497,6 +497,16 @@ def _autonomy_payload_from_ctx(ctx: Dict[str, Any]) -> Dict[str, Any]:
         if isinstance(biometrics, dict):
             reason = str(biometrics.get("reason") or reason)
         payload["turn_effect_missing_reason"] = reason
+    ctx_meta = ctx.get("metadata")
+    if isinstance(ctx_meta, dict):
+        for key in (
+            "mind_requested",
+            "mind_skip_reason",
+            "mind_invocation_failed",
+            "mind_artifact_persist_failed",
+        ):
+            if key in ctx_meta:
+                payload[key] = ctx_meta[key]
     return payload
 
 

--- a/services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py
+++ b/services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py
@@ -361,6 +361,23 @@ def test_autonomy_payload_omits_empty_turn_effect() -> None:
     assert md["turn_effect_missing_reason"] == "no_state_reply"
 
 
+def test_autonomy_payload_forwards_mind_status_from_ctx_metadata() -> None:
+    md = _autonomy_payload_from_ctx(
+        {
+            "metadata": {
+                "mind_requested": False,
+                "mind_skip_reason": "mind_enabled_not_true",
+                "mind_invocation_failed": "timeout",
+                "mind_artifact_persist_failed": True,
+            }
+        }
+    )
+    assert md["mind_requested"] is False
+    assert md["mind_skip_reason"] == "mind_enabled_not_true"
+    assert md["mind_invocation_failed"] == "timeout"
+    assert md["mind_artifact_persist_failed"] is True
+
+
 def test_router_exports_turn_effect_in_plan_metadata(monkeypatch) -> None:
     runner = PlanRunner()
     fake_step = StepExecutionResult(

--- a/services/orion-cortex-orch/app/orchestrator.py
+++ b/services/orion-cortex-orch/app/orchestrator.py
@@ -540,6 +540,7 @@ async def call_verb_runtime(
 
     cr_meta = client_request.context.metadata if isinstance(client_request.context.metadata, dict) else {}
     if _mind_enabled_exact(cr_meta):
+        plan_request.context.setdefault("metadata", {})["mind_requested"] = True
         from .mind_runtime import prepare_plan_context_for_mind_projection
 
         await prepare_plan_context_for_mind_projection(
@@ -585,6 +586,16 @@ async def call_verb_runtime(
         except Exception as mind_exc:
             logger.warning("mind_http_failed corr=%s err=%s", correlation_id, mind_exc)
             plan_request.context.setdefault("metadata", {})["mind_invocation_failed"] = str(mind_exc)
+    else:
+        raw_mind = cr_meta.get("mind_enabled") if isinstance(cr_meta, dict) else None
+        logger.info(
+            "mind_skipped corr=%s reason=mind_enabled_not_true metadata_value=%s metadata_type=%s",
+            correlation_id,
+            raw_mind,
+            type(raw_mind).__name__ if raw_mind is not None else "missing",
+        )
+        plan_request.context.setdefault("metadata", {})["mind_requested"] = False
+        plan_request.context["metadata"]["mind_skip_reason"] = "mind_enabled_not_true"
 
     use_direct_exec = settings.exec_lane_routing_enabled and lane_decision.lane != "chat"
     # Same id allocation as the verb envelope path so VerbResultV1.request_id is stable per invocation

--- a/services/orion-cortex-orch/tests/test_mind_skip_logging.py
+++ b/services/orion-cortex-orch/tests/test_mind_skip_logging.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+_guard = Path(__file__).resolve().parent / "_orch_import_guard.py"
+_spec = importlib.util.spec_from_file_location("_orch_guard_mind_skip", _guard)
+assert _spec and _spec.loader
+_guard_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guard_mod)
+
+ROOT = Path(__file__).resolve().parents[3]
+APP_ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+
+def _orch_prep() -> None:
+    _guard_mod.ensure_orion_cortex_orch_app()
+
+
+def test_call_verb_runtime_logs_and_marks_skip_when_mind_enabled_missing(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _orch_prep()
+    from app.orchestrator import call_verb_runtime
+    from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+    from orion.core.verbs.models import VerbResultV1
+    from orion.schemas.cortex.contracts import CortexClientContext, CortexClientRequest, LLMMessage
+    from orion.schemas.cortex.schemas import ExecutionPlan, ExecutionStep, PlanExecutionArgs, PlanExecutionRequest
+
+    class _PubSub:
+        def __init__(self, channel: str):
+            self.channel = channel
+
+    class _SubscribeCtx:
+        def __init__(self, channel: str):
+            self.pubsub = _PubSub(channel)
+
+        async def __aenter__(self):
+            return self.pubsub
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _FakeCodec:
+        def decode(self, data):
+            return SimpleNamespace(ok=True, envelope=data, error=None)
+
+    class _FakeBus:
+        def __init__(self):
+            self.codec = _FakeCodec()
+            self.published: list[tuple[str, BaseEnvelope]] = []
+
+        def subscribe(self, channel: str):
+            self.subscribed = channel
+            return _SubscribeCtx(channel)
+
+        async def publish(self, channel: str, env: BaseEnvelope):
+            self.published.append((channel, env))
+
+        async def iter_messages(self, pubsub: _PubSub):
+            _channel, env = self.published[0]
+            reply_env = BaseEnvelope(
+                kind="verb.result",
+                source=ServiceRef(name="cortex-exec", version="0", node="n"),
+                correlation_id=env.correlation_id,
+                payload=VerbResultV1(
+                    verb="legacy.plan",
+                    ok=True,
+                    output={"result": {"status": "success", "final_text": "ok", "metadata": {}}},
+                    request_id=env.payload["request_id"],
+                ).model_dump(mode="json"),
+            )
+            yield {"data": reply_env}
+
+    captured: dict = {}
+
+    def _fake_build_plan_request(client_request, correlation_id, router_metadata=None):
+        plan = PlanExecutionRequest(
+            plan=ExecutionPlan(
+                verb_name="chat_general",
+                steps=[ExecutionStep(verb_name="chat_general", step_name="noop", order=0, services=[])],
+            ),
+            args=PlanExecutionArgs(request_id="trace-1"),
+            context={"metadata": {}},
+        )
+        captured["plan"] = plan
+        return plan
+
+    monkeypatch.setattr("app.orchestrator.build_plan_request", _fake_build_plan_request)
+
+    async def _no_state(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.orchestrator._maybe_fetch_state", _no_state)
+    monkeypatch.setattr(
+        "app.orchestrator.get_settings",
+        lambda: SimpleNamespace(exec_lane_routing_enabled=False),
+    )
+
+    corr = str(uuid4())
+    with caplog.at_level(logging.INFO, logger="orion.cortex.orch"):
+        asyncio.run(
+            call_verb_runtime(
+                _FakeBus(),
+                source=ServiceRef(name="cortex-orch", version="0", node="n"),
+                client_request=CortexClientRequest(
+                    verb="chat_general",
+                    mode="brain",
+                    context=CortexClientContext(
+                        messages=[LLMMessage(role="user", content="hi")],
+                        session_id="s",
+                        trace_id="t",
+                        user_message="hi",
+                        metadata={},
+                    ),
+                ),
+                correlation_id=corr,
+                timeout_sec=5.0,
+            )
+        )
+
+    meta = captured["plan"].context.get("metadata") or {}
+    assert meta.get("mind_requested") is False
+    assert meta.get("mind_skip_reason") == "mind_enabled_not_true"
+    assert any(
+        "mind_skipped" in r.message and "mind_enabled_not_true" in r.message and corr in r.message
+        for r in caplog.records
+    )

--- a/services/orion-cortex-orch/tests/test_mind_skip_logging.py
+++ b/services/orion-cortex-orch/tests/test_mind_skip_logging.py
@@ -138,3 +138,120 @@ def test_call_verb_runtime_logs_and_marks_skip_when_mind_enabled_missing(
         "mind_skipped" in r.message and "mind_enabled_not_true" in r.message and corr in r.message
         for r in caplog.records
     )
+
+
+def test_call_verb_runtime_sets_mind_requested_when_mind_enabled_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _orch_prep()
+    from app.orchestrator import call_verb_runtime
+    from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+    from orion.core.verbs.models import VerbResultV1
+    from orion.schemas.cortex.contracts import CortexClientContext, CortexClientRequest, LLMMessage
+    from orion.schemas.cortex.schemas import ExecutionPlan, ExecutionStep, PlanExecutionArgs, PlanExecutionRequest
+
+    class _PubSub:
+        def __init__(self, channel: str):
+            self.channel = channel
+
+    class _SubscribeCtx:
+        def __init__(self, channel: str):
+            self.pubsub = _PubSub(channel)
+
+        async def __aenter__(self):
+            return self.pubsub
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _FakeCodec:
+        def decode(self, data):
+            return SimpleNamespace(ok=True, envelope=data, error=None)
+
+    class _FakeBus:
+        def __init__(self):
+            self.codec = _FakeCodec()
+            self.published: list[tuple[str, BaseEnvelope]] = []
+
+        def subscribe(self, channel: str):
+            return _SubscribeCtx(channel)
+
+        async def publish(self, channel: str, env: BaseEnvelope):
+            self.published.append((channel, env))
+
+        async def iter_messages(self, pubsub: _PubSub):
+            _channel, env = self.published[0]
+            reply_env = BaseEnvelope(
+                kind="verb.result",
+                source=ServiceRef(name="cortex-exec", version="0", node="n"),
+                correlation_id=env.correlation_id,
+                payload=VerbResultV1(
+                    verb="legacy.plan",
+                    ok=True,
+                    output={"result": {"status": "success", "final_text": "ok", "metadata": {}}},
+                    request_id=env.payload["request_id"],
+                ).model_dump(mode="json"),
+            )
+            yield {"data": reply_env}
+
+    captured: dict = {}
+
+    def _fake_build_plan_request(client_request, correlation_id, router_metadata=None):
+        plan = PlanExecutionRequest(
+            plan=ExecutionPlan(
+                verb_name="chat_general",
+                steps=[ExecutionStep(verb_name="chat_general", step_name="noop", order=0, services=[])],
+            ),
+            args=PlanExecutionArgs(request_id="trace-1"),
+            context={"metadata": {}},
+        )
+        captured["plan"] = plan
+        return plan
+
+    async def _noop_prepare(*args, **kwargs):
+        return None
+
+    async def _fake_mind_http(*args, **kwargs):
+        from orion.mind.v1 import MindRunResultV1
+
+        return MindRunResultV1(mind_run_id=uuid4(), ok=True, mind_quality="contract_only")
+
+    monkeypatch.setattr("app.orchestrator.build_plan_request", _fake_build_plan_request)
+    monkeypatch.setattr("app.orchestrator._maybe_fetch_state", lambda *a, **k: asyncio.sleep(0))
+    monkeypatch.setattr("app.mind_runtime.prepare_plan_context_for_mind_projection", _noop_prepare)
+    monkeypatch.setattr("app.orchestrator.build_mind_run_request", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr("app.orchestrator.call_orion_mind_http", _fake_mind_http)
+    monkeypatch.setattr("app.orchestrator.publish_mind_run_artifact", _noop_prepare)
+    monkeypatch.setattr("app.orchestrator.merge_mind_brief_into_plan_metadata", lambda *a, **k: None)
+    async def _no_substrate(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("app.orchestrator.fetch_substrate_telemetry_facet_for_mind", _no_substrate)
+    monkeypatch.setattr(
+        "app.orchestrator.get_settings",
+        lambda: SimpleNamespace(exec_lane_routing_enabled=False),
+    )
+
+    asyncio.run(
+        call_verb_runtime(
+            _FakeBus(),
+            source=ServiceRef(name="cortex-orch", version="0", node="n"),
+            client_request=CortexClientRequest(
+                verb="chat_general",
+                mode="brain",
+                context=CortexClientContext(
+                    messages=[LLMMessage(role="user", content="hi")],
+                    session_id="s",
+                    trace_id="t",
+                    user_message="hi",
+                    metadata={"mind_enabled": True},
+                ),
+            ),
+            correlation_id=str(uuid4()),
+            timeout_sec=5.0,
+        )
+    )
+
+    meta = captured["plan"].context.get("metadata") or {}
+    assert meta.get("mind_requested") is True
+    assert "mind_skip_reason" not in meta

--- a/services/orion-hub/scripts/cortex_request_builder.py
+++ b/services/orion-hub/scripts/cortex_request_builder.py
@@ -164,6 +164,47 @@ def _normalize_flag(value: Any, *, default: bool = False) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
+def _coerce_mind_enabled(value: Any) -> bool:
+    """Normalize boolean-ish mind_enabled values for Hub request building."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _mind_requested_from_payload(payload: Dict[str, Any]) -> Tuple[bool, Dict[str, Any]]:
+    """Inspect accepted mind_enabled locations; return requested flag + diagnostics."""
+    diagnostics: Dict[str, Any] = {
+        "mind_requested": False,
+        "mind_requested_source": None,
+        "mind_enabled_metadata_value": None,
+        "mind_enabled_metadata_type": None,
+    }
+    candidates: List[Tuple[str, Any]] = []
+    client_context = payload.get("context")
+    if isinstance(client_context, dict):
+        client_meta = client_context.get("metadata")
+        if isinstance(client_meta, dict) and "mind_enabled" in client_meta:
+            candidates.append(("payload.context.metadata.mind_enabled", client_meta.get("mind_enabled")))
+    if "mind_enabled" in payload:
+        candidates.append(("payload.mind_enabled", payload.get("mind_enabled")))
+    options = payload.get("options")
+    if isinstance(options, dict) and "mind_enabled" in options:
+        candidates.append(("payload.options.mind_enabled", options.get("mind_enabled")))
+
+    for source, raw_value in candidates:
+        diagnostics["mind_enabled_metadata_value"] = raw_value
+        diagnostics["mind_enabled_metadata_type"] = type(raw_value).__name__
+        if _coerce_mind_enabled(raw_value):
+            diagnostics["mind_requested"] = True
+            diagnostics["mind_requested_source"] = source
+            return True, diagnostics
+    return False, diagnostics
+
+
 def build_continuity_messages(
     *,
     history: Any,
@@ -464,9 +505,8 @@ def build_cortex_chat_request(
     mutation_cognition_context = payload.get("mutation_cognition_context")
     if isinstance(mutation_cognition_context, dict) and mutation_cognition_context:
         metadata["mutation_cognition_context"] = mutation_cognition_context
-    _client_context = payload.get("context")
-    _client_meta = _client_context.get("metadata") if isinstance(_client_context, dict) else None
-    if isinstance(_client_meta, dict) and _client_meta.get("mind_enabled") is True:
+    mind_requested, mind_diagnostics = _mind_requested_from_payload(payload)
+    if mind_requested:
         metadata["mind_enabled"] = True
     draft_ac = build_answer_contract_draft_for_hub(prompt)
     metadata["answer_contract_draft"] = draft_ac
@@ -669,6 +709,10 @@ def build_cortex_chat_request(
             else None
         ),
         "skill_runner_deterministic": bool(deterministic_requested),
+        "mind_requested": mind_diagnostics.get("mind_requested"),
+        "mind_requested_source": mind_diagnostics.get("mind_requested_source"),
+        "mind_enabled_metadata_value": mind_diagnostics.get("mind_enabled_metadata_value"),
+        "mind_enabled_metadata_type": mind_diagnostics.get("mind_enabled_metadata_type"),
     }
     if social_room:
         debug["social_skill_allowlist"] = metadata.get("social_skill_request", {}).get("allowlist") or []

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -993,9 +993,12 @@ loadDismissedIds();
     if (rawMeta.mind_invocation_failed) {
       return "Mind was requested but invocation failed.";
     }
-    const mindRequested = routing.mind_requested ?? rawMeta.mind_requested;
+    const mindRequested = rawMeta.mind_requested !== undefined && rawMeta.mind_requested !== null
+      ? rawMeta.mind_requested
+      : routing.mind_requested;
     if (mindRequested === false) {
-      return "Mind was not requested for this turn.";
+      const skipReason = rawMeta.mind_skip_reason ? ` (${rawMeta.mind_skip_reason})` : "";
+      return `Mind was not requested for this turn.${skipReason}`;
     }
     return "No Mind runs for this correlation yet.";
   }

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -981,7 +981,26 @@ loadDismissedIds();
     ).trim();
   }
 
-  function openMindRunsModal(correlationId, triggerEl = null) {
+  function resolveMindRunsEmptyStatus(turnMeta) {
+    const routing = turnMeta && typeof turnMeta.routingDebug === "object"
+      ? turnMeta.routingDebug
+      : (turnMeta && typeof turnMeta.routing_debug === "object" ? turnMeta.routing_debug : {});
+    const raw = turnMeta && typeof turnMeta.raw === "object" ? turnMeta.raw : {};
+    const rawMeta = raw && typeof raw.metadata === "object" ? raw.metadata : {};
+    if (rawMeta.mind_artifact_persist_failed) {
+      return "Mind ran but artifact publish failed.";
+    }
+    if (rawMeta.mind_invocation_failed) {
+      return "Mind was requested but invocation failed.";
+    }
+    const mindRequested = routing.mind_requested ?? rawMeta.mind_requested;
+    if (mindRequested === false) {
+      return "Mind was not requested for this turn.";
+    }
+    return "No Mind runs for this correlation yet.";
+  }
+
+  function openMindRunsModal(correlationId, triggerEl = null, turnMeta = null) {
     if (!mindRunsModal || !correlationId) return;
     mindModalLastFocus = triggerEl && typeof triggerEl.focus === "function" ? triggerEl : document.activeElement;
     mindRunsModal.classList.remove("hidden");
@@ -993,7 +1012,7 @@ loadDismissedIds();
       mindRunsModalDetails.textContent = "Select a run.";
     }
     enableMindModalFocusTrap();
-    refreshMindRunsForCorrelation(correlationId);
+    refreshMindRunsForCorrelation(correlationId, turnMeta);
     syncDebugModalScrollLock();
   }
 
@@ -1122,7 +1141,7 @@ loadDismissedIds();
     return await response.json();
   }
 
-  async function refreshMindRunsForCorrelation(correlationId) {
+  async function refreshMindRunsForCorrelation(correlationId, turnMeta = null) {
     if (!mindRunsModalList || !mindRunsModalStatus) return;
     if (!correlationId) {
       mindRunsModalStatus.textContent = "No correlation id available for this message.";
@@ -1141,7 +1160,7 @@ loadDismissedIds();
       }
       const rows = await response.json();
       if (!Array.isArray(rows) || rows.length === 0) {
-        mindRunsModalStatus.textContent = "No Mind runs for this correlation yet.";
+        mindRunsModalStatus.textContent = resolveMindRunsEmptyStatus(turnMeta);
         mindRunsModalList.innerHTML = '<div class="text-xs text-gray-500">No runs yet.</div>';
         if (mindRunsModalDetails) {
           mindRunsModalDetails.textContent = "Select a run.";
@@ -6416,7 +6435,7 @@ loadDismissedIds();
         mindButton.type = 'button';
         mindButton.className = 'rounded-full border border-indigo-500/40 bg-indigo-500/10 px-2 py-1 text-[10px] font-semibold text-indigo-200 hover:bg-indigo-500/20';
         mindButton.textContent = 'Mind';
-        mindButton.addEventListener('click', () => openMindRunsModal(mindCorrelationId, mindButton));
+        mindButton.addEventListener('click', () => openMindRunsModal(mindCorrelationId, mindButton, meta));
         actionRow.appendChild(mindButton);
       } else {
         const disabledMindButton = document.createElement('button');

--- a/services/orion-hub/static/js/thought-process.js
+++ b/services/orion-hub/static/js/thought-process.js
@@ -990,6 +990,9 @@
         ...(asObject(payload.surface_context) || {}),
         hub_chat_lane: LANE_GROUNDED_SMALL,
       };
+      payload.context = asObject(payload.context) || {};
+      payload.context.metadata = asObject(payload.context.metadata) || {};
+      payload.context.metadata.mind_enabled = true;
       return payload;
     }
 

--- a/services/orion-hub/tests/test_chat_stance_debug_panel.py
+++ b/services/orion-hub/tests/test_chat_stance_debug_panel.py
@@ -151,6 +151,7 @@ def test_thought_process_js_registers_grounded_small_lane_contract() -> None:
     assert "payload.verbs = [];" in thought_js
     assert "delete options.chat_quick_full_stance;" in thought_js
     assert "hub_chat_lane" in thought_js
+    assert "payload.context.metadata.mind_enabled = true" in thought_js
     assert "patchWebSocketSend" in thought_js
     assert "patchFetch" in thought_js
 

--- a/services/orion-hub/tests/test_mind_enabled_contract.py
+++ b/services/orion-hub/tests/test_mind_enabled_contract.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "cortex_request_builder.py"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+SPEC = importlib.util.spec_from_file_location("hub_cortex_request_builder_mind", MODULE_PATH)
+assert SPEC and SPEC.loader
+hub_builder = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(hub_builder)
+
+APP_JS = Path(__file__).resolve().parents[1] / "static" / "js" / "app.js"
+THOUGHT_JS = Path(__file__).resolve().parents[1] / "static" / "js" / "thought-process.js"
+
+
+def _build(payload: dict) -> tuple:
+    return hub_builder.build_chat_request(
+        payload=payload,
+        session_id="sid-mind",
+        user_id="user-1",
+        trace_id="trace-mind",
+        default_mode="brain",
+        auto_default_enabled=False,
+        source_label="hub_ws",
+        prompt="hello grounded small",
+    )
+
+
+def test_grounded_small_payload_sets_metadata_mind_enabled_true() -> None:
+    req, debug, _ = _build(
+        {
+            "mode": "brain",
+            "verbs": [],
+            "options": {"llm_route": "quick"},
+            "surface_context": {"hub_chat_lane": "grounded_small"},
+            "context": {"metadata": {"mind_enabled": True}},
+        }
+    )
+    assert req.metadata.get("mind_enabled") is True
+    assert debug.get("mind_requested") is True
+    assert debug.get("mind_requested_source") == "payload.context.metadata.mind_enabled"
+
+
+def test_context_metadata_mind_enabled_true_passes_through() -> None:
+    req, debug, _ = _build({"context": {"metadata": {"mind_enabled": True}}})
+    assert req.metadata.get("mind_enabled") is True
+    assert debug.get("mind_requested") is True
+
+
+def test_top_level_mind_enabled_true_is_normalized() -> None:
+    req, debug, _ = _build({"mind_enabled": True})
+    assert req.metadata.get("mind_enabled") is True
+    assert debug.get("mind_requested") is True
+    assert debug.get("mind_requested_source") == "payload.mind_enabled"
+
+
+def test_string_true_in_context_metadata_is_normalized() -> None:
+    req, debug, _ = _build({"context": {"metadata": {"mind_enabled": "true"}}})
+    assert req.metadata.get("mind_enabled") is True
+    assert debug.get("mind_requested") is True
+    assert debug.get("mind_enabled_metadata_type") == "str"
+
+
+def test_missing_mind_enabled_reports_not_requested() -> None:
+    req, debug, _ = _build({"mode": "brain"})
+    assert "mind_enabled" not in req.metadata
+    assert debug.get("mind_requested") is False
+    assert debug.get("mind_requested_source") is None
+
+
+def test_mind_requested_from_payload_helper_diagnostics() -> None:
+    requested, diag = hub_builder._mind_requested_from_payload(
+        {"options": {"mind_enabled": "yes"}, "context": {"metadata": {"mind_enabled": False}}}
+    )
+    assert requested is True
+    assert diag["mind_requested_source"] == "payload.options.mind_enabled"
+
+
+def test_hub_mind_panel_distinguishes_not_requested() -> None:
+    app_js = APP_JS.read_text(encoding="utf-8")
+    assert "resolveMindRunsEmptyStatus" in app_js
+    assert "Mind was not requested for this turn." in app_js
+    assert "Mind was requested but invocation failed." in app_js
+    assert "Mind ran but artifact publish failed." in app_js
+
+
+def test_grounded_small_lane_js_sets_context_metadata_mind_enabled() -> None:
+    thought_js = THOUGHT_JS.read_text(encoding="utf-8")
+    assert "payload.context.metadata.mind_enabled = true" in thought_js
+    assert "LANE_GROUNDED_SMALL" in thought_js


### PR DESCRIPTION
Live-verify branch fix/ground-small-mind-enabled.

Branch:
fix/ground-small-mind-enabled

Already fixed:
- Grounded Small outbound payload now sets context.metadata.mind_enabled=true.
- Hub normalizes legacy payload.mind_enabled / options.mind_enabled into metadata.
- Hub routing_debug exposes mind_requested diagnostics.
- Orch logs mind_skipped when mind_enabled is absent/not true.
- Orch writes mind_requested / mind_skip_reason to plan metadata.
- Exec forwards Mind status keys into result metadata.
- Hub Mind panel distinguishes:
  - Mind not requested
  - Mind invocation failed
  - artifact publish failed
  - no artifact yet

Tests passed:
- services/orion-hub/tests/test_mind_enabled_contract.py: 8 passed
- services/orion-cortex-orch/tests/test_mind_skip_logging.py: 2 passed
- services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py::test_autonomy_payload_forwards_mind_status_from_ctx_metadata: 1 passed

Task:
Redeploy/restart:
- hub
- orch
- exec
- mind
- gateway

Then run one Grounded Small turn from the UI.

Capture:
- correlation_id
- Hub routing_debug.mind_requested
- Hub routing_debug.mind_requested_source
- outbound payload shape if visible
- Orch logs for the correlation:
  - orch_execution_lane_decision
  - mind_recall_prefetch_start/result
  - mind_cognitive_projection...
  - mind_http_failed, if any
  - mind_artifact_publish_failed, if any
- Mind service logs:
  - POST /v1/mind/run
  - mind_run_id
  - mind_quality
  - projection item_count
- Hub Mind panel:
  - correlation-scoped run appears
  - details load

Expected:
- Grounded Small payload includes context.metadata.mind_enabled=true.
- Orch does not log mind_skipped.
- Mind HTTP is called.
- Mind artifact is published.
- Hub Mind panel shows the run for the same correlation.
- mind_quality should be shadow_synthesis if projection material is available.
- projection item_count should be > 0.

Failure interpretation:
- If routing_debug.mind_requested=false:
  Hub/JS payload fix did not reach server.
- If routing_debug.mind_requested=true but Orch logs mind_skipped:
  metadata changed/dropped between Hub and Orch.
- If Mind HTTP fails:
  check ORION_MIND_BASE_URL / mind container health.
- If Mind runs but panel empty:
  artifact publish or Hub query path issue.
- If Mind runs but starves:
  projection/recall path regression, separate from Grounded Small.