### PR TITLE
fix(mind,hub): set and infer mind.llm_synthesis_attempted on success

### DIFF
--- a/services/orion-hub/static/js/mind_provenance.js
+++ b/services/orion-hub/static/js/mind_provenance.js
@@ -67,13 +67,30 @@
       .filter((m) => typeof m === "string" && m.trim());
   }
 
+  const LLM_PHASE_NAMES = new Set(["semantic_synthesis", "active_frontier_judge", "stance_handoff"]);
+
+  function phaseTelemetryShowsLlmExecution(mc) {
+    return phaseTelemetryRecords(mc).some((row) => {
+      if (!row || !LLM_PHASE_NAMES.has(row.phase_name)) return false;
+      if (row.skipped) return false;
+      if (row.ok === true || row.parse_ok === true) return true;
+      const model = String(row.model || row.model_id || "").trim();
+      return Boolean(model && model !== "deterministic");
+    });
+  }
+
+  function resolveLlmAttempted(mc, llmEnabled) {
+    if (asBool(mc["mind.llm_synthesis_attempted"])) return true;
+    return llmEnabled && phaseTelemetryShowsLlmExecution(mc);
+  }
+
   function normalizeMindRunProvenance(run) {
     const resultParsed = parseMindJsonbField(run?.result_jsonb);
     const reqParsed = parseMindJsonbField(run?.request_summary_jsonb);
     const mc = machineContract(resultParsed);
     const brief = asObject(resultParsed?.brief);
     const llmEnabled = asBool(mc["mind.llm_synthesis_enabled"]);
-    const llmAttempted = asBool(mc["mind.llm_synthesis_attempted"]);
+    const llmAttempted = resolveLlmAttempted(mc, llmEnabled);
     const failOpenToDeterministic = asBool(mc["mind.llm_fail_open_to_deterministic"]);
     const orchHttpFailed = asBool(mc["mind.orch_http_failed"]);
     const failedPhase = mc["mind.llm_synthesis_failed_phase"] || null;

--- a/services/orion-hub/tests/test_mind_provenance_normalizer.py
+++ b/services/orion-hub/tests/test_mind_provenance_normalizer.py
@@ -111,6 +111,48 @@ console.log(JSON.stringify({{
     assert out["no_derailment_card"] is True
 
 
+def test_success_without_attempted_flag_infers_llm_synthesis() -> None:
+    """Historical runs may omit mind.llm_synthesis_attempted on the success path."""
+    out = _run_node(
+        f"""
+const fs = require('fs');
+const src = fs.readFileSync({json.dumps(str(MIND_PROVENANCE_JS))}, 'utf8');
+eval(src);
+const run = {{
+  ok: true,
+  result_jsonb: {{
+    ok: true,
+    mind_quality: "meaningful_synthesis",
+    brief: {{
+      mind_quality: "meaningful_synthesis",
+      mind_authorized_for_stance_skip: true,
+      machine_contract: {{
+        "mind.llm_synthesis_enabled": true,
+        "mind.quality": "meaningful_synthesis",
+        "mind.authorized_for_stance_skip": true,
+        "mind.authorized_for_stance_use": true,
+        "mind.phase_telemetry": [
+          {{ phase_name: "semantic_synthesis", route: "quick", ok: true, parse_ok: true, validation_ok: true, elapsed_ms: 1504 }},
+          {{ phase_name: "active_frontier_judge", route: "metacog", ok: true, parse_ok: true, validation_ok: true, elapsed_ms: 3470 }},
+          {{ phase_name: "stance_handoff", route: "chat", ok: true, parse_ok: true, validation_ok: true, elapsed_ms: 4282 }},
+        ],
+      }},
+    }},
+  }},
+}};
+const prov = OrionMindProvenance.normalizeMindRunProvenance(run);
+console.log(JSON.stringify({{
+  cognition_path: prov.cognition_path,
+  llm_attempted: prov.llm_attempted,
+  final_source: prov.final_source,
+}}));
+"""
+    )
+    assert out["cognition_path"] == "llm_synthesis"
+    assert out["llm_attempted"] is True
+    assert out["final_source"] == "mind_llm_handoff"
+
+
 def test_success_fixture_renders_brief_item_cards() -> None:
     out = _run_node(
         f"""

--- a/services/orion-mind/app/engine.py
+++ b/services/orion-mind/app/engine.py
@@ -663,6 +663,7 @@ def _llm_machine_contract(
         "mind.shadow_synthesis_present": shadow_synthesis is not None,
         "mind.authorized_for_stance_skip": bool(handoff.authorized_for_stance_use) if handoff else False,
         "mind.llm_synthesis_enabled": llm_enabled,
+        "mind.llm_synthesis_attempted": bool(llm_enabled),
         "mind.semantic_synthesis_seen": synthesis is not None,
         "mind.semantic_claim_count": len(synthesis.claims) if synthesis else 0,
         "mind.semantic_claim_labels": claim_labels,

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -222,6 +222,7 @@ def test_mocked_mind_run_returns_meaningful_synthesis(monkeypatch: pytest.Monkey
     assert result.mind_quality == "meaningful_synthesis"
     assert result.brief.mind_authorized_for_stance_skip is True
     assert result.brief.machine_contract.get("mind.authorized_for_stance_use") is True
+    assert result.brief.machine_contract.get("mind.llm_synthesis_attempted") is True
 
 
 def test_llm_failure_falls_back_to_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
PR description (paste into the body)

Summary
orion-mind: Emit mind.llm_synthesis_attempted: true on successful LLM synthesis runs (fail-open already set this; the success path did not).
orion-hub: When the flag is missing on older runs, infer LLM attempted from non-skipped phase telemetry (semantic_synthesis, active_frontier_judge, stance_handoff with ok/parse_ok), so Cognition path resolves to llm_synthesis instead of unknown.
Fixes the Hub Mind run modal showing LLM attempted: no and Cognition path: unknown for healthy meaningful_synthesis runs where all three LLM phases completed successfully.

Test plan

 Hub: test_success_without_attempted_flag_infers_llm_synthesis (node fixture matching historical success payloads)

 Hub: existing test_success_fixture_normalizer still passes

 Mind: test_mocked_mind_run_returns_meaningful_synthesis asserts mind.llm_synthesis_attempted

 Manual: open existing Mind run in Hub → provenance chips show llm_synthesis / LLM attempted: yes

 Manual: one new brain chat_general turn → new run persists mind.llm_synthesis_attempted from Mind