### PR TITLE
Run run_llm_chat in a thread so HTTP passthrough stays responsive.

### DIFF
--- a/services/orion-llm-gateway/app/main.py
+++ b/services/orion-llm-gateway/app/main.py
@@ -253,7 +253,7 @@ async def handle_chat(env: BaseEnvelope) -> BaseEnvelope:
         len(messages),
     )
 
-    result = run_llm_chat(body)
+    result = await asyncio.to_thread(run_llm_chat, body)
     text = result.get("text") if isinstance(result, dict) else str(result)
 
     # Optional Spark/NeuralHost enrichments. These may be absent depending on


### PR DESCRIPTION
Pushed branch `fix/llm-gateway-event-loop-passthrough` (`4cb56f15`).

`gh pr create` failed — no GitHub auth on this machine. Open manually:

**https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/llm-gateway-event-loop-passthrough**

Or after `gh auth login`:

```bash
gh pr create --title "Fix llm-gateway event loop blocking Anthropic passthrough" --body-file -
```

Paste this body:

---

## Summary

- Run `run_llm_chat()` via `asyncio.to_thread()` in the bus `handle_chat` handler.
- Prevents synchronous upstream HTTP from blocking the asyncio event loop.
- Restores responsive `POST /v1/messages` passthrough while bus traffic is active.

## Outcome moved

FCC / Claude Code passthrough on `:8210` no longer stalls 17s+ or 502s when other bus clients are hammering the gateway.

## Files changed

- `services/orion-llm-gateway/app/main.py`: offload `run_llm_chat` to thread pool

## Tests run

```text
curl -s -X POST http://127.0.0.1:8210/v1/messages \
  -H 'content-type: application/json' \
  -H 'anthropic-version: 2023-06-01' \
  -d '{"model":"llamacpp/agent","max_tokens":64,"stream":false,"messages":[{"role":"user","content":"say OK"}]}'
# 200 OK ~200ms (was 17s+ or 502 under load)
```

## Restart required

```bash
docker compose \
  --env-file services/orion-llm-gateway/.env \
  -f services/orion-llm-gateway/docker-compose.yml \
  up -d --build llm-gateway
```

## Test plan

- [ ] Rebuild `llm-gateway` after merge
- [ ] Under active bus load, `POST /v1/messages` returns in <2s
- [ ] Bus `llm.chat.request` still returns valid `llm.chat.result`

---

**Change:** one line — `result = await asyncio.to_thread(run_llm_chat, body)`