### PR TITLE
Worktree feat+substrate signal bridge v1

### DIFF
--- a/docs/superpowers/pr-reports/2026-06-19-substrate-signal-bridge-v1-pr.md
+++ b/docs/superpowers/pr-reports/2026-06-19-substrate-signal-bridge-v1-pr.md
@@ -1,0 +1,85 @@
+# PR: Substrate Signal Bridge V1
+
+**Branch:** `worktree-feat+substrate-signal-bridge-v1`  
+**Base:** `main`  
+**Worktree:** `/mnt/scripts/Orion-Sapienform/.claude/worktrees/feat+substrate-signal-bridge-v1`  
+**Head:** `1618043e` (5 commits)
+
+## Summary
+
+Bridges existing `OrionSignalV1` records produced by `CognitionTraceAdapter` (organ `cortex_exec`, signal kinds `cognition_run` and `cognition_step`) into the shared substrate grammar as `SubstrateMoleculeV1` of a new `organ_signal` molecule kind. The substrate can now consume real organ signals without a parallel signal schema.
+
+```text
+CognitionTraceAdapter (orion-cortex-exec)
+  → OrionSignalV1 (organ_id=cortex_exec, signal_kind=cognition_run|cognition_step)
+  → orion/substrate/signal_bridge.py :: signal_to_molecule()
+  → SubstrateMoleculeV1(molecule_kind=organ_signal)
+  → MoleculeJsonlStore / SubstrateExperimentHarness
+  → daily rollup: organ_coverage["cortex_exec"]
+```
+
+**Non-goals respected:** no new atom kinds, predicate kinds, or gradient keys; no edits to `orion/signals/**`, `orion/substrate/molecules.py`, molecule_store, operators, or signal gateway.
+
+## Architecture
+
+| Layer | Component | Output |
+|-------|-----------|--------|
+| Schema | `orion/schema_kernel/registry.py` | `organ_signal` added to `default_registry()` molecule_kinds (one-line) |
+| Bridge | `orion/substrate/signal_bridge.py` | Pure projection: `OrionSignalV1 → SubstrateMoleculeV1` |
+| Worker | `orion/substrate/signal_bus_worker.py` | Optional bus-driver-agnostic seam (not wired to live bus yet) |
+
+Gradient mapping from signal dimensions to canonical substrate gradients:
+
+| Gradient | Source |
+|----------|--------|
+| `salience` | `max(latency_level, step_count, service_count, level, salience)` |
+| `contradiction` | `max(error_present, 1-success if success present, contradiction)` |
+| `coherence` | `max(success if present, coherence) × confidence` |
+| `novelty` | `max(novelty, surprise)` |
+
+## Files changed
+
+| Path | Change |
+|------|--------|
+| `orion/schema_kernel/registry.py` | Add `organ_signal` to `default_registry()` molecule_kinds |
+| `orion/substrate/signal_bridge.py` | New — pure `OrionSignalV1 → SubstrateMoleculeV1` projection |
+| `orion/substrate/signal_bus_worker.py` | New — optional `handle_envelope()` seam for live bus bridging |
+| `tests/test_substrate_signal_bridge.py` | 7 unit tests: registry, happy path, failure→contradiction, step error, unsupported skip/raise, grammar validation |
+| `tests/test_substrate_signal_bridge_e2e.py` | 1 e2e test: bridge → store → harness → daily rollup shows `cortex_exec` coverage |
+
+## Tests
+
+```bash
+cd .claude/worktrees/feat+substrate-signal-bridge-v1
+/mnt/scripts/Orion-Sapienform/.orion_dev/bin/pytest tests/test_substrate_signal_bridge.py tests/test_substrate_signal_bridge_e2e.py -q
+# 8 passed in 0.77s
+```
+
+## Code review
+
+Reviewer flagged two worker issues (no bridge issues):
+
+1. **Bridge/store exceptions unguarded** — `signal_to_molecule`/`store.add` exceptions propagated to bus driver loop. Wrapped in `try/except` with `logger.warning`. Fixed in `1618043e`.
+2. **Payload type guard inconsistent with project convention** — missing `model_dump()` check for pre-deserialized Pydantic payloads (pattern from `ConceptWorker`). Fixed in `1618043e`.
+
+Verdict: **approved after fixes**.
+
+## Rollout
+
+No migrations required. No env changes required.
+
+To wire the live bus worker (follow-up, not in this PR):
+1. Subscribe `SubstrateSignalBusWorker.handle_envelope` to `orion:signals:cortex_exec` via an `OrionBusAsync` driver
+2. Verify: `cognition_run` signal → `organ_signal` molecule in store → daily rollup shows `organ_coverage["cortex_exec"] > 0`
+
+## Test plan
+
+- [x] `organ_signal` registered in `default_registry()`
+- [x] `cognition_run` success → correct gradients (salience=latency, coherence=1, contradiction=0)
+- [x] `cognition_run` failure → contradiction=1, coherence=0
+- [x] `cognition_step` with `error_present` → contradiction=1
+- [x] Batch helper skips unsupported; single raises `ValueError`
+- [x] All bridged molecules validate against `default_registry()` (atoms, predicates, gradient keys)
+- [x] End-to-end: bridge → store → harness → daily rollup `organ_coverage["cortex_exec"] == 3`
+- [x] Worker fail-open: malformed payload silently dropped; bridge/store errors logged as warning
+- [ ] Live: `cortex_exec` signal → `organ_signal` molecule observed in daily rollup (requires bus wiring follow-up)

--- a/orion/schema_kernel/registry.py
+++ b/orion/schema_kernel/registry.py
@@ -100,5 +100,6 @@ def default_registry() -> SchemaKernelRegistry:
             "claim",
             "pressure",
             "contradiction",
+            "organ_signal",
         ),
     )

--- a/orion/substrate/signal_bridge.py
+++ b/orion/substrate/signal_bridge.py
@@ -1,0 +1,163 @@
+"""Substrate signal bridge — project OrionSignalV1 into SubstrateMoleculeV1.
+
+This module is a pure projection. It does not subscribe to a bus, does not
+persist anything, and does not introduce a new signal schema. It exists so the
+substrate can consume the existing organ signal stream through one well-defined
+seam.
+
+Supported inputs (MVP):
+    (organ_id="cortex_exec", signal_kind="cognition_run")
+    (organ_id="cortex_exec", signal_kind="cognition_step")
+
+These are the signals produced by orion.signals.adapters.cognition_trace.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from orion.schema_kernel import (
+    ConceptRelationV1,
+    clamp_gradient,
+    default_registry,
+)
+from orion.signals.models import OrionSignalV1
+from orion.substrate.molecules import SubstrateMoleculeV1, validate_molecule
+
+
+SUPPORTED_SIGNAL_KINDS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("cortex_exec", "cognition_run"),
+        ("cortex_exec", "cognition_step"),
+    }
+)
+
+
+def supports_signal(signal: OrionSignalV1) -> bool:
+    return (signal.organ_id, signal.signal_kind) in SUPPORTED_SIGNAL_KINDS
+
+
+def _dim(signal: OrionSignalV1, key: str, default: float = 0.0) -> float:
+    value = (signal.dimensions or {}).get(key, default)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def signal_intensity(signal: OrionSignalV1) -> float:
+    return clamp_gradient(
+        max(
+            _dim(signal, "salience"),
+            _dim(signal, "level"),
+            _dim(signal, "latency_level"),
+            _dim(signal, "step_count"),
+            _dim(signal, "service_count"),
+        )
+    )
+
+
+def signal_confidence(signal: OrionSignalV1) -> float:
+    return clamp_gradient(_dim(signal, "confidence", 1.0))
+
+
+def dimensions_to_gradients(signal: OrionSignalV1) -> dict[str, float]:
+    dims = signal.dimensions or {}
+    success_present = "success" in dims
+    success = _dim(signal, "success", 0.0)
+
+    salience = signal_intensity(signal)
+
+    contradiction = max(
+        _dim(signal, "contradiction"),
+        _dim(signal, "error_present"),
+        1.0 - success if success_present else 0.0,
+    )
+
+    novelty = max(
+        _dim(signal, "novelty"),
+        _dim(signal, "surprise"),
+    )
+
+    coherence = max(
+        _dim(signal, "coherence"),
+        success if success_present else 0.0,
+    )
+
+    confidence = signal_confidence(signal)
+
+    return {
+        "salience": clamp_gradient(salience),
+        "contradiction": clamp_gradient(contradiction),
+        "novelty": clamp_gradient(novelty),
+        "coherence": clamp_gradient(coherence * confidence),
+    }
+
+
+def signal_to_molecule(signal: OrionSignalV1) -> SubstrateMoleculeV1:
+    if not supports_signal(signal):
+        raise ValueError(
+            f"unsupported substrate signal bridge: "
+            f"{signal.organ_id}.{signal.signal_kind}"
+        )
+
+    intensity = signal_intensity(signal)
+    confidence = signal_confidence(signal)
+
+    molecule = SubstrateMoleculeV1(
+        molecule_kind="organ_signal",
+        atoms={
+            "primary": "signal",
+            "source_process": "agency",
+            "source_context": "context",
+            "field": "gradient",
+            "witness": "evidence",
+        },
+        relations=[
+            ConceptRelationV1(
+                source="primary",
+                predicate="references",
+                target="source_process",
+                weight=1.0,
+            ),
+            ConceptRelationV1(
+                source="primary",
+                predicate="elicits",
+                target="field",
+                weight=intensity,
+            ),
+            ConceptRelationV1(
+                source="witness",
+                predicate="supports",
+                target="primary",
+                weight=confidence,
+                polarity=1.0,
+            ),
+        ],
+        gradients=dimensions_to_gradients(signal),
+        provenance={
+            "organ": signal.organ_id,
+            "signal_id": signal.signal_id,
+            "signal_kind": signal.signal_kind,
+            "source_event_id": signal.source_event_id,
+            "otel_trace_id": signal.otel_trace_id,
+            "otel_span_id": signal.otel_span_id,
+        },
+        payload={
+            "dimensions": dict(signal.dimensions or {}),
+            "summary": signal.summary,
+            "notes": list(signal.notes or []),
+            "causal_parents": list(signal.causal_parents or []),
+            "observed_at": signal.observed_at.isoformat(),
+            "emitted_at": signal.emitted_at.isoformat(),
+        },
+    )
+
+    validate_molecule(molecule, default_registry())
+    return molecule
+
+
+def signals_to_molecules(
+    signals: Iterable[OrionSignalV1],
+) -> list[SubstrateMoleculeV1]:
+    return [signal_to_molecule(s) for s in signals if supports_signal(s)]

--- a/orion/substrate/signal_bus_worker.py
+++ b/orion/substrate/signal_bus_worker.py
@@ -34,6 +34,8 @@ class SubstrateSignalBusWorker:
 
     async def handle_envelope(self, env: Any) -> None:
         payload = env.payload
+        if hasattr(payload, "model_dump"):
+            payload = payload.model_dump()
         if not isinstance(payload, dict):
             return
 
@@ -46,7 +48,15 @@ class SubstrateSignalBusWorker:
         if not supports_signal(signal):
             return
 
-        molecule = signal_to_molecule(signal)
-        self._store.add(molecule)
-        if self._harness is not None:
-            self._harness.record_emit(molecule, organ=signal.organ_id)
+        try:
+            molecule = signal_to_molecule(signal)
+            self._store.add(molecule)
+            if self._harness is not None:
+                self._harness.record_emit(molecule, organ=signal.organ_id)
+        except Exception as exc:
+            logger.warning(
+                "substrate signal bus worker: bridge/store failed organ=%s kind=%s: %s",
+                signal.organ_id,
+                signal.signal_kind,
+                exc,
+            )

--- a/orion/substrate/signal_bus_worker.py
+++ b/orion/substrate/signal_bus_worker.py
@@ -1,0 +1,52 @@
+"""Substrate signal bus worker.
+
+Subscribes (via an external bus driver) to signal envelopes emitted by the
+orion-signal-gateway and bridges the supported subset into the substrate
+molecule store. The worker does not mutate gateway behavior; it runs alongside.
+
+The handle_envelope() seam is bus-driver agnostic so tests can drive it without
+spinning up a real OrionBusAsync instance.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from orion.signals.models import OrionSignalV1
+from orion.substrate.experiment.harness import SubstrateExperimentHarness
+from orion.substrate.molecule_store import MoleculeJsonlStore
+from orion.substrate.signal_bridge import signal_to_molecule, supports_signal
+
+
+logger = logging.getLogger(__name__)
+
+
+class SubstrateSignalBusWorker:
+    def __init__(
+        self,
+        *,
+        store: MoleculeJsonlStore,
+        harness: Optional[SubstrateExperimentHarness] = None,
+    ) -> None:
+        self._store = store
+        self._harness = harness
+
+    async def handle_envelope(self, env: Any) -> None:
+        payload = env.payload
+        if not isinstance(payload, dict):
+            return
+
+        try:
+            signal = OrionSignalV1.model_validate(payload)
+        except Exception as exc:
+            logger.debug("substrate signal bus worker: payload not OrionSignalV1: %s", exc)
+            return
+
+        if not supports_signal(signal):
+            return
+
+        molecule = signal_to_molecule(signal)
+        self._store.add(molecule)
+        if self._harness is not None:
+            self._harness.record_emit(molecule, organ=signal.organ_id)

--- a/tests/test_substrate_signal_bridge.py
+++ b/tests/test_substrate_signal_bridge.py
@@ -1,0 +1,174 @@
+"""Substrate signal bridge: OrionSignalV1 → SubstrateMoleculeV1."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from orion.schema_kernel import default_registry
+from orion.signals.models import OrganClass, OrionSignalV1
+from orion.substrate.molecules import validate_molecule
+
+
+def make_cognition_run_signal(
+    *,
+    signal_kind: str = "cognition_run",
+    dimensions: dict[str, float] | None = None,
+    source_event_id: str = "corr-test-1",
+) -> OrionSignalV1:
+    now = datetime.now(timezone.utc)
+    return OrionSignalV1(
+        signal_id="sig-test-1",
+        organ_id="cortex_exec",
+        organ_class=OrganClass.endogenous,
+        signal_kind=signal_kind,
+        dimensions=dimensions or {},
+        causal_parents=[],
+        source_event_id=source_event_id,
+        otel_trace_id="00000000000000000000000000000001",
+        otel_span_id="0000000000000001",
+        observed_at=now,
+        emitted_at=now,
+        summary="test signal",
+        notes=[],
+    )
+
+
+def test_default_registry_includes_organ_signal_molecule_kind():
+    registry = default_registry()
+    assert registry.has_molecule_kind("organ_signal"), (
+        "default_registry() must register 'organ_signal' so the signal bridge "
+        "can emit molecules that validate."
+    )
+
+
+def test_cognition_run_success_converts_to_organ_signal_molecule():
+    from orion.substrate.signal_bridge import signal_to_molecule
+
+    signal = make_cognition_run_signal(
+        dimensions={
+            "success": 1.0,
+            "step_count": 0.15,
+            "latency_level": 0.30,
+            "recall_used": 1.0,
+            "reasoning_present": 1.0,
+            "final_text_present": 1.0,
+        },
+    )
+
+    molecule = signal_to_molecule(signal)
+
+    assert molecule.molecule_kind == "organ_signal"
+    assert molecule.provenance["organ"] == "cortex_exec"
+    assert molecule.provenance["signal_kind"] == "cognition_run"
+    assert molecule.provenance["signal_id"] == "sig-test-1"
+    assert molecule.provenance["source_event_id"] == "corr-test-1"
+    assert molecule.atoms["primary"] == "signal"
+    assert molecule.atoms["source_process"] == "agency"
+    assert molecule.atoms["source_context"] == "context"
+    assert molecule.atoms["field"] == "gradient"
+    assert molecule.atoms["witness"] == "evidence"
+
+    assert molecule.gradients["salience"] == pytest.approx(0.30)
+    assert molecule.gradients["contradiction"] == pytest.approx(0.0)
+    assert molecule.gradients["novelty"] == pytest.approx(0.0)
+    assert molecule.gradients["coherence"] == pytest.approx(1.0)
+
+    validate_molecule(molecule, default_registry())
+
+
+def test_cognition_run_failure_maps_to_contradiction_gradient():
+    from orion.substrate.signal_bridge import signal_to_molecule
+
+    signal = make_cognition_run_signal(
+        dimensions={
+            "success": 0.0,
+            "step_count": 0.30,
+            "latency_level": 0.70,
+        },
+    )
+
+    molecule = signal_to_molecule(signal)
+
+    assert molecule.gradients["contradiction"] == pytest.approx(1.0)
+    assert molecule.gradients["salience"] == pytest.approx(0.70)
+    assert molecule.gradients["coherence"] == pytest.approx(0.0)
+    assert molecule.gradients["novelty"] == pytest.approx(0.0)
+
+
+def test_cognition_step_error_present_maps_to_contradiction():
+    from orion.substrate.signal_bridge import signal_to_molecule
+
+    signal = make_cognition_run_signal(
+        signal_kind="cognition_step",
+        dimensions={
+            "success": 0.0,
+            "latency_level": 0.20,
+            "error_present": 1.0,
+            "service_count": 0.20,
+        },
+    )
+
+    molecule = signal_to_molecule(signal)
+
+    assert molecule.provenance["signal_kind"] == "cognition_step"
+    assert molecule.gradients["contradiction"] == pytest.approx(1.0)
+    assert molecule.gradients["salience"] == pytest.approx(0.20)
+    assert molecule.gradients["coherence"] == pytest.approx(0.0)
+
+
+def test_signals_to_molecules_skips_unsupported_signals():
+    from orion.substrate.signal_bridge import signals_to_molecules
+
+    unsupported_other_organ = make_cognition_run_signal().model_copy(
+        update={"organ_id": "biometrics", "signal_kind": "gpu_load"}
+    )
+    supported = make_cognition_run_signal(
+        dimensions={"success": 1.0, "step_count": 0.10, "latency_level": 0.10},
+    )
+
+    result = signals_to_molecules([unsupported_other_organ, supported])
+
+    assert len(result) == 1
+    assert result[0].provenance["organ"] == "cortex_exec"
+    assert result[0].provenance["signal_kind"] == "cognition_run"
+
+
+def test_signal_to_molecule_raises_on_unsupported_signal():
+    from orion.substrate.signal_bridge import signal_to_molecule
+
+    rogue = make_cognition_run_signal().model_copy(
+        update={"organ_id": "biometrics", "signal_kind": "gpu_load"}
+    )
+
+    with pytest.raises(ValueError, match="unsupported substrate signal bridge"):
+        signal_to_molecule(rogue)
+
+
+def test_bridged_molecule_validates_against_default_registry_for_both_kinds():
+    from orion.substrate.signal_bridge import signal_to_molecule
+
+    run = make_cognition_run_signal(
+        dimensions={"success": 1.0, "step_count": 0.10, "latency_level": 0.10},
+    )
+    step = make_cognition_run_signal(
+        signal_kind="cognition_step",
+        dimensions={
+            "success": 1.0,
+            "latency_level": 0.10,
+            "error_present": 0.0,
+            "service_count": 0.20,
+        },
+    )
+
+    for molecule in (signal_to_molecule(run), signal_to_molecule(step)):
+        validate_molecule(molecule, default_registry())
+
+        registry = default_registry()
+        for role, atom_key in molecule.atoms.items():
+            assert registry.has_atom(atom_key), (
+                f"role {role!r} maps to unregistered atom {atom_key!r}"
+            )
+        for relation in molecule.relations:
+            assert registry.has_predicate(relation.predicate)

--- a/tests/test_substrate_signal_bridge_e2e.py
+++ b/tests/test_substrate_signal_bridge_e2e.py
@@ -1,0 +1,70 @@
+"""End-to-end: bridge → MoleculeJsonlStore → harness → daily rollup."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from orion.signals.models import OrganClass, OrionSignalV1
+from orion.substrate.experiment.daily_rollup import compute_daily_rollup
+from orion.substrate.experiment.harness import SubstrateExperimentHarness
+from orion.substrate.molecule_store import MoleculeJsonlStore
+from orion.substrate.signal_bridge import signal_to_molecule
+
+
+def _signal(*, signal_id: str, signal_kind: str, dimensions: dict[str, float]) -> OrionSignalV1:
+    now = datetime.now(timezone.utc)
+    return OrionSignalV1(
+        signal_id=signal_id,
+        organ_id="cortex_exec",
+        organ_class=OrganClass.endogenous,
+        signal_kind=signal_kind,
+        dimensions=dimensions,
+        causal_parents=[],
+        source_event_id=f"corr-{signal_id}",
+        observed_at=now,
+        emitted_at=now,
+        summary=f"{signal_kind} {signal_id}",
+        notes=[],
+    )
+
+
+def test_bridged_signals_land_in_daily_rollup_under_cortex_exec(tmp_path):
+    store = MoleculeJsonlStore(tmp_path / "molecules.jsonl")
+    harness = SubstrateExperimentHarness()
+
+    raw_signals = [
+        _signal(signal_id="s-ok", signal_kind="cognition_run",
+                dimensions={"success": 1.0, "step_count": 0.10, "latency_level": 0.20}),
+        _signal(signal_id="s-fail", signal_kind="cognition_run",
+                dimensions={"success": 0.0, "step_count": 0.40, "latency_level": 0.80}),
+        _signal(signal_id="s-step-err", signal_kind="cognition_step",
+                dimensions={"success": 0.0, "latency_level": 0.30, "error_present": 1.0, "service_count": 0.40}),
+    ]
+
+    for raw in raw_signals:
+        molecule = signal_to_molecule(raw)
+        store.add(molecule)
+        harness.record_emit(molecule, organ=raw.organ_id)
+
+    today = datetime.now(timezone.utc).date()
+    metrics = compute_daily_rollup(day=today, harness=harness, store=store)
+
+    assert metrics.organ_coverage.by_organ.get("cortex_exec") == 3
+
+    contradiction_stat = next(
+        g for g in metrics.gradient_distribution if g.key == "contradiction"
+    )
+    assert contradiction_stat.max == 1.0
+    assert contradiction_stat.mean > 0.0
+
+    salience_stat = next(
+        g for g in metrics.gradient_distribution if g.key == "salience"
+    )
+    assert salience_stat.max == pytest.approx(0.80)
+
+    assert len(metrics.contradiction_clusters) >= 1
+    cluster = metrics.contradiction_clusters[0]
+    assert "signal" in cluster.shared_atoms
+    assert cluster.contradiction_sum >= 1.0


### PR DESCRIPTION
# PR: Substrate Signal Bridge V1

**Branch:** `worktree-feat+substrate-signal-bridge-v1`  
**Base:** `main`  
**Worktree:** `/mnt/scripts/Orion-Sapienform/.claude/worktrees/feat+substrate-signal-bridge-v1`  
**Head:** `1618043e` (5 commits)

## Summary

Bridges existing `OrionSignalV1` records produced by `CognitionTraceAdapter` (organ `cortex_exec`, signal kinds `cognition_run` and `cognition_step`) into the shared substrate grammar as `SubstrateMoleculeV1` of a new `organ_signal` molecule kind. The substrate can now consume real organ signals without a parallel signal schema.

```text
CognitionTraceAdapter (orion-cortex-exec)
  → OrionSignalV1 (organ_id=cortex_exec, signal_kind=cognition_run|cognition_step)
  → orion/substrate/signal_bridge.py :: signal_to_molecule()
  → SubstrateMoleculeV1(molecule_kind=organ_signal)
  → MoleculeJsonlStore / SubstrateExperimentHarness
  → daily rollup: organ_coverage["cortex_exec"]
```

**Non-goals respected:** no new atom kinds, predicate kinds, or gradient keys; no edits to `orion/signals/**`, `orion/substrate/molecules.py`, molecule_store, operators, or signal gateway.

## Architecture

| Layer | Component | Output |
|-------|-----------|--------|
| Schema | `orion/schema_kernel/registry.py` | `organ_signal` added to `default_registry()` molecule_kinds (one-line) |
| Bridge | `orion/substrate/signal_bridge.py` | Pure projection: `OrionSignalV1 → SubstrateMoleculeV1` |
| Worker | `orion/substrate/signal_bus_worker.py` | Optional bus-driver-agnostic seam (not wired to live bus yet) |

Gradient mapping from signal dimensions to canonical substrate gradients:

| Gradient | Source |
|----------|--------|
| `salience` | `max(latency_level, step_count, service_count, level, salience)` |
| `contradiction` | `max(error_present, 1-success if success present, contradiction)` |
| `coherence` | `max(success if present, coherence) × confidence` |
| `novelty` | `max(novelty, surprise)` |

## Files changed

| Path | Change |
|------|--------|
| `orion/schema_kernel/registry.py` | Add `organ_signal` to `default_registry()` molecule_kinds |
| `orion/substrate/signal_bridge.py` | New — pure `OrionSignalV1 → SubstrateMoleculeV1` projection |
| `orion/substrate/signal_bus_worker.py` | New — optional `handle_envelope()` seam for live bus bridging |
| `tests/test_substrate_signal_bridge.py` | 7 unit tests: registry, happy path, failure→contradiction, step error, unsupported skip/raise, grammar validation |
| `tests/test_substrate_signal_bridge_e2e.py` | 1 e2e test: bridge → store → harness → daily rollup shows `cortex_exec` coverage |

## Tests

```bash
cd .claude/worktrees/feat+substrate-signal-bridge-v1
/mnt/scripts/Orion-Sapienform/.orion_dev/bin/pytest tests/test_substrate_signal_bridge.py tests/test_substrate_signal_bridge_e2e.py -q
# 8 passed in 0.77s
```

## Code review

Reviewer flagged two worker issues (no bridge issues):

1. **Bridge/store exceptions unguarded** — `signal_to_molecule`/`store.add` exceptions propagated to bus driver loop. Wrapped in `try/except` with `logger.warning`. Fixed in `1618043e`.
2. **Payload type guard inconsistent with project convention** — missing `model_dump()` check for pre-deserialized Pydantic payloads (pattern from `ConceptWorker`). Fixed in `1618043e`.

Verdict: **approved after fixes**.

## Rollout

No migrations required. No env changes required.

To wire the live bus worker (follow-up, not in this PR):
1. Subscribe `SubstrateSignalBusWorker.handle_envelope` to `orion:signals:cortex_exec` via an `OrionBusAsync` driver
2. Verify: `cognition_run` signal → `organ_signal` molecule in store → daily rollup shows `organ_coverage["cortex_exec"] > 0`

## Test plan

- [x] `organ_signal` registered in `default_registry()`
- [x] `cognition_run` success → correct gradients (salience=latency, coherence=1, contradiction=0)
- [x] `cognition_run` failure → contradiction=1, coherence=0
- [x] `cognition_step` with `error_present` → contradiction=1
- [x] Batch helper skips unsupported; single raises `ValueError`
- [x] All bridged molecules validate against `default_registry()` (atoms, predicates, gradient keys)
- [x] End-to-end: bridge → store → harness → daily rollup `organ_coverage["cortex_exec"] == 3`
- [x] Worker fail-open: malformed payload silently dropped; bridge/store errors logged as warning
- [ ] Live: `cortex_exec` signal → `organ_signal` molecule observed in daily rollup (requires bus wiring follow-up)