### PR TITLE
Fix cortex-exec lane port inheritance and mesh-guardian bring-up.

### DIFF
--- a/docs/superpowers/plans/2026-06-18-mesh-bus-resilience-implementation.md
+++ b/docs/superpowers/plans/2026-06-18-mesh-bus-resilience-implementation.md
@@ -794,7 +794,7 @@ services:
       service_name: orion-equilibrium-service
 ```
 
-**Port verification before commit:** cross-check every `ready_url` against the service's `docker-compose.yml` and `.env_example` (known values: gateway `8022`, orch `8072`, exec `8070`, landing-pad `8370`, recall `8260`, llm-gateway `8210`). Equilibrium is bus-only (no HTTP); guardian observes it via equilibrium snapshot layer only — set `probe.mode: redis` with empty channels so active probe is a no-op and equilibrium layer drives status.
+**Port verification before commit:** cross-check every `ready_url` against the service's `docker-compose.yml` and `.env_example` (known values: gateway `8022`, orch `8072`, exec `8070`, landing-pad `8370`, recall `8260`, llm-gateway `8210`, mesh-guardian `7161` — `orion-actions` owns `7160`). Equilibrium is bus-only (no HTTP); guardian observes it via equilibrium snapshot layer only — set `probe.mode: redis` with empty channels so active probe is a no-op and equilibrium layer drives status.
 
 - [ ] **Step 2: Commit**
 
@@ -878,7 +878,7 @@ def health() -> dict:
     }
 ```
 
-- [ ] **Step 2: Dockerfile** (copy pattern from `services/orion-notify-digest/Dockerfile`; port 7160; COPY `orion/`)
+- [ ] **Step 2: Dockerfile** (copy pattern from `services/orion-notify-digest/Dockerfile`; port 7161; COPY `orion/`)
 
 - [ ] **Step 3: docker-compose.yml** (from design spec — `app-net`, docker.sock, `/repo:ro`, env vars)
 
@@ -1402,8 +1402,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-curl -sf "http://${PROJECT:-orion}-mesh-guardian:7160/health" | jq -e '.ok == true'
-curl -sf "http://${PROJECT:-orion}-mesh-guardian:7160/ready" || true  # may 503 before bus connect
+curl -sf "http://${PROJECT:-orion}-mesh-guardian:7161/health" | jq -e '.ok == true'
+curl -sf "http://${PROJECT:-orion}-mesh-guardian:7161/ready" || true  # may 503 before bus connect
 
 PYTHONPATH=. ./orion_dev/bin/python -m pytest \
   services/orion-mesh-guardian/tests/test_state_machine.py \

--- a/scripts/smoke_mesh_guardian.sh
+++ b/scripts/smoke_mesh_guardian.sh
@@ -17,8 +17,8 @@ else
 fi
 
 if command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
-  curl -sf "http://${PROJECT:-orion}-mesh-guardian:7160/health" | jq -e '.ok == true' || true
-  curl -sf "http://${PROJECT:-orion}-mesh-guardian:7160/ready" || true
+  curl -sf "http://${PROJECT:-orion}-mesh-guardian:7161/health" | jq -e '.ok == true' || true
+  curl -sf "http://${PROJECT:-orion}-mesh-guardian:7161/ready" || true
 fi
 
 PYTHONPATH=.:services/orion-mesh-guardian "${PY}" -m pytest \

--- a/services/orion-cortex-exec/docker-compose.yml
+++ b/services/orion-cortex-exec/docker-compose.yml
@@ -195,6 +195,7 @@ services:
     extends:
       service: cortex-exec
     container_name: ${PROJECT}-cortex-exec-chat
+    ports: !override []
     environment:
       EXEC_LANE: chat
       CHANNEL_EXEC_REQUEST: orion:cortex:exec:request:chat
@@ -203,6 +204,7 @@ services:
     extends:
       service: cortex-exec
     container_name: ${PROJECT}-cortex-exec-spark
+    ports: !override []
     environment:
       EXEC_LANE: spark
       CHANNEL_EXEC_REQUEST: orion:cortex:exec:request:spark
@@ -211,6 +213,7 @@ services:
     extends:
       service: cortex-exec
     container_name: ${PROJECT}-cortex-exec-background
+    ports: !override []
     environment:
       EXEC_LANE: background
       CHANNEL_EXEC_REQUEST: orion:cortex:exec:request:background

--- a/services/orion-mesh-guardian/.env_example
+++ b/services/orion-mesh-guardian/.env_example
@@ -1,11 +1,12 @@
-PROJECT=orion-athena
-NODE_NAME=athena
+#PROJECT=orion-athena
+#NODE_NAME=athena
 
 SERVICE_NAME=orion-mesh-guardian
 SERVICE_VERSION=0.1.0
-PORT=7160
+PORT=7161
 
 ORION_REPO_ROOT=/mnt/scripts/Orion-Sapienform
+# Mesh bus (same as repo root .env); compose passes ${ORION_BUS_URL} when brought up with --env-file ../../.env
 ORION_BUS_URL=redis://100.92.216.81:6379/0
 
 NOTIFY_BASE_URL=http://orion-athena-notify:7140

--- a/services/orion-mesh-guardian/Dockerfile
+++ b/services/orion-mesh-guardian/Dockerfile
@@ -16,6 +16,6 @@ COPY services/orion-mesh-guardian/app ./app
 COPY orion ./orion
 COPY config ./config
 
-EXPOSE 7160
+EXPOSE 7161
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "7160"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "7161"]

--- a/services/orion-mesh-guardian/app/service.py
+++ b/services/orion-mesh-guardian/app/service.py
@@ -44,7 +44,7 @@ class MeshGuardianService:
         roster_errors = validate_roster(self.roster)
         if roster_errors:
             raise ValueError("invalid mesh guardian roster: " + "; ".join(roster_errors))
-        await self.bus.connect()
+        await self._connect_bus_with_retry()
         if self.bus.redis is not None:
             self.states = await load_all(self.bus.redis)
         for entry in self.roster.services:
@@ -66,6 +66,34 @@ class MeshGuardianService:
 
     def equilibrium_subscriber_alive(self) -> bool:
         return self._equilibrium_task_alive
+
+    async def _connect_bus_with_retry(
+        self,
+        *,
+        max_wait_sec: float = 60.0,
+        initial_backoff_sec: float = 1.0,
+    ) -> None:
+        """Connect to mesh Redis; retry through transient bring-up races (batched compose up)."""
+        deadline = time.monotonic() + max_wait_sec
+        backoff = initial_backoff_sec
+        while True:
+            try:
+                await self.bus.connect()
+                return
+            except Exception as exc:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise
+                wait = min(backoff, remaining)
+                logger.warning(
+                    "mesh guardian bus connect failed url=%s err=%s; retry in %.1fs",
+                    self.settings.orion_bus_url,
+                    exc,
+                    wait,
+                )
+                await self.bus.close()
+                await asyncio.sleep(wait)
+                backoff = min(backoff * 2.0, 15.0)
 
     async def _equilibrium_loop(self) -> None:
         self._equilibrium_task_alive = True

--- a/services/orion-mesh-guardian/app/settings.py
+++ b/services/orion-mesh-guardian/app/settings.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     consecutive_probe_fails: int = Field(2, alias="MESH_GUARDIAN_CONSECUTIVE_PROBE_FAILS")
     equilibrium_grace_sec: int = Field(30, alias="MESH_GUARDIAN_EQUILIBRIUM_GRACE_SEC")
     channel_equilibrium_snapshot: str = Field("orion:equilibrium:snapshot", alias="CHANNEL_EQUILIBRIUM_SNAPSHOT")
-    health_http_port: int = Field(7160, alias="PORT")
+    health_http_port: int = Field(7161, alias="PORT")
 
     class Config:
         env_file = ".env"

--- a/services/orion-mesh-guardian/docker-compose.yml
+++ b/services/orion-mesh-guardian/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - .env
     ports:
-      - "${PORT:-7160}:${PORT:-7160}"
+      - "${PORT:-7161}:${PORT:-7161}"
     volumes:
       - ${ORION_REPO_ROOT:-../..}:/repo:ro
       - ${DOCKER_SOCK_PATH:-/var/run/docker.sock}:/var/run/docker.sock
@@ -17,7 +17,7 @@ services:
       NODE_NAME: ${NODE_NAME}
       SERVICE_NAME: ${SERVICE_NAME:-orion-mesh-guardian}
       SERVICE_VERSION: ${SERVICE_VERSION:-0.1.0}
-      PORT: ${PORT:-7160}
+      PORT: ${PORT:-7161}
       ORION_REPO_ROOT: /repo
       ORION_BUS_URL: ${ORION_BUS_URL}
       NOTIFY_BASE_URL: ${NOTIFY_BASE_URL:-http://${PROJECT}-notify:7140}

--- a/services/orion-mesh-guardian/tests/test_bus_connect_retry.py
+++ b/services/orion-mesh-guardian/tests/test_bus_connect_retry.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.service import MeshGuardianService
+from app.settings import Settings
+
+
+@pytest.mark.asyncio
+async def test_connect_bus_with_retry_recovers_after_transient_failure() -> None:
+    service = MeshGuardianService(Settings())
+    attempts = 0
+
+    async def _flaky_connect() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise ConnectionError("Network is unreachable")
+
+    service.bus.connect = AsyncMock(side_effect=_flaky_connect)
+    service.bus.close = AsyncMock()
+
+    await service._connect_bus_with_retry(max_wait_sec=10.0, initial_backoff_sec=0.01)
+
+    assert attempts == 3
+    assert service.bus.close.await_count == 2


### PR DESCRIPTION
Branch **`fix/cortex-exec-guardian-compose`** is pushed to origin. `gh` isn't authenticated here, so open the PR manually:

**https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/cortex-exec-guardian-compose**

---

**Title:** Fix cortex-exec lane ports and mesh-guardian bring-up

**Body:**

## Summary
- **cortex-exec:** lane replicas (`chat`, `spark`, `background`) use `ports: !override []` so they no longer inherit host `8070` from the base service via `extends` (fixes `Bind for 0.0.0.0:8070 failed: port is already allocated` on full compose up).
- **mesh-guardian:** retry mesh Redis connect on startup with backoff (handles transient `Network is unreachable` during batched bring-up while keeping root `ORION_BUS_URL`).
- **mesh-guardian:** move HTTP port to **7161** to avoid collision with `orion-actions` on **7160**; update smoke script and implementation plan.

## Test plan
- [x] `docker compose config` — only primary `cortex-exec` publishes `8070`
- [x] `docker compose up -d` (cortex-exec stack) — all four lane containers start without port conflict
- [x] `curl http://127.0.0.1:8070/ready` on primary cortex-exec — `ok: true`
- [x] `docker compose run mesh-guardian` ping to mesh `ORION_BUS_URL` — `ping True`
- [x] `docker compose up -d --build mesh-guardian` — binds `7161`, `/health` returns ok
- [x] `pytest services/orion-mesh-guardian/tests/test_bus_connect_retry.py services/orion-mesh-guardian/tests/test_health.py` — pass

---

**Commit:** `0aa01406` — 9 files, excludes unrelated local edits in `orion/substrate/execution_loop/merge.py` and `tests/test_execution_substrate_reducer.py`.