### PR TITLE
Feat/policy gate v1

### DIFF
--- a/config/policy/substrate_policy.v1.yaml
+++ b/config/policy/substrate_policy.v1.yaml
@@ -1,0 +1,67 @@
+schema_version: substrate_policy.v1
+policy_id: substrate_policy.v1
+
+autonomy:
+  default_tier: observe_only
+  max_tier_without_operator: read_only
+  allow_execution_without_operator: false
+
+thresholds:
+  approve_read_only_max_risk: 0.15
+  defer_above_risk: 0.60
+  reject_above_risk: 0.85
+  require_review_above_risk: 0.20
+  require_review_below_reversibility: 0.50
+  require_review_below_confidence: 0.50
+
+proposal_kind_rules:
+  observe:
+    allowed_scope: inspect_only
+    default_decision: approved_read_only
+    max_autonomy_tier: read_only
+
+  inspect:
+    allowed_scope: inspect_only
+    default_decision: approved_read_only
+    max_autonomy_tier: read_only
+
+  summarize:
+    allowed_scope: summarize_only
+    default_decision: approved_read_only
+    max_autonomy_tier: read_only
+
+  stabilize:
+    allowed_scope: prepare_only
+    default_decision: requires_operator_review
+    max_autonomy_tier: operator_review
+
+  defer:
+    allowed_scope: none
+    default_decision: deferred
+    max_autonomy_tier: observe_only
+
+  request_policy_review:
+    allowed_scope: operator_review_required
+    default_decision: requires_operator_review
+    max_autonomy_tier: operator_review
+
+  prepare_action:
+    allowed_scope: prepare_only
+    default_decision: requires_operator_review
+    max_autonomy_tier: operator_review
+
+hard_blocks:
+  - cortex_exec_direct_call
+  - external_side_effect
+  - settings_mutation
+  - file_write
+  - network_call
+  - operator_notification
+  - service_restart
+  - destructive_action
+
+read_only_effects:
+  - increase_observability
+  - preserve_stability
+  - increase_coherence
+  - no_effect

--- a/docs/superpowers/plans/2026-05-24-policy-gate-v1.md
+++ b/docs/superpowers/plans/2026-05-24-policy-gate-v1.md
@@ -1,0 +1,965 @@
+# Policy Gate v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Layer 8 — evaluate `ProposalFrameV1` candidates against `SubstratePolicyV1` and persist deterministic `PolicyDecisionFrameV1` snapshots (governed decisions only; no execution).
+
+**Architecture:** Schemas in `orion/schemas/policy_decision_frame.py`; pure policy logic in `orion/policy/`; polling service `orion-policy-runtime` idempotent per `source_proposal_frame_id`; optional Hub `GET /api/substrate/policy/latest`. Config from `config/policy/substrate_policy.v1.yaml`.
+
+**Tech Stack:** Python 3.12, Pydantic v2, PyYAML, SQLAlchemy, FastAPI/uvicorn, pytest, Postgres.
+
+**Depends on:** Layer 7 on `main` (`ProposalFrameV1`, `substrate_proposal_frames`, port 8119). Layer 6 `SelfStateV1` in `substrate_self_state`.
+
+**Non-goals:** Layer 9 execution, cortex-exec, bus publish, LLM, operator notify, settings mutation, autonomy mutation.
+
+---
+
+## Worktree and branch hygiene
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+git fetch origin main
+git worktree add .worktrees/feat-policy-gate-v1 -b feat/policy-gate-v1 origin/main
+cd .worktrees/feat-policy-gate-v1
+```
+
+**Rules:**
+
+- All implementation commits happen only inside `.worktrees/feat-policy-gate-v1`.
+- Do **not** copy changed files back to the main workspace checkout except syncing `services/orion-policy-runtime/.env` from `.env_example` on the operator machine (`.env` is gitignored).
+- **Port:** `8120` (`POLICY_RUNTIME_PORT`).
+- **Bus:** Register schemas in `orion/schemas/registry.py` only. **No** `orion/bus/channels.yaml` entry — policy runtime does not publish (matches Layer 7 proposal-runtime pattern).
+
+---
+
+## File structure
+
+| Path | Role |
+|------|------|
+| `orion/schemas/policy_decision_frame.py` | `PolicyDecisionV1`, `PolicyDecisionFrameV1` |
+| `orion/schemas/registry.py` | Register new schema types |
+| `config/policy/substrate_policy.v1.yaml` | Substrate policy thresholds + kind rules |
+| `orion/policy/__init__.py` | Package export |
+| `orion/policy/policy.py` | YAML loader + `SubstratePolicyV1` |
+| `orion/policy/rules.py` | Hard-block + read-only helpers |
+| `orion/policy/evaluator.py` | Per-candidate `evaluate_proposal_candidate` |
+| `orion/policy/builder.py` | `build_policy_decision_frame` |
+| `services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql` | DDL |
+| `services/orion-policy-runtime/` | Polling runtime (mirror `orion-proposal-runtime`) |
+| `services/orion-hub/scripts/substrate_policy_routes.py` | Optional debug API |
+| `services/orion-hub/scripts/api_routes.py` | Include policy router |
+| `services/orion-hub/tests/test_substrate_policy_debug_api.py` | Hub route tests |
+| `tests/test_policy_*.py` | Unit tests |
+| `scripts/smoke_policy_decision_frame_v1.sh` | Live SQL smoke |
+| `docs/superpowers/pr-reports/2026-05-24-policy-gate-v1-pr.md` | PR report (post-implementation) |
+
+---
+
+### Task 1: Policy decision schemas + registry
+
+**Files:**
+
+- Create: `orion/schemas/policy_decision_frame.py`
+- Modify: `orion/schemas/registry.py` (import + `SCHEMA_REGISTRY` entries)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_policy_decision_frame_schemas.py`:
+
+```python
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def test_policy_decision_validates() -> None:
+    d = PolicyDecisionV1(
+        decision_id="policy.decision:proposal:inspect:state:substrate_policy.v1",
+        proposal_id="proposal:inspect:state",
+        decision="approved_read_only",
+        policy_gate="read_only",
+        risk_score=0.05,
+        reversibility_score=1.0,
+        confidence_score=0.9,
+        allowed_scope="inspect_only",
+        reasons=["read_only_low_risk"],
+    )
+    assert d.decision == "approved_read_only"
+
+
+def test_policy_decision_frame_validates() -> None:
+    decision = PolicyDecisionV1(
+        decision_id="policy.decision:proposal:inspect:state:substrate_policy.v1",
+        proposal_id="proposal:inspect:state",
+        decision="approved_read_only",
+        policy_gate="read_only",
+        risk_score=0.05,
+        reversibility_score=1.0,
+        confidence_score=0.9,
+    )
+    frame = PolicyDecisionFrameV1(
+        frame_id="policy.frame:proposal.frame:state:substrate_policy.v1",
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:state:proposal_policy.v1",
+        source_self_state_id="self.state:state",
+        decisions=[decision],
+        approved_decisions=[decision],
+        overall_risk=0.05,
+    )
+    assert frame.schema_version == "policy.decision.frame.v1"
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        PolicyDecisionV1(
+            decision_id="d1",
+            proposal_id="p1",
+            decision="rejected",
+            policy_gate="none",
+            risk_score=0.1,
+            reversibility_score=1.0,
+            confidence_score=0.9,
+            extra_field=True,
+        )
+
+
+def test_score_bounds_rejected() -> None:
+    with pytest.raises(ValidationError):
+        PolicyDecisionV1(
+            decision_id="d1",
+            proposal_id="p1",
+            decision="rejected",
+            policy_gate="none",
+            risk_score=1.5,
+            reversibility_score=1.0,
+            confidence_score=0.9,
+        )
+
+
+def test_roundtrip_json() -> None:
+    decision = PolicyDecisionV1(
+        decision_id="policy.decision:p1:substrate_policy.v1",
+        proposal_id="p1",
+        decision="requires_operator_review",
+        policy_gate="operator_review",
+        risk_score=0.3,
+        reversibility_score=0.4,
+        confidence_score=0.6,
+        reasons=["low_reversibility"],
+    )
+    frame = PolicyDecisionFrameV1(
+        frame_id="policy.frame:pf1:substrate_policy.v1",
+        generated_at=NOW,
+        source_proposal_frame_id="pf1",
+        source_self_state_id="ss1",
+        decisions=[decision],
+        review_required_decisions=[decision],
+        overall_risk=0.3,
+        operator_review_required=True,
+    )
+    payload = frame.model_dump(mode="json")
+    restored = PolicyDecisionFrameV1.model_validate(payload)
+    assert restored.frame_id == frame.frame_id
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest tests/test_policy_decision_frame_schemas.py -v`
+
+Expected: FAIL — `ModuleNotFoundError: orion.schemas.policy_decision_frame`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `orion/schemas/policy_decision_frame.py` (full models per PR spec — `PolicyDecisionV1` and `PolicyDecisionFrameV1` with all literals and `extra="forbid"`).
+
+Register in `orion/schemas/registry.py`:
+
+```python
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
+```
+
+Add to `SCHEMA_REGISTRY`:
+
+```python
+    "PolicyDecisionV1": PolicyDecisionV1,
+    "PolicyDecisionFrameV1": PolicyDecisionFrameV1,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest tests/test_policy_decision_frame_schemas.py -q`
+
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/schemas/policy_decision_frame.py orion/schemas/registry.py tests/test_policy_decision_frame_schemas.py
+git commit -m "feat(policy): add PolicyDecisionFrameV1 schemas and registry"
+```
+
+---
+
+### Task 2: Substrate policy config + loader
+
+**Files:**
+
+- Create: `config/policy/substrate_policy.v1.yaml` (exact YAML from PR spec)
+- Create: `orion/policy/__init__.py`
+- Create: `orion/policy/policy.py`
+- Test: `tests/test_policy_loader.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_policy_loader.py`:
+
+```python
+from pathlib import Path
+
+from orion.policy.policy import load_substrate_policy
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO / "config" / "policy" / "substrate_policy.v1.yaml"
+
+
+def test_loads_yaml() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    assert policy.schema_version == "substrate_policy.v1"
+
+
+def test_policy_id() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    assert policy.policy_id == "substrate_policy.v1"
+
+
+def test_execution_without_operator_disabled() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    assert policy.autonomy.allow_execution_without_operator is False
+
+
+def test_prepare_action_requires_review() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    rule = policy.proposal_kind_rules["prepare_action"]
+    assert rule.default_decision == "requires_operator_review"
+    assert rule.max_autonomy_tier == "operator_review"
+
+
+def test_inspect_read_only() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    rule = policy.proposal_kind_rules["inspect"]
+    assert rule.default_decision == "approved_read_only"
+    assert rule.allowed_scope == "inspect_only"
+
+
+def test_hard_blocks_include_cortex_exec() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    assert "cortex_exec_direct_call" in policy.hard_blocks
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest tests/test_policy_loader.py -v`
+
+Expected: FAIL — module/config missing
+
+- [ ] **Step 3: Write minimal implementation**
+
+`config/policy/substrate_policy.v1.yaml` — copy verbatim from PR spec (`schema_version`, `policy_id`, `autonomy`, `thresholds`, `proposal_kind_rules`, `hard_blocks`, `read_only_effects`).
+
+`orion/policy/policy.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AutonomyConfigV1(BaseModel):
+    default_tier: str = "observe_only"
+    max_tier_without_operator: str = "read_only"
+    allow_execution_without_operator: bool = False
+
+
+class PolicyThresholdsV1(BaseModel):
+    approve_read_only_max_risk: float = 0.15
+    defer_above_risk: float = 0.60
+    reject_above_risk: float = 0.85
+    require_review_above_risk: float = 0.20
+    require_review_below_reversibility: float = 0.50
+    require_review_below_confidence: float = 0.50
+
+
+class ProposalKindRuleV1(BaseModel):
+    allowed_scope: str
+    default_decision: str
+    max_autonomy_tier: str
+
+
+class SubstratePolicyV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["substrate_policy.v1"] = "substrate_policy.v1"
+    policy_id: str = "substrate_policy.v1"
+
+    autonomy: AutonomyConfigV1 = Field(default_factory=AutonomyConfigV1)
+    thresholds: PolicyThresholdsV1 = Field(default_factory=PolicyThresholdsV1)
+    proposal_kind_rules: dict[str, ProposalKindRuleV1] = Field(default_factory=dict)
+    hard_blocks: list[str] = Field(default_factory=list)
+    read_only_effects: list[str] = Field(default_factory=list)
+
+
+def load_substrate_policy(path: str | Path) -> SubstratePolicyV1:
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    return SubstratePolicyV1.model_validate(data)
+```
+
+`orion/policy/__init__.py`:
+
+```python
+from orion.policy.builder import build_policy_decision_frame
+from orion.policy.evaluator import evaluate_proposal_candidate
+from orion.policy.policy import SubstratePolicyV1, load_substrate_policy
+
+__all__ = [
+    "SubstratePolicyV1",
+    "build_policy_decision_frame",
+    "evaluate_proposal_candidate",
+    "load_substrate_policy",
+]
+```
+
+(Defer exporting builder/evaluator until Task 3–4 exist; or use lazy imports in `__init__.py` after those modules land.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest tests/test_policy_loader.py -q`
+
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config/policy/substrate_policy.v1.yaml orion/policy/ tests/test_policy_loader.py
+git commit -m "feat(policy): add substrate policy config and loader"
+```
+
+---
+
+### Task 3: Policy rules + evaluator
+
+**Files:**
+
+- Create: `orion/policy/rules.py`
+- Create: `orion/policy/evaluator.py`
+- Test: `tests/test_policy_evaluator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_policy_evaluator.py` with fixtures building minimal `ProposalCandidateV1`, `ProposalFrameV1`, `SelfStateV1`, and loading policy from `config/policy/substrate_policy.v1.yaml`.
+
+Include these tests (implement full assertions):
+
+1. `test_read_only_inspect_low_risk_approved` — `proposal_kind="inspect"`, `risk_score=0.05`, `proposed_effect="increase_observability"`, `required_policy_gate="read_only"` → `approved_read_only`
+2. `test_summarize_low_risk_approved_read_only`
+3. `test_prepare_action_requires_operator_review`
+4. `test_high_risk_rejected` — `risk_score=0.90` → `rejected`
+5. `test_low_reversibility_requires_review` — `reversibility_score=0.30`
+6. `test_low_confidence_requires_review` — `confidence_score=0.40`
+7. `test_hard_blocked_execution_intent_rejected` — `execution_intent={"mode": "cortex_exec_direct_call"}`
+8. `test_no_approved_for_execution_when_disabled` — loop all kinds; assert no `approved_for_execution`
+
+Example candidate factory:
+
+```python
+def _candidate(**overrides) -> ProposalCandidateV1:
+    base = dict(
+        proposal_id="proposal:test:state",
+        proposal_kind="inspect",
+        title="Inspect",
+        description="Desc",
+        target_id="capability:orchestration",
+        target_kind="capability",
+        priority_score=0.5,
+        urgency_score=0.4,
+        confidence_score=0.9,
+        risk_score=0.05,
+        reversibility_score=1.0,
+        proposed_effect="increase_observability",
+        required_policy_gate="read_only",
+        execution_intent={"mode": "descriptive_only"},
+    )
+    base.update(overrides)
+    return ProposalCandidateV1(**base)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest tests/test_policy_evaluator.py -v`
+
+Expected: FAIL — `evaluate_proposal_candidate` not defined
+
+- [ ] **Step 3: Write minimal implementation**
+
+`orion/policy/rules.py`:
+
+```python
+from __future__ import annotations
+
+from orion.policy.policy import SubstratePolicyV1
+from orion.schemas.proposal_frame import ProposalCandidateV1
+
+
+def stable_policy_decision_id(*, proposal_id: str, policy_id: str) -> str:
+    return f"policy.decision:{proposal_id}:{policy_id}"
+
+
+def execution_intent_blob(candidate: ProposalCandidateV1) -> str:
+    parts: list[str] = []
+    for key, value in candidate.execution_intent.items():
+        parts.append(str(key))
+        parts.append(str(value))
+    return " ".join(parts).lower()
+
+
+def hard_block_hits(candidate: ProposalCandidateV1, policy: SubstratePolicyV1) -> list[str]:
+    blob = execution_intent_blob(candidate)
+    return [block for block in policy.hard_blocks if block.lower() in blob]
+
+
+def is_read_only_candidate(candidate: ProposalCandidateV1, policy: SubstratePolicyV1) -> bool:
+    if candidate.proposal_kind in ("observe", "inspect", "summarize"):
+        return True
+    return candidate.proposed_effect in policy.read_only_effects
+
+
+def kind_rule(policy: SubstratePolicyV1, proposal_kind: str):
+    return policy.proposal_kind_rules.get(proposal_kind)
+```
+
+`orion/policy/evaluator.py` — evaluation order (conservative v1):
+
+```python
+def evaluate_proposal_candidate(
+    *,
+    candidate: ProposalCandidateV1,
+    proposal_frame: ProposalFrameV1,
+    self_state: SelfStateV1,
+    policy: SubstratePolicyV1,
+) -> PolicyDecisionV1:
+    rule = kind_rule(policy, candidate.proposal_kind)
+    allowed_scope = rule.allowed_scope if rule else "none"
+    autonomy_tier = rule.max_autonomy_tier if rule else policy.autonomy.default_tier
+    policy_gate = candidate.required_policy_gate
+    reasons: list[str] = []
+    blocked_by: list[str] = []
+    evidence_refs = list(candidate.evidence_refs)
+    evidence_refs.extend(
+        [
+            f"proposal_frame:{proposal_frame.frame_id}",
+            f"self_state:{self_state.self_state_id}",
+        ]
+    )
+
+    decision = rule.default_decision if rule else "deferred"
+    blocked = hard_block_hits(candidate, policy)
+    if blocked:
+        return _finish(
+            candidate=candidate,
+            policy=policy,
+            decision="rejected",
+            policy_gate="execution_policy",
+            autonomy_tier="observe_only",
+            allowed_scope="none",
+            risk_score=candidate.risk_score,
+            reversibility_score=candidate.reversibility_score,
+            confidence_score=candidate.confidence_score,
+            reasons=["hard_block_execution_intent"],
+            evidence_refs=evidence_refs,
+            blocked_by=blocked,
+            execution_constraints={"layer": "9_deferred"},
+        )
+
+    if candidate.proposal_kind == "defer":
+        decision = "deferred"
+        reasons.append("proposal_kind_defer")
+    elif candidate.risk_score >= policy.thresholds.reject_above_risk:
+        decision = "rejected"
+        reasons.append("risk_above_reject_threshold")
+    elif candidate.risk_score >= policy.thresholds.defer_above_risk:
+        decision = "deferred"
+        reasons.append("risk_above_defer_threshold")
+    elif candidate.proposal_kind == "prepare_action":
+        decision = "requires_operator_review"
+        reasons.append("prepare_action_never_auto_execute_v1")
+    elif candidate.required_policy_gate == "operator_review":
+        decision = "requires_operator_review"
+        reasons.append("candidate_requires_operator_review")
+    elif candidate.risk_score >= policy.thresholds.require_review_above_risk:
+        decision = "requires_operator_review"
+        reasons.append("risk_above_review_threshold")
+    elif candidate.reversibility_score < policy.thresholds.require_review_below_reversibility:
+        decision = "requires_operator_review"
+        reasons.append("reversibility_below_threshold")
+    elif candidate.confidence_score < policy.thresholds.require_review_below_confidence:
+        decision = "requires_operator_review"
+        reasons.append("confidence_below_threshold")
+    elif (
+        is_read_only_candidate(candidate, policy)
+        and candidate.risk_score <= policy.thresholds.approve_read_only_max_risk
+        and candidate.required_policy_gate in ("none", "read_only")
+    ):
+        decision = "approved_read_only"
+        reasons.append("read_only_low_risk")
+    elif rule and rule.default_decision:
+        decision = rule.default_decision
+        reasons.append("proposal_kind_default")
+
+    if (
+        policy.autonomy.allow_execution_without_operator
+        and decision == "approved_for_execution"
+    ):
+        pass  # unreachable in v1 config
+    else:
+        if decision == "approved_for_execution":
+            decision = "requires_operator_review"
+            reasons.append("execution_without_operator_disabled")
+
+    return _finish(...)  # map decision → policy_gate, allowed_scope, execution_constraints
+```
+
+Implement `_finish(...)` to build `PolicyDecisionV1` with `decision_id=stable_policy_decision_id(...)`, clamp scores via existing `orion.proposals.scoring.clamp01` if desired, and set `execution_constraints` keys like `max_scope`, `requires_operator`, `layer` (always `"9_deferred"` in v1).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest tests/test_policy_evaluator.py -q`
+
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/policy/rules.py orion/policy/evaluator.py tests/test_policy_evaluator.py
+git commit -m "feat(policy): add conservative proposal evaluator"
+```
+
+---
+
+### Task 4: Policy decision frame builder
+
+**Files:**
+
+- Create: `orion/policy/builder.py`
+- Test: `tests/test_policy_decision_builder.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Synthetic `ProposalFrameV1` with four candidates matching PR spec keys:
+
+- `inspect_execution_pressure` (inspect, low risk)
+- `summarize_loaded_state` (summarize, low risk)
+- `request_policy_review_for_action` (request_policy_review)
+- `prepare_action` (synthetic — add candidate with `proposal_kind="prepare_action"`, `required_policy_gate="operator_review"`, `risk_score=0.25`)
+
+Use `_loaded_self_state()` pattern from `tests/test_proposal_frame_builder.py`.
+
+Assertions:
+
+1. Builds `PolicyDecisionFrameV1`
+2. `source_proposal_frame_id` / `source_self_state_id` wired
+3. Partitions: read-only in `approved_decisions`; review in `review_required_decisions`; prepare in review or rejected
+4. `operator_review_required is True`
+5. `execution_allowed is False`
+6. Stable frame id: `policy.frame:{proposal_frame.frame_id}:{policy.policy_id}`
+7. At least one `approved_read_only` and one review-required
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest tests/test_policy_decision_builder.py -v`
+
+Expected: FAIL
+
+- [ ] **Step 3: Write minimal implementation**
+
+`orion/policy/builder.py`:
+
+```python
+def stable_policy_frame_id(*, proposal_frame_id: str, policy_id: str) -> str:
+    return f"policy.frame:{proposal_frame_id}:{policy_id}"
+
+
+def build_policy_decision_frame(
+    *,
+    proposal_frame: ProposalFrameV1,
+    self_state: SelfStateV1,
+    policy: SubstratePolicyV1,
+    now: datetime | None = None,
+) -> PolicyDecisionFrameV1:
+    generated_at = now or datetime.now(timezone.utc)
+    decisions = [
+        evaluate_proposal_candidate(
+            candidate=candidate,
+            proposal_frame=proposal_frame,
+            self_state=self_state,
+            policy=policy,
+        )
+        for candidate in proposal_frame.candidates
+    ]
+    approved = [d for d in decisions if d.decision == "approved_for_execution"]
+    approved_read_only = [d for d in decisions if d.decision == "approved_read_only"]
+    review = [d for d in decisions if d.decision == "requires_operator_review"]
+    deferred = [d for d in decisions if d.decision == "deferred"]
+    rejected = [d for d in decisions if d.decision == "rejected"]
+    overall_risk = max((d.risk_score for d in decisions), default=0.0)
+    return PolicyDecisionFrameV1(
+        frame_id=stable_policy_frame_id(
+            proposal_frame_id=proposal_frame.frame_id,
+            policy_id=policy.policy_id,
+        ),
+        generated_at=generated_at,
+        source_proposal_frame_id=proposal_frame.frame_id,
+        source_self_state_id=proposal_frame.source_self_state_id,
+        source_attention_frame_id=proposal_frame.source_attention_frame_id,
+        source_field_tick_id=proposal_frame.source_field_tick_id,
+        policy_id=policy.policy_id,
+        decisions=decisions,
+        approved_decisions=approved + approved_read_only,
+        review_required_decisions=review,
+        deferred_decisions=deferred,
+        rejected_decisions=rejected,
+        overall_risk=overall_risk,
+        operator_review_required=any(d.decision == "requires_operator_review" for d in decisions),
+        execution_allowed=any(d.decision == "approved_for_execution" for d in decisions),
+        warnings=list(proposal_frame.warnings),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest tests/test_policy_decision_builder.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/policy/builder.py tests/test_policy_decision_builder.py orion/policy/__init__.py
+git commit -m "feat(policy): build PolicyDecisionFrameV1 from proposals"
+```
+
+---
+
+### Task 5: SQL migration
+
+**Files:**
+
+- Create: `services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql`
+
+- [ ] **Step 1: Add migration SQL** (verbatim from PR spec — table `substrate_policy_decision_frames` + three indexes)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql
+git commit -m "feat(policy): add substrate_policy_decision_frames migration"
+```
+
+---
+
+### Task 6: `orion-policy-runtime` service
+
+**Files:**
+
+- Create: `services/orion-policy-runtime/app/{__init__.py,main.py,worker.py,store.py,settings.py}`
+- Create: `services/orion-policy-runtime/{Dockerfile,docker-compose.yml,requirements.txt,README.md,.env_example}`
+- Create: `services/orion-policy-runtime/.env` (copy from `.env_example` — local only, not committed)
+- Test: `tests/test_policy_runtime_store.py`
+
+Mirror `services/orion-proposal-runtime/` with these deltas:
+
+| Setting | Value |
+|---------|-------|
+| Port | `8120` |
+| Policy path | `/app/config/policy/substrate_policy.v1.yaml` |
+| Idempotency key | `source_proposal_frame_id` (not self_state_id) |
+| Worker inputs | latest proposal frame + matching self_state by `source_self_state_id` |
+| No bus / no cortex | worker only calls `build_policy_decision_frame` + `save` |
+
+**`.env_example`:**
+
+```env
+PROJECT=orion-athena
+SERVICE_NAME=orion-policy-runtime
+SERVICE_VERSION=0.1.0
+POSTGRES_URI=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+SUBSTRATE_POLICY_PATH=/app/config/policy/substrate_policy.v1.yaml
+POLICY_POLL_INTERVAL_SEC=2.0
+ENABLE_POLICY_RUNTIME=true
+LOG_LEVEL=INFO
+```
+
+**Dockerfile** copies: `orion/`, `config/policy/`, `services/orion-policy-runtime/`.
+
+**`docker-compose.yml`:** port `${POLICY_RUNTIME_PORT:-8120}:8120`, container `${PROJECT}-policy-runtime`, external `app-net`.
+
+**Worker `_tick` logic:**
+
+```python
+def _tick(self) -> None:
+    if not self._settings.enable_policy_runtime:
+        return
+    proposal = self._store.load_latest_proposal_frame()
+    if proposal is None:
+        return
+    if self._store.load_policy_frame_for_proposal(proposal.frame_id) is not None:
+        return
+    self_state = self._store.load_self_state(proposal.source_self_state_id)
+    if self_state is None:
+        logger.warning("policy_skip_missing_self_state self_state_id=%s", proposal.source_self_state_id)
+        return
+    frame = build_policy_decision_frame(
+        proposal_frame=proposal,
+        self_state=self_state,
+        policy=self._policy,
+    )
+    self._store.save_policy_decision_frame(frame)
+```
+
+- [ ] **Step 1: Write failing store tests** (`tests/test_policy_runtime_store.py` — copy pattern from `tests/test_proposal_runtime_store.py`, table `substrate_policy_decision_frames`, methods `save_policy_decision_frame`, `load_latest` via proposal id query, idempotent upsert on `frame_id`)
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `PYTHONPATH=. pytest tests/test_policy_runtime_store.py -v`
+
+- [ ] **Step 3: Implement store + settings + worker + main**
+
+`store.py` SQL (from PR spec):
+
+- `load_latest_proposal_frame` — `substrate_proposal_frames` ORDER BY `generated_at` DESC LIMIT 1
+- `load_self_state` — `substrate_self_state` WHERE `self_state_id`
+- `load_policy_frame_for_proposal` — `substrate_policy_decision_frames` WHERE `source_proposal_frame_id`
+- `save_policy_decision_frame` — INSERT … ON CONFLICT (`frame_id`) DO UPDATE
+
+- [ ] **Step 4: Run store tests — expect PASS**
+
+- [ ] **Step 5: Sync local `.env`**
+
+```bash
+cd services/orion-policy-runtime
+cp -n .env_example .env
+# merge any operator-specific POSTGRES_URI overrides
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/orion-policy-runtime/ tests/test_policy_runtime_store.py
+git commit -m "feat(policy): add orion-policy-runtime polling service"
+```
+
+---
+
+### Task 7: Hub read-only debug route (low risk)
+
+**Files:**
+
+- Create: `services/orion-hub/scripts/substrate_policy_routes.py` (mirror `substrate_proposal_routes.py`, table `substrate_policy_decision_frames`, schema `PolicyDecisionFrameV1`, prefix `/api/substrate/policy`)
+- Modify: `services/orion-hub/scripts/api_routes.py` — import + `include_router`
+- Create: `services/orion-hub/tests/test_substrate_policy_debug_api.py` (mirror proposal hub tests)
+
+- [ ] **Step 1: Write failing hub test**
+
+- [ ] **Step 2: Run — FAIL**
+
+Run: `PYTHONPATH=. pytest services/orion-hub/tests/test_substrate_policy_debug_api.py -v`
+
+- [ ] **Step 3: Implement route + register**
+
+- [ ] **Step 4: Run — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/orion-hub/scripts/substrate_policy_routes.py services/orion-hub/scripts/api_routes.py services/orion-hub/tests/test_substrate_policy_debug_api.py
+git commit -m "feat(policy): expose substrate policy latest debug API"
+```
+
+---
+
+### Task 8: Smoke script
+
+**Files:**
+
+- Create: `scripts/smoke_policy_decision_frame_v1.sh` (chmod +x)
+
+Copy structure from `scripts/smoke_proposal_frame_v1.sh` with SQL 1 (latest proposal) and SQL 2 (latest policy frame) from PR spec.
+
+- [ ] **Commit**
+
+```bash
+git add scripts/smoke_policy_decision_frame_v1.sh
+git commit -m "chore(policy): add policy decision frame smoke script"
+```
+
+---
+
+### Task 9: Verification gate (required before PR)
+
+- [ ] **Unit tests**
+
+```bash
+cd .worktrees/feat-policy-gate-v1
+PYTHONPATH=. pytest \
+  tests/test_policy_decision_frame_schemas.py \
+  tests/test_policy_loader.py \
+  tests/test_policy_evaluator.py \
+  tests/test_policy_decision_builder.py \
+  tests/test_policy_runtime_store.py \
+  -q
+```
+
+Expected: all passed
+
+- [ ] **Regression**
+
+```bash
+PYTHONPATH=. pytest tests/test_proposal_*.py -q
+PYTHONPATH=. pytest tests/test_self_state_*.py -q
+```
+
+Expected: all passed
+
+- [ ] **Compile**
+
+```bash
+PYTHONPATH=. python -m compileall \
+  orion/policy \
+  orion/schemas/policy_decision_frame.py \
+  services/orion-policy-runtime \
+  -q
+```
+
+- [ ] **No execution bleed check** (grep proof for PR report)
+
+```bash
+rg -n "cortex.exec|cortex_exec|bus\.publish|operator.notify|settings\.mutation" \
+  services/orion-policy-runtime orion/policy || true
+```
+
+Expected: no matches in runtime/worker paths (evaluator may mention `cortex_exec_direct_call` only as hard-block string)
+
+- [ ] **Commit any fixups**
+
+---
+
+### Task 10: Live operator steps (document in PR report; run if DB available)
+
+```bash
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql
+
+cd services/orion-policy-runtime
+docker compose up -d --build
+
+./scripts/smoke_policy_decision_frame_v1.sh
+curl -s http://localhost:8080/api/substrate/policy/latest | jq
+curl -s http://localhost:8120/latest | jq
+```
+
+---
+
+### Task 11: Code review subagent + fixes
+
+- [ ] **Dispatch code-reviewer subagent** on full diff vs `origin/main`
+
+Required SUB-SKILL: `superpowers:requesting-code-review` then fix all substantive issues before PR.
+
+- [ ] **Re-run Task 9 verification** after fixes
+
+- [ ] **Commit fixes** as separate commits (do not amend unless hook requires)
+
+---
+
+### Task 12: PR report, push, and open PR
+
+**Files:**
+
+- Create: `docs/superpowers/pr-reports/2026-05-24-policy-gate-v1-pr.md`
+
+PR report must include:
+
+1. Layer 8 mapping in 11-layer roadmap
+2. Example `PolicyDecisionFrameV1` JSON (from `/latest` or unit test fixture)
+3. Proof no execution (grep + worker has no outbound clients)
+4. Tests run with command output
+5. Explicit Layer 9 deferred statement
+
+```bash
+cd .worktrees/feat-policy-gate-v1
+git push -u origin feat/policy-gate-v1
+gh pr create --title "feat: Policy Gate v1 — ProposalFrame → Governed Decisions" --body "$(cat <<'EOF'
+## Summary
+- Layer 8: deterministic PolicyDecisionFrameV1 from ProposalFrameV1 + SelfStateV1
+- orion-policy-runtime persists to substrate_policy_decision_frames (port 8120)
+- No execution, bus publish, or operator side effects
+
+## Test plan
+- [ ] pytest policy + proposal + self-state regression
+- [ ] migration applied
+- [ ] smoke_policy_decision_frame_v1.sh
+- [ ] GET /api/substrate/policy/latest
+
+Layer 9 execution explicitly deferred.
+
+EOF
+)"
+```
+
+Attach full PR report path in PR body or comment.
+
+---
+
+## Self-review (plan author checklist)
+
+| Spec requirement | Task |
+|------------------|------|
+| PolicyDecisionV1 / PolicyDecisionFrameV1 | Task 1 |
+| substrate_policy.v1.yaml | Task 2 |
+| load_substrate_policy | Task 2 |
+| evaluate_proposal_candidate rules 1–10 | Task 3 |
+| build_policy_decision_frame partitions | Task 4 |
+| substrate_policy_decision_frames DDL | Task 5 |
+| orion-policy-runtime poll + idempotent | Task 6 |
+| Hub GET /latest | Task 7 |
+| All five test files | Tasks 1–6 |
+| smoke script | Task 8 |
+| registry | Task 1 |
+| No bus publish | Worktree rules (no channels.yaml) |
+| Layer 9 non-goals | Header + Task 11 grep |
+| .env sync | Task 6 Step 5 |
+
+**Placeholder scan:** No TBD steps; all code paths named with file paths.
+
+**Type consistency:** Uses existing `ProposalCandidateV1`, `ProposalFrameV1`, `SelfStateV1` from `orion/schemas/proposal_frame.py` and `orion/schemas/self_state.py`.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-24-policy-gate-v1.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task with two-stage review between tasks.
+
+**2. Inline Execution** — run tasks in this session using `executing-plans`, batched with checkpoints.
+
+**Which approach?**
+
+After implementation, the user-requested workflow also requires: code-review subagent (Task 11), PR markdown report (Task 12), and `gh pr create` push from worktree only.

--- a/docs/superpowers/pr-reports/2026-05-24-policy-gate-v1-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-24-policy-gate-v1-pr.md
@@ -1,0 +1,113 @@
+# PR: Policy Gate v1 — ProposalFrame → Governed Decisions
+
+**Branch:** `feat/policy-gate-v1`  
+**Base:** `main`  
+**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-policy-gate-v1`  
+**Head:** `b0a97538` (4 commits)
+
+## Summary
+
+Implements **Layer 8** of the Orion cognition substrate: deterministic policy gating over Layer 7 proposals. Converts `ProposalFrameV1` + `SelfStateV1` into `PolicyDecisionFrameV1` snapshots persisted for inspection. **Policy is not execution** — no cortex-exec, bus publish, operator notifications, or settings mutation.
+
+```text
+substrate_proposal_frames + substrate_self_state
+  → orion-policy-runtime (port 8120)
+  → PolicyDecisionFrameV1
+  → substrate_policy_decision_frames
+  → GET /api/substrate/policy/latest (Hub, read-only)
+```
+
+**Layer 9 execution is explicitly deferred.**
+
+## Roadmap position (11-layer substrate)
+
+| Layer | This PR |
+|-------|---------|
+| 7 Proposal | Consumes `ProposalFrameV1` |
+| **8 Policy** | **Implemented** |
+| 9 Execution | Deferred |
+
+## Example `PolicyDecisionFrameV1` (synthetic loaded state)
+
+Built from demo proposal with inspect, summarize, request_policy_review, prepare_action candidates:
+
+| Field | Value |
+|-------|-------|
+| `frame_id` | `policy.frame:proposal.frame:demo:proposal_policy.v1:substrate_policy.v1` |
+| `operator_review_required` | `true` |
+| `execution_allowed` | `false` |
+| `approved_decisions` | 2 (inspect, summarize → `approved_read_only`) |
+| `review_required_decisions` | 2 (request_policy_review, prepare_action) |
+
+Per-candidate decisions:
+
+```text
+proposal:inspect   → approved_read_only
+proposal:summarize → approved_read_only
+proposal:review    → requires_operator_review
+proposal:prepare   → requires_operator_review
+```
+
+## Proof: no execution performed
+
+- `orion-policy-runtime` worker only calls `build_policy_decision_frame` + SQL upsert.
+- Grep over `services/orion-policy-runtime` and `orion/policy` finds no `cortex_exec`, `bus.publish`, or runtime side effects (only README/docs and hard-block token `cortex_exec_direct_call`).
+- `execution_constraints` on decisions are tagged `layer: 9_deferred` for future execution runtime.
+- `allow_execution_without_operator: false` in `config/policy/substrate_policy.v1.yaml` with tests asserting no `approved_for_execution`.
+
+## Files changed
+
+| Path | Role |
+|------|------|
+| `orion/schemas/policy_decision_frame.py` | `PolicyDecisionV1`, `PolicyDecisionFrameV1` |
+| `orion/schemas/registry.py` | Schema registry |
+| `config/policy/substrate_policy.v1.yaml` | Substrate policy v1 |
+| `orion/policy/{policy,rules,evaluator,builder}.py` | Pure policy logic |
+| `services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql` | DDL |
+| `services/orion-policy-runtime/` | Polling runtime (8120) |
+| `services/orion-hub/scripts/substrate_policy_routes.py` | Debug API |
+| `scripts/smoke_policy_decision_frame_v1.sh` | Live SQL smoke |
+| `tests/test_policy_*.py` | Unit + worker tests |
+
+## Review fixes (post code-review)
+
+- Enforce `autonomy_policy` / `execution_policy` gates → `requires_operator_review` (no kind-default bypass).
+- Worker backfills **oldest** proposal without a policy frame (not only latest).
+- Nested policy YAML models use `extra="forbid"`.
+
+## Tests run
+
+```bash
+cd .worktrees/feat-policy-gate-v1
+PYTHONPATH=. pytest tests/test_policy_*.py services/orion-hub/tests/test_substrate_policy_debug_api.py -q
+# 34 passed
+
+PYTHONPATH=. pytest tests/test_proposal_*.py tests/test_self_state_*.py -q
+# 57 passed
+
+PYTHONPATH=. python -m compileall orion/policy orion/schemas/policy_decision_frame.py services/orion-policy-runtime -q
+```
+
+## Live operator steps
+
+```bash
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql
+
+cd services/orion-policy-runtime
+cp -n .env_example .env
+docker compose up -d --build
+
+./scripts/smoke_policy_decision_frame_v1.sh
+curl -s http://localhost:8120/latest | jq
+curl -s http://localhost:8080/api/substrate/policy/latest | jq
+```
+
+## Test plan
+
+- [ ] Apply migration on target DB
+- [ ] Start `orion-policy-runtime` with proposal + self-state data present
+- [ ] Confirm idempotent noop on same proposal frame
+- [ ] Smoke script shows latest policy frame with partitioned decisions
+- [ ] Hub `/api/substrate/policy/latest` returns frame JSON
+- [ ] Confirm `execution_allowed` is false for live frames

--- a/orion/policy/__init__.py
+++ b/orion/policy/__init__.py
@@ -1,0 +1,10 @@
+from orion.policy.builder import build_policy_decision_frame
+from orion.policy.evaluator import evaluate_proposal_candidate
+from orion.policy.policy import SubstratePolicyV1, load_substrate_policy
+
+__all__ = [
+    "SubstratePolicyV1",
+    "build_policy_decision_frame",
+    "evaluate_proposal_candidate",
+    "load_substrate_policy",
+]

--- a/orion/policy/builder.py
+++ b/orion/policy/builder.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.policy.evaluator import evaluate_proposal_candidate
+from orion.policy.policy import SubstratePolicyV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
+from orion.schemas.proposal_frame import ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+
+def stable_policy_frame_id(*, proposal_frame_id: str, policy_id: str) -> str:
+    return f"policy.frame:{proposal_frame_id}:{policy_id}"
+
+
+def build_policy_decision_frame(
+    *,
+    proposal_frame: ProposalFrameV1,
+    self_state: SelfStateV1,
+    policy: SubstratePolicyV1,
+    now: datetime | None = None,
+) -> PolicyDecisionFrameV1:
+    generated_at = now or datetime.now(timezone.utc)
+    decisions = [
+        evaluate_proposal_candidate(
+            candidate=candidate,
+            proposal_frame=proposal_frame,
+            self_state=self_state,
+            policy=policy,
+        )
+        for candidate in proposal_frame.candidates
+    ]
+    approved_for_execution = [d for d in decisions if d.decision == "approved_for_execution"]
+    approved_read_only = [d for d in decisions if d.decision == "approved_read_only"]
+    review = [d for d in decisions if d.decision == "requires_operator_review"]
+    deferred = [d for d in decisions if d.decision == "deferred"]
+    rejected = [d for d in decisions if d.decision == "rejected"]
+    overall_risk = max((d.risk_score for d in decisions), default=0.0)
+    return PolicyDecisionFrameV1(
+        frame_id=stable_policy_frame_id(
+            proposal_frame_id=proposal_frame.frame_id,
+            policy_id=policy.policy_id,
+        ),
+        generated_at=generated_at,
+        source_proposal_frame_id=proposal_frame.frame_id,
+        source_self_state_id=proposal_frame.source_self_state_id,
+        source_attention_frame_id=proposal_frame.source_attention_frame_id,
+        source_field_tick_id=proposal_frame.source_field_tick_id,
+        policy_id=policy.policy_id,
+        decisions=decisions,
+        approved_decisions=approved_for_execution + approved_read_only,
+        review_required_decisions=review,
+        deferred_decisions=deferred,
+        rejected_decisions=rejected,
+        overall_risk=overall_risk,
+        operator_review_required=any(d.decision == "requires_operator_review" for d in decisions),
+        execution_allowed=any(d.decision == "approved_for_execution" for d in decisions),
+        warnings=list(proposal_frame.warnings),
+    )

--- a/orion/policy/evaluator.py
+++ b/orion/policy/evaluator.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from orion.policy.policy import SubstratePolicyV1
+from orion.policy.rules import (
+    hard_block_hits,
+    is_read_only_candidate,
+    kind_rule,
+    stable_policy_decision_id,
+)
+from orion.proposals.scoring import clamp01
+from orion.schemas.policy_decision_frame import PolicyDecisionV1
+from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+DecisionLiteral = Literal[
+    "approved_for_execution",
+    "approved_read_only",
+    "requires_operator_review",
+    "deferred",
+    "rejected",
+]
+
+
+def _policy_gate_for_decision(
+    decision: DecisionLiteral,
+    candidate_gate: str,
+) -> str:
+    if decision == "approved_read_only":
+        return "read_only"
+    if decision == "requires_operator_review":
+        return "operator_review"
+    if decision == "approved_for_execution":
+        return "execution_policy"
+    if decision in ("rejected", "deferred"):
+        return "execution_policy" if candidate_gate == "execution_policy" else "autonomy_policy"
+    return "none"
+
+
+def _finish(
+    *,
+    candidate: ProposalCandidateV1,
+    policy: SubstratePolicyV1,
+    decision: DecisionLiteral,
+    policy_gate: str | None,
+    autonomy_tier: str,
+    allowed_scope: str,
+    risk_score: float,
+    reversibility_score: float,
+    confidence_score: float,
+    reasons: list[str],
+    evidence_refs: list[str],
+    blocked_by: list[str],
+    execution_constraints: dict[str, str] | None = None,
+) -> PolicyDecisionV1:
+    gate = policy_gate or _policy_gate_for_decision(decision, candidate.required_policy_gate)
+    constraints = dict(execution_constraints or {})
+    constraints.setdefault("layer", "9_deferred")
+    if decision == "requires_operator_review":
+        constraints["requires_operator"] = "true"
+    constraints["max_scope"] = allowed_scope
+    return PolicyDecisionV1(
+        decision_id=stable_policy_decision_id(
+            proposal_id=candidate.proposal_id,
+            policy_id=policy.policy_id,
+        ),
+        proposal_id=candidate.proposal_id,
+        decision=decision,
+        policy_gate=gate,
+        autonomy_tier=autonomy_tier,
+        risk_score=clamp01(risk_score),
+        reversibility_score=clamp01(reversibility_score),
+        confidence_score=clamp01(confidence_score),
+        allowed_scope=allowed_scope,
+        reasons=reasons,
+        evidence_refs=sorted(set(evidence_refs)),
+        blocked_by=blocked_by,
+        execution_constraints=constraints,
+    )
+
+
+def evaluate_proposal_candidate(
+    *,
+    candidate: ProposalCandidateV1,
+    proposal_frame: ProposalFrameV1,
+    self_state: SelfStateV1,
+    policy: SubstratePolicyV1,
+) -> PolicyDecisionV1:
+    del self_state  # reserved for future context-aware rules
+    rule = kind_rule(policy, candidate.proposal_kind)
+    allowed_scope = rule.allowed_scope if rule else "none"
+    autonomy_tier = rule.max_autonomy_tier if rule else policy.autonomy.default_tier
+    reasons: list[str] = []
+    evidence_refs = list(candidate.evidence_refs)
+    evidence_refs.extend(
+        [
+            f"proposal_frame:{proposal_frame.frame_id}",
+            f"self_state:{proposal_frame.source_self_state_id}",
+        ]
+    )
+
+    decision: DecisionLiteral = (
+        rule.default_decision if rule else "deferred"  # type: ignore[assignment]
+    )
+
+    blocked = hard_block_hits(candidate, policy)
+    if blocked:
+        return _finish(
+            candidate=candidate,
+            policy=policy,
+            decision="rejected",
+            policy_gate="execution_policy",
+            autonomy_tier="observe_only",
+            allowed_scope="none",
+            risk_score=candidate.risk_score,
+            reversibility_score=candidate.reversibility_score,
+            confidence_score=candidate.confidence_score,
+            reasons=["hard_block_execution_intent"],
+            evidence_refs=evidence_refs,
+            blocked_by=blocked,
+            execution_constraints={"layer": "9_deferred", "blocked": "true"},
+        )
+
+    if candidate.proposal_kind == "defer":
+        decision = "deferred"
+        reasons.append("proposal_kind_defer")
+    elif candidate.risk_score >= policy.thresholds.reject_above_risk:
+        decision = "rejected"
+        reasons.append("risk_above_reject_threshold")
+    elif candidate.risk_score >= policy.thresholds.defer_above_risk:
+        decision = "deferred"
+        reasons.append("risk_above_defer_threshold")
+    elif candidate.proposal_kind == "prepare_action":
+        decision = "requires_operator_review"
+        reasons.append("prepare_action_never_auto_execute_v1")
+    elif candidate.required_policy_gate == "operator_review":
+        decision = "requires_operator_review"
+        reasons.append("candidate_requires_operator_review")
+    elif candidate.risk_score >= policy.thresholds.require_review_above_risk:
+        decision = "requires_operator_review"
+        reasons.append("risk_above_review_threshold")
+    elif candidate.reversibility_score < policy.thresholds.require_review_below_reversibility:
+        decision = "requires_operator_review"
+        reasons.append("reversibility_below_threshold")
+    elif candidate.confidence_score < policy.thresholds.require_review_below_confidence:
+        decision = "requires_operator_review"
+        reasons.append("confidence_below_threshold")
+    elif (
+        is_read_only_candidate(candidate, policy)
+        and candidate.risk_score <= policy.thresholds.approve_read_only_max_risk
+        and candidate.required_policy_gate in ("none", "read_only")
+    ):
+        decision = "approved_read_only"
+        reasons.append("read_only_low_risk")
+    elif rule is not None:
+        decision = rule.default_decision  # type: ignore[assignment]
+        reasons.append("proposal_kind_default")
+
+    if decision == "approved_for_execution" and not policy.autonomy.allow_execution_without_operator:
+        decision = "requires_operator_review"
+        reasons.append("execution_without_operator_disabled")
+
+    return _finish(
+        candidate=candidate,
+        policy=policy,
+        decision=decision,
+        policy_gate=None,
+        autonomy_tier=autonomy_tier,
+        allowed_scope=allowed_scope,
+        risk_score=candidate.risk_score,
+        reversibility_score=candidate.reversibility_score,
+        confidence_score=candidate.confidence_score,
+        reasons=reasons,
+        evidence_refs=evidence_refs,
+        blocked_by=[],
+    )

--- a/orion/policy/evaluator.py
+++ b/orion/policy/evaluator.py
@@ -146,6 +146,9 @@ def evaluate_proposal_candidate(
     elif candidate.confidence_score < policy.thresholds.require_review_below_confidence:
         decision = "requires_operator_review"
         reasons.append("confidence_below_threshold")
+    elif candidate.required_policy_gate in ("autonomy_policy", "execution_policy"):
+        decision = "requires_operator_review"
+        reasons.append("elevated_policy_gate_required")
     elif (
         is_read_only_candidate(candidate, policy)
         and candidate.risk_score <= policy.thresholds.approve_read_only_max_risk

--- a/orion/policy/policy.py
+++ b/orion/policy/policy.py
@@ -8,12 +8,16 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class AutonomyConfigV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     default_tier: str = "observe_only"
     max_tier_without_operator: str = "read_only"
     allow_execution_without_operator: bool = False
 
 
 class PolicyThresholdsV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     approve_read_only_max_risk: float = 0.15
     defer_above_risk: float = 0.60
     reject_above_risk: float = 0.85
@@ -23,6 +27,8 @@ class PolicyThresholdsV1(BaseModel):
 
 
 class ProposalKindRuleV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     allowed_scope: str
     default_decision: str
     max_autonomy_tier: str

--- a/orion/policy/policy.py
+++ b/orion/policy/policy.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AutonomyConfigV1(BaseModel):
+    default_tier: str = "observe_only"
+    max_tier_without_operator: str = "read_only"
+    allow_execution_without_operator: bool = False
+
+
+class PolicyThresholdsV1(BaseModel):
+    approve_read_only_max_risk: float = 0.15
+    defer_above_risk: float = 0.60
+    reject_above_risk: float = 0.85
+    require_review_above_risk: float = 0.20
+    require_review_below_reversibility: float = 0.50
+    require_review_below_confidence: float = 0.50
+
+
+class ProposalKindRuleV1(BaseModel):
+    allowed_scope: str
+    default_decision: str
+    max_autonomy_tier: str
+
+
+class SubstratePolicyV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["substrate_policy.v1"] = "substrate_policy.v1"
+    policy_id: str = "substrate_policy.v1"
+
+    autonomy: AutonomyConfigV1 = Field(default_factory=AutonomyConfigV1)
+    thresholds: PolicyThresholdsV1 = Field(default_factory=PolicyThresholdsV1)
+    proposal_kind_rules: dict[str, ProposalKindRuleV1] = Field(default_factory=dict)
+    hard_blocks: list[str] = Field(default_factory=list)
+    read_only_effects: list[str] = Field(default_factory=list)
+
+
+def load_substrate_policy(path: str | Path) -> SubstratePolicyV1:
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    return SubstratePolicyV1.model_validate(data)

--- a/orion/policy/rules.py
+++ b/orion/policy/rules.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from orion.policy.policy import SubstratePolicyV1, ProposalKindRuleV1
+from orion.schemas.proposal_frame import ProposalCandidateV1
+
+
+def stable_policy_decision_id(*, proposal_id: str, policy_id: str) -> str:
+    return f"policy.decision:{proposal_id}:{policy_id}"
+
+
+def execution_intent_blob(candidate: ProposalCandidateV1) -> str:
+    parts: list[str] = []
+    for key, value in candidate.execution_intent.items():
+        parts.append(str(key))
+        parts.append(str(value))
+    return " ".join(parts).lower()
+
+
+def hard_block_hits(candidate: ProposalCandidateV1, policy: SubstratePolicyV1) -> list[str]:
+    blob = execution_intent_blob(candidate)
+    return [block for block in policy.hard_blocks if block.lower() in blob]
+
+
+def is_read_only_candidate(candidate: ProposalCandidateV1, policy: SubstratePolicyV1) -> bool:
+    if candidate.proposal_kind in ("observe", "inspect", "summarize"):
+        return True
+    return candidate.proposed_effect in policy.read_only_effects
+
+
+def kind_rule(policy: SubstratePolicyV1, proposal_kind: str) -> ProposalKindRuleV1 | None:
+    return policy.proposal_kind_rules.get(proposal_kind)

--- a/orion/schemas/policy_decision_frame.py
+++ b/orion/schemas/policy_decision_frame.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PolicyDecisionV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision_id: str
+    proposal_id: str
+
+    decision: Literal[
+        "approved_for_execution",
+        "approved_read_only",
+        "requires_operator_review",
+        "deferred",
+        "rejected",
+    ]
+
+    policy_gate: Literal[
+        "none",
+        "read_only",
+        "operator_review",
+        "autonomy_policy",
+        "execution_policy",
+    ]
+
+    autonomy_tier: Literal[
+        "none",
+        "observe_only",
+        "read_only",
+        "prepare_only",
+        "operator_review",
+        "execution_allowed",
+    ] = "observe_only"
+
+    risk_score: float = Field(ge=0.0, le=1.0)
+    reversibility_score: float = Field(ge=0.0, le=1.0)
+    confidence_score: float = Field(ge=0.0, le=1.0)
+
+    allowed_scope: Literal[
+        "none",
+        "inspect_only",
+        "summarize_only",
+        "prepare_only",
+        "low_risk_execution",
+        "operator_review_required",
+    ] = "none"
+
+    reasons: list[str] = Field(default_factory=list)
+    evidence_refs: list[str] = Field(default_factory=list)
+    blocked_by: list[str] = Field(default_factory=list)
+
+    execution_constraints: dict[str, str] = Field(default_factory=dict)
+
+
+class PolicyDecisionFrameV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["policy.decision.frame.v1"] = "policy.decision.frame.v1"
+
+    frame_id: str
+    generated_at: datetime
+
+    source_proposal_frame_id: str
+    source_self_state_id: str
+    source_attention_frame_id: str | None = None
+    source_field_tick_id: str | None = None
+
+    policy_id: str = "substrate_policy.v1"
+
+    decisions: list[PolicyDecisionV1] = Field(default_factory=list)
+    approved_decisions: list[PolicyDecisionV1] = Field(default_factory=list)
+    review_required_decisions: list[PolicyDecisionV1] = Field(default_factory=list)
+    deferred_decisions: list[PolicyDecisionV1] = Field(default_factory=list)
+    rejected_decisions: list[PolicyDecisionV1] = Field(default_factory=list)
+
+    overall_risk: float = Field(ge=0.0, le=1.0)
+    operator_review_required: bool = False
+    execution_allowed: bool = False
+
+    warnings: list[str] = Field(default_factory=list)

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -461,6 +461,7 @@ from orion.schemas.situation import (
 )
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
 from orion.schemas.field_state import FieldEdgeV1, FieldStateV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
 from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
 from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
 from orion.schemas.evidence_index import (
@@ -944,6 +945,8 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "FieldAttentionFrameV1": FieldAttentionFrameV1,
     "SelfStateDimensionV1": SelfStateDimensionV1,
     "SelfStateV1": SelfStateV1,
+    "PolicyDecisionV1": PolicyDecisionV1,
+    "PolicyDecisionFrameV1": PolicyDecisionFrameV1,
     "ProposalCandidateV1": ProposalCandidateV1,
     "ProposalFrameV1": ProposalFrameV1,
     "EvidenceUnitV1": EvidenceUnitV1,

--- a/scripts/smoke_policy_decision_frame_v1.sh
+++ b/scripts/smoke_policy_decision_frame_v1.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB="${DB:-orion-athena-sql-db}"
+PGDATABASE="${PGDATABASE:-conjourney}"
+PGUSER="${PGUSER:-postgres}"
+
+echo "=== Latest proposal frame ==="
+docker exec -i "$DB" psql -U "$PGUSER" -d "$PGDATABASE" -c "
+select
+    generated_at,
+    frame_id,
+    source_self_state_id,
+    proposal_frame_json #>> '{overall_action_pressure}' as overall_action_pressure,
+    proposal_frame_json #> '{candidates}' as candidates
+from substrate_proposal_frames
+order by generated_at desc
+limit 1;
+"
+
+echo ""
+echo "=== Latest policy decision frame ==="
+docker exec -i "$DB" psql -U "$PGUSER" -d "$PGDATABASE" -c "
+select
+    generated_at,
+    frame_id,
+    source_proposal_frame_id,
+    policy_decision_frame_json #>> '{overall_risk}' as overall_risk,
+    policy_decision_frame_json #>> '{operator_review_required}' as operator_review_required,
+    policy_decision_frame_json #>> '{execution_allowed}' as execution_allowed,
+    policy_decision_frame_json #> '{approved_decisions}' as approved_decisions,
+    policy_decision_frame_json #> '{review_required_decisions}' as review_required_decisions,
+    policy_decision_frame_json #> '{rejected_decisions}' as rejected_decisions
+from substrate_policy_decision_frames
+order by generated_at desc
+limit 1;
+"

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -147,6 +147,7 @@ from .substrate_field_routes import router as substrate_field_router
 from .substrate_attention_routes import router as substrate_attention_router
 from .substrate_self_state_routes import router as substrate_self_state_router
 from .substrate_proposal_routes import router as substrate_proposal_router
+from .substrate_policy_routes import router as substrate_policy_router
 
 router.include_router(grammar_atlas_router)
 router.include_router(substrate_biometrics_router)
@@ -154,6 +155,7 @@ router.include_router(substrate_field_router)
 router.include_router(substrate_attention_router)
 router.include_router(substrate_self_state_router)
 router.include_router(substrate_proposal_router)
+router.include_router(substrate_policy_router)
 
 
 def _hub_uses_host_network_mode() -> bool:

--- a/services/orion-hub/scripts/substrate_policy_routes.py
+++ b/services/orion-hub/scripts/substrate_policy_routes.py
@@ -1,0 +1,49 @@
+"""Read-only debug API for substrate policy decision frames."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import create_engine, text
+
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
+
+router = APIRouter(prefix="/api/substrate/policy", tags=["substrate-policy"])
+
+
+def _engine():
+    uri = os.getenv("POSTGRES_URI", "").strip()
+    if not uri:
+        raise HTTPException(status_code=503, detail="postgres_uri_not_configured")
+    return create_engine(uri, pool_pre_ping=True)
+
+
+def _load_latest_policy_frame() -> PolicyDecisionFrameV1 | None:
+    with _engine().connect() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT policy_decision_frame_json
+                FROM substrate_policy_decision_frames
+                ORDER BY generated_at DESC
+                LIMIT 1
+                """
+            ),
+        ).mappings().first()
+    if not row:
+        return None
+    payload = row["policy_decision_frame_json"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return PolicyDecisionFrameV1.model_validate(payload)
+
+
+@router.get("/latest")
+async def policy_latest() -> dict[str, Any]:
+    frame = _load_latest_policy_frame()
+    if frame is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return frame.model_dump(mode="json")

--- a/services/orion-hub/tests/test_substrate_policy_debug_api.py
+++ b/services/orion-hub/tests/test_substrate_policy_debug_api.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_hub_scripts_import_path() -> None:
+    for key in list(sys.modules):
+        if key == "scripts" or key.startswith("scripts."):
+            del sys.modules[key]
+    for p in (str(REPO_ROOT), str(HUB_ROOT)):
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(HUB_ROOT))
+
+
+_ensure_hub_scripts_import_path()
+
+from scripts import substrate_policy_routes  # noqa: E402
+
+
+def _sample_policy_frame() -> dict:
+    return {
+        "schema_version": "policy.decision.frame.v1",
+        "frame_id": "policy.frame:proposal.frame:test:substrate_policy.v1",
+        "generated_at": "2026-05-24T12:00:00+00:00",
+        "source_proposal_frame_id": "proposal.frame:test:proposal_policy.v1",
+        "source_self_state_id": "self.state:test",
+        "policy_id": "substrate_policy.v1",
+        "decisions": [],
+        "approved_decisions": [],
+        "review_required_decisions": [],
+        "deferred_decisions": [],
+        "rejected_decisions": [],
+        "overall_risk": 0.1,
+        "operator_review_required": False,
+        "execution_allowed": False,
+        "warnings": [],
+    }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    app = FastAPI()
+    app.include_router(substrate_policy_routes.router)
+    return TestClient(app)
+
+
+def _fake_engine_with_frame(frame_json: dict | None):
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute(stmt, params=None):
+        m = MagicMock()
+        if frame_json is None:
+            m.mappings.return_value.first.return_value = None
+        else:
+            m.mappings.return_value.first.return_value = {
+                "policy_decision_frame_json": frame_json,
+            }
+        return m
+
+    conn.execute.side_effect = execute
+    return fake_engine
+
+
+def test_policy_latest_returns_frame(client):
+    frame = _sample_policy_frame()
+    fake_engine = _fake_engine_with_frame(frame)
+
+    with patch.object(substrate_policy_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/policy/latest")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["schema_version"] == "policy.decision.frame.v1"
+
+
+def test_policy_latest_not_found(client):
+    fake_engine = _fake_engine_with_frame(None)
+
+    with patch.object(substrate_policy_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/policy/latest")
+
+    assert r.status_code == 404

--- a/services/orion-policy-runtime/.env_example
+++ b/services/orion-policy-runtime/.env_example
@@ -1,0 +1,8 @@
+PROJECT=orion-athena
+SERVICE_NAME=orion-policy-runtime
+SERVICE_VERSION=0.1.0
+POSTGRES_URI=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+SUBSTRATE_POLICY_PATH=/app/config/policy/substrate_policy.v1.yaml
+POLICY_POLL_INTERVAL_SEC=2.0
+ENABLE_POLICY_RUNTIME=true
+LOG_LEVEL=INFO

--- a/services/orion-policy-runtime/Dockerfile
+++ b/services/orion-policy-runtime/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir --upgrade pip
+
+COPY services/orion-policy-runtime/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY orion /app/orion
+COPY config/policy /app/config/policy
+COPY services/orion-policy-runtime /app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8120"]

--- a/services/orion-policy-runtime/README.md
+++ b/services/orion-policy-runtime/README.md
@@ -1,0 +1,46 @@
+# orion-policy-runtime
+
+Layer 8 substrate service: evaluates `ProposalFrameV1` candidates against `SubstratePolicyV1` and persists **governed decisions** (`PolicyDecisionFrameV1`). Policy is not execution.
+
+## Data flow
+
+```text
+substrate_proposal_frames
++ substrate_self_state
+  → orion-policy-runtime
+  → PolicyDecisionFrameV1
+  → substrate_policy_decision_frames
+```
+
+## Non-goals
+
+- No cortex-exec, bus publish, operator notifications, settings mutation, or LLM calls.
+- `execution_constraints` on decisions are instructions for Layer 9 only.
+
+## Idempotency
+
+One policy decision frame per `source_proposal_frame_id`. Re-running the worker for the same proposal frame is a no-op.
+
+## Run
+
+```bash
+cp -n .env_example .env
+docker compose up -d --build
+curl -s http://localhost:8120/health
+curl -s http://localhost:8120/latest | jq
+```
+
+## Migration
+
+```bash
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < ../../services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql
+```
+
+## Smoke
+
+From repo root:
+
+```bash
+./scripts/smoke_policy_decision_frame_v1.sh
+```

--- a/services/orion-policy-runtime/app/main.py
+++ b/services/orion-policy-runtime/app/main.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from app.settings import get_settings
+from app.store import PolicyRuntimeStore
+from app.worker import PolicyRuntimeWorker
+
+_settings = get_settings()
+logging.basicConfig(level=getattr(logging, _settings.log_level.upper(), logging.INFO))
+
+worker = PolicyRuntimeWorker()
+store = PolicyRuntimeStore(_settings.postgres_uri)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await worker.start()
+    try:
+        yield
+    finally:
+        await worker.stop()
+
+
+app = FastAPI(title="orion-policy-runtime", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "service": get_settings().service_name}
+
+
+@app.get("/latest")
+async def latest() -> dict[str, Any]:
+    frame = store.load_latest_policy_decision_frame()
+    if frame is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return frame.model_dump(mode="json")

--- a/services/orion-policy-runtime/app/settings.py
+++ b/services/orion-policy-runtime/app/settings.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    project: str = Field("orion-athena", alias="PROJECT")
+    service_name: str = Field("orion-policy-runtime", alias="SERVICE_NAME")
+    service_version: str = Field("0.1.0", alias="SERVICE_VERSION")
+
+    postgres_uri: str = Field(..., alias="POSTGRES_URI")
+    substrate_policy_path: str = Field(
+        "config/policy/substrate_policy.v1.yaml",
+        alias="SUBSTRATE_POLICY_PATH",
+    )
+    policy_poll_interval_sec: float = Field(2.0, alias="POLICY_POLL_INTERVAL_SEC")
+    enable_policy_runtime: bool = Field(True, alias="ENABLE_POLICY_RUNTIME")
+    log_level: str = Field("INFO", alias="LOG_LEVEL")
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings

--- a/services/orion-policy-runtime/app/store.py
+++ b/services/orion-policy-runtime/app/store.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from psycopg2.extras import Json
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
+from orion.schemas.proposal_frame import ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+
+class PolicyRuntimeStore:
+    def __init__(self, postgres_uri: str) -> None:
+        self._engine: Engine = create_engine(
+            postgres_uri,
+            pool_pre_ping=True,
+            json_serializer=json.dumps,
+            json_deserializer=json.loads,
+        )
+
+    def load_latest_proposal_frame(self) -> ProposalFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT proposal_frame_json FROM substrate_proposal_frames
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["proposal_frame_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return ProposalFrameV1.model_validate(payload)
+
+    def load_self_state(self, self_state_id: str) -> SelfStateV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT self_state_json FROM substrate_self_state
+                        WHERE self_state_id = :self_state_id
+                        LIMIT 1
+                        """
+                    ),
+                    {"self_state_id": self_state_id},
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["self_state_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return SelfStateV1.model_validate(payload)
+
+    def load_policy_frame_for_proposal(self, proposal_frame_id: str) -> PolicyDecisionFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT policy_decision_frame_json
+                        FROM substrate_policy_decision_frames
+                        WHERE source_proposal_frame_id = :proposal_frame_id
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                    {"proposal_frame_id": proposal_frame_id},
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["policy_decision_frame_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return PolicyDecisionFrameV1.model_validate(payload)
+
+    def load_latest_policy_decision_frame(self) -> PolicyDecisionFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT policy_decision_frame_json
+                        FROM substrate_policy_decision_frames
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["policy_decision_frame_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return PolicyDecisionFrameV1.model_validate(payload)
+
+    def save_policy_decision_frame(self, frame: PolicyDecisionFrameV1) -> None:
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO substrate_policy_decision_frames (
+                        frame_id,
+                        source_proposal_frame_id,
+                        source_self_state_id,
+                        generated_at,
+                        policy_id,
+                        policy_decision_frame_json,
+                        created_at
+                    ) VALUES (
+                        :frame_id,
+                        :source_proposal_frame_id,
+                        :source_self_state_id,
+                        :generated_at,
+                        :policy_id,
+                        :policy_decision_frame_json,
+                        :created_at
+                    )
+                    ON CONFLICT (frame_id) DO UPDATE SET
+                        source_proposal_frame_id = EXCLUDED.source_proposal_frame_id,
+                        source_self_state_id = EXCLUDED.source_self_state_id,
+                        generated_at = EXCLUDED.generated_at,
+                        policy_id = EXCLUDED.policy_id,
+                        policy_decision_frame_json = EXCLUDED.policy_decision_frame_json
+                    """
+                ),
+                {
+                    "frame_id": frame.frame_id,
+                    "source_proposal_frame_id": frame.source_proposal_frame_id,
+                    "source_self_state_id": frame.source_self_state_id,
+                    "generated_at": frame.generated_at,
+                    "policy_id": frame.policy_id,
+                    "policy_decision_frame_json": Json(frame.model_dump(mode="json")),
+                    "created_at": now,
+                },
+            )

--- a/services/orion-policy-runtime/app/store.py
+++ b/services/orion-policy-runtime/app/store.py
@@ -21,6 +21,32 @@ class PolicyRuntimeStore:
             json_deserializer=json.loads,
         )
 
+    def load_next_proposal_without_policy_frame(self) -> ProposalFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT p.proposal_frame_json
+                        FROM substrate_proposal_frames p
+                        LEFT JOIN substrate_policy_decision_frames d
+                          ON d.source_proposal_frame_id = p.frame_id
+                        WHERE d.frame_id IS NULL
+                        ORDER BY p.generated_at ASC
+                        LIMIT 1
+                        """
+                    ),
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        payload = row["proposal_frame_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return ProposalFrameV1.model_validate(payload)
+
     def load_latest_proposal_frame(self) -> ProposalFrameV1 | None:
         with self._engine.connect() as conn:
             row = (

--- a/services/orion-policy-runtime/app/worker.py
+++ b/services/orion-policy-runtime/app/worker.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from orion.policy.builder import build_policy_decision_frame
+from orion.policy.policy import load_substrate_policy
+
+from app.settings import get_settings
+from app.store import PolicyRuntimeStore
+
+logger = logging.getLogger("orion.policy.runtime")
+
+
+class PolicyRuntimeWorker:
+    def __init__(self) -> None:
+        self._settings = get_settings()
+        self._store = PolicyRuntimeStore(self._settings.postgres_uri)
+        self._policy = load_substrate_policy(Path(self._settings.substrate_policy_path))
+        self._stop = asyncio.Event()
+
+    async def start(self) -> None:
+        asyncio.create_task(self._poll_loop(), name="policy-runtime-poll")
+
+    async def stop(self) -> None:
+        self._stop.set()
+
+    async def _poll_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                await asyncio.to_thread(self._tick)
+            except Exception:
+                logger.exception("policy_runtime_tick_failed")
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(),
+                    timeout=float(self._settings.policy_poll_interval_sec),
+                )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+    def _tick(self) -> None:
+        if not self._settings.enable_policy_runtime:
+            return
+
+        proposal = self._store.load_latest_proposal_frame()
+        if proposal is None:
+            return
+
+        if self._store.load_policy_frame_for_proposal(proposal.frame_id) is not None:
+            return
+
+        self_state = self._store.load_self_state(proposal.source_self_state_id)
+        if self_state is None:
+            logger.warning(
+                "policy_skip_missing_self_state self_state_id=%s proposal_frame_id=%s",
+                proposal.source_self_state_id,
+                proposal.frame_id,
+            )
+            return
+
+        frame = build_policy_decision_frame(
+            proposal_frame=proposal,
+            self_state=self_state,
+            policy=self._policy,
+        )
+        self._store.save_policy_decision_frame(frame)
+        logger.info(
+            "policy_decision_frame_saved frame_id=%s proposal_frame_id=%s decisions=%d",
+            frame.frame_id,
+            proposal.frame_id,
+            len(frame.decisions),
+        )

--- a/services/orion-policy-runtime/app/worker.py
+++ b/services/orion-policy-runtime/app/worker.py
@@ -46,11 +46,8 @@ class PolicyRuntimeWorker:
         if not self._settings.enable_policy_runtime:
             return
 
-        proposal = self._store.load_latest_proposal_frame()
+        proposal = self._store.load_next_proposal_without_policy_frame()
         if proposal is None:
-            return
-
-        if self._store.load_policy_frame_for_proposal(proposal.frame_id) is not None:
             return
 
         self_state = self._store.load_self_state(proposal.source_self_state_id)

--- a/services/orion-policy-runtime/docker-compose.yml
+++ b/services/orion-policy-runtime/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  policy-runtime:
+    build:
+      context: ../..
+      dockerfile: services/orion-policy-runtime/Dockerfile
+    container_name: ${PROJECT}-policy-runtime
+    restart: unless-stopped
+    networks:
+      - app-net
+    ports:
+      - "${POLICY_RUNTIME_PORT:-8120}:8120"
+    environment:
+      - PROJECT=${PROJECT}
+      - SERVICE_NAME=${SERVICE_NAME:-orion-policy-runtime}
+      - SERVICE_VERSION=${SERVICE_VERSION:-0.1.0}
+      - POSTGRES_URI=${POSTGRES_URI}
+      - SUBSTRATE_POLICY_PATH=${SUBSTRATE_POLICY_PATH:-/app/config/policy/substrate_policy.v1.yaml}
+      - POLICY_POLL_INTERVAL_SEC=${POLICY_POLL_INTERVAL_SEC:-2.0}
+      - ENABLE_POLICY_RUNTIME=${ENABLE_POLICY_RUNTIME:-true}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+
+networks:
+  app-net:
+    external: true

--- a/services/orion-policy-runtime/requirements.txt
+++ b/services/orion-policy-runtime/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+pydantic==2.10.3
+pydantic-settings==2.6.1
+sqlalchemy==2.0.36
+psycopg2-binary==2.9.10
+PyYAML==6.0.2

--- a/services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql
+++ b/services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql
@@ -1,0 +1,18 @@
+create table if not exists substrate_policy_decision_frames (
+    frame_id text primary key,
+    source_proposal_frame_id text not null,
+    source_self_state_id text not null,
+    generated_at timestamptz not null,
+    policy_id text not null,
+    policy_decision_frame_json jsonb not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_policy_decision_frames_generated_at
+    on substrate_policy_decision_frames (generated_at desc);
+
+create index if not exists idx_substrate_policy_decision_frames_source_proposal
+    on substrate_policy_decision_frames (source_proposal_frame_id);
+
+create index if not exists idx_substrate_policy_decision_frames_source_self_state
+    on substrate_policy_decision_frames (source_self_state_id);

--- a/tests/test_policy_decision_builder.py
+++ b/tests/test_policy_decision_builder.py
@@ -1,0 +1,195 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.policy.builder import build_policy_decision_frame, stable_policy_frame_id
+from orion.policy.policy import load_substrate_policy
+from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_substrate_policy(REPO / "config" / "policy" / "substrate_policy.v1.yaml")
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _loaded_self_state() -> SelfStateV1:
+    def dim(dimension_id: str, score: float) -> SelfStateDimensionV1:
+        return SelfStateDimensionV1(
+            dimension_id=dimension_id,
+            score=score,
+            confidence=0.9,
+        )
+
+    return SelfStateV1(
+        self_state_id="self.state:tick_live:frame_live:self_state_policy.v1",
+        generated_at=NOW,
+        source_field_tick_id="tick_live",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="attention.frame:tick_live:field_attention_policy.v1",
+        source_attention_generated_at=NOW,
+        overall_condition="loaded",
+        overall_intensity=0.655,
+        overall_confidence=0.9,
+        dimensions={
+            "execution_pressure": dim("execution_pressure", 1.0),
+            "reasoning_pressure": dim("reasoning_pressure", 0.9),
+            "resource_pressure": dim("resource_pressure", 1.0),
+            "agency_readiness": dim("agency_readiness", 0.6),
+            "reliability_pressure": dim("reliability_pressure", 0.0),
+        },
+        summary_labels=["execution_loaded", "resource_pressurized"],
+    )
+
+
+def _candidate(
+    proposal_id: str,
+    proposal_kind: str,
+    *,
+    risk_score: float = 0.05,
+    required_policy_gate: str = "read_only",
+    proposed_effect: str = "increase_observability",
+    execution_intent: dict[str, str] | None = None,
+) -> ProposalCandidateV1:
+    return ProposalCandidateV1(
+        proposal_id=proposal_id,
+        proposal_kind=proposal_kind,
+        title=proposal_id,
+        description="test",
+        target_id="capability:orchestration",
+        target_kind="capability",
+        priority_score=0.5,
+        urgency_score=0.4,
+        confidence_score=0.9,
+        risk_score=risk_score,
+        reversibility_score=1.0,
+        proposed_effect=proposed_effect,
+        required_policy_gate=required_policy_gate,
+        execution_intent=execution_intent or {"mode": "descriptive_only"},
+    )
+
+
+def _proposal_frame(candidates: list[ProposalCandidateV1]) -> ProposalFrameV1:
+    state = _loaded_self_state()
+    return ProposalFrameV1(
+        frame_id="proposal.frame:test:proposal_policy.v1",
+        generated_at=NOW,
+        source_self_state_id=state.self_state_id,
+        source_self_state_generated_at=state.generated_at,
+        source_attention_frame_id=state.source_attention_frame_id,
+        source_field_tick_id=state.source_field_tick_id,
+        overall_action_pressure=0.6,
+        overall_risk=0.3,
+        candidates=candidates,
+    )
+
+
+def test_builds_policy_decision_frame() -> None:
+    state = _loaded_self_state()
+    proposal = _proposal_frame(
+        [
+            _candidate("proposal:inspect:state", "inspect"),
+            _candidate("proposal:summarize:state", "summarize"),
+            _candidate(
+                "proposal:review:state",
+                "request_policy_review",
+                required_policy_gate="operator_review",
+                proposed_effect="prepare_for_policy_gate",
+                risk_score=0.25,
+            ),
+            _candidate(
+                "proposal:prepare:state",
+                "prepare_action",
+                required_policy_gate="operator_review",
+                proposed_effect="prepare_for_policy_gate",
+                risk_score=0.25,
+            ),
+        ]
+    )
+    frame = build_policy_decision_frame(
+        proposal_frame=proposal,
+        self_state=state,
+        policy=POLICY,
+        now=NOW,
+    )
+    assert frame.schema_version == "policy.decision.frame.v1"
+    assert frame.source_proposal_frame_id == proposal.frame_id
+    assert frame.source_self_state_id == state.self_state_id
+
+
+def test_partitions_decisions() -> None:
+    state = _loaded_self_state()
+    proposal = _proposal_frame(
+        [
+            _candidate("proposal:inspect:state", "inspect"),
+            _candidate(
+                "proposal:prepare:state",
+                "prepare_action",
+                required_policy_gate="operator_review",
+                proposed_effect="prepare_for_policy_gate",
+                risk_score=0.25,
+            ),
+            _candidate(
+                "proposal:blocked:state",
+                "inspect",
+                execution_intent={"mode": "cortex_exec_direct_call"},
+            ),
+        ]
+    )
+    frame = build_policy_decision_frame(
+        proposal_frame=proposal,
+        self_state=state,
+        policy=POLICY,
+        now=NOW,
+    )
+    assert any(d.decision == "approved_read_only" for d in frame.approved_decisions)
+    assert len(frame.review_required_decisions) >= 1
+    assert len(frame.rejected_decisions) >= 1
+
+
+def test_operator_review_required() -> None:
+    state = _loaded_self_state()
+    proposal = _proposal_frame(
+        [
+            _candidate(
+                "proposal:prepare:state",
+                "prepare_action",
+                required_policy_gate="operator_review",
+                proposed_effect="prepare_for_policy_gate",
+                risk_score=0.25,
+            ),
+        ]
+    )
+    frame = build_policy_decision_frame(
+        proposal_frame=proposal,
+        self_state=state,
+        policy=POLICY,
+        now=NOW,
+    )
+    assert frame.operator_review_required is True
+
+
+def test_execution_allowed_false_in_v1() -> None:
+    state = _loaded_self_state()
+    proposal = _proposal_frame([_candidate("proposal:inspect:state", "inspect")])
+    frame = build_policy_decision_frame(
+        proposal_frame=proposal,
+        self_state=state,
+        policy=POLICY,
+        now=NOW,
+    )
+    assert frame.execution_allowed is False
+
+
+def test_stable_frame_id() -> None:
+    state = _loaded_self_state()
+    proposal = _proposal_frame([_candidate("proposal:inspect:state", "inspect")])
+    expected = stable_policy_frame_id(
+        proposal_frame_id=proposal.frame_id,
+        policy_id=POLICY.policy_id,
+    )
+    frame = build_policy_decision_frame(
+        proposal_frame=proposal,
+        self_state=state,
+        policy=POLICY,
+        now=NOW,
+    )
+    assert frame.frame_id == expected

--- a/tests/test_policy_decision_frame_schemas.py
+++ b/tests/test_policy_decision_frame_schemas.py
@@ -1,0 +1,98 @@
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def test_policy_decision_validates() -> None:
+    d = PolicyDecisionV1(
+        decision_id="policy.decision:proposal:inspect:state:substrate_policy.v1",
+        proposal_id="proposal:inspect:state",
+        decision="approved_read_only",
+        policy_gate="read_only",
+        risk_score=0.05,
+        reversibility_score=1.0,
+        confidence_score=0.9,
+        allowed_scope="inspect_only",
+        reasons=["read_only_low_risk"],
+    )
+    assert d.decision == "approved_read_only"
+
+
+def test_policy_decision_frame_validates() -> None:
+    decision = PolicyDecisionV1(
+        decision_id="policy.decision:proposal:inspect:state:substrate_policy.v1",
+        proposal_id="proposal:inspect:state",
+        decision="approved_read_only",
+        policy_gate="read_only",
+        risk_score=0.05,
+        reversibility_score=1.0,
+        confidence_score=0.9,
+    )
+    frame = PolicyDecisionFrameV1(
+        frame_id="policy.frame:proposal.frame:state:substrate_policy.v1",
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:state:proposal_policy.v1",
+        source_self_state_id="self.state:state",
+        decisions=[decision],
+        approved_decisions=[decision],
+        overall_risk=0.05,
+    )
+    assert frame.schema_version == "policy.decision.frame.v1"
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        PolicyDecisionV1(
+            decision_id="d1",
+            proposal_id="p1",
+            decision="rejected",
+            policy_gate="none",
+            risk_score=0.1,
+            reversibility_score=1.0,
+            confidence_score=0.9,
+            extra_field=True,
+        )
+
+
+def test_score_bounds_rejected() -> None:
+    with pytest.raises(ValidationError):
+        PolicyDecisionV1(
+            decision_id="d1",
+            proposal_id="p1",
+            decision="rejected",
+            policy_gate="none",
+            risk_score=1.5,
+            reversibility_score=1.0,
+            confidence_score=0.9,
+        )
+
+
+def test_roundtrip_json() -> None:
+    decision = PolicyDecisionV1(
+        decision_id="policy.decision:p1:substrate_policy.v1",
+        proposal_id="p1",
+        decision="requires_operator_review",
+        policy_gate="operator_review",
+        risk_score=0.3,
+        reversibility_score=0.4,
+        confidence_score=0.6,
+        reasons=["low_reversibility"],
+    )
+    frame = PolicyDecisionFrameV1(
+        frame_id="policy.frame:pf1:substrate_policy.v1",
+        generated_at=NOW,
+        source_proposal_frame_id="pf1",
+        source_self_state_id="ss1",
+        decisions=[decision],
+        review_required_decisions=[decision],
+        overall_risk=0.3,
+        operator_review_required=True,
+    )
+    payload = frame.model_dump(mode="json")
+    restored = PolicyDecisionFrameV1.model_validate(payload)
+    assert restored.frame_id == frame.frame_id

--- a/tests/test_policy_evaluator.py
+++ b/tests/test_policy_evaluator.py
@@ -1,0 +1,158 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.policy.evaluator import evaluate_proposal_candidate
+from orion.policy.policy import load_substrate_policy
+from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_substrate_policy(REPO / "config" / "policy" / "substrate_policy.v1.yaml")
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _self_state() -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id="self.state:test",
+        generated_at=NOW,
+        source_field_tick_id="tick:test",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="frame:test",
+        source_attention_generated_at=NOW,
+        overall_intensity=0.5,
+        overall_confidence=0.9,
+    )
+
+
+def _proposal_frame() -> ProposalFrameV1:
+    return ProposalFrameV1(
+        frame_id="proposal.frame:test:proposal_policy.v1",
+        generated_at=NOW,
+        source_self_state_id="self.state:test",
+        source_self_state_generated_at=NOW,
+        source_attention_frame_id="frame:test",
+        source_field_tick_id="tick:test",
+        overall_action_pressure=0.5,
+        overall_risk=0.1,
+    )
+
+
+def _candidate(**overrides) -> ProposalCandidateV1:
+    base = dict(
+        proposal_id="proposal:test:state",
+        proposal_kind="inspect",
+        title="Inspect",
+        description="Desc",
+        target_id="capability:orchestration",
+        target_kind="capability",
+        priority_score=0.5,
+        urgency_score=0.4,
+        confidence_score=0.9,
+        risk_score=0.05,
+        reversibility_score=1.0,
+        proposed_effect="increase_observability",
+        required_policy_gate="read_only",
+        execution_intent={"mode": "descriptive_only"},
+    )
+    base.update(overrides)
+    return ProposalCandidateV1(**base)
+
+
+def test_read_only_inspect_low_risk_approved() -> None:
+    result = evaluate_proposal_candidate(
+        candidate=_candidate(),
+        proposal_frame=_proposal_frame(),
+        self_state=_self_state(),
+        policy=POLICY,
+    )
+    assert result.decision == "approved_read_only"
+
+
+def test_summarize_low_risk_approved_read_only() -> None:
+    result = evaluate_proposal_candidate(
+        candidate=_candidate(
+            proposal_kind="summarize",
+            target_kind="self_state",
+            target_id="self:current",
+        ),
+        proposal_frame=_proposal_frame(),
+        self_state=_self_state(),
+        policy=POLICY,
+    )
+    assert result.decision == "approved_read_only"
+
+
+def test_prepare_action_requires_operator_review() -> None:
+    result = evaluate_proposal_candidate(
+        candidate=_candidate(
+            proposal_kind="prepare_action",
+            required_policy_gate="operator_review",
+            risk_score=0.25,
+            proposed_effect="prepare_for_policy_gate",
+        ),
+        proposal_frame=_proposal_frame(),
+        self_state=_self_state(),
+        policy=POLICY,
+    )
+    assert result.decision == "requires_operator_review"
+
+
+def test_high_risk_rejected() -> None:
+    result = evaluate_proposal_candidate(
+        candidate=_candidate(risk_score=0.90),
+        proposal_frame=_proposal_frame(),
+        self_state=_self_state(),
+        policy=POLICY,
+    )
+    assert result.decision == "rejected"
+
+
+def test_low_reversibility_requires_review() -> None:
+    result = evaluate_proposal_candidate(
+        candidate=_candidate(reversibility_score=0.30, risk_score=0.10),
+        proposal_frame=_proposal_frame(),
+        self_state=_self_state(),
+        policy=POLICY,
+    )
+    assert result.decision == "requires_operator_review"
+
+
+def test_low_confidence_requires_review() -> None:
+    result = evaluate_proposal_candidate(
+        candidate=_candidate(confidence_score=0.40, risk_score=0.10),
+        proposal_frame=_proposal_frame(),
+        self_state=_self_state(),
+        policy=POLICY,
+    )
+    assert result.decision == "requires_operator_review"
+
+
+def test_hard_blocked_execution_intent_rejected() -> None:
+    result = evaluate_proposal_candidate(
+        candidate=_candidate(execution_intent={"mode": "cortex_exec_direct_call"}),
+        proposal_frame=_proposal_frame(),
+        self_state=_self_state(),
+        policy=POLICY,
+    )
+    assert result.decision == "rejected"
+    assert "cortex_exec_direct_call" in result.blocked_by
+
+
+def test_no_approved_for_execution_when_disabled() -> None:
+    kinds = (
+        "observe",
+        "inspect",
+        "summarize",
+        "stabilize",
+        "defer",
+        "request_policy_review",
+        "prepare_action",
+    )
+    for kind in kinds:
+        result = evaluate_proposal_candidate(
+            candidate=_candidate(proposal_kind=kind, risk_score=0.05),
+            proposal_frame=_proposal_frame(),
+            self_state=_self_state(),
+            policy=POLICY,
+        )
+        assert result.decision != "approved_for_execution"

--- a/tests/test_policy_evaluator.py
+++ b/tests/test_policy_evaluator.py
@@ -138,6 +138,18 @@ def test_hard_blocked_execution_intent_rejected() -> None:
     assert "cortex_exec_direct_call" in result.blocked_by
 
 
+def test_elevated_policy_gate_requires_review() -> None:
+    for gate in ("autonomy_policy", "execution_policy"):
+        result = evaluate_proposal_candidate(
+            candidate=_candidate(required_policy_gate=gate, risk_score=0.05),
+            proposal_frame=_proposal_frame(),
+            self_state=_self_state(),
+            policy=POLICY,
+        )
+        assert result.decision == "requires_operator_review"
+        assert "elevated_policy_gate_required" in result.reasons
+
+
 def test_no_approved_for_execution_when_disabled() -> None:
     kinds = (
         "observe",

--- a/tests/test_policy_loader.py
+++ b/tests/test_policy_loader.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from orion.policy.policy import load_substrate_policy
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO / "config" / "policy" / "substrate_policy.v1.yaml"
+
+
+def test_loads_yaml() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    assert policy.schema_version == "substrate_policy.v1"
+
+
+def test_policy_id() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    assert policy.policy_id == "substrate_policy.v1"
+
+
+def test_execution_without_operator_disabled() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    assert policy.autonomy.allow_execution_without_operator is False
+
+
+def test_prepare_action_requires_review() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    rule = policy.proposal_kind_rules["prepare_action"]
+    assert rule.default_decision == "requires_operator_review"
+    assert rule.max_autonomy_tier == "operator_review"
+
+
+def test_inspect_read_only() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    rule = policy.proposal_kind_rules["inspect"]
+    assert rule.default_decision == "approved_read_only"
+    assert rule.allowed_scope == "inspect_only"
+
+
+def test_hard_blocks_include_cortex_exec() -> None:
+    policy = load_substrate_policy(POLICY_PATH)
+    assert "cortex_exec_direct_call" in policy.hard_blocks

--- a/tests/test_policy_loader.py
+++ b/tests/test_policy_loader.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
-from orion.policy.policy import load_substrate_policy
+import pytest
+from pydantic import ValidationError
+
+from orion.policy.policy import SubstratePolicyV1, load_substrate_policy
 
 REPO = Path(__file__).resolve().parents[1]
 POLICY_PATH = REPO / "config" / "policy" / "substrate_policy.v1.yaml"
@@ -38,3 +41,14 @@ def test_inspect_read_only() -> None:
 def test_hard_blocks_include_cortex_exec() -> None:
     policy = load_substrate_policy(POLICY_PATH)
     assert "cortex_exec_direct_call" in policy.hard_blocks
+
+
+def test_nested_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        SubstratePolicyV1.model_validate(
+            {
+                "schema_version": "substrate_policy.v1",
+                "policy_id": "substrate_policy.v1",
+                "autonomy": {"allow_executon_without_operator": False},
+            }
+        )

--- a/tests/test_policy_runtime_store.py
+++ b/tests/test_policy_runtime_store.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO = Path(__file__).resolve().parents[1]
+SVC = REPO / "services" / "orion-policy-runtime"
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _load_store_class():
+    spec = importlib.util.spec_from_file_location(
+        "policy_runtime_store",
+        SVC / "app" / "store.py",
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.PolicyRuntimeStore
+
+
+PolicyRuntimeStore = _load_store_class()
+
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1  # noqa: E402
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _frame() -> PolicyDecisionFrameV1:
+    decision = PolicyDecisionV1(
+        decision_id="policy.decision:p1:substrate_policy.v1",
+        proposal_id="p1",
+        decision="approved_read_only",
+        policy_gate="read_only",
+        risk_score=0.05,
+        reversibility_score=1.0,
+        confidence_score=0.9,
+    )
+    return PolicyDecisionFrameV1(
+        frame_id="policy.frame:proposal.frame:test:substrate_policy.v1",
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:test:proposal_policy.v1",
+        source_self_state_id="self.state:test",
+        decisions=[decision],
+        approved_decisions=[decision],
+        overall_risk=0.05,
+    )
+
+
+def test_save_and_load_latest(monkeypatch) -> None:
+    payload = _frame().model_dump(mode="json")
+    store = PolicyRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "INSERT INTO substrate_policy_decision_frames" in sql:
+            result.rowcount = 1
+        elif "source_proposal_frame_id" in sql and "ORDER BY" in sql:
+            result.mappings.return_value.first.return_value = None
+        else:
+            result.mappings.return_value.first.return_value = {
+                "policy_decision_frame_json": payload,
+            }
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    store.save_policy_decision_frame(_frame())
+    loaded = store.load_latest_policy_decision_frame()
+    assert loaded is not None
+    assert loaded.frame_id == _frame().frame_id
+
+
+def test_load_by_proposal_frame_id(monkeypatch) -> None:
+    payload = _frame().model_dump(mode="json")
+    store = PolicyRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute_side_effect(stmt, params=None):
+        result = MagicMock()
+        if "source_proposal_frame_id" in str(stmt):
+            result.mappings.return_value.first.return_value = {
+                "policy_decision_frame_json": payload,
+            }
+        else:
+            result.mappings.return_value.first.return_value = None
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    loaded = store.load_policy_frame_for_proposal("proposal.frame:test:proposal_policy.v1")
+    assert loaded is not None
+    assert loaded.source_proposal_frame_id == "proposal.frame:test:proposal_policy.v1"
+
+
+def test_save_idempotent_by_frame_id(monkeypatch) -> None:
+    store = PolicyRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value = MagicMock(rowcount=1)
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    store.save_policy_decision_frame(_frame())
+    sql = str(conn.execute.call_args[0][0])
+    assert "ON CONFLICT (frame_id)" in sql

--- a/tests/test_policy_runtime_worker.py
+++ b/tests/test_policy_runtime_worker.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO = Path(__file__).resolve().parents[1]
+SVC = REPO / "services" / "orion-policy-runtime"
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(SVC))
+
+from app.worker import PolicyRuntimeWorker  # noqa: E402
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1  # noqa: E402
+from orion.schemas.proposal_frame import ProposalFrameV1  # noqa: E402
+from orion.schemas.self_state import SelfStateV1  # noqa: E402
+
+NOW = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _self_state() -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id="self.state:test",
+        generated_at=NOW,
+        source_field_tick_id="tick:test",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="frame:test",
+        source_attention_generated_at=NOW,
+        overall_intensity=0.5,
+        overall_confidence=0.9,
+    )
+
+
+def _proposal() -> ProposalFrameV1:
+    return ProposalFrameV1(
+        frame_id="proposal.frame:test:proposal_policy.v1",
+        generated_at=NOW,
+        source_self_state_id="self.state:test",
+        source_self_state_generated_at=NOW,
+        source_attention_frame_id="frame:test",
+        source_field_tick_id="tick:test",
+        overall_action_pressure=0.4,
+        overall_risk=0.1,
+        candidates=[],
+    )
+
+
+def _existing_policy_frame() -> PolicyDecisionFrameV1:
+    return PolicyDecisionFrameV1(
+        frame_id="policy.frame:proposal.frame:test:substrate_policy.v1",
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:test:proposal_policy.v1",
+        source_self_state_id="self.state:test",
+        overall_risk=0.0,
+    )
+
+
+def test_worker_skips_when_no_proposal_pending(monkeypatch) -> None:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    worker = PolicyRuntimeWorker()
+    worker._store.load_next_proposal_without_policy_frame = MagicMock(return_value=None)
+    worker._store.save_policy_decision_frame = MagicMock()
+
+    worker._tick()
+
+    worker._store.save_policy_decision_frame.assert_not_called()
+
+
+def test_worker_skips_when_self_state_missing(monkeypatch) -> None:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    worker = PolicyRuntimeWorker()
+    worker._store.load_next_proposal_without_policy_frame = MagicMock(return_value=_proposal())
+    worker._store.load_self_state = MagicMock(return_value=None)
+    worker._store.save_policy_decision_frame = MagicMock()
+
+    worker._tick()
+
+    worker._store.save_policy_decision_frame.assert_not_called()
+
+
+def test_worker_saves_policy_frame_for_pending_proposal(monkeypatch) -> None:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    worker = PolicyRuntimeWorker()
+    proposal = _proposal()
+    worker._store.load_next_proposal_without_policy_frame = MagicMock(return_value=proposal)
+    worker._store.load_self_state = MagicMock(return_value=_self_state())
+    worker._store.save_policy_decision_frame = MagicMock()
+
+    worker._tick()
+
+    worker._store.save_policy_decision_frame.assert_called_once()


### PR DESCRIPTION
# PR: Policy Gate v1 — ProposalFrame → Governed Decisions

**Branch:** `feat/policy-gate-v1`  
**Base:** `main`  
**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-policy-gate-v1`  
**Head:** `b0a97538` (4 commits)

## Summary

Implements **Layer 8** of the Orion cognition substrate: deterministic policy gating over Layer 7 proposals. Converts `ProposalFrameV1` + `SelfStateV1` into `PolicyDecisionFrameV1` snapshots persisted for inspection. **Policy is not execution** — no cortex-exec, bus publish, operator notifications, or settings mutation.

```text
substrate_proposal_frames + substrate_self_state
  → orion-policy-runtime (port 8120)
  → PolicyDecisionFrameV1
  → substrate_policy_decision_frames
  → GET /api/substrate/policy/latest (Hub, read-only)
```

**Layer 9 execution is explicitly deferred.**

## Roadmap position (11-layer substrate)

| Layer | This PR |
|-------|---------|
| 7 Proposal | Consumes `ProposalFrameV1` |
| **8 Policy** | **Implemented** |
| 9 Execution | Deferred |

## Example `PolicyDecisionFrameV1` (synthetic loaded state)

Built from demo proposal with inspect, summarize, request_policy_review, prepare_action candidates:

| Field | Value |
|-------|-------|
| `frame_id` | `policy.frame:proposal.frame:demo:proposal_policy.v1:substrate_policy.v1` |
| `operator_review_required` | `true` |
| `execution_allowed` | `false` |
| `approved_decisions` | 2 (inspect, summarize → `approved_read_only`) |
| `review_required_decisions` | 2 (request_policy_review, prepare_action) |

Per-candidate decisions:

```text
proposal:inspect   → approved_read_only
proposal:summarize → approved_read_only
proposal:review    → requires_operator_review
proposal:prepare   → requires_operator_review
```

## Proof: no execution performed

- `orion-policy-runtime` worker only calls `build_policy_decision_frame` + SQL upsert.
- Grep over `services/orion-policy-runtime` and `orion/policy` finds no `cortex_exec`, `bus.publish`, or runtime side effects (only README/docs and hard-block token `cortex_exec_direct_call`).
- `execution_constraints` on decisions are tagged `layer: 9_deferred` for future execution runtime.
- `allow_execution_without_operator: false` in `config/policy/substrate_policy.v1.yaml` with tests asserting no `approved_for_execution`.

## Files changed

| Path | Role |
|------|------|
| `orion/schemas/policy_decision_frame.py` | `PolicyDecisionV1`, `PolicyDecisionFrameV1` |
| `orion/schemas/registry.py` | Schema registry |
| `config/policy/substrate_policy.v1.yaml` | Substrate policy v1 |
| `orion/policy/{policy,rules,evaluator,builder}.py` | Pure policy logic |
| `services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql` | DDL |
| `services/orion-policy-runtime/` | Polling runtime (8120) |
| `services/orion-hub/scripts/substrate_policy_routes.py` | Debug API |
| `scripts/smoke_policy_decision_frame_v1.sh` | Live SQL smoke |
| `tests/test_policy_*.py` | Unit + worker tests |

## Review fixes (post code-review)

- Enforce `autonomy_policy` / `execution_policy` gates → `requires_operator_review` (no kind-default bypass).
- Worker backfills **oldest** proposal without a policy frame (not only latest).
- Nested policy YAML models use `extra="forbid"`.

## Tests run

```bash
cd .worktrees/feat-policy-gate-v1
PYTHONPATH=. pytest tests/test_policy_*.py services/orion-hub/tests/test_substrate_policy_debug_api.py -q
# 34 passed

PYTHONPATH=. pytest tests/test_proposal_*.py tests/test_self_state_*.py -q
# 57 passed

PYTHONPATH=. python -m compileall orion/policy orion/schemas/policy_decision_frame.py services/orion-policy-runtime -q
```

## Live operator steps

```bash
docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
  < services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql

cd services/orion-policy-runtime
cp -n .env_example .env
docker compose up -d --build

./scripts/smoke_policy_decision_frame_v1.sh
curl -s http://localhost:8120/latest | jq
curl -s http://localhost:8080/api/substrate/policy/latest | jq
```

## Test plan

- [ ] Apply migration on target DB
- [ ] Start `orion-policy-runtime` with proposal + self-state data present
- [ ] Confirm idempotent noop on same proposal frame
- [ ] Smoke script shows latest policy frame with partitioned decisions
- [ ] Hub `/api/substrate/policy/latest` returns frame JSON
- [ ] Confirm `execution_allowed` is false for live frames