### PR TITLE
Feat/biometrics substrate delta seam hardening

### DIFF
--- a/docs/superpowers/pr-reports/2026-05-24-biometrics-substrate-delta-seam-hardening-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-24-biometrics-substrate-delta-seam-hardening-pr.md
@@ -1,0 +1,86 @@
+# PR: Harden biometrics substrate delta seam for field digestion
+
+**Branch:** `feat/biometrics-substrate-delta-seam-hardening`  
+**Base:** `feat/biometrics-substrate-closed-loop-v1`  
+**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-biometrics-substrate-delta-seam-hardening`  
+**Head:** `f7d17930` (3 commits)
+
+## Summary
+
+Hardens the committed substrate delta seam so `orion-field-digester` can consume `ReductionReceiptV1` / `StateDeltaV1` without duplicate perturbations on replay. Replaces UUID-ish `receipt_id` / `delta_id` with deterministic SHA-256-derived identities, fixes Hub debug to return **node-scoped** emission/receipt lineage (not global latest), and adds receipt lookup for digester prep.
+
+## Problem
+
+- Reducers minted `rcpt_{uuid}` / `delta_{uuid}` — replay/retry produced logically identical deltas with new IDs.
+- Hub `GET /api/substrate/biometrics-node/{node_id}/latest` returned the latest **global** organ emission and reduction receipt, not the chain for that node.
+
+## Solution
+
+### Deterministic IDs (`orion/substrate/ids.py`)
+
+- `stable_hash_id(prefix, parts)` → `{prefix}_{sha256[:24]}`
+- `stable_delta_id(...)` — reducer, projection, target, operation, sorted `caused_by_event_ids`
+- `stable_receipt_id(...)` — reducer, sorted event buckets, optional `emission_id`
+
+Wired in `node_reducer.py` and `pressure_reducer.py` (noop receipts included).
+
+**Digester note:** Pressure receipts include `emission_id` in the preimage (organ still creates a new `emission_id` per invocation). Dedupe across emissions should use **`delta_id`**, not `receipt_id`.
+
+### Node-scoped lineage (`orion/substrate/biometrics_loop/lineage.py`)
+
+- `receipt_touches_node` / `emission_touches_node` / `state_deltas_for_node`
+- Hub and `BiometricsSubstrateStore` scan the last 50 rows and filter by node (replacing global `LIMIT 1`).
+
+### Hub API
+
+| Route | Change |
+|-------|--------|
+| `GET /api/substrate/biometrics-node/{node_id}/latest` | Node-filtered emission/receipt + `committed_state_deltas` |
+| `GET /api/substrate/receipts/{receipt_id}` | **New** — load committed receipt by id |
+
+### Runtime store
+
+- `latest_receipt_for_node`, `load_receipt`
+- `latest_emission_for_node` uses shared lineage helper
+
+Existing `ON CONFLICT (receipt_id) DO NOTHING` on insert remains the persistence idempotency guard.
+
+## Architecture (unchanged loop)
+
+```text
+orion-biometrics → grammar_events → substrate-runtime
+  → node_biometrics_projection → biometrics_pressure → active_node_pressure_projection
+  → committed ReductionReceiptV1 + StateDeltaV1 (now stable IDs)
+```
+
+## Test plan
+
+- [x] `PYTHONPATH=. pytest tests/test_substrate_deterministic_ids.py tests/test_substrate_lineage.py tests/test_node_biometrics_reducer.py tests/test_node_pressure_reducer.py tests/test_biometrics_pipeline.py orion/grammar/tests/test_biometrics_substrate_schemas.py services/orion-hub/tests/test_substrate_biometrics_debug_api.py -q` → **28 passed**
+- [ ] Live stack: replay same grammar event / runtime poll — receipt row count does not grow for same logical delta
+- [ ] Hub: `curl .../biometrics-node/atlas/latest` shows atlas emission/receipt when a newer global receipt exists for another node
+
+## Verification evidence
+
+```
+28 passed in ~1.5s (targeted substrate + hub debug suite)
+```
+
+Code review (subagent): **Approved** — spec compliant; added negative lineage hub test post-review.
+
+## Non-goals (confirmed)
+
+- No field digester service, tensor math, new organ, grammar redesign, collector rewrite, UI polish, autonomy actions, cluster aggregate source, `debug_trace` parsing.
+
+## Files touched
+
+| Area | Files |
+|------|--------|
+| IDs | `orion/substrate/ids.py` |
+| Reducers | `node_reducer.py`, `pressure_reducer.py` |
+| Lineage | `lineage.py`, `store.py`, `substrate_biometrics_routes.py` |
+| Tests | `test_substrate_deterministic_ids.py`, `test_substrate_lineage.py`, reducer/hub tests |
+| Docs | `services/orion-substrate-runtime/README.md` |
+
+## Operator notes
+
+No new env vars or SQL migration. Redeploy `orion-substrate-runtime` and Hub after merge. Existing receipts with random IDs remain in DB; new writes use deterministic IDs.

--- a/orion/substrate/biometrics_loop/lineage.py
+++ b/orion/substrate/biometrics_loop/lineage.py
@@ -1,0 +1,44 @@
+"""Node-scoped filtering for substrate receipts and organ emissions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orion.schemas.organ_emission import OrganEmissionV1
+from orion.schemas.reduction_receipt import ReductionReceiptV1
+
+
+def _normalize_node_id(node_id: str) -> str:
+    return node_id.strip().lower()
+
+
+def receipt_touches_node(receipt: ReductionReceiptV1, node_id: str) -> bool:
+    nid = _normalize_node_id(node_id)
+    for delta in receipt.state_deltas:
+        if _normalize_node_id(delta.target_id) == nid:
+            return True
+    for update in receipt.projection_updates:
+        if update.node_id and _normalize_node_id(update.node_id) == nid:
+            return True
+    return False
+
+
+def emission_touches_node(emission: OrganEmissionV1, node_id: str) -> bool:
+    nid = _normalize_node_id(node_id)
+    needle = f":{nid}:"
+    for event in emission.candidate_events:
+        if event.trace_id and needle in event.trace_id:
+            return True
+        if event.atom and event.atom.text_value:
+            if _normalize_node_id(event.atom.text_value) == nid:
+                return True
+    return False
+
+
+def state_deltas_for_node(receipt: ReductionReceiptV1, node_id: str) -> list[dict[str, Any]]:
+    nid = _normalize_node_id(node_id)
+    return [
+        delta.model_dump(mode="json")
+        for delta in receipt.state_deltas
+        if _normalize_node_id(delta.target_id) == nid
+    ]

--- a/orion/substrate/biometrics_loop/node_reducer.py
+++ b/orion/substrate/biometrics_loop/node_reducer.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import datetime, timezone
-from uuid import uuid4
 
 from orion.biometrics.node_catalog import NodeCatalog
+from orion.substrate.ids import stable_delta_id, stable_receipt_id
 from orion.schemas.biometrics_projection import NodeBiometricsProjectionV1
 from orion.schemas.grammar import GrammarEventV1
 from orion.schemas.reduction_receipt import ProjectionUpdateV1, ReductionReceiptV1
@@ -23,9 +23,15 @@ def _utc_now(now: datetime | None) -> datetime:
     return now if now.tzinfo else now.replace(tzinfo=timezone.utc)
 
 
-def _noop_receipt(*, event_id: str, now: datetime) -> ReductionReceiptV1:
+def _noop_receipt(*, event_id: str, now: datetime, reducer_id: str) -> ReductionReceiptV1:
     return ReductionReceiptV1(
-        receipt_id=f"rcpt_{uuid4().hex[:12]}",
+        receipt_id=stable_receipt_id(
+            reducer_id=reducer_id,
+            accepted_event_ids=[],
+            rejected_event_ids=[],
+            merged_event_ids=[],
+            noop_event_ids=[event_id],
+        ),
         noop_event_ids=[event_id],
         created_at=now,
     )
@@ -43,10 +49,14 @@ def reduce_biometrics_node_event(
     clock = _utc_now(now)
 
     if event.provenance.source_service != BIOMETRICS_SOURCE_SERVICE:
-        return projection, _noop_receipt(event_id=event.event_id, now=clock)
+        return projection, _noop_receipt(
+            event_id=event.event_id, now=clock, reducer_id=reducer_id
+        )
 
     if not parse_biometrics_trace_id(event.trace_id):
-        return projection, _noop_receipt(event_id=event.event_id, now=clock)
+        return projection, _noop_receipt(
+            event_id=event.event_id, now=clock, reducer_id=reducer_id
+        )
 
     updated = deepcopy(projection)
     updated.generated_at = clock
@@ -91,11 +101,24 @@ def reduce_biometrics_node_event(
     updated.nodes[node_id] = merged
 
     receipt = ReductionReceiptV1(
-        receipt_id=f"rcpt_{uuid4().hex[:12]}",
+        receipt_id=stable_receipt_id(
+            reducer_id=reducer_id,
+            accepted_event_ids=[event.event_id],
+            rejected_event_ids=[],
+            merged_event_ids=[],
+            noop_event_ids=[],
+        ),
         accepted_event_ids=[event.event_id],
         state_deltas=[
             StateDeltaV1(
-                delta_id=f"delta_{uuid4().hex[:12]}",
+                delta_id=stable_delta_id(
+                    reducer_id=reducer_id,
+                    target_projection=updated.projection_id,
+                    target_kind="node_biometrics",
+                    target_id=node_id,
+                    operation=operation,
+                    caused_by_event_ids=[event.event_id],
+                ),
                 target_projection=updated.projection_id,
                 target_kind="node_biometrics",
                 target_id=node_id,

--- a/orion/substrate/biometrics_loop/pressure_reducer.py
+++ b/orion/substrate/biometrics_loop/pressure_reducer.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import datetime, timezone
-from uuid import uuid4
 
 from orion.biometrics.node_catalog import NodeCatalog
+from orion.substrate.ids import stable_delta_id, stable_receipt_id
 from orion.schemas.biometrics_projection import ActiveNodePressureProjectionV1, ActiveNodePressureStateV1
 from orion.schemas.grammar import GrammarEventV1
 from orion.schemas.reduction_receipt import ProjectionUpdateV1, ReductionReceiptV1
@@ -214,7 +214,14 @@ def reduce_node_pressure_candidates(
 
         state_deltas.append(
             StateDeltaV1(
-                delta_id=f"delta_{uuid4().hex[:12]}",
+                delta_id=stable_delta_id(
+                    reducer_id=reducer_id,
+                    target_projection=updated.projection_id,
+                    target_kind="active_node_pressure",
+                    target_id=canonical_node_id,
+                    operation=ROLE_TO_OPERATION[role],
+                    caused_by_event_ids=[atom_event_id],
+                ),
                 target_projection=updated.projection_id,
                 target_kind="active_node_pressure",
                 target_id=canonical_node_id,
@@ -235,7 +242,14 @@ def reduce_node_pressure_candidates(
         )
 
     receipt = ReductionReceiptV1(
-        receipt_id=f"rcpt_{uuid4().hex[:12]}",
+        receipt_id=stable_receipt_id(
+            reducer_id=reducer_id,
+            accepted_event_ids=accepted,
+            rejected_event_ids=rejected,
+            merged_event_ids=merged,
+            noop_event_ids=[],
+            emission_id=emission_id,
+        ),
         emission_id=emission_id,
         organ_id=organ_id,
         accepted_event_ids=accepted,

--- a/orion/substrate/ids.py
+++ b/orion/substrate/ids.py
@@ -1,0 +1,60 @@
+"""Deterministic substrate receipt and state-delta identifiers."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def _sorted_join(values: list[str]) -> str:
+    return ",".join(sorted(v.strip() for v in values if v and str(v).strip()))
+
+
+def stable_hash_id(prefix: str, parts: list[str]) -> str:
+    """Return ``{prefix}_{sha256(preimage)[:24]}`` from ordered semantic parts."""
+    normalized = [str(p).strip() for p in parts if p is not None and str(p).strip()]
+    preimage = "|".join(normalized)
+    digest = hashlib.sha256(preimage.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}_{digest}"
+
+
+def stable_delta_id(
+    *,
+    reducer_id: str,
+    target_projection: str,
+    target_kind: str,
+    target_id: str,
+    operation: str,
+    caused_by_event_ids: list[str],
+) -> str:
+    return stable_hash_id(
+        "delta",
+        [
+            reducer_id,
+            target_projection,
+            target_kind,
+            target_id.strip().lower(),
+            operation,
+            _sorted_join(caused_by_event_ids),
+        ],
+    )
+
+
+def stable_receipt_id(
+    *,
+    reducer_id: str,
+    accepted_event_ids: list[str],
+    rejected_event_ids: list[str],
+    merged_event_ids: list[str],
+    noop_event_ids: list[str],
+    emission_id: str | None = None,
+) -> str:
+    parts = [
+        reducer_id,
+        _sorted_join(accepted_event_ids),
+        _sorted_join(rejected_event_ids),
+        _sorted_join(merged_event_ids),
+        _sorted_join(noop_event_ids),
+    ]
+    if emission_id:
+        parts.append(emission_id.strip())
+    return stable_hash_id("rcpt", parts)

--- a/services/orion-hub/scripts/substrate_biometrics_routes.py
+++ b/services/orion-hub/scripts/substrate_biometrics_routes.py
@@ -9,9 +9,16 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from sqlalchemy import create_engine, text
 
+from orion.schemas.organ_emission import OrganEmissionV1
+from orion.schemas.reduction_receipt import ReductionReceiptV1
 from orion.substrate.biometrics_loop.constants import (
     ACTIVE_NODE_PRESSURE_PROJECTION_ID,
     NODE_BIOMETRICS_PROJECTION_ID,
+)
+from orion.substrate.biometrics_loop.lineage import (
+    emission_touches_node,
+    receipt_touches_node,
+    state_deltas_for_node,
 )
 
 router = APIRouter(prefix="/api/substrate", tags=["substrate-biometrics"])
@@ -24,6 +31,8 @@ EVENT_CHAIN = [
     "pressure reduction receipt",
     "active pressure projection update",
 ]
+
+_LINEAGE_SCAN_LIMIT = 50
 
 
 def _engine():
@@ -64,43 +73,80 @@ def _latest_trace_for_node(node_id: str) -> str | None:
     return row["trace_id"] if row else None
 
 
-def _latest_emission_json() -> dict[str, Any] | None:
+def _recent_emissions() -> list[OrganEmissionV1]:
     with _engine().connect() as conn:
-        row = conn.execute(
+        rows = conn.execute(
             text(
                 """
                 SELECT emission_json FROM substrate_organ_emissions
                 WHERE organ_id = 'biometrics_pressure'
                 ORDER BY created_at DESC
-                LIMIT 1
+                LIMIT :limit
                 """
             ),
-        ).mappings().first()
-    if not row:
-        return None
-    payload = row["emission_json"]
-    if isinstance(payload, str):
-        payload = json.loads(payload)
-    return payload
+            {"limit": _LINEAGE_SCAN_LIMIT},
+        ).mappings().all()
+    emissions: list[OrganEmissionV1] = []
+    for row in rows:
+        payload = row["emission_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        emissions.append(OrganEmissionV1.model_validate(payload))
+    return emissions
 
 
-def _latest_receipt_json() -> dict[str, Any] | None:
+def _recent_receipts() -> list[ReductionReceiptV1]:
+    with _engine().connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT receipt_json FROM substrate_reduction_receipts
+                ORDER BY created_at DESC
+                LIMIT :limit
+                """
+            ),
+            {"limit": _LINEAGE_SCAN_LIMIT},
+        ).mappings().all()
+    receipts: list[ReductionReceiptV1] = []
+    for row in rows:
+        payload = row["receipt_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        receipts.append(ReductionReceiptV1.model_validate(payload))
+    return receipts
+
+
+def _latest_emission_for_node(node_id: str) -> dict[str, Any] | None:
+    for emission in _recent_emissions():
+        if emission_touches_node(emission, node_id):
+            return emission.model_dump(mode="json")
+    return None
+
+
+def _latest_receipt_for_node(node_id: str) -> dict[str, Any] | None:
+    for receipt in _recent_receipts():
+        if receipt_touches_node(receipt, node_id):
+            return receipt.model_dump(mode="json")
+    return None
+
+
+def _load_receipt(receipt_id: str) -> ReductionReceiptV1 | None:
     with _engine().connect() as conn:
         row = conn.execute(
             text(
                 """
                 SELECT receipt_json FROM substrate_reduction_receipts
-                ORDER BY created_at DESC
-                LIMIT 1
+                WHERE receipt_id = :receipt_id
                 """
             ),
+            {"receipt_id": receipt_id},
         ).mappings().first()
     if not row:
         return None
     payload = row["receipt_json"]
     if isinstance(payload, str):
         payload = json.loads(payload)
-    return payload
+    return ReductionReceiptV1.model_validate(payload)
 
 
 @router.get("/biometrics-node/{node_id}/latest")
@@ -114,15 +160,30 @@ async def biometrics_node_latest(node_id: str) -> dict[str, Any]:
         "substrate_active_node_pressure_projection",
         ACTIVE_NODE_PRESSURE_PROJECTION_ID,
     )
+    latest_receipt_payload = _latest_receipt_for_node(nid)
+    committed_state_deltas: list[dict[str, Any]] = []
+    if latest_receipt_payload:
+        receipt = ReductionReceiptV1.model_validate(latest_receipt_payload)
+        committed_state_deltas = state_deltas_for_node(receipt, nid)
+
     return {
         "node_id": nid,
         "latest_biometrics_trace": _latest_trace_for_node(nid),
         "node_biometrics_projection": (node_bio or {}).get("nodes", {}).get(nid, {}),
-        "latest_organ_emission": _latest_emission_json() or {},
-        "latest_reduction_receipt": _latest_receipt_json() or {},
+        "latest_organ_emission": _latest_emission_for_node(nid) or {},
+        "latest_reduction_receipt": latest_receipt_payload or {},
+        "committed_state_deltas": committed_state_deltas,
         "active_node_pressure_projection": (pressure or {}).get("nodes", {}).get(nid, {}),
         "event_chain": EVENT_CHAIN,
     }
+
+
+@router.get("/receipts/{receipt_id}")
+async def substrate_receipt_by_id(receipt_id: str) -> dict[str, Any]:
+    receipt = _load_receipt(receipt_id.strip())
+    if receipt is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return receipt.model_dump(mode="json")
 
 
 @router.get("/biometrics/latest")

--- a/services/orion-hub/tests/test_substrate_biometrics_debug_api.py
+++ b/services/orion-hub/tests/test_substrate_biometrics_debug_api.py
@@ -38,11 +38,63 @@ def client(monkeypatch):
     return TestClient(app)
 
 
+def _atlas_pressure_receipt() -> dict:
+    return {
+        "receipt_id": "rcpt_atlas_pressure",
+        "created_at": "2026-05-24T12:00:00+00:00",
+        "organ_id": "biometrics_pressure",
+        "accepted_event_ids": ["gev_pressure_1"],
+        "state_deltas": [
+            {
+                "delta_id": "delta_atlas_pressure",
+                "target_projection": "active_node_pressure_projection",
+                "target_kind": "active_node_pressure",
+                "target_id": "atlas",
+                "operation": "create",
+                "caused_by_event_ids": ["gev_pressure_1"],
+                "reducer_id": "node_pressure_reducer",
+            }
+        ],
+        "projection_updates": [
+            {
+                "projection_kind": "active_node_pressure",
+                "projection_id": "active_node_pressure_projection",
+                "node_id": "atlas",
+                "operation": "create",
+            }
+        ],
+    }
+
+
+def _atlas_emission() -> dict:
+    return {
+        "emission_id": "oem_atlas",
+        "invocation_id": "inv_atlas",
+        "created_at": "2026-05-24T12:00:00+00:00",
+        "organ_id": "biometrics_pressure",
+        "candidate_events": [
+            {
+                "event_id": "gev_pressure_1",
+                "trace_id": "substrate.pressure:atlas:2026-05-24T12:00:00Z",
+                "event_kind": "atom_emitted",
+                "emitted_at": "2026-05-24T12:00:00+00:00",
+                "provenance": {
+                    "source_service": "orion-substrate-runtime",
+                    "source_component": "biometrics_pressure",
+                },
+            }
+        ],
+    }
+
+
 def test_latest_chain_shape(client):
     fake_engine = MagicMock()
     conn = MagicMock()
     fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
     fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    receipt_rows = [{"receipt_json": _atlas_pressure_receipt()}]
+    emission_rows = [{"emission_json": _atlas_emission()}]
 
     def execute(stmt, params=None):
         sql = str(stmt)
@@ -51,14 +103,10 @@ def test_latest_chain_shape(client):
             m.mappings.return_value.first.return_value = {
                 "trace_id": "biometrics.node:atlas:2026-05-24T12:00:00Z",
             }
-        elif "substrate_organ_emissions" in sql:
-            m.mappings.return_value.first.return_value = {
-                "emission_json": {"emission_id": "oem_1", "organ_id": "biometrics_pressure"},
-            }
-        elif "substrate_reduction_receipts" in sql:
-            m.mappings.return_value.first.return_value = {
-                "receipt_json": {"receipt_id": "rcpt_1", "accepted_event_ids": ["gev_1"]},
-            }
+        elif "substrate_organ_emissions" in sql and "LIMIT" in sql:
+            m.mappings.return_value.all.return_value = emission_rows
+        elif "substrate_reduction_receipts" in sql and "LIMIT" in sql:
+            m.mappings.return_value.all.return_value = receipt_rows
         elif "substrate_node_biometrics_projection" in sql:
             m.mappings.return_value.first.return_value = {
                 "projection_json": {
@@ -89,4 +137,28 @@ def test_latest_chain_shape(client):
     assert body["node_id"] == "atlas"
     assert "event_chain" in body
     assert len(body["event_chain"]) == 6
-    assert body["latest_reduction_receipt"]["receipt_id"] == "rcpt_1"
+    assert body["latest_reduction_receipt"]["receipt_id"] == "rcpt_atlas_pressure"
+    assert body["latest_organ_emission"]["emission_id"] == "oem_atlas"
+    assert body["committed_state_deltas"][0]["target_id"] == "atlas"
+
+
+def test_receipt_by_id(client):
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute(stmt, params=None):
+        m = MagicMock()
+        m.mappings.return_value.first.return_value = {
+            "receipt_json": _atlas_pressure_receipt(),
+        }
+        return m
+
+    conn.execute.side_effect = execute
+
+    with patch.object(substrate_biometrics_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/receipts/rcpt_atlas_pressure")
+
+    assert r.status_code == 200
+    assert r.json()["receipt_id"] == "rcpt_atlas_pressure"

--- a/services/orion-hub/tests/test_substrate_biometrics_debug_api.py
+++ b/services/orion-hub/tests/test_substrate_biometrics_debug_api.py
@@ -142,6 +142,59 @@ def test_latest_chain_shape(client):
     assert body["committed_state_deltas"][0]["target_id"] == "atlas"
 
 
+def test_latest_chain_skips_non_matching_global_receipt(client):
+    """Newest global receipt for another node must not appear on atlas latest."""
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    circe_receipt = {
+        "receipt_id": "rcpt_circe_only",
+        "created_at": "2026-05-24T12:01:00+00:00",
+        "state_deltas": [
+            {
+                "delta_id": "delta_circe",
+                "target_projection": "active_node_pressure_projection",
+                "target_kind": "active_node_pressure",
+                "target_id": "circe",
+                "operation": "create",
+                "caused_by_event_ids": ["gev_circe"],
+                "reducer_id": "node_pressure_reducer",
+            }
+        ],
+    }
+    receipt_rows = [
+        {"receipt_json": circe_receipt},
+        {"receipt_json": _atlas_pressure_receipt()},
+    ]
+
+    def execute(stmt, params=None):
+        sql = str(stmt)
+        m = MagicMock()
+        if "grammar_events" in sql:
+            m.mappings.return_value.first.return_value = None
+        elif "substrate_reduction_receipts" in sql and "LIMIT" in sql:
+            m.mappings.return_value.all.return_value = receipt_rows
+        elif "substrate_organ_emissions" in sql and "LIMIT" in sql:
+            m.mappings.return_value.all.return_value = []
+        elif "substrate_node_biometrics_projection" in sql:
+            m.mappings.return_value.first.return_value = {"projection_json": {"nodes": {}}}
+        elif "substrate_active_node_pressure_projection" in sql:
+            m.mappings.return_value.first.return_value = {"projection_json": {"nodes": {}}}
+        else:
+            m.mappings.return_value.first.return_value = None
+        return m
+
+    conn.execute.side_effect = execute
+
+    with patch.object(substrate_biometrics_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/biometrics-node/atlas/latest")
+
+    assert r.status_code == 200
+    assert r.json()["latest_reduction_receipt"]["receipt_id"] == "rcpt_atlas_pressure"
+
+
 def test_receipt_by_id(client):
     fake_engine = MagicMock()
     conn = MagicMock()

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -22,3 +22,12 @@ docker compose up --build
 ```
 
 Health: `GET http://localhost:8115/health`
+
+## Idempotent committed deltas
+
+`ReductionReceiptV1.receipt_id` and `StateDeltaV1.delta_id` are derived from reducer inputs via `orion.substrate.ids` so replay/retry does not mint duplicate committed identities. Postgres inserts use `ON CONFLICT (receipt_id) DO NOTHING`.
+
+Hub debug (node-scoped lineage):
+
+- `GET /api/substrate/biometrics-node/{node_id}/latest`
+- `GET /api/substrate/receipts/{receipt_id}`

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -27,6 +27,8 @@ Health: `GET http://localhost:8115/health`
 
 `ReductionReceiptV1.receipt_id` and `StateDeltaV1.delta_id` are derived from reducer inputs via `orion.substrate.ids` so replay/retry does not mint duplicate committed identities. Postgres inserts use `ON CONFLICT (receipt_id) DO NOTHING`.
 
+Pressure receipts also include `emission_id` in the receipt preimage (organ still mints a fresh `emission_id` per invocation). Field digester dedupe should key on **`delta_id`** (event-scoped), not `receipt_id`, when comparing across emissions.
+
 Hub debug (node-scoped lineage):
 
 - `GET /api/substrate/biometrics-node/{node_id}/latest`

--- a/services/orion-substrate-runtime/app/store.py
+++ b/services/orion-substrate-runtime/app/store.py
@@ -16,6 +16,7 @@ from orion.schemas.organ_emission import OrganEmissionV1
 from orion.schemas.reduction_receipt import ReductionReceiptV1
 
 from orion.substrate.biometrics_loop.constants import GRAMMAR_CURSOR_NAME
+from orion.substrate.biometrics_loop.lineage import emission_touches_node, receipt_touches_node
 
 
 class BiometricsSubstrateStore:
@@ -214,7 +215,7 @@ class BiometricsSubstrateStore:
                     SELECT emission_json FROM substrate_organ_emissions
                     WHERE organ_id = 'biometrics_pressure'
                     ORDER BY created_at DESC
-                    LIMIT 20
+                    LIMIT 50
                     """
                 ),
             ).mappings().all()
@@ -223,10 +224,47 @@ class BiometricsSubstrateStore:
             if isinstance(payload, str):
                 payload = json.loads(payload)
             emission = OrganEmissionV1.model_validate(payload)
-            for ev in emission.candidate_events:
-                if node_id in ev.trace_id:
-                    return emission
+            if emission_touches_node(emission, node_id):
+                return emission
         return None
+
+    def latest_receipt_for_node(self, node_id: str) -> ReductionReceiptV1 | None:
+        with self._engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT receipt_json FROM substrate_reduction_receipts
+                    ORDER BY created_at DESC
+                    LIMIT 50
+                    """
+                ),
+            ).mappings().all()
+        for row in rows:
+            payload = row["receipt_json"]
+            if isinstance(payload, str):
+                payload = json.loads(payload)
+            receipt = ReductionReceiptV1.model_validate(payload)
+            if receipt_touches_node(receipt, node_id):
+                return receipt
+        return None
+
+    def load_receipt(self, receipt_id: str) -> ReductionReceiptV1 | None:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    """
+                    SELECT receipt_json FROM substrate_reduction_receipts
+                    WHERE receipt_id = :receipt_id
+                    """
+                ),
+                {"receipt_id": receipt_id},
+            ).mappings().first()
+        if not row:
+            return None
+        payload = row["receipt_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return ReductionReceiptV1.model_validate(payload)
 
     def grammar_event_created_at(self, event_id: str) -> datetime | None:
         with self._engine.connect() as conn:

--- a/tests/test_node_biometrics_reducer.py
+++ b/tests/test_node_biometrics_reducer.py
@@ -210,3 +210,29 @@ def test_non_biometrics_source_is_noop(
     )
     assert projection == empty_projection
     assert receipt.noop_event_ids == ["gev_other"]
+
+
+def test_node_reducer_ids_are_stable_on_replay(
+    catalog: NodeCatalog, empty_projection: NodeBiometricsProjectionV1
+) -> None:
+    trace_id = "biometrics.node:atlas:2026-05-24T12:00:00Z"
+    event = _atom_event(
+        trace_id=trace_id,
+        event_id="gev_body",
+        role="body_state",
+        payload_ref="biometrics.summary:atlas:2026-05-24T12:00:00Z",
+    )
+    _, r1 = reduce_biometrics_node_event(
+        event=event,
+        projection=empty_projection,
+        catalog=catalog,
+        now=FIXED_TS,
+    )
+    _, r2 = reduce_biometrics_node_event(
+        event=event,
+        projection=empty_projection,
+        catalog=catalog,
+        now=FIXED_TS,
+    )
+    assert r1.receipt_id == r2.receipt_id
+    assert r1.state_deltas[0].delta_id == r2.state_deltas[0].delta_id

--- a/tests/test_node_pressure_reducer.py
+++ b/tests/test_node_pressure_reducer.py
@@ -133,6 +133,8 @@ def test_projection_rebuilds_deterministically(
     )
     assert p1.model_dump(mode="json") == p2.model_dump(mode="json")
     assert r1.accepted_event_ids == r2.accepted_event_ids
+    assert r1.receipt_id == r2.receipt_id
+    assert [d.delta_id for d in r1.state_deltas] == [d.delta_id for d in r2.state_deltas]
 
 
 def test_low_confidence_rejected(

--- a/tests/test_substrate_deterministic_ids.py
+++ b/tests/test_substrate_deterministic_ids.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from orion.substrate.ids import stable_delta_id, stable_hash_id, stable_receipt_id
+
+
+def test_stable_hash_id_is_deterministic() -> None:
+    a = stable_hash_id("rcpt", ["reducer", "gev_1", "gev_2"])
+    b = stable_hash_id("rcpt", ["reducer", "gev_1", "gev_2"])
+    assert a == b
+    assert a.startswith("rcpt_")
+
+
+def test_stable_receipt_id_sorts_event_buckets() -> None:
+    r1 = stable_receipt_id(
+        reducer_id="node_pressure_reducer",
+        accepted_event_ids=["gev_b", "gev_a"],
+        rejected_event_ids=[],
+        merged_event_ids=[],
+        noop_event_ids=[],
+        emission_id="oem_1",
+    )
+    r2 = stable_receipt_id(
+        reducer_id="node_pressure_reducer",
+        accepted_event_ids=["gev_a", "gev_b"],
+        rejected_event_ids=[],
+        merged_event_ids=[],
+        noop_event_ids=[],
+        emission_id="oem_1",
+    )
+    assert r1 == r2
+
+
+def test_stable_delta_id_normalizes_node_id() -> None:
+    d1 = stable_delta_id(
+        reducer_id="biometrics_node_reducer",
+        target_projection="proj_node_bio",
+        target_kind="node_biometrics",
+        target_id="Atlas",
+        operation="update",
+        caused_by_event_ids=["gev_1"],
+    )
+    d2 = stable_delta_id(
+        reducer_id="biometrics_node_reducer",
+        target_projection="proj_node_bio",
+        target_kind="node_biometrics",
+        target_id="atlas",
+        operation="update",
+        caused_by_event_ids=["gev_1"],
+    )
+    assert d1 == d2
+    assert d1.startswith("delta_")

--- a/tests/test_substrate_lineage.py
+++ b/tests/test_substrate_lineage.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.schemas.organ_emission import OrganEmissionV1
+from orion.schemas.reduction_receipt import ProjectionUpdateV1, ReductionReceiptV1
+from orion.schemas.state_delta import StateDeltaV1
+from orion.substrate.biometrics_loop.lineage import (
+    emission_touches_node,
+    receipt_touches_node,
+    state_deltas_for_node,
+)
+
+
+FIXED_TS = datetime(2026, 5, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_receipt_touches_node_via_state_delta() -> None:
+    receipt = ReductionReceiptV1(
+        receipt_id="rcpt_1",
+        created_at=FIXED_TS,
+        state_deltas=[
+            StateDeltaV1(
+                delta_id="delta_1",
+                target_projection="proj",
+                target_kind="active_node_pressure",
+                target_id="atlas",
+                operation="create",
+                caused_by_event_ids=["gev_1"],
+                reducer_id="node_pressure_reducer",
+            )
+        ],
+    )
+    assert receipt_touches_node(receipt, "atlas")
+    assert not receipt_touches_node(receipt, "circe")
+
+
+def test_emission_touches_node_via_trace() -> None:
+    emission = OrganEmissionV1.model_validate(
+        {
+            "emission_id": "oem_1",
+            "organ_id": "biometrics_pressure",
+            "invocation_id": "inv_1",
+            "created_at": FIXED_TS.isoformat(),
+            "candidate_events": [
+                {
+                    "event_id": "gev_1",
+                    "trace_id": "substrate.pressure:atlas:2026-05-24T12:00:00Z",
+                    "event_kind": "atom_emitted",
+                    "emitted_at": FIXED_TS.isoformat(),
+                    "provenance": {
+                        "source_service": "orion-substrate-runtime",
+                        "source_component": "biometrics_pressure",
+                    },
+                }
+            ],
+        }
+    )
+    assert emission_touches_node(emission, "atlas")
+
+
+def test_state_deltas_for_node_filters() -> None:
+    receipt = ReductionReceiptV1(
+        receipt_id="rcpt_1",
+        created_at=FIXED_TS,
+        state_deltas=[
+            StateDeltaV1(
+                delta_id="delta_atlas",
+                target_projection="proj",
+                target_kind="node_biometrics",
+                target_id="atlas",
+                operation="update",
+                caused_by_event_ids=["gev_1"],
+                reducer_id="biometrics_node_reducer",
+            ),
+            StateDeltaV1(
+                delta_id="delta_circe",
+                target_projection="proj",
+                target_kind="node_biometrics",
+                target_id="circe",
+                operation="update",
+                caused_by_event_ids=["gev_2"],
+                reducer_id="biometrics_node_reducer",
+            ),
+        ],
+        projection_updates=[
+            ProjectionUpdateV1(
+                projection_kind="node_biometrics",
+                projection_id="proj",
+                node_id="atlas",
+                operation="update",
+            )
+        ],
+    )
+    deltas = state_deltas_for_node(receipt, "atlas")
+    assert len(deltas) == 1
+    assert deltas[0]["delta_id"] == "delta_atlas"


### PR DESCRIPTION
# PR: Harden biometrics substrate delta seam for field digestion

**Branch:** `feat/biometrics-substrate-delta-seam-hardening`  
**Base:** `feat/biometrics-substrate-closed-loop-v1`  
**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-biometrics-substrate-delta-seam-hardening`  
**Head:** `f7d17930` (3 commits)

## Summary

Hardens the committed substrate delta seam so `orion-field-digester` can consume `ReductionReceiptV1` / `StateDeltaV1` without duplicate perturbations on replay. Replaces UUID-ish `receipt_id` / `delta_id` with deterministic SHA-256-derived identities, fixes Hub debug to return **node-scoped** emission/receipt lineage (not global latest), and adds receipt lookup for digester prep.

## Problem

- Reducers minted `rcpt_{uuid}` / `delta_{uuid}` — replay/retry produced logically identical deltas with new IDs.
- Hub `GET /api/substrate/biometrics-node/{node_id}/latest` returned the latest **global** organ emission and reduction receipt, not the chain for that node.

## Solution

### Deterministic IDs (`orion/substrate/ids.py`)

- `stable_hash_id(prefix, parts)` → `{prefix}_{sha256[:24]}`
- `stable_delta_id(...)` — reducer, projection, target, operation, sorted `caused_by_event_ids`
- `stable_receipt_id(...)` — reducer, sorted event buckets, optional `emission_id`

Wired in `node_reducer.py` and `pressure_reducer.py` (noop receipts included).

**Digester note:** Pressure receipts include `emission_id` in the preimage (organ still creates a new `emission_id` per invocation). Dedupe across emissions should use **`delta_id`**, not `receipt_id`.

### Node-scoped lineage (`orion/substrate/biometrics_loop/lineage.py`)

- `receipt_touches_node` / `emission_touches_node` / `state_deltas_for_node`
- Hub and `BiometricsSubstrateStore` scan the last 50 rows and filter by node (replacing global `LIMIT 1`).

### Hub API

| Route | Change |
|-------|--------|
| `GET /api/substrate/biometrics-node/{node_id}/latest` | Node-filtered emission/receipt + `committed_state_deltas` |
| `GET /api/substrate/receipts/{receipt_id}` | **New** — load committed receipt by id |

### Runtime store

- `latest_receipt_for_node`, `load_receipt`
- `latest_emission_for_node` uses shared lineage helper

Existing `ON CONFLICT (receipt_id) DO NOTHING` on insert remains the persistence idempotency guard.

## Architecture (unchanged loop)

```text
orion-biometrics → grammar_events → substrate-runtime
  → node_biometrics_projection → biometrics_pressure → active_node_pressure_projection
  → committed ReductionReceiptV1 + StateDeltaV1 (now stable IDs)
```

## Test plan

- [x] `PYTHONPATH=. pytest tests/test_substrate_deterministic_ids.py tests/test_substrate_lineage.py tests/test_node_biometrics_reducer.py tests/test_node_pressure_reducer.py tests/test_biometrics_pipeline.py orion/grammar/tests/test_biometrics_substrate_schemas.py services/orion-hub/tests/test_substrate_biometrics_debug_api.py -q` → **28 passed**
- [ ] Live stack: replay same grammar event / runtime poll — receipt row count does not grow for same logical delta
- [ ] Hub: `curl .../biometrics-node/atlas/latest` shows atlas emission/receipt when a newer global receipt exists for another node

## Verification evidence

```
28 passed in ~1.5s (targeted substrate + hub debug suite)
```

Code review (subagent): **Approved** — spec compliant; added negative lineage hub test post-review.

## Non-goals (confirmed)

- No field digester service, tensor math, new organ, grammar redesign, collector rewrite, UI polish, autonomy actions, cluster aggregate source, `debug_trace` parsing.

## Files touched

| Area | Files |
|------|--------|
| IDs | `orion/substrate/ids.py` |
| Reducers | `node_reducer.py`, `pressure_reducer.py` |
| Lineage | `lineage.py`, `store.py`, `substrate_biometrics_routes.py` |
| Tests | `test_substrate_deterministic_ids.py`, `test_substrate_lineage.py`, reducer/hub tests |
| Docs | `services/orion-substrate-runtime/README.md` |

## Operator notes

No new env vars or SQL migration. Redeploy `orion-substrate-runtime` and Hub after merge. Existing receipts with random IDs remain in DB; new writes use deterministic IDs.
