### PR TITLE
Feat/hub social room ops v1

### DIFF
--- a/orion/inspection/social.py
+++ b/orion/inspection/social.py
@@ -97,6 +97,133 @@ def _candidate_bucket(candidates: Iterable[Dict[str, Any]], *, decision: str) ->
     return [item for item in candidates if str(item.get("inclusion_decision") or "") == decision]
 
 
+def build_hub_direct_inspection_sections(
+    *,
+    route_debug: Dict[str, Any],
+    metadata: Dict[str, Any] | None = None,
+) -> list[SocialInspectionSectionV1]:
+    """Materialize hub-local inspection sections when bridge turn-policy surfaces are absent."""
+    debug = dict(route_debug or {})
+    meta = dict(metadata or {})
+    sections: list[SocialInspectionSectionV1] = []
+
+    verb = _compact_text(debug.get("verb") or meta.get("verb"), limit=80)
+    mode = _compact_text(debug.get("mode") or debug.get("selected_ui_route"), limit=40)
+    llm_route = _compact_text((debug.get("options") or {}).get("llm_route") or debug.get("llm_route"), limit=40)
+    social_mode = _compact_text(debug.get("social_room_mode"), limit=40)
+    routing_selected = [item for item in (f"verb={verb}" if verb else "", f"mode={mode}" if mode else "", f"compute={llm_route}" if llm_route else "", f"social_room_mode={social_mode}" if social_mode else "") if item]
+    routing_section = _make_section(
+        section_kind="routing",
+        included=[],
+        selected=routing_selected,
+        softened=[],
+        excluded=[],
+        why="Hub-direct routing uses chat_social_room; compute lane comes from the Hub Compute dropdown.",
+        traces=[
+            _trace(
+                trace_kind="hub_direct_route",
+                decision_state="active",
+                summary=f"{verb or 'chat_social_room'} on compute lane {llm_route or 'quick'}",
+                why="Social room toggle forces the social verb; llm_route is orthogonal.",
+            )
+        ],
+        metadata={"source": "hub_direct"},
+    )
+    if routing_section is not None:
+        sections.append(routing_section)
+
+    recall_profile = _compact_text(debug.get("recall_profile") or (debug.get("options") or {}).get("recall_profile"), limit=80)
+    recall_enabled = debug.get("recall_enabled")
+    recall_selected = [
+        item
+        for item in (
+            f"profile={recall_profile}" if recall_profile else "",
+            f"enabled={recall_enabled}" if recall_enabled is not None else "",
+            "lane=social",
+        )
+        if item
+    ]
+    context_section = _make_section(
+        section_kind="context_window",
+        included=[],
+        selected=recall_selected,
+        softened=[],
+        excluded=[],
+        why="Hub-direct recall uses social.room.v1 when enabled.",
+        traces=[
+            _trace(
+                trace_kind="hub_direct_recall",
+                decision_state="active",
+                summary=recall_profile or "social.room.v1",
+                why="Recall profile is pinned for social_room turns.",
+            )
+        ],
+    )
+    if context_section is not None:
+        sections.append(context_section)
+
+    posture = _compact_text(debug.get("social_redaction_posture") or meta.get("social_redaction_posture"), limit=40)
+    epistemic_section = _make_section(
+        section_kind="epistemic",
+        included=[],
+        selected=[f"redaction_posture={posture}"] if posture else [],
+        softened=[],
+        excluded=[],
+        why="Redaction posture gates keyword blocklist and artifact scope defaults.",
+        traces=[],
+    )
+    if epistemic_section is not None:
+        sections.append(epistemic_section)
+
+    skill_selection = debug.get("social_skill_selection") if isinstance(debug.get("social_skill_selection"), dict) else {}
+    skill_result = debug.get("social_skill_result") if isinstance(debug.get("social_skill_result"), dict) else {}
+    if skill_selection.get("selected_skill") or skill_result.get("summary"):
+        skill_section = _make_section(
+            section_kind="artifact_dialogue",
+            included=[_safe_text(skill_result.get("summary"), limit=180)] if skill_result.get("summary") else [],
+            selected=[_compact_text(skill_selection.get("selected_skill"), limit=80)] if skill_selection.get("selected_skill") else [],
+            softened=[],
+            excluded=[],
+            why="Deterministic social skill surfacing ran before the LLM reply.",
+            traces=[],
+        )
+        if skill_section is not None:
+            sections.append(skill_section)
+
+    safety_section = _make_section(
+        section_kind="safety",
+        included=[],
+        selected=[f"posture={posture}"] if posture else ["bounded recall"],
+        softened=[],
+        excluded=[],
+        why="Hub-direct keeps PII regex hygiene regardless of posture.",
+        traces=[],
+    )
+    if safety_section is not None:
+        sections.append(safety_section)
+
+    gif_section = _make_section(
+        section_kind="gif",
+        included=[],
+        selected=["hub_direct — GIF policy N/A (bridge-only)"],
+        softened=[],
+        excluded=[],
+        why="GIF observe/policy/post lives in orion-social-room-bridge, not Hub websocket chat.",
+        traces=[
+            _trace(
+                trace_kind="hub_direct_gif",
+                decision_state="omitted",
+                summary="GIF policy N/A (bridge-only)",
+                why="Bridge-only transport seam; Hub UI is text-only.",
+            )
+        ],
+    )
+    if gif_section is not None:
+        sections.append(gif_section)
+
+    return sections
+
+
 def build_social_inspection_snapshot(
     *,
     platform: str,

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -426,6 +426,16 @@ Then open the Hub Memory tab → **Review queue**, or `GET /api/memory/cards?sta
 
 **Compute lane override (mode vs compute):** Hub chat UI exposes **Mode** and **Compute** dropdowns. Mode decides behavior (`Auto`, `Grounded Small`, `Brain`, `Quick`, `Story`, `Agent`, `Council`); **Compute** selects the GPU/model lane (`chat`, `quick`, `agent`, `metacog`). Default compute is `quick`. Hub proxies `GET /api/llm-routes` from `HUB_LLM_GATEWAY_URL` (`GET /routes` on orion-llm-gateway) and polls every 30s. Selected lane is sent as `llm_route` on chat payloads (wired into cortex `options.llm_route`). Agent mode still routes to context-exec with `llm_profile` bound to the selected compute lane. Down lanes warn with explicit **Use quick / Try anyway / Cancel** — no silent fallback.
 
+**Social room toggle vs Mode vs Compute:**
+
+| Control | What it sets | Social room ON override |
+|---------|----------------|-------------------------|
+| **Mode** | Behavior lane (`brain`, `agent`, `council`, …) | Forces `mode=brain` |
+| **Compute** | GPU/model lane via `llm_route` (`chat`, `quick`, …) | **Still applies** — pick which model serves `chat_social_room` |
+| **Social room** checkbox | `chat_profile=social_room`, `social_room_mode=hub_direct` | Forces verb **`chat_social_room`** (not `chat_general` / `chat_quick`) |
+
+Bridge env keys `SOCIAL_BRIDGE_HUB_MODE` / `SOCIAL_BRIDGE_HUB_VERB` affect **CallSyne bridge → Hub** calls only; the Hub UI toggle ignores them.
+
 **Agent mode → context-exec:** When `HUB_AGENT_CONTEXT_EXEC_ENABLED=true` (default), Hub **Agent** mode calls `POST /context-exec/run` on `HUB_CONTEXT_EXEC_API_URL` instead of legacy AgentChain/ReAct. Selected route is passed as `llm_profile` on the context-exec request. Hub renders an inline operator response (`Agent run complete`, mode, route, synthesis status, result, proposal link, mutation none) from `operator_summary`. Proposal review / Pending Decisions remain unchanged.
 
 **Investigation v2 (epistemic pipeline):** When `CONTEXT_EXEC_INVESTIGATION_V2_ENABLED=true`, Hub Agent lane threads `answer_contract` from `answer_contract_draft` into context-exec, sends `mode=investigation_v2` with profile-derived permissions (`context_exec_permissions_for_llm_profile`), and receives **`final_text`** (finalize-rendered user voice) as `llm_response`. `InvestigationReportV2` remains an inspectable operator sidecar in `metadata.context_exec` (`operator_report_text`). Conceptual/personal turns do not trigger repo/trace sweeps. Default is `false` (legacy keyword mode inference preserved).

--- a/services/orion-hub/scripts/social_room.py
+++ b/services/orion-hub/scripts/social_room.py
@@ -4,7 +4,7 @@ import logging
 import re
 from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 
-from orion.inspection.social import build_social_inspection_snapshot
+from orion.inspection.social import build_hub_direct_inspection_sections, build_social_inspection_snapshot
 from orion.schemas.social_chat import (
     SocialConceptEvidenceV1,
     SocialGroundingStateV1,
@@ -898,6 +898,16 @@ def build_social_inspection_debug(
             inspection.participant_id or "room",
             inspection.metadata.get("safety_omissions"),
         )
+    hub_direct = str(
+        route_debug.get("social_room_mode") or payload.get("social_room_mode") or ""
+    ).strip().lower() == "hub_direct"
+    if hub_direct:
+        hub_sections = build_hub_direct_inspection_sections(route_debug=route_debug, metadata=metadata)
+        if hub_sections:
+            inspection.sections.extend(hub_sections)
+            inspection.summary = inspection.summary or (
+                f"Hub-direct turn · {len(inspection.sections)} sections · verb {route_debug.get('verb') or 'chat_social_room'}"
+            )
     return SocialInspectionSnapshotV1.model_validate(inspection).model_dump(mode="json")
 
 

--- a/services/orion-hub/scripts/social_room.py
+++ b/services/orion-hub/scripts/social_room.py
@@ -905,7 +905,7 @@ def build_social_inspection_debug(
         hub_sections = build_hub_direct_inspection_sections(route_debug=route_debug, metadata=metadata)
         if hub_sections:
             inspection.sections.extend(hub_sections)
-            inspection.summary = inspection.summary or (
+            inspection.summary = (
                 f"Hub-direct turn · {len(inspection.sections)} sections · verb {route_debug.get('verb') or 'chat_social_room'}"
             )
     return SocialInspectionSnapshotV1.model_validate(inspection).model_dump(mode="json")

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -34,6 +34,7 @@ from scripts.social_room import (
     is_social_room_payload,
     social_room_client_meta,
 )
+from scripts import social_room_inspection_cache
 from scripts.cortex_chat_display import hub_effective_chat_text
 from scripts.context_exec_agent_bridge import run_hub_agent_via_context_exec, should_use_context_exec_agent_lane
 from scripts.trace_payloads import extract_agent_trace_payload
@@ -1246,6 +1247,10 @@ async def websocket_endpoint(websocket: WebSocket):
                 cortex_corr_id=cortex_corr_id,
                 root_correlation_id=str(root_corr).strip() if root_corr else None,
             )
+            if is_social_room_payload(data):
+                _social_room_id = str((data.get("external_room") or {}).get("room_id") or "").strip()
+                if _social_room_id and route_debug:
+                    social_room_inspection_cache.store(_social_room_id, route_debug)
             ws_payload = {
                 "llm_response": orion_response_text,
                 # Parity with HTTP /api/chat: lets the UI coalesce if primary string ever lags `raw.final_text`

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -233,6 +233,7 @@
               id="hubModeSelect"
               class="flex-1 min-w-0 bg-gray-900/80 text-gray-100 text-xs rounded border border-gray-700 px-2 py-1.5 focus:outline-none focus:border-indigo-500"
               aria-label="Hub chat mode"
+              title="Behavior lane: agent/council/brain routing. Social room ON forces brain mode and chat_social_room verb."
             >
               <option value="auto">Auto</option>
               <option value="grounded_small" selected>Grounded Small</option>
@@ -249,6 +250,7 @@
               id="hubComputeSelect"
               class="flex-1 min-w-0 bg-gray-900/80 text-gray-100 text-xs rounded border border-gray-700 px-2 py-1.5 focus:outline-none focus:border-indigo-500 font-mono"
               aria-label="Compute lane"
+              title="GPU/model lane (llm_route): chat, quick, agent, metacog. Still applies when Social room is ON."
             >
               <option value="quick">quick — loading…</option>
             </select>

--- a/services/orion-hub/tests/test_hub_direct_inspection_cache.py
+++ b/services/orion-hub/tests/test_hub_direct_inspection_cache.py
@@ -34,3 +34,11 @@ def test_get_latest_returns_most_recent_room() -> None:
     latest = cache.get_latest()
     assert latest is not None
     assert latest["room_id"] in {"hub-direct", "other-room"}
+
+
+def test_websocket_handler_calls_inspection_cache_store() -> None:
+    """Regression: WS path must store routing_debug (parity with api_routes HTTP path)."""
+    ws_path = Path(__file__).resolve().parents[1] / "scripts" / "websocket_handler.py"
+    source = ws_path.read_text(encoding="utf-8")
+    assert "social_room_inspection_cache.store" in source
+    assert "is_social_room_payload(data)" in source

--- a/services/orion-hub/tests/test_hub_direct_inspection_cache.py
+++ b/services/orion-hub/tests/test_hub_direct_inspection_cache.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_store_social_room_inspection_from_route_debug() -> None:
+    cache = importlib.import_module("scripts.social_room_inspection_cache")
+    cache._latest.clear()
+    route_debug = {
+        "verb": "chat_social_room",
+        "social_room_mode": "hub_direct",
+        "social_inspection": {"platform": "hub", "room_id": "hub-direct", "sections": []},
+    }
+    cache.store("hub-direct", route_debug)
+    entry = cache.get("hub-direct")
+    assert entry is not None
+    assert entry["routing_debug"]["verb"] == "chat_social_room"
+    assert entry["room_id"] == "hub-direct"
+    assert entry["stored_at"]
+
+
+def test_get_latest_returns_most_recent_room() -> None:
+    cache = importlib.import_module("scripts.social_room_inspection_cache")
+    cache._latest.clear()
+    cache.store("hub-direct", {"verb": "chat_social_room", "corr": "a"})
+    cache.store("other-room", {"verb": "chat_social_room", "corr": "b"})
+    latest = cache.get_latest()
+    assert latest is not None
+    assert latest["room_id"] in {"hub-direct", "other-room"}

--- a/services/orion-hub/tests/test_hub_direct_inspection_cache.py
+++ b/services/orion-hub/tests/test_hub_direct_inspection_cache.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
-import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+CACHE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "social_room_inspection_cache.py"
+SPEC = importlib.util.spec_from_file_location("hub_social_room_inspection_cache", CACHE_PATH)
+assert SPEC and SPEC.loader
+cache = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = cache
+SPEC.loader.exec_module(cache)
 
 
 def test_store_social_room_inspection_from_route_debug() -> None:
-    cache = importlib.import_module("scripts.social_room_inspection_cache")
     cache._latest.clear()
     route_debug = {
         "verb": "chat_social_room",
@@ -20,7 +28,6 @@ def test_store_social_room_inspection_from_route_debug() -> None:
 
 
 def test_get_latest_returns_most_recent_room() -> None:
-    cache = importlib.import_module("scripts.social_room_inspection_cache")
     cache._latest.clear()
     cache.store("hub-direct", {"verb": "chat_social_room", "corr": "a"})
     cache.store("other-room", {"verb": "chat_social_room", "corr": "b"})

--- a/services/orion-hub/tests/test_social_room.py
+++ b/services/orion-hub/tests/test_social_room.py
@@ -692,3 +692,4 @@ def test_build_social_inspection_debug_hub_direct_has_sections() -> None:
     assert len(snapshot["sections"]) >= 3
     assert snapshot["platform"] == "hub"
     assert snapshot["room_id"] == "hub-direct"
+    assert "Hub-direct turn" in snapshot["summary"]

--- a/services/orion-hub/tests/test_social_room.py
+++ b/services/orion-hub/tests/test_social_room.py
@@ -693,3 +693,5 @@ def test_build_social_inspection_debug_hub_direct_has_sections() -> None:
     assert snapshot["platform"] == "hub"
     assert snapshot["room_id"] == "hub-direct"
     assert "Hub-direct turn" in snapshot["summary"]
+    section_kinds = {section["section_kind"] for section in snapshot["sections"]}
+    assert {"routing", "context_window", "gif"}.issubset(section_kinds)

--- a/services/orion-hub/tests/test_social_room.py
+++ b/services/orion-hub/tests/test_social_room.py
@@ -666,3 +666,29 @@ def test_safe_recall_relaxed_posture_does_not_suppress_blocked_memory_snippets()
     assert strict_result.snippets == []
     assert relaxed_result.snippets
     assert "private journal" in relaxed_result.snippets[0]
+
+
+def test_build_social_inspection_debug_hub_direct_has_sections() -> None:
+    payload = {
+        "chat_profile": "social_room",
+        "social_room_mode": "hub_direct",
+        "external_room": {"platform": "hub", "room_id": "hub-direct"},
+        "external_participant": {"participant_id": "juniper"},
+    }
+    route_debug = {
+        "verb": "chat_social_room",
+        "mode": "brain",
+        "llm_route": "chat",
+        "social_room_mode": "hub_direct",
+        "recall_profile": "social.room.v1",
+        "recall_enabled": True,
+        "social_redaction_posture": "strict",
+    }
+    snapshot = hub_social_room.build_social_inspection_debug(
+        payload=payload,
+        route_debug=route_debug,
+        metadata={"social_redaction_posture": "strict"},
+    )
+    assert len(snapshot["sections"]) >= 3
+    assert snapshot["platform"] == "hub"
+    assert snapshot["room_id"] == "hub-direct"

--- a/services/orion-social-memory/README.md
+++ b/services/orion-social-memory/README.md
@@ -1,0 +1,23 @@
+# orion-social-memory
+
+Relational continuity synthesizer for social-room turns (`orion:chat:social:stored`).
+
+## Database migration (required on existing installs)
+
+`Base.metadata.create_all()` does **not** add columns to existing tables. After pulling hub-social-room-ops-v1, run:
+
+```bash
+psql "$DATABASE_URL" -f services/orion-sql-db/manual_migration_social_memory_calibration_v1.sql
+```
+
+Use the same DSN as `DATABASE_URL` in this service's `.env` (default database: `conjourney`).
+
+## Smoke checks
+
+```bash
+curl -fsS 'http://localhost:8765/health'
+curl -fsS 'http://localhost:8765/summary?platform=hub&room_id=hub-direct&participant_id=juniper'
+curl -fsS 'http://localhost:8765/inspection?platform=hub&room_id=hub-direct&participant_id=juniper'
+```
+
+Restart `orion-social-memory` after migration if it was crash-looping on schema errors.

--- a/services/orion-social-room-bridge/.env_example
+++ b/services/orion-social-room-bridge/.env_example
@@ -33,7 +33,9 @@ SOCIAL_BRIDGE_LIGHT_INITIATIVE_MIN_CONTINUITY=0.45
 SOCIAL_BRIDGE_DEDUPE_TTL_SEC=3600
 SOCIAL_BRIDGE_SESSION_NAMESPACE=callsyne-room
 SOCIAL_BRIDGE_HUB_MODE=brain
-SOCIAL_BRIDGE_HUB_VERB=chat_quick
+# Bridge-only: verb sent when bridge calls Hub /api/chat. Empty = omit verbs (Hub resolves chat_social_room).
+# Hub UI social-room toggle ignores this; do not set chat_quick if you want peer-mode social room from CallSyne.
+SOCIAL_BRIDGE_HUB_VERB=
 SOCIAL_BRIDGE_RETURN_2XX_ON_DELIVERY_FAILURE=true
 # Polling CallSyne for inbound messages. Leave false for Hub-direct social room
 # (Hub UI toggle uses orion-social-memory directly; no CallSyne poll/read path).

--- a/services/orion-social-room-bridge/.env_example
+++ b/services/orion-social-room-bridge/.env_example
@@ -32,6 +32,7 @@ SOCIAL_BRIDGE_MIN_NOVELTY_SCORE=0.22
 SOCIAL_BRIDGE_LIGHT_INITIATIVE_MIN_CONTINUITY=0.45
 SOCIAL_BRIDGE_DEDUPE_TTL_SEC=3600
 SOCIAL_BRIDGE_SESSION_NAMESPACE=callsyne-room
+# Bridge-only: mode sent when bridge calls Hub /api/chat. Hub UI social-room toggle ignores this.
 SOCIAL_BRIDGE_HUB_MODE=brain
 # Bridge-only: verb sent when bridge calls Hub /api/chat. Empty = omit verbs (Hub resolves chat_social_room).
 # Hub UI social-room toggle ignores this; do not set chat_quick if you want peer-mode social room from CallSyne.

--- a/services/orion-sql-db/manual_migration_social_memory_calibration_v1.sql
+++ b/services/orion-sql-db/manual_migration_social_memory_calibration_v1.sql
@@ -1,0 +1,45 @@
+-- Hub social-room ops v1: align live Postgres with orion-social-memory models.
+-- Run against the conjourney DSN used by orion-social-memory (see service README).
+
+BEGIN;
+
+-- social_participant_continuity (hygiene + artifact dialogue columns)
+ALTER TABLE social_participant_continuity ADD COLUMN IF NOT EXISTS shared_artifact_proposal JSONB;
+ALTER TABLE social_participant_continuity ADD COLUMN IF NOT EXISTS shared_artifact_revision JSONB;
+ALTER TABLE social_participant_continuity ADD COLUMN IF NOT EXISTS shared_artifact_confirmation JSONB;
+ALTER TABLE social_participant_continuity ADD COLUMN IF NOT EXISTS calibration_signals JSONB;
+ALTER TABLE social_participant_continuity ADD COLUMN IF NOT EXISTS peer_calibration JSONB;
+ALTER TABLE social_participant_continuity ADD COLUMN IF NOT EXISTS trust_boundary JSONB;
+ALTER TABLE social_participant_continuity ADD COLUMN IF NOT EXISTS memory_freshness JSONB;
+ALTER TABLE social_participant_continuity ADD COLUMN IF NOT EXISTS decay_signals JSONB;
+ALTER TABLE social_participant_continuity ADD COLUMN IF NOT EXISTS regrounding_decisions JSONB;
+
+-- social_room_continuity (thread/deliberation/gif/hygiene columns)
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS shared_artifact_proposal JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS shared_artifact_revision JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS shared_artifact_confirmation JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS active_threads JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS current_thread_key TEXT;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS current_thread_summary TEXT NOT NULL DEFAULT '';
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS handoff_signal JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS active_claims JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS recent_claim_revisions JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS claim_attributions JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS claim_consensus_states JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS claim_divergence_signals JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS bridge_summary JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS clarifying_question JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS deliberation_decision JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS turn_handoff JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS closure_signal JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS floor_decision JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS gif_usage_state JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS active_commitments JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS calibration_signals JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS peer_calibrations JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS trust_boundaries JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS memory_freshness JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS decay_signals JSONB;
+ALTER TABLE social_room_continuity ADD COLUMN IF NOT EXISTS regrounding_decisions JSONB;
+
+COMMIT;

--- a/tests/test_social_inspection.py
+++ b/tests/test_social_inspection.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from orion.inspection.social import build_social_inspection_snapshot
+from orion.inspection.social import (
+    build_hub_direct_inspection_sections,
+    build_social_inspection_snapshot,
+)
 
 
 def _surfaces() -> dict:
@@ -250,3 +253,34 @@ def test_social_inspection_snapshot_omits_blocked_material_and_keeps_pending_art
         for item in bucket
     ).lower()
     assert "sealed private note" not in combined
+
+
+def test_hub_direct_inspection_sections_include_routing_recall_and_gif_na() -> None:
+    route_debug = {
+        "verb": "chat_social_room",
+        "mode": "brain",
+        "llm_route": "chat",
+        "social_room_mode": "hub_direct",
+        "chat_profile": "social_room",
+        "recall_profile": "social.room.v1",
+        "recall_enabled": True,
+        "social_redaction_posture": "strict",
+    }
+    sections = build_hub_direct_inspection_sections(route_debug=route_debug, metadata={})
+    kinds = {section.section_kind for section in sections}
+    assert "routing" in kinds
+    assert "context_window" in kinds
+    assert "gif" in kinds
+    gif = next(item for item in sections if item.section_kind == "gif")
+    assert any("bridge-only" in trace.summary.lower() for trace in gif.decision_traces)
+
+
+def test_hub_direct_inspection_sections_include_skill_when_present() -> None:
+    route_debug = {
+        "verb": "chat_social_room",
+        "social_room_mode": "hub_direct",
+        "social_skill_selection": {"selected_skill": "social_self_ground", "used": True},
+        "social_skill_result": {"summary": "Oríon is here as a peer."},
+    }
+    sections = build_hub_direct_inspection_sections(route_debug=route_debug, metadata={})
+    assert any(section.section_kind == "artifact_dialogue" for section in sections)


### PR DESCRIPTION
## Summary

- Add idempotent Postgres migration for missing `orion-social-memory` calibration/hygiene columns so `/summary` and `/inspection` stop 500ing on hub-direct.
- Add `build_hub_direct_inspection_sections()` and wire into `build_social_inspection_debug()` so Social Inspection panel shows routing, recall, epistemic, safety, and GIF (bridge-only) sections from `route_debug`.
- Store websocket social-room `routing_debug` in `social_room_inspection_cache` for parity with HTTP `/api/chat`.
- Document Mode vs Compute vs social-room toggle in Hub README, UI tooltips, and bridge `.env_example` comments.
- Post-review fixups: hub-direct summary overwrite, cache test import isolation, WS wiring contract test, stronger integration assertions.

## Outcome moved

- Social-memory `/summary` and `/inspection` return HTTP 200 after migration (was 500 on `calibration_signals does not exist`).
- Hub-direct Social Inspection materializes ≥5 sections from live `route_debug` instead of empty panel.
- Websocket turns populate `/api/social-room/inspection/latest` the same way HTTP chat does.
- Operators can distinguish Mode (behavior lane) from Compute (model lane) when social room is ON.

## Current architecture

Before this patch, hub-direct social room had schema drift in Postgres (models ahead of live DB), zero bridge-policy inspection sections in the Hub UI, and no WS write to the in-memory inspection cache. Mode/Compute semantics were undocumented.

## Architecture touched

- `services/orion-sql-db/` — manual migration SQL
- `services/orion-social-memory/` — operator README
- `orion/inspection/social.py` — hub-direct section builder
- `services/orion-hub/scripts/social_room.py` — merge hub sections into inspection snapshot
- `services/orion-hub/scripts/websocket_handler.py` — cache store on WS social turns
- `services/orion-hub/templates/index.html` — Mode/Compute tooltips
- `services/orion-social-room-bridge/.env_example` — bridge-only env comments

## Files changed

- `services/orion-sql-db/manual_migration_social_memory_calibration_v1.sql`: IF NOT EXISTS column migration
- `services/orion-social-memory/README.md`: operator migration + smoke curls
- `orion/inspection/social.py`: `build_hub_direct_inspection_sections()`
- `services/orion-hub/scripts/social_room.py`: hub-direct section merge + summary overwrite
- `services/orion-hub/scripts/websocket_handler.py`: `social_room_inspection_cache.store()` before WS send
- `services/orion-hub/README.md`: Mode/Compute/social-room table
- `services/orion-hub/templates/index.html`: tooltips on `#hubModeSelect` / `#hubComputeSelect`
- `services/orion-social-room-bridge/.env_example`: bridge-only comments; `SOCIAL_BRIDGE_HUB_VERB` default empty
- `tests/test_social_inspection.py`, `services/orion-hub/tests/test_social_room.py`, `services/orion-hub/tests/test_hub_direct_inspection_cache.py`

## Schema / bus / API changes

- Added: Postgres columns on `social_participant_continuity` and `social_room_continuity` (manual migration)
- Behavior changed: hub-direct inspection snapshots include hub-local sections; WS turns write inspection cache
- Compatibility: migration idempotent; existing bridge `.env` with `SOCIAL_BRIDGE_HUB_VERB=chat_quick` unchanged unless operator opts in

## Env/config changes

- `.env_example` updated: `services/orion-social-room-bridge/.env_example`
- local `.env` synced: default sync run — **no bridge keys synced** (`SOCIAL_BRIDGE_*` not on allowlist). Main workspace still has `SOCIAL_BRIDGE_HUB_VERB=chat_quick`.

## Tests run

```text
PYTHONPATH=. pytest tests/test_social_inspection.py \
  services/orion-hub/tests/test_hub_direct_inspection_cache.py \
  services/orion-hub/tests/test_social_room.py::test_build_social_inspection_debug_hub_direct_has_sections -q
→ 9 passed
```

## Evals run

No eval harness for this seam; covered by unit + integration tests.

## Docker/build/smoke checks

Migration applied on operator Postgres during implementation. Social-memory curls → 200. Hub redeploy with branch code: **UNVERIFIED** until rebuild.

## Review findings fixed

- Hub-direct summary overwrite (was showing "0 sections…")
- Cache test import isolation for combined pytest suite
- WS → cache contract test
- Rebased onto current main (clean 11-file diff)

## Restart required

```bash
psql "$DATABASE_URL" -f services/orion-sql-db/manual_migration_social_memory_calibration_v1.sql
docker compose -f services/orion-social-memory/docker-compose.yml restart
docker compose -f services/orion-hub/docker-compose.yml up -d --build
```

## Risks / concerns

- **Low:** Operator must run manual Postgres migration on existing conjourney DB
- **Low:** Bridge `.env_example` default verb empty; local `.env` not auto-synced

---

**Status: DONE** (push complete; PR body ready — needs manual create or `gh auth login` then I can run `gh pr create`).