### PR TITLE
Fix/mind hub modal live verification

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-16-mind-hub-modal-live-verification-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-16-mind-hub-modal-live-verification-pr.md
@@ -1,118 +1,174 @@
-# PR: Fix Hub Mind modal live verification
+# PR: Hub Mind modal visibility + Orch→Mind service discovery
 
 **Branch:** `fix/mind-hub-modal-live-verification`
 
 ## Summary
 
-The Mind modal was empty because Hub read APIs required an exact `session_id` match while the browser’s active `orion_sid` often differed from the session stored on `mind_runs` for the same `correlation_id`. Rows existed in Postgres; `/api/mind/runs?correlation_id=…` returned `[]` when sessions diverged.
+Two live-verified fixes on one branch:
 
-This change keeps `/api/mind/runs/recent` strictly session-scoped, relaxes **correlation-specific** lookups with safe fallbacks (`session_match`, `session_id IS NULL`, optional `context_session_id` from the message turn), improves modal empty/error diagnostics, and adds orch publish logging for `session_id`.
+1. **Hub Mind modal empty** — `mind_runs` rows existed but `/api/mind/runs?correlation_id=…` returned `[]` when the browser `orion_sid` did not match the row’s `session_id`. Correlation-scoped reads now allow safe fallbacks; the frontend passes `context_session_id` from the message turn and shows session/correlation diagnostics on empty/error.
 
-## Root cause
+2. **No new `mind_runs` after orch recreate** — `ORION_MIND_BASE_URL` pointed at `orion-athena-mind:6611` while the live Mind container is `orion-mind` (`PROJECT=orion`). Orch logged `mind_http_failed` / DNS resolution failure. URL and compose network aliases were corrected; a new Mind-enabled turn now persists and appears in Hub API/UI.
+
+## Commits (this work)
+
+| Commit | Description |
+|--------|-------------|
+| `8c58daa1` | Hub modal session visibility (routes + `app.js` + tests) |
+| `62fb0ea9` | Orch `mind_run_artifact_publish` structured logging + publish test |
+| `91fb854d` | Orch Mind base URL + failure diagnostics + Mind compose aliases |
+| `70eb64cc` | This PR report |
+
+## Root causes
+
+### A. Modal / API session mismatch
 
 | Layer | Finding |
 |-------|---------|
-| **DB** | `mind_runs` has rows; no NULL `session_id` in recent data. Example: `correlation_id=e7256fd6…` stored under `session_id=eb6d05c4…` while browser used `723d819d…`. |
-| **API** | `WHERE correlation_id = $1 AND session_id = $2` returned `[]` on session mismatch. |
-| **UI** | Modal showed generic empty state; no correlation/session diagnostics. |
+| **DB** | Rows present; e.g. `correlation_id=e7256fd6…` under `session_id=eb6d05c4…` while browser had `723d819d…`. |
+| **API** | `WHERE correlation_id = $1 AND session_id = $2` returned `[]` on mismatch. |
+| **UI** | Generic “Select a run.” / “No runs yet.” with no session diagnostics. |
 
-## Changes
+### B. Orch → Mind DNS
+
+| Layer | Finding |
+|-------|---------|
+| **Config** | `ORION_MIND_BASE_URL=http://orion-athena-mind:6611` in orch `.env` / `.env_example`. |
+| **Runtime** | Mind `container_name` = `orion-mind` (`PROJECT=orion` in `services/orion-mind/.env`). |
+| **Orch logs** | `mind_http_failed … Temporary failure in name resolution` when calling Mind after container recreate. |
+| **From orch** | `getent hosts orion-mind` OK; `orion-athena-mind` failed until alias added. |
+
+## Files changed
 
 | File | Change |
 |------|--------|
-| `services/orion-hub/scripts/mind_routes.py` | Correlation list/detail: allow current session, NULL session, or `context_session_id`; add `session_visibility`; recent empty `diagnostics.hint`. |
-| `services/orion-hub/static/js/app.js` | Stamp `sessionId` on message meta; pass `context_session_id` from turn; richer modal empty/error copy; recent tab shows diagnostics hint. |
-| `services/orion-cortex-orch/app/mind_runtime.py` | Log `mind_run_artifact_publish` with `mind_run_id`, `correlation_id`, `session_id`, etc. |
-| `services/orion-hub/tests/test_mind_routes.py` | Session match, NULL fallback, context session, recent diagnostics. |
+| `services/orion-hub/scripts/mind_routes.py` | Correlation list/detail: current session, `NULL` session, or `context_session_id`; `session_visibility` on rows; recent empty `diagnostics.hint`. |
+| `services/orion-hub/static/js/app.js` | `sessionId` on message meta; `context_session_id` query param; `mindRunsEmptyDiagnostics`; improved modal/API error copy; recent tab diagnostics hint. |
+| `services/orion-hub/tests/test_mind_routes.py` | Session match, NULL fallback, context session, exclusion of other sessions, recent diagnostics. |
 | `services/orion-hub/tests/test_mind_hub_tab.py` | Static asserts for new JS helpers. |
-| `services/orion-cortex-orch/tests/test_mind_orch.py` | Artifact publish includes request `session_id`. |
+| `services/orion-cortex-orch/app/mind_runtime.py` | `mind_http_base_url`, `log_mind_http_failure`, `mind_run_artifact_publish` logging. |
+| `services/orion-cortex-orch/app/orchestrator.py` | Call structured `log_mind_http_failure` on Mind HTTP errors. |
+| `services/orion-cortex-orch/.env_example` | `ORION_MIND_BASE_URL=http://orion-mind:6611` + hostname comment. |
+| `services/orion-cortex-orch/tests/test_mind_orch.py` | Publish `session_id` test; base URL; failure log fields; HTTP client URL test. |
+| `services/orion-mind/docker-compose.yml` | `app-net` aliases: `orion-athena-mind`, `orion-mind`. |
+
+**Operator note:** Copy `ORION_MIND_BASE_URL` from `.env_example` into local `services/orion-cortex-orch/.env` (gitignored).
 
 ## Tests
 
 ```bash
+# Hub (12 passed)
 PYTHONPATH=. ./scripts/test_service.sh orion-hub \
   services/orion-hub/tests/test_mind_routes.py \
   services/orion-hub/tests/test_mind_hub_tab.py -q
-# 12 passed
 
+# Orch (16 passed)
 PYTHONPATH=. ./orion_dev/bin/python -m pytest \
-  services/orion-cortex-orch/tests/test_mind_orch.py::test_publish_mind_run_artifact_includes_request_session_id -q
-# 1 passed
+  services/orion-cortex-orch/tests/test_mind_orch.py -q
 ```
 
 ## Live verification
 
-### Phase 1 — DB (Postgres `orion-athena-sql-db`, user `postgres`, db `conjourney`)
+### Hub modal / read path
 
-- `mind_runs`: 97+ rows; latest `e7256fd6…` / `session_id=eb6d05c4…`
-- Session distribution: multiple distinct sessions; dominant `723d819d…` (89 rows)
+**DB** (`orion-athena-sql-db`, `postgres` / `conjourney`):
 
-### Phase 2 — API (Hub `http://127.0.0.1:8080`)
+- `mind_runs`: 97+ rows; multiple sessions; no NULL `session_id` in recent sample.
+
+**API** (`http://127.0.0.1:8080`):
 
 | Request | Result |
 |---------|--------|
-| `GET /api/mind/runs?correlation_id=e7256fd6…` + header `723d819d…` | `[]` (0 rows) |
+| `GET /api/mind/runs?correlation_id=e7256fd6…` + `X-Orion-Session-Id: 723d819d…` | `[]` |
 | Same + `context_session_id=eb6d05c4…` | **1 row**, `session_visibility=session_other` |
-| `GET /api/mind/runs/recent` + new session | `items: []`, `diagnostics.hint` present |
+| `GET /api/mind/runs/recent` + unknown session | `items: []`, `diagnostics.hint` present |
 
-### Phase 6 — New Mind-enabled turn
-
-- `POST /api/chat` with `mind_enabled: true` → `correlation_id=4a070376…`, `session_id=723d819d…`
-- **No `mind_runs` row** for that correlation: orch log `mind_http_failed … Temporary failure in name resolution` (Mind service DNS from recreated orch container). Infra blocker for end-to-end new-run proof, not a Hub modal read-path bug.
-
-### Hub redeploy
+**Hub redeploy:**
 
 ```bash
 docker compose --env-file .env --env-file services/orion-hub/.env \
   -f services/orion-hub/docker-compose.yml up -d hub-app
-# HTTP 200 on /
+# HTTP 200
+```
+
+### Orch → Mind / write path
+
+**DNS / health (inside `orion-athena-cortex-orch`):**
+
+```
+ORION_MIND_BASE_URL=http://orion-mind:6611
+getent hosts orion-athena-mind → 172.18.0.30  (after compose alias)
+curl -sf http://orion-mind:6611/health → {"ok":true,...}
+```
+
+**Mind-enabled chat:**
+
+```bash
+POST /api/chat  (mind_enabled: true, X-Orion-Session-Id: 723d819d…)
+# correlation_id=d6521171-242d-4b6d-9c8e-f746744d48ac
+# session_id=723d819d-e4a3-4b19-96db-62e96faf83f5
+# (LLM reply may timeout independently; Mind path succeeded)
+```
+
+**Orch log:**
+
+```
+mind_run_artifact_publish mind_run_id=ff35c6a9-7eb5-4ff9-bd5b-e30fd5901529
+  correlation_id=d6521171-242d-4b6d-9c8e-f746744d48ac
+  session_id=723d819d-e4a3-4b19-96db-62e96faf83f5 trigger=user_turn ok=True
+```
+
+**DB:**
+
+```sql
+SELECT mind_run_id, correlation_id, session_id, ok, trigger, created_at_utc
+FROM mind_runs
+WHERE correlation_id = 'd6521171-242d-4b6d-9c8e-f746744d48ac';
+-- 1 row: ff35c6a9-…, session_id=723d819d-…, ok=t, trigger=user_turn
+```
+
+**Hub API:**
+
+```bash
+GET /api/mind/runs?correlation_id=d6521171-…
+# 1 row, session_visibility=session_match
+
+GET /api/mind/runs/recent?hours=168&limit=5
+# New run first in list for session 723d819d…
+```
+
+**Services restarted:**
+
+```bash
+# Mind (aliases)
+cd services/orion-mind && docker compose --env-file .env up -d
+
+# Orch (rebuild + env)
+docker compose --env-file .env --env-file services/orion-cortex-orch/.env \
+  -f services/orion-cortex-orch/docker-compose.yml up -d --build
 ```
 
 ## Acceptance criteria
 
 | Criterion | Status |
 |-----------|--------|
-| Correlation API returns rows for modal when message session provided | **Pass** (live curl) |
-| Modal can show real run details (existing row) | **Pass** (API returns full `result_jsonb`) |
-| Recent tab session-scoped | **Pass** (SQL unchanged) |
-| New turn creates `mind_runs` with non-null `session_id` | **Blocked** (Mind HTTP DNS failure on orch during test) |
-| Tests pass | **Pass** |
-
-## Follow-up: Orch → Mind service discovery (same branch)
-
-### Root cause
-
-`ORION_MIND_BASE_URL=http://orion-athena-mind:6611` in orch, but Mind container is `orion-mind` (`PROJECT=orion` in `services/orion-mind/.env`). After orch recreate, DNS for `orion-athena-mind` failed (`Temporary failure in name resolution`).
-
-### Fix
-
-| Change | Purpose |
-|--------|---------|
-| `services/orion-cortex-orch/.env_example` → `http://orion-mind:6611` | Match live container hostname |
-| `services/orion-cortex-orch/.env` (local, gitignored) | Same |
-| `services/orion-mind/docker-compose.yml` | `app-net` aliases `orion-athena-mind`, `orion-mind` |
-| `mind_runtime.log_mind_http_failure` | Logs `mind_base_url`, `session_id`, `trigger`, `exc_type`, `status_code` |
-
-### Live proof (2026-05-17)
-
-| Step | Evidence |
-|------|----------|
-| Orch → Mind health | `curl -sf http://orion-mind:6611/health` OK; `getent hosts orion-athena-mind` resolves after alias |
-| Mind-enabled chat | `correlation_id=d6521171-242d-4b6d-9c8e-f746744d48ac` |
-| Orch publish | `mind_run_artifact_publish mind_run_id=ff35c6a9-… session_id=723d819d… ok=True` |
-| DB | 1 row, non-null `session_id`, `ok=t` |
-| API | `GET /api/mind/runs?correlation_id=…` → 1 row, `session_visibility=session_match` |
-| Recent tab | New run appears in `/api/mind/runs/recent` for session `723d819d…` |
+| Correlation API returns rows for modal (with message session when needed) | **Pass** |
+| Modal can show real run details (`result_jsonb` in list response) | **Pass** (API) |
+| Recent Mind tab session-scoped | **Pass** |
+| New Mind-enabled turn creates `mind_runs` with non-null `session_id` | **Pass** (`d6521171…`) |
+| Orch → Mind HTTP succeeds | **Pass** (`/health`, artifact publish) |
+| Hub + orch tests pass | **Pass** (12 + 16) |
 
 ## Remaining limitations
 
-1. **Mind tab “open run”** does not pass `turnMeta`; fine while recent list is session-scoped only.
-2. **`session_id IS NULL` fallback** widens correlation lookup for legacy rows; prod has no NULL sessions today—consider removing after backfill.
-3. **PROJECT mismatch**: orch stack uses `PROJECT=orion-athena`; Mind may run with `PROJECT=orion` — keep `ORION_MIND_BASE_URL` aligned with actual Mind `container_name` or use compose aliases.
+1. **Mind tab row click** does not pass `turnMeta` to the modal (OK while recent list is session-scoped).
+2. **`session_id IS NULL` fallback** on correlation lookup is for legacy rows only; prod sample had no NULL sessions.
+3. **`PROJECT` mismatch** between stacks (`orion-athena` vs `orion`) — keep `ORION_MIND_BASE_URL` aligned with Mind `container_name` or use compose aliases.
+4. **Browser UI** not automated here; hard-refresh Hub and open Mind on `d6521171…` message to confirm modal rendering.
 
-## Test plan (manual)
+## Manual test plan
 
-1. Hard refresh Hub; confirm `orion_sid` in localStorage.
-2. Open a message with Mind button from a prior session; modal should load runs when message `sessionId` differs from active session.
-3. Open Mind tab; confirm recent runs for current session only; empty state shows diagnostics hint.
-4. Send Mind-enabled chat; verify `mind_runs` row and modal after orch/Mind DNS is healthy.
+1. Hard refresh Hub; note `orion_sid` in localStorage.
+2. Open Mind on an older message whose `sessionId` differs from active session — runs should load via `context_session_id`.
+3. Send Mind-enabled chat; confirm Mind button opens modal with run id, ok, timestamps, request/result JSON.
+4. Open `#mind` tab; confirm recent table includes the new run for the current session.

--- a/docs/superpowers/pr-reports/2026-05-16-mind-hub-modal-live-verification-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-16-mind-hub-modal-live-verification-pr.md
@@ -1,0 +1,118 @@
+# PR: Fix Hub Mind modal live verification
+
+**Branch:** `fix/mind-hub-modal-live-verification`
+
+## Summary
+
+The Mind modal was empty because Hub read APIs required an exact `session_id` match while the browser’s active `orion_sid` often differed from the session stored on `mind_runs` for the same `correlation_id`. Rows existed in Postgres; `/api/mind/runs?correlation_id=…` returned `[]` when sessions diverged.
+
+This change keeps `/api/mind/runs/recent` strictly session-scoped, relaxes **correlation-specific** lookups with safe fallbacks (`session_match`, `session_id IS NULL`, optional `context_session_id` from the message turn), improves modal empty/error diagnostics, and adds orch publish logging for `session_id`.
+
+## Root cause
+
+| Layer | Finding |
+|-------|---------|
+| **DB** | `mind_runs` has rows; no NULL `session_id` in recent data. Example: `correlation_id=e7256fd6…` stored under `session_id=eb6d05c4…` while browser used `723d819d…`. |
+| **API** | `WHERE correlation_id = $1 AND session_id = $2` returned `[]` on session mismatch. |
+| **UI** | Modal showed generic empty state; no correlation/session diagnostics. |
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `services/orion-hub/scripts/mind_routes.py` | Correlation list/detail: allow current session, NULL session, or `context_session_id`; add `session_visibility`; recent empty `diagnostics.hint`. |
+| `services/orion-hub/static/js/app.js` | Stamp `sessionId` on message meta; pass `context_session_id` from turn; richer modal empty/error copy; recent tab shows diagnostics hint. |
+| `services/orion-cortex-orch/app/mind_runtime.py` | Log `mind_run_artifact_publish` with `mind_run_id`, `correlation_id`, `session_id`, etc. |
+| `services/orion-hub/tests/test_mind_routes.py` | Session match, NULL fallback, context session, recent diagnostics. |
+| `services/orion-hub/tests/test_mind_hub_tab.py` | Static asserts for new JS helpers. |
+| `services/orion-cortex-orch/tests/test_mind_orch.py` | Artifact publish includes request `session_id`. |
+
+## Tests
+
+```bash
+PYTHONPATH=. ./scripts/test_service.sh orion-hub \
+  services/orion-hub/tests/test_mind_routes.py \
+  services/orion-hub/tests/test_mind_hub_tab.py -q
+# 12 passed
+
+PYTHONPATH=. ./orion_dev/bin/python -m pytest \
+  services/orion-cortex-orch/tests/test_mind_orch.py::test_publish_mind_run_artifact_includes_request_session_id -q
+# 1 passed
+```
+
+## Live verification
+
+### Phase 1 — DB (Postgres `orion-athena-sql-db`, user `postgres`, db `conjourney`)
+
+- `mind_runs`: 97+ rows; latest `e7256fd6…` / `session_id=eb6d05c4…`
+- Session distribution: multiple distinct sessions; dominant `723d819d…` (89 rows)
+
+### Phase 2 — API (Hub `http://127.0.0.1:8080`)
+
+| Request | Result |
+|---------|--------|
+| `GET /api/mind/runs?correlation_id=e7256fd6…` + header `723d819d…` | `[]` (0 rows) |
+| Same + `context_session_id=eb6d05c4…` | **1 row**, `session_visibility=session_other` |
+| `GET /api/mind/runs/recent` + new session | `items: []`, `diagnostics.hint` present |
+
+### Phase 6 — New Mind-enabled turn
+
+- `POST /api/chat` with `mind_enabled: true` → `correlation_id=4a070376…`, `session_id=723d819d…`
+- **No `mind_runs` row** for that correlation: orch log `mind_http_failed … Temporary failure in name resolution` (Mind service DNS from recreated orch container). Infra blocker for end-to-end new-run proof, not a Hub modal read-path bug.
+
+### Hub redeploy
+
+```bash
+docker compose --env-file .env --env-file services/orion-hub/.env \
+  -f services/orion-hub/docker-compose.yml up -d hub-app
+# HTTP 200 on /
+```
+
+## Acceptance criteria
+
+| Criterion | Status |
+|-----------|--------|
+| Correlation API returns rows for modal when message session provided | **Pass** (live curl) |
+| Modal can show real run details (existing row) | **Pass** (API returns full `result_jsonb`) |
+| Recent tab session-scoped | **Pass** (SQL unchanged) |
+| New turn creates `mind_runs` with non-null `session_id` | **Blocked** (Mind HTTP DNS failure on orch during test) |
+| Tests pass | **Pass** |
+
+## Follow-up: Orch → Mind service discovery (same branch)
+
+### Root cause
+
+`ORION_MIND_BASE_URL=http://orion-athena-mind:6611` in orch, but Mind container is `orion-mind` (`PROJECT=orion` in `services/orion-mind/.env`). After orch recreate, DNS for `orion-athena-mind` failed (`Temporary failure in name resolution`).
+
+### Fix
+
+| Change | Purpose |
+|--------|---------|
+| `services/orion-cortex-orch/.env_example` → `http://orion-mind:6611` | Match live container hostname |
+| `services/orion-cortex-orch/.env` (local, gitignored) | Same |
+| `services/orion-mind/docker-compose.yml` | `app-net` aliases `orion-athena-mind`, `orion-mind` |
+| `mind_runtime.log_mind_http_failure` | Logs `mind_base_url`, `session_id`, `trigger`, `exc_type`, `status_code` |
+
+### Live proof (2026-05-17)
+
+| Step | Evidence |
+|------|----------|
+| Orch → Mind health | `curl -sf http://orion-mind:6611/health` OK; `getent hosts orion-athena-mind` resolves after alias |
+| Mind-enabled chat | `correlation_id=d6521171-242d-4b6d-9c8e-f746744d48ac` |
+| Orch publish | `mind_run_artifact_publish mind_run_id=ff35c6a9-… session_id=723d819d… ok=True` |
+| DB | 1 row, non-null `session_id`, `ok=t` |
+| API | `GET /api/mind/runs?correlation_id=…` → 1 row, `session_visibility=session_match` |
+| Recent tab | New run appears in `/api/mind/runs/recent` for session `723d819d…` |
+
+## Remaining limitations
+
+1. **Mind tab “open run”** does not pass `turnMeta`; fine while recent list is session-scoped only.
+2. **`session_id IS NULL` fallback** widens correlation lookup for legacy rows; prod has no NULL sessions today—consider removing after backfill.
+3. **PROJECT mismatch**: orch stack uses `PROJECT=orion-athena`; Mind may run with `PROJECT=orion` — keep `ORION_MIND_BASE_URL` aligned with actual Mind `container_name` or use compose aliases.
+
+## Test plan (manual)
+
+1. Hard refresh Hub; confirm `orion_sid` in localStorage.
+2. Open a message with Mind button from a prior session; modal should load runs when message `sessionId` differs from active session.
+3. Open Mind tab; confirm recent runs for current session only; empty state shows diagnostics hint.
+4. Send Mind-enabled chat; verify `mind_runs` row and modal after orch/Mind DNS is healthy.

--- a/services/orion-cortex-orch/.env_example
+++ b/services/orion-cortex-orch/.env_example
@@ -84,8 +84,8 @@ ORION_AUTO_EXTRACTOR_STAGE2_ENABLED=false
 ORION_AUTO_EXTRACTOR_AUTO_PROMOTE_THRESHOLD=2
 
 # --- Orion Mind (HTTP to services/orion-mind; Hub enables via context.metadata mind_enabled only through Orch) ---
-# Use the Mind container hostname on app-net (e.g. orion-athena-mind when PROJECT=orion-athena).
-ORION_MIND_BASE_URL=http://orion-athena-mind:6611
+# Hostname must match the Mind container on app-net: ${PROJECT:-orion}-mind (e.g. orion-mind or orion-athena-mind).
+ORION_MIND_BASE_URL=http://orion-mind:6611
 ORION_MIND_TIMEOUT_SEC=45
 MIND_N_LOOPS_DEFAULT=1
 MIND_WALL_MS_DEFAULT=120000

--- a/services/orion-cortex-orch/app/mind_runtime.py
+++ b/services/orion-cortex-orch/app/mind_runtime.py
@@ -592,12 +592,40 @@ def merge_mind_brief_into_plan_metadata(plan_request: PlanExecutionRequest, resu
         meta["mind_error_code"] = result.error_code
 
 
+def mind_http_base_url() -> str:
+    return (get_settings().orion_mind_base_url or "").rstrip("/")
+
+
+def log_mind_http_failure(
+    *,
+    correlation_id: str,
+    session_id: str | None,
+    trigger: str | None,
+    exc: BaseException,
+    base_url: str | None = None,
+) -> None:
+    configured = (base_url if base_url is not None else mind_http_base_url()) or "(unset)"
+    status_code: int | None = None
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
+    logger.warning(
+        "mind_http_failed correlation_id=%s session_id=%s trigger=%s mind_base_url=%s exc_type=%s status_code=%s err=%s",
+        correlation_id,
+        session_id,
+        trigger,
+        configured,
+        type(exc).__name__,
+        status_code,
+        exc,
+    )
+
+
 async def call_orion_mind_http(req: MindRunRequestV1) -> MindRunResultV1:
-    s = get_settings()
-    base = (s.orion_mind_base_url or "").rstrip("/")
+    base = mind_http_base_url()
     if not base:
         raise RuntimeError("orion_mind_unconfigured")
     url = f"{base}/v1/mind/run"
+    s = get_settings()
     timeout_sec = float(s.orion_mind_timeout_sec)
     timeout = httpx.Timeout(
         connect=min(10.0, timeout_sec),

--- a/services/orion-cortex-orch/app/mind_runtime.py
+++ b/services/orion-cortex-orch/app/mind_runtime.py
@@ -646,6 +646,16 @@ async def publish_mind_run_artifact(
         request_summary_jsonb=summary,
         created_at_utc=datetime.now(timezone.utc),
     )
+    logger.info(
+        "mind_run_artifact_publish mind_run_id=%s correlation_id=%s session_id=%s trigger=%s ok=%s error_code=%s router_profile_id=%s",
+        artifact.mind_run_id,
+        correlation_id,
+        artifact.session_id,
+        artifact.trigger,
+        artifact.ok,
+        artifact.error_code,
+        artifact.router_profile_id,
+    )
     env = BaseEnvelope(
         kind=MIND_ARTIFACT_KIND,
         source=source,

--- a/services/orion-cortex-orch/app/orchestrator.py
+++ b/services/orion-cortex-orch/app/orchestrator.py
@@ -27,6 +27,7 @@ from .mind_runtime import (
     _mind_enabled_exact,
     build_mind_run_request,
     call_orion_mind_http,
+    log_mind_http_failure,
     fetch_substrate_telemetry_facet_for_mind,
     merge_mind_brief_into_plan_metadata,
     publish_mind_run_artifact,
@@ -584,7 +585,12 @@ async def call_verb_runtime(
                 )
                 plan_request.context.setdefault("metadata", {})["mind_artifact_persist_failed"] = True
         except Exception as mind_exc:
-            logger.warning("mind_http_failed corr=%s err=%s", correlation_id, mind_exc)
+            log_mind_http_failure(
+                correlation_id=correlation_id,
+                session_id=client_request.context.session_id,
+                trigger=mind_req.trigger,
+                exc=mind_exc,
+            )
             plan_request.context.setdefault("metadata", {})["mind_invocation_failed"] = str(mind_exc)
     else:
         raw_mind = cr_meta.get("mind_enabled") if isinstance(cr_meta, dict) else None

--- a/services/orion-cortex-orch/tests/test_mind_orch.py
+++ b/services/orion-cortex-orch/tests/test_mind_orch.py
@@ -474,3 +474,52 @@ def test_build_mind_run_request_ignores_empty_inline_projection_shell(monkeypatc
     facets = (req.snapshot_inputs or {}).get("facets") or {}
     assert facets.get("cognitive_projection", {}).get("projection_id") == "cog-proj-built"
     assert facets.get("cognitive_projection", {}).get("item_count") == 1
+
+
+def test_publish_mind_run_artifact_includes_request_session_id(monkeypatch) -> None:
+    _orch_prep()
+    from datetime import datetime, timezone
+
+    from app.mind_runtime import publish_mind_run_artifact
+    from orion.mind.v1 import MindRunRequestV1, MindRunResultV1
+    from orion.core.bus.bus_schemas import ServiceRef
+
+    published: list[dict] = []
+
+    class _Bus:
+        async def publish(self, channel: str, env) -> None:
+            published.append({"channel": channel, "payload": env.payload})
+
+    mind_res = MindRunResultV1(mind_run_id=uuid4(), ok=True)
+    corr = "550e8400-e29b-41d4-a716-446655440099"
+    mind_req = MindRunRequestV1.model_validate(
+        {
+            "schema_id": "mind.run.request.v1",
+            "correlation_id": corr,
+            "trigger": "user_turn",
+            "policy": {"router_profile_id": "default"},
+            "snapshot_inputs": {},
+        }
+    )
+    client = _client_request()
+    client.context.session_id = "sess-from-request"
+
+    import asyncio
+
+    asyncio.run(
+        publish_mind_run_artifact(
+            _Bus(),
+            source=ServiceRef(service="orion-cortex-orch", instance="test"),
+            correlation_id=corr,
+            causality_chain=[],
+            trace={},
+            client_request=client,
+            mind_req=mind_req,
+            mind_res=mind_res,
+        )
+    )
+    assert published
+    artifact = published[0]["payload"]
+    assert artifact["session_id"] == "sess-from-request"
+    assert artifact["correlation_id"] == corr
+    assert datetime.fromisoformat(artifact["created_at_utc"].replace("Z", "+00:00")).tzinfo is not None

--- a/services/orion-cortex-orch/tests/test_mind_orch.py
+++ b/services/orion-cortex-orch/tests/test_mind_orch.py
@@ -523,3 +523,83 @@ def test_publish_mind_run_artifact_includes_request_session_id(monkeypatch) -> N
     assert artifact["session_id"] == "sess-from-request"
     assert artifact["correlation_id"] == corr
     assert datetime.fromisoformat(artifact["created_at_utc"].replace("Z", "+00:00")).tzinfo is not None
+
+
+def test_mind_http_base_url_from_settings(monkeypatch) -> None:
+    _orch_prep()
+    from app.mind_runtime import mind_http_base_url
+    from app.settings import get_settings
+
+    monkeypatch.setenv("ORION_MIND_BASE_URL", "http://orion-mind:6611")
+    get_settings.cache_clear()
+    assert mind_http_base_url() == "http://orion-mind:6611"
+
+
+def test_log_mind_http_failure_includes_endpoint_and_session(caplog) -> None:
+    _orch_prep()
+    import logging
+
+    from app.mind_runtime import log_mind_http_failure
+
+    caplog.set_level(logging.WARNING, logger="orion.cortex.orch.mind")
+    log_mind_http_failure(
+        correlation_id="550e8400-e29b-41d4-a716-446655440001",
+        session_id="sess-abc",
+        trigger="user_turn",
+        exc=ConnectionError("Temporary failure in name resolution"),
+        base_url="http://orion-athena-mind:6611",
+    )
+    assert any("mind_http_failed" in r.message for r in caplog.records)
+    assert any("orion-athena-mind:6611" in r.message for r in caplog.records)
+    assert any("sess-abc" in r.message for r in caplog.records)
+    assert any("user_turn" in r.message for r in caplog.records)
+
+
+def test_call_orion_mind_http_uses_configured_base_url(monkeypatch) -> None:
+    _orch_prep()
+    import asyncio
+
+    import httpx
+
+    from app.mind_runtime import call_orion_mind_http
+    from app.settings import get_settings
+    from orion.mind.v1 import MindRunRequestV1, MindRunResultV1
+
+    monkeypatch.setenv("ORION_MIND_BASE_URL", "http://orion-mind:6611")
+    get_settings.cache_clear()
+
+    captured: dict[str, str] = {}
+
+    class _Resp:
+        def __init__(self) -> None:
+            self.content = MindRunResultV1(mind_run_id=uuid4(), ok=True).model_dump_json().encode()
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self):
+            return MindRunResultV1.model_validate_json(self.content)
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url: str, json: dict):
+            captured["url"] = url
+            return _Resp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: _Client())
+    req = MindRunRequestV1.model_validate(
+        {
+            "schema_id": "mind.run.request.v1",
+            "correlation_id": "550e8400-e29b-41d4-a716-446655440002",
+            "trigger": "user_turn",
+            "policy": {"router_profile_id": "default"},
+            "snapshot_inputs": {},
+        }
+    )
+    asyncio.run(call_orion_mind_http(req))
+    assert captured["url"] == "http://orion-mind:6611/v1/mind/run"

--- a/services/orion-hub/scripts/mind_routes.py
+++ b/services/orion-hub/scripts/mind_routes.py
@@ -27,6 +27,20 @@ def _pool(request: Request):
     return pool
 
 
+def _session_visibility(row_session_id: str | None, current_session_id: str) -> str:
+    if row_session_id is None:
+        return "session_null_fallback"
+    if row_session_id == current_session_id:
+        return "session_match"
+    return "session_other"
+
+
+def _mind_run_row_dict(row: Any, *, current_session_id: str) -> dict[str, Any]:
+    out = dict(row)
+    out["session_visibility"] = _session_visibility(out.get("session_id"), current_session_id)
+    return out
+
+
 @router.get("/api/mind/runs/recent")
 async def list_recent_mind_runs(
     request: Request,
@@ -150,8 +164,19 @@ async def list_recent_mind_runs(
             router_profile_id,
         )
 
-    return {
-        "items": [dict(r) for r in rows],
+    items = [dict(r) for r in rows]
+    diagnostics: dict[str, Any] | None = None
+    if not items:
+        diagnostics = {
+            "hint": (
+                "No Mind runs for current session. There may be runs under another or null session; "
+                "check DB/session or open Mind from the message that produced the run."
+            ),
+            "session_id": session_id,
+        }
+
+    payload: dict[str, Any] = {
+        "items": items,
         "next_cursor": None,
         "aggregates": {
             **dict(summary or {"total_runs": 0, "ok_count": 0, "failed_count": 0}),
@@ -160,10 +185,18 @@ async def list_recent_mind_runs(
             "time_buckets": [dict(r) for r in bucket_counts],
         },
     }
+    if diagnostics is not None:
+        payload["diagnostics"] = diagnostics
+    return payload
 
 
 @router.get("/api/mind/runs/{mind_run_id}")
-async def get_mind_run(mind_run_id: str, request: Request, x_orion_session_id: Optional[str] = Header(None, alias="X-Orion-Session-Id")) -> dict[str, Any]:
+async def get_mind_run(
+    mind_run_id: str,
+    request: Request,
+    context_session_id: Optional[str] = Query(None, min_length=4, max_length=256),
+    x_orion_session_id: Optional[str] = Header(None, alias="X-Orion-Session-Id"),
+) -> dict[str, Any]:
     session_id = await _need_session(x_orion_session_id)
     pool = _pool(request)
     async with pool.acquire() as conn:
@@ -172,14 +205,21 @@ async def get_mind_run(mind_run_id: str, request: Request, x_orion_session_id: O
             SELECT mind_run_id, correlation_id, session_id, trigger, ok, error_code,
                    snapshot_hash, router_profile_id, result_jsonb, request_summary_jsonb,
                    redaction_profile_id, created_at_utc
-            FROM mind_runs WHERE mind_run_id = $1 AND session_id = $2
+            FROM mind_runs
+            WHERE mind_run_id = $1
+              AND (
+                session_id = $2
+                OR session_id IS NULL
+                OR ($3::text IS NOT NULL AND session_id = $3)
+              )
             """,
             mind_run_id,
             session_id,
+            context_session_id,
         )
     if row is None:
         raise HTTPException(status_code=404, detail="mind_run_not_found")
-    return dict(row)
+    return _mind_run_row_dict(row, current_session_id=session_id)
 
 
 @router.get("/api/mind/runs")
@@ -187,6 +227,7 @@ async def list_mind_runs(
     request: Request,
     correlation_id: str = Query(..., min_length=4),
     limit: int = Query(50, ge=1, le=200),
+    context_session_id: Optional[str] = Query(None, min_length=4, max_length=256),
     x_orion_session_id: Optional[str] = Header(None, alias="X-Orion-Session-Id"),
 ) -> list[dict[str, Any]]:
     session_id = await _need_session(x_orion_session_id)
@@ -197,12 +238,19 @@ async def list_mind_runs(
             SELECT mind_run_id, correlation_id, session_id, trigger, ok, error_code,
                    snapshot_hash, router_profile_id, result_jsonb, request_summary_jsonb,
                    redaction_profile_id, created_at_utc
-            FROM mind_runs WHERE correlation_id = $1 AND session_id = $2
+            FROM mind_runs
+            WHERE correlation_id = $1
+              AND (
+                session_id = $2
+                OR session_id IS NULL
+                OR ($4::text IS NOT NULL AND session_id = $4)
+              )
             ORDER BY created_at_utc DESC
             LIMIT $3
             """,
             correlation_id,
             session_id,
             limit,
+            context_session_id,
         )
-    return [dict(r) for r in rows]
+    return [_mind_run_row_dict(r, current_session_id=session_id) for r in rows]

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -1003,16 +1003,50 @@ loadDismissedIds();
     return "No Mind runs for this correlation yet.";
   }
 
+  function mindSessionIdFromMeta(turnMeta) {
+    if (!turnMeta || typeof turnMeta !== "object") return null;
+    const sid = turnMeta.sessionId || turnMeta.session_id;
+    return sid ? String(sid).trim() : null;
+  }
+
+  function mindRunsApiHeaders(turnMeta = null) {
+    const headers = {};
+    if (orionSessionId) headers["X-Orion-Session-Id"] = orionSessionId;
+    return headers;
+  }
+
+  function mindRunsApiParams(correlationId, turnMeta = null) {
+    const params = new URLSearchParams({ correlation_id: String(correlationId), limit: "200" });
+    const contextSessionId = mindSessionIdFromMeta(turnMeta);
+    if (contextSessionId && contextSessionId !== orionSessionId) {
+      params.set("context_session_id", contextSessionId);
+    }
+    return params;
+  }
+
+  function mindRunsEmptyDiagnostics(correlationId, turnMeta = null) {
+    const contextSessionId = mindSessionIdFromMeta(turnMeta);
+    const lines = [
+      `Correlation: ${String(correlationId)}`,
+      `Active session: ${orionSessionId || "(none)"}`,
+    ];
+    if (contextSessionId) lines.push(`Message session: ${contextSessionId}`);
+    if (contextSessionId && orionSessionId && contextSessionId !== orionSessionId) {
+      lines.push("Session mismatch: Mind runs may be stored under the message session.");
+    }
+    return lines.join("\n");
+  }
+
   function openMindRunsModal(correlationId, triggerEl = null, turnMeta = null) {
     if (!mindRunsModal || !correlationId) return;
     mindModalLastFocus = triggerEl && typeof triggerEl.focus === "function" ? triggerEl : document.activeElement;
     mindRunsModal.classList.remove("hidden");
     mindRunsModal.setAttribute("aria-hidden", "false");
     if (mindRunsModalMeta) {
-      mindRunsModalMeta.textContent = `Correlation: ${String(correlationId)}`;
+      mindRunsModalMeta.textContent = mindRunsEmptyDiagnostics(correlationId, turnMeta);
     }
     if (mindRunsModalDetails) {
-      mindRunsModalDetails.textContent = "Select a run.";
+      mindRunsModalDetails.textContent = "Loading runs…";
     }
     enableMindModalFocusTrap();
     refreshMindRunsForCorrelation(correlationId, turnMeta);
@@ -1134,9 +1168,18 @@ loadDismissedIds();
     mindRunsModalDetails.innerHTML = parts.join("");
   }
 
-  async function fetchMindRunDetail(mindRunId) {
-    const headers = orionSessionId ? { 'X-Orion-Session-Id': orionSessionId } : {};
-    const response = await fetch(`${API_BASE_URL}/api/mind/runs/${encodeURIComponent(mindRunId)}`, { headers });
+  async function fetchMindRunDetail(mindRunId, turnMeta = null) {
+    const headers = mindRunsApiHeaders(turnMeta);
+    const params = new URLSearchParams();
+    const contextSessionId = mindSessionIdFromMeta(turnMeta);
+    if (contextSessionId && contextSessionId !== orionSessionId) {
+      params.set("context_session_id", contextSessionId);
+    }
+    const qs = params.toString();
+    const response = await fetch(
+      `${API_BASE_URL}/api/mind/runs/${encodeURIComponent(mindRunId)}${qs ? `?${qs}` : ""}`,
+      { headers },
+    );
     if (!response.ok) {
       const detail = await response.text();
       throw new Error(`status ${response.status} ${detail || ""}`.trim());
@@ -1154,19 +1197,23 @@ loadDismissedIds();
     mindRunsModalStatus.textContent = "Loading runs...";
     mindRunsModalList.innerHTML = "";
     try {
-      const params = new URLSearchParams({ correlation_id: correlationId, limit: "200" });
-      const headers = orionSessionId ? { 'X-Orion-Session-Id': orionSessionId } : {};
+      const params = mindRunsApiParams(correlationId, turnMeta);
+      const headers = mindRunsApiHeaders(turnMeta);
       const response = await fetch(`${API_BASE_URL}/api/mind/runs?${params.toString()}`, { headers });
       if (!response.ok) {
         const detail = await response.text();
-        throw new Error(`status ${response.status} ${detail || ""}`.trim());
+        throw new Error(`HTTP ${response.status}: ${detail || "(no body)"}`.trim());
       }
       const rows = await response.json();
       if (!Array.isArray(rows) || rows.length === 0) {
-        mindRunsModalStatus.textContent = resolveMindRunsEmptyStatus(turnMeta);
+        const emptyStatus = resolveMindRunsEmptyStatus(turnMeta);
+        mindRunsModalStatus.textContent = emptyStatus;
         mindRunsModalList.innerHTML = '<div class="text-xs text-gray-500">No runs yet.</div>';
         if (mindRunsModalDetails) {
-          mindRunsModalDetails.textContent = "Select a run.";
+          mindRunsModalDetails.textContent = `${emptyStatus}\n\n${mindRunsEmptyDiagnostics(correlationId, turnMeta)}`;
+        }
+        if (mindRunsModalMeta) {
+          mindRunsModalMeta.textContent = mindRunsEmptyDiagnostics(correlationId, turnMeta);
         }
         return;
       }
@@ -1196,7 +1243,7 @@ loadDismissedIds();
           }
           if (mindRunsModalStatus) mindRunsModalStatus.textContent = `Loading run ${row.mind_run_id}...`;
           try {
-            const detail = await fetchMindRunDetail(row.mind_run_id);
+            const detail = await fetchMindRunDetail(row.mind_run_id, turnMeta);
             renderMindRunDetails(detail);
             if (mindRunsModalStatus) mindRunsModalStatus.textContent = `Loaded run ${row.mind_run_id}.`;
           } catch (err) {
@@ -1209,7 +1256,7 @@ loadDismissedIds();
       if (firstRun && firstRun.mind_run_id) {
         if (mindRunsModalStatus) mindRunsModalStatus.textContent = `Loading run ${firstRun.mind_run_id}...`;
         try {
-          const detail = await fetchMindRunDetail(firstRun.mind_run_id);
+          const detail = await fetchMindRunDetail(firstRun.mind_run_id, turnMeta);
           renderMindRunDetails(detail);
           if (mindRunsModalStatus) mindRunsModalStatus.textContent = `Loaded ${rows.length} run(s).`;
         } catch (err) {
@@ -1224,6 +1271,9 @@ loadDismissedIds();
     } catch (err) {
       mindRunsModalStatus.textContent = `Failed to load runs: ${String(err.message || err)}`;
       mindRunsModalList.innerHTML = '<div class="text-xs text-rose-300">Could not load runs.</div>';
+      if (mindRunsModalDetails) {
+        mindRunsModalDetails.textContent = `${String(err.message || err)}\n\n${mindRunsEmptyDiagnostics(correlationId, turnMeta)}`;
+      }
     }
   }
 
@@ -1367,7 +1417,12 @@ loadDismissedIds();
       if (mindSummaryTotal) mindSummaryTotal.textContent = String(aggregates.total_runs || 0);
       if (mindSummaryOk) mindSummaryOk.textContent = String(aggregates.ok_count || 0);
       if (mindSummaryFailed) mindSummaryFailed.textContent = String(aggregates.failed_count || 0);
-      mindStatus.textContent = `Loaded ${Array.isArray(payload.items) ? payload.items.length : 0} run(s).`;
+      const itemCount = Array.isArray(payload.items) ? payload.items.length : 0;
+      if (itemCount === 0 && payload.diagnostics && payload.diagnostics.hint) {
+        mindStatus.textContent = `${payload.diagnostics.hint} (session ${payload.diagnostics.session_id || orionSessionId || "?"})`;
+      } else {
+        mindStatus.textContent = `Loaded ${itemCount} run(s).`;
+      }
     } catch (error) {
       renderMindRows([]);
       mindStatus.textContent = `Failed to load Mind runs: ${error.message || error}`;
@@ -6315,6 +6370,9 @@ loadDismissedIds();
   function appendMessage(sender, text, colorClass = 'text-white') {
     if (!conversationDiv) return;
     const meta = arguments.length > 3 && arguments[3] && typeof arguments[3] === 'object' ? arguments[3] : {};
+    if (orionSessionId && !meta.sessionId && !meta.session_id) {
+      meta.sessionId = orionSessionId;
+    }
     if (sender === 'Orion') {
       const corr = memoryGraphCorrelationBase(meta);
       if (corr) backfillLatestUserTurnIdForGraph(conversationDiv, corr);

--- a/services/orion-hub/tests/test_mind_hub_tab.py
+++ b/services/orion-hub/tests/test_mind_hub_tab.py
@@ -58,4 +58,7 @@ def test_app_js_wires_mind_hash_and_recent_api() -> None:
     assert "/api/mind/runs/" in app_js
     assert "refreshMindRuns" in app_js
     assert "openMindRunsModal" in app_js
+    assert "mindRunsEmptyDiagnostics" in app_js
+    assert "context_session_id" in app_js
+    assert "meta.sessionId = orionSessionId" in app_js
     assert "payload.context.metadata.mind_enabled = true" in app_js

--- a/services/orion-hub/tests/test_mind_routes.py
+++ b/services/orion-hub/tests/test_mind_routes.py
@@ -17,11 +17,21 @@ for p in (str(_REPO), str(_HUB)):
 from scripts import mind_routes
 
 
+def _mock_pool(conn: AsyncMock) -> tuple[MagicMock, SimpleNamespace]:
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(memory_pg_pool=pool)))
+    return pool, req
+
+
 def test_get_mind_run_returns_row() -> None:
     row = {
         "mind_run_id": "mid-1",
         "correlation_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-        "session_id": "s1",
+        "session_id": "sess",
         "trigger": "user_turn",
         "ok": True,
         "error_code": None,
@@ -35,40 +45,56 @@ def test_get_mind_run_returns_row() -> None:
 
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(return_value=row)
-    acquire_cm = MagicMock()
-    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
-    acquire_cm.__aexit__ = AsyncMock(return_value=None)
-
-    pool = MagicMock()
-    pool.acquire = MagicMock(return_value=acquire_cm)
-
-    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(memory_pg_pool=pool)))
+    _, req = _mock_pool(conn)
 
     with patch.object(mind_routes, "_need_session", new_callable=AsyncMock, return_value="sess"):
-        out = asyncio.run(mind_routes.get_mind_run("mid-1", req, None))
+        out = asyncio.run(mind_routes.get_mind_run("mid-1", req, None, None))
         assert out["mind_run_id"] == "mid-1"
+        assert out["session_visibility"] == "session_match"
         fetch_args = conn.fetchrow.await_args.args
-        assert "mind_run_id = $1 AND session_id = $2" in fetch_args[0]
+        assert "mind_run_id = $1" in fetch_args[0]
         assert fetch_args[1] == "mid-1"
         assert fetch_args[2] == "sess"
 
 
-def test_get_mind_run_not_found_when_session_mismatch() -> None:
+def test_get_mind_run_not_found_when_other_session() -> None:
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(return_value=None)
-    acquire_cm = MagicMock()
-    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
-    acquire_cm.__aexit__ = AsyncMock(return_value=None)
-    pool = MagicMock()
-    pool.acquire = MagicMock(return_value=acquire_cm)
-    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(memory_pg_pool=pool)))
+    _, req = _mock_pool(conn)
 
     with patch.object(mind_routes, "_need_session", new_callable=AsyncMock, return_value="sess-a"):
         try:
-            asyncio.run(mind_routes.get_mind_run("mid-other-session", req, None))
+            asyncio.run(mind_routes.get_mind_run("mid-other-session", req, None, None))
             assert False, "Expected HTTPException"
         except Exception as exc:  # fastapi.HTTPException
             assert getattr(exc, "status_code", None) == 404
+
+
+def test_get_mind_run_allows_context_session_id() -> None:
+    row = {
+        "mind_run_id": "mid-ctx",
+        "correlation_id": "corr-ctx",
+        "session_id": "sess-message",
+        "trigger": "user_turn",
+        "ok": True,
+        "error_code": None,
+        "snapshot_hash": "abc",
+        "router_profile_id": "default",
+        "result_jsonb": {},
+        "request_summary_jsonb": {},
+        "redaction_profile_id": None,
+        "created_at_utc": None,
+    }
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=row)
+    _, req = _mock_pool(conn)
+
+    with patch.object(mind_routes, "_need_session", new_callable=AsyncMock, return_value="sess-browser"):
+        out = asyncio.run(
+            mind_routes.get_mind_run("mid-ctx", req, context_session_id="sess-message", x_orion_session_id=None)
+        )
+    assert out["mind_run_id"] == "mid-ctx"
+    assert out["session_visibility"] == "session_other"
 
 
 def test_list_recent_mind_runs_returns_summary_payload() -> None:
@@ -91,13 +117,7 @@ def test_list_recent_mind_runs_returns_summary_payload() -> None:
     conn = AsyncMock()
     conn.fetch = AsyncMock(side_effect=[recent_rows, top_error_rows, top_router_rows, bucket_rows])
     conn.fetchrow = AsyncMock(return_value=summary_row)
-    acquire_cm = MagicMock()
-    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
-    acquire_cm.__aexit__ = AsyncMock(return_value=None)
-
-    pool = MagicMock()
-    pool.acquire = MagicMock(return_value=acquire_cm)
-    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(memory_pg_pool=pool)))
+    _, req = _mock_pool(conn)
 
     with patch.object(mind_routes, "_need_session", new_callable=AsyncMock, return_value="sess-123"):
         out = asyncio.run(
@@ -127,16 +147,10 @@ def test_list_recent_mind_runs_scopes_by_session_id() -> None:
     conn = AsyncMock()
     conn.fetch = AsyncMock(side_effect=[[], [], [], []])
     conn.fetchrow = AsyncMock(return_value={"total_runs": 0, "ok_count": 0, "failed_count": 0})
-    acquire_cm = MagicMock()
-    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
-    acquire_cm.__aexit__ = AsyncMock(return_value=None)
-
-    pool = MagicMock()
-    pool.acquire = MagicMock(return_value=acquire_cm)
-    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(memory_pg_pool=pool)))
+    _, req = _mock_pool(conn)
 
     with patch.object(mind_routes, "_need_session", new_callable=AsyncMock, return_value="sess-abc"):
-        asyncio.run(
+        out = asyncio.run(
             mind_routes.list_recent_mind_runs(
                 req,
                 hours=12,
@@ -155,9 +169,10 @@ def test_list_recent_mind_runs_scopes_by_session_id() -> None:
     assert first_fetch_args[1] == "sess-abc"
     assert first_fetch_args[2] == 12
     assert first_fetch_args[3] is True
+    assert out.get("diagnostics", {}).get("hint")
 
 
-def test_list_mind_runs_scopes_by_session_id() -> None:
+def test_list_mind_runs_returns_session_matching_rows() -> None:
     rows = [
         {
             "mind_run_id": "mid-1",
@@ -176,18 +191,90 @@ def test_list_mind_runs_scopes_by_session_id() -> None:
     ]
     conn = AsyncMock()
     conn.fetch = AsyncMock(return_value=rows)
-    acquire_cm = MagicMock()
-    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
-    acquire_cm.__aexit__ = AsyncMock(return_value=None)
-    pool = MagicMock()
-    pool.acquire = MagicMock(return_value=acquire_cm)
-    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(memory_pg_pool=pool)))
+    _, req = _mock_pool(conn)
 
     with patch.object(mind_routes, "_need_session", new_callable=AsyncMock, return_value="sess-x"):
         out = asyncio.run(mind_routes.list_mind_runs(req, correlation_id="corr-1", limit=10, x_orion_session_id=None))
     assert len(out) == 1
+    assert out[0]["session_visibility"] == "session_match"
     fetch_args = conn.fetch.await_args.args
-    assert "correlation_id = $1 AND session_id = $2" in fetch_args[0]
+    assert "correlation_id = $1" in fetch_args[0]
+    assert "session_id = $2" in fetch_args[0]
     assert fetch_args[1] == "corr-1"
     assert fetch_args[2] == "sess-x"
-    assert fetch_args[3] == 10
+
+
+def test_list_mind_runs_returns_null_session_fallback_rows() -> None:
+    rows = [
+        {
+            "mind_run_id": "mid-null",
+            "correlation_id": "corr-1",
+            "session_id": None,
+            "trigger": "user_turn",
+            "ok": True,
+            "error_code": None,
+            "snapshot_hash": "abc",
+            "router_profile_id": "default",
+            "result_jsonb": {},
+            "request_summary_jsonb": {},
+            "redaction_profile_id": None,
+            "created_at_utc": None,
+        }
+    ]
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    _, req = _mock_pool(conn)
+
+    with patch.object(mind_routes, "_need_session", new_callable=AsyncMock, return_value="sess-x"):
+        out = asyncio.run(mind_routes.list_mind_runs(req, correlation_id="corr-1", limit=10, x_orion_session_id=None))
+    assert len(out) == 1
+    assert out[0]["session_visibility"] == "session_null_fallback"
+
+
+def test_list_mind_runs_allows_context_session_without_current_match() -> None:
+    rows = [
+        {
+            "mind_run_id": "mid-msg",
+            "correlation_id": "corr-1",
+            "session_id": "sess-message",
+            "trigger": "user_turn",
+            "ok": True,
+            "error_code": None,
+            "snapshot_hash": "abc",
+            "router_profile_id": "default",
+            "result_jsonb": {},
+            "request_summary_jsonb": {},
+            "redaction_profile_id": None,
+            "created_at_utc": None,
+        }
+    ]
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    _, req = _mock_pool(conn)
+
+    with patch.object(mind_routes, "_need_session", new_callable=AsyncMock, return_value="sess-browser"):
+        out = asyncio.run(
+            mind_routes.list_mind_runs(
+                req,
+                correlation_id="corr-1",
+                limit=10,
+                context_session_id="sess-message",
+                x_orion_session_id=None,
+            )
+        )
+    assert len(out) == 1
+    fetch_args = conn.fetch.await_args.args
+    assert fetch_args[4] == "sess-message"
+
+
+def test_list_mind_runs_excludes_other_non_null_session_without_context() -> None:
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+    _, req = _mock_pool(conn)
+
+    with patch.object(mind_routes, "_need_session", new_callable=AsyncMock, return_value="sess-browser"):
+        out = asyncio.run(mind_routes.list_mind_runs(req, correlation_id="corr-1", limit=10, x_orion_session_id=None))
+    assert out == []
+    fetch_sql = conn.fetch.await_args.args[0]
+    assert "session_id IS NULL" in fetch_sql
+    assert "session_id = $4" not in fetch_sql or "$4::text IS NOT NULL" in fetch_sql

--- a/services/orion-mind/docker-compose.yml
+++ b/services/orion-mind/docker-compose.yml
@@ -21,7 +21,10 @@ services:
       MIND_N_LOOPS_DEFAULT: ${MIND_N_LOOPS_DEFAULT:-1}
       MIND_ROUTER_PROFILES_PATH: ${MIND_ROUTER_PROFILES_PATH:-}
     networks:
-      - app-net
+      app-net:
+        aliases:
+          - orion-athena-mind
+          - orion-mind
     ports:
       - "${HOST_PORT:-6611}:${PORT:-6611}"
     healthcheck:


### PR DESCRIPTION
# PR: Hub Mind modal visibility + Orch→Mind service discovery

**Branch:** `fix/mind-hub-modal-live-verification`

## Summary

Two live-verified fixes on one branch:

1. **Hub Mind modal empty** — `mind_runs` rows existed but `/api/mind/runs?correlation_id=…` returned `[]` when the browser `orion_sid` did not match the row’s `session_id`. Correlation-scoped reads now allow safe fallbacks; the frontend passes `context_session_id` from the message turn and shows session/correlation diagnostics on empty/error.

2. **No new `mind_runs` after orch recreate** — `ORION_MIND_BASE_URL` pointed at `orion-athena-mind:6611` while the live Mind container is `orion-mind` (`PROJECT=orion`). Orch logged `mind_http_failed` / DNS resolution failure. URL and compose network aliases were corrected; a new Mind-enabled turn now persists and appears in Hub API/UI.

## Commits (this work)

| Commit | Description |
|--------|-------------|
| `8c58daa1` | Hub modal session visibility (routes + `app.js` + tests) |
| `62fb0ea9` | Orch `mind_run_artifact_publish` structured logging + publish test |
| `91fb854d` | Orch Mind base URL + failure diagnostics + Mind compose aliases |
| `70eb64cc` | This PR report |

## Root causes

### A. Modal / API session mismatch

| Layer | Finding |
|-------|---------|
| **DB** | Rows present; e.g. `correlation_id=e7256fd6…` under `session_id=eb6d05c4…` while browser had `723d819d…`. |
| **API** | `WHERE correlation_id = $1 AND session_id = $2` returned `[]` on mismatch. |
| **UI** | Generic “Select a run.” / “No runs yet.” with no session diagnostics. |

### B. Orch → Mind DNS

| Layer | Finding |
|-------|---------|
| **Config** | `ORION_MIND_BASE_URL=http://orion-athena-mind:6611` in orch `.env` / `.env_example`. |
| **Runtime** | Mind `container_name` = `orion-mind` (`PROJECT=orion` in `services/orion-mind/.env`). |
| **Orch logs** | `mind_http_failed … Temporary failure in name resolution` when calling Mind after container recreate. |
| **From orch** | `getent hosts orion-mind` OK; `orion-athena-mind` failed until alias added. |

## Files changed

| File | Change |
|------|--------|
| `services/orion-hub/scripts/mind_routes.py` | Correlation list/detail: current session, `NULL` session, or `context_session_id`; `session_visibility` on rows; recent empty `diagnostics.hint`. |
| `services/orion-hub/static/js/app.js` | `sessionId` on message meta; `context_session_id` query param; `mindRunsEmptyDiagnostics`; improved modal/API error copy; recent tab diagnostics hint. |
| `services/orion-hub/tests/test_mind_routes.py` | Session match, NULL fallback, context session, exclusion of other sessions, recent diagnostics. |
| `services/orion-hub/tests/test_mind_hub_tab.py` | Static asserts for new JS helpers. |
| `services/orion-cortex-orch/app/mind_runtime.py` | `mind_http_base_url`, `log_mind_http_failure`, `mind_run_artifact_publish` logging. |
| `services/orion-cortex-orch/app/orchestrator.py` | Call structured `log_mind_http_failure` on Mind HTTP errors. |
| `services/orion-cortex-orch/.env_example` | `ORION_MIND_BASE_URL=http://orion-mind:6611` + hostname comment. |
| `services/orion-cortex-orch/tests/test_mind_orch.py` | Publish `session_id` test; base URL; failure log fields; HTTP client URL test. |
| `services/orion-mind/docker-compose.yml` | `app-net` aliases: `orion-athena-mind`, `orion-mind`. |

**Operator note:** Copy `ORION_MIND_BASE_URL` from `.env_example` into local `services/orion-cortex-orch/.env` (gitignored).

## Tests

```bash
# Hub (12 passed)
PYTHONPATH=. ./scripts/test_service.sh orion-hub \
  services/orion-hub/tests/test_mind_routes.py \
  services/orion-hub/tests/test_mind_hub_tab.py -q

# Orch (16 passed)
PYTHONPATH=. ./orion_dev/bin/python -m pytest \
  services/orion-cortex-orch/tests/test_mind_orch.py -q
```

## Live verification

### Hub modal / read path

**DB** (`orion-athena-sql-db`, `postgres` / `conjourney`):

- `mind_runs`: 97+ rows; multiple sessions; no NULL `session_id` in recent sample.

**API** (`http://127.0.0.1:8080`):

| Request | Result |
|---------|--------|
| `GET /api/mind/runs?correlation_id=e7256fd6…` + `X-Orion-Session-Id: 723d819d…` | `[]` |
| Same + `context_session_id=eb6d05c4…` | **1 row**, `session_visibility=session_other` |
| `GET /api/mind/runs/recent` + unknown session | `items: []`, `diagnostics.hint` present |

**Hub redeploy:**

```bash
docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d hub-app
# HTTP 200
```

### Orch → Mind / write path

**DNS / health (inside `orion-athena-cortex-orch`):**

```
ORION_MIND_BASE_URL=http://orion-mind:6611
getent hosts orion-athena-mind → 172.18.0.30  (after compose alias)
curl -sf http://orion-mind:6611/health → {"ok":true,...}
```

**Mind-enabled chat:**

```bash
POST /api/chat  (mind_enabled: true, X-Orion-Session-Id: 723d819d…)
# correlation_id=d6521171-242d-4b6d-9c8e-f746744d48ac
# session_id=723d819d-e4a3-4b19-96db-62e96faf83f5
# (LLM reply may timeout independently; Mind path succeeded)
```

**Orch log:**

```
mind_run_artifact_publish mind_run_id=ff35c6a9-7eb5-4ff9-bd5b-e30fd5901529
  correlation_id=d6521171-242d-4b6d-9c8e-f746744d48ac
  session_id=723d819d-e4a3-4b19-96db-62e96faf83f5 trigger=user_turn ok=True
```

**DB:**

```sql
SELECT mind_run_id, correlation_id, session_id, ok, trigger, created_at_utc
FROM mind_runs
WHERE correlation_id = 'd6521171-242d-4b6d-9c8e-f746744d48ac';
-- 1 row: ff35c6a9-…, session_id=723d819d-…, ok=t, trigger=user_turn
```

**Hub API:**

```bash
GET /api/mind/runs?correlation_id=d6521171-…
# 1 row, session_visibility=session_match

GET /api/mind/runs/recent?hours=168&limit=5
# New run first in list for session 723d819d…
```

**Services restarted:**

```bash
# Mind (aliases)
cd services/orion-mind && docker compose --env-file .env up -d

# Orch (rebuild + env)
docker compose --env-file .env --env-file services/orion-cortex-orch/.env \
  -f services/orion-cortex-orch/docker-compose.yml up -d --build
```

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Correlation API returns rows for modal (with message session when needed) | **Pass** |
| Modal can show real run details (`result_jsonb` in list response) | **Pass** (API) |
| Recent Mind tab session-scoped | **Pass** |
| New Mind-enabled turn creates `mind_runs` with non-null `session_id` | **Pass** (`d6521171…`) |
| Orch → Mind HTTP succeeds | **Pass** (`/health`, artifact publish) |
| Hub + orch tests pass | **Pass** (12 + 16) |

## Remaining limitations

1. **Mind tab row click** does not pass `turnMeta` to the modal (OK while recent list is session-scoped).
2. **`session_id IS NULL` fallback** on correlation lookup is for legacy rows only; prod sample had no NULL sessions.
3. **`PROJECT` mismatch** between stacks (`orion-athena` vs `orion`) — keep `ORION_MIND_BASE_URL` aligned with Mind `container_name` or use compose aliases.
4. **Browser UI** not automated here; hard-refresh Hub and open Mind on `d6521171…` message to confirm modal rendering.

## Manual test plan

1. Hard refresh Hub; note `orion_sid` in localStorage.
2. Open Mind on an older message whose `sessionId` differs from active session — runs should load via `context_session_id`.
3. Send Mind-enabled chat; confirm Mind button opens modal with run id, ok, timestamps, request/result JSON.
4. Open `#mind` tab; confirm recent table includes the new run for the current session.
