### PR TITLE
Fix context-exec bus reply causality_chain=None crash.

### DIFF
--- a/services/orion-context-exec/app/bus_listener.py
+++ b/services/orion-context-exec/app/bus_listener.py
@@ -111,7 +111,7 @@ async def _handle_request(bus: OrionBusAsync, raw_msg: Dict[str, Any], runner: C
             kind=resp_kind,
             source=_source(),
             correlation_id=corr,
-            causality_chain=causality or None,
+            causality_chain=causality,
             payload=resp_payload,
         )
         await bus.publish(reply_channel, resp)
@@ -130,7 +130,7 @@ async def _handle_request(bus: OrionBusAsync, raw_msg: Dict[str, Any], runner: C
                 kind="agent.chain.result" if compat else "context.exec.result.v1",
                 source=_source(),
                 correlation_id=corr,
-                causality_chain=causality or None,
+                causality_chain=causality,
                 payload=err_payload,
             ),
         )

--- a/services/orion-context-exec/tests/test_bus_listener_causality.py
+++ b/services/orion-context-exec/tests/test_bus_listener_causality.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.bus_listener import _handle_request
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.schemas.context_exec import ContextExecRunV1
+
+
+def _request_envelope(*, causality_chain=None) -> BaseEnvelope:
+    kwargs: dict = {
+        "kind": "context.exec.request.v1",
+        "source": ServiceRef(name="cortex-exec", version="0.2.0"),
+        "correlation_id": uuid4(),
+        "reply_to": "orion:exec:result:ContextExecService:test-corr",
+        "payload": {"text": "trace autopsy", "mode": "trace_autopsy"},
+    }
+    if causality_chain is not None:
+        kwargs["causality_chain"] = causality_chain
+    return BaseEnvelope(**kwargs)
+
+
+def _bus_for_envelope(env: BaseEnvelope) -> SimpleNamespace:
+    return SimpleNamespace(
+        codec=SimpleNamespace(
+            decode=lambda _raw: SimpleNamespace(ok=True, envelope=env, error=None)
+        ),
+        publish=AsyncMock(),
+    )
+
+
+def _ok_run() -> ContextExecRunV1:
+    return ContextExecRunV1(
+        run_id="ctxrun_test",
+        status="ok",
+        mode="trace_autopsy",
+        text="trace autopsy",
+        final_text="trace summary",
+        runtime_debug={"engine": "context_exec"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_bus_success_reply_uses_empty_causality_list():
+    env = _request_envelope(causality_chain=[])
+    bus = _bus_for_envelope(env)
+    runner = SimpleNamespace(run=AsyncMock(return_value=_ok_run()))
+
+    await _handle_request(bus, {"data": b"x"}, runner)  # type: ignore[arg-type]
+
+    bus.publish.assert_awaited_once()
+    reply_channel, reply_env = bus.publish.await_args.args
+    assert reply_channel == env.reply_to
+    assert reply_env.kind == "context.exec.result.v1"
+    assert reply_env.causality_chain == []
+
+
+@pytest.mark.asyncio
+async def test_bus_reply_normalizes_missing_causality_to_empty_list():
+    env = _request_envelope()
+    assert env.causality_chain == []
+    bus = _bus_for_envelope(env)
+    runner = SimpleNamespace(run=AsyncMock(return_value=_ok_run()))
+
+    await _handle_request(bus, {"data": b"x"}, runner)  # type: ignore[arg-type]
+
+    _, reply_env = bus.publish.await_args.args
+    assert reply_env.causality_chain == []
+
+
+@pytest.mark.asyncio
+async def test_bus_error_reply_uses_empty_causality_list():
+    env = _request_envelope(causality_chain=[])
+    bus = _bus_for_envelope(env)
+    runner = SimpleNamespace(run=AsyncMock(side_effect=RuntimeError("runner blew up")))
+
+    await _handle_request(bus, {"data": b"x"}, runner)  # type: ignore[arg-type]
+
+    bus.publish.assert_awaited_once()
+    _, reply_env = bus.publish.await_args.args
+    assert reply_env.kind == "context.exec.result.v1"
+    assert reply_env.causality_chain == []
+    assert "runner blew up" in str(reply_env.payload.get("structured", {}).get("context_exec_error", ""))


### PR DESCRIPTION
### Summary

Fixed the context-exec bus reply crash: `causality_chain=causality or None` turned an empty list into `None` (`[]` is falsy), which broke `BaseEnvelope` validation and caused Cortex-Exec RPC timeouts. Replies now always pass `causality_chain=causality` (a list). Three regression tests added; golden probes pass including `trace_autopsy` with corr `5506f854-2606-42b5-a2ee-89775b3a8ed5`.

### Files changed

- `services/orion-context-exec/app/bus_listener.py`
- `services/orion-context-exec/tests/test_bus_listener_causality.py`

### Verification

| Command | Exit | Result |
|---------|------|--------|
| `pytest services/orion-context-exec/tests/ -q` | 0 | 22 passed |
| `docker compose ... orion-context-exec up -d --build` (worktree) | 0 | Container recreated |
| `CONTEXT_EXEC_PROBE_CORR_ID=5506f854-... bash scripts/context_exec_golden_probes.sh` | 0 | `trace_autopsy ok`, **GOLDEN PROBES PASS** |
| `docker logs ... \| grep -Ei 'ValidationError\|causality_chain'` | 1 | No matches (no validation errors) |
| `docker logs ... \| grep 'replied kind=context.exec.result.v1'` | 0 | Multiple successful reply lines |

### Remaining risks

- `gh pr create` blocked (no `GH_TOKEN`). Branch pushed — open PR manually: https://github.com/junebug-junie/Orion-Sapienform/compare/feat/context-exec-cortex-dispatch...feat/context-exec-causality-chain-fix

---

## PR #666 description

**Branch:** `feat/context-exec-causality-chain-fix` (stacks on `feat/context-exec-cortex-dispatch`)  
**Commit:** `53d108bb`

### Summary

Fixes a context-exec bus reply crash where `BaseEnvelope.causality_chain` received `None` when the incoming request had an empty causality chain. Context-exec executed but failed publishing its reply, causing Cortex-Exec to timeout and fall back to AgentChainService.

**Root cause:** `causality_chain=causality or None` — when `causality == []`, Python evaluates `[] or None` → `None`.

### Changes

- Success replies: `causality_chain=causality`
- Error replies: `causality_chain=causality`
- Incoming causality already normalized: `causality = list(envelope.causality_chain or [])`
- Tests: `test_bus_success_reply_uses_empty_causality_list`, `test_bus_reply_normalizes_missing_causality_to_empty_list`, `test_bus_error_reply_uses_empty_causality_list`

### Verification

```text
pytest services/orion-context-exec/tests/ -q  → 22 passed
trace_autopsy ok (corr 5506f854-2606-42b5-a2ee-89775b3a8ed5)
GOLDEN PROBES PASS
docker logs: replied kind=context.exec.result.v1 (no ValidationError)
```