### PR TITLE
Feat/collapse mirror tab

### DIFF
--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -1618,6 +1618,7 @@ loadDismissedIds();
         || h === "#signals"
         || h === "#forge"
         || h === "#substrate-atlas"
+        || h === "#collapse-mirror"
       ) {
         history.replaceState(null, "", "#hub");
       }

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -667,6 +667,8 @@ loadDismissedIds();
   const substrateAtlasPanelRefresh = document.getElementById("substrateAtlasPanelRefresh");
   const pressureAnalyticsTabButton = document.getElementById("pressureAnalyticsTabButton");
   const pressurePanel = document.getElementById("pressure");
+  const collapseMirrorTabButton = document.getElementById("collapseMirrorTabButton");
+  const collapseMirrorPanel = document.getElementById("collapse-mirror");
   const pressureAnalyticsFrame = document.getElementById("pressureAnalyticsFrame");
   const pressureAnalyticsRefresh = document.getElementById("pressureAnalyticsRefresh");
   const topicFoundryBaseLabel = document.getElementById("topicFoundryBaseLabel");
@@ -942,6 +944,9 @@ loadDismissedIds();
     if (tabKey === "substrate-atlas" && !substrateAtlasPanel) {
       effectiveTab = "hub";
     }
+    if (tabKey === "collapse-mirror" && !collapseMirrorPanel) {
+      effectiveTab = "hub";
+    }
     const isHub = effectiveTab === "hub";
     const isTopicStudio = effectiveTab === "topic-studio";
     const isServiceLogs = effectiveTab === "service-logs";
@@ -952,6 +957,7 @@ loadDismissedIds();
     const isMind = effectiveTab === "mind";
     const isSignals = effectiveTab === "signals";
     const isForge = effectiveTab === "forge";
+    const isCollapseMirror = effectiveTab === "collapse-mirror";
     hubTabPanel.classList.toggle("hidden", !isHub);
     topicStudioPanel.classList.toggle("hidden", !isTopicStudio);
     serviceLogsPanel.classList.toggle("hidden", !isServiceLogs);
@@ -1002,6 +1008,9 @@ loadDismissedIds();
         refreshForgeTab();
       }
     }
+    if (collapseMirrorPanel) {
+      collapseMirrorPanel.classList.toggle("hidden", !isCollapseMirror);
+    }
     styleTabButton(hubTabButton, isHub);
     styleTabButton(topicStudioTabButton, isTopicStudio);
     styleTabButton(serviceLogsTabButton, isServiceLogs);
@@ -1023,6 +1032,9 @@ loadDismissedIds();
     }
     if (forgeTabButton) {
       styleTabButton(forgeTabButton, isForge);
+    }
+    if (collapseMirrorTabButton) {
+      styleTabButton(collapseMirrorTabButton, isCollapseMirror);
     }
   }
 
@@ -1596,6 +1608,8 @@ loadDismissedIds();
       setActiveTab("signals");
     } else if (h === "#forge" && forgePanel && forgeTabButton) {
       setActiveTab("forge");
+    } else if (h === "#collapse-mirror" && collapseMirrorPanel && collapseMirrorTabButton) {
+      setActiveTab("collapse-mirror");
     } else {
       if (
         h === "#pressure"
@@ -11151,205 +11165,6 @@ loadDismissedIds();
 
   // --- Boot Sequence ---
 
-  // ───────────────────────────────────────────────────────────────
-  // Collapse Mirror (Legacy submit path)
-  // ───────────────────────────────────────────────────────────────
-  (function initCollapseMirror() {
-    const guidedBtn = document.getElementById("collapseModeGuided");
-    const rawBtn = document.getElementById("collapseModeRaw");
-    const guidedSection = document.getElementById("collapseGuidedSection");
-    const rawSection = document.getElementById("collapseRawSection");
-
-    const tooltipToggle = document.getElementById("collapseTooltipToggle");
-    const tooltip = document.getElementById("collapseTooltip");
-
-    const statusEl = document.getElementById("collapseStatus");
-
-    const guidedSubmit =
-      document.getElementById("collapseGuidedSubmit") ||
-      document.getElementById("collapseSubmit"); // legacy id fallback
-
-    const rawSubmit =
-      document.getElementById("collapseRawSubmit") ||
-      document.getElementById("collapseSubmitRaw"); // legacy id fallback
-
-    const rawJsonEl = document.getElementById("collapseRawJson");
-
-    // Guided inputs
-    const el = (id) => document.getElementById(id);
-    const observerEl = el("collapseObserver");
-    const typeEl = el("collapseType");
-    const triggerEl = el("collapseTrigger");
-    const observerStateEl = el("collapseObserverState");
-    const fieldResonanceEl = el("collapseFieldResonance");
-    const emergentEntityEl = el("collapseEmergentEntity");
-    const summaryEl = el("collapseSummary");
-    const mantraEl = el("collapseMantra");
-    const causalEchoEl = el("collapseCausalEcho");
-
-    function setCollapseStatus(msg, isError=false) {
-      if (statusEl) {
-        statusEl.textContent = msg;
-        statusEl.classList.toggle("text-red-400", !!isError);
-        statusEl.classList.toggle("text-gray-400", !isError);
-        return;
-      }
-      // If template is missing status element, do something visible.
-      console[isError ? "error" : "log"]("[collapse]", msg);
-      if (isError) alert(msg);
-    }
-
-    function showGuided() {
-      if (guidedSection) guidedSection.classList.remove("hidden");
-      if (rawSection) rawSection.classList.add("hidden");
-      if (guidedBtn) {
-        guidedBtn.classList.add("bg-gray-700", "text-gray-100");
-        guidedBtn.classList.remove("text-gray-300");
-      }
-      if (rawBtn) {
-        rawBtn.classList.remove("bg-gray-700", "text-gray-100");
-        rawBtn.classList.add("text-gray-300");
-      }
-    }
-
-    function showRaw() {
-      if (rawSection) rawSection.classList.remove("hidden");
-      if (guidedSection) guidedSection.classList.add("hidden");
-      if (rawBtn) {
-        rawBtn.classList.add("bg-gray-700", "text-gray-100");
-        rawBtn.classList.remove("text-gray-300");
-      }
-      if (guidedBtn) {
-        guidedBtn.classList.remove("bg-gray-700", "text-gray-100");
-        guidedBtn.classList.add("text-gray-300");
-      }
-    }
-
-    if (guidedBtn) guidedBtn.addEventListener("click", showGuided);
-    if (rawBtn) rawBtn.addEventListener("click", showRaw);
-
-    if (tooltipToggle && tooltip) {
-      tooltipToggle.addEventListener("click", () => tooltip.classList.toggle("hidden"));
-    }
-
-    async function postCollapse(payload) {
-      setCollapseStatus("Submitting…");
-      try {
-        const resp = await fetch("/submit-collapse", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        });
-
-        const txt = await resp.text();
-        let data = null;
-        try { data = txt ? JSON.parse(txt) : null; } catch { data = { raw: txt }; }
-
-        if (!resp.ok) {
-          const detail =
-            (data && (data.error || data.detail || data.message)) ||
-            `HTTP ${resp.status}`;
-          setCollapseStatus(`❌ ${detail}`, true);
-          return;
-        }
-
-        if (data && data.success === false) {
-          setCollapseStatus(`❌ ${data.error || "Unknown error"}`, true);
-          return;
-        }
-
-        setCollapseStatus("✅ Collapse submitted.");
-      } catch (e) {
-        setCollapseStatus(`❌ Network error: ${e}`, true);
-      }
-    }
-
-    function buildGuidedPayload() {
-      // If the guided inputs don't exist, fail loudly.
-      const missing = [];
-      const must = [
-        ["observer", observerEl],
-        ["type", typeEl],
-        ["trigger", triggerEl],
-        ["observer_state", observerStateEl],
-        ["field_resonance", fieldResonanceEl],
-        ["emergent_entity", emergentEntityEl],
-        ["summary", summaryEl],
-        ["mantra", mantraEl],
-      ];
-      for (const [name, node] of must) if (!node) missing.push(name);
-      if (missing.length) {
-        setCollapseStatus(`❌ UI missing required inputs: ${missing.join(", ")}`, true);
-        return null;
-      }
-
-      const observer_state = (observerStateEl.value || "")
-        .split(/\r?\n/)
-        .map((s) => s.trim())
-        .filter(Boolean);
-
-      const payload = {
-        observer: observerEl.value.trim(),
-        trigger: triggerEl.value.trim(),
-        observer_state,
-        field_resonance: fieldResonanceEl.value.trim(),
-        type: typeEl.value.trim(),
-        emergent_entity: emergentEntityEl.value.trim(),
-        summary: summaryEl.value.trim(),
-        mantra: mantraEl.value.trim(),
-        causal_echo: (causalEchoEl && causalEchoEl.value.trim()) || null,
-      };
-
-      // Basic validation (FastAPI will also validate)
-      const req = [
-        ["observer", payload.observer],
-        ["trigger", payload.trigger],
-        ["observer_state", payload.observer_state.length ? "ok" : ""],
-        ["field_resonance", payload.field_resonance],
-        ["type", payload.type],
-        ["emergent_entity", payload.emergent_entity],
-        ["summary", payload.summary],
-        ["mantra", payload.mantra],
-      ];
-      const missing2 = req.filter(([_, v]) => !v).map(([k]) => k);
-      if (missing2.length) {
-        setCollapseStatus(`❌ Missing: ${missing2.join(", ")}`, true);
-        return null;
-      }
-
-      return payload;
-    }
-
-    if (guidedSubmit) {
-      guidedSubmit.addEventListener("click", async (e) => {
-        e.preventDefault();
-        const payload = buildGuidedPayload();
-        if (!payload) return;
-        await postCollapse(payload);
-      });
-    }
-
-    if (rawSubmit) {
-      rawSubmit.addEventListener("click", async (e) => {
-        e.preventDefault();
-        const raw = (rawJsonEl && rawJsonEl.value) ? rawJsonEl.value.trim() : "";
-        if (!raw) {
-          setCollapseStatus("❌ Paste JSON first.", true);
-          return;
-        }
-        try {
-          const payload = JSON.parse(raw);
-          await postCollapse(payload);
-        } catch (err) {
-          setCollapseStatus(`❌ Invalid JSON: ${err}`, true);
-        }
-      });
-    }
-
-    // default to guided
-    showGuided();
-  })();
-
   // Connect WebSocket immediately so chat is not blocked on slow initSession/library loads.
   setupWebSocket();
 
@@ -11652,6 +11467,13 @@ loadDismissedIds();
         event.preventDefault();
         setActiveTab("forge");
         history.replaceState(null, "", "#forge");
+      });
+    }
+    if (collapseMirrorTabButton && collapseMirrorPanel) {
+      collapseMirrorTabButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        setActiveTab("collapse-mirror");
+        history.replaceState(null, "", "#collapse-mirror");
       });
     }
     applyHashToTab();

--- a/services/orion-hub/static/js/collapse-mirror.js
+++ b/services/orion-hub/static/js/collapse-mirror.js
@@ -1,0 +1,206 @@
+// Collapse Mirror — standalone init
+// Extracted from app.js so the Collapse Mirror tab can live in its own file.
+// Works whether loaded before or after DOM ready.
+(function () {
+  function initCollapseMirror() {
+    const guidedBtn = document.getElementById("collapseModeGuided");
+    const rawBtn = document.getElementById("collapseModeRaw");
+    const guidedSection = document.getElementById("collapseGuidedSection");
+    const rawSection = document.getElementById("collapseRawSection");
+
+    const tooltipToggle = document.getElementById("collapseTooltipToggle");
+    const tooltip = document.getElementById("collapseTooltip");
+
+    const statusEl = document.getElementById("collapseStatus");
+
+    const guidedSubmit =
+      document.getElementById("collapseGuidedSubmit") ||
+      document.getElementById("collapseSubmit"); // legacy id fallback
+
+    const rawSubmit =
+      document.getElementById("collapseRawSubmit") ||
+      document.getElementById("collapseSubmitRaw"); // legacy id fallback
+
+    const rawJsonEl = document.getElementById("collapseRawJson");
+
+    // Guided inputs
+    const el = (id) => document.getElementById(id);
+    const observerEl = el("collapseObserver");
+    const typeEl = el("collapseType");
+    const triggerEl = el("collapseTrigger");
+    const observerStateEl = el("collapseObserverState");
+    const fieldResonanceEl = el("collapseFieldResonance");
+    const emergentEntityEl = el("collapseEmergentEntity");
+    const summaryEl = el("collapseSummary");
+    const mantraEl = el("collapseMantra");
+    const causalEchoEl = el("collapseCausalEcho");
+
+    function setCollapseStatus(msg, isError=false) {
+      if (statusEl) {
+        statusEl.textContent = msg;
+        statusEl.classList.toggle("text-red-400", !!isError);
+        statusEl.classList.toggle("text-gray-400", !isError);
+        return;
+      }
+      // If template is missing status element, do something visible.
+      console[isError ? "error" : "log"]("[collapse]", msg);
+      if (isError) alert(msg);
+    }
+
+    function showGuided() {
+      if (guidedSection) guidedSection.classList.remove("hidden");
+      if (rawSection) rawSection.classList.add("hidden");
+      if (guidedBtn) {
+        guidedBtn.classList.add("bg-gray-700", "text-gray-100");
+        guidedBtn.classList.remove("text-gray-300");
+      }
+      if (rawBtn) {
+        rawBtn.classList.remove("bg-gray-700", "text-gray-100");
+        rawBtn.classList.add("text-gray-300");
+      }
+    }
+
+    function showRaw() {
+      if (rawSection) rawSection.classList.remove("hidden");
+      if (guidedSection) guidedSection.classList.add("hidden");
+      if (rawBtn) {
+        rawBtn.classList.add("bg-gray-700", "text-gray-100");
+        rawBtn.classList.remove("text-gray-300");
+      }
+      if (guidedBtn) {
+        guidedBtn.classList.remove("bg-gray-700", "text-gray-100");
+        guidedBtn.classList.add("text-gray-300");
+      }
+    }
+
+    if (guidedBtn) guidedBtn.addEventListener("click", showGuided);
+    if (rawBtn) rawBtn.addEventListener("click", showRaw);
+
+    if (tooltipToggle && tooltip) {
+      tooltipToggle.addEventListener("click", () => tooltip.classList.toggle("hidden"));
+    }
+
+    async function postCollapse(payload) {
+      setCollapseStatus("Submitting…");
+      try {
+        const resp = await fetch("/submit-collapse", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        const txt = await resp.text();
+        let data = null;
+        try { data = txt ? JSON.parse(txt) : null; } catch { data = { raw: txt }; }
+
+        if (!resp.ok) {
+          const detail =
+            (data && (data.error || data.detail || data.message)) ||
+            `HTTP ${resp.status}`;
+          setCollapseStatus(`❌ ${detail}`, true);
+          return;
+        }
+
+        if (data && data.success === false) {
+          setCollapseStatus(`❌ ${data.error || "Unknown error"}`, true);
+          return;
+        }
+
+        setCollapseStatus("✅ Collapse submitted.");
+      } catch (e) {
+        setCollapseStatus(`❌ Network error: ${e}`, true);
+      }
+    }
+
+    function buildGuidedPayload() {
+      // If the guided inputs don't exist, fail loudly.
+      const missing = [];
+      const must = [
+        ["observer", observerEl],
+        ["type", typeEl],
+        ["trigger", triggerEl],
+        ["observer_state", observerStateEl],
+        ["field_resonance", fieldResonanceEl],
+        ["emergent_entity", emergentEntityEl],
+        ["summary", summaryEl],
+        ["mantra", mantraEl],
+      ];
+      for (const [name, node] of must) if (!node) missing.push(name);
+      if (missing.length) {
+        setCollapseStatus(`❌ UI missing required inputs: ${missing.join(", ")}`, true);
+        return null;
+      }
+
+      const observer_state = (observerStateEl.value || "")
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+      const payload = {
+        observer: observerEl.value.trim(),
+        trigger: triggerEl.value.trim(),
+        observer_state,
+        field_resonance: fieldResonanceEl.value.trim(),
+        type: typeEl.value.trim(),
+        emergent_entity: emergentEntityEl.value.trim(),
+        summary: summaryEl.value.trim(),
+        mantra: mantraEl.value.trim(),
+        causal_echo: (causalEchoEl && causalEchoEl.value.trim()) || null,
+      };
+
+      // Basic validation (FastAPI will also validate)
+      const req = [
+        ["observer", payload.observer],
+        ["trigger", payload.trigger],
+        ["observer_state", payload.observer_state.length ? "ok" : ""],
+        ["field_resonance", payload.field_resonance],
+        ["type", payload.type],
+        ["emergent_entity", payload.emergent_entity],
+        ["summary", payload.summary],
+        ["mantra", payload.mantra],
+      ];
+      const missing2 = req.filter(([_, v]) => !v).map(([k]) => k);
+      if (missing2.length) {
+        setCollapseStatus(`❌ Missing: ${missing2.join(", ")}`, true);
+        return null;
+      }
+
+      return payload;
+    }
+
+    if (guidedSubmit) {
+      guidedSubmit.addEventListener("click", async (e) => {
+        e.preventDefault();
+        const payload = buildGuidedPayload();
+        if (!payload) return;
+        await postCollapse(payload);
+      });
+    }
+
+    if (rawSubmit) {
+      rawSubmit.addEventListener("click", async (e) => {
+        e.preventDefault();
+        const raw = (rawJsonEl && rawJsonEl.value) ? rawJsonEl.value.trim() : "";
+        if (!raw) {
+          setCollapseStatus("❌ Paste JSON first.", true);
+          return;
+        }
+        try {
+          const payload = JSON.parse(raw);
+          await postCollapse(payload);
+        } catch (err) {
+          setCollapseStatus(`❌ Invalid JSON: ${err}`, true);
+        }
+      });
+    }
+
+    // default to guided
+    showGuided();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCollapseMirror);
+  } else {
+    initCollapseMirror();
+  }
+})();

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -90,6 +90,13 @@
             class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
             role="button"
           >Pressure</a>
+          <a
+            id="collapseMirrorTabButton"
+            href="#collapse-mirror"
+            data-hash-target="#collapse-mirror"
+            class="px-3 py-1.5 text-xs font-semibold rounded-full bg-gray-800 text-gray-200 border border-gray-700 hover:bg-gray-700"
+            role="button"
+          >Collapse Mirror</a>
         </div>
       </div>
       <div class="flex items-center gap-3">
@@ -836,8 +843,15 @@
         </div>
       </div>
 
-      <!-- ✅ UPDATED: Collapse Mirror (keeps placement; adds required DOM + fields) -->
-      <div class="w-full lg:w-1/2 bg-gray-900 rounded-2xl shadow-lg p-6 space-y-4">
+    </div>
+
+    
+
+        </div>
+      </section>
+
+      <section id="collapse-mirror" data-panel="collapse-mirror" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-6 space-y-4 min-h-[56rem]">
+        <!-- ✅ Collapse Mirror — lifted out of hub into its own tab section -->
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
             <h2 class="text-xl font-bold text-white">Collapse Mirror</h2>
@@ -922,12 +936,6 @@
         </div>
 
         <div id="collapseStatus" class="text-xs text-gray-400"></div>
-      </div>
-    </div>
-
-    
-
-        </div>
       </section>
 
       <section id="memory" data-panel="memory" class="hidden w-full bg-gray-900 rounded-2xl shadow-lg p-5 flex flex-col gap-4 min-h-[56rem]">
@@ -3326,6 +3334,7 @@
   <script src="/static/js/memory.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/mind_provenance.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/substrate-effect-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
+  <script src="/static/js/collapse-mirror.js"></script>
   <script src="/static/js/app.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
 </body>
 </html>

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -845,8 +845,6 @@
 
     </div>
 
-    
-
         </div>
       </section>
 
@@ -3334,7 +3332,7 @@
   <script src="/static/js/memory.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/mind_provenance.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/substrate-effect-ui.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
-  <script src="/static/js/collapse-mirror.js"></script>
+  <script src="/static/js/collapse-mirror.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
   <script src="/static/js/app.js?v={{HUB_UI_ASSET_VERSION}}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Here's what shipped across 4 commits on `feat/collapse-mirror-tab`:

| Commit | Change |
|--------|--------|
| `f8798201` | New `collapse-mirror.js` — verbatim extraction + DOM-ready guard |
| `b1ee4685` | `index.html` — tab button, new section, script tag |
| `002b1c92` | `app.js` — all 7 routing touch points wired, IIFE deleted |
| `f0982dd8` | Fix: `defer` + cache-buster on script tag, `#collapse-mirror` in hash cleanup list |

**Net effect on `app.js`:** −178 lines. Collapse Mirror is now a first-class tab that toggles with `.hidden` — hub's WebSocket, EKG, and biometrics polling are completely untouched when you switch between tabs