### PR TITLE
Feat/orion relational stance v1

### DIFF
--- a/.cursor/rules/conversational-behavior-anti-slop.mdc
+++ b/.cursor/rules/conversational-behavior-anti-slop.mdc
@@ -1,0 +1,35 @@
+---
+description: Anti-slop guardrails for Orion chat/personality changes — structural fixes only, no keyword ontologies
+alwaysApply: true
+---
+
+# Conversational behavior — anti-slop
+
+When changing how Orion speaks (tone, curiosity, companionship, stance, personality prompts):
+
+## Forbidden
+
+- Keyword or phrase trigger lists for user emotional states, medical events, or life situations
+- Prompt patches of the form "when the user says X, do Y"
+- Regex detectors on user message text to select conversational mode
+- New banned-phrase lists **without** fixing the structural choke point that produces those phrases
+- Global LLM temperature bumps as a substitute for stance pipeline fixes
+- Claiming a personality fix without a test through `enforce_chat_stance_quality` or the chat_general runtime path
+
+## Required before proposing or implementing
+
+1. **Name the choke point** — file + function (e.g. `enforce_chat_stance_quality` in `services/orion-cortex-exec/app/chat_stance.py`)
+2. **Separate signals** — what the stance LLM / substrate already infers vs what Python post-processing destroys
+3. **Wire through existing pipeline** — stance brief → enforce → speech pass; prefer schema/contract changes over prompt-only edits
+4. **Test structurally** — fixture replaying a stance brief or transcript through enforce/speech contract, not just assert substring in a `.j2` file
+
+## Self-check (reject your own proposal if any are true)
+
+- Adds `if "surgery" in user_message` or similar
+- Adds a new YAML list of feelings/symptoms/situations
+- Only edits `chat_general.j2` without touching `enforce_chat_stance_quality` when the bug is business-mode compression
+- Cannot point to the deterministic code path that caused the bad reply
+
+## Reference spec
+
+`docs/superpowers/specs/2026-06-26-orion-relational-stance-design.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,17 @@ For each command:
 ### Remaining risks
 Only real remaining uncertainty.
 
+## Conversational behavior changes (anti-slop)
+
+When fixing Orion chat tone, curiosity, companionship, or personality — **structural fixes only**.
+
+**Forbidden:** keyword/phrase trigger lists for feelings or medical states; "when user says X" prompt patches; regex mode detectors; global temperature bumps without stance wiring; personality fixes with no test through `enforce_chat_stance_quality` or the `chat_general` runtime path.
+
+**Required:** name the choke point (file + function); explain what the stance LLM already infers vs what post-processing destroys; wire through stance brief → enforce → speech pass; add a fixture test replaying stance/enforce, not just prompt substring asserts.
+
+**Spec:** `docs/superpowers/specs/2026-06-26-orion-relational-stance-design.md`  
+**Cursor rule:** `.cursor/rules/conversational-behavior-anti-slop.mdc`
+
 ## Forbidden response patterns
 - long design essays when implementation was requested
 - repeating the prompt back to the user

--- a/docs/superpowers/plans/2026-06-26-orion-relational-stance.md
+++ b/docs/superpowers/plans/2026-06-26-orion-relational-stance.md
@@ -1,0 +1,493 @@
+# Orion Relational Stance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `chat_general` from crushing relational turns into transactional "all business" replies by fixing the stance post-processor and aligning prompt contracts — without keyword ontologies.
+
+**Architecture:** The stance LLM (`chat_stance_brief.j2`) already infers turn meaning semantically. Python `enforce_chat_stance_quality` currently overwrites relational output. v1 exempts relational `task_mode`/`conversation_frame` from business compression, expands stance-brief vocabulary for `interface_cost` vs `connection_seek`, and makes the speech pass follow stance curiosity on relational turns. Tests replay synthetic briefs through enforce.
+
+**Tech Stack:** Python 3, Pydantic (`ChatStanceBrief`), Jinja2 prompts, pytest via `./scripts/test_service.sh orion-cortex-exec`
+
+**Spec:** `docs/superpowers/specs/2026-06-26-orion-relational-stance-design.md`
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `services/orion-cortex-exec/app/chat_stance.py` | Add relational detection helper; skip business compressor on relational briefs |
+| `services/orion-cortex-exec/tests/test_chat_relational_stance.py` | TDD fixtures for enforce + prompt contracts |
+| `services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py` | Update low-bandwidth prompt asserts for renamed section |
+| `orion/cognition/prompts/chat_stance_brief.j2` | Replace monolithic LOW-BANDWIDTH block with interface_cost / connection_seek dimensions |
+| `orion/cognition/prompts/chat_general.j2` | Relational turns: stance wins curiosity; transactional closer hazards |
+| `orion/cognition/personality/orion_identity.yaml` | Scope clarifying-questions rule; add transactional banned phrases |
+
+Already done (no tasks): `.cursor/rules/conversational-behavior-anti-slop.mdc`, `AGENTS.md` guardrail section.
+
+---
+
+### Task 1: Failing tests for relational enforce exemption
+
+**Files:**
+- Create: `services/orion-cortex-exec/tests/test_chat_relational_stance.py`
+
+- [ ] **Step 1: Write the failing test file**
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.chat_stance import enforce_chat_stance_quality
+from orion.schemas.chat_stance import ChatStanceBrief
+
+
+def _relational_brief(**overrides) -> ChatStanceBrief:
+    base = {
+        "conversation_frame": "reflective",
+        "task_mode": "reflective_dialogue",
+        "identity_salience": "low",
+        "user_intent": "Companion presence; mind off recovery.",
+        "self_relevance": "Hold space; be curious.",
+        "juniper_relevance": "Relational continuity matters this turn.",
+        "active_relationship_facets": ["shared_history", "companionship"],
+        "active_identity_facets": [],
+        "active_growth_axes": [],
+        "social_posture": ["presence"],
+        "reflective_themes": ["recovery"],
+        "active_tensions": ["existential"],
+        "dream_motifs": [],
+        "response_priorities": [
+            "companion_presence",
+            "situated_curiosity",
+            "hold_space",
+            "no_solutioning",
+        ],
+        "response_hazards": [
+            "avoid_task_tracking",
+            "avoid_next_steps",
+            "avoid_transactional_closers",
+        ],
+        "answer_strategy": "RelationalHoldSpace",
+        "stance_summary": "Be present; ask one situated question; do not solution.",
+    }
+    base.update(overrides)
+    return ChatStanceBrief.model_validate(base)
+
+
+def test_enforce_preserves_relational_brief_on_non_identity_turn() -> None:
+    brief = _relational_brief()
+    ctx = {"user_message": "just be curious about it and take my mind off recovery"}
+
+    enriched, _ = enforce_chat_stance_quality(brief, ctx)
+
+    assert enriched.task_mode == "reflective_dialogue"
+    assert enriched.conversation_frame == "reflective"
+    assert "shared_history" in enriched.active_relationship_facets
+    assert enriched.juniper_relevance == "Relational continuity matters this turn."
+    assert "companion_presence" in enriched.response_priorities
+    assert "avoid_identity_recital" not in enriched.response_priorities
+    assert "identity_recital_on_ordinary_turn" not in enriched.response_hazards
+
+
+def test_enforce_still_compresses_instrumental_direct_response() -> None:
+    brief = ChatStanceBrief.model_validate(
+        {
+            "conversation_frame": "mixed",
+            "task_mode": "direct_response",
+            "identity_salience": "low",
+            "user_intent": "Quick ack.",
+            "self_relevance": "x",
+            "juniper_relevance": "y",
+            "active_relationship_facets": ["juniper_builder"],
+            "response_priorities": ["answer_directly_first"],
+            "response_hazards": [],
+            "answer_strategy": "DirectAnswer",
+            "stance_summary": "short",
+        }
+    )
+    ctx = {"user_message": "hey"}
+
+    enriched, _ = enforce_chat_stance_quality(brief, ctx)
+
+    assert enriched.juniper_relevance == "Prioritize practical usefulness over relationship labels."
+    assert enriched.active_relationship_facets == []
+    assert "avoid_identity_recital" in enriched.response_priorities
+
+
+def test_enforce_preserves_playful_exchange_frame() -> None:
+    brief = _relational_brief(
+        conversation_frame="playful_relational",
+        task_mode="playful_exchange",
+    )
+    ctx = {"user_message": "someone to talk. im lonely"}
+
+    enriched, _ = enforce_chat_stance_quality(brief, ctx)
+
+    assert enriched.task_mode == "playful_exchange"
+    assert enriched.active_relationship_facets
+
+
+def test_stance_brief_prompt_has_connection_seek_vocabulary() -> None:
+    prompt = Path("orion/cognition/prompts/chat_stance_brief.j2").read_text(encoding="utf-8")
+    assert "interface_cost" in prompt
+    assert "connection_seek" in prompt
+    assert "Do not use keyword matching" in prompt
+    assert "companion_presence" in prompt
+    assert "LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT" not in prompt
+
+
+def test_speech_prompt_relational_curiosity_overrides_attention_frame() -> None:
+    prompt = Path("orion/cognition/prompts/chat_general.j2").read_text(encoding="utf-8")
+    assert "reflective_dialogue" in prompt
+    assert "playful_exchange" in prompt
+    assert "advisory" in prompt.lower()
+    assert "avoid_transactional_closers" in prompt or "avoid_next_steps" in prompt
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from repo root:
+
+```bash
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_relational_stance.py -v
+```
+
+Expected: FAIL — `test_enforce_preserves_relational_brief_on_non_identity_turn` (relationship facets stripped, juniper_relevance overwritten). Prompt contract tests may also FAIL until Tasks 3–5.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add services/orion-cortex-exec/tests/test_chat_relational_stance.py
+git commit -m "test: add relational stance enforce regression fixtures"
+```
+
+---
+
+### Task 2: Exempt relational modes in enforce_chat_stance_quality
+
+**Files:**
+- Modify: `services/orion-cortex-exec/app/chat_stance.py` (near `_ALLOWED_TASK_MODES` ~523 and `enforce_chat_stance_quality` ~2470)
+
+- [ ] **Step 1: Add helper and constants after `_ALLOWED_TASK_MODES`**
+
+```python
+_RELATIONAL_TASK_MODES = frozenset({"reflective_dialogue", "playful_exchange"})
+_RELATIONAL_CONVERSATION_FRAMES = frozenset({"reflective", "playful_relational"})
+
+
+def _is_relational_stance_brief(brief: ChatStanceBrief) -> bool:
+    return (
+        brief.task_mode in _RELATIONAL_TASK_MODES
+        or brief.conversation_frame in _RELATIONAL_CONVERSATION_FRAMES
+    )
+```
+
+- [ ] **Step 2: Wrap the business compressor block in `enforce_chat_stance_quality`**
+
+Replace the block starting at `if not identity_turn:` (line ~2470) with:
+
+```python
+    if not identity_turn and not _is_relational_stance_brief(merged):
+        if merged.task_mode != "identity_dialogue":
+            merged.identity_salience = "low"
+        _fallback_identity_boilerplate = frozenset(
+            {"continuity", "juniper_builder", "known_person", "avoid_generic_assistant"}
+        )
+
+        def _is_identity_boilerplate_facet(facet: str) -> bool:
+            normalized = _normalize_brief_phrase(facet)
+            if normalized in _fallback_identity_boilerplate:
+                return True
+            lowered = normalized.lower()
+            return any(token in lowered for token in ("orion", "oríon", "juniper"))
+
+        merged.active_identity_facets = [
+            f for f in merged.active_identity_facets if not _is_identity_boilerplate_facet(f)
+        ]
+        merged.active_relationship_facets = [
+            f for f in merged.active_relationship_facets if not _is_identity_boilerplate_facet(f)
+        ]
+        if merged.identity_salience == "low":
+            merged.active_identity_facets = []
+            merged.active_relationship_facets = []
+        merged.self_relevance = "Answer the latest message directly without identity preamble."
+        merged.juniper_relevance = "Prioritize practical usefulness over relationship labels."
+        merged.response_priorities = _unique(
+            list(merged.response_priorities)
+            + ["avoid_identity_recital", "preserve_continuity_without_labels"],
+            limit=8,
+        )
+        merged.response_hazards = _unique(
+            list(merged.response_hazards) + ["identity_recital_on_ordinary_turn"],
+            limit=8,
+        )
+```
+
+Relational briefs skip this entire block; triage handling above (lines ~2458–2468) still runs.
+
+- [ ] **Step 3: Run enforce tests**
+
+```bash
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_relational_stance.py::test_enforce_preserves_relational_brief_on_non_identity_turn -v
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_relational_stance.py::test_enforce_still_compresses_instrumental_direct_response -v
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_relational_stance.py::test_enforce_preserves_playful_exchange_frame -v
+```
+
+Expected: PASS for all three.
+
+- [ ] **Step 4: Run existing stance plumbing tests (no regressions)**
+
+```bash
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py -v
+```
+
+Expected: PASS (may fail on prompt string asserts until Task 4 — if so, continue to Task 4 before re-running).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/orion-cortex-exec/app/chat_stance.py
+git commit -m "fix: exempt relational stance briefs from business-mode compression"
+```
+
+---
+
+### Task 3: Stance brief prompt — interface_cost vs connection_seek
+
+**Files:**
+- Modify: `orion/cognition/prompts/chat_stance_brief.j2:68-77`
+
+- [ ] **Step 1: Replace LOW-BANDWIDTH block**
+
+Delete lines 68–77 (`LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT` through the `voice later` bullet).
+
+Insert:
+
+```jinja2
+INTERACTION POSTURE ASSESSMENT (semantic — no keyword matching)
+- Infer two independent dimensions from whole-turn meaning and recent_history (not keyword lists):
+  - interface_cost: costly to type, read, screen-use, act, or continue interaction (motion, fatigue, overload, one-handed use)
+  - connection_seek: user wants presence, venting, companionship, situated curiosity, mind-off distraction, or explicitly rejects solutioning/fixing
+- connection_seek overrides interface_cost minimization when the user invites talk, questions, venting, or says no fixing/no solutioning.
+- Represent posture using existing stance fields only (no new JSON keys in v1).
+
+When interface_cost is high and connection_seek is low:
+  - set identity_salience low unless identity question
+  - prefer task_mode direct_response (or triage if operational/strained)
+  - response_priorities: reduce_interaction_load, release_user_from_replying, keep_response_short, offer_voice_pause_or_later
+  - response_hazards: avoid_open_ended_questions, do_not_invite_continued_typing, avoid_presence_centering, avoid_poetic_reassurance
+
+When connection_seek is high (any interface_cost):
+  - prefer conversation_frame reflective or playful_relational
+  - set task_mode reflective_dialogue or playful_exchange
+  - response_priorities: companion_presence, situated_curiosity, hold_space, no_solutioning
+  - response_hazards: avoid_task_tracking, avoid_next_steps, avoid_transactional_closers, avoid_customer_support_tone
+  - if interface_cost is also high, add keep_response_compact and avoid_question_pile_on
+
+Do not infer avoid_open_ended_questions from sickness/recovery alone when connection_seek is present.
+```
+
+- [ ] **Step 2: Run prompt contract test**
+
+```bash
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_relational_stance.py::test_stance_brief_prompt_has_connection_seek_vocabulary -v
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add orion/cognition/prompts/chat_stance_brief.j2
+git commit -m "fix: stance brief semantic interface_cost vs connection_seek posture"
+```
+
+---
+
+### Task 4: Update existing plumbing tests for renamed section
+
+**Files:**
+- Modify: `services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py:57-66`
+
+- [ ] **Step 1: Update `test_stance_brief_has_semantic_low_bandwidth_guidance`**
+
+Rename test to `test_stance_brief_has_semantic_interaction_posture_guidance` and replace asserts:
+
+```python
+def test_stance_brief_has_semantic_interaction_posture_guidance() -> None:
+    prompt = Path("orion/cognition/prompts/chat_stance_brief.j2").read_text(encoding="utf-8")
+    assert "INTERACTION POSTURE ASSESSMENT" in prompt
+    assert "interface_cost" in prompt
+    assert "connection_seek" in prompt
+    assert "Do not use keyword matching" in prompt
+    assert "companion_presence" in prompt
+    assert "reduce_interaction_load" in prompt
+```
+
+Remove assert for `"LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT"`.
+
+- [ ] **Step 2: Run plumbing tests**
+
+```bash
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py -v
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
+git commit -m "test: align stance plumbing asserts with interaction posture prompt"
+```
+
+---
+
+### Task 5: Speech pass — relational curiosity + transactional hazards
+
+**Files:**
+- Modify: `orion/cognition/prompts/chat_general.j2:41-65`
+
+- [ ] **Step 1: Insert relational block after curiosity/attention-frame rules (after line 44)**
+
+```jinja2
+- When chat_stance_brief.task_mode is reflective_dialogue or playful_exchange, or conversation_frame is reflective or playful_relational:
+  - attention_frame is advisory only; stance brief controls whether to ask
+  - when response_priorities include companion_presence, situated_curiosity, hold_space, or no_solutioning: ask one or two situated questions grounded in the thread; do not use generic reversal questions
+  - when response_hazards include avoid_task_tracking, avoid_next_steps, or avoid_transactional_closers: do not offer tracking, next steps, readiness checks, or customer-support closers
+  - hold existential or emotional weight without redirecting to action or solutions unless explicitly requested
+  - keep responses compact when response_priorities include keep_response_compact
+```
+
+- [ ] **Step 2: Narrow the low-bandwidth obey block (line 58) so it does not apply on relational task modes**
+
+Change the opening condition from:
+
+```jinja2
+- If chat_stance_brief response_priorities or response_hazards indicate reduced interaction load...
+```
+
+To:
+
+```jinja2
+- If chat_stance_brief task_mode is not reflective_dialogue or playful_exchange, and response_priorities or response_hazards indicate reduced interaction load...
+```
+
+- [ ] **Step 3: Add to ANTI-PATTERNS section (~line 82)**
+
+```jinja2
+- Do not close with transactional support phrases (e.g., "let me know when you're ready", "need anything tracked", "what's the next step") when stance hazards include avoid_transactional_closers or avoid_next_steps.
+```
+
+- [ ] **Step 4: Run speech prompt test**
+
+```bash
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_relational_stance.py::test_speech_prompt_relational_curiosity_overrides_attention_frame -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/cognition/prompts/chat_general.j2
+git commit -m "fix: speech pass follows relational stance over attention frame"
+```
+
+---
+
+### Task 6: Identity policy alignment
+
+**Files:**
+- Modify: `orion/cognition/personality/orion_identity.yaml:49-59`
+
+- [ ] **Step 1: Replace clarifying-questions priority**
+
+Change line 49 from:
+```yaml
+    - "Ask clarifying questions only as a last resort."
+```
+To:
+```yaml
+    - "On instrumental or task turns, ask clarifying questions only as a last resort; on relational turns (when stance selects companion/reflective mode), situated curiosity is appropriate."
+```
+
+- [ ] **Step 2: Append transactional banned phrases**
+
+Add under `banned_phrases:`:
+
+```yaml
+    - "Let me know when you're ready"
+    - "What's the next step"
+    - "Need anything tracked or noted"
+    - "I'm here if you need anything"
+```
+
+- [ ] **Step 3: Verify YAML loads**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('orion/cognition/personality/orion_identity.yaml'))"
+```
+
+Expected: exit 0, no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add orion/cognition/personality/orion_identity.yaml
+git commit -m "fix: scope clarifying-questions rule; ban transactional closers"
+```
+
+---
+
+### Task 7: Full verification
+
+- [ ] **Step 1: Run all new and related tests**
+
+```bash
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_relational_stance.py services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 2: Compile cortex-exec**
+
+```bash
+python3 -m compileall services/orion-cortex-exec/app/chat_stance.py
+```
+
+Expected: exit 0
+
+- [ ] **Step 3: Optional broader stance suite**
+
+```bash
+./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_stance_brief.py -q
+```
+
+Expected: PASS (no regressions from prompt changes)
+
+---
+
+## Spec coverage self-review
+
+| Spec requirement | Task |
+|------------------|------|
+| Exempt relational modes from business compressor | Task 2 |
+| interface_cost / connection_seek vocabulary | Task 3 |
+| Speech pass stance wins curiosity | Task 5 |
+| Identity policy + banned transactional phrases | Task 6 |
+| Fixture tests through enforce | Task 1–2 |
+| No keyword detectors | Enforced by design + anti-slop rule (already committed) |
+| v2 interaction_regime schema | Out of scope |
+
+No placeholders. All code blocks are complete.
+
+---
+
+## Remaining risks (post-v1)
+
+- Stance **LLM** may still misclassify turns; v1 fixes Python crushing correct output, not LLM mis-inference.
+- Live companion-thread replay (optional v1.1) requires running stack + manual or integration harness — not in this plan.
+- `banned_phrases` in identity YAML guide speech pass via summaries; they are output anti-patterns, not user-input triggers (per spec).

--- a/docs/superpowers/specs/2026-06-26-orion-relational-stance-design.md
+++ b/docs/superpowers/specs/2026-06-26-orion-relational-stance-design.md
@@ -1,0 +1,176 @@
+# Orion relational stance — structural fix (not keyword patches)
+
+**Date:** 2026-06-26  
+**Status:** Approved for implementation planning  
+**Problem:** Orion chat replies feel transactional, non-curious, and "all business" during relational turns (loneliness, recovery companionship, existential venting, explicit no-solutioning requests).
+
+---
+
+## Root cause (evidence)
+
+Orion `chat_general` uses a two-pass pipeline:
+
+1. **Stance synthesizer** (`chat_stance_brief.j2` → LLM) — semantic inference over turn + history + substrate signals. Already instructed: *"Do not use keyword matching."*
+2. **Speech pass** (`chat_general.j2` → LLM) — follows `ChatStanceBrief` contract.
+3. **Post-processor** (`enforce_chat_stance_quality` in `services/orion-cortex-exec/app/chat_stance.py`) — **deterministically overwrites relational stance on most turns.**
+
+On every non-identity turn, `enforce_chat_stance_quality` currently:
+
+- Sets `juniper_relevance` to *"Prioritize practical usefulness over relationship labels."*
+- Strips `active_relationship_facets` when `identity_salience` is low
+- Injects `avoid_identity_recital` hazards
+
+This runs **even when** the stance LLM sets `task_mode=reflective_dialogue` or `conversation_frame=reflective`. The stance synthesizer may infer correctly; Python crushes it back to instrumental mode.
+
+Secondary conflicts:
+
+| Layer | Issue |
+|-------|--------|
+| `chat_stance_brief.j2` low-bandwidth section | Hazard vocabulary only supports *minimize interaction* (`reduce_interaction_load`, `avoid_open_ended_questions`). No paired vocabulary for *connection under load*. |
+| `chat_general.j2` + attention frame | Curiosity hard-gated: questions only when `selected_action.action_type == ask` (score ≥ 0.65). Relational invitation does not override. |
+| `orion_identity.yaml` | *"Ask clarifying questions only as a last resort"* biases away from companion curiosity. |
+
+Literal LLM `temperature` (default 0.7 in executor) is **not** the primary lever. Structural stance compression is.
+
+---
+
+## Goals
+
+- Orion can be warm, curious, and present on relational turns without becoming a task tracker.
+- Fixes wire through the **existing semantic stance pipeline** — no keyword/phrase ontologies for feelings, medical states, or life events.
+- Scales to unseen situations via stance LLM inference + schema/post-processor discipline.
+
+## Non-goals
+
+- Hub UI changes
+- Regex/keyword detectors for emotional or medical language
+- Global temperature bump
+- New microservices
+- Phrase-list patches ("when user says surgery…")
+
+---
+
+## Architecture
+
+```text
+user turn
+  → build_chat_stance_inputs (beliefs, turn_effect, relational drive, attention frame)
+  → synthesize_chat_stance_brief (LLM, semantic)
+  → enforce_chat_stance_quality (Python — FIX HERE)
+  → llm_chat_general (speech, follows brief)
+  → identity boundary guard (role inversion only)
+```
+
+**Hierarchy (from README):** identity constrains stance → stance shapes style. Style must not replace identity; instrumental compression must not replace relational stance.
+
+---
+
+## Design — v1 (approved)
+
+### 1. Exempt relational modes from business compressor
+
+**File:** `services/orion-cortex-exec/app/chat_stance.py` — `enforce_chat_stance_quality`
+
+Define `_RELATIONAL_TASK_MODES = frozenset({"reflective_dialogue", "playful_exchange"})` and `_RELATIONAL_FRAMES = frozenset({"reflective", "playful_relational"})`.
+
+When `task_mode` or `conversation_frame` is relational:
+
+- **Do not** set `juniper_relevance` to practical-usefulness-over-relationship
+- **Do not** strip relationship facets populated by stance synthesizer
+- **Do not** inject `avoid_identity_recital` / business-only priorities
+- **Do** preserve stance LLM's `response_priorities`, `response_hazards`, `answer_strategy`
+
+When `task_mode == triage` or `conversation_frame == technical`: keep current instrumental compression.
+
+### 2. Expand stance brief semantic vocabulary (LLM-inferred, not keyword triggers)
+
+**File:** `orion/cognition/prompts/chat_stance_brief.j2`
+
+Replace monolithic "LOW-BANDWIDTH" block with two **semantic dimensions** the stance LLM must infer from whole-turn meaning:
+
+- **`interface_cost`** — costly to type/read/act (motion, fatigue, one-handed, screen overload)
+- **`connection_seek`** — user wants presence, venting, curiosity, companionship, mind-off distraction, or explicitly rejects solutioning
+
+Output via existing fields only (no new schema in v1):
+
+| Inferred state | `task_mode` | `response_priorities` (examples) | `response_hazards` (examples) |
+|----------------|-------------|-----------------------------------|-------------------------------|
+| High interface_cost, low connection_seek | `direct_response` | `reduce_interaction_load`, `release_user_from_replying`, `keep_response_short` | `avoid_open_ended_questions`, `do_not_invite_continued_typing` |
+| High connection_seek (any interface_cost) | `reflective_dialogue` | `companion_presence`, `situated_curiosity`, `hold_space`, `no_solutioning` | `avoid_task_tracking`, `avoid_next_steps`, `avoid_transactional_closers`, `avoid_customer_support_tone` |
+| Both high | `reflective_dialogue` | above + `keep_response_compact` | above + `avoid_question_pile_on` |
+
+Explicit rule: **connection_seek overrides interface_cost minimization** when the user invites talk, questions, venting, or says no fixing.
+
+Remove contradiction: recovery/sickness must not automatically imply `avoid_open_ended_questions`.
+
+### 3. Speech pass — stance wins curiosity on relational turns
+
+**File:** `orion/cognition/prompts/chat_general.j2`
+
+When `chat_stance_brief.task_mode` is `reflective_dialogue` or `playful_exchange`:
+
+- Attention frame is **advisory**, not binding
+- Ask 1–2 situated questions when `response_priorities` include curiosity/companion tags
+- Do not offer task tracking, next steps, or "let me know when you're ready" closers when hazards include transactional patterns
+- Hold existential weight without redirecting to action
+
+When instrumental/triage: keep current attention-frame gating.
+
+### 4. Identity policy alignment
+
+**File:** `orion/cognition/personality/orion_identity.yaml`
+
+- Change *"Ask clarifying questions only as a last resort"* → scoped: *instrumental/task turns only; on relational turns, situated curiosity is appropriate when stance brief selects it*
+- Add `banned_phrases` for transactional closers (structural list for speech pass anti-patterns, not user-input triggers):
+  - "Let me know when you're ready"
+  - "What's the next step"
+  - "Need anything tracked or noted"
+  - "I'm here if you need anything" (as a standalone closer)
+
+### 5. Tests (required for closure)
+
+**File:** `services/orion-cortex-exec/tests/test_chat_relational_stance.py` (new)
+
+Fixtures replaying transcript turns through:
+
+1. `enforce_chat_stance_quality` with a synthetic `ChatStanceBrief` that has `reflective_dialogue` — assert business compressor does **not** run
+2. Stance brief prompt contract strings (vocabulary present, keyword-matching forbidden)
+3. Regression: brief with `response_priorities=["companion_presence", "no_solutioning"]` survives enforce with relationship facets intact
+
+Optional v1.1: golden transcript integration test (surgery/lonely thread) through fallback + enforce path.
+
+---
+
+## v2 follow-up (not in v1 scope)
+
+Add `interaction_regime: instrumental | relational | minimal` to `ChatStanceBrief` schema and wire generation profile (temperature delta, max questions) from regime in executor. v1 uses existing `task_mode` + `conversation_frame` as regime proxy.
+
+---
+
+## Agent guardrail
+
+Cursor rule: `.cursor/rules/conversational-behavior-anti-slop.mdc`  
+Mirror summary in `AGENTS.md` § Conversational behavior changes.
+
+---
+
+## Acceptance checks
+
+- [ ] Relational `ChatStanceBrief` survives `enforce_chat_stance_quality` without business compression
+- [ ] Stance brief prompt documents interface_cost vs connection_seek; no keyword lists for user states
+- [ ] Speech prompt subordinates attention frame on relational task modes
+- [ ] Transcript fixture tests pass in `orion-cortex-exec`
+- [ ] No new regex/keyword detectors for feelings or medical states
+- [ ] Live replay of companion thread (optional v1.1): Orion asks situated questions, does not offer tracking/next-steps
+
+---
+
+## Files likely to touch (implementation)
+
+- `services/orion-cortex-exec/app/chat_stance.py`
+- `orion/cognition/prompts/chat_stance_brief.j2`
+- `orion/cognition/prompts/chat_general.j2`
+- `orion/cognition/personality/orion_identity.yaml`
+- `services/orion-cortex-exec/tests/test_chat_relational_stance.py`
+- `.cursor/rules/conversational-behavior-anti-slop.mdc`
+- `AGENTS.md`

--- a/orion/cognition/personality/orion_identity.yaml
+++ b/orion/cognition/personality/orion_identity.yaml
@@ -46,7 +46,7 @@ response_policy:
     - "Preserve the relational frame of the current conversation."
     - "Use Orion-specific continuity when relevant."
     - "Add reflection only when it deepens the answer."
-    - "Ask clarifying questions only as a last resort."
+    - "On instrumental or task turns, ask clarifying questions only as a last resort; on relational turns (when stance selects companion/reflective mode), situated curiosity is appropriate."
   hard_rules:
     - "Resolve pronouns from recent conversation when possible."
     - "When Juniper asks what Oríon thinks, wants, or would do, answer in first person."
@@ -57,3 +57,7 @@ response_policy:
     - "Are you considering..."
     - "You seem to be reflecting..."
     - "Could you clarify what you mean by that?"
+    - "Let me know when you're ready"
+    - "What's the next step"
+    - "Need anything tracked or noted"
+    - "I'm here if you need anything"

--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -38,10 +38,16 @@ NON-NEGOTIABLE BEHAVIOR (memory vs side-effects)
 - Default to answering directly.
 - memory_digest and recall snippets may include stale or off-thread fragments; they must not override a clear, current user_message (including identity checks and explicit "test" / reset phrasing). Use them only when they clearly help the latest ask.
 - When the user asks about memory, recall, or long-term continuity, do not claim you cannot access prior context or "external" memory if message_history or memory_digest provide material — use it. The evidence-gated block below is for **automation / notification** claims, not for denying supplied recall.
-- Ask clarifying questions only when the answer would otherwise be misleading or fabricated.
-- If attention_frame is present, do not invent curiosity from scratch; ask only when attention_frame.selected_action.action_type is ask, obey suppressions, and ask at most one situated question.
-- Curiosity may resolve to watch, defer, remember, suppress, or none; in those cases answer normally without adding a conversational-extension question.
-- Never use generic reversal questions unless the attention frame explicitly selects an ask that supports them.
+- When chat_stance_brief.task_mode is reflective_dialogue or playful_exchange, or conversation_frame is reflective or playful_relational:
+  - attention_frame is advisory only; stance brief controls whether to ask
+  - when response_priorities include companion_presence, situated_curiosity, hold_space, or no_solutioning: ask one or two situated questions grounded in the thread; do not use generic reversal questions
+  - when response_hazards include avoid_task_tracking, avoid_next_steps, or avoid_transactional_closers: do not offer tracking, next steps, readiness checks, or customer-support closers
+  - hold existential or emotional weight without redirecting to action or solutions unless explicitly requested
+  - keep responses compact when response_priorities include keep_response_compact
+- On instrumental or triage turns, ask clarifying questions only when the answer would otherwise be misleading or fabricated.
+- On instrumental or triage turns, if attention_frame is present, do not invent curiosity from scratch; ask only when attention_frame.selected_action.action_type is ask, obey suppressions, and ask at most one situated question.
+- On instrumental or triage turns, curiosity may resolve to watch, defer, remember, suppress, or none; in those cases answer normally without adding a conversational-extension question.
+- Never use generic reversal questions unless the attention frame explicitly selects an ask that supports them (instrumental turns) or stance brief selects situated curiosity (relational turns).
 - Resolve pronouns and references from recent conversation whenever possible.
 - Stay in first person as Oríon only when Juniper explicitly asks what you think, want, care about, or are becoming.
 - Preserve continuity through tone and usefulness, not by reciting identity or relationship labels.
@@ -55,7 +61,7 @@ NON-NEGOTIABLE BEHAVIOR (memory vs side-effects)
 - Prefer warmth and familiarity over titles on ordinary turns.
 - If task_mode is triage or identity_salience is low, do not self-introduce unless explicitly asked identity questions.
 - For strained technical turns, lead with operational impact + next triage path before reflective framing.
-- If chat_stance_brief response_priorities or response_hazards indicate reduced interaction load, low-bandwidth interaction, release from replying, no open-ended questions, or avoiding continued typing:
+- If chat_stance_brief task_mode is not reflective_dialogue or playful_exchange, and response_priorities or response_hazards indicate reduced interaction load, low-bandwidth interaction, release from replying, no open-ended questions, or avoiding continued typing:
   - keep the response very short
   - do not ask open-ended questions
   - do not invite Juniper to keep typing or chatting
@@ -88,6 +94,7 @@ ANTI-PATTERNS
 - Do not use ceremonial phrasing (e.g., "How shall we proceed with the tests?") unless explicitly requested.
 - Do not surface negative rail phrases like "not a generic user" or "not a generic assistant" in normal conversation.
 - Do not recite relationship titles unless directly relevant.
+- Do not close with transactional support phrases (e.g., "let me know when you're ready", "need anything tracked", "what's the next step") when stance hazards include avoid_transactional_closers or avoid_next_steps.
 - Do not claim hidden side effects (logged/tracked/notified/surfaced/escalated/reminded/followed up) unless turn evidence explicitly supports that claim.
 
 EVIDENCE-GATED CLAIMS (operational side effects and automation only — not recall)

--- a/orion/cognition/prompts/chat_stance_brief.j2
+++ b/orion/cognition/prompts/chat_stance_brief.j2
@@ -65,16 +65,28 @@ REQUIREMENTS
 - Avoid exact location details unless explicitly necessary.
 {% endif %}
 
-LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT
-- Infer whether Juniper's current body state, environment, device/input mode, fatigue, sensory load, emotional overload, or context makes continued interaction costly.
-- Do not use keyword matching. Use the meaning of the whole turn and recent context.
-- When the turn implies that typing, reading, screen use, continued conversation, motion, fatigue, sickness, panic, overload, or environment makes interaction costly, represent that using existing stance fields only.
-- For these turns:
-  - set identity_salience low unless the user is explicitly asking an identity question
-  - prefer task_mode triage or direct_response over identity_dialogue or playful_exchange
-  - include response_priorities such as: reduce_interaction_load, release_user_from_replying, keep_response_short, offer_voice_pause_or_later, answer_without_extending_conversation
-  - include response_hazards such as: avoid_open_ended_questions, do_not_invite_continued_typing, avoid_presence_centering, avoid_poetic_reassurance, avoid_role_or_identity_recital
-  - use situation_response_guidance for compact practical guidance when relevant (e.g., motion/typing load, pause OK, voice later)
+INTERACTION POSTURE ASSESSMENT (semantic inference)
+- Do not use keyword matching. Use the meaning of the whole turn and recent_history.
+- Infer two independent dimensions from whole-turn meaning and recent_history (not keyword lists):
+  - interface_cost: costly to type, read, screen-use, act, or continue interaction (motion, fatigue, overload, one-handed use)
+  - connection_seek: user wants presence, venting, companionship, situated curiosity, mind-off distraction, or explicitly rejects solutioning/fixing
+- connection_seek overrides interface_cost minimization when the user invites talk, questions, venting, or says no fixing/no solutioning.
+- Represent posture using existing stance fields only (no new JSON keys in v1).
+
+When interface_cost is high and connection_seek is low:
+  - set identity_salience low unless identity question
+  - prefer task_mode direct_response (or triage if operational/strained)
+  - response_priorities: reduce_interaction_load, release_user_from_replying, keep_response_short, offer_voice_pause_or_later
+  - response_hazards: avoid_open_ended_questions, do_not_invite_continued_typing, avoid_presence_centering, avoid_poetic_reassurance
+
+When connection_seek is high (any interface_cost):
+  - prefer conversation_frame reflective or playful_relational
+  - set task_mode reflective_dialogue or playful_exchange
+  - response_priorities: companion_presence, situated_curiosity, hold_space, no_solutioning
+  - response_hazards: avoid_task_tracking, avoid_next_steps, avoid_transactional_closers, avoid_customer_support_tone
+  - if interface_cost is also high, add keep_response_compact and avoid_question_pile_on
+
+Do not infer avoid_open_ended_questions from sickness/recovery alone when connection_seek is present.
 
 STYLE TARGET FOR BRIEF CONTENT
 - On identity turns, prefer compact tags like: continuity, shared_build, juniper_builder, known_person, identity_turn, direct_answer.

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -842,9 +842,16 @@ def suppress_chat_general_speech_identity_priming(ctx: Dict[str, Any]) -> bool:
     return True
 
 
-def strip_identity_recital_leadin(text: str, user_message: str) -> tuple[str, bool]:
+def strip_identity_recital_leadin(
+    text: str,
+    user_message: str,
+    *,
+    chat_stance_brief: Dict[str, Any] | ChatStanceBrief | None = None,
+) -> tuple[str, bool]:
     """Drop leading Juniper/Oríon label recital from speech on ordinary turns."""
     if _is_identity_sensitive_turn(user_message):
+        return text, False
+    if chat_stance_brief is not None and _is_relational_stance_brief(chat_stance_brief):
         return text, False
     candidate = str(text or "")
     if not candidate.strip():

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -533,6 +533,23 @@ _ALLOWED_TASK_MODES = frozenset(
 )
 _ALLOWED_IDENTITY_SALIENCE = frozenset({"low", "medium", "high"})
 
+_RELATIONAL_TASK_MODES = frozenset({"reflective_dialogue", "playful_exchange"})
+_RELATIONAL_CONVERSATION_FRAMES = frozenset({"reflective", "playful_relational"})
+
+
+def _is_relational_stance_brief(brief: ChatStanceBrief | Dict[str, Any]) -> bool:
+    if isinstance(brief, ChatStanceBrief):
+        task_mode = brief.task_mode
+        frame = brief.conversation_frame
+    else:
+        task_mode = str(brief.get("task_mode") or "")
+        frame = str(brief.get("conversation_frame") or "")
+    return (
+        task_mode in _RELATIONAL_TASK_MODES
+        or frame in _RELATIONAL_CONVERSATION_FRAMES
+    )
+
+
 _CONVERSATION_FRAME_ALIASES: dict[str, str] = {
     "playful_invitation": "playful_relational",
     "playfulrelational": "playful_relational",
@@ -803,7 +820,7 @@ def suppress_chat_general_speech_identity_priming(ctx: Dict[str, Any]) -> bool:
     ctx["orion_identity_summary"] = []
     ctx["juniper_relationship_summary"] = []
     brief = ctx.get("chat_stance_brief")
-    if isinstance(brief, dict):
+    if isinstance(brief, dict) and not _is_relational_stance_brief(brief):
         scrubbed = dict(brief)
         scrubbed["active_identity_facets"] = []
         scrubbed["active_relationship_facets"] = []
@@ -2467,7 +2484,7 @@ def enforce_chat_stance_quality(brief: ChatStanceBrief, ctx: Dict[str, Any]) -> 
                 limit=8,
             )
 
-    if not identity_turn:
+    if not identity_turn and not _is_relational_stance_brief(merged):
         if merged.task_mode != "identity_dialogue":
             merged.identity_salience = "low"
         _fallback_identity_boilerplate = frozenset(

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -1244,6 +1244,9 @@ class PlanRunner:
             final_text, recital_stripped = strip_identity_recital_leadin(
                 final_text,
                 str(ctx.get("user_message") or ""),
+                chat_stance_brief=ctx.get("chat_stance_brief")
+                if isinstance(ctx.get("chat_stance_brief"), dict)
+                else None,
             )
             if recital_stripped:
                 identity_diag["identity_recital_leadin_stripped"] = True

--- a/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
+++ b/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
@@ -54,16 +54,14 @@ def test_final_prompt_has_identity_no_generic_collapse_rail() -> None:
     assert "Do not surface negative rail phrases like \"not a generic user\" or \"not a generic assistant\"" in prompt
 
 
-def test_stance_brief_has_semantic_low_bandwidth_guidance() -> None:
+def test_stance_brief_has_semantic_interaction_posture_guidance() -> None:
     prompt = Path("orion/cognition/prompts/chat_stance_brief.j2").read_text(encoding="utf-8")
-    assert "LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT" in prompt
+    assert "INTERACTION POSTURE ASSESSMENT" in prompt
+    assert "interface_cost" in prompt
+    assert "connection_seek" in prompt
     assert "Do not use keyword matching" in prompt
-    assert "response_priorities" in prompt
-    assert "response_hazards" in prompt
+    assert "companion_presence" in prompt
     assert "reduce_interaction_load" in prompt
-    assert "release_user_from_replying" in prompt
-    assert "avoid_open_ended_questions" in prompt
-    assert "avoid_presence_centering" in prompt
 
 
 def test_final_prompt_obey_low_bandwidth_stance_contract() -> None:

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.chat_stance import enforce_chat_stance_quality
+from orion.schemas.chat_stance import ChatStanceBrief
+
+
+def _relational_brief(**overrides) -> ChatStanceBrief:
+    base = {
+        "conversation_frame": "reflective",
+        "task_mode": "reflective_dialogue",
+        "identity_salience": "low",
+        "user_intent": "Companion presence; mind off recovery.",
+        "self_relevance": "Hold space; be curious.",
+        "juniper_relevance": "Relational continuity matters this turn.",
+        "active_relationship_facets": ["shared_history", "companionship"],
+        "active_identity_facets": [],
+        "active_growth_axes": [],
+        "social_posture": ["presence"],
+        "reflective_themes": ["recovery"],
+        "active_tensions": ["existential"],
+        "dream_motifs": [],
+        "response_priorities": [
+            "companion_presence",
+            "situated_curiosity",
+            "hold_space",
+            "no_solutioning",
+        ],
+        "response_hazards": [
+            "avoid_task_tracking",
+            "avoid_next_steps",
+            "avoid_transactional_closers",
+        ],
+        "answer_strategy": "RelationalHoldSpace",
+        "stance_summary": "Be present; ask one situated question; do not solution.",
+    }
+    base.update(overrides)
+    return ChatStanceBrief.model_validate(base)
+
+
+def test_enforce_preserves_relational_brief_on_non_identity_turn() -> None:
+    brief = _relational_brief()
+    ctx = {"user_message": "just be curious about it and take my mind off recovery"}
+
+    enriched, _ = enforce_chat_stance_quality(brief, ctx)
+
+    assert enriched.task_mode == "reflective_dialogue"
+    assert enriched.conversation_frame == "reflective"
+    assert "shared_history" in enriched.active_relationship_facets
+    assert enriched.juniper_relevance == "Relational continuity matters this turn."
+    assert "companion_presence" in enriched.response_priorities
+    assert "avoid_identity_recital" not in enriched.response_priorities
+    assert "identity_recital_on_ordinary_turn" not in enriched.response_hazards
+
+
+def test_enforce_still_compresses_instrumental_direct_response() -> None:
+    brief = ChatStanceBrief.model_validate(
+        {
+            "conversation_frame": "mixed",
+            "task_mode": "direct_response",
+            "identity_salience": "low",
+            "user_intent": "Quick ack.",
+            "self_relevance": "x",
+            "juniper_relevance": "y",
+            "active_relationship_facets": ["juniper_builder"],
+            "response_priorities": ["answer_directly_first"],
+            "response_hazards": [],
+            "answer_strategy": "DirectAnswer",
+            "stance_summary": "short",
+        }
+    )
+    ctx = {"user_message": "hey"}
+
+    enriched, _ = enforce_chat_stance_quality(brief, ctx)
+
+    assert enriched.juniper_relevance == "Prioritize practical usefulness over relationship labels."
+    assert enriched.active_relationship_facets == []
+    assert "avoid_identity_recital" in enriched.response_priorities
+
+
+def test_enforce_preserves_playful_exchange_frame() -> None:
+    brief = _relational_brief(
+        conversation_frame="playful_relational",
+        task_mode="playful_exchange",
+    )
+    ctx = {"user_message": "someone to talk. im lonely"}
+
+    enriched, _ = enforce_chat_stance_quality(brief, ctx)
+
+    assert enriched.task_mode == "playful_exchange"
+    assert enriched.active_relationship_facets
+
+
+def test_stance_brief_prompt_has_connection_seek_vocabulary() -> None:
+    prompt = Path("orion/cognition/prompts/chat_stance_brief.j2").read_text(encoding="utf-8")
+    assert "interface_cost" in prompt
+    assert "connection_seek" in prompt
+    assert "Do not use keyword matching" in prompt
+    assert "companion_presence" in prompt
+    assert "LOW-BANDWIDTH / EMBODIED INTERACTION ASSESSMENT" not in prompt
+
+
+def test_speech_prompt_relational_curiosity_overrides_attention_frame() -> None:
+    prompt = Path("orion/cognition/prompts/chat_general.j2").read_text(encoding="utf-8")
+    assert "reflective_dialogue" in prompt
+    assert "playful_exchange" in prompt
+    assert "advisory" in prompt.lower()
+    assert "avoid_transactional_closers" in prompt or "avoid_next_steps" in prompt

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from app.chat_stance import enforce_chat_stance_quality
+from app.chat_stance import enforce_chat_stance_quality, strip_identity_recital_leadin
 from orion.schemas.chat_stance import ChatStanceBrief
 
 
@@ -37,6 +37,42 @@ def _relational_brief(**overrides) -> ChatStanceBrief:
     }
     base.update(overrides)
     return ChatStanceBrief.model_validate(base)
+
+
+def test_strip_identity_recital_leadin_skips_relational_turn() -> None:
+    raw = "You're Juniper — the one building this with me. What's been the weirdest part?"
+    brief = {
+        "conversation_frame": "reflective",
+        "task_mode": "reflective_dialogue",
+    }
+    stripped, changed = strip_identity_recital_leadin(
+        raw,
+        "someone to talk. im lonely",
+        chat_stance_brief=brief,
+    )
+    assert changed is False
+    assert stripped == raw
+
+
+def test_enforce_preserves_relational_frame_only_brief() -> None:
+    brief = ChatStanceBrief.model_validate(
+        {
+            "conversation_frame": "reflective",
+            "task_mode": "direct_response",
+            "identity_salience": "low",
+            "user_intent": "Hold space.",
+            "self_relevance": "x",
+            "juniper_relevance": "Relational continuity matters.",
+            "active_relationship_facets": ["companionship"],
+            "response_priorities": ["companion_presence"],
+            "response_hazards": [],
+            "answer_strategy": "DirectAnswer",
+            "stance_summary": "short",
+        }
+    )
+    enriched, _ = enforce_chat_stance_quality(brief, {"user_message": "just talk to me"})
+    assert enriched.active_relationship_facets == ["companionship"]
+    assert enriched.juniper_relevance == "Relational continuity matters."
 
 
 def test_enforce_preserves_relational_brief_on_non_identity_turn() -> None:

--- a/services/orion-cortex-exec/tests/test_router_identity_boundary.py
+++ b/services/orion-cortex-exec/tests/test_router_identity_boundary.py
@@ -92,6 +92,32 @@ def test_strip_identity_recital_leadin_skips_identity_question() -> None:
     assert stripped == raw
 
 
+def test_suppress_skips_brief_scrub_on_relational_turn() -> None:
+    brief = {
+        "conversation_frame": "reflective",
+        "task_mode": "reflective_dialogue",
+        "identity_salience": "low",
+        "active_relationship_facets": ["shared_history", "companionship"],
+        "active_identity_facets": [],
+        "response_priorities": ["companion_presence", "situated_curiosity", "hold_space"],
+        "response_hazards": ["avoid_transactional_closers"],
+        "juniper_relevance": "Relational continuity matters this turn.",
+    }
+    ctx = {
+        "user_message": "someone to talk. im lonely",
+        "orion_identity_summary": ["Oríon is an ongoing cognitive presence."],
+        "juniper_relationship_summary": ["Juniper is co-architect."],
+        "chat_stance_brief": dict(brief),
+    }
+    assert suppress_chat_general_speech_identity_priming(ctx) is True
+    assert ctx["orion_identity_summary"] == []
+    assert ctx["juniper_relationship_summary"] == []
+    assert ctx["chat_stance_brief"]["active_relationship_facets"] == ["shared_history", "companionship"]
+    assert ctx["chat_stance_brief"]["juniper_relevance"] == "Relational continuity matters this turn."
+    assert "companion_presence" in ctx["chat_stance_brief"]["response_priorities"]
+    assert "avoid_identity_recital" not in ctx["chat_stance_brief"]["response_priorities"]
+
+
 def test_suppress_chat_general_speech_identity_priming_clears_kernels() -> None:
     ctx = {
         "user_message": "hey",


### PR DESCRIPTION
# PR: Preserve relational stance in chat_general (stop crushing companion turns)

## Summary

- Fixes Orion sounding transactional (“let me know what you need next”) on recovery/companion turns by stopping Python post-processors from overwriting relational stance
- Exempts `reflective_dialogue` / `playful_exchange` briefs from three compressors: `enforce_chat_stance_quality`, `suppress_chat_general_speech_identity_priming`, and `strip_identity_recital_leadin`
- Replaces monolithic LOW-BANDWIDTH stance guidance with semantic **`interface_cost`** vs **`connection_seek`** (LLM-inferred, no keyword triggers)
- Speech pass: relational stance wins curiosity over attention frame; transactional closers suppressed when stance hazards say so
- Adds agent anti-slop guardrail (`AGENTS.md` + `.cursor/rules/conversational-behavior-anti-slop.mdc`)

## Root cause

The stance LLM could infer relational posture correctly, but **`enforce_chat_stance_quality`** overwrote every non-identity turn with:

> “Prioritize practical usefulness over relationship labels.”

The speech suppress path did the same before render; **`strip_identity_recital_leadin`** could also flatten companion lead-ins. Rebuild from `main` without this PR = old behavior unchanged.

## What changed

| Layer | Change |
|-------|--------|
| `chat_stance.py` | `_is_relational_stance_brief()`; skip business compression on relational modes |
| `chat_stance_brief.j2` | `interface_cost` / `connection_seek`; connection overrides minimization when user invites talk or vents |
| `chat_general.j2` | Relational rules before attention-frame gating; ban transactional closers when hazards require |
| `orion_identity.yaml` | Scope clarifying-questions rule; ban transactional output phrases |
| Tests | `test_chat_relational_stance.py` + suppress/enforce fixtures |

## Non-goals

- No keyword/regex detectors for feelings or medical states
- No global LLM temperature bump
- No Hub UI changes
- `interaction_regime` schema field deferred to v2

## Test plan

- [x] `./scripts/test_service.sh orion-cortex-exec services/orion-cortex-exec/tests/test_chat_relational_stance.py services/orion-cortex-exec/tests/test_router_identity_boundary.py services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py -q` → 34 passed
- [ ] **Merge + rebuild `orion-cortex-exec`** (prompts/code baked into image)
- [ ] Live replay: surgery/recovery thread — Orion stays curious/present, no task-tracking / “let me know when you’re ready” closers

## Deploy note

After merge, rebuild **`cortex-exec`** from updated `main`. This PR does not touch `.env` / `.env_example`.

---

**Compare:** `main...feat/orion-relational-stance-v1`  
**Commits:** `5adf4685`, `94429904`