### PR TITLE
Fix mesh health noise: landing-pad /ready crash and duplicate guardia…

### DIFF
--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -5483,6 +5483,11 @@ loadDismissedIds();
     return notification && notification.event_kind === ATTENTION_EVENT_KIND;
   }
 
+  function isNotificationTrayItem(notification) {
+    // Attention requests have their own Pending Attention panel; keep them out of the general tray.
+    return notification && !isAttentionNotification(notification);
+  }
+
   function normalizeAttentionItem(notification) {
     if (!notification) return null;
     return {
@@ -6457,7 +6462,9 @@ loadDismissedIds();
     const filter = notificationFilter ? notificationFilter.value : 'all';
     notificationList.innerHTML = '';
     const filtered = sortedNotificationsForTray(notifications).filter(
-      (n) => filter === 'all' || (n.severity || '').toLowerCase() === filter
+      (n) =>
+        isNotificationTrayItem(n) &&
+        (filter === 'all' || (n.severity || '').toLowerCase() === filter)
     );
 
     if (filtered.length === 0) {

--- a/services/orion-landing-pad/app/main.py
+++ b/services/orion-landing-pad/app/main.py
@@ -71,7 +71,7 @@ async def ready() -> JSONResponse:
         redis,
         intake_channel=service.settings.pad_rpc_request_channel,
         service_name=service.settings.app_name,
-        health_channel=service.settings.orion_health_channel,
+        health_channel=service.settings.health_channel,
         heartbeat_ttl_sec=float(service.settings.heartbeat_interval_sec) * 3.0,
         check_heartbeat=True,
         rpc_smoke_fn=_rpc_smoke,

--- a/services/orion-landing-pad/tests/test_ready.py
+++ b/services/orion-landing-pad/tests/test_ready.py
@@ -51,7 +51,7 @@ def test_ready_200_when_consumer_ready(client: TestClient) -> None:
         mock_service.bus = MagicMock(enabled=True, redis=fake_redis)
         mock_service.settings.pad_rpc_request_channel = "orion:pad:rpc:request"
         mock_service.settings.app_name = "landing-pad"
-        mock_service.settings.orion_health_channel = "orion:system:health"
+        mock_service.settings.health_channel = "orion:system:health"
         mock_service.settings.heartbeat_interval_sec = 10
         mock_service.rpc._task = rpc_task
         mock_v1.return_value = MagicMock(ok=True, model_dump=lambda mode: {"ok": True})

--- a/services/orion-mesh-guardian/app/state_machine.py
+++ b/services/orion-mesh-guardian/app/state_machine.py
@@ -160,6 +160,22 @@ def transition(state: ServiceState, inp: TransitionInput, *, service_id: str = "
         if not confirmed:
             return TransitionOutput(new_state=new_state, attention_events=attention_events)
 
+        if not inp.auto_remediate:
+            new_state.phase = ServicePhase.attention_only
+            attention_events.append(
+                _attention_event(
+                    severity="error",
+                    message=(
+                        f"mesh health: {service_id} unhealthy confirmed "
+                        f"(observe-only, auto_remediate disabled)"
+                    ),
+                    service_id=service_id,
+                    correlation_id=corr,
+                    event="observe_only",
+                )
+            )
+            return TransitionOutput(new_state=new_state, attention_events=attention_events)
+
         new_state.phase = ServicePhase.unhealthy_confirmed
         attention_events.append(
             _attention_event(

--- a/services/orion-mesh-guardian/tests/test_state_machine.py
+++ b/services/orion-mesh-guardian/tests/test_state_machine.py
@@ -48,6 +48,18 @@ def test_unhealthy_confirmed_auto_remediate_tier1() -> None:
     assert out.new_state.phase == ServicePhase.remediating_tier1
 
 
+def test_suspect_confirmed_observe_only_skips_unhealthy_confirmed_phase() -> None:
+    state = ServiceState(phase=ServicePhase.suspect, consecutive_probe_fails=1)
+    out = transition(
+        state,
+        _inp(equilibrium_bad=True, probe_status="probe_bad", auto_remediate=False),
+        service_id="landing-pad",
+    )
+    assert out.new_state.phase == ServicePhase.attention_only
+    assert len(out.attention_events) == 1
+    assert "observe-only" in out.attention_events[0]["message"]
+
+
 def test_unhealthy_confirmed_observe_only_without_auto_remediate() -> None:
     state = ServiceState(phase=ServicePhase.unhealthy_confirmed)
     out = transition(state, _inp(probe_status="probe_bad", auto_remediate=False), service_id="landing-pad")


### PR DESCRIPTION
## Summary

Hub was showing duplicate mesh-health alerts: mesh-guardian `attention_request` events appeared in **Pending Attention** and again in **Notifications**. Separately, landing-pad `/ready` was returning **500** on every probe because it referenced a nonexistent settings field, which made mesh-guardian flag landing-pad as unhealthy even when the service was otherwise fine.

This PR fixes three things:

1. **landing-pad `/ready` crash** — use `settings.health_channel` instead of the nonexistent `orion_health_channel`.
2. **Duplicate guardian alerts in observe-only mode** — when `MESH_GUARDIAN_AUTO_REMEDIATE=false`, emit one combined alert (`unhealthy confirmed (observe-only, auto_remediate disabled)`) instead of paired `unhealthy confirmed` + `observe-only` events on consecutive ticks.
3. **Hub UI dedupe** — exclude `orion.chat.attention` from the Notifications panel; those items already render in Pending Attention with ack actions.

## Context

Mesh-guardian watches roster services and raises `attention_request` notifications via orion-notify. Hub treats those as `orion.chat.attention` and was rendering them in both panels. landing-pad probes were failing with:

```
AttributeError: 'Settings' object has no attribute 'orion_health_channel'. Did you mean: 'health_channel'?
```

That unhandled exception surfaced as HTTP 500, not a proper readiness response.

## Changes

| Area | Change |
|------|--------|
| `orion-landing-pad` | `/ready` passes `health_channel` to `check_bus_consumer_readiness` |
| `orion-mesh-guardian` | Observe-only path skips `unhealthy_confirmed` intermediate phase; single attention event on first confirmation |
| `orion-hub` | `isNotificationTrayItem()` filters attention events out of Notifications tray |

## Test plan

- [x] `PYTHONPATH=services/orion-landing-pad:. ./venv/bin/python -m pytest services/orion-landing-pad/tests/test_ready.py -q` — 2 passed
- [x] `cd services/orion-mesh-guardian && PYTHONPATH=. ../../venv/bin/python -m pytest tests/test_state_machine.py -q` — 11 passed
- [x] `node --check services/orion-hub/static/js/app.js`
- [ ] Rebuild/restart `orion-landing-pad`; `curl /ready` returns JSON with 503 or 200 (not 500)
- [ ] Rebuild/restart `mesh-guardian`; one alert per unhealthy service in observe-only mode
- [ ] Hard-refresh Hub; attention items only in Pending Attention, not Notifications
- [ ] Dismiss any stale pre-fix attention items still in the queue

## Deploy notes

After merge, rebuild affected containers:

```bash
docker compose --env-file .env --env-file services/orion-landing-pad/.env \
  -f services/orion-landing-pad/docker-compose.yml up -d --build orion-landing-pad

docker compose --env-file .env --env-file services/orion-mesh-guardian/.env \
  -f services/orion-mesh-guardian/docker-compose.yml up -d --build mesh-guardian
```

Hub needs a hard refresh (or container restart) to pick up `app.js`.

**PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/mesh-health-attention-noise