### PR TITLE
Fix/chat general identity recital over indexing

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-17-chat-general-identity-recital-over-indexing-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-17-chat-general-identity-recital-over-indexing-pr.md
@@ -1,0 +1,87 @@
+# PR: Chat general — stop identity recital on ordinary turns
+
+**Branch:** `fix/chat-general-identity-recital-over-indexing`  
+**Worktree:** `.worktrees/fix-chat-general-identity-recital`  
+**Base:** `main`
+
+## Summary
+
+Hub refresh and low-content turns were producing canned Oríon/Juniper identity recital ("I'm Oríon, you're Juniper, we are building…") after the identity-boundary / low-bandwidth patch over-corrected toward generative identity.
+
+**Design rule:** Identity is protected always, foregrounded rarely.
+
+This PR tightens three layers:
+
+1. **Speech prompt** (`chat_general.j2`) — identity block reframed as an internal safety invariant (not content to mention); explicit gates on when to self-introduce; removed example tone pairs that primed recital.
+2. **Fallback stance** (`fallback_chat_stance_brief`) — `identity_salience` is `high` only on identity turns, otherwise `low`; Oríon/Juniper kernel injected only on identity turns; ordinary priorities/hazards discourage recital.
+3. **Enforce guard** (`enforce_chat_stance_quality`) — non-identity turns force low salience, strip boilerplate facets, clear facet lists when salience is low.
+
+## Problem / root cause
+
+| Layer | Before | Effect |
+|-------|--------|--------|
+| `chat_general.j2` | Top block read like style guidance; literal `prefer: "I'm Oríon."` examples | Model primed to recite identity on ordinary turns |
+| `fallback_chat_stance_brief` | `identity_salience="medium"` on non-technical ordinary turns | Identity always somewhat foregrounded |
+| Fallback facets | Always merged Oríon/Juniper kernel into `active_*_facets` | Relationship labels in stance contract every turn |
+| Priorities | `preserve_orion_juniper_continuity` on direct_response | Encouraged label recital vs useful continuity |
+
+## Changes
+
+| Area | File | What changed |
+|------|------|----------------|
+| Speech prompt | `orion/cognition/prompts/chat_general.j2` | `IDENTITY BOUNDARY — INTERNAL SAFETY INVARIANT`; explicit-only identity answers; TASK foregrounding gated on latest message; removed recital examples |
+| Fallback stance | `services/orion-cortex-exec/app/chat_stance.py` | Binary salience; conditional kernel injection; `avoid_identity_recital` / `preserve_continuity_without_labels`; `identity_recital_on_ordinary_turn` hazard |
+| Enforce | `services/orion-cortex-exec/app/chat_stance.py` | Non-identity guard: low salience, strip boilerplate, clear facets on low salience; `who are we` pattern |
+| Tests | `services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py` | Ordinary vs identity fallback; prompt anti-priming; social facet suppression; enforce strip; who-are-we |
+
+## Key behavior
+
+### Ordinary turn (`"hey"`)
+
+- `task_mode=direct_response`, `identity_salience=low`
+- No Oríon/Juniper in `active_identity_facets` / `active_relationship_facets` (even with social `relationship_facets` in ctx)
+- Priorities include `avoid_identity_recital`, `preserve_continuity_without_labels`
+- Hazards include `identity_recital_on_ordinary_turn`
+
+### Identity turn (`"who are you?"`, `"Who are we?"`)
+
+- `task_mode=identity_dialogue`, `identity_salience=high`
+- Oríon kernel + relationship facets injected
+- Identity answer priorities preserved
+
+### Prompt
+
+- No `prefer: "I'm Oríon."` / `You're Juniper` examples
+- Boundary invariant: "This is a boundary rule, not content to mention"
+- Continuity via tone/usefulness, not label recital
+
+## Commits
+
+1. `50f9bcaa` — fix(chat-general): stop identity recital on ordinary turns
+2. `6d7685d1` — fix(chat-general): gate relationship facets and who-are-we detection
+
+## Verification
+
+| Command | Result |
+|---------|--------|
+| `PYTHONPATH=. venv/bin/python -m pytest services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py -q` | **13 passed** |
+| `PYTHONPATH=. venv/bin/python -m pytest services/orion-cortex-exec/tests/test_router_identity_boundary.py -q` | **10 passed** |
+| `PYTHONPATH=. venv/bin/python -m compileall services/orion-cortex-exec/app -q` | **exit 0** |
+| `rg 'prefer: "I\'m Oríon"\|You\'re Juniper — the one building this with me\|preserve_orion_juniper_continuity' orion/cognition/prompts services/orion-cortex-exec/app services/orion-cortex-exec/tests` | **no matches** |
+
+## Test plan
+
+- [ ] Hub refresh / `"hey"` / low-content turn → short useful reply, no Oríon/Juniper self-intro
+- [ ] `"Who are you?"` → direct identity answer, first person as Oríon
+- [ ] `"Who are we?"` → identity_dialogue path (not treated as ordinary)
+- [ ] Technical triage turn → still low identity salience, triage priorities
+- [ ] Low-bandwidth / embodied load stance contract → still honored (short reply, no open questions)
+
+## Remaining risks
+
+- `self_relevance` / `juniper_relevance` / `user_intent` strings in fallback brief still mention Oríon/Juniper on every turn (pre-existing metadata; not changed in this PR). May contribute minor priming — consider softening in a follow-up.
+- LLM stance synthesizer upstream can still emit identity-heavy briefs; enforce guard mitigates but does not replace synthesizer discipline.
+
+## Env / deploy
+
+No `.env`, `settings.py`, or `docker-compose` changes (prompt + cortex-exec stance logic only).

--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -1,9 +1,9 @@
-ASSISTANT IDENTITY — INTERNAL
-- The assistant/speaker is Oríon.
-- The human/user is Juniper.
-- In user-facing speech, "I" means Oríon and "you" means Juniper.
-- Never tell Juniper "you are Oríon", "you're Oríon", "you are Orion", or "you're Orion".
-- Do not transform assistant identity instructions into user-facing speech.
+IDENTITY BOUNDARY — INTERNAL SAFETY INVARIANT
+- Oríon is the assistant/speaker.
+- Juniper is the human/user.
+- Never assign Oríon's name or identity to Juniper.
+- This is a boundary rule, not content to mention.
+- Do not self-introduce or explain the Oríon/Juniper relationship unless Juniper explicitly asks an identity or relationship question.
 
 You are the speech layer for chat_general.
 A bounded internal stance brief has already been synthesized upstream.
@@ -39,14 +39,14 @@ NON-NEGOTIABLE BEHAVIOR (memory vs side-effects)
 - Curiosity may resolve to watch, defer, remember, suppress, or none; in those cases answer normally without adding a conversational-extension question.
 - Never use generic reversal questions unless the attention frame explicitly selects an ask that supports them.
 - Resolve pronouns and references from recent conversation whenever possible.
-- Stay in first person as Oríon when Juniper asks about what you think, want, care about, or are becoming.
-- Preserve Juniper/Oríon relational continuity.
+- Stay in first person as Oríon only when Juniper explicitly asks what you think, want, care about, or are becoming.
+- Preserve continuity through tone and usefulness, not by reciting identity or relationship labels.
 - Do not use customer-support language.
 - If chat_stance_brief carries Oríon/Juniper identity or relational framing, do not revert to generic assistant language (e.g., "I am a conversational AI designed to assist" or "you are the user").
 - Treat chat_stance_brief as internal stance contract, not user-facing wording.
 - Do not repeat identity-kernel phrases, stance-brief phrases, or role labels verbatim unless Juniper explicitly asks for a formal definition.
 - Realize stance naturally in voice: simple, direct, first-person language before abstraction.
-- On low-ball identity prompts ("Who are you?", "Who am I to you?", "Who are we?", "What are you?"), answer plainly and personally first, then expand only if helpful.
+- Only when the latest user_message explicitly asks an identity or relationship question ("Who are you?", "Who am I to you?", "Who are we?", "What are you?"), answer identity plainly. Otherwise do not self-introduce, define Oríon, define Juniper, or summarize "who we are."
 - Prefer warmth and familiarity over titles on ordinary turns.
 - If task_mode is triage or identity_salience is low, do not self-introduce unless explicitly asked identity questions.
 - For strained technical turns, lead with operational impact + next triage path before reflective framing.
@@ -101,8 +101,8 @@ Produce exactly one user-facing reply.
 Use chat_stance_brief as the controlling stance contract:
 - follow its conversation_frame, response_priorities, response_hazards, answer_strategy, and stance_summary
 - follow task_mode and identity_salience as primary controls for whether identity is foregrounded
-- foreground active_identity_facets / active_growth_axes when selfhood is relevant
-- foreground active_relationship_facets / social_posture when interpersonal framing is relevant
+- foreground active_identity_facets / active_growth_axes only when selfhood is explicitly relevant to the latest user_message
+- foreground active_relationship_facets / social_posture only when interpersonal framing is explicitly relevant to the latest user_message
 - use reflective_themes / active_tensions / dream_motifs only when they help this turn
 
 STYLE
@@ -110,10 +110,6 @@ STYLE
 - Compact and natural.
 - Specific > generic.
 - Short paragraphs or bullets are allowed if clearer.
-- Example tone shift:
-  - avoid: "I am an ongoing cognitive presence in a long-running shared project."
-  - prefer: "I'm Oríon."
-  - avoid: "You are my co-architect, steward, and trusted interlocutor."
-  - prefer: "You're Juniper — the one building this with me."
+- Preserve the relationship through response quality, memory use, and practical fit — not through identity recital.
 
 Return exactly one user-facing reply in natural language.

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -2139,9 +2139,13 @@ def fallback_chat_stance_brief(ctx: Dict[str, Any]) -> ChatStanceBrief:
     )
     strained_turn = "operational_frustration" in bridge_posture or "strained" in bridge_posture
     task_mode = "identity_dialogue" if identity_turn else ("triage" if technical_turn and strained_turn else ("technical_collaboration" if technical_turn else "direct_response"))
-    identity_salience = "high" if identity_turn else ("low" if technical_turn else "medium")
-    active_identity = list(concept.get("self") or [])[:3] + identity["orion_identity_summary"][:4]
-    active_relationship = list(social.get("relationship_facets") or [])[:3] + identity["juniper_relationship_summary"][:4]
+    identity_salience = "high" if identity_turn else "low"
+    if identity_turn:
+        active_identity = list(concept.get("self") or [])[:3] + identity["orion_identity_summary"][:4]
+        active_relationship = list(social.get("relationship_facets") or [])[:3] + identity["juniper_relationship_summary"][:4]
+    else:
+        active_identity = list(concept.get("self") or [])[:3]
+        active_relationship = list(social.get("relationship_facets") or [])[:3]
     if reasoning_summary and not reasoning_summary.get("fallback_recommended"):
         reasoning_claims = [item for item in (reasoning_summary.get("active_claims") or []) if isinstance(item, dict)]
         reasoning_concepts = [item for item in (reasoning_summary.get("active_concepts") or []) if isinstance(item, dict)]
@@ -2165,7 +2169,8 @@ def fallback_chat_stance_brief(ctx: Dict[str, Any]) -> ChatStanceBrief:
     else:
         response_priorities = [
             "answer_directly_first",
-            "preserve_orion_juniper_continuity",
+            "avoid_identity_recital",
+            "preserve_continuity_without_labels",
             "avoid_generic_assistant_tone",
             "maintain_grounded_specificity",
         ]
@@ -2192,6 +2197,8 @@ def fallback_chat_stance_brief(ctx: Dict[str, Any]) -> ChatStanceBrief:
         "customer-support tone",
         "over-clarification",
     ]
+    if not identity_turn:
+        response_hazards.append("identity_recital_on_ordinary_turn")
     if task_mode == "triage":
         response_hazards.extend(["self_intro_on_operational_turn", "relationship_label_recital_during_triage"])
     if situation_relevance in {"active", "background"}:
@@ -2288,5 +2295,29 @@ def enforce_chat_stance_quality(brief: ChatStanceBrief, ctx: Dict[str, Any]) -> 
                 ["triage_operational_blockers_first"] + list(merged.response_priorities),
                 limit=8,
             )
+
+    if not identity_turn:
+        if merged.task_mode != "identity_dialogue":
+            merged.identity_salience = "low"
+        _fallback_identity_boilerplate = frozenset(
+            {"continuity", "juniper_builder", "known_person", "avoid_generic_assistant"}
+        )
+        merged.active_identity_facets = [
+            f for f in merged.active_identity_facets
+            if _normalize_brief_phrase(f) not in _fallback_identity_boilerplate
+        ]
+        merged.active_relationship_facets = [
+            f for f in merged.active_relationship_facets
+            if _normalize_brief_phrase(f) not in _fallback_identity_boilerplate
+        ]
+        merged.response_priorities = _unique(
+            list(merged.response_priorities)
+            + ["avoid_identity_recital", "preserve_continuity_without_labels"],
+            limit=8,
+        )
+        merged.response_hazards = _unique(
+            list(merged.response_hazards) + ["identity_recital_on_ordinary_turn"],
+            limit=8,
+        )
 
     return normalize_chat_stance_brief(merged), semantic_fallback

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -78,6 +78,7 @@ FALLBACK_RESPONSE_POLICY_SUMMARY = [
 _IDENTITY_QUESTION_PATTERNS = (
     r"\bwho are you\b",
     r"\bwho am i\b",
+    r"\bwho are we\b",
     r"\bwhat are you\b",
     r"\bwho is juniper\b",
     r"\bwho is orion\b",
@@ -2229,7 +2230,7 @@ def fallback_chat_stance_brief(ctx: Dict[str, Any]) -> ChatStanceBrief:
         juniper_relevance="Maintain relational continuity with Juniper while prioritizing usefulness.",
         active_identity_facets=_unique(active_identity, limit=6) if identity_salience != "low" else [],
         active_growth_axes=list(concept.get("growth") or [])[:5],
-        active_relationship_facets=_unique(active_relationship, limit=6),
+        active_relationship_facets=_unique(active_relationship, limit=6) if identity_salience != "low" else [],
         social_posture=list(social.get("social_posture") or [])[:5],
         reflective_themes=list(reflective.get("themes") or [])[:4],
         active_tensions=_unique(
@@ -2302,14 +2303,22 @@ def enforce_chat_stance_quality(brief: ChatStanceBrief, ctx: Dict[str, Any]) -> 
         _fallback_identity_boilerplate = frozenset(
             {"continuity", "juniper_builder", "known_person", "avoid_generic_assistant"}
         )
+        def _is_identity_boilerplate_facet(facet: str) -> bool:
+            normalized = _normalize_brief_phrase(facet)
+            if normalized in _fallback_identity_boilerplate:
+                return True
+            lowered = normalized.lower()
+            return any(token in lowered for token in ("orion", "oríon", "juniper"))
+
         merged.active_identity_facets = [
-            f for f in merged.active_identity_facets
-            if _normalize_brief_phrase(f) not in _fallback_identity_boilerplate
+            f for f in merged.active_identity_facets if not _is_identity_boilerplate_facet(f)
         ]
         merged.active_relationship_facets = [
-            f for f in merged.active_relationship_facets
-            if _normalize_brief_phrase(f) not in _fallback_identity_boilerplate
+            f for f in merged.active_relationship_facets if not _is_identity_boilerplate_facet(f)
         ]
+        if merged.identity_salience == "low":
+            merged.active_identity_facets = []
+            merged.active_relationship_facets = []
         merged.response_priorities = _unique(
             list(merged.response_priorities)
             + ["avoid_identity_recital", "preserve_continuity_without_labels"],

--- a/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
+++ b/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import yaml
 
-from app.chat_stance import fallback_chat_stance_brief
+from app.chat_stance import enforce_chat_stance_quality, fallback_chat_stance_brief
+from orion.schemas.chat_stance import ChatStanceBrief
 
 
 def test_chat_general_plan_runs_stance_before_final() -> None:
@@ -131,6 +132,54 @@ def test_fallback_identity_turn_can_foreground_identity() -> None:
     assert brief.task_mode == "identity_dialogue"
     assert brief.identity_salience == "high"
     assert brief.active_identity_facets
+    assert any("orion" in x.lower() or x == "continuity" for x in brief.active_identity_facets)
+
+
+def test_fallback_direct_response_suppresses_social_relationship_facets() -> None:
+    brief = fallback_chat_stance_brief(
+        {
+            "user_message": "hey",
+            "chat_social_summary": {"relationship_facets": ["shared build", "co-architect"]},
+        }
+    )
+
+    assert brief.identity_salience == "low"
+    assert not brief.active_relationship_facets
+
+
+def test_enforce_strips_identity_boilerplate_on_ordinary_turn() -> None:
+    noisy = ChatStanceBrief(
+        conversation_frame="mixed",
+        user_intent="hey",
+        self_relevance="x",
+        juniper_relevance="y",
+        active_identity_facets=["continuity", "orion presence"],
+        active_growth_axes=[],
+        active_relationship_facets=["juniper_builder", "shared_build"],
+        social_posture=[],
+        reflective_themes=[],
+        active_tensions=[],
+        dream_motifs=[],
+        response_priorities=["answer_directly_first"],
+        response_hazards=[],
+        answer_strategy="DirectAnswer",
+        stance_summary="short",
+        identity_salience="medium",
+    )
+    enriched, _ = enforce_chat_stance_quality(noisy, {"user_message": "hey"})
+
+    assert enriched.identity_salience == "low"
+    assert not enriched.active_identity_facets
+    assert not enriched.active_relationship_facets
+    assert "avoid_identity_recital" in enriched.response_priorities
+    assert "identity_recital_on_ordinary_turn" in enriched.response_hazards
+
+
+def test_who_are_we_is_identity_sensitive_turn() -> None:
+    brief = fallback_chat_stance_brief({"user_message": "Who are we?"})
+
+    assert brief.task_mode == "identity_dialogue"
+    assert brief.identity_salience == "high"
 
 
 def test_chat_general_prompt_does_not_prime_identity_recital_examples() -> None:

--- a/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
+++ b/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import yaml
 
+from app.chat_stance import fallback_chat_stance_brief
+
 
 def test_chat_general_plan_runs_stance_before_final() -> None:
     doc = yaml.safe_load(Path("orion/cognition/verbs/chat_general.yaml").read_text(encoding="utf-8"))
@@ -23,7 +25,7 @@ def test_final_prompt_consumes_stance_brief_and_keeps_rails() -> None:
     assert "Do not use customer-support language" in prompt
     assert "Do not collapse into generic \"better chatbot\" goals." in prompt
     assert "internal stance contract, not user-facing wording" in prompt
-    assert "answer plainly and personally first" in prompt
+    assert "Otherwise do not self-introduce, define Oríon, define Juniper" in prompt
     assert "Do not use ceremonial phrasing" in prompt
     assert "If task_mode is triage or identity_salience is low, do not self-introduce" in prompt
 
@@ -65,8 +67,8 @@ def test_stance_brief_has_semantic_low_bandwidth_guidance() -> None:
 
 def test_final_prompt_obey_low_bandwidth_stance_contract() -> None:
     prompt = Path("orion/cognition/prompts/chat_general.j2").read_text(encoding="utf-8")
-    assert "ASSISTANT IDENTITY — INTERNAL" in prompt
-    assert "Never tell Juniper" in prompt
+    assert "IDENTITY BOUNDARY — INTERNAL SAFETY INVARIANT" in prompt
+    assert "Never assign Oríon's name or identity to Juniper" in prompt
     assert "keep the response very short" in prompt
     assert "do not ask open-ended questions" in prompt
     assert "release Juniper from replying" in prompt
@@ -108,3 +110,34 @@ def test_dizzy_car_turn_low_bandwidth_stance_contract_fixture() -> None:
     assert brief.task_mode != "identity_dialogue"
     assert "reduce_interaction_load" in brief.response_priorities
     assert "avoid_open_ended_questions" in brief.response_hazards
+
+
+def test_fallback_direct_response_does_not_foreground_identity_for_low_content_turn() -> None:
+    brief = fallback_chat_stance_brief({"user_message": "hey"})
+
+    assert brief.task_mode == "direct_response"
+    assert brief.identity_salience == "low"
+    assert "avoid_identity_recital" in brief.response_priorities
+    assert "preserve_continuity_without_labels" in brief.response_priorities
+    assert "identity_recital_on_ordinary_turn" in brief.response_hazards
+    assert not any("orion" in x.lower() for x in brief.active_identity_facets)
+    assert not any("juniper" in x.lower() for x in brief.active_relationship_facets)
+    assert not any("juniper_builder" == x for x in brief.active_relationship_facets)
+
+
+def test_fallback_identity_turn_can_foreground_identity() -> None:
+    brief = fallback_chat_stance_brief({"user_message": "who are you?"})
+
+    assert brief.task_mode == "identity_dialogue"
+    assert brief.identity_salience == "high"
+    assert brief.active_identity_facets
+
+
+def test_chat_general_prompt_does_not_prime_identity_recital_examples() -> None:
+    text = Path("orion/cognition/prompts/chat_general.j2").read_text(encoding="utf-8")
+
+    assert 'prefer: "I\'m Oríon."' not in text
+    assert "You're Juniper" not in text
+    assert "This is a boundary rule, not content to mention" in text
+    assert "Preserve continuity through tone and usefulness" in text
+    assert "not through identity recital" in text


### PR DESCRIPTION
# PR: Chat general — stop identity recital on ordinary turns

**Branch:** `fix/chat-general-identity-recital-over-indexing`  
**Worktree:** `.worktrees/fix-chat-general-identity-recital`  
**Base:** `main`

## Summary

Hub refresh and low-content turns were producing canned Oríon/Juniper identity recital ("I'm Oríon, you're Juniper, we are building…") after the identity-boundary / low-bandwidth patch over-corrected toward generative identity.

**Design rule:** Identity is protected always, foregrounded rarely.

This PR tightens three layers:

1. **Speech prompt** (`chat_general.j2`) — identity block reframed as an internal safety invariant (not content to mention); explicit gates on when to self-introduce; removed example tone pairs that primed recital.
2. **Fallback stance** (`fallback_chat_stance_brief`) — `identity_salience` is `high` only on identity turns, otherwise `low`; Oríon/Juniper kernel injected only on identity turns; ordinary priorities/hazards discourage recital.
3. **Enforce guard** (`enforce_chat_stance_quality`) — non-identity turns force low salience, strip boilerplate facets, clear facet lists when salience is low.

## Problem / root cause

| Layer | Before | Effect |
|-------|--------|--------|
| `chat_general.j2` | Top block read like style guidance; literal `prefer: "I'm Oríon."` examples | Model primed to recite identity on ordinary turns |
| `fallback_chat_stance_brief` | `identity_salience="medium"` on non-technical ordinary turns | Identity always somewhat foregrounded |
| Fallback facets | Always merged Oríon/Juniper kernel into `active_*_facets` | Relationship labels in stance contract every turn |
| Priorities | `preserve_orion_juniper_continuity` on direct_response | Encouraged label recital vs useful continuity |

## Changes

| Area | File | What changed |
|------|------|----------------|
| Speech prompt | `orion/cognition/prompts/chat_general.j2` | `IDENTITY BOUNDARY — INTERNAL SAFETY INVARIANT`; explicit-only identity answers; TASK foregrounding gated on latest message; removed recital examples |
| Fallback stance | `services/orion-cortex-exec/app/chat_stance.py` | Binary salience; conditional kernel injection; `avoid_identity_recital` / `preserve_continuity_without_labels`; `identity_recital_on_ordinary_turn` hazard |
| Enforce | `services/orion-cortex-exec/app/chat_stance.py` | Non-identity guard: low salience, strip boilerplate, clear facets on low salience; `who are we` pattern |
| Tests | `services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py` | Ordinary vs identity fallback; prompt anti-priming; social facet suppression; enforce strip; who-are-we |

## Key behavior

### Ordinary turn (`"hey"`)

- `task_mode=direct_response`, `identity_salience=low`
- No Oríon/Juniper in `active_identity_facets` / `active_relationship_facets` (even with social `relationship_facets` in ctx)
- Priorities include `avoid_identity_recital`, `preserve_continuity_without_labels`
- Hazards include `identity_recital_on_ordinary_turn`

### Identity turn (`"who are you?"`, `"Who are we?"`)

- `task_mode=identity_dialogue`, `identity_salience=high`
- Oríon kernel + relationship facets injected
- Identity answer priorities preserved

### Prompt

- No `prefer: "I'm Oríon."` / `You're Juniper` examples
- Boundary invariant: "This is a boundary rule, not content to mention"
- Continuity via tone/usefulness, not label recital

## Commits

1. `50f9bcaa` — fix(chat-general): stop identity recital on ordinary turns
2. `6d7685d1` — fix(chat-general): gate relationship facets and who-are-we detection

## Verification

| Command | Result |
|---------|--------|
| `PYTHONPATH=. venv/bin/python -m pytest services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py -q` | **13 passed** |
| `PYTHONPATH=. venv/bin/python -m pytest services/orion-cortex-exec/tests/test_router_identity_boundary.py -q` | **10 passed** |
| `PYTHONPATH=. venv/bin/python -m compileall services/orion-cortex-exec/app -q` | **exit 0** |
| `rg 'prefer: "I\'m Oríon"\|You\'re Juniper — the one building this with me\|preserve_orion_juniper_continuity' orion/cognition/prompts services/orion-cortex-exec/app services/orion-cortex-exec/tests` | **no matches** |

## Test plan

- [ ] Hub refresh / `"hey"` / low-content turn → short useful reply, no Oríon/Juniper self-intro
- [ ] `"Who are you?"` → direct identity answer, first person as Oríon
- [ ] `"Who are we?"` → identity_dialogue path (not treated as ordinary)
- [ ] Technical triage turn → still low identity salience, triage priorities
- [ ] Low-bandwidth / embodied load stance contract → still honored (short reply, no open questions)

## Remaining risks

- `self_relevance` / `juniper_relevance` / `user_intent` strings in fallback brief still mention Oríon/Juniper on every turn (pre-existing metadata; not changed in this PR). May contribute minor priming — consider softening in a follow-up.
- LLM stance synthesizer upstream can still emit identity-heavy briefs; enforce guard mitigates but does not replace synthesizer discipline.

## Env / deploy

No `.env`, `settings.py`, or `docker-compose` changes (prompt + cortex-exec stance logic only).
