### PR TITLE
Fix/hub source delta UI

### DIFF
--- a/docs/PR-fix-hub-source-delta-ui.md
+++ b/docs/PR-fix-hub-source-delta-ui.md
@@ -1,0 +1,122 @@
+# PR: Hub Forge — Source Delta Review UI (fix)
+
+## Summary
+
+Fixes the Hub **Source Delta Review** panel that was missing at runtime despite PR #598 merging the Knowledge Forge ingest API and Hub proxy.
+
+**Root cause:** PR #598 (`feat/orion-knowledge-forge-source-delta-v1.2`) shipped backend + `POST /api/knowledge/sources/ingest` proxy only. The Hub template and `app.js` wiring lived on a separate branch (`feat-orion-knowledge-forge-hub-source-delta-v1.2b`) that was never merged. Runtime diagnosis confirmed:
+
+| Check | Result |
+|-------|--------|
+| Repo `api_routes.py` proxy | Present |
+| Running container proxy | Present |
+| Repo `index.html` / `app.js` panel | **Missing on main** |
+| Running container template/JS | **Missing** |
+| `curl http://127.0.0.1:8080/` before fix | No `Source Delta Review` |
+| Docker image stale? | **No** — code was never on main |
+| Browser cache? | **No** — HTML never contained panel |
+
+## Architecture
+
+```text
+Hub Forge tab (#forge)
+  Source Delta Review panel (template + app.js)  ← this PR
+       ↓ POST /api/knowledge/sources/ingest
+  Hub proxy (already on main from #598)
+       ↓ POST /v1/sources/ingest
+  Knowledge Forge service (already on main)
+```
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `services/orion-hub/templates/index.html` | Source Delta Review panel (fields, safety copy, result area, debug JSON) |
+| `services/orion-hub/static/js/app.js` | DOM refs, `runForgeSourceIngest`, validation, render, click handler, `escapeHtml` on lists |
+| `services/orion-hub/tests/test_forge_hub_tab.py` | Assertions for panel markup and JS wiring |
+
+**Branch:** `fix/hub-source-delta-ui`  
+**Worktree:** `.worktrees/fix-hub-source-delta-ui`
+
+## Commits
+
+1. `903507a0` — fix(hub): wire Source Delta Review panel on Forge tab  
+2. `d268b3b5` — fix(hub): escape source ingest list HTML and restore Forge subtitle  
+
+## Verification
+
+### Runtime (Athena)
+
+```bash
+# Panel in served HTML (after template sync + hub restart)
+curl -s http://127.0.0.1:8080/ | grep -n "Source Delta Review\|forgeSourceIngestButton"
+
+# Direct Forge API (use /repo path inside containers)
+curl -s -X POST http://127.0.0.1:8630/v1/sources/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"path":"/repo/docs/PR-orion-knowledge-forge-source-delta-v1.2.md","source_id":"source:hub-source-delta-test","kind":"design_doc","write_review":false,"dry_run":true}'
+
+# Hub proxy
+curl -s -X POST http://127.0.0.1:8080/api/knowledge/sources/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"path":"/repo/docs/PR-orion-knowledge-forge-source-delta-v1.2.md","source_id":"source:hub-source-delta-test","kind":"design_doc","write_review":false,"dry_run":true}'
+```
+
+**Results:** Both APIs return `status: proposed`, `content` with `# Source Delta Review`, warnings `preview only: write_review is false`. HTML includes panel after fix.
+
+**Note:** `/tmp/...` paths fail with `source path not found` — Forge/Hub containers see host paths via `/repo` mount, not arbitrary `/tmp`.
+
+### Tests
+
+```bash
+docker exec orion-athena-hub sh -lc \
+  'cd /repo && PYTHONPATH=/repo:/repo/services/orion-hub python3 -m pytest \
+   services/orion-hub/tests/test_forge_hub_tab.py \
+   services/orion-hub/tests/test_knowledge_forge_proxy_routes.py -q'
+```
+
+**Result:** `5 passed`
+
+### Hub live reload
+
+Hub `docker-compose.yml` bind-mounts `./templates` and `./static` from `services/orion-hub/`. After merging, either:
+
+- Copy/sync updated files into the mounted paths and restart `orion-athena-hub`, or  
+- Rebuild: `cd services/orion-hub && docker compose build --no-cache hub-app && docker compose up -d hub-app`
+
+`HUB_UI_ASSET_VERSION` cache-busts `app.js` on each Hub process start — no manual version bump required.
+
+## Acceptance criteria
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | `#forge` shows Source Delta Review panel | ✅ |
+| 2 | Dry-run from Hub returns proposed claims/content preview | ✅ (via API; UI wired) |
+| 3 | Hub calls `/api/knowledge/sources/ingest` | ✅ |
+| 4 | API/proxy smoke works with curl | ✅ |
+| 5 | UI handles write-disabled warning cleanly | ✅ (403 / message pattern) |
+| 6 | Write + writable mount creates pending review | ✅ (existing backend; UI refreshes tab) |
+| 7 | Pending review count refreshes after write | ✅ `refreshForgeTab()` |
+| 8 | No accepted claims/specs/decisions mutated | ✅ (backend allowlist unchanged) |
+| 9 | Tests pass | ✅ Hub tab + proxy tests |
+
+## Code review
+
+Subagent review: **APPROVED**. Addressed minor items:
+
+- `escapeHtml()` on proposed-claims and warnings lists  
+- Restored Forge subtitle: “Source ingest, claims, specs…”  
+
+**Deferred (known):** Operator token header for write mode when `KNOWLEDGE_FORGE_OPERATOR_TOKEN` is set — same as v1.2b non-goals.
+
+## Non-goals
+
+Unchanged — no MCP, GraphDB, vectors, auto-accept, file watcher, or ideation panel.
+
+## Test plan (manual)
+
+1. Open Hub → **Forge** tab → confirm **Source Delta Review** panel (teal block, above Search).
+2. Enter path `docs/PR-orion-knowledge-forge-source-delta-v1.2.md`, ID `source:hub-manual-test`, kind `design_doc`, **Dry run** checked → **Ingest Source**.
+3. Confirm result: status, content preview, warnings.
+4. Uncheck dry run, check **Write pending review** (requires `KNOWLEDGE_FORGE_WRITE_ENABLED=true` on Forge) → ingest → pending reviews count updates.
+5. Hard refresh if an old tab was open (unlikely; panel was absent from HTML).

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -2287,7 +2287,7 @@ loadDismissedIds();
     if (forgeSourceIngestWarnings) {
       if (warnings.length) {
         forgeSourceIngestWarnings.classList.remove("hidden");
-        forgeSourceIngestWarnings.innerHTML = warnings.map((w) => `<li>${w}</li>`).join("");
+        forgeSourceIngestWarnings.innerHTML = warnings.map((w) => `<li>${escapeHtml(w)}</li>`).join("");
       } else {
         forgeSourceIngestWarnings.classList.add("hidden");
         forgeSourceIngestWarnings.innerHTML = "";

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -596,6 +596,24 @@ loadDismissedIds();
   const forgeDebugStatus = document.getElementById("forgeDebugStatus");
   const forgeDebugSearch = document.getElementById("forgeDebugSearch");
   const forgeDebugCompile = document.getElementById("forgeDebugCompile");
+  const forgeSourcePath = document.getElementById("forgeSourcePath");
+  const forgeSourceId = document.getElementById("forgeSourceId");
+  const forgeSourceKind = document.getElementById("forgeSourceKind");
+  const forgeSourceDryRun = document.getElementById("forgeSourceDryRun");
+  const forgeSourceWriteReview = document.getElementById("forgeSourceWriteReview");
+  const forgeSourceIngestButton = document.getElementById("forgeSourceIngestButton");
+  const forgeSourceIngestResult = document.getElementById("forgeSourceIngestResult");
+  const forgeSourceIngestStatus = document.getElementById("forgeSourceIngestStatus");
+  const forgeSourceIngestSourceId = document.getElementById("forgeSourceIngestSourceId");
+  const forgeSourceIngestSourcePath = document.getElementById("forgeSourceIngestSourcePath");
+  const forgeSourceIngestReviewPath = document.getElementById("forgeSourceIngestReviewPath");
+  const forgeSourceIngestClaimsCount = document.getElementById("forgeSourceIngestClaimsCount");
+  const forgeSourceIngestClaimsList = document.getElementById("forgeSourceIngestClaimsList");
+  const forgeSourceIngestAffectedSpecs = document.getElementById("forgeSourceIngestAffectedSpecs");
+  const forgeSourceIngestWarnings = document.getElementById("forgeSourceIngestWarnings");
+  const forgeSourceIngestContentPreview = document.getElementById("forgeSourceIngestContentPreview");
+  const forgeSourceIngestError = document.getElementById("forgeSourceIngestError");
+  const forgeDebugSourceIngest = document.getElementById("forgeDebugSourceIngest");
   const signalsTabButton = document.getElementById("signalsTabButton");
   const signalsPanel = document.getElementById("signals");
   const mindHoursInput = document.getElementById("mindHoursInput");
@@ -1876,6 +1894,7 @@ loadDismissedIds();
   let forgeStatusCache = null;
   let forgeSearchCache = null;
   let forgeCompileCache = null;
+  let forgeSourceIngestCache = null;
 
   async function knowledgeForgeFetch(path, options = {}) {
     const response = await fetch(`${KNOWLEDGE_PROXY_BASE}${path}`, {
@@ -2214,6 +2233,141 @@ loadDismissedIds();
         forgeSearchResults.innerHTML = `<p class="text-rose-300">Search failed: ${error?.message || error}</p>`;
       }
       if (forgeStatus) forgeStatus.textContent = `Search failed: ${error?.message || error}`;
+    }
+  }
+
+  function forgeHideSourceIngestError() {
+    if (forgeSourceIngestError) {
+      forgeSourceIngestError.classList.add("hidden");
+      forgeSourceIngestError.textContent = "";
+    }
+  }
+
+  function forgeShowSourceIngestError(message) {
+    if (forgeSourceIngestError) {
+      forgeSourceIngestError.textContent = message;
+      forgeSourceIngestError.classList.remove("hidden");
+    }
+    if (forgeSourceIngestResult) forgeSourceIngestResult.classList.add("hidden");
+  }
+
+  function forgeRenderSourceIngestResult(body) {
+    if (!forgeSourceIngestResult) return;
+    if (!body) {
+      forgeSourceIngestResult.classList.add("hidden");
+      return;
+    }
+    forgeSourceIngestResult.classList.remove("hidden");
+    if (forgeSourceIngestStatus) forgeSourceIngestStatus.textContent = body.status || "—";
+    if (forgeSourceIngestSourceId) forgeSourceIngestSourceId.textContent = body.source_id || "—";
+    if (forgeSourceIngestSourcePath) {
+      forgeSourceIngestSourcePath.textContent = body.source_path || "(not written)";
+    }
+    if (forgeSourceIngestReviewPath) {
+      forgeSourceIngestReviewPath.textContent = body.review_path || "(not written)";
+    }
+    const claims = Array.isArray(body.proposed_claims) ? body.proposed_claims : [];
+    if (forgeSourceIngestClaimsCount) {
+      forgeSourceIngestClaimsCount.textContent = String(claims.length);
+    }
+    if (forgeSourceIngestClaimsList) {
+      if (claims.length) {
+        forgeSourceIngestClaimsList.classList.remove("hidden");
+        forgeSourceIngestClaimsList.innerHTML = claims.map((c) => `<li>${c}</li>`).join("");
+      } else {
+        forgeSourceIngestClaimsList.classList.add("hidden");
+        forgeSourceIngestClaimsList.innerHTML = "";
+      }
+    }
+    const specs = Array.isArray(body.possibly_affected_specs) ? body.possibly_affected_specs : [];
+    if (forgeSourceIngestAffectedSpecs) {
+      forgeSourceIngestAffectedSpecs.textContent = specs.length ? specs.join(", ") : "—";
+    }
+    const warnings = Array.isArray(body.warnings) ? body.warnings : [];
+    if (forgeSourceIngestWarnings) {
+      if (warnings.length) {
+        forgeSourceIngestWarnings.classList.remove("hidden");
+        forgeSourceIngestWarnings.innerHTML = warnings.map((w) => `<li>${w}</li>`).join("");
+      } else {
+        forgeSourceIngestWarnings.classList.add("hidden");
+        forgeSourceIngestWarnings.innerHTML = "";
+      }
+    }
+    if (forgeSourceIngestContentPreview) {
+      forgeSourceIngestContentPreview.textContent = body.content || "";
+    }
+    forgeSetDebugPre(forgeDebugSourceIngest, body);
+  }
+
+  function forgeValidateSourceIngestInputs() {
+    const path = (forgeSourcePath?.value || "").trim();
+    const sourceId = (forgeSourceId?.value || "").trim();
+    if (!path) {
+      return { ok: false, message: "Enter a source path." };
+    }
+    if (!sourceId) {
+      return { ok: false, message: "Enter a source ID (e.g. source:my-design-doc)." };
+    }
+    if (!/^source:[a-z0-9][a-z0-9._-]*$/i.test(sourceId)) {
+      return {
+        ok: false,
+        message: "Invalid source ID. Use format source:slug (letters, numbers, dots, hyphens, underscores).",
+      };
+    }
+    return { ok: true, path, sourceId };
+  }
+
+  async function runForgeSourceIngest() {
+    forgeHideSourceIngestError();
+    const validation = forgeValidateSourceIngestInputs();
+    if (!validation.ok) {
+      forgeShowSourceIngestError(validation.message);
+      showToastText(validation.message);
+      return;
+    }
+    const payload = {
+      path: validation.path,
+      source_id: validation.sourceId,
+      kind: forgeSourceKind?.value || "design_doc",
+      dry_run: Boolean(forgeSourceDryRun?.checked),
+      write_review: Boolean(forgeSourceWriteReview?.checked),
+    };
+    if (forgeSourceIngestButton) forgeSourceIngestButton.disabled = true;
+    if (forgeStatus) forgeStatus.textContent = "Ingesting source…";
+    try {
+      const body = await knowledgeForgeFetch("/sources/ingest", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      forgeSourceIngestCache = body;
+      forgeRenderSourceIngestResult(body);
+      const claimCount = Array.isArray(body?.proposed_claims) ? body.proposed_claims.length : 0;
+      if (forgeStatus) {
+        forgeStatus.textContent = `Source ingest ${body?.status || "done"} · ${claimCount} proposed claim(s).`;
+      }
+      showToastText(`Source ingest ${body?.status || "complete"}.`);
+      if (payload.write_review && !payload.dry_run) {
+        await refreshForgeTab();
+      }
+    } catch (error) {
+      forgeSourceIngestCache = { error: error?.message || String(error), body: error?.body };
+      forgeSetDebugPre(forgeDebugSourceIngest, forgeSourceIngestCache);
+      forgeRenderSourceIngestResult(null);
+      const msg = error?.message || String(error);
+      const status = error?.status;
+      let display = msg;
+      if (status === 403 || /write.*disabled/i.test(msg)) {
+        display = `Write disabled: ${msg}. Enable KNOWLEDGE_FORGE_WRITE_ENABLED on the Forge service.`;
+      } else if (status === 502 || status === 503 || /unreachable|not configured/i.test(msg)) {
+        display = `Knowledge Forge unavailable: ${msg}`;
+      } else if (status === 422 || status === 400) {
+        display = `Validation error: ${msg}`;
+      }
+      forgeShowSourceIngestError(display);
+      if (forgeStatus) forgeStatus.textContent = `Source ingest failed: ${msg}`;
+      showToastText(`Source ingest failed: ${msg}`);
+    } finally {
+      if (forgeSourceIngestButton) forgeSourceIngestButton.disabled = false;
     }
   }
 
@@ -10938,6 +11092,9 @@ loadDismissedIds();
   }
   if (forgeCompileButton) {
     forgeCompileButton.addEventListener("click", () => runForgeCompile());
+  }
+  if (forgeSourceIngestButton) {
+    forgeSourceIngestButton.addEventListener("click", () => runForgeSourceIngest());
   }
 
   if (tsDatasetSelect) {

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -2273,7 +2273,7 @@ loadDismissedIds();
     if (forgeSourceIngestClaimsList) {
       if (claims.length) {
         forgeSourceIngestClaimsList.classList.remove("hidden");
-        forgeSourceIngestClaimsList.innerHTML = claims.map((c) => `<li>${c}</li>`).join("");
+        forgeSourceIngestClaimsList.innerHTML = claims.map((c) => `<li>${escapeHtml(c)}</li>`).join("");
       } else {
         forgeSourceIngestClaimsList.classList.add("hidden");
         forgeSourceIngestClaimsList.innerHTML = "";

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -1028,7 +1028,7 @@
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 class="text-xl font-bold text-white">Knowledge Forge</h2>
-            <p class="text-xs text-gray-400">Claims, specs, reviews, and context-pack compiler via Hub <code class="text-gray-500">/api/knowledge</code>.</p>
+            <p class="text-xs text-gray-400">Source ingest, claims, specs, reviews, and context-pack compiler via Hub <code class="text-gray-500">/api/knowledge</code>.</p>
           </div>
           <button type="button" id="forgeRefreshButton" class="px-2 py-1 text-xs rounded border border-gray-600 bg-gray-800 text-gray-200 hover:bg-gray-700">Refresh</button>
         </div>

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -1055,6 +1055,52 @@
           <p id="forgeSuggestedAction" class="text-xs text-gray-300">—</p>
         </div>
 
+        <div class="rounded-xl border border-teal-900/60 bg-teal-950/20 p-4 flex flex-col gap-3">
+          <span class="text-sm font-semibold text-teal-100">Source Delta Review</span>
+          <p class="text-xs text-gray-400">Ingest a design doc or note; Forge proposes claim deltas as a pending review (no canonical mutation).</p>
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-3 text-xs">
+            <label class="flex flex-col gap-1 text-gray-400">
+              Source path
+              <input id="forgeSourcePath" type="text" class="bg-gray-800 text-gray-200 border border-gray-700 rounded px-2 py-1 font-mono text-[11px]" placeholder="docs/PR-orion-knowledge-forge-source-delta-v1.2.md" />
+            </label>
+            <label class="flex flex-col gap-1 text-gray-400">
+              Source ID
+              <input id="forgeSourceId" type="text" class="bg-gray-800 text-gray-200 border border-gray-700 rounded px-2 py-1 font-mono text-[11px]" placeholder="source:my-design-doc" />
+            </label>
+            <label class="flex flex-col gap-1 text-gray-400">
+              Kind
+              <select id="forgeSourceKind" class="bg-gray-800 text-gray-200 border border-gray-700 rounded px-2 py-1">
+                <option value="design_doc" selected>design_doc</option>
+                <option value="conversation">conversation</option>
+                <option value="pr_note">pr_note</option>
+                <option value="research_note">research_note</option>
+                <option value="other">other</option>
+              </select>
+            </label>
+            <div class="flex flex-wrap items-end gap-4 text-gray-300">
+              <label class="inline-flex items-center gap-2"><input id="forgeSourceDryRun" type="checkbox" checked class="rounded border border-gray-600 bg-gray-800" /> Dry run</label>
+              <label class="inline-flex items-center gap-2"><input id="forgeSourceWriteReview" type="checkbox" class="rounded border border-gray-600 bg-gray-800" /> Write pending review</label>
+            </div>
+          </div>
+          <p class="text-[11px] text-amber-200/80">Source ingest creates pending review artifacts. It does not mutate accepted claims, execution-ready specs, or decisions.</p>
+          <button type="button" id="forgeSourceIngestButton" class="self-start px-3 py-1.5 text-xs font-semibold rounded border border-teal-600 bg-teal-700 text-white hover:bg-teal-600">Ingest Source</button>
+          <div id="forgeSourceIngestResult" class="text-xs text-gray-300 space-y-2 hidden">
+            <div><span class="text-gray-500">Status:</span> <span id="forgeSourceIngestStatus" class="text-gray-200">—</span></div>
+            <div><span class="text-gray-500">Source ID:</span> <span id="forgeSourceIngestSourceId" class="font-mono text-gray-200">—</span></div>
+            <div><span class="text-gray-500">Source path:</span> <span id="forgeSourceIngestSourcePath" class="font-mono text-gray-200 break-all">—</span></div>
+            <div><span class="text-gray-500">Review path:</span> <span id="forgeSourceIngestReviewPath" class="font-mono text-gray-200 break-all">—</span></div>
+            <div><span class="text-gray-500">Proposed claims:</span> <span id="forgeSourceIngestClaimsCount" class="text-gray-200">—</span></div>
+            <ul id="forgeSourceIngestClaimsList" class="text-[11px] text-gray-400 list-disc list-inside max-h-32 overflow-auto hidden"></ul>
+            <div><span class="text-gray-500">Possibly affected specs:</span> <span id="forgeSourceIngestAffectedSpecs" class="text-gray-200">—</span></div>
+            <ul id="forgeSourceIngestWarnings" class="text-amber-200/90 list-disc list-inside hidden"></ul>
+            <details class="rounded border border-gray-700 bg-gray-950/50 p-2">
+              <summary class="cursor-pointer text-gray-400 hover:text-gray-200">Review content preview</summary>
+              <pre id="forgeSourceIngestContentPreview" class="mt-2 text-[10px] leading-relaxed text-gray-300 whitespace-pre-wrap font-mono max-h-64 overflow-auto"></pre>
+            </details>
+          </div>
+          <p id="forgeSourceIngestError" class="text-xs text-rose-300 hidden"></p>
+        </div>
+
         <div class="rounded-xl border border-gray-800 bg-gray-950/40 p-3 flex flex-col gap-2">
           <div class="text-[10px] uppercase tracking-wide text-gray-500">Search</div>
           <div class="flex flex-wrap items-center gap-2">
@@ -1141,6 +1187,7 @@
             <details><summary class="text-gray-500">Status</summary><pre id="forgeDebugStatus" class="mt-1 text-[10px] font-mono text-gray-400 overflow-auto max-h-40"></pre></details>
             <details><summary class="text-gray-500">Search</summary><pre id="forgeDebugSearch" class="mt-1 text-[10px] font-mono text-gray-400 overflow-auto max-h-40"></pre></details>
             <details><summary class="text-gray-500">Compile</summary><pre id="forgeDebugCompile" class="mt-1 text-[10px] font-mono text-gray-400 overflow-auto max-h-40"></pre></details>
+            <details><summary class="text-gray-500">Source ingest</summary><pre id="forgeDebugSourceIngest" class="mt-1 text-[10px] font-mono text-gray-400 overflow-auto max-h-40"></pre></details>
           </div>
         </details>
       </section>

--- a/services/orion-hub/tests/test_forge_hub_tab.py
+++ b/services/orion-hub/tests/test_forge_hub_tab.py
@@ -31,6 +31,17 @@ def test_index_has_forge_tab_and_panel() -> None:
     assert 'id="forgeCompileTask"' in index_html
     assert 'id="forgeCompileButton"' in index_html
     assert 'id="forgeDebugDetails"' in index_html
+    assert "Source Delta Review" in index_html
+    assert 'id="forgeSourcePath"' in index_html
+    assert 'id="forgeSourceId"' in index_html
+    assert 'id="forgeSourceKind"' in index_html
+    assert 'id="forgeSourceDryRun"' in index_html
+    assert 'id="forgeSourceWriteReview"' in index_html
+    assert 'id="forgeSourceIngestButton"' in index_html
+    assert 'id="forgeSourceIngestResult"' in index_html
+    assert 'id="forgeSourceIngestError"' in index_html
+    assert "does not mutate accepted claims" in index_html
+    assert 'value="docs/PR-orion-knowledge-forge-source-delta-v1.2.md"' not in index_html
 
 
 def test_app_js_wires_forge_hash_and_knowledge_api() -> None:
@@ -47,3 +58,8 @@ def test_app_js_wires_forge_hash_and_knowledge_api() -> None:
     assert "context-packs/compile" in app_js
     assert "runForgeSearch" in app_js
     assert "runForgeCompile" in app_js
+    assert "runForgeSourceIngest" in app_js
+    assert "/sources/ingest" in app_js
+    assert "forgeRenderSourceIngestResult" in app_js
+    assert "forgeSourceIngestContentPreview" in app_js
+    assert "forgeDebugSourceIngest" in app_js


### PR DESCRIPTION
# PR: Hub Forge — Source Delta Review UI (fix)

## Summary

Fixes the Hub **Source Delta Review** panel that was missing at runtime despite PR #598 merging the Knowledge Forge ingest API and Hub proxy.

**Root cause:** PR #598 (`feat/orion-knowledge-forge-source-delta-v1.2`) shipped backend + `POST /api/knowledge/sources/ingest` proxy only. The Hub template and `app.js` wiring lived on a separate branch (`feat-orion-knowledge-forge-hub-source-delta-v1.2b`) that was never merged. Runtime diagnosis confirmed:

| Check | Result |
|-------|--------|
| Repo `api_routes.py` proxy | Present |
| Running container proxy | Present |
| Repo `index.html` / `app.js` panel | **Missing on main** |
| Running container template/JS | **Missing** |
| `curl http://127.0.0.1:8080/` before fix | No `Source Delta Review` |
| Docker image stale? | **No** — code was never on main |
| Browser cache? | **No** — HTML never contained panel |

## Architecture

```text
Hub Forge tab (#forge)
  Source Delta Review panel (template + app.js)  ← this PR
       ↓ POST /api/knowledge/sources/ingest
  Hub proxy (already on main from #598)
       ↓ POST /v1/sources/ingest
  Knowledge Forge service (already on main)
```

## Changes

| File | Change |
|------|--------|
| `services/orion-hub/templates/index.html` | Source Delta Review panel (fields, safety copy, result area, debug JSON) |
| `services/orion-hub/static/js/app.js` | DOM refs, `runForgeSourceIngest`, validation, render, click handler, `escapeHtml` on lists |
| `services/orion-hub/tests/test_forge_hub_tab.py` | Assertions for panel markup and JS wiring |

**Branch:** `fix/hub-source-delta-ui`  
**Worktree:** `.worktrees/fix-hub-source-delta-ui`

## Commits

1. `903507a0` — fix(hub): wire Source Delta Review panel on Forge tab  
2. `d268b3b5` — fix(hub): escape source ingest list HTML and restore Forge subtitle  

## Verification

### Runtime (Athena)

```bash
# Panel in served HTML (after template sync + hub restart)
curl -s http://127.0.0.1:8080/ | grep -n "Source Delta Review\|forgeSourceIngestButton"

# Direct Forge API (use /repo path inside containers)
curl -s -X POST http://127.0.0.1:8630/v1/sources/ingest \
  -H "Content-Type: application/json" \
  -d '{"path":"/repo/docs/PR-orion-knowledge-forge-source-delta-v1.2.md","source_id":"source:hub-source-delta-test","kind":"design_doc","write_review":false,"dry_run":true}'

# Hub proxy
curl -s -X POST http://127.0.0.1:8080/api/knowledge/sources/ingest \
  -H "Content-Type: application/json" \
  -d '{"path":"/repo/docs/PR-orion-knowledge-forge-source-delta-v1.2.md","source_id":"source:hub-source-delta-test","kind":"design_doc","write_review":false,"dry_run":true}'
```

**Results:** Both APIs return `status: proposed`, `content` with `# Source Delta Review`, warnings `preview only: write_review is false`. HTML includes panel after fix.

**Note:** `/tmp/...` paths fail with `source path not found` — Forge/Hub containers see host paths via `/repo` mount, not arbitrary `/tmp`.

### Tests

```bash
docker exec orion-athena-hub sh -lc \
  'cd /repo && PYTHONPATH=/repo:/repo/services/orion-hub python3 -m pytest \
   services/orion-hub/tests/test_forge_hub_tab.py \
   services/orion-hub/tests/test_knowledge_forge_proxy_routes.py -q'
```

**Result:** `5 passed`

### Hub live reload

Hub `docker-compose.yml` bind-mounts `./templates` and `./static` from `services/orion-hub/`. After merging, either:

- Copy/sync updated files into the mounted paths and restart `orion-athena-hub`, or  
- Rebuild: `cd services/orion-hub && docker compose build --no-cache hub-app && docker compose up -d hub-app`

`HUB_UI_ASSET_VERSION` cache-busts `app.js` on each Hub process start — no manual version bump required.

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `#forge` shows Source Delta Review panel | ✅ |
| 2 | Dry-run from Hub returns proposed claims/content preview | ✅ (via API; UI wired) |
| 3 | Hub calls `/api/knowledge/sources/ingest` | ✅ |
| 4 | API/proxy smoke works with curl | ✅ |
| 5 | UI handles write-disabled warning cleanly | ✅ (403 / message pattern) |
| 6 | Write + writable mount creates pending review | ✅ (existing backend; UI refreshes tab) |
| 7 | Pending review count refreshes after write | ✅ `refreshForgeTab()` |
| 8 | No accepted claims/specs/decisions mutated | ✅ (backend allowlist unchanged) |
| 9 | Tests pass | ✅ Hub tab + proxy tests |

## Code review

Subagent review: **APPROVED**. Addressed minor items:

- `escapeHtml()` on proposed-claims and warnings lists  
- Restored Forge subtitle: “Source ingest, claims, specs…”  

**Deferred (known):** Operator token header for write mode when `KNOWLEDGE_FORGE_OPERATOR_TOKEN` is set — same as v1.2b non-goals.

## Non-goals

Unchanged — no MCP, GraphDB, vectors, auto-accept, file watcher, or ideation panel.

## Test plan (manual)

1. Open Hub → **Forge** tab → confirm **Source Delta Review** panel (teal block, above Search).
2. Enter path `docs/PR-orion-knowledge-forge-source-delta-v1.2.md`, ID `source:hub-manual-test`, kind `design_doc`, **Dry run** checked → **Ingest Source**.
3. Confirm result: status, content preview, warnings.
4. Uncheck dry run, check **Write pending review** (requires `KNOWLEDGE_FORGE_WRITE_ENABLED=true` on Forge) → ingest → pending reviews count updates.
5. Hard refresh if an old tab was open (unlikely; panel was absent from HTML).
