### PR TITLE
Fix/chat general identity low bandwidth semantic

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-16-chat-general-identity-low-bandwidth-semantic-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-16-chat-general-identity-low-bandwidth-semantic-pr.md
@@ -1,0 +1,105 @@
+# PR: chat_general identity boundary + semantic low-bandwidth stance
+
+**Branch:** `fix/chat-general-identity-low-bandwidth-semantic`  
+**Base:** `origin/main`  
+**Worktree:** `.worktrees/chat-general-identity-low-bandwidth-semantic`
+
+## Summary
+
+Reverts the **regex/prose-scrubber** approach merged in #575 (`fix/chat-general-speech-boundary-guards`) and replaces it with:
+
+1. A **narrow, deterministic** `chat_general` identity-boundary guard (assistant identity must not be assigned to Juniper).
+2. **Semantic** low-bandwidth / embodied-interaction behavior via `chat_stance_brief.j2` + `chat_general.j2` (no Python keyword classifiers, no post-generation phrase rewrites).
+
+Fixes the live failure where Orion replied *"You're Oríon. I'm here, and I'm not going anywhere..."* to a dizzy-in-car typing turn.
+
+## Problem
+
+| Bug | Bad behavior | Fix |
+|-----|--------------|-----|
+| **A. Identity inversion** | `"You're Oríon."` spoken to Juniper | Post-extract guard repairs `you're/you are/your name is … Orion` → `I'm Oríon` |
+| **B. Low-bandwidth failure** | Long poetic reassurance, presence-centering, interaction demand | Stance + speech prompts: short reply, release from replying, no open questions, no typing invites |
+
+## Removed (cleanup)
+
+From `services/orion-cortex-exec/app/router.py`:
+
+- `_SOMATIC_USER_LOAD_RE` — symptom keyword classifier
+- `_INTERACTION_DEMAND_RE` — intimacy-phrase detector
+- `_INTERACTION_DEMAND_REPLACEMENTS` — rewrites like `"not going anywhere"` → `"no rush"`
+- `_apply_interaction_load_guard` — combined somatic + phrase scrubber
+
+No final-output rewrite of warmth, curiosity, or availability phrases.
+
+## Added / changed
+
+| File | Change |
+|------|--------|
+| `services/orion-cortex-exec/app/router.py` | `_apply_chat_general_identity_boundary_guard` after `_extract_final_text`; diagnostics in logs + `runtime_response_diagnostics` |
+| `orion/cognition/prompts/chat_stance_brief.j2` | LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT (semantic, no keywords) |
+| `orion/cognition/prompts/chat_general.j2` | Internal assistant/user identity block; obey stance priorities/hazards for reduced interaction load |
+| `services/orion-cortex-exec/tests/test_router_identity_boundary.py` | **New** — guard + banned-symbol tests |
+| `services/orion-cortex-exec/tests/test_router_final_text_assembly.py` | Removed scrubber tests; extract no longer applies identity guard |
+| `services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py` | Prompt contract + dizzy-car stance fixture |
+
+### Identity guard contract
+
+- **Scope:** `chat_general` only
+- **Catches:** `You're Oríon`, `You are Orion`, `your name is orion`, etc.
+- **Repair:** substitute `I'm Oríon` (does not rewrite general prose)
+- **Diagnostics:** `identity_boundary_applied`, `identity_boundary_violations`
+- **Wiring:** repaired text → `final_text`, `ctx["chat_general_final_text_clean"]`, `PlanExecutionResult`
+
+### Low-bandwidth contract (prompt-only)
+
+Stance synthesizer should populate existing fields, e.g.:
+
+- `identity_salience`: `low` (unless explicit identity ask)
+- `task_mode`: `triage` / `direct_response` (not `identity_dialogue`)
+- `response_priorities`: `reduce_interaction_load`, `release_user_from_replying`, `keep_response_short`, …
+- `response_hazards`: `avoid_open_ended_questions`, `do_not_invite_continued_typing`, `avoid_presence_centering`, …
+
+## Commits
+
+1. `fix(cortex-exec): remove regex interaction scrubber; narrow identity guard`
+2. `feat(cognition): semantic low-bandwidth stance and speech identity rails`
+3. `test(cortex-exec): identity boundary and low-bandwidth prompt contracts`
+4. `fix(cortex-exec): log identity boundary diagnostics on final text assembly`
+
+## Verification
+
+```bash
+cd .worktrees/chat-general-identity-low-bandwidth-semantic
+PYTHONPATH=. /path/to/venv/bin/python -m pytest \
+  services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py \
+  services/orion-cortex-exec/tests/test_router_identity_boundary.py \
+  services/orion-cortex-exec/tests/test_router_final_text_assembly.py -q
+# 38 passed
+
+PYTHONPATH=. /path/to/venv/bin/python -m pytest \
+  services/orion-cortex-exec/tests/test_chat_stance_brief.py -q
+# 17 passed, 2 failed (pre-existing on main: observer consumer label drift)
+
+python -m compileall services/orion-cortex-exec/app  # exit 0
+
+rg "_SOMATIC_USER_LOAD_RE|_INTERACTION_DEMAND_RE|_INTERACTION_DEMAND_REPLACEMENTS" .
+# only test_router_identity_boundary.py (negative assertion)
+```
+
+## Test plan (manual)
+
+- [ ] `chat_general` turn: *"I'm getting dizzy typing to you while my wife drives the car lol"* — short reply, no `"You're Oríon"`, no poetic loyalty/presence centering, no open-ended questions.
+- [ ] Forced bad LLM output containing `You're Oríon` — exec log shows `identity_boundary_applied=True`.
+- [ ] `chat_quick` / other verbs — identity guard does not run.
+- [ ] Normal identity line *"I'm Oríon. You're Juniper."* — unchanged when model emits it correctly.
+
+## Risks / follow-up
+
+- **LLM adherence:** Low-bandwidth behavior depends on stance synthesis + speech pass following prompts; no runtime tone rewrite.
+- **Blunt identity repair:** Embedded inversions in long sentences get a substring replace (acceptable safety rail).
+- **Pre-existing test failures** in `test_chat_stance_brief.py` (observer `consumer` label) — unrelated to this PR.
+- **Stale doc:** `2026-05-16-chat-general-speech-boundary-guards-pr.md` describes the reverted design; superseded by this report.
+
+## Env / compose
+
+No `.env_example`, `settings.py`, or `docker-compose` changes required.

--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -1,4 +1,9 @@
-You are Oríon.
+ASSISTANT IDENTITY — INTERNAL
+- The assistant/speaker is Oríon.
+- The human/user is Juniper.
+- In user-facing speech, "I" means Oríon and "you" means Juniper.
+- Never tell Juniper "you are Oríon", "you're Oríon", "you are Orion", or "you're Orion".
+- Do not transform assistant identity instructions into user-facing speech.
 
 You are the speech layer for chat_general.
 A bounded internal stance brief has already been synthesized upstream.
@@ -45,6 +50,14 @@ NON-NEGOTIABLE BEHAVIOR (memory vs side-effects)
 - Prefer warmth and familiarity over titles on ordinary turns.
 - If task_mode is triage or identity_salience is low, do not self-introduce unless explicitly asked identity questions.
 - For strained technical turns, lead with operational impact + next triage path before reflective framing.
+- If chat_stance_brief response_priorities or response_hazards indicate reduced interaction load, low-bandwidth interaction, release from replying, no open-ended questions, or avoiding continued typing:
+  - keep the response very short
+  - do not ask open-ended questions
+  - do not invite Juniper to keep typing or chatting
+  - explicitly release Juniper from replying when appropriate
+  - offer voice, pause, or later continuation when appropriate
+  - do not center Oríon's loyalty or presence as the care object
+  - do not use poetic reassurance
 {% if situation_prompt_fragment %}
 - Situation context is grounding, not an instruction to mention it.
 - Use situation only when relevant; do not force time/weather/location commentary.

--- a/orion/cognition/prompts/chat_stance_brief.j2
+++ b/orion/cognition/prompts/chat_stance_brief.j2
@@ -64,6 +64,17 @@ REQUIREMENTS
 - Avoid exact location details unless explicitly necessary.
 {% endif %}
 
+LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT
+- Infer whether Juniper's current body state, environment, device/input mode, fatigue, sensory load, emotional overload, or context makes continued interaction costly.
+- Do not use keyword matching. Use the meaning of the whole turn and recent context.
+- When the turn implies that typing, reading, screen use, continued conversation, motion, fatigue, sickness, panic, overload, or environment makes interaction costly, represent that using existing stance fields only.
+- For these turns:
+  - set identity_salience low unless the user is explicitly asking an identity question
+  - prefer task_mode triage or direct_response over identity_dialogue or playful_exchange
+  - include response_priorities such as: reduce_interaction_load, release_user_from_replying, keep_response_short, offer_voice_pause_or_later, answer_without_extending_conversation
+  - include response_hazards such as: avoid_open_ended_questions, do_not_invite_continued_typing, avoid_presence_centering, avoid_poetic_reassurance, avoid_role_or_identity_recital
+  - use situation_response_guidance for compact practical guidance when relevant (e.g., motion/typing load, pause OK, voice later)
+
 STYLE TARGET FOR BRIEF CONTENT
 - Prefer: continuity, shared_build, juniper_builder, known_person, identity_turn, direct_answer, playful_relational.
 - Prefer constraints like: avoid_formal_definition, avoid_role_recital, avoid_ceremonial_tone.

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -1024,7 +1024,7 @@ class PlanRunner:
                 final_text_diag["result_len"] = len(final_text)
                 final_text_diag["final_len"] = len(final_text)
         logger.info(
-            "final_text_assembly corr_id=%s verb=%s source_service=%s source_field=%s think_tags_detected=%s think_full_block_detected=%s think_close_tag_only_detected=%s think_stripping_applied=%s planning_stripping_applied=%s planning_lines_dropped=%s planning_candidate_rejected=%s planning_candidate_rejection_reason=%s provider_has_reasoning_content=%s provider_has_reasoning_trace=%s provider_reasoning_available=%s inline_think_extracted=%s provider_completion_tokens=%s provider_finish_reason=%s truncation_detected=%s structured_output_sanitized=%s structured_output_rejected=%s structured_json_extraction_attempted=%s candidates=%s rejected_candidates=%s candidate_fields_considered=%s raw_len=%s clean_len=%s final_len=%s result_len=%s",
+            "final_text_assembly corr_id=%s verb=%s source_service=%s source_field=%s think_tags_detected=%s think_full_block_detected=%s think_close_tag_only_detected=%s think_stripping_applied=%s planning_stripping_applied=%s planning_lines_dropped=%s planning_candidate_rejected=%s planning_candidate_rejection_reason=%s provider_has_reasoning_content=%s provider_has_reasoning_trace=%s provider_reasoning_available=%s inline_think_extracted=%s provider_completion_tokens=%s provider_finish_reason=%s truncation_detected=%s structured_output_sanitized=%s structured_output_rejected=%s structured_json_extraction_attempted=%s candidates=%s rejected_candidates=%s candidate_fields_considered=%s identity_boundary_applied=%s identity_boundary_violations=%s raw_len=%s clean_len=%s final_len=%s result_len=%s",
             correlation_id,
             plan.verb_name,
             final_text_diag.get("source_service"),
@@ -1050,6 +1050,8 @@ class PlanRunner:
             final_text_diag.get("candidate_count"),
             final_text_diag.get("rejected_candidate_count"),
             final_text_diag.get("candidate_fields_considered"),
+            final_text_diag.get("identity_boundary_applied"),
+            final_text_diag.get("identity_boundary_violations"),
             final_text_diag.get("raw_len"),
             final_text_diag.get("clean_len"),
             final_text_diag.get("final_len"),
@@ -1069,6 +1071,8 @@ class PlanRunner:
             "capsule_filtered_reason": ctx.get("capsule_filtered_reason"),
             "stance_world_context_items_used": ctx.get("stance_world_context_items_used"),
             "politics_context_suppressed": bool(ctx.get("politics_context_suppressed")),
+            "identity_boundary_applied": bool(final_text_diag.get("identity_boundary_applied")),
+            "identity_boundary_violations": final_text_diag.get("identity_boundary_violations"),
         }
         if overall_status == "success" and soft_failure:
             overall_status = "partial"

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -141,33 +141,14 @@ _IDENTITY_BOUNDARY_REPAIRS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(rf"\byoure\s+{_ORION_NAME}\b", re.IGNORECASE), "youre orion"),
     (re.compile(rf"\byour\s+name\s+is\s+{_ORION_NAME}\b", re.IGNORECASE), "your name is Orion"),
 )
-_IDENTITY_BOUNDARY_REPLACEMENT = "I'm Oríon"
-
-_SOMATIC_USER_LOAD_RE = re.compile(
-    r"\b(dizzy|dizziness|nauseous|nausea|carsick|motion[- ]sick|moving car|while driving|hard to type)\b",
-    re.IGNORECASE,
-)
-_INTERACTION_DEMAND_RE = re.compile(
-    r"(?:not going anywhere|tell me (?:more|what)|what(?:'s| is) on your mind|keep (?:talking|going)|"
-    r"want to (?:talk|chat|continue)|share more)",
-    re.IGNORECASE,
-)
-_INTERACTION_DEMAND_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (
-        re.compile(
-            r"i['\u2019]m here,?\s+and\s+i['\u2019]m not going anywhere\b",
-            re.IGNORECASE,
-        ),
-        "I'm here — no rush.",
-    ),
-    (
-        re.compile(r"\bnot going anywhere\b", re.IGNORECASE),
-        "no rush",
-    ),
-)
+_IDENTITY_BOUNDARY_ASSISTANT_CLAIM = "I'm Oríon"
 
 
-def _apply_identity_boundary_guard(text: str, *, verb_name: str | None) -> tuple[str, dict[str, Any]]:
+def _apply_chat_general_identity_boundary_guard(
+    text: str,
+    *,
+    verb_name: str | None,
+) -> tuple[str, dict[str, Any]]:
     diagnostics: dict[str, Any] = {
         "identity_boundary_applied": False,
         "identity_boundary_violations": [],
@@ -182,51 +163,10 @@ def _apply_identity_boundary_guard(text: str, *, verb_name: str | None) -> tuple
     for pattern, label in _IDENTITY_BOUNDARY_REPAIRS:
         if pattern.search(repaired):
             violations.append(label)
-            repaired = pattern.sub(_IDENTITY_BOUNDARY_REPLACEMENT, repaired)
+            repaired = pattern.sub(_IDENTITY_BOUNDARY_ASSISTANT_CLAIM, repaired)
     if violations:
         diagnostics["identity_boundary_applied"] = True
         diagnostics["identity_boundary_violations"] = violations
-    return repaired, diagnostics
-
-
-def _apply_interaction_load_guard(
-    text: str,
-    *,
-    verb_name: str | None,
-    user_message: str | None,
-) -> tuple[str, dict[str, Any]]:
-    diagnostics: dict[str, Any] = {
-        "interaction_load_guard_applied": False,
-        "interaction_load_violations": [],
-    }
-    if str(verb_name or "").strip().lower() != "chat_general":
-        return text, diagnostics
-    user = str(user_message or "").strip()
-    candidate = str(text or "")
-    if not user or not candidate.strip():
-        return text, diagnostics
-    if not _SOMATIC_USER_LOAD_RE.search(user):
-        return text, diagnostics
-    if not _INTERACTION_DEMAND_RE.search(candidate):
-        return text, diagnostics
-    violations: list[str] = []
-    repaired = candidate
-    for pattern, _label in _INTERACTION_DEMAND_REPLACEMENTS:
-        for match in pattern.finditer(repaired):
-            violations.append(match.group(0))
-        repaired = pattern.sub(_label, repaired)
-    for match in _INTERACTION_DEMAND_RE.finditer(repaired):
-        phrase = match.group(0)
-        if phrase not in violations:
-            violations.append(phrase)
-    repaired = _INTERACTION_DEMAND_RE.sub("", repaired)
-    repaired = re.sub(r"\s{2,}", " ", repaired)
-    repaired = re.sub(r"\s+([,.!?])", r"\1", repaired).strip()
-    if violations and not re.search(r"\b(no rush|when you['\u2019]re steady|parked|rest|go easy)\b", repaired, re.I):
-        repaired = f"{repaired.rstrip()} Go easy — reply when you're steady.".strip()
-    if violations:
-        diagnostics["interaction_load_guard_applied"] = True
-        diagnostics["interaction_load_violations"] = violations
     return repaired, diagnostics
 
 
@@ -386,8 +326,6 @@ def _extract_final_text(steps: List[StepExecutionResult], *, verb_name: str | No
                     diagnostics["truncation_detected"] = True
                     if final_text and final_text[-1] not in ".!?…":
                         final_text = f"{final_text}…"
-                final_text, identity_diag = _apply_identity_boundary_guard(final_text, verb_name=verb_name)
-                diagnostics.update(identity_diag)
                 diagnostics["result_len"] = len(final_text)
                 diagnostics["raw_len"] = pre_len
                 diagnostics["clean_len"] = post_len
@@ -1077,14 +1015,12 @@ class PlanRunner:
 
         final_text, final_text_diag = _extract_final_text(step_results, verb_name=plan.verb_name)
         if plan.verb_name == "chat_general" and isinstance(final_text, str) and final_text.strip():
-            user_message = plan_ctx_latest_user_text(ctx)
-            final_text, load_diag = _apply_interaction_load_guard(
+            final_text, identity_diag = _apply_chat_general_identity_boundary_guard(
                 final_text,
                 verb_name=plan.verb_name,
-                user_message=user_message,
             )
-            final_text_diag.update(load_diag)
-            if load_diag.get("interaction_load_guard_applied"):
+            final_text_diag.update(identity_diag)
+            if identity_diag.get("identity_boundary_applied"):
                 final_text_diag["result_len"] = len(final_text)
                 final_text_diag["final_len"] = len(final_text)
         logger.info(

--- a/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
+++ b/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
@@ -49,3 +49,62 @@ def test_final_prompt_has_identity_no_generic_collapse_rail() -> None:
     prompt = Path("orion/cognition/prompts/chat_general.j2").read_text(encoding="utf-8")
     assert "do not revert to generic assistant language" in prompt
     assert "Do not surface negative rail phrases like \"not a generic user\" or \"not a generic assistant\"" in prompt
+
+
+def test_stance_brief_has_semantic_low_bandwidth_guidance() -> None:
+    prompt = Path("orion/cognition/prompts/chat_stance_brief.j2").read_text(encoding="utf-8")
+    assert "LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT" in prompt
+    assert "Do not use keyword matching" in prompt
+    assert "response_priorities" in prompt
+    assert "response_hazards" in prompt
+    assert "reduce_interaction_load" in prompt
+    assert "release_user_from_replying" in prompt
+    assert "avoid_open_ended_questions" in prompt
+    assert "avoid_presence_centering" in prompt
+
+
+def test_final_prompt_obey_low_bandwidth_stance_contract() -> None:
+    prompt = Path("orion/cognition/prompts/chat_general.j2").read_text(encoding="utf-8")
+    assert "ASSISTANT IDENTITY — INTERNAL" in prompt
+    assert "Never tell Juniper" in prompt
+    assert "keep the response very short" in prompt
+    assert "do not ask open-ended questions" in prompt
+    assert "release Juniper from replying" in prompt
+    assert "do not invite Juniper to keep typing" in prompt
+    assert "do not center Oríon's loyalty or presence" in prompt
+    assert "do not use poetic reassurance" in prompt
+
+
+def test_dizzy_car_turn_low_bandwidth_stance_contract_fixture() -> None:
+    """Contract shape for embodied load turns (stance synthesizer target, not a keyword detector)."""
+    from orion.schemas.chat_stance import ChatStanceBrief
+
+    brief = ChatStanceBrief.model_validate(
+        {
+            "conversation_frame": "mixed",
+            "task_mode": "triage",
+            "identity_salience": "low",
+            "user_intent": "Typing while car motion; light check-in.",
+            "self_relevance": "low",
+            "juniper_relevance": "Body/interface load; minimize reply demand.",
+            "response_priorities": [
+                "reduce_interaction_load",
+                "release_user_from_replying",
+                "keep_response_short",
+                "offer_voice_pause_or_later",
+            ],
+            "response_hazards": [
+                "avoid_open_ended_questions",
+                "do_not_invite_continued_typing",
+                "avoid_presence_centering",
+                "avoid_poetic_reassurance",
+            ],
+            "situation_response_guidance": ["motion_typing_load", "pause_ok", "voice_later"],
+            "answer_strategy": "DirectAnswer",
+            "stance_summary": "Brief ack; no extension.",
+        }
+    )
+    assert brief.identity_salience == "low"
+    assert brief.task_mode != "identity_dialogue"
+    assert "reduce_interaction_load" in brief.response_priorities
+    assert "avoid_open_ended_questions" in brief.response_hazards

--- a/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
+++ b/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import pytest
-
-from app.recall_utils import plan_ctx_latest_user_text
 from app.router import (
-    _apply_identity_boundary_guard,
-    _apply_interaction_load_guard,
     _extract_final_text,
     _extract_reasoning_payload,
     _should_fail_empty_runtime_skill_output,
@@ -248,79 +243,13 @@ def test_runtime_skill_extracts_terminal_text_from_final_text_field() -> None:
     assert diag["result_len"] > 0
 
 
-def test_chat_general_identity_boundary_guard_repairs_user_role_inversion() -> None:
-    final_text, diag = _extract_final_text([
-        _step({"content": "You're Oríon. I'm here, and I'm not going anywhere."})
-    ], verb_name="chat_general")
-    assert final_text.startswith("I'm Oríon.")
-    assert diag["identity_boundary_applied"] is True
-    assert "You're Oríon" in diag["identity_boundary_violations"]
-
-
-@pytest.mark.parametrize(
-    ("raw", "violation"),
-    [
-        ("You are Oríon — steady.", "You are Oríon"),
-        ("You’re Oríon here.", "You're Oríon"),
-        ("youre orion, thanks.", "youre orion"),
-        ("Your name is Orion, right?", "your name is Orion"),
-    ],
-)
-def test_identity_boundary_guard_repairs_variants(raw: str, violation: str) -> None:
-    repaired, diag = _apply_identity_boundary_guard(raw, verb_name="chat_general")
-    assert repaired.startswith("I'm Oríon")
-    assert diag["identity_boundary_applied"] is True
-    assert violation in diag["identity_boundary_violations"]
-
-
-def test_identity_boundary_guard_skips_non_chat_general() -> None:
-    raw = "You're Oríon."
-    repaired, diag = _apply_identity_boundary_guard(raw, verb_name="chat_quick")
-    assert repaired == raw
-    assert diag["identity_boundary_applied"] is False
-
-
-def test_interaction_load_guard_reduces_intimacy_when_user_somatic_distress() -> None:
-    repaired, diag = _apply_interaction_load_guard(
-        "You're Oríon. I'm here, and I'm not going anywhere.",
+def test_extract_final_text_leaves_identity_inversion_for_post_extract_guard() -> None:
+    final_text, diag = _extract_final_text(
+        [_step({"content": "You're Oríon. I'm here."})],
         verb_name="chat_general",
-        user_message="I'm dizzy typing in a moving car",
     )
-    assert "not going anywhere" not in repaired.lower()
-    assert diag["interaction_load_guard_applied"] is True
-    assert diag["interaction_load_violations"]
-
-
-def test_interaction_load_guard_uses_plan_ctx_latest_user_text_for_raw_only_somatic() -> None:
-    ctx = {"raw_user_text": "I'm dizzy typing in a moving car", "user_message": ""}
-    repaired, diag = _apply_interaction_load_guard(
-        "I'm here, and I'm not going anywhere.",
-        verb_name="chat_general",
-        user_message=plan_ctx_latest_user_text(ctx),
-    )
-    assert diag["interaction_load_guard_applied"] is True
-    assert "not going anywhere" not in repaired.lower()
-
-
-def test_interaction_load_guard_skips_in_car_without_distress() -> None:
-    repaired, diag = _apply_interaction_load_guard(
-        "I'm here, and I'm not going anywhere.",
-        verb_name="chat_general",
-        user_message="I left my laptop in the car",
-    )
-    assert repaired == "I'm here, and I'm not going anywhere."
-    assert diag["interaction_load_guard_applied"] is False
-
-
-def test_interaction_load_guard_skips_without_somatic_user_signal() -> None:
-    raw = "I'm here, and I'm not going anywhere."
-    repaired, diag = _apply_interaction_load_guard(
-        raw,
-        verb_name="chat_general",
-        user_message="quick question about GPUs",
-    )
-    assert repaired == raw
-    assert diag["interaction_load_guard_applied"] is False
+    assert final_text.startswith("You're Oríon")
+    assert not diag.get("identity_boundary_applied")
 
 
 def test_runtime_skill_falls_back_to_status_and_error_when_terminal_text_missing() -> None:

--- a/services/orion-cortex-exec/tests/test_router_identity_boundary.py
+++ b/services/orion-cortex-exec/tests/test_router_identity_boundary.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.router import _apply_chat_general_identity_boundary_guard, _extract_final_text
+from orion.schemas.cortex.schemas import StepExecutionResult
+
+
+def _step(payload: dict, *, verb_name: str = "chat_general", step_name: str = "llm") -> StepExecutionResult:
+    return StepExecutionResult(
+        status="success",
+        verb_name=verb_name,
+        step_name=step_name,
+        order=0,
+        result={"LLMGatewayService": payload},
+        latency_ms=1,
+        node="n",
+        logs=[],
+        error=None,
+    )
+
+
+def test_router_has_no_banned_scrubber_symbols() -> None:
+    router_src = (Path(__file__).resolve().parents[1] / "app" / "router.py").read_text(encoding="utf-8")
+    banned = (
+        "_SOMATIC_USER_LOAD_RE",
+        "_INTERACTION_DEMAND_RE",
+        "_INTERACTION_DEMAND_REPLACEMENTS",
+        "_apply_interaction_load_guard",
+        "interaction_load_guard_applied",
+    )
+    for symbol in banned:
+        assert symbol not in router_src
+
+
+def test_chat_general_identity_boundary_repairs_user_role_inversion() -> None:
+    repaired, diag = _apply_chat_general_identity_boundary_guard(
+        "You're Oríon. I'm here.",
+        verb_name="chat_general",
+    )
+    assert repaired.startswith("I'm Oríon.")
+    assert diag["identity_boundary_applied"] is True
+    assert "You're Oríon" in diag["identity_boundary_violations"]
+
+
+@pytest.mark.parametrize(
+    ("raw", "violation"),
+    [
+        ("You are Orion.", "You are Oríon"),
+        ("You are Oríon — steady.", "You are Oríon"),
+        ("You’re Oríon here.", "You're Oríon"),
+        ("youre orion, thanks.", "youre orion"),
+        ("your name is orion", "your name is Orion"),
+    ],
+)
+def test_identity_boundary_repairs_variants(raw: str, violation: str) -> None:
+    repaired, diag = _apply_chat_general_identity_boundary_guard(raw, verb_name="chat_general")
+    assert repaired.startswith("I'm Oríon")
+    assert diag["identity_boundary_applied"] is True
+    assert violation in diag["identity_boundary_violations"]
+
+
+def test_identity_boundary_skips_non_chat_general() -> None:
+    raw = "You're Oríon."
+    repaired, diag = _apply_chat_general_identity_boundary_guard(raw, verb_name="chat_quick")
+    assert repaired == raw
+    assert diag["identity_boundary_applied"] is False
+
+
+def test_identity_boundary_leaves_correct_assistant_user_roles() -> None:
+    raw = "I'm Oríon. You're Juniper."
+    repaired, diag = _apply_chat_general_identity_boundary_guard(raw, verb_name="chat_general")
+    assert repaired == raw
+    assert diag["identity_boundary_applied"] is False
+
+
+def test_extract_final_text_does_not_rewrite_availability_phrases() -> None:
+    raw = "I'm here, and I'm not going anywhere."
+    final_text, diag = _extract_final_text([_step({"content": raw})], verb_name="chat_general")
+    assert final_text == raw
+    assert not diag.get("interaction_load_guard_applied")


### PR DESCRIPTION
# PR: chat_general identity boundary + semantic low-bandwidth stance

**Branch:** `fix/chat-general-identity-low-bandwidth-semantic`  
**Base:** `origin/main`  
**Worktree:** `.worktrees/chat-general-identity-low-bandwidth-semantic`

## Summary

Reverts the **regex/prose-scrubber** approach merged in #575 (`fix/chat-general-speech-boundary-guards`) and replaces it with:

1. A **narrow, deterministic** `chat_general` identity-boundary guard (assistant identity must not be assigned to Juniper).
2. **Semantic** low-bandwidth / embodied-interaction behavior via `chat_stance_brief.j2` + `chat_general.j2` (no Python keyword classifiers, no post-generation phrase rewrites).

Fixes the live failure where Orion replied *"You're Oríon. I'm here, and I'm not going anywhere..."* to a dizzy-in-car typing turn.

## Problem

| Bug | Bad behavior | Fix |
|-----|--------------|-----|
| **A. Identity inversion** | `"You're Oríon."` spoken to Juniper | Post-extract guard repairs `you're/you are/your name is … Orion` → `I'm Oríon` |
| **B. Low-bandwidth failure** | Long poetic reassurance, presence-centering, interaction demand | Stance + speech prompts: short reply, release from replying, no open questions, no typing invites |

## Removed (cleanup)

From `services/orion-cortex-exec/app/router.py`:

- `_SOMATIC_USER_LOAD_RE` — symptom keyword classifier
- `_INTERACTION_DEMAND_RE` — intimacy-phrase detector
- `_INTERACTION_DEMAND_REPLACEMENTS` — rewrites like `"not going anywhere"` → `"no rush"`
- `_apply_interaction_load_guard` — combined somatic + phrase scrubber

No final-output rewrite of warmth, curiosity, or availability phrases.

## Added / changed

| File | Change |
|------|--------|
| `services/orion-cortex-exec/app/router.py` | `_apply_chat_general_identity_boundary_guard` after `_extract_final_text`; diagnostics in logs + `runtime_response_diagnostics` |
| `orion/cognition/prompts/chat_stance_brief.j2` | LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT (semantic, no keywords) |
| `orion/cognition/prompts/chat_general.j2` | Internal assistant/user identity block; obey stance priorities/hazards for reduced interaction load |
| `services/orion-cortex-exec/tests/test_router_identity_boundary.py` | **New** — guard + banned-symbol tests |
| `services/orion-cortex-exec/tests/test_router_final_text_assembly.py` | Removed scrubber tests; extract no longer applies identity guard |
| `services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py` | Prompt contract + dizzy-car stance fixture |

### Identity guard contract

- **Scope:** `chat_general` only
- **Catches:** `You're Oríon`, `You are Orion`, `your name is orion`, etc.
- **Repair:** substitute `I'm Oríon` (does not rewrite general prose)
- **Diagnostics:** `identity_boundary_applied`, `identity_boundary_violations`
- **Wiring:** repaired text → `final_text`, `ctx["chat_general_final_text_clean"]`, `PlanExecutionResult`

### Low-bandwidth contract (prompt-only)

Stance synthesizer should populate existing fields, e.g.:

- `identity_salience`: `low` (unless explicit identity ask)
- `task_mode`: `triage` / `direct_response` (not `identity_dialogue`)
- `response_priorities`: `reduce_interaction_load`, `release_user_from_replying`, `keep_response_short`, …
- `response_hazards`: `avoid_open_ended_questions`, `do_not_invite_continued_typing`, `avoid_presence_centering`, …

## Commits

1. `fix(cortex-exec): remove regex interaction scrubber; narrow identity guard`
2. `feat(cognition): semantic low-bandwidth stance and speech identity rails`
3. `test(cortex-exec): identity boundary and low-bandwidth prompt contracts`
4. `fix(cortex-exec): log identity boundary diagnostics on final text assembly`

## Verification

```bash
cd .worktrees/chat-general-identity-low-bandwidth-semantic
PYTHONPATH=. /path/to/venv/bin/python -m pytest \
  services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py \
  services/orion-cortex-exec/tests/test_router_identity_boundary.py \
  services/orion-cortex-exec/tests/test_router_final_text_assembly.py -q
# 38 passed

PYTHONPATH=. /path/to/venv/bin/python -m pytest \
  services/orion-cortex-exec/tests/test_chat_stance_brief.py -q
# 17 passed, 2 failed (pre-existing on main: observer consumer label drift)

python -m compileall services/orion-cortex-exec/app  # exit 0

rg "_SOMATIC_USER_LOAD_RE|_INTERACTION_DEMAND_RE|_INTERACTION_DEMAND_REPLACEMENTS" .
# only test_router_identity_boundary.py (negative assertion)
```

## Test plan (manual)

- [ ] `chat_general` turn: *"I'm getting dizzy typing to you while my wife drives the car lol"* — short reply, no `"You're Oríon"`, no poetic loyalty/presence centering, no open-ended questions.
- [ ] Forced bad LLM output containing `You're Oríon` — exec log shows `identity_boundary_applied=True`.
- [ ] `chat_quick` / other verbs — identity guard does not run.
- [ ] Normal identity line *"I'm Oríon. You're Juniper."* — unchanged when model emits it correctly.

## Risks / follow-up

- **LLM adherence:** Low-bandwidth behavior depends on stance synthesis + speech pass following prompts; no runtime tone rewrite.
- **Blunt identity repair:** Embedded inversions in long sentences get a substring replace (acceptable safety rail).
- **Pre-existing test failures** in `test_chat_stance_brief.py` (observer `consumer` label) — unrelated to this PR.
- **Stale doc:** `2026-05-16-chat-general-speech-boundary-guards-pr.md` describes the reverted design; superseded by this report.

## Env / compose

No `.env_example`, `settings.py`, or `docker-compose` changes required.
