### PR TITLE
Feat/mind semantic synthesis survival

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-20-mind-semantic-synthesis-survival-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-20-mind-semantic-synthesis-survival-pr.md
@@ -1,0 +1,169 @@
+# PR: Mind semantic synthesis survival (`feat/mind-semantic-synthesis-survival`)
+
+**Base:** `feat/mind-llm-timeout-hardening`  
+**Branch:** `feat/mind-semantic-synthesis-survival`  
+**Worktree:** `.worktrees/feat-mind-semantic-synthesis-survival`
+
+## Summary
+
+Mind’s semantic LLM path was receiving Gateway replies, but **all claims were removed by guardrails** because `evidence_refs` from the model often did not match the evidence pack (e.g. `projection:0` vs pack refs like `cognitive_projection:1` after `current_turn:0`). The pipeline then failed open with `semantic_synthesis_empty` / `deterministic_shadow` with little explainability.
+
+This PR adds **deterministic evidence-ref resolution**, **filter telemetry**, a distinct **`semantic_synthesis_empty`** error code, and Hub phase/derailment display for retained vs filtered counts—without weakening label, source-tag, or “all refs must resolve” guardrails.
+
+## Root cause
+
+| Question | Answer |
+|----------|--------|
+| Does raw LLM output contain claims before filtering? | **Yes** when Gateway returns valid JSON (`parse_ok=true`). Prior live smoke `4d6c5866-efdd-492f-98fd-ec092f0d178f` had claims then `validation_ok=false`, `status=filtered`. |
+| Why `semantic_synthesis_empty`? | `engine.py` fails open when `synthesis.claims` is empty after `filter_semantic_claims`. Diagnostic token `semantic_synthesis_empty` when no LLM error string is present. |
+| Dominant filter reason (historical) | **`unsupported_or_weak`** — `evidence_refs` not in `evidence_refs_in_pack(pack)` (wrong kind prefix, per-kind `:0` vs global index, or missing refs). |
+| Authorization blocked because | `evaluate_stance_authorization` requires `synthesis.claims` and `frontier.selected`; empty claims → `no_evidence_backed_claims` → fail-open shadow. |
+| `claim_kind` mismatch? | **No** — guardrails do not filter on `claim_kind`; `situation_claim` is schema-valid. |
+| `evidence_refs` / projection refs? | **Yes** — pack uses `{source_kind}:{len(items)}` at append time; projection items are not `:0` when `current_turn:0` exists. |
+
+## Exact conditions
+
+**`semantic_synthesis_empty` (fail-open):**
+
+```python
+# engine.py — after run_semantic_synthesis
+if synthesis is None: → sem_err / semantic_synthesis_failed / semantic_schema_invalid
+if not synthesis.claims: → error_code="semantic_synthesis_empty"
+```
+
+**Claim removed in guardrails:**
+
+- `source_tag_not_semantic` — label matches infrastructure tags  
+- `unsupported_or_weak` — no refs, any original ref unresolvable after normalization, or normalized ref not in pack  
+- `empty` — missing label/summary  
+
+**Stance handoff authorized (`authorized_for_stance_use=true`):**
+
+- Non-empty retained claims, non-empty `frontier.selected`, valid stance payload, no source-tag leakage, not boilerplate-dominated, no `llm_errors`
+
+**Semantic advisory (phase telemetry only):**
+
+- `authorized_for_stance_use=true` on phase telemetry when retained claims exist; `authorized_for_stance_skip=false` until full handoff authorizes
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `services/orion-mind/app/evidence.py` | `resolve_evidence_ref_for_pack`, alias map, `normalize_evidence_refs_for_pack` |
+| `services/orion-mind/app/guardrails.py` | `SemanticClaimFilterStats`, strict unresolved-ref check, `evaluate_semantic_handoff_authorization` |
+| `services/orion-mind/app/synthesis.py` | Prompt lists `evidence_refs_available`; filter telemetry; legacy default `current_turn_claim` |
+| `services/orion-mind/app/phase_telemetry.py` | `raw_claim_count`, `retained_claim_count`, `filter_reasons_by_count`, etc. |
+| `services/orion-mind/app/engine.py` | Split `semantic_synthesis_empty` vs transport/schema failures |
+| `services/orion-mind/.env_example` | `ORION_BUS_URL` for host-network stacks |
+| `services/orion-hub/static/js/mind_provenance.js` | Phase row filter counts; derailment dedupe for filter-empty |
+| `services/orion-mind/tests/test_mind_llm_pipeline.py` | Survival, alias, mixed-ref suppression, empty telemetry |
+| `services/orion-hub/tests/test_mind_provenance_normalizer.py` | Hub filter count + derailment tests |
+
+## Before / after artifact (conceptual)
+
+**Before (live fail-open):**
+
+```json
+{
+  "mind_quality": "shadow_synthesis",
+  "machine_contract": {
+    "mind.llm_fail_open_to_deterministic": true,
+    "mind.llm_synthesis_failed_phase": "semantic_synthesis",
+    "mind.llm_synthesis_error_code": "semantic_synthesis_failed",
+    "mind.semantic_claim_count": 0,
+    "mind.phase_telemetry": [{
+      "phase_name": "semantic_synthesis",
+      "ok": true,
+      "parse_ok": true,
+      "validation_ok": false,
+      "status": "filtered"
+    }]
+  },
+  "diagnostics": ["semantic_synthesis_empty"]
+}
+```
+
+**After (happy path — unit-tested; live model-dependent):**
+
+```json
+{
+  "mind_quality": "meaningful_synthesis",
+  "machine_contract": {
+    "mind.llm_fail_open_to_deterministic": false,
+    "mind.semantic_claim_count": 1,
+    "mind.authorized_for_stance_use": true,
+    "mind.phase_telemetry": [{
+      "phase_name": "semantic_synthesis",
+      "ok": true,
+      "validation_ok": true,
+      "status": "ok",
+      "raw_claim_count": 1,
+      "retained_claim_count": 1,
+      "filtered_claim_count": 0,
+      "authorization_reason": "semantic_claims_retained"
+    }]
+  },
+  "brief": { "semantic_synthesis": { "claims": [{ "evidence_refs": ["current_turn:0"] }] } }
+}
+```
+
+**After (filter-empty — explainable fail-open):**
+
+```json
+{
+  "mind.llm_synthesis_error_code": "semantic_synthesis_empty",
+  "mind.phase_telemetry": [{
+    "raw_claim_count": 2,
+    "retained_claim_count": 0,
+    "filtered_claim_count": 2,
+    "filter_reasons_by_count": { "unsupported_or_weak": 2 },
+    "authorization_reason": "semantic_synthesis_empty",
+    "error": "semantic_synthesis_empty"
+  }],
+  "diagnostics": [
+    "claims_generated=2",
+    "claims_filtered=2",
+    "dominant_filter_reason=unsupported_or_weak"
+  ]
+}
+```
+
+## Tests
+
+```bash
+cd .worktrees/feat-mind-semantic-synthesis-survival
+PYTHONPATH=. ../../venv/bin/python -m pytest \
+  services/orion-mind/tests/test_mind_llm_pipeline.py \
+  services/orion-mind/tests/test_mind_governance.py \
+  services/orion-hub/tests/test_mind_provenance_normalizer.py -q
+# 33 passed
+
+PYTHONPATH=. ../../venv/bin/python -m compileall \
+  services/orion-mind/app services/orion-hub orion/schemas -q
+# exit 0
+```
+
+## Live smoke (2026-05-20)
+
+| Step | Result |
+|------|--------|
+| Rebuild `orion-mind` from worktree | OK |
+| Set `ORION_BUS_URL=redis://100.92.216.81:6379/0` in mind `.env` | OK — bus RPC ~1.6s |
+| Hub `mind_provenance.js` synced to running static mount | OK |
+| Direct `POST /v1/mind/run` (LLM enabled) | **Partial** — model returned non-object JSON (`semantic_schema_invalid:not_object`) in this session; not a filter regression |
+| Filter-empty telemetry path | Covered by unit + Hub normalizer tests |
+
+**Operator check when model returns valid JSON:** Mind modal should show `raw=N retained=M filtered=K` on semantic phase row; filter-empty runs use warning `semantic_filtered` only (not duplicate `semantic_failed`).
+
+## Remaining risks
+
+1. **Live `meaningful_synthesis`** still depends on Gateway returning object-shaped `SemanticSynthesisV1` JSON and appraisal/stance phases completing within wall budget.  
+2. **Alias normalization** maps `projection:0` to first projection ref only when index 0 is wrong; fabricated refs still suppress claims.  
+3. **Hub static** in main repo was copied for smoke; merge PR updates `services/orion-hub/static/js/mind_provenance.js` on branch.
+
+## Test plan
+
+- [ ] Merge after `feat/mind-llm-timeout-hardening`  
+- [ ] Deploy Mind + Hub from branch; set `ORION_BUS_URL` in mind `.env`  
+- [ ] One `chat_general` turn; confirm semantic phase `retained_claim_count > 0` OR explainable `semantic_synthesis_empty` with filter counts  
+- [ ] Hard-refresh Hub; verify phase table and derailment cards

--- a/services/orion-hub/static/js/mind_provenance.js
+++ b/services/orion-hub/static/js/mind_provenance.js
@@ -308,7 +308,14 @@
     }
 
     const semTelemetry = findPhaseTelemetry(mc, "semantic_synthesis");
-    if (prov.failed_phase === "semantic_synthesis" || (semTelemetry && semTelemetry.ok === false)) {
+    const semanticFilteredEmpty =
+      prov.error_code === "semantic_synthesis_empty" ||
+      semTelemetry?.status === "filtered" ||
+      semTelemetry?.error === "semantic_synthesis_empty";
+    if (
+      (prov.failed_phase === "semantic_synthesis" || (semTelemetry && semTelemetry.ok === false)) &&
+      !semanticFilteredEmpty
+    ) {
       push({
         id: "semantic_failed",
         severity: "error",

--- a/services/orion-hub/static/js/mind_provenance.js
+++ b/services/orion-hub/static/js/mind_provenance.js
@@ -174,11 +174,23 @@
             ? "appraisal"
             : "stance";
       let outputCount = null;
+      let claimFilterSummary = null;
       if (phaseName === "semantic_synthesis") {
-        outputCount = mc["mind.semantic_claim_count"];
+        outputCount =
+          telemetry && telemetry.retained_claim_count != null
+            ? telemetry.retained_claim_count
+            : mc["mind.semantic_claim_count"];
+        if (telemetry && telemetry.raw_claim_count != null) {
+          claimFilterSummary = `raw=${telemetry.raw_claim_count} retained=${telemetry.retained_claim_count ?? 0} filtered=${telemetry.filtered_claim_count ?? 0}`;
+        }
       } else if (phaseName === "active_frontier_judge") {
         outputCount = mc["mind.active_frontier_selected_count"];
       }
+      const errorBits = [];
+      if (telemetry && telemetry.error) errorBits.push(String(telemetry.error));
+      if (telemetry && telemetry.skip_reason) errorBits.push(String(telemetry.skip_reason));
+      if (claimFilterSummary) errorBits.push(claimFilterSummary);
+      if (telemetry && telemetry.authorization_reason) errorBits.push(`auth=${telemetry.authorization_reason}`);
       return {
         phase: phaseName,
         status: phaseStatusFromTelemetry(telemetry, mc, phaseName),
@@ -188,8 +200,11 @@
         parse_ok: telemetry ? telemetry.parse_ok : null,
         validation_ok: telemetry ? telemetry.validation_ok : null,
         token_usage: telemetry ? telemetry.token_usage || {} : {},
-        error: (telemetry && (telemetry.error || telemetry.skip_reason)) || null,
+        error: errorBits.length ? errorBits.join(" · ") : null,
         output_count: outputCount,
+        raw_claim_count: telemetry ? telemetry.raw_claim_count : null,
+        retained_claim_count: telemetry ? telemetry.retained_claim_count : null,
+        filtered_claim_count: telemetry ? telemetry.filtered_claim_count : null,
       };
     });
     if (prov.orch_http_failed || prov.cognition_path === "orch_mind_http_failed") {
@@ -323,6 +338,12 @@
           semantic_claim_count: mc["mind.semantic_claim_count"],
           semantic_claim_labels: asList(mc["mind.semantic_claim_labels"]),
           suppressed: asList(brief?.semantic_synthesis?.suppressed),
+          raw_claim_count: semTelemetry?.raw_claim_count,
+          retained_claim_count: semTelemetry?.retained_claim_count,
+          filtered_claim_count: semTelemetry?.filtered_claim_count,
+          filter_reasons_by_count: semTelemetry?.filter_reasons_by_count,
+          sample_filter_reasons: asList(semTelemetry?.sample_filter_reasons),
+          authorization_reason: semTelemetry?.authorization_reason,
         },
       });
     }
@@ -489,6 +510,10 @@
       ["cognitive_projection_id", mc["mind.cognitive_projection_id"]],
       ["cognitive_projection_item_count", mc["mind.cognitive_projection_item_count"]],
       ["semantic_claim_count", mc["mind.semantic_claim_count"]],
+      ["semantic_raw_claim_count", findPhaseTelemetry(mc, "semantic_synthesis")?.raw_claim_count],
+      ["semantic_retained_claim_count", findPhaseTelemetry(mc, "semantic_synthesis")?.retained_claim_count],
+      ["semantic_filtered_claim_count", findPhaseTelemetry(mc, "semantic_synthesis")?.filtered_claim_count],
+      ["semantic_authorization_reason", findPhaseTelemetry(mc, "semantic_synthesis")?.authorization_reason],
       ["active_frontier_selected_count", mc["mind.active_frontier_selected_count"]],
       ["active_frontier_top_labels", asList(mc["mind.active_frontier_top_labels"]).join(", ")],
       ["semantic_claim_labels", asList(mc["mind.semantic_claim_labels"]).join(", ")],

--- a/services/orion-hub/tests/test_mind_provenance_normalizer.py
+++ b/services/orion-hub/tests/test_mind_provenance_normalizer.py
@@ -156,6 +156,50 @@ console.log(JSON.stringify({{
     assert out["has_projection_refs"] is True
 
 
+def test_fail_open_fixture_phase_rows_expose_semantic_filter_counts() -> None:
+    out = _run_node(
+        f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(MIND_PROVENANCE_JS))}, 'utf8');
+eval(src);
+const run = {{
+  result_jsonb: {{
+    brief: {{
+      machine_contract: {{
+        "mind.llm_fail_open_to_deterministic": true,
+        "mind.semantic_claim_count": 0,
+        "mind.phase_telemetry": [{{
+          phase_name: "semantic_synthesis",
+          route: "quick",
+          ok: true,
+          parse_ok: true,
+          validation_ok: false,
+          status: "filtered",
+          error: "semantic_synthesis_empty",
+          raw_claim_count: 2,
+          retained_claim_count: 0,
+          filtered_claim_count: 2,
+          filter_reasons_by_count: {{ unsupported_or_weak: 2 }},
+          authorization_reason: "semantic_synthesis_empty",
+        }}],
+      }},
+    }},
+  }},
+}};
+const rows = OrionMindProvenance.normalizeMindPhaseRows(run);
+const sem = rows.find(r => r.phase === 'semantic_synthesis');
+console.log(JSON.stringify({{
+  retained: sem && sem.retained_claim_count,
+  raw: sem && sem.raw_claim_count,
+  error_has_counts: sem && String(sem.error || '').includes('raw=2'),
+}}));
+"""
+    )
+    assert out["retained"] == 0
+    assert out["raw"] == 2
+    assert out["error_has_counts"] is True
+
+
 def test_fail_open_fixture_still_renders_provenance_sections() -> None:
     out = _run_node(
         f"""

--- a/services/orion-hub/tests/test_mind_provenance_normalizer.py
+++ b/services/orion-hub/tests/test_mind_provenance_normalizer.py
@@ -200,6 +200,46 @@ console.log(JSON.stringify({{
     assert out["error_has_counts"] is True
 
 
+def test_filtered_empty_semantic_only_warns_not_failed_callout() -> None:
+    out = _run_node(
+        f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(MIND_PROVENANCE_JS))}, 'utf8');
+eval(src);
+const run = {{
+  result_jsonb: {{
+    diagnostics: ["claims_generated=1", "claims_filtered=1", "dominant_filter_reason=unsupported_or_weak"],
+    brief: {{
+      machine_contract: {{
+        "mind.llm_fail_open_to_deterministic": true,
+        "mind.llm_synthesis_failed_phase": "semantic_synthesis",
+        "mind.llm_synthesis_error_code": "semantic_synthesis_empty",
+        "mind.phase_telemetry": [{{
+          phase_name: "semantic_synthesis",
+          route: "quick",
+          ok: true,
+          parse_ok: true,
+          validation_ok: false,
+          status: "filtered",
+          error: "semantic_synthesis_empty",
+          raw_claim_count: 1,
+          retained_claim_count: 0,
+          filtered_claim_count: 1,
+        }}],
+      }},
+    }},
+  }},
+}};
+const callouts = OrionMindProvenance.normalizeMindDerailments(run);
+console.log(JSON.stringify({{
+  ids: callouts.map(c => c.id),
+}}));
+"""
+    )
+    assert "semantic_filtered" in out["ids"]
+    assert "semantic_failed" not in out["ids"]
+
+
 def test_fail_open_fixture_still_renders_provenance_sections() -> None:
     out = _run_node(
         f"""

--- a/services/orion-mind/.env_example
+++ b/services/orion-mind/.env_example
@@ -49,5 +49,7 @@ MIND_LLM_PHASE_SAFETY_MS=50
 # --- Bus → LLM gateway -------------------------------------------------------
 MIND_LLM_USE_BUS=true
 ORION_BUS_ENABLED=true
+# Host-reachable Redis (Tailscale/LAN). Compose default redis://redis:6379 fails on host-network stacks.
+ORION_BUS_URL=redis://100.92.216.81:6379/0
 MIND_LLM_INTAKE_CHANNEL=orion:exec:request:LLMGatewayService
 MIND_LLM_REPLY_PREFIX=orion:mind:llm:reply

--- a/services/orion-mind/app/engine.py
+++ b/services/orion-mind/app/engine.py
@@ -848,10 +848,30 @@ def run_mind_llm_synthesis(
             diagnostics=["wall_time_exceeded_after_semantic"],
             failed_phase="semantic_synthesis",
         )
-    if synthesis is None or not synthesis.claims:
+    if synthesis is None:
         return _fail_open_or_error(
-            error_code="semantic_synthesis_failed",
-            diagnostics=llm_errors or ["semantic_synthesis_empty"],
+            error_code=sem_err or "semantic_synthesis_failed",
+            diagnostics=llm_errors or [sem_err or "semantic_synthesis_failed"],
+            failed_phase="semantic_synthesis",
+        )
+    if not synthesis.claims:
+        empty_diag = list(llm_errors)
+        if sem_telemetry.raw_claim_count is not None:
+            empty_diag.append(f"claims_generated={sem_telemetry.raw_claim_count}")
+        if sem_telemetry.filtered_claim_count is not None:
+            empty_diag.append(f"claims_filtered={sem_telemetry.filtered_claim_count}")
+        dominant = None
+        if sem_telemetry.filter_reasons_by_count:
+            dominant = max(sem_telemetry.filter_reasons_by_count.items(), key=lambda kv: kv[1])[0]
+        if dominant:
+            empty_diag.append(f"dominant_filter_reason={dominant}")
+        if sem_telemetry.authorization_reason:
+            empty_diag.append(f"authorization_reason={sem_telemetry.authorization_reason}")
+        if not empty_diag:
+            empty_diag.append("semantic_synthesis_empty")
+        return _fail_open_or_error(
+            error_code="semantic_synthesis_empty",
+            diagnostics=empty_diag,
             failed_phase="semantic_synthesis",
         )
 

--- a/services/orion-mind/app/evidence.py
+++ b/services/orion-mind/app/evidence.py
@@ -300,47 +300,69 @@ def _pack_ref_indexes(pack: MindEvidencePackV1) -> tuple[
     return by_kind, by_source_ref, by_item_id
 
 
+def resolve_evidence_ref_for_pack(
+    ref: str,
+    pack: MindEvidencePackV1,
+    *,
+    by_kind: dict[str, list[str]] | None = None,
+    by_source_ref: dict[str, str] | None = None,
+    by_item_id: dict[str, str] | None = None,
+    valid: set[str] | None = None,
+) -> str | None:
+    """Resolve one ref to a pack evidence_ref, or None if unresolvable."""
+    cleaned = str(ref or "").strip()
+    if not cleaned:
+        return None
+    valid_refs = valid if valid is not None else evidence_refs_in_pack(pack)
+    if cleaned in valid_refs:
+        return cleaned
+    if by_kind is None or by_source_ref is None or by_item_id is None:
+        by_kind, by_source_ref, by_item_id = _pack_ref_indexes(pack)
+    if cleaned in by_source_ref:
+        return by_source_ref[cleaned]
+    if cleaned in by_item_id:
+        return by_item_id[cleaned]
+    if ":" in cleaned:
+        prefix, suffix = cleaned.split(":", 1)
+        mapped = _EVIDENCE_REF_KIND_ALIASES.get(prefix, prefix)
+        candidate = f"{mapped}:{suffix}"
+        if candidate in valid_refs:
+            return candidate
+        kind_refs = by_kind.get(mapped) or by_kind.get(prefix)
+        if kind_refs:
+            try:
+                idx = int(suffix)
+            except ValueError:
+                idx = -1
+            if 0 <= idx < len(kind_refs):
+                return kind_refs[idx]
+            if idx == 0:
+                return kind_refs[0]
+    if cleaned in by_kind and len(by_kind[cleaned]) == 1:
+        return by_kind[cleaned][0]
+    return None
+
+
 def normalize_evidence_refs_for_pack(
     refs: list[str],
     pack: MindEvidencePackV1,
 ) -> list[str]:
     """Map common LLM ref mistakes to evidence_pack refs without weakening guardrails."""
-    valid = evidence_refs_in_pack(pack)
     if not refs:
         return []
+    valid = evidence_refs_in_pack(pack)
     by_kind, by_source_ref, by_item_id = _pack_ref_indexes(pack)
     out: list[str] = []
     seen: set[str] = set()
     for raw in refs:
-        ref = str(raw or "").strip()
-        if not ref:
-            continue
-        resolved: str | None = None
-        if ref in valid:
-            resolved = ref
-        elif ref in by_source_ref:
-            resolved = by_source_ref[ref]
-        elif ref in by_item_id:
-            resolved = by_item_id[ref]
-        elif ":" in ref:
-            prefix, suffix = ref.split(":", 1)
-            mapped = _EVIDENCE_REF_KIND_ALIASES.get(prefix, prefix)
-            candidate = f"{mapped}:{suffix}"
-            if candidate in valid:
-                resolved = candidate
-            else:
-                kind_refs = by_kind.get(mapped) or by_kind.get(prefix)
-                if kind_refs:
-                    try:
-                        idx = int(suffix)
-                    except ValueError:
-                        idx = -1
-                    if 0 <= idx < len(kind_refs):
-                        resolved = kind_refs[idx]
-                    elif idx == 0:
-                        resolved = kind_refs[0]
-        elif ref in by_kind and len(by_kind[ref]) == 1:
-            resolved = by_kind[ref][0]
+        resolved = resolve_evidence_ref_for_pack(
+            str(raw or ""),
+            pack,
+            by_kind=by_kind,
+            by_source_ref=by_source_ref,
+            by_item_id=by_item_id,
+            valid=valid,
+        )
         if resolved and resolved not in seen:
             seen.add(resolved)
             out.append(resolved)

--- a/services/orion-mind/app/evidence.py
+++ b/services/orion-mind/app/evidence.py
@@ -270,6 +270,83 @@ def evidence_refs_in_pack(pack: MindEvidencePackV1) -> set[str]:
     return {item.evidence_ref for item in pack.items}
 
 
+_EVIDENCE_REF_KIND_ALIASES: dict[str, str] = {
+    "projection": "cognitive_projection",
+    "cognitive_projection_item": "cognitive_projection",
+    "recall": "recall_fragment",
+    "message": "message_history",
+    "turn": "current_turn",
+    "identity": "background_identity",
+    "autonomy": "autonomy_compact",
+    "social": "social_compact",
+    "situation": "situation_compact",
+}
+
+
+def _pack_ref_indexes(pack: MindEvidencePackV1) -> tuple[
+    dict[str, list[str]],
+    dict[str, str],
+    dict[str, str],
+]:
+    by_kind: dict[str, list[str]] = {}
+    by_source_ref: dict[str, str] = {}
+    by_item_id: dict[str, str] = {}
+    for item in pack.items:
+        by_kind.setdefault(item.source_kind, []).append(item.evidence_ref)
+        if item.source_ref:
+            by_source_ref[str(item.source_ref).strip()] = item.evidence_ref
+        if item.item_id:
+            by_item_id[str(item.item_id).strip()] = item.evidence_ref
+    return by_kind, by_source_ref, by_item_id
+
+
+def normalize_evidence_refs_for_pack(
+    refs: list[str],
+    pack: MindEvidencePackV1,
+) -> list[str]:
+    """Map common LLM ref mistakes to evidence_pack refs without weakening guardrails."""
+    valid = evidence_refs_in_pack(pack)
+    if not refs:
+        return []
+    by_kind, by_source_ref, by_item_id = _pack_ref_indexes(pack)
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in refs:
+        ref = str(raw or "").strip()
+        if not ref:
+            continue
+        resolved: str | None = None
+        if ref in valid:
+            resolved = ref
+        elif ref in by_source_ref:
+            resolved = by_source_ref[ref]
+        elif ref in by_item_id:
+            resolved = by_item_id[ref]
+        elif ":" in ref:
+            prefix, suffix = ref.split(":", 1)
+            mapped = _EVIDENCE_REF_KIND_ALIASES.get(prefix, prefix)
+            candidate = f"{mapped}:{suffix}"
+            if candidate in valid:
+                resolved = candidate
+            else:
+                kind_refs = by_kind.get(mapped) or by_kind.get(prefix)
+                if kind_refs:
+                    try:
+                        idx = int(suffix)
+                    except ValueError:
+                        idx = -1
+                    if 0 <= idx < len(kind_refs):
+                        resolved = kind_refs[idx]
+                    elif idx == 0:
+                        resolved = kind_refs[0]
+        elif ref in by_kind and len(by_kind[ref]) == 1:
+            resolved = by_kind[ref][0]
+        if resolved and resolved not in seen:
+            seen.add(resolved)
+            out.append(resolved)
+    return out
+
+
 def is_source_tag_label(label: str) -> bool:
     normalized = (label or "").strip().lower().replace(" ", "_")
     if not normalized:

--- a/services/orion-mind/app/guardrails.py
+++ b/services/orion-mind/app/guardrails.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Any
 
 from orion.mind.synthesis_v1 import (
@@ -14,50 +15,131 @@ from orion.mind.synthesis_v1 import (
 )
 from orion.mind.validation import validate_merged_stance_brief_optional
 
-from .evidence import evidence_refs_in_pack, is_source_tag_label
+from .evidence import (
+    evidence_refs_in_pack,
+    is_source_tag_label,
+    normalize_evidence_refs_for_pack,
+)
 
 _MAX_CLAIMS = 24
 _MAX_SELECTED = 8
+_MAX_SAMPLE_FILTER_REASONS = 6
+_MAX_SAMPLE_LABEL_LEN = 48
+
+
+@dataclass
+class SemanticClaimFilterStats:
+    raw_claim_count: int = 0
+    normalized_claim_count: int = 0
+    schema_valid_claim_count: int = 0
+    retained_claim_count: int = 0
+    filtered_claim_count: int = 0
+    filter_reasons_by_count: dict[str, int] = field(default_factory=dict)
+    sample_filter_reasons: list[dict[str, str]] = field(default_factory=list)
+
+    def dominant_filter_reason(self) -> str | None:
+        if not self.filter_reasons_by_count:
+            return None
+        return max(self.filter_reasons_by_count.items(), key=lambda kv: kv[1])[0]
+
+    def record_suppressed(self, *, label: str, reason: str, source_kind: str) -> None:
+        self.filtered_claim_count += 1
+        self.filter_reasons_by_count[reason] = self.filter_reasons_by_count.get(reason, 0) + 1
+        if len(self.sample_filter_reasons) >= _MAX_SAMPLE_FILTER_REASONS:
+            return
+        short_label = (label or "(empty)").strip()
+        if len(short_label) > _MAX_SAMPLE_LABEL_LEN:
+            short_label = f"{short_label[: _MAX_SAMPLE_LABEL_LEN - 1].rstrip()}…"
+        self.sample_filter_reasons.append(
+            {"reason": reason, "label": short_label, "source_kind": source_kind}
+        )
 
 
 def filter_semantic_claims(
     synthesis: SemanticSynthesisV1,
     pack: MindEvidencePackV1,
+    *,
+    stats: SemanticClaimFilterStats | None = None,
 ) -> SemanticSynthesisV1:
+    filtered, _ = filter_semantic_claims_with_stats(synthesis, pack, stats=stats)
+    return filtered
+
+
+def filter_semantic_claims_with_stats(
+    synthesis: SemanticSynthesisV1,
+    pack: MindEvidencePackV1,
+    *,
+    stats: SemanticClaimFilterStats | None = None,
+) -> tuple[SemanticSynthesisV1, SemanticClaimFilterStats]:
+    metrics = stats or SemanticClaimFilterStats()
+    metrics.schema_valid_claim_count = len(synthesis.claims[:_MAX_CLAIMS])
     valid_refs = evidence_refs_in_pack(pack)
     kept: list[SemanticClaimV1] = []
     suppressed = list(synthesis.suppressed)
     for claim in synthesis.claims[:_MAX_CLAIMS]:
         label = (claim.label or "").strip()
+        source_kind = claim.source_kinds[0] if claim.source_kinds else "unknown"
         if is_source_tag_label(label):
             suppressed.append(
                 SuppressedMindCandidateV1(
                     label=label,
-                    source_kind=claim.source_kinds[0] if claim.source_kinds else "unknown",
+                    source_kind=source_kind,
                     reason="source_tag_not_semantic",
                 )
             )
+            metrics.record_suppressed(label=label, reason="source_tag_not_semantic", source_kind=source_kind)
             continue
-        if not claim.evidence_refs or not all(ref in valid_refs for ref in claim.evidence_refs):
+        normalized_refs = normalize_evidence_refs_for_pack(list(claim.evidence_refs), pack)
+        if normalized_refs != list(claim.evidence_refs):
+            metrics.normalized_claim_count += 1
+            claim = claim.model_copy(update={"evidence_refs": normalized_refs})
+        if not normalized_refs or not all(ref in valid_refs for ref in normalized_refs):
             suppressed.append(
                 SuppressedMindCandidateV1(
                     label=label or "(empty)",
-                    source_kind=claim.source_kinds[0] if claim.source_kinds else "unknown",
+                    source_kind=source_kind,
                     reason="unsupported_or_weak",
                 )
             )
+            metrics.record_suppressed(label=label, reason="unsupported_or_weak", source_kind=source_kind)
             continue
         if not label or not (claim.summary or "").strip():
             suppressed.append(
                 SuppressedMindCandidateV1(
                     label=label or "(empty)",
-                    source_kind=claim.source_kinds[0] if claim.source_kinds else "unknown",
+                    source_kind=source_kind,
                     reason="empty",
                 )
             )
+            metrics.record_suppressed(label=label, reason="empty", source_kind=source_kind)
             continue
         kept.append(claim)
-    return synthesis.model_copy(update={"claims": kept, "suppressed": suppressed})
+    metrics.retained_claim_count = len(kept)
+    return synthesis.model_copy(update={"claims": kept, "suppressed": suppressed}), metrics
+
+
+def evaluate_semantic_handoff_authorization(
+    *,
+    synthesis: SemanticSynthesisV1 | None,
+    llm_errors: list[str],
+) -> tuple[bool, bool, str, list[str]]:
+    """Return (advisory_usable, stance_skip_authorized, authorization_reason, reasons)."""
+    reasons: list[str] = []
+    if llm_errors:
+        reasons.append(f"llm_error:{llm_errors[0]}")
+    if synthesis is None:
+        reasons.append("semantic_synthesis_missing")
+        return False, False, "semantic_synthesis_missing", reasons
+    if not synthesis.claims:
+        reasons.append("no_retained_semantic_claims")
+        dominant = synthesis.diagnostics.notes[-1] if synthesis.diagnostics.notes else None
+        if dominant:
+            reasons.append(str(dominant))
+        return False, False, "semantic_synthesis_empty", reasons
+    if any(is_source_tag_label(c.label) for c in synthesis.claims):
+        reasons.append("source_tag_claim_present")
+        return False, False, "source_tag_claim_present", reasons
+    return True, False, "semantic_claims_retained", ["evidence_backed_semantic_claims"]
 
 
 def filter_active_frontier(

--- a/services/orion-mind/app/guardrails.py
+++ b/services/orion-mind/app/guardrails.py
@@ -19,6 +19,7 @@ from .evidence import (
     evidence_refs_in_pack,
     is_source_tag_label,
     normalize_evidence_refs_for_pack,
+    resolve_evidence_ref_for_pack,
 )
 
 _MAX_CLAIMS = 24
@@ -89,11 +90,20 @@ def filter_semantic_claims_with_stats(
             )
             metrics.record_suppressed(label=label, reason="source_tag_not_semantic", source_kind=source_kind)
             continue
-        normalized_refs = normalize_evidence_refs_for_pack(list(claim.evidence_refs), pack)
-        if normalized_refs != list(claim.evidence_refs):
+        original_refs = [str(r).strip() for r in claim.evidence_refs if str(r).strip()]
+        normalized_refs = normalize_evidence_refs_for_pack(original_refs, pack)
+        if normalized_refs != original_refs:
             metrics.normalized_claim_count += 1
             claim = claim.model_copy(update={"evidence_refs": normalized_refs})
-        if not normalized_refs or not all(ref in valid_refs for ref in normalized_refs):
+        unresolved = any(
+            resolve_evidence_ref_for_pack(ref, pack) is None for ref in original_refs
+        )
+        if (
+            not original_refs
+            or unresolved
+            or not normalized_refs
+            or not all(ref in valid_refs for ref in normalized_refs)
+        ):
             suppressed.append(
                 SuppressedMindCandidateV1(
                     label=label or "(empty)",

--- a/services/orion-mind/app/phase_telemetry.py
+++ b/services/orion-mind/app/phase_telemetry.py
@@ -23,9 +23,20 @@ class MindPhaseTelemetry:
     token_usage: dict[str, Any] = field(default_factory=dict)
     skipped: bool = False
     skip_reason: str | None = None
+    raw_claim_count: int | None = None
+    normalized_claim_count: int | None = None
+    schema_valid_claim_count: int | None = None
+    retained_claim_count: int | None = None
+    filtered_claim_count: int | None = None
+    filter_reasons_by_count: dict[str, int] | None = None
+    sample_filter_reasons: list[dict[str, str]] | None = None
+    authorization_reason: str | None = None
+    authorized_for_stance_use: bool | None = None
+    authorized_for_stance_skip: bool | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        out = asdict(self)
+        return {k: v for k, v in out.items() if v is not None}
 
 
 def utc_now_iso() -> str:

--- a/services/orion-mind/app/synthesis.py
+++ b/services/orion-mind/app/synthesis.py
@@ -10,14 +10,18 @@ from typing import Any
 from pydantic import ValidationError
 
 from orion.mind.synthesis_v1 import MindEvidencePackV1, SemanticSynthesisV1
-from .guardrails import filter_semantic_claims
+from .guardrails import (
+    SemanticClaimFilterStats,
+    evaluate_semantic_handoff_authorization,
+    filter_semantic_claims_with_stats,
+)
 from .llm_client import MindLLMClientProtocol
 from .llm_context import MindLLMRequestContext
 from .phase_telemetry import MindPhaseTelemetry
 
 _SEMANTIC_SYSTEM = """You extract grounded semantic claims from evidence for an internal cognition organ.
 You are NOT writing the user-facing reply.
-Every claim MUST cite evidence_refs from the provided evidence pack only.
+Every claim MUST cite evidence_refs from evidence_refs_available in the user payload (exact strings only).
 Labels must be semantic meanings, never source tags like identity_yaml, projection, autonomy, or social_bridge.
 Identity background is not primary evidence unless the current turn explicitly involves identity, selfhood, role boundaries, or Orion/Juniper relationship framing.
 Prefer uncertainty over invention.
@@ -40,7 +44,11 @@ def _pack_prompt(pack: MindEvidencePackV1) -> str:
         for it in pack.items
     ]
     return json.dumps(
-        {"current_user_text": pack.current_user_text, "evidence_items": items},
+        {
+            "current_user_text": pack.current_user_text,
+            "evidence_refs_available": [it.evidence_ref for it in pack.items],
+            "evidence_items": items,
+        },
         ensure_ascii=False,
     )
 
@@ -117,12 +125,13 @@ def try_normalize_legacy_semantic_raw(raw: dict[str, Any]) -> tuple[dict[str, An
         source_kinds = item.get("source_kinds")
         if not isinstance(source_kinds, list) or not source_kinds:
             source_kinds = ["current_turn"] if evidence_refs else []
+        default_kind = "current_turn_claim" if evidence_refs else "situation_claim"
         normalized_claims.append(
             {
                 "claim_id": _legacy_claim_id(index, claim_text),
                 "label": _short_label(claim_text),
                 "summary": claim_text,
-                "claim_kind": "situation_claim",
+                "claim_kind": default_kind,
                 "evidence_refs": evidence_refs,
                 "source_kinds": [str(k) for k in source_kinds if str(k).strip()],
                 "anchor": item.get("anchor") or "unknown",
@@ -237,7 +246,23 @@ def run_semantic_synthesis(
             ),
         }
     )
-    filtered = filter_semantic_claims(synthesis, pack)
+    raw_claim_count = len(synthesis.claims)
+    filter_stats = SemanticClaimFilterStats(raw_claim_count=raw_claim_count)
+    filtered, filter_stats = filter_semantic_claims_with_stats(synthesis, pack, stats=filter_stats)
+    advisory_ok, stance_skip_ok, auth_reason, auth_reasons = evaluate_semantic_handoff_authorization(
+        synthesis=filtered,
+        llm_errors=[],
+    )
+    telemetry.raw_claim_count = filter_stats.raw_claim_count
+    telemetry.normalized_claim_count = filter_stats.normalized_claim_count
+    telemetry.schema_valid_claim_count = filter_stats.schema_valid_claim_count
+    telemetry.retained_claim_count = filter_stats.retained_claim_count
+    telemetry.filtered_claim_count = filter_stats.filtered_claim_count
+    telemetry.filter_reasons_by_count = dict(filter_stats.filter_reasons_by_count)
+    telemetry.sample_filter_reasons = list(filter_stats.sample_filter_reasons)
+    telemetry.authorization_reason = auth_reason
+    telemetry.authorized_for_stance_use = advisory_ok
+    telemetry.authorized_for_stance_skip = stance_skip_ok
     telemetry.validation_ok = bool(filtered.claims)
     if filtered.claims:
         telemetry.ok = True
@@ -247,4 +272,19 @@ def run_semantic_synthesis(
     else:
         telemetry.ok = True
         telemetry.status = "filtered"
+        dominant = filter_stats.dominant_filter_reason()
+        telemetry.error = "semantic_synthesis_empty"
+        diag_notes = list(filtered.diagnostics.notes)
+        diag_notes.append(
+            f"claims_generated={filter_stats.raw_claim_count};"
+            f"claims_filtered={filter_stats.filtered_claim_count};"
+            f"dominant_filter_reason={dominant or 'unknown'}"
+        )
+        if auth_reasons:
+            diag_notes.append(f"authorization_failed:{';'.join(auth_reasons[:4])}")
+        filtered = filtered.model_copy(
+            update={
+                "diagnostics": filtered.diagnostics.model_copy(update={"notes": diag_notes}),
+            }
+        )
     return filtered, None, telemetry

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -374,6 +374,37 @@ def test_valid_semantic_synthesis_survives_with_grounded_evidence_refs() -> None
     assert stats.filtered_claim_count == 0
 
 
+def test_mixed_valid_and_invalid_evidence_refs_are_suppressed() -> None:
+    from app.evidence import build_evidence_pack
+    from app.guardrails import filter_semantic_claims_with_stats
+    from orion.mind.synthesis_v1 import SemanticSynthesisV1
+
+    pack = build_evidence_pack({"user_text": "hello"})
+    synthesis = SemanticSynthesisV1.model_validate(
+        {
+            **_semantic_payload(claim_label="user greeting", evidence_ref="current_turn:0"),
+            "claims": [
+                {
+                    "claim_id": "c1",
+                    "label": "user greeting",
+                    "summary": "User says hello.",
+                    "claim_kind": "current_turn_claim",
+                    "evidence_refs": ["current_turn:0", "fabricated:99"],
+                    "source_kinds": ["current_turn"],
+                    "anchor": "relationship",
+                    "confidence": 0.9,
+                    "salience_hint": 0.8,
+                    "recommended_effect": "receive_warmly",
+                }
+            ],
+        }
+    )
+    filtered, stats = filter_semantic_claims_with_stats(synthesis, pack)
+    assert filtered.claims == []
+    assert stats.filtered_claim_count == 1
+    assert stats.filter_reasons_by_count.get("unsupported_or_weak") == 1
+
+
 def test_projection_alias_ref_maps_to_pack_ref() -> None:
     from app.evidence import build_evidence_pack
     from app.guardrails import filter_semantic_claims_with_stats

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -250,7 +250,7 @@ def test_llm_failure_falls_back_to_deterministic(monkeypatch: pytest.MonkeyPatch
     assert machine.get("mind.llm_synthesis_attempted") is True
     assert machine.get("mind.llm_fail_open_to_deterministic") is True
     assert machine.get("mind.llm_synthesis_failed_phase") == "semantic_synthesis"
-    assert machine.get("mind.llm_synthesis_error_code") == "semantic_synthesis_failed"
+    assert machine.get("mind.llm_synthesis_error_code") == "fake_exhausted"
     assert machine.get("mind.llm_synthesis_error") == "fake_exhausted"
     assert machine.get("mind.authorized_for_stance_skip") is False
     assert machine.get("mind.authorized_for_stance_use") is False
@@ -283,11 +283,12 @@ def test_source_tag_semantic_fail_open_preserves_phase_telemetry(monkeypatch: py
     machine = result.brief.machine_contract
     assert machine.get("mind.llm_synthesis_attempted") is True
     assert machine.get("mind.llm_synthesis_failed_phase") == "semantic_synthesis"
-    assert machine.get("mind.llm_synthesis_error_code") == "semantic_synthesis_failed"
+    assert machine.get("mind.llm_synthesis_error_code") == "semantic_synthesis_empty"
     telemetry = machine.get("mind.phase_telemetry") or []
     sem = next(t for t in telemetry if t.get("phase_name") == "semantic_synthesis")
     assert sem.get("ok") is True
     assert sem.get("validation_ok") is False
+    assert sem.get("retained_claim_count") == 0
     assert result.mind_quality == "fallback_contract_only"
 
 
@@ -311,7 +312,7 @@ def test_legacy_semantic_claim_shape_is_normalized() -> None:
     assert normalized is not None
     synthesis = SemanticSynthesisV1.model_validate(normalized)
     assert synthesis.claims[0].claim_id.startswith("legacy_")
-    assert synthesis.claims[0].claim_kind == "situation_claim"
+    assert synthesis.claims[0].claim_kind == "current_turn_claim"
     assert synthesis.diagnostics.notes[-1] == "normalized_from_legacy_claim_shape"
 
     pack = build_evidence_pack({"user_text": "watching a show with Amanda"})
@@ -356,6 +357,113 @@ def test_legacy_normalizer_preserves_zero_confidence_fields() -> None:
     assert normalized is not None
     assert normalized["claims"][0]["confidence"] == 0.0
     assert normalized["claims"][0]["salience_hint"] == 0.0
+
+
+def test_valid_semantic_synthesis_survives_with_grounded_evidence_refs() -> None:
+    from app.evidence import build_evidence_pack
+    from app.guardrails import filter_semantic_claims_with_stats
+    from orion.mind.synthesis_v1 import SemanticSynthesisV1
+
+    pack = build_evidence_pack({"user_text": "watching a show with Amanda"})
+    synthesis = SemanticSynthesisV1.model_validate(
+        _semantic_payload(claim_label="shared evening moment", evidence_ref="current_turn:0")
+    )
+    filtered, stats = filter_semantic_claims_with_stats(synthesis, pack)
+    assert len(filtered.claims) == 1
+    assert stats.retained_claim_count == 1
+    assert stats.filtered_claim_count == 0
+
+
+def test_projection_alias_ref_maps_to_pack_ref() -> None:
+    from app.evidence import build_evidence_pack
+    from app.guardrails import filter_semantic_claims_with_stats
+    from orion.mind.synthesis_v1 import SemanticSynthesisV1
+
+    pack = build_evidence_pack(
+        {
+            "user_text": "hello",
+            "facets": {
+                "cognitive_projection": {
+                    "anchors": {
+                        "relationship": {
+                            "items": [{"label": "bike outing", "summary": "Earlier bike ride.", "salience": 0.7}]
+                        }
+                    }
+                }
+            },
+        }
+    )
+    proj_refs = [it.evidence_ref for it in pack.items if it.source_kind == "cognitive_projection"]
+    assert proj_refs
+    synthesis = SemanticSynthesisV1.model_validate(
+        _semantic_payload(claim_label="bike memory", evidence_ref="projection:0")
+    )
+    filtered, stats = filter_semantic_claims_with_stats(synthesis, pack)
+    assert filtered.claims
+    assert filtered.claims[0].evidence_refs[0] == proj_refs[0]
+    assert stats.normalized_claim_count >= 1
+
+
+def test_empty_after_filter_sets_semantic_synthesis_empty_telemetry() -> None:
+    from app.evidence import build_evidence_pack
+    from app.synthesis import run_semantic_synthesis
+
+    pack = build_evidence_pack({"user_text": "hello"})
+
+    class _Client:
+        def request_json(self, **kwargs):  # type: ignore[no-untyped-def]
+            return (
+                _semantic_payload(claim_label="identity_yaml", evidence_ref="current_turn:0"),
+                None,
+                {"model_used": "quick"},
+            )
+
+    result, err, telemetry = run_semantic_synthesis(
+        pack,
+        client=_Client(),  # type: ignore[arg-type]
+        route="quick",
+        model_id="quick",
+        max_tokens=512,
+    )
+    assert err is None
+    assert result is not None
+    assert result.claims == []
+    assert telemetry.raw_claim_count == 1
+    assert telemetry.retained_claim_count == 0
+    assert telemetry.filtered_claim_count == 1
+    assert telemetry.validation_ok is False
+    assert telemetry.error == "semantic_synthesis_empty"
+    assert telemetry.authorization_reason == "semantic_synthesis_empty"
+    assert telemetry.filter_reasons_by_count.get("source_tag_not_semantic") == 1
+
+
+def test_semantic_empty_fail_open_uses_semantic_synthesis_empty_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.engine import run_mind
+    from app.llm_client import FakeMindLLMClient, set_llm_client_override
+    from app.settings import settings
+    from orion.mind.v1 import MindRunRequestV1, MindRunPolicyV1
+
+    monkeypatch.setattr(settings, "MIND_LLM_SYNTHESIS_ENABLED", True)
+    set_llm_client_override(
+        FakeMindLLMClient([_semantic_payload(claim_label="identity_yaml", evidence_ref="current_turn:0")])
+    )
+    req = MindRunRequestV1(
+        correlation_id=str(uuid4()),
+        snapshot_inputs={"user_text": "hello"},
+        policy=MindRunPolicyV1(n_loops_max=1, wall_time_ms_max=60_000),
+    )
+    result = run_mind(
+        req,
+        router_profiles_dir=Path(__file__).resolve().parents[1] / "app" / "config",
+        snapshot_max_bytes=512_000,
+        mind_settings=settings,
+    )
+    machine = result.brief.machine_contract
+    assert machine.get("mind.llm_synthesis_error_code") == "semantic_synthesis_empty"
+    sem = next(t for t in (machine.get("mind.phase_telemetry") or []) if t.get("phase_name") == "semantic_synthesis")
+    assert sem.get("retained_claim_count") == 0
+    assert sem.get("raw_claim_count") == 1
+    assert sem.get("authorization_reason") == "semantic_synthesis_empty"
 
 
 def test_unrecoverable_semantic_shape_fail_opens_with_schema_telemetry() -> None:


### PR DESCRIPTION
## Summary

- Resolve common LLM `evidence_refs` mismatches against the Mind evidence pack (e.g. `projection:0` → `cognitive_projection:N`) so grounded semantic claims survive guardrails.
- Add semantic_synthesis phase telemetry (`raw_claim_count`, `retained_claim_count`, `filter_reasons_by_count`, `authorization_reason`, etc.).
- Fail open with distinct `semantic_synthesis_empty` when all claims are filtered, with diagnostics explaining counts and dominant filter reason.
- Hub Mind provenance: show filter counts on phase rows; avoid duplicate `semantic_failed` + `semantic_filtered` callouts for filter-empty fail-open.
- Document `ORION_BUS_URL` in `services/orion-mind/.env_example` for host-network stacks.

## Root cause

Gateway replies were reaching Mind, but guardrails removed every claim because `evidence_refs` did not match pack refs (`{source_kind}:{global_index}`). Pipeline then failed open to `deterministic_shadow` with little explainability.

## Test plan

- [x] `PYTHONPATH=. ../../venv/bin/python -m pytest services/orion-mind/tests/test_mind_llm_pipeline.py services/orion-mind/tests/test_mind_governance.py services/orion-hub/tests/test_mind_provenance_normalizer.py -q` (33 passed)
- [x] `compileall` on `services/orion-mind/app`, `services/orion-hub`, `orion/schemas`
- [ ] Deploy Mind from branch; set `ORION_BUS_URL` in mind `.env`
- [ ] One `chat_general` turn: semantic phase `retained_claim_count > 0` OR explainable `semantic_synthesis_empty` with filter counts in Hub modal

Full report: `docs/superpowers/pr-reports/2026-05-20-mind-semantic-synthesis-survival-pr.md`