### PR TITLE
Feat/relational stance speech contract

### DIFF
--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -108,6 +108,11 @@ EVIDENCE-GATED CLAIMS (operational side effects and automation only — not reca
   - prefer (no evidence): "I don't have an automatic tracker here, but I can keep this as an explicit next check-in in this conversation."
   - prefer (with evidence): "I can see an open room-local commitment for this thread; I'll treat it as a local follow-up cue, not a global notification."
 
+{% if speech_contract %}
+TURN CONTRACT
+{{ speech_contract }}
+
+{% endif %}
 TASK
 Produce exactly one user-facing reply.
 Use chat_stance_brief as the controlling stance contract:

--- a/orion/cognition/prompts/chat_stance_brief.j2
+++ b/orion/cognition/prompts/chat_stance_brief.j2
@@ -25,12 +25,17 @@ SOURCES (bounded internal inputs)
 {% if chat_situation_summary %}
 - situation_summary: {{ chat_situation_summary }}
 {% endif %}
+{% if prior_stance %}
+- prior_stance: {{ prior_stance }}
+{% endif %}
 
 SCHEMA LITERALS (use only these exact strings)
 - conversation_frame must be one of: technical, planning, reflective, playful_relational, identity_emergence, mixed
 - task_mode must be one of: direct_response, triage, technical_collaboration, identity_dialogue, reflective_dialogue, playful_exchange, mixed
 - identity_salience must be one of: low, medium, high
 - List-shaped fields must be JSON arrays of strings (never a single string): active_identity_facets, active_growth_axes, active_relationship_facets, social_posture, reflective_themes, active_tensions, dream_motifs, response_priorities, response_hazards. Use [] when none.
+- interaction_regime must be one of: instrumental, relational, minimal, or null (when unclear)
+- companion_closing_move must be one of: end_with_a_wondering, leave_space_without_offer, ground_observation, be_with_silence, or null; set when connection_seek is high
 
 REQUIREMENTS
 - Distinguish selfhood (identity/concept induction) from relationship state (social module).
@@ -87,6 +92,12 @@ When connection_seek is high (any interface_cost):
   - if interface_cost is also high, add keep_response_compact and avoid_question_pile_on
 
 Do not infer avoid_open_ended_questions from sickness/recovery alone when connection_seek is present.
+{% if prior_stance %}
+- If prior_stance.interaction_regime is "relational" and this turn continues the same emotional thread (venting, presence-seeking, recovery, companionship) without a clear pivot to task or technical work, carry interaction_regime="relational" forward. Do not re-infer as instrumental just because the explicit companion invite is absent from this message. A task pivot (explicit technical question, deploy/debug/restart request) overrides.
+{% endif %}
+- When connection_seek is high, set interaction_regime="relational" and companion_closing_move to the most fitting value.
+- When interface_cost is high and connection_seek is low, set interaction_regime="minimal".
+- Otherwise set interaction_regime="instrumental".
 
 STYLE TARGET FOR BRIEF CONTENT
 - On identity turns, prefer compact tags like: continuity, shared_build, juniper_builder, known_person, identity_turn, direct_answer.
@@ -122,3 +133,5 @@ operational_context
 situation_response_guidance
 answer_strategy
 stance_summary
+interaction_regime
+companion_closing_move

--- a/orion/cognition/prompts/chat_stance_brief.j2
+++ b/orion/cognition/prompts/chat_stance_brief.j2
@@ -76,7 +76,7 @@ INTERACTION POSTURE ASSESSMENT (semantic inference)
   - interface_cost: costly to type, read, screen-use, act, or continue interaction (motion, fatigue, overload, one-handed use)
   - connection_seek: user wants presence, venting, companionship, situated curiosity, mind-off distraction, or explicitly rejects solutioning/fixing
 - connection_seek overrides interface_cost minimization when the user invites talk, questions, venting, or says no fixing/no solutioning.
-- Represent posture using existing stance fields only (no new JSON keys in v1).
+- Represent posture primarily using existing stance fields; the only sanctioned posture keys are interaction_regime and companion_closing_move. Do not invent any other new JSON keys.
 
 When interface_cost is high and connection_seek is low:
   - set identity_salience low unless identity question

--- a/orion/schemas/chat_stance.py
+++ b/orion/schemas/chat_stance.py
@@ -51,3 +51,5 @@ class ChatStanceBrief(BaseModel):
 
     answer_strategy: str = Field(...)
     stance_summary: str = Field(...)
+    interaction_regime: Literal["instrumental", "relational", "minimal"] | None = Field(default=None)
+    companion_closing_move: str | None = Field(default=None)

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -2149,6 +2149,13 @@ def _run_autonomy_reducer(ctx: Dict[str, Any], autonomy: Dict[str, Any]):
     )
 
 
+def _inject_prior_stance_to_inputs(ctx: Dict[str, Any], inputs: Dict[str, Any]) -> None:
+    """Copy prior brief summary from ctx into stance inputs when present and non-empty."""
+    prior = ctx.get("prior_chat_stance_brief")
+    if isinstance(prior, dict) and prior:
+        inputs["prior_stance"] = prior
+
+
 def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
     # Single unified beliefs call replaces independent producer fan-outs for
     # identity, orionmem, recall, and social lanes.
@@ -2239,6 +2246,7 @@ def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
             ctx.pop("chat_attention_frame", None)
             ctx.pop("chat_attention_frame_debug", None)
 
+    _inject_prior_stance_to_inputs(ctx, inputs)
     ctx["chat_stance_inputs"] = inputs
     ctx["chat_concept_summary"] = concept
     ctx["chat_social_summary"] = social

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1039,6 +1039,51 @@ def _upgrade_brief_for_relational_continuation(brief: ChatStanceBrief) -> ChatSt
     return merged
 
 
+_COMPANION_CLOSING_MOVE_MAP: dict[str, str] = {
+    "end_with_a_wondering": "End with a wondering, not an offer.",
+    "leave_space_without_offer": "Leave space. Do not close with an offer to help.",
+    "ground_observation": "End with a grounded observation from the thread.",
+    "be_with_silence": "Hold the silence. No closing move required.",
+}
+
+
+def compile_speech_contract(brief: "ChatStanceBrief") -> str:
+    """Deterministic regime-specific contract injected near TASK in chat_general.j2.
+
+    Pure Python — no LLM, no I/O. Called after enforce_chat_stance_quality.
+    """
+    regime = brief.interaction_regime
+
+    if regime is None:
+        if brief.task_mode in _RELATIONAL_TASK_MODES or brief.conversation_frame in _RELATIONAL_CONVERSATION_FRAMES:
+            regime = "relational"
+        else:
+            regime = "instrumental"
+
+    if regime == "minimal":
+        return (
+            "Keep this reply very short. Do not ask questions. "
+            "Release Juniper from replying — offer voice, a pause, or continuation later."
+        )
+
+    if regime == "relational":
+        parts = ["This is a companion turn."]
+        move = brief.companion_closing_move
+        if move and move in _COMPANION_CLOSING_MOVE_MAP:
+            parts.append(_COMPANION_CLOSING_MOVE_MAP[move])
+        else:
+            parts.append("Stay present; do not offer next steps, trackers, or support closers.")
+        if "situated_curiosity" in list(brief.response_priorities or []):
+            parts.append("Ask one grounded question from this thread — not a generic reversal.")
+        return " ".join(parts)
+
+    # instrumental (default)
+    parts = ["Answer directly."]
+    if brief.task_mode == "triage":
+        parts.append("Lead with the operational blocker.")
+    return " ".join(parts)
+
+
 def strip_identity_recital_leadin(
     text: str,
     user_message: str,

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1019,6 +1019,7 @@ def _upgrade_brief_for_relational_continuation(brief: ChatStanceBrief) -> ChatSt
         merged.conversation_frame = "reflective"
     if merged.task_mode not in _RELATIONAL_TASK_MODES:
         merged.task_mode = "reflective_dialogue"
+    merged.interaction_regime = "relational"
     merged.response_priorities = _unique(
         list(merged.response_priorities)
         + ["companion_presence", "hold_space", "no_solutioning", "situated_curiosity"],
@@ -2150,10 +2151,12 @@ def _run_autonomy_reducer(ctx: Dict[str, Any], autonomy: Dict[str, Any]):
 
 
 def _inject_prior_stance_to_inputs(ctx: Dict[str, Any], inputs: Dict[str, Any]) -> None:
-    """Copy prior brief summary from ctx into stance inputs when present and non-empty."""
+    """Copy prior brief summary into stance inputs and expose it as a TOP-LEVEL ctx
+    key for the chat_stance_brief.j2 render (which uses ctx.copy()), when present and non-empty."""
     prior = ctx.get("prior_chat_stance_brief")
     if isinstance(prior, dict) and prior:
         inputs["prior_stance"] = prior
+        ctx["prior_stance"] = prior
 
 
 def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -73,6 +73,7 @@ from .spark_narrative import spark_phi_hint, spark_phi_narrative
 from .chat_stance import (
     build_chat_stance_debug_payload,
     build_chat_stance_inputs,
+    compile_speech_contract,
     enforce_chat_stance_quality,
     fallback_chat_stance_brief,
     identity_kernel_with_fallbacks,
@@ -2571,6 +2572,12 @@ async def call_step_services(
                 consumed_by,
             )
             ctx["message_history"] = _format_message_history_for_chat_prompt(ctx.get("messages"))
+            if step.verb_name == "chat_general" and step.step_name == "synthesize_chat_stance_brief":
+                _session_id = str(ctx.get("session_id") or "")
+                if _session_id:
+                    _prior = _prior_stance_cache_get(_session_id)
+                    if _prior:
+                        ctx["prior_chat_stance_brief"] = _prior
             if step.verb_name == "chat_general" and step.step_name == "llm_chat_general":
                 if suppress_chat_general_speech_identity_priming(ctx):
                     logs.append("info <- suppressed identity kernel priming for ordinary chat_general speech turn")
@@ -3830,6 +3837,15 @@ async def call_step_services(
                         semantic_fallback,
                     )
                     ctx["chat_stance_brief"] = parsed_brief.model_dump(mode="json")
+                    _session_id = str(ctx.get("session_id") or "")
+                    if _session_id:
+                        _prior_stance_cache_set(_session_id, {
+                            "interaction_regime": parsed_brief.interaction_regime,
+                            "task_mode": parsed_brief.task_mode,
+                            "response_priorities": list(parsed_brief.response_priorities[:4]),
+                            "response_hazards": list(parsed_brief.response_hazards[:4]),
+                        })
+                    ctx["speech_contract"] = compile_speech_contract(parsed_brief)
                     quality_modified = synthesized_brief != ctx["chat_stance_brief"]
                     ctx["chat_stance_debug"] = build_chat_stance_debug_payload(
                         ctx=ctx,

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -84,6 +84,32 @@ from .llm_lane import resolve_llm_lane_for_step
 
 logger = logging.getLogger("orion.cortex.exec")
 
+import threading as _threading
+
+_PRIOR_STANCE_CACHE: dict[str, tuple[float, dict]] = {}
+_PRIOR_STANCE_LOCK = _threading.Lock()
+_PRIOR_STANCE_TTL_SECONDS: float = 1800.0  # 30 minutes; mutable for tests
+
+
+def _prior_stance_cache_set(session_id: str, summary: dict) -> None:
+    """Store compact brief summary keyed by session_id for next-turn carryforward."""
+    with _PRIOR_STANCE_LOCK:
+        _PRIOR_STANCE_CACHE[session_id] = (time.monotonic(), dict(summary))
+
+
+def _prior_stance_cache_get(session_id: str) -> dict | None:
+    """Return stored brief summary if present and not expired; evict on expiry."""
+    with _PRIOR_STANCE_LOCK:
+        entry = _PRIOR_STANCE_CACHE.get(session_id)
+        if entry is None:
+            return None
+        ts, summary = entry
+        if time.monotonic() - ts > _PRIOR_STANCE_TTL_SECONDS:
+            del _PRIOR_STANCE_CACHE[session_id]
+            return None
+        return dict(summary)
+
+
 _SYSTEM_TELEMETRY_KEYS = {
     "turn_effect",
     "turn_effect_summary",

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -11,6 +11,7 @@ import inspect
 import json
 import logging
 import re
+import threading
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -85,17 +86,23 @@ from .llm_lane import resolve_llm_lane_for_step
 
 logger = logging.getLogger("orion.cortex.exec")
 
-import threading as _threading
-
 _PRIOR_STANCE_CACHE: dict[str, tuple[float, dict]] = {}
-_PRIOR_STANCE_LOCK = _threading.Lock()
+_PRIOR_STANCE_LOCK = threading.Lock()
 _PRIOR_STANCE_TTL_SECONDS: float = 1800.0  # 30 minutes; mutable for tests
+_PRIOR_STANCE_MAX_ENTRIES: int = 1024  # opportunistic-sweep threshold
 
 
 def _prior_stance_cache_set(session_id: str, summary: dict) -> None:
-    """Store compact brief summary keyed by session_id for next-turn carryforward."""
+    """Store compact brief summary keyed by session_id for next-turn carryforward.
+
+    Opportunistically evicts expired entries when the cache grows past a threshold so
+    sessions that are written once and never re-read cannot leak unboundedly."""
     with _PRIOR_STANCE_LOCK:
-        _PRIOR_STANCE_CACHE[session_id] = (time.monotonic(), dict(summary))
+        now = time.monotonic()
+        if len(_PRIOR_STANCE_CACHE) > _PRIOR_STANCE_MAX_ENTRIES:
+            for _k in [k for k, (ts, _) in _PRIOR_STANCE_CACHE.items() if now - ts > _PRIOR_STANCE_TTL_SECONDS]:
+                del _PRIOR_STANCE_CACHE[_k]
+        _PRIOR_STANCE_CACHE[session_id] = (now, dict(summary))
 
 
 def _prior_stance_cache_get(session_id: str) -> dict | None:
@@ -109,6 +116,19 @@ def _prior_stance_cache_get(session_id: str) -> dict | None:
             del _PRIOR_STANCE_CACHE[session_id]
             return None
         return dict(summary)
+
+
+def _load_prior_stance_into_ctx(ctx: Dict[str, Any]) -> None:
+    """Load prior-turn stance summary from the session cache into ctx as a TOP-LEVEL
+    key so chat_stance_brief.j2 (rendered via ctx.copy()) can carry the prior
+    interaction_regime forward. No-op when no session_id or no cached prior."""
+    session_id = str(ctx.get("session_id") or "")
+    if not session_id:
+        return
+    prior = _prior_stance_cache_get(session_id)
+    if prior:
+        ctx["prior_chat_stance_brief"] = prior
+        ctx["prior_stance"] = prior
 
 
 _SYSTEM_TELEMETRY_KEYS = {
@@ -2573,11 +2593,7 @@ async def call_step_services(
             )
             ctx["message_history"] = _format_message_history_for_chat_prompt(ctx.get("messages"))
             if step.verb_name == "chat_general" and step.step_name == "synthesize_chat_stance_brief":
-                _session_id = str(ctx.get("session_id") or "")
-                if _session_id:
-                    _prior = _prior_stance_cache_get(_session_id)
-                    if _prior:
-                        ctx["prior_chat_stance_brief"] = _prior
+                _load_prior_stance_into_ctx(ctx)
             if step.verb_name == "chat_general" and step.step_name == "llm_chat_general":
                 if suppress_chat_general_speech_identity_priming(ctx):
                     logs.append("info <- suppressed identity kernel priming for ordinary chat_general speech turn")

--- a/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
+++ b/services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py
@@ -190,3 +190,34 @@ def test_chat_general_prompt_does_not_prime_identity_recital_examples() -> None:
     assert "not through identity recital" in text
     assert "{% if orion_identity_summary %}" in text
     assert "Chat profile, recall profile, or config edits" in text
+
+
+def test_turn_contract_block_appears_before_task() -> None:
+    prompt = Path("orion/cognition/prompts/chat_general.j2").read_text(encoding="utf-8")
+    assert "{% if speech_contract %}" in prompt
+    assert "TURN CONTRACT" in prompt
+    contract_pos = prompt.find("TURN CONTRACT")
+    task_pos = prompt.find("\nTASK\n")
+    assert task_pos > 0, "TASK section not found"
+    assert contract_pos < task_pos, "TURN CONTRACT must appear before TASK"
+
+
+def test_turn_contract_block_absent_when_speech_contract_falsy() -> None:
+    """Jinja block must be guarded — no TURN CONTRACT emitted when speech_contract is not set."""
+    from jinja2 import Template
+    tmpl = Template(Path("orion/cognition/prompts/chat_general.j2").read_text(encoding="utf-8"))
+    rendered = tmpl.render(
+        user_message="test",
+        message_history="",
+        memory_digest="",
+        orion_identity_summary=[],
+        juniper_relationship_summary=[],
+        response_policy_summary=[],
+        chat_stance_brief="{}",
+        chat_attention_frame=None,
+        situation_prompt_fragment=None,
+        world_context_capsule=None,
+        menu_topic_selection=None,
+        speech_contract=None,
+    )
+    assert "TURN CONTRACT" not in rendered

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -377,3 +377,62 @@ def test_stance_brief_prompt_has_prior_stance_and_regime_fields() -> None:
     assert "companion_closing_move" in prompt
     assert "carry" in prompt.lower() or "carryforward" in prompt.lower() or "carry forward" in prompt.lower()
 
+
+def test_inject_prior_stance_exposes_top_level_ctx_key() -> None:
+    prior = {"interaction_regime": "relational", "task_mode": "reflective_dialogue"}
+    ctx = {"prior_chat_stance_brief": prior}
+    inputs: dict = {}
+    _inject_prior_stance_to_inputs(ctx, inputs)
+    assert inputs.get("prior_stance") == prior
+    assert ctx.get("prior_stance") == prior
+
+
+def test_prior_stance_reaches_stance_brief_render() -> None:
+    from jinja2 import Template
+    from app.executor import _prompt_render_ctx
+    prior = {"interaction_regime": "relational", "task_mode": "reflective_dialogue"}
+    ctx = {"prior_chat_stance_brief": prior}
+    inputs: dict = {}
+    _inject_prior_stance_to_inputs(ctx, inputs)
+    render_ctx = _prompt_render_ctx(ctx)
+    rendered = Template(
+        Path("orion/cognition/prompts/chat_stance_brief.j2").read_text(encoding="utf-8")
+    ).render(**render_ctx)
+    assert "- prior_stance:" in rendered
+    assert "relational" in rendered
+    assert "carry" in rendered.lower()
+
+
+def test_stance_brief_render_omits_prior_stance_when_absent() -> None:
+    from jinja2 import Template
+    from app.executor import _prompt_render_ctx
+    render_ctx = _prompt_render_ctx({})
+    rendered = Template(
+        Path("orion/cognition/prompts/chat_stance_brief.j2").read_text(encoding="utf-8")
+    ).render(**render_ctx)
+    assert "- prior_stance:" not in rendered
+
+
+def test_load_prior_stance_into_ctx_sets_top_level_from_cache() -> None:
+    from app.executor import _load_prior_stance_into_ctx, _prior_stance_cache_set
+    _prior_stance_cache_set("sess-load-test", {"interaction_regime": "relational", "task_mode": "reflective_dialogue"})
+    ctx = {"session_id": "sess-load-test"}
+    _load_prior_stance_into_ctx(ctx)
+    assert ctx.get("prior_stance", {}).get("interaction_regime") == "relational"
+    assert ctx.get("prior_chat_stance_brief", {}).get("interaction_regime") == "relational"
+
+
+def test_load_prior_stance_into_ctx_noop_without_session_id() -> None:
+    from app.executor import _load_prior_stance_into_ctx
+    ctx: dict = {}
+    _load_prior_stance_into_ctx(ctx)
+    assert "prior_stance" not in ctx
+
+
+def test_upgrade_brief_for_relational_continuation_sets_regime() -> None:
+    from app.chat_stance import _upgrade_brief_for_relational_continuation
+    brief = _instrumental_brief()
+    upgraded = _upgrade_brief_for_relational_continuation(brief)
+    assert upgraded.interaction_regime == "relational"
+    assert upgraded.conversation_frame in {"reflective", "playful_relational"}
+

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -216,3 +216,22 @@ def test_enforce_upgrades_companion_thread_continuation() -> None:
     assert "avoid_transactional_closers" in enriched.response_hazards
     assert "companion_presence" in enriched.response_priorities
 
+
+def test_chat_stance_brief_new_fields_default_none() -> None:
+    brief = _relational_brief()
+    assert brief.interaction_regime is None
+    assert brief.companion_closing_move is None
+
+
+def test_chat_stance_brief_new_fields_roundtrip() -> None:
+    brief = _relational_brief(
+        interaction_regime="relational",
+        companion_closing_move="end_with_a_wondering",
+    )
+    d = brief.model_dump(mode="json")
+    assert d["interaction_regime"] == "relational"
+    assert d["companion_closing_move"] == "end_with_a_wondering"
+    restored = ChatStanceBrief(**d)
+    assert restored.interaction_regime == "relational"
+    assert restored.companion_closing_move == "end_with_a_wondering"
+

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -8,6 +8,7 @@ from app.chat_stance import (
     strip_identity_recital_leadin,
     strip_transactional_closers,
 )
+from app.executor import _prior_stance_cache_get, _prior_stance_cache_set
 from orion.schemas.chat_stance import ChatStanceBrief
 
 
@@ -321,4 +322,26 @@ def test_compile_speech_contract_all_closing_moves() -> None:
         brief = _relational_brief(interaction_regime="relational", companion_closing_move=move)
         contract = compile_speech_contract(brief)
         assert expected_word in contract, f"move={move!r}: expected {expected_word!r} in {contract!r}"
+
+
+def test_prior_stance_cache_set_and_get() -> None:
+    _prior_stance_cache_set("sess-abc", {"interaction_regime": "relational", "task_mode": "reflective_dialogue"})
+    result = _prior_stance_cache_get("sess-abc")
+    assert result is not None
+    assert result["interaction_regime"] == "relational"
+
+
+def test_prior_stance_cache_returns_none_for_missing_key() -> None:
+    result = _prior_stance_cache_get("sess-does-not-exist-xyz")
+    assert result is None
+
+
+def test_prior_stance_cache_evicts_expired_entry(monkeypatch) -> None:
+    import app.executor as _exec
+    # Override TTL to 0 to force immediate expiry
+    monkeypatch.setattr(_exec, "_PRIOR_STANCE_TTL_SECONDS", 0)
+    _prior_stance_cache_set("sess-ttl-test", {"interaction_regime": "relational"})
+    import time as _t; _t.sleep(0.01)
+    result = _prior_stance_cache_get("sess-ttl-test")
+    assert result is None
 

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -367,3 +367,11 @@ def test_inject_prior_stance_to_inputs_noop_for_empty_dict() -> None:
     _inject_prior_stance_to_inputs(ctx, inputs)
     assert "prior_stance" not in inputs
 
+
+def test_stance_brief_prompt_has_prior_stance_and_regime_fields() -> None:
+    prompt = Path("orion/cognition/prompts/chat_stance_brief.j2").read_text(encoding="utf-8")
+    assert "prior_stance" in prompt
+    assert "interaction_regime" in prompt
+    assert "companion_closing_move" in prompt
+    assert "carry" in prompt.lower() or "carryforward" in prompt.lower() or "carry forward" in prompt.lower()
+

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -338,9 +338,11 @@ def test_prior_stance_cache_returns_none_for_missing_key() -> None:
 
 
 def test_prior_stance_cache_evicts_expired_entry(monkeypatch) -> None:
-    import app.executor as _exec
-    # Override TTL to 0 to force immediate expiry
-    monkeypatch.setattr(_exec, "_PRIOR_STANCE_TTL_SECONDS", 0)
+    # Override TTL to 0 to force immediate expiry. Patch the function's own module
+    # namespace (__globals__) rather than a fresh `import app.executor`: under the
+    # full suite the executor can be imported under duplicate module identities, and
+    # __globals__ is the exact dict the helpers read _PRIOR_STANCE_TTL_SECONDS from.
+    monkeypatch.setitem(_prior_stance_cache_get.__globals__, "_PRIOR_STANCE_TTL_SECONDS", 0)
     _prior_stance_cache_set("sess-ttl-test", {"interaction_regime": "relational"})
     import time as _t; _t.sleep(0.01)
     result = _prior_stance_cache_get("sess-ttl-test")

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from app.chat_stance import (
+    _inject_prior_stance_to_inputs,
     compile_speech_contract,
     enforce_chat_stance_quality,
     strip_identity_recital_leadin,
@@ -344,4 +345,25 @@ def test_prior_stance_cache_evicts_expired_entry(monkeypatch) -> None:
     import time as _t; _t.sleep(0.01)
     result = _prior_stance_cache_get("sess-ttl-test")
     assert result is None
+
+
+def test_inject_prior_stance_to_inputs_when_present() -> None:
+    ctx = {"prior_chat_stance_brief": {"interaction_regime": "relational", "task_mode": "reflective_dialogue"}}
+    inputs: dict = {}
+    _inject_prior_stance_to_inputs(ctx, inputs)
+    assert inputs.get("prior_stance") == ctx["prior_chat_stance_brief"]
+
+
+def test_inject_prior_stance_to_inputs_noop_when_absent() -> None:
+    ctx: dict = {}
+    inputs: dict = {}
+    _inject_prior_stance_to_inputs(ctx, inputs)
+    assert "prior_stance" not in inputs
+
+
+def test_inject_prior_stance_to_inputs_noop_for_empty_dict() -> None:
+    ctx = {"prior_chat_stance_brief": {}}
+    inputs: dict = {}
+    _inject_prior_stance_to_inputs(ctx, inputs)
+    assert "prior_stance" not in inputs
 

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from app.chat_stance import (
+    compile_speech_contract,
     enforce_chat_stance_quality,
     strip_identity_recital_leadin,
     strip_transactional_closers,
@@ -41,6 +42,21 @@ def _relational_brief(**overrides) -> ChatStanceBrief:
     }
     base.update(overrides)
     return ChatStanceBrief.model_validate(base)
+
+
+def _instrumental_brief(**overrides) -> ChatStanceBrief:
+    base = {
+        "conversation_frame": "mixed",
+        "task_mode": "direct_response",
+        "identity_salience": "low",
+        "user_intent": "direct question",
+        "self_relevance": "answer",
+        "juniper_relevance": "practical",
+        "answer_strategy": "direct",
+        "stance_summary": "short",
+    }
+    base.update(overrides)
+    return ChatStanceBrief(**base)
 
 
 def test_strip_identity_recital_leadin_skips_relational_turn() -> None:
@@ -234,4 +250,75 @@ def test_chat_stance_brief_new_fields_roundtrip() -> None:
     restored = ChatStanceBrief(**d)
     assert restored.interaction_regime == "relational"
     assert restored.companion_closing_move == "end_with_a_wondering"
+
+
+def test_compile_speech_contract_relational_with_closing_move() -> None:
+    brief = _relational_brief(
+        interaction_regime="relational",
+        companion_closing_move="end_with_a_wondering",
+    )
+    contract = compile_speech_contract(brief)
+    assert "companion turn" in contract
+    assert "wondering" in contract
+    assert "let me know" not in contract.lower()
+    assert "if you need" not in contract.lower()
+
+
+def test_compile_speech_contract_relational_default_no_move() -> None:
+    brief = _relational_brief(
+        interaction_regime="relational",
+        response_priorities=["companion_presence", "hold_space"],
+    )
+    contract = compile_speech_contract(brief)
+    assert "companion turn" in contract
+    assert "next steps" in contract or "support closers" in contract
+
+
+def test_compile_speech_contract_relational_situated_curiosity() -> None:
+    brief = _relational_brief(
+        interaction_regime="relational",
+        response_priorities=["companion_presence", "situated_curiosity"],
+    )
+    contract = compile_speech_contract(brief)
+    assert "grounded question" in contract
+    assert "generic reversal" in contract
+
+
+def test_compile_speech_contract_minimal() -> None:
+    brief = _instrumental_brief(interaction_regime="minimal")
+    contract = compile_speech_contract(brief)
+    assert "short" in contract
+    assert "replying" in contract
+
+
+def test_compile_speech_contract_instrumental_direct() -> None:
+    brief = _instrumental_brief(interaction_regime="instrumental")
+    contract = compile_speech_contract(brief)
+    assert "directly" in contract
+    assert "blocker" not in contract
+
+
+def test_compile_speech_contract_instrumental_triage() -> None:
+    brief = _instrumental_brief(interaction_regime="instrumental", task_mode="triage")
+    contract = compile_speech_contract(brief)
+    assert "blocker" in contract
+
+
+def test_compile_speech_contract_derives_regime_from_task_mode() -> None:
+    brief = _relational_brief(interaction_regime=None)
+    contract = compile_speech_contract(brief)
+    assert "companion turn" in contract
+
+
+def test_compile_speech_contract_all_closing_moves() -> None:
+    moves = {
+        "end_with_a_wondering": "wondering",
+        "leave_space_without_offer": "offer",
+        "ground_observation": "observation",
+        "be_with_silence": "silence",
+    }
+    for move, expected_word in moves.items():
+        brief = _relational_brief(interaction_regime="relational", companion_closing_move=move)
+        contract = compile_speech_contract(brief)
+        assert expected_word in contract, f"move={move!r}: expected {expected_word!r} in {contract!r}"
 


### PR DESCRIPTION
## Summary

Fixes relational chat drift by (1) injecting a **deterministic speech contract** near the generation point in `chat_general.j2`, and (2) **persisting the interaction regime across follow-up turns** via an ephemeral in-process session cache. Both halves are verified working end-to-end at runtime (see Verification).

Implements the plan at `docs/superpowers/plans/2026-06-30-relational-stance-v2.md` via subagent-driven development (per-task spec + code-quality review), plus fixes surfaced by the final whole-feature review.

This is a **structural** conversational-behavior change (honors `.cursor/rules/conversational-behavior-anti-slop.mdc`): the reply shape switches purely on structured `ChatStanceBrief` fields through the `compile_speech_contract` choke point after `enforce_chat_stance_quality` — no keyword/phrase trigger lists, regex mode detectors, or "when user says X" prompt patches.

## What changed

- **Schema** (`orion/schemas/chat_stance.py`): add `interaction_regime` (`instrumental|relational|minimal|None`) and `companion_closing_move` (`str|None`) to `ChatStanceBrief`. Nullable, backward-compatible.
- **Compiler** (`services/orion-cortex-exec/app/chat_stance.py`): `compile_speech_contract(brief)` — pure-Python, deterministic, emits a regime-specific contract string (relational companion turn + closing move; minimal release; instrumental/triage). Falls back to deriving the regime from `task_mode`/`conversation_frame` when unset.
- **Session cache** (`services/orion-cortex-exec/app/executor.py`): thread-safe, TTL'd (30 min), bounded in-process cache keyed by `session_id` for next-turn carryforward, with `_load_prior_stance_into_ctx`.
- **Carryforward seam**: `_inject_prior_stance_to_inputs` + top-level `ctx["prior_stance"]` exposure so `chat_stance_brief.j2` (rendered via `ctx.copy()`) can carry a prior relational regime forward.
- **Prompts**:
  - `chat_stance_brief.j2`: `prior_stance` source, schema literals for the new fields, a carryforward rule, and the two new output keys.
  - `chat_general.j2`: guarded `{% if speech_contract %} TURN CONTRACT ... {% endif %}` block injected immediately before `TASK` (near the generation point, ~283 tokens before the end in a representative render).
- **Executor wiring**: load prior stance before the brief renders; after enforce, store a compact summary back to the cache and compile `ctx["speech_contract"]`.

## Files changed
- `orion/schemas/chat_stance.py`
- `orion/cognition/prompts/chat_stance_brief.j2`
- `orion/cognition/prompts/chat_general.j2`
- `services/orion-cortex-exec/app/chat_stance.py`
- `services/orion-cortex-exec/app/executor.py`
- `services/orion-cortex-exec/tests/test_chat_relational_stance.py`
- `services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py`

## Config / infra impact (audited)
- **No new env vars** → nothing to add to `.env` / `.env_example`; nothing to sync.
- **No new dependencies** (stdlib `threading`/`time` + existing Pydantic/Jinja2).
- **No schema-registry change** (`ChatStanceBrief` class already registered; new fields live on the model).
- **No bus channel / grammar / JSON-schema artifact** to regenerate (stance synthesis is prompt-driven + `model_validate`; no constrained-decoding grammar enumerates the keys).
- **Docker rebuild required**: the `.j2` prompts and `orion/` schemas are baked into the `orion-cortex-exec` image at build time (Dockerfile `COPY orion /app/orion`; dev bind-mount is commented out). Rebuild to pick up prompt/schema changes.

## Verification
- **Feature tests:** `test_chat_relational_stance.py` + `test_chat_general_stance_plumbing.py` → **48 passed**.
- **compileall** on `executor.py` + `chat_stance.py` → OK.
- **Runtime render proof — speech contract:** `TURN CONTRACT` renders immediately before `TASK` (~token 1925 of ~1962).
- **Runtime render proof — carryforward:** with a primed prior, `- prior_stance:` and the carryforward rule appear in the rendered `chat_stance_brief.j2`; absent case does not leak.
- **Regression check:** full `orion-cortex-exec` suite diffed at BASE (`9bf449d9`) vs HEAD. **Zero real regressions** from this feature. The only delta is 2 order-dependent failures in the untouched `test_context_exec_depth2_routing.py` (passes 5/5 in isolation; pre-existing collection-order flakiness triggered by adding a new test file). The pre-existing ~59 suite failures are unrelated.

## Test plan
- [ ] Rebuild + restart `orion-cortex-exec` (prompts are baked).
- [ ] Turn 1: "just looking for a shoulder to talk. Can you help keep my mind off things?"
- [ ] Turn 2: "thanks, it's just hard… we have to be out by 5:30am and nurses are in and out all night."
- [ ] Confirm Turn 2 has no support-closer, ends with a grounded wondering/observation, and logs show `chat_stance_brief_quality_guard frame=reflective` on turn 2.

## Follow-ups (not blocking)
- `test_context_exec_depth2_routing.py` (and the executor's duplicate-module import identity under the full suite) has pre-existing test-isolation fragility worth a separate cleanup.