### PR TITLE
fix(equilibrium): decode Redis hash keys on load to stop duplicate di…

### DIFF
--- a/services/orion-equilibrium-service/app/service.py
+++ b/services/orion-equilibrium-service/app/service.py
@@ -68,6 +68,10 @@ class EquilibriumService(BaseChassis):
             raw = await self.bus.redis.hgetall(settings.redis_state_key)
             for key, blob in raw.items():
                 try:
+                    if isinstance(key, (bytes, bytearray)):
+                        key = key.decode("utf-8")
+                    else:
+                        key = str(key)
                     data = json.loads(blob.decode("utf-8") if isinstance(blob, (bytes, bytearray)) else blob)
                     if isinstance(data, dict):
                         if "last_seen_ts" in data and isinstance(data["last_seen_ts"], str):

--- a/services/orion-equilibrium-service/tests/test_load_state_key_decode.py
+++ b/services/orion-equilibrium-service/tests/test_load_state_key_decode.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.service import EquilibriumService
+
+
+@pytest.mark.asyncio
+async def test_load_state_decodes_bytes_redis_keys_to_str():
+    """Bytes hash keys from redis must not duplicate str keys from heartbeats."""
+    svc = EquilibriumService()
+    svc.bus = MagicMock()
+    svc.bus.redis = MagicMock()
+    now = datetime.now(timezone.utc).isoformat()
+    svc.bus.redis.hgetall = AsyncMock(
+        return_value={
+            b"sql-writer@athena": json.dumps(
+                {
+                    "service": "sql-writer",
+                    "node": "athena",
+                    "status": "ok",
+                    "last_seen_ts": now,
+                    "heartbeat_interval_sec": 10.0,
+                }
+            ).encode(),
+        }
+    )
+
+    await svc._load_state()
+
+    assert "sql-writer@athena" in svc._state
+    assert b"sql-writer@athena" not in svc._state


### PR DESCRIPTION
Pushed from a clean branch — only the equilibrium fix is committed (untracked files left unstaged).

**Branch:** `fix/equilibrium-redis-key-decode` (`31de098a`)  
**PR link:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/equilibrium-redis-key-decode

(`gh pr create` failed — no GitHub CLI auth in this environment.)

---

### PR title
`fix(equilibrium): decode Redis hash keys to stop stuck distress`

### PR body

## Summary

- Decode Redis `hgetall` hash keys to `str` in `_load_state()` so persisted state does not duplicate heartbeat entries stored under `bytes` keys.
- Fixes equilibrium `distress_score` stuck near **0.507** (~half the fleet counted down twice) when the mesh is actually healthy.
- Adds unit test asserting bytes keys load as `str` only.

## Root cause

On restart, `_load_state()` stored keys as `bytes` (`b'sql-writer@athena'`). Heartbeats via `_evaluate_state()` stored the same services under `str` keys (`'sql-writer@athena'`). `_calculate_metrics()` counted both — stale bytes ghosts as down + fresh str entries as ok → ~34/67 services down → distress ≈ 0.507 and `zen_state: not_zen` on metacog triggers.

This is **not visible in `collapse_mirror`** except indirectly as `telemetry.trigger_payload.pressure`.

## Test plan

- [x] `cd services/orion-equilibrium-service && PYTHONPATH=<repo> ../../orion_dev/bin/python -m pytest tests/test_load_state_key_decode.py -q` — 1 passed
- [ ] After merge + deploy: restart equilibrium; confirm snapshot shows ~34 services (not 67) and distress drops to ~0.03 unless real outages exist

---

### Files changed
- `services/orion-equilibrium-service/app/service.py`
- `services/orion-equilibrium-service/tests/test_load_state_key_decode.py`

### Not committed (still untracked)
- `PR_social_stored_consumer_resilience.md`
- `docs/superpowers/plans/2026-07-03-repair-pressure-speech-wiring.md`