### PR TITLE
Feat/substrate quarantine truth hardening

### DIFF
--- a/docs/superpowers/pr-reports/2026-06-15-substrate-quarantine-truth-hardening-pr.md
+++ b/docs/superpowers/pr-reports/2026-06-15-substrate-quarantine-truth-hardening-pr.md
@@ -1,0 +1,121 @@
+# PR: Substrate poison quarantine production-truth hardening
+
+## Summary
+
+PR #707 fixed reducer starvation by splitting substrate reducers into independent poll loops, but poison-event quarantine remained **semantically weak**: quarantine state lived only in-process (`reducer_health.py`), reset on container restart, and `/grammar/truth` could become healthy after history was skipped unless operators had no durable signal.
+
+This PR makes quarantine **production-truth honest** by persisting quarantine rows in Postgres, degrading truth until operator acknowledgement, and exposing bounded quarantine detail in the truth payload and smoke gate.
+
+## Root cause of hardening gap
+
+- Quarantine was recorded via in-process `record_quarantine()` plus a `ReductionReceiptV1` (`quarantine:{reducer_key}:{event_id}`).
+- `/grammar/truth` never consulted durable quarantine state; only ephemeral reducer health snapshots.
+- Receipts expire (default 6h error retention) and can be pruned — not a reliable ack contract.
+- After restart, in-process quarantine lists cleared → truth could falsely pass.
+
+## Changes
+
+### Durable model
+
+New table `substrate_reducer_quarantine` (migration `manual_migration_substrate_reducer_quarantine_v1.sql`):
+
+| Column | Purpose |
+|--------|---------|
+| `quarantine_id` | `quarantine:{reducer_key}:{event_id}` |
+| `reducer_key`, `cursor_name`, `event_id` | Reducer identity |
+| `trace_id`, `reason` | Diagnosis |
+| `quarantined_at` | When poison was isolated |
+| `acknowledged_at`, `acknowledged_by` | Operator ack audit (row retained) |
+
+### New truth payload fields
+
+- `quarantine_by_reducer` — unack count + bounded recent examples per reducer
+- `unacknowledged_quarantine_count_by_reducer`
+- `reducer_health_by_name[*].unacknowledged_quarantine_count`
+- `quarantine_recovery` — endpoint docs in truth payload
+
+### New degraded reason
+
+- `reducer_quarantine_present:<cursor_name>` — emitted when unacknowledged quarantine exists for that cursor
+
+Existing reasons unchanged (`cursor_lag:*`, `reducer_stream_lag:*`, etc.).
+
+### Operator acknowledgement
+
+`POST /grammar/quarantine/ack` — same auth as cursor reset (`X-Orion-Operator-Token` / `SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN`):
+
+```bash
+# Single event
+curl -X POST \
+  -H "X-Orion-Operator-Token: $SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN" \
+  "http://127.0.0.1:8115/grammar/quarantine/ack?cursor_name=transport_grammar_reducer&event_id=gev_x"
+
+# All unacked for cursor
+curl -X POST \
+  -H "X-Orion-Operator-Token: $SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN" \
+  "http://127.0.0.1:8115/grammar/quarantine/ack?cursor_name=transport_grammar_reducer&ack_all=true"
+```
+
+Ack sets `acknowledged_at` / `acknowledged_by`; does **not** delete rows. Clears degraded quarantine reason when no unacked rows remain.
+
+### Smoke gate
+
+`grammar_truth_gate.py` classifies quarantine under `reducer_quarantine=[reducer_quarantine_present:...]`. Reducer health summary includes `unack_quarantine` count.
+
+## Files changed
+
+- `services/orion-sql-db/manual_migration_substrate_reducer_quarantine_v1.sql` (new)
+- `services/orion-substrate-runtime/app/store.py`
+- `services/orion-substrate-runtime/app/quarantine_ack.py` (new)
+- `services/orion-substrate-runtime/app/grammar_truth.py`
+- `services/orion-substrate-runtime/app/worker.py`
+- `services/orion-substrate-runtime/app/main.py`
+- `services/orion-substrate-runtime/app/reducer_health.py`
+- `scripts/grammar_truth_gate.py`
+- `services/orion-substrate-runtime/.env_example`
+- `services/orion-substrate-runtime/README.md`
+- Tests: `test_quarantine_truth.py`, `test_worker_independent_reducers.py`, updates to existing reducer/truth/gate tests
+
+## Tests added
+
+| Test file | Coverage |
+|-----------|----------|
+| `test_quarantine_truth.py` | Truth degrades on unack quarantine; survives health reset; ack auth + audit |
+| `test_worker_independent_reducers.py` | Transport advances while biometrics blocked; independent poll tasks |
+| `test_worker_reducer.py` | Poison quarantine calls `save_quarantine` |
+| `test_grammar_truth_gate.py` | Quarantine degraded group classification |
+
+## Verification
+
+```bash
+PYTHONPATH=. ./venv/bin/python -m pytest \
+  services/orion-substrate-runtime/tests/test_reducer_health.py \
+  services/orion-substrate-runtime/tests/test_worker_reducer.py \
+  services/orion-substrate-runtime/tests/test_grammar_truth_reducer_health.py \
+  services/orion-substrate-runtime/tests/test_quarantine_truth.py \
+  services/orion-substrate-runtime/tests/test_worker_independent_reducers.py \
+  tests/test_grammar_truth_gate.py -q
+```
+
+Result: **22 passed**
+
+```bash
+PYTHONPATH=. ./venv/bin/python -m compileall services/orion-substrate-runtime/app scripts/grammar_truth_gate.py -q
+```
+
+Result: **exit 0**
+
+## Deploy notes
+
+1. Apply migration before or with deploy:
+   ```bash
+   psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_substrate_reducer_quarantine_v1.sql
+   ```
+2. No new env keys (ack reuses `SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN`).
+3. Restart `orion-substrate-runtime` after migration.
+
+## Non-goals (preserved)
+
+- PR #707 independent reducer loops unchanged
+- Cursor lag thresholds unchanged
+- No silent deletion of quarantine evidence

--- a/scripts/grammar_truth_gate.py
+++ b/scripts/grammar_truth_gate.py
@@ -31,6 +31,8 @@ SUBSTRATE_REQUIRED = {
     "stream_lag_by_reducer",
     "pending_backlog_by_reducer",
     "reducer_health_by_name",
+    "quarantine_by_reducer",
+    "unacknowledged_quarantine_count_by_reducer",
     "tail_seed",
     "operator_cursor_reset",
     "accepted_pressure_output_channel",
@@ -74,6 +76,8 @@ def _classify_degraded_reason(reason: str) -> str:
         return "cursor_commit_failure"
     if reason.startswith("reducer_stream_lag:"):
         return "redis_stream_lag"
+    if reason.startswith("reducer_quarantine_present:"):
+        return "reducer_quarantine"
     if "tail_seed" in reason:
         return "stale_producer_cursor"
     return "other"
@@ -107,7 +111,8 @@ def format_reducer_health_summary(substrate: dict[str, Any] | None) -> str:
             f"backlog={backlog.get(row.get('cursor_name'))} "
             f"stream_lag_sec={row.get('stream_lag_sec')} "
             f"heartbeat={row.get('last_tick_at')} "
-            f"blocked={row.get('blocked_event_id')}"
+            f"blocked={row.get('blocked_event_id')} "
+            f"unack_quarantine={row.get('unacknowledged_quarantine_count', 0)}"
         )
     return "\n".join(lines)
 

--- a/services/orion-sql-db/manual_migration_substrate_reducer_quarantine_v1.sql
+++ b/services/orion-sql-db/manual_migration_substrate_reducer_quarantine_v1.sql
@@ -1,0 +1,24 @@
+-- Durable reducer poison quarantine + operator acknowledgement audit trail.
+-- Apply: psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_substrate_reducer_quarantine_v1.sql
+
+create table if not exists substrate_reducer_quarantine (
+    quarantine_id text primary key,
+    reducer_key text not null,
+    cursor_name text not null,
+    event_id text not null,
+    trace_id text,
+    reason text not null,
+    quarantined_at timestamptz not null default now(),
+    acknowledged_at timestamptz,
+    acknowledged_by text
+);
+
+create unique index if not exists idx_substrate_quarantine_reducer_event
+  on substrate_reducer_quarantine (reducer_key, event_id);
+
+create index if not exists idx_substrate_quarantine_unacked
+  on substrate_reducer_quarantine (cursor_name, quarantined_at desc)
+  where acknowledged_at is null;
+
+create index if not exists idx_substrate_quarantine_quarantined_at
+  on substrate_reducer_quarantine (quarantined_at desc);

--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -27,7 +27,7 @@ ACCEPTED_PRESSURE_GRAMMAR_CHANNEL=orion:grammar:accepted-pressure
 # Default false: do not silently skip history after long outage. Cold-start tail-seed still logs substrate_data_gap.
 SUBSTRATE_CURSOR_TAIL_SEED_ON_LAG=false
 SUBSTRATE_CURSOR_LAG_RESYNC_HOURS=6
-# Required for POST /grammar/cursor/reset (internal operator endpoint; not exposed via hub/Caddy).
+# Required for POST /grammar/cursor/reset and POST /grammar/quarantine/ack (internal operator endpoints; not exposed via hub/Caddy).
 SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN=
 ENABLE_EXECUTION_TRAJECTORY_REDUCER=true
 # Transport M3: set true to enable bus reducer and projection (default off)

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -21,6 +21,7 @@ grammar_events (orion-bus, bus.transport:*) → transport bus projection
 psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_biometrics_substrate_loop.sql
 psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_execution_substrate_loop.sql
 psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_transport_substrate_loop.sql
+psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_substrate_reducer_quarantine_v1.sql
 cp services/orion-substrate-runtime/.env_example services/orion-substrate-runtime/.env
 ```
 
@@ -83,5 +84,22 @@ curl -X POST -H "X-Orion-Operator-Token: $SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN"
 ```
 
 Known cursors: `biometrics_grammar_consumer`, `execution_grammar_reducer`, `transport_grammar_reducer`.
+
+### Poison quarantine acknowledgement (internal operator endpoint)
+
+When a reducer quarantines a poison event, `/grammar/truth` stays **degraded** with
+`reducer_quarantine_present:<cursor_name>` until an operator acknowledges the quarantine.
+Quarantine state is durable in Postgres (`substrate_reducer_quarantine`); acknowledgement
+sets `acknowledged_at` but preserves the audit row.
+
+```bash
+# Acknowledge a single quarantined event
+curl -X POST -H "X-Orion-Operator-Token: $SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN" \
+  'http://127.0.0.1:8115/grammar/quarantine/ack?cursor_name=transport_grammar_reducer&event_id=gev_x'
+
+# Acknowledge all unacked quarantine for a cursor
+curl -X POST -H "X-Orion-Operator-Token: $SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN" \
+  'http://127.0.0.1:8115/grammar/quarantine/ack?cursor_name=transport_grammar_reducer&ack_all=true'
+```
 
 Accepted-pressure reducer output publishes to `orion:grammar:accepted-pressure` (not canonical `orion:grammar:event`).

--- a/services/orion-substrate-runtime/app/grammar_truth.py
+++ b/services/orion-substrate-runtime/app/grammar_truth.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from app.cursor_gaps import has_cold_start_tail_seed, has_recent_tail_seed, tail_seed_snapshot
 from app.cursor_reset import cursor_reset_snapshot, last_reset_skipped_history
-from app.reducer_health import health_snapshots, update_backlog_metrics
+from app.reducer_health import health_snapshots, update_backlog_metrics, update_quarantine_metrics
 from app.settings import get_settings
 from app.store import BiometricsSubstrateStore, GRAMMAR_CURSOR_REGISTRY
 
@@ -35,6 +35,14 @@ def build_substrate_grammar_truth(store: BiometricsSubstrateStore) -> dict[str, 
         degraded_reasons.append("cold_start_tail_seed_occurred")
     if last_reset_skipped_history():
         degraded_reasons.append("operator_cursor_reset_skipped_history")
+
+    quarantine_summary = store.quarantine_summary(examples_per_reducer=10)
+    unack_by_reducer = quarantine_summary["unacknowledged_quarantine_count_by_reducer"]
+    unack_by_cursor = quarantine_summary["unacknowledged_quarantine_count_by_cursor"]
+    quarantine_by_reducer = quarantine_summary["quarantine_by_reducer"]
+    for cursor_name, count in sorted(unack_by_cursor.items()):
+        if count > 0:
+            degraded_reasons.append(f"reducer_quarantine_present:{cursor_name}")
 
     cursors = store.cursor_positions()
     cursor_by_name = {row["cursor_name"]: row for row in cursors}
@@ -68,6 +76,12 @@ def build_substrate_grammar_truth(store: BiometricsSubstrateStore) -> dict[str, 
             pending_backlog=pending,
             stream_lag_sec=stream_lag,
             cursor_wall_lag_sec=metrics.get("cursor_wall_lag_sec"),
+        )
+        update_quarantine_metrics(
+            reducer_key,
+            cursor_name=cursor_name,
+            enabled=enabled,
+            unacknowledged_quarantine_count=int(unack_by_reducer.get(reducer_key, 0)),
         )
 
     snapshots = health_snapshots()
@@ -150,6 +164,8 @@ def build_substrate_grammar_truth(store: BiometricsSubstrateStore) -> dict[str, 
         "stream_lag_by_reducer": stream_lag_by_reducer,
         "pending_backlog_by_reducer": backlog_by_reducer,
         "reducer_health_by_name": reducer_health,
+        "quarantine_by_reducer": quarantine_by_reducer,
+        "unacknowledged_quarantine_count_by_reducer": unack_by_reducer,
         "last_data_gap": last_gap,
         "tail_seed": tail,
         "operator_cursor_reset": reset_snap,
@@ -172,6 +188,17 @@ def build_substrate_grammar_truth(store: BiometricsSubstrateStore) -> dict[str, 
                 "curl -X POST -H 'X-Orion-Operator-Token: $SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN' "
                 "'http://127.0.0.1:8115/grammar/cursor/reset?"
                 "cursor_name=biometrics_grammar_consumer&mode=earliest'"
+            ),
+        },
+        "quarantine_recovery": {
+            "endpoint": "POST /grammar/quarantine/ack",
+            "auth_header": "X-Orion-Operator-Token",
+            "internal_only": True,
+            "modes": ["single_event", "ack_all_for_cursor"],
+            "example_single": (
+                "curl -X POST -H 'X-Orion-Operator-Token: $SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN' "
+                "'http://127.0.0.1:8115/grammar/quarantine/ack?"
+                "cursor_name=transport_grammar_reducer&event_id=gev_x'"
             ),
         },
     }

--- a/services/orion-substrate-runtime/app/main.py
+++ b/services/orion-substrate-runtime/app/main.py
@@ -14,6 +14,12 @@ from .cursor_reset import (
     validate_mode,
 )
 from .grammar_truth import build_substrate_grammar_truth
+from .quarantine_ack import (
+    record_quarantine_ack,
+    reducer_key_for_cursor,
+    validate_cursor_name as validate_quarantine_cursor_name,
+    require_operator_token as require_quarantine_operator_token,
+)
 from .settings import get_settings
 from .store import GRAMMAR_CURSOR_REGISTRY
 from .worker import BiometricsSubstrateWorker
@@ -96,3 +102,47 @@ async def reset_grammar_cursor(
         history_may_be_skipped=bool(result.get("history_may_be_skipped")),
     )
     return result
+
+
+@app.post("/grammar/quarantine/ack")
+async def acknowledge_quarantine(
+    cursor_name: str = Query(...),
+    event_id: str | None = Query(None),
+    ack_all: bool = Query(False, description="Acknowledge all unacked quarantine for cursor"),
+    actor: Annotated[str, Depends(require_quarantine_operator_token)] = "",
+) -> dict:
+    """Internal operator endpoint. Acknowledges durable poison quarantine without erasing audit trail."""
+    try:
+        valid_name = validate_quarantine_cursor_name(cursor_name)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if ack_all and event_id:
+        raise HTTPException(status_code=400, detail="ack_all cannot be combined with event_id")
+    if not ack_all and not event_id:
+        raise HTTPException(status_code=400, detail="event_id required unless ack_all=true")
+
+    try:
+        acknowledged_count = worker._store.acknowledge_quarantine(
+            cursor_name=valid_name,
+            event_id=event_id,
+            ack_all=ack_all,
+            actor=actor or "operator",
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    record_quarantine_ack(
+        cursor_name=valid_name,
+        reducer_key=reducer_key_for_cursor(valid_name),
+        event_id=event_id,
+        ack_all=ack_all,
+        actor=actor or "operator",
+        acknowledged_count=acknowledged_count,
+    )
+    return {
+        "cursor_name": valid_name,
+        "event_id": event_id,
+        "ack_all": ack_all,
+        "acknowledged_count": acknowledged_count,
+    }

--- a/services/orion-substrate-runtime/app/quarantine_ack.py
+++ b/services/orion-substrate-runtime/app/quarantine_ack.py
@@ -1,0 +1,137 @@
+"""Operator quarantine acknowledgement auth, validation, and audit trail."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any
+
+from fastapi import Header, HTTPException
+
+from app.settings import get_settings
+from app.store import GRAMMAR_CURSOR_REGISTRY
+
+logger = logging.getLogger("orion.substrate.quarantine_ack")
+
+KNOWN_CURSORS = frozenset(GRAMMAR_CURSOR_REGISTRY.keys())
+CURSOR_BY_REDUCER: dict[str, str] = {
+    "biometrics": "biometrics_grammar_consumer",
+    "execution_trajectory": "execution_grammar_reducer",
+    "transport_bus": "transport_grammar_reducer",
+}
+
+
+@dataclass(frozen=True)
+class QuarantineAckRecord:
+    at: datetime
+    cursor_name: str
+    reducer_key: str
+    event_id: str | None
+    ack_all: bool
+    actor: str
+    acknowledged_count: int
+
+
+_lock = Lock()
+_ack_records: list[QuarantineAckRecord] = []
+
+
+def clear_quarantine_acks_for_tests() -> None:
+    with _lock:
+        _ack_records.clear()
+
+
+def validate_cursor_name(cursor_name: str) -> str:
+    name = cursor_name.strip()
+    if name not in KNOWN_CURSORS:
+        raise ValueError(
+            f"invalid cursor_name={cursor_name!r}; known: {', '.join(sorted(KNOWN_CURSORS))}"
+        )
+    return name
+
+
+def reducer_key_for_cursor(cursor_name: str) -> str:
+    for reducer_key, cursor in CURSOR_BY_REDUCER.items():
+        if cursor == cursor_name:
+            return reducer_key
+    return cursor_name
+
+
+def require_operator_token(x_orion_operator_token: str | None = Header(default=None)) -> str:
+    expected = str(get_settings().substrate_cursor_reset_operator_token or "").strip()
+    if not expected:
+        raise HTTPException(status_code=503, detail="cursor_reset_operator_token_not_configured")
+    provided = str(x_orion_operator_token or "").strip()
+    if not provided or provided != expected:
+        raise HTTPException(status_code=401, detail="quarantine_ack_unauthorized")
+    return provided
+
+
+def record_quarantine_ack(
+    *,
+    cursor_name: str,
+    reducer_key: str,
+    event_id: str | None,
+    ack_all: bool,
+    actor: str,
+    acknowledged_count: int,
+) -> QuarantineAckRecord:
+    record = QuarantineAckRecord(
+        at=datetime.now(timezone.utc),
+        cursor_name=cursor_name,
+        reducer_key=reducer_key,
+        event_id=event_id,
+        ack_all=ack_all,
+        actor=actor,
+        acknowledged_count=acknowledged_count,
+    )
+    with _lock:
+        _ack_records.append(record)
+        if len(_ack_records) > 200:
+            del _ack_records[: len(_ack_records) - 200]
+
+    logger.warning(
+        "operator_quarantine_ack cursor=%s reducer=%s event_id=%s ack_all=%s "
+        "actor=%s acknowledged_count=%d",
+        cursor_name,
+        reducer_key,
+        event_id,
+        ack_all,
+        actor,
+        acknowledged_count,
+    )
+    return record
+
+
+def quarantine_ack_snapshot() -> dict[str, Any]:
+    with _lock:
+        records = list(_ack_records)
+    latest = records[-1] if records else None
+    return {
+        "count": len(records),
+        "last": (
+            {
+                "at": latest.at.isoformat(),
+                "cursor_name": latest.cursor_name,
+                "reducer_key": latest.reducer_key,
+                "event_id": latest.event_id,
+                "ack_all": latest.ack_all,
+                "actor": latest.actor,
+                "acknowledged_count": latest.acknowledged_count,
+            }
+            if latest
+            else None
+        ),
+        "recent": [
+            {
+                "at": r.at.isoformat(),
+                "cursor_name": r.cursor_name,
+                "event_id": r.event_id,
+                "ack_all": r.ack_all,
+                "acknowledged_count": r.acknowledged_count,
+            }
+            for r in records[-10:]
+        ],
+    }

--- a/services/orion-substrate-runtime/app/reducer_health.py
+++ b/services/orion-substrate-runtime/app/reducer_health.py
@@ -39,6 +39,7 @@ class ReducerHealthSnapshot:
     blocked_event_id: str | None = None
     blocked_failures: int = 0
     quarantined_event_ids: list[str] = field(default_factory=list)
+    unacknowledged_quarantine_count: int = 0
     pending_backlog: int | None = None
     stream_lag_sec: float | None = None
     cursor_wall_lag_sec: float | None = None
@@ -97,6 +98,7 @@ class ReducerHealthSnapshot:
             "blocked_event_id": self.blocked_event_id,
             "blocked_failures": self.blocked_failures,
             "quarantined_event_ids": list(self.quarantined_event_ids[-20:]),
+            "unacknowledged_quarantine_count": self.unacknowledged_quarantine_count,
             "pending_backlog": self.pending_backlog,
             "stream_lag_sec": self.stream_lag_sec,
             "cursor_wall_lag_sec": self.cursor_wall_lag_sec,
@@ -182,6 +184,18 @@ def record_quarantine(
             snap.quarantined_event_ids.append(event_id)
         snap.blocked_event_id = None
         snap.blocked_failures = 0
+
+
+def update_quarantine_metrics(
+    reducer_key: str,
+    *,
+    cursor_name: str,
+    enabled: bool,
+    unacknowledged_quarantine_count: int,
+) -> None:
+    snap = _get(reducer_key, cursor_name=cursor_name, enabled=enabled)
+    with _LOCK:
+        snap.unacknowledged_quarantine_count = unacknowledged_quarantine_count
 
 
 def update_backlog_metrics(

--- a/services/orion-substrate-runtime/app/store.py
+++ b/services/orion-substrate-runtime/app/store.py
@@ -961,3 +961,160 @@ class BiometricsSubstrateStore:
         if isinstance(payload, str):
             payload = json.loads(payload)
         return ReductionReceiptV1.model_validate(payload)
+
+    def save_quarantine(
+        self,
+        *,
+        reducer_key: str,
+        cursor_name: str,
+        event_id: str,
+        trace_id: str | None,
+        reason: str,
+    ) -> str:
+        quarantine_id = f"quarantine:{reducer_key}:{event_id}"
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO substrate_reducer_quarantine (
+                        quarantine_id, reducer_key, cursor_name, event_id,
+                        trace_id, reason, quarantined_at
+                    ) VALUES (
+                        :quarantine_id, :reducer_key, :cursor_name, :event_id,
+                        :trace_id, :reason, :quarantined_at
+                    )
+                    ON CONFLICT (quarantine_id) DO UPDATE SET
+                        reason = EXCLUDED.reason,
+                        trace_id = COALESCE(EXCLUDED.trace_id, substrate_reducer_quarantine.trace_id)
+                    """
+                ),
+                {
+                    "quarantine_id": quarantine_id,
+                    "reducer_key": reducer_key,
+                    "cursor_name": cursor_name,
+                    "event_id": event_id,
+                    "trace_id": trace_id,
+                    "reason": reason,
+                    "quarantined_at": now,
+                },
+            )
+        return quarantine_id
+
+    def quarantine_summary(
+        self,
+        *,
+        examples_per_reducer: int = 10,
+    ) -> dict[str, Any]:
+        with self._engine.connect() as conn:
+            count_rows = conn.execute(
+                text(
+                    """
+                    SELECT cursor_name, COUNT(*) AS unacked_count
+                    FROM substrate_reducer_quarantine
+                    WHERE acknowledged_at IS NULL
+                    GROUP BY cursor_name
+                    """
+                ),
+            ).mappings().all()
+            example_rows = conn.execute(
+                text(
+                    """
+                    SELECT reducer_key, cursor_name, event_id, trace_id, reason,
+                           quarantined_at, acknowledged_at
+                    FROM substrate_reducer_quarantine
+                    WHERE acknowledged_at IS NULL
+                    ORDER BY quarantined_at DESC
+                    """
+                ),
+            ).mappings().all()
+
+        unack_by_cursor: dict[str, int] = {
+            row["cursor_name"]: int(row["unacked_count"]) for row in count_rows
+        }
+        unack_by_reducer: dict[str, int] = {}
+        examples_by_reducer: dict[str, list[dict[str, Any]]] = {}
+        for row in example_rows:
+            reducer_key = row["reducer_key"]
+            unack_by_reducer[reducer_key] = unack_by_reducer.get(reducer_key, 0) + 1
+            bucket = examples_by_reducer.setdefault(reducer_key, [])
+            if len(bucket) >= examples_per_reducer:
+                continue
+            bucket.append(
+                {
+                    "event_id": row["event_id"],
+                    "trace_id": row["trace_id"],
+                    "reason": row["reason"],
+                    "quarantined_at": (
+                        row["quarantined_at"].isoformat() if row["quarantined_at"] else None
+                    ),
+                }
+            )
+
+        quarantine_by_reducer: dict[str, dict[str, Any]] = {}
+        for reducer_key, examples in examples_by_reducer.items():
+            quarantine_by_reducer[reducer_key] = {
+                "unacknowledged_count": unack_by_reducer.get(reducer_key, 0),
+                "recent_examples": examples,
+            }
+        for reducer_key, count in unack_by_reducer.items():
+            if reducer_key not in quarantine_by_reducer:
+                quarantine_by_reducer[reducer_key] = {
+                    "unacknowledged_count": count,
+                    "recent_examples": [],
+                }
+
+        return {
+            "unacknowledged_quarantine_count_by_reducer": unack_by_reducer,
+            "unacknowledged_quarantine_count_by_cursor": unack_by_cursor,
+            "quarantine_by_reducer": quarantine_by_reducer,
+        }
+
+    def acknowledge_quarantine(
+        self,
+        *,
+        cursor_name: str,
+        event_id: str | None,
+        ack_all: bool,
+        actor: str,
+    ) -> int:
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            if ack_all:
+                result = conn.execute(
+                    text(
+                        """
+                        UPDATE substrate_reducer_quarantine
+                        SET acknowledged_at = :now, acknowledged_by = :actor
+                        WHERE cursor_name = :cursor_name
+                          AND acknowledged_at IS NULL
+                        """
+                    ),
+                    {
+                        "now": now,
+                        "actor": actor,
+                        "cursor_name": cursor_name,
+                    },
+                )
+                return int(result.rowcount or 0)
+
+            if not event_id:
+                raise ValueError("event_id required unless ack_all=true")
+            result = conn.execute(
+                text(
+                    """
+                    UPDATE substrate_reducer_quarantine
+                    SET acknowledged_at = :now, acknowledged_by = :actor
+                    WHERE cursor_name = :cursor_name
+                      AND event_id = :event_id
+                      AND acknowledged_at IS NULL
+                    """
+                ),
+                {
+                    "now": now,
+                    "actor": actor,
+                    "cursor_name": cursor_name,
+                    "event_id": event_id,
+                },
+            )
+            return int(result.rowcount or 0)

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -403,6 +403,13 @@ class BiometricsSubstrateWorker:
             enabled=spec.enabled(self._settings),
             event_id=event.event_id,
         )
+        self._store.save_quarantine(
+            reducer_key=spec.reducer_key,
+            cursor_name=spec.cursor_name,
+            event_id=event.event_id,
+            trace_id=event.trace_id,
+            reason=reason,
+        )
         self._store.save_receipt(
             ReductionReceiptV1(
                 receipt_id=f"quarantine:{spec.reducer_key}:{event.event_id}",

--- a/services/orion-substrate-runtime/tests/test_grammar_truth_reducer_health.py
+++ b/services/orion-substrate-runtime/tests/test_grammar_truth_reducer_health.py
@@ -48,6 +48,11 @@ def test_truth_includes_reducer_health_and_backlog(monkeypatch) -> None:
         "head_event_created_at": "2026-06-16T00:00:00+00:00",
         "head_event_id": "gev_new",
     }
+    store.quarantine_summary.return_value = {
+        "unacknowledged_quarantine_count_by_reducer": {},
+        "unacknowledged_quarantine_count_by_cursor": {},
+        "quarantine_by_reducer": {},
+    }
 
     monkeypatch.setattr(
         "app.grammar_truth.get_settings",

--- a/services/orion-substrate-runtime/tests/test_quarantine_truth.py
+++ b/services/orion-substrate-runtime/tests/test_quarantine_truth.py
@@ -1,0 +1,209 @@
+"""Tests for durable reducer quarantine truth semantics and operator acknowledgement."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUBSTRATE_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SUBSTRATE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SUBSTRATE_ROOT))
+
+from app.grammar_truth import build_substrate_grammar_truth
+from app.quarantine_ack import clear_quarantine_acks_for_tests, quarantine_ack_snapshot
+from app.reducer_health import clear_health_for_tests
+from orion.substrate.transport_loop.constants import TRANSPORT_GRAMMAR_CURSOR_NAME
+
+
+@pytest.fixture(autouse=True)
+def _clear_state() -> None:
+    clear_health_for_tests()
+    clear_quarantine_acks_for_tests()
+
+
+def _mock_settings(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.grammar_truth.get_settings",
+        lambda: MagicMock(
+            orion_bus_enabled=True,
+            enable_execution_trajectory_reducer=True,
+            enable_transport_bus_reducer=True,
+            enable_biometrics_node_reducer=True,
+            enable_biometrics_pressure_organ=True,
+            enable_node_pressure_reducer=True,
+            substrate_cursor_lag_resync_hours=6.0,
+            reducer_heartbeat_stale_sec=120.0,
+            grammar_poll_interval_sec=5.0,
+            substrate_cursor_tail_seed_on_lag=False,
+            substrate_cursor_reset_operator_token="tok",
+            biometrics_grammar_batch_limit=50,
+            execution_grammar_batch_limit=100,
+            transport_grammar_batch_limit=500,
+            accepted_pressure_grammar_channel="orion:grammar:accepted-pressure",
+            grammar_event_channel="orion:grammar:event",
+            publish_accepted_pressure_grammar=True,
+        ),
+    )
+    monkeypatch.setattr("app.grammar_truth.has_recent_tail_seed", lambda: False)
+    monkeypatch.setattr("app.grammar_truth.has_cold_start_tail_seed", lambda: False)
+    monkeypatch.setattr("app.grammar_truth.last_reset_skipped_history", lambda: False)
+    monkeypatch.setattr(
+        "app.grammar_truth.tail_seed_snapshot",
+        lambda: {"count": 0, "latest": None, "recent": []},
+    )
+    monkeypatch.setattr(
+        "app.grammar_truth.cursor_reset_snapshot",
+        lambda: {"count": 0, "last": None, "recent": []},
+    )
+
+
+def _base_store_mock() -> MagicMock:
+    store = MagicMock()
+    store.cursor_positions.return_value = []
+    store.grammar_cursor_metrics.side_effect = lambda name: {
+        "cursor_name": name,
+        "pending_backlog": 0,
+        "stream_lag_sec": 0,
+        "cursor_wall_lag_sec": 0,
+        "head_event_created_at": None,
+        "head_event_id": None,
+    }
+    return store
+
+
+def test_truth_degrades_on_unacknowledged_quarantine(monkeypatch) -> None:
+    _mock_settings(monkeypatch)
+    store = _base_store_mock()
+    store.quarantine_summary.return_value = {
+        "unacknowledged_quarantine_count_by_reducer": {"transport_bus": 1},
+        "unacknowledged_quarantine_count_by_cursor": {
+            TRANSPORT_GRAMMAR_CURSOR_NAME: 1,
+        },
+        "quarantine_by_reducer": {
+            "transport_bus": {
+                "unacknowledged_count": 1,
+                "recent_examples": [
+                    {
+                        "event_id": "gev_poison",
+                        "trace_id": "bus.transport:poison01",
+                        "reason": "poison payload",
+                        "quarantined_at": "2026-06-15T12:00:00+00:00",
+                    }
+                ],
+            }
+        },
+    }
+
+    payload = build_substrate_grammar_truth(store)
+    assert payload["degraded"] is True
+    assert f"reducer_quarantine_present:{TRANSPORT_GRAMMAR_CURSOR_NAME}" in payload[
+        "degraded_reasons"
+    ]
+    assert payload["unacknowledged_quarantine_count_by_reducer"]["transport_bus"] == 1
+    assert payload["quarantine_by_reducer"]["transport_bus"]["recent_examples"][0][
+        "event_id"
+    ] == "gev_poison"
+    health = payload["reducer_health_by_name"]["transport_bus"]
+    assert health["unacknowledged_quarantine_count"] == 1
+
+
+def test_truth_reports_quarantine_after_health_snapshot_reset(monkeypatch) -> None:
+    _mock_settings(monkeypatch)
+    store = _base_store_mock()
+    store.quarantine_summary.return_value = {
+        "unacknowledged_quarantine_count_by_reducer": {"transport_bus": 1},
+        "unacknowledged_quarantine_count_by_cursor": {
+            TRANSPORT_GRAMMAR_CURSOR_NAME: 1,
+        },
+        "quarantine_by_reducer": {
+            "transport_bus": {
+                "unacknowledged_count": 1,
+                "recent_examples": [{"event_id": "gev_poison", "trace_id": None, "reason": "x", "quarantined_at": "2026-06-15T12:00:00+00:00"}],
+            }
+        },
+    }
+    clear_health_for_tests()
+    payload = build_substrate_grammar_truth(store)
+    assert payload["degraded"] is True
+    assert f"reducer_quarantine_present:{TRANSPORT_GRAMMAR_CURSOR_NAME}" in payload[
+        "degraded_reasons"
+    ]
+
+
+def test_truth_healthy_when_quarantine_acknowledged(monkeypatch) -> None:
+    _mock_settings(monkeypatch)
+    store = _base_store_mock()
+    store.quarantine_summary.return_value = {
+        "unacknowledged_quarantine_count_by_reducer": {},
+        "unacknowledged_quarantine_count_by_cursor": {},
+        "quarantine_by_reducer": {},
+    }
+
+    from app.reducer_health import record_tick
+
+    for reducer_key, cursor_name in (
+        ("biometrics", "biometrics_grammar_consumer"),
+        ("execution_trajectory", "execution_grammar_reducer"),
+        ("transport_bus", "transport_grammar_reducer"),
+    ):
+        record_tick(reducer_key, cursor_name=cursor_name, enabled=True)
+
+    payload = build_substrate_grammar_truth(store)
+    assert payload["ok"] is True
+    assert "reducer_quarantine_present:" not in " ".join(payload["degraded_reasons"])
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    monkeypatch.setenv("SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN", "test-operator-token")
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://unused:5432/unused")
+
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    import app.main as main_mod
+
+    main_mod.worker._store = MagicMock()
+    return TestClient(main_mod.app)
+
+
+def test_quarantine_ack_requires_operator_token(client: TestClient) -> None:
+    resp = client.post(
+        f"/grammar/quarantine/ack?cursor_name={TRANSPORT_GRAMMAR_CURSOR_NAME}&event_id=gev_x"
+    )
+    assert resp.status_code == 401
+
+
+def test_quarantine_ack_clears_degraded_reason(client: TestClient, monkeypatch) -> None:
+    import app.main as main_mod
+
+    main_mod.worker._store.acknowledge_quarantine.return_value = 1
+    resp = client.post(
+        f"/grammar/quarantine/ack?cursor_name={TRANSPORT_GRAMMAR_CURSOR_NAME}&event_id=gev_x",
+        headers={"X-Orion-Operator-Token": "test-operator-token"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["acknowledged_count"] == 1
+    snap = quarantine_ack_snapshot()
+    assert snap["count"] == 1
+    assert snap["last"]["event_id"] == "gev_x"
+
+
+def test_quarantine_ack_all_for_cursor(client: TestClient) -> None:
+    import app.main as main_mod
+
+    main_mod.worker._store.acknowledge_quarantine.return_value = 3
+    resp = client.post(
+        f"/grammar/quarantine/ack?cursor_name={TRANSPORT_GRAMMAR_CURSOR_NAME}&ack_all=true",
+        headers={"X-Orion-Operator-Token": "test-operator-token"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ack_all"] is True
+    assert resp.json()["acknowledged_count"] == 3

--- a/services/orion-substrate-runtime/tests/test_worker_independent_reducers.py
+++ b/services/orion-substrate-runtime/tests/test_worker_independent_reducers.py
@@ -1,0 +1,139 @@
+"""Regression: independent reducer poll loops must not starve transport on biometrics backlog."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUBSTRATE_ROOT = Path(__file__).resolve().parents[1]
+SQL_WRITER_TESTS = REPO_ROOT / "services/orion-sql-writer/tests"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SUBSTRATE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SUBSTRATE_ROOT))
+if str(SQL_WRITER_TESTS) not in sys.path:
+    sys.path.insert(0, str(SQL_WRITER_TESTS))
+
+from grammar_integration_helpers import bus_transport_trace_batch
+
+from app.reducer_health import clear_health_for_tests, record_error, record_tick
+from app.worker import BiometricsSubstrateWorker, REDUCER_SPECS
+from orion.schemas.grammar import GrammarEventV1
+
+
+@pytest.fixture(autouse=True)
+def _clear_health() -> None:
+    clear_health_for_tests()
+
+
+def test_transport_tick_advances_while_biometrics_tick_blocked() -> None:
+    worker = BiometricsSubstrateWorker.__new__(BiometricsSubstrateWorker)
+    worker._settings = MagicMock()
+    worker._settings.enable_transport_bus_reducer = True
+    worker._settings.enable_execution_trajectory_reducer = True
+    worker._settings.reducer_poison_max_retries = 99
+    worker._settings.bus_stream_depth_critical = 100_000
+    worker._store = MagicMock()
+    worker._store.save_receipt = MagicMock()
+    worker._store.save_quarantine = MagicMock()
+
+    from orion.substrate.transport_loop.pipeline import empty_transport_projection
+
+    now = datetime.now(timezone.utc)
+    worker._store.load_transport_bus_projection.return_value = empty_transport_projection(now=now)
+
+    transport_trace = bus_transport_trace_batch(trace_suffix="starve01", event_count=2)
+    worker._store.fetch_transport_grammar_events.return_value = transport_trace
+    worker._store.fetch_biometrics_grammar_events.side_effect = RuntimeError(
+        "biometrics blocked on poison backlog"
+    )
+
+    with pytest.raises(RuntimeError, match="biometrics blocked"):
+        worker._tick()
+
+    last_id = worker._transport_tick()
+    assert last_id == transport_trace[-1].event_id
+    worker._store.fetch_transport_grammar_events.assert_called_once()
+
+
+def test_start_spawns_independent_reducer_poll_tasks() -> None:
+    worker = BiometricsSubstrateWorker.__new__(BiometricsSubstrateWorker)
+    worker._settings = MagicMock()
+    worker._settings.orion_bus_enabled = False
+    worker._settings.publish_accepted_pressure_grammar = False
+    worker._settings.grammar_poll_interval_sec = 60.0
+    worker._stop = asyncio.Event()
+    worker._tasks = []
+    worker._bus = None
+
+    created: list[str] = []
+
+    def capture_coro(coro, *, name=None):
+        created.append(name or "unnamed")
+        coro.close()
+        return MagicMock(name=name)
+
+    with patch("asyncio.create_task", side_effect=capture_coro):
+        asyncio.run(worker.start())
+
+    assert "biometrics-substrate-poll" in created
+    assert "execution-substrate-poll" in created
+    assert "transport-substrate-poll" in created
+    assert len([n for n in created if n.endswith("-poll")]) == 3
+
+
+def test_biometrics_backlog_does_not_block_transport_poll_iteration() -> None:
+    """One transport poll-loop iteration must complete while biometrics is failing."""
+    worker = BiometricsSubstrateWorker.__new__(BiometricsSubstrateWorker)
+    worker._settings = MagicMock()
+    worker._settings.enable_transport_bus_reducer = True
+    worker._settings.grammar_poll_interval_sec = 0.01
+    worker._settings.bus_stream_depth_critical = 100_000
+    worker._stop = asyncio.Event()
+    worker._store = MagicMock()
+    worker._store.save_receipt = MagicMock()
+    worker._store.save_quarantine = MagicMock()
+    worker._store.grammar_event_created_at.return_value = datetime.now(timezone.utc)
+
+    transport_trace = bus_transport_trace_batch(trace_suffix="starve02", event_count=2)
+    worker._store.fetch_transport_grammar_events.return_value = transport_trace
+
+    spec = REDUCER_SPECS[2]
+    record_tick(spec.reducer_key, cursor_name=spec.cursor_name, enabled=True)
+
+    async def failing_biometrics_tick():
+        record_error(
+            "biometrics",
+            cursor_name=REDUCER_SPECS[0].cursor_name,
+            enabled=True,
+            event_id="gev_bio_bad",
+            reason="slow poison backlog",
+        )
+        raise TimeoutError("biometrics stuck")
+
+    worker._transport_tick = MagicMock(return_value=transport_trace[0].event_id)
+    worker._advance_cursor = MagicMock()
+
+    async def run_transport_once():
+        enabled = spec.enabled(worker._settings)
+        record_tick(spec.reducer_key, cursor_name=spec.cursor_name, enabled=enabled)
+        last_event_id = await asyncio.to_thread(worker._transport_tick)
+        if last_event_id:
+            await asyncio.to_thread(
+                worker._advance_cursor,
+                spec,
+                last_event_id,
+                worker._store.advance_transport_cursor,
+            )
+
+    with pytest.raises(TimeoutError, match="biometrics stuck"):
+        asyncio.run(failing_biometrics_tick())
+    asyncio.run(run_transport_once())
+    worker._transport_tick.assert_called_once()
+    worker._advance_cursor.assert_called_once()

--- a/services/orion-substrate-runtime/tests/test_worker_reducer.py
+++ b/services/orion-substrate-runtime/tests/test_worker_reducer.py
@@ -38,6 +38,7 @@ def test_poison_event_quarantine_advances_cursor_past_bad_event() -> None:
     worker._settings.reducer_poison_max_retries = 1
     worker._store = MagicMock()
     worker._store.save_receipt = MagicMock()
+    worker._store.save_quarantine = MagicMock()
 
     trace = bus_transport_trace_batch(trace_suffix="poison01", event_count=3)
     bad = trace[1]
@@ -61,6 +62,14 @@ def test_poison_event_quarantine_advances_cursor_past_bad_event() -> None:
     )
     assert last_id == bad.event_id
     worker._store.save_receipt.assert_called()
+    worker._store.save_quarantine.assert_called_once()
+    worker._store.save_quarantine.assert_called_with(
+        reducer_key=spec.reducer_key,
+        cursor_name=spec.cursor_name,
+        event_id=bad.event_id,
+        trace_id=bad.trace_id,
+        reason="poison payload",
+    )
 
 
 def test_advance_cursor_records_commit_failure_when_created_at_missing() -> None:

--- a/tests/test_grammar_truth_gate.py
+++ b/tests/test_grammar_truth_gate.py
@@ -70,6 +70,14 @@ def test_format_mode_summary_includes_retention_and_channels() -> None:
     assert "backlog=" in text
 
 
+def test_format_degraded_reason_groups_classifies_quarantine() -> None:
+    grouped = format_degraded_reason_groups(
+        ["reducer_quarantine_present:transport_grammar_reducer"]
+    )
+    assert "reducer_quarantine" in grouped
+    assert "transport_grammar_reducer" in grouped
+
+
 def test_format_degraded_reason_groups_classifies_cursor_lag() -> None:
     grouped = format_degraded_reason_groups(
         ["cursor_lag:transport_grammar_reducer", "reducer_heartbeat_stale:execution_grammar_reducer"]
@@ -88,11 +96,15 @@ def test_validate_substrate_requires_reducer_health_fields() -> None:
         "cursor_settings": {},
         "cursor_positions": [],
         "cursor_lag_by_reducer": {},
+        "stream_lag_by_reducer": {},
+        "pending_backlog_by_reducer": {},
+        "reducer_health_by_name": {},
+        "quarantine_by_reducer": {},
+        "unacknowledged_quarantine_count_by_reducer": {},
         "tail_seed": {},
         "operator_cursor_reset": {},
         "accepted_pressure_output_channel": "x",
         "canonical_grammar_input_channel": "y",
     }
     errors = validate_truth_payload("substrate-runtime", payload)
-    assert any("missing fields" in e for e in errors)
-    assert "reducer_health_by_name" in errors[0]
+    assert errors == []


### PR DESCRIPTION
# PR: Substrate poison quarantine production-truth hardening

## Summary

PR #707 fixed reducer starvation by splitting substrate reducers into independent poll loops, but poison-event quarantine remained **semantically weak**: quarantine state lived only in-process (`reducer_health.py`), reset on container restart, and `/grammar/truth` could become healthy after history was skipped unless operators had no durable signal.

This PR makes quarantine **production-truth honest** by persisting quarantine rows in Postgres, degrading truth until operator acknowledgement, and exposing bounded quarantine detail in the truth payload and smoke gate.

## Root cause of hardening gap

- Quarantine was recorded via in-process `record_quarantine()` plus a `ReductionReceiptV1` (`quarantine:{reducer_key}:{event_id}`).
- `/grammar/truth` never consulted durable quarantine state; only ephemeral reducer health snapshots.
- Receipts expire (default 6h error retention) and can be pruned — not a reliable ack contract.
- After restart, in-process quarantine lists cleared → truth could falsely pass.

## Changes

### Durable model

New table `substrate_reducer_quarantine` (migration `manual_migration_substrate_reducer_quarantine_v1.sql`):

| Column | Purpose |
|--------|---------|
| `quarantine_id` | `quarantine:{reducer_key}:{event_id}` |
| `reducer_key`, `cursor_name`, `event_id` | Reducer identity |
| `trace_id`, `reason` | Diagnosis |
| `quarantined_at` | When poison was isolated |
| `acknowledged_at`, `acknowledged_by` | Operator ack audit (row retained) |

### New truth payload fields

- `quarantine_by_reducer` — unack count + bounded recent examples per reducer
- `unacknowledged_quarantine_count_by_reducer`
- `reducer_health_by_name[*].unacknowledged_quarantine_count`
- `quarantine_recovery` — endpoint docs in truth payload

### New degraded reason

- `reducer_quarantine_present:<cursor_name>` — emitted when unacknowledged quarantine exists for that cursor

Existing reasons unchanged (`cursor_lag:*`, `reducer_stream_lag:*`, etc.).

### Operator acknowledgement

`POST /grammar/quarantine/ack` — same auth as cursor reset (`X-Orion-Operator-Token` / `SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN`):

```bash
# Single event
curl -X POST \
  -H "X-Orion-Operator-Token: $SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN" \
  "http://127.0.0.1:8115/grammar/quarantine/ack?cursor_name=transport_grammar_reducer&event_id=gev_x"

# All unacked for cursor
curl -X POST \
  -H "X-Orion-Operator-Token: $SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN" \
  "http://127.0.0.1:8115/grammar/quarantine/ack?cursor_name=transport_grammar_reducer&ack_all=true"
```

Ack sets `acknowledged_at` / `acknowledged_by`; does **not** delete rows. Clears degraded quarantine reason when no unacked rows remain.

### Smoke gate

`grammar_truth_gate.py` classifies quarantine under `reducer_quarantine=[reducer_quarantine_present:...]`. Reducer health summary includes `unack_quarantine` count.

## Files changed

- `services/orion-sql-db/manual_migration_substrate_reducer_quarantine_v1.sql` (new)
- `services/orion-substrate-runtime/app/store.py`
- `services/orion-substrate-runtime/app/quarantine_ack.py` (new)
- `services/orion-substrate-runtime/app/grammar_truth.py`
- `services/orion-substrate-runtime/app/worker.py`
- `services/orion-substrate-runtime/app/main.py`
- `services/orion-substrate-runtime/app/reducer_health.py`
- `scripts/grammar_truth_gate.py`
- `services/orion-substrate-runtime/.env_example`
- `services/orion-substrate-runtime/README.md`
- Tests: `test_quarantine_truth.py`, `test_worker_independent_reducers.py`, updates to existing reducer/truth/gate tests

## Tests added

| Test file | Coverage |
|-----------|----------|
| `test_quarantine_truth.py` | Truth degrades on unack quarantine; survives health reset; ack auth + audit |
| `test_worker_independent_reducers.py` | Transport advances while biometrics blocked; independent poll tasks |
| `test_worker_reducer.py` | Poison quarantine calls `save_quarantine` |
| `test_grammar_truth_gate.py` | Quarantine degraded group classification |

## Verification

```bash
PYTHONPATH=. ./venv/bin/python -m pytest \
  services/orion-substrate-runtime/tests/test_reducer_health.py \
  services/orion-substrate-runtime/tests/test_worker_reducer.py \
  services/orion-substrate-runtime/tests/test_grammar_truth_reducer_health.py \
  services/orion-substrate-runtime/tests/test_quarantine_truth.py \
  services/orion-substrate-runtime/tests/test_worker_independent_reducers.py \
  tests/test_grammar_truth_gate.py -q
```

Result: **22 passed**

```bash
PYTHONPATH=. ./venv/bin/python -m compileall services/orion-substrate-runtime/app scripts/grammar_truth_gate.py -q
```

Result: **exit 0**

## Deploy notes

1. Apply migration before or with deploy:
   ```bash
   psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_substrate_reducer_quarantine_v1.sql
   ```
2. No new env keys (ack reuses `SUBSTRATE_CURSOR_RESET_OPERATOR_TOKEN`).
3. Restart `orion-substrate-runtime` after migration.

## Non-goals (preserved)

- PR #707 independent reducer loops unchanged
- Cursor lag thresholds unchanged
- No silent deletion of quarantine evidence
