### PR TITLE
Feat/orion knowledge forge source delta v1.2

### DIFF
--- a/docs/PR-orion-knowledge-forge-source-delta-v1.2.md
+++ b/docs/PR-orion-knowledge-forge-source-delta-v1.2.md
@@ -1,0 +1,178 @@
+# PR: Orion Knowledge Forge — Source Delta Review v1.2
+
+## Summary
+
+Implements the **source-ingest → proposed delta review** spine for Knowledge Forge. Given a design doc path, Forge deterministically extracts claim candidates, registers the source under `raw/sources/`, and writes a human-review artifact to `reviews/pending/` — without mutating accepted claims, execution-ready specs, or decisions.
+
+This is the first real HITL loop:
+
+```text
+source changed
+  → ingest-source (CLI or API)
+  → proposed claims/spec hints in pending review
+  → human accepts/rejects later (existing review apply flow unchanged)
+  → context packs compile from reviewed state
+```
+
+## Architecture
+
+```text
+design doc (path)
+       ↓
+orion/knowledge_forge/sources.py   parse + propose + write (allowlisted)
+       ↓
+CLI: python -m orion.knowledge_forge ingest-source
+API: POST /v1/sources/ingest
+Hub: POST /api/knowledge/sources/ingest  (proxy alias)
+       ↓
+orion-knowledge/raw/sources/{slug}.md
+orion-knowledge/raw/sources/source-{slug}.yaml
+orion-knowledge/reviews/pending/source-delta-{ts}-{slug}.md
+```
+
+**Read-only / never written by this slice:**
+- `claims/accepted/`
+- `specs/execution_ready/`
+- `decisions/`
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `orion/knowledge_forge/sources.py` | **New** — markdown parse, claim extraction, review builder, ingest orchestration, write allowlist |
+| `orion/knowledge_forge/cli.py` | Add `ingest-source` subcommand |
+| `services/orion-knowledge-forge/app/api_schemas.py` | `SourceIngestRequestV1`, `SourceIngestResultV1` |
+| `services/orion-knowledge-forge/app/service.py` | `ingest_source()` service method |
+| `services/orion-knowledge-forge/app/routers/v1.py` | `POST /v1/sources/ingest` + operator token gate on writes |
+| `tests/test_knowledge_forge_source_ingest.py` | CLI/core unit + integration tests |
+| `services/orion-knowledge-forge/tests/test_source_ingest_api.py` | API tests incl. write-disabled + operator token |
+| `services/orion-hub/scripts/api_routes.py` | Hub proxy `POST /api/knowledge/sources/ingest` |
+| `services/orion-hub/tests/test_knowledge_forge_proxy_routes.py` | Proxy alias coverage |
+
+## New CLI
+
+```bash
+ORION_KNOWLEDGE_ROOT=$PWD/orion-knowledge \
+PYTHONPATH=. python -m orion.knowledge_forge ingest-source \
+  --path docs/some-design-doc.md \
+  --source-id source:some-design-doc \
+  --kind design_doc \
+  --dry-run
+
+ORION_KNOWLEDGE_ROOT=$PWD/orion-knowledge \
+PYTHONPATH=. python -m orion.knowledge_forge ingest-source \
+  --path docs/some-design-doc.md \
+  --source-id source:some-design-doc \
+  --kind design_doc \
+  --write-review
+```
+
+CLI honors `KNOWLEDGE_FORGE_WRITE_ENABLED` (defaults to enabled when unset).
+
+## New API
+
+```http
+POST /v1/sources/ingest
+Content-Type: application/json
+
+{
+  "path": "/tmp/kf-test-design.md",
+  "source_id": "source:test-design-doc",
+  "kind": "design_doc",
+  "write_review": true,
+  "dry_run": false
+}
+```
+
+Response fields: `source_id`, `status`, `source_path`, `review_path`, `proposed_claims`, `possibly_affected_specs`, `warnings`, `content`.
+
+Write requires `KNOWLEDGE_FORGE_WRITE_ENABLED=true`. Operator token required when `KNOWLEDGE_FORGE_OPERATOR_TOKEN` is set and `write_review=true`.
+
+## Hub proxy
+
+Added: `POST /api/knowledge/sources/ingest` → `v1/sources/ingest` (explicit alias before catch-all).
+
+No Hub UI panel — proxy only.
+
+## Deterministic extractor (v1.2)
+
+From markdown headings, extracts bullets under:
+- Requirements, Decisions, Non-goals, Acceptance checks, Known traps, Implementation path
+
+Outputs review artifact sections:
+- Source / Source summary / Proposed claims (checkboxes) / Possibly affected specs / Suggested context packs / Human action needed
+
+`possibly_affected_specs` uses lightweight keyword overlap against loaded specs (heuristic, not LLM).
+
+## Configuration
+
+No new env vars. Reuses existing Forge settings:
+
+| Variable | Purpose |
+|----------|---------|
+| `ORION_KNOWLEDGE_ROOT` / `KNOWLEDGE_FORGE_REPO_ROOT` | Corpus root |
+| `KNOWLEDGE_FORGE_WRITE_ENABLED` | Gate API/CLI writes |
+| `KNOWLEDGE_FORGE_OPERATOR_TOKEN` | Gate authenticated writes |
+
+## Test results
+
+```bash
+PYTHONPATH=. pytest tests/test_knowledge_forge_*.py -q
+# 24 passed
+
+PYTHONPATH=services/orion-knowledge-forge pytest services/orion-knowledge-forge/tests/ -q
+# 21 passed
+
+PYTHONPATH=. pytest services/orion-hub/tests/test_knowledge_forge_proxy_routes.py -q
+# 3 passed
+```
+
+## Manual smoke
+
+Dry-run (no corpus writes):
+
+```bash
+ORION_KNOWLEDGE_ROOT=$PWD/orion-knowledge \
+PYTHONPATH=. python -m orion.knowledge_forge ingest-source \
+  --path /tmp/kf-test-design.md \
+  --source-id source:test-design-doc \
+  --kind design_doc \
+  --dry-run
+# status=proposed, proposed_claim lines printed, no files under raw/sources or reviews/pending
+```
+
+Write mode:
+
+```bash
+ORION_KNOWLEDGE_ROOT=$PWD/orion-knowledge \
+PYTHONPATH=. python -m orion.knowledge_forge ingest-source \
+  --path /tmp/kf-test-design.md \
+  --source-id source:test-design-doc \
+  --kind design_doc \
+  --write-review
+# writes raw/sources/test-design-doc.md, source-test-design-doc.yaml, reviews/pending/source-delta-*.md
+```
+
+## Skipped / deferred
+
+- LLM / frontier extraction (deterministic only)
+- MCP, GraphDB, vector search, autonomous rewrite, chat ingestion
+- Hub UI for source delta review
+- Auto-accept of proposed claims (human review required)
+- Numbered-list / `###` subsection parsing (future parser hardening)
+- Source change detection / watch mode (ingest is explicit in v1.2)
+
+## Branch
+
+- **Worktree:** `.worktrees/feat-orion-knowledge-forge-source-delta-v1.2`
+- **Branch:** `feat/orion-knowledge-forge-source-delta-v1.2`
+- **Commits:** `c0c7aac7` (feature), follow-up (review hardening)
+
+## Test plan
+
+- [ ] CLI dry-run on a real design doc — verify no corpus mutation
+- [ ] CLI `--write-review` — verify only `raw/sources/` + `reviews/pending/` change
+- [ ] API dry-run with `write_review=false` — `review_path: null`, content populated
+- [ ] API write with `KNOWLEDGE_FORGE_WRITE_ENABLED=true` — pending review created
+- [ ] Hub proxy curl through Orion Hub when Forge running on 8630
+- [ ] Existing lint/compile/ideation flows unchanged

--- a/orion/knowledge_forge/cli.py
+++ b/orion/knowledge_forge/cli.py
@@ -9,6 +9,7 @@ from orion.knowledge_forge.lint import lint_corpus
 from orion.knowledge_forge.paths import resolve_corpus_root
 from orion.knowledge_forge.probes import probe_source_coverage
 from orion.knowledge_forge.review import apply_pending_patch, list_pending_patches
+from orion.knowledge_forge.sources import ingest_source
 from orion.knowledge_forge.store import KnowledgeStore
 from orion.knowledge_forge.yaml_doc import save_yaml_doc
 
@@ -39,6 +40,13 @@ def main(argv: list[str] | None = None) -> int:
     src.add_argument("--source-id", required=True)
     src.add_argument("--path", required=True)
     src.add_argument("--keyword", required=True)
+
+    ingest_p = sub.add_parser("ingest-source")
+    ingest_p.add_argument("--path", required=True)
+    ingest_p.add_argument("--source-id", required=True)
+    ingest_p.add_argument("--kind", default="design_doc")
+    ingest_p.add_argument("--write-review", action="store_true")
+    ingest_p.add_argument("--dry-run", action="store_true")
 
     args = parser.parse_args(argv)
     root = resolve_corpus_root()
@@ -102,6 +110,32 @@ def main(argv: list[str] | None = None) -> int:
         for issue in report.issues:
             print(f"{issue.code}\t{issue.message}")
         return 0 if report.ok else 1
+
+    if args.cmd == "ingest-source":
+        try:
+            result = ingest_source(
+                root,
+                source_path=Path(args.path),
+                source_id=args.source_id,
+                kind=args.kind,
+                write_review=args.write_review,
+                dry_run=args.dry_run,
+                write_enabled=True,
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"error\t{exc}", file=sys.stderr)
+            return 1
+        print(f"source_id\t{result.source_id}")
+        print(f"status\t{result.status}")
+        if result.source_path:
+            print(f"source_path\t{result.source_path}")
+        if result.review_path:
+            print(f"review_path\t{result.review_path}")
+        for warning in result.warnings:
+            print(f"warning\t{warning}")
+        for claim in result.proposed_claims:
+            print(f"proposed_claim\t{claim}")
+        return 0
 
     parser.error("unknown command")
     return 2

--- a/orion/knowledge_forge/cli.py
+++ b/orion/knowledge_forge/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -112,6 +113,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if report.ok else 1
 
     if args.cmd == "ingest-source":
+        write_enabled = os.environ.get("KNOWLEDGE_FORGE_WRITE_ENABLED", "true").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
         try:
             result = ingest_source(
                 root,
@@ -120,7 +126,7 @@ def main(argv: list[str] | None = None) -> int:
                 kind=args.kind,
                 write_review=args.write_review,
                 dry_run=args.dry_run,
-                write_enabled=True,
+                write_enabled=write_enabled,
             )
         except (FileNotFoundError, ValueError) as exc:
             print(f"error\t{exc}", file=sys.stderr)

--- a/orion/knowledge_forge/sources.py
+++ b/orion/knowledge_forge/sources.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.knowledge_forge.models import SourceKindV1, SpecV1, TrustLevelV1
+from orion.knowledge_forge.store import KnowledgeStore
+from orion.knowledge_forge.yaml_doc import save_yaml_doc
+
+_CLAIM_SECTIONS = frozenset(
+    {
+        "requirements",
+        "decisions",
+        "non-goals",
+        "acceptance checks",
+        "known traps",
+        "implementation path",
+    }
+)
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
+_BULLET_RE = re.compile(r"^\s*[-*]\s+(.+)$")
+_FORBIDDEN_WRITE_PREFIXES = (
+    "claims/accepted/",
+    "specs/execution_ready/",
+    "decisions/",
+)
+
+
+@dataclass
+class ProposedClaim:
+    text: str
+    provenance: str
+    line_ref: int | None = None
+
+
+@dataclass
+class SourceParseResult:
+    title: str
+    summary_lines: list[str]
+    proposed_claims: list[ProposedClaim] = field(default_factory=list)
+    section_bullets: dict[str, list[str]] = field(default_factory=dict)
+
+
+@dataclass
+class IngestSourceResult:
+    source_id: str
+    status: str
+    source_path: str | None
+    review_path: str | None
+    proposed_claims: list[str]
+    possibly_affected_specs: list[str]
+    warnings: list[str]
+    content: str
+
+
+def slug_from_source_id(source_id: str) -> str:
+    slug = source_id.removeprefix("source:").strip()
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", slug).strip("-")
+    return slug or "source"
+
+
+def parse_source_markdown(text: str) -> SourceParseResult:
+    lines = text.splitlines()
+    title = _infer_title(lines)
+    section_bullets: dict[str, list[str]] = {}
+    current_section: str | None = None
+
+    for idx, line in enumerate(lines, start=1):
+        heading = _HEADING_RE.match(line)
+        if heading:
+            current_section = heading.group(2).strip()
+            section_bullets.setdefault(current_section, [])
+            continue
+        bullet = _BULLET_RE.match(line)
+        if bullet and current_section is not None:
+            section_bullets.setdefault(current_section, []).append(bullet.group(1).strip())
+
+    proposed: list[ProposedClaim] = []
+    for section, bullets in section_bullets.items():
+        if section.casefold() not in _CLAIM_SECTIONS:
+            continue
+        for bullet_idx, bullet in enumerate(bullets):
+            line_ref = _bullet_line_number(lines, section, bullet_idx)
+            provenance = f"{section} § {bullet[:80]}"
+            if line_ref is not None:
+                provenance = f"L{line_ref} · {provenance}"
+            proposed.append(ProposedClaim(text=bullet, provenance=provenance, line_ref=line_ref))
+
+    summary_lines = section_bullets.get("Requirements", [])[:3]
+    if not summary_lines:
+        for bullets in section_bullets.values():
+            summary_lines.extend(bullets[:2])
+            if summary_lines:
+                break
+
+    return SourceParseResult(
+        title=title,
+        summary_lines=summary_lines,
+        proposed_claims=proposed,
+        section_bullets=section_bullets,
+    )
+
+
+def build_source_delta_review(
+    *,
+    source_id: str,
+    source_kind: str,
+    source_rel_path: str,
+    parsed: SourceParseResult,
+    possibly_affected_specs: list[str],
+) -> str:
+    lines = [
+        "# Source Delta Review",
+        "",
+        "## Source",
+        f"- id: `{source_id}`",
+        f"- kind: `{source_kind}`",
+        f"- path: `{source_rel_path}`",
+        "",
+        "## Source summary",
+        f"**{parsed.title}**",
+        "",
+    ]
+    if parsed.summary_lines:
+        for item in parsed.summary_lines:
+            lines.append(f"- {item}")
+    else:
+        lines.append("- (no summary bullets extracted)")
+
+    lines.extend(["", "## Proposed claims"])
+    if parsed.proposed_claims:
+        for claim in parsed.proposed_claims:
+            suffix = f" _({claim.provenance})_"
+            lines.append(f"- [ ] {claim.text}{suffix}")
+    else:
+        lines.append("- [ ] (no claim candidates extracted)")
+
+    lines.extend(["", "## Possibly affected specs"])
+    if possibly_affected_specs:
+        for spec_id in possibly_affected_specs:
+            lines.append(f"- `{spec_id}`")
+    else:
+        lines.append("- (none identified)")
+
+    lines.extend(["", "## Suggested context packs"])
+    if possibly_affected_specs:
+        for spec_id in possibly_affected_specs:
+            lines.append(f"- compile context pack for `{spec_id}` after claims are accepted")
+    else:
+        lines.append("- compile after review once related specs are identified")
+
+    lines.extend(
+        [
+            "",
+            "## Human action needed",
+            "- accept/reject proposed claims",
+            "- update affected specs if needed",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def find_possibly_affected_specs(store: KnowledgeStore, proposed_claims: list[ProposedClaim]) -> list[str]:
+    if not proposed_claims:
+        return []
+    needles = [claim.text.casefold() for claim in proposed_claims]
+    hits: list[str] = []
+    for spec in store.specs():
+        if not isinstance(spec, SpecV1):
+            continue
+        haystacks = [spec.component.casefold(), *[req.casefold() for req in spec.requirements]]
+        haystacks.extend(ng.casefold() for ng in spec.non_goals)
+        if any(
+            needle in hay or any(word in hay for word in needle.split() if len(word) > 4)
+            for needle in needles
+            for hay in haystacks
+        ):
+            hits.append(spec.id)
+    return sorted(set(hits))
+
+
+def ingest_source(
+    corpus_root: Path,
+    *,
+    source_path: Path,
+    source_id: str,
+    kind: str,
+    write_review: bool = False,
+    dry_run: bool = False,
+    write_enabled: bool = True,
+    store: KnowledgeStore | None = None,
+    now: datetime | None = None,
+) -> IngestSourceResult:
+    if not source_id.startswith("source:"):
+        raise ValueError("source_id must start with source:")
+
+    resolved = source_path.expanduser().resolve()
+    if not resolved.is_file():
+        raise FileNotFoundError(f"source path not found: {source_path}")
+
+    try:
+        source_kind = SourceKindV1(kind)
+    except ValueError as exc:
+        raise ValueError(f"unsupported source kind: {kind}") from exc
+
+    text = resolved.read_text(encoding="utf-8")
+    parsed = parse_source_markdown(text)
+
+    active_store = store or KnowledgeStore(corpus_root)
+    if store is None:
+        active_store.load()
+    affected = find_possibly_affected_specs(active_store, parsed.proposed_claims)
+
+    slug = slug_from_source_id(source_id)
+    dest_md_name = f"{slug}.md"
+    source_rel_path = f"raw/sources/{dest_md_name}"
+    review_rel_path: str | None = None
+    warnings: list[str] = []
+
+    content = build_source_delta_review(
+        source_id=source_id,
+        source_kind=source_kind.value,
+        source_rel_path=source_rel_path,
+        parsed=parsed,
+        possibly_affected_specs=affected,
+    )
+
+    should_write = write_review and not dry_run
+    if write_review and dry_run:
+        warnings.append("dry run: no files written")
+    elif write_review and not write_enabled:
+        warnings.append("write disabled: KNOWLEDGE_FORGE_WRITE_ENABLED is false")
+        should_write = False
+    elif not write_review:
+        warnings.append("write disabled: write_review is false")
+
+    if should_write:
+        _assert_write_targets_allowed(corpus_root, source_rel_path)
+        sources_dir = corpus_root / "raw" / "sources"
+        sources_dir.mkdir(parents=True, exist_ok=True)
+        dest_md = sources_dir / dest_md_name
+        shutil.copy2(resolved, dest_md)
+
+        registry_name = f"source-{slug}.yaml"
+        registry_rel = f"raw/sources/{registry_name}"
+        _assert_write_targets_allowed(corpus_root, registry_rel)
+        save_yaml_doc(
+            corpus_root / registry_rel,
+            {
+                "type": "source",
+                "id": source_id,
+                "kind": source_kind.value,
+                "path": source_rel_path,
+                "trust_level": TrustLevelV1.primary.value,
+            },
+        )
+
+        ts = (now or datetime.now(timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
+        review_name = f"source-delta-{ts}-{slug}.md"
+        review_rel_path = f"reviews/pending/{review_name}"
+        _assert_write_targets_allowed(corpus_root, review_rel_path)
+        pending_dir = corpus_root / "reviews" / "pending"
+        pending_dir.mkdir(parents=True, exist_ok=True)
+        (pending_dir / review_name).write_text(content, encoding="utf-8")
+
+    return IngestSourceResult(
+        source_id=source_id,
+        status="proposed",
+        source_path=source_rel_path if should_write else None,
+        review_path=review_rel_path,
+        proposed_claims=[c.text for c in parsed.proposed_claims],
+        possibly_affected_specs=affected,
+        warnings=warnings,
+        content=content,
+    )
+
+
+def _infer_title(lines: list[str]) -> str:
+    for line in lines:
+        m = _HEADING_RE.match(line)
+        if m:
+            return m.group(2).strip()
+    return "Untitled source"
+
+
+def _bullet_line_number(lines: list[str], section: str, bullet_index: int) -> int | None:
+    in_section = False
+    seen = 0
+    for idx, line in enumerate(lines, start=1):
+        heading = _HEADING_RE.match(line)
+        if heading:
+            name = heading.group(2).strip()
+            in_section = name == section
+            continue
+        if in_section and _BULLET_RE.match(line):
+            if seen == bullet_index:
+                return idx
+            seen += 1
+    return None
+
+
+def _assert_write_targets_allowed(corpus_root: Path, rel_path: str) -> None:
+    normalized = rel_path.replace("\\", "/")
+    for forbidden in _FORBIDDEN_WRITE_PREFIXES:
+        if normalized.startswith(forbidden):
+            raise ValueError(f"refusing to write to protected path: {rel_path}")
+    target = (corpus_root / rel_path).resolve()
+    root = corpus_root.resolve()
+    if not target.is_relative_to(root):
+        raise ValueError(f"path escapes corpus root: {rel_path}")

--- a/orion/knowledge_forge/sources.py
+++ b/orion/knowledge_forge/sources.py
@@ -27,6 +27,10 @@ _FORBIDDEN_WRITE_PREFIXES = (
     "specs/execution_ready/",
     "decisions/",
 )
+_ALLOWED_WRITE_PREFIXES = (
+    "raw/sources/",
+    "reviews/pending/",
+)
 
 
 @dataclass
@@ -236,7 +240,7 @@ def ingest_source(
         warnings.append("write disabled: KNOWLEDGE_FORGE_WRITE_ENABLED is false")
         should_write = False
     elif not write_review:
-        warnings.append("write disabled: write_review is false")
+        warnings.append("preview only: write_review is false")
 
     if should_write:
         _assert_write_targets_allowed(corpus_root, source_rel_path)
@@ -308,6 +312,8 @@ def _assert_write_targets_allowed(corpus_root: Path, rel_path: str) -> None:
     for forbidden in _FORBIDDEN_WRITE_PREFIXES:
         if normalized.startswith(forbidden):
             raise ValueError(f"refusing to write to protected path: {rel_path}")
+    if not any(normalized.startswith(allowed) for allowed in _ALLOWED_WRITE_PREFIXES):
+        raise ValueError(f"refusing to write outside allowed ingest paths: {rel_path}")
     target = (corpus_root / rel_path).resolve()
     root = corpus_root.resolve()
     if not target.is_relative_to(root):

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -1185,6 +1185,11 @@ async def proxy_knowledge_forge_ideation_run(request: Request) -> Response:
     return await _proxy_knowledge_forge_request("v1/ideation/run", request)
 
 
+@router.api_route("/api/knowledge/sources/ingest", methods=["POST"])
+async def proxy_knowledge_forge_sources_ingest(request: Request) -> Response:
+    return await _proxy_knowledge_forge_request("v1/sources/ingest", request)
+
+
 @router.api_route("/api/knowledge/context-packs/{pack_id}", methods=["GET"])
 async def proxy_knowledge_forge_context_pack(pack_id: str, request: Request) -> Response:
     return await _proxy_knowledge_forge_request(f"v1/context-packs/{pack_id}", request)

--- a/services/orion-hub/tests/test_knowledge_forge_proxy_routes.py
+++ b/services/orion-hub/tests/test_knowledge_forge_proxy_routes.py
@@ -65,6 +65,11 @@ def test_knowledge_forge_alias_routes_forward_expected_paths(monkeypatch: pytest
             _request("POST", b'{"task":"test"}')
         )
     )
+    asyncio.run(
+        hub_api_routes.proxy_knowledge_forge_sources_ingest(
+            _request("POST", b'{"path":"/tmp/x.md","source_id":"source:x"}')
+        )
+    )
     asyncio.run(hub_api_routes.proxy_knowledge_forge("v1/custom-endpoint", _request("GET")))
 
     assert calls == [
@@ -72,6 +77,7 @@ def test_knowledge_forge_alias_routes_forward_expected_paths(monkeypatch: pytest
         "v1/status",
         "v1/context-packs/compile",
         "v1/ideation/run",
+        "v1/sources/ingest",
         "v1/custom-endpoint",
     ]
 

--- a/services/orion-knowledge-forge/app/api_schemas.py
+++ b/services/orion-knowledge-forge/app/api_schemas.py
@@ -139,6 +139,29 @@ class ContextPackCompileResultV1(BaseModel):
     content: str
 
 
+class SourceIngestRequestV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    source_id: str
+    kind: str = "design_doc"
+    write_review: bool = False
+    dry_run: bool = False
+
+
+class SourceIngestResultV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str
+    status: str
+    source_path: str | None = None
+    review_path: str | None = None
+    proposed_claims: list[str] = Field(default_factory=list)
+    possibly_affected_specs: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    content: str
+
+
 class IdeationMode(str, Enum):
     arsonist_review = "arsonist_review"
     spec_critique = "spec_critique"

--- a/services/orion-knowledge-forge/app/routers/v1.py
+++ b/services/orion-knowledge-forge/app/routers/v1.py
@@ -17,7 +17,7 @@ from app.api_schemas import (
     SpecSummaryV1,
 )
 from app.service import KnowledgeForgeService
-from app.settings import settings
+from app.settings import Settings, settings
 
 router = APIRouter(prefix="/v1", tags=["knowledge-forge-v1"])
 
@@ -169,7 +169,7 @@ def ingest_source_route(
     service: KnowledgeForgeService = Depends(require_enabled),
 ) -> SourceIngestResultV1:
     if request.write_review:
-        expected = settings.knowledge_forge_operator_token
+        expected = Settings().knowledge_forge_operator_token
         if expected and x_knowledge_forge_token != expected:
             raise HTTPException(status_code=401, detail="invalid operator token")
     try:

--- a/services/orion-knowledge-forge/app/routers/v1.py
+++ b/services/orion-knowledge-forge/app/routers/v1.py
@@ -11,6 +11,8 @@ from app.api_schemas import (
     KnowledgeForgeStatusV1,
     ReviewSummaryV1,
     SearchHitV1,
+    SourceIngestRequestV1,
+    SourceIngestResultV1,
     SourceSummaryV1,
     SpecSummaryV1,
 )
@@ -158,3 +160,19 @@ def reject_review(
 @router.get("/sources", response_model=list[SourceSummaryV1])
 def list_sources(service: KnowledgeForgeService = Depends(require_enabled)) -> list[SourceSummaryV1]:
     return service.list_sources()
+
+
+@router.post("/sources/ingest", response_model=SourceIngestResultV1)
+def ingest_source_route(
+    request: SourceIngestRequestV1,
+    x_knowledge_forge_token: str | None = Header(default=None, alias="X-Knowledge-Forge-Token"),
+    service: KnowledgeForgeService = Depends(require_enabled),
+) -> SourceIngestResultV1:
+    if request.write_review:
+        expected = settings.knowledge_forge_operator_token
+        if expected and x_knowledge_forge_token != expected:
+            raise HTTPException(status_code=401, detail="invalid operator token")
+    try:
+        return service.ingest_source(request)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/services/orion-knowledge-forge/app/service.py
+++ b/services/orion-knowledge-forge/app/service.py
@@ -19,6 +19,7 @@ from orion.knowledge_forge.models import (
     SpecV1,
 )
 from orion.knowledge_forge.review import apply_pending_patch, list_pending_patches
+from orion.knowledge_forge.sources import ingest_source
 from orion.knowledge_forge.store import KnowledgeStore, DocModel
 from orion.knowledge_forge.yaml_doc import load_yaml_doc
 
@@ -31,6 +32,8 @@ from app.api_schemas import (
     KnowledgeForgeStatusV1,
     ReviewSummaryV1,
     SearchHitV1,
+    SourceIngestRequestV1,
+    SourceIngestResultV1,
     SourceSummaryV1,
     SpecSummaryV1,
 )
@@ -187,6 +190,33 @@ class KnowledgeForgeService:
 
     def list_sources(self) -> list[SourceSummaryV1]:
         return [self._source_summary(source) for source in sorted(self._sources(), key=lambda s: s.id)]
+
+    def ingest_source(self, request: SourceIngestRequestV1) -> SourceIngestResultV1:
+        try:
+            result = ingest_source(
+                self.root,
+                source_path=Path(request.path),
+                source_id=request.source_id,
+                kind=request.kind,
+                write_review=request.write_review,
+                dry_run=request.dry_run,
+                write_enabled=self.settings.knowledge_forge_write_enabled,
+                store=self.store,
+            )
+        except FileNotFoundError as exc:
+            raise ValueError(str(exc)) from exc
+        if result.review_path or result.source_path:
+            self.reload()
+        return SourceIngestResultV1(
+            source_id=result.source_id,
+            status=result.status,
+            source_path=result.source_path,
+            review_path=result.review_path,
+            proposed_claims=result.proposed_claims,
+            possibly_affected_specs=result.possibly_affected_specs,
+            warnings=result.warnings,
+            content=result.content,
+        )
 
     def list_pending_reviews(self) -> list[ReviewSummaryV1]:
         return [

--- a/services/orion-knowledge-forge/tests/test_source_ingest_api.py
+++ b/services/orion-knowledge-forge/tests/test_source_ingest_api.py
@@ -41,7 +41,7 @@ def test_ingest_dry_run_returns_content_no_review_path(client: TestClient, tmp_p
     assert body["review_path"] is None
     assert body["source_path"] is None
     assert "# Source Delta Review" in body["content"]
-    assert any("write disabled" in w for w in body["warnings"])
+    assert any("preview only" in w for w in body["warnings"])
 
 
 def test_ingest_write_disabled_returns_null_paths(client: TestClient, tmp_path: Path) -> None:
@@ -61,6 +61,50 @@ def test_ingest_write_disabled_returns_null_paths(client: TestClient, tmp_path: 
     body = response.json()
     assert body["review_path"] is None
     assert any("write disabled" in w for w in body["warnings"])
+
+
+def test_ingest_write_requires_operator_token(
+    corpus_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    src = tmp_path / "kf-test-design.md"
+    _write_sample(src)
+
+    monkeypatch.setenv("KNOWLEDGE_FORGE_REPO_ROOT", str(corpus_root))
+    monkeypatch.setenv("KNOWLEDGE_FORGE_WRITE_ENABLED", "true")
+    monkeypatch.setenv("KNOWLEDGE_FORGE_OPERATOR_TOKEN", "secret-token")
+
+    from app.settings import Settings
+    from app.service import KnowledgeForgeService
+    from app.routers import v1
+    from app.main import app
+
+    cfg = Settings()
+    v1.reset_service(KnowledgeForgeService(cfg))
+    write_client = TestClient(app)
+
+    denied = write_client.post(
+        "/v1/sources/ingest",
+        json={
+            "path": str(src),
+            "source_id": "source:token-test",
+            "kind": "design_doc",
+            "write_review": True,
+        },
+    )
+    assert denied.status_code == 401
+
+    allowed = write_client.post(
+        "/v1/sources/ingest",
+        json={
+            "path": str(src),
+            "source_id": "source:token-test",
+            "kind": "design_doc",
+            "write_review": True,
+        },
+        headers={"X-Knowledge-Forge-Token": "secret-token"},
+    )
+    assert allowed.status_code == 200
+    assert allowed.json()["review_path"] is not None
 
 
 def test_ingest_write_enabled_creates_pending_review(

--- a/services/orion-knowledge-forge/tests/test_source_ingest_api.py
+++ b/services/orion-knowledge-forge/tests/test_source_ingest_api.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+SAMPLE_DOC = """# Test Design Doc
+
+## Requirements
+
+- Knowledge Forge should track changed design docs.
+- Source ingest should propose claims, not accept them.
+
+## Acceptance checks
+
+- Dry run writes no files.
+"""
+
+
+def _write_sample(path: Path) -> None:
+    path.write_text(SAMPLE_DOC, encoding="utf-8")
+
+
+def test_ingest_dry_run_returns_content_no_review_path(client: TestClient, tmp_path: Path) -> None:
+    src = tmp_path / "kf-test-design.md"
+    _write_sample(src)
+    response = client.post(
+        "/v1/sources/ingest",
+        json={
+            "path": str(src),
+            "source_id": "source:test-design-doc",
+            "kind": "design_doc",
+            "write_review": False,
+            "dry_run": True,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["review_path"] is None
+    assert body["source_path"] is None
+    assert "# Source Delta Review" in body["content"]
+    assert any("write disabled" in w for w in body["warnings"])
+
+
+def test_ingest_write_disabled_returns_null_paths(client: TestClient, tmp_path: Path) -> None:
+    src = tmp_path / "kf-test-design.md"
+    _write_sample(src)
+    response = client.post(
+        "/v1/sources/ingest",
+        json={
+            "path": str(src),
+            "source_id": "source:test-design-doc",
+            "kind": "design_doc",
+            "write_review": True,
+            "dry_run": False,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["review_path"] is None
+    assert any("write disabled" in w for w in body["warnings"])
+
+
+def test_ingest_write_enabled_creates_pending_review(
+    client: TestClient, corpus_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    src = tmp_path / "kf-test-design.md"
+    _write_sample(src)
+
+    monkeypatch.setenv("KNOWLEDGE_FORGE_WRITE_ENABLED", "true")
+    from app.settings import Settings
+    from app.service import KnowledgeForgeService
+    from app.routers import v1
+
+    cfg = Settings()
+    v1.reset_service(KnowledgeForgeService(cfg))
+
+    from app.main import app
+
+    write_client = TestClient(app)
+    response = write_client.post(
+        "/v1/sources/ingest",
+        json={
+            "path": str(src),
+            "source_id": "source:api-test-design",
+            "kind": "design_doc",
+            "write_review": True,
+            "dry_run": False,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["review_path"] is not None
+    assert body["review_path"].startswith("reviews/pending/source-delta-")
+    assert (corpus_root / body["review_path"]).is_file()
+    assert body["source_path"] == "raw/sources/api-test-design.md"
+    assert (corpus_root / body["source_path"]).is_file()
+
+
+def test_ingest_missing_path_returns_400(client: TestClient) -> None:
+    response = client.post(
+        "/v1/sources/ingest",
+        json={
+            "path": "/tmp/does-not-exist-kf-source.md",
+            "source_id": "source:missing",
+            "kind": "design_doc",
+        },
+    )
+    assert response.status_code == 400

--- a/tests/test_knowledge_forge_source_ingest.py
+++ b/tests/test_knowledge_forge_source_ingest.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from orion.knowledge_forge.sources import (
+    build_source_delta_review,
+    ingest_source,
+    parse_source_markdown,
+    slug_from_source_id,
+)
+
+
+SAMPLE_DOC = """# Test Design Doc
+
+## Requirements
+
+- Knowledge Forge should track changed design docs.
+- Source ingest should propose claims, not accept them.
+- Review artifacts should be written to reviews/pending.
+
+## Non-goals
+
+- No MCP.
+- No vector search.
+
+## Acceptance checks
+
+- Dry run writes no files.
+- Write mode creates a pending review.
+"""
+
+
+def test_slug_from_source_id() -> None:
+    assert slug_from_source_id("source:test-design-doc") == "test-design-doc"
+
+
+def test_parse_source_markdown_extracts_claims() -> None:
+    parsed = parse_source_markdown(SAMPLE_DOC)
+    assert parsed.title == "Test Design Doc"
+    assert len(parsed.proposed_claims) >= 5
+    assert any("MCP" in c.text for c in parsed.proposed_claims)
+
+
+def test_build_source_delta_review_includes_human_action() -> None:
+    parsed = parse_source_markdown(SAMPLE_DOC)
+    content = build_source_delta_review(
+        source_id="source:test-design-doc",
+        source_kind="design_doc",
+        source_rel_path="raw/sources/test-design-doc.md",
+        parsed=parsed,
+        possibly_affected_specs=["spec:test:compile"],
+    )
+    assert "# Source Delta Review" in content
+    assert "## Proposed claims" in content
+    assert "- [ ]" in content
+    assert "## Human action needed" in content
+    assert "accept/reject proposed claims" in content
+    assert "spec:test:compile" in content
+
+
+def test_ingest_source_dry_run_writes_nothing(tmp_path: Path) -> None:
+    src = tmp_path / "design.md"
+    src.write_text(SAMPLE_DOC, encoding="utf-8")
+    corpus = tmp_path / "corpus"
+    (corpus / "raw" / "sources").mkdir(parents=True)
+    (corpus / "reviews" / "pending").mkdir(parents=True)
+
+    result = ingest_source(
+        corpus,
+        source_path=src,
+        source_id="source:test-design-doc",
+        kind="design_doc",
+        write_review=True,
+        dry_run=True,
+    )
+
+    assert result.review_path is None
+    assert result.source_path is None
+    assert result.content
+    assert any("dry run" in w for w in result.warnings)
+    assert list((corpus / "reviews" / "pending").glob("*.md")) == []
+    assert list((corpus / "raw" / "sources").glob("*.md")) == []
+
+
+def test_ingest_source_write_mode_only_allowed_dirs(tmp_path: Path) -> None:
+    src = tmp_path / "design.md"
+    src.write_text(SAMPLE_DOC, encoding="utf-8")
+    corpus = tmp_path / "corpus"
+    for sub in (
+        "raw/sources",
+        "reviews/pending",
+        "claims/accepted",
+        "specs/execution_ready",
+        "decisions",
+    ):
+        (corpus / sub).mkdir(parents=True)
+
+    before_claims = set((corpus / "claims" / "accepted").iterdir())
+    before_specs = set((corpus / "specs" / "execution_ready").iterdir())
+    before_decisions = set((corpus / "decisions").iterdir())
+
+    result = ingest_source(
+        corpus,
+        source_path=src,
+        source_id="source:test-design-doc",
+        kind="design_doc",
+        write_review=True,
+        dry_run=False,
+        now=datetime(2026, 5, 20, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert result.source_path == "raw/sources/test-design-doc.md"
+    assert result.review_path == "reviews/pending/source-delta-20260520T120000Z-test-design-doc.md"
+    assert (corpus / result.source_path).is_file()
+    assert (corpus / result.review_path).is_file()
+    assert (corpus / "raw" / "sources" / "source-test-design-doc.yaml").is_file()
+
+    registry = (corpus / "raw" / "sources" / "source-test-design-doc.yaml").read_text(encoding="utf-8")
+    assert "source:test-design-doc" in registry
+    assert "design_doc" in registry
+
+    review = (corpus / result.review_path).read_text(encoding="utf-8")
+    assert "## Proposed claims" in review
+    assert "## Human action needed" in review
+
+    assert set((corpus / "claims" / "accepted").iterdir()) == before_claims
+    assert set((corpus / "specs" / "execution_ready").iterdir()) == before_specs
+    assert set((corpus / "decisions").iterdir()) == before_decisions
+
+
+def test_ingest_source_missing_path_raises(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    with pytest.raises(FileNotFoundError):
+        ingest_source(
+            corpus,
+            source_path=tmp_path / "missing.md",
+            source_id="source:missing",
+            kind="design_doc",
+        )
+
+
+def test_ingest_source_invalid_kind_raises(tmp_path: Path) -> None:
+    src = tmp_path / "design.md"
+    src.write_text(SAMPLE_DOC, encoding="utf-8")
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    with pytest.raises(ValueError, match="unsupported source kind"):
+        ingest_source(
+            corpus,
+            source_path=src,
+            source_id="source:bad-kind",
+            kind="not_a_kind",
+        )


### PR DESCRIPTION
# PR: Orion Knowledge Forge — Source Delta Review v1.2

## Summary

Implements the **source-ingest → proposed delta review** spine for Knowledge Forge. Given a design doc path, Forge deterministically extracts claim candidates, registers the source under `raw/sources/`, and writes a human-review artifact to `reviews/pending/` — without mutating accepted claims, execution-ready specs, or decisions.

This is the first real HITL loop:

```text
source changed
  → ingest-source (CLI or API)
  → proposed claims/spec hints in pending review
  → human accepts/rejects later (existing review apply flow unchanged)
  → context packs compile from reviewed state
```

## Architecture

```text
design doc (path)
       ↓
orion/knowledge_forge/sources.py   parse + propose + write (allowlisted)
       ↓
CLI: python -m orion.knowledge_forge ingest-source
API: POST /v1/sources/ingest
Hub: POST /api/knowledge/sources/ingest  (proxy alias)
       ↓
orion-knowledge/raw/sources/{slug}.md
orion-knowledge/raw/sources/source-{slug}.yaml
orion-knowledge/reviews/pending/source-delta-{ts}-{slug}.md
```

**Read-only / never written by this slice:**
- `claims/accepted/`
- `specs/execution_ready/`
- `decisions/`

## Changes

| File | Change |
|------|--------|
| `orion/knowledge_forge/sources.py` | **New** — markdown parse, claim extraction, review builder, ingest orchestration, write allowlist |
| `orion/knowledge_forge/cli.py` | Add `ingest-source` subcommand |
| `services/orion-knowledge-forge/app/api_schemas.py` | `SourceIngestRequestV1`, `SourceIngestResultV1` |
| `services/orion-knowledge-forge/app/service.py` | `ingest_source()` service method |
| `services/orion-knowledge-forge/app/routers/v1.py` | `POST /v1/sources/ingest` + operator token gate on writes |
| `tests/test_knowledge_forge_source_ingest.py` | CLI/core unit + integration tests |
| `services/orion-knowledge-forge/tests/test_source_ingest_api.py` | API tests incl. write-disabled + operator token |
| `services/orion-hub/scripts/api_routes.py` | Hub proxy `POST /api/knowledge/sources/ingest` |
| `services/orion-hub/tests/test_knowledge_forge_proxy_routes.py` | Proxy alias coverage |

## New CLI

```bash
ORION_KNOWLEDGE_ROOT=$PWD/orion-knowledge \
PYTHONPATH=. python -m orion.knowledge_forge ingest-source \
  --path docs/some-design-doc.md \
  --source-id source:some-design-doc \
  --kind design_doc \
  --dry-run

ORION_KNOWLEDGE_ROOT=$PWD/orion-knowledge \
PYTHONPATH=. python -m orion.knowledge_forge ingest-source \
  --path docs/some-design-doc.md \
  --source-id source:some-design-doc \
  --kind design_doc \
  --write-review
```

CLI honors `KNOWLEDGE_FORGE_WRITE_ENABLED` (defaults to enabled when unset).

## New API

```http
POST /v1/sources/ingest
Content-Type: application/json

{
  "path": "/tmp/kf-test-design.md",
  "source_id": "source:test-design-doc",
  "kind": "design_doc",
  "write_review": true,
  "dry_run": false
}
```

Response fields: `source_id`, `status`, `source_path`, `review_path`, `proposed_claims`, `possibly_affected_specs`, `warnings`, `content`.

Write requires `KNOWLEDGE_FORGE_WRITE_ENABLED=true`. Operator token required when `KNOWLEDGE_FORGE_OPERATOR_TOKEN` is set and `write_review=true`.

## Hub proxy

Added: `POST /api/knowledge/sources/ingest` → `v1/sources/ingest` (explicit alias before catch-all).

No Hub UI panel — proxy only.

## Deterministic extractor (v1.2)

From markdown headings, extracts bullets under:
- Requirements, Decisions, Non-goals, Acceptance checks, Known traps, Implementation path

Outputs review artifact sections:
- Source / Source summary / Proposed claims (checkboxes) / Possibly affected specs / Suggested context packs / Human action needed

`possibly_affected_specs` uses lightweight keyword overlap against loaded specs (heuristic, not LLM).

## Configuration

No new env vars. Reuses existing Forge settings:

| Variable | Purpose |
|----------|---------|
| `ORION_KNOWLEDGE_ROOT` / `KNOWLEDGE_FORGE_REPO_ROOT` | Corpus root |
| `KNOWLEDGE_FORGE_WRITE_ENABLED` | Gate API/CLI writes |
| `KNOWLEDGE_FORGE_OPERATOR_TOKEN` | Gate authenticated writes |

## Test results

```bash
PYTHONPATH=. pytest tests/test_knowledge_forge_*.py -q
# 24 passed

PYTHONPATH=services/orion-knowledge-forge pytest services/orion-knowledge-forge/tests/ -q
# 21 passed

PYTHONPATH=. pytest services/orion-hub/tests/test_knowledge_forge_proxy_routes.py -q
# 3 passed
```

## Manual smoke

Dry-run (no corpus writes):

```bash
ORION_KNOWLEDGE_ROOT=$PWD/orion-knowledge \
PYTHONPATH=. python -m orion.knowledge_forge ingest-source \
  --path /tmp/kf-test-design.md \
  --source-id source:test-design-doc \
  --kind design_doc \
  --dry-run
# status=proposed, proposed_claim lines printed, no files under raw/sources or reviews/pending
```

Write mode:

```bash
ORION_KNOWLEDGE_ROOT=$PWD/orion-knowledge \
PYTHONPATH=. python -m orion.knowledge_forge ingest-source \
  --path /tmp/kf-test-design.md \
  --source-id source:test-design-doc \
  --kind design_doc \
  --write-review
# writes raw/sources/test-design-doc.md, source-test-design-doc.yaml, reviews/pending/source-delta-*.md
```

## Skipped / deferred

- LLM / frontier extraction (deterministic only)
- MCP, GraphDB, vector search, autonomous rewrite, chat ingestion
- Hub UI for source delta review
- Auto-accept of proposed claims (human review required)
- Numbered-list / `###` subsection parsing (future parser hardening)
- Source change detection / watch mode (ingest is explicit in v1.2)

## Branch

- **Worktree:** `.worktrees/feat-orion-knowledge-forge-source-delta-v1.2`
- **Branch:** `feat/orion-knowledge-forge-source-delta-v1.2`
- **Commits:** `c0c7aac7` (feature), follow-up (review hardening)

## Test plan

- [ ] CLI dry-run on a real design doc — verify no corpus mutation
- [ ] CLI `--write-review` — verify only `raw/sources/` + `reviews/pending/` change
- [ ] API dry-run with `write_review=false` — `review_path: null`, content populated
- [ ] API write with `KNOWLEDGE_FORGE_WRITE_ENABLED=true` — pending review created
- [ ] Hub proxy curl through Orion Hub when Forge running on 8630
- [ ] Existing lint/compile/ideation flows unchanged
