### PR TITLE
Add Hub proposal review actions without execution.

### DIFF
--- a/docs/context-exec-beta-runbook.md
+++ b/docs/context-exec-beta-runbook.md
@@ -404,31 +404,32 @@ bash scripts/proposal_review_api_smoke.sh
 
 See [docs/proposal-review-api.md](proposal-review-api.md).
 
-### Hub read-only proposal review surface
+### Hub proposal review surface
 
-Hub exposes a read-only **Pending Decisions** panel on the main Hub tab. It calls the proposal review API only — never JSON ledger files.
+Hub exposes a **Pending Decisions** panel on the main Hub tab. It calls the proposal review API only — never JSON ledger files. Hub can record review decisions (`approve`, `reject`, `request_changes`) via `POST /proposals/{proposal_id}/review`. Hub cannot triage or execute.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `HUB_PROPOSAL_REVIEW_ENABLED` | `false` | When true, Hub fetches pending-review proposals from context-exec. |
 | `HUB_PROPOSAL_REVIEW_API_URL` | `http://orion-context-exec:8096` | Base URL for proposal review API (host dev: `http://127.0.0.1:8096`). |
 
-Hub routes (read-only):
+Hub routes:
 
 ```text
 GET /api/proposal-review/health
 GET /api/proposal-review/pending?status=pending_review
 GET /api/proposal-review/proposals/{proposal_id}
 GET /api/proposal-review/proposals/{proposal_id}/eligibility
+POST /api/proposal-review/proposals/{proposal_id}/review
 ```
 
 Default filter is `pending_review` only. Optional secondary filters (blocked, stored, approved/rejected history) are hidden in the UI until the operator reveals the filter control.
 
-When disabled or upstream unavailable, Hub shows a quiet empty/unavailable state — no error spam. Hub does not POST triage/review and does not execute proposals.
+When disabled or upstream unavailable, Hub shows a quiet empty/unavailable state — no error spam. Hub does not POST triage and does not execute proposals. Approval creates future execution eligibility only.
 
 ### Denver memory correction vertical slice
 
-End-to-end usefulness smoke for the proposal control plane (read-only in Hub; no approval or execution):
+End-to-end usefulness smoke for the proposal control plane (read-only listing in smoke; Hub review actions tested separately):
 
 ```text
 memory_correction_proposal
@@ -438,7 +439,7 @@ memory_correction_proposal
   → Hub Pending Decisions
 ```
 
-This smoke does **not** approve, reject, execute, or mutate memory. It only proves a decision-worthy proposal can surface read-only in Hub.
+Denver smoke verifies read-only surfacing only. Hub review actions do not execute or mutate memory/repo/runtime.
 
 ```bash
 ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh

--- a/docs/proposal-review-api.md
+++ b/docs/proposal-review-api.md
@@ -2,7 +2,7 @@
 
 Future Hub-facing control-plane seam over the proposal ledger. Exposes safe review operations without execution, memory writes, or repo mutation.
 
-Hub now includes a **read-only** proposal review surface (`Pending Decisions`) that calls this API. Hub does not read JSON ledger files, does not own lifecycle logic, and does not approve/reject/triage yet.
+Hub now includes a proposal review surface (`Pending Decisions`) that calls this API. Hub can record review decisions (`approve`, `reject`, `request_changes`) through `POST /proposals/{proposal_id}/review`. Hub does not read JSON ledger files, does not own lifecycle logic, and does not triage or execute.
 
 ## Flow
 
@@ -87,8 +87,9 @@ curl -s "http://127.0.0.1:8096/proposals/{id}/eligibility"
 
 ## Safety
 
-- Hub read-only surface (list/detail/eligibility only; no POST from Hub)
-- No approve/reject/triage buttons in Hub yet
+- Hub records review decisions only via `POST /proposals/{proposal_id}/review`
+- Hub cannot triage (`POST /triage` is not exposed from Hub)
+- Hub cannot execute proposals
 - No executor
 - No execution receipts
 - No approval automation or auto-approval
@@ -111,9 +112,9 @@ ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smo
 
 ### Denver memory correction vertical slice
 
-Proves `memory_correction_proposal` → ledger intake → auto-triage `pending_review` → proposal review API → Hub Pending Decisions (read-only).
+Proves `memory_correction_proposal` → ledger intake → auto-triage `pending_review` → proposal review API → Hub Pending Decisions.
 
-This smoke does **not** approve, reject, execute, or mutate memory.
+Denver smoke verifies read-only listing/detail. Hub review actions are tested separately and still do not execute or mutate memory during smoke.
 
 ```bash
 ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh

--- a/docs/superpowers/pr-reports/2026-06-14-hub-proposal-review-actions-pr.md
+++ b/docs/superpowers/pr-reports/2026-06-14-hub-proposal-review-actions-pr.md
@@ -1,0 +1,65 @@
+# PR: Add Hub proposal review actions without execution
+
+**Branch:** `feat/hub-proposal-review-actions`  
+**Title:** Add Hub proposal review actions without execution
+
+## Summary
+
+Adds Hub proposal review actions without execution.
+
+Hub can now approve, reject, or request changes for pending proposals through the proposal review API. Approval creates future execution eligibility only; it does not execute, mutate memory, mutate repo files, or create execution receipts.
+
+## Changes
+
+- Extend Hub proposal review client with POST allowlist for `/proposals/{proposal_id}/review` only (no triage, execute, or arbitrary POST).
+- Add Hub route `POST /api/proposal-review/proposals/{proposal_id}/review` with server-side rationale validation.
+- Add Pending Decisions detail actions: **Approve**, **Reject**, **Request changes** (required rationale; optional constraints on approve).
+- After action: refresh detail, refresh pending list, show status update.
+- Add six safety-focused Hub tests plus test isolation fix for combined pytest runs.
+- Update docs: Hub records review decisions; Hub cannot execute; approval creates eligibility only.
+
+## Architecture
+
+```text
+Hub UI (Pending Decisions detail card)
+  → POST /api/proposal-review/proposals/{id}/review
+  → proposal_review_client (POST allowlist: /proposals/{id}/review only)
+  → context-exec POST /proposals/{id}/review
+  → JsonFileProposalLedgerRepository (context-exec only — Hub never reads/writes ledger files directly)
+```
+
+## Safety
+
+- No executor
+- No execution receipts
+- No memory/repo/runtime mutation
+- Hub only records review decisions via review API
+- Hub does not POST triage
+- Approval only creates future execution eligibility (`eligible=true`, `execution_requested=false`)
+
+## Verification
+
+| Command | Exit | Result |
+|---------|------|--------|
+| `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-hub/tests/test_proposal_review_hub.py services/orion-hub/tests/test_proposal_review_ui.py tests/services/test_proposal_review_api.py -q` | 0 | 34 passed |
+| `ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh` | 0 | PASS |
+| `orion_dev/bin/python -m compileall services/orion-hub/scripts/proposal_review_client.py services/orion-hub/scripts/proposal_review_routes.py -q` | 0 | OK |
+
+## Manual smoke (operator)
+
+1. Seed Denver proposal (`denver_memory_correction_vertical_smoke.sh` or CLI seed-demo).
+2. Start context-exec with proposal review API enabled.
+3. Start Hub with `HUB_PROPOSAL_REVIEW_ENABLED=true`.
+4. Open Hub Pending Decisions → Denver detail.
+5. Reject with rationale → card leaves pending list or status updates to `rejected`.
+6. Repeat with approve → `eligible=true`, no execution receipt, no memory mutation.
+
+## Test plan
+
+- [ ] Hub review buttons visible on pending_review detail card
+- [ ] Empty rationale rejected (client + server 422)
+- [ ] Approve sets `status=approved`, `eligible=true`, `execution_requested=false`
+- [ ] Reject sets `status=rejected`, `eligible=false`
+- [ ] Request changes sets `status=request_changes`, `eligible=false`
+- [ ] Network tab shows POST to `/api/proposal-review/proposals/{id}/review` only (no `/triage`, no execute)
+- [ ] Denver smoke still passes

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -420,9 +420,9 @@ Then open the Hub Memory tab → **Review queue**, or `GET /api/memory/cards?sta
 
 **Memory crystallizations (governed cognitive memory):** `MemoryCrystallizationV1` is separate from `MemoryCardV1` (not MemoryCardV2). Turn-facing recall remains cards; crystallizations are durable governed memory in Postgres with optional projections to cards, Chroma (`orion:memory:vector:upsert`), and Graphiti/FalkorDB via `services/orion-graphiti-adapter/`. RDF `/api/memory/graph/*` is unchanged. Hub Memory tab → **Crystallizations** subview (inbox, approve/reject, projection health). Smoke: `scripts/smoke_memory_crystallization_e2e.sh` (requires Hub restart with this branch).
 
-**Proposal review (read-only attention surface):** Hub main tab → **Pending Decisions** lists decision-worthy `pending_review` proposals from the context-exec proposal review API. Disabled by default (`HUB_PROPOSAL_REVIEW_ENABLED=false`). Hub calls `GET /health`, `GET /proposals`, detail, and eligibility only — it does not read JSON ledger files, does not POST triage/review, and does not approve/reject/execute. See [docs/proposal-review-api.md](../../docs/proposal-review-api.md).
+**Proposal review (attention + review decisions):** Hub main tab → **Pending Decisions** lists decision-worthy `pending_review` proposals from the context-exec proposal review API. Disabled by default (`HUB_PROPOSAL_REVIEW_ENABLED=false`). Hub calls `GET /health`, `GET /proposals`, detail, eligibility, and `POST /proposals/{id}/review` only — it does not read JSON ledger files, does not POST triage, and does not execute. Approval creates future execution eligibility only. See [docs/proposal-review-api.md](../../docs/proposal-review-api.md).
 
-**Denver memory correction vertical slice:** `ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh` proves a Denver `memory_correction_proposal` reaches Pending Decisions read-only. No approval, execution, or memory mutation.
+**Denver memory correction vertical slice:** `ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh` proves a Denver `memory_correction_proposal` reaches Pending Decisions. Smoke is read-only; Hub review actions are tested separately and still do not execute or mutate memory.
 
 ---
 

--- a/services/orion-hub/scripts/proposal_review_client.py
+++ b/services/orion-hub/scripts/proposal_review_client.py
@@ -1,9 +1,10 @@
-"""Read-only Hub client for the context-exec proposal review API."""
+"""Hub client for the context-exec proposal review API (read + review decisions only)."""
 
 from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
 
 import aiohttp
@@ -18,6 +19,8 @@ _ALLOWED_GET_PATHS = frozenset(
         "/proposals",
     }
 )
+
+_REVIEW_POST_PATH = re.compile(r"^/proposals/[^/]+/review$")
 
 
 class ProposalReviewClientError(Exception):
@@ -50,8 +53,26 @@ def _assert_get_path(path: str) -> None:
     raise ProposalReviewClientError(f"forbidden proposal review path: {path}")
 
 
-async def _get_json(path: str, *, params: dict[str, str] | None = None) -> dict[str, Any]:
-    _assert_get_path(path)
+def _assert_post_path(path: str) -> None:
+    if _REVIEW_POST_PATH.match(path):
+        return
+    raise ProposalReviewClientError(f"forbidden proposal review path: {path}")
+
+
+async def _request_json(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if method == "GET":
+        _assert_get_path(path)
+    elif method == "POST":
+        _assert_post_path(path)
+    else:
+        raise ProposalReviewClientError(f"forbidden proposal review method: {method}")
+
     base = _base_url()
     if not base:
         raise ProposalReviewUnavailable("HUB_PROPOSAL_REVIEW_API_URL is not configured")
@@ -59,26 +80,37 @@ async def _get_json(path: str, *, params: dict[str, str] | None = None) -> dict[
     url = f"{base}{path}"
     try:
         async with aiohttp.ClientSession(timeout=_timeout()) as session:
-            async with session.get(url, params=params) as response:
+            kwargs: dict[str, Any] = {"params": params}
+            if body is not None:
+                kwargs["json"] = body
+            async with session.request(method, url, **kwargs) as response:
                 text = await response.text()
                 try:
-                    body: dict[str, Any] = {} if not text else json.loads(text)
+                    payload: dict[str, Any] = {} if not text else json.loads(text)
                 except ValueError:
-                    body = {"raw": text}
+                    payload = {"raw": text}
                 if response.status >= 500:
                     raise ProposalReviewUnavailable(
-                        f"proposal review API error {response.status}: {body.get('detail', text)}"
+                        f"proposal review API error {response.status}: {payload.get('detail', text)}"
                     )
                 if response.status >= 400:
                     raise ProposalReviewClientError(
-                        f"proposal review API error {response.status}: {body.get('detail', text)}"
+                        f"proposal review API error {response.status}: {payload.get('detail', text)}"
                     )
-                if not isinstance(body, dict):
-                    return {"data": body}
-                return body
+                if not isinstance(payload, dict):
+                    return {"data": payload}
+                return payload
     except aiohttp.ClientError as exc:
         logger.warning("proposal_review_client_transport_error path=%s err=%s", path, exc)
         raise ProposalReviewUnavailable("proposal review API unavailable") from exc
+
+
+async def _get_json(path: str, *, params: dict[str, str] | None = None) -> dict[str, Any]:
+    return await _request_json("GET", path, params=params)
+
+
+async def _post_json(path: str, *, body: dict[str, Any]) -> dict[str, Any]:
+    return await _request_json("POST", path, body=body)
 
 
 async def fetch_health() -> dict[str, Any]:
@@ -96,3 +128,8 @@ async def get_proposal(proposal_id: str) -> dict[str, Any]:
 
 async def get_eligibility(proposal_id: str) -> dict[str, Any]:
     return await _get_json(f"/proposals/{proposal_id}/eligibility")
+
+
+async def post_review(proposal_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    """POST review decision to context-exec (approve/reject/request_changes only)."""
+    return await _post_json(f"/proposals/{proposal_id}/review", body=body)

--- a/services/orion-hub/scripts/proposal_review_routes.py
+++ b/services/orion-hub/scripts/proposal_review_routes.py
@@ -1,4 +1,4 @@
-"""Read-only Hub routes proxying the context-exec proposal review API."""
+"""Hub routes proxying the context-exec proposal review API."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
 
 from scripts import proposal_review_client as client
 
@@ -19,7 +20,21 @@ ProposalListFilter = Literal[
     "stored",
     "approved",
     "rejected",
+    "request_changes",
 ]
+
+ProposalReviewDecision = Literal["approve", "reject", "request_changes"]
+
+
+class ProposalReviewActionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: ProposalReviewDecision
+    rationale: str
+    reviewer_type: Literal["human"] = "human"
+    reviewer_id: str = "hub-operator"
+    approved_actions: list[str] = Field(default_factory=list)
+    constraints: dict[str, Any] = Field(default_factory=dict)
 
 
 def _disabled_payload(*, state: str = "disabled") -> dict[str, Any]:
@@ -112,6 +127,26 @@ async def proposal_review_eligibility(proposal_id: str) -> dict[str, Any]:
 
     try:
         return await client.get_eligibility(proposal_id)
+    except client.ProposalReviewUnavailable as exc:
+        raise HTTPException(status_code=503, detail="proposal_review_unavailable") from exc
+    except client.ProposalReviewClientError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.post("/proposals/{proposal_id}/review")
+async def proposal_review_action(proposal_id: str, body: ProposalReviewActionRequest) -> dict[str, Any]:
+    if not client.is_enabled():
+        raise HTTPException(status_code=503, detail="proposal_review_disabled")
+
+    rationale = body.rationale.strip()
+    if not rationale:
+        raise HTTPException(status_code=422, detail="rationale is required")
+
+    payload = body.model_dump(mode="json")
+    payload["rationale"] = rationale
+
+    try:
+        return await client.post_review(proposal_id, payload)
     except client.ProposalReviewUnavailable as exc:
         raise HTTPException(status_code=503, detail="proposal_review_unavailable") from exc
     except client.ProposalReviewClientError as exc:

--- a/services/orion-hub/static/js/proposal-review-ui.js
+++ b/services/orion-hub/static/js/proposal-review-ui.js
@@ -1,4 +1,4 @@
-/* Orion Hub — read-only proposal review attention surface (Pending Decisions) */
+/* Orion Hub — proposal review attention surface (Pending Decisions + review actions) */
 (function () {
   const pathSegments = window.location.pathname.split("/").filter((p) => p.length > 0);
   const URL_PREFIX = pathSegments.length > 0 ? `/${pathSegments[0]}` : "";
@@ -9,12 +9,13 @@
     return sid ? { "X-Orion-Session-Id": sid } : {};
   }
 
-  async function apiFetch(path) {
+  async function apiFetch(path, options) {
     const res = await fetch(`${API_BASE}${path}`, {
       headers: {
         "Content-Type": "application/json",
         ...sessionHeader(),
       },
+      ...options,
     });
     const text = await res.text();
     let body = null;
@@ -44,6 +45,7 @@
     el.textContent = msg || "";
     el.classList.toggle("text-red-400", !!isErr);
     el.classList.toggle("text-gray-500", !isErr);
+    el.classList.toggle("text-emerald-400", !isErr && !!msg);
   }
 
   function renderListRow(item, onSelect) {
@@ -76,6 +78,26 @@
     return parts.join(" · ");
   }
 
+  function renderReviewActions(proposalId, status) {
+    const pending = status === "pending_review" || status === "request_changes";
+    if (!pending) {
+      return `<div class="text-[10px] text-gray-500 pt-2 border-t border-gray-800">Review closed (${escapeHtml(status || "—")}).</div>`;
+    }
+    return `<div class="pt-2 border-t border-gray-800 space-y-2" data-proposal-id="${escapeHtml(proposalId)}">
+      <div class="text-[10px] uppercase tracking-wide text-gray-500">Review decision</div>
+      <label class="block text-[10px] text-gray-500">Rationale (required)</label>
+      <textarea id="proposalReviewRationale" rows="2" class="w-full bg-gray-800 text-gray-200 rounded border border-gray-700 px-2 py-1 text-[11px]" placeholder="Why this decision?"></textarea>
+      <label class="block text-[10px] text-gray-500">Constraints (optional, approve only)</label>
+      <input id="proposalReviewConstraints" type="text" class="w-full bg-gray-800 text-gray-200 rounded border border-gray-700 px-2 py-1 text-[11px]" placeholder="e.g. bounded scope" />
+      <div class="flex flex-wrap gap-2">
+        <button type="button" data-review-decision="approve" class="proposalReviewActionBtn text-[10px] bg-emerald-900/60 hover:bg-emerald-800/70 text-emerald-100 rounded px-2 py-1 border border-emerald-800">Approve</button>
+        <button type="button" data-review-decision="reject" class="proposalReviewActionBtn text-[10px] bg-red-900/50 hover:bg-red-800/60 text-red-100 rounded px-2 py-1 border border-red-900">Reject</button>
+        <button type="button" data-review-decision="request_changes" class="proposalReviewActionBtn text-[10px] bg-amber-900/50 hover:bg-amber-800/60 text-amber-100 rounded px-2 py-1 border border-amber-900">Request changes</button>
+      </div>
+      <div id="proposalReviewActionStatus" class="text-[10px] text-gray-500"></div>
+    </div>`;
+  }
+
   function renderDetail(detail, eligibility) {
     const envelope = (detail && detail.envelope) || {};
     const inner = (detail && detail.inner_artifact_summary) || {};
@@ -100,7 +122,99 @@
       <div><span class="text-gray-500">Execution eligibility:</span> ${escapeHtml(execElig.eligible === true ? "eligible" : execElig.eligible === false ? "not eligible" : "—")}${execElig.reason ? ` — ${escapeHtml(execElig.reason)}` : ""}</div>
       <div><span class="text-gray-500">Safety:</span> mutation_allowed=${escapeHtml(String(mutationAllowed))}, requires_human_approval=${escapeHtml(String(requiresHuman))}</div>
       <div><span class="text-gray-500">Open questions:</span> ${escapeHtml((envelope.open_questions || []).join("; ") || "—")}</div>
+      ${renderReviewActions(detail.proposal_id, detail.status)}
     </div>`;
+  }
+
+  async function submitReviewDecision(proposalId, decision, rationale, constraintsText, actionStatusEl, reload) {
+    const rationaleTrimmed = (rationale || "").trim();
+    if (!rationaleTrimmed) {
+      setStatus(actionStatusEl, "Rationale is required.", true);
+      return;
+    }
+
+    const body = {
+      decision,
+      rationale: rationaleTrimmed,
+      reviewer_type: "human",
+      reviewer_id: "hub-operator",
+    };
+    if (decision === "approve" && constraintsText && constraintsText.trim()) {
+      body.constraints = { note: constraintsText.trim() };
+    }
+
+    setStatus(actionStatusEl, "Submitting review…", false);
+    try {
+      const result = await apiFetch(
+        `/api/proposal-review/proposals/${encodeURIComponent(proposalId)}/review`,
+        { method: "POST", body: JSON.stringify(body) },
+      );
+      const status = result && result.status ? result.status : decision;
+      const eligible =
+        result && result.execution_eligibility && result.execution_eligibility.eligible === true;
+      const msg =
+        decision === "approve"
+          ? `Approved (${status}). Eligible for future execution: ${eligible ? "yes" : "no"}.`
+          : `Recorded ${decision.replace("_", " ")} (${status}).`;
+      setStatus(actionStatusEl, msg, false);
+      if (typeof reload === "function") {
+        await reload(proposalId);
+      }
+    } catch (e) {
+      const detail =
+        (e.body && (e.body.detail || e.body.message)) || e.message || String(e);
+      setStatus(actionStatusEl, `Review failed: ${detail}`, true);
+    }
+  }
+
+  function wireReviewActions(detailEl, reload) {
+    if (!detailEl) return;
+    const proposalId = detailEl.querySelector("[data-proposal-id]");
+    if (!proposalId) return;
+    const id = proposalId.getAttribute("data-proposal-id");
+    const rationaleEl = detailEl.querySelector("#proposalReviewRationale");
+    const constraintsEl = detailEl.querySelector("#proposalReviewConstraints");
+    const actionStatusEl = detailEl.querySelector("#proposalReviewActionStatus");
+    detailEl.querySelectorAll(".proposalReviewActionBtn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const decision = btn.getAttribute("data-review-decision");
+        if (!decision) return;
+        submitReviewDecision(
+          id,
+          decision,
+          rationaleEl ? rationaleEl.value : "",
+          constraintsEl ? constraintsEl.value : "",
+          actionStatusEl,
+          reload,
+        );
+      });
+    });
+  }
+
+  async function loadProposalDetail(proposalId, detailEl, reloadList) {
+    if (!detailEl) return;
+    detailEl.classList.remove("hidden");
+    detailEl.innerHTML = "<div class='text-gray-500'>Loading detail…</div>";
+    try {
+      const detail = await apiFetch(`/api/proposal-review/proposals/${encodeURIComponent(proposalId)}`);
+      let eligibility = null;
+      try {
+        eligibility = await apiFetch(
+          `/api/proposal-review/proposals/${encodeURIComponent(proposalId)}/eligibility`,
+        );
+      } catch {
+        eligibility = detail.execution_eligibility || null;
+      }
+      detailEl.innerHTML = renderDetail(detail, eligibility);
+      wireReviewActions(detailEl, async (refreshedId) => {
+        await loadProposalDetail(refreshedId, detailEl, reloadList);
+        if (typeof reloadList === "function") {
+          await reloadList();
+        }
+      });
+    } catch (e) {
+      detailEl.innerHTML = `<div class="text-red-400">${escapeHtml(e.message || String(e))}</div>`;
+    }
   }
 
   async function loadPendingDecisions(listEl, statusEl, detailEl, filterEl) {
@@ -137,27 +251,10 @@
       }
 
       setStatus(statusEl, `${items.length} decision-worthy proposal(s)`, false);
+      const reloadList = () => loadPendingDecisions(listEl, statusEl, detailEl, filterEl);
       items.forEach((item) => {
         listEl.appendChild(
-          renderListRow(item, async (row) => {
-            if (!detailEl) return;
-            detailEl.classList.remove("hidden");
-            detailEl.innerHTML = "<div class='text-gray-500'>Loading detail…</div>";
-            try {
-              const detail = await apiFetch(`/api/proposal-review/proposals/${encodeURIComponent(row.proposal_id)}`);
-              let eligibility = null;
-              try {
-                eligibility = await apiFetch(
-                  `/api/proposal-review/proposals/${encodeURIComponent(row.proposal_id)}/eligibility`,
-                );
-              } catch {
-                eligibility = detail.execution_eligibility || null;
-              }
-              detailEl.innerHTML = renderDetail(detail, eligibility);
-            } catch (e) {
-              detailEl.innerHTML = `<div class="text-red-400">${escapeHtml(e.message || String(e))}</div>`;
-            }
-          }),
+          renderListRow(item, (row) => loadProposalDetail(row.proposal_id, detailEl, reloadList)),
         );
       });
     } catch (e) {

--- a/services/orion-hub/tests/test_proposal_review_hub.py
+++ b/services/orion-hub/tests/test_proposal_review_hub.py
@@ -1,4 +1,4 @@
-"""Hub read-only proposal review client and routes."""
+"""Hub proposal review client, routes, and review actions."""
 
 from __future__ import annotations
 
@@ -52,6 +52,18 @@ def _reload_hub_modules(monkeypatch: pytest.MonkeyPatch, *, enabled: bool, api_u
     importlib.import_module("scripts.settings")
     importlib.import_module("scripts.proposal_review_client")
     importlib.import_module("scripts.proposal_review_routes")
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_hub_path_pollution() -> None:
+    """Prevent hub reload from shadowing orion-context-exec `app` in later tests."""
+    yield
+    hub_root = str(HUB_ROOT)
+    while hub_root in sys.path:
+        sys.path.remove(hub_root)
+    for mod in list(sys.modules):
+        if mod == "app" or mod.startswith("app."):
+            sys.modules.pop(mod, None)
 
 
 @pytest.fixture
@@ -153,22 +165,21 @@ def test_hub_proposal_review_unavailable_is_nonfatal(monkeypatch: pytest.MonkeyP
     assert body["proposals"] == []
 
 
-def test_hub_proposal_review_does_not_call_post_review_or_triage(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hub_review_does_not_call_triage_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     _reload_hub_modules(monkeypatch, enabled=True)
     import scripts.proposal_review_client as client_mod
 
+    assert hasattr(client_mod, "post_review")
     assert not hasattr(client_mod, "post_triage")
-    assert not hasattr(client_mod, "post_review")
     assert not hasattr(client_mod, "triage_proposal")
-    assert not hasattr(client_mod, "review_proposal")
 
-    captured_methods: list[str] = []
+    captured: list[tuple[str, str]] = []
 
     class FakeResponse:
         status = 200
 
         async def text(self) -> str:
-            return '{"proposals":[],"count":0}'
+            return '{"status":"rejected","execution_eligibility":{"eligible":false,"execution_requested":false}}'
 
         async def __aenter__(self):
             return self
@@ -177,8 +188,8 @@ def test_hub_proposal_review_does_not_call_post_review_or_triage(monkeypatch: py
             return None
 
     class FakeSession:
-        def get(self, url: str, params: dict | None = None):
-            captured_methods.append("GET")
+        def request(self, method: str, url: str, **kwargs: object):
+            captured.append((method.upper(), url))
             return FakeResponse()
 
         async def __aenter__(self):
@@ -189,18 +200,198 @@ def test_hub_proposal_review_does_not_call_post_review_or_triage(monkeypatch: py
 
     monkeypatch.setattr(client_mod.aiohttp, "ClientSession", lambda **kwargs: FakeSession())
 
-    asyncio.run(client_mod.list_proposals(status="pending_review"))
-    assert captured_methods == ["GET"]
+    asyncio.run(
+        client_mod.post_review(
+            "prop_1",
+            {"decision": "reject", "rationale": "no", "reviewer_type": "human", "reviewer_id": "hub"},
+        )
+    )
+    assert captured == [("POST", "http://proposal-review.test/proposals/prop_1/review")]
 
     with pytest.raises(client_mod.ProposalReviewClientError):
-        asyncio.run(client_mod._get_json("/proposals/prop_1/triage"))  # noqa: SLF001
+        asyncio.run(client_mod._post_json("/proposals/prop_1/triage", body={"action": "store_only"}))  # noqa: SLF001
 
     with pytest.raises(client_mod.ProposalReviewClientError):
-        asyncio.run(client_mod._get_json("/proposals/prop_1/review"))  # noqa: SLF001
+        asyncio.run(client_mod._post_json("/proposals/prop_1/execute", body={}))  # noqa: SLF001
 
     routes_source = (HUB_ROOT / "scripts" / "proposal_review_routes.py").read_text(encoding="utf-8")
-    assert "@router.post" not in routes_source
-    assert "POST" not in routes_source
+    assert routes_source.count("@router.post") == 1
+    assert "/proposals/{proposal_id}/review" in routes_source
+    assert "/triage" not in routes_source
+
+
+def test_hub_review_does_not_call_executor(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_hub_modules(monkeypatch, enabled=True)
+    import scripts.proposal_review_routes as routes
+
+    async def fake_post(proposal_id: str, body: dict) -> dict:
+        assert proposal_id == "prop_demo_1"
+        assert body["decision"] == "approve"
+        return {
+            "proposal_id": proposal_id,
+            "status": "approved",
+            "execution_eligibility": {
+                "eligible": True,
+                "execution_requested": False,
+            },
+        }
+
+    monkeypatch.setattr(routes.client, "post_review", fake_post)
+    import scripts.main as hub_main
+
+    client_source = (HUB_ROOT / "scripts" / "proposal_review_client.py").read_text(encoding="utf-8")
+    assert "execute" not in client_source.lower().split("_ALLOWED")[0]
+    assert "/execute" not in client_source
+
+    with TestClient(hub_main.app) as client:
+        response = client.post(
+            "/api/proposal-review/proposals/prop_demo_1/review",
+            json={
+                "decision": "approve",
+                "rationale": "bounded and reversible",
+            },
+        )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "approved"
+    assert payload["execution_eligibility"]["eligible"] is True
+    assert payload["execution_eligibility"]["execution_requested"] is False
+    assert "execution_receipt" not in payload
+    assert "receipt" not in payload
+    assert "changed_targets" not in payload
+
+
+def test_hub_review_reject_posts_review_decision_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_hub_modules(monkeypatch, enabled=True)
+    import scripts.proposal_review_routes as routes
+
+    captured: dict[str, object] = {}
+
+    async def fake_post(proposal_id: str, body: dict) -> dict:
+        captured["proposal_id"] = proposal_id
+        captured["body"] = body
+        return {
+            "proposal_id": proposal_id,
+            "status": "rejected",
+            "execution_eligibility": {"eligible": False, "execution_requested": False},
+        }
+
+    monkeypatch.setattr(routes.client, "post_review", fake_post)
+    import scripts.main as hub_main
+
+    with TestClient(hub_main.app) as client:
+        response = client.post(
+            "/api/proposal-review/proposals/prop_demo_1/review",
+            json={"decision": "reject", "rationale": "unsupported evidence"},
+        )
+
+    assert response.status_code == 200
+    assert captured["proposal_id"] == "prop_demo_1"
+    body = captured["body"]
+    assert isinstance(body, dict)
+    assert body["decision"] == "reject"
+    assert body["rationale"] == "unsupported evidence"
+    assert response.json()["status"] == "rejected"
+    assert response.json()["execution_eligibility"]["eligible"] is False
+
+
+def test_hub_review_request_changes_posts_review_decision_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_hub_modules(monkeypatch, enabled=True)
+    import scripts.proposal_review_routes as routes
+
+    captured: dict[str, object] = {}
+
+    async def fake_post(proposal_id: str, body: dict) -> dict:
+        captured["body"] = body
+        return {
+            "proposal_id": proposal_id,
+            "status": "request_changes",
+            "execution_eligibility": {"eligible": False, "execution_requested": False},
+        }
+
+    monkeypatch.setattr(routes.client, "post_review", fake_post)
+    import scripts.main as hub_main
+
+    with TestClient(hub_main.app) as client:
+        response = client.post(
+            "/api/proposal-review/proposals/prop_demo_1/review",
+            json={"decision": "request_changes", "rationale": "needs more evidence"},
+        )
+
+    assert response.status_code == 200
+    body = captured["body"]
+    assert isinstance(body, dict)
+    assert body["decision"] == "request_changes"
+    assert response.json()["status"] == "request_changes"
+    assert response.json()["execution_eligibility"]["eligible"] is False
+
+
+def test_hub_review_approve_creates_eligibility_not_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_hub_modules(monkeypatch, enabled=True)
+    import scripts.proposal_review_routes as routes
+
+    async def fake_post(proposal_id: str, body: dict) -> dict:
+        assert body["decision"] == "approve"
+        return {
+            "proposal_id": proposal_id,
+            "status": "approved",
+            "review_decision": {"decision": "approve", "rationale": body["rationale"]},
+            "execution_eligibility": {
+                "eligible": True,
+                "execution_requested": False,
+                "reason": "approved by review decision",
+            },
+        }
+
+    monkeypatch.setattr(routes.client, "post_review", fake_post)
+    import scripts.main as hub_main
+
+    with TestClient(hub_main.app) as client:
+        response = client.post(
+            "/api/proposal-review/proposals/prop_demo_1/review",
+            json={
+                "decision": "approve",
+                "rationale": "bounded and reversible",
+                "constraints": {"note": "scope limited"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "approved"
+    assert payload["execution_eligibility"]["eligible"] is True
+    assert payload["execution_eligibility"]["execution_requested"] is False
+
+
+def test_hub_review_requires_rationale(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_hub_modules(monkeypatch, enabled=True)
+    import scripts.proposal_review_routes as routes
+
+    called = {"value": False}
+
+    async def fake_post(proposal_id: str, body: dict) -> dict:
+        called["value"] = True
+        return {}
+
+    monkeypatch.setattr(routes.client, "post_review", fake_post)
+    import scripts.main as hub_main
+
+    with TestClient(hub_main.app) as client:
+        empty = client.post(
+            "/api/proposal-review/proposals/prop_demo_1/review",
+            json={"decision": "reject", "rationale": "   "},
+        )
+        missing = client.post(
+            "/api/proposal-review/proposals/prop_demo_1/review",
+            json={"decision": "reject"},
+        )
+
+    assert empty.status_code == 422
+    assert missing.status_code == 422
+    assert called["value"] is False
+
+    ui = (HUB_ROOT / "static" / "js" / "proposal-review-ui.js").read_text(encoding="utf-8")
+    assert "Rationale is required" in ui
 
 
 def test_hub_pending_decisions_shows_denver_memory_correction(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -289,8 +480,11 @@ def test_hub_pending_decisions_shows_denver_memory_correction(monkeypatch: pytes
     assert 'id="proposalReviewPanel"' in template
     for token in ("Current belief:", "Proposed correction:", "Rationale:", "mutation_allowed="):
         assert token in ui
-    assert 'method="post"' not in ui.lower()
-    assert "/review" not in ui
+    for label in ("Approve", "Reject", "Request changes"):
+        assert label in ui
+    assert "/api/proposal-review/proposals/" in ui
+    assert "/review" in ui
     assert "/triage" not in ui
+    assert "execute" not in ui.lower()
     routes_source = (HUB_ROOT / "scripts" / "proposal_review_routes.py").read_text(encoding="utf-8")
-    assert "@router.post" not in routes_source
+    assert "/proposals/{proposal_id}/review" in routes_source

--- a/services/orion-hub/tests/test_proposal_review_ui.py
+++ b/services/orion-hub/tests/test_proposal_review_ui.py
@@ -14,10 +14,15 @@ def test_proposal_review_ui_wired() -> None:
     assert "Pending Decisions" in template
     assert "/api/proposal-review/pending" in ui
     assert "/api/proposal-review/proposals/" in ui
+    assert "/api/proposal-review/proposals/" in ui and "/review" in ui
     assert "No pending decisions." in ui
     assert "Proposal review API unavailable." in ui
     assert "Current belief:" in ui
     assert "Proposed correction:" in ui
     assert "mutation_allowed=" in ui
     assert "requires_human_approval=" in ui
-    assert "approve" not in ui.lower() or "approval inbox" not in ui.lower()
+    for label in ("Approve", "Reject", "Request changes"):
+        assert label in ui
+    assert "Rationale is required" in ui
+    assert "/triage" not in ui
+    assert "execute" not in ui.lower()


### PR DESCRIPTION
# PR: Add Hub proposal review actions without execution

**Branch:** `feat/hub-proposal-review-actions`  
**Title:** Add Hub proposal review actions without execution

## Summary

Adds Hub proposal review actions without execution.

Hub can now approve, reject, or request changes for pending proposals through the proposal review API. Approval creates future execution eligibility only; it does not execute, mutate memory, mutate repo files, or create execution receipts.

## Changes

- Extend Hub proposal review client with POST allowlist for `/proposals/{proposal_id}/review` only (no triage, execute, or arbitrary POST).
- Add Hub route `POST /api/proposal-review/proposals/{proposal_id}/review` with server-side rationale validation.
- Add Pending Decisions detail actions: **Approve**, **Reject**, **Request changes** (required rationale; optional constraints on approve).
- After action: refresh detail, refresh pending list, show status update.
- Add six safety-focused Hub tests plus test isolation fix for combined pytest runs.
- Update docs: Hub records review decisions; Hub cannot execute; approval creates eligibility only.

## Architecture

```text
Hub UI (Pending Decisions detail card)
  → POST /api/proposal-review/proposals/{id}/review
  → proposal_review_client (POST allowlist: /proposals/{id}/review only)
  → context-exec POST /proposals/{id}/review
  → JsonFileProposalLedgerRepository (context-exec only — Hub never reads/writes ledger files directly)
```

## Safety

- No executor
- No execution receipts
- No memory/repo/runtime mutation
- Hub only records review decisions via review API
- Hub does not POST triage
- Approval only creates future execution eligibility (`eligible=true`, `execution_requested=false`)

## Verification

| Command | Exit | Result |
|---------|------|--------|
| `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-hub/tests/test_proposal_review_hub.py services/orion-hub/tests/test_proposal_review_ui.py tests/services/test_proposal_review_api.py -q` | 0 | 34 passed |
| `ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smoke.sh` | 0 | PASS |
| `orion_dev/bin/python -m compileall services/orion-hub/scripts/proposal_review_client.py services/orion-hub/scripts/proposal_review_routes.py -q` | 0 | OK |

## Manual smoke (operator)

1. Seed Denver proposal (`denver_memory_correction_vertical_smoke.sh` or CLI seed-demo).
2. Start context-exec with proposal review API enabled.
3. Start Hub with `HUB_PROPOSAL_REVIEW_ENABLED=true`.
4. Open Hub Pending Decisions → Denver detail.
5. Reject with rationale → card leaves pending list or status updates to `rejected`.
6. Repeat with approve → `eligible=true`, no execution receipt, no memory mutation.

## Test plan

- [ ] Hub review buttons visible on pending_review detail card
- [ ] Empty rationale rejected (client + server 422)
- [ ] Approve sets `status=approved`, `eligible=true`, `execution_requested=false`
- [ ] Reject sets `status=rejected`, `eligible=false`
- [ ] Request changes sets `status=request_changes`, `eligible=false`
- [ ] Network tab shows POST to `/api/proposal-review/proposals/{id}/review` only (no `/triage`, no execute)
- [ ] Denver smoke still passes
