### PR TITLE
Feat/bus rpc subscriber hardening

### DIFF
--- a/docs/superpowers/pr-reports/2026-06-17-bus-rpc-subscriber-hardening-pr.md
+++ b/docs/superpowers/pr-reports/2026-06-17-bus-rpc-subscriber-hardening-pr.md
@@ -1,0 +1,67 @@
+# Bus RPC subscriber hardening
+
+## Summary
+
+After the June 16 pub/sub socket-timeout fix, services that combined **long-lived `subscribe()` loops** with **inline `rpc_request()`** on the same `OrionBusAsync` instance began losing RPC replies (stolen by trace/biometrics caches or torn down by overlapping `listen()`).
+
+This PR introduces a shared `fork_rpc_client()` helper and routes outbound RPC through a **forked bus + RPC worker** while keeping Hunter/Rabbit/cache intake on the parent bus.
+
+## Services hardened
+
+| Service | Change |
+|---------|--------|
+| **orion-hub** | Single `rpc_bus` for cortex gateway, TTS/STT, and crystallization bus embed |
+| **orion-context-exec** | `ContextExecRunner.rpc_bus` for LLM/recall/synthesis tool RPC |
+| **orion-cortex-orch** | `_bus_for_rpc()` for DecisionRouter, workflow, verb dispatch |
+| **orion-cortex-exec** | `_rpc_bus` for plan execution and verb runtime nested RPC |
+| **orion-actions** | `_actions_rpc_bus` for cortex orch/exec RPC from Hunter handlers |
+| **orion-chat-memory** | `embed_rpc_bus` for embedding RPC from Hunter handler |
+| **orion-vision-council** | `_rpc_bus` for LLM RPC while dual intake listeners run |
+| **orion-agent-chain** | `fork_rpc_client` per intake request (worker enabled) |
+
+## Pattern
+
+```python
+from orion.core.bus.rpc_fork import fork_rpc_client
+
+rpc_bus = await fork_rpc_client(listener_bus)
+# listener_bus: subscribe/publish intake
+# rpc_bus: all rpc_request() calls
+```
+
+Documented in `services/orion-bus/AGENT_CONTEXT.md`.
+
+## Test plan
+
+- [x] `tests/test_bus_rpc_fork_client.py` — helper delegates to `fork(start_rpc_worker=True)`
+- [x] `tests/test_bus_pubsub_timeout.py` — pubsub socket_timeout=None unchanged
+- [x] `services/orion-agent-chain/tests/test_bus_listener_rpc.py` — fork mock updated (4 passed)
+- [x] `services/orion-cortex-gateway/tests/test_gateway_consumer_resilience.py` — intake/RPC fork (1 passed)
+- [x] `services/orion-context-exec/tests/test_llm_profile_binding.py` — runner smoke (8 passed)
+- [ ] Rebuild/restart Hub + gateway after merge; confirm Hub logs show `[rpc-fork] worker started` and `path=worker`
+- [ ] Smoke `memory_graph_suggest` end-to-end (180s budget, no 63s cancel)
+
+## Env / config
+
+No new environment variables. `.env_example` unchanged; `sync_local_env_from_example.py` reported no changes needed.
+
+## Remaining risks
+
+- **orion-cortex-orch / exec**: module-level `_rpc_bus` initialized in `main()` — import-time callers still fall back to `svc.bus` (same as before fork existed).
+- **Per-request fork in agent-chain**: one worker per intake message; acceptable for low QPS, revisit if hot-path latency matters.
+- **Hub TTS + cortex share one `rpc_bus`**: worker multiplexes reply channels; fine under concurrent RPC.
+
+## Deploy notes
+
+Rebuild and restart affected containers after merge:
+
+```bash
+# Hub (confirms path=worker in logs)
+docker compose -f services/orion-hub/docker-compose.yml build hub-app
+docker compose -f services/orion-hub/docker-compose.yml up -d hub-app
+
+# Cortex stack
+docker compose -f services/orion-cortex-gateway/docker-compose.yml build
+docker compose -f services/orion-cortex-orch/docker-compose.yml build
+docker compose -f services/orion-cortex-exec/docker-compose.yml build
+```

--- a/orion/core/bus/rpc_fork.py
+++ b/orion/core/bus/rpc_fork.py
@@ -1,0 +1,21 @@
+"""Helpers for isolating RPC reply listeners from long-lived bus subscribers."""
+
+from __future__ import annotations
+
+import logging
+
+from .async_service import OrionBusAsync
+
+logger = logging.getLogger("orion.bus.rpc_fork")
+
+
+async def fork_rpc_client(parent: OrionBusAsync) -> OrionBusAsync:
+    """
+    Fork a dedicated bus client with an RPC worker for outbound request/reply traffic.
+
+    Use when the parent bus instance also runs long-lived subscribe()/listen() loops
+    (Hunter, trace caches, etc.) so reply messages are not stolen or dropped.
+    """
+    child = await parent.fork(start_rpc_worker=True)
+    logger.info("[rpc-fork] fork_rpc_client ready enabled=%s url=%s", child.enabled, child.url)
+    return child

--- a/services/orion-actions/app/main.py
+++ b/services/orion-actions/app/main.py
@@ -7,7 +7,7 @@ import logging
 import os
 import time
 import requests
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict
@@ -72,6 +72,7 @@ from .workflow_schedule_metrics import WorkflowScheduleMetrics
 from .workflow_schedule_store import ClaimedSchedule, ScheduleAttentionSignal, WorkflowScheduleStore
 
 logger = logging.getLogger("orion-actions")
+_actions_rpc_bus = None
 PROCESS_STARTED_AT_UTC = datetime.now(timezone.utc)
 
 ACTION_DAILY_PULSE_V1 = "daily_pulse_v1"
@@ -915,6 +916,7 @@ def _threshold_notify_skill_args(*, findings: list[str], correlation_id: str) ->
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    global _actions_rpc_bus
     deduper = ActionDedupe(ttl_seconds=settings.actions_dedupe_ttl_seconds)
     journal_deduper = ActionDedupe(ttl_seconds=settings.actions_journaling_cooldown_seconds)
     journal_post_persist_deduper = ActionDedupe(ttl_seconds=settings.actions_notify_dedupe_window_seconds)
@@ -992,7 +994,7 @@ async def lifespan(app: FastAPI):
             return parent.derive_child(kind=req.kind, source=src, payload=req, reply_to=reply_channel)
 
         msg = await _rpc_request_with_retry(
-            bus=hunter.bus,
+            bus=_actions_rpc_bus,
             request_channel=settings.cortex_exec_request_channel,
             reply_prefix="orion:exec:result",
             timeout_sec=timeout_sec,
@@ -1043,13 +1045,13 @@ async def lifespan(app: FastAPI):
         )
         reply_channel = new_reply_channel("orion:cortex:result")
         req_env = parent.derive_child(kind="cortex.orch.request", source=src, payload=req, reply_to=reply_channel)
-        msg = await hunter.bus.rpc_request(
+        msg = await _actions_rpc_bus.rpc_request(
             settings.cortex_request_channel,
             req_env,
             reply_channel=reply_channel,
             timeout_sec=float(settings.actions_exec_timeout_seconds),
         )
-        decoded = hunter.bus.codec.decode(msg.get("data"))
+        decoded = _actions_rpc_bus.codec.decode(msg.get("data"))
         if not decoded.ok or decoded.envelope is None:
             raise RuntimeError(f"cortex_orch_decode_failed:{decoded.error}")
         orch_payload = decoded.envelope.payload if isinstance(decoded.envelope.payload, dict) else {}
@@ -1810,13 +1812,13 @@ async def lifespan(app: FastAPI):
             return {}
         reply_channel = new_reply_channel("orion:cortex:result")
         rpc_env = env.model_copy(update={"reply_to": reply_channel})
-        msg = await hunter.bus.rpc_request(
+        msg = await _actions_rpc_bus.rpc_request(
             settings.cortex_request_channel,
             rpc_env,
             reply_channel=reply_channel,
             timeout_sec=float(settings.actions_exec_timeout_seconds),
         )
-        decoded = hunter.bus.codec.decode(msg.get("data"))
+        decoded = _actions_rpc_bus.codec.decode(msg.get("data"))
         if not decoded.ok or decoded.envelope is None:
             raise RuntimeError(f"cortex_orch_decode_failed:{decoded.error}")
         orch_payload = decoded.envelope.payload if isinstance(decoded.envelope.payload, dict) else {}
@@ -2125,6 +2127,11 @@ async def lifespan(app: FastAPI):
         patterns.append("orion:world_pulse:run:result")
     hunter = Hunter(_cfg(), patterns=patterns, handler=handle_envelope)
     app.state.bus_handler = handle_envelope
+    await hunter.bus.connect()
+    from orion.core.bus.rpc_fork import fork_rpc_client
+
+    _actions_rpc_bus = await fork_rpc_client(hunter.bus)
+    app.state.rpc_bus = _actions_rpc_bus
 
     logger.info(
         "Starting orion-actions Hunter channels=%s bus=%s cortex_request=%s",
@@ -2138,6 +2145,11 @@ async def lifespan(app: FastAPI):
     scheduler_task = asyncio.create_task(_scheduler_loop(), name="orion-actions-scheduler")
 
     yield
+
+    if _actions_rpc_bus is not None:
+        with suppress(Exception):
+            await _actions_rpc_bus.close()
+        _actions_rpc_bus = None
 
     for t in (hunter_task, scheduler_task):
         t.cancel()

--- a/services/orion-actions/tests/test_rpc_bus_fork.py
+++ b/services/orion-actions/tests/test_rpc_bus_fork.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app import main as actions_main
+
+
+@pytest.mark.asyncio
+async def test_rpc_request_with_retry_uses_supplied_bus_not_listener() -> None:
+    rpc_bus = AsyncMock()
+    rpc_bus.rpc_request = AsyncMock(return_value={"data": b"ok"})
+    rpc_bus.codec = MagicMock()
+
+    def _factory(reply_channel: str, attempt: int):
+        from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+
+        return BaseEnvelope(
+            kind="test.request",
+            source=ServiceRef(name="test", version="1"),
+            correlation_id=str(uuid4()),
+            reply_to=reply_channel,
+            payload={"attempt": attempt},
+        )
+
+    msg = await actions_main._rpc_request_with_retry(
+        bus=rpc_bus,
+        request_channel="orion:test:request",
+        reply_prefix="orion:test:result:",
+        timeout_sec=1.0,
+        envelope_factory=_factory,
+        operation_name="test op",
+        max_attempts=1,
+    )
+    assert msg == {"data": b"ok"}
+    rpc_bus.rpc_request.assert_awaited_once()
+    args, kwargs = rpc_bus.rpc_request.await_args
+    assert args[0] == "orion:test:request"
+    assert kwargs["reply_channel"].startswith("orion:test:result:")

--- a/services/orion-agent-chain/app/bus_listener.py
+++ b/services/orion-agent-chain/app/bus_listener.py
@@ -96,8 +96,7 @@ async def _handle_request(bus: OrionBusAsync, raw_msg: Dict[str, Any]) -> None:
         from orion.core.bus.rpc_fork import fork_rpc_client
 
         rpc_bus = await fork_rpc_client(bus)
-        await rpc_bus.connect()
-        logger.info("[agent-chain] planner rpc bus=fork parent=%s rpc_worker=%s", incoming_corr, False)
+        logger.info("[agent-chain] planner rpc bus=fork parent=%s rpc_worker=true", incoming_corr)
         result = await execute_agent_chain(req, correlation_id=incoming_corr, rpc_bus=rpc_bus)
         resp = BaseEnvelope(
             kind="agent.chain.result",

--- a/services/orion-agent-chain/app/bus_listener.py
+++ b/services/orion-agent-chain/app/bus_listener.py
@@ -93,7 +93,9 @@ async def _handle_request(bus: OrionBusAsync, raw_msg: Dict[str, Any]) -> None:
 
     try:
         req = AgentChainRequest(**payload)
-        rpc_bus = await bus.fork(start_rpc_worker=False)
+        from orion.core.bus.rpc_fork import fork_rpc_client
+
+        rpc_bus = await fork_rpc_client(bus)
         await rpc_bus.connect()
         logger.info("[agent-chain] planner rpc bus=fork parent=%s rpc_worker=%s", incoming_corr, False)
         result = await execute_agent_chain(req, correlation_id=incoming_corr, rpc_bus=rpc_bus)

--- a/services/orion-agent-chain/tests/test_bus_listener_rpc.py
+++ b/services/orion-agent-chain/tests/test_bus_listener_rpc.py
@@ -34,7 +34,6 @@ class _FakeBus:
 
     async def fork(self, *, start_rpc_worker: bool = False):
         self.fork_start_rpc_worker = start_rpc_worker
-        assert start_rpc_worker is False
         if self.forked is None:
             self.forked = _FakePlannerBus()
         return self.forked
@@ -108,10 +107,12 @@ def test_agent_chain_rpc_reply_preserves_corr_and_reply_channel(monkeypatch):
 
     monkeypatch.setattr(bus_listener, "execute_agent_chain", _fake_execute)
 
+    _patch_fork_rpc_client(monkeypatch)
+
     asyncio.run(bus_listener._handle_request(bus, {"data": b"ignored"}))
 
     assert len(bus.published) == 1
-    assert bus.fork_start_rpc_worker is False
+    assert bus.fork_start_rpc_worker is True
     assert bus.forked is not None and bus.forked.connected is True
     channel, result_env = bus.published[0]
     assert channel == reply_to
@@ -132,6 +133,8 @@ def test_exec_style_rpc_consumer_would_receive_matching_result(monkeypatch):
 
     monkeypatch.setattr(bus_listener, "execute_agent_chain", _fake_execute)
 
+    _patch_fork_rpc_client(monkeypatch)
+
     asyncio.run(bus_listener._handle_request(bus, {"data": b"ignored"}))
 
     # Integration-ish assertion: the publish tuple is exactly what Exec rpc_request waits on
@@ -142,6 +145,13 @@ def test_exec_style_rpc_consumer_would_receive_matching_result(monkeypatch):
     assert result_env.payload.get("text") == "agent done"
 
 
+def _patch_fork_rpc_client(monkeypatch):
+    async def _fake_fork_rpc_client(parent):
+        return await parent.fork(start_rpc_worker=True)
+
+    monkeypatch.setattr("orion.core.bus.rpc_fork.fork_rpc_client", _fake_fork_rpc_client)
+
+
 def test_nested_planner_child_corr_still_replies_to_exec_parent(monkeypatch):
     parent_corr = str(uuid4())
     reply_to = f"orion:exec:result:AgentChainService:{parent_corr}"
@@ -149,6 +159,7 @@ def test_nested_planner_child_corr_still_replies_to_exec_parent(monkeypatch):
     bus = _FakeBus(env)
     monkeypatch.setattr(agent_api, "_resolve_tools", lambda _body, **_kwargs: ([], []))
     monkeypatch.setattr(bus_listener, "execute_agent_chain", agent_api.execute_agent_chain)
+    _patch_fork_rpc_client(monkeypatch)
 
     asyncio.run(bus_listener._handle_request(bus, {"data": b"ignored"}))
 
@@ -178,6 +189,7 @@ def test_bus_listener_error_reply_uses_agent_chain_result_shape(monkeypatch):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(bus_listener, "execute_agent_chain", _boom)
+    _patch_fork_rpc_client(monkeypatch)
 
     asyncio.run(bus_listener._handle_request(bus, {"data": b"ignored"}))
 

--- a/services/orion-agent-chain/tests/test_bus_listener_rpc.py
+++ b/services/orion-agent-chain/tests/test_bus_listener_rpc.py
@@ -94,6 +94,13 @@ def _request_env(*, corr: str, reply_to: str) -> BaseEnvelope:
     )
 
 
+def _patch_fork_rpc_client(monkeypatch):
+    async def _fake_fork_rpc_client(parent):
+        return await parent.fork(start_rpc_worker=True)
+
+    monkeypatch.setattr("orion.core.bus.rpc_fork.fork_rpc_client", _fake_fork_rpc_client)
+
+
 def test_agent_chain_rpc_reply_preserves_corr_and_reply_channel(monkeypatch):
     corr = str(uuid4())
     reply_to = f"orion:exec:result:AgentChainService:{corr}"
@@ -113,7 +120,7 @@ def test_agent_chain_rpc_reply_preserves_corr_and_reply_channel(monkeypatch):
 
     assert len(bus.published) == 1
     assert bus.fork_start_rpc_worker is True
-    assert bus.forked is not None and bus.forked.connected is True
+    assert bus.forked is not None
     channel, result_env = bus.published[0]
     assert channel == reply_to
     assert str(result_env.correlation_id) == corr
@@ -143,13 +150,6 @@ def test_exec_style_rpc_consumer_would_receive_matching_result(monkeypatch):
     assert channel == reply_to
     assert str(result_env.correlation_id) == corr
     assert result_env.payload.get("text") == "agent done"
-
-
-def _patch_fork_rpc_client(monkeypatch):
-    async def _fake_fork_rpc_client(parent):
-        return await parent.fork(start_rpc_worker=True)
-
-    monkeypatch.setattr("orion.core.bus.rpc_fork.fork_rpc_client", _fake_fork_rpc_client)
 
 
 def test_nested_planner_child_corr_still_replies_to_exec_parent(monkeypatch):

--- a/services/orion-bus/AGENT_CONTEXT.md
+++ b/services/orion-bus/AGENT_CONTEXT.md
@@ -20,5 +20,20 @@ Never emit full message payloads or per-packet traces.
 ## Publishing
 Default `PUBLISH_ORION_BUS_GRAMMAR=false`. Fail-open on publish errors.
 
+## RPC + long-lived subscribers
+Services that run Hunter/Rabbit `subscribe()` loops **and** outbound `rpc_request()` on the same
+`OrionBusAsync` instance can lose replies (stolen by trace caches or torn down by overlapping
+`listen()`). Pattern:
+
+```python
+from orion.core.bus.rpc_fork import fork_rpc_client
+
+rpc_bus = await fork_rpc_client(listener_bus)  # dedicated worker pubsub
+# keep listener_bus for intake/publish; route all rpc_request via rpc_bus
+```
+
+Hub, cortex-gateway, cortex-orch, cortex-exec, context-exec, actions, chat-memory, vision-council,
+and agent-chain follow this split as of the bus RPC hardening pass.
+
 ## Downstream (deferred)
 `bus_transport_reducer` → `StateDeltaV1(target_kind=transport_bus)` → field pressure hints.

--- a/services/orion-chat-memory/app/main.py
+++ b/services/orion-chat-memory/app/main.py
@@ -21,6 +21,7 @@ from app.settings import settings
 logger = logging.getLogger(settings.SERVICE_NAME)
 
 bus_hunter: Optional[Hunter] = None
+embed_rpc_bus = None
 http_client: Optional[httpx.AsyncClient] = None
 chunk_counts: Dict[str, int] = {}
 
@@ -159,7 +160,7 @@ async def _request_embedding_http(doc: MemoryDocument) -> Optional[EmbeddingResu
 
 
 async def _request_embedding_bus(doc: MemoryDocument) -> Optional[EmbeddingResultV1]:
-    if bus_hunter is None or bus_hunter.bus is None:
+    if bus_hunter is None or bus_hunter.bus is None or embed_rpc_bus is None:
         logger.warning("Bus not initialized; cannot request embedding.")
         return None
 
@@ -177,13 +178,13 @@ async def _request_embedding_bus(doc: MemoryDocument) -> Optional[EmbeddingResul
     )
 
     try:
-        msg = await bus_hunter.bus.rpc_request(
+        msg = await embed_rpc_bus.rpc_request(
             settings.CHAT_MEMORY_EMBED_REQUEST_CHANNEL,
             env,
             reply_channel=reply_channel,
             timeout_sec=float(settings.CHAT_MEMORY_EMBED_TIMEOUT_MS) / 1000.0,
         )
-        decoded = bus_hunter.bus.codec.decode(msg.get("data"))
+        decoded = embed_rpc_bus.codec.decode(msg.get("data"))
         if not decoded.ok or decoded.envelope is None:
             logger.warning(f"Embedding RPC decode failed: {decoded.error}")
             return None
@@ -253,7 +254,7 @@ async def handle_envelope(env: BaseEnvelope) -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global bus_hunter, http_client
+    global bus_hunter, embed_rpc_bus, http_client
 
     logging.basicConfig(
         level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
@@ -262,6 +263,10 @@ async def lifespan(app: FastAPI):
 
     cfg = _cfg()
     bus_hunter = Hunter(cfg, patterns=settings.SUBSCRIBE_CHANNELS, handler=handle_envelope)
+    await bus_hunter.bus.connect()
+    from orion.core.bus.rpc_fork import fork_rpc_client
+
+    embed_rpc_bus = await fork_rpc_client(bus_hunter.bus)
     await bus_hunter.start_background()
 
     if (settings.CHAT_MEMORY_EMBED_MODE or "bus").lower() == "http":
@@ -270,6 +275,9 @@ async def lifespan(app: FastAPI):
 
     yield
 
+    if embed_rpc_bus is not None:
+        await embed_rpc_bus.close()
+        embed_rpc_bus = None
     if bus_hunter:
         await bus_hunter.stop()
     if http_client:

--- a/services/orion-context-exec/app/bus_listener.py
+++ b/services/orion-context-exec/app/bus_listener.py
@@ -38,8 +38,11 @@ async def run_bus_worker(stop_event: asyncio.Event | None = None) -> None:
             channels.append(alias)
 
     await bus.connect()
+    from orion.core.bus.rpc_fork import fork_rpc_client
+
+    rpc_bus = await fork_rpc_client(bus)
     logger.info("subscribed channels=%s compat_alias=%s", channels, settings.context_exec_compat_agent_chain_enabled)
-    runner = ContextExecRunner(bus=bus)
+    runner = ContextExecRunner(bus=bus, rpc_bus=rpc_bus)
 
     try:
         async with bus.subscribe(*channels) as pubsub:
@@ -62,6 +65,8 @@ async def run_bus_worker(stop_event: asyncio.Event | None = None) -> None:
     except asyncio.CancelledError:
         raise
     finally:
+        with suppress(Exception):
+            await rpc_bus.close()
         with suppress(Exception):
             await bus.close()
 

--- a/services/orion-context-exec/app/main.py
+++ b/services/orion-context-exec/app/main.py
@@ -76,10 +76,15 @@ async def lifespan(app: FastAPI):
     log_agent_lane_startup_warning()
     app.state.bus_stop_event = asyncio.Event()
     bus = OrionBusAsync(url=settings.orion_bus_url, enabled=settings.orion_bus_enabled)
+    rpc_bus = None
     if bus.enabled:
         await bus.connect()
+        from orion.core.bus.rpc_fork import fork_rpc_client
+
+        rpc_bus = await fork_rpc_client(bus)
     app.state.bus = bus
-    runner = ContextExecRunner(bus=bus if bus.enabled else None)
+    app.state.rpc_bus = rpc_bus
+    runner = ContextExecRunner(bus=bus if bus.enabled else None, rpc_bus=rpc_bus if rpc_bus is not None else None)
     set_runner(runner)
     app.state.bus_task = asyncio.create_task(run_bus_worker(app.state.bus_stop_event))
     app.state.heartbeat_task = asyncio.create_task(heartbeat_loop())
@@ -90,6 +95,10 @@ async def lifespan(app: FastAPI):
         with suppress(asyncio.CancelledError):
             await task
     bus = getattr(app.state, "bus", None)
+    rpc_bus = getattr(app.state, "rpc_bus", None)
+    if rpc_bus is not None and rpc_bus.enabled:
+        with suppress(Exception):
+            await rpc_bus.close()
     if bus is not None and bus.enabled:
         with suppress(Exception):
             await bus.close()

--- a/services/orion-context-exec/app/runner.py
+++ b/services/orion-context-exec/app/runner.py
@@ -103,10 +103,12 @@ class ContextExecRunner:
         engine: RLMEngine | None = None,
         *,
         bus: OrionBusAsync | None = None,
+        rpc_bus: OrionBusAsync | None = None,
     ) -> None:
         self.engine_selected = (settings.rlm_engine or "fake").strip().lower()
         self.engine = engine or build_engine(settings.rlm_engine)
         self.bus = bus
+        self.rpc_bus = rpc_bus or bus
 
     def _engine_runtime_debug(
         self,
@@ -336,7 +338,7 @@ class ContextExecRunner:
         request = request.model_copy(update={"llm_profile": profile_selection.selected})
 
         organ_runtime = OrganRuntime(
-            bus=self.bus,
+            bus=self.rpc_bus,
             request=request,
             run_id=run_id,
             llm_route=profile_selection.route_used,
@@ -445,7 +447,7 @@ class ContextExecRunner:
             artifact=artifact,
             profile_selection=profile_selection,
             runtime_debug=runtime_debug,
-            bus=self.bus,
+            bus=self.rpc_bus,
         )
         runtime_debug["model_synthesis_used"] = synthesis_result.model_synthesis_used
         if synthesis_result.fallback_reason:
@@ -538,7 +540,7 @@ class ContextExecRunner:
         failure_modes: list[str],
     ) -> ContextExecRunV1:
         organ_runtime = OrganRuntime(
-            bus=self.bus,
+            bus=self.rpc_bus,
             request=request,
             run_id=run_id,
             llm_route=str(request.llm_profile or settings.context_exec_default_llm_profile),
@@ -602,7 +604,7 @@ class ContextExecRunner:
                 artifact=artifact,
                 profile_selection=profile_selection,
                 runtime_debug=runtime_debug_base,
-                bus=self.bus,
+                bus=self.rpc_bus,
             )
         runtime_debug = dict(runtime_debug_base)
         runtime_debug["model_synthesis_used"] = synthesis_result.model_synthesis_used

--- a/services/orion-cortex-exec/app/main.py
+++ b/services/orion-cortex-exec/app/main.py
@@ -794,6 +794,16 @@ def _bus_for_rpc():
     return _rpc_bus if _rpc_bus is not None else svc.bus
 
 
+async def _close_rpc_bus() -> None:
+    global _rpc_bus
+    if _rpc_bus is not None:
+        from contextlib import suppress
+
+        with suppress(Exception):
+            await _rpc_bus.close()
+        _rpc_bus = None
+
+
 verb_runtime = VerbRuntime(
     service_name=settings.service_name,
     instance_id=settings.node_name,
@@ -842,11 +852,14 @@ async def main() -> None:
     logger.info("exec_rpc_bus_fork_ready")
     assert trace_listener is not None, "Trace listener not initialized"
     assert core_event_listener is not None, "Core event listener not initialized"
-    if verb_listener is not None:
-        await verb_listener.start_background()
-    await trace_listener.start_background()
-    await core_event_listener.start_background()
-    await svc.start()
+    try:
+        if verb_listener is not None:
+            await verb_listener.start_background()
+        await trace_listener.start_background()
+        await core_event_listener.start_background()
+        await svc.start()
+    finally:
+        await _close_rpc_bus()
 
 
 if __name__ == "__main__":

--- a/services/orion-cortex-exec/app/main.py
+++ b/services/orion-cortex-exec/app/main.py
@@ -497,7 +497,7 @@ async def handle(env: BaseEnvelope) -> BaseEnvelope:
 
     # 3. Execute Plan
     res = await router.run_plan(
-        svc.bus,
+        _bus_for_rpc(),
         source=_source(),
         req=req_env.payload,
         correlation_id=corr_id,
@@ -726,7 +726,7 @@ async def handle_verb_request(env: BaseEnvelope) -> None:
     result = await verb_runtime.handle_request(
         req,
         extra_meta={
-            "bus": svc.bus,
+            "bus": _bus_for_rpc(),
             "source": _source(),
             "correlation_id": corr_id,
         },
@@ -787,6 +787,13 @@ async def handle_verb_request(env: BaseEnvelope) -> None:
 
 
 svc = Rabbit(_cfg(), request_channel=settings.channel_exec_request, handler=handle)
+_rpc_bus = None
+
+
+def _bus_for_rpc():
+    return _rpc_bus if _rpc_bus is not None else svc.bus
+
+
 verb_runtime = VerbRuntime(
     service_name=settings.service_name,
     instance_id=settings.node_name,
@@ -810,6 +817,7 @@ core_event_listener = Hunter(_cfg(), handler=handle_core_event, patterns=[settin
 
 
 async def main() -> None:
+    global _rpc_bus
     logging.basicConfig(level=logging.INFO, stream=sys.stdout, force=True)
     pageindex_base_url = str(settings.journal_pageindex_service_url or "").strip()
     pageindex_client_enabled = bool(pageindex_base_url)
@@ -826,6 +834,12 @@ async def main() -> None:
         "on" if verb_listener is not None else "off",
     )
     _run_autonomy_graph_probe()
+    await svc.bus.connect()
+    from orion.core.bus.rpc_fork import fork_rpc_client
+
+    _rpc_bus = await fork_rpc_client(svc.bus)
+    verb_runtime.bus = _rpc_bus
+    logger.info("exec_rpc_bus_fork_ready")
     assert trace_listener is not None, "Trace listener not initialized"
     assert core_event_listener is not None, "Core event listener not initialized"
     if verb_listener is not None:

--- a/services/orion-cortex-exec/tests/test_rpc_bus_fork.py
+++ b/services/orion-cortex-exec/tests/test_rpc_bus_fork.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app import main as exec_main
+
+
+def test_bus_for_rpc_prefers_fork() -> None:
+    sentinel = object()
+    exec_main._rpc_bus = sentinel  # type: ignore[assignment]
+    try:
+        assert exec_main._bus_for_rpc() is sentinel
+    finally:
+        exec_main._rpc_bus = None
+
+
+def test_bus_for_rpc_falls_back_to_svc_bus() -> None:
+    exec_main._rpc_bus = None
+    assert exec_main._bus_for_rpc() is exec_main.svc.bus
+
+
+@pytest.mark.asyncio
+async def test_close_rpc_bus_closes_and_clears_global() -> None:
+    fake = AsyncMock()
+    exec_main._rpc_bus = fake  # type: ignore[assignment]
+    await exec_main._close_rpc_bus()
+    fake.close.assert_awaited_once()
+    assert exec_main._rpc_bus is None

--- a/services/orion-cortex-orch/app/main.py
+++ b/services/orion-cortex-orch/app/main.py
@@ -579,6 +579,16 @@ def _bus_for_rpc():
     return _rpc_bus if _rpc_bus is not None else svc.bus
 
 
+async def _close_rpc_bus() -> None:
+    global _rpc_bus
+    if _rpc_bus is not None:
+        from contextlib import suppress
+
+        with suppress(Exception):
+            await _rpc_bus.close()
+        _rpc_bus = None
+
+
 equilibrium_hunter: Hunter
 dream_hunter: Hunter
 
@@ -654,12 +664,15 @@ async def main() -> None:
 
     _rpc_bus = await fork_rpc_client(svc.bus)
     logger.info("orch_rpc_bus_fork_ready")
-    await asyncio.gather(
-        svc.start(),
-        equilibrium_hunter.start(),
-        dream_hunter.start(),
-        memory_cards_hunter.start(),
-    )
+    try:
+        await asyncio.gather(
+            svc.start(),
+            equilibrium_hunter.start(),
+            dream_hunter.start(),
+            memory_cards_hunter.start(),
+        )
+    finally:
+        await _close_rpc_bus()
 
 
 if __name__ == "__main__":

--- a/services/orion-cortex-orch/app/main.py
+++ b/services/orion-cortex-orch/app/main.py
@@ -242,7 +242,7 @@ async def handle(env: BaseEnvelope) -> BaseEnvelope:
         )
 
         if should_route:
-            router = DecisionRouter(svc.bus)
+            router = DecisionRouter(_bus_for_rpc())
             routed = await router.route(req, correlation_id=str(env.correlation_id), source=sref)
             req = routed.request
             route_meta = routed.decision.model_dump(mode="json")
@@ -277,7 +277,7 @@ async def handle(env: BaseEnvelope) -> BaseEnvelope:
         if has_explicit_workflow_request(req):
             try:
                 workflow_result = await execute_chat_workflow(
-                    bus=svc.bus,
+                    bus=_bus_for_rpc(),
                     source=sref,
                     req=req,
                     correlation_id=str(env.correlation_id),
@@ -322,7 +322,7 @@ async def handle(env: BaseEnvelope) -> BaseEnvelope:
 
         if has_workflow_schedule_management_request(req):
             management_result = await execute_workflow_schedule_management(
-                bus=svc.bus,
+                bus=_bus_for_rpc(),
                 source=sref,
                 req=req,
                 correlation_id=str(env.correlation_id),
@@ -380,7 +380,7 @@ async def handle(env: BaseEnvelope) -> BaseEnvelope:
     # 3. Execution
     try:
         verb_result = await call_verb_runtime(
-            svc.bus,
+            _bus_for_rpc(),
             source=sref,
             client_request=req,
             correlation_id=str(env.correlation_id),
@@ -572,6 +572,13 @@ svc = Rabbit(
     handler=handle,
     concurrent_handlers=True,
 )
+_rpc_bus = None
+
+
+def _bus_for_rpc():
+    return _rpc_bus if _rpc_bus is not None else svc.bus
+
+
 equilibrium_hunter: Hunter
 dream_hunter: Hunter
 
@@ -625,6 +632,7 @@ memory_cards_hunter = Hunter(
 
 
 async def main() -> None:
+    global _rpc_bus
     logging.basicConfig(level=logging.INFO)
     s = get_settings()
     logger.info(
@@ -641,6 +649,11 @@ async def main() -> None:
             "exec_lane_routing_enabled=true: run one cortex-exec consumer per lane (chat, spark, background) "
             "subscribed to the lane exec channels; a missing subscriber causes PlanExecution RPC timeouts."
         )
+    await svc.bus.connect()
+    from orion.core.bus.rpc_fork import fork_rpc_client
+
+    _rpc_bus = await fork_rpc_client(svc.bus)
+    logger.info("orch_rpc_bus_fork_ready")
     await asyncio.gather(
         svc.start(),
         equilibrium_hunter.start(),

--- a/services/orion-cortex-orch/tests/test_rpc_bus_fork.py
+++ b/services/orion-cortex-orch/tests/test_rpc_bus_fork.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app import main as orch_main
+
+
+def test_bus_for_rpc_prefers_fork() -> None:
+    sentinel = object()
+    orch_main._rpc_bus = sentinel  # type: ignore[assignment]
+    try:
+        assert orch_main._bus_for_rpc() is sentinel
+    finally:
+        orch_main._rpc_bus = None
+
+
+def test_bus_for_rpc_falls_back_to_svc_bus() -> None:
+    orch_main._rpc_bus = None
+    assert orch_main._bus_for_rpc() is orch_main.svc.bus
+
+
+@pytest.mark.asyncio
+async def test_close_rpc_bus_closes_and_clears_global() -> None:
+    fake = AsyncMock()
+    orch_main._rpc_bus = fake  # type: ignore[assignment]
+    await orch_main._close_rpc_bus()
+    fake.close.assert_awaited_once()
+    assert orch_main._rpc_bus is None

--- a/services/orion-hub/scripts/crystallization_routes.py
+++ b/services/orion-hub/scripts/crystallization_routes.py
@@ -101,6 +101,12 @@ async def _bus():
     return bus
 
 
+async def _rpc_bus():
+    from .main import rpc_bus
+
+    return rpc_bus
+
+
 @router.post("/api/memory/crystallizations/propose")
 async def crystallization_propose(
     request: Request,
@@ -269,7 +275,7 @@ async def crystallization_approve_proposal(
     projection_summary = None
     if bool(getattr(_settings(), "CRYSTALLIZER_AUTO_PROJECT_ON_APPROVE", True)):
         updated, proj = await project_crystallization(
-            pool, await _bus(), updated, actor=session, config=_projection_config(),
+            pool, await _rpc_bus(), updated, actor=session, config=_projection_config(),
         )
         await update_crystallization(pool, updated)
         projection_summary = {
@@ -710,7 +716,7 @@ async def crystallization_projection_rebuild(
     items = await list_crystallizations(pool, status="active", limit=limit)
     results = []
     for item in items:
-        updated, proj = await project_crystallization(pool, await _bus(), item, actor=session, config=_projection_config())
+        updated, proj = await project_crystallization(pool, await _rpc_bus(), item, actor=session, config=_projection_config())
         await update_crystallization(pool, updated)
         results.append({"crystallization_id": item.crystallization_id, "card_id": proj.card_id, "chroma": proj.chroma, "errors": proj.errors})
     return {"rebuilt": len(results), "items": results}
@@ -728,7 +734,7 @@ async def graphiti_sync(
     if not row:
         raise HTTPException(status_code=404, detail="not_found")
     updated, proj = await project_crystallization(
-        pool, await _bus(), row, actor=session, config=_projection_config(),
+        pool, await _rpc_bus(), row, actor=session, config=_projection_config(),
         project_card=False, project_chroma=False, project_graphiti=True,
     )
     await update_crystallization(pool, updated)

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -124,7 +124,7 @@ app = FastAPI(
 
 # These are populated on startup and imported by other modules:
 bus: Optional[OrionBusAsync] = None
-cortex_bus: Optional[OrionBusAsync] = None
+rpc_bus: Optional[OrionBusAsync] = None
 cortex_client: Optional[CortexGatewayClient] = None
 tts_client: Optional[TTSClient] = None
 html_content: str = "<html><body><h1>Error loading UI</h1></body></html>"
@@ -207,7 +207,7 @@ async def startup_event():
     Initializes all shared services at application startup.
     OrionBus + Clients + UI template.
     """
-    global bus, cortex_bus, cortex_client, tts_client, html_content, biometrics_cache, notification_cache, signals_inspect_cache, cognition_trace_cache, presence_state, presence_context_store, substrate_autonomy_task
+    global bus, rpc_bus, cortex_client, tts_client, html_content, biometrics_cache, notification_cache, signals_inspect_cache, cognition_trace_cache, presence_state, presence_context_store, substrate_autonomy_task
 
     # ------------------------------------------------------------
     # Orion Bus Initialization
@@ -223,12 +223,14 @@ async def startup_event():
             await bus.connect()
             logger.info("OrionBusAsync connection established successfully.")
 
-            # Cortex RPC uses a forked bus + rpc worker so long-lived Hub subscribers
-            # (trace/biometrics caches) cannot steal gateway reply messages.
-            cortex_bus = await bus.fork(start_rpc_worker=True)
-            cortex_client = CortexGatewayClient(cortex_bus)
-            tts_client = TTSClient(bus)
-            logger.info("Bus Clients initialized (cortex RPC on forked bus).")
+            # Outbound RPC uses a forked bus + worker so long-lived Hub subscribers
+            # (trace/biometrics caches) cannot steal gateway/TTS/embedding replies.
+            from orion.core.bus.rpc_fork import fork_rpc_client
+
+            rpc_bus = await fork_rpc_client(bus)
+            cortex_client = CortexGatewayClient(rpc_bus)
+            tts_client = TTSClient(rpc_bus)
+            logger.info("Bus Clients initialized (Hub RPC on forked bus).")
 
             # Biometrics cache (singleton)
             biometrics_cache = BiometricsCache(
@@ -429,7 +431,7 @@ async def startup_event():
 
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
-    global bus, cortex_bus, biometrics_cache, notification_cache, signals_inspect_cache, cognition_trace_cache, substrate_autonomy_task
+    global bus, rpc_bus, biometrics_cache, notification_cache, signals_inspect_cache, cognition_trace_cache, substrate_autonomy_task
     pool = getattr(app.state, "memory_pg_pool", None)
     if pool is not None:
         try:
@@ -453,13 +455,13 @@ async def shutdown_event() -> None:
         await signals_inspect_cache.stop()
     if cognition_trace_cache is not None:
         await cognition_trace_cache.stop()
-    if cortex_bus is not None:
+    if rpc_bus is not None:
         try:
-            await cortex_bus.close()
-            logger.info("Cortex OrionBusAsync fork closed.")
+            await rpc_bus.close()
+            logger.info("Hub RPC OrionBusAsync fork closed.")
         except Exception as e:
-            logger.warning("Error while closing cortex bus fork: %s", e)
-        cortex_bus = None
+            logger.warning("Error while closing Hub RPC bus fork: %s", e)
+        rpc_bus = None
     if bus is not None:
         try:
             await bus.close()

--- a/services/orion-vision-council/app/main.py
+++ b/services/orion-vision-council/app/main.py
@@ -31,6 +31,7 @@ settings = Settings()
 class CouncilService:
     def __init__(self):
         self.bus = OrionBusAsync(url=settings.ORION_BUS_URL)
+        self._rpc_bus: OrionBusAsync | None = None
         self._consumer_task: Optional[asyncio.Task] = None
         self._rpc_task: Optional[asyncio.Task] = None
         self._shutdown_event = asyncio.Event()
@@ -40,6 +41,9 @@ class CouncilService:
         logger.add(lambda m: print(m, end=""), level=settings.LOG_LEVEL)
 
         await self.bus.connect()
+        from orion.core.bus.rpc_fork import fork_rpc_client
+
+        self._rpc_bus = await fork_rpc_client(self.bus)
         self._consumer_task = asyncio.create_task(self._consume())
         self._rpc_task = asyncio.create_task(self._consume_rpc())
         logger.info(f"[COUNCIL] Started. Listening on {settings.CHANNEL_COUNCIL_INTAKE} and {settings.CHANNEL_COUNCIL_REQUEST}")
@@ -53,6 +57,9 @@ class CouncilService:
                     await t
                 except asyncio.CancelledError:
                     pass
+        if self._rpc_bus is not None:
+            await self._rpc_bus.close()
+            self._rpc_bus = None
         await self.bus.close()
 
     async def _consume(self):
@@ -217,14 +224,14 @@ class CouncilService:
         )
 
         try:
-            reply = await self.bus.rpc_request(
+            reply = await self._rpc_bus.rpc_request(
                 settings.CHANNEL_LLM_REQUEST,
                 envelope,
                 reply_channel=reply_to,
                 timeout_sec=30.0
             )
 
-            decoded = self.bus.codec.decode(reply.get("data"))
+            decoded = self._rpc_bus.codec.decode(reply.get("data"))
             if not decoded.ok:
                 logger.error(f"[COUNCIL] LLM decode error: {decoded.error}")
                 return []

--- a/services/orion-vision-council/app/main.py
+++ b/services/orion-vision-council/app/main.py
@@ -223,6 +223,10 @@ class CouncilService:
             payload=chat_request
         )
 
+        if self._rpc_bus is None:
+            logger.error("[COUNCIL] RPC bus not initialized; cannot call LLM gateway")
+            return []
+
         try:
             reply = await self._rpc_bus.rpc_request(
                 settings.CHANNEL_LLM_REQUEST,

--- a/tests/test_bus_rpc_fork_client.py
+++ b/tests/test_bus_rpc_fork_client.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.rpc_fork import fork_rpc_client
+
+
+@pytest.mark.asyncio
+async def test_fork_rpc_client_starts_worker() -> None:
+    parent = OrionBusAsync("redis://127.0.0.1:6379/0", enabled=True)
+    child = AsyncMock(spec=OrionBusAsync)
+    child.enabled = True
+    child.url = parent.url
+
+    with patch.object(parent, "fork", new=AsyncMock(return_value=child)) as fork_mock:
+        got = await fork_rpc_client(parent)
+
+    fork_mock.assert_awaited_once_with(start_rpc_worker=True)
+    assert got is child


### PR DESCRIPTION
Revised PR description for `feat/bus-rpc-subscriber-hardening` (includes committed work plus the uncommitted `require_rpc_bus` theft guard):

---

## Summary

Fixes recurring RPC timeouts and `memory_graph_suggest_failed` caused by **reply theft** on the Orion bus: services that ran long-lived `subscribe()` loops and inline `rpc_request()` on the same `OrionBusAsync` instance lost replies to trace/biometrics caches or overlapping `listen()` handlers.

This PR:

1. Adds shared helpers `fork_rpc_client()` and `require_rpc_bus()` in `orion/core/bus/rpc_fork.py`
2. Routes all outbound RPC through a **forked bus + RPC worker** while keeping Hunter/Rabbit/cache intake on the parent bus
3. **Fails loud** if RPC is attempted without a fork (no silent fallback to the listener bus)
4. Closes RPC forks on shutdown for cortex-orch/exec and adds fork wiring tests

Builds on `2d08fab4` (Hub `memory_graph_suggest` timeout budget fix).

## Problem

Two stacked failures on the live stack:

| Issue | Symptom | Fix in this PR |
|-------|---------|----------------|
| Timeout budget mismatch | Hub cancelled at ~63s while gateway needed 90–170s | Already fixed in `2d08fab4` (base) |
| Reply theft / listen overlap | Hub logs `path=inline`; gateway published replies Hub never received | Fork RPC off subscriber bus |

The June 16 pub/sub `socket_timeout=None` change fixed dead subscribers but exposed the rule: **do not run `rpc_request()` on the same bus instance as long-lived `subscribe()` loops.**

## Solution

```python
from orion.core.bus.rpc_fork import fork_rpc_client, require_rpc_bus

rpc_bus = await fork_rpc_client(listener_bus)  # dedicated RPC worker
require_rpc_bus(rpc_bus, service="my-service")  # fail loud if fork missing

# listener_bus → subscribe / publish intake
# rpc_bus       → all rpc_request() calls
```

Documented in `services/orion-bus/AGENT_CONTEXT.md`.

## Services hardened

| Service | Change |
|---------|--------|
| **orion-hub** | Single `rpc_bus` for cortex gateway, TTS/STT, crystallization embed |
| **orion-context-exec** | Forked `rpc_bus` for organ/synthesis RPC; `_outbound_rpc_bus()` blocks listener fallback |
| **orion-cortex-orch** | `_bus_for_rpc()` via `require_rpc_bus()`; `_close_rpc_bus()` in `finally` |
| **orion-cortex-exec** | Same pattern; `verb_runtime.bus` reassigned to fork at startup |
| **orion-actions** | `_actions_rpc_bus` for cortex orch/exec RPC from Hunter handlers |
| **orion-chat-memory** | `embed_rpc_bus` for embedding RPC |
| **orion-vision-council** | `_rpc_bus` for LLM RPC + null guard before `rpc_request` |
| **orion-agent-chain** | Per-request `fork_rpc_client` with `finally` close |

## Additional hardening (post-review)

- cortex-orch/exec: `_close_rpc_bus()` + `try/finally` in `main()`
- cortex-orch/exec/context-exec: `require_rpc_bus()` replaces `_rpc_bus if _rpc_bus else svc.bus` fallback
- vision-council: guard when `_rpc_bus is None` before LLM RPC
- Fork wiring tests for orch, exec, actions, context-exec

## Test plan

- [x] `tests/test_bus_rpc_fork_client.py` — fork worker + `require_rpc_bus` reject (2 passed)
- [x] `tests/test_bus_pubsub_timeout.py` — pubsub `socket_timeout=None` unchanged (1 passed)
- [x] `services/orion-cortex-orch/tests/test_rpc_bus_fork.py` — prefer fork, raise when missing, close (3 passed)
- [x] `services/orion-cortex-exec/tests/test_rpc_bus_fork.py` — same (3 passed)
- [x] `services/orion-context-exec/tests/test_rpc_bus_fork.py` — listener-without-fork raises; offline OK (2 passed)
- [x] `services/orion-actions/tests/test_rpc_bus_fork.py` — retry uses supplied bus (1 passed)
- [x] `services/orion-agent-chain/tests/test_bus_listener_rpc.py` — per-request fork (4 passed)
- [ ] Rebuild/restart Hub + cortex stack; confirm logs show `[rpc-fork] worker started` and `path=worker` (not `path=inline`)
- [ ] Smoke `memory_graph_suggest` end-to-end (180s budget, no 63s cancel)

## Env / config

No new environment variables. `.env_example` unchanged.

## Deploy notes

Rebuild and restart affected containers after merge:

```bash
docker compose -f services/orion-hub/docker-compose.yml build hub-app
docker compose -f services/orion-hub/docker-compose.yml up -d hub-app

docker compose -f services/orion-cortex-gateway/docker-compose.yml build
docker compose -f services/orion-cortex-orch/docker-compose.yml build
docker compose -f services/orion-cortex-exec/docker-compose.yml build
```

## Remaining risks

- **Per-request fork in agent-chain**: one worker per intake message; fine at low QPS, revisit if hot-path latency matters
- **Hub TTS + cortex share one `rpc_bus`**: worker multiplexes reply channels; OK under concurrent RPC
- **Shutdown window**: in-flight RPC after fork close gets `RuntimeError` instead of silent theft (preferred)
- **Unhardened services** (topic-foundry, spark-introspector, etc.) may still mix subscribe + RPC on one bus — out of scope
