### PR TITLE
fix(spark): enqueue heavy introspection on meta patch, skip mind hops

### DIFF
--- a/scripts/eval_spark_introspection_contract.sh
+++ b/scripts/eval_spark_introspection_contract.sh
@@ -25,6 +25,7 @@ export PYTHONPATH=.
 
 "$PY" -m pytest \
   services/orion-spark-introspector/tests/test_handle_candidate_enqueue_policy.py \
+  services/orion-spark-introspector/tests/test_spark_meta_patch_heavy_enqueue.py \
   -q --tb=short
 
 "$PY" -m pytest \

--- a/services/orion-llm-gateway/app/llm_backend.py
+++ b/services/orion-llm-gateway/app/llm_backend.py
@@ -560,6 +560,10 @@ def _should_publish_spark_candidate(body: ChatBody, spark_meta: Dict) -> bool:
     if bool(opts.get("post_turn")) and bool(opts.get("skip_chat_stance_inputs")):
         return False
 
+    mind_phase = str(opts.get("mind_phase") or "").strip()
+    if mind_phase:
+        return False
+
     return True
 
 

--- a/services/orion-llm-gateway/tests/test_spark_candidate_publish_policy.py
+++ b/services/orion-llm-gateway/tests/test_spark_candidate_publish_policy.py
@@ -47,6 +47,8 @@ def test_should_publish_on_normal_chat_completion() -> None:
             None,
             {},
         ),
+        ({"mind_phase": "stance_handoff"}, None, {}),
+        ({"mind_phase": "semantic_synthesis"}, None, {}),
     ],
 )
 def test_should_not_publish_internal_rpc_completions(options, verb, meta_extra) -> None:

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -65,6 +65,8 @@ _CANDIDATE_QUALITY: Dict[str, int] = {}
 _CANDIDATE_LAST_SEEN_TS: Dict[str, float] = {}
 _CANDIDATE_TELEM_EMITTED: Dict[str, float] = {}
 _CANDIDATE_SPARK_META: Dict[str, Dict[str, Any]] = {}
+_CANDIDATE_STIMULUS: Dict[str, Dict[str, Any]] = {}
+_CANDIDATE_HEAVY_ENQUEUED: Dict[str, float] = {}
 # keep cache small + bounded
 _CANDIDATE_CACHE_TTL_SEC = 600.0  # 10 minutes
 _EXPECTED_EMB: Dict[str, np.ndarray] = {}
@@ -220,12 +222,18 @@ def _prune_candidate_caches() -> None:
         _CANDIDATE_QUALITY.pop(k, None)
         _CANDIDATE_TELEM_EMITTED.pop(k, None)
         _CANDIDATE_SPARK_META.pop(k, None)
+        _CANDIDATE_STIMULUS.pop(k, None)
+        _CANDIDATE_HEAVY_ENQUEUED.pop(k, None)
     # drop entries that no longer have a last-seen timestamp
     known_keys = set(_CANDIDATE_LAST_SEEN_TS)
     for k in set(_CANDIDATE_QUALITY) - known_keys:
         _CANDIDATE_QUALITY.pop(k, None)
     for k in set(_CANDIDATE_TELEM_EMITTED) - known_keys:
         _CANDIDATE_TELEM_EMITTED.pop(k, None)
+    for k in set(_CANDIDATE_STIMULUS) - known_keys:
+        _CANDIDATE_STIMULUS.pop(k, None)
+    for k in set(_CANDIDATE_HEAVY_ENQUEUED) - known_keys:
+        _CANDIDATE_HEAVY_ENQUEUED.pop(k, None)
     # hard cap (just in case)
     if len(_CANDIDATE_LAST_SEEN_TS) > 5000:
         # drop oldest
@@ -235,6 +243,8 @@ def _prune_candidate_caches() -> None:
             _CANDIDATE_QUALITY.pop(k, None)
             _CANDIDATE_TELEM_EMITTED.pop(k, None)
             _CANDIDATE_SPARK_META.pop(k, None)
+            _CANDIDATE_STIMULUS.pop(k, None)
+            _CANDIDATE_HEAVY_ENQUEUED.pop(k, None)
 
 
 def _register_signal(signal: SparkSignalV1) -> None:
@@ -573,6 +583,18 @@ def _candidate_quality(spark_meta: Dict[str, Any]) -> int:
         "turn_effect_evidence",
     )
     return 1 if any(k in spark_meta for k in rich_keys) else 0
+
+
+def _remember_candidate_stimulus(candidate: SparkCandidatePayload) -> None:
+    trace_id = str(candidate.trace_id)
+    if not (candidate.prompt or candidate.response):
+        return
+    _CANDIDATE_STIMULUS[trace_id] = {
+        "prompt": candidate.prompt or "",
+        "response": candidate.response or "",
+        "source": candidate.source or "unknown",
+        "introspection": candidate.introspection,
+    }
 
 
 def _merge_spark_meta_dict(base: Dict[str, Any], patch: Dict[str, Any]) -> Dict[str, Any]:
@@ -1055,6 +1077,10 @@ async def handle_spark_meta_patch(env: BaseEnvelope) -> None:
         )
     except Exception as exc:
         logger.warning("Failed to broadcast spark_meta patch tissue update corr=%s: %s", corr, exc)
+        return
+
+    if _candidate_quality(merged) >= 1:
+        await _maybe_enqueue_heavy_after_rich_meta(corr, merged, env)
 
 
 async def handle_trace(env: BaseEnvelope) -> None:
@@ -1837,6 +1863,154 @@ async def run_heavy_spark_introspection(
             _get_intro_sem().release()
 
 
+async def _enqueue_heavy_introspection(
+    candidate: SparkCandidatePayload,
+    env: BaseEnvelope,
+) -> bool:
+    """Queue or inline-run heavy introspection once per trace_id."""
+    trace_id = str(candidate.trace_id)
+    if candidate.introspection:
+        return False
+    if trace_id in _CANDIDATE_HEAVY_ENQUEUED:
+        return False
+
+    qual = _candidate_quality(candidate.spark_meta or {})
+    if bool(settings.spark_introspection_require_rich_meta) and qual < 1:
+        return False
+
+    global _warned_queue_inline_both
+    q_on = bool(settings.spark_introspection_queue_enabled)
+    inline_on = bool(settings.spark_introspection_inline_heavy_enabled)
+    if q_on and inline_on and not _warned_queue_inline_both:
+        logger.warning(
+            "spark_queue_inline_both_enabled preferring_queue trace_id=%s",
+            trace_id,
+        )
+        _warned_queue_inline_both = True
+
+    corr_s = str(env.correlation_id) if env.correlation_id else None
+
+    if q_on:
+        try:
+            job_env = build_spark_introspection_job_envelope(candidate, env, settings, _svc_ref())
+            work = (job_env.trace or {}).get("work") or {}
+            if not isinstance(work, dict):
+                work = {}
+            job_id = str(work.get("job_id", ""))
+            idem = str(work.get("idempotency_key", build_idempotency_key(trace_id)))
+            expires_at = str(work.get("expires_at", ""))
+            wq = await get_stream_enqueue_wq()
+            mx = settings.spark_introspection_queue_maxlen
+            sess = (candidate.spark_meta or {}).get("session_id") or (candidate.spark_meta or {}).get(
+                "conversation_id"
+            )
+            msg_id = await wq.enqueue(
+                settings.spark_introspection_queue_stream,
+                job_env,
+                maxlen=int(mx) if mx is not None else None,
+                extra_fields={
+                    "lane": "spark",
+                    "job_id": job_id,
+                    "idempotency_key": idem,
+                    "trace_id": trace_id,
+                    "session_id": str(sess or ""),
+                },
+            )
+            _CANDIDATE_HEAVY_ENQUEUED[trace_id] = time.time()
+            logger.info(
+                "spark_queue_enqueue trace_id=%s correlation_id=%s stream=%s message_id=%s job_id=%s idempotency_key=%s expires_at=%s",
+                trace_id,
+                corr_s,
+                settings.spark_introspection_queue_stream,
+                msg_id,
+                job_id,
+                idem,
+                expires_at,
+            )
+            return True
+        except Exception as ex:
+            logger.error(
+                "spark_queue_enqueue_failed trace_id=%s correlation_id=%s stream=%s error=%s",
+                trace_id,
+                corr_s,
+                settings.spark_introspection_queue_stream,
+                ex,
+            )
+            if inline_on:
+                _CANDIDATE_HEAVY_ENQUEUED[trace_id] = time.time()
+                await run_heavy_spark_introspection(
+                    candidate=candidate,
+                    source_env=env,
+                    correlation_id=corr_s,
+                    bus=None,
+                    from_queue=False,
+                )
+                return True
+            logger.info(
+                "spark_queue_enqueue_failed_skip trace_id=%s correlation_id=%s reason=no_inline_fallback",
+                trace_id,
+                corr_s,
+            )
+            return False
+
+    if inline_on:
+        _CANDIDATE_HEAVY_ENQUEUED[trace_id] = time.time()
+        await run_heavy_spark_introspection(
+            candidate=candidate,
+            source_env=env,
+            correlation_id=corr_s,
+            bus=None,
+            from_queue=False,
+        )
+        return True
+
+    logger.info(
+        "spark_introspection_skipped trace_id=%s reason=heavy_paths_disabled queue_enabled=%s inline_heavy=%s",
+        trace_id,
+        q_on,
+        inline_on,
+    )
+    return False
+
+
+async def _maybe_enqueue_heavy_after_rich_meta(
+    corr: str,
+    merged_meta: Dict[str, Any],
+    env: BaseEnvelope,
+) -> None:
+    """After consolidation patches rich spark_meta, enqueue one heavy introspection job."""
+    if _candidate_quality(merged_meta) < 1:
+        return
+    if corr in _CANDIDATE_HEAVY_ENQUEUED:
+        return
+
+    stim = _CANDIDATE_STIMULUS.get(corr)
+    if not stim or not str(stim.get("prompt") or "").strip():
+        logger.info(
+            "spark_introspection_skipped trace_id=%s reason=patch_no_stimulus",
+            corr,
+        )
+        return
+    if stim.get("introspection"):
+        return
+
+    candidate = SparkCandidatePayload(
+        trace_id=corr,
+        source=str(stim.get("source") or "unknown"),
+        prompt=str(stim.get("prompt") or ""),
+        response=str(stim.get("response") or ""),
+        spark_meta=dict(merged_meta),
+        introspection=None,
+    )
+    _CANDIDATE_QUALITY[corr] = 1
+    if await _enqueue_heavy_introspection(candidate, env):
+        logger.info(
+            "spark_introspection_enqueued_from_patch trace_id=%s correlation_id=%s",
+            corr,
+            env.correlation_id,
+        )
+
+
 async def handle_candidate(env: BaseEnvelope) -> None:
     raw = env.payload if isinstance(env.payload, dict) else {}
     if env.kind == "legacy.message" and isinstance(raw.get("payload"), dict):
@@ -1851,6 +2025,7 @@ async def handle_candidate(env: BaseEnvelope) -> None:
     trace_id = str(candidate.trace_id)
     _prune_candidate_caches()
     _CANDIDATE_LAST_SEEN_TS[trace_id] = time.time()
+    _remember_candidate_stimulus(candidate)
 
     qual = _candidate_quality(candidate.spark_meta or {})
     prev_qual = _CANDIDATE_QUALITY.get(trace_id, -1)
@@ -1899,95 +2074,7 @@ async def handle_candidate(env: BaseEnvelope) -> None:
         )
         return
 
-    global _warned_queue_inline_both
-    q_on = bool(settings.spark_introspection_queue_enabled)
-    inline_on = bool(settings.spark_introspection_inline_heavy_enabled)
-    if q_on and inline_on and not _warned_queue_inline_both:
-        logger.warning(
-            "spark_queue_inline_both_enabled preferring_queue trace_id=%s",
-            trace_id,
-        )
-        _warned_queue_inline_both = True
-
-    corr_s = str(env.correlation_id) if env.correlation_id else None
-
-    if q_on:
-        try:
-            job_env = build_spark_introspection_job_envelope(candidate, env, settings, _svc_ref())
-            work = (job_env.trace or {}).get("work") or {}
-            if not isinstance(work, dict):
-                work = {}
-            job_id = str(work.get("job_id", ""))
-            idem = str(work.get("idempotency_key", build_idempotency_key(trace_id)))
-            expires_at = str(work.get("expires_at", ""))
-            wq = await get_stream_enqueue_wq()
-            mx = settings.spark_introspection_queue_maxlen
-            sess = (candidate.spark_meta or {}).get("session_id") or (candidate.spark_meta or {}).get(
-                "conversation_id"
-            )
-            msg_id = await wq.enqueue(
-                settings.spark_introspection_queue_stream,
-                job_env,
-                maxlen=int(mx) if mx is not None else None,
-                extra_fields={
-                    "lane": "spark",
-                    "job_id": job_id,
-                    "idempotency_key": idem,
-                    "trace_id": trace_id,
-                    "session_id": str(sess or ""),
-                },
-            )
-            logger.info(
-                "spark_queue_enqueue trace_id=%s correlation_id=%s stream=%s message_id=%s job_id=%s idempotency_key=%s expires_at=%s",
-                trace_id,
-                corr_s,
-                settings.spark_introspection_queue_stream,
-                msg_id,
-                job_id,
-                idem,
-                expires_at,
-            )
-            return
-        except Exception as ex:
-            logger.error(
-                "spark_queue_enqueue_failed trace_id=%s correlation_id=%s stream=%s error=%s",
-                trace_id,
-                corr_s,
-                settings.spark_introspection_queue_stream,
-                ex,
-            )
-            if inline_on:
-                await run_heavy_spark_introspection(
-                    candidate=candidate,
-                    source_env=env,
-                    correlation_id=corr_s,
-                    bus=None,
-                    from_queue=False,
-                )
-            else:
-                logger.info(
-                    "spark_queue_enqueue_failed_skip trace_id=%s correlation_id=%s reason=no_inline_fallback",
-                    trace_id,
-                    corr_s,
-                )
-            return
-
-    if inline_on:
-        await run_heavy_spark_introspection(
-            candidate=candidate,
-            source_env=env,
-            correlation_id=corr_s,
-            bus=None,
-            from_queue=False,
-        )
-        return
-
-    logger.info(
-        "spark_introspection_skipped trace_id=%s reason=heavy_paths_disabled queue_enabled=%s inline_heavy=%s",
-        trace_id,
-        q_on,
-        inline_on,
-    )
+    await _enqueue_heavy_introspection(candidate, env)
 
 
 async def handle_signal(env: BaseEnvelope) -> None:

--- a/services/orion-spark-introspector/tests/test_spark_meta_patch_heavy_enqueue.py
+++ b/services/orion-spark-introspector/tests/test_spark_meta_patch_heavy_enqueue.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+
+from app import worker
+
+
+def _reset_candidate_caches() -> None:
+    worker._CANDIDATE_QUALITY.clear()
+    worker._CANDIDATE_LAST_SEEN_TS.clear()
+    worker._CANDIDATE_TELEM_EMITTED.clear()
+    worker._CANDIDATE_SPARK_META.clear()
+    worker._CANDIDATE_STIMULUS.clear()
+    worker._CANDIDATE_HEAVY_ENQUEUED.clear()
+
+
+def _rich_patch_payload(corr: str) -> dict:
+    return {
+        "correlation_id": corr,
+        "spark_meta": {
+            "turn_change_appraisal": {
+                "turn_change_status": "ok",
+                "novelty_score": 0.82,
+            },
+            "novelty": 0.82,
+        },
+    }
+
+
+def test_patch_enqueues_heavy_after_thin_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        _reset_candidate_caches()
+        monkeypatch.setattr(worker.settings, "spark_introspection_queue_enabled", True)
+        monkeypatch.setattr(worker.settings, "spark_introspection_inline_heavy_enabled", False)
+        monkeypatch.setattr(worker.settings, "spark_introspection_require_rich_meta", True)
+
+        corr = str(uuid4())
+        thin_env = BaseEnvelope(
+            kind="spark.candidate",
+            source=ServiceRef(name="llm-gateway", node="n1"),
+            correlation_id=corr,
+            payload={
+                "trace_id": corr,
+                "prompt": "user said hello",
+                "response": "assistant replied",
+                "spark_meta": {"latest_user_message": "user said hello"},
+            },
+        )
+
+        wq = MagicMock()
+        wq.enqueue = AsyncMock(return_value="99-0")
+
+        async def _get_wq():
+            return wq
+
+        monkeypatch.setattr(worker, "get_stream_enqueue_wq", _get_wq)
+        monkeypatch.setattr(worker, "run_heavy_spark_introspection", AsyncMock())
+        monkeypatch.setattr(worker, "_update_tissue_from_candidate", AsyncMock())
+        monkeypatch.setattr(worker, "_emit_candidate_telemetry", AsyncMock())
+
+        await worker.handle_candidate(thin_env)
+        wq.enqueue.assert_not_awaited()
+
+        patch_env = BaseEnvelope(
+            kind="chat.history.spark_meta.patch.v1",
+            correlation_id=corr,
+            source=ServiceRef(name="memory-consolidation", node="athena"),
+            payload=_rich_patch_payload(corr),
+        )
+        monkeypatch.setattr(worker, "_broadcast_tissue_update", AsyncMock())
+        await worker.handle_spark_meta_patch(patch_env)
+
+        wq.enqueue.assert_awaited_once()
+        job_env = wq.enqueue.await_args.args[1]
+        payload = job_env.payload if isinstance(job_env.payload, dict) else {}
+        assert payload.get("trace_id") == corr
+        assert payload.get("prompt") == "user said hello"
+
+    asyncio.run(_run())
+
+
+def test_duplicate_patch_does_not_double_enqueue(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        _reset_candidate_caches()
+        monkeypatch.setattr(worker.settings, "spark_introspection_queue_enabled", True)
+        monkeypatch.setattr(worker.settings, "spark_introspection_inline_heavy_enabled", False)
+        monkeypatch.setattr(worker.settings, "spark_introspection_require_rich_meta", True)
+
+        corr = str(uuid4())
+        thin_env = BaseEnvelope(
+            kind="spark.candidate",
+            source=ServiceRef(name="hub_http", node="n1"),
+            correlation_id=corr,
+            payload={
+                "trace_id": corr,
+                "prompt": "q",
+                "response": "a",
+                "spark_meta": {},
+            },
+        )
+
+        wq = MagicMock()
+        wq.enqueue = AsyncMock(return_value="99-0")
+
+        async def _get_wq():
+            return wq
+
+        monkeypatch.setattr(worker, "get_stream_enqueue_wq", _get_wq)
+        monkeypatch.setattr(worker, "_update_tissue_from_candidate", AsyncMock())
+        monkeypatch.setattr(worker, "_emit_candidate_telemetry", AsyncMock())
+        monkeypatch.setattr(worker, "_broadcast_tissue_update", AsyncMock())
+
+        await worker.handle_candidate(thin_env)
+
+        patch_env = BaseEnvelope(
+            kind="chat.history.spark_meta.patch.v1",
+            correlation_id=corr,
+            source=ServiceRef(name="memory-consolidation", node="athena"),
+            payload=_rich_patch_payload(corr),
+        )
+        await worker.handle_spark_meta_patch(patch_env)
+        await worker.handle_spark_meta_patch(patch_env)
+
+        assert wq.enqueue.await_count == 1
+
+    asyncio.run(_run())
+
+
+def test_patch_without_stimulus_does_not_enqueue(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        _reset_candidate_caches()
+        monkeypatch.setattr(worker.settings, "spark_introspection_queue_enabled", True)
+        monkeypatch.setattr(worker.settings, "spark_introspection_require_rich_meta", True)
+
+        corr = str(uuid4())
+        wq = MagicMock()
+        wq.enqueue = AsyncMock(return_value="99-0")
+
+        async def _get_wq():
+            return wq
+
+        monkeypatch.setattr(worker, "get_stream_enqueue_wq", _get_wq)
+        monkeypatch.setattr(worker, "_broadcast_tissue_update", AsyncMock())
+
+        patch_env = BaseEnvelope(
+            kind="chat.history.spark_meta.patch.v1",
+            correlation_id=corr,
+            source=ServiceRef(name="memory-consolidation", node="athena"),
+            payload=_rich_patch_payload(corr),
+        )
+        await worker.handle_spark_meta_patch(patch_env)
+        wq.enqueue.assert_not_awaited()
+
+    asyncio.run(_run())


### PR DESCRIPTION
<h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 4px; font-size: 1.214em; line-height: 1.42; --tw-font-weight: 600; font-weight: 590; margin-top: 0px; color: rgb(255, 255, 255); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 0); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h3><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(255, 255, 255); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 0); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Implemented both follow-ups on branch<span> </span><code class="md-inline-path-filename-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 1 1 1 / 0.14); color: color(srgb 1 1 1 / 0.94); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;"><span class="md-inline-path-prefix">fix/</span><span class="md-inline-path-filename">spark-patch-enqueue-mind-phase</span></code><span> </span>(based on current<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 1 1 1 / 0.14); color: color(srgb 1 1 1 / 0.94); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">main</code><span> </span>after #793): patch-triggered heavy introspection enqueue (once per turn) and gateway skip for<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 1 1 1 / 0.14); color: color(srgb 1 1 1 / 0.94); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">mind_phase</code><span> </span>internal hops. Pushed to origin;<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 1 1 1 / 0.14); color: color(srgb 1 1 1 / 0.94); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">gh</code><span> </span>isn’t authenticated here so the PR wasn’t auto-created.</p><h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 4px; font-size: 1.214em; line-height: 1.42; --tw-font-weight: 600; font-weight: 590; margin-top: 16px; color: rgb(255, 255, 255); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 0); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h3><ul class="list-inside list-disc whitespace-normal [li_&amp;]:pl-6" data-streamdown="unordered-list" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; list-style-type: disc; white-space: normal; padding-left: 2em; display: flex !important; flex-direction: column !important; gap: 6px !important; margin: 6px 0px !important; color: rgb(255, 255, 255); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(0, 0, 0); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 1 1 1 / 0.14); color: rgb(0, 0, 238); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-prefix">services/orion-spark-introspector/app/</span><span class="md-inline-path-filename">worker.py</span></code></li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 1 1 1 / 0.14); color: rgb(0, 0, 238); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-prefix">services/orion-spark-introspector/tests/</span><span class="md-inline-path-filename">test_spark_meta_patch_heavy_enqueue.py</span></code></li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 1 1 1 / 0.14); color: rgb(0, 0, 238); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-prefix">services/orion-llm-gateway/app/</span><span class="md-inline-path-filename">llm_backend.py</span></code></li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 1 1 1 / 0.14); color: rgb(0, 0, 238); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-prefix">services/orion-llm-gateway/tests/</span><span class="md-inline-path-filename">test_spark_candidate_publish_policy.py</span></code></li><li class="py-1 [&amp;&gt;p]:inline" data-streamdown="list-item" style="padding-block: 4px; word-break: break-word; padding: 0px !important;"><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 1 1 1 / 0.14); color: rgb(0, 0, 238); font-family: &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-prefix">scripts/</span><span class="md-inline-path-filename">eval_spark_introspection_contract.sh</span></code></li></ul><h3 class="mt-6 mb-2 font-semibold text-xl" data-streamdown="heading-3" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 4px; font-size: 1.214em; line-height: 1.42; --tw-font-weight: 600; font-weight: 590; margin-top: 16px; color: rgb(255, 255, 255); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 0); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Verification</h3><div class="ui-scroll-area" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; --scroll-area-scroll-padding: 4px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 1 1 1 / 0.28); border-style: solid; border-width: 0.555556px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgb(255, 255, 255); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 0, 0); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain auto; scrollbar-width: none !important;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">
Command | Exit | Result
-- | -- | --
./scripts/eval_spark_introspection_contract.sh | 0 | PASS: spark introspection contract eval (10 gateway + 6 introspector + 1 integration)
git push -u origin fix/spark-patch-enqueue-mind-phase | 0 | Branch pushed (ae6e3548)

</div></div></div>