### PR TITLE
Fix Mind LLM phases when models return almost-valid JSON shapes.

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-20-mind-llm-e2e-shape-normalization.md
+++ b/docs/superpowers/pr-reports/2026-05-20-mind-llm-e2e-shape-normalization.md
@@ -1,0 +1,53 @@
+# PR: Mind LLM shape normalization + Hub E2E verifier
+
+**Branch:** `feat/mind-llm-shape-normalization-e2e`
+
+## Summary
+
+Mind+LLM was failing open to `shadow_synthesis` because Atlas models return **almost-valid JSON** that Pydantic accepted with empty `claims` / `selected` or invalid stance enums. This PR adds deterministic shape normalization for all three Mind LLM phases and a **Hub brain E2E script** with hard quality gates.
+
+## Root causes (live)
+
+| Phase | Model mistake | Symptom |
+|-------|---------------|---------|
+| semantic (quick) | Bare claim at JSON root | `semantic_synthesis_empty`, raw=0 |
+| appraisal (metacog) | `active_cognitive_frontier` key + wrong `schema_version` | `frontier_schema_invalid` |
+| stance (chat) | `conversation_frame: smoketest`, `identity_salience: neutral` | `stance_handoff_invalid` |
+
+## Changes
+
+- `services/orion-mind/app/synthesis.py` — wrap singleton claim root; coerce claim_kind/effects
+- `services/orion-mind/app/appraisal.py` — frontier alias normalization; stronger prompt
+- `services/orion-mind/app/stance_handoff.py` — ChatStanceBrief enum coercion; explicit prompt
+- `services/orion-mind/tests/test_mind_llm_pipeline.py` — 21 tests
+- `services/orion-mind/scripts/verify_mind_llm_e2e.sh` — L1–L4 Hub `/api/chat` verifier
+
+## Tests
+
+```bash
+PYTHONPATH=.:services/orion-mind venv/bin/python -m pytest \
+  services/orion-mind/tests/test_mind_llm_pipeline.py -q
+# 21 passed
+```
+
+## Live E2E (Hub brain)
+
+```bash
+./services/orion-mind/scripts/verify_mind_llm_e2e.sh
+# E2E VERIFIED — meaningful_synthesis, semantic retained=1, stance_skip=true
+```
+
+Example correlation: `fb456bfe-371e-46a3-9781-3e30d3aea254`
+
+## Operator notes
+
+- Mind container: `MIND_LLM_SYNTHESIS_ENABLED=true`, `ORION_BUS_URL` host-reachable (see `.env_example`)
+- Orch: `ORION_MIND_BASE_URL=http://orion-mind:6611`, `ORION_MIND_TIMEOUT_SEC=45` > Mind `MIND_LLM_TIMEOUT_SEC=25`
+- Rebuild Mind after merge: `cd services/orion-mind && docker compose up -d --build`
+- Run `./services/orion-mind/scripts/verify_mind_llm_e2e.sh` after atlas/gateway/mind changes
+
+## Test plan
+
+- [ ] Merge; rebuild `orion-mind`
+- [ ] `./services/orion-mind/scripts/verify_mind_llm_e2e.sh` passes
+- [ ] Hub Mind toggle on; one brain `chat_general` turn; modal shows `meaningful_synthesis`

--- a/services/orion-mind/app/appraisal.py
+++ b/services/orion-mind/app/appraisal.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -15,11 +16,244 @@ from .llm_client import MindLLMClientProtocol
 from .llm_context import MindLLMRequestContext
 from .phase_telemetry import MindPhaseTelemetry, utc_now_iso
 
+_FRONTIER_SCHEMA_VERSION = "mind.active_cognitive_frontier.v1"
+_SCHEMA_VERSION_ALIASES: dict[str, str] = {
+    "active_cognitive_frontier.v1": _FRONTIER_SCHEMA_VERSION,
+    "mind.active_cognitive_frontier.v1": _FRONTIER_SCHEMA_VERSION,
+}
+_SELECTED_LIST_KEYS = (
+    "selected",
+    "active_cognitive_frontier",
+    "frontier",
+    "matters",
+    "selected_matters",
+)
+_VALID_MATTER_KINDS: frozenset[str] = frozenset(
+    {
+        "turn_anchor",
+        "continuity_memory",
+        "relationship_opportunity",
+        "autonomy_pressure",
+        "social_posture",
+        "identity_boundary",
+        "task_directive",
+        "hazard",
+        "curiosity_affordance",
+        "uncertainty",
+    }
+)
+_CLAIM_KIND_TO_MATTER_KIND: dict[str, str] = {
+    "current_turn_claim": "turn_anchor",
+    "continuity_claim": "continuity_memory",
+    "relationship_claim": "relationship_opportunity",
+    "task_claim": "task_directive",
+    "identity_boundary_claim": "identity_boundary",
+    "autonomy_claim": "autonomy_pressure",
+    "social_claim": "social_posture",
+    "situation_claim": "turn_anchor",
+    "hazard_claim": "hazard",
+    "curiosity_affordance_claim": "curiosity_affordance",
+    "uncertainty_claim": "uncertainty",
+}
+_VALID_RECOMMENDED_EFFECTS: frozenset[str] = frozenset(
+    {
+        "answer_directly",
+        "receive_warmly",
+        "ask_one_situated_question",
+        "suppress_question",
+        "preserve_identity_boundary",
+        "avoid_identity_sermon",
+        "technical_triage",
+        "surface_uncertainty",
+        "no_effect",
+    }
+)
+
 _APPRAISAL_SYSTEM = """You judge which semantic claims should shape the next assistant response.
 Select a small active frontier (at most 6 matters). Defer or suppress the rest with reasons.
 Preserve hazards. Do not let background identity dominate ordinary turns.
 Include feature scores for selected matters.
-Return strict JSON matching ActiveCognitiveFrontierV1 with schema_version mind.active_cognitive_frontier.v1."""
+Return strict JSON only (no prose) matching ActiveCognitiveFrontierV1 with schema_version mind.active_cognitive_frontier.v1.
+Use key "selected" (not active_cognitive_frontier) for chosen matters.
+Each selected item MUST include: matter_id, source_claim_id (from semantic claim_id), label, summary, matter_kind, score, features, evidence_refs, reason_selected, recommended_effect.
+Example:
+{"schema_version":"mind.active_cognitive_frontier.v1","selected":[{"matter_id":"m1","source_claim_id":"c1","label":"smoketest","summary":"User performed a smoketest.","matter_kind":"turn_anchor","score":0.85,"features":{"current_turn_relevance":0.9,"confidence":0.85},"evidence_refs":["current_turn:0"],"reason_selected":"grounded in current turn","recommended_effect":"answer_directly"}],"deferred":[],"suppressed":[],"hazards":[],"response_directives":[]}"""
+
+
+def _float_field(item: dict[str, Any], key: str, default: float) -> float:
+    value = item.get(key)
+    if isinstance(value, (int, float)):
+        return float(value)
+    return default
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(v).strip() for v in value if str(v).strip()]
+
+
+def _resolve_source_claim_id(item: dict[str, Any], *, claim_ids: set[str]) -> str:
+    for key in ("source_claim_id", "claim_id"):
+        cid = str(item.get(key) or "").strip()
+        if cid and (not claim_ids or cid in claim_ids):
+            return cid
+    if len(claim_ids) == 1:
+        return next(iter(claim_ids))
+    return str(item.get("source_claim_id") or item.get("claim_id") or "").strip()
+
+
+def _coerce_matter_kind(item: dict[str, Any]) -> str:
+    matter_kind = str(item.get("matter_kind") or "").strip()
+    if matter_kind in _VALID_MATTER_KINDS:
+        return matter_kind
+    claim_kind = str(item.get("claim_kind") or "").strip()
+    return _CLAIM_KIND_TO_MATTER_KIND.get(claim_kind, "turn_anchor")
+
+
+def _coerce_recommended_effect(item: dict[str, Any]) -> str:
+    effect = str(item.get("recommended_effect") or "").strip()
+    if effect in _VALID_RECOMMENDED_EFFECTS:
+        return effect
+    return "no_effect"
+
+
+def _coerce_features(item: dict[str, Any]) -> dict[str, Any]:
+    features = item.get("features")
+    if isinstance(features, dict) and features:
+        return dict(features)
+    confidence = _float_field(item, "confidence", 0.5)
+    salience = _float_field(item, "salience_hint", 0.5)
+    return {
+        "current_turn_relevance": salience,
+        "confidence": confidence,
+        "evidence_strength": confidence,
+    }
+
+
+def _coerce_matter_item(
+    item: dict[str, Any],
+    *,
+    index: int,
+    claim_ids: set[str],
+) -> dict[str, Any] | None:
+    label = str(item.get("label") or "").strip()
+    summary = str(item.get("summary") or "").strip()
+    if not label or not summary:
+        return None
+    source_claim_id = _resolve_source_claim_id(item, claim_ids=claim_ids)
+    if not source_claim_id:
+        return None
+    matter_id = str(item.get("matter_id") or "").strip() or f"m{index + 1}"
+    return {
+        "matter_id": matter_id,
+        "source_claim_id": source_claim_id,
+        "label": label,
+        "summary": summary,
+        "matter_kind": _coerce_matter_kind(item),
+        "score": _float_field(item, "score", _float_field(item, "salience_hint", 0.5)),
+        "features": _coerce_features(item),
+        "evidence_refs": _coerce_string_list(item.get("evidence_refs")),
+        "reason_selected": str(item.get("reason_selected") or "llm_selected").strip() or "llm_selected",
+        "recommended_effect": _coerce_recommended_effect(item),
+        "metadata": dict(item.get("metadata") or {}) if isinstance(item.get("metadata"), dict) else {},
+    }
+
+
+def _extract_selected_raw(raw: dict[str, Any]) -> tuple[list[Any] | None, str | None]:
+    for key in _SELECTED_LIST_KEYS:
+        value = raw.get(key)
+        if isinstance(value, list) and value:
+            return value, key
+    return None, None
+
+
+def _is_bare_frontier_matter_root(raw: dict[str, Any]) -> bool:
+    selected_raw, _ = _extract_selected_raw(raw)
+    if selected_raw:
+        return False
+    label = str(raw.get("label") or "").strip()
+    summary = str(raw.get("summary") or "").strip()
+    if not label or not summary:
+        return False
+    return bool(raw.get("matter_id") or raw.get("source_claim_id") or raw.get("claim_id"))
+
+
+def try_normalize_frontier_raw(
+    raw: dict[str, Any],
+    *,
+    claim_ids: set[str],
+) -> tuple[dict[str, Any] | None, bool]:
+    """Normalize common LLM frontier shapes (wrong schema_version, selected key aliases, claim-shaped matters)."""
+    notes: list[str] = []
+    selected_raw, selected_key = _extract_selected_raw(raw)
+    if selected_raw is None and _is_bare_frontier_matter_root(raw):
+        selected_raw = [raw]
+        selected_key = "root_matter"
+        notes.append("normalized_from_singleton_matter_root")
+
+    if not selected_raw:
+        return None, False
+
+    if selected_key and selected_key != "selected":
+        notes.append(f"normalized_selected_key:{selected_key}")
+
+    schema_version = str(raw.get("schema_version") or "").strip()
+    if schema_version in _SCHEMA_VERSION_ALIASES:
+        if schema_version != _FRONTIER_SCHEMA_VERSION:
+            notes.append("normalized_frontier_schema_version")
+    elif not schema_version:
+        notes.append("normalized_frontier_schema_version_missing")
+
+    selected: list[dict[str, Any]] = []
+    for index, item in enumerate(selected_raw[:6]):
+        if not isinstance(item, dict):
+            continue
+        matter = _coerce_matter_item(item, index=index, claim_ids=claim_ids)
+        if matter is not None:
+            selected.append(matter)
+
+    if not selected:
+        return None, False
+
+    deferred_in = raw.get("deferred")
+    suppressed_in = raw.get("suppressed")
+    out: dict[str, Any] = {
+        "schema_version": _FRONTIER_SCHEMA_VERSION,
+        "selected": selected,
+        "deferred": list(deferred_in) if isinstance(deferred_in, list) else [],
+        "suppressed": list(suppressed_in) if isinstance(suppressed_in, list) else [],
+        "hazards": _coerce_string_list(raw.get("hazards")),
+        "response_directives": _coerce_string_list(raw.get("response_directives")),
+        "diagnostics": dict(raw.get("diagnostics") or {}) if isinstance(raw.get("diagnostics"), dict) else {},
+    }
+    diagnostics = dict(out["diagnostics"])
+    diag_notes = list(diagnostics.get("notes") or [])
+    diag_notes.extend(notes)
+    diagnostics["notes"] = diag_notes
+    out["diagnostics"] = diagnostics
+    return out, True
+
+
+def _validate_frontier_raw(
+    raw: dict[str, Any],
+    *,
+    claim_ids: set[str],
+) -> tuple[ActiveCognitiveFrontierV1 | None, bool]:
+    normalized, did_normalize = try_normalize_frontier_raw(raw, claim_ids=claim_ids)
+    candidate = normalized if did_normalize and normalized is not None else raw
+    try:
+        return ActiveCognitiveFrontierV1.model_validate(candidate), did_normalize
+    except ValidationError:
+        if did_normalize:
+            return None, True
+        retry, did_retry = try_normalize_frontier_raw(raw, claim_ids=claim_ids)
+        if not did_retry or retry is None:
+            return None, False
+        try:
+            return ActiveCognitiveFrontierV1.model_validate(retry), True
+        except ValidationError:
+            return None, True
 
 
 def run_active_frontier_judge(
@@ -67,13 +301,23 @@ def run_active_frontier_judge(
         token_usage=dict(meta.get("usage") or {}),
     )
     if raw is None:
+        telemetry.status = "failed"
         return None, err or "appraisal_failed", telemetry
-    try:
-        frontier = ActiveCognitiveFrontierV1.model_validate(raw)
-    except ValidationError as exc:
+    if not isinstance(raw, dict):
         telemetry.validation_ok = False
-        return None, f"frontier_schema_invalid:{exc}", telemetry
+        telemetry.status = "schema_invalid"
+        telemetry.error = "frontier_schema_invalid:not_object"
+        return None, "frontier_schema_invalid", telemetry
+
     claim_ids = {c.claim_id for c in synthesis.claims}
+    frontier, normalized_from_shape = _validate_frontier_raw(raw, claim_ids=claim_ids)
+    if frontier is None:
+        telemetry.validation_ok = False
+        telemetry.status = "schema_invalid"
+        telemetry.error = "frontier_schema_invalid"
+        return None, "frontier_schema_invalid", telemetry
+
+    diag_notes = list(frontier.diagnostics.notes)
     frontier = frontier.model_copy(
         update={
             "model_id": model_id,
@@ -84,10 +328,20 @@ def run_active_frontier_judge(
                     "suppressed_count": len(frontier.suppressed),
                     "llm_ok": True,
                     "llm_error": None,
+                    "notes": diag_notes,
                 }
             ),
         }
     )
     filtered = filter_active_frontier(frontier, pack, claim_ids=claim_ids)
     telemetry.validation_ok = bool(filtered.selected)
+    if filtered.selected:
+        telemetry.ok = True
+        telemetry.status = "ok"
+        if normalized_from_shape:
+            telemetry.error = None
+    else:
+        telemetry.ok = True
+        telemetry.status = "filtered"
+        telemetry.error = "frontier_selection_empty"
     return filtered, None, telemetry

--- a/services/orion-mind/app/stance_handoff.py
+++ b/services/orion-mind/app/stance_handoff.py
@@ -16,13 +16,80 @@ from .llm_client import MindLLMClientProtocol
 from .llm_context import MindLLMRequestContext
 from .phase_telemetry import MindPhaseTelemetry, utc_now_iso
 
+_VALID_CONVERSATION_FRAMES: frozenset[str] = frozenset(
+    {
+        "technical",
+        "planning",
+        "reflective",
+        "playful_relational",
+        "identity_emergence",
+        "mixed",
+    }
+)
+_VALID_TASK_MODES: frozenset[str] = frozenset(
+    {
+        "direct_response",
+        "triage",
+        "technical_collaboration",
+        "identity_dialogue",
+        "reflective_dialogue",
+        "playful_exchange",
+        "mixed",
+    }
+)
+_VALID_IDENTITY_SALIENCE: frozenset[str] = frozenset({"low", "medium", "high"})
+_CONVERSATION_FRAME_ALIASES: dict[str, str] = {
+    "smoketest": "mixed",
+    "casual": "playful_relational",
+    "relational": "playful_relational",
+    "general": "mixed",
+}
+_TASK_MODE_ALIASES: dict[str, str] = {
+    "direct_answer": "direct_response",
+    "answer_directly": "direct_response",
+}
+_IDENTITY_SALIENCE_ALIASES: dict[str, str] = {
+    "neutral": "low",
+    "minimal": "low",
+    "none": "low",
+}
+
 _STANCE_SYSTEM = """You convert the active cognitive frontier into a compact ChatStanceBrief-compatible stance_payload.
 You are NOT writing the final user reply.
 Respect the current user message first.
-Produce JSON with fields: conversation_frame, task_mode, identity_salience, user_intent, self_relevance,
-juniper_relevance, active_identity_facets, active_relationship_facets, reflective_themes, active_tensions,
-response_priorities, response_hazards, answer_strategy, stance_summary.
-Use only supported conversation_frame and task_mode enum values from ChatStanceBrief."""
+Return strict JSON only (no prose) with these exact enum values:
+- conversation_frame: technical | planning | reflective | playful_relational | identity_emergence | mixed
+- task_mode: direct_response | triage | technical_collaboration | identity_dialogue | reflective_dialogue | playful_exchange | mixed
+- identity_salience: low | medium | high
+Also include: user_intent, self_relevance, juniper_relevance, response_priorities, response_hazards, answer_strategy, stance_summary.
+Example for a simple operational turn:
+{"conversation_frame":"mixed","task_mode":"direct_response","identity_salience":"low","user_intent":"User is running a smoketest.","self_relevance":"Confirm receipt without over-interpreting.","juniper_relevance":"Stay concise and operational.","response_priorities":["confirm receipt"],"response_hazards":["do not invent context"],"answer_strategy":"DirectAnswer","stance_summary":"Operational smoketest turn."}"""
+
+
+def try_coerce_stance_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Coerce common invalid LLM enum strings before ChatStanceBrief validation."""
+    out = dict(payload)
+    changed = False
+
+    frame = str(out.get("conversation_frame") or "").strip().lower()
+    if frame not in _VALID_CONVERSATION_FRAMES:
+        coerced = _CONVERSATION_FRAME_ALIASES.get(frame, "mixed")
+        out["conversation_frame"] = coerced
+        changed = True
+
+    task_mode = str(out.get("task_mode") or "").strip().lower()
+    if task_mode not in _VALID_TASK_MODES:
+        coerced = _TASK_MODE_ALIASES.get(task_mode, "direct_response")
+        out["task_mode"] = coerced
+        changed = True
+
+    salience = str(out.get("identity_salience") or "").strip().lower()
+    if salience not in _VALID_IDENTITY_SALIENCE:
+        coerced = _IDENTITY_SALIENCE_ALIASES.get(salience, "low")
+        out["identity_salience"] = coerced
+        changed = True
+
+    return out, changed
 
 
 def _minimal_stance_from_pack(pack: MindEvidencePackV1) -> dict[str, Any]:
@@ -96,6 +163,7 @@ def run_stance_handoff(
         return _minimal_stance_from_pack(pack), "stance_payload_not_object", telemetry
     merged = _minimal_stance_from_pack(pack)
     merged.update(payload)
+    merged, _ = try_coerce_stance_payload(merged)
     valid, validation_err = validate_merged_stance_brief_optional(merged)
     if valid is None:
         telemetry.validation_ok = False

--- a/services/orion-mind/app/synthesis.py
+++ b/services/orion-mind/app/synthesis.py
@@ -9,7 +9,44 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from orion.mind.synthesis_v1 import MindEvidencePackV1, SemanticSynthesisV1
+from orion.mind.synthesis_v1 import MindEvidencePackV1, RecommendedEffectV1, SemanticSynthesisV1
+
+_VALID_CLAIM_KINDS: frozenset[str] = frozenset(
+    {
+        "current_turn_claim",
+        "continuity_claim",
+        "relationship_claim",
+        "task_claim",
+        "identity_boundary_claim",
+        "autonomy_claim",
+        "social_claim",
+        "situation_claim",
+        "hazard_claim",
+        "curiosity_affordance_claim",
+        "uncertainty_claim",
+    }
+)
+_VALID_RECOMMENDED_EFFECTS: frozenset[str] = frozenset(
+    {
+        "answer_directly",
+        "receive_warmly",
+        "ask_one_situated_question",
+        "suppress_question",
+        "preserve_identity_boundary",
+        "avoid_identity_sermon",
+        "technical_triage",
+        "surface_uncertainty",
+        "no_effect",
+    }
+)
+_VALID_CLAIM_ANCHORS: frozenset[str] = frozenset(
+    {"orion", "juniper", "relationship", "none", "mixed", "unknown"}
+)
+_RECOMMENDED_EFFECT_ALIASES: dict[str, RecommendedEffectV1] = {
+    "acknowledge": "answer_directly",
+    "ack": "answer_directly",
+    "warm_ack": "receive_warmly",
+}
 from .guardrails import (
     SemanticClaimFilterStats,
     evaluate_semantic_handoff_authorization,
@@ -103,6 +140,65 @@ def _coerce_evidence_refs(item: dict[str, Any]) -> list[str]:
     return []
 
 
+def _claims_list_empty(raw: dict[str, Any]) -> bool:
+    claims_in = raw.get("claims")
+    return not isinstance(claims_in, list) or len(claims_in) == 0
+
+
+def _is_bare_semantic_claim_root(raw: dict[str, Any]) -> bool:
+    if not _claims_list_empty(raw):
+        return False
+    if _has_current_claim_shape(raw):
+        return True
+    label = str(raw.get("label") or "").strip()
+    summary = str(raw.get("summary") or "").strip()
+    if not label or not summary:
+        return False
+    return bool(_coerce_evidence_refs(raw) or raw.get("claim_id") or raw.get("claim_kind"))
+
+
+def _coerce_semantic_claim_item(item: dict[str, Any], *, index: int = 0) -> dict[str, Any]:
+    out = dict(item)
+    claim_id = str(out.get("claim_id") or "").strip()
+    if not claim_id:
+        seed = str(out.get("label") or out.get("summary") or f"claim_{index}")
+        out["claim_id"] = _legacy_claim_id(index, seed)
+    claim_kind = str(out.get("claim_kind") or "").strip()
+    if claim_kind not in _VALID_CLAIM_KINDS:
+        refs = _coerce_evidence_refs(out)
+        out["claim_kind"] = "current_turn_claim" if refs else "situation_claim"
+    effect = str(out.get("recommended_effect") or "").strip()
+    if effect in _RECOMMENDED_EFFECT_ALIASES:
+        out["recommended_effect"] = _RECOMMENDED_EFFECT_ALIASES[effect]
+    elif effect not in _VALID_RECOMMENDED_EFFECTS:
+        out["recommended_effect"] = "no_effect"
+    anchor = str(out.get("anchor") or "").strip()
+    if anchor not in _VALID_CLAIM_ANCHORS:
+        out["anchor"] = "unknown"
+    source_kinds = out.get("source_kinds")
+    if not isinstance(source_kinds, list) or not source_kinds:
+        out["source_kinds"] = ["current_turn"] if _coerce_evidence_refs(out) else []
+    return out
+
+
+def try_wrap_singleton_semantic_claim(raw: dict[str, Any]) -> tuple[dict[str, Any] | None, bool]:
+    if not _is_bare_semantic_claim_root(raw):
+        return None, False
+    claim = _coerce_semantic_claim_item(raw, index=0)
+    out: dict[str, Any] = {
+        "schema_version": "mind.semantic_synthesis.v1",
+        "claims": [claim],
+        "suppressed": list(raw.get("suppressed") or []) if isinstance(raw.get("suppressed"), list) else [],
+        "diagnostics": dict(raw.get("diagnostics") or {}) if isinstance(raw.get("diagnostics"), dict) else {},
+    }
+    diagnostics = dict(out["diagnostics"])
+    notes = list(diagnostics.get("notes") or [])
+    notes.append("normalized_from_singleton_claim_root")
+    diagnostics["notes"] = notes
+    out["diagnostics"] = diagnostics
+    return out, True
+
+
 def try_normalize_legacy_semantic_raw(raw: dict[str, Any]) -> tuple[dict[str, Any] | None, bool]:
     """Convert obvious legacy claim objects into SemanticSynthesisV1 claim shape."""
     claims_in = raw.get("claims")
@@ -161,10 +257,32 @@ def try_normalize_legacy_semantic_raw(raw: dict[str, Any]) -> tuple[dict[str, An
 
 
 def _validate_semantic_raw(raw: dict[str, Any]) -> tuple[SemanticSynthesisV1 | None, bool]:
+    candidate = raw
+    normalized_from_shape = False
+
+    wrapped, did_wrap = try_wrap_singleton_semantic_claim(raw)
+    if did_wrap and wrapped is not None:
+        candidate = wrapped
+        normalized_from_shape = True
+
     try:
-        return SemanticSynthesisV1.model_validate(raw), False
+        synthesis = SemanticSynthesisV1.model_validate(candidate)
+        if not synthesis.claims and not normalized_from_shape:
+            wrapped2, did_wrap2 = try_wrap_singleton_semantic_claim(raw)
+            if did_wrap2 and wrapped2 is not None:
+                return SemanticSynthesisV1.model_validate(wrapped2), True
+        return synthesis, normalized_from_shape
     except ValidationError:
-        normalized, did_normalize = try_normalize_legacy_semantic_raw(raw)
+        if not normalized_from_shape:
+            wrapped, did_wrap = try_wrap_singleton_semantic_claim(raw)
+            if did_wrap and wrapped is not None:
+                try:
+                    return SemanticSynthesisV1.model_validate(wrapped), True
+                except ValidationError:
+                    pass
+        normalized, did_normalize = try_normalize_legacy_semantic_raw(candidate)
+        if not did_normalize or normalized is None:
+            normalized, did_normalize = try_normalize_legacy_semantic_raw(raw)
         if not did_normalize or normalized is None:
             return None, False
         try:
@@ -217,7 +335,7 @@ def run_semantic_synthesis(
         telemetry.error = "semantic_schema_invalid:not_object"
         return None, "semantic_schema_invalid", telemetry
 
-    synthesis, normalized_from_legacy = _validate_semantic_raw(raw)
+    synthesis, normalized_from_shape = _validate_semantic_raw(raw)
     if synthesis is None:
         telemetry.validation_ok = False
         telemetry.ok = False
@@ -226,8 +344,6 @@ def run_semantic_synthesis(
         return None, "semantic_schema_invalid", telemetry
 
     diag_notes = list(synthesis.diagnostics.notes)
-    if normalized_from_legacy:
-        diag_notes.append("normalized_from_legacy_claim_shape")
     synthesis = synthesis.model_copy(
         update={
             "model_id": model_id,
@@ -267,7 +383,7 @@ def run_semantic_synthesis(
     if filtered.claims:
         telemetry.ok = True
         telemetry.status = "ok"
-        if normalized_from_legacy:
+        if normalized_from_shape:
             telemetry.error = None
     else:
         telemetry.ok = True

--- a/services/orion-mind/scripts/verify_mind_llm_e2e.sh
+++ b/services/orion-mind/scripts/verify_mind_llm_e2e.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# End-to-end Mind+LLM verification: preflight → Hub brain chat → mind_runs artifact → phase gates.
+# Usage: ./services/orion-mind/scripts/verify_mind_llm_e2e.sh [HUB_BASE_URL]
+set -euo pipefail
+
+HUB_BASE="${1:-http://127.0.0.1:8080}"
+SESSION_ID="${ORION_SESSION_ID:-$(uuidgen 2>/dev/null || python3 -c 'import uuid; print(uuid.uuid4())')}"
+CHAT_TIMEOUT="${CHAT_TIMEOUT_SEC:-180}"
+PROMPT="${VERIFY_PROMPT:-mind llm e2e verify $(date -u +%H:%M:%S) — one short reply.}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC} $*"; }
+fail() { echo -e "${RED}FAIL${NC} $*"; FAILED=1; }
+warn() { echo -e "${YELLOW}WARN${NC} $*"; }
+
+FAILED=0
+
+echo "=== Mind LLM E2E verification ==="
+echo "hub=$HUB_BASE session=$SESSION_ID"
+
+echo ""
+echo "--- 1. Infrastructure preflight ---"
+
+check_url() {
+  local name="$1" url="$2"
+  if curl -sf -m 8 "$url" >/dev/null 2>&1; then
+    pass "$name reachable ($url)"
+  else
+    fail "$name unreachable ($url)"
+  fi
+}
+
+check_url "hub" "$HUB_BASE/health"
+check_url "mind-direct" "http://127.0.0.1:6611/health"
+
+if docker exec orion-mind printenv MIND_LLM_SYNTHESIS_ENABLED 2>/dev/null | grep -q true; then
+  pass "orion-mind MIND_LLM_SYNTHESIS_ENABLED=true"
+else
+  fail "orion-mind MIND_LLM_SYNTHESIS_ENABLED not true"
+fi
+
+if docker exec orion-mind printenv ORION_BUS_URL 2>/dev/null | grep -q redis; then
+  pass "orion-mind ORION_BUS_URL set ($(docker exec orion-mind printenv ORION_BUS_URL 2>/dev/null))"
+else
+  fail "orion-mind ORION_BUS_URL missing"
+fi
+
+if docker exec orion-athena-cortex-orch curl -sf http://orion-mind:6611/health >/dev/null 2>&1; then
+  pass "orch → mind HTTP (/health)"
+else
+  fail "orch cannot reach orion-mind:6611"
+fi
+
+GW_ROUTES=$(docker exec orion-llm-gateway printenv LLM_GATEWAY_ROUTE_TABLE_JSON 2>/dev/null || true)
+for route in quick metacog chat; do
+  if echo "$GW_ROUTES" | grep -q "\"$route\""; then
+    pass "gateway route table includes $route"
+  else
+    fail "gateway route table missing $route"
+  fi
+done
+
+echo ""
+echo "--- 2. Hub brain chat (mind_enabled) ---"
+CHAT_PAYLOAD=$(cat <<EOF
+{
+  "mode": "brain",
+  "verbs": ["chat_general"],
+  "messages": [{"role": "user", "content": $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$PROMPT")}],
+  "use_recall": false,
+  "context": {"metadata": {"mind_enabled": true}},
+  "surface_context": {"surface": "verify_script", "hub_chat_lane": "brain"}
+}
+EOF
+)
+
+CHAT_OUT=$(mktemp)
+HTTP_CODE=$(curl -sS -m "$CHAT_TIMEOUT" -o "$CHAT_OUT" -w '%{http_code}' \
+  -X POST "$HUB_BASE/api/chat" \
+  -H "Content-Type: application/json" \
+  -H "X-Orion-Session-Id: $SESSION_ID" \
+  -d "$CHAT_PAYLOAD" || echo "000")
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+  fail "POST /api/chat HTTP $HTTP_CODE"
+  head -c 2000 "$CHAT_OUT" 2>/dev/null || true
+  echo ""
+else
+  pass "POST /api/chat HTTP 200"
+fi
+
+CORR=$(python3 - <<'PY' "$CHAT_OUT"
+import json, sys
+path = sys.argv[1]
+try:
+    data = json.load(open(path))
+except Exception:
+    print("")
+    sys.exit(0)
+print(data.get("correlation_id") or "")
+PY
+)
+
+if [[ -z "$CORR" ]]; then
+  fail "chat response missing correlation_id"
+else
+  pass "correlation_id=$CORR"
+fi
+
+REPLY_LEN=$(python3 - <<'PY' "$CHAT_OUT"
+import json, sys
+data = json.load(open(sys.argv[1]))
+text = data.get("text") or data.get("response") or ""
+print(len(str(text)))
+PY
+)
+if [[ "${REPLY_LEN:-0}" -gt 0 ]]; then
+  pass "assistant reply received (${REPLY_LEN} chars)"
+else
+  warn "no assistant text in chat response (Mind may still have run)"
+fi
+
+echo ""
+echo "--- 3. mind_runs artifact (Hub DB via API) ---"
+sleep 2
+RUNS_OUT=$(mktemp)
+RUNS_CODE=$(curl -sS -m 30 -o "$RUNS_OUT" -w '%{http_code}' \
+  "$HUB_BASE/api/mind/runs?correlation_id=$CORR" \
+  -H "X-Orion-Session-Id: $SESSION_ID" || echo "000")
+
+if [[ "$RUNS_CODE" != "200" ]]; then
+  fail "GET /api/mind/runs HTTP $RUNS_CODE"
+else
+  pass "GET /api/mind/runs HTTP 200"
+fi
+
+python3 - <<'PY' "$RUNS_OUT" "$CORR"
+import json, sys
+
+path, corr = sys.argv[1], sys.argv[2]
+data = json.load(open(path))
+items = data if isinstance(data, list) else data.get("items") or data.get("runs") or []
+if not items:
+    print("FAIL no mind_runs row for correlation (Orch→Mind write path broken or mind skipped)")
+    sys.exit(2)
+
+row = items[0]
+print(f"PASS mind_run_id={row.get('mind_run_id')} ok={row.get('ok')}")
+
+result = row.get("result_jsonb") or row.get("result") or {}
+if isinstance(result, str):
+    try:
+        result = json.loads(result)
+    except Exception:
+        result = {}
+
+quality = result.get("mind_quality") or (result.get("brief") or {}).get("mind_quality")
+machine = (result.get("brief") or {}).get("machine_contract") or {}
+fail_open = machine.get("mind.llm_fail_open_to_deterministic")
+error_code = machine.get("mind.llm_synthesis_error_code")
+stance_skip = (result.get("brief") or {}).get("mind_authorized_for_stance_skip")
+
+print(f"  mind_quality={quality}")
+print(f"  fail_open={fail_open}")
+print(f"  error_code={error_code}")
+print(f"  stance_skip={stance_skip}")
+
+phases = machine.get("mind.phase_telemetry") or []
+for phase in ("semantic_synthesis", "active_frontier_judge", "stance_handoff"):
+    rec = next((t for t in phases if t.get("phase_name") == phase), None)
+    if not rec:
+        print(f"  FAIL phase missing: {phase}")
+        continue
+    status = rec.get("status")
+    vok = rec.get("validation_ok")
+    err = rec.get("error")
+    raw_n = rec.get("raw_claim_count")
+    ret_n = rec.get("retained_claim_count")
+    print(f"  phase {phase}: status={status} validation_ok={vok} raw={raw_n} retained={ret_n} error={err}")
+
+gates_ok = True
+if quality != "meaningful_synthesis":
+    print(f"FAIL expected mind_quality=meaningful_synthesis got {quality}")
+    gates_ok = False
+if fail_open:
+    print(f"FAIL mind.llm_fail_open_to_deterministic={fail_open}")
+    gates_ok = False
+sem = next((t for t in phases if t.get("phase_name") == "semantic_synthesis"), {})
+if sem and sem.get("retained_claim_count", 0) < 1:
+    print("FAIL semantic retained_claim_count < 1")
+    gates_ok = False
+if not stance_skip:
+    print("WARN mind_authorized_for_stance_skip is false (may still be valid if legacy stance used)")
+
+if gates_ok:
+    print("PASS all Mind LLM quality gates")
+    sys.exit(0)
+sys.exit(3)
+PY
+GATE_RC=$?
+[[ $GATE_RC -eq 0 ]] || FAILED=1
+
+echo ""
+echo "--- 4. Orch / Mind log hints (same correlation) ---"
+if [[ -n "$CORR" ]]; then
+  docker logs orion-athena-cortex-orch 2>&1 | rg "$CORR" | rg -i 'mind_run_artifact|mind_http|mind_skipped' | tail -5 || warn "no orch mind lines for correlation"
+  docker logs orion-mind 2>&1 | rg "$CORR" | tail -8 || warn "no mind log lines for correlation"
+fi
+
+echo ""
+if [[ "$FAILED" -eq 0 && "$GATE_RC" -eq 0 ]]; then
+  echo -e "${GREEN}E2E VERIFIED${NC} — Hub brain path produced meaningful_synthesis Mind run."
+  exit 0
+fi
+echo -e "${RED}E2E FAILED${NC} — see gates above; fix infra before chasing more shape normalizers."
+exit 1

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -292,6 +292,109 @@ def test_source_tag_semantic_fail_open_preserves_phase_telemetry(monkeypatch: py
     assert result.mind_quality == "fallback_contract_only"
 
 
+def test_singleton_root_semantic_claim_is_wrapped_and_retained() -> None:
+    from app.evidence import build_evidence_pack
+    from app.synthesis import run_semantic_synthesis, try_wrap_singleton_semantic_claim
+    from orion.mind.synthesis_v1 import SemanticSynthesisV1
+
+    bare_claim = {
+        "claim_id": "c1",
+        "label": "smoketest",
+        "summary": "User performed a smoketest action.",
+        "claim_kind": "action_claim",
+        "evidence_refs": ["current_turn:0"],
+        "source_kinds": ["current_turn"],
+        "recommended_effect": "acknowledge",
+    }
+    wrapped, did = try_wrap_singleton_semantic_claim(bare_claim)
+    assert did is True
+    synthesis = SemanticSynthesisV1.model_validate(wrapped)
+    assert len(synthesis.claims) == 1
+
+    pack = build_evidence_pack({"user_text": "smoketest!"})
+    result, err, telemetry = run_semantic_synthesis(
+        pack,
+        client=type("_C", (), {"request_json": lambda self, **kw: (bare_claim, None, {"model_used": "quick"})})(),  # type: ignore[arg-type]
+        route="quick",
+        model_id="quick",
+        max_tokens=512,
+    )
+    assert err is None and result and result.claims
+    assert telemetry.retained_claim_count == 1
+
+
+def test_metacog_frontier_alias_shape_is_normalized() -> None:
+    from app.appraisal import run_active_frontier_judge, try_normalize_frontier_raw
+    from app.evidence import build_evidence_pack
+    from orion.mind.synthesis_v1 import ActiveCognitiveFrontierV1, SemanticSynthesisV1
+
+    raw = {
+        "schema_version": "active_cognitive_frontier.v1",
+        "active_cognitive_frontier": [
+            {
+                "matter_id": "m1",
+                "claim_id": "c1",
+                "label": "smoketest",
+                "summary": "User performed a smoketest.",
+                "claim_kind": "current_turn_claim",
+                "evidence_refs": ["current_turn:0"],
+                "recommended_effect": "answer_directly",
+                "confidence": 0.9,
+            }
+        ],
+    }
+    normalized, did = try_normalize_frontier_raw(raw, claim_ids={"c1"})
+    assert did is True
+    frontier = ActiveCognitiveFrontierV1.model_validate(normalized)
+    assert len(frontier.selected) == 1
+    assert frontier.selected[0].source_claim_id == "c1"
+    assert frontier.selected[0].matter_kind == "turn_anchor"
+
+    pack = build_evidence_pack({"user_text": "smoketest!"})
+    synthesis = SemanticSynthesisV1.model_validate(_semantic_payload(claim_label="smoketest"))
+
+    class _Client:
+        def request_json(self, **kwargs):  # type: ignore[no-untyped-def]
+            return raw, None, {"model_used": "metacog"}
+
+    result, err, telemetry = run_active_frontier_judge(
+        synthesis,
+        pack,
+        client=_Client(),  # type: ignore[arg-type]
+        route="metacog",
+        model_id="metacog",
+        max_tokens=512,
+    )
+    assert err is None
+    assert result is not None
+    assert result.selected
+    assert telemetry.validation_ok is True
+
+
+def test_stance_payload_enum_aliases_are_coerced() -> None:
+    from app.stance_handoff import try_coerce_stance_payload
+    from orion.mind.validation import validate_merged_stance_brief_optional
+
+    payload = {
+        "conversation_frame": "smoketest",
+        "task_mode": "direct_answer",
+        "identity_salience": "neutral",
+        "user_intent": "test",
+        "self_relevance": "minimal",
+        "juniper_relevance": "none",
+        "answer_strategy": "DirectAnswer",
+        "stance_summary": "Operational smoketest.",
+    }
+    coerced, did = try_coerce_stance_payload(payload)
+    assert did is True
+    valid, err = validate_merged_stance_brief_optional(coerced)
+    assert err is None
+    assert valid is not None
+    assert valid.conversation_frame == "mixed"
+    assert valid.task_mode == "direct_response"
+    assert valid.identity_salience == "low"
+
+
 def test_legacy_semantic_claim_shape_is_normalized() -> None:
     from app.evidence import build_evidence_pack
     from app.synthesis import run_semantic_synthesis, try_normalize_legacy_semantic_raw


### PR DESCRIPTION
# PR: Mind LLM shape normalization + Hub E2E verifier

**Branch:** `feat/mind-llm-shape-normalization-e2e`

## Summary

Mind+LLM was failing open to `shadow_synthesis` because Atlas models return **almost-valid JSON** that Pydantic accepted with empty `claims` / `selected` or invalid stance enums. This PR adds deterministic shape normalization for all three Mind LLM phases and a **Hub brain E2E script** with hard quality gates.

## Root causes (live)

| Phase | Model mistake | Symptom |
|-------|---------------|---------|
| semantic (quick) | Bare claim at JSON root | `semantic_synthesis_empty`, raw=0 |
| appraisal (metacog) | `active_cognitive_frontier` key + wrong `schema_version` | `frontier_schema_invalid` |
| stance (chat) | `conversation_frame: smoketest`, `identity_salience: neutral` | `stance_handoff_invalid` |

## Changes

- `services/orion-mind/app/synthesis.py` — wrap singleton claim root; coerce claim_kind/effects
- `services/orion-mind/app/appraisal.py` — frontier alias normalization; stronger prompt
- `services/orion-mind/app/stance_handoff.py` — ChatStanceBrief enum coercion; explicit prompt
- `services/orion-mind/tests/test_mind_llm_pipeline.py` — 21 tests
- `services/orion-mind/scripts/verify_mind_llm_e2e.sh` — L1–L4 Hub `/api/chat` verifier

## Tests

```bash
PYTHONPATH=.:services/orion-mind venv/bin/python -m pytest \
  services/orion-mind/tests/test_mind_llm_pipeline.py -q
# 21 passed
```

## Live E2E (Hub brain)

```bash
./services/orion-mind/scripts/verify_mind_llm_e2e.sh
# E2E VERIFIED — meaningful_synthesis, semantic retained=1, stance_skip=true
```

Example correlation: `fb456bfe-371e-46a3-9781-3e30d3aea254`

## Operator notes

- Mind container: `MIND_LLM_SYNTHESIS_ENABLED=true`, `ORION_BUS_URL` host-reachable (see `.env_example`)
- Orch: `ORION_MIND_BASE_URL=http://orion-mind:6611`, `ORION_MIND_TIMEOUT_SEC=45` > Mind `MIND_LLM_TIMEOUT_SEC=25`
- Rebuild Mind after merge: `cd services/orion-mind && docker compose up -d --build`
- Run `./services/orion-mind/scripts/verify_mind_llm_e2e.sh` after atlas/gateway/mind changes

## Test plan

- [ ] Merge; rebuild `orion-mind`
- [ ] `./services/orion-mind/scripts/verify_mind_llm_e2e.sh` passes
- [ ] Hub Mind toggle on; one brain `chat_general` turn; modal shows `meaningful_synthesis`
