### PR TITLE
fix(vision): ground person presence end-to-end after edge decouple.

### DIFF
--- a/orion/vision/__init__.py
+++ b/orion/vision/__init__.py
@@ -1,0 +1,1 @@
+"""Shared vision pipeline helpers."""

--- a/orion/vision/caption_echo.py
+++ b/orion/vision/caption_echo.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+
+CAPTION_PROMPT = (
+    "List visible objects and people. "
+    "State only what is directly visible. "
+    "No guesses about activity."
+)
+
+_LEGACY_PROMPT_ECHO = re.compile(r"describe this image", re.I)
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.lower().strip().split()).strip(".,!?")
+
+
+def is_caption_prompt_echo(text: str) -> bool:
+    """True when caption text is the VLM prompt echoed back, not scene description."""
+    raw = (text or "").strip()
+    if not raw:
+        return False
+    if _LEGACY_PROMPT_ECHO.search(raw):
+        return True
+    norm = _normalize(raw)
+    prompt_norm = _normalize(CAPTION_PROMPT)
+    if norm == prompt_norm:
+        return True
+    # BLIP often echoes the prompt with minor suffix noise (e.g. trailing "s").
+    if norm.startswith(prompt_norm) and len(norm) <= len(prompt_norm) + 4:
+        return True
+    prompt_tokens = prompt_norm.split()
+    text_tokens = norm.split()
+    if len(text_tokens) <= len(prompt_tokens) + 1 and text_tokens[: len(prompt_tokens)] == prompt_tokens:
+        return True
+    return False

--- a/orion/vision/tests/test_caption_echo.py
+++ b/orion/vision/tests/test_caption_echo.py
@@ -1,0 +1,17 @@
+from orion.vision.caption_echo import CAPTION_PROMPT, is_caption_prompt_echo
+
+
+def test_is_caption_prompt_echo_matches_current_prompt() -> None:
+    assert is_caption_prompt_echo(CAPTION_PROMPT) is True
+
+
+def test_is_caption_prompt_echo_matches_legacy_phrase() -> None:
+    assert is_caption_prompt_echo("Describe this image in detail.") is True
+
+
+def test_is_caption_prompt_echo_rejects_blip_suffix_noise() -> None:
+    assert is_caption_prompt_echo(CAPTION_PROMPT + "s") is True
+
+
+def test_is_caption_prompt_echo_rejects_real_caption() -> None:
+    assert is_caption_prompt_echo("A desk with two monitors and an open door.") is False

--- a/services/orion-vision-council/app/evidence_grounding.py
+++ b/services/orion-vision-council/app/evidence_grounding.py
@@ -166,6 +166,42 @@ def enforce_evidence_grounding(
     return interpretation.model_copy(update=updates), notes
 
 
+def _events_mention_person(candidates: list[VisionEventCandidateV1]) -> bool:
+    return any(
+        c.event_type == "person_presence" or _text_mentions_person(c.narrative or "")
+        for c in candidates
+    )
+
+
+def ensure_grounded_person_presence(
+    interpretation: VisionSceneInterpretationV1,
+    window: VisionWindowPayload,
+) -> tuple[VisionSceneInterpretationV1, list[str]]:
+    """Inject person_presence when detections prove person but the LLM omitted them."""
+    hard = _hard_labels(window)
+    if "person" not in hard and host_person_hits(window) <= 0:
+        return interpretation, []
+    if _events_mention_person(list(interpretation.event_candidates)):
+        return interpretation, []
+
+    refs = list(window.artifact_ids or [])
+    person_event = VisionEventCandidateV1(
+        event_type="person_presence",
+        narrative="A person was detected on camera.",
+        entities=["person"],
+        tags=["host_detect"],
+        confidence=0.85,
+        salience=0.7,
+        evidence_refs=refs,
+    )
+    updates: dict[str, object] = {
+        "event_candidates": [*interpretation.event_candidates, person_event],
+    }
+    if not _text_mentions_person(interpretation.scene_summary):
+        updates["scene_summary"] = _grounded_scene_summary_from_labels(hard | {"person"})
+    return interpretation.model_copy(update=updates), ["injected:person_presence:grounded_evidence"]
+
+
 def build_person_presence_fallback(window: VisionWindowPayload) -> VisionSceneInterpretationV1:
     refs = list(window.artifact_ids or [])
     return VisionSceneInterpretationV1(

--- a/services/orion-vision-council/app/main.py
+++ b/services/orion-vision-council/app/main.py
@@ -27,6 +27,7 @@ except ImportError:
 
 from .evidence_grounding import (
     build_person_presence_fallback,
+    ensure_grounded_person_presence,
     host_person_hits,
     enforce_evidence_grounding,
 )
@@ -248,6 +249,9 @@ class CouncilService:
         if interpretation is not None:
             interpretation, grounding_notes = enforce_evidence_grounding(interpretation, window)
             for note in grounding_notes:
+                logger.info(f"[COUNCIL] grounding {note}")
+            interpretation, inject_notes = ensure_grounded_person_presence(interpretation, window)
+            for note in inject_notes:
                 logger.info(f"[COUNCIL] grounding {note}")
             if not interpretation.event_candidates and host_person_hits(window) > 0:
                 interpretation = build_person_presence_fallback(window)

--- a/services/orion-vision-council/tests/test_evidence_grounding.py
+++ b/services/orion-vision-council/tests/test_evidence_grounding.py
@@ -8,6 +8,7 @@ from orion.schemas.vision import VisionSceneInterpretationV1, VisionWindowPayloa
 from app.evidence_grounding import (
     ACTIVITY_PATTERN,
     build_person_presence_fallback,
+    ensure_grounded_person_presence,
     enforce_evidence_grounding,
 )
 
@@ -169,6 +170,36 @@ def test_enforce_scrubs_person_from_event_entities() -> None:
     grounded, notes = enforce_evidence_grounding(interpretation, window)
     assert grounded.event_candidates[0].entities == ["door", "screen"]
     assert any("scrubbed:entities" in note for note in notes)
+
+
+def test_ensure_grounded_person_presence_injects_when_llm_omits_person() -> None:
+    window = _window(
+        evidence={
+            "hard_labels": ["door", "person", "screen"],
+            "host_person_hits": 5,
+            "edge_person_hits": 0,
+        },
+    )
+    interpretation = VisionSceneInterpretationV1(
+        window_id="w1",
+        scene_summary="Multiple screens and doors are visible.",
+        event_candidates=[
+            {
+                "event_type": "visual_observation",
+                "narrative": "Two doors are identified in the scene.",
+                "entities": ["door"],
+                "tags": [],
+                "confidence": 0.8,
+                "salience": 0.7,
+                "evidence_refs": ["art-edge-1"],
+            },
+        ],
+    )
+    updated, notes = ensure_grounded_person_presence(interpretation, window)
+    assert len(updated.event_candidates) == 2
+    assert updated.event_candidates[-1].event_type == "person_presence"
+    assert "person" in updated.scene_summary.lower()
+    assert notes == ["injected:person_presence:grounded_evidence"]
 
 
 def test_enforce_caps_activity_confidence_when_captions_present() -> None:

--- a/services/orion-vision-council/tests/test_main_grounding_wiring.py
+++ b/services/orion-vision-council/tests/test_main_grounding_wiring.py
@@ -61,7 +61,7 @@ def test_finalize_drops_youtube_activity_without_hard_person() -> None:
     assert outcome.parse_mode == "strict_v2"
 
 
-def test_finalize_preserves_strict_v2_when_host_fallback_after_grounding() -> None:
+def test_finalize_preserves_strict_v2_when_host_person_injected_after_grounding() -> None:
     svc = CouncilService()
     window = _window(
         captions=["describe this image. youtube"],
@@ -75,7 +75,40 @@ def test_finalize_preserves_strict_v2_when_host_fallback_after_grounding() -> No
     assert interpretation is not None
     assert interpretation.event_candidates[0].event_type == "person_presence"
     assert outcome.parse_mode == "strict_v2"
-    assert "host_fallback_after_grounding" in outcome.salvage_warnings
+
+
+def test_finalize_injects_person_when_llm_omits_despite_hard_labels() -> None:
+    svc = CouncilService()
+    window = _window(
+        evidence={
+            "hard_labels": ["door", "person", "screen"],
+            "host_person_hits": 3,
+            "edge_person_hits": 0,
+        },
+    )
+    interpretation = VisionSceneInterpretationV1(
+        window_id="w1",
+        scene_summary="Doors and screens visible.",
+        event_candidates=[
+            {
+                "event_type": "visual_observation",
+                "narrative": "Two doors are identified in the scene.",
+                "entities": ["door"],
+                "tags": [],
+                "confidence": 0.8,
+                "salience": 0.7,
+                "evidence_refs": ["art-edge-1"],
+            }
+        ],
+    )
+    interpretation, outcome = svc._finalize_interpretation(
+        interpretation,
+        InterpretationParseOutcome(interpretation=interpretation, parse_mode="strict_v2"),
+        window,
+    )
+    assert interpretation is not None
+    assert any(c.event_type == "person_presence" for c in interpretation.event_candidates)
+    assert outcome.parse_mode == "strict_v2"
 
 
 def test_finalize_host_fallback_on_parse_failure() -> None:

--- a/services/orion-vision-host/app/caption_sanitize.py
+++ b/services/orion-vision-host/app/caption_sanitize.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
-import re
+from orion.vision.caption_echo import CAPTION_PROMPT, is_caption_prompt_echo
 
-CAPTION_PROMPT = (
-    "List visible objects and people. "
-    "State only what is directly visible. "
-    "No guesses about activity."
-)
-_PROMPT_ECHO = re.compile(r"describe this image", re.I)
 _STOPLIST = frozenset({"youtube", "google", "video", "watching", "webcam", "com"})
 
 
 def sanitize_caption(raw: str) -> tuple[str | None, bool, str | None]:
     text = (raw or "").strip()
-    if _PROMPT_ECHO.search(text):
+    if is_caption_prompt_echo(text):
         return None, False, "prompt_echo"
     if len(text) < 12:
         return None, False, "too_short"

--- a/services/orion-vision-host/tests/test_caption_sanitize.py
+++ b/services/orion-vision-host/tests/test_caption_sanitize.py
@@ -20,6 +20,20 @@ def test_sanitize_rejects_prompt_echo() -> None:
     assert reason == "prompt_echo"
 
 
+def test_sanitize_rejects_caption_prompt_echo() -> None:
+    text, ok, reason = sanitize_caption(CAPTION_PROMPT)
+    assert ok is False
+    assert text is None
+    assert reason == "prompt_echo"
+
+
+def test_sanitize_rejects_caption_prompt_echo_with_suffix() -> None:
+    text, ok, reason = sanitize_caption(CAPTION_PROMPT + "s")
+    assert ok is False
+    assert text is None
+    assert reason == "prompt_echo"
+
+
 def test_sanitize_accepts_plain_scene() -> None:
     text, ok, reason = sanitize_caption("A desk with two monitors and an open door.")
     assert ok is True

--- a/services/orion-vision-window/app/projection.py
+++ b/services/orion-vision-window/app/projection.py
@@ -11,11 +11,16 @@ from typing import Any, Dict, List, Tuple
 
 from orion.core.bus.bus_schemas import BaseEnvelope
 from orion.schemas.vision import VisionArtifactPayload, VisionWindowPayload
+from orion.vision.caption_echo import is_caption_prompt_echo
 
 SNAPSHOT_SCHEMA_V1 = "vision_window_snapshot.v1"
 MAX_URIS_PER_ENVELOPE = 32
 HARD_SCORE_THRESHOLD = 0.25
 CAPTION_STOPLIST = frozenset({"youtube", "google", "video", "watching", "describe", "image"})
+
+
+def _skip_edge_artifact(art: VisionArtifactPayload) -> bool:
+    return art.task_type == "edge_detection"
 
 
 def stream_key_from_artifact(art: VisionArtifactPayload) -> str:
@@ -77,11 +82,14 @@ def _build_evidence(items: List[Tuple[VisionArtifactPayload, float]]) -> Dict[st
     host_person_hits = 0
     caption_count = 0
     for art, _ts in items:
-        if art.task_type == "edge_detection":
+        if _skip_edge_artifact(art):
             continue
         if art.outputs.caption and art.outputs.caption.text:
+            cap = art.outputs.caption.text
+            if is_caption_prompt_echo(cap):
+                continue
             caption_count += 1
-            soft_labels.extend(_caption_soft_tokens(art.outputs.caption.text))
+            soft_labels.extend(_caption_soft_tokens(cap))
         for obj in art.outputs.objects or []:
             if obj.score < HARD_SCORE_THRESHOLD:
                 continue
@@ -103,11 +111,15 @@ def summarize_items(items: List[Tuple[VisionArtifactPayload, float]]) -> Dict[st
     counts: Dict[str, int] = {}
     captions: List[str] = []
     for art, _ts in items:
+        if _skip_edge_artifact(art):
+            continue
         if art.outputs.objects:
             for obj in art.outputs.objects:
                 counts[obj.label] = counts.get(obj.label, 0) + 1
         if art.outputs.caption and art.outputs.caption.text:
-            captions.append(art.outputs.caption.text)
+            cap = art.outputs.caption.text
+            if not is_caption_prompt_echo(cap):
+                captions.append(cap)
     top_labels = sorted(counts.items(), key=lambda x: x[1], reverse=True)[:5]
     return {
         "object_counts": counts,

--- a/services/orion-vision-window/tests/test_projection_evidence.py
+++ b/services/orion-vision-window/tests/test_projection_evidence.py
@@ -1,6 +1,11 @@
+import sys
 import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from orion.schemas.vision import VisionArtifactOutputs, VisionArtifactPayload, VisionCaption, VisionObject
+from orion.vision.caption_echo import CAPTION_PROMPT
 
 from app.projection import summarize_items
 
@@ -34,3 +39,19 @@ def test_evidence_ignores_edge_detection_artifacts() -> None:
     assert ev["host_person_hits"] == 1
     assert "person" in ev["hard_labels"]
     assert "door" in ev["hard_labels"]
+
+
+def test_summarize_items_excludes_edge_detection_from_object_counts() -> None:
+    items = [(_art("edge_detection", "person", 0.9), time.time())]
+    summary = summarize_items(items)
+    assert summary["object_counts"] == {}
+    assert summary["item_count"] == 1
+
+
+def test_summarize_items_skips_caption_prompt_echo() -> None:
+    items = [
+        (_art("retina_fast", "door", 0.8, caption=CAPTION_PROMPT), time.time()),
+        (_art("retina_fast", "person", 0.7, caption="A desk with two monitors."), time.time()),
+    ]
+    summary = summarize_items(items)
+    assert summary["captions"] == ["A desk with two monitors."]


### PR DESCRIPTION
## Summary

Follow-up to #794 (host pipe / edge decouple). The decouple landed in repo but live stack was still failing the basic goal: **person in frame → grounded `person_presence` in scribe**.

Three structural gaps caused that:

1. **Split-brain window summary** — `evidence` skipped `edge_detection` artifacts but `object_counts` still counted them, producing windows with 60+ persons in counts and empty `hard_labels`. Council saw phantom person signal without grounded evidence.
2. **Council person omission** — When `person ∈ hard_labels` (or `host_person_hits > 0`) the LLM often returned door/screen-only events. Fallback only fired on parse failure or when grounding dropped *all* events.
3. **Caption prompt echo** — BLIP returned the caption prompt (sometimes with trailing `s`), which passed sanitization and polluted window/council context.

## Changes

- **`orion/vision/caption_echo.py`** — shared prompt-echo detection (legacy + current prompt + BLIP suffix noise)
- **`orion-vision-window`** — skip `edge_detection` in `summarize_items` object counts; filter echo captions from summary and evidence
- **`orion-vision-host`** — reject prompt echo via shared helper
- **`orion-vision-council`** — `ensure_grounded_person_presence()` injects `person_presence` when host evidence proves person but LLM omitted them (wired in `_finalize_interpretation` after `enforce_evidence_grounding`)

## Test plan

- [x] `PYTHONPATH=.:services/orion-vision-window ./orion_dev/bin/python -m pytest services/orion-vision-window/tests/test_projection_evidence.py -q`
- [x] `PYTHONPATH=.:services/orion-vision-host ./orion_dev/bin/python -m pytest services/orion-vision-host/tests/test_caption_sanitize.py -q`
- [x] `./scripts/test_service.sh orion-vision-council services/orion-vision-council/tests/test_evidence_grounding.py services/orion-vision-council/tests/test_main_grounding_wiring.py -q`
- [x] `PYTHONPATH=. ./orion_dev/bin/python -m pytest orion/vision/tests/test_caption_echo.py -q`
- [x] Live stack rebuild/restart: `person_presence | A person was detected on camera.` rows in `vision_events`; window evidence shows `host_person_hits > 0`, `edge_person_hits: 0`, `person ∈ hard_labels`

## Deploy note

Rebuild and restart **vision-window**, **vision-council**, **vision-host**, and **vision-frame-router** — images bake code in; restart alone is not enough after merge.