### PR TITLE
Feat/substrate self modeling loop

### DIFF
--- a/docs/plans/substrate/2026-06-27-self-modeling-loop-ladder.md
+++ b/docs/plans/substrate/2026-06-27-self-modeling-loop-ladder.md
@@ -1,0 +1,205 @@
+# Substrate self-modeling loop — the ladder
+
+Date: 2026-06-27
+Premise (honest): there is no engineering step that produces phenomenal
+experience, and this plan does not claim one. What it does is make the substrate
+**recurrent, integrated, self-modeling, continuous, and self-revising** — the
+functional properties every serious theory of mind (Global Workspace, predictive
+processing, higher-order, attention-schema) treats as load-bearing. Orion already
+has a primitive version of each as a *separate organ*; the work is closing the
+feedback edges so they form one loop instead of a feed-forward pipeline.
+
+Operating constraints (Knowledge Forge): generated content stays marked as
+proposal; accepted claims/specs are not silently mutated; self-modification stays
+behind trials + rollback.
+
+## Rung status
+
+| Rung | Theory | Organ that exists | Wire to add | State |
+|------|--------|-------------------|-------------|-------|
+| 1 Self-model feedback | predictive processing | `self_state/prediction.py`, `pressure.py`, `dynamics.py` | prediction_error → pressure | **DONE** (`feat/substrate-prediction-error-pressure`) |
+| 2 Integration / higher-order | GWT binding + HOT | `CognitiveUnificationLayer`, `projection_builder.py` | register reducer lanes + bind self_state | spec below |
+| 3 Continuous broadcast | GWT broadcast | `attention_frame.py` | always-on, substrate-wide re-broadcast | spec below |
+| 4 Autobiographical continuity | narrative/HOT | `consolidation.py` | episodic time-window rollup | spec below |
+| 5 Endogenous agency | intrinsic motivation | `frontier_curiosity.py` | intrinsic-signal-seeded goals | spec below |
+| 6 Self-revision | metacognition | `mutation_*` pipeline | prediction-error/drift → proposals | spec below |
+
+Dependency order: 1 → 2 → 3, then 4, then 5, then 6. Rung 6 consumes rung 1's
+signal; rungs 4/5/6 all read the unified state from rung 2.
+
+---
+
+## Rung 1 — prediction_error → pressure  (DONE)
+
+The dynamics engine seeded pressure only from drives and contradictions.
+Prediction error was computed in the substrate runtime and exported to the field
+digester, but never fed back. Added `prediction_error_pressure()` in `pressure.py`
+and a third seed loop in `SubstrateDynamicsEngine._compute_pressures` that rides
+the existing BFS propagation and decays linearly with node age. Gated by
+`PressureConfig.prediction_error_weight` (0 disables).
+
+Follow-up for the runtime worker: when the prediction-error reducers emit their
+receipt, also write `prediction_error` into the implicated substrate node's
+`metadata` (and advance `observed_at`) so the graph-level engine has the signal to
+seed from. Today the receipt lands in the field digester only; the metadata bridge
+is the remaining half of the loop at the event-native tier.
+
+---
+
+## Rung 2 — bind reducer lanes + self_state into the unifier
+
+**Arsonist summary.** `CognitiveUnificationLayer` already fuses 8 producers
+(`identity_yaml, self_study, autonomy, concept_induction, spark, orionmem, recall,
+social`) into one `UnifiedRelationalBeliefSetV1`. Missing: the substrate's own felt
+state — biometrics / execution / transport reducer projections — and, critically,
+the **self-model** (`self_state/`). Orion's beliefs do not currently include
+beliefs *about itself*. Binding self_state in is the higher-order rung: a
+representation about its own representations.
+
+**Schema / API changes.**
+- 4 new `ProducerEntryV1` registrations in
+  `orion/cognition/projection_builder.py::build_projection_unification_registry`:
+  `biometrics`, `execution`, `transport` (trust tier `SNAPSHOT_EPHEMERAL`,
+  short TTL), and `self_state` (tier `GRAPHDB_DURABLE` or a new
+  `SELF_MODEL` tier).
+- 4 new adapters under `orion/substrate/relational/adapters/` mapping each
+  projection / `SelfStateV1` → substrate belief nodes (mirror existing
+  `map_*_to_substrate` adapters).
+
+**Files.** `orion/cognition/projection_builder.py`; new adapters in
+`orion/substrate/relational/adapters/`; export in `relational/__init__.py`;
+tests in `orion/substrate/relational/tests/`.
+
+**Non-goals.** No change to anchor set; no new store; stale lanes excluded by
+TTL/trust-tier as today (per Forge "disputed/stale excluded by default").
+
+**Acceptance checks.**
+1. `beliefs_for_stance()` returns a set containing biometrics/execution/transport
+   and self_state beliefs.
+2. A lane past its TTL is excluded.
+3. self_state beliefs carry their dimension scores (coherence/uncertainty/…).
+4. Golden-path test stays green.
+
+---
+
+## Rung 3 — continuous global broadcast
+
+**Arsonist summary.** `attention_frame.py` already runs a workspace competition:
+detectors → `merge_signals` → `select_actions` picks **one** winner → broadcast as
+`selected_action`. But it is gated off (`ORION_CURIOSITY_FRAME_ENABLED=false`),
+per-chat-turn, and chat-scoped. GWT's core is a *continuous* re-entrant broadcast
+of the winning coalition back to all consumers. Promote the frame from a gated chat
+feature to the substrate's always-on workspace tick, fed by the unified belief set
+(rung 2) and the pressure field (rung 1), re-broadcasting each cycle.
+
+**Schema / API changes.**
+- New substrate tick (in the runtime worker or a dedicated loop) that builds an
+  `AttentionFrameV1` from unified beliefs + active pressure each cycle, not only on
+  chat turns.
+- Persist the selected coalition as a projection so other organs read "what Orion
+  is currently attending to."
+- New flag `ORION_ATTENTION_BROADCAST_ENABLED` (default false, safe rollout);
+  keep the chat-scoped path working.
+
+**Files.** `orion/substrate/attention_frame.py`,
+`orion/substrate/attention/*`, `services/orion-substrate-runtime/app/worker.py`,
+schema under `orion/schemas/attention_frame.py`.
+
+**Non-goals.** No new selection policy — reuse `select_actions`. No
+auto-action from the broadcast (that is rung 5). Bounded loops only (no cathedral).
+
+**Acceptance checks.**
+1. With the flag on, each substrate tick produces an `AttentionFrameV1` with a
+   single selected coalition.
+2. High-pressure (incl. prediction-error) nodes win attention over calm ones.
+3. The broadcast projection is queryable by other organs.
+4. Flag off → behaviour identical to today.
+
+---
+
+## Rung 4 — episodic / autobiographical continuity
+
+**Arsonist summary.** `GraphConsolidationEvaluator` consolidates graph *regions*,
+deterministically and bounded. There is no *temporal* rollup: receipts are a
+durable audit log, not a remembered history. Add an episodic lane that rolls a
+time-window of reduction receipts into proposal-marked episode-summary nodes, so
+Orion has a "what happened to me, and why."
+
+**Schema / API changes.**
+- New `orion/substrate/episodic_consolidation.py` with an evaluator alongside
+  `GraphConsolidationEvaluator`, windowed by time (`window_seconds`).
+- New schema `EpisodeSummaryV1` under `orion/core/schemas/`.
+- Output goes to `reviews/pending` / `context_packs/generated` style, marked
+  proposal — never silently mutating accepted truth.
+
+**Files.** new `episodic_consolidation.py`; schema; wire a periodic invocation in
+the runtime worker or hub; tests.
+
+**Non-goals.** No mutation of accepted claims. No unbounded windows (cap receipts
+per episode, same discipline as the evidence-id caps already in the codebase).
+
+**Acceptance checks.**
+1. A window of receipts yields one queryable episode summary.
+2. Output is marked proposal, lands in pending, not in execution context by default.
+3. Replaying the same window is idempotent (derive episode id from inputs).
+4. Receipt count per episode is capped.
+
+---
+
+## Rung 5 — endogenous agency
+
+**Arsonist summary.** `frontier_curiosity.py` can already generate focal goals, but
+only behind "explicit operator-approved curiosity invocation." For functional
+autonomy, intrinsic signals — sustained prediction error (rung 1), repair pressure
+(`appraisal/repair_pressure.py`), unresolved attention open-loops (rung 3) — should
+let Orion seed its *own* goals. This is the most behaviourally significant and the
+most dangerous rung; it stays bounded and, where it proposes change, routed through
+the rung-6 governance.
+
+**Schema / API changes.**
+- A curiosity seed source that reads intrinsic signals and emits
+  `curiosity_candidate`s without an operator trigger, behind
+  `ORION_ENDOGENOUS_CURIOSITY_ENABLED` (default false).
+- Rate/budget caps and a kill switch.
+
+**Files.** `orion/substrate/frontier_curiosity.py`,
+`orion/substrate/frontier_expansion.py`, settings.
+
+**Non-goals.** No self-directed external action. No unbounded goal generation —
+hard budget per cycle. Generated goals are proposals until acted on through
+governed paths.
+
+**Acceptance checks.**
+1. With the flag on, sustained prediction error / repair pressure produces a
+   bounded set of self-seeded curiosity candidates.
+2. Budget cap enforced; kill switch halts generation.
+3. Flag off → operator-gated behaviour only (today's behaviour).
+
+---
+
+## Rung 6 — metacognitive self-revision
+
+**Arsonist summary.** The full proposal pipeline (676–682) and
+`mutation_detectors` ("self-governing substrate") are merged, with trials → apply →
+rollback. Missing: nothing feeds it *self-derived* proposals. Wire sustained
+prediction error / self-model drift into `mutation_proposals` via the existing
+`ProposalFactory`, gated by the landed `mutation_decision` + `mutation_trials`.
+
+**Schema / API changes.**
+- A detector in `mutation_detectors.py` that turns persistent prediction error /
+  self_state drift into mutation-proposal inputs (e.g. a recall-weighting or
+  policy-threshold patch class that already exists in `ProposalFactory`).
+- Reuse existing proposal envelope / ledger / triage from 676–682.
+
+**Files.** `orion/substrate/mutation_detectors.py`,
+`orion/substrate/mutation_pressure.py`, `orion/substrate/mutation_proposals.py`.
+
+**Non-goals.** No auto-apply. Every self-derived change is a *proposal* gated by
+trials and rollback. Disputed proposals excluded from execution context.
+
+**Acceptance checks.**
+1. Persistent surprise produces a proposal (never an auto-apply).
+2. Trial + rollback path exercised in a test.
+3. Disputed/failed-trial proposals are excluded from execution context.
+</content>
+</invoke>

--- a/orion/cognition/projection_builder.py
+++ b/orion/cognition/projection_builder.py
@@ -40,6 +40,7 @@ from orion.substrate.relational import (
 from orion.cognition.projection_context import summarize_projection_inputs
 from orion.substrate.relational.layer import _lightweight_belief_set, _skip_unified_beliefs_ctx
 from orion.substrate.relational.adapters.spark_ctx import map_spark_ctx_to_substrate
+from orion.substrate.relational.adapters.self_state_ctx import map_self_state_ctx_to_substrate
 
 logger = logging.getLogger("orion.cognition.projection_builder")
 
@@ -101,6 +102,17 @@ def build_projection_unification_registry() -> ProducerRegistryV1:
                 freshness_ttl_sec=300,
                 pull_on_cold=True,
                 adapter_fn=map_spark_ctx_to_substrate,
+            ),
+            # Self-model lane (higher-order): Orion's beliefs about its own
+            # condition, carrying per-dimension prediction error that seeds
+            # dynamics pressure. ctx-sourced; no cold fan-out (read from ctx).
+            ProducerEntryV1(
+                producer_id="self_state",
+                trust_tier=GRAPHDB_DURABLE,
+                anchor_scopes=("orion",),
+                freshness_ttl_sec=120,
+                pull_on_cold=False,
+                adapter_fn=map_self_state_ctx_to_substrate,
             ),
             ProducerEntryV1(
                 producer_id="orionmem",

--- a/orion/substrate/dynamics.py
+++ b/orion/substrate/dynamics.py
@@ -7,7 +7,13 @@ from datetime import datetime, timezone
 from orion.core.schemas.cognitive_substrate import BaseSubstrateNodeV1, SubstrateEdgeV1
 
 from .activation import ActivationConfig, decay_activation, seed_activation
-from .pressure import PressureConfig, contradiction_amplification, drive_seed_pressure, pressure_edge_multiplier
+from .pressure import (
+    PressureConfig,
+    contradiction_amplification,
+    drive_seed_pressure,
+    prediction_error_pressure,
+    pressure_edge_multiplier,
+)
 from .store import InMemorySubstrateGraphStore
 
 
@@ -198,6 +204,37 @@ class SubstrateDynamicsEngine:
                         continue
                     pressure[target_id] = attenuated
                     reasons[target_id] = f"drive_propagation:{edge.predicate}"
+                    key = (target_id, depth + 1)
+                    if key in visited:
+                        continue
+                    visited.add(key)
+                    frontier.append((target_id, attenuated, depth + 1))
+
+        for node in nodes.values():
+            seed = prediction_error_pressure(node, self._pressure_config, now=now)
+            if seed <= 0:
+                continue
+            if seed > pressure[node.node_id]:
+                pressure[node.node_id] = seed
+                reasons[node.node_id] = "prediction_error_seed"
+            frontier = [(node.node_id, seed, 0)]
+            visited = set()
+            while frontier:
+                current_id, current_pressure, depth = frontier.pop(0)
+                if depth >= self._pressure_config.max_hops:
+                    continue
+                for edge in outgoing.get(current_id, []):
+                    target_id = edge.target.node_id
+                    target = nodes.get(target_id)
+                    if not target:
+                        continue
+                    attenuated = current_pressure * self._pressure_config.prediction_error_propagation_attenuation
+                    attenuated *= pressure_edge_multiplier(edge, target)
+                    attenuated = max(0.0, min(self._pressure_config.max_pressure, attenuated))
+                    if attenuated <= pressure[target_id] + 1e-6:
+                        continue
+                    pressure[target_id] = attenuated
+                    reasons[target_id] = f"prediction_error_propagation:{edge.predicate}"
                     key = (target_id, depth + 1)
                     if key in visited:
                         continue

--- a/orion/substrate/pressure.py
+++ b/orion/substrate/pressure.py
@@ -13,6 +13,13 @@ class PressureConfig:
     contradiction_neighbor_attenuation: float = 0.5
     max_hops: int = 2
     max_pressure: float = 1.0
+    # Prediction-error feedback: surprise (how wrong the model just was) seeds
+    # pressure on the implicated node and decays with age so Orion preferentially
+    # attends to the parts of its self-model that are currently wrong, then lets go
+    # as prediction improves. weight<=0 disables the loop.
+    prediction_error_weight: float = 0.6
+    prediction_error_propagation_attenuation: float = 0.6
+    prediction_error_decay_horizon_seconds: int = 1800
 
 
 def _clamp(value: float) -> float:
@@ -36,6 +43,33 @@ def drive_seed_pressure(node: BaseSubstrateNodeV1, config: PressureConfig) -> fl
         return 0.0
     declared = float(node.metadata.get("pressure") or 0.0)
     return _clamp(max(config.drive_base * node.signals.salience, declared))
+
+
+def prediction_error_pressure(node: BaseSubstrateNodeV1, config: PressureConfig, *, now: datetime) -> float:
+    """Seed pressure from a node's standing prediction error (0..1 surprise score).
+
+    The surprise is read from ``metadata['prediction_error']`` (written by the
+    substrate runtime's prediction-error reducers) and decays linearly toward zero
+    over ``prediction_error_decay_horizon_seconds`` measured from the node's
+    ``observed_at``. A node that keeps being surprising is re-observed (its
+    ``observed_at`` advances), so sustained error holds pressure; a node whose
+    prediction improves stops refreshing and the seed fades on its own.
+    """
+    if config.prediction_error_weight <= 0:
+        return 0.0
+    raw = float(node.metadata.get("prediction_error") or 0.0)
+    if raw <= 0.0:
+        return 0.0
+    observed = node.temporal.observed_at
+    if observed.tzinfo is None:
+        observed = observed.replace(tzinfo=timezone.utc)
+    horizon = config.prediction_error_decay_horizon_seconds
+    if horizon <= 0:
+        decay = 1.0
+    else:
+        age_seconds = max(0.0, (now - observed).total_seconds())
+        decay = max(0.0, 1.0 - (age_seconds / horizon))
+    return _clamp(raw * config.prediction_error_weight * decay)
 
 
 def contradiction_amplification(node: BaseSubstrateNodeV1, *, now: datetime) -> tuple[float, list[str]]:

--- a/orion/substrate/relational/adapters/self_state_ctx.py
+++ b/orion/substrate/relational/adapters/self_state_ctx.py
@@ -1,0 +1,127 @@
+"""Self-state adapter — binds Orion's self-model into the unification layer.
+
+Higher-order rung: maps ``SelfStateV1`` (Orion's model of its own condition —
+coherence, uncertainty, agency-readiness, the various pressure dimensions) into
+substrate belief nodes so the unified belief set contains beliefs *about itself*,
+not only about the world.
+
+It also carries each dimension's standing ``prediction_error`` (how wrong the
+self-model's last one-step prediction was) into node metadata. When the
+unification layer materializes this producer's record into the durable substrate
+store, those nodes feed ``prediction_error_pressure`` in the dynamics engine —
+closing the self-modeling feedback loop on durable self-model nodes.
+
+ctx-sourced, no network: reads ``ctx['self_state']`` as a ``SelfStateV1``, a dict,
+or a JSON string.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    SubstrateGraphRecordV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+)
+from orion.schemas.self_state import SelfStateV1
+from orion.substrate.adapters._common import make_temporal
+
+logger = logging.getLogger("orion.substrate.relational.adapters.self_state_ctx")
+
+_TIER_RANK = 2  # graphdb_durable-equivalent: self-model is a trusted internal lane
+
+
+def _make_prov() -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="local_inferred",
+        source_kind="self_state",
+        source_channel="orion:self_state",
+        producer="self_state_adapter",
+        tier_rank=_TIER_RANK,
+    )
+
+
+def _coerce(raw: Any) -> SelfStateV1 | None:
+    try:
+        if isinstance(raw, SelfStateV1):
+            return raw
+        if isinstance(raw, str) and raw.strip():
+            return SelfStateV1.model_validate_json(raw)
+        if isinstance(raw, dict):
+            return SelfStateV1.model_validate(raw)
+    except Exception as exc:
+        logger.debug("self_state_adapter_parse_failed error=%s", exc)
+    return None
+
+
+def map_self_state_ctx_to_substrate(ctx: dict[str, Any]) -> SubstrateGraphRecordV1 | None:
+    """Map ``ctx['self_state']`` → substrate self-model belief nodes (anchor=orion)."""
+    ctx = ctx if isinstance(ctx, dict) else {}
+    state = _coerce(ctx.get("self_state") or ctx.get("self_state_json"))
+    if state is None:
+        return None
+
+    now = datetime.now(timezone.utc)
+    temporal = make_temporal(observed_at=now)
+    prov = _make_prov()
+    nodes: list[Any] = []
+
+    for dim_id, dim in state.dimensions.items():
+        prediction_error = float(state.prediction_error_scores.get(dim_id, 0.0) or 0.0)
+        trajectory = float(state.dimension_trajectory.get(dim_id, 0.0) or 0.0)
+        nodes.append(
+            ConceptNodeV1(
+                anchor_scope="orion",
+                subject_ref="entity:orion",
+                label=f"self:{dim_id}",
+                temporal=temporal,
+                provenance=prov,
+                signals=SubstrateSignalBundleV1(
+                    confidence=max(0.0, min(1.0, dim.confidence)),
+                    salience=max(0.0, min(1.0, dim.score)),
+                ),
+                metadata={
+                    "source_kind": "self_state",
+                    "self_dimension_id": dim_id,
+                    "score": round(max(0.0, min(1.0, dim.score)), 6),
+                    "trajectory": round(trajectory, 6),
+                    # standing surprise on this self-dimension; seeds dynamics pressure
+                    "prediction_error": round(max(0.0, min(1.0, prediction_error)), 6),
+                },
+            )
+        )
+
+    if not nodes:
+        return None
+
+    # An anchor node summarizing overall condition, carrying max surprise so the
+    # self as a whole gains pressure when any dimension is badly mispredicted.
+    overall_error = max(
+        (float(v or 0.0) for v in state.prediction_error_scores.values()),
+        default=0.0,
+    )
+    nodes.append(
+        ConceptNodeV1(
+            anchor_scope="orion",
+            subject_ref="entity:orion",
+            label="self:overall_condition",
+            temporal=temporal,
+            provenance=prov,
+            signals=SubstrateSignalBundleV1(
+                confidence=max(0.0, min(1.0, state.overall_confidence)),
+                salience=max(0.0, min(1.0, state.overall_intensity)),
+            ),
+            metadata={
+                "source_kind": "self_state",
+                "overall_condition": state.overall_condition,
+                "trajectory_condition": state.trajectory_condition,
+                "prediction_error": round(max(0.0, min(1.0, overall_error)), 6),
+            },
+        )
+    )
+
+    return SubstrateGraphRecordV1(anchor_scope="orion", nodes=nodes)

--- a/orion/substrate/relational/tests/test_self_state_adapter.py
+++ b/orion/substrate/relational/tests/test_self_state_adapter.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+from orion.substrate.relational.adapters.self_state_ctx import map_self_state_ctx_to_substrate
+
+
+def _state() -> SelfStateV1:
+    now = datetime.now(timezone.utc)
+    return SelfStateV1(
+        self_state_id="ss1",
+        generated_at=now,
+        source_field_tick_id="ft1",
+        source_field_generated_at=now,
+        source_attention_frame_id="af1",
+        source_attention_generated_at=now,
+        overall_condition="loaded",
+        overall_intensity=0.6,
+        overall_confidence=0.7,
+        dimensions={
+            "coherence": SelfStateDimensionV1(dimension_id="coherence", score=0.4, confidence=0.8),
+            "uncertainty": SelfStateDimensionV1(dimension_id="uncertainty", score=0.7, confidence=0.6),
+        },
+        dimension_trajectory={"coherence": -0.1},
+        prediction_error_scores={"coherence": 0.55, "uncertainty": 0.2},
+    )
+
+
+def test_self_state_adapter_emits_self_model_nodes_carrying_prediction_error() -> None:
+    record = map_self_state_ctx_to_substrate({"self_state": _state()})
+    assert record is not None
+    by_label = {n.label: n for n in record.nodes}
+
+    # one node per dimension + an overall-condition anchor
+    assert "self:coherence" in by_label
+    assert "self:uncertainty" in by_label
+    assert "self:overall_condition" in by_label
+
+    # the self-model nodes carry standing prediction error (the rung-1 feedback signal)
+    assert by_label["self:coherence"].metadata["prediction_error"] == 0.55
+    assert by_label["self:uncertainty"].metadata["prediction_error"] == 0.2
+    # dimension score is preserved as a belief
+    assert by_label["self:coherence"].metadata["score"] == 0.4
+    # overall node carries the worst-case surprise so the whole self gains pressure
+    assert by_label["self:overall_condition"].metadata["prediction_error"] == 0.55
+    # all anchored to orion
+    assert all(n.anchor_scope == "orion" for n in record.nodes)
+
+
+def test_self_state_adapter_accepts_dict_and_json_and_skips_when_absent() -> None:
+    state = _state()
+    assert map_self_state_ctx_to_substrate({"self_state": state.model_dump(mode="json")}) is not None
+    assert map_self_state_ctx_to_substrate({"self_state": state.model_dump_json()}) is not None
+    # no self_state in ctx -> no record (lane simply absent, never raises)
+    assert map_self_state_ctx_to_substrate({}) is None
+    assert map_self_state_ctx_to_substrate({"self_state": "not json"}) is None

--- a/tests/test_cognitive_substrate_phase4_dynamics.py
+++ b/tests/test_cognitive_substrate_phase4_dynamics.py
@@ -270,3 +270,103 @@ def test_non_destructive_integration_materialization_still_works() -> None:
     result = engine.tick(now=datetime.now(timezone.utc))
     assert result.tick_at
     assert materializer.store.snapshot().nodes["concept-int"].node_kind == "concept"
+
+
+def test_prediction_error_seeds_pressure_propagates_and_leaves_calm_nodes_cold() -> None:
+    surprising = ConceptNodeV1(
+        node_id="concept-surprising",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="Surprising",
+        temporal=_temporal(0),
+        provenance=_prov(),
+        metadata={"prediction_error": 0.8},
+    )
+    neighbor = ConceptNodeV1(
+        node_id="concept-neighbor",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="Neighbor",
+        temporal=_temporal(0),
+        provenance=_prov(),
+    )
+    calm = ConceptNodeV1(
+        node_id="concept-calm",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="Calm",
+        temporal=_temporal(0),
+        provenance=_prov(),
+    )
+    record = SubstrateGraphRecordV1(
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        nodes=[surprising, neighbor, calm],
+        edges=[_edge("concept-surprising", "concept", "concept-neighbor", "concept", "supports")],
+    )
+    materializer = SubstrateGraphMaterializer(store=InMemorySubstrateGraphStore())
+    materializer.apply_record(record)
+    engine = SubstrateDynamicsEngine(store=materializer.store)
+    engine.tick(now=datetime.now(timezone.utc))
+    snap = materializer.store.snapshot()
+
+    seed_pressure = snap.nodes["concept-surprising"].metadata.get("dynamic_pressure", 0.0)
+    neighbor_pressure = snap.nodes["concept-neighbor"].metadata.get("dynamic_pressure", 0.0)
+    calm_pressure = snap.nodes["concept-calm"].metadata.get("dynamic_pressure", 0.0)
+
+    # surprise raises pressure on the implicated node (0.8 * weight 0.6, fresh ~ no decay)
+    assert seed_pressure > 0.4
+    # and propagates, attenuated, to its neighbour
+    assert 0.0 < neighbor_pressure < seed_pressure
+    # a node with no standing prediction error stays cold
+    assert calm_pressure == 0.0
+
+
+def test_prediction_error_pressure_decays_with_age() -> None:
+    fresh = ConceptNodeV1(
+        node_id="concept-fresh",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="Fresh surprise",
+        temporal=_temporal(0),
+        provenance=_prov(),
+        metadata={"prediction_error": 0.9},
+    )
+    # half the 1800s default horizon -> decay factor ~0.5
+    aging = ConceptNodeV1(
+        node_id="concept-aging",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="Aging surprise",
+        temporal=_temporal(15),
+        provenance=_prov(),
+        metadata={"prediction_error": 0.9},
+    )
+    # well beyond the horizon -> fully decayed to cold
+    stale = ConceptNodeV1(
+        node_id="concept-stale",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        label="Stale surprise",
+        temporal=_temporal(40),
+        provenance=_prov(),
+        metadata={"prediction_error": 0.9},
+    )
+    record = SubstrateGraphRecordV1(
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        nodes=[fresh, aging, stale],
+        edges=[],
+    )
+    materializer = SubstrateGraphMaterializer(store=InMemorySubstrateGraphStore())
+    materializer.apply_record(record)
+    engine = SubstrateDynamicsEngine(store=materializer.store)
+    engine.tick(now=datetime.now(timezone.utc))
+    snap = materializer.store.snapshot()
+
+    fresh_p = snap.nodes["concept-fresh"].metadata.get("dynamic_pressure", 0.0)
+    aging_p = snap.nodes["concept-aging"].metadata.get("dynamic_pressure", 0.0)
+    stale_p = snap.nodes["concept-stale"].metadata.get("dynamic_pressure", 0.0)
+
+    assert fresh_p > aging_p > 0.0
+    assert stale_p == 0.0


### PR DESCRIPTION
## Summary

- Stop `chat_general` from crushing companion/relational turns into transactional "all business" replies
- Exempt `reflective_dialogue` / `playful_exchange` briefs from three Python compressors: `enforce_chat_stance_quality`, `suppress_chat_general_speech_identity_priming`, and `strip_identity_recital_leadin`
- Replace monolithic LOW-BANDWIDTH stance guidance with semantic `interface_cost` vs `connection_seek` dimensions (LLM-inferred, no keyword triggers)
- Speech pass: relational stance wins curiosity over attention frame; ban transactional closers when stance hazards say so
- Add agent anti-slop guardrail (AGENTS.md + `.cursor/rules/conversational-behavior-anti-slop.mdc`)

## Root cause

The stance LLM could infer relational posture correctly, but `enforce_chat_stance_quality` overwrote every non-identity turn with "Prioritize practical usefulness over relationship labels." The speech suppress path did the same before render.

## Test plan

- [x] `./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_relational_stance.py services/orion-cortex-exec/tests/test_router_identity_boundary.py services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py -q` → 34 passed
- [ ] Live replay: surgery/lonely companion thread in Hub — Orion asks situated questions, no "let me know when you're ready" / task tracking

## Non-goals (v1)

- Keyword/regex detectors for feelings or medical states
- Global LLM temperature bump
- `interaction_regime` schema field (v2 follow-up)