### PR TITLE
Feat/memory graph topical spine editor timeout

### DIFF
--- a/orion/cognition/prompts/memory_graph_suggest_prompt.j2
+++ b/orion/cognition/prompts/memory_graph_suggest_prompt.j2
@@ -59,9 +59,16 @@ Role-grounded extraction rules:
 - Ordinary/routine turns should still produce a minimal semantic graph when they contain actions, states, promises, availability, movement, return expectations, emotions, preferences, or relational posture.
 - Salience/durability is not your job in this draft. Extract the faithful structure first.
 
-Minimal example (match real turn ids; keep output compact — prefer 2 entities + 2 situations for two turns):
-- User turn → person entity + situation about user state/action.
-- Assistant turn → abstract Orion entity + situation about assistant posture.
+Dual spine (relational + topical — both required when the text supports them):
+- Relational spine: User and Orion entities, situations for interpersonal moves (affect, availability, trust), orionmem:inSituation / stimulus / about / target edges as appropriate.
+- Topical spine: when utterances name a stance, artifact, evaluative object, plan fork, or other discourse center, add entityKind "abstract" entities with verbatim surfaceForms from the text (e.g. "pragmatic take", "model training"). Link each relevant situation with schema:about (situation → topic entity) and/or participants with role "topic". Reuse the same topic entity id across turns when a later turn continues the same thread.
+- Do not fold topical content only into situation.label strings; labels summarize, entities carry recallable subjects.
+- generalizes_to may connect a specific topical entity to a broader one (e.g. usable stance → pragmatic take).
+- At minimum User + Orion when both roles appear; add topical abstract entities whenever salient noun phrases carry the conversational center (not only when names are capitalized).
+
+Minimal example (match real turn ids; keep output compact):
+- Two-turn feedback on a "pragmatic take": User + Orion + abstract "pragmatic take"; situations for user acknowledgment and assistant affirmation; schema:about from situation to topic; shared topic id if both turns discuss it.
+- Shower example: User + Orion + abstract "shower"; situations for departure and availability.
 - Include orionmem:inSituation edges; fill utterance_text_by_id; dispositions only when trust/distrust is explicit.
 
 Rules:

--- a/orion/memory_graph/approve.py
+++ b/orion/memory_graph/approve.py
@@ -171,21 +171,33 @@ def preview_validate_only(
     supplemental_utterance_text: Optional[Mapping[str, str]] = None,
 ) -> tuple[bool, List[str], Dict[str, Any]]:
     """Validate RDF + SHACL without persistence; return preview card shells."""
+    from orion.memory_graph.suggest_validate import collect_topical_spine_warnings
+
     try:
         draft = ensure_draft_utterance_text(draft, supplemental=supplemental_utterance_text)
     except ValueError as exc:
         if str(exc).startswith("utterance_text_missing:"):
-            return (False, [str(exc)], {"card_count": 0, "edge_count": 0, "titles": []})
+            return (False, [str(exc)], {"card_count": 0, "edge_count": 0, "titles": [], "warnings": []})
         raise
     try:
         g = draft_to_graph(draft)
     except ValueError as exc:
-        return (False, [str(exc)], {"card_count": 0, "edge_count": 0, "titles": []})
+        return (False, [str(exc)], {"card_count": 0, "edge_count": 0, "titles": [], "warnings": []})
     violations = validate_graph(g)
     pack = project_graph_to_cards(g, draft)
+    corpus_parts: List[str] = []
+    if supplemental_utterance_text:
+        corpus_parts.extend(str(v) for v in supplemental_utterance_text.values() if str(v).strip())
+    if draft.utterance_text_by_id:
+        corpus_parts.extend(str(v) for v in draft.utterance_text_by_id.values() if str(v).strip())
+    warnings = collect_topical_spine_warnings(
+        draft.model_dump(mode="json"),
+        utterance_text=" ".join(corpus_parts),
+    )
     preview = {
         "card_count": len(pack.creates),
         "edge_count": len(pack.edge_indices),
         "titles": [c.title for c in pack.creates],
+        "warnings": warnings,
     }
     return (len(violations) == 0, violations, preview)

--- a/orion/memory_graph/approve.py
+++ b/orion/memory_graph/approve.py
@@ -9,6 +9,7 @@ import requests
 
 from orion.core.storage.memory_cards import insert_cards_and_edges_batch
 from orion.memory_graph.dto import SuggestDraftV1
+from orion.memory_graph.draft_sanitize import sanitize_suggest_draft_dict
 from orion.memory_graph.graphdb import compensate_batch, insert_batch
 from orion.memory_graph.json_to_rdf import draft_to_graph
 from orion.memory_graph.utterance_text import ensure_draft_utterance_text
@@ -98,6 +99,9 @@ async def approve_memory_graph_draft(
     implicitly select GraphDB from stale ``GRAPHDB_URL`` while ``MEMORY_GRAPH_APPROVAL_BACKEND=auto``.
     """
     batch_id = str(uuid4())
+    draft = SuggestDraftV1.model_validate(
+        sanitize_suggest_draft_dict(draft.model_dump(mode="json"))
+    )
     draft = ensure_draft_utterance_text(draft)
     g2 = draft_to_graph(draft, revision_batch=batch_id)
     violations = validate_graph(g2)
@@ -174,6 +178,9 @@ def preview_validate_only(
     from orion.memory_graph.suggest_validate import collect_topical_spine_warnings
 
     try:
+        draft = SuggestDraftV1.model_validate(
+            sanitize_suggest_draft_dict(draft.model_dump(mode="json"))
+        )
         draft = ensure_draft_utterance_text(draft, supplemental=supplemental_utterance_text)
     except ValueError as exc:
         if str(exc).startswith("utterance_text_missing:"):

--- a/orion/memory_graph/draft_sanitize.py
+++ b/orion/memory_graph/draft_sanitize.py
@@ -1,0 +1,206 @@
+"""Normalize and repair SuggestDraftV1-shaped dicts before RDF / approval."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+_UUID_TAIL = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.I,
+)
+
+
+def is_blank_ref(ref: Any) -> bool:
+    if ref is None:
+        return True
+    s = str(ref).strip()
+    return not s or s.lower() in ("null", "none")
+
+
+def is_resolvable_entity_ref(ref: Any, *, entity_base: str = "https://orion.example/ns/mem/entity/") -> bool:
+    if is_blank_ref(ref):
+        return False
+    s = str(ref).strip()
+    if s.startswith("http://") or s.startswith("https://"):
+        return True
+    if s.startswith("urn:uuid:"):
+        return bool(_UUID_TAIL.match(s.removeprefix("urn:uuid:")))
+    return False
+
+
+def _known_node_ids(data: Dict[str, Any]) -> Tuple[Set[str], Set[str], Set[str]]:
+    entity_ids: Set[str] = set()
+    situation_ids: Set[str] = set()
+    utterance_ids: Set[str] = set()
+    for ent in data.get("entities") or []:
+        if isinstance(ent, dict):
+            eid = str(ent.get("id") or "").strip()
+            if eid:
+                entity_ids.add(eid)
+    for sit in data.get("situations") or []:
+        if isinstance(sit, dict):
+            sid = str(sit.get("id") or "").strip()
+            if sid:
+                situation_ids.add(sid)
+    for uid in data.get("utterance_ids") or []:
+        u = str(uid or "").strip()
+        if u:
+            utterance_ids.add(u)
+    return entity_ids, situation_ids, utterance_ids
+
+
+def _structural_edges(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Edges implied by situation fields (preview + RDF spine when model edges are wrong)."""
+    entity_ids, situation_ids, _ = _known_node_ids(data)
+    graph_nodes = entity_ids | situation_ids
+    out: List[Dict[str, Any]] = []
+    seen: Set[Tuple[str, str, str]] = set()
+
+    def add(s: str, p: str, o: str, confidence: float = 0.85) -> None:
+        if not is_resolvable_entity_ref(s) or not is_resolvable_entity_ref(o):
+            return
+        if s not in graph_nodes or o not in graph_nodes:
+            return
+        key = (s, p, o)
+        if key in seen:
+            return
+        seen.add(key)
+        out.append({"s": s, "p": p, "o": o, "confidence": confidence})
+
+    for sit in data.get("situations") or []:
+        if not isinstance(sit, dict):
+            continue
+        sid = str(sit.get("id") or "").strip()
+        if not sid or sid not in situation_ids:
+            continue
+        stim = sit.get("stimulus_entity_id")
+        if not is_blank_ref(stim):
+            add(sid, "orionmem:stimulusEntity", str(stim).strip())
+        for ae in sit.get("about_entity_ids") or []:
+            if not is_blank_ref(ae):
+                add(sid, "schema:about", str(ae).strip())
+        for ta in sit.get("target_entity_ids") or []:
+            if not is_blank_ref(ta):
+                add(sid, "orionmem:targetOfNegativeAffect", str(ta).strip())
+        for part in sit.get("participants") or []:
+            if not isinstance(part, dict):
+                continue
+            eid = str(part.get("entity_id") or part.get("entityId") or "").strip()
+            if eid and eid in entity_ids:
+                add(eid, "orionmem:inSituation", sid)
+
+    return out
+
+
+def sanitize_suggest_draft_dict(
+    data: Dict[str, Any],
+    *,
+    rebuild_edges_from_structure: bool = False,
+) -> Dict[str, Any]:
+    """Strip null refs, drop invalid edges, optionally rebuild edges from situations."""
+    if not isinstance(data, dict):
+        return data
+
+    out = dict(data)
+    entity_ids, situation_ids, utterance_ids = _known_node_ids(out)
+    graph_nodes = entity_ids | situation_ids
+
+    entities = []
+    for ent in out.get("entities") or []:
+        if not isinstance(ent, dict):
+            continue
+        row = dict(ent)
+        if is_blank_ref(row.get("generalizes_to")):
+            row["generalizes_to"] = None
+        elif not is_resolvable_entity_ref(row.get("generalizes_to")):
+            row["generalizes_to"] = None
+        entities.append(row)
+    out["entities"] = entities
+
+    situations = []
+    for sit in out.get("situations") or []:
+        if not isinstance(sit, dict):
+            continue
+        row = dict(sit)
+        for key in ("stimulus_entity_id",):
+            if is_blank_ref(row.get(key)) or (
+                not is_blank_ref(row.get(key))
+                and str(row.get(key)).strip() not in entity_ids
+                and str(row.get(key)).strip() in utterance_ids
+            ):
+                row[key] = None
+        row["about_entity_ids"] = [
+            str(x).strip()
+            for x in (row.get("about_entity_ids") or [])
+            if not is_blank_ref(x)
+            and str(x).strip() in entity_ids
+        ]
+        row["target_entity_ids"] = [
+            str(x).strip()
+            for x in (row.get("target_entity_ids") or [])
+            if not is_blank_ref(x) and str(x).strip() in entity_ids
+        ]
+        parts = []
+        for part in row.get("participants") or []:
+            if not isinstance(part, dict):
+                continue
+            eid = str(part.get("entity_id") or part.get("entityId") or "").strip()
+            if eid and eid in entity_ids:
+                parts.append(
+                    {
+                        "entity_id": eid,
+                        "role": str(part.get("role") or "participant").strip() or "participant",
+                    }
+                )
+        row["participants"] = parts
+        situations.append(row)
+    out["situations"] = situations
+
+    dispositions = []
+    for disp in out.get("dispositions") or []:
+        if not isinstance(disp, dict):
+            continue
+        row = dict(disp)
+        if is_blank_ref(row.get("id")):
+            row["id"] = None
+        if is_blank_ref(row.get("holder_id")):
+            continue
+        if is_blank_ref(row.get("target_id")):
+            continue
+        dispositions.append(row)
+    out["dispositions"] = dispositions
+
+    cleaned_edges: List[Dict[str, Any]] = []
+    for edge in out.get("edges") or []:
+        if not isinstance(edge, dict):
+            continue
+        s = str(edge.get("s") or "").strip()
+        o = str(edge.get("o") or "").strip()
+        p = str(edge.get("p") or "").strip()
+        if is_blank_ref(s) or is_blank_ref(o) or not p:
+            continue
+        if s in utterance_ids or o in utterance_ids:
+            continue
+        if s not in graph_nodes or o not in graph_nodes:
+            continue
+        if not is_resolvable_entity_ref(s) or not is_resolvable_entity_ref(o):
+            continue
+        conf = edge.get("confidence")
+        try:
+            c = float(conf) if conf is not None else 0.8
+        except (TypeError, ValueError):
+            c = 0.8
+        cleaned_edges.append({"s": s, "p": p, "o": o, "confidence": c})
+
+    if rebuild_edges_from_structure or not cleaned_edges:
+        structural = _structural_edges(out)
+        merged_keys = {(e["s"], e["p"], e["o"]) for e in cleaned_edges}
+        for e in structural:
+            key = (e["s"], e["p"], e["o"])
+            if key not in merged_keys:
+                cleaned_edges.append(e)
+                merged_keys.add(key)
+
+    out["edges"] = cleaned_edges
+    return out

--- a/orion/memory_graph/json_to_rdf.py
+++ b/orion/memory_graph/json_to_rdf.py
@@ -8,6 +8,7 @@ from rdflib import Graph, Literal, Namespace, URIRef
 from rdflib.namespace import RDF, RDFS, XSD
 
 from orion.memory_graph.dto import SuggestDraftV1
+from orion.memory_graph.draft_sanitize import is_blank_ref, is_resolvable_entity_ref
 from orion.memory_graph.utterance_text import ensure_draft_utterance_text
 
 ORIONMEM = Namespace("https://orion.local/ns/mem/v2026-05#")
@@ -82,7 +83,16 @@ def draft_to_graph(
     g.bind("schema", SCHEMA)
 
     def eb(ref: str) -> URIRef:
-        return entity_uri(ref, entity_base=entity_base)
+        if is_blank_ref(ref):
+            raise ValueError(f"unsupported entity ref {ref!r}")
+        return entity_uri(str(ref).strip(), entity_base=entity_base)
+
+    def eb_opt(ref: Optional[str]) -> Optional[URIRef]:
+        if is_blank_ref(ref):
+            return None
+        if not is_resolvable_entity_ref(ref, entity_base=entity_base):
+            return None
+        return entity_uri(str(ref).strip(), entity_base=entity_base)
 
     for uid in draft.utterance_ids:
         u = utterance_uri(uid, prefix=utterance_prefix)
@@ -103,8 +113,9 @@ def draft_to_graph(
         for sf in ent.surfaceForms or []:
             if sf:
                 g.add((node, ORIONMEM.surfaceForm, Literal(sf)))
-        if ent.generalizes_to:
-            g.add((node, ORIONMEM.generalizationOf, eb(ent.generalizes_to)))
+        gen = eb_opt(ent.generalizes_to)
+        if gen is not None:
+            g.add((node, ORIONMEM.generalizationOf, gen))
         if revision_batch:
             g.add((node, ORIONMEM.revisionBatch, Literal(revision_batch)))
 
@@ -115,12 +126,17 @@ def draft_to_graph(
             g.add((snode, RDFS.label, Literal(sit.label)))
         for uid in sit.utterance_ids:
             g.add((snode, PROV.wasDerivedFrom, utterance_uri(uid, prefix=utterance_prefix)))
-        if sit.stimulus_entity_id:
-            g.add((snode, ORIONMEM.stimulusEntity, eb(sit.stimulus_entity_id)))
+        stim = eb_opt(sit.stimulus_entity_id)
+        if stim is not None:
+            g.add((snode, ORIONMEM.stimulusEntity, stim))
         for ae in sit.about_entity_ids:
-            g.add((snode, ORIONMEM.aboutEntity, eb(ae)))
+            about = eb_opt(ae)
+            if about is not None:
+                g.add((snode, ORIONMEM.aboutEntity, about))
         for ta in sit.target_entity_ids:
-            g.add((snode, ORIONMEM.targetOfNegativeAffect, eb(ta)))
+            target = eb_opt(ta)
+            if target is not None:
+                g.add((snode, ORIONMEM.targetOfNegativeAffect, target))
         if sit.affectLabel:
             g.add((snode, ORIONMEM.affectLabel, Literal(sit.affectLabel)))
         if sit.timeQualitative:
@@ -128,29 +144,42 @@ def draft_to_graph(
         if sit.occurredAt:
             g.add((snode, ORIONMEM.occurredAt, Literal(sit.occurredAt, datatype=XSD.date)))
         for part in sit.participants:
-            en = eb(part.entity_id)
+            en = eb_opt(part.entity_id)
+            if en is None:
+                continue
             g.add((en, ORIONMEM.inSituation, snode))
             g.add((en, ORIONMEM.participantRole, Literal(part.role)))
         if revision_batch:
             g.add((snode, ORIONMEM.revisionBatch, Literal(revision_batch)))
 
     for disp in draft.dispositions:
-        disp_id = (disp.id or "").strip() or f"urn:uuid:{uuid4()}"
+        disp_id = (disp.id or "").strip()
+        if is_blank_ref(disp_id) or not is_resolvable_entity_ref(disp_id):
+            disp_id = f"urn:uuid:{uuid4()}"
         dnode = eb(disp_id)
         g.add((dnode, RDF.type, ORIONMEM.AffectiveDisposition))
         g.add((dnode, ORIONMEM.trustPolarity, Literal(disp.trustPolarity)))
-        g.add((dnode, ORIONMEM.dispositionTarget, eb(disp.target_id)))
+        target = eb_opt(disp.target_id)
+        if target is None:
+            continue
+        g.add((dnode, ORIONMEM.dispositionTarget, target))
         if draft.utterance_ids:
             g.add((dnode, PROV.wasDerivedFrom, utterance_uri(draft.utterance_ids[0], prefix=utterance_prefix)))
         if disp.description:
             g.add((dnode, SCHEMA.description, Literal(disp.description)))
-        g.add((eb(disp.holder_id), ORIONMEM.dispositionToward, dnode))
+        holder = eb_opt(disp.holder_id)
+        if holder is None:
+            continue
+        g.add((holder, ORIONMEM.dispositionToward, dnode))
         if revision_batch:
             g.add((dnode, ORIONMEM.revisionBatch, Literal(revision_batch)))
 
     for e in draft.edges:
+        snode = eb_opt(e.s)
+        onode = eb_opt(e.o)
+        if snode is None or onode is None:
+            continue
         pred = expand_curie(e.p)
-        snode, onode = eb(e.s), eb(e.o)
         g.add((snode, URIRef(pred), onode))
         if revision_batch:
             g.add((snode, ORIONMEM.revisionBatch, Literal(revision_batch)))

--- a/orion/memory_graph/suggest_validate.py
+++ b/orion/memory_graph/suggest_validate.py
@@ -64,6 +64,18 @@ _ASSISTANT_ENTITY_HINTS = frozenset(
 
 _ROLE_ENTITY_NAMESPACE = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c0")
 
+_ROLE_ENTITY_LABELS = frozenset({"user", "orion", "juniper", "assistant", "here"})
+
+_TOPICAL_CUE_RE = re.compile(
+    r"\b(?:take|stance|approach|rollout|training|design|usable|decorative|pragmatic|pov|plan)\b",
+    re.I,
+)
+_QUOTED_PHRASE_RE = re.compile(r'["\']([^"\']{3,80})["\']')
+_TOPICAL_BIGRAM_RE = re.compile(
+    r"\b(pragmatic\s+take|point\s+of\s+view|model\s+training|cert\s+rollout)\b",
+    re.I,
+)
+
 
 def extract_selected_role_evidence(utterance_text: str) -> Dict[str, bool]:
     """Parse bridge-style transcript evidence for selected user/assistant turns."""
@@ -115,6 +127,109 @@ def role_grounded_extraction_expected(utterance_text: str) -> bool:
     if not ev.get("has_nonempty_text"):
         return False
     return bool(ev.get("has_extractable_relation"))
+
+
+def _draft_utterance_corpus(data: Dict[str, Any], utterance_text: str = "") -> str:
+    parts: List[str] = []
+    if utterance_text and str(utterance_text).strip():
+        parts.append(str(utterance_text))
+    text_map = data.get("utterance_text_by_id")
+    if isinstance(text_map, dict):
+        for val in text_map.values():
+            s = str(val or "").strip()
+            if s:
+                parts.append(s)
+    return " ".join(parts)
+
+
+def _entity_surface_forms_lower(entities: List[Any]) -> set[str]:
+    out: set[str] = set()
+    for ent in entities:
+        if not isinstance(ent, dict):
+            continue
+        label = str(ent.get("label") or "").strip().lower()
+        if label:
+            out.add(label)
+        sf = ent.get("surfaceForms")
+        if isinstance(sf, list):
+            for item in sf:
+                s = str(item or "").strip().lower()
+                if s:
+                    out.add(s)
+    return out
+
+
+def _has_topical_entity(entities: List[Any]) -> bool:
+    for ent in entities:
+        if not isinstance(ent, dict):
+            continue
+        kind = str(ent.get("entityKind") or "").strip().lower()
+        label = str(ent.get("label") or "").strip().lower()
+        if kind == "abstract" and label not in _ROLE_ENTITY_LABELS:
+            return True
+        if kind not in ("person", "abstract"):
+            return True
+        if kind == "person" and label not in _ROLE_ENTITY_LABELS:
+            return True
+    return False
+
+
+def _salient_phrases_in_corpus(corpus: str) -> List[str]:
+    phrases: List[str] = []
+    for match in _QUOTED_PHRASE_RE.finditer(corpus):
+        phrases.append(match.group(1).strip())
+    for match in _TOPICAL_BIGRAM_RE.finditer(corpus):
+        phrases.append(match.group(0).strip())
+    seen: set[str] = set()
+    out: List[str] = []
+    for phrase in phrases:
+        key = phrase.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(phrase)
+    return out
+
+
+def _phrase_covered_by_surfaces(phrase: str, surfaces: set[str]) -> bool:
+    norm = phrase.strip().lower()
+    if not norm:
+        return True
+    for surface in surfaces:
+        if norm in surface or surface in norm:
+            return True
+    return False
+
+
+def collect_topical_spine_warnings(
+    data: Dict[str, Any],
+    *,
+    utterance_text: str = "",
+) -> List[str]:
+    """Non-blocking hints when relational spine exists but topical subjects are thin."""
+    if not isinstance(data, dict):
+        return []
+    corpus = _draft_utterance_corpus(data, utterance_text)
+    if not corpus.strip() or not _TOPICAL_CUE_RE.search(corpus):
+        return []
+
+    entities = data.get("entities")
+    if not isinstance(entities, list):
+        entities = []
+
+    warnings: List[str] = []
+    surfaces = _entity_surface_forms_lower(entities)
+
+    if role_grounded_extraction_expected(utterance_text or corpus) and entities and not _has_topical_entity(
+        entities
+    ):
+        warnings.append("topical_spine_missing:consider_abstract_topic_entities")
+
+    for phrase in _salient_phrases_in_corpus(corpus):
+        if not _phrase_covered_by_surfaces(phrase, surfaces):
+            warnings.append(f"topical_phrase_not_extracted:{phrase[:72]}")
+
+    return warnings[:10]
 
 
 def _entity_tokens(entities: List[Any]) -> Tuple[set[str], set[str]]:

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -189,9 +189,12 @@ MEMORY_GRAPH_SUGGEST_ENABLE_ESCALATION=true
 MEMORY_GRAPH_SUGGEST_INCLUDE_GROUNDING=true
 # Verb budget (ms); matches orion/cognition/verbs/memory_graph_suggest.yaml timeout_ms.
 MEMORY_GRAPH_SUGGEST_VERB_TIMEOUT_MS=180000
-# Per-route hub waits (seconds). 0 = derive from verb budget (Quick ~72s, Brain 180s).
+# Per-route hub waits (seconds). 0 = derive from verb budget (Quick+Brain share 180s when escalation on).
 MEMORY_GRAPH_SUGGEST_BRAIN_TIMEOUT_SEC=0
 MEMORY_GRAPH_SUGGEST_QUICK_TIMEOUT_SEC=0
+# Hub UI fetch AbortController (ms). 0 = auto (server budget + buffer, typically 205000).
+MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_TIMEOUT_MS=0
+MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_BUFFER_SEC=25
 # After probe_structured_output.py: json_object_schema | json_schema_schema | json_object_only | none
 MEMORY_GRAPH_SUGGEST_STRUCTURED_OUTPUT_METHOD=json_object_schema
 MEMORY_GRAPH_SUGGEST_MAX_TOKENS=4096

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -365,7 +365,23 @@ class Settings(BaseSettings):
     MEMORY_GRAPH_SUGGEST_QUICK_TIMEOUT_SEC: float = Field(
         default=0.0,
         alias="MEMORY_GRAPH_SUGGEST_QUICK_TIMEOUT_SEC",
-        description="Per Quick-route hub wait; 0 = ~40% of verb timeout (72s when verb is 180s).",
+        description=(
+            "Per Quick-route hub wait; 0 = ~35% of verb budget when escalation is on "
+            "(Quick+Brain share one verb budget), else ~40% of verb."
+        ),
+    )
+    MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_TIMEOUT_MS: int = Field(
+        default=0,
+        alias="MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_TIMEOUT_MS",
+        description=(
+            "Hub UI fetch AbortController for POST /api/memory/graph/suggest; "
+            "0 = auto (server budget + buffer, typically ~205s when verb=180s and escalation on)."
+        ),
+    )
+    MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_BUFFER_SEC: float = Field(
+        default=25.0,
+        alias="MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_BUFFER_SEC",
+        description="Added to computed server budget for browser fetch timeout when client ms is 0.",
     )
     MEMORY_GRAPH_SUGGEST_STRUCTURED_OUTPUT_METHOD: str = Field(
         default="json_object_schema",

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -339,11 +339,17 @@ async def startup_event():
             "{{HUB_UI_ASSET_VERSION}}",
             ui_asset_version,
         )
+        from scripts.memory_graph_suggest_timeout import hub_client_fetch_timeout_ms
+
+        mg_escalation = bool(getattr(settings, "MEMORY_GRAPH_SUGGEST_ENABLE_ESCALATION", True))
         hub_cfg = {
             "apiBaseOverride": settings.HUB_API_BASE_OVERRIDE or "",
             "wsBaseOverride": settings.HUB_WS_BASE_OVERRIDE or "",
             "autoDefaultEnabled": bool(settings.HUB_AUTO_DEFAULT_ENABLED),
             "worldPulseFixtureRunEnabled": bool(settings.WORLD_PULSE_UI_FIXTURE_RUN_ENABLED),
+            "memoryGraphSuggestFetchTimeoutMs": hub_client_fetch_timeout_ms(
+                settings, escalation_enabled=mg_escalation
+            ),
         }
         html_content = html_content.replace(
             "{{HUB_CFG}}",

--- a/services/orion-hub/scripts/memory_graph_routes.py
+++ b/services/orion-hub/scripts/memory_graph_routes.py
@@ -69,7 +69,8 @@ async def memory_graph_validate(
         draft,
         supplemental_utterance_text=supplemental,
     )
-    return {"ok": ok, "violations": violations, "preview": preview}
+    warnings = preview.get("warnings") if isinstance(preview, dict) else []
+    return {"ok": ok, "violations": violations, "warnings": warnings or [], "preview": preview}
 
 
 @router.post("/api/memory/graph/suggest")

--- a/services/orion-hub/scripts/memory_graph_suggest.py
+++ b/services/orion-hub/scripts/memory_graph_suggest.py
@@ -31,6 +31,8 @@ from scripts.cortex_request_builder import (
 )
 from scripts.memory_graph_suggest_timeout import (
     cortex_rpc_timeout_sec,
+    hub_client_fetch_timeout_ms,
+    memory_graph_suggest_server_budget_sec,
     resolve_memory_graph_suggest_timeouts,
 )
 from scripts.memory_graph_structured_output import (
@@ -224,7 +226,9 @@ async def suggest_with_escalation(
     include_grounding = bool(
         getattr(settings, "MEMORY_GRAPH_SUGGEST_INCLUDE_GROUNDING", True)
     )
-    verb_timeout_sec, t_quick, t_brain, verb_timeout_ms = resolve_memory_graph_suggest_timeouts(settings)
+    verb_timeout_sec, t_quick, t_brain, verb_timeout_ms = resolve_memory_graph_suggest_timeouts(
+        settings, escalation_enabled=enable_escalation
+    )
 
     def timeout_for(route: RouteName) -> float:
         return t_brain if route == "brain" else t_quick
@@ -278,6 +282,13 @@ async def suggest_with_escalation(
         "verb_timeout_sec": verb_timeout_sec,
         "quick_timeout_sec": t_quick,
         "brain_timeout_sec": t_brain,
+        "escalation_enabled": enable_escalation,
+        "max_server_sec": memory_graph_suggest_server_budget_sec(
+            settings, escalation_enabled=enable_escalation
+        ),
+        "client_fetch_timeout_ms": hub_client_fetch_timeout_ms(
+            settings, escalation_enabled=enable_escalation
+        ),
         "source": "orion/cognition/verbs/memory_graph_suggest.yaml",
     }
 

--- a/services/orion-hub/scripts/memory_graph_suggest.py
+++ b/services/orion-hub/scripts/memory_graph_suggest.py
@@ -170,6 +170,10 @@ def _parse_suggest_draft_from_text(
     if role_grounded_extraction_expected(utterance_text):
         data = repair_role_grounded_suggest_draft(data, utterance_text=utterance_text)
 
+    from orion.memory_graph.draft_sanitize import sanitize_suggest_draft_dict
+
+    data = sanitize_suggest_draft_dict(data)
+
     should_escalate, validation_errors = validate_for_escalation(data, utterance_text=utterance_text)
     if should_escalate:
         return None, True, validation_errors, None

--- a/services/orion-hub/scripts/memory_graph_suggest_timeout.py
+++ b/services/orion-hub/scripts/memory_graph_suggest_timeout.py
@@ -6,6 +6,7 @@ from typing import Any, Tuple
 
 MEMORY_GRAPH_SUGGEST_VERB = "memory_graph_suggest"
 DEFAULT_VERB_TIMEOUT_MS = 180_000
+DEFAULT_CLIENT_FETCH_BUFFER_SEC = 25.0
 
 
 def memory_graph_verb_timeout_ms(settings: Any | None = None) -> int:
@@ -29,26 +30,88 @@ def memory_graph_verb_timeout_ms(settings: Any | None = None) -> int:
         return DEFAULT_VERB_TIMEOUT_MS
 
 
-def resolve_memory_graph_suggest_timeouts(settings: Any) -> Tuple[float, float, float, int]:
+def resolve_memory_graph_suggest_timeouts(
+    settings: Any,
+    *,
+    escalation_enabled: bool = True,
+) -> Tuple[float, float, float, int]:
     """
     Return (verb_timeout_sec, quick_timeout_sec, brain_timeout_sec, verb_timeout_ms).
 
-    Per-route caps default from verb timeout_ms (orion/cognition/verbs/memory_graph_suggest.yaml):
-    - Quick primary: ~40% of verb budget (floor 45s)
-    - Brain escalation: full verb budget
-  """
+    When escalation is enabled, Quick + Brain share one verb budget (default 180s total),
+    so a browser fetch limit of 180s is not exceeded by sequential attempts.
+
+    Per-route overrides (MEMORY_GRAPH_SUGGEST_*_TIMEOUT_SEC) are capped to the verb budget.
+    """
     verb_ms = memory_graph_verb_timeout_ms(settings)
     verb_sec = float(verb_ms) / 1000.0
 
     quick_raw = float(getattr(settings, "MEMORY_GRAPH_SUGGEST_QUICK_TIMEOUT_SEC", 0) or 0)
     brain_raw = float(getattr(settings, "MEMORY_GRAPH_SUGGEST_BRAIN_TIMEOUT_SEC", 0) or 0)
 
-    quick = quick_raw if quick_raw > 0 else max(45.0, round(verb_sec * 0.4, 1))
-    brain = brain_raw if brain_raw > 0 else verb_sec
+    if escalation_enabled:
+        if quick_raw > 0:
+            quick = min(quick_raw, verb_sec)
+        else:
+            quick = max(45.0, round(verb_sec * 0.35, 1))
+        if brain_raw > 0:
+            brain = min(brain_raw, max(45.0, verb_sec - quick))
+        else:
+            brain = max(45.0, round(verb_sec - quick, 1))
+        total = quick + brain
+        if total > verb_sec:
+            scale = verb_sec / total
+            quick = round(quick * scale, 1)
+            brain = round(verb_sec - quick, 1)
+    else:
+        if quick_raw > 0:
+            quick = min(quick_raw, verb_sec)
+        else:
+            quick = max(45.0, round(verb_sec * 0.4, 1))
+        if brain_raw > 0:
+            brain = min(brain_raw, verb_sec)
+        else:
+            brain = verb_sec
+        quick = min(quick, verb_sec)
+        brain = min(brain, verb_sec)
 
-    quick = min(quick, verb_sec)
-    brain = min(brain, verb_sec)
     return verb_sec, quick, brain, verb_ms
+
+
+def memory_graph_suggest_server_budget_sec(
+    settings: Any,
+    *,
+    escalation_enabled: bool = True,
+) -> float:
+    """Wall-clock budget for all suggest attempts in one Hub request."""
+    _, quick, brain, _ = resolve_memory_graph_suggest_timeouts(
+        settings, escalation_enabled=escalation_enabled
+    )
+    if escalation_enabled:
+        return float(quick) + float(brain)
+    primary = str(getattr(settings, "MEMORY_GRAPH_SUGGEST_PRIMARY_ROUTE", "quick") or "quick").strip().lower()
+    return float(brain if primary == "brain" else quick)
+
+
+def hub_client_fetch_timeout_ms(
+    settings: Any,
+    *,
+    escalation_enabled: bool = True,
+) -> int:
+    """
+    Browser / Hub fetch AbortController budget (must exceed server_budget + overhead).
+    """
+    override = int(getattr(settings, "MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_TIMEOUT_MS", 0) or 0)
+    if override > 0:
+        return override
+    server_sec = memory_graph_suggest_server_budget_sec(
+        settings, escalation_enabled=escalation_enabled
+    )
+    buffer = float(
+        getattr(settings, "MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_BUFFER_SEC", 0)
+        or DEFAULT_CLIENT_FETCH_BUFFER_SEC
+    )
+    return int((server_sec + buffer) * 1000)
 
 
 def cortex_rpc_timeout_sec(hub_attempt_timeout_sec: float, settings: Any) -> float:

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -501,12 +501,19 @@ loadDismissedIds();
   let memoryGraphBridgeAnchorDiv = null;
   const MEMORY_GRAPH_BRIDGE_MAX_TURNS_CAP = 80;
   const MEMORY_GRAPH_BRIDGE_MAX_TURNS_DEFAULT = 40;
-  // Match `orion/cognition/verbs/memory_graph_suggest.yaml` timeout_ms (hub fetch must not abort first).
-  const MEMORY_GRAPH_SUGGEST_TIMEOUT_MS = 180000;
+  function memoryGraphSuggestFetchTimeoutMs() {
+    const ui = window.OrionMemoryGraphDraftUI || {};
+    if (typeof ui.resolveMemoryGraphSuggestFetchTimeoutMs === 'function') {
+      return ui.resolveMemoryGraphSuggestFetchTimeoutMs();
+    }
+    const raw = Number((window.__HUB_CFG__ || {}).memoryGraphSuggestFetchTimeoutMs);
+    return Number.isFinite(raw) && raw > 0 ? raw : 205000;
+  }
   const MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS = 12000;
   const MEMORY_GRAPH_SUGGEST_INPUT_PER_TURN_CHARS = 1800;
   const LS_MEMORY_GRAPH_BRIDGE_MAX_TURNS = 'orion_memory_graph_bridge_max_turns';
   let memoryGraphBridgeDraftViz = null;
+  let memoryGraphBridgeDraftForm = null;
   let organSignalsGraphCtl = null;
   const RECALL_CANARY_PROFILE_STORAGE_KEY = 'orion_recall_canary_profile_v1';
 
@@ -7499,14 +7506,36 @@ loadDismissedIds();
     const cy = document.getElementById('memoryGraphBridgeCyHost');
     const det = document.getElementById('memoryGraphBridgeDetail');
     const ban = document.getElementById('memoryGraphBridgeParseBanner');
+    const formHost = document.getElementById('memoryGraphBridgeFormHost');
     if (!ta || !cy || !det) return null;
     memoryGraphBridgeDraftViz = window.OrionMemoryGraphDraftUI.attach({
       draftTextarea: ta,
       cyHost: cy,
       detailHost: det,
       bannerEl: ban,
+      onDraftJsonChange: () => {
+        if (memoryGraphBridgeDraftForm && typeof memoryGraphBridgeDraftForm.refresh === 'function') {
+          memoryGraphBridgeDraftForm.refresh();
+        }
+      },
     });
+    if (formHost && window.OrionMemoryGraphDraftForm && !memoryGraphBridgeDraftForm) {
+      memoryGraphBridgeDraftForm = window.OrionMemoryGraphDraftForm.attachFormEditor({
+        draftTextarea: ta,
+        formHost,
+        onDraftChange: () => {
+          const viz = memoryGraphBridgeDraftViz || ensureMemoryGraphBridgeDraftViz();
+          if (viz && typeof viz.refresh === 'function') viz.refresh();
+        },
+      });
+    }
     return memoryGraphBridgeDraftViz;
+  }
+
+  function flushMemoryGraphBridgeDraftForm() {
+    if (memoryGraphBridgeDraftForm && typeof memoryGraphBridgeDraftForm.flushToTextarea === 'function') {
+      memoryGraphBridgeDraftForm.flushToTextarea();
+    }
   }
 
   function ensureOrganSignalsGraph() {
@@ -7833,7 +7862,7 @@ loadDismissedIds();
               } catch (_) {
                 /* ignore */
               }
-            }, MEMORY_GRAPH_SUGGEST_TIMEOUT_MS)
+            }, memoryGraphSuggestFetchTimeoutMs())
             : null;
           let res;
           try {
@@ -7907,6 +7936,9 @@ loadDismissedIds();
           draftTa.value = out;
           const vDraft = ensureMemoryGraphBridgeDraftViz();
           if (vDraft && vDraft.refresh) vDraft.refresh();
+          if (memoryGraphBridgeDraftForm && memoryGraphBridgeDraftForm.refresh) {
+            memoryGraphBridgeDraftForm.refresh();
+          }
           renderMemoryGraphBridgeDiagnostics(coalesce, data);
           if (statusEl) {
             const statusFn =
@@ -7935,7 +7967,8 @@ loadDismissedIds();
         } catch (err) {
           if (statusEl) {
             if (err && err.name === 'AbortError') {
-              statusEl.textContent = `Suggest timed out after ${Math.round(MEMORY_GRAPH_SUGGEST_TIMEOUT_MS / 1000)}s (browser fetch limit). Retry when the model gateway is responsive; reduce selected bridge turns only if the compiled prompt is very large.`;
+              const fetchSec = Math.round(memoryGraphSuggestFetchTimeoutMs() / 1000);
+              statusEl.textContent = `Suggest timed out after ${fetchSec}s (browser fetch limit; Hub may still be running Quick then Brain). Retry when the gateway is responsive, or set MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_TIMEOUT_MS higher. Reduce selected turns only if the prompt was clipped.`;
             } else {
               statusEl.textContent = String(err.message || err);
             }
@@ -7948,6 +7981,7 @@ loadDismissedIds();
     }
     if (toMemBtn) {
       toMemBtn.addEventListener('click', () => {
+        flushMemoryGraphBridgeDraftForm();
         const raw = document.getElementById('memoryGraphBridgeDraft')?.value || '';
         if (!String(raw).trim()) {
           showToast('Add or generate a draft first (run Suggest draft), then continue.');

--- a/services/orion-hub/static/js/memory-graph-draft-form.js
+++ b/services/orion-hub/static/js/memory-graph-draft-form.js
@@ -42,6 +42,12 @@
     return `urn:uuid:${Date.now()}-draft`;
   }
 
+  function normalizeRef(value) {
+    const s = String(value == null ? "" : value).trim();
+    if (!s || s.toLowerCase() === "null" || s.toLowerCase() === "none") return null;
+    return s;
+  }
+
   function splitCsv(s) {
     return String(s || "")
       .split(",")
@@ -217,7 +223,7 @@
           label: card.querySelector("[data-ent=label]")?.value?.trim() || "",
           entityKind: card.querySelector("[data-ent=entityKind]")?.value || "abstract",
           surfaceForms: splitCsv(card.querySelector("[data-ent=surfaceForms]")?.value),
-          generalizes_to: card.querySelector("[data-ent=generalizes_to]")?.value?.trim() || null,
+          generalizes_to: normalizeRef(card.querySelector("[data-ent=generalizes_to]")?.value),
         });
       });
 
@@ -228,12 +234,12 @@
           id: card.querySelector("[data-sit=id]")?.value?.trim() || newEntityId(),
           utterance_ids: splitCsv(card.querySelector("[data-sit=utterance_ids]")?.value),
           label: card.querySelector("[data-sit=label]")?.value?.trim() || "",
-          stimulus_entity_id: card.querySelector("[data-sit=stimulus_entity_id]")?.value?.trim() || null,
+          stimulus_entity_id: normalizeRef(card.querySelector("[data-sit=stimulus_entity_id]")?.value),
           about_entity_ids: splitCsv(card.querySelector("[data-sit=about_entity_ids]")?.value),
           target_entity_ids: splitCsv(card.querySelector("[data-sit=target_entity_ids]")?.value),
           affectLabel: card.querySelector("[data-sit=affectLabel]")?.value || "neutral",
           timeQualitative: card.querySelector("[data-sit=timeQualitative]")?.value || "unknown",
-          occurredAt: occurred || null,
+          occurredAt: normalizeRef(occurred),
           participants: participantsFromText(card.querySelector("[data-sit=participants]")?.value),
         });
       });

--- a/services/orion-hub/static/js/memory-graph-draft-form.js
+++ b/services/orion-hub/static/js/memory-graph-draft-form.js
@@ -1,0 +1,604 @@
+/* Orion Hub — human-readable SuggestDraftV1 form editor (syncs with JSON textarea). */
+(function () {
+  const ENTITY_KINDS = ["person", "animal", "pet", "breed", "taxon", "collective", "abstract"];
+  const AFFECT_LABELS = [
+    "anger",
+    "annoyance",
+    "affection",
+    "fear",
+    "trust",
+    "distrust",
+    "neutral",
+    "ambivalence",
+    "none",
+  ];
+  const TIME_QUAL = ["today", "yesterday", "last_week", "recent", "unknown"];
+  const TRUST_POL = ["trust", "distrust", "ambivalent", "unknown"];
+  const EDGE_PREDS = [
+    "orionmem:inSituation",
+    "orionmem:stimulusEntity",
+    "orionmem:aboutEntity",
+    "orionmem:targetOfNegativeAffect",
+    "orionmem:generalizationOf",
+    "orionmem:contradictsSituation",
+    "prov:wasDerivedFrom",
+    "schema:about",
+  ];
+
+  function debounce(fn, ms) {
+    let t = null;
+    return function debounced() {
+      const args = arguments;
+      const self = this;
+      clearTimeout(t);
+      t = setTimeout(() => fn.apply(self, args), ms);
+    };
+  }
+
+  function newEntityId() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+      return `urn:uuid:${crypto.randomUUID()}`;
+    }
+    return `urn:uuid:${Date.now()}-draft`;
+  }
+
+  function splitCsv(s) {
+    return String(s || "")
+      .split(",")
+      .map((x) => x.trim())
+      .filter(Boolean);
+  }
+
+  function joinCsv(arr) {
+    return (Array.isArray(arr) ? arr : [])
+      .map((x) => String(x || "").trim())
+      .filter(Boolean)
+      .join(", ");
+  }
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  function fieldRow(labelText, control) {
+    const row = el("label", "block space-y-0.5");
+    const lab = el("span", "text-[10px] text-gray-500 uppercase tracking-wide");
+    lab.textContent = labelText;
+    row.appendChild(lab);
+    row.appendChild(control);
+    return row;
+  }
+
+  function textInput(value, placeholder) {
+    const inp = document.createElement("input");
+    inp.type = "text";
+    inp.className =
+      "w-full bg-gray-950 border border-gray-700 rounded px-2 py-1 text-gray-100 text-[11px]";
+    inp.value = value != null ? String(value) : "";
+    if (placeholder) inp.placeholder = placeholder;
+    return inp;
+  }
+
+  function textArea(value, rows) {
+    const ta = document.createElement("textarea");
+    ta.className =
+      "w-full bg-gray-950 border border-gray-700 rounded px-2 py-1 text-gray-100 text-[11px] font-mono leading-relaxed";
+    ta.rows = rows || 2;
+    ta.value = value != null ? String(value) : "";
+    return ta;
+  }
+
+  function selectInput(value, options) {
+    const sel = document.createElement("select");
+    sel.className =
+      "w-full bg-gray-950 border border-gray-700 rounded px-2 py-1 text-gray-100 text-[11px]";
+    options.forEach((opt) => {
+      const o = document.createElement("option");
+      o.value = opt;
+      o.textContent = opt;
+      if (String(value) === opt) o.selected = true;
+      sel.appendChild(o);
+    });
+    return sel;
+  }
+
+  function entityLabelById(entities, id) {
+    const sid = String(id || "").trim();
+    if (!sid) return "";
+    const ents = Array.isArray(entities) ? entities : [];
+    for (let i = 0; i < ents.length; i += 1) {
+      const e = ents[i];
+      if (e && String(e.id) === sid) return String(e.label || e.id);
+    }
+    return sid.slice(0, 24);
+  }
+
+  function participantsToText(parts) {
+    if (!Array.isArray(parts)) return "";
+    return parts
+      .map((p) => {
+        if (!p || typeof p !== "object") return "";
+        const role = String(p.role || "").trim();
+        const eid = String(p.entity_id || p.entityId || "").trim();
+        if (!role && !eid) return "";
+        return `${role || "participant"}: ${eid}`;
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  function participantsFromText(text) {
+    return String(text || "")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const idx = line.indexOf(":");
+        if (idx < 0) return { entity_id: line, role: "participant" };
+        return {
+          role: line.slice(0, idx).trim() || "participant",
+          entity_id: line.slice(idx + 1).trim(),
+        };
+      });
+  }
+
+  function emptyDraftFromUi(ui) {
+    if (ui && typeof ui.emptySuggestDraft === "function") return ui.emptySuggestDraft();
+    return {
+      ontology_version: "orionmem-2026-05",
+      utterance_ids: [],
+      entities: [],
+      situations: [],
+      edges: [],
+      dispositions: [],
+      utterance_text_by_id: {},
+    };
+  }
+
+  /**
+   * @param {object} options
+   * @param {HTMLTextAreaElement} options.draftTextarea
+   * @param {HTMLElement} options.formHost
+   * @param {() => void} [options.onDraftChange]
+   */
+  function attachFormEditor(options) {
+    const draftTextarea = options.draftTextarea;
+    const formHost = options.formHost;
+    const onDraftChange = options.onDraftChange || function () {};
+    const ui = window.OrionMemoryGraphDraftUI || {};
+    const parseFn =
+      typeof ui.parseMemoryGraphDraftJson === "function"
+        ? ui.parseMemoryGraphDraftJson
+        : null;
+    const looksDraft =
+      typeof ui.looksLikeMemoryGraphDraftObject === "function"
+        ? ui.looksLikeMemoryGraphDraftObject
+        : function () {
+            return false;
+          };
+
+    let syncing = false;
+    let draftObj = null;
+
+    function readTextarea() {
+      if (!draftTextarea || !parseFn) return { ok: false, object: null };
+      return parseFn(draftTextarea.value);
+    }
+
+    function writeTextarea(obj) {
+      if (!draftTextarea) return;
+      syncing = true;
+      draftTextarea.value = JSON.stringify(obj, null, 2);
+      syncing = false;
+      draftObj = obj;
+      onDraftChange();
+      try {
+        draftTextarea.dispatchEvent(new Event("input", { bubbles: true }));
+      } catch (_) {
+        /* ignore */
+      }
+    }
+
+    function collectDraftFromForm() {
+      const base = draftObj && typeof draftObj === "object" ? { ...draftObj } : emptyDraftFromUi(ui);
+      const root = formHost;
+      if (!root) return base;
+
+      const uidInp = root.querySelector("[data-draft-field=utterance_ids]");
+      if (uidInp) base.utterance_ids = splitCsv(uidInp.value);
+
+      base.entities = [];
+      root.querySelectorAll("[data-entity-card]").forEach((card) => {
+        base.entities.push({
+          id: card.querySelector("[data-ent=id]")?.value?.trim() || newEntityId(),
+          label: card.querySelector("[data-ent=label]")?.value?.trim() || "",
+          entityKind: card.querySelector("[data-ent=entityKind]")?.value || "abstract",
+          surfaceForms: splitCsv(card.querySelector("[data-ent=surfaceForms]")?.value),
+          generalizes_to: card.querySelector("[data-ent=generalizes_to]")?.value?.trim() || null,
+        });
+      });
+
+      base.situations = [];
+      root.querySelectorAll("[data-situation-card]").forEach((card) => {
+        const occurred = card.querySelector("[data-sit=occurredAt]")?.value?.trim();
+        base.situations.push({
+          id: card.querySelector("[data-sit=id]")?.value?.trim() || newEntityId(),
+          utterance_ids: splitCsv(card.querySelector("[data-sit=utterance_ids]")?.value),
+          label: card.querySelector("[data-sit=label]")?.value?.trim() || "",
+          stimulus_entity_id: card.querySelector("[data-sit=stimulus_entity_id]")?.value?.trim() || null,
+          about_entity_ids: splitCsv(card.querySelector("[data-sit=about_entity_ids]")?.value),
+          target_entity_ids: splitCsv(card.querySelector("[data-sit=target_entity_ids]")?.value),
+          affectLabel: card.querySelector("[data-sit=affectLabel]")?.value || "neutral",
+          timeQualitative: card.querySelector("[data-sit=timeQualitative]")?.value || "unknown",
+          occurredAt: occurred || null,
+          participants: participantsFromText(card.querySelector("[data-sit=participants]")?.value),
+        });
+      });
+
+      base.edges = [];
+      root.querySelectorAll("[data-edge-row]").forEach((row) => {
+        const confRaw = row.querySelector("[data-edge=confidence]")?.value;
+        let confidence = 0.8;
+        const c = parseFloat(confRaw);
+        if (!Number.isNaN(c)) confidence = c;
+        base.edges.push({
+          s: row.querySelector("[data-edge=s]")?.value?.trim() || "",
+          p: row.querySelector("[data-edge=p]")?.value || "schema:about",
+          o: row.querySelector("[data-edge=o]")?.value?.trim() || "",
+          confidence,
+        });
+      });
+
+      base.dispositions = [];
+      root.querySelectorAll("[data-disposition-card]").forEach((card) => {
+        const idVal = card.querySelector("[data-disp=id]")?.value?.trim();
+        base.dispositions.push({
+          id: idVal || null,
+          holder_id: card.querySelector("[data-disp=holder_id]")?.value?.trim() || "",
+          target_id: card.querySelector("[data-disp=target_id]")?.value?.trim() || "",
+          trustPolarity: card.querySelector("[data-disp=trustPolarity]")?.value || "unknown",
+          description: card.querySelector("[data-disp=description]")?.value?.trim() || "",
+        });
+      });
+
+      return base;
+    }
+
+    const debouncedWrite = debounce(() => {
+      if (syncing) return;
+      writeTextarea(collectDraftFromForm());
+    }, 180);
+
+    function bindInput(node) {
+      if (!node) return;
+      node.addEventListener("input", debouncedWrite);
+      node.addEventListener("change", debouncedWrite);
+    }
+
+    function sectionHeader(title, addLabel, onAdd) {
+      const head = el("div", "flex items-center justify-between gap-2 mt-3 mb-1");
+      head.appendChild(el("div", "text-[11px] font-semibold text-gray-300", title));
+      if (onAdd) {
+        const btn = el("button", "px-2 py-0.5 rounded border border-gray-600 bg-gray-800 text-[10px] text-gray-200");
+        btn.type = "button";
+        btn.textContent = addLabel || "+ Add";
+        btn.addEventListener("click", onAdd);
+        head.appendChild(btn);
+      }
+      return head;
+    }
+
+    function renderEntityCard(ent, index) {
+      const card = el("div", "border border-gray-800 rounded-lg p-2 space-y-2 bg-gray-950/40");
+      card.dataset.entityCard = String(index);
+      const title = el("div", "text-[11px] text-indigo-200 font-medium");
+      title.textContent = `Entity: ${ent.label || ent.id || `#${index + 1}`}`;
+      card.appendChild(title);
+      const idInp = textInput(ent.id, "urn:uuid:…");
+      idInp.dataset.ent = "id";
+      const labelInp = textInput(ent.label, "display label");
+      labelInp.dataset.ent = "label";
+      const kindSel = selectInput(ent.entityKind || "abstract", ENTITY_KINDS);
+      kindSel.dataset.ent = "entityKind";
+      const sfInp = textInput(joinCsv(ent.surfaceForms), "surface forms, comma-separated");
+      sfInp.dataset.ent = "surfaceForms";
+      const genInp = textInput(ent.generalizes_to || "", "generalizes_to entity id");
+      genInp.dataset.ent = "generalizes_to";
+      [idInp, labelInp, kindSel, sfInp, genInp].forEach(bindInput);
+      card.appendChild(fieldRow("ID", idInp));
+      card.appendChild(fieldRow("Label", labelInp));
+      card.appendChild(fieldRow("Kind", kindSel));
+      card.appendChild(fieldRow("Surface forms", sfInp));
+      card.appendChild(fieldRow("Generalizes to", genInp));
+      const rm = el("button", "text-[10px] text-red-300/90 hover:text-red-200");
+      rm.type = "button";
+      rm.textContent = "Remove entity";
+      rm.addEventListener("click", () => {
+        card.remove();
+        debouncedWrite();
+      });
+      card.appendChild(rm);
+      return card;
+    }
+
+    function renderSituationCard(sit, index, entities) {
+      const card = el("div", "border border-gray-800 rounded-lg p-2 space-y-2 bg-gray-950/40");
+      card.dataset.situationCard = String(index);
+      const title = el("div", "text-[11px] text-emerald-200 font-medium");
+      title.textContent = `Situation: ${sit.label || sit.id || `#${index + 1}`}`;
+      card.appendChild(title);
+      const fields = [
+        ["id", sit.id, "urn:uuid:…"],
+        ["utterance_ids", joinCsv(sit.utterance_ids), "turn ids"],
+        ["label", sit.label, "short description"],
+        ["stimulus_entity_id", sit.stimulus_entity_id || "", "entity id"],
+        ["about_entity_ids", joinCsv(sit.about_entity_ids), "entity ids"],
+        ["target_entity_ids", joinCsv(sit.target_entity_ids), "entity ids"],
+      ];
+      fields.forEach(([key, val, ph]) => {
+        const inp = textInput(val, ph);
+        inp.dataset.sit = key;
+        bindInput(inp);
+        card.appendChild(fieldRow(key.replace(/_/g, " "), inp));
+      });
+      const affSel = selectInput(sit.affectLabel || "neutral", AFFECT_LABELS);
+      affSel.dataset.sit = "affectLabel";
+      const timeSel = selectInput(sit.timeQualitative || "unknown", TIME_QUAL);
+      timeSel.dataset.sit = "timeQualitative";
+      const occInp = textInput(sit.occurredAt || "", "YYYY-MM-DD or empty");
+      occInp.dataset.sit = "occurredAt";
+      const partTa = textArea(participantsToText(sit.participants), 3);
+      partTa.dataset.sit = "participants";
+      partTa.placeholder = "role: entity_id (one per line), e.g. topic: urn:uuid:…";
+      [affSel, timeSel, occInp, partTa].forEach(bindInput);
+      card.appendChild(fieldRow("Affect", affSel));
+      card.appendChild(fieldRow("Time", timeSel));
+      card.appendChild(fieldRow("Occurred at", occInp));
+      card.appendChild(fieldRow("Participants", partTa));
+      const hint = el(
+        "p",
+        "text-[10px] text-gray-500",
+        `Entities: ${(entities || [])
+          .map((e) => `${e.label || "?"} → ${e.id}`)
+          .join(" · ") || "(none yet)"}`,
+      );
+      card.appendChild(hint);
+      const rm = el("button", "text-[10px] text-red-300/90 hover:text-red-200");
+      rm.type = "button";
+      rm.textContent = "Remove situation";
+      rm.addEventListener("click", () => {
+        card.remove();
+        debouncedWrite();
+      });
+      card.appendChild(rm);
+      return card;
+    }
+
+    function renderEdgeRow(edge, index) {
+      const row = el("div", "grid grid-cols-1 sm:grid-cols-4 gap-2 items-end border-b border-gray-800/80 pb-2");
+      row.dataset.edgeRow = String(index);
+      const sInp = textInput(edge.s, "source id");
+      sInp.dataset.edge = "s";
+      const pSel = selectInput(edge.p || "schema:about", EDGE_PREDS);
+      pSel.dataset.edge = "p";
+      const oInp = textInput(edge.o, "target id");
+      oInp.dataset.edge = "o";
+      const cInp = textInput(edge.confidence != null ? String(edge.confidence) : "0.8", "0–1");
+      cInp.dataset.edge = "confidence";
+      [sInp, pSel, oInp, cInp].forEach(bindInput);
+      row.appendChild(fieldRow("Source", sInp));
+      row.appendChild(fieldRow("Predicate", pSel));
+      row.appendChild(fieldRow("Target", oInp));
+      row.appendChild(fieldRow("Conf.", cInp));
+      const rmWrap = el("div", "sm:col-span-4");
+      const rm = el("button", "text-[10px] text-red-300/90");
+      rm.type = "button";
+      rm.textContent = "Remove edge";
+      rm.addEventListener("click", () => {
+        row.remove();
+        debouncedWrite();
+      });
+      rmWrap.appendChild(rm);
+      row.appendChild(rmWrap);
+      return row;
+    }
+
+    function renderDispositionCard(disp, index) {
+      const card = el("div", "border border-gray-800 rounded-lg p-2 space-y-2 bg-gray-950/40");
+      card.dataset.dispositionCard = String(index);
+      const fields = [
+        ["id", disp.id || "", "optional"],
+        ["holder_id", disp.holder_id, "entity id"],
+        ["target_id", disp.target_id, "entity id"],
+      ];
+      fields.forEach(([key, val, ph]) => {
+        const inp = textInput(val, ph);
+        inp.dataset.disp = key;
+        bindInput(inp);
+        card.appendChild(fieldRow(key, inp));
+      });
+      const polSel = selectInput(disp.trustPolarity || "unknown", TRUST_POL);
+      polSel.dataset.disp = "trustPolarity";
+      const descTa = textArea(disp.description, 2);
+      descTa.dataset.disp = "description";
+      [polSel, descTa].forEach(bindInput);
+      card.appendChild(fieldRow("Trust polarity", polSel));
+      card.appendChild(fieldRow("Description", descTa));
+      const rm = el("button", "text-[10px] text-red-300/90");
+      rm.type = "button";
+      rm.textContent = "Remove disposition";
+      rm.addEventListener("click", () => {
+        card.remove();
+        debouncedWrite();
+      });
+      card.appendChild(rm);
+      return card;
+    }
+
+    function render(obj) {
+      if (!formHost) return;
+      formHost.innerHTML = "";
+      draftObj = obj;
+
+      if (!obj || !looksDraft(obj)) {
+        const msg = el(
+          "p",
+          "text-[11px] text-gray-500 leading-relaxed",
+          "No valid SuggestDraftV1 yet. Use Suggest from chat, paste JSON in Advanced below, or add entities here after the first suggest.",
+        );
+        formHost.appendChild(msg);
+        const seed = el("button", "mt-2 px-2 py-1 rounded border border-gray-600 bg-gray-800 text-[10px] text-gray-200");
+        seed.type = "button";
+        seed.textContent = "Start empty draft";
+        seed.addEventListener("click", () => writeTextarea(emptyDraftFromUi(ui)));
+        formHost.appendChild(seed);
+        return;
+      }
+
+      const meta = el("div", "space-y-2 border border-gray-800 rounded-lg p-2 bg-gray-950/30");
+      meta.appendChild(el("div", "text-[10px] text-gray-500", `Ontology: ${obj.ontology_version || "?"}`));
+      const uidInp = textInput(joinCsv(obj.utterance_ids), "utterance turn ids");
+      uidInp.dataset.draftField = "utterance_ids";
+      bindInput(uidInp);
+      meta.appendChild(fieldRow("Utterance IDs", uidInp));
+      formHost.appendChild(meta);
+
+      const textMap = obj.utterance_text_by_id;
+      if (textMap && typeof textMap === "object" && Object.keys(textMap).length) {
+        const utWrap = el("details", "border border-gray-800 rounded-lg p-2 bg-gray-950/20");
+        const sum = document.createElement("summary");
+        sum.className = "text-[10px] text-gray-400 cursor-pointer";
+        sum.textContent = "Source utterances (read-only)";
+        utWrap.appendChild(sum);
+        Object.keys(textMap).forEach((id) => {
+          const block = el("div", "mt-2 text-[10px] text-gray-400");
+          block.innerHTML = `<span class="text-gray-500 font-mono">${id}</span><p class="text-gray-300 mt-0.5 whitespace-pre-wrap">${String(
+            textMap[id] || "",
+          )
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")}</p>`;
+          utWrap.appendChild(block);
+        });
+        formHost.appendChild(utWrap);
+      }
+
+      const entWrap = el("div", "");
+      formHost.appendChild(
+        sectionHeader("Entities (relational + topical)", "+ Entity", () => {
+          entWrap.appendChild(
+            renderEntityCard(
+              {
+                id: newEntityId(),
+                label: "",
+                entityKind: "abstract",
+                surfaceForms: [],
+                generalizes_to: null,
+              },
+              entWrap.children.length,
+            ),
+          );
+          debouncedWrite();
+        }),
+      );
+      formHost.appendChild(entWrap);
+      (obj.entities || []).forEach((e, i) => entWrap.appendChild(renderEntityCard(e, i)));
+
+      const sitWrap = el("div", "");
+      formHost.appendChild(
+        sectionHeader("Situations", "+ Situation", () => {
+          sitWrap.appendChild(
+            renderSituationCard(
+              {
+                id: newEntityId(),
+                utterance_ids: obj.utterance_ids || [],
+                label: "",
+                stimulus_entity_id: null,
+                about_entity_ids: [],
+                target_entity_ids: [],
+                affectLabel: "neutral",
+                timeQualitative: "recent",
+                occurredAt: null,
+                participants: [],
+              },
+              sitWrap.children.length,
+              collectDraftFromForm().entities,
+            ),
+          );
+          debouncedWrite();
+        }),
+      );
+      formHost.appendChild(sitWrap);
+      (obj.situations || []).forEach((s, i) =>
+        sitWrap.appendChild(renderSituationCard(s, i, obj.entities)),
+      );
+
+      const edgeWrap = el("div", "space-y-2");
+      formHost.appendChild(
+        sectionHeader("Edges", "+ Edge", () => {
+          edgeWrap.appendChild(
+            renderEdgeRow({ s: "", p: "schema:about", o: "", confidence: 0.85 }, edgeWrap.children.length),
+          );
+          debouncedWrite();
+        }),
+      );
+      formHost.appendChild(edgeWrap);
+      (obj.edges || []).forEach((e, i) => edgeWrap.appendChild(renderEdgeRow(e, i)));
+
+      const dispWrap = el("div", "");
+      formHost.appendChild(
+        sectionHeader("Dispositions", "+ Disposition", () => {
+          dispWrap.appendChild(
+            renderDispositionCard(
+              {
+                id: newEntityId(),
+                holder_id: "",
+                target_id: "",
+                trustPolarity: "unknown",
+                description: "",
+              },
+              dispWrap.children.length,
+            ),
+          );
+          debouncedWrite();
+        }),
+      );
+      formHost.appendChild(dispWrap);
+      (obj.dispositions || []).forEach((d, i) => dispWrap.appendChild(renderDispositionCard(d, i)));
+    }
+
+    function refresh() {
+      if (syncing) return;
+      const parsed = readTextarea();
+      if (parsed.ok && parsed.object) {
+        render(parsed.object);
+        return;
+      }
+      render(null);
+    }
+
+    const debouncedRefresh = debounce(refresh, 100);
+    if (draftTextarea) {
+      draftTextarea.addEventListener("input", debouncedRefresh);
+    }
+
+    refresh();
+
+    return {
+      refresh,
+      destroy() {
+        if (draftTextarea) draftTextarea.removeEventListener("input", debouncedRefresh);
+        if (formHost) formHost.innerHTML = "";
+      },
+      flushToTextarea() {
+        writeTextarea(collectDraftFromForm());
+      },
+    };
+  }
+
+  window.OrionMemoryGraphDraftForm = {
+    attachFormEditor,
+  };
+})();

--- a/services/orion-hub/static/js/memory-graph-draft-ui.js
+++ b/services/orion-hub/static/js/memory-graph-draft-ui.js
@@ -121,6 +121,15 @@
   }
 
   const SUGGEST_DRAFT_ONTOLOGY_VERSION = "orionmem-2026-05";
+  const DEFAULT_MEMORY_GRAPH_SUGGEST_FETCH_TIMEOUT_MS = 205000;
+
+  /** Hub UI fetch budget; must exceed server Quick+Brain budget (see memory_graph_suggest_timeout.py). */
+  function resolveMemoryGraphSuggestFetchTimeoutMs() {
+    const cfg = typeof window !== "undefined" && window.__HUB_CFG__ ? window.__HUB_CFG__ : {};
+    const raw = Number(cfg.memoryGraphSuggestFetchTimeoutMs);
+    if (Number.isFinite(raw) && raw > 0) return raw;
+    return DEFAULT_MEMORY_GRAPH_SUGGEST_FETCH_TIMEOUT_MS;
+  }
 
   function looksLikeMemoryGraphDraftObject(obj) {
     if (!obj || typeof obj !== "object" || Array.isArray(obj)) return false;
@@ -828,6 +837,7 @@
   }
 
   window.OrionMemoryGraphDraftUI = {
+    resolveMemoryGraphSuggestFetchTimeoutMs,
     parseMemoryGraphDraftJson,
     looksLikeMemoryGraphDraftObject,
     looksLikeEvidenceEnvelopeOnly,

--- a/services/orion-hub/static/js/memory-graph-draft-ui.js
+++ b/services/orion-hub/static/js/memory-graph-draft-ui.js
@@ -475,28 +475,91 @@
     return out;
   }
 
+  function isBlankRef(v) {
+    const s = String(v == null ? "" : v).trim();
+    return !s || s.toLowerCase() === "null" || s.toLowerCase() === "none";
+  }
+
   function draftToCyElements(obj) {
     const nodes = [];
     const edges = [];
     const seen = new Set();
+    const entityIds = new Set();
+    const situationIds = new Set();
+    const utteranceIds = new Set();
+
     function addNode(id, label, kind) {
       const sid = String(id);
-      if (seen.has(sid)) return;
+      if (isBlankRef(sid) || seen.has(sid)) return;
       seen.add(sid);
-      nodes.push({ data: { id: sid, label: String(label || sid), kind } });
+      nodes.push({ data: { id: sid, label: String(label || sid).slice(0, 48), kind } });
     }
+
+    function addEdge(source, target, label, extra) {
+      if (isBlankRef(source) || isBlankRef(target)) return;
+      const sid = String(source);
+      const oid = String(target);
+      if (utteranceIds.has(sid) || utteranceIds.has(oid)) return;
+      edges.push({
+        data: Object.assign(
+          {
+            id: `cy-edge-${edges.length}`,
+            source: sid,
+            target: oid,
+            label: String(label || ""),
+          },
+          extra || {},
+        ),
+      });
+    }
+
+    (Array.isArray(obj.utterance_ids) ? obj.utterance_ids : []).forEach((uid) => {
+      const u = String(uid || "").trim();
+      if (u) utteranceIds.add(u);
+    });
 
     const ents = Array.isArray(obj.entities) ? obj.entities : [];
     ents.forEach((e) => {
-      if (e && e.id) addNode(e.id, e.label || e.id, "entity");
+      if (e && e.id) {
+        entityIds.add(String(e.id));
+        addNode(e.id, e.label || e.id, "entity");
+      }
     });
     const sits = Array.isArray(obj.situations) ? obj.situations : [];
     sits.forEach((s) => {
-      if (s && s.id) addNode(s.id, s.label || s.id, "situation");
+      if (s && s.id) {
+        situationIds.add(String(s.id));
+        addNode(s.id, s.label || s.id, "situation");
+      }
     });
+    const graphNodes = new Set([...entityIds, ...situationIds]);
+
+    sits.forEach((sit) => {
+      if (!sit || !sit.id) return;
+      const sid = String(sit.id);
+      if (!situationIds.has(sid)) return;
+      const stim = sit.stimulus_entity_id;
+      if (!isBlankRef(stim) && entityIds.has(String(stim))) {
+        addEdge(sid, stim, "stimulus", { structural: true });
+      }
+      (Array.isArray(sit.about_entity_ids) ? sit.about_entity_ids : []).forEach((ae) => {
+        if (!isBlankRef(ae) && entityIds.has(String(ae))) {
+          addEdge(sid, ae, "about", { structural: true });
+        }
+      });
+      (Array.isArray(sit.participants) ? sit.participants : []).forEach((p) => {
+        const eid = p && (p.entity_id || p.entityId);
+        if (!isBlankRef(eid) && entityIds.has(String(eid))) {
+          addEdge(eid, sid, "inSituation", { structural: true });
+        }
+      });
+    });
+
     const disps = Array.isArray(obj.dispositions) ? obj.dispositions : [];
     disps.forEach((d) => {
-      if (d && d.id) addNode(d.id, (d.description && String(d.description).slice(0, 40)) || String(d.id), "disposition");
+      if (d && d.id && !isBlankRef(d.id)) {
+        addNode(d.id, (d.description && String(d.description).slice(0, 40)) || String(d.id), "disposition");
+      }
     });
 
     const edgs = Array.isArray(obj.edges) ? obj.edges : [];
@@ -504,17 +567,9 @@
       if (!e || e.s == null || e.o == null) return;
       const sid = String(e.s);
       const oid = String(e.o);
-      if (!seen.has(sid)) addNode(sid, sid, "ref");
-      if (!seen.has(oid)) addNode(oid, oid, "ref");
-      edges.push({
-        data: {
-          id: `draft-edge-${i}`,
-          source: sid,
-          target: oid,
-          label: String(e.p || ""),
-          edgeIndex: i,
-        },
-      });
+      if (!graphNodes.has(sid) || !graphNodes.has(oid)) return;
+      if (utteranceIds.has(sid) || utteranceIds.has(oid)) return;
+      addEdge(sid, oid, e.p || "", { edgeIndex: i, structural: false });
     });
 
     return { nodes, edges };
@@ -799,6 +854,14 @@
               label: "data(label)",
               "font-size": 8,
               color: "#94a3b8",
+            },
+          },
+          {
+            selector: "edge[structural = true]",
+            style: {
+              "line-color": "#34d399",
+              "target-arrow-color": "#34d399",
+              "line-style": "solid",
             },
           },
         ],

--- a/services/orion-hub/static/js/memory.js
+++ b/services/orion-hub/static/js/memory.js
@@ -4,8 +4,14 @@
   const pathSegments = window.location.pathname.split("/").filter((p) => p.length > 0);
   const URL_PREFIX = pathSegments.length > 0 ? `/${pathSegments[0]}` : "";
   const API_BASE = window.location.origin + URL_PREFIX;
-  // Match `orion/cognition/verbs/memory_graph_suggest.yaml` timeout_ms (hub fetch must not abort first).
-  const MEMORY_GRAPH_SUGGEST_TIMEOUT_MS = 180000;
+  function memoryGraphSuggestFetchTimeoutMs() {
+    const ui = window.OrionMemoryGraphDraftUI || {};
+    if (typeof ui.resolveMemoryGraphSuggestFetchTimeoutMs === "function") {
+      return ui.resolveMemoryGraphSuggestFetchTimeoutMs();
+    }
+    const raw = Number((window.__HUB_CFG__ || {}).memoryGraphSuggestFetchTimeoutMs);
+    return Number.isFinite(raw) && raw > 0 ? raw : 205000;
+  }
   const MEMORY_GRAPH_SUGGEST_INPUT_TOTAL_CHARS = 12000;
 
   function sessionHeader() {
@@ -420,17 +426,40 @@
     const aBtn = document.getElementById("memoryGraphApproveBtn");
     const sBtn = document.getElementById("memoryGraphSuggestBtn");
     let memoryDraftViz = null;
+    let memoryDraftForm = null;
     if (window.OrionMemoryGraphDraftUI && draftTa) {
       const cyH = document.getElementById("memoryGraphDraftCyHost");
       const det = document.getElementById("memoryGraphDraftDetail");
       const ban = document.getElementById("memoryGraphDraftParseBanner");
+      const formHost = document.getElementById("memoryGraphDraftFormHost");
       if (cyH && det) {
         memoryDraftViz = window.OrionMemoryGraphDraftUI.attach({
           draftTextarea: draftTa,
           cyHost: cyH,
           detailHost: det,
           bannerEl: ban,
+          onDraftJsonChange: () => {
+            if (memoryDraftForm && typeof memoryDraftForm.refresh === "function") {
+              memoryDraftForm.refresh();
+            }
+          },
         });
+      }
+      if (formHost && window.OrionMemoryGraphDraftForm) {
+        memoryDraftForm = window.OrionMemoryGraphDraftForm.attachFormEditor({
+          draftTextarea: draftTa,
+          formHost,
+          onDraftChange: () => {
+            if (memoryDraftViz && typeof memoryDraftViz.refresh === "function") {
+              memoryDraftViz.refresh();
+            }
+          },
+        });
+      }
+    }
+    function flushDraftEditorToJson() {
+      if (memoryDraftForm && typeof memoryDraftForm.flushToTextarea === "function") {
+        memoryDraftForm.flushToTextarea();
       }
     }
     function graphSetOut(obj, isErr) {
@@ -443,10 +472,15 @@
       vBtn.addEventListener("click", async () => {
         graphSetOut("…", false);
         try {
+          flushDraftEditorToJson();
           const raw = draftTa.value.trim();
           const body = JSON.parse(raw);
           const data = await apiFetch("/api/memory/graph/validate", { method: "POST", body: JSON.stringify(body) });
-          graphSetOut(data, !data.ok);
+          const out = { ...data };
+          if (Array.isArray(data.warnings) && data.warnings.length) {
+            out.topical_warnings = data.warnings;
+          }
+          graphSetOut(out, !data.ok);
         } catch (e) {
           graphSetOut(e.body || e.message || String(e), true);
         }
@@ -456,6 +490,7 @@
       aBtn.addEventListener("click", async () => {
         graphSetOut("…", false);
         try {
+          flushDraftEditorToJson();
           const raw = draftTa.value.trim();
           const body = JSON.parse(raw);
           const data = await apiFetch("/api/memory/graph/approve", { method: "POST", body: JSON.stringify(body) });
@@ -494,7 +529,7 @@
                   } catch (_) {
                     /* ignore */
                   }
-                }, MEMORY_GRAPH_SUGGEST_TIMEOUT_MS)
+                }, memoryGraphSuggestFetchTimeoutMs())
               : null;
           let data = null;
           try {
@@ -555,6 +590,7 @@
                 );
           draftTa.value = draftText;
           if (memoryDraftViz && memoryDraftViz.refresh) memoryDraftViz.refresh();
+          if (memoryDraftForm && memoryDraftForm.refresh) memoryDraftForm.refresh();
           const statusFn =
             typeof ui.formatSuggestCoalesceUserStatus === "function"
               ? ui.formatSuggestCoalesceUserStatus
@@ -598,8 +634,8 @@
               {
                 ok: false,
                 error: `Suggest timed out after ${Math.round(
-                  MEMORY_GRAPH_SUGGEST_TIMEOUT_MS / 1000
-                )}s (browser fetch limit). Retry when the model gateway is responsive; reduce selected bridge turns only if the compiled prompt is very large.`,
+                  memoryGraphSuggestFetchTimeoutMs() / 1000
+                )}s (browser fetch limit; server budget is typically ~180s with Quick+Brain escalation). Retry when the model gateway is responsive; reduce selected turns only if the prompt was clipped.`,
               },
               true
             );
@@ -643,6 +679,7 @@
       if (isDraft && !isEvidence) {
         draftTa.value = JSON.stringify(obj, null, 2);
         if (memoryDraftViz && memoryDraftViz.refresh) memoryDraftViz.refresh();
+        if (memoryDraftForm && memoryDraftForm.refresh) memoryDraftForm.refresh();
         graphSetOut(
           { ok: true, note: "Loaded validated role-grounded SuggestDraftV1 JSON." },
           false,
@@ -673,6 +710,7 @@
         2,
       );
       if (memoryDraftViz && memoryDraftViz.refresh) memoryDraftViz.refresh();
+      if (memoryDraftForm && memoryDraftForm.refresh) memoryDraftForm.refresh();
       graphSetOut(
         {
           ok: false,

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -945,13 +945,17 @@
         </div>
         <div id="memoryGraphAnnotator" class="border border-gray-700 rounded-lg p-3 space-y-3 text-xs">
           <div class="font-semibold text-gray-200">Memory graph (optional)</div>
-          <p class="text-[10px] text-gray-500"><span class="text-gray-400">Suggest</span> — type plain language or paste a chat snippet (or leave empty). The model drafts JSON here; trim any prose around it, then Validate.</p>
-          <p class="text-[10px] text-gray-500"><span class="text-gray-400">Validate / Approve</span> — need structured JSON the API accepts. Approve needs GraphDB on this Hub.</p>
+          <p class="text-[10px] text-gray-500"><span class="text-gray-400">Editor</span> — structured fields for entities, situations, edges (relational + topical). <span class="text-gray-400">Suggest</span> uses plain language in Advanced JSON when empty.</p>
+          <p class="text-[10px] text-gray-500"><span class="text-gray-400">Validate / Approve</span> — syncs the editor to JSON first. Approve needs GraphDB on this Hub.</p>
           <div id="memoryGraphDraftParseBanner" class="hidden text-[11px] rounded border px-2 py-1 whitespace-pre-wrap border-gray-700 text-gray-400 bg-gray-950/60" role="status"></div>
           <div class="grid grid-cols-1 xl:grid-cols-2 gap-3 items-start">
             <div class="space-y-2 min-w-0">
-              <div class="text-[10px] uppercase tracking-wide text-gray-500">Draft</div>
-              <textarea id="memoryGraphDraftJson" class="w-full min-h-[11rem] bg-gray-950 border border-gray-700 rounded p-2 font-mono text-xs leading-relaxed" placeholder="Plain text for Suggest, or JSON for Validate / Approve…"></textarea>
+              <div class="text-[10px] uppercase tracking-wide text-gray-500">Draft editor</div>
+              <div id="memoryGraphDraftFormHost" class="max-h-[28rem] overflow-y-auto border border-gray-800 rounded-lg p-2 bg-gray-950/30 space-y-1"></div>
+              <details class="border border-gray-800 rounded-lg bg-gray-950/20">
+                <summary class="text-[10px] text-gray-500 cursor-pointer px-2 py-1">Advanced JSON &amp; suggest prompt</summary>
+                <textarea id="memoryGraphDraftJson" class="w-full min-h-[9rem] bg-gray-950 border-0 border-t border-gray-800 rounded-b p-2 font-mono text-xs leading-relaxed" placeholder="Plain text for Suggest, or JSON for Validate / Approve…"></textarea>
+              </details>
               <div class="flex flex-wrap gap-2">
                 <button type="button" id="memoryGraphValidateBtn" class="px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200">Validate</button>
                 <button type="button" id="memoryGraphApproveBtn" class="px-2 py-1 rounded border border-emerald-800 bg-emerald-900/40 text-emerald-100">Approve</button>
@@ -3276,8 +3280,12 @@
         <div id="memoryGraphBridgeParseBanner" class="hidden text-[11px] rounded border px-2 py-1 whitespace-pre-wrap border-gray-700 text-gray-400 bg-gray-950/60" role="status"></div>
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-3 items-start">
           <div class="space-y-2 min-w-0">
-            <div class="text-[10px] uppercase tracking-wide text-gray-500">Draft JSON</div>
-            <textarea id="memoryGraphBridgeDraft" class="w-full min-h-[11rem] bg-gray-950 border border-gray-700 rounded p-2 font-mono text-xs leading-relaxed" placeholder="Draft JSON appears here after Suggest…"></textarea>
+            <div class="text-[10px] uppercase tracking-wide text-gray-500">Draft editor</div>
+            <div id="memoryGraphBridgeFormHost" class="max-h-[26rem] overflow-y-auto border border-gray-800 rounded-lg p-2 bg-gray-950/30 space-y-1"></div>
+            <details class="border border-gray-800 rounded-lg bg-gray-950/20">
+              <summary class="text-[10px] text-gray-500 cursor-pointer px-2 py-1">Advanced JSON</summary>
+              <textarea id="memoryGraphBridgeDraft" class="w-full min-h-[9rem] bg-gray-950 border-0 border-t border-gray-800 rounded-b p-2 font-mono text-xs leading-relaxed" placeholder="Draft JSON appears here after Suggest…"></textarea>
+            </details>
           </div>
           <div class="space-y-2 min-w-0">
             <div class="text-[10px] uppercase tracking-wide text-gray-500">Preview graph &amp; selection</div>
@@ -3312,6 +3320,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="/static/js/organ-signals-graph-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/memory-graph-draft-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
+  <script src="/static/js/memory-graph-draft-form.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/memory.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/mind_provenance.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/substrate-effect-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>

--- a/services/orion-hub/tests/test_memory_graph_suggest_timeout.py
+++ b/services/orion-hub/tests/test_memory_graph_suggest_timeout.py
@@ -52,11 +52,41 @@ def test_resolve_timeouts_derives_from_verb_when_route_secs_zero() -> None:
         MEMORY_GRAPH_SUGGEST_QUICK_TIMEOUT_SEC=0.0,
         MEMORY_GRAPH_SUGGEST_BRAIN_TIMEOUT_SEC=0.0,
     )
-    verb_sec, quick, brain, verb_ms = resolve_memory_graph_suggest_timeouts(settings)
+    verb_sec, quick, brain, verb_ms = resolve_memory_graph_suggest_timeouts(
+        settings, escalation_enabled=True
+    )
     assert verb_ms == 180_000
     assert verb_sec == 180.0
+    assert quick == 63.0
+    assert brain == 117.0
+    assert quick + brain == verb_sec
+
+
+def test_resolve_timeouts_single_route_when_escalation_disabled() -> None:
+    from scripts.memory_graph_suggest_timeout import resolve_memory_graph_suggest_timeouts
+
+    settings = SimpleNamespace(
+        MEMORY_GRAPH_SUGGEST_VERB_TIMEOUT_MS=180_000,
+        MEMORY_GRAPH_SUGGEST_QUICK_TIMEOUT_SEC=0.0,
+        MEMORY_GRAPH_SUGGEST_BRAIN_TIMEOUT_SEC=0.0,
+    )
+    _, quick, brain, _ = resolve_memory_graph_suggest_timeouts(settings, escalation_enabled=False)
     assert quick == 72.0
     assert brain == 180.0
+
+
+def test_hub_client_fetch_timeout_covers_escalation_budget() -> None:
+    from scripts.memory_graph_suggest_timeout import hub_client_fetch_timeout_ms
+
+    settings = SimpleNamespace(
+        MEMORY_GRAPH_SUGGEST_VERB_TIMEOUT_MS=180_000,
+        MEMORY_GRAPH_SUGGEST_QUICK_TIMEOUT_SEC=0.0,
+        MEMORY_GRAPH_SUGGEST_BRAIN_TIMEOUT_SEC=0.0,
+        MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_TIMEOUT_MS=0,
+        MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_BUFFER_SEC=25.0,
+    )
+    ms = hub_client_fetch_timeout_ms(settings, escalation_enabled=True)
+    assert ms == 205_000
 
 
 def test_resolve_timeouts_honors_explicit_route_overrides() -> None:
@@ -67,9 +97,10 @@ def test_resolve_timeouts_honors_explicit_route_overrides() -> None:
         MEMORY_GRAPH_SUGGEST_QUICK_TIMEOUT_SEC=90.0,
         MEMORY_GRAPH_SUGGEST_BRAIN_TIMEOUT_SEC=120.0,
     )
-    _, quick, brain, _ = resolve_memory_graph_suggest_timeouts(settings)
+    _, quick, brain, _ = resolve_memory_graph_suggest_timeouts(settings, escalation_enabled=True)
     assert quick == 90.0
-    assert brain == 120.0
+    assert brain == 90.0
+    assert quick + brain == 180.0
 
 
 def test_suggest_attempt_includes_timeout_diagnostics_on_hub_wait(monkeypatch) -> None:

--- a/tests/fixtures/memory_graph/pragmatic_take_draft.json
+++ b/tests/fixtures/memory_graph/pragmatic_take_draft.json
@@ -1,0 +1,121 @@
+{
+  "ontology_version": "orionmem-2026-05",
+  "utterance_ids": [
+    "hub-utterance:71b025d1-420a-4fcc-9aa4-2761ede53b25",
+    "81478614-56c1-4592-8505-a48d28bc70fa"
+  ],
+  "entities": [
+    {
+      "id": "urn:uuid:a1000001-0000-4000-8000-000000000001",
+      "label": "User",
+      "entityKind": "person",
+      "surfaceForms": ["I", "you"],
+      "generalizes_to": null
+    },
+    {
+      "id": "urn:uuid:a1000002-0000-4000-8000-000000000002",
+      "label": "Orion",
+      "entityKind": "person",
+      "surfaceForms": ["I", "Orion"],
+      "generalizes_to": null
+    },
+    {
+      "id": "urn:uuid:a1000003-0000-4000-8000-000000000003",
+      "label": "pragmatic take",
+      "entityKind": "abstract",
+      "surfaceForms": ["pragmatic take", "pragmatic"],
+      "generalizes_to": null
+    },
+    {
+      "id": "urn:uuid:a1000004-0000-4000-8000-000000000004",
+      "label": "usable design stance",
+      "entityKind": "abstract",
+      "surfaceForms": ["usable", "not decorative", "keep it usable"],
+      "generalizes_to": "urn:uuid:a1000003-0000-4000-8000-000000000003"
+    }
+  ],
+  "situations": [
+    {
+      "id": "urn:uuid:b1000001-0000-4000-8000-000000000001",
+      "utterance_ids": ["hub-utterance:71b025d1-420a-4fcc-9aa4-2761ede53b25"],
+      "label": "User acknowledges Orion's pragmatic take without underselling it",
+      "stimulus_entity_id": "urn:uuid:a1000001-0000-4000-8000-000000000001",
+      "about_entity_ids": [
+        "urn:uuid:a1000003-0000-4000-8000-000000000003",
+        "urn:uuid:a1000002-0000-4000-8000-000000000002"
+      ],
+      "target_entity_ids": [],
+      "affectLabel": "affection",
+      "timeQualitative": "recent",
+      "occurredAt": null,
+      "participants": [
+        {"entity_id": "urn:uuid:a1000001-0000-4000-8000-000000000001", "role": "agent"},
+        {"entity_id": "urn:uuid:a1000003-0000-4000-8000-000000000003", "role": "topic"}
+      ]
+    },
+    {
+      "id": "urn:uuid:b1000002-0000-4000-8000-000000000002",
+      "utterance_ids": ["81478614-56c1-4592-8505-a48d28bc70fa"],
+      "label": "Orion affirms usable stance and offers support for next steps",
+      "stimulus_entity_id": "urn:uuid:a1000002-0000-4000-8000-000000000002",
+      "about_entity_ids": [
+        "urn:uuid:a1000004-0000-4000-8000-000000000004",
+        "urn:uuid:a1000001-0000-4000-8000-000000000001"
+      ],
+      "target_entity_ids": [],
+      "affectLabel": "trust",
+      "timeQualitative": "recent",
+      "occurredAt": null,
+      "participants": [
+        {"entity_id": "urn:uuid:a1000002-0000-4000-8000-000000000002", "role": "agent"},
+        {"entity_id": "urn:uuid:a1000004-0000-4000-8000-000000000004", "role": "topic"},
+        {"entity_id": "urn:uuid:a1000001-0000-4000-8000-000000000001", "role": "recipient"}
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "s": "urn:uuid:a1000001-0000-4000-8000-000000000001",
+      "p": "orionmem:inSituation",
+      "o": "urn:uuid:b1000001-0000-4000-8000-000000000001",
+      "confidence": 0.9
+    },
+    {
+      "s": "urn:uuid:a1000002-0000-4000-8000-000000000002",
+      "p": "orionmem:inSituation",
+      "o": "urn:uuid:b1000002-0000-4000-8000-000000000002",
+      "confidence": 0.9
+    },
+    {
+      "s": "urn:uuid:b1000001-0000-4000-8000-000000000001",
+      "p": "schema:about",
+      "o": "urn:uuid:a1000003-0000-4000-8000-000000000003",
+      "confidence": 0.92
+    },
+    {
+      "s": "urn:uuid:b1000002-0000-4000-8000-000000000002",
+      "p": "schema:about",
+      "o": "urn:uuid:a1000004-0000-4000-8000-000000000004",
+      "confidence": 0.9
+    },
+    {
+      "s": "urn:uuid:a1000004-0000-4000-8000-000000000004",
+      "p": "orionmem:generalizationOf",
+      "o": "urn:uuid:a1000003-0000-4000-8000-000000000003",
+      "confidence": 0.75
+    }
+  ],
+  "dispositions": [
+    {
+      "id": "urn:uuid:c1000001-0000-4000-8000-000000000001",
+      "holder_id": "urn:uuid:a1000002-0000-4000-8000-000000000002",
+      "target_id": "urn:uuid:a1000001-0000-4000-8000-000000000001",
+      "trustPolarity": "trust",
+      "description": "Orion trusts the user to pivot when ready; no pressure to keep typing."
+    }
+  ],
+  "utterance_text_by_id": {
+    "hub-utterance:71b025d1-420a-4fcc-9aa4-2761ede53b25": "thanks for sharing. Certainly a POV. You didn't undersell the pragmatic take.",
+    "81478614-56c1-4592-8505-a48d28bc70fa": "Appreciate that. The whole point was to keep it usable, not decorative. I'm glad it landed right."
+  }
+}

--- a/tests/test_memory_graph_draft_sanitize.py
+++ b/tests/test_memory_graph_draft_sanitize.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+
+from orion.memory_graph.dto import SuggestDraftV1
+from orion.memory_graph.draft_sanitize import sanitize_suggest_draft_dict
+from orion.memory_graph.json_to_rdf import draft_to_graph
+
+
+def test_sanitize_strips_null_string_refs_and_approve_graph_builds() -> None:
+    data = {
+        "ontology_version": "orionmem-2026-05",
+        "utterance_ids": ["hub-utterance:u1"],
+        "entities": [
+            {
+                "id": "urn:uuid:a0000001-0000-4000-8000-000000000001",
+                "label": "User",
+                "entityKind": "person",
+                "surfaceForms": ["I"],
+                "generalizes_to": "null",
+            },
+            {
+                "id": "urn:uuid:a0000002-0000-4000-8000-000000000002",
+                "label": "Orion",
+                "entityKind": "person",
+                "surfaceForms": ["Orion"],
+            },
+        ],
+        "situations": [
+            {
+                "id": "urn:uuid:b0000001-0000-4000-8000-000000000001",
+                "utterance_ids": ["hub-utterance:u1"],
+                "label": "User states age",
+                "stimulus_entity_id": "null",
+                "about_entity_ids": [],
+                "target_entity_ids": [],
+                "affectLabel": "neutral",
+                "timeQualitative": "recent",
+                "participants": [
+                    {"entity_id": "urn:uuid:a0000001-0000-4000-8000-000000000001", "role": "agent"}
+                ],
+            }
+        ],
+        "edges": [
+            {
+                "s": "hub-utterance:u1",
+                "p": "orionmem:inSituation",
+                "o": "hub-utterance:u1",
+                "confidence": 0.9,
+            }
+        ],
+        "dispositions": [],
+        "utterance_text_by_id": {"hub-utterance:u1": "I'm 43"},
+    }
+    cleaned = sanitize_suggest_draft_dict(data)
+    assert cleaned["entities"][0]["generalizes_to"] is None
+    assert cleaned["situations"][0]["stimulus_entity_id"] is None
+    assert any(e["p"] == "orionmem:inSituation" for e in cleaned["edges"])
+    draft = SuggestDraftV1.model_validate(cleaned)
+    g = draft_to_graph(draft)
+    assert len(g) > 10
+
+
+def test_sanitize_rebuilds_structural_edges_from_situation() -> None:
+    data = {
+        "ontology_version": "orionmem-2026-05",
+        "utterance_ids": ["t1"],
+        "entities": [
+            {
+                "id": "urn:uuid:a0000001-0000-4000-8000-000000000001",
+                "label": "User",
+                "entityKind": "person",
+                "surfaceForms": ["User"],
+            },
+            {
+                "id": "urn:uuid:a0000002-0000-4000-8000-000000000002",
+                "label": "Orion",
+                "entityKind": "person",
+                "surfaceForms": ["Orion"],
+            },
+        ],
+        "situations": [
+            {
+                "id": "urn:uuid:b0000001-0000-4000-8000-000000000001",
+                "utterance_ids": ["t1"],
+                "label": "Orion responds",
+                "stimulus_entity_id": "urn:uuid:a0000002-0000-4000-8000-000000000002",
+                "about_entity_ids": ["urn:uuid:a0000001-0000-4000-8000-000000000001"],
+                "target_entity_ids": [],
+                "affectLabel": "neutral",
+                "timeQualitative": "recent",
+                "participants": [],
+            }
+        ],
+        "edges": [],
+        "dispositions": [],
+    }
+    cleaned = sanitize_suggest_draft_dict(data)
+    preds = {e["p"] for e in cleaned["edges"]}
+    assert "orionmem:stimulusEntity" in preds
+    assert "schema:about" in preds

--- a/tests/test_memory_graph_suggest_validate.py
+++ b/tests/test_memory_graph_suggest_validate.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from orion.memory_graph.suggest_validate import (
+    collect_topical_spine_warnings,
     extract_selected_role_evidence,
     repair_role_grounded_suggest_draft,
     role_grounded_extraction_expected,
@@ -265,3 +266,75 @@ def test_assistant_role_detected_via_assistant_turn_situation_without_orion_labe
     should, errors = validate_for_escalation(draft, utterance_text=SHOWER_UTTERANCE_TEXT)
     assert should is False
     assert "missing_assistant_role_entity" not in errors
+
+
+PRAGMATIC_UTTERANCE_TEXT = """Structured transcript evidence for memory graph extraction (do not invent turns).
+
+--- turn 1 id=u-prag role=user ---
+thanks for sharing. Certainly a POV. You didn't undersell the pragmatic take.
+
+--- turn 2 id=a-prag role=assistant ---
+Appreciate that. The whole point was to keep it usable, not decorative.
+
+Emit utterance_ids matching the ids above; fill utterance_text_by_id with excerpts."""
+
+
+def test_pragmatic_take_fixture_does_not_escalate() -> None:
+    path = Path("tests/fixtures/memory_graph/pragmatic_take_draft.json")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    should, errors = validate_for_escalation(data, utterance_text=PRAGMATIC_UTTERANCE_TEXT)
+    assert should is False
+    assert errors == []
+
+
+def test_pragmatic_take_fixture_has_no_topical_warnings() -> None:
+    path = Path("tests/fixtures/memory_graph/pragmatic_take_draft.json")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    warnings = collect_topical_spine_warnings(data, utterance_text=PRAGMATIC_UTTERANCE_TEXT)
+    assert warnings == []
+
+
+def test_dyad_only_pragmatic_emits_topical_warnings() -> None:
+    dyad_only = {
+        "ontology_version": "orionmem-2026-05",
+        "utterance_ids": ["u-prag", "a-prag"],
+        "entities": [
+            {
+                "id": "urn:uuid:12345678-1234-1234-1234-1234567890ab",
+                "label": "User",
+                "entityKind": "person",
+                "surfaceForms": ["User"],
+                "generalizes_to": None,
+            },
+            {
+                "id": "urn:uuid:12345678-1234-1234-1234-1234567890ac",
+                "label": "Orion",
+                "entityKind": "person",
+                "surfaceForms": ["Orion"],
+                "generalizes_to": None,
+            },
+        ],
+        "situations": [
+            {
+                "id": "urn:uuid:12345678-1234-1234-1234-1234567890ad",
+                "utterance_ids": ["u-prag"],
+                "label": "User acknowledges Orion's pragmatic approach",
+                "stimulus_entity_id": "urn:uuid:12345678-1234-1234-1234-1234567890ac",
+                "about_entity_ids": ["urn:uuid:12345678-1234-1234-1234-1234567890ab"],
+                "target_entity_ids": [],
+                "affectLabel": "affection",
+                "timeQualitative": "recent",
+                "occurredAt": None,
+                "participants": [],
+            }
+        ],
+        "edges": [],
+        "dispositions": [],
+        "utterance_text_by_id": {
+            "u-prag": "You didn't undersell the pragmatic take.",
+            "a-prag": "keep it usable, not decorative.",
+        },
+    }
+    warnings = collect_topical_spine_warnings(dyad_only, utterance_text=PRAGMATIC_UTTERANCE_TEXT)
+    assert any("topical_spine_missing" in w for w in warnings)
+    assert any("pragmatic take" in w for w in warnings)


### PR DESCRIPTION
## Summary

Memory graph suggest and review get a **dual-spine extraction model** (relational User/Orion plus topical `abstract` entities), a **structured Hub draft editor** instead of raw JSON-only editing, **aligned suggest timeouts** so the browser no longer aborts before Quick→Brain escalation finishes, and **draft sanitization** so approve does not fail on `"null"` refs or utterance IDs misused as entity endpoints.

- **Extraction:** Prompt asks for topical entities (`surfaceForms`, `schema:about`, `participants.role: topic`) alongside User/Orion; golden fixture `pragmatic_take_draft.json`; non-blocking `collect_topical_spine_warnings()` on validate.
- **Hub UI:** `memory-graph-draft-form.js` — sectioned editor (entities, situations, edges, dispositions); Advanced JSON collapsed; graph preview draws **structural edges** from situations and filters junk utterance-id edges.
- **Timeouts:** Quick + Brain share one 180s verb budget (~63s + ~117s); client fetch timeout ~205s via `memoryGraphSuggestFetchTimeoutMs` in `__HUB_CFG__`.
- **Approve fix:** `draft_sanitize.py` strips literal `"null"`, drops invalid edges, rebuilds structural edges; `json_to_rdf` skips unresolvable refs; sanitize runs on suggest, validate, and approve.

## Test plan

- [ ] Restart Hub, hard-refresh; Memory graph bridge → Suggest on a 2-turn chat (e.g. pragmatic take / age fact).
- [ ] Confirm draft editor shows entities + situations; preview shows User/Orion linked to green situation nodes (not utterance self-loops).
- [ ] Memory tab → Validate (check `warnings` for missing topical spine when appropriate) → Approve succeeds (no `unsupported entity ref 'null'`).
- [ ] Suggest completes without 180s browser abort when escalation runs (allow up to ~205s).
- [ ] `python scripts/sync_local_env_from_example.py orion-hub` picks up `MEMORY_GRAPH_SUGGEST_CLIENT_FETCH_*` if `.env` is stale.
- [ ] `pytest tests/test_memory_graph_suggest_validate.py tests/test_memory_graph_draft_sanitize.py services/orion-hub/tests/test_memory_graph_suggest_timeout.py` (where `pyshacl` is available).