### PR TITLE
Integrate substrate self-state publishing into runtime and introspector

### DIFF
--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1930,3 +1930,12 @@ channels:
     consumer_services: []
     stability: "experimental"
     since: "2026-06-06"
+
+  - name: "orion:substrate:self_state"
+    kind: "event"
+    schema_id: "SelfStateV1"
+    message_kind: "substrate.self_state.v1"
+    producer_services: ["orion-self-state-runtime"]
+    consumer_services: ["orion-spark-introspector"]
+    stability: "experimental"
+    since: "2026-06-23"

--- a/services/orion-self-state-runtime/app/main.py
+++ b/services/orion-self-state-runtime/app/main.py
@@ -6,9 +6,12 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException
 
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.codec import OrionCodec
+
 from app.settings import get_settings
 from app.store import SelfStateRuntimeStore
-from app.worker import SelfStateRuntimeWorker
+from app.worker import SelfStateRuntimeWorker, set_publisher_bus
 
 _settings = get_settings()
 logging.basicConfig(level=getattr(logging, _settings.log_level.upper(), logging.INFO))
@@ -19,11 +22,15 @@ store = SelfStateRuntimeStore(_settings.postgres_uri)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    bus = OrionBusAsync(_settings.bus_url, enabled=_settings.bus_enabled, codec=OrionCodec())
+    await bus.connect()
+    set_publisher_bus(bus)
     await worker.start()
     try:
         yield
     finally:
         await worker.stop()
+        await bus.close()
 
 
 app = FastAPI(title="orion-self-state-runtime", lifespan=lifespan)

--- a/services/orion-self-state-runtime/app/settings.py
+++ b/services/orion-self-state-runtime/app/settings.py
@@ -22,6 +22,13 @@ class Settings(BaseSettings):
     )
     log_level: str = Field("INFO", alias="LOG_LEVEL")
 
+    bus_url: str = Field("redis://100.92.216.81:6379/0", alias="ORION_BUS_URL")
+    bus_enabled: bool = Field(True, alias="ORION_BUS_ENABLED")
+    channel_substrate_self_state: str = Field(
+        "orion:substrate:self_state",
+        alias="CHANNEL_SUBSTRATE_SELF_STATE",
+    )
+
 
 _settings: Settings | None = None
 

--- a/services/orion-self-state-runtime/app/worker.py
+++ b/services/orion-self-state-runtime/app/worker.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
+from typing import Optional
+from uuid import uuid4
 
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.bus.resilience import publish_with_reconnect
+from orion.schemas.self_state import SelfStateV1
 from orion.self_state.builder import build_self_state
 from orion.self_state.policy import load_self_state_policy
 
@@ -11,6 +17,17 @@ from app.settings import get_settings
 from app.store import SelfStateRuntimeStore
 
 logger = logging.getLogger("orion.self_state.runtime")
+
+_bus: Optional[OrionBusAsync] = None
+
+
+def set_publisher_bus(bus: OrionBusAsync) -> None:
+    global _bus
+    _bus = bus
+
+
+def _svc_ref(settings) -> ServiceRef:
+    return ServiceRef(name=settings.service_name, version=settings.service_version)
 
 
 class SelfStateRuntimeWorker:
@@ -29,7 +46,9 @@ class SelfStateRuntimeWorker:
     async def _poll_loop(self) -> None:
         while not self._stop.is_set():
             try:
-                await asyncio.to_thread(self._tick)
+                state = await asyncio.to_thread(self._tick)
+                if state is not None and _bus is not None and _bus.enabled:
+                    await self._publish_self_state(state)
             except Exception:
                 logger.exception("self_state_runtime_tick_failed")
             try:
@@ -42,16 +61,35 @@ class SelfStateRuntimeWorker:
             except asyncio.CancelledError:
                 break
 
-    def _tick(self) -> None:
+    async def _publish_self_state(self, state: SelfStateV1) -> None:
+        envelope = BaseEnvelope(
+            kind="substrate.self_state.v1",
+            source=_svc_ref(self._settings),
+            correlation_id=uuid4(),
+            payload=state.model_dump(mode="json"),
+        )
+        try:
+            await publish_with_reconnect(
+                _bus,
+                self._settings.channel_substrate_self_state,
+                envelope,
+                log_label="self_state_publish",
+            )
+        except Exception:
+            logger.exception(
+                "self_state_publish_failed self_state_id=%s", state.self_state_id
+            )
+
+    def _tick(self) -> Optional[SelfStateV1]:
         if not self._settings.enable_self_state_runtime:
-            return
+            return None
 
         attention = self._store.load_latest_attention_frame()
         if attention is None:
-            return
+            return None
 
         if self._store.load_self_state_for_attention_frame(attention.frame_id) is not None:
-            return
+            return None
 
         field = self._store.load_field_for_tick(attention.source_field_tick_id)
         if field is None:
@@ -60,7 +98,7 @@ class SelfStateRuntimeWorker:
                 attention.source_field_tick_id,
                 attention.frame_id,
             )
-            return
+            return None
 
         previous = self._store.load_latest_self_state()
         state = build_self_state(
@@ -78,3 +116,4 @@ class SelfStateRuntimeWorker:
             state.overall_condition,
             state.overall_intensity,
         )
+        return state

--- a/services/orion-self-state-runtime/requirements.txt
+++ b/services/orion-self-state-runtime/requirements.txt
@@ -5,3 +5,5 @@ pydantic-settings==2.6.1
 sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
 PyYAML==6.0.2
+redis==5.0.4
+loguru>=0.7

--- a/services/orion-spark-introspector/app/main.py
+++ b/services/orion-spark-introspector/app/main.py
@@ -28,6 +28,7 @@ from .worker import (
     _PRODUCER_BOOT_ID,
     close_spark_stream_wq,
     handle_candidate,
+    handle_self_state,
     handle_semantic_upsert,
     handle_signal,
     handle_trace,
@@ -72,6 +73,8 @@ async def lifespan(app: FastAPI):
             await handle_semantic_upsert(env)
         elif env.kind == "spark.signal.v1":
             await handle_signal(env)
+        elif env.kind == "substrate.self_state.v1":
+            await handle_self_state(env)
         else:
             await handle_candidate(env)
 
@@ -80,6 +83,7 @@ async def lifespan(app: FastAPI):
         settings.channel_cognition_trace_pub,
         settings.channel_spark_signal,
         settings.channel_vector_semantic_upsert,
+        settings.channel_substrate_self_state,
     ]
 
     svc = Hunter(

--- a/services/orion-spark-introspector/app/settings.py
+++ b/services/orion-spark-introspector/app/settings.py
@@ -50,6 +50,12 @@ class Settings(BaseSettings):
     # Spark signals (normalized distress/equilibrium)
     channel_spark_signal: str = Field("orion:spark:signal", alias="CHANNEL_SPARK_SIGNAL")
 
+    # Substrate self-state (replace tissue phi when available)
+    channel_substrate_self_state: str = Field(
+        "orion:substrate:self_state",
+        alias="CHANNEL_SUBSTRATE_SELF_STATE",
+    )
+
     # Core events (legacy bus events)
     channel_core_events: str = Field("orion:core:events", alias="CHANNEL_CORE_EVENTS")
 

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -17,6 +17,7 @@ from orion.core.bus.bus_schemas import BaseEnvelope, Envelope, ServiceRef
 from orion.core.bus.codec import OrionCodec
 from orion.core.bus.work_queue import RedisStreamWorkQueue
 from orion.schemas.platform import CoreEventV1
+from orion.schemas.self_state import SelfStateV1
 from orion.schemas.telemetry.cognition_trace import CognitionTracePayload
 from orion.schemas.telemetry.spark import SparkTelemetryPayload, SparkStateSnapshotV1
 from orion.schemas.telemetry.spark_signal import SparkSignalV1
@@ -70,6 +71,31 @@ _VALENCE_POS: Optional[np.ndarray] = None
 _VALENCE_NEG: Optional[np.ndarray] = None
 _VALENCE_INIT_TASK: Optional[asyncio.Task] = None
 _VALENCE_ANCHORS_EXPIRES_AT: float = 0.0
+
+_LATEST_SELF_STATE: Optional[SelfStateV1] = None
+
+
+def set_latest_self_state(ss: SelfStateV1) -> None:
+    global _LATEST_SELF_STATE
+    _LATEST_SELF_STATE = ss
+
+
+def _phi_from_self_state(ss: SelfStateV1) -> Dict[str, float]:
+    d = ss.dimensions
+    return {
+        "coherence": d["coherence"].score if "coherence" in d else 0.5,
+        "energy":    1.0 - d["resource_pressure"].score if "resource_pressure" in d else 0.5,
+        "novelty":   d["uncertainty"].score if "uncertainty" in d else 0.5,
+        "valence":   d["agency_readiness"].score * 2.0 - 1.0 if "agency_readiness" in d else 0.0,
+    }
+
+
+def _get_phi_stats() -> Dict[str, float]:
+    """Return phi dimensions from substrate self-state when available, tissue otherwise."""
+    ss = _LATEST_SELF_STATE
+    if ss is not None:
+        return _phi_from_self_state(ss)
+    return {k: float(v) for k, v in (TISSUE.phi() or {}).items()}
 
 
 def set_publisher_bus(bus: OrionBusAsync):
@@ -817,7 +843,7 @@ async def _update_tissue_from_candidate(c: SparkCandidatePayload) -> None:
     )
     
     # Snapshot & Broadcast to UI
-    phi_stats = {k: float(v) for k, v in (TISSUE.phi() or {}).items()}
+    phi_stats = _get_phi_stats()
     phi_stats = _apply_signal_deltas(phi_stats)
     
     # Update defaults with actual tissue state
@@ -915,7 +941,7 @@ async def handle_trace(env: BaseEnvelope) -> None:
         iso_ts = _to_iso_utc(ts_epoch)
 
         if _is_heartbeat_trace(trace):
-            phi_stats = {k: float(v) for k, v in (TISSUE.phi() or {}).items()}
+            phi_stats = _get_phi_stats()
             phi_stats = _apply_signal_deltas(phi_stats)
             valence = float(phi_stats.get("valence", 0.5))
             arousal = float(phi_stats.get("energy", 0.5))
@@ -1045,7 +1071,7 @@ async def handle_trace(env: BaseEnvelope) -> None:
 
         novelty = float(TISSUE.calculate_novelty(stimulus, channel_key=channel_key))
         TISSUE.propagate(stimulus, steps=2, learning_rate=0.1, channel_key=channel_key, embedding=embedding_vec, distress=0.0)
-        phi_stats = {k: float(v) for k, v in (TISSUE.phi() or {}).items()}
+        phi_stats = _get_phi_stats()
         phi_stats = _apply_signal_deltas(phi_stats)
         valence = float(phi_stats.get("valence", valence))
         arousal = float(phi_stats.get("energy", arousal))
@@ -1250,7 +1276,7 @@ async def handle_semantic_upsert(env: BaseEnvelope) -> None:
         distress=0.0,
     )
 
-    phi_stats = {k: float(v) for k, v in (TISSUE.phi() or {}).items()}
+    phi_stats = _get_phi_stats()
     phi_stats = _apply_signal_deltas(phi_stats)
     tissue_valence = float(phi_stats.get("valence", 0.0))
     arousal_display = max(0.0, min(1.0, 0.15 + (1.2 * novelty)))
@@ -1859,3 +1885,19 @@ async def handle_signal(env: BaseEnvelope) -> None:
         logger.warning("Ignoring malformed spark.signal payload")
         return
     _register_signal(sig)
+
+
+async def handle_self_state(env: BaseEnvelope) -> None:
+    payload = env.payload if isinstance(env.payload, dict) else {}
+    try:
+        ss = SelfStateV1.model_validate(payload)
+    except ValidationError:
+        logger.warning("Ignoring malformed substrate.self_state payload")
+        return
+    set_latest_self_state(ss)
+    logger.debug(
+        "self_state_updated self_state_id=%s condition=%s intensity=%.3f",
+        ss.self_state_id,
+        ss.overall_condition,
+        ss.overall_intensity,
+    )


### PR DESCRIPTION
## Summary

Adds self-state publishing capability to the self-state runtime worker and integrates substrate self-state consumption into the spark introspector. The runtime now publishes computed self-state to a message bus, and the introspector consumes these events to use substrate-derived phi dimensions instead of tissue-only calculations when available.

## Key Changes

- **orion-self-state-runtime worker**: Modified `_tick()` to return the computed `SelfStateV1` state instead of `None`, enabling state publication
  - Added `_publish_self_state()` async method to envelope and publish state to the bus
  - Added `set_publisher_bus()` function to inject bus dependency
  - Added helper `_svc_ref()` to construct service references for envelopes

- **orion-self-state-runtime main**: Initialized `OrionBusAsync` in the lifespan context and passed it to the worker via `set_publisher_bus()`

- **orion-self-state-runtime settings**: Added bus configuration (URL, enabled flag) and channel name for substrate self-state events

- **orion-spark-introspector worker**: 
  - Added `handle_self_state()` handler to consume `substrate.self_state.v1` events
  - Added `set_latest_self_state()` to store the most recent self-state
  - Added `_phi_from_self_state()` to extract phi dimensions from substrate self-state
  - Added `_get_phi_stats()` to return substrate phi when available, falling back to tissue phi
  - Replaced four inline `TISSUE.phi()` calls with `_get_phi_stats()` to use substrate state when present

- **orion-spark-introspector main**: Registered `handle_self_state` in the event multiplexer and added the channel to subscriptions

- **orion-spark-introspector settings**: Added channel configuration for substrate self-state

- **orion/bus/channels.yaml**: Declared new `orion:substrate:self_state` channel with producer (self-state-runtime) and consumer (spark-introspector) mappings

## Implementation Details

- Self-state publishing is conditional: only publishes if state is non-null, bus is initialized, and bus is enabled
- Phi dimension extraction from self-state uses safe dictionary access with sensible defaults (0.5 for most, 0.0 for valence)
- Valence is scaled from agency_readiness (0–1 range) to (−1, 1) range via `score * 2.0 - 1.0`
- Energy is inverted from resource_pressure: `1.0 - score`
- Fallback to tissue phi ensures backward compatibility when substrate self-state is unavailable

https://claude.ai/code/session_01KSm4dUZ4abENw526CHD6LJ