### PR TITLE
fix(vision-council): route LLM inference through metacog lane

### DIFF
--- a/services/orion-vision-council/.env_example
+++ b/services/orion-vision-council/.env_example
@@ -11,5 +11,6 @@ CHANNEL_LLM_REQUEST=orion:exec:request:LLMGatewayService
 CHANNEL_LLM_REPLY_PREFIX=orion:council:reply
 
 COUNCIL_MODEL=gpt-4o
+COUNCIL_LLM_ROUTE=metacog
 
 VISION_COUNCIL_HTTP_PORT=8025

--- a/services/orion-vision-council/app/main.py
+++ b/services/orion-vision-council/app/main.py
@@ -193,6 +193,7 @@ class CouncilService:
 
         chat_request = ChatRequestPayload(
             model=settings.COUNCIL_MODEL,
+            route=settings.COUNCIL_LLM_ROUTE,
             messages=[
                 LLMMessage(role="system", content="You are a visual analysis AI. Output strict JSON."),
                 LLMMessage(role="user", content=prompt)

--- a/services/orion-vision-council/app/settings.py
+++ b/services/orion-vision-council/app/settings.py
@@ -23,3 +23,4 @@ class Settings(BaseSettings):
 
     # Config
     COUNCIL_MODEL: str = "gpt-4o"
+    COUNCIL_LLM_ROUTE: str = "metacog"

--- a/services/orion-vision-council/docker-compose.yml
+++ b/services/orion-vision-council/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - CHANNEL_LLM_REQUEST=${CHANNEL_LLM_REQUEST:-orion:exec:request:LLMGatewayService}
       - CHANNEL_LLM_REPLY_PREFIX=${CHANNEL_LLM_REPLY_PREFIX:-orion:council:reply}
       - COUNCIL_MODEL=${COUNCIL_MODEL:-gpt-4o}
+      - COUNCIL_LLM_ROUTE=${COUNCIL_LLM_ROUTE:-metacog}
     networks:
       - app-net
     ports:


### PR DESCRIPTION
## Summary

Vision council was using the LLM gateway's default **chat** route (`atlas-worker-1:8011`), which times out on the athena mesh. This adds a service-local `COUNCIL_LLM_ROUTE` setting (default `metacog`) and passes it as `ChatRequestPayload.route` so council inference uses the metacog lane (`atlas-worker-2:8012`) without changing global LLM gateway routing.

## Changes

- `COUNCIL_LLM_ROUTE=metacog` in settings, `.env_example`, and `docker-compose.yml`
- `_call_llm` passes `route=settings.COUNCIL_LLM_ROUTE` on LLM gateway RPC requests

## Test plan

- [x] Live on athena: `docker exec orion-athena-vision-council printenv COUNCIL_LLM_ROUTE` → `metacog`
- [x] LLM gateway logs: `route=metacog request_source=vision-council` → `HTTP/1.1 200 OK` on `100.121.214.30:8012`
- [x] Council publishes `vision.event.bundle` on `orion:vision:events`; scribe consumes and acks
- [x] Global chat route unchanged (`8011` / `atlas-worker-1`) for hub and other services
- [ ] After merge: `PROJECT=orion-athena docker compose up -d --build` in `services/orion-vision-council`

## Files changed

- `services/orion-vision-council/app/settings.py`
- `services/orion-vision-council/app/main.py`
- `services/orion-vision-council/.env_example`
- `services/orion-vision-council/docker-compose.yml`

## Out of scope

- Scribe SQL/RDF payload shape mismatches (`SqlWriteRequest` / `RdfWriteRequest`) — pre-existing, separate fix