### PR TITLE
fix(autonomy): route goal archive SPARQL UPDATE to /orion/update

### DIFF
--- a/orion/autonomy/goal_archive.py
+++ b/orion/autonomy/goal_archive.py
@@ -9,7 +9,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Sequence
 
 from orion.autonomy.constants import AUTONOMY_GOALS_GRAPH
-from orion.graph.backend_config import resolve_autonomy_read_query_url, resolve_graph_update_url, resolve_rdf_store_auth
+from orion.graph.backend_config import (
+    resolve_autonomy_graph_update_url,
+    resolve_autonomy_read_query_url,
+    resolve_graph_update_url,
+    resolve_rdf_store_auth,
+)
 from orion.graph.sparql_client import SparqlHttpClient
 
 logger = logging.getLogger("orion.autonomy.goal_archive")
@@ -59,7 +64,9 @@ def build_archive_candidates(
 def _resolve_graph_endpoints() -> tuple[str, str, str | None, str | None]:
     query_url, _src = resolve_autonomy_read_query_url()
     if query_url:
-        update_url = resolve_graph_update_url() or query_url
+        update_url, _usrc = resolve_autonomy_graph_update_url()
+        if not update_url:
+            update_url = resolve_graph_update_url() or query_url
         user, password = resolve_rdf_store_auth()
         return query_url, update_url, user, password
 

--- a/orion/graph/backend_config.py
+++ b/orion/graph/backend_config.py
@@ -236,6 +236,26 @@ def resolve_autonomy_read_query_url(environ: Mapping[str, str] | None = None) ->
     return None, "unconfigured"
 
 
+def resolve_autonomy_graph_update_url(environ: Mapping[str, str] | None = None) -> tuple[str | None, str]:
+    """SPARQL update URL for autonomy writes (AUTONOMY_GRAPH_UPDATE_URL wins, then RDF_STORE, then Fuseki derive)."""
+    env = dict(os.environ if environ is None else environ)
+    u = _strip(env.get("AUTONOMY_GRAPH_UPDATE_URL"))
+    if u:
+        return u, "AUTONOMY_GRAPH_UPDATE_URL"
+    u = _strip(env.get("RDF_STORE_UPDATE_URL"))
+    if u:
+        return u, "RDF_STORE_UPDATE_URL"
+    cfg = resolve_graph_backend(env)
+    if cfg.update_url and cfg.backend in {"fuseki", "sparql"}:
+        return cfg.update_url, cfg.source
+    base = _fuseki_base()
+    ds = _fuseki_dataset()
+    if _strip(env.get("RDF_STORE_BACKEND")).lower() == "fuseki" and base:
+        _, url, _, src = _derive_fuseki_urls(base, ds)
+        return url, src
+    return None, "unconfigured"
+
+
 def resolve_generic_sparql_read_query_url(environ: Mapping[str, str] | None = None) -> tuple[str | None, str]:
     """Non-autonomy reads (self-study, orionmem): RDF_STORE_QUERY_URL first, then autonomy URL, then resolver."""
     env = dict(os.environ if environ is None else environ)

--- a/orion/graph/tests/test_backend_config.py
+++ b/orion/graph/tests/test_backend_config.py
@@ -73,3 +73,13 @@ def test_autonomy_read_prefers_autonomy_query_url(monkeypatch: pytest.MonkeyPatc
     url, src = resolve_autonomy_read_query_url()
     assert url == "http://a/orion/query"
     assert src == "AUTONOMY_GRAPH_QUERY_URL"
+
+
+def test_autonomy_update_prefers_autonomy_update_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orion.graph.backend_config import resolve_autonomy_graph_update_url
+
+    monkeypatch.setenv("AUTONOMY_GRAPH_UPDATE_URL", "http://a/orion/update")
+    monkeypatch.setenv("RDF_STORE_UPDATE_URL", "http://b/orion/update")
+    url, src = resolve_autonomy_graph_update_url()
+    assert url == "http://a/orion/update"
+    assert src == "AUTONOMY_GRAPH_UPDATE_URL"

--- a/services/orion-actions/.env_example
+++ b/services/orion-actions/.env_example
@@ -1,4 +1,5 @@
 # orion-actions (v1)
+# PROJECT and NET: repo root .env (pass with --env-file ../../.env when composing)
 SERVICE_NAME=actions
 SERVICE_VERSION=0.1.0
 NODE_NAME=athena
@@ -77,7 +78,7 @@ AUTONOMY_GOAL_ARCHIVE_BOOTSTRAP_MAX_ROUNDS=30
 AUTONOMY_GOAL_RETENTION_DAYS=30
 AUTONOMY_GOAL_MAX_ACTIVE_PER_SUBJECT=3
 AUTONOMY_GOAL_ARCHIVE_MAX_UPDATES=200
-# Required for archive SPARQL (mirror cortex-exec / spark Fuseki endpoints)
+# Both URLs required — archive reads via QUERY, writes via UPDATE (not /query).
 AUTONOMY_GRAPH_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
 AUTONOMY_GRAPH_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
 AUTONOMY_GRAPH_TIMEOUT_SEC=30


### PR DESCRIPTION
Branch is pushed; `gh` isn’t authenticated here so the PR wasn’t created automatically.

**Branch:** `fix/autonomy-goal-archive-update-url`  
**Open PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/autonomy-goal-archive-update-url

---

**Title:** `fix(autonomy): route goal archive SPARQL UPDATE to /orion/update`

**Description:**

## Summary

- **Root cause:** `goal_archive` resolved the read URL via `resolve_autonomy_read_query_url()` but fell back to `resolve_graph_update_url()` for writes, ignoring `AUTONOMY_GRAPH_UPDATE_URL`. SPARQL UPDATE was sent to `/orion/query` → **415 Unsupported Media Type**, so the orion-actions nightly archive scheduler never archived goals (`applied=0` every run).
- **Fix:** Add `resolve_autonomy_graph_update_url()` (mirrors the read resolver) and use it in `goal_archive._resolve_graph_endpoints()`.
- **Ops:** Clarify in `services/orion-actions/.env_example` that both query and update URLs are required; `PROJECT`/`NET` stay in repo root `.env`.

## Impact

- Unblocks the ~220k `ProposedGoal` backlog drain in `orion-athena-actions`.
- Grounded Small chat stance queries should improve as archived goals accumulate (heavy goals SPARQL dropped from ~76s → ~6s in live probe after partial archive).
- **Rebuild required:** `orion-actions` only.

## Test plan

- [x] `PYTHONPATH=. ./orion_dev/bin/python -m pytest orion/graph/tests/test_backend_config.py -q` — 8 passed
- [ ] Rebuild/restart `orion-actions` and confirm logs show `applied=200` (not 415) per archive round
- [ ] Optional: time stance goals SPARQL before/after archive drain; Grounded Small chat latency

---

**Files in commit (4):**
- `orion/graph/backend_config.py`
- `orion/autonomy/goal_archive.py`
- `orion/graph/tests/test_backend_config.py`
- `services/orion-actions/.env_example`

Run `gh auth login` locally if you want `gh pr create` to work from this machine next time.