### PR TITLE
Fix repair-pressure v2 fleet RPC race and surface contract in cogniti…

### DIFF
--- a/mesh-utilities/common/cortex_exec_fleet_helpers.sh
+++ b/mesh-utilities/common/cortex_exec_fleet_helpers.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Shared helpers: explicit cortex-exec lane bring-up + post-up verification.
+# Sourced by mesh-utilities/common/up_all_services*.sh
+
+CORTEX_EXEC_SERVICE_DIR="orion-cortex-exec"
+
+CORTEX_EXEC_COMPOSE_SERVICES=(
+  cortex-exec
+  cortex-exec-chat
+  cortex-exec-spark
+  cortex-exec-background
+)
+
+_cortex_exec_project_name() {
+  local repo_root="$1"
+  local project=""
+  if [[ -f "$repo_root/services/$CORTEX_EXEC_SERVICE_DIR/.env" ]]; then
+    project="$(grep -E '^PROJECT=' "$repo_root/services/$CORTEX_EXEC_SERVICE_DIR/.env" | tail -1 | cut -d= -f2- | tr -d "\"'" | xargs)"
+  fi
+  echo "${project:-orion-athena}"
+}
+
+# Build + up all compose services in the cortex-exec stack (not just the default service).
+up_cortex_exec_fleet() {
+  local compose_cmd="$1"
+  local repo_root="$2"
+
+  echo ""
+  echo "=== [$CORTEX_EXEC_SERVICE_DIR] build + up (all lane containers, explicit) ==="
+  set +e
+  # shellcheck disable=SC2086
+  $compose_cmd up -d --build \
+    "${CORTEX_EXEC_COMPOSE_SERVICES[@]}"
+  local rc=$?
+  set -e
+  if [[ "$rc" -ne 0 ]]; then
+    return "$rc"
+  fi
+  verify_cortex_exec_fleet "$repo_root"
+}
+
+# Fail if any lane container is missing weights or has the wrong pre-turn handler flag.
+verify_cortex_exec_fleet() {
+  local repo_root="$1"
+  local project
+  project="$(_cortex_exec_project_name "$repo_root")"
+
+  local -a cnames=(
+    "${project}-cortex-exec"
+    "${project}-cortex-exec-chat"
+    "${project}-cortex-exec-spark"
+    "${project}-cortex-exec-background"
+  )
+  local -a expect_handler=(true false false false)
+  local failures=0
+
+  echo ""
+  echo "=== [$CORTEX_EXEC_SERVICE_DIR] fleet verification (project=$project) ==="
+
+  local i=0
+  for cname in "${cnames[@]}"; do
+    local expect="${expect_handler[$i]}"
+    i=$((i + 1))
+
+    if ! docker inspect "$cname" >/dev/null 2>&1; then
+      echo "❌ $cname: container missing"
+      failures=$((failures + 1))
+      continue
+    fi
+
+    local status
+    status="$(docker inspect -f '{{.State.Status}}' "$cname" 2>/dev/null || echo unknown)"
+    if [[ "$status" != "running" ]]; then
+      echo "❌ $cname: status=$status (expected running)"
+      failures=$((failures + 1))
+      continue
+    fi
+
+    if ! docker exec "$cname" test -f /app/config/substrate/repair_pressure_weights.v2.yaml 2>/dev/null; then
+      echo "❌ $cname: missing /app/config/substrate/repair_pressure_weights.v2.yaml"
+      failures=$((failures + 1))
+      continue
+    fi
+
+    local handler
+    handler="$(docker exec "$cname" printenv ENABLE_PRE_TURN_APPRAISAL_HANDLER 2>/dev/null || true)"
+    handler="${handler,,}"
+    if [[ "$expect" == "true" ]]; then
+      if [[ "$handler" == "false" || "$handler" == "0" ]]; then
+        echo "❌ $cname: ENABLE_PRE_TURN_APPRAISAL_HANDLER=$handler (main must handle pre-turn RPC)"
+        failures=$((failures + 1))
+        continue
+      fi
+    else
+      if [[ -n "$handler" && "$handler" != "false" && "$handler" != "0" ]]; then
+        echo "❌ $cname: ENABLE_PRE_TURN_APPRAISAL_HANDLER=$handler (lane must not handle pre-turn RPC)"
+        failures=$((failures + 1))
+        continue
+      fi
+    fi
+
+    echo "✅ $cname: running, weights OK, pre_turn_handler=$expect"
+  done
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo "ERROR: cortex-exec fleet verification failed ($failures issue(s))" >&2
+    return 1
+  fi
+  return 0
+}

--- a/mesh-utilities/common/up_all_services.sh
+++ b/mesh-utilities/common/up_all_services.sh
@@ -63,6 +63,10 @@ fi
 
 cd "$REPO_ROOT" || exit 2
 
+# cortex-exec multi-lane helpers (explicit build + fleet verification)
+# shellcheck source=cortex_exec_fleet_helpers.sh
+source "$SCRIPT_DIR/cortex_exec_fleet_helpers.sh"
+
 if [[ ! -f "$ROOT_ENV" ]]; then
   echo "ERROR: missing $REPO_ROOT/$ROOT_ENV (run from repo root or ensure it exists)." >&2
   exit 2
@@ -128,6 +132,14 @@ up_one() {
   local svc="$1"
   local cmd
   cmd="$(compose_cmd "$svc")" || return 2
+
+  if [[ "$svc" == "$CORTEX_EXEC_SERVICE_DIR" ]]; then
+    set +e
+    up_cortex_exec_fleet "$cmd" "$REPO_ROOT"
+    local rc=$?
+    set -e
+    return $rc
+  fi
 
   echo ""
   echo "=== [$svc] build + up ==="

--- a/mesh-utilities/common/up_all_services_batched.sh
+++ b/mesh-utilities/common/up_all_services_batched.sh
@@ -69,6 +69,10 @@ fi
 
 cd "$REPO_ROOT" || exit 2
 
+# cortex-exec multi-lane helpers (explicit build + fleet verification)
+# shellcheck source=cortex_exec_fleet_helpers.sh
+source "$SCRIPT_DIR/cortex_exec_fleet_helpers.sh"
+
 if [[ ! -f "$ROOT_ENV" ]]; then
   echo "ERROR: missing $REPO_ROOT/$ROOT_ENV (run from repo root or ensure it exists)." >&2
   exit 2
@@ -149,6 +153,14 @@ up_one() {
   local svc="$1"
   local cmd
   cmd="$(compose_cmd "$svc")" || return 2
+
+  if [[ "$svc" == "$CORTEX_EXEC_SERVICE_DIR" ]]; then
+    set +e
+    up_cortex_exec_fleet "$cmd" "$REPO_ROOT"
+    local rc=$?
+    set -e
+    return $rc
+  fi
 
   echo ""
   echo "=== [$svc] build + up ==="

--- a/orion/substrate/appraisal/paradigms/repair_pressure_v2.py
+++ b/orion/substrate/appraisal/paradigms/repair_pressure_v2.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import inspect
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -17,8 +19,11 @@ from orion.substrate.appraisal.models import EvidenceKind, RepairEvidenceV1
 from orion.substrate.appraisal.probe.logprob_runner import (
     kind_probe_to_evidence,
     parse_yes_no_lines,
+    score_binary_logprob,
     score_kind_from_answer_token,
 )
+
+logger = logging.getLogger("orion.substrate.repair_pressure_v2")
 
 _EVIDENCE_KINDS: tuple[EvidenceKind, ...] = (
     "specificity_demand",
@@ -134,6 +139,35 @@ def _normalize_logprob_content(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return []
 
 
+_TEXT_FALLBACK_DETECTOR = "text_classifier_v2_fallback"
+_TEXT_FALLBACK_CONFIDENCE = 0.65
+_TEXT_FALLBACK_YES = (-0.15, -2.5)
+_TEXT_FALLBACK_NO = (-2.5, -0.15)
+
+
+def _evidence_from_parsed_text_only(parsed: dict[str, str]) -> list[RepairEvidenceV1]:
+    """When logprob tokens cannot align to YES/NO lines, use classifier text answers."""
+    evidence: list[RepairEvidenceV1] = []
+    for kind in _EVIDENCE_KINDS:
+        answer = parsed.get(kind)
+        if answer not in {"YES", "NO"}:
+            continue
+        yes_lp, no_lp = _TEXT_FALLBACK_YES if answer == "YES" else _TEXT_FALLBACK_NO
+        score = score_binary_logprob(logprob_yes=yes_lp, logprob_no=no_lp)
+        evidence.append(
+            RepairEvidenceV1(
+                evidence_id=f"ev_{kind}",
+                source_molecule_id="turn_window",
+                evidence_kind=kind,
+                detector=_TEXT_FALLBACK_DETECTOR,
+                score=score,
+                confidence=_TEXT_FALLBACK_CONFIDENCE,
+                features={"text_answer_yes": 1.0 if answer == "YES" else 0.0, "fallback": 1.0},
+            )
+        )
+    return evidence
+
+
 def _answer_token_entries(content: list[dict[str, Any]]) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for entry in content:
@@ -148,36 +182,37 @@ def _answer_token_entries(content: list[dict[str, Any]]) -> list[dict[str, Any]]
 
 
 def _evidence_from_probe_response(payload: dict[str, Any]) -> list[RepairEvidenceV1]:
-    unc = payload.get("llm_uncertainty")
-    if isinstance(unc, dict) and unc.get("available") is False:
-        return []
-
-    text = str(payload.get("text") or "")
+    text = str(payload.get("text") or payload.get("content") or "")
     parsed = parse_yes_no_lines(text)
     if not parsed:
         return []
 
-    content = _normalize_logprob_content(payload)
-    if not content:
-        return []
+    unc = payload.get("llm_uncertainty")
+    if not isinstance(unc, dict):
+        meta = payload.get("meta") if isinstance(payload.get("meta"), dict) else {}
+        unc = meta.get("llm_uncertainty")
 
-    answer_entries = _answer_token_entries(content)
-    if not answer_entries:
-        return []
+    logprob_usable = isinstance(unc, dict) and unc.get("available") is not False
+    content = _normalize_logprob_content(payload) if logprob_usable else []
+    answer_entries = _answer_token_entries(content) if content else []
 
     evidence: list[RepairEvidenceV1] = []
-    entry_idx = 0
-    for kind in _EVIDENCE_KINDS:
-        if kind not in parsed:
-            continue
-        if entry_idx >= len(answer_entries):
-            break
-        entry = answer_entries[entry_idx]
-        entry_idx += 1
-        scored = score_kind_from_answer_token(kind, entry)
-        if scored is None:
-            continue
-        evidence.append(kind_probe_to_evidence(scored))
+    if answer_entries:
+        entry_idx = 0
+        for kind in _EVIDENCE_KINDS:
+            if kind not in parsed:
+                continue
+            if entry_idx >= len(answer_entries):
+                break
+            entry = answer_entries[entry_idx]
+            entry_idx += 1
+            scored = score_kind_from_answer_token(kind, entry)
+            if scored is None:
+                continue
+            evidence.append(kind_probe_to_evidence(scored))
+
+    if not evidence:
+        evidence = _evidence_from_parsed_text_only(parsed)
     return evidence
 
 
@@ -205,6 +240,12 @@ class RepairPressureV2Paradigm:
         evidence = _evidence_from_probe_response(payload)
 
         if not evidence:
+            probe_text = str(payload.get("text") or payload.get("content") or "")
+            logger.warning(
+                "repair_pressure_probe_no_evidence corr=%s text_head=%r",
+                req.correlation_id,
+                probe_text[:240],
+            )
             return TurnAppraisalParadigmSliceV1(
                 appraisal_kind="repair_pressure",
                 level=0.0,

--- a/orion/substrate/appraisal/probe/logprob_runner.py
+++ b/orion/substrate/appraisal/probe/logprob_runner.py
@@ -10,7 +10,10 @@ from orion.substrate.appraisal.models import EvidenceKind, RepairEvidenceV1
 
 
 DETECTOR_NAME = "logprob_probe_v2"
-_LINE_RE = re.compile(r"^([a-z_]+):\s*(YES|NO)\s*$", re.IGNORECASE | re.MULTILINE)
+_LINE_RE = re.compile(
+    r"^\s*(?:[-*•]|\d+[.)])?\s*([a-z_]+)\s*:\s*(YES|NO)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 
 def _new_evidence_id() -> str:

--- a/services/orion-cortex-exec/.env_example
+++ b/services/orion-cortex-exec/.env_example
@@ -249,7 +249,9 @@ CHAT_STANCE_MEMORY_GRAPH_GRAPHS=
 CHAT_STANCE_MEMORY_GRAPH_TIMEOUT_SEC=2.0
 GRAPHDB_PROBE_TIMEOUT_SEC=3.0
 AUTONOMY_GRAPH_PROBE_DEEP=false
-# Pre-turn appraisal RPC handler (always on; hub ENABLE_PRE_TURN_APPRAISAL is the operator gate)
+# Pre-turn appraisal RPC handler — ONLY on main cortex-exec (legacy lane).
+# Lane replicas (chat/spark/background) must set false to avoid RPC reply races.
+ENABLE_PRE_TURN_APPRAISAL_HANDLER=true
 REPAIR_PRESSURE_WEIGHTS_V2_PATH=config/substrate/repair_pressure_weights.v2.yaml
 REPAIR_PRESSURE_PROBE_ROUTE=quick
 CHANNEL_PRE_TURN_APPRAISAL_REQUEST=orion:cortex:pre_turn_appraisal:request

--- a/services/orion-cortex-exec/Dockerfile
+++ b/services/orion-cortex-exec/Dockerfile
@@ -46,6 +46,9 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # copy schemas into the container
 COPY orion /app/orion
 
+# Substrate config (repair-pressure v2 weights, etc.)
+COPY config/substrate /app/config/substrate
+
 # Copy rest of hub service code
 COPY services/orion-cortex-exec /app
 

--- a/services/orion-cortex-exec/README.md
+++ b/services/orion-cortex-exec/README.md
@@ -22,10 +22,11 @@ Second Rabbit listener (`app/pre_turn_appraisal.py`) serves Hub pre-turn apprais
 4. Kind scores + weights (`REPAIR_PRESSURE_WEIGHTS_V2_PATH`) feed `assemble_repair_contract_delta()`; contract metadata attached when mode changes.
 5. Reply on `orion:cortex:pre_turn_appraisal:result:{correlation_id}` as `TurnAppraisalBundleV1`.
 
-**Operator enable** — Hub only: `ENABLE_PRE_TURN_APPRAISAL=true`. This listener is always registered when cortex-exec starts; no cortex-exec kill switch.
+**Operator enable** — Hub: `ENABLE_PRE_TURN_APPRAISAL=true`. Cortex-exec: **only one replica** may register the pre-turn listener (`ENABLE_PRE_TURN_APPRAISAL_HANDLER=true` on main `cortex-exec`; lane containers `chat` / `spark` / `background` must set `false` in compose to avoid RPC reply races).
 
 | Variable | Default | Description |
 | :--- | :--- | :--- |
+| `ENABLE_PRE_TURN_APPRAISAL_HANDLER` | `true` (main only) | Register Rabbit listener on `orion:cortex:pre_turn_appraisal:request`. Lane replicas: `false`. |
 | `REPAIR_PRESSURE_WEIGHTS_V2_PATH` | `config/substrate/repair_pressure_weights.v2.yaml` | Kind weights for level reduction. |
 | `REPAIR_PRESSURE_PROBE_ROUTE` | `quick` | LLM Gateway route for logprob probes. |
 | `CHANNEL_PRE_TURN_APPRAISAL_REQUEST` | `orion:cortex:pre_turn_appraisal:request` | Request channel. |

--- a/services/orion-cortex-exec/app/main.py
+++ b/services/orion-cortex-exec/app/main.py
@@ -26,6 +26,7 @@ from orion.schemas.cortex.schemas import PlanExecutionRequest, PlanExecutionResu
 from orion.schemas.platform import CoreEventV1
 from orion.schemas.telemetry.cognition_trace import CognitionTracePayload
 from orion.schemas.metacognitive_trace import MetacognitiveTraceEnvelope, MetacognitiveTraceV1
+from orion.substrate.appraisal.contract import REPAIR_PRESSURE_CONTRACT_METADATA_KEY
 from .settings import settings
 from .router import PlanRouter
 from .dream_publish import build_dream_publish_envelope
@@ -64,12 +65,65 @@ def _uuid_from_correlation_id(value: str) -> UUID:
         return uuid5(NAMESPACE_URL, str(value))
 
 
+def _request_metadata_sources(
+    *,
+    req_extra: dict[str, Any],
+    ctx: dict[str, Any] | None,
+) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    ctx_meta = (ctx or {}).get("metadata")
+    if isinstance(ctx_meta, dict):
+        merged.update(ctx_meta)
+    for key, value in req_extra.items():
+        if key not in merged:
+            merged[key] = value
+    return merged
+
+
+def _substrate_trace_fields(incoming: dict[str, Any]) -> dict[str, Any]:
+    contract = incoming.get(REPAIR_PRESSURE_CONTRACT_METADATA_KEY)
+    contract_dict = dict(contract) if isinstance(contract, dict) else None
+    summary = incoming.get("substrate_effect_summary")
+    summary_dict = dict(summary) if isinstance(summary, dict) else None
+    level = None
+    level_label = None
+    changed_behavior = None
+    if summary_dict is not None:
+        level = summary_dict.get("level")
+        level_label = summary_dict.get("level_label")
+        changed_behavior = summary_dict.get("changed_behavior")
+    elif contract_dict is not None:
+        mode = str(contract_dict.get("mode") or "")
+        changed_behavior = mode or None
+    attached = bool(contract_dict) or bool(summary_dict)
+    out: dict[str, Any] = {
+        "repair_pressure_contract": contract_dict,
+        "substrate_effect_attached": attached,
+        "repair_pressure_mode": (contract_dict or {}).get("mode") if contract_dict else None,
+        "repair_pressure_level": level,
+        "repair_pressure_level_label": level_label,
+        "repair_pressure_changed_behavior": changed_behavior,
+    }
+    if summary_dict is not None:
+        out["substrate_effect_summary"] = {
+            "appraisal_kind": summary_dict.get("appraisal_kind"),
+            "level": summary_dict.get("level"),
+            "level_label": summary_dict.get("level_label"),
+            "confidence": summary_dict.get("confidence"),
+            "changed_behavior": summary_dict.get("changed_behavior"),
+            "evidence_count": summary_dict.get("evidence_count"),
+        }
+    return out
+
+
 def build_cognition_trace_metadata(
     res: PlanExecutionResult,
     *,
     req_extra: dict | None = None,
+    ctx: dict | None = None,
 ) -> dict[str, Any]:
     extra = req_extra or {}
+    incoming = _request_metadata_sources(req_extra=extra, ctx=ctx)
     steps = res.steps or []
     last_step = steps[-1].step_name if steps else None
     stance_present = any(
@@ -98,9 +152,10 @@ def build_cognition_trace_metadata(
         "final_text_present": bool((res.final_text or "").strip()),
         "canonical_final_step_name": last_step,
         "canonical_thought_source": thought_source,
-        "session_id": extra.get("session_id") or extra.get("sessionId"),
-        "message_id": extra.get("message_id") or extra.get("messageId"),
+        "session_id": extra.get("session_id") or extra.get("sessionId") or (ctx or {}).get("session_id"),
+        "message_id": extra.get("message_id") or extra.get("messageId") or (ctx or {}).get("message_id"),
         "root_correlation_id": extra.get("root_correlation_id"),
+        **_substrate_trace_fields(incoming),
     }
 
 
@@ -133,7 +188,7 @@ async def _publish_cognition_trace_for_plan_result(
         source_node=settings.node_name,
         recall_used=res.memory_used,
         recall_debug=res.recall_debug,
-        metadata=build_cognition_trace_metadata(res, req_extra=extra),
+        metadata=build_cognition_trace_metadata(res, req_extra=extra, ctx=ctx),
     )
 
     trace_envelope = CognitionTraceEnvelope(
@@ -850,11 +905,12 @@ async def main() -> None:
         pageindex_client_enabled,
     )
     logger.info(
-        "Starting cortex-exec lane=%s channel=%s bus=%s verb_intake=%s",
+        "Starting cortex-exec lane=%s channel=%s bus=%s verb_intake=%s pre_turn_handler=%s",
         settings.exec_lane,
         settings.channel_exec_request,
         settings.orion_bus_url,
         "on" if verb_listener is not None else "off",
+        "on" if settings.enable_pre_turn_appraisal_handler else "off",
     )
     _run_autonomy_graph_probe()
     await svc.bus.connect()
@@ -875,7 +931,8 @@ async def main() -> None:
 
     _rpc_bus = await fork_rpc_client(svc.bus)
     verb_runtime.bus = _rpc_bus
-    bind_pre_turn_appraisal_bus(_rpc_bus or svc.bus)
+    if settings.enable_pre_turn_appraisal_handler:
+        bind_pre_turn_appraisal_bus(_rpc_bus or svc.bus)
     logger.info("exec_rpc_bus_fork_ready")
     assert trace_listener is not None, "Trace listener not initialized"
     assert core_event_listener is not None, "Core event listener not initialized"
@@ -884,7 +941,10 @@ async def main() -> None:
             await verb_listener.start_background()
         await trace_listener.start_background()
         await core_event_listener.start_background()
-        await asyncio.gather(svc.start(), pre_turn_appraisal_svc.start(), health_task)
+        starters: list[Any] = [svc.start(), health_task]
+        if settings.enable_pre_turn_appraisal_handler:
+            starters.insert(1, pre_turn_appraisal_svc.start())
+        await asyncio.gather(*starters)
     finally:
         await _close_rpc_bus()
 

--- a/services/orion-cortex-exec/app/pre_turn_appraisal.py
+++ b/services/orion-cortex-exec/app/pre_turn_appraisal.py
@@ -20,6 +20,21 @@ def _source() -> ServiceRef:
     return ServiceRef(name=settings.service_name, version=settings.service_version, node=settings.node_name)
 
 
+def normalize_llm_gateway_probe_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Map LLM gateway ChatResultPayload → repair probe shape (text + llm_uncertainty + raw)."""
+    meta = payload.get("meta") if isinstance(payload.get("meta"), dict) else {}
+    text = payload.get("content") or payload.get("text") or ""
+    unc = payload.get("llm_uncertainty")
+    if not isinstance(unc, dict):
+        unc = meta.get("llm_uncertainty")
+    raw = payload.get("raw") if isinstance(payload.get("raw"), dict) else {}
+    return {
+        "text": text,
+        "llm_uncertainty": unc if isinstance(unc, dict) else {"available": False},
+        "raw": raw,
+    }
+
+
 async def _llm_probe_call(bus: OrionBusAsync, *, prompt: str, route: str, timeout_sec: float) -> dict[str, Any]:
     rpc_corr = str(uuid4())
     reply_channel = f"orion:exec:result:LLMGatewayService:{rpc_corr}"
@@ -48,7 +63,7 @@ async def _llm_probe_call(bus: OrionBusAsync, *, prompt: str, route: str, timeou
     decoded = bus.codec.decode(msg.get("data"))
     if not decoded.ok or not isinstance(decoded.envelope.payload, dict):
         return {"text": "", "llm_uncertainty": {"available": False}}
-    return decoded.envelope.payload
+    return normalize_llm_gateway_probe_payload(decoded.envelope.payload)
 
 
 async def handle_pre_turn_appraisal_request(env: BaseEnvelope) -> BaseEnvelope:
@@ -98,6 +113,19 @@ async def handle_pre_turn_appraisal_request(env: BaseEnvelope) -> BaseEnvelope:
                 after_mode = str((slice_.contract_delta or {}).get("mode") or before_mode)
                 if before_mode != after_mode:
                     metadata_attachments[REPAIR_PRESSURE_CONTRACT_METADATA_KEY] = dict(slice_.contract_delta)
+            logger.info(
+                "pre_turn_appraisal_paradigm_result corr=%s paradigm=%s level=%.3f confidence=%.3f "
+                "mode=%s evidence=%s notes=%s metadata_attached=%s",
+                req.correlation_id,
+                paradigm_name,
+                slice_.level,
+                slice_.confidence,
+                (slice_.contract_delta or {}).get("mode"),
+                len(slice_.evidence),
+                slice_.notes,
+                paradigm_name == "repair_pressure"
+                and REPAIR_PRESSURE_CONTRACT_METADATA_KEY in metadata_attachments,
+            )
         except Exception:
             logger.warning(
                 "pre_turn_appraisal_paradigm_failed corr=%s paradigm=%s",

--- a/services/orion-cortex-exec/app/settings.py
+++ b/services/orion-cortex-exec/app/settings.py
@@ -248,6 +248,10 @@ class Settings(BaseSettings):
         alias="REPAIR_PRESSURE_WEIGHTS_V2_PATH",
     )
     repair_pressure_probe_route: str = Field("quick", alias="REPAIR_PRESSURE_PROBE_ROUTE")
+    enable_pre_turn_appraisal_handler: bool = Field(
+        True,
+        alias="ENABLE_PRE_TURN_APPRAISAL_HANDLER",
+    )
     channel_pre_turn_appraisal_request: str = Field(
         "orion:cortex:pre_turn_appraisal:request",
         alias="CHANNEL_PRE_TURN_APPRAISAL_REQUEST",

--- a/services/orion-cortex-exec/docker-compose.yml
+++ b/services/orion-cortex-exec/docker-compose.yml
@@ -51,6 +51,7 @@ services:
 
       CHANNEL_EXEC_REQUEST: ${CHANNEL_EXEC_REQUEST}
       EXEC_LANE: ${EXEC_LANE:-legacy}
+      ENABLE_PRE_TURN_APPRAISAL_HANDLER: ${ENABLE_PRE_TURN_APPRAISAL_HANDLER:-true}
       CHANNEL_COGNITION_TRACE_PUB: ${CHANNEL_COGNITION_TRACE_PUB:-orion:cognition:trace}
       CHANNEL_METACOG_TRACE_PUB: ${CHANNEL_METACOG_TRACE_PUB:-orion:metacog:trace}
       EXEC_REQUEST_PREFIX: ${EXEC_REQUEST_PREFIX}
@@ -202,6 +203,7 @@ services:
     environment:
       EXEC_LANE: chat
       CHANNEL_EXEC_REQUEST: orion:cortex:exec:request:chat
+      ENABLE_PRE_TURN_APPRAISAL_HANDLER: "false"
 
   cortex-exec-spark:
     extends:
@@ -211,6 +213,7 @@ services:
     environment:
       EXEC_LANE: spark
       CHANNEL_EXEC_REQUEST: orion:cortex:exec:request:spark
+      ENABLE_PRE_TURN_APPRAISAL_HANDLER: "false"
 
   cortex-exec-background:
     extends:
@@ -220,6 +223,7 @@ services:
     environment:
       EXEC_LANE: background
       CHANNEL_EXEC_REQUEST: orion:cortex:exec:request:background
+      ENABLE_PRE_TURN_APPRAISAL_HANDLER: "false"
 
 networks:
   app-net:

--- a/services/orion-cortex-exec/tests/test_cognition_trace_metadata.py
+++ b/services/orion-cortex-exec/tests/test_cognition_trace_metadata.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from orion.schemas.cortex.schemas import PlanExecutionResult, StepExecutionResult
 
 
-def _build_trace_metadata(res: PlanExecutionResult, *, req_extra: dict | None = None) -> dict:
+def _build_trace_metadata(res: PlanExecutionResult, *, req_extra: dict | None = None, ctx: dict | None = None) -> dict:
     from app.main import build_cognition_trace_metadata
 
-    return build_cognition_trace_metadata(res, req_extra=req_extra or {})
+    return build_cognition_trace_metadata(res, req_extra=req_extra or {}, ctx=ctx)
 
 
 def test_metadata_includes_routing_and_presence_flags() -> None:
@@ -61,3 +61,53 @@ def test_metadata_includes_routing_and_presence_flags() -> None:
     assert meta["session_id"] == "sess-1"
     assert meta["message_id"] == "msg-1"
     assert "secret" not in str(meta)
+
+
+def test_metadata_includes_repair_pressure_contract_from_ctx() -> None:
+    res = PlanExecutionResult(
+        verb_name="chat_general",
+        status="success",
+        mode="brain",
+        steps=[],
+        final_text="paste-ready answer",
+    )
+    meta = _build_trace_metadata(
+        res,
+        ctx={
+            "session_id": "sess-rp",
+            "metadata": {
+                "repair_pressure_contract": {
+                    "mode": "concrete_bias",
+                    "rules": ["be more specific"],
+                },
+                "substrate_effect_summary": {
+                    "appraisal_kind": "repair_pressure",
+                    "level": 0.698,
+                    "level_label": "MEDIUM",
+                    "confidence": 0.65,
+                    "changed_behavior": "concrete_bias",
+                    "evidence_count": 7,
+                },
+            },
+        },
+    )
+    assert meta["substrate_effect_attached"] is True
+    assert meta["repair_pressure_contract"]["mode"] == "concrete_bias"
+    assert meta["repair_pressure_mode"] == "concrete_bias"
+    assert meta["repair_pressure_level_label"] == "MEDIUM"
+    assert meta["repair_pressure_changed_behavior"] == "concrete_bias"
+    assert meta["substrate_effect_summary"]["evidence_count"] == 7
+
+
+def test_metadata_repair_pressure_absent_when_not_attached() -> None:
+    res = PlanExecutionResult(
+        verb_name="chat_general",
+        status="success",
+        mode="brain",
+        steps=[],
+        final_text="hello",
+    )
+    meta = _build_trace_metadata(res, ctx={"metadata": {}})
+    assert meta["substrate_effect_attached"] is False
+    assert meta["repair_pressure_contract"] is None
+    assert meta["repair_pressure_mode"] is None

--- a/services/orion-cortex-exec/tests/test_pre_turn_appraisal_rpc.py
+++ b/services/orion-cortex-exec/tests/test_pre_turn_appraisal_rpc.py
@@ -4,7 +4,7 @@ import pytest
 
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.schemas.pre_turn_appraisal import PreTurnAppraisalRequestV1, TurnWindowMessageV1
-from app.pre_turn_appraisal import handle_pre_turn_appraisal_request
+from app.pre_turn_appraisal import handle_pre_turn_appraisal_request, normalize_llm_gateway_probe_payload
 
 
 @pytest.mark.asyncio
@@ -70,3 +70,106 @@ async def test_handler_marks_unknown_paradigm_failed(monkeypatch) -> None:
     bundle = reply.payload
     assert bundle["failed_paradigms"] == ["not_a_real_paradigm"]
     assert bundle["paradigms"] == {}
+
+
+def test_normalize_llm_gateway_probe_payload_maps_content_and_meta_uncertainty() -> None:
+    normalized = normalize_llm_gateway_probe_payload(
+        {
+            "content": "specificity_demand: YES\n",
+            "meta": {
+                "llm_uncertainty": {
+                    "available": True,
+                    "content": [
+                        {
+                            "token": "YES",
+                            "logprob": -0.1,
+                            "top_logprobs": [
+                                {"token": "YES", "logprob": -0.1},
+                                {"token": "NO", "logprob": -2.0},
+                            ],
+                        }
+                    ],
+                }
+            },
+            "raw": {"probs": []},
+        }
+    )
+    assert normalized["text"] == "specificity_demand: YES\n"
+    assert normalized["llm_uncertainty"]["available"] is True
+
+
+@pytest.mark.asyncio
+async def test_handler_parses_gateway_shaped_llm_probe(monkeypatch) -> None:
+    """End-to-end: gateway ChatResultPayload shape → non-zero repair level when thread warrants it."""
+    captured: list[str] = []
+
+    async def _fake_llm_probe(_bus, *, prompt, route, timeout_sec):
+        captured.append(prompt)
+        return normalize_llm_gateway_probe_payload(
+            {
+                "content": "\n".join(
+                    f"{kind}: YES"
+                    for kind in (
+                        "specificity_demand",
+                        "trust_rupture",
+                        "coherence_gap",
+                        "repetition_failure",
+                        "operational_block",
+                        "explicit_repair_command",
+                        "assistant_accountability_demand",
+                    )
+                ),
+                "meta": {
+                    "llm_uncertainty": {
+                        "available": True,
+                        "content": [
+                            {
+                                "token": "YES",
+                                "logprob": -0.1,
+                                "top_logprobs": [
+                                    {"token": "YES", "logprob": -0.1},
+                                    {"token": "NO", "logprob": -2.5},
+                                ],
+                            }
+                        ]
+                        * 7,
+                    }
+                },
+                "raw": {},
+            }
+        )
+
+    import app.pre_turn_appraisal as handler_module
+
+    monkeypatch.setattr(handler_module, "_llm_probe_call", _fake_llm_probe)
+    monkeypatch.setattr(handler_module, "_BUS", object())
+
+    payload = PreTurnAppraisalRequestV1(
+        correlation_id="00000000-0000-4000-8000-000000000004",
+        session_id="sess",
+        turn_window=[
+            TurnWindowMessageV1(role="user", content="you gave garbage directions — again"),
+            TurnWindowMessageV1(role="assistant", content="Here is another high-level overview."),
+            TurnWindowMessageV1(
+                role="user",
+                content="Stop hand waving. Build me a spec with file boundaries and tests.",
+            ),
+        ],
+        paradigms_requested=["repair_pressure"],
+    ).model_dump(mode="json")
+
+    env = BaseEnvelope(
+        kind="pre_turn_appraisal.request.v1",
+        source=ServiceRef(name="orion-hub", version="test"),
+        correlation_id="00000000-0000-4000-8000-000000000004",
+        payload=payload,
+    )
+    reply = await handle_pre_turn_appraisal_request(env)
+    bundle = reply.payload
+    rp = bundle["paradigms"]["repair_pressure"]
+    assert rp["level"] >= 0.45, rp
+    assert bundle["metadata_attachments"].get("repair_pressure_contract", {}).get("mode") in {
+        "repair_concrete",
+        "concrete_bias",
+    }
+    assert captured, "probe should have run"

--- a/services/orion-cortex-exec/tests/test_pre_turn_handler_gate.py
+++ b/services/orion-cortex-exec/tests/test_pre_turn_handler_gate.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from app.settings import Settings
+
+
+def test_pre_turn_handler_defaults_enabled() -> None:
+    s = Settings(_env_file=None)
+    assert s.enable_pre_turn_appraisal_handler is True
+
+
+def test_pre_turn_handler_lane_disabled_via_env() -> None:
+    s = Settings(_env_file=None, ENABLE_PRE_TURN_APPRAISAL_HANDLER="false")
+    assert s.enable_pre_turn_appraisal_handler is False

--- a/services/orion-hub/scripts/pre_turn_appraisal_wiring.py
+++ b/services/orion-hub/scripts/pre_turn_appraisal_wiring.py
@@ -83,6 +83,10 @@ async def run_pre_turn_appraisal_wiring(
         )
     )
     summary = apply_pre_turn_appraisal_bundle(req, bundle, enabled=True)
+    if summary is not None:
+        meta = dict(req.metadata or {})
+        meta["substrate_effect_summary"] = summary
+        req.metadata = meta
     return summary, bundle
 
 

--- a/services/orion-hub/tests/test_cognition_trace_api.py
+++ b/services/orion-hub/tests/test_cognition_trace_api.py
@@ -1,6 +1,7 @@
 """Tests for Hub CognitionTraceCache and cognition trace API (Runtime Trace Nexus A4)."""
 from __future__ import annotations
 
+import importlib.util
 import os
 import sys
 from pathlib import Path
@@ -11,6 +12,13 @@ HUB_ROOT = Path(__file__).resolve().parents[1]
 for candidate in (str(REPO_ROOT), str(HUB_ROOT)):
     if candidate not in sys.path:
         sys.path.insert(0, candidate)
+
+_cache_path = HUB_ROOT / "scripts" / "cognition_trace_cache.py"
+_cache_spec = importlib.util.spec_from_file_location("hub_cognition_trace_cache", _cache_path)
+assert _cache_spec and _cache_spec.loader
+_cache_mod = importlib.util.module_from_spec(_cache_spec)
+_cache_spec.loader.exec_module(_cache_mod)
+CognitionTraceCache = _cache_mod.CognitionTraceCache
 
 for key, value in {
     "CHANNEL_VOICE_TRANSCRIPT": "orion:voice:transcript",
@@ -27,7 +35,6 @@ def test_cognition_trace_cache_api_redacted_default() -> None:
 
     from orion.schemas.cortex.types import StepExecutionResult
     from orion.schemas.telemetry.cognition_trace import CognitionTracePayload
-    from scripts.cognition_trace_cache import CognitionTraceCache
 
     cache = CognitionTraceCache(
         enabled=True,
@@ -52,6 +59,12 @@ def test_cognition_trace_cache_api_redacted_default() -> None:
             )
         ],
         recall_used=True,
+        metadata={
+            "repair_pressure_contract": {"mode": "concrete_bias", "rules": ["be more specific"]},
+            "substrate_effect_attached": True,
+            "repair_pressure_mode": "concrete_bias",
+            "repair_pressure_level_label": "MEDIUM",
+        },
     )
 
     async def _run():
@@ -62,4 +75,6 @@ def test_cognition_trace_cache_api_redacted_default() -> None:
     assert body is not None
     assert body["final_text_present"] is True
     assert "SECRET" not in str(body)
+    assert body["metadata"]["repair_pressure_contract"]["mode"] == "concrete_bias"
+    assert body["metadata"]["substrate_effect_attached"] is True
     assert body["steps"][0]["error_present"] is False

--- a/services/orion-hub/tests/test_pre_turn_appraisal_wiring.py
+++ b/services/orion-hub/tests/test_pre_turn_appraisal_wiring.py
@@ -39,6 +39,33 @@ def test_apply_bundle_attaches_metadata_when_mode_changes() -> None:
     assert summary is not None
     assert summary["level"] == 0.82
     assert summary["changed_behavior"] == "repair_concrete"
+    assert req.metadata.get("substrate_effect_summary") is None
+
+
+def test_substrate_effect_summary_attached_to_request_metadata() -> None:
+    """Mirrors run_pre_turn_appraisal_wiring post-apply metadata attach (lines 86-89)."""
+    req = CortexChatRequest(prompt="paste test", mode="brain")
+    bundle = TurnAppraisalBundleV1(
+        correlation_id="00000000-0000-4000-8000-000000000005",
+        paradigms={
+            "repair_pressure": TurnAppraisalParadigmSliceV1(
+                appraisal_kind="repair_pressure",
+                level=0.698,
+                confidence=0.65,
+                contract_delta={"mode": "concrete_bias", "rules": ["be more specific"]},
+            )
+        },
+        metadata_attachments={
+            "repair_pressure_contract": {"mode": "concrete_bias", "rules": ["be more specific"]}
+        },
+    )
+    summary = apply_pre_turn_appraisal_bundle(req, bundle, enabled=True)
+    assert summary is not None
+    meta = dict(req.metadata or {})
+    meta["substrate_effect_summary"] = summary
+    req.metadata = meta
+    assert req.metadata["substrate_effect_summary"]["level_label"] == "MEDIUM"
+    assert req.metadata[REPAIR_PRESSURE_CONTRACT_METADATA_KEY]["mode"] == "concrete_bias"
 
 
 def test_apply_bundle_skips_when_disabled() -> None:

--- a/tests/test_logprob_probe_runner.py
+++ b/tests/test_logprob_probe_runner.py
@@ -12,11 +12,15 @@ def test_parse_yes_no_lines() -> None:
 specificity_demand: YES
 trust_rupture: NO
 coherence_gap: yes
+- operational_block: YES
+1. explicit_repair_command: NO
 """
     parsed = parse_yes_no_lines(text)
     assert parsed["specificity_demand"] == "YES"
     assert parsed["trust_rupture"] == "NO"
     assert parsed["coherence_gap"] == "YES"
+    assert parsed["operational_block"] == "YES"
+    assert parsed["explicit_repair_command"] == "NO"
 
 
 def test_score_binary_logprob_sigmoid() -> None:

--- a/tests/test_repair_pressure_v2_paradigm.py
+++ b/tests/test_repair_pressure_v2_paradigm.py
@@ -85,3 +85,77 @@ async def test_paradigm_fail_closed_on_empty_llm() -> None:
     slice_ = await paradigm.run(req)
     assert slice_.level == 0.0
     assert "no_repair_evidence" in slice_.notes
+
+
+@pytest.mark.asyncio
+async def test_paradigm_text_fallback_when_llm_uncertainty_unavailable() -> None:
+    kinds_text = "\n".join(
+        f"{kind}: YES"
+        for kind in (
+            "specificity_demand",
+            "trust_rupture",
+            "coherence_gap",
+            "repetition_failure",
+            "operational_block",
+            "explicit_repair_command",
+            "assistant_accountability_demand",
+        )
+    )
+
+    async def _llm(_prompt: str) -> dict:
+        return {
+            "content": kinds_text,
+            "meta": {"llm_uncertainty": {"available": False, "token_count_observed": 0}},
+            "raw": {},
+        }
+
+    paradigm = RepairPressureV2Paradigm(llm_caller=_llm)
+    req = PreTurnAppraisalRequestV1(
+        correlation_id="c4",
+        session_id="s1",
+        turn_window=[TurnWindowMessageV1(role="user", content="give me files and tests")],
+    )
+    slice_ = await paradigm.run(req)
+    assert slice_.level >= 0.45
+    assert "no_repair_evidence" not in slice_.notes
+
+
+@pytest.mark.asyncio
+async def test_paradigm_text_fallback_when_logprob_tokens_do_not_align() -> None:
+    kinds_text = "\n".join(f"{kind}: YES" for kind in (
+        "specificity_demand", "trust_rupture", "coherence_gap",
+        "repetition_failure", "operational_block", "explicit_repair_command",
+        "assistant_accountability_demand",
+    ))
+
+    async def _llm(_prompt: str) -> dict:
+        return {
+            "content": kinds_text,
+            "meta": {"llm_uncertainty": {"available": True, "token_count_observed": 40}},
+            "raw": {
+                "probs": [
+                    {
+                        "token": "Hello",
+                        "logprob": -0.2,
+                        "top_logprobs": [
+                            {"token": "Hello", "logprob": -0.2},
+                            {"token": "Hi", "logprob": -1.5},
+                        ],
+                    }
+                ]
+            },
+        }
+
+    paradigm = RepairPressureV2Paradigm(llm_caller=_llm)
+    req = PreTurnAppraisalRequestV1(
+        correlation_id="c3",
+        session_id="s1",
+        turn_window=[
+            TurnWindowMessageV1(role="user", content="stop hand waving"),
+            TurnWindowMessageV1(role="assistant", content="here is another overview"),
+            TurnWindowMessageV1(role="user", content="give me files and tests"),
+        ],
+    )
+    slice_ = await paradigm.run(req)
+    assert slice_.level >= 0.45
+    assert slice_.contract_delta.get("mode") in {"repair_concrete", "concrete_bias"}


### PR DESCRIPTION
## Summary

- Gate pre-turn appraisal RPC handler to main `cortex-exec` only (`ENABLE_PRE_TURN_APPRAISAL_HANDLER`), eliminating multi-replica reply race on `orion:cortex:pre_turn_appraisal:request`.
- Harden repair-pressure v2 runtime: Docker weights copy, gateway payload normalization, logprob/text-classifier fallback, relaxed yes/no line parsing.
- Wire `repair_pressure_contract` and substrate effect fields through hub request metadata → cortex-exec cognition trace publish → hub trace cache/API redaction.
- Add mesh fleet helpers: explicit 4-lane `up --build` plus post-up verification (weights file + handler flags).

## Outcome moved

Pre-turn appraisal now reliably returns scored bundles from the weighted main lane; cognition trace API exposes `metadata.repair_pressure_contract` and related substrate fields for inspectable repair-pressure behavior (verified live on corr `fce75f9d` before trace hardening).

## Current architecture

All four cortex-exec compose services subscribed to the same pre-turn RPC channel; hub received whichever replica replied first (often a lane without weights). Trace publish carried routing/presence flags but dropped repair-pressure contract metadata.

## Architecture touched

- `services/orion-cortex-exec` — handler gate, pre-turn parsing, trace metadata builder, Dockerfile, compose
- `services/orion-hub` — pre-turn wiring attaches `substrate_effect_summary` to request metadata
- `orion/substrate/appraisal` — repair_pressure_v2 paradigm + logprob runner
- `mesh-utilities/common` — cortex-exec fleet bring-up + verification

## Files changed

- `services/orion-cortex-exec/app/main.py`: `build_cognition_trace_metadata()` reads repair-pressure fields from exec context; passes `ctx` from trace publish path
- `services/orion-cortex-exec/app/pre_turn_appraisal.py`: gateway probe payload normalization
- `services/orion-cortex-exec/app/settings.py`, `docker-compose.yml`, `.env_example`, `README.md`: `ENABLE_PRE_TURN_APPRAISAL_HANDLER` gate
- `services/orion-cortex-exec/Dockerfile`: COPY substrate weights into image
- `services/orion-hub/scripts/pre_turn_appraisal_wiring.py`: attach `substrate_effect_summary` after bundle apply
- `orion/substrate/appraisal/paradigms/repair_pressure_v2.py`: text-classifier fallback when logprob alignment fails
- `orion/substrate/appraisal/probe/logprob_runner.py`: relaxed yes/no line parsing
- `mesh-utilities/common/cortex_exec_fleet_helpers.sh`: new fleet up + verify
- Tests across cortex-exec, hub, and substrate

## Schema / bus / API changes

- Added: none (metadata fields only on existing cognition trace payload / request metadata)
- Removed: none
- Renamed: none
- Behavior changed: only main `cortex-exec` consumes pre-turn RPC; trace API `metadata` now includes repair-pressure contract when attached
- Compatibility notes: lane containers must set `ENABLE_PRE_TURN_APPRAISAL_HANDLER=false` (compose defaults updated)

## Env/config changes

- Added keys: `ENABLE_PRE_TURN_APPRAISAL_HANDLER` (cortex-exec, default `true` on main service, `false` on chat/spark/background lanes)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: yes
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: yes
- skipped keys requiring operator action: none

## Tests run

```text
pytest services/orion-cortex-exec/tests/test_cognition_trace_metadata.py \
  services/orion-cortex-exec/tests/test_pre_turn_handler_gate.py \
  services/orion-cortex-exec/tests/test_pre_turn_appraisal_rpc.py \
  services/orion-hub/tests/test_cognition_trace_api.py \
  services/orion-hub/tests/test_pre_turn_appraisal_wiring.py \
  tests/test_logprob_probe_runner.py \
  tests/test_repair_pressure_v2_paradigm.py -q
23 passed
```

## Evals run

```text
None (unit/regression tests only for this patch)
```

## Docker/build/smoke checks

```text
Live smoke on Athena prior to trace hardening: corr fce75f9d — cortex level=0.698, hub level=MEDIUM changed=concrete_bias
Mesh verify_cortex_exec_fleet: all four lanes ✅ after rebuild
```

## Review findings fixed

- Finding: hub tests failed when run with cortex-exec suite due to `scripts` namespace shadowing
  - Fix: importlib load for cognition trace cache; deterministic unit test for substrate summary attach
  - Evidence: 23/23 focused tests pass in combined run

## Restart required

```bash
# Rebuild all four cortex-exec lanes (mesh helper or manual):
docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml up -d --build \
  cortex-exec cortex-exec-chat cortex-exec-spark cortex-exec-background

# Hub if not already running latest wiring:
docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build hub
```

## Risks / concerns

- Severity: low
- Concern: trace metadata depends on hub attaching summary before exec publish; if hub restarts without this patch, traces revert to missing contract
- Mitigation: hub restart included above; trace fields are additive only

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/repair-pressure-v2-trace-and-fleet
