### PR TITLE
Feat/677 proposal envelope

### DIFF
--- a/docs/context-exec-beta-runbook.md
+++ b/docs/context-exec-beta-runbook.md
@@ -33,11 +33,13 @@ Other modes exist in schema (`runtime_debug`, `grammar_collision_audit`, etc.) b
 
 ### patch_proposal (proposal-mode scaffold)
 
-- **Purpose:** Emit a read-only patch blueprint (`PatchProposalV1`). Context-exec may **propose** mutation; it may **not perform** mutation.
+- **Purpose:** Emit a read-only patch blueprint wrapped in `ProposalEnvelopeV1`. Inner payload is `PatchProposalV1`. Context-exec may **propose** mutation; it may **not perform** mutation.
 - **Input shape:** Natural-language request to diagnose a weakness and propose a patch (e.g. weak trace-autopsy synthesis).
-- **Artifact type:** `PatchProposalV1` — fields include `problem`, `evidence`, `files_to_change`, `proposed_change_summary`, `risk`, `tests_to_run`, `rollback_plan`, `open_questions`, `mutation_allowed` (always `false` for context-exec output).
-- **Expected behavior:** Read-only repo grounding via existing organ hooks; schema-valid proposal; `mutation_allowed=false` in artifact and `runtime_debug`.
-- **Boundary:** Proposal artifacts are not actions. Executors are separate. Cortex/human approval is required before mutation.
+- **Artifact type:** `ProposalEnvelopeV1` — review envelope with `proposal_type`, `title`, `summary`, `evidence`, `risk`, `requires_human_approval` (always `true`), `mutation_allowed` (always `false`), `review_status` (`draft` or `pending_review` only from context-exec), inner `artifact_type=PatchProposalV1`, and nested `artifact` payload.
+- **Inner payload:** `PatchProposalV1` — `problem`, `evidence`, `files_to_change`, `proposed_change_summary`, `risk`, `tests_to_run`, `rollback_plan`, `open_questions`, `mutation_allowed` (always `false`).
+- **Review lifecycle:** `draft` → `pending_review` → (`approved` | `rejected` | `superseded`) → `executed` (by Cortex/human + separate executor only; context-exec never emits `approved` or `executed`).
+- **Expected behavior:** Read-only repo grounding via existing organ hooks; schema-valid envelope; `mutation_allowed=false` and `requires_human_approval=true` in artifact and `runtime_debug`; `proposal_enveloped=true` in `runtime_debug`.
+- **Boundary:** Proposal artifacts are not actions. Proposal envelopes are review objects. Executors are separate. Cortex/human approval is required before mutation. Context-exec may draft proposals, but it may not approve or execute them.
 - **Not beta-certified:** Eval fixtures exist; Hub/Cortex auto-routing is not wired in this release.
 
 ### belief_provenance
@@ -226,7 +228,7 @@ bash scripts/context_exec_beta_gate.sh --live
 
 - Only three modes are beta-certified; other schema modes are not eval/golden gated.
 - Legacy AgentChain fallback still active on cortex-exec when `CONTEXT_EXEC_LEGACY_FALLBACK=true`.
-- Proposal artifacts (`PatchProposalV1`, etc.) are documented but not implemented.
+- Proposal envelope scaffold (`ProposalEnvelopeV1` wrapping `PatchProposalV1`) is implemented for `patch_proposal`; other proposal types remain documented only.
 - AlexZhang engine requires opt-in; fake remains default.
 - Repo impact quality differs between fake (pattern grep) and alexzhang (engine-file grounding).
 - No write/network/shell; mutation is out of scope for beta.
@@ -288,15 +290,21 @@ Proposal-mode scaffold ( **partially implemented** ):
 
 | Proposal artifact | Status | Purpose |
 |-------------------|--------|---------|
-| `PatchProposalV1` | Scaffold (`patch_proposal` mode) | Propose code/doc patch — read-only blueprint only |
+| `ProposalEnvelopeV1` | Scaffold | Shared review wrapper for all proposal artifacts |
+| `PatchProposalV1` | Scaffold (inner payload) | Propose code/doc patch — read-only blueprint only |
 | `MemoryCorrectionProposalV1` | Not implemented | Propose memory correction |
 | `RuntimeConfigProposalV1` | Not implemented | Propose runtime config change |
 | `TestPlanProposalV1` | Not implemented | Propose test additions |
 
-`patch_proposal` is proposal-mode scaffold. It may emit `PatchProposalV1`. It may not execute changes.
+`patch_proposal` emits `ProposalEnvelopeV1` wrapping `PatchProposalV1`. It may not execute changes.
 
 **Rule:**
 
+- Proposal artifacts are not actions.
+- Proposal envelopes are review objects.
+- Executors are separate.
+- Cortex/human approval is required before mutation.
+- Context-exec may draft proposals, but it may not approve or execute them.
 - Context-exec may **propose** mutation.
 - Context-exec may **not perform** mutation.
 - Cortex/human gate approves.

--- a/orion/schemas/context_exec.py
+++ b/orion/schemas/context_exec.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -159,6 +160,30 @@ class RepoImpactAnalysisReportV1(BaseModel):
     findings: list[ContextExecFindingV1] = Field(default_factory=list)
 
 
+ProposalRiskLevel = Literal["low", "medium", "high", "unknown"]
+
+ProposalReviewState = Literal[
+    "draft",
+    "pending_review",
+    "approved",
+    "rejected",
+    "superseded",
+    "executed",
+]
+
+ContextExecCreatableReviewState = Literal["draft", "pending_review"]
+
+ProposalArtifactType = Literal[
+    "patch_proposal",
+    "memory_correction_proposal",
+    "runtime_config_proposal",
+    "test_plan_proposal",
+]
+
+# Context-exec may only create draft or pending_review envelopes.
+CONTEXT_EXEC_CREATABLE_REVIEW_STATES: frozenset[str] = frozenset({"draft", "pending_review"})
+
+
 class PatchProposalV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -166,11 +191,89 @@ class PatchProposalV1(BaseModel):
     evidence: list[str] = Field(default_factory=list)
     files_to_change: list[str] = Field(default_factory=list)
     proposed_change_summary: str
-    risk: Literal["low", "medium", "high", "unknown"] = "unknown"
+    risk: ProposalRiskLevel = "unknown"
     tests_to_run: list[str] = Field(default_factory=list)
     rollback_plan: str
     open_questions: list[str] = Field(default_factory=list)
     mutation_allowed: bool = False
+
+
+class ProposalEnvelopeV1(BaseModel):
+    """Shared review wrapper for context-exec proposal artifacts."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    proposal_id: str
+    proposal_type: ProposalArtifactType
+    source_mode: str
+    source_run_id: str | None = None
+    created_by: Literal["context-exec"] = "context-exec"
+    created_at: str | None = None
+
+    title: str
+    summary: str
+    evidence: list[str] = Field(default_factory=list)
+    risk: ProposalRiskLevel = "unknown"
+
+    requires_human_approval: bool = True
+    mutation_allowed: bool = False
+    review_status: ProposalReviewState = "draft"
+
+    artifact_type: str
+    artifact: dict[str, Any]
+
+    open_questions: list[str] = Field(default_factory=list)
+    safety_notes: list[str] = Field(default_factory=list)
+
+
+def assert_context_exec_proposal_safe(envelope: ProposalEnvelopeV1) -> None:
+    """Context-exec may only emit draft/pending_review envelopes with mutation disallowed."""
+    if envelope.review_status not in CONTEXT_EXEC_CREATABLE_REVIEW_STATES:
+        raise ValueError(
+            f"context-exec may only emit review_status in "
+            f"{sorted(CONTEXT_EXEC_CREATABLE_REVIEW_STATES)}; got {envelope.review_status!r}"
+        )
+    if envelope.mutation_allowed:
+        raise ValueError("context-exec proposals must set mutation_allowed=false")
+    if not envelope.requires_human_approval:
+        raise ValueError("context-exec proposals must set requires_human_approval=true")
+
+
+def build_patch_proposal_envelope(
+    patch: PatchProposalV1,
+    *,
+    source_mode: str,
+    source_run_id: str | None = None,
+    review_status: ContextExecCreatableReviewState = "draft",
+) -> ProposalEnvelopeV1:
+    """Wrap a PatchProposalV1 in a context-exec proposal envelope."""
+    inner = patch.model_dump(mode="json")
+    title = (patch.problem[:120] if patch.problem else "Patch proposal").strip()
+    envelope = ProposalEnvelopeV1(
+        proposal_id=f"prop_{uuid.uuid4().hex[:12]}",
+        proposal_type="patch_proposal",
+        source_mode=source_mode,
+        source_run_id=source_run_id,
+        title=title,
+        summary=patch.proposed_change_summary,
+        evidence=list(patch.evidence),
+        risk=patch.risk,
+        requires_human_approval=True,
+        mutation_allowed=False,
+        review_status=review_status,
+        artifact_type="PatchProposalV1",
+        artifact=inner,
+        open_questions=list(patch.open_questions),
+        safety_notes=[
+            "Proposal artifacts are not actions.",
+            "Proposal envelopes are review objects.",
+            "Executors are separate.",
+            "Cortex/human approval is required before mutation.",
+            "Context-exec may draft proposals, but it may not approve or execute them.",
+        ],
+    )
+    assert_context_exec_proposal_safe(envelope)
+    return envelope
 
 
 class ContextExecRunV1(BaseModel):

--- a/orion/schemas/context_exec.py
+++ b/orion/schemas/context_exec.py
@@ -237,6 +237,9 @@ def assert_context_exec_proposal_safe(envelope: ProposalEnvelopeV1) -> None:
         raise ValueError("context-exec proposals must set mutation_allowed=false")
     if not envelope.requires_human_approval:
         raise ValueError("context-exec proposals must set requires_human_approval=true")
+    inner = envelope.artifact
+    if isinstance(inner, dict) and inner.get("mutation_allowed"):
+        raise ValueError("inner proposal artifact must set mutation_allowed=false")
 
 
 def build_patch_proposal_envelope(
@@ -248,6 +251,7 @@ def build_patch_proposal_envelope(
 ) -> ProposalEnvelopeV1:
     """Wrap a PatchProposalV1 in a context-exec proposal envelope."""
     inner = patch.model_dump(mode="json")
+    inner["mutation_allowed"] = False
     title = (patch.problem[:120] if patch.problem else "Patch proposal").strip()
     envelope = ProposalEnvelopeV1(
         proposal_id=f"prop_{uuid.uuid4().hex[:12]}",

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -70,6 +70,7 @@ from orion.schemas.context_exec import (
     ContextExecRunV1,
     ContextExecVerbStepV1,
     PatchProposalV1,
+    ProposalEnvelopeV1,
     RepoImpactAnalysisReportV1,
     TraceAutopsyReportV1,
 )
@@ -1041,6 +1042,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "TraceAutopsyReportV1": TraceAutopsyReportV1,
     "RepoImpactAnalysisReportV1": RepoImpactAnalysisReportV1,
     "PatchProposalV1": PatchProposalV1,
+    "ProposalEnvelopeV1": ProposalEnvelopeV1,
 
 }
 

--- a/scripts/context_exec_rlm_eval.py
+++ b/scripts/context_exec_rlm_eval.py
@@ -31,6 +31,16 @@ from app.rlm_eval_harness import (  # noqa: E402
 )
 
 
+def _inner_patch_artifact(artifact: dict) -> dict:
+    if artifact.get("artifact_type") == "PatchProposalV1":
+        return artifact
+    if artifact.get("artifact_type") == "PatchProposalV1" or artifact.get("proposal_type") == "patch_proposal":
+        inner = artifact.get("artifact") or {}
+        if isinstance(inner, dict):
+            return inner
+    return artifact
+
+
 def _quality_pass(case_name: str, engine: str, run) -> bool:
     if run.status != "ok":
         return False
@@ -46,13 +56,24 @@ def _quality_pass(case_name: str, engine: str, run) -> bool:
             return False
     if case_name == "patch_proposal_trace_autopsy_quality":
         artifact = run.artifact or {}
+        if run.artifact_type != "ProposalEnvelopeV1":
+            return False
+        if artifact.get("proposal_type") != "patch_proposal":
+            return False
+        if artifact.get("artifact_type") != "PatchProposalV1":
+            return False
         if artifact.get("mutation_allowed") is not False:
             return False
-        risk = str(artifact.get("risk") or "unknown")
+        if artifact.get("requires_human_approval") is not True:
+            return False
+        if artifact.get("review_status") not in {"draft", "pending_review"}:
+            return False
+        inner = _inner_patch_artifact(artifact)
+        risk = str(inner.get("risk") or artifact.get("risk") or "unknown")
         if risk not in {"low", "medium", "unknown"}:
             return False
-        if engine == "alexzhang" and artifact.get("files_to_change"):
-            blob = " ".join(str(p) for p in artifact.get("files_to_change") or []).lower()
+        if engine == "alexzhang" and inner.get("files_to_change"):
+            blob = " ".join(str(p) for p in inner.get("files_to_change") or []).lower()
             if not any(name.lower() in blob for name in (
                 "alexzhang_rlm_engine.py",
                 "test_alexzhang_rlm_engine.py",
@@ -60,15 +81,15 @@ def _quality_pass(case_name: str, engine: str, run) -> bool:
                 "rlm_eval_harness.py",
             )):
                 return False
-        if engine == "alexzhang" and not artifact.get("files_to_change"):
-            open_q = " ".join(str(q) for q in artifact.get("open_questions") or []).lower()
+        if engine == "alexzhang" and not inner.get("files_to_change"):
+            open_q = " ".join(str(q) for q in inner.get("open_questions") or []).lower()
             if "insufficient repo grounding" not in open_q:
                 return False
     return True
 
 
-async def _run(engine: str) -> list[tuple[str, str, str, str, str, bool, str]]:
-    rows: list[tuple[str, str, str, str, str, bool, str]] = []
+async def _run(engine: str) -> list[tuple]:
+    rows: list[tuple] = []
     repo_settings = {
         "context_exec_repo_root": REPO_ROOT,
         "orion_repo_root": REPO_ROOT,
@@ -90,25 +111,54 @@ async def _run(engine: str) -> list[tuple[str, str, str, str, str, bool, str]]:
                 permissions=perms,
                 settings_overrides=overrides,
             )
-            artifact_status = str((run.artifact or {}).get("status", run.status))
+            artifact = run.artifact or {}
+            inner = _inner_patch_artifact(artifact)
+            artifact_status = str(inner.get("status", artifact.get("status", run.status)))
             quality = _quality_pass(case.name, engine, run)
+            proposal_type = str(artifact.get("proposal_type") or "")
+            inner_artifact_type = str(artifact.get("artifact_type") or "")
+            review_status = str(artifact.get("review_status") or "")
+            mutation_allowed = artifact.get("mutation_allowed")
+            requires_human_approval = artifact.get("requires_human_approval")
         except Exception as exc:
             artifact_status = "error"
             quality = False
             notes = str(exc)
             run = None
+            proposal_type = ""
+            inner_artifact_type = ""
+            review_status = ""
+            mutation_allowed = ""
+            requires_human_approval = ""
         if run is not None:
-            rows.append(
-                (
-                    case.name,
-                    engine,
-                    case.mode,
-                    artifact_status,
-                    str(run.artifact_type or ""),
-                    quality,
-                    notes,
+            if case.mode == "patch_proposal":
+                rows.append(
+                    (
+                        case.name,
+                        engine,
+                        case.mode,
+                        quality,
+                        str(run.artifact_type or ""),
+                        proposal_type,
+                        inner_artifact_type,
+                        review_status,
+                        mutation_allowed,
+                        requires_human_approval,
+                        notes,
+                    )
                 )
-            )
+            else:
+                rows.append(
+                    (
+                        case.name,
+                        engine,
+                        case.mode,
+                        artifact_status,
+                        str(run.artifact_type or ""),
+                        quality,
+                        notes,
+                    )
+                )
     return rows
 
 
@@ -118,7 +168,23 @@ def main() -> int:
     args = parser.parse_args()
 
     rows = asyncio.run(_run(args.engine))
-    header = ("case", "engine", "mode", "status", "artifact_type", "quality_pass", "notes")
+    has_proposal = any(c.mode == "patch_proposal" for c in ALL_EVAL_CASES)
+    if has_proposal:
+        header = (
+            "case",
+            "engine",
+            "mode",
+            "quality_pass",
+            "artifact_type",
+            "proposal_type",
+            "inner_artifact_type",
+            "review_status",
+            "mutation_allowed",
+            "requires_human_approval",
+            "notes",
+        )
+    else:
+        header = ("case", "engine", "mode", "status", "artifact_type", "quality_pass", "notes")
     print(" | ".join(header))
     for row in rows:
         print(" | ".join(str(c) for c in row))

--- a/scripts/context_exec_rlm_eval.py
+++ b/scripts/context_exec_rlm_eval.py
@@ -32,12 +32,11 @@ from app.rlm_eval_harness import (  # noqa: E402
 
 
 def _inner_patch_artifact(artifact: dict) -> dict:
-    if artifact.get("artifact_type") == "PatchProposalV1":
-        return artifact
-    if artifact.get("artifact_type") == "PatchProposalV1" or artifact.get("proposal_type") == "patch_proposal":
+    if artifact.get("proposal_type") == "patch_proposal":
         inner = artifact.get("artifact") or {}
-        if isinstance(inner, dict):
-            return inner
+        return inner if isinstance(inner, dict) else artifact
+    if artifact.get("artifact_type") == "PatchProposalV1" and "proposal_id" not in artifact:
+        return artifact
     return artifact
 
 

--- a/services/orion-context-exec/README.md
+++ b/services/orion-context-exec/README.md
@@ -28,7 +28,7 @@ Context-exec is in **beta** for three investigative modes. Full runbook: [docs/c
 
 **Supported beta modes:** `belief_provenance`, `trace_autopsy`, `repo_impact_analysis` → artifacts `BeliefProvenanceReportV1`, `TraceAutopsyReportV1`, `RepoImpactAnalysisReportV1`.
 
-**Proposal-mode scaffold (not beta-certified):** `patch_proposal` → `PatchProposalV1`. It may emit structured patch blueprints; it may not execute changes, write files, or mutate runtime state. Proposal artifacts are not actions — Cortex/human approval and a separate executor are required before mutation.
+**Proposal-mode scaffold (not beta-certified):** `patch_proposal` → `ProposalEnvelopeV1` wrapping `PatchProposalV1`. It may emit structured patch blueprints inside a review envelope; it may not execute changes, write files, or mutate runtime state. Proposal artifacts are not actions. Proposal envelopes are review objects. Executors are separate. Cortex/human approval is required before mutation. Context-exec may draft proposals, but it may not approve or execute them.
 
 **Engine selection:** `fake` (default) | `alexzhang` (opt-in). Fallback must be explicit (`CONTEXT_EXEC_RLM_FALLBACK_ENABLED=true`) and visible in `runtime_debug`.
 

--- a/services/orion-context-exec/app/artifact_builder.py
+++ b/services/orion-context-exec/app/artifact_builder.py
@@ -10,8 +10,10 @@ from orion.schemas.context_exec import (
     ContextExecRequestV1,
     ContextExecRunV1,
     PatchProposalV1,
+    ProposalEnvelopeV1,
     RepoImpactAnalysisReportV1,
     TraceAutopsyReportV1,
+    build_patch_proposal_envelope,
 )
 
 
@@ -20,10 +22,19 @@ def artifact_type_for_mode(mode: ContextExecMode) -> str | None:
         "belief_provenance": "BeliefProvenanceReportV1",
         "trace_autopsy": "TraceAutopsyReportV1",
         "repo_impact_analysis": "RepoImpactAnalysisReportV1",
-        "patch_proposal": "PatchProposalV1",
+        "patch_proposal": "ProposalEnvelopeV1",
         "runtime_debug": "TraceAutopsyReportV1",
     }
     return mapping.get(mode)
+
+
+def _wrap_patch_proposal(raw: dict[str, Any], mode: ContextExecMode) -> tuple[dict[str, Any], str, bool]:
+    try:
+        patch = PatchProposalV1.model_validate(raw)
+        envelope = build_patch_proposal_envelope(patch, source_mode=mode)
+        return envelope.model_dump(mode="json"), "ProposalEnvelopeV1", True
+    except Exception:
+        return raw, "PatchProposalV1", False
 
 
 def validate_artifact(mode: ContextExecMode, raw: Any) -> tuple[dict[str, Any], str | None, bool]:
@@ -37,7 +48,7 @@ def validate_artifact(mode: ContextExecMode, raw: Any) -> tuple[dict[str, Any], 
         elif mode == "repo_impact_analysis":
             model = RepoImpactAnalysisReportV1.model_validate(raw)
         elif mode == "patch_proposal":
-            model = PatchProposalV1.model_validate(raw)
+            return _wrap_patch_proposal(raw, mode)
         else:
             return raw, "GenericInvestigationV1", True
         return model.model_dump(mode="json"), model.__class__.__name__, True
@@ -52,9 +63,17 @@ def synthesize_findings_bundle(
     schema_valid: bool,
 ) -> FindingsBundle | None:
     ac = request.answer_contract
-    if ac is None and not (artifact.get("findings") or artifact.get("evidence")):
+    findings_source = artifact
+    if request.mode == "patch_proposal" and artifact.get("artifact_type") == "PatchProposalV1":
+        findings_source = artifact.get("artifact") or {}
+    if ac is None and not (findings_source.get("findings") or findings_source.get("evidence") or artifact.get("evidence")):
         return None
-    raw_findings: list[Any] = list(artifact.get("findings") or artifact.get("evidence") or [])
+    raw_findings: list[Any] = list(
+        findings_source.get("findings")
+        or findings_source.get("evidence")
+        or artifact.get("evidence")
+        or []
+    )
     findings: list[Finding] = []
     verified_count = 0
     for item in raw_findings:
@@ -109,8 +128,9 @@ def build_final_text(mode: ContextExecMode, artifact: dict[str, Any], *, status:
         path_hint = f" Grounded files: {', '.join(path_names)}." if path_names else ""
         return f"Repo impact: {st}. Risk={risk}.{path_hint}"
     if mode == "patch_proposal":
-        risk = artifact.get("risk", "unknown")
-        files = artifact.get("files_to_change") or []
+        inner = artifact.get("artifact") if artifact.get("artifact_type") == "PatchProposalV1" else artifact
+        risk = artifact.get("risk", inner.get("risk", "unknown"))
+        files = inner.get("files_to_change") or []
         if not files:
             return (
                 "Patch proposal generated. Mutation is not allowed by context-exec. "

--- a/services/orion-context-exec/app/rlm_eval_harness.py
+++ b/services/orion-context-exec/app/rlm_eval_harness.py
@@ -124,7 +124,7 @@ PATCH_PROPOSAL_TRACE_AUTOPSY = RlmEvalCase(
     name="patch_proposal_trace_autopsy_quality",
     mode="patch_proposal",
     text="Propose a patch for weak trace-autopsy root cause synthesis in context-exec.",
-    expected_artifact_type="PatchProposalV1",
+    expected_artifact_type="ProposalEnvelopeV1",
     expected_statuses=set(PATCH_PROPOSAL_RISKS),
 )
 
@@ -169,6 +169,13 @@ def assert_safety_posture(run: ContextExecRunV1) -> None:
         assert rd["network_enabled"] is False
     if "mutation_allowed" in rd:
         assert rd["mutation_allowed"] is False
+    if run.artifact_type == "ProposalEnvelopeV1":
+        assert run.artifact.get("mutation_allowed") is False
+        assert run.artifact.get("requires_human_approval") is True
+        assert run.artifact.get("review_status") in {"draft", "pending_review"}
+        inner = run.artifact.get("artifact") or {}
+        if run.artifact.get("artifact_type") == "PatchProposalV1":
+            assert inner.get("mutation_allowed") is False
     if run.artifact_type == "PatchProposalV1":
         assert run.artifact.get("mutation_allowed") is False
     if "sandbox_mode" in rd:

--- a/services/orion-context-exec/app/runner.py
+++ b/services/orion-context-exec/app/runner.py
@@ -289,6 +289,20 @@ class ContextExecRunner:
         final_text = build_final_text(request.mode, artifact, status=status)
         ac_dump = request.answer_contract.model_dump(mode="json") if request.answer_contract else None
 
+        runtime_debug = self._engine_runtime_debug(
+            engine_used=engine_used,
+            fallback_engine=fallback_engine,
+            fallback_reason=fallback_reason,
+            subcalls=subcalls,
+            schema_valid=schema_valid,
+            mode=request.mode,
+            extra_steps=rlm_steps or None,
+        )
+        if request.mode == "patch_proposal" and schema_valid and artifact_type == "ProposalEnvelopeV1":
+            runtime_debug["proposal_enveloped"] = True
+            runtime_debug["requires_human_approval"] = artifact.get("requires_human_approval", True)
+            runtime_debug["mutation_allowed"] = artifact.get("mutation_allowed", False)
+
         await events.finished(
             run_id=run_id,
             mode=request.mode,
@@ -310,15 +324,7 @@ class ContextExecRunner:
             final_text=final_text,
             verb_trace=verb_trace,
             runtime_debug={
-                **self._engine_runtime_debug(
-                    engine_used=engine_used,
-                    fallback_engine=fallback_engine,
-                    fallback_reason=fallback_reason,
-                    subcalls=subcalls,
-                    schema_valid=schema_valid,
-                    mode=request.mode,
-                    extra_steps=rlm_steps or None,
-                ),
+                **runtime_debug,
                 "correlation_id": request.correlation_id,
             },
             failure_modes=failure_modes,

--- a/services/orion-context-exec/tests/test_patch_proposal.py
+++ b/services/orion-context-exec/tests/test_patch_proposal.py
@@ -10,9 +10,12 @@ from orion.schemas.context_exec import (
     ContextExecPermissionV1,
     ContextExecRequestV1,
     PatchProposalV1,
+    ProposalEnvelopeV1,
+    build_patch_proposal_envelope,
 )
 
 from app.alexzhang_rlm_engine import AlexZhangRLMEngine
+from app.artifact_builder import validate_artifact
 from app.callable_namespace import ContextNamespace
 from app.repo_tools import RepoHit
 from app.rlm_engine import FakeRLMEngine
@@ -34,6 +37,16 @@ EXECUTION_FORBIDDEN_ARTIFACT_KEYS = frozenset(
 )
 
 
+def _assert_proposal_envelope_contract(envelope: ProposalEnvelopeV1) -> None:
+    assert envelope.proposal_type == "patch_proposal"
+    assert envelope.artifact_type == "PatchProposalV1"
+    assert envelope.mutation_allowed is False
+    assert envelope.requires_human_approval is True
+    assert envelope.review_status in {"draft", "pending_review"}
+    inner = PatchProposalV1.model_validate(envelope.artifact)
+    assert inner.mutation_allowed is False
+
+
 def test_patch_proposal_schema_defaults_to_no_mutation() -> None:
     model = PatchProposalV1(
         problem="weak synthesis",
@@ -49,20 +62,24 @@ def test_patch_proposal_schema_defaults_to_no_mutation() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fake_engine_patch_proposal_is_schema_valid_and_read_only() -> None:
+async def test_fake_engine_patch_proposal_returns_proposal_envelope() -> None:
     engine = FakeRLMEngine()
     ns = ContextNamespace(permissions=ContextExecPermissionV1())
     req = ContextExecRequestV1(text=PATCH_PROMPT, mode="patch_proposal")
     raw = await engine.run(req, ns)
-    model = PatchProposalV1.model_validate(raw)
-    assert model.mutation_allowed is False
-    assert model.risk == "unknown"
-    assert model.files_to_change == []
-    assert model.rollback_plan == "No changes proposed; no rollback required."
+    artifact, artifact_type, valid = validate_artifact("patch_proposal", raw)
+    assert valid is True
+    assert artifact_type == "ProposalEnvelopeV1"
+    envelope = ProposalEnvelopeV1.model_validate(artifact)
+    _assert_proposal_envelope_contract(envelope)
+    inner = PatchProposalV1.model_validate(envelope.artifact)
+    assert inner.risk == "unknown"
+    assert inner.files_to_change == []
+    assert inner.rollback_plan == "No changes proposed; no rollback required."
 
 
 @pytest.mark.asyncio
-async def test_alexzhang_patch_proposal_is_read_only_blueprint(monkeypatch) -> None:
+async def test_alexzhang_patch_proposal_returns_proposal_envelope(monkeypatch) -> None:
     fake_hits = [
         {
             "path": "services/orion-context-exec/app/alexzhang_rlm_engine.py",
@@ -91,13 +108,17 @@ async def test_alexzhang_patch_proposal_is_read_only_blueprint(monkeypatch) -> N
         permissions=ContextExecPermissionV1(read_repo=True),
     )
     raw = await engine.run(req, ns)
-    model = PatchProposalV1.model_validate(raw)
-    assert model.mutation_allowed is False
+    artifact, artifact_type, valid = validate_artifact("patch_proposal", raw)
+    assert valid is True
+    assert artifact_type == "ProposalEnvelopeV1"
+    envelope = ProposalEnvelopeV1.model_validate(artifact)
+    _assert_proposal_envelope_contract(envelope)
+    inner = PatchProposalV1.model_validate(envelope.artifact)
     grounded_refs = {str(h.get("path") or "") for h in fake_hits}
-    for path in model.files_to_change:
+    for path in inner.files_to_change:
         assert path in grounded_refs
-    assert model.tests_to_run or any(
-        "tests_to_run" in q.lower() or "ground" in q.lower() for q in model.open_questions
+    assert inner.tests_to_run or any(
+        "tests_to_run" in q.lower() or "ground" in q.lower() for q in inner.open_questions
     )
 
 
@@ -119,13 +140,16 @@ async def test_patch_proposal_does_not_execute_or_request_mutation(monkeypatch) 
     )
     run = await runner.run(req)
     assert run.status == "ok"
-    assert run.artifact_type == "PatchProposalV1"
-    assert run.artifact.get("mutation_allowed") is False
+    assert run.artifact_type == "ProposalEnvelopeV1"
+    envelope = ProposalEnvelopeV1.model_validate(run.artifact)
+    _assert_proposal_envelope_contract(envelope)
     rd = run.runtime_debug
     assert rd.get("schema_valid") is True
+    assert rd.get("proposal_enveloped") is True
     assert rd.get("write_enabled") is False
     assert rd.get("network_enabled") is False
     assert rd.get("mutation_allowed") is False
+    assert rd.get("requires_human_approval") is True
     assert rd.get("rlm_depth", 99) <= 1
 
     for key in EXECUTION_FORBIDDEN_ARTIFACT_KEYS:
@@ -149,4 +173,15 @@ async def test_runner_patch_proposal_final_text_boundary(monkeypatch) -> None:
     req = ContextExecRequestV1(text=PATCH_PROMPT, mode="patch_proposal")
     run = await runner.run(req)
     assert "Mutation is not allowed by context-exec" in run.final_text
-    assert run.artifact.get("mutation_allowed") is False
+    envelope = ProposalEnvelopeV1.model_validate(run.artifact)
+    assert envelope.mutation_allowed is False
+
+
+def test_build_patch_proposal_envelope_rejects_self_approval() -> None:
+    patch = PatchProposalV1(
+        problem="p",
+        proposed_change_summary="s",
+        rollback_plan="r",
+    )
+    envelope = build_patch_proposal_envelope(patch, source_mode="patch_proposal")
+    assert envelope.review_status == "draft"

--- a/services/orion-context-exec/tests/test_proposal_envelope.py
+++ b/services/orion-context-exec/tests/test_proposal_envelope.py
@@ -1,0 +1,76 @@
+"""ProposalEnvelopeV1 and proposal review contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from orion.schemas.context_exec import (
+    CONTEXT_EXEC_CREATABLE_REVIEW_STATES,
+    PatchProposalV1,
+    ProposalEnvelopeV1,
+    assert_context_exec_proposal_safe,
+    build_patch_proposal_envelope,
+)
+from orion.schemas.registry import _REGISTRY
+
+
+def test_proposal_envelope_defaults_require_review_and_disallow_mutation() -> None:
+    envelope = ProposalEnvelopeV1(
+        proposal_id="prop_test",
+        proposal_type="patch_proposal",
+        source_mode="patch_proposal",
+        title="Test proposal",
+        summary="Summary",
+        artifact_type="PatchProposalV1",
+        artifact={
+            "problem": "p",
+            "proposed_change_summary": "s",
+            "rollback_plan": "r",
+            "mutation_allowed": False,
+        },
+    )
+    assert envelope.mutation_allowed is False
+    assert envelope.requires_human_approval is True
+    assert envelope.review_status in CONTEXT_EXEC_CREATABLE_REVIEW_STATES
+
+
+def test_proposal_envelope_registered_with_context_exec_schemas() -> None:
+    assert _REGISTRY["ProposalEnvelopeV1"] is ProposalEnvelopeV1
+    assert _REGISTRY["PatchProposalV1"] is PatchProposalV1
+    assert _REGISTRY["BeliefProvenanceReportV1"] is not None
+    assert _REGISTRY["TraceAutopsyReportV1"] is not None
+    assert _REGISTRY["RepoImpactAnalysisReportV1"] is not None
+
+
+def test_build_patch_proposal_envelope_wraps_inner_payload() -> None:
+    patch = PatchProposalV1(
+        problem="weak synthesis",
+        proposed_change_summary="Improve heuristics",
+        rollback_plan="Revert edits",
+    )
+    envelope = build_patch_proposal_envelope(patch, source_mode="patch_proposal")
+    assert envelope.proposal_type == "patch_proposal"
+    assert envelope.artifact_type == "PatchProposalV1"
+    assert envelope.artifact["mutation_allowed"] is False
+    assert envelope.mutation_allowed is False
+    assert envelope.requires_human_approval is True
+    assert envelope.review_status in {"draft", "pending_review"}
+
+
+def test_context_exec_proposal_cannot_self_approve_or_execute() -> None:
+    patch = PatchProposalV1(
+        problem="p",
+        proposed_change_summary="s",
+        rollback_plan="r",
+    )
+    envelope = build_patch_proposal_envelope(patch, source_mode="patch_proposal")
+    assert envelope.review_status not in {"approved", "executed"}
+    assert envelope.mutation_allowed is False
+
+    bad_envelope = envelope.model_copy(update={"review_status": "approved"})
+    with pytest.raises(ValueError, match="review_status"):
+        assert_context_exec_proposal_safe(bad_envelope)
+
+    bad_mutation = envelope.model_copy(update={"mutation_allowed": True})
+    with pytest.raises(ValueError, match="mutation_allowed"):
+        assert_context_exec_proposal_safe(bad_mutation)

--- a/services/orion-context-exec/tests/test_proposal_envelope.py
+++ b/services/orion-context-exec/tests/test_proposal_envelope.py
@@ -57,6 +57,17 @@ def test_build_patch_proposal_envelope_wraps_inner_payload() -> None:
     assert envelope.review_status in {"draft", "pending_review"}
 
 
+def test_build_patch_proposal_envelope_sanitizes_inner_mutation_allowed() -> None:
+    patch = PatchProposalV1(
+        problem="p",
+        proposed_change_summary="s",
+        rollback_plan="r",
+        mutation_allowed=True,
+    )
+    envelope = build_patch_proposal_envelope(patch, source_mode="patch_proposal")
+    assert envelope.artifact["mutation_allowed"] is False
+
+
 def test_context_exec_proposal_cannot_self_approve_or_execute() -> None:
     patch = PatchProposalV1(
         problem="p",
@@ -74,3 +85,13 @@ def test_context_exec_proposal_cannot_self_approve_or_execute() -> None:
     bad_mutation = envelope.model_copy(update={"mutation_allowed": True})
     with pytest.raises(ValueError, match="mutation_allowed"):
         assert_context_exec_proposal_safe(bad_mutation)
+
+    bad_approval = envelope.model_copy(update={"requires_human_approval": False})
+    with pytest.raises(ValueError, match="requires_human_approval"):
+        assert_context_exec_proposal_safe(bad_approval)
+
+    bad_inner = envelope.model_copy(
+        update={"artifact": {**envelope.artifact, "mutation_allowed": True}}
+    )
+    with pytest.raises(ValueError, match="inner proposal artifact"):
+        assert_context_exec_proposal_safe(bad_inner)

--- a/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
+++ b/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
@@ -7,6 +7,7 @@ import pytest
 from orion.schemas.context_exec import (
     BeliefProvenanceReportV1,
     ContextExecPermissionV1,
+    ProposalEnvelopeV1,
     PatchProposalV1,
     RepoImpactAnalysisReportV1,
     TraceAutopsyReportV1,
@@ -236,10 +237,17 @@ async def test_rlm_eval_patch_proposal_trace_autopsy_quality(
         settings_overrides=repo_settings,
     )
     assert run.status == "ok"
-    model = PatchProposalV1.model_validate(run.artifact)
+    envelope = ProposalEnvelopeV1.model_validate(run.artifact)
+    assert envelope.proposal_type == "patch_proposal"
+    assert envelope.artifact_type == "PatchProposalV1"
+    assert envelope.mutation_allowed is False
+    assert envelope.requires_human_approval is True
+    assert envelope.review_status in {"draft", "pending_review"}
+    model = PatchProposalV1.model_validate(envelope.artifact)
     assert model.mutation_allowed is False
     assert model.risk in {"low", "medium", "unknown"}
     assert run.runtime_debug.get("mutation_allowed") is False
+    assert run.runtime_debug.get("proposal_enveloped") is True
 
     if engine == "alexzhang" and model.files_to_change:
         blob = blob_text(run)


### PR DESCRIPTION
## Summary

Adds `ProposalEnvelopeV1` and the shared proposal review contract for context-exec proposal artifacts.

This wraps `PatchProposalV1` in a common review envelope so future proposal types can share the same policy rail: proposal identity, source mode, evidence, risk, review status, approval requirement, and mutation boundary.

## Changes

- Add `ProposalEnvelopeV1` with review-state contract (`draft` / `pending_review` only from context-exec).
- Register/export `ProposalEnvelopeV1` and verify `PatchProposalV1` remains registered in `orion/schemas/registry.py`.
- Wrap `patch_proposal` output in `ProposalEnvelopeV1` via `artifact_builder` (engines still emit inner `PatchProposalV1` dicts).
- Inner `mutation_allowed` forced false; envelope-level safety checks reject self-approval and inner mutation.
- Add tests proving proposal envelopes require human approval and disallow mutation.
- Update eval harness, CLI output (proposal envelope fields), beta gate docs/README.

## Verification

- `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/ -q` — 81 passed, 1 xfailed
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine fake` — patch_proposal quality_pass=True
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine alexzhang` — patch_proposal quality_pass=True
- `ORION_PY=orion_dev/bin/python bash scripts/context_exec_beta_gate.sh` — BETA GATE PASS
- `rg "ProposalEnvelopeV1|PatchProposalV1" orion/schemas` — both in registry

## Safety

- No routing changes
- No new organs
- No write/network/shell access
- No mutation
- No approval endpoint
- No executor
- Context-exec cannot approve or execute its own proposals