### PR TITLE
Feat/biometrics node grammar ingress

### DIFF
--- a/config/biometrics/node_catalog.yaml
+++ b/config/biometrics/node_catalog.yaml
@@ -1,0 +1,70 @@
+schema_version: biometrics_node_catalog.v1
+
+defaults:
+  expected_online: true
+  role: unknown
+  capabilities: {}
+
+nodes:
+  atlas:
+    aliases:
+      - atlas
+      - atlas.tail348bbe.ts.net
+    role: inference_gpu
+    expected_online: true
+    capabilities:
+      local_llm_heavy: true
+      local_llm_quick: true
+      embedding: true
+      batch_inference: true
+      graphdb: false
+      postgres: false
+      hub: false
+      monitoring: false
+
+  athena:
+    aliases:
+      - athena
+      - athena.tail348bbe.ts.net
+    role: orchestration
+    expected_online: true
+    capabilities:
+      hub: true
+      redis_bus: true
+      graphdb: true
+      postgres: true
+      orchestration: true
+      local_llm_heavy: false
+      local_llm_quick: false
+      monitoring: false
+
+  circe:
+    aliases:
+      - circe
+      - circe.tail348bbe.ts.net
+    role: burst_gpu
+    expected_online: false
+    capabilities:
+      local_llm_heavy: true
+      local_llm_quick: true
+      training: true
+      batch_inference: true
+      dream_batch: true
+      graphdb: false
+      postgres: false
+      hub: false
+
+  prometheus:
+    aliases:
+      - prometheus
+      - prometheous
+      - prometheus.tail348bbe.ts.net
+      - prometheous.tail348bbe.ts.net
+    role: observability
+    expected_online: true
+    capabilities:
+      monitoring: true
+      logs: true
+      metrics: true
+      orchestration: false
+      local_llm_heavy: false

--- a/docs/superpowers/pr-reports/2026-05-24-node-scoped-biometrics-grammar-ingress-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-24-node-scoped-biometrics-grammar-ingress-pr.md
@@ -1,0 +1,79 @@
+# PR: Node-scoped biometrics grammar ingress
+
+**Branch:** `feat/biometrics-node-grammar-ingress`  
+**Base:** `main`  
+**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-biometrics-node-grammar-ingress`
+
+## Summary
+
+- Publishes per-node `GrammarEventV1` traces on `orion:grammar:event` from existing biometrics sample/summary/induction (not cluster aggregate).
+- YAML node catalog canonicalizes aliases (e.g. `prometheous` → `prometheus`) and attaches role, capability, and `expected_online` context atoms.
+- Grammar publish failures are non-fatal; normal biometrics telemetry continues.
+
+## Architecture
+
+```text
+collect_biometrics()
+  → BiometricsSampleV1
+  → BiometricsPipeline.update()
+  → BiometricsSummaryV1 + BiometricsInductionV1
+  → publish sample/summary/induction (unchanged)
+  → NodeCatalog.resolve(node)
+  → build_biometrics_node_grammar_events()
+  → publish grammar.event.v1 × 13 per tick on orion:grammar:event
+```
+
+Trace unit: **one node, one observed biometrics moment** (`biometrics.node:{node_id}:{timestamp}`).
+
+## Changes by area
+
+### `config/biometrics/node_catalog.yaml`
+- Canonical nodes: atlas, athena, circe, prometheus with Tailscale aliases and typo aliases.
+
+### `services/orion-biometrics`
+- `app/node_catalog.py` — resolve raw node → `NodeProfile`
+- `app/grammar_emit.py` — five atoms, six edges, trace lifecycle
+- `app/main.py` — optional grammar publish after induction
+- `app/settings.py` — `PUBLISH_BIOMETRICS_GRAMMAR`, `GRAMMAR_EVENT_CHANNEL`, `NODE_CATALOG_PATH`
+- `tests/` — 10 unit tests (catalog + emitter schema/trace shape)
+- `Dockerfile` / `docker-compose.yml` — catalog mount + env
+- `README.md`, `.env_example`
+
+### `orion/bus/channels.yaml`
+- `orion-biometrics` added as producer on `orion:grammar:event`
+
+### `scripts/smoke_biometrics_grammar.sh`
+- Host unit tests + optional container pytest + redis tap instructions
+
+## Test plan
+
+- [x] `PYTHONPATH=services/orion-biometrics:. pytest services/orion-biometrics/tests/ -q` → **10 passed**
+- [ ] `redis-cli SUBSCRIBE orion:grammar:event` after biometrics tick → trace_id `biometrics.node:*`, `provenance.source_service=orion-biometrics`
+- [ ] sql-writer ingests `grammar.event.v1` (if stack running)
+
+## Verification evidence
+
+```
+10 passed in 0.23s (worktree, repo .venv)
+```
+
+Runtime bus subscribe: **UNVERIFIED** in CI/agent environment (no live biometrics container + redis tap in this session).
+
+## Acceptance criteria
+
+| # | Criterion | Met |
+|---|-----------|-----|
+| 1 | Atlas trace `biometrics.node:atlas:...` | Yes (emitter + catalog tests) |
+| 2 | Separate Athena trace per deployment | Yes (per `NODE_NAME` / sample.node) |
+| 3 | Circe `expected_online=false` | Yes (catalog + availability atom test) |
+| 4 | `prometheous` → `prometheus` | Yes |
+| 5 | Valid GrammarEventV1 fields only | Yes (literal membership tests) |
+| 6 | `payload_ref` only, no blob fields | Yes |
+| 7 | Grammar failure non-fatal | Yes (`try/except` in `publish_metrics`) |
+| 8 | No new organ | Yes |
+| 9 | No cluster grammar source | Yes |
+| 10 | Distinct capability surfaces | Yes (athena vs atlas test) |
+
+## Non-goals (confirmed out of scope)
+
+- New organ, mesh-average grammar, cluster-as-source, UI, signal-registry redesign.

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1790,7 +1790,12 @@ channels:
     kind: "event"
     schema_id: "GrammarEventV1"
     message_kind: "grammar.event.v1"
-    producer_services: ["orion-vision-retina", "orion-hub", "orion-vision-edge", "orion-vision-window"]
+    producer_services:
+      - orion-vision-retina
+      - orion-hub
+      - orion-vision-edge
+      - orion-vision-window
+      - orion-biometrics
     consumer_services: ["orion-sql-writer"]
     stability: "experimental"
     since: "2026-05-23"

--- a/scripts/smoke_biometrics_grammar.sh
+++ b/scripts/smoke_biometrics_grammar.sh
@@ -5,7 +5,12 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 echo "== unit tests (host) =="
-PYTHONPATH="services/orion-biometrics:." pytest \
+export PYTHONPATH="services/orion-biometrics:."
+PYTEST=(python3 -m pytest)
+if command -v pytest >/dev/null 2>&1; then
+  PYTEST=(pytest)
+fi
+"${PYTEST[@]}" \
   services/orion-biometrics/tests/test_node_catalog.py \
   services/orion-biometrics/tests/test_biometrics_grammar_emit.py -q
 

--- a/scripts/smoke_biometrics_grammar.sh
+++ b/scripts/smoke_biometrics_grammar.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== unit tests (host) =="
+PYTHONPATH="services/orion-biometrics:." pytest \
+  services/orion-biometrics/tests/test_node_catalog.py \
+  services/orion-biometrics/tests/test_biometrics_grammar_emit.py -q
+
+echo "== optional: container tests =="
+if docker compose -f services/orion-biometrics/docker-compose.yml ps -q biometrics 2>/dev/null | grep -q .; then
+  docker compose -f services/orion-biometrics/docker-compose.yml exec -T biometrics \
+    pytest tests/test_node_catalog.py tests/test_biometrics_grammar_emit.py -q
+fi
+
+echo "== bus tap (manual, 30s) =="
+echo "Run: redis-cli SUBSCRIBE orion:grammar:event"
+echo "Expect: schema_version grammar_event.v1, trace_id biometrics.node:<node>:..., provenance.source_service orion-biometrics"

--- a/services/orion-biometrics/.env_example
+++ b/services/orion-biometrics/.env_example
@@ -15,6 +15,9 @@ BIOMETRICS_SUMMARY_CHANNEL=orion:biometrics:summary
 BIOMETRICS_INDUCTION_CHANNEL=orion:biometrics:induction
 BIOMETRICS_CLUSTER_CHANNEL=orion:biometrics:cluster
 SPARK_SIGNAL_CHANNEL=orion:spark:signal
+PUBLISH_BIOMETRICS_GRAMMAR=true
+GRAMMAR_EVENT_CHANNEL=orion:grammar:event
+NODE_CATALOG_PATH=/app/config/biometrics/node_catalog.yaml
 EXTERNAL_SUBSCRIBE_CHANNEL=
 
 #ORION_BUS_URL=redis://${PROJECT}-bus-core:6379/0

--- a/services/orion-biometrics/Dockerfile
+++ b/services/orion-biometrics/Dockerfile
@@ -23,6 +23,8 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
 # App code
 COPY services/orion-biometrics/app ./app
 COPY orion /app/orion
+COPY config/biometrics /app/config/biometrics
+COPY services/orion-biometrics/tests ./tests
 
 ENV PYTHONPATH="/app:${PYTHONPATH}"
 

--- a/services/orion-biometrics/README.md
+++ b/services/orion-biometrics/README.md
@@ -13,6 +13,7 @@ The **Biometrics** service collects hardware telemetry (CPU, memory, GPU usage, 
 | `orion:biometrics:induction` | `BIOMETRICS_INDUCTION_CHANNEL` | `biometrics.induction.v1` | EWMA level/trend/volatility/spikes. |
 | `orion:biometrics:cluster` | `BIOMETRICS_CLUSTER_CHANNEL` | `biometrics.cluster.v1` | Role-weighted cluster aggregate (hub mode). |
 | `orion:spark:signal` | `SPARK_SIGNAL_CHANNEL` | `spark.signal.v1` | Bounded resource signal from cluster strain (hub mode). |
+| `orion:grammar:event` | `GRAMMAR_EVENT_CHANNEL` | `grammar.event.v1` | Node-scoped grammar trace (one trace per observed node per tick). |
 
 ### Environment Variables
 Provenance: `.env_example` → `docker-compose.yml` → `settings.py`
@@ -31,6 +32,11 @@ Provenance: `.env_example` → `docker-compose.yml` → `settings.py`
 | `DISK_BW_MBPS` | `200.0` | Disk bandwidth scale (MB/s). |
 | `NET_BW_MBPS` | `125.0` | Network bandwidth scale (MB/s). |
 | `ORION_HEALTH_CHANNEL` | `orion:system:health` | Health check channel. |
+| `PUBLISH_BIOMETRICS_GRAMMAR` | `true` | Enable grammar trace publish after each biometrics tick. |
+| `GRAMMAR_EVENT_CHANNEL` | `orion:grammar:event` | Grammar event publish channel. |
+| `NODE_CATALOG_PATH` | `/app/config/biometrics/node_catalog.yaml` | Path to node catalog YAML (host: `config/biometrics/node_catalog.yaml`). |
+
+Node identity for grammar traces is resolved via `config/biometrics/node_catalog.yaml` (aliases canonicalize hostnames, e.g. `prometheous` → `prometheus`).
 
 ## Running & Testing
 

--- a/services/orion-biometrics/app/grammar_emit.py
+++ b/services/orion-biometrics/app/grammar_emit.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from orion.schemas.grammar import (
+    GrammarAtomV1,
+    GrammarEdgeV1,
+    GrammarEventV1,
+    GrammarProvenanceV1,
+)
+from orion.schemas.telemetry.biometrics import (
+    BiometricsInductionV1,
+    BiometricsSampleV1,
+    BiometricsSummaryV1,
+)
+
+from .node_catalog import NodeProfile
+
+
+def _dt(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc)
+
+
+def _safe_ts(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _hash_id(*parts: object, prefix: str) -> str:
+    raw = "|".join(str(p) for p in parts)
+    return f"{prefix}_{hashlib.sha1(raw.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _availability_summary(
+    node_id: str,
+    node_profile: NodeProfile,
+    summary: BiometricsSummaryV1,
+) -> str:
+    if summary.telemetry_error_rate and summary.telemetry_error_rate > 0.1:
+        status = "DEGRADED"
+    else:
+        status = "OK"
+    online = "expected online" if node_profile.expected_online else "expected offline"
+    known = "known node" if node_profile.known else "unknown node"
+    return f"{node_id} telemetry status {status} ({online}, {known})"
+
+
+def _event(
+    *,
+    event_kind: str,
+    trace_id: str,
+    emitted_at: datetime,
+    observed_at: datetime,
+    provenance: GrammarProvenanceV1,
+    atom: GrammarAtomV1 | None = None,
+    edge: GrammarEdgeV1 | None = None,
+    parent_event_id: str | None = None,
+    root_event_id: str | None = None,
+    layer: str | None = None,
+    dimensions: list[str] | None = None,
+) -> GrammarEventV1:
+    body_key = atom.atom_id if atom else edge.edge_id if edge else uuid4().hex
+    return GrammarEventV1(
+        event_id=_hash_id(trace_id, event_kind, body_key, prefix="gev"),
+        event_kind=event_kind,  # type: ignore[arg-type]
+        trace_id=trace_id,
+        parent_event_id=parent_event_id,
+        root_event_id=root_event_id,
+        emitted_at=emitted_at,
+        observed_at=observed_at,
+        layer=layer,
+        dimensions=dimensions or [],
+        atom=atom,
+        edge=edge,
+        provenance=provenance,
+    )
+
+
+def build_biometrics_node_grammar_events(
+    *,
+    sample: BiometricsSampleV1,
+    summary: BiometricsSummaryV1,
+    induction: BiometricsInductionV1,
+    node_profile: NodeProfile,
+    source_channel: str,
+    code_version: str | None = None,
+) -> list[GrammarEventV1]:
+    observed_at = _dt(summary.timestamp or sample.timestamp or induction.timestamp)
+    emitted_at = datetime.now(timezone.utc)
+    ts = _safe_ts(observed_at)
+
+    node_id = node_profile.node_id
+    trace_id = f"biometrics.node:{node_id}:{ts}"
+
+    provenance = GrammarProvenanceV1(
+        source_service="orion-biometrics",
+        source_component="biometrics_grammar_emit",
+        source_event_id=f"{node_id}:{ts}",
+        source_trace_id=trace_id,
+        source_payload_ref=source_channel,
+        code_version=code_version,
+    )
+
+    root_event = _event(
+        event_kind="trace_started",
+        trace_id=trace_id,
+        emitted_at=emitted_at,
+        observed_at=observed_at,
+        provenance=provenance,
+        layer="biometrics",
+        dimensions=["node", "telemetry", "capability"],
+    )
+    root_id = root_event.event_id
+
+    def atom_id(role: str) -> str:
+        return f"{trace_id}:{role}"
+
+    atoms = {
+        "node_context": GrammarAtomV1(
+            atom_id=atom_id("node_context"),
+            trace_id=trace_id,
+            atom_type="entity",
+            semantic_role="node_context",
+            layer="context",
+            dimensions=["node", "role", "capability"],
+            summary=f"{node_id} node context: role={node_profile.role}",
+            text_value=node_id,
+            confidence=1.0 if node_profile.known else 0.45,
+            salience=1.0,
+            source_event_id=f"{node_id}:{ts}",
+            payload_ref=f"biometrics.node_profile:{node_id}",
+        ),
+        "telemetry_sample": GrammarAtomV1(
+            atom_id=atom_id("telemetry_sample"),
+            trace_id=trace_id,
+            atom_type="signal",
+            semantic_role="telemetry_sample",
+            layer="raw_input",
+            dimensions=["telemetry", "node"],
+            summary=f"Raw biometrics sample observed for {node_id}",
+            confidence=0.95,
+            salience=0.7,
+            source_event_id=f"{node_id}:{ts}",
+            payload_ref=f"biometrics.sample:{node_id}:{ts}",
+        ),
+        "body_state": GrammarAtomV1(
+            atom_id=atom_id("body_state"),
+            trace_id=trace_id,
+            atom_type="observation",
+            semantic_role="body_state",
+            layer="organ_signal",
+            dimensions=["physiology", "telemetry", "node"],
+            summary=f"Biometrics summary/induction observed for {node_id}",
+            confidence=0.95,
+            salience=float((summary.composites or {}).get("strain", 0.5)),
+            source_event_id=f"{node_id}:{ts}",
+            payload_ref=f"biometrics.summary:{node_id}:{ts}",
+        ),
+        "capability_surface": GrammarAtomV1(
+            atom_id=atom_id("capability_surface"),
+            trace_id=trace_id,
+            atom_type="action_candidate",
+            semantic_role="capability_surface",
+            layer="capability",
+            dimensions=["capability", "boundary", "node"],
+            summary=(
+                f"{node_id} capability surface: "
+                f"{', '.join(sorted(k for k, v in node_profile.capabilities.items() if v)) or 'none'}"
+            ),
+            confidence=1.0 if node_profile.known else 0.45,
+            salience=0.8,
+            source_event_id=f"{node_id}:{ts}",
+            payload_ref=f"biometrics.capabilities:{node_id}",
+        ),
+        "node_availability": GrammarAtomV1(
+            atom_id=atom_id("node_availability"),
+            trace_id=trace_id,
+            atom_type="uncertainty_marker",
+            semantic_role="node_availability",
+            layer="substrate",
+            dimensions=["freshness", "availability", "node"],
+            summary=_availability_summary(node_id, node_profile, summary),
+            confidence=0.9,
+            salience=0.7,
+            source_event_id=f"{node_id}:{ts}",
+            payload_ref=f"biometrics.availability:{node_id}:{ts}",
+        ),
+    }
+
+    edge_specs = [
+        ("node_context", "telemetry_sample", "references"),
+        ("telemetry_sample", "body_state", "derived_from"),
+        ("node_context", "body_state", "contains"),
+        ("body_state", "capability_surface", "influenced"),
+        ("node_availability", "capability_surface", "influenced"),
+        ("node_context", "capability_surface", "supports"),
+    ]
+
+    events: list[GrammarEventV1] = [root_event]
+
+    for atom in atoms.values():
+        events.append(
+            _event(
+                event_kind="atom_emitted",
+                trace_id=trace_id,
+                emitted_at=emitted_at,
+                observed_at=observed_at,
+                provenance=provenance,
+                atom=atom,
+                parent_event_id=root_id,
+                root_event_id=root_id,
+                layer=atom.layer,
+                dimensions=atom.dimensions,
+            )
+        )
+
+    for from_key, to_key, relation_type in edge_specs:
+        edge = GrammarEdgeV1(
+            edge_id=f"{trace_id}:edge:{from_key}:{relation_type}:{to_key}",
+            trace_id=trace_id,
+            from_atom_id=atoms[from_key].atom_id,
+            to_atom_id=atoms[to_key].atom_id,
+            relation_type=relation_type,  # type: ignore[arg-type]
+            confidence=0.9,
+            salience=0.7,
+            layer_from=atoms[from_key].layer,
+            layer_to=atoms[to_key].layer,
+            evidence_event_ids=[f"{node_id}:{ts}"],
+        )
+        events.append(
+            _event(
+                event_kind="edge_emitted",
+                trace_id=trace_id,
+                emitted_at=emitted_at,
+                observed_at=observed_at,
+                provenance=provenance,
+                edge=edge,
+                parent_event_id=root_id,
+                root_event_id=root_id,
+                layer=edge.layer_to,
+                dimensions=["node", "telemetry", "capability"],
+            )
+        )
+
+    events.append(
+        _event(
+            event_kind="trace_ended",
+            trace_id=trace_id,
+            emitted_at=datetime.now(timezone.utc),
+            observed_at=observed_at,
+            provenance=provenance,
+            parent_event_id=root_id,
+            root_event_id=root_id,
+            layer="biometrics",
+            dimensions=["node", "telemetry", "capability"],
+        )
+    )
+
+    return events

--- a/services/orion-biometrics/app/main.py
+++ b/services/orion-biometrics/app/main.py
@@ -173,6 +173,10 @@ _pipeline = BiometricsPipeline(
     window_sec=settings.TELEMETRY_INTERVAL,
 )
 
+from app.node_catalog import NodeCatalog
+from app.grammar_emit import build_biometrics_node_grammar_events
+_NODE_CATALOG = NodeCatalog.load(settings.NODE_CATALOG_PATH)
+
 
 async def publish_metrics(bus: OrionBusAsync) -> None:
     if not settings.ORION_BUS_ENABLED:
@@ -205,6 +209,32 @@ async def publish_metrics(bus: OrionBusAsync) -> None:
         await _publish(bus, settings.BIOMETRICS_SAMPLE_CHANNEL, "biometrics.sample.v1", sample)
         await _publish(bus, settings.BIOMETRICS_SUMMARY_CHANNEL, "biometrics.summary.v1", summary)
         await _publish(bus, settings.BIOMETRICS_INDUCTION_CHANNEL, "biometrics.induction.v1", induction)
+        if settings.PUBLISH_BIOMETRICS_GRAMMAR:
+            try:
+                node_profile = _NODE_CATALOG.resolve(
+                    sample.node or summary.node or induction.node
+                )
+                grammar_events = build_biometrics_node_grammar_events(
+                    sample=sample,
+                    summary=summary,
+                    induction=induction,
+                    node_profile=node_profile,
+                    source_channel=settings.BIOMETRICS_INDUCTION_CHANNEL,
+                    code_version=settings.SERVICE_VERSION,
+                )
+                for event in grammar_events:
+                    await _publish(
+                        bus,
+                        settings.GRAMMAR_EVENT_CHANNEL,
+                        "grammar.event.v1",
+                        event,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to publish biometrics grammar events: %s",
+                    exc,
+                    exc_info=True,
+                )
         logger.debug("Published biometrics sample/summary/induction")
     except Exception as exc:
         logger.error(f"Failed to publish biometrics: {exc}")
@@ -393,6 +423,8 @@ def health():
         "summary_channel": settings.BIOMETRICS_SUMMARY_CHANNEL,
         "induction_channel": settings.BIOMETRICS_INDUCTION_CHANNEL,
         "cluster_channel": settings.BIOMETRICS_CLUSTER_CHANNEL,
+        "grammar_event_channel": settings.GRAMMAR_EVENT_CHANNEL,
+        "publish_biometrics_grammar": settings.PUBLISH_BIOMETRICS_GRAMMAR,
         "bus_url": settings.ORION_BUS_URL,
         "node": settings.NODE_NAME,
         "mode": settings.BIOMETRICS_MODE,

--- a/services/orion-biometrics/app/node_catalog.py
+++ b/services/orion-biometrics/app/node_catalog.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class NodeProfile:
+    node_id: str
+    raw_node: str | None
+    role: str
+    expected_online: bool
+    capabilities: dict[str, bool] = field(default_factory=dict)
+    known: bool = True
+
+
+class NodeCatalog:
+    def __init__(
+        self,
+        profiles: dict[str, NodeProfile],
+        aliases: dict[str, str],
+        defaults: dict[str, Any],
+    ) -> None:
+        self.profiles = profiles
+        self.aliases = aliases
+        self.defaults = defaults
+
+    @classmethod
+    def load(cls, path: str | Path) -> "NodeCatalog":
+        data = yaml.safe_load(Path(path).read_text()) or {}
+        defaults = data.get("defaults") or {}
+        profiles: dict[str, NodeProfile] = {}
+        aliases: dict[str, str] = {}
+
+        for node_id, spec in (data.get("nodes") or {}).items():
+            canonical = str(node_id).strip().lower()
+            role = str(spec.get("role") or defaults.get("role") or "unknown")
+            expected_online = bool(
+                spec.get("expected_online", defaults.get("expected_online", True))
+            )
+            capabilities = {
+                str(k): bool(v) for k, v in (spec.get("capabilities") or {}).items()
+            }
+
+            profiles[canonical] = NodeProfile(
+                node_id=canonical,
+                raw_node=None,
+                role=role,
+                expected_online=expected_online,
+                capabilities=capabilities,
+                known=True,
+            )
+
+            aliases[canonical] = canonical
+            for alias in spec.get("aliases") or []:
+                aliases[str(alias).strip().lower()] = canonical
+
+        return cls(profiles=profiles, aliases=aliases, defaults=defaults)
+
+    def resolve(self, raw_node: str | None) -> NodeProfile:
+        raw = str(raw_node or "").strip()
+        key = raw.lower()
+        canonical = self.aliases.get(key)
+
+        if canonical and canonical in self.profiles:
+            base = self.profiles[canonical]
+            return NodeProfile(
+                node_id=base.node_id,
+                raw_node=raw or None,
+                role=base.role,
+                expected_online=base.expected_online,
+                capabilities=dict(base.capabilities),
+                known=True,
+            )
+
+        fallback_id = key or "unknown"
+        return NodeProfile(
+            node_id=fallback_id,
+            raw_node=raw or None,
+            role=str(self.defaults.get("role") or "unknown"),
+            expected_online=bool(self.defaults.get("expected_online", True)),
+            capabilities={
+                str(k): bool(v)
+                for k, v in (self.defaults.get("capabilities") or {}).items()
+            },
+            known=False,
+        )

--- a/services/orion-biometrics/app/settings.py
+++ b/services/orion-biometrics/app/settings.py
@@ -27,6 +27,9 @@ class Settings(BaseSettings):
     BIOMETRICS_INDUCTION_CHANNEL: str = Field(default="orion:biometrics:induction")
     BIOMETRICS_CLUSTER_CHANNEL: str = Field(default="orion:biometrics:cluster")
     SPARK_SIGNAL_CHANNEL: str = Field(default="orion:spark:signal")
+    PUBLISH_BIOMETRICS_GRAMMAR: bool = Field(default=True)
+    GRAMMAR_EVENT_CHANNEL: str = Field(default="orion:grammar:event")
+    NODE_CATALOG_PATH: str = Field(default="/app/config/biometrics/node_catalog.yaml")
 
     # Behavior
     TELEMETRY_INTERVAL: int = Field(default=30)

--- a/services/orion-biometrics/docker-compose.yml
+++ b/services/orion-biometrics/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       - BIOMETRICS_INDUCTION_CHANNEL=${BIOMETRICS_INDUCTION_CHANNEL}
       - BIOMETRICS_CLUSTER_CHANNEL=${BIOMETRICS_CLUSTER_CHANNEL}
       - SPARK_SIGNAL_CHANNEL=${SPARK_SIGNAL_CHANNEL}
+      - PUBLISH_BIOMETRICS_GRAMMAR=${PUBLISH_BIOMETRICS_GRAMMAR:-true}
+      - GRAMMAR_EVENT_CHANNEL=${GRAMMAR_EVENT_CHANNEL:-orion:grammar:event}
+      - NODE_CATALOG_PATH=${NODE_CATALOG_PATH:-/app/config/biometrics/node_catalog.yaml}
       - EXTERNAL_SUBSCRIBE_CHANNEL=${EXTERNAL_SUBSCRIBE_CHANNEL}
       - BIOMETRICS_MODE=${BIOMETRICS_MODE}
       - CLUSTER_PUBLISH_INTERVAL=${CLUSTER_PUBLISH_INTERVAL}
@@ -45,6 +48,7 @@ services:
       - POWER_BAND_ALPHA=${POWER_BAND_ALPHA}
 
     volumes:
+      - ../../config/biometrics:/app/config/biometrics:ro
       - /mnt/scripts/Orion-Sapienform/orion/sensors:/orion/sensors # access host gpus
       - /mnt/storage-lukewarm/logs/biometrics/logs:/app/logs
 

--- a/services/orion-biometrics/requirements.txt
+++ b/services/orion-biometrics/requirements.txt
@@ -6,3 +6,5 @@ pydantic-settings==2.5.2
 redis[hiredis]==5.0.7
 psycopg2-binary==2.9.9
 loguru>0.7
+PyYAML==6.0.2
+pytest==8.3.4

--- a/services/orion-biometrics/tests/test_biometrics_grammar_emit.py
+++ b/services/orion-biometrics/tests/test_biometrics_grammar_emit.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import get_args
+
+import pytest
+
+from app.grammar_emit import build_biometrics_node_grammar_events
+from app.node_catalog import NodeCatalog
+from orion.schemas.grammar import AtomType, RelationType
+from orion.schemas.telemetry.biometrics import (
+    BiometricsInductionMetricV1,
+    BiometricsInductionV1,
+    BiometricsSampleV1,
+    BiometricsSummaryV1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CATALOG_PATH = REPO_ROOT / "config" / "biometrics" / "node_catalog.yaml"
+FIXED_TS = datetime(2026, 5, 24, 20, 6, 18, 624380, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def catalog() -> NodeCatalog:
+    return NodeCatalog.load(CATALOG_PATH)
+
+
+def _fixtures(node: str, *, strain: float = 0.42):
+    sample = BiometricsSampleV1(timestamp=FIXED_TS, node=node, cpu={"util": 0.1})
+    summary = BiometricsSummaryV1(
+        timestamp=FIXED_TS,
+        node=node,
+        composites={"strain": strain},
+        telemetry_error_rate=0.0,
+    )
+    induction = BiometricsInductionV1(
+        timestamp=FIXED_TS,
+        node=node,
+        metrics={
+            "cpu": BiometricsInductionMetricV1(
+                level=0.5, trend=0.5, volatility=0.1, spike_rate=0.0
+            )
+        },
+    )
+    return sample, summary, induction
+
+
+def test_builds_node_scoped_trace_for_atlas(catalog: NodeCatalog) -> None:
+    sample, summary, induction = _fixtures("atlas")
+    profile = catalog.resolve("atlas")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+        code_version="0.1.0",
+    )
+    assert events
+    assert all(e.trace_id.startswith("biometrics.node:atlas:") for e in events)
+    atoms = [e.atom for e in events if e.atom]
+    node_context = next(a for a in atoms if a.semantic_role == "node_context")
+    assert node_context.text_value == "atlas"
+    assert "capability" in node_context.dimensions
+
+
+def test_uses_allowed_atom_types_only(catalog: NodeCatalog) -> None:
+    sample, summary, induction = _fixtures("atlas")
+    profile = catalog.resolve("atlas")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+    )
+    allowed = set(get_args(AtomType))
+    for event in events:
+        if event.atom:
+            assert event.atom.atom_type in allowed
+
+
+def test_uses_allowed_relation_types_only(catalog: NodeCatalog) -> None:
+    sample, summary, induction = _fixtures("atlas")
+    profile = catalog.resolve("atlas")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+    )
+    allowed = set(get_args(RelationType))
+    for event in events:
+        if event.edge:
+            assert event.edge.relation_type in allowed
+
+
+def test_athena_capability_surface_mentions_graphdb_not_heavy_llm(
+    catalog: NodeCatalog,
+) -> None:
+    sample, summary, induction = _fixtures("athena")
+    profile = catalog.resolve("athena")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+    )
+    cap = next(
+        e.atom
+        for e in events
+        if e.atom and e.atom.semantic_role == "capability_surface"
+    )
+    assert "graphdb" in cap.summary
+    assert "local_llm_heavy" not in cap.summary
+
+
+def test_trace_has_start_atoms_edges_end(catalog: NodeCatalog) -> None:
+    sample, summary, induction = _fixtures("prometheous")
+    profile = catalog.resolve("prometheous")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+    )
+    kinds = [e.event_kind for e in events]
+    assert kinds[0] == "trace_started"
+    assert "atom_emitted" in kinds
+    assert "edge_emitted" in kinds
+    assert kinds[-1] == "trace_ended"
+    assert events[0].trace_id.startswith("biometrics.node:prometheus:")
+
+
+def test_circe_node_availability_reflects_expected_offline(catalog: NodeCatalog) -> None:
+    sample, summary, induction = _fixtures("circe")
+    profile = catalog.resolve("circe")
+    events = build_biometrics_node_grammar_events(
+        sample=sample,
+        summary=summary,
+        induction=induction,
+        node_profile=profile,
+        source_channel="orion:biometrics:induction",
+    )
+    avail = next(
+        e.atom
+        for e in events
+        if e.atom and e.atom.semantic_role == "node_availability"
+    )
+    assert "expected offline" in avail.summary.lower()

--- a/services/orion-biometrics/tests/test_node_catalog.py
+++ b/services/orion-biometrics/tests/test_node_catalog.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.node_catalog import NodeCatalog
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CATALOG_PATH = REPO_ROOT / "config" / "biometrics" / "node_catalog.yaml"
+
+
+@pytest.fixture
+def catalog() -> NodeCatalog:
+    return NodeCatalog.load(CATALOG_PATH)
+
+
+def test_resolves_atlas_alias(catalog: NodeCatalog) -> None:
+    p = catalog.resolve("atlas.tail348bbe.ts.net")
+    assert p.node_id == "atlas"
+    assert p.role == "inference_gpu"
+    assert p.capabilities["local_llm_heavy"] is True
+    assert p.known is True
+    assert p.raw_node == "atlas.tail348bbe.ts.net"
+
+
+def test_resolves_prometheus_typo(catalog: NodeCatalog) -> None:
+    p = catalog.resolve("prometheous")
+    assert p.node_id == "prometheus"
+    assert p.role == "observability"
+    assert p.known is True
+
+
+def test_unknown_node_gets_fallback(catalog: NodeCatalog) -> None:
+    p = catalog.resolve("weirdbox")
+    assert p.node_id == "weirdbox"
+    assert p.known is False
+    assert p.role == "unknown"
+
+
+def test_circe_expected_offline(catalog: NodeCatalog) -> None:
+    p = catalog.resolve("circe")
+    assert p.expected_online is False
+    assert p.node_id == "circe"


### PR DESCRIPTION
# PR: Node-scoped biometrics grammar ingress

**Branch:** `feat/biometrics-node-grammar-ingress`  
**Base:** `main`  
**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-biometrics-node-grammar-ingress`

## Summary

- Publishes per-node `GrammarEventV1` traces on `orion:grammar:event` from existing biometrics sample/summary/induction (not cluster aggregate).
- YAML node catalog canonicalizes aliases (e.g. `prometheous` → `prometheus`) and attaches role, capability, and `expected_online` context atoms.
- Grammar publish failures are non-fatal; normal biometrics telemetry continues.

## Architecture

```text
collect_biometrics()
  → BiometricsSampleV1
  → BiometricsPipeline.update()
  → BiometricsSummaryV1 + BiometricsInductionV1
  → publish sample/summary/induction (unchanged)
  → NodeCatalog.resolve(node)
  → build_biometrics_node_grammar_events()
  → publish grammar.event.v1 × 13 per tick on orion:grammar:event
```

Trace unit: **one node, one observed biometrics moment** (`biometrics.node:{node_id}:{timestamp}`).

## Changes by area

### `config/biometrics/node_catalog.yaml`
- Canonical nodes: atlas, athena, circe, prometheus with Tailscale aliases and typo aliases.

### `services/orion-biometrics`
- `app/node_catalog.py` — resolve raw node → `NodeProfile`
- `app/grammar_emit.py` — five atoms, six edges, trace lifecycle
- `app/main.py` — optional grammar publish after induction
- `app/settings.py` — `PUBLISH_BIOMETRICS_GRAMMAR`, `GRAMMAR_EVENT_CHANNEL`, `NODE_CATALOG_PATH`
- `tests/` — 10 unit tests (catalog + emitter schema/trace shape)
- `Dockerfile` / `docker-compose.yml` — catalog mount + env
- `README.md`, `.env_example`

### `orion/bus/channels.yaml`
- `orion-biometrics` added as producer on `orion:grammar:event`

### `scripts/smoke_biometrics_grammar.sh`
- Host unit tests + optional container pytest + redis tap instructions

## Test plan

- [x] `PYTHONPATH=services/orion-biometrics:. pytest services/orion-biometrics/tests/ -q` → **10 passed**
- [ ] `redis-cli SUBSCRIBE orion:grammar:event` after biometrics tick → trace_id `biometrics.node:*`, `provenance.source_service=orion-biometrics`
- [ ] sql-writer ingests `grammar.event.v1` (if stack running)

## Verification evidence

```
10 passed in 0.23s (worktree, repo .venv)
```

Runtime bus subscribe: **UNVERIFIED** in CI/agent environment (no live biometrics container + redis tap in this session).

## Acceptance criteria

| # | Criterion | Met |
|---|-----------|-----|
| 1 | Atlas trace `biometrics.node:atlas:...` | Yes (emitter + catalog tests) |
| 2 | Separate Athena trace per deployment | Yes (per `NODE_NAME` / sample.node) |
| 3 | Circe `expected_online=false` | Yes (catalog + availability atom test) |
| 4 | `prometheous` → `prometheus` | Yes |
| 5 | Valid GrammarEventV1 fields only | Yes (literal membership tests) |
| 6 | `payload_ref` only, no blob fields | Yes |
| 7 | Grammar failure non-fatal | Yes (`try/except` in `publish_metrics`) |
| 8 | No new organ | Yes |
| 9 | No cluster grammar source | Yes |
| 10 | Distinct capability surfaces | Yes (athena vs atlas test) |

## Non-goals (confirmed out of scope)

- New organ, mesh-average grammar, cluster-as-source, UI, signal-registry redesign.
