### PR TITLE
fix(vision): wire perception chain for athena mesh bring-up

### DIFF
--- a/mesh-utilities/common/exclude_services.txt
+++ b/mesh-utilities/common/exclude_services.txt
@@ -1,14 +1,8 @@
 ## service to exclude from auto rebuilding
 # one service per line
 orion-llamacpp-neural-host
-orion-vision-edge
 #orion-security-watcher
 orion-vllm-host
-orion-vision-council
-#orion-vision-host
-orion-vision-retina
-orion-vision-scribe
-#orion-vision-window
 orion-rag
 orion-ollama-host
 orion-voip-endpoint

--- a/services/orion-vision-council/.env_example
+++ b/services/orion-vision-council/.env_example
@@ -1,3 +1,15 @@
-#ORION_BUS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+
+ORION_BUS_URL=redis://100.92.216.81:6379/0
 ORION_BUS_ENFORCE_CATALOG=true
+
+CHANNEL_COUNCIL_INTAKE=orion:vision:windows
+CHANNEL_COUNCIL_PUB=orion:vision:events
 CHANNEL_COUNCIL_REQUEST=orion:exec:request:VisionCouncilService
+
+CHANNEL_LLM_REQUEST=orion:exec:request:LLMGatewayService
+CHANNEL_LLM_REPLY_PREFIX=orion:council:reply
+
+COUNCIL_MODEL=gpt-4o
+
+VISION_COUNCIL_HTTP_PORT=8025

--- a/services/orion-vision-council/Dockerfile
+++ b/services/orion-vision-council/Dockerfile
@@ -2,13 +2,19 @@ FROM python:3.10-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends     build-essential     && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt .
+COPY services/orion-vision-council/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app /app/app
+COPY services/orion-vision-council/app ./app
+COPY orion ./orion
 
 ENV PYTHONPATH=/app
+
+EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/orion-vision-council/docker-compose.yml
+++ b/services/orion-vision-council/docker-compose.yml
@@ -1,14 +1,27 @@
 services:
   orion-vision-council:
-    build: .
+    build:
+      context: ../..
+      dockerfile: services/orion-vision-council/Dockerfile
+    container_name: ${PROJECT}-vision-council
+    restart: unless-stopped
+    env_file:
+      - .env
     environment:
-      - ORION_BUS_URL=redis://redis:6379/0
-      - ORION_BUS_ENFORCE_CATALOG=${ORION_BUS_ENFORCE_CATALOG}
-      - CHANNEL_COUNCIL_INTAKE=orion:vision:windows
-      - CHANNEL_COUNCIL_PUB=orion:vision:events
-      - CHANNEL_COUNCIL_REQUEST=orion:exec:request:VisionCouncilService
-    volumes:
-      - ./app:/app/app
-      - ../../orion:/app/orion
-    depends_on:
-      - redis
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - ORION_BUS_URL=${ORION_BUS_URL}
+      - ORION_BUS_ENFORCE_CATALOG=${ORION_BUS_ENFORCE_CATALOG:-true}
+      - CHANNEL_COUNCIL_INTAKE=${CHANNEL_COUNCIL_INTAKE:-orion:vision:windows}
+      - CHANNEL_COUNCIL_PUB=${CHANNEL_COUNCIL_PUB:-orion:vision:events}
+      - CHANNEL_COUNCIL_REQUEST=${CHANNEL_COUNCIL_REQUEST:-orion:exec:request:VisionCouncilService}
+      - CHANNEL_LLM_REQUEST=${CHANNEL_LLM_REQUEST:-orion:exec:request:LLMGatewayService}
+      - CHANNEL_LLM_REPLY_PREFIX=${CHANNEL_LLM_REPLY_PREFIX:-orion:council:reply}
+      - COUNCIL_MODEL=${COUNCIL_MODEL:-gpt-4o}
+    networks:
+      - app-net
+    ports:
+      - "${VISION_COUNCIL_HTTP_PORT:-8025}:8000"
+
+networks:
+  app-net:
+    external: true

--- a/services/orion-vision-edge/.env_example
+++ b/services/orion-vision-edge/.env_example
@@ -58,4 +58,6 @@ YOLO_IMG_SIZE=640
 YOLO_PERSON_RETRY_THRESHOLD=0.15
 EDGE_DEBUG_SAVE_FRAMES=False
 EDGE_DEBUG_DIR=/mnt/debug
-FRAME_STORAGE_DIR=/tmp/orion-frames
+FRAME_STORAGE_DIR=/mnt/telemetry/vision/frames
+# When Host+Router semantic path is active, set false so Window ingests Host artifacts only.
+EDGE_PUBLISH_ARTIFACTS=false

--- a/services/orion-vision-edge/app/detector_worker.py
+++ b/services/orion-vision-edge/app/detector_worker.py
@@ -249,7 +249,10 @@ async def run_detector_loop():
                         None, _save_debug_frame, frame, vision_objects, "all"
                     )
 
-                # Publish Artifact
+                # Publish Artifact (optional; Host chain owns orion:vision:artifacts when disabled)
+                if not settings.EDGE_PUBLISH_ARTIFACTS:
+                    continue
+
                 artifact = VisionEdgeArtifact(
                     artifact_id=str(uuid.uuid4()),
                     correlation_id=str(env.correlation_id),

--- a/services/orion-vision-edge/app/settings.py
+++ b/services/orion-vision-edge/app/settings.py
@@ -91,6 +91,9 @@ class Settings(BaseSettings):
     CHANNEL_VISION_EDGE_HEALTH: str = Field("orion:vision:edge:health", alias="CHANNEL_VISION_EDGE_HEALTH")
     CHANNEL_VISION_EDGE_ERROR: str = Field("orion:vision:edge:error", alias="CHANNEL_VISION_EDGE_ERROR")
 
+    # When false, edge still publishes frame pointers but Host owns orion:vision:artifacts.
+    EDGE_PUBLISH_ARTIFACTS: bool = Field(True, alias="EDGE_PUBLISH_ARTIFACTS")
+
     @property
     def detector_names(self) -> List[str]:
         return [d.strip() for d in self.DETECTORS.split(",") if d.strip()]

--- a/services/orion-vision-edge/docker-compose.yml
+++ b/services/orion-vision-edge/docker-compose.yml
@@ -55,12 +55,13 @@ services:
       - CHANNEL_VISION_ARTIFACTS=${CHANNEL_VISION_ARTIFACTS}
 
       - FRAME_STORAGE_DIR=${FRAME_STORAGE_DIR}
+      - EDGE_PUBLISH_ARTIFACTS=${EDGE_PUBLISH_ARTIFACTS:-false}
       - EDGE_DEBUG_SAVE_FRAMES=${EDGE_DEBUG_SAVE_FRAMES}
       - EDGE_DEBUG_DIR=${EDGE_DEBUG_DIR}
 
     volumes:
       - /mnt/telemetry/orion-vision-edge
-      - /tmp/orion-frames:/mnt/frames
+      - /mnt/telemetry/vision/frames:/mnt/telemetry/vision/frames
       - /tmp/orion-debug:/mnt/debug
 
     ports:

--- a/services/orion-vision-host/.env_example
+++ b/services/orion-vision-host/.env_example
@@ -17,8 +17,8 @@ TRANSFORMERS_CACHE=/mnt/telemetry/models/hf/transformers
 VISION_PROFILES_PATH=/app/config/vision_profiles.yaml
 VISION_ENABLED_PROFILES=pipeline_retina_fast,retina_detect_open_vocab,embed_image,vlm_caption
 
-# Caption VLM — must fit VRAM (default ~2.7B BLIP-2 class; override e.g. for IDEFICS / larger VLMs).
-VISION_VLM_MODEL_ID=Salesforce/blip2-opt-2.7b
+# Caption VLM — must fit VRAM. blip-image-captioning-base is lighter/reliable on P100 cohabitation.
+VISION_VLM_MODEL_ID=Salesforce/blip-image-captioning-base
 VISION_VLM_MAX_TOKENS=128
 VISION_VLM_TEMPERATURE=0.4
 

--- a/services/orion-vision-host/app/main.py
+++ b/services/orion-vision-host/app/main.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 from loguru import logger
 
 from orion.core.bus.async_service import OrionBusAsync
-from orion.core.bus.bus_schemas import BaseEnvelope
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.schemas.vision import (
     VisionTaskRequestPayload,
     VisionTaskResultPayload,
@@ -280,7 +280,7 @@ class VisionHostService:
             logger.error(f"[BUS] payload validation failed: {e}")
             return
 
-        corr_id = envelope.correlation_id or str(uuid.uuid4())
+        corr_id = str(envelope.correlation_id) if envelope.correlation_id else str(uuid.uuid4())
         reply_to = envelope.reply_to or f"{settings.CHANNEL_VISIONHOST_REPLY_PREFIX}:{corr_id}"
 
         task = VisionTask(
@@ -321,17 +321,15 @@ class VisionHostService:
             meta=result_meta,
         )
 
-        # Publish reply
-        reply_envelope = BaseEnvelope(
-            schema_id="vision.task.result",
-            schema_version="1.0.0",
+        # Publish reply (orion.envelope wrapper; kind carries vision.task.result)
+        host_ref = ServiceRef(name=settings.SERVICE_NAME, version=settings.SERVICE_VERSION)
+        reply_envelope = source_envelope.derive_child(
             kind="vision.task.result",
-            source=f"{settings.SERVICE_NAME}:{settings.SERVICE_VERSION}",
-            correlation_id=res.corr_id,
-            causality_chain=source_envelope.causality_chain + [source_envelope.correlation_id] if source_envelope.correlation_id else [],
-            payload=result_payload
+            source=host_ref,
+            payload=result_payload,
         )
-        await self.bus.publish(res.reply_channel, reply_envelope)
+        reply_channel = source_envelope.reply_to or f"{settings.CHANNEL_VISIONHOST_REPLY_PREFIX}:{res.corr_id}"
+        await self.bus.publish(reply_channel, reply_envelope)
 
         if res.ok and artifact_payload:
              await self._publish_artifact_broadcast(artifact_payload, source_envelope)
@@ -340,14 +338,11 @@ class VisionHostService:
         return build_artifact_payload(res)
 
     async def _publish_artifact_broadcast(self, payload: VisionArtifactPayload, source_envelope: BaseEnvelope):
-        envelope = BaseEnvelope(
-            schema_id="vision.artifact",
-            schema_version="1.0.0",
+        host_ref = ServiceRef(name=settings.SERVICE_NAME, version=settings.SERVICE_VERSION)
+        envelope = source_envelope.derive_child(
             kind="vision.artifact",
-            source=f"{settings.SERVICE_NAME}:{settings.SERVICE_VERSION}",
-            correlation_id=payload.correlation_id,
-            causality_chain=source_envelope.causality_chain + [source_envelope.correlation_id] if source_envelope.correlation_id else [],
-            payload=payload
+            source=host_ref,
+            payload=payload,
         )
 
         await self.bus.publish(settings.CHANNEL_VISIONHOST_PUB, envelope)
@@ -437,7 +432,10 @@ async def http_task(payload: Dict[str, Any]):
         if res.ok and res.artifacts and service.bus:
              # Create dummy source envelope
              dummy_env = BaseEnvelope(
-                 schema_id="http", schema_version="1", kind="http", source="http", correlation_id=corr_id, payload={}
+                 kind="http.direct",
+                 source=ServiceRef(name=settings.SERVICE_NAME, version=settings.SERVICE_VERSION),
+                 correlation_id=uuid.UUID(corr_id),
+                 payload={},
              )
              # Reuse creation logic
              art_payload = service._create_artifact_payload(res, dummy_env)

--- a/services/orion-vision-host/app/model_manager.py
+++ b/services/orion-vision-host/app/model_manager.py
@@ -154,8 +154,20 @@ class ModelManager:
             torch_dtype = self._torch_dtype(dtype, device)
             logger.info(f"[MODEL] loading vlm profile={profile_name} device={device} dtype={torch_dtype} id={model_id}")
 
-            processor = AutoProcessor.from_pretrained(model_id)
-            model = AutoModelForVision2Seq.from_pretrained(model_id, torch_dtype=torch_dtype)
+            mid = model_id.lower()
+            if "blip2" in mid:
+                from transformers import Blip2ForConditionalGeneration, Blip2Processor
+
+                processor = Blip2Processor.from_pretrained(model_id)
+                model = Blip2ForConditionalGeneration.from_pretrained(model_id, torch_dtype=torch_dtype)
+            elif "blip" in mid:
+                from transformers import BlipForConditionalGeneration, BlipProcessor
+
+                processor = BlipProcessor.from_pretrained(model_id)
+                model = BlipForConditionalGeneration.from_pretrained(model_id, torch_dtype=torch_dtype)
+            else:
+                processor = AutoProcessor.from_pretrained(model_id)
+                model = AutoModelForVision2Seq.from_pretrained(model_id, torch_dtype=torch_dtype)
 
             model.eval()
             if device.startswith("cuda"):

--- a/services/orion-vision-host/app/runner.py
+++ b/services/orion-vision-host/app/runner.py
@@ -80,6 +80,12 @@ class VisionRunner:
     def _is_enabled(self, name: str) -> bool:
         return name in self.enabled
 
+    def _resolve_dtype(self, p: ProfileDef) -> str:
+        profile_dtype = (p.dtype or "").strip().lower()
+        if profile_dtype and profile_dtype != "auto":
+            return profile_dtype
+        return (settings.VISION_DTYPE or "auto").strip().lower()
+
     def warm_profiles(self) -> List[str]:
         """
         Load weights for profiles with warm_on_start=true that are enabled and implemented.
@@ -109,7 +115,7 @@ class VisionRunner:
         return warmed
 
     def _warm_profile_backend(self, p: ProfileDef, device: str) -> None:
-        dtype = p.dtype or settings.VISION_DTYPE
+        dtype = self._resolve_dtype(p)
         if p.kind == "embedding":
             model_id = (
                 p.model_id if p.model_id and not p.model_id.startswith("REPLACE_ME") else self.DEFAULT_EMBED_MODEL
@@ -318,7 +324,7 @@ class VisionRunner:
         img = _load_image_from_request(request)
 
         model_id = p.model_id if p.model_id and not p.model_id.startswith("REPLACE_ME") else self.DEFAULT_EMBED_MODEL
-        dtype = p.dtype or "auto"
+        dtype = self._resolve_dtype(p)
 
         model, processor = self.models.load_siglip_image_embedder(
             profile_name=p.name,
@@ -330,7 +336,11 @@ class VisionRunner:
 
         inputs = processor(images=img, return_tensors="pt")
         if device.startswith("cuda"):
-            inputs = {k: v.to(device) for k, v in inputs.items()}
+            model_dtype = next(model.parameters()).dtype
+            inputs = {
+                k: v.to(device=device, dtype=model_dtype if torch.is_floating_point(v) else v.dtype)
+                for k, v in inputs.items()
+            }
 
         with torch.inference_mode():
             if hasattr(model, "get_image_features"):
@@ -378,7 +388,7 @@ class VisionRunner:
         img = _load_image_from_request(request)
 
         model_id = p.model_id if p.model_id and not p.model_id.startswith("REPLACE_ME") else self.DEFAULT_GDINO_MODEL
-        dtype = p.dtype or "auto"
+        dtype = self._resolve_dtype(p)
 
         # Prompts:
         prompts = request.get("prompts")
@@ -408,7 +418,11 @@ class VisionRunner:
 
         inputs = processor(images=img, text=text, return_tensors="pt")
         if device.startswith("cuda"):
-            inputs = {k: v.to(device) for k, v in inputs.items()}
+            model_dtype = next(model.parameters()).dtype
+            inputs = {
+                k: v.to(device=device, dtype=model_dtype if torch.is_floating_point(v) else v.dtype)
+                for k, v in inputs.items()
+            }
 
         with torch.inference_mode():
             outputs = model(**inputs)
@@ -512,7 +526,7 @@ class VisionRunner:
         if p.model_id and not p.model_id.startswith("REPLACE_ME"):
             model_id = p.model_id
 
-        dtype = p.dtype or "auto"
+        dtype = self._resolve_dtype(p)
 
         model, processor = self.models.load_vlm_captioner(
             profile_name=p.name,
@@ -536,7 +550,11 @@ class VisionRunner:
         inputs = processor(images=img, text=text_prompt, return_tensors="pt")
 
         if device.startswith("cuda"):
-            inputs = {k: v.to(device) for k, v in inputs.items()}
+            model_dtype = next(model.parameters()).dtype
+            inputs = {
+                k: v.to(device=device, dtype=model_dtype if torch.is_floating_point(v) else v.dtype)
+                for k, v in inputs.items()
+            }
 
         max_tokens = settings.VISION_VLM_MAX_TOKENS
         temperature = settings.VISION_VLM_TEMPERATURE

--- a/services/orion-vision-host/docker-compose.yml
+++ b/services/orion-vision-host/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       - /mnt/telemetry/orion-vision-host:/mnt/telemetry/orion-vision-host
       - /mnt/telemetry/models/vision:/mnt/telemetry/models/vision
       - /mnt/telemetry/models/hf:/mnt/telemetry/models/hf
+      - /mnt/telemetry/vision/frames:/mnt/telemetry/vision/frames:ro
 
     ports:
       - "${HOST_PORT}:6600"

--- a/services/orion-vision-host/requirements.txt
+++ b/services/orion-vision-host/requirements.txt
@@ -14,6 +14,8 @@ opencv-python-headless==4.10.0.84
 transformers==4.44.2
 accelerate==0.34.2
 safetensors==0.4.5
+sentencepiece==0.2.0
+protobuf==5.28.2
 
 # GroundingDINO transformer deps commonly needed
 timm==1.0.9

--- a/services/orion-vision-scribe/.env_example
+++ b/services/orion-vision-scribe/.env_example
@@ -1,3 +1,14 @@
-#ORION_BUS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+
+ORION_BUS_URL=redis://100.92.216.81:6379/0
 ORION_BUS_ENFORCE_CATALOG=true
+
+CHANNEL_SCRIBE_INTAKE=orion:vision:events
+CHANNEL_SCRIBE_PUB=orion:vision:scribe:pub
 CHANNEL_SCRIBE_REQUEST=orion:exec:request:VisionScribeService
+
+CHANNEL_SQL_WRITE=orion:collapse:sql-write
+CHANNEL_RDF_ENQUEUE=orion:rdf-collapse:enqueue
+CHANNEL_VECTOR_WRITE=orion:vector:write
+
+VISION_SCRIBE_HTTP_PORT=8026

--- a/services/orion-vision-scribe/Dockerfile
+++ b/services/orion-vision-scribe/Dockerfile
@@ -2,13 +2,19 @@ FROM python:3.10-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends     build-essential     && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt .
+COPY services/orion-vision-scribe/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app /app/app
+COPY services/orion-vision-scribe/app ./app
+COPY orion ./orion
 
 ENV PYTHONPATH=/app
+
+EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/orion-vision-scribe/docker-compose.yml
+++ b/services/orion-vision-scribe/docker-compose.yml
@@ -1,13 +1,27 @@
 services:
   orion-vision-scribe:
-    build: .
+    build:
+      context: ../..
+      dockerfile: services/orion-vision-scribe/Dockerfile
+    container_name: ${PROJECT}-vision-scribe
+    restart: unless-stopped
+    env_file:
+      - .env
     environment:
-      - ORION_BUS_URL=redis://redis:6379/0
-      - ORION_BUS_ENFORCE_CATALOG=${ORION_BUS_ENFORCE_CATALOG}
-      - CHANNEL_SCRIBE_INTAKE=orion:vision:events
-      - CHANNEL_SCRIBE_REQUEST=orion:exec:request:VisionScribeService
-    volumes:
-      - ./app:/app/app
-      - ../../orion:/app/orion
-    depends_on:
-      - redis
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - ORION_BUS_URL=${ORION_BUS_URL}
+      - ORION_BUS_ENFORCE_CATALOG=${ORION_BUS_ENFORCE_CATALOG:-true}
+      - CHANNEL_SCRIBE_INTAKE=${CHANNEL_SCRIBE_INTAKE:-orion:vision:events}
+      - CHANNEL_SCRIBE_PUB=${CHANNEL_SCRIBE_PUB:-orion:vision:scribe:pub}
+      - CHANNEL_SCRIBE_REQUEST=${CHANNEL_SCRIBE_REQUEST:-orion:exec:request:VisionScribeService}
+      - CHANNEL_SQL_WRITE=${CHANNEL_SQL_WRITE:-orion:collapse:sql-write}
+      - CHANNEL_RDF_ENQUEUE=${CHANNEL_RDF_ENQUEUE:-orion:rdf-collapse:enqueue}
+      - CHANNEL_VECTOR_WRITE=${CHANNEL_VECTOR_WRITE:-orion:vector:write}
+    networks:
+      - app-net
+    ports:
+      - "${VISION_SCRIBE_HTTP_PORT:-8026}:8000"
+
+networks:
+  app-net:
+    external: true


### PR DESCRIPTION
## Summary

Live-stack bring-up on athena to run the full perception chain: **edge → frame-router → vision-host → window**, with council/scribe re-enabled in the mesh.

Fixes three blocker classes from diagnostics:

1. **Infrastructure / path visibility** — edge and router share `/mnt/telemetry/vision/frames`; host mounts frames read-only; edge can skip duplicate artifact publish when the host chain is active (`EDGE_PUBLISH_ARTIFACTS=false`).
2. **Bus contract (v2 envelope)** — host replies/artifacts use `orion.envelope` + `derive_child`; `corr_id` coerced to `str` on intake; replies publish to `source_envelope.reply_to`.
3. **Inference reliability on P100** — `_resolve_dtype()` honors `VISION_DTYPE` over profile `auto`; inputs cast to model dtype; explicit BLIP/BLIP-2 loaders; default caption model → `blip-image-captioning-base`; `sentencepiece` + `protobuf` for embed warm.

Council/scribe moved to mesh compose pattern (repo-root build, `app-net`, remote bus) and removed from `exclude_services.txt`.

## Live verification (athena, 2026-07-01)

| Check | Result |
|-------|--------|
| Host `/ready` | `true`, all profiles warmed |
| Router | `host_replies_total > 0`, dispatches flowing |
| Host tasks | `ok: true`, ~0.7–1.2s on `cuda:0` |
| Window `/api/vision-window/current` | `stream_id: cam0`, captions + detections |
| GPU | ~7.8 GB on GPU 1 |

## Files changed (17)

- `mesh-utilities/common/exclude_services.txt`
- `services/orion-vision-edge/` — shared frames, `EDGE_PUBLISH_ARTIFACTS`, compose volume
- `services/orion-vision-host/` — envelope v2, corr_id, dtype, BLIP loaders, frames mount, deps
- `services/orion-vision-council/` — mesh compose + Dockerfile + `.env_example`
- `services/orion-vision-scribe/` — mesh compose + Dockerfile + `.env_example`

## Test plan

- [x] Live athena: shared frames; router dispatches (not `image_path_not_visible`)
- [x] Live athena: host `/ready` true; `[VISION_TASK] ok: true`
- [x] Live athena: router replies; window captions + detections
- [x] `PYTHONPATH=. ./venv/bin/python -m compileall services/orion-vision-host/app services/orion-vision-edge/app` — exit 0
- [ ] `./scripts/test_service.sh orion-vision-host -q`
- [ ] `./scripts/test_service.sh orion-vision-frame-router -q`

## Known follow-ups (out of scope)

- **Vision-council** still uses legacy cortex envelope format — needs v2 migration.
- BLIP-base caption prefix bleed — separate prompt fix.
- Post-merge: `python scripts/sync_local_env_from_example.py` + recreate containers.

## Related

Builds on #765 (`feat/vision-caption-provenance-v1`, merged).