### PR TITLE
Shorten journal recall lookback from 7 days to 24 hours.

### DIFF
--- a/orion/recall/profiles/journal.daily.grounded.v1.yaml
+++ b/orion/recall/profiles/journal.daily.grounded.v1.yaml
@@ -10,12 +10,12 @@ vector_top_k: 0
 rdf_top_k: 8
 max_per_source: 4
 max_total_items: 24
-time_decay_half_life_hours: 72
+time_decay_half_life_hours: 24
 render_budget_tokens: 256
 cards_top_k: 4
 enable_query_expansion: true
 enable_sql_timeline: true
-sql_since_minutes: 10080
+sql_since_minutes: 1440
 sql_top_k: 200
 
 filters:
@@ -44,4 +44,4 @@ relevance:
   text_similarity_weight: 0.15
   recency_weight: 0.1
   enable_recency: true
-  recency_half_life_hours: 72
+  recency_half_life_hours: 24

--- a/orion/recall/profiles/journal.daily.metacog.grounded.v1.yaml
+++ b/orion/recall/profiles/journal.daily.metacog.grounded.v1.yaml
@@ -1,5 +1,5 @@
 # Daily metacog grounded recall: true 24h window, tight fusion/render budgets.
-# Scheduler daily journal keeps journal.daily.grounded.v1 (7d); metacog uses this profile.
+# All journal recall profiles use a 24h SQL window; metacog keeps tighter fusion/render budgets.
 profile: journal.daily.metacog.grounded.v1
 enable_vector: false
 

--- a/orion/recall/profiles/journal.notify.grounded.v1.yaml
+++ b/orion/recall/profiles/journal.notify.grounded.v1.yaml
@@ -7,12 +7,12 @@ vector_top_k: 0
 rdf_top_k: 8
 max_per_source: 4
 max_total_items: 24
-time_decay_half_life_hours: 72
+time_decay_half_life_hours: 24
 render_budget_tokens: 256
 cards_top_k: 4
 enable_query_expansion: true
 enable_sql_timeline: true
-sql_since_minutes: 10080
+sql_since_minutes: 1440
 sql_top_k: 200
 
 filters:
@@ -40,4 +40,4 @@ relevance:
   text_similarity_weight: 0.15
   recency_weight: 0.1
   enable_recency: true
-  recency_half_life_hours: 72
+  recency_half_life_hours: 24

--- a/orion/recall/profiles/journal.world_pulse.grounded.v1.yaml
+++ b/orion/recall/profiles/journal.world_pulse.grounded.v1.yaml
@@ -6,12 +6,12 @@ vector_top_k: 0
 rdf_top_k: 8
 max_per_source: 4
 max_total_items: 24
-time_decay_half_life_hours: 72
+time_decay_half_life_hours: 24
 render_budget_tokens: 256
 cards_top_k: 4
 enable_query_expansion: true
 enable_sql_timeline: true
-sql_since_minutes: 10080
+sql_since_minutes: 1440
 sql_top_k: 200
 
 filters:
@@ -39,4 +39,4 @@ relevance:
   text_similarity_weight: 0.15
   recency_weight: 0.1
   enable_recency: true
-  recency_half_life_hours: 72
+  recency_half_life_hours: 24


### PR DESCRIPTION
Branch is pushed; `gh` isn’t authenticated here so the PR wasn’t created automatically.

**Branch:** `fix/journal-recall-24h-window`  
**Commit:** `007a4b67` — Shorten journal recall lookback from 7 days to 24 hours  
**Open PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/journal-recall-24h-window

---

**Title:** Shorten journal recall lookback to 24 hours

**Description:**

## Summary
- Reduces journal recall SQL lookback from 7 days (`10080` min) to 24 hours (`1440` min) for daily scheduler, notify digest, and world pulse journal profiles.
- Aligns time decay and recency half-life from 72h to 24h on those profiles so scoring matches the narrower window.
- Metacog profile was already 24h; comment updated to reflect all journal profiles now share the same window.

## Profiles touched
| Profile | Trigger |
|---|---|
| `journal.daily.grounded.v1` | Scheduler daily journal |
| `journal.notify.grounded.v1` | Notify digest → journal |
| `journal.world_pulse.grounded.v1` | World Pulse reflective journal |
| `journal.daily.metacog.grounded.v1` | Daily metacog (comment only) |

## Test plan
- [x] `PYTHONPATH=. ./orion_dev/bin/python -m pytest orion/cognition/tests/test_recall_profiles.py orion/cognition/tests/test_recall_render_lane_separation.py services/orion-recall/tests/test_fusion_profile_filters.py -q` (19 passed)
- [ ] Restart `orion-recall` and `orion-actions` after merge so profiles reload at boot
- [ ] Trigger a daily journal / digest run and confirm recall context is limited to the last 24h
