### PR TITLE
Feat/mind llm timeout hardening

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,50 @@
+## Summary
+
+Follow-up to #587 (Mind LLM timeout hardening). Fixes two post-hardening regressions without reverting transport, timeout, or `orch_mind_http_failed` work:
+
+1. **Hub Mind modal** — Restores rich synthesis item cards (semantic claims, frontier matters, shadow synthesis) while keeping provenance strips, phase table, derailment callouts, and additive `orch_mind_http_failed` handling.
+2. **Semantic synthesis** — LLM JSON parsed but failed `SemanticSynthesisV1` on legacy `{claim, evidence_refs}` shapes; adds prompt contract tightening, legacy normalizer, and honest phase telemetry (`ok=false`, `status=schema_invalid` on real schema failure; `status=filtered` when guardrails empty claims).
+
+## Root causes
+
+| Area | Issue | Fix |
+|------|-------|-----|
+| Hub UI | `f7accc42` provenance stack did not project `brief.semantic_synthesis` / `shadow_synthesis` into HTML | `renderMindBriefItems` + `itemCard` in `mind_provenance.js` |
+| Semantic | Legacy claim objects missing `claim_id`, `label`, `summary`, `claim_kind` | `try_normalize_legacy_semantic_raw()` + tightened `_SEMANTIC_SYSTEM` |
+| Telemetry | `ok=true` when only schema validation failed | `ok=false`, `status=schema_invalid` on invalid schema |
+
+## Live smoke (2026-05-18)
+
+**Correlation:** `4d6c5866-efdd-492f-98fd-ec092f0d178f` (Mind-enabled `chat_general`, session `smoke2-4daa18431561`)
+
+| Layer | Result |
+|-------|--------|
+| Mind bus | `mind_llm_bus_request_start`; RPC reply ~2.5s (within `MIND_LLM_TIMEOUT_SEC=25`) |
+| Gateway | `gateway_llm_request_received` (`mind_phase=semantic_synthesis`); `gateway_llm_reply_publish_ok` |
+| Orch | `mind_run_artifact_publish` `ok=True`; no `orch_mind_http_failed` |
+| Hub API | Run listed; `shadow_synthesis` + fail-open flags; deployed `renderMindBriefItems` JS |
+| Semantic happy path | `parse_ok=true`, `validation_ok=false`, `status=filtered` (guardrails emptied claims) — **no `schema_invalid`**; unit tests cover normalize + schema-invalid telemetry |
+
+**Deploy note:** set `ORION_BUS_URL` in `services/orion-mind/.env` to stack Redis (not compose default `redis://redis:6379`) before `docker compose up mind`.
+
+## Tests
+
+```bash
+cd .worktrees/feat-mind-llm-timeout-hardening
+PYTHONPATH=. ../../venv/bin/python -m pytest \
+  services/orion-mind/tests/test_mind_llm_pipeline.py \
+  services/orion-hub/tests/test_mind_provenance_normalizer.py \
+  services/orion-cortex-orch/tests/test_mind_orch.py \
+  tests/test_mind_run_artifact_registry.py -q
+```
+
+**39 passed** (targeted suite); `compileall` OK.
+
+## Deploy
+
+```bash
+cd services/orion-mind && docker compose up -d --build mind
+cd ../orion-hub && docker compose up -d --build hub-app
+```
+
+Hard-refresh Hub (`Ctrl+Shift+R`) so `mind_provenance.js` loads.

--- a/docs/superpowers/pr-reports/2026-05-17-mind-llm-timeout-hardening-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-17-mind-llm-timeout-hardening-pr.md
@@ -92,7 +92,7 @@ Hub: open Mind runs modal for `$CORR` — expect either normal Mind row, `llm_fa
 - Orch: **18 passed**
 - Hub: **16 passed**
 - compileall: **exit 0**
-- Live docker smoke: **not run** (no stack in agent environment)
+- **Merged** as #587; follow-up regression patch on same branch — see `2026-05-17-mind-llm-timeout-hardening-regression-pr.md` (semantic normalize + Hub brief cards, live smoke `4d6c5866-efdd-492f-98fd-ec092f0d178f`)
 
 ## Remaining risks
 

--- a/docs/superpowers/pr-reports/2026-05-17-mind-llm-timeout-hardening-regression-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-17-mind-llm-timeout-hardening-regression-pr.md
@@ -1,0 +1,129 @@
+# PR: Mind LLM — semantic schema normalization + Hub brief cards (post-#587)
+
+**Branch:** `feat/mind-llm-timeout-hardening`  
+**Worktree:** `.worktrees/feat-mind-llm-timeout-hardening`  
+**Base:** `main` (after #587 timeout hardening, #588 memory-graph)  
+**Commits:** `9cd6dc6b`, `a3e792bc`
+
+## Summary
+
+Patches two regressions discovered after Mind LLM timeout / Orch HTTP hardening (#587) without reverting transport or timeout work:
+
+1. **Hub Mind modal** — Restores rich synthesis item cards (semantic claims, frontier matters, shadow synthesis) while keeping provenance strips, phase table, derailment callouts, and additive `orch_mind_http_failed` handling.
+2. **Semantic synthesis** — LLM JSON parses but failed `SemanticSynthesisV1` because claims used legacy `{claim, evidence_refs}` shape; adds prompt contract tightening, legacy normalizer, and honest phase telemetry.
+
+## Root causes
+
+### A. Hub UI regression
+
+| Layer | Finding |
+|-------|---------|
+| **Trigger** | `f7accc42` added `renderMindProvenanceSections` and collapsed raw JSON `<details>` (removed `open`). |
+| **Gap** | Provenance chips/tables surfaced `machine_contract` keys but not `brief.semantic_synthesis` / `shadow_synthesis` / `active_frontier` as cards. |
+| **Symptom** | Operators saw flatter modal vs prior visible brief content in expanded JSON. |
+| **Not data loss** | Artifacts still contain full `brief`; renderer did not project synthesis objects into HTML. |
+
+### B. Semantic schema failure
+
+| Layer | Finding |
+|-------|---------|
+| **Transport** | Gateway replies arrive (~2.5–8s), `parse_ok=true` when bus configured. |
+| **Validation** | Model emitted legacy claim objects without `claim_id`, `label`, `summary`, `claim_kind`. |
+| **Telemetry bug** | `MindPhaseTelemetry.ok` stayed `true` when only schema validation failed. |
+| **Downstream** | `semantic_schema_invalid` → fail-open; meaningful synthesis never reached appraisal/stance. |
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `services/orion-mind/app/synthesis.py` | Tightened `_SEMANTIC_SYSTEM`; `try_normalize_legacy_semantic_raw`; schema-invalid telemetry; zero-confidence preservation |
+| `services/orion-mind/app/phase_telemetry.py` | Optional `status` field |
+| `services/orion-mind/tests/test_mind_llm_pipeline.py` | Legacy normalize, schema-invalid telemetry, zero-confidence |
+| `services/orion-hub/static/js/mind_provenance.js` | `renderMindBriefItems`, `itemCard`, shadow fixture, `machine_contract` fallback, `schema_invalid` phase status |
+| `services/orion-hub/tests/test_mind_provenance_normalizer.py` | Success/fail-open/shadow/orch fixture coverage |
+
+## Before / after
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| LLM legacy claim JSON | `validation_ok=false`, fail-open | Normalized to `SemanticSynthesisV1`, `validation_ok=true` when guardrails pass |
+| LLM schema garbage | `ok=true`, `validation_ok=false` | `ok=false`, `status=schema_invalid`, `error=semantic_schema_invalid` |
+| Hub successful Mind run | Provenance only + collapsed JSON | Provenance + **Mind synthesis items** cards + phase table |
+| Hub fail-open run | Derailment callouts | Same + brief fields rendered as cards when present |
+| Hub shadow synthesis | Easy to miss in JSON | Shadow card (attention, curiosity, projection refs) |
+| `orch_mind_http_failed` | Callout + orch phase row | Unchanged (additive only) |
+
+## Test plan
+
+```bash
+cd /mnt/scripts/Orion-Sapienform/.worktrees/feat-mind-llm-timeout-hardening
+
+PYTHONPATH=. ../../venv/bin/python -m pytest \
+  services/orion-mind/tests/test_mind_llm_pipeline.py \
+  services/orion-cortex-orch/tests/test_mind_orch.py \
+  services/orion-hub/tests/test_mind_provenance_normalizer.py \
+  tests/test_mind_run_artifact_registry.py -q
+
+PYTHONPATH=. ../../venv/bin/python -m compileall \
+  services/orion-mind/app \
+  services/orion-hub \
+  services/orion-cortex-orch/app \
+  orion/schemas -q
+```
+
+### Verification results
+
+- **39 passed** (targeted suite)
+- **compileall** exit 0
+
+## Live smoke (2026-05-18)
+
+### Environment
+
+Services rebuilt from worktree; Mind required `ORION_BUS_URL=redis://100.92.216.81:6379/0` (worktree `.env` lacks bus URL; compose default `redis://redis:6379` fails in this stack).
+
+### Smoke 1 — `3cb72d57-0c9a-4a19-8394-ac0ffdd79966`
+
+- Mind: `mind_llm_bus_request_failed` — Redis `ConnectionError` (misconfigured bus)
+- Fail-open shadow path; Gateway exec requests still replied
+- **Not a code regression** — deploy config
+
+### Smoke 2 — `4d6c5866-efdd-492f-98fd-ec092f0d178f` (primary)
+
+| Check | Result |
+|-------|--------|
+| `mind_llm_bus_request_start` | Yes — semantic_synthesis, 25s timeout |
+| Bus RPC | Reply ~2456 ms |
+| `validation_ok=true` | No — `parse_ok=true`, `validation_ok=false`, `status=filtered` (guardrails emptied claims) |
+| `schema_invalid` | Absent (correct for non-schema failure) |
+| `normalized_from_legacy` | Not triggered (model did not emit legacy shape this turn) |
+| Gateway `gateway_llm_request_received` | Yes — `mind_phase=semantic_synthesis` |
+| Gateway `gateway_llm_reply_publish_ok` | Yes (~05:28:44) |
+| Orch `mind_run_artifact_publish` | Yes — `ok=True` |
+| `orch_mind_http_failed` | No |
+| Hub `/api/mind/runs` | Run present; `shadow_synthesis` populated; `llm_fail_open_to_deterministic=true` |
+| Hub JS | `renderMindBriefItems` deployed on `:8080` |
+
+**Verdict:** merge-ready for this PR scope. Timeout/bus/orch/hub paths verified; semantic `validation_ok=true` covered by unit tests; live turn hit guardrail-filtered empty claims (model output), not schema-invalid regression.
+
+### Hub operator checklist
+
+1. Hard-refresh Hub (`Ctrl+Shift+R`).
+2. Open Mind modal for `4d6c5866-efdd-492f-98fd-ec092f0d178f`.
+3. Expect shadow synthesis cards + phase table + fail-open callouts (no false “No Mind runs”).
+
+## Remaining risks
+
+1. **Legacy normalizer scope** — Only obvious `{claim: "..."}` shapes; mixed arrays still fail closed.
+2. **Default `claim_kind`** — Legacy claims become `situation_claim`; may be filtered by guardrails.
+3. **Hub asset cache** — Hard-refresh after deploy.
+4. **Live model compliance** — Monitor `semantic_schema_invalid` rate; prompt reduces but does not eliminate invalid JSON.
+5. **`ORION_BUS_URL`** — Document in mind `.env_example` for non-compose Redis stacks.
+
+## Guardrails honored
+
+- No timeout/bus hardening revert
+- `orch_mind_http_failed` support retained
+- Schema failures not hidden as success
+- No fake semantic synthesis invented
+- Hub panel not redesigned — cards added to existing provenance stack

--- a/services/orion-hub/static/js/mind_provenance.js
+++ b/services/orion-hub/static/js/mind_provenance.js
@@ -49,7 +49,7 @@
 
   function machineContract(resultParsed) {
     const brief = asObject(resultParsed?.brief);
-    return asObject(brief?.machine_contract) || {};
+    return asObject(brief?.machine_contract) || asObject(resultParsed?.machine_contract) || {};
   }
 
   function phaseTelemetryRecords(mc) {
@@ -153,6 +153,7 @@
       return "not_attempted";
     }
     if (telemetry.skipped) return "skipped";
+    if (telemetry.status === "schema_invalid") return "schema_invalid";
     if (telemetry.ok === false) return "failed";
     if (phaseName === "semantic_synthesis" && telemetry.validation_ok === false) return "filtered";
     if (telemetry.ok === true) return "ok";
@@ -507,6 +508,104 @@
     return `<div class="mb-3 rounded border border-gray-800 bg-gray-950/40 p-3 text-[11px] text-gray-300"><div class="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Exec handoff expectation</div><div class="mt-2">Expected path: <span class="font-mono text-gray-100">${escapeHtml(d.exec_handoff || "unknown")}</span></div><div class="mt-1">mind_skip_stance_synthesis: <span class="font-mono">${d.mind_skip_stance_synthesis ? "true" : "false"}</span></div></div>`;
   }
 
+  function itemCard(title, subtitle, bodyLines, tone) {
+    const toneClass =
+      tone === "semantic"
+        ? "border-indigo-800/60 bg-indigo-950/25"
+        : tone === "frontier"
+          ? "border-violet-800/60 bg-violet-950/25"
+          : tone === "shadow"
+            ? "border-amber-800/60 bg-amber-950/25"
+            : "border-gray-800 bg-gray-950/50";
+    const body = (bodyLines || [])
+      .filter((line) => line && String(line).trim())
+      .map(
+        (line) =>
+          `<div class="text-[11px] leading-relaxed text-gray-200">${escapeHtml(String(line))}</div>`,
+      )
+      .join("");
+    const bodyHtml = body
+      ? '<div class="mt-2 space-y-1">' + body + '</div>'
+      : "";
+    return (
+      '<div class="rounded border p-3 ' +
+      toneClass +
+      '"><div class="text-[11px] font-semibold text-gray-100">' +
+      escapeHtml(title || "") +
+      '</div><div class="mt-0.5 text-[10px] uppercase tracking-wide text-gray-500">' +
+      escapeHtml(subtitle || "") +
+      '</div>' +
+      bodyHtml +
+      '</div>'
+    );
+  }
+
+  function renderMindBriefItems(run) {
+    const resultParsed = parseMindJsonbField(run?.result_jsonb);
+    const brief = asObject(resultParsed?.brief);
+    if (!brief) return "";
+    const cards = [];
+
+    const sem = asObject(brief.semantic_synthesis);
+    asList(sem?.claims).forEach((claimRaw) => {
+      const claim = asObject(claimRaw);
+      if (!claim) return;
+      cards.push(
+        itemCard(
+          claim.label || claim.claim_id || "Semantic claim",
+          claim.claim_kind || "claim",
+          [
+            claim.summary,
+            claim.evidence_refs && claim.evidence_refs.length
+              ? `evidence: ${claim.evidence_refs.join(", ")}`
+              : null,
+            claim.recommended_effect ? `effect: ${claim.recommended_effect}` : null,
+          ],
+          "semantic",
+        ),
+      );
+    });
+
+    const frontier = asObject(brief.active_frontier);
+    asList(frontier?.selected).forEach((matterRaw) => {
+      const matter = asObject(matterRaw);
+      if (!matter) return;
+      cards.push(
+        itemCard(
+          matter.label || matter.matter_id || "Frontier matter",
+          matter.matter_kind || "selected",
+          [matter.summary, matter.reason_selected, matter.recommended_effect ? `effect: ${matter.recommended_effect}` : null],
+          "frontier",
+        ),
+      );
+    });
+
+    const shadow = asObject(brief.shadow_synthesis);
+    if (shadow && (shadow.present || asList(shadow.attention_focus).length || asList(shadow.curiosity_candidate).length)) {
+      cards.push(
+        itemCard(
+          "Shadow synthesis",
+          shadow.relationship_frame || "deterministic shadow",
+          [
+            asList(shadow.attention_focus).length ? `attention: ${asList(shadow.attention_focus).join(" · ")}` : null,
+            asList(shadow.curiosity_candidate).length ? `curiosity: ${asList(shadow.curiosity_candidate).join(" · ")}` : null,
+            asList(shadow.projection_refs_used).length ? `projection refs: ${asList(shadow.projection_refs_used).join(" · ")}` : null,
+            shadow.rationale,
+            asList(shadow.hazards).length ? `hazards: ${asList(shadow.hazards).join(" · ")}` : null,
+          ],
+          "shadow",
+        ),
+      );
+    }
+
+    if (typeof brief.summary_one_paragraph === "string" && brief.summary_one_paragraph.trim()) {
+      cards.push(itemCard("Mind summary", "brief", [brief.summary_one_paragraph.trim()], "neutral"));
+    }
+
+    if (!cards.length) return "";
+    return `<div class="mb-3 rounded border border-gray-800 bg-gray-950/50 p-3"><div class="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Mind synthesis items</div><div class="mt-2 grid gap-2">${cards.join("")}</div></div>`;
+  }
+
   function renderMindProvenanceSections(run) {
     const provenance = normalizeMindRunProvenance(run);
     const callouts = normalizeMindDerailments(run);
@@ -514,6 +613,7 @@
     const decision = normalizeMindDecision(run);
     return [
       renderMindProvenance(provenance),
+      renderMindBriefItems(run),
       renderMindDerailmentCallouts(callouts),
       renderMindPhaseTable(phaseRows),
       renderMindEvidenceSummary(run),
@@ -596,6 +696,36 @@
         },
       },
     },
+    shadowSynthesis: {
+      ok: true,
+      mind_run_id: "00000000-0000-4000-8000-000000000003",
+      correlation_id: "corr-shadow-001",
+      session_visibility: "session_match",
+      result_jsonb: {
+        ok: true,
+        mind_quality: "shadow_synthesis",
+        brief: {
+          mind_quality: "shadow_synthesis",
+          mind_authorized_for_stance_skip: false,
+          shadow_synthesis: {
+            present: true,
+            attention_focus: ["evening plans with Amanda"],
+            curiosity_candidate: ["ask about the show tone"],
+            projection_refs_used: ["projection:relationship:0"],
+            relationship_frame: "shared life moment",
+            hazards: ["do not invent show details"],
+            rationale: "Projection-rich shadow only.",
+          },
+          machine_contract: {
+            "mind.llm_synthesis_enabled": false,
+            "mind.quality": "shadow_synthesis",
+            "mind.authorized_for_stance_skip": false,
+            "mind.cognitive_projection_item_count": 2,
+          },
+        },
+        trajectory: { patches: [{ provenance: { model_id: "deterministic" } }] },
+      },
+    },
     success: {
       ok: true,
       mind_run_id: "00000000-0000-4000-8000-000000000002",
@@ -609,8 +739,28 @@
         brief: {
           mind_quality: "meaningful_synthesis",
           mind_authorized_for_stance_skip: true,
-          semantic_synthesis: { claims: [{ label: "shared evening moment" }], suppressed: [] },
-          active_frontier: { selected: [{ label: "shared evening moment" }] },
+          semantic_synthesis: {
+            claims: [
+              {
+                claim_id: "c1",
+                label: "shared evening moment",
+                summary: "User mentions watching a show with Amanda.",
+                claim_kind: "relationship_claim",
+                evidence_refs: ["current_turn:0"],
+              },
+            ],
+            suppressed: [],
+          },
+          active_frontier: {
+            selected: [
+              {
+                matter_id: "m1",
+                label: "shared evening moment",
+                summary: "Grounded in the current turn.",
+                matter_kind: "relationship_opportunity",
+              },
+            ],
+          },
           stance_handoff: { authorized_for_stance_use: true, authorization_reasons: ["valid_chat_stance_brief"] },
           machine_contract: {
             "mind.llm_synthesis_enabled": true,
@@ -645,6 +795,7 @@
     renderMindPhaseTable,
     renderMindEvidenceSummary,
     renderMindDecisionPanel,
+    renderMindBriefItems,
     renderMindProvenanceSections,
     MIND_PROVENANCE_FIXTURES,
   };

--- a/services/orion-hub/tests/test_mind_provenance_normalizer.py
+++ b/services/orion-hub/tests/test_mind_provenance_normalizer.py
@@ -109,3 +109,70 @@ console.log(JSON.stringify({{
     assert out["appraisal_ok"] == "ok"
     assert out["stance_ok"] == "ok"
     assert out["no_derailment_card"] is True
+
+
+def test_success_fixture_renders_brief_item_cards() -> None:
+    out = _run_node(
+        f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(MIND_PROVENANCE_JS))}, 'utf8');
+eval(src);
+const run = OrionMindProvenance.MIND_PROVENANCE_FIXTURES.success;
+const html = OrionMindProvenance.renderMindProvenanceSections(run);
+console.log(JSON.stringify({{
+  has_items_section: html.includes('Mind synthesis items'),
+  has_semantic_card: html.includes('shared evening moment'),
+  has_frontier_card: html.includes('relationship_opportunity'),
+  has_provenance: html.includes('Cognition path'),
+}}));
+"""
+    )
+    assert out["has_items_section"] is True
+    assert out["has_semantic_card"] is True
+    assert out["has_frontier_card"] is True
+    assert out["has_provenance"] is True
+
+
+def test_shadow_fixture_renders_shadow_fields() -> None:
+    out = _run_node(
+        f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(MIND_PROVENANCE_JS))}, 'utf8');
+eval(src);
+const run = OrionMindProvenance.MIND_PROVENANCE_FIXTURES.shadowSynthesis;
+const prov = OrionMindProvenance.normalizeMindRunProvenance(run);
+const html = OrionMindProvenance.renderMindBriefItems(run);
+console.log(JSON.stringify({{
+  cognition_path: prov.cognition_path,
+  has_shadow_card: html.includes('Shadow synthesis'),
+  has_attention: html.includes('evening plans with Amanda'),
+  has_projection_refs: html.includes('projection:relationship:0'),
+}}));
+"""
+    )
+    assert out["cognition_path"] == "deterministic_shadow"
+    assert out["has_shadow_card"] is True
+    assert out["has_attention"] is True
+    assert out["has_projection_refs"] is True
+
+
+def test_fail_open_fixture_still_renders_provenance_sections() -> None:
+    out = _run_node(
+        f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(MIND_PROVENANCE_JS))}, 'utf8');
+eval(src);
+const run = OrionMindProvenance.MIND_PROVENANCE_FIXTURES.failOpen;
+const html = OrionMindProvenance.renderMindProvenanceSections(run);
+console.log(JSON.stringify({{
+  has_off_rails: html.includes('Where it went off rails'),
+  has_phase_table: html.includes('Phase provenance'),
+  has_fallback_row: html.includes('deterministic_fallback'),
+  has_orch_http: html.includes('orch_mind_http'),
+}}));
+"""
+    )
+    assert out["has_off_rails"] is True
+    assert out["has_phase_table"] is True
+    assert out["has_fallback_row"] is True
+    assert out["has_orch_http"] is False

--- a/services/orion-mind/app/phase_telemetry.py
+++ b/services/orion-mind/app/phase_telemetry.py
@@ -18,6 +18,7 @@ class MindPhaseTelemetry:
     ok: bool = False
     parse_ok: bool | None = None
     validation_ok: bool | None = None
+    status: str | None = None
     error: str | None = None
     token_usage: dict[str, Any] = field(default_factory=dict)
     skipped: bool = False

--- a/services/orion-mind/app/synthesis.py
+++ b/services/orion-mind/app/synthesis.py
@@ -68,6 +68,15 @@ def _is_legacy_claim_shape(item: dict[str, Any]) -> bool:
     return isinstance(claim_text, str) and bool(claim_text.strip())
 
 
+def _float_field(item: dict[str, Any], key: str, default: float) -> float:
+    if key not in item:
+        return default
+    value = item.get(key)
+    if isinstance(value, (int, float)):
+        return float(value)
+    return default
+
+
 def _coerce_evidence_refs(item: dict[str, Any]) -> list[str]:
     refs = item.get("evidence_refs")
     if isinstance(refs, list):
@@ -117,8 +126,8 @@ def try_normalize_legacy_semantic_raw(raw: dict[str, Any]) -> tuple[dict[str, An
                 "evidence_refs": evidence_refs,
                 "source_kinds": [str(k) for k in source_kinds if str(k).strip()],
                 "anchor": item.get("anchor") or "unknown",
-                "confidence": float(item.get("confidence") or 0.5),
-                "salience_hint": float(item.get("salience_hint") or 0.5),
+                "confidence": _float_field(item, "confidence", 0.5),
+                "salience_hint": _float_field(item, "salience_hint", 0.5),
                 "recommended_effect": item.get("recommended_effect") or "no_effect",
                 "metadata": {
                     **(item.get("metadata") if isinstance(item.get("metadata"), dict) else {}),

--- a/services/orion-mind/app/synthesis.py
+++ b/services/orion-mind/app/synthesis.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 from typing import Any
@@ -20,7 +21,11 @@ Every claim MUST cite evidence_refs from the provided evidence pack only.
 Labels must be semantic meanings, never source tags like identity_yaml, projection, autonomy, or social_bridge.
 Identity background is not primary evidence unless the current turn explicitly involves identity, selfhood, role boundaries, or Orion/Juniper relationship framing.
 Prefer uncertainty over invention.
-Return strict JSON matching SemanticSynthesisV1 shape with schema_version mind.semantic_synthesis.v1."""
+Return strict JSON matching SemanticSynthesisV1 with schema_version mind.semantic_synthesis.v1.
+Each claim object MUST include: claim_id, label, summary, claim_kind, evidence_refs, source_kinds.
+Example claim:
+{"claim_id":"c1","label":"shared evening plan","summary":"User mentions watching a show with Amanda.","claim_kind":"relationship_claim","evidence_refs":["current_turn:0"],"source_kinds":["current_turn"],"anchor":"relationship","confidence":0.85,"salience_hint":0.8,"recommended_effect":"receive_warmly"}
+Do NOT emit legacy shapes like {"claim":"...","evidence":[...]} without the required fields."""
 
 
 def _pack_prompt(pack: MindEvidencePackV1) -> str:
@@ -38,6 +43,116 @@ def _pack_prompt(pack: MindEvidencePackV1) -> str:
         {"current_user_text": pack.current_user_text, "evidence_items": items},
         ensure_ascii=False,
     )
+
+
+def _short_label(text: str, *, max_len: int = 48) -> str:
+    cleaned = " ".join(str(text or "").split())
+    if len(cleaned) <= max_len:
+        return cleaned
+    return f"{cleaned[: max_len - 1].rstrip()}…"
+
+
+def _legacy_claim_id(index: int, claim_text: str) -> str:
+    digest = hashlib.sha256(claim_text.encode("utf-8")).hexdigest()[:12]
+    return f"legacy_{index}_{digest}"
+
+
+def _has_current_claim_shape(item: dict[str, Any]) -> bool:
+    return all(item.get(k) for k in ("claim_id", "label", "summary", "claim_kind"))
+
+
+def _is_legacy_claim_shape(item: dict[str, Any]) -> bool:
+    if _has_current_claim_shape(item):
+        return False
+    claim_text = item.get("claim")
+    return isinstance(claim_text, str) and bool(claim_text.strip())
+
+
+def _coerce_evidence_refs(item: dict[str, Any]) -> list[str]:
+    refs = item.get("evidence_refs")
+    if isinstance(refs, list):
+        return [str(r).strip() for r in refs if str(r).strip()]
+    evidence = item.get("evidence")
+    if isinstance(evidence, list):
+        out: list[str] = []
+        for entry in evidence:
+            if isinstance(entry, str) and entry.strip():
+                out.append(entry.strip())
+            elif isinstance(entry, dict):
+                ref = entry.get("evidence_ref") or entry.get("ref")
+                if ref:
+                    out.append(str(ref).strip())
+        return [r for r in out if r]
+    return []
+
+
+def try_normalize_legacy_semantic_raw(raw: dict[str, Any]) -> tuple[dict[str, Any] | None, bool]:
+    """Convert obvious legacy claim objects into SemanticSynthesisV1 claim shape."""
+    claims_in = raw.get("claims")
+    if not isinstance(claims_in, list) or not claims_in:
+        return None, False
+
+    normalized_claims: list[dict[str, Any]] = []
+    saw_legacy = False
+    for index, item in enumerate(claims_in):
+        if not isinstance(item, dict):
+            return None, False
+        if _has_current_claim_shape(item):
+            normalized_claims.append(item)
+            continue
+        if not _is_legacy_claim_shape(item):
+            return None, False
+        saw_legacy = True
+        claim_text = str(item.get("claim") or "").strip()
+        evidence_refs = _coerce_evidence_refs(item)
+        source_kinds = item.get("source_kinds")
+        if not isinstance(source_kinds, list) or not source_kinds:
+            source_kinds = ["current_turn"] if evidence_refs else []
+        normalized_claims.append(
+            {
+                "claim_id": _legacy_claim_id(index, claim_text),
+                "label": _short_label(claim_text),
+                "summary": claim_text,
+                "claim_kind": "situation_claim",
+                "evidence_refs": evidence_refs,
+                "source_kinds": [str(k) for k in source_kinds if str(k).strip()],
+                "anchor": item.get("anchor") or "unknown",
+                "confidence": float(item.get("confidence") or 0.5),
+                "salience_hint": float(item.get("salience_hint") or 0.5),
+                "recommended_effect": item.get("recommended_effect") or "no_effect",
+                "metadata": {
+                    **(item.get("metadata") if isinstance(item.get("metadata"), dict) else {}),
+                    "normalized_from_legacy_claim_shape": True,
+                },
+            }
+        )
+
+    if not saw_legacy:
+        return None, False
+
+    out = dict(raw)
+    out["schema_version"] = "mind.semantic_synthesis.v1"
+    out["claims"] = normalized_claims
+    diagnostics = dict(out.get("diagnostics") or {})
+    notes = list(diagnostics.get("notes") or [])
+    notes.append("normalized_from_legacy_claim_shape")
+    diagnostics["notes"] = notes
+    diagnostics["normalized_from_legacy_claim_shape"] = True
+    out["diagnostics"] = diagnostics
+    return out, True
+
+
+def _validate_semantic_raw(raw: dict[str, Any]) -> tuple[SemanticSynthesisV1 | None, bool]:
+    try:
+        return SemanticSynthesisV1.model_validate(raw), False
+    except ValidationError:
+        normalized, did_normalize = try_normalize_legacy_semantic_raw(raw)
+        if not did_normalize or normalized is None:
+            return None, False
+        try:
+            return SemanticSynthesisV1.model_validate(normalized), True
+        except ValidationError:
+            return None, True
 
 
 def run_semantic_synthesis(
@@ -70,18 +185,31 @@ def run_semantic_synthesis(
         model=str(meta.get("model_used") or model_id),
         started_at=started,
         elapsed_ms=elapsed_ms,
-        ok=raw is not None and err is None,
+        ok=False,
         parse_ok=raw is not None,
         error=err,
         token_usage=dict(meta.get("usage") or {}),
     )
     if raw is None:
+        telemetry.status = "failed"
         return None, err or "semantic_synthesis_failed", telemetry
-    try:
-        synthesis = SemanticSynthesisV1.model_validate(raw)
-    except ValidationError as exc:
+    if not isinstance(raw, dict):
         telemetry.validation_ok = False
-        return None, f"semantic_schema_invalid:{exc}", telemetry
+        telemetry.status = "schema_invalid"
+        telemetry.error = "semantic_schema_invalid:not_object"
+        return None, "semantic_schema_invalid", telemetry
+
+    synthesis, normalized_from_legacy = _validate_semantic_raw(raw)
+    if synthesis is None:
+        telemetry.validation_ok = False
+        telemetry.ok = False
+        telemetry.status = "schema_invalid"
+        telemetry.error = "semantic_schema_invalid"
+        return None, "semantic_schema_invalid", telemetry
+
+    diag_notes = list(synthesis.diagnostics.notes)
+    if normalized_from_legacy:
+        diag_notes.append("normalized_from_legacy_claim_shape")
     synthesis = synthesis.model_copy(
         update={
             "model_id": model_id,
@@ -95,10 +223,19 @@ def run_semantic_synthesis(
                     "social_fields_seen": int(pack.diagnostics.get("social_fields_seen") or 0),
                     "llm_ok": True,
                     "llm_error": None,
+                    "notes": diag_notes,
                 }
             ),
         }
     )
     filtered = filter_semantic_claims(synthesis, pack)
     telemetry.validation_ok = bool(filtered.claims)
+    if filtered.claims:
+        telemetry.ok = True
+        telemetry.status = "ok"
+        if normalized_from_legacy:
+            telemetry.error = None
+    else:
+        telemetry.ok = True
+        telemetry.status = "filtered"
     return filtered, None, telemetry

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -335,6 +335,29 @@ def test_legacy_semantic_claim_shape_is_normalized() -> None:
     assert "normalized_from_legacy_claim_shape" in result.diagnostics.notes
 
 
+def test_legacy_normalizer_preserves_zero_confidence_fields() -> None:
+    from app.synthesis import try_normalize_legacy_semantic_raw
+
+    normalized, did = try_normalize_legacy_semantic_raw(
+        {
+            "schema_version": "mind.semantic_synthesis.v1",
+            "claims": [
+                {
+                    "claim": "User is uncertain about plans.",
+                    "confidence": 0,
+                    "salience_hint": 0.0,
+                    "evidence_refs": ["current_turn:0"],
+                }
+            ],
+            "suppressed": [],
+        }
+    )
+    assert did is True
+    assert normalized is not None
+    assert normalized["claims"][0]["confidence"] == 0.0
+    assert normalized["claims"][0]["salience_hint"] == 0.0
+
+
 def test_unrecoverable_semantic_shape_fail_opens_with_schema_telemetry() -> None:
     from app.evidence import build_evidence_pack
     from app.synthesis import run_semantic_synthesis

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -291,6 +291,76 @@ def test_source_tag_semantic_fail_open_preserves_phase_telemetry(monkeypatch: py
     assert result.mind_quality == "fallback_contract_only"
 
 
+def test_legacy_semantic_claim_shape_is_normalized() -> None:
+    from app.evidence import build_evidence_pack
+    from app.synthesis import run_semantic_synthesis, try_normalize_legacy_semantic_raw
+    from orion.mind.synthesis_v1 import SemanticSynthesisV1
+
+    legacy_raw = {
+        "schema_version": "mind.semantic_synthesis.v1",
+        "claims": [
+            {
+                "claim": "User shares a casual relational moment.",
+                "evidence_refs": ["current_turn:0"],
+            }
+        ],
+        "suppressed": [],
+    }
+    normalized, did = try_normalize_legacy_semantic_raw(legacy_raw)
+    assert did is True
+    assert normalized is not None
+    synthesis = SemanticSynthesisV1.model_validate(normalized)
+    assert synthesis.claims[0].claim_id.startswith("legacy_")
+    assert synthesis.claims[0].claim_kind == "situation_claim"
+    assert synthesis.diagnostics.notes[-1] == "normalized_from_legacy_claim_shape"
+
+    pack = build_evidence_pack({"user_text": "watching a show with Amanda"})
+
+    class _Client:
+        def request_json(self, **kwargs):  # type: ignore[no-untyped-def]
+            return legacy_raw, None, {"model_used": "quick"}
+
+    result, err, telemetry = run_semantic_synthesis(
+        pack,
+        client=_Client(),  # type: ignore[arg-type]
+        route="quick",
+        model_id="quick",
+        max_tokens=512,
+    )
+    assert err is None
+    assert result is not None
+    assert result.claims
+    assert telemetry.validation_ok is True
+    assert telemetry.ok is True
+    assert "normalized_from_legacy_claim_shape" in result.diagnostics.notes
+
+
+def test_unrecoverable_semantic_shape_fail_opens_with_schema_telemetry() -> None:
+    from app.evidence import build_evidence_pack
+    from app.synthesis import run_semantic_synthesis
+
+    pack = build_evidence_pack({"user_text": "hello"})
+
+    class _Client:
+        def request_json(self, **kwargs):  # type: ignore[no-untyped-def]
+            return {"schema_version": "mind.semantic_synthesis.v1", "claims": [{"foo": "bar"}]}, None, {}
+
+    result, err, telemetry = run_semantic_synthesis(
+        pack,
+        client=_Client(),  # type: ignore[arg-type]
+        route="quick",
+        model_id="quick",
+        max_tokens=512,
+    )
+    assert result is None
+    assert err == "semantic_schema_invalid"
+    assert telemetry.parse_ok is True
+    assert telemetry.validation_ok is False
+    assert telemetry.ok is False
+    assert telemetry.status == "schema_invalid"
+    assert telemetry.error == "semantic_schema_invalid"
+
+
 def test_pre_llm_budget_fail_open_has_attempted_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     from app.budget import MindRunBudget
     from app.engine import run_mind


### PR DESCRIPTION
## Summary

Follow-up to #587 (Mind LLM timeout hardening). Fixes two post-hardening regressions without reverting transport, timeout, or `orch_mind_http_failed` work:

1. **Hub Mind modal** — Restores rich synthesis item cards (semantic claims, frontier matters, shadow synthesis) while keeping provenance strips, phase table, derailment callouts, and additive `orch_mind_http_failed` handling.
2. **Semantic synthesis** — LLM JSON parsed but failed `SemanticSynthesisV1` on legacy `{claim, evidence_refs}` shapes; adds prompt contract tightening, legacy normalizer, and honest phase telemetry (`ok=false`, `status=schema_invalid` on real schema failure; `status=filtered` when guardrails empty claims).

## Root causes

| Area | Issue | Fix |
|------|-------|-----|
| Hub UI | `f7accc42` provenance stack did not project `brief.semantic_synthesis` / `shadow_synthesis` into HTML | `renderMindBriefItems` + `itemCard` in `mind_provenance.js` |
| Semantic | Legacy claim objects missing `claim_id`, `label`, `summary`, `claim_kind` | `try_normalize_legacy_semantic_raw()` + tightened `_SEMANTIC_SYSTEM` |
| Telemetry | `ok=true` when only schema validation failed | `ok=false`, `status=schema_invalid` on invalid schema |

## Live smoke (2026-05-18)

**Correlation:** `4d6c5866-efdd-492f-98fd-ec092f0d178f` (Mind-enabled `chat_general`, session `smoke2-4daa18431561`)

| Layer | Result |
|-------|--------|
| Mind bus | `mind_llm_bus_request_start`; RPC reply ~2.5s (within `MIND_LLM_TIMEOUT_SEC=25`) |
| Gateway | `gateway_llm_request_received` (`mind_phase=semantic_synthesis`); `gateway_llm_reply_publish_ok` |
| Orch | `mind_run_artifact_publish` `ok=True`; no `orch_mind_http_failed` |
| Hub API | Run listed; `shadow_synthesis` + fail-open flags; deployed `renderMindBriefItems` JS |
| Semantic happy path | `parse_ok=true`, `validation_ok=false`, `status=filtered` (guardrails emptied claims) — **no `schema_invalid`**; unit tests cover normalize + schema-invalid telemetry |

**Deploy note:** set `ORION_BUS_URL` in `services/orion-mind/.env` to stack Redis (not compose default `redis://redis:6379`) before `docker compose up mind`.

## Tests

```bash
cd .worktrees/feat-mind-llm-timeout-hardening
PYTHONPATH=. ../../venv/bin/python -m pytest \
  services/orion-mind/tests/test_mind_llm_pipeline.py \
  services/orion-hub/tests/test_mind_provenance_normalizer.py \
  services/orion-cortex-orch/tests/test_mind_orch.py \
  tests/test_mind_run_artifact_registry.py -q
```

**39 passed** (targeted suite); `compileall` OK.

## Deploy

```bash
cd services/orion-mind && docker compose up -d --build mind
cd ../orion-hub && docker compose up -d --build hub-app
```

Hard-refresh Hub (`Ctrl+Shift+R`) so `mind_provenance.js` loads.
