### PR TITLE
Feat/671 alexzhang claim extraction

### DIFF
--- a/scripts/context_exec_rlm_eval.py
+++ b/scripts/context_exec_rlm_eval.py
@@ -23,7 +23,9 @@ from orion.schemas.context_exec import ContextExecPermissionV1  # noqa: E402
 
 from app.rlm_eval_harness import (  # noqa: E402
     ALL_EVAL_CASES,
+    DENVER_CLAIM_FORBIDDEN,
     REPO_ROOT,
+    assert_claim_clean,
     run_eval_case,
     seed_case_organs,
 )
@@ -33,7 +35,11 @@ def _quality_pass(case_name: str, engine: str, run) -> bool:
     if run.status != "ok":
         return False
     if case_name == "belief_provenance_denver" and engine == "alexzhang":
-        return False
+        claim = str((run.artifact or {}).get("claim") or "")
+        try:
+            assert_claim_clean(claim, DENVER_CLAIM_FORBIDDEN)
+        except AssertionError:
+            return False
     return True
 
 

--- a/services/orion-context-exec/app/alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/app/alexzhang_rlm_engine.py
@@ -26,17 +26,73 @@ class AlexZhangInitError(Exception):
     pass
 
 
+_VOCATIVE_PREFIX = re.compile(r"^(?:hey\s+)?orion[\s,]+", re.IGNORECASE)
+
+_CLAIM_TAIL_STOP = re.compile(
+    r"\s+(?:come\s+from|comes\s+from|across\s+your\s+runtime|across\s+the\s+runtime|"
+    r"from\s+across\s+your\s+runtime|in\s+your\s+runtime)\b",
+    re.IGNORECASE,
+)
+
+_CLAIM_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"where\s+did\s+(?:the\s+claim\s+that|orion\s+get\s+the\s+claim\s+that)\s+"
+        r"(?P<claim>.+?)(?:\s+come\s+from|\s+comes\s+from|\s+across\s+your\s+runtime|\?|$)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"claim\s+that\s+(?P<claim>.+?)(?:\s+come\s+from|\s+comes\s+from|"
+        r"\s+across\s+your\s+runtime|\?|$)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"why\s+does\s+orion\s+think\s+(?P<claim>.+?)(?:\?|$)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"what\s+evidence\s+(?:says|supports)\s+(?P<claim>.+?)(?:\?|$)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"is\s+it\s+true\s+that\s+(?P<claim>.+?)(?:\?|$)",
+        re.IGNORECASE,
+    ),
+)
+
+
+def _normalize_claim(claim: str) -> str:
+    normalized = re.sub(r"\s+", " ", claim.strip(" ?.,;"))
+    return normalized[:500]
+
+
+def _strip_claim_tail(claim: str) -> str:
+    match = _CLAIM_TAIL_STOP.search(claim)
+    if match:
+        return claim[: match.start()]
+    return claim
+
+
 def _extract_claim_from_text(text: str) -> str:
-    lowered = text.lower()
+    cleaned = _VOCATIVE_PREFIX.sub("", text.strip())
+
+    for pattern in _CLAIM_PATTERNS:
+        match = pattern.search(cleaned)
+        if match:
+            claim = _normalize_claim(_strip_claim_tail(match.group("claim")))
+            if claim:
+                return claim
+
+    lowered = cleaned.lower()
     for marker in ("claim that ", "claim: ", "belief that "):
         idx = lowered.find(marker)
         if idx >= 0:
-            tail = text[idx + len(marker) :].strip(" ?.")
+            tail = _normalize_claim(_strip_claim_tail(cleaned[idx + len(marker) :]))
             if tail:
-                return tail[:500]
-    if len(text) <= 500:
-        return text.strip()
-    return text[:500].strip()
+                return tail
+
+    if len(cleaned) <= 500:
+        return cleaned.strip()
+    return cleaned[:500].strip()
 
 
 def _repo_search_terms(text: str) -> list[str]:

--- a/services/orion-context-exec/app/alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/app/alexzhang_rlm_engine.py
@@ -28,8 +28,14 @@ class AlexZhangInitError(Exception):
 
 _VOCATIVE_PREFIX = re.compile(r"^(?:hey\s+)?orion[\s,]+", re.IGNORECASE)
 
+_SCAFFOLD_TERMINATOR = (
+    r"(?:\s+come\s+from\s+(?:across\s+(?:your\s+)?runtime|(?:your\s+)?runtime)"
+    r"|\s+across\s+(?:your\s+)?runtime|\?|$)"
+)
+
 _CLAIM_TAIL_STOP = re.compile(
-    r"\s+(?:come\s+from|comes\s+from|across\s+your\s+runtime|across\s+the\s+runtime|"
+    r"\s+(?:come\s+from\s+(?:across\s+(?:your\s+)?runtime|(?:your\s+)?runtime)"
+    r"|across\s+your\s+runtime|across\s+the\s+runtime|"
     r"from\s+across\s+your\s+runtime|in\s+your\s+runtime)\b",
     re.IGNORECASE,
 )
@@ -37,12 +43,11 @@ _CLAIM_TAIL_STOP = re.compile(
 _CLAIM_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
         r"where\s+did\s+(?:the\s+claim\s+that|orion\s+get\s+the\s+claim\s+that)\s+"
-        r"(?P<claim>.+?)(?:\s+come\s+from|\s+comes\s+from|\s+across\s+your\s+runtime|\?|$)",
+        rf"(?P<claim>.+?){_SCAFFOLD_TERMINATOR}",
         re.IGNORECASE,
     ),
     re.compile(
-        r"claim\s+that\s+(?P<claim>.+?)(?:\s+come\s+from|\s+comes\s+from|"
-        r"\s+across\s+your\s+runtime|\?|$)",
+        rf"claim\s+that\s+(?P<claim>.+?){_SCAFFOLD_TERMINATOR}",
         re.IGNORECASE,
     ),
     re.compile(
@@ -78,7 +83,7 @@ def _extract_claim_from_text(text: str) -> str:
     for pattern in _CLAIM_PATTERNS:
         match = pattern.search(cleaned)
         if match:
-            claim = _normalize_claim(_strip_claim_tail(match.group("claim")))
+            claim = _normalize_claim(match.group("claim"))
             if claim:
                 return claim
 

--- a/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.alexzhang_rlm_engine import AlexZhangRLMEngine, UnsupportedModeError
+from app.alexzhang_rlm_engine import AlexZhangRLMEngine, UnsupportedModeError, _extract_claim_from_text
 from app.rlm_engine import FakeRLMEngine, build_engine
 from app.runner import ContextExecRunner, FAKE_ORGANS
 from orion.schemas.context_exec import (
@@ -22,6 +22,43 @@ def _reset_fake_organs():
     yield
     FAKE_ORGANS.memory_hits = None
     FAKE_ORGANS.trace_hits = None
+
+
+_FORBIDDEN_CLAIM_TERMS = (
+    "come from across your runtime",
+    "where did",
+    "claim that",
+    "Orion",
+)
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected"),
+    [
+        (
+            "Orion, where did the claim that I am from Denver come from across your runtime?",
+            "I am from Denver",
+        ),
+        (
+            "Where did Orion get the claim that Juniper lives in Denver?",
+            "Juniper lives in Denver",
+        ),
+        (
+            "Why does Orion think I live in Ogden?",
+            "I live in Ogden",
+        ),
+        (
+            "Is it true that I am from Denver?",
+            "I am from Denver",
+        ),
+    ],
+)
+def test_extract_claim_from_text(prompt: str, expected: str) -> None:
+    claim = _extract_claim_from_text(prompt)
+    assert claim == expected
+    lowered = claim.lower()
+    for term in _FORBIDDEN_CLAIM_TERMS:
+        assert term.lower() not in lowered, f"claim contains forbidden term {term!r}: {claim!r}"
 
 
 def test_build_engine_defaults_to_fake():

--- a/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
@@ -51,6 +51,18 @@ _FORBIDDEN_CLAIM_TERMS = (
             "Is it true that I am from Denver?",
             "I am from Denver",
         ),
+        (
+            "What evidence says my location is not Denver?",
+            "my location is not Denver",
+        ),
+        (
+            "Where did Orion get the claim that users come from Denver?",
+            "users come from Denver",
+        ),
+        (
+            "Why does Orion think people come from Denver?",
+            "people come from Denver",
+        ),
     ],
 )
 def test_extract_claim_from_text(prompt: str, expected: str) -> None:

--- a/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
+++ b/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
@@ -66,10 +66,6 @@ async def test_rlm_eval_belief_provenance_denver_claim_clean(
     assert run.status == "ok"
     model = BeliefProvenanceReportV1.model_validate(run.artifact)
     assert model.status in BELIEF_DENVER.expected_statuses
-
-    if engine == "alexzhang":
-        pytest.xfail("AlexZhang _extract_claim_from_text tail extraction includes prompt noise")
-
     assert_claim_clean(model.claim, DENVER_CLAIM_FORBIDDEN)
 
 


### PR DESCRIPTION
#671: Improve AlexZhang belief-provenance claim extraction

## Summary

Improves AlexZhang belief-provenance claim extraction so prompt scaffolding is not included in extracted claims.

This resolves the known Denver eval gap encoded in #670, where the engine extracted:

`I am from Denver come from across your runtime`

instead of the clean claim:

`I am from Denver`.

## Changes

- Improve conservative claim extraction patterns in `AlexZhangRLMEngine` (`_extract_claim_from_text`):
  - Strip vocative prefixes (`Orion,`, `hey Orion`)
  - Match belief-provenance prompt forms (`where did the claim that …`, `why does Orion think …`, `what evidence says …`, `is it true that …`)
  - Stop at runtime scaffolding tails (`come from across your runtime`, etc.) without truncating legitimate claims like `users come from Denver`
- Add direct `_extract_claim_from_text` unit coverage (7 parametrized cases)
- Convert the Denver belief-provenance eval from expected failure to passing
- Fix `context_exec_rlm_eval.py` `_quality_pass` to assert claim cleanliness instead of hardcoding `False`
- Preserve existing fake engine behavior and context-exec routing

## Verification

- `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/ -q` → 57 passed, 1 xfailed
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine alexzhang` → Denver `quality_pass=True`
- AlexZhang golden probes pass (`claim: "I am from Denver"` in direct organ check)

## Scope

- No routing / Hub / Cortex-Orch / Cortex-Exec changes
- No new organs
- FakeRLMEngine unchanged
- Unrelated xfails preserved (trace autopsy echo, fake repo engine files)