### PR TITLE
Fix spark telemetry upsert metadata json/jsonb coercion.

### DIFF
--- a/services/orion-sql-writer/app/spark_telemetry_persist.py
+++ b/services/orion-sql-writer/app/spark_telemetry_persist.py
@@ -30,7 +30,8 @@ def upsert_spark_telemetry(sess: Session, data: dict[str, Any]) -> bool:
         "stimulus_summary": stmt.excluded.stimulus_summary,
         "timestamp": stmt.excluded.timestamp,
         "metadata_": text(
-            "COALESCE(spark_telemetry.metadata, '{}'::jsonb) || COALESCE(EXCLUDED.metadata, '{}'::jsonb)"
+            "(COALESCE(spark_telemetry.metadata::jsonb, '{}'::jsonb) "
+            "|| COALESCE(EXCLUDED.metadata::jsonb, '{}'::jsonb))::json"
         ),
     }
     stmt = stmt.on_conflict_do_update(


### PR DESCRIPTION
:

## Summary
Follow-up to #670. Spark telemetry idempotent upserts were failing at runtime with:
COALESCE could not convert type jsonb to json

`spark_telemetry.metadata` is a `json` column; the ON CONFLICT merge used `jsonb` literals without casting. This caused ~28 spark fallbacks per 30 minutes while grammar persistence remained healthy.
## Fix
Cast existing and excluded metadata through `jsonb` for merge, then cast the result back to `json` before writing the column.
## Test plan
- [x] `./scripts/test_service.sh orion-sql-writer services/orion-sql-writer/tests/test_spark_telemetry_idempotency.py -q` (3 passed)
- [ ] Rebuild/restart sql-writer; confirm spark fallbacks stop
After merge, rebuild sql-writer to pick up the fix on the live stack.