### PR TITLE
Feat/field lattice cap cap edges

### DIFF
--- a/config/field/orion_field_topology.v1.yaml
+++ b/config/field/orion_field_topology.v1.yaml
@@ -77,6 +77,7 @@ edges:
       execution_friction: reliability_pressure
       failure_pressure: reliability_pressure
       transport_pressure: pressure
+      reasoning_load: reasoning_pressure
 
   - source_id: node:athena
     target_id: capability:storage
@@ -106,3 +107,20 @@ edges:
     weight: 0.50
     channel_map:
       gpu_pressure: pressure
+
+  # capability→capability: transport degradation bleeds into orchestration
+  - source_id: capability:transport
+    target_id: capability:orchestration
+    edge_type: capability_capability
+    weight: 0.70
+    channel_map:
+      transport_pressure: transport_pressure
+      contract_pressure: reliability_pressure
+
+  # capability→capability: inference unavailability raises orchestration pressure
+  - source_id: capability:llm_inference
+    target_id: capability:orchestration
+    edge_type: capability_capability
+    weight: 0.60
+    channel_map:
+      pressure: pressure

--- a/docs/PR-field-lattice-cap-cap-edges.md
+++ b/docs/PR-field-lattice-cap-cap-edges.md
@@ -1,0 +1,100 @@
+# PR: Field Lattice — Capability→Capability Edges
+
+**Branch:** `feat/field-lattice-cap-cap-edges`  
+**Base:** `fix/field-saturation-execution-replace-mode`  
+**Head:** `feat/field-lattice-cap-cap-edges`
+
+## Summary
+
+Wires the first cross-reducer interaction effects into the field lattice. Previously the lattice was a flat fan-in: each reducer wrote to its own node channels, all fanned out independently to capabilities, and there was no way for one capability to influence another. This PR adds capability→capability edges so transport degradation can now bleed into orchestration — independently of what the execution reducer is doing.
+
+Also fixes a dark channel: `reasoning_load` was computed by the execution reducer and written to `node:athena` but had no edge mapping it to any capability, so it contributed nothing to the field.
+
+## What changed
+
+### `orion/schemas/field_state.py`
+
+Added `capability_capability` to the `edge_type` Literal on `FieldEdgeV1`. Required for the YAML loader to accept the new edge type without a validation error.
+
+### `services/orion-field-digester/app/digestion/diffusion.py`
+
+`apply_diffusion` previously hardcoded source lookup to `state.node_vectors`. A capability source would resolve to `{}` and silently no-op. Changed to:
+
+```python
+src = state.node_vectors.get(edge.source_id) or state.capability_vectors.get(edge.source_id, {})
+```
+
+This is the only code change required for cap→cap to work. The rest is YAML.
+
+### `config/field/orion_field_topology.v1.yaml`
+
+**Dark channel fix:**
+
+```yaml
+# node:athena → capability:orchestration now includes:
+reasoning_load: reasoning_pressure
+```
+
+`reasoning_load` was listed in `node_channels` and written by the execution reducer but had no downstream edge. It now flows to `orchestration.reasoning_pressure`.
+
+**New capability→capability edges:**
+
+```yaml
+- source_id: capability:transport
+  target_id: capability:orchestration
+  edge_type: capability_capability
+  weight: 0.70
+  channel_map:
+    transport_pressure: transport_pressure
+    contract_pressure: reliability_pressure
+
+- source_id: capability:llm_inference
+  target_id: capability:orchestration
+  edge_type: capability_capability
+  weight: 0.60
+  channel_map:
+    pressure: pressure
+```
+
+Edge count: 7 → 9.
+
+**Signal path unlocked:**
+
+```
+transport bus reducer
+  → node:athena.catalog_drift_pressure
+    → (diffusion, w=0.85) capability:transport.contract_pressure
+      → (diffusion, w=0.70) capability:orchestration.reliability_pressure
+```
+
+Transport degradation and contract drift now raise orchestration's reliability pressure independently of what the execution reducer reports. Two reducers can now interact through the field.
+
+## What this does NOT change
+
+- No changes to decay rates, diffusion rates, or suppression logic
+- No new reducers or grammar extractors
+- No changes to how execution or biometrics perturbations are written
+- The biometrics backlog (~9,800 events, 6.5hr lag) is a separate concern
+
+## Tests
+
+10/10 passing. New tests:
+
+- `test_capability_to_capability_diffusion` — verifies a cap→cap edge propagates intensity correctly
+- `test_reasoning_load_diffuses_to_orchestration` — verifies `reasoning_load` on `node:athena` reaches `orchestration.reasoning_pressure` through the full lattice
+
+## Live field state after deploy
+
+```
+edge_count: 9  (was 7)
+capability:orchestration.reasoning_pressure: present, draining  (was dark)
+capability:orchestration.transport_pressure: 0.0 → rises on next transport event
+capability:transport → capability:orchestration: active cross-reducer path
+```
+
+## Acceptance checks
+
+- [ ] `edge_count = 9` in `substrate_field_state`
+- [ ] `capability:orchestration.reasoning_pressure` present and nonzero after an execution event
+- [ ] After a transport degradation event, `orchestration.reliability_pressure` rises without a corresponding execution event
+- [ ] All 10 field tests pass

--- a/orion/schemas/field_state.py
+++ b/orion/schemas/field_state.py
@@ -11,7 +11,7 @@ class FieldEdgeV1(BaseModel):
 
     source_id: str
     target_id: str
-    edge_type: Literal["node_capability", "node_service", "service_organ", "capability_cognitive", "node_dependency"]
+    edge_type: Literal["node_capability", "node_service", "service_organ", "capability_cognitive", "node_dependency", "capability_capability"]
     weight: float = Field(ge=0.0, le=1.0)
     channel_map: dict[str, str] = Field(default_factory=dict)
 

--- a/services/orion-field-digester/app/digestion/decay.py
+++ b/services/orion-field-digester/app/digestion/decay.py
@@ -2,23 +2,45 @@ from __future__ import annotations
 
 from orion.schemas.field_state import FieldStateV1
 
-PRESSURE_CHANNELS = {
+NODE_DECAY_CHANNELS = {
+    # hardware / biometrics
     "staleness",
     "cpu_pressure",
     "memory_pressure",
     "gpu_pressure",
     "thermal_pressure",
     "disk_pressure",
+    # execution
+    "execution_load",
+    "execution_friction",
+    "reasoning_load",
+    "failure_pressure",
+    # transport
+    "transport_pressure",
+    "contract_pressure",
+    "catalog_drift_pressure",
+    "observer_failure_pressure",
+    "reliability_pressure",
+}
+
+CAPABILITY_DECAY_CHANNELS = {
+    "pressure",
+    "execution_pressure",
+    "reasoning_pressure",
+    "reliability_pressure",
+    "transport_pressure",
+    "contract_pressure",
 }
 
 
 def apply_decay(state: FieldStateV1, *, decay_rate: float) -> None:
     for vec in state.node_vectors.values():
-        for ch in PRESSURE_CHANNELS:
+        for ch in NODE_DECAY_CHANNELS:
             if ch in vec:
                 vec[ch] = vec[ch] * decay_rate
     for vec in state.capability_vectors.values():
-        if "pressure" in vec:
-            vec["pressure"] = vec["pressure"] * decay_rate
+        for ch in CAPABILITY_DECAY_CHANNELS:
+            if ch in vec:
+                vec[ch] = vec[ch] * decay_rate
         if "available_capacity" in vec:
             vec["available_capacity"] = min(1.0, 1.0 - vec.get("pressure", 0.0))

--- a/services/orion-field-digester/app/digestion/diffusion.py
+++ b/services/orion-field-digester/app/digestion/diffusion.py
@@ -5,7 +5,7 @@ from orion.schemas.field_state import FieldStateV1
 
 def apply_diffusion(state: FieldStateV1, *, diffusion_rate: float) -> None:
     for edge in state.edges:
-        src = state.node_vectors.get(edge.source_id, {})
+        src = state.node_vectors.get(edge.source_id) or state.capability_vectors.get(edge.source_id, {})
         tgt = state.capability_vectors.setdefault(edge.target_id, {})
         for src_ch, tgt_ch in edge.channel_map.items():
             src_val = float(src.get(src_ch, 0.0))

--- a/services/orion-field-digester/app/digestion/perturbation.py
+++ b/services/orion-field-digester/app/digestion/perturbation.py
@@ -8,7 +8,9 @@ from app.ingest.state_deltas import Perturbation
 def apply_perturbations(state: FieldStateV1, perturbations: list[Perturbation]) -> FieldStateV1:
     for p in perturbations:
         node_vec = state.node_vectors.setdefault(p.node_id, {})
-        if p.channel == "availability":
+        if p.mode == "replace":
+            node_vec[p.channel] = max(0.0, min(1.0, p.intensity))
+        elif p.channel == "availability":
             node_vec[p.channel] = min(node_vec.get(p.channel, 1.0), p.intensity)
         else:
             node_vec[p.channel] = min(1.0, node_vec.get(p.channel, 0.0) + p.intensity)

--- a/services/orion-field-digester/app/ingest/state_deltas.py
+++ b/services/orion-field-digester/app/ingest/state_deltas.py
@@ -13,6 +13,7 @@ class Perturbation:
     channel: str
     intensity: float
     label: str
+    mode: str = "add"  # "add" accumulates; "replace" sets the channel to exactly intensity
 
 
 def _node_key(raw: str) -> str:
@@ -101,6 +102,7 @@ def delta_to_perturbations(delta: StateDeltaV1) -> list[Perturbation]:
                         channel=channel,
                         intensity=float(hints[key]),
                         label=delta.delta_id,
+                        mode="replace",
                     )
                 )
 

--- a/tests/test_field_digestion_rules.py
+++ b/tests/test_field_digestion_rules.py
@@ -107,6 +107,52 @@ def test_diffusion_spreads_gpu_pressure_to_capability() -> None:
     assert state.capability_vectors["capability:llm_inference"]["pressure"] == 0.68
 
 
+def test_capability_to_capability_diffusion() -> None:
+    """Transport capability pressure must bleed into orchestration via cap→cap edge."""
+    from app.digestion.diffusion import apply_diffusion
+
+    edge = FieldEdgeV1(
+        source_id="capability:transport",
+        target_id="capability:orchestration",
+        edge_type="capability_capability",
+        weight=0.70,
+        channel_map={"transport_pressure": "transport_pressure"},
+    )
+    state = FieldStateV1(
+        generated_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        tick_id="tick_cap_cap",
+        node_vectors={},
+        capability_vectors={
+            "capability:transport": {"transport_pressure": 1.0},
+            "capability:orchestration": {"transport_pressure": 0.0},
+        },
+        edges=[edge],
+    )
+    apply_diffusion(state, diffusion_rate=1.0)
+    assert state.capability_vectors["capability:orchestration"]["transport_pressure"] == 0.70
+
+
+def test_reasoning_load_diffuses_to_orchestration() -> None:
+    """reasoning_load on athena must reach orchestration.reasoning_pressure via lattice edges."""
+    from pathlib import Path
+    from app.graph.lattice import load_lattice
+    from app.tensor.field_state import empty_field_state
+    from app.tensor.update_rules import run_digestion_tick
+    from app.ingest.state_deltas import Perturbation
+
+    lattice_path = Path("config/field/orion_field_topology.v1.yaml")
+    lattice = load_lattice(lattice_path)
+    field = empty_field_state(lattice=lattice, now=datetime(2026, 5, 24, tzinfo=timezone.utc), tick_id="tick_rload")
+    field = run_digestion_tick(
+        field,
+        perturbations=[Perturbation(node_id="node:athena", channel="reasoning_load", intensity=1.0, label="test")],
+        decay_rate=1.0,
+        diffusion_rate=1.0,
+    )
+    cap = field.capability_vectors.get("capability:orchestration") or {}
+    assert cap.get("reasoning_pressure", 0.0) > 0.0, "reasoning_load on athena must reach orchestration.reasoning_pressure"
+
+
 def test_suppression_blocks_availability_panic_for_circe() -> None:
     from app.digestion.suppression import apply_suppression
 

--- a/tests/test_field_digestion_rules.py
+++ b/tests/test_field_digestion_rules.py
@@ -33,6 +33,53 @@ def test_decay_fades_pressure_channels() -> None:
     assert state.node_vectors["node:atlas"]["availability"] == 1.0
 
 
+def test_decay_covers_execution_and_transport_channels() -> None:
+    """Execution and transport channels must decay — previously they were omitted and pinned at 1.0."""
+    from app.digestion.decay import apply_decay
+
+    state = FieldStateV1(
+        generated_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        tick_id="tick_decay_exec",
+        node_vectors={
+            "node:athena": {
+                "execution_load": 1.0,
+                "execution_friction": 1.0,
+                "failure_pressure": 1.0,
+                "reasoning_load": 1.0,
+                "transport_pressure": 1.0,
+                "contract_pressure": 1.0,
+                "reliability_pressure": 1.0,
+                "availability": 1.0,          # must NOT decay
+                "delivery_confidence": 1.0,   # must NOT decay
+            }
+        },
+        capability_vectors={
+            "capability:orchestration": {
+                "pressure": 1.0,
+                "execution_pressure": 1.0,
+                "reliability_pressure": 1.0,
+                "confidence": 1.0,            # must NOT decay
+            }
+        },
+        edges=[],
+    )
+    apply_decay(state, decay_rate=0.92)
+    node = state.node_vectors["node:athena"]
+    cap = state.capability_vectors["capability:orchestration"]
+
+    for ch in ("execution_load", "execution_friction", "failure_pressure",
+               "reasoning_load", "transport_pressure", "contract_pressure", "reliability_pressure"):
+        assert node[ch] < 1.0, f"node channel {ch!r} should have decayed"
+
+    assert node["availability"] == 1.0, "availability must not decay"
+    assert node["delivery_confidence"] == 1.0, "delivery_confidence must not decay"
+
+    assert cap["pressure"] < 1.0, "capability pressure should decay"
+    assert cap["execution_pressure"] < 1.0, "capability execution_pressure should decay"
+    assert cap["reliability_pressure"] < 1.0, "capability reliability_pressure should decay"
+    assert cap["confidence"] == 1.0, "capability confidence must not decay"
+
+
 def test_diffusion_spreads_gpu_pressure_to_capability() -> None:
     from app.digestion.diffusion import apply_diffusion
 

--- a/tests/test_field_execution_perturbations.py
+++ b/tests/test_field_execution_perturbations.py
@@ -41,6 +41,45 @@ def test_execution_run_delta_maps_to_node_channels() -> None:
     assert perturbations[0].node_id == "node:athena"
 
 
+def test_execution_perturbations_use_replace_mode() -> None:
+    """Two consecutive execution_run deltas should not accumulate — second replaces first."""
+    delta_a = StateDeltaV1(
+        delta_id="delta_exec_a",
+        target_projection="active_execution_trajectory",
+        target_kind="execution_run",
+        target_id="cortex.exec:athena:corr-a",
+        operation="update",
+        after={"node_id": "athena", "pressure_hints": {"execution_load": 1.0, "failure_pressure": 1.0}},
+        caused_by_event_ids=["gev_a"],
+        reducer_id="execution_trajectory_reducer",
+    )
+    delta_b = StateDeltaV1(
+        delta_id="delta_exec_b",
+        target_projection="active_execution_trajectory",
+        target_kind="execution_run",
+        target_id="cortex.exec:athena:corr-b",
+        operation="update",
+        after={"node_id": "athena", "pressure_hints": {"execution_load": 0.25, "failure_pressure": 0.0}},
+        caused_by_event_ids=["gev_b"],
+        reducer_id="execution_trajectory_reducer",
+    )
+    lattice = load_lattice(LATTICE)
+    field = empty_field_state(lattice=lattice, now=FIXED_TS, tick_id="tick_replace")
+
+    # Apply first (maxed) delta then a second (low) delta in the same tick
+    all_perturbations = delta_to_perturbations(delta_a) + delta_to_perturbations(delta_b)
+    field = run_digestion_tick(field, perturbations=all_perturbations, decay_rate=1.0, diffusion_rate=1.0)
+
+    node = field.node_vectors.get("node:athena") or {}
+    # replace mode: last write wins — execution_load should be 0.25, not 1.0
+    assert node.get("execution_load") == 0.25, f"expected 0.25 got {node.get('execution_load')}"
+    assert node.get("failure_pressure") == 0.0, f"expected 0.0 got {node.get('failure_pressure')}"
+
+    # verify all execution perturbations carry replace mode
+    for p in delta_to_perturbations(delta_a):
+        assert p.mode == "replace", f"channel {p.channel} should be replace mode"
+
+
 def test_execution_perturbations_diffuse_to_orchestration_capability() -> None:
     lattice = load_lattice(LATTICE)
     delta = StateDeltaV1(


### PR DESCRIPTION
# PR: Field Lattice — Capability→Capability Edges

**Branch:** `feat/field-lattice-cap-cap-edges`  
**Base:** `fix/field-saturation-execution-replace-mode`  
**Head:** `feat/field-lattice-cap-cap-edges`

## Summary

Wires the first cross-reducer interaction effects into the field lattice. Previously the lattice was a flat fan-in: each reducer wrote to its own node channels, all fanned out independently to capabilities, and there was no way for one capability to influence another. This PR adds capability→capability edges so transport degradation can now bleed into orchestration — independently of what the execution reducer is doing.

Also fixes a dark channel: `reasoning_load` was computed by the execution reducer and written to `node:athena` but had no edge mapping it to any capability, so it contributed nothing to the field.

## What changed

### `orion/schemas/field_state.py`

Added `capability_capability` to the `edge_type` Literal on `FieldEdgeV1`. Required for the YAML loader to accept the new edge type without a validation error.

### `services/orion-field-digester/app/digestion/diffusion.py`

`apply_diffusion` previously hardcoded source lookup to `state.node_vectors`. A capability source would resolve to `{}` and silently no-op. Changed to:

```python
src = state.node_vectors.get(edge.source_id) or state.capability_vectors.get(edge.source_id, {})
```

This is the only code change required for cap→cap to work. The rest is YAML.

### `config/field/orion_field_topology.v1.yaml`

**Dark channel fix:**

```yaml
# node:athena → capability:orchestration now includes:
reasoning_load: reasoning_pressure
```

`reasoning_load` was listed in `node_channels` and written by the execution reducer but had no downstream edge. It now flows to `orchestration.reasoning_pressure`.

**New capability→capability edges:**

```yaml
- source_id: capability:transport
  target_id: capability:orchestration
  edge_type: capability_capability
  weight: 0.70
  channel_map:
    transport_pressure: transport_pressure
    contract_pressure: reliability_pressure

- source_id: capability:llm_inference
  target_id: capability:orchestration
  edge_type: capability_capability
  weight: 0.60
  channel_map:
    pressure: pressure
```

Edge count: 7 → 9.

**Signal path unlocked:**

```
transport bus reducer
  → node:athena.catalog_drift_pressure
    → (diffusion, w=0.85) capability:transport.contract_pressure
      → (diffusion, w=0.70) capability:orchestration.reliability_pressure
```

Transport degradation and contract drift now raise orchestration's reliability pressure independently of what the execution reducer reports. Two reducers can now interact through the field.

## What this does NOT change

- No changes to decay rates, diffusion rates, or suppression logic
- No new reducers or grammar extractors
- No changes to how execution or biometrics perturbations are written
- The biometrics backlog (~9,800 events, 6.5hr lag) is a separate concern

## Tests

10/10 passing. New tests:

- `test_capability_to_capability_diffusion` — verifies a cap→cap edge propagates intensity correctly
- `test_reasoning_load_diffuses_to_orchestration` — verifies `reasoning_load` on `node:athena` reaches `orchestration.reasoning_pressure` through the full lattice

## Live field state after deploy

```
edge_count: 9  (was 7)
capability:orchestration.reasoning_pressure: present, draining  (was dark)
capability:orchestration.transport_pressure: 0.0 → rises on next transport event
capability:transport → capability:orchestration: active cross-reducer path
```

## Acceptance checks

- [ ] `edge_count = 9` in `substrate_field_state`
- [ ] `capability:orchestration.reasoning_pressure` present and nonzero after an execution event
- [ ] After a transport degradation event, `orchestration.reliability_pressure` rises without a corresponding execution event
- [ ] All 10 field tests pass