### PR TITLE
Feat/cola novelty signal

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-04-cola-novelty-signal-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-04-cola-novelty-signal-pr.md
@@ -1,0 +1,128 @@
+# PR Report: CoLA-Derived Novelty Signal (`feat/cola-novelty-signal`)
+
+## Summary
+
+- Adds `POST /v1/understand` to `orion-llama-cola-host`: a single deterministic forward pass through CoLA's `bc_mode` (Inverse Dynamics) branch, returning the pooled pre-argmax action-codebook distribution for finished text.
+- Patches `intention.py`'s `IntentionModel_v1.forward()` `bc_mode` return from a 2-tuple to a 3-tuple to expose that distribution (previously only the collapsed argmax index was returned).
+- `orion-spark-introspector` calls the new endpoint directly per chat turn (bypassing `orion-llm-gateway`'s shared routing table on purpose), scores novelty as cosine distance from a bounded, LRU-evicted rolling per-session reference, and publishes it as `SparkSignalV1.novelty_delta` over the existing `orion:spark:signal` bus — the same wire `orion-cortex-exec` already reads for metacognition.
+- Adds `signal_type="language"` to `SparkSignalV1` (additive) instead of overloading an existing value that would have mislabeled the signal downstream.
+- Ships disabled via `COLA_UNDERSTAND_ENABLE=false` and fails open on any error.
+
+## Outcome moved
+
+`orion-cortex-exec`'s metacognitive context can now receive a novelty signal derived from CoLA's latent-action understanding of what was actually said in a turn, instead of only the self-state-substrate-derived novelty baseline (which reflects biometric/attention pressure, not language content).
+
+## Current architecture
+
+`orion-llama-cola-host` existed but was unreachable from the live chat path (routing table maps `chat`/`agent`/`metacog`/`quick` to `llamacpp`; the one code path that would default to `llama-cola` is never called) and only exposed a stochastic, generation-time policy-sampling signal (`action_indices`, sampled at `tau=2.0`) via `/v1/chat/completions` — meant for output diversity, not for scoring the meaning of a finished reply. `orion-spark-introspector` had no producer of language-derived novelty at all; its only novelty source was `_phi_from_self_state`, derived from biometric/attention pressure dimensions.
+
+## Architecture touched
+
+- `services/orion-llama-cola-host`: new endpoint, model return-signature change (only `IntentionModel_v1`, the currently-configured variant — other unused variants in `intention.py` untouched).
+- `services/orion-spark-introspector`: new HTTP client call, novelty scoring, signal publish, wired into the existing `handle_semantic_upsert` chat-turn handler.
+- `orion/schemas/telemetry/spark_signal.py`: additive schema change (new `signal_type` literal).
+- No changes to `orion-llm-gateway`, `SelfStateV1`, or the `SignalMapper`/`OrionTissue` grid pipeline (left as-is, out of scope).
+
+## Files changed
+
+- `services/orion-llama-cola-host/intention.py`: `bc_mode` branch in `IntentionModel_v1.forward()` now also returns the pre-argmax action-probability distribution.
+- `services/orion-llama-cola-host/app/main.py`: new `POST /v1/understand` endpoint + request/response schemas.
+- `services/orion-llama-cola-host/README.md`: documents the new endpoint.
+- `services/orion-llama-cola-host/tests/`: new — model-level tests with a tiny randomly-initialized CoLA model (real torch execution, not mocked) proving the 3-tuple return, valid softmax distribution, determinism, and the endpoint's pooling logic.
+- `services/orion-spark-introspector/app/worker.py`: new CoLA-understand HTTP client, LRU-bounded rolling per-session novelty history, `SparkSignalV1` publish, wiring into `handle_semantic_upsert`; extracted `_publish_spark_signal()` shared with the existing turn-effect-alert path.
+- `services/orion-spark-introspector/app/settings.py`: new `COLA_*` settings (all opt-in, disabled by default).
+- `services/orion-spark-introspector/.env_example`: documents the new keys.
+- `services/orion-spark-introspector/README.md`: new §6.8 documenting the feature, data flow, settings, and rollback.
+- `services/orion-spark-introspector/tests/test_cola_novelty_signal.py`: new — unit, fail-open, LRU-eviction, dimension-mismatch, and `handle_semantic_upsert` wiring tests, plus an in-process trace proving a published signal reaches the same `phi_stats` merge `orion-cortex-exec` reads.
+- `orion/schemas/telemetry/spark_signal.py`: added `"language"` to `signal_type`'s literal set (additive; verified no exhaustive-match consumer exists elsewhere).
+
+## Schema / bus / API changes
+
+- Added: `POST /v1/understand` on `orion-llama-cola-host`.
+- Added: `SparkSignalV1.signal_type` literal `"language"`.
+- Behavior changed: `IntentionModel_v1.forward(bc_mode=True)` now returns a 3-tuple instead of 2-tuple. Verified this is the only production call site in the repo (no other caller assumes the old arity); other model variants (`v1p`, `v1a`, base) in the same file were left untouched since they're not the currently-configured model (`config.v == 1`).
+- Compatibility notes: both additions are backward compatible; no existing consumer breaks.
+
+## Env/config changes
+
+- Added keys (all in `services/orion-spark-introspector/.env_example`): `COLA_UNDERSTAND_ENABLE` (default `false`), `COLA_UNDERSTAND_URL`, `COLA_UNDERSTAND_TIMEOUT_SEC`, `COLA_NOVELTY_WINDOW`, `COLA_NOVELTY_MAX_SESSIONS`, `COLA_NOVELTY_GAIN`, `COLA_NOVELTY_SIGNAL_TTL_MS`.
+- `orion-llama-cola-host` needed no new env keys.
+- Local `.env` synced manually (main checkout's real `services/orion-spark-introspector/.env`, since the default `sync_local_env_from_example.py` prefix allowlist doesn't cover new `COLA_*` keys) — confirmed `git check-ignore` still holds, nothing tracked.
+- No skipped keys requiring operator action beyond flipping `COLA_UNDERSTAND_ENABLE=true` once `orion-llama-cola-host` is confirmed running and reachable.
+
+## Tests run
+
+```text
+services/orion-spark-introspector: 61 passed, 1 skipped (pytest tests/ -q)
+services/orion-llama-cola-host:     4 passed (pytest tests/ -q)
+repo-root tests/test_spark_metrics_v2.py, test_spark_contract_gate.py:
+  4 passed, 3 pre-existing failures (confirmed via git stash to reproduce
+  identically on this branch's parent commit -- unrelated to this change,
+  a stale-shape issue in orion/spark/orion_tissue.py's snapshot loading)
+```
+
+Run in an isolated venv since this sandbox had no dependencies preinstalled; installed each service's own `requirements.txt` plus CPU-only `torch`/`transformers==4.44.2` to genuinely execute `intention.py`'s patched model code with a tiny randomly-initialized CoLA-shaped model, rather than only AST-parsing it.
+
+## Evals run
+
+No eval harness exists for either touched service. Flagging as a gap: there's no automated check that the CoLA IDM branch's distribution is semantically meaningful (i.e. that paraphrases cluster and unrelated turns diverge) against the real 10B checkpoint — this environment has no GPU/model weights to run that against. Follow-up recommended before fully trusting this signal in metacognition (see Risks below).
+
+## Docker/build/smoke checks
+
+```text
+docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml config   -> validates, new COLA_* keys pass through via env_file
+docker compose --env-file .env --env-file services/orion-llama-cola-host/.env \
+  -f services/orion-llama-cola-host/docker-compose.yml config      -> validates, confirms host binds :8005
+```
+
+No live container smoke: `orion-llama-cola-host` is not part of default deploy tooling (excluded from `mesh-utilities` auto-rebuild lists) and wasn't brought up in this environment. `COLA_UNDERSTAND_ENABLE=false` by default specifically so this ships without requiring that host to be live.
+
+## Review findings fixed
+
+- Finding: fail-open contract gap — dimension mismatch (cola-host redeployed with different `num_code`) would raise uncaught inside the fire-and-forget scoring task instead of the documented "logged and skipped" behavior.
+  - Fix: explicit shape check resets the stale per-session reference before scoring; broader try/except as backstop.
+  - Evidence: new test `test_score_cola_novelty_fails_open_on_dimension_mismatch`.
+- Finding: fire-and-forget `asyncio.create_task` result wasn't retained, exposed to asyncio's weak-reference GC risk.
+  - Fix: task stored in a module-level set with a done-callback to discard.
+  - Evidence: new test `test_handle_semantic_upsert_schedules_cola_novelty_scoring` awaits from that set directly.
+- Finding: session eviction was insertion-order FIFO, not LRU — an idle new session could starve out an actively-used older one.
+  - Fix: switched to `OrderedDict` + `move_to_end` on every touch.
+  - Evidence: new test `test_novelty_remember_evicts_least_recently_used_session`.
+- Finding: `signal_type="recall"` gets embedded verbatim into `OrionSignalV1.summary` by `orion/signals/adapters/spark.py` for downstream consumers — a real semantic mislabel once enabled, not cosmetic.
+  - Fix: added `signal_type="language"` to the schema instead.
+  - Evidence: `test_publish_cola_novelty_signal_reaches_phi_stats_via_signal_bus` asserts `env.payload["signal_type"] == "language"`.
+- Finding: new `httpx.AsyncClient()` opened per chat turn instead of pooled, on a hot path.
+  - Fix: single lazily-initialized module-level client.
+- Finding: signal-envelope publish logic duplicated between the new novelty path and the existing turn-effect-alert path.
+  - Fix: extracted `_publish_spark_signal()`, both call sites now share it.
+- Finding: no test exercised the actual `handle_semantic_upsert` wiring (only the helper functions in isolation).
+  - Fix: added `test_handle_semantic_upsert_schedules_cola_novelty_scoring` / `..._skips_..._when_disabled`.
+- Not fixed (documented limitation): no live smoke against the real loaded 10B CoLA model proving the IDM branch's distribution is semantically non-degenerate — no GPU/model weights available in this environment. See Risks.
+
+## Restart required
+
+```bash
+# Only needed once COLA_UNDERSTAND_ENABLE is flipped to true:
+docker compose -f services/orion-spark-introspector/docker-compose.yml restart
+# orion-llama-cola-host would also need to actually be brought up and reachable
+# at COLA_UNDERSTAND_URL (currently not part of default deploy tooling).
+```
+
+If left at the shipped default (`COLA_UNDERSTAND_ENABLE=false`), no restart is required — behavior is unchanged until explicitly enabled.
+
+## Risks / concerns
+
+- Severity: Medium
+  - Concern: The CoLA model card's claim that its 64-code action distribution represents "distinct semantic meanings of language" is the paper authors' own framing, checked against their own benchmark — not independently validated against Orion's data. Enabling this feeds an unvalidated signal into metacognitive context.
+  - Mitigation: ships disabled by default. Recommend a cheap validation pass (paraphrase pairs vs. unrelated pairs through `/v1/understand`, checking the pooled distributions actually cluster paraphrases together) before flipping `COLA_UNDERSTAND_ENABLE=true` in production.
+- Severity: Low
+  - Concern: `orion-llama-cola-host` is excluded from `mesh-utilities` auto-rebuild tooling and not part of default deploy compose sets; bringing it up for the first time in months may surface the model-loading issues already documented in its own README (shard/index mismatch).
+  - Mitigation: documented in that README; the feature fails open regardless if the host can't load.
+- Severity: Low (operational note, not a code risk)
+  - Concern: running `docker compose ... config` against the real `.env` during this work printed a live-looking `HF_TOKEN` value in plaintext into the agent session transcript.
+  - Mitigation: none applied in this PR (out of scope) — flagging so the operator can decide whether to rotate it.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/cola-novelty-signal

--- a/orion/schemas/telemetry/spark_signal.py
+++ b/orion/schemas/telemetry/spark_signal.py
@@ -13,7 +13,9 @@ class SparkSignalV1(BaseModel):
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-    signal_type: Literal["equilibrium", "recall", "routing", "resource", "human", "vision", "collapse"]
+    signal_type: Literal[
+        "equilibrium", "recall", "routing", "resource", "human", "vision", "collapse", "language"
+    ]
     intensity: float = Field(0.0, ge=0.0, le=1.0)
     valence_delta: Optional[float] = None
     arousal_delta: Optional[float] = None

--- a/services/orion-llama-cola-host/README.md
+++ b/services/orion-llama-cola-host/README.md
@@ -75,6 +75,35 @@ Returns an OpenAI-style chat completion plus `action_indices` (latent actions):
 
 Generates embeddings by running a short generation and extracting action indices.
 
+### `POST /v1/understand`
+
+Deterministic "understanding" signal for a finished piece of text — no generation, no sampling.
+
+```json
+{ "text": "...", "doc_id": "optional-correlation-id" }
+```
+
+Runs a single forward pass through CoLA's Inverse Dynamics branch (`bc_mode=True`), which derives a
+latent action from an already-written sentence rather than sampling one to drive generation. Returns
+the pre-argmax softmax distribution over the action codebook, mean-pooled across tokens:
+
+```json
+{
+  "doc_id": "optional-correlation-id",
+  "embedding": [0.01, 0.22, ...],
+  "embedding_dim": 64,
+  "embedding_kind": "cola_action_distribution",
+  "embedding_model": "llama3-1-cola",
+  "token_count": 12
+}
+```
+
+This is deliberately different from `action_indices` on `/v1/chat/completions`, which is sampled at
+`tau=2.0` during generation for output diversity/novelty — sampled, non-deterministic, and only a
+collapsed argmax index. `/v1/understand` is for callers that need a stable, repeatable signal for the
+*meaning* of finished text (e.g. `orion-spark-introspector`'s novelty scoring — see its README §6.8),
+not for steering generation.
+
 ### `GET /health`
 
 Returns `{ "status": "ok" }` once the model is loaded.

--- a/services/orion-llama-cola-host/app/main.py
+++ b/services/orion-llama-cola-host/app/main.py
@@ -297,6 +297,20 @@ class EmbeddingRequest(BaseModel):
     input: Union[str, List[str]]
     model: Optional[str] = None
 
+
+class UnderstandRequest(BaseModel):
+    text: str
+    doc_id: Optional[str] = None
+
+
+class UnderstandResponse(BaseModel):
+    doc_id: Optional[str] = None
+    embedding: List[float]
+    embedding_dim: int
+    embedding_kind: str = "cola_action_distribution"
+    embedding_model: str
+    token_count: int
+
 # ----------------------------------------------------------------------
 # Endpoints
 # ----------------------------------------------------------------------
@@ -380,6 +394,46 @@ def create_embeddings(request: EmbeddingRequest):
         data.append({"object": "embedding", "embedding": embedding, "index": idx})
 
     return {"object": "list", "data": data, "model": request.model or "llama-cola"}
+
+
+@app.post("/v1/understand", response_model=UnderstandResponse)
+def understand(request: UnderstandRequest):
+    """Deterministic 'understanding' signal for a finished piece of text.
+
+    Runs a single non-autoregressive forward pass through the CoLA Inverse
+    Dynamics branch (bc_mode=True), which derives a latent action from an
+    already-written sentence rather than sampling one to drive generation.
+    Unlike /v1/chat/completions' action_indices (sampled at tau=2.0 during
+    generation, for novelty/diversity), this is deterministic and pools the
+    pre-argmax softmax distribution over the action codebook, not a single
+    collapsed index.
+    """
+    if not state.llm or not state.tokenizer or not state.device:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    text = (request.text or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="Missing text")
+
+    inputs = state.tokenizer(text, return_tensors="pt").to(state.device)
+    with torch.no_grad():
+        _policy_logits, _action_idx, action_probs = state.llm(
+            input_ids=inputs["input_ids"],
+            attention_mask=inputs.get("attention_mask"),
+            use_cache=False,
+            bc_mode=True,
+        )
+
+    pooled = action_probs[0].mean(dim=0).float().cpu()
+
+    return UnderstandResponse(
+        doc_id=request.doc_id,
+        embedding=pooled.tolist(),
+        embedding_dim=int(pooled.shape[-1]),
+        embedding_model=settings.llm_profile_name,
+        token_count=int(inputs["input_ids"].shape[-1]),
+    )
+
 
 @app.get("/health")
 def health():

--- a/services/orion-llama-cola-host/intention.py
+++ b/services/orion-llama-cola-host/intention.py
@@ -1423,7 +1423,10 @@ class IntentionModel_v1(LlamaPreTrainedModel):
             hidden_states_action_probs = hidden_states_action_probs_.detach().clone()
             # hidden_states_action_probs[:, :-1] = hidden_states_action_probs[:, 1:].clone()
             action_idx = hidden_states_action_probs.argmax(dim=-1)
-            return hidden_states_policy_logits, action_idx
+            # hidden_states_action_probs is the pre-argmax softmax distribution over the
+            # num_code action codebook (IDM/"understanding" branch); callers that want a
+            # deterministic, calibrated signal (not just the collapsed argmax) need this.
+            return hidden_states_policy_logits, action_idx, hidden_states_action_probs
         if act_mode:
             return hidden_states_policy_logits / self.tau
         if vq_mode:

--- a/services/orion-llama-cola-host/tests/conftest.py
+++ b/services/orion-llama-cola-host/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+SERVICE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+if SERVICE_DIR not in sys.path:
+    sys.path.insert(0, SERVICE_DIR)
+
+os.environ.setdefault("LLM_PROFILE_NAME", "test-profile")

--- a/services/orion-llama-cola-host/tests/test_bc_mode_understand.py
+++ b/services/orion-llama-cola-host/tests/test_bc_mode_understand.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from transformers import LlamaConfig
+
+from intention import IntentionForCausalLM
+
+
+def _tiny_config() -> LlamaConfig:
+    config = LlamaConfig(
+        vocab_size=37,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        max_position_embeddings=32,
+        pad_token_id=0,
+    )
+    # CoLA-specific fields required by IntentionModel_v1.__init__.
+    config.v = 1
+    config.num_code = 5
+    config.num_action_layer = 1
+    config.num_policy_layer = 1
+    config.num_dyna_layer = 1
+    return config
+
+
+def _tiny_model() -> IntentionForCausalLM:
+    torch.manual_seed(0)
+    model = IntentionForCausalLM(_tiny_config())
+    model.eval()
+    return model
+
+
+def test_bc_mode_returns_three_tensors_with_valid_distribution():
+    model = _tiny_model()
+    input_ids = torch.randint(low=1, high=37, size=(1, 6))
+    attention_mask = torch.ones_like(input_ids)
+
+    with torch.no_grad():
+        policy_logits, action_idx, action_probs = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+            bc_mode=True,
+        )
+
+    assert action_probs.shape == (1, 6, 5)
+    assert action_idx.shape == (1, 6)
+    assert policy_logits.shape == (1, 6, 5)
+
+    # A real softmax distribution over the 5-code action codebook.
+    row_sums = action_probs.sum(dim=-1)
+    assert torch.allclose(row_sums, torch.ones_like(row_sums), atol=1e-5)
+    assert torch.all(action_probs >= 0.0)
+
+
+def test_bc_mode_is_deterministic_across_repeated_calls():
+    model = _tiny_model()
+    input_ids = torch.randint(low=1, high=37, size=(1, 6))
+    attention_mask = torch.ones_like(input_ids)
+
+    with torch.no_grad():
+        _, _, probs_1 = model(
+            input_ids=input_ids, attention_mask=attention_mask, use_cache=False, bc_mode=True
+        )
+        _, _, probs_2 = model(
+            input_ids=input_ids, attention_mask=attention_mask, use_cache=False, bc_mode=True
+        )
+
+    # Unlike the stochastic policy-sampling path (tau=2.0 top-k sampling), the
+    # bc_mode/IDM branch has no sampling in it -- same input must give the same
+    # distribution every time.
+    assert torch.allclose(probs_1, probs_2)
+
+
+class _FakeBatch(dict):
+    def to(self, _device):
+        return self
+
+
+class _FakeTokenizer:
+    def __call__(self, text, return_tensors="pt"):
+        ids = [((abs(hash(w)) % 36) + 1) for w in text.split()] or [1]
+        input_ids = torch.tensor([ids], dtype=torch.long)
+        return _FakeBatch(input_ids=input_ids, attention_mask=torch.ones_like(input_ids))
+
+
+def test_understand_endpoint_pools_distribution_over_tokens(monkeypatch):
+    from app import main as app_main
+
+    model = _tiny_model()
+    monkeypatch.setattr(app_main.state, "llm", model)
+    monkeypatch.setattr(app_main.state, "tokenizer", _FakeTokenizer())
+    monkeypatch.setattr(app_main.state, "device", torch.device("cpu"))
+
+    response = app_main.understand(app_main.UnderstandRequest(text="hello there world", doc_id="turn-1"))
+
+    assert response.doc_id == "turn-1"
+    assert response.embedding_dim == 5
+    assert len(response.embedding) == 5
+    assert response.token_count == 3
+    # Pooled mean of per-token softmax rows is itself ~a distribution.
+    assert sum(response.embedding) == pytest.approx(1.0, abs=1e-4)
+
+
+def test_understand_endpoint_rejects_empty_text(monkeypatch):
+    from fastapi import HTTPException
+    from app import main as app_main
+
+    model = _tiny_model()
+    monkeypatch.setattr(app_main.state, "llm", model)
+    monkeypatch.setattr(app_main.state, "tokenizer", _FakeTokenizer())
+    monkeypatch.setattr(app_main.state, "device", torch.device("cpu"))
+
+    try:
+        app_main.understand(app_main.UnderstandRequest(text="   "))
+        assert False, "expected HTTPException"
+    except HTTPException as exc:
+        assert exc.status_code == 400

--- a/services/orion-spark-introspector/.env_example
+++ b/services/orion-spark-introspector/.env_example
@@ -65,6 +65,17 @@ VALENCE_GAIN=1.75
 VALENCE_ANCHOR_REFRESH_SEC=21600
 VALENCE_ANCHOR_TIMEOUT_SEC=10
 
+# --- CoLA-derived novelty signal (Inverse Dynamics branch of orion-llama-cola-host) ---
+# Off by default: orion-llama-cola-host is not part of default deploy tooling yet.
+# Flip on only once the host is confirmed running and reachable at COLA_UNDERSTAND_URL.
+COLA_UNDERSTAND_ENABLE=false
+COLA_UNDERSTAND_URL=http://orion-llama-cola-host:8005
+COLA_UNDERSTAND_TIMEOUT_SEC=8
+COLA_NOVELTY_WINDOW=8
+COLA_NOVELTY_MAX_SESSIONS=500
+COLA_NOVELTY_GAIN=0.35
+COLA_NOVELTY_SIGNAL_TTL_MS=20000
+
 # Real-time snapshot stream (state-service + UI can subscribe)
 CHANNEL_SPARK_STATE_SNAPSHOT=orion:spark:state:snapshot
 

--- a/services/orion-spark-introspector/README.md
+++ b/services/orion-spark-introspector/README.md
@@ -517,6 +517,60 @@ Checklist:
 
 ---
 
+### 6.8 CoLA-Derived Novelty Signal
+
+Separate from the semantic-embedding valence path above, `handle_semantic_upsert` can also score
+**novelty** for each chat turn using `orion-llama-cola-host`'s CoLA Inverse Dynamics branch instead of
+a generic text embedding. Where valence asks "does this feel good or bad" via a fixed anchor pair,
+this asks "how different is this turn's latent action distribution from what this session has been
+producing" — a per-session, distribution-based novelty score, not a fixed-anchor one.
+
+**How it works:**
+
+1. `orion-llama-cola-host` exposes `POST /v1/understand`, which runs one deterministic (non-sampled)
+   forward pass through CoLA's `bc_mode` branch and returns a pooled probability distribution over its
+   latent action codebook for a given piece of text. Unlike `/v1/chat/completions`' `action_indices`
+   (sampled at `tau=2.0` during generation, meant for output diversity), this is deterministic — same
+   text always gives the same distribution.
+2. `orion-spark-introspector` calls that endpoint directly (bypassing `orion-llm-gateway`'s shared
+   routing table on purpose — this signal doesn't need to compete with chat/agent/metacog routing).
+3. Novelty is scored as cosine distance between the new turn's distribution and the mean of the last
+   `COLA_NOVELTY_WINDOW` turns for that session (a rolling reference, not a fixed anchor).
+4. The result is published as a `SparkSignalV1.novelty_delta` on `CHANNEL_SPARK_SIGNAL` — the same
+   signal bus `handle_signal`/`_register_signal`/`_apply_signal_deltas` already use for the
+   `turn_effect_alerts` "human" signals. It gets folded into `phi_stats["novelty"]` the next time
+   `handle_trace` or `handle_self_state` publishes a `SparkStateSnapshotV1`, which is what
+   `orion-cortex-exec` actually reads for its metacognitive context.
+
+This intentionally does **not** touch `SignalMapper`/`OrionTissue`/`SurfaceEncoding` (the `spark_vector`
+neural-projection path is a separate, currently-dead code path — see the data-flow notes above) and
+does **not** write anything to `orion-vector-host`'s Chroma collections. `orion-vector-host` deliberately
+rejects raw latent vectors (`include_latent=True` is forced back to `False` there, guarded by
+`scripts/smoke_no_latent_leak.py`) to keep its semantic-recall collections uncorrupted — the CoLA
+distribution never goes anywhere near that store.
+
+**Settings:**
+
+| Setting                        | Env var                        | Default                                |
+| ------------------------------- | ------------------------------- | --------------------------------------- |
+| `cola_understand_enable`       | `COLA_UNDERSTAND_ENABLE`       | `false` (opt-in; see rollout note below) |
+| `cola_understand_url`          | `COLA_UNDERSTAND_URL`          | `http://orion-llama-cola-host:8005`     |
+| `cola_understand_timeout_sec`  | `COLA_UNDERSTAND_TIMEOUT_SEC`  | `8`                                      |
+| `cola_novelty_window`          | `COLA_NOVELTY_WINDOW`          | `8` (per-session rolling reference size) |
+| `cola_novelty_max_sessions`    | `COLA_NOVELTY_MAX_SESSIONS`    | `500` (bounded LRU-ish session cap)      |
+| `cola_novelty_gain`            | `COLA_NOVELTY_GAIN`            | `0.35`                                   |
+| `cola_novelty_signal_ttl_ms`   | `COLA_NOVELTY_SIGNAL_TTL_MS`   | `20000`                                  |
+
+**Rollout / rollback:** ships disabled (`COLA_UNDERSTAND_ENABLE=false`). `orion-llama-cola-host` is not
+in default deploy tooling and is excluded from `mesh-utilities`' auto-rebuild lists, so leaving this off
+is the safe default until the host is confirmed running and reachable. Failure mode is fail-open by
+design: any HTTP error, timeout, or disabled flag simply skips publishing a signal, and
+`phi_stats["novelty"]` falls back to its existing self-state-derived baseline (`_phi_from_self_state`)
+untouched. To roll back, set `COLA_UNDERSTAND_ENABLE=false` — no other state needs cleanup, the rolling
+per-session history is in-memory only.
+
+---
+
 ## 7. Roadmap & Open Questions
 
 Planned directions for Spark:

--- a/services/orion-spark-introspector/app/settings.py
+++ b/services/orion-spark-introspector/app/settings.py
@@ -110,6 +110,21 @@ class Settings(BaseSettings):
     # Freshness semantics (for read-model)
     spark_state_valid_for_ms: int = Field(15000, alias="SPARK_STATE_VALID_FOR_MS")
 
+    # CoLA-derived novelty signal (Inverse Dynamics branch of orion-llama-cola-host).
+    # Off by default: the host isn't in default deploy tooling yet, and calling an
+    # unreachable/absent host per turn would just add log noise. Flip on once the
+    # host is confirmed running and reachable.
+    cola_understand_enable: bool = Field(False, alias="COLA_UNDERSTAND_ENABLE")
+    cola_understand_url: str = Field(
+        "http://orion-llama-cola-host:8005",
+        alias="COLA_UNDERSTAND_URL",
+    )
+    cola_understand_timeout_sec: float = Field(8.0, alias="COLA_UNDERSTAND_TIMEOUT_SEC")
+    cola_novelty_window: int = Field(8, alias="COLA_NOVELTY_WINDOW")
+    cola_novelty_max_sessions: int = Field(500, alias="COLA_NOVELTY_MAX_SESSIONS")
+    cola_novelty_gain: float = Field(0.35, alias="COLA_NOVELTY_GAIN")
+    cola_novelty_signal_ttl_ms: int = Field(20000, alias="COLA_NOVELTY_SIGNAL_TTL_MS")
+
     # Tissue
     orion_tissue_snapshot_path: str = Field(
         "/mnt/graphdb/orion/spark/tissue-brain.npy",

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Deque, Dict, List, Optional
 from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
 
+import httpx
 import numpy as np
 from pydantic import BaseModel, Field, ValidationError
 
@@ -407,6 +409,105 @@ def _valence_from_embedding(emb: np.ndarray) -> float:
     if v < -1.0:
         return -1.0
     return v
+
+
+# ---------------------------------------------------------------------------
+# CoLA-derived novelty signal
+#
+# orion-llama-cola-host's /v1/understand runs a deterministic forward pass
+# through the CoLA Inverse Dynamics branch and returns a pooled probability
+# distribution over its latent action codebook for a piece of finished text.
+# We score novelty as distance from a rolling per-session reference of recent
+# turns' distributions (same cosine-distance style already used for valence)
+# and publish it as a SparkSignalV1.novelty_delta over the existing signal bus
+# -- the same live wire orion-cortex-exec already reads for metacognition.
+#
+# Fails open: any error (host down, timeout, bad response) is logged and
+# skipped. No signal is registered, so _apply_signal_deltas leaves the
+# self-state-derived novelty baseline untouched.
+# ---------------------------------------------------------------------------
+
+_COLA_NOVELTY_HISTORY: Dict[str, Deque[np.ndarray]] = {}
+_COLA_NOVELTY_HISTORY_ORDER: Deque[str] = deque()
+
+
+def _cola_novelty_reference(session_key: str) -> Optional[np.ndarray]:
+    history = _COLA_NOVELTY_HISTORY.get(session_key)
+    if not history:
+        return None
+    return np.mean(np.stack(list(history)), axis=0)
+
+
+def _cola_novelty_remember(session_key: str, distribution: np.ndarray) -> None:
+    history = _COLA_NOVELTY_HISTORY.get(session_key)
+    if history is None:
+        if len(_COLA_NOVELTY_HISTORY) >= max(1, int(settings.cola_novelty_max_sessions)):
+            oldest = _COLA_NOVELTY_HISTORY_ORDER.popleft()
+            _COLA_NOVELTY_HISTORY.pop(oldest, None)
+        history = deque(maxlen=max(1, int(settings.cola_novelty_window)))
+        _COLA_NOVELTY_HISTORY[session_key] = history
+        _COLA_NOVELTY_HISTORY_ORDER.append(session_key)
+    history.append(distribution)
+
+
+async def _fetch_cola_understanding(text: str, *, doc_id: str) -> Optional[np.ndarray]:
+    if not settings.cola_understand_enable:
+        return None
+    url = settings.cola_understand_url.rstrip("/") + "/v1/understand"
+    try:
+        async with httpx.AsyncClient(timeout=float(settings.cola_understand_timeout_sec)) as client:
+            resp = await client.post(url, json={"text": text, "doc_id": doc_id})
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as exc:
+        logger.warning("CoLA understand request failed doc_id=%s error=%s", doc_id, exc)
+        return None
+
+    embedding = data.get("embedding")
+    if not isinstance(embedding, list) or not embedding:
+        return None
+    return np.array(embedding, dtype=np.float32)
+
+
+async def _publish_cola_novelty_signal(distance: float, *, correlation_id: Any) -> None:
+    if not (_pub_bus and _pub_bus.enabled):
+        return
+    delta = float(settings.cola_novelty_gain) * distance
+    signal = SparkSignalV1(
+        # Closest existing signal_type to a language/meaning-derived signal;
+        # SparkSignalV1 has no dedicated "semantic" or "cola" literal.
+        signal_type="recall",
+        intensity=max(0.0, min(1.0, distance)),
+        novelty_delta=delta,
+        as_of_ts=datetime.now(timezone.utc),
+        ttl_ms=int(settings.cola_novelty_signal_ttl_ms),
+        source_service=settings.service_name,
+        source_node=settings.node_name,
+    )
+    signal_env = BaseEnvelope(
+        kind="spark.signal.v1",
+        source=_svc_ref(),
+        correlation_id=correlation_id,
+        payload=signal.model_dump(mode="json"),
+    )
+    await _pub_bus.publish(settings.channel_spark_signal, signal_env)
+
+
+async def _score_cola_novelty(*, text: str, doc_id: str, session_key: str, correlation_id: Any) -> None:
+    if not settings.cola_understand_enable or not text.strip():
+        return
+    distribution = await _fetch_cola_understanding(text, doc_id=doc_id)
+    if distribution is None:
+        return
+
+    reference = _cola_novelty_reference(session_key)
+    distance = 1.0 if reference is None else _cosine_distance(distribution, reference)
+    _cola_novelty_remember(session_key, distribution)
+
+    try:
+        await _publish_cola_novelty_signal(distance, correlation_id=correlation_id)
+    except Exception as exc:
+        logger.warning("Failed to publish CoLA novelty signal doc_id=%s error=%s", doc_id, exc)
 
 
 def _extract_introspection_text(cortex_reply: BaseEnvelope) -> Optional[str]:
@@ -1449,6 +1550,17 @@ async def handle_semantic_upsert(env: BaseEnvelope) -> None:
         v_semantic,
         tissue_valence,
     )
+
+    if settings.cola_understand_enable and (upsert.text or "").strip():
+        session_key = str(upsert.meta.get("session_id") or upsert.doc_id)
+        asyncio.create_task(
+            _score_cola_novelty(
+                text=upsert.text,
+                doc_id=upsert.doc_id,
+                session_key=session_key,
+                correlation_id=env.correlation_id,
+            )
+        )
 
 
 def _get_intro_sem() -> asyncio.Semaphore:

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections import deque
+from collections import OrderedDict, deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Deque, Dict, List, Optional
@@ -427,8 +427,8 @@ def _valence_from_embedding(emb: np.ndarray) -> float:
 # self-state-derived novelty baseline untouched.
 # ---------------------------------------------------------------------------
 
-_COLA_NOVELTY_HISTORY: Dict[str, Deque[np.ndarray]] = {}
-_COLA_NOVELTY_HISTORY_ORDER: Deque[str] = deque()
+_COLA_NOVELTY_HISTORY: "OrderedDict[str, Deque[np.ndarray]]" = OrderedDict()
+_COLA_NOVELTY_TASKS: set = set()
 
 
 def _cola_novelty_reference(session_key: str) -> Optional[np.ndarray]:
@@ -440,14 +440,30 @@ def _cola_novelty_reference(session_key: str) -> Optional[np.ndarray]:
 
 def _cola_novelty_remember(session_key: str, distribution: np.ndarray) -> None:
     history = _COLA_NOVELTY_HISTORY.get(session_key)
+    if history is not None and history and history[-1].shape != distribution.shape:
+        # Codebook dimension changed underneath us (e.g. cola-host redeployed
+        # with a different num_code); stale history would break np.stack, so
+        # start this session's reference over instead of crashing.
+        history.clear()
     if history is None:
         if len(_COLA_NOVELTY_HISTORY) >= max(1, int(settings.cola_novelty_max_sessions)):
-            oldest = _COLA_NOVELTY_HISTORY_ORDER.popleft()
-            _COLA_NOVELTY_HISTORY.pop(oldest, None)
+            _COLA_NOVELTY_HISTORY.popitem(last=False)
         history = deque(maxlen=max(1, int(settings.cola_novelty_window)))
         _COLA_NOVELTY_HISTORY[session_key] = history
-        _COLA_NOVELTY_HISTORY_ORDER.append(session_key)
     history.append(distribution)
+    # Touching a session (new or existing) marks it most-recently-used so
+    # eviction above drops the least-active session, not just the oldest one.
+    _COLA_NOVELTY_HISTORY.move_to_end(session_key)
+
+
+_COLA_HTTP_CLIENT: Optional[httpx.AsyncClient] = None
+
+
+def _cola_http_client() -> httpx.AsyncClient:
+    global _COLA_HTTP_CLIENT
+    if _COLA_HTTP_CLIENT is None or _COLA_HTTP_CLIENT.is_closed:
+        _COLA_HTTP_CLIENT = httpx.AsyncClient(timeout=float(settings.cola_understand_timeout_sec))
+    return _COLA_HTTP_CLIENT
 
 
 async def _fetch_cola_understanding(text: str, *, doc_id: str) -> Optional[np.ndarray]:
@@ -455,10 +471,10 @@ async def _fetch_cola_understanding(text: str, *, doc_id: str) -> Optional[np.nd
         return None
     url = settings.cola_understand_url.rstrip("/") + "/v1/understand"
     try:
-        async with httpx.AsyncClient(timeout=float(settings.cola_understand_timeout_sec)) as client:
-            resp = await client.post(url, json={"text": text, "doc_id": doc_id})
-            resp.raise_for_status()
-            data = resp.json()
+        client = _cola_http_client()
+        resp = await client.post(url, json={"text": text, "doc_id": doc_id})
+        resp.raise_for_status()
+        data = resp.json()
     except Exception as exc:
         logger.warning("CoLA understand request failed doc_id=%s error=%s", doc_id, exc)
         return None
@@ -469,21 +485,9 @@ async def _fetch_cola_understanding(text: str, *, doc_id: str) -> Optional[np.nd
     return np.array(embedding, dtype=np.float32)
 
 
-async def _publish_cola_novelty_signal(distance: float, *, correlation_id: Any) -> None:
+async def _publish_spark_signal(signal: SparkSignalV1, *, correlation_id: Any) -> None:
     if not (_pub_bus and _pub_bus.enabled):
         return
-    delta = float(settings.cola_novelty_gain) * distance
-    signal = SparkSignalV1(
-        # Closest existing signal_type to a language/meaning-derived signal;
-        # SparkSignalV1 has no dedicated "semantic" or "cola" literal.
-        signal_type="recall",
-        intensity=max(0.0, min(1.0, distance)),
-        novelty_delta=delta,
-        as_of_ts=datetime.now(timezone.utc),
-        ttl_ms=int(settings.cola_novelty_signal_ttl_ms),
-        source_service=settings.service_name,
-        source_node=settings.node_name,
-    )
     signal_env = BaseEnvelope(
         kind="spark.signal.v1",
         source=_svc_ref(),
@@ -493,6 +497,20 @@ async def _publish_cola_novelty_signal(distance: float, *, correlation_id: Any) 
     await _pub_bus.publish(settings.channel_spark_signal, signal_env)
 
 
+async def _publish_cola_novelty_signal(distance: float, *, correlation_id: Any) -> None:
+    delta = float(settings.cola_novelty_gain) * distance
+    signal = SparkSignalV1(
+        signal_type="language",
+        intensity=max(0.0, min(1.0, distance)),
+        novelty_delta=delta,
+        as_of_ts=datetime.now(timezone.utc),
+        ttl_ms=int(settings.cola_novelty_signal_ttl_ms),
+        source_service=settings.service_name,
+        source_node=settings.node_name,
+    )
+    await _publish_spark_signal(signal, correlation_id=correlation_id)
+
+
 async def _score_cola_novelty(*, text: str, doc_id: str, session_key: str, correlation_id: Any) -> None:
     if not settings.cola_understand_enable or not text.strip():
         return
@@ -500,9 +518,19 @@ async def _score_cola_novelty(*, text: str, doc_id: str, session_key: str, corre
     if distribution is None:
         return
 
-    reference = _cola_novelty_reference(session_key)
-    distance = 1.0 if reference is None else _cosine_distance(distribution, reference)
-    _cola_novelty_remember(session_key, distribution)
+    try:
+        reference = _cola_novelty_reference(session_key)
+        if reference is not None and reference.shape != distribution.shape:
+            # Codebook dimension changed underneath us (e.g. cola-host redeployed
+            # with a different num_code); drop the stale reference and restart
+            # this session's history instead of crashing on np.dot.
+            _COLA_NOVELTY_HISTORY.pop(session_key, None)
+            reference = None
+        distance = 1.0 if reference is None else _cosine_distance(distribution, reference)
+        _cola_novelty_remember(session_key, distribution)
+    except Exception as exc:
+        logger.warning("CoLA novelty scoring failed doc_id=%s error=%s", doc_id, exc)
+        return
 
     try:
         await _publish_cola_novelty_signal(distance, correlation_id=correlation_id)
@@ -931,13 +959,7 @@ async def _emit_candidate_telemetry(env: BaseEnvelope, candidate: SparkCandidate
                         source_service=settings.service_name,
                         source_node=settings.node_name,
                     )
-                    signal_env = BaseEnvelope(
-                        kind="spark.signal.v1",
-                        source=_svc_ref(),
-                        correlation_id=trace_id,
-                        payload=signal.model_dump(mode="json"),
-                    )
-                    await _pub_bus.publish(settings.channel_spark_signal, signal_env)
+                    await _publish_spark_signal(signal, correlation_id=trace_id)
                     if settings.turn_effect_alerts_notify_enable:
                         notify = CoreEventV1(
                             event="notify",
@@ -1553,7 +1575,7 @@ async def handle_semantic_upsert(env: BaseEnvelope) -> None:
 
     if settings.cola_understand_enable and (upsert.text or "").strip():
         session_key = str(upsert.meta.get("session_id") or upsert.doc_id)
-        asyncio.create_task(
+        task = asyncio.create_task(
             _score_cola_novelty(
                 text=upsert.text,
                 doc_id=upsert.doc_id,
@@ -1561,6 +1583,8 @@ async def handle_semantic_upsert(env: BaseEnvelope) -> None:
                 correlation_id=env.correlation_id,
             )
         )
+        _COLA_NOVELTY_TASKS.add(task)
+        task.add_done_callback(_COLA_NOVELTY_TASKS.discard)
 
 
 def _get_intro_sem() -> asyncio.Semaphore:

--- a/services/orion-spark-introspector/tests/test_cola_novelty_signal.py
+++ b/services/orion-spark-introspector/tests/test_cola_novelty_signal.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from app import worker
+from app.settings import settings
+from orion.core.bus.bus_schemas import BaseEnvelope
+
+
+def setup_function(_fn) -> None:
+    worker._COLA_NOVELTY_HISTORY.clear()
+    worker._COLA_NOVELTY_HISTORY_ORDER.clear()
+    worker._ACTIVE_SIGNALS.clear()
+
+
+def test_novelty_reference_none_when_no_history() -> None:
+    assert worker._cola_novelty_reference("session-a") is None
+
+
+def test_novelty_remember_bounds_per_session_window(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_novelty_window", 3)
+    for i in range(5):
+        worker._cola_novelty_remember("session-a", np.full(4, float(i), dtype=np.float32))
+    history = worker._COLA_NOVELTY_HISTORY["session-a"]
+    assert len(history) == 3
+    # Oldest entries (0, 1) should have been evicted; only 2, 3, 4 remain.
+    assert [float(v[0]) for v in history] == [2.0, 3.0, 4.0]
+
+
+def test_novelty_remember_bounds_total_session_count(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_novelty_max_sessions", 2)
+    worker._cola_novelty_remember("session-a", np.zeros(4, dtype=np.float32))
+    worker._cola_novelty_remember("session-b", np.zeros(4, dtype=np.float32))
+    worker._cola_novelty_remember("session-c", np.zeros(4, dtype=np.float32))
+    assert len(worker._COLA_NOVELTY_HISTORY) == 2
+    assert "session-a" not in worker._COLA_NOVELTY_HISTORY
+    assert "session-c" in worker._COLA_NOVELTY_HISTORY
+
+
+@pytest.mark.asyncio
+async def test_fetch_cola_understanding_returns_none_when_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_understand_enable", False)
+    with patch("app.worker.httpx.AsyncClient") as mock_client_cls:
+        result = await worker._fetch_cola_understanding("hello", doc_id="d1")
+    assert result is None
+    mock_client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_cola_understanding_fails_open_on_http_error(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_understand_enable", True)
+
+    class _RaisingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, *_args, **_kwargs):
+            raise RuntimeError("host unreachable")
+
+    with patch("app.worker.httpx.AsyncClient", return_value=_RaisingClient()):
+        result = await worker._fetch_cola_understanding("hello", doc_id="d1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_cola_understanding_parses_embedding(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_understand_enable", True)
+
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"embedding": [0.1, 0.2, 0.3], "embedding_dim": 3}
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, *_args, **_kwargs):
+            return _Resp()
+
+    with patch("app.worker.httpx.AsyncClient", return_value=_Client()):
+        result = await worker._fetch_cola_understanding("hello", doc_id="d1")
+    assert result is not None
+    assert result.tolist() == pytest.approx([0.1, 0.2, 0.3])
+
+
+@pytest.mark.asyncio
+async def test_score_cola_novelty_noop_when_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_understand_enable", False)
+    fetch_mock = AsyncMock(return_value=np.array([1.0, 0.0], dtype=np.float32))
+    publish_mock = AsyncMock()
+    with patch("app.worker._fetch_cola_understanding", fetch_mock), patch(
+        "app.worker._publish_cola_novelty_signal", publish_mock
+    ):
+        await worker._score_cola_novelty(
+            text="hello", doc_id="d1", session_key="s1", correlation_id=uuid4()
+        )
+    fetch_mock.assert_not_called()
+    publish_mock.assert_not_called()
+    assert "s1" not in worker._COLA_NOVELTY_HISTORY
+
+
+@pytest.mark.asyncio
+async def test_score_cola_novelty_noop_when_host_unreachable(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_understand_enable", True)
+    fetch_mock = AsyncMock(return_value=None)  # simulates fail-open from _fetch_cola_understanding
+    publish_mock = AsyncMock()
+    with patch("app.worker._fetch_cola_understanding", fetch_mock), patch(
+        "app.worker._publish_cola_novelty_signal", publish_mock
+    ):
+        await worker._score_cola_novelty(
+            text="hello", doc_id="d1", session_key="s1", correlation_id=uuid4()
+        )
+    publish_mock.assert_not_called()
+    assert "s1" not in worker._COLA_NOVELTY_HISTORY
+
+
+@pytest.mark.asyncio
+async def test_score_cola_novelty_first_turn_is_max_novelty(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_understand_enable", True)
+    fetch_mock = AsyncMock(return_value=np.array([1.0, 0.0, 0.0], dtype=np.float32))
+    publish_mock = AsyncMock()
+    with patch("app.worker._fetch_cola_understanding", fetch_mock), patch(
+        "app.worker._publish_cola_novelty_signal", publish_mock
+    ):
+        await worker._score_cola_novelty(
+            text="hello", doc_id="d1", session_key="s1", correlation_id=uuid4()
+        )
+    publish_mock.assert_awaited_once()
+    (distance, ), kwargs = publish_mock.call_args
+    assert distance == pytest.approx(1.0)
+    assert "s1" in worker._COLA_NOVELTY_HISTORY
+
+
+@pytest.mark.asyncio
+async def test_score_cola_novelty_repeated_turn_is_low_novelty(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_understand_enable", True)
+    same_vec = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    fetch_mock = AsyncMock(return_value=same_vec)
+    publish_mock = AsyncMock()
+    with patch("app.worker._fetch_cola_understanding", fetch_mock), patch(
+        "app.worker._publish_cola_novelty_signal", publish_mock
+    ):
+        await worker._score_cola_novelty(
+            text="hello", doc_id="d1", session_key="s1", correlation_id=uuid4()
+        )
+        await worker._score_cola_novelty(
+            text="hello again", doc_id="d2", session_key="s1", correlation_id=uuid4()
+        )
+    assert publish_mock.await_count == 2
+    second_distance = publish_mock.call_args_list[1].args[0]
+    assert second_distance == pytest.approx(0.0, abs=1e-5)
+
+
+@pytest.mark.asyncio
+async def test_publish_cola_novelty_signal_reaches_phi_stats_via_signal_bus() -> None:
+    """End-to-end (in-process) proof that a published novelty signal reaches
+    the same phi_stats merge orion-cortex-exec reads for metacognition,
+    without needing a live bus/model/service stack."""
+    captured: dict = {}
+
+    class _FakeBus:
+        enabled = True
+
+        async def publish(self, channel, envelope):
+            captured["channel"] = channel
+            captured["envelope"] = envelope
+
+    worker._pub_bus = _FakeBus()
+    try:
+        await worker._publish_cola_novelty_signal(0.8, correlation_id=uuid4())
+    finally:
+        worker._pub_bus = None
+
+    assert captured["channel"] == settings.channel_spark_signal
+    env: BaseEnvelope = captured["envelope"]
+
+    baseline = worker._get_phi_stats()
+    adjusted_before = worker._apply_signal_deltas(dict(baseline))
+    assert adjusted_before["novelty"] == pytest.approx(baseline["novelty"])
+
+    await worker.handle_signal(env)
+    adjusted_after = worker._apply_signal_deltas(dict(baseline))
+    expected_delta = float(settings.cola_novelty_gain) * 0.8
+    assert adjusted_after["novelty"] == pytest.approx(baseline["novelty"] + expected_delta)

--- a/services/orion-spark-introspector/tests/test_cola_novelty_signal.py
+++ b/services/orion-spark-introspector/tests/test_cola_novelty_signal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -9,12 +10,12 @@ import pytest
 
 from app import worker
 from app.settings import settings
-from orion.core.bus.bus_schemas import BaseEnvelope
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 
 
 def setup_function(_fn) -> None:
     worker._COLA_NOVELTY_HISTORY.clear()
-    worker._COLA_NOVELTY_HISTORY_ORDER.clear()
+    worker._COLA_NOVELTY_TASKS.clear()
     worker._ACTIVE_SIGNALS.clear()
 
 
@@ -32,40 +33,49 @@ def test_novelty_remember_bounds_per_session_window(monkeypatch) -> None:
     assert [float(v[0]) for v in history] == [2.0, 3.0, 4.0]
 
 
-def test_novelty_remember_bounds_total_session_count(monkeypatch) -> None:
+def test_novelty_remember_evicts_least_recently_used_session(monkeypatch) -> None:
     monkeypatch.setattr(settings, "cola_novelty_max_sessions", 2)
     worker._cola_novelty_remember("session-a", np.zeros(4, dtype=np.float32))
     worker._cola_novelty_remember("session-b", np.zeros(4, dtype=np.float32))
+    # Touch session-a again so it's more recently used than session-b.
+    worker._cola_novelty_remember("session-a", np.ones(4, dtype=np.float32))
     worker._cola_novelty_remember("session-c", np.zeros(4, dtype=np.float32))
+
     assert len(worker._COLA_NOVELTY_HISTORY) == 2
-    assert "session-a" not in worker._COLA_NOVELTY_HISTORY
+    # session-b is least-recently-used (touched once, longest ago) and must
+    # be the one evicted, not session-a which was touched most recently
+    # despite being created first.
+    assert "session-b" not in worker._COLA_NOVELTY_HISTORY
+    assert "session-a" in worker._COLA_NOVELTY_HISTORY
     assert "session-c" in worker._COLA_NOVELTY_HISTORY
+
+
+def test_novelty_remember_resets_history_on_dimension_change() -> None:
+    worker._cola_novelty_remember("session-a", np.zeros(4, dtype=np.float32))
+    worker._cola_novelty_remember("session-a", np.zeros(4, dtype=np.float32))
+    # Simulate a cola-host redeploy with a different num_code: shape changes.
+    worker._cola_novelty_remember("session-a", np.zeros(7, dtype=np.float32))
+    history = worker._COLA_NOVELTY_HISTORY["session-a"]
+    assert len(history) == 1
+    assert history[0].shape == (7,)
 
 
 @pytest.mark.asyncio
 async def test_fetch_cola_understanding_returns_none_when_disabled(monkeypatch) -> None:
     monkeypatch.setattr(settings, "cola_understand_enable", False)
-    with patch("app.worker.httpx.AsyncClient") as mock_client_cls:
+    client_mock = AsyncMock()
+    with patch("app.worker._cola_http_client", return_value=client_mock):
         result = await worker._fetch_cola_understanding("hello", doc_id="d1")
     assert result is None
-    mock_client_cls.assert_not_called()
+    client_mock.post.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_fetch_cola_understanding_fails_open_on_http_error(monkeypatch) -> None:
     monkeypatch.setattr(settings, "cola_understand_enable", True)
-
-    class _RaisingClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *exc):
-            return False
-
-        async def post(self, *_args, **_kwargs):
-            raise RuntimeError("host unreachable")
-
-    with patch("app.worker.httpx.AsyncClient", return_value=_RaisingClient()):
+    client_mock = AsyncMock()
+    client_mock.post.side_effect = RuntimeError("host unreachable")
+    with patch("app.worker._cola_http_client", return_value=client_mock):
         result = await worker._fetch_cola_understanding("hello", doc_id="d1")
     assert result is None
 
@@ -81,17 +91,9 @@ async def test_fetch_cola_understanding_parses_embedding(monkeypatch) -> None:
         def json(self):
             return {"embedding": [0.1, 0.2, 0.3], "embedding_dim": 3}
 
-    class _Client:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *exc):
-            return False
-
-        async def post(self, *_args, **_kwargs):
-            return _Resp()
-
-    with patch("app.worker.httpx.AsyncClient", return_value=_Client()):
+    client_mock = AsyncMock()
+    client_mock.post.return_value = _Resp()
+    with patch("app.worker._cola_http_client", return_value=client_mock):
         result = await worker._fetch_cola_understanding("hello", doc_id="d1")
     assert result is not None
     assert result.tolist() == pytest.approx([0.1, 0.2, 0.3])
@@ -129,6 +131,26 @@ async def test_score_cola_novelty_noop_when_host_unreachable(monkeypatch) -> Non
 
 
 @pytest.mark.asyncio
+async def test_score_cola_novelty_fails_open_on_dimension_mismatch(monkeypatch) -> None:
+    """A stale reference (different shape, e.g. cola-host redeployed with a
+    different num_code) must not raise -- it should reset and still publish."""
+    monkeypatch.setattr(settings, "cola_understand_enable", True)
+    worker._cola_novelty_remember("s1", np.zeros(3, dtype=np.float32))
+
+    fetch_mock = AsyncMock(return_value=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32))
+    publish_mock = AsyncMock()
+    with patch("app.worker._fetch_cola_understanding", fetch_mock), patch(
+        "app.worker._publish_cola_novelty_signal", publish_mock
+    ):
+        await worker._score_cola_novelty(
+            text="hello", doc_id="d1", session_key="s1", correlation_id=uuid4()
+        )
+    publish_mock.assert_awaited_once()
+    distance = publish_mock.call_args.args[0]
+    assert distance == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
 async def test_score_cola_novelty_first_turn_is_max_novelty(monkeypatch) -> None:
     monkeypatch.setattr(settings, "cola_understand_enable", True)
     fetch_mock = AsyncMock(return_value=np.array([1.0, 0.0, 0.0], dtype=np.float32))
@@ -140,7 +162,7 @@ async def test_score_cola_novelty_first_turn_is_max_novelty(monkeypatch) -> None
             text="hello", doc_id="d1", session_key="s1", correlation_id=uuid4()
         )
     publish_mock.assert_awaited_once()
-    (distance, ), kwargs = publish_mock.call_args
+    distance = publish_mock.call_args.args[0]
     assert distance == pytest.approx(1.0)
     assert "s1" in worker._COLA_NOVELTY_HISTORY
 
@@ -187,6 +209,7 @@ async def test_publish_cola_novelty_signal_reaches_phi_stats_via_signal_bus() ->
 
     assert captured["channel"] == settings.channel_spark_signal
     env: BaseEnvelope = captured["envelope"]
+    assert env.payload["signal_type"] == "language"
 
     baseline = worker._get_phi_stats()
     adjusted_before = worker._apply_signal_deltas(dict(baseline))
@@ -196,3 +219,63 @@ async def test_publish_cola_novelty_signal_reaches_phi_stats_via_signal_bus() ->
     adjusted_after = worker._apply_signal_deltas(dict(baseline))
     expected_delta = float(settings.cola_novelty_gain) * 0.8
     assert adjusted_after["novelty"] == pytest.approx(baseline["novelty"] + expected_delta)
+
+
+@pytest.mark.asyncio
+async def test_handle_semantic_upsert_schedules_cola_novelty_scoring(monkeypatch) -> None:
+    """Proves the actual wiring in handle_semantic_upsert -- not just the
+    helper functions in isolation."""
+    monkeypatch.setattr(settings, "cola_understand_enable", True)
+    score_mock = AsyncMock()
+    monkeypatch.setattr(worker, "_score_cola_novelty", score_mock)
+
+    env = BaseEnvelope(
+        kind="vector.upsert.v1",
+        source=ServiceRef(name="orion-vector-host", node="n1"),
+        correlation_id=uuid4(),
+        payload={
+            "doc_id": "turn-123",
+            "collection": "orion_chat_turns",
+            "embedding": [0.1, 0.2, 0.3],
+            "embedding_kind": "semantic",
+            "text": "hello world",
+            "meta": {"session_id": "sess-42"},
+        },
+    )
+
+    await worker.handle_semantic_upsert(env)
+
+    assert len(worker._COLA_NOVELTY_TASKS) == 1
+    await asyncio.gather(*worker._COLA_NOVELTY_TASKS)
+
+    score_mock.assert_awaited_once()
+    kwargs = score_mock.call_args.kwargs
+    assert kwargs["text"] == "hello world"
+    assert kwargs["doc_id"] == "turn-123"
+    assert kwargs["session_key"] == "sess-42"
+
+
+@pytest.mark.asyncio
+async def test_handle_semantic_upsert_skips_cola_scoring_when_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "cola_understand_enable", False)
+    score_mock = AsyncMock()
+    monkeypatch.setattr(worker, "_score_cola_novelty", score_mock)
+
+    env = BaseEnvelope(
+        kind="vector.upsert.v1",
+        source=ServiceRef(name="orion-vector-host", node="n1"),
+        correlation_id=uuid4(),
+        payload={
+            "doc_id": "turn-124",
+            "collection": "orion_chat_turns",
+            "embedding": [0.1, 0.2, 0.3],
+            "embedding_kind": "semantic",
+            "text": "hello world",
+            "meta": {},
+        },
+    )
+
+    await worker.handle_semantic_upsert(env)
+
+    assert len(worker._COLA_NOVELTY_TASKS) == 0
+    score_mock.assert_not_called()


### PR DESCRIPTION
# PR Report: CoLA-Derived Novelty Signal (`feat/cola-novelty-signal`)

## Summary

- Adds `POST /v1/understand` to `orion-llama-cola-host`: a single deterministic forward pass through CoLA's `bc_mode` (Inverse Dynamics) branch, returning the pooled pre-argmax action-codebook distribution for finished text.
- Patches `intention.py`'s `IntentionModel_v1.forward()` `bc_mode` return from a 2-tuple to a 3-tuple to expose that distribution (previously only the collapsed argmax index was returned).
- `orion-spark-introspector` calls the new endpoint directly per chat turn (bypassing `orion-llm-gateway`'s shared routing table on purpose), scores novelty as cosine distance from a bounded, LRU-evicted rolling per-session reference, and publishes it as `SparkSignalV1.novelty_delta` over the existing `orion:spark:signal` bus — the same wire `orion-cortex-exec` already reads for metacognition.
- Adds `signal_type="language"` to `SparkSignalV1` (additive) instead of overloading an existing value that would have mislabeled the signal downstream.
- Ships disabled via `COLA_UNDERSTAND_ENABLE=false` and fails open on any error.

## Outcome moved

`orion-cortex-exec`'s metacognitive context can now receive a novelty signal derived from CoLA's latent-action understanding of what was actually said in a turn, instead of only the self-state-substrate-derived novelty baseline (which reflects biometric/attention pressure, not language content).

## Current architecture

`orion-llama-cola-host` existed but was unreachable from the live chat path (routing table maps `chat`/`agent`/`metacog`/`quick` to `llamacpp`; the one code path that would default to `llama-cola` is never called) and only exposed a stochastic, generation-time policy-sampling signal (`action_indices`, sampled at `tau=2.0`) via `/v1/chat/completions` — meant for output diversity, not for scoring the meaning of a finished reply. `orion-spark-introspector` had no producer of language-derived novelty at all; its only novelty source was `_phi_from_self_state`, derived from biometric/attention pressure dimensions.

## Architecture touched

- `services/orion-llama-cola-host`: new endpoint, model return-signature change (only `IntentionModel_v1`, the currently-configured variant — other unused variants in `intention.py` untouched).
- `services/orion-spark-introspector`: new HTTP client call, novelty scoring, signal publish, wired into the existing `handle_semantic_upsert` chat-turn handler.
- `orion/schemas/telemetry/spark_signal.py`: additive schema change (new `signal_type` literal).
- No changes to `orion-llm-gateway`, `SelfStateV1`, or the `SignalMapper`/`OrionTissue` grid pipeline (left as-is, out of scope).

## Files changed

- `services/orion-llama-cola-host/intention.py`: `bc_mode` branch in `IntentionModel_v1.forward()` now also returns the pre-argmax action-probability distribution.
- `services/orion-llama-cola-host/app/main.py`: new `POST /v1/understand` endpoint + request/response schemas.
- `services/orion-llama-cola-host/README.md`: documents the new endpoint.
- `services/orion-llama-cola-host/tests/`: new — model-level tests with a tiny randomly-initialized CoLA model (real torch execution, not mocked) proving the 3-tuple return, valid softmax distribution, determinism, and the endpoint's pooling logic.
- `services/orion-spark-introspector/app/worker.py`: new CoLA-understand HTTP client, LRU-bounded rolling per-session novelty history, `SparkSignalV1` publish, wiring into `handle_semantic_upsert`; extracted `_publish_spark_signal()` shared with the existing turn-effect-alert path.
- `services/orion-spark-introspector/app/settings.py`: new `COLA_*` settings (all opt-in, disabled by default).
- `services/orion-spark-introspector/.env_example`: documents the new keys.
- `services/orion-spark-introspector/README.md`: new §6.8 documenting the feature, data flow, settings, and rollback.
- `services/orion-spark-introspector/tests/test_cola_novelty_signal.py`: new — unit, fail-open, LRU-eviction, dimension-mismatch, and `handle_semantic_upsert` wiring tests, plus an in-process trace proving a published signal reaches the same `phi_stats` merge `orion-cortex-exec` reads.
- `orion/schemas/telemetry/spark_signal.py`: added `"language"` to `signal_type`'s literal set (additive; verified no exhaustive-match consumer exists elsewhere).

## Schema / bus / API changes

- Added: `POST /v1/understand` on `orion-llama-cola-host`.
- Added: `SparkSignalV1.signal_type` literal `"language"`.
- Behavior changed: `IntentionModel_v1.forward(bc_mode=True)` now returns a 3-tuple instead of 2-tuple. Verified this is the only production call site in the repo (no other caller assumes the old arity); other model variants (`v1p`, `v1a`, base) in the same file were left untouched since they're not the currently-configured model (`config.v == 1`).
- Compatibility notes: both additions are backward compatible; no existing consumer breaks.

## Env/config changes

- Added keys (all in `services/orion-spark-introspector/.env_example`): `COLA_UNDERSTAND_ENABLE` (default `false`), `COLA_UNDERSTAND_URL`, `COLA_UNDERSTAND_TIMEOUT_SEC`, `COLA_NOVELTY_WINDOW`, `COLA_NOVELTY_MAX_SESSIONS`, `COLA_NOVELTY_GAIN`, `COLA_NOVELTY_SIGNAL_TTL_MS`.
- `orion-llama-cola-host` needed no new env keys.
- Local `.env` synced manually (main checkout's real `services/orion-spark-introspector/.env`, since the default `sync_local_env_from_example.py` prefix allowlist doesn't cover new `COLA_*` keys) — confirmed `git check-ignore` still holds, nothing tracked.
- No skipped keys requiring operator action beyond flipping `COLA_UNDERSTAND_ENABLE=true` once `orion-llama-cola-host` is confirmed running and reachable.

## Tests run

```text
services/orion-spark-introspector: 61 passed, 1 skipped (pytest tests/ -q)
services/orion-llama-cola-host:     4 passed (pytest tests/ -q)
repo-root tests/test_spark_metrics_v2.py, test_spark_contract_gate.py:
  4 passed, 3 pre-existing failures (confirmed via git stash to reproduce
  identically on this branch's parent commit -- unrelated to this change,
  a stale-shape issue in orion/spark/orion_tissue.py's snapshot loading)
```

Run in an isolated venv since this sandbox had no dependencies preinstalled; installed each service's own `requirements.txt` plus CPU-only `torch`/`transformers==4.44.2` to genuinely execute `intention.py`'s patched model code with a tiny randomly-initialized CoLA-shaped model, rather than only AST-parsing it.

## Evals run

No eval harness exists for either touched service. Flagging as a gap: there's no automated check that the CoLA IDM branch's distribution is semantically meaningful (i.e. that paraphrases cluster and unrelated turns diverge) against the real 10B checkpoint — this environment has no GPU/model weights to run that against. Follow-up recommended before fully trusting this signal in metacognition (see Risks below).

## Docker/build/smoke checks

```text
docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml config   -> validates, new COLA_* keys pass through via env_file
docker compose --env-file .env --env-file services/orion-llama-cola-host/.env \
  -f services/orion-llama-cola-host/docker-compose.yml config      -> validates, confirms host binds :8005
```

No live container smoke: `orion-llama-cola-host` is not part of default deploy tooling (excluded from `mesh-utilities` auto-rebuild lists) and wasn't brought up in this environment. `COLA_UNDERSTAND_ENABLE=false` by default specifically so this ships without requiring that host to be live.

## Review findings fixed

- Finding: fail-open contract gap — dimension mismatch (cola-host redeployed with different `num_code`) would raise uncaught inside the fire-and-forget scoring task instead of the documented "logged and skipped" behavior.
  - Fix: explicit shape check resets the stale per-session reference before scoring; broader try/except as backstop.
  - Evidence: new test `test_score_cola_novelty_fails_open_on_dimension_mismatch`.
- Finding: fire-and-forget `asyncio.create_task` result wasn't retained, exposed to asyncio's weak-reference GC risk.
  - Fix: task stored in a module-level set with a done-callback to discard.
  - Evidence: new test `test_handle_semantic_upsert_schedules_cola_novelty_scoring` awaits from that set directly.
- Finding: session eviction was insertion-order FIFO, not LRU — an idle new session could starve out an actively-used older one.
  - Fix: switched to `OrderedDict` + `move_to_end` on every touch.
  - Evidence: new test `test_novelty_remember_evicts_least_recently_used_session`.
- Finding: `signal_type="recall"` gets embedded verbatim into `OrionSignalV1.summary` by `orion/signals/adapters/spark.py` for downstream consumers — a real semantic mislabel once enabled, not cosmetic.
  - Fix: added `signal_type="language"` to the schema instead.
  - Evidence: `test_publish_cola_novelty_signal_reaches_phi_stats_via_signal_bus` asserts `env.payload["signal_type"] == "language"`.
- Finding: new `httpx.AsyncClient()` opened per chat turn instead of pooled, on a hot path.
  - Fix: single lazily-initialized module-level client.
- Finding: signal-envelope publish logic duplicated between the new novelty path and the existing turn-effect-alert path.
  - Fix: extracted `_publish_spark_signal()`, both call sites now share it.
- Finding: no test exercised the actual `handle_semantic_upsert` wiring (only the helper functions in isolation).
  - Fix: added `test_handle_semantic_upsert_schedules_cola_novelty_scoring` / `..._skips_..._when_disabled`.
- Not fixed (documented limitation): no live smoke against the real loaded 10B CoLA model proving the IDM branch's distribution is semantically non-degenerate — no GPU/model weights available in this environment. See Risks.

## Restart required

```bash
# Only needed once COLA_UNDERSTAND_ENABLE is flipped to true:
docker compose -f services/orion-spark-introspector/docker-compose.yml restart
# orion-llama-cola-host would also need to actually be brought up and reachable
# at COLA_UNDERSTAND_URL (currently not part of default deploy tooling).
```

If left at the shipped default (`COLA_UNDERSTAND_ENABLE=false`), no restart is required — behavior is unchanged until explicitly enabled.

## Risks / concerns

- Severity: Medium
  - Concern: The CoLA model card's claim that its 64-code action distribution represents "distinct semantic meanings of language" is the paper authors' own framing, checked against their own benchmark — not independently validated against Orion's data. Enabling this feeds an unvalidated signal into metacognitive context.
  - Mitigation: ships disabled by default. Recommend a cheap validation pass (paraphrase pairs vs. unrelated pairs through `/v1/understand`, checking the pooled distributions actually cluster paraphrases together) before flipping `COLA_UNDERSTAND_ENABLE=true` in production.
- Severity: Low
  - Concern: `orion-llama-cola-host` is excluded from `mesh-utilities` auto-rebuild tooling and not part of default deploy compose sets; bringing it up for the first time in months may surface the model-loading issues already documented in its own README (shard/index mismatch).
  - Mitigation: documented in that README; the feature fails open regardless if the host can't load.
- Severity: Low (operational note, not a code risk)
  - Concern: running `docker compose ... config` against the real `.env` during this work printed a live-looking `HF_TOKEN` value in plaintext into the agent session transcript.
  - Mitigation: none applied in this PR (out of scope) — flagging so the operator can decide whether to rotate it.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/cola-novelty-signal