### PR TITLE
Feat/proposal frame v1

### DIFF
--- a/config/proposals/proposal_policy.v1.yaml
+++ b/config/proposals/proposal_policy.v1.yaml
@@ -1,0 +1,85 @@
+schema_version: proposal_policy.v1
+policy_id: proposal_policy.v1
+
+limits:
+  max_candidates: 10
+  max_suppressed: 10
+
+thresholds:
+  min_priority: 0.10
+  suppress_below: 0.05
+  policy_required_above_risk: 0.20
+
+dimension_weights:
+  execution_pressure: 0.30
+  resource_pressure: 0.25
+  reasoning_pressure: 0.15
+  reliability_pressure: 0.35
+  uncertainty: 0.25
+  field_intensity: 0.20
+  agency_readiness: -0.15
+  coherence: -0.20
+
+proposal_templates:
+  inspect_execution_pressure:
+    kind: inspect
+    target_kind: capability
+    target_id: capability:orchestration
+    proposed_effect: increase_observability
+    required_policy_gate: read_only
+    base_priority: 0.40
+    base_risk: 0.05
+    reversibility: 1.0
+    dimensions:
+      execution_pressure: 0.60
+
+  summarize_loaded_state:
+    kind: summarize
+    target_kind: self_state
+    target_id: self:current
+    proposed_effect: increase_observability
+    required_policy_gate: read_only
+    base_priority: 0.35
+    base_risk: 0.05
+    reversibility: 1.0
+    dimensions:
+      field_intensity: 0.50
+      resource_pressure: 0.40
+
+  watch_reliability:
+    kind: observe
+    target_kind: capability
+    target_id: capability:orchestration
+    proposed_effect: preserve_stability
+    required_policy_gate: read_only
+    base_priority: 0.30
+    base_risk: 0.02
+    reversibility: 1.0
+    dimensions:
+      reliability_pressure: 0.50
+
+  request_policy_review_for_action:
+    kind: request_policy_review
+    target_kind: system
+    target_id: policy:execution
+    proposed_effect: prepare_for_policy_gate
+    required_policy_gate: operator_review
+    base_priority: 0.20
+    base_risk: 0.30
+    reversibility: 0.8
+    dimensions:
+      agency_readiness: 0.50
+      execution_pressure: 0.40
+
+  defer_due_to_low_readiness:
+    kind: defer
+    target_kind: self_state
+    target_id: self:current
+    proposed_effect: preserve_stability
+    required_policy_gate: none
+    base_priority: 0.25
+    base_risk: 0.0
+    reversibility: 1.0
+    dimensions:
+      uncertainty: 0.50
+      reliability_pressure: 0.50

--- a/docs/superpowers/plans/2026-05-24-proposal-frame-v1.md
+++ b/docs/superpowers/plans/2026-05-24-proposal-frame-v1.md
@@ -1,0 +1,46 @@
+# Proposal Frame v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Layer 7 — convert `SelfStateV1` (+ optional attention/field) into deterministic `ProposalFrameV1` snapshots (possible actions only), persisted for inspection with no execution or bus publish.
+
+**Architecture:** Shared schemas in `orion/schemas/proposal_frame.py`; pure synthesis in `orion/proposals/`; polling service `orion-proposal-runtime` idempotent per `source_self_state_id`; optional Hub `GET /api/substrate/proposals/latest`. Policy from `config/proposals/proposal_policy.v1.yaml`.
+
+**Tech Stack:** Python 3.12, Pydantic v2, PyYAML, SQLAlchemy, FastAPI/uvicorn, pytest, Postgres.
+
+**Depends on:** Layer 6 on `main` (`SelfStateV1`, `substrate_self_state`, port 8118).
+
+**Non-goals:** Layer 8 policy, cortex-exec, bus, LLM, operator notify, settings mutation.
+
+---
+
+## Worktree
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+git worktree add .worktrees/feat-proposal-frame-v1 -b feat/proposal-frame-v1 main
+```
+
+**Port:** 8119. **Bus:** registry only; no `channels.yaml` changes. **Field SQL:** `WHERE tick_id = :tick_id` (not JSON path).
+
+---
+
+## File structure
+
+| Path | Role |
+|------|------|
+| `orion/schemas/proposal_frame.py` | `ProposalCandidateV1`, `ProposalFrameV1` |
+| `orion/schemas/registry.py` | Register schemas |
+| `config/proposals/proposal_policy.v1.yaml` | Templates + thresholds |
+| `orion/proposals/{policy,scoring,templates,builder}.py` | Synthesis |
+| `services/orion-sql-db/manual_migration_proposal_frame_v1.sql` | DDL |
+| `services/orion-proposal-runtime/` | Runtime service |
+| `services/orion-hub/scripts/substrate_proposal_routes.py` | Debug API |
+| `tests/test_proposal_*.py` | Unit tests |
+| `scripts/smoke_proposal_frame_v1.sh` | Live SQL smoke |
+
+---
+
+## Implementation status
+
+This plan was executed on branch `feat/proposal-frame-v1` (commits `138e1aac`, `75997c1f`). See `docs/superpowers/pr-reports/2026-05-24-proposal-frame-v1-pr.md` for PR summary and verification commands.

--- a/docs/superpowers/pr-reports/2026-05-24-proposal-frame-v1-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-24-proposal-frame-v1-pr.md
@@ -1,0 +1,137 @@
+# PR: Proposal Frame v1 — Self-State → Possible Actions, Not Automatic Actions
+
+**Branch:** `feat/proposal-frame-v1`  
+**Base:** `main`  
+**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-proposal-frame-v1`
+
+## Summary
+
+Implements **Layer 7** of the Orion cognition substrate: deterministic conversion of `SelfStateV1` (+ optional attention/field context) into **inspectable possible actions** (`ProposalFrameV1`), without execution, policy approval, or bus publish.
+
+```text
+substrate_self_state (SelfStateV1)
++ substrate_attention_frames (FieldAttentionFrameV1)
++ substrate_field_state (FieldStateV1)
+  → orion-proposal-runtime
+  → ProposalFrameV1
+  → substrate_proposal_frames
+  → GET /api/substrate/proposals/latest (Hub debug)
+```
+
+**Core phrase:** *Proposal is action pressure made inspectable* — not approval, not execution, not autonomy.
+
+### 11-layer roadmap placement
+
+| Layer | Name | This PR |
+|-------|------|---------|
+| 1–6 | Organs → … → Self-state | Prerequisite (merged on `main`) |
+| **7** | **Proposals** | **Implemented** |
+| 8 | Policy | **Explicitly deferred** |
+| 9–11 | Execution → Feedback → Consolidation | Deferred |
+
+## Architecture
+
+| Component | Role |
+|-----------|------|
+| `config/proposals/proposal_policy.v1.yaml` | Templates, thresholds, dimension weights |
+| `orion/proposals/{policy,scoring,templates,builder}.py` | Pure deterministic proposal synthesis |
+| `orion/schemas/proposal_frame.py` | `ProposalCandidateV1`, `ProposalFrameV1` |
+| `services/orion-proposal-runtime` | Poll latest self-state → build → persist (port **8119**, no bus) |
+| `substrate_proposal_frames` | Postgres persistence |
+| `scripts/smoke_proposal_frame_v1.sh` | SQL inspection |
+
+## Example `ProposalFrameV1` (live-shaped self-state)
+
+Synthetic input matching operator live output (`execution_pressure=1.0`, `resource_pressure=1.0`, `overall_condition=loaded`):
+
+```json
+{
+  "schema_version": "proposal.frame.v1",
+  "frame_id": "proposal.frame:self.state:live:tick:frame:self_state_policy.v1:proposal_policy.v1",
+  "overall_action_pressure": 0.93,
+  "overall_risk": 0.45,
+  "policy_required": true,
+  "candidates": [
+    {
+      "proposal_kind": "inspect",
+      "title": "Inspect orchestration execution pressure",
+      "required_policy_gate": "read_only",
+      "execution_intent": {
+        "mode": "descriptive_only",
+        "template": "inspect_execution_pressure",
+        "policy_gate": "read_only"
+      }
+    },
+    {
+      "proposal_kind": "summarize",
+      "title": "Summarize loaded operating condition",
+      "required_policy_gate": "read_only",
+      "execution_intent": { "mode": "descriptive_only" }
+    },
+    {
+      "proposal_kind": "request_policy_review",
+      "title": "Prepare policy review for possible action",
+      "required_policy_gate": "operator_review",
+      "execution_intent": {
+        "mode": "descriptive_only",
+        "note": "policy_review_not_execution"
+      }
+    }
+  ]
+}
+```
+
+Top candidates are **read-only inspect/summarize** under loaded execution pressure. `request_policy_review` is a *proposal to prepare policy evaluation later* — not approval and not cortex-exec.
+
+## Proof: proposals only, not actions
+
+| Check | Evidence |
+|-------|----------|
+| No cortex-exec / verb bus | No imports or calls; `orion/bus/channels.yaml` unchanged |
+| No action execution | Worker only `INSERT` into `substrate_proposal_frames` |
+| Descriptive `execution_intent` | Builder sets `mode: descriptive_only`; policy-review adds `policy_review_not_execution` |
+| No approval API | Hub route is `GET /latest` only |
+| Tests | `test_no_execution_in_candidates`, read-only gate assertions |
+| Layer 8 deferred | No consent, blast-radius, or autonomy mutation |
+
+## Tests run
+
+```bash
+PYTHONPATH=. pytest tests/test_proposal_frame_schemas.py \
+  tests/test_proposal_policy_loader.py tests/test_proposal_scoring.py \
+  tests/test_proposal_frame_builder.py tests/test_proposal_runtime_store.py \
+  tests/test_proposal_runtime_worker.py -q
+# 29 passed
+
+PYTHONPATH=. pytest tests/test_self_state_*.py tests/test_attention_*.py -q
+# 46 passed
+
+PYTHONPATH=. pytest services/orion-hub/tests/test_substrate_proposal_debug_api.py -q
+# 2 passed
+
+PYTHONPATH=. python -m compileall orion/proposals orion/schemas/proposal_frame.py \
+  services/orion-proposal-runtime -q
+```
+
+## Operator steps
+
+```bash
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < services/orion-sql-db/manual_migration_proposal_frame_v1.sql
+
+cd services/orion-proposal-runtime
+cp -n .env_example .env
+docker compose up -d --build
+
+./scripts/smoke_proposal_frame_v1.sh
+curl -s http://localhost:8080/api/substrate/proposals/latest | jq
+curl -s http://localhost:8119/latest | jq
+```
+
+## Layer 8 policy (deferred)
+
+This PR does **not** implement policy gates, consent checks, blast-radius enforcement, cortex-exec dispatch, or operator notifications. Downstream Layer 8 will evaluate `required_policy_gate` and `risk_score` on each candidate.
+
+## Code review
+
+Subagent review: **Ready** after fixes for dimension weight wiring, missing-field worker skip (aligned with self-state runtime), and worker idempotency tests.

--- a/orion/proposals/__init__.py
+++ b/orion/proposals/__init__.py
@@ -1,0 +1,8 @@
+from orion.proposals.builder import build_proposal_frame
+from orion.proposals.policy import ProposalPolicyV1, load_proposal_policy
+
+__all__ = [
+    "ProposalPolicyV1",
+    "build_proposal_frame",
+    "load_proposal_policy",
+]

--- a/orion/proposals/builder.py
+++ b/orion/proposals/builder.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.proposals.policy import ProposalPolicyV1, ProposalTemplateV1
+from orion.proposals.scoring import (
+    clamp01,
+    dimension_score,
+    proposal_confidence,
+    proposal_priority,
+    proposal_risk,
+    proposal_urgency,
+    template_match_score,
+)
+from orion.proposals.templates import (
+    cast_policy_gate,
+    cast_proposal_kind,
+    cast_proposed_effect,
+    cast_target_kind,
+    template_title_description,
+)
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.field_state import FieldStateV1
+from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+
+def stable_proposal_frame_id(*, self_state_id: str, policy_id: str) -> str:
+    return f"proposal.frame:{self_state_id}:{policy_id}"
+
+
+def stable_proposal_id(*, template_key: str, self_state_id: str) -> str:
+    return f"proposal:{template_key}:{self_state_id}"
+
+
+def _build_candidate(
+    *,
+    template_key: str,
+    template: ProposalTemplateV1,
+    self_state: SelfStateV1,
+    attention: FieldAttentionFrameV1 | None,
+    policy: ProposalPolicyV1,
+) -> ProposalCandidateV1:
+    match_score, motivating_dimensions = template_match_score(
+        self_state=self_state,
+        template=template,
+    )
+    urgency = proposal_urgency(self_state=self_state, template=template)
+    confidence = proposal_confidence(self_state=self_state, template=template)
+    priority = proposal_priority(
+        base_priority=template.base_priority,
+        match_score=match_score,
+        urgency=urgency,
+        confidence=confidence,
+    )
+    risk = proposal_risk(
+        base_risk=template.base_risk,
+        self_state=self_state,
+        template=template,
+    )
+    title, description, reasons = template_title_description(
+        template_key,
+        target_id=template.target_id,
+    )
+    evidence_refs = [
+        f"self_state:{self_state.self_state_id}",
+        f"attention:{self_state.source_attention_frame_id}",
+        f"field:{self_state.source_field_tick_id}",
+    ]
+    if attention is not None:
+        evidence_refs.append(f"attention_frame:{attention.frame_id}")
+    motivating_targets = list(self_state.dominant_attention_targets[:5])
+    execution_intent: dict[str, str] = {
+        "mode": "descriptive_only",
+        "template": template_key,
+        "policy_gate": template.required_policy_gate,
+    }
+    if template.kind == "request_policy_review":
+        execution_intent["note"] = "policy_review_not_execution"
+    return ProposalCandidateV1(
+        proposal_id=stable_proposal_id(
+            template_key=template_key,
+            self_state_id=self_state.self_state_id,
+        ),
+        proposal_kind=cast_proposal_kind(template.kind),
+        title=title,
+        description=description,
+        target_id=template.target_id,
+        target_kind=cast_target_kind(template.target_kind),
+        priority_score=priority,
+        urgency_score=urgency,
+        confidence_score=confidence,
+        risk_score=risk,
+        reversibility_score=clamp01(template.reversibility),
+        motivating_dimensions=motivating_dimensions,
+        motivating_targets=motivating_targets,
+        evidence_refs=sorted(set(evidence_refs)),
+        reasons=reasons,
+        proposed_effect=cast_proposed_effect(template.proposed_effect),
+        required_policy_gate=cast_policy_gate(template.required_policy_gate),
+        execution_intent=execution_intent,
+    )
+
+
+def _overall_action_pressure(candidates: list[ProposalCandidateV1]) -> float:
+    if not candidates:
+        return 0.0
+    return clamp01(max(c.priority_score for c in candidates))
+
+
+def _overall_risk(candidates: list[ProposalCandidateV1]) -> float:
+    if not candidates:
+        return 0.0
+    return clamp01(max(c.risk_score for c in candidates))
+
+
+def _policy_required(
+    *,
+    candidates: list[ProposalCandidateV1],
+    overall_risk: float,
+    policy: ProposalPolicyV1,
+) -> bool:
+    if overall_risk >= policy.thresholds.policy_required_above_risk:
+        return True
+    return any(c.required_policy_gate not in ("none", "read_only") for c in candidates)
+
+
+def _dominant_motivations(candidates: list[ProposalCandidateV1]) -> list[str]:
+    counts: dict[str, float] = {}
+    for candidate in candidates:
+        for dim_id, weight in candidate.motivating_dimensions.items():
+            counts[dim_id] = counts.get(dim_id, 0.0) + float(weight)
+    ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return [dim_id for dim_id, _ in ranked[:5]]
+
+
+def build_proposal_frame(
+    *,
+    self_state: SelfStateV1,
+    attention: FieldAttentionFrameV1 | None,
+    field: FieldStateV1 | None,
+    policy: ProposalPolicyV1,
+    previous_frame: ProposalFrameV1 | None = None,
+    now: datetime | None = None,
+) -> ProposalFrameV1:
+    del previous_frame, field  # reserved for continuity in later revisions
+    generated_at = now or datetime.now(timezone.utc)
+    warnings: list[str] = []
+    if attention is not None and attention.frame_id != self_state.source_attention_frame_id:
+        warnings.append(
+            f"attention_frame_mismatch:{attention.frame_id}!={self_state.source_attention_frame_id}"
+        )
+
+    built: list[ProposalCandidateV1] = []
+    for template_key, template in policy.proposal_templates.items():
+        built.append(
+            _build_candidate(
+                template_key=template_key,
+                template=template,
+                self_state=self_state,
+                attention=attention,
+                policy=policy,
+            )
+        )
+
+    built.sort(key=lambda c: (-c.priority_score, c.proposal_id))
+    active: list[ProposalCandidateV1] = []
+    suppressed: list[ProposalCandidateV1] = []
+    for candidate in built:
+        if candidate.priority_score < policy.thresholds.suppress_below:
+            suppressed.append(candidate)
+        elif candidate.priority_score < policy.thresholds.min_priority:
+            suppressed.append(candidate)
+        else:
+            active.append(candidate)
+
+    active = active[: policy.limits.max_candidates]
+    suppressed = suppressed[: policy.limits.max_suppressed]
+
+    overall_risk = _overall_risk(active)
+    return ProposalFrameV1(
+        frame_id=stable_proposal_frame_id(
+            self_state_id=self_state.self_state_id,
+            policy_id=policy.policy_id,
+        ),
+        generated_at=generated_at,
+        source_self_state_id=self_state.self_state_id,
+        source_self_state_generated_at=self_state.generated_at,
+        source_attention_frame_id=self_state.source_attention_frame_id,
+        source_field_tick_id=self_state.source_field_tick_id,
+        proposal_policy_id=policy.policy_id,
+        overall_action_pressure=_overall_action_pressure(active),
+        overall_risk=overall_risk,
+        policy_required=_policy_required(
+            candidates=active,
+            overall_risk=overall_risk,
+            policy=policy,
+        ),
+        candidates=active,
+        suppressed_candidates=suppressed,
+        dominant_motivations=_dominant_motivations(active),
+        warnings=warnings,
+    )

--- a/orion/proposals/builder.py
+++ b/orion/proposals/builder.py
@@ -44,6 +44,7 @@ def _build_candidate(
     match_score, motivating_dimensions = template_match_score(
         self_state=self_state,
         template=template,
+        policy=policy,
     )
     urgency = proposal_urgency(self_state=self_state, template=template)
     confidence = proposal_confidence(self_state=self_state, template=template)

--- a/orion/proposals/policy.py
+++ b/orion/proposals/policy.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProposalLimitsV1(BaseModel):
+    max_candidates: int = 10
+    max_suppressed: int = 10
+
+
+class ProposalThresholdsV1(BaseModel):
+    min_priority: float = 0.10
+    suppress_below: float = 0.05
+    policy_required_above_risk: float = 0.20
+
+
+class ProposalTemplateV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    target_kind: str
+    target_id: str
+    proposed_effect: str
+    required_policy_gate: str
+    base_priority: float = 0.0
+    base_risk: float = 0.0
+    reversibility: float = 1.0
+    dimensions: dict[str, float] = Field(default_factory=dict)
+
+
+class ProposalPolicyV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["proposal_policy.v1"] = "proposal_policy.v1"
+    policy_id: str = "proposal_policy.v1"
+
+    limits: ProposalLimitsV1 = Field(default_factory=ProposalLimitsV1)
+    thresholds: ProposalThresholdsV1 = Field(default_factory=ProposalThresholdsV1)
+
+    dimension_weights: dict[str, float] = Field(default_factory=dict)
+    proposal_templates: dict[str, ProposalTemplateV1] = Field(default_factory=dict)
+
+
+def load_proposal_policy(path: str | Path) -> ProposalPolicyV1:
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    return ProposalPolicyV1.model_validate(data)

--- a/orion/proposals/scoring.py
+++ b/orion/proposals/scoring.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from orion.proposals.policy import ProposalTemplateV1
+from orion.proposals.policy import ProposalPolicyV1, ProposalTemplateV1
 from orion.schemas.self_state import SelfStateV1
 
 PRESSURE_DIMENSIONS = frozenset({
@@ -36,10 +36,16 @@ def template_match_score(
     *,
     self_state: SelfStateV1,
     template: ProposalTemplateV1,
+    policy: ProposalPolicyV1 | None = None,
 ) -> tuple[float, dict[str, float]]:
     contributions: dict[str, float] = {}
     for dim_id, weight in template.dimensions.items():
-        contributions[dim_id] = clamp01(dimension_score(self_state, dim_id) * float(weight))
+        policy_weight = 1.0
+        if policy is not None:
+            policy_weight = float(policy.dimension_weights.get(dim_id, 1.0))
+        contributions[dim_id] = clamp01(
+            dimension_score(self_state, dim_id) * float(weight) * abs(policy_weight)
+        )
     match = max(contributions.values()) if contributions else 0.0
     return clamp01(match), contributions
 

--- a/orion/proposals/scoring.py
+++ b/orion/proposals/scoring.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from orion.proposals.policy import ProposalTemplateV1
+from orion.schemas.self_state import SelfStateV1
+
+PRESSURE_DIMENSIONS = frozenset({
+    "execution_pressure",
+    "resource_pressure",
+    "reasoning_pressure",
+    "reliability_pressure",
+    "field_intensity",
+    "uncertainty",
+    "policy_pressure",
+})
+
+
+def clamp01(x: float) -> float:
+    return max(0.0, min(1.0, float(x)))
+
+
+def dimension_score(self_state: SelfStateV1, dimension_id: str) -> float:
+    dim = self_state.dimensions.get(dimension_id)
+    if dim is None:
+        return 0.0
+    return clamp01(dim.score)
+
+
+def dimension_confidence(self_state: SelfStateV1, dimension_id: str) -> float:
+    dim = self_state.dimensions.get(dimension_id)
+    if dim is None:
+        return self_state.overall_confidence
+    return clamp01(dim.confidence)
+
+
+def template_match_score(
+    *,
+    self_state: SelfStateV1,
+    template: ProposalTemplateV1,
+) -> tuple[float, dict[str, float]]:
+    contributions: dict[str, float] = {}
+    for dim_id, weight in template.dimensions.items():
+        contributions[dim_id] = clamp01(dimension_score(self_state, dim_id) * float(weight))
+    match = max(contributions.values()) if contributions else 0.0
+    return clamp01(match), contributions
+
+
+def proposal_urgency(
+    *,
+    self_state: SelfStateV1,
+    template: ProposalTemplateV1,
+) -> float:
+    scores = [
+        dimension_score(self_state, dim_id)
+        for dim_id in template.dimensions
+        if dim_id in PRESSURE_DIMENSIONS or dim_id.endswith("_pressure")
+    ]
+    if not scores:
+        scores = [dimension_score(self_state, d) for d in PRESSURE_DIMENSIONS]
+    return clamp01(max(scores) if scores else self_state.overall_intensity)
+
+
+def proposal_confidence(
+    *,
+    self_state: SelfStateV1,
+    template: ProposalTemplateV1,
+) -> float:
+    confs = [
+        dimension_confidence(self_state, dim_id)
+        for dim_id in template.dimensions
+    ]
+    if not confs:
+        return clamp01(self_state.overall_confidence)
+    return clamp01(sum(confs) / len(confs))
+
+
+def proposal_priority(
+    *,
+    base_priority: float,
+    match_score: float,
+    urgency: float,
+    confidence: float,
+) -> float:
+    return clamp01(
+        base_priority + 0.4 * match_score + 0.2 * urgency + 0.1 * confidence
+    )
+
+
+def proposal_risk(
+    *,
+    base_risk: float,
+    self_state: SelfStateV1,
+    template: ProposalTemplateV1,
+) -> float:
+    risk = float(base_risk)
+    if template.kind in ("prepare_action", "request_policy_review"):
+        risk += 0.10
+    if template.required_policy_gate not in ("none", "read_only"):
+        risk += 0.05
+    if dimension_score(self_state, "reliability_pressure") >= 0.5:
+        risk += 0.10
+    if dimension_score(self_state, "uncertainty") >= 0.5:
+        risk += 0.08
+    if template.kind in ("observe", "inspect", "summarize") and template.required_policy_gate == "read_only":
+        risk = min(risk, 0.15)
+    return clamp01(risk)

--- a/orion/proposals/templates.py
+++ b/orion/proposals/templates.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Literal, cast
+
+ProposalKind = Literal[
+    "observe",
+    "inspect",
+    "summarize",
+    "stabilize",
+    "defer",
+    "request_policy_review",
+    "prepare_action",
+]
+
+TargetKind = Literal[
+    "node",
+    "capability",
+    "field",
+    "self_state",
+    "service",
+    "system",
+]
+
+ProposedEffect = Literal[
+    "increase_observability",
+    "reduce_pressure",
+    "preserve_stability",
+    "increase_coherence",
+    "defer_until_policy",
+    "prepare_for_policy_gate",
+    "no_effect",
+]
+
+PolicyGate = Literal[
+    "none",
+    "read_only",
+    "operator_review",
+    "autonomy_policy",
+    "execution_policy",
+]
+
+
+_TEMPLATE_COPY: dict[str, tuple[str, str, list[str]]] = {
+    "inspect_execution_pressure": (
+        "Inspect orchestration execution pressure",
+        "Execution pressure is elevated on capability:orchestration; inspect supporting field and attention evidence.",
+        ["execution_pressure_elevated", "orchestration_inspect"],
+    ),
+    "summarize_loaded_state": (
+        "Summarize loaded operating condition",
+        "Self-state is loaded with elevated field/resource/execution pressure; summarize for downstream review.",
+        ["loaded_operating_condition", "downstream_review"],
+    ),
+    "watch_reliability": (
+        "Observe orchestration reliability signals",
+        "Reliability pressure warrants continued observation of capability:orchestration without action.",
+        ["reliability_watch", "preserve_stability"],
+    ),
+    "request_policy_review_for_action": (
+        "Prepare policy review for possible action",
+        "Agency readiness and execution pressure are sufficient to consider a policy-gated action proposal.",
+        ["policy_gate_required", "not_approval", "not_execution"],
+    ),
+    "defer_due_to_low_readiness": (
+        "Defer action until readiness improves",
+        "Uncertainty or reliability pressure suggests deferring possible action until policy can evaluate later.",
+        ["defer_stability", "low_readiness"],
+    ),
+}
+
+
+def template_title_description(
+    template_key: str,
+    *,
+    target_id: str,
+) -> tuple[str, str, list[str]]:
+    title, description, reasons = _TEMPLATE_COPY.get(
+        template_key,
+        (
+            f"Proposal for {target_id}",
+            f"Template {template_key} matched current self-state dimensions.",
+            [f"template:{template_key}"],
+        ),
+    )
+    return title, description, list(reasons)
+
+
+def cast_proposal_kind(kind: str) -> ProposalKind:
+    return cast(ProposalKind, kind)
+
+
+def cast_target_kind(kind: str) -> TargetKind:
+    return cast(TargetKind, kind)
+
+
+def cast_proposed_effect(effect: str) -> ProposedEffect:
+    return cast(ProposedEffect, effect)
+
+
+def cast_policy_gate(gate: str) -> PolicyGate:
+    return cast(PolicyGate, gate)

--- a/orion/schemas/proposal_frame.py
+++ b/orion/schemas/proposal_frame.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProposalCandidateV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id: str
+
+    proposal_kind: Literal[
+        "observe",
+        "inspect",
+        "summarize",
+        "stabilize",
+        "defer",
+        "request_policy_review",
+        "prepare_action",
+    ]
+
+    title: str
+    description: str
+
+    target_id: str
+    target_kind: Literal[
+        "node",
+        "capability",
+        "field",
+        "self_state",
+        "service",
+        "system",
+    ]
+
+    priority_score: float = Field(ge=0.0, le=1.0)
+    urgency_score: float = Field(ge=0.0, le=1.0)
+    confidence_score: float = Field(ge=0.0, le=1.0)
+    risk_score: float = Field(ge=0.0, le=1.0)
+    reversibility_score: float = Field(ge=0.0, le=1.0)
+
+    motivating_dimensions: dict[str, float] = Field(default_factory=dict)
+    motivating_targets: list[str] = Field(default_factory=list)
+    evidence_refs: list[str] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+
+    proposed_effect: Literal[
+        "increase_observability",
+        "reduce_pressure",
+        "preserve_stability",
+        "increase_coherence",
+        "defer_until_policy",
+        "prepare_for_policy_gate",
+        "no_effect",
+    ]
+
+    required_policy_gate: Literal[
+        "none",
+        "read_only",
+        "operator_review",
+        "autonomy_policy",
+        "execution_policy",
+    ] = "read_only"
+
+    execution_intent: dict[str, str] = Field(default_factory=dict)
+
+
+class ProposalFrameV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["proposal.frame.v1"] = "proposal.frame.v1"
+
+    frame_id: str
+    generated_at: datetime
+
+    source_self_state_id: str
+    source_self_state_generated_at: datetime
+
+    source_attention_frame_id: str
+    source_field_tick_id: str
+
+    proposal_policy_id: str = "proposal_policy.v1"
+
+    overall_action_pressure: float = Field(ge=0.0, le=1.0)
+    overall_risk: float = Field(ge=0.0, le=1.0)
+    policy_required: bool = True
+
+    candidates: list[ProposalCandidateV1] = Field(default_factory=list)
+    suppressed_candidates: list[ProposalCandidateV1] = Field(default_factory=list)
+
+    dominant_motivations: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -461,6 +461,7 @@ from orion.schemas.situation import (
 )
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
 from orion.schemas.field_state import FieldEdgeV1, FieldStateV1
+from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
 from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
 from orion.schemas.evidence_index import (
     EvidenceQueryResultItemV1,
@@ -943,6 +944,8 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "FieldAttentionFrameV1": FieldAttentionFrameV1,
     "SelfStateDimensionV1": SelfStateDimensionV1,
     "SelfStateV1": SelfStateV1,
+    "ProposalCandidateV1": ProposalCandidateV1,
+    "ProposalFrameV1": ProposalFrameV1,
     "EvidenceUnitV1": EvidenceUnitV1,
     "EvidenceQueryV1": EvidenceQueryV1,
     "EvidenceQueryResultItemV1": EvidenceQueryResultItemV1,

--- a/scripts/smoke_proposal_frame_v1.sh
+++ b/scripts/smoke_proposal_frame_v1.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB="${DB:-orion-athena-sql-db}"
+PGDATABASE="${PGDATABASE:-conjourney}"
+PGUSER="${PGUSER:-postgres}"
+
+echo "=== Latest self-state ==="
+docker exec -i "$DB" psql -U "$PGUSER" -d "$PGDATABASE" -c "
+select
+    generated_at,
+    self_state_id,
+    self_state_json #>> '{overall_condition}' as overall_condition,
+    self_state_json #>> '{overall_intensity}' as overall_intensity,
+    self_state_json #> '{summary_labels}' as summary_labels
+from substrate_self_state
+order by generated_at desc
+limit 1;
+"
+
+echo ""
+echo "=== Latest proposal frame ==="
+docker exec -i "$DB" psql -U "$PGUSER" -d "$PGDATABASE" -c "
+select
+    generated_at,
+    frame_id,
+    source_self_state_id,
+    proposal_frame_json #>> '{overall_action_pressure}' as overall_action_pressure,
+    proposal_frame_json #>> '{overall_risk}' as overall_risk,
+    proposal_frame_json #>> '{policy_required}' as policy_required,
+    proposal_frame_json #> '{candidates}' as candidates
+from substrate_proposal_frames
+order by generated_at desc
+limit 1;
+"

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -146,12 +146,14 @@ from .substrate_biometrics_routes import router as substrate_biometrics_router
 from .substrate_field_routes import router as substrate_field_router
 from .substrate_attention_routes import router as substrate_attention_router
 from .substrate_self_state_routes import router as substrate_self_state_router
+from .substrate_proposal_routes import router as substrate_proposal_router
 
 router.include_router(grammar_atlas_router)
 router.include_router(substrate_biometrics_router)
 router.include_router(substrate_field_router)
 router.include_router(substrate_attention_router)
 router.include_router(substrate_self_state_router)
+router.include_router(substrate_proposal_router)
 
 
 def _hub_uses_host_network_mode() -> bool:

--- a/services/orion-hub/scripts/substrate_proposal_routes.py
+++ b/services/orion-hub/scripts/substrate_proposal_routes.py
@@ -1,0 +1,48 @@
+"""Read-only debug API for substrate proposal frames."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import create_engine, text
+
+from orion.schemas.proposal_frame import ProposalFrameV1
+
+router = APIRouter(prefix="/api/substrate/proposals", tags=["substrate-proposals"])
+
+
+def _engine():
+    uri = os.getenv("POSTGRES_URI", "").strip()
+    if not uri:
+        raise HTTPException(status_code=503, detail="postgres_uri_not_configured")
+    return create_engine(uri, pool_pre_ping=True)
+
+
+def _load_latest_proposal_frame() -> ProposalFrameV1 | None:
+    with _engine().connect() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT proposal_frame_json FROM substrate_proposal_frames
+                ORDER BY generated_at DESC
+                LIMIT 1
+                """
+            ),
+        ).mappings().first()
+    if not row:
+        return None
+    payload = row["proposal_frame_json"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return ProposalFrameV1.model_validate(payload)
+
+
+@router.get("/latest")
+async def proposals_latest() -> dict[str, Any]:
+    frame = _load_latest_proposal_frame()
+    if frame is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return frame.model_dump(mode="json")

--- a/services/orion-hub/tests/test_substrate_proposal_debug_api.py
+++ b/services/orion-hub/tests/test_substrate_proposal_debug_api.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_hub_scripts_import_path() -> None:
+    for key in list(sys.modules):
+        if key == "scripts" or key.startswith("scripts."):
+            del sys.modules[key]
+    for p in (str(REPO_ROOT), str(HUB_ROOT)):
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(HUB_ROOT))
+
+
+_ensure_hub_scripts_import_path()
+
+from scripts import substrate_proposal_routes  # noqa: E402
+
+
+def _sample_proposal_frame() -> dict:
+    return {
+        "schema_version": "proposal.frame.v1",
+        "frame_id": "proposal.frame:self.state:tick:policy:self_state_policy.v1:proposal_policy.v1",
+        "generated_at": "2026-05-24T12:00:00+00:00",
+        "source_self_state_id": "self.state:tick:frame:policy",
+        "source_self_state_generated_at": "2026-05-24T12:00:00+00:00",
+        "source_attention_frame_id": "attention.frame:tick:policy",
+        "source_field_tick_id": "tick",
+        "proposal_policy_id": "proposal_policy.v1",
+        "overall_action_pressure": 0.5,
+        "overall_risk": 0.1,
+        "policy_required": True,
+        "candidates": [],
+        "suppressed_candidates": [],
+        "dominant_motivations": [],
+        "warnings": [],
+    }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    app = FastAPI()
+    app.include_router(substrate_proposal_routes.router)
+    return TestClient(app)
+
+
+def _fake_engine_with_frame(frame_json: dict | None):
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute(stmt, params=None):
+        m = MagicMock()
+        if frame_json is None:
+            m.mappings.return_value.first.return_value = None
+        else:
+            m.mappings.return_value.first.return_value = {"proposal_frame_json": frame_json}
+        return m
+
+    conn.execute.side_effect = execute
+    return fake_engine
+
+
+def test_proposals_latest_returns_frame(client):
+    frame = _sample_proposal_frame()
+    fake_engine = _fake_engine_with_frame(frame)
+
+    with patch.object(substrate_proposal_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/proposals/latest")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["schema_version"] == "proposal.frame.v1"
+
+
+def test_proposals_latest_not_found(client):
+    fake_engine = _fake_engine_with_frame(None)
+
+    with patch.object(substrate_proposal_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/proposals/latest")
+
+    assert r.status_code == 404

--- a/services/orion-proposal-runtime/.env_example
+++ b/services/orion-proposal-runtime/.env_example
@@ -1,0 +1,8 @@
+PROJECT=orion-athena
+SERVICE_NAME=orion-proposal-runtime
+SERVICE_VERSION=0.1.0
+POSTGRES_URI=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+PROPOSAL_POLICY_PATH=/app/config/proposals/proposal_policy.v1.yaml
+PROPOSAL_POLL_INTERVAL_SEC=2.0
+ENABLE_PROPOSAL_RUNTIME=true
+LOG_LEVEL=INFO

--- a/services/orion-proposal-runtime/Dockerfile
+++ b/services/orion-proposal-runtime/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir --upgrade pip
+
+COPY services/orion-proposal-runtime/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY orion /app/orion
+COPY config/proposals /app/config/proposals
+COPY services/orion-proposal-runtime /app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8119"]

--- a/services/orion-proposal-runtime/README.md
+++ b/services/orion-proposal-runtime/README.md
@@ -1,0 +1,43 @@
+# orion-proposal-runtime
+
+Layer 7 substrate service: converts `SelfStateV1` (+ optional attention/field context) into **possible actions** (`ProposalFrameV1`), not automatic actions.
+
+## Data flow
+
+```text
+substrate_self_state
++ substrate_attention_frames
++ substrate_field_state
+  → orion-proposal-runtime
+  → ProposalFrameV1
+  → substrate_proposal_frames
+```
+
+## Non-goals
+
+- No policy approval, cortex-exec, bus publish, operator notifications, or LLM calls.
+- `execution_intent` on candidates is descriptive only.
+
+## Run
+
+```bash
+cp -n .env_example .env
+docker compose up -d --build
+curl -s http://localhost:8119/health
+curl -s http://localhost:8119/latest | jq
+```
+
+## Migration
+
+```bash
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < ../../services/orion-sql-db/manual_migration_proposal_frame_v1.sql
+```
+
+## Smoke
+
+From repo root:
+
+```bash
+./scripts/smoke_proposal_frame_v1.sh
+```

--- a/services/orion-proposal-runtime/README.md
+++ b/services/orion-proposal-runtime/README.md
@@ -18,6 +18,10 @@ substrate_self_state
 - No policy approval, cortex-exec, bus publish, operator notifications, or LLM calls.
 - `execution_intent` on candidates is descriptive only.
 
+## Idempotency
+
+One proposal frame per `source_self_state_id`. Re-running the worker for the same self-state snapshot is a no-op. Policy/template changes do not regenerate until a new self-state row exists (v1 semantics).
+
 ## Run
 
 ```bash

--- a/services/orion-proposal-runtime/app/main.py
+++ b/services/orion-proposal-runtime/app/main.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from app.settings import get_settings
+from app.store import ProposalRuntimeStore
+from app.worker import ProposalRuntimeWorker
+
+_settings = get_settings()
+logging.basicConfig(level=getattr(logging, _settings.log_level.upper(), logging.INFO))
+
+worker = ProposalRuntimeWorker()
+store = ProposalRuntimeStore(_settings.postgres_uri)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await worker.start()
+    try:
+        yield
+    finally:
+        await worker.stop()
+
+
+app = FastAPI(title="orion-proposal-runtime", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "service": get_settings().service_name}
+
+
+@app.get("/latest")
+async def latest() -> dict[str, Any]:
+    frame = store.load_latest_proposal_frame()
+    if frame is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return frame.model_dump(mode="json")

--- a/services/orion-proposal-runtime/app/settings.py
+++ b/services/orion-proposal-runtime/app/settings.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    project: str = Field("orion-athena", alias="PROJECT")
+    service_name: str = Field("orion-proposal-runtime", alias="SERVICE_NAME")
+    service_version: str = Field("0.1.0", alias="SERVICE_VERSION")
+
+    postgres_uri: str = Field(..., alias="POSTGRES_URI")
+    proposal_policy_path: str = Field(
+        "config/proposals/proposal_policy.v1.yaml",
+        alias="PROPOSAL_POLICY_PATH",
+    )
+    proposal_poll_interval_sec: float = Field(2.0, alias="PROPOSAL_POLL_INTERVAL_SEC")
+    enable_proposal_runtime: bool = Field(True, alias="ENABLE_PROPOSAL_RUNTIME")
+    log_level: str = Field("INFO", alias="LOG_LEVEL")
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings

--- a/services/orion-proposal-runtime/app/store.py
+++ b/services/orion-proposal-runtime/app/store.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from psycopg2.extras import Json
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.field_state import FieldStateV1
+from orion.schemas.proposal_frame import ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+
+class ProposalRuntimeStore:
+    def __init__(self, postgres_uri: str) -> None:
+        self._engine: Engine = create_engine(
+            postgres_uri,
+            pool_pre_ping=True,
+            json_serializer=json.dumps,
+            json_deserializer=json.loads,
+        )
+
+    def load_latest_self_state(self) -> SelfStateV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT self_state_json FROM substrate_self_state
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["self_state_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return SelfStateV1.model_validate(payload)
+
+    def load_attention_frame(self, frame_id: str) -> FieldAttentionFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT frame_json FROM substrate_attention_frames
+                        WHERE frame_id = :frame_id
+                        LIMIT 1
+                        """
+                    ),
+                    {"frame_id": frame_id},
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["frame_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return FieldAttentionFrameV1.model_validate(payload)
+
+    def load_field_for_tick(self, tick_id: str) -> FieldStateV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT field_json FROM substrate_field_state
+                        WHERE tick_id = :tick_id
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                    {"tick_id": tick_id},
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["field_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return FieldStateV1.model_validate(payload)
+
+    def load_latest_proposal_frame(self) -> ProposalFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT proposal_frame_json FROM substrate_proposal_frames
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["proposal_frame_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return ProposalFrameV1.model_validate(payload)
+
+    def load_proposal_frame_for_self_state(self, self_state_id: str) -> ProposalFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT proposal_frame_json FROM substrate_proposal_frames
+                        WHERE source_self_state_id = :self_state_id
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                    {"self_state_id": self_state_id},
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["proposal_frame_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return ProposalFrameV1.model_validate(payload)
+
+    def save_proposal_frame(self, frame: ProposalFrameV1) -> None:
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO substrate_proposal_frames (
+                        frame_id,
+                        source_self_state_id,
+                        source_attention_frame_id,
+                        source_field_tick_id,
+                        generated_at,
+                        policy_id,
+                        proposal_frame_json,
+                        created_at
+                    ) VALUES (
+                        :frame_id,
+                        :source_self_state_id,
+                        :source_attention_frame_id,
+                        :source_field_tick_id,
+                        :generated_at,
+                        :policy_id,
+                        :proposal_frame_json,
+                        :created_at
+                    )
+                    ON CONFLICT (frame_id) DO UPDATE SET
+                        source_self_state_id = EXCLUDED.source_self_state_id,
+                        source_attention_frame_id = EXCLUDED.source_attention_frame_id,
+                        source_field_tick_id = EXCLUDED.source_field_tick_id,
+                        generated_at = EXCLUDED.generated_at,
+                        policy_id = EXCLUDED.policy_id,
+                        proposal_frame_json = EXCLUDED.proposal_frame_json
+                    """
+                ),
+                {
+                    "frame_id": frame.frame_id,
+                    "source_self_state_id": frame.source_self_state_id,
+                    "source_attention_frame_id": frame.source_attention_frame_id,
+                    "source_field_tick_id": frame.source_field_tick_id,
+                    "generated_at": frame.generated_at,
+                    "policy_id": frame.proposal_policy_id,
+                    "proposal_frame_json": Json(frame.model_dump(mode="json")),
+                    "created_at": now,
+                },
+            )

--- a/services/orion-proposal-runtime/app/worker.py
+++ b/services/orion-proposal-runtime/app/worker.py
@@ -61,6 +61,7 @@ class ProposalRuntimeWorker:
                 self_state.source_field_tick_id,
                 self_state.self_state_id,
             )
+            return
 
         previous = self._store.load_latest_proposal_frame()
         frame = build_proposal_frame(

--- a/services/orion-proposal-runtime/app/worker.py
+++ b/services/orion-proposal-runtime/app/worker.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from orion.proposals.builder import build_proposal_frame
+from orion.proposals.policy import load_proposal_policy
+
+from app.settings import get_settings
+from app.store import ProposalRuntimeStore
+
+logger = logging.getLogger("orion.proposal.runtime")
+
+
+class ProposalRuntimeWorker:
+    def __init__(self) -> None:
+        self._settings = get_settings()
+        self._store = ProposalRuntimeStore(self._settings.postgres_uri)
+        self._policy = load_proposal_policy(Path(self._settings.proposal_policy_path))
+        self._stop = asyncio.Event()
+
+    async def start(self) -> None:
+        asyncio.create_task(self._poll_loop(), name="proposal-runtime-poll")
+
+    async def stop(self) -> None:
+        self._stop.set()
+
+    async def _poll_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                await asyncio.to_thread(self._tick)
+            except Exception:
+                logger.exception("proposal_runtime_tick_failed")
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(),
+                    timeout=float(self._settings.proposal_poll_interval_sec),
+                )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+    def _tick(self) -> None:
+        if not self._settings.enable_proposal_runtime:
+            return
+
+        self_state = self._store.load_latest_self_state()
+        if self_state is None:
+            return
+
+        if self._store.load_proposal_frame_for_self_state(self_state.self_state_id) is not None:
+            return
+
+        attention = self._store.load_attention_frame(self_state.source_attention_frame_id)
+        field = self._store.load_field_for_tick(self_state.source_field_tick_id)
+        if field is None:
+            logger.warning(
+                "proposal_skip_missing_field tick_id=%s self_state_id=%s",
+                self_state.source_field_tick_id,
+                self_state.self_state_id,
+            )
+
+        previous = self._store.load_latest_proposal_frame()
+        frame = build_proposal_frame(
+            self_state=self_state,
+            attention=attention,
+            field=field,
+            policy=self._policy,
+            previous_frame=previous,
+        )
+        self._store.save_proposal_frame(frame)
+        logger.info(
+            "proposal_frame_saved frame_id=%s self_state_id=%s candidates=%d",
+            frame.frame_id,
+            self_state.self_state_id,
+            len(frame.candidates),
+        )

--- a/services/orion-proposal-runtime/docker-compose.yml
+++ b/services/orion-proposal-runtime/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  proposal-runtime:
+    build:
+      context: ../..
+      dockerfile: services/orion-proposal-runtime/Dockerfile
+    container_name: ${PROJECT}-proposal-runtime
+    restart: unless-stopped
+    networks:
+      - app-net
+    ports:
+      - "${PROPOSAL_RUNTIME_PORT:-8119}:8119"
+    environment:
+      - PROJECT=${PROJECT}
+      - SERVICE_NAME=${SERVICE_NAME:-orion-proposal-runtime}
+      - SERVICE_VERSION=${SERVICE_VERSION:-0.1.0}
+      - POSTGRES_URI=${POSTGRES_URI}
+      - PROPOSAL_POLICY_PATH=${PROPOSAL_POLICY_PATH:-/app/config/proposals/proposal_policy.v1.yaml}
+      - PROPOSAL_POLL_INTERVAL_SEC=${PROPOSAL_POLL_INTERVAL_SEC:-2.0}
+      - ENABLE_PROPOSAL_RUNTIME=${ENABLE_PROPOSAL_RUNTIME:-true}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+
+networks:
+  app-net:
+    external: true

--- a/services/orion-proposal-runtime/requirements.txt
+++ b/services/orion-proposal-runtime/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+pydantic==2.10.3
+pydantic-settings==2.6.1
+sqlalchemy==2.0.36
+psycopg2-binary==2.9.10
+PyYAML==6.0.2

--- a/services/orion-sql-db/manual_migration_proposal_frame_v1.sql
+++ b/services/orion-sql-db/manual_migration_proposal_frame_v1.sql
@@ -1,0 +1,16 @@
+create table if not exists substrate_proposal_frames (
+    frame_id text primary key,
+    source_self_state_id text not null,
+    source_attention_frame_id text,
+    source_field_tick_id text,
+    generated_at timestamptz not null,
+    policy_id text not null,
+    proposal_frame_json jsonb not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_proposal_frames_generated_at
+    on substrate_proposal_frames (generated_at desc);
+
+create index if not exists idx_substrate_proposal_frames_source_self_state
+    on substrate_proposal_frames (source_self_state_id);

--- a/tests/test_proposal_frame_builder.py
+++ b/tests/test_proposal_frame_builder.py
@@ -1,0 +1,157 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.proposals.builder import build_proposal_frame, stable_proposal_frame_id
+from orion.proposals.policy import load_proposal_policy
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_proposal_policy(REPO / "config" / "proposals" / "proposal_policy.v1.yaml")
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _loaded_self_state() -> SelfStateV1:
+    def dim(dimension_id: str, score: float) -> SelfStateDimensionV1:
+        return SelfStateDimensionV1(
+            dimension_id=dimension_id,
+            score=score,
+            confidence=0.9,
+        )
+
+    return SelfStateV1(
+        self_state_id="self.state:tick_live:frame_live:self_state_policy.v1",
+        generated_at=NOW,
+        source_field_tick_id="tick_live",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="attention.frame:tick_live:field_attention_policy.v1",
+        source_attention_generated_at=NOW,
+        overall_condition="loaded",
+        overall_intensity=0.655,
+        overall_confidence=0.9,
+        dimensions={
+            "execution_pressure": dim("execution_pressure", 1.0),
+            "reasoning_pressure": dim("reasoning_pressure", 0.9),
+            "resource_pressure": dim("resource_pressure", 1.0),
+            "agency_readiness": dim("agency_readiness", 0.6),
+            "reliability_pressure": dim("reliability_pressure", 0.0),
+            "field_intensity": dim("field_intensity", 0.7),
+            "uncertainty": dim("uncertainty", 0.2),
+        },
+        dominant_attention_targets=[
+            "field:recent_perturbations",
+            "node:athena",
+            "capability:orchestration",
+            "capability:graph",
+        ],
+        summary_labels=[
+            "attention_saturated",
+            "execution_loaded",
+            "field_active",
+            "orchestration_pressurized",
+            "reliability_clear",
+            "resource_pressurized",
+        ],
+    )
+
+
+def test_frame_references_source_self_state() -> None:
+    state = _loaded_self_state()
+    frame = build_proposal_frame(self_state=state, attention=None, field=None, policy=POLICY, now=NOW)
+    assert frame.source_self_state_id == state.self_state_id
+
+
+def test_at_least_one_candidate() -> None:
+    frame = build_proposal_frame(
+        self_state=_loaded_self_state(),
+        attention=None,
+        field=None,
+        policy=POLICY,
+        now=NOW,
+    )
+    assert len(frame.candidates) >= 1
+
+
+def test_inspect_or_summarize_candidate_present() -> None:
+    frame = build_proposal_frame(
+        self_state=_loaded_self_state(),
+        attention=None,
+        field=None,
+        policy=POLICY,
+        now=NOW,
+    )
+    kinds = {c.proposal_kind for c in frame.candidates}
+    assert "inspect" in kinds or "summarize" in kinds
+
+
+def test_read_only_candidates_not_execution_policy() -> None:
+    frame = build_proposal_frame(
+        self_state=_loaded_self_state(),
+        attention=None,
+        field=None,
+        policy=POLICY,
+        now=NOW,
+    )
+    for candidate in frame.candidates:
+        if candidate.proposal_kind in ("observe", "inspect", "summarize", "defer"):
+            assert candidate.required_policy_gate in ("none", "read_only")
+        assert candidate.execution_intent.get("mode") == "descriptive_only"
+
+
+def test_no_execution_in_candidates() -> None:
+    frame = build_proposal_frame(
+        self_state=_loaded_self_state(),
+        attention=None,
+        field=None,
+        policy=POLICY,
+        now=NOW,
+    )
+    for candidate in frame.candidates + frame.suppressed_candidates:
+        assert "execute" not in candidate.proposal_kind
+        assert candidate.execution_intent.get("note") != "approved_for_execution"
+
+
+def test_policy_required_when_operator_review_present() -> None:
+    frame = build_proposal_frame(
+        self_state=_loaded_self_state(),
+        attention=None,
+        field=None,
+        policy=POLICY,
+        now=NOW,
+    )
+    has_operator = any(
+        c.required_policy_gate == "operator_review" for c in frame.candidates
+    )
+    if has_operator or frame.overall_risk >= POLICY.thresholds.policy_required_above_risk:
+        assert frame.policy_required is True
+
+
+def test_frame_id_stable() -> None:
+    state = _loaded_self_state()
+    a = build_proposal_frame(self_state=state, attention=None, field=None, policy=POLICY, now=NOW)
+    b = build_proposal_frame(self_state=state, attention=None, field=None, policy=POLICY, now=NOW)
+    assert a.frame_id == b.frame_id
+    assert a.frame_id == stable_proposal_frame_id(
+        self_state_id=state.self_state_id,
+        policy_id=POLICY.policy_id,
+    )
+
+
+def test_evidence_refs_include_self_state() -> None:
+    state = _loaded_self_state()
+    frame = build_proposal_frame(self_state=state, attention=None, field=None, policy=POLICY, now=NOW)
+    assert any(
+        ref.startswith("self_state:") for c in frame.candidates for ref in c.evidence_refs
+    )
+
+
+def test_suppressed_candidates_separate() -> None:
+    frame = build_proposal_frame(
+        self_state=_loaded_self_state(),
+        attention=None,
+        field=None,
+        policy=POLICY,
+        now=NOW,
+    )
+    active_ids = {c.proposal_id for c in frame.candidates}
+    suppressed_ids = {c.proposal_id for c in frame.suppressed_candidates}
+    assert active_ids.isdisjoint(suppressed_ids)

--- a/tests/test_proposal_frame_schemas.py
+++ b/tests/test_proposal_frame_schemas.py
@@ -1,0 +1,111 @@
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def test_proposal_candidate_validates() -> None:
+    c = ProposalCandidateV1(
+        proposal_id="proposal:inspect:state1",
+        proposal_kind="inspect",
+        title="Inspect",
+        description="Desc",
+        target_id="capability:orchestration",
+        target_kind="capability",
+        priority_score=0.5,
+        urgency_score=0.4,
+        confidence_score=0.8,
+        risk_score=0.05,
+        reversibility_score=1.0,
+        proposed_effect="increase_observability",
+        required_policy_gate="read_only",
+    )
+    assert c.proposal_kind == "inspect"
+
+
+def test_proposal_frame_validates() -> None:
+    frame = ProposalFrameV1(
+        frame_id="proposal.frame:state1:proposal_policy.v1",
+        generated_at=NOW,
+        source_self_state_id="self.state:1",
+        source_self_state_generated_at=NOW,
+        source_attention_frame_id="frame:1",
+        source_field_tick_id="tick:1",
+        overall_action_pressure=0.4,
+        overall_risk=0.1,
+    )
+    assert frame.schema_version == "proposal.frame.v1"
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        ProposalCandidateV1(
+            proposal_id="p1",
+            proposal_kind="observe",
+            title="T",
+            description="D",
+            target_id="t",
+            target_kind="system",
+            priority_score=0.1,
+            urgency_score=0.1,
+            confidence_score=0.1,
+            risk_score=0.1,
+            reversibility_score=1.0,
+            proposed_effect="no_effect",
+            extra_field=True,
+        )
+
+
+def test_score_bounds_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ProposalCandidateV1(
+            proposal_id="p1",
+            proposal_kind="observe",
+            title="T",
+            description="D",
+            target_id="t",
+            target_kind="system",
+            priority_score=1.5,
+            urgency_score=0.1,
+            confidence_score=0.1,
+            risk_score=0.1,
+            reversibility_score=1.0,
+            proposed_effect="no_effect",
+        )
+
+
+def test_roundtrip_json() -> None:
+    frame = ProposalFrameV1(
+        frame_id="proposal.frame:state1:proposal_policy.v1",
+        generated_at=NOW,
+        source_self_state_id="self.state:1",
+        source_self_state_generated_at=NOW,
+        source_attention_frame_id="frame:1",
+        source_field_tick_id="tick:1",
+        overall_action_pressure=0.4,
+        overall_risk=0.1,
+        candidates=[
+            ProposalCandidateV1(
+                proposal_id="proposal:inspect:state1",
+                proposal_kind="inspect",
+                title="Inspect",
+                description="Desc",
+                target_id="capability:orchestration",
+                target_kind="capability",
+                priority_score=0.5,
+                urgency_score=0.4,
+                confidence_score=0.8,
+                risk_score=0.05,
+                reversibility_score=1.0,
+                proposed_effect="increase_observability",
+            )
+        ],
+    )
+    payload = frame.model_dump(mode="json")
+    restored = ProposalFrameV1.model_validate(payload)
+    assert restored.frame_id == frame.frame_id
+    assert len(restored.candidates) == 1

--- a/tests/test_proposal_policy_loader.py
+++ b/tests/test_proposal_policy_loader.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from orion.proposals.policy import load_proposal_policy
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO / "config" / "proposals" / "proposal_policy.v1.yaml"
+
+
+def test_loads_yaml() -> None:
+    policy = load_proposal_policy(POLICY_PATH)
+    assert policy.schema_version == "proposal_policy.v1"
+
+
+def test_policy_id() -> None:
+    policy = load_proposal_policy(POLICY_PATH)
+    assert policy.policy_id == "proposal_policy.v1"
+
+
+def test_inspect_template_exists() -> None:
+    policy = load_proposal_policy(POLICY_PATH)
+    assert "inspect_execution_pressure" in policy.proposal_templates
+
+
+def test_policy_review_requires_operator_review() -> None:
+    policy = load_proposal_policy(POLICY_PATH)
+    tmpl = policy.proposal_templates["request_policy_review_for_action"]
+    assert tmpl.required_policy_gate == "operator_review"
+
+
+def test_dimension_weights_include_execution_pressure() -> None:
+    policy = load_proposal_policy(POLICY_PATH)
+    assert "execution_pressure" in policy.dimension_weights

--- a/tests/test_proposal_runtime_store.py
+++ b/tests/test_proposal_runtime_store.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO = Path(__file__).resolve().parents[1]
+SVC = REPO / "services" / "orion-proposal-runtime"
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _load_store_class():
+    spec = importlib.util.spec_from_file_location(
+        "proposal_runtime_store",
+        SVC / "app" / "store.py",
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.ProposalRuntimeStore
+
+
+ProposalRuntimeStore = _load_store_class()
+
+from orion.schemas.proposal_frame import ProposalFrameV1  # noqa: E402
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _frame() -> ProposalFrameV1:
+    return ProposalFrameV1(
+        frame_id="proposal.frame:self.state:tick:frame:policy:proposal_policy.v1",
+        generated_at=NOW,
+        source_self_state_id="self.state:tick:frame:policy",
+        source_self_state_generated_at=NOW,
+        source_attention_frame_id="frame_a",
+        source_field_tick_id="tick_a",
+        overall_action_pressure=0.5,
+        overall_risk=0.1,
+    )
+
+
+def test_save_and_load_latest(monkeypatch) -> None:
+    payload = _frame().model_dump(mode="json")
+    store = ProposalRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "INSERT INTO substrate_proposal_frames" in sql:
+            result.rowcount = 1
+        elif "source_self_state_id" in sql and "ORDER BY" in sql:
+            result.mappings.return_value.first.return_value = None
+        else:
+            result.mappings.return_value.first.return_value = {"proposal_frame_json": payload}
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    store.save_proposal_frame(_frame())
+    loaded = store.load_latest_proposal_frame()
+    assert loaded is not None
+    assert loaded.frame_id == _frame().frame_id
+
+
+def test_load_by_self_state_id(monkeypatch) -> None:
+    payload = _frame().model_dump(mode="json")
+    store = ProposalRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute_side_effect(stmt, params=None):
+        result = MagicMock()
+        if "source_self_state_id" in str(stmt):
+            result.mappings.return_value.first.return_value = {"proposal_frame_json": payload}
+        else:
+            result.mappings.return_value.first.return_value = None
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    loaded = store.load_proposal_frame_for_self_state("self.state:tick:frame:policy")
+    assert loaded is not None
+    assert loaded.source_self_state_id == "self.state:tick:frame:policy"
+
+
+def test_save_idempotent_by_frame_id(monkeypatch) -> None:
+    store = ProposalRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    calls: list[str] = []
+
+    def execute_side_effect(stmt, params=None):
+        calls.append(str(stmt))
+        return MagicMock()
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    store.save_proposal_frame(_frame())
+    assert any("ON CONFLICT (frame_id)" in sql for sql in calls)

--- a/tests/test_proposal_runtime_worker.py
+++ b/tests/test_proposal_runtime_worker.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO = Path(__file__).resolve().parents[1]
+SVC = REPO / "services" / "orion-proposal-runtime"
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(SVC))
+
+from app.worker import ProposalRuntimeWorker  # noqa: E402
+from orion.schemas.field_state import FieldStateV1  # noqa: E402
+from orion.schemas.proposal_frame import ProposalFrameV1  # noqa: E402
+from orion.schemas.self_state import SelfStateV1  # noqa: E402
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _self_state() -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id="self.state:tick_existing:frame_existing:self_state_policy.v1",
+        generated_at=NOW,
+        source_field_tick_id="tick_existing",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="attention.frame:tick_existing:field_attention_policy.v1",
+        source_attention_generated_at=NOW,
+        overall_intensity=0.5,
+        overall_confidence=0.7,
+    )
+
+
+def _field() -> FieldStateV1:
+    return FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_existing",
+        node_vectors={"node:athena": {"execution_load": 1.0}},
+    )
+
+
+def _existing_frame() -> ProposalFrameV1:
+    return ProposalFrameV1(
+        frame_id="proposal.frame:self.state:tick_existing:frame_existing:self_state_policy.v1:proposal_policy.v1",
+        generated_at=NOW,
+        source_self_state_id="self.state:tick_existing:frame_existing:self_state_policy.v1",
+        source_self_state_generated_at=NOW,
+        source_attention_frame_id="attention.frame:tick_existing:field_attention_policy.v1",
+        source_field_tick_id="tick_existing",
+        overall_action_pressure=0.4,
+        overall_risk=0.1,
+    )
+
+
+def test_worker_skips_when_proposal_exists_for_self_state(monkeypatch) -> None:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    worker = ProposalRuntimeWorker()
+    worker._store.load_latest_self_state = MagicMock(return_value=_self_state())
+    worker._store.load_proposal_frame_for_self_state = MagicMock(return_value=_existing_frame())
+    worker._store.save_proposal_frame = MagicMock()
+
+    worker._tick()
+
+    worker._store.save_proposal_frame.assert_not_called()
+
+
+def test_worker_skips_when_field_missing(monkeypatch) -> None:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    worker = ProposalRuntimeWorker()
+    worker._store.load_latest_self_state = MagicMock(return_value=_self_state())
+    worker._store.load_proposal_frame_for_self_state = MagicMock(return_value=None)
+    worker._store.load_attention_frame = MagicMock(return_value=None)
+    worker._store.load_field_for_tick = MagicMock(return_value=None)
+    worker._store.save_proposal_frame = MagicMock()
+
+    worker._tick()
+
+    worker._store.save_proposal_frame.assert_not_called()

--- a/tests/test_proposal_scoring.py
+++ b/tests/test_proposal_scoring.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.proposals.policy import load_proposal_policy
+from orion.proposals.scoring import (
+    clamp01,
+    proposal_priority,
+    proposal_risk,
+    template_match_score,
+)
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_proposal_policy(REPO / "config" / "proposals" / "proposal_policy.v1.yaml")
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _self_state(**dim_scores: float) -> SelfStateV1:
+    dimensions = {
+        dim_id: SelfStateDimensionV1(
+            dimension_id=dim_id,
+            score=score,
+            confidence=0.9,
+        )
+        for dim_id, score in dim_scores.items()
+    }
+    return SelfStateV1(
+        self_state_id="self.state:test:frame:policy",
+        generated_at=NOW,
+        source_field_tick_id="tick_test",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="frame_test",
+        source_attention_generated_at=NOW,
+        overall_condition="loaded",
+        overall_intensity=0.65,
+        overall_confidence=0.9,
+        dimensions=dimensions,
+    )
+
+
+def test_high_execution_pressure_raises_inspect_match() -> None:
+    state = _self_state(execution_pressure=1.0)
+    tmpl = POLICY.proposal_templates["inspect_execution_pressure"]
+    match, _ = template_match_score(self_state=state, template=tmpl)
+    low_state = _self_state(execution_pressure=0.1)
+    low_match, _ = template_match_score(self_state=low_state, template=tmpl)
+    assert match > low_match
+
+
+def test_high_field_resource_raises_summarize_match() -> None:
+    state = _self_state(field_intensity=0.9, resource_pressure=0.9)
+    tmpl = POLICY.proposal_templates["summarize_loaded_state"]
+    match, _ = template_match_score(self_state=state, template=tmpl)
+    assert match >= 0.4
+
+
+def test_read_only_proposals_low_risk() -> None:
+    state = _self_state(execution_pressure=1.0, reliability_pressure=0.8)
+    tmpl = POLICY.proposal_templates["inspect_execution_pressure"]
+    assert proposal_risk(base_risk=tmpl.base_risk, self_state=state, template=tmpl) <= 0.15
+
+
+def test_policy_review_higher_risk() -> None:
+    state = _self_state(agency_readiness=0.8, execution_pressure=1.0)
+    review = POLICY.proposal_templates["request_policy_review_for_action"]
+    inspect = POLICY.proposal_templates["inspect_execution_pressure"]
+    assert proposal_risk(
+        base_risk=review.base_risk, self_state=state, template=review
+    ) > proposal_risk(
+        base_risk=inspect.base_risk, self_state=state, template=inspect
+    )
+
+
+def test_scores_clamped() -> None:
+    assert clamp01(2.0) == 1.0
+    assert proposal_priority(
+        base_priority=0.9,
+        match_score=0.9,
+        urgency=0.9,
+        confidence=0.9,
+    ) == 1.0


### PR DESCRIPTION
# PR: Proposal Frame v1 — Self-State → Possible Actions, Not Automatic Actions

**Branch:** `feat/proposal-frame-v1`  
**Base:** `main`  
**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-proposal-frame-v1`

## Summary

Implements **Layer 7** of the Orion cognition substrate: deterministic conversion of `SelfStateV1` (+ optional attention/field context) into **inspectable possible actions** (`ProposalFrameV1`), without execution, policy approval, or bus publish.

```text
substrate_self_state (SelfStateV1)
+ substrate_attention_frames (FieldAttentionFrameV1)
+ substrate_field_state (FieldStateV1)
  → orion-proposal-runtime
  → ProposalFrameV1
  → substrate_proposal_frames
  → GET /api/substrate/proposals/latest (Hub debug)
```

**Core phrase:** *Proposal is action pressure made inspectable* — not approval, not execution, not autonomy.

### 11-layer roadmap placement

| Layer | Name | This PR |
|-------|------|---------|
| 1–6 | Organs → … → Self-state | Prerequisite (merged on `main`) |
| **7** | **Proposals** | **Implemented** |
| 8 | Policy | **Explicitly deferred** |
| 9–11 | Execution → Feedback → Consolidation | Deferred |

## Architecture

| Component | Role |
|-----------|------|
| `config/proposals/proposal_policy.v1.yaml` | Templates, thresholds, dimension weights |
| `orion/proposals/{policy,scoring,templates,builder}.py` | Pure deterministic proposal synthesis |
| `orion/schemas/proposal_frame.py` | `ProposalCandidateV1`, `ProposalFrameV1` |
| `services/orion-proposal-runtime` | Poll latest self-state → build → persist (port **8119**, no bus) |
| `substrate_proposal_frames` | Postgres persistence |
| `scripts/smoke_proposal_frame_v1.sh` | SQL inspection |

## Example `ProposalFrameV1` (live-shaped self-state)

Synthetic input matching operator live output (`execution_pressure=1.0`, `resource_pressure=1.0`, `overall_condition=loaded`):

```json
{
  "schema_version": "proposal.frame.v1",
  "frame_id": "proposal.frame:self.state:live:tick:frame:self_state_policy.v1:proposal_policy.v1",
  "overall_action_pressure": 0.93,
  "overall_risk": 0.45,
  "policy_required": true,
  "candidates": [
    {
      "proposal_kind": "inspect",
      "title": "Inspect orchestration execution pressure",
      "required_policy_gate": "read_only",
      "execution_intent": {
        "mode": "descriptive_only",
        "template": "inspect_execution_pressure",
        "policy_gate": "read_only"
      }
    },
    {
      "proposal_kind": "summarize",
      "title": "Summarize loaded operating condition",
      "required_policy_gate": "read_only",
      "execution_intent": { "mode": "descriptive_only" }
    },
    {
      "proposal_kind": "request_policy_review",
      "title": "Prepare policy review for possible action",
      "required_policy_gate": "operator_review",
      "execution_intent": {
        "mode": "descriptive_only",
        "note": "policy_review_not_execution"
      }
    }
  ]
}
```

Top candidates are **read-only inspect/summarize** under loaded execution pressure. `request_policy_review` is a *proposal to prepare policy evaluation later* — not approval and not cortex-exec.

## Proof: proposals only, not actions

| Check | Evidence |
|-------|----------|
| No cortex-exec / verb bus | No imports or calls; `orion/bus/channels.yaml` unchanged |
| No action execution | Worker only `INSERT` into `substrate_proposal_frames` |
| Descriptive `execution_intent` | Builder sets `mode: descriptive_only`; policy-review adds `policy_review_not_execution` |
| No approval API | Hub route is `GET /latest` only |
| Tests | `test_no_execution_in_candidates`, read-only gate assertions |
| Layer 8 deferred | No consent, blast-radius, or autonomy mutation |

## Tests run

```bash
PYTHONPATH=. pytest tests/test_proposal_frame_schemas.py \
  tests/test_proposal_policy_loader.py tests/test_proposal_scoring.py \
  tests/test_proposal_frame_builder.py tests/test_proposal_runtime_store.py \
  tests/test_proposal_runtime_worker.py -q
# 29 passed

PYTHONPATH=. pytest tests/test_self_state_*.py tests/test_attention_*.py -q
# 46 passed

PYTHONPATH=. pytest services/orion-hub/tests/test_substrate_proposal_debug_api.py -q
# 2 passed

PYTHONPATH=. python -m compileall orion/proposals orion/schemas/proposal_frame.py \
  services/orion-proposal-runtime -q
```

## Operator steps

```bash
docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
  < services/orion-sql-db/manual_migration_proposal_frame_v1.sql

cd services/orion-proposal-runtime
cp -n .env_example .env
docker compose up -d --build

./scripts/smoke_proposal_frame_v1.sh
curl -s http://localhost:8080/api/substrate/proposals/latest | jq
curl -s http://localhost:8119/latest | jq
```

## Layer 8 policy (deferred)

This PR does **not** implement policy gates, consent checks, blast-radius enforcement, cortex-exec dispatch, or operator notifications. Downstream Layer 8 will evaluate `required_policy_gate` and `risk_score` on each candidate.

## Code review

Subagent review: **Ready** after fixes for dimension weight wiring, missing-field worker skip (aligned with self-state runtime), and worker idempotency tests.