### PR TITLE
fixes to RDF bloat

### DIFF
--- a/orion/substrate/biometrics_loop/pipeline.py
+++ b/orion/substrate/biometrics_loop/pipeline.py
@@ -70,6 +70,8 @@ def process_biometrics_grammar_events(
 
     node_bio = load_node_bio()
     pressure = load_pressure()
+    node_bio_dirty = False
+    pressure_dirty = False
 
     for event in events:
         stats["events"] += 1
@@ -81,7 +83,7 @@ def process_biometrics_grammar_events(
                 catalog=catalog,
                 stale_after_sec=stale_after_sec,
             )
-            save_node_bio(node_bio)
+            node_bio_dirty = True
             save_receipt(bio_receipt)
             stats["receipts"] += 1
 
@@ -118,7 +120,7 @@ def process_biometrics_grammar_events(
             emission_id=emission.emission_id,
             now=clock,
         )
-        save_pressure(pressure)
+        pressure_dirty = True
         save_receipt(pressure_receipt)
         stats["receipts"] += 1
 
@@ -131,5 +133,11 @@ def process_biometrics_grammar_events(
             if accepted:
                 publish_accepted(accepted)
                 stats["published"] += len(accepted)
+
+    # Flush projections once per batch instead of once per event to avoid hot-row TOAST bloat.
+    if node_bio_dirty:
+        save_node_bio(node_bio)
+    if pressure_dirty:
+        save_pressure(pressure)
 
     return stats

--- a/services/orion-rdf-writer/app/rdf_builder.py
+++ b/services/orion-rdf-writer/app/rdf_builder.py
@@ -260,9 +260,7 @@ def _handle_cognition_trace(g: Graph, trace: CognitionTracePayload) -> Tuple[str
     g.add((run_uri, ORION.timestamp, Literal(trace.timestamp, datatype=XSD.double)))
     g.add((run_uri, ORION.sourceService, Literal(trace.source_service, datatype=XSD.string)))
 
-    if trace.final_text:
-        # Truncate if excessively large, but generally keep it
-        g.add((run_uri, ORION.producedFinalText, Literal(trace.final_text)))
+    # final_text omitted: full text lives in Postgres; IRI is the join key
 
     # Steps
     prev_step_uri = None
@@ -284,11 +282,7 @@ def _handle_cognition_trace(g: Graph, trace: CognitionTracePayload) -> Tuple[str
             g.add((step_uri, ORION.prevStep, prev_step_uri))
         prev_step_uri = step_uri
 
-        # Evidence / Thoughts (if any in result/artifacts)
-        if step.result:
-            thought = step.result.get("thought") or step.result.get("reasoning")
-            if thought:
-                g.add((step_uri, ORION.hasThought, Literal(thought)))
+        # thought/reasoning text omitted: full text lives in Postgres; IRI is the join key
 
         # Used Services/Tools
         # We don't have explicit 'tools used' in StepExecutionResult other than artifacts?
@@ -310,9 +304,7 @@ def _handle_social_room_turn(g: Graph, payload: dict[str, Any]) -> Tuple[str, st
     g.add((turn_uri, ORION.artifactId, Literal(turn.turn_id, datatype=XSD.string)))
     g.add((turn_uri, ORION.sessionId, Literal(session_val, datatype=XSD.string)))
     g.add((turn_uri, ORION.profile, Literal(turn.profile, datatype=XSD.string)))
-    g.add((turn_uri, ORION.promptText, Literal(turn.prompt)))
-    g.add((turn_uri, ORION.responseText, Literal(turn.response)))
-    g.add((turn_uri, ORION.textContent, Literal(turn.text or f"User: {turn.prompt}\nOrion: {turn.response}")))
+    # promptText/responseText/textContent omitted: full text lives in Postgres; IRI is the join key
     if turn.trace_verb:
         g.add((turn_uri, ORION.traceVerb, Literal(turn.trace_verb, datatype=XSD.string)))
     if turn.recall_profile:
@@ -353,7 +345,7 @@ def _handle_metacognitive_trace(g: Graph, trace: MetacognitiveTraceV1) -> Tuple[
     g.add((trace_uri, ORION.generatedByModel, Literal(trace.model, datatype=XSD.string)))
     g.add((trace_uri, ORION.traceStage, Literal(trace.trace_stage, datatype=XSD.string)))
     g.add((trace_uri, ORION.traceRole, Literal(trace.trace_role, datatype=XSD.string)))
-    g.add((trace_uri, ORION.traceText, Literal(trace.content)))
+    # traceText omitted: full text lives in Postgres; IRI is the join key
     g.add((trace_uri, ORION.correlationId, Literal(trace.correlation_id, datatype=XSD.string)))
     if trace.session_id:
         g.add((trace_uri, ORION.sessionId, Literal(trace.session_id, datatype=XSD.string)))
@@ -378,12 +370,7 @@ def _handle_chat_turn(g: Graph, data: dict) -> Tuple[str, str]:
 
     g.add((turn_uri, ORION.sessionId, Literal(session_id, datatype=XSD.string)))
 
-    prompt = data.get("prompt")
-    if prompt:
-        g.add((turn_uri, ORION.prompt, Literal(prompt)))
-    response = data.get("response")
-    if response:
-        g.add((turn_uri, ORION.response, Literal(response)))
+    # prompt/response text omitted: full text lives in Postgres; IRI is the join key
 
     timestamp = data.get("timestamp")
     if timestamp:
@@ -450,9 +437,7 @@ def _handle_chat_message(g: Graph, data: dict) -> Tuple[str, str]:
 
     g.add((message_uri, ORION.sessionId, Literal(session_id, datatype=XSD.string)))
 
-    content = data.get("content")
-    if content:
-        g.add((message_uri, ORION.content, Literal(content)))
+    # content text omitted: full text lives in Postgres; IRI is the join key
 
     role = data.get("role")
     if role:


### PR DESCRIPTION
wasted RDF bloat with long literals getting pushed into RDF graph when they exist in SQL. should improve graph performance.

Unrelated. Keep getting Athena brown outs where I can't access local machine, ssh, but server lights still green and disks spinning. It can last for 20 mins to several days and then come back or not.

Root cause: biometrics_loop/pipeline.py called save_node_bio() and save_pressure() inside the event-processing loop — one UPSERT per grammar event.
  With a batch limit of 500, that's 500 TOAST writes per batch tick to the same single row. Each write creates new TOAST chunks and leaves the old ones
  as dead. Over time:
  - Dead TOAST chunks filled pg_toast_113839 (7MB heap, 15MB index — index 2× the heap)
  - Autovacuum triggered, allocated ~50GB anon-RSS to process the bloated TOAST index
  - Cgroup OOM-killed the autovacuum worker; postgres crash-recovered; restart: unless-stopped restarted; autovacuum started immediately; repeat every ~2
  minutes
  - The sustained I/O + CPU churn from the crash/restart loop made the host completely unresponsive
 
  What was fixed:
  1. orion/substrate/biometrics_loop/pipeline.py — moved save_node_bio() and save_pressure() outside the loop, saving once per batch using node_bio_dirty
  / pressure_dirty flags. Up to 500× fewer TOAST writes.
  2. TRUNCATE substrate_active_node_pressure_projection — destroyed the bloated TOAST immediately (7.3MB heap, 15MB index → 0 bytes).
  3. services/orion-sql-db/docker-compose.yml — removed the temporary autovacuum=off flag. Autovacuum is re-enabled with autovacuum_work_mem=256MB and
  mem_limit=16g as guardrails.
  4. Per-table autovacuum: scale_factor=0.01, threshold=1, cost_limit=400 on all three hot projection tables — autovacuum will trigger after just 1 dead
  tuple instead of waiting for 20% accumulation.

  Current state: Postgres at 260MiB / 16GiB. Autovacuum running. TOAST heap 0 bytes. No OOM kills since 02:50 UTC. Host RAM: 19GB used of 346GB, swap
  empty.
