### PR TITLE
Feat/agent grounding preflight

### DIFF
--- a/docs/superpowers/pr-reports/2026-06-15-agent-grounding-preflight-pr.md
+++ b/docs/superpowers/pr-reports/2026-06-15-agent-grounding-preflight-pr.md
@@ -1,0 +1,85 @@
+# PR: Agent grounding preflight — block fake-engine false investigation success
+
+**Branch:** `feat/agent-grounding-preflight`  
+**Worktree:** `.worktrees/feat/agent-grounding-preflight`
+
+## Summary
+
+Fixes a real bug where the Hub Agent lane reported **"Investigation complete"** / `status ok` for recall questions (e.g. *"do you recall where my mom lives?"*) even when:
+
+- `engine_selected` was `fake`
+- `model_synthesis_used` was `false`
+- no recall/trace/repo evidence was captured
+- `tool_call_count` was `1` while `tools: []` (from counting `rlm_engine.run` as a user tool)
+
+The patch **separates runtime success from answer success** and blocks ungrounded investigations from presenting as complete.
+
+## Behavior changes
+
+### Answer evaluation (`answer_evaluation` in `runtime_debug`)
+
+New fields (also surfaced in Hub `routing_debug` and agent trace `raw`):
+
+| Field | Values |
+|-------|--------|
+| `runtime_status` | `ok` \| `failed` |
+| `answer_status` | `answered_grounded` \| `partial_or_weak_evidence` \| `no_reliable_evidence` \| `failed_grounding_preflight` \| `failed_fake_engine_selected` |
+| `grounding_status` | `not_required` \| `attempted` \| `skipped` \| `unavailable` \| `failed` |
+| `synthesis_status` | `completed` \| `skipped` \| `deterministic_no_memory` \| `blocked` |
+| `evidence_count` | int |
+| `grounding_required` | bool |
+
+### Grounding preflight rules
+
+1. **Fake engine block** — If `engine_selected` is `fake`/`mock`/`smoke`/`stub` and the user did not explicitly request a smoke/fake run, set `answer_status=failed_fake_engine_selected` and replace summary with an explicit blocked message.
+2. **No grounding attempted** — For grounding-required requests with zero evidence and no recall/trace/repo attempt, set `failed_grounding_preflight`.
+3. **Placeholder summaries** — `"Investigation complete for: …"` is never shown as a successful answer when grounding failed.
+
+### Tool count fix
+
+- `rlm_engine.run` remains in the timeline (`steps`) as a runtime step.
+- `tool_call_count`, `unique_tool_count`, and grouped tool usage only count **user-visible** tools (excludes `rlm_engine.run`).
+- `raw.runtime_step_count` preserves total step count.
+
+### UI messaging
+
+- Hub inline agent response headline becomes **"Runtime completed (not a grounded investigation)"** when answer failed preflight.
+- Agent trace overview shows **Answer** status and separates runtime steps from tool calls.
+
+## Files changed
+
+| Area | Path |
+|------|------|
+| Grounding eval (new) | `services/orion-context-exec/app/grounding_eval.py` |
+| Runner wiring | `services/orion-context-exec/app/runner.py` |
+| Hub bridge | `services/orion-hub/scripts/context_exec_agent_bridge.py` |
+| Hub UI | `services/orion-hub/static/js/app.js` |
+| Tests | `services/orion-context-exec/tests/test_grounding_eval.py` |
+| Tests | `services/orion-context-exec/tests/test_runner_grounding_preflight.py` |
+| Tests | `services/orion-hub/tests/test_context_exec_agent_grounding.py` |
+
+No `.env_example` changes (no new env keys).
+
+## Verification
+
+| Command | Exit | Result |
+|---------|------|--------|
+| `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/test_grounding_eval.py services/orion-context-exec/tests/test_runner_grounding_preflight.py -q` | 0 | 7 passed |
+| `cd services/orion-hub && orion_dev/bin/python -m pytest tests/test_context_exec_agent_grounding.py tests/test_llm_route_selector.py -q` | 0 | 19 passed |
+| `python -m compileall services/orion-context-exec/app/grounding_eval.py …` | 0 | OK |
+
+## Acceptance mapping
+
+| Criterion | Status |
+|-----------|--------|
+| Runtime can be `ok` while answer is not grounded | ✅ |
+| Fake engine → `failed_fake_engine_selected` | ✅ |
+| Summary not `"Investigation complete for: …"` on failure | ✅ |
+| UI does not present as completed investigation | ✅ |
+| `tool_call_count` agrees with `tools: []` when only `rlm_engine.run` ran | ✅ |
+| Grounded path with evidence still succeeds | ✅ (`answered_grounded` for general_investigation + evidence) |
+
+## Remaining risks
+
+- `grounding_required` heuristics are broad (any `?` triggers grounding). Intentional for recall-style safety; may over-classify casual prompts.
+- Fake-engine blocking applies to all non-`general_investigation` modes when engine is fake — existing smoke tests may need `scopes.smoke_run` if they rely on fake engine for structured modes.

--- a/services/orion-context-exec/app/grounding_eval.py
+++ b/services/orion-context-exec/app/grounding_eval.py
@@ -225,11 +225,11 @@ def evaluate_investigation_outcome(
             "summary_text": summary,
         }
 
-    if evidence_count > 0 and model_synthesis_used:
-        answer_status = "answered_grounded"
-        grounding_status = "attempted"
-    elif evidence_count > 0:
-        answer_status = "partial_or_weak_evidence"
+    if evidence_count > 0 and grounding_attempted:
+        if model_synthesis_used or mode == "general_investigation":
+            answer_status = "answered_grounded"
+        else:
+            answer_status = "partial_or_weak_evidence"
         grounding_status = "attempted"
     elif model_synthesis_used:
         answer_status = "partial_or_weak_evidence"

--- a/services/orion-context-exec/app/grounding_eval.py
+++ b/services/orion-context-exec/app/grounding_eval.py
@@ -1,0 +1,253 @@
+"""Grounding preflight and answer-success evaluation for context-exec investigations."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from orion.schemas.context_exec import ContextExecVerbStepV1
+
+FAKE_ENGINES = frozenset({"fake", "mock", "smoke", "stub"})
+RUNTIME_ONLY_CALLABLES = frozenset({"rlm_engine.run"})
+
+_GROUNDING_PHRASES = (
+    "do you recall",
+    "do you remember",
+    "where did",
+    "what do you know",
+    "look into",
+    "tell me about",
+    "what do you remember",
+    "from memory",
+    "in our history",
+    "previously",
+    "last time",
+    "you said",
+    "we discussed",
+)
+
+_EXPLICIT_FAKE_PHRASES = (
+    "smoke test",
+    "smoke run",
+    "fake run",
+    "fake engine",
+    "stub run",
+    "mock run",
+)
+
+_INVESTIGATION_COMPLETE_RE = re.compile(
+    r"^investigation complete(?:\s+for:)?",
+    re.IGNORECASE,
+)
+
+
+def grounding_required(
+    text: str,
+    *,
+    mode: str,
+    answer_contract: dict[str, Any] | None = None,
+) -> bool:
+    if answer_contract:
+        if answer_contract.get("requires_runtime_grounding"):
+            return True
+        if answer_contract.get("requires_repo_grounding"):
+            return True
+    if mode != "general_investigation":
+        return True
+    normalized = (text or "").strip().lower()
+    if not normalized:
+        return False
+    if any(phrase in normalized for phrase in _GROUNDING_PHRASES):
+        return True
+    if "?" in normalized:
+        return True
+    if any(token in normalized for token in ("recall", "remember", "memory", "trace", "file", "repo")):
+        return True
+    return False
+
+
+def explicit_fake_run_requested(text: str, scopes: dict[str, Any] | None = None) -> bool:
+    scope = scopes if isinstance(scopes, dict) else {}
+    if scope.get("smoke_run") or scope.get("fake_engine") or scope.get("allow_fake_engine"):
+        return True
+    normalized = (text or "").strip().lower()
+    return any(phrase in normalized for phrase in _EXPLICIT_FAKE_PHRASES)
+
+
+def count_evidence(
+    artifact: dict[str, Any],
+    *,
+    findings_bundle: Any = None,
+    organ_cache: dict[str, Any] | None = None,
+) -> int:
+    total = 0
+    for key in ("findings", "evidence", "supporting_evidence", "contradicting_evidence"):
+        items = artifact.get(key)
+        if isinstance(items, list):
+            total += len(items)
+    if findings_bundle is not None:
+        findings = getattr(findings_bundle, "findings", None)
+        if isinstance(findings, list) and findings:
+            total = max(total, len(findings))
+    cache = organ_cache if isinstance(organ_cache, dict) else {}
+    recall = cache.get("recall")
+    if isinstance(recall, dict):
+        hits = recall.get("hits")
+        if isinstance(hits, list) and hits:
+            total = max(total, len(hits))
+    traces = cache.get("traces")
+    if isinstance(traces, list) and traces:
+        total = max(total, len(traces))
+    return total
+
+
+def _grounding_sources_attempted(
+    *,
+    verb_trace: list[ContextExecVerbStepV1],
+    runtime_debug: dict[str, Any],
+    organ_cache: dict[str, Any] | None,
+) -> bool:
+    for step in verb_trace:
+        callable_name = (step.callable or "").strip()
+        if callable_name and callable_name not in RUNTIME_ONLY_CALLABLES:
+            return True
+    attempts = runtime_debug.get("grounding_attempts")
+    if isinstance(attempts, dict) and any(attempts.values()):
+        return True
+    cache = organ_cache if isinstance(organ_cache, dict) else {}
+    if cache.get("recall") is not None or cache.get("traces") is not None:
+        return True
+    return False
+
+
+def _synthesis_status_label(*, model_synthesis_used: bool, runtime_debug: dict[str, Any]) -> str:
+    if model_synthesis_used:
+        return "completed"
+    if runtime_debug.get("synthesis_fallback_used") or str(
+        runtime_debug.get("synthesis_fallback_reason") or ""
+    ).startswith("synthesis"):
+        return "blocked"
+    return "skipped"
+
+
+def _blocked_summary(answer_status: str) -> str:
+    if answer_status == "failed_fake_engine_selected":
+        return (
+            "Runtime completed, but this was not a grounded investigation. "
+            "The selected engine was fake and no real recall or synthesis was performed."
+        )
+    if answer_status == "failed_grounding_preflight":
+        return (
+            "Runtime completed, but grounding failed: no recall, trace, or source evidence was captured."
+        )
+    return "No reliable grounded answer found."
+
+
+def is_placeholder_investigation_summary(text: str) -> bool:
+    return bool(_INVESTIGATION_COMPLETE_RE.match((text or "").strip()))
+
+
+def evaluate_investigation_outcome(
+    *,
+    runtime_status: str,
+    text: str,
+    mode: str,
+    artifact: dict[str, Any],
+    runtime_debug: dict[str, Any],
+    verb_trace: list[ContextExecVerbStepV1],
+    findings_bundle: Any = None,
+    organ_cache: dict[str, Any] | None = None,
+    answer_contract: dict[str, Any] | None = None,
+    scopes: dict[str, Any] | None = None,
+    model_synthesis_used: bool = False,
+    current_summary: str = "",
+) -> dict[str, Any]:
+    """Separate runtime success from grounded answer success."""
+    runtime_ok = str(runtime_status or "").lower() == "ok"
+    runtime_label = "ok" if runtime_ok else "failed"
+    grounding_required_flag = grounding_required(text, mode=mode, answer_contract=answer_contract)
+    evidence_count = count_evidence(artifact, findings_bundle=findings_bundle, organ_cache=organ_cache)
+    grounding_attempted = _grounding_sources_attempted(
+        verb_trace=verb_trace,
+        runtime_debug=runtime_debug,
+        organ_cache=organ_cache,
+    )
+    engine_selected = str(runtime_debug.get("engine_selected") or runtime_debug.get("engine") or "").lower()
+    synthesis_status = _synthesis_status_label(
+        model_synthesis_used=model_synthesis_used,
+        runtime_debug=runtime_debug,
+    )
+
+    if not grounding_required_flag:
+        return {
+            "runtime_status": runtime_label,
+            "answer_status": "answered_grounded" if runtime_ok else "failed",
+            "grounding_status": "not_required",
+            "synthesis_status": synthesis_status,
+            "evidence_count": evidence_count,
+            "grounding_required": False,
+            "summary_text": current_summary,
+        }
+
+    if engine_selected in FAKE_ENGINES and not explicit_fake_run_requested(text, scopes):
+        return {
+            "runtime_status": runtime_label,
+            "answer_status": "failed_fake_engine_selected",
+            "grounding_status": "skipped",
+            "synthesis_status": "skipped",
+            "evidence_count": evidence_count,
+            "grounding_required": True,
+            "summary_text": _blocked_summary("failed_fake_engine_selected"),
+        }
+
+    if not grounding_attempted and evidence_count == 0:
+        return {
+            "runtime_status": runtime_label,
+            "answer_status": "failed_grounding_preflight",
+            "grounding_status": "skipped",
+            "synthesis_status": synthesis_status,
+            "evidence_count": 0,
+            "grounding_required": True,
+            "summary_text": _blocked_summary("failed_grounding_preflight"),
+        }
+
+    if evidence_count == 0 and not model_synthesis_used:
+        summary = current_summary
+        if is_placeholder_investigation_summary(summary):
+            summary = _blocked_summary("failed_grounding_preflight")
+        return {
+            "runtime_status": runtime_label,
+            "answer_status": "no_reliable_evidence",
+            "grounding_status": "attempted",
+            "synthesis_status": synthesis_status,
+            "evidence_count": 0,
+            "grounding_required": True,
+            "summary_text": summary,
+        }
+
+    if evidence_count > 0 and model_synthesis_used:
+        answer_status = "answered_grounded"
+        grounding_status = "attempted"
+    elif evidence_count > 0:
+        answer_status = "partial_or_weak_evidence"
+        grounding_status = "attempted"
+    elif model_synthesis_used:
+        answer_status = "partial_or_weak_evidence"
+        grounding_status = "attempted"
+    else:
+        answer_status = "no_reliable_evidence"
+        grounding_status = "attempted"
+
+    summary = current_summary
+    if answer_status != "answered_grounded" and is_placeholder_investigation_summary(summary):
+        summary = "No reliable grounded answer found."
+
+    return {
+        "runtime_status": runtime_label,
+        "answer_status": answer_status,
+        "grounding_status": grounding_status,
+        "synthesis_status": synthesis_status,
+        "evidence_count": evidence_count,
+        "grounding_required": True,
+        "summary_text": summary,
+    }

--- a/services/orion-context-exec/app/runner.py
+++ b/services/orion-context-exec/app/runner.py
@@ -15,6 +15,7 @@ from orion.schemas.context_exec import (
 )
 
 from .agent_synthesis import run_agent_synthesis
+from .grounding_eval import evaluate_investigation_outcome
 from .artifact_builder import (
     artifact_type_for_mode,
     build_final_text,
@@ -297,6 +298,7 @@ class ContextExecRunner:
         )
         namespace = self._build_namespace(organ_runtime)
         await namespace._prefetch_organs()  # type: ignore[attr-defined]
+        organ_cache = getattr(namespace, "_organ_cache", {}) or {}
 
         raw_final, engine_used, subcalls, rlm_steps, rlm_failures = await self._execute_rlm(
             request,
@@ -404,6 +406,11 @@ class ContextExecRunner:
             runtime_debug["synthesis_fallback_reason"] = synthesis_result.fallback_reason
         if synthesis_result.fallback_used:
             runtime_debug["synthesis_fallback_used"] = True
+        runtime_debug["grounding_attempts"] = {
+            "recall": organ_cache.get("recall") is not None,
+            "trace": organ_cache.get("traces") is not None,
+            "repo": bool(organ_cache.get("repo_hits")),
+        }
         operator_summary = synthesis_result.operator_summary
         if (
             operator_summary is not None
@@ -414,6 +421,34 @@ class ContextExecRunner:
                 final_text = synthesis_result.synthesis_summary
             elif operator_summary.summary:
                 final_text = operator_summary.summary
+
+        answer_eval = evaluate_investigation_outcome(
+            runtime_status=status,
+            text=request.text,
+            mode=request.mode,
+            artifact=artifact,
+            runtime_debug=runtime_debug,
+            verb_trace=verb_trace,
+            findings_bundle=fb,
+            organ_cache=organ_cache,
+            answer_contract=ac_dump,
+            scopes=request.scopes,
+            model_synthesis_used=synthesis_result.model_synthesis_used,
+            current_summary=final_text,
+        )
+        runtime_debug["answer_evaluation"] = answer_eval
+        if answer_eval.get("summary_text"):
+            final_text = str(answer_eval["summary_text"])
+        if operator_summary is not None and answer_eval.get("answer_status") not in {
+            "answered_grounded",
+            "partial_or_weak_evidence",
+        }:
+            operator_summary = operator_summary.model_copy(
+                update={
+                    "title": "Runtime completed (not grounded)",
+                    "summary": final_text,
+                }
+            )
 
         await events.finished(
             run_id=run_id,

--- a/services/orion-context-exec/app/runner.py
+++ b/services/orion-context-exec/app/runner.py
@@ -15,7 +15,7 @@ from orion.schemas.context_exec import (
 )
 
 from .agent_synthesis import run_agent_synthesis
-from .grounding_eval import evaluate_investigation_outcome
+from .grounding_eval import evaluate_investigation_outcome, is_placeholder_investigation_summary
 from .artifact_builder import (
     artifact_type_for_mode,
     build_final_text,
@@ -439,10 +439,11 @@ class ContextExecRunner:
         runtime_debug["answer_evaluation"] = answer_eval
         if answer_eval.get("summary_text"):
             final_text = str(answer_eval["summary_text"])
-        if operator_summary is not None and answer_eval.get("answer_status") not in {
-            "answered_grounded",
-            "partial_or_weak_evidence",
-        }:
+        if operator_summary is not None and (
+            answer_eval.get("answer_status")
+            not in {"answered_grounded", "partial_or_weak_evidence"}
+            or is_placeholder_investigation_summary(operator_summary.summary)
+        ):
             operator_summary = operator_summary.model_copy(
                 update={
                     "title": "Runtime completed (not grounded)",

--- a/services/orion-context-exec/tests/test_grounding_eval.py
+++ b/services/orion-context-exec/tests/test_grounding_eval.py
@@ -1,0 +1,120 @@
+"""Tests for grounding preflight and answer-success evaluation."""
+
+from __future__ import annotations
+
+from app.grounding_eval import (
+    evaluate_investigation_outcome,
+    explicit_fake_run_requested,
+    grounding_required,
+    is_placeholder_investigation_summary,
+)
+from orion.schemas.context_exec import ContextExecVerbStepV1
+
+
+def test_grounding_required_for_recall_questions() -> None:
+    assert grounding_required("do you recall where my mom lives?", mode="general_investigation") is True
+    assert grounding_required("hello", mode="general_investigation") is False
+
+
+def test_explicit_fake_run_requested() -> None:
+    assert explicit_fake_run_requested("run a smoke test please") is True
+    assert explicit_fake_run_requested("do you recall Denver?") is False
+    assert explicit_fake_run_requested("question", scopes={"smoke_run": True}) is True
+
+
+def test_placeholder_summary_detection() -> None:
+    assert is_placeholder_investigation_summary("Investigation complete for: where is mom?")
+    assert not is_placeholder_investigation_summary("Denver evidence found in memory.")
+
+
+def test_fake_engine_blocks_answer_success() -> None:
+    verb_trace = [
+        ContextExecVerbStepV1(
+            step_index=0,
+            verb="synthesize",
+            callable="rlm_engine.run",
+            status="ok",
+        )
+    ]
+    runtime_debug = {
+        "engine_selected": "fake",
+        "model_synthesis_used": False,
+        "subcalls": 0,
+        "real_recall_enabled": True,
+        "real_trace_enabled": True,
+        "llm_profile_selected": "quick",
+    }
+    outcome = evaluate_investigation_outcome(
+        runtime_status="ok",
+        text="do you recall where my mom lives?",
+        mode="general_investigation",
+        artifact={"summary": "Investigation complete for: do you recall where my mom lives?"},
+        runtime_debug=runtime_debug,
+        verb_trace=verb_trace,
+        model_synthesis_used=False,
+        current_summary="Investigation complete for: do you recall where my mom lives?",
+    )
+    assert outcome["runtime_status"] == "ok"
+    assert outcome["answer_status"] == "failed_fake_engine_selected"
+    assert outcome["grounding_status"] == "skipped"
+    assert outcome["synthesis_status"] == "skipped"
+    assert outcome["evidence_count"] == 0
+    assert "not a grounded investigation" in outcome["summary_text"]
+    assert not is_placeholder_investigation_summary(outcome["summary_text"])
+
+
+def test_grounded_path_with_evidence() -> None:
+    verb_trace = [
+        ContextExecVerbStepV1(
+            step_index=0,
+            verb="recall",
+            callable="recall.query",
+            status="ok",
+        )
+    ]
+    runtime_debug = {
+        "engine_selected": "alexzhang",
+        "model_synthesis_used": True,
+        "grounding_attempts": {"recall": True, "trace": False, "repo": False},
+    }
+    artifact = {
+        "findings": [
+            {
+                "claim": "Mom lives in Denver",
+                "evidence_type": "user_statement",
+                "verified": True,
+                "confidence": 0.9,
+                "scope": "fact",
+            }
+        ]
+    }
+    outcome = evaluate_investigation_outcome(
+        runtime_status="ok",
+        text="do you recall where my mom lives?",
+        mode="general_investigation",
+        artifact=artifact,
+        runtime_debug=runtime_debug,
+        verb_trace=verb_trace,
+        model_synthesis_used=True,
+        current_summary="Mom lives in Denver based on prior session memory.",
+    )
+    assert outcome["answer_status"] == "answered_grounded"
+    assert outcome["grounding_status"] == "attempted"
+    assert outcome["synthesis_status"] == "completed"
+    assert outcome["evidence_count"] == 1
+
+
+def test_failed_grounding_preflight_when_no_sources_attempted() -> None:
+    outcome = evaluate_investigation_outcome(
+        runtime_status="ok",
+        text="do you recall where my mom lives?",
+        mode="general_investigation",
+        artifact={},
+        runtime_debug={"engine_selected": "alexzhang", "model_synthesis_used": False},
+        verb_trace=[],
+        model_synthesis_used=False,
+        current_summary="Investigation complete for: do you recall where my mom lives?",
+    )
+    assert outcome["answer_status"] == "failed_grounding_preflight"
+    assert outcome["evidence_count"] == 0
+    assert "grounding failed" in outcome["summary_text"]

--- a/services/orion-context-exec/tests/test_grounding_eval.py
+++ b/services/orion-context-exec/tests/test_grounding_eval.py
@@ -74,7 +74,7 @@ def test_grounded_path_with_evidence() -> None:
     ]
     runtime_debug = {
         "engine_selected": "alexzhang",
-        "model_synthesis_used": True,
+        "model_synthesis_used": False,
         "grounding_attempts": {"recall": True, "trace": False, "repo": False},
     }
     artifact = {
@@ -95,12 +95,12 @@ def test_grounded_path_with_evidence() -> None:
         artifact=artifact,
         runtime_debug=runtime_debug,
         verb_trace=verb_trace,
-        model_synthesis_used=True,
+        model_synthesis_used=False,
         current_summary="Mom lives in Denver based on prior session memory.",
     )
     assert outcome["answer_status"] == "answered_grounded"
     assert outcome["grounding_status"] == "attempted"
-    assert outcome["synthesis_status"] == "completed"
+    assert outcome["synthesis_status"] == "skipped"
     assert outcome["evidence_count"] == 1
 
 

--- a/services/orion-context-exec/tests/test_runner_grounding_preflight.py
+++ b/services/orion-context-exec/tests/test_runner_grounding_preflight.py
@@ -1,0 +1,35 @@
+"""Integration test: runner blocks fake-engine answer success for recall questions."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.runner import ContextExecRunner
+from app.grounding_eval import is_placeholder_investigation_summary
+from orion.schemas.context_exec import ContextExecRequestV1
+
+
+@pytest.mark.asyncio
+async def test_runner_fake_engine_recall_question_blocks_answer_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.settings import settings as cfg
+
+    monkeypatch.setattr(cfg, "context_exec_fake_organs_enabled", False)
+    monkeypatch.setattr(cfg, "context_exec_agent_synthesis_enabled", False)
+    monkeypatch.setattr(cfg, "rlm_engine", "fake")
+
+    runner = ContextExecRunner()
+    req = ContextExecRequestV1(
+        text="do you recall where my mom lives?",
+        mode="general_investigation",
+        llm_profile="quick",
+    )
+    run = await runner.run(req)
+    assert run.status == "ok"
+    answer_eval = run.runtime_debug.get("answer_evaluation") or {}
+    assert answer_eval.get("runtime_status") == "ok"
+    assert answer_eval.get("answer_status") == "failed_fake_engine_selected"
+    assert answer_eval.get("grounding_status") == "skipped"
+    assert not is_placeholder_investigation_summary(run.final_text)
+    assert "not a grounded investigation" in run.final_text

--- a/services/orion-hub/scripts/context_exec_agent_bridge.py
+++ b/services/orion-hub/scripts/context_exec_agent_bridge.py
@@ -260,6 +260,7 @@ def build_context_exec_chat_response(
         "llm_response": inline,
         "raw": {
             "ok": run.status == "ok",
+            "answer_ok": answer_eval.get("answer_status") == "answered_grounded",
             "mode": "agent",
             "status": run.status,
             "final_text": run.final_text,

--- a/services/orion-hub/scripts/context_exec_agent_bridge.py
+++ b/services/orion-hub/scripts/context_exec_agent_bridge.py
@@ -5,12 +5,21 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from orion.schemas.context_exec import ContextExecPermissionV1, ContextExecRequestV1, ContextExecRunV1
-from orion.schemas.cortex.contracts import AgentTraceStepV1, AgentTraceSummaryV1, CortexChatRequest
+from orion.schemas.cortex.contracts import AgentTraceStepV1, AgentTraceSummaryV1, AgentTraceToolStatV1, CortexChatRequest
 
 from scripts.context_exec_client import ContextExecClientError, agent_lane_enabled, run_context_exec
 
 
 VALID_LLM_PROFILES = frozenset({"chat", "quick", "agent", "metacog"})
+RUNTIME_ONLY_CALLABLES = frozenset({"rlm_engine.run"})
+FAILED_ANSWER_STATUSES = frozenset(
+    {
+        "failed_fake_engine_selected",
+        "failed_grounding_preflight",
+        "no_reliable_evidence",
+        "failed",
+    }
+)
 
 
 def normalize_llm_profile(raw: Any, *, default: str = "quick") -> str:
@@ -87,26 +96,80 @@ def _steps_from_verb_trace(run: ContextExecRunV1) -> List[AgentTraceStepV1]:
     return steps
 
 
+def _user_visible_steps(steps: List[AgentTraceStepV1]) -> List[AgentTraceStepV1]:
+    visible: List[AgentTraceStepV1] = []
+    for step in steps:
+        tool_id = (step.tool_id or "").strip()
+        if tool_id in RUNTIME_ONLY_CALLABLES:
+            continue
+        visible.append(step)
+    return visible
+
+
+def _tool_stats_from_steps(steps: List[AgentTraceStepV1]) -> List[AgentTraceToolStatV1]:
+    buckets: dict[str, AgentTraceToolStatV1] = {}
+    for step in steps:
+        tool_id = (step.tool_id or step.event_type or "unknown").strip() or "unknown"
+        if tool_id not in buckets:
+            buckets[tool_id] = AgentTraceToolStatV1(
+                tool_id=tool_id,
+                tool_family=step.tool_family or "unknown",
+                action_kind=step.action_kind or "unknown",
+                effect_kind=step.effect_kind or "unknown",
+                count=0,
+                duration_ms=0,
+            )
+        stat = buckets[tool_id]
+        stat.count += 1
+        stat.duration_ms = int(stat.duration_ms or 0) + int(step.duration_ms or 0)
+    return list(buckets.values())
+
+
+def _answer_evaluation(run: ContextExecRunV1) -> dict[str, Any]:
+    dbg = run.runtime_debug or {}
+    raw = dbg.get("answer_evaluation")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _trace_status_for_run(run: ContextExecRunV1, answer_eval: dict[str, Any]) -> str:
+    answer_status = str(answer_eval.get("answer_status") or "")
+    if answer_status in FAILED_ANSWER_STATUSES:
+        return answer_status
+    return run.status
+
+
 def build_agent_trace_summary(
     *,
     run: ContextExecRunV1,
     correlation_id: Optional[str],
 ) -> Dict[str, Any]:
     steps = _steps_from_verb_trace(run)
+    tool_steps = _user_visible_steps(steps)
+    tool_stats = _tool_stats_from_steps(tool_steps)
+    answer_eval = _answer_evaluation(run)
+    summary_text = str(answer_eval.get("summary_text") or run.final_text or "")
     summary = AgentTraceSummaryV1(
         corr_id=correlation_id,
         mode="agent",
-        status=run.status,
+        status=_trace_status_for_run(run, answer_eval),
         step_count=len(steps),
-        tool_call_count=len(steps),
-        unique_tool_count=len({s.tool_id or s.event_type for s in steps}),
-        summary_text=run.final_text or "",
+        tool_call_count=sum(tool.count for tool in tool_stats),
+        unique_tool_count=len(tool_stats),
+        summary_text=summary_text,
+        tools=tool_stats,
         steps=steps,
         raw={
             "engine": "context_exec",
             "context_exec_mode": run.mode,
             "artifact_type": run.artifact_type,
             "runtime_debug": run.runtime_debug,
+            "runtime_step_count": len(steps),
+            "runtime_status": answer_eval.get("runtime_status") or run.status,
+            "answer_status": answer_eval.get("answer_status"),
+            "grounding_status": answer_eval.get("grounding_status"),
+            "synthesis_status": answer_eval.get("synthesis_status"),
+            "evidence_count": answer_eval.get("evidence_count"),
+            "grounding_required": answer_eval.get("grounding_required"),
         },
     )
     return summary.model_dump(mode="json")
@@ -129,6 +192,8 @@ def format_agent_operator_inline(
 ) -> str:
     """Build Hub inline Agent operator response."""
     dbg = run.runtime_debug or {}
+    answer_eval = _answer_evaluation(run)
+    answer_status = str(answer_eval.get("answer_status") or "")
     op = run.operator_summary
     mode = (op.agent_mode if op else run.mode) or "unknown"
     route = (
@@ -140,13 +205,20 @@ def format_agent_operator_inline(
     )
     synthesis = _synthesis_status_label(dbg)
     result = (op.summary if op else None) or run.final_text or "No summary available."
+    headline = (
+        "Runtime completed (not a grounded investigation)"
+        if answer_status in FAILED_ANSWER_STATUSES
+        else "Agent run complete"
+    )
     lines = [
-        "Agent run complete",
+        headline,
         f"Mode: {mode}",
         f"Route: {route}",
         f"Synthesis: {synthesis}",
         f"Result: {result}",
     ]
+    if answer_status:
+        lines.insert(1, f"Answer status: {answer_status}")
     proposal_id = (op.proposal_id if op else None) or dbg.get("proposal_id")
     proposal_status = (op.proposal_status if op else None) or dbg.get("ledger_status")
     if proposal_id:
@@ -171,6 +243,14 @@ def build_context_exec_chat_response(
     routing["llm_profile"] = dbg.get("llm_profile_selected") or dbg.get("route_used")
     routing["route_used"] = dbg.get("route_used")
     routing["model_synthesis_used"] = dbg.get("model_synthesis_used")
+    answer_eval = dbg.get("answer_evaluation") if isinstance(dbg.get("answer_evaluation"), dict) else {}
+    if answer_eval:
+        routing["answer_status"] = answer_eval.get("answer_status")
+        routing["runtime_status"] = answer_eval.get("runtime_status")
+        routing["grounding_status"] = answer_eval.get("grounding_status")
+        routing["synthesis_status"] = answer_eval.get("synthesis_status")
+        routing["evidence_count"] = answer_eval.get("evidence_count")
+        routing["grounding_required"] = answer_eval.get("grounding_required")
     inline = format_agent_operator_inline(
         run,
         llm_profile=str(routing.get("llm_profile") or ""),

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -8061,13 +8061,14 @@ loadDismissedIds();
   function buildAgentTraceOverviewNode(summary) {
     const root = document.createElement('div');
     root.className = 'grid gap-3 md:grid-cols-3 xl:grid-cols-6';
+    const raw = summary && summary.raw && typeof summary.raw === 'object' ? summary.raw : {};
     const cards = [
       ['Status', summary.status || '--'],
+      ['Answer', raw.answer_status || '--'],
       ['Duration', agentTraceApi.formatDuration ? agentTraceApi.formatDuration(summary.duration_ms) : '--'],
-      ['Steps', summary.step_count ?? 0],
+      ['Steps', raw.runtime_step_count ?? summary.step_count ?? 0],
       ['Tool calls', summary.tool_call_count ?? 0],
       ['Unique tools', summary.unique_tool_count ?? 0],
-      ['Families', Array.isArray(summary.unique_tool_families) && summary.unique_tool_families.length ? summary.unique_tool_families.join(', ') : '--'],
     ];
     cards.forEach(([label, value]) => {
       const card = document.createElement('div');
@@ -10266,15 +10267,28 @@ loadDismissedIds();
     if (d.mode === 'agent' && d.operator_summary && typeof d.operator_summary === 'object') {
       const op = d.operator_summary;
       const dbg = d.routing_debug && typeof d.routing_debug === 'object' ? d.routing_debug : {};
+      const answerStatus = String(dbg.answer_status || '').trim();
+      const failedAnswerStatuses = new Set([
+        'failed_fake_engine_selected',
+        'failed_grounding_preflight',
+        'no_reliable_evidence',
+        'failed',
+      ]);
       const synthesis = dbg.model_synthesis_used ? 'used'
         : (dbg.synthesis_fallback_used || String(dbg.synthesis_fallback_reason || '').startsWith('synthesis') ? 'fallback' : 'skipped');
+      const headline = failedAnswerStatuses.has(answerStatus)
+        ? 'Runtime completed (not a grounded investigation)'
+        : 'Agent run complete';
       const lines = [
-        'Agent run complete',
+        headline,
         `Mode: ${op.agent_mode || dbg.context_exec_mode || 'unknown'}`,
         `Route: ${op.route_used || dbg.route_used || dbg.llm_profile || 'chat'}`,
         `Synthesis: ${synthesis}`,
         `Result: ${op.summary || ''}`,
       ];
+      if (answerStatus) {
+        lines.splice(1, 0, `Answer status: ${answerStatus}`);
+      }
       if (op.proposal_id) {
         lines.push(`Proposal: ${op.proposal_id} ${op.proposal_status || 'pending_review'}`);
         lines.push('Open Pending Decisions to review.');

--- a/services/orion-hub/tests/test_context_exec_agent_grounding.py
+++ b/services/orion-hub/tests/test_context_exec_agent_grounding.py
@@ -1,0 +1,129 @@
+"""Hub bridge tests for context-exec agent grounding preflight."""
+
+from __future__ import annotations
+
+from scripts.context_exec_agent_bridge import build_agent_trace_summary, format_agent_operator_inline
+from orion.schemas.context_exec import (
+    ContextExecOperatorSummaryV1,
+    ContextExecRunV1,
+    ContextExecSafetySummaryV1,
+    ContextExecVerbStepV1,
+)
+
+
+def _fake_engine_run() -> ContextExecRunV1:
+    return ContextExecRunV1(
+        run_id="run-fake",
+        status="ok",
+        mode="general_investigation",
+        text="do you recall where my mom lives?",
+        final_text=(
+            "Runtime completed, but this was not a grounded investigation. "
+            "The selected engine was fake and no real recall or synthesis was performed."
+        ),
+        artifact_type="GenericInvestigationV1",
+        artifact={"summary": "Investigation complete for: do you recall where my mom lives?"},
+        verb_trace=[
+            ContextExecVerbStepV1(
+                step_index=0,
+                verb="synthesize",
+                callable="rlm_engine.run",
+                status="ok",
+            )
+        ],
+        runtime_debug={
+            "engine_selected": "fake",
+            "model_synthesis_used": False,
+            "subcalls": 0,
+            "real_recall_enabled": True,
+            "real_trace_enabled": True,
+            "llm_profile_selected": "quick",
+            "answer_evaluation": {
+                "runtime_status": "ok",
+                "answer_status": "failed_fake_engine_selected",
+                "grounding_status": "skipped",
+                "synthesis_status": "skipped",
+                "evidence_count": 0,
+                "grounding_required": True,
+                "summary_text": (
+                    "Runtime completed, but this was not a grounded investigation. "
+                    "The selected engine was fake and no real recall or synthesis was performed."
+                ),
+            },
+        },
+        operator_summary=ContextExecOperatorSummaryV1(
+            title="Runtime completed (not grounded)",
+            summary=(
+                "Runtime completed, but this was not a grounded investigation. "
+                "The selected engine was fake and no real recall or synthesis was performed."
+            ),
+            agent_mode="general_investigation",
+            route_used="quick",
+            model_synthesis_used=False,
+            safety=ContextExecSafetySummaryV1(),
+        ),
+    )
+
+
+def test_agent_trace_summary_fake_engine_failure_shape() -> None:
+    run = _fake_engine_run()
+    summary = build_agent_trace_summary(run=run, correlation_id="corr-fake")
+    assert summary["status"] == "failed_fake_engine_selected"
+    assert summary["tool_call_count"] == 0
+    assert summary["unique_tool_count"] == 0
+    assert summary["tools"] == []
+    assert summary["raw"]["runtime_step_count"] == 1
+    assert summary["raw"]["answer_status"] == "failed_fake_engine_selected"
+    assert "Investigation complete for:" not in summary["summary_text"]
+
+
+def test_format_agent_operator_inline_does_not_claim_success() -> None:
+    inline = format_agent_operator_inline(_fake_engine_run(), llm_profile="quick")
+    assert "Runtime completed (not a grounded investigation)" in inline
+    assert "Agent run complete" not in inline
+    assert "failed_fake_engine_selected" in inline
+
+
+def test_agent_trace_summary_grounded_success_shape() -> None:
+    run = ContextExecRunV1(
+        run_id="run-grounded",
+        status="ok",
+        mode="general_investigation",
+        text="do you recall where my mom lives?",
+        final_text="Mom lives in Denver based on prior session memory.",
+        verb_trace=[
+            ContextExecVerbStepV1(
+                step_index=0,
+                verb="recall",
+                callable="recall.query",
+                status="ok",
+            )
+        ],
+        runtime_debug={
+            "engine_selected": "alexzhang",
+            "model_synthesis_used": True,
+            "answer_evaluation": {
+                "runtime_status": "ok",
+                "answer_status": "answered_grounded",
+                "grounding_status": "attempted",
+                "synthesis_status": "completed",
+                "evidence_count": 1,
+                "grounding_required": True,
+                "summary_text": "Mom lives in Denver based on prior session memory.",
+            },
+        },
+        operator_summary=ContextExecOperatorSummaryV1(
+            title="Agent investigation complete",
+            summary="Mom lives in Denver based on prior session memory.",
+            agent_mode="general_investigation",
+            route_used="agent",
+            model_synthesis_used=True,
+            safety=ContextExecSafetySummaryV1(),
+        ),
+    )
+    summary = build_agent_trace_summary(run=run, correlation_id="corr-grounded")
+    assert summary["status"] == "ok"
+    assert summary["tool_call_count"] == 1
+    assert summary["unique_tool_count"] == 1
+    assert len(summary["tools"]) == 1
+    assert summary["raw"]["answer_status"] == "answered_grounded"


### PR DESCRIPTION
# PR: Agent grounding preflight — block fake-engine false investigation success

**Branch:** `feat/agent-grounding-preflight`  
**Worktree:** `.worktrees/feat/agent-grounding-preflight`

## Summary

Fixes a real bug where the Hub Agent lane reported **"Investigation complete"** / `status ok` for recall questions (e.g. *"do you recall where my mom lives?"*) even when:

- `engine_selected` was `fake`
- `model_synthesis_used` was `false`
- no recall/trace/repo evidence was captured
- `tool_call_count` was `1` while `tools: []` (from counting `rlm_engine.run` as a user tool)

The patch **separates runtime success from answer success** and blocks ungrounded investigations from presenting as complete.

## Behavior changes

### Answer evaluation (`answer_evaluation` in `runtime_debug`)

New fields (also surfaced in Hub `routing_debug` and agent trace `raw`):

| Field | Values |
|-------|--------|
| `runtime_status` | `ok` \| `failed` |
| `answer_status` | `answered_grounded` \| `partial_or_weak_evidence` \| `no_reliable_evidence` \| `failed_grounding_preflight` \| `failed_fake_engine_selected` |
| `grounding_status` | `not_required` \| `attempted` \| `skipped` \| `unavailable` \| `failed` |
| `synthesis_status` | `completed` \| `skipped` \| `deterministic_no_memory` \| `blocked` |
| `evidence_count` | int |
| `grounding_required` | bool |

### Grounding preflight rules

1. **Fake engine block** — If `engine_selected` is `fake`/`mock`/`smoke`/`stub` and the user did not explicitly request a smoke/fake run, set `answer_status=failed_fake_engine_selected` and replace summary with an explicit blocked message.
2. **No grounding attempted** — For grounding-required requests with zero evidence and no recall/trace/repo attempt, set `failed_grounding_preflight`.
3. **Placeholder summaries** — `"Investigation complete for: …"` is never shown as a successful answer when grounding failed.

### Tool count fix

- `rlm_engine.run` remains in the timeline (`steps`) as a runtime step.
- `tool_call_count`, `unique_tool_count`, and grouped tool usage only count **user-visible** tools (excludes `rlm_engine.run`).
- `raw.runtime_step_count` preserves total step count.

### UI messaging

- Hub inline agent response headline becomes **"Runtime completed (not a grounded investigation)"** when answer failed preflight.
- Agent trace overview shows **Answer** status and separates runtime steps from tool calls.

## Files changed

| Area | Path |
|------|------|
| Grounding eval (new) | `services/orion-context-exec/app/grounding_eval.py` |
| Runner wiring | `services/orion-context-exec/app/runner.py` |
| Hub bridge | `services/orion-hub/scripts/context_exec_agent_bridge.py` |
| Hub UI | `services/orion-hub/static/js/app.js` |
| Tests | `services/orion-context-exec/tests/test_grounding_eval.py` |
| Tests | `services/orion-context-exec/tests/test_runner_grounding_preflight.py` |
| Tests | `services/orion-hub/tests/test_context_exec_agent_grounding.py` |

No `.env_example` changes (no new env keys).

## Verification

| Command | Exit | Result |
|---------|------|--------|
| `PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-context-exec/tests/test_grounding_eval.py services/orion-context-exec/tests/test_runner_grounding_preflight.py -q` | 0 | 7 passed |
| `cd services/orion-hub && orion_dev/bin/python -m pytest tests/test_context_exec_agent_grounding.py tests/test_llm_route_selector.py -q` | 0 | 19 passed |
| `python -m compileall services/orion-context-exec/app/grounding_eval.py …` | 0 | OK |

## Acceptance mapping

| Criterion | Status |
|-----------|--------|
| Runtime can be `ok` while answer is not grounded | ✅ |
| Fake engine → `failed_fake_engine_selected` | ✅ |
| Summary not `"Investigation complete for: …"` on failure | ✅ |
| UI does not present as completed investigation | ✅ |
| `tool_call_count` agrees with `tools: []` when only `rlm_engine.run` ran | ✅ |
| Grounded path with evidence still succeeds | ✅ (`answered_grounded` for general_investigation + evidence) |

## Remaining risks

- `grounding_required` heuristics are broad (any `?` triggers grounding). Intentional for recall-style safety; may over-classify casual prompts.
- Fake-engine blocking applies to all non-`general_investigation` modes when engine is fake — existing smoke tests may need `scopes.smoke_run` if they rely on fake engine for structured modes.
