### PR TITLE
Make Hub golden probes assert real context-exec execution, not chat_g…

### DIFF
--- a/scripts/context_exec_golden_probes.sh
+++ b/scripts/context_exec_golden_probes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Hub golden-path probes for context-exec (#663).
+# Hub golden-path probes for context-exec — must prove routing, not just HTTP 200 (#664).
 # Requires: context-exec :8096, cortex-exec + cortex-orch with CONTEXT_EXEC_ENABLED=true, Hub :8080.
 set -euo pipefail
 
@@ -10,11 +10,12 @@ CTX_PORT="${CONTEXT_EXEC_PORT:-8096}"
 HUB_BASE="${HUB_BASE_URL:-http://127.0.0.1:8080}"
 CTX_BASE="http://127.0.0.1:${CTX_PORT}"
 REAL_CORR_ID="${CONTEXT_EXEC_PROBE_CORR_ID:-}"
+export PYTHONPATH="${ROOT}${PYTHONPATH:+:$PYTHONPATH}"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
 echo "== env posture =="
-for f in services/orion-context-exec/.env services/orion-cortex-exec/.env; do
+for f in services/orion-context-exec/.env services/orion-cortex-exec/.env services/orion-cortex-orch/.env; do
   if [[ -f "$f" ]]; then
     echo "--- $f ---"
     grep -E '^(CONTEXT_EXEC_|CHANNEL_CONTEXT_EXEC|CHANNEL_RECALL)' "$f" || true
@@ -22,6 +23,23 @@ for f in services/orion-context-exec/.env services/orion-cortex-exec/.env; do
     echo "WARN: missing $f"
   fi
 done
+
+echo "== context-exec direct organ check =="
+direct="$(curl -sf "${CTX_BASE}/context-exec/run" \
+  -H 'content-type: application/json' \
+  -d '{
+    "text": "Where did Orion get the claim that I am from Denver?",
+    "mode": "belief_provenance",
+    "expected_artifact_type": "BeliefProvenanceReportV1"
+  }')"
+echo "$direct" | python3 -m json.tool 2>/dev/null | head -40 || true
+echo "$direct" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+assert d.get('status') == 'ok', d
+assert d.get('artifact_type') == 'BeliefProvenanceReportV1', d
+print('direct context-exec organ ok')
+"
 
 echo "== context-exec health =="
 health="$(curl -sf "${CTX_BASE}/health")"
@@ -34,63 +52,110 @@ assert d.get('write_enabled') is False
 print('health ok')
 "
 
-hub_chat() {
-  local prompt="$1"
-  local body
-  body="$(PROMPT="$prompt" python3 - <<'PY'
-import json, os
-print(json.dumps({
-    "mode": "brain",
-    "use_recall": True,
-    "recall_profile": "assist.light.v1",
-    "no_write": True,
-    "messages": [{"role": "user", "content": os.environ["PROMPT"]}],
-}))
+hub_chat_json() {
+  python3 - "$1" <<'PY'
+import json, os, sys
+spec = json.loads(sys.argv[1])
+print(json.dumps(spec))
 PY
-)"
-  curl -sf --max-time "${HUB_CHAT_TIMEOUT_SEC:-120}" "${HUB_BASE}/api/chat" \
+}
+
+hub_post() {
+  local body="$1"
+  curl -sf --max-time "${HUB_CHAT_TIMEOUT_SEC:-180}" "${HUB_BASE}/api/chat" \
     -H 'content-type: application/json' \
     -H 'X-Orion-No-Write: 1' \
     -d "$body"
 }
 
-echo "== probe 1: Denver belief provenance (Hub) =="
-p1="$(hub_chat "Orion, where did the claim that I am from Denver come from across your runtime?")"
-echo "$p1" | python3 -m json.tool 2>/dev/null | head -60 || true
+echo "== probe 1: Denver belief provenance (Hub, mode=auto) =="
+p1_body="$(hub_chat_json '{
+  "mode": "auto",
+  "use_recall": true,
+  "no_write": true,
+  "messages": [{
+    "role": "user",
+    "content": "Orion, where did the claim that I am from Denver come from across your runtime?"
+  }],
+  "options": {
+    "route_intent": "auto",
+    "answer_contract": {
+      "request_kind": "runtime_debug",
+      "requires_runtime_grounding": true,
+      "allow_unverified_specifics": false,
+      "preferred_render_style": "answer"
+    }
+  }
+}')"
+p1="$(hub_post "$p1_body")"
+echo "$p1" | python3 -m json.tool 2>/dev/null | head -80 || true
 echo "$p1" | python3 -c "
 import json,sys
+from scripts.context_exec_probe_lib import assert_hub_context_exec_routing
 d=json.load(sys.stdin)
-blob=json.dumps(d).lower()
-assert blob.strip() not in ('{}', 'null'), d
-print('denver probe ok (response received)')
+assert_hub_context_exec_routing(d, probe_name='denver_provenance', expected_mode='belief_provenance')
 "
 
-echo "== probe 2: trace autopsy (Hub) =="
+echo "== probe 2: trace autopsy (Hub, mode=auto) =="
 if [[ -z "$REAL_CORR_ID" ]]; then
   echo "SKIP: set CONTEXT_EXEC_PROBE_CORR_ID to a real correlation id from a prior run"
 else
-  p2="$(hub_chat "Orion, why did corr ${REAL_CORR_ID} fail open?")"
-  echo "$p2" | python3 -m json.tool 2>/dev/null | head -60 || true
+  p2_body="$(REAL_CORR_ID="$REAL_CORR_ID" python3 - <<'PY'
+import json, os
+corr = os.environ["REAL_CORR_ID"]
+print(json.dumps({
+    "mode": "auto",
+    "use_recall": True,
+    "no_write": True,
+    "messages": [{"role": "user", "content": f"Orion, why did corr {corr} fail open?"}],
+    "options": {
+        "route_intent": "auto",
+        "answer_contract": {
+            "request_kind": "runtime_debug",
+            "requires_runtime_grounding": True,
+            "allow_unverified_specifics": False,
+            "preferred_render_style": "answer",
+        },
+    },
+}))
+PY
+)"
+  p2="$(hub_post "$p2_body")"
+  echo "$p2" | python3 -m json.tool 2>/dev/null | head -80 || true
   echo "$p2" | python3 -c "
-import json,sys,os
+import json,sys
+from scripts.context_exec_probe_lib import assert_hub_context_exec_routing
 d=json.load(sys.stdin)
-corr=os.environ.get('CONTEXT_EXEC_PROBE_CORR_ID','').lower()
-blob=json.dumps(d).lower()
-assert corr in blob or 'trace' in blob or 'unknown' in blob or 'evidence' in blob
-print('trace autopsy probe ok')
+assert_hub_context_exec_routing(d, probe_name='trace_autopsy', expected_mode='trace_autopsy')
 "
 fi
 
-echo "== probe 3: repo impact (Hub) =="
-p3="$(hub_chat "What breaks if I replace agent-chain-service with context-exec?")"
-echo "$p3" | python3 -m json.tool 2>/dev/null | head -60 || true
+echo "== probe 3: repo impact (Hub, mode=auto) =="
+p3_body="$(hub_chat_json '{
+  "mode": "auto",
+  "use_recall": true,
+  "no_write": true,
+  "messages": [{
+    "role": "user",
+    "content": "What breaks if I replace agent-chain-service with context-exec? Ground this in my repo."
+  }],
+  "options": {
+    "route_intent": "auto",
+    "answer_contract": {
+      "request_kind": "repo_technical",
+      "requires_repo_grounding": true,
+      "allow_unverified_specifics": false,
+      "preferred_render_style": "answer"
+    }
+  }
+}')"
+p3="$(hub_post "$p3_body")"
+echo "$p3" | python3 -m json.tool 2>/dev/null | head -80 || true
 echo "$p3" | python3 -c "
 import json,sys
+from scripts.context_exec_probe_lib import assert_hub_context_exec_routing
 d=json.load(sys.stdin)
-blob=json.dumps(d).lower()
-assert blob.strip() not in ('{}', 'null'), d
-assert any(k in blob for k in ('agent', 'context-exec', 'context_exec', 'repo', 'error', 'timeout'))
-print('repo impact probe ok')
+assert_hub_context_exec_routing(d, probe_name='repo_impact', expected_mode='repo_impact_analysis')
 "
 
-echo "GOLDEN PROBES PASS (Hub reachable; set CONTEXT_EXEC_PROBE_CORR_ID for full trace autopsy validation)"
+echo "GOLDEN PROBES PASS — context-exec routing verified through Hub"

--- a/scripts/context_exec_probe_lib.py
+++ b/scripts/context_exec_probe_lib.py
@@ -1,0 +1,116 @@
+"""Assertions for Hub golden probes — context-exec routing must be proven, not assumed."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _walk(obj: Any):
+    if isinstance(obj, dict):
+        yield obj
+        for v in obj.values():
+            yield from _walk(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _walk(item)
+
+
+def _blob(response: dict[str, Any]) -> str:
+    return json.dumps(response, default=str).lower()
+
+
+def _has_context_exec_signal(response: dict[str, Any]) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    raw = response.get("raw") if isinstance(response.get("raw"), dict) else {}
+    routing = response.get("routing_debug") if isinstance(response.get("routing_debug"), dict) else {}
+    route_opts = routing.get("options") if isinstance(routing.get("options"), dict) else {}
+    meta = raw.get("metadata") if isinstance(raw.get("metadata"), dict) else {}
+    auto_route = meta.get("auto_route") if isinstance(meta.get("auto_route"), dict) else {}
+
+    hard_evidence = False
+
+    if route_opts.get("agent_runtime_engine") == "context_exec":
+        reasons.append("routing_debug.options.agent_runtime_engine=context_exec")
+        hard_evidence = True
+    if route_opts.get("context_exec_mode"):
+        reasons.append(f"routing_debug.options.context_exec_mode={route_opts.get('context_exec_mode')}")
+
+    for node in _walk(response):
+        if not isinstance(node, dict):
+            continue
+        if node.get("context_exec_attempted") is True:
+            reasons.append("runtime_debug.context_exec_attempted")
+            hard_evidence = True
+        if isinstance(node.get("context_exec"), dict):
+            reasons.append("structured.context_exec")
+            hard_evidence = True
+        if node.get("step_name") == "context_exec" or node.get("verb_name") == "context_exec":
+            reasons.append("step.context_exec")
+            hard_evidence = True
+        if "ContextExecService" in node:
+            reasons.append("result.ContextExecService")
+            hard_evidence = True
+        if node.get("engine") == "context_exec":
+            reasons.append("runtime_debug.engine=context_exec")
+            hard_evidence = True
+
+    if raw.get("verb") == "agent_runtime":
+        reasons.append("raw.verb=agent_runtime")
+    if "context_exec_investigation" in str(auto_route.get("reason") or ""):
+        reasons.append(f"auto_route.reason={auto_route.get('reason')}")
+
+    return (hard_evidence, reasons)
+
+
+def assert_hub_context_exec_routing(
+    response: dict[str, Any],
+    *,
+    probe_name: str,
+    expected_mode: str | None = None,
+) -> None:
+    if response.get("error"):
+        raise AssertionError(f"{probe_name}: hub error={response.get('error')}")
+
+    raw = response.get("raw") if isinstance(response.get("raw"), dict) else {}
+    verb = str(raw.get("verb") or "")
+    final_text = str(raw.get("final_text") or response.get("text") or "")
+    blob = _blob(response)
+
+    if "llamacpp timed out" in final_text.lower():
+        raise AssertionError(
+            f"{probe_name}: LLM timeout — request likely stayed on chat_general, not context-exec"
+        )
+
+    if verb == "chat_general":
+        raise AssertionError(
+            f"{probe_name}: raw.verb=chat_general — cortex-orch did not route to agent_runtime/context-exec"
+        )
+
+    ok, reasons = _has_context_exec_signal(response)
+    if not ok:
+        extra = ""
+        if verb == "agent_runtime":
+            extra = " (orch reached agent_runtime but ContextExecService did not run — check cortex-exec flags)"
+        raise AssertionError(
+            f"{probe_name}: no context-exec execution evidence in Hub response{extra} "
+            f"(verb={verb!r}, session_id={response.get('session_id')!r}, signals={reasons})"
+        )
+
+    routing = response.get("routing_debug") if isinstance(response.get("routing_debug"), dict) else {}
+    route_opts = routing.get("options") if isinstance(routing.get("options"), dict) else {}
+
+    if expected_mode:
+        routed_mode = route_opts.get("context_exec_mode")
+        if not routed_mode:
+            for node in _walk(response):
+                if isinstance(node, dict) and isinstance(node.get("context_exec"), dict):
+                    routed_mode = node["context_exec"].get("mode")
+                    if routed_mode:
+                        break
+        if routed_mode and str(routed_mode) != expected_mode:
+            raise AssertionError(
+                f"{probe_name}: expected context_exec_mode={expected_mode!r}, got {routed_mode!r}; signals={reasons}"
+            )
+
+    print(f"{probe_name} ok: {', '.join(reasons)}")

--- a/tests/test_context_exec_golden_probe_lib.py
+++ b/tests/test_context_exec_golden_probe_lib.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.context_exec_probe_lib import assert_hub_context_exec_routing
+
+
+def test_rejects_chat_general_without_context_exec():
+    with pytest.raises(AssertionError, match="chat_general"):
+        assert_hub_context_exec_routing(
+            {
+                "session_id": "s1",
+                "text": "[Error: llamacpp timed out after waiting]",
+                "raw": {"verb": "chat_general", "final_text": "[Error: llamacpp timed out after waiting]"},
+            },
+            probe_name="denver",
+        )
+
+
+def test_accepts_agent_runtime_with_context_exec_step():
+    assert_hub_context_exec_routing(
+        {
+            "session_id": "s2",
+            "raw": {
+                "verb": "agent_runtime",
+                "final_text": "Belief provenance for Denver",
+                "steps": [
+                    {
+                        "step_name": "context_exec",
+                        "result": {
+                            "ContextExecService": {
+                                "structured": {"context_exec": {"mode": "belief_provenance"}},
+                                "runtime_debug": {"engine": "context_exec", "context_exec_attempted": True},
+                            }
+                        },
+                    }
+                ],
+            },
+            "routing_debug": {
+                "options": {
+                    "agent_runtime_engine": "context_exec",
+                    "context_exec_mode": "belief_provenance",
+                    "execution_depth": 2,
+                }
+            },
+        },
+        probe_name="denver",
+        expected_mode="belief_provenance",
+    )
+
+
+def test_agent_runtime_without_context_exec_step_fails():
+    with pytest.raises(AssertionError, match="ContextExecService did not run"):
+        assert_hub_context_exec_routing(
+            {
+                "session_id": "s3",
+                "raw": {
+                    "verb": "agent_runtime",
+                    "final_text": "Some agent answer",
+                    "metadata": {
+                        "auto_route": {
+                            "execution_depth": 2,
+                            "reason": "heuristic:default+context_exec_investigation",
+                        }
+                    },
+                    "steps": [
+                        {"step_name": "agent_chain", "result": {"AgentChainService": {"text": "x"}}},
+                    ],
+                },
+            },
+            probe_name="denver",
+        )
+
+
+def test_rejects_llm_timeout_even_if_verb_not_chat_general():
+    with pytest.raises(AssertionError, match="LLM timeout"):
+        assert_hub_context_exec_routing(
+            {
+                "raw": {"verb": "agent_runtime", "final_text": "[Error: llamacpp timed out after waiting]"},
+            },
+            probe_name="repo",
+        )


### PR DESCRIPTION
### Summary

**#664** is on branch `feat/context-exec-golden-probe-routing` (`7247fc29`, pushed). The golden probe script no longer false-passes on `chat_general` + LLM timeout. It sends `mode=auto` + `answer_contract`, and **requires hard evidence that ContextExecService ran**.

Open PR: https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/context-exec-golden-probe-routing

### Root cause (live stack)

Your diagnosis was right. With the old script (`mode=brain`), Hub stayed on `chat_general`. With the fixed payload (`mode=auto` + `answer_contract`), **cortex-orch routes correctly**:

```text
execution_depth=2
reason=heuristic:default+context_exec_investigation
raw.verb=agent_runtime
```

But **cortex-exec still runs `agent_chain`**, not `ContextExecService`:

```text
steps: recall → planner_react → answer_direct → agent_chain
(no context_exec step; no agent_runtime_engine in routing_debug.options)
```

Direct organ call works (`/context-exec/run` → `BeliefProvenanceReportV1`). The hallway door is closed at **cortex-exec**, not context-exec.

### What #664 changed

| Before | After |
|--------|-------|
| `mode=brain` → `chat_general` | `mode=auto` + `route_intent=auto` + `answer_contract` |
| Pass if JSON returned | Fail on `chat_general`, LLM timeout, or missing ContextExecService |
| No organ check | Direct `/context-exec/run` sanity check first |

Live probe now fails with:

```text
denver_provenance: no context-exec execution evidence in Hub response
(orch reached agent_runtime but ContextExecService did not run — check cortex-exec flags)
signals=['raw.verb=agent_runtime', 'auto_route.reason=heuristic:default+context_exec_investigation']
```

That is the correct gate behavior.

### Files changed

`scripts/context_exec_golden_probes.sh`, `scripts/context_exec_probe_lib.py`, `tests/test_context_exec_golden_probe_lib.py`

### Verification

| Command | Exit | Result |
|---------|------|--------|
| `pytest tests/test_context_exec_golden_probe_lib.py -q` | 0 | **4 passed** |
| `bash scripts/context_exec_golden_probes.sh` (live) | 1 | **Correct fail** — orch depth-2 OK, ContextExecService not invoked |
| Direct `curl :8096/context-exec/run` | 0 | Organ OK |

### Next PR (actual integration fix)

**Not AlexZhang.** Fix why `agent_runtime_engine=context_exec` / `context_exec_mode` set by cortex-orch do not reach cortex-exec supervisor (options dropped between orch → gateway → exec). Once that lands, golden probes should pass without loosening assertions.

Suggested title: `#665: wire context_exec flags from cortex-orch through cortex-exec to ContextExecService`