### PR TITLE
Finish context-exec proposal storage migration

### DIFF
--- a/docs/proposal-review-api.md
+++ b/docs/proposal-review-api.md
@@ -39,8 +39,12 @@ Proposal routes return **503** when enabled but `PROPOSAL_LEDGER_STORE_PATH` is 
 |-------|---------|
 | `enabled` | `PROPOSAL_REVIEW_API_ENABLED` |
 | `store_configured` | non-empty `PROPOSAL_LEDGER_STORE_PATH` |
+| `store_path` | configured ledger JSON path |
 | `store_path_present` | configured path exists on disk |
-| `ok` | enabled, configured, and store opens cleanly |
+| `store_parent_present` | parent directory of ledger file exists |
+| `store_parent_writable` | parent directory is writable (readiness signal before first write) |
+| `reject_store_path` | sibling reject ledger path (`orion-proposals.reject.json`) |
+| `ok` | enabled, configured, parent writable, and store opens cleanly |
 | `error` | human-readable reason when not `ok` |
 
 Hub must call this API — not read JSON ledger files directly.
@@ -114,7 +118,7 @@ Requirements:
 
 ```bash
 PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py dry-run-execute <proposal_id> \
-  --store /tmp/orion-proposals.json \
+  --store /var/lib/orion/context-exec/ledger/orion-proposals.json \
   --executor dry-run
 ```
 
@@ -143,13 +147,26 @@ ORION_PY=orion_dev/bin/python bash scripts/denver_memory_correction_vertical_smo
 
 Expected: `denver_memory_correction_vertical_smoke PASS` with one `pending_review` Denver proposal, API GET checks showing `eligible=false`, `mutation_allowed=false`, `requires_human_approval=true`. Hub live GET is optional (`HUB_SMOKE=true HUB_BASE_URL=...`).
 
-Or manually:
+Or manually (host-run smoke paths):
 
 ```bash
-rm -f /tmp/orion-proposals.json
-PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py seed-demo --store /tmp/orion-proposals.json
-PROPOSAL_REVIEW_API_ENABLED=true PROPOSAL_LEDGER_STORE_PATH=/tmp/orion-proposals.json \
+rm -f /mnt/rlm-nvme/context-exec/ledger/orion-proposals.json
+PYTHONPATH=. orion_dev/bin/python scripts/orion_proposal_cli.py seed-demo \
+  --store /mnt/rlm-nvme/context-exec/ledger/orion-proposals.json
+PROPOSAL_REVIEW_API_ENABLED=true \
+PROPOSAL_LEDGER_STORE_PATH=/mnt/rlm-nvme/context-exec/ledger/orion-proposals.json \
   PYTHONPATH=. orion_dev/bin/python -m pytest tests/services/test_proposal_review_api.py -q
+```
+
+Container-side ledger default: `/var/lib/orion/context-exec/ledger/orion-proposals.json`.
+
+### Migration from `/tmp`
+
+Legacy deployments that used `/tmp/orion-proposals.json` can migrate with:
+
+```bash
+sudo mkdir -p /mnt/rlm-nvme/context-exec/ledger
+sudo cp -av /tmp/orion-proposals.json /mnt/rlm-nvme/context-exec/ledger/orion-proposals.json 2>/dev/null || true
 ```
 
 ## Verification

--- a/scripts/proposal_review_api_smoke.sh
+++ b/scripts/proposal_review_api_smoke.sh
@@ -6,14 +6,18 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-STORE="${PROPOSAL_LEDGER_STORE_PATH:-/tmp/orion-proposals.json}"
+# Host-run default; set CONTEXT_EXEC_STORAGE_ROOT=/var/lib/orion/context-exec for container-side smoke.
+CONTEXT_EXEC_STORAGE_ROOT="${CONTEXT_EXEC_STORAGE_ROOT:-/mnt/rlm-nvme/context-exec}"
+STORE="${PROPOSAL_LEDGER_STORE_PATH:-${CONTEXT_EXEC_STORAGE_ROOT}/ledger/orion-proposals.json}"
+REJECT_STORE="${PROPOSAL_LEDGER_REJECT_STORE_PATH:-${CONTEXT_EXEC_STORAGE_ROOT}/ledger/orion-proposals.reject.json}"
 PY="${ORION_PY:-orion_dev/bin/python}"
 # Resolve venv from repo root when run from a worktree without a local orion_dev.
 if [[ ! -x "$PY" ]] && [[ -x "$ROOT/orion_dev/bin/python" ]]; then
   PY="$ROOT/orion_dev/bin/python"
 fi
 
-rm -f "$STORE"
+mkdir -p "$(dirname "$STORE")" "$(dirname "$REJECT_STORE")"
+rm -f "$STORE" "$REJECT_STORE"
 
 echo "== seed demo ledger =="
 PYTHONPATH=. "$PY" scripts/orion_proposal_cli.py seed-demo --store "$STORE"

--- a/scripts/repl/orion_fresh_main_smoke.sh
+++ b/scripts/repl/orion_fresh_main_smoke.sh
@@ -8,19 +8,22 @@
 #
 # Usage:
 #   chmod +x scripts/repl/orion_fresh_main_smoke.sh
-#   ORION_PY=orion_dev/bin/python STORE=/tmp/orion-proposals.json \
+#   ORION_PY=orion_dev/bin/python \
+#     CONTEXT_EXEC_STORAGE_ROOT=/mnt/rlm-nvme/context-exec \
 #     ./scripts/repl/orion_fresh_main_smoke.sh
 
 set -u
 set -o pipefail
 
 ORION_PY="${ORION_PY:-orion_dev/bin/python}"
-STORE="${STORE:-/tmp/orion-proposals.json}"
-REJECT_STORE="${REJECT_STORE:-/tmp/orion-proposals.json.reject}"
-LOG_ROOT="${LOG_ROOT:-./.orion-smoke-logs}"
+CONTEXT_EXEC_STORAGE_ROOT="${CONTEXT_EXEC_STORAGE_ROOT:-/mnt/rlm-nvme/context-exec}"
+STORE="${STORE:-${CONTEXT_EXEC_STORAGE_ROOT}/ledger/orion-proposals.json}"
+REJECT_STORE="${REJECT_STORE:-${CONTEXT_EXEC_STORAGE_ROOT}/ledger/orion-proposals.reject.json}"
+LOG_ROOT="${LOG_ROOT:-${CONTEXT_EXEC_STORAGE_ROOT}/smoke-logs}"
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 LOG_DIR="${LOG_ROOT}/${STAMP}"
 
+mkdir -p "$(dirname "$STORE")" "$(dirname "$REJECT_STORE")" "$LOG_ROOT"
 mkdir -p "$LOG_DIR"
 
 PASS_COUNT=0

--- a/services/orion-context-exec/README.md
+++ b/services/orion-context-exec/README.md
@@ -21,7 +21,7 @@ Control-plane HTTP surface over the proposal ledger. **Disabled by default** (`P
 | POST | `/proposals/{proposal_id}/review` | Apply `ProposalReviewDecisionV1` |
 | GET | `/proposals/{proposal_id}/eligibility` | Inspect `ProposalExecutionEligibilityV1` |
 
-Routes mount only when `PROPOSAL_REVIEW_API_ENABLED=true`. `/health` always reports `proposal_review_api.enabled`, `store_configured`, `store_path_present`, `ok`, and `error`, plus a `storage` block for mounted arena paths.
+Routes mount only when `PROPOSAL_REVIEW_API_ENABLED=true`. `/health` always reports `proposal_review_api.enabled`, `store_configured`, `store_path`, `store_path_present`, `store_parent_present`, `store_parent_writable`, `reject_store_path`, `ok`, and `error`, plus a `storage` block for mounted arena paths.
 
 Approval creates execution eligibility only — no executor, no receipts, no auto-approval. Context-exec cannot approve (`reviewer_id=context-exec` → 403). Hub must call this API, not read JSON ledger files.
 

--- a/services/orion-context-exec/app/proposal_review_api.py
+++ b/services/orion-context-exec/app/proposal_review_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -278,28 +279,47 @@ async def proposal_eligibility(proposal_id: str) -> dict[str, Any]:
     return eligibility.model_dump(mode="json")
 
 
+def _reject_store_path(store: str) -> str:
+    return str(Path(store).parent / "orion-proposals.reject.json")
+
+
 def proposal_review_health_block() -> dict[str, Any]:
     enabled = settings.proposal_review_api_enabled
     store = (settings.proposal_ledger_store_path or "").strip()
     configured = bool(store)
-    store_path_present = configured and Path(store).exists()
+    store_path_obj = Path(store) if configured else None
+    store_path_present = bool(store_path_obj and store_path_obj.exists())
+    store_parent_present = False
+    store_parent_writable = False
     store_ok = False
     error: str | None = None
     if not enabled:
         error = "proposal review API is disabled"
     elif not configured:
         error = "PROPOSAL_LEDGER_STORE_PATH is required (explicit JSON ledger path; no repo default)"
-    elif configured:
-        try:
-            _open_repo(Path(store))
-            store_ok = True
-        except ProposalReviewApiError as exc:
-            error = str(exc)
-    ok = enabled and configured and store_path_present and store_ok
+    elif store_path_obj is not None:
+        parent = store_path_obj.parent
+        store_parent_present = parent.exists()
+        store_parent_writable = store_parent_present and os.access(parent, os.W_OK)
+        if not store_parent_present:
+            error = f"proposal ledger store parent does not exist: {parent}"
+        elif not store_parent_writable:
+            error = f"proposal ledger store parent is not writable: {parent}"
+        else:
+            try:
+                _open_repo(store_path_obj)
+                store_ok = True
+            except ProposalReviewApiError as exc:
+                error = str(exc)
+    ok = enabled and configured and store_parent_writable and store_ok and error is None
     return {
         "enabled": enabled,
         "store_configured": configured,
+        "store_path": store if configured else None,
         "store_path_present": store_path_present,
+        "store_parent_present": store_parent_present,
+        "store_parent_writable": store_parent_writable,
+        "reject_store_path": _reject_store_path(store) if configured else None,
         "ok": ok,
         "error": error,
     }

--- a/services/orion-context-exec/tests/test_health.py
+++ b/services/orion-context-exec/tests/test_health.py
@@ -40,7 +40,11 @@ async def test_health(monkeypatch: pytest.MonkeyPatch) -> None:
     block = data["proposal_review_api"]
     assert "enabled" in block
     assert "store_configured" in block
+    assert "store_path" in block
     assert "store_path_present" in block
+    assert "store_parent_present" in block
+    assert "store_parent_writable" in block
+    assert "reject_store_path" in block
     assert "ok" in block
     assert "error" in block
     assert "bus_enabled" in data
@@ -100,5 +104,30 @@ async def test_health_proposal_review_block_store_configured(
     block = resp.json()["proposal_review_api"]
     assert block["store_configured"] is True
     assert block["store_path_present"] is True
+    assert block["store_parent_present"] is True
+    assert block["store_parent_writable"] is True
+    assert block["ok"] is True
+    assert block["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_health_proposal_review_block_parent_writable_before_first_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    store = tmp_path / "ledger" / "orion-proposals.json"
+    store.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("PROPOSAL_REVIEW_API_ENABLED", "true")
+    monkeypatch.setenv("PROPOSAL_LEDGER_STORE_PATH", str(store))
+    app = _load_app(monkeypatch, reload_settings=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+    block = resp.json()["proposal_review_api"]
+    assert block["store_configured"] is True
+    assert block["store_path"] == str(store)
+    assert block["store_path_present"] is False
+    assert block["store_parent_present"] is True
+    assert block["store_parent_writable"] is True
+    assert block["reject_store_path"] == str(tmp_path / "ledger" / "orion-proposals.reject.json")
     assert block["ok"] is True
     assert block["error"] is None

--- a/tests/scripts/test_context_exec_proposal_storage_defaults.py
+++ b/tests/scripts/test_context_exec_proposal_storage_defaults.py
@@ -1,0 +1,50 @@
+"""Assert context-exec proposal ledger smoke scripts use durable storage defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+FRESH_MAIN_SMOKE = ROOT / "scripts" / "repl" / "orion_fresh_main_smoke.sh"
+PROPOSAL_API_SMOKE = ROOT / "scripts" / "proposal_review_api_smoke.sh"
+PROPOSAL_REVIEW_DOC = ROOT / "docs" / "proposal-review-api.md"
+
+HOST_STORAGE_ROOT = "/mnt/rlm-nvme/context-exec"
+HOST_LEDGER_SUFFIX = "ledger/orion-proposals.json"
+CONTAINER_LEDGER = "/var/lib/orion/context-exec/ledger/orion-proposals.json"
+
+
+def _active_doc_text() -> str:
+    text = PROPOSAL_REVIEW_DOC.read_text(encoding="utf-8")
+    marker = "### Migration from `/tmp`"
+    if marker in text:
+        return text.split(marker, maxsplit=1)[0]
+    return text
+
+
+def test_fresh_main_smoke_defaults_use_durable_storage() -> None:
+    text = FRESH_MAIN_SMOKE.read_text(encoding="utf-8")
+    assert "/tmp/orion-proposals.json" not in text
+    assert "./.orion-smoke-logs" not in text
+    assert "CONTEXT_EXEC_STORAGE_ROOT" in text
+    assert HOST_STORAGE_ROOT in text
+    assert HOST_LEDGER_SUFFIX in text
+    assert "orion-proposals.reject.json" in text
+    assert "smoke-logs" in text
+
+
+def test_proposal_review_api_smoke_defaults_use_durable_storage() -> None:
+    text = PROPOSAL_API_SMOKE.read_text(encoding="utf-8")
+    assert "/tmp/orion-proposals.json" not in text
+    assert "CONTEXT_EXEC_STORAGE_ROOT" in text
+    assert HOST_STORAGE_ROOT in text
+    assert HOST_LEDGER_SUFFIX in text
+    assert "orion-proposals.reject.json" in text
+
+
+def test_proposal_review_doc_active_examples_use_durable_storage() -> None:
+    text = _active_doc_text()
+    assert "/tmp/orion-proposals.json" not in text
+    assert CONTAINER_LEDGER in text
+    assert f"{HOST_STORAGE_ROOT}/{HOST_LEDGER_SUFFIX}" in text


### PR DESCRIPTION
## Summary

- Migrate host-run smoke scripts from ephemeral `/tmp/orion-proposals.json` and repo-local `./.orion-smoke-logs` to durable `CONTEXT_EXEC_STORAGE_ROOT` defaults under `/mnt/rlm-nvme/context-exec`.
- Update `docs/proposal-review-api.md` with container/host durable path examples and a `/tmp` → NVMe migration note.
- Strengthen `proposal_review_health_block()` with `store_path`, `store_parent_present`, `store_parent_writable`, and `reject_store_path`; `ok` keys off parent writability, not ledger file existence.
- Add regression tests for script defaults and health parent-writable-before-first-write.

## Scope / non-goals

- No workspace manager, proposal semantics, run ledger, or repo-write changes.
- Denver vertical smoke and `context-exec-beta-runbook.md` still use separate `/tmp` paths (follow-up).

## Test plan

- [x] Targeted pytest (health + storage defaults + proposal review API) — 29 passed
- [x] Smoke scripts grep — no `/tmp/orion-proposals.json` in active defaults
- [x] Code review subagent — approved
- [ ] Full host smoke ladder — requires writable `/mnt/rlm-nvme/context-exec/smoke-logs`

## Migration

sudo mkdir -p /mnt/rlm-nvme/context-exec/ledger /mnt/rlm-nvme/context-exec/smoke-logs
sudo cp -av /tmp/orion-proposals.json /mnt/rlm-nvme/context-exec/ledger/orion-proposals.json 2>/dev/null || true