### PR TITLE
Feat/hub pending attention timestamp

### DIFF
--- a/services/orion-actions/.env_example
+++ b/services/orion-actions/.env_example
@@ -70,7 +70,8 @@ ACTIONS_DAILY_METACOG_HOUR_LOCAL=20
 ACTIONS_DAILY_METACOG_MINUTE_LOCAL=15
 
 # Nightly autonomy goal graph archive (orion-actions scheduler loop, same cadence as daily pulse/metacog — not host crontab)
-ACTIONS_DAILY_GOAL_ARCHIVE_ENABLED=true
+# false while autonomy graph reads disabled (no nightly Fuseki goal-archive churn).
+ACTIONS_DAILY_GOAL_ARCHIVE_ENABLED=false
 # First scheduler tick after deploy/restart: drain backlog (no host script). Nightly 03:15 = maintenance pass.
 ACTIONS_DAILY_GOAL_ARCHIVE_RUN_ON_STARTUP=true
 ACTIONS_DAILY_GOAL_ARCHIVE_HOUR_LOCAL=3

--- a/services/orion-cortex-exec/.env_example
+++ b/services/orion-cortex-exec/.env_example
@@ -157,9 +157,10 @@ GDB_CLIENT_ENABLED=false
 
 # Autonomy graph reads (Fuseki / SPARQL): default auto resolves from AUTONOMY_GRAPH_QUERY_URL, RDF_STORE_QUERY_URL, or RDF_STORE_BACKEND=fuseki + RDF_STORE_BASE_URL.
 # Legacy GraphDB: AUTONOMY_GRAPH_BACKEND=graphdb + GRAPHDB_URL / CONCEPT_PROFILE_GRAPHDB_*.
-AUTONOMY_GRAPH_BACKEND=auto
-AUTONOMY_GRAPH_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
-AUTONOMY_GRAPH_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
+# disabled = chat stance skips SPARQL (LocalAutonomyRepository + identity YAML); no Fuseki fan-out on brain lanes.
+AUTONOMY_GRAPH_BACKEND=disabled
+AUTONOMY_GRAPH_QUERY_URL=
+AUTONOMY_GRAPH_UPDATE_URL=
 RDF_STORE_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
 RDF_STORE_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
 RDF_STORE_GRAPH_STORE_URL=http://orion-athena-fuseki:3030/orion/data
@@ -173,9 +174,10 @@ RDF_STORE_USER=admin
 RDF_STORE_PASS=orion
 
 # --- Substrate durable semantic graph (materializer / exec substrate reads) ---
+# in_memory = unified-beliefs cold fan-out stays local (no self_study/orionmem SPARQL on chat stance).
 # Fuseki-backed when SUBSTRATE_STORE_BACKEND=sparql. If SUBSTRATE_GRAPH_QUERY_URL / SUBSTRATE_GRAPH_UPDATE_URL
 # are unset, the builder uses RDF_STORE_QUERY_URL / RDF_STORE_UPDATE_URL.
-SUBSTRATE_STORE_BACKEND=sparql
+SUBSTRATE_STORE_BACKEND=in_memory
 SUBSTRATE_GRAPH_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
 SUBSTRATE_GRAPH_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
 SUBSTRATE_GRAPH_URI=http://conjourney.net/graph/substrate
@@ -219,6 +221,8 @@ AUTONOMY_CHAT_STANCE_DRIVES_QUERY_LIMIT=20
 AUTONOMY_CHAT_STANCE_SHORT_CIRCUIT=true
 # list_latest observer consumer names that may honor bounded fan-out (see orion.autonomy.fanout_policy). Omitted variable uses code default (chat_stance,autonomy_ctx_adapter).
 AUTONOMY_SHORT_CIRCUIT_CONSUMERS=chat_stance,autonomy_ctx_adapter
+# Self-study SPARQL (unified-beliefs producer); leave empty to skip Fuseki on chat stance.
+SELF_STUDY_NAMED_GRAPH=
 # Chat stance: optional SPARQL disposition hints from memory named graphs (comma-separated IRIs)
 CHAT_STANCE_MEMORY_GRAPH_GRAPHS=
 CHAT_STANCE_MEMORY_GRAPH_TIMEOUT_SEC=2.0

--- a/services/orion-cortex-exec/app/main.py
+++ b/services/orion-cortex-exec/app/main.py
@@ -293,6 +293,12 @@ def _resolve_autonomy_backend() -> str:
 
 
 def _run_autonomy_graph_probe() -> None:
+    from orion.autonomy.graph_gate import autonomy_graph_backend_raw
+
+    if autonomy_graph_backend_raw() == "disabled":
+        logger.info("autonomy_graph_probe skipped reason=autonomy_graph_backend_disabled")
+        return
+
     backend = _resolve_autonomy_backend()
     if backend != "graph":
         return

--- a/services/orion-cortex-exec/docker-compose.yml
+++ b/services/orion-cortex-exec/docker-compose.yml
@@ -167,8 +167,8 @@ services:
       FUSEKI_USER: ${FUSEKI_USER:-}
       FUSEKI_PASS: ${FUSEKI_PASS:-}
       GDB_CLIENT_ENABLED: ${GDB_CLIENT_ENABLED:-false}
-      AUTONOMY_GRAPH_QUERY_URL: ${AUTONOMY_GRAPH_QUERY_URL:-http://orion-athena-fuseki:3030/orion/query}
-      AUTONOMY_GRAPH_UPDATE_URL: ${AUTONOMY_GRAPH_UPDATE_URL:-http://orion-athena-fuseki:3030/orion/update}
+      AUTONOMY_GRAPH_QUERY_URL: ${AUTONOMY_GRAPH_QUERY_URL-http://orion-athena-fuseki:3030/orion/query}
+      AUTONOMY_GRAPH_UPDATE_URL: ${AUTONOMY_GRAPH_UPDATE_URL-http://orion-athena-fuseki:3030/orion/update}
       SUBSTRATE_STORE_BACKEND: ${SUBSTRATE_STORE_BACKEND:-sparql}
       SUBSTRATE_GRAPH_QUERY_URL: ${SUBSTRATE_GRAPH_QUERY_URL:-http://orion-athena-fuseki:3030/orion/query}
       SUBSTRATE_GRAPH_UPDATE_URL: ${SUBSTRATE_GRAPH_UPDATE_URL:-http://orion-athena-fuseki:3030/orion/update}

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -5546,6 +5546,12 @@ loadDismissedIds();
       header.appendChild(title);
       header.appendChild(badge);
 
+      const meta = document.createElement('div');
+      meta.className = 'text-[10px] text-gray-400';
+      const createdAt = item.created_at ? new Date(item.created_at).toLocaleString() : null;
+      const source = item.source_service || 'unknown';
+      meta.textContent = createdAt ? `${createdAt} • ${source}` : source;
+
       const body = document.createElement('div');
       body.className = 'text-[11px] text-gray-300 whitespace-pre-wrap';
       body.textContent = item.message || '';
@@ -5575,6 +5581,7 @@ loadDismissedIds();
       actions.appendChild(snoozeBtn);
 
       card.appendChild(header);
+      card.appendChild(meta);
       card.appendChild(body);
       card.appendChild(actions);
       attentionList.appendChild(card);

--- a/services/orion-rdf-writer/.env_example
+++ b/services/orion-rdf-writer/.env_example
@@ -116,7 +116,8 @@ FUSEKI_JVM_ARGS=-Xms${FUSEKI_JVM_XMS} -Xmx${FUSEKI_JVM_XMX} ${FUSEKI_JVM_GC_OPTS
 
 # --- Runtime ---
 LOG_LEVEL=INFO
-RDF_SKIP_KINDS=chat.history.message.v1
+# Skip autonomy theater materialization (drives/goals/identity snapshots) while chat stance graph reads are off.
+RDF_SKIP_KINDS=chat.history.message.v1,memory.identity.snapshot.v1,memory.drives.audit.v1,memory.goals.proposed.v1
 RDF_SKIP_REJECTED=true
 RDF_DURABLE_ONLY=false
 

--- a/services/orion-spark-concept-induction/.env_example
+++ b/services/orion-spark-concept-induction/.env_example
@@ -76,7 +76,8 @@ CONCEPT_PROFILE_PARITY_CRITICAL_MISMATCH_CLASSES=profile_missing_on_graph,profil
 CONCEPT_PROFILE_PARITY_SUMMARY_INTERVAL=25
 
 # Autonomy goal graph hygiene (orion.autonomy.goal_archive; nightly via orion-actions when enabled there)
-AUTONOMY_GOAL_ARCHIVE_ENABLED=true
+# false while autonomy graph reads disabled (post-publish trim hits Fuseki).
+AUTONOMY_GOAL_ARCHIVE_ENABLED=false
 AUTONOMY_GOAL_ARCHIVE_MAX_UPDATES_PER_TICK=25
 AUTONOMY_GOAL_ARCHIVE_SUBJECTS=orion,relationship
 AUTONOMY_GOAL_RETENTION_DAYS=30


### PR DESCRIPTION
## Summary

- **Hub:** Pending attention cards show `created_at` and `source_service` so operators can spot stale mesh-health alerts vs fresh ones (API already returned the fields; UI did not render them).
- **Ops / chat latency:** Turn off autonomy Fuseki dependency on the chat-stance path by default — no SPARQL fan-out for drives/goals/identity on brain lanes, no startup graph probe, no nightly goal-archive churn, no RDF materialization of autonomy theater artifacts.

## Motivation

Grounded Small (`chat_general` + `mode=brain`) was paying a heavy Fuseki tax for autonomy graphs that are mostly self-referential math + template text, not actionable cognition. Quick lane was already graph-free; this makes the default operator stack match that posture until autonomy graphs are worth re-enabling.

## Changes

### Hub (`7afb2e73`)
- `services/orion-hub/static/js/app.js` — render `created_at • source_service` under each pending attention card header.

### Autonomy / Fuseki off (`e9b233e9`)

| Service | Knob | Effect |
|---------|------|--------|
| **orion-cortex-exec** | `AUTONOMY_GRAPH_BACKEND=disabled` | Chat stance uses `LocalAutonomyRepository` + identity YAML; no autonomy SPARQL |
| **orion-cortex-exec** | `SUBSTRATE_STORE_BACKEND=in_memory` | Unified-beliefs cold fan-out skips self_study/orionmem SPARQL |
| **orion-cortex-exec** | `SELF_STUDY_NAMED_GRAPH=` | No self-study graph reads on stance path |
| **orion-cortex-exec** | `main.py` | Skip `autonomy_graph_probe` when backend is `disabled` |
| **orion-cortex-exec** | `docker-compose.yml` | `${VAR-default}` (not `:-`) so empty `AUTONOMY_GRAPH_QUERY_URL` is honored |
| **orion-rdf-writer** | `RDF_SKIP_KINDS` + autonomy snapshot kinds | Stop materializing identity/drive/goal artifacts |
| **orion-actions** | `ACTIONS_DAILY_GOAL_ARCHIVE_ENABLED=false` | No nightly Fuseki goal-archive loop |
| **orion-spark-concept-induction** | `AUTONOMY_GOAL_ARCHIVE_ENABLED=false` | No post-publish Fuseki trim |

`.env_example` only (gitignored `.env` synced locally on operator host).

## What still runs

- Chat replies via identity YAML, social/recall/metacog (unchanged).
- Concept-induction still publishes drive/goal **bus** events; rdf-writer now skips writing them to Fuseki.
- Fuseki remains available for memory graph approve, recall, and other non-autonomy paths.

## Re-enable checklist (later)

1. `AUTONOMY_GRAPH_BACKEND=auto` + restore `AUTONOMY_GRAPH_*_URL`
2. `SUBSTRATE_STORE_BACKEND=sparql`
3. `ACTIONS_DAILY_GOAL_ARCHIVE_ENABLED=true`, `AUTONOMY_GOAL_ARCHIVE_ENABLED=true`
4. Trim autonomy kinds from `RDF_SKIP_KINDS`
5. Recreate affected containers

## Test plan

- [ ] Hub → Pending Attention: cards show timestamp + source (e.g. `6/19/2026, … • orion-landing-pad`)
- [ ] Grounded Small chat turn: no multi-second goals/drives SPARQL in `orion-athena-cortex-exec` logs
- [ ] Cortex-exec startup log: `autonomy_graph_probe skipped reason=autonomy_graph_backend_disabled`
- [ ] `docker exec orion-athena-cortex-exec printenv AUTONOMY_GRAPH_BACKEND SUBSTRATE_STORE_BACKEND` → `disabled` / `in_memory`
- [ ] `docker exec orion-athena-rdf-writer printenv RDF_SKIP_KINDS` includes autonomy snapshot kinds
- [ ] Quick lane still fast (unchanged path)

## Verification (operator host)

```bash
docker exec orion-athena-cortex-exec printenv AUTONOMY_GRAPH_BACKEND SUBSTRATE_STORE_BACKEND
docker logs orion-athena-cortex-exec 2>&1 | rg 'autonomy_graph_probe'
docker exec orion-athena-actions printenv ACTIONS_DAILY_GOAL_ARCHIVE_ENABLED
docker exec orion-athena-spark-concept-induction printenv AUTONOMY_GOAL_ARCHIVE_ENABLED