### PR TITLE
Feat/repair pressure speech wiring

### DIFF
--- a/orion/substrate/appraisal/__init__.py
+++ b/orion/substrate/appraisal/__init__.py
@@ -1,6 +1,10 @@
 """Substrate-derived appraisers. See docs/plans/substrate/2026-05-23-repair-pressure-v1.md."""
 
-from .contract import REPAIR_PRESSURE_DEBUG_KEY, apply_repair_pressure_contract
+from .contract import (
+    REPAIR_PRESSURE_CONTRACT_METADATA_KEY,
+    REPAIR_PRESSURE_DEBUG_KEY,
+    apply_repair_pressure_contract,
+)
 from .evidence import DETECTOR_NAME, extract_repair_evidence
 from .models import RepairEvidenceV1, RepairPressureAppraisalV1
 from .repair_pressure import appraise_repair_pressure
@@ -30,6 +34,7 @@ __all__ = [
     "KIND_LABELS",
     "MoleculeSummaryV1",
     "ORGAN_ID",
+    "REPAIR_PRESSURE_CONTRACT_METADATA_KEY",
     "REPAIR_PRESSURE_DEBUG_KEY",
     "RepairEvidenceV1",
     "RepairPressureAppraisalV1",

--- a/orion/substrate/appraisal/contract.py
+++ b/orion/substrate/appraisal/contract.py
@@ -16,6 +16,7 @@ from .signal_bridge import SIGNAL_KIND
 
 
 REPAIR_PRESSURE_DEBUG_KEY = "repair_pressure"
+REPAIR_PRESSURE_CONTRACT_METADATA_KEY = "repair_pressure_contract"
 
 _LEVEL_HIGH = 0.75
 _LEVEL_MID = 0.45

--- a/services/orion-cortex-exec/.env_example
+++ b/services/orion-cortex-exec/.env_example
@@ -197,6 +197,9 @@ SUBSTRATE_GRAPH_PASS=orion
 # (stale rows past MAX_AGE_SEC are dropped). DB URL falls back to
 # ENDOGENOUS_RUNTIME_SQL_DATABASE_URL when unset.
 ENABLE_SUBSTRATE_FELT_STATE_CTX=true
+
+# When true, Hub repair_pressure_contract metadata merges into chat TURN CONTRACT.
+ENABLE_REPAIR_PRESSURE_SPEECH_WIRING=true
 SUBSTRATE_FELT_STATE_DATABASE_URL=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
 SUBSTRATE_FELT_STATE_MAX_AGE_SEC=120
 # Self-model belief projection (chat_stance): per-dimension score threshold above

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1048,7 +1048,26 @@ _COMPANION_CLOSING_MOVE_MAP: dict[str, str] = {
 }
 
 
-def compile_speech_contract(brief: "ChatStanceBrief") -> str:
+def _compile_repair_speech_overlay(repair_contract: dict[str, Any] | None) -> str | None:
+    if not isinstance(repair_contract, dict):
+        return None
+    mode = str(repair_contract.get("mode") or "")
+    rules = repair_contract.get("rules") or []
+    if mode not in {"repair_concrete", "concrete_bias"} or not rules:
+        return None
+    intro = (
+        "Repair turn: answer concretely and operationally."
+        if mode == "repair_concrete"
+        else "Add concrete specificity this turn."
+    )
+    return intro + " " + "; ".join(str(r) for r in rules) + "."
+
+
+def compile_speech_contract(
+    brief: "ChatStanceBrief",
+    *,
+    repair_contract: dict[str, Any] | None = None,
+) -> str:
     """Deterministic regime-specific contract injected near TASK in chat_general.j2.
 
     Pure Python — no LLM, no I/O. Called after enforce_chat_stance_quality.
@@ -1062,12 +1081,11 @@ def compile_speech_contract(brief: "ChatStanceBrief") -> str:
             regime = "instrumental"
 
     if regime == "minimal":
-        return (
+        regime_text = (
             "Keep this reply very short. Do not ask questions. "
             "Release Juniper from replying — offer voice, a pause, or continuation later."
         )
-
-    if regime == "relational":
+    elif regime == "relational":
         parts = ["This is a companion turn."]
         move = brief.companion_closing_move
         if move and move in _COMPANION_CLOSING_MOVE_MAP:
@@ -1076,13 +1094,21 @@ def compile_speech_contract(brief: "ChatStanceBrief") -> str:
             parts.append("Stay present; do not offer next steps, trackers, or support closers.")
         if "situated_curiosity" in list(brief.response_priorities or []):
             parts.append("Ask one grounded question from this thread — not a generic reversal.")
-        return " ".join(parts)
+        regime_text = " ".join(parts)
+    else:
+        # instrumental (default)
+        parts = ["Answer directly."]
+        if brief.task_mode == "triage":
+            parts.append("Lead with the operational blocker.")
+        regime_text = " ".join(parts)
 
-    # instrumental (default)
-    parts = ["Answer directly."]
-    if brief.task_mode == "triage":
-        parts.append("Lead with the operational blocker.")
-    return " ".join(parts)
+    overlay = _compile_repair_speech_overlay(repair_contract)
+    if overlay is None:
+        return regime_text
+    mode = str((repair_contract or {}).get("mode") or "")
+    if mode == "repair_concrete":
+        return overlay
+    return f"{regime_text} {overlay}"
 
 
 def strip_identity_recital_leadin(

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -52,6 +52,7 @@ from orion.schemas.telemetry.turn_effect_explanations import (
 )
 from orion.schemas.state.contracts import StateGetLatestRequest, StateLatestReply
 from orion.schemas.chat_stance import ChatStanceBrief
+from orion.substrate.appraisal import REPAIR_PRESSURE_CONTRACT_METADATA_KEY
 from orion.schemas.metacog_patches import MetacogDraftTextPatchV1, MetacogEnrichScorePatchV1
 from orion.schemas.platform import CoreEventV1
 
@@ -4249,7 +4250,16 @@ async def call_step_services(
                             "response_priorities": list(parsed_brief.response_priorities[:4]),
                             "response_hazards": list(parsed_brief.response_hazards[:4]),
                         })
-                    ctx["speech_contract"] = compile_speech_contract(parsed_brief)
+                    _md = ctx.get("metadata") if isinstance(ctx.get("metadata"), dict) else {}
+                    _repair_contract = None
+                    if settings.repair_pressure_speech_wiring_enabled:
+                        _raw = _md.get(REPAIR_PRESSURE_CONTRACT_METADATA_KEY)
+                        if isinstance(_raw, dict):
+                            _repair_contract = _raw
+                    ctx["speech_contract"] = compile_speech_contract(
+                        parsed_brief,
+                        repair_contract=_repair_contract,
+                    )
                     quality_modified = synthesized_brief != ctx["chat_stance_brief"]
                     ctx["chat_stance_debug"] = build_chat_stance_debug_payload(
                         ctx=ctx,

--- a/services/orion-cortex-exec/app/settings.py
+++ b/services/orion-cortex-exec/app/settings.py
@@ -239,6 +239,10 @@ class Settings(BaseSettings):
     autonomy_quick_graph_timeout_sec: float = Field(3.0, alias="AUTONOMY_QUICK_GRAPH_TIMEOUT_SEC")
     autonomy_quick_graph_subjects: str = Field("orion", alias="AUTONOMY_QUICK_GRAPH_SUBJECTS")
     autonomy_quick_graph_subqueries: str = Field("identity", alias="AUTONOMY_QUICK_GRAPH_SUBQUERIES")
+    repair_pressure_speech_wiring_enabled: bool = Field(
+        True,
+        alias="ENABLE_REPAIR_PRESSURE_SPEECH_WIRING",
+    )
     world_pulse_stance_enabled: bool = Field(False, alias="WORLD_PULSE_STANCE_ENABLED")
     world_pulse_stance_max_topics: int = Field(5, alias="WORLD_PULSE_STANCE_MAX_TOPICS")
     world_pulse_stance_min_confidence: float = Field(0.65, alias="WORLD_PULSE_STANCE_MIN_CONFIDENCE")

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -436,3 +436,36 @@ def test_upgrade_brief_for_relational_continuation_sets_regime() -> None:
     assert upgraded.interaction_regime == "relational"
     assert upgraded.conversation_frame in {"reflective", "playful_relational"}
 
+
+def test_compile_speech_contract_repair_concrete_overrides_relational() -> None:
+    brief = _relational_brief(interaction_regime="relational", companion_closing_move="end_with_a_wondering")
+    repair = {
+        "mode": "repair_concrete",
+        "rules": [
+            "no broad architecture wandering",
+            "include tests/acceptance checks",
+        ],
+    }
+    contract = compile_speech_contract(brief, repair_contract=repair)
+    assert "companion turn" not in contract.lower()
+    assert "include tests/acceptance checks" in contract
+    assert "no broad architecture wandering" in contract
+
+
+def test_compile_speech_contract_concrete_bias_appends_to_instrumental() -> None:
+    brief = _instrumental_brief(task_mode="direct_response")
+    repair = {
+        "mode": "concrete_bias",
+        "rules": ["be more specific", "include next concrete action"],
+    }
+    contract = compile_speech_contract(brief, repair_contract=repair)
+    assert contract.startswith("Answer directly.")
+    assert "be more specific" in contract
+    assert "include next concrete action" in contract
+
+
+def test_compile_speech_contract_ignores_default_repair_contract() -> None:
+    brief = _instrumental_brief()
+    contract = compile_speech_contract(brief, repair_contract={"mode": "default"})
+    assert contract == "Answer directly."
+

--- a/services/orion-cortex-exec/tests/test_chat_relational_stance.py
+++ b/services/orion-cortex-exec/tests/test_chat_relational_stance.py
@@ -452,6 +452,18 @@ def test_compile_speech_contract_repair_concrete_overrides_relational() -> None:
     assert "no broad architecture wandering" in contract
 
 
+def test_compile_speech_contract_concrete_bias_appends_to_relational() -> None:
+    brief = _relational_brief(interaction_regime="relational", companion_closing_move="end_with_a_wondering")
+    repair = {
+        "mode": "concrete_bias",
+        "rules": ["be more specific", "include next concrete action"],
+    }
+    contract = compile_speech_contract(brief, repair_contract=repair)
+    assert "companion turn" in contract.lower()
+    assert "be more specific" in contract
+    assert "include next concrete action" in contract
+
+
 def test_compile_speech_contract_concrete_bias_appends_to_instrumental() -> None:
     brief = _instrumental_brief(task_mode="direct_response")
     repair = {

--- a/services/orion-cortex-exec/tests/test_repair_pressure_speech_wiring.py
+++ b/services/orion-cortex-exec/tests/test_repair_pressure_speech_wiring.py
@@ -39,3 +39,14 @@ def test_metadata_repair_concrete_reaches_speech_contract() -> None:
 def test_metadata_absent_keeps_instrumental_contract() -> None:
     text = _resolve_speech_contract({})
     assert text == "Answer directly."
+
+
+def test_metadata_disabled_keeps_instrumental_contract() -> None:
+    md = {
+        REPAIR_PRESSURE_CONTRACT_METADATA_KEY: {
+            "mode": "repair_concrete",
+            "rules": ["include file/module boundaries"],
+        }
+    }
+    text = _resolve_speech_contract(md, enabled=False)
+    assert text == "Answer directly."

--- a/services/orion-cortex-exec/tests/test_repair_pressure_speech_wiring.py
+++ b/services/orion-cortex-exec/tests/test_repair_pressure_speech_wiring.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from app.chat_stance import compile_speech_contract
+from orion.schemas.chat_stance import ChatStanceBrief
+from orion.substrate.appraisal import REPAIR_PRESSURE_CONTRACT_METADATA_KEY
+
+
+def _resolve_speech_contract(metadata: dict | None, *, enabled: bool = True) -> str:
+    """Mirror executor merge logic under test."""
+    brief = ChatStanceBrief(
+        conversation_frame="mixed",
+        task_mode="direct_response",
+        user_intent="fix this",
+        self_relevance="operational",
+        juniper_relevance="practical",
+        answer_strategy="direct",
+        stance_summary="repair",
+    )
+    repair_contract = None
+    if enabled and isinstance(metadata, dict):
+        raw = metadata.get(REPAIR_PRESSURE_CONTRACT_METADATA_KEY)
+        if isinstance(raw, dict):
+            repair_contract = raw
+    return compile_speech_contract(brief, repair_contract=repair_contract)
+
+
+def test_metadata_repair_concrete_reaches_speech_contract() -> None:
+    md = {
+        REPAIR_PRESSURE_CONTRACT_METADATA_KEY: {
+            "mode": "repair_concrete",
+            "rules": ["include file/module boundaries"],
+        }
+    }
+    text = _resolve_speech_contract(md)
+    assert "include file/module boundaries" in text
+    assert "Repair turn" in text
+
+
+def test_metadata_absent_keeps_instrumental_contract() -> None:
+    text = _resolve_speech_contract({})
+    assert text == "Answer directly."

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -298,6 +298,8 @@ ORION_SITUATION_WEATHER_PROVIDER=stub
 # --- No-Write Debug Mode ---
 HUB_DEFAULT_NO_WRITE=false
 HUB_AUTO_DEFAULT_ENABLED=false
+# Attach substrate repair contract to cortex chat metadata when behavior changes.
+ENABLE_REPAIR_PRESSURE_SPEECH_WIRING=true
 # Autonomy compact/debug availability denominator: two (orion+relationship) or three (legacy juniper row)
 HUB_AUTONOMY_SUBJECT_DISPLAY=two
 # Phase 3 operator goal promote/dismiss/complete routes (default off).

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -353,6 +353,10 @@ class Settings(BaseSettings):
     # --- No-Write Debug Mode (skip publishing chat history) ---
     HUB_DEFAULT_NO_WRITE: bool = Field(default=False, alias="HUB_DEFAULT_NO_WRITE")
     HUB_AUTO_DEFAULT_ENABLED: bool = Field(default=False, alias="HUB_AUTO_DEFAULT_ENABLED")
+    ENABLE_REPAIR_PRESSURE_SPEECH_WIRING: bool = Field(
+        default=True,
+        alias="ENABLE_REPAIR_PRESSURE_SPEECH_WIRING",
+    )
     HUB_AUTONOMY_SUBJECT_DISPLAY: str = Field(default="two", alias="HUB_AUTONOMY_SUBJECT_DISPLAY")
     SUBSTRATE_AUTONOMY_ENABLED: bool = Field(default=False, alias="SUBSTRATE_AUTONOMY_ENABLED")
     SUBSTRATE_AUTONOMY_PROPOSALS_ENABLED: bool = Field(default=True, alias="SUBSTRATE_AUTONOMY_PROPOSALS_ENABLED")

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -46,6 +46,7 @@ from .cortex_request_builder import (
 from .mutation_cognition_context import build_mutation_cognition_context
 from .context_exec_agent_bridge import run_hub_agent_via_context_exec, should_use_context_exec_agent_lane
 from .substrate_effect_pipeline import run_substrate_effect_pipeline
+from .repair_pressure_wiring import attach_repair_pressure_contract
 from orion.substrate.appraisal.view_model import build_substrate_effect_view
 from .substrate_effect_cache import substrate_effect_cache
 from .autonomy_constitution import (
@@ -2099,7 +2100,7 @@ async def handle_chat_request(
     # Runs sync before the cortex call so the snapshot exists when the
     # chat result is serialized. Today the appraiser is sub-millisecond;
     # if it ever grows costly, move to asyncio.to_thread or post-cortex.
-    substrate_summary, _ = run_substrate_effect_pipeline(
+    substrate_summary, substrate_snapshot = run_substrate_effect_pipeline(
         turn_id=corr_id,
         message_id=None,
         user_text=user_prompt,
@@ -2146,6 +2147,11 @@ async def handle_chat_request(
         )
     except HubRequestValidationError as exc:
         return {"error": str(exc), "error_code": exc.code}
+    attach_repair_pressure_contract(
+        req,
+        substrate_snapshot,
+        enabled=bool(getattr(settings, "ENABLE_REPAIR_PRESSURE_SPEECH_WIRING", True)),
+    )
     workflow_request = req.metadata.get("workflow_request") if isinstance(req.metadata, dict) else None
     execution_policy = workflow_request.get("execution_policy") if isinstance(workflow_request, dict) else None
     logger.info(

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -2150,7 +2150,7 @@ async def handle_chat_request(
     attach_repair_pressure_contract(
         req,
         substrate_snapshot,
-        enabled=bool(getattr(settings, "ENABLE_REPAIR_PRESSURE_SPEECH_WIRING", True)),
+        enabled=settings.ENABLE_REPAIR_PRESSURE_SPEECH_WIRING,
     )
     workflow_request = req.metadata.get("workflow_request") if isinstance(req.metadata, dict) else None
     execution_policy = workflow_request.get("execution_policy") if isinstance(workflow_request, dict) else None

--- a/services/orion-hub/scripts/repair_pressure_wiring.py
+++ b/services/orion-hub/scripts/repair_pressure_wiring.py
@@ -1,0 +1,30 @@
+"""Wire substrate repair contract into Hub → Cortex chat metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orion.schemas.cortex.contracts import CortexChatRequest
+from orion.substrate.appraisal import REPAIR_PRESSURE_CONTRACT_METADATA_KEY
+
+from .substrate_effect_cache import SubstrateEffectSnapshot
+
+
+def _contract_changed(snapshot: SubstrateEffectSnapshot) -> bool:
+    before = str((snapshot.contract_before or {}).get("mode") or "")
+    after = str((snapshot.contract_after or {}).get("mode") or "")
+    return before != after
+
+
+def attach_repair_pressure_contract(
+    req: CortexChatRequest,
+    snapshot: SubstrateEffectSnapshot | None,
+    *,
+    enabled: bool,
+) -> None:
+    """Mutate req.metadata in place when repair pressure changed behavior."""
+    if not enabled or snapshot is None or not _contract_changed(snapshot):
+        return
+    meta: dict[str, Any] = dict(req.metadata or {})
+    meta[REPAIR_PRESSURE_CONTRACT_METADATA_KEY] = dict(snapshot.contract_after)
+    req.metadata = meta

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -48,6 +48,7 @@ from scripts.workflow_payloads import extract_workflow_payload
 from scripts.mutation_cognition_context import build_mutation_cognition_context
 from scripts.presence_session import inject_session_presence
 from scripts.substrate_effect_pipeline import run_substrate_effect_pipeline
+from scripts.repair_pressure_wiring import attach_repair_pressure_contract
 from scripts.spark_candidate import publish_spark_introspect_candidate
 from scripts.warm_start import mini_personality_summary
 from orion.schemas.cortex.contracts import CortexChatRequest, CortexChatResult
@@ -887,7 +888,7 @@ async def websocket_endpoint(websocket: WebSocket):
             except Exception:
                 pass
 
-            substrate_summary, _ = run_substrate_effect_pipeline(
+            substrate_summary, substrate_snapshot = run_substrate_effect_pipeline(
                 turn_id=trace_id,
                 message_id=None,
                 user_text=transcript,
@@ -901,6 +902,12 @@ async def websocket_endpoint(websocket: WebSocket):
                     substrate_summary.get("level_label"),
                     substrate_summary.get("changed_behavior"),
                 )
+
+            attach_repair_pressure_contract(
+                chat_req,
+                substrate_snapshot,
+                enabled=bool(getattr(settings, "ENABLE_REPAIR_PRESSURE_SPEECH_WIRING", True)),
+            )
 
             # Chat grammar trace (fail-open, behind PUBLISH_HUB_CHAT_GRAMMAR env flag)
             if bus and settings.PUBLISH_HUB_CHAT_GRAMMAR:

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -906,7 +906,7 @@ async def websocket_endpoint(websocket: WebSocket):
             attach_repair_pressure_contract(
                 chat_req,
                 substrate_snapshot,
-                enabled=bool(getattr(settings, "ENABLE_REPAIR_PRESSURE_SPEECH_WIRING", True)),
+                enabled=settings.ENABLE_REPAIR_PRESSURE_SPEECH_WIRING,
             )
 
             # Chat grammar trace (fail-open, behind PUBLISH_HUB_CHAT_GRAMMAR env flag)

--- a/services/orion-hub/tests/test_handle_chat_request_substrate_effect.py
+++ b/services/orion-hub/tests/test_handle_chat_request_substrate_effect.py
@@ -58,6 +58,8 @@ def test_handle_chat_request_summary_marks_no_change_for_benign():
     assert summary is not None
     assert summary["changed_behavior"] is False
     assert summary["behavior_applied"] is None
+    assert cortex.last_req is not None
+    assert REPAIR_PRESSURE_CONTRACT_METADATA_KEY not in (cortex.last_req.metadata or {})
 
 
 def test_handle_chat_request_attaches_repair_contract_metadata_on_high_pressure():
@@ -73,3 +75,15 @@ def test_handle_chat_request_attaches_repair_contract_metadata_on_high_pressure(
     assert isinstance(contract, dict)
     assert contract.get("mode") in {"repair_concrete", "concrete_bias"}
     assert contract.get("rules")
+
+
+def test_handle_chat_request_omits_repair_contract_when_flag_disabled(monkeypatch):
+    monkeypatch.setattr(api_routes.settings, "ENABLE_REPAIR_PRESSURE_SPEECH_WIRING", False)
+    cortex = _FakeCortex()
+    payload = _make_payload(
+        "you gave me garbage directions — stop, build me a design spec for claude, "
+        "arsonist pov only, nuts and bolts"
+    )
+    asyncio.run(api_routes.handle_chat_request(cortex, payload, "session-flag-off", no_write=True))
+    assert cortex.last_req is not None
+    assert REPAIR_PRESSURE_CONTRACT_METADATA_KEY not in (cortex.last_req.metadata or {})

--- a/services/orion-hub/tests/test_handle_chat_request_substrate_effect.py
+++ b/services/orion-hub/tests/test_handle_chat_request_substrate_effect.py
@@ -5,12 +5,16 @@ import asyncio
 import pytest
 
 from orion.schemas.cortex.contracts import CortexChatResult, CortexClientResult
+from orion.substrate.appraisal import REPAIR_PRESSURE_CONTRACT_METADATA_KEY
 from scripts import api_routes
 from scripts.substrate_effect_cache import substrate_effect_cache
 
 
 class _FakeCortex:
+    last_req = None
+
     async def chat(self, req, correlation_id=None):
+        self.last_req = req
         result = CortexClientResult(
             ok=True,
             mode="brain",
@@ -54,3 +58,18 @@ def test_handle_chat_request_summary_marks_no_change_for_benign():
     assert summary is not None
     assert summary["changed_behavior"] is False
     assert summary["behavior_applied"] is None
+
+
+def test_handle_chat_request_attaches_repair_contract_metadata_on_high_pressure():
+    cortex = _FakeCortex()
+    payload = _make_payload(
+        "you gave me garbage directions — stop, build me a design spec for claude, "
+        "arsonist pov only, nuts and bolts"
+    )
+    asyncio.run(api_routes.handle_chat_request(cortex, payload, "session-x", no_write=True))
+    assert cortex.last_req is not None
+    md = cortex.last_req.metadata or {}
+    contract = md.get(REPAIR_PRESSURE_CONTRACT_METADATA_KEY)
+    assert isinstance(contract, dict)
+    assert contract.get("mode") in {"repair_concrete", "concrete_bias"}
+    assert contract.get("rules")

--- a/services/orion-hub/tests/test_repair_pressure_wiring.py
+++ b/services/orion-hub/tests/test_repair_pressure_wiring.py
@@ -1,7 +1,44 @@
 from __future__ import annotations
 
+from orion.schemas.cortex.contracts import CortexChatRequest
 from orion.substrate.appraisal import REPAIR_PRESSURE_CONTRACT_METADATA_KEY
+from scripts.repair_pressure_wiring import attach_repair_pressure_contract
+from scripts.substrate_effect_cache import SubstrateEffectSnapshot
 
 
 def test_metadata_key_is_stable_string() -> None:
     assert REPAIR_PRESSURE_CONTRACT_METADATA_KEY == "repair_pressure_contract"
+
+
+def _snapshot(*, before_mode: str, after_mode: str, rules: list[str] | None = None) -> SubstrateEffectSnapshot:
+    return SubstrateEffectSnapshot(
+        turn_id="t1",
+        message_id=None,
+        user_text="x",
+        appraisal=None,
+        signal=None,
+        contract_before={"mode": before_mode},
+        contract_after={"mode": after_mode, "rules": rules or ["be more specific"]},
+    )
+
+
+def test_attach_skips_when_disabled() -> None:
+    req = CortexChatRequest(prompt="hi", mode="brain")
+    attach_repair_pressure_contract(req, _snapshot(before_mode="default", after_mode="repair_concrete"), enabled=False)
+    assert req.metadata is None or REPAIR_PRESSURE_CONTRACT_METADATA_KEY not in (req.metadata or {})
+
+
+def test_attach_skips_when_mode_unchanged() -> None:
+    req = CortexChatRequest(prompt="hi", mode="brain")
+    attach_repair_pressure_contract(req, _snapshot(before_mode="default", after_mode="default"), enabled=True)
+    assert req.metadata is None or REPAIR_PRESSURE_CONTRACT_METADATA_KEY not in (req.metadata or {})
+
+
+def test_attach_writes_contract_when_mode_changed() -> None:
+    req = CortexChatRequest(prompt="hi", mode="brain", metadata={"source": "hub_http"})
+    snap = _snapshot(before_mode="default", after_mode="repair_concrete", rules=["include tests/acceptance checks"])
+    attach_repair_pressure_contract(req, snap, enabled=True)
+    assert isinstance(req.metadata, dict)
+    payload = req.metadata[REPAIR_PRESSURE_CONTRACT_METADATA_KEY]
+    assert payload["mode"] == "repair_concrete"
+    assert "include tests/acceptance checks" in payload["rules"]

--- a/services/orion-hub/tests/test_repair_pressure_wiring.py
+++ b/services/orion-hub/tests/test_repair_pressure_wiring.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from orion.substrate.appraisal import REPAIR_PRESSURE_CONTRACT_METADATA_KEY
+
+
+def test_metadata_key_is_stable_string() -> None:
+    assert REPAIR_PRESSURE_CONTRACT_METADATA_KEY == "repair_pressure_contract"

--- a/services/orion-hub/tests/test_repair_pressure_wiring.py
+++ b/services/orion-hub/tests/test_repair_pressure_wiring.py
@@ -4,6 +4,7 @@ from orion.schemas.cortex.contracts import CortexChatRequest
 from orion.substrate.appraisal import REPAIR_PRESSURE_CONTRACT_METADATA_KEY
 from scripts.repair_pressure_wiring import attach_repair_pressure_contract
 from scripts.substrate_effect_cache import SubstrateEffectSnapshot
+from scripts.substrate_effect_pipeline import run_substrate_effect_pipeline
 
 
 def test_metadata_key_is_stable_string() -> None:
@@ -42,3 +43,21 @@ def test_attach_writes_contract_when_mode_changed() -> None:
     payload = req.metadata[REPAIR_PRESSURE_CONTRACT_METADATA_KEY]
     assert payload["mode"] == "repair_concrete"
     assert "include tests/acceptance checks" in payload["rules"]
+
+
+def test_ws_path_can_attach_after_pipeline_before_cortex():
+    """WS builds chat_req before pipeline; attach must run after pipeline."""
+    high = (
+        "you gave me garbage directions — stop, build me a design spec for claude, "
+        "arsonist pov only, nuts and bolts"
+    )
+    _, snap = run_substrate_effect_pipeline(
+        turn_id="ws-turn",
+        message_id=None,
+        user_text=high,
+        source_id="sess-ws",
+        contract_before={"mode": "default"},
+    )
+    req = CortexChatRequest(prompt=high, mode="brain")
+    attach_repair_pressure_contract(req, snap, enabled=True)
+    assert REPAIR_PRESSURE_CONTRACT_METADATA_KEY in (req.metadata or {})

--- a/services/orion-hub/tests/test_repair_pressure_wiring.py
+++ b/services/orion-hub/tests/test_repair_pressure_wiring.py
@@ -23,6 +23,12 @@ def _snapshot(*, before_mode: str, after_mode: str, rules: list[str] | None = No
     )
 
 
+def test_attach_skips_when_snapshot_none() -> None:
+    req = CortexChatRequest(prompt="hi", mode="brain")
+    attach_repair_pressure_contract(req, None, enabled=True)
+    assert req.metadata is None or REPAIR_PRESSURE_CONTRACT_METADATA_KEY not in (req.metadata or {})
+
+
 def test_attach_skips_when_disabled() -> None:
     req = CortexChatRequest(prompt="hi", mode="brain")
     attach_repair_pressure_contract(req, _snapshot(before_mode="default", after_mode="repair_concrete"), enabled=False)


### PR DESCRIPTION
# PR: feat/repair-pressure-speech-wiring

**Title:** feat: wire repair pressure contract into chat TURN CONTRACT

**Branch:** `feat/repair-pressure-speech-wiring` → `main`

**Create PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/repair-pressure-speech-wiring

---

## Summary

- Add shared metadata key `repair_pressure_contract` for substrate `contract_after` on Hub → cortex chat requests
- Hub `attach_repair_pressure_contract()` writes metadata when repair pressure changes contract mode (HTTP + WebSocket)
- Cortex-exec `compile_speech_contract()` merges repair overlay: `repair_concrete` overrides regime text, `concrete_bias` appends
- Executor reads metadata from `ctx` when `ENABLE_REPAIR_PRESSURE_SPEECH_WIRING=true` (default on both services)
- Regression tests cover benign turns, flag-off rollback, snapshot=None fail-open, and relational+concrete_bias blend

## Outcome moved

HIGH/MEDIUM repair pressure on a chat turn now changes the TURN CONTRACT on that same turn — substrate `contract_after` flows Hub metadata → cortex `compile_speech_contract` → `chat_general.j2`.

## Current architecture

Before this patch, Hub substrate appraisal could change `contract_after` and surface a Substrate Effect chip, but cortex-exec compiled speech contracts from stance brief alone. Repair pressure did not reach the TURN CONTRACT on the same turn.

## Architecture touched

- Shared: `orion/substrate/appraisal/contract.py` — metadata key constant
- Hub: `repair_pressure_wiring.py`, `api_routes.py`, `websocket_handler.py`, settings
- Cortex-exec: `chat_stance.py`, `executor.py`, settings

## Files changed

- `orion/substrate/appraisal/contract.py`: `REPAIR_PRESSURE_CONTRACT_METADATA_KEY` constant
- `orion/substrate/appraisal/__init__.py`: re-export metadata key
- `services/orion-hub/scripts/repair_pressure_wiring.py`: attach helper (new)
- `services/orion-hub/scripts/api_routes.py`: capture snapshot, attach before cortex call
- `services/orion-hub/scripts/websocket_handler.py`: same for WebSocket path
- `services/orion-hub/app/settings.py`, `.env_example`: `ENABLE_REPAIR_PRESSURE_SPEECH_WIRING`
- `services/orion-cortex-exec/app/chat_stance.py`: `_compile_repair_speech_overlay` + merge in `compile_speech_contract`
- `services/orion-cortex-exec/app/executor.py`: read metadata, pass `repair_contract`
- `services/orion-cortex-exec/app/settings.py`, `.env_example`: feature flag
- Hub + cortex-exec tests: wiring, precedence, integration, review-gap regressions

## Schema / bus / API changes

- Added: metadata field `repair_pressure_contract` on `CortexChatRequest.metadata` (convention only, no schema registry change)
- Removed: none
- Renamed: none
- Behavior changed: repair pressure contract now affects TURN CONTRACT text when mode changes
- Compatibility notes: flag defaults on; set `ENABLE_REPAIR_PRESSURE_SPEECH_WIRING=false` on hub and/or cortex-exec to roll back

## Env/config changes

- Added keys: `ENABLE_REPAIR_PRESSURE_SPEECH_WIRING` (hub + cortex-exec)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: yes (both services)
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: yes (parent repo; no new keys needed)
- skipped keys requiring operator action: none

## Tests run

```text
cd services/orion-hub && PYTHONPATH=.:../.. pytest tests/test_repair_pressure_wiring.py tests/test_handle_chat_request_substrate_effect.py -q
10 passed

PYTHONPATH=services/orion-cortex-exec:. pytest \
  services/orion-cortex-exec/tests/test_chat_relational_stance.py \
  services/orion-cortex-exec/tests/test_repair_pressure_speech_wiring.py -q
40 passed
```

## Evals run

```text
No eval harness for this seam; covered by deterministic unit + integration tests per plan Task 7.
```

## Docker/build/smoke checks

```text
Not run in this session. Live smoke UNVERIFIED.
Recommended: high-pressure utterance → Substrate Effect chip changed_behavior=true AND cortex debug shows Repair turn or rule substring in speech_contract.
```

## Review findings fixed

- Finding: Benign HTTP turn did not assert metadata absence on cortex request
  - Fix: Extended `test_handle_chat_request_summary_marks_no_change_for_benign`
  - Evidence: 10/10 hub tests pass

- Finding: No flag-off regression tests
  - Fix: Added hub monkeypatch test + `test_metadata_disabled_keeps_instrumental_contract`
  - Evidence: tests pass

- Finding: No `snapshot=None` attach test
  - Fix: Added `test_attach_skips_when_snapshot_none`
  - Evidence: tests pass

- Finding: `concrete_bias` + relational blend untested
  - Fix: Added `test_compile_speech_contract_concrete_bias_appends_to_relational`
  - Evidence: 40/40 cortex-exec tests pass

- Finding: Inconsistent `getattr(settings, ...)` at call sites
  - Fix: Use `settings.ENABLE_REPAIR_PRESSURE_SPEECH_WIRING` directly
  - Evidence: api_routes.py + websocket_handler.py updated

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build orion-hub

docker compose \
  --env-file .env \
  --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml \
  up -d --build orion-cortex-exec
```

## Risks / concerns

- Severity: low
- Concern: Live end-to-end metadata → speech_contract propagation not smoke-tested with running containers
- Mitigation: Post-deploy spot-check with high-pressure fixture; flag-off rollback available on both services

## Test plan

- [ ] Merge and restart hub + cortex-exec
- [ ] Send high-pressure message via Hub HTTP chat
- [ ] Confirm Substrate Effect chip shows `changed_behavior=true`
- [ ] Inspect cortex debug/trace for `speech_contract` containing `Repair turn` or rule substring
- [ ] Send benign message; confirm no `repair_pressure_contract` in cortex metadata
- [ ] Set `ENABLE_REPAIR_PRESSURE_SPEECH_WIRING=false` on hub; confirm high-pressure message omits metadata

## Commits (7)

```
b819a89a feat(substrate): add repair_pressure_contract metadata key constant
c6568317 feat(hub): attach repair_pressure_contract to CortexChatRequest metadata
8ed460cb feat(cortex-exec): merge repair pressure into compile_speech_contract
e4997822 feat(cortex-exec): read repair_pressure_contract from ctx metadata
d58c74d4 feat(hub): wire repair contract into HTTP chat metadata
c789e6a7 feat(hub): wire repair contract into WebSocket chat metadata
6aefd8f5 test: address code review gaps for repair pressure speech wiring
```
