### PR TITLE
Feat/self state v1

### DIFF
--- a/config/self_state/self_state_policy.v1.yaml
+++ b/config/self_state/self_state_policy.v1.yaml
@@ -1,0 +1,54 @@
+schema_version: self_state_policy.v1
+policy_id: self_state_policy.v1
+
+condition_thresholds:
+  quiet_max: 0.15
+  steady_max: 0.40
+  loaded_max: 0.70
+  strained_max: 0.90
+
+dimension_weights:
+  field_intensity: 0.15
+  coherence: 0.15
+  uncertainty: 0.10
+  agency_readiness: 0.10
+  resource_pressure: 0.10
+  execution_pressure: 0.15
+  reasoning_pressure: 0.05
+  reliability_pressure: 0.15
+  continuity_pressure: 0.03
+  introspection_pressure: 0.02
+
+attention_target_weights:
+  system: 0.30
+  node: 0.35
+  capability: 0.35
+
+channel_dimension_map:
+  execution_load: execution_pressure
+  execution_friction: reliability_pressure
+  failure_pressure: reliability_pressure
+  reasoning_load: reasoning_pressure
+  cpu_pressure: resource_pressure
+  gpu_pressure: resource_pressure
+  memory_pressure: resource_pressure
+  disk_pressure: resource_pressure
+  thermal_pressure: resource_pressure
+  staleness: continuity_pressure
+  availability: coherence
+  expected_offline_suppression: coherence
+  pressure: resource_pressure
+  execution_pressure: execution_pressure
+  reasoning_pressure: reasoning_pressure
+  reliability_pressure: reliability_pressure
+  confidence: coherence
+  available_capacity: coherence
+
+stabilizing_channels:
+  availability: 0.50
+  confidence: 0.50
+  available_capacity: 0.50
+  expected_offline_suppression: 0.30
+
+unresolved_pressure_threshold: 0.60
+dominant_channel_threshold: 0.25

--- a/docs/superpowers/pr-reports/2026-05-24-self-state-v1-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-24-self-state-v1-pr.md
@@ -1,0 +1,116 @@
+# PR: Self-State v1 — Attention + Field → Orion Operating Condition
+
+**Branch:** `feat/self-state-v1`  
+**Base:** `main`  
+**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-self-state-v1`
+
+## Summary
+
+Implements **Layer 6** of the Orion cognition substrate: deterministic, read-only synthesis of Orion’s **operating condition** from digested field state and the attention frame.
+
+```text
+substrate_field_state (FieldStateV1)
++ substrate_attention_frames (FieldAttentionFrameV1)
+  → orion-self-state-runtime
+  → SelfStateV1
+  → substrate_self_state
+  → GET /api/substrate/self-state/latest (Hub debug)
+```
+
+**Core phrase:** *Self-state is the substrate’s estimate of operating condition* — not agency, not action, not personality prose.
+
+### 11-layer roadmap placement
+
+| Layer | Name | This PR |
+|-------|------|---------|
+| 1–5 | Organs → … → Attention | Prerequisite (field-digester + attention-runtime) |
+| **6** | **Self-state** | **Implemented** |
+| 7 | Proposals | Deferred |
+| 8–11 | Policy → Execution → Feedback → Consolidation | Deferred |
+
+## Architecture
+
+| Component | Role |
+|-----------|------|
+| `config/self_state/self_state_policy.v1.yaml` | Dimension weights, channel→dimension map, condition thresholds |
+| `orion/self_state/{policy,scoring,builder}.py` | Pure deterministic self-state synthesis |
+| `services/orion-self-state-runtime` | Poll latest attention → load field → build → persist (no bus) |
+| `substrate_self_state` | Postgres persistence |
+| `scripts/smoke_self_state_v1.sh` | SQL inspection |
+
+## Example synthetic `SelfStateV1`
+
+From live builder run (`node:athena.execution_load=1.0`, `capability:orchestration.execution_pressure=1.0`):
+
+```json
+{
+  "overall_condition": "steady",
+  "overall_intensity": 0.3194,
+  "execution_pressure": 1.0,
+  "agency_readiness": 0.205,
+  "summary_labels": [
+    "execution_loaded",
+    "reliability_clear"
+  ],
+  "dominant_attention_targets": [
+    "capability:orchestration",
+    "node:athena",
+    "field:recent_perturbations"
+  ]
+}
+```
+
+`agency_readiness` is computed but **does not authorize action** — Layer 7+ owns proposals and policy gates.
+
+## Non-goals (explicit)
+
+This PR does **not** implement:
+
+- proposal/action generation (`ProposalFrameV1`)
+- policy gates or cortex-exec steering
+- mind service / LLM interpretation
+- bus-published events (`orion/bus/channels.yaml` unchanged)
+- mutation of `FieldStateV1` or `FieldAttentionFrameV1`
+- operator notifications
+
+## Tests run
+
+```bash
+PYTHONPATH=. pytest tests/test_self_state_*.py -q
+# 21 passed
+
+PYTHONPATH=. pytest tests/test_attention_frame_schemas.py tests/test_attention_frame_builder.py \
+  tests/test_attention_field_scoring.py tests/test_attention_policy_loader.py -q
+# 20 passed
+
+PYTHONPATH=. pytest services/orion-hub/tests/test_substrate_self_state_debug_api.py -q
+# 2 passed
+
+PYTHONPATH=. pytest tests/test_field_state_schemas.py -q
+# 2 passed
+
+PYTHONPATH=. python -m compileall orion/self_state orion/schemas/self_state.py services/orion-self-state-runtime -q
+# clean
+```
+
+## Operator checklist
+
+1. Apply migration: `services/orion-sql-db/manual_migration_self_state_v1.sql`
+2. Ensure `orion-field-digester` and `orion-attention-runtime` are running
+3. Start runtime: `services/orion-self-state-runtime` (port **8118**)
+4. Smoke: `./scripts/smoke_self_state_v1.sh`
+
+## Known gaps (Layer 7+)
+
+- `previous_self_state` parameter reserved; continuity deltas not yet applied
+- Worker processes **latest** attention frame only (same idempotency pattern as attention-runtime)
+- No `ProposalFrameV1` or action pressure export
+
+## Files changed (high level)
+
+- `orion/schemas/self_state.py`, `orion/schemas/registry.py`
+- `orion/self_state/*`, `config/self_state/self_state_policy.v1.yaml`
+- `services/orion-self-state-runtime/*`
+- `services/orion-sql-db/manual_migration_self_state_v1.sql`
+- `services/orion-hub/scripts/substrate_self_state_routes.py`
+- `tests/test_self_state_*.py`, `scripts/smoke_self_state_v1.sh`

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -461,6 +461,7 @@ from orion.schemas.situation import (
 )
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
 from orion.schemas.field_state import FieldEdgeV1, FieldStateV1
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
 from orion.schemas.evidence_index import (
     EvidenceQueryResultItemV1,
     EvidenceQueryV1,
@@ -940,6 +941,8 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "FieldStateV1": FieldStateV1,
     "FieldAttentionTargetV1": FieldAttentionTargetV1,
     "FieldAttentionFrameV1": FieldAttentionFrameV1,
+    "SelfStateDimensionV1": SelfStateDimensionV1,
+    "SelfStateV1": SelfStateV1,
     "EvidenceUnitV1": EvidenceUnitV1,
     "EvidenceQueryV1": EvidenceQueryV1,
     "EvidenceQueryResultItemV1": EvidenceQueryResultItemV1,

--- a/orion/schemas/self_state.py
+++ b/orion/schemas/self_state.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SelfStateDimensionV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dimension_id: Literal[
+        "field_intensity",
+        "coherence",
+        "uncertainty",
+        "agency_readiness",
+        "resource_pressure",
+        "execution_pressure",
+        "reasoning_pressure",
+        "reliability_pressure",
+        "continuity_pressure",
+        "introspection_pressure",
+        "social_pressure",
+        "policy_pressure",
+    ]
+
+    score: float = Field(ge=0.0, le=1.0)
+    confidence: float = Field(ge=0.0, le=1.0)
+
+    dominant_evidence: list[str] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+
+
+class SelfStateV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["self.state.v1"] = "self.state.v1"
+
+    self_state_id: str
+    generated_at: datetime
+
+    source_field_tick_id: str
+    source_field_generated_at: datetime
+
+    source_attention_frame_id: str
+    source_attention_generated_at: datetime
+
+    self_state_policy_id: str = "self_state_policy.v1"
+
+    overall_condition: Literal[
+        "quiet",
+        "steady",
+        "loaded",
+        "strained",
+        "unstable",
+        "unknown",
+    ] = "unknown"
+
+    overall_intensity: float = Field(ge=0.0, le=1.0)
+    overall_confidence: float = Field(ge=0.0, le=1.0)
+
+    dimensions: dict[str, SelfStateDimensionV1] = Field(default_factory=dict)
+
+    dominant_attention_targets: list[str] = Field(default_factory=list)
+    dominant_field_channels: dict[str, float] = Field(default_factory=dict)
+
+    unresolved_pressures: list[str] = Field(default_factory=list)
+    stabilizing_factors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    summary_labels: list[str] = Field(default_factory=list)

--- a/orion/self_state/__init__.py
+++ b/orion/self_state/__init__.py
@@ -1,0 +1,8 @@
+from orion.self_state.builder import build_self_state
+from orion.self_state.policy import SelfStatePolicyV1, load_self_state_policy
+
+__all__ = [
+    "SelfStatePolicyV1",
+    "build_self_state",
+    "load_self_state_policy",
+]

--- a/orion/self_state/builder.py
+++ b/orion/self_state/builder.py
@@ -64,6 +64,7 @@ def _emit_summary_labels(
     *,
     dimension_scores: dict[str, float],
     overall_condition: str,
+    overall_salience: float,
 ) -> list[str]:
     labels: list[str] = []
     if dimension_scores.get("execution_pressure", 0.0) >= 0.5:
@@ -74,8 +75,10 @@ def _emit_summary_labels(
         labels.append("reliability_clear")
     if dimension_scores.get("field_intensity", 0.0) >= 0.5:
         labels.append("field_active")
+    if overall_salience >= 0.7:
+        labels.append("attention_saturated")
     if overall_condition in ("loaded", "strained", "unstable"):
-        labels.append("condition_elevated")
+        labels.append("orchestration_pressurized")
     return sorted(set(labels))
 
 
@@ -153,11 +156,12 @@ def build_self_state(
     evidence_density = clamp01(len(dominant_targets) / 5.0)
     overall_confidence = clamp01(0.5 + 0.5 * evidence_density)
 
-    dominant_field_channels = {
-        ch: v
+    ranked_channels = [
+        (ch, v)
         for ch, v in sorted(field_channels.items(), key=lambda kv: kv[1], reverse=True)
         if v >= policy.dominant_channel_threshold
-    }
+    ]
+    dominant_field_channels = {ch: v for ch, v in ranked_channels[:8]}
 
     unresolved: list[str] = []
     stabilizing: list[str] = []
@@ -185,6 +189,7 @@ def build_self_state(
     summary_labels = _emit_summary_labels(
         dimension_scores=dimension_scores,
         overall_condition=overall_condition,
+        overall_salience=attention.overall_salience,
     )
 
     return SelfStateV1(

--- a/orion/self_state/builder.py
+++ b/orion/self_state/builder.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal, cast
+
+from orion.self_state.policy import SelfStatePolicyV1
+from orion.self_state.scoring import (
+    agency_readiness_score,
+    clamp01,
+    collect_attention_channel_pressures,
+    collect_field_channel_pressures,
+    condition_from_intensity,
+    coherence_score,
+    field_intensity_score,
+    map_channels_to_dimensions,
+    uncertainty_score,
+    weighted_overall_intensity,
+)
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.field_state import FieldStateV1
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+DimensionId = Literal[
+    "field_intensity",
+    "coherence",
+    "uncertainty",
+    "agency_readiness",
+    "resource_pressure",
+    "execution_pressure",
+    "reasoning_pressure",
+    "reliability_pressure",
+    "continuity_pressure",
+    "introspection_pressure",
+    "social_pressure",
+    "policy_pressure",
+]
+
+ALL_DIMENSION_IDS: tuple[DimensionId, ...] = (
+    "field_intensity",
+    "coherence",
+    "uncertainty",
+    "agency_readiness",
+    "resource_pressure",
+    "execution_pressure",
+    "reasoning_pressure",
+    "reliability_pressure",
+    "continuity_pressure",
+    "introspection_pressure",
+    "social_pressure",
+    "policy_pressure",
+)
+
+
+def stable_self_state_id(
+    *,
+    source_field_tick_id: str,
+    source_attention_frame_id: str,
+    policy_id: str,
+) -> str:
+    return f"self.state:{source_field_tick_id}:{source_attention_frame_id}:{policy_id}"
+
+
+def _emit_summary_labels(
+    *,
+    dimension_scores: dict[str, float],
+    overall_condition: str,
+) -> list[str]:
+    labels: list[str] = []
+    if dimension_scores.get("execution_pressure", 0.0) >= 0.5:
+        labels.append("execution_loaded")
+    if dimension_scores.get("resource_pressure", 0.0) >= 0.5:
+        labels.append("resource_pressurized")
+    if dimension_scores.get("reliability_pressure", 0.0) < 0.3:
+        labels.append("reliability_clear")
+    if dimension_scores.get("field_intensity", 0.0) >= 0.5:
+        labels.append("field_active")
+    if overall_condition in ("loaded", "strained", "unstable"):
+        labels.append("condition_elevated")
+    return sorted(set(labels))
+
+
+def build_self_state(
+    *,
+    field: FieldStateV1,
+    attention: FieldAttentionFrameV1,
+    policy: SelfStatePolicyV1,
+    previous_self_state: SelfStateV1 | None = None,
+    now: datetime | None = None,
+) -> SelfStateV1:
+    del previous_self_state  # reserved for continuity deltas in a later revision
+    generated_at = now or datetime.now(timezone.utc)
+
+    warnings: list[str] = []
+    if attention.source_field_tick_id != field.tick_id:
+        warnings.append(
+            f"attention_source_tick_mismatch:{attention.source_field_tick_id}!={field.tick_id}"
+        )
+
+    field_channels = collect_field_channel_pressures(field)
+    attn_channels = collect_attention_channel_pressures(attention, policy)
+    merged_channels: dict[str, float] = dict(field_channels)
+    for k, v in attn_channels.items():
+        merged_channels[k] = max(merged_channels.get(k, 0.0), v)
+
+    mapped = map_channels_to_dimensions(channel_pressures=merged_channels, policy=policy)
+
+    coherence = coherence_score(channel_pressures=merged_channels, policy=policy)
+    uncertainty = uncertainty_score(
+        overall_salience=attention.overall_salience,
+        coherence=coherence,
+    )
+    field_intensity = field_intensity_score(
+        overall_salience=attention.overall_salience,
+        recent_perturbation_saturation=merged_channels.get("recent_perturbation_count", 0.0),
+    )
+
+    execution_p = mapped.get("execution_pressure", 0.0)
+    reliability_p = mapped.get("reliability_pressure", 0.0)
+    resource_p = mapped.get("resource_pressure", 0.0)
+    reasoning_p = mapped.get("reasoning_pressure", 0.0)
+    continuity_p = mapped.get("continuity_pressure", 0.0)
+
+    agency = agency_readiness_score(
+        coherence=coherence,
+        execution_pressure=execution_p,
+        reliability_pressure=reliability_p,
+        uncertainty=uncertainty,
+        resource_pressure=resource_p,
+    )
+
+    dimension_scores: dict[str, float] = {
+        "field_intensity": field_intensity,
+        "coherence": coherence,
+        "uncertainty": uncertainty,
+        "agency_readiness": agency,
+        "resource_pressure": resource_p,
+        "execution_pressure": execution_p,
+        "reasoning_pressure": reasoning_p,
+        "reliability_pressure": reliability_p,
+        "continuity_pressure": continuity_p,
+        "introspection_pressure": 0.0,
+        "social_pressure": 0.0,
+        "policy_pressure": 0.0,
+    }
+
+    overall_intensity = weighted_overall_intensity(dimension_scores, policy)
+    overall_condition = cast(
+        Literal["quiet", "steady", "loaded", "strained", "unstable", "unknown"],
+        condition_from_intensity(overall_intensity, policy.condition_thresholds),
+    )
+
+    dominant_targets = [t.target_id for t in attention.dominant_targets[:5]]
+    evidence_density = clamp01(len(dominant_targets) / 5.0)
+    overall_confidence = clamp01(0.5 + 0.5 * evidence_density)
+
+    dominant_field_channels = {
+        ch: v
+        for ch, v in sorted(field_channels.items(), key=lambda kv: kv[1], reverse=True)
+        if v >= policy.dominant_channel_threshold
+    }
+
+    unresolved: list[str] = []
+    stabilizing: list[str] = []
+    for ch, v in merged_channels.items():
+        if ch in policy.stabilizing_channels and v >= 0.3:
+            stabilizing.append(f"{ch}={v:.2f}")
+        dim = policy.channel_dimension_map.get(ch)
+        if dim and v >= policy.unresolved_pressure_threshold:
+            unresolved.append(f"{ch}→{dim}")
+
+    dimensions: dict[str, SelfStateDimensionV1] = {}
+    for dim_id in ALL_DIMENSION_IDS:
+        score = dimension_scores.get(dim_id, 0.0)
+        dimensions[dim_id] = SelfStateDimensionV1(
+            dimension_id=dim_id,
+            score=clamp01(score),
+            confidence=overall_confidence,
+            dominant_evidence=[
+                f"{ch}={dominant_field_channels[ch]:.2f}"
+                for ch in list(dominant_field_channels.keys())[:3]
+            ],
+            reasons=[f"{dim_id} from field+attention channel synthesis"],
+        )
+
+    summary_labels = _emit_summary_labels(
+        dimension_scores=dimension_scores,
+        overall_condition=overall_condition,
+    )
+
+    return SelfStateV1(
+        self_state_id=stable_self_state_id(
+            source_field_tick_id=field.tick_id,
+            source_attention_frame_id=attention.frame_id,
+            policy_id=policy.policy_id,
+        ),
+        generated_at=generated_at,
+        source_field_tick_id=field.tick_id,
+        source_field_generated_at=field.generated_at,
+        source_attention_frame_id=attention.frame_id,
+        source_attention_generated_at=attention.generated_at,
+        self_state_policy_id=policy.policy_id,
+        overall_condition=overall_condition,
+        overall_intensity=overall_intensity,
+        overall_confidence=overall_confidence,
+        dimensions=dimensions,
+        dominant_attention_targets=dominant_targets,
+        dominant_field_channels=dominant_field_channels,
+        unresolved_pressures=unresolved,
+        stabilizing_factors=stabilizing,
+        warnings=warnings,
+        summary_labels=summary_labels,
+    )

--- a/orion/self_state/policy.py
+++ b/orion/self_state/policy.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SelfStateConditionThresholdsV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    quiet_max: float = 0.15
+    steady_max: float = 0.40
+    loaded_max: float = 0.70
+    strained_max: float = 0.90
+
+
+class SelfStatePolicyV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["self_state_policy.v1"] = "self_state_policy.v1"
+    policy_id: str = "self_state_policy.v1"
+
+    condition_thresholds: SelfStateConditionThresholdsV1 = Field(
+        default_factory=SelfStateConditionThresholdsV1
+    )
+
+    dimension_weights: dict[str, float] = Field(default_factory=dict)
+    attention_target_weights: dict[str, float] = Field(default_factory=dict)
+    channel_dimension_map: dict[str, str] = Field(default_factory=dict)
+    stabilizing_channels: dict[str, float] = Field(default_factory=dict)
+
+    unresolved_pressure_threshold: float = 0.60
+    dominant_channel_threshold: float = 0.25
+
+
+def load_self_state_policy(path: str | Path) -> SelfStatePolicyV1:
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    return SelfStatePolicyV1.model_validate(data)

--- a/orion/self_state/scoring.py
+++ b/orion/self_state/scoring.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from orion.self_state.policy import SelfStateConditionThresholdsV1, SelfStatePolicyV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.field_state import FieldStateV1
+
+PRESSURE_CHANNELS = frozenset({
+    "execution_load",
+    "execution_friction",
+    "execution_pressure",
+    "failure_pressure",
+    "reasoning_load",
+    "reasoning_pressure",
+    "reliability_pressure",
+    "cpu_pressure",
+    "gpu_pressure",
+    "memory_pressure",
+    "disk_pressure",
+    "thermal_pressure",
+    "staleness",
+    "pressure",
+})
+
+
+def clamp01(x: float) -> float:
+    return max(0.0, min(1.0, float(x)))
+
+
+def condition_from_intensity(
+    intensity: float,
+    thresholds: SelfStateConditionThresholdsV1,
+) -> str:
+    x = clamp01(intensity)
+    if x <= thresholds.quiet_max:
+        return "quiet"
+    if x <= thresholds.steady_max:
+        return "steady"
+    if x <= thresholds.loaded_max:
+        return "loaded"
+    if x <= thresholds.strained_max:
+        return "strained"
+    return "unstable"
+
+
+def collect_field_channel_pressures(field: FieldStateV1) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for vector in list(field.node_vectors.values()) + list(field.capability_vectors.values()):
+        for channel, value in vector.items():
+            if channel in PRESSURE_CHANNELS or float(value) > 0:
+                out[channel] = max(out.get(channel, 0.0), clamp01(float(value)))
+    n = len(field.recent_perturbations)
+    if n > 0:
+        out["recent_perturbation_count"] = clamp01(min(1.0, n / 20.0))
+    return out
+
+
+def collect_attention_channel_pressures(
+    attention: FieldAttentionFrameV1,
+    policy: SelfStatePolicyV1,
+) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for target in attention.dominant_targets:
+        kind_weight = float(policy.attention_target_weights.get(target.target_kind, 0.0))
+        salience = clamp01(target.salience_score)
+        for channel, contrib in target.dominant_channels.items():
+            weighted = clamp01(float(contrib) * salience * kind_weight)
+            out[channel] = max(out.get(channel, 0.0), weighted)
+    out["overall_salience"] = clamp01(attention.overall_salience)
+    return out
+
+
+def map_channels_to_dimensions(
+    *,
+    channel_pressures: dict[str, float],
+    policy: SelfStatePolicyV1,
+) -> dict[str, float]:
+    dims: dict[str, float] = {}
+    for channel, pressure in channel_pressures.items():
+        dim_id = policy.channel_dimension_map.get(channel)
+        if not dim_id:
+            continue
+        dims[dim_id] = max(dims.get(dim_id, 0.0), clamp01(pressure))
+    return dims
+
+
+def coherence_score(
+    *,
+    channel_pressures: dict[str, float],
+    policy: SelfStatePolicyV1,
+) -> float:
+    stabilizing = 0.0
+    for channel, weight in policy.stabilizing_channels.items():
+        stabilizing += clamp01(channel_pressures.get(channel, 0.0)) * float(weight)
+    penalty = 0.0
+    for ch in ("failure_pressure", "execution_friction", "staleness", "pressure"):
+        penalty += clamp01(channel_pressures.get(ch, 0.0)) * 0.25
+    return clamp01(stabilizing - penalty)
+
+
+def uncertainty_score(*, overall_salience: float, coherence: float) -> float:
+    return clamp01(clamp01(overall_salience) * (1.0 - clamp01(coherence)))
+
+
+def agency_readiness_score(
+    *,
+    coherence: float,
+    execution_pressure: float,
+    reliability_pressure: float,
+    uncertainty: float,
+    resource_pressure: float,
+) -> float:
+    base = clamp01(coherence)
+    base -= execution_pressure * 0.25
+    base -= reliability_pressure * 0.35
+    base -= uncertainty * 0.25
+    base -= resource_pressure * 0.15
+    return clamp01(base)
+
+
+def field_intensity_score(
+    *,
+    overall_salience: float,
+    recent_perturbation_saturation: float,
+) -> float:
+    return clamp01(0.6 * overall_salience + 0.4 * recent_perturbation_saturation)
+
+
+def weighted_overall_intensity(
+    dimension_scores: dict[str, float],
+    policy: SelfStatePolicyV1,
+) -> float:
+    total_w = 0.0
+    acc = 0.0
+    for dim_id, weight in policy.dimension_weights.items():
+        w = float(weight)
+        if w <= 0:
+            continue
+        total_w += w
+        acc += w * clamp01(dimension_scores.get(dim_id, 0.0))
+    if total_w <= 0:
+        return 0.0
+    return clamp01(acc / total_w)

--- a/scripts/smoke_self_state_v1.sh
+++ b/scripts/smoke_self_state_v1.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB="${DB:-orion-athena-sql-db}"
+PGDATABASE="${PGDATABASE:-conjourney}"
+PGUSER="${PGUSER:-postgres}"
+
+echo "=== Latest attention frame ==="
+docker exec -i "$DB" psql -U "$PGUSER" -d "$PGDATABASE" -c "
+select
+    generated_at,
+    frame_id,
+    source_field_tick_id,
+    frame_json #>> '{overall_salience}' as overall_salience,
+    frame_json #> '{dominant_targets}' as dominant_targets
+from substrate_attention_frames
+order by generated_at desc
+limit 1;
+"
+
+echo ""
+echo "=== Latest self-state ==="
+docker exec -i "$DB" psql -U "$PGUSER" -d "$PGDATABASE" -c "
+select
+    generated_at,
+    self_state_id,
+    source_field_tick_id,
+    source_attention_frame_id,
+    self_state_json #>> '{overall_condition}' as overall_condition,
+    self_state_json #>> '{overall_intensity}' as overall_intensity,
+    self_state_json #> '{dimensions}' as dimensions,
+    self_state_json #> '{dominant_attention_targets}' as dominant_attention_targets,
+    self_state_json #> '{summary_labels}' as summary_labels
+from substrate_self_state
+order by generated_at desc
+limit 1;
+"

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -145,11 +145,13 @@ from .grammar_atlas_routes import router as grammar_atlas_router
 from .substrate_biometrics_routes import router as substrate_biometrics_router
 from .substrate_field_routes import router as substrate_field_router
 from .substrate_attention_routes import router as substrate_attention_router
+from .substrate_self_state_routes import router as substrate_self_state_router
 
 router.include_router(grammar_atlas_router)
 router.include_router(substrate_biometrics_router)
 router.include_router(substrate_field_router)
 router.include_router(substrate_attention_router)
+router.include_router(substrate_self_state_router)
 
 
 def _hub_uses_host_network_mode() -> bool:

--- a/services/orion-hub/scripts/substrate_self_state_routes.py
+++ b/services/orion-hub/scripts/substrate_self_state_routes.py
@@ -1,0 +1,48 @@
+"""Read-only debug API for substrate self-state snapshots."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import create_engine, text
+
+from orion.schemas.self_state import SelfStateV1
+
+router = APIRouter(prefix="/api/substrate/self-state", tags=["substrate-self-state"])
+
+
+def _engine():
+    uri = os.getenv("POSTGRES_URI", "").strip()
+    if not uri:
+        raise HTTPException(status_code=503, detail="postgres_uri_not_configured")
+    return create_engine(uri, pool_pre_ping=True)
+
+
+def _load_latest_self_state() -> SelfStateV1 | None:
+    with _engine().connect() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT self_state_json FROM substrate_self_state
+                ORDER BY generated_at DESC
+                LIMIT 1
+                """
+            ),
+        ).mappings().first()
+    if not row:
+        return None
+    payload = row["self_state_json"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return SelfStateV1.model_validate(payload)
+
+
+@router.get("/latest")
+async def self_state_latest() -> dict[str, Any]:
+    state = _load_latest_self_state()
+    if state is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return state.model_dump(mode="json")

--- a/services/orion-hub/tests/test_substrate_self_state_debug_api.py
+++ b/services/orion-hub/tests/test_substrate_self_state_debug_api.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_hub_scripts_import_path() -> None:
+    for key in list(sys.modules):
+        if key == "scripts" or key.startswith("scripts."):
+            del sys.modules[key]
+    for p in (str(REPO_ROOT), str(HUB_ROOT)):
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(HUB_ROOT))
+
+
+_ensure_hub_scripts_import_path()
+
+from scripts import substrate_self_state_routes  # noqa: E402
+
+
+def _sample_self_state() -> dict:
+    return {
+        "schema_version": "self.state.v1",
+        "self_state_id": "self.state:tick_exec:frame_exec:self_state_policy.v1",
+        "generated_at": "2026-05-24T12:00:00+00:00",
+        "source_field_tick_id": "tick_exec",
+        "source_field_generated_at": "2026-05-24T12:00:00+00:00",
+        "source_attention_frame_id": "attention.frame:tick_exec:field_attention_policy.v1",
+        "source_attention_generated_at": "2026-05-24T12:00:00+00:00",
+        "self_state_policy_id": "self_state_policy.v1",
+        "overall_condition": "loaded",
+        "overall_intensity": 0.55,
+        "overall_confidence": 0.7,
+        "dimensions": {},
+        "dominant_attention_targets": ["node:athena"],
+        "dominant_field_channels": {"execution_load": 1.0},
+        "unresolved_pressures": [],
+        "stabilizing_factors": [],
+        "warnings": [],
+        "summary_labels": ["execution_loaded"],
+    }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    app = FastAPI()
+    app.include_router(substrate_self_state_routes.router)
+    return TestClient(app)
+
+
+def _fake_engine_with_state(state_json: dict | None):
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute(stmt, params=None):
+        m = MagicMock()
+        if state_json is None:
+            m.mappings.return_value.first.return_value = None
+        else:
+            m.mappings.return_value.first.return_value = {"self_state_json": state_json}
+        return m
+
+    conn.execute.side_effect = execute
+    return fake_engine
+
+
+def test_self_state_latest_returns_state(client):
+    state = _sample_self_state()
+    fake_engine = _fake_engine_with_state(state)
+
+    with patch.object(substrate_self_state_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/self-state/latest")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["schema_version"] == "self.state.v1"
+    assert body["overall_condition"] == "loaded"
+
+
+def test_self_state_latest_not_found(client):
+    fake_engine = _fake_engine_with_state(None)
+
+    with patch.object(substrate_self_state_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/self-state/latest")
+
+    assert r.status_code == 404

--- a/services/orion-self-state-runtime/.env_example
+++ b/services/orion-self-state-runtime/.env_example
@@ -1,0 +1,9 @@
+PROJECT=orion-athena
+SERVICE_NAME=orion-self-state-runtime
+SERVICE_VERSION=0.1.0
+POSTGRES_URI=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+SELF_STATE_POLICY_PATH=/app/config/self_state/self_state_policy.v1.yaml
+SELF_STATE_POLL_INTERVAL_SEC=2.0
+ENABLE_SELF_STATE_RUNTIME=true
+LOG_LEVEL=INFO
+SELF_STATE_RUNTIME_PORT=8118

--- a/services/orion-self-state-runtime/Dockerfile
+++ b/services/orion-self-state-runtime/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir --upgrade pip
+
+COPY services/orion-self-state-runtime/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY orion /app/orion
+COPY config/self_state /app/config/self_state
+COPY services/orion-self-state-runtime /app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8118"]

--- a/services/orion-self-state-runtime/README.md
+++ b/services/orion-self-state-runtime/README.md
@@ -1,0 +1,30 @@
+# orion-self-state-runtime
+
+Layer 6 substrate service: synthesizes `SelfStateV1` from the latest `FieldAttentionFrameV1` and matching `FieldStateV1`.
+
+## Data flow
+
+```text
+substrate_attention_frames + substrate_field_state
+  → orion-self-state-runtime
+  → substrate_self_state
+```
+
+## Dependencies
+
+- `orion-field-digester` writing `substrate_field_state`
+- `orion-attention-runtime` writing `substrate_attention_frames`
+- Apply migration: `services/orion-sql-db/manual_migration_self_state_v1.sql`
+
+## Run locally
+
+```bash
+cp .env_example .env
+docker compose up -d --build
+curl -s http://localhost:8118/health
+curl -s http://localhost:8118/latest | jq .
+```
+
+## Non-goals (v1)
+
+No bus publish, proposals, policy gates, cortex-exec steering, or LLM interpretation.

--- a/services/orion-self-state-runtime/app/main.py
+++ b/services/orion-self-state-runtime/app/main.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from app.settings import get_settings
+from app.store import SelfStateRuntimeStore
+from app.worker import SelfStateRuntimeWorker
+
+_settings = get_settings()
+logging.basicConfig(level=getattr(logging, _settings.log_level.upper(), logging.INFO))
+
+worker = SelfStateRuntimeWorker()
+store = SelfStateRuntimeStore(_settings.postgres_uri)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await worker.start()
+    try:
+        yield
+    finally:
+        await worker.stop()
+
+
+app = FastAPI(title="orion-self-state-runtime", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "service": get_settings().service_name}
+
+
+@app.get("/latest")
+async def latest() -> dict[str, Any]:
+    state = store.load_latest_self_state()
+    if state is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return state.model_dump(mode="json")

--- a/services/orion-self-state-runtime/app/settings.py
+++ b/services/orion-self-state-runtime/app/settings.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    project: str = Field("orion-athena", alias="PROJECT")
+    service_name: str = Field("orion-self-state-runtime", alias="SERVICE_NAME")
+    service_version: str = Field("0.1.0", alias="SERVICE_VERSION")
+
+    postgres_uri: str = Field(..., alias="POSTGRES_URI")
+    self_state_policy_path: str = Field(
+        "config/self_state/self_state_policy.v1.yaml",
+        alias="SELF_STATE_POLICY_PATH",
+    )
+    self_state_poll_interval_sec: float = Field(2.0, alias="SELF_STATE_POLL_INTERVAL_SEC")
+    enable_self_state_runtime: bool = Field(True, alias="ENABLE_SELF_STATE_RUNTIME")
+    log_level: str = Field("INFO", alias="LOG_LEVEL")
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings

--- a/services/orion-self-state-runtime/app/store.py
+++ b/services/orion-self-state-runtime/app/store.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from psycopg2.extras import Json
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.field_state import FieldStateV1
+from orion.schemas.self_state import SelfStateV1
+
+
+class SelfStateRuntimeStore:
+    def __init__(self, postgres_uri: str) -> None:
+        self._engine: Engine = create_engine(
+            postgres_uri,
+            pool_pre_ping=True,
+            json_serializer=json.dumps,
+            json_deserializer=json.loads,
+        )
+
+    def load_latest_attention_frame(self) -> FieldAttentionFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT frame_json FROM substrate_attention_frames
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["frame_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return FieldAttentionFrameV1.model_validate(payload)
+
+    def load_field_for_tick(self, tick_id: str) -> FieldStateV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT field_json FROM substrate_field_state
+                        WHERE tick_id = :tick_id
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                    {"tick_id": tick_id},
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["field_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return FieldStateV1.model_validate(payload)
+
+    def load_latest_self_state(self) -> SelfStateV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT self_state_json FROM substrate_self_state
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["self_state_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return SelfStateV1.model_validate(payload)
+
+    def load_self_state_for_attention_frame(self, frame_id: str) -> SelfStateV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT self_state_json FROM substrate_self_state
+                        WHERE source_attention_frame_id = :frame_id
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                    {"frame_id": frame_id},
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["self_state_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return SelfStateV1.model_validate(payload)
+
+    def save_self_state(self, state: SelfStateV1) -> None:
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO substrate_self_state (
+                        self_state_id,
+                        source_field_tick_id,
+                        source_attention_frame_id,
+                        generated_at,
+                        policy_id,
+                        self_state_json,
+                        created_at
+                    ) VALUES (
+                        :self_state_id,
+                        :source_field_tick_id,
+                        :source_attention_frame_id,
+                        :generated_at,
+                        :policy_id,
+                        :self_state_json,
+                        :created_at
+                    )
+                    ON CONFLICT (self_state_id) DO UPDATE SET
+                        source_field_tick_id = EXCLUDED.source_field_tick_id,
+                        source_attention_frame_id = EXCLUDED.source_attention_frame_id,
+                        generated_at = EXCLUDED.generated_at,
+                        policy_id = EXCLUDED.policy_id,
+                        self_state_json = EXCLUDED.self_state_json
+                    """
+                ),
+                {
+                    "self_state_id": state.self_state_id,
+                    "source_field_tick_id": state.source_field_tick_id,
+                    "source_attention_frame_id": state.source_attention_frame_id,
+                    "generated_at": state.generated_at,
+                    "policy_id": state.self_state_policy_id,
+                    "self_state_json": Json(state.model_dump(mode="json")),
+                    "created_at": now,
+                },
+            )

--- a/services/orion-self-state-runtime/app/worker.py
+++ b/services/orion-self-state-runtime/app/worker.py
@@ -55,6 +55,11 @@ class SelfStateRuntimeWorker:
 
         field = self._store.load_field_for_tick(attention.source_field_tick_id)
         if field is None:
+            logger.warning(
+                "self_state_skip_missing_field tick_id=%s frame_id=%s",
+                attention.source_field_tick_id,
+                attention.frame_id,
+            )
             return
 
         previous = self._store.load_latest_self_state()

--- a/services/orion-self-state-runtime/app/worker.py
+++ b/services/orion-self-state-runtime/app/worker.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from orion.self_state.builder import build_self_state
+from orion.self_state.policy import load_self_state_policy
+
+from app.settings import get_settings
+from app.store import SelfStateRuntimeStore
+
+logger = logging.getLogger("orion.self_state.runtime")
+
+
+class SelfStateRuntimeWorker:
+    def __init__(self) -> None:
+        self._settings = get_settings()
+        self._store = SelfStateRuntimeStore(self._settings.postgres_uri)
+        self._policy = load_self_state_policy(Path(self._settings.self_state_policy_path))
+        self._stop = asyncio.Event()
+
+    async def start(self) -> None:
+        asyncio.create_task(self._poll_loop(), name="self-state-runtime-poll")
+
+    async def stop(self) -> None:
+        self._stop.set()
+
+    async def _poll_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                await asyncio.to_thread(self._tick)
+            except Exception:
+                logger.exception("self_state_runtime_tick_failed")
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(),
+                    timeout=float(self._settings.self_state_poll_interval_sec),
+                )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+    def _tick(self) -> None:
+        if not self._settings.enable_self_state_runtime:
+            return
+
+        attention = self._store.load_latest_attention_frame()
+        if attention is None:
+            return
+
+        if self._store.load_self_state_for_attention_frame(attention.frame_id) is not None:
+            return
+
+        field = self._store.load_field_for_tick(attention.source_field_tick_id)
+        if field is None:
+            return
+
+        previous = self._store.load_latest_self_state()
+        state = build_self_state(
+            field=field,
+            attention=attention,
+            policy=self._policy,
+            previous_self_state=previous,
+        )
+        self._store.save_self_state(state)
+        logger.info(
+            "self_state_saved self_state_id=%s frame_id=%s condition=%s intensity=%.3f",
+            state.self_state_id,
+            attention.frame_id,
+            state.overall_condition,
+            state.overall_intensity,
+        )

--- a/services/orion-self-state-runtime/docker-compose.yml
+++ b/services/orion-self-state-runtime/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  self-state-runtime:
+    build:
+      context: ../..
+      dockerfile: services/orion-self-state-runtime/Dockerfile
+    container_name: ${PROJECT}-self-state-runtime
+    restart: unless-stopped
+    networks:
+      - app-net
+    ports:
+      - "${SELF_STATE_RUNTIME_PORT:-8118}:8118"
+    environment:
+      - PROJECT=${PROJECT}
+      - SERVICE_NAME=${SERVICE_NAME:-orion-self-state-runtime}
+      - SERVICE_VERSION=${SERVICE_VERSION:-0.1.0}
+      - POSTGRES_URI=${POSTGRES_URI}
+      - SELF_STATE_POLICY_PATH=${SELF_STATE_POLICY_PATH:-/app/config/self_state/self_state_policy.v1.yaml}
+      - SELF_STATE_POLL_INTERVAL_SEC=${SELF_STATE_POLL_INTERVAL_SEC:-2.0}
+      - ENABLE_SELF_STATE_RUNTIME=${ENABLE_SELF_STATE_RUNTIME:-true}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+
+networks:
+  app-net:
+    external: true

--- a/services/orion-self-state-runtime/requirements.txt
+++ b/services/orion-self-state-runtime/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+pydantic==2.10.3
+pydantic-settings==2.6.1
+sqlalchemy==2.0.36
+psycopg2-binary==2.9.10
+PyYAML==6.0.2

--- a/services/orion-sql-db/manual_migration_self_state_v1.sql
+++ b/services/orion-sql-db/manual_migration_self_state_v1.sql
@@ -1,0 +1,21 @@
+-- Self-state v1 (apply before orion-self-state-runtime)
+-- Apply: psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_self_state_v1.sql
+
+create table if not exists substrate_self_state (
+    self_state_id text primary key,
+    source_field_tick_id text not null,
+    source_attention_frame_id text not null,
+    generated_at timestamptz not null,
+    policy_id text not null,
+    self_state_json jsonb not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_self_state_generated_at
+    on substrate_self_state (generated_at desc);
+
+create index if not exists idx_substrate_self_state_source_field_tick
+    on substrate_self_state (source_field_tick_id);
+
+create index if not exists idx_substrate_self_state_source_attention_frame
+    on substrate_self_state (source_attention_frame_id);

--- a/tests/test_self_state_builder.py
+++ b/tests/test_self_state_builder.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.attention.field_attention.builder import build_attention_frame
+from orion.attention.field_attention.policy import load_attention_policy
+from orion.self_state.builder import build_self_state
+from orion.self_state.policy import load_self_state_policy
+from orion.schemas.field_state import FieldStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+ATTENTION_POLICY = load_attention_policy(REPO / "config" / "attention" / "field_attention_policy.v1.yaml")
+SELF_POLICY = load_self_state_policy(REPO / "config" / "self_state" / "self_state_policy.v1.yaml")
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _synthetic_field() -> FieldStateV1:
+    return FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_exec_attention",
+        node_vectors={
+            "node:athena": {
+                "execution_load": 1.0,
+                "reasoning_load": 0.35,
+                "availability": 1.0,
+            },
+        },
+        capability_vectors={
+            "capability:orchestration": {
+                "execution_pressure": 1.0,
+                "reliability_pressure": 0.0,
+            }
+        },
+        recent_perturbations=["state_delta:exec_1", "state_delta:exec_2"],
+    )
+
+
+def test_builder_references_sources() -> None:
+    field = _synthetic_field()
+    attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)
+    state = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
+    assert state.source_field_tick_id == field.tick_id
+    assert state.source_attention_frame_id == attention.frame_id
+
+
+def test_execution_pressure_nonzero() -> None:
+    field = _synthetic_field()
+    attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)
+    state = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
+    assert "execution_pressure" in state.dimensions
+    assert state.dimensions["execution_pressure"].score > 0.0
+
+
+def test_agency_readiness_present() -> None:
+    field = _synthetic_field()
+    attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)
+    state = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
+    assert "agency_readiness" in state.dimensions
+
+
+def test_dominant_attention_targets() -> None:
+    field = _synthetic_field()
+    attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)
+    state = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
+    ids = set(state.dominant_attention_targets)
+    assert "node:athena" in ids or "capability:orchestration" in ids
+
+
+def test_summary_labels_execution_loaded() -> None:
+    field = _synthetic_field()
+    attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)
+    state = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
+    assert "execution_loaded" in state.summary_labels
+
+
+def test_self_state_id_stable() -> None:
+    field = _synthetic_field()
+    attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)
+    a = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
+    b = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
+    assert a.self_state_id == b.self_state_id
+
+
+def test_no_action_outputs() -> None:
+    field = _synthetic_field()
+    attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)
+    payload = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW).model_dump()
+    forbidden = ("proposal", "action", "policy_gate", "cortex", "selected_action")
+    for key in payload:
+        assert not any(f in key.lower() for f in forbidden)

--- a/tests/test_self_state_policy_loader.py
+++ b/tests/test_self_state_policy_loader.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from orion.self_state.policy import SelfStatePolicyV1, load_self_state_policy
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = REPO / "config" / "self_state" / "self_state_policy.v1.yaml"
+
+
+def test_load_self_state_policy_v1() -> None:
+    policy = load_self_state_policy(POLICY)
+    assert isinstance(policy, SelfStatePolicyV1)
+    assert policy.policy_id == "self_state_policy.v1"
+    assert policy.channel_dimension_map["execution_load"] == "execution_pressure"
+    assert policy.condition_thresholds.quiet_max == 0.15

--- a/tests/test_self_state_runtime_store.py
+++ b/tests/test_self_state_runtime_store.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO = Path(__file__).resolve().parents[1]
+SVC = REPO / "services" / "orion-self-state-runtime"
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _load_store_class():
+    spec = importlib.util.spec_from_file_location(
+        "self_state_runtime_store",
+        SVC / "app" / "store.py",
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.SelfStateRuntimeStore
+
+
+SelfStateRuntimeStore = _load_store_class()
+
+from orion.schemas.self_state import SelfStateV1  # noqa: E402
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _state() -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id="self.state:tick_a:frame_a:self_state_policy.v1",
+        generated_at=NOW,
+        source_field_tick_id="tick_a",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="frame_a",
+        source_attention_generated_at=NOW,
+        overall_intensity=0.5,
+        overall_confidence=0.6,
+    )
+
+
+def test_save_and_load_latest(monkeypatch) -> None:
+    payload = _state().model_dump(mode="json")
+    store = SelfStateRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "INSERT INTO substrate_self_state" in sql:
+            result.rowcount = 1
+        elif "source_attention_frame_id" in sql:
+            result.mappings.return_value.first.return_value = None
+        else:
+            result.mappings.return_value.first.return_value = {"self_state_json": payload}
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    store.save_self_state(_state())
+    loaded = store.load_latest_self_state()
+    assert loaded is not None
+    assert loaded.self_state_id == "self.state:tick_a:frame_a:self_state_policy.v1"
+
+
+def test_load_by_attention_frame_id(monkeypatch) -> None:
+    payload = _state().model_dump(mode="json")
+    store = SelfStateRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute_side_effect(stmt, params=None):
+        result = MagicMock()
+        if "source_attention_frame_id" in str(stmt):
+            result.mappings.return_value.first.return_value = {"self_state_json": payload}
+        else:
+            result.mappings.return_value.first.return_value = None
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    loaded = store.load_self_state_for_attention_frame("frame_a")
+    assert loaded is not None
+    assert loaded.source_attention_frame_id == "frame_a"

--- a/tests/test_self_state_schemas.py
+++ b/tests/test_self_state_schemas.py
@@ -1,0 +1,54 @@
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def test_self_state_dimension_v1_validates() -> None:
+    d = SelfStateDimensionV1(
+        dimension_id="execution_pressure",
+        score=0.8,
+        confidence=0.7,
+        dominant_evidence=["node:athena.execution_load"],
+        reasons=["execution_load elevated"],
+    )
+    assert d.dimension_id == "execution_pressure"
+
+
+def test_self_state_v1_roundtrip() -> None:
+    state = SelfStateV1(
+        self_state_id="self.state:tick_a:frame_a:self_state_policy.v1",
+        generated_at=NOW,
+        source_field_tick_id="tick_a",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="attention.frame:tick_a:field_attention_policy.v1",
+        source_attention_generated_at=NOW,
+        overall_intensity=0.5,
+        overall_confidence=0.6,
+    )
+    payload = state.model_dump(mode="json")
+    restored = SelfStateV1.model_validate(payload)
+    assert restored.schema_version == "self.state.v1"
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        SelfStateDimensionV1(
+            dimension_id="coherence",
+            score=0.5,
+            confidence=0.5,
+            bogus=True,  # type: ignore[call-arg]
+        )
+
+
+def test_scores_reject_out_of_range() -> None:
+    with pytest.raises(ValidationError):
+        SelfStateDimensionV1(
+            dimension_id="coherence",
+            score=1.5,
+            confidence=0.5,
+        )

--- a/tests/test_self_state_scoring.py
+++ b/tests/test_self_state_scoring.py
@@ -1,0 +1,100 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.self_state.policy import load_self_state_policy
+from orion.self_state.scoring import (
+    agency_readiness_score,
+    collect_field_channel_pressures,
+    condition_from_intensity,
+    coherence_score,
+    map_channels_to_dimensions,
+    uncertainty_score,
+)
+from orion.schemas.field_state import FieldStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_self_state_policy(REPO / "config" / "self_state" / "self_state_policy.v1.yaml")
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _field_high_execution() -> FieldStateV1:
+    return FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_scoring",
+        node_vectors={"node:athena": {"execution_load": 1.0, "execution_friction": 0.0}},
+        capability_vectors={},
+    )
+
+
+def test_high_execution_load_raises_execution_pressure() -> None:
+    channels = collect_field_channel_pressures(_field_high_execution())
+    dims = map_channels_to_dimensions(channel_pressures=channels, policy=POLICY)
+    assert dims.get("execution_pressure", 0.0) > 0.5
+
+
+def test_high_execution_friction_raises_reliability_pressure() -> None:
+    field = FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_friction",
+        node_vectors={"node:athena": {"execution_friction": 1.0}},
+    )
+    channels = collect_field_channel_pressures(field)
+    dims = map_channels_to_dimensions(channel_pressures=channels, policy=POLICY)
+    assert dims.get("reliability_pressure", 0.0) > 0.5
+
+
+def test_high_failure_pressure_raises_reliability() -> None:
+    field = FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_fail",
+        node_vectors={"node:athena": {"failure_pressure": 1.0}},
+    )
+    dims = map_channels_to_dimensions(
+        channel_pressures=collect_field_channel_pressures(field),
+        policy=POLICY,
+    )
+    assert dims.get("reliability_pressure", 0.0) > 0.5
+
+
+def test_available_capacity_improves_coherence() -> None:
+    low = coherence_score(
+        channel_pressures={"cpu_pressure": 0.9},
+        policy=POLICY,
+    )
+    high = coherence_score(
+        channel_pressures={"available_capacity": 1.0, "confidence": 1.0},
+        policy=POLICY,
+    )
+    assert high > low
+
+
+def test_high_salience_low_coherence_raises_uncertainty() -> None:
+    u = uncertainty_score(overall_salience=1.0, coherence=0.1)
+    assert u > 0.5
+
+
+def test_agency_readiness_falls_with_reliability_pressure() -> None:
+    high_rel = agency_readiness_score(
+        coherence=0.9,
+        execution_pressure=0.2,
+        reliability_pressure=0.9,
+        uncertainty=0.1,
+        resource_pressure=0.1,
+    )
+    low_rel = agency_readiness_score(
+        coherence=0.9,
+        execution_pressure=0.2,
+        reliability_pressure=0.1,
+        uncertainty=0.1,
+        resource_pressure=0.1,
+    )
+    assert low_rel > high_rel
+
+
+def test_condition_thresholds() -> None:
+    t = POLICY.condition_thresholds
+    assert condition_from_intensity(0.10, t) == "quiet"
+    assert condition_from_intensity(0.30, t) == "steady"
+    assert condition_from_intensity(0.55, t) == "loaded"
+    assert condition_from_intensity(0.85, t) == "strained"
+    assert condition_from_intensity(0.95, t) == "unstable"


### PR DESCRIPTION
# PR: Self-State v1 — Attention + Field → Orion Operating Condition

**Branch:** `feat/self-state-v1`  
**Base:** `main`  
**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-self-state-v1`

## Summary

Implements **Layer 6** of the Orion cognition substrate: deterministic, read-only synthesis of Orion’s **operating condition** from digested field state and the attention frame.

```text
substrate_field_state (FieldStateV1)
+ substrate_attention_frames (FieldAttentionFrameV1)
  → orion-self-state-runtime
  → SelfStateV1
  → substrate_self_state
  → GET /api/substrate/self-state/latest (Hub debug)
```

**Core phrase:** *Self-state is the substrate’s estimate of operating condition* — not agency, not action, not personality prose.

### 11-layer roadmap placement

| Layer | Name | This PR |
|-------|------|---------|
| 1–5 | Organs → … → Attention | Prerequisite (field-digester + attention-runtime) |
| **6** | **Self-state** | **Implemented** |
| 7 | Proposals | Deferred |
| 8–11 | Policy → Execution → Feedback → Consolidation | Deferred |

## Architecture

| Component | Role |
|-----------|------|
| `config/self_state/self_state_policy.v1.yaml` | Dimension weights, channel→dimension map, condition thresholds |
| `orion/self_state/{policy,scoring,builder}.py` | Pure deterministic self-state synthesis |
| `services/orion-self-state-runtime` | Poll latest attention → load field → build → persist (no bus) |
| `substrate_self_state` | Postgres persistence |
| `scripts/smoke_self_state_v1.sh` | SQL inspection |

## Example synthetic `SelfStateV1`

From live builder run (`node:athena.execution_load=1.0`, `capability:orchestration.execution_pressure=1.0`):

```json
{
  "overall_condition": "steady",
  "overall_intensity": 0.3194,
  "execution_pressure": 1.0,
  "agency_readiness": 0.205,
  "summary_labels": [
    "execution_loaded",
    "reliability_clear"
  ],
  "dominant_attention_targets": [
    "capability:orchestration",
    "node:athena",
    "field:recent_perturbations"
  ]
}
```

`agency_readiness` is computed but **does not authorize action** — Layer 7+ owns proposals and policy gates.

## Non-goals (explicit)

This PR does **not** implement:

- proposal/action generation (`ProposalFrameV1`)
- policy gates or cortex-exec steering
- mind service / LLM interpretation
- bus-published events (`orion/bus/channels.yaml` unchanged)
- mutation of `FieldStateV1` or `FieldAttentionFrameV1`
- operator notifications

## Tests run

```bash
PYTHONPATH=. pytest tests/test_self_state_*.py -q
# 21 passed

PYTHONPATH=. pytest tests/test_attention_frame_schemas.py tests/test_attention_frame_builder.py \
  tests/test_attention_field_scoring.py tests/test_attention_policy_loader.py -q
# 20 passed

PYTHONPATH=. pytest services/orion-hub/tests/test_substrate_self_state_debug_api.py -q
# 2 passed

PYTHONPATH=. pytest tests/test_field_state_schemas.py -q
# 2 passed

PYTHONPATH=. python -m compileall orion/self_state orion/schemas/self_state.py services/orion-self-state-runtime -q
# clean
```

## Operator checklist

1. Apply migration: `services/orion-sql-db/manual_migration_self_state_v1.sql`
2. Ensure `orion-field-digester` and `orion-attention-runtime` are running
3. Start runtime: `services/orion-self-state-runtime` (port **8118**)
4. Smoke: `./scripts/smoke_self_state_v1.sh`

## Known gaps (Layer 7+)

- `previous_self_state` parameter reserved; continuity deltas not yet applied
- Worker processes **latest** attention frame only (same idempotency pattern as attention-runtime)
- No `ProposalFrameV1` or action pressure export

## Files changed (high level)

- `orion/schemas/self_state.py`, `orion/schemas/registry.py`
- `orion/self_state/*`, `config/self_state/self_state_policy.v1.yaml`
- `services/orion-self-state-runtime/*`
- `services/orion-sql-db/manual_migration_self_state_v1.sql`
- `services/orion-hub/scripts/substrate_self_state_routes.py`
- `tests/test_self_state_*.py`, `scripts/smoke_self_state_v1.sh`