### PR TITLE
Add live vision persistence smoke and fix artifacts bus catalog.

### DIFF
--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -724,7 +724,10 @@ channels:
     kind: "event"
     schema_id: "VisionArtifactPayload"
     producer_services: ["orion-vision-edge", "orion-vision-host"]
-    consumer_services: ["orion-security-watcher", "orion-vision-council"]
+    consumer_services:
+      - "orion-security-watcher"
+      - "orion-vision-window"
+      - "orion-vision-council"
     stability: "experimental"
     since: "2026-01-08"
 

--- a/scripts/smoke_vision_persistence_live.sh
+++ b/scripts/smoke_vision_persistence_live.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# smoke_vision_persistence_live.sh
+#
+# Verifies the Orion Vision event persistence path:
+#   orion:vision:events -> orion-vision-scribe -> sql-write + rdf enqueue
+#
+# MODES (explicit selection required when deps are missing):
+#   VISION_PERSISTENCE_SMOKE_MODE=live
+#       Requires ORION_BUS_URL and DATABASE_URL (or POSTGRES_URI).
+#       Asserts scribe ack, vision_events row, and RDF enqueue or confirm.
+#
+#   VISION_PERSISTENCE_SMOKE_MODE=contract
+#       In-process contract validation (no Redis/Postgres). Does NOT claim live persistence.
+#
+# ENV:
+#   ORION_BUS_URL
+#   DATABASE_URL (or POSTGRES_URI)
+#   VISION_PERSISTENCE_SMOKE_TIMEOUT_SEC (default 30)
+#   VISION_PERSISTENCE_SMOKE_MODE
+#   VISION_PERSISTENCE_SMOKE_PYTHON (optional interpreter override)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+pick_python() {
+    local main_root="${REPO_ROOT}"
+    if git -C "${REPO_ROOT}" rev-parse --git-common-dir >/dev/null 2>&1; then
+        main_root="$(cd "$(git -C "${REPO_ROOT}" rev-parse --path-format=absolute --git-common-dir)/.." && pwd)"
+    fi
+    if [[ -n "${VISION_PERSISTENCE_SMOKE_PYTHON:-}" ]]; then
+        echo "${VISION_PERSISTENCE_SMOKE_PYTHON}"
+    elif [[ -x "${REPO_ROOT}/orion_dev/bin/python" ]]; then
+        echo "${REPO_ROOT}/orion_dev/bin/python"
+    elif [[ -x "${main_root}/orion_dev/bin/python" ]]; then
+        echo "${main_root}/orion_dev/bin/python"
+    elif [[ -x "${REPO_ROOT}/venv/bin/python" ]]; then
+        echo "${REPO_ROOT}/venv/bin/python"
+    elif [[ -x "${main_root}/venv/bin/python" ]]; then
+        echo "${main_root}/venv/bin/python"
+    else
+        echo "python3"
+    fi
+}
+
+PY="$(pick_python)"
+export PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+exec "${PY}" -m scripts.vision_persistence_smoke "$@"

--- a/scripts/vision_persistence_smoke.py
+++ b/scripts/vision_persistence_smoke.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""
+Helpers for scripts/smoke_vision_persistence_live.sh.
+
+Live mode exercises the real bus + Postgres mesh. Contract mode validates payload
+shape, SQL coercion, RDF N-Triples, and channel/kind constants without claiming
+live persistence.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any, Optional
+from uuid import UUID
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from orion.core.bus.async_service import OrionBusAsync  # noqa: E402
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef  # noqa: E402
+from orion.schemas.rdf import RdfWriteRequest  # noqa: E402
+from orion.schemas.vision import (  # noqa: E402
+    VisionEventBundleItem,
+    VisionEventPayload,
+    VisionScribeAckPayload,
+)
+
+CHANNEL_VISION_EVENTS = "orion:vision:events"
+CHANNEL_SCRIBE_PUB = "orion:vision:scribe:pub"
+CHANNEL_SQL_WRITE = "orion:vision:events:sql-write"
+CHANNEL_RDF_ENQUEUE = "orion:rdf:enqueue"
+CHANNEL_RDF_CONFIRM = "orion:rdf:confirm"
+
+KIND_VISION_EVENT_BUNDLE = "vision.event.bundle"
+KIND_VISION_SCRIBE_ACK = "vision.scribe.ack"
+KIND_VISION_EVENT_V1 = "vision.event.v1"
+KIND_RDF_WRITE_REQUEST = "rdf.write.request"
+
+SMOKE_SERVICE = ServiceRef(name="vision-persistence-smoke", version="0.1.0")
+
+
+def new_smoke_ids() -> tuple[str, UUID, str]:
+    ts = int(time.time())
+    event_id = f"vision-smoke-{ts}-{uuid.uuid4().hex[:8]}"
+    correlation_id = uuid.uuid4()
+    narrative = f"Vision persistence live smoke event {event_id}"
+    return event_id, correlation_id, narrative
+
+
+def build_smoke_bundle_item(
+    event_id: str,
+    narrative: str,
+    *,
+    event_type: str = "smoke_test",
+) -> VisionEventBundleItem:
+    return VisionEventBundleItem(
+        event_id=event_id,
+        event_type=event_type,
+        narrative=narrative,
+        entities=["orion", "vision", "smoke"],
+        tags=["smoke", "vision", "persistence"],
+        confidence=0.99,
+        salience=0.5,
+        evidence_refs=["artifact:smoke"],
+    )
+
+
+def build_vision_event_payload(events: list[VisionEventBundleItem]) -> VisionEventPayload:
+    return VisionEventPayload(events=events)
+
+
+def build_intake_envelope(
+    correlation_id: UUID,
+    payload: VisionEventPayload,
+) -> BaseEnvelope:
+    return BaseEnvelope(
+        kind=KIND_VISION_EVENT_BUNDLE,
+        source=SMOKE_SERVICE,
+        correlation_id=correlation_id,
+        payload=payload.model_dump(mode="json"),
+    )
+
+
+def expected_sql_row_fields(
+    item: VisionEventBundleItem,
+    correlation_id: UUID,
+) -> dict[str, Any]:
+    return {
+        "event_id": item.event_id,
+        "event_type": item.event_type,
+        "narrative": item.narrative,
+        "entities": item.entities,
+        "tags": item.tags,
+        "confidence": item.confidence,
+        "salience": item.salience,
+        "evidence_refs": item.evidence_refs,
+        "correlation_id": str(correlation_id),
+    }
+
+
+def rdf_ntriple_markers(
+    event_id: str,
+    narrative: str,
+    event_type: str,
+    entities: list[str],
+) -> list[str]:
+    uri = f"http://conjourney.net/event/{event_id}"
+    markers = [uri, narrative, event_type]
+    markers.extend(entities)
+    return markers
+
+
+def build_rdf_write_request(event_id: str, nt_content: str) -> RdfWriteRequest:
+    return RdfWriteRequest(
+        id=event_id,
+        source="vision-scribe",
+        graph="orion:vision",
+        triples=nt_content,
+    )
+
+
+def _purge_app_modules() -> None:
+    for mod_name in list(sys.modules):
+        if mod_name == "app" or mod_name.startswith("app."):
+            sys.modules.pop(mod_name, None)
+
+
+def coerce_sql_row(
+    item: VisionEventBundleItem,
+    correlation_id: UUID,
+):
+    """Contract-mode SQL row coercion using the real sql-writer model."""
+    _purge_app_modules()
+    sql_writer_root = os.path.join(REPO_ROOT, "services", "orion-sql-writer")
+    saved_path = sys.path[:]
+    try:
+        if sql_writer_root not in sys.path:
+            sys.path.insert(0, sql_writer_root)
+        from app.models.vision_event import VisionEventSQL  # noqa: E402
+
+        data = item.model_dump()
+        data["correlation_id"] = str(correlation_id)
+        return VisionEventSQL(**data)
+    finally:
+        sys.path[:] = saved_path
+        _purge_app_modules()
+
+
+def _fail(
+    stage: str,
+    *,
+    event_id: str,
+    correlation_id: str,
+    channel: str = "",
+    last_error: str = "",
+) -> int:
+    print(f"failed_stage={stage}")
+    print(f"event_id={event_id}")
+    print(f"correlation_id={correlation_id}")
+    if channel:
+        print(f"channel={channel}")
+    if last_error:
+        print(f"last_error={last_error}")
+    return 1
+
+
+def _pass(
+    *,
+    event_id: str,
+    scribe_ack: bool,
+    sql_row: bool,
+    rdf_confirm: bool,
+    rdf_enqueue_observed: bool,
+) -> int:
+    print("VISION PERSISTENCE SMOKE PASS")
+    print(f"scribe_ack={str(scribe_ack).lower()}")
+    print(f"sql_row={str(sql_row).lower()}")
+    if rdf_confirm:
+        print("rdf_confirm=true")
+    elif rdf_enqueue_observed:
+        print("rdf_enqueue_observed=true")
+        print("rdf_confirm=not_available")
+    else:
+        print("rdf_confirm=false")
+        print("rdf_enqueue_observed=false")
+    print(f"event_id={event_id}")
+    return 0
+
+
+def run_contract_mode() -> int:
+    event_id, correlation_id, narrative = new_smoke_ids()
+    item = build_smoke_bundle_item(event_id, narrative)
+    payload = build_vision_event_payload([item])
+    envelope = build_intake_envelope(correlation_id, payload)
+
+    assert envelope.kind == KIND_VISION_EVENT_BUNDLE
+    assert envelope.payload["events"][0]["event_id"] == event_id
+
+    expected = expected_sql_row_fields(item, correlation_id)
+
+    saved_path = sys.path[:]
+    scribe_root = os.path.join(REPO_ROOT, "services", "orion-vision-scribe")
+    try:
+        if scribe_root not in sys.path:
+            sys.path.insert(0, scribe_root)
+        from app.main import _build_event_triples  # noqa: E402
+
+        nt = _build_event_triples(item)
+    finally:
+        sys.path[:] = saved_path
+        _purge_app_modules()
+
+    for marker in rdf_ntriple_markers(
+        item.event_id, item.narrative, item.event_type, item.entities
+    ):
+        assert marker in nt, f"RDF N-Triples missing marker: {marker!r}"
+
+    rdf_req = build_rdf_write_request(item.event_id, nt)
+    assert rdf_req.id == item.event_id
+    assert isinstance(rdf_req.triples, str)
+
+    row = coerce_sql_row(item, correlation_id)
+    for key, want in expected.items():
+        got = getattr(row, key)
+        assert got == want, f"sql row field {key}: got {got!r}, want {want!r}"
+
+    print("VISION PERSISTENCE SMOKE PASS (contract mode)")
+    print("mode=contract")
+    print(f"event_id={event_id}")
+    print(f"correlation_id={correlation_id}")
+    print(f"intake_channel={CHANNEL_VISION_EVENTS}")
+    print(f"intake_kind={KIND_VISION_EVENT_BUNDLE}")
+    print(f"sql_write_channel={CHANNEL_SQL_WRITE}")
+    print(f"sql_write_kind={KIND_VISION_EVENT_V1}")
+    print(f"rdf_enqueue_channel={CHANNEL_RDF_ENQUEUE}")
+    print(f"rdf_enqueue_kind={KIND_RDF_WRITE_REQUEST}")
+    print(f"scribe_ack_channel={CHANNEL_SCRIBE_PUB}")
+    print(f"scribe_ack_kind={KIND_VISION_SCRIBE_ACK}")
+    return 0
+
+
+async def _collect_envelopes(
+    bus: OrionBusAsync,
+    channel: str,
+    queue: asyncio.Queue,
+) -> None:
+    async with bus.subscribe(channel) as pubsub:
+        async for msg in bus.iter_messages(pubsub):
+            data = msg.get("data")
+            decoded = bus.codec.decode(data)
+            if decoded.ok and decoded.envelope is not None:
+                await queue.put(decoded.envelope)
+
+
+def _payload_dict(env: BaseEnvelope) -> dict[str, Any]:
+    payload = env.payload
+    return payload if isinstance(payload, dict) else {}
+
+
+def _matches_correlation(env: BaseEnvelope, correlation_id: UUID) -> bool:
+    return str(env.correlation_id) == str(correlation_id)
+
+
+async def _wait_for_scribe_ack(
+    queue: asyncio.Queue,
+    correlation_id: UUID,
+    timeout_sec: float,
+) -> tuple[bool, str]:
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        try:
+            env = await asyncio.wait_for(queue.get(), timeout=min(remaining, 0.5))
+        except asyncio.TimeoutError:
+            continue
+        if env.kind != KIND_VISION_SCRIBE_ACK:
+            continue
+        if not _matches_correlation(env, correlation_id):
+            continue
+        try:
+            ack = VisionScribeAckPayload.model_validate(_payload_dict(env))
+        except Exception as exc:
+            return False, f"invalid ack payload: {exc}"
+        if not ack.ok:
+            return False, ack.error or ack.message or "ack.ok=false"
+        return True, ""
+    return False, "timeout waiting for vision.scribe.ack"
+
+
+async def _wait_for_rdf_signals(
+    enqueue_q: asyncio.Queue,
+    confirm_q: asyncio.Queue,
+    *,
+    event_id: str,
+    correlation_id: UUID,
+    timeout_sec: float,
+) -> tuple[bool, bool, str]:
+    deadline = time.monotonic() + timeout_sec
+    enqueue_seen = False
+    confirm_seen = False
+    while time.monotonic() < deadline and not (enqueue_seen and confirm_seen):
+        remaining = deadline - time.monotonic()
+        try:
+            env = await asyncio.wait_for(enqueue_q.get(), timeout=min(remaining, 0.25))
+            if _matches_correlation(env, correlation_id) and env.kind == KIND_RDF_WRITE_REQUEST:
+                payload = _payload_dict(env)
+                if str(payload.get("id")) == event_id:
+                    enqueue_seen = True
+        except asyncio.TimeoutError:
+            pass
+        try:
+            env = await asyncio.wait_for(confirm_q.get(), timeout=min(remaining, 0.25))
+            if env.kind in ("rdf.write.confirm", "rdf.write.result"):
+                payload = _payload_dict(env)
+                if str(payload.get("id")) == event_id and payload.get("ok") is True:
+                    confirm_seen = True
+        except asyncio.TimeoutError:
+            pass
+    err = ""
+    if not enqueue_seen and not confirm_seen:
+        err = "timeout waiting for rdf enqueue or confirm"
+    return enqueue_seen, confirm_seen, err
+
+
+def _query_vision_event_row(
+    db_url: str,
+    event_id: str,
+    expected: dict[str, Any],
+    *,
+    timeout_sec: float,
+) -> tuple[bool, str]:
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine(db_url, pool_pre_ping=True)
+    deadline = time.monotonic() + timeout_sec
+    last_err = "no row"
+    sql = text(
+        """
+        SELECT event_id, event_type, narrative, entities, tags,
+               confidence, salience, evidence_refs, correlation_id
+        FROM vision_events
+        WHERE event_id = :event_id
+        LIMIT 1
+        """
+    )
+    while time.monotonic() < deadline:
+        try:
+            with engine.connect() as conn:
+                row = conn.execute(sql, {"event_id": event_id}).mappings().first()
+            if row is None:
+                last_err = "row not found yet"
+                time.sleep(0.5)
+                continue
+            for key, want in expected.items():
+                got = row.get(key)
+                if key in ("entities", "tags", "evidence_refs"):
+                    if list(got or []) != list(want):
+                        last_err = f"field {key}: got {got!r}, want {want!r}"
+                        break
+                elif got != want:
+                    last_err = f"field {key}: got {got!r}, want {want!r}"
+                    break
+            else:
+                return True, ""
+            time.sleep(0.5)
+        except Exception as exc:
+            last_err = str(exc)
+            time.sleep(0.5)
+    return False, last_err
+
+
+async def run_live_mode(
+    *,
+    bus_url: str,
+    db_url: str,
+    timeout_sec: float,
+) -> int:
+    event_id, correlation_id, narrative = new_smoke_ids()
+    item = build_smoke_bundle_item(event_id, narrative)
+    payload = build_vision_event_payload([item])
+    envelope = build_intake_envelope(correlation_id, payload)
+    expected = expected_sql_row_fields(item, correlation_id)
+
+    bus = OrionBusAsync(url=bus_url)
+    await bus.connect()
+
+    scribe_q: asyncio.Queue = asyncio.Queue()
+    rdf_enqueue_q: asyncio.Queue = asyncio.Queue()
+    rdf_confirm_q: asyncio.Queue = asyncio.Queue()
+    collectors = [
+        asyncio.create_task(_collect_envelopes(bus, CHANNEL_SCRIBE_PUB, scribe_q)),
+        asyncio.create_task(_collect_envelopes(bus, CHANNEL_RDF_ENQUEUE, rdf_enqueue_q)),
+        asyncio.create_task(_collect_envelopes(bus, CHANNEL_RDF_CONFIRM, rdf_confirm_q)),
+    ]
+    await asyncio.sleep(0.5)
+
+    try:
+        await bus.publish(CHANNEL_VISION_EVENTS, envelope)
+
+        scribe_ok, scribe_err = await _wait_for_scribe_ack(
+            scribe_q, correlation_id, timeout_sec
+        )
+        if not scribe_ok:
+            return _fail(
+                "scribe_ack",
+                event_id=event_id,
+                correlation_id=str(correlation_id),
+                channel=CHANNEL_SCRIBE_PUB,
+                last_error=scribe_err,
+            )
+
+        rdf_enqueue, rdf_confirm, rdf_err = await _wait_for_rdf_signals(
+            rdf_enqueue_q,
+            rdf_confirm_q,
+            event_id=event_id,
+            correlation_id=correlation_id,
+            timeout_sec=timeout_sec,
+        )
+        if not rdf_confirm and not rdf_enqueue:
+            return _fail(
+                "rdf_enqueue",
+                event_id=event_id,
+                correlation_id=str(correlation_id),
+                channel=CHANNEL_RDF_ENQUEUE,
+                last_error=rdf_err,
+            )
+
+        sql_ok, sql_err = await asyncio.to_thread(
+            _query_vision_event_row,
+            db_url,
+            event_id,
+            expected,
+            timeout_sec=timeout_sec,
+        )
+        if not sql_ok:
+            return _fail(
+                "sql_row",
+                event_id=event_id,
+                correlation_id=str(correlation_id),
+                channel=CHANNEL_SQL_WRITE,
+                last_error=sql_err,
+            )
+
+        return _pass(
+            event_id=event_id,
+            scribe_ack=True,
+            sql_row=True,
+            rdf_confirm=rdf_confirm,
+            rdf_enqueue_observed=rdf_enqueue,
+        )
+    finally:
+        for task in collectors:
+            task.cancel()
+        await asyncio.gather(*collectors, return_exceptions=True)
+        await bus.close()
+
+
+def _resolve_mode(explicit: Optional[str]) -> str:
+    if explicit:
+        return explicit
+    bus_url = os.getenv("ORION_BUS_URL", "").strip()
+    db_url = os.getenv("DATABASE_URL", "").strip() or os.getenv("POSTGRES_URI", "").strip()
+    if bus_url and db_url:
+        return "live"
+    return ""
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Vision persistence smoke")
+    parser.add_argument(
+        "--mode",
+        choices=("live", "contract"),
+        default=None,
+        help="Smoke mode (default: live when ORION_BUS_URL and DATABASE_URL are set)",
+    )
+    args = parser.parse_args(argv)
+
+    mode = _resolve_mode(args.mode or os.getenv("VISION_PERSISTENCE_SMOKE_MODE", "").strip())
+    if not mode:
+        print(
+            "ERROR: select mode explicitly. Examples:\n"
+            "  VISION_PERSISTENCE_SMOKE_MODE=contract bash scripts/smoke_vision_persistence_live.sh\n"
+            "  ORION_BUS_URL=redis://... DATABASE_URL=postgresql+psycopg2://... "
+            "VISION_PERSISTENCE_SMOKE_MODE=live bash scripts/smoke_vision_persistence_live.sh",
+            file=sys.stderr,
+        )
+        return 2
+
+    if mode == "contract":
+        return run_contract_mode()
+
+    bus_url = os.getenv("ORION_BUS_URL", "").strip()
+    db_url = os.getenv("DATABASE_URL", "").strip() or os.getenv("POSTGRES_URI", "").strip()
+    if not bus_url or not db_url:
+        print(
+            "ERROR: live mode requires ORION_BUS_URL and DATABASE_URL (or POSTGRES_URI).",
+            file=sys.stderr,
+        )
+        return 2
+
+    timeout_sec = float(os.getenv("VISION_PERSISTENCE_SMOKE_TIMEOUT_SEC", "30"))
+    return asyncio.run(
+        run_live_mode(bus_url=bus_url, db_url=db_url, timeout_sec=timeout_sec)
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-sql-writer/tests/test_vision_persistence_lane.py
+++ b/services/orion-sql-writer/tests/test_vision_persistence_lane.py
@@ -1,0 +1,46 @@
+"""Regression tests for the vision SQL persistence lane in sql-writer."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SQL_WRITER_ROOT = Path(__file__).resolve().parents[1]
+for mod_name in list(sys.modules):
+    if mod_name == "app" or mod_name.startswith("app."):
+        sys.modules.pop(mod_name, None)
+if str(SQL_WRITER_ROOT) not in sys.path:
+    sys.path.insert(0, str(SQL_WRITER_ROOT))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app.settings import DEFAULT_ROUTE_MAP, settings  # noqa: E402
+
+
+VISION_SQL_WRITE_CHANNEL = "orion:vision:events:sql-write"
+VISION_EVENT_KIND = "vision.event.v1"
+
+
+def test_vision_event_kind_maps_to_vision_event_sql():
+    assert DEFAULT_ROUTE_MAP.get(VISION_EVENT_KIND) == "VisionEventSQL"
+    assert VISION_EVENT_KIND in settings.route_map
+
+
+def test_sql_writer_subscribes_to_vision_events_sql_write_channel():
+    channels = settings.effective_subscribe_channels
+    assert VISION_SQL_WRITE_CHANNEL in channels
+
+
+def test_vision_artifacts_catalog_lists_vision_window_consumer():
+    channels_path = REPO_ROOT / "orion" / "bus" / "channels.yaml"
+    data = yaml.safe_load(channels_path.read_text(encoding="utf-8")) or {}
+    entry = next(
+        e for e in data.get("channels", []) if e.get("name") == "orion:vision:artifacts"
+    )
+    consumers = entry.get("consumer_services") or []
+    assert "orion-vision-window" in consumers
+    assert "orion-security-watcher" in consumers
+    assert "orion-vision-council" in consumers

--- a/services/orion-vision-scribe/app/main.py
+++ b/services/orion-vision-scribe/app/main.py
@@ -154,17 +154,29 @@ class ScribeService:
             payload=ack
         )
         await self.bus.publish(settings.CHANNEL_SCRIBE_PUB, ack_env)
-        logger.info(f"[SCRIBE] Processed and acked {len(payload.events)} events")
+        logger.info(
+            "[SCRIBE] Processed {} events ack_ok={}",
+            len(payload.events),
+            ack.ok,
+        )
 
     async def _write_to_sinks(self, payload: VisionEventPayload, source_env: BaseEnvelope) -> VisionScribeAckPayload:
         errors = []
         try:
             for evt in payload.events:
+                sql_ok = False
+                rdf_ok = False
                 # 1. SQL Write
                 try:
                     await self._send_write(settings.CHANNEL_SQL_WRITE, "vision.event.v1", evt, source_env)
+                    sql_ok = True
                 except Exception as e:
-                    logger.error(f"[SCRIBE] SQL Write failed for {evt.event_id}: {e}")
+                    logger.error(
+                        "[SCRIBE] SQL Write failed event_id={} channel={}: {}",
+                        evt.event_id,
+                        settings.CHANNEL_SQL_WRITE,
+                        e,
+                    )
                     errors.append(f"SQL:{e}")
 
                 # 2. RDF Write
@@ -177,9 +189,23 @@ class ScribeService:
                         triples=nt_content,
                     )
                     await self._send_write(settings.CHANNEL_RDF_ENQUEUE, "rdf.write.request", rdf_req, source_env)
+                    rdf_ok = True
                 except Exception as e:
-                    logger.error(f"[SCRIBE] RDF Write failed for {evt.event_id}: {e}")
+                    logger.error(
+                        "[SCRIBE] RDF Write failed event_id={} channel={}: {}",
+                        evt.event_id,
+                        settings.CHANNEL_RDF_ENQUEUE,
+                        e,
+                    )
                     errors.append(f"RDF:{e}")
+
+                logger.info(
+                    "[SCRIBE] vision_persist event_id={} sql={} rdf={} ack_ok={}",
+                    evt.event_id,
+                    sql_ok,
+                    rdf_ok,
+                    sql_ok and rdf_ok,
+                )
 
             if errors:
                  return VisionScribeAckPayload(ok=False, error="; ".join(errors), message="Partial success")

--- a/services/orion-vision-scribe/tests/test_vision_persistence_smoke_helpers.py
+++ b/services/orion-vision-scribe/tests/test_vision_persistence_smoke_helpers.py
@@ -1,0 +1,96 @@
+"""Unit tests for scripts/vision_persistence_smoke.py helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.vision_persistence_smoke as smoke  # noqa: E402
+from orion.schemas.vision import VisionEventBundleItem  # noqa: E402
+
+
+def test_build_smoke_bundle_item_and_payload_shape():
+    event_id, correlation_id, narrative = smoke.new_smoke_ids()
+    item = smoke.build_smoke_bundle_item(event_id, narrative)
+    payload = smoke.build_vision_event_payload([item])
+    envelope = smoke.build_intake_envelope(correlation_id, payload)
+
+    assert envelope.kind == smoke.KIND_VISION_EVENT_BUNDLE
+    assert envelope.payload["events"][0]["event_id"] == event_id
+    assert envelope.correlation_id == correlation_id
+
+
+def test_expected_sql_row_fields_match_bundle_item():
+    event_id, correlation_id, narrative = smoke.new_smoke_ids()
+    item = smoke.build_smoke_bundle_item(event_id, narrative)
+    expected = smoke.expected_sql_row_fields(item, correlation_id)
+
+    assert expected["event_id"] == event_id
+    assert expected["narrative"] == narrative
+    assert expected["correlation_id"] == str(correlation_id)
+    assert expected["entities"] == ["orion", "vision", "smoke"]
+
+
+def test_rdf_ntriple_markers_cover_event_fields():
+    item = smoke.build_smoke_bundle_item("evt-abc", "smoke narrative")
+    markers = smoke.rdf_ntriple_markers(
+        item.event_id, item.narrative, item.event_type, item.entities
+    )
+    assert "http://conjourney.net/event/evt-abc" in markers
+    assert "smoke narrative" in markers
+    assert "smoke_test" in markers
+    assert "orion" in markers
+
+
+def test_coerce_sql_row_uses_vision_event_sql_model():
+    event_id, correlation_id, narrative = smoke.new_smoke_ids()
+    item = smoke.build_smoke_bundle_item(event_id, narrative)
+    row = smoke.coerce_sql_row(item, correlation_id)
+
+    assert row.event_id == event_id
+    assert row.correlation_id == str(correlation_id)
+    assert row.narrative == narrative
+
+
+def test_channel_constants_match_bus_catalog():
+    assert smoke.CHANNEL_VISION_EVENTS == "orion:vision:events"
+    assert smoke.CHANNEL_SCRIBE_PUB == "orion:vision:scribe:pub"
+    assert smoke.CHANNEL_SQL_WRITE == "orion:vision:events:sql-write"
+    assert smoke.CHANNEL_RDF_ENQUEUE == "orion:rdf:enqueue"
+    assert smoke.KIND_VISION_EVENT_V1 == "vision.event.v1"
+    assert smoke.KIND_RDF_WRITE_REQUEST == "rdf.write.request"
+
+
+def test_build_rdf_write_request_accepts_ntriples_string():
+    item = VisionEventBundleItem(
+        event_id="evt-rdf",
+        event_type="smoke_test",
+        narrative="n",
+        entities=["a"],
+        tags=["t"],
+        confidence=0.9,
+        salience=0.5,
+        evidence_refs=["e"],
+    )
+    scribe_root = REPO_ROOT / "services" / "orion-vision-scribe"
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(scribe_root))
+        from app.main import _build_event_triples  # noqa: E402
+
+        nt = _build_event_triples(item)
+    finally:
+        sys.path[:] = saved_path
+        for mod_name in list(sys.modules):
+            if mod_name == "app" or mod_name.startswith("app."):
+                sys.modules.pop(mod_name, None)
+
+    req = smoke.build_rdf_write_request(item.event_id, nt)
+    assert req.id == "evt-rdf"
+    assert isinstance(req.triples, str)


### PR DESCRIPTION
## Summary

Adds a live smoke for the repaired Orion Vision persistence path and cleans up the vision bus catalog topology.

This verifies:

- `orion:vision:events` → `orion-vision-scribe`
- Scribe ack on `orion:vision:scribe:pub`
- SQL write on `orion:vision:events:sql-write`
- Row persisted in `vision_events`
- RDF enqueue/confirmation path for `orion:rdf:enqueue`

Also updates `orion:vision:artifacts` catalog consumers to include `orion-vision-window`, which is the actual subscriber for artifact-to-window projection.

## Changes

- Added `scripts/smoke_vision_persistence_live.sh` and `scripts/vision_persistence_smoke.py` (live + contract modes)
- Added/updated tests for vision SQL route/subscription/catalog assumptions
- Updated `orion/bus/channels.yaml` vision artifact consumers
- Improved Scribe persistence diagnostics (`[SCRIBE] vision_persist event_id=... sql=... rdf=... ack_ok=...`)

## Validation

- [x] `pytest services/orion-vision-scribe/tests -q` — 10 passed
- [x] `pytest services/orion-sql-writer/tests/test_vision_event_sql_shape.py services/orion-sql-writer/tests/test_route_map_completeness.py services/orion-sql-writer/tests/test_vision_persistence_lane.py -q` — 11 passed
- [x] `python -m compileall services/orion-vision-scribe/app services/orion-sql-writer/app scripts/vision_persistence_smoke.py` — ok
- [x] Contract smoke: `VISION_PERSISTENCE_SMOKE_MODE=contract bash scripts/smoke_vision_persistence_live.sh` — PASS
- [x] Live smoke against mesh — PASS (`scribe_ack=true`, `sql_row=true`, `rdf_enqueue_observed=true`, `rdf_confirm=not_available`)

## Out of scope

- Council V2
- Vision grammar projection
- Vector persistence
- Memory cards
- Scene graph/OCR/VQA
- New perception-core service
- `vision-edge` behavior changes