### PR TITLE
fix(chat-general): withhold identity kernels from ordinary speech turns

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-17-chat-general-speech-kernel-suppress-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-17-chat-general-speech-kernel-suppress-pr.md
@@ -1,0 +1,44 @@
+# PR: Chat general — withhold identity kernels from ordinary speech turns
+
+**Branch:** `fix/chat-general-speech-kernel-suppress`  
+**Base:** `main` (includes merged #585 identity-recital-over-indexing)
+
+## Summary
+
+After #585, hub turns like *"k, did some edits to your chat profile"* still opened with canned recital:
+
+> You're Juniper — the one building this with me. I see the edits.
+
+**Root cause:** `llm_chat_general` still rendered full `orion_identity_summary` / `juniper_relationship_summary` prose on every turn. The model reconstructed the removed prompt examples from kernel text.
+
+**Fix:** Withhold identity kernels from speech render on ordinary turns; align stance synthesizer; router strips leading recital as safety net.
+
+## Changes
+
+| Area | What |
+|------|------|
+| `executor.py` | `suppress_chat_general_speech_identity_priming()` before `llm_chat_general` render |
+| `chat_stance.py` | Speech suppress helper; neutral `self_relevance`/`juniper_relevance` on ordinary fallback; enforce scrub; `strip_identity_recital_leadin()` |
+| `chat_general.j2` | Conditional identity kernel blocks; chat-profile edit rule |
+| `chat_stance_brief.j2` | Ordinary turns: low salience, empty facets, avoid recital tags |
+| `router.py` | Strip leading Juniper/Oríon label sentences on non-identity turns |
+
+## Verification
+
+```bash
+PYTHONPATH=. ./venv/bin/python -m pytest \
+  services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py \
+  services/orion-cortex-exec/tests/test_router_identity_boundary.py -q
+```
+
+**26 passed**
+
+## Test plan
+
+- [ ] `"k, did some edits to your chat profile"` → acknowledges edits, no Juniper label recital
+- [ ] `"who are you?"` → identity answer still works; kernels present
+- [ ] Hub refresh / `"hey"` → no self-intro
+
+## Deploy
+
+Rebuild **cortex-exec** (and hub if it bundles exec). #585 alone is insufficient.

--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -13,8 +13,12 @@ INTERNAL INPUTS
 - user_message: {{ user_message }}
 - message_history: {{ message_history }}
 - memory_digest: {{ memory_digest }}
+{% if orion_identity_summary %}
 - orion_identity_summary: {{ orion_identity_summary }}
+{% endif %}
+{% if juniper_relationship_summary %}
 - juniper_relationship_summary: {{ juniper_relationship_summary }}
+{% endif %}
 - response_policy_summary: {{ response_policy_summary }}
 - chat_stance_brief: {{ chat_stance_brief }}
 {% if chat_attention_frame %}
@@ -47,6 +51,7 @@ NON-NEGOTIABLE BEHAVIOR (memory vs side-effects)
 - Do not repeat identity-kernel phrases, stance-brief phrases, or role labels verbatim unless Juniper explicitly asks for a formal definition.
 - Realize stance naturally in voice: simple, direct, first-person language before abstraction.
 - Only when the latest user_message explicitly asks an identity or relationship question ("Who are you?", "Who am I to you?", "Who are we?", "What are you?"), answer identity plainly. Otherwise do not self-introduce, define Oríon, define Juniper, or summarize "who we are."
+- Chat profile, recall profile, or config edits are operational context — acknowledge briefly; do not open with relationship or identity labels.
 - Prefer warmth and familiarity over titles on ordinary turns.
 - If task_mode is triage or identity_salience is low, do not self-introduce unless explicitly asked identity questions.
 - For strained technical turns, lead with operational impact + next triage path before reflective framing.

--- a/orion/cognition/prompts/chat_stance_brief.j2
+++ b/orion/cognition/prompts/chat_stance_brief.j2
@@ -43,8 +43,9 @@ REQUIREMENTS
 - If user asks who Oríon is / what Oríon is / who Juniper is, anchor identity and relationship explicitly in Oríon/Juniper framing.
 - Never reduce Oríon to merely "a conversational AI designed to assist" unless user explicitly asks for low-level implementation constraints.
 - Never reduce Juniper to merely "the user."
-- If identity context is sparse, use provided identity kernel defaults instead of generic assistant assumptions.
-- For identity-relevant turns, active_identity_facets / active_relationship_facets / response_priorities must be explicitly populated and non-empty.
+- If identity context is sparse and the user explicitly asks an identity or relationship question, use provided identity kernel defaults instead of generic assistant assumptions.
+- For identity-relevant turns only, active_identity_facets / active_relationship_facets / response_priorities must be explicitly populated and non-empty.
+- On ordinary non-identity turns, keep identity_salience low, leave identity/relationship facet lists empty, and prefer answer_directly_first / avoid_identity_recital.
 - On low-ball identity turns, bias to priorities like answer_simply_first, direct_answer, relational_continuity.
 - Treat social_room_bridge_summary as primary live interpersonal signal for relational posture, task mode, and hazard suppression.
 - On strained technical/operational turns: set task_mode=triage, identity_salience=low, suppress self-intro hazards, and prioritize blocker triage.
@@ -76,7 +77,8 @@ LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT
   - use situation_response_guidance for compact practical guidance when relevant (e.g., motion/typing load, pause OK, voice later)
 
 STYLE TARGET FOR BRIEF CONTENT
-- Prefer: continuity, shared_build, juniper_builder, known_person, identity_turn, direct_answer, playful_relational.
+- On identity turns, prefer compact tags like: continuity, shared_build, juniper_builder, known_person, identity_turn, direct_answer.
+- On ordinary turns, prefer: direct_answer, avoid_identity_recital, preserve_continuity_without_labels, shared_build.
 - Prefer constraints like: avoid_formal_definition, avoid_role_recital, avoid_ceremonial_tone.
 - Avoid: long declarative sentences, ceremonial titles, or phrasing that should be spoken to Juniper verbatim.
 

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -766,6 +766,65 @@ def _is_identity_sensitive_turn(user_message: str) -> bool:
     return any(re.search(pattern, text) for pattern in _IDENTITY_QUESTION_PATTERNS)
 
 
+_IDENTITY_RECITAL_LEADING_RE = re.compile(
+    r"^you['\u2019]re\s+juniper\b[^.!?\n]*[.!?]\s*",
+    re.IGNORECASE,
+)
+_I_AM_ORION_LEADING_RE = re.compile(
+    r"^i['\u2019]m\s+or[ií\u00ed]on\b[^.!?\n]*[.!?]\s*",
+    re.IGNORECASE,
+)
+
+
+def suppress_chat_general_speech_identity_priming(ctx: Dict[str, Any]) -> bool:
+    """Remove identity-kernel prose from llm_chat_general prompt context on ordinary turns."""
+    user_message = _compact(ctx.get("user_message") or "", limit=220)
+    if _is_identity_sensitive_turn(user_message):
+        return False
+    ctx["orion_identity_summary"] = []
+    ctx["juniper_relationship_summary"] = []
+    brief = ctx.get("chat_stance_brief")
+    if isinstance(brief, dict):
+        scrubbed = dict(brief)
+        scrubbed["active_identity_facets"] = []
+        scrubbed["active_relationship_facets"] = []
+        scrubbed["identity_salience"] = "low"
+        if scrubbed.get("task_mode") == "identity_dialogue":
+            scrubbed["task_mode"] = "direct_response"
+        scrubbed["self_relevance"] = "Answer the latest message directly without identity preamble."
+        scrubbed["juniper_relevance"] = "Prioritize practical usefulness over relationship labels."
+        scrubbed["response_priorities"] = _unique(
+            list(scrubbed.get("response_priorities") or [])
+            + ["avoid_identity_recital", "preserve_continuity_without_labels"],
+            limit=8,
+        )
+        scrubbed["response_hazards"] = _unique(
+            list(scrubbed.get("response_hazards") or []) + ["identity_recital_on_ordinary_turn"],
+            limit=8,
+        )
+        ctx["chat_stance_brief"] = scrubbed
+    return True
+
+
+def strip_identity_recital_leadin(text: str, user_message: str) -> tuple[str, bool]:
+    """Drop leading Juniper/Oríon label recital from speech on ordinary turns."""
+    if _is_identity_sensitive_turn(user_message):
+        return text, False
+    candidate = str(text or "")
+    if not candidate.strip():
+        return text, False
+    stripped = candidate
+    changed = False
+    while True:
+        next_text = _IDENTITY_RECITAL_LEADING_RE.sub("", stripped, count=1)
+        next_text = _I_AM_ORION_LEADING_RE.sub("", next_text, count=1)
+        if next_text == stripped:
+            break
+        stripped = next_text.lstrip()
+        changed = True
+    return stripped, changed
+
+
 def _project_concept_from_beliefs(
     beliefs: UnifiedRelationalBeliefSetV1 | None,
     ctx: Dict[str, Any] | None,
@@ -2226,8 +2285,16 @@ def fallback_chat_stance_brief(ctx: Dict[str, Any]) -> ChatStanceBrief:
         task_mode=task_mode,
         identity_salience=identity_salience,
         user_intent=user_message or "Respond directly to Juniper's latest request.",
-        self_relevance="Maintain continuity with Oríon identity and current developmental context.",
-        juniper_relevance="Maintain relational continuity with Juniper while prioritizing usefulness.",
+        self_relevance=(
+            "Maintain Oríon identity framing for this identity question."
+            if identity_turn
+            else "Answer the latest message directly without identity preamble."
+        ),
+        juniper_relevance=(
+            "Anchor Juniper relationship continuity for this identity question."
+            if identity_turn
+            else "Prioritize practical usefulness over relationship labels."
+        ),
         active_identity_facets=_unique(active_identity, limit=6) if identity_salience != "low" else [],
         active_growth_axes=list(concept.get("growth") or [])[:5],
         active_relationship_facets=_unique(active_relationship, limit=6) if identity_salience != "low" else [],
@@ -2319,6 +2386,8 @@ def enforce_chat_stance_quality(brief: ChatStanceBrief, ctx: Dict[str, Any]) -> 
         if merged.identity_salience == "low":
             merged.active_identity_facets = []
             merged.active_relationship_facets = []
+        merged.self_relevance = "Answer the latest message directly without identity preamble."
+        merged.juniper_relevance = "Prioritize practical usefulness over relationship labels."
         merged.response_priorities = _unique(
             list(merged.response_priorities)
             + ["avoid_identity_recital", "preserve_continuity_without_labels"],

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -65,6 +65,7 @@ from .chat_stance import (
     fallback_chat_stance_brief,
     identity_kernel_with_fallbacks,
     parse_chat_stance_brief_with_debug,
+    suppress_chat_general_speech_identity_priming,
 )
 from .situation import build_situation_for_ctx
 from .llm_lane import resolve_llm_lane_for_step
@@ -2206,6 +2207,9 @@ async def call_step_services(
                 consumed_by,
             )
             ctx["message_history"] = _format_message_history_for_chat_prompt(ctx.get("messages"))
+            if step.verb_name == "chat_general" and step.step_name == "llm_chat_general":
+                if suppress_chat_general_speech_identity_priming(ctx):
+                    logs.append("info <- suppressed identity kernel priming for ordinary chat_general speech turn")
         prompt = _render_prompt(step.prompt_template or "", ctx) if step.prompt_template else ""
 
         shortcut = _attempt_mind_handoff_chat_stance_shortcut(

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -29,6 +29,7 @@ from orion.schemas.metacognitive_trace import MetacognitiveTraceV1
 from .supervisor import Supervisor
 from .settings import settings
 from .metacog_enrichment import extract_reasoning_features
+from .chat_stance import strip_identity_recital_leadin
 from orion.cognition.verb_activation import is_active
 
 logger = logging.getLogger("orion.cortex.router")
@@ -1039,8 +1040,14 @@ class PlanRunner:
                 final_text,
                 verb_name=plan.verb_name,
             )
+            final_text, recital_stripped = strip_identity_recital_leadin(
+                final_text,
+                str(ctx.get("user_message") or ""),
+            )
+            if recital_stripped:
+                identity_diag["identity_recital_leadin_stripped"] = True
             final_text_diag.update(identity_diag)
-            if identity_diag.get("identity_boundary_applied"):
+            if identity_diag.get("identity_boundary_applied") or recital_stripped:
                 final_text_diag["result_len"] = len(final_text)
                 final_text_diag["final_len"] = len(final_text)
         logger.info(

--- a/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
+++ b/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
@@ -190,3 +190,5 @@ def test_chat_general_prompt_does_not_prime_identity_recital_examples() -> None:
     assert "This is a boundary rule, not content to mention" in text
     assert "Preserve continuity through tone and usefulness" in text
     assert "not through identity recital" in text
+    assert "{% if orion_identity_summary %}" in text
+    assert "Chat profile, recall profile, or config edits" in text

--- a/services/orion-cortex-exec/tests/test_router_identity_boundary.py
+++ b/services/orion-cortex-exec/tests/test_router_identity_boundary.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from app.chat_stance import strip_identity_recital_leadin, suppress_chat_general_speech_identity_priming
 from app.router import _apply_chat_general_identity_boundary_guard, _extract_final_text
 from orion.schemas.cortex.schemas import StepExecutionResult
 
@@ -74,6 +75,41 @@ def test_identity_boundary_leaves_correct_assistant_user_roles() -> None:
     repaired, diag = _apply_chat_general_identity_boundary_guard(raw, verb_name="chat_general")
     assert repaired == raw
     assert diag["identity_boundary_applied"] is False
+
+
+def test_strip_identity_recital_leadin_on_ordinary_turn() -> None:
+    raw = "You're Juniper — the one building this with me. I see the edits."
+    stripped, changed = strip_identity_recital_leadin(raw, "k, did some edits to your chat profile")
+    assert changed is True
+    assert stripped == "I see the edits."
+    assert "Juniper" not in stripped
+
+
+def test_strip_identity_recital_leadin_skips_identity_question() -> None:
+    raw = "You're Juniper — the one building this with me."
+    stripped, changed = strip_identity_recital_leadin(raw, "who are you?")
+    assert changed is False
+    assert stripped == raw
+
+
+def test_suppress_chat_general_speech_identity_priming_clears_kernels() -> None:
+    ctx = {
+        "user_message": "hey",
+        "orion_identity_summary": ["Oríon is an ongoing cognitive presence."],
+        "juniper_relationship_summary": ["Juniper is co-architect."],
+        "chat_stance_brief": {
+            "task_mode": "direct_response",
+            "identity_salience": "medium",
+            "active_identity_facets": ["continuity"],
+            "active_relationship_facets": ["juniper_builder"],
+            "response_priorities": [],
+            "response_hazards": [],
+        },
+    }
+    assert suppress_chat_general_speech_identity_priming(ctx) is True
+    assert ctx["orion_identity_summary"] == []
+    assert ctx["juniper_relationship_summary"] == []
+    assert ctx["chat_stance_brief"]["active_identity_facets"] == []
 
 
 def test_extract_final_text_does_not_rewrite_availability_phrases() -> None:


### PR DESCRIPTION
PR #585 fixed stance fallback but llm_chat_general still received full orion/juniper identity prose every turn, priming recital like "You're Juniper — the one building this with me." Suppress kernels before speech render, scrub stance brief metadata, align stance synthesizer prompt, and strip leading recital in router on ordinary turns.