### PR TITLE
fix(autonomy): dedupe merged goals and honest Hub debug section title

### DIFF
--- a/orion/autonomy/summary.py
+++ b/orion/autonomy/summary.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Mapping
 
 from orion.autonomy.models import (
     AutonomyActiveGoalV1,
+    AutonomyGoalHeadlineV1,
     AutonomyStateQuality,
     AutonomyStateV1,
     AutonomyStateV2,
@@ -183,9 +184,29 @@ def _derive_context_note(
     return None
 
 
+def dedupe_goal_headlines_by_drive_origin(
+    goals: list[AutonomyGoalHeadlineV1],
+    *,
+    limit: int = 3,
+) -> list[AutonomyGoalHeadlineV1]:
+    """Keep highest-priority goal per drive_origin (matches repository active-goal read path)."""
+    ranked = sorted(goals, key=lambda goal: (-float(goal.priority), goal.artifact_id))
+    seen_origins: set[str] = set()
+    out: list[AutonomyGoalHeadlineV1] = []
+    for goal in ranked:
+        origin = str(goal.drive_origin or "").strip().lower()
+        if not origin or origin in seen_origins:
+            continue
+        seen_origins.add(origin)
+        out.append(goal)
+        if len(out) >= limit:
+            break
+    return out
+
+
 def _active_goals_from_state(state: AutonomyStateV1 | AutonomyStateV2) -> list[AutonomyActiveGoalV1]:
     out: list[AutonomyActiveGoalV1] = []
-    for goal in state.goal_headlines[:3]:
+    for goal in dedupe_goal_headlines_by_drive_origin(state.goal_headlines, limit=3):
         headline = _proposal_headline_for_display(goal.goal_statement)
         if not headline:
             continue
@@ -300,7 +321,10 @@ def summarize_autonomy_state(state: AutonomyStateV1 | AutonomyStateV2 | None) ->
         tension_sources.append(_PRESSURE_COMPETITION_KIND)
     active_tensions = _bounded_unique(tension_sources, limit=3)
     proposal_headlines = _bounded_unique(
-        [_proposal_headline_for_display(goal.goal_statement) for goal in state.goal_headlines],
+        [
+            _proposal_headline_for_display(goal.goal_statement)
+            for goal in dedupe_goal_headlines_by_drive_origin(state.goal_headlines, limit=3)
+        ],
         limit=3,
     )
     if isinstance(state, AutonomyStateV2) and not state.goal_headlines and state.attention_items:

--- a/orion/autonomy/tests/test_goal_headline_dedupe.py
+++ b/orion/autonomy/tests/test_goal_headline_dedupe.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from orion.autonomy.models import AutonomyGoalHeadlineV1
+from orion.autonomy.summary import dedupe_goal_headlines_by_drive_origin
+
+
+def _goal(artifact_id: str, drive_origin: str, priority: float) -> AutonomyGoalHeadlineV1:
+    return AutonomyGoalHeadlineV1(
+        artifact_id=artifact_id,
+        goal_statement=f"Goal for {drive_origin}",
+        drive_origin=drive_origin,
+        priority=priority,
+        proposal_signature=artifact_id,
+    )
+
+
+def test_dedupe_goal_headlines_keeps_highest_priority_per_drive_origin() -> None:
+    goals = [
+        _goal("goal-high", "autonomy", 0.9),
+        _goal("goal-low", "autonomy", 0.1),
+        _goal("goal-cont", "continuity", 0.5),
+    ]
+    out = dedupe_goal_headlines_by_drive_origin(goals, limit=3)
+    assert [g.artifact_id for g in out] == ["goal-high", "goal-cont"]

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1245,7 +1245,11 @@ def _merge_orion_goals_into_state(
             seen.add(goal.artifact_id)
     if len(merged_goals) == len(preferred_state.goal_headlines):
         return preferred_state
-    return preferred_state.model_copy(update={"goal_headlines": merged_goals})
+    from orion.autonomy.summary import dedupe_goal_headlines_by_drive_origin
+
+    return preferred_state.model_copy(
+        update={"goal_headlines": dedupe_goal_headlines_by_drive_origin(merged_goals, limit=3)}
+    )
 
 
 def _load_autonomy_state_fallback_local(

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_plumbing.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_plumbing.py
@@ -202,6 +202,83 @@ def test_chat_stance_partial_drives_timeout_falls_back_to_relationship(monkeypat
     assert ctx["chat_autonomy_debug"]["_runtime"]["contextual_fallback"] is True
 
 
+def test_merge_orion_goals_dedupes_drive_origin_after_contextual_fallback(monkeypatch, enable_autonomy_graphdb) -> None:
+    from orion.autonomy.models import AutonomyGoalHeadlineV1, AutonomyStateV1
+
+    orion_state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="orion",
+        goal_headlines=[
+            AutonomyGoalHeadlineV1(
+                artifact_id="goal-orion-stale",
+                goal_statement="Clarify autonomy boundaries without executing any new action.",
+                drive_origin="autonomy",
+                priority=0.0,
+                cooldown_until=None,
+                proposal_signature="sig-stale",
+            )
+        ],
+        source="graph",
+    )
+    relationship_state = AutonomyStateV1(
+        subject="relationship",
+        model_layer="relationship-model",
+        entity_id="relationship:orion|juniper",
+        dominant_drive="predictive",
+        drive_pressures={"predictive": 0.41},
+        active_drives=["predictive"],
+        goal_headlines=[
+            AutonomyGoalHeadlineV1(
+                artifact_id="goal-rel-autonomy",
+                goal_statement="Clarify autonomy boundaries. Primary tension: tension.identity_drift.v1.",
+                drive_origin="autonomy",
+                priority=0.88,
+                cooldown_until=None,
+                proposal_signature="sig-rel",
+            ),
+            AutonomyGoalHeadlineV1(
+                artifact_id="goal-rel-continuity",
+                goal_statement="Preserve continuity across recent identity and relation shifts.",
+                drive_origin="continuity",
+                priority=0.83,
+                cooldown_until=None,
+                proposal_signature="sig-cont",
+            ),
+        ],
+        source="graph",
+    )
+    repo = _Repo(
+        {
+            "orion": _Lookup(
+                "orion",
+                "degraded",
+                orion_state,
+                unavailable_reason="timeout",
+                subquery_diagnostics={
+                    "drives": {"status": "timeout", "row_count": 0, "error_type": "timeout"},
+                },
+            ),
+            "relationship": _Lookup(
+                "relationship",
+                "available",
+                relationship_state,
+                subquery_diagnostics={"drives": {"status": "ok", "row_count": 6}},
+            ),
+        }
+    )
+    monkeypatch.setattr(chat_stance, "build_autonomy_repository", lambda **_: repo)
+
+    ctx = {"user_message": "hello", "verb": "chat_general", "mode": "brain"}
+    chat_stance.build_chat_stance_inputs(ctx)
+
+    active = ctx["chat_autonomy_summary"]["active_goals"]
+    origins = [g["drive_origin"] for g in active]
+    assert origins.count("autonomy") == 1
+    assert "continuity" in origins
+    assert active[0]["artifact_id"] == "goal-rel-autonomy"
+
+
 def test_chat_stance_partial_drives_timeout_exports_degraded_summary(monkeypatch, enable_autonomy_graphdb) -> None:
     from orion.autonomy.models import AutonomyGoalHeadlineV1, AutonomyStateV1
 

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -474,7 +474,7 @@
               <div id="autonomyDebugState" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
             </div>
             <div>
-              <div class="text-gray-500 mb-1">Proposals <span class="text-amber-300">(proposal-only)</span></div>
+              <div id="autonomyDebugProposalsTitle" class="text-xs uppercase tracking-wide text-amber-400/80 mb-1">Active goals (non-executing)</div>
               <div id="autonomyDebugProposals" class="rounded-xl border border-gray-700 bg-gray-900/50 p-3 text-[11px] space-y-2">--</div>
             </div>
             <div>

--- a/services/orion-hub/tests/test_autonomy_runtime_ui_panel.py
+++ b/services/orion-hub/tests/test_autonomy_runtime_ui_panel.py
@@ -340,6 +340,14 @@ def test_app_js_shows_goals_badge_and_active_goals_section_title() -> None:
     assert "autonomy_goals_present" in app_js
 
 
+def test_template_uses_single_active_goals_section_title_not_static_proposal_only() -> None:
+    template = TEMPLATE_PATH.read_text(encoding="utf-8")
+    assert 'id="autonomyDebugProposalsTitle"' in template
+    assert "Active goals (non-executing)" in template
+    proposals_section = template.split('id="autonomyDebugProposals"', 1)[0]
+    assert "Proposals <span" not in proposals_section.split("autonomyDebugProposalsTitle", 1)[-1]
+
+
 def test_app_js_supports_two_subject_autonomy_display_mode() -> None:
     app_js = APP_JS_PATH.read_text(encoding="utf-8")
     template = TEMPLATE_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
Dedupe goal_headlines by drive_origin after Orion/relationship merge and in summary active_goals; replace static "Proposals (proposal-only)" template label with autonomyDebugProposalsTitle updated by app.js.