### PR TITLE
Feat/consolidation frame v1

### DIFF
--- a/config/consolidation/consolidation_policy.v1.yaml
+++ b/config/consolidation/consolidation_policy.v1.yaml
@@ -81,3 +81,23 @@ motif_rules:
       self_state_delta:
         allowed:
           - unchanged
+
+tensor:
+  enabled: true
+  max_coordinates: 200
+
+tensor_axes:
+  field_attention_self:
+    - time_bucket
+    - self_condition
+    - attention_target
+    - dimension
+  policy_dispatch_feedback:
+    - proposal_kind
+    - policy_decision
+    - dispatch_status
+    - feedback_outcome
+  motif_condition_outcome:
+    - motif
+    - self_condition
+    - outcome_status

--- a/config/consolidation/consolidation_policy.v1.yaml
+++ b/config/consolidation/consolidation_policy.v1.yaml
@@ -1,0 +1,83 @@
+schema_version: consolidation_policy.v1
+policy_id: consolidation_policy.v1
+
+window:
+  lookback_minutes: 60
+  min_support_count: 3
+  max_frames_per_source: 500
+
+motif_thresholds:
+  min_support_score: 0.20
+  min_confidence_score: 0.30
+  dominant_motif_min_support: 0.50
+
+tracked_self_dimensions:
+  - field_intensity
+  - execution_pressure
+  - reasoning_pressure
+  - resource_pressure
+  - reliability_pressure
+  - agency_readiness
+  - uncertainty
+  - coherence
+
+tracked_attention_targets:
+  - node:athena
+  - capability:orchestration
+  - capability:graph
+  - field:recent_perturbations
+
+tracked_feedback_outcomes:
+  - dry_run_only
+  - prepared_only
+  - completed
+  - failed
+  - blocked
+  - absent
+  - deferred
+  - mixed
+
+motif_rules:
+  loaded_but_reliable:
+    kind: self_state_pattern
+    label: loaded_but_reliable
+    conditions:
+      overall_condition: loaded
+      reliability_pressure_max: 0.30
+      execution_pressure_min: 0.70
+
+  attention_saturated_execution:
+    kind: attention_pattern
+    label: attention_saturated_execution
+    conditions:
+      attention_target_any:
+        - node:athena
+        - capability:orchestration
+      min_overall_salience: 0.70
+
+  read_only_policy_loop:
+    kind: proposal_policy_pattern
+    label: read_only_policy_loop
+    conditions:
+      approved_read_only_min: 1
+
+  dry_run_feedback_loop:
+    kind: dispatch_feedback_pattern
+    label: dry_run_feedback_loop
+    conditions:
+      outcome_status: dry_run_only
+
+  blocked_review_loop:
+    kind: dispatch_feedback_pattern
+    label: blocked_review_loop
+    conditions:
+      blocked_or_review_min: 1
+
+  stable_after_dry_run:
+    kind: stability_pattern
+    label: stable_after_dry_run
+    conditions:
+      outcome_status: dry_run_only
+      self_state_delta:
+        allowed:
+          - unchanged

--- a/docs/superpowers/plans/2026-05-25-consolidation-frame-v1.md
+++ b/docs/superpowers/plans/2026-05-25-consolidation-frame-v1.md
@@ -1,0 +1,1500 @@
+# Consolidation Frame v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Layer 11 — deterministic consolidation over Layers 5–10 substrate history: motifs (11a), expectations (11b), sparse tensor slices (11c), schema candidates (11d), read-only Hub surfaces (11e). No learning, no policy mutation, no bus publish, no LLM.
+
+**Architecture:** Schemas in `orion/schemas/consolidation_frame.py`; pure logic in `orion/consolidation/`; polling service `orion-consolidation-runtime` idempotent per consolidation window; read-only Hub routes in Phase 11e. Config from `config/consolidation/consolidation_policy.v1.yaml`. **Distinct from** `orion/substrate/consolidation.py` (graph-region consolidation — do not modify).
+
+**Tech Stack:** Python 3.12, Pydantic v2, PyYAML, SQLAlchemy, psycopg2, FastAPI/uvicorn, pytest, Postgres.
+
+**Depends on:** Layer 10 on `main` (`FeedbackFrameV1`, `substrate_feedback_frames`, port 8122). Layers 5–9 on `main` (`FieldAttentionFrameV1`, `SelfStateV1`, `ProposalFrameV1`, `PolicyDecisionFrameV1`, `ExecutionDispatchFrameV1` and their `substrate_*` tables).
+
+**Non-goals:** Policy/proposal/attention weight mutation, habit execution, RDF writes, cortex steering, bus publish, LLM prose, neural tensor training, automatic schema promotion.
+
+---
+
+## Worktree and branch hygiene
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+git fetch origin main
+git worktree add .worktrees/feat-consolidation-frame-v1 -b feat/consolidation-frame-v1 origin/main
+cd .worktrees/feat-consolidation-frame-v1
+```
+
+**Rules:**
+
+- All implementation commits happen only inside `.worktrees/feat-consolidation-frame-v1`.
+- Do **not** copy changed files back to the main workspace checkout except syncing `services/orion-consolidation-runtime/.env` from `.env_example` on the operator machine (`.env` is gitignored).
+- **Port:** `8123` (`CONSOLIDATION_RUNTIME_PORT`).
+- **Bus:** Register schemas in `orion/schemas/registry.py` only. **Do not** add `orion/bus/channels.yaml` entries — consolidation runtime does not publish (matches Layers 8–10).
+- After all tasks: run **requesting-code-review** skill via subagent, fix findings, write `docs/superpowers/pr-reports/2026-05-25-consolidation-frame-v1-pr.md`, push branch, `gh pr create`.
+
+---
+
+## File structure
+
+| Path | Role |
+|------|------|
+| `orion/schemas/consolidation_frame.py` | `MotifObservationV1`, `ExpectationV1`, `SparseTensorSliceV1`, `SchemaCandidateV1`, `ConsolidationFrameV1` |
+| `orion/schemas/registry.py` | Register consolidation schema types |
+| `config/consolidation/consolidation_policy.v1.yaml` | Window, thresholds, motif rules, tensor axes |
+| `orion/consolidation/__init__.py` | Package exports |
+| `orion/consolidation/policy.py` | YAML loader + `ConsolidationPolicyV1` |
+| `orion/consolidation/windows.py` | Window bounds + `ConsolidationWindowData` |
+| `orion/consolidation/motif.py` | Deterministic motif detectors |
+| `orion/consolidation/expectation.py` | Motif → expectation mapping (11b) |
+| `orion/consolidation/tensorize.py` | Sparse tensor slices (11c) |
+| `orion/consolidation/schema_candidates.py` | Schema candidates (11d) |
+| `orion/consolidation/builder.py` | `build_consolidation_frame` |
+| `orion/consolidation/repository.py` | Read-only DB helpers (11e) |
+| `services/orion-sql-db/manual_migration_consolidation_v1.sql` | Frames table (11a) |
+| `services/orion-sql-db/manual_migration_consolidation_expectations_v1.sql` | Expectations table (11b) |
+| `services/orion-sql-db/manual_migration_consolidation_tensor_slices_v1.sql` | Tensor slices table (11c) |
+| `services/orion-sql-db/manual_migration_consolidation_schema_candidates_v1.sql` | Schema candidates table (11d) |
+| `services/orion-consolidation-runtime/` | Polling runtime (mirror `orion-feedback-runtime`) |
+| `services/orion-hub/scripts/substrate_consolidation_routes.py` | Read-only debug API (11e) |
+| `services/orion-hub/scripts/api_routes.py` | Include consolidation router |
+| `scripts/smoke_consolidation_v1.sh` | Live SQL smoke |
+| `tests/test_consolidation_*.py` | Unit tests per phase |
+| `docs/superpowers/pr-reports/2026-05-25-consolidation-frame-v1-pr.md` | PR report (post-implementation) |
+
+---
+
+## Phase 11a — Motif observations
+
+### Task 1: Consolidation schemas + registry
+
+**Files:**
+
+- Create: `orion/schemas/consolidation_frame.py`
+- Modify: `orion/schemas/registry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_consolidation_frame_schemas.py`:
+
+```python
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, MotifObservationV1
+
+NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
+
+
+def test_motif_observation_validates() -> None:
+    motif = MotifObservationV1(
+        motif_id="motif:loaded_but_reliable:consolidation_policy.v1",
+        motif_kind="self_state_pattern",
+        label="loaded_but_reliable",
+        recurrence_count=3,
+        support_score=0.6,
+        confidence_score=0.7,
+        evidence_frame_ids=["self.state:s1"],
+    )
+    assert motif.motif_kind == "self_state_pattern"
+
+
+def test_consolidation_frame_validates() -> None:
+    frame = ConsolidationFrameV1(
+        frame_id="consolidation.frame:2026-05-25T14:30:00+00:00:2026-05-25T15:30:00+00:00:consolidation_policy.v1",
+        generated_at=NOW,
+        window_start=datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc),
+        window_end=NOW,
+        motif_observations=[
+            MotifObservationV1(
+                motif_id="motif:loaded_but_reliable:consolidation_policy.v1",
+                motif_kind="self_state_pattern",
+                label="loaded_but_reliable",
+                recurrence_count=3,
+                support_score=0.6,
+                confidence_score=0.7,
+            )
+        ],
+    )
+    assert frame.schema_version == "consolidation.frame.v1"
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        MotifObservationV1(
+            motif_id="m1",
+            motif_kind="self_state_pattern",
+            label="x",
+            recurrence_count=1,
+            support_score=0.5,
+            confidence_score=0.5,
+            extra_field=True,
+        )
+
+
+def test_recurrence_count_min_one() -> None:
+    with pytest.raises(ValidationError):
+        MotifObservationV1(
+            motif_id="m1",
+            motif_kind="self_state_pattern",
+            label="x",
+            recurrence_count=0,
+            support_score=0.5,
+            confidence_score=0.5,
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_frame_schemas.py -v`
+
+Expected: FAIL — `ModuleNotFoundError: orion.schemas.consolidation_frame`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `orion/schemas/consolidation_frame.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MotifObservationV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    motif_id: str
+
+    motif_kind: Literal[
+        "field_pattern",
+        "attention_pattern",
+        "self_state_pattern",
+        "proposal_policy_pattern",
+        "dispatch_feedback_pattern",
+        "absence_pattern",
+        "stability_pattern",
+    ]
+
+    label: str
+
+    recurrence_count: int = Field(ge=1)
+    support_score: float = Field(ge=0.0, le=1.0)
+    confidence_score: float = Field(ge=0.0, le=1.0)
+
+    evidence_frame_ids: list[str] = Field(default_factory=list)
+    dominant_dimensions: dict[str, float] = Field(default_factory=dict)
+    dominant_channels: dict[str, float] = Field(default_factory=dict)
+
+    first_seen_at: datetime | None = None
+    last_seen_at: datetime | None = None
+
+    reasons: list[str] = Field(default_factory=list)
+
+
+class ConsolidationFrameV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["consolidation.frame.v1"] = "consolidation.frame.v1"
+
+    frame_id: str
+    generated_at: datetime
+
+    window_start: datetime
+    window_end: datetime
+
+    consolidation_policy_id: str = "consolidation_policy.v1"
+
+    motif_observations: list[MotifObservationV1] = Field(default_factory=list)
+    dominant_motifs: list[str] = Field(default_factory=list)
+
+    source_counts: dict[str, int] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+```
+
+Register in `orion/schemas/registry.py`:
+
+```python
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, MotifObservationV1
+```
+
+Add to `_REGISTRY`:
+
+```python
+    "ConsolidationFrameV1": ConsolidationFrameV1,
+    "MotifObservationV1": MotifObservationV1,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_frame_schemas.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/schemas/consolidation_frame.py orion/schemas/registry.py tests/test_consolidation_frame_schemas.py
+git commit -m "feat(consolidation): add ConsolidationFrameV1 schemas and registry"
+```
+
+---
+
+### Task 2: Consolidation policy config + loader
+
+**Files:**
+
+- Create: `config/consolidation/consolidation_policy.v1.yaml`
+- Create: `orion/consolidation/__init__.py`
+- Create: `orion/consolidation/policy.py`
+- Test: `tests/test_consolidation_policy_loader.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_consolidation_policy_loader.py`:
+
+```python
+from pathlib import Path
+
+from orion.consolidation.policy import ConsolidationPolicyV1, load_consolidation_policy
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO / "config" / "consolidation" / "consolidation_policy.v1.yaml"
+
+
+def test_loads_yaml() -> None:
+    policy = load_consolidation_policy(POLICY_PATH)
+    assert policy.schema_version == "consolidation_policy.v1"
+    assert policy.policy_id == "consolidation_policy.v1"
+
+
+def test_window_config() -> None:
+    policy = load_consolidation_policy(POLICY_PATH)
+    assert policy.window.lookback_minutes == 60
+    assert policy.window.min_support_count == 3
+
+
+def test_motif_rules_present() -> None:
+    policy = load_consolidation_policy(POLICY_PATH)
+    labels = {r.label for r in policy.motif_rules}
+    assert "loaded_but_reliable" in labels
+    assert "dry_run_feedback_loop" in labels
+    assert "stable_after_dry_run" in labels
+
+
+def test_tracked_dimensions() -> None:
+    policy = load_consolidation_policy(POLICY_PATH)
+    assert "execution_pressure" in policy.tracked_self_dimensions
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_policy_loader.py -v`
+
+Expected: FAIL — module/config missing
+
+- [ ] **Step 3: Write minimal implementation**
+
+`config/consolidation/consolidation_policy.v1.yaml`:
+
+```yaml
+schema_version: consolidation_policy.v1
+policy_id: consolidation_policy.v1
+
+window:
+  lookback_minutes: 60
+  min_support_count: 3
+  max_frames_per_source: 500
+
+motif_thresholds:
+  min_support_score: 0.20
+  min_confidence_score: 0.30
+  dominant_motif_min_support: 0.50
+
+tracked_self_dimensions:
+  - field_intensity
+  - execution_pressure
+  - reasoning_pressure
+  - resource_pressure
+  - reliability_pressure
+  - agency_readiness
+  - uncertainty
+  - coherence
+
+tracked_attention_targets:
+  - node:athena
+  - capability:orchestration
+  - capability:graph
+  - field:recent_perturbations
+
+tracked_feedback_outcomes:
+  - dry_run_only
+  - prepared_only
+  - completed
+  - failed
+  - blocked
+  - absent
+  - deferred
+  - mixed
+
+motif_rules:
+  loaded_but_reliable:
+    kind: self_state_pattern
+    label: loaded_but_reliable
+    conditions:
+      overall_condition: loaded
+      reliability_pressure_max: 0.30
+      execution_pressure_min: 0.70
+
+  attention_saturated_execution:
+    kind: attention_pattern
+    label: attention_saturated_execution
+    conditions:
+      attention_target_any:
+        - node:athena
+        - capability:orchestration
+      min_overall_salience: 0.70
+
+  read_only_policy_loop:
+    kind: proposal_policy_pattern
+    label: read_only_policy_loop
+    conditions:
+      approved_read_only_min: 1
+
+  dry_run_feedback_loop:
+    kind: dispatch_feedback_pattern
+    label: dry_run_feedback_loop
+    conditions:
+      outcome_status: dry_run_only
+
+  blocked_review_loop:
+    kind: dispatch_feedback_pattern
+    label: blocked_review_loop
+    conditions:
+      blocked_or_review_min: 1
+
+  stable_after_dry_run:
+    kind: stability_pattern
+    label: stable_after_dry_run
+    conditions:
+      outcome_status: dry_run_only
+      self_state_delta:
+        allowed:
+          - unchanged
+```
+
+`orion/consolidation/policy.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConsolidationWindowConfigV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lookback_minutes: int = 60
+    min_support_count: int = 3
+    max_frames_per_source: int = 500
+
+
+class MotifThresholdsV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    min_support_score: float = 0.20
+    min_confidence_score: float = 0.30
+    dominant_motif_min_support: float = 0.50
+
+
+class MotifRuleV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal[
+        "field_pattern",
+        "attention_pattern",
+        "self_state_pattern",
+        "proposal_policy_pattern",
+        "dispatch_feedback_pattern",
+        "absence_pattern",
+        "stability_pattern",
+    ]
+    label: str
+    conditions: dict[str, Any] = Field(default_factory=dict)
+
+
+class ConsolidationPolicyV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["consolidation_policy.v1"] = "consolidation_policy.v1"
+    policy_id: str = "consolidation_policy.v1"
+
+    window: ConsolidationWindowConfigV1 = Field(default_factory=ConsolidationWindowConfigV1)
+    motif_thresholds: MotifThresholdsV1 = Field(default_factory=MotifThresholdsV1)
+
+    tracked_self_dimensions: list[str] = Field(default_factory=list)
+    tracked_attention_targets: list[str] = Field(default_factory=list)
+    tracked_feedback_outcomes: list[str] = Field(default_factory=list)
+
+    motif_rules: dict[str, MotifRuleV1] = Field(default_factory=dict)
+
+
+def load_consolidation_policy(path: str | Path) -> ConsolidationPolicyV1:
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    raw_rules = data.pop("motif_rules", {}) or {}
+    rules = {key: MotifRuleV1.model_validate(val) for key, val in raw_rules.items()}
+    base = ConsolidationPolicyV1.model_validate(data)
+    return base.model_copy(update={"motif_rules": rules})
+```
+
+`orion/consolidation/__init__.py`:
+
+```python
+from orion.consolidation.policy import ConsolidationPolicyV1, load_consolidation_policy
+
+__all__ = ["ConsolidationPolicyV1", "load_consolidation_policy"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_policy_loader.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config/consolidation/consolidation_policy.v1.yaml orion/consolidation/ tests/test_consolidation_policy_loader.py
+git commit -m "feat(consolidation): add consolidation policy config and loader"
+```
+
+---
+
+### Task 3: Window computation + `ConsolidationWindowData`
+
+**Files:**
+
+- Create: `orion/consolidation/windows.py`
+- Test: extend `tests/test_consolidation_builder.py` (stub file created in Task 5) or add `tests/test_consolidation_windows.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_consolidation_windows.py`:
+
+```python
+from datetime import datetime, timedelta, timezone
+
+from orion.consolidation.windows import compute_consolidation_window, stable_consolidation_frame_id
+
+NOW = datetime(2026, 5, 25, 15, 37, tzinfo=timezone.utc)
+
+
+def test_window_lookback_60_minutes() -> None:
+    start, end = compute_consolidation_window(now=NOW, lookback_minutes=60)
+    assert end == NOW
+    assert start == NOW - timedelta(minutes=60)
+
+
+def test_stable_frame_id() -> None:
+    start = datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
+    fid = stable_consolidation_frame_id(
+        window_start=start,
+        window_end=end,
+        policy_id="consolidation_policy.v1",
+    )
+    assert fid == "consolidation.frame:2026-05-25T14:30:00+00:00:2026-05-25T15:30:00+00:00:consolidation_policy.v1"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_windows.py -v`
+
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`orion/consolidation/windows.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
+from orion.schemas.proposal_frame import ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+
+@dataclass(frozen=True)
+class ConsolidationWindowData:
+    window_start: datetime
+    window_end: datetime
+    self_states: list[SelfStateV1]
+    attention_frames: list[FieldAttentionFrameV1]
+    proposal_frames: list[ProposalFrameV1]
+    policy_frames: list[PolicyDecisionFrameV1]
+    dispatch_frames: list[ExecutionDispatchFrameV1]
+    feedback_frames: list[FeedbackFrameV1]
+
+
+def compute_consolidation_window(
+    *,
+    now: datetime | None = None,
+    lookback_minutes: int,
+) -> tuple[datetime, datetime]:
+    end = now or datetime.now(timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+    start = end - timedelta(minutes=lookback_minutes)
+    return start, end
+
+
+def stable_consolidation_frame_id(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    policy_id: str,
+) -> str:
+    ws = window_start.astimezone(timezone.utc).isoformat()
+    we = window_end.astimezone(timezone.utc).isoformat()
+    return f"consolidation.frame:{ws}:{we}:{policy_id}"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_windows.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/consolidation/windows.py tests/test_consolidation_windows.py
+git commit -m "feat(consolidation): add window bounds and stable frame id"
+```
+
+---
+
+### Task 4: Motif detection
+
+**Files:**
+
+- Create: `orion/consolidation/motif.py`
+- Test: `tests/test_consolidation_motif_detection.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_consolidation_motif_detection.py` with fixtures building minimal `SelfStateV1`, `FieldAttentionFrameV1`, `PolicyDecisionFrameV1`, `FeedbackFrameV1` lists (mirror patterns from `tests/test_feedback_builder.py`). Required tests:
+
+```python
+# test_loaded_but_reliable_detected — 3+ self states: loaded, execution_pressure>=0.7, reliability_pressure<=0.3
+# test_attention_saturated_execution_detected — attention overall_salience>=0.7 + node:athena target
+# test_read_only_policy_loop_detected — policy frame approved_read_only + execution_allowed false
+# test_dry_run_feedback_loop_detected — feedback outcome_status dry_run_only x3
+# test_blocked_review_loop_detected — policy operator_review_required true
+# test_stable_after_dry_run_detected — dry_run_only + unchanged self_state_delta obs + empty absence/negative
+# test_motif_scores_and_evidence — recurrence_count, support_score, confidence_score, evidence_frame_ids populated
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_motif_detection.py -v`
+
+Expected: FAIL — `motif` module missing
+
+- [ ] **Step 3: Write minimal implementation**
+
+`orion/consolidation/motif.py` — core helpers and detectors:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.consolidation.policy import ConsolidationPolicyV1, MotifRuleV1
+from orion.consolidation.windows import ConsolidationWindowData
+from orion.schemas.consolidation_frame import MotifObservationV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+
+def _dim_score(state: SelfStateV1, dimension_id: str) -> float:
+    dim = state.dimensions.get(dimension_id)
+    return float(dim.score) if dim is not None else 0.0
+
+
+def _motif_id(label: str, policy_id: str) -> str:
+    return f"motif:{label}:{policy_id}"
+
+
+def _score_motif(*, match_count: int, total: int, policy: ConsolidationPolicyV1) -> tuple[float, float]:
+    if total <= 0:
+        return 0.0, 0.0
+    support = match_count / float(total)
+    confidence = min(1.0, match_count / float(max(1, policy.window.min_support_count)))
+    return support, confidence
+
+
+def detect_motifs(
+    *,
+    window: ConsolidationWindowData,
+    policy: ConsolidationPolicyV1,
+) -> list[MotifObservationV1]:
+    motifs: list[MotifObservationV1] = []
+    for _key, rule in policy.motif_rules.items():
+        detector = _DETECTORS.get(rule.label)
+        if detector is None:
+            continue
+        motif = detector(window=window, rule=rule, policy=policy)
+        if motif is None:
+            continue
+        if motif.support_score < policy.motif_thresholds.min_support_score:
+            continue
+        if motif.confidence_score < policy.motif_thresholds.min_confidence_score:
+            continue
+        motifs.append(motif)
+    return motifs
+
+
+def _detect_loaded_but_reliable(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    cond = rule.conditions
+    matches = [
+        s
+        for s in window.self_states
+        if s.overall_condition == cond.get("overall_condition", "loaded")
+        and _dim_score(s, "execution_pressure") >= float(cond.get("execution_pressure_min", 0.7))
+        and _dim_score(s, "reliability_pressure") <= float(cond.get("reliability_pressure_max", 0.3))
+    ]
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.self_states) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.self_state_id for m in matches],
+        dominant_dimensions={
+            "execution_pressure": sum(_dim_score(m, "execution_pressure") for m in matches) / len(matches),
+            "reliability_pressure": sum(_dim_score(m, "reliability_pressure") for m in matches) / len(matches),
+        },
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+        reasons=["loaded_with_high_execution_low_reliability_pressure"],
+    )
+
+
+def _target_ids(frame: FieldAttentionFrameV1) -> set[str]:
+    ids: set[str] = set()
+    for bucket in (
+        frame.dominant_targets,
+        frame.node_targets,
+        frame.capability_targets,
+        frame.system_targets,
+    ):
+        for t in bucket:
+            ids.add(f"{t.target_kind}:{t.target_id}" if ":" not in t.target_id else t.target_id)
+            if t.target_kind == "node":
+                ids.add(f"node:{t.target_id}")
+            if t.target_kind == "capability":
+                ids.add(f"capability:{t.target_id}")
+    return ids
+
+
+def _detect_attention_saturated_execution(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    cond = rule.conditions
+    targets_any = set(cond.get("attention_target_any", []))
+    min_salience = float(cond.get("min_overall_salience", 0.7))
+    matches = [
+        f
+        for f in window.attention_frames
+        if f.overall_salience >= min_salience and _target_ids(f).intersection(targets_any)
+    ]
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.attention_frames) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.frame_id for m in matches],
+        reasons=["attention_salience_saturated_on_execution_targets"],
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+    )
+
+
+def _detect_read_only_policy_loop(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    min_count = int(rule.conditions.get("approved_read_only_min", 1))
+    matches = [
+        p
+        for p in window.policy_frames
+        if not p.execution_allowed
+        and sum(1 for d in p.decisions if d.decision == "approved_read_only") >= min_count
+    ]
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.policy_frames) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.frame_id for m in matches],
+        reasons=["read_only_policy_decisions_without_execution"],
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+    )
+
+
+def _detect_dry_run_feedback_loop(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    expected = rule.conditions.get("outcome_status", "dry_run_only")
+    matches = [f for f in window.feedback_frames if f.outcome_status == expected]
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.feedback_frames) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.frame_id for m in matches],
+        reasons=[f"feedback_outcome_status:{expected}"],
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+    )
+
+
+def _detect_blocked_review_loop(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    matches: list[str] = []
+    for p in window.policy_frames:
+        if p.operator_review_required or p.review_required_decisions:
+            matches.append(p.frame_id)
+    for d in window.dispatch_frames:
+        if d.blocked_candidates:
+            matches.append(d.frame_id)
+    for f in window.feedback_frames:
+        if f.outcome_status == "blocked":
+            matches.append(f.frame_id)
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(match_count=len(matches), total=max(len(matches), 1), policy=policy)
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=matches,
+        reasons=["blocked_or_operator_review_signals"],
+    )
+
+
+def _detect_stable_after_dry_run(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    allowed = set(rule.conditions.get("self_state_delta", {}).get("allowed", ["unchanged"]))
+    matches = []
+    for f in window.feedback_frames:
+        if f.outcome_status != rule.conditions.get("outcome_status", "dry_run_only"):
+            continue
+        if f.absence_evidence or f.negative_evidence:
+            continue
+        has_unchanged = any(
+            o.source_kind == "self_state_delta" and o.outcome_kind in allowed for o in f.observations
+        )
+        if has_unchanged:
+            matches.append(f)
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.feedback_frames) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.frame_id for m in matches],
+        reasons=["dry_run_with_unchanged_self_state"],
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+    )
+
+
+_DETECTORS = {
+    "loaded_but_reliable": _detect_loaded_but_reliable,
+    "attention_saturated_execution": _detect_attention_saturated_execution,
+    "read_only_policy_loop": _detect_read_only_policy_loop,
+    "dry_run_feedback_loop": _detect_dry_run_feedback_loop,
+    "blocked_review_loop": _detect_blocked_review_loop,
+    "stable_after_dry_run": _detect_stable_after_dry_run,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_motif_detection.py -q`
+
+Expected: PASS (all motif assertions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/consolidation/motif.py tests/test_consolidation_motif_detection.py
+git commit -m "feat(consolidation): deterministic motif detection over substrate history"
+```
+
+---
+
+### Task 5: Consolidation frame builder (11a only)
+
+**Files:**
+
+- Create: `orion/consolidation/builder.py`
+- Test: `tests/test_consolidation_builder.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from datetime import datetime, timezone
+
+from orion.consolidation.builder import build_consolidation_frame
+from orion.consolidation.policy import load_consolidation_policy
+from orion.consolidation.windows import ConsolidationWindowData, stable_consolidation_frame_id
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_consolidation_policy(REPO / "config" / "consolidation" / "consolidation_policy.v1.yaml")
+NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
+START = datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc)
+
+
+def test_builder_emits_source_counts_and_stable_frame_id():
+    window = ConsolidationWindowData(
+        window_start=START,
+        window_end=NOW,
+        self_states=[],
+        attention_frames=[],
+        proposal_frames=[],
+        policy_frames=[],
+        dispatch_frames=[],
+        feedback_frames=[],
+    )
+    frame = build_consolidation_frame(window=window, policy=POLICY, generated_at=NOW)
+    assert frame.frame_id == stable_consolidation_frame_id(
+        window_start=START, window_end=NOW, policy_id=POLICY.policy_id
+    )
+    assert frame.source_counts["self_state"] == 0
+    assert frame.source_counts["feedback"] == 0
+    assert frame.consolidation_policy_id == "consolidation_policy.v1"
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+- [ ] **Step 3: Implement `builder.py`**
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.consolidation.motif import detect_motifs
+from orion.consolidation.policy import ConsolidationPolicyV1
+from orion.consolidation.windows import ConsolidationWindowData, stable_consolidation_frame_id
+from orion.schemas.consolidation_frame import ConsolidationFrameV1
+
+
+def build_consolidation_frame(
+    *,
+    window: ConsolidationWindowData,
+    policy: ConsolidationPolicyV1,
+    generated_at: datetime | None = None,
+) -> ConsolidationFrameV1:
+    now = generated_at or datetime.now(timezone.utc)
+    motifs = detect_motifs(window=window, policy=policy)
+    dominant = [
+        m.label
+        for m in sorted(motifs, key=lambda x: x.support_score, reverse=True)
+        if m.support_score >= policy.motif_thresholds.dominant_motif_min_support
+    ]
+    return ConsolidationFrameV1(
+        frame_id=stable_consolidation_frame_id(
+            window_start=window.window_start,
+            window_end=window.window_end,
+            policy_id=policy.policy_id,
+        ),
+        generated_at=now,
+        window_start=window.window_start,
+        window_end=window.window_end,
+        consolidation_policy_id=policy.policy_id,
+        motif_observations=motifs,
+        dominant_motifs=dominant,
+        source_counts={
+            "self_state": len(window.self_states),
+            "attention": len(window.attention_frames),
+            "proposal": len(window.proposal_frames),
+            "policy": len(window.policy_frames),
+            "dispatch": len(window.dispatch_frames),
+            "feedback": len(window.feedback_frames),
+        },
+    )
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_builder.py tests/test_consolidation_motif_detection.py -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/consolidation/builder.py tests/test_consolidation_builder.py
+git commit -m "feat(consolidation): build ConsolidationFrameV1 with motifs and source counts"
+```
+
+---
+
+### Task 6: SQL migration (11a frames)
+
+**Files:**
+
+- Create: `services/orion-sql-db/manual_migration_consolidation_v1.sql`
+
+- [ ] **Step 1: Add migration SQL** (per spec — `substrate_consolidation_frames` table + indexes)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add services/orion-sql-db/manual_migration_consolidation_v1.sql
+git commit -m "feat(consolidation): add substrate_consolidation_frames migration"
+```
+
+---
+
+### Task 7: `orion-consolidation-runtime` service
+
+**Files:**
+
+- Create: `services/orion-consolidation-runtime/app/{__init__.py,main.py,worker.py,store.py,settings.py}`
+- Create: `services/orion-consolidation-runtime/{Dockerfile,docker-compose.yml,requirements.txt,README.md,.env_example}`
+- Create: `services/orion-consolidation-runtime/.env` (copy from `.env_example` — local only, not committed)
+- Test: `tests/test_consolidation_runtime_store.py`
+
+| Setting | Value |
+|---------|-------|
+| Port | `8123` |
+| Policy path | `/app/config/consolidation/consolidation_policy.v1.yaml` |
+| Poll interval | `60` sec default |
+| Idempotency key | `(window_start, window_end)` via `frame_id` |
+| Worker | load frames in window → `build_consolidation_frame` → INSERT if missing |
+| No bus / no mutation | worker only builds + saves |
+
+**`.env_example`:**
+
+```env
+# orion-consolidation-runtime — Layer 11 consolidation (docker compose)
+# Requires: substrate_feedback_frames, substrate_self_state, substrate_attention_frames, etc.
+# Apply migrations: services/orion-sql-db/manual_migration_consolidation_v1.sql (+ later phase migrations)
+PROJECT=orion-athena
+SERVICE_NAME=orion-consolidation-runtime
+SERVICE_VERSION=0.1.0
+POSTGRES_URI=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+CONSOLIDATION_POLICY_PATH=/app/config/consolidation/consolidation_policy.v1.yaml
+CONSOLIDATION_POLL_INTERVAL_SEC=60.0
+ENABLE_CONSOLIDATION_RUNTIME=true
+LOG_LEVEL=INFO
+CONSOLIDATION_RUNTIME_PORT=8123
+```
+
+**`app/settings.py`:**
+
+```python
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    project: str = Field("orion-athena", alias="PROJECT")
+    service_name: str = Field("orion-consolidation-runtime", alias="SERVICE_NAME")
+    service_version: str = Field("0.1.0", alias="SERVICE_VERSION")
+
+    postgres_uri: str = Field(..., alias="POSTGRES_URI")
+    consolidation_policy_path: str = Field(
+        "config/consolidation/consolidation_policy.v1.yaml",
+        alias="CONSOLIDATION_POLICY_PATH",
+    )
+    consolidation_poll_interval_sec: float = Field(
+        60.0,
+        alias="CONSOLIDATION_POLL_INTERVAL_SEC",
+    )
+    enable_consolidation_runtime: bool = Field(
+        True,
+        alias="ENABLE_CONSOLIDATION_RUNTIME",
+    )
+    log_level: str = Field("INFO", alias="LOG_LEVEL")
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings
+```
+
+**`app/store.py`** — required methods:
+
+```python
+def load_consolidation_frame_for_window(self, frame_id: str) -> ConsolidationFrameV1 | None:
+    # SELECT FROM substrate_consolidation_frames WHERE frame_id = :id
+
+def load_window_data(self, window_start: datetime, window_end: datetime, max_per_source: int) -> ConsolidationWindowData:
+    # SELECT substrate_self_state WHERE generated_at >= :start AND generated_at < :end ORDER BY generated_at DESC LIMIT :n
+    # Same pattern for substrate_attention_frames, substrate_proposal_frames,
+    # substrate_policy_decision_frames, substrate_execution_dispatch_frames, substrate_feedback_frames
+
+def save_consolidation_frame(self, frame: ConsolidationFrameV1) -> None:
+    # INSERT INTO substrate_consolidation_frames (...) ON CONFLICT (frame_id) DO NOTHING
+```
+
+**`app/worker.py` `_tick`:**
+
+```python
+def _tick(self) -> None:
+    if not self._settings.enable_consolidation_runtime:
+        return
+    window_start, window_end = compute_consolidation_window(
+        lookback_minutes=self._policy.window.lookback_minutes,
+    )
+    frame_id = stable_consolidation_frame_id(
+        window_start=window_start,
+        window_end=window_end,
+        policy_id=self._policy.policy_id,
+    )
+    if self._store.load_consolidation_frame_for_window(frame_id) is not None:
+        return
+    data = self._store.load_window_data(
+        window_start,
+        window_end,
+        self._policy.window.max_frames_per_source,
+    )
+    frame = build_consolidation_frame(window=data, policy=self._policy)
+    self._store.save_consolidation_frame(frame)
+```
+
+**`docker-compose.yml`** — mirror feedback; port `8123`, env vars from `.env_example`.
+
+**`Dockerfile`** — copy from `services/orion-feedback-runtime/Dockerfile`; change service path and port.
+
+**`requirements.txt`:**
+
+```
+fastapi>=0.110
+uvicorn[standard]>=0.27
+pydantic>=2.6
+pydantic-settings>=2.2
+sqlalchemy>=2.0
+psycopg2-binary>=2.9
+pyyaml>=6.0
+```
+
+**`README.md`** — document port 8123, migrations, no bus publish, idempotent windows.
+
+- [ ] **Step 4: Run store tests**
+
+Run: `PYTHONPATH=. pytest tests/test_consolidation_runtime_store.py -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/orion-consolidation-runtime/ tests/test_consolidation_runtime_store.py
+git commit -m "feat(consolidation): add orion-consolidation-runtime polling service"
+```
+
+---
+
+### Task 8: Smoke script (11a)
+
+**Files:**
+
+- Create: `scripts/smoke_consolidation_v1.sh`
+
+- [ ] **Step 1:** Copy SQL queries from spec (feedback frames, self-state, consolidation frame) into executable script using `psql "$POSTGRES_URI"`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/smoke_consolidation_v1.sh
+git commit -m "chore(consolidation): add smoke_consolidation_v1.sh"
+```
+
+---
+
+## Phase 11b — Expectations
+
+### Task 9: `ExpectationV1` schema + frame field
+
+**Files:**
+
+- Modify: `orion/schemas/consolidation_frame.py`
+- Modify: `orion/schemas/registry.py`
+- Modify: `tests/test_consolidation_frame_schemas.py`
+
+- [ ] Add `ExpectationV1` per spec; add `expectations: list[ExpectationV1]` to `ConsolidationFrameV1`.
+- [ ] Register `ExpectationV1` in registry.
+- [ ] Extend schema tests; commit: `feat(consolidation): add ExpectationV1 schema`
+
+---
+
+### Task 10: Expectation builder
+
+**Files:**
+
+- Create: `orion/consolidation/expectation.py`
+- Modify: `orion/consolidation/builder.py`
+- Test: `tests/test_consolidation_expectations.py`
+
+- [ ] **Implement mapping** (deterministic):
+
+```python
+_MOTIF_TO_EXPECTATION: dict[str, str] = {
+    "loaded_but_reliable": "reliability_clear",
+    "attention_saturated_execution": "execution_pressure_high",
+    "read_only_policy_loop": "read_only_approved",
+    "dry_run_feedback_loop": "dry_run_feedback",
+    "blocked_review_loop": "policy_review_required",
+    "stable_after_dry_run": "dry_run_feedback",
+}
+
+
+def build_expectations_from_motifs(
+    *,
+    motifs: list[MotifObservationV1],
+    feedback_frames: list[FeedbackFrameV1],
+    policy: ConsolidationPolicyV1,
+) -> list[ExpectationV1]:
+    out: list[ExpectationV1] = []
+    for motif in motifs:
+        kind = _MOTIF_TO_EXPECTATION.get(motif.label)
+        if kind is None:
+            continue
+        out.append(
+            ExpectationV1(
+                expectation_id=f"expectation:{motif.motif_id}:{kind}",
+                trigger_motif_id=motif.motif_id,
+                expected_outcome_kind=kind,
+                confidence_score=motif.confidence_score,
+                support_count=motif.recurrence_count,
+                evidence_refs=list(motif.evidence_frame_ids),
+                reasons=[f"derived_from_motif:{motif.label}"],
+            )
+        )
+    return out
+```
+
+- [ ] Wire into `build_consolidation_frame` (pass `window.feedback_frames`).
+- [ ] Tests per spec assertions 1–6; commit.
+
+---
+
+### Task 11: Expectations migration + runtime upsert
+
+**Files:**
+
+- Create: `services/orion-sql-db/manual_migration_consolidation_expectations_v1.sql`
+- Modify: `services/orion-consolidation-runtime/app/store.py`
+- Modify: `services/orion-consolidation-runtime/app/worker.py`
+
+- [ ] `upsert_expectations(expectations)` — `INSERT ... ON CONFLICT (expectation_id) DO UPDATE` on `substrate_expectations`.
+- [ ] Worker calls upsert after saving consolidation frame.
+- [ ] Test idempotent upsert in `tests/test_consolidation_runtime_store.py`; commit.
+
+---
+
+## Phase 11c — Sparse tensor slices
+
+### Task 12: `SparseTensorSliceV1` + policy tensor config
+
+**Files:**
+
+- Modify: `orion/schemas/consolidation_frame.py`, `config/consolidation/consolidation_policy.v1.yaml`, `orion/consolidation/policy.py`
+
+- [ ] Add `SparseTensorSliceV1` and `tensor_slices` field on frame.
+- [ ] Extend policy models:
+
+```yaml
+tensor:
+  enabled: true
+  max_coordinates: 200
+
+tensor_axes:
+  field_attention_self:
+    - time_bucket
+    - self_condition
+    - attention_target
+    - dimension
+  policy_dispatch_feedback:
+    - proposal_kind
+    - policy_decision
+    - dispatch_status
+    - feedback_outcome
+  motif_condition_outcome:
+    - motif
+    - self_condition
+    - outcome_status
+```
+
+- [ ] Commit: `feat(consolidation): add SparseTensorSliceV1 and tensor policy config`
+
+---
+
+### Task 13: `tensorize.py`
+
+**Files:**
+
+- Create: `orion/consolidation/tensorize.py`
+- Modify: `orion/consolidation/builder.py`
+- Test: `tests/test_consolidation_tensorize.py`
+
+- [ ] Implement `build_sparse_tensor_slices` producing three slice kinds; cap coordinates at `policy.tensor.max_coordinates`; set `tensor_id` stable per window+kind.
+- [ ] `field_attention_self`: join self_state + attention on time buckets (ISO minute), value = dimension score.
+- [ ] `policy_dispatch_feedback`: join dispatch candidates + feedback outcome paths, value `1.0`.
+- [ ] `motif_condition_outcome`: motif label × self_condition × feedback outcome, value = `motif.support_score`.
+- [ ] Assert tests 1–8 from spec; commit.
+
+---
+
+### Task 14: Tensor migration + runtime persist
+
+**Files:**
+
+- Create: `services/orion-sql-db/manual_migration_consolidation_tensor_slices_v1.sql`
+- Modify: store + worker
+
+- [ ] `save_tensor_slices(slices, window_start, window_end)` with `ON CONFLICT DO NOTHING` on `tensor_id`.
+- [ ] Commit.
+
+---
+
+## Phase 11d — Schema candidates
+
+### Task 15: `SchemaCandidateV1` + `schema_candidates.py`
+
+**Files:**
+
+- Modify: `orion/schemas/consolidation_frame.py`
+- Create: `orion/consolidation/schema_candidates.py`
+- Test: `tests/test_consolidation_schema_candidates.py`
+
+- [ ] Implement `build_schema_candidates` with three initial candidates from spec; **`promotion_status` always `candidate_only`**.
+- [ ] Wire into builder; commit.
+
+---
+
+### Task 16: Schema candidates migration + runtime upsert
+
+**Files:**
+
+- Create: `services/orion-sql-db/manual_migration_consolidation_schema_candidates_v1.sql`
+- Modify: store + worker
+
+- [ ] Upsert `substrate_schema_candidates`; commit.
+
+---
+
+## Phase 11e — Read-only surfaces
+
+### Task 17: `repository.py`
+
+**Files:**
+
+- Create: `orion/consolidation/repository.py`
+- Test: `tests/test_consolidation_repository.py`
+
+- [ ] Read-only SQL helpers: `load_recent_motifs`, `load_expectations_for_motif`, `load_schema_candidates`, `load_latest_tensor_slices` — accept `postgres_uri` or engine param; no writes.
+- [ ] Commit.
+
+---
+
+### Task 18: Hub debug routes
+
+**Files:**
+
+- Create: `services/orion-hub/scripts/substrate_consolidation_routes.py`
+- Modify: `services/orion-hub/scripts/api_routes.py`
+- Test: `services/orion-hub/tests/test_substrate_consolidation_debug_api.py`
+
+Routes (GET only):
+
+```text
+/api/substrate/consolidation/latest
+/api/substrate/consolidation/motifs
+/api/substrate/consolidation/expectations
+/api/substrate/consolidation/schema-candidates
+/api/substrate/consolidation/tensor-slices/latest
+```
+
+Mirror `substrate_feedback_routes.py` pattern — SQL → Pydantic validate → JSON. Register router in `api_routes.py`.
+
+- [ ] Assert no POST routes in tests; commit.
+
+---
+
+## Post-implementation: code review, PR report, push
+
+### Task 19: Verification gate
+
+- [ ] Apply all SQL migrations on dev Postgres.
+- [ ] Run full consolidation test suite:
+
+```bash
+PYTHONPATH=. pytest \
+  tests/test_consolidation_frame_schemas.py \
+  tests/test_consolidation_policy_loader.py \
+  tests/test_consolidation_windows.py \
+  tests/test_consolidation_motif_detection.py \
+  tests/test_consolidation_builder.py \
+  tests/test_consolidation_expectations.py \
+  tests/test_consolidation_tensorize.py \
+  tests/test_consolidation_schema_candidates.py \
+  tests/test_consolidation_repository.py \
+  tests/test_consolidation_runtime_store.py \
+  services/orion-hub/tests/test_substrate_consolidation_debug_api.py \
+  -q
+```
+
+Expected: all PASS
+
+- [ ] **REQUIRED SUB-SKILL:** `requesting-code-review` — dispatch subagent with plan + diff summary; fix all blocking issues before PR.
+
+---
+
+### Task 20: PR report + GitHub PR
+
+**Files:**
+
+- Create: `docs/superpowers/pr-reports/2026-05-25-consolidation-frame-v1-pr.md`
+
+- [ ] Write PR report (Summary, Architecture diagram, Files changed, Test plan, Non-goals verified).
+- [ ] Push and open PR:
+
+```bash
+git push -u origin feat/consolidation-frame-v1
+gh pr create --title "feat(consolidation): Layer 11 consolidation frame v1 (11a–11e)" --body "$(cat <<'EOF'
+## Summary
+- Layer 11 deterministic consolidation: motifs, expectations, sparse tensor slices, schema candidates, read-only Hub APIs.
+- New `orion-consolidation-runtime` on port 8123; idempotent per window; no bus publish; no behavior mutation.
+
+## Test plan
+- [ ] `pytest tests/test_consolidation_* services/orion-hub/tests/test_substrate_consolidation_debug_api.py`
+- [ ] Apply SQL migrations and run `scripts/smoke_consolidation_v1.sh`
+- [ ] Confirm no `orion/bus/channels.yaml` changes
+
+EOF
+)"
+```
+
+---
+
+## Self-review (plan author checklist)
+
+| Spec requirement | Task |
+|------------------|------|
+| MotifObservationV1 + ConsolidationFrameV1 | Task 1 |
+| consolidation_policy.v1.yaml + 6 motif rules | Tasks 2, 4 |
+| loaded_but_reliable … stable_after_dry_run | Task 4 |
+| Runtime idempotent per window | Tasks 3, 7 |
+| ExpectationV1 + mappings | Tasks 9–11 |
+| SparseTensorSliceV1 + 3 tensor kinds | Tasks 12–14 |
+| SchemaCandidateV1 candidate_only | Tasks 15–16 |
+| Read-only Hub + repository | Tasks 17–18 |
+| No LLM / no policy mutation / no bus | Worktree rules + all tasks |
+| SQL migrations | Tasks 6, 11, 14, 16 |
+| .env sync from .env_example | Task 7 |
+| Code review + PR | Tasks 19–20 |
+
+**Placeholder scan:** No TBD steps. All motif rules have detector implementations specified.
+
+**Type consistency:** `ConsolidationPolicyV1`, `ConsolidationWindowData`, `build_consolidation_frame`, `stable_consolidation_frame_id` used consistently across tasks.
+
+---
+
+## Final acceptance (Layer 11 v1)
+
+```text
+1. Recent substrate history produces consolidation frames.
+2. Repeated conditions produce motif observations.
+3. Motifs produce expectations.
+4. Sparse tensor-shaped history slices are persisted.
+5. Schema candidates emitted without automatic promotion.
+6. Read-only Hub surfaces expose artifacts.
+7. Nothing mutates behavior automatically.
+8. No LLM required.
+9. No policy/proposal/execution weight changes.
+10. No RDF concept creation without explicit later review.
+```

--- a/docs/superpowers/pr-reports/2026-05-25-consolidation-frame-v1-pr.md
+++ b/docs/superpowers/pr-reports/2026-05-25-consolidation-frame-v1-pr.md
@@ -1,0 +1,104 @@
+# PR: Consolidation Frame v1 — Layer 11 Pattern Memory
+
+**Branch:** `feat/consolidation-frame-v1`  
+**Base:** `main`  
+**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-consolidation-frame-v1`
+
+## Summary
+
+Implements **Layer 11** of the Orion cognition substrate: deterministic consolidation over Layers 5–10 history. Repeated substrate frames become inspectable motifs, expectations, sparse tensor slices, and schema candidates — without mutating policy, proposals, execution, or habits.
+
+```text
+substrate_self_state
++ substrate_attention_frames
++ substrate_proposal_frames
++ substrate_policy_decision_frames
++ substrate_execution_dispatch_frames
++ substrate_feedback_frames
+  → orion-consolidation-runtime (port 8123)
+  → ConsolidationFrameV1
+  → substrate_consolidation_frames (+ expectations, tensor_slices, schema_candidates)
+  → GET /api/substrate/consolidation/* (Hub, read-only)
+```
+
+**Consolidation is repeated consequence becoming structure.** No LLM, no bus publish, no automatic promotion.
+
+## Phases delivered
+
+| Phase | Scope |
+|-------|--------|
+| **11a** | `MotifObservationV1`, `ConsolidationFrameV1`, 6 motif rules, runtime, smoke |
+| **11b** | `ExpectationV1`, motif→outcome mapping, `substrate_expectations` upsert |
+| **11c** | `SparseTensorSliceV1`, three tensor kinds, coordinate cap |
+| **11d** | `SchemaCandidateV1`, `promotion_status=candidate_only` only |
+| **11e** | `repository.py`, five GET Hub routes |
+
+## Motif rules (deterministic)
+
+| Motif | Source signal |
+|-------|----------------|
+| `loaded_but_reliable` | Self-state: loaded + high execution / low reliability pressure |
+| `attention_saturated_execution` | Attention salience ≥ 0.7 on athena/orchestration |
+| `read_only_policy_loop` | Policy approved_read_only, execution disallowed |
+| `dry_run_feedback_loop` | Feedback `outcome_status=dry_run_only` |
+| `blocked_review_loop` | Policy review / dispatch blocked / feedback blocked |
+| `stable_after_dry_run` | Dry-run feedback + unchanged self-state delta |
+
+## Idempotency
+
+- Window bounds align to `lookback_minutes` UTC buckets (hourly when lookback=60).
+- `frame_id` = `consolidation.frame:{window_start}:{window_end}:{policy_id}` — stable within bucket.
+- Runtime `ON CONFLICT (frame_id) DO NOTHING` on consolidation frames.
+
+## Proof: no forbidden side effects
+
+- `orion/substrate/consolidation.py` unchanged (graph consolidation is separate)
+- `orion/bus/channels.yaml` unchanged
+- Worker only reads Layers 5–10 tables; writes consolidation artifact tables only
+- Hub routes are GET-only; tests assert no POST on router
+- Schema candidates always `promotion_status=candidate_only`
+
+## Files changed (40 files, ~3900 lines)
+
+| Path | Role |
+|------|------|
+| `orion/schemas/consolidation_frame.py` | All Layer 11 v1 schemas |
+| `orion/schemas/registry.py` | Registry entries |
+| `config/consolidation/consolidation_policy.v1.yaml` | Policy + motif + tensor config |
+| `orion/consolidation/*.py` | Policy, windows, motifs, expectations, tensorize, schema candidates, builder, repository |
+| `services/orion-sql-db/manual_migration_consolidation_*.sql` | 4 DDL migrations |
+| `services/orion-consolidation-runtime/` | Polling runtime (8123) |
+| `services/orion-hub/scripts/substrate_consolidation_routes.py` | Debug API |
+| `scripts/smoke_consolidation_v1.sh` | Live SQL smoke |
+| `tests/test_consolidation_*.py` | Unit + store + worker tests |
+
+## Migrations (apply in order)
+
+1. `manual_migration_consolidation_v1.sql`
+2. `manual_migration_consolidation_expectations_v1.sql`
+3. `manual_migration_consolidation_tensor_slices_v1.sql`
+4. `manual_migration_consolidation_schema_candidates_v1.sql`
+
+## Test plan
+
+```bash
+cd .worktrees/feat-consolidation-frame-v1
+PYTHONPATH=. pytest tests/test_consolidation_*.py \
+  services/orion-hub/tests/test_substrate_consolidation_debug_api.py -q
+# Expected: 67 passed
+
+# After migrations + runtime:
+./scripts/smoke_consolidation_v1.sh
+```
+
+## Review fixes (post code-review)
+
+- **Window bucketing:** `compute_consolidation_window` aligns `window_end` to lookback-minute UTC buckets so repeated polls share one `frame_id` (was inserting every tick).
+
+## Non-goals verified
+
+- No policy/proposal/attention weight mutation
+- No habit execution or RDF writes
+- No cortex-exec steering
+- No bus publish
+- No LLM calls

--- a/orion/consolidation/__init__.py
+++ b/orion/consolidation/__init__.py
@@ -1,0 +1,3 @@
+from orion.consolidation.policy import ConsolidationPolicyV1, load_consolidation_policy
+
+__all__ = ["ConsolidationPolicyV1", "load_consolidation_policy"]

--- a/orion/consolidation/builder.py
+++ b/orion/consolidation/builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from orion.consolidation.expectation import build_expectations_from_motifs
 from orion.consolidation.motif import detect_motifs
 from orion.consolidation.policy import ConsolidationPolicyV1
 from orion.consolidation.windows import ConsolidationWindowData, stable_consolidation_frame_id
@@ -16,6 +17,11 @@ def build_consolidation_frame(
 ) -> ConsolidationFrameV1:
     now = generated_at or datetime.now(timezone.utc)
     motifs = detect_motifs(window=window, policy=policy)
+    expectations = build_expectations_from_motifs(
+        motifs=motifs,
+        feedback_frames=window.feedback_frames,
+        policy=policy,
+    )
     dominant = [
         m.label
         for m in sorted(motifs, key=lambda x: x.support_score, reverse=True)
@@ -33,6 +39,7 @@ def build_consolidation_frame(
         consolidation_policy_id=policy.policy_id,
         motif_observations=motifs,
         dominant_motifs=dominant,
+        expectations=expectations,
         source_counts={
             "self_state": len(window.self_states),
             "attention": len(window.attention_frames),

--- a/orion/consolidation/builder.py
+++ b/orion/consolidation/builder.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 from orion.consolidation.expectation import build_expectations_from_motifs
 from orion.consolidation.motif import detect_motifs
+from orion.consolidation.schema_candidates import build_schema_candidates
 from orion.consolidation.tensorize import build_sparse_tensor_slices
 from orion.consolidation.policy import ConsolidationPolicyV1
 from orion.consolidation.windows import ConsolidationWindowData, stable_consolidation_frame_id
@@ -29,6 +30,11 @@ def build_consolidation_frame(
         expectations=expectations,
         policy=policy,
     )
+    schema_candidates = build_schema_candidates(
+        motifs=motifs,
+        expectations=expectations,
+        policy=policy,
+    )
     dominant = [
         m.label
         for m in sorted(motifs, key=lambda x: x.support_score, reverse=True)
@@ -48,6 +54,7 @@ def build_consolidation_frame(
         dominant_motifs=dominant,
         expectations=expectations,
         tensor_slices=tensor_slices,
+        schema_candidates=schema_candidates,
         source_counts={
             "self_state": len(window.self_states),
             "attention": len(window.attention_frames),

--- a/orion/consolidation/builder.py
+++ b/orion/consolidation/builder.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.consolidation.motif import detect_motifs
+from orion.consolidation.policy import ConsolidationPolicyV1
+from orion.consolidation.windows import ConsolidationWindowData, stable_consolidation_frame_id
+from orion.schemas.consolidation_frame import ConsolidationFrameV1
+
+
+def build_consolidation_frame(
+    *,
+    window: ConsolidationWindowData,
+    policy: ConsolidationPolicyV1,
+    generated_at: datetime | None = None,
+) -> ConsolidationFrameV1:
+    now = generated_at or datetime.now(timezone.utc)
+    motifs = detect_motifs(window=window, policy=policy)
+    dominant = [
+        m.label
+        for m in sorted(motifs, key=lambda x: x.support_score, reverse=True)
+        if m.support_score >= policy.motif_thresholds.dominant_motif_min_support
+    ]
+    return ConsolidationFrameV1(
+        frame_id=stable_consolidation_frame_id(
+            window_start=window.window_start,
+            window_end=window.window_end,
+            policy_id=policy.policy_id,
+        ),
+        generated_at=now,
+        window_start=window.window_start,
+        window_end=window.window_end,
+        consolidation_policy_id=policy.policy_id,
+        motif_observations=motifs,
+        dominant_motifs=dominant,
+        source_counts={
+            "self_state": len(window.self_states),
+            "attention": len(window.attention_frames),
+            "proposal": len(window.proposal_frames),
+            "policy": len(window.policy_frames),
+            "dispatch": len(window.dispatch_frames),
+            "feedback": len(window.feedback_frames),
+        },
+    )

--- a/orion/consolidation/builder.py
+++ b/orion/consolidation/builder.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 from orion.consolidation.expectation import build_expectations_from_motifs
 from orion.consolidation.motif import detect_motifs
+from orion.consolidation.tensorize import build_sparse_tensor_slices
 from orion.consolidation.policy import ConsolidationPolicyV1
 from orion.consolidation.windows import ConsolidationWindowData, stable_consolidation_frame_id
 from orion.schemas.consolidation_frame import ConsolidationFrameV1
@@ -20,6 +21,12 @@ def build_consolidation_frame(
     expectations = build_expectations_from_motifs(
         motifs=motifs,
         feedback_frames=window.feedback_frames,
+        policy=policy,
+    )
+    tensor_slices = build_sparse_tensor_slices(
+        window=window,
+        motifs=motifs,
+        expectations=expectations,
         policy=policy,
     )
     dominant = [
@@ -40,6 +47,7 @@ def build_consolidation_frame(
         motif_observations=motifs,
         dominant_motifs=dominant,
         expectations=expectations,
+        tensor_slices=tensor_slices,
         source_counts={
             "self_state": len(window.self_states),
             "attention": len(window.attention_frames),

--- a/orion/consolidation/expectation.py
+++ b/orion/consolidation/expectation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from orion.consolidation.policy import ConsolidationPolicyV1
+from orion.schemas.consolidation_frame import ExpectationV1, MotifObservationV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+
+_MOTIF_TO_EXPECTATION: dict[str, str] = {
+    "loaded_but_reliable": "reliability_clear",
+    "attention_saturated_execution": "execution_pressure_high",
+    "read_only_policy_loop": "read_only_approved",
+    "dry_run_feedback_loop": "dry_run_feedback",
+    "blocked_review_loop": "policy_review_required",
+    "stable_after_dry_run": "dry_run_feedback",
+}
+
+
+def build_expectations_from_motifs(
+    *,
+    motifs: list[MotifObservationV1],
+    feedback_frames: list[FeedbackFrameV1],
+    policy: ConsolidationPolicyV1,
+) -> list[ExpectationV1]:
+    del feedback_frames, policy
+    out: list[ExpectationV1] = []
+    for motif in motifs:
+        kind = _MOTIF_TO_EXPECTATION.get(motif.label)
+        if kind is None:
+            continue
+        out.append(
+            ExpectationV1(
+                expectation_id=f"expectation:{motif.motif_id}:{kind}",
+                trigger_motif_id=motif.motif_id,
+                expected_outcome_kind=kind,  # type: ignore[arg-type]
+                confidence_score=motif.confidence_score,
+                support_count=motif.recurrence_count,
+                evidence_refs=list(motif.evidence_frame_ids),
+                reasons=[f"derived_from_motif:{motif.label}"],
+            )
+        )
+    return out

--- a/orion/consolidation/motif.py
+++ b/orion/consolidation/motif.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.consolidation.policy import ConsolidationPolicyV1, MotifRuleV1
+from orion.consolidation.windows import ConsolidationWindowData
+from orion.schemas.consolidation_frame import MotifObservationV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+
+def _dim_score(state: SelfStateV1, dimension_id: str) -> float:
+    dim = state.dimensions.get(dimension_id)
+    return float(dim.score) if dim is not None else 0.0
+
+
+def _motif_id(label: str, policy_id: str) -> str:
+    return f"motif:{label}:{policy_id}"
+
+
+def _score_motif(*, match_count: int, total: int, policy: ConsolidationPolicyV1) -> tuple[float, float]:
+    if total <= 0:
+        return 0.0, 0.0
+    support = match_count / float(total)
+    confidence = min(1.0, match_count / float(max(1, policy.window.min_support_count)))
+    return support, confidence
+
+
+def detect_motifs(
+    *,
+    window: ConsolidationWindowData,
+    policy: ConsolidationPolicyV1,
+) -> list[MotifObservationV1]:
+    motifs: list[MotifObservationV1] = []
+    for _key, rule in policy.motif_rules.items():
+        detector = _DETECTORS.get(rule.label)
+        if detector is None:
+            continue
+        motif = detector(window=window, rule=rule, policy=policy)
+        if motif is None:
+            continue
+        if motif.support_score < policy.motif_thresholds.min_support_score:
+            continue
+        if motif.confidence_score < policy.motif_thresholds.min_confidence_score:
+            continue
+        motifs.append(motif)
+    return motifs
+
+
+def _detect_loaded_but_reliable(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    cond = rule.conditions
+    matches = [
+        s
+        for s in window.self_states
+        if s.overall_condition == cond.get("overall_condition", "loaded")
+        and _dim_score(s, "execution_pressure") >= float(cond.get("execution_pressure_min", 0.7))
+        and _dim_score(s, "reliability_pressure") <= float(cond.get("reliability_pressure_max", 0.3))
+    ]
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.self_states) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.self_state_id for m in matches],
+        dominant_dimensions={
+            "execution_pressure": sum(_dim_score(m, "execution_pressure") for m in matches) / len(matches),
+            "reliability_pressure": sum(_dim_score(m, "reliability_pressure") for m in matches) / len(matches),
+        },
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+        reasons=["loaded_with_high_execution_low_reliability_pressure"],
+    )
+
+
+def _target_ids(frame: FieldAttentionFrameV1) -> set[str]:
+    ids: set[str] = set()
+    for bucket in (
+        frame.dominant_targets,
+        frame.node_targets,
+        frame.capability_targets,
+        frame.system_targets,
+    ):
+        for t in bucket:
+            ids.add(f"{t.target_kind}:{t.target_id}" if ":" not in t.target_id else t.target_id)
+            if t.target_kind == "node":
+                ids.add(f"node:{t.target_id}")
+            if t.target_kind == "capability":
+                ids.add(f"capability:{t.target_id}")
+    return ids
+
+
+def _detect_attention_saturated_execution(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    cond = rule.conditions
+    targets_any = set(cond.get("attention_target_any", []))
+    min_salience = float(cond.get("min_overall_salience", 0.7))
+    matches = [
+        f
+        for f in window.attention_frames
+        if f.overall_salience >= min_salience and _target_ids(f).intersection(targets_any)
+    ]
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.attention_frames) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.frame_id for m in matches],
+        reasons=["attention_salience_saturated_on_execution_targets"],
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+    )
+
+
+def _detect_read_only_policy_loop(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    min_count = int(rule.conditions.get("approved_read_only_min", 1))
+    matches = [
+        p
+        for p in window.policy_frames
+        if not p.execution_allowed
+        and sum(1 for d in p.decisions if d.decision == "approved_read_only") >= min_count
+    ]
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.policy_frames) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.frame_id for m in matches],
+        reasons=["read_only_policy_decisions_without_execution"],
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+    )
+
+
+def _detect_dry_run_feedback_loop(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    expected = rule.conditions.get("outcome_status", "dry_run_only")
+    matches = [f for f in window.feedback_frames if f.outcome_status == expected]
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.feedback_frames) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.frame_id for m in matches],
+        reasons=[f"feedback_outcome_status:{expected}"],
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+    )
+
+
+def _detect_blocked_review_loop(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    matches: list[str] = []
+    for p in window.policy_frames:
+        if p.operator_review_required or p.review_required_decisions:
+            matches.append(p.frame_id)
+    for d in window.dispatch_frames:
+        if d.blocked_candidates:
+            matches.append(d.frame_id)
+    for f in window.feedback_frames:
+        if f.outcome_status == "blocked":
+            matches.append(f.frame_id)
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(match_count=len(matches), total=max(len(matches), 1), policy=policy)
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=matches,
+        reasons=["blocked_or_operator_review_signals"],
+    )
+
+
+def _detect_stable_after_dry_run(
+    *,
+    window: ConsolidationWindowData,
+    rule: MotifRuleV1,
+    policy: ConsolidationPolicyV1,
+) -> MotifObservationV1 | None:
+    allowed = set(rule.conditions.get("self_state_delta", {}).get("allowed", ["unchanged"]))
+    matches = []
+    for f in window.feedback_frames:
+        if f.outcome_status != rule.conditions.get("outcome_status", "dry_run_only"):
+            continue
+        if f.absence_evidence or f.negative_evidence:
+            continue
+        has_unchanged = any(
+            o.source_kind == "self_state_delta" and o.outcome_kind in allowed for o in f.observations
+        )
+        if has_unchanged:
+            matches.append(f)
+    if len(matches) < policy.window.min_support_count:
+        return None
+    support, confidence = _score_motif(
+        match_count=len(matches), total=len(window.feedback_frames) or len(matches), policy=policy
+    )
+    return MotifObservationV1(
+        motif_id=_motif_id(rule.label, policy.policy_id),
+        motif_kind=rule.kind,
+        label=rule.label,
+        recurrence_count=len(matches),
+        support_score=support,
+        confidence_score=confidence,
+        evidence_frame_ids=[m.frame_id for m in matches],
+        reasons=["dry_run_with_unchanged_self_state"],
+        first_seen_at=min(m.generated_at for m in matches),
+        last_seen_at=max(m.generated_at for m in matches),
+    )
+
+
+_DETECTORS = {
+    "loaded_but_reliable": _detect_loaded_but_reliable,
+    "attention_saturated_execution": _detect_attention_saturated_execution,
+    "read_only_policy_loop": _detect_read_only_policy_loop,
+    "dry_run_feedback_loop": _detect_dry_run_feedback_loop,
+    "blocked_review_loop": _detect_blocked_review_loop,
+    "stable_after_dry_run": _detect_stable_after_dry_run,
+}

--- a/orion/consolidation/policy.py
+++ b/orion/consolidation/policy.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConsolidationWindowConfigV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lookback_minutes: int = 60
+    min_support_count: int = 3
+    max_frames_per_source: int = 500
+
+
+class MotifThresholdsV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    min_support_score: float = 0.20
+    min_confidence_score: float = 0.30
+    dominant_motif_min_support: float = 0.50
+
+
+class MotifRuleV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal[
+        "field_pattern",
+        "attention_pattern",
+        "self_state_pattern",
+        "proposal_policy_pattern",
+        "dispatch_feedback_pattern",
+        "absence_pattern",
+        "stability_pattern",
+    ]
+    label: str
+    conditions: dict[str, Any] = Field(default_factory=dict)
+
+
+class ConsolidationPolicyV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["consolidation_policy.v1"] = "consolidation_policy.v1"
+    policy_id: str = "consolidation_policy.v1"
+
+    window: ConsolidationWindowConfigV1 = Field(default_factory=ConsolidationWindowConfigV1)
+    motif_thresholds: MotifThresholdsV1 = Field(default_factory=MotifThresholdsV1)
+
+    tracked_self_dimensions: list[str] = Field(default_factory=list)
+    tracked_attention_targets: list[str] = Field(default_factory=list)
+    tracked_feedback_outcomes: list[str] = Field(default_factory=list)
+
+    motif_rules: dict[str, MotifRuleV1] = Field(default_factory=dict)
+
+
+def load_consolidation_policy(path: str | Path) -> ConsolidationPolicyV1:
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    raw_rules = data.pop("motif_rules", {}) or {}
+    rules = {key: MotifRuleV1.model_validate(val) for key, val in raw_rules.items()}
+    base = ConsolidationPolicyV1.model_validate(data)
+    return base.model_copy(update={"motif_rules": rules})

--- a/orion/consolidation/policy.py
+++ b/orion/consolidation/policy.py
@@ -39,6 +39,13 @@ class MotifRuleV1(BaseModel):
     conditions: dict[str, Any] = Field(default_factory=dict)
 
 
+class TensorConfigV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    max_coordinates: int = 200
+
+
 class ConsolidationPolicyV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -53,6 +60,9 @@ class ConsolidationPolicyV1(BaseModel):
     tracked_feedback_outcomes: list[str] = Field(default_factory=list)
 
     motif_rules: dict[str, MotifRuleV1] = Field(default_factory=dict)
+
+    tensor: TensorConfigV1 = Field(default_factory=TensorConfigV1)
+    tensor_axes: dict[str, list[str]] = Field(default_factory=dict)
 
 
 def load_consolidation_policy(path: str | Path) -> ConsolidationPolicyV1:

--- a/orion/consolidation/repository.py
+++ b/orion/consolidation/repository.py
@@ -1,0 +1,146 @@
+"""Read-only Postgres accessors for consolidation substrate artifacts."""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, TypeVar
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from orion.schemas.consolidation_frame import (
+    ConsolidationFrameV1,
+    ExpectationV1,
+    MotifObservationV1,
+    SchemaCandidateV1,
+    SparseTensorSliceV1,
+)
+
+T = TypeVar("T")
+
+
+def _engine_for(postgres_uri: str, engine: Engine | None = None) -> Engine:
+    if engine is not None:
+        return engine
+    return create_engine(
+        postgres_uri,
+        pool_pre_ping=True,
+        json_serializer=json.dumps,
+        json_deserializer=json.loads,
+    )
+
+
+def _parse_json(payload: object, model: Callable[[dict], T]) -> T:
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return model.model_validate(payload)
+
+
+def _load_latest_consolidation_frame(
+    engine: Engine,
+) -> ConsolidationFrameV1 | None:
+    with engine.connect() as conn:
+        row = (
+            conn.execute(
+                text(
+                    """
+                    SELECT consolidation_frame_json
+                    FROM substrate_consolidation_frames
+                    ORDER BY generated_at DESC
+                    LIMIT 1
+                    """
+                ),
+            )
+            .mappings()
+            .first()
+        )
+    if not row:
+        return None
+    return _parse_json(row["consolidation_frame_json"], ConsolidationFrameV1)
+
+
+def load_recent_motifs(
+    postgres_uri: str,
+    limit: int,
+    *,
+    engine: Engine | None = None,
+) -> list[MotifObservationV1]:
+    frame = _load_latest_consolidation_frame(_engine_for(postgres_uri, engine))
+    if frame is None:
+        return []
+    return list(frame.motif_observations[: max(0, limit)])
+
+
+def load_expectations_for_motif(
+    postgres_uri: str,
+    trigger_motif_id: str,
+    *,
+    engine: Engine | None = None,
+) -> list[ExpectationV1]:
+    with _engine_for(postgres_uri, engine).connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT expectation_json
+                FROM substrate_expectations
+                WHERE trigger_motif_id = :trigger_motif_id
+                ORDER BY updated_at DESC
+                """
+            ),
+            {"trigger_motif_id": trigger_motif_id},
+        ).mappings()
+        return [
+            _parse_json(row["expectation_json"], ExpectationV1)
+            for row in rows
+            if row.get("expectation_json") is not None
+        ]
+
+
+def load_schema_candidates(
+    postgres_uri: str,
+    limit: int,
+    *,
+    engine: Engine | None = None,
+) -> list[SchemaCandidateV1]:
+    with _engine_for(postgres_uri, engine).connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT schema_candidate_json
+                FROM substrate_schema_candidates
+                ORDER BY updated_at DESC
+                LIMIT :limit
+                """
+            ),
+            {"limit": max(0, limit)},
+        ).mappings()
+        return [
+            _parse_json(row["schema_candidate_json"], SchemaCandidateV1)
+            for row in rows
+            if row.get("schema_candidate_json") is not None
+        ]
+
+
+def load_latest_tensor_slices(
+    postgres_uri: str,
+    limit: int,
+    *,
+    engine: Engine | None = None,
+) -> list[SparseTensorSliceV1]:
+    with _engine_for(postgres_uri, engine).connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT tensor_json
+                FROM substrate_tensor_slices
+                ORDER BY created_at DESC
+                LIMIT :limit
+                """
+            ),
+            {"limit": max(0, limit)},
+        ).mappings()
+        return [
+            _parse_json(row["tensor_json"], SparseTensorSliceV1)
+            for row in rows
+            if row.get("tensor_json") is not None
+        ]

--- a/orion/consolidation/schema_candidates.py
+++ b/orion/consolidation/schema_candidates.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from orion.consolidation.policy import ConsolidationPolicyV1
+from orion.schemas.consolidation_frame import ExpectationV1, MotifObservationV1, SchemaCandidateV1
+
+_CANDIDATE_SPECS: dict[str, dict[str, object]] = {
+    "loaded_but_reliable": {
+        "candidate_kind": "prior_candidate",
+        "label": "loaded_but_reliable_operating_mode",
+        "proposed_schema": {
+            "condition": "loaded",
+            "reliability_pressure": "low",
+            "execution_pressure": "high",
+            "interpretation": "high load does not imply instability",
+        },
+        "reason": "derived_from_motif:loaded_but_reliable",
+    },
+    "dry_run_feedback_loop": {
+        "candidate_kind": "habit_candidate",
+        "label": "dry_run_feedback_review_loop",
+        "proposed_schema": {
+            "trigger": "approved_read_only dispatch envelope",
+            "expected_feedback": "dry_run_only",
+            "mutation": "none",
+        },
+        "reason": "derived_from_motif:dry_run_feedback_loop",
+    },
+    "read_only_policy_loop": {
+        "candidate_kind": "policy_candidate",
+        "label": "read_only_policy_approval_pattern",
+        "proposed_schema": {
+            "candidate_behavior": "inspect/summarize/observe",
+            "gate": "read_only",
+            "execution_allowed": False,
+        },
+        "reason": "derived_from_motif:read_only_policy_loop",
+    },
+}
+
+
+def build_schema_candidates(
+    *,
+    motifs: list[MotifObservationV1],
+    expectations: list[ExpectationV1],
+    policy: ConsolidationPolicyV1,
+) -> list[SchemaCandidateV1]:
+    del policy
+    expectations_by_motif = {
+        expectation.trigger_motif_id: expectation.expectation_id for expectation in expectations
+    }
+    out: list[SchemaCandidateV1] = []
+    for motif in motifs:
+        spec = _CANDIDATE_SPECS.get(motif.label)
+        if spec is None:
+            continue
+        candidate_kind = str(spec["candidate_kind"])
+        out.append(
+            SchemaCandidateV1(
+                schema_candidate_id=f"schema_candidate:{candidate_kind}:{motif.motif_id}",
+                candidate_kind=candidate_kind,  # type: ignore[arg-type]
+                label=str(spec["label"]),
+                source_motif_ids=[motif.motif_id],
+                source_expectation_ids=[
+                    expectations_by_motif[motif.motif_id]
+                ]
+                if motif.motif_id in expectations_by_motif
+                else [],
+                support_score=motif.support_score,
+                confidence_score=motif.confidence_score,
+                proposed_schema=dict(spec["proposed_schema"]),  # type: ignore[arg-type]
+                promotion_status="candidate_only",
+                reasons=[str(spec["reason"])],
+                evidence_refs=list(motif.evidence_frame_ids),
+            )
+        )
+    return out

--- a/orion/consolidation/tensorize.py
+++ b/orion/consolidation/tensorize.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.consolidation.policy import ConsolidationPolicyV1
+from orion.consolidation.windows import ConsolidationWindowData
+from orion.schemas.consolidation_frame import ExpectationV1, MotifObservationV1, SparseTensorSliceV1
+from orion.schemas.execution_dispatch_frame import ExecutionDispatchCandidateV1, ExecutionDispatchFrameV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
+from orion.schemas.proposal_frame import ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+
+def _time_bucket(dt: datetime) -> str:
+    normalized = dt.astimezone(timezone.utc).replace(second=0, microsecond=0)
+    return normalized.isoformat()
+
+
+def _stable_tensor_id(*, tensor_kind: str, window: ConsolidationWindowData) -> str:
+    ws = window.window_start.astimezone(timezone.utc).isoformat()
+    we = window.window_end.astimezone(timezone.utc).isoformat()
+    return f"tensor:{tensor_kind}:{ws}:{we}"
+
+
+def _attention_target_ids(frame: FieldAttentionFrameV1) -> list[str]:
+    ids: list[str] = []
+    seen: set[str] = set()
+    for bucket in (
+        frame.dominant_targets,
+        frame.node_targets,
+        frame.capability_targets,
+        frame.system_targets,
+    ):
+        for target in bucket:
+            target_id = f"{target.target_kind}:{target.target_id}"
+            if target_id not in seen:
+                seen.add(target_id)
+                ids.append(target_id)
+    return ids
+
+
+def _cap_slice(
+    *,
+    coordinates: list[dict[str, str]],
+    values: list[float],
+    evidence_refs: list[str],
+    max_coordinates: int,
+) -> tuple[list[dict[str, str]], list[float], list[str]]:
+    if len(coordinates) <= max_coordinates:
+        return coordinates, values, evidence_refs
+    return coordinates[:max_coordinates], values[:max_coordinates], evidence_refs[:max_coordinates]
+
+
+def _build_field_attention_self_slice(
+    *,
+    window: ConsolidationWindowData,
+    policy: ConsolidationPolicyV1,
+) -> SparseTensorSliceV1:
+    axes = list(policy.tensor_axes.get("field_attention_self", []))
+    attention_by_id = {frame.frame_id: frame for frame in window.attention_frames}
+    attention_by_bucket: dict[str, list[FieldAttentionFrameV1]] = {}
+    for frame in window.attention_frames:
+        attention_by_bucket.setdefault(_time_bucket(frame.generated_at), []).append(frame)
+
+    coordinates: list[dict[str, str]] = []
+    values: list[float] = []
+    evidence_refs: list[str] = []
+
+    for state in window.self_states:
+        linked = attention_by_id.get(state.source_attention_frame_id)
+        bucket_frames = attention_by_bucket.get(_time_bucket(state.generated_at), [])
+        frames = [linked] if linked is not None else bucket_frames
+        targets: list[str] = []
+        for frame in frames:
+            if frame is None:
+                continue
+            targets.extend(_attention_target_ids(frame))
+        if not targets:
+            targets = ["unknown:unknown"]
+        for dimension_id in policy.tracked_self_dimensions:
+            dim = state.dimensions.get(dimension_id)
+            if dim is None:
+                continue
+            for target_id in targets:
+                coordinates.append(
+                    {
+                        "time_bucket": _time_bucket(state.generated_at),
+                        "self_condition": state.overall_condition,
+                        "attention_target": target_id,
+                        "dimension": dimension_id,
+                    }
+                )
+                values.append(float(dim.score))
+                evidence_refs.append(state.self_state_id)
+
+    coordinates, values, evidence_refs = _cap_slice(
+        coordinates=coordinates,
+        values=values,
+        evidence_refs=evidence_refs,
+        max_coordinates=policy.tensor.max_coordinates,
+    )
+    return SparseTensorSliceV1(
+        tensor_id=_stable_tensor_id(tensor_kind="field_attention_self", window=window),
+        tensor_kind="field_attention_self",
+        axes=axes,
+        coordinates=coordinates,
+        values=values,
+        evidence_refs=sorted(set(evidence_refs)),
+    )
+
+
+def _proposal_kind(proposal_frames: list[ProposalFrameV1], proposal_frame_id: str) -> str:
+    frame = next((item for item in proposal_frames if item.frame_id == proposal_frame_id), None)
+    if frame is None or not frame.candidates:
+        return "unknown"
+    return frame.candidates[0].proposal_kind
+
+
+def _policy_decision(policy_frames: list[PolicyDecisionFrameV1], policy_frame_id: str) -> str:
+    frame = next((item for item in policy_frames if item.frame_id == policy_frame_id), None)
+    if frame is None or not frame.decisions:
+        return "unknown"
+    if frame.approved_decisions:
+        return frame.approved_decisions[0].decision
+    return frame.decisions[0].decision
+
+
+def _feedback_outcome(
+    *,
+    dispatch_frame_id: str,
+    feedback_by_dispatch: dict[str, str],
+) -> str:
+    return feedback_by_dispatch.get(dispatch_frame_id, "absent")
+
+
+def _append_dispatch_path(
+    *,
+    coordinates: list[dict[str, str]],
+    values: list[float],
+    evidence_refs: list[str],
+    candidate: ExecutionDispatchCandidateV1,
+    dispatch_frame: ExecutionDispatchFrameV1,
+    proposal_kind: str,
+    policy_decision: str,
+    feedback_outcome: str,
+) -> None:
+    coordinates.append(
+        {
+            "proposal_kind": proposal_kind,
+            "policy_decision": policy_decision,
+            "dispatch_status": candidate.dispatch_status,
+            "feedback_outcome": feedback_outcome,
+        }
+    )
+    values.append(1.0)
+    evidence_refs.append(dispatch_frame.frame_id)
+
+
+def _build_policy_dispatch_feedback_slice(
+    *,
+    window: ConsolidationWindowData,
+    policy: ConsolidationPolicyV1,
+) -> SparseTensorSliceV1:
+    axes = list(policy.tensor_axes.get("policy_dispatch_feedback", []))
+    feedback_by_dispatch = {
+        frame.source_execution_dispatch_frame_id: frame.outcome_status
+        for frame in window.feedback_frames
+    }
+    coordinates: list[dict[str, str]] = []
+    values: list[float] = []
+    evidence_refs: list[str] = []
+
+    for dispatch_frame in window.dispatch_frames:
+        proposal_kind = _proposal_kind(window.proposal_frames, dispatch_frame.source_proposal_frame_id)
+        policy_decision = _policy_decision(window.policy_frames, dispatch_frame.source_policy_frame_id)
+        feedback_outcome = _feedback_outcome(
+            dispatch_frame_id=dispatch_frame.frame_id,
+            feedback_by_dispatch=feedback_by_dispatch,
+        )
+        for bucket in (
+            dispatch_frame.candidates,
+            dispatch_frame.blocked_candidates,
+            dispatch_frame.dispatched_candidates,
+        ):
+            for candidate in bucket:
+                _append_dispatch_path(
+                    coordinates=coordinates,
+                    values=values,
+                    evidence_refs=evidence_refs,
+                    candidate=candidate,
+                    dispatch_frame=dispatch_frame,
+                    proposal_kind=proposal_kind,
+                    policy_decision=policy_decision,
+                    feedback_outcome=feedback_outcome,
+                )
+
+    coordinates, values, evidence_refs = _cap_slice(
+        coordinates=coordinates,
+        values=values,
+        evidence_refs=evidence_refs,
+        max_coordinates=policy.tensor.max_coordinates,
+    )
+    return SparseTensorSliceV1(
+        tensor_id=_stable_tensor_id(tensor_kind="policy_dispatch_feedback", window=window),
+        tensor_kind="policy_dispatch_feedback",
+        axes=axes,
+        coordinates=coordinates,
+        values=values,
+        evidence_refs=sorted(set(evidence_refs)),
+    )
+
+
+def _self_condition_for_motif(
+    *,
+    motif: MotifObservationV1,
+    self_states: list[SelfStateV1],
+) -> str:
+    for state in self_states:
+        if state.self_state_id in motif.evidence_frame_ids:
+            return state.overall_condition
+    if self_states:
+        return self_states[0].overall_condition
+    return "unknown"
+
+
+def _outcome_status_for_motif(
+    *,
+    motif: MotifObservationV1,
+    feedback_by_id: dict[str, str],
+) -> str:
+    for frame_id in motif.evidence_frame_ids:
+        if frame_id in feedback_by_id:
+            return feedback_by_id[frame_id]
+    if feedback_by_id:
+        return next(iter(feedback_by_id.values()))
+    return "unknown"
+
+
+def _build_motif_condition_outcome_slice(
+    *,
+    window: ConsolidationWindowData,
+    motifs: list[MotifObservationV1],
+    policy: ConsolidationPolicyV1,
+) -> SparseTensorSliceV1:
+    axes = list(policy.tensor_axes.get("motif_condition_outcome", []))
+    feedback_by_id = {frame.frame_id: frame.outcome_status for frame in window.feedback_frames}
+    coordinates: list[dict[str, str]] = []
+    values: list[float] = []
+    evidence_refs: list[str] = []
+
+    for motif in motifs:
+        coordinates.append(
+            {
+                "motif": motif.label,
+                "self_condition": _self_condition_for_motif(motif=motif, self_states=window.self_states),
+                "outcome_status": _outcome_status_for_motif(motif=motif, feedback_by_id=feedback_by_id),
+            }
+        )
+        values.append(float(motif.support_score))
+        evidence_refs.extend(motif.evidence_frame_ids)
+
+    coordinates, values, evidence_refs = _cap_slice(
+        coordinates=coordinates,
+        values=values,
+        evidence_refs=evidence_refs,
+        max_coordinates=policy.tensor.max_coordinates,
+    )
+    return SparseTensorSliceV1(
+        tensor_id=_stable_tensor_id(tensor_kind="motif_condition_outcome", window=window),
+        tensor_kind="motif_condition_outcome",
+        axes=axes,
+        coordinates=coordinates,
+        values=values,
+        evidence_refs=sorted(set(evidence_refs)),
+    )
+
+
+def build_sparse_tensor_slices(
+    *,
+    window: ConsolidationWindowData,
+    motifs: list[MotifObservationV1],
+    expectations: list[ExpectationV1],
+    policy: ConsolidationPolicyV1,
+) -> list[SparseTensorSliceV1]:
+    del expectations
+    if not policy.tensor.enabled:
+        return []
+    return [
+        _build_field_attention_self_slice(window=window, policy=policy),
+        _build_policy_dispatch_feedback_slice(window=window, policy=policy),
+        _build_motif_condition_outcome_slice(window=window, motifs=motifs, policy=policy),
+    ]

--- a/orion/consolidation/windows.py
+++ b/orion/consolidation/windows.py
@@ -28,11 +28,24 @@ def compute_consolidation_window(
     now: datetime | None = None,
     lookback_minutes: int,
 ) -> tuple[datetime, datetime]:
+    """Return a stable UTC window aligned to lookback bucket boundaries.
+
+    For lookback_minutes=60, window_end is truncated to the hour so repeated
+    polls within the same hour share one frame_id (idempotent per window).
+    """
     end = now or datetime.now(timezone.utc)
     if end.tzinfo is None:
         end = end.replace(tzinfo=timezone.utc)
-    start = end - timedelta(minutes=lookback_minutes)
-    return start, end
+    else:
+        end = end.astimezone(timezone.utc)
+
+    bucket_minutes = max(1, lookback_minutes)
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    total_minutes = int((end - epoch).total_seconds() // 60)
+    aligned_end_minutes = (total_minutes // bucket_minutes) * bucket_minutes
+    window_end = epoch + timedelta(minutes=aligned_end_minutes)
+    window_start = window_end - timedelta(minutes=lookback_minutes)
+    return window_start, window_end
 
 
 def stable_consolidation_frame_id(

--- a/orion/consolidation/windows.py
+++ b/orion/consolidation/windows.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
+from orion.schemas.proposal_frame import ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+
+@dataclass(frozen=True)
+class ConsolidationWindowData:
+    window_start: datetime
+    window_end: datetime
+    self_states: list[SelfStateV1]
+    attention_frames: list[FieldAttentionFrameV1]
+    proposal_frames: list[ProposalFrameV1]
+    policy_frames: list[PolicyDecisionFrameV1]
+    dispatch_frames: list[ExecutionDispatchFrameV1]
+    feedback_frames: list[FeedbackFrameV1]
+
+
+def compute_consolidation_window(
+    *,
+    now: datetime | None = None,
+    lookback_minutes: int,
+) -> tuple[datetime, datetime]:
+    end = now or datetime.now(timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+    start = end - timedelta(minutes=lookback_minutes)
+    return start, end
+
+
+def stable_consolidation_frame_id(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    policy_id: str,
+) -> str:
+    ws = window_start.astimezone(timezone.utc).isoformat()
+    we = window_end.astimezone(timezone.utc).isoformat()
+    return f"consolidation.frame:{ws}:{we}:{policy_id}"

--- a/orion/schemas/consolidation_frame.py
+++ b/orion/schemas/consolidation_frame.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MotifObservationV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    motif_id: str
+
+    motif_kind: Literal[
+        "field_pattern",
+        "attention_pattern",
+        "self_state_pattern",
+        "proposal_policy_pattern",
+        "dispatch_feedback_pattern",
+        "absence_pattern",
+        "stability_pattern",
+    ]
+
+    label: str
+
+    recurrence_count: int = Field(ge=1)
+    support_score: float = Field(ge=0.0, le=1.0)
+    confidence_score: float = Field(ge=0.0, le=1.0)
+
+    evidence_frame_ids: list[str] = Field(default_factory=list)
+    dominant_dimensions: dict[str, float] = Field(default_factory=dict)
+    dominant_channels: dict[str, float] = Field(default_factory=dict)
+
+    first_seen_at: datetime | None = None
+    last_seen_at: datetime | None = None
+
+    reasons: list[str] = Field(default_factory=list)
+
+
+class ConsolidationFrameV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["consolidation.frame.v1"] = "consolidation.frame.v1"
+
+    frame_id: str
+    generated_at: datetime
+
+    window_start: datetime
+    window_end: datetime
+
+    consolidation_policy_id: str = "consolidation_policy.v1"
+
+    motif_observations: list[MotifObservationV1] = Field(default_factory=list)
+    dominant_motifs: list[str] = Field(default_factory=list)
+
+    source_counts: dict[str, int] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)

--- a/orion/schemas/consolidation_frame.py
+++ b/orion/schemas/consolidation_frame.py
@@ -37,6 +37,33 @@ class MotifObservationV1(BaseModel):
     reasons: list[str] = Field(default_factory=list)
 
 
+class ExpectationV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expectation_id: str
+
+    trigger_motif_id: str
+
+    expected_outcome_kind: Literal[
+        "loaded_self_state",
+        "attention_saturation",
+        "policy_review_required",
+        "read_only_approved",
+        "dry_run_feedback",
+        "absence_feedback",
+        "reliability_clear",
+        "execution_pressure_high",
+        "resource_pressure_high",
+        "unknown",
+    ]
+
+    confidence_score: float = Field(ge=0.0, le=1.0)
+    support_count: int = Field(ge=1)
+
+    evidence_refs: list[str] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+
+
 class ConsolidationFrameV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -52,6 +79,8 @@ class ConsolidationFrameV1(BaseModel):
 
     motif_observations: list[MotifObservationV1] = Field(default_factory=list)
     dominant_motifs: list[str] = Field(default_factory=list)
+
+    expectations: list[ExpectationV1] = Field(default_factory=list)
 
     source_counts: dict[str, int] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)

--- a/orion/schemas/consolidation_frame.py
+++ b/orion/schemas/consolidation_frame.py
@@ -83,6 +83,40 @@ class SparseTensorSliceV1(BaseModel):
     evidence_refs: list[str] = Field(default_factory=list)
 
 
+class SchemaCandidateV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_candidate_id: str
+
+    candidate_kind: Literal[
+        "concept_candidate",
+        "habit_candidate",
+        "prior_candidate",
+        "ontology_candidate",
+        "policy_candidate",
+    ]
+
+    label: str
+
+    source_motif_ids: list[str] = Field(default_factory=list)
+    source_expectation_ids: list[str] = Field(default_factory=list)
+
+    support_score: float = Field(ge=0.0, le=1.0)
+    confidence_score: float = Field(ge=0.0, le=1.0)
+
+    proposed_schema: dict[str, object] = Field(default_factory=dict)
+
+    promotion_status: Literal[
+        "candidate_only",
+        "needs_review",
+        "rejected",
+        "promoted_elsewhere",
+    ] = "candidate_only"
+
+    reasons: list[str] = Field(default_factory=list)
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
 class ConsolidationFrameV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -101,6 +135,7 @@ class ConsolidationFrameV1(BaseModel):
 
     expectations: list[ExpectationV1] = Field(default_factory=list)
     tensor_slices: list[SparseTensorSliceV1] = Field(default_factory=list)
+    schema_candidates: list[SchemaCandidateV1] = Field(default_factory=list)
 
     source_counts: dict[str, int] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)

--- a/orion/schemas/consolidation_frame.py
+++ b/orion/schemas/consolidation_frame.py
@@ -64,6 +64,25 @@ class ExpectationV1(BaseModel):
     reasons: list[str] = Field(default_factory=list)
 
 
+class SparseTensorSliceV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tensor_id: str
+
+    tensor_kind: Literal[
+        "substrate_history_sparse",
+        "motif_condition_outcome",
+        "field_attention_self",
+        "policy_dispatch_feedback",
+    ]
+
+    axes: list[str] = Field(default_factory=list)
+    coordinates: list[dict[str, str]] = Field(default_factory=list)
+    values: list[float] = Field(default_factory=list)
+
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
 class ConsolidationFrameV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -81,6 +100,7 @@ class ConsolidationFrameV1(BaseModel):
     dominant_motifs: list[str] = Field(default_factory=list)
 
     expectations: list[ExpectationV1] = Field(default_factory=list)
+    tensor_slices: list[SparseTensorSliceV1] = Field(default_factory=list)
 
     source_counts: dict[str, int] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -465,7 +465,13 @@ from orion.schemas.execution_dispatch_frame import (
     ExecutionDispatchCandidateV1,
     ExecutionDispatchFrameV1,
 )
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, MotifObservationV1, SparseTensorSliceV1
+from orion.schemas.consolidation_frame import (
+    ConsolidationFrameV1,
+    ExpectationV1,
+    MotifObservationV1,
+    SchemaCandidateV1,
+    SparseTensorSliceV1,
+)
 from orion.schemas.feedback_frame import FeedbackFrameV1, OutcomeObservationV1
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
 from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
@@ -961,6 +967,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "MotifObservationV1": MotifObservationV1,
     "ExpectationV1": ExpectationV1,
     "SparseTensorSliceV1": SparseTensorSliceV1,
+    "SchemaCandidateV1": SchemaCandidateV1,
     "FeedbackFrameV1": FeedbackFrameV1,
     "OutcomeObservationV1": OutcomeObservationV1,
     "EvidenceUnitV1": EvidenceUnitV1,

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -465,7 +465,7 @@ from orion.schemas.execution_dispatch_frame import (
     ExecutionDispatchCandidateV1,
     ExecutionDispatchFrameV1,
 )
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, MotifObservationV1
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, MotifObservationV1
 from orion.schemas.feedback_frame import FeedbackFrameV1, OutcomeObservationV1
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
 from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
@@ -959,6 +959,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "ExecutionDispatchFrameV1": ExecutionDispatchFrameV1,
     "ConsolidationFrameV1": ConsolidationFrameV1,
     "MotifObservationV1": MotifObservationV1,
+    "ExpectationV1": ExpectationV1,
     "FeedbackFrameV1": FeedbackFrameV1,
     "OutcomeObservationV1": OutcomeObservationV1,
     "EvidenceUnitV1": EvidenceUnitV1,

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -465,7 +465,7 @@ from orion.schemas.execution_dispatch_frame import (
     ExecutionDispatchCandidateV1,
     ExecutionDispatchFrameV1,
 )
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, MotifObservationV1
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, MotifObservationV1, SparseTensorSliceV1
 from orion.schemas.feedback_frame import FeedbackFrameV1, OutcomeObservationV1
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
 from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
@@ -960,6 +960,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "ConsolidationFrameV1": ConsolidationFrameV1,
     "MotifObservationV1": MotifObservationV1,
     "ExpectationV1": ExpectationV1,
+    "SparseTensorSliceV1": SparseTensorSliceV1,
     "FeedbackFrameV1": FeedbackFrameV1,
     "OutcomeObservationV1": OutcomeObservationV1,
     "EvidenceUnitV1": EvidenceUnitV1,

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -465,6 +465,7 @@ from orion.schemas.execution_dispatch_frame import (
     ExecutionDispatchCandidateV1,
     ExecutionDispatchFrameV1,
 )
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, MotifObservationV1
 from orion.schemas.feedback_frame import FeedbackFrameV1, OutcomeObservationV1
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
 from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
@@ -956,6 +957,8 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "ProposalFrameV1": ProposalFrameV1,
     "ExecutionDispatchCandidateV1": ExecutionDispatchCandidateV1,
     "ExecutionDispatchFrameV1": ExecutionDispatchFrameV1,
+    "ConsolidationFrameV1": ConsolidationFrameV1,
+    "MotifObservationV1": MotifObservationV1,
     "FeedbackFrameV1": FeedbackFrameV1,
     "OutcomeObservationV1": OutcomeObservationV1,
     "EvidenceUnitV1": EvidenceUnitV1,

--- a/scripts/smoke_consolidation_v1.sh
+++ b/scripts/smoke_consolidation_v1.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PROJECT="${PROJECT:-orion-athena}"
+DB="${PROJECT}-sql-db"
+PSQL=(docker exec -i "$DB" psql -U postgres -d conjourney -v ON_ERROR_STOP=1)
+
+echo "=== Latest feedback frame ==="
+"${PSQL[@]}" -c "
+select
+    generated_at,
+    frame_id,
+    feedback_frame_json #>> '{outcome_status}' as outcome_status,
+    feedback_frame_json #>> '{outcome_score}' as outcome_score,
+    jsonb_array_length(feedback_frame_json #> '{observations}') as observation_count,
+    feedback_frame_json #> '{absence_evidence}' as absence_evidence
+from substrate_feedback_frames
+order by generated_at desc
+limit 1;
+"
+
+echo "=== Latest self-state ==="
+"${PSQL[@]}" -c "
+select
+    generated_at,
+    self_state_id,
+    source_field_tick_id,
+    source_attention_frame_id,
+    self_state_json #>> '{overall_condition}' as overall_condition,
+    self_state_json #>> '{overall_intensity}' as overall_intensity,
+    self_state_json #> '{dimensions}' as dimensions,
+    self_state_json #> '{dominant_attention_targets}' as dominant_attention_targets,
+    self_state_json #> '{summary_labels}' as summary_labels
+from substrate_self_state
+order by generated_at desc
+limit 1;
+"
+
+echo "=== Latest consolidation frame ==="
+"${PSQL[@]}" -c "
+select
+    generated_at,
+    frame_id,
+    window_start,
+    window_end,
+    consolidation_frame_json #> '{dominant_motifs}' as dominant_motifs,
+    consolidation_frame_json #> '{motif_observations}' as motif_observations,
+    consolidation_frame_json #> '{source_counts}' as source_counts
+from substrate_consolidation_frames
+order by generated_at desc
+limit 1;
+"

--- a/services/orion-consolidation-runtime/.env_example
+++ b/services/orion-consolidation-runtime/.env_example
@@ -1,0 +1,12 @@
+# orion-consolidation-runtime — Layer 11 consolidation (docker compose)
+# Requires: substrate_feedback_frames, substrate_self_state, substrate_attention_frames, etc.
+# Apply migrations: services/orion-sql-db/manual_migration_consolidation_v1.sql (+ later phase migrations)
+PROJECT=orion-athena
+SERVICE_NAME=orion-consolidation-runtime
+SERVICE_VERSION=0.1.0
+POSTGRES_URI=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+CONSOLIDATION_POLICY_PATH=/app/config/consolidation/consolidation_policy.v1.yaml
+CONSOLIDATION_POLL_INTERVAL_SEC=60.0
+ENABLE_CONSOLIDATION_RUNTIME=true
+LOG_LEVEL=INFO
+CONSOLIDATION_RUNTIME_PORT=8123

--- a/services/orion-consolidation-runtime/Dockerfile
+++ b/services/orion-consolidation-runtime/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir --upgrade pip
+
+COPY services/orion-consolidation-runtime/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY orion /app/orion
+COPY config/consolidation /app/config/consolidation
+COPY services/orion-consolidation-runtime /app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8123"]

--- a/services/orion-consolidation-runtime/README.md
+++ b/services/orion-consolidation-runtime/README.md
@@ -1,0 +1,47 @@
+# orion-consolidation-runtime
+
+Layer 11 of the Orion cognition substrate: aggregates Layers 5–10 substrate history over a time window and persists `ConsolidationFrameV1` motif snapshots.
+
+**Consolidation is pattern observation, not learning.** This service does not mutate policy, publish to the bus, invoke an LLM, or change runtime behavior.
+
+## Inputs
+
+- `substrate_self_state`
+- `substrate_attention_frames`
+- `substrate_proposal_frames`
+- `substrate_policy_decision_frames`
+- `substrate_execution_dispatch_frames`
+- `substrate_feedback_frames`
+
+## Outputs
+
+- `substrate_consolidation_frames`
+
+## Port
+
+`8123` (`CONSOLIDATION_RUNTIME_PORT`)
+
+## Migration
+
+```bash
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < services/orion-sql-db/manual_migration_consolidation_v1.sql
+```
+
+## Run
+
+```bash
+cd services/orion-consolidation-runtime
+cp -n .env_example .env
+docker compose up -d --build
+```
+
+## Smoke
+
+```bash
+./scripts/smoke_consolidation_v1.sh
+```
+
+## Idempotency
+
+One frame per `(window_start, window_end, policy_id)` via stable `frame_id`. Re-runs use `INSERT ... ON CONFLICT (frame_id) DO NOTHING`.

--- a/services/orion-consolidation-runtime/app/main.py
+++ b/services/orion-consolidation-runtime/app/main.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from app.settings import get_settings
+from app.store import ConsolidationRuntimeStore
+from app.worker import ConsolidationRuntimeWorker
+
+_settings = get_settings()
+logging.basicConfig(level=getattr(logging, _settings.log_level.upper(), logging.INFO))
+
+worker = ConsolidationRuntimeWorker()
+store = ConsolidationRuntimeStore(_settings.postgres_uri)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await worker.start()
+    try:
+        yield
+    finally:
+        await worker.stop()
+
+
+app = FastAPI(title="orion-consolidation-runtime", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "service": get_settings().service_name}
+
+
+@app.get("/latest")
+async def latest() -> dict[str, Any]:
+    frame = store.load_latest_consolidation_frame()
+    if frame is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return frame.model_dump(mode="json")

--- a/services/orion-consolidation-runtime/app/settings.py
+++ b/services/orion-consolidation-runtime/app/settings.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    project: str = Field("orion-athena", alias="PROJECT")
+    service_name: str = Field("orion-consolidation-runtime", alias="SERVICE_NAME")
+    service_version: str = Field("0.1.0", alias="SERVICE_VERSION")
+
+    postgres_uri: str = Field(..., alias="POSTGRES_URI")
+    consolidation_policy_path: str = Field(
+        "config/consolidation/consolidation_policy.v1.yaml",
+        alias="CONSOLIDATION_POLICY_PATH",
+    )
+    consolidation_poll_interval_sec: float = Field(
+        60.0,
+        alias="CONSOLIDATION_POLL_INTERVAL_SEC",
+    )
+    enable_consolidation_runtime: bool = Field(
+        True,
+        alias="ENABLE_CONSOLIDATION_RUNTIME",
+    )
+    log_level: str = Field("INFO", alias="LOG_LEVEL")
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings

--- a/services/orion-consolidation-runtime/app/store.py
+++ b/services/orion-consolidation-runtime/app/store.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
 from orion.consolidation.windows import ConsolidationWindowData
-from orion.schemas.consolidation_frame import ConsolidationFrameV1
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1
 from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
 from orion.schemas.feedback_frame import FeedbackFrameV1
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1
@@ -209,6 +209,44 @@ class ConsolidationRuntimeStore:
                     "created_at": now,
                 },
             )
+
+    def upsert_expectations(self, expectations: list[ExpectationV1]) -> None:
+        if not expectations:
+            return
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            for expectation in expectations:
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO substrate_expectations (
+                            expectation_id,
+                            trigger_motif_id,
+                            expected_outcome_kind,
+                            expectation_json,
+                            updated_at
+                        ) VALUES (
+                            :expectation_id,
+                            :trigger_motif_id,
+                            :expected_outcome_kind,
+                            :expectation_json,
+                            :updated_at
+                        )
+                        ON CONFLICT (expectation_id) DO UPDATE SET
+                            trigger_motif_id = EXCLUDED.trigger_motif_id,
+                            expected_outcome_kind = EXCLUDED.expected_outcome_kind,
+                            expectation_json = EXCLUDED.expectation_json,
+                            updated_at = EXCLUDED.updated_at
+                        """
+                    ),
+                    {
+                        "expectation_id": expectation.expectation_id,
+                        "trigger_motif_id": expectation.trigger_motif_id,
+                        "expected_outcome_kind": expectation.expected_outcome_kind,
+                        "expectation_json": Json(expectation.model_dump(mode="json")),
+                        "updated_at": now,
+                    },
+                )
 
     def _load_rows(
         self,

--- a/services/orion-consolidation-runtime/app/store.py
+++ b/services/orion-consolidation-runtime/app/store.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
 from orion.consolidation.windows import ConsolidationWindowData
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, SparseTensorSliceV1
 from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
 from orion.schemas.feedback_frame import FeedbackFrameV1
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1
@@ -245,6 +245,48 @@ class ConsolidationRuntimeStore:
                         "expected_outcome_kind": expectation.expected_outcome_kind,
                         "expectation_json": Json(expectation.model_dump(mode="json")),
                         "updated_at": now,
+                    },
+                )
+
+    def save_tensor_slices(
+        self,
+        slices: list[SparseTensorSliceV1],
+        window_start: datetime,
+        window_end: datetime,
+    ) -> None:
+        if not slices:
+            return
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            for tensor_slice in slices:
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO substrate_tensor_slices (
+                            tensor_id,
+                            tensor_kind,
+                            window_start,
+                            window_end,
+                            tensor_json,
+                            created_at
+                        ) VALUES (
+                            :tensor_id,
+                            :tensor_kind,
+                            :window_start,
+                            :window_end,
+                            :tensor_json,
+                            :created_at
+                        )
+                        ON CONFLICT (tensor_id) DO NOTHING
+                        """
+                    ),
+                    {
+                        "tensor_id": tensor_slice.tensor_id,
+                        "tensor_kind": tensor_slice.tensor_kind,
+                        "window_start": window_start,
+                        "window_end": window_end,
+                        "tensor_json": Json(tensor_slice.model_dump(mode="json")),
+                        "created_at": now,
                     },
                 )
 

--- a/services/orion-consolidation-runtime/app/store.py
+++ b/services/orion-consolidation-runtime/app/store.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Callable, TypeVar
+
+from psycopg2.extras import Json
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from orion.consolidation.windows import ConsolidationWindowData
+from orion.schemas.consolidation_frame import ConsolidationFrameV1
+from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
+from orion.schemas.proposal_frame import ProposalFrameV1
+from orion.schemas.self_state import SelfStateV1
+
+T = TypeVar("T")
+
+
+class ConsolidationRuntimeStore:
+    def __init__(self, postgres_uri: str) -> None:
+        self._engine: Engine = create_engine(
+            postgres_uri,
+            pool_pre_ping=True,
+            json_serializer=json.dumps,
+            json_deserializer=json.loads,
+        )
+
+    def load_consolidation_frame_for_window(
+        self, frame_id: str
+    ) -> ConsolidationFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT consolidation_frame_json
+                        FROM substrate_consolidation_frames
+                        WHERE frame_id = :frame_id
+                        LIMIT 1
+                        """
+                    ),
+                    {"frame_id": frame_id},
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        return self._parse_json(row["consolidation_frame_json"], ConsolidationFrameV1)
+
+    def load_latest_consolidation_frame(self) -> ConsolidationFrameV1 | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT consolidation_frame_json
+                        FROM substrate_consolidation_frames
+                        ORDER BY generated_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        return self._parse_json(row["consolidation_frame_json"], ConsolidationFrameV1)
+
+    def load_window_data(
+        self,
+        window_start: datetime,
+        window_end: datetime,
+        max_per_source: int,
+    ) -> ConsolidationWindowData:
+        return ConsolidationWindowData(
+            window_start=window_start,
+            window_end=window_end,
+            self_states=self._load_rows(
+                """
+                SELECT self_state_json
+                FROM substrate_self_state
+                WHERE generated_at >= :window_start
+                  AND generated_at < :window_end
+                ORDER BY generated_at DESC
+                LIMIT :max_per_source
+                """,
+                window_start,
+                window_end,
+                max_per_source,
+                SelfStateV1,
+                "self_state_json",
+            ),
+            attention_frames=self._load_rows(
+                """
+                SELECT frame_json
+                FROM substrate_attention_frames
+                WHERE generated_at >= :window_start
+                  AND generated_at < :window_end
+                ORDER BY generated_at DESC
+                LIMIT :max_per_source
+                """,
+                window_start,
+                window_end,
+                max_per_source,
+                FieldAttentionFrameV1,
+                "frame_json",
+            ),
+            proposal_frames=self._load_rows(
+                """
+                SELECT proposal_frame_json
+                FROM substrate_proposal_frames
+                WHERE generated_at >= :window_start
+                  AND generated_at < :window_end
+                ORDER BY generated_at DESC
+                LIMIT :max_per_source
+                """,
+                window_start,
+                window_end,
+                max_per_source,
+                ProposalFrameV1,
+                "proposal_frame_json",
+            ),
+            policy_frames=self._load_rows(
+                """
+                SELECT policy_decision_frame_json
+                FROM substrate_policy_decision_frames
+                WHERE generated_at >= :window_start
+                  AND generated_at < :window_end
+                ORDER BY generated_at DESC
+                LIMIT :max_per_source
+                """,
+                window_start,
+                window_end,
+                max_per_source,
+                PolicyDecisionFrameV1,
+                "policy_decision_frame_json",
+            ),
+            dispatch_frames=self._load_rows(
+                """
+                SELECT dispatch_frame_json
+                FROM substrate_execution_dispatch_frames
+                WHERE generated_at >= :window_start
+                  AND generated_at < :window_end
+                ORDER BY generated_at DESC
+                LIMIT :max_per_source
+                """,
+                window_start,
+                window_end,
+                max_per_source,
+                ExecutionDispatchFrameV1,
+                "dispatch_frame_json",
+            ),
+            feedback_frames=self._load_rows(
+                """
+                SELECT feedback_frame_json
+                FROM substrate_feedback_frames
+                WHERE generated_at >= :window_start
+                  AND generated_at < :window_end
+                ORDER BY generated_at DESC
+                LIMIT :max_per_source
+                """,
+                window_start,
+                window_end,
+                max_per_source,
+                FeedbackFrameV1,
+                "feedback_frame_json",
+            ),
+        )
+
+    def save_consolidation_frame(self, frame: ConsolidationFrameV1) -> None:
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO substrate_consolidation_frames (
+                        frame_id,
+                        window_start,
+                        window_end,
+                        generated_at,
+                        policy_id,
+                        consolidation_frame_json,
+                        created_at
+                    ) VALUES (
+                        :frame_id,
+                        :window_start,
+                        :window_end,
+                        :generated_at,
+                        :policy_id,
+                        :consolidation_frame_json,
+                        :created_at
+                    )
+                    ON CONFLICT (frame_id) DO NOTHING
+                    """
+                ),
+                {
+                    "frame_id": frame.frame_id,
+                    "window_start": frame.window_start,
+                    "window_end": frame.window_end,
+                    "generated_at": frame.generated_at,
+                    "policy_id": frame.consolidation_policy_id,
+                    "consolidation_frame_json": Json(frame.model_dump(mode="json")),
+                    "created_at": now,
+                },
+            )
+
+    def _load_rows(
+        self,
+        sql: str,
+        window_start: datetime,
+        window_end: datetime,
+        max_per_source: int,
+        model: Callable[[dict], T],
+        json_column: str,
+    ) -> list[T]:
+        with self._engine.connect() as conn:
+            rows = conn.execute(
+                text(sql),
+                {
+                    "window_start": window_start,
+                    "window_end": window_end,
+                    "max_per_source": max_per_source,
+                },
+            ).mappings()
+            return [
+                self._parse_json(row[json_column], model)
+                for row in rows
+                if row.get(json_column) is not None
+            ]
+
+    @staticmethod
+    def _parse_json(payload: object, model: Callable[[dict], T]) -> T:
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return model.model_validate(payload)

--- a/services/orion-consolidation-runtime/app/store.py
+++ b/services/orion-consolidation-runtime/app/store.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
 from orion.consolidation.windows import ConsolidationWindowData
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, SparseTensorSliceV1
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, SchemaCandidateV1, SparseTensorSliceV1
 from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
 from orion.schemas.feedback_frame import FeedbackFrameV1
 from orion.schemas.field_attention_frame import FieldAttentionFrameV1
@@ -287,6 +287,48 @@ class ConsolidationRuntimeStore:
                         "window_end": window_end,
                         "tensor_json": Json(tensor_slice.model_dump(mode="json")),
                         "created_at": now,
+                    },
+                )
+
+    def upsert_schema_candidates(self, candidates: list[SchemaCandidateV1]) -> None:
+        if not candidates:
+            return
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            for candidate in candidates:
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO substrate_schema_candidates (
+                            schema_candidate_id,
+                            candidate_kind,
+                            label,
+                            promotion_status,
+                            schema_candidate_json,
+                            updated_at
+                        ) VALUES (
+                            :schema_candidate_id,
+                            :candidate_kind,
+                            :label,
+                            :promotion_status,
+                            :schema_candidate_json,
+                            :updated_at
+                        )
+                        ON CONFLICT (schema_candidate_id) DO UPDATE SET
+                            candidate_kind = EXCLUDED.candidate_kind,
+                            label = EXCLUDED.label,
+                            promotion_status = EXCLUDED.promotion_status,
+                            schema_candidate_json = EXCLUDED.schema_candidate_json,
+                            updated_at = EXCLUDED.updated_at
+                        """
+                    ),
+                    {
+                        "schema_candidate_id": candidate.schema_candidate_id,
+                        "candidate_kind": candidate.candidate_kind,
+                        "label": candidate.label,
+                        "promotion_status": candidate.promotion_status,
+                        "schema_candidate_json": Json(candidate.model_dump(mode="json")),
+                        "updated_at": now,
                     },
                 )
 

--- a/services/orion-consolidation-runtime/app/worker.py
+++ b/services/orion-consolidation-runtime/app/worker.py
@@ -68,11 +68,17 @@ class ConsolidationRuntimeWorker:
         frame = build_consolidation_frame(window=data, policy=self._policy)
         self._store.save_consolidation_frame(frame)
         self._store.upsert_expectations(frame.expectations)
+        self._store.save_tensor_slices(
+            frame.tensor_slices,
+            window_start=frame.window_start,
+            window_end=frame.window_end,
+        )
         logger.info(
-            "consolidation_frame_saved frame_id=%s window_start=%s window_end=%s motifs=%d expectations=%d",
+            "consolidation_frame_saved frame_id=%s window_start=%s window_end=%s motifs=%d expectations=%d tensor_slices=%d",
             frame.frame_id,
             frame.window_start.isoformat(),
             frame.window_end.isoformat(),
             len(frame.motif_observations),
             len(frame.expectations),
+            len(frame.tensor_slices),
         )

--- a/services/orion-consolidation-runtime/app/worker.py
+++ b/services/orion-consolidation-runtime/app/worker.py
@@ -73,12 +73,14 @@ class ConsolidationRuntimeWorker:
             window_start=frame.window_start,
             window_end=frame.window_end,
         )
+        self._store.upsert_schema_candidates(frame.schema_candidates)
         logger.info(
-            "consolidation_frame_saved frame_id=%s window_start=%s window_end=%s motifs=%d expectations=%d tensor_slices=%d",
+            "consolidation_frame_saved frame_id=%s window_start=%s window_end=%s motifs=%d expectations=%d tensor_slices=%d schema_candidates=%d",
             frame.frame_id,
             frame.window_start.isoformat(),
             frame.window_end.isoformat(),
             len(frame.motif_observations),
             len(frame.expectations),
             len(frame.tensor_slices),
+            len(frame.schema_candidates),
         )

--- a/services/orion-consolidation-runtime/app/worker.py
+++ b/services/orion-consolidation-runtime/app/worker.py
@@ -67,10 +67,12 @@ class ConsolidationRuntimeWorker:
         )
         frame = build_consolidation_frame(window=data, policy=self._policy)
         self._store.save_consolidation_frame(frame)
+        self._store.upsert_expectations(frame.expectations)
         logger.info(
-            "consolidation_frame_saved frame_id=%s window_start=%s window_end=%s motifs=%d",
+            "consolidation_frame_saved frame_id=%s window_start=%s window_end=%s motifs=%d expectations=%d",
             frame.frame_id,
             frame.window_start.isoformat(),
             frame.window_end.isoformat(),
             len(frame.motif_observations),
+            len(frame.expectations),
         )

--- a/services/orion-consolidation-runtime/app/worker.py
+++ b/services/orion-consolidation-runtime/app/worker.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from orion.consolidation.builder import build_consolidation_frame
+from orion.consolidation.policy import load_consolidation_policy
+from orion.consolidation.windows import compute_consolidation_window, stable_consolidation_frame_id
+
+from app.settings import get_settings
+from app.store import ConsolidationRuntimeStore
+
+logger = logging.getLogger("orion.consolidation.runtime")
+
+
+class ConsolidationRuntimeWorker:
+    def __init__(self) -> None:
+        self._settings = get_settings()
+        self._store = ConsolidationRuntimeStore(self._settings.postgres_uri)
+        self._policy = load_consolidation_policy(
+            Path(self._settings.consolidation_policy_path)
+        )
+        self._stop = asyncio.Event()
+
+    async def start(self) -> None:
+        asyncio.create_task(self._poll_loop(), name="consolidation-runtime-poll")
+
+    async def stop(self) -> None:
+        self._stop.set()
+
+    async def _poll_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                await asyncio.to_thread(self._tick)
+            except Exception:
+                logger.exception("consolidation_runtime_tick_failed")
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(),
+                    timeout=float(self._settings.consolidation_poll_interval_sec),
+                )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+    def _tick(self) -> None:
+        if not self._settings.enable_consolidation_runtime:
+            return
+
+        window_start, window_end = compute_consolidation_window(
+            lookback_minutes=self._policy.window.lookback_minutes,
+        )
+        frame_id = stable_consolidation_frame_id(
+            window_start=window_start,
+            window_end=window_end,
+            policy_id=self._policy.policy_id,
+        )
+        if self._store.load_consolidation_frame_for_window(frame_id) is not None:
+            return
+
+        data = self._store.load_window_data(
+            window_start,
+            window_end,
+            self._policy.window.max_frames_per_source,
+        )
+        frame = build_consolidation_frame(window=data, policy=self._policy)
+        self._store.save_consolidation_frame(frame)
+        logger.info(
+            "consolidation_frame_saved frame_id=%s window_start=%s window_end=%s motifs=%d",
+            frame.frame_id,
+            frame.window_start.isoformat(),
+            frame.window_end.isoformat(),
+            len(frame.motif_observations),
+        )

--- a/services/orion-consolidation-runtime/docker-compose.yml
+++ b/services/orion-consolidation-runtime/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  consolidation-runtime:
+    build:
+      context: ../..
+      dockerfile: services/orion-consolidation-runtime/Dockerfile
+    container_name: ${PROJECT}-consolidation-runtime
+    restart: unless-stopped
+    networks:
+      - app-net
+    ports:
+      - "${CONSOLIDATION_RUNTIME_PORT:-8123}:8123"
+    environment:
+      - PROJECT=${PROJECT}
+      - SERVICE_NAME=${SERVICE_NAME:-orion-consolidation-runtime}
+      - SERVICE_VERSION=${SERVICE_VERSION:-0.1.0}
+      - POSTGRES_URI=${POSTGRES_URI}
+      - CONSOLIDATION_POLICY_PATH=${CONSOLIDATION_POLICY_PATH:-/app/config/consolidation/consolidation_policy.v1.yaml}
+      - CONSOLIDATION_POLL_INTERVAL_SEC=${CONSOLIDATION_POLL_INTERVAL_SEC:-60.0}
+      - ENABLE_CONSOLIDATION_RUNTIME=${ENABLE_CONSOLIDATION_RUNTIME:-true}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+
+networks:
+  app-net:
+    external: true

--- a/services/orion-consolidation-runtime/requirements.txt
+++ b/services/orion-consolidation-runtime/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+pydantic==2.10.3
+pydantic-settings==2.6.1
+sqlalchemy==2.0.36
+psycopg2-binary==2.9.10
+PyYAML==6.0.2

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -150,6 +150,7 @@ from .substrate_proposal_routes import router as substrate_proposal_router
 from .substrate_policy_routes import router as substrate_policy_router
 from .substrate_execution_dispatch_routes import router as substrate_execution_dispatch_router
 from .substrate_feedback_routes import router as substrate_feedback_router
+from .substrate_consolidation_routes import router as substrate_consolidation_router
 
 router.include_router(grammar_atlas_router)
 router.include_router(substrate_biometrics_router)
@@ -160,6 +161,7 @@ router.include_router(substrate_proposal_router)
 router.include_router(substrate_policy_router)
 router.include_router(substrate_execution_dispatch_router)
 router.include_router(substrate_feedback_router)
+router.include_router(substrate_consolidation_router)
 
 
 def _hub_uses_host_network_mode() -> bool:

--- a/services/orion-hub/scripts/substrate_consolidation_routes.py
+++ b/services/orion-hub/scripts/substrate_consolidation_routes.py
@@ -1,0 +1,94 @@
+"""Read-only debug API for substrate consolidation frames."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import create_engine, text
+
+from orion.consolidation.repository import (
+    load_expectations_for_motif,
+    load_latest_tensor_slices,
+    load_recent_motifs,
+    load_schema_candidates,
+)
+from orion.schemas.consolidation_frame import ConsolidationFrameV1
+
+router = APIRouter(prefix="/api/substrate/consolidation", tags=["substrate-consolidation"])
+
+
+def _engine():
+    uri = os.getenv("POSTGRES_URI", "").strip()
+    if not uri:
+        raise HTTPException(status_code=503, detail="postgres_uri_not_configured")
+    return create_engine(uri, pool_pre_ping=True)
+
+
+def _postgres_uri() -> str:
+    uri = os.getenv("POSTGRES_URI", "").strip()
+    if not uri:
+        raise HTTPException(status_code=503, detail="postgres_uri_not_configured")
+    return uri
+
+
+def _load_latest_consolidation_frame() -> ConsolidationFrameV1 | None:
+    with _engine().connect() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT consolidation_frame_json
+                FROM substrate_consolidation_frames
+                ORDER BY generated_at DESC
+                LIMIT 1
+                """
+            ),
+        ).mappings().first()
+    if not row:
+        return None
+    payload = row["consolidation_frame_json"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return ConsolidationFrameV1.model_validate(payload)
+
+
+@router.get("/latest")
+async def consolidation_latest() -> dict[str, Any]:
+    frame = _load_latest_consolidation_frame()
+    if frame is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return frame.model_dump(mode="json")
+
+
+@router.get("/motifs")
+async def consolidation_motifs(
+    limit: int = Query(default=50, ge=1, le=500),
+) -> list[dict[str, Any]]:
+    motifs = load_recent_motifs(_postgres_uri(), limit)
+    return [motif.model_dump(mode="json") for motif in motifs]
+
+
+@router.get("/expectations")
+async def consolidation_expectations(
+    trigger_motif_id: str = Query(..., min_length=1),
+) -> list[dict[str, Any]]:
+    expectations = load_expectations_for_motif(_postgres_uri(), trigger_motif_id)
+    return [expectation.model_dump(mode="json") for expectation in expectations]
+
+
+@router.get("/schema-candidates")
+async def consolidation_schema_candidates(
+    limit: int = Query(default=50, ge=1, le=500),
+) -> list[dict[str, Any]]:
+    candidates = load_schema_candidates(_postgres_uri(), limit)
+    return [candidate.model_dump(mode="json") for candidate in candidates]
+
+
+@router.get("/tensor-slices/latest")
+async def consolidation_tensor_slices_latest(
+    limit: int = Query(default=50, ge=1, le=500),
+) -> list[dict[str, Any]]:
+    slices = load_latest_tensor_slices(_postgres_uri(), limit)
+    return [tensor_slice.model_dump(mode="json") for tensor_slice in slices]

--- a/services/orion-hub/tests/test_substrate_consolidation_debug_api.py
+++ b/services/orion-hub/tests/test_substrate_consolidation_debug_api.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_hub_scripts_import_path() -> None:
+    for key in list(sys.modules):
+        if key == "scripts" or key.startswith("scripts."):
+            del sys.modules[key]
+    for p in (str(REPO_ROOT), str(HUB_ROOT)):
+        try:
+            sys.path.remove(p)
+        except ValueError:
+            pass
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(HUB_ROOT))
+
+
+_ensure_hub_scripts_import_path()
+
+from scripts import substrate_consolidation_routes  # noqa: E402
+from orion.schemas.consolidation_frame import (  # noqa: E402
+    ConsolidationFrameV1,
+    ExpectationV1,
+    MotifObservationV1,
+    SchemaCandidateV1,
+    SparseTensorSliceV1,
+)
+
+MOTIF_ID = "motif:loaded_but_reliable:consolidation_policy.v1"
+
+
+def _sample_consolidation_frame() -> ConsolidationFrameV1:
+    return ConsolidationFrameV1(
+        frame_id=(
+            "consolidation.frame:2026-05-25T14:30:00+00:00:"
+            "2026-05-25T15:30:00+00:00:consolidation_policy.v1"
+        ),
+        generated_at="2026-05-25T15:30:00+00:00",
+        window_start="2026-05-25T14:30:00+00:00",
+        window_end="2026-05-25T15:30:00+00:00",
+        motif_observations=[
+            MotifObservationV1(
+                motif_id=MOTIF_ID,
+                motif_kind="self_state_pattern",
+                label="loaded_but_reliable",
+                recurrence_count=3,
+                support_score=0.6,
+                confidence_score=0.7,
+            )
+        ],
+        source_counts={"self_state": 1, "feedback": 2},
+    )
+
+
+def _sample_expectation() -> ExpectationV1:
+    return ExpectationV1(
+        expectation_id=f"expectation:{MOTIF_ID}:reliability_clear",
+        trigger_motif_id=MOTIF_ID,
+        expected_outcome_kind="reliability_clear",
+        confidence_score=0.7,
+        support_count=3,
+    )
+
+
+def _sample_schema_candidate() -> SchemaCandidateV1:
+    return SchemaCandidateV1(
+        schema_candidate_id="schema.candidate:habit:loaded_but_reliable",
+        candidate_kind="habit_candidate",
+        label="loaded_but_reliable",
+        source_motif_ids=[MOTIF_ID],
+        support_score=0.6,
+        confidence_score=0.7,
+    )
+
+
+def _sample_tensor_slice() -> SparseTensorSliceV1:
+    return SparseTensorSliceV1(
+        tensor_id=(
+            "tensor:field_attention_self:2026-05-25T14:30:00+00:00:"
+            "2026-05-25T15:30:00+00:00"
+        ),
+        tensor_kind="field_attention_self",
+        axes=["time_bucket", "self_condition"],
+        coordinates=[{"time_bucket": "2026-05-25T15:00:00+00:00", "self_condition": "loaded"}],
+        values=[0.8],
+    )
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    app = FastAPI()
+    app.include_router(substrate_consolidation_routes.router)
+    return TestClient(app)
+
+
+def test_latest_returns_frame(client) -> None:
+    sample = _sample_consolidation_frame()
+    with patch.object(
+        substrate_consolidation_routes,
+        "_load_latest_consolidation_frame",
+        return_value=sample,
+    ):
+        resp = client.get("/api/substrate/consolidation/latest")
+    assert resp.status_code == 200
+    assert resp.json()["source_counts"]["feedback"] == 2
+
+
+def test_motifs_returns_recent_motifs(client) -> None:
+    with patch.object(
+        substrate_consolidation_routes,
+        "load_recent_motifs",
+        return_value=[_sample_consolidation_frame().motif_observations[0]],
+    ):
+        resp = client.get("/api/substrate/consolidation/motifs")
+    assert resp.status_code == 200
+    assert resp.json()[0]["motif_id"] == MOTIF_ID
+
+
+def test_expectations_returns_rows(client) -> None:
+    with patch.object(
+        substrate_consolidation_routes,
+        "load_expectations_for_motif",
+        return_value=[_sample_expectation()],
+    ):
+        resp = client.get(
+            "/api/substrate/consolidation/expectations",
+            params={"trigger_motif_id": MOTIF_ID},
+        )
+    assert resp.status_code == 200
+    assert resp.json()[0]["expected_outcome_kind"] == "reliability_clear"
+
+
+def test_schema_candidates_returns_rows(client) -> None:
+    with patch.object(
+        substrate_consolidation_routes,
+        "load_schema_candidates",
+        return_value=[_sample_schema_candidate()],
+    ):
+        resp = client.get("/api/substrate/consolidation/schema-candidates")
+    assert resp.status_code == 200
+    assert resp.json()[0]["candidate_kind"] == "habit_candidate"
+
+
+def test_tensor_slices_latest_returns_rows(client) -> None:
+    with patch.object(
+        substrate_consolidation_routes,
+        "load_latest_tensor_slices",
+        return_value=[_sample_tensor_slice()],
+    ):
+        resp = client.get("/api/substrate/consolidation/tensor-slices/latest")
+    assert resp.status_code == 200
+    assert resp.json()[0]["tensor_kind"] == "field_attention_self"
+
+
+def test_router_has_no_post_routes() -> None:
+    post_routes = [
+        route
+        for route in substrate_consolidation_routes.router.routes
+        if "POST" in getattr(route, "methods", set())
+    ]
+    assert post_routes == []

--- a/services/orion-sql-db/manual_migration_consolidation_expectations_v1.sql
+++ b/services/orion-sql-db/manual_migration_consolidation_expectations_v1.sql
@@ -1,0 +1,13 @@
+create table if not exists substrate_expectations (
+    expectation_id text primary key,
+    trigger_motif_id text not null,
+    expected_outcome_kind text not null,
+    expectation_json jsonb not null,
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_expectations_trigger_motif
+    on substrate_expectations (trigger_motif_id);
+
+create index if not exists idx_substrate_expectations_outcome
+    on substrate_expectations (expected_outcome_kind);

--- a/services/orion-sql-db/manual_migration_consolidation_schema_candidates_v1.sql
+++ b/services/orion-sql-db/manual_migration_consolidation_schema_candidates_v1.sql
@@ -1,0 +1,14 @@
+create table if not exists substrate_schema_candidates (
+    schema_candidate_id text primary key,
+    candidate_kind text not null,
+    label text not null,
+    promotion_status text not null,
+    schema_candidate_json jsonb not null,
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_schema_candidates_kind
+    on substrate_schema_candidates (candidate_kind);
+
+create index if not exists idx_substrate_schema_candidates_status
+    on substrate_schema_candidates (promotion_status);

--- a/services/orion-sql-db/manual_migration_consolidation_tensor_slices_v1.sql
+++ b/services/orion-sql-db/manual_migration_consolidation_tensor_slices_v1.sql
@@ -1,0 +1,14 @@
+create table if not exists substrate_tensor_slices (
+    tensor_id text primary key,
+    tensor_kind text not null,
+    window_start timestamptz not null,
+    window_end timestamptz not null,
+    tensor_json jsonb not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_tensor_slices_kind
+    on substrate_tensor_slices (tensor_kind);
+
+create index if not exists idx_substrate_tensor_slices_window
+    on substrate_tensor_slices (window_start, window_end);

--- a/services/orion-sql-db/manual_migration_consolidation_v1.sql
+++ b/services/orion-sql-db/manual_migration_consolidation_v1.sql
@@ -1,0 +1,15 @@
+create table if not exists substrate_consolidation_frames (
+    frame_id text primary key,
+    window_start timestamptz not null,
+    window_end timestamptz not null,
+    generated_at timestamptz not null,
+    policy_id text not null,
+    consolidation_frame_json jsonb not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_consolidation_frames_generated_at
+    on substrate_consolidation_frames (generated_at desc);
+
+create index if not exists idx_substrate_consolidation_frames_window
+    on substrate_consolidation_frames (window_start, window_end);

--- a/tests/test_consolidation_builder.py
+++ b/tests/test_consolidation_builder.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.consolidation.builder import build_consolidation_frame
+from orion.consolidation.policy import load_consolidation_policy
+from orion.consolidation.windows import ConsolidationWindowData, stable_consolidation_frame_id
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_consolidation_policy(REPO / "config" / "consolidation" / "consolidation_policy.v1.yaml")
+NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
+START = datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc)
+
+
+def test_builder_emits_source_counts_and_stable_frame_id() -> None:
+    window = ConsolidationWindowData(
+        window_start=START,
+        window_end=NOW,
+        self_states=[],
+        attention_frames=[],
+        proposal_frames=[],
+        policy_frames=[],
+        dispatch_frames=[],
+        feedback_frames=[],
+    )
+    frame = build_consolidation_frame(window=window, policy=POLICY, generated_at=NOW)
+    assert frame.frame_id == stable_consolidation_frame_id(
+        window_start=START, window_end=NOW, policy_id=POLICY.policy_id
+    )
+    assert frame.source_counts["self_state"] == 0
+    assert frame.source_counts["feedback"] == 0
+    assert frame.consolidation_policy_id == "consolidation_policy.v1"

--- a/tests/test_consolidation_expectations.py
+++ b/tests/test_consolidation_expectations.py
@@ -1,0 +1,250 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.consolidation.expectation import build_expectations_from_motifs
+from orion.consolidation.motif import detect_motifs
+from orion.consolidation.policy import load_consolidation_policy
+from orion.consolidation.windows import ConsolidationWindowData
+from orion.schemas.consolidation_frame import MotifObservationV1
+from orion.schemas.execution_dispatch_frame import ExecutionDispatchCandidateV1, ExecutionDispatchFrameV1
+from orion.schemas.feedback_frame import FeedbackFrameV1, OutcomeObservationV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_consolidation_policy(REPO / "config" / "consolidation" / "consolidation_policy.v1.yaml")
+NOW = datetime(2026, 5, 25, 15, 0, tzinfo=timezone.utc)
+START = datetime(2026, 5, 25, 14, 0, tzinfo=timezone.utc)
+POLICY_ID = POLICY.policy_id
+
+
+def _dim(dimension_id: str, score: float) -> SelfStateDimensionV1:
+    return SelfStateDimensionV1(dimension_id=dimension_id, score=score, confidence=0.9)
+
+
+def _self_state(self_state_id: str) -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id=self_state_id,
+        generated_at=NOW,
+        source_field_tick_id="tick",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="att",
+        source_attention_generated_at=NOW,
+        overall_condition="loaded",
+        overall_intensity=0.7,
+        overall_confidence=0.9,
+        dimensions={
+            "execution_pressure": _dim("execution_pressure", 0.8),
+            "reliability_pressure": _dim("reliability_pressure", 0.2),
+        },
+    )
+
+
+def _attention_frame(frame_id: str) -> FieldAttentionFrameV1:
+    target = FieldAttentionTargetV1(
+        target_id="athena",
+        target_kind="node",
+        salience_score=0.8,
+        pressure_score=0.7,
+        novelty_score=0.1,
+        urgency_score=0.5,
+        confidence_score=0.9,
+    )
+    return FieldAttentionFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_field_tick_id="tick",
+        source_field_generated_at=NOW,
+        overall_salience=0.8,
+        node_targets=[target],
+        dominant_targets=[target],
+    )
+
+
+def _policy_frame(frame_id: str) -> PolicyDecisionFrameV1:
+    decision = PolicyDecisionV1(
+        decision_id=f"policy.decision:{frame_id}",
+        proposal_id="proposal:inspect:state",
+        decision="approved_read_only",
+        policy_gate="read_only",
+        risk_score=0.05,
+        reversibility_score=1.0,
+        confidence_score=0.9,
+        allowed_scope="inspect_only",
+    )
+    return PolicyDecisionFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:test",
+        source_self_state_id="self.state:test",
+        decisions=[decision],
+        approved_decisions=[decision],
+        overall_risk=0.05,
+        execution_allowed=False,
+    )
+
+
+def _review_policy_frame(frame_id: str) -> PolicyDecisionFrameV1:
+    decision = PolicyDecisionV1(
+        decision_id=f"policy.decision:{frame_id}",
+        proposal_id="proposal:exec:state",
+        decision="requires_operator_review",
+        policy_gate="operator_review",
+        risk_score=0.6,
+        reversibility_score=0.4,
+        confidence_score=0.8,
+        allowed_scope="operator_review_required",
+    )
+    return PolicyDecisionFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:review",
+        source_self_state_id="self.state:review",
+        decisions=[decision],
+        review_required_decisions=[decision],
+        overall_risk=0.6,
+        operator_review_required=True,
+        execution_allowed=False,
+    )
+
+
+def _feedback_frame(frame_id: str) -> FeedbackFrameV1:
+    return FeedbackFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_execution_dispatch_frame_id=f"execution.dispatch.frame:{frame_id}",
+        outcome_status="dry_run_only",
+        outcome_score=0.5,
+        confidence_score=0.9,
+    )
+
+
+def _dispatch_blocked(frame_id: str) -> ExecutionDispatchFrameV1:
+    return ExecutionDispatchFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_policy_frame_id="policy.frame:blocked",
+        source_proposal_frame_id="proposal.frame:blocked",
+        source_self_state_id="self.state:blocked",
+        blocked_candidates=[
+            ExecutionDispatchCandidateV1(
+                dispatch_id=f"dispatch:blocked:{frame_id}",
+                source_decision_id="pd1",
+                source_proposal_id="proposal:blocked",
+                dispatch_status="blocked",
+                dispatch_mode="dry_run",
+                dispatch_kind="inspect",
+                target_id="t1",
+                target_kind="capability",
+                risk_score=0.3,
+                confidence_score=0.9,
+                blocked_by=["rejected"],
+            )
+        ],
+        blocked_count=1,
+    )
+
+
+def _empty_window(**overrides: object) -> ConsolidationWindowData:
+    defaults: dict[str, object] = {
+        "window_start": START,
+        "window_end": NOW,
+        "self_states": [],
+        "attention_frames": [],
+        "proposal_frames": [],
+        "policy_frames": [],
+        "dispatch_frames": [],
+        "feedback_frames": [],
+    }
+    defaults.update(overrides)
+    return ConsolidationWindowData(**defaults)  # type: ignore[arg-type]
+
+
+def _motif(label: str, *, confidence: float = 1.0, recurrence: int = 3) -> MotifObservationV1:
+    return MotifObservationV1(
+        motif_id=f"motif:{label}:{POLICY_ID}",
+        motif_kind="self_state_pattern",
+        label=label,
+        recurrence_count=recurrence,
+        support_score=0.75,
+        confidence_score=confidence,
+        evidence_frame_ids=[f"evidence:{label}:1", f"evidence:{label}:2"],
+    )
+
+
+def _expectations_for_window(window: ConsolidationWindowData):
+    motifs = detect_motifs(window=window, policy=POLICY)
+    return build_expectations_from_motifs(
+        motifs=motifs,
+        feedback_frames=window.feedback_frames,
+        policy=POLICY,
+    )
+
+
+def test_loaded_but_reliable_creates_reliability_clear_expectation() -> None:
+    window = _empty_window(
+        self_states=[_self_state("self.state:1"), _self_state("self.state:2"), _self_state("self.state:3")]
+    )
+    expectations = _expectations_for_window(window)
+    match = [e for e in expectations if e.expected_outcome_kind == "reliability_clear"]
+    assert len(match) == 1
+    assert match[0].trigger_motif_id == f"motif:loaded_but_reliable:{POLICY_ID}"
+
+
+def test_read_only_policy_loop_creates_read_only_approved_expectation() -> None:
+    window = _empty_window(
+        policy_frames=[_policy_frame("policy.frame:1"), _policy_frame("policy.frame:2"), _policy_frame("policy.frame:3")]
+    )
+    expectations = _expectations_for_window(window)
+    match = [e for e in expectations if e.expected_outcome_kind == "read_only_approved"]
+    assert len(match) == 1
+
+
+def test_dry_run_feedback_loop_creates_dry_run_feedback_expectation() -> None:
+    window = _empty_window(
+        feedback_frames=[
+            _feedback_frame("feedback.frame:1"),
+            _feedback_frame("feedback.frame:2"),
+            _feedback_frame("feedback.frame:3"),
+        ]
+    )
+    expectations = _expectations_for_window(window)
+    match = [e for e in expectations if e.expected_outcome_kind == "dry_run_feedback"]
+    assert len(match) == 1
+
+
+def test_blocked_review_loop_creates_policy_review_required_expectation() -> None:
+    window = _empty_window(
+        policy_frames=[_review_policy_frame("policy.frame:review:1"), _review_policy_frame("policy.frame:review:2")],
+        dispatch_frames=[_dispatch_blocked("execution.dispatch.frame:blocked:1")],
+    )
+    expectations = _expectations_for_window(window)
+    match = [e for e in expectations if e.expected_outcome_kind == "policy_review_required"]
+    assert len(match) == 1
+
+
+def test_expectation_confidence_follows_motif_confidence() -> None:
+    motifs = [_motif("loaded_but_reliable", confidence=0.42)]
+    expectations = build_expectations_from_motifs(motifs=motifs, feedback_frames=[], policy=POLICY)
+    assert expectations[0].confidence_score == 0.42
+    assert expectations[0].support_count == 3
+
+
+def test_evidence_refs_are_preserved() -> None:
+    motifs = [_motif("loaded_but_reliable")]
+    expectations = build_expectations_from_motifs(motifs=motifs, feedback_frames=[], policy=POLICY)
+    assert expectations[0].evidence_refs == ["evidence:loaded_but_reliable:1", "evidence:loaded_but_reliable:2"]
+
+
+def test_attention_saturated_execution_creates_execution_pressure_high() -> None:
+    window = _empty_window(
+        attention_frames=[
+            _attention_frame("attention.frame:1"),
+            _attention_frame("attention.frame:2"),
+            _attention_frame("attention.frame:3"),
+        ]
+    )
+    expectations = _expectations_for_window(window)
+    match = [e for e in expectations if e.expected_outcome_kind == "execution_pressure_high"]
+    assert len(match) == 1

--- a/tests/test_consolidation_frame_schemas.py
+++ b/tests/test_consolidation_frame_schemas.py
@@ -3,7 +3,13 @@ from datetime import datetime, timezone
 import pytest
 from pydantic import ValidationError
 
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, MotifObservationV1, SparseTensorSliceV1
+from orion.schemas.consolidation_frame import (
+    ConsolidationFrameV1,
+    ExpectationV1,
+    MotifObservationV1,
+    SchemaCandidateV1,
+    SparseTensorSliceV1,
+)
 from orion.schemas.registry import resolve
 
 NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
@@ -125,3 +131,21 @@ def test_sparse_tensor_slice_v1_validates() -> None:
 
 def test_sparse_tensor_slice_v1_registered() -> None:
     assert resolve("SparseTensorSliceV1") is SparseTensorSliceV1
+
+
+def test_schema_candidate_v1_validates() -> None:
+    candidate = SchemaCandidateV1(
+        schema_candidate_id="schema_candidate:prior:loaded_but_reliable",
+        candidate_kind="prior_candidate",
+        label="loaded_but_reliable_operating_mode",
+        source_motif_ids=["motif:loaded_but_reliable:consolidation_policy.v1"],
+        support_score=0.75,
+        confidence_score=1.0,
+        proposed_schema={"condition": "loaded"},
+        promotion_status="candidate_only",
+    )
+    assert candidate.promotion_status == "candidate_only"
+
+
+def test_schema_candidate_v1_registered() -> None:
+    assert resolve("SchemaCandidateV1") is SchemaCandidateV1

--- a/tests/test_consolidation_frame_schemas.py
+++ b/tests/test_consolidation_frame_schemas.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 import pytest
 from pydantic import ValidationError
 
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, MotifObservationV1
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, MotifObservationV1, SparseTensorSliceV1
 from orion.schemas.registry import resolve
 
 NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
@@ -101,3 +101,27 @@ def test_consolidation_frame_includes_expectations() -> None:
 
 def test_expectation_v1_registered() -> None:
     assert resolve("ExpectationV1") is ExpectationV1
+
+
+def test_sparse_tensor_slice_v1_validates() -> None:
+    tensor = SparseTensorSliceV1(
+        tensor_id="tensor:field_attention_self:2026-05-25T14:30:00+00:00:2026-05-25T15:30:00+00:00",
+        tensor_kind="field_attention_self",
+        axes=["time_bucket", "self_condition", "attention_target", "dimension"],
+        coordinates=[
+            {
+                "time_bucket": "2026-05-25T15:00:00+00:00",
+                "self_condition": "loaded",
+                "attention_target": "node:athena",
+                "dimension": "execution_pressure",
+            }
+        ],
+        values=[0.8],
+        evidence_refs=["self.state:s1"],
+    )
+    assert tensor.tensor_kind == "field_attention_self"
+    assert len(tensor.values) == len(tensor.coordinates)
+
+
+def test_sparse_tensor_slice_v1_registered() -> None:
+    assert resolve("SparseTensorSliceV1") is SparseTensorSliceV1

--- a/tests/test_consolidation_frame_schemas.py
+++ b/tests/test_consolidation_frame_schemas.py
@@ -1,0 +1,66 @@
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, MotifObservationV1
+
+NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
+
+
+def test_motif_observation_validates() -> None:
+    motif = MotifObservationV1(
+        motif_id="motif:loaded_but_reliable:consolidation_policy.v1",
+        motif_kind="self_state_pattern",
+        label="loaded_but_reliable",
+        recurrence_count=3,
+        support_score=0.6,
+        confidence_score=0.7,
+        evidence_frame_ids=["self.state:s1"],
+    )
+    assert motif.motif_kind == "self_state_pattern"
+
+
+def test_consolidation_frame_validates() -> None:
+    frame = ConsolidationFrameV1(
+        frame_id="consolidation.frame:2026-05-25T14:30:00+00:00:2026-05-25T15:30:00+00:00:consolidation_policy.v1",
+        generated_at=NOW,
+        window_start=datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc),
+        window_end=NOW,
+        motif_observations=[
+            MotifObservationV1(
+                motif_id="motif:loaded_but_reliable:consolidation_policy.v1",
+                motif_kind="self_state_pattern",
+                label="loaded_but_reliable",
+                recurrence_count=3,
+                support_score=0.6,
+                confidence_score=0.7,
+            )
+        ],
+    )
+    assert frame.schema_version == "consolidation.frame.v1"
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        MotifObservationV1(
+            motif_id="m1",
+            motif_kind="self_state_pattern",
+            label="x",
+            recurrence_count=1,
+            support_score=0.5,
+            confidence_score=0.5,
+            extra_field=True,
+        )
+
+
+def test_recurrence_count_min_one() -> None:
+    with pytest.raises(ValidationError):
+        MotifObservationV1(
+            motif_id="m1",
+            motif_kind="self_state_pattern",
+            label="x",
+            recurrence_count=0,
+            support_score=0.5,
+            confidence_score=0.5,
+        )

--- a/tests/test_consolidation_frame_schemas.py
+++ b/tests/test_consolidation_frame_schemas.py
@@ -3,7 +3,8 @@ from datetime import datetime, timezone
 import pytest
 from pydantic import ValidationError
 
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, MotifObservationV1
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, MotifObservationV1
+from orion.schemas.registry import resolve
 
 NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
 
@@ -64,3 +65,39 @@ def test_recurrence_count_min_one() -> None:
             support_score=0.5,
             confidence_score=0.5,
         )
+
+
+def test_expectation_v1_validates() -> None:
+    expectation = ExpectationV1(
+        expectation_id="expectation:motif:loaded_but_reliable:consolidation_policy.v1:reliability_clear",
+        trigger_motif_id="motif:loaded_but_reliable:consolidation_policy.v1",
+        expected_outcome_kind="reliability_clear",
+        confidence_score=0.7,
+        support_count=3,
+        evidence_refs=["self.state:s1"],
+        reasons=["derived_from_motif:loaded_but_reliable"],
+    )
+    assert expectation.expected_outcome_kind == "reliability_clear"
+
+
+def test_consolidation_frame_includes_expectations() -> None:
+    frame = ConsolidationFrameV1(
+        frame_id="consolidation.frame:test",
+        generated_at=NOW,
+        window_start=datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc),
+        window_end=NOW,
+        expectations=[
+            ExpectationV1(
+                expectation_id="expectation:test",
+                trigger_motif_id="motif:test",
+                expected_outcome_kind="unknown",
+                confidence_score=0.5,
+                support_count=1,
+            )
+        ],
+    )
+    assert frame.expectations[0].expectation_id == "expectation:test"
+
+
+def test_expectation_v1_registered() -> None:
+    assert resolve("ExpectationV1") is ExpectationV1

--- a/tests/test_consolidation_motif_detection.py
+++ b/tests/test_consolidation_motif_detection.py
@@ -1,0 +1,297 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from orion.consolidation.motif import detect_motifs
+from orion.consolidation.policy import load_consolidation_policy
+from orion.consolidation.windows import ConsolidationWindowData
+from orion.schemas.execution_dispatch_frame import ExecutionDispatchCandidateV1, ExecutionDispatchFrameV1
+from orion.schemas.feedback_frame import FeedbackFrameV1, OutcomeObservationV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_consolidation_policy(REPO / "config" / "consolidation" / "consolidation_policy.v1.yaml")
+NOW = datetime(2026, 5, 25, 15, 0, tzinfo=timezone.utc)
+START = datetime(2026, 5, 25, 14, 0, tzinfo=timezone.utc)
+
+
+def _dim(dimension_id: str, score: float) -> SelfStateDimensionV1:
+    return SelfStateDimensionV1(dimension_id=dimension_id, score=score, confidence=0.9)
+
+
+def _self_state(
+    self_state_id: str,
+    *,
+    overall_condition: str = "loaded",
+    execution_pressure: float = 0.8,
+    reliability_pressure: float = 0.2,
+) -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id=self_state_id,
+        generated_at=NOW,
+        source_field_tick_id="tick",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="att",
+        source_attention_generated_at=NOW,
+        overall_condition=overall_condition,
+        overall_intensity=0.7,
+        overall_confidence=0.9,
+        dimensions={
+            "execution_pressure": _dim("execution_pressure", execution_pressure),
+            "reliability_pressure": _dim("reliability_pressure", reliability_pressure),
+        },
+    )
+
+
+def _attention_frame(frame_id: str, *, salience: float = 0.8) -> FieldAttentionFrameV1:
+    target = FieldAttentionTargetV1(
+        target_id="athena",
+        target_kind="node",
+        salience_score=salience,
+        pressure_score=0.7,
+        novelty_score=0.1,
+        urgency_score=0.5,
+        confidence_score=0.9,
+    )
+    return FieldAttentionFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_field_tick_id="tick",
+        source_field_generated_at=NOW,
+        overall_salience=salience,
+        node_targets=[target],
+        dominant_targets=[target],
+    )
+
+
+def _policy_frame(frame_id: str, *, execution_allowed: bool = False, read_only: bool = True) -> PolicyDecisionFrameV1:
+    decision = PolicyDecisionV1(
+        decision_id=f"policy.decision:{frame_id}",
+        proposal_id="proposal:inspect:state",
+        decision="approved_read_only" if read_only else "rejected",
+        policy_gate="read_only",
+        risk_score=0.05,
+        reversibility_score=1.0,
+        confidence_score=0.9,
+        allowed_scope="inspect_only",
+    )
+    return PolicyDecisionFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:test",
+        source_self_state_id="self.state:test",
+        decisions=[decision],
+        approved_decisions=[decision] if read_only else [],
+        overall_risk=0.05,
+        execution_allowed=execution_allowed,
+    )
+
+
+def _review_policy_frame(frame_id: str) -> PolicyDecisionFrameV1:
+    decision = PolicyDecisionV1(
+        decision_id=f"policy.decision:{frame_id}",
+        proposal_id="proposal:exec:state",
+        decision="requires_operator_review",
+        policy_gate="operator_review",
+        risk_score=0.6,
+        reversibility_score=0.4,
+        confidence_score=0.8,
+        allowed_scope="operator_review_required",
+    )
+    return PolicyDecisionFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:review",
+        source_self_state_id="self.state:review",
+        decisions=[decision],
+        review_required_decisions=[decision],
+        overall_risk=0.6,
+        operator_review_required=True,
+        execution_allowed=False,
+    )
+
+
+def _feedback_frame(
+    frame_id: str,
+    *,
+    outcome_status: str = "dry_run_only",
+    with_unchanged_delta: bool = False,
+) -> FeedbackFrameV1:
+    observations: list[OutcomeObservationV1] = []
+    if with_unchanged_delta:
+        observations.append(
+            OutcomeObservationV1(
+                observation_id=f"obs:{frame_id}:delta",
+                source_kind="self_state_delta",
+                source_id="self.state:before",
+                outcome_kind="unchanged",
+                score=0.5,
+                confidence=0.9,
+                observed_at=NOW,
+            )
+        )
+    return FeedbackFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_execution_dispatch_frame_id=f"execution.dispatch.frame:{frame_id}",
+        outcome_status=outcome_status,
+        outcome_score=0.5,
+        confidence_score=0.9,
+        observations=observations,
+    )
+
+
+def _dispatch_blocked(frame_id: str) -> ExecutionDispatchFrameV1:
+    return ExecutionDispatchFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_policy_frame_id="policy.frame:blocked",
+        source_proposal_frame_id="proposal.frame:blocked",
+        source_self_state_id="self.state:blocked",
+        blocked_candidates=[
+            ExecutionDispatchCandidateV1(
+                dispatch_id=f"dispatch:blocked:{frame_id}",
+                source_decision_id="pd1",
+                source_proposal_id="proposal:blocked",
+                dispatch_status="blocked",
+                dispatch_mode="dry_run",
+                dispatch_kind="inspect",
+                target_id="t1",
+                target_kind="capability",
+                risk_score=0.3,
+                confidence_score=0.9,
+                blocked_by=["rejected"],
+            )
+        ],
+        blocked_count=1,
+    )
+
+
+def _empty_window(**overrides: object) -> ConsolidationWindowData:
+    defaults: dict[str, object] = {
+        "window_start": START,
+        "window_end": NOW,
+        "self_states": [],
+        "attention_frames": [],
+        "proposal_frames": [],
+        "policy_frames": [],
+        "dispatch_frames": [],
+        "feedback_frames": [],
+    }
+    defaults.update(overrides)
+    return ConsolidationWindowData(**defaults)  # type: ignore[arg-type]
+
+
+def _motif_by_label(motifs: list, label: str):
+    matches = [m for m in motifs if m.label == label]
+    assert len(matches) == 1, f"expected one motif {label}, got {matches}"
+    return matches[0]
+
+
+def test_loaded_but_reliable_detected() -> None:
+    window = _empty_window(
+        self_states=[
+            _self_state("self.state:1"),
+            _self_state("self.state:2"),
+            _self_state("self.state:3"),
+        ]
+    )
+    motifs = detect_motifs(window=window, policy=POLICY)
+    motif = _motif_by_label(motifs, "loaded_but_reliable")
+    assert motif.recurrence_count == 3
+    assert motif.motif_kind == "self_state_pattern"
+
+
+def test_attention_saturated_execution_detected() -> None:
+    window = _empty_window(
+        attention_frames=[
+            _attention_frame("attention.frame:1"),
+            _attention_frame("attention.frame:2"),
+            _attention_frame("attention.frame:3"),
+        ]
+    )
+    motifs = detect_motifs(window=window, policy=POLICY)
+    motif = _motif_by_label(motifs, "attention_saturated_execution")
+    assert motif.recurrence_count == 3
+    assert motif.motif_kind == "attention_pattern"
+
+
+def test_read_only_policy_loop_detected() -> None:
+    window = _empty_window(
+        policy_frames=[
+            _policy_frame("policy.frame:1"),
+            _policy_frame("policy.frame:2"),
+            _policy_frame("policy.frame:3"),
+        ]
+    )
+    motifs = detect_motifs(window=window, policy=POLICY)
+    motif = _motif_by_label(motifs, "read_only_policy_loop")
+    assert motif.recurrence_count == 3
+    assert motif.motif_kind == "proposal_policy_pattern"
+
+
+def test_dry_run_feedback_loop_detected() -> None:
+    window = _empty_window(
+        feedback_frames=[
+            _feedback_frame("feedback.frame:1"),
+            _feedback_frame("feedback.frame:2"),
+            _feedback_frame("feedback.frame:3"),
+        ]
+    )
+    motifs = detect_motifs(window=window, policy=POLICY)
+    motif = _motif_by_label(motifs, "dry_run_feedback_loop")
+    assert motif.recurrence_count == 3
+    assert motif.motif_kind == "dispatch_feedback_pattern"
+
+
+def test_blocked_review_loop_detected() -> None:
+    window = _empty_window(
+        policy_frames=[
+            _review_policy_frame("policy.frame:review:1"),
+            _review_policy_frame("policy.frame:review:2"),
+        ],
+        dispatch_frames=[_dispatch_blocked("execution.dispatch.frame:blocked:1")],
+    )
+    motifs = detect_motifs(window=window, policy=POLICY)
+    motif = _motif_by_label(motifs, "blocked_review_loop")
+    assert motif.recurrence_count == 3
+    assert motif.motif_kind == "dispatch_feedback_pattern"
+
+
+def test_stable_after_dry_run_detected() -> None:
+    window = _empty_window(
+        feedback_frames=[
+            _feedback_frame("feedback.frame:stable:1", with_unchanged_delta=True),
+            _feedback_frame("feedback.frame:stable:2", with_unchanged_delta=True),
+            _feedback_frame("feedback.frame:stable:3", with_unchanged_delta=True),
+        ]
+    )
+    motifs = detect_motifs(window=window, policy=POLICY)
+    motif = _motif_by_label(motifs, "stable_after_dry_run")
+    assert motif.recurrence_count == 3
+    assert motif.motif_kind == "stability_pattern"
+
+
+def test_motif_scores_and_evidence() -> None:
+    window = _empty_window(
+        self_states=[
+            _self_state("self.state:1"),
+            _self_state("self.state:2"),
+            _self_state("self.state:3"),
+            _self_state("self.state:4", overall_condition="steady"),
+        ]
+    )
+    motifs = detect_motifs(window=window, policy=POLICY)
+    motif = _motif_by_label(motifs, "loaded_but_reliable")
+    assert motif.recurrence_count == 3
+    assert motif.support_score == 0.75
+    assert motif.confidence_score == 1.0
+    assert len(motif.evidence_frame_ids) == 3
+    assert "self.state:1" in motif.evidence_frame_ids
+    assert motif.first_seen_at == NOW
+    assert motif.last_seen_at == NOW
+    assert motif.dominant_dimensions["execution_pressure"] == pytest.approx(0.8)
+    assert motif.dominant_dimensions["reliability_pressure"] == pytest.approx(0.2)

--- a/tests/test_consolidation_policy_loader.py
+++ b/tests/test_consolidation_policy_loader.py
@@ -29,3 +29,26 @@ def test_motif_rules_present() -> None:
 def test_tracked_dimensions() -> None:
     policy = load_consolidation_policy(POLICY_PATH)
     assert "execution_pressure" in policy.tracked_self_dimensions
+
+
+def test_tensor_config() -> None:
+    policy = load_consolidation_policy(POLICY_PATH)
+    assert policy.tensor.enabled is True
+    assert policy.tensor.max_coordinates == 200
+    assert policy.tensor_axes["field_attention_self"] == [
+        "time_bucket",
+        "self_condition",
+        "attention_target",
+        "dimension",
+    ]
+    assert policy.tensor_axes["policy_dispatch_feedback"] == [
+        "proposal_kind",
+        "policy_decision",
+        "dispatch_status",
+        "feedback_outcome",
+    ]
+    assert policy.tensor_axes["motif_condition_outcome"] == [
+        "motif",
+        "self_condition",
+        "outcome_status",
+    ]

--- a/tests/test_consolidation_policy_loader.py
+++ b/tests/test_consolidation_policy_loader.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from orion.consolidation.policy import ConsolidationPolicyV1, load_consolidation_policy
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO / "config" / "consolidation" / "consolidation_policy.v1.yaml"
+
+
+def test_loads_yaml() -> None:
+    policy = load_consolidation_policy(POLICY_PATH)
+    assert policy.schema_version == "consolidation_policy.v1"
+    assert policy.policy_id == "consolidation_policy.v1"
+
+
+def test_window_config() -> None:
+    policy = load_consolidation_policy(POLICY_PATH)
+    assert policy.window.lookback_minutes == 60
+    assert policy.window.min_support_count == 3
+
+
+def test_motif_rules_present() -> None:
+    policy = load_consolidation_policy(POLICY_PATH)
+    labels = {r.label for r in policy.motif_rules.values()}
+    assert "loaded_but_reliable" in labels
+    assert "dry_run_feedback_loop" in labels
+    assert "stable_after_dry_run" in labels
+
+
+def test_tracked_dimensions() -> None:
+    policy = load_consolidation_policy(POLICY_PATH)
+    assert "execution_pressure" in policy.tracked_self_dimensions

--- a/tests/test_consolidation_repository.py
+++ b/tests/test_consolidation_repository.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from orion.consolidation import repository as consolidation_repository
+from orion.schemas.consolidation_frame import (
+    ConsolidationFrameV1,
+    ExpectationV1,
+    MotifObservationV1,
+    SchemaCandidateV1,
+    SparseTensorSliceV1,
+)
+
+NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
+START = datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc)
+MOTIF_ID = "motif:loaded_but_reliable:consolidation_policy.v1"
+
+
+def _motif() -> MotifObservationV1:
+    return MotifObservationV1(
+        motif_id=MOTIF_ID,
+        motif_kind="self_state_pattern",
+        label="loaded_but_reliable",
+        recurrence_count=3,
+        support_score=0.6,
+        confidence_score=0.7,
+        evidence_frame_ids=["self.state:s1"],
+    )
+
+
+def _frame_payload() -> dict:
+    return ConsolidationFrameV1(
+        frame_id=(
+            "consolidation.frame:2026-05-25T14:30:00+00:00:"
+            "2026-05-25T15:30:00+00:00:consolidation_policy.v1"
+        ),
+        generated_at=NOW,
+        window_start=START,
+        window_end=NOW,
+        motif_observations=[_motif()],
+    ).model_dump(mode="json")
+
+
+def _expectation_payload() -> dict:
+    return ExpectationV1(
+        expectation_id=f"expectation:{MOTIF_ID}:reliability_clear",
+        trigger_motif_id=MOTIF_ID,
+        expected_outcome_kind="reliability_clear",
+        confidence_score=0.7,
+        support_count=3,
+    ).model_dump(mode="json")
+
+
+def _schema_candidate_payload() -> dict:
+    return SchemaCandidateV1(
+        schema_candidate_id="schema.candidate:habit:loaded_but_reliable",
+        candidate_kind="habit_candidate",
+        label="loaded_but_reliable",
+        source_motif_ids=[MOTIF_ID],
+        support_score=0.6,
+        confidence_score=0.7,
+    ).model_dump(mode="json")
+
+
+def _tensor_slice_payload() -> dict:
+    return SparseTensorSliceV1(
+        tensor_id=(
+            "tensor:field_attention_self:2026-05-25T14:30:00+00:00:"
+            "2026-05-25T15:30:00+00:00"
+        ),
+        tensor_kind="field_attention_self",
+        axes=["time_bucket", "self_condition"],
+        coordinates=[{"time_bucket": "2026-05-25T15:00:00+00:00", "self_condition": "loaded"}],
+        values=[0.8],
+    ).model_dump(mode="json")
+
+
+def _fake_engine(rows_by_query: dict[str, list[dict]]):
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    executed_sql: list[str] = []
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        executed_sql.append(sql)
+        result = MagicMock()
+        if "substrate_consolidation_frames" in sql:
+            rows = rows_by_query.get("consolidation_frames", [])
+            if "LIMIT 1" in sql:
+                result.mappings.return_value.first.return_value = rows[0] if rows else None
+            else:
+                result.mappings.return_value = rows
+        elif "substrate_expectations" in sql:
+            result.mappings.return_value = rows_by_query.get("expectations", [])
+        elif "substrate_schema_candidates" in sql:
+            result.mappings.return_value = rows_by_query.get("schema_candidates", [])
+        elif "substrate_tensor_slices" in sql:
+            result.mappings.return_value = rows_by_query.get("tensor_slices", [])
+        else:
+            result.mappings.return_value = []
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    return fake_engine, executed_sql
+
+
+def test_load_recent_motifs_from_latest_frame() -> None:
+    fake_engine, executed_sql = _fake_engine(
+        {"consolidation_frames": [{"consolidation_frame_json": _frame_payload()}]}
+    )
+
+    motifs = consolidation_repository.load_recent_motifs(
+        "postgresql://test:test@localhost/test",
+        limit=10,
+        engine=fake_engine,
+    )
+
+    assert len(motifs) == 1
+    assert motifs[0].motif_id == MOTIF_ID
+    assert all("INSERT" not in sql.upper() for sql in executed_sql)
+
+
+def test_load_recent_motifs_empty_when_no_frame() -> None:
+    fake_engine, executed_sql = _fake_engine({"consolidation_frames": []})
+
+    motifs = consolidation_repository.load_recent_motifs(
+        "postgresql://test:test@localhost/test",
+        limit=10,
+        engine=fake_engine,
+    )
+
+    assert motifs == []
+    assert all("INSERT" not in sql.upper() for sql in executed_sql)
+
+
+def test_load_expectations_for_motif() -> None:
+    fake_engine, executed_sql = _fake_engine(
+        {"expectations": [{"expectation_json": _expectation_payload()}]}
+    )
+
+    expectations = consolidation_repository.load_expectations_for_motif(
+        "postgresql://test:test@localhost/test",
+        MOTIF_ID,
+        engine=fake_engine,
+    )
+
+    assert len(expectations) == 1
+    assert expectations[0].trigger_motif_id == MOTIF_ID
+    assert all("INSERT" not in sql.upper() for sql in executed_sql)
+
+
+def test_load_schema_candidates() -> None:
+    fake_engine, executed_sql = _fake_engine(
+        {"schema_candidates": [{"schema_candidate_json": _schema_candidate_payload()}]}
+    )
+
+    candidates = consolidation_repository.load_schema_candidates(
+        "postgresql://test:test@localhost/test",
+        limit=5,
+        engine=fake_engine,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].candidate_kind == "habit_candidate"
+    assert all("INSERT" not in sql.upper() for sql in executed_sql)
+
+
+def test_load_latest_tensor_slices() -> None:
+    fake_engine, executed_sql = _fake_engine(
+        {"tensor_slices": [{"tensor_json": _tensor_slice_payload()}]}
+    )
+
+    slices = consolidation_repository.load_latest_tensor_slices(
+        "postgresql://test:test@localhost/test",
+        limit=5,
+        engine=fake_engine,
+    )
+
+    assert len(slices) == 1
+    assert slices[0].tensor_kind == "field_attention_self"
+    assert all("INSERT" not in sql.upper() for sql in executed_sql)

--- a/tests/test_consolidation_runtime_store.py
+++ b/tests/test_consolidation_runtime_store.py
@@ -25,7 +25,7 @@ def _load_store_class():
 
 ConsolidationRuntimeStore = _load_store_class()
 
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1  # noqa: E402
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, SparseTensorSliceV1  # noqa: E402
 
 NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
 START = datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc)
@@ -148,3 +148,32 @@ def test_upsert_expectations_idempotent(monkeypatch) -> None:
     store.upsert_expectations([expectation])
     assert sum("INSERT INTO substrate_expectations" in sql for sql in calls) == 2
     assert all("ON CONFLICT (expectation_id) DO UPDATE" in sql for sql in calls if "substrate_expectations" in sql)
+
+
+def test_save_tensor_slices_idempotent(monkeypatch) -> None:
+    store = ConsolidationRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    calls: list[str] = []
+
+    def execute_side_effect(stmt, params=None):
+        calls.append(str(stmt))
+        return MagicMock()
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    tensor_slice = SparseTensorSliceV1(
+        tensor_id="tensor:field_attention_self:2026-05-25T14:30:00+00:00:2026-05-25T15:30:00+00:00",
+        tensor_kind="field_attention_self",
+        axes=["time_bucket", "self_condition", "attention_target", "dimension"],
+        coordinates=[{"time_bucket": "2026-05-25T15:00:00+00:00", "self_condition": "loaded", "attention_target": "node:athena", "dimension": "execution_pressure"}],
+        values=[0.8],
+    )
+    store.save_tensor_slices([tensor_slice], START, NOW)
+    store.save_tensor_slices([tensor_slice], START, NOW)
+    assert sum("INSERT INTO substrate_tensor_slices" in sql for sql in calls) == 2
+    assert all("ON CONFLICT (tensor_id) DO NOTHING" in sql for sql in calls if "substrate_tensor_slices" in sql)

--- a/tests/test_consolidation_runtime_store.py
+++ b/tests/test_consolidation_runtime_store.py
@@ -25,7 +25,12 @@ def _load_store_class():
 
 ConsolidationRuntimeStore = _load_store_class()
 
-from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, SparseTensorSliceV1  # noqa: E402
+from orion.schemas.consolidation_frame import (  # noqa: E402
+    ConsolidationFrameV1,
+    ExpectationV1,
+    SchemaCandidateV1,
+    SparseTensorSliceV1,
+)
 
 NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
 START = datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc)
@@ -177,3 +182,37 @@ def test_save_tensor_slices_idempotent(monkeypatch) -> None:
     store.save_tensor_slices([tensor_slice], START, NOW)
     assert sum("INSERT INTO substrate_tensor_slices" in sql for sql in calls) == 2
     assert all("ON CONFLICT (tensor_id) DO NOTHING" in sql for sql in calls if "substrate_tensor_slices" in sql)
+
+
+def test_upsert_schema_candidates_idempotent(monkeypatch) -> None:
+    store = ConsolidationRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    calls: list[str] = []
+
+    def execute_side_effect(stmt, params=None):
+        calls.append(str(stmt))
+        return MagicMock()
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    candidate = SchemaCandidateV1(
+        schema_candidate_id="schema_candidate:prior:motif:loaded_but_reliable:consolidation_policy.v1",
+        candidate_kind="prior_candidate",
+        label="loaded_but_reliable_operating_mode",
+        support_score=0.75,
+        confidence_score=1.0,
+        promotion_status="candidate_only",
+    )
+    store.upsert_schema_candidates([candidate])
+    store.upsert_schema_candidates([candidate])
+    assert sum("INSERT INTO substrate_schema_candidates" in sql for sql in calls) == 2
+    assert all(
+        "ON CONFLICT (schema_candidate_id) DO UPDATE" in sql
+        for sql in calls
+        if "substrate_schema_candidates" in sql
+    )

--- a/tests/test_consolidation_runtime_store.py
+++ b/tests/test_consolidation_runtime_store.py
@@ -25,7 +25,7 @@ def _load_store_class():
 
 ConsolidationRuntimeStore = _load_store_class()
 
-from orion.schemas.consolidation_frame import ConsolidationFrameV1  # noqa: E402
+from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1  # noqa: E402
 
 NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
 START = datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc)
@@ -119,3 +119,32 @@ def test_save_idempotent_by_frame_id(monkeypatch) -> None:
 
     store.save_consolidation_frame(_frame())
     assert any("ON CONFLICT (frame_id) DO NOTHING" in sql for sql in calls)
+
+
+def test_upsert_expectations_idempotent(monkeypatch) -> None:
+    store = ConsolidationRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    calls: list[str] = []
+
+    def execute_side_effect(stmt, params=None):
+        calls.append(str(stmt))
+        return MagicMock()
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    expectation = ExpectationV1(
+        expectation_id="expectation:motif:loaded_but_reliable:consolidation_policy.v1:reliability_clear",
+        trigger_motif_id="motif:loaded_but_reliable:consolidation_policy.v1",
+        expected_outcome_kind="reliability_clear",
+        confidence_score=0.7,
+        support_count=3,
+    )
+    store.upsert_expectations([expectation])
+    store.upsert_expectations([expectation])
+    assert sum("INSERT INTO substrate_expectations" in sql for sql in calls) == 2
+    assert all("ON CONFLICT (expectation_id) DO UPDATE" in sql for sql in calls if "substrate_expectations" in sql)

--- a/tests/test_consolidation_runtime_store.py
+++ b/tests/test_consolidation_runtime_store.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO = Path(__file__).resolve().parents[1]
+SVC = REPO / "services" / "orion-consolidation-runtime"
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def _load_store_class():
+    spec = importlib.util.spec_from_file_location(
+        "consolidation_runtime_store",
+        SVC / "app" / "store.py",
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.ConsolidationRuntimeStore
+
+
+ConsolidationRuntimeStore = _load_store_class()
+
+from orion.schemas.consolidation_frame import ConsolidationFrameV1  # noqa: E402
+
+NOW = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
+START = datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc)
+
+
+def _frame() -> ConsolidationFrameV1:
+    return ConsolidationFrameV1(
+        frame_id=(
+            "consolidation.frame:2026-05-25T14:30:00+00:00:"
+            "2026-05-25T15:30:00+00:00:consolidation_policy.v1"
+        ),
+        generated_at=NOW,
+        window_start=START,
+        window_end=NOW,
+        source_counts={"self_state": 1, "feedback": 2},
+    )
+
+
+def test_save_and_load_for_window(monkeypatch) -> None:
+    payload = _frame().model_dump(mode="json")
+    store = ConsolidationRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute_side_effect(stmt, params=None):
+        sql = str(stmt)
+        result = MagicMock()
+        if "INSERT INTO substrate_consolidation_frames" in sql:
+            result.rowcount = 1
+        elif "WHERE frame_id = :frame_id" in sql:
+            result.mappings.return_value.first.return_value = {
+                "consolidation_frame_json": payload
+            }
+        else:
+            result.mappings.return_value.first.return_value = {
+                "consolidation_frame_json": payload
+            }
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    store.save_consolidation_frame(_frame())
+    loaded = store.load_consolidation_frame_for_window(_frame().frame_id)
+    assert loaded is not None
+    assert loaded.frame_id == _frame().frame_id
+
+
+def test_load_latest(monkeypatch) -> None:
+    payload = _frame().model_dump(mode="json")
+    store = ConsolidationRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute_side_effect(stmt, params=None):
+        result = MagicMock()
+        result.mappings.return_value.first.return_value = {
+            "consolidation_frame_json": payload
+        }
+        return result
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    loaded = store.load_latest_consolidation_frame()
+    assert loaded is not None
+    assert loaded.source_counts["feedback"] == 2
+
+
+def test_save_idempotent_by_frame_id(monkeypatch) -> None:
+    store = ConsolidationRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    calls: list[str] = []
+
+    def execute_side_effect(stmt, params=None):
+        calls.append(str(stmt))
+        return MagicMock()
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    store.save_consolidation_frame(_frame())
+    assert any("ON CONFLICT (frame_id) DO NOTHING" in sql for sql in calls)

--- a/tests/test_consolidation_runtime_worker.py
+++ b/tests/test_consolidation_runtime_worker.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO = Path(__file__).resolve().parents[1]
+SVC = REPO / "services" / "orion-consolidation-runtime"
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+if str(SVC) not in sys.path:
+    sys.path.insert(0, str(SVC))
+
+
+def _load_worker_class():
+    spec = importlib.util.spec_from_file_location(
+        "consolidation_runtime_worker",
+        SVC / "app" / "worker.py",
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.ConsolidationRuntimeWorker
+
+
+ConsolidationRuntimeWorker = _load_worker_class()
+
+from orion.consolidation.windows import compute_consolidation_window, stable_consolidation_frame_id  # noqa: E402
+from orion.schemas.consolidation_frame import ConsolidationFrameV1  # noqa: E402
+
+NOW = datetime(2026, 5, 25, 15, 37, tzinfo=timezone.utc)
+
+
+def test_tick_skips_when_frame_exists_for_bucket(monkeypatch) -> None:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    worker = ConsolidationRuntimeWorker()
+    window_start, window_end = compute_consolidation_window(now=NOW, lookback_minutes=60)
+    frame_id = stable_consolidation_frame_id(
+        window_start=window_start,
+        window_end=window_end,
+        policy_id=worker._policy.policy_id,
+    )
+    existing = ConsolidationFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        window_start=window_start,
+        window_end=window_end,
+    )
+
+    worker._store.load_consolidation_frame_for_window = MagicMock(return_value=existing)
+    worker._store.load_window_data = MagicMock()
+    worker._store.save_consolidation_frame = MagicMock()
+
+    with patch(
+        "orion.consolidation.windows.compute_consolidation_window",
+        return_value=(window_start, window_end),
+    ):
+        worker._tick()
+
+    worker._store.load_window_data.assert_not_called()
+    worker._store.save_consolidation_frame.assert_not_called()

--- a/tests/test_consolidation_schema_candidates.py
+++ b/tests/test_consolidation_schema_candidates.py
@@ -1,0 +1,198 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import orion.consolidation.schema_candidates as schema_candidates_module
+from orion.consolidation.builder import build_consolidation_frame
+from orion.consolidation.policy import load_consolidation_policy
+from orion.consolidation.schema_candidates import build_schema_candidates
+from orion.consolidation.windows import ConsolidationWindowData
+from orion.schemas.consolidation_frame import ExpectationV1, MotifObservationV1
+from orion.schemas.execution_dispatch_frame import ExecutionDispatchCandidateV1, ExecutionDispatchFrameV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_consolidation_policy(REPO / "config" / "consolidation" / "consolidation_policy.v1.yaml")
+NOW = datetime(2026, 5, 25, 15, 0, tzinfo=timezone.utc)
+START = datetime(2026, 5, 25, 14, 0, tzinfo=timezone.utc)
+POLICY_ID = POLICY.policy_id
+
+
+def _dim(dimension_id: str, score: float) -> SelfStateDimensionV1:
+    return SelfStateDimensionV1(dimension_id=dimension_id, score=score, confidence=0.9)
+
+
+def _self_state(self_state_id: str) -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id=self_state_id,
+        generated_at=NOW,
+        source_field_tick_id="tick",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="att",
+        source_attention_generated_at=NOW,
+        overall_condition="loaded",
+        overall_intensity=0.7,
+        overall_confidence=0.9,
+        dimensions={
+            "execution_pressure": _dim("execution_pressure", 0.8),
+            "reliability_pressure": _dim("reliability_pressure", 0.2),
+        },
+    )
+
+
+def _policy_frame(frame_id: str) -> PolicyDecisionFrameV1:
+    decision = PolicyDecisionV1(
+        decision_id=f"policy.decision:{frame_id}",
+        proposal_id="proposal:inspect:state",
+        decision="approved_read_only",
+        policy_gate="read_only",
+        risk_score=0.05,
+        reversibility_score=1.0,
+        confidence_score=0.9,
+        allowed_scope="inspect_only",
+    )
+    return PolicyDecisionFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:test",
+        source_self_state_id="self.state:test",
+        decisions=[decision],
+        approved_decisions=[decision],
+        overall_risk=0.05,
+        execution_allowed=False,
+    )
+
+
+def _feedback_frame(frame_id: str) -> FeedbackFrameV1:
+    return FeedbackFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_execution_dispatch_frame_id=f"execution.dispatch.frame:{frame_id}",
+        outcome_status="dry_run_only",
+        outcome_score=0.5,
+        confidence_score=0.9,
+    )
+
+
+def _dispatch_blocked(frame_id: str) -> ExecutionDispatchFrameV1:
+    return ExecutionDispatchFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_policy_frame_id="policy.frame:blocked",
+        source_proposal_frame_id="proposal.frame:blocked",
+        source_self_state_id="self.state:blocked",
+        blocked_candidates=[
+            ExecutionDispatchCandidateV1(
+                dispatch_id=f"dispatch:blocked:{frame_id}",
+                source_decision_id="pd1",
+                source_proposal_id="proposal:blocked",
+                dispatch_status="blocked",
+                dispatch_mode="dry_run",
+                dispatch_kind="inspect",
+                target_id="t1",
+                target_kind="capability",
+                risk_score=0.3,
+                confidence_score=0.9,
+                blocked_by=["rejected"],
+            )
+        ],
+        blocked_count=1,
+    )
+
+
+def _motif(label: str) -> MotifObservationV1:
+    return MotifObservationV1(
+        motif_id=f"motif:{label}:{POLICY_ID}",
+        motif_kind="self_state_pattern",
+        label=label,
+        recurrence_count=3,
+        support_score=0.75,
+        confidence_score=1.0,
+        evidence_frame_ids=[f"evidence:{label}:1"],
+    )
+
+
+def _expectation(motif: MotifObservationV1, kind: str) -> ExpectationV1:
+    return ExpectationV1(
+        expectation_id=f"expectation:{motif.motif_id}:{kind}",
+        trigger_motif_id=motif.motif_id,
+        expected_outcome_kind=kind,  # type: ignore[arg-type]
+        confidence_score=motif.confidence_score,
+        support_count=motif.recurrence_count,
+    )
+
+
+def test_loaded_but_reliable_produces_prior_candidate() -> None:
+    motif = _motif("loaded_but_reliable")
+    candidates = build_schema_candidates(
+        motifs=[motif],
+        expectations=[_expectation(motif, "reliability_clear")],
+        policy=POLICY,
+    )
+    match = [item for item in candidates if item.candidate_kind == "prior_candidate"]
+    assert len(match) == 1
+    assert match[0].label == "loaded_but_reliable_operating_mode"
+
+
+def test_dry_run_feedback_loop_produces_habit_candidate() -> None:
+    motif = _motif("dry_run_feedback_loop")
+    candidates = build_schema_candidates(
+        motifs=[motif],
+        expectations=[_expectation(motif, "dry_run_feedback")],
+        policy=POLICY,
+    )
+    match = [item for item in candidates if item.candidate_kind == "habit_candidate"]
+    assert len(match) == 1
+    assert match[0].proposed_schema["expected_feedback"] == "dry_run_only"
+
+
+def test_read_only_policy_loop_produces_policy_candidate() -> None:
+    motif = _motif("read_only_policy_loop")
+    candidates = build_schema_candidates(
+        motifs=[motif],
+        expectations=[_expectation(motif, "read_only_approved")],
+        policy=POLICY,
+    )
+    match = [item for item in candidates if item.candidate_kind == "policy_candidate"]
+    assert len(match) == 1
+    assert match[0].proposed_schema["gate"] == "read_only"
+
+
+def test_promotion_status_is_candidate_only() -> None:
+    motif = _motif("loaded_but_reliable")
+    candidates = build_schema_candidates(motifs=[motif], expectations=[], policy=POLICY)
+    assert candidates
+    assert all(candidate.promotion_status == "candidate_only" for candidate in candidates)
+
+
+def test_candidate_includes_evidence_refs() -> None:
+    motif = _motif("loaded_but_reliable")
+    candidates = build_schema_candidates(motifs=[motif], expectations=[], policy=POLICY)
+    assert candidates[0].evidence_refs == ["evidence:loaded_but_reliable:1"]
+
+
+def test_no_rdf_writes() -> None:
+    source = Path(schema_candidates_module.__file__).read_text(encoding="utf-8")
+    assert "rdf" not in source.lower()
+    assert "graphdb" not in source.lower()
+
+
+def test_builder_emits_schema_candidates_without_policy_mutation() -> None:
+    window = ConsolidationWindowData(
+        window_start=START,
+        window_end=NOW,
+        self_states=[_self_state("self.state:1"), _self_state("self.state:2"), _self_state("self.state:3")],
+        attention_frames=[],
+        proposal_frames=[],
+        policy_frames=[_policy_frame("policy.frame:1"), _policy_frame("policy.frame:2"), _policy_frame("policy.frame:3")],
+        dispatch_frames=[_dispatch_blocked("execution.dispatch.frame:1")],
+        feedback_frames=[
+            _feedback_frame("feedback.frame:1"),
+            _feedback_frame("feedback.frame:2"),
+            _feedback_frame("feedback.frame:3"),
+        ],
+    )
+    frame = build_consolidation_frame(window=window, policy=POLICY, generated_at=NOW)
+    assert frame.schema_candidates
+    assert all(candidate.promotion_status == "candidate_only" for candidate in frame.schema_candidates)

--- a/tests/test_consolidation_tensorize.py
+++ b/tests/test_consolidation_tensorize.py
@@ -1,0 +1,255 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import orion.consolidation.tensorize as tensorize_module
+from orion.consolidation.policy import ConsolidationPolicyV1, load_consolidation_policy
+from orion.consolidation.tensorize import build_sparse_tensor_slices
+from orion.consolidation.windows import ConsolidationWindowData
+from orion.schemas.consolidation_frame import MotifObservationV1
+from orion.schemas.execution_dispatch_frame import ExecutionDispatchCandidateV1, ExecutionDispatchFrameV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
+from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1, PolicyDecisionV1
+from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_consolidation_policy(REPO / "config" / "consolidation" / "consolidation_policy.v1.yaml")
+NOW = datetime(2026, 5, 25, 15, 0, tzinfo=timezone.utc)
+START = datetime(2026, 5, 25, 14, 0, tzinfo=timezone.utc)
+
+
+def _dim(dimension_id: str, score: float) -> SelfStateDimensionV1:
+    return SelfStateDimensionV1(dimension_id=dimension_id, score=score, confidence=0.9)
+
+
+def _self_state(self_state_id: str, *, attention_frame_id: str = "attention.frame:1") -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id=self_state_id,
+        generated_at=NOW,
+        source_field_tick_id="tick",
+        source_field_generated_at=NOW,
+        source_attention_frame_id=attention_frame_id,
+        source_attention_generated_at=NOW,
+        overall_condition="loaded",
+        overall_intensity=0.7,
+        overall_confidence=0.9,
+        dimensions={
+            "execution_pressure": _dim("execution_pressure", 0.8),
+            "reliability_pressure": _dim("reliability_pressure", 0.2),
+        },
+    )
+
+
+def _attention_frame(frame_id: str) -> FieldAttentionFrameV1:
+    target = FieldAttentionTargetV1(
+        target_id="athena",
+        target_kind="node",
+        salience_score=0.8,
+        pressure_score=0.7,
+        novelty_score=0.1,
+        urgency_score=0.5,
+        confidence_score=0.9,
+    )
+    return FieldAttentionFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_field_tick_id="tick",
+        source_field_generated_at=NOW,
+        overall_salience=0.8,
+        node_targets=[target],
+        dominant_targets=[target],
+    )
+
+
+def _proposal_frame(frame_id: str) -> ProposalFrameV1:
+    return ProposalFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_self_state_id="self.state:1",
+        source_self_state_generated_at=NOW,
+        source_attention_frame_id="attention.frame:1",
+        source_field_tick_id="tick",
+        overall_action_pressure=0.5,
+        overall_risk=0.1,
+        candidates=[
+            ProposalCandidateV1(
+                proposal_id="proposal:inspect:1",
+                proposal_kind="inspect",
+                title="Inspect",
+                description="Inspect state",
+                target_id="athena",
+                target_kind="node",
+                priority_score=0.5,
+                urgency_score=0.4,
+                confidence_score=0.8,
+                risk_score=0.1,
+                reversibility_score=1.0,
+                proposed_effect="increase_observability",
+            )
+        ],
+    )
+
+
+def _policy_frame(frame_id: str) -> PolicyDecisionFrameV1:
+    decision = PolicyDecisionV1(
+        decision_id=f"policy.decision:{frame_id}",
+        proposal_id="proposal:inspect:1",
+        decision="approved_read_only",
+        policy_gate="read_only",
+        risk_score=0.05,
+        reversibility_score=1.0,
+        confidence_score=0.9,
+        allowed_scope="inspect_only",
+    )
+    return PolicyDecisionFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_proposal_frame_id="proposal.frame:1",
+        source_self_state_id="self.state:1",
+        decisions=[decision],
+        approved_decisions=[decision],
+        overall_risk=0.05,
+        execution_allowed=False,
+    )
+
+
+def _dispatch_frame(frame_id: str) -> ExecutionDispatchFrameV1:
+    return ExecutionDispatchFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_policy_frame_id="policy.frame:1",
+        source_proposal_frame_id="proposal.frame:1",
+        source_self_state_id="self.state:1",
+        candidates=[
+            ExecutionDispatchCandidateV1(
+                dispatch_id="dispatch:1",
+                source_decision_id="policy.decision:1",
+                source_proposal_id="proposal:inspect:1",
+                dispatch_status="dry_run",
+                dispatch_mode="dry_run",
+                dispatch_kind="inspect",
+                target_id="athena",
+                target_kind="node",
+                risk_score=0.1,
+                confidence_score=0.9,
+            )
+        ],
+    )
+
+
+def _feedback_frame(frame_id: str, *, dispatch_frame_id: str) -> FeedbackFrameV1:
+    return FeedbackFrameV1(
+        frame_id=frame_id,
+        generated_at=NOW,
+        source_execution_dispatch_frame_id=dispatch_frame_id,
+        outcome_status="dry_run_only",
+        outcome_score=0.5,
+        confidence_score=0.9,
+    )
+
+
+def _motif(label: str) -> MotifObservationV1:
+    return MotifObservationV1(
+        motif_id=f"motif:{label}:consolidation_policy.v1",
+        motif_kind="self_state_pattern",
+        label=label,
+        recurrence_count=3,
+        support_score=0.75,
+        confidence_score=1.0,
+        evidence_frame_ids=["self.state:1", "feedback.frame:1"],
+    )
+
+
+def _window(**overrides: object) -> ConsolidationWindowData:
+    defaults: dict[str, object] = {
+        "window_start": START,
+        "window_end": NOW,
+        "self_states": [_self_state("self.state:1")],
+        "attention_frames": [_attention_frame("attention.frame:1")],
+        "proposal_frames": [_proposal_frame("proposal.frame:1")],
+        "policy_frames": [_policy_frame("policy.frame:1")],
+        "dispatch_frames": [_dispatch_frame("execution.dispatch.frame:1")],
+        "feedback_frames": [_feedback_frame("feedback.frame:1", dispatch_frame_id="execution.dispatch.frame:1")],
+    }
+    defaults.update(overrides)
+    return ConsolidationWindowData(**defaults)  # type: ignore[arg-type]
+
+
+def _slices(**overrides: object):
+    window = _window(**overrides)
+    motifs = [_motif("loaded_but_reliable")]
+    return build_sparse_tensor_slices(
+        window=window,
+        motifs=motifs,
+        expectations=[],
+        policy=POLICY,
+    )
+
+
+def _slice_by_kind(slices, kind: str):
+    matches = [item for item in slices if item.tensor_kind == kind]
+    assert len(matches) == 1, f"expected one slice for {kind}, got {matches}"
+    return matches[0]
+
+
+def test_field_attention_self_tensor_has_expected_axes() -> None:
+    tensor = _slice_by_kind(_slices(), "field_attention_self")
+    assert tensor.axes == ["time_bucket", "self_condition", "attention_target", "dimension"]
+
+
+def test_policy_dispatch_feedback_tensor_has_expected_axes() -> None:
+    tensor = _slice_by_kind(_slices(), "policy_dispatch_feedback")
+    assert tensor.axes == ["proposal_kind", "policy_decision", "dispatch_status", "feedback_outcome"]
+
+
+def test_motif_condition_outcome_tensor_has_expected_axes() -> None:
+    tensor = _slice_by_kind(_slices(), "motif_condition_outcome")
+    assert tensor.axes == ["motif", "self_condition", "outcome_status"]
+
+
+def test_coordinates_are_sparse_dicts() -> None:
+    tensor = _slice_by_kind(_slices(), "field_attention_self")
+    assert tensor.coordinates
+    assert all(isinstance(coord, dict) for coord in tensor.coordinates)
+    assert all(isinstance(key, str) and isinstance(value, str) for coord in tensor.coordinates for key, value in coord.items())
+
+
+def test_values_length_equals_coordinates_length() -> None:
+    for tensor in _slices():
+        assert len(tensor.values) == len(tensor.coordinates)
+
+
+def test_coordinate_count_is_capped() -> None:
+    capped_policy = POLICY.model_copy(update={"tensor": POLICY.tensor.model_copy(update={"max_coordinates": 2})})
+    window = _window(
+        self_states=[
+            _self_state("self.state:1"),
+            _self_state("self.state:2", attention_frame_id="attention.frame:2"),
+            _self_state("self.state:3", attention_frame_id="attention.frame:3"),
+        ],
+        attention_frames=[
+            _attention_frame("attention.frame:1"),
+            _attention_frame("attention.frame:2"),
+            _attention_frame("attention.frame:3"),
+        ],
+    )
+    tensor = build_sparse_tensor_slices(
+        window=window,
+        motifs=[_motif("loaded_but_reliable")],
+        expectations=[],
+        policy=capped_policy,
+    )[0]
+    assert len(tensor.coordinates) <= 2
+    assert len(tensor.values) <= 2
+
+
+def test_tensor_evidence_refs_are_present() -> None:
+    for tensor in _slices():
+        assert tensor.evidence_refs
+
+
+def test_no_model_training_or_embedding_code() -> None:
+    source = Path(tensorize_module.__file__).read_text(encoding="utf-8")
+    forbidden = ("sklearn", "torch", "tensorflow", "embedding", "train(")
+    assert not any(token in source for token in forbidden)

--- a/tests/test_consolidation_windows.py
+++ b/tests/test_consolidation_windows.py
@@ -5,10 +5,25 @@ from orion.consolidation.windows import compute_consolidation_window, stable_con
 NOW = datetime(2026, 5, 25, 15, 37, tzinfo=timezone.utc)
 
 
-def test_window_lookback_60_minutes() -> None:
+def test_window_lookback_60_minutes_aligned_to_hour() -> None:
     start, end = compute_consolidation_window(now=NOW, lookback_minutes=60)
-    assert end == NOW
-    assert start == NOW - timedelta(minutes=60)
+    assert end == datetime(2026, 5, 25, 15, 0, tzinfo=timezone.utc)
+    assert start == datetime(2026, 5, 25, 14, 0, tzinfo=timezone.utc)
+
+
+def test_same_bucket_produces_identical_frame_id() -> None:
+    t1 = datetime(2026, 5, 25, 15, 10, tzinfo=timezone.utc)
+    t2 = datetime(2026, 5, 25, 15, 45, tzinfo=timezone.utc)
+    s1, e1 = compute_consolidation_window(now=t1, lookback_minutes=60)
+    s2, e2 = compute_consolidation_window(now=t2, lookback_minutes=60)
+    assert (s1, e1) == (s2, e2)
+    fid1 = stable_consolidation_frame_id(
+        window_start=s1, window_end=e1, policy_id="consolidation_policy.v1"
+    )
+    fid2 = stable_consolidation_frame_id(
+        window_start=s2, window_end=e2, policy_id="consolidation_policy.v1"
+    )
+    assert fid1 == fid2
 
 
 def test_stable_frame_id() -> None:

--- a/tests/test_consolidation_windows.py
+++ b/tests/test_consolidation_windows.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timedelta, timezone
+
+from orion.consolidation.windows import compute_consolidation_window, stable_consolidation_frame_id
+
+NOW = datetime(2026, 5, 25, 15, 37, tzinfo=timezone.utc)
+
+
+def test_window_lookback_60_minutes() -> None:
+    start, end = compute_consolidation_window(now=NOW, lookback_minutes=60)
+    assert end == NOW
+    assert start == NOW - timedelta(minutes=60)
+
+
+def test_stable_frame_id() -> None:
+    start = datetime(2026, 5, 25, 14, 30, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 25, 15, 30, tzinfo=timezone.utc)
+    fid = stable_consolidation_frame_id(
+        window_start=start,
+        window_end=end,
+        policy_id="consolidation_policy.v1",
+    )
+    assert fid == "consolidation.frame:2026-05-25T14:30:00+00:00:2026-05-25T15:30:00+00:00:consolidation_policy.v1"


### PR DESCRIPTION
# PR: Consolidation Frame v1 — Layer 11 Pattern Memory

**Branch:** `feat/consolidation-frame-v1`  
**Base:** `main`  
**Worktree:** `/mnt/scripts/Orion-Sapienform/.worktrees/feat-consolidation-frame-v1`

## Summary

Implements **Layer 11** of the Orion cognition substrate: deterministic consolidation over Layers 5–10 history. Repeated substrate frames become inspectable motifs, expectations, sparse tensor slices, and schema candidates — without mutating policy, proposals, execution, or habits.

```text
substrate_self_state
+ substrate_attention_frames
+ substrate_proposal_frames
+ substrate_policy_decision_frames
+ substrate_execution_dispatch_frames
+ substrate_feedback_frames
  → orion-consolidation-runtime (port 8123)
  → ConsolidationFrameV1
  → substrate_consolidation_frames (+ expectations, tensor_slices, schema_candidates)
  → GET /api/substrate/consolidation/* (Hub, read-only)
```

**Consolidation is repeated consequence becoming structure.** No LLM, no bus publish, no automatic promotion.

## Phases delivered

| Phase | Scope |
|-------|--------|
| **11a** | `MotifObservationV1`, `ConsolidationFrameV1`, 6 motif rules, runtime, smoke |
| **11b** | `ExpectationV1`, motif→outcome mapping, `substrate_expectations` upsert |
| **11c** | `SparseTensorSliceV1`, three tensor kinds, coordinate cap |
| **11d** | `SchemaCandidateV1`, `promotion_status=candidate_only` only |
| **11e** | `repository.py`, five GET Hub routes |

## Motif rules (deterministic)

| Motif | Source signal |
|-------|----------------|
| `loaded_but_reliable` | Self-state: loaded + high execution / low reliability pressure |
| `attention_saturated_execution` | Attention salience ≥ 0.7 on athena/orchestration |
| `read_only_policy_loop` | Policy approved_read_only, execution disallowed |
| `dry_run_feedback_loop` | Feedback `outcome_status=dry_run_only` |
| `blocked_review_loop` | Policy review / dispatch blocked / feedback blocked |
| `stable_after_dry_run` | Dry-run feedback + unchanged self-state delta |

## Idempotency

- Window bounds align to `lookback_minutes` UTC buckets (hourly when lookback=60).
- `frame_id` = `consolidation.frame:{window_start}:{window_end}:{policy_id}` — stable within bucket.
- Runtime `ON CONFLICT (frame_id) DO NOTHING` on consolidation frames.

## Proof: no forbidden side effects

- `orion/substrate/consolidation.py` unchanged (graph consolidation is separate)
- `orion/bus/channels.yaml` unchanged
- Worker only reads Layers 5–10 tables; writes consolidation artifact tables only
- Hub routes are GET-only; tests assert no POST on router
- Schema candidates always `promotion_status=candidate_only`

## Files changed (40 files, ~3900 lines)

| Path | Role |
|------|------|
| `orion/schemas/consolidation_frame.py` | All Layer 11 v1 schemas |
| `orion/schemas/registry.py` | Registry entries |
| `config/consolidation/consolidation_policy.v1.yaml` | Policy + motif + tensor config |
| `orion/consolidation/*.py` | Policy, windows, motifs, expectations, tensorize, schema candidates, builder, repository |
| `services/orion-sql-db/manual_migration_consolidation_*.sql` | 4 DDL migrations |
| `services/orion-consolidation-runtime/` | Polling runtime (8123) |
| `services/orion-hub/scripts/substrate_consolidation_routes.py` | Debug API |
| `scripts/smoke_consolidation_v1.sh` | Live SQL smoke |
| `tests/test_consolidation_*.py` | Unit + store + worker tests |

## Migrations (apply in order)

1. `manual_migration_consolidation_v1.sql`
2. `manual_migration_consolidation_expectations_v1.sql`
3. `manual_migration_consolidation_tensor_slices_v1.sql`
4. `manual_migration_consolidation_schema_candidates_v1.sql`

## Test plan

```bash
cd .worktrees/feat-consolidation-frame-v1
PYTHONPATH=. pytest tests/test_consolidation_*.py \
  services/orion-hub/tests/test_substrate_consolidation_debug_api.py -q
# Expected: 67 passed

# After migrations + runtime:
./scripts/smoke_consolidation_v1.sh
```

## Review fixes (post code-review)

- **Window bucketing:** `compute_consolidation_window` aligns `window_end` to lookback-minute UTC buckets so repeated polls share one `frame_id` (was inserting every tick).

## Non-goals verified

- No policy/proposal/attention weight mutation
- No habit execution or RDF writes
- No cortex-exec steering
- No bus publish
- No LLM calls
