### PR TITLE
Pr/674 alexzhang repo impact

### DIFF
--- a/services/orion-context-exec/app/alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/app/alexzhang_rlm_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+from pathlib import Path
 from typing import Any
 
 from orion.schemas.context_exec import ContextExecRequestV1
@@ -180,7 +181,67 @@ def _synthesize_trace_root_cause(snippets: list[str], request_text: str) -> str 
     return usable[0]
 
 
+_ENGINE_SELECTION_MARKERS = frozenset(
+    {
+        "alexzhang",
+        "fakerlmengine",
+        "context_exec_rlm_engine",
+        "engine selection",
+        "rlm engine",
+    }
+)
+
+_ENGINE_REPO_ANCHORS: tuple[str, ...] = (
+    "AlexZhangRLMEngine",
+    "FakeRLMEngine",
+    "CONTEXT_EXEC_RLM_ENGINE",
+    "engine_selected",
+    "fallback_engine",
+    "build_engine",
+    "ContextExecRunner",
+    "repo_impact_analysis",
+    "rlm_engine",
+)
+
+_ENGINE_SELECTION_PATHS: tuple[str, ...] = (
+    "rlm_engine.py",
+    "alexzhang_rlm_engine.py",
+    "runner.py",
+    "settings.py",
+    "rlm_eval_harness.py",
+)
+
+_CONTEXT_EXEC_APP_PREFIXES: tuple[str, ...] = (
+    "services/orion-context-exec/app/",
+    "app/",
+)
+
+
+def _engine_selection_grep_path() -> str | None:
+    root = Path(settings.context_exec_repo_root or settings.orion_repo_root)
+    for rel in ("services/orion-context-exec/app", "app"):
+        if (root / rel).is_dir():
+            return rel
+    return None
+
+
+def _is_engine_selection_query(text: str) -> bool:
+    lowered = text.lower()
+    if any(marker in lowered for marker in _ENGINE_SELECTION_MARKERS):
+        return True
+    if ("context-exec" in lowered or "context exec" in lowered) and "engine" in lowered:
+        return True
+    if "rlm" in lowered and "engine" in lowered:
+        return True
+    if "engine" in lowered and "selection" in lowered:
+        return True
+    return False
+
+
 def _repo_search_terms(text: str) -> list[str]:
+    if _is_engine_selection_query(text):
+        return list(_ENGINE_REPO_ANCHORS)
+
     terms: list[str] = []
     for token in re.findall(r"[A-Za-z][A-Za-z0-9_-]{2,}", text):
         if token.lower() in {"what", "breaks", "replace", "with", "context", "exec", "agent", "chain"}:
@@ -198,6 +259,58 @@ def _repo_search_terms(text: str) -> list[str]:
             seen.add(key)
             out.append(t)
     return out[:6] or ["agent.chain"]
+
+
+def _merge_repo_hits(
+    hits: list[dict[str, Any]],
+    batch: list[dict[str, Any]],
+    seen_paths: set[str],
+) -> None:
+    for h in batch:
+        path = str(h.get("path") or "")
+        if path and path not in seen_paths:
+            seen_paths.add(path)
+            hits.append(h)
+
+
+def _prioritize_engine_selection_hits(hits: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def rank(h: dict[str, Any]) -> tuple[int, str]:
+        path = str(h.get("path") or "")
+        lowered = path.lower()
+        for prefix in _CONTEXT_EXEC_APP_PREFIXES:
+            if lowered.startswith(prefix):
+                for idx, name in enumerate(_ENGINE_SELECTION_PATHS):
+                    if lowered.endswith(name):
+                        return (idx, path)
+                return (len(_ENGINE_SELECTION_PATHS), path)
+        return (len(_ENGINE_SELECTION_PATHS) + 1, path)
+
+    return sorted(hits, key=rank)
+
+
+def _engine_selection_risk(affected_paths: list[str]) -> str:
+    if not affected_paths:
+        return "unknown"
+    runtime_markers = frozenset(_ENGINE_SELECTION_PATHS[:4])
+    for path in affected_paths:
+        name = path.rsplit("/", 1)[-1].lower()
+        if name in runtime_markers:
+            return "medium"
+    if any(
+        path.lower().startswith(prefix)
+        for path in affected_paths
+        for prefix in _CONTEXT_EXEC_APP_PREFIXES
+    ):
+        return "low"
+    return "unknown"
+
+
+def _agent_chain_risk(affected_paths: list[str]) -> str:
+    if len(affected_paths) > 3:
+        return "medium"
+    if affected_paths:
+        return "low"
+    return "unknown"
 
 
 class AlexZhangRLMEngine(RLMEngine):
@@ -430,6 +543,23 @@ class AlexZhangRLMEngine(RLMEngine):
             "recommended_patch": None,
         }
 
+    async def _repo_grep_batch(
+        self,
+        pattern: str,
+        request: ContextExecRequestV1,
+        namespace: ContextNamespace,
+        runtime: OrganRuntime | None,
+        *,
+        path: str | None = None,
+        limit: int = 30,
+    ) -> list[dict[str, Any]]:
+        if runtime is not None and request.permissions.read_repo:
+            self._subcalls += 1
+            return runtime.repo_grep(pattern, path=path, limit=limit)
+        if request.permissions.read_repo:
+            return namespace.repo.grep(pattern, path=path, limit=limit)
+        return []
+
     async def _repo_impact(
         self,
         request: ContextExecRequestV1,
@@ -438,23 +568,36 @@ class AlexZhangRLMEngine(RLMEngine):
         organ_cache: dict[str, Any] | None,
     ) -> dict[str, Any]:
         self._debug_steps.append("retrieve")
+        engine_selection = _is_engine_selection_query(request.text)
         terms = _repo_search_terms(request.text)
         hits: list[dict[str, Any]] = []
         seen_paths: set[str] = set()
+        scoped_path = _engine_selection_grep_path() if engine_selection else None
+
         for term in terms:
-            batch: list[dict[str, Any]]
-            if runtime is not None and request.permissions.read_repo:
-                batch = runtime.repo_grep(term, limit=30)
-                self._subcalls += 1
-            elif request.permissions.read_repo:
-                batch = namespace.repo.grep(term, limit=30)
-            else:
-                batch = []
-            for h in batch:
-                path = str(h.get("path") or "")
-                if path and path not in seen_paths:
-                    seen_paths.add(path)
-                    hits.append(h)
+            batch = await self._repo_grep_batch(
+                term,
+                request,
+                namespace,
+                runtime,
+                path=scoped_path,
+                limit=30,
+            )
+            _merge_repo_hits(hits, batch, seen_paths)
+
+        if engine_selection and not hits:
+            for term in terms[:4]:
+                batch = await self._repo_grep_batch(
+                    term,
+                    request,
+                    namespace,
+                    runtime,
+                    limit=30,
+                )
+                _merge_repo_hits(hits, batch, seen_paths)
+
+        if engine_selection:
+            hits = _prioritize_engine_selection_hits(hits)
 
         self._debug_steps.append("synthesize")
         if not hits:
@@ -471,15 +614,28 @@ class AlexZhangRLMEngine(RLMEngine):
             }
 
         affected = [h.get("path") for h in hits if isinstance(h, dict) and h.get("path")][:20]
+        if engine_selection:
+            risk = _engine_selection_risk(affected)
+            breaking_surfaces: list[str] = []
+            compatibility_shims: list[str] = []
+            tests_to_add: list[str] = []
+            migration_steps: list[str] = []
+        else:
+            risk = _agent_chain_risk(affected)
+            breaking_surfaces = ["cortex-exec AgentChainClient hop"]
+            compatibility_shims = ["AgentChainResult-compatible context-exec reply"]
+            tests_to_add = ["test_context_exec_depth2_routing"]
+            migration_steps = ["feature flag CONTEXT_EXEC_ENABLED"]
+
         return {
             "proposed_change": request.text[:500],
             "status": "analyzed" if len(affected) >= 2 else "partial",
             "affected_paths": affected,
-            "breaking_surfaces": ["cortex-exec AgentChainClient hop"] if hits else [],
-            "compatibility_shims": ["AgentChainResult-compatible context-exec reply"],
-            "tests_to_add_or_update": ["test_context_exec_depth2_routing"],
-            "migration_steps": ["feature flag CONTEXT_EXEC_ENABLED"],
-            "risk": "medium" if len(affected) > 3 else "low",
+            "breaking_surfaces": breaking_surfaces,
+            "compatibility_shims": compatibility_shims,
+            "tests_to_add_or_update": tests_to_add,
+            "migration_steps": migration_steps,
+            "risk": risk,
             "findings": [
                 {
                     "claim": f"{h.get('path')}:{h.get('line_start')} {str(h.get('snippet', ''))[:120]}",

--- a/services/orion-context-exec/app/artifact_builder.py
+++ b/services/orion-context-exec/app/artifact_builder.py
@@ -96,5 +96,12 @@ def build_final_text(mode: ContextExecMode, artifact: dict[str, Any], *, status:
         rc = artifact.get("root_cause") or "unknown"
         return f"Trace autopsy: {artifact.get('status', 'unknown')}. Root cause: {rc}."
     if mode == "repo_impact_analysis":
-        return f"Repo impact: {artifact.get('status', 'unknown')}. Risk={artifact.get('risk', 'unknown')}."
+        st = artifact.get("status", "unknown")
+        risk = artifact.get("risk", "unknown")
+        if st == "insufficient_grounding":
+            return "Repo impact: insufficient_grounding. Risk=unknown."
+        paths = artifact.get("affected_paths") or []
+        path_names = [str(p).rsplit("/", 1)[-1] for p in paths[:4] if p]
+        path_hint = f" Grounded files: {', '.join(path_names)}." if path_names else ""
+        return f"Repo impact: {st}. Risk={risk}.{path_hint}"
     return str(artifact.get("summary") or artifact.get("target") or "Investigation complete.")

--- a/services/orion-context-exec/app/repo_tools.py
+++ b/services/orion-context-exec/app/repo_tools.py
@@ -18,7 +18,7 @@ DENY_PATTERNS = (
     r"\.git/",
 )
 
-ALLOW_PREFIXES = ("orion/", "services/", "docs/", "tests/", "scripts/")
+ALLOW_PREFIXES = ("orion/", "services/", "app/", "docs/", "tests/", "scripts/")
 
 
 def _repo_root() -> Path:

--- a/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
@@ -374,10 +374,8 @@ async def test_repo_impact_engine_selection_identifies_context_exec_files(monkey
     model = RepoImpactAnalysisReportV1.model_validate(raw)
     blob = " ".join(model.affected_paths).lower()
     assert model.status in {"analyzed", "partial"}
-    matched = sum(
-        1 for name in ("rlm_engine.py", "alexzhang_rlm_engine.py", "runner.py", "settings.py") if name in blob
-    )
-    assert matched >= 2
+    for name in ("rlm_engine.py", "alexzhang_rlm_engine.py", "runner.py", "settings.py"):
+        assert name in blob
 
 
 @pytest.mark.asyncio

--- a/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/tests/test_alexzhang_rlm_engine.py
@@ -14,6 +14,7 @@ from app.rlm_engine import FakeRLMEngine, build_engine
 from app.runner import ContextExecRunner, FAKE_ORGANS
 from orion.schemas.context_exec import (
     BeliefProvenanceReportV1,
+    ContextExecPermissionV1,
     ContextExecRequestV1,
     RepoImpactAnalysisReportV1,
     TraceAutopsyReportV1,
@@ -324,11 +325,170 @@ async def test_alexzhang_trace_autopsy_insufficient_evidence():
 
 
 @pytest.mark.asyncio
+async def test_repo_impact_engine_selection_identifies_context_exec_files(monkeypatch):
+    """AlexZhang repo-impact should ground engine-selection prompts to context-exec app files."""
+    monkeypatch.setattr("app.alexzhang_rlm_engine.settings.context_exec_real_repo_enabled", True)
+    engine = AlexZhangRLMEngine()
+    from app.callable_namespace import ContextNamespace
+    from app.schemas import RepoHit
+
+    fake_hits = [
+        {
+            "path": "services/orion-context-exec/app/rlm_engine.py",
+            "line_start": 236,
+            "snippet": "def build_engine(name: str) -> RLMEngine:",
+            "source_ref": "repo:rlm_engine.py:236",
+        },
+        {
+            "path": "services/orion-context-exec/app/alexzhang_rlm_engine.py",
+            "line_start": 123,
+            "snippet": "class AlexZhangRLMEngine(RLMEngine):",
+            "source_ref": "repo:alexzhang_rlm_engine.py:123",
+        },
+        {
+            "path": "services/orion-context-exec/app/runner.py",
+            "line_start": 79,
+            "snippet": "self.engine_selected = (settings.rlm_engine or fake)",
+            "source_ref": "repo:runner.py:79",
+        },
+        {
+            "path": "services/orion-context-exec/app/settings.py",
+            "line_start": 12,
+            "snippet": "CONTEXT_EXEC_RLM_ENGINE",
+            "source_ref": "repo:settings.py:12",
+        },
+    ]
+
+    def _stub_grep(pattern: str, path: str | None = None, limit: int = 50) -> list[RepoHit]:
+        return [RepoHit.model_validate(h) for h in fake_hits]
+
+    monkeypatch.setattr("app.repo_tools.repo_grep", _stub_grep)
+
+    ns = ContextNamespace(permissions=ContextExecPermissionV1(read_repo=True))
+    req = ContextExecRequestV1(
+        text="What files are involved in context-exec RLM engine selection?",
+        mode="repo_impact_analysis",
+        permissions=ContextExecPermissionV1(read_repo=True),
+    )
+    raw = await engine.run(req, ns)
+    model = RepoImpactAnalysisReportV1.model_validate(raw)
+    blob = " ".join(model.affected_paths).lower()
+    assert model.status in {"analyzed", "partial"}
+    matched = sum(
+        1 for name in ("rlm_engine.py", "alexzhang_rlm_engine.py", "runner.py", "settings.py") if name in blob
+    )
+    assert matched >= 2
+
+
+@pytest.mark.asyncio
+async def test_repo_impact_does_not_invent_unseen_paths(monkeypatch):
+    """Repo-impact paths must come from grep findings, not invention."""
+    monkeypatch.setattr("app.alexzhang_rlm_engine.settings.context_exec_real_repo_enabled", True)
+    engine = AlexZhangRLMEngine()
+    from app.callable_namespace import ContextNamespace
+    from app.schemas import RepoHit
+
+    stub_hits = [
+        {
+            "path": "services/orion-cortex-exec/app/clients.py",
+            "line_start": 10,
+            "snippet": "AgentChainClient",
+            "source_ref": "repo:clients.py:10",
+        }
+    ]
+
+    def _stub_grep(pattern: str, path: str | None = None, limit: int = 50) -> list[RepoHit]:
+        return [RepoHit.model_validate(h) for h in stub_hits]
+
+    monkeypatch.setattr("app.repo_tools.repo_grep", _stub_grep)
+
+    ns = ContextNamespace(permissions=ContextExecPermissionV1(read_repo=True))
+    req = ContextExecRequestV1(
+        text="What breaks if I replace agent-chain-service with context-exec?",
+        mode="repo_impact_analysis",
+        permissions=ContextExecPermissionV1(read_repo=True),
+    )
+    raw = await engine.run(req, ns)
+    model = RepoImpactAnalysisReportV1.model_validate(raw)
+    allowed = {h["path"] for h in stub_hits}
+    for path in model.affected_paths:
+        assert path in allowed
+
+
+@pytest.mark.asyncio
+async def test_repo_impact_missing_evidence_reports_insufficient_grounding(monkeypatch):
+    """When repo organ returns no hits, report insufficient grounding honestly."""
+    monkeypatch.setattr("app.alexzhang_rlm_engine.settings.context_exec_real_repo_enabled", True)
+    engine = AlexZhangRLMEngine()
+    from app.callable_namespace import ContextNamespace
+
+    monkeypatch.setattr("app.repo_tools.repo_grep", lambda *a, **k: [])
+
+    ns = ContextNamespace(permissions=ContextExecPermissionV1(read_repo=True))
+    req = ContextExecRequestV1(
+        text="What files are involved in context-exec RLM engine selection?",
+        mode="repo_impact_analysis",
+        permissions=ContextExecPermissionV1(read_repo=True),
+    )
+    raw = await engine.run(req, ns)
+    model = RepoImpactAnalysisReportV1.model_validate(raw)
+    assert model.status == "insufficient_grounding"
+    assert model.risk == "unknown"
+    assert not model.affected_paths
+    assert not model.findings
+
+
+@pytest.mark.asyncio
+async def test_alexzhang_repo_impact_runtime_debug_and_safety(monkeypatch):
+    """Runtime debug and safety posture remain intact for repo-impact runs."""
+    monkeypatch.setattr("app.runner.settings.rlm_engine", "alexzhang")
+    monkeypatch.setattr("app.alexzhang_rlm_engine.settings.context_exec_real_repo_enabled", True)
+
+    fake_hits = [
+        {
+            "path": "services/orion-context-exec/app/rlm_engine.py",
+            "line_start": 1,
+            "snippet": "build_engine",
+            "source_ref": "repo:rlm_engine.py:1",
+        },
+        {
+            "path": "services/orion-context-exec/app/runner.py",
+            "line_start": 1,
+            "snippet": "ContextExecRunner",
+            "source_ref": "repo:runner.py:1",
+        },
+    ]
+
+    from app.schemas import RepoHit
+
+    def _stub_grep(pattern: str, path: str | None = None, limit: int = 50) -> list[RepoHit]:
+        return [RepoHit.model_validate(h) for h in fake_hits]
+
+    monkeypatch.setattr("app.repo_tools.repo_grep", _stub_grep)
+
+    runner = ContextExecRunner()
+    req = ContextExecRequestV1(
+        text="What files are involved in context-exec RLM engine selection?",
+        mode="repo_impact_analysis",
+        permissions=ContextExecPermissionV1(read_repo=True),
+    )
+    run = await runner.run(req)
+
+    assert run.runtime_debug["engine"] == "alexzhang"
+    assert run.runtime_debug["engine_selected"] == "alexzhang"
+    assert run.runtime_debug["schema_valid"] is True
+    assert run.runtime_debug["rlm_depth"] <= 1
+    assert run.runtime_debug.get("write_enabled") is False
+    assert run.runtime_debug.get("network_enabled") is False
+    assert "rlm_engine.py" in run.final_text or "runner.py" in run.final_text
+
+
+@pytest.mark.asyncio
 async def test_alexzhang_repo_impact_schema_valid(monkeypatch):
     monkeypatch.setattr("app.alexzhang_rlm_engine.settings.context_exec_real_repo_enabled", True)
     engine = AlexZhangRLMEngine()
     from app.callable_namespace import ContextNamespace
-    from orion.schemas.context_exec import ContextExecPermissionV1
+    from app.schemas import RepoHit
 
     fake_hits = [
         {
@@ -339,16 +499,20 @@ async def test_alexzhang_repo_impact_schema_valid(monkeypatch):
         }
     ]
 
+    def _stub_grep(pattern: str, path: str | None = None, limit: int = 50) -> list[RepoHit]:
+        return [RepoHit.model_validate(h) for h in fake_hits]
+
+    monkeypatch.setattr("app.repo_tools.repo_grep", _stub_grep)
+
     ns = ContextNamespace(
         permissions=ContextExecPermissionV1(read_repo=True),
     )
-    with patch.object(ns.repo, "grep", return_value=fake_hits):
-        req = ContextExecRequestV1(
-            text="What breaks if I replace agent-chain-service with context-exec?",
-            mode="repo_impact_analysis",
-            permissions=ContextExecPermissionV1(read_repo=True),
-        )
-        raw = await engine.run(req, ns)
+    req = ContextExecRequestV1(
+        text="What breaks if I replace agent-chain-service with context-exec?",
+        mode="repo_impact_analysis",
+        permissions=ContextExecPermissionV1(read_repo=True),
+    )
+    raw = await engine.run(req, ns)
     model = RepoImpactAnalysisReportV1.model_validate(raw)
     assert model.status in {"analyzed", "partial", "insufficient_grounding"}
 

--- a/services/orion-context-exec/tests/test_repo_tools.py
+++ b/services/orion-context-exec/tests/test_repo_tools.py
@@ -29,6 +29,20 @@ def test_repo_grep_and_read_respect_allow_deny(tmp_path, monkeypatch):
     assert repo_tools.repo_read("../outside") is None
 
 
+def test_repo_grep_allows_app_prefix(tmp_path, monkeypatch):
+    from app import settings as settings_mod
+
+    (tmp_path / "app").mkdir(parents=True)
+    target = tmp_path / "app" / "rlm_engine.py"
+    target.write_text("def build_engine():\n    pass\n", encoding="utf-8")
+
+    monkeypatch.setattr(settings_mod.settings, "context_exec_repo_root", str(tmp_path))
+    monkeypatch.setattr(settings_mod.settings, "orion_repo_root", str(tmp_path))
+
+    hits = repo_tools.repo_grep("build_engine", path="app", limit=20)
+    assert any(h.path == "app/rlm_engine.py" for h in hits)
+
+
 def test_repo_write_blocked():
     try:
         repo_tools.repo_write()


### PR DESCRIPTION
## Summary

Improves AlexZhang repo-impact grounding for prompts about context-exec RLM engine selection.

## Changes

- Strengthen repo-impact grounding for prompts about context-exec RLM engine selection using existing local repo organ/runtime evidence only.
- Search curated anchors (`AlexZhangRLMEngine`, `build_engine`, `CONTEXT_EXEC_RLM_ENGINE`, etc.) with scoped grep under context-exec app code.
- Identify grounded files such as `rlm_engine.py`, `alexzhang_rlm_engine.py`, `runner.py`, and `settings.py`.
- Allow `app/` in repo grep allowlist for docker sandbox layout (`/app/app/`).
- Resolve scoped grep path for dev vs docker layouts.
- Preserve honest `insufficient_grounding` when repo evidence is missing.
- Surface grounded filenames in `final_text`.
- Add tests to prevent hallucinated paths.
- Update eval coverage for the repo-impact engine-selection case.

## Verification

- `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/ -q`
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine alexzhang`
- AlexZhang golden probes pass
- Live direct probe with `read_repo=true` returns grounded engine files