### PR TITLE
Add tension extraction from self-state and feedback frames

### DIFF
--- a/orion/field_coherence.py
+++ b/orion/field_coherence.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from orion.schemas.field_state import FieldStateV1
+
+# Each rule is (channel_a, channel_b, description).
+# Suspicion fires when channel_a is HIGH and channel_b is LOW, suggesting
+# the two reducers disagree about the node's actual state.
+_RULES: tuple[tuple[str, str], ...] = (
+    ("execution_load", "cpu_pressure"),
+    ("execution_load", "gpu_pressure"),
+    ("failure_pressure", "availability"),
+    ("transport_pressure", "bus_health"),
+    ("reasoning_load", "cpu_pressure"),
+)
+
+_HIGH = 0.6
+_LOW = 0.25
+
+
+def _rule_suspicion(vec: dict[str, float]) -> float:
+    """Return 0-1 incoherence score for one node vector."""
+    hits = 0
+    applicable = 0
+    for high_ch, low_ch in _RULES:
+        if high_ch not in vec and low_ch not in vec:
+            continue
+        applicable += 1
+        high_val = vec.get(high_ch, 0.0)
+        low_val = vec.get(low_ch, 1.0)
+        if high_val >= _HIGH and low_val <= _LOW:
+            hits += 1
+    if applicable == 0:
+        return 0.0
+    return hits / applicable
+
+
+def check_field_coherence(state: FieldStateV1) -> dict[str, float]:
+    """Return per-node incoherence scores (0-1). Empty if no suspicion found."""
+    scores: dict[str, float] = {}
+    for node_id, vec in state.node_vectors.items():
+        s = _rule_suspicion(vec)
+        if s > 0.0:
+            scores[node_id] = round(s, 4)
+    return scores

--- a/orion/identity/snapshot.py
+++ b/orion/identity/snapshot.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.schemas.identity_snapshot import IdentitySnapshotV1
+from orion.schemas.self_state import SelfStateV1
+
+
+def _snapshot_id(self_state_id: str, generated_at: datetime) -> str:
+    return f"identity:{self_state_id}:{generated_at.isoformat()}"
+
+
+def build_identity_snapshot(
+    *,
+    self_state: SelfStateV1,
+    dominant_drive: str,
+    active_drives: list[str],
+    key_unknowns: list[str],
+    subject: str = "orion",
+    now: datetime | None = None,
+) -> IdentitySnapshotV1:
+    generated_at = now or datetime.now(timezone.utc)
+    return IdentitySnapshotV1(
+        snapshot_id=_snapshot_id(self_state.self_state_id, generated_at),
+        generated_at=generated_at,
+        dominant_drive=dominant_drive,
+        active_drives=active_drives,
+        self_state_condition=self_state.overall_condition,
+        overall_intensity=self_state.overall_intensity,
+        summary_labels=self_state.summary_labels,
+        key_unknowns=key_unknowns,
+        trajectory_condition=self_state.trajectory_condition,
+        source_self_state_id=self_state.self_state_id,
+        source_autonomy_subject=subject,
+    )

--- a/orion/schemas/identity_snapshot.py
+++ b/orion/schemas/identity_snapshot.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class IdentitySnapshotV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["identity_snapshot.v1"] = "identity_snapshot.v1"
+    snapshot_id: str
+    generated_at: datetime
+
+    dominant_drive: str
+    active_drives: list[str] = Field(default_factory=list)
+    self_state_condition: str
+    overall_intensity: float = Field(ge=0.0, le=1.0)
+    summary_labels: list[str] = Field(default_factory=list)
+    key_unknowns: list[str] = Field(default_factory=list)
+    trajectory_condition: str = "unknown"
+    source_self_state_id: str
+    source_autonomy_subject: str = "orion"

--- a/orion/schemas/self_state_prediction.py
+++ b/orion/schemas/self_state_prediction.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SelfStatePredictionV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["self_state_prediction.v1"] = "self_state_prediction.v1"
+    prediction_id: str
+    generated_at: datetime
+    source_self_state_id: str
+    predicted_dimension_scores: dict[str, float] = Field(default_factory=dict)

--- a/orion/self_state/prediction.py
+++ b/orion/self_state/prediction.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.schemas.self_state import SelfStateV1
+from orion.schemas.self_state_prediction import SelfStatePredictionV1
+
+
+def build_next_cycle_prediction(
+    self_state: SelfStateV1,
+    *,
+    now: datetime | None = None,
+) -> SelfStatePredictionV1:
+    """Linear one-step extrapolation from current scores + trajectory deltas."""
+    generated_at = now or datetime.now(timezone.utc)
+    predicted: dict[str, float] = {}
+    for dim_id, dim in self_state.dimensions.items():
+        delta = self_state.dimension_trajectory.get(dim_id, 0.0)
+        predicted[dim_id] = max(0.0, min(1.0, dim.score + delta))
+    return SelfStatePredictionV1(
+        prediction_id=f"pred:{self_state.self_state_id}",
+        generated_at=generated_at,
+        source_self_state_id=self_state.self_state_id,
+        predicted_dimension_scores=predicted,
+    )
+
+
+def compute_prediction_errors(
+    actual: SelfStateV1,
+    prediction: SelfStatePredictionV1,
+) -> dict[str, float]:
+    """Per-dimension absolute error between predicted and actual scores."""
+    errors: dict[str, float] = {}
+    for dim_id, predicted_score in prediction.predicted_dimension_scores.items():
+        actual_dim = actual.dimensions.get(dim_id)
+        if actual_dim is None:
+            continue
+        err = abs(actual_dim.score - predicted_score)
+        if err >= 0.01:
+            errors[dim_id] = round(err, 4)
+    return errors

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -11,6 +11,8 @@ from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.core.schemas.concept_induction import ConceptProfile, ConceptProfileDelta
 from orion.core.schemas.drives import ArtifactProvenance, GraphReadyArtifact, TurnDossierV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+from orion.schemas.self_state import SelfStateV1
 from orion.schemas.vector.schemas import VectorWriteRequest
 
 from .audit import build_drive_audit
@@ -29,7 +31,12 @@ from .inducer import ConceptInducer, WindowEvent
 from .settings import ConceptSettings
 from .store import LocalProfileStore
 from .summarizer import Summarizer
-from .tensions import derive_pressure_competition_tensions, extract_tensions
+from .tensions import (
+    derive_pressure_competition_tensions,
+    extract_tensions,
+    extract_tensions_from_feedback,
+    extract_tensions_from_self_state,
+)
 from .rdf_materialization import build_concept_profile_rdf_request
 
 logger = logging.getLogger("orion.spark.concept.worker")
@@ -112,6 +119,7 @@ class ConceptWorker:
         self.inflight_subjects: Set[str] = set()
         self.recent_event_seen: Dict[str, datetime] = {}
         self.trigger_decisions: List[dict] = []
+        self._previous_self_state: Optional[SelfStateV1] = None
         self._stopped = False
         self._liveness = WorkerLivenessState(
             worker_initialized=True,
@@ -144,6 +152,8 @@ class ConceptWorker:
             ],
             "cognition_trace": ["channel contains cognition:trace"],
             "collapse_event": ["channel contains collapse"],
+            "self_state_update": ["kind=substrate.self_state.v1"],
+            "feedback_outcome": ["kind=feedback.frame.v1"],
             "generic_activity": ["fallback"],
         }
 
@@ -207,6 +217,10 @@ class ConceptWorker:
             return "cognition_trace"
         if "collapse" in lowered_channel:
             return "collapse_event"
+        if lowered_kind == "substrate.self_state.v1":
+            return "self_state_update"
+        if lowered_kind == "feedback.frame.v1":
+            return "feedback_outcome"
         return "generic_activity"
 
     def _select_trigger_subjects(
@@ -415,19 +429,64 @@ class ConceptWorker:
         )
         await self.bus.publish(self.cfg.turn_dossier_channel, env)
 
-    async def handle_envelope(self, env: BaseEnvelope, intake_channel: str) -> None:
-        text = self._extract_text(env)
-        subject = self._detect_subject(env, intake_channel)
-        model_layer = self._model_layer(subject, intake_channel)
-        entity_id = self._entity_id(subject, model_layer)
+    @staticmethod
+    def _payload_dict(env: BaseEnvelope) -> dict:
+        payload = env.payload
+        if hasattr(payload, "model_dump"):
+            payload = payload.model_dump()
+        return payload if isinstance(payload, dict) else {}
 
-        spark_tensions = extract_tensions(
+    def _tensions_from_self_state(self, env: BaseEnvelope, intake_channel: str) -> List[TensionEventV1]:
+        try:
+            self_state = SelfStateV1.model_validate(self._payload_dict(env))
+        except Exception:
+            logger.warning("substrate_self_state_parse_failed kind=%s", env.kind)
+            return []
+        tensions = extract_tensions_from_self_state(
             envelope=env,
             intake_channel=intake_channel,
-            subject=subject,
-            model_layer=model_layer,
-            entity_id=entity_id,
+            self_state=self_state,
+            previous_self_state=self._previous_self_state,
         )
+        self._previous_self_state = self_state
+        return tensions
+
+    def _tensions_from_feedback(self, env: BaseEnvelope, intake_channel: str) -> List[TensionEventV1]:
+        try:
+            frame = FeedbackFrameV1.model_validate(self._payload_dict(env))
+        except Exception:
+            logger.warning("feedback_frame_parse_failed kind=%s", env.kind)
+            return []
+        return extract_tensions_from_feedback(
+            envelope=env,
+            intake_channel=intake_channel,
+            feedback_frame=frame,
+        )
+
+    async def handle_envelope(self, env: BaseEnvelope, intake_channel: str) -> None:
+        text = self._extract_text(env)
+
+        if env.kind == "substrate.self_state.v1":
+            subject = "orion"
+            model_layer = model_layer_for_subject(subject)
+            entity_id = entity_id_for_subject(subject, model_layer)
+            spark_tensions = self._tensions_from_self_state(env, intake_channel)
+        elif env.kind == "feedback.frame.v1":
+            subject = "orion"
+            model_layer = model_layer_for_subject(subject)
+            entity_id = entity_id_for_subject(subject, model_layer)
+            spark_tensions = self._tensions_from_feedback(env, intake_channel)
+        else:
+            subject = self._detect_subject(env, intake_channel)
+            model_layer = self._model_layer(subject, intake_channel)
+            entity_id = self._entity_id(subject, model_layer)
+            spark_tensions = extract_tensions(
+                envelope=env,
+                intake_channel=intake_channel,
+                subject=subject,
+                model_layer=model_layer,
+                entity_id=entity_id,
+            )
         published_artifacts: List[GraphReadyArtifact] = []
         for tension in spark_tensions:
             await self._publish_tension_event(tension, env.correlation_id)
@@ -535,6 +594,10 @@ class ConceptWorker:
             suppressed_goal_signatures=suppressed_signatures,
         )
         await self._publish_dossier(dossier, env.correlation_id)
+
+        # Structured substrate/feedback signals carry no text: skip concept induction.
+        if env.kind in {"substrate.self_state.v1", "feedback.frame.v1"}:
+            return
 
         source_kind = self._source_kind(env, intake_channel)
         subjects = self._select_trigger_subjects(env, intake_channel, source_kind, text)

--- a/orion/spark/concept_induction/extractor.py
+++ b/orion/spark/concept_induction/extractor.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from typing import Iterable, List, Tuple
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import spacy
 from spacy.language import Language
@@ -12,6 +12,7 @@ from spacy.language import Language
 class ExtractionResult:
     candidates: List[str]
     debug: dict
+    entity_types: Dict[str, str] = field(default_factory=dict)
 
 
 _WORD_RE = re.compile(r"[A-Za-z][\w'-]+")
@@ -34,24 +35,30 @@ class SpacyConceptExtractor:
     def _normalize(self, text: str) -> str:
         return re.sub(r"\s+", " ", text.strip().lower())
 
-    def _chunk_candidates(self, doc) -> List[str]:
-        labels: List[str] = []
+    def _chunk_candidates(self, doc) -> List[Tuple[str, Optional[str]]]:
+        """Return (text, ner_label_or_None) pairs; NER entities first, then noun chunks."""
+        results: List[Tuple[str, Optional[str]]] = []
+        seen: set[str] = set()
         for ent in getattr(doc, "ents", []):
             if ent.label_:
-                labels.append(ent.text)
+                results.append((ent.text, ent.label_.lower()))
+                seen.add(ent.text)
         try:
-            labels.extend(chunk.text for chunk in doc.noun_chunks)
+            for chunk in doc.noun_chunks:
+                if chunk.text not in seen:
+                    results.append((chunk.text, None))
         except Exception:
             # Blank models or parser-less pipelines cannot provide noun chunks.
             pass
-        return labels
+        return results
 
-    def _regex_candidates(self, text: str) -> List[str]:
-        return _WORD_RE.findall(text)
+    def _regex_candidates(self, text: str) -> List[Tuple[str, Optional[str]]]:
+        return [(_w, None) for _w in _WORD_RE.findall(text)]
 
     def extract(self, texts: Iterable[str], *, top_k: int = 50) -> ExtractionResult:
         freq: dict[str, float] = {}
         debug_meta: dict[str, dict[str, float]] = {}
+        entity_types: dict[str, str] = {}
         for idx, text in enumerate(texts):
             if not text:
                 continue
@@ -59,15 +66,23 @@ class SpacyConceptExtractor:
             raw_candidates = self._chunk_candidates(doc)
             if not raw_candidates:
                 raw_candidates = self._regex_candidates(text)
-            normed = [self._normalize(c) for c in raw_candidates if c]
             weight = 1.0 + (idx * 0.01)
-            for cand in normed:
+            for raw_text, ner_label in raw_candidates:
+                if not raw_text:
+                    continue
+                cand = self._normalize(raw_text)
                 freq[cand] = freq.get(cand, 0.0) + weight
                 meta = debug_meta.setdefault(cand, {"count": 0.0})
                 meta["count"] += weight
+                if ner_label and cand not in entity_types:
+                    entity_types[cand] = ner_label
 
         sorted_items: List[Tuple[str, float]] = sorted(
             freq.items(), key=lambda kv: kv[1], reverse=True
         )
         top_candidates = [c for c, _ in sorted_items[:top_k]]
-        return ExtractionResult(candidates=top_candidates, debug={"freq": debug_meta})
+        return ExtractionResult(
+            candidates=top_candidates,
+            debug={"freq": debug_meta},
+            entity_types=entity_types,
+        )

--- a/orion/spark/concept_induction/inducer.py
+++ b/orion/spark/concept_induction/inducer.py
@@ -21,9 +21,31 @@ from orion.core.schemas.concept_induction import (
 
 from .clusterer import ConceptClusterer
 from .embedder import EmbeddingClient
-from .extractor import SpacyConceptExtractor
+from .extractor import ExtractionResult, SpacyConceptExtractor
 from .settings import ConceptSettings
 from .summarizer import Summarizer
+
+# spaCy NER labels → open concept type vocabulary
+_NER_TO_CONCEPT_TYPE: dict[str, str] = {
+    "person": "person",
+    "norp": "group",
+    "fac": "place",
+    "org": "organization",
+    "gpe": "place",
+    "loc": "place",
+    "product": "artifact",
+    "event": "event",
+    "work_of_art": "artifact",
+    "law": "policy",
+    "language": "language",
+    "date": "temporal",
+    "time": "temporal",
+    "money": "quantity",
+    "quantity": "quantity",
+    "cardinal": "quantity",
+    "ordinal": "quantity",
+    "percent": "quantity",
+}
 
 logger = logging.getLogger("orion.spark.concept.inducer")
 
@@ -149,22 +171,40 @@ class ConceptInducer:
         embeddings_resp = self.embedder.embed(candidates)
         clusters = self.clusterer.cluster(candidates, embeddings_resp.embeddings)
 
+        freq_data = extraction.debug.get("freq", {})
+        raw_counts = [
+            v["count"] for v in freq_data.values() if isinstance(v, dict) and "count" in v
+        ]
+        max_freq = max(raw_counts, default=1.0) or 1.0
+
         concept_items: List[ConceptItem] = []
         for cand in candidates:
             concept_id = make_concept_id(cand)
+            raw_freq = freq_data.get(cand, {})
+            raw_count = raw_freq["count"] if isinstance(raw_freq, dict) else 0.0
+            salience = raw_count / max_freq
+
+            has_embed = cand in embeddings_resp.embeddings
+            confidence = min(1.0, 0.5 + (0.15 if has_embed else 0.0) + 0.35 * salience)
+
+            ner_label = extraction.entity_types.get(cand)
+            concept_type = _NER_TO_CONCEPT_TYPE.get(ner_label, "topic") if ner_label else "topic"
+
             concept_items.append(
                 ConceptItem(
                     concept_id=concept_id,
                     label=cand,
                     aliases=[],
-                    type="identity" if subject in {"orion", "juniper"} else "relationship",
-                    salience=1.0,
-                    confidence=0.6 if not embeddings_resp.embeddings else 0.75,
-                    embedding_ref=f"embedding:{concept_id}"
-                    if cand in embeddings_resp.embeddings
-                    else None,
+                    type=concept_type,
+                    salience=salience,
+                    confidence=confidence,
+                    embedding_ref=f"embedding:{concept_id}" if has_embed else None,
                     evidence=evidence[:5],
-                    metadata={"source": "spacy", "extraction": "ner+chunks"},
+                    metadata={
+                        "source": "spacy",
+                        "extraction": "ner+chunks",
+                        "ner_label": ner_label or "",
+                    },
                 )
             )
 

--- a/orion/spark/concept_induction/settings.py
+++ b/orion/spark/concept_induction/settings.py
@@ -36,6 +36,8 @@ class ConceptSettings(BaseSettings):
             "orion:spark:telemetry",
             "orion:metacognition:tick",
             "orion:cognition:trace",
+            "orion:substrate:self_state",
+            "orion:feedback:frame",
         ],
         validation_alias=AliasChoices("BUS_INTAKE_CHANNELS", "CONCEPT_INTAKE_CHANNELS"),
     )

--- a/orion/spark/concept_induction/tensions.py
+++ b/orion/spark/concept_induction/tensions.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional, Sequence
 
 from orion.core.bus.bus_schemas import BaseEnvelope
 from orion.core.schemas.drives import ArtifactProvenance, TensionEventV1
+from orion.schemas.feedback_frame import FeedbackFrameV1
+from orion.schemas.self_state import SelfStateV1
 
 from .dossier import build_evidence_items, build_source_event_ref, extract_trace_id, extract_turn_id
 
@@ -257,3 +259,207 @@ def derive_pressure_competition_tensions(
     )
     event.provenance.tension_refs = [event.artifact_id]
     return [event]
+
+
+def extract_tensions_from_self_state(
+    *,
+    envelope: BaseEnvelope,
+    intake_channel: str,
+    self_state: SelfStateV1,
+    previous_self_state: Optional[SelfStateV1] = None,
+) -> List[TensionEventV1]:
+    """Derive tensions from substrate self-state ticks, using dimension deltas where a previous state exists."""
+    subject = "orion"
+    model_layer = "self-model"
+    entity_id = "self:orion"
+
+    d = self_state.dimensions
+
+    def _s(key: str, default: float = 0.5) -> float:
+        dim = d.get(key)
+        return float(dim.score) if dim is not None else default
+
+    def _delta(key: str) -> Optional[float]:
+        if previous_self_state is None:
+            return None
+        prev = previous_self_state.dimensions.get(key)
+        return _s(key) - (float(prev.score) if prev is not None else _s(key))
+
+    ts = envelope.created_at if envelope.created_at.tzinfo else envelope.created_at.replace(tzinfo=timezone.utc)
+    trace_id = extract_trace_id(envelope)
+    turn_id = extract_turn_id(envelope)
+    source_event_ref = build_source_event_ref(envelope, intake_channel)
+    evidence_text = f"condition={self_state.overall_condition} trajectory={self_state.trajectory_condition}"
+    evidence_items = build_evidence_items(envelope, intake_channel, evidence_text)
+    prov = ArtifactProvenance(
+        intake_channel=intake_channel,
+        correlation_id=str(envelope.correlation_id),
+        trace_id=str(trace_id) if trace_id else None,
+        turn_id=turn_id,
+        evidence_text=evidence_text,
+        evidence_summary=evidence_items[0].summary if evidence_items else None,
+        source_event_refs=[source_event_ref],
+        evidence_items=evidence_items,
+    )
+    traj_mul = 1.25 if self_state.trajectory_condition == "degrading" else 1.0
+
+    events: List[TensionEventV1] = []
+
+    # Coherence drop → contradiction (integration is breaking down)
+    coh_delta = _delta("coherence")
+    coh_now = _s("coherence")
+    fire_coh = coh_delta < -0.04 if coh_delta is not None else coh_now < 0.35
+    mag_coh = clamp01(abs(coh_delta) * traj_mul) if coh_delta is not None else clamp01((0.5 - coh_now) * traj_mul)
+    if fire_coh and mag_coh > 0.0:
+        events.append(TensionEventV1(
+            artifact_id=_artifact_id(envelope, entity_id, "tension.contradiction.v1"),
+            subject=subject, model_layer=model_layer, entity_id=entity_id,
+            kind="tension.contradiction.v1", ts=ts, confidence=0.82,
+            correlation_id=str(envelope.correlation_id),
+            trace_id=str(trace_id) if trace_id else None, turn_id=turn_id,
+            provenance=prov,
+            related_nodes=["substrate:coherence", "drive:coherence", "drive:predictive"],
+            magnitude=mag_coh,
+            drive_impacts={"coherence": 1.0, "predictive": 0.7},
+        ))
+
+    # Agency/social-ease drop → distress
+    agency_delta = _delta("agency_readiness")
+    social_delta = _delta("social_pressure")  # rising pressure = distress signal
+    agency_now = _s("agency_readiness")
+    if agency_delta is not None or social_delta is not None:
+        combined = (-(agency_delta or 0.0) + (social_delta or 0.0)) / 2.0
+        fire_dist = combined > 0.04
+        mag_dist = clamp01(combined * traj_mul)
+    else:
+        fire_dist = agency_now < 0.30
+        mag_dist = clamp01((0.5 - agency_now) * traj_mul)
+    if fire_dist and mag_dist > 0.0:
+        events.append(TensionEventV1(
+            artifact_id=_artifact_id(envelope, entity_id, "tension.distress.v1"),
+            subject=subject, model_layer=model_layer, entity_id=entity_id,
+            kind="tension.distress.v1", ts=ts, confidence=0.78,
+            correlation_id=str(envelope.correlation_id),
+            trace_id=str(trace_id) if trace_id else None, turn_id=turn_id,
+            provenance=prov,
+            related_nodes=["substrate:agency_readiness", "substrate:social_pressure", "drive:relational", "drive:continuity"],
+            magnitude=mag_dist,
+            drive_impacts={"relational": 0.9, "continuity": 0.55},
+        ))
+
+    # Uncertainty rise → identity_drift (ground shifting)
+    unc_delta = _delta("uncertainty")
+    unc_now = _s("uncertainty")
+    fire_unc = unc_delta > 0.05 if unc_delta is not None else unc_now > 0.75
+    mag_unc = clamp01(unc_delta * traj_mul) if unc_delta is not None else clamp01((unc_now - 0.5) * traj_mul)
+    if fire_unc and mag_unc > 0.0:
+        events.append(TensionEventV1(
+            artifact_id=_artifact_id(envelope, entity_id, "tension.identity_drift.v1"),
+            subject=subject, model_layer=model_layer, entity_id=entity_id,
+            kind="tension.identity_drift.v1", ts=ts, confidence=0.72,
+            correlation_id=str(envelope.correlation_id),
+            trace_id=str(trace_id) if trace_id else None, turn_id=turn_id,
+            provenance=prov,
+            related_nodes=["substrate:uncertainty", "drive:continuity", "drive:autonomy"],
+            magnitude=mag_unc,
+            drive_impacts={"continuity": 0.8, "autonomy": 0.6, "predictive": 0.4},
+        ))
+
+    # Resource + execution pressure rise → cognitive_load
+    res_delta = _delta("resource_pressure")
+    exe_delta = _delta("execution_pressure")
+    res_now = _s("resource_pressure")
+    exe_now = _s("execution_pressure")
+    if res_delta is not None or exe_delta is not None:
+        load_delta = ((res_delta or 0.0) + (exe_delta or 0.0)) / 2.0
+        fire_load = load_delta > 0.04
+        mag_load = clamp01(load_delta * traj_mul)
+    else:
+        overall_load = (res_now + exe_now) / 2.0
+        fire_load = overall_load > 0.65
+        mag_load = clamp01((overall_load - 0.5) * traj_mul)
+    if fire_load and mag_load > 0.0:
+        events.append(TensionEventV1(
+            artifact_id=_artifact_id(envelope, entity_id, "tension.cognitive_load.v1"),
+            subject=subject, model_layer=model_layer, entity_id=entity_id,
+            kind="tension.cognitive_load.v1", ts=ts, confidence=0.76,
+            correlation_id=str(envelope.correlation_id),
+            trace_id=str(trace_id) if trace_id else None, turn_id=turn_id,
+            provenance=prov,
+            related_nodes=["substrate:resource_pressure", "substrate:execution_pressure", "drive:capability"],
+            magnitude=mag_load,
+            drive_impacts={"capability": 0.9, "coherence": 0.45},
+        ))
+
+    for event in events:
+        event.provenance.tension_refs = [event.artifact_id]
+    return events
+
+
+def extract_tensions_from_feedback(
+    *,
+    envelope: BaseEnvelope,
+    intake_channel: str,
+    feedback_frame: FeedbackFrameV1,
+) -> List[TensionEventV1]:
+    """Derive tensions from a scored feedback frame — real outcome signal closing the autonomy loop."""
+    subject = "orion"
+    model_layer = "self-model"
+    entity_id = "self:orion"
+
+    ts = envelope.created_at if envelope.created_at.tzinfo else envelope.created_at.replace(tzinfo=timezone.utc)
+    trace_id = extract_trace_id(envelope)
+    turn_id = extract_turn_id(envelope)
+    source_event_ref = build_source_event_ref(envelope, intake_channel)
+    evidence_text = (
+        f"outcome_status={feedback_frame.outcome_status} "
+        f"score={feedback_frame.outcome_score:.3f} "
+        f"confidence={feedback_frame.confidence_score:.3f}"
+    )
+    evidence_items = build_evidence_items(envelope, intake_channel, evidence_text)
+    prov = ArtifactProvenance(
+        intake_channel=intake_channel,
+        correlation_id=str(envelope.correlation_id),
+        trace_id=str(trace_id) if trace_id else None,
+        turn_id=turn_id,
+        evidence_text=evidence_text,
+        evidence_summary=evidence_items[0].summary if evidence_items else None,
+        source_event_refs=[source_event_ref],
+        evidence_items=evidence_items,
+    )
+
+    events: List[TensionEventV1] = []
+    conf = clamp01(feedback_frame.confidence_score)
+
+    # Failed/absent/blocked outcome → contradiction (predicted success, got nothing)
+    if feedback_frame.outcome_status in ("failed", "absent", "blocked"):
+        events.append(TensionEventV1(
+            artifact_id=_artifact_id(envelope, entity_id, "tension.contradiction.v1"),
+            subject=subject, model_layer=model_layer, entity_id=entity_id,
+            kind="tension.contradiction.v1", ts=ts, confidence=conf,
+            correlation_id=str(envelope.correlation_id),
+            trace_id=str(trace_id) if trace_id else None, turn_id=turn_id,
+            provenance=prov,
+            related_nodes=["feedback:outcome_status", "drive:predictive", "drive:coherence"],
+            magnitude=clamp01(1.0 - feedback_frame.outcome_score),
+            drive_impacts={"predictive": 1.0, "coherence": 0.65},
+        ))
+
+    # Low outcome score → distress (the action didn't land; autonomy frustrated)
+    if feedback_frame.outcome_score < 0.4:
+        mag = clamp01((0.5 - feedback_frame.outcome_score) * 2.0)
+        events.append(TensionEventV1(
+            artifact_id=_artifact_id(envelope, entity_id, "tension.distress.v1"),
+            subject=subject, model_layer=model_layer, entity_id=entity_id,
+            kind="tension.distress.v1", ts=ts, confidence=conf,
+            correlation_id=str(envelope.correlation_id),
+            trace_id=str(trace_id) if trace_id else None, turn_id=turn_id,
+            provenance=prov,
+            related_nodes=["feedback:outcome_score", "drive:relational", "drive:continuity", "drive:autonomy"],
+            magnitude=mag,
+            drive_impacts={"relational": 0.8, "continuity": 0.55, "autonomy": 0.5},
+        ))
+
+    for event in events:
+        event.provenance.tension_refs = [event.artifact_id]
+    return events

--- a/orion/substrate/prediction_error.py
+++ b/orion/substrate/prediction_error.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from orion.schemas.execution_projection import ExecutionTrajectoryProjectionV1
+from orion.schemas.transport_projection import TransportBusProjectionV1
+
+_THRESHOLD = 0.30
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def execution_prediction_error(
+    prev: ExecutionTrajectoryProjectionV1,
+    curr: ExecutionTrajectoryProjectionV1,
+) -> float:
+    """0-1 surprise score: how much did execution pressure hints change this batch?"""
+    deltas: list[float] = []
+    for trace_id, curr_run in curr.runs.items():
+        prev_run = prev.runs.get(trace_id)
+        if prev_run is None:
+            continue
+        for key in ("execution_load", "execution_friction", "failure_pressure", "reasoning_load"):
+            pv = prev_run.pressure_hints.get(key, 0.0)
+            cv = curr_run.pressure_hints.get(key, 0.0)
+            deltas.append(abs(cv - pv))
+    return min(1.0, _mean(deltas) / _THRESHOLD) if deltas else 0.0
+
+
+def transport_prediction_error(
+    prev: TransportBusProjectionV1,
+    curr: TransportBusProjectionV1,
+) -> float:
+    """0-1 surprise score: how much did transport bus health change this batch?"""
+    deltas: list[float] = []
+    for bus_id, curr_bus in curr.buses.items():
+        prev_bus = prev.buses.get(bus_id)
+        if prev_bus is None:
+            continue
+        for field in ("bus_health", "delivery_confidence", "transport_pressure"):
+            pv = getattr(prev_bus, field, 0.0)
+            cv = getattr(curr_bus, field, 0.0)
+            deltas.append(abs(cv - pv))
+    return min(1.0, _mean(deltas) / _THRESHOLD) if deltas else 0.0

--- a/services/orion-feedback-runtime/app/settings.py
+++ b/services/orion-feedback-runtime/app/settings.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     project: str = Field("orion-athena", alias="PROJECT")
     service_name: str = Field("orion-feedback-runtime", alias="SERVICE_NAME")
     service_version: str = Field("0.1.0", alias="SERVICE_VERSION")
+    node_name: str = Field("athena", alias="NODE_NAME")
 
     postgres_uri: str = Field(..., alias="POSTGRES_URI")
     feedback_policy_path: str = Field(
@@ -17,6 +18,10 @@ class Settings(BaseSettings):
     feedback_poll_interval_sec: float = Field(2.0, alias="FEEDBACK_POLL_INTERVAL_SEC")
     enable_feedback_runtime: bool = Field(True, alias="ENABLE_FEEDBACK_RUNTIME")
     log_level: str = Field("INFO", alias="LOG_LEVEL")
+
+    bus_url: str = Field("redis://100.92.216.81:6379/0", alias="ORION_BUS_URL")
+    bus_enabled: bool = Field(True, alias="ORION_BUS_ENABLED")
+    feedback_bus_channel: str = Field("orion:feedback:frame", alias="FEEDBACK_BUS_CHANNEL")
 
 
 _settings: Settings | None = None

--- a/services/orion-feedback-runtime/app/worker.py
+++ b/services/orion-feedback-runtime/app/worker.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
+from typing import Optional
 
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.feedback.builder import build_feedback_frame
 from orion.feedback.policy import load_feedback_policy
+from orion.schemas.feedback_frame import FeedbackFrameV1
 
 from app.settings import get_settings
 from app.store import FeedbackRuntimeStore
@@ -19,17 +23,32 @@ class FeedbackRuntimeWorker:
         self._store = FeedbackRuntimeStore(self._settings.postgres_uri)
         self._policy = load_feedback_policy(Path(self._settings.feedback_policy_path))
         self._stop = asyncio.Event()
+        self._bus = OrionBusAsync(
+            self._settings.bus_url,
+            enabled=self._settings.bus_enabled,
+        )
+
+    def _service_ref(self) -> ServiceRef:
+        return ServiceRef(
+            name=self._settings.service_name,
+            version=self._settings.service_version,
+            node=self._settings.node_name,
+        )
 
     async def start(self) -> None:
+        await self._bus.connect()
         asyncio.create_task(self._poll_loop(), name="feedback-runtime-poll")
 
     async def stop(self) -> None:
         self._stop.set()
+        await self._bus.close()
 
     async def _poll_loop(self) -> None:
         while not self._stop.is_set():
             try:
-                await asyncio.to_thread(self._tick)
+                frame = await asyncio.to_thread(self._tick)
+                if frame is not None:
+                    await self._publish_feedback_frame(frame)
             except Exception:
                 logger.exception("feedback_runtime_tick_failed")
             try:
@@ -42,15 +61,28 @@ class FeedbackRuntimeWorker:
             except asyncio.CancelledError:
                 break
 
-    def _tick(self) -> None:
+    async def _publish_feedback_frame(self, frame: FeedbackFrameV1) -> None:
+        env = BaseEnvelope(
+            kind="feedback.frame.v1",
+            source=self._service_ref(),
+            payload=frame.model_dump(mode="json"),
+        )
+        await self._bus.publish(self._settings.feedback_bus_channel, env)
+        logger.info(
+            "feedback_frame_published frame_id=%s channel=%s",
+            frame.frame_id,
+            self._settings.feedback_bus_channel,
+        )
+
+    def _tick(self) -> Optional[FeedbackFrameV1]:
         if not self._settings.enable_feedback_runtime:
-            return
+            return None
 
         dispatch = self._store.load_latest_dispatch_frame_without_feedback()
         if dispatch is None:
-            return
+            return None
         if self._store.load_feedback_frame_for_dispatch(dispatch.frame_id) is not None:
-            return
+            return None
 
         policy_frame = self._store.load_policy_frame(dispatch.source_policy_frame_id)
         proposal_frame = self._store.load_proposal_frame(dispatch.source_proposal_frame_id)
@@ -78,3 +110,4 @@ class FeedbackRuntimeWorker:
             frame.outcome_status,
             len(frame.observations),
         )
+        return frame

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -74,6 +74,7 @@ _VALENCE_INIT_TASK: Optional[asyncio.Task] = None
 _VALENCE_ANCHORS_EXPIRES_AT: float = 0.0
 
 _LATEST_SELF_STATE: Optional[SelfStateV1] = None
+_PREV_PHI: Optional[Dict[str, float]] = None
 
 
 def set_latest_self_state(ss: SelfStateV1) -> None:
@@ -1844,16 +1845,92 @@ async def handle_signal(env: BaseEnvelope) -> None:
 
 
 async def handle_self_state(env: BaseEnvelope) -> None:
+    global _PREV_PHI
     payload = env.payload if isinstance(env.payload, dict) else {}
     try:
         ss = SelfStateV1.model_validate(payload)
     except ValidationError:
         logger.warning("Ignoring malformed substrate.self_state payload")
         return
+
+    phi_now = _phi_from_self_state(ss)
+    phi_prev = _PREV_PHI  # snapshot before update
+    _PREV_PHI = phi_now
     set_latest_self_state(ss)
+
+    # Compute real inter-tick delta — two genuinely time-separated substrate snapshots.
+    turn_effect: Optional[Dict[str, float]] = None
+    if phi_prev is not None:
+        turn_effect = {k: round(phi_now[k] - phi_prev.get(k, phi_now[k]), 4) for k in phi_now}
+
     logger.debug(
-        "self_state_updated self_state_id=%s condition=%s intensity=%.3f",
+        "self_state_updated self_state_id=%s condition=%s intensity=%.3f phi=%s delta=%s",
         ss.self_state_id,
         ss.overall_condition,
         ss.overall_intensity,
+        phi_now,
+        turn_effect,
     )
+
+    if not (_pub_bus and _pub_bus.enabled):
+        return
+
+    seq = _next_seq()
+    meta: Dict[str, Any] = {
+        "trigger": "substrate_tick",
+        "self_state_id": ss.self_state_id,
+        "condition": ss.overall_condition,
+        "trajectory": ss.trajectory_condition,
+        "phi_before": phi_prev,
+        "phi_after": phi_now,
+    }
+    if turn_effect is not None:
+        meta["turn_effect"] = {"turn": turn_effect}
+        meta["spark_meta"] = {
+            "phi_before": phi_prev,
+            "phi_post_after": phi_now,
+        }
+
+    snap = SparkStateSnapshotV1(
+        source_service=settings.service_name,
+        source_node=settings.node_name,
+        producer_boot_id=_PRODUCER_BOOT_ID,
+        seq=seq,
+        snapshot_ts=ss.generated_at,
+        valid_for_ms=int(settings.spark_state_valid_for_ms),
+        correlation_id=ss.self_state_id,
+        trace_mode="substrate",
+        trace_verb="self_state_tick",
+        phi=phi_now,
+        valence=float(phi_now.get("valence", 0.0)),
+        arousal=float(phi_now.get("energy", 0.5)),
+        dominance=0.5,
+        vector_present=False,
+        metadata=meta,
+    )
+    snap_env = SparkStateSnapshotEnvelope(
+        source=_svc_ref(),
+        correlation_id=ss.self_state_id,
+        causality_chain=env.causality_chain,
+        payload=snap,
+    )
+    await _pub_bus.publish(settings.channel_spark_state_snapshot, snap_env)
+
+    try:
+        ws_payload = {
+            "type": "tissue.update",
+            "telemetry_id": str(uuid4()),
+            "correlation_id": ss.self_state_id,
+            "timestamp": ss.generated_at.isoformat(),
+            "stats": {
+                "phi": float(phi_now.get("coherence", 0.5)),
+                "novelty": float(phi_now.get("novelty", 0.0)),
+                "valence": float(phi_now.get("valence", 0.0)),
+                "arousal": float(phi_now.get("energy", 0.5)),
+            },
+            "grid": [],
+            "metadata": meta,
+        }
+        await manager.broadcast(ws_payload)
+    except Exception as exc:
+        logger.warning("Failed to broadcast substrate tick to WebSocket: %s", exc)

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -83,11 +83,60 @@ def set_latest_self_state(ss: SelfStateV1) -> None:
 
 def _phi_from_self_state(ss: SelfStateV1) -> Dict[str, float]:
     d = ss.dimensions
+    traj = ss.dimension_trajectory  # per-dimension change vectors from self-state-runtime
+
+    def _s(key: str, default: float = 0.5) -> float:
+        dim = d.get(key)
+        return float(dim.score) if dim is not None else default
+
+    def _t(key: str) -> float:
+        return max(-1.0, min(1.0, float(traj.get(key, 0.0))))
+
+    # Coherence: geometric mean across integration dimensions.
+    # Every factor must be healthy — a single broken link collapses the whole.
+    # This mirrors IIT: consciousness requires global integration, not local patches.
+    field_coh   = _s("coherence", 0.5)
+    continuity  = 1.0 - _s("continuity_pressure", 0.0)
+    reliability = 1.0 - _s("reliability_pressure", 0.0)
+    transport   = _s("transport_integrity", 1.0)
+    coherence   = max(0.01, (field_coh * continuity * reliability * transport) ** 0.25)
+
+    # Energy: activation × available capacity (multiplicative, not additive).
+    # Being highly active with no room left isn't energy — it's grinding.
+    intensity     = _s("field_intensity", 0.5)
+    resource_cap  = 1.0 - _s("resource_pressure", 0.5)
+    execution_cap = 1.0 - _s("execution_pressure", 0.3)
+    energy = intensity * (resource_cap * execution_cap) ** 0.5
+    # Trajectory: rising intensity or recovering capacity builds energy momentum.
+    energy += 0.1 * max(0.0, _t("field_intensity")) - 0.1 * max(0.0, _t("resource_pressure"))
+    energy = max(0.0, min(1.0, energy))
+
+    # Novelty: genuine surprise requires a stable ground to notice it against.
+    # Uncertainty on a fragmented system is noise. Uncertainty when coherent = signal.
+    uncertainty   = _s("uncertainty", 0.5)
+    introspection = _s("introspection_pressure", 0.3)
+    novelty = min(1.0, (0.6 * uncertainty + 0.4 * introspection) * (0.3 + 0.7 * coherence))
+
+    # Valence: hedonic tone from agency, social ease, and constraint load.
+    agency      = _s("agency_readiness", 0.5)
+    social_ease = 1.0 - _s("social_pressure", 0.0)
+    policy_ease = 1.0 - _s("policy_pressure", 0.0)
+    raw_valence = 0.5 * agency + 0.3 * social_ease + 0.2 * policy_ease  # [0, 1]
+    # Coherence modulates: fragmentation mutes affect in both directions —
+    # can't feel fully alive, or fully distressed, when scattered.
+    valence = (raw_valence * 2.0 - 1.0) * (0.4 + 0.6 * coherence)
+    # Trajectory: the direction of change matters for how this moment is experienced.
+    if ss.trajectory_condition == "improving":
+        valence += 0.12
+    elif ss.trajectory_condition == "degrading":
+        valence -= 0.12
+    valence = max(-1.0, min(1.0, valence))
+
     return {
-        "coherence": d["coherence"].score if "coherence" in d else 0.5,
-        "energy":    1.0 - d["resource_pressure"].score if "resource_pressure" in d else 0.5,
-        "novelty":   d["uncertainty"].score if "uncertainty" in d else 0.5,
-        "valence":   d["agency_readiness"].score * 2.0 - 1.0 if "agency_readiness" in d else 0.0,
+        "coherence": round(coherence, 4),
+        "energy":    round(energy, 4),
+        "novelty":   round(novelty, 4),
+        "valence":   round(valence, 4),
     }
 
 


### PR DESCRIPTION
## Summary

Extends the tension induction system to derive tensions directly from substrate self-state ticks and feedback outcomes, closing the autonomy loop with real outcome signals. Adds sophisticated phi (coherence, energy, novelty, valence) computation from self-state dimensions, and introduces new schema types for identity snapshots and self-state predictions.

## Key Changes

### Tension Extraction
- **`extract_tensions_from_self_state()`**: Derives four tension types from self-state dimension deltas:
  - `tension.contradiction.v1` on coherence drops (integration breakdown)
  - `tension.distress.v1` on agency/social-ease degradation
  - `tension.identity_drift.v1` on uncertainty rise
  - `tension.cognitive_load.v1` on resource/execution pressure spikes
  - Uses delta-based firing thresholds when previous state exists; falls back to absolute thresholds otherwise
  - Trajectory condition ("improving"/"degrading") modulates magnitude via `traj_mul`

- **`extract_tensions_from_feedback()`**: Derives tensions from scored feedback frames:
  - `tension.contradiction.v1` on failed/absent/blocked outcomes
  - `tension.distress.v1` on low outcome scores (<0.4)
  - Confidence sourced from feedback frame's confidence_score

### Phi (Conscious State) Computation
- **`_phi_from_self_state()`** in worker.py now computes four-dimensional phi vector:
  - **Coherence**: Geometric mean of field coherence, continuity, reliability, and transport integrity (IIT-inspired global integration)
  - **Energy**: Activation × available capacity (multiplicative), with trajectory momentum
  - **Novelty**: Uncertainty modulated by coherence (signal vs. noise distinction)
  - **Valence**: Hedonic tone from agency, social ease, policy ease; modulated by coherence fragmentation; trajectory-adjusted
  - All values clamped to valid ranges and rounded to 4 decimals

### Bus Integration
- **`handle_self_state()`** now:
  - Computes phi before/after deltas
  - Publishes `SparkStateSnapshotV1` to bus with phi vector and metadata
  - Broadcasts tissue updates to WebSocket with phi, novelty, valence, arousal
  - Tracks `_PREV_PHI` for inter-tick delta computation

- **`bus_worker.py`** extended to:
  - Route `substrate.self_state.v1` and `feedback.frame.v1` kinds to dedicated handlers
  - Store previous self-state for delta computation across ticks
  - Parse and validate payloads with fallback error handling

### Concept Induction Improvements
- **`inducer.py`**: 
  - Maps spaCy NER labels to open concept type vocabulary (person→person, org→organization, etc.)
  - Computes salience from frequency normalized by max frequency
  - Confidence now combines embedding presence (0.15 bonus) and salience (0.35 weight)
  - Stores NER label in concept metadata

- **`extractor.py`**:
  - `ExtractionResult` now tracks `entity_types: Dict[str, str]` mapping candidates to NER labels
  - `_chunk_candidates()` returns (text, ner_label) tuples; NER entities prioritized over noun chunks
  - Deduplicates candidates across NER and chunk sources

### New Schema Types
- **`IdentitySnapshotV1`**: Captures dominant drive, active drives, self-state condition, intensity, trajectory, and key unknowns at a point in time
- **`SelfStatePredictionV1`**: Linear one-step extrapolation of dimension scores using trajectory deltas

### Utility Modules
- **`field_coherence.py`**: Detects incoherence in field state via rule-based suspicion scoring (e.g., high execution load but low CPU pressure)
- **`prediction_error.py`**: Computes surprise scores for execution and transport projections
- **`self_state/prediction.py`**: Builds next-cycle predictions and computes per

https://claude.ai/code/session_01NDn9V4Tg8pgRM9vSmhZkk3