### PR TITLE
Skip vision-council metacog when window evidence is unchanged.

### DIFF
--- a/services/orion-vision-council/.env_example
+++ b/services/orion-vision-council/.env_example
@@ -17,4 +17,9 @@ COUNCIL_LLM_MAX_TOKENS=1024
 COUNCIL_LLM_TIMEOUT_SEC=90
 COUNCIL_STRUCTURED_OUTPUT_METHOD=json_object_schema
 
+# Skip atlas metacog when per-stream evidence fingerprint is unchanged.
+COUNCIL_EVIDENCE_SKIP_ENABLED=true
+# Force refresh at least every N seconds even if scene evidence is stable (0 = disable force).
+COUNCIL_EVIDENCE_SKIP_MAX_SEC=120
+
 VISION_COUNCIL_HTTP_PORT=8025

--- a/services/orion-vision-council/README.md
+++ b/services/orion-vision-council/README.md
@@ -5,17 +5,20 @@ Consumes visual window summaries from the bus, calls the LLM gateway for scene i
 ## V2 pipeline
 
 ```
-VisionWindowPayload → VisionSceneInterpretationV1 → enforce_evidence_grounding → VisionEventPayload
+VisionWindowPayload → evidence_preflight (skip if unchanged) → VisionSceneInterpretationV1 → enforce_evidence_grounding → VisionEventPayload
 ```
 
 1. **Intake** — `VisionWindowPayload` arrives on the council intake channel (or via RPC request).
-2. **Interpretation** — `build_interpretation_prompt` shapes the LLM prompt (includes `summary.evidence` rules); the response is parsed into `VisionSceneInterpretationV1` via strict validation, salvage/coercion, then legacy fallback.
-3. **Grounding** — `CouncilService._finalize_interpretation()` calls `enforce_evidence_grounding()` on **both** intake and RPC paths:
+2. **Evidence preflight** — `evidence_preflight.py` fingerprints host evidence (`hard_labels`, `host_person_hits`, `object_counts`). When unchanged for a stream, council skips the metacog LLM and does not publish (configurable refresh via `COUNCIL_EVIDENCE_SKIP_MAX_SEC`).
+3. **Interpretation** — `build_interpretation_prompt` shapes the LLM prompt (includes `summary.evidence` rules); the response is parsed into `VisionSceneInterpretationV1` via strict validation, salvage/coercion, then legacy fallback.
+4. **Grounding** — `CouncilService._finalize_interpretation()` calls `enforce_evidence_grounding()` on **both** intake and RPC paths:
    - Drop person/activity claims when `person` ∉ `summary.evidence.hard_labels`
    - Cap activity confidence when only captions support the claim
    - On parse failure + `host_person_hits > 0`: deterministic `person_presence` fallback (no YouTube hallucination)
-4. **Projection** — `project_interpretation_to_events` maps grounded `event_candidates` to `VisionEventBundleItem` entries.
-5. **Publish** — the event bundle is published on `orion:vision:events` (and returned on RPC reply when applicable).
+5. **Projection** — `project_interpretation_to_events` maps grounded `event_candidates` to `VisionEventBundleItem` entries.
+6. **Publish** — the event bundle is published on `orion:vision:events` (and returned on RPC reply when applicable).
+
+Bus intake honors evidence skip; **RPC requests always run interpretation** (on-demand callers must not hang or get silent no-ops).
 
 ## Evidence grounding rules
 
@@ -27,6 +30,8 @@ VisionWindowPayload → VisionSceneInterpretationV1 → enforce_evidence_groundi
 | LLM parse fails; `host_person_hits > 0` | Emit `person_presence` fallback (`parse_mode=host_fallback`, tag `host_detect`) |
 
 Choke point: `services/orion-vision-council/app/evidence_grounding.py`, wired via `_finalize_interpretation()` in `main.py`.
+
+Evidence skip choke point: `services/orion-vision-council/app/evidence_preflight.py`, wired in `_generate_interpretation()` / `_process_window()` in `main.py`.
 
 ## Debug endpoints
 

--- a/services/orion-vision-council/app/evidence_preflight.py
+++ b/services/orion-vision-council/app/evidence_preflight.py
@@ -1,0 +1,84 @@
+"""Deterministic pre-LLM gate: skip council inference when window evidence is unchanged."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from orion.schemas.vision import VisionWindowPayload
+
+
+@dataclass(frozen=True)
+class EvidenceSkipDecision:
+    skip: bool
+    reason: str = ""
+
+
+def stream_key_from_window(window: VisionWindowPayload) -> str:
+    for value in (window.stream_id, window.camera_id):
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return "default"
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def evidence_material(window: VisionWindowPayload) -> dict[str, Any]:
+    """Fields council grounding cares about; excludes volatile window ids and timestamps."""
+    summary = window.summary or {}
+    evidence = summary.get("evidence") or {}
+    if not isinstance(evidence, dict):
+        evidence = {}
+    object_counts = summary.get("object_counts") or {}
+    if not isinstance(object_counts, dict):
+        object_counts = {}
+    return {
+        "evidence": {
+            "hard_labels": sorted(str(x) for x in (evidence.get("hard_labels") or [])),
+            "soft_labels": sorted(str(x) for x in (evidence.get("soft_labels") or [])),
+            "host_person_hits": _safe_int(evidence.get("host_person_hits")),
+            "caption_count": _safe_int(evidence.get("caption_count")),
+        },
+        "object_counts": {str(k): _safe_int(v) for k, v in sorted(object_counts.items())},
+        "detection_count": _safe_int(summary.get("detection_count")),
+    }
+
+
+def evidence_fingerprint(window: VisionWindowPayload) -> str:
+    payload = json.dumps(evidence_material(window), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class EvidenceSkipTracker:
+    def __init__(self) -> None:
+        self._by_stream: dict[str, dict[str, Any]] = {}
+
+    def evaluate(
+        self,
+        *,
+        stream_key: str,
+        fingerprint: str,
+        now: float,
+        max_skip_sec: float,
+    ) -> EvidenceSkipDecision:
+        row = self._by_stream.get(stream_key)
+        if row is None:
+            return EvidenceSkipDecision(skip=False, reason="first_window")
+        if row.get("fingerprint") != fingerprint:
+            return EvidenceSkipDecision(skip=False, reason="evidence_changed")
+        last_llm_at = float(row.get("last_llm_at") or 0.0)
+        if max_skip_sec > 0 and (now - last_llm_at) >= max_skip_sec:
+            return EvidenceSkipDecision(skip=False, reason="max_skip_sec_elapsed")
+        return EvidenceSkipDecision(skip=True, reason="evidence_unchanged")
+
+    def record_llm(self, *, stream_key: str, fingerprint: str, now: float | None = None) -> None:
+        ts = time.time() if now is None else now
+        self._by_stream[stream_key] = {"fingerprint": fingerprint, "last_llm_at": ts}

--- a/services/orion-vision-council/app/main.py
+++ b/services/orion-vision-council/app/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import uuid
 from typing import Any, Optional
 
@@ -30,6 +31,11 @@ from .evidence_grounding import (
     ensure_grounded_person_presence,
     host_person_hits,
     enforce_evidence_grounding,
+)
+from .evidence_preflight import (
+    EvidenceSkipTracker,
+    evidence_fingerprint,
+    stream_key_from_window,
 )
 from .interpretation import (
     InterpretationParseOutcome,
@@ -91,6 +97,8 @@ class CouncilService:
         self._shutdown_event = asyncio.Event()
         self._recent_interpretations: list[dict] = []
         self._llm_semaphore = asyncio.Semaphore(1)
+        self._evidence_skip = EvidenceSkipTracker()
+        self._evidence_skip_lock = asyncio.Lock()
 
     def _record_interpretation(
         self,
@@ -169,7 +177,9 @@ class CouncilService:
             logger.error(f"[COUNCIL] RPC invalid payload: {e}")
             return
 
-        interpretation, parse_outcome = await self._generate_interpretation(req.window, env)
+        interpretation, parse_outcome = await self._generate_interpretation(
+            req.window, env, allow_evidence_skip=False
+        )
         interpretation, parse_outcome = self._finalize_interpretation(
             interpretation, parse_outcome, req.window
         )
@@ -216,6 +226,13 @@ class CouncilService:
             return
 
         interpretation, parse_outcome = await self._generate_interpretation(payload, env)
+        if parse_outcome.parse_mode == "evidence_unchanged":
+            logger.info(
+                f"[COUNCIL] evidence_preflight noop stream={stream_key_from_window(payload)} "
+                f"window_id={payload.window_id}"
+            )
+            return
+
         interpretation, parse_outcome = self._finalize_interpretation(
             interpretation, parse_outcome, payload
         )
@@ -270,17 +287,53 @@ class CouncilService:
             )
         return interpretation, parse_outcome
 
+    def _evidence_skip_decision(
+        self, window: VisionWindowPayload, *, allow_evidence_skip: bool
+    ):
+        if not allow_evidence_skip or not settings.COUNCIL_EVIDENCE_SKIP_ENABLED:
+            return None
+        stream_key = stream_key_from_window(window)
+        fingerprint = evidence_fingerprint(window)
+        return stream_key, fingerprint, self._evidence_skip.evaluate(
+            stream_key=stream_key,
+            fingerprint=fingerprint,
+            now=time.time(),
+            max_skip_sec=settings.COUNCIL_EVIDENCE_SKIP_MAX_SEC,
+        )
+
     async def _generate_interpretation(
         self,
         window: VisionWindowPayload,
         source_env: BaseEnvelope,
+        *,
+        allow_evidence_skip: bool = True,
     ) -> tuple[VisionSceneInterpretationV1 | None, InterpretationParseOutcome]:
+        skip_ctx = None
+        if allow_evidence_skip and settings.COUNCIL_EVIDENCE_SKIP_ENABLED:
+            async with self._evidence_skip_lock:
+                skip_ctx = self._evidence_skip_decision(window, allow_evidence_skip=True)
+                if skip_ctx is not None:
+                    stream_key, fingerprint, decision = skip_ctx
+                    if decision.skip:
+                        logger.info(
+                            f"[COUNCIL] evidence_preflight skip stream={stream_key} "
+                            f"fingerprint={fingerprint[:12]} reason={decision.reason}"
+                        )
+                        return None, InterpretationParseOutcome(
+                            interpretation=None,
+                            parse_mode="evidence_unchanged",
+                        )
+
         prompt = build_interpretation_prompt(window)
         content = await self._call_llm_raw(prompt, source_env)
         if not content:
             return None, InterpretationParseOutcome(interpretation=None, parse_mode="parse_failed")
 
         outcome = parse_llm_content(content, window)
+        if skip_ctx is not None and outcome.interpretation is not None:
+            stream_key, fingerprint, _ = skip_ctx
+            async with self._evidence_skip_lock:
+                self._evidence_skip.record_llm(stream_key=stream_key, fingerprint=fingerprint)
         return outcome.interpretation, outcome
 
     def _project_interpretation_to_events(

--- a/services/orion-vision-council/app/settings.py
+++ b/services/orion-vision-council/app/settings.py
@@ -27,3 +27,8 @@ class Settings(BaseSettings):
     COUNCIL_LLM_MAX_TOKENS: int = 1024
     COUNCIL_LLM_TIMEOUT_SEC: float = 90.0
     COUNCIL_STRUCTURED_OUTPUT_METHOD: str = "json_object_schema"
+
+    # Skip metacog LLM when per-stream evidence fingerprint is unchanged (see evidence_preflight.py).
+    COUNCIL_EVIDENCE_SKIP_ENABLED: bool = True
+    # Force a refresh inference at least this often even when evidence is stable (0 = never force).
+    COUNCIL_EVIDENCE_SKIP_MAX_SEC: float = 120.0

--- a/services/orion-vision-council/tests/test_evidence_preflight.py
+++ b/services/orion-vision-council/tests/test_evidence_preflight.py
@@ -1,0 +1,132 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from orion.schemas.vision import VisionWindowPayload
+
+from app.evidence_preflight import (
+    EvidenceSkipTracker,
+    evidence_fingerprint,
+)
+from app.main import CouncilService
+
+
+def _window(
+    *,
+    window_id: str = "w1",
+    stream_id: str = "cam0",
+    hard_labels: list[str] | None = None,
+    host_person_hits: int = 0,
+    object_counts: dict[str, int] | None = None,
+) -> VisionWindowPayload:
+    hard_labels = hard_labels or []
+    object_counts = object_counts or {}
+    return VisionWindowPayload(
+        window_id=window_id,
+        start_ts=1.0,
+        end_ts=2.0,
+        stream_id=stream_id,
+        summary={
+            "object_counts": object_counts,
+            "top_labels": [],
+            "captions": [],
+            "item_count": 1,
+            "detection_count": sum(object_counts.values()),
+            "evidence": {
+                "hard_labels": hard_labels,
+                "soft_labels": [],
+                "host_person_hits": host_person_hits,
+                "caption_count": 0,
+            },
+        },
+        artifact_ids=["art-1"],
+    )
+
+
+def test_evidence_fingerprint_stable_for_same_material() -> None:
+    a = _window(hard_labels=["person"], object_counts={"person": 2})
+    b = _window(window_id="w2", hard_labels=["person"], object_counts={"person": 2})
+    assert evidence_fingerprint(a) == evidence_fingerprint(b)
+
+
+def test_evidence_fingerprint_changes_when_hard_labels_change() -> None:
+    a = _window(hard_labels=["person"])
+    b = _window(hard_labels=["door"])
+    assert evidence_fingerprint(a) != evidence_fingerprint(b)
+
+
+def test_skip_tracker_first_window_never_skips() -> None:
+    tracker = EvidenceSkipTracker()
+    decision = tracker.evaluate(
+        stream_key="cam0",
+        fingerprint="abc",
+        now=100.0,
+        max_skip_sec=120.0,
+    )
+    assert decision.skip is False
+    assert decision.reason == "first_window"
+
+
+def test_skip_tracker_skips_unchanged_evidence() -> None:
+    tracker = EvidenceSkipTracker()
+    tracker.record_llm(stream_key="cam0", fingerprint="abc", now=100.0)
+    decision = tracker.evaluate(
+        stream_key="cam0",
+        fingerprint="abc",
+        now=110.0,
+        max_skip_sec=120.0,
+    )
+    assert decision.skip is True
+    assert decision.reason == "evidence_unchanged"
+
+
+def test_skip_tracker_refreshes_after_max_skip_sec() -> None:
+    tracker = EvidenceSkipTracker()
+    tracker.record_llm(stream_key="cam0", fingerprint="abc", now=100.0)
+    decision = tracker.evaluate(
+        stream_key="cam0",
+        fingerprint="abc",
+        now=221.0,
+        max_skip_sec=120.0,
+    )
+    assert decision.skip is False
+    assert decision.reason == "max_skip_sec_elapsed"
+
+
+@pytest.mark.asyncio
+async def test_generate_interpretation_skips_llm_when_evidence_unchanged() -> None:
+    svc = CouncilService()
+    window = _window()
+    fp = evidence_fingerprint(window)
+    now = 1_000_000.0
+    svc._evidence_skip.record_llm(stream_key="cam0", fingerprint=fp, now=now)
+
+    with patch.object(svc, "_call_llm_raw", new_callable=AsyncMock) as mock_llm, patch(
+        "app.main.time.time", return_value=now + 10.0
+    ):
+        interpretation, outcome = await svc._generate_interpretation(window, source_env=None)  # type: ignore[arg-type]
+
+    assert interpretation is None
+    assert outcome.parse_mode == "evidence_unchanged"
+    mock_llm.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_interpretation_calls_llm_when_evidence_changes() -> None:
+    svc = CouncilService()
+    first = _window(hard_labels=["person"])
+    svc._evidence_skip.record_llm(
+        stream_key="cam0",
+        fingerprint=evidence_fingerprint(first),
+        now=1.0,
+    )
+    changed = _window(hard_labels=["door"])
+
+    with patch.object(svc, "_call_llm_raw", new_callable=AsyncMock, return_value=None) as mock_llm:
+        await svc._generate_interpretation(changed, source_env=None)  # type: ignore[arg-type]
+
+    mock_llm.assert_called_once()


### PR DESCRIPTION
### Summary

- Add `evidence_preflight.py`: per-stream SHA-256 fingerprint of host evidence (`hard_labels`, `host_person_hits`, `object_counts`) with skip tracker and 120s forced refresh.
- Wire preflight into bus intake: unchanged windows skip atlas metacog LLM and do not publish events (`evidence_preflight skip` / `noop` logs).
- RPC path bypasses skip (`allow_evidence_skip=False`) so on-demand callers always get interpretation; async lock guards tracker under concurrent window tasks.

### Outcome moved

Static cam0 loops were driving ~1051 metacog calls/2h (~7/min) on atlas-worker-2. Steady-state atlas load should drop to ~1 inference per stream per 120s unless evidence changes.

### Tests run

```text
PYTHONPATH=services/orion-vision-council:. pytest services/orion-vision-council/tests -q
# 47 passed
```

### Review findings fixed

- RPC silent no-reply on skip → RPC always runs interpretation
- Tracker race under concurrent windows → `asyncio.Lock`
- `int()` crash on malformed summary → `_safe_int()`

### Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-vision-council/.env \
  -f services/orion-vision-council/docker-compose.yml \
  up -d --build
```

### Test plan

- [ ] Rebuild/restart `orion-athena-vision-council`
- [ ] Logs show `evidence_preflight skip` on static cam0
- [ ] Atlas-worker-2 metacog rate drops in llm-gateway logs
- [ ] Person enter/leave still triggers metacog on evidence change
- [ ] RPC `VisionCouncilService` still returns interpretation when evidence unchanged

### Risks

Caption text changes with same counts won't re-trigger LLM until `COUNCIL_EVIDENCE_SKIP_MAX_SEC` refresh (default 120s). Tune or disable via `COUNCIL_EVIDENCE_SKIP_ENABLED=false` if needed.