### PR TITLE
fix(mesh-critical-email): apply code review feedback

### DIFF
--- a/docs/superpowers/pr-reports/2026-06-19-mesh-critical-email-pr.md
+++ b/docs/superpowers/pr-reports/2026-06-19-mesh-critical-email-pr.md
@@ -50,6 +50,9 @@ docker compose --env-file .env --env-file services/orion-notify/.env \
 
 docker compose --env-file .env --env-file services/orion-mesh-guardian/.env \
   -f services/orion-mesh-guardian/docker-compose.yml up -d --build mesh-guardian
+
+docker compose --env-file .env --env-file services/orion-sql-writer/.env \
+  -f services/orion-sql-writer/docker-compose.yml up -d --build orion-sql-writer
 ```
 
 Ensure SMTP vars are set in `services/orion-notify/.env` (`NOTIFY_EMAIL_*`). Escalation runs when `NOTIFY_ESCALATION_POLL_SECONDS > 0` (default 60).
@@ -63,4 +66,6 @@ Ensure SMTP vars are set in `services/orion-notify/.env` (`NOTIFY_EMAIL_*`). Esc
 ## Code review notes
 
 - Escalation marks DB before SMTP send to avoid duplicate emails on partial failure
+- Escalation email includes `Attention ID` in body for Hub lookup
 - Multi-notify-replica deploy may still race; acceptable for single-replica Athena stack
+- SMTP failure after escalate mark does not retry (anti-spam tradeoff)

--- a/services/orion-mesh-guardian/tests/test_attention.py
+++ b/services/orion-mesh-guardian/tests/test_attention.py
@@ -17,9 +17,17 @@ def test_attention_publisher_calls_notify_client() -> None:
         publisher.publish_transition(
             service_id="landing-pad",
             heartbeat_name="landing-pad",
-            event={"severity": "error", "message": "unhealthy", "correlation_id": "abc"},
+            event={
+                "severity": "critical",
+                "message": "mesh health: landing-pad observe-only",
+                "correlation_id": "abc",
+                "context": {"event": "observe_only"},
+            },
         )
     mock_client.attention_request.assert_called_once()
     kwargs = mock_client.attention_request.call_args.kwargs
-    assert kwargs["severity"] == "error"
+    assert kwargs["severity"] == "critical"
     assert kwargs["context"]["event_kind"] == "orion.mesh.health.attention.v1"
+    assert kwargs["context"]["reason"] == "[Orion mesh] landing-pad — observe_only"
+    assert "service: landing-pad" in kwargs["message"]
+    assert "heartbeat: landing-pad" in kwargs["message"]

--- a/services/orion-mesh-guardian/tests/test_state_machine.py
+++ b/services/orion-mesh-guardian/tests/test_state_machine.py
@@ -112,6 +112,19 @@ def test_post_grace_still_bad_schedules_tier2() -> None:
     assert out.new_state.pending_tier2 is True
 
 
+def test_post_grace_persistent_failure_is_critical() -> None:
+    state = ServiceState(
+        phase=ServicePhase.post_check_grace,
+        post_grace_until_ts=1000.0,
+        pending_tier2=True,
+        attempts_this_hour=3,
+    )
+    out = transition(state, _inp(now=1100.0, probe_status="probe_bad"), service_id="landing-pad")
+    assert out.new_state.phase == ServicePhase.attention_only
+    assert out.attention_events[0]["severity"] == "critical"
+    assert "persistent failure" in out.attention_events[0]["message"]
+
+
 def test_max_attempts_moves_to_attention_only() -> None:
     state = ServiceState(phase=ServicePhase.unhealthy_confirmed, attempts_this_hour=3)
     out = transition(state, _inp(probe_status="probe_bad"), service_id="landing-pad")

--- a/services/orion-notify/app/attention_escalation.py
+++ b/services/orion-notify/app/attention_escalation.py
@@ -39,8 +39,8 @@ def _parse_ts(value: Any) -> Optional[datetime]:
 
 def _hub_link(hub_url_base: str, attention_id: str) -> Optional[str]:
     base = hub_url_base.strip().rstrip("/")
-    if not base:
-        return None
+    if not base or not attention_id:
+        return base or None
     return f"{base}/#attention"
 
 
@@ -52,6 +52,8 @@ def _build_escalation_request(row: Dict[str, Any], *, hub_url_base: str) -> Noti
         "Attention request was not acknowledged before the escalation deadline.",
         "",
         str(row.get("message") or ""),
+        "",
+        f"Attention ID: {attention_id}",
     ]
     if hub_url:
         body_lines.extend(["", f"Hub: {hub_url}"])

--- a/services/orion-notify/app/email_delivery.py
+++ b/services/orion-notify/app/email_delivery.py
@@ -46,8 +46,6 @@ def maybe_send_email(
     should, reason = should_send_email(payload)
     if not should:
         return
-    if immediate_critical_only and severity == "error":
-        return
     try:
         transport.send(payload)
         logger.info(

--- a/services/orion-notify/app/main.py
+++ b/services/orion-notify/app/main.py
@@ -272,7 +272,10 @@ async def attention_request(
         )
         asyncio.create_task(_publish_persistence_event(bus, "orion:notify:persistence:request", record))
 
-    return _attention_request_to_state(payload, notify_payload.notification_id)
+    return _attention_request_to_state(
+        payload.model_copy(update={"context": notify_payload.context}),
+        notify_payload.notification_id,
+    )
 
 
 @app.post("/attention/{attention_id}/ack")


### PR DESCRIPTION
### Summary

Code review fixes are applied on `feat/mesh-critical-email-notifications` and pushed (`f9cdf553`). All 23 targeted tests pass. `gh pr create` still needs auth — open the PR manually at the link below.

### Files changed

- `docs/superpowers/pr-reports/2026-06-19-mesh-critical-email-pr.md`
- `services/orion-mesh-guardian/tests/test_attention.py`
- `services/orion-mesh-guardian/tests/test_state_machine.py`
- `services/orion-notify/app/attention_escalation.py`
- `services/orion-notify/app/email_delivery.py`
- `services/orion-notify/app/main.py`

### Review fixes applied

| Finding | Fix |
|---------|-----|
| Deploy docs missing sql-writer | Added `orion-sql-writer` rebuild to PR report deploy section |
| `/attention/request` dropped enriched context | Returns state with `notify_payload.context` merged in |
| Redundant guard in `email_delivery.py` | Removed unreachable `immediate_critical_only` error check |
| Escalation email hard to correlate | Body now includes `Attention ID: {id}` |
| Missing mesh-guardian tests | Added tier-1 persistent-failure → critical + enriched attention publisher assertions |

### Verification

| Command | Exit | Result |
|---------|------|--------|
| `PYTHONPATH=.:services/orion-mesh-guardian venv/bin/python -m pytest services/orion-mesh-guardian/tests/test_state_machine.py services/orion-mesh-guardian/tests/test_attention.py -q` | 0 | 16 passed |
| `PYTHONPATH=.:services/orion-notify venv/bin/python -m pytest services/orion-notify/tests/test_attention_email_delivery.py services/orion-notify/tests/test_attention_escalation_loop.py -q` | 0 | 5 passed |
| `PYTHONPATH=.:services/orion-sql-writer venv/bin/python -m pytest services/orion-sql-writer/tests/test_notify_attention_escalate.py -q` | 0 | 2 passed |
| `git push origin feat/mesh-critical-email-notifications` | 0 | Pushed `f9cdf553` |
| `gh pr create ...` | 4 | `gh auth login` required |

### Remaining risks

- **UNVERIFIED** for live SMTP: no post-deploy smoke test against a running stack.
- Hub deep-link still uses `/#attention` only (Hub has no per-id route); escalation emails carry the ID in the body instead.
- PR creation: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/mesh-critical-email-notifications