### PR TITLE
Fix cortex-gateway bus consumer dying after the first Hub chat.

### DIFF
--- a/orion/core/bus/async_service.py
+++ b/orion/core/bus/async_service.py
@@ -272,40 +272,50 @@ class OrionBusAsync:
         """
         started = perf_counter()
         corr = str(envelope.correlation_id)
+        if self._rpc_worker_task and not self._rpc_worker_task.done():
+            key = (reply_channel, corr)
+            fut = asyncio.get_running_loop().create_future()
+            self._pending_rpc[key] = fut
+            try:
+                async with self._rpc_lock:
+                    await self._rpc_subscribe(reply_channel)
+                logger.info(
+                    "[rpc] publish begin corr_id=%s request_channel=%s reply_channel=%s path=worker elapsed_ms=%.1f",
+                    corr,
+                    request_channel,
+                    reply_channel,
+                    (perf_counter() - started) * 1000.0,
+                )
+                await self.publish(request_channel, envelope)
+                logger.info(
+                    "[rpc] publish success corr_id=%s request_channel=%s reply_channel=%s path=worker elapsed_ms=%.1f",
+                    corr,
+                    request_channel,
+                    reply_channel,
+                    (perf_counter() - started) * 1000.0,
+                )
+                logger.info(
+                    "[rpc] waiting for reply corr_id=%s reply_channel=%s timeout_sec=%.2f path=worker",
+                    corr,
+                    reply_channel,
+                    timeout_sec,
+                )
+                return await asyncio.wait_for(fut, timeout=timeout_sec)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[rpc] timeout waiting for reply corr_id=%s request_channel=%s reply_channel=%s timeout_sec=%.2f elapsed_ms=%.1f",
+                    corr,
+                    request_channel,
+                    reply_channel,
+                    timeout_sec,
+                    (perf_counter() - started) * 1000.0,
+                )
+                raise TimeoutError(f"RPC timeout waiting on {reply_channel}")
+            finally:
+                self._pending_rpc.pop(key, None)
+
         async with self.subscribe(reply_channel) as pubsub:
             try:
-                if self._rpc_worker_task and not self._rpc_worker_task.done():
-                    key = (reply_channel, corr)
-                    fut = asyncio.get_running_loop().create_future()
-                    self._pending_rpc[key] = fut
-                    async with self._rpc_lock:
-                        await self._rpc_subscribe(reply_channel)
-                    logger.info(
-                        "[rpc] publish begin corr_id=%s request_channel=%s reply_channel=%s path=worker elapsed_ms=%.1f",
-                        corr,
-                        request_channel,
-                        reply_channel,
-                        (perf_counter() - started) * 1000.0,
-                    )
-                    await self.publish(request_channel, envelope)
-                    logger.info(
-                        "[rpc] publish success corr_id=%s request_channel=%s reply_channel=%s path=worker elapsed_ms=%.1f",
-                        corr,
-                        request_channel,
-                        reply_channel,
-                        (perf_counter() - started) * 1000.0,
-                    )
-                    try:
-                        logger.info(
-                            "[rpc] waiting for reply corr_id=%s reply_channel=%s timeout_sec=%.2f path=worker",
-                            corr,
-                            reply_channel,
-                            timeout_sec,
-                        )
-                        return await asyncio.wait_for(fut, timeout=timeout_sec)
-                    finally:
-                        self._pending_rpc.pop(key, None)
-
                 logger.info(
                     "[rpc] publish begin corr_id=%s request_channel=%s reply_channel=%s path=inline elapsed_ms=%.1f",
                     corr,

--- a/services/orion-cortex-gateway/app/bus_client.py
+++ b/services/orion-cortex-gateway/app/bus_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 from uuid import uuid4
 from typing import Any, Dict
@@ -79,6 +80,8 @@ class BusClient:
         self.bus = OrionBusAsync(url=self.settings.orion_bus_url)
         self._intake_bus: OrionBusAsync | None = None
         self._rpc_bus: OrionBusAsync | None = None
+        self._consumer_task: asyncio.Task | None = None
+        self._consumer_stop = False
         self.reply_prefix = self.settings.channel_cortex_result_prefix
 
     async def connect(self):
@@ -86,11 +89,16 @@ class BusClient:
         await self.bus.connect()
         self._intake_bus = await self.bus.fork()
         await self._intake_bus.connect()
-        self._rpc_bus = await self.bus.fork()
-        await self._rpc_bus.connect()
+        self._rpc_bus = await self.bus.fork(start_rpc_worker=True)
 
     async def close(self):
         logger.info("Closing bus connection")
+        self._consumer_stop = True
+        if self._consumer_task is not None:
+            self._consumer_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._consumer_task
+            self._consumer_task = None
         if self._rpc_bus is not None:
             await self._rpc_bus.close()
             self._rpc_bus = None
@@ -139,71 +147,92 @@ class BusClient:
         if rpc_bus is None:
             raise RuntimeError("Gateway RPC bus is not connected")
 
-        async def _wait_for_matching_reply() -> Dict[str, Any]:
-            async with rpc_bus.subscribe(reply_to) as pubsub:
-                await rpc_bus.publish(
+        deadline = asyncio.get_running_loop().time() + self.settings.gateway_rpc_timeout_sec
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                logger.error(
+                    "gateway_orch_timeout corr=%s reply=%s timeout_sec=%s",
+                    corr,
+                    reply_to,
+                    self.settings.gateway_rpc_timeout_sec,
+                )
+                raise TimeoutError(
+                    f"RPC timed out after {self.settings.gateway_rpc_timeout_sec}s"
+                )
+            try:
+                msg = await rpc_bus.rpc_request(
                     self.settings.channel_cortex_request,
                     env,
+                    reply_channel=reply_to,
+                    timeout_sec=remaining,
                 )
-                async for msg in rpc_bus.iter_messages(pubsub):
-                    decoded = rpc_bus.codec.decode(msg.get("data"))
-                    if not decoded.ok:
-                        logger.warning("Decode failed correlation_id=%s error=%s", corr, decoded.error)
-                        continue
+            except TimeoutError:
+                logger.error(
+                    "gateway_orch_timeout corr=%s reply=%s timeout_sec=%s",
+                    corr,
+                    reply_to,
+                    self.settings.gateway_rpc_timeout_sec,
+                )
+                raise TimeoutError(
+                    f"RPC timed out after {self.settings.gateway_rpc_timeout_sec}s"
+                )
 
-                    payload = decoded.envelope.payload
-                    payload_dict: Dict[str, Any] | None = None
-                    if isinstance(payload, dict):
-                        payload_dict = payload
-                    elif hasattr(payload, "model_dump"):
-                        payload_dict = payload.model_dump(mode="json")
+            decoded = rpc_bus.codec.decode(msg.get("data"))
+            if not decoded.ok:
+                logger.warning("Decode failed correlation_id=%s error=%s", corr, decoded.error)
+                continue
 
-                    if payload_dict is not None:
-                        verb = payload_dict.get("verb") or payload_dict.get("verb_name")
-                        if verb == "introspect_spark" and req.verb != "introspect_spark":
-                            logger.info(
-                                "RPC reply filtered corr=%s verb=%s expected=%s",
-                                corr,
-                                verb,
-                                req.verb,
-                            )
-                            continue
-                        logger.info(
-                            "gateway_orch_result corr=%s reply=%s kind=%s",
-                            corr,
-                            reply_to,
-                            decoded.envelope.kind,
-                        )
-                        return payload_dict
+            payload = decoded.envelope.payload
+            payload_dict: Dict[str, Any] | None = None
+            if isinstance(payload, dict):
+                payload_dict = payload
+            elif hasattr(payload, "model_dump"):
+                payload_dict = payload.model_dump(mode="json")
 
+            if payload_dict is not None:
+                verb = payload_dict.get("verb") or payload_dict.get("verb_name")
+                if verb == "introspect_spark" and req.verb != "introspect_spark":
                     logger.info(
-                        "gateway_orch_result corr=%s reply=%s kind=%s",
+                        "RPC reply filtered corr=%s verb=%s expected=%s",
                         corr,
-                        reply_to,
-                        decoded.envelope.kind,
+                        verb,
+                        req.verb,
                     )
-                    return payload
-            raise RuntimeError("RPC reply subscription closed without a match.")
+                    continue
+                logger.info(
+                    "gateway_orch_result corr=%s reply=%s kind=%s",
+                    corr,
+                    reply_to,
+                    decoded.envelope.kind,
+                )
+                return payload_dict
 
-        try:
-            return await asyncio.wait_for(
-                _wait_for_matching_reply(),
-                timeout=self.settings.gateway_rpc_timeout_sec,
-            )
-        except asyncio.TimeoutError as te:
-            logger.error(
-                "gateway_orch_timeout corr=%s reply=%s timeout_sec=%s",
+            logger.info(
+                "gateway_orch_result corr=%s reply=%s kind=%s",
                 corr,
                 reply_to,
-                self.settings.gateway_rpc_timeout_sec,
+                decoded.envelope.kind,
             )
-            raise TimeoutError(
-                f"RPC timed out after {self.settings.gateway_rpc_timeout_sec}s"
-            ) from te
+            return payload if isinstance(payload, dict) else {}
 
     async def start_gateway_consumer(self):
         logger.info(f"Starting gateway consumer on {self.settings.channel_gateway_request}")
-        asyncio.create_task(self._consume_gateway_request())
+        if self._consumer_task is not None and not self._consumer_task.done():
+            return
+        self._consumer_stop = False
+        self._consumer_task = asyncio.create_task(self._run_gateway_consumer_supervisor())
+
+    async def _run_gateway_consumer_supervisor(self) -> None:
+        while not self._consumer_stop:
+            try:
+                await self._consume_gateway_request()
+            except asyncio.CancelledError:
+                logger.info("Gateway consumer supervisor cancelled")
+                break
+            except Exception as e:
+                logger.error("Gateway consumer supervisor restarting: %s", e, exc_info=True)
+                await asyncio.sleep(5.0)
 
     async def _gateway_dispatch_one(self, message: Dict[str, Any]) -> None:
         try:
@@ -216,20 +245,18 @@ class BusClient:
         intake_bus = self._intake_bus
         if intake_bus is None:
             raise RuntimeError("Gateway intake bus is not initialized")
-        while True:
-            try:
-                # Long-lived intake on a forked bus; orch RPC uses _rpc_bus so listen() overlap
-                # cannot tear down the subscriber. Dispatch in background so slow Hub chats
-                # do not miss messages published while a prior corr is still in flight.
-                async with intake_bus.subscribe(self.settings.channel_gateway_request) as pubsub:
-                    async for msg in intake_bus.iter_messages(pubsub):
-                        asyncio.create_task(self._gateway_dispatch_one(msg))
-            except asyncio.CancelledError:
-                logger.info("Gateway consumer cancelled")
-                break
-            except Exception as e:
-                logger.error(f"Gateway consumer failed: {e}", exc_info=True)
-                await asyncio.sleep(5.0)
+        try:
+            # Long-lived intake on a forked bus; orch RPC uses _rpc_bus worker so per-request
+            # subscribe teardown cannot kill this listener. Dispatch in background so slow Hub
+            # chats do not miss messages published while a prior corr is still in flight.
+            async with intake_bus.subscribe(self.settings.channel_gateway_request) as pubsub:
+                async for msg in intake_bus.iter_messages(pubsub):
+                    if self._consumer_stop:
+                        break
+                    asyncio.create_task(self._gateway_dispatch_one(msg))
+        except asyncio.CancelledError:
+            logger.info("Gateway consumer cancelled")
+            raise
 
 
     async def _publish_gateway_reply(

--- a/services/orion-cortex-gateway/tests/test_gateway_consumer_resilience.py
+++ b/services/orion-cortex-gateway/tests/test_gateway_consumer_resilience.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
@@ -16,7 +20,277 @@ if str(REPO_ROOT) not in sys.path:
 if str(SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(SERVICE_ROOT))
 
+from orion.core.bus.async_service import OrionBusAsync  # noqa: E402
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef  # noqa: E402
+from orion.core.bus.codec import OrionCodec  # noqa: E402
+from orion.schemas.cortex.contracts import CortexClientContext, CortexClientRequest, RecallDirective  # noqa: E402
 from app.bus_client import BusClient  # type: ignore  # noqa: E402
+
+
+class _FakePubSub:
+    def __init__(self, broker: "_FakeBroker") -> None:
+        self._broker = broker
+        self.channels: set[str] = set()
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def subscribe(self, *channels: str) -> None:
+        for channel in channels:
+            self.channels.add(channel)
+
+    async def unsubscribe(self, *channels: str) -> None:
+        for channel in channels:
+            self.channels.discard(channel)
+
+    async def close(self) -> None:
+        self._broker.drop_pubsub(self)
+
+    async def listen(self):
+        while True:
+            yield await self._queue.get()
+
+    async def get_message(self, ignore_subscribe_messages: bool = True, timeout: float = 1.0):
+        try:
+            msg = await asyncio.wait_for(self._queue.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+        if ignore_subscribe_messages and msg.get("type") != "message":
+            return await self.get_message(ignore_subscribe_messages=ignore_subscribe_messages, timeout=timeout)
+        return msg
+
+    async def deliver(self, msg: dict[str, Any]) -> None:
+        await self._queue.put(msg)
+
+
+class _FakeCommandRedis:
+    def __init__(self, broker: "_FakeBroker") -> None:
+        self._broker = broker
+
+    async def ping(self) -> bool:
+        return True
+
+    async def publish(self, channel: str, data: bytes) -> None:
+        await self._broker.route_publish(channel, data)
+
+    async def close(self) -> None:
+        return None
+
+    def pubsub(self) -> _FakePubSub:
+        return self._broker.new_pubsub()
+
+
+class _FakeBroker:
+    def __init__(self) -> None:
+        self._pubsubs: list[_FakePubSub] = []
+        self._command = _FakeCommandRedis(self)
+
+    def command_redis(self) -> _FakeCommandRedis:
+        return self._command
+
+    def new_pubsub_redis(self) -> _FakeCommandRedis:
+        return _FakeCommandRedis(self)
+
+    def new_pubsub(self) -> _FakePubSub:
+        pubsub = _FakePubSub(self)
+        self._pubsubs.append(pubsub)
+        return pubsub
+
+    def drop_pubsub(self, pubsub: _FakePubSub) -> None:
+        with contextlib.suppress(ValueError):
+            self._pubsubs.remove(pubsub)
+
+    async def route_publish(self, channel: str, data: bytes) -> None:
+        payload = {
+            "type": "message",
+            "channel": channel.encode("utf-8"),
+            "data": data,
+        }
+        for pubsub in list(self._pubsubs):
+            if channel in pubsub.channels:
+                await pubsub.deliver(payload)
+
+
+def _make_fake_bus(broker: _FakeBroker, *, start_rpc_worker: bool = False) -> OrionBusAsync:
+    bus = OrionBusAsync("redis://fake", enforce_catalog=False)
+    bus._redis = broker.command_redis()
+    bus._create_pubsub_redis = broker.new_pubsub_redis  # type: ignore[method-assign]
+
+    async def _connect() -> None:
+        if bus._redis is None:
+            bus._redis = broker.command_redis()
+        await bus._redis.ping()
+
+    bus.connect = _connect  # type: ignore[method-assign]
+    if start_rpc_worker:
+        bus.start_rpc_worker()
+    return bus
+
+
+def _gateway_bus_message(*, corr_id: str, reply_to: str, prompt: str) -> dict[str, bytes]:
+    env = BaseEnvelope(
+        kind="cortex.gateway.chat.request",
+        source=ServiceRef(name="hub", version="0.4.0", node="test"),
+        correlation_id=corr_id,
+        reply_to=reply_to,
+        payload={"prompt": prompt, "mode": "brain"},
+    )
+    return {"data": OrionCodec().encode(env)}
+
+
+def _orch_result_payload(corr_id: str) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "mode": "brain",
+        "verb": "chat_general",
+        "status": "success",
+        "final_text": "ok",
+        "memory_used": False,
+        "steps": [],
+        "correlation_id": corr_id,
+        "metadata": {},
+        "recall_debug": {},
+        "metacog_traces": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_gateway_consumer_dispatches_consecutive_hub_chats() -> None:
+    """Regression: intake listener must survive orch RPC and dispatch a second Hub chat."""
+    broker = _FakeBroker()
+    parent_bus = _make_fake_bus(broker)
+    intake_bus = _make_fake_bus(broker)
+    rpc_bus = _make_fake_bus(broker, start_rpc_worker=True)
+
+    client = BusClient()
+    client.bus = parent_bus
+    hub_replies: list[str] = []
+
+    async def _client_connect() -> None:
+        await parent_bus.connect()
+        client._intake_bus = intake_bus
+        await intake_bus.connect()
+        client._rpc_bus = rpc_bus
+        await rpc_bus.connect()
+
+    client.connect = _client_connect  # type: ignore[method-assign]
+
+    original_rpc_publish = rpc_bus.publish
+
+    async def _orch_auto_reply(channel: str, envelope: BaseEnvelope | dict[str, Any]) -> None:
+        await original_rpc_publish(channel, envelope)
+        if channel != client.settings.channel_cortex_request:
+            return
+        corr = str(getattr(envelope, "correlation_id", "") or "")
+        reply_ch = f"{client.reply_prefix}:{corr}"
+        await asyncio.sleep(0.02)
+        orch_env = BaseEnvelope(
+            kind="cortex.orch.result",
+            source=ServiceRef(name="cortex-orch", version="1", node="test"),
+            correlation_id=corr,
+            payload=_orch_result_payload(corr),
+        )
+        await rpc_bus.publish(reply_ch, orch_env)
+
+    rpc_bus.publish = _orch_auto_reply  # type: ignore[method-assign]
+
+    original_parent_publish = parent_bus.publish
+
+    async def _track_hub_replies(channel: str, envelope: BaseEnvelope | dict[str, Any]) -> None:
+        await original_parent_publish(channel, envelope)
+        if channel.startswith("orion:cortex:gateway:result:"):
+            hub_replies.append(channel)
+
+    parent_bus.publish = _track_hub_replies  # type: ignore[method-assign]
+
+    await client.connect()
+    await client.start_gateway_consumer()
+    await asyncio.sleep(0.05)
+
+    assert client._consumer_task is not None
+    assert not client._consumer_task.done()
+
+    for idx in range(2):
+        corr = str(uuid4())
+        reply_to = f"orion:cortex:gateway:result:{corr}"
+        await broker.route_publish(
+            client.settings.channel_gateway_request,
+            _gateway_bus_message(corr_id=corr, reply_to=reply_to, prompt=f"ping {idx}")["data"],
+        )
+
+    deadline = asyncio.get_running_loop().time() + 3.0
+    while len(hub_replies) < 2 and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.05)
+
+    assert len(hub_replies) == 2
+    assert client._consumer_task is not None
+    assert not client._consumer_task.done()
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_request_worker_path_skips_ephemeral_subscribe() -> None:
+    """Worker-path RPC must not open a throwaway subscribe() context."""
+    broker = _FakeBroker()
+    bus = _make_fake_bus(broker, start_rpc_worker=True)
+    await bus.connect()
+
+    subscribe_calls: list[tuple[str, ...]] = []
+    original_subscribe = OrionBusAsync.subscribe
+
+    @asynccontextmanager
+    async def _spy_subscribe(self, *channels: str, patterns: bool = False):
+        subscribe_calls.append(channels)
+        async with original_subscribe(self, *channels, patterns=patterns) as pubsub:
+            yield pubsub
+
+    bus.subscribe = _spy_subscribe.__get__(bus, OrionBusAsync)  # type: ignore[method-assign]
+
+    corr = str(uuid4())
+    reply_ch = f"orion:cortex:result:{corr}"
+    env = BaseEnvelope(
+        kind="cortex.orch.request",
+        source=ServiceRef(name="cortex-gateway", version="1", node="test"),
+        correlation_id=corr,
+        reply_to=reply_ch,
+        payload=CortexClientRequest(
+            mode="brain",
+            verb="chat_general",
+            packs=["executive_pack"],
+            recall=RecallDirective(),
+            context=CortexClientContext(
+                messages=[],
+                raw_user_text="ping",
+                user_message="ping",
+                session_id="test-session",
+                user_id="test-user",
+            ),
+        ).model_dump(mode="json"),
+    )
+
+    async def _reply_later() -> None:
+        await asyncio.sleep(0.02)
+        reply = BaseEnvelope(
+            kind="cortex.orch.result",
+            source=ServiceRef(name="cortex-orch", version="1", node="test"),
+            correlation_id=corr,
+            payload=_orch_result_payload(corr),
+        )
+        await bus.publish(reply_ch, reply)
+
+    reply_task = asyncio.create_task(_reply_later())
+    try:
+        msg = await bus.rpc_request(
+            "orion:cortex:request",
+            env,
+            reply_channel=reply_ch,
+            timeout_sec=2.0,
+        )
+    finally:
+        await reply_task
+
+    assert msg.get("type") == "message"
+    assert subscribe_calls == []
+    await bus.close()
 
 
 @pytest.mark.asyncio

--- a/services/orion-cortex-gateway/tests/test_gateway_consumer_resilience.py
+++ b/services/orion-cortex-gateway/tests/test_gateway_consumer_resilience.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -33,6 +34,8 @@ async def test_connect_forks_separate_intake_and_rpc_buses(monkeypatch) -> None:
         child = BusClient()
         child.connect = fake_connect  # type: ignore[method-assign]
         child.close = AsyncMock()
+        if start_rpc_worker:
+            child._rpc_worker_task = asyncio.get_running_loop().create_future()
         return child
 
     client.bus = AsyncMock()
@@ -47,3 +50,4 @@ async def test_connect_forks_separate_intake_and_rpc_buses(monkeypatch) -> None:
     assert client._intake_bus is not client._rpc_bus
     assert client._intake_bus is not client.bus
     assert client._rpc_bus is not client.bus
+    assert client._rpc_bus._rpc_worker_task is not None


### PR DESCRIPTION
Branch is pushed. `gh` isn’t authenticated here, so create the PR from the link below (or run `gh auth login` and I can open it).

**Branch:** `fix/cortex-gateway-bus-consumer`  
**Commit:** `a31ae209`  
**Create PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/cortex-gateway-bus-consumer

---

**Title:** Fix cortex-gateway bus consumer dying after first Hub chat

**Description:**

## Summary

- Hub chats hung after the first request because cortex-gateway's long-lived Redis intake subscriber was killed when orch RPC tore down ephemeral pub/sub connections (`Task was destroyed`, `aclose(): asynchronous generator is already running`).
- Route gateway → orch RPC through a forked bus with an RPC worker so worker-path requests no longer enter a throwaway `subscribe()` context that conflicted with the intake listener.
- Add a consumer supervisor that restarts the intake loop on failure, and update the resilience test to assert the RPC fork starts a worker.

## Root cause

After handling one Hub chat, the gateway consumer task was destroyed. Subsequent publishes to `orion:cortex:gateway:request` were never consumed; the hub waited up to 400s and timed out.

## Test plan

- [x] `PYTHONPATH=. ./orion_dev/bin/python -m pytest services/orion-cortex-gateway/tests/test_gateway_consumer_resilience.py -q`
- [x] Rebuild/restart `orion-athena-cortex-gateway`
- [x] Two consecutive `POST /api/chat` requests both returned responses; gateway logs show two `Received request` lines with no `Task was destroyed` errors

---

**Files in PR (3):**
- `orion/core/bus/async_service.py`
- `services/orion-cortex-gateway/app/bus_client.py`
- `services/orion-cortex-gateway/tests/test_gateway_consumer_resilience.py`

Unrelated local WIP (env examples, worktree deletion) was left out of this branch and remains in your stash as `unrelated-wip`.