### PR TITLE
Fix landing-pad /ready flapping by disabling pubsub heartbeat gate.

### DIFF
--- a/services/orion-landing-pad/app/main.py
+++ b/services/orion-landing-pad/app/main.py
@@ -71,9 +71,8 @@ async def ready() -> JSONResponse:
         redis,
         intake_channel=service.settings.pad_rpc_request_channel,
         service_name=service.settings.app_name,
-        health_channel=service.settings.health_channel,
         heartbeat_ttl_sec=float(service.settings.heartbeat_interval_sec) * 3.0,
-        check_heartbeat=True,
+        check_heartbeat=False,
         rpc_smoke_fn=_rpc_smoke,
     )
     body = bus_consumer_readiness_v1(result, http_alive=True)


### PR DESCRIPTION
## Summary

- Disable the pubsub heartbeat gate on landing-pad `/ready` so readiness matches the other mesh services.
- The earlier `health_channel` fix stopped the **500** crash; this PR stops **503 flapping** caused by a race in `check_heartbeat_fresh`.

## Problem

After the settings-field fix, landing-pad `/ready` still failed most probes:

```json
{"ok":false,"heartbeat_fresh":false,"bus_consumer_ready":true,"rpc_smoke_ok":true,...}
```

Root cause: landing-pad was the **only** mesh roster service with `check_heartbeat=True`. That check subscribes to `orion:system:health` and listens for only **1.5s**, while heartbeats publish every **10s** — so probes catch a heartbeat roughly **15%** of the time.

Measured locally: **2/15** probes returned `ok=true` before this change; **10/10** after.

Peers already gate on bus subscriber + RPC smoke only:

| Service | `check_heartbeat` |
|---------|-------------------|
| llm-gateway | `False` |
| cortex-exec | `False` |
| cortex-gateway | `False` |
| recall | `False` |
| **landing-pad** | `True` ← this PR fixes |

## Change

Set `check_heartbeat=False` on landing-pad `/ready` and drop the unused `health_channel` argument. Heartbeats still publish for equilibrium/telemetry; they are just no longer used as a probabilistic `/ready` gate.

## Test plan

- [x] `PYTHONPATH=services/orion-landing-pad:. ./venv/bin/python -m pytest services/orion-landing-pad/tests/test_ready.py -q` — 2 passed
- [x] Rebuild `orion-landing-pad`; 10 consecutive `curl /ready` → all `ok=true`, `rpc_smoke_ok=true`
- [ ] Merge + deploy; mesh-guardian stops flagging landing-pad on next probe cycle
- [ ] Dismiss stale landing-pad attention items in Hub

## Deploy

```bash
docker compose --env-file .env --env-file services/orion-landing-pad/.env \
  -f services/orion-landing-pad/docker-compose.yml up -d --build orion-landing-pad
```

**PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/landing-pad-ready-heartbeat