### PR TITLE
Feature/hub presence grounding

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-16-hub-presence-grounding-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-16-hub-presence-grounding-pr.md
@@ -1,0 +1,112 @@
+# PR: Hub presence grounding hardening
+
+**Branch:** `feature/hub-presence-grounding`  
+**Worktree:** `.worktrees/hub-presence-grounding`  
+**Base:** `master` (`a06463a8`)  
+**Commit:** `7b64048e`
+
+## Summary
+
+Session-scoped **audience presence** (solo / kid_present / family / etc.) already existed across Hub API, UI, chat metadata, cortex-exec situation, and chat prompts. This PR proves the chain, fixes the main stale-cache seam, unifies HTTP/WebSocket injection, improves observability, and adds tests plus a smoke script.
+
+**Answer:** Presence **does work** end-to-end when the session id is consistent. The main bug was cortex-exec `build_situation_for_ctx` caching by `session_id` only, so a mid-session presence change could keep solo grounding until TTL expiry.
+
+## Classification (preflight)
+
+**E — Multiple seams, mostly D + C:**
+
+| Seam | Severity | Status in PR |
+|------|----------|--------------|
+| Situation cache ignored presence changes | **C** | Fixed (fingerprint in cache key) |
+| `loadPresenceContext()` before `initSession()` on first visit | Minor | Fixed (reload after session init) |
+| HTTP vs WS presence inject duplicated | Minor | Fixed (`presence_session.py` helper) |
+| Tests / smoke / debug flags | **D** | Added |
+| UI modal / API store | Already worked | No redesign |
+
+## Consumers (verified)
+
+| # | Consumer | Evidence |
+|---|----------|----------|
+| 1 | Hub UI / API | `index.html` Presence button; `app.js` modal save/clear/chip; `api_routes.py` GET/POST/DELETE `/api/presence`; `PresenceContextStore` in `main.py` |
+| 2 | Hub `/api/situation/brief` | `api_situation_brief` reads same store (`api_routes.py` ~1018–1049) |
+| 3 | Hub chat builder / WS | `inject_session_presence` + `build_chat_request` → `metadata.presence_context`; WS + HTTP both call helper |
+| 4 | cortex-exec situation | `executor.py` → `build_situation_for_ctx`; affordance `kid_friendly_explanation` when kid_present / child companion |
+| 5 | chat_stance | `build_chat_stance_inputs` / `build_chat_stance_debug_payload` situation + `final_prompt_contract` |
+| 6 | `chat_quick.j2` / `chat_general.j2` | `situation_prompt_fragment` block; `test_situation_prompt_integration` |
+| 7 | Attention / autonomy / detectors | **Not presence consumers** (no wiring found in this pass) |
+
+## NOT consumers (unless proven otherwise)
+
+- Autonomy mutation loop
+- Social / durable memory (unless `persist_to_memory` + `orion_presence_persist_allowed`)
+- notify / actions / dreams workflows
+- `presence_state` websocket connection counter (separate from audience presence)
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `services/orion-cortex-exec/app/situation.py` | Cache key includes presence fingerprint (audience, companions, requestor, privacy, timestamps) |
+| `services/orion-cortex-exec/app/router.py` | `_situation_grounding_metadata_from_ctx`; response metadata debug flags |
+| `services/orion-hub/scripts/presence_session.py` | **New** — shared `inject_session_presence` |
+| `services/orion-hub/scripts/api_routes.py` | Use inject helper on HTTP chat |
+| `services/orion-hub/scripts/websocket_handler.py` | Use inject helper on WS chat |
+| `services/orion-hub/scripts/cortex_request_builder.py` | `routing_debug`: `presence_context_present`, `audience_mode`, `situation_fragment_present` |
+| `services/orion-hub/static/js/app.js` | `loadPresenceContext()` after `initSession()`; remove eager pre-session load |
+| `scripts/smoke_presence_grounding.py` | **New** — API + optional chat smoke |
+| Hub tests | `test_presence_api`, `test_presence_session`, `test_presence_chat_injection`, `test_situation_request_builder` |
+| Cortex tests | `test_situation_provider` (cache + kid_present), `test_router_autonomy_payload_export` (metadata) |
+
+No `.env_example` / docker-compose changes (no new settings).
+
+## Tests run
+
+```bash
+# Hub (from worktree, with services/orion-hub/.env)
+cd .worktrees/hub-presence-grounding/services/orion-hub
+set -a && source /path/to/services/orion-hub/.env && set +a
+PYTHONPATH=".:scripts:../../.." orion_dev/bin/pytest \
+  tests/test_presence_api.py \
+  tests/test_presence_session.py \
+  tests/test_situation_request_builder.py \
+  tests/test_presence_chat_injection.py -q
+# 10 passed
+
+# Cortex-exec
+cd .worktrees/hub-presence-grounding
+PYTHONPATH="services/orion-cortex-exec:." orion_dev/bin/pytest \
+  services/orion-cortex-exec/tests/test_situation_provider.py \
+  services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py::test_situation_grounding_metadata_from_ctx -q
+# 7 passed
+```
+
+## Smoke commands
+
+```bash
+# Presence + situation brief only (no cortex chat)
+python3 scripts/smoke_presence_grounding.py --hub-base http://127.0.0.1:8080 --skip-chat
+
+# Full path (requires running Hub + cortex-exec)
+python3 scripts/smoke_presence_grounding.py --hub-base http://127.0.0.1:8080
+```
+
+Manual curl sequence (same session id throughout):
+
+```bash
+SID="presence-smoke-$(uuidgen | tr -d '-')"
+H=(-H "X-Orion-Session-Id: $SID" -H "Content-Type: application/json")
+curl -s "${H[@]}" http://127.0.0.1:8080/api/presence | jq .audience_mode
+curl -s -X POST "${H[@]}" http://127.0.0.1:8080/api/presence \
+  -d '{"audience_mode":"kid_present","requestor":{"display_name":"Juniper"},"companions":[{"display_name":"Kid","relationship":"child","role":"listener","age_band":"child"}]}' | jq .audience_mode
+curl -s "${H[@]}" http://127.0.0.1:8080/api/situation/brief | jq .presence.audience_mode
+```
+
+## Acceptance
+
+- [x] Hub UI can set/clear presence; chip reflects mode
+- [x] Store is session-scoped with TTL (`PresenceContextStore`)
+- [x] `/api/situation/brief` matches stored presence for same `X-Orion-Session-Id`
+- [x] Chat HTTP/WS inject store when client omits meaningful `presence_context`
+- [x] cortex-exec rebuilds situation when presence changes (cache key)
+- [x] chat_stance / prompts receive fragment (existing path + tests)
+- [x] Debug: `routing_debug` + cortex `metadata` flags for inspect/smoke

--- a/scripts/smoke_presence_grounding.py
+++ b/scripts/smoke_presence_grounding.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Smoke Hub presence → situation brief → chat grounding (session-scoped)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from typing import Any
+
+try:
+    import requests
+except ImportError:
+    print("Install requests to run smoke_presence_grounding.py", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def _headers(session_id: str) -> dict[str, str]:
+    return {"X-Orion-Session-Id": session_id, "Content-Type": "application/json"}
+
+
+def _print_step(label: str, payload: Any) -> None:
+    print(f"\n=== {label} ===")
+    print(json.dumps(payload, indent=2, sort_keys=True)[:4000])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Smoke Hub presence grounding")
+    parser.add_argument("--hub-base", default="http://127.0.0.1:8080", help="Hub base URL")
+    parser.add_argument("--skip-chat", action="store_true", help="Only exercise presence + situation brief APIs")
+    args = parser.parse_args()
+    base = args.hub_base.rstrip("/")
+    session_id = f"smoke-presence-{uuid.uuid4().hex[:12]}"
+    headers = _headers(session_id)
+
+    r = requests.get(f"{base}/api/presence", headers=headers, timeout=15)
+    r.raise_for_status()
+    solo = r.json()
+    _print_step("GET /api/presence (expect solo)", solo)
+    assert str(solo.get("audience_mode") or "solo") == "solo", solo
+
+    kid_payload = {
+        "audience_mode": "kid_present",
+        "requestor": {"display_name": "Juniper", "relationship_to_orion": "primary_operator"},
+        "companions": [
+            {"display_name": "Kid", "relationship": "child", "role": "listener", "age_band": "child"},
+        ],
+        "source": "hub_manual",
+    }
+    r = requests.post(f"{base}/api/presence", headers=headers, json=kid_payload, timeout=15)
+    r.raise_for_status()
+    posted = r.json()
+    _print_step("POST /api/presence kid_present", posted)
+    assert posted.get("audience_mode") == "kid_present"
+
+    r = requests.get(f"{base}/api/presence", headers=headers, timeout=15)
+    r.raise_for_status()
+    got = r.json()
+    _print_step("GET /api/presence (expect kid_present)", got)
+    assert got.get("audience_mode") == "kid_present"
+
+    r = requests.get(f"{base}/api/situation/brief", headers=headers, timeout=15)
+    r.raise_for_status()
+    brief = r.json()
+    _print_step("GET /api/situation/brief", brief)
+    presence = brief.get("presence") or {}
+    assert presence.get("audience_mode") == "kid_present", brief
+
+    if args.skip_chat:
+        print("\nOK: presence + situation brief smoke passed (chat skipped).")
+        return 0
+
+    chat_body = {
+        "messages": [{"role": "user", "content": "explain what a GPU is to the kid listening"}],
+        "mode": "brain",
+        "verbs": ["chat_quick"],
+        "no_write": True,
+        "disable_tts": True,
+    }
+    r = requests.post(f"{base}/api/chat", headers=headers, json=chat_body, timeout=120)
+    r.raise_for_status()
+    chat = r.json()
+    routing = chat.get("routing_debug") or {}
+    raw_meta = {}
+    raw = chat.get("raw") if isinstance(chat.get("raw"), dict) else {}
+    if isinstance(raw.get("metadata"), dict):
+        raw_meta = raw["metadata"]
+    debug = {
+        "routing_debug_presence_context_present": routing.get("presence_context_present"),
+        "routing_debug_audience_mode": routing.get("audience_mode"),
+        "metadata_presence_context_present": raw_meta.get("presence_context_present"),
+        "metadata_audience_mode": raw_meta.get("audience_mode"),
+        "metadata_situation_fragment_present": raw_meta.get("situation_fragment_present"),
+        "chat_stance_debug": chat.get("chat_stance_debug") or raw_meta.get("chat_stance_debug"),
+    }
+    _print_step("POST /api/chat debug slice", debug)
+    assert routing.get("presence_context_present") is True, routing
+    assert routing.get("audience_mode") == "kid_present", routing
+    stance = debug.get("chat_stance_debug") if isinstance(debug.get("chat_stance_debug"), dict) else {}
+    source = stance.get("source_inputs") if isinstance(stance.get("source_inputs"), dict) else {}
+    situation = source.get("situation") if isinstance(source.get("situation"), dict) else {}
+    presence = situation.get("presence") if isinstance(situation.get("presence"), dict) else {}
+    if presence:
+        assert presence.get("audience_mode") == "kid_present", presence
+    print("\nOK: full presence grounding smoke finished.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -395,6 +395,26 @@ def _autonomy_state_preview(ctx: Dict[str, Any]) -> Dict[str, Any] | None:
     return preview
 
 
+def _situation_grounding_metadata_from_ctx(ctx: Dict[str, Any]) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    if isinstance(ctx.get("situation_brief"), dict):
+        metadata["situation_brief"] = ctx.get("situation_brief")
+    if isinstance(ctx.get("situation_prompt_fragment"), dict) and ctx.get("situation_prompt_fragment"):
+        metadata["situation_prompt_fragment"] = ctx.get("situation_prompt_fragment")
+    if isinstance(ctx.get("presence_context"), dict):
+        metadata["presence_context"] = ctx.get("presence_context")
+    presence_ctx = ctx.get("presence_context") if isinstance(ctx.get("presence_context"), dict) else {}
+    metadata["presence_context_present"] = bool(presence_ctx)
+    metadata["audience_mode"] = str(presence_ctx.get("audience_mode") or "solo")
+    fragment = ctx.get("situation_prompt_fragment")
+    metadata["situation_fragment_present"] = isinstance(fragment, dict) and bool(fragment)
+    if isinstance(ctx.get("situation_affordances"), list):
+        metadata["situation_affordances"] = ctx.get("situation_affordances")
+    if ctx.get("temporal_phase") is not None:
+        metadata["temporal_phase"] = ctx.get("temporal_phase")
+    return metadata
+
+
 def _autonomy_payload_from_ctx(ctx: Dict[str, Any]) -> Dict[str, Any]:
     summary = ctx.get("chat_autonomy_summary") if isinstance(ctx.get("chat_autonomy_summary"), dict) else None
     debug = ctx.get("chat_autonomy_debug") if isinstance(ctx.get("chat_autonomy_debug"), dict) else None
@@ -1094,16 +1114,7 @@ class PlanRunner:
                 len(metacog_traces) == 0,
             )
         metadata = _autonomy_payload_from_ctx(ctx)
-        if isinstance(ctx.get("situation_brief"), dict):
-            metadata["situation_brief"] = ctx.get("situation_brief")
-        if isinstance(ctx.get("situation_prompt_fragment"), dict) and ctx.get("situation_prompt_fragment"):
-            metadata["situation_prompt_fragment"] = ctx.get("situation_prompt_fragment")
-        if isinstance(ctx.get("presence_context"), dict):
-            metadata["presence_context"] = ctx.get("presence_context")
-        if isinstance(ctx.get("situation_affordances"), list):
-            metadata["situation_affordances"] = ctx.get("situation_affordances")
-        if ctx.get("temporal_phase") is not None:
-            metadata["temporal_phase"] = ctx.get("temporal_phase")
+        metadata.update(_situation_grounding_metadata_from_ctx(ctx))
         mark_orion_turn(str(ctx.get("session_id") or "global"))
 
         return PlanExecutionResult(

--- a/services/orion-cortex-exec/app/situation.py
+++ b/services/orion-cortex-exec/app/situation.py
@@ -92,11 +92,44 @@ def settings_from_runtime(settings: Any) -> SituationSettings:
     )
 
 
+def _presence_cache_fingerprint(ctx: dict[str, Any]) -> str:
+    raw = ctx.get("presence_context") if isinstance(ctx.get("presence_context"), dict) else {}
+    companions = raw.get("companions") if isinstance(raw.get("companions"), list) else []
+    normalized_companions = [
+        {
+            "display_name": item.get("display_name"),
+            "relationship": item.get("relationship"),
+            "role": item.get("role"),
+            "age_band": item.get("age_band"),
+        }
+        for item in companions[:8]
+        if isinstance(item, dict) and item.get("display_name")
+    ]
+    requestor = raw.get("requestor") if isinstance(raw.get("requestor"), dict) else {}
+    fingerprint = {
+        "audience_mode": str(raw.get("audience_mode") or "solo"),
+        "companions": normalized_companions,
+        "requestor": {
+            "display_name": requestor.get("display_name"),
+            "relationship_to_orion": requestor.get("relationship_to_orion"),
+        },
+        "privacy_mode": raw.get("privacy_mode"),
+        "submitted_at": raw.get("submitted_at"),
+        "expires_at": raw.get("expires_at"),
+    }
+    return json.dumps(fingerprint, sort_keys=True, separators=(",", ":"))
+
+
+def _situation_cache_key(ctx: dict[str, Any]) -> str:
+    session_key = str(ctx.get("session_id") or "global")
+    return f"{session_key}:{_presence_cache_fingerprint(ctx)}"
+
+
 def build_situation_for_ctx(ctx: dict[str, Any], runtime_settings: Any) -> tuple[dict[str, Any], dict[str, Any]]:
     cfg = settings_from_runtime(runtime_settings)
     if not cfg.enabled:
         return {}, {}
-    cache_key = str(ctx.get("session_id") or "global")
+    cache_key = _situation_cache_key(ctx)
     with _LOCK:
         cached = _SITUATION_CACHE.get(cache_key)
         if cached and (datetime.now(UTC) - cached[0]).total_seconds() < cfg.ttl_seconds:

--- a/services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py
+++ b/services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock
 
-from app.router import PlanRunner, _autonomy_payload_from_ctx
+from app.router import PlanRunner, _autonomy_payload_from_ctx, _situation_grounding_metadata_from_ctx
 from orion.core.bus.bus_schemas import ServiceRef
 from orion.schemas.cortex.schemas import ExecutionPlan, ExecutionStep, PlanExecutionArgs, PlanExecutionRequest, StepExecutionResult
 
@@ -339,6 +339,20 @@ def test_autonomy_payload_includes_v2_preview_and_delta() -> None:
     assert md["autonomy_state_v2_preview"]["dominant_drive"] == "coherence"
     assert len(md["autonomy_state_v2_preview"]["active_drives"]) <= 3
     assert md["autonomy_state_delta"]["confidence_delta"] == 0.1
+
+
+def test_situation_grounding_metadata_from_ctx() -> None:
+    md = _situation_grounding_metadata_from_ctx(
+        {
+            "presence_context": {"audience_mode": "kid_present"},
+            "situation_prompt_fragment": {"compact_text": "Presence: kid_present."},
+            "situation_brief": {"kind": "situation.brief.v1"},
+        }
+    )
+    assert md["presence_context_present"] is True
+    assert md["audience_mode"] == "kid_present"
+    assert md["situation_fragment_present"] is True
+    assert md["situation_brief"]["kind"] == "situation.brief.v1"
 
 
 def test_autonomy_payload_includes_turn_effect_when_present() -> None:

--- a/services/orion-cortex-exec/tests/test_situation_provider.py
+++ b/services/orion-cortex-exec/tests/test_situation_provider.py
@@ -46,6 +46,9 @@ def test_situation_marks_temporal_resume_for_long_gap():
 
 
 def test_situation_presence_child_affordance():
+    from app import situation as situation_mod
+
+    situation_mod._SITUATION_CACHE.clear()
     ctx = {
         "session_id": "sid-kid",
         "raw_user_text": "can you explain this for my kid",
@@ -55,9 +58,63 @@ def test_situation_presence_child_affordance():
             "requestor": {"display_name": "Juniper"},
         },
     }
-    brief, _ = build_situation_for_ctx(ctx, _settings())
+    brief, fragment = build_situation_for_ctx(ctx, _settings())
     kinds = {item["kind"] for item in brief["affordances"]}
+    assert brief["presence"]["audience_mode"] == "kid_present"
     assert "kid_friendly_explanation" in kinds
+    assert "kid_present" in fragment["compact_text"]
+
+
+def test_situation_cache_refreshes_when_presence_changes():
+    from app import situation as situation_mod
+
+    situation_mod._SITUATION_CACHE.clear()
+    session = "sid-cache-presence"
+    brief_solo, _ = build_situation_for_ctx(
+        {"session_id": session, "presence_context": {"audience_mode": "solo"}},
+        _settings(orion_situation_ttl_seconds=300),
+    )
+    brief_kid, fragment_kid = build_situation_for_ctx(
+        {
+            "session_id": session,
+            "presence_context": {
+                "audience_mode": "kid_present",
+                "companions": [{"display_name": "Kid", "relationship": "child", "role": "listener", "age_band": "child"}],
+            },
+        },
+        _settings(orion_situation_ttl_seconds=300),
+    )
+    assert brief_solo["presence"]["audience_mode"] == "solo"
+    assert brief_kid["presence"]["audience_mode"] == "kid_present"
+    assert "kid_present" in fragment_kid["compact_text"]
+
+
+def test_situation_cache_refreshes_when_requestor_changes():
+    from app import situation as situation_mod
+
+    situation_mod._SITUATION_CACHE.clear()
+    session = "sid-cache-requestor"
+    build_situation_for_ctx(
+        {
+            "session_id": session,
+            "presence_context": {
+                "audience_mode": "solo",
+                "requestor": {"display_name": "Juniper"},
+            },
+        },
+        _settings(orion_situation_ttl_seconds=300),
+    )
+    brief_guest, _ = build_situation_for_ctx(
+        {
+            "session_id": session,
+            "presence_context": {
+                "audience_mode": "solo",
+                "requestor": {"display_name": "Guest"},
+            },
+        },
+        _settings(orion_situation_ttl_seconds=300),
+    )
+    assert brief_guest["presence"]["requestor"]["display_name"] == "Guest"
 
 
 def test_situation_outdoor_departure_affordance():

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -1822,15 +1822,13 @@ async def handle_chat_request(
     )
     routed_payload = dict(payload)
     routed_payload["no_write"] = bool(no_write)
-    if "presence_context" not in routed_payload:
-        try:
-            from .main import presence_context_store
+    try:
+        from .main import presence_context_store
+        from .presence_session import inject_session_presence
 
-            stored_presence = presence_context_store.get(session_id) if presence_context_store else None
-            if stored_presence:
-                routed_payload["presence_context"] = stored_presence
-        except Exception:
-            pass
+        routed_payload = inject_session_presence(routed_payload, session_id, presence_context_store)
+    except Exception:
+        pass
     routed_payload["mutation_cognition_context"] = build_mutation_cognition_context(store=SUBSTRATE_MUTATION_STORE)
     try:
         req, route_debug, _ = build_chat_request(

--- a/services/orion-hub/scripts/cortex_request_builder.py
+++ b/services/orion-hub/scripts/cortex_request_builder.py
@@ -670,6 +670,12 @@ def build_cortex_chat_request(
         ),
         "skill_runner_deterministic": bool(deterministic_requested),
     }
+    presence_ctx = metadata.get("presence_context") if isinstance(metadata.get("presence_context"), dict) else {}
+    debug["presence_context_present"] = bool(presence_ctx)
+    debug["audience_mode"] = str(presence_ctx.get("audience_mode") or "solo")
+    debug["situation_fragment_present"] = bool(
+        isinstance(metadata.get("situation_prompt_fragment"), dict) and metadata.get("situation_prompt_fragment")
+    )
     if social_room:
         debug["social_skill_allowlist"] = metadata.get("social_skill_request", {}).get("allowlist") or []
         debug["social_skill_selection"] = metadata.get("social_skill_selection")

--- a/services/orion-hub/scripts/presence_session.py
+++ b/services/orion-hub/scripts/presence_session.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def load_session_presence(session_id: str | None, store: Any | None) -> dict[str, Any] | None:
+    """Return session-scoped audience presence, or None when unavailable."""
+    if not store or not session_id:
+        return None
+    payload = store.get(str(session_id))
+    return dict(payload) if isinstance(payload, dict) else None
+
+
+def _payload_has_presence_context(payload: dict[str, Any]) -> bool:
+    presence = payload.get("presence_context")
+    if not isinstance(presence, dict) or not presence:
+        return False
+    if presence.get("audience_mode"):
+        return True
+    companions = presence.get("companions")
+    return isinstance(companions, list) and bool(companions)
+
+
+def inject_session_presence(payload: dict[str, Any], session_id: str | None, store: Any | None) -> dict[str, Any]:
+    """Merge stored presence into a chat payload when the client did not send one."""
+    routed = dict(payload or {})
+    if _payload_has_presence_context(routed):
+        return routed
+    stored = load_session_presence(session_id, store)
+    if stored:
+        routed["presence_context"] = stored
+    return routed

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -33,6 +33,7 @@ from scripts.trace_payloads import extract_agent_trace_payload
 from scripts.autonomy_payloads import extract_autonomy_payload
 from scripts.workflow_payloads import extract_workflow_payload
 from scripts.mutation_cognition_context import build_mutation_cognition_context
+from scripts.presence_session import inject_session_presence
 from scripts.warm_start import mini_personality_summary
 from orion.schemas.cortex.contracts import CortexChatRequest, CortexChatResult
 from orion.schemas.metacognitive_trace import MetacognitiveTraceV1
@@ -572,8 +573,6 @@ async def websocket_endpoint(websocket: WebSocket):
                 turns=turns,
             )
             data = dict(data)
-            from scripts.presence_session import inject_session_presence
-
             data = inject_session_presence(data, str(session_id or "anonymous"), presence_context_store)
             data["mutation_cognition_context"] = build_mutation_cognition_context()
             try:

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -572,10 +572,9 @@ async def websocket_endpoint(websocket: WebSocket):
                 turns=turns,
             )
             data = dict(data)
-            if "presence_context" not in data and presence_context_store:
-                stored_presence = presence_context_store.get(str(session_id or "anonymous"))
-                if stored_presence:
-                    data["presence_context"] = stored_presence
+            from scripts.presence_session import inject_session_presence
+
+            data = inject_session_presence(data, str(session_id or "anonymous"), presence_context_store)
             data["mutation_cognition_context"] = build_mutation_cognition_context()
             try:
                 chat_req, route_debug, use_recall = build_chat_request(

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -9416,8 +9416,6 @@ loadDismissedIds();
       await loadPresenceContext();
     });
   }
-  loadPresenceContext();
-
   async function submitExplicitChatText(text, opts = {}) {
     const value = String(text || '').trim();
     if (!value) return;
@@ -9893,6 +9891,7 @@ loadDismissedIds();
   (async () => {
       // 1. Session
       await initSession();
+      await loadPresenceContext();
       // 2. Library (Safe)
       await loadCognitionLibrary();
       // 3. WS

--- a/services/orion-hub/tests/test_presence_api.py
+++ b/services/orion-hub/tests/test_presence_api.py
@@ -71,6 +71,23 @@ def test_situation_status_and_brief_disabled(monkeypatch):
     assert brief["reason"] == "disabled_by_config"
 
 
+def test_situation_brief_reflects_manual_presence(monkeypatch):
+    store = _Store()
+    monkeypatch.setitem(sys.modules, "scripts.main", types.SimpleNamespace(presence_context_store=store, presence_state=None))
+    hub_api_routes.api_presence_set(
+        {
+            "audience_mode": "kid_present",
+            "requestor": {"display_name": "Juniper"},
+            "companions": [
+                {"display_name": "Kid", "relationship": "child", "role": "listener", "age_band": "child"},
+            ],
+        },
+        x_orion_session_id="sid-kid-brief",
+    )
+    brief = hub_api_routes.api_situation_brief(x_orion_session_id="sid-kid-brief")
+    assert brief["presence"]["audience_mode"] == "kid_present"
+
+
 def test_presence_invalid_payload_is_422(monkeypatch):
     store = _Store()
     monkeypatch.setitem(sys.modules, "scripts.main", types.SimpleNamespace(presence_context_store=store, presence_state=None))

--- a/services/orion-hub/tests/test_presence_chat_injection.py
+++ b/services/orion-hub/tests/test_presence_chat_injection.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+from pathlib import Path
+from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+for candidate in (REPO_ROOT, HUB_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+os.environ.setdefault("CHANNEL_VOICE_TRANSCRIPT", "orion:voice:transcript")
+os.environ.setdefault("CHANNEL_VOICE_LLM", "orion:voice:llm")
+os.environ.setdefault("CHANNEL_VOICE_TTS", "orion:voice:tts")
+os.environ.setdefault("CHANNEL_COLLAPSE_INTAKE", "orion:collapse:intake")
+os.environ.setdefault("CHANNEL_COLLAPSE_TRIAGE", "orion:collapse:triage")
+
+from orion.schemas.cortex.contracts import CortexChatResult, CortexClientResult
+from scripts.api_routes import handle_chat_request
+
+
+class _Store:
+    def __init__(self):
+        self.values = {}
+
+    def get(self, key):
+        return self.values.get(key)
+
+
+class _FakeCortexClient:
+    def __init__(self) -> None:
+        self.requests = []
+
+    async def chat(self, req, correlation_id=None):
+        self.requests.append((req, correlation_id))
+        result = CortexClientResult(
+            ok=True,
+            mode="brain",
+            verb="chat_quick",
+            status="success",
+            final_text="ok",
+            memory_used=False,
+            recall_debug={},
+            steps=[],
+            correlation_id=correlation_id or str(uuid4()),
+            metadata={},
+        )
+        return CortexChatResult(cortex_result=result, final_text=result.final_text)
+
+
+def test_handle_chat_request_injects_session_presence(monkeypatch) -> None:
+    store = _Store()
+    store.values["sid-presence-chat"] = {
+        "audience_mode": "kid_present",
+        "requestor": {"display_name": "Juniper"},
+    }
+    monkeypatch.setitem(
+        sys.modules,
+        "scripts.main",
+        types.SimpleNamespace(presence_context_store=store, presence_state=None),
+    )
+    client = _FakeCortexClient()
+    payload = {
+        "mode": "brain",
+        "verbs": ["chat_quick"],
+        "messages": [{"role": "user", "content": "explain GPUs simply"}],
+    }
+    result = asyncio.run(handle_chat_request(client, payload, "sid-presence-chat", no_write=True))
+    assert not result.get("error")
+    req, _ = client.requests[0]
+    assert req.metadata["presence_context"]["audience_mode"] == "kid_present"
+    assert result["routing_debug"]["presence_context_present"] is True
+    assert result["routing_debug"]["audience_mode"] == "kid_present"

--- a/services/orion-hub/tests/test_presence_session.py
+++ b/services/orion-hub/tests/test_presence_session.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+HUB_ROOT = Path(__file__).resolve().parents[1]
+if str(HUB_ROOT) not in sys.path:
+    sys.path.insert(0, str(HUB_ROOT))
+
+presence_session = importlib.import_module("scripts.presence_session")
+
+
+class _Store:
+    def __init__(self):
+        self.values = {}
+
+    def get(self, key):
+        return self.values.get(key)
+
+
+def test_inject_session_presence_uses_store_when_payload_missing():
+    store = _Store()
+    store.values["sid-1"] = {"audience_mode": "kid_present"}
+    out = presence_session.inject_session_presence({}, "sid-1", store)
+    assert out["presence_context"]["audience_mode"] == "kid_present"
+
+
+def test_inject_session_presence_fills_empty_client_dict_from_store():
+    store = _Store()
+    store.values["sid-1"] = {"audience_mode": "kid_present"}
+    out = presence_session.inject_session_presence({"presence_context": {}}, "sid-1", store)
+    assert out["presence_context"]["audience_mode"] == "kid_present"
+
+
+def test_inject_session_presence_preserves_client_payload():
+    store = _Store()
+    store.values["sid-1"] = {"audience_mode": "solo"}
+    out = presence_session.inject_session_presence(
+        {"presence_context": {"audience_mode": "family"}},
+        "sid-1",
+        store,
+    )
+    assert out["presence_context"]["audience_mode"] == "family"

--- a/services/orion-hub/tests/test_situation_request_builder.py
+++ b/services/orion-hub/tests/test_situation_request_builder.py
@@ -32,3 +32,5 @@ def test_build_chat_request_includes_presence_metadata():
     assert req.metadata["surface_context"]["surface"] == "hub_desktop"
     assert req.metadata["browser_client_id"] == "browser-1"
     assert debug["mode"] == "brain"
+    assert debug["presence_context_present"] is True
+    assert debug["audience_mode"] == "kid_present"


### PR DESCRIPTION
## Summary
- Fix cortex-exec situation cache so mid-session presence changes (solo → kid_present) rebuild grounding instead of serving stale solo until TTL.
- Unify HTTP/WebSocket session presence injection via `presence_session.inject_session_presence`.
- Add routing/metadata debug flags (`presence_context_present`, `audience_mode`, `situation_fragment_present`) and reload presence after `initSession()` in Hub UI.
- Fix Hub startup: keep `from __future__` valid in `websocket_handler.py` (module-level imports only).
- Add Hub/cortex tests and `scripts/smoke_presence_grounding.py`.

## Test plan
- [x] Hub: `pytest tests/test_presence_api.py tests/test_presence_session.py tests/test_situation_request_builder.py tests/test_presence_chat_injection.py -q` (10 passed)
- [x] Cortex: `pytest services/orion-cortex-exec/tests/test_situation_provider.py` + `test_situation_grounding_metadata_from_ctx` (7 passed)
- [ ] Smoke: `python3 scripts/smoke_presence_grounding.py --hub-base http://127.0.0.1:8080 --skip-chat`
- [ ] Manual: set Presence to Kid present, send chat, confirm Inspect shows `audience_mode=kid_present`