### PR TITLE
Add proposal schema hardening tests and operator proposal CLI.

### DIFF
--- a/docs/context-exec-beta-runbook.md
+++ b/docs/context-exec-beta-runbook.md
@@ -373,6 +373,27 @@ Triage actions:
 - A separate executor performs the action.
 - Result is traced.
 
+### Operator proposal review CLI
+
+The proposal ledger is the system of record. Hub is an attention router. The operator CLI is the first inspectable review surface for proposal ledger records.
+
+Not every proposal becomes a human chore. Only `pending_review` records require active attention. Stored, blocked, discarded, expired, or superseded proposals are hidden by default when filtering for operator review queues.
+
+The CLI can list, show, triage, and review proposals. It cannot execute proposals, write memory, mutate repo files, or call Hub/Cortex/context-exec to generate new proposals (except `seed-demo`, which writes fixture records only to an explicit `--store` path).
+
+Approval creates future execution eligibility only; it does not execute anything.
+
+Example commands:
+
+```bash
+PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py seed-demo --store /tmp/orion-proposals.json
+PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py list --status pending_review --store /tmp/orion-proposals.json
+PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py show <proposal_id> --store /tmp/orion-proposals.json
+PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py triage <proposal_id> --action promote_to_review --reason "identity memory correction" --store /tmp/orion-proposals.json
+PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py review <proposal_id> --decision reject --reason "unsupported evidence" --reviewer human:june --store /tmp/orion-proposals.json
+PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py eligibility <proposal_id> --store /tmp/orion-proposals.json
+```
+
 ## 14. Deprecation path for legacy planner / AgentChain
 
 ### AgentChain retirement milestones

--- a/orion/schemas/proposal_ledger.py
+++ b/orion/schemas/proposal_ledger.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any, Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -188,3 +190,73 @@ class InMemoryProposalLedgerRepository:
         updated = apply_review_decision(record, decision)
         self._records[updated.proposal_id] = updated
         return updated
+
+    def list_all(self) -> list[ProposalLedgerRecordV1]:
+        return list(self._records.values())
+
+
+class JsonFileProposalLedgerRepository:
+    """JSON file-backed ledger for operator CLI and local testing."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._inner = InMemoryProposalLedgerRepository()
+        self._review_decisions: dict[str, list[ProposalReviewDecisionV1]] = {}
+        if path.exists():
+            self._load()
+
+    def _load(self) -> None:
+        raw = json.loads(self._path.read_text(encoding="utf-8"))
+        for record_data in raw.get("records", []):
+            record = ProposalLedgerRecordV1.model_validate(record_data)
+            self._inner.store(record)
+        for proposal_id, decisions in raw.get("review_decisions", {}).items():
+            self._review_decisions[proposal_id] = [
+                ProposalReviewDecisionV1.model_validate(item) for item in decisions
+            ]
+
+    def save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "records": [
+                record.model_dump(mode="json") for record in self._inner.list_all()
+            ],
+            "review_decisions": {
+                proposal_id: [decision.model_dump(mode="json") for decision in decisions]
+                for proposal_id, decisions in self._review_decisions.items()
+            },
+        }
+        self._path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def store(self, record: ProposalLedgerRecordV1) -> ProposalLedgerRecordV1:
+        stored = self._inner.store(record)
+        self.save()
+        return stored
+
+    def get(self, proposal_id: str) -> ProposalLedgerRecordV1 | None:
+        return self._inner.get(proposal_id)
+
+    def list_by_status(self, status: ProposalStatus) -> list[ProposalLedgerRecordV1]:
+        return self._inner.list_by_status(status)
+
+    def list_all(self) -> list[ProposalLedgerRecordV1]:
+        return self._inner.list_all()
+
+    def apply_triage(self, decision: ProposalTriageDecisionV1) -> ProposalLedgerRecordV1:
+        updated = self._inner.apply_triage(decision)
+        self.save()
+        return updated
+
+    def apply_review(self, decision: ProposalReviewDecisionV1) -> ProposalLedgerRecordV1:
+        updated = self._inner.apply_review(decision)
+        history = self._review_decisions.setdefault(decision.proposal_id, [])
+        history.append(decision)
+        self.save()
+        return updated
+
+    def review_history(self, proposal_id: str) -> list[ProposalReviewDecisionV1]:
+        return list(self._review_decisions.get(proposal_id, []))
+
+    def latest_review_decision(self, proposal_id: str) -> ProposalReviewDecisionV1 | None:
+        history = self._review_decisions.get(proposal_id, [])
+        return history[-1] if history else None

--- a/orion/schemas/tests/test_proposal_ledger_registry.py
+++ b/orion/schemas/tests/test_proposal_ledger_registry.py
@@ -15,15 +15,54 @@ from orion.schemas.proposal_ledger import (
 )
 from orion.schemas.registry import _REGISTRY, resolve
 
+PROPOSAL_CONTROL_PLANE_SCHEMAS = (
+    "PatchProposalV1",
+    "ProposalEnvelopeV1",
+    "MemoryCorrectionProposalV1",
+    "ProposalLedgerRecordV1",
+    "ProposalTriageDecisionV1",
+    "ProposalReviewDecisionV1",
+    "ProposalExecutionEligibilityV1",
+)
+
+
+def test_all_proposal_control_plane_schemas_registered() -> None:
+    for schema_id in PROPOSAL_CONTROL_PLANE_SCHEMAS:
+        assert schema_id in _REGISTRY
+        assert resolve(schema_id) is _REGISTRY[schema_id]
+
 
 def test_proposal_ledger_schemas_resolve() -> None:
-    for schema_id in (
-        "ProposalLedgerRecordV1",
-        "ProposalTriageDecisionV1",
-        "ProposalReviewDecisionV1",
-        "ProposalExecutionEligibilityV1",
-        "ProposalEnvelopeV1",
-        "PatchProposalV1",
-        "MemoryCorrectionProposalV1",
-    ):
+    for schema_id in PROPOSAL_CONTROL_PLANE_SCHEMAS:
         assert resolve(schema_id) is _REGISTRY[schema_id]
+
+
+def test_memory_correction_proposal_registered_schema_is_full_version() -> None:
+    registered = resolve("MemoryCorrectionProposalV1")
+    assert registered is MemoryCorrectionProposalV1
+
+    sample = MemoryCorrectionProposalV1(
+        current_belief="User is from Denver",
+        proposed_belief="User location is unknown",
+        correction_type="mark_uncertain",
+        rationale="Insufficient evidence for Denver claim",
+        supporting_evidence=["user said maybe Colorado once"],
+        contradicting_evidence=["no verified Denver source"],
+        missing_evidence=["passport or address record"],
+        target_memory_domains=["cards", "rdf"],
+        affected_ids=["card_123"],
+        confidence=0.2,
+        risk="medium",
+        tests_to_run=["recall regression"],
+        rollback_plan="No mutation proposed; no rollback required.",
+        open_questions=["Which memory card holds the Denver claim?"],
+        mutation_allowed=False,
+    )
+    validated = registered.model_validate(sample.model_dump(mode="json"))
+    assert validated.current_belief == sample.current_belief
+    assert validated.correction_type == "mark_uncertain"
+    assert validated.target_memory_domains == ["cards", "rdf"]
+    assert validated.mutation_allowed is False
+
+    assert _REGISTRY["MemoryCorrectionProposalV1"] is MemoryCorrectionProposalV1
+    assert _REGISTRY["MemoryCorrectionProposalV1"] is not PatchProposalV1

--- a/scripts/orion_proposal_cli.py
+++ b/scripts/orion_proposal_cli.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Operator proposal ledger CLI — list, show, triage, review, eligibility."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import sysconfig
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path = [p for p in sys.path if not p.endswith("/orion/schemas")]
+sys.path.insert(0, str(ROOT))
+# orion/schemas can shadow stdlib `platform`; restore before uuid imports it.
+stdlib_platform = Path(sysconfig.get_paths()["stdlib"]) / "platform.py"
+spec = importlib.util.spec_from_file_location("platform", stdlib_platform)
+if spec and spec.loader:
+    platform_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(platform_mod)
+    sys.modules["platform"] = platform_mod
+
+import uuid
+
+from orion.schemas.context_exec import (  # noqa: E402
+    MemoryCorrectionProposalV1,
+    PatchProposalV1,
+    ProposalEnvelopeV1,
+    build_memory_correction_proposal_envelope,
+    build_patch_proposal_envelope,
+)
+from orion.schemas.proposal_ledger import (  # noqa: E402
+    JsonFileProposalLedgerRepository,
+    ProposalLedgerRecordV1,
+    ProposalReviewDecisionV1,
+    ProposalTriageDecisionV1,
+)
+from orion.schemas.proposal_lifecycle import derive_execution_eligibility  # noqa: E402
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _require_store(path: str | None) -> Path:
+    if not path:
+        raise SystemExit("--store is required (explicit JSON path; no repo writes)")
+    return Path(path)
+
+
+def _open_repo(store_path: Path) -> JsonFileProposalLedgerRepository:
+    return JsonFileProposalLedgerRepository(store_path)
+
+
+def _parse_reviewer(reviewer: str) -> tuple[str, str]:
+    if reviewer.startswith("human:"):
+        return "human", reviewer.split(":", 1)[1]
+    if reviewer.startswith("cortex_policy:"):
+        return "cortex_policy", reviewer.split(":", 1)[1]
+    if reviewer.startswith("system:"):
+        return "system", reviewer.split(":", 1)[1]
+    if reviewer == "context-exec":
+        raise SystemExit("context-exec cannot act as proposal reviewer")
+    return "human", reviewer
+
+
+def _record_row(record: ProposalLedgerRecordV1) -> dict[str, Any]:
+    return {
+        "proposal_id": record.proposal_id,
+        "proposal_type": record.envelope.proposal_type,
+        "status": record.status,
+        "risk": record.envelope.risk,
+        "attention_required": record.attention_required,
+        "title": record.envelope.title,
+    }
+
+
+def _inner_artifact_summary(envelope: ProposalEnvelopeV1) -> dict[str, Any]:
+    artifact = envelope.artifact
+    if envelope.artifact_type == "PatchProposalV1":
+        patch = PatchProposalV1.model_validate(artifact)
+        return {
+            "artifact_type": envelope.artifact_type,
+            "problem": patch.problem,
+            "proposed_change_summary": patch.proposed_change_summary,
+            "files_to_change": patch.files_to_change,
+            "rollback_plan": patch.rollback_plan,
+        }
+    if envelope.artifact_type == "MemoryCorrectionProposalV1":
+        correction = MemoryCorrectionProposalV1.model_validate(artifact)
+        return {
+            "artifact_type": envelope.artifact_type,
+            "current_belief": correction.current_belief,
+            "proposed_belief": correction.proposed_belief,
+            "correction_type": correction.correction_type,
+            "rationale": correction.rationale,
+            "target_memory_domains": correction.target_memory_domains,
+            "rollback_plan": correction.rollback_plan,
+        }
+    return {
+        "artifact_type": envelope.artifact_type,
+        "artifact_keys": sorted(artifact.keys()) if isinstance(artifact, dict) else [],
+    }
+
+
+def cmd_seed_demo(args: argparse.Namespace) -> int:
+    store_path = _require_store(args.store)
+    repo = _open_repo(store_path)
+
+    patch = PatchProposalV1(
+        problem="README typo in operator section",
+        proposed_change_summary="Fix spelling in operator docs",
+        rollback_plan="Revert README change",
+        evidence=["typo spotted in review"],
+        risk="low",
+    )
+    patch_envelope = build_patch_proposal_envelope(patch, source_mode="patch_proposal")
+    stored_record = ProposalLedgerRecordV1(
+        proposal_id=patch_envelope.proposal_id,
+        envelope=patch_envelope,
+        status="stored",
+        source_mode="patch_proposal",
+        created_at=_utc_now(),
+    )
+    repo.store(stored_record)
+
+    correction = MemoryCorrectionProposalV1(
+        current_belief="User is from Denver",
+        proposed_belief="User location is unknown",
+        correction_type="mark_uncertain",
+        rationale="Insufficient evidence for Denver claim",
+        rollback_plan="No mutation proposed; no rollback required.",
+        supporting_evidence=["user mentioned Colorado once"],
+        risk="medium",
+    )
+    memory_envelope = build_memory_correction_proposal_envelope(
+        correction,
+        source_mode="memory_correction_proposal",
+    )
+    memory_record = ProposalLedgerRecordV1(
+        proposal_id=memory_envelope.proposal_id,
+        envelope=memory_envelope,
+        status="stored",
+        source_mode="memory_correction_proposal",
+        created_at=_utc_now(),
+    )
+    repo.store(memory_record)
+    pending = repo.apply_triage(
+        ProposalTriageDecisionV1(
+            proposal_id=memory_record.proposal_id,
+            action="promote_to_review",
+            rationale="identity memory correction",
+            attention_required=True,
+            attention_reason="identity memory correction",
+        )
+    )
+
+    blocked_correction = MemoryCorrectionProposalV1(
+        current_belief="User prefers dark mode",
+        rationale="Low confidence preference claim",
+        rollback_plan="No mutation proposed; no rollback required.",
+        confidence=0.1,
+        risk="low",
+    )
+    blocked_envelope = build_memory_correction_proposal_envelope(
+        blocked_correction,
+        source_mode="memory_correction_proposal",
+    )
+    blocked_record = ProposalLedgerRecordV1(
+        proposal_id=blocked_envelope.proposal_id,
+        envelope=blocked_envelope,
+        status="stored",
+        source_mode="memory_correction_proposal",
+        created_at=_utc_now(),
+    )
+    repo.store(blocked_record)
+    blocked = repo.apply_triage(
+        ProposalTriageDecisionV1(
+            proposal_id=blocked_record.proposal_id,
+            action="block_for_evidence",
+            rationale="needs stronger grounding",
+            attention_required=True,
+            attention_reason="low confidence",
+        )
+    )
+
+    payload = {
+        "seeded": True,
+        "store": str(store_path),
+        "records": {
+            "stored_patch": stored_record.proposal_id,
+            "pending_review_memory": pending.proposal_id,
+            "blocked_low_confidence": blocked.proposal_id,
+        },
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    store_path = _require_store(args.store)
+    repo = _open_repo(store_path)
+    records = repo.list_by_status(args.status) if args.status else repo.list_all()
+    rows = [_record_row(record) for record in records]
+    if args.json:
+        for row in rows:
+            print(json.dumps(row, sort_keys=True))
+    else:
+        for row in rows:
+            print(
+                "\t".join(
+                    [
+                        row["proposal_id"],
+                        row["proposal_type"],
+                        row["status"],
+                        row["risk"],
+                        str(row["attention_required"]).lower(),
+                        row["title"],
+                    ]
+                )
+            )
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    store_path = _require_store(args.store)
+    repo = _open_repo(store_path)
+    record = repo.get(args.proposal_id)
+    if record is None:
+        raise SystemExit(f"proposal not found: {args.proposal_id}")
+
+    review_history = [
+        item.model_dump(mode="json") for item in repo.review_history(args.proposal_id)
+    ]
+    latest_review = repo.latest_review_decision(args.proposal_id)
+    eligibility = derive_execution_eligibility(record, latest_review)
+
+    payload = {
+        "proposal_id": record.proposal_id,
+        "status": record.status,
+        "attention_required": record.attention_required,
+        "attention_reason": record.attention_reason,
+        "envelope": record.envelope.model_dump(mode="json"),
+        "inner_artifact_summary": _inner_artifact_summary(record.envelope),
+        "evidence": record.envelope.evidence,
+        "risk": record.envelope.risk,
+        "review_history": review_history,
+        "execution_eligibility": eligibility.model_dump(mode="json"),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_triage(args: argparse.Namespace) -> int:
+    store_path = _require_store(args.store)
+    repo = _open_repo(store_path)
+    decision = ProposalTriageDecisionV1(
+        proposal_id=args.proposal_id,
+        action=args.action,
+        rationale=args.reason,
+        reviewer_type="cortex_policy",
+        created_at=_utc_now(),
+    )
+    try:
+        updated = repo.apply_triage(decision)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    except KeyError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    payload = {
+        "proposal_id": updated.proposal_id,
+        "status": updated.status,
+        "attention_required": updated.attention_required,
+        "attention_reason": updated.attention_reason,
+        "triage_action": updated.triage_action,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_review(args: argparse.Namespace) -> int:
+    store_path = _require_store(args.store)
+    repo = _open_repo(store_path)
+    reviewer_type, reviewer_id = _parse_reviewer(args.reviewer)
+    if reviewer_type == "human" and reviewer_id == "context-exec":
+        raise SystemExit("context-exec cannot act as proposal reviewer")
+
+    decision = ProposalReviewDecisionV1(
+        decision_id=f"dec_{uuid.uuid4().hex[:12]}",
+        proposal_id=args.proposal_id,
+        decision=args.decision,
+        reviewer_type=reviewer_type,
+        reviewer_id=reviewer_id,
+        rationale=args.reason,
+        created_at=_utc_now(),
+    )
+    try:
+        updated = repo.apply_review(decision)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    except KeyError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    eligibility = derive_execution_eligibility(updated, decision)
+    payload = {
+        "proposal_id": updated.proposal_id,
+        "status": updated.status,
+        "review_decision": decision.model_dump(mode="json"),
+        "execution_eligibility": eligibility.model_dump(mode="json"),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_eligibility(args: argparse.Namespace) -> int:
+    store_path = _require_store(args.store)
+    repo = _open_repo(store_path)
+    record = repo.get(args.proposal_id)
+    if record is None:
+        raise SystemExit(f"proposal not found: {args.proposal_id}")
+
+    latest_review = repo.latest_review_decision(args.proposal_id)
+    eligibility = derive_execution_eligibility(record, latest_review)
+    print(json.dumps(eligibility.model_dump(mode="json"), indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Orion proposal ledger operator CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    seed = sub.add_parser("seed-demo", help="Seed demo proposal records (no mutation)")
+    seed.add_argument("--store", required=True, help="JSON ledger file path")
+    seed.set_defaults(func=cmd_seed_demo)
+
+    list_cmd = sub.add_parser("list", help="List proposal ledger records")
+    list_cmd.add_argument("--store", required=True, help="JSON ledger file path")
+    list_cmd.add_argument("--status", default=None, help="Filter by proposal status")
+    list_cmd.add_argument("--json", action="store_true", help="Emit JSON lines")
+    list_cmd.set_defaults(func=cmd_list)
+
+    show = sub.add_parser("show", help="Show proposal details")
+    show.add_argument("proposal_id")
+    show.add_argument("--store", required=True, help="JSON ledger file path")
+    show.set_defaults(func=cmd_show)
+
+    triage = sub.add_parser("triage", help="Apply triage decision")
+    triage.add_argument("proposal_id")
+    triage.add_argument(
+        "--action",
+        required=True,
+        choices=[
+            "store_only",
+            "promote_to_review",
+            "block_for_evidence",
+            "discard",
+            "supersede",
+            "expire",
+        ],
+    )
+    triage.add_argument("--reason", required=True)
+    triage.add_argument("--store", required=True, help="JSON ledger file path")
+    triage.set_defaults(func=cmd_triage)
+
+    review = sub.add_parser("review", help="Apply review decision")
+    review.add_argument("proposal_id")
+    review.add_argument("--decision", required=True, choices=["approve", "reject", "request_changes"])
+    review.add_argument("--reason", required=True)
+    review.add_argument("--reviewer", default="human:operator")
+    review.add_argument("--store", required=True, help="JSON ledger file path")
+    review.set_defaults(func=cmd_review)
+
+    eligibility = sub.add_parser("eligibility", help="Show execution eligibility")
+    eligibility.add_argument("proposal_id")
+    eligibility.add_argument("--store", required=True, help="JSON ledger file path")
+    eligibility.set_defaults(func=cmd_eligibility)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-context-exec/README.md
+++ b/services/orion-context-exec/README.md
@@ -34,6 +34,8 @@ Context-exec is in **beta** for three investigative modes. Full runbook: [docs/c
 
 **Lifecycle:** context-exec proposal → `ProposalEnvelopeV1` → `ProposalLedgerRecordV1(status=stored)` → `ProposalTriageDecisionV1` → `pending_review` (only if attention-worthy) → `ProposalReviewDecisionV1` → `ProposalExecutionEligibilityV1` → future executor → future receipt.
 
+**Operator CLI:** `scripts/orion_proposal_cli.py` is the first operator review surface. It lists/shows ledger records, applies triage/review via lifecycle validators, and prints execution eligibility. It does not execute proposals or mutate memory/repo/runtime state. Use an explicit `--store /path/to/proposals.json` path (never repo files). Only `pending_review` records require active human attention by default; stored/blocked/discarded/expired/superseded proposals stay out of the default review queue.
+
 **Engine selection:** `fake` (default) | `alexzhang` (opt-in). Fallback must be explicit (`CONTEXT_EXEC_RLM_FALLBACK_ENABLED=true`) and visible in `runtime_debug`.
 
 **Safety defaults:** read-only, `CONTEXT_EXEC_MAX_DEPTH=1`, write/network off, compat AgentChain bus alias off.

--- a/services/orion-context-exec/tests/test_proposal_ledger.py
+++ b/services/orion-context-exec/tests/test_proposal_ledger.py
@@ -222,3 +222,52 @@ def test_in_memory_repository_triage_and_review() -> None:
 
     listed = repo.list_by_status("approved")
     assert len(listed) == 1
+
+
+def test_eligibility_does_not_create_execution_receipt() -> None:
+    record = _stored_record()
+    promote = ProposalTriageDecisionV1(
+        proposal_id=record.proposal_id,
+        action="promote_to_review",
+        rationale="review needed",
+    )
+    pending = apply_triage_decision(record, promote)
+    review = ProposalReviewDecisionV1(
+        decision_id="dec_elig",
+        proposal_id=pending.proposal_id,
+        decision="approve",
+        reviewer_type="human",
+        reviewer_id="operator",
+        rationale="bounded and reversible",
+    )
+    approved = apply_review_decision(pending, review)
+    eligibility = derive_execution_eligibility(approved, review)
+
+    assert eligibility.eligible is True
+    assert eligibility.execution_requested is False
+    assert approved.status == "approved"
+    assert approved.status not in {"executed", "execution_requested"}
+
+
+def test_review_reject_does_not_execute() -> None:
+    record = _stored_record()
+    promote = ProposalTriageDecisionV1(
+        proposal_id=record.proposal_id,
+        action="promote_to_review",
+        rationale="review needed",
+    )
+    pending = apply_triage_decision(record, promote)
+    review = ProposalReviewDecisionV1(
+        decision_id="dec_reject",
+        proposal_id=pending.proposal_id,
+        decision="reject",
+        reviewer_type="human",
+        reviewer_id="operator",
+        rationale="unsupported evidence",
+    )
+    rejected = apply_review_decision(pending, review)
+    eligibility = derive_execution_eligibility(rejected, review)
+
+    assert rejected.status == "rejected"
+    assert eligibility.eligible is False
+    assert eligibility.execution_requested is False

--- a/tests/scripts/test_orion_proposal_cli.py
+++ b/tests/scripts/test_orion_proposal_cli.py
@@ -1,0 +1,285 @@
+"""Tests for operator proposal CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CLI = ROOT / "scripts" / "orion_proposal_cli.py"
+PYTHON = ROOT / "orion_dev" / "bin" / "python"
+
+
+def _run_cli(*args: str, store: Path) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        str(PYTHON if PYTHON.exists() else sys.executable),
+        str(CLI),
+        *args,
+        "--store",
+        str(store),
+    ]
+    env = {"PYTHONPATH": str(ROOT)}
+    return subprocess.run(
+        cmd,
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def store_path(tmp_path: Path) -> Path:
+    return tmp_path / "proposals.json"
+
+
+def test_proposal_cli_seed_demo_creates_fixture_records(store_path: Path) -> None:
+    result = subprocess.run(
+        [
+            str(PYTHON if PYTHON.exists() else sys.executable),
+            str(CLI),
+            "seed-demo",
+            "--store",
+            str(store_path),
+        ],
+        cwd=ROOT,
+        env={"PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["seeded"] is True
+    assert store_path.exists()
+
+
+def test_proposal_cli_list_filters_pending_review(store_path: Path) -> None:
+    seed = subprocess.run(
+        [
+            str(PYTHON if PYTHON.exists() else sys.executable),
+            str(CLI),
+            "seed-demo",
+            "--store",
+            str(store_path),
+        ],
+        cwd=ROOT,
+        env={"PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    seed_payload = json.loads(seed.stdout)
+    pending_id = seed_payload["records"]["pending_review_memory"]
+
+    result = _run_cli("list", "--status", "pending_review", "--json", store=store_path)
+    assert result.returncode == 0, result.stderr
+    rows = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+    assert len(rows) == 1
+    assert rows[0]["proposal_id"] == pending_id
+    assert rows[0]["status"] == "pending_review"
+
+    stored_result = _run_cli("list", "--status", "stored", "--json", store=store_path)
+    stored_rows = [
+        json.loads(line) for line in stored_result.stdout.strip().splitlines() if line.strip()
+    ]
+    assert all(row["status"] == "stored" for row in stored_rows)
+    assert pending_id not in {row["proposal_id"] for row in stored_rows}
+
+
+def test_proposal_cli_show_displays_envelope_and_inner_artifact(store_path: Path) -> None:
+    seed = subprocess.run(
+        [
+            str(PYTHON if PYTHON.exists() else sys.executable),
+            str(CLI),
+            "seed-demo",
+            "--store",
+            str(store_path),
+        ],
+        cwd=ROOT,
+        env={"PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    proposal_id = json.loads(seed.stdout)["records"]["pending_review_memory"]
+
+    result = _run_cli("show", proposal_id, store=store_path)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["proposal_id"] == proposal_id
+    assert payload["envelope"]["proposal_type"] == "memory_correction_proposal"
+    assert payload["inner_artifact_summary"]["artifact_type"] == "MemoryCorrectionProposalV1"
+    assert payload["inner_artifact_summary"]["current_belief"]
+    assert "execution_eligibility" in payload
+
+
+def test_proposal_cli_triage_store_only_does_not_create_human_chore(store_path: Path) -> None:
+    seed = subprocess.run(
+        [
+            str(PYTHON if PYTHON.exists() else sys.executable),
+            str(CLI),
+            "seed-demo",
+            "--store",
+            str(store_path),
+        ],
+        cwd=ROOT,
+        env={"PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    proposal_id = json.loads(seed.stdout)["records"]["stored_patch"]
+
+    result = _run_cli(
+        "triage",
+        proposal_id,
+        "--action",
+        "store_only",
+        "--reason",
+        "not worth human attention",
+        store=store_path,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "stored"
+    assert payload["attention_required"] is False
+
+
+def test_proposal_cli_triage_promote_sets_pending_review_attention(store_path: Path) -> None:
+    seed = subprocess.run(
+        [
+            str(PYTHON if PYTHON.exists() else sys.executable),
+            str(CLI),
+            "seed-demo",
+            "--store",
+            str(store_path),
+        ],
+        cwd=ROOT,
+        env={"PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    proposal_id = json.loads(seed.stdout)["records"]["stored_patch"]
+
+    result = _run_cli(
+        "triage",
+        proposal_id,
+        "--action",
+        "promote_to_review",
+        "--reason",
+        "identity memory correction",
+        store=store_path,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "pending_review"
+    assert payload["attention_required"] is True
+
+
+def test_proposal_cli_review_reject_does_not_execute(store_path: Path) -> None:
+    seed = subprocess.run(
+        [
+            str(PYTHON if PYTHON.exists() else sys.executable),
+            str(CLI),
+            "seed-demo",
+            "--store",
+            str(store_path),
+        ],
+        cwd=ROOT,
+        env={"PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    proposal_id = json.loads(seed.stdout)["records"]["pending_review_memory"]
+
+    result = _run_cli(
+        "review",
+        proposal_id,
+        "--decision",
+        "reject",
+        "--reason",
+        "unsupported evidence",
+        "--reviewer",
+        "human:june",
+        store=store_path,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "rejected"
+    assert payload["execution_eligibility"]["eligible"] is False
+    assert payload["execution_eligibility"]["execution_requested"] is False
+
+
+def test_proposal_cli_review_approve_creates_eligibility_not_execution(store_path: Path) -> None:
+    seed = subprocess.run(
+        [
+            str(PYTHON if PYTHON.exists() else sys.executable),
+            str(CLI),
+            "seed-demo",
+            "--store",
+            str(store_path),
+        ],
+        cwd=ROOT,
+        env={"PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    proposal_id = json.loads(seed.stdout)["records"]["pending_review_memory"]
+
+    result = _run_cli(
+        "review",
+        proposal_id,
+        "--decision",
+        "approve",
+        "--reason",
+        "bounded and reversible",
+        "--reviewer",
+        "human:june",
+        store=store_path,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "approved"
+    assert payload["execution_eligibility"]["eligible"] is True
+    assert payload["execution_eligibility"]["execution_requested"] is False
+
+
+def test_proposal_cli_rejects_context_exec_as_reviewer_for_approval(store_path: Path) -> None:
+    seed = subprocess.run(
+        [
+            str(PYTHON if PYTHON.exists() else sys.executable),
+            str(CLI),
+            "seed-demo",
+            "--store",
+            str(store_path),
+        ],
+        cwd=ROOT,
+        env={"PYTHONPATH": str(ROOT)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    proposal_id = json.loads(seed.stdout)["records"]["pending_review_memory"]
+
+    result = _run_cli(
+        "review",
+        proposal_id,
+        "--decision",
+        "approve",
+        "--reason",
+        "bad actor",
+        "--reviewer",
+        "context-exec",
+        store=store_path,
+    )
+    assert result.returncode != 0
+    assert "context-exec" in (result.stderr + result.stdout).lower()


### PR DESCRIPTION
## Summary

Hardens proposal schema registration and adds the first operator proposal read/review CLI surface.

This verifies the proposal control-plane schemas are registered and not duplicated, then adds a small CLI for seeding demo proposals, listing/showing proposal records, applying triage decisions, and recording review decisions. Approval creates future execution eligibility only; it does not execute anything.

## Changes

- Add proposal schema registry hardening tests.
- Verify `MemoryCorrectionProposalV1` is the real registered schema, not a duplicate stub.
- Add `JsonFileProposalLedgerRepository` for explicit `--store` JSON persistence.
- Add operator proposal CLI (`scripts/orion_proposal_cli.py`).
- Add demo proposal seeding.
- Add list/show/triage/review/eligibility commands.
- Add tests proving CLI review does not execute.
- Add docs for proposal operator surface and Hub attention model.

## Verification

- `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/ -q` → 107 passed, 1 xfailed
- `PYTHONPATH=. orion_dev/bin/python -m pytest orion/schemas -q` → 9 passed
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine fake` → pass
- `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine alexzhang` → pass
- `ORION_PY=orion_dev/bin/python bash scripts/context_exec_beta_gate.sh` → BETA GATE PASS
- CLI smoke with `/tmp/orion-proposals.json` → pass

## Safety

- No Hub UI
- No approval endpoint
- No executor
- No proposal execution
- No repo/memory/runtime mutation
- Approval only creates eligibility for a future executor

## Operator CLI

Proposal ledger is the system of record. Hub is an attention router. CLI is the first operator review surface. CLI can triage/review but cannot execute. Approval only creates future execution eligibility.

Not every proposal becomes a human chore. Only `pending_review` records require active attention.

```bash
PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py seed-demo --store /tmp/orion-proposals.json
PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py list --status pending_review --store /tmp/orion-proposals.json
PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py show <proposal_id> --store /tmp/orion-proposals.json
PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py review <proposal_id> --decision reject --reason "unsupported evidence" --reviewer human:june --store /tmp/orion-proposals.json