### PR TITLE
Feat/substrate rung1 bridge rung2 lanes

### DIFF
--- a/docs/plans/substrate/PR_substrate_felt_state_activation.md
+++ b/docs/plans/substrate/PR_substrate_felt_state_activation.md
@@ -1,0 +1,118 @@
+# PR: substrate self-modeling loop — rung-1 runtime bridge + rung-2 felt-state lanes (activated)
+
+> Committed to the branch as the PR body because this checkout has no GitHub auth
+> (no `gh` login / `GH_TOKEN`). Open the PR at:
+> https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/substrate-rung1-bridge-rung2-lanes
+> and paste the body below.
+
+Branch: `feat/substrate-rung1-bridge-rung2-lanes`
+
+---
+
+## Summary
+
+Finishes the two remaining edges of the substrate self-modeling loop from
+`docs/plans/substrate/CONTINUATION.md`, and wires them so they actually run on the
+Athena host:
+
+1. **Rung 1 runtime bridge** — the runtime worker now writes the execution/transport
+   `prediction_error` it computes onto a durable substrate node, not just a
+   field-digester receipt, so the dynamics engine has a node to seed pressure from.
+2. **Rung 2 remainder** — binds the substrate's own "felt state" (biometrics
+   pressure, in-flight execution, transport-bus health) into the
+   CognitiveUnificationLayer as three belief lanes, and adds the ctx-hydration step
+   that actually populates them at chat-stance time (which also lights up the
+   previously-dormant `self_state` lane shipped in `d9dbe624`).
+
+Honest framing (unchanged from the ladder doc): this implements the *functional*
+properties — predictive feedback, integration/higher-order self-model — as thin,
+inspectable, tested seams. No claim about phenomenal experience.
+
+## What this closes
+
+```
+prediction error (worker)
+  → durable substrate node metadata['prediction_error']        (rung 1, this PR)
+  → [dynamics engine seeds pressure from it]                   (consumer: follow-up)
+
+reducer projections (biometrics/execution/transport) + self_state
+  → hydrated into chat-stance ctx                              (rung 2 ctx wire, this PR)
+  → felt-state belief lanes in the unified belief set          (rung 2 adapters, this PR)
+```
+
+## Changes
+
+| Rung | Change | Files |
+|------|--------|-------|
+| 1 | On `error>0` in `_execution_tick`/`_transport_tick`, upsert a `ConceptNodeV1` (`node:substrate.execution` / `.transport`, anchor `orion`) carrying `metadata['prediction_error']` + fresh `observed_at`, under a fixed identity_key so re-writes collapse. Field-digester receipt untouched. Default-off (`SUBSTRATE_WRITE_PREDICTION_ERROR_NODES`), fail-open. | `services/orion-substrate-runtime/app/worker.py` (+ test) |
+| 2a | Three ctx-sourced adapters (biometrics/execution/transport) mirroring `self_state_ctx`: pure, degrade-to-None, capped at 20. Registry 9 → 12 producers. | `orion/substrate/relational/adapters/{biometrics,execution,transport}_ctx.py`, `orion/cognition/projection_builder.py` (+ tests; repairs the pre-existing-red registry test that `d9dbe624` left stale) |
+| 2b | `SubstrateFeltStateReader` loads the latest projection from the four substrate Postgres tables into chat-stance ctx before the unifier runs, at the single common caller `build_chat_stance_inputs`. Default-off (`ENABLE_SUBSTRATE_FELT_STATE_CTX`), fail-open, freshness-gated, non-clobbering. | `services/orion-cortex-exec/app/substrate_felt_state_reader.py`, `services/orion-cortex-exec/app/chat_stance.py` (+ test) |
+| env | Feature flags + supporting config enabled in `.env_example` (and copied to local `.env`) so the loop runs on Athena. | `services/orion-cortex-exec/.env_example`, `services/orion-substrate-runtime/.env_example` |
+
+## Deployment / how it runs
+
+**cortex-exec** (rung 2 — fully live; reads projections from the `conjourney` Postgres):
+```
+ENABLE_SUBSTRATE_FELT_STATE_CTX=true
+SUBSTRATE_FELT_STATE_DATABASE_URL=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+SUBSTRATE_FELT_STATE_MAX_AGE_SEC=120
+```
+The execution/transport reducers are already enabled on the runtime, so their
+projections exist; the biometrics reducer is always on. Enabling the flag activates
+all four belief lanes.
+
+**orion-substrate-runtime** (rung 1 — write path):
+```
+SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true
+SUBSTRATE_STORE_BACKEND=sparql
+SUBSTRATE_GRAPH_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
+SUBSTRATE_GRAPH_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
+SUBSTRATE_GRAPH_URI=http://conjourney.net/graph/substrate
+SUBSTRATE_GRAPH_USER=admin
+SUBSTRATE_GRAPH_PASS=orion
+```
+
+## Known gap (honest)
+
+**Rung 1's consumer is not wired yet.** No periodic `SubstrateDynamicsEngine.tick()`
+runs against the shared store in any service today (verified by grep). So with the
+config above, surprise is *persisted* to Fuseki but not yet *seeded into pressure*.
+Closing that is a small follow-up (a bounded dynamics tick in the runtime worker or a
+dedicated loop) and is rung-3 adjacent. Rung 2 is fully live and end-to-end.
+
+## Safety / governance
+
+- Both features default-off in code; enabled only via env. Flag off ⇒ byte-identical
+  to prior behavior.
+- Fail-open everywhere: store init, upserts, and each hydration lane are wrapped so a
+  tick / chat turn never crashes; one lane can't break another.
+- Freshness-gated: stale projections past `MAX_AGE_SEC` are excluded, not felt as
+  current (Forge: stale excluded by default).
+- Non-clobbering: hydration never overwrites a pre-existing ctx key.
+- Bounded: fixed identity_key (no unbounded node growth); every adapter collection
+  capped at 20; single latest row per lane + TTL cache.
+- Not touched: the dangerous endogenous-agency gate (rung 5) — not in this PR.
+
+## Tests
+
+All green:
+- `services/orion-substrate-runtime/tests/test_worker_prediction_error_node.py` — flag on/off, fail-open (3).
+- `orion/substrate/relational/tests/test_reducer_lane_adapters.py` — per-adapter label/anchor/salience/metadata, dict+json, absent/garbage → None, cap ≤ 20, quiet-node exclusion, registry = 12 (10).
+- `orion/cognition/tests/test_projection_builder.py` — registry order incl. the 4 felt-state lanes (repaired) (2).
+- `services/orion-cortex-exec/tests/test_substrate_felt_state_reader.py` — fresh→injected, stale→skipped, existing-key preserved, disabled no-op, one-lane fail-open, flag-unset entrypoint no-op (6).
+- Neighbors: `test_self_state_adapter`, `test_golden_path`, `test_projection_starvation_diagnostics`, `test_chat_stance_shared_spine`, `test_cognitive_substrate_phase4_dynamics` — unchanged, green.
+
+## Commits
+
+- `a9d0d9c9` — rung 1 runtime bridge
+- `01e35c92` — rung 2 remainder (felt-state adapters + registry)
+- `a3c27eb5` — rung 2 ctx hydration wire
+
+## Reviewer notes
+
+- The repo is concurrently mutated by an automation user; work was done on this
+  branch off a clean `main`.
+- Design choice: the rung-2 lanes are **ctx-sourced**, not DB-pull adapters — the
+  hydration reader (cortex-exec, service-local DB access) injects the projections,
+  keeping the adapters pure and matching the shipped `self_state` pattern. No
+  importable substrate-projection reader was invented in the `orion` package.

--- a/orion/cognition/projection_builder.py
+++ b/orion/cognition/projection_builder.py
@@ -41,6 +41,9 @@ from orion.cognition.projection_context import summarize_projection_inputs
 from orion.substrate.relational.layer import _lightweight_belief_set, _skip_unified_beliefs_ctx
 from orion.substrate.relational.adapters.spark_ctx import map_spark_ctx_to_substrate
 from orion.substrate.relational.adapters.self_state_ctx import map_self_state_ctx_to_substrate
+from orion.substrate.relational.adapters.execution_ctx import map_execution_ctx_to_substrate
+from orion.substrate.relational.adapters.transport_ctx import map_transport_ctx_to_substrate
+from orion.substrate.relational.adapters.biometrics_ctx import map_biometrics_ctx_to_substrate
 
 logger = logging.getLogger("orion.cognition.projection_builder")
 
@@ -113,6 +116,33 @@ def build_projection_unification_registry() -> ProducerRegistryV1:
                 freshness_ttl_sec=120,
                 pull_on_cold=False,
                 adapter_fn=map_self_state_ctx_to_substrate,
+            ),
+            # Substrate "felt state" reducer lanes (rung 2): Orion's beliefs about
+            # its own body — biometric pressure, in-flight execution, transport bus.
+            # ctx-sourced; no cold fan-out (read from ctx).
+            ProducerEntryV1(
+                producer_id="biometrics",
+                trust_tier=SNAPSHOT_EPHEMERAL,
+                anchor_scopes=("orion",),
+                freshness_ttl_sec=120,
+                pull_on_cold=False,
+                adapter_fn=map_biometrics_ctx_to_substrate,
+            ),
+            ProducerEntryV1(
+                producer_id="execution",
+                trust_tier=SNAPSHOT_EPHEMERAL,
+                anchor_scopes=("orion",),
+                freshness_ttl_sec=120,
+                pull_on_cold=False,
+                adapter_fn=map_execution_ctx_to_substrate,
+            ),
+            ProducerEntryV1(
+                producer_id="transport",
+                trust_tier=SNAPSHOT_EPHEMERAL,
+                anchor_scopes=("orion",),
+                freshness_ttl_sec=120,
+                pull_on_cold=False,
+                adapter_fn=map_transport_ctx_to_substrate,
             ),
             ProducerEntryV1(
                 producer_id="orionmem",

--- a/orion/cognition/tests/test_projection_builder.py
+++ b/orion/cognition/tests/test_projection_builder.py
@@ -19,6 +19,11 @@ def test_projection_registry_matches_expected_chat_stance_producers() -> None:
         "autonomy",
         "concept_induction",
         "spark",
+        # self-model (higher-order rung) + substrate "felt state" reducer lanes
+        "self_state",
+        "biometrics",
+        "execution",
+        "transport",
         "orionmem",
         "recall",
         "social",

--- a/orion/substrate/relational/adapters/biometrics_ctx.py
+++ b/orion/substrate/relational/adapters/biometrics_ctx.py
@@ -1,0 +1,110 @@
+"""Biometrics-pressure adapter — binds the substrate's biometric "felt state".
+
+Maps ``ActiveNodePressureProjectionV1`` (per-node availability plus the active /
+suppressed pressures and capability impacts the biometrics lane derives) into
+substrate belief nodes anchored to Orion, so the unified belief set contains
+beliefs about which parts of Orion's own body are under load.
+
+Only nodes that are actually *felt* (pressure_score > 0 or non-empty
+active_pressures) are emitted.
+
+ctx-sourced, pure (no network, no DB): reads
+``ctx['active_node_pressure_projection']`` as a model, dict, or JSON string, and
+degrades to ``None`` when the key is absent or unparseable — never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    SubstrateGraphRecordV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+)
+from orion.schemas.biometrics_projection import ActiveNodePressureProjectionV1
+from orion.substrate.adapters._common import make_temporal
+
+logger = logging.getLogger("orion.substrate.relational.adapters.biometrics_ctx")
+
+_TIER_RANK = 4  # snapshot_ephemeral: derived biometric pressure state
+_MAX_NODES = 20
+
+
+def _clamp(x: Any) -> float:
+    try:
+        return max(0.0, min(1.0, float(x)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _make_prov() -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="local_inferred",
+        source_kind="biometrics_pressure",
+        source_channel="substrate.biometrics",
+        producer="biometrics_lane_adapter",
+        tier_rank=_TIER_RANK,
+    )
+
+
+def _coerce(raw: Any) -> ActiveNodePressureProjectionV1 | None:
+    try:
+        if isinstance(raw, ActiveNodePressureProjectionV1):
+            return raw
+        if isinstance(raw, str) and raw.strip():
+            return ActiveNodePressureProjectionV1.model_validate_json(raw)
+        if isinstance(raw, dict):
+            return ActiveNodePressureProjectionV1.model_validate(raw)
+    except Exception as exc:
+        logger.debug("biometrics_ctx_adapter_parse_failed error=%s", exc)
+    return None
+
+
+def map_biometrics_ctx_to_substrate(ctx: dict[str, Any]) -> SubstrateGraphRecordV1 | None:
+    """Map ``ctx['active_node_pressure_projection']`` → biometric belief nodes."""
+    ctx = ctx if isinstance(ctx, dict) else {}
+    projection = _coerce(ctx.get("active_node_pressure_projection"))
+    if projection is None:
+        return None
+
+    now = datetime.now(timezone.utc)
+    temporal = make_temporal(observed_at=now)
+    prov = _make_prov()
+
+    felt = [
+        node
+        for node in projection.nodes.values()
+        if node.pressure_score > 0.0 or node.active_pressures
+    ]
+    felt = sorted(felt, key=lambda n: n.pressure_score, reverse=True)[:_MAX_NODES]
+
+    nodes: list[Any] = []
+    for node in felt:
+        salience = _clamp(node.pressure_score)
+        nodes.append(
+            ConceptNodeV1(
+                anchor_scope="orion",
+                subject_ref="entity:orion",
+                label=f"biometrics:{node.node_id}",
+                temporal=temporal,
+                provenance=prov,
+                signals=SubstrateSignalBundleV1(confidence=0.7, salience=salience),
+                metadata={
+                    "source_kind": "biometrics_pressure",
+                    "node_id": node.node_id,
+                    "availability_status": node.availability_status,
+                    "pressure_score": round(node.pressure_score, 6),
+                    "active_pressures": list(node.active_pressures[:20]),
+                    "capability_impacts": list(node.capability_impacts[:20]),
+                },
+            )
+        )
+
+    if not nodes:
+        return None
+
+    return SubstrateGraphRecordV1(anchor_scope="orion", nodes=nodes)

--- a/orion/substrate/relational/adapters/execution_ctx.py
+++ b/orion/substrate/relational/adapters/execution_ctx.py
@@ -1,0 +1,108 @@
+"""Execution-trajectory adapter — binds the substrate's execution "felt state".
+
+Maps ``ExecutionTrajectoryProjectionV1`` (per-run trace state: verb, status,
+step counts, and the pressure hints the execution lane derives — execution_load,
+execution_friction, failure_pressure, reasoning_load) into substrate belief nodes
+anchored to Orion, so the unified belief set contains beliefs about Orion's own
+in-flight execution.
+
+ctx-sourced, pure (no network, no DB): reads
+``ctx['execution_trajectory_projection']`` as a model, dict, or JSON string, and
+degrades to ``None`` when the key is absent or unparseable — never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    SubstrateGraphRecordV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+)
+from orion.schemas.execution_projection import ExecutionTrajectoryProjectionV1
+from orion.substrate.adapters._common import make_temporal
+
+logger = logging.getLogger("orion.substrate.relational.adapters.execution_ctx")
+
+_TIER_RANK = 4  # snapshot_ephemeral: derived in-flight execution state
+_MAX_NODES = 20
+
+
+def _clamp(x: Any) -> float:
+    try:
+        return max(0.0, min(1.0, float(x)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _make_prov() -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="local_inferred",
+        source_kind="execution_trajectory",
+        source_channel="substrate.execution",
+        producer="execution_lane_adapter",
+        tier_rank=_TIER_RANK,
+    )
+
+
+def _coerce(raw: Any) -> ExecutionTrajectoryProjectionV1 | None:
+    try:
+        if isinstance(raw, ExecutionTrajectoryProjectionV1):
+            return raw
+        if isinstance(raw, str) and raw.strip():
+            return ExecutionTrajectoryProjectionV1.model_validate_json(raw)
+        if isinstance(raw, dict):
+            return ExecutionTrajectoryProjectionV1.model_validate(raw)
+    except Exception as exc:
+        logger.debug("execution_ctx_adapter_parse_failed error=%s", exc)
+    return None
+
+
+def map_execution_ctx_to_substrate(ctx: dict[str, Any]) -> SubstrateGraphRecordV1 | None:
+    """Map ``ctx['execution_trajectory_projection']`` → execution belief nodes."""
+    ctx = ctx if isinstance(ctx, dict) else {}
+    projection = _coerce(ctx.get("execution_trajectory_projection"))
+    if projection is None:
+        return None
+
+    now = datetime.now(timezone.utc)
+    temporal = make_temporal(observed_at=now)
+    prov = _make_prov()
+
+    runs = sorted(
+        projection.runs.values(),
+        key=lambda r: r.last_updated_at,
+        reverse=True,
+    )[:_MAX_NODES]
+
+    nodes: list[Any] = []
+    for run in runs:
+        hints = dict(run.pressure_hints or {})
+        salience = _clamp(max(hints.values(), default=0.0))
+        nodes.append(
+            ConceptNodeV1(
+                anchor_scope="orion",
+                subject_ref="entity:orion",
+                label=f"execution:{run.verb}:{run.trace_id[:8]}",
+                temporal=temporal,
+                provenance=prov,
+                signals=SubstrateSignalBundleV1(confidence=0.7, salience=salience),
+                metadata={
+                    "source_kind": "execution_trajectory",
+                    "trace_id": run.trace_id,
+                    "verb": run.verb,
+                    "status": run.status,
+                    "step_count": run.step_count,
+                    "pressure_hints": hints,
+                },
+            )
+        )
+
+    if not nodes:
+        return None
+
+    return SubstrateGraphRecordV1(anchor_scope="orion", nodes=nodes)

--- a/orion/substrate/relational/adapters/transport_ctx.py
+++ b/orion/substrate/relational/adapters/transport_ctx.py
@@ -1,0 +1,115 @@
+"""Transport-bus adapter — binds the substrate's transport "felt state".
+
+Maps ``TransportBusProjectionV1`` (per-bus health, delivery confidence, and the
+family of transport pressures — transport_pressure, backpressure, contract,
+reliability, stream-depth) into substrate belief nodes anchored to Orion, so the
+unified belief set contains beliefs about how Orion's own message bus is faring.
+
+ctx-sourced, pure (no network, no DB): reads
+``ctx['transport_bus_projection']`` as a model, dict, or JSON string, and
+degrades to ``None`` when the key is absent or unparseable — never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from orion.core.schemas.cognitive_substrate import (
+    ConceptNodeV1,
+    SubstrateGraphRecordV1,
+    SubstrateProvenanceV1,
+    SubstrateSignalBundleV1,
+)
+from orion.schemas.transport_projection import TransportBusProjectionV1
+from orion.substrate.adapters._common import make_temporal
+
+logger = logging.getLogger("orion.substrate.relational.adapters.transport_ctx")
+
+_TIER_RANK = 4  # snapshot_ephemeral: derived transport bus state
+_MAX_NODES = 20
+
+
+def _clamp(x: Any) -> float:
+    try:
+        return max(0.0, min(1.0, float(x)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _make_prov() -> SubstrateProvenanceV1:
+    return SubstrateProvenanceV1(
+        authority="local_inferred",
+        source_kind="transport_bus",
+        source_channel="substrate.transport",
+        producer="transport_lane_adapter",
+        tier_rank=_TIER_RANK,
+    )
+
+
+def _coerce(raw: Any) -> TransportBusProjectionV1 | None:
+    try:
+        if isinstance(raw, TransportBusProjectionV1):
+            return raw
+        if isinstance(raw, str) and raw.strip():
+            return TransportBusProjectionV1.model_validate_json(raw)
+        if isinstance(raw, dict):
+            return TransportBusProjectionV1.model_validate(raw)
+    except Exception as exc:
+        logger.debug("transport_ctx_adapter_parse_failed error=%s", exc)
+    return None
+
+
+def map_transport_ctx_to_substrate(ctx: dict[str, Any]) -> SubstrateGraphRecordV1 | None:
+    """Map ``ctx['transport_bus_projection']`` → transport belief nodes."""
+    ctx = ctx if isinstance(ctx, dict) else {}
+    projection = _coerce(ctx.get("transport_bus_projection"))
+    if projection is None:
+        return None
+
+    now = datetime.now(timezone.utc)
+    temporal = make_temporal(observed_at=now)
+    prov = _make_prov()
+
+    buses = sorted(
+        projection.buses.values(),
+        key=lambda b: b.transport_pressure,
+        reverse=True,
+    )[:_MAX_NODES]
+
+    nodes: list[Any] = []
+    for bus in buses:
+        salience = _clamp(
+            max(
+                bus.transport_pressure,
+                bus.backpressure,
+                bus.reliability_pressure,
+                bus.contract_pressure,
+                bus.stream_depth_pressure,
+            )
+        )
+        confidence = _clamp(bus.delivery_confidence) or 0.7
+        nodes.append(
+            ConceptNodeV1(
+                anchor_scope="orion",
+                subject_ref="entity:orion",
+                label=f"transport:{bus.node_id or bus.target_id}",
+                temporal=temporal,
+                provenance=prov,
+                signals=SubstrateSignalBundleV1(confidence=confidence, salience=salience),
+                metadata={
+                    "source_kind": "transport_bus",
+                    "target_id": bus.target_id,
+                    "node_id": bus.node_id,
+                    "bus_health": round(bus.bus_health, 6),
+                    "delivery_confidence": round(bus.delivery_confidence, 6),
+                    "transport_pressure": round(bus.transport_pressure, 6),
+                },
+            )
+        )
+
+    if not nodes:
+        return None
+
+    return SubstrateGraphRecordV1(anchor_scope="orion", nodes=nodes)

--- a/orion/substrate/relational/tests/test_reducer_lane_adapters.py
+++ b/orion/substrate/relational/tests/test_reducer_lane_adapters.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from orion.schemas.biometrics_projection import (
+    ActiveNodePressureProjectionV1,
+    ActiveNodePressureStateV1,
+)
+from orion.schemas.execution_projection import (
+    ExecutionRunStateV1,
+    ExecutionTrajectoryProjectionV1,
+)
+from orion.schemas.transport_projection import (
+    TransportBusProjectionV1,
+    TransportBusStateV1,
+)
+from orion.substrate.relational.adapters.biometrics_ctx import (
+    map_biometrics_ctx_to_substrate,
+)
+from orion.substrate.relational.adapters.execution_ctx import (
+    map_execution_ctx_to_substrate,
+)
+from orion.substrate.relational.adapters.transport_ctx import (
+    map_transport_ctx_to_substrate,
+)
+
+NOW = datetime.now(timezone.utc)
+
+
+# --------------------------------------------------------------------------- #
+# execution
+# --------------------------------------------------------------------------- #
+def _execution_projection(n: int = 1) -> ExecutionTrajectoryProjectionV1:
+    runs: dict[str, ExecutionRunStateV1] = {}
+    for i in range(n):
+        trace_id = f"trace{i:04d}abcdef"
+        runs[trace_id] = ExecutionRunStateV1(
+            trace_id=trace_id,
+            correlation_id=f"corr{i}",
+            node_id="orion-exec",
+            verb="chat",
+            mode="stream",
+            status="running",
+            step_count=3 + i,
+            pressure_hints={
+                "execution_load": 0.4,
+                "execution_friction": 0.9,
+                "failure_pressure": 0.1,
+                "reasoning_load": 0.2,
+            },
+            last_updated_at=NOW + timedelta(seconds=i),
+        )
+    return ExecutionTrajectoryProjectionV1(projection_id="exec1", generated_at=NOW, runs=runs)
+
+
+def test_execution_adapter_emits_run_nodes() -> None:
+    proj = _execution_projection(1)
+    record = map_execution_ctx_to_substrate({"execution_trajectory_projection": proj})
+    assert record is not None
+    assert record.anchor_scope == "orion"
+    node = record.nodes[0]
+    assert node.label.startswith("execution:chat:")
+    assert node.anchor_scope == "orion"
+    assert node.subject_ref == "entity:orion"
+    # salience = max pressure hint = execution_friction 0.9
+    assert node.signals.salience == 0.9
+    assert node.metadata["source_kind"] == "execution_trajectory"
+    assert node.metadata["verb"] == "chat"
+    assert node.metadata["status"] == "running"
+    assert node.metadata["pressure_hints"]["execution_friction"] == 0.9
+
+
+def test_execution_adapter_accepts_dict_json_absent_and_garbage() -> None:
+    proj = _execution_projection(1)
+    assert map_execution_ctx_to_substrate(
+        {"execution_trajectory_projection": proj.model_dump(mode="json")}
+    ) is not None
+    assert map_execution_ctx_to_substrate(
+        {"execution_trajectory_projection": proj.model_dump_json()}
+    ) is not None
+    assert map_execution_ctx_to_substrate({}) is None
+    assert map_execution_ctx_to_substrate({"execution_trajectory_projection": "not json"}) is None
+
+
+def test_execution_adapter_caps_at_20() -> None:
+    record = map_execution_ctx_to_substrate(
+        {"execution_trajectory_projection": _execution_projection(35)}
+    )
+    assert record is not None
+    assert len(record.nodes) <= 20
+
+
+# --------------------------------------------------------------------------- #
+# transport
+# --------------------------------------------------------------------------- #
+def _transport_projection(n: int = 1) -> TransportBusProjectionV1:
+    buses: dict[str, TransportBusStateV1] = {}
+    for i in range(n):
+        key = f"bus{i}"
+        buses[key] = TransportBusStateV1(
+            target_id=f"target{i}",
+            node_id=f"node{i}",
+            sample_window_id="w1",
+            source_trace_id="t1",
+            bus_health=0.5,
+            delivery_confidence=0.8,
+            transport_pressure=0.3 + (i % 5) * 0.1,
+            backpressure=0.6,
+            reliability_pressure=0.2,
+            contract_pressure=0.1,
+            stream_depth_pressure=0.05,
+            observed_at=NOW,
+        )
+    return TransportBusProjectionV1(updated_at=NOW, buses=buses)
+
+
+def test_transport_adapter_emits_bus_nodes() -> None:
+    proj = _transport_projection(1)
+    record = map_transport_ctx_to_substrate({"transport_bus_projection": proj})
+    assert record is not None
+    assert record.anchor_scope == "orion"
+    node = record.nodes[0]
+    assert node.label == "transport:node0"
+    assert node.anchor_scope == "orion"
+    assert node.subject_ref == "entity:orion"
+    # salience = max of the pressures = backpressure 0.6
+    assert node.signals.salience == 0.6
+    # confidence = delivery_confidence
+    assert node.signals.confidence == 0.8
+    assert node.metadata["source_kind"] == "transport_bus"
+    assert node.metadata["target_id"] == "target0"
+    assert node.metadata["node_id"] == "node0"
+
+
+def test_transport_adapter_accepts_dict_json_absent_and_garbage() -> None:
+    proj = _transport_projection(1)
+    assert map_transport_ctx_to_substrate(
+        {"transport_bus_projection": proj.model_dump(mode="json")}
+    ) is not None
+    assert map_transport_ctx_to_substrate(
+        {"transport_bus_projection": proj.model_dump_json()}
+    ) is not None
+    assert map_transport_ctx_to_substrate({}) is None
+    assert map_transport_ctx_to_substrate({"transport_bus_projection": "not json"}) is None
+
+
+def test_transport_adapter_caps_at_20() -> None:
+    record = map_transport_ctx_to_substrate(
+        {"transport_bus_projection": _transport_projection(40)}
+    )
+    assert record is not None
+    assert len(record.nodes) <= 20
+
+
+# --------------------------------------------------------------------------- #
+# biometrics
+# --------------------------------------------------------------------------- #
+def _biometrics_projection(n: int = 1, include_quiet: bool = False) -> ActiveNodePressureProjectionV1:
+    nodes: dict[str, ActiveNodePressureStateV1] = {}
+    for i in range(n):
+        key = f"n{i}"
+        nodes[key] = ActiveNodePressureStateV1(
+            node_id=key,
+            availability_status="online",
+            active_pressures=["cpu_saturation"],
+            capability_impacts=["chat_latency"],
+            pressure_score=0.5 + (i % 4) * 0.1,
+            last_updated_at=NOW,
+        )
+    if include_quiet:
+        nodes["quiet"] = ActiveNodePressureStateV1(
+            node_id="quiet",
+            availability_status="online",
+            active_pressures=[],
+            pressure_score=0.0,
+            last_updated_at=NOW,
+        )
+    return ActiveNodePressureProjectionV1(projection_id="bio1", generated_at=NOW, nodes=nodes)
+
+
+def test_biometrics_adapter_emits_pressure_nodes() -> None:
+    proj = _biometrics_projection(1)
+    record = map_biometrics_ctx_to_substrate({"active_node_pressure_projection": proj})
+    assert record is not None
+    assert record.anchor_scope == "orion"
+    node = record.nodes[0]
+    assert node.label == "biometrics:n0"
+    assert node.anchor_scope == "orion"
+    assert node.subject_ref == "entity:orion"
+    assert node.signals.salience == 0.5
+    assert node.metadata["source_kind"] == "biometrics_pressure"
+    assert node.metadata["node_id"] == "n0"
+    assert node.metadata["pressure_score"] == 0.5
+    assert node.metadata["active_pressures"] == ["cpu_saturation"]
+
+
+def test_biometrics_adapter_excludes_quiet_nodes() -> None:
+    proj = _biometrics_projection(1, include_quiet=True)
+    record = map_biometrics_ctx_to_substrate({"active_node_pressure_projection": proj})
+    assert record is not None
+    labels = {n.label for n in record.nodes}
+    assert "biometrics:quiet" not in labels
+    assert "biometrics:n0" in labels
+
+
+def test_biometrics_adapter_accepts_dict_json_absent_and_garbage() -> None:
+    proj = _biometrics_projection(1)
+    assert map_biometrics_ctx_to_substrate(
+        {"active_node_pressure_projection": proj.model_dump(mode="json")}
+    ) is not None
+    assert map_biometrics_ctx_to_substrate(
+        {"active_node_pressure_projection": proj.model_dump_json()}
+    ) is not None
+    assert map_biometrics_ctx_to_substrate({}) is None
+    assert map_biometrics_ctx_to_substrate({"active_node_pressure_projection": "not json"}) is None
+
+
+def test_biometrics_adapter_caps_at_20() -> None:
+    record = map_biometrics_ctx_to_substrate(
+        {"active_node_pressure_projection": _biometrics_projection(30)}
+    )
+    assert record is not None
+    assert len(record.nodes) <= 20
+
+
+# --------------------------------------------------------------------------- #
+# registry wiring
+# --------------------------------------------------------------------------- #
+def test_registry_registers_three_reducer_lanes() -> None:
+    from orion.cognition.projection_builder import build_projection_unification_registry
+
+    reg = build_projection_unification_registry()
+    ids = [p.producer_id for p in reg.producers]
+    assert len(reg.producers) == 12
+    assert {"biometrics", "execution", "transport"} <= set(ids)

--- a/services/orion-cortex-exec/.env_example
+++ b/services/orion-cortex-exec/.env_example
@@ -185,6 +185,16 @@ SUBSTRATE_GRAPH_TIMEOUT_SEC=5.0
 SUBSTRATE_GRAPH_USER=admin
 SUBSTRATE_GRAPH_PASS=orion
 
+# --- Substrate felt-state ctx hydration (rung 2) ---
+# Loads the latest biometrics/execution/transport/self_state reducer projections
+# from Postgres (conjourney) into chat-stance ctx so those unified-belief lanes
+# activate. Default-off in code; enabled here to run. Fail-open + freshness-gated
+# (stale rows past MAX_AGE_SEC are dropped). DB URL falls back to
+# ENDOGENOUS_RUNTIME_SQL_DATABASE_URL when unset.
+ENABLE_SUBSTRATE_FELT_STATE_CTX=true
+SUBSTRATE_FELT_STATE_DATABASE_URL=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+SUBSTRATE_FELT_STATE_MAX_AGE_SEC=120
+
 # Legacy GraphDB substrate (explicit SUBSTRATE_STORE_BACKEND=graphdb only):
 # SUBSTRATE_STORE_BACKEND=graphdb
 # SUBSTRATE_GRAPHDB_ENDPOINT=http://orion-athena-graphdb:7200/repositories/collapse

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -2107,6 +2107,8 @@ def _run_autonomy_reducer(ctx: Dict[str, Any], autonomy: Dict[str, Any]):
 def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
     # Single unified beliefs call replaces independent producer fan-outs for
     # identity, orionmem, recall, and social lanes.
+    from app.substrate_felt_state_reader import hydrate_felt_state_ctx
+    hydrate_felt_state_ctx(ctx)
     beliefs = _unified_beliefs_for_stance(ctx)
 
     identity = _project_identity_from_beliefs(beliefs, ctx)

--- a/services/orion-cortex-exec/app/substrate_felt_state_reader.py
+++ b/services/orion-cortex-exec/app/substrate_felt_state_reader.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import create_engine, text
+
+logger = logging.getLogger("orion.cortex.exec.substrate_felt_state_reader")
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+_DEFAULT_DATABASE_URL = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+_DEFAULT_MAX_AGE_SEC = 120
+
+
+@dataclass(frozen=True)
+class LaneSpec:
+    ctx_key: str
+    table: str
+    payload_col: str
+    ts_col: str
+    projection_id: str | None
+
+
+# Trusted module constants (NOT user input). Each lane is a single latest row in
+# the substrate Postgres. Note the ts column differs across lanes.
+_LANES: tuple[LaneSpec, ...] = (
+    LaneSpec(
+        ctx_key="self_state",
+        table="substrate_self_state",
+        payload_col="self_state_json",
+        ts_col="generated_at",
+        projection_id=None,
+    ),
+    LaneSpec(
+        ctx_key="execution_trajectory_projection",
+        table="substrate_execution_trajectory_projection",
+        payload_col="projection_json",
+        ts_col="generated_at",
+        projection_id="active_execution_trajectory",
+    ),
+    LaneSpec(
+        ctx_key="transport_bus_projection",
+        table="substrate_transport_bus_projection",
+        payload_col="projection_json",
+        ts_col="updated_at",
+        projection_id="active_transport_bus_projection",
+    ),
+    LaneSpec(
+        ctx_key="active_node_pressure_projection",
+        table="substrate_active_node_pressure_projection",
+        payload_col="projection_json",
+        ts_col="generated_at",
+        projection_id="active_node_pressure_projection",
+    ),
+)
+
+
+def _flag_enabled() -> bool:
+    return os.getenv("ENABLE_SUBSTRATE_FELT_STATE_CTX", "false").strip().lower() in _TRUTHY
+
+
+def _max_age_sec() -> int:
+    raw = os.getenv("SUBSTRATE_FELT_STATE_MAX_AGE_SEC", str(_DEFAULT_MAX_AGE_SEC))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_AGE_SEC
+
+
+def _database_url() -> str:
+    return (
+        os.getenv("SUBSTRATE_FELT_STATE_DATABASE_URL")
+        or os.getenv("ENDOGENOUS_RUNTIME_SQL_DATABASE_URL")
+        or _DEFAULT_DATABASE_URL
+    )
+
+
+class SubstrateFeltStateReader:
+    def __init__(self, *, enabled: bool, database_url: str, max_age_sec: int) -> None:
+        self._enabled = enabled
+        self._database_url = database_url
+        self._max_age_sec = max_age_sec
+        self._engine = create_engine(database_url, pool_pre_ping=True) if enabled else None
+        # Per-lane in-process cache: ctx_key -> (payload, monotonic fetched-at).
+        self._cache: dict[str, tuple[Any, float]] = {}
+
+    def _fetch_lane(self, lane: LaneSpec) -> tuple[Any, datetime] | None:
+        """Run the real query against self._engine. Returns (payload, ts) or None.
+
+        This is the ONLY method that touches the DB. Tests override it.
+        """
+        if self._engine is None:
+            return None
+        if lane.projection_id is None:
+            query = text(
+                f"SELECT {lane.payload_col}, {lane.ts_col} "
+                f"FROM {lane.table} "
+                f"ORDER BY {lane.ts_col} DESC LIMIT 1"
+            )
+            params: dict[str, Any] = {}
+        else:
+            query = text(
+                f"SELECT {lane.payload_col}, {lane.ts_col} "
+                f"FROM {lane.table} "
+                f"WHERE projection_id = :pid"
+            )
+            params = {"pid": lane.projection_id}
+        with self._engine.connect() as conn:
+            row = conn.execute(query, params).mappings().first()
+        if row is None:
+            return None
+        # Payload comes back from JSONB as dict already (or str) — return AS-IS.
+        return (row.get(lane.payload_col), row.get(lane.ts_col))
+
+    def hydrate(self, ctx: dict) -> None:
+        if not self._enabled:
+            return
+        for lane in _LANES:
+            try:
+                # Respect upstream: never overwrite a pre-existing ctx key.
+                if ctx.get(lane.ctx_key) is not None:
+                    continue
+                # Cache check (TTL bounded by max_age_sec).
+                cached = self._cache.get(lane.ctx_key)
+                if cached is not None:
+                    payload, fetched_at = cached
+                    if (time.monotonic() - fetched_at) <= self._max_age_sec:
+                        ctx[lane.ctx_key] = payload
+                        continue
+                result = self._fetch_lane(lane)
+                if result is None:
+                    continue
+                payload, ts = result
+                if ts is None:
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                age = (datetime.now(timezone.utc) - ts).total_seconds()
+                if age > self._max_age_sec:
+                    # Stale: do not inject.
+                    continue
+                ctx[lane.ctx_key] = payload
+                self._cache[lane.ctx_key] = (payload, time.monotonic())
+            except Exception:  # never let one lane break another
+                logger.debug("felt-state lane hydrate failed: %s", lane.ctx_key, exc_info=True)
+                continue
+
+
+_READER: SubstrateFeltStateReader | None = None
+
+
+def _get_reader() -> SubstrateFeltStateReader:
+    global _READER
+    if _READER is None:
+        _READER = SubstrateFeltStateReader(
+            enabled=_flag_enabled(),
+            database_url=_database_url(),
+            max_age_sec=_max_age_sec(),
+        )
+    return _READER
+
+
+def hydrate_felt_state_ctx(ctx: dict) -> None:
+    """Public entrypoint. Fail-open: never raises."""
+    try:
+        if not isinstance(ctx, dict):
+            return
+        reader = _get_reader()
+        reader.hydrate(ctx)
+    except Exception:
+        logger.debug("hydrate_felt_state_ctx failed", exc_info=True)
+        return
+
+
+def reset_reader_for_tests() -> None:
+    global _READER
+    _READER = None

--- a/services/orion-cortex-exec/tests/test_substrate_felt_state_reader.py
+++ b/services/orion-cortex-exec/tests/test_substrate_felt_state_reader.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.substrate_felt_state_reader import (
+    _LANES,
+    SubstrateFeltStateReader,
+    hydrate_felt_state_ctx,
+    reset_reader_for_tests,
+)
+
+
+def _make_reader(max_age_sec: int = 120) -> SubstrateFeltStateReader:
+    # Build disabled (no create_engine / no DB), then flip to enabled with no engine.
+    reader = SubstrateFeltStateReader(
+        enabled=False, database_url="postgresql://unused", max_age_sec=max_age_sec
+    )
+    reader._enabled = True
+    reader._engine = None
+    return reader
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def test_fresh_rows_all_lanes_hydrated():
+    reader = _make_reader()
+
+    def fake_fetch(lane):
+        return ({"lane": lane.ctx_key, "value": 1}, _now())
+
+    reader._fetch_lane = fake_fetch  # type: ignore[assignment]
+
+    ctx: dict = {}
+    reader.hydrate(ctx)
+
+    for lane in _LANES:
+        assert ctx.get(lane.ctx_key) == {"lane": lane.ctx_key, "value": 1}
+
+
+def test_stale_row_not_injected():
+    reader = _make_reader(max_age_sec=120)
+    stale_ts = _now() - timedelta(seconds=10000)
+
+    def fake_fetch(lane):
+        return ({"lane": lane.ctx_key}, stale_ts)
+
+    reader._fetch_lane = fake_fetch  # type: ignore[assignment]
+
+    ctx: dict = {}
+    reader.hydrate(ctx)
+
+    for lane in _LANES:
+        assert lane.ctx_key not in ctx
+
+
+def test_existing_ctx_key_not_overwritten():
+    reader = _make_reader()
+    sentinel = {"preexisting": True}
+
+    def fake_fetch(lane):
+        return ({"lane": lane.ctx_key}, _now())
+
+    reader._fetch_lane = fake_fetch  # type: ignore[assignment]
+
+    ctx: dict = {"execution_trajectory_projection": sentinel}
+    reader.hydrate(ctx)
+
+    assert ctx["execution_trajectory_projection"] is sentinel
+
+
+def test_disabled_is_noop():
+    reader = SubstrateFeltStateReader(
+        enabled=False, database_url="postgresql://unused", max_age_sec=120
+    )
+
+    def fake_fetch(lane):
+        raise AssertionError("should not be called when disabled")
+
+    reader._fetch_lane = fake_fetch  # type: ignore[assignment]
+
+    ctx: dict = {}
+    reader.hydrate(ctx)
+
+    assert ctx == {}
+
+
+def test_one_lane_raises_fail_open_others_hydrate():
+    reader = _make_reader()
+
+    def fake_fetch(lane):
+        if lane.ctx_key == "self_state":
+            raise RuntimeError("boom")
+        return ({"lane": lane.ctx_key}, _now())
+
+    reader._fetch_lane = fake_fetch  # type: ignore[assignment]
+
+    ctx: dict = {}
+    # Must not raise.
+    reader.hydrate(ctx)
+
+    assert "self_state" not in ctx
+    for lane in _LANES:
+        if lane.ctx_key == "self_state":
+            continue
+        assert ctx.get(lane.ctx_key) == {"lane": lane.ctx_key}
+
+
+def test_entrypoint_flag_unset_is_noop(monkeypatch):
+    monkeypatch.delenv("ENABLE_SUBSTRATE_FELT_STATE_CTX", raising=False)
+    reset_reader_for_tests()
+
+    ctx: dict = {}
+    hydrate_felt_state_ctx(ctx)
+
+    assert ctx == {}
+
+    reset_reader_for_tests()

--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -35,6 +35,20 @@ ENABLE_TRANSPORT_BUS_REDUCER=true
 BUS_STREAM_DEPTH_CRITICAL=100000
 # trace_only | m3 | m4 | m5 | full
 TRANSPORT_SUBSTRATE_MATURITY=full_observe
+# --- Rung 1 bridge: write execution/transport prediction_error onto a durable ---
+# substrate node so the dynamics engine can seed pressure from it. Default-off in
+# code, fail-open. For cross-process effect the write must target the shared
+# semantic store (SUBSTRATE_STORE_BACKEND=sparql + Fuseki URLs below); with the
+# in-memory default the node is process-local. NOTE: no periodic dynamics-engine
+# tick consumes these nodes yet — this persists surprise; the seeding tick is
+# follow-up work (see PR report).
+SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true
+SUBSTRATE_STORE_BACKEND=sparql
+SUBSTRATE_GRAPH_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
+SUBSTRATE_GRAPH_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
+SUBSTRATE_GRAPH_URI=http://conjourney.net/graph/substrate
+SUBSTRATE_GRAPH_USER=admin
+SUBSTRATE_GRAPH_PASS=orion
 # Chat grammar reducer (set true after PUBLISH_HUB_CHAT_GRAMMAR=true is set on hub)
 ENABLE_CHAT_GRAMMAR_REDUCER=true
 CHAT_GRAMMAR_BATCH_LIMIT=100

--- a/services/orion-substrate-runtime/app/worker.py
+++ b/services/orion-substrate-runtime/app/worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -62,6 +63,13 @@ from .settings import Settings, get_settings
 from .store import BiometricsSubstrateStore
 
 logger = logging.getLogger("orion.substrate.runtime")
+
+_PREDICTION_ERROR_NODE_FLAG = "SUBSTRATE_WRITE_PREDICTION_ERROR_NODES"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _prediction_error_nodes_enabled() -> bool:
+    return os.getenv(_PREDICTION_ERROR_NODE_FLAG, "false").strip().lower() in _TRUTHY
 
 
 def _prediction_error_receipt(
@@ -147,6 +155,7 @@ class BiometricsSubstrateWorker:
         self._stop = asyncio.Event()
         self._bus = None
         self._tasks: list[asyncio.Task[None]] = []
+        self._substrate_graph_store: Any = None
 
     async def start(self) -> None:
         s = self._settings
@@ -524,6 +533,75 @@ class BiometricsSubstrateWorker:
         )
         return last_id, published
 
+    def _write_prediction_error_node(
+        self,
+        *,
+        node_id: str,
+        error: float,
+        now: datetime,
+        reducer_key: str = "",
+    ) -> None:
+        """Upsert a durable substrate node carrying the surprise (Rung 1 bridge).
+
+        Default-off (env flag), fail-open: never raises out of a tick. When
+        enabled it writes a single node under a fixed identity_key so re-writes
+        collapse (no unbounded node growth), letting the dynamics engine seed
+        pressure from ``metadata['prediction_error']``.
+        """
+        if not _prediction_error_nodes_enabled():
+            return
+
+        try:
+            store = self._substrate_graph_store
+            if store is None:
+                from orion.substrate.graphdb_store import build_substrate_store_from_env
+
+                store = build_substrate_store_from_env()
+                self._substrate_graph_store = store
+        except Exception:
+            logger.exception("substrate_prediction_error_store_init_failed")
+            return
+
+        try:
+            from orion.core.schemas.cognitive_substrate import (
+                ConceptNodeV1,
+                SubstrateProvenanceV1,
+                SubstrateSignalBundleV1,
+            )
+            from orion.substrate.adapters._common import make_temporal
+
+            salience = max(0.0, min(1.0, error))
+            node = ConceptNodeV1(
+                node_id=node_id,
+                anchor_scope="orion",
+                subject_ref="entity:orion",
+                label=f"substrate:{node_id}",
+                temporal=make_temporal(observed_at=now),
+                provenance=SubstrateProvenanceV1(
+                    authority="local_inferred",
+                    source_kind="substrate_prediction_error",
+                    source_channel="substrate.runtime",
+                    producer="substrate_runtime_worker",
+                    tier_rank=2,
+                ),
+                signals=SubstrateSignalBundleV1(confidence=1.0, salience=salience),
+                metadata={
+                    "source_kind": "substrate_prediction_error",
+                    "prediction_error": round(salience, 6),
+                    "reducer_key": reducer_key,
+                },
+            )
+            store.upsert_node(
+                identity_key=f"substrate_prediction_error|{node_id}",
+                node=node,
+            )
+        except Exception:
+            logger.warning(
+                "substrate_prediction_error_node_upsert_failed node_id=%s",
+                node_id,
+                exc_info=True,
+            )
+
     def _execution_tick(self) -> str | None:
         spec = REDUCER_SPECS[1]
         events = self._store.fetch_execution_grammar_events(
@@ -566,6 +644,12 @@ class BiometricsSubstrateWorker:
                         prediction_error=error,
                         now=now,
                     )
+                )
+                self._write_prediction_error_node(
+                    node_id="node:substrate.execution",
+                    error=error,
+                    now=now,
+                    reducer_key="execution_trajectory",
                 )
 
         return last_id
@@ -649,6 +733,12 @@ class BiometricsSubstrateWorker:
                         prediction_error=error,
                         now=now,
                     )
+                )
+                self._write_prediction_error_node(
+                    node_id="node:substrate.transport",
+                    error=error,
+                    now=now,
+                    reducer_key="transport_bus",
                 )
 
         return last_id

--- a/services/orion-substrate-runtime/tests/test_worker_prediction_error_node.py
+++ b/services/orion-substrate-runtime/tests/test_worker_prediction_error_node.py
@@ -1,0 +1,102 @@
+"""Unit tests for the Rung 1 bridge: worker writes prediction_error onto a
+durable substrate node (default-off, fail-open)."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SUBSTRATE_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SUBSTRATE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SUBSTRATE_ROOT))
+
+from app.worker import BiometricsSubstrateWorker, _PREDICTION_ERROR_NODE_FLAG
+
+
+class _FakeStore:
+    """Records upsert_node calls without touching a real graph store."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def upsert_node(self, *, identity_key, node) -> None:
+        self.calls.append({"identity_key": identity_key, "node": node})
+
+
+class _RaisingStore:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def upsert_node(self, *, identity_key, node) -> None:
+        self.calls += 1
+        raise RuntimeError("boom")
+
+
+def _make_worker(store) -> BiometricsSubstrateWorker:
+    worker = BiometricsSubstrateWorker.__new__(BiometricsSubstrateWorker)
+    worker._substrate_graph_store = store
+    return worker
+
+
+def test_write_prediction_error_node_upserts_when_flag_on(monkeypatch) -> None:
+    monkeypatch.setenv(_PREDICTION_ERROR_NODE_FLAG, "true")
+    store = _FakeStore()
+    worker = _make_worker(store)
+    now = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    worker._write_prediction_error_node(
+        node_id="node:substrate.execution",
+        error=0.42,
+        now=now,
+        reducer_key="execution_trajectory",
+    )
+
+    assert len(store.calls) == 1
+    call = store.calls[0]
+    assert call["identity_key"] == "substrate_prediction_error|node:substrate.execution"
+    node = call["node"]
+    assert node.metadata["prediction_error"] == 0.42
+    assert node.anchor_scope == "orion"
+    assert node.subject_ref == "entity:orion"
+    assert node.temporal.observed_at == now
+    assert node.node_id == "node:substrate.execution"
+    assert node.metadata["reducer_key"] == "execution_trajectory"
+
+
+def test_write_prediction_error_node_noop_when_flag_off(monkeypatch) -> None:
+    monkeypatch.delenv(_PREDICTION_ERROR_NODE_FLAG, raising=False)
+    store = _FakeStore()
+    worker = _make_worker(store)
+    now = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    worker._write_prediction_error_node(
+        node_id="node:substrate.execution",
+        error=0.42,
+        now=now,
+        reducer_key="execution_trajectory",
+    )
+
+    assert store.calls == []
+
+
+def test_write_prediction_error_node_fail_open_on_raise(monkeypatch) -> None:
+    monkeypatch.setenv(_PREDICTION_ERROR_NODE_FLAG, "1")
+    store = _RaisingStore()
+    worker = _make_worker(store)
+    now = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Must not propagate.
+    worker._write_prediction_error_node(
+        node_id="node:substrate.transport",
+        error=0.9,
+        now=now,
+        reducer_key="transport_bus",
+    )
+
+    assert store.calls == 1


### PR DESCRIPTION
# PR: substrate self-modeling loop — rung-1 runtime bridge + rung-2 felt-state lanes (activated)

> Committed to the branch as the PR body because this checkout has no GitHub auth
> (no `gh` login / `GH_TOKEN`). Open the PR at:
> https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/substrate-rung1-bridge-rung2-lanes
> and paste the body below.

Branch: `feat/substrate-rung1-bridge-rung2-lanes`

---

## Summary

Finishes the two remaining edges of the substrate self-modeling loop from
`docs/plans/substrate/CONTINUATION.md`, and wires them so they actually run on the
Athena host:

1. **Rung 1 runtime bridge** — the runtime worker now writes the execution/transport
   `prediction_error` it computes onto a durable substrate node, not just a
   field-digester receipt, so the dynamics engine has a node to seed pressure from.
2. **Rung 2 remainder** — binds the substrate's own "felt state" (biometrics
   pressure, in-flight execution, transport-bus health) into the
   CognitiveUnificationLayer as three belief lanes, and adds the ctx-hydration step
   that actually populates them at chat-stance time (which also lights up the
   previously-dormant `self_state` lane shipped in `d9dbe624`).

Honest framing (unchanged from the ladder doc): this implements the *functional*
properties — predictive feedback, integration/higher-order self-model — as thin,
inspectable, tested seams. No claim about phenomenal experience.

## What this closes

```
prediction error (worker)
  → durable substrate node metadata['prediction_error']        (rung 1, this PR)
  → [dynamics engine seeds pressure from it]                   (consumer: follow-up)

reducer projections (biometrics/execution/transport) + self_state
  → hydrated into chat-stance ctx                              (rung 2 ctx wire, this PR)
  → felt-state belief lanes in the unified belief set          (rung 2 adapters, this PR)
```

## Changes

| Rung | Change | Files |
|------|--------|-------|
| 1 | On `error>0` in `_execution_tick`/`_transport_tick`, upsert a `ConceptNodeV1` (`node:substrate.execution` / `.transport`, anchor `orion`) carrying `metadata['prediction_error']` + fresh `observed_at`, under a fixed identity_key so re-writes collapse. Field-digester receipt untouched. Default-off (`SUBSTRATE_WRITE_PREDICTION_ERROR_NODES`), fail-open. | `services/orion-substrate-runtime/app/worker.py` (+ test) |
| 2a | Three ctx-sourced adapters (biometrics/execution/transport) mirroring `self_state_ctx`: pure, degrade-to-None, capped at 20. Registry 9 → 12 producers. | `orion/substrate/relational/adapters/{biometrics,execution,transport}_ctx.py`, `orion/cognition/projection_builder.py` (+ tests; repairs the pre-existing-red registry test that `d9dbe624` left stale) |
| 2b | `SubstrateFeltStateReader` loads the latest projection from the four substrate Postgres tables into chat-stance ctx before the unifier runs, at the single common caller `build_chat_stance_inputs`. Default-off (`ENABLE_SUBSTRATE_FELT_STATE_CTX`), fail-open, freshness-gated, non-clobbering. | `services/orion-cortex-exec/app/substrate_felt_state_reader.py`, `services/orion-cortex-exec/app/chat_stance.py` (+ test) |
| env | Feature flags + supporting config enabled in `.env_example` (and copied to local `.env`) so the loop runs on Athena. | `services/orion-cortex-exec/.env_example`, `services/orion-substrate-runtime/.env_example` |

## Deployment / how it runs

**cortex-exec** (rung 2 — fully live; reads projections from the `conjourney` Postgres):
```
ENABLE_SUBSTRATE_FELT_STATE_CTX=true
SUBSTRATE_FELT_STATE_DATABASE_URL=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
SUBSTRATE_FELT_STATE_MAX_AGE_SEC=120
```
The execution/transport reducers are already enabled on the runtime, so their
projections exist; the biometrics reducer is always on. Enabling the flag activates
all four belief lanes.

**orion-substrate-runtime** (rung 1 — write path):
```
SUBSTRATE_WRITE_PREDICTION_ERROR_NODES=true
SUBSTRATE_STORE_BACKEND=sparql
SUBSTRATE_GRAPH_QUERY_URL=http://orion-athena-fuseki:3030/orion/query
SUBSTRATE_GRAPH_UPDATE_URL=http://orion-athena-fuseki:3030/orion/update
SUBSTRATE_GRAPH_URI=http://conjourney.net/graph/substrate
SUBSTRATE_GRAPH_USER=admin
SUBSTRATE_GRAPH_PASS=orion
```

## Known gap (honest)

**Rung 1's consumer is not wired yet.** No periodic `SubstrateDynamicsEngine.tick()`
runs against the shared store in any service today (verified by grep). So with the
config above, surprise is *persisted* to Fuseki but not yet *seeded into pressure*.
Closing that is a small follow-up (a bounded dynamics tick in the runtime worker or a
dedicated loop) and is rung-3 adjacent. Rung 2 is fully live and end-to-end.

## Safety / governance

- Both features default-off in code; enabled only via env. Flag off ⇒ byte-identical
  to prior behavior.
- Fail-open everywhere: store init, upserts, and each hydration lane are wrapped so a
  tick / chat turn never crashes; one lane can't break another.
- Freshness-gated: stale projections past `MAX_AGE_SEC` are excluded, not felt as
  current (Forge: stale excluded by default).
- Non-clobbering: hydration never overwrites a pre-existing ctx key.
- Bounded: fixed identity_key (no unbounded node growth); every adapter collection
  capped at 20; single latest row per lane + TTL cache.
- Not touched: the dangerous endogenous-agency gate (rung 5) — not in this PR.

## Tests

All green:
- `services/orion-substrate-runtime/tests/test_worker_prediction_error_node.py` — flag on/off, fail-open (3).
- `orion/substrate/relational/tests/test_reducer_lane_adapters.py` — per-adapter label/anchor/salience/metadata, dict+json, absent/garbage → None, cap ≤ 20, quiet-node exclusion, registry = 12 (10).
- `orion/cognition/tests/test_projection_builder.py` — registry order incl. the 4 felt-state lanes (repaired) (2).
- `services/orion-cortex-exec/tests/test_substrate_felt_state_reader.py` — fresh→injected, stale→skipped, existing-key preserved, disabled no-op, one-lane fail-open, flag-unset entrypoint no-op (6).
- Neighbors: `test_self_state_adapter`, `test_golden_path`, `test_projection_starvation_diagnostics`, `test_chat_stance_shared_spine`, `test_cognitive_substrate_phase4_dynamics` — unchanged, green.

## Commits

- `a9d0d9c9` — rung 1 runtime bridge
- `01e35c92` — rung 2 remainder (felt-state adapters + registry)
- `a3c27eb5` — rung 2 ctx hydration wire

## Reviewer notes

- The repo is concurrently mutated by an automation user; work was done on this
  branch off a clean `main`.
- Design choice: the rung-2 lanes are **ctx-sourced**, not DB-pull adapters — the
  hydration reader (cortex-exec, service-local DB access) injects the projections,
  keeping the adapters pure and matching the shipped `self_state` pattern. No
  importable substrate-projection reader was invented in the `orion` package.