### PR TITLE
Fix investigation_v2 bus wiring false negatives and Agent lane permis…

### DIFF
--- a/orion/bus/consumer_readiness.py
+++ b/orion/bus/consumer_readiness.py
@@ -15,6 +15,19 @@ def _decode_redis_val(x: Any) -> Any:
     return x
 
 
+def bus_consumer_readiness_v1(
+    result: BusConsumerReadinessResult,
+    *,
+    http_alive: bool = True,
+) -> "BusConsumerReadinessV1":
+    """Map internal readiness result to telemetry schema (single http_alive source)."""
+    from orion.schemas.telemetry.system_health import BusConsumerReadinessV1
+
+    payload = result.model_dump(mode="json")
+    payload["http_alive"] = http_alive
+    return BusConsumerReadinessV1(**payload)
+
+
 class BusConsumerReadinessResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/orion/bus/tests/test_consumer_readiness.py
+++ b/orion/bus/tests/test_consumer_readiness.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from orion.bus.consumer_readiness import (
+    BusConsumerReadinessResult,
+    bus_consumer_readiness_v1,
     check_bus_consumer_readiness,
     redis_pubsub_numsub,
 )
@@ -51,3 +53,18 @@ async def test_check_bus_consumer_readiness_no_subscribers() -> None:
     assert result.intake_channel == intake
     assert result.dependency_status == "unavailable"
     assert result.error == f"no subscribers on intake channel: {intake}"
+
+
+def test_bus_consumer_readiness_v1_sets_http_alive_without_duplicate_kwarg() -> None:
+    result = BusConsumerReadinessResult(
+        ok=True,
+        bus_consumer_ready=True,
+        intake_channel="orion:exec:request:LLMGatewayService",
+        subscriber_count=1,
+        dependency_status="available",
+        http_alive=None,
+    )
+    body = bus_consumer_readiness_v1(result, http_alive=True)
+    assert body.http_alive is True
+    assert body.ok is True
+    assert body.subscriber_count == 1

--- a/orion/core/bus/bus_service_chassis.py
+++ b/orion/core/bus/bus_service_chassis.py
@@ -284,58 +284,78 @@ class Rabbit(BaseChassis):
                 )
 
     async def _run(self) -> None:
-        logger.info(f"Rabbit listening channel={self.request_channel} bus={self.cfg.bus_url}")
-
-        async with self.bus.subscribe(self.request_channel) as pubsub:
+        backoff_sec = 1.0
+        while not self._stop.is_set():
+            logger.info(f"Rabbit listening channel={self.request_channel} bus={self.cfg.bus_url}")
             try:
-                async for msg in self.bus.iter_messages(pubsub):
-                    if self._stop.is_set():
-                        break
-                    if not isinstance(msg, dict):
-                        continue
-                    data = msg.get("data")
-                    if data is None:
-                        continue
-
-                    channel = msg.get("channel")
-                    if hasattr(channel, "decode"):
-                        channel = channel.decode("utf-8")
-
-                    decoded = self.bus.codec.decode(data)
-                    if not decoded.ok or decoded.envelope is None:
-                        logger.warning(
-                            f"Rabbit decode failed channel={channel} error={decoded.error}"
-                        )
-                        await self._publish_error(
-                            RuntimeError(decoded.error or "decode_failed"),
-                            when="rabbit.decode",
-                            env=None,
-                        )
-                        continue
-
-                    env = decoded.envelope
-                    if self.concurrent_handlers:
-                        async def _run_handler(envelope: BaseEnvelope, channel_name: str) -> None:
-                            try:
-                                await self._handle_decoded_envelope(channel=channel_name, env=envelope)
-                            except Exception as e:
-                                await self._publish_error(e, when="rabbit.handle", env=envelope)
-
-                        task = asyncio.create_task(_run_handler(env, str(channel)))
-                        self._inflight_tasks.add(task)
-                        task.add_done_callback(lambda t: self._inflight_tasks.discard(t))
-                        continue
-
+                if not self.bus.enabled:
+                    break
+                if self.bus.redis is None:
+                    await self.bus.connect()
+                async with self.bus.subscribe(self.request_channel) as pubsub:
+                    backoff_sec = 1.0
                     try:
-                        await self._handle_decoded_envelope(channel=str(channel), env=env)
-                    except Exception as e:
-                        await self._publish_error(e, when="rabbit.handle", env=env)
-            finally:
-                if self._inflight_tasks:
-                    for task in list(self._inflight_tasks):
-                        if not task.done():
-                            task.cancel()
-                    await asyncio.gather(*self._inflight_tasks, return_exceptions=True)
+                        async for msg in self.bus.iter_messages(pubsub):
+                            if self._stop.is_set():
+                                break
+                            if not isinstance(msg, dict):
+                                continue
+                            data = msg.get("data")
+                            if data is None:
+                                continue
+
+                            channel = msg.get("channel")
+                            if hasattr(channel, "decode"):
+                                channel = channel.decode("utf-8")
+
+                            decoded = self.bus.codec.decode(data)
+                            if not decoded.ok or decoded.envelope is None:
+                                logger.warning(
+                                    f"Rabbit decode failed channel={channel} error={decoded.error}"
+                                )
+                                await self._publish_error(
+                                    RuntimeError(decoded.error or "decode_failed"),
+                                    when="rabbit.decode",
+                                    env=None,
+                                )
+                                continue
+
+                            env = decoded.envelope
+                            if self.concurrent_handlers:
+                                async def _run_handler(envelope: BaseEnvelope, channel_name: str) -> None:
+                                    try:
+                                        await self._handle_decoded_envelope(channel=channel_name, env=envelope)
+                                    except Exception as e:
+                                        await self._publish_error(e, when="rabbit.handle", env=envelope)
+
+                                task = asyncio.create_task(_run_handler(env, str(channel)))
+                                self._inflight_tasks.add(task)
+                                task.add_done_callback(lambda t: self._inflight_tasks.discard(t))
+                                continue
+
+                            try:
+                                await self._handle_decoded_envelope(channel=str(channel), env=env)
+                            except Exception as e:
+                                await self._publish_error(e, when="rabbit.handle", env=env)
+                    finally:
+                        if self._inflight_tasks:
+                            for task in list(self._inflight_tasks):
+                                if not task.done():
+                                    task.cancel()
+                            await asyncio.gather(*self._inflight_tasks, return_exceptions=True)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "Rabbit subscriber loop failed channel=%s err=%s; reconnecting in %.1fs",
+                    self.request_channel,
+                    exc,
+                    backoff_sec,
+                )
+            if self._stop.is_set():
+                break
+            await asyncio.sleep(backoff_sec)
+            backoff_sec = min(backoff_sec * 2.0, 30.0)
 
 
 class Hunter(BaseChassis):

--- a/services/orion-context-exec/.env_example
+++ b/services/orion-context-exec/.env_example
@@ -35,8 +35,8 @@ CONTEXT_EXEC_RLM_ENGINE=alexzhang
 CONTEXT_EXEC_RLM_FALLBACK_ENABLED=true
 
 CONTEXT_EXEC_COMPAT_AGENT_CHAIN_ENABLED=false
-# Profile-derived investigation_v2 path (agent compat + Hub). Off preserves keyword mode inference.
-CONTEXT_EXEC_INVESTIGATION_V2_ENABLED=false
+# Profile-derived investigation_v2 path (agent compat + Hub). Must match Hub.
+CONTEXT_EXEC_INVESTIGATION_V2_ENABLED=true
 # Per-source probe timeout for investigation_v2 evidence sweep (seconds)
 CONTEXT_EXEC_INVESTIGATION_V2_PROBE_TIMEOUT_SEC=15
 CONTEXT_EXEC_BUS_READINESS_HEARTBEAT_TTL_SEC=30

--- a/services/orion-context-exec/app/agent_compat.py
+++ b/services/orion-context-exec/app/agent_compat.py
@@ -18,7 +18,7 @@ def agent_chain_request_to_context_exec(body: AgentChainRequest) -> ContextExecR
     text = body.text or ""
     if settings.context_exec_investigation_v2_enabled:
         profile = str(body.response_profile or "agent").strip().lower()
-        permissions = context_exec_permissions_for_llm_profile(profile)
+        permissions = context_exec_permissions_for_llm_profile("agent")
         return ContextExecRequestV1(
             text=text,
             mode="investigation_v2",
@@ -28,6 +28,7 @@ def agent_chain_request_to_context_exec(body: AgentChainRequest) -> ContextExecR
             answer_contract=_parse_answer_contract(body.answer_contract),
             packs=list(body.packs or []),
             permissions=permissions,
+            llm_profile=profile,
         )
 
     mode = "general_investigation"

--- a/services/orion-context-exec/app/bus_dependency_preflight.py
+++ b/services/orion-context-exec/app/bus_dependency_preflight.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import httpx
+
 from orion.bus.consumer_readiness import BusConsumerReadinessResult, check_bus_consumer_readiness
-from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.async_service import OrionBusAsync
 from orion.schemas.context_exec import SourceResult, SourceStatus
 
@@ -62,6 +63,44 @@ async def check_llm_gateway_bus_ready(bus: OrionBusAsync, *, timeout_sec: float)
         service_name="llm-gateway",
         timeout_sec=timeout_sec,
     )
+
+
+async def llm_gateway_http_alive(*, timeout_sec: float) -> bool:
+    gateway_url = str(settings.context_exec_llm_gateway_url or "").strip().rstrip("/")
+    if not gateway_url:
+        return False
+    try:
+        async with httpx.AsyncClient(timeout=min(float(timeout_sec), float(settings.context_exec_llm_gateway_timeout_sec))) as client:
+            resp = await client.get(f"{gateway_url}/health")
+        return resp.status_code < 400
+    except Exception:
+        return False
+
+
+async def effective_llm_gateway_ready(
+    bus: OrionBusAsync,
+    *,
+    timeout_sec: float,
+) -> tuple[BusConsumerReadinessResult, bool, bool]:
+    """Return (numsub readiness, http alive, effective ok for operator surfaces)."""
+    bus_ready = await check_llm_gateway_bus_ready(bus, timeout_sec=timeout_sec)
+    http_ok = await llm_gateway_http_alive(timeout_sec=timeout_sec)
+    effective_ok = bus_ready.ok or http_ok
+    return bus_ready, http_ok, effective_ok
+
+
+def llm_gateway_readiness_metadata(
+    bus_ready: BusConsumerReadinessResult,
+    *,
+    http_ok: bool,
+    effective_ok: bool,
+) -> dict[str, Any]:
+    payload = bus_ready.model_dump(mode="json")
+    payload["http_alive_ok"] = http_ok
+    payload["effective_ready"] = effective_ok
+    if http_ok and not bus_ready.ok:
+        payload["note"] = "NUMSUB=0 but LLM gateway HTTP health ok"
+    return payload
 
 
 def dependency_health_entry(
@@ -141,14 +180,20 @@ async def collect_bus_dependencies_health(
         check_recall_bus_ready(bus, timeout_sec=timeout_sec),
         check_llm_gateway_bus_ready(bus, timeout_sec=timeout_sec),
     )
+    llm_http_ok = await llm_gateway_http_alive(timeout_sec=timeout_sec)
+    llm_effective_ok = llm_ready.ok or llm_http_ok
     dependencies = {
         "recall": dependency_health_entry(recall_ready, redis_ping_ok=ping_ok),
-        "llm_gateway": dependency_health_entry(llm_ready, redis_ping_ok=ping_ok),
+        "llm_gateway": {
+            **dependency_health_entry(llm_ready, redis_ping_ok=ping_ok),
+            "http_alive_ok": llm_http_ok,
+            "effective_ready": llm_effective_ok,
+        },
     }
     return {
         "bus_enabled": True,
         "bus_connected": True,
-        "bus_consumer_ready": recall_ready.ok and llm_ready.ok,
+        "bus_consumer_ready": recall_ready.ok and llm_effective_ok,
         "dependencies": dependencies,
     }
 

--- a/services/orion-context-exec/app/investigation_v2.py
+++ b/services/orion-context-exec/app/investigation_v2.py
@@ -19,6 +19,8 @@ from .alexzhang_rlm_engine import _merge_repo_hits, _repo_search_terms
 from .bus_dependency_preflight import (
     check_llm_gateway_bus_ready,
     check_recall_bus_ready,
+    effective_llm_gateway_ready,
+    llm_gateway_readiness_metadata,
     unavailable_source_result,
 )
 from .callable_namespace import ContextNamespace
@@ -330,13 +332,21 @@ async def health_probe(
     if settings.orion_bus_enabled and runtime.bus is not None:
         readiness_timeout = _readiness_timeout_sec()
         recall_ready = await check_recall_bus_ready(runtime.bus, timeout_sec=readiness_timeout)
-        llm_ready = await check_llm_gateway_bus_ready(runtime.bus, timeout_sec=readiness_timeout)
+        llm_ready, llm_http_ok, llm_effective_ok = await effective_llm_gateway_ready(
+            runtime.bus,
+            timeout_sec=readiness_timeout,
+        )
         checks["recall_bus_ready"] = "yes" if recall_ready.ok else "no"
         checks["recall_subscriber_count"] = recall_ready.subscriber_count
-        checks["llm_gateway_bus_ready"] = "yes" if llm_ready.ok else "no"
+        checks["llm_gateway_bus_ready"] = "yes" if llm_effective_ok else "no"
         checks["llm_gateway_subscriber_count"] = llm_ready.subscriber_count
+        checks["llm_gateway_http_alive"] = "yes" if llm_http_ok else "no"
         checks["recall_readiness"] = recall_ready.model_dump(mode="json")
-        checks["llm_gateway_readiness"] = llm_ready.model_dump(mode="json")
+        checks["llm_gateway_readiness"] = llm_gateway_readiness_metadata(
+            llm_ready,
+            http_ok=llm_http_ok,
+            effective_ok=llm_effective_ok,
+        )
     return SourceResult(
         source="health",
         status=SourceStatus.no_hit,

--- a/services/orion-context-exec/app/investigation_v2_reducers.py
+++ b/services/orion-context-exec/app/investigation_v2_reducers.py
@@ -406,10 +406,20 @@ def reduce_health_section(result: SourceResult | None) -> InvestigationSectionV2
         )
 
     checks = result.metadata if isinstance(result.metadata, dict) else {}
-    check_lines = [f"{k}={v}" for k, v in sorted(checks.items())]
+    parts: list[str] = []
+    recall_ready = checks.get("recall_bus_ready")
+    llm_ready = checks.get("llm_gateway_bus_ready")
+    if recall_ready:
+        recall_count = checks.get("recall_subscriber_count", "?")
+        parts.append(f"recall={recall_ready} (subscribers={recall_count})")
+    if llm_ready:
+        llm_count = checks.get("llm_gateway_subscriber_count", "?")
+        http_flag = checks.get("llm_gateway_http_alive")
+        http_note = f", http={http_flag}" if http_flag else ""
+        parts.append(f"llm_gateway={llm_ready} (subscribers={llm_count}{http_note})")
     summary = result.summary or "Shallow dependency health snapshot."
-    if check_lines:
-        summary = f"{summary} ({'; '.join(check_lines)})"
+    if parts:
+        summary = f"{summary}: {'; '.join(parts)}."
 
     return InvestigationSectionV2(
         source="health",

--- a/services/orion-context-exec/app/runner.py
+++ b/services/orion-context-exec/app/runner.py
@@ -22,7 +22,7 @@ from .agent_synthesis import (
     run_agent_synthesis,
     synthesis_unavailable_for_llm_gateway_readiness,
 )
-from .bus_dependency_preflight import check_llm_gateway_bus_ready
+from .bus_dependency_preflight import check_llm_gateway_bus_ready, effective_llm_gateway_ready, llm_gateway_http_alive
 from .grounding_eval import evaluate_investigation_outcome, is_placeholder_investigation_summary
 from .investigation_v2 import (
     INVESTIGATION_V2_ARTIFACT_TYPE,
@@ -561,11 +561,11 @@ class ContextExecRunner:
             and settings.orion_bus_enabled
             and self.bus is not None
         ):
-            llm_ready = await check_llm_gateway_bus_ready(
+            llm_ready, llm_http_ok, llm_effective_ok = await effective_llm_gateway_ready(
                 self.bus,
                 timeout_sec=float(settings.context_exec_bus_readiness_timeout_sec),
             )
-            if not llm_ready.ok:
+            if not llm_effective_ok:
                 synthesis_result = synthesis_unavailable_for_llm_gateway_readiness(
                     request=request,
                     artifact=artifact,

--- a/services/orion-context-exec/tests/test_context_exec_v2_readiness_hardening.py
+++ b/services/orion-context-exec/tests/test_context_exec_v2_readiness_hardening.py
@@ -152,8 +152,14 @@ async def test_llm_gateway_dead_consumer_skips_synthesis_rpc(monkeypatch: pytest
     monkeypatch.setattr(settings, "context_exec_agent_synthesis_enabled", True)
     monkeypatch.setattr("app.agent_synthesis.llm_chat_route", llm_chat)
     monkeypatch.setattr(
-        "app.runner.check_llm_gateway_bus_ready",
-        AsyncMock(return_value=_dead_readiness(intake_channel=settings.channel_llm_intake)),
+        "app.runner.effective_llm_gateway_ready",
+        AsyncMock(
+            return_value=(
+                _dead_readiness(intake_channel=settings.channel_llm_intake),
+                False,
+                False,
+            )
+        ),
     )
 
     bus = MagicMock()
@@ -194,8 +200,14 @@ async def test_synthesis_runs_when_llm_gateway_ready(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(settings, "context_exec_agent_synthesis_enabled", True)
     monkeypatch.setattr("app.agent_synthesis.llm_chat_route", llm_chat)
     monkeypatch.setattr(
-        "app.runner.check_llm_gateway_bus_ready",
-        AsyncMock(return_value=_live_readiness(intake_channel=settings.channel_llm_intake)),
+        "app.runner.effective_llm_gateway_ready",
+        AsyncMock(
+            return_value=(
+                _live_readiness(intake_channel=settings.channel_llm_intake),
+                True,
+                True,
+            )
+        ),
     )
 
     bus = MagicMock()

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -56,8 +56,8 @@ HUB_LLM_GATEWAY_TIMEOUT_SEC=5
 HUB_AGENT_CONTEXT_EXEC_ENABLED=true
 HUB_CONTEXT_EXEC_API_URL=http://127.0.0.1:8096
 HUB_CONTEXT_EXEC_TIMEOUT_SEC=120
-# Profile-derived investigation_v2 path (Hub Agent lane). Off preserves keyword mode inference.
-CONTEXT_EXEC_INVESTIGATION_V2_ENABLED=false
+# Profile-derived investigation_v2 path (Hub Agent lane). Must match context-exec.
+CONTEXT_EXEC_INVESTIGATION_V2_ENABLED=true
 
 # --- Knowledge Forge ---
 KNOWLEDGE_FORGE_BASE_URL=http://127.0.0.1:8630

--- a/services/orion-hub/scripts/context_exec_agent_bridge.py
+++ b/services/orion-hub/scripts/context_exec_agent_bridge.py
@@ -139,6 +139,8 @@ def build_context_exec_request(
 ) -> ContextExecRequestV1:
     llm_profile_norm = normalize_llm_profile(llm_profile)
     if investigation_v2_enabled():
+        # Agent lane investigation: broad read permissions; compute lane selects LLM route only.
+        permissions = context_exec_permissions_for_llm_profile("agent")
         return ContextExecRequestV1(
             text=prompt,
             mode="investigation_v2",
@@ -147,7 +149,7 @@ def build_context_exec_request(
             correlation_id=req.trace_id,
             messages=list(req.messages or []),
             packs=list(req.packs or []),
-            permissions=context_exec_permissions_for_llm_profile(llm_profile_norm),
+            permissions=permissions,
             llm_profile=llm_profile_norm,
         )
 

--- a/services/orion-hub/tests/test_investigation_v2_request.py
+++ b/services/orion-hub/tests/test_investigation_v2_request.py
@@ -120,13 +120,16 @@ def test_v2_disabled_preserves_keyword_mode_inference() -> None:
     assert body.permissions.read_repo is True
 
 
-def test_v2_enabled_quick_profile_does_not_grant_mutation_permissions() -> None:
+def test_v2_enabled_quick_profile_grants_read_broad_agent_permissions() -> None:
     build_context_exec_request, _, CortexChatRequest = _hub_imports()
     with patch("scripts.context_exec_agent_bridge.investigation_v2_enabled", return_value=True):
         req = CortexChatRequest(prompt=CORTEX_CHANGE_PROMPT, mode="agent", trace_id="corr-quick")
         body = build_context_exec_request(req=req, prompt=req.prompt, llm_profile="quick")
     assert body.mode == "investigation_v2"
-    assert body.permissions.read_repo is False
+    assert body.llm_profile == "quick"
+    assert body.permissions.read_repo is True
+    assert body.permissions.read_recall is True
+    assert body.permissions.read_runtime_logs is True
     assert body.permissions.write_repo is False
     assert body.permissions.mutate_runtime is False
 

--- a/services/orion-llm-gateway/app/main.py
+++ b/services/orion-llm-gateway/app/main.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 # [FIX] Added ServiceRef to imports
 from orion.core.bus.bus_schemas import BaseEnvelope, ChatRequestPayload, ChatResultPayload, Envelope, ServiceRef
 from orion.core.bus.bus_service_chassis import ChassisConfig, Rabbit
-from orion.bus.consumer_readiness import check_bus_consumer_readiness
+from orion.bus.consumer_readiness import bus_consumer_readiness_v1, check_bus_consumer_readiness
 from orion.schemas.telemetry.system_health import BusConsumerReadinessV1
 from orion.schemas.vector.schemas import VectorUpsertV1
 
@@ -94,8 +94,9 @@ async def ready() -> JSONResponse:
         intake_channel=settings.channel_llm_intake,
         service_name=settings.service_name,
         heartbeat_ttl_sec=float(settings.heartbeat_interval_sec) * 3.0,
+        check_heartbeat=False,
     )
-    body = BusConsumerReadinessV1(**result.model_dump(), http_alive=True)
+    body = bus_consumer_readiness_v1(result, http_alive=True)
     status_code = 200 if body.ok else 503
     return JSONResponse(body.model_dump(mode="json"), status_code=status_code)
 

--- a/services/orion-recall/app/main.py
+++ b/services/orion-recall/app/main.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from orion.core.bus.bus_service_chassis import Rabbit
-from orion.bus.consumer_readiness import check_bus_consumer_readiness
+from orion.bus.consumer_readiness import bus_consumer_readiness_v1, check_bus_consumer_readiness
 from orion.schemas.telemetry.system_health import BusConsumerReadinessV1
 
 from .http_models import RecallCompareRequestBody, RecallCompareResponseBody, RecallRequestBody, RecallResponseBody
@@ -151,8 +151,9 @@ async def ready():
         service_name=settings.SERVICE_NAME,
         health_channel=settings.ORION_HEALTH_CHANNEL,
         heartbeat_ttl_sec=float(settings.HEARTBEAT_INTERVAL_SEC) * 3.0,
+        check_heartbeat=False,
     )
-    body = BusConsumerReadinessV1(**result.model_dump(), http_alive=True)
+    body = bus_consumer_readiness_v1(result, http_alive=True)
     status_code = 200 if body.ok else 503
     return JSONResponse(body.model_dump(mode="json"), status_code=status_code)
 


### PR DESCRIPTION
Summary
Rabbit pubsub reconnect: Rabbit._run reconnects when Redis pubsub drops — fixes stale NUMSUB=0 while HTTP /health still looks fine (llm-gateway/recall listeners went zombie after uptime).
/ready repair: Fixes BusConsumerReadinessV1 duplicate http_alive TypeError (500); uses NUMSUB-only readiness so /ready matches RPC availability.
Context-exec health accuracy: health_probe and /health use NUMSUB + LLM gateway HTTP health; health section is readable instead of raw dict dumps.
Synthesis preflight: Skips LLM RPC only when both NUMSUB and HTTP health fail.
Hub Agent v2 permissions: investigation_v2 always gets read-broad agent permissions; compute lane picks LLM route only (fixes repo blocked when Compute=quick).
Env examples: CONTEXT_EXEC_INVESTIGATION_V2_ENABLED=true on Hub + context-exec.
Files changed
orion/bus/consumer_readiness.py
orion/bus/tests/test_consumer_readiness.py
orion/core/bus/bus_service_chassis.py
services/orion-context-exec/.env_example
services/orion-context-exec/app/agent_compat.py
services/orion-context-exec/app/bus_dependency_preflight.py
services/orion-context-exec/app/investigation_v2.py
services/orion-context-exec/app/investigation_v2_reducers.py
services/orion-context-exec/app/runner.py
services/orion-context-exec/tests/test_context_exec_v2_readiness_hardening.py
services/orion-hub/.env_example
services/orion-hub/scripts/context_exec_agent_bridge.py
services/orion-hub/tests/test_investigation_v2_request.py
services/orion-llm-gateway/app/main.py
services/orion-recall/app/main.py
Test plan

 PYTHONPATH=. orion_dev/bin/python -m pytest orion/bus/tests/test_consumer_readiness.py services/orion-context-exec/tests/test_context_exec_v2_readiness_hardening.py services/orion-hub/tests/test_investigation_v2_request.py -q — 17 passed

 Live: PUBSUB NUMSUB → 1 for LLMGateway + Recall

 Live: GET :8210/ready → HTTP 200

 Live: GET :8096/health → bus_consumer_ready: true

 Live: investigation_v2 run → recall hit, repo hit, synthesis completed

 Hub Agent prompt after merge + restart
Remaining
Repo grep noise (134 paths on generic terms) — follow-up
Unstaged local .gitignore edits not included in PR