### PR TITLE
Harden Denver vertical slice read-only verification path.

### DIFF
--- a/docs/context-exec-beta-runbook.md
+++ b/docs/context-exec-beta-runbook.md
@@ -444,6 +444,26 @@ This smoke does **not** approve, reject, execute, or mutate memory. It only prov
 ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh
 ```
 
+Expected output (abbreviated):
+
+```text
+== Denver vertical slice (context-exec + ledger + auto-triage) ==
+VERTICAL_SLICE proposal_id=prop_... status=pending_review type=memory_correction_proposal envelope=ProposalEnvelopeV1 inner=MemoryCorrectionProposalV1 mutation_allowed=False requires_human_approval=True
+== proposal review API (pytest harness) ==
+1 passed
+== proposal review API inline GET check ==
+API GET PASS eligible=false mutation_allowed=false requires_human_approval=true
+== Hub live check skipped (set HUB_SMOKE=true and HUB_BASE_URL to enable) ==
+denver_memory_correction_vertical_smoke PASS
+```
+
+Assertions verified by the smoke:
+
+- exactly one Denver `pending_review` proposal in the temp ledger
+- proposal type `memory_correction_proposal`, envelope `ProposalEnvelopeV1`, inner `MemoryCorrectionProposalV1`
+- `mutation_allowed=false`, `requires_human_approval=true`
+- eligibility `eligible=false` before approval (no execution requested)
+
 Optional env:
 
 ```bash

--- a/docs/proposal-review-api.md
+++ b/docs/proposal-review-api.md
@@ -119,6 +119,8 @@ This smoke does **not** approve, reject, execute, or mutate memory.
 ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh
 ```
 
+Expected: `denver_memory_correction_vertical_smoke PASS` with one `pending_review` Denver proposal, API GET checks showing `eligible=false`, `mutation_allowed=false`, `requires_human_approval=true`. Hub live GET is optional (`HUB_SMOKE=true HUB_BASE_URL=...`).
+
 Or manually:
 
 ```bash

--- a/docs/superpowers/pr-reports/2026-06-14-denver-vertical-harden-pr.md
+++ b/docs/superpowers/pr-reports/2026-06-14-denver-vertical-harden-pr.md
@@ -1,0 +1,57 @@
+# PR: Harden Denver vertical slice after merge
+
+**Branch:** `feat/denver-vertical-harden`  
+**Title:** Harden Denver vertical slice after merge  
+**Create PR:** https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/denver-vertical-harden?expand=1
+
+## Summary
+
+Hardens the merged Denver memory-correction vertical slice.
+
+This verifies the end-to-end read-only path from context-exec proposal generation through proposal ledger intake, deterministic auto-triage, proposal review API exposure, and Hub Pending Decisions display.
+
+## Changes
+
+- Strengthen `assert_denver_vertical_slice_safety` with inner-artifact checks (belief, correction type, rationale, risk, confidence).
+- Expand smoke script assertions: envelope/inner types, safety flags, eligibility `eligible=false`, richer stdout.
+- Add `_GetOnlyClientSession` GET-only HTTP guard in Hub proposal review client (blocks POST/PUT/PATCH/DELETE).
+- Add Hub tests: GET path allowlist, non-GET method rejection, stronger Denver card + read-only UI assertions.
+- Strengthen UI wiring test for evidence/risk/confidence fields and absence of action buttons.
+- Document expected smoke output in runbook, proposal-review-api, and Hub README.
+
+## Flow
+
+```text
+memory_correction_proposal (Denver)
+  → ProposalEnvelopeV1
+  → ProposalLedgerRecordV1
+  → auto-triage pending_review
+  → GET /proposals (proposal review API)
+  → Hub Pending Decisions (read-only)
+```
+
+## Safety
+
+- Read-only Hub surface
+- No approve/reject/triage actions
+- No executor
+- No execution receipts
+- No memory/repo/runtime mutation
+- Hub performs GET only
+- `mutation_allowed=false`, `requires_human_approval=true`, eligibility `eligible=false` before approval
+
+## Verification
+
+| Command | Exit | Result |
+|---------|------|--------|
+| `ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh` | 0 | PASS |
+| `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/test_proposal_ledger_intake.py tests/services/test_proposal_review_api.py services/orion-hub/tests/test_proposal_review_hub.py services/orion-hub/tests/test_proposal_review_ui.py -q` | 0 | 56 passed |
+| `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine fake` | 0 | all cases ok |
+| `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine alexzhang` | 0 | all cases ok |
+
+## Test plan
+
+- [ ] Run smoke script from clean main — one Denver `pending_review` proposal
+- [ ] Confirm API GET checks: `eligible=false`, safety flags set
+- [ ] Hub Pending Decisions shows Denver card with belief/correction/rationale/evidence/risk — no action buttons
+- [ ] Confirm Hub client rejects POST to `/triage` and `/review`

--- a/scripts/denver_memory_correction_vertical_smoke.sh
+++ b/scripts/denver_memory_correction_vertical_smoke.sh
@@ -41,11 +41,13 @@ inner = MemoryCorrectionProposalV1.model_validate(envelope.artifact)
 
 assert run.artifact_type == "ProposalEnvelopeV1", run.artifact_type
 assert envelope.proposal_type == "memory_correction_proposal", envelope.proposal_type
-assert envelope.artifact_type == "MemoryCorrectionProposalV1"
+assert envelope.artifact_type == "MemoryCorrectionProposalV1", envelope.artifact_type
 assert envelope.proposal_id
+assert envelope.mutation_allowed is False
+assert envelope.requires_human_approval is True
 assert run.runtime_debug.get("ledger_status") in {"pending_review", "blocked"}
 assert run.runtime_debug.get("ledger_status") == "pending_review", run.runtime_debug
-assert_denver_vertical_slice_safety(run, record, envelope)
+assert_denver_vertical_slice_safety(run, record, envelope, inner=inner)
 
 pending = result["repo"].list_by_status("pending_review")
 denver_rows = [
@@ -53,7 +55,17 @@ denver_rows = [
     if "denver" in json.dumps(row.envelope.model_dump(mode="json")).lower()
 ]
 assert len(denver_rows) == 1, f"expected one Denver pending_review row, got {len(denver_rows)}"
-print(f"VERTICAL_SLICE proposal_id={envelope.proposal_id} status={record.status}")
+assert denver_rows[0].envelope.proposal_type == "memory_correction_proposal"
+assert denver_rows[0].envelope.artifact_type == "MemoryCorrectionProposalV1"
+print(
+    f"VERTICAL_SLICE proposal_id={envelope.proposal_id} "
+    f"status={record.status} "
+    f"type={envelope.proposal_type} "
+    f"envelope={run.artifact_type} "
+    f"inner={envelope.artifact_type} "
+    f"mutation_allowed={envelope.mutation_allowed} "
+    f"requires_human_approval={envelope.requires_human_approval}"
+)
 PY
 
 echo "== proposal review API (pytest harness) =="
@@ -88,10 +100,21 @@ with TestClient(app) as client:
     eligibility = client.get(f"/proposals/{pid}/eligibility")
     assert detail.status_code == 200, detail.text
     assert eligibility.status_code == 200, eligibility.text
-    assert eligibility.json()["eligible"] is False
+    elig_body = eligibility.json()
+    assert elig_body["eligible"] is False, elig_body
+    assert elig_body.get("execution_requested") is False
     inner = detail.json()["inner_artifact_summary"]
+    detail_env = detail.json()["envelope"]
+    assert detail_env["proposal_type"] == "memory_correction_proposal"
+    assert detail_env["artifact_type"] == "MemoryCorrectionProposalV1"
+    assert inner["artifact_type"] == "MemoryCorrectionProposalV1"
     assert "denver" in inner["current_belief"].lower()
-print("API GET PASS")
+    assert inner["correction_type"] in {"mark_uncertain", "mark_contradicted", "replace_belief"}
+    assert inner["mutation_allowed"] is False
+    assert inner["requires_human_approval"] is True
+    assert inner.get("rationale")
+    assert inner.get("risk") in {"low", "medium", "high"}
+print("API GET PASS eligible=false mutation_allowed=false requires_human_approval=true")
 PY
 
 if [[ "${HUB_SMOKE:-false}" == "true" ]] && [[ -n "${HUB_BASE_URL:-}" ]]; then

--- a/services/orion-context-exec/tests/test_proposal_ledger_intake.py
+++ b/services/orion-context-exec/tests/test_proposal_ledger_intake.py
@@ -669,7 +669,7 @@ async def test_denver_memory_correction_vertical_slice_persists_pending_review(
     assert envelope.artifact_type == "MemoryCorrectionProposalV1"
     assert run.runtime_debug.get("ledger_status") == "pending_review"
     assert run.runtime_debug.get("proposal_id") == envelope.proposal_id
-    assert_denver_vertical_slice_safety(run, record, envelope)
+    assert_denver_vertical_slice_safety(run, record, envelope, inner=inner)
     assert "denver" in inner.current_belief.lower()
     assert inner.correction_type in {"mark_uncertain", "mark_contradicted", "replace_belief"}
     assert len(result["repo"].list_by_status("pending_review")) == 1

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -422,7 +422,7 @@ Then open the Hub Memory tab → **Review queue**, or `GET /api/memory/cards?sta
 
 **Proposal review (read-only attention surface):** Hub main tab → **Pending Decisions** lists decision-worthy `pending_review` proposals from the context-exec proposal review API. Disabled by default (`HUB_PROPOSAL_REVIEW_ENABLED=false`). Hub calls `GET /health`, `GET /proposals`, detail, and eligibility only — it does not read JSON ledger files, does not POST triage/review, and does not approve/reject/execute. See [docs/proposal-review-api.md](../../docs/proposal-review-api.md).
 
-**Denver memory correction vertical slice:** `ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh` proves a Denver `memory_correction_proposal` reaches Pending Decisions read-only. No approval, execution, or memory mutation.
+**Denver memory correction vertical slice:** `ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh` proves a Denver `memory_correction_proposal` reaches Pending Decisions read-only. Expected final line: `denver_memory_correction_vertical_smoke PASS`. Hub card shows current belief, proposed correction, rationale, evidence summary, risk/confidence, and safety flags — no approve/reject buttons. No approval, execution, or memory mutation.
 
 ---
 

--- a/services/orion-hub/scripts/proposal_review_client.py
+++ b/services/orion-hub/scripts/proposal_review_client.py
@@ -50,6 +50,35 @@ def _assert_get_path(path: str) -> None:
     raise ProposalReviewClientError(f"forbidden proposal review path: {path}")
 
 
+class _GetOnlyClientSession:
+    """Wrap aiohttp.ClientSession so only GET requests reach the proposal review API."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._session = aiohttp.ClientSession(**kwargs)
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        return self._session.get(url, **kwargs)
+
+    async def post(self, *args: Any, **kwargs: Any) -> Any:
+        raise ProposalReviewClientError("forbidden HTTP method for proposal review client: POST")
+
+    async def put(self, *args: Any, **kwargs: Any) -> Any:
+        raise ProposalReviewClientError("forbidden HTTP method for proposal review client: PUT")
+
+    async def patch(self, *args: Any, **kwargs: Any) -> Any:
+        raise ProposalReviewClientError("forbidden HTTP method for proposal review client: PATCH")
+
+    async def delete(self, *args: Any, **kwargs: Any) -> Any:
+        raise ProposalReviewClientError("forbidden HTTP method for proposal review client: DELETE")
+
+    async def __aenter__(self) -> _GetOnlyClientSession:
+        await self._session.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self._session.__aexit__(*args)
+
+
 async def _get_json(path: str, *, params: dict[str, str] | None = None) -> dict[str, Any]:
     _assert_get_path(path)
     base = _base_url()
@@ -58,7 +87,7 @@ async def _get_json(path: str, *, params: dict[str, str] | None = None) -> dict[
 
     url = f"{base}{path}"
     try:
-        async with aiohttp.ClientSession(timeout=_timeout()) as session:
+        async with _GetOnlyClientSession(timeout=_timeout()) as session:
             async with session.get(url, params=params) as response:
                 text = await response.text()
                 try:

--- a/services/orion-hub/tests/test_proposal_review_hub.py
+++ b/services/orion-hub/tests/test_proposal_review_hub.py
@@ -153,6 +153,53 @@ def test_hub_proposal_review_unavailable_is_nonfatal(monkeypatch: pytest.MonkeyP
     assert body["proposals"] == []
 
 
+def test_hub_proposal_review_client_get_allowlist_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_hub_modules(monkeypatch, enabled=True)
+    import scripts.proposal_review_client as client_mod
+
+    allowed = (
+        "/health",
+        "/proposals",
+        "/proposals/prop_1",
+        "/proposals/prop_1/eligibility",
+    )
+    for path in allowed:
+        client_mod._assert_get_path(path)  # noqa: SLF001
+
+    forbidden = (
+        "/proposals/prop_1/triage",
+        "/proposals/prop_1/review",
+        "/triage",
+        "/review",
+    )
+    for path in forbidden:
+        with pytest.raises(client_mod.ProposalReviewClientError):
+            client_mod._assert_get_path(path)  # noqa: SLF001
+
+
+def test_hub_proposal_review_client_rejects_non_get_http_methods(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reload_hub_modules(monkeypatch, enabled=True)
+    import scripts.proposal_review_client as client_mod
+
+    class _NoopSession:
+        def get(self, *args: object, **kwargs: object) -> object:
+            return None
+
+        async def __aenter__(self) -> _NoopSession:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(client_mod.aiohttp, "ClientSession", lambda **kwargs: _NoopSession())
+    session = client_mod._GetOnlyClientSession()  # noqa: SLF001
+    for method in ("post", "put", "patch", "delete"):
+        with pytest.raises(client_mod.ProposalReviewClientError, match="forbidden HTTP method"):
+            asyncio.run(getattr(session, method)())
+
+
 def test_hub_proposal_review_does_not_call_post_review_or_triage(monkeypatch: pytest.MonkeyPatch) -> None:
     _reload_hub_modules(monkeypatch, enabled=True)
     import scripts.proposal_review_client as client_mod
@@ -282,15 +329,34 @@ def test_hub_pending_decisions_shows_denver_memory_correction(monkeypatch: pytes
     assert inner["correction_type"] == "mark_uncertain"
     assert inner["mutation_allowed"] is False
     assert inner["requires_human_approval"] is True
+    assert inner.get("rationale")
+    assert inner.get("risk") in {"low", "medium", "high", "unknown"}
+    assert inner.get("confidence") is not None
+    assert inner.get("supporting_evidence") or inner.get("missing_evidence")
 
     template = (HUB_ROOT / "templates" / "index.html").read_text(encoding="utf-8")
     ui = (HUB_ROOT / "static" / "js" / "proposal-review-ui.js").read_text(encoding="utf-8")
     assert "Pending Decisions" in template
     assert 'id="proposalReviewPanel"' in template
-    for token in ("Current belief:", "Proposed correction:", "Rationale:", "mutation_allowed="):
+    for token in (
+        "Current belief:",
+        "Proposed correction:",
+        "Rationale:",
+        "Evidence:",
+        "Risk:",
+        "Confidence:",
+        "mutation_allowed=",
+        "requires_human_approval=",
+    ):
         assert token in ui
-    assert 'method="post"' not in ui.lower()
-    assert "/review" not in ui
-    assert "/triage" not in ui
+    ui_lower = ui.lower()
+    assert 'method="post"' not in ui_lower
+    assert "fetch(" in ui  # read-only GET via apiFetch
+    for forbidden in ("/review", "/triage", "request-changes", "request changes"):
+        assert forbidden not in ui_lower
+    for forbidden_button in ('id="approve', 'id="reject', ">approve<", ">reject<", "approve proposal", "reject proposal"):
+        assert forbidden_button not in ui_lower
+    for token in ('type="submit"',):
+        assert token not in ui_lower
     routes_source = (HUB_ROOT / "scripts" / "proposal_review_routes.py").read_text(encoding="utf-8")
     assert "@router.post" not in routes_source

--- a/services/orion-hub/tests/test_proposal_review_ui.py
+++ b/services/orion-hub/tests/test_proposal_review_ui.py
@@ -18,6 +18,14 @@ def test_proposal_review_ui_wired() -> None:
     assert "Proposal review API unavailable." in ui
     assert "Current belief:" in ui
     assert "Proposed correction:" in ui
+    assert "Rationale:" in ui
+    assert "Evidence:" in ui
+    assert "Risk:" in ui
+    assert "Confidence:" in ui
     assert "mutation_allowed=" in ui
     assert "requires_human_approval=" in ui
-    assert "approve" not in ui.lower() or "approval inbox" not in ui.lower()
+    ui_lower = ui.lower()
+    for forbidden in ("/triage", "/review", 'method="post"', "request-changes"):
+        assert forbidden not in ui_lower
+    for forbidden_button in ('id="approve', 'id="reject', ">approve<", ">reject<", "approve proposal", "reject proposal"):
+        assert forbidden_button not in ui_lower

--- a/tests/fixtures/denver_vertical_slice.py
+++ b/tests/fixtures/denver_vertical_slice.py
@@ -57,9 +57,18 @@ def run_denver_vertical_slice(
     return asyncio.run(run_denver_vertical_slice_async(store_path, auto_triage=auto_triage))
 
 
-def assert_denver_vertical_slice_safety(run: Any, record: Any, envelope: ProposalEnvelopeV1) -> None:
+def assert_denver_vertical_slice_safety(
+    run: Any,
+    record: Any,
+    envelope: ProposalEnvelopeV1,
+    *,
+    inner: Any | None = None,
+) -> None:
+    from orion.schemas.context_exec import MemoryCorrectionProposalV1
+
     assert run.artifact_type == "ProposalEnvelopeV1"
     assert envelope.proposal_type == "memory_correction_proposal"
+    assert envelope.artifact_type == "MemoryCorrectionProposalV1"
     assert envelope.mutation_allowed is False
     assert envelope.requires_human_approval is True
     assert envelope.review_status in {"draft", "pending_review"}
@@ -69,3 +78,11 @@ def assert_denver_vertical_slice_safety(run: Any, record: Any, envelope: Proposa
     assert record.attention_required is True
     reason = (record.attention_reason or "").lower()
     assert any(token in reason for token in ("memory", "identity", "denver", "core"))
+
+    parsed_inner = inner or MemoryCorrectionProposalV1.model_validate(envelope.artifact)
+    assert parsed_inner.mutation_allowed is False
+    assert "denver" in parsed_inner.current_belief.lower()
+    assert parsed_inner.correction_type in {"mark_uncertain", "mark_contradicted", "replace_belief"}
+    assert parsed_inner.rationale
+    assert parsed_inner.risk in {"low", "medium", "high", "unknown"}
+    assert parsed_inner.confidence is not None


### PR DESCRIPTION
# PR: Harden Denver vertical slice after merge

**Branch:** `feat/denver-vertical-harden`  
**Title:** Harden Denver vertical slice after merge  
**Create PR:** https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/denver-vertical-harden?expand=1

## Summary

Hardens the merged Denver memory-correction vertical slice.

This verifies the end-to-end read-only path from context-exec proposal generation through proposal ledger intake, deterministic auto-triage, proposal review API exposure, and Hub Pending Decisions display.

## Changes

- Strengthen `assert_denver_vertical_slice_safety` with inner-artifact checks (belief, correction type, rationale, risk, confidence).
- Expand smoke script assertions: envelope/inner types, safety flags, eligibility `eligible=false`, richer stdout.
- Add `_GetOnlyClientSession` GET-only HTTP guard in Hub proposal review client (blocks POST/PUT/PATCH/DELETE).
- Add Hub tests: GET path allowlist, non-GET method rejection, stronger Denver card + read-only UI assertions.
- Strengthen UI wiring test for evidence/risk/confidence fields and absence of action buttons.
- Document expected smoke output in runbook, proposal-review-api, and Hub README.

## Flow

```text
memory_correction_proposal (Denver)
  → ProposalEnvelopeV1
  → ProposalLedgerRecordV1
  → auto-triage pending_review
  → GET /proposals (proposal review API)
  → Hub Pending Decisions (read-only)
```

## Safety

- Read-only Hub surface
- No approve/reject/triage actions
- No executor
- No execution receipts
- No memory/repo/runtime mutation
- Hub performs GET only
- `mutation_allowed=false`, `requires_human_approval=true`, eligibility `eligible=false` before approval

## Verification

| Command | Exit | Result |
|---------|------|--------|
| `ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh` | 0 | PASS |
| `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/test_proposal_ledger_intake.py tests/services/test_proposal_review_api.py services/orion-hub/tests/test_proposal_review_hub.py services/orion-hub/tests/test_proposal_review_ui.py -q` | 0 | 56 passed |
| `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine fake` | 0 | all cases ok |
| `PYTHONPATH=. orion_dev/bin/python scripts/context_exec_rlm_eval.py --engine alexzhang` | 0 | all cases ok |

## Test plan

- [ ] Run smoke script from clean main — one Denver `pending_review` proposal
- [ ] Confirm API GET checks: `eligible=false`, safety flags set
- [ ] Hub Pending Decisions shows Denver card with belief/correction/rationale/evidence/risk — no action buttons
- [ ] Confirm Hub client rejects POST to `/triage` and `/review`
