### PR TITLE
Feat/vision caption provenance v1

### DIFF
--- a/config/vision_frame_router.yaml
+++ b/config/vision_frame_router.yaml
@@ -6,7 +6,9 @@ defaults:
   every_n_frames: 10
   min_seconds_between_tasks_per_camera: 5
   max_inflight_per_camera: 1
-  request: {}
+  request:
+    want_caption: true
+    want_embeddings: true
 
 global:
   max_inflight_total: 2

--- a/config/vision_profiles.yaml
+++ b/config/vision_profiles.yaml
@@ -261,7 +261,7 @@ profiles:
   - name: vlm_caption
     enabled: true
     warm_on_start: true
-    kind: vlm
+    kind: caption_frame
     backend: transformers
     description: >
       Vision-Language captioner for converting perception into language artifacts.

--- a/scripts/smoke_vision_caption_provenance.sh
+++ b/scripts/smoke_vision_caption_provenance.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# smoke_vision_caption_provenance.sh
+#
+# Verifies the Orion Vision caption + provenance chain end-to-end at the
+# CONTRACT level, WITHOUT requiring the `vision-edge` capture service:
+#
+#   frame/task request+meta
+#     -> Vision Host artifact (caption + provenance inputs)
+#       -> Vision Window projection (stream/camera/uris + caption summary)
+#
+# The dev/CI box typically has NO torch/GPU, so real VLM inference cannot run
+# here. This smoke therefore supports an explicit FAKE (contract) mode that
+# exercises the schema/builder/projection contracts using a synthetic-but-
+# honest VisionResult. It does NOT pretend that real inference happened.
+#
+# MODES (select via env; there is no implicit default):
+#   VISION_SMOKE_FAKE_CAPTION=1
+#       FAKE (contract) mode. Runs fully in-process using the repo's Python
+#       schema/builders; no bus, no GPU, no vision-edge. This is the path that
+#       is run and verified in CI on GPU-less boxes.
+#
+#   VISION_HOST_URL=<base-url>   (and FAKE mode NOT set)
+#       REAL mode. POSTs a task to a running Vision Host and asserts the
+#       response contract. Requires a real, host-visible image via
+#       VISION_SMOKE_IMAGE. Will not run on a GPU-less box.
+#
+#   (neither set)
+#       Prints a usage error to stderr and exits non-zero. Does NOT fake.
+#
+# ENV VARS:
+#   VISION_SMOKE_FAKE_CAPTION  set to 1 to select FAKE (contract) mode.
+#   VISION_HOST_URL            base URL of a running Vision Host (REAL mode).
+#   VISION_SMOKE_IMAGE         real, host-visible image path (REAL mode only).
+#   VISION_SMOKE_PYTHON        explicit python interpreter to use (optional).
+#
+# INTERPRETER SELECTION (first that exists wins):
+#   $VISION_SMOKE_PYTHON, else $REPO_ROOT/orion_dev/bin/python,
+#   else $REPO_ROOT/venv/bin/python, else python3.
+#   The interpreter must have `pydantic` (and, for the contract imports, the
+#   repo's `orion` package on PYTHONPATH, which this script sets up).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+pick_python() {
+    if [[ -n "${VISION_SMOKE_PYTHON:-}" ]]; then
+        echo "${VISION_SMOKE_PYTHON}"
+    elif [[ -x "${REPO_ROOT}/orion_dev/bin/python" ]]; then
+        echo "${REPO_ROOT}/orion_dev/bin/python"
+    elif [[ -x "${REPO_ROOT}/venv/bin/python" ]]; then
+        echo "${REPO_ROOT}/venv/bin/python"
+    else
+        echo "python3"
+    fi
+}
+
+PY="$(pick_python)"
+
+run_fake_mode() {
+    # Temp image (a real file, not required to be a valid image in fake mode)
+    # and temp artifact JSON to pass Host -> Window across two python processes.
+    SMOKE_IMG="$(mktemp --suffix=.jpg)"
+    SMOKE_ART="$(mktemp --suffix=.json)"
+    export SMOKE_IMG SMOKE_ART
+    # shellcheck disable=SC2064
+    trap "rm -f '${SMOKE_IMG}' '${SMOKE_ART}'" EXIT
+
+    # --- Step A: Vision Host side (build artifact from synthetic result) ---
+    # NOTE: orion-vision-host and orion-vision-window BOTH ship a top-level
+    # package named `app`, so they cannot be imported in one process. Split
+    # into two invocations, passing data via SMOKE_ART.
+    PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/services/orion-vision-host" "${PY}" - <<'PYEOF'
+from app.artifacts import merge_result_inputs, build_artifact_payload
+from app.models import VisionResult
+import json, os
+request = {"image_path": os.environ["SMOKE_IMG"], "want_caption": True, "want_embeddings": True}
+meta = {"camera_id": "mock-cam-01", "stream_id": "mock-stream", "frame_ts": 123.4,
+        "source_frame_envelope_id": "frame-env-1", "source_frame_correlation_id": "frame-corr-1",
+        "router_policy": "defaults"}
+res = VisionResult(
+    corr_id="smoke-1", ok=True, task_type="retina_fast", device="cuda:0",
+    artifacts={
+        "objects": [{"label": "screen", "score": 0.8, "box_xyxy": [0, 0, 10, 10]}],
+        "caption": {"text": "A terminal window is visible.", "confidence": 0.9},
+        "embedding": {"ref": "emb:smoke", "path": "/tmp/emb.npy", "dim": 8},
+        "model_id": "fake-vlm",
+        "_fingerprints": {"retina_detect_open_vocab": "fake-gdino", "vlm_caption": "fake-vlm"},
+    },
+    meta={"latency_s": 0.01},
+    inputs=merge_result_inputs(request, meta),
+)
+art = build_artifact_payload(res)
+assert art is not None, "artifact is None"
+assert art.outputs.caption and art.outputs.caption.text, "caption missing"
+assert art.outputs.embedding and art.outputs.embedding.ref, "embedding missing"
+for k in ("image_path", "camera_id", "stream_id", "frame_ts"):
+    assert k in art.inputs, f"missing provenance input: {k}"
+with open(os.environ["SMOKE_ART"], "w") as fh:
+    json.dump(art.model_dump(mode="json"), fh)
+print(f"[host] OK caption={art.outputs.caption.text!r} inputs={sorted(art.inputs)}")
+PYEOF
+
+    # --- Step B: Vision Window side (project artifact -> stream/camera/uris) ---
+    PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/services/orion-vision-window" "${PY}" - <<'PYEOF'
+from orion.schemas.vision import VisionArtifactPayload
+from app.projection import (stream_key_from_artifact, camera_id_from_artifact,
+                            artifact_uris_from_artifact, summarize_items)
+import json, os
+with open(os.environ["SMOKE_ART"]) as fh:
+    art = VisionArtifactPayload(**json.load(fh))
+assert stream_key_from_artifact(art) == "mock-stream", stream_key_from_artifact(art)
+assert camera_id_from_artifact(art) == "mock-cam-01"
+assert os.environ["SMOKE_IMG"] in artifact_uris_from_artifact(art), artifact_uris_from_artifact(art)
+summ = summarize_items([(art, 1.0)])
+assert "A terminal window is visible." in summ["captions"], summ
+print(f"[window] OK stream={stream_key_from_artifact(art)} camera={camera_id_from_artifact(art)} captions={summ['captions']}")
+PYEOF
+
+    echo "SMOKE PASS (fake mode)"
+}
+
+run_real_mode() {
+    local img="${VISION_SMOKE_IMAGE:-}"
+    if [[ -z "${img}" ]]; then
+        echo "ERROR: REAL mode requires VISION_SMOKE_IMAGE (a real, host-visible image path)." >&2
+        exit 2
+    fi
+
+    local url="${VISION_HOST_URL%/}/v1/vision/task"
+    # Vision Host serves HTTP on container port 6600 (mapped to ${HOST_PORT}).
+    local body
+    body="$("${PY}" - "${img}" <<'PYEOF'
+import json, sys
+img = sys.argv[1]
+print(json.dumps({
+    "task_type": "retina_fast",
+    "request": {"image_path": img, "want_caption": True, "want_embeddings": True},
+    "meta": {"camera_id": "mock-cam-01", "stream_id": "mock-stream", "frame_ts": 123.4},
+}))
+PYEOF
+)"
+
+    local resp
+    resp="$(curl -fsS -X POST -H 'Content-Type: application/json' -d "${body}" "${url}")"
+
+    printf '%s' "${resp}" | "${PY}" - <<'PYEOF'
+import json, sys
+data = json.load(sys.stdin)
+assert data.get("ok") is True, f"host did not report ok=True: {data.get('ok')!r}"
+artifact = data.get("artifact") or {}
+outputs = artifact.get("outputs") or {}
+caption = outputs.get("caption") or {}
+assert caption.get("text"), "artifact.outputs.caption.text missing/empty"
+inputs = artifact.get("inputs") or {}
+for k in ("image_path", "camera_id", "stream_id", "frame_ts"):
+    assert k in inputs, f"missing provenance input: {k}"
+print(f"[real] OK caption={caption['text']!r} inputs={sorted(inputs)}")
+PYEOF
+
+    echo "SMOKE PASS (real mode)"
+    # NOTE: a fuller live-stack check (Vision Window current/recent contains
+    # the caption, Council event bundle, Scribe ack) can be layered on later.
+    # This script deliberately stays focused on the host -> window contract.
+}
+
+main() {
+    if [[ "${VISION_SMOKE_FAKE_CAPTION:-}" == "1" ]]; then
+        run_fake_mode
+    elif [[ -n "${VISION_HOST_URL:-}" ]]; then
+        run_real_mode
+    else
+        cat >&2 <<'USAGE'
+ERROR: no mode selected. Choose exactly one:
+  * FAKE (contract) mode  : VISION_SMOKE_FAKE_CAPTION=1 bash scripts/smoke_vision_caption_provenance.sh
+      Runs in-process against the repo schema/builders (no bus, no GPU).
+  * REAL mode             : VISION_HOST_URL=<base-url> VISION_SMOKE_IMAGE=<img> bash scripts/smoke_vision_caption_provenance.sh
+      POSTs a task to a running Vision Host and asserts the response contract.
+USAGE
+        exit 2
+    fi
+}
+
+main "$@"

--- a/services/orion-vision-frame-router/tests/test_default_request_config.py
+++ b/services/orion-vision-frame-router/tests/test_default_request_config.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.policy import FrameDispatchPolicy, load_policy_file
+from app.settings import Settings
+
+
+def _cfg_path() -> Path:
+    return Path(__file__).resolve().parents[3] / "config" / "vision_frame_router.yaml"
+
+
+def test_defaults_request_enables_caption_and_embeddings() -> None:
+    raw = load_policy_file(_cfg_path())
+    assert raw["defaults"]["request"]["want_caption"] is True
+    assert raw["defaults"]["request"]["want_embeddings"] is True
+
+
+def test_camera_without_override_inherits_default_request() -> None:
+    settings = Settings(ROUTER_POLICY_PATH=str(_cfg_path()))
+    policy = FrameDispatchPolicy.load(settings)
+
+    merged, _name = policy.resolve_camera_policy("mock-cam-01")
+    assert merged["request"]["want_caption"] is True
+    assert merged["request"]["want_embeddings"] is True
+
+    porch_request = policy.resolve_camera_policy("porch_eye")[0]["request"]
+    assert "want_caption" not in porch_request

--- a/services/orion-vision-host/app/artifacts.py
+++ b/services/orion-vision-host/app/artifacts.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Optional
+
+from orion.schemas.vision import (
+    VisionArtifactPayload,
+    VisionArtifactOutputs,
+    VisionObject,
+    VisionCaption,
+    VisionEmbedding,
+)
+
+from .models import VisionResult
+
+_RESERVED_OUTPUT_KEYS = {
+    "objects",
+    "caption",
+    "embedding",
+    "configured",
+    "implemented",
+    "kind",
+    "device",
+    "model_id",
+    "_fingerprints",
+}
+
+
+def merge_result_inputs(
+    request: Optional[Dict[str, Any]],
+    meta: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Combine task request + meta into the artifact provenance inputs dict."""
+    return {**(request or {}), **(meta or {})}
+
+
+def build_artifact_payload(res: VisionResult) -> Optional[VisionArtifactPayload]:
+    """Build VisionArtifactPayload from a successful VisionResult, or None if no artifacts."""
+    if not res.artifacts:
+        return None
+
+    artifacts = res.artifacts
+    artifact_id = str(uuid.uuid4())
+
+    objects = None
+    caption = None
+    embedding = None
+
+    if "objects" in artifacts and isinstance(artifacts["objects"], list):
+        objects = []
+        for obj in artifacts["objects"]:
+            objects.append(VisionObject(
+                label=str(obj.get("label", "unknown")),
+                score=float(obj.get("score", 0.0)),
+                box_xyxy=obj.get("box_xyxy", [0, 0, 0, 0])
+            ))
+
+    if "caption" in artifacts and isinstance(artifacts["caption"], dict):
+        caption = VisionCaption(
+            text=artifacts["caption"].get("text", ""),
+            confidence=artifacts["caption"].get("confidence")
+        )
+
+    if "embedding" in artifacts and isinstance(artifacts["embedding"], dict):
+        embedding = VisionEmbedding(
+            ref=artifacts["embedding"].get("ref", ""),
+            path=artifacts["embedding"].get("path", ""),
+            dim=artifacts["embedding"].get("dim", 0)
+        )
+
+    outputs = VisionArtifactOutputs(
+        objects=objects,
+        caption=caption,
+        embedding=embedding
+    )
+
+    for k, v in artifacts.items():
+        if k not in _RESERVED_OUTPUT_KEYS:
+            if hasattr(outputs, k):
+                pass
+            else:
+                setattr(outputs, k, v)
+
+    fingerprints = artifacts.get("_fingerprints")
+    if isinstance(fingerprints, dict) and fingerprints:
+        model_fingerprints = {str(k): str(v) for k, v in fingerprints.items()}
+    else:
+        model_fingerprints = {res.task_type: str(artifacts.get("model_id", "unknown"))}
+
+    return VisionArtifactPayload(
+        artifact_id=artifact_id,
+        correlation_id=res.corr_id,
+        task_type=res.task_type,
+        device=res.device or "unknown",
+        inputs=dict(res.inputs or {}),
+        outputs=outputs,
+        timing={"latency_s": res.meta.get("latency_s", 0.0)},
+        model_fingerprints=model_fingerprints,
+    )

--- a/services/orion-vision-host/app/artifacts.py
+++ b/services/orion-vision-host/app/artifacts.py
@@ -30,7 +30,10 @@ def merge_result_inputs(
     request: Optional[Dict[str, Any]],
     meta: Optional[Dict[str, Any]],
 ) -> Dict[str, Any]:
-    """Combine task request + meta into the artifact provenance inputs dict."""
+    """Combine task request + meta into the artifact provenance inputs dict.
+
+    On key collision, frame/routing meta wins over request.
+    """
     return {**(request or {}), **(meta or {})}
 
 
@@ -75,11 +78,8 @@ def build_artifact_payload(res: VisionResult) -> Optional[VisionArtifactPayload]
     )
 
     for k, v in artifacts.items():
-        if k not in _RESERVED_OUTPUT_KEYS:
-            if hasattr(outputs, k):
-                pass
-            else:
-                setattr(outputs, k, v)
+        if k not in _RESERVED_OUTPUT_KEYS and not hasattr(outputs, k):
+            setattr(outputs, k, v)
 
     fingerprints = artifacts.get("_fingerprints")
     if isinstance(fingerprints, dict) and fingerprints:

--- a/services/orion-vision-host/app/main.py
+++ b/services/orion-vision-host/app/main.py
@@ -16,12 +16,9 @@ from orion.schemas.vision import (
     VisionTaskRequestPayload,
     VisionTaskResultPayload,
     VisionArtifactPayload,
-    VisionArtifactOutputs,
-    VisionObject,
-    VisionCaption,
-    VisionEmbedding,
 )
 
+from .artifacts import build_artifact_payload
 from .models import VisionResult, VisionTask
 from .profiles import VisionProfiles
 from .runner import VisionRunner
@@ -340,63 +337,7 @@ class VisionHostService:
              await self._publish_artifact_broadcast(artifact_payload, source_envelope)
 
     def _create_artifact_payload(self, res: VisionResult, source_envelope: BaseEnvelope) -> Optional[VisionArtifactPayload]:
-        if not res.artifacts:
-            return None
-
-        artifacts = res.artifacts
-        artifact_id = str(uuid.uuid4())
-
-        objects = None
-        caption = None
-        embedding = None
-
-        if "objects" in artifacts and isinstance(artifacts["objects"], list):
-            objects = []
-            for obj in artifacts["objects"]:
-                objects.append(VisionObject(
-                    label=str(obj.get("label", "unknown")),
-                    score=float(obj.get("score", 0.0)),
-                    box_xyxy=obj.get("box_xyxy", [0,0,0,0])
-                ))
-
-        if "caption" in artifacts and isinstance(artifacts["caption"], dict):
-            caption = VisionCaption(
-                text=artifacts["caption"].get("text", ""),
-                confidence=artifacts["caption"].get("confidence")
-            )
-
-        if "embedding" in artifacts and isinstance(artifacts["embedding"], dict):
-            embedding = VisionEmbedding(
-                ref=artifacts["embedding"].get("ref", ""),
-                path=artifacts["embedding"].get("path", ""),
-                dim=artifacts["embedding"].get("dim", 0)
-            )
-
-        outputs = VisionArtifactOutputs(
-            objects=objects,
-            caption=caption,
-            embedding=embedding
-        )
-
-        # Add extras
-        for k, v in artifacts.items():
-            if k not in ("objects", "caption", "embedding", "configured", "implemented", "kind", "device", "model_id"):
-                if hasattr(outputs, k): # Shouldn't happen given above
-                     pass
-                else:
-                    # VisionArtifactOutputs allows extra, but Pydantic might need setattr
-                    setattr(outputs, k, v)
-
-        return VisionArtifactPayload(
-            artifact_id=artifact_id,
-            correlation_id=res.corr_id,
-            task_type=res.task_type,
-            device=res.device or "unknown",
-            inputs=res.meta.get("request", {}) or {},
-            outputs=outputs,
-            timing={"latency_s": res.meta.get("latency_s", 0.0)},
-            model_fingerprints={res.task_type: str(artifacts.get("model_id", "unknown"))}
-        )
+        return build_artifact_payload(res)
 
     async def _publish_artifact_broadcast(self, payload: VisionArtifactPayload, source_envelope: BaseEnvelope):
         envelope = BaseEnvelope(

--- a/services/orion-vision-host/app/models.py
+++ b/services/orion-vision-host/app/models.py
@@ -41,6 +41,7 @@ class VisionResult(BaseModel):
     device: Optional[str] = None
 
     artifacts: Dict[str, Any] = Field(default_factory=dict)
+    inputs: Dict[str, Any] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)
     error: Optional[str] = None
 

--- a/services/orion-vision-host/app/runner.py
+++ b/services/orion-vision-host/app/runner.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 import torch
 
+from .artifacts import merge_result_inputs
 from .model_manager import ModelManager
 from .models import VisionResult, VisionTask
 from .profiles import PipelineDef, ProfileDef, VisionProfiles
@@ -226,6 +227,7 @@ class VisionRunner:
             task_type=task.task_type,
             device=device,
             artifacts=artifacts,
+            inputs=merge_result_inputs(task.request, task.meta),
             warnings=warnings,
             meta=meta,
         )
@@ -242,6 +244,7 @@ class VisionRunner:
 
         out: Dict[str, Any] = {"pipeline": pipe.name, "steps": [], "artifacts": {}}
         merged_artifacts = {}
+        fingerprints: Dict[str, str] = {}
 
         for step in pipe.steps:
             if step.when and not _safe_when(step.when, request):
@@ -263,6 +266,12 @@ class VisionRunner:
             # Merge fields for the consolidated artifact
             if isinstance(artifacts, dict):
                 merged_artifacts.update(artifacts)
+                mid = artifacts.get("model_id")
+                if mid:
+                    fingerprints[step.use] = str(mid)
+
+        if fingerprints:
+            merged_artifacts["_fingerprints"] = fingerprints
 
         # For retina_fast or other pipelines, we return the merged result as the top-level artifact content
         # preserving key metadata

--- a/services/orion-vision-host/app/runner.py
+++ b/services/orion-vision-host/app/runner.py
@@ -157,6 +157,7 @@ class VisionRunner:
                         task_type=task.task_type,
                         device=device,
                         error=f"pipeline disabled: {target}",
+                        inputs=merge_result_inputs(task.request, task.meta),
                         meta={"error_code": "pipeline_disabled"},
                     )
                 artifacts = self._run_pipeline(self.profiles.get_pipeline(target), task.request, device, warnings)
@@ -168,6 +169,7 @@ class VisionRunner:
                         task_type=task.task_type,
                         device=device,
                         error=f"profile disabled: {target}",
+                        inputs=merge_result_inputs(task.request, task.meta),
                         meta={"error_code": "profile_disabled"},
                     )
                 artifacts = self._run_profile(self.profiles.get_profile(target), task.request, device, warnings)
@@ -179,6 +181,7 @@ class VisionRunner:
                 task_type=task.task_type,
                 device=device,
                 error=f"unknown task/profile: {target}",
+                inputs=merge_result_inputs(task.request, task.meta),
                 meta={"error_code": "unknown_task"},
             )
         except FileNotFoundError as e:
@@ -189,6 +192,7 @@ class VisionRunner:
                 device=device,
                 error=str(e),
                 warnings=warnings,
+                inputs=merge_result_inputs(task.request, task.meta),
                 meta={"error_code": "image_not_found"},
             )
         except ValueError as e:
@@ -201,6 +205,7 @@ class VisionRunner:
                 device=device,
                 error=msg,
                 warnings=warnings,
+                inputs=merge_result_inputs(task.request, task.meta),
                 meta={"error_code": code},
             )
         except Exception as e:
@@ -214,6 +219,7 @@ class VisionRunner:
                 device=device,
                 error=msg,
                 warnings=warnings,
+                inputs=merge_result_inputs(task.request, task.meta),
                 meta={"error_code": code},
             )
 

--- a/services/orion-vision-host/tests/test_artifact_provenance.py
+++ b/services/orion-vision-host/tests/test_artifact_provenance.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.artifacts import build_artifact_payload, merge_result_inputs
+from app.models import VisionResult
+
+
+def test_merge_result_inputs_combines_request_and_meta() -> None:
+    request = {
+        "image_path": "/tmp/test.jpg",
+        "want_caption": True,
+        "want_embeddings": True,
+    }
+    meta = {
+        "camera_id": "mock-cam-01",
+        "stream_id": "mock-stream",
+        "frame_ts": 123.4,
+        "source_frame_envelope_id": "frame-env-1",
+        "source_frame_correlation_id": "frame-corr-1",
+        "router_policy": "defaults",
+    }
+    merged = merge_result_inputs(request, meta)
+    assert merged["image_path"] == "/tmp/test.jpg"
+    assert merged["want_caption"] is True
+    assert merged["want_embeddings"] is True
+    assert merged["camera_id"] == "mock-cam-01"
+    assert merged["stream_id"] == "mock-stream"
+    assert merged["frame_ts"] == 123.4
+    assert merged["source_frame_envelope_id"] == "frame-env-1"
+    assert merged["source_frame_correlation_id"] == "frame-corr-1"
+    assert merged["router_policy"] == "defaults"
+
+
+def test_build_artifact_payload_preserves_request_and_meta_provenance() -> None:
+    request = {
+        "image_path": "/tmp/test.jpg",
+        "want_caption": True,
+        "want_embeddings": True,
+    }
+    meta = {
+        "camera_id": "mock-cam-01",
+        "stream_id": "mock-stream",
+        "frame_ts": 123.4,
+        "source_frame_envelope_id": "frame-env-1",
+        "source_frame_correlation_id": "frame-corr-1",
+        "router_policy": "defaults",
+    }
+    res = VisionResult(
+        corr_id="c1",
+        ok=True,
+        task_type="retina_fast",
+        device="cuda:0",
+        artifacts={
+            "objects": [{"label": "cup", "score": 0.9, "box_xyxy": [0, 0, 1, 1]}],
+            "caption": {"text": "A terminal window is visible.", "confidence": 0.8},
+            "embedding": {"ref": "emb:x", "path": "/tmp/e.npy", "dim": 16},
+            "model_id": "caption-model",
+            "_fingerprints": {"retina_detect_open_vocab": "gdino", "vlm_caption": "blip2"},
+        },
+        warnings=[],
+        meta={"latency_s": 0.5},
+        inputs=merge_result_inputs(request, meta),
+    )
+    art = build_artifact_payload(res)
+    assert art is not None
+    assert art.inputs["image_path"] == "/tmp/test.jpg"
+    assert art.inputs["camera_id"] == "mock-cam-01"
+    assert art.inputs["stream_id"] == "mock-stream"
+    assert art.inputs["frame_ts"] == 123.4
+    assert art.inputs["source_frame_envelope_id"] == "frame-env-1"
+    assert art.inputs["source_frame_correlation_id"] == "frame-corr-1"
+    assert art.inputs["router_policy"] == "defaults"
+    assert art.inputs["want_caption"] is True
+    assert art.inputs["want_embeddings"] is True
+    assert art.outputs.caption.text == "A terminal window is visible."
+    assert art.outputs.embedding.ref == "emb:x"
+    assert art.outputs.objects[0].label == "cup"
+    assert art.model_fingerprints == {"retina_detect_open_vocab": "gdino", "vlm_caption": "blip2"}
+
+
+def test_build_artifact_payload_none_when_empty() -> None:
+    res = VisionResult(corr_id="c", ok=True, task_type="retina_fast", artifacts={})
+    assert build_artifact_payload(res) is None
+
+
+def test_model_fingerprints_fallback_single_profile() -> None:
+    res = VisionResult(
+        corr_id="c",
+        ok=True,
+        task_type="retina_fast",
+        artifacts={"caption": {"text": "hi"}, "model_id": "m1"},
+    )
+    art = build_artifact_payload(res)
+    assert art is not None
+    assert art.model_fingerprints == {"retina_fast": "m1"}

--- a/services/orion-vision-host/tests/test_caption_profile_routing.py
+++ b/services/orion-vision-host/tests/test_caption_profile_routing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.profiles import VisionProfiles
+
+
+def _load_profiles() -> VisionProfiles:
+    cfg_path = Path(__file__).resolve().parents[3] / "config" / "vision_profiles.yaml"
+    p = VisionProfiles(str(cfg_path))
+    p.load()
+    return p
+
+
+def test_caption_frame_routes_to_vlm_caption() -> None:
+    p = _load_profiles()
+    assert p.resolve_target("caption_frame") == "vlm_caption"
+
+
+def test_vlm_caption_kind_is_caption_frame() -> None:
+    p = _load_profiles()
+    assert p.get_profile("vlm_caption").kind == "caption_frame"
+
+
+def test_vlm_vqa_untouched() -> None:
+    p = _load_profiles()
+    vqa = p.get_profile("vlm_vqa")
+    assert vqa.kind == "vlm"
+    assert vqa.enabled is False

--- a/services/orion-vision-window/tests/test_projection_provenance.py
+++ b/services/orion-vision-window/tests/test_projection_provenance.py
@@ -1,0 +1,73 @@
+from orion.schemas.vision import (
+    VisionArtifactOutputs,
+    VisionArtifactPayload,
+    VisionCaption,
+)
+
+from app.projection import (
+    artifact_uris_from_artifact,
+    camera_id_from_artifact,
+    stream_key_from_artifact,
+    summarize_items,
+)
+
+
+def _artifact(**kwargs) -> VisionArtifactPayload:
+    base = dict(
+        artifact_id="a1",
+        correlation_id="c1",
+        task_type="detect",
+        device="cam-1",
+        inputs={},
+        outputs=VisionArtifactOutputs(objects=[]),
+        timing={},
+        model_fingerprints={},
+    )
+    base.update(kwargs)
+    return VisionArtifactPayload(**base)
+
+
+def test_stream_key_prefers_stream_id_over_device():
+    art = _artifact(
+        inputs={
+            "stream_id": "mock-stream",
+            "camera_id": "mock-cam-01",
+            "image_path": "/tmp/test.jpg",
+        },
+        device="cuda:0",
+    )
+    assert stream_key_from_artifact(art) == "mock-stream"
+
+
+def test_camera_id_from_inputs():
+    art = _artifact(
+        inputs={
+            "stream_id": "mock-stream",
+            "camera_id": "mock-cam-01",
+            "image_path": "/tmp/test.jpg",
+        },
+        device="cuda:0",
+    )
+    assert camera_id_from_artifact(art) == "mock-cam-01"
+
+
+def test_artifact_uris_includes_image_path():
+    art = _artifact(
+        inputs={
+            "stream_id": "mock-stream",
+            "camera_id": "mock-cam-01",
+            "image_path": "/tmp/test.jpg",
+        },
+        device="cuda:0",
+    )
+    assert "/tmp/test.jpg" in artifact_uris_from_artifact(art)
+
+
+def test_summarize_items_includes_caption():
+    art = _artifact(
+        outputs=VisionArtifactOutputs(
+            caption=VisionCaption(text="A terminal window is visible."),
+        ),
+    )
+    result = summarize_items([(art, 1719800000.0)])
+    assert "A terminal window is visible." in result["captions"]


### PR DESCRIPTION
## Summary

Repairs the first Orion Vision semantic path so sampled frames can produce captioned, provenance-preserving artifacts and window summaries. Narrow scope: no new perception service, no `vision-edge` changes, no Council V2 / grammar projection.

### Root causes fixed

**1. Caption profile kind mismatch** (`config/vision_profiles.yaml`)

`vlm_caption` had `kind: vlm`, but `VisionRunner._run_profile` only executes captioning when `kind == "caption_frame"`. With `task_routing` mapping `caption_frame → vlm_caption`, caption steps silently fell into the "kind not implemented yet" fallback and never produced `outputs.caption`.

- Changed `vlm_caption` to `kind: caption_frame` (warmup now includes the caption profile)
- `vlm_vqa` stays `kind: vlm`, `enabled: false`

**2. Router did not request captions by default** (`config/vision_frame_router.yaml`)

`defaults.request` was `{}`, so `pipeline_retina_fast` never satisfied `when: "request.want_caption == true"` or `want_embeddings == true`.

- `defaults.request` now sets `want_caption: true` and `want_embeddings: true`
- Existing rate limits and inflight caps unchanged (`every_n_frames: 10`, `min_seconds_between_tasks_per_camera: 5`, `max_inflight_per_camera: 1`, `max_inflight_total: 2`)
- Per-camera `request` overrides (e.g. `porch_eye` prompts) still fully replace defaults

**3. Host artifact provenance loss** (`services/orion-vision-host`)

`_create_artifact_payload` set `inputs=res.meta.get("request", {})`, but `res.meta` is copied from `task.meta` (camera/stream/frame/router provenance) — never `task.request` (image_path, want_caption, etc.). `artifact.inputs` was effectively always `{}`, breaking Window's ability to derive `stream_id`, `camera_id`, and `artifact_uris`.

- Added `VisionResult.inputs`, populated via `merge_result_inputs(task.request, task.meta)` on success (meta wins on key collision; current router key sets don't overlap)
- Extracted torch-free `app/artifacts.py` (`merge_result_inputs`, `build_artifact_payload`); `main._create_artifact_payload` delegates
- `_run_pipeline` collects per-step `_fingerprints` so merged `retina_fast` outputs get meaningful `model_fingerprints` instead of only the last step's `model_id`
- Code-review follow-up: error-path `VisionResult` returns also carry `inputs` for debug/log traceability (`res.model_dump()` on HTTP failures); published artifacts still only emit when `res.ok is True`

Target `VisionArtifactPayload.inputs` shape:

```json
{
  "image_path": "/path/to/frame.jpg",
  "camera_id": "mock-cam-01",
  "stream_id": "mock-stream",
  "frame_ts": 123.4,
  "source_frame_envelope_id": "frame-env-1",
  "source_frame_correlation_id": "frame-corr-1",
  "router_policy": "defaults",
  "want_caption": true,
  "want_embeddings": true
}
```

No raw frame bytes on the bus.

### Downstream impact

- **Window** — projection already derived stream/camera/URIs/captions from `art.inputs`; no production code change needed. Now exercised by regression tests.
- **Council / Scribe** — untouched. Contracts unchanged; captions and provenance now flow into window summaries they already consume.

---

## Files changed (11)

| Area | Files |
|------|-------|
| Config | `config/vision_profiles.yaml`, `config/vision_frame_router.yaml` |
| Host | `app/artifacts.py` (new), `app/models.py`, `app/main.py`, `app/runner.py` |
| Tests | `test_caption_profile_routing.py`, `test_artifact_provenance.py`, `test_default_request_config.py`, `test_projection_provenance.py` |
| Smoke | `scripts/smoke_vision_caption_provenance.sh` |

No changes to: `vision-edge`, `orion/schemas/vision.py`, bus channels, schema registry, docker-compose, requirements, or service `.env` / `.env_example`.

---

## Validation

Test env has no torch/GPU, so unit tests avoid torch-bound host modules and the smoke uses an explicit fake (contract) mode.

| Command | Result |
|---------|--------|
| `pytest services/orion-vision-host/tests` | **9 passed** |
| `pytest services/orion-vision-frame-router/tests` | **25 passed** |
| `pytest services/orion-vision-window/tests` | **9 passed** |
| `python -m compileall services/orion-vision-host/app` | OK |
| `VISION_SMOKE_FAKE_CAPTION=1 bash scripts/smoke_vision_caption_provenance.sh` | **SMOKE PASS (fake mode)** |

Smoke modes:
- `VISION_SMOKE_FAKE_CAPTION=1` — in-process contract test (host `build_artifact_payload` → window projection); no GPU, no bus; does not pretend real inference
- `VISION_HOST_URL` + `VISION_SMOKE_IMAGE` — POST to running host `/v1/vision/task`; requires real VLM weights

---

## Test plan (GPU / live stack)

- [ ] GPU host with VLM weights: real-mode smoke → `ok=true`, non-empty `artifact.outputs.caption.text`, provenance keys in `artifact.inputs`
- [ ] Full bus stack: Window current/recent contains caption and `stream_id == mock-stream`
- [ ] Council emits at least one event bundle; Scribe emits an ack

---

## Non-goals

Vision Council V2, grammar projection, memory cards, vector persistence, scene graph, OCR, VQA, dream/simulation, motor control, new perception-core service, `vision-edge` changes.

---

## Commits (6)

1. `fix(vision): route caption_frame kind and request caption/embeddings by default`
2. `fix(vision-host): preserve request+frame provenance in artifact inputs`
3. `refactor(vision-host): clarify inputs precedence and extras setattr`
4. `test(vision-window): assert projection derives stream/camera/uris/caption from artifact inputs`
5. `test(vision): add caption+provenance smoke (host→window contract, fake mode)`
6. `fix(vision-host): carry request/meta provenance into inputs on error paths`