### PR TITLE
fix(social-memory): keep stored-turn consumer alive on empty artifact…

### DIFF
--- a/services/orion-social-memory/app/service.py
+++ b/services/orion-social-memory/app/service.py
@@ -264,7 +264,13 @@ class SocialMemoryService:
                 env = decoded.envelope
                 if env.kind != "social.turn.stored.v1":
                     continue
-                await self.process_social_turn(env.payload)
+                try:
+                    await self.process_social_turn(env.payload)
+                except Exception:
+                    logger.exception(
+                        "social_turn_stored_process_failed corr=%s",
+                        getattr(env, "correlation_id", None),
+                    )
 
     async def process_social_turn(self, payload: Dict[str, Any]) -> SocialRelationalMemoryUpdateV1:
         turn = SocialRoomTurnStoredV1.model_validate(payload)

--- a/services/orion-social-memory/app/synthesizer.py
+++ b/services/orion-social-memory/app/synthesizer.py
@@ -2873,6 +2873,15 @@ def _artifact_confirmation_activates_continuity(
     )
 
 
+def _optional_artifact_record(model_cls, value: object):
+    if not isinstance(value, dict) or not value:
+        return None
+    try:
+        return model_cls.model_validate(value)
+    except Exception:
+        return None
+
+
 def artifact_dialogue_records(
     turn: SocialRoomTurnStoredV1,
     *,
@@ -2882,9 +2891,9 @@ def artifact_dialogue_records(
     proposal = client_meta.get("social_artifact_proposal")
     revision = client_meta.get("social_artifact_revision")
     confirmation = client_meta.get("social_artifact_confirmation")
-    proposal_obj = SocialArtifactProposalV1.model_validate(proposal) if isinstance(proposal, dict) else None
-    revision_obj = SocialArtifactRevisionV1.model_validate(revision) if isinstance(revision, dict) else None
-    confirmation_obj = SocialArtifactConfirmationV1.model_validate(confirmation) if isinstance(confirmation, dict) else None
+    proposal_obj = _optional_artifact_record(SocialArtifactProposalV1, proposal)
+    revision_obj = _optional_artifact_record(SocialArtifactRevisionV1, revision)
+    confirmation_obj = _optional_artifact_record(SocialArtifactConfirmationV1, confirmation)
     if proposal_obj and not _artifact_scope_matches(scope, proposal_obj.proposed_scope):
         proposal_obj = None
     if revision_obj and not _artifact_scope_matches(scope, revision_obj.revised_scope):

--- a/services/orion-social-memory/tests/test_artifact_dialogue_records.py
+++ b/services/orion-social-memory/tests/test_artifact_dialogue_records.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from app.synthesizer import artifact_dialogue_records
+from orion.schemas.social_chat import SocialRoomTurnStoredV1
+
+
+def test_artifact_dialogue_records_ignores_empty_placeholder_dicts() -> None:
+    turn = SocialRoomTurnStoredV1.model_validate(
+        {
+            "prompt": "k, we're back",
+            "response": "Back and ready.",
+            "client_meta": {
+                "external_room": {"platform": "hub", "room_id": "hub-direct"},
+                "external_participant": {"participant_id": "juniper"},
+                "social_artifact_proposal": {},
+                "social_artifact_revision": {},
+                "social_artifact_confirmation": {},
+            },
+        }
+    )
+
+    proposal, revision, confirmation = artifact_dialogue_records(turn, scope="peer_local")
+
+    assert proposal is None
+    assert revision is None
+    assert confirmation is None


### PR DESCRIPTION
## Summary

- Treat empty hub `social_artifact_*` placeholders in `client_meta` as absent instead of validating them into hard failures.
- Wrap `orion:chat:social:stored` consumption in try/except so one bad turn cannot silently kill the subscription task.
- Add regression test for empty artifact placeholder dicts on real hub-direct turn shape.
- Completes the hub-direct social continuity pipeline together with sql-writer post-commit `publish_with_reconnect` (already on `main` in `291a45ca`).

## Outcome moved

Hub-direct social-room turns now have a live path from Postgres write → `orion:chat:social:stored` → social-memory synthesis without manual backfill or consumer restart.

## Current architecture

Before this patch, sql-writer could persist `social_room_turns` and (after `publish_with_reconnect`) emit stored events, but social-memory’s bus consumer died on the first hub turn carrying empty `social_artifact_proposal: {}` keys. Continuity tables stayed stale even though `/summary` prefetch still worked from old projections.

## Architecture touched

- `services/orion-social-memory/app/synthesizer.py` — `_optional_artifact_record()` guard
- `services/orion-social-memory/app/service.py` — consumer error isolation
- Related upstream (already on main): `services/orion-sql-writer/app/worker.py` — `_publish_post_commit()` via `publish_with_reconnect`

## Files changed

- `services/orion-social-memory/app/synthesizer.py`: skip empty/invalid artifact dialogue records
- `services/orion-social-memory/app/service.py`: log and continue on stored-turn processing failures
- `services/orion-social-memory/tests/test_artifact_dialogue_records.py`: regression for hub empty placeholders

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: social-memory no longer crashes on `{}` artifact placeholders in stored-turn payloads
- Compatibility notes: consumer now survives malformed artifact fragments; invalid non-empty payloads are ignored per-field

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not needed
- skipped keys requiring operator action: none

## Tests run

```text
PYTHONPATH=services/orion-social-memory:. pytest services/orion-social-memory/tests/test_artifact_dialogue_records.py -q
# 1 passed

PYTHONPATH=services/orion-sql-writer:. pytest services/orion-sql-writer/tests/test_social_turn_stored_emit.py -q
# 1 passed (upstream fix already on main)
```

## Evals run

```text
Not run — no social-memory eval harness for bus consumer path; regression covered by unit test + live smoke on athena.
```

## Docker/build/smoke checks

```text
docker compose -f services/orion-social-memory/docker-compose.yml up -d --build
# rebuilt and restarted orion-athena-social-memory

Live smoke (athena):
- Full client_meta turn from social_room_turns no longer crashes process_social_turn
- Bus publish to orion:chat:social:stored updates evidence_count after consumer restart
- Hub-direct turn 02811559 backfilled manually pre-patch
```

## Review findings fixed

- Finding: empty `{}` artifact keys from hub are not valid Pydantic records
  - Fix: `_optional_artifact_record()` treats empty/invalid dicts as absent
  - Evidence: `test_artifact_dialogue_records_ignores_empty_placeholder_dicts`
- Finding: unhandled exception in consumer loop kills subscription with no log
  - Fix: try/except with `social_turn_stored_process_failed` log
  - Evidence: consumer survived subsequent bus publishes in live smoke

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-social-memory/.env \
  -f services/orion-social-memory/docker-compose.yml up -d --build

# sql-writer already patched on main; restart if not yet redeployed:
docker compose --env-file .env --env-file services/orion-sql-writer/.env \
  -f services/orion-sql-writer/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: silently dropping malformed non-empty artifact payloads could hide producer bugs
- Mitigation: log on handler failure; valid populated artifact records still validate strictly via `_optional_artifact_record` only after non-empty check

## PR link

https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/social-stored-consumer-resilience
