### PR TITLE
Feat/676 patch proposal scaffold

### DIFF
--- a/docs/context-exec-beta-runbook.md
+++ b/docs/context-exec-beta-runbook.md
@@ -31,6 +31,15 @@ Beta-safe modes (schema-valid artifacts, eval fixtures, golden probes):
 
 Other modes exist in schema (`runtime_debug`, `grammar_collision_audit`, etc.) but are **not** beta-certified in this release.
 
+### patch_proposal (proposal-mode scaffold)
+
+- **Purpose:** Emit a read-only patch blueprint (`PatchProposalV1`). Context-exec may **propose** mutation; it may **not perform** mutation.
+- **Input shape:** Natural-language request to diagnose a weakness and propose a patch (e.g. weak trace-autopsy synthesis).
+- **Artifact type:** `PatchProposalV1` — fields include `problem`, `evidence`, `files_to_change`, `proposed_change_summary`, `risk`, `tests_to_run`, `rollback_plan`, `open_questions`, `mutation_allowed` (always `false` for context-exec output).
+- **Expected behavior:** Read-only repo grounding via existing organ hooks; schema-valid proposal; `mutation_allowed=false` in artifact and `runtime_debug`.
+- **Boundary:** Proposal artifacts are not actions. Executors are separate. Cortex/human approval is required before mutation.
+- **Not beta-certified:** Eval fixtures exist; Hub/Cortex auto-routing is not wired in this release.
+
 ### belief_provenance
 
 - **Purpose:** Investigate origin and support status of a user/runtime claim.
@@ -275,14 +284,16 @@ Checklist:
 
 ## 13. Future proposal-artifact path
 
-Next architecture step ( **not implemented in beta** ):
+Proposal-mode scaffold ( **partially implemented** ):
 
-| Proposal artifact | Purpose |
-|-------------------|---------|
-| `PatchProposalV1` | Propose code/doc patch |
-| `MemoryCorrectionProposalV1` | Propose memory correction |
-| `RuntimeConfigProposalV1` | Propose runtime config change |
-| `TestPlanProposalV1` | Propose test additions |
+| Proposal artifact | Status | Purpose |
+|-------------------|--------|---------|
+| `PatchProposalV1` | Scaffold (`patch_proposal` mode) | Propose code/doc patch — read-only blueprint only |
+| `MemoryCorrectionProposalV1` | Not implemented | Propose memory correction |
+| `RuntimeConfigProposalV1` | Not implemented | Propose runtime config change |
+| `TestPlanProposalV1` | Not implemented | Propose test additions |
+
+`patch_proposal` is proposal-mode scaffold. It may emit `PatchProposalV1`. It may not execute changes.
 
 **Rule:**
 

--- a/orion/schemas/context_exec.py
+++ b/orion/schemas/context_exec.py
@@ -13,6 +13,7 @@ ContextExecMode = Literal[
     "belief_provenance",
     "trace_autopsy",
     "repo_impact_analysis",
+    "patch_proposal",
     "runtime_debug",
     "grammar_collision_audit",
     "memory_contradiction_review",
@@ -156,6 +157,20 @@ class RepoImpactAnalysisReportV1(BaseModel):
     migration_steps: list[str] = Field(default_factory=list)
     risk: Literal["low", "medium", "high", "unknown"] = "unknown"
     findings: list[ContextExecFindingV1] = Field(default_factory=list)
+
+
+class PatchProposalV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    problem: str
+    evidence: list[str] = Field(default_factory=list)
+    files_to_change: list[str] = Field(default_factory=list)
+    proposed_change_summary: str
+    risk: Literal["low", "medium", "high", "unknown"] = "unknown"
+    tests_to_run: list[str] = Field(default_factory=list)
+    rollback_plan: str
+    open_questions: list[str] = Field(default_factory=list)
+    mutation_allowed: bool = False
 
 
 class ContextExecRunV1(BaseModel):

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -69,6 +69,7 @@ from orion.schemas.context_exec import (
     ContextExecRequestV1,
     ContextExecRunV1,
     ContextExecVerbStepV1,
+    PatchProposalV1,
     RepoImpactAnalysisReportV1,
     TraceAutopsyReportV1,
 )
@@ -1039,6 +1040,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "BeliefProvenanceReportV1": BeliefProvenanceReportV1,
     "TraceAutopsyReportV1": TraceAutopsyReportV1,
     "RepoImpactAnalysisReportV1": RepoImpactAnalysisReportV1,
+    "PatchProposalV1": PatchProposalV1,
 
 }
 

--- a/scripts/context_exec_rlm_eval.py
+++ b/scripts/context_exec_rlm_eval.py
@@ -44,6 +44,26 @@ def _quality_pass(case_name: str, engine: str, run) -> bool:
         root_cause = str((run.artifact or {}).get("root_cause") or "").lower()
         if any(term in root_cause for term in ("why did", "orion")):
             return False
+    if case_name == "patch_proposal_trace_autopsy_quality":
+        artifact = run.artifact or {}
+        if artifact.get("mutation_allowed") is not False:
+            return False
+        risk = str(artifact.get("risk") or "unknown")
+        if risk not in {"low", "medium", "unknown"}:
+            return False
+        if engine == "alexzhang" and artifact.get("files_to_change"):
+            blob = " ".join(str(p) for p in artifact.get("files_to_change") or []).lower()
+            if not any(name.lower() in blob for name in (
+                "alexzhang_rlm_engine.py",
+                "test_alexzhang_rlm_engine.py",
+                "test_rlm_eval_fixtures.py",
+                "rlm_eval_harness.py",
+            )):
+                return False
+        if engine == "alexzhang" and not artifact.get("files_to_change"):
+            open_q = " ".join(str(q) for q in artifact.get("open_questions") or []).lower()
+            if "insufficient repo grounding" not in open_q:
+                return False
     return True
 
 
@@ -59,10 +79,10 @@ async def _run(engine: str) -> list[tuple[str, str, str, str, str, bool, str]]:
         notes = ""
         perms = (
             ContextExecPermissionV1(read_repo=True)
-            if case.mode == "repo_impact_analysis"
+            if case.mode in {"repo_impact_analysis", "patch_proposal"}
             else None
         )
-        overrides = repo_settings if case.mode == "repo_impact_analysis" else None
+        overrides = repo_settings if case.mode in {"repo_impact_analysis", "patch_proposal"} else None
         try:
             run = await run_eval_case(
                 engine,

--- a/services/orion-context-exec/README.md
+++ b/services/orion-context-exec/README.md
@@ -28,6 +28,8 @@ Context-exec is in **beta** for three investigative modes. Full runbook: [docs/c
 
 **Supported beta modes:** `belief_provenance`, `trace_autopsy`, `repo_impact_analysis` → artifacts `BeliefProvenanceReportV1`, `TraceAutopsyReportV1`, `RepoImpactAnalysisReportV1`.
 
+**Proposal-mode scaffold (not beta-certified):** `patch_proposal` → `PatchProposalV1`. It may emit structured patch blueprints; it may not execute changes, write files, or mutate runtime state. Proposal artifacts are not actions — Cortex/human approval and a separate executor are required before mutation.
+
 **Engine selection:** `fake` (default) | `alexzhang` (opt-in). Fallback must be explicit (`CONTEXT_EXEC_RLM_FALLBACK_ENABLED=true`) and visible in `runtime_debug`.
 
 **Safety defaults:** read-only, `CONTEXT_EXEC_MAX_DEPTH=1`, write/network off, compat AgentChain bus alias off.

--- a/services/orion-context-exec/app/alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/app/alexzhang_rlm_engine.py
@@ -39,7 +39,7 @@ _TRACE_SIGNAL_ORDER: tuple[tuple[tuple[str, ...], str], ...] = (
 
 logger = logging.getLogger("orion-context-exec.alexzhang_rlm_engine")
 
-SUPPORTED_MODES = frozenset({"belief_provenance", "trace_autopsy", "repo_impact_analysis"})
+SUPPORTED_MODES = frozenset({"belief_provenance", "trace_autopsy", "repo_impact_analysis", "patch_proposal"})
 
 
 class UnsupportedModeError(Exception):
@@ -211,6 +211,80 @@ _ENGINE_SELECTION_PATHS: tuple[str, ...] = (
     "rlm_eval_harness.py",
 )
 
+_TRACE_AUTOPSY_PATCH_ANCHORS: tuple[str, ...] = (
+    "_synthesize_trace_root_cause",
+    "_usable_trace_snippets",
+    "insufficient_trace_evidence",
+    "trace_autopsy",
+    "root_cause",
+)
+
+_PATCH_PROPOSAL_LIKELY_FILES: tuple[str, ...] = (
+    "alexzhang_rlm_engine.py",
+    "test_alexzhang_rlm_engine.py",
+    "test_rlm_eval_fixtures.py",
+    "rlm_eval_harness.py",
+)
+
+def _is_trace_autopsy_patch_query(text: str) -> bool:
+    lowered = text.lower()
+    if "trace autopsy" in lowered or "trace_autopsy" in lowered:
+        return True
+    if "trace-autopsy" in lowered:
+        return True
+    if "root cause" in lowered and ("trace" in lowered or "autopsy" in lowered):
+        return True
+    if "weak" in lowered and "trace" in lowered:
+        return True
+    return False
+
+
+def _is_repo_impact_patch_query(text: str) -> bool:
+    lowered = text.lower()
+    return "repo-impact" in lowered or "repo impact" in lowered or (
+        "repo" in lowered and "ground" in lowered and "patch" in lowered
+    )
+
+
+def _patch_proposal_search_terms(text: str) -> list[str]:
+    if _is_trace_autopsy_patch_query(text):
+        return list(_TRACE_AUTOPSY_PATCH_ANCHORS)
+    if _is_repo_impact_patch_query(text):
+        return list(_ENGINE_REPO_ANCHORS)
+    terms: list[str] = []
+    for token in re.findall(r"[A-Za-z][A-Za-z0-9_-]{2,}", text):
+        if token.lower() in {"propose", "patch", "weak", "diagnose", "context", "exec"}:
+            continue
+        terms.append(token)
+    return terms[:6] or list(_TRACE_AUTOPSY_PATCH_ANCHORS[:3])
+
+
+def _patch_proposal_risk(files: list[str]) -> str:
+    if not files:
+        return "unknown"
+    names = {path.rsplit("/", 1)[-1].lower() for path in files}
+    likely = frozenset(_PATCH_PROPOSAL_LIKELY_FILES)
+    if names & likely:
+        return "medium"
+    if len(files) > 3:
+        return "medium"
+    return "low"
+
+
+def _prioritize_patch_proposal_hits(hits: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def rank(h: dict[str, Any]) -> tuple[int, str]:
+        path = str(h.get("path") or "")
+        name = path.rsplit("/", 1)[-1].lower()
+        if name in _PATCH_PROPOSAL_LIKELY_FILES:
+            return (_PATCH_PROPOSAL_LIKELY_FILES.index(name), path)
+        for prefix in _CONTEXT_EXEC_APP_PREFIXES:
+            if path.lower().startswith(prefix):
+                return (len(_PATCH_PROPOSAL_LIKELY_FILES), path)
+        return (len(_PATCH_PROPOSAL_LIKELY_FILES) + 1, path)
+
+    return sorted(hits, key=rank)
+
+
 _CONTEXT_EXEC_APP_PREFIXES: tuple[str, ...] = (
     "services/orion-context-exec/app/",
     "app/",
@@ -374,6 +448,8 @@ class AlexZhangRLMEngine(RLMEngine):
             report = await self._belief_provenance(request, namespace, runtime, organ_cache)
         elif mode == "trace_autopsy":
             report = await self._trace_autopsy(request, namespace, runtime, organ_cache)
+        elif mode == "patch_proposal":
+            report = await self._patch_proposal(request, namespace, runtime, organ_cache)
         else:
             report = await self._repo_impact(request, namespace, runtime, organ_cache)
 
@@ -648,4 +724,105 @@ class AlexZhangRLMEngine(RLMEngine):
                 for h in hits
                 if isinstance(h, dict)
             ],
+        }
+
+    async def _patch_proposal(
+        self,
+        request: ContextExecRequestV1,
+        namespace: ContextNamespace,
+        runtime: OrganRuntime | None,
+        organ_cache: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        self._debug_steps.append("retrieve")
+        terms = _patch_proposal_search_terms(request.text)
+        hits: list[dict[str, Any]] = []
+        seen_paths: set[str] = set()
+        scoped_path = _engine_selection_grep_path()
+
+        for term in terms:
+            batch = await self._repo_grep_batch(
+                term,
+                request,
+                namespace,
+                runtime,
+                path=scoped_path,
+                limit=30,
+            )
+            _merge_repo_hits(hits, batch, seen_paths)
+
+        if not hits:
+            for term in terms[:4]:
+                batch = await self._repo_grep_batch(
+                    term,
+                    request,
+                    namespace,
+                    runtime,
+                    limit=30,
+                )
+                _merge_repo_hits(hits, batch, seen_paths)
+
+        hits = _prioritize_patch_proposal_hits(hits)
+        self._debug_steps.append("synthesize")
+
+        if not hits:
+            return {
+                "problem": request.text[:500],
+                "evidence": [],
+                "files_to_change": [],
+                "proposed_change_summary": "Insufficient repo evidence to propose a grounded patch.",
+                "risk": "unknown",
+                "tests_to_run": [],
+                "rollback_plan": "No changes proposed; no rollback required.",
+                "open_questions": ["insufficient repo grounding"],
+                "mutation_allowed": False,
+            }
+
+        files = [h.get("path") for h in hits if isinstance(h, dict) and h.get("path")][:12]
+        evidence = [
+            f"{h.get('path')}:{h.get('line_start')} {str(h.get('snippet', ''))[:120]}"
+            for h in hits
+            if isinstance(h, dict)
+        ][:8]
+        risk = _patch_proposal_risk(files)
+        tests = [
+            name
+            for name in _PATCH_PROPOSAL_LIKELY_FILES
+            if name.startswith("test_") and any(name in str(p) for p in files)
+        ]
+        if not tests:
+            tests = [
+                name
+                for name in ("test_alexzhang_rlm_engine.py", "test_rlm_eval_fixtures.py")
+                if any(name in str(p) for p in files)
+            ]
+        if not tests and any("alexzhang_rlm_engine.py" in str(p) for p in files):
+            tests = ["test_alexzhang_rlm_engine.py"]
+        if not tests:
+            tests = []
+            open_questions = ["tests_to_run unclear without grounded test file hits"]
+        else:
+            open_questions = []
+
+        summary_parts = []
+        if _is_trace_autopsy_patch_query(request.text):
+            summary_parts.append(
+                "Improve trace-autopsy root cause synthesis using grounded repo evidence"
+            )
+        elif _is_repo_impact_patch_query(request.text):
+            summary_parts.append("Strengthen repo-impact grounding for patch proposals")
+        else:
+            summary_parts.append("Apply targeted fixes based on grounded repo findings")
+        file_names = [str(p).rsplit("/", 1)[-1] for p in files[:4]]
+        summary_parts.append(f"Likely files: {', '.join(file_names)}")
+
+        return {
+            "problem": request.text[:500],
+            "evidence": evidence,
+            "files_to_change": files,
+            "proposed_change_summary": ". ".join(summary_parts),
+            "risk": risk,
+            "tests_to_run": tests,
+            "rollback_plan": "Revert proposed file changes via version control; no runtime mutation performed.",
+            "open_questions": open_questions,
+            "mutation_allowed": False,
         }

--- a/services/orion-context-exec/app/artifact_builder.py
+++ b/services/orion-context-exec/app/artifact_builder.py
@@ -9,6 +9,7 @@ from orion.schemas.context_exec import (
     ContextExecMode,
     ContextExecRequestV1,
     ContextExecRunV1,
+    PatchProposalV1,
     RepoImpactAnalysisReportV1,
     TraceAutopsyReportV1,
 )
@@ -19,6 +20,7 @@ def artifact_type_for_mode(mode: ContextExecMode) -> str | None:
         "belief_provenance": "BeliefProvenanceReportV1",
         "trace_autopsy": "TraceAutopsyReportV1",
         "repo_impact_analysis": "RepoImpactAnalysisReportV1",
+        "patch_proposal": "PatchProposalV1",
         "runtime_debug": "TraceAutopsyReportV1",
     }
     return mapping.get(mode)
@@ -34,6 +36,8 @@ def validate_artifact(mode: ContextExecMode, raw: Any) -> tuple[dict[str, Any], 
             model = TraceAutopsyReportV1.model_validate(raw)
         elif mode == "repo_impact_analysis":
             model = RepoImpactAnalysisReportV1.model_validate(raw)
+        elif mode == "patch_proposal":
+            model = PatchProposalV1.model_validate(raw)
         else:
             return raw, "GenericInvestigationV1", True
         return model.model_dump(mode="json"), model.__class__.__name__, True
@@ -104,4 +108,18 @@ def build_final_text(mode: ContextExecMode, artifact: dict[str, Any], *, status:
         path_names = [str(p).rsplit("/", 1)[-1] for p in paths[:4] if p]
         path_hint = f" Grounded files: {', '.join(path_names)}." if path_names else ""
         return f"Repo impact: {st}. Risk={risk}.{path_hint}"
+    if mode == "patch_proposal":
+        risk = artifact.get("risk", "unknown")
+        files = artifact.get("files_to_change") or []
+        if not files:
+            return (
+                "Patch proposal generated. Mutation is not allowed by context-exec. "
+                "Insufficient repo grounding; no files proposed."
+            )
+        path_names = [str(p).rsplit("/", 1)[-1] for p in files[:4] if p]
+        file_hint = ", ".join(path_names)
+        return (
+            f"Patch proposal generated. Mutation is not allowed by context-exec. "
+            f"Patch proposal: update {file_hint}. Risk={risk}. Mutation allowed=false."
+        )
     return str(artifact.get("summary") or artifact.get("target") or "Investigation complete.")

--- a/services/orion-context-exec/app/rlm_engine.py
+++ b/services/orion-context-exec/app/rlm_engine.py
@@ -210,6 +210,24 @@ class FakeRLMEngine(RLMEngine):
             namespace.FINAL_VAR("report")
             return namespace.get_final()
 
+        if mode == "patch_proposal":
+            report = {
+                "problem": "No grounded patch evidence available in fake engine",
+                "evidence": [],
+                "files_to_change": [],
+                "proposed_change_summary": (
+                    "Fake engine placeholder; use AlexZhang with read_repo for grounded patch proposals."
+                ),
+                "risk": "unknown",
+                "tests_to_run": [],
+                "rollback_plan": "No changes proposed; no rollback required.",
+                "open_questions": [],
+                "mutation_allowed": False,
+            }
+            namespace.set_local("report", report)
+            namespace.FINAL_VAR("report")
+            return namespace.get_final()
+
         report = {
             "summary": f"Investigation complete for: {request.text[:200]}",
             "mode": mode,

--- a/services/orion-context-exec/app/rlm_eval_harness.py
+++ b/services/orion-context-exec/app/rlm_eval_harness.py
@@ -25,6 +25,14 @@ BELIEF_STATUSES = frozenset(
 TRACE_STATUSES = frozenset({"explained", "partial", "unknown"})
 REPO_STATUSES = frozenset({"analyzed", "partial", "insufficient_grounding"})
 REPO_RISKS = frozenset({"low", "medium", "high", "unknown"})
+PATCH_PROPOSAL_RISKS = frozenset({"low", "medium", "high", "unknown"})
+
+PATCH_PROPOSAL_LIKELY_FILES = (
+    "alexzhang_rlm_engine.py",
+    "test_alexzhang_rlm_engine.py",
+    "test_rlm_eval_fixtures.py",
+    "rlm_eval_harness.py",
+)
 
 TRACE_REQUIRED_TERMS = (
     "fail open",
@@ -112,6 +120,14 @@ REPO_ENGINE_FILES_CASE = RlmEvalCase(
     expected_statuses=set(REPO_STATUSES),
 )
 
+PATCH_PROPOSAL_TRACE_AUTOPSY = RlmEvalCase(
+    name="patch_proposal_trace_autopsy_quality",
+    mode="patch_proposal",
+    text="Propose a patch for weak trace-autopsy root cause synthesis in context-exec.",
+    expected_artifact_type="PatchProposalV1",
+    expected_statuses=set(PATCH_PROPOSAL_RISKS),
+)
+
 ALL_EVAL_CASES = (
     BELIEF_DENVER,
     BELIEF_OGDEN,
@@ -119,6 +135,7 @@ ALL_EVAL_CASES = (
     TRACE_MISSING_CORR,
     REPO_AGENT_CHAIN,
     REPO_ENGINE_FILES_CASE,
+    PATCH_PROPOSAL_TRACE_AUTOPSY,
 )
 
 
@@ -150,6 +167,10 @@ def assert_safety_posture(run: ContextExecRunV1) -> None:
         assert rd["write_enabled"] is False
     if "network_enabled" in rd:
         assert rd["network_enabled"] is False
+    if "mutation_allowed" in rd:
+        assert rd["mutation_allowed"] is False
+    if run.artifact_type == "PatchProposalV1":
+        assert run.artifact.get("mutation_allowed") is False
     if "sandbox_mode" in rd:
         assert rd["sandbox_mode"] == "docker"
     if "rlm_depth" in rd:

--- a/services/orion-context-exec/app/runner.py
+++ b/services/orion-context-exec/app/runner.py
@@ -102,6 +102,7 @@ class ContextExecRunner:
             "write_enabled": settings.context_exec_write_enabled,
             "network_enabled": settings.context_exec_network_enabled,
             "shell_enabled": False,
+            "mutation_allowed": False,
             "mode": mode,
             "fake_organs_enabled": settings.context_exec_fake_organs_enabled,
             "real_trace_enabled": settings.context_exec_real_trace_enabled,

--- a/services/orion-context-exec/tests/test_patch_proposal.py
+++ b/services/orion-context-exec/tests/test_patch_proposal.py
@@ -1,0 +1,156 @@
+"""Patch proposal mode scaffold tests (read-only blueprint, no mutation)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from orion.schemas.context_exec import (
+    ContextExecPermissionV1,
+    ContextExecRequestV1,
+    PatchProposalV1,
+)
+
+from app.alexzhang_rlm_engine import AlexZhangRLMEngine
+from app.callable_namespace import ContextNamespace
+from app.repo_tools import RepoHit
+from app.rlm_engine import FakeRLMEngine
+from app.runner import ContextExecRunner, FAKE_ORGANS
+
+REPO_ROOT = __import__("os").path.abspath(
+    __import__("os").path.join(__import__("os").path.dirname(__file__), "..", "..", "..")
+)
+
+PATCH_PROMPT = (
+    "Propose a patch for weak trace-autopsy root cause synthesis in context-exec."
+)
+
+EXECUTION_FORBIDDEN_ARTIFACT_KEYS = frozenset(
+    {
+        "git_commit",
+        "git_push",
+        "apply_patch",
+        "write_enabled",
+        "shell_command",
+        "pr_create",
+    }
+)
+
+
+def test_patch_proposal_schema_defaults_to_no_mutation() -> None:
+    model = PatchProposalV1(
+        problem="weak synthesis",
+        proposed_change_summary="Improve root cause heuristics",
+        rollback_plan="Revert file edits",
+    )
+    assert model.mutation_allowed is False
+    assert model.risk == "unknown"
+    assert model.evidence == []
+    assert model.files_to_change == []
+    assert model.tests_to_run == []
+    assert model.open_questions == []
+
+
+@pytest.mark.asyncio
+async def test_fake_engine_patch_proposal_is_schema_valid_and_read_only() -> None:
+    engine = FakeRLMEngine()
+    ns = ContextNamespace(permissions=ContextExecPermissionV1())
+    req = ContextExecRequestV1(text=PATCH_PROMPT, mode="patch_proposal")
+    raw = await engine.run(req, ns)
+    model = PatchProposalV1.model_validate(raw)
+    assert model.mutation_allowed is False
+    assert model.risk == "unknown"
+    assert model.files_to_change == []
+    assert model.rollback_plan == "No changes proposed; no rollback required."
+
+
+@pytest.mark.asyncio
+async def test_alexzhang_patch_proposal_is_read_only_blueprint(monkeypatch) -> None:
+    fake_hits = [
+        {
+            "path": "services/orion-context-exec/app/alexzhang_rlm_engine.py",
+            "line_start": 162,
+            "snippet": "def _synthesize_trace_root_cause",
+            "source_ref": "repo:alexzhang:1",
+        },
+        {
+            "path": "services/orion-context-exec/tests/test_alexzhang_rlm_engine.py",
+            "line_start": 109,
+            "snippet": "mode=\"trace_autopsy\"",
+            "source_ref": "repo:test:1",
+        },
+    ]
+
+    def _stub_grep(pattern: str, path: str | None = None, limit: int = 50) -> list[RepoHit]:
+        return [RepoHit.model_validate(h) for h in fake_hits]
+
+    monkeypatch.setattr("app.repo_tools.repo_grep", _stub_grep)
+
+    engine = AlexZhangRLMEngine()
+    ns = ContextNamespace(permissions=ContextExecPermissionV1(read_repo=True))
+    req = ContextExecRequestV1(
+        text=PATCH_PROMPT,
+        mode="patch_proposal",
+        permissions=ContextExecPermissionV1(read_repo=True),
+    )
+    raw = await engine.run(req, ns)
+    model = PatchProposalV1.model_validate(raw)
+    assert model.mutation_allowed is False
+    grounded_refs = {str(h.get("path") or "") for h in fake_hits}
+    for path in model.files_to_change:
+        assert path in grounded_refs
+    assert model.tests_to_run or any(
+        "tests_to_run" in q.lower() or "ground" in q.lower() for q in model.open_questions
+    )
+
+
+@pytest.mark.asyncio
+async def test_patch_proposal_does_not_execute_or_request_mutation(monkeypatch) -> None:
+    monkeypatch.setattr("app.runner.settings.rlm_engine", "fake")
+    runner = ContextExecRunner()
+    req = ContextExecRequestV1(
+        text=PATCH_PROMPT,
+        mode="patch_proposal",
+        permissions=ContextExecPermissionV1(
+            write_memory=False,
+            write_graph=False,
+            write_repo=False,
+            mutate_runtime=False,
+            network_enabled=False,
+            shell_enabled=False,
+        ),
+    )
+    run = await runner.run(req)
+    assert run.status == "ok"
+    assert run.artifact_type == "PatchProposalV1"
+    assert run.artifact.get("mutation_allowed") is False
+    rd = run.runtime_debug
+    assert rd.get("schema_valid") is True
+    assert rd.get("write_enabled") is False
+    assert rd.get("network_enabled") is False
+    assert rd.get("mutation_allowed") is False
+    assert rd.get("rlm_depth", 99) <= 1
+
+    for key in EXECUTION_FORBIDDEN_ARTIFACT_KEYS:
+        assert key not in run.artifact
+    artifact_blob = json.dumps(run.artifact, default=str).lower()
+    assert '"write_enabled": true' not in artifact_blob
+    assert '"mutation_allowed": true' not in artifact_blob
+
+    for step in run.verb_trace:
+        summary = f"{step.verb} {step.callable or ''} {step.output_summary or ''}".lower()
+        assert "git commit" not in summary
+        assert "git push" not in summary
+        assert "gh pr create" not in summary
+        assert "apply patch now" not in summary
+
+
+@pytest.mark.asyncio
+async def test_runner_patch_proposal_final_text_boundary(monkeypatch) -> None:
+    monkeypatch.setattr("app.runner.settings.rlm_engine", "fake")
+    runner = ContextExecRunner()
+    req = ContextExecRequestV1(text=PATCH_PROMPT, mode="patch_proposal")
+    run = await runner.run(req)
+    assert "Mutation is not allowed by context-exec" in run.final_text
+    assert run.artifact.get("mutation_allowed") is False

--- a/services/orion-context-exec/tests/test_patch_proposal.py
+++ b/services/orion-context-exec/tests/test_patch_proposal.py
@@ -16,11 +16,7 @@ from app.alexzhang_rlm_engine import AlexZhangRLMEngine
 from app.callable_namespace import ContextNamespace
 from app.repo_tools import RepoHit
 from app.rlm_engine import FakeRLMEngine
-from app.runner import ContextExecRunner, FAKE_ORGANS
-
-REPO_ROOT = __import__("os").path.abspath(
-    __import__("os").path.join(__import__("os").path.dirname(__file__), "..", "..", "..")
-)
+from app.runner import ContextExecRunner
 
 PATCH_PROMPT = (
     "Propose a patch for weak trace-autopsy root cause synthesis in context-exec."

--- a/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
+++ b/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
@@ -7,6 +7,7 @@ import pytest
 from orion.schemas.context_exec import (
     BeliefProvenanceReportV1,
     ContextExecPermissionV1,
+    PatchProposalV1,
     RepoImpactAnalysisReportV1,
     TraceAutopsyReportV1,
 )
@@ -19,6 +20,8 @@ from app.rlm_eval_harness import (
     DENVER_CLAIM_FORBIDDEN,
     ENGINES,
     KNOWN_CORR,
+    PATCH_PROPOSAL_LIKELY_FILES,
+    PATCH_PROPOSAL_TRACE_AUTOPSY,
     REPO_AGENT_CHAIN,
     REPO_ENGINE_FILES,
     REPO_ENGINE_FILES_CASE,
@@ -207,7 +210,7 @@ async def test_rlm_eval_safety_posture_read_only(engine: str) -> None:
 
 
 def test_all_eval_cases_registered() -> None:
-    assert len(ALL_EVAL_CASES) == 6
+    assert len(ALL_EVAL_CASES) == 7
     assert {c.name for c in ALL_EVAL_CASES} == {
         "belief_provenance_denver",
         "belief_provenance_ogden",
@@ -215,4 +218,32 @@ def test_all_eval_cases_registered() -> None:
         "trace_autopsy_missing_corr",
         "repo_impact_agent_chain",
         "repo_impact_engine_files",
+        "patch_proposal_trace_autopsy_quality",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ENGINES)
+async def test_rlm_eval_patch_proposal_trace_autopsy_quality(
+    engine: str,
+    repo_settings: dict[str, object],
+) -> None:
+    perms = ContextExecPermissionV1(read_repo=True)
+    run = await run_eval_case(
+        engine,
+        PATCH_PROPOSAL_TRACE_AUTOPSY,
+        permissions=perms,
+        settings_overrides=repo_settings,
+    )
+    assert run.status == "ok"
+    model = PatchProposalV1.model_validate(run.artifact)
+    assert model.mutation_allowed is False
+    assert model.risk in {"low", "medium", "unknown"}
+    assert run.runtime_debug.get("mutation_allowed") is False
+
+    if engine == "alexzhang" and model.files_to_change:
+        blob = blob_text(run)
+        assert any(name.lower() in blob for name in PATCH_PROPOSAL_LIKELY_FILES)
+    if engine == "alexzhang" and not model.files_to_change:
+        open_q = " ".join(model.open_questions).lower()
+        assert "insufficient repo grounding" in open_q


### PR DESCRIPTION
## Summary

Adds `PatchProposalV1` and a read-only `patch_proposal` context-exec mode scaffold.

This introduces the first proposal artifact in the AgentChain replacement path. Context-exec can now generate a structured patch blueprint, but it cannot execute, write files, create branches, or mutate runtime state.

## Changes

- Add `PatchProposalV1` schema and registry entry.
- Add `patch_proposal` mode support in FakeRLMEngine and AlexZhangRLMEngine.
- Wire artifact validation/final text and `mutation_allowed=false` in `runtime_debug`.
- Add eval fixture `patch_proposal_trace_autopsy_quality`.
- Add tests proving patch proposals are schema-valid and mutation-disallowed.
- Update beta runbook / README with proposal-mode boundary.

## Verification

- `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/ -q` → 75 passed, 1 xfailed
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine fake` → `patch_proposal_trace_autopsy_quality quality_pass=True`
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine alexzhang` → `patch_proposal_trace_autopsy_quality quality_pass=True`
- `ORION_PY=.../orion_dev/bin/python bash scripts/context_exec_beta_gate.sh` → BETA GATE PASS

## Safety

- No routing changes
- No new organs
- No write/network/shell access
- No mutation (`mutation_allowed` always false)
- No branch creation, git operations, PR creation, or file mutation from context-exec

## Test plan

- [x] Schema defaults `mutation_allowed=false`
- [x] Fake engine returns safe placeholder `PatchProposalV1`
- [x] AlexZhang returns grounded blueprint from repo hits only
- [x] Execution guard test (no git/pr/write fields)
- [x] Eval fixture quality pass for fake + alexzhang
- [x] Existing investigative modes still pass beta gate