### PR TITLE
Add MemoryCorrectionProposalV1 and memory_correction_proposal scaffold.

### DIFF
--- a/docs/context-exec-beta-runbook.md
+++ b/docs/context-exec-beta-runbook.md
@@ -42,6 +42,17 @@ Other modes exist in schema (`runtime_debug`, `grammar_collision_audit`, etc.) b
 - **Boundary:** Proposal artifacts are not actions. Proposal envelopes are review objects. Executors are separate. Cortex/human approval is required before mutation. Context-exec may draft proposals, but it may not approve or execute them.
 - **Not beta-certified:** Eval fixtures exist; Hub/Cortex auto-routing is not wired in this release.
 
+### memory_correction_proposal (proposal-mode scaffold)
+
+- **Purpose:** Emit a read-only memory correction blueprint wrapped in `ProposalEnvelopeV1`. Inner payload is `MemoryCorrectionProposalV1`. Context-exec may **propose** a memory correction; it may **not perform** mutation or write to any memory backend.
+- **Input shape:** Natural-language request to draft a correction for an unsupported or contradicted belief (e.g. unsupported Denver location claim).
+- **Artifact type:** `ProposalEnvelopeV1` — review envelope with `proposal_type=memory_correction_proposal`, `requires_human_approval` (always `true`), `mutation_allowed` (always `false`), `review_status` (`draft` or `pending_review` only from context-exec), inner `artifact_type=MemoryCorrectionProposalV1`, and nested `artifact` payload.
+- **Inner payload:** `MemoryCorrectionProposalV1` — `current_belief`, `proposed_belief`, `correction_type`, `rationale`, `supporting_evidence`, `contradicting_evidence`, `missing_evidence`, `target_memory_domains`, `risk`, `tests_to_run`, `rollback_plan`, `open_questions`, `mutation_allowed` (always `false`).
+- **Review lifecycle:** Same as `patch_proposal` — context-exec never emits `approved` or `executed`; a separate executor applies corrections after Cortex/human approval.
+- **Expected behavior:** Read-only recall/memory/trace grounding; schema-valid envelope; no cards/RDF/Graphiti/Chroma/SQL writes.
+- **Boundary:** Memory correction proposals are not memory writes. Context-exec may draft a correction proposal, but it may not update cards, RDF, Graphiti, Chroma, SQL timeline, or any other memory backend. Cortex/human approval is required before a separate executor can apply a correction.
+- **Not beta-certified:** Eval fixtures exist; Hub/Cortex auto-routing is not wired in this release.
+
 ### belief_provenance
 
 - **Purpose:** Investigate origin and support status of a user/runtime claim.
@@ -228,7 +239,7 @@ bash scripts/context_exec_beta_gate.sh --live
 
 - Only three modes are beta-certified; other schema modes are not eval/golden gated.
 - Legacy AgentChain fallback still active on cortex-exec when `CONTEXT_EXEC_LEGACY_FALLBACK=true`.
-- Proposal envelope scaffold (`ProposalEnvelopeV1` wrapping `PatchProposalV1`) is implemented for `patch_proposal`; other proposal types remain documented only.
+- Proposal envelope scaffold (`ProposalEnvelopeV1`) is implemented for `patch_proposal` (wrapping `PatchProposalV1`) and `memory_correction_proposal` (wrapping `MemoryCorrectionProposalV1`); other proposal types remain documented only.
 - AlexZhang engine requires opt-in; fake remains default.
 - Repo impact quality differs between fake (pattern grep) and alexzhang (engine-file grounding).
 - No write/network/shell; mutation is out of scope for beta.
@@ -292,11 +303,11 @@ Proposal-mode scaffold ( **partially implemented** ):
 |-------------------|--------|---------|
 | `ProposalEnvelopeV1` | Scaffold | Shared review wrapper for all proposal artifacts |
 | `PatchProposalV1` | Scaffold (inner payload) | Propose code/doc patch — read-only blueprint only |
-| `MemoryCorrectionProposalV1` | Not implemented | Propose memory correction |
+| `MemoryCorrectionProposalV1` | Scaffold (inner payload) | Propose memory correction — read-only blueprint only |
 | `RuntimeConfigProposalV1` | Not implemented | Propose runtime config change |
 | `TestPlanProposalV1` | Not implemented | Propose test additions |
 
-`patch_proposal` emits `ProposalEnvelopeV1` wrapping `PatchProposalV1`. It may not execute changes.
+`patch_proposal` emits `ProposalEnvelopeV1` wrapping `PatchProposalV1`. `memory_correction_proposal` emits `ProposalEnvelopeV1` wrapping `MemoryCorrectionProposalV1`. Neither mode may execute changes or write to memory backends.
 
 **Rule:**
 

--- a/orion/schemas/context_exec.py
+++ b/orion/schemas/context_exec.py
@@ -15,6 +15,7 @@ ContextExecMode = Literal[
     "trace_autopsy",
     "repo_impact_analysis",
     "patch_proposal",
+    "memory_correction_proposal",
     "runtime_debug",
     "grammar_collision_audit",
     "memory_contradiction_review",
@@ -198,6 +199,49 @@ class PatchProposalV1(BaseModel):
     mutation_allowed: bool = False
 
 
+MemoryCorrectionType = Literal[
+    "mark_uncertain",
+    "mark_contradicted",
+    "replace_belief",
+    "add_disambiguation",
+    "delete_candidate",
+    "merge_duplicate",
+]
+
+MemoryTargetDomain = Literal[
+    "cards",
+    "rdf",
+    "graphiti",
+    "chroma",
+    "sql_timeline",
+    "unknown",
+]
+
+
+class MemoryCorrectionProposalV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    current_belief: str
+    proposed_belief: str | None = None
+    correction_type: MemoryCorrectionType = "mark_uncertain"
+
+    rationale: str
+    supporting_evidence: list[str] = Field(default_factory=list)
+    contradicting_evidence: list[str] = Field(default_factory=list)
+    missing_evidence: list[str] = Field(default_factory=list)
+
+    target_memory_domains: list[MemoryTargetDomain] = Field(default_factory=list)
+    affected_ids: list[str] = Field(default_factory=list)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    risk: ProposalRiskLevel = "unknown"
+
+    tests_to_run: list[str] = Field(default_factory=list)
+    rollback_plan: str
+    open_questions: list[str] = Field(default_factory=list)
+
+    mutation_allowed: bool = False
+
+
 class ProposalEnvelopeV1(BaseModel):
     """Shared review wrapper for context-exec proposal artifacts."""
 
@@ -273,6 +317,48 @@ def build_patch_proposal_envelope(
             "Proposal envelopes are review objects.",
             "Executors are separate.",
             "Cortex/human approval is required before mutation.",
+            "Context-exec may draft proposals, but it may not approve or execute them.",
+        ],
+    )
+    assert_context_exec_proposal_safe(envelope)
+    return envelope
+
+
+def build_memory_correction_proposal_envelope(
+    correction: MemoryCorrectionProposalV1,
+    *,
+    source_mode: str,
+    source_run_id: str | None = None,
+    review_status: ContextExecCreatableReviewState = "draft",
+) -> ProposalEnvelopeV1:
+    """Wrap a MemoryCorrectionProposalV1 in a context-exec proposal envelope."""
+    inner = correction.model_dump(mode="json")
+    inner["mutation_allowed"] = False
+    title = (
+        f"Memory correction: {(correction.current_belief[:100] if correction.current_belief else 'unknown belief')}"
+    ).strip()
+    envelope = ProposalEnvelopeV1(
+        proposal_id=f"prop_{uuid.uuid4().hex[:12]}",
+        proposal_type="memory_correction_proposal",
+        source_mode=source_mode,
+        source_run_id=source_run_id,
+        title=title,
+        summary=correction.rationale,
+        evidence=list(correction.supporting_evidence) + list(correction.contradicting_evidence),
+        risk=correction.risk,
+        requires_human_approval=True,
+        mutation_allowed=False,
+        review_status=review_status,
+        artifact_type="MemoryCorrectionProposalV1",
+        artifact=inner,
+        open_questions=list(correction.open_questions),
+        safety_notes=[
+            "Memory correction proposals are not memory writes.",
+            "Context-exec may draft a correction proposal, but it may not update cards, RDF, Graphiti, Chroma, SQL timeline, or any other memory backend.",
+            "Proposal artifacts are not actions.",
+            "Proposal envelopes are review objects.",
+            "Executors are separate.",
+            "Cortex/human approval is required before a separate executor can apply a correction.",
             "Context-exec may draft proposals, but it may not approve or execute them.",
         ],
     )

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -69,6 +69,7 @@ from orion.schemas.context_exec import (
     ContextExecRequestV1,
     ContextExecRunV1,
     ContextExecVerbStepV1,
+    MemoryCorrectionProposalV1,
     PatchProposalV1,
     ProposalEnvelopeV1,
     RepoImpactAnalysisReportV1,
@@ -1043,6 +1044,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "RepoImpactAnalysisReportV1": RepoImpactAnalysisReportV1,
     "PatchProposalV1": PatchProposalV1,
     "ProposalEnvelopeV1": ProposalEnvelopeV1,
+    "MemoryCorrectionProposalV1": MemoryCorrectionProposalV1,
 
 }
 

--- a/scripts/context_exec_rlm_eval.py
+++ b/scripts/context_exec_rlm_eval.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import os
 import sys
 
@@ -31,11 +32,12 @@ from app.rlm_eval_harness import (  # noqa: E402
 )
 
 
-def _inner_patch_artifact(artifact: dict) -> dict:
-    if artifact.get("proposal_type") == "patch_proposal":
+def _inner_proposal_artifact(artifact: dict) -> dict:
+    proposal_type = artifact.get("proposal_type")
+    if proposal_type in {"patch_proposal", "memory_correction_proposal"}:
         inner = artifact.get("artifact") or {}
         return inner if isinstance(inner, dict) else artifact
-    if artifact.get("artifact_type") == "PatchProposalV1" and "proposal_id" not in artifact:
+    if artifact.get("artifact_type") in {"PatchProposalV1", "MemoryCorrectionProposalV1"} and "proposal_id" not in artifact:
         return artifact
     return artifact
 
@@ -67,7 +69,7 @@ def _quality_pass(case_name: str, engine: str, run) -> bool:
             return False
         if artifact.get("review_status") not in {"draft", "pending_review"}:
             return False
-        inner = _inner_patch_artifact(artifact)
+        inner = _inner_proposal_artifact(artifact)
         risk = str(inner.get("risk") or artifact.get("risk") or "unknown")
         if risk not in {"low", "medium", "unknown"}:
             return False
@@ -84,6 +86,38 @@ def _quality_pass(case_name: str, engine: str, run) -> bool:
             open_q = " ".join(str(q) for q in inner.get("open_questions") or []).lower()
             if "insufficient repo grounding" not in open_q:
                 return False
+    if case_name == "memory_correction_denver_uncertain":
+        artifact = run.artifact or {}
+        if run.artifact_type != "ProposalEnvelopeV1":
+            return False
+        if artifact.get("proposal_type") != "memory_correction_proposal":
+            return False
+        if artifact.get("artifact_type") != "MemoryCorrectionProposalV1":
+            return False
+        if artifact.get("mutation_allowed") is not False:
+            return False
+        if artifact.get("requires_human_approval") is not True:
+            return False
+        if artifact.get("review_status") not in {"draft", "pending_review"}:
+            return False
+        inner = _inner_proposal_artifact(artifact)
+        current_belief = str(inner.get("current_belief") or "").lower()
+        if "denver" not in current_belief:
+            return False
+        correction_type = str(inner.get("correction_type") or "")
+        if correction_type not in {"mark_uncertain", "mark_contradicted", "replace_belief"}:
+            return False
+        confidence = float(inner.get("confidence") or 0.0)
+        if confidence > 0.7:
+            ogden_evidence = any(
+                "ogden" in str(e).lower()
+                for e in (inner.get("contradicting_evidence") or [])
+            )
+            if not ogden_evidence:
+                return False
+        blob = json.dumps(inner, default=str).lower()
+        if any(term in blob for term in ("applied=true", "memory_written=true", "graph_written=true")):
+            return False
     return True
 
 
@@ -111,7 +145,7 @@ async def _run(engine: str) -> list[tuple]:
                 settings_overrides=overrides,
             )
             artifact = run.artifact or {}
-            inner = _inner_patch_artifact(artifact)
+            inner = _inner_proposal_artifact(artifact)
             artifact_status = str(inner.get("status", artifact.get("status", run.status)))
             quality = _quality_pass(case.name, engine, run)
             proposal_type = str(artifact.get("proposal_type") or "")
@@ -130,7 +164,7 @@ async def _run(engine: str) -> list[tuple]:
             mutation_allowed = ""
             requires_human_approval = ""
         if run is not None:
-            if case.mode == "patch_proposal":
+            if case.mode in {"patch_proposal", "memory_correction_proposal"}:
                 rows.append(
                     (
                         case.name,
@@ -167,7 +201,7 @@ def main() -> int:
     args = parser.parse_args()
 
     rows = asyncio.run(_run(args.engine))
-    has_proposal = any(c.mode == "patch_proposal" for c in ALL_EVAL_CASES)
+    has_proposal = any(c.mode in {"patch_proposal", "memory_correction_proposal"} for c in ALL_EVAL_CASES)
     if has_proposal:
         header = (
             "case",

--- a/services/orion-context-exec/README.md
+++ b/services/orion-context-exec/README.md
@@ -28,7 +28,7 @@ Context-exec is in **beta** for three investigative modes. Full runbook: [docs/c
 
 **Supported beta modes:** `belief_provenance`, `trace_autopsy`, `repo_impact_analysis` → artifacts `BeliefProvenanceReportV1`, `TraceAutopsyReportV1`, `RepoImpactAnalysisReportV1`.
 
-**Proposal-mode scaffold (not beta-certified):** `patch_proposal` → `ProposalEnvelopeV1` wrapping `PatchProposalV1`. It may emit structured patch blueprints inside a review envelope; it may not execute changes, write files, or mutate runtime state. Proposal artifacts are not actions. Proposal envelopes are review objects. Executors are separate. Cortex/human approval is required before mutation. Context-exec may draft proposals, but it may not approve or execute them.
+**Proposal-mode scaffold (not beta-certified):** `patch_proposal` → `ProposalEnvelopeV1` wrapping `PatchProposalV1`; `memory_correction_proposal` → `ProposalEnvelopeV1` wrapping `MemoryCorrectionProposalV1`. These modes may emit structured proposals inside a review envelope; they may not execute changes, write files, update memory backends, or mutate runtime state. Memory correction proposals are not memory writes. Context-exec may draft a correction proposal, but it may not update cards, RDF, Graphiti, Chroma, SQL timeline, or any other memory backend. Cortex/human approval is required before a separate executor can apply a correction. Proposal artifacts are not actions. Proposal envelopes are review objects. Executors are separate. Cortex/human approval is required before mutation. Context-exec may draft proposals, but it may not approve or execute them.
 
 **Engine selection:** `fake` (default) | `alexzhang` (opt-in). Fallback must be explicit (`CONTEXT_EXEC_RLM_FALLBACK_ENABLED=true`) and visible in `runtime_debug`.
 

--- a/services/orion-context-exec/app/alexzhang_rlm_engine.py
+++ b/services/orion-context-exec/app/alexzhang_rlm_engine.py
@@ -39,7 +39,13 @@ _TRACE_SIGNAL_ORDER: tuple[tuple[tuple[str, ...], str], ...] = (
 
 logger = logging.getLogger("orion-context-exec.alexzhang_rlm_engine")
 
-SUPPORTED_MODES = frozenset({"belief_provenance", "trace_autopsy", "repo_impact_analysis", "patch_proposal"})
+SUPPORTED_MODES = frozenset({
+    "belief_provenance",
+    "trace_autopsy",
+    "repo_impact_analysis",
+    "patch_proposal",
+    "memory_correction_proposal",
+})
 
 
 class UnsupportedModeError(Exception):
@@ -450,6 +456,8 @@ class AlexZhangRLMEngine(RLMEngine):
             report = await self._trace_autopsy(request, namespace, runtime, organ_cache)
         elif mode == "patch_proposal":
             report = await self._patch_proposal(request, namespace, runtime, organ_cache)
+        elif mode == "memory_correction_proposal":
+            report = await self._memory_correction_proposal(request, namespace, runtime, organ_cache)
         else:
             report = await self._repo_impact(request, namespace, runtime, organ_cache)
 
@@ -823,6 +831,198 @@ class AlexZhangRLMEngine(RLMEngine):
             "risk": risk,
             "tests_to_run": tests,
             "rollback_plan": "Revert proposed file changes via version control; no runtime mutation performed.",
+            "open_questions": open_questions,
+            "mutation_allowed": False,
+        }
+
+    def _infer_memory_domain(self, source_ref: str | None) -> str | None:
+        if not source_ref:
+            return None
+        lowered = str(source_ref).lower()
+        prefixes = (
+            ("rdf:", "rdf"),
+            ("chroma:", "chroma"),
+            ("graphiti:", "graphiti"),
+            ("sql:", "sql_timeline"),
+            ("timeline:", "sql_timeline"),
+            ("cards:", "cards"),
+            ("card:", "cards"),
+            ("memory:", "cards"),
+        )
+        for prefix, domain in prefixes:
+            if lowered.startswith(prefix):
+                return domain
+        return None
+
+    def _collect_memory_correction_evidence(
+        self,
+        *,
+        memory_hits: list[dict[str, Any]],
+        recall_hits: list[dict[str, Any]],
+        trace_hits: list[dict[str, Any]],
+    ) -> tuple[list[str], list[str], list[str], list[str], list[str]]:
+        supporting: list[str] = []
+        contradicting: list[str] = []
+        missing: list[str] = []
+        domains: list[str] = []
+        affected_ids: list[str] = []
+
+        for hit in memory_hits + recall_hits:
+            claim = str(hit.get("claim") or hit.get("snippet") or hit.get("title") or "").strip()
+            source_ref = hit.get("source_ref") or hit.get("id") or hit.get("handle")
+            if not claim:
+                continue
+            entry = f"{claim} (source: {source_ref})" if source_ref else claim
+            lowered = claim.lower()
+            if any(term in lowered for term in ("not denver", "ogden", "contradict", "unsupported")):
+                contradicting.append(entry)
+            else:
+                supporting.append(entry)
+            domain = self._infer_memory_domain(str(source_ref) if source_ref else None)
+            if domain and domain not in domains:
+                domains.append(domain)
+            if source_ref and str(source_ref) not in affected_ids:
+                affected_ids.append(str(source_ref))
+
+        for th in trace_hits:
+            snippet = str(th.get("snippet") or th.get("kind") or "").strip()
+            handle = th.get("handle") or th.get("corr_id")
+            if not snippet:
+                continue
+            entry = f"{snippet} (trace: {handle})" if handle else snippet
+            lowered = snippet.lower()
+            if any(term in lowered for term in ("not denver", "ogden", "contradict", "unsupported")):
+                contradicting.append(entry)
+            else:
+                supporting.append(entry)
+            if handle and str(handle) not in affected_ids:
+                affected_ids.append(str(handle))
+
+        if not supporting and not contradicting:
+            missing.append("insufficient memory evidence")
+
+        return supporting, contradicting, missing, domains, affected_ids
+
+    async def _memory_correction_proposal(
+        self,
+        request: ContextExecRequestV1,
+        namespace: ContextNamespace,
+        runtime: OrganRuntime | None,
+        organ_cache: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        current_belief = _extract_claim_from_text(request.text)
+        query_terms = current_belief.split()[:8] or [request.text[:80]]
+        search_q = " ".join(query_terms)
+
+        self._debug_steps.append("retrieve")
+        recall_result: dict[str, Any] = {"hits": []}
+        trace_hits: list[dict[str, Any]] = []
+        if runtime is not None:
+            recall_result = await runtime.recall_query(search_q, limit=self._settings.context_exec_recall_limit)
+            self._subcalls += 1
+            trace_hits = await runtime.traces_search(query=search_q, limit=self._settings.context_exec_trace_limit)
+            self._subcalls += 1
+        if organ_cache is not None:
+            organ_cache["recall"] = recall_result
+            organ_cache["traces"] = trace_hits
+
+        memory_hits = namespace.memory.search_claims(search_q, limit=20)
+        recall_hits = [
+            {
+                "claim": str(h.get("snippet") or h.get("title") or "recall hit"),
+                "source_ref": h.get("source_ref") or h.get("id"),
+                "verified": True,
+                "confidence": float(h.get("score") or 0.5),
+            }
+            for h in recall_result.get("hits") or []
+        ]
+        if not memory_hits and recall_hits:
+            memory_hits = recall_hits
+        if not trace_hits:
+            trace_hits = namespace.traces.search(query=search_q)
+        trace_hits = [
+            th
+            for th in trace_hits
+            if not (
+                str(th.get("source")) == "context_exec"
+                and str(th.get("kind", "")).startswith("context.exec.")
+            )
+        ]
+
+        self._debug_steps.append("synthesize")
+        supporting, contradicting, missing, domains, affected_ids = self._collect_memory_correction_evidence(
+            memory_hits=memory_hits,
+            recall_hits=recall_hits,
+            trace_hits=trace_hits,
+        )
+
+        has_evidence = bool(supporting or contradicting)
+        if not has_evidence:
+            missing.append("insufficient memory evidence")
+
+        correction_type = "mark_uncertain"
+        proposed_belief: str | None = None
+        confidence = 0.15
+        risk = "unknown"
+
+        ogden_contradiction = any("ogden" in c.lower() for c in contradicting)
+        denver_unsupported = "denver" in current_belief.lower() and not supporting
+
+        if ogden_contradiction:
+            correction_type = "replace_belief"
+            proposed_belief = next(
+                (c.split(" (source:")[0] for c in contradicting if "ogden" in c.lower()),
+                "User location is Ogden, not Denver",
+            )
+            confidence = 0.65
+            risk = "medium"
+        elif contradicting and supporting:
+            correction_type = "mark_contradicted"
+            confidence = 0.45
+            risk = "medium"
+        elif contradicting:
+            correction_type = "mark_contradicted"
+            confidence = 0.4
+            risk = "medium"
+        elif denver_unsupported or not has_evidence:
+            correction_type = "mark_uncertain"
+            confidence = 0.2
+            risk = "unknown"
+
+        if confidence > 0.7 and not (ogden_contradiction or (contradicting and len(contradicting) >= 2)):
+            confidence = 0.7
+
+        target_domains = domains or ["unknown"]
+        rationale_parts = [
+            f"Proposed memory correction for belief: {current_belief}",
+        ]
+        if correction_type == "mark_uncertain":
+            rationale_parts.append("Evidence is insufficient to propose a definitive correction.")
+        elif correction_type == "mark_contradicted":
+            rationale_parts.append("Recall/trace evidence contradicts the current belief.")
+        elif correction_type == "replace_belief":
+            rationale_parts.append("Contradicting evidence supports replacing the current belief.")
+
+        open_questions: list[str] = []
+        if not has_evidence:
+            open_questions.append("insufficient memory evidence for grounded correction")
+        if not domains:
+            open_questions.append("target memory domain unclear from evidence source refs")
+
+        return {
+            "current_belief": current_belief,
+            "proposed_belief": proposed_belief,
+            "correction_type": correction_type,
+            "rationale": " ".join(rationale_parts),
+            "supporting_evidence": supporting[:8],
+            "contradicting_evidence": contradicting[:8],
+            "missing_evidence": missing,
+            "target_memory_domains": target_domains,
+            "affected_ids": affected_ids[:12],
+            "confidence": confidence,
+            "risk": risk,
+            "tests_to_run": [],
+            "rollback_plan": "No mutation proposed; no rollback required.",
             "open_questions": open_questions,
             "mutation_allowed": False,
         }

--- a/services/orion-context-exec/app/artifact_builder.py
+++ b/services/orion-context-exec/app/artifact_builder.py
@@ -9,10 +9,12 @@ from orion.schemas.context_exec import (
     ContextExecMode,
     ContextExecRequestV1,
     ContextExecRunV1,
+    MemoryCorrectionProposalV1,
     PatchProposalV1,
     ProposalEnvelopeV1,
     RepoImpactAnalysisReportV1,
     TraceAutopsyReportV1,
+    build_memory_correction_proposal_envelope,
     build_patch_proposal_envelope,
 )
 
@@ -23,6 +25,7 @@ def artifact_type_for_mode(mode: ContextExecMode) -> str | None:
         "trace_autopsy": "TraceAutopsyReportV1",
         "repo_impact_analysis": "RepoImpactAnalysisReportV1",
         "patch_proposal": "ProposalEnvelopeV1",
+        "memory_correction_proposal": "ProposalEnvelopeV1",
         "runtime_debug": "TraceAutopsyReportV1",
     }
     return mapping.get(mode)
@@ -37,6 +40,17 @@ def _wrap_patch_proposal(raw: dict[str, Any], mode: ContextExecMode) -> tuple[di
         return raw, "PatchProposalV1", False
 
 
+def _wrap_memory_correction_proposal(
+    raw: dict[str, Any], mode: ContextExecMode
+) -> tuple[dict[str, Any], str, bool]:
+    try:
+        correction = MemoryCorrectionProposalV1.model_validate(raw)
+        envelope = build_memory_correction_proposal_envelope(correction, source_mode=mode)
+        return envelope.model_dump(mode="json"), "ProposalEnvelopeV1", True
+    except Exception:
+        return raw, "MemoryCorrectionProposalV1", False
+
+
 def validate_artifact(mode: ContextExecMode, raw: Any) -> tuple[dict[str, Any], str | None, bool]:
     if not isinstance(raw, dict):
         return {}, None, False
@@ -49,6 +63,8 @@ def validate_artifact(mode: ContextExecMode, raw: Any) -> tuple[dict[str, Any], 
             model = RepoImpactAnalysisReportV1.model_validate(raw)
         elif mode == "patch_proposal":
             return _wrap_patch_proposal(raw, mode)
+        elif mode == "memory_correction_proposal":
+            return _wrap_memory_correction_proposal(raw, mode)
         else:
             return raw, "GenericInvestigationV1", True
         return model.model_dump(mode="json"), model.__class__.__name__, True
@@ -66,11 +82,21 @@ def synthesize_findings_bundle(
     findings_source = artifact
     if request.mode == "patch_proposal" and artifact.get("artifact_type") == "PatchProposalV1":
         findings_source = artifact.get("artifact") or {}
-    if ac is None and not (findings_source.get("findings") or findings_source.get("evidence") or artifact.get("evidence")):
+    if request.mode == "memory_correction_proposal" and artifact.get("artifact_type") == "MemoryCorrectionProposalV1":
+        findings_source = artifact.get("artifact") or {}
+    if ac is None and not (
+        findings_source.get("findings")
+        or findings_source.get("evidence")
+        or findings_source.get("supporting_evidence")
+        or findings_source.get("contradicting_evidence")
+        or artifact.get("evidence")
+    ):
         return None
     raw_findings: list[Any] = list(
         findings_source.get("findings")
         or findings_source.get("evidence")
+        or findings_source.get("supporting_evidence")
+        or findings_source.get("contradicting_evidence")
         or artifact.get("evidence")
         or []
     )
@@ -141,5 +167,19 @@ def build_final_text(mode: ContextExecMode, artifact: dict[str, Any], *, status:
         return (
             f"Patch proposal generated. Mutation is not allowed by context-exec. "
             f"Patch proposal: update {file_hint}. Risk={risk}. Mutation allowed=false."
+        )
+    if mode == "memory_correction_proposal":
+        inner = (
+            artifact.get("artifact")
+            if artifact.get("artifact_type") == "MemoryCorrectionProposalV1"
+            else artifact
+        )
+        current = inner.get("current_belief") or "unknown belief"
+        correction_type = inner.get("correction_type") or "mark_uncertain"
+        risk = artifact.get("risk", inner.get("risk", "unknown"))
+        return (
+            f"Memory correction proposal generated. Mutation is not allowed by context-exec. "
+            f"Current belief: {current[:120]}. Proposed correction: {correction_type}. "
+            f"Risk={risk}. Mutation allowed=false."
         )
     return str(artifact.get("summary") or artifact.get("target") or "Investigation complete.")

--- a/services/orion-context-exec/app/rlm_engine.py
+++ b/services/orion-context-exec/app/rlm_engine.py
@@ -39,6 +39,17 @@ def _extract_corr_id(text: str) -> str | None:
     return None
 
 
+def _extract_memory_correction_belief(text: str) -> str:
+    lowered = text.lower()
+    for marker in ("claim that ", "claim: ", "belief that "):
+        idx = lowered.find(marker)
+        if idx >= 0:
+            tail = text[idx + len(marker) :].strip(" ?.,;")
+            if tail:
+                return tail[:500]
+    return "unknown"
+
+
 class FakeRLMEngine(RLMEngine):
     """Deterministic engine for tests — no model dependency."""
 
@@ -55,6 +66,29 @@ class FakeRLMEngine(RLMEngine):
         text = request.text.lower()
         organ_cache = getattr(namespace, "_organ_cache", None)
         runtime = organ_runtime or getattr(namespace, "_organ_runtime", None)
+
+        if mode == "memory_correction_proposal":
+            current_belief = _extract_memory_correction_belief(request.text)
+            report = {
+                "current_belief": current_belief,
+                "proposed_belief": None,
+                "correction_type": "mark_uncertain",
+                "rationale": "Fake engine does not inspect memory evidence.",
+                "supporting_evidence": [],
+                "contradicting_evidence": [],
+                "missing_evidence": ["fake engine has no grounded memory evidence"],
+                "target_memory_domains": ["unknown"],
+                "affected_ids": [],
+                "confidence": 0.0,
+                "risk": "unknown",
+                "tests_to_run": [],
+                "rollback_plan": "No mutation proposed; no rollback required.",
+                "open_questions": [],
+                "mutation_allowed": False,
+            }
+            namespace.set_local("report", report)
+            namespace.FINAL_VAR("report")
+            return namespace.get_final()
 
         if mode == "belief_provenance" or "denver" in text:
             recall_result: dict[str, Any] = {"hits": []}

--- a/services/orion-context-exec/app/rlm_eval_harness.py
+++ b/services/orion-context-exec/app/rlm_eval_harness.py
@@ -128,6 +128,14 @@ PATCH_PROPOSAL_TRACE_AUTOPSY = RlmEvalCase(
     expected_statuses=set(PATCH_PROPOSAL_RISKS),
 )
 
+MEMORY_CORRECTION_DENVER = RlmEvalCase(
+    name="memory_correction_denver_uncertain",
+    mode="memory_correction_proposal",
+    text="Propose a memory correction for the unsupported claim that I am from Denver.",
+    expected_artifact_type="ProposalEnvelopeV1",
+    expected_statuses=set(PATCH_PROPOSAL_RISKS),
+)
+
 ALL_EVAL_CASES = (
     BELIEF_DENVER,
     BELIEF_OGDEN,
@@ -136,6 +144,7 @@ ALL_EVAL_CASES = (
     REPO_AGENT_CHAIN,
     REPO_ENGINE_FILES_CASE,
     PATCH_PROPOSAL_TRACE_AUTOPSY,
+    MEMORY_CORRECTION_DENVER,
 )
 
 
@@ -175,6 +184,8 @@ def assert_safety_posture(run: ContextExecRunV1) -> None:
         assert run.artifact.get("review_status") in {"draft", "pending_review"}
         inner = run.artifact.get("artifact") or {}
         if run.artifact.get("artifact_type") == "PatchProposalV1":
+            assert inner.get("mutation_allowed") is False
+        if run.artifact.get("artifact_type") == "MemoryCorrectionProposalV1":
             assert inner.get("mutation_allowed") is False
     if run.artifact_type == "PatchProposalV1":
         assert run.artifact.get("mutation_allowed") is False
@@ -251,6 +262,15 @@ def seed_case_organs(case_name: str) -> None:
             {
                 "claim": "User location is Ogden, not Denver",
                 "source_ref": "m:ogden:1",
+                "verified": True,
+                "confidence": 0.9,
+            }
+        ]
+    elif case_name == "memory_correction_denver_uncertain":
+        FAKE_ORGANS.memory_hits = [
+            {
+                "claim": "User is from Denver",
+                "source_ref": "m:denver:1",
                 "verified": True,
                 "confidence": 0.9,
             }

--- a/services/orion-context-exec/app/runner.py
+++ b/services/orion-context-exec/app/runner.py
@@ -298,8 +298,9 @@ class ContextExecRunner:
             mode=request.mode,
             extra_steps=rlm_steps or None,
         )
-        if request.mode == "patch_proposal" and schema_valid and artifact_type == "ProposalEnvelopeV1":
+        if request.mode in {"patch_proposal", "memory_correction_proposal"} and schema_valid and artifact_type == "ProposalEnvelopeV1":
             runtime_debug["proposal_enveloped"] = True
+            runtime_debug["proposal_type"] = artifact.get("proposal_type")
             runtime_debug["requires_human_approval"] = artifact.get("requires_human_approval", True)
             runtime_debug["mutation_allowed"] = artifact.get("mutation_allowed", False)
 

--- a/services/orion-context-exec/tests/test_memory_correction_proposal.py
+++ b/services/orion-context-exec/tests/test_memory_correction_proposal.py
@@ -1,0 +1,195 @@
+"""Memory correction proposal mode scaffold tests (read-only, no mutation)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from orion.schemas.context_exec import (
+    ContextExecPermissionV1,
+    ContextExecRequestV1,
+    MemoryCorrectionProposalV1,
+    PatchProposalV1,
+    ProposalEnvelopeV1,
+    build_memory_correction_proposal_envelope,
+)
+from orion.schemas.registry import _REGISTRY
+
+from app.alexzhang_rlm_engine import AlexZhangRLMEngine
+from app.artifact_builder import validate_artifact
+from app.callable_namespace import ContextNamespace
+from app.rlm_engine import FakeRLMEngine
+from app.runner import ContextExecRunner
+
+MEMORY_CORRECTION_PROMPT = (
+    "Propose a memory correction for the unsupported claim that I am from Denver."
+)
+
+EXECUTION_FORBIDDEN_ARTIFACT_KEYS = frozenset(
+    {
+        "git_commit",
+        "git_push",
+        "apply_patch",
+        "write_enabled",
+        "shell_command",
+        "pr_create",
+        "applied",
+        "memory_written",
+        "graph_written",
+    }
+)
+
+MUTATION_FORBIDDEN_REVIEW_STATUSES = frozenset({"approved", "executed"})
+
+
+def _assert_memory_correction_envelope_contract(envelope: ProposalEnvelopeV1) -> None:
+    assert envelope.proposal_type == "memory_correction_proposal"
+    assert envelope.artifact_type == "MemoryCorrectionProposalV1"
+    assert envelope.mutation_allowed is False
+    assert envelope.requires_human_approval is True
+    assert envelope.review_status in {"draft", "pending_review"}
+    inner = MemoryCorrectionProposalV1.model_validate(envelope.artifact)
+    assert inner.mutation_allowed is False
+
+
+def test_memory_correction_proposal_schema_defaults_to_no_mutation() -> None:
+    model = MemoryCorrectionProposalV1(
+        current_belief="User is from Denver",
+        rationale="Insufficient evidence for Denver claim",
+        rollback_plan="No mutation proposed; no rollback required.",
+    )
+    assert model.mutation_allowed is False
+    assert model.correction_type == "mark_uncertain"
+    assert model.confidence == 0.0
+    assert model.supporting_evidence == []
+    assert model.contradicting_evidence == []
+    assert model.missing_evidence == []
+    assert model.target_memory_domains == []
+    assert model.affected_ids == []
+    assert model.tests_to_run == []
+    assert model.open_questions == []
+    assert model.risk == "unknown"
+
+
+def test_memory_correction_proposal_registered_with_context_exec_schemas() -> None:
+    assert _REGISTRY["MemoryCorrectionProposalV1"] is MemoryCorrectionProposalV1
+    assert _REGISTRY["ProposalEnvelopeV1"] is ProposalEnvelopeV1
+    assert _REGISTRY["PatchProposalV1"] is PatchProposalV1
+
+
+@pytest.mark.asyncio
+async def test_fake_engine_memory_correction_proposal_returns_safe_envelope() -> None:
+    engine = FakeRLMEngine()
+    ns = ContextNamespace(permissions=ContextExecPermissionV1())
+    req = ContextExecRequestV1(text=MEMORY_CORRECTION_PROMPT, mode="memory_correction_proposal")
+    raw = await engine.run(req, ns)
+    artifact, artifact_type, valid = validate_artifact("memory_correction_proposal", raw)
+    assert valid is True
+    assert artifact_type == "ProposalEnvelopeV1"
+    envelope = ProposalEnvelopeV1.model_validate(artifact)
+    _assert_memory_correction_envelope_contract(envelope)
+    inner = MemoryCorrectionProposalV1.model_validate(envelope.artifact)
+    assert inner.correction_type == "mark_uncertain"
+    assert inner.risk == "unknown"
+    assert inner.confidence == 0.0
+    assert "fake engine has no grounded memory evidence" in inner.missing_evidence
+
+
+@pytest.mark.asyncio
+async def test_alexzhang_memory_correction_proposal_returns_read_only_envelope() -> None:
+    memory_hits = [
+        {
+            "claim": "User is from Denver",
+            "source_ref": "m:denver:1",
+            "verified": True,
+            "confidence": 0.9,
+        }
+    ]
+    engine = AlexZhangRLMEngine()
+    ns = ContextNamespace(
+        permissions=ContextExecPermissionV1(),
+        memory_fn={
+            "search_claims": lambda q, limit=20: memory_hits[:limit],
+            "read": lambda h: {},
+        },
+    )
+    req = ContextExecRequestV1(text=MEMORY_CORRECTION_PROMPT, mode="memory_correction_proposal")
+    raw = await engine.run(req, ns)
+    artifact, artifact_type, valid = validate_artifact("memory_correction_proposal", raw)
+    assert valid is True
+    assert artifact_type == "ProposalEnvelopeV1"
+    envelope = ProposalEnvelopeV1.model_validate(artifact)
+    _assert_memory_correction_envelope_contract(envelope)
+    inner = MemoryCorrectionProposalV1.model_validate(envelope.artifact)
+    assert "denver" in inner.current_belief.lower()
+    assert inner.correction_type in {"mark_uncertain", "mark_contradicted", "replace_belief"}
+
+
+@pytest.mark.asyncio
+async def test_memory_correction_proposal_does_not_mutate_memory(monkeypatch) -> None:
+    monkeypatch.setattr("app.runner.settings.rlm_engine", "fake")
+    runner = ContextExecRunner()
+    req = ContextExecRequestV1(
+        text=MEMORY_CORRECTION_PROMPT,
+        mode="memory_correction_proposal",
+        permissions=ContextExecPermissionV1(
+            write_memory=False,
+            write_graph=False,
+            write_repo=False,
+            mutate_runtime=False,
+            network_enabled=False,
+            shell_enabled=False,
+        ),
+    )
+    run = await runner.run(req)
+    assert run.status == "ok"
+    assert run.artifact_type == "ProposalEnvelopeV1"
+    envelope = ProposalEnvelopeV1.model_validate(run.artifact)
+    _assert_memory_correction_envelope_contract(envelope)
+    rd = run.runtime_debug
+    assert rd.get("schema_valid") is True
+    assert rd.get("proposal_enveloped") is True
+    assert rd.get("proposal_type") == "memory_correction_proposal"
+    assert rd.get("write_enabled") is False
+    assert rd.get("network_enabled") is False
+    assert rd.get("mutation_allowed") is False
+    assert rd.get("requires_human_approval") is True
+    assert rd.get("rlm_depth", 99) <= 1
+
+    for key in EXECUTION_FORBIDDEN_ARTIFACT_KEYS:
+        assert key not in run.artifact
+    artifact_blob = json.dumps(run.artifact, default=str).lower()
+    assert '"write_enabled": true' not in artifact_blob
+    assert '"mutation_allowed": true' not in artifact_blob
+    assert '"applied": true' not in artifact_blob
+    assert '"memory_written": true' not in artifact_blob
+    assert '"graph_written": true' not in artifact_blob
+    assert envelope.review_status not in MUTATION_FORBIDDEN_REVIEW_STATUSES
+
+
+@pytest.mark.asyncio
+async def test_memory_correction_denver_proposal_mentions_current_belief(monkeypatch) -> None:
+    monkeypatch.setattr("app.runner.settings.rlm_engine", "fake")
+    runner = ContextExecRunner()
+    req = ContextExecRequestV1(text=MEMORY_CORRECTION_PROMPT, mode="memory_correction_proposal")
+    run = await runner.run(req)
+    envelope = ProposalEnvelopeV1.model_validate(run.artifact)
+    inner = MemoryCorrectionProposalV1.model_validate(envelope.artifact)
+    assert "denver" in inner.current_belief.lower()
+    final_blob = f"{run.final_text} {json.dumps(run.artifact, default=str)}".lower()
+    assert "applied" not in final_blob or "not allowed" in run.final_text.lower()
+    assert "mutation is not allowed" in run.final_text.lower()
+
+
+def test_build_memory_correction_proposal_envelope_rejects_self_approval() -> None:
+    correction = MemoryCorrectionProposalV1(
+        current_belief="User is from Denver",
+        rationale="Unsupported Denver claim",
+        rollback_plan="No mutation proposed; no rollback required.",
+    )
+    envelope = build_memory_correction_proposal_envelope(
+        correction, source_mode="memory_correction_proposal"
+    )
+    assert envelope.review_status == "draft"
+    assert envelope.proposal_type == "memory_correction_proposal"

--- a/services/orion-context-exec/tests/test_proposal_envelope.py
+++ b/services/orion-context-exec/tests/test_proposal_envelope.py
@@ -6,6 +6,7 @@ import pytest
 
 from orion.schemas.context_exec import (
     CONTEXT_EXEC_CREATABLE_REVIEW_STATES,
+    MemoryCorrectionProposalV1,
     PatchProposalV1,
     ProposalEnvelopeV1,
     assert_context_exec_proposal_safe,
@@ -37,6 +38,7 @@ def test_proposal_envelope_defaults_require_review_and_disallow_mutation() -> No
 def test_proposal_envelope_registered_with_context_exec_schemas() -> None:
     assert _REGISTRY["ProposalEnvelopeV1"] is ProposalEnvelopeV1
     assert _REGISTRY["PatchProposalV1"] is PatchProposalV1
+    assert _REGISTRY["MemoryCorrectionProposalV1"] is MemoryCorrectionProposalV1
     assert _REGISTRY["BeliefProvenanceReportV1"] is not None
     assert _REGISTRY["TraceAutopsyReportV1"] is not None
     assert _REGISTRY["RepoImpactAnalysisReportV1"] is not None

--- a/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
+++ b/services/orion-context-exec/tests/test_rlm_eval_fixtures.py
@@ -7,6 +7,7 @@ import pytest
 from orion.schemas.context_exec import (
     BeliefProvenanceReportV1,
     ContextExecPermissionV1,
+    MemoryCorrectionProposalV1,
     ProposalEnvelopeV1,
     PatchProposalV1,
     RepoImpactAnalysisReportV1,
@@ -21,6 +22,7 @@ from app.rlm_eval_harness import (
     DENVER_CLAIM_FORBIDDEN,
     ENGINES,
     KNOWN_CORR,
+    MEMORY_CORRECTION_DENVER,
     PATCH_PROPOSAL_LIKELY_FILES,
     PATCH_PROPOSAL_TRACE_AUTOPSY,
     REPO_AGENT_CHAIN,
@@ -37,6 +39,7 @@ from app.rlm_eval_harness import (
     blob_text,
     reset_fake_organs,
     run_eval_case,
+    seed_case_organs,
 )
 
 REPO_SETTINGS = {
@@ -211,7 +214,7 @@ async def test_rlm_eval_safety_posture_read_only(engine: str) -> None:
 
 
 def test_all_eval_cases_registered() -> None:
-    assert len(ALL_EVAL_CASES) == 7
+    assert len(ALL_EVAL_CASES) == 8
     assert {c.name for c in ALL_EVAL_CASES} == {
         "belief_provenance_denver",
         "belief_provenance_ogden",
@@ -220,6 +223,7 @@ def test_all_eval_cases_registered() -> None:
         "repo_impact_agent_chain",
         "repo_impact_engine_files",
         "patch_proposal_trace_autopsy_quality",
+        "memory_correction_denver_uncertain",
     }
 
 
@@ -255,3 +259,25 @@ async def test_rlm_eval_patch_proposal_trace_autopsy_quality(
     if engine == "alexzhang" and not model.files_to_change:
         open_q = " ".join(model.open_questions).lower()
         assert "insufficient repo grounding" in open_q
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ENGINES)
+async def test_rlm_eval_memory_correction_denver_uncertain(engine: str) -> None:
+    seed_case_organs("memory_correction_denver_uncertain")
+    run = await run_eval_case(engine, MEMORY_CORRECTION_DENVER)
+    assert run.status == "ok"
+    envelope = ProposalEnvelopeV1.model_validate(run.artifact)
+    assert envelope.proposal_type == "memory_correction_proposal"
+    assert envelope.artifact_type == "MemoryCorrectionProposalV1"
+    assert envelope.mutation_allowed is False
+    assert envelope.requires_human_approval is True
+    assert envelope.review_status in {"draft", "pending_review"}
+    model = MemoryCorrectionProposalV1.model_validate(envelope.artifact)
+    assert model.mutation_allowed is False
+    assert "denver" in model.current_belief.lower()
+    assert model.correction_type in {"mark_uncertain", "mark_contradicted", "replace_belief"}
+    assert model.confidence <= 0.7 or any("ogden" in e.lower() for e in model.contradicting_evidence)
+    assert run.runtime_debug.get("mutation_allowed") is False
+    assert run.runtime_debug.get("proposal_enveloped") is True
+    assert run.runtime_debug.get("proposal_type") == "memory_correction_proposal"


### PR DESCRIPTION
# #678: Add MemoryCorrectionProposalV1 schema and proposal mode scaffold

## Summary

Adds `MemoryCorrectionProposalV1` and a read-only `memory_correction_proposal` context-exec mode scaffold.

This lets context-exec draft memory correction proposals inside `ProposalEnvelopeV1` without writing to cards, RDF, Graphiti, Chroma, SQL timeline, or any other memory backend.

## Changes

- Add `MemoryCorrectionProposalV1` schema with `mutation_allowed=false` default and bounded confidence.
- Register/export `MemoryCorrectionProposalV1` in `orion/schemas/registry.py`.
- Add `memory_correction_proposal` to `ContextExecMode` and artifact builder envelope wrapping.
- Add fake and AlexZhang engine read-only scaffold behavior.
- Wrap outputs in `ProposalEnvelopeV1` with `proposal_type=memory_correction_proposal`.
- Add eval fixture `memory_correction_denver_uncertain` and CLI proposal-column output.
- Add tests proving proposals require approval and disallow mutation.
- Update beta runbook and context-exec README with memory correction proposal boundary.

## Verification

- `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/ -q` → 90 passed, 1 xfailed
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine fake` → `memory_correction_denver_uncertain quality_pass=True`
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine alexzhang` → `memory_correction_denver_uncertain quality_pass=True`
- `ORION_PY=orion_dev/bin/python bash scripts/context_exec_beta_gate.sh` → BETA GATE PASS
- `rg "MemoryCorrectionProposalV1|ProposalEnvelopeV1|PatchProposalV1" orion/schemas` → all three visible in registry/export path

## Safety

- No routing changes
- No new organs
- No write/network/shell access
- No memory writes
- No graph writes
- No approval endpoint
- No executor
- Context-exec cannot approve or execute its own proposals

## Test plan

- [x] Schema defaults (`mutation_allowed=false`, confidence bounded)
- [x] Registry includes `MemoryCorrectionProposalV1`
- [x] Fake engine returns safe `ProposalEnvelopeV1`
- [x] AlexZhang engine returns read-only envelope with Denver belief extraction
- [x] Runner does not emit mutation/approval/execution fields
- [x] Eval harness Denver uncertain case passes both engines
- [x] Existing investigative and patch proposal modes still pass