### PR TITLE
fix: compose-safe Knowledge Forge env and CLI wrapper script

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -3,8 +3,9 @@
 # Automatically sourced by all services
 # ────────────────────────────────────────────────
 
-# Orion Knowledge Forge corpus root (local host; in-container via hub: /repo/orion-knowledge)
+# Orion Knowledge Forge — copy ORION_KNOWLEDGE_ROOT into .env (KEY=value only; no shell functions)
 ORION_KNOWLEDGE_ROOT=/mnt/scripts/Orion-Sapienform/orion-knowledge
+# CLI: ./scripts/orion-knowledge-forge.sh lint   (or: PYTHONPATH=. ./venv/bin/python -m orion.knowledge_forge lint)
 
 # Identify this node and project namespace dynamically
 # (rebuild-services.sh auto-overwrites this with the real hostname)

--- a/scripts/orion-knowledge-forge.sh
+++ b/scripts/orion-knowledge-forge.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Orion Knowledge Forge CLI wrapper (replaces shell functions in .env — compose-safe).
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export ORION_KNOWLEDGE_ROOT="${ORION_KNOWLEDGE_ROOT:-$REPO_ROOT/orion-knowledge}"
+export PYTHONPATH="${PYTHONPATH:-$REPO_ROOT}"
+exec "$REPO_ROOT/venv/bin/python" -m orion.knowledge_forge "$@"

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -16,7 +16,7 @@ HUB_API_BASE_OVERRIDE=
 HUB_WS_BASE_OVERRIDE=
 # Mounted repo root in Docker (config/memory_graph, ontology shapes). Default in compose: /repo
 ORION_REPO_ROOT=/repo
-# Knowledge Forge corpus (CLI / agents; default under repo mount)
+# Knowledge Forge — in-container path (repo bind-mount at /repo). Local host .env: use host path to orion-knowledge/
 ORION_KNOWLEDGE_ROOT=/repo/orion-knowledge
 
 # --- Bus Configuration ---


### PR DESCRIPTION
Remove shell functions from .env guidance; document KEY=value ORION_KNOWLEDGE_ROOT and add scripts/orion-knowledge-forge.sh for local forge commands.