### PR TITLE
feat(substrate): self-revision rung — self-model drift -> governed dr…

### DIFF
--- a/docs/plans/substrate/2026-06-27-self-modeling-loop-ladder.md
+++ b/docs/plans/substrate/2026-06-27-self-modeling-loop-ladder.md
@@ -17,12 +17,12 @@ behind trials + rollback.
 
 | Rung | Theory | Organ that exists | Wire to add | State |
 |------|--------|-------------------|-------------|-------|
-| 1 Self-model feedback | predictive processing | `self_state/prediction.py`, `pressure.py`, `dynamics.py` | prediction_error → pressure | **DONE** (`feat/substrate-prediction-error-pressure`) |
-| 2 Integration / higher-order | GWT binding + HOT | `CognitiveUnificationLayer`, `projection_builder.py` | register reducer lanes + bind self_state | spec below |
+| 1 Self-model feedback | predictive processing | `self_state/prediction.py`, `pressure.py`, `dynamics.py` | prediction_error → pressure | **DONE** |
+| 2 Integration / higher-order | GWT binding + HOT | `CognitiveUnificationLayer`, `projection_builder.py` | register reducer lanes + bind self_state | **self_state DONE**; reducer lanes pending |
 | 3 Continuous broadcast | GWT broadcast | `attention_frame.py` | always-on, substrate-wide re-broadcast | spec below |
 | 4 Autobiographical continuity | narrative/HOT | `consolidation.py` | episodic time-window rollup | spec below |
 | 5 Endogenous agency | intrinsic motivation | `frontier_curiosity.py` | intrinsic-signal-seeded goals | spec below |
-| 6 Self-revision | metacognition | `mutation_*` pipeline | prediction-error/drift → proposals | spec below |
+| 6 Self-revision | metacognition | `mutation_*` pipeline | prediction-error/drift → proposals | **DONE** (signals path: `mutation_self_revision.py`) |
 
 Dependency order: 1 → 2 → 3, then 4, then 5, then 6. Rung 6 consumes rung 1's
 signal; rungs 4/5/6 all read the unified state from rung 2.

--- a/docs/plans/substrate/CONTINUATION.md
+++ b/docs/plans/substrate/CONTINUATION.md
@@ -1,0 +1,94 @@
+# Continuation spec — substrate self-modeling loop
+
+Execution layer on top of `2026-06-27-self-modeling-loop-ladder.md`. Lets a fresh
+session finish the remaining rungs without re-deriving context.
+
+## State
+- Branch `feat/substrate-self-modeling-loop` (on origin).
+- Done + tested (12/12): rung 1 (`prediction_error→pressure`), rung 2 keystone
+  (`self_state` lane), rung 6 (`mutation_self_revision.py`).
+
+## Environment gotchas (read first)
+1. A concurrent automation process drives git in this checkout (merges PRs,
+   switches branches, `pull origin main`) and has moved branches off their commits.
+   **Always work in an isolated worktree**, never the main checkout:
+   `git worktree add <scratch>/wt feat/substrate-self-modeling-loop`
+   (run `git worktree prune` first if a stale registration blocks it).
+2. **Run pytest from inside the worktree** (`cd <wt>`), else `orion` resolves to the
+   main checkout. `python` isn't on PATH — use `.venv/bin/python`.
+3. Edits to `pressure.py`/`dynamics.py` were reverted twice by something external;
+   re-verify with `grep` after editing critical files.
+4. Stray root-owned dir `services/orion-cortex-exec/services/` blocks `git stash -u`/
+   clean; ignore it (needs `sudo rm`).
+5. No GitHub auth (no gh login, no `GH_TOKEN`). SSH `git push` works; PR objects
+   cannot be created/edited programmatically until a token exists.
+
+## Remaining work, priority order
+
+### A. Rung 1 runtime bridge (first, small)
+Dynamics engine seeds from `node.metadata['prediction_error']`, but the runtime
+worker only writes prediction error into a field-digester receipt, not onto a
+durable substrate node.
+- File: `services/orion-substrate-runtime/app/worker.py` (~555, ~645,
+  `_prediction_error_receipt`).
+- Do: on `error>0`, upsert/refresh a durable node (`node:substrate.execution` /
+  `node:substrate.transport`) with `metadata['prediction_error']=error`,
+  `observed_at=now`. Needs the worker to reach the substrate graph store (today it
+  has only `BiometricsSubstrateStore` SQL). If that boundary is too big, route via
+  the rung-2 adapter path and document.
+- Accept: surprising batch → node `prediction_error` set → next
+  `SubstrateDynamicsEngine.tick()` raises its `dynamic_pressure`.
+
+### B. Rung 2 remainder — reducer lane adapters (mechanical)
+Mirror `orion/substrate/relational/adapters/self_state_ctx.py`.
+- New: `adapters/execution_ctx.py`, `transport_ctx.py`, `biometrics_ctx.py` —
+  `map_*_ctx_to_substrate(ctx) -> SubstrateGraphRecordV1 | None`, carrying
+  prediction_error / pressure hints into node metadata. Read from ctx, or DB-pull
+  like `self_study.py` if the projection isn't in ctx.
+- Register 3 `ProducerEntryV1` in
+  `orion/cognition/projection_builder.py::build_projection_unification_registry`
+  (tier `SNAPSHOT_EPHEMERAL`, short TTL).
+- Accept: adapter unit tests; registry lists all 12 producers.
+
+### C. Rung 4 — episodic continuity (safe, fully unit-testable; recommended next)
+- New: `orion/substrate/episodic_consolidation.py` — evaluator alongside
+  `GraphConsolidationEvaluator`, windowed by `window_seconds`, rolling a **capped**
+  list of reduction receipts → one `EpisodeSummaryV1` (proposal-marked).
+- New schema `EpisodeSummaryV1` under `orion/core/schemas/`.
+- Rules: output marked proposal → pending/generated; cap receipts per episode;
+  episode id derived from inputs (idempotent replay).
+- Accept: window → one queryable episode; replay idempotent; excluded from
+  execution context by default; cap enforced.
+
+### D. Rung 3 — continuous broadcast (bigger; new runtime loop)
+- Files: `orion/substrate/attention_frame.py`, `attention/*`,
+  `services/orion-substrate-runtime/app/worker.py`,
+  `orion/schemas/attention_frame.py`.
+- Do: build `AttentionFrameV1` from unified beliefs + active pressure every tick
+  (not just chat turns); persist selected coalition as a projection. New flag
+  `ORION_ATTENTION_BROADCAST_ENABLED` (default false). Reuse `select_actions`.
+- Accept: flag on → one selected coalition per tick; high-pressure (incl.
+  prediction-error) nodes win; flag off → identical to today.
+
+### E. Rung 5 — endogenous agency (build flag-gated; DO NOT enable without sign-off)
+- Files: `orion/substrate/frontier_curiosity.py`, `frontier_expansion.py`, settings.
+- Do: curiosity seed source reading intrinsic signals (sustained prediction error,
+  `appraisal/repair_pressure.py`, rung-3 open-loops) emitting `curiosity_candidate`s
+  without operator trigger — behind `ORION_ENDOGENOUS_CURIOSITY_ENABLED`
+  (default false), per-cycle budget cap + kill switch. Proposal-only; routes through
+  rung-6 governance.
+- Accept: flag on → bounded candidate set; budget cap + kill switch enforced; flag
+  off → today's operator-gated behaviour.
+
+## Sequencing
+A → B → C → D → E. A/B/C are safe and unit-testable. D adds a runtime loop. E is
+the only one that changes autonomy at runtime — ship code, leave flag off, get
+explicit approval before flipping it.
+
+## Pattern that works here
+Each rung = one pure/ctx function + a focused unit test, committed small, pushed to
+the branch. Adapters degrade to `None` (never raise) on absent input. Reuse existing
+accumulators/factories/engines rather than adding parallel machinery — every rung so
+far rode an existing seam (the BFS propagator, the unifier registry, the mutation
+pressure accumulator).
+</content>

--- a/docs/plans/substrate/PR_self_modeling_loop.md
+++ b/docs/plans/substrate/PR_self_modeling_loop.md
@@ -1,0 +1,79 @@
+# PR: substrate self-modeling loop — prediction-error feedback → governed self-revision
+
+> This file is the PR description report, committed to the branch because no
+> GitHub auth was available to write the PR body directly. Paste the body section
+> into the PR at:
+> https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/substrate-self-modeling-loop
+
+---
+
+## Summary
+
+Turns the substrate from a feed-forward pipeline into a closed, self-correcting
+loop. Prediction error (how wrong Orion's model just was) was previously measured
+and exported but never acted on. This PR wires the feedback edges so surprise
+shapes attention, the self-model is bound into Orion's beliefs, and *sustained*
+self-model drift produces governed, draft-only change proposals.
+
+Honest framing: this is not a claim about phenomenal experience. It implements the
+*functional* properties (predictive feedback, integration/higher-order self-model,
+metacognitive self-revision) that theories of mind treat as load-bearing — each as
+a thin, inspectable, tested seam riding existing machinery.
+
+## What this PR closes (loop, end to end)
+
+```
+prediction error → pressure (rung 1)
+    → self-model bound into unified beliefs, carrying prediction_error (rung 2)
+    → sustained drift → governed DRAFT proposal, never auto-applied (rung 6)
+```
+
+## Changes
+
+| Rung | Change | Files |
+|------|--------|-------|
+| 1 | `prediction_error_pressure()` as a third seed source in the dynamics engine; BFS-propagated, age-decayed; gated by `PressureConfig.prediction_error_weight` | `orion/substrate/pressure.py`, `orion/substrate/dynamics.py` |
+| 2 | `self_state` producer + adapter binding Orion's self-model into the unification layer; each node carries standing `prediction_error` (durable-node completion of rung 1) | `orion/substrate/relational/adapters/self_state_ctx.py`, `orion/cognition/projection_builder.py` |
+| 6 | `prediction_error_mutation_signals()`: sustained self-dimension drift → `MutationSignalV1` → existing `PressureAccumulator` → `ProposalFactory` **draft** (`draft_only_not_applied`) | `orion/substrate/mutation_self_revision.py` |
+| docs | Full ladder + per-rung specs (rungs 3/4/5 + rung-2 lanes) for follow-up | `docs/plans/substrate/2026-06-27-self-modeling-loop-ladder.md`, `docs/plans/substrate/CONTINUATION.md` |
+
+## Safety / governance
+
+- **No auto-application.** Rung 6 emits *signals* only; thresholding, cooldown,
+  draft generation, trials and rollback remain owned by the unchanged mutation
+  pipeline. A single surprising tick stays below threshold; only persistent error
+  drafts a proposal, and every proposal is `draft_only_not_applied`.
+- **No invented surfaces.** Self-dimensions map only to already-supported cognitive
+  mutation surfaces; unmapped dimensions are ignored.
+- **No silent mutation** of accepted claims/specs (Knowledge Forge rule preserved).
+- Rung 1 is gated by `prediction_error_weight` (set 0 to disable).
+
+## Tests
+
+`12/12` passing:
+- `tests/test_cognitive_substrate_phase4_dynamics.py` — seed + propagation + age-decay + no regression (7).
+- `orion/substrate/relational/tests/test_self_state_adapter.py` — self-model nodes carry prediction_error; dict/JSON input; absent → None (2).
+- `orion/substrate/tests/test_mutation_self_revision.py` — supported-surface routing; calm → nothing; sustained drift → draft proposal, never applied (3).
+
+```
+cd <worktree> && .venv/bin/python -m pytest \
+  tests/test_cognitive_substrate_phase4_dynamics.py \
+  orion/substrate/relational/tests/test_self_state_adapter.py \
+  orion/substrate/tests/test_mutation_self_revision.py -q
+```
+
+## Follow-up (not in this PR — see CONTINUATION.md)
+
+- Rung 1 runtime bridge: worker writes `prediction_error` onto durable substrate
+  nodes (currently lands in a field-digester receipt only).
+- Rung 2 remainder: biometrics/execution/transport lane adapters.
+- Rung 4 episodic continuity; rung 3 continuous broadcast; rung 5 endogenous
+  agency (build flag-gated, **do not enable without sign-off**).
+
+## Reviewer notes
+
+- The repo is concurrently mutated by an automation user; this branch was built in
+  an isolated worktree to avoid corruption.
+- Commits: `85d29c62` (rung 1), `ca176e4e` (specs), `d9dbe624` (rung 2), `de21cb3a`
+  (rung 6).
+</content>

--- a/orion/substrate/mutation_self_revision.py
+++ b/orion/substrate/mutation_self_revision.py
@@ -1,0 +1,81 @@
+"""Self-revision rung: turn sustained self-model prediction error into governed
+mutation *signals*.
+
+This is the metacognitive close of the self-modeling loop. Rung 1 fed prediction
+error into pressure (attention); this rung feeds *sustained* prediction error on
+self-model dimensions into the existing mutation pipeline as ``MutationSignalV1``s.
+Those signals flow through the unchanged governance path:
+
+    signal -> PressureAccumulator (decay + activation threshold)
+           -> ProposalFactory.from_pressure -> DRAFT proposal (never auto-applied)
+
+We deliberately emit only *signals*, not proposals or applied changes: thresholding,
+cooldown, draft generation, trials and rollback all remain owned by the existing
+pipeline. A single surprising tick produces nothing; only error that persists past
+the accumulator's activation threshold becomes a reviewable draft.
+
+Mapping self-model dimensions to the existing cognitive mutation surfaces is
+intentionally conservative — only dimensions with a clear, already-supported
+cognitive surface are routed; everything else is ignored rather than invented.
+"""
+
+from __future__ import annotations
+
+from orion.core.schemas.substrate_mutation import MutationSignalV1
+from orion.schemas.self_state import SelfStateV1
+
+# self-model dimension -> existing cognitive mutation surface (see
+# orion/substrate/mutation_proposals.py SURFACE_TO_CLASS / SURFACE_TO_LANE).
+# Only surfaces that the ProposalFactory already knows how to draft are listed.
+_DIMENSION_TO_SURFACE: dict[str, str] = {
+    "continuity_pressure": "cognitive_identity_continuity_adjustment",
+    "introspection_pressure": "cognitive_identity_continuity_adjustment",
+    "social_pressure": "cognitive_social_continuity_repair",
+    "coherence": "cognitive_contradiction_reconciliation",
+}
+
+# Minimum standing prediction error before a self-dimension is allowed to emit a
+# signal at all. Below this the loop stays silent — surprise must be real.
+_DEFAULT_MIN_ERROR = 0.3
+
+
+def prediction_error_mutation_signals(
+    self_state: SelfStateV1,
+    *,
+    min_error: float = _DEFAULT_MIN_ERROR,
+) -> list[MutationSignalV1]:
+    """Map sustained self-model prediction error to governed mutation signals.
+
+    Returns one ``MutationSignalV1`` per self-dimension whose standing prediction
+    error exceeds ``min_error`` *and* maps to a supported cognitive surface. The
+    signal ``strength`` is the prediction error itself (already 0..1), so the
+    accumulator integrates worse-predicted dimensions to threshold faster.
+    """
+    signals: list[MutationSignalV1] = []
+    for dim_id, surface in _DIMENSION_TO_SURFACE.items():
+        error = float(self_state.prediction_error_scores.get(dim_id, 0.0) or 0.0)
+        if error < min_error:
+            continue
+        strength = max(0.0, min(1.0, error))
+        signals.append(
+            MutationSignalV1(
+                event_kind=f"self_model_drift:{dim_id}",
+                anchor_scope="orion",
+                subject_ref="entity:orion",
+                target_surface=surface,
+                target_zone="concept_graph",
+                strength=strength,
+                evidence_refs=[
+                    f"self_state:{self_state.self_state_id}",
+                    f"self_dimension:{dim_id}",
+                ],
+                source_ref=f"self_state:{self_state.self_state_id}",
+                metadata={
+                    "source_kind": "self_model_prediction_error",
+                    "self_dimension_id": dim_id,
+                    "prediction_error": round(strength, 6),
+                    "trajectory": round(float(self_state.dimension_trajectory.get(dim_id, 0.0) or 0.0), 6),
+                },
+            )
+        )
+    return signals

--- a/orion/substrate/tests/test_mutation_self_revision.py
+++ b/orion/substrate/tests/test_mutation_self_revision.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+from orion.substrate.mutation_pressure import PressureAccumulator, PressurePolicy
+from orion.substrate.mutation_proposals import ProposalFactory
+from orion.substrate.mutation_self_revision import prediction_error_mutation_signals
+
+
+def _self_state(prediction_error_scores: dict[str, float]) -> SelfStateV1:
+    now = datetime.now(timezone.utc)
+    dims = {
+        dim: SelfStateDimensionV1(dimension_id=dim, score=0.5, confidence=0.7)
+        for dim in prediction_error_scores
+    }
+    return SelfStateV1(
+        self_state_id="ss-revision",
+        generated_at=now,
+        source_field_tick_id="ft",
+        source_field_generated_at=now,
+        source_attention_frame_id="af",
+        source_attention_generated_at=now,
+        overall_condition="strained",
+        overall_intensity=0.6,
+        overall_confidence=0.6,
+        dimensions=dims,
+        prediction_error_scores=prediction_error_scores,
+    )
+
+
+def test_sustained_self_model_error_emits_only_supported_cognitive_signals() -> None:
+    signals = prediction_error_mutation_signals(
+        _self_state({"continuity_pressure": 0.7, "transport_integrity": 0.9})
+    )
+    # continuity maps to a supported cognitive surface; transport_integrity has no
+    # cognitive surface, so it is ignored rather than invented.
+    surfaces = {s.target_surface for s in signals}
+    assert surfaces == {"cognitive_identity_continuity_adjustment"}
+    sig = signals[0]
+    assert sig.event_kind == "self_model_drift:continuity_pressure"
+    assert sig.strength == 0.7
+    assert sig.metadata["source_kind"] == "self_model_prediction_error"
+
+
+def test_calm_self_model_emits_nothing() -> None:
+    # all dimensions below the min_error floor
+    assert prediction_error_mutation_signals(
+        _self_state({"continuity_pressure": 0.1, "coherence": 0.05})
+    ) == []
+
+
+def test_single_weak_signal_is_below_threshold_but_sustained_error_drafts_a_proposal() -> None:
+    accumulator = PressureAccumulator(policy=PressurePolicy())
+    factory = ProposalFactory()
+    now = datetime.now(timezone.utc)
+
+    # a mild-but-real drift: strength 0.3 -> +1.5 per tick, threshold is 3.0
+    signal = prediction_error_mutation_signals(
+        _self_state({"continuity_pressure": 0.3}), min_error=0.3
+    )[0]
+
+    pressure = accumulator.apply(current=None, signal=signal, now=now)
+    # one weak tick is not enough — governance: surprise must persist
+    assert not accumulator.ready_for_proposal(pressure, now=now)
+
+    # the same drift, sustained over further ticks, accumulates past the threshold
+    ticks = 1
+    while not accumulator.ready_for_proposal(pressure, now=now) and ticks < 10:
+        pressure = accumulator.apply(current=pressure, signal=signal, now=now)
+        ticks += 1
+    assert accumulator.ready_for_proposal(pressure, now=now)
+    assert ticks > 1  # required more than a single tick
+
+    proposal = factory.from_pressure(pressure)
+    assert proposal is not None
+    # routed through the existing governed cognitive lane...
+    assert proposal.lane == "cognitive"
+    assert proposal.mutation_class == "cognitive_identity_continuity_adjustment"
+    # ...and is a DRAFT — never auto-applied
+    assert proposal.patch.patch["not_applied_status"] == "draft_only_not_applied"


### PR DESCRIPTION
# PR: substrate self-modeling loop — prediction-error feedback → governed self-revision

> This file is the PR description report, committed to the branch because no
> GitHub auth was available to write the PR body directly. Paste the body section
> into the PR at:
> https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/substrate-self-modeling-loop

---

## Summary

Turns the substrate from a feed-forward pipeline into a closed, self-correcting
loop. Prediction error (how wrong Orion's model just was) was previously measured
and exported but never acted on. This PR wires the feedback edges so surprise
shapes attention, the self-model is bound into Orion's beliefs, and *sustained*
self-model drift produces governed, draft-only change proposals.

Honest framing: this is not a claim about phenomenal experience. It implements the
*functional* properties (predictive feedback, integration/higher-order self-model,
metacognitive self-revision) that theories of mind treat as load-bearing — each as
a thin, inspectable, tested seam riding existing machinery.

## What this PR closes (loop, end to end)

```
prediction error → pressure (rung 1)
    → self-model bound into unified beliefs, carrying prediction_error (rung 2)
    → sustained drift → governed DRAFT proposal, never auto-applied (rung 6)
```

## Changes

| Rung | Change | Files |
|------|--------|-------|
| 1 | `prediction_error_pressure()` as a third seed source in the dynamics engine; BFS-propagated, age-decayed; gated by `PressureConfig.prediction_error_weight` | `orion/substrate/pressure.py`, `orion/substrate/dynamics.py` |
| 2 | `self_state` producer + adapter binding Orion's self-model into the unification layer; each node carries standing `prediction_error` (durable-node completion of rung 1) | `orion/substrate/relational/adapters/self_state_ctx.py`, `orion/cognition/projection_builder.py` |
| 6 | `prediction_error_mutation_signals()`: sustained self-dimension drift → `MutationSignalV1` → existing `PressureAccumulator` → `ProposalFactory` **draft** (`draft_only_not_applied`) | `orion/substrate/mutation_self_revision.py` |
| docs | Full ladder + per-rung specs (rungs 3/4/5 + rung-2 lanes) for follow-up | `docs/plans/substrate/2026-06-27-self-modeling-loop-ladder.md`, `docs/plans/substrate/CONTINUATION.md` |

## Safety / governance

- **No auto-application.** Rung 6 emits *signals* only; thresholding, cooldown,
  draft generation, trials and rollback remain owned by the unchanged mutation
  pipeline. A single surprising tick stays below threshold; only persistent error
  drafts a proposal, and every proposal is `draft_only_not_applied`.
- **No invented surfaces.** Self-dimensions map only to already-supported cognitive
  mutation surfaces; unmapped dimensions are ignored.
- **No silent mutation** of accepted claims/specs (Knowledge Forge rule preserved).
- Rung 1 is gated by `prediction_error_weight` (set 0 to disable).

## Tests

`12/12` passing:
- `tests/test_cognitive_substrate_phase4_dynamics.py` — seed + propagation + age-decay + no regression (7).
- `orion/substrate/relational/tests/test_self_state_adapter.py` — self-model nodes carry prediction_error; dict/JSON input; absent → None (2).
- `orion/substrate/tests/test_mutation_self_revision.py` — supported-surface routing; calm → nothing; sustained drift → draft proposal, never applied (3).

```
cd <worktree> && .venv/bin/python -m pytest \
  tests/test_cognitive_substrate_phase4_dynamics.py \
  orion/substrate/relational/tests/test_self_state_adapter.py \
  orion/substrate/tests/test_mutation_self_revision.py -q
```

## Follow-up (not in this PR — see CONTINUATION.md)

- Rung 1 runtime bridge: worker writes `prediction_error` onto durable substrate
  nodes (currently lands in a field-digester receipt only).
- Rung 2 remainder: biometrics/execution/transport lane adapters.
- Rung 4 episodic continuity; rung 3 continuous broadcast; rung 5 endogenous
  agency (build flag-gated, **do not enable without sign-off**).

## Reviewer notes

- The repo is concurrently mutated by an automation user; this branch was built in
  an isolated worktree to avoid corruption.
- Commits: `85d29c62` (rung 1), `ca176e4e` (specs), `d9dbe624` (rung 2), `de21cb3a`
  (rung 6).
</content>