### PR TITLE
Feat/mind llm fail open observability

### DIFF
--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -1160,10 +1160,13 @@ loadDismissedIds();
     const safeStatus = escapeHtml(run.ok ? "ok" : "failed");
     const safeCreated = escapeHtml(formatMindTs(run.created_at_utc));
     parts.push(`<div class="text-[11px] text-gray-400">Run ${safeRunId} · ${safeStatus} · ${safeCreated}</div>`);
+    if (globalThis.OrionMindProvenance && typeof globalThis.OrionMindProvenance.renderMindProvenanceSections === "function") {
+      parts.push(globalThis.OrionMindProvenance.renderMindProvenanceSections(run));
+    }
     parts.push(mindRequestOverviewHtml(reqParsed));
     parts.push(mindResultOverviewHtml(resultParsed));
-    parts.push(`<details class="rounded border border-gray-800 bg-gray-950/40 p-2" open><summary class="cursor-pointer text-[11px] text-gray-300">Decision / brief (JSON)</summary><pre class="mt-2 whitespace-pre-wrap break-words font-mono text-[11px] text-gray-200">${escapeHtml(JSON.stringify(reqPretty, null, 2))}</pre></details>`);
-    parts.push(`<details class="rounded border border-gray-800 bg-gray-950/40 p-2" open><summary class="cursor-pointer text-[11px] text-gray-300">Trajectory / result (JSON)</summary><pre class="mt-2 whitespace-pre-wrap break-words font-mono text-[11px] text-gray-200">${escapeHtml(JSON.stringify(resultPretty, null, 2))}</pre></details>`);
+    parts.push(`<details class="rounded border border-gray-800 bg-gray-950/40 p-2"><summary class="cursor-pointer text-[11px] text-gray-300">Decision / brief (JSON)</summary><pre class="mt-2 whitespace-pre-wrap break-words font-mono text-[11px] text-gray-200">${escapeHtml(JSON.stringify(reqPretty, null, 2))}</pre></details>`);
+    parts.push(`<details class="rounded border border-gray-800 bg-gray-950/40 p-2"><summary class="cursor-pointer text-[11px] text-gray-300">Trajectory / result (JSON)</summary><pre class="mt-2 whitespace-pre-wrap break-words font-mono text-[11px] text-gray-200">${escapeHtml(JSON.stringify(resultPretty, null, 2))}</pre></details>`);
     parts.push(`<details class="rounded border border-gray-800 bg-gray-950/40 p-2"><summary class="cursor-pointer text-[11px] text-gray-300">Raw run payload</summary><pre class="mt-2 whitespace-pre-wrap break-words font-mono text-[11px] text-gray-200">${escapeHtml(JSON.stringify(runForRaw, null, 2))}</pre></details>`);
     mindRunsModalDetails.innerHTML = parts.join("");
   }

--- a/services/orion-hub/static/js/mind_provenance.js
+++ b/services/orion-hub/static/js/mind_provenance.js
@@ -1,0 +1,586 @@
+(function (global) {
+  const SOURCE_TAG_LABELS = new Set([
+    "identity_yaml",
+    "snapshot_source",
+    "projection",
+    "autonomy",
+    "social_bridge",
+  ]);
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function asObject(value) {
+    return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+  }
+
+  function asList(value) {
+    return Array.isArray(value) ? value : [];
+  }
+
+  function asBool(value) {
+    return value === true;
+  }
+
+  function shortId(value, len) {
+    const s = String(value || "").trim();
+    if (!s) return "—";
+    if (s.length <= (len || 8)) return s;
+    return `${s.slice(0, len || 8)}…`;
+  }
+
+  function parseMindJsonbField(value) {
+    if (value == null) return null;
+    if (typeof value === "object") return value;
+    if (typeof value === "string") {
+      try {
+        return JSON.parse(value);
+      } catch (_err) {
+        return { _unparsed: value };
+      }
+    }
+    return null;
+  }
+
+  function machineContract(resultParsed) {
+    const brief = asObject(resultParsed?.brief);
+    return asObject(brief?.machine_contract) || {};
+  }
+
+  function phaseTelemetryRecords(mc) {
+    return asList(mc["mind.phase_telemetry"]);
+  }
+
+  function findPhaseTelemetry(mc, phaseName) {
+    return phaseTelemetryRecords(mc).find((row) => row && row.phase_name === phaseName) || null;
+  }
+
+  function trajectoryModelIds(resultParsed) {
+    const patches = asList(resultParsed?.trajectory?.patches);
+    return patches
+      .map((p) => asObject(p)?.provenance?.model_id)
+      .filter((m) => typeof m === "string" && m.trim());
+  }
+
+  function normalizeMindRunProvenance(run) {
+    const resultParsed = parseMindJsonbField(run?.result_jsonb);
+    const reqParsed = parseMindJsonbField(run?.request_summary_jsonb);
+    const mc = machineContract(resultParsed);
+    const brief = asObject(resultParsed?.brief);
+    const llmEnabled = asBool(mc["mind.llm_synthesis_enabled"]);
+    const llmAttempted = asBool(mc["mind.llm_synthesis_attempted"]);
+    const failOpenToDeterministic = asBool(mc["mind.llm_fail_open_to_deterministic"]);
+    const failedPhase = mc["mind.llm_synthesis_failed_phase"] || null;
+    const mindQuality = String(brief?.mind_quality || resultParsed?.mind_quality || mc["mind.quality"] || "unknown");
+    const authorizedSkip = asBool(brief?.mind_authorized_for_stance_skip) || asBool(mc["mind.authorized_for_stance_skip"]);
+    const authorizedUse = asBool(mc["mind.authorized_for_stance_use"]);
+    const models = trajectoryModelIds(resultParsed);
+    const deterministicTrajectory = models.length > 0 && models.every((m) => m === "deterministic");
+
+    let cognitionPath = "unknown";
+    if (run && run.ok === false) {
+      cognitionPath = "error";
+    } else if (failOpenToDeterministic || (llmAttempted && (deterministicTrajectory || mindQuality !== "meaningful_synthesis"))) {
+      cognitionPath = "llm_fail_open_to_deterministic";
+    } else if (llmAttempted && mindQuality === "meaningful_synthesis") {
+      cognitionPath = "llm_synthesis";
+    } else if (!llmEnabled && mindQuality === "shadow_synthesis") {
+      cognitionPath = "deterministic_shadow";
+    } else if (mindQuality === "fallback_contract_only") {
+      cognitionPath = "deterministic_contract";
+    } else if (mindQuality === "shadow_synthesis") {
+      cognitionPath = "deterministic_shadow";
+    } else if (deterministicTrajectory) {
+      cognitionPath = "deterministic_shadow";
+    }
+
+    let finalSource = "unknown";
+    if (mindQuality === "meaningful_synthesis" && authorizedUse) {
+      finalSource = "mind_llm_handoff";
+    } else if (mindQuality === "shadow_synthesis") {
+      finalSource = "deterministic_shadow";
+    } else if (mindQuality === "fallback_contract_only") {
+      finalSource = "contract_only";
+    } else if (deterministicTrajectory && !llmAttempted) {
+      finalSource = "legacy_chat_stance";
+    } else if (cognitionPath === "llm_fail_open_to_deterministic") {
+      finalSource = mindQuality === "shadow_synthesis" ? "deterministic_shadow" : "contract_only";
+    }
+
+    const timing = asObject(resultParsed?.timing_ms_by_phase) || {};
+    const totalMs = Number(timing.total_ms ?? timing["total_ms"] ?? mc["mind.wall_time_elapsed_ms"] ?? 0);
+
+    return {
+      cognition_path: cognitionPath,
+      final_source: finalSource,
+      llm_enabled: llmEnabled,
+      llm_attempted: llmAttempted,
+      fail_open_to_deterministic: failOpenToDeterministic,
+      failed_phase: failedPhase,
+      error_code: run?.error_code || mc["mind.llm_synthesis_error_code"] || resultParsed?.error_code || null,
+      error: mc["mind.llm_synthesis_error"] || null,
+      routes: {
+        semantic: mc["mind.semantic_route"] || null,
+        appraisal: mc["mind.appraisal_route"] || null,
+        stance: mc["mind.stance_route"] || null,
+      },
+      mind_quality: mindQuality,
+      authorized_for_stance_skip: authorizedSkip,
+      authorized_for_stance_use: authorizedUse,
+      snapshot_hash: shortId(run?.snapshot_hash || resultParsed?.snapshot_hash, 12),
+      mind_run_id: shortId(run?.mind_run_id || resultParsed?.mind_run_id, 12),
+      correlation_id: shortId(run?.correlation_id || reqParsed?.correlation_id, 12),
+      session_visibility: run?.session_visibility || null,
+      total_ms: Number.isFinite(totalMs) ? Math.round(totalMs) : null,
+      router_profile_id: run?.router_profile_id || null,
+    };
+  }
+
+  function phaseStatusFromTelemetry(telemetry, mc, phaseName) {
+    if (!telemetry) {
+      if (phaseName === "deterministic_fallback") {
+        return mc["mind.llm_fail_open_to_deterministic"] ? "fallback" : "not_attempted";
+      }
+      return "not_attempted";
+    }
+    if (telemetry.skipped) return "skipped";
+    if (telemetry.ok === false) return "failed";
+    if (phaseName === "semantic_synthesis" && telemetry.validation_ok === false) return "filtered";
+    if (telemetry.ok === true) return "ok";
+    return "failed";
+  }
+
+  function normalizeMindPhaseRows(run) {
+    const resultParsed = parseMindJsonbField(run?.result_jsonb);
+    const mc = machineContract(resultParsed);
+    const prov = normalizeMindRunProvenance(run);
+    const phases = ["semantic_synthesis", "active_frontier_judge", "stance_handoff"];
+    const rows = phases.map((phaseName) => {
+      const telemetry = findPhaseTelemetry(mc, phaseName);
+      const routeKey =
+        phaseName === "semantic_synthesis"
+          ? "semantic"
+          : phaseName === "active_frontier_judge"
+            ? "appraisal"
+            : "stance";
+      let outputCount = null;
+      if (phaseName === "semantic_synthesis") {
+        outputCount = mc["mind.semantic_claim_count"];
+      } else if (phaseName === "active_frontier_judge") {
+        outputCount = mc["mind.active_frontier_selected_count"];
+      }
+      return {
+        phase: phaseName,
+        status: phaseStatusFromTelemetry(telemetry, mc, phaseName),
+        route: (telemetry && telemetry.route) || prov.routes[routeKey] || null,
+        model: (telemetry && telemetry.model) || null,
+        elapsed_ms: telemetry && Number.isFinite(Number(telemetry.elapsed_ms)) ? Math.round(Number(telemetry.elapsed_ms)) : null,
+        parse_ok: telemetry ? telemetry.parse_ok : null,
+        validation_ok: telemetry ? telemetry.validation_ok : null,
+        token_usage: telemetry ? telemetry.token_usage || {} : {},
+        error: (telemetry && (telemetry.error || telemetry.skip_reason)) || null,
+        output_count: outputCount,
+      };
+    });
+    if (prov.cognition_path === "llm_fail_open_to_deterministic" || prov.fail_open_to_deterministic) {
+      const timing = asObject(resultParsed?.timing_ms_by_phase) || {};
+      rows.push({
+        phase: "deterministic_fallback",
+        status: "fallback",
+        route: "deterministic",
+        model: "deterministic",
+        elapsed_ms: Number.isFinite(Number(timing.loops_ms)) ? Math.round(Number(timing.loops_ms)) : null,
+        parse_ok: true,
+        validation_ok: true,
+        token_usage: {},
+        error: prov.error || (asList(mc["mind.fallback_reason"])[0] || null),
+        output_count: null,
+      });
+    }
+    return rows;
+  }
+
+  function textBlob(run) {
+    const resultParsed = parseMindJsonbField(run?.result_jsonb);
+    const mc = machineContract(resultParsed);
+    const diag = asList(resultParsed?.diagnostics).join(" ");
+    const fallback = asList(mc["mind.fallback_reason"]).join(" ");
+    const labels = asList(mc["mind.semantic_claim_labels"]).join(" ");
+    return `${diag} ${fallback} ${labels} ${mc["mind.llm_synthesis_error"] || ""}`.toLowerCase();
+  }
+
+  function hasSourceTagLeakage(run, mc) {
+    const labels = asList(mc["mind.semantic_claim_labels"]);
+    if (labels.some((label) => SOURCE_TAG_LABELS.has(String(label || "").toLowerCase()))) return true;
+    const resultParsed = parseMindJsonbField(run?.result_jsonb);
+    const brief = asObject(resultParsed?.brief);
+    const suppressed = asList(brief?.semantic_synthesis?.suppressed);
+    return suppressed.some((s) => String(s?.reason || "").includes("source_tag"));
+  }
+
+  function normalizeMindDerailments(run) {
+    const resultParsed = parseMindJsonbField(run?.result_jsonb);
+    const mc = machineContract(resultParsed);
+    const brief = asObject(resultParsed?.brief);
+    const prov = normalizeMindRunProvenance(run);
+    const blob = textBlob(run);
+    const callouts = [];
+    const push = (item) => callouts.push(item);
+
+    if (prov.llm_attempted && (prov.fail_open_to_deterministic || prov.failed_phase)) {
+      push({
+        id: "llm_fail_open",
+        severity: "error",
+        stage: prov.failed_phase || "llm_pipeline",
+        title: "Mind LLM synthesis failed open before a usable handoff.",
+        explanation:
+          `LLM synthesis was enabled and attempted, but ${prov.failed_phase || "the pipeline"} did not produce an authorized handoff. Mind fell back to ${prov.mind_quality} / deterministic output; Exec should not skip legacy chat_stance.`,
+        next_action:
+          `Check gateway routes (${prov.routes.semantic || "?"}/${prov.routes.appraisal || "?"}/${prov.routes.stance || "?"}), semantic JSON validity, and evidence_refs in semantic output.`,
+        evidence: {
+          error_code: prov.error_code,
+          error: prov.error,
+          failed_phase: prov.failed_phase,
+          fallback_reason: asList(mc["mind.fallback_reason"]),
+        },
+      });
+    }
+
+    const semTelemetry = findPhaseTelemetry(mc, "semantic_synthesis");
+    if (prov.failed_phase === "semantic_synthesis" || (semTelemetry && semTelemetry.ok === false)) {
+      push({
+        id: "semantic_failed",
+        severity: "error",
+        stage: "semantic_synthesis",
+        title: "Semantic synthesis phase failed.",
+        explanation: semTelemetry?.error
+          ? `Semantic phase reported: ${semTelemetry.error}.`
+          : "Semantic phase did not return usable claims.",
+        next_action: `Inspect semantic route \`${prov.routes.semantic || "quick"}\` and LLM JSON output.`,
+        evidence: { telemetry: semTelemetry, diagnostics: asList(resultParsed?.diagnostics) },
+      });
+    }
+
+    if (
+      (semTelemetry && semTelemetry.validation_ok === false) ||
+      (Number(mc["mind.semantic_claim_count"]) === 0 && (semTelemetry || prov.llm_attempted))
+    ) {
+      push({
+        id: "semantic_filtered",
+        severity: "warning",
+        stage: "semantic_synthesis",
+        title: "Semantic claims were filtered or empty after guardrails.",
+        explanation:
+          "The semantic model responded, but guardrails removed all claims (unsupported evidence, source tags, or weak grounding).",
+        next_action: "Review semantic claim labels, evidence_refs, and suppressed reasons in the raw synthesis JSON.",
+        evidence: {
+          semantic_claim_count: mc["mind.semantic_claim_count"],
+          semantic_claim_labels: asList(mc["mind.semantic_claim_labels"]),
+          suppressed: asList(brief?.semantic_synthesis?.suppressed),
+        },
+      });
+    }
+
+    if (hasSourceTagLeakage(run, mc)) {
+      push({
+        id: "source_tag_leakage",
+        severity: "warning",
+        stage: "semantic_synthesis",
+        title: "Source-tag labels leaked into semantic claims.",
+        explanation: "Semantic output used infrastructure/source labels instead of user-meaningful claims.",
+        next_action: "Tune semantic prompt and verify guardrails suppress source_tag labels.",
+        evidence: { semantic_claim_labels: asList(mc["mind.semantic_claim_labels"]) },
+      });
+    }
+
+    if (blob.includes("unsupported_or_weak") || blob.includes("evidence_ref")) {
+      push({
+        id: "missing_evidence_refs",
+        severity: "warning",
+        stage: "semantic_synthesis",
+        title: "Claims lacked supported evidence references.",
+        explanation: "Diagnostics or fallback reasons mention missing/unsupported evidence refs.",
+        next_action: "Ensure semantic claims cite current_turn / recall / projection refs present in the evidence pack.",
+        evidence: { diagnostics: asList(resultParsed?.diagnostics), fallback_reason: asList(mc["mind.fallback_reason"]) },
+      });
+    }
+
+    if (prov.mind_quality === "shadow_synthesis" && !prov.authorized_for_stance_skip) {
+      push({
+        id: "shadow_only",
+        severity: "info",
+        stage: "deterministic",
+        title: "Shadow synthesis only — stance skip denied.",
+        explanation: "Mind produced shadow synthesis from projection but did not authorize Exec to skip legacy stance.",
+        next_action: "Inspect projection richness and shadow_synthesis fields; expect legacy chat_stance path.",
+        evidence: { mind_quality: prov.mind_quality, authorized_for_stance_skip: prov.authorized_for_stance_skip },
+      });
+    }
+
+    if (prov.mind_quality === "fallback_contract_only") {
+      push({
+        id: "contract_only",
+        severity: "info",
+        stage: "deterministic",
+        title: "Contract-only Mind output.",
+        explanation: "No meaningful synthesis; Mind returned a minimal contract for routing only.",
+        next_action: "Check whether LLM synthesis was disabled, failed open, or projection-starved.",
+        evidence: { mind_quality: prov.mind_quality, cognition_path: prov.cognition_path },
+      });
+    }
+
+    const handoff = asObject(brief?.stance_handoff);
+    if ((handoff && handoff.authorized_for_stance_use === false) || (prov.llm_attempted && !prov.authorized_for_stance_use)) {
+      push({
+        id: "handoff_rejected",
+        severity: "warning",
+        stage: "stance_handoff",
+        title: "Mind handoff not authorized for Exec stance skip.",
+        explanation:
+          "Mind produced a handoff object but did not authorize stance use. Exec should keep legacy chat_stance synthesis.",
+        next_action: "Review authorization_reasons and mind_quality; do not expect mind_skip_stance_synthesis.",
+        evidence: {
+          authorization_reasons: asList(mc["mind.authorization_reasons"]),
+          mind_authorized_for_stance_skip: prov.authorized_for_stance_skip,
+          authorized_for_stance_use: prov.authorized_for_stance_use,
+        },
+      });
+    }
+
+    const severityRank = { error: 0, warning: 1, info: 2 };
+    callouts.sort((a, b) => (severityRank[a.severity] ?? 9) - (severityRank[b.severity] ?? 9));
+    return callouts;
+  }
+
+  function normalizeMindDecision(run) {
+    const prov = normalizeMindRunProvenance(run);
+    const resultParsed = parseMindJsonbField(run?.result_jsonb);
+    const mc = machineContract(resultParsed);
+    let execHandoff = "unknown";
+    if (prov.authorized_for_stance_use && prov.mind_quality === "meaningful_synthesis") {
+      execHandoff = "would_skip_legacy_chat_stance";
+    } else if (prov.llm_attempted || prov.mind_quality !== "meaningful_synthesis") {
+      execHandoff = "legacy_chat_stance_expected";
+    }
+    return {
+      exec_handoff: execHandoff,
+      mind_skip_stance_synthesis: prov.authorized_for_stance_skip && prov.authorized_for_stance_use,
+      authorization_reasons: asList(mc["mind.authorization_reasons"]),
+    };
+  }
+
+  function chip(label, value, tone) {
+    const toneClass =
+      tone === "ok"
+        ? "border-emerald-800/60 bg-emerald-950/40 text-emerald-200"
+        : tone === "warn"
+          ? "border-amber-800/60 bg-amber-950/40 text-amber-200"
+          : tone === "bad"
+            ? "border-rose-800/60 bg-rose-950/40 text-rose-200"
+            : "border-gray-700 bg-gray-900/60 text-gray-200";
+    return `<div class="rounded border px-2 py-1 ${toneClass}"><div class="text-[9px] uppercase tracking-wide text-gray-500">${escapeHtml(label)}</div><div class="mt-0.5 text-[11px] font-medium">${escapeHtml(value)}</div></div>`;
+  }
+
+  function renderMindProvenance(provenance) {
+    const p = provenance || {};
+    const authTone = p.authorized_for_stance_use ? "ok" : p.authorized_for_stance_skip ? "warn" : "bad";
+    const chips = [
+      chip("Cognition path", p.cognition_path || "unknown", p.cognition_path === "llm_synthesis" ? "ok" : "warn"),
+      chip("Final source", p.final_source || "unknown", "neutral"),
+      chip("LLM enabled", p.llm_enabled ? "yes" : "no", p.llm_enabled ? "ok" : "neutral"),
+      chip("LLM attempted", p.llm_attempted ? "yes" : "no", p.llm_attempted ? "ok" : "neutral"),
+      chip("Mind quality", p.mind_quality || "unknown", "neutral"),
+      chip("Authorized", p.authorized_for_stance_use ? "yes" : "no", authTone),
+    ];
+    if (p.failed_phase) chips.push(chip("Failed phase", p.failed_phase, "bad"));
+    if (p.routes?.semantic) chips.push(chip("Semantic route", p.routes.semantic, "neutral"));
+    if (p.routes?.appraisal) chips.push(chip("Appraisal route", p.routes.appraisal, "neutral"));
+    if (p.routes?.stance) chips.push(chip("Stance route", p.routes.stance, "neutral"));
+    if (p.snapshot_hash) chips.push(chip("Snapshot", p.snapshot_hash, "neutral"));
+    if (p.total_ms != null) chips.push(chip("Wall time", `${p.total_ms} ms`, "neutral"));
+    return `<div class="mb-3 rounded border border-gray-800 bg-gray-950/50 p-3"><div class="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Provenance</div><div class="mt-2 grid grid-cols-2 gap-2 md:grid-cols-3">${chips.join("")}</div><div class="mt-2 text-[10px] text-gray-500">run ${escapeHtml(p.mind_run_id || "—")} · corr ${escapeHtml(p.correlation_id || "—")} · visibility ${escapeHtml(p.session_visibility || "—")}</div></div>`;
+  }
+
+  function calloutSeverityClass(severity) {
+    if (severity === "error") return "border-rose-800/70 bg-rose-950/30 text-rose-100";
+    if (severity === "warning") return "border-amber-800/70 bg-amber-950/30 text-amber-100";
+    return "border-emerald-800/60 bg-emerald-950/20 text-emerald-100";
+  }
+
+  function renderMindDerailmentCallouts(callouts) {
+    if (!callouts || !callouts.length) {
+      return `<div class="mb-3 rounded border border-emerald-900/50 bg-emerald-950/20 p-3"><div class="text-[11px] font-medium text-emerald-200">Mind path completed without derailment.</div></div>`;
+    }
+    const primary = callouts[0];
+    const primaryHtml = `<div class="mb-3 rounded border p-3 ${calloutSeverityClass(primary.severity)}"><div class="text-[10px] uppercase tracking-wide opacity-80">Where it went off rails · ${escapeHtml(primary.stage || "mind")}</div><div class="mt-1 text-sm font-semibold">${escapeHtml(primary.title || "")}</div><div class="mt-2 text-[11px] leading-relaxed opacity-95">${escapeHtml(primary.explanation || "")}</div><div class="mt-2 text-[10px] uppercase tracking-wide opacity-70">Next action</div><div class="mt-1 text-[11px]">${escapeHtml(primary.next_action || "")}</div><details class="mt-2"><summary class="cursor-pointer text-[10px] opacity-80">Evidence</summary><pre class="mt-1 whitespace-pre-wrap break-words font-mono text-[10px] opacity-90">${escapeHtml(JSON.stringify(primary.evidence || {}, null, 2))}</pre></details></div>`;
+    if (callouts.length === 1) return primaryHtml;
+    const rest = callouts
+      .slice(1)
+      .map(
+        (c) =>
+          `<details class="rounded border border-gray-800 bg-gray-950/40 p-2"><summary class="cursor-pointer text-[11px] text-gray-300">[${escapeHtml(c.severity)}] ${escapeHtml(c.title || c.id || "callout")}</summary><div class="mt-2 text-[11px] text-gray-300">${escapeHtml(c.explanation || "")}</div><pre class="mt-2 whitespace-pre-wrap break-words font-mono text-[10px] text-gray-400">${escapeHtml(JSON.stringify(c.evidence || {}, null, 2))}</pre></details>`,
+      )
+      .join("");
+    return `${primaryHtml}<details class="mb-3 rounded border border-gray-800 bg-gray-950/30 p-2"><summary class="cursor-pointer text-[11px] text-gray-300">Additional derailments (${callouts.length - 1})</summary><div class="mt-2 space-y-2">${rest}</div></details>`;
+  }
+
+  function renderMindPhaseTable(rows) {
+    const header =
+      '<thead><tr class="text-left text-[10px] uppercase tracking-wide text-gray-500"><th class="px-2 py-1">Phase</th><th class="px-2 py-1">Status</th><th class="px-2 py-1">Route</th><th class="px-2 py-1">Model</th><th class="px-2 py-1">Elapsed</th><th class="px-2 py-1">Parse</th><th class="px-2 py-1">Validation</th><th class="px-2 py-1">Output</th><th class="px-2 py-1">Error / skip</th></tr></thead>';
+    const body = (rows || [])
+      .map((row) => {
+        return `<tr class="border-t border-gray-800/70 text-[11px] text-gray-200"><td class="px-2 py-1 font-mono">${escapeHtml(row.phase)}</td><td class="px-2 py-1">${escapeHtml(row.status)}</td><td class="px-2 py-1">${escapeHtml(row.route || "—")}</td><td class="px-2 py-1">${escapeHtml(row.model || "—")}</td><td class="px-2 py-1">${row.elapsed_ms != null ? `${row.elapsed_ms} ms` : "—"}</td><td class="px-2 py-1">${row.parse_ok == null ? "—" : row.parse_ok ? "ok" : "fail"}</td><td class="px-2 py-1">${row.validation_ok == null ? "—" : row.validation_ok ? "ok" : "fail"}</td><td class="px-2 py-1">${row.output_count != null ? escapeHtml(String(row.output_count)) : "—"}</td><td class="px-2 py-1 text-gray-400">${escapeHtml(row.error || "—")}</td></tr>`;
+      })
+      .join("");
+    return `<div class="mb-3 overflow-x-auto rounded border border-gray-800 bg-gray-950/40 p-2"><div class="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Phase provenance</div><table class="mt-2 w-full min-w-[720px] border-collapse">${header}<tbody>${body}</tbody></table></div>`;
+  }
+
+  function renderMindEvidenceSummary(run) {
+    const resultParsed = parseMindJsonbField(run?.result_jsonb);
+    const mc = machineContract(resultParsed);
+    const rows = [
+      ["cognitive_projection_seen", mc["mind.cognitive_projection_seen"]],
+      ["cognitive_projection_id", mc["mind.cognitive_projection_id"]],
+      ["cognitive_projection_item_count", mc["mind.cognitive_projection_item_count"]],
+      ["semantic_claim_count", mc["mind.semantic_claim_count"]],
+      ["active_frontier_selected_count", mc["mind.active_frontier_selected_count"]],
+      ["active_frontier_top_labels", asList(mc["mind.active_frontier_top_labels"]).join(", ")],
+      ["semantic_claim_labels", asList(mc["mind.semantic_claim_labels"]).join(", ")],
+      ["fallback_reason", asList(mc["mind.fallback_reason"]).join(", ")],
+    ]
+      .filter(([, val]) => val != null && String(val).trim() !== "")
+      .map(
+        ([label, val]) =>
+          `<div class="flex flex-col gap-0.5 border-b border-gray-800/60 pb-2 last:border-0 last:pb-0"><div class="text-[10px] uppercase tracking-wide text-gray-500">${escapeHtml(label)}</div><div class="break-words text-[11px] text-gray-200">${escapeHtml(String(val))}</div></div>`,
+      );
+    if (!rows.length) return "";
+    return `<div class="mb-3 rounded border border-gray-800 bg-gray-950/50 p-3"><div class="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Evidence / synthesis summary</div><div class="mt-2 space-y-2">${rows.join("")}</div></div>`;
+  }
+
+  function renderMindDecisionPanel(decision) {
+    const d = decision || {};
+    return `<div class="mb-3 rounded border border-gray-800 bg-gray-950/40 p-3 text-[11px] text-gray-300"><div class="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Exec handoff expectation</div><div class="mt-2">Expected path: <span class="font-mono text-gray-100">${escapeHtml(d.exec_handoff || "unknown")}</span></div><div class="mt-1">mind_skip_stance_synthesis: <span class="font-mono">${d.mind_skip_stance_synthesis ? "true" : "false"}</span></div></div>`;
+  }
+
+  function renderMindProvenanceSections(run) {
+    const provenance = normalizeMindRunProvenance(run);
+    const callouts = normalizeMindDerailments(run);
+    const phaseRows = normalizeMindPhaseRows(run);
+    const decision = normalizeMindDecision(run);
+    return [
+      renderMindProvenance(provenance),
+      renderMindDerailmentCallouts(callouts),
+      renderMindPhaseTable(phaseRows),
+      renderMindEvidenceSummary(run),
+      renderMindDecisionPanel(decision),
+    ].join("");
+  }
+
+  const MIND_PROVENANCE_FIXTURES = {
+    failOpen: {
+      ok: true,
+      mind_run_id: "00000000-0000-4000-8000-000000000001",
+      correlation_id: "corr-fail-open-001",
+      snapshot_hash: "snap-fail-open",
+      session_visibility: "session_match",
+      result_jsonb: {
+        ok: true,
+        mind_quality: "fallback_contract_only",
+        diagnostics: ["llm_fail_open:semantic_synthesis_failed", "llm_failed_phase:semantic_synthesis", "fake_exhausted"],
+        timing_ms_by_phase: { semantic_synthesis_ms: 12.5, loops_ms: 4.2, total_ms: 28.0 },
+        brief: {
+          mind_quality: "fallback_contract_only",
+          mind_authorized_for_stance_skip: false,
+          machine_contract: {
+            "mind.llm_synthesis_enabled": true,
+            "mind.llm_synthesis_attempted": true,
+            "mind.llm_fail_open_to_deterministic": true,
+            "mind.llm_synthesis_failed_phase": "semantic_synthesis",
+            "mind.llm_synthesis_error_code": "semantic_synthesis_failed",
+            "mind.llm_synthesis_error": "fake_exhausted",
+            "mind.semantic_route": "quick",
+            "mind.appraisal_route": "metacog",
+            "mind.stance_route": "chat",
+            "mind.quality": "fallback_contract_only",
+            "mind.authorized_for_stance_skip": false,
+            "mind.authorized_for_stance_use": false,
+            "mind.semantic_claim_count": 0,
+            "mind.phase_telemetry": [
+              {
+                phase_name: "semantic_synthesis",
+                route: "quick",
+                model: "quick",
+                ok: false,
+                parse_ok: false,
+                error: "fake_exhausted",
+              },
+            ],
+            "mind.fallback_reason": ["semantic_synthesis_failed", "fake_exhausted"],
+          },
+        },
+        trajectory: { patches: [{ provenance: { model_id: "deterministic" } }] },
+      },
+    },
+    success: {
+      ok: true,
+      mind_run_id: "00000000-0000-4000-8000-000000000002",
+      correlation_id: "corr-success-001",
+      snapshot_hash: "snap-success",
+      session_visibility: "session_match",
+      result_jsonb: {
+        ok: true,
+        mind_quality: "meaningful_synthesis",
+        timing_ms_by_phase: { semantic_synthesis_ms: 120, appraisal_ms: 80, stance_handoff_ms: 40, total_ms: 260 },
+        brief: {
+          mind_quality: "meaningful_synthesis",
+          mind_authorized_for_stance_skip: true,
+          semantic_synthesis: { claims: [{ label: "shared evening moment" }], suppressed: [] },
+          active_frontier: { selected: [{ label: "shared evening moment" }] },
+          stance_handoff: { authorized_for_stance_use: true, authorization_reasons: ["valid_chat_stance_brief"] },
+          machine_contract: {
+            "mind.llm_synthesis_enabled": true,
+            "mind.llm_synthesis_attempted": true,
+            "mind.quality": "meaningful_synthesis",
+            "mind.authorized_for_stance_skip": true,
+            "mind.authorized_for_stance_use": true,
+            "mind.semantic_claim_count": 1,
+            "mind.active_frontier_selected_count": 1,
+            "mind.semantic_route": "quick",
+            "mind.appraisal_route": "metacog",
+            "mind.stance_route": "chat",
+            "mind.phase_telemetry": [
+              { phase_name: "semantic_synthesis", route: "quick", ok: true, parse_ok: true, validation_ok: true, elapsed_ms: 120 },
+              { phase_name: "active_frontier_judge", route: "metacog", ok: true, parse_ok: true, validation_ok: true, elapsed_ms: 80 },
+              { phase_name: "stance_handoff", route: "chat", ok: true, parse_ok: true, validation_ok: true, elapsed_ms: 40 },
+            ],
+          },
+        },
+        trajectory: { patches: [{ provenance: { model_id: "chat" } }] },
+      },
+    },
+  };
+
+  const api = {
+    normalizeMindRunProvenance,
+    normalizeMindDerailments,
+    normalizeMindPhaseRows,
+    normalizeMindDecision,
+    renderMindProvenance,
+    renderMindDerailmentCallouts,
+    renderMindPhaseTable,
+    renderMindEvidenceSummary,
+    renderMindDecisionPanel,
+    renderMindProvenanceSections,
+    MIND_PROVENANCE_FIXTURES,
+  };
+
+  global.OrionMindProvenance = api;
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -3078,6 +3078,7 @@
   <script src="/static/js/organ-signals-graph-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/memory-graph-draft-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/memory.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
+  <script src="/static/js/mind_provenance.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/app.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
 </body>
 </html>

--- a/services/orion-hub/tests/test_mind_hub_tab.py
+++ b/services/orion-hub/tests/test_mind_hub_tab.py
@@ -18,6 +18,7 @@ for candidate in (str(REPO_ROOT), str(HUB_ROOT)):
 
 INDEX_HTML = HUB_ROOT / "templates" / "index.html"
 APP_JS = HUB_ROOT / "static" / "js" / "app.js"
+MIND_PROVENANCE_JS = HUB_ROOT / "static" / "js" / "mind_provenance.js"
 
 
 def test_mind_runs_modal_is_sibling_of_schedule_modal_not_nested() -> None:
@@ -62,3 +63,24 @@ def test_app_js_wires_mind_hash_and_recent_api() -> None:
     assert "context_session_id" in app_js
     assert "meta.sessionId = orionSessionId" in app_js
     assert "payload.context.metadata.mind_enabled = true" in app_js
+    assert "OrionMindProvenance.renderMindProvenanceSections" in app_js
+
+
+def test_mind_provenance_js_exports_normalizers_and_renderers() -> None:
+    mind_js = MIND_PROVENANCE_JS.read_text(encoding="utf-8")
+    index_html = INDEX_HTML.read_text(encoding="utf-8")
+    assert "mind_provenance.js" in index_html
+    for symbol in (
+        "normalizeMindRunProvenance",
+        "normalizeMindDerailments",
+        "normalizeMindPhaseRows",
+        "normalizeMindDecision",
+        "renderMindProvenance",
+        "renderMindDerailmentCallouts",
+        "renderMindPhaseTable",
+        "Where it went off rails",
+        "Cognition path",
+        "Phase provenance",
+        "MIND_PROVENANCE_FIXTURES",
+    ):
+        assert symbol in mind_js, symbol

--- a/services/orion-hub/tests/test_mind_provenance_normalizer.py
+++ b/services/orion-hub/tests/test_mind_provenance_normalizer.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+HUB_ROOT = Path(__file__).resolve().parents[1]
+MIND_PROVENANCE_JS = HUB_ROOT / "static" / "js" / "mind_provenance.js"
+
+
+def _run_node(script: str) -> dict:
+    proc = subprocess.run(
+        ["node", "-e", script],
+        cwd=HUB_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return json.loads(proc.stdout.strip())
+
+
+def test_fail_open_fixture_normalizer() -> None:
+    out = _run_node(
+        f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(MIND_PROVENANCE_JS))}, 'utf8');
+eval(src);
+const run = OrionMindProvenance.MIND_PROVENANCE_FIXTURES.failOpen;
+const prov = OrionMindProvenance.normalizeMindRunProvenance(run);
+const rows = OrionMindProvenance.normalizeMindPhaseRows(run);
+const callouts = OrionMindProvenance.normalizeMindDerailments(run);
+const html = OrionMindProvenance.renderMindDerailmentCallouts(callouts);
+console.log(JSON.stringify({{
+  cognition_path: prov.cognition_path,
+  llm_attempted: prov.llm_attempted,
+  failed_phase: prov.failed_phase,
+  semantic_status: rows.find(r => r.phase === 'semantic_synthesis')?.status,
+  has_fallback_row: rows.some(r => r.phase === 'deterministic_fallback'),
+  callout_count: callouts.length,
+  has_off_rails: html.includes('Where it went off rails'),
+}}));
+"""
+    )
+    assert out["cognition_path"] == "llm_fail_open_to_deterministic"
+    assert out["llm_attempted"] is True
+    assert out["failed_phase"] == "semantic_synthesis"
+    assert out["semantic_status"] == "failed"
+    assert out["has_fallback_row"] is True
+    assert out["callout_count"] >= 1
+    assert out["has_off_rails"] is True
+
+
+def test_success_fixture_normalizer() -> None:
+    out = _run_node(
+        f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(MIND_PROVENANCE_JS))}, 'utf8');
+eval(src);
+const run = OrionMindProvenance.MIND_PROVENANCE_FIXTURES.success;
+const prov = OrionMindProvenance.normalizeMindRunProvenance(run);
+const rows = OrionMindProvenance.normalizeMindPhaseRows(run);
+const callouts = OrionMindProvenance.normalizeMindDerailments(run);
+const html = OrionMindProvenance.renderMindDerailmentCallouts(callouts);
+console.log(JSON.stringify({{
+  cognition_path: prov.cognition_path,
+  authorized: prov.authorized_for_stance_use,
+  error_callouts: callouts.filter(c => c.severity === 'error').length,
+  semantic_ok: rows.find(r => r.phase === 'semantic_synthesis')?.status,
+  appraisal_ok: rows.find(r => r.phase === 'active_frontier_judge')?.status,
+  stance_ok: rows.find(r => r.phase === 'stance_handoff')?.status,
+  no_derailment_card: html.includes('without derailment'),
+}}));
+"""
+    )
+    assert out["cognition_path"] == "llm_synthesis"
+    assert out["authorized"] is True
+    assert out["error_callouts"] == 0
+    assert out["semantic_ok"] == "ok"
+    assert out["appraisal_ok"] == "ok"
+    assert out["stance_ok"] == "ok"
+    assert out["no_derailment_card"] is True

--- a/services/orion-mind/app/engine.py
+++ b/services/orion-mind/app/engine.py
@@ -750,6 +750,7 @@ def run_mind_llm_synthesis(
     semantic_route = str(getattr(s, "MIND_SEMANTIC_MODEL_ROUTE", "quick"))
     appraisal_route = str(getattr(s, "MIND_APPRAISAL_MODEL_ROUTE", "metacog"))
     stance_route = str(getattr(s, "MIND_STANCE_MODEL_ROUTE", "chat"))
+    phase_records: list[MindPhaseTelemetry] = []
 
     def _fail_open_or_error(
         *,
@@ -801,7 +802,6 @@ def run_mind_llm_synthesis(
 
     client = get_llm_client()
     llm_errors: list[str] = []
-    phase_records: list[MindPhaseTelemetry] = []
 
     def _phase_context(phase_name: str) -> MindLLMRequestContext:
         return MindLLMRequestContext(
@@ -1032,7 +1032,7 @@ def _llm_fail_open_from_exception(
         snapshot_hash=hash_snapshot_inputs(bounded),
         error_code="llm_synthesis_exception",
         diagnostics=[str(exc)],
-        failed_phase=None,
+        failed_phase="unknown",
         semantic_route=str(getattr(mind_settings, "MIND_SEMANTIC_MODEL_ROUTE", "quick")),
         appraisal_route=str(getattr(mind_settings, "MIND_APPRAISAL_MODEL_ROUTE", "metacog")),
         stance_route=str(getattr(mind_settings, "MIND_STANCE_MODEL_ROUTE", "chat")),

--- a/services/orion-mind/app/engine.py
+++ b/services/orion-mind/app/engine.py
@@ -7,7 +7,7 @@ import logging
 import re
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 from uuid import uuid4
 
 import yaml
@@ -690,13 +690,17 @@ def _llm_machine_contract(
     return machine
 
 
+MindLLMSynthesisOutcome = Union[MindRunResultV1, "MindLLMFailOpenRecord", None]
+
+
 def run_mind_llm_synthesis(
     req: MindRunRequestV1,
     *,
     router_profiles_dir: Path,
     snapshot_max_bytes: int,
     mind_settings: Any,
-) -> MindRunResultV1 | None:
+) -> MindLLMSynthesisOutcome:
+    from .llm_fail_open import MindLLMFailOpenRecord
     from .appraisal import run_active_frontier_judge
     from .budget import MindRunBudget
     from .evidence import build_evidence_pack
@@ -743,14 +747,30 @@ def run_mind_llm_synthesis(
 
     fail_open = bool(getattr(s, "MIND_LLM_FAIL_OPEN_LEGACY", True))
     configured_timeout = float(getattr(s, "MIND_LLM_TIMEOUT_SEC", 90.0))
+    semantic_route = str(getattr(s, "MIND_SEMANTIC_MODEL_ROUTE", "quick"))
+    appraisal_route = str(getattr(s, "MIND_APPRAISAL_MODEL_ROUTE", "metacog"))
+    stance_route = str(getattr(s, "MIND_STANCE_MODEL_ROUTE", "chat"))
 
     def _fail_open_or_error(
         *,
         error_code: str,
         diagnostics: list[str],
-    ) -> MindRunResultV1 | None:
+        failed_phase: str | None = None,
+    ) -> MindRunResultV1 | MindLLMFailOpenRecord:
         if fail_open:
-            return None
+            return MindLLMFailOpenRecord(
+                mind_run_id=mind_run_id,
+                snapshot_hash=snap_hash,
+                error_code=error_code,
+                diagnostics=list(diagnostics),
+                failed_phase=failed_phase,
+                semantic_route=semantic_route,
+                appraisal_route=appraisal_route,
+                stance_route=stance_route,
+                phase_telemetry=list(phase_records),
+                timing_ms_by_phase=dict(phases),
+                fallback_reason=[error_code, *diagnostics[:4]],
+            )
         return _error_result(
             mind_run_id=mind_run_id,
             error_code=error_code,
@@ -760,11 +780,12 @@ def run_mind_llm_synthesis(
         )
 
     if budget.over_budget():
-        return _fail_open_or_error(error_code="loop_budget_exceeded", diagnostics=["wall_time_exceeded_before_llm"])
+        return _fail_open_or_error(
+            error_code="loop_budget_exceeded",
+            diagnostics=["wall_time_exceeded_before_llm"],
+            failed_phase="pre_llm",
+        )
 
-    semantic_route = str(getattr(s, "MIND_SEMANTIC_MODEL_ROUTE", "quick"))
-    appraisal_route = str(getattr(s, "MIND_APPRAISAL_MODEL_ROUTE", "metacog"))
-    stance_route = str(getattr(s, "MIND_STANCE_MODEL_ROUTE", "chat"))
     for phase_name, route in (
         ("semantic_synthesis", semantic_route),
         ("active_frontier_judge", appraisal_route),
@@ -772,7 +793,11 @@ def run_mind_llm_synthesis(
     ):
         route_err = _validate_phase_route(route, phase=phase_name)
         if route_err:
-            return _fail_open_or_error(error_code="invalid_llm_route", diagnostics=[route_err])
+            return _fail_open_or_error(
+                error_code="invalid_llm_route",
+                diagnostics=[route_err],
+                failed_phase=phase_name,
+            )
 
     client = get_llm_client()
     llm_errors: list[str] = []
@@ -800,6 +825,7 @@ def run_mind_llm_synthesis(
         return _fail_open_or_error(
             error_code="loop_budget_exceeded",
             diagnostics=["wall_budget_insufficient_before_semantic"],
+            failed_phase="semantic_synthesis",
         )
 
     t_sem = time.perf_counter()
@@ -820,11 +846,13 @@ def run_mind_llm_synthesis(
         return _fail_open_or_error(
             error_code="loop_budget_exceeded",
             diagnostics=["wall_time_exceeded_after_semantic"],
+            failed_phase="semantic_synthesis",
         )
     if synthesis is None or not synthesis.claims:
         return _fail_open_or_error(
             error_code="semantic_synthesis_failed",
             diagnostics=llm_errors or ["semantic_synthesis_empty"],
+            failed_phase="semantic_synthesis",
         )
 
     frontier = None
@@ -849,6 +877,7 @@ def run_mind_llm_synthesis(
             return _fail_open_or_error(
                 error_code="loop_budget_exceeded",
                 diagnostics=["wall_time_exceeded_after_appraisal"],
+                failed_phase="active_frontier_judge",
             )
     elif synthesis.claims:
         phase_records.append(
@@ -902,7 +931,11 @@ def run_mind_llm_synthesis(
     valid, err = validate_merged_stance_brief_optional(stance_payload)
     if valid is None:
         if bool(getattr(s, "MIND_LLM_FAIL_OPEN_LEGACY", True)):
-            return None
+            return _fail_open_or_error(
+                error_code="stance_handoff_invalid",
+                diagnostics=[err or "invalid_stance_payload", *llm_errors],
+                failed_phase="stance_handoff",
+            )
         return _error_result(
             mind_run_id=mind_run_id,
             error_code="stance_handoff_invalid",
@@ -984,6 +1017,29 @@ def run_mind_llm_synthesis(
     )
 
 
+def _llm_fail_open_from_exception(
+    exc: BaseException,
+    *,
+    req: MindRunRequestV1,
+    mind_settings: Any,
+    snapshot_max_bytes: int,
+) -> "MindLLMFailOpenRecord":
+    from .llm_fail_open import MindLLMFailOpenRecord
+
+    bounded, _ = build_bounded_snapshot_inputs(dict(req.snapshot_inputs or {}), snapshot_max_bytes)
+    return MindLLMFailOpenRecord(
+        mind_run_id=uuid4(),
+        snapshot_hash=hash_snapshot_inputs(bounded),
+        error_code="llm_synthesis_exception",
+        diagnostics=[str(exc)],
+        failed_phase=None,
+        semantic_route=str(getattr(mind_settings, "MIND_SEMANTIC_MODEL_ROUTE", "quick")),
+        appraisal_route=str(getattr(mind_settings, "MIND_APPRAISAL_MODEL_ROUTE", "metacog")),
+        stance_route=str(getattr(mind_settings, "MIND_STANCE_MODEL_ROUTE", "chat")),
+        fallback_reason=["llm_synthesis_exception", str(exc)],
+    )
+
+
 def run_mind(
     req: MindRunRequestV1,
     *,
@@ -991,9 +1047,11 @@ def run_mind(
     snapshot_max_bytes: int,
     mind_settings: Any | None = None,
 ) -> MindRunResultV1:
+    from .llm_fail_open import MindLLMFailOpenRecord
     from .settings import settings as default_settings
 
     s = mind_settings if mind_settings is not None else default_settings
+    fail_open_record: MindLLMFailOpenRecord | None = None
     if bool(getattr(s, "MIND_LLM_SYNTHESIS_ENABLED", False)):
         try:
             llm_result = run_mind_llm_synthesis(
@@ -1002,8 +1060,10 @@ def run_mind(
                 snapshot_max_bytes=snapshot_max_bytes,
                 mind_settings=s,
             )
-            if llm_result is not None:
+            if isinstance(llm_result, MindRunResultV1):
                 return llm_result
+            if isinstance(llm_result, MindLLMFailOpenRecord):
+                fail_open_record = llm_result
         except Exception as exc:  # noqa: BLE001
             logger.warning("mind_llm_synthesis_failed correlation_id=%s err=%s", req.correlation_id, exc)
             if not bool(getattr(s, "MIND_LLM_FAIL_OPEN_LEGACY", True)):
@@ -1014,8 +1074,17 @@ def run_mind(
                     diagnostics=[str(exc)],
                     snapshot_hash=hash_snapshot_inputs(dict(req.snapshot_inputs or {})),
                 )
-    return run_mind_deterministic(
+            fail_open_record = _llm_fail_open_from_exception(
+                exc,
+                req=req,
+                mind_settings=s,
+                snapshot_max_bytes=snapshot_max_bytes,
+            )
+    det = run_mind_deterministic(
         req,
         router_profiles_dir=router_profiles_dir,
         snapshot_max_bytes=snapshot_max_bytes,
     )
+    if fail_open_record is not None:
+        return fail_open_record.merge_into_deterministic(det)
+    return det

--- a/services/orion-mind/app/llm_fail_open.py
+++ b/services/orion-mind/app/llm_fail_open.py
@@ -13,6 +13,7 @@ from .phase_telemetry import MindPhaseTelemetry, phase_telemetry_machine_keys
 _LLM_FAIL_OPEN_ADVISORY_KEYS = (
     "mind.llm_synthesis_enabled",
     "mind.llm_synthesis_attempted",
+    "mind.llm_fail_open_to_deterministic",
     "mind.llm_synthesis_failed_phase",
     "mind.llm_synthesis_error_code",
     "mind.llm_synthesis_error",
@@ -43,6 +44,7 @@ class MindLLMFailOpenRecord:
         patch: dict[str, Any] = {
             "mind.llm_synthesis_enabled": True,
             "mind.llm_synthesis_attempted": True,
+            "mind.llm_fail_open_to_deterministic": True,
             "mind.llm_synthesis_error_code": self.error_code,
             "mind.semantic_route": self.semantic_route,
             "mind.appraisal_route": self.appraisal_route,

--- a/services/orion-mind/app/llm_fail_open.py
+++ b/services/orion-mind/app/llm_fail_open.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID
 
-from orion.mind.v1 import MindHandoffBriefV1, MindRunResultV1
+from orion.mind.v1 import MindRunResultV1
 
 from .phase_telemetry import MindPhaseTelemetry, phase_telemetry_machine_keys
 
@@ -15,6 +15,11 @@ _LLM_FAIL_OPEN_ADVISORY_KEYS = (
     "mind.llm_synthesis_attempted",
     "mind.llm_synthesis_failed_phase",
     "mind.llm_synthesis_error_code",
+    "mind.llm_synthesis_error",
+    "mind.semantic_route",
+    "mind.appraisal_route",
+    "mind.stance_route",
+    "mind.semantic_synthesis_seen",
     "mind.phase_telemetry",
     "mind.fallback_reason",
 )

--- a/services/orion-mind/app/llm_fail_open.py
+++ b/services/orion-mind/app/llm_fail_open.py
@@ -1,0 +1,95 @@
+"""Fail-open metadata preserved when LLM synthesis falls back to deterministic Mind."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from orion.mind.v1 import MindHandoffBriefV1, MindRunResultV1
+
+from .phase_telemetry import MindPhaseTelemetry, phase_telemetry_machine_keys
+
+_LLM_FAIL_OPEN_ADVISORY_KEYS = (
+    "mind.llm_synthesis_enabled",
+    "mind.llm_synthesis_attempted",
+    "mind.llm_synthesis_failed_phase",
+    "mind.llm_synthesis_error_code",
+    "mind.phase_telemetry",
+    "mind.fallback_reason",
+)
+
+
+@dataclass(frozen=True)
+class MindLLMFailOpenRecord:
+    mind_run_id: UUID
+    snapshot_hash: str
+    error_code: str
+    diagnostics: list[str]
+    failed_phase: str | None
+    semantic_route: str
+    appraisal_route: str
+    stance_route: str
+    phase_telemetry: list[MindPhaseTelemetry] = field(default_factory=list)
+    timing_ms_by_phase: dict[str, float] = field(default_factory=dict)
+    fallback_reason: list[str] = field(default_factory=list)
+
+    def machine_contract_patch(self) -> dict[str, Any]:
+        patch: dict[str, Any] = {
+            "mind.llm_synthesis_enabled": True,
+            "mind.llm_synthesis_attempted": True,
+            "mind.llm_synthesis_error_code": self.error_code,
+            "mind.semantic_route": self.semantic_route,
+            "mind.appraisal_route": self.appraisal_route,
+            "mind.stance_route": self.stance_route,
+            "mind.authorized_for_stance_skip": False,
+            "mind.authorized_for_stance_use": False,
+            "mind.semantic_synthesis_seen": any(
+                r.phase_name == "semantic_synthesis" and not r.skipped for r in self.phase_telemetry
+            ),
+        }
+        if self.failed_phase:
+            patch["mind.llm_synthesis_failed_phase"] = self.failed_phase
+        if self.diagnostics:
+            patch["mind.llm_synthesis_error"] = self.diagnostics[0]
+        if self.phase_telemetry:
+            patch.update(phase_telemetry_machine_keys(self.phase_telemetry))
+        reasons = list(self.fallback_reason)[:8]
+        if not reasons:
+            reasons = [self.error_code, *self.diagnostics[:3]]
+        patch["mind.fallback_reason"] = reasons[:8]
+        return patch
+
+    def diagnostics_patch(self) -> list[str]:
+        out = [f"llm_fail_open:{self.error_code}"]
+        if self.failed_phase:
+            out.append(f"llm_failed_phase:{self.failed_phase}")
+        out.extend(self.diagnostics[:6])
+        return out
+
+    def merge_into_deterministic(self, result: MindRunResultV1) -> MindRunResultV1:
+        machine = dict(result.brief.machine_contract)
+        machine.update(self.machine_contract_patch())
+        advisory = list(result.brief.advisory_keys)
+        for key in _LLM_FAIL_OPEN_ADVISORY_KEYS:
+            if key not in advisory:
+                advisory.append(key)
+        brief = result.brief.model_copy(
+            update={
+                "machine_contract": machine,
+                "advisory_keys": advisory,
+                "mind_authorized_for_stance_skip": False,
+            }
+        )
+        timing = {**self.timing_ms_by_phase, **(result.timing_ms_by_phase or {})}
+        diagnostics = list(result.diagnostics or [])
+        for item in self.diagnostics_patch():
+            if item not in diagnostics:
+                diagnostics.append(item)
+        return result.model_copy(
+            update={
+                "brief": brief,
+                "diagnostics": diagnostics,
+                "timing_ms_by_phase": timing,
+            }
+        )

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -245,3 +245,69 @@ def test_llm_failure_falls_back_to_deterministic(monkeypatch: pytest.MonkeyPatch
     )
     assert result.mind_quality == "fallback_contract_only"
     assert result.brief.mind_authorized_for_stance_skip is False
+    machine = result.brief.machine_contract
+    assert machine.get("mind.llm_synthesis_enabled") is True
+    assert machine.get("mind.llm_synthesis_attempted") is True
+    assert machine.get("mind.llm_synthesis_failed_phase") == "semantic_synthesis"
+    assert machine.get("mind.llm_synthesis_error_code") == "semantic_synthesis_failed"
+    assert machine.get("mind.llm_synthesis_error") == "fake_exhausted"
+    assert machine.get("mind.authorized_for_stance_skip") is False
+    assert machine.get("mind.authorized_for_stance_use") is False
+    telemetry = machine.get("mind.phase_telemetry") or []
+    assert any(t.get("phase_name") == "semantic_synthesis" for t in telemetry)
+    assert any(d.startswith("llm_fail_open:") for d in result.diagnostics)
+
+
+def test_source_tag_semantic_fail_open_preserves_phase_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.engine import run_mind
+    from app.llm_client import FakeMindLLMClient, set_llm_client_override
+    from app.settings import settings
+    from orion.mind.v1 import MindRunRequestV1, MindRunPolicyV1
+
+    monkeypatch.setattr(settings, "MIND_LLM_SYNTHESIS_ENABLED", True)
+    set_llm_client_override(
+        FakeMindLLMClient([_semantic_payload(claim_label="identity_yaml", evidence_ref="current_turn:0")])
+    )
+    req = MindRunRequestV1(
+        correlation_id=str(uuid4()),
+        snapshot_inputs={"user_text": "hello"},
+        policy=MindRunPolicyV1(n_loops_max=1, wall_time_ms_max=60_000),
+    )
+    result = run_mind(
+        req,
+        router_profiles_dir=Path(__file__).resolve().parents[1] / "app" / "config",
+        snapshot_max_bytes=512_000,
+        mind_settings=settings,
+    )
+    machine = result.brief.machine_contract
+    assert machine.get("mind.llm_synthesis_attempted") is True
+    assert machine.get("mind.llm_synthesis_failed_phase") == "semantic_synthesis"
+    assert machine.get("mind.llm_synthesis_error_code") == "semantic_synthesis_failed"
+    telemetry = machine.get("mind.phase_telemetry") or []
+    sem = next(t for t in telemetry if t.get("phase_name") == "semantic_synthesis")
+    assert sem.get("ok") is True
+    assert sem.get("validation_ok") is False
+    assert result.mind_quality == "fallback_contract_only"
+
+
+def test_disabled_llm_path_has_no_attempted_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.engine import run_mind
+    from app.settings import settings
+    from orion.mind.v1 import MindRunRequestV1, MindRunPolicyV1
+
+    monkeypatch.setattr(settings, "MIND_LLM_SYNTHESIS_ENABLED", False)
+    req = MindRunRequestV1(
+        correlation_id=str(uuid4()),
+        snapshot_inputs={"user_text": "hello"},
+        policy=MindRunPolicyV1(n_loops_max=1, wall_time_ms_max=60_000),
+    )
+    result = run_mind(
+        req,
+        router_profiles_dir=Path(__file__).resolve().parents[1] / "app" / "config",
+        snapshot_max_bytes=512_000,
+        mind_settings=settings,
+    )
+    machine = result.brief.machine_contract
+    assert "mind.llm_synthesis_attempted" not in machine
+    assert machine.get("mind.llm_synthesis_enabled") is not True
+    assert not any(d.startswith("llm_fail_open:") for d in result.diagnostics)

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -290,6 +290,40 @@ def test_source_tag_semantic_fail_open_preserves_phase_telemetry(monkeypatch: py
     assert result.mind_quality == "fallback_contract_only"
 
 
+def test_pre_llm_budget_fail_open_has_attempted_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.budget import MindRunBudget
+    from app.engine import run_mind
+    from app.settings import settings
+    from orion.mind.v1 import MindRunRequestV1, MindRunPolicyV1
+
+    real_over_budget = MindRunBudget.over_budget
+    calls = {"n": 0}
+
+    def _over_budget_first_check_only(self: MindRunBudget) -> bool:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return True
+        return real_over_budget(self)
+
+    monkeypatch.setattr(MindRunBudget, "over_budget", _over_budget_first_check_only)
+    monkeypatch.setattr(settings, "MIND_LLM_SYNTHESIS_ENABLED", True)
+    req = MindRunRequestV1(
+        correlation_id=str(uuid4()),
+        snapshot_inputs={"user_text": "hello"},
+        policy=MindRunPolicyV1(n_loops_max=1, wall_time_ms_max=60_000),
+    )
+    result = run_mind(
+        req,
+        router_profiles_dir=Path(__file__).resolve().parents[1] / "app" / "config",
+        snapshot_max_bytes=512_000,
+        mind_settings=settings,
+    )
+    machine = result.brief.machine_contract
+    assert machine.get("mind.llm_synthesis_attempted") is True
+    assert machine.get("mind.llm_synthesis_failed_phase") == "pre_llm"
+    assert machine.get("mind.llm_synthesis_error_code") == "loop_budget_exceeded"
+
+
 def test_disabled_llm_path_has_no_attempted_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     from app.engine import run_mind
     from app.settings import settings

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -248,6 +248,7 @@ def test_llm_failure_falls_back_to_deterministic(monkeypatch: pytest.MonkeyPatch
     machine = result.brief.machine_contract
     assert machine.get("mind.llm_synthesis_enabled") is True
     assert machine.get("mind.llm_synthesis_attempted") is True
+    assert machine.get("mind.llm_fail_open_to_deterministic") is True
     assert machine.get("mind.llm_synthesis_failed_phase") == "semantic_synthesis"
     assert machine.get("mind.llm_synthesis_error_code") == "semantic_synthesis_failed"
     assert machine.get("mind.llm_synthesis_error") == "fake_exhausted"


### PR DESCRIPTION
# PR: Mind LLM fail-open observability + Hub provenance UI

**Branch:** `feat/mind-llm-fail-open-observability`  
**Worktree:** `.worktrees/feat-mind-llm-fail-open-observability`  
**Commits:** `55624813`, `21392fac`, `73ee73a9`  
**Base:** `main` (`f4a504bb`)

## Summary

Two layers:

1. **Mind (layer 1):** Preserve LLM fail-open metadata when synthesis falls back to deterministic Mind (`MindLLMFailOpenRecord`).
2. **Hub (layer 2):** Render provenance strips, derailment callouts, phase tables, and evidence summary in the Mind runs modal — so operators can answer “did LLM run?”, “where did it fail?”, and “what to check next?” without parsing raw JSON.

No changes to `chat_general`, `concept_induction`, env/docker, or new services.

## Hub Mind modal (layer 2)

When inspecting a run (`mindRunsModalDetails`), above collapsed raw JSON:

| Section | Purpose |
|---------|---------|
| **Provenance** | Cognition path, final source, LLM enabled/attempted, failed phase, quality, authorized, routes, snapshot, wall time |
| **Where it went off rails** | Highest-severity derailment callout + collapsed additional callouts |
| **Phase provenance** | Table: semantic / appraisal / stance / deterministic_fallback |
| **Evidence / synthesis summary** | Projection counts, claim labels, fallback_reason |
| **Exec handoff expectation** | Inferred legacy vs skip path from Mind contract |

### Fail-open example callout

**Title:** Mind LLM synthesis failed open before a usable handoff.

**Body:** LLM synthesis was enabled and attempted, but `semantic_synthesis` did not produce an authorized handoff. Mind fell back to `fallback_contract_only` / deterministic output; Exec should not skip legacy `chat_stance`.

**Next action:** Check gateway routes (`quick`/`metacog`/`chat`), semantic JSON validity, and `evidence_refs` in semantic output.

### Success path

Neutral card: “Mind path completed without derailment.” Phase table shows semantic/appraisal/stance `ok`.

## Mind contract (layer 1 + minimal layer-2 key)

Fail-open merge adds (among others):

- `mind.llm_synthesis_enabled`, `mind.llm_synthesis_attempted`
- `mind.llm_fail_open_to_deterministic` (new — Hub trigger for fail-open path)
- `mind.llm_synthesis_failed_phase`, `mind.llm_synthesis_error_code`, `mind.llm_synthesis_error`
- `mind.phase_telemetry`, `mind.fallback_reason`
- `mind.authorized_for_stance_skip/use` forced `false`

## Files changed

**Mind**
- `services/orion-mind/app/llm_fail_open.py`
- `services/orion-mind/app/engine.py`
- `services/orion-mind/tests/test_mind_llm_pipeline.py`

**Hub**
- `services/orion-hub/static/js/mind_provenance.js` (new)
- `services/orion-hub/static/js/app.js`
- `services/orion-hub/templates/index.html`
- `services/orion-hub/tests/test_mind_hub_tab.py`
- `services/orion-hub/tests/test_mind_provenance_normalizer.py` (new)

## Test plan

```bash
cd .worktrees/feat-mind-llm-fail-open-observability

PYTHONPATH=. ../../venv/bin/python -m pytest \
  services/orion-hub/tests/test_mind_hub_tab.py \
  services/orion-hub/tests/test_mind_routes.py \
  services/orion-hub/tests/test_mind_provenance_normalizer.py -q
# 15 passed

PYTHONPATH=. ../../venv/bin/python -m pytest \
  services/orion-mind/tests/test_mind_llm_pipeline.py \
  services/orion-mind/tests/test_mind_governance.py \
  services/orion-mind/tests/test_http_contract.py -q
# 21 passed
```

Node fixture tests validate fail-open → `cognition_path=llm_fail_open_to_deterministic` and success → no error callouts.

## Manual smoke

1. `MIND_LLM_SYNTHESIS_ENABLED=true`, `MIND_LLM_FAIL_OPEN_LEGACY=true`
2. Run Mind-enabled `chat_general` turn
3. Hub → Mind tab → open run modal

**Fail-open:** provenance strip, red “Where it went off rails” callout, semantic row `failed`, `deterministic_fallback` row, Authorized = no.

**Success:** cognition path `llm_synthesis`, green “without derailment”, all phases `ok`, Authorized = yes.

## Remaining gaps

- Exec acceptance is **inferred** from Mind `authorized_for_stance_use` (Exec plan metadata not stored on `mind_runs` row). Sufficient for operator guidance; live Exec trace still in thought-process panel.
- Exception fail-open: `failed_phase=unknown`, thin phase telemetry.
