### PR TITLE
Feat/vision council v2 salvage parsing

### DIFF
--- a/docs/plans/vision/PR_vision_council_v2_salvage_parsing.md
+++ b/docs/plans/vision/PR_vision_council_v2_salvage_parsing.md
@@ -1,0 +1,44 @@
+## Summary
+
+Hardens Vision Council V2 parsing against real LLM output shapes observed in runtime.
+
+The Council V2 architecture is live, but strict Pydantic validation was discarding useful bid model output when one nested field had a non-canonical shape. This adds a salvage/coercion pass before legacy fallback.
+
+Fixes live failure modes:
+
+- `salient_observations` with `{event_type, narrative}` now coerces to `{observation}`
+- `uncertainties: ["door", "screen"]` now coerces to uncertainty objects
+- `{uncertainty_type: ...}` now maps to `{uncertainty: ...}`
+- good `scene_summary` and valid `event_candidates` survive partial nested validation errors
+- event candidates can be synthesized from salient observations when missing
+- flat legacy event dicts still route through legacy path (not mislabeled `salvaged_v2`)
+
+## Changes
+
+- Added `salvage_interpretation_dict` lenient V2 normalization pass
+- Added `InterpretationParseOutcome` with parse modes: `strict_v2`, `salvaged_v2`, `legacy_events_dict`, `legacy_events_list`, `parse_failed`
+- Added salvage warnings to Council debug ring buffer (`parse_mode`, `salvage_warnings`)
+- Added concise parse-mode logging (`interpretation_parse`, `interpretation_strict_failed`)
+- Added 21 unit tests covering live malformed output shapes and legacy regression guards
+
+## Validation
+
+- [x] `PYTHONPATH=services/orion-vision-council:. pytest services/orion-vision-council/tests -q` — **21 passed**
+- [x] `cd services/orion-vision-scribe && PYTHONPATH=.:../.. pytest tests -q` — **10 passed**
+- [x] `python3 -m compileall services/orion-vision-council/app orion/schemas/vision.py orion/schemas/registry.py` — **exit 0**
+- [ ] Runtime debug buffer shows real scene summaries with `parse_mode=strict_v2|salvaged_v2` (post-deploy)
+
+## Out of scope
+
+- Grammar projection
+- Vector persistence
+- Memory cards
+- Scribe changes
+- SQL/RDF changes
+- Vision Host / Frame Router / Window changes
+- New perception service
+- `vision-edge` behavior changes
+
+## Base branch
+
+Stacks on `feat/vision-council-scene-interpretation-v1` (Council V2 scene interpretation).

--- a/docs/plans/vision/PR_vision_council_v2_salvage_parsing.md
+++ b/docs/plans/vision/PR_vision_council_v2_salvage_parsing.md
@@ -2,7 +2,7 @@
 
 Hardens Vision Council V2 parsing against real LLM output shapes observed in runtime.
 
-The Council V2 architecture is live, but strict Pydantic validation was discarding useful bid model output when one nested field had a non-canonical shape. This adds a salvage/coercion pass before legacy fallback.
+The Council V2 architecture is live, but strict Pydantic validation was discarding useful model output when one nested field had a non-canonical shape. This adds a salvage/coercion pass before legacy fallback.
 
 Fixes live failure modes:
 
@@ -10,7 +10,9 @@ Fixes live failure modes:
 - `uncertainties: ["door", "screen"]` now coerces to uncertainty objects
 - `{uncertainty_type: ...}` now maps to `{uncertainty: ...}`
 - good `scene_summary` and valid `event_candidates` survive partial nested validation errors
+- missing `scene_summary` is derived from window captions during salvage (not misrouted to legacy)
 - event candidates can be synthesized from salient observations when missing
+- top-level `event_type`/`narrative` promote to `event_candidates` when salvage runs with empty events
 - flat legacy event dicts still route through legacy path (not mislabeled `salvaged_v2`)
 
 ## Changes
@@ -18,12 +20,19 @@ Fixes live failure modes:
 - Added `salvage_interpretation_dict` lenient V2 normalization pass
 - Added `InterpretationParseOutcome` with parse modes: `strict_v2`, `salvaged_v2`, `legacy_events_dict`, `legacy_events_list`, `parse_failed`
 - Added salvage warnings to Council debug ring buffer (`parse_mode`, `salvage_warnings`)
-- Added concise parse-mode logging (`interpretation_parse`, `interpretation_strict_failed`)
-- Added 21 unit tests covering live malformed output shapes and legacy regression guards
+- Added concise parse-mode logging (`interpretation_parse`, `interpretation_strict_failed`, `interpretation_salvage_failed`)
+- Added `_is_flat_legacy_event_dict` guard so flat event shapes skip salvage
+- Added 23 unit tests covering live malformed output shapes and legacy regression guards
+
+## Code review fixes
+
+- Removed overly strict salvage acceptance gate that dropped scene-summary-only recoveries into legacy
+- Added `scene_summary` to flat-legacy V2 marker set so hybrid payloads keep summary through salvage
+- Added top-level event field promotion during salvage when `event_candidates` empty
 
 ## Validation
 
-- [x] `PYTHONPATH=services/orion-vision-council:. pytest services/orion-vision-council/tests -q` — **21 passed**
+- [x] `PYTHONPATH=services/orion-vision-council:. pytest services/orion-vision-council/tests -q` — **23 passed**
 - [x] `cd services/orion-vision-scribe && PYTHONPATH=.:../.. pytest tests -q` — **10 passed**
 - [x] `python3 -m compileall services/orion-vision-council/app orion/schemas/vision.py orion/schemas/registry.py` — **exit 0**
 - [ ] Runtime debug buffer shows real scene summaries with `parse_mode=strict_v2|salvaged_v2` (post-deploy)

--- a/docs/vision_services.md
+++ b/docs/vision_services.md
@@ -9,7 +9,7 @@ The vision pipeline is a distributed system using the Titanium Contract Stack ov
 1.  **Vision Host (`orion-vision-host`)**: GPU-accelerated inference service. Executes tasks (Embed, Detect, Caption, Retina) and broadcasts artifacts.
 2.  **Vision Retina (`orion-vision-retina`)**: Capture service that publishes frame pointers.
 3.  **Vision Window (`orion-vision-window`)**: Aggregates artifacts into time-based windows.
-4.  **Vision Council (`orion-vision-council`)**: Performs high-level cognitive analysis on windows using LLMs. Council V2 parses `VisionSceneInterpretationV1` internally, then projects `event_candidates` to the legacy `VisionEventPayload` published on `orion:vision:events` (Scribe contract unchanged).
+4.  **Vision Council (`orion-vision-council`)**: Performs high-level cognitive analysis on windows using LLMs. Council V2 parses `VisionSceneInterpretationV1` internally (strict validation, then salvage/coercion for common malformed nested fields, then legacy fallback), then projects `event_candidates` to the legacy `VisionEventPayload` published on `orion:vision:events` (Scribe contract unchanged).
 5.  **Vision Scribe (`orion-vision-scribe`)**: Persists events to SQL, RDF, and Vector stores.
 
 ## Channels and Kinds

--- a/services/orion-vision-council/README.md
+++ b/services/orion-vision-council/README.md
@@ -9,7 +9,7 @@ VisionWindowPayload → VisionSceneInterpretationV1 → VisionEventPayload
 ```
 
 1. **Intake** — `VisionWindowPayload` arrives on the council intake channel (or via RPC request).
-2. **Interpretation** — `build_interpretation_prompt` shapes the LLM prompt; the response is parsed into `VisionSceneInterpretationV1` (with legacy flat event-list fallback when needed).
+2. **Interpretation** — `build_interpretation_prompt` shapes the LLM prompt; the response is parsed into `VisionSceneInterpretationV1` via strict validation, a salvage/coercion pass for common malformed nested fields, then legacy flat event-list fallback when needed.
 3. **Projection** — `project_interpretation_to_events` maps `event_candidates` to `VisionEventBundleItem` entries in a `VisionEventPayload`.
 4. **Publish** — the event bundle is published on `orion:vision:events` (and returned on RPC reply when applicable).
 
@@ -19,6 +19,6 @@ VisionWindowPayload → VisionSceneInterpretationV1 → VisionEventPayload
 |----------|-------------|
 | `GET /health` | Liveness check (`{"ok": true}`) |
 | `GET /debug/last-interpretation` | Most recent `VisionSceneInterpretationV1` (in-memory ring buffer) |
-| `GET /debug/recent-interpretations?limit=10` | Last N interpretations (max 20) |
+| `GET /debug/recent-interpretations?limit=10` | Last N interpretations (max 20); each record includes Council-local `parse_mode` and optional `salvage_warnings` |
 
 Interpretations are retained in an in-memory ring buffer (max 20 items) for local debugging only; they are not persisted. Debug endpoints are unauthenticated — restrict network exposure in production.

--- a/services/orion-vision-council/app/interpretation.py
+++ b/services/orion-vision-council/app/interpretation.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import Any
+from dataclasses import dataclass, field
+from typing import Any, Literal
 
 from loguru import logger
+from pydantic import ValidationError
 
 from orion.schemas.vision import (
     VisionEventBundleItem,
@@ -18,6 +20,21 @@ from orion.schemas.vision import (
     VisionSceneInterpretationV1,
     VisionWindowPayload,
 )
+
+ParseMode = Literal[
+    "strict_v2",
+    "salvaged_v2",
+    "legacy_events_dict",
+    "legacy_events_list",
+    "parse_failed",
+]
+
+
+@dataclass(frozen=True)
+class InterpretationParseOutcome:
+    interpretation: VisionSceneInterpretationV1 | None
+    parse_mode: ParseMode = "parse_failed"
+    salvage_warnings: list[str] = field(default_factory=list)
 
 
 def _strip_markdown_fences(content: str) -> str:
@@ -99,6 +116,284 @@ def build_interpretation_prompt(window: VisionWindowPayload) -> str:
     )
 
 
+def _clamp_float(value: Any, default: float = 0.5) -> float:
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0.0, min(1.0, coerced))
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if item is not None]
+
+
+def _default_evidence_refs(item: dict[str, Any], window: VisionWindowPayload | None) -> list[str]:
+    refs = item.get("evidence_refs")
+    if isinstance(refs, list) and refs:
+        return [str(r) for r in refs]
+    if window and window.artifact_ids:
+        return list(window.artifact_ids)
+    return []
+
+
+def _coerce_salient_observation_item(
+    item: Any,
+    index: int,
+    window: VisionWindowPayload | None,
+    warnings: list[str],
+) -> dict[str, Any] | None:
+    if isinstance(item, str):
+        warnings.append(f"coerced salient_observations[{index}] string -> object")
+        return {
+            "observation": item,
+            "confidence": 0.5,
+            "salience": 0.5,
+            "tags": [],
+            "evidence_refs": _default_evidence_refs({}, window),
+        }
+    if not isinstance(item, dict):
+        warnings.append(f"skipped salient_observations[{index}] uncoercible type")
+        return None
+
+    observation = (
+        item.get("observation")
+        or item.get("narrative")
+        or item.get("summary")
+        or item.get("description")
+        or item.get("event_type")
+    )
+    if not observation:
+        observation = str(item)
+        warnings.append(f"coerced salient_observations[{index}] dict -> stringified observation")
+    elif item.get("narrative") and not item.get("observation"):
+        warnings.append(f"coerced salient_observations[{index}].narrative -> observation")
+    elif item.get("event_type") and not item.get("observation") and not item.get("narrative"):
+        warnings.append(f"coerced salient_observations[{index}].event_type -> observation")
+
+    return {
+        "observation": str(observation),
+        "confidence": _clamp_float(item.get("confidence")),
+        "salience": _clamp_float(item.get("salience")),
+        "tags": _string_list(item.get("tags")),
+        "evidence_refs": _default_evidence_refs(item, window),
+    }
+
+
+def _coerce_uncertainty_item(item: Any, index: int, warnings: list[str]) -> dict[str, Any] | None:
+    if isinstance(item, str):
+        warnings.append(f"coerced uncertainties[{index}] string -> object")
+        return {"uncertainty": item}
+    if not isinstance(item, dict):
+        warnings.append(f"skipped uncertainties[{index}] uncoercible type")
+        return None
+
+    uncertainty = (
+        item.get("uncertainty")
+        or item.get("uncertainty_type")
+        or item.get("label")
+        or item.get("topic")
+        or item.get("text")
+        or item.get("reason")
+    )
+    if not uncertainty:
+        uncertainty = str(item)
+        warnings.append(f"coerced uncertainties[{index}] dict -> stringified uncertainty")
+    elif item.get("uncertainty_type") and not item.get("uncertainty"):
+        warnings.append(f"coerced uncertainties[{index}].uncertainty_type -> uncertainty")
+
+    coerced: dict[str, Any] = {"uncertainty": str(uncertainty)}
+    if item.get("reason") is not None:
+        coerced["reason"] = str(item.get("reason"))
+    if item.get("confidence") is not None:
+        coerced["confidence"] = _clamp_float(item.get("confidence"))
+    refs = item.get("evidence_refs")
+    if isinstance(refs, list) and refs:
+        coerced["evidence_refs"] = [str(r) for r in refs]
+    return coerced
+
+
+def _coerce_event_candidate_item(
+    item: Any,
+    index: int,
+    window: VisionWindowPayload | None,
+    warnings: list[str],
+) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        warnings.append(f"skipped event_candidates[{index}] uncoercible type")
+        return None
+
+    event_type = item.get("event_type") or item.get("type") or item.get("label") or "observation"
+    narrative = (
+        item.get("narrative")
+        or item.get("observation")
+        or item.get("summary")
+        or item.get("description")
+        or event_type
+    )
+    return {
+        "event_type": str(event_type),
+        "narrative": str(narrative),
+        "entities": _string_list(item.get("entities")),
+        "tags": _string_list(item.get("tags")),
+        "confidence": _clamp_float(item.get("confidence")),
+        "salience": _clamp_float(item.get("salience")),
+        "evidence_refs": _default_evidence_refs(item, window),
+    }
+
+
+def _synthesize_event_candidates_from_observations(
+    observations: list[dict[str, Any]],
+    window: VisionWindowPayload | None,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    if not observations:
+        return []
+    warnings.append("synthesized event_candidates from salient_observations")
+    synthesized: list[dict[str, Any]] = []
+    for obs in observations:
+        synthesized.append(
+            {
+                "event_type": "visual_observation",
+                "narrative": obs.get("observation", ""),
+                "entities": [],
+                "tags": list(obs.get("tags") or []),
+                "confidence": _clamp_float(obs.get("confidence")),
+                "salience": _clamp_float(obs.get("salience")),
+                "evidence_refs": list(obs.get("evidence_refs") or _default_evidence_refs({}, window)),
+            }
+        )
+    return synthesized
+
+
+def _derive_scene_summary(data: dict[str, Any], window: VisionWindowPayload | None) -> str:
+    existing = data.get("scene_summary")
+    if existing:
+        return str(existing)
+    if window:
+        summary = window.summary or {}
+        captions = summary.get("captions") or []
+        if captions:
+            return str(captions[0])
+    return "Visual scene interpreted from window summary"
+
+
+def _is_flat_legacy_event_dict(data: dict[str, Any]) -> bool:
+    """Detect a lone event-shaped dict that is not V2 scene interpretation."""
+    if "event_candidates" in data or "events" in data:
+        return False
+    v2_markers = {
+        "salient_observations",
+        "uncertainties",
+        "entities",
+        "relations",
+        "task_relevance",
+        "memory_delta_candidates",
+        "grammar_projection",
+        "scene_state",
+    }
+    if v2_markers.intersection(data.keys()):
+        return False
+    return bool(data.get("event_type") or data.get("narrative") or data.get("type"))
+
+
+def _legacy_outcome_from_data(
+    data: Any,
+    content: str,
+    window: VisionWindowPayload,
+    raw_model_output: dict[str, Any] | None,
+) -> InterpretationParseOutcome | None:
+    legacy = try_legacy_fallback(content, window)
+    if legacy is None:
+        return None
+    if raw_model_output is not None:
+        legacy = legacy.model_copy(update={"raw_model_output": raw_model_output})
+    mode: ParseMode = "legacy_events_list" if isinstance(data, list) else "legacy_events_dict"
+    return InterpretationParseOutcome(interpretation=legacy, parse_mode=mode)
+
+
+def salvage_interpretation_dict(
+    raw: Any,
+    *,
+    window: VisionWindowPayload | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Normalize V2-ish model output into a dict suitable for VisionSceneInterpretationV1."""
+    if not isinstance(raw, dict):
+        return None, []
+
+    warnings: list[str] = []
+    data = _coerce_legacy_events_field(dict(raw))
+
+    preserved_keys = (
+        "schema_version",
+        "scene_summary",
+        "scene_state",
+        "entities",
+        "relations",
+        "task_relevance",
+        "memory_delta_candidates",
+        "grammar_projection",
+        "raw_model_output",
+        "window_id",
+        "stream_id",
+        "camera_id",
+        "evidence_refs",
+    )
+    salvaged: dict[str, Any] = {k: data[k] for k in preserved_keys if k in data}
+
+    if window:
+        salvaged.setdefault("window_id", window.window_id)
+        salvaged.setdefault("stream_id", window.stream_id)
+        salvaged.setdefault("camera_id", window.camera_id)
+        if not salvaged.get("evidence_refs") and window.artifact_ids:
+            salvaged["evidence_refs"] = list(window.artifact_ids)
+
+    salvaged["scene_summary"] = _derive_scene_summary(data, window)
+
+    raw_salient = data.get("salient_observations")
+    coerced_salient: list[dict[str, Any]] = []
+    if isinstance(raw_salient, list):
+        for idx, item in enumerate(raw_salient):
+            coerced = _coerce_salient_observation_item(item, idx, window, warnings)
+            if coerced is not None:
+                coerced_salient.append(coerced)
+    elif raw_salient is not None:
+        warnings.append("ignored salient_observations: expected list")
+    salvaged["salient_observations"] = coerced_salient
+
+    raw_uncertainties = data.get("uncertainties")
+    coerced_uncertainties: list[dict[str, Any]] = []
+    if isinstance(raw_uncertainties, list):
+        for idx, item in enumerate(raw_uncertainties):
+            coerced = _coerce_uncertainty_item(item, idx, warnings)
+            if coerced is not None:
+                coerced_uncertainties.append(coerced)
+    elif raw_uncertainties is not None:
+        warnings.append("ignored uncertainties: expected list")
+    salvaged["uncertainties"] = coerced_uncertainties
+
+    raw_events = data.get("event_candidates")
+    coerced_events: list[dict[str, Any]] = []
+    if isinstance(raw_events, list):
+        for idx, item in enumerate(raw_events):
+            coerced = _coerce_event_candidate_item(item, idx, window, warnings)
+            if coerced is not None:
+                coerced_events.append(coerced)
+
+    if not coerced_events and coerced_salient:
+        coerced_events = _synthesize_event_candidates_from_observations(
+            coerced_salient, window, warnings
+        )
+    salvaged["event_candidates"] = coerced_events
+
+    if not salvaged.get("window_id"):
+        return None, warnings
+
+    return salvaged, warnings
+
+
 def _dict_to_event_candidate(evt: dict[str, Any]) -> VisionEventCandidateV1:
     return VisionEventCandidateV1(
         event_type=str(evt.get("event_type", "unknown")),
@@ -117,7 +412,7 @@ def _events_list_to_minimal_interpretation(
 ) -> VisionSceneInterpretationV1:
     scene_summary = "Events from legacy format"
     if events:
-        first_narrative = events[0].get("narrative")
+        first_narrative = events[0].get("narrative") if isinstance(events[0], dict) else None
         if first_narrative:
             scene_summary = str(first_narrative)
 
@@ -126,7 +421,7 @@ def _events_list_to_minimal_interpretation(
         stream_id=window.stream_id,
         camera_id=window.camera_id,
         scene_summary=scene_summary,
-        event_candidates=[_dict_to_event_candidate(evt) for evt in events],
+        event_candidates=[_dict_to_event_candidate(evt) for evt in events if isinstance(evt, dict)],
         evidence_refs=list(window.artifact_ids or []),
     )
 
@@ -144,42 +439,126 @@ def _coerce_legacy_events_field(data: dict[str, Any]) -> dict[str, Any]:
     return coerced
 
 
-def parse_llm_content(content: str, window: VisionWindowPayload) -> VisionSceneInterpretationV1 | None:
+def _attach_raw_model_output(
+    interpretation: VisionSceneInterpretationV1,
+    raw_model_output: dict[str, Any] | None,
+    data: dict[str, Any],
+) -> VisionSceneInterpretationV1:
+    if interpretation.raw_model_output is None and raw_model_output is not None:
+        return interpretation.model_copy(update={"raw_model_output": raw_model_output})
+    if interpretation.raw_model_output is None:
+        return interpretation.model_copy(update={"raw_model_output": data})
+    return interpretation
+
+
+def _log_parse_outcome(
+    outcome: InterpretationParseOutcome,
+    window: VisionWindowPayload,
+) -> None:
+    if outcome.interpretation is None:
+        return
+    event_count = len(outcome.interpretation.event_candidates)
+    logger.info(
+        f"[COUNCIL] interpretation_parse mode={outcome.parse_mode} "
+        f"window_id={window.window_id} events={event_count} "
+        f"warnings={len(outcome.salvage_warnings)}"
+    )
+
+
+def parse_llm_content(content: str, window: VisionWindowPayload) -> InterpretationParseOutcome:
     try:
         text = _strip_markdown_fences(content)
         data = json.loads(text)
-        raw_model_output: dict[str, Any] | list[Any] | None = None
+        raw_model_output: dict[str, Any] | None = None
 
         if isinstance(data, dict) and "interpretation" in data:
             raw_model_output = data
             data = data["interpretation"]
 
         if isinstance(data, list):
-            interpretation = _events_list_to_minimal_interpretation(data, window)
-            return interpretation.model_copy(
-                update={"raw_model_output": raw_model_output if isinstance(raw_model_output, dict) else {"events": data}}
+            interpretation = _events_list_to_minimal_interpretation(
+                [evt for evt in data if isinstance(evt, dict)],
+                window,
             )
+            raw = raw_model_output if isinstance(raw_model_output, dict) else {"events": data}
+            interpretation = interpretation.model_copy(update={"raw_model_output": raw})
+            outcome = InterpretationParseOutcome(
+                interpretation=interpretation,
+                parse_mode="legacy_events_list",
+            )
+            _log_parse_outcome(outcome, window)
+            return outcome
 
         if isinstance(data, dict):
             if set(data.keys()) == {"events"} and isinstance(data.get("events"), list):
                 interpretation = _events_list_to_minimal_interpretation(data["events"], window)
-                return interpretation.model_copy(update={"raw_model_output": data})
-
-            data = _coerce_legacy_events_field(data)
-            if not data.get("window_id"):
-                data = {**data, "window_id": window.window_id}
-            interpretation = VisionSceneInterpretationV1.model_validate(data)
-            if interpretation.raw_model_output is None and raw_model_output is not None:
-                interpretation = interpretation.model_copy(update={"raw_model_output": raw_model_output})
-            elif interpretation.raw_model_output is None:
                 interpretation = interpretation.model_copy(update={"raw_model_output": data})
-            return interpretation
+                outcome = InterpretationParseOutcome(
+                    interpretation=interpretation,
+                    parse_mode="legacy_events_dict",
+                )
+                _log_parse_outcome(outcome, window)
+                return outcome
+
+            if _is_flat_legacy_event_dict(data):
+                outcome = _legacy_outcome_from_data(data, content, window, raw_model_output)
+                if outcome is not None:
+                    _log_parse_outcome(outcome, window)
+                    return outcome
+
+            strict_data = _coerce_legacy_events_field(dict(data))
+            if not strict_data.get("window_id"):
+                strict_data["window_id"] = window.window_id
+
+            try:
+                interpretation = VisionSceneInterpretationV1.model_validate(strict_data)
+                interpretation = _attach_raw_model_output(interpretation, raw_model_output, data)
+                outcome = InterpretationParseOutcome(
+                    interpretation=interpretation,
+                    parse_mode="strict_v2",
+                )
+                _log_parse_outcome(outcome, window)
+                return outcome
+            except ValidationError as exc:
+                logger.warning(
+                    f"[COUNCIL] interpretation_strict_failed window_id={window.window_id} "
+                    f"error_count={len(exc.errors())}"
+                )
+
+            salvaged, warnings = salvage_interpretation_dict(data, window=window)
+            if salvaged is not None:
+                try:
+                    interpretation = VisionSceneInterpretationV1.model_validate(salvaged)
+                    if warnings or interpretation.event_candidates or interpretation.salient_observations:
+                        interpretation = _attach_raw_model_output(
+                            interpretation, raw_model_output, data
+                        )
+                        outcome = InterpretationParseOutcome(
+                            interpretation=interpretation,
+                            parse_mode="salvaged_v2",
+                            salvage_warnings=warnings,
+                        )
+                        _log_parse_outcome(outcome, window)
+                        return outcome
+                except ValidationError as exc:
+                    logger.warning(
+                        f"[COUNCIL] interpretation_salvage_failed window_id={window.window_id} "
+                        f"error_count={len(exc.errors())}"
+                    )
+
+            outcome = _legacy_outcome_from_data(data, content, window, raw_model_output)
+            if outcome is not None:
+                _log_parse_outcome(outcome, window)
+                return outcome
 
         logger.error(f"[COUNCIL] Unexpected LLM JSON type: {type(data).__name__}")
-        return None
-    except Exception as e:
-        logger.error(f"[COUNCIL] Failed to parse interpretation JSON: {e} | Content: {content!r}")
-        return None
+        return InterpretationParseOutcome(interpretation=None, parse_mode="parse_failed")
+    except json.JSONDecodeError as exc:
+        logger.error(f"[COUNCIL] Failed to parse interpretation JSON: {exc}")
+        return InterpretationParseOutcome(interpretation=None, parse_mode="parse_failed")
+    except Exception as exc:
+        logger.error(f"[COUNCIL] Failed to parse interpretation JSON: {exc}")
+        return InterpretationParseOutcome(interpretation=None, parse_mode="parse_failed")
 
 
 def project_interpretation_to_events(
@@ -217,26 +596,28 @@ def try_legacy_fallback(
         data = json.loads(text)
         events: list[dict[str, Any]] | None = None
         if isinstance(data, list):
-            events = data
+            events = [evt for evt in data if isinstance(evt, dict)]
         elif isinstance(data, dict) and isinstance(data.get("events"), list):
-            events = data["events"]
+            events = [evt for evt in data["events"] if isinstance(evt, dict)]
         elif isinstance(data, dict):
             events = [data]
         if not events:
             return None
         return _events_list_to_minimal_interpretation(events, window)
-    except Exception as e:
-        logger.error(f"[COUNCIL] Legacy fallback parse failed: {e} | Content: {content!r}")
+    except Exception as exc:
+        logger.error(f"[COUNCIL] Legacy fallback parse failed: {exc}")
         return None
 
 
 def parse_and_project(
     content: str,
     window: VisionWindowPayload,
-) -> tuple[VisionSceneInterpretationV1 | None, VisionEventPayload | None]:
-    interpretation = parse_llm_content(content, window)
-    if interpretation is None:
-        interpretation = try_legacy_fallback(content, window)
-    if interpretation is None:
-        return None, None
-    return interpretation, project_interpretation_to_events(interpretation, window)
+) -> tuple[VisionSceneInterpretationV1 | None, VisionEventPayload | None, InterpretationParseOutcome]:
+    outcome = parse_llm_content(content, window)
+    if outcome.interpretation is None:
+        return None, None, outcome
+    return (
+        outcome.interpretation,
+        project_interpretation_to_events(outcome.interpretation, window),
+        outcome,
+    )

--- a/services/orion-vision-council/app/interpretation.py
+++ b/services/orion-vision-council/app/interpretation.py
@@ -285,6 +285,7 @@ def _is_flat_legacy_event_dict(data: dict[str, Any]) -> bool:
     if "event_candidates" in data or "events" in data:
         return False
     v2_markers = {
+        "scene_summary",
         "salient_observations",
         "uncertainties",
         "entities",
@@ -386,6 +387,22 @@ def salvage_interpretation_dict(
         coerced_events = _synthesize_event_candidates_from_observations(
             coerced_salient, window, warnings
         )
+    if not coerced_events and (
+        data.get("event_type") or data.get("narrative") or data.get("type")
+    ):
+        top_level = {
+            "event_type": data.get("event_type") or data.get("type"),
+            "narrative": data.get("narrative") or data.get("observation") or data.get("summary"),
+            "entities": data.get("entities"),
+            "tags": data.get("tags"),
+            "confidence": data.get("confidence"),
+            "salience": data.get("salience"),
+            "evidence_refs": data.get("evidence_refs"),
+        }
+        coerced = _coerce_event_candidate_item(top_level, 0, window, warnings)
+        if coerced is not None:
+            warnings.append("promoted top-level event fields -> event_candidates[0]")
+            coerced_events = [coerced]
     salvaged["event_candidates"] = coerced_events
 
     if not salvaged.get("window_id"):
@@ -529,17 +546,16 @@ def parse_llm_content(content: str, window: VisionWindowPayload) -> Interpretati
             if salvaged is not None:
                 try:
                     interpretation = VisionSceneInterpretationV1.model_validate(salvaged)
-                    if warnings or interpretation.event_candidates or interpretation.salient_observations:
-                        interpretation = _attach_raw_model_output(
-                            interpretation, raw_model_output, data
-                        )
-                        outcome = InterpretationParseOutcome(
-                            interpretation=interpretation,
-                            parse_mode="salvaged_v2",
-                            salvage_warnings=warnings,
-                        )
-                        _log_parse_outcome(outcome, window)
-                        return outcome
+                    interpretation = _attach_raw_model_output(
+                        interpretation, raw_model_output, data
+                    )
+                    outcome = InterpretationParseOutcome(
+                        interpretation=interpretation,
+                        parse_mode="salvaged_v2",
+                        salvage_warnings=warnings,
+                    )
+                    _log_parse_outcome(outcome, window)
+                    return outcome
                 except ValidationError as exc:
                     logger.warning(
                         f"[COUNCIL] interpretation_salvage_failed window_id={window.window_id} "

--- a/services/orion-vision-council/app/main.py
+++ b/services/orion-vision-council/app/main.py
@@ -25,10 +25,10 @@ except ImportError:
     logger.warning("Cortex schemas not found, using dicts")
 
 from .interpretation import (
+    InterpretationParseOutcome,
     build_interpretation_prompt,
     parse_llm_content,
     project_interpretation_to_events,
-    try_legacy_fallback,
 )
 
 _MAX_DEBUG_INTERPRETATIONS = 20
@@ -46,8 +46,16 @@ class CouncilService:
         self._shutdown_event = asyncio.Event()
         self._recent_interpretations: list[dict] = []
 
-    def _record_interpretation(self, interpretation: VisionSceneInterpretationV1) -> None:
-        self._recent_interpretations.append(interpretation.model_dump())
+    def _record_interpretation(
+        self,
+        interpretation: VisionSceneInterpretationV1,
+        outcome: InterpretationParseOutcome,
+    ) -> None:
+        record = interpretation.model_dump()
+        record["parse_mode"] = outcome.parse_mode
+        if outcome.salvage_warnings:
+            record["salvage_warnings"] = list(outcome.salvage_warnings)
+        self._recent_interpretations.append(record)
         if len(self._recent_interpretations) > _MAX_DEBUG_INTERPRETATIONS:
             self._recent_interpretations = self._recent_interpretations[-_MAX_DEBUG_INTERPRETATIONS:]
 
@@ -115,9 +123,9 @@ class CouncilService:
             logger.error(f"[COUNCIL] RPC invalid payload: {e}")
             return
 
-        interpretation = await self._generate_interpretation(req.window, env)
+        interpretation, parse_outcome = await self._generate_interpretation(req.window, env)
         if interpretation is not None:
-            self._record_interpretation(interpretation)
+            self._record_interpretation(interpretation, parse_outcome)
 
         event_payload = (
             self._project_interpretation_to_events(interpretation, req.window)
@@ -158,9 +166,9 @@ class CouncilService:
             logger.error(f"[COUNCIL] Invalid payload: {e}")
             return
 
-        interpretation = await self._generate_interpretation(payload, env)
+        interpretation, parse_outcome = await self._generate_interpretation(payload, env)
         if interpretation is not None:
-            self._record_interpretation(interpretation)
+            self._record_interpretation(interpretation, parse_outcome)
 
         event_payload = (
             self._project_interpretation_to_events(interpretation, payload)
@@ -183,16 +191,14 @@ class CouncilService:
         self,
         window: VisionWindowPayload,
         source_env: BaseEnvelope,
-    ) -> VisionSceneInterpretationV1 | None:
+    ) -> tuple[VisionSceneInterpretationV1 | None, InterpretationParseOutcome]:
         prompt = build_interpretation_prompt(window)
         content = await self._call_llm_raw(prompt, source_env)
         if not content:
-            return None
+            return None, InterpretationParseOutcome(interpretation=None, parse_mode="parse_failed")
 
-        interpretation = parse_llm_content(content, window)
-        if interpretation is None:
-            interpretation = try_legacy_fallback(content, window)
-        return interpretation
+        outcome = parse_llm_content(content, window)
+        return outcome.interpretation, outcome
 
     def _project_interpretation_to_events(
         self,

--- a/services/orion-vision-council/tests/test_interpretation_v2.py
+++ b/services/orion-vision-council/tests/test_interpretation_v2.py
@@ -13,6 +13,7 @@ SERVICE_ROOT = Path(__file__).resolve().parents[1]
 sys.path[:0] = [str(REPO_ROOT), str(SERVICE_ROOT)]
 
 from app.interpretation import (  # noqa: E402
+    InterpretationParseOutcome,
     parse_llm_content,
     project_interpretation_to_events,
     try_legacy_fallback,
@@ -38,6 +39,10 @@ def _window(**kwargs) -> VisionWindowPayload:
     )
     base.update(kwargs)
     return VisionWindowPayload(**base)
+
+
+def _parse(content: str, window: VisionWindowPayload) -> InterpretationParseOutcome:
+    return parse_llm_content(content, window)
 
 
 def _valid_interpretation_json(window: VisionWindowPayload) -> str:
@@ -71,25 +76,291 @@ def _valid_interpretation_json(window: VisionWindowPayload) -> str:
     return json.dumps(payload)
 
 
-def test_parse_valid_vision_scene_interpretation_v1_json():
+def test_strict_v2_still_parses_as_strict_v2():
     window = _window()
-    interpretation = parse_llm_content(_valid_interpretation_json(window), window)
+    outcome = _parse(_valid_interpretation_json(window), window)
 
-    assert interpretation is not None
-    assert isinstance(interpretation, VisionSceneInterpretationV1)
-    assert interpretation.window_id == "w1"
-    assert interpretation.scene_summary == "A person walks through the frame."
-    assert len(interpretation.event_candidates) == 1
-    assert interpretation.event_candidates[0].event_type == "movement"
-    assert interpretation.event_candidates[0].narrative == "Person enters from the left."
+    assert outcome.parse_mode == "strict_v2"
+    assert outcome.interpretation is not None
+    assert isinstance(outcome.interpretation, VisionSceneInterpretationV1)
+    assert outcome.interpretation.scene_summary == "A person walks through the frame."
+    assert outcome.salvage_warnings == []
+
+
+def test_salient_observations_event_type_narrative_salvages_to_observation():
+    window = _window()
+    content = json.dumps(
+        {
+            "window_id": window.window_id,
+            "scene_summary": "A door and a screen are visible.",
+            "salient_observations": [
+                {
+                    "event_type": "object_seen",
+                    "narrative": "A door and a screen are visible.",
+                    "confidence": 0.8,
+                    "salience": 0.6,
+                    "tags": ["door", "screen"],
+                }
+            ],
+            "uncertainties": [],
+            "event_candidates": [],
+        }
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "salvaged_v2"
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.scene_summary == "A door and a screen are visible."
+    obs = outcome.interpretation.salient_observations[0]
+    assert obs.observation == "A door and a screen are visible."
+    assert obs.confidence == pytest.approx(0.8)
+    assert obs.tags == ["door", "screen"]
+    assert any("narrative" in w for w in outcome.salvage_warnings)
+
+
+def test_uncertainties_string_list_salvages_to_objects():
+    window = _window()
+    content = json.dumps(
+        {
+            "window_id": window.window_id,
+            "scene_summary": "Uncertain scene.",
+            "salient_observations": [],
+            "uncertainties": ["door", "screen"],
+            "event_candidates": [
+                {
+                    "event_type": "observation",
+                    "narrative": "Something visible.",
+                }
+            ],
+        }
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "salvaged_v2"
+    assert outcome.interpretation is not None
+    uncertainties = outcome.interpretation.uncertainties
+    assert len(uncertainties) == 2
+    assert uncertainties[0].uncertainty == "door"
+    assert uncertainties[1].uncertainty == "screen"
+
+
+def test_uncertainties_uncertainty_type_salvages_to_uncertainty():
+    window = _window()
+    content = json.dumps(
+        {
+            "window_id": window.window_id,
+            "scene_summary": "Ambiguous context.",
+            "salient_observations": [],
+            "uncertainties": [{"uncertainty_type": "unknown context", "reason": "camera angle"}],
+            "event_candidates": [
+                {
+                    "event_type": "observation",
+                    "narrative": "Scene is unclear.",
+                }
+            ],
+        }
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "salvaged_v2"
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.uncertainties[0].uncertainty == "unknown context"
+    assert outcome.interpretation.uncertainties[0].reason == "camera angle"
+
+
+def test_scene_summary_preserved_when_nested_fields_malformed():
+    window = _window()
+    content = json.dumps(
+        {
+            "window_id": window.window_id,
+            "scene_summary": "A door and a screen are visible.",
+            "salient_observations": [{"event_type": "object_seen", "narrative": "door visible"}],
+            "uncertainties": ["door"],
+            "event_candidates": [],
+        }
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "salvaged_v2"
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.scene_summary == "A door and a screen are visible."
+
+
+def test_valid_event_candidates_preserved_while_other_nested_malformed():
+    window = _window()
+    content = json.dumps(
+        {
+            "window_id": window.window_id,
+            "scene_summary": "Person at door.",
+            "salient_observations": [{"event_type": "bad", "narrative": "ignored for events"}],
+            "uncertainties": ["lighting"],
+            "event_candidates": [
+                {
+                    "event_type": "presence",
+                    "narrative": "Someone stands at the door.",
+                    "confidence": 0.9,
+                    "salience": 0.8,
+                    "tags": ["person"],
+                }
+            ],
+        }
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "salvaged_v2"
+    assert outcome.interpretation is not None
+    assert len(outcome.interpretation.event_candidates) == 1
+    assert outcome.interpretation.event_candidates[0].event_type == "presence"
+    assert outcome.interpretation.event_candidates[0].narrative == "Someone stands at the door."
+
+
+def test_event_candidates_synthesized_from_salient_observations_when_missing():
+    window = _window()
+    content = json.dumps(
+        {
+            "window_id": window.window_id,
+            "scene_summary": "Door and screen visible.",
+            "salient_observations": [
+                {
+                    "event_type": "object_seen",
+                    "narrative": "A door and a screen are visible.",
+                    "confidence": 0.8,
+                    "salience": 0.6,
+                    "tags": ["door", "screen"],
+                }
+            ],
+            "uncertainties": [],
+            "event_candidates": [],
+        }
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "salvaged_v2"
+    assert outcome.interpretation is not None
+    assert len(outcome.interpretation.event_candidates) == 1
+    candidate = outcome.interpretation.event_candidates[0]
+    assert candidate.event_type == "visual_observation"
+    assert candidate.narrative == "A door and a screen are visible."
+    assert candidate.tags == ["door", "screen"]
+    assert any("synthesized" in w for w in outcome.salvage_warnings)
+
+
+def test_flat_event_dict_uses_legacy_not_salvaged_v2():
+    window = _window()
+    content = json.dumps({"event_type": "solo", "narrative": "solo event"})
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "legacy_events_dict"
+    assert outcome.interpretation is not None
+    assert len(outcome.interpretation.event_candidates) == 1
+    assert outcome.interpretation.event_candidates[0].event_type == "solo"
+    assert outcome.interpretation.event_candidates[0].narrative == "solo event"
+
+
+def test_raw_events_dict_uses_legacy_path_not_salvaged_v2():
+    window = _window()
+    content = json.dumps(
+        {
+            "events": [
+                {
+                    "event_type": "presence",
+                    "narrative": "Someone is visible near the door.",
+                    "entities": ["person"],
+                    "tags": ["entry"],
+                    "confidence": 0.6,
+                    "salience": 0.5,
+                }
+            ]
+        }
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "legacy_events_dict"
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.scene_summary == "Someone is visible near the door."
+
+
+def test_raw_event_list_uses_legacy_list_path():
+    window = _window()
+    content = json.dumps(
+        [
+            {
+                "event_type": "activity",
+                "narrative": "Person sits at the table.",
+                "confidence": 0.75,
+            }
+        ]
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "legacy_events_list"
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.scene_summary == "Person sits at the table."
+
+
+def test_garbage_json_does_not_crash():
+    window = _window()
+
+    outcome = _parse("not json at all", window)
+    assert outcome.interpretation is None
+    assert outcome.parse_mode == "parse_failed"
+
+    outcome = _parse("{broken", window)
+    assert outcome.interpretation is None
+    assert outcome.parse_mode == "parse_failed"
+
+    assert try_legacy_fallback("also not json", window) is None
+
+
+def test_evidence_refs_default_to_window_artifact_ids_on_salvage():
+    window = _window(artifact_ids=["fallback-a", "fallback-b"])
+    content = json.dumps(
+        {
+            "window_id": window.window_id,
+            "scene_summary": "Salvaged scene.",
+            "salient_observations": [
+                {"event_type": "object_seen", "narrative": "Object visible."},
+            ],
+            "uncertainties": [],
+            "event_candidates": [],
+        }
+    )
+
+    outcome = _parse(content, window)
+    assert outcome.interpretation is not None
+
+    payload = project_interpretation_to_events(outcome.interpretation, window)
+    assert len(payload.events) == 1
+    assert payload.events[0].evidence_refs == ["fallback-a", "fallback-b"]
+
+
+def test_debug_parse_mode_available_from_outcome():
+    window = _window()
+    outcome = _parse(_valid_interpretation_json(window), window)
+
+    record = outcome.interpretation.model_dump() if outcome.interpretation else {}
+    record["parse_mode"] = outcome.parse_mode
+    record["salvage_warnings"] = outcome.salvage_warnings
+
+    assert record["parse_mode"] == "strict_v2"
+    assert "salvage_warnings" in record
 
 
 def test_project_event_candidates_to_vision_event_payload():
     window = _window()
-    interpretation = parse_llm_content(_valid_interpretation_json(window), window)
-    assert interpretation is not None
+    outcome = _parse(_valid_interpretation_json(window), window)
+    assert outcome.interpretation is not None
 
-    payload = project_interpretation_to_events(interpretation, window)
+    payload = project_interpretation_to_events(outcome.interpretation, window)
 
     assert isinstance(payload, VisionEventPayload)
     assert len(payload.events) == 1
@@ -109,12 +380,12 @@ def test_parse_interpretation_wrapper():
     inner = json.loads(_valid_interpretation_json(window))
     content = json.dumps({"interpretation": inner})
 
-    interpretation = parse_llm_content(content, window)
+    outcome = _parse(content, window)
 
-    assert interpretation is not None
-    assert interpretation.scene_summary == "A person walks through the frame."
-    assert interpretation.raw_model_output is not None
-    assert "interpretation" in interpretation.raw_model_output
+    assert outcome.parse_mode == "strict_v2"
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.raw_model_output is not None
+    assert "interpretation" in outcome.interpretation.raw_model_output
 
 
 def test_hybrid_events_key_with_scene_summary_coerces_event_candidates():
@@ -137,12 +408,13 @@ def test_hybrid_events_key_with_scene_summary_coerces_event_candidates():
         }
     )
 
-    interpretation = parse_llm_content(content, window)
+    outcome = _parse(content, window)
 
-    assert interpretation is not None
-    assert interpretation.scene_summary == "Hybrid legacy events field."
-    assert len(interpretation.event_candidates) == 1
-    assert interpretation.event_candidates[0].event_type == "presence"
+    assert outcome.parse_mode == "strict_v2"
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.scene_summary == "Hybrid legacy events field."
+    assert len(outcome.interpretation.event_candidates) == 1
+    assert outcome.interpretation.event_candidates[0].event_type == "presence"
 
 
 def test_empty_event_candidates_projection_returns_empty_payload():
@@ -162,74 +434,13 @@ def test_markdown_fenced_json_parses():
     window = _window()
     fenced = f"```json\n{_valid_interpretation_json(window)}\n```"
 
-    interpretation = parse_llm_content(fenced, window)
+    outcome = _parse(fenced, window)
 
-    assert interpretation is not None
-    assert interpretation.event_candidates[0].event_type == "movement"
-
-
-def test_fallback_events_dict_to_minimal_interpretation():
-    window = _window()
-    content = json.dumps(
-        {
-            "events": [
-                {
-                    "event_type": "presence",
-                    "narrative": "Someone is visible near the door.",
-                    "entities": ["person"],
-                    "tags": ["entry"],
-                    "confidence": 0.6,
-                    "salience": 0.5,
-                }
-            ]
-        }
-    )
-
-    interpretation = parse_llm_content(content, window)
-
-    assert interpretation is not None
-    assert interpretation.window_id == "w1"
-    assert interpretation.stream_id == "stream-1"
-    assert interpretation.camera_id == "cam-1"
-    assert interpretation.scene_summary == "Someone is visible near the door."
-    assert len(interpretation.event_candidates) == 1
-    assert interpretation.event_candidates[0].event_type == "presence"
-    assert interpretation.evidence_refs == ["art-1", "art-2"]
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.event_candidates[0].event_type == "movement"
 
 
-def test_fallback_raw_event_list_to_minimal_interpretation():
-    window = _window()
-    content = json.dumps(
-        [
-            {
-                "event_type": "activity",
-                "narrative": "Person sits at the table.",
-                "confidence": 0.75,
-            }
-        ]
-    )
-
-    interpretation = parse_llm_content(content, window)
-
-    assert interpretation is not None
-    assert interpretation.scene_summary == "Person sits at the table."
-    assert len(interpretation.event_candidates) == 1
-    assert interpretation.event_candidates[0].event_type == "activity"
-
-    legacy = try_legacy_fallback(content, window)
-    assert legacy is not None
-    assert legacy.scene_summary == "Person sits at the table."
-
-
-def test_invalid_json_returns_none_without_crashing():
-    window = _window()
-
-    assert parse_llm_content("not json at all", window) is None
-    assert parse_llm_content("{broken", window) is None
-    assert try_legacy_fallback("also not json", window) is None
-
-
-def test_evidence_refs_default_to_window_artifact_ids():
+def test_evidence_refs_default_to_window_artifact_ids_on_projection():
     window = _window(artifact_ids=["fallback-a", "fallback-b"])
     interpretation = VisionSceneInterpretationV1(
         window_id=window.window_id,
@@ -253,10 +464,10 @@ def test_evidence_refs_default_to_window_artifact_ids():
 
 def test_vision_event_payload_shape_compatible():
     window = _window()
-    interpretation = parse_llm_content(_valid_interpretation_json(window), window)
-    assert interpretation is not None
+    outcome = _parse(_valid_interpretation_json(window), window)
+    assert outcome.interpretation is not None
 
-    payload = project_interpretation_to_events(interpretation, window)
+    payload = project_interpretation_to_events(outcome.interpretation, window)
 
     assert hasattr(payload, "events")
     assert isinstance(payload.events, list)

--- a/services/orion-vision-council/tests/test_interpretation_v2.py
+++ b/services/orion-vision-council/tests/test_interpretation_v2.py
@@ -251,6 +251,49 @@ def test_event_candidates_synthesized_from_salient_observations_when_missing():
     assert any("synthesized" in w for w in outcome.salvage_warnings)
 
 
+def test_missing_scene_summary_salvages_not_legacy():
+    window = _window()
+    content = json.dumps(
+        {
+            "window_id": window.window_id,
+            "salient_observations": [],
+            "uncertainties": [],
+            "event_candidates": [],
+        }
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "salvaged_v2"
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.scene_summary == "a person walks"
+    assert outcome.interpretation.event_candidates == []
+
+
+def test_scene_summary_with_top_level_event_fields_salvages():
+    window = _window()
+    content = json.dumps(
+        {
+            "window_id": window.window_id,
+            "scene_summary": "Person visible at door.",
+            "event_type": "presence",
+            "narrative": "Someone stands at the door.",
+            "salient_observations": [],
+            "uncertainties": ["lighting"],
+            "event_candidates": [],
+        }
+    )
+
+    outcome = _parse(content, window)
+
+    assert outcome.parse_mode == "salvaged_v2"
+    assert outcome.interpretation is not None
+    assert outcome.interpretation.scene_summary == "Person visible at door."
+    assert len(outcome.interpretation.event_candidates) == 1
+    assert outcome.interpretation.event_candidates[0].event_type == "presence"
+    assert outcome.interpretation.event_candidates[0].narrative == "Someone stands at the door."
+
+
 def test_flat_event_dict_uses_legacy_not_salvaged_v2():
     window = _window()
     content = json.dumps({"event_type": "solo", "narrative": "solo event"})


### PR DESCRIPTION
## Summary

Hardens Vision Council V2 parsing against real LLM output shapes observed in runtime.

The Council V2 architecture is live, but strict Pydantic validation was discarding useful model output when one nested field had a non-canonical shape. This adds a salvage/coercion pass before legacy fallback.

Fixes live failure modes:

- `salient_observations` with `{event_type, narrative}` now coerces to `{observation}`
- `uncertainties: ["door", "screen"]` now coerces to uncertainty objects
- `{uncertainty_type: ...}` now maps to `{uncertainty: ...}`
- good `scene_summary` and valid `event_candidates` survive partial nested validation errors
- missing `scene_summary` is derived from window captions during salvage (not misrouted to legacy)
- event candidates can be synthesized from salient observations when missing
- top-level `event_type`/`narrative` promote to `event_candidates` when salvage runs with empty events
- flat legacy event dicts still route through legacy path (not mislabeled `salvaged_v2`)

## Changes

- Added `salvage_interpretation_dict` lenient V2 normalization pass
- Added `InterpretationParseOutcome` with parse modes: `strict_v2`, `salvaged_v2`, `legacy_events_dict`, `legacy_events_list`, `parse_failed`
- Added salvage warnings to Council debug ring buffer (`parse_mode`, `salvage_warnings`)
- Added concise parse-mode logging (`interpretation_parse`, `interpretation_strict_failed`, `interpretation_salvage_failed`)
- Added `_is_flat_legacy_event_dict` guard so flat event shapes skip salvage
- Added 23 unit tests covering live malformed output shapes and legacy regression guards

## Code review fixes

- Removed overly strict salvage acceptance gate that dropped scene-summary-only recoveries into legacy
- Added `scene_summary` to flat-legacy V2 marker set so hybrid payloads keep summary through salvage
- Added top-level event field promotion during salvage when `event_candidates` empty

## Validation

- [x] `PYTHONPATH=services/orion-vision-council:. pytest services/orion-vision-council/tests -q` — **23 passed**
- [x] `cd services/orion-vision-scribe && PYTHONPATH=.:../.. pytest tests -q` — **10 passed**
- [x] `python3 -m compileall services/orion-vision-council/app orion/schemas/vision.py orion/schemas/registry.py` — **exit 0**
- [ ] Runtime debug buffer shows real scene summaries with `parse_mode=strict_v2|salvaged_v2` (post-deploy)

## Out of scope

- Grammar projection, vector persistence, memory cards, Scribe/SQL/RDF changes
- Vision Host / Frame Router / Window changes, new perception service, `vision-edge` changes

## Base branch

Stacks on `feat/vision-council-scene-interpretation-v1`.