### PR TITLE
Cap orion-sql-db Postgres at 48g to prevent host OOM.

### DIFF
--- a/services/orion-sql-db/.env_example
+++ b/services/orion-sql-db/.env_example
@@ -3,6 +3,9 @@ POSTGRES_USER=cat
 POSTGRES_PASSWORD=cat
 POSTGRES_DB=conjourney
 
+# Docker cgroup cap for orion-sql-db (prevents host-wide OOM from runaway vacuum/TOAST).
+POSTGRES_MEM_LIMIT=48g
+
 # pgAdmin creds
 PGADMIN_DEFAULT_EMAIL=orion@conjourney.net
 PGADMIN_DEFAULT_PASSWORD=cats

--- a/services/orion-sql-db/docker-compose.yml
+++ b/services/orion-sql-db/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     image: postgres:15
     container_name: ${PROJECT}-sql-db
     shm_size: '1gb'
+    # Cap RSS so runaway autovacuum/TOAST work cannot take the whole host (346Gi).
+    mem_limit: ${POSTGRES_MEM_LIMIT:-48g}
+    memswap_limit: ${POSTGRES_MEM_LIMIT:-48g}
     restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER}


### PR DESCRIPTION
## Summary

- Add a Docker cgroup memory cap (`mem_limit` / `memswap_limit`) to `orion-sql-db`, default **48g** via `POSTGRES_MEM_LIMIT`.
- Prevents runaway Postgres work (notably autovacuum on bloated `substrate_reduction_receipts` TOAST) from consuming 300GB+ RSS and freezing the host (SSH/console unresponsive).

## Context

On Athena, `substrate_reduction_receipts` had ~3MB heap but **15GB dead TOAST** from receipt insert/prune churn. Autovacuum on that TOAST repeatedly ballooned to **200–350GB RSS**, triggering kernel OOM kills and system-wide memory pressure. Fuseki was not the cause.

Capping Postgres confines that failure mode to the sql-db container instead of taking down the node.

## Changes

- `services/orion-sql-db/docker-compose.yml` — `mem_limit` + `memswap_limit` from env
- `services/orion-sql-db/.env_example` — document `POSTGRES_MEM_LIMIT=48g`

## Deploy

```bash
python3 scripts/sync_local_env_from_example.py --all-keys orion-sql-db
cd services/orion-sql-db && docker compose up -d --force-recreate orion-sql-db
```

Verify: `docker inspect orion-athena-sql-db --format 'Mem={{.HostConfig.Memory}}'` → `51539607552` (48g).

## Test plan

- [x] Recreated `orion-athena-sql-db` with cap applied; `pg_isready` OK
- [ ] Confirm host stays responsive if autovacuum/OOM occurs inside container
- [ ] Follow-up (separate PR): `VACUUM FULL` on `substrate_reduction_receipts` to reclaim 15GB TOAST bloat

## Non-goals

- Does not fix TOAST bloat root cause (receipt retention/prune churn)
- Does not cap Fuseki or other services
