### PR TITLE
Docs: add substrate trace context engineering pack

### DIFF
--- a/docs/context-engineering/00_substrate_trace_doctrine.md
+++ b/docs/context-engineering/00_substrate_trace_doctrine.md
@@ -1,0 +1,102 @@
+# Substrate Trace Doctrine
+
+## Definition
+
+A substrate trace is the shared causal record of meaningful transitions in the Orion mesh.
+
+A service may keep native local payloads for execution, storage, transport, UI, model calls, or external APIs. Those native payloads are local. But any transition that matters to Orion's future cognition must leave a substrate trace.
+
+The current implementation schema is `GrammarEventV1`.
+
+The design concept is **Substrate Trace**.
+
+## Core rule
+
+```text
+Native payloads are local.
+Substrate traces are shared.
+Typed frames are compiled artifacts.
+Every meaningful transition must be causally legible.
+```
+
+## What a substrate trace records
+
+A substrate trace records:
+
+- what happened;
+- where it happened;
+- when it happened;
+- which service and node observed it;
+- what source event, artifact, frame, receipt, or delta it derived from;
+- what consequence it produced;
+- what evidence supports it;
+- what confidence, risk, uncertainty, or scope bound applies;
+- how it connects to other events in a causal episode.
+
+## What a substrate trace is not
+
+A substrate trace is not:
+
+- a raw payload dump;
+- a mirror of every internal dict;
+- a packet log;
+- a full prompt/completion store;
+- a stack trace archive;
+- an unbounded debug blob;
+- a replacement for native service contracts.
+
+## Useful distinction
+
+```text
+Native operational contract:
+  The thing a service needs to do its local job.
+
+Shared substrate trace contract:
+  The causal shadow of meaningful transitions that later layers can reason over.
+```
+
+For example:
+
+- `orion-hub` may use HTTP/WebSocket payloads locally; operator decisions should emit substrate traces.
+- `orion-sql-writer` may use SQL inserts locally; write commits/failures should emit substrate traces.
+- `orion-bus` may use Redis messages locally; channel violations/backpressure should emit substrate traces.
+- `orion-cortex-exec` may execute plans locally; plan/step/result lifecycle should emit substrate traces.
+
+## Relationship to `GrammarEventV1`
+
+Do not rename code casually.
+
+For now:
+
+```text
+Substrate Trace = design concept
+GrammarEventV1 = current implementation schema
+```
+
+Docs should say:
+
+```text
+substrate trace event, implemented today as GrammarEventV1
+```
+
+## Relationship to typed frames
+
+Typed frames are compiled artifacts derived from traces, state deltas, field state, attention, and prior frames.
+
+Examples:
+
+- `FieldAttentionFrameV1`
+- `SelfStateV1`
+- `ProposalFrameV1`
+- `PolicyDecisionFrameV1`
+- `ExecutionDispatchFrameV1`
+- `FeedbackFrameV1`
+- `ConsolidationFrameV1`
+
+Typed frames do not eliminate substrate traces. The frame is the artifact; the trace records the meaningful lifecycle and causal lineage of creating that artifact.
+
+## End-state
+
+The mesh becomes legible to itself.
+
+That means no important service behavior remains an opaque box forever. Local internals may stay private, but substrate-relevant transitions must be traceable, reducible, digestible, and eventually consolidatable.

--- a/docs/context-engineering/01_service_taxonomy.md
+++ b/docs/context-engineering/01_service_taxonomy.md
@@ -1,0 +1,194 @@
+# Service Taxonomy
+
+## Services are not taxa
+
+A single service can have multiple roles.
+
+Classify service **ports/contracts**, not whole services.
+
+Example:
+
+```text
+orion-hub
+  GET /api/substrate/self-state/latest
+    role: operator_read_surface
+
+  POST /api/chat
+    role: operator_ingress
+
+  POST /api/proposal/review
+    role: control_plane
+```
+
+## Port roles
+
+Use these roles in `SERVICE_PORTS.yaml`.
+
+### `organ_ingress`
+
+A port that observes the world, body, infrastructure, operator, model behavior, or internal cognition and turns it into substrate-legible events.
+
+Typical trace responsibility: high.
+
+Examples:
+
+- biometrics samples;
+- vision frame observations;
+- world pulse observations;
+- security watcher events;
+- power telemetry;
+- operator input ingress;
+- audio/STT ingress.
+
+### `reducer`
+
+A port or runtime that consumes substrate traces and commits state deltas or reduction receipts.
+
+Typical primary contract:
+
+```text
+StateDeltaV1
+ReductionReceiptV1
+```
+
+### `substrate_frame_runtime`
+
+A runtime that consumes committed substrate state or typed frames and emits a compiled typed frame.
+
+Examples:
+
+- field digester;
+- attention runtime;
+- self-state runtime;
+- proposal runtime;
+- policy runtime;
+- execution dispatch runtime;
+- feedback runtime;
+- future consolidation runtime.
+
+Primary contract: typed frame.
+
+Trace responsibility: lifecycle and lineage traces for frame creation.
+
+### `transport_infrastructure`
+
+Message movement and channel semantics.
+
+Examples:
+
+- bus service;
+- bus tap;
+- channel catalog enforcement.
+
+Trace responsibility: transport anomalies, delivery lag, channel violations, backpressure, schema rejection.
+
+### `persistence_infrastructure`
+
+Durable storage and projections.
+
+Examples:
+
+- SQL writer;
+- SQL DB;
+- vector DB;
+- state journaler;
+- GraphDB/RDF writer.
+
+Trace responsibility: write committed, write failed, schema decode failed, projection lag, duplicate suppressed.
+
+### `operator_read_surface`
+
+Read-only human/UI/debug surfaces.
+
+Trace responsibility: usually low. Optional traces for substrate-relevant inspections.
+
+### `operator_ingress`
+
+Human input entering the mesh.
+
+Trace responsibility: high, but redacted.
+
+Examples:
+
+- chat message received;
+- operator approval/denial;
+- manual override requested;
+- review submitted.
+
+### `runtime_engine`
+
+Executes plans, chains, councils, workflows, or routing decisions.
+
+Trace responsibility: route selected, plan started, step completed, step failed, result emitted, blocked.
+
+### `model_host`
+
+Hosts inference endpoints.
+
+Trace responsibility: model load, request accepted/rejected, latency, token pressure, failure, capacity. Do not emit raw prompts or completions by default.
+
+### `external_gateway`
+
+Translates between Orion and an external protocol/system.
+
+Trace responsibility: ingress events, egress attempts, consent/policy boundaries, external failure.
+
+### `effector`
+
+Produces external effects.
+
+Examples:
+
+- TTS speech;
+- outbound social message;
+- service restart;
+- power control;
+- file write;
+- operator notification.
+
+Trace responsibility: high. Must pass through proposal/policy/dispatch unless explicitly manual/operator-driven.
+
+### `control_plane`
+
+Mutates configuration, approvals, policy state, runtime state, or operator-reviewed decisions.
+
+Trace responsibility: high. Policy and evidence required.
+
+## Role-to-contract matrix
+
+| Role | Native contract | Trace required? | Downstream stage |
+|---|---|---:|---|
+| organ_ingress | service-specific observation | yes | Layer 1–3 |
+| reducer | state delta / receipt | yes for lifecycle | Layer 3 |
+| substrate_frame_runtime | typed frame | yes for lifecycle/lineage | Layers 4–11 |
+| transport_infrastructure | bus/message envelope | telemetry only | Layer 1/10/11 if relevant |
+| persistence_infrastructure | write/projection | telemetry only | Layer 1/10/11 if relevant |
+| operator_read_surface | HTTP/UI read | usually no | no direct stage |
+| operator_ingress | operator event | yes | Layer 1/8/10 |
+| runtime_engine | plan/step/result | yes | Layer 1–3 or 9–10 |
+| model_host | inference endpoint | telemetry only | Layer 1/10/11 if relevant |
+| external_gateway | protocol bridge | yes for ingress/egress | Layer 1/9/10 |
+| effector | external effect | yes | Layer 9/10 |
+| control_plane | mutation/approval | yes | Layer 8/10 |
+
+## Classification workflow
+
+For each service:
+
+1. List ports/contracts.
+2. Assign each port a role.
+3. Identify meaningful transitions.
+4. Decide whether substrate traces are primary, lifecycle, telemetry, or not needed.
+5. Decide whether a reducer is needed.
+6. Decide whether field/attention/self/proposal/policy/dispatch/feedback/consolidation should consume the outputs.
+
+## Warning signs
+
+A service needs taxonomy hardening if:
+
+- it has a POST route that mutates state but no control-plane classification;
+- it emits bus messages without a documented channel contract;
+- it performs external effects without policy/dispatch lineage;
+- it stores artifacts without source/evidence refs;
+- it is described only by prose README claims;
+- agents must inspect code to infer basic role and contract.

--- a/docs/context-engineering/02_service_port_manifest_spec.md
+++ b/docs/context-engineering/02_service_port_manifest_spec.md
@@ -1,0 +1,150 @@
+# Service Port Manifest Spec
+
+Each service should declare substrate-facing ports in `services/<service>/SERVICE_PORTS.yaml`.
+
+The manifest is intentionally small. It tells an agent what contracts exist, what role each port plays, and where substrate traces belong.
+
+## Required shape
+
+```yaml
+service: orion-example
+status: draft
+
+ports:
+  - name: example_ingress
+    role: organ_ingress
+    native_contract: http_json
+    substrate_trace_required: true
+    trace_roles:
+      - example_request_received
+      - example_request_validated
+      - example_result_emitted
+    downstream_layers: [1, 2, 3]
+    evidence_refs:
+      - correlation_id
+      - source_event_id
+    redaction:
+      never_emit:
+        - raw_model_prompt
+        - credential_material
+        - full_payload_blob
+```
+
+## Fields
+
+`service` is the repository service name, usually matching `services/<service>`.
+
+`ports[].name` is a stable local name such as `chat_ingress`, `proposal_review`, `state_read_api`, `bus_publish_loop`, or `feedback_worker_tick`.
+
+`ports[].role` must be one of:
+
+```text
+organ_ingress
+reducer
+substrate_frame_runtime
+transport_infrastructure
+persistence_infrastructure
+operator_read_surface
+operator_ingress
+runtime_engine
+model_host
+external_gateway
+effector
+control_plane
+```
+
+`ports[].native_contract` is the local operational format, such as `http_json`, `websocket_json`, `redis_channel`, `sql_table`, `file`, `model_api`, `audio_stream`, or `internal_worker_tick`.
+
+`ports[].substrate_trace_required` is true when the port produces transitions that matter to future cognition.
+
+`ports[].trace_roles` lists meaningful transition names. Use names like `operator_review_submitted`, `policy_decision_rejected`, `dispatch_candidate_blocked`, `sql_write_failed`, or `bus_schema_validation_failed` rather than function names.
+
+`ports[].downstream_layers` lists which Layers 1–11 are relevant.
+
+`ports[].evidence_refs` lists expected identifiers such as `correlation_id`, `session_id`, `source_event_id`, `frame_id`, `proposal_id`, `policy_decision_id`, `dispatch_id`, `receipt_id`, `delta_id`, or `otel_trace_id`.
+
+`ports[].redaction.never_emit` lists local safety boundaries. Prefer references and ids over large or private content.
+
+## Example: Hub
+
+```yaml
+service: orion-hub
+status: draft
+
+ports:
+  - name: substrate_read_api
+    role: operator_read_surface
+    native_contract: http_json
+    substrate_trace_required: false
+    notes: Read-only projection of typed substrate frames.
+
+  - name: chat_ingress
+    role: operator_ingress
+    native_contract: websocket_json
+    substrate_trace_required: true
+    trace_roles:
+      - operator_message_received
+      - operator_message_routed
+    downstream_layers: [1, 2, 3, 10, 11]
+    evidence_refs:
+      - session_id
+      - message_id
+      - correlation_id
+    redaction:
+      never_emit:
+        - raw_model_prompt
+        - full_user_message_text
+        - credential_material
+
+  - name: proposal_review
+    role: control_plane
+    native_contract: http_json
+    substrate_trace_required: true
+    trace_roles:
+      - operator_review_submitted
+      - operator_approval_granted
+      - operator_approval_denied
+    downstream_layers: [1, 2, 3, 8, 10, 11]
+    evidence_refs:
+      - proposal_id
+      - policy_frame_id
+      - review_decision_id
+```
+
+## Example: SQL writer
+
+```yaml
+service: orion-sql-writer
+status: draft
+
+ports:
+  - name: grammar_event_writer
+    role: persistence_infrastructure
+    native_contract: sql_insert
+    substrate_trace_required: true
+    trace_roles:
+      - grammar_event_persisted
+      - grammar_event_persist_failed
+      - schema_decode_failed
+      - write_lag_observed
+    downstream_layers: [1, 2, 10, 11]
+    evidence_refs:
+      - event_id
+      - table
+      - error_class
+    redaction:
+      never_emit:
+        - database_connection_material
+        - full_payload_blob
+```
+
+## Acceptance criteria
+
+A manifest is acceptable when an agent can answer:
+
+- what ports exist;
+- which ports emit traces;
+- which semantic roles are expected;
+- which layers are affected;
+- what identifiers provide lineage;
+- what data should be represented only by safe references.

--- a/docs/context-engineering/03_substrate_trace_emitter_pattern.md
+++ b/docs/context-engineering/03_substrate_trace_emitter_pattern.md
@@ -1,0 +1,247 @@
+# Substrate Trace Emitter Pattern
+
+Do not create a central emitter service.
+
+Each service owns local trace emission because each service owns the semantics of its meaningful transitions.
+
+## Standard file layout
+
+For a Python service, prefer:
+
+```text
+services/<service>/app/grammar_emit.py
+services/<service>/app/grammar_publish.py
+services/<service>/tests/test_<service>_grammar_emit.py
+services/<service>/tests/test_<service>_grammar_publish_fail_open.py
+```
+
+The design concept is substrate trace. The current implementation file names may still use `grammar_*` until the codebase is renamed deliberately.
+
+## Split responsibilities
+
+`grammar_emit.py`:
+
+- pure builders;
+- no Redis;
+- no SQL;
+- no network calls;
+- no side effects;
+- validates event shape;
+- redacts or omits sensitive material;
+- builds stable ids where possible.
+
+`grammar_publish.py`:
+
+- fail-open publisher;
+- env-flag controlled;
+- catches/logs exceptions;
+- never breaks the service's native runtime path.
+
+## Env flags
+
+Use service-specific flags:
+
+```text
+PUBLISH_<SERVICE>_GRAMMAR=false
+GRAMMAR_EVENT_CHANNEL=orion:grammar:event
+```
+
+Default should usually be `false` until the service is live-smoked.
+
+## Trace shape
+
+A useful trace is a bounded causal episode:
+
+```text
+trace_started
+  atom_emitted
+  edge_emitted
+  atom_emitted
+  edge_emitted
+trace_ended
+```
+
+Trace id format:
+
+```text
+<service-short>:<node-id>:<correlation-or-artifact-id>
+```
+
+Examples:
+
+```text
+cortex.exec:athena:<correlation_id>
+policy.runtime:athena:<frame_id>
+hub.operator:athena:<session_id>
+sql.writer:athena:<event_id>
+bus.transport:athena:<message_id>
+```
+
+## Semantic role naming
+
+Good semantic roles name meaningful transitions:
+
+```text
+request_received
+request_invalid
+artifact_built
+artifact_persisted
+decision_approved_read_only
+decision_requires_operator_review
+dispatch_candidate_blocked
+feedback_outcome_captured
+write_failed
+schema_validation_failed
+```
+
+Bad roles encode implementation trivia:
+
+```text
+function_called
+loop_entered
+dict_created
+line_47_ran
+```
+
+## Atom rules
+
+Atoms should be compact semantic facts.
+
+Examples:
+
+```text
+Policy approved read-only proposal
+Dispatch candidate blocked because operator review required
+Feedback captured dry-run-only outcome
+SQL writer failed to persist event
+Hub received operator approval decision
+```
+
+Atom metadata should be safe and bounded:
+
+```json
+{
+  "proposal_id": "...",
+  "decision": "approved_read_only",
+  "risk_score": 0.05,
+  "required_policy_gate": "read_only"
+}
+```
+
+Prefer references over payloads:
+
+```text
+payload_ref
+artifact_id
+frame_id
+event_id
+receipt_id
+delta_id
+correlation_id
+session_id
+```
+
+## Edge rules
+
+Edges connect source and consequence.
+
+Use existing `RelationType` values unless the schema has been intentionally extended.
+
+Preferred relationships:
+
+```text
+contains
+derived_from
+temporal_successor
+rendered_as
+```
+
+If a needed relation such as `blocked_by` or `caused_by` is not available in the closed enum, use the closest existing relation and document the semantic gap. Do not invent enum literals casually.
+
+## Redaction rules
+
+Never mirror raw or high-risk payloads into trace events.
+
+Avoid:
+
+```text
+raw model prompts
+raw model completions
+credential material
+large blobs
+full audio/image/video payloads
+full private user text unless explicitly approved
+raw database connection material
+unbounded stack traces
+```
+
+Use:
+
+```text
+safe summary
+artifact id
+payload ref
+redacted error class
+bounded status fields
+evidence refs
+```
+
+## Channel catalog
+
+If the service publishes substrate trace events, update:
+
+```text
+orion/bus/channels.yaml
+```
+
+Add the service as a producer for:
+
+```text
+orion:grammar:event
+```
+
+## README requirements
+
+Each service README should document:
+
+- env flags;
+- trace roles;
+- trace id format;
+- what is emitted;
+- what is never emitted;
+- tests;
+- live smoke command;
+- whether a downstream reducer exists or is deferred.
+
+## Builder tests
+
+Tests should assert:
+
+- valid `GrammarEventV1`;
+- closed `GrammarEventKind` values only;
+- closed `RelationType` values only;
+- stable ids where expected;
+- trace start/end lifecycle;
+- expected semantic roles;
+- no unsafe payload leakage;
+- source/evidence refs present.
+
+## Publisher tests
+
+Tests should assert:
+
+- publisher exceptions do not raise;
+- service runtime path continues;
+- warning/log is emitted;
+- publishing disabled is a no-op.
+
+## Acceptance criteria
+
+A service emitter is acceptable when:
+
+- semantic mapping is local to the service;
+- shared helpers are reused but not turned into a god mapper;
+- trace emission is behind an env flag;
+- publisher is fail-open;
+- tests prove schema validity and redaction;
+- existing service behavior is unchanged when publishing is disabled.

--- a/docs/context-engineering/04_layer_1_to_11_pipeline.md
+++ b/docs/context-engineering/04_layer_1_to_11_pipeline.md
@@ -1,0 +1,246 @@
+# Layer 1–11 Pipeline Guide
+
+This document explains how a service transition moves through the Orion cognition substrate.
+
+Not every service needs every layer. The point of the context pack is to make the decision explicit.
+
+## Layer 1: Organs / ingress
+
+Local service transitions become substrate traces.
+
+Examples:
+
+- biometrics sample observed;
+- cortex-exec step completed;
+- operator approval submitted;
+- SQL write failed;
+- bus channel violation observed;
+- dispatch candidate blocked;
+- feedback outcome captured.
+
+Primary implementation today:
+
+```text
+GrammarEventV1
+orion:grammar:event
+grammar_events
+```
+
+## Layer 2: Trace substrate
+
+Substrate trace events are persisted and made queryable.
+
+A useful trace includes:
+
+- stable trace id;
+- source service;
+- source node;
+- semantic role;
+- atom/edge;
+- event kind;
+- evidence refs;
+- temporal/causal links.
+
+## Layer 3: Reducers
+
+Reducers compile trace histories into durable state deltas and receipts.
+
+Primary artifacts:
+
+```text
+StateDeltaV1
+ReductionReceiptV1
+```
+
+Reducer questions:
+
+- Which trace roles matter?
+- What target kind is updated?
+- What target id is affected?
+- Is the operation create/update/noop?
+- What pressure hints or state changes are produced?
+- What evidence ids prove the reduction?
+
+## Layer 4: Field digestion
+
+State deltas perturb the field/lattice/tensor state.
+
+Primary artifact:
+
+```text
+FieldStateV1
+```
+
+Field digestion maps pressure hints onto nodes, capabilities, channels, and edges.
+
+Examples:
+
+```text
+execution_load -> execution_pressure
+failure_pressure -> reliability_pressure
+cpu_pressure -> resource pressure
+```
+
+## Layer 5: Attention
+
+Field state selects what matters now.
+
+Primary artifact:
+
+```text
+FieldAttentionFrameV1
+```
+
+Attention should preserve:
+
+- source field tick;
+- salient targets;
+- scores;
+- dominant channels;
+- evidence refs;
+- suggested observation mode.
+
+## Layer 6: Self-state
+
+Attention and field synthesize Orion's current operating condition.
+
+Primary artifact:
+
+```text
+SelfStateV1
+```
+
+Self-state should preserve:
+
+- source field tick;
+- source attention frame;
+- dimensions;
+- stabilizers;
+- unresolved pressures;
+- summary labels;
+- dominant targets.
+
+## Layer 7: Proposal
+
+Operating condition becomes possible actions.
+
+Primary artifact:
+
+```text
+ProposalFrameV1
+```
+
+Proposal is not action. It is action pressure made inspectable.
+
+## Layer 8: Policy
+
+Proposals are gated by risk, consent, reversibility, and scope.
+
+Primary artifact:
+
+```text
+PolicyDecisionFrameV1
+```
+
+Policy is not execution. It decides whether a proposal is approved read-only, requires operator review, is deferred, rejected, or approved for execution.
+
+## Layer 9: Dispatch
+
+Approved decisions become dry-run/prepared/dispatch envelopes.
+
+Primary artifact:
+
+```text
+ExecutionDispatchFrameV1
+```
+
+Default mode should be dry-run. Actual dispatch should route to cortex-orch first, not directly to cortex-exec, unless explicitly smoke-testing.
+
+## Layer 10: Feedback
+
+Consequences, failures, blocks, absences, and unchanged outcomes are captured.
+
+Primary artifact:
+
+```text
+FeedbackFrameV1
+```
+
+Feedback is not learning yet. It is consequence made observable.
+
+## Layer 11: Consolidation
+
+Repeated consequences become durable pattern structures.
+
+Primary artifacts may include:
+
+```text
+ConsolidationFrameV1
+MotifObservationV1
+ExpectationV1
+PriorCandidateV1
+SparseTensorSliceV1
+SchemaCandidateV1
+```
+
+Consolidation is repeated consequence becoming structure.
+
+## Decision checklist
+
+For a service transition, ask:
+
+1. Does it need a substrate trace?
+2. Does it need a reducer?
+3. Does it produce pressure/state deltas?
+4. Should it affect field state?
+5. Could attention care about it?
+6. Could self-state reflect it?
+7. Could it suggest proposals?
+8. Does it require policy?
+9. Could it dispatch?
+10. Does it have consequences or absence to capture?
+11. Could repeated occurrences form motifs or expectations?
+
+## Minimal path patterns
+
+### Telemetry organ
+
+```text
+Layer 1 trace -> Layer 3 reducer -> Layer 4 field -> Layers 5/6 -> maybe 11
+```
+
+### Runtime engine trace
+
+```text
+Layer 1 trace -> Layer 3 reducer -> Layer 4 field -> Layers 5/6/7/8/9/10 -> 11
+```
+
+### Operator approval
+
+```text
+Layer 1 trace -> Layer 8 policy/control evidence -> Layer 10 feedback -> Layer 11 consolidation
+```
+
+### Infrastructure anomaly
+
+```text
+Layer 1 trace -> Layer 3 reducer -> Layer 4 field pressure -> Layer 5 attention -> Layer 10/11
+```
+
+### Read-only UI endpoint
+
+```text
+No trace required by default.
+Optional trace only if inspection itself becomes substrate-relevant.
+```
+
+## Anti-patterns
+
+Avoid:
+
+- service emits raw payloads and calls it trace;
+- service emits traces but no reducer when field impact is expected;
+- typed frames without source ids;
+- policy/dispatch bypassing proposal and policy layers;
+- feedback that retries or mutates policy;
+- consolidation that silently changes behavior.

--- a/docs/context-engineering/05_reducer_and_state_delta_pattern.md
+++ b/docs/context-engineering/05_reducer_and_state_delta_pattern.md
@@ -1,0 +1,180 @@
+# Reducer and State Delta Pattern
+
+Reducers are Layer 3.
+
+They consume substrate trace histories and produce committed substrate state changes.
+
+## Primary artifacts
+
+```text
+StateDeltaV1
+ReductionReceiptV1
+```
+
+A reducer should answer:
+
+```text
+Given this trace history, what durable substrate state changed?
+```
+
+## Reducer responsibilities
+
+A reducer should:
+
+- fetch eligible trace events;
+- group events by trace id or target id;
+- validate expected semantic roles;
+- extract bounded state facts;
+- produce stable delta ids;
+- produce reduction receipts;
+- persist projection state if needed;
+- advance a cursor idempotently;
+- fail isolated from unrelated reducers.
+
+## Reducer non-goals
+
+Reducers should not:
+
+- call LLMs;
+- emit proposals;
+- execute actions;
+- mutate policy;
+- inspect raw private payloads;
+- read service-private internals;
+- produce untyped dict swamp.
+
+## Suggested files
+
+For shared reducer logic:
+
+```text
+orion/substrate/<domain>/
+  __init__.py
+  extract.py
+  reducer.py
+  pipeline.py
+```
+
+For runtime integration:
+
+```text
+services/orion-substrate-runtime/app/store.py
+services/orion-substrate-runtime/app/worker.py
+services/orion-substrate-runtime/app/settings.py
+```
+
+For persistence:
+
+```text
+services/orion-sql-db/manual_migration_<domain>_substrate_loop.sql
+```
+
+## Reducer inputs
+
+Reducers should read from substrate trace persistence, usually:
+
+```text
+grammar_events
+```
+
+The current schema uses `GrammarEventV1`; design docs should call these substrate trace events.
+
+## Reducer outputs
+
+A reducer emits receipts/deltas, usually persisted to:
+
+```text
+substrate_reduction_receipts
+```
+
+A reducer may also maintain a projection table, for example:
+
+```text
+substrate_execution_trajectory_projection
+```
+
+## Stable ids
+
+Delta ids should be deterministic when possible.
+
+Recommended preimage:
+
+```text
+<target_kind>:<target_id>:<operation>:<source_trace_id>:<source_event_ids_hash>
+```
+
+Receipt ids should also be deterministic when rerunning the same source window would otherwise duplicate work.
+
+## Pressure hints
+
+When a reducer output should affect field digestion, include bounded pressure hints.
+
+Example:
+
+```json
+{
+  "execution_load": 0.375,
+  "reasoning_load": 0.05,
+  "failure_pressure": 0.0,
+  "egress_confidence": 1.0,
+  "execution_friction": 0.0
+}
+```
+
+Pressure hints should be:
+
+- bounded where possible;
+- semantically named;
+- documented in field lattice/channel mapping;
+- stable enough for field digestion;
+- not raw service payloads.
+
+## Reducer tests
+
+Required tests:
+
+- schema roundtrip;
+- trace grouping;
+- extraction from valid trace roles;
+- ignored unknown/irrelevant roles;
+- stable delta ids;
+- idempotent pipeline;
+- cursor advancement;
+- projection persistence;
+- malformed trace handling;
+- no raw payload leakage.
+
+## Runtime tests
+
+If integrated into `orion-substrate-runtime`, test:
+
+- reducer tick is isolated from other ticks;
+- reducer disabled flag works;
+- missing tables produce clear errors;
+- reducer failure does not kill unrelated loops;
+- receipts are persisted;
+- cursor does not skip unprocessed events.
+
+## Field handoff
+
+If a reducer produces deltas for Layer 4, document:
+
+```text
+target_kind
+pressure_hints
+node_id/capability_id mapping
+field channel mapping
+expected perturbations
+```
+
+## Acceptance criteria
+
+A reducer is acceptable when:
+
+- it consumes substrate traces, not private service internals;
+- it emits `StateDeltaV1` / `ReductionReceiptV1`;
+- it is idempotent;
+- it preserves evidence refs;
+- it has isolated runtime failure behavior;
+- it documents whether field digestion is in scope;
+- it has live SQL proof queries.

--- a/docs/context-engineering/06_frame_runtime_pattern.md
+++ b/docs/context-engineering/06_frame_runtime_pattern.md
@@ -1,0 +1,164 @@
+# Frame Runtime Pattern
+
+Frame runtimes are substrate cognition layers.
+
+They consume prior substrate artifacts and emit typed compiled frames.
+
+Examples:
+
+```text
+FieldStateV1
+FieldAttentionFrameV1
+SelfStateV1
+ProposalFrameV1
+PolicyDecisionFrameV1
+ExecutionDispatchFrameV1
+FeedbackFrameV1
+ConsolidationFrameV1
+```
+
+## Core rule
+
+Typed frames are compiled artifacts. They are not a replacement for substrate traces.
+
+A frame runtime should persist the frame and, where useful, emit substrate traces describing the frame lifecycle and its causal lineage.
+
+## Frame runtime responsibilities
+
+A frame runtime should:
+
+- load latest eligible source artifacts;
+- avoid reprocessing the same source id/window;
+- build a deterministic typed frame;
+- preserve source ids and evidence refs;
+- persist the frame idempotently;
+- expose read-only debug/latest endpoint when useful;
+- include a smoke script and SQL proof query.
+
+## Frame runtime non-goals
+
+A frame runtime should not:
+
+- read private service internals;
+- call LLMs unless explicitly designed and schema-bounded;
+- execute actions unless it is the dispatch layer and policy allows it;
+- mutate policy/proposal weights;
+- hide source lineage;
+- emit opaque dict blobs.
+
+## Standard service layout
+
+```text
+services/orion-<frame>-runtime/
+  app/
+    __init__.py
+    main.py
+    settings.py
+    store.py
+    worker.py
+  Dockerfile
+  docker-compose.yml
+  requirements.txt
+  .env_example
+  README.md
+```
+
+## Standard shared package layout
+
+```text
+orion/<frame_domain>/
+  __init__.py
+  builder.py
+  policy.py
+  scoring.py
+  extractors.py
+```
+
+Not every domain needs every file.
+
+## Standard config
+
+```text
+config/<frame_domain>/<policy_or_config>.v1.yaml
+```
+
+The config should include:
+
+- schema version;
+- policy/config id;
+- thresholds;
+- limits;
+- scoring weights;
+- channel mappings;
+- redaction or exclusion rules where applicable.
+
+## Standard frame fields
+
+A typed frame should usually include:
+
+```text
+schema_version
+frame_id / self_state_id / artifact_id
+generated_at
+source_*_id fields
+policy_id / config_id
+scores or dimensions
+candidates / observations / decisions where applicable
+evidence_refs
+warnings
+```
+
+## Lifecycle traces
+
+If a frame runtime emits substrate traces, useful roles include:
+
+```text
+frame_build_started
+source_artifact_loaded
+source_artifact_missing
+candidate_emitted
+candidate_suppressed
+decision_emitted
+observation_emitted
+frame_persisted
+frame_build_failed
+```
+
+Do not emit full frame JSON into trace atoms. Emit frame ids and bounded summaries.
+
+## Idempotency
+
+Frame runtimes should be idempotent per source id/window.
+
+Examples:
+
+```text
+ProposalFrameV1: one frame per source SelfStateV1 and proposal policy id
+PolicyDecisionFrameV1: one frame per source ProposalFrameV1 and policy id
+ExecutionDispatchFrameV1: one frame per source PolicyDecisionFrameV1 and dispatch policy id
+FeedbackFrameV1: one frame per source ExecutionDispatchFrameV1 and feedback policy id
+ConsolidationFrameV1: one frame per time window and consolidation policy id
+```
+
+## Live proof shape
+
+Each frame runtime should have a smoke script that proves:
+
+1. source artifact exists;
+2. runtime container is running;
+3. destination table exists;
+4. latest frame row exists;
+5. critical fields have expected values;
+6. no disallowed side effects happened.
+
+## Acceptance criteria
+
+A frame runtime is acceptable when:
+
+- typed schema exists and validates;
+- config/policy loads;
+- builder is deterministic;
+- runtime persists idempotently;
+- source ids and evidence refs are present;
+- live smoke proves the chain;
+- no behavior mutation happens outside the layer's explicit responsibility.

--- a/docs/context-engineering/07_evidence_and_epistemic_classes.md
+++ b/docs/context-engineering/07_evidence_and_epistemic_classes.md
@@ -1,0 +1,174 @@
+# Evidence and Epistemic Classes
+
+Substrate traces and derived artifacts must preserve how we know what we claim.
+
+This guide borrows the evidence discipline from the architecture graph design.
+
+## Evidence classes
+
+### Observed
+
+Measured from runtime or captured traffic.
+
+Examples:
+
+- persisted trace event;
+- bus message observed;
+- SQL write succeeded;
+- policy frame row exists;
+- feedback frame captured dry-run outcome;
+- health check observed during a time window.
+
+Observed claims should include time window and source ids.
+
+### Declared
+
+Machine-parseable repository or config facts.
+
+Examples:
+
+- `docker-compose.yml` service definitions;
+- channel catalog entries;
+- `.env_example` keys;
+- schema definitions;
+- import/client references;
+- service port manifests.
+
+Declared claims are not proof of runtime behavior.
+
+### Documented
+
+Human-authored text in repo docs.
+
+Examples:
+
+- README descriptions;
+- design specs;
+- PR reports;
+- ARCH.md files.
+
+Documented claims may be stale and should carry source path and commit/ref.
+
+### Inferred
+
+Synthesized claims from interpretation.
+
+Examples:
+
+- “this service appears to be a control plane”;
+- “this route likely affects policy review”;
+- “these services are causally coupled.”
+
+Inferred claims must not be treated as Observed unless telemetry or persistence proves them.
+
+## Claim discipline
+
+Every substrate-relevant claim should be able to answer:
+
+```text
+What is claimed?
+How do we know?
+What evidence ids support it?
+What class of evidence is it?
+What time window applies?
+What uncertainty remains?
+```
+
+## Evidence refs
+
+Prefer stable refs:
+
+```text
+trace_id
+event_id
+frame_id
+receipt_id
+delta_id
+source_event_id
+correlation_id
+session_id
+artifact_id
+policy_id
+proposal_id
+decision_id
+dispatch_id
+feedback_frame_id
+git_path@git_ref
+otel_trace_id
+```
+
+## Substrate traces
+
+Trace atoms should include evidence refs rather than raw blobs.
+
+Example:
+
+```json
+{
+  "summary": "Policy decision requires operator review",
+  "proposal_id": "proposal:...",
+  "decision_id": "decision:...",
+  "evidence_refs": ["proposal.frame:...", "policy.frame:..."]
+}
+```
+
+## Typed frames
+
+Typed frames should carry source ids explicitly.
+
+Examples:
+
+```text
+source_self_state_id
+source_attention_frame_id
+source_field_tick_id
+source_proposal_frame_id
+source_policy_frame_id
+source_execution_dispatch_frame_id
+```
+
+## Reducers
+
+Reducers should preserve the trace ids/event ids that caused a delta.
+
+Reduction receipts should make it possible to audit:
+
+```text
+trace events -> extraction -> state delta -> receipt -> field perturbation
+```
+
+## Architecture claims
+
+If a context-engineering or meta-services agent writes architecture claims, it must classify them:
+
+```text
+Observed
+Declared
+Documented
+Inferred
+```
+
+Inferred claims should be quarantined or clearly marked when they lack observed/declared support.
+
+## Anti-patterns
+
+Avoid:
+
+- treating README prose as runtime truth;
+- treating compose dependencies as proof of traffic;
+- treating model interpretation as observed behavior;
+- emitting trace atoms with no evidence refs;
+- frames with no source ids;
+- pressure hints with no reduction receipt lineage;
+- policy decisions with no proposal source;
+- feedback with no dispatch source.
+
+## Acceptance criteria
+
+A service is evidence-disciplined when:
+
+- substrate traces include source/evidence refs;
+- typed frames include source ids;
+- reducers preserve trace-to-delta lineage;
+- docs distinguish observed, declared, documented, and inferred claims;
+- live proof commands produce observed evidence before declaring a layer live.

--- a/docs/context-engineering/08_testing_and_live_proof.md
+++ b/docs/context-engineering/08_testing_and_live_proof.md
@@ -1,0 +1,238 @@
+# Testing and Live Proof Guide
+
+This guide defines the minimum proof standard for substrate trace and Layer 1–11 work.
+
+A PR report should not say a layer is live unless there is observed proof from runtime tables, logs, or API responses.
+
+## Unit tests
+
+For substrate trace emission:
+
+```bash
+PYTHONPATH=. pytest services/<service>/tests/test_<service>_grammar_emit.py -q
+PYTHONPATH=. pytest services/<service>/tests/test_<service>_grammar_publish_fail_open.py -q
+```
+
+Required assertions:
+
+- events validate against `GrammarEventV1`;
+- only closed `GrammarEventKind` values are used;
+- only closed `RelationType` values are used;
+- semantic roles match the local trace map;
+- redaction rules are enforced;
+- publishing exceptions are fail-open;
+- disabled publishing is a no-op.
+
+## Reducer tests
+
+```bash
+PYTHONPATH=. pytest tests/test_<domain>_substrate_reducer.py -q
+PYTHONPATH=. pytest tests/test_<domain>_substrate_pipeline.py -q
+```
+
+Required assertions:
+
+- trace grouping works;
+- extraction works;
+- malformed events are handled;
+- stable delta ids are stable;
+- receipts persist;
+- cursor behavior is safe;
+- no raw payload leakage.
+
+## Frame runtime tests
+
+```bash
+PYTHONPATH=. pytest tests/test_<frame>_schemas.py -q
+PYTHONPATH=. pytest tests/test_<frame>_policy_loader.py -q
+PYTHONPATH=. pytest tests/test_<frame>_builder.py -q
+```
+
+Runtime services should also test store and worker behavior.
+
+## Compile check
+
+```bash
+PYTHONPATH=. python -m compileall \
+  orion/<domain> \
+  orion/schemas/<schema_file>.py \
+  services/<service> \
+  -q
+```
+
+## Live proof: Layer 1/2 traces
+
+```sql
+select
+    created_at
+  , source_service
+  , trace_id
+  , event_json::jsonb #>> '{atom,semantic_role}' as semantic_role
+  , event_json::jsonb #>> '{atom,summary}' as summary
+from grammar_events
+where source_service = '<service>'
+order by created_at desc
+limit 20;
+```
+
+## Live proof: Layer 3 reduction
+
+```sql
+select
+    created_at
+  , receipt_id
+  , delta_id
+  , target_kind
+  , target_id
+  , operation
+  , delta_json::jsonb #> '{pressure_hints}' as pressure_hints
+from substrate_reduction_receipts
+where target_kind = '<target_kind>'
+order by created_at desc
+limit 20;
+```
+
+## Live proof: Layer 4 field
+
+```sql
+select
+    generated_at
+  , field_json::jsonb -> 'nodes' as nodes
+  , field_json::jsonb -> 'capabilities' as capabilities
+  , field_json::jsonb -> 'recent_perturbations' as recent_perturbations
+from substrate_field_state
+order by generated_at desc
+limit 1;
+```
+
+## Live proof: Layer 5 attention
+
+```sql
+select
+    generated_at
+  , frame_id
+  , source_field_tick_id
+  , frame_json #>> '{overall_salience}' as overall_salience
+  , frame_json #> '{dominant_targets}' as dominant_targets
+from substrate_attention_frames
+order by generated_at desc
+limit 1;
+```
+
+## Live proof: Layer 6 self-state
+
+```sql
+select
+    generated_at
+  , self_state_id
+  , self_state_json #>> '{overall_condition}' as overall_condition
+  , self_state_json #>> '{overall_intensity}' as overall_intensity
+  , self_state_json #> '{summary_labels}' as summary_labels
+from substrate_self_state
+order by generated_at desc
+limit 1;
+```
+
+## Live proof: Layer 7 proposal
+
+```sql
+select
+    generated_at
+  , frame_id
+  , proposal_frame_json #>> '{overall_action_pressure}' as overall_action_pressure
+  , proposal_frame_json #>> '{policy_required}' as policy_required
+  , proposal_frame_json #> '{candidates}' as candidates
+from substrate_proposal_frames
+order by generated_at desc
+limit 1;
+```
+
+## Live proof: Layer 8 policy
+
+```sql
+select
+    generated_at
+  , frame_id
+  , policy_decision_frame_json #>> '{execution_allowed}' as execution_allowed
+  , policy_decision_frame_json #>> '{operator_review_required}' as operator_review_required
+  , jsonb_array_length(policy_decision_frame_json #> '{approved_decisions}') as approved_count
+  , jsonb_array_length(policy_decision_frame_json #> '{review_required_decisions}') as review_count
+from substrate_policy_decision_frames
+order by generated_at desc
+limit 1;
+```
+
+## Live proof: Layer 9 dispatch
+
+```sql
+select
+    generated_at
+  , frame_id
+  , dispatch_frame_json #>> '{dispatch_mode}' as dispatch_mode
+  , dispatch_frame_json #>> '{dispatch_attempted}' as dispatch_attempted
+  , dispatch_frame_json #>> '{dispatch_count}' as dispatch_count
+  , jsonb_array_length(dispatch_frame_json #> '{candidates}') as candidate_count
+  , jsonb_array_length(dispatch_frame_json #> '{blocked_candidates}') as blocked_count
+from substrate_execution_dispatch_frames
+order by generated_at desc
+limit 1;
+```
+
+## Live proof: Layer 10 feedback
+
+```sql
+select
+    generated_at
+  , frame_id
+  , feedback_frame_json #>> '{outcome_status}' as outcome_status
+  , feedback_frame_json #>> '{outcome_score}' as outcome_score
+  , jsonb_array_length(feedback_frame_json #> '{observations}') as observation_count
+  , feedback_frame_json #> '{absence_evidence}' as absence_evidence
+from substrate_feedback_frames
+order by generated_at desc
+limit 1;
+```
+
+## Live proof: Layer 11 consolidation
+
+```sql
+select
+    generated_at
+  , frame_id
+  , window_start
+  , window_end
+  , consolidation_frame_json #> '{dominant_motifs}' as dominant_motifs
+  , consolidation_frame_json #> '{motif_observations}' as motif_observations
+  , consolidation_frame_json #> '{source_counts}' as source_counts
+from substrate_consolidation_frames
+order by generated_at desc
+limit 1;
+```
+
+## PR report proof levels
+
+Use these labels:
+
+```text
+unit_tested
+integration_tested
+live_smoked
+observed_in_sql
+observed_in_hub
+not_verified_live
+```
+
+Do not claim `live` without observed runtime evidence.
+
+## Failure triage
+
+If a downstream table is empty, check in order:
+
+1. upstream source table has rows;
+2. runtime container exists;
+3. env flag is enabled;
+4. migration was applied;
+5. logs show save or failure;
+6. policy/config path exists inside container;
+7. source id has not already been processed idempotently;
+8. Hub route was rebuilt if API proof is expected.

--- a/docs/context-engineering/09_agent_handoff_template.md
+++ b/docs/context-engineering/09_agent_handoff_template.md
@@ -1,0 +1,115 @@
+# Agent Handoff Template Guide
+
+Use this when handing any service to an agent for substrate trace adoption.
+
+## Standard handoff
+
+```markdown
+# Service substrate trace adoption handoff
+
+## Target service
+
+`services/<service>`
+
+## Goal
+
+Implement service-owned substrate trace emission for substrate-relevant transitions in `<service>`, then document whether the service needs reducers, field digestion, typed frames, feedback, or consolidation.
+
+Do not create a central god emitter service.
+
+Use shared schema/helpers, but keep service-specific semantic mapping local.
+
+## Required reading
+
+Read:
+
+```text
+docs/context-engineering/README.md
+docs/context-engineering/00_substrate_trace_doctrine.md
+docs/context-engineering/01_service_taxonomy.md
+docs/context-engineering/03_substrate_trace_emitter_pattern.md
+docs/context-engineering/04_layer_1_to_11_pipeline.md
+services/<service>/AGENT_CONTEXT.md
+services/<service>/SERVICE_PORTS.yaml
+services/<service>/SUBSTRATE_TRACE_MAP.md
+services/<service>/LAYER_PIPELINE_PLAN.md
+```
+
+If service-local files are missing, create them from templates first.
+
+## Implementation requirements
+
+Add or update:
+
+```text
+services/<service>/app/grammar_emit.py
+services/<service>/app/grammar_publish.py
+services/<service>/tests/test_<service>_grammar_emit.py
+services/<service>/tests/test_<service>_grammar_publish_fail_open.py
+```
+
+Use `Substrate Trace` in docs and `GrammarEventV1` for the current implementation schema.
+
+## Semantic mapping
+
+Define local semantic roles based on service transitions, not function names.
+
+Required trace properties:
+
+```text
+trace_id
+event_id
+source_service
+source_node
+semantic_role
+source/evidence refs
+bounded summary
+no unsafe payloads
+```
+
+## Redaction
+
+Do not emit raw model prompts, raw completions, credential material, full blobs, full private payloads, or unbounded debug dumps. Use ids, refs, summaries, and redacted error classes.
+
+## Tests
+
+Run:
+
+```bash
+PYTHONPATH=. pytest services/<service>/tests/test_<service>_grammar_emit.py -q
+PYTHONPATH=. pytest services/<service>/tests/test_<service>_grammar_publish_fail_open.py -q
+```
+
+If a reducer/frame layer is added, run its tests too.
+
+## Live proof
+
+Provide at least one SQL query showing recent trace events from this service.
+
+If reducer/field/frame layers are implemented, provide proof at each layer.
+
+## PR report
+
+Include:
+
+- service ports touched;
+- role classification;
+- semantic roles emitted;
+- redaction guarantees;
+- tests run;
+- live smoke status;
+- downstream reducer/digester/frame follow-ups;
+- known gaps.
+```
+
+## Review checklist
+
+A reviewer should reject the PR if:
+
+- semantic roles are generic function names;
+- raw sensitive payloads are mirrored into trace events;
+- publisher failure can break service behavior;
+- service semantics are placed in a global god mapper;
+- trace events lack evidence refs;
+- README/AGENT_CONTEXT files are not updated;
+- downstream layer claims are made without proof.

--- a/docs/context-engineering/README.md
+++ b/docs/context-engineering/README.md
@@ -1,0 +1,132 @@
+# Context Engineering Pack: Substrate Trace Adoption
+
+This folder is the portable context pack for agents working in Orion services.
+
+Its purpose is to let an agent open a service folder, understand the service's substrate role, implement service-owned substrate trace emission, and reason about how that service's meaningful transitions move through Layers 1–11 of the Orion cognition substrate.
+
+## Core doctrine
+
+```text
+Native payloads are local.
+Substrate traces are shared.
+Typed frames are compiled artifacts.
+Every meaningful transition must be causally legible.
+```
+
+The current implementation schema for substrate trace events is `GrammarEventV1`. The design concept is **Substrate Trace**.
+
+Use the phrase **substrate trace** in design docs. Use `GrammarEventV1` when referring to the concrete schema/code that currently implements it.
+
+## Why this exists
+
+Earlier design work already pointed here:
+
+- The Organ Signal Gateway design defined common normalized signals, causal parents, dimensional representation, source event ids, and trace propagation.
+- The meta-services architecture graph design defined evidence classes: Observed, Declared, Documented, and Inferred.
+- The recent Layers 1–10 substrate work proved the pipeline: service traces → reducers → field → attention → self-state → proposal → policy → dispatch → feedback.
+
+This pack turns that into an agent-readable harness.
+
+## Read order for agents
+
+1. `00_substrate_trace_doctrine.md`
+2. `01_service_taxonomy.md`
+3. `02_service_port_manifest_spec.md`
+4. `03_substrate_trace_emitter_pattern.md`
+5. `04_layer_1_to_11_pipeline.md`
+6. `05_reducer_and_state_delta_pattern.md`
+7. `06_frame_runtime_pattern.md`
+8. `07_evidence_and_epistemic_classes.md`
+9. `08_testing_and_live_proof.md`
+10. `09_agent_handoff_template.md`
+
+Then read the service-local files:
+
+```text
+services/<service>/AGENT_CONTEXT.md
+services/<service>/SERVICE_PORTS.yaml
+services/<service>/SUBSTRATE_TRACE_MAP.md
+services/<service>/LAYER_PIPELINE_PLAN.md
+```
+
+If those files do not exist yet, use the templates under `docs/context-engineering/templates/` to create them.
+
+## What this pack is not
+
+This is not a central emitter service.
+
+Each service owns its own substrate trace emitter because the service owns the semantics of its meaningful transitions.
+
+Shared code may provide schemas, validators, publishing helpers, redaction helpers, and ID helpers. Shared code must not become a god mapper that decides what each service means.
+
+## Layer map
+
+```text
+1. Organs / ingress
+   local service transitions become substrate traces
+
+2. Trace substrate
+   GrammarEventV1 / substrate trace events are persisted
+
+3. Reducers
+   trace histories become StateDeltaV1 / ReductionReceiptV1
+
+4. Field digestion
+   state deltas perturb lattice/tensor field state
+
+5. Attention
+   field state selects what matters now
+
+6. Self-state
+   attention + field synthesize operating condition
+
+7. Proposal
+   operating condition becomes possible actions
+
+8. Policy
+   proposals are gated by risk/consent/scope
+
+9. Dispatch
+   approved decisions become dry-run/prepared/dispatch envelopes
+
+10. Feedback
+   consequences, failures, blocks, absences are captured
+
+11. Consolidation
+   repeated consequences become motifs, expectations, priors, sparse tensor slices, and schema candidates
+```
+
+## Service-level rule
+
+Do not ask, "Is this whole service grammar-worthy?"
+
+Ask:
+
+```text
+Which service ports produce substrate-relevant transitions?
+```
+
+For each port:
+
+```text
+What happened?
+Where did it happen?
+When did it happen?
+What did it derive from?
+What consequence did it produce?
+What evidence supports it?
+How should later layers consume it, if at all?
+```
+
+## Acceptance standard
+
+A service is substrate-trace ready when:
+
+- its service-local context files exist;
+- each meaningful port is classified;
+- trace emission is service-owned and fail-open;
+- raw payloads, secrets, prompts, completions, and blobs are not mirrored into traces;
+- all trace events validate against `GrammarEventV1`;
+- source ids, evidence refs, and lineage are present;
+- unit tests and live proof queries are documented;
+- downstream reducer/field/frame/consolidation needs are explicit.

--- a/docs/context-engineering/templates/AGENT_BUILD_PROMPT.md
+++ b/docs/context-engineering/templates/AGENT_BUILD_PROMPT.md
@@ -1,0 +1,87 @@
+# Agent Build Prompt: <service>
+
+## Target
+
+`services/<service>`
+
+## Goal
+
+Implement service-owned substrate trace emission for substrate-relevant transitions in `<service>`, then document the service's path through Layers 1–11.
+
+Do not create a central emitter service.
+
+Use shared schema/helpers, but keep service-specific semantic mapping local.
+
+## Required reading
+
+Read:
+
+```text
+docs/context-engineering/README.md
+docs/context-engineering/00_substrate_trace_doctrine.md
+docs/context-engineering/01_service_taxonomy.md
+docs/context-engineering/02_service_port_manifest_spec.md
+docs/context-engineering/03_substrate_trace_emitter_pattern.md
+docs/context-engineering/04_layer_1_to_11_pipeline.md
+docs/context-engineering/07_evidence_and_epistemic_classes.md
+services/<service>/AGENT_CONTEXT.md
+services/<service>/SERVICE_PORTS.yaml
+services/<service>/SUBSTRATE_TRACE_MAP.md
+services/<service>/LAYER_PIPELINE_PLAN.md
+```
+
+If service-local files are missing, create them from templates first.
+
+## Implementation requirements
+
+Add or update:
+
+```text
+services/<service>/app/grammar_emit.py
+services/<service>/app/grammar_publish.py
+services/<service>/tests/test_<service>_grammar_emit.py
+services/<service>/tests/test_<service>_grammar_publish_fail_open.py
+```
+
+Use `Substrate Trace` in docs and `GrammarEventV1` for the current implementation schema.
+
+## Rules
+
+- Builder must be pure.
+- Publisher must be fail-open.
+- Publishing must be env-flag controlled.
+- No raw model prompts or completions.
+- No credential material.
+- No large blobs.
+- No full private payload mirroring.
+- Use evidence refs and source ids.
+- Update channel catalog only if publishing is enabled.
+- Existing behavior must be unchanged when publishing is disabled.
+
+## Tests
+
+Run:
+
+```bash
+PYTHONPATH=. pytest services/<service>/tests/test_<service>_grammar_emit.py -q
+PYTHONPATH=. pytest services/<service>/tests/test_<service>_grammar_publish_fail_open.py -q
+```
+
+Add reducer/frame tests only if downstream layers are in this PR.
+
+## Live proof
+
+Provide SQL proof from `grammar_events`.
+
+If reducer/field/frame stages are implemented, provide proof at each layer.
+
+## PR report must include
+
+- service ports touched;
+- roles classified;
+- semantic roles emitted;
+- redaction guarantees;
+- tests run;
+- live smoke status;
+- downstream follow-ups;
+- known gaps.

--- a/docs/context-engineering/templates/LAYER_PIPELINE_PLAN.md
+++ b/docs/context-engineering/templates/LAYER_PIPELINE_PLAN.md
@@ -1,0 +1,142 @@
+# Layer Pipeline Plan: <service>
+
+## Goal
+
+Move `<service>` substrate-relevant transitions through the appropriate parts of the 1–11 substrate.
+
+## Layer 1: Service-owned substrate trace emission
+
+Status: planned / implemented / not applicable
+
+Files:
+
+```text
+services/<service>/app/grammar_emit.py
+services/<service>/app/grammar_publish.py
+```
+
+Semantic roles:
+
+- <role>
+
+## Layer 2: Trace substrate persistence
+
+Status: planned / implemented / not applicable
+
+Expected table:
+
+```text
+grammar_events
+```
+
+Proof query:
+
+```sql
+select * from grammar_events where source_service = '<service>' order by created_at desc limit 10;
+```
+
+## Layer 3: Reducer
+
+Needed? yes/no
+
+If yes:
+
+```text
+orion/substrate/<domain>/
+```
+
+Reducer output:
+
+```text
+StateDeltaV1
+ReductionReceiptV1
+```
+
+## Layer 4: Field digestion
+
+Needed? yes/no
+
+Pressure hints:
+
+```yaml
+example_pressure: 0.0
+```
+
+Field channels:
+
+```yaml
+example_pressure: example_field_channel
+```
+
+## Layer 5: Attention
+
+Does this service affect attention? yes/no
+
+Expected attention targets:
+
+- <target>
+
+## Layer 6: Self-state
+
+Does this service affect self-state? yes/no
+
+Expected dimensions or labels:
+
+- <dimension_or_label>
+
+## Layer 7: Proposal
+
+Could this service create proposal pressure? yes/no
+
+Expected proposal types:
+
+- <proposal>
+
+## Layer 8: Policy
+
+Does this service require policy gating? yes/no
+
+Policy gates:
+
+- read_only
+- operator_review
+- execution_policy
+
+## Layer 9: Dispatch
+
+Can this service be an effector or dispatch target? yes/no
+
+Default stance:
+
+```text
+dry_run unless explicitly approved
+```
+
+## Layer 10: Feedback
+
+What consequences or absences should be captured?
+
+- <feedback observation>
+
+## Layer 11: Consolidation
+
+What repeated patterns should become motifs or expectations?
+
+- <motif>
+
+## Out of scope
+
+- <explicit non-goal>
+
+## Live proof checklist
+
+- [ ] Layer 1 trace observed
+- [ ] Layer 3 receipt observed, if applicable
+- [ ] Layer 4 field perturbation observed, if applicable
+- [ ] Layer 5 attention observed, if applicable
+- [ ] Layer 6 self-state observed, if applicable
+- [ ] Layer 7 proposal observed, if applicable
+- [ ] Layer 8 policy decision observed, if applicable
+- [ ] Layer 9 dispatch frame observed, if applicable
+- [ ] Layer 10 feedback observed, if applicable
+- [ ] Layer 11 motif observed, if applicable

--- a/docs/context-engineering/templates/PR_REPORT_TEMPLATE.md
+++ b/docs/context-engineering/templates/PR_REPORT_TEMPLATE.md
@@ -1,0 +1,103 @@
+# PR Report: <service> substrate trace adoption
+
+## Branch
+
+`<branch>`
+
+## Summary
+
+Describe what changed in one paragraph.
+
+## Service role classification
+
+| Port | Role | Trace required | Notes |
+|---|---|---:|---|
+| <port> | <role> | yes/no | <notes> |
+
+## Semantic roles emitted
+
+| Semantic role | When emitted | Layer | Evidence refs |
+|---|---|---|---|
+| <role> | <condition> | <layer> | <refs> |
+
+## Architecture
+
+```text
+<service native transition>
+  -> substrate trace event (GrammarEventV1)
+  -> grammar_events
+  -> optional reducer
+  -> optional state delta / field / frame / feedback / consolidation
+```
+
+## Files changed
+
+| Path | Change |
+|---|---|
+| <path> | <change> |
+
+## Redaction guarantees
+
+This PR does not emit:
+
+- raw model prompts;
+- raw model completions;
+- credential material;
+- full payload blobs;
+- full private payloads;
+- database connection material.
+
+It emits ids, refs, bounded summaries, and redacted error classes.
+
+## Tests
+
+```bash
+<commands>
+```
+
+Results:
+
+```text
+<results>
+```
+
+## Live proof
+
+SQL/API/log proof:
+
+```text
+<proof>
+```
+
+Status:
+
+```text
+unit_tested / integration_tested / live_smoked / observed_in_sql / observed_in_hub / not_verified_live
+```
+
+## Downstream stages
+
+| Layer | Status | Notes |
+|---|---|---|
+| 1 Trace emission | implemented/planned/not applicable | |
+| 2 Trace persistence | implemented/planned/not applicable | |
+| 3 Reducer | implemented/planned/not applicable | |
+| 4 Field digestion | implemented/planned/not applicable | |
+| 5 Attention | implemented/planned/not applicable | |
+| 6 Self-state | implemented/planned/not applicable | |
+| 7 Proposal | implemented/planned/not applicable | |
+| 8 Policy | implemented/planned/not applicable | |
+| 9 Dispatch | implemented/planned/not applicable | |
+| 10 Feedback | implemented/planned/not applicable | |
+| 11 Consolidation | implemented/planned/not applicable | |
+
+## Known gaps / follow-ups
+
+- <gap>
+
+## Non-goals respected
+
+- No central emitter service.
+- No behavior change when publishing disabled.
+- No raw payload mirroring.
+- No downstream mutation unless explicitly implemented and tested.

--- a/docs/context-engineering/templates/SERVICE_CONTEXT.md
+++ b/docs/context-engineering/templates/SERVICE_CONTEXT.md
@@ -1,0 +1,92 @@
+# Agent Context: <service>
+
+## Service purpose
+
+Describe what this service does in one factual paragraph.
+
+## Primary roles
+
+List port-level roles used by this service.
+
+```text
+organ_ingress
+reducer
+substrate_frame_runtime
+transport_infrastructure
+persistence_infrastructure
+operator_read_surface
+operator_ingress
+runtime_engine
+model_host
+external_gateway
+effector
+control_plane
+```
+
+## Native contracts
+
+- HTTP:
+- WebSocket:
+- Bus:
+- SQL:
+- Files:
+- External APIs:
+- Models:
+- Worker ticks:
+
+## Substrate trace responsibility
+
+This service should emit substrate traces for meaningful transitions, not every internal operation.
+
+Design concept: `Substrate Trace`
+
+Current implementation schema: `GrammarEventV1`
+
+## Substrate-relevant transitions
+
+- <transition 1>
+- <transition 2>
+- <transition 3>
+
+## What must never be emitted
+
+- raw model prompts
+- raw model completions
+- credential material
+- large blobs
+- full private payloads unless explicitly approved
+- database connection material
+- unbounded debug dumps
+
+## Layer path
+
+| Layer | Applies? | Notes |
+|---|---:|---|
+| 1 Organs / ingress | no | |
+| 2 Trace substrate | no | |
+| 3 Reducer | no | |
+| 4 Field digestion | no | |
+| 5 Attention | no | |
+| 6 Self-state | no | |
+| 7 Proposal | no | |
+| 8 Policy | no | |
+| 9 Dispatch | no | |
+| 10 Feedback | no | |
+| 11 Consolidation | no | |
+
+## Evidence refs
+
+Expected refs:
+
+- correlation_id
+- source_event_id
+- trace_id
+- event_id
+- frame_id
+- receipt_id
+- delta_id
+
+## Open questions
+
+- <question 1>
+- <question 2>

--- a/docs/context-engineering/templates/SERVICE_PORTS.yaml
+++ b/docs/context-engineering/templates/SERVICE_PORTS.yaml
@@ -1,0 +1,22 @@
+service: <service>
+status: draft
+
+ports:
+  - name: <port_name>
+    role: <organ_ingress|reducer|substrate_frame_runtime|transport_infrastructure|persistence_infrastructure|operator_read_surface|operator_ingress|runtime_engine|model_host|external_gateway|effector|control_plane>
+    native_contract: <http_json|websocket_json|redis_channel|sql_table|file|model_api|audio_stream|internal_worker_tick>
+    substrate_trace_required: true
+    trace_roles:
+      - <semantic_role_1>
+      - <semantic_role_2>
+    downstream_layers: [1, 2]
+    evidence_refs:
+      - correlation_id
+      - source_event_id
+    redaction:
+      never_emit:
+        - raw_model_prompt
+        - raw_model_completion
+        - credential_material
+        - full_payload_blob
+    notes: <brief notes>

--- a/docs/context-engineering/templates/SUBSTRATE_TRACE_MAP.md
+++ b/docs/context-engineering/templates/SUBSTRATE_TRACE_MAP.md
@@ -1,0 +1,100 @@
+# Substrate Trace Map: <service>
+
+## Trace id format
+
+```text
+<service-short>:<node-id>:<correlation-or-artifact-id>
+```
+
+## Semantic roles
+
+| Role | When emitted | Atom type | Layer | Evidence refs |
+|---|---|---|---|---|
+| <role> | <condition> | observation | 1/2 | correlation_id |
+
+## Trace lifecycle
+
+```text
+trace_started
+  atom_emitted
+  edge_emitted
+  atom_emitted
+trace_ended
+```
+
+## Atoms
+
+Describe bounded atom summaries and safe metadata.
+
+| Role | Summary pattern | Metadata |
+|---|---|---|
+| <role> | <summary> | <safe keys> |
+
+## Edges
+
+Describe lineage/provenance edges.
+
+| From | Relation | To |
+|---|---|---|
+| <atom id> | derived_from | <source artifact id> |
+
+Use closed `RelationType` values only unless the enum is deliberately extended.
+
+## Redaction rules
+
+Never emit:
+
+- raw model prompts
+- raw model completions
+- credential material
+- full payload blobs
+- full private text unless explicitly allowed
+- database connection material
+- unbounded debug dumps
+
+Emit references instead:
+
+- payload_ref
+- artifact_id
+- event_id
+- trace_id
+- frame_id
+- receipt_id
+- delta_id
+- correlation_id
+- session_id
+
+## Publishing
+
+Env flags:
+
+```text
+PUBLISH_<SERVICE>_GRAMMAR=false
+GRAMMAR_EVENT_CHANNEL=orion:grammar:event
+```
+
+Publishing must be fail-open.
+
+## Tests
+
+Expected tests:
+
+```text
+services/<service>/tests/test_<service>_grammar_emit.py
+services/<service>/tests/test_<service>_grammar_publish_fail_open.py
+```
+
+## Live proof query
+
+```sql
+select
+    created_at
+  , source_service
+  , trace_id
+  , event_json::jsonb #>> '{atom,semantic_role}' as semantic_role
+  , event_json::jsonb #>> '{atom,summary}' as summary
+from grammar_events
+where source_service = '<service>'
+order by created_at desc
+limit 20;
+```


### PR DESCRIPTION
## Summary

Adds a repo-level context engineering pack for service-owned substrate trace adoption.

This centers the design language around **Substrate Trace** while preserving `GrammarEventV1` as the current implementation schema.

## What changed

- Adds `docs/context-engineering/README.md`
- Adds doctrine, taxonomy, service port manifest spec, emitter pattern, Layer 1–11 pipeline, reducer/frame-runtime patterns, evidence discipline, live proof guide, and handoff guide
- Adds templates for per-service context packs:
  - `SERVICE_CONTEXT.md`
  - `SERVICE_PORTS.yaml`
  - `SUBSTRATE_TRACE_MAP.md`
  - `LAYER_PIPELINE_PLAN.md`
  - `AGENT_BUILD_PROMPT.md`
  - `PR_REPORT_TEMPLATE.md`

## Design center

```text
Native payloads are local.
Substrate traces are shared.
Typed frames are compiled artifacts.
Every meaningful transition must be causally legible.
```

## Non-goals

- No code behavior changes
- No central emitter service
- No schema rename from `GrammarEventV1`
- No service-specific emitters added yet

## Validation

Docs-only change. Compared branch against `main`; 17 new files under `docs/context-engineering/`.