### PR TITLE
Feat/substrate graph mvp

### DIFF
--- a/PR_SUBSTRATE_GRAPH_MVP.md
+++ b/PR_SUBSTRATE_GRAPH_MVP.md
@@ -1,0 +1,104 @@
+# Substrate Graph MVP: shared grammar + 7-day experiment harness
+
+## Summary
+
+This PR lands the **Substrate Graph MVP** — a tiny shared-grammar layer that lets multiple Orion organs perturb one common reality model instead of each owning its own bespoke schema. It is *additive*; no existing organ code paths are modified.
+
+Core stance: **organs do not own reality. Organs emit transformations over a shared substrate.**
+
+What this is:
+- A shared substrate grammar
+- A field-stabilization scaffolding layer
+- A common reality model for multiple Orion organs
+
+What this is **not**: a memory system, an ontology platform, an agent framework, an AGI stack, a GraphDB project.
+
+## What's inside
+
+### Phase 1–2, 4 — Schema kernel (`orion/schema_kernel/`)
+- `ConceptAtomV1` with a closed set of **12 atom kinds** that are *invariants*, not domain nouns: `signal`, `constraint`, `attention`, `state`, `change`, `relation`, `context`, `agency`, `evidence`, `gradient`, `persistence`, `boundary`.
+- `ConceptRelationV1`: source, predicate, target, `weight ≥ 0`, `polarity ∈ [-1, 1]`.
+- `CompositeV1`: small kernel-level bundle.
+- Canonical gradient vector: `salience`, `contradiction`, `novelty`, `coherence`.
+- `SchemaKernelRegistry` + `default_registry()` seed.
+- `validate_atom` / `validate_relation` / `validate_composite`.
+
+### Phase 3, 5, 6, 8 — Substrate molecules (`orion/substrate/`)
+- `SubstrateMoleculeV1` — every organ emits the *same* shape: `{molecule_id, molecule_kind, atoms, relations, gradients, provenance, payload, created_at, last_touched_at}`.
+- Operators that mutate gradients only:
+  - `reinforce_molecule` — salience + coherence up.
+  - `decay_molecule` — slow loss when untouched.
+  - `amplify_contradiction` — contradiction + salience up.
+  - `stabilize_coherence` — coherence up, contradiction down.
+- `find_resonant_molecules(gradients, threshold)` — O(n) traversal, descending by summed gradient pressure.
+- `MoleculeJsonlStore` — append-only JSONL + in-memory mirror; round-trips through Pydantic.
+
+### Phase 7 — Organ integration
+- `orion/mind/substrate_emit.py`: `emit_observation`, `emit_claim`.
+- `orion/autonomy/substrate_emit.py`: `emit_pressure`, `emit_contradiction`.
+- Both produce identical `SubstrateMoleculeV1` shape — proves the no-bespoke-schemas claim.
+- Existing chat / autonomy code is untouched.
+
+### Phase 9 — 7-day experiment harness (`orion/substrate/experiment/`)
+- `SubstrateExperimentHarness` records `emit`, `traversal`, gradient deltas (reinforce/decay/contradiction/stabilize).
+- `compute_daily_rollup` → `DailyMetricsV1`:
+  - molecule_count, organ_coverage
+  - gradient_distribution (min/mean/max for each canonical key)
+  - resonance_hits, cross_organ_reuse
+  - reinforcement_count, decay_count
+  - contradiction_clusters (grouped by shared atom signature)
+  - orphan_molecule_rate
+  - substrate_health_score = `coherence + cross_organ_rate + reinforcement_rate − contradiction − orphan_rate`, clamped to `[-1, 1]`.
+- `write_daily_rollup` → `runs/YYYY-MM-DD.json`.
+- `generate_week_report` → one Markdown verdict answering: *Did the shared substrate become more useful than bespoke organ state?*
+
+## What this PR deliberately avoids
+
+- No giant ontology.
+- No tensors, no embeddings.
+- No GraphDB integration.
+- No autonomous agents, no symbolic reasoner.
+- No dashboards, no ML, no causal claims.
+- No invented atom types beyond the 12-kind closed set.
+- No changes to any existing organ code paths.
+
+## Architecture rules respected
+
+| Rule | Status |
+|------|--------|
+| Atoms are invariants, not domain nouns | ✅ 12 kinds, all dimensions of interaction |
+| Same molecule shape across organs | ✅ mind + autonomy both emit `SubstrateMoleculeV1` |
+| Operators mutate gradients only | ✅ four operators, no structural rewrites |
+| Substrate owns shared reality | ✅ `MoleculeJsonlStore` is the source of truth |
+| Inspectable | ✅ JSONL on disk, JSON daily rollups, Markdown report |
+| Evolvable | ✅ kernel sits beside (not on top of) the existing `orion.substrate` graph layer |
+
+## Files likely to touch in follow-up work
+
+- A bridge between `MoleculeJsonlStore` and the existing `SubstrateGraphMaterializer`.
+- A scheduler that fires `compute_daily_rollup` once per UTC day.
+- Real wiring of `mind_emit.emit_*` into `orion/chat.py` and of `autonomy_emit.emit_*` into the existing pressure loop. (Done intentionally as a separate change to keep this PR additive.)
+
+## Non-goals (out of scope here)
+
+- Replacing or refactoring `orion/substrate/materializer.py`, `dynamics.py`, or `relational/`.
+- Persisting molecules into Postgres or the graph store.
+- Embedding-based traversal.
+- Cross-organ reasoning beyond gradient resonance.
+
+## Test plan
+
+- [x] `venv/bin/pytest tests/test_substrate_kernel_atoms.py tests/test_substrate_kernel_molecules.py tests/test_substrate_kernel_operators.py tests/test_substrate_organ_emit.py tests/test_substrate_experiment_harness.py` — 26 passed in 0.78s
+- [x] Existing `orion.substrate` package still imports without error.
+- [ ] Run the harness against a real 7-day window and inspect `weekly.md`.
+- [ ] Wire `mind_emit` into a chat code path (follow-up PR).
+- [ ] Wire `autonomy_emit` into the pressure loop (follow-up PR).
+
+## Acceptance checks (per the spec)
+
+1. ✅ Chat-shaped molecules can be emitted via `mind_emit.emit_observation` / `emit_claim`.
+2. ✅ Pressure-shaped molecules can be emitted via `autonomy_emit.emit_pressure` / `emit_contradiction`.
+3. ✅ Gradients evolve over time via the four operators.
+4. ✅ `find_resonant_molecules` retrieves by gradient pressure.
+5. ✅ Both organs share the same `SubstrateMoleculeV1` grammar — verified by `test_substrate_organ_emit::test_both_organs_emit_substrate_molecules`.
+6. ✅ No bespoke organ-specific state systems introduced.

--- a/orion/autonomy/substrate_emit.py
+++ b/orion/autonomy/substrate_emit.py
@@ -1,0 +1,86 @@
+"""Thin substrate-emit helpers for the autonomy/pressure organ.
+
+These do not modify any existing autonomy code — they exist so the pressure
+loop can drop molecules onto the shared substrate from anywhere.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orion.schema_kernel import ConceptRelationV1
+from orion.substrate.molecules import SubstrateMoleculeV1
+
+
+ORGAN_NAME = "autonomy"
+
+
+def emit_pressure(
+    *,
+    label: str,
+    magnitude: float,
+    source_goal_id: str | None = None,
+    extra_payload: dict[str, Any] | None = None,
+) -> SubstrateMoleculeV1:
+    """A pressure molecule is a constraint+gradient pair.
+
+    ``magnitude`` is folded directly into the salience gradient so the harness
+    can see autonomy load aggregate over time.
+    """
+
+    relations = [
+        ConceptRelationV1(
+            source="primary",
+            predicate="constrains",
+            target="scope",
+            weight=max(0.0, magnitude),
+        )
+    ]
+    payload = {"label": label, "magnitude": magnitude}
+    if extra_payload:
+        payload.update(extra_payload)
+    provenance = {"organ": ORGAN_NAME, "channel": "pressure"}
+    if source_goal_id:
+        provenance["source_id"] = source_goal_id
+    molecule = SubstrateMoleculeV1(
+        molecule_kind="pressure",
+        atoms={"primary": "constraint", "scope": "context", "field": "gradient"},
+        relations=relations,
+        provenance=provenance,
+        payload=payload,
+    )
+    molecule.gradients["salience"] = min(1.0, max(0.0, magnitude))
+    return molecule
+
+
+def emit_contradiction(
+    *,
+    summary: str,
+    between: tuple[str, str],
+    extra_payload: dict[str, Any] | None = None,
+) -> SubstrateMoleculeV1:
+    """Emit a contradiction molecule that points at two other molecule ids."""
+
+    left, right = between
+    relations = [
+        ConceptRelationV1(
+            source=left,
+            predicate="contradicts",
+            target=right,
+            polarity=-1.0,
+        )
+    ]
+    payload = {"summary": summary, "between": [left, right]}
+    if extra_payload:
+        payload.update(extra_payload)
+    provenance = {"organ": ORGAN_NAME, "channel": "pressure"}
+    molecule = SubstrateMoleculeV1(
+        molecule_kind="contradiction",
+        atoms={"primary": "constraint", "left": "evidence", "right": "evidence"},
+        relations=relations,
+        provenance=provenance,
+        payload=payload,
+    )
+    molecule.gradients["contradiction"] = 0.5
+    molecule.gradients["salience"] = 0.4
+    return molecule

--- a/orion/mind/substrate_emit.py
+++ b/orion/mind/substrate_emit.py
@@ -1,0 +1,95 @@
+"""Thin substrate-emit helpers for the mind/chat organ.
+
+This module deliberately does NOT touch any existing chat code. Callers (or a
+future shim) can invoke ``emit_observation`` / ``emit_claim`` to put molecules
+on the substrate without restructuring the mind layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orion.schema_kernel import ConceptRelationV1
+from orion.substrate.molecules import SubstrateMoleculeV1
+
+
+ORGAN_NAME = "mind"
+
+
+def emit_observation(
+    *,
+    surface_text: str,
+    source_id: str | None = None,
+    extra_payload: dict[str, Any] | None = None,
+) -> SubstrateMoleculeV1:
+    """Build an ``observation`` molecule from a chat turn.
+
+    The molecule binds two atoms: a primary signal (the utterance perturbation)
+    and a context atom (the surrounding chat scope). No NLP — just structure.
+    """
+
+    relations = [
+        ConceptRelationV1(
+            source="primary",
+            predicate="references",
+            target="scope",
+            weight=1.0,
+        )
+    ]
+    payload = {"surface_text": surface_text}
+    if extra_payload:
+        payload.update(extra_payload)
+    provenance = {"organ": ORGAN_NAME, "channel": "chat"}
+    if source_id:
+        provenance["source_id"] = source_id
+    return SubstrateMoleculeV1(
+        molecule_kind="observation",
+        atoms={"primary": "signal", "scope": "context"},
+        relations=relations,
+        provenance=provenance,
+        payload=payload,
+    )
+
+
+def emit_claim(
+    *,
+    claim_text: str,
+    supports: list[str] | None = None,
+    contradicts: list[str] | None = None,
+    source_id: str | None = None,
+    extra_payload: dict[str, Any] | None = None,
+) -> SubstrateMoleculeV1:
+    """Build a ``claim`` molecule. Supports/contradicts are other molecule ids."""
+
+    relations: list[ConceptRelationV1] = []
+    for target in supports or ():
+        relations.append(
+            ConceptRelationV1(
+                source="primary",
+                predicate="supports",
+                target=target,
+                polarity=1.0,
+            )
+        )
+    for target in contradicts or ():
+        relations.append(
+            ConceptRelationV1(
+                source="primary",
+                predicate="contradicts",
+                target=target,
+                polarity=-1.0,
+            )
+        )
+    payload = {"claim_text": claim_text}
+    if extra_payload:
+        payload.update(extra_payload)
+    provenance = {"organ": ORGAN_NAME, "channel": "chat"}
+    if source_id:
+        provenance["source_id"] = source_id
+    return SubstrateMoleculeV1(
+        molecule_kind="claim",
+        atoms={"primary": "evidence", "scope": "context"},
+        relations=relations,
+        provenance=provenance,
+        payload=payload,
+    )

--- a/orion/schema_kernel/__init__.py
+++ b/orion/schema_kernel/__init__.py
@@ -1,0 +1,55 @@
+"""Schema kernel — universal grammar for the Orion substrate.
+
+Atoms are reusable semantic invariants (not domain nouns).
+Relations connect atoms with predicate + weight + polarity.
+The registry pins the allowed vocabulary.
+
+This module is intentionally small. No ontology trees, no inheritance, no
+embeddings, no graph backends.
+"""
+
+from .atom import (
+    ATOM_KINDS,
+    DEFAULT_ATOMS,
+    ConceptAtomV1,
+)
+from .relation import (
+    DEFAULT_PREDICATES,
+    ConceptRelationV1,
+)
+from .composite import (
+    CompositeV1,
+)
+from .gradient import (
+    DEFAULT_GRADIENT_KEYS,
+    clamp_gradient,
+    empty_gradient_vector,
+)
+from .registry import (
+    SchemaKernelRegistry,
+    default_registry,
+)
+from .validator import (
+    SchemaValidationError,
+    validate_atom,
+    validate_composite,
+    validate_relation,
+)
+
+__all__ = [
+    "ATOM_KINDS",
+    "DEFAULT_ATOMS",
+    "ConceptAtomV1",
+    "DEFAULT_PREDICATES",
+    "ConceptRelationV1",
+    "CompositeV1",
+    "DEFAULT_GRADIENT_KEYS",
+    "clamp_gradient",
+    "empty_gradient_vector",
+    "SchemaKernelRegistry",
+    "default_registry",
+    "SchemaValidationError",
+    "validate_atom",
+    "validate_composite",
+    "validate_relation",
+]

--- a/orion/schema_kernel/atom.py
+++ b/orion/schema_kernel/atom.py
@@ -1,0 +1,120 @@
+"""Atoms — reusable semantic invariants.
+
+An atom is *not* a domain noun (memory, dream, emotion). It is a dimension of
+interaction that recurs across cognition, biology, social, and metabolism.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+ATOM_KINDS: Final[tuple[str, ...]] = (
+    "signal",
+    "constraint",
+    "attention",
+    "state",
+    "change",
+    "relation",
+    "context",
+    "agency",
+    "evidence",
+    "gradient",
+    "persistence",
+    "boundary",
+)
+
+
+class ConceptAtomV1(BaseModel):
+    """A reusable semantic invariant.
+
+    `key` is the unique handle (e.g. "signal.valence", "attention.allocation").
+    `atom_kind` must come from `ATOM_KINDS` — the closed set of invariant
+    families. Axes describe optional sub-dimensions the atom carries when it
+    participates in a composite (kept open-ended on purpose).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str = Field(min_length=1)
+    atom_kind: str
+    description: str | None = None
+    axes: tuple[str, ...] = ()
+
+
+DEFAULT_ATOMS: Final[tuple[ConceptAtomV1, ...]] = (
+    ConceptAtomV1(
+        key="signal",
+        atom_kind="signal",
+        description="A perturbation with valence/intensity/persistence.",
+        axes=("valence", "intensity", "persistence"),
+    ),
+    ConceptAtomV1(
+        key="constraint",
+        atom_kind="constraint",
+        description="A pressure or boundary that shapes admissible states.",
+        axes=("pressure", "resistance"),
+    ),
+    ConceptAtomV1(
+        key="attention",
+        atom_kind="attention",
+        description="Allocation/competition over signals.",
+        axes=("allocation", "fixation", "competition"),
+    ),
+    ConceptAtomV1(
+        key="state",
+        atom_kind="state",
+        description="A point in a configuration space.",
+        axes=("value",),
+    ),
+    ConceptAtomV1(
+        key="change",
+        atom_kind="change",
+        description="A transformation between states.",
+        axes=("magnitude", "direction"),
+    ),
+    ConceptAtomV1(
+        key="relation",
+        atom_kind="relation",
+        description="A coupling between two loci.",
+        axes=("weight", "polarity"),
+    ),
+    ConceptAtomV1(
+        key="context",
+        atom_kind="context",
+        description="The surround that gives a signal meaning.",
+        axes=("scope",),
+    ),
+    ConceptAtomV1(
+        key="agency",
+        atom_kind="agency",
+        description="The locus from which a transformation originates.",
+        axes=("source", "intent"),
+    ),
+    ConceptAtomV1(
+        key="evidence",
+        atom_kind="evidence",
+        description="A witness for or against a claim.",
+        axes=("polarity", "weight", "source"),
+    ),
+    ConceptAtomV1(
+        key="gradient",
+        atom_kind="gradient",
+        description="A directional pressure across a field.",
+        axes=("magnitude", "direction"),
+    ),
+    ConceptAtomV1(
+        key="persistence",
+        atom_kind="persistence",
+        description="How long a structure resists decay.",
+        axes=("half_life",),
+    ),
+    ConceptAtomV1(
+        key="boundary",
+        atom_kind="boundary",
+        description="A separation between inside/outside of a structure.",
+        axes=("permeability",),
+    ),
+)

--- a/orion/schema_kernel/composite.py
+++ b/orion/schema_kernel/composite.py
@@ -1,0 +1,25 @@
+"""Composite — a small bundle of atoms + relations.
+
+This is the *kernel-level* composite. The substrate layer wraps composites into
+SubstrateMoleculeV1, which adds gradients, provenance, and persistence.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .relation import ConceptRelationV1
+
+
+class CompositeV1(BaseModel):
+    """A named bundle of atoms and the relations among them.
+
+    `atoms` maps a *role name* inside the composite to the atom key it binds.
+    e.g. {"primary": "signal", "scope": "context"}.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    composite_kind: str = Field(min_length=1)
+    atoms: dict[str, str] = Field(default_factory=dict)
+    relations: tuple[ConceptRelationV1, ...] = ()

--- a/orion/schema_kernel/gradient.py
+++ b/orion/schema_kernel/gradient.py
@@ -1,0 +1,29 @@
+"""Gradient utilities — small helpers for the canonical gradient vector."""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+DEFAULT_GRADIENT_KEYS: Final[tuple[str, ...]] = (
+    "salience",
+    "contradiction",
+    "novelty",
+    "coherence",
+)
+
+
+def empty_gradient_vector() -> dict[str, float]:
+    """Return a fresh gradient vector seeded at 0.0 for the canonical keys."""
+
+    return {key: 0.0 for key in DEFAULT_GRADIENT_KEYS}
+
+
+def clamp_gradient(value: float, *, lo: float = 0.0, hi: float = 1.0) -> float:
+    """Clamp a single gradient component to [lo, hi]."""
+
+    if value < lo:
+        return lo
+    if value > hi:
+        return hi
+    return value

--- a/orion/schema_kernel/registry.py
+++ b/orion/schema_kernel/registry.py
@@ -1,0 +1,104 @@
+"""In-memory registry for the kernel vocabulary.
+
+The registry is intentionally lightweight: it tracks what atoms, predicates,
+and molecule kinds are legal. It does not persist anything itself.
+"""
+
+from __future__ import annotations
+
+from threading import RLock
+from typing import Iterable
+
+from .atom import DEFAULT_ATOMS, ConceptAtomV1
+from .relation import DEFAULT_PREDICATES
+
+
+class SchemaKernelRegistry:
+    """Holds the active atom vocabulary, predicate vocabulary, and known
+    molecule kinds. Organs read from this registry to discover what they can
+    legally emit.
+    """
+
+    def __init__(
+        self,
+        *,
+        atoms: Iterable[ConceptAtomV1] | None = None,
+        predicates: Iterable[str] | None = None,
+        molecule_kinds: Iterable[str] | None = None,
+    ) -> None:
+        self._lock = RLock()
+        self._atoms: dict[str, ConceptAtomV1] = {}
+        self._predicates: set[str] = set()
+        self._molecule_kinds: set[str] = set()
+
+        for atom in atoms or ():
+            self.register_atom(atom)
+        for predicate in predicates or ():
+            self.register_predicate(predicate)
+        for kind in molecule_kinds or ():
+            self.register_molecule_kind(kind)
+
+    # -- atoms -----------------------------------------------------------------
+
+    def register_atom(self, atom: ConceptAtomV1) -> None:
+        with self._lock:
+            self._atoms[atom.key] = atom
+
+    def atom(self, key: str) -> ConceptAtomV1 | None:
+        with self._lock:
+            return self._atoms.get(key)
+
+    def has_atom(self, key: str) -> bool:
+        with self._lock:
+            return key in self._atoms
+
+    def atoms(self) -> tuple[ConceptAtomV1, ...]:
+        with self._lock:
+            return tuple(self._atoms.values())
+
+    # -- predicates ------------------------------------------------------------
+
+    def register_predicate(self, predicate: str) -> None:
+        with self._lock:
+            self._predicates.add(predicate)
+
+    def has_predicate(self, predicate: str) -> bool:
+        with self._lock:
+            return predicate in self._predicates
+
+    def predicates(self) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(sorted(self._predicates))
+
+    # -- molecule kinds --------------------------------------------------------
+
+    def register_molecule_kind(self, kind: str) -> None:
+        with self._lock:
+            self._molecule_kinds.add(kind)
+
+    def has_molecule_kind(self, kind: str) -> bool:
+        with self._lock:
+            return kind in self._molecule_kinds
+
+    def molecule_kinds(self) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(sorted(self._molecule_kinds))
+
+
+def default_registry() -> SchemaKernelRegistry:
+    """Build a registry seeded with the canonical defaults.
+
+    Molecule kinds expected by the MVP organs are pre-registered so emit calls
+    do not blow up before the first run.
+    """
+
+    return SchemaKernelRegistry(
+        atoms=DEFAULT_ATOMS,
+        predicates=DEFAULT_PREDICATES,
+        molecule_kinds=(
+            "observation",
+            "claim",
+            "pressure",
+            "contradiction",
+        ),
+    )

--- a/orion/schema_kernel/relation.py
+++ b/orion/schema_kernel/relation.py
@@ -1,0 +1,59 @@
+"""Relations — directed couplings between atoms or molecules.
+
+Predicates are deliberately kept as free strings, but a small default vocabulary
+is registered so cross-organ usage stays comparable.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+DEFAULT_PREDICATES: Final[tuple[str, ...]] = (
+    "supports",
+    "contradicts",
+    "depends_on",
+    "elicits",
+    "constrains",
+    "amplifies",
+    "decays",
+    "references",
+    "co_occurs_with",
+    "transforms",
+)
+
+
+class ConceptRelationV1(BaseModel):
+    """A directed edge between two loci.
+
+    `source` and `target` are opaque keys — they may point at atom keys,
+    molecule ids, or atom roles inside a molecule. The schema kernel does not
+    resolve them; the substrate or caller does.
+
+    `weight` is non-negative magnitude. `polarity` is in [-1, 1]; negative
+    means inhibitory/dissonant, positive means supportive.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    source: str = Field(min_length=1)
+    predicate: str = Field(min_length=1)
+    target: str = Field(min_length=1)
+    weight: float = 1.0
+    polarity: float = 0.0
+
+    @field_validator("weight")
+    @classmethod
+    def _weight_non_negative(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("weight must be non-negative")
+        return value
+
+    @field_validator("polarity")
+    @classmethod
+    def _polarity_bounded(cls, value: float) -> float:
+        if value < -1.0 or value > 1.0:
+            raise ValueError("polarity must be in [-1, 1]")
+        return value

--- a/orion/schema_kernel/validator.py
+++ b/orion/schema_kernel/validator.py
@@ -1,0 +1,42 @@
+"""Tiny validator — checks an atom/relation/composite against a registry."""
+
+from __future__ import annotations
+
+from .atom import ATOM_KINDS, ConceptAtomV1
+from .composite import CompositeV1
+from .relation import ConceptRelationV1
+from .registry import SchemaKernelRegistry
+
+
+class SchemaValidationError(ValueError):
+    """Raised when a kernel object does not fit the registry vocabulary."""
+
+
+def validate_atom(atom: ConceptAtomV1) -> None:
+    if atom.atom_kind not in ATOM_KINDS:
+        raise SchemaValidationError(
+            f"atom_kind '{atom.atom_kind}' is not in ATOM_KINDS"
+        )
+
+
+def validate_relation(
+    relation: ConceptRelationV1,
+    registry: SchemaKernelRegistry,
+) -> None:
+    if not registry.has_predicate(relation.predicate):
+        raise SchemaValidationError(
+            f"predicate '{relation.predicate}' is not registered"
+        )
+
+
+def validate_composite(
+    composite: CompositeV1,
+    registry: SchemaKernelRegistry,
+) -> None:
+    for role, atom_key in composite.atoms.items():
+        if not registry.has_atom(atom_key):
+            raise SchemaValidationError(
+                f"role '{role}' references unregistered atom '{atom_key}'"
+            )
+    for relation in composite.relations:
+        validate_relation(relation, registry)

--- a/orion/substrate/experiment/__init__.py
+++ b/orion/substrate/experiment/__init__.py
@@ -1,0 +1,24 @@
+"""7-day substrate experiment harness.
+
+The harness records lightweight daily metrics that answer one question:
+*Did the shared substrate become more useful than bespoke organ state?*
+"""
+
+from .harness import SubstrateExperimentHarness
+from .metrics import (
+    DailyMetricsV1,
+    GradientStats,
+    OrganCoverage,
+)
+from .daily_rollup import compute_daily_rollup, write_daily_rollup
+from .report import generate_week_report
+
+__all__ = [
+    "SubstrateExperimentHarness",
+    "DailyMetricsV1",
+    "GradientStats",
+    "OrganCoverage",
+    "compute_daily_rollup",
+    "write_daily_rollup",
+    "generate_week_report",
+]

--- a/orion/substrate/experiment/daily_rollup.py
+++ b/orion/substrate/experiment/daily_rollup.py
@@ -1,0 +1,184 @@
+"""Per-day rollup computation + JSON persistence."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+from statistics import mean
+
+from orion.schema_kernel import DEFAULT_GRADIENT_KEYS
+from orion.substrate.molecule_store import MoleculeJsonlStore
+from orion.substrate.molecules import SubstrateMoleculeV1
+
+from .harness import SubstrateExperimentHarness, _DayBucket
+from .metrics import (
+    ContradictionCluster,
+    DailyMetricsV1,
+    GradientStats,
+    OrganCoverage,
+)
+
+
+def _gradient_stats(molecules: list[SubstrateMoleculeV1]) -> list[GradientStats]:
+    out: list[GradientStats] = []
+    for key in DEFAULT_GRADIENT_KEYS:
+        values = [m.gradient(key) for m in molecules]
+        if not values:
+            out.append(GradientStats(key=key))
+            continue
+        out.append(
+            GradientStats(
+                key=key,
+                min=min(values),
+                mean=mean(values),
+                max=max(values),
+            )
+        )
+    return out
+
+
+def _contradiction_clusters(
+    molecules: list[SubstrateMoleculeV1],
+) -> list[ContradictionCluster]:
+    """Cluster molecules with contradiction>0 by their atom signature."""
+
+    grouped: dict[tuple[str, ...], list[SubstrateMoleculeV1]] = defaultdict(list)
+    for molecule in molecules:
+        if molecule.gradient("contradiction") <= 0.0:
+            continue
+        signature = tuple(sorted(molecule.atoms.values()))
+        grouped[signature].append(molecule)
+    clusters: list[ContradictionCluster] = []
+    for signature, members in grouped.items():
+        if not members:
+            continue
+        clusters.append(
+            ContradictionCluster(
+                shared_atoms=list(signature),
+                molecule_ids=[m.molecule_id for m in members],
+                contradiction_sum=sum(m.gradient("contradiction") for m in members),
+            )
+        )
+    clusters.sort(key=lambda c: c.contradiction_sum, reverse=True)
+    return clusters
+
+
+def _health_score(
+    *,
+    coherence_mean: float,
+    contradiction_mean: float,
+    cross_organ_rate: float,
+    reinforcement_rate: float,
+    orphan_rate: float,
+) -> float:
+    score = (
+        coherence_mean
+        + cross_organ_rate
+        + reinforcement_rate
+        - contradiction_mean
+        - orphan_rate
+    )
+    # Soft clamp into [-1, 1] purely for readability.
+    return max(-1.0, min(1.0, score))
+
+
+def compute_daily_rollup(
+    *,
+    day: date,
+    harness: SubstrateExperimentHarness,
+    store: MoleculeJsonlStore,
+) -> DailyMetricsV1:
+    """Compute a DailyMetricsV1 for ``day`` using harness events and store state."""
+
+    bucket: _DayBucket | None = harness.bucket_for(day)
+    metrics = DailyMetricsV1.empty(day)
+
+    day_molecules = [
+        molecule
+        for molecule in store.all()
+        if molecule.created_at.date() == day
+    ]
+    metrics.molecule_count = len(day_molecules)
+
+    coverage = OrganCoverage()
+    for molecule in day_molecules:
+        organ = molecule.provenance.get("organ", "unknown")
+        coverage.by_organ[organ] = coverage.by_organ.get(organ, 0) + 1
+    metrics.organ_coverage = coverage
+
+    metrics.gradient_distribution = _gradient_stats(day_molecules)
+    metrics.contradiction_clusters = _contradiction_clusters(day_molecules)
+
+    reinforcement_count = 0
+    decay_count = 0
+    if bucket is not None:
+        metrics.resonance_hits = sum(len(t.hit_ids) for t in bucket.traversals)
+        metrics.cross_organ_reuse = sum(
+            len(ids) for ids in bucket.references_by_organ.values()
+        )
+        for gradient_record in bucket.gradient_changes:
+            cause = gradient_record.cause
+            if cause in {"reinforce", "stabilize", "contradiction"}:
+                reinforcement_count += 1
+            elif cause == "decay":
+                decay_count += 1
+        touched_ids = bucket.referenced_ids
+    else:
+        touched_ids = set()
+
+    metrics.reinforcement_count = reinforcement_count
+    metrics.decay_count = decay_count
+
+    if metrics.molecule_count:
+        orphans = sum(
+            1 for molecule in day_molecules if molecule.molecule_id not in touched_ids
+        )
+        metrics.orphan_molecule_rate = orphans / metrics.molecule_count
+    else:
+        metrics.orphan_molecule_rate = 0.0
+
+    coherence_stat = next(
+        (g for g in metrics.gradient_distribution if g.key == "coherence"),
+        None,
+    )
+    contradiction_stat = next(
+        (g for g in metrics.gradient_distribution if g.key == "contradiction"),
+        None,
+    )
+    coherence_mean = coherence_stat.mean if coherence_stat else 0.0
+    contradiction_mean = contradiction_stat.mean if contradiction_stat else 0.0
+    cross_organ_rate = (
+        metrics.cross_organ_reuse / metrics.molecule_count
+        if metrics.molecule_count
+        else 0.0
+    )
+    reinforcement_rate = (
+        metrics.reinforcement_count / metrics.molecule_count
+        if metrics.molecule_count
+        else 0.0
+    )
+    metrics.substrate_health_score = _health_score(
+        coherence_mean=coherence_mean,
+        contradiction_mean=contradiction_mean,
+        cross_organ_rate=cross_organ_rate,
+        reinforcement_rate=reinforcement_rate,
+        orphan_rate=metrics.orphan_molecule_rate,
+    )
+    return metrics
+
+
+def write_daily_rollup(
+    metrics: DailyMetricsV1,
+    *,
+    runs_dir: str | Path,
+) -> Path:
+    """Write a daily rollup to ``runs_dir/YYYY-MM-DD.json`` and return the path."""
+
+    runs_path = Path(runs_dir)
+    runs_path.mkdir(parents=True, exist_ok=True)
+    target = runs_path / f"{metrics.day.isoformat()}.json"
+    payload = metrics.model_dump(mode="json")
+    target.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    return target

--- a/orion/substrate/experiment/harness.py
+++ b/orion/substrate/experiment/harness.py
@@ -1,0 +1,163 @@
+"""SubstrateExperimentHarness — records substrate activity for daily rollups.
+
+Designed to be sprinkled into emit/traversal sites with minimal coupling. The
+harness is fully in-memory; persistence happens via the daily_rollup module.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from threading import RLock
+from typing import Iterable
+
+from orion.substrate.molecules import SubstrateMoleculeV1
+from orion.substrate.operators import GradientDelta
+
+
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+@dataclass
+class _EmitRecord:
+    molecule_id: str
+    molecule_kind: str
+    organ: str
+    when: datetime
+    atoms_snapshot: dict[str, str]
+
+
+@dataclass
+class _TraversalRecord:
+    when: datetime
+    requesting_organ: str
+    query_gradients: tuple[str, ...]
+    threshold: float
+    hit_ids: tuple[str, ...]
+
+
+@dataclass
+class _GradientRecord:
+    molecule_id: str
+    when: datetime
+    cause: str
+    before: dict[str, float]
+    after: dict[str, float]
+
+
+@dataclass
+class _DayBucket:
+    emits: list[_EmitRecord] = field(default_factory=list)
+    traversals: list[_TraversalRecord] = field(default_factory=list)
+    gradient_changes: list[_GradientRecord] = field(default_factory=list)
+    referenced_ids: set[str] = field(default_factory=set)
+    references_by_organ: dict[str, set[str]] = field(default_factory=lambda: defaultdict(set))
+
+
+class SubstrateExperimentHarness:
+    """In-memory recorder for substrate emit/traversal/gradient events.
+
+    A single harness can span many days; metrics are bucketed by UTC date.
+    """
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._buckets: dict[date, _DayBucket] = defaultdict(_DayBucket)
+        self._emits_by_id: dict[str, _EmitRecord] = {}
+
+    # -- bucket helpers --------------------------------------------------------
+
+    def _bucket(self, when: datetime) -> _DayBucket:
+        return self._buckets[when.date()]
+
+    # -- public recording API --------------------------------------------------
+
+    def record_emit(
+        self,
+        molecule: SubstrateMoleculeV1,
+        organ: str,
+        *,
+        when: datetime | None = None,
+    ) -> None:
+        when = when or datetime.now(timezone.utc)
+        record = _EmitRecord(
+            molecule_id=molecule.molecule_id,
+            molecule_kind=molecule.molecule_kind,
+            organ=organ,
+            when=when,
+            atoms_snapshot=dict(molecule.atoms),
+        )
+        with self._lock:
+            self._bucket(when).emits.append(record)
+            self._emits_by_id[molecule.molecule_id] = record
+
+    def record_traversal(
+        self,
+        *,
+        query_gradients: Iterable[str],
+        threshold: float,
+        results: Iterable[SubstrateMoleculeV1],
+        requesting_organ: str,
+        when: datetime | None = None,
+    ) -> None:
+        when = when or datetime.now(timezone.utc)
+        hit_ids = tuple(m.molecule_id for m in results)
+        record = _TraversalRecord(
+            when=when,
+            requesting_organ=requesting_organ,
+            query_gradients=tuple(query_gradients),
+            threshold=threshold,
+            hit_ids=hit_ids,
+        )
+        with self._lock:
+            bucket = self._bucket(when)
+            bucket.traversals.append(record)
+            for hit_id in hit_ids:
+                emit = self._emits_by_id.get(hit_id)
+                bucket.referenced_ids.add(hit_id)
+                if emit is not None and emit.organ != requesting_organ:
+                    bucket.references_by_organ[requesting_organ].add(hit_id)
+
+    def record_gradient_delta(
+        self,
+        delta: GradientDelta,
+        *,
+        when: datetime | None = None,
+    ) -> None:
+        when = when or datetime.now(timezone.utc)
+        record = _GradientRecord(
+            molecule_id=delta.molecule_id,
+            when=when,
+            cause=delta.cause,
+            before=dict(delta.before),
+            after=dict(delta.after),
+        )
+        with self._lock:
+            self._bucket(when).gradient_changes.append(record)
+            if delta.cause not in {"decay",}:
+                # reinforcement/contradiction/stabilize all count as "touched"
+                self._bucket(when).referenced_ids.add(delta.molecule_id)
+
+    # -- convenience wrappers --------------------------------------------------
+
+    def record_reinforcement(self, delta: GradientDelta) -> None:
+        self.record_gradient_delta(delta)
+
+    def record_decay(self, delta: GradientDelta) -> None:
+        self.record_gradient_delta(delta)
+
+    # -- read API for rollups --------------------------------------------------
+
+    def days_recorded(self) -> tuple[date, ...]:
+        with self._lock:
+            return tuple(sorted(self._buckets.keys()))
+
+    def bucket_for(self, day: date) -> _DayBucket | None:
+        with self._lock:
+            return self._buckets.get(day)
+
+    def all_emit_records(self) -> list[_EmitRecord]:
+        with self._lock:
+            return list(self._emits_by_id.values())

--- a/orion/substrate/experiment/metrics.py
+++ b/orion/substrate/experiment/metrics.py
@@ -1,0 +1,60 @@
+"""Metric models for the 7-day substrate harness.
+
+These are plain Pydantic models so daily rollups can be written/loaded as JSON
+without ceremony.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, Field
+
+from orion.schema_kernel import DEFAULT_GRADIENT_KEYS
+
+
+class GradientStats(BaseModel):
+    key: str
+    min: float = 0.0
+    mean: float = 0.0
+    max: float = 0.0
+
+
+class OrganCoverage(BaseModel):
+    by_organ: dict[str, int] = Field(default_factory=dict)
+
+    def total(self) -> int:
+        return sum(self.by_organ.values())
+
+
+class ContradictionCluster(BaseModel):
+    shared_atoms: list[str]
+    molecule_ids: list[str]
+    contradiction_sum: float
+
+
+class DailyMetricsV1(BaseModel):
+    """One day's rollup of substrate activity."""
+
+    day: date
+
+    molecule_count: int = 0
+    organ_coverage: OrganCoverage = Field(default_factory=OrganCoverage)
+    gradient_distribution: list[GradientStats] = Field(default_factory=list)
+
+    resonance_hits: int = 0
+    cross_organ_reuse: int = 0
+    reinforcement_count: int = 0
+    decay_count: int = 0
+
+    contradiction_clusters: list[ContradictionCluster] = Field(default_factory=list)
+
+    orphan_molecule_rate: float = 0.0
+    substrate_health_score: float = 0.0
+
+    @staticmethod
+    def empty(day: date) -> "DailyMetricsV1":
+        return DailyMetricsV1(
+            day=day,
+            gradient_distribution=[GradientStats(key=key) for key in DEFAULT_GRADIENT_KEYS],
+        )

--- a/orion/substrate/experiment/report.py
+++ b/orion/substrate/experiment/report.py
@@ -1,0 +1,126 @@
+"""Generate a single Markdown weekly report from daily rollups."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Iterable
+
+from .metrics import DailyMetricsV1
+
+
+def _load_day(runs_dir: Path, day: date) -> DailyMetricsV1 | None:
+    target = runs_dir / f"{day.isoformat()}.json"
+    if not target.exists():
+        return None
+    return DailyMetricsV1.model_validate(json.loads(target.read_text(encoding="utf-8")))
+
+
+def _date_range(start: date, end: date) -> Iterable[date]:
+    current = start
+    while current <= end:
+        yield current
+        current = current + timedelta(days=1)
+
+
+def _verdict(start_score: float | None, end_score: float | None) -> str:
+    if start_score is None or end_score is None:
+        return "Insufficient data — substrate did not record a full week."
+    delta = end_score - start_score
+    if delta > 0.05:
+        return (
+            f"Yes — substrate health rose by {delta:+.2f}. Shared grammar is "
+            "outperforming bespoke organ state."
+        )
+    if delta < -0.05:
+        return (
+            f"No — substrate health fell by {delta:+.2f}. Shared substrate is "
+            "currently noisier than the bespoke alternative."
+        )
+    return (
+        f"Inconclusive — substrate health barely moved ({delta:+.2f}). Run "
+        "longer or wire more organs."
+    )
+
+
+def generate_week_report(
+    *,
+    start_date: date,
+    end_date: date,
+    runs_dir: str | Path,
+    out_path: str | Path | None = None,
+) -> str:
+    """Render a markdown report over the [start_date, end_date] inclusive range.
+
+    Writes to ``out_path`` if provided; always returns the markdown body.
+    """
+
+    runs_path = Path(runs_dir)
+    days = list(_date_range(start_date, end_date))
+    loaded: list[tuple[date, DailyMetricsV1 | None]] = [
+        (day, _load_day(runs_path, day)) for day in days
+    ]
+    present = [(day, metrics) for day, metrics in loaded if metrics is not None]
+
+    lines: list[str] = []
+    lines.append(f"# Substrate Experiment Report — {start_date} → {end_date}")
+    lines.append("")
+    lines.append("**Question:** Did the shared substrate become more useful than bespoke organ state?")
+    lines.append("")
+
+    if not present:
+        lines.append("_No daily rollups were found for this window._")
+        body = "\n".join(lines) + "\n"
+        if out_path:
+            Path(out_path).write_text(body, encoding="utf-8")
+        return body
+
+    start_score = present[0][1].substrate_health_score
+    end_score = present[-1][1].substrate_health_score
+    lines.append(f"**Verdict:** {_verdict(start_score, end_score)}")
+    lines.append("")
+
+    lines.append("## Daily snapshot")
+    lines.append("")
+    lines.append(
+        "| date | molecules | organs | resonance | cross-organ | reinforce | decay | orphan% | health |"
+    )
+    lines.append("|------|-----------|--------|-----------|-------------|-----------|-------|---------|--------|")
+    for day, metrics in loaded:
+        if metrics is None:
+            lines.append(f"| {day} | — | — | — | — | — | — | — | — |")
+            continue
+        organs = ", ".join(sorted(metrics.organ_coverage.by_organ)) or "—"
+        lines.append(
+            f"| {day} | {metrics.molecule_count} | {organs} | "
+            f"{metrics.resonance_hits} | {metrics.cross_organ_reuse} | "
+            f"{metrics.reinforcement_count} | {metrics.decay_count} | "
+            f"{metrics.orphan_molecule_rate * 100:.0f}% | "
+            f"{metrics.substrate_health_score:+.2f} |"
+        )
+    lines.append("")
+
+    last = present[-1][1]
+    lines.append("## End-of-window gradient distribution")
+    lines.append("")
+    lines.append("| gradient | min | mean | max |")
+    lines.append("|----------|-----|------|-----|")
+    for stat in last.gradient_distribution:
+        lines.append(f"| {stat.key} | {stat.min:.2f} | {stat.mean:.2f} | {stat.max:.2f} |")
+    lines.append("")
+
+    if last.contradiction_clusters:
+        lines.append("## Contradiction clusters (end of window)")
+        lines.append("")
+        for cluster in last.contradiction_clusters[:5]:
+            lines.append(
+                f"- atoms={cluster.shared_atoms} sum={cluster.contradiction_sum:.2f} "
+                f"members={len(cluster.molecule_ids)}"
+            )
+        lines.append("")
+
+    body = "\n".join(lines) + "\n"
+    if out_path:
+        Path(out_path).write_text(body, encoding="utf-8")
+    return body

--- a/orion/substrate/molecule_store.py
+++ b/orion/substrate/molecule_store.py
@@ -1,0 +1,94 @@
+"""Append-only molecule persistence.
+
+The MVP persists to JSONL. A future iteration may swap in Postgres or the
+existing graph store — the interface is intentionally narrow.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from threading import RLock
+from typing import Iterable, Iterator
+
+from .molecules import SubstrateMoleculeV1
+
+
+class MoleculeJsonlStore:
+    """An in-memory + append-only-file molecule store.
+
+    Designed for inspectability. Every write is a single JSON line; the in-memory
+    map mirrors disk state so the traversal/operators stay fast.
+    """
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = RLock()
+        self._molecules: dict[str, SubstrateMoleculeV1] = {}
+        if self._path.exists():
+            self._load()
+
+    # -- internals -------------------------------------------------------------
+
+    def _load(self) -> None:
+        with self._path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                data = json.loads(line)
+                molecule = SubstrateMoleculeV1.model_validate(data)
+                self._molecules[molecule.molecule_id] = molecule
+
+    def _append(self, molecule: SubstrateMoleculeV1) -> None:
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(molecule.to_jsonable(), default=str))
+            handle.write("\n")
+
+    # -- public --------------------------------------------------------------
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def add(self, molecule: SubstrateMoleculeV1) -> SubstrateMoleculeV1:
+        with self._lock:
+            self._molecules[molecule.molecule_id] = molecule
+            self._append(molecule)
+            return molecule
+
+    def get(self, molecule_id: str) -> SubstrateMoleculeV1 | None:
+        with self._lock:
+            return self._molecules.get(molecule_id)
+
+    def all(self) -> list[SubstrateMoleculeV1]:
+        with self._lock:
+            return list(self._molecules.values())
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._molecules)
+
+    def __iter__(self) -> Iterator[SubstrateMoleculeV1]:
+        return iter(self.all())
+
+    def filter(
+        self,
+        *,
+        molecule_kind: str | None = None,
+        organ: str | None = None,
+    ) -> list[SubstrateMoleculeV1]:
+        result: list[SubstrateMoleculeV1] = []
+        for molecule in self.all():
+            if molecule_kind and molecule.molecule_kind != molecule_kind:
+                continue
+            if organ and molecule.provenance.get("organ") != organ:
+                continue
+            result.append(molecule)
+        return result
+
+    def extend(self, molecules: Iterable[SubstrateMoleculeV1]) -> None:
+        for molecule in molecules:
+            self.add(molecule)

--- a/orion/substrate/molecules.py
+++ b/orion/substrate/molecules.py
@@ -1,0 +1,101 @@
+"""SubstrateMoleculeV1 — the shared substrate currency.
+
+A molecule is a small composite of atoms + relations enriched with gradient
+state and provenance. Every organ emits the *same* molecule shape; no
+organ-specific schemas live here.
+
+This module is intentionally decoupled from the existing
+``orion.substrate.*`` graph layer — it is the MVP kernel, not the production
+materializer. The two co-exist; future work can bridge them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from orion.schema_kernel import (
+    ConceptRelationV1,
+    DEFAULT_GRADIENT_KEYS,
+    SchemaKernelRegistry,
+    SchemaValidationError,
+    empty_gradient_vector,
+)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_molecule_id() -> str:
+    return f"mol_{uuid.uuid4().hex[:16]}"
+
+
+class SubstrateMoleculeV1(BaseModel):
+    """A unit of shared substrate reality.
+
+    ``molecule_kind`` examples (MVP): observation, claim, pressure, contradiction.
+    ``atoms`` maps an in-molecule role -> atom key from the kernel.
+    ``relations`` describe couplings inside or pointing out of the molecule.
+    ``gradients`` carry the canonical evolving field state.
+    ``provenance`` records emitting organ, source ids, etc.
+    ``payload`` is a free-form bag for organ specifics that should *not* leak
+        into the grammar.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    molecule_id: str = Field(default_factory=_new_molecule_id)
+    molecule_kind: str
+
+    atoms: dict[str, str] = Field(default_factory=dict)
+    relations: list[ConceptRelationV1] = Field(default_factory=list)
+
+    gradients: dict[str, float] = Field(default_factory=empty_gradient_vector)
+
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+    created_at: datetime = Field(default_factory=_utcnow)
+    last_touched_at: datetime = Field(default_factory=_utcnow)
+
+    # -- helpers ---------------------------------------------------------------
+
+    def gradient(self, key: str) -> float:
+        return self.gradients.get(key, 0.0)
+
+    def touch(self, when: datetime | None = None) -> None:
+        self.last_touched_at = when or _utcnow()
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+
+def validate_molecule(
+    molecule: SubstrateMoleculeV1,
+    registry: SchemaKernelRegistry,
+) -> None:
+    """Ensure a molecule fits the active kernel vocabulary."""
+
+    if not registry.has_molecule_kind(molecule.molecule_kind):
+        raise SchemaValidationError(
+            f"molecule_kind '{molecule.molecule_kind}' is not registered"
+        )
+    for role, atom_key in molecule.atoms.items():
+        if not registry.has_atom(atom_key):
+            raise SchemaValidationError(
+                f"role '{role}' references unregistered atom '{atom_key}'"
+            )
+    for relation in molecule.relations:
+        if not registry.has_predicate(relation.predicate):
+            raise SchemaValidationError(
+                f"predicate '{relation.predicate}' is not registered"
+            )
+    for key in molecule.gradients:
+        if key not in DEFAULT_GRADIENT_KEYS:
+            raise SchemaValidationError(
+                f"gradient key '{key}' is not part of the canonical set"
+            )

--- a/orion/substrate/operators.py
+++ b/orion/substrate/operators.py
@@ -1,0 +1,154 @@
+"""Field operators — small functions that mutate gradient state.
+
+These are deliberately simple. No tensors, no learned weights. The harness
+records before/after deltas and aggregates them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Iterable
+
+from orion.schema_kernel import clamp_gradient
+
+from .molecules import SubstrateMoleculeV1
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class GradientDelta:
+    """Snapshot of a gradient mutation, useful for the experiment harness."""
+
+    molecule_id: str
+    before: dict[str, float]
+    after: dict[str, float]
+    cause: str
+
+    def changed_keys(self) -> tuple[str, ...]:
+        keys = []
+        for key, value in self.after.items():
+            if self.before.get(key, 0.0) != value:
+                keys.append(key)
+        return tuple(keys)
+
+
+GradientObserver = Callable[[GradientDelta], None]
+
+
+def _apply(
+    molecule: SubstrateMoleculeV1,
+    mutation: Callable[[dict[str, float]], dict[str, float]],
+    *,
+    cause: str,
+    observer: GradientObserver | None,
+) -> GradientDelta:
+    before = dict(molecule.gradients)
+    new_state = mutation(dict(before))
+    new_state = {key: clamp_gradient(value) for key, value in new_state.items()}
+    molecule.gradients = new_state
+    molecule.touch(_utcnow())
+    delta = GradientDelta(
+        molecule_id=molecule.molecule_id,
+        before=before,
+        after=dict(new_state),
+        cause=cause,
+    )
+    if observer is not None:
+        observer(delta)
+    return delta
+
+
+def reinforce_molecule(
+    molecule: SubstrateMoleculeV1,
+    *,
+    salience_step: float = 0.1,
+    coherence_step: float = 0.05,
+    observer: GradientObserver | None = None,
+) -> GradientDelta:
+    """Repeated access nudges salience + coherence upward."""
+
+    def _mut(state: dict[str, float]) -> dict[str, float]:
+        state["salience"] = state.get("salience", 0.0) + salience_step
+        state["coherence"] = state.get("coherence", 0.0) + coherence_step
+        return state
+
+    return _apply(molecule, _mut, cause="reinforce", observer=observer)
+
+
+def decay_molecule(
+    molecule: SubstrateMoleculeV1,
+    *,
+    salience_step: float = 0.02,
+    coherence_step: float = 0.01,
+    observer: GradientObserver | None = None,
+) -> GradientDelta:
+    """Untouched molecules slowly lose salience/coherence."""
+
+    def _mut(state: dict[str, float]) -> dict[str, float]:
+        state["salience"] = state.get("salience", 0.0) - salience_step
+        state["coherence"] = state.get("coherence", 0.0) - coherence_step
+        return state
+
+    return _apply(molecule, _mut, cause="decay", observer=observer)
+
+
+def amplify_contradiction(
+    molecule: SubstrateMoleculeV1,
+    *,
+    contradiction_step: float = 0.15,
+    salience_step: float = 0.1,
+    observer: GradientObserver | None = None,
+) -> GradientDelta:
+    """A contradiction signal lights up both fields."""
+
+    def _mut(state: dict[str, float]) -> dict[str, float]:
+        state["contradiction"] = state.get("contradiction", 0.0) + contradiction_step
+        state["salience"] = state.get("salience", 0.0) + salience_step
+        return state
+
+    return _apply(molecule, _mut, cause="contradiction", observer=observer)
+
+
+def stabilize_coherence(
+    molecule: SubstrateMoleculeV1,
+    *,
+    coherence_step: float = 0.1,
+    contradiction_decay: float = 0.05,
+    observer: GradientObserver | None = None,
+) -> GradientDelta:
+    """Reinforcement after a reconciliation: coherence up, contradiction down."""
+
+    def _mut(state: dict[str, float]) -> dict[str, float]:
+        state["coherence"] = state.get("coherence", 0.0) + coherence_step
+        state["contradiction"] = state.get("contradiction", 0.0) - contradiction_decay
+        return state
+
+    return _apply(molecule, _mut, cause="stabilize", observer=observer)
+
+
+# -- traversal -----------------------------------------------------------------
+
+
+def find_resonant_molecules(
+    molecules: Iterable[SubstrateMoleculeV1],
+    *,
+    gradients: list[str],
+    threshold: float,
+) -> list[SubstrateMoleculeV1]:
+    """Return molecules whose *summed* pressure across the requested gradient
+    keys clears the threshold. Order is descending by total pressure.
+
+    The MVP keeps this O(n). A future indexer can swap in.
+    """
+
+    scored: list[tuple[float, SubstrateMoleculeV1]] = []
+    for molecule in molecules:
+        total = sum(molecule.gradient(key) for key in gradients)
+        if total >= threshold:
+            scored.append((total, molecule))
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    return [molecule for _, molecule in scored]

--- a/tests/test_substrate_experiment_harness.py
+++ b/tests/test_substrate_experiment_harness.py
@@ -1,0 +1,124 @@
+"""End-to-end smoke for the experiment harness, daily rollup, and weekly report."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+from orion.autonomy import substrate_emit as autonomy_emit
+from orion.mind import substrate_emit as mind_emit
+from orion.substrate.experiment import (
+    SubstrateExperimentHarness,
+    compute_daily_rollup,
+    generate_week_report,
+    write_daily_rollup,
+)
+from orion.substrate.molecule_store import MoleculeJsonlStore
+from orion.substrate.operators import (
+    amplify_contradiction,
+    decay_molecule,
+    find_resonant_molecules,
+    reinforce_molecule,
+)
+
+
+def _seed_one_day(
+    *,
+    day: date,
+    store: MoleculeJsonlStore,
+    harness: SubstrateExperimentHarness,
+) -> None:
+    when = datetime(day.year, day.month, day.day, 12, 0, tzinfo=timezone.utc)
+    obs = mind_emit.emit_observation(surface_text="hi")
+    obs.created_at = when
+    obs.last_touched_at = when
+    pressure = autonomy_emit.emit_pressure(label="goal:learn", magnitude=0.5)
+    pressure.created_at = when
+    pressure.last_touched_at = when
+
+    store.add(obs)
+    store.add(pressure)
+    harness.record_emit(obs, organ="mind", when=when)
+    harness.record_emit(pressure, organ="autonomy", when=when)
+
+    # Reinforce + contradiction so the harness sees gradient events.
+    delta_reinforce = reinforce_molecule(obs)
+    harness.record_gradient_delta(delta_reinforce, when=when)
+    delta_contradict = amplify_contradiction(obs)
+    harness.record_gradient_delta(delta_contradict, when=when)
+    delta_decay = decay_molecule(pressure)
+    harness.record_decay(delta_decay)
+
+    # Cross-organ traversal: autonomy looks up molecules with salience pressure.
+    hits = find_resonant_molecules(
+        store.all(), gradients=["salience"], threshold=0.1
+    )
+    harness.record_traversal(
+        query_gradients=["salience"],
+        threshold=0.1,
+        results=hits,
+        requesting_organ="autonomy",
+        when=when,
+    )
+
+
+def test_full_harness_to_report(tmp_path):
+    store = MoleculeJsonlStore(tmp_path / "molecules.jsonl")
+    harness = SubstrateExperimentHarness()
+
+    start = date(2026, 5, 17)
+    end = date(2026, 5, 23)
+
+    runs_dir = tmp_path / "runs"
+    for offset in range(7):
+        day = start + timedelta(days=offset)
+        _seed_one_day(day=day, store=store, harness=harness)
+        metrics = compute_daily_rollup(day=day, harness=harness, store=store)
+        write_daily_rollup(metrics, runs_dir=runs_dir)
+        # Two organs always present on every day.
+        assert metrics.organ_coverage.total() >= 2
+        assert metrics.molecule_count >= 2
+
+    report_path = tmp_path / "weekly.md"
+    body = generate_week_report(
+        start_date=start,
+        end_date=end,
+        runs_dir=runs_dir,
+        out_path=report_path,
+    )
+    assert "Substrate Experiment Report" in body
+    assert "Daily snapshot" in body
+    assert report_path.exists()
+    assert "salience" not in body.split("End-of-window gradient distribution")[0]
+
+
+def test_empty_report_when_no_rollups(tmp_path):
+    body = generate_week_report(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 7),
+        runs_dir=tmp_path / "missing",
+    )
+    assert "No daily rollups" in body
+
+
+def test_orphan_rate_drops_with_traversal(tmp_path):
+    """A molecule never touched should be counted as orphan; touched ones not."""
+
+    store = MoleculeJsonlStore(tmp_path / "molecules.jsonl")
+    harness = SubstrateExperimentHarness()
+
+    day = date(2026, 5, 23)
+    when = datetime(day.year, day.month, day.day, 12, 0, tzinfo=timezone.utc)
+
+    touched = mind_emit.emit_observation(surface_text="touched")
+    orphan = mind_emit.emit_observation(surface_text="orphan")
+    for molecule in (touched, orphan):
+        molecule.created_at = when
+        molecule.last_touched_at = when
+        store.add(molecule)
+        harness.record_emit(molecule, organ="mind", when=when)
+
+    harness.record_gradient_delta(reinforce_molecule(touched), when=when)
+
+    metrics = compute_daily_rollup(day=day, harness=harness, store=store)
+    assert metrics.molecule_count == 2
+    assert 0.0 < metrics.orphan_molecule_rate <= 0.5 + 1e-9

--- a/tests/test_substrate_kernel_atoms.py
+++ b/tests/test_substrate_kernel_atoms.py
@@ -1,0 +1,76 @@
+"""Schema kernel: atoms, relations, registry, validator."""
+
+from __future__ import annotations
+
+import pytest
+
+from orion.schema_kernel import (
+    ATOM_KINDS,
+    ConceptAtomV1,
+    ConceptRelationV1,
+    DEFAULT_ATOMS,
+    DEFAULT_PREDICATES,
+    SchemaKernelRegistry,
+    SchemaValidationError,
+    default_registry,
+    validate_atom,
+    validate_relation,
+)
+
+
+def test_default_registry_has_canonical_vocabulary():
+    registry = default_registry()
+    assert len(registry.atoms()) == len(DEFAULT_ATOMS)
+    for atom in DEFAULT_ATOMS:
+        assert registry.has_atom(atom.key)
+    for predicate in DEFAULT_PREDICATES:
+        assert registry.has_predicate(predicate)
+    for kind in ("observation", "claim", "pressure", "contradiction"):
+        assert registry.has_molecule_kind(kind)
+
+
+def test_atom_kind_must_be_in_closed_set():
+    rogue = ConceptAtomV1(key="dream", atom_kind="dream")
+    with pytest.raises(SchemaValidationError):
+        validate_atom(rogue)
+
+
+def test_atom_default_set_passes_validation():
+    for atom in DEFAULT_ATOMS:
+        validate_atom(atom)
+    # And every default atom_kind is in the closed set.
+    for atom in DEFAULT_ATOMS:
+        assert atom.atom_kind in ATOM_KINDS
+
+
+def test_relation_polarity_bounded():
+    with pytest.raises(ValueError):
+        ConceptRelationV1(source="a", predicate="supports", target="b", polarity=2.0)
+    with pytest.raises(ValueError):
+        ConceptRelationV1(source="a", predicate="supports", target="b", polarity=-1.5)
+
+
+def test_relation_weight_must_be_non_negative():
+    with pytest.raises(ValueError):
+        ConceptRelationV1(source="a", predicate="supports", target="b", weight=-0.1)
+
+
+def test_validate_relation_against_registry():
+    registry = default_registry()
+    valid = ConceptRelationV1(source="a", predicate="supports", target="b")
+    validate_relation(valid, registry)
+
+    invalid = ConceptRelationV1(source="a", predicate="invented", target="b")
+    with pytest.raises(SchemaValidationError):
+        validate_relation(invalid, registry)
+
+
+def test_registry_register_extends_vocabulary():
+    registry = SchemaKernelRegistry()
+    atom = ConceptAtomV1(key="signal", atom_kind="signal")
+    registry.register_atom(atom)
+    registry.register_predicate("references")
+    registry.register_molecule_kind("observation")
+    assert registry.has_atom("signal")
+    assert registry.has_predicate("references")
+    assert registry.has_molecule_kind("observation")

--- a/tests/test_substrate_kernel_molecules.py
+++ b/tests/test_substrate_kernel_molecules.py
@@ -1,0 +1,76 @@
+"""Molecule schema + persistence."""
+
+from __future__ import annotations
+
+import pytest
+
+from orion.schema_kernel import (
+    ConceptRelationV1,
+    DEFAULT_GRADIENT_KEYS,
+    SchemaValidationError,
+    default_registry,
+)
+from orion.substrate.molecule_store import MoleculeJsonlStore
+from orion.substrate.molecules import SubstrateMoleculeV1, validate_molecule
+
+
+def _good_molecule() -> SubstrateMoleculeV1:
+    return SubstrateMoleculeV1(
+        molecule_kind="observation",
+        atoms={"primary": "signal", "scope": "context"},
+        relations=[
+            ConceptRelationV1(source="primary", predicate="references", target="scope")
+        ],
+        provenance={"organ": "mind"},
+    )
+
+
+def test_new_molecule_has_default_gradient_vector():
+    molecule = _good_molecule()
+    for key in DEFAULT_GRADIENT_KEYS:
+        assert key in molecule.gradients
+        assert molecule.gradients[key] == 0.0
+
+
+def test_validate_molecule_accepts_canonical_shape():
+    validate_molecule(_good_molecule(), default_registry())
+
+
+def test_validate_molecule_rejects_unknown_kind():
+    molecule = _good_molecule()
+    molecule.molecule_kind = "made-up-kind"
+    with pytest.raises(SchemaValidationError):
+        validate_molecule(molecule, default_registry())
+
+
+def test_validate_molecule_rejects_unknown_atom_role():
+    molecule = _good_molecule()
+    molecule.atoms = {"primary": "ghost_atom"}
+    with pytest.raises(SchemaValidationError):
+        validate_molecule(molecule, default_registry())
+
+
+def test_molecule_jsonl_round_trip(tmp_path):
+    path = tmp_path / "molecules.jsonl"
+    store = MoleculeJsonlStore(path)
+    first = _good_molecule()
+    store.add(first)
+
+    rehydrated = MoleculeJsonlStore(path)
+    assert len(rehydrated) == 1
+    fetched = rehydrated.get(first.molecule_id)
+    assert fetched is not None
+    assert fetched.molecule_kind == "observation"
+    assert fetched.provenance["organ"] == "mind"
+
+
+def test_molecule_store_filter_by_organ(tmp_path):
+    store = MoleculeJsonlStore(tmp_path / "m.jsonl")
+    mind_molecule = _good_molecule()
+    auto_molecule = _good_molecule()
+    auto_molecule.provenance = {"organ": "autonomy"}
+    store.add(mind_molecule)
+    store.add(auto_molecule)
+    assert len(store.filter(organ="mind")) == 1
+    assert len(store.filter(organ="autonomy")) == 1
+    assert len(store.filter(molecule_kind="observation")) == 2

--- a/tests/test_substrate_kernel_operators.py
+++ b/tests/test_substrate_kernel_operators.py
@@ -1,0 +1,76 @@
+"""Operators + traversal."""
+
+from __future__ import annotations
+
+from orion.substrate.molecules import SubstrateMoleculeV1
+from orion.substrate.operators import (
+    amplify_contradiction,
+    decay_molecule,
+    find_resonant_molecules,
+    reinforce_molecule,
+    stabilize_coherence,
+)
+
+
+def _mol(kind: str = "observation") -> SubstrateMoleculeV1:
+    return SubstrateMoleculeV1(
+        molecule_kind=kind,
+        atoms={"primary": "signal", "scope": "context"},
+        provenance={"organ": "mind"},
+    )
+
+
+def test_reinforce_raises_salience_and_coherence():
+    molecule = _mol()
+    delta = reinforce_molecule(molecule)
+    assert molecule.gradients["salience"] > 0
+    assert molecule.gradients["coherence"] > 0
+    assert delta.cause == "reinforce"
+    assert "salience" in delta.changed_keys()
+
+
+def test_decay_lowers_salience_clamped_at_zero():
+    molecule = _mol()
+    decay_molecule(molecule)
+    assert molecule.gradients["salience"] == 0.0
+    assert molecule.gradients["coherence"] == 0.0
+
+
+def test_amplify_contradiction_raises_both_fields():
+    molecule = _mol()
+    amplify_contradiction(molecule)
+    assert molecule.gradients["contradiction"] > 0
+    assert molecule.gradients["salience"] > 0
+
+
+def test_stabilize_increases_coherence_and_drops_contradiction():
+    molecule = _mol()
+    amplify_contradiction(molecule)
+    pre_contradiction = molecule.gradients["contradiction"]
+    stabilize_coherence(molecule)
+    assert molecule.gradients["coherence"] > 0
+    assert molecule.gradients["contradiction"] < pre_contradiction
+
+
+def test_observer_receives_delta():
+    molecule = _mol()
+    captured = []
+    reinforce_molecule(molecule, observer=captured.append)
+    assert len(captured) == 1
+    assert captured[0].molecule_id == molecule.molecule_id
+
+
+def test_find_resonant_molecules_returns_above_threshold_descending():
+    low = _mol()
+    mid = _mol()
+    high = _mol()
+    reinforce_molecule(mid)  # salience ~0.1
+    for _ in range(3):
+        reinforce_molecule(high)  # salience ~0.3
+
+    hits = find_resonant_molecules(
+        [low, mid, high], gradients=["salience"], threshold=0.05
+    )
+    assert hits[0].molecule_id == high.molecule_id
+    assert hits[1].molecule_id == mid.molecule_id
+    assert low not in hits

--- a/tests/test_substrate_organ_emit.py
+++ b/tests/test_substrate_organ_emit.py
@@ -1,0 +1,47 @@
+"""Smoke tests for the mind + autonomy substrate_emit helpers.
+
+The point is that BOTH organs produce the *same* molecule shape — no bespoke
+schemas per organ.
+"""
+
+from __future__ import annotations
+
+from orion.autonomy import substrate_emit as autonomy_emit
+from orion.mind import substrate_emit as mind_emit
+from orion.schema_kernel import default_registry
+from orion.substrate.molecules import SubstrateMoleculeV1, validate_molecule
+
+
+def test_both_organs_emit_substrate_molecules():
+    observation = mind_emit.emit_observation(surface_text="hello world", source_id="msg-1")
+    claim = mind_emit.emit_claim(claim_text="the sky is blue")
+    pressure = autonomy_emit.emit_pressure(label="goal:learn", magnitude=0.6)
+    contradiction = autonomy_emit.emit_contradiction(
+        summary="claim X conflicts with observation Y",
+        between=(claim.molecule_id, observation.molecule_id),
+    )
+
+    registry = default_registry()
+    for molecule in (observation, claim, pressure, contradiction):
+        assert isinstance(molecule, SubstrateMoleculeV1)
+        validate_molecule(molecule, registry)
+
+
+def test_mind_observation_carries_surface_text_in_payload():
+    obs = mind_emit.emit_observation(surface_text="hello world")
+    assert obs.payload["surface_text"] == "hello world"
+    assert obs.provenance["organ"] == "mind"
+
+
+def test_autonomy_pressure_magnitude_lands_in_salience_gradient():
+    pressure = autonomy_emit.emit_pressure(label="goal:learn", magnitude=0.7)
+    assert pressure.gradients["salience"] == 0.7
+    assert pressure.provenance["organ"] == "autonomy"
+
+
+def test_autonomy_contradiction_has_nonzero_contradiction_gradient():
+    contradiction = autonomy_emit.emit_contradiction(
+        summary="x vs y",
+        between=("mol_a", "mol_b"),
+    )
+    assert contradiction.gradients["contradiction"] > 0


### PR DESCRIPTION
# Substrate Graph MVP: shared grammar + 7-day experiment harness

## Summary

This PR lands the **Substrate Graph MVP** — a tiny shared-grammar layer that lets multiple Orion organs perturb one common reality model instead of each owning its own bespoke schema. It is *additive*; no existing organ code paths are modified.

Core stance: **organs do not own reality. Organs emit transformations over a shared substrate.**

What this is:
- A shared substrate grammar
- A field-stabilization scaffolding layer
- A common reality model for multiple Orion organs

What this is **not**: a memory system, an ontology platform, an agent framework, an AGI stack, a GraphDB project.

## What's inside

### Phase 1–2, 4 — Schema kernel (`orion/schema_kernel/`)
- `ConceptAtomV1` with a closed set of **12 atom kinds** that are *invariants*, not domain nouns: `signal`, `constraint`, `attention`, `state`, `change`, `relation`, `context`, `agency`, `evidence`, `gradient`, `persistence`, `boundary`.
- `ConceptRelationV1`: source, predicate, target, `weight ≥ 0`, `polarity ∈ [-1, 1]`.
- `CompositeV1`: small kernel-level bundle.
- Canonical gradient vector: `salience`, `contradiction`, `novelty`, `coherence`.
- `SchemaKernelRegistry` + `default_registry()` seed.
- `validate_atom` / `validate_relation` / `validate_composite`.

### Phase 3, 5, 6, 8 — Substrate molecules (`orion/substrate/`)
- `SubstrateMoleculeV1` — every organ emits the *same* shape: `{molecule_id, molecule_kind, atoms, relations, gradients, provenance, payload, created_at, last_touched_at}`.
- Operators that mutate gradients only:
  - `reinforce_molecule` — salience + coherence up.
  - `decay_molecule` — slow loss when untouched.
  - `amplify_contradiction` — contradiction + salience up.
  - `stabilize_coherence` — coherence up, contradiction down.
- `find_resonant_molecules(gradients, threshold)` — O(n) traversal, descending by summed gradient pressure.
- `MoleculeJsonlStore` — append-only JSONL + in-memory mirror; round-trips through Pydantic.

### Phase 7 — Organ integration
- `orion/mind/substrate_emit.py`: `emit_observation`, `emit_claim`.
- `orion/autonomy/substrate_emit.py`: `emit_pressure`, `emit_contradiction`.
- Both produce identical `SubstrateMoleculeV1` shape — proves the no-bespoke-schemas claim.
- Existing chat / autonomy code is untouched.

### Phase 9 — 7-day experiment harness (`orion/substrate/experiment/`)
- `SubstrateExperimentHarness` records `emit`, `traversal`, gradient deltas (reinforce/decay/contradiction/stabilize).
- `compute_daily_rollup` → `DailyMetricsV1`:
  - molecule_count, organ_coverage
  - gradient_distribution (min/mean/max for each canonical key)
  - resonance_hits, cross_organ_reuse
  - reinforcement_count, decay_count
  - contradiction_clusters (grouped by shared atom signature)
  - orphan_molecule_rate
  - substrate_health_score = `coherence + cross_organ_rate + reinforcement_rate − contradiction − orphan_rate`, clamped to `[-1, 1]`.
- `write_daily_rollup` → `runs/YYYY-MM-DD.json`.
- `generate_week_report` → one Markdown verdict answering: *Did the shared substrate become more useful than bespoke organ state?*

## What this PR deliberately avoids

- No giant ontology.
- No tensors, no embeddings.
- No GraphDB integration.
- No autonomous agents, no symbolic reasoner.
- No dashboards, no ML, no causal claims.
- No invented atom types beyond the 12-kind closed set.
- No changes to any existing organ code paths.

## Architecture rules respected

| Rule | Status |
|------|--------|
| Atoms are invariants, not domain nouns | ✅ 12 kinds, all dimensions of interaction |
| Same molecule shape across organs | ✅ mind + autonomy both emit `SubstrateMoleculeV1` |
| Operators mutate gradients only | ✅ four operators, no structural rewrites |
| Substrate owns shared reality | ✅ `MoleculeJsonlStore` is the source of truth |
| Inspectable | ✅ JSONL on disk, JSON daily rollups, Markdown report |
| Evolvable | ✅ kernel sits beside (not on top of) the existing `orion.substrate` graph layer |

## Files likely to touch in follow-up work

- A bridge between `MoleculeJsonlStore` and the existing `SubstrateGraphMaterializer`.
- A scheduler that fires `compute_daily_rollup` once per UTC day.
- Real wiring of `mind_emit.emit_*` into `orion/chat.py` and of `autonomy_emit.emit_*` into the existing pressure loop. (Done intentionally as a separate change to keep this PR additive.)

## Non-goals (out of scope here)

- Replacing or refactoring `orion/substrate/materializer.py`, `dynamics.py`, or `relational/`.
- Persisting molecules into Postgres or the graph store.
- Embedding-based traversal.
- Cross-organ reasoning beyond gradient resonance.

## Test plan

- [x] `venv/bin/pytest tests/test_substrate_kernel_atoms.py tests/test_substrate_kernel_molecules.py tests/test_substrate_kernel_operators.py tests/test_substrate_organ_emit.py tests/test_substrate_experiment_harness.py` — 26 passed in 0.78s
- [x] Existing `orion.substrate` package still imports without error.
- [ ] Run the harness against a real 7-day window and inspect `weekly.md`.
- [ ] Wire `mind_emit` into a chat code path (follow-up PR).
- [ ] Wire `autonomy_emit` into the pressure loop (follow-up PR).

## Acceptance checks (per the spec)

1. ✅ Chat-shaped molecules can be emitted via `mind_emit.emit_observation` / `emit_claim`.
2. ✅ Pressure-shaped molecules can be emitted via `autonomy_emit.emit_pressure` / `emit_contradiction`.
3. ✅ Gradients evolve over time via the four operators.
4. ✅ `find_resonant_molecules` retrieves by gradient pressure.
5. ✅ Both organs share the same `SubstrateMoleculeV1` grammar — verified by `test_substrate_organ_emit::test_both_organs_emit_substrate_molecules`.
6. ✅ No bespoke organ-specific state systems introduced.
