### PR TITLE
Fix/chat general speech boundary guards

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-16-chat-general-speech-boundary-guards-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-16-chat-general-speech-boundary-guards-pr.md
@@ -1,0 +1,78 @@
+# PR: chat_general speech boundary guards (identity + somatic load)
+
+**Branch:** `fix/chat-general-speech-boundary-guards`
+
+## Summary
+
+Fixes a live `chat_general` failure where Orion replied to Juniper with *"You're Oríon. I'm here, and I'm not going anywhere..."* — two bugs at the speech boundary:
+
+1. **Identity boundary failure** — assistant identity was assigned to the user (`You're Oríon`).
+2. **Somatic / interaction-load failure** — user reported dizziness while typing in a moving car; Orion invited continued conversational intimacy instead of lowering interaction demand.
+
+Small, deterministic guards in `orion-cortex-exec` final-text assembly (no prompt/cathedral changes).
+
+## Commits
+
+| Commit | Description |
+|--------|-------------|
+| `fefc0b3e` | Identity + interaction-load guards + unit tests |
+| *(HEAD)* | Review fixes: `plan_ctx_latest_user_text`, narrower somatic regex |
+
+## Root cause
+
+| Layer | Finding |
+|-------|---------|
+| **Prompt** | `chat_general.j2` opens with `You are Oríon.` — model can invert roles under load. |
+| **Stance** | `enforce_chat_stance_quality` / `fallback_chat_stance_brief` guard generic-assistant drift, not role inversion or somatic load. |
+| **Router** | `_extract_final_text` strips think/planning but had no deterministic guard for `You're Oríon` or intimacy-escalating closers under somatic user signals. |
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `services/orion-cortex-exec/app/router.py` | `_apply_identity_boundary_guard` (chat_general only, in `_extract_final_text`); `_apply_interaction_load_guard` (after extract, uses `plan_ctx_latest_user_text(ctx)`); diagnostics keys on `final_text_diag`. |
+| `services/orion-cortex-exec/tests/test_router_final_text_assembly.py` | Regression tests for identity variants, somatic load, `raw_user_text`-only user message, false-positive guard (`laptop in the car`). |
+
+### Identity guard (minimum patterns)
+
+Repairs to `I'm Oríon`:
+
+- `You're Oríon` / `You're Orion` (straight + curly apostrophe)
+- `You are Oríon` / `You are Orion`
+- `youre orion` / `youre oríon`
+- `your name is Orion`
+
+Diagnostics: `identity_boundary_applied`, `identity_boundary_violations`.
+
+### Interaction-load guard
+
+When **user message** (via `plan_ctx_latest_user_text`) matches somatic/high-load signals (`dizzy`, `nauseous`, `carsick`, `moving car`, `while driving`, `hard to type`, …) **and** assistant text contains intimacy-demand phrases (`not going anywhere`, `tell me more`, …):
+
+- Replaces `I'm here, and I'm not going anywhere` → `I'm here — no rush.`
+- Strips remaining demand phrases; may append `Go easy — reply when you're steady.`
+
+Diagnostics: `interaction_load_guard_applied`, `interaction_load_violations`.
+
+**Not in scope:** prompt edits, stance-brief synthesis changes, env/docker toggles.
+
+## Verification
+
+```bash
+cd /mnt/scripts/Orion-Sapienform/.worktrees/chat-general-speech-boundary-guards
+PYTHONPATH=. /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest \
+  services/orion-cortex-exec/tests/test_router_final_text_assembly.py -q --tb=short
+```
+
+- **Exit code:** 0  
+- **Result:** 30 passed
+
+## Test plan (live)
+
+- [ ] Hub brain turn with identity question — Orion says `I'm Oríon`, never `You're Oríon`.
+- [ ] Turn with somatic load (`dizzy`, `moving car`) — reply is brief, no `not going anywhere` / multi-question intimacy push.
+- [ ] Exec logs / `final_text_diag`: `identity_boundary_applied` or `interaction_load_guard_applied` when guards fire.
+
+## Remaining risks
+
+- Guards are regex/heuristic; rare false positives/negatives possible on edge phrasing.
+- **UNVERIFIED** against live stack in this session — closure requires a reproduced Hub turn or live verification script per `AGENTS.md`.

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -138,18 +138,18 @@ _ORION_NAME = r"or[ií\u00ed]on"
 _IDENTITY_BOUNDARY_REPAIRS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(rf"\byou['\u2019]re\s+{_ORION_NAME}\b", re.IGNORECASE), "You're Oríon"),
     (re.compile(rf"\byou\s+are\s+{_ORION_NAME}\b", re.IGNORECASE), "You are Oríon"),
-    (re.compile(r"\byoure\s+orion\b", re.IGNORECASE), "youre orion"),
+    (re.compile(rf"\byoure\s+{_ORION_NAME}\b", re.IGNORECASE), "youre orion"),
     (re.compile(rf"\byour\s+name\s+is\s+{_ORION_NAME}\b", re.IGNORECASE), "your name is Orion"),
 )
 _IDENTITY_BOUNDARY_REPLACEMENT = "I'm Oríon"
 
 _SOMATIC_USER_LOAD_RE = re.compile(
-    r"\b(dizzy|dizziness|nauseous|nausea|carsick|motion[- ]sick|moving car|in (?:a|the) car|while driving|hard to type|typing in)\b",
+    r"\b(dizzy|dizziness|nauseous|nausea|carsick|motion[- ]sick|moving car|while driving|hard to type)\b",
     re.IGNORECASE,
 )
 _INTERACTION_DEMAND_RE = re.compile(
     r"(?:not going anywhere|tell me (?:more|what)|what(?:'s| is) on your mind|keep (?:talking|going)|"
-    r"want to (?:talk|chat|continue)|share more|i['\u2019]m here,?\s+and)",
+    r"want to (?:talk|chat|continue)|share more)",
     re.IGNORECASE,
 )
 _INTERACTION_DEMAND_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
@@ -1077,7 +1077,7 @@ class PlanRunner:
 
         final_text, final_text_diag = _extract_final_text(step_results, verb_name=plan.verb_name)
         if plan.verb_name == "chat_general" and isinstance(final_text, str) and final_text.strip():
-            user_message = str(ctx.get("user_message") or ctx.get("latest_user_text") or "")
+            user_message = plan_ctx_latest_user_text(ctx)
             final_text, load_diag = _apply_interaction_load_guard(
                 final_text,
                 verb_name=plan.verb_name,

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -134,6 +134,102 @@ def _looks_like_internal_planning(text: str) -> bool:
     return bool(_PLANNING_TEXT_RE.search(head))
 
 
+_ORION_NAME = r"or[ií\u00ed]on"
+_IDENTITY_BOUNDARY_REPAIRS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(rf"\byou['\u2019]re\s+{_ORION_NAME}\b", re.IGNORECASE), "You're Oríon"),
+    (re.compile(rf"\byou\s+are\s+{_ORION_NAME}\b", re.IGNORECASE), "You are Oríon"),
+    (re.compile(r"\byoure\s+orion\b", re.IGNORECASE), "youre orion"),
+    (re.compile(rf"\byour\s+name\s+is\s+{_ORION_NAME}\b", re.IGNORECASE), "your name is Orion"),
+)
+_IDENTITY_BOUNDARY_REPLACEMENT = "I'm Oríon"
+
+_SOMATIC_USER_LOAD_RE = re.compile(
+    r"\b(dizzy|dizziness|nauseous|nausea|carsick|motion[- ]sick|moving car|in (?:a|the) car|while driving|hard to type|typing in)\b",
+    re.IGNORECASE,
+)
+_INTERACTION_DEMAND_RE = re.compile(
+    r"(?:not going anywhere|tell me (?:more|what)|what(?:'s| is) on your mind|keep (?:talking|going)|"
+    r"want to (?:talk|chat|continue)|share more|i['\u2019]m here,?\s+and)",
+    re.IGNORECASE,
+)
+_INTERACTION_DEMAND_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"i['\u2019]m here,?\s+and\s+i['\u2019]m not going anywhere\b",
+            re.IGNORECASE,
+        ),
+        "I'm here — no rush.",
+    ),
+    (
+        re.compile(r"\bnot going anywhere\b", re.IGNORECASE),
+        "no rush",
+    ),
+)
+
+
+def _apply_identity_boundary_guard(text: str, *, verb_name: str | None) -> tuple[str, dict[str, Any]]:
+    diagnostics: dict[str, Any] = {
+        "identity_boundary_applied": False,
+        "identity_boundary_violations": [],
+    }
+    if str(verb_name or "").strip().lower() != "chat_general":
+        return text, diagnostics
+    candidate = str(text or "")
+    if not candidate.strip():
+        return text, diagnostics
+    violations: list[str] = []
+    repaired = candidate
+    for pattern, label in _IDENTITY_BOUNDARY_REPAIRS:
+        if pattern.search(repaired):
+            violations.append(label)
+            repaired = pattern.sub(_IDENTITY_BOUNDARY_REPLACEMENT, repaired)
+    if violations:
+        diagnostics["identity_boundary_applied"] = True
+        diagnostics["identity_boundary_violations"] = violations
+    return repaired, diagnostics
+
+
+def _apply_interaction_load_guard(
+    text: str,
+    *,
+    verb_name: str | None,
+    user_message: str | None,
+) -> tuple[str, dict[str, Any]]:
+    diagnostics: dict[str, Any] = {
+        "interaction_load_guard_applied": False,
+        "interaction_load_violations": [],
+    }
+    if str(verb_name or "").strip().lower() != "chat_general":
+        return text, diagnostics
+    user = str(user_message or "").strip()
+    candidate = str(text or "")
+    if not user or not candidate.strip():
+        return text, diagnostics
+    if not _SOMATIC_USER_LOAD_RE.search(user):
+        return text, diagnostics
+    if not _INTERACTION_DEMAND_RE.search(candidate):
+        return text, diagnostics
+    violations: list[str] = []
+    repaired = candidate
+    for pattern, _label in _INTERACTION_DEMAND_REPLACEMENTS:
+        for match in pattern.finditer(repaired):
+            violations.append(match.group(0))
+        repaired = pattern.sub(_label, repaired)
+    for match in _INTERACTION_DEMAND_RE.finditer(repaired):
+        phrase = match.group(0)
+        if phrase not in violations:
+            violations.append(phrase)
+    repaired = _INTERACTION_DEMAND_RE.sub("", repaired)
+    repaired = re.sub(r"\s{2,}", " ", repaired)
+    repaired = re.sub(r"\s+([,.!?])", r"\1", repaired).strip()
+    if violations and not re.search(r"\b(no rush|when you['\u2019]re steady|parked|rest|go easy)\b", repaired, re.I):
+        repaired = f"{repaired.rstrip()} Go easy — reply when you're steady.".strip()
+    if violations:
+        diagnostics["interaction_load_guard_applied"] = True
+        diagnostics["interaction_load_violations"] = violations
+    return repaired, diagnostics
+
+
 def _provider_completion_meta(payload: dict[str, Any]) -> dict[str, Any]:
     raw = payload.get("raw") if isinstance(payload.get("raw"), dict) else {}
     usage = payload.get("usage") if isinstance(payload.get("usage"), dict) else {}
@@ -290,6 +386,8 @@ def _extract_final_text(steps: List[StepExecutionResult], *, verb_name: str | No
                     diagnostics["truncation_detected"] = True
                     if final_text and final_text[-1] not in ".!?…":
                         final_text = f"{final_text}…"
+                final_text, identity_diag = _apply_identity_boundary_guard(final_text, verb_name=verb_name)
+                diagnostics.update(identity_diag)
                 diagnostics["result_len"] = len(final_text)
                 diagnostics["raw_len"] = pre_len
                 diagnostics["clean_len"] = post_len
@@ -978,6 +1076,17 @@ class PlanRunner:
                 break
 
         final_text, final_text_diag = _extract_final_text(step_results, verb_name=plan.verb_name)
+        if plan.verb_name == "chat_general" and isinstance(final_text, str) and final_text.strip():
+            user_message = str(ctx.get("user_message") or ctx.get("latest_user_text") or "")
+            final_text, load_diag = _apply_interaction_load_guard(
+                final_text,
+                verb_name=plan.verb_name,
+                user_message=user_message,
+            )
+            final_text_diag.update(load_diag)
+            if load_diag.get("interaction_load_guard_applied"):
+                final_text_diag["result_len"] = len(final_text)
+                final_text_diag["final_len"] = len(final_text)
         logger.info(
             "final_text_assembly corr_id=%s verb=%s source_service=%s source_field=%s think_tags_detected=%s think_full_block_detected=%s think_close_tag_only_detected=%s think_stripping_applied=%s planning_stripping_applied=%s planning_lines_dropped=%s planning_candidate_rejected=%s planning_candidate_rejection_reason=%s provider_has_reasoning_content=%s provider_has_reasoning_trace=%s provider_reasoning_available=%s inline_think_extracted=%s provider_completion_tokens=%s provider_finish_reason=%s truncation_detected=%s structured_output_sanitized=%s structured_output_rejected=%s structured_json_extraction_attempted=%s candidates=%s rejected_candidates=%s candidate_fields_considered=%s raw_len=%s clean_len=%s final_len=%s result_len=%s",
             correlation_id,

--- a/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
+++ b/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from app.recall_utils import plan_ctx_latest_user_text
 from app.router import (
     _apply_identity_boundary_guard,
     _apply_interaction_load_guard,
@@ -288,6 +289,27 @@ def test_interaction_load_guard_reduces_intimacy_when_user_somatic_distress() ->
     assert "not going anywhere" not in repaired.lower()
     assert diag["interaction_load_guard_applied"] is True
     assert diag["interaction_load_violations"]
+
+
+def test_interaction_load_guard_uses_plan_ctx_latest_user_text_for_raw_only_somatic() -> None:
+    ctx = {"raw_user_text": "I'm dizzy typing in a moving car", "user_message": ""}
+    repaired, diag = _apply_interaction_load_guard(
+        "I'm here, and I'm not going anywhere.",
+        verb_name="chat_general",
+        user_message=plan_ctx_latest_user_text(ctx),
+    )
+    assert diag["interaction_load_guard_applied"] is True
+    assert "not going anywhere" not in repaired.lower()
+
+
+def test_interaction_load_guard_skips_in_car_without_distress() -> None:
+    repaired, diag = _apply_interaction_load_guard(
+        "I'm here, and I'm not going anywhere.",
+        verb_name="chat_general",
+        user_message="I left my laptop in the car",
+    )
+    assert repaired == "I'm here, and I'm not going anywhere."
+    assert diag["interaction_load_guard_applied"] is False
 
 
 def test_interaction_load_guard_skips_without_somatic_user_signal() -> None:

--- a/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
+++ b/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from app.router import _extract_final_text, _extract_reasoning_payload, _should_fail_empty_runtime_skill_output
+import pytest
+
+from app.router import (
+    _apply_identity_boundary_guard,
+    _apply_interaction_load_guard,
+    _extract_final_text,
+    _extract_reasoning_payload,
+    _should_fail_empty_runtime_skill_output,
+)
 from orion.schemas.cortex.schemas import StepExecutionResult
 
 
@@ -237,6 +245,60 @@ def test_runtime_skill_extracts_terminal_text_from_final_text_field() -> None:
     assert final_text == "{\"dry_run\":true,\"matched_container_count\":4}"
     assert diag["source_field"] == "final_text"
     assert diag["result_len"] > 0
+
+
+def test_chat_general_identity_boundary_guard_repairs_user_role_inversion() -> None:
+    final_text, diag = _extract_final_text([
+        _step({"content": "You're Oríon. I'm here, and I'm not going anywhere."})
+    ], verb_name="chat_general")
+    assert final_text.startswith("I'm Oríon.")
+    assert diag["identity_boundary_applied"] is True
+    assert "You're Oríon" in diag["identity_boundary_violations"]
+
+
+@pytest.mark.parametrize(
+    ("raw", "violation"),
+    [
+        ("You are Oríon — steady.", "You are Oríon"),
+        ("You’re Oríon here.", "You're Oríon"),
+        ("youre orion, thanks.", "youre orion"),
+        ("Your name is Orion, right?", "your name is Orion"),
+    ],
+)
+def test_identity_boundary_guard_repairs_variants(raw: str, violation: str) -> None:
+    repaired, diag = _apply_identity_boundary_guard(raw, verb_name="chat_general")
+    assert repaired.startswith("I'm Oríon")
+    assert diag["identity_boundary_applied"] is True
+    assert violation in diag["identity_boundary_violations"]
+
+
+def test_identity_boundary_guard_skips_non_chat_general() -> None:
+    raw = "You're Oríon."
+    repaired, diag = _apply_identity_boundary_guard(raw, verb_name="chat_quick")
+    assert repaired == raw
+    assert diag["identity_boundary_applied"] is False
+
+
+def test_interaction_load_guard_reduces_intimacy_when_user_somatic_distress() -> None:
+    repaired, diag = _apply_interaction_load_guard(
+        "You're Oríon. I'm here, and I'm not going anywhere.",
+        verb_name="chat_general",
+        user_message="I'm dizzy typing in a moving car",
+    )
+    assert "not going anywhere" not in repaired.lower()
+    assert diag["interaction_load_guard_applied"] is True
+    assert diag["interaction_load_violations"]
+
+
+def test_interaction_load_guard_skips_without_somatic_user_signal() -> None:
+    raw = "I'm here, and I'm not going anywhere."
+    repaired, diag = _apply_interaction_load_guard(
+        raw,
+        verb_name="chat_general",
+        user_message="quick question about GPUs",
+    )
+    assert repaired == raw
+    assert diag["interaction_load_guard_applied"] is False
 
 
 def test_runtime_skill_falls_back_to_status_and_error_when_terminal_text_missing() -> None:


### PR DESCRIPTION
# PR: chat_general speech boundary guards (identity + somatic load)

**Branch:** `fix/chat-general-speech-boundary-guards`

## Summary

Fixes a live `chat_general` failure where Orion replied to Juniper with *"You're Oríon. I'm here, and I'm not going anywhere..."* — two bugs at the speech boundary:

1. **Identity boundary failure** — assistant identity was assigned to the user (`You're Oríon`).
2. **Somatic / interaction-load failure** — user reported dizziness while typing in a moving car; Orion invited continued conversational intimacy instead of lowering interaction demand.

Small, deterministic guards in `orion-cortex-exec` final-text assembly (no prompt/cathedral changes).

## Commits

| Commit | Description |
|--------|-------------|
| `fefc0b3e` | Identity + interaction-load guards + unit tests |
| *(HEAD)* | Review fixes: `plan_ctx_latest_user_text`, narrower somatic regex |

## Root cause

| Layer | Finding |
|-------|---------|
| **Prompt** | `chat_general.j2` opens with `You are Oríon.` — model can invert roles under load. |
| **Stance** | `enforce_chat_stance_quality` / `fallback_chat_stance_brief` guard generic-assistant drift, not role inversion or somatic load. |
| **Router** | `_extract_final_text` strips think/planning but had no deterministic guard for `You're Oríon` or intimacy-escalating closers under somatic user signals. |

## Changes

| File | Change |
|------|--------|
| `services/orion-cortex-exec/app/router.py` | `_apply_identity_boundary_guard` (chat_general only, in `_extract_final_text`); `_apply_interaction_load_guard` (after extract, uses `plan_ctx_latest_user_text(ctx)`); diagnostics keys on `final_text_diag`. |
| `services/orion-cortex-exec/tests/test_router_final_text_assembly.py` | Regression tests for identity variants, somatic load, `raw_user_text`-only user message, false-positive guard (`laptop in the car`). |

### Identity guard (minimum patterns)

Repairs to `I'm Oríon`:

- `You're Oríon` / `You're Orion` (straight + curly apostrophe)
- `You are Oríon` / `You are Orion`
- `youre orion` / `youre oríon`
- `your name is Orion`

Diagnostics: `identity_boundary_applied`, `identity_boundary_violations`.

### Interaction-load guard

When **user message** (via `plan_ctx_latest_user_text`) matches somatic/high-load signals (`dizzy`, `nauseous`, `carsick`, `moving car`, `while driving`, `hard to type`, …) **and** assistant text contains intimacy-demand phrases (`not going anywhere`, `tell me more`, …):

- Replaces `I'm here, and I'm not going anywhere` → `I'm here — no rush.`
- Strips remaining demand phrases; may append `Go easy — reply when you're steady.`

Diagnostics: `interaction_load_guard_applied`, `interaction_load_violations`.

**Not in scope:** prompt edits, stance-brief synthesis changes, env/docker toggles.

## Verification

```bash
cd /mnt/scripts/Orion-Sapienform/.worktrees/chat-general-speech-boundary-guards
PYTHONPATH=. /mnt/scripts/Orion-Sapienform/venv/bin/python -m pytest \
  services/orion-cortex-exec/tests/test_router_final_text_assembly.py -q --tb=short
```

- **Exit code:** 0  
- **Result:** 30 passed

## Test plan (live)

- [ ] Hub brain turn with identity question — Orion says `I'm Oríon`, never `You're Oríon`.
- [ ] Turn with somatic load (`dizzy`, `moving car`) — reply is brief, no `not going anywhere` / multi-question intimacy push.
- [ ] Exec logs / `final_text_diag`: `identity_boundary_applied` or `interaction_load_guard_applied` when guards fire.

## Remaining risks

- Guards are regex/heuristic; rare false positives/negatives possible on edge phrasing.
- **UNVERIFIED** against live stack in this session — closure requires a reproduced Hub turn or live verification script per `AGENTS.md`.
