### PR TITLE
fix(vision-retina): use shared mesh bus and fix compose startup

### DIFF
--- a/services/orion-vision-retina/.env_example
+++ b/services/orion-vision-retina/.env_example
@@ -1,4 +1,4 @@
-ORION_BUS_URL=redis://localhost:6379/0
+ORION_BUS_URL=redis://100.92.216.81:6379/0
 ORION_BUS_ENFORCE_CATALOG=false
 
 CHANNEL_RETINA_PUB=orion:vision:frames

--- a/services/orion-vision-retina/Dockerfile
+++ b/services/orion-vision-retina/Dockerfile
@@ -13,6 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY services/orion-vision-retina/app ./app
 COPY orion ./orion
 
-ENV PYTHONPATH=/app
+ENV PYTHONPATH=/app \
+    PYTHONUNBUFFERED=1
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/orion-vision-retina/README.md
+++ b/services/orion-vision-retina/README.md
@@ -62,7 +62,7 @@ cp .env_example .env
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `ORION_BUS_URL` | `redis://localhost:6379/0` | Redis pub/sub (use mesh URL in prod) |
+| `ORION_BUS_URL` | `redis://100.92.216.81:6379/0` | Redis pub/sub — shared mesh bus (same as sibling vision services) |
 | `RETINA_SOURCE_TYPE` | `folder` | `folder`, `mock`, `rtsp`, `webcam` |
 | `RETINA_SOURCE` | `/mnt/telemetry/vision/intake` | Folder path, RTSP URL, or webcam index |
 | `RETINA_SOURCE_PATH` | — | Legacy alias for `RETINA_SOURCE` |

--- a/services/orion-vision-retina/app/settings.py
+++ b/services/orion-vision-retina/app/settings.py
@@ -44,6 +44,13 @@ class Settings(BaseSettings):
             return 90
         return max(1, min(100, n))
 
+    @field_validator("RETINA_WIDTH", "RETINA_HEIGHT", mode="before")
+    @classmethod
+    def _blank_to_none(cls, v: object) -> object:
+        if isinstance(v, str) and v.strip() == "":
+            return None
+        return v
+
     @model_validator(mode="after")
     def _apply_source_path_alias(self) -> "Settings":
         if self.RETINA_SOURCE_PATH and "RETINA_SOURCE" not in self.model_fields_set:

--- a/services/orion-vision-retina/docker-compose.yml
+++ b/services/orion-vision-retina/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: services/orion-vision-retina/Dockerfile
     container_name: orion-vision-retina
     environment:
-      - ORION_BUS_URL=${ORION_BUS_URL:-redis://redis:6379/0}
+      - ORION_BUS_URL=${ORION_BUS_URL:-redis://100.92.216.81:6379/0}
       - ORION_BUS_ENFORCE_CATALOG=${ORION_BUS_ENFORCE_CATALOG:-false}
       - CHANNEL_RETINA_PUB=${CHANNEL_RETINA_PUB:-orion:vision:frames}
       - CHANNEL_RETINA_ERROR=${CHANNEL_RETINA_ERROR:-orion:vision:retina:error}
@@ -27,13 +27,12 @@ services:
       - ../../orion:/app/orion
       - /mnt/telemetry/vision/frames:/mnt/telemetry/vision/frames
       - /mnt/telemetry/vision/intake:/mnt/telemetry/vision/intake
-    depends_on:
-      - redis
     # Optional USB webcam:
     # devices:
     #   - /dev/video0:/dev/video0
+    networks:
+      - app-net
 
-  redis:
-    image: redis:7-alpine
-    ports:
-      - "6379:6379"
+networks:
+  app-net:
+    external: true

--- a/tests/test_vision_retina_settings.py
+++ b/tests/test_vision_retina_settings.py
@@ -67,3 +67,34 @@ def test_jpeg_quality_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
     assert s.JPEG_QUALITY == 100
     s2 = _reload_settings(monkeypatch, JPEG_QUALITY="-5")
     assert s2.JPEG_QUALITY == 1
+
+
+@pytest.mark.parametrize(
+    ("env_key", "env_value"),
+    [
+        ("RETINA_WIDTH", ""),
+        ("RETINA_HEIGHT", ""),
+        ("RETINA_WIDTH", "   "),
+        ("RETINA_HEIGHT", "   "),
+    ],
+)
+def test_blank_retina_dimensions_coerced_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+    env_key: str,
+    env_value: str,
+) -> None:
+    """Docker compose passes empty RETINA_WIDTH/HEIGHT; must not crash Settings()."""
+    s = _reload_settings(monkeypatch, **{env_key: env_value})
+    assert getattr(s, env_key) is None
+
+
+def test_blank_retina_width_and_height_together(monkeypatch: pytest.MonkeyPatch) -> None:
+    s = _reload_settings(monkeypatch, RETINA_WIDTH="", RETINA_HEIGHT="")
+    assert s.RETINA_WIDTH is None
+    assert s.RETINA_HEIGHT is None
+
+
+def test_retina_dimensions_explicit_integers(monkeypatch: pytest.MonkeyPatch) -> None:
+    s = _reload_settings(monkeypatch, RETINA_WIDTH="640", RETINA_HEIGHT="480")
+    assert s.RETINA_WIDTH == 640
+    assert s.RETINA_HEIGHT == 480


### PR DESCRIPTION
## Summary

- **Remove bundled Redis** from `orion-vision-retina` docker-compose — it was binding host port `6379`, colliding with `orion-orion-athena-bus-core` on the athena mesh.
- **Join external `app-net`** and point `ORION_BUS_URL` at the shared mesh bus (`redis://100.92.216.81:6379/0`), matching sibling vision services (edge, host, council, scribe).
- **Fix compose startup crash**: docker-compose passes empty strings for `RETINA_WIDTH`/`RETINA_HEIGHT`; added a pydantic validator to coerce blanks to `None`.
- **Enable `PYTHONUNBUFFERED=1`** in the Dockerfile so loguru `[RETINA]` lines appear in `docker logs` immediately.

## Test plan

- [x] `PYTHONPATH=. ./venv/bin/python -m pytest tests/test_vision_retina_*.py -q` → 25 passed
- [x] `docker compose build && docker compose up -d` in `services/orion-vision-retina` → container starts without port conflict
- [x] `docker logs orion-vision-retina` shows `[RETINA] Started → orion:vision:frames` and `[RETINA] Published frame pointer: ...`
- [x] `redis-cli SUBSCRIBE orion:vision:frames` on mesh bus → `vision.frame.pointer` envelopes with `source.name=vision-retina`

## Files changed

- `services/orion-vision-retina/docker-compose.yml`
- `services/orion-vision-retina/.env_example`
- `services/orion-vision-retina/app/settings.py`
- `services/orion-vision-retina/Dockerfile`
- `services/orion-vision-retina/README.md`
- `tests/test_vision_retina_settings.py`