### PR TITLE
Improve AlexZhang trace-autopsy root-cause extraction.

### DIFF
--- a/scripts/context_exec_rlm_eval.py
+++ b/scripts/context_exec_rlm_eval.py
@@ -40,6 +40,10 @@ def _quality_pass(case_name: str, engine: str, run) -> bool:
             assert_claim_clean(claim, DENVER_CLAIM_FORBIDDEN)
         except AssertionError:
             return False
+    if case_name == "trace_autopsy_known_corr" and engine == "alexzhang":
+        root_cause = str((run.artifact or {}).get("root_cause") or "").lower()
+        if any(term in root_cause for term in ("why did", "orion")):
+            return False
     return True
 
 

--- a/services/orion-context-exec/app/alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/app/alexzhang_rlm_engine.py
@@ -11,6 +11,31 @@ from .organ_runtime import OrganRuntime
 from .rlm_engine import RLMEngine, _extract_corr_id
 from .settings import ContextExecSettings, settings
 
+_UUID_RE = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+_PROMPT_ECHO_MARKERS = (
+    "why did",
+    "orion,",
+    "orion ",
+    "fail open?",
+    "trace autopsy",
+    "root cause:",
+)
+
+_TRACE_SIGNAL_ORDER: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("contextexecservice", "timeout"), "ContextExecService timed out"),
+    (("context.exec.result", "missing"), "context.exec.result missing"),
+    (("fallback", "true"), "fallback=True"),
+    (("agentchainservice", "fallback"), "AgentChainService fallback"),
+    (("baseenvelope", "validationerror"), "BaseEnvelope ValidationError"),
+    (("causality_chain", "list_type"), "causality_chain list_type"),
+    (("recall", "timeout"), "recall timeout"),
+    (("contextexecservice",), "ContextExecService"),
+    (("agentchainservice",), "AgentChainService"),
+    (("fallback",), "fallback"),
+    (("timeout",), "timeout"),
+)
+
 logger = logging.getLogger("orion-context-exec.alexzhang_rlm_engine")
 
 SUPPORTED_MODES = frozenset({"belief_provenance", "trace_autopsy", "repo_impact_analysis"})
@@ -98,6 +123,61 @@ def _extract_claim_from_text(text: str) -> str:
     if len(cleaned) <= 500:
         return cleaned.strip()
     return cleaned[:500].strip()
+
+
+def _extract_corr_id_from_text(text: str) -> str | None:
+    corr_eq = re.search(rf"correlation_id\s*=\s*({_UUID_RE})", text, flags=re.IGNORECASE)
+    if corr_eq:
+        return corr_eq.group(1)
+    corr_sp = re.search(rf"\bcorr[:\s#]+({_UUID_RE})\b", text, flags=re.IGNORECASE)
+    if corr_sp:
+        return corr_sp.group(1)
+    bare = re.search(rf"\b({_UUID_RE})\b", text, flags=re.IGNORECASE)
+    if bare:
+        return bare.group(1)
+    return _extract_corr_id(text)
+
+
+def _normalize_evidence_blob(text: str) -> str:
+    return re.sub(r"[\s_\-]+", "", text.lower())
+
+
+def _snippet_echoes_prompt(snippet: str, request_text: str) -> bool:
+    snippet_clean = snippet.strip()
+    request_clean = request_text.strip()
+    if not snippet_clean:
+        return True
+    sl = snippet_clean.lower()
+    rl = request_clean.lower()
+    if sl == rl or sl in rl or rl in sl:
+        return True
+    return any(marker in sl for marker in _PROMPT_ECHO_MARKERS)
+
+
+def _usable_trace_snippets(snippets: list[str], request_text: str) -> list[str]:
+    return [snippet for snippet in snippets if not _snippet_echoes_prompt(snippet, request_text)]
+
+
+def _synthesize_trace_root_cause(snippets: list[str], request_text: str) -> str | None:
+    usable = _usable_trace_snippets(snippets, request_text)
+    if not usable:
+        return None
+
+    blob = _normalize_evidence_blob(" ".join(usable))
+    matched: list[str] = []
+    for needles, label in _TRACE_SIGNAL_ORDER:
+        if all(_normalize_evidence_blob(needle) in blob for needle in needles):
+            if label not in matched:
+                matched.append(label)
+
+    if matched:
+        if "ContextExecService timed out" in matched and "AgentChainService fallback" in matched:
+            return "ContextExecService timed out and Cortex-Exec fell back to AgentChainService"
+        if "ContextExecService timed out" in matched and "fallback" in matched:
+            return "ContextExecService timed out and Cortex-Exec fell back to AgentChainService"
+        return matched[0]
+
+    return usable[0]
 
 
 def _repo_search_terms(text: str) -> list[str]:
@@ -295,7 +375,7 @@ class AlexZhangRLMEngine(RLMEngine):
         runtime: OrganRuntime | None,
         organ_cache: dict[str, Any] | None,
     ) -> dict[str, Any]:
-        corr = _extract_corr_id(request.text)
+        corr = _extract_corr_id_from_text(request.text)
         self._debug_steps.append("retrieve")
         trace_hits: list[dict[str, Any]] = []
         if runtime is not None and corr:
@@ -307,11 +387,13 @@ class AlexZhangRLMEngine(RLMEngine):
             trace_hits = namespace.traces.search(corr_id=corr, limit=self._settings.context_exec_trace_limit)
 
         self._debug_steps.append("synthesize")
+        raw_snippets: list[str] = []
         evidence: list[dict[str, Any]] = []
-        failure_chain: list[str] = []
         for th in trace_hits:
             snippet = str(th.get("snippet") or th.get("kind") or "trace hit")
-            failure_chain.append(snippet)
+            raw_snippets.append(snippet)
+            if _snippet_echoes_prompt(snippet, request.text):
+                continue
             evidence.append(
                 {
                     "claim": snippet,
@@ -323,7 +405,10 @@ class AlexZhangRLMEngine(RLMEngine):
                 }
             )
 
-        if not trace_hits:
+        usable_snippets = _usable_trace_snippets(raw_snippets, request.text)
+        root_cause = _synthesize_trace_root_cause(raw_snippets, request.text)
+
+        if not trace_hits or not usable_snippets or root_cause is None:
             return {
                 "target": corr or request.text[:80],
                 "status": "unknown",
@@ -334,11 +419,12 @@ class AlexZhangRLMEngine(RLMEngine):
                 "recommended_patch": "Collect Redis/Cortex trace evidence for the correlation id",
             }
 
+        failure_chain = usable_snippets
         return {
             "target": corr or request.text[:80],
-            "status": "explained" if len(trace_hits) >= 2 else "partial",
+            "status": "explained" if len(failure_chain) >= 2 else "partial",
             "failure_chain": failure_chain,
-            "root_cause": failure_chain[0],
+            "root_cause": root_cause,
             "contributing_factors": failure_chain[1:4],
             "evidence": evidence,
             "recommended_patch": None,

--- a/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
@@ -4,7 +4,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.alexzhang_rlm_engine import AlexZhangRLMEngine, UnsupportedModeError, _extract_claim_from_text
+from app.alexzhang_rlm_engine import (
+    AlexZhangRLMEngine,
+    UnsupportedModeError,
+    _extract_claim_from_text,
+    _extract_corr_id_from_text,
+)
 from app.rlm_engine import FakeRLMEngine, build_engine
 from app.runner import ContextExecRunner, FAKE_ORGANS
 from orion.schemas.context_exec import (
@@ -30,6 +35,142 @@ _FORBIDDEN_CLAIM_TERMS = (
     "claim that",
     "Orion",
 )
+
+
+_KNOWN_CORR = "5506f854-2606-42b5-a2ee-89775b3a8ed5"
+
+_TRACE_ECHO_FORBIDDEN = (
+    "Orion, why did corr",
+    "why did corr",
+    "fail open?",
+    "Root cause: Orion",
+)
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected"),
+    [
+        (
+            f"Orion, why did corr {_KNOWN_CORR} fail open?",
+            _KNOWN_CORR,
+        ),
+        (
+            f"why did correlation_id={_KNOWN_CORR} fail?",
+            _KNOWN_CORR,
+        ),
+        (
+            f"trace autopsy for {_KNOWN_CORR}",
+            _KNOWN_CORR,
+        ),
+    ],
+)
+def test_extract_corr_id_from_trace_autopsy_prompt(prompt: str, expected: str) -> None:
+    assert _extract_corr_id_from_text(prompt) == expected
+
+
+@pytest.mark.asyncio
+async def test_trace_autopsy_root_cause_does_not_echo_prompt():
+    prompt = f"Orion, why did corr {_KNOWN_CORR} fail open?"
+    FAKE_ORGANS.trace_hits = [
+        {
+            "handle": "t:echo",
+            "snippet": prompt,
+            "corr_id": _KNOWN_CORR,
+            "kind": "request",
+            "source": "hub",
+        },
+        {
+            "handle": "t:5506",
+            "snippet": "context_exec_early_dispatch RPC timeout waiting for ContextExecService",
+            "corr_id": _KNOWN_CORR,
+            "kind": "error",
+            "source": "cortex",
+        },
+        {
+            "handle": "t:5507",
+            "snippet": "fallback to AgentChainService",
+            "corr_id": _KNOWN_CORR,
+            "kind": "error",
+            "source": "cortex",
+        },
+    ]
+    engine = AlexZhangRLMEngine()
+    from app.callable_namespace import ContextNamespace
+    from orion.schemas.context_exec import ContextExecPermissionV1
+
+    ns = ContextNamespace(
+        permissions=ContextExecPermissionV1(),
+        traces_fn={
+            "search": lambda **kw: FAKE_ORGANS.trace_hits or [],
+            "read": lambda h: {"handle": h},
+        },
+    )
+    req = ContextExecRequestV1(text=prompt, mode="trace_autopsy")
+    raw = await engine.run(req, ns)
+    model = TraceAutopsyReportV1.model_validate(raw)
+    root_cause = (model.root_cause or "").lower()
+    final_text = f"Trace autopsy: {model.status}. Root cause: {model.root_cause}."
+    for forbidden in _TRACE_ECHO_FORBIDDEN:
+        assert forbidden.lower() not in root_cause
+        assert forbidden.lower() not in final_text.lower()
+    assert any(term in root_cause for term in ("contextexecservice", "timeout", "fallback", "agentchainservice"))
+
+
+@pytest.mark.asyncio
+async def test_trace_autopsy_evidence_backed_fallback_summary():
+    prompt = f"Orion, why did corr {_KNOWN_CORR} fail open?"
+    FAKE_ORGANS.trace_hits = [
+        {
+            "handle": "t:5506",
+            "snippet": "context_exec_early_dispatch RPC timeout waiting for ContextExecService",
+            "corr_id": _KNOWN_CORR,
+            "kind": "error",
+            "source": "cortex",
+        },
+        {
+            "handle": "t:5507",
+            "snippet": "fallback to AgentChainService",
+            "corr_id": _KNOWN_CORR,
+            "kind": "error",
+            "source": "cortex",
+        },
+    ]
+    engine = AlexZhangRLMEngine()
+    from app.callable_namespace import ContextNamespace
+    from orion.schemas.context_exec import ContextExecPermissionV1
+
+    ns = ContextNamespace(
+        permissions=ContextExecPermissionV1(),
+        traces_fn={
+            "search": lambda **kw: FAKE_ORGANS.trace_hits or [],
+            "read": lambda h: {"handle": h},
+        },
+    )
+    req = ContextExecRequestV1(text=prompt, mode="trace_autopsy")
+    raw = await engine.run(req, ns)
+    model = TraceAutopsyReportV1.model_validate(raw)
+    blob = f"{model.root_cause or ''} {model.failure_chain}".lower()
+    assert any(term in blob for term in ("contextexecservice", "timeout", "fallback", "agentchainservice"))
+
+
+@pytest.mark.asyncio
+async def test_trace_autopsy_missing_corr_is_controlled():
+    engine = AlexZhangRLMEngine()
+    from app.callable_namespace import ContextNamespace
+    from orion.schemas.context_exec import ContextExecPermissionV1
+
+    ns = ContextNamespace(
+        permissions=ContextExecPermissionV1(),
+        traces_fn={"search": lambda **kw: [], "read": lambda h: {}},
+    )
+    req = ContextExecRequestV1(text="Why did corr does-not-exist fail open?", mode="trace_autopsy")
+    raw = await engine.run(req, ns)
+    model = TraceAutopsyReportV1.model_validate(raw)
+    assert model.status in {"unknown", "partial"}
+    assert model.root_cause == "insufficient_trace_evidence"
+    root_cause = (model.root_cause or "").lower()
+    assert "agentchainservice" not in root_cause
+    assert "contextexecservice" not in root_cause
 
 
 @pytest.mark.parametrize(

--- a/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
+++ b/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
@@ -100,10 +100,6 @@ async def test_rlm_eval_trace_autopsy_does_not_echo_question_as_root_cause(
     assert any(term.lower() in blob for term in TRACE_REQUIRED_TERMS)
 
     root_cause = (model.root_cause or "").lower()
-    question_echo_terms = ("why did", "orion")
-    if engine == "alexzhang" and any(t in root_cause for t in question_echo_terms):
-        pytest.xfail("AlexZhang trace autopsy root_cause echoes question text")
-
     assert "why did" not in root_cause
     assert "orion" not in root_cause
 


### PR DESCRIPTION
## Summary

Improves AlexZhang trace-autopsy synthesis so root cause is evidence-backed instead of echoing the user prompt.

## Changes

- Add `_extract_corr_id_from_text` for `corr UUID`, `correlation_id=UUID`, and bare UUID prompts.
- Filter prompt-echo snippets out of trace evidence before synthesis.
- Synthesize root cause from observed timeout/fallback/failure markers when present; otherwise return `insufficient_trace_evidence`.
- Add targeted unit tests preventing prompt echo as root cause.
- Remove the AlexZhang trace-autopsy eval xfail guard; eval CLI now checks trace-autopsy quality for prompt echo.

## Verification

- `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/ -q` → **63 passed, 1 xfailed** (unchanged fake repo-impact xfail)
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine alexzhang` → **trace_autopsy_known_corr quality_pass=True**
- AlexZhang golden probes pass (`CONTEXT_EXEC_RLM_ENGINE=alexzhang`, corr `5506f854-2606-42b5-a2ee-89775b3a8ed5`)

## Non-goals (confirmed)

- No routing, Hub, Cortex-Orch, or Cortex-Exec changes
- No new organs; schema unchanged (`TraceAutopsyReportV1`)
- FakeRLMEngine behavior unchanged