### PR TITLE
Add Gemma 4 LLM profiles and llamacpp multimodal host wiring.

### DIFF
--- a/config/llm_profiles.yaml
+++ b/config/llm_profiles.yaml
@@ -649,6 +649,203 @@ profiles:
       - If OOM: lower ctx_size to 49152 before falling back to qwen3-coder-next-q4km-2xv100-32gb-agent-breadth.
 
 
+  # Gemma 4 31B IT — HF: https://huggingface.co/google/gemma-4-31B-it
+  # GGUF: Krasnopjorovs/gemma-4-31b-it-Imatrix-GGUF (imatrix Q5_K_M ~21G)
+  # Google sampling (model card § Best Practices): temperature=1.0, top_p=0.95, top_k=64
+  # BF16 google/gemma-4-31B-it needs ~80GB; Q5_K_M + row split fits 2x V100 32GB with usable KV.
+  # Multimodal (image) on llama.cpp uses ggml-org LM + mmproj; see orion-llamacpp-host mmproj/image/ubatch flags.
+  gemma4-31b-it-q5km-2xv100-32gb-balanced:
+    display_name: "Gemma 4 31B IT – Q5_K_M (llama.cpp, 2x V100 32GB, balanced)"
+    task_type: chat
+    backend: llamacpp
+    model_id: "gemma4-31b-it-q5_k_m"
+
+    supports_tools: true
+    supports_embeddings: false
+    supports_vision: false
+
+    gpu:
+      num_gpus: 2
+      tensor_parallel_size: 1
+      device_ids: [0, 1]
+      max_model_len: 65536
+      max_batch_tokens: 1024
+      max_concurrent_requests: 1
+      gpu_memory_fraction: 0.90
+
+    llamacpp:
+      model_root: "/models/gguf"
+      hf_repo_id: "Krasnopjorovs/gemma-4-31b-it-Imatrix-GGUF"
+      hf_filename: "gemma-4-31b-it-Q5_K_M.gguf"
+      host: "0.0.0.0"
+      port: 8080
+
+      ctx_size: 65536
+      n_gpu_layers: 99
+      threads: 16
+      n_parallel: 1
+      batch_size: 1024
+
+      chat_template_kwargs:
+        enable_thinking: true
+
+      no_context_shift: true
+      split_mode: "row"
+      tensor_split: "1,1"
+      flash_attn: "on"
+
+      # Google Gemma 4 standardized sampling — do not drift low without cause
+      temperature: 1.0
+      top_k: 64
+      top_p: 0.95
+      min_p: 0.0
+      presence_penalty: 0.0
+
+      n_predict: 16384
+
+    notes: |
+      Balanced Gemma 4 31B profile for 2x V100 32GB (row split, equal tensor_split).
+      - Target lane: general chat + reasoning + tool use where multimodal is not required.
+      - Q5_K_M imatrix GGUF (~21G): much smaller weights than Qwen3-Coder-Next Q5 (~57G), so 64k ctx is
+        safer here than on the coder depth profile on the same 2x32GB box.
+      - 64k ctx matches qwen3-coder-next-q5km-2xv100-32gb-agent-depth — proven for ~41k+ agent prompts.
+      - Sampling matches Google model-card defaults (temp 1.0, top_k 64, top_p 0.95). Gemma quality degrades with overly cold temps.
+      - Thinking on via chat_template_kwargs.enable_thinking (Gemma 4 <|think|> / channel template). Strip prior-turn thoughts from history per Google multi-turn guidance.
+      - Single parallel slot for stable long-context + thinking outputs.
+      - Wire: LLM_PROFILE_NAME=gemma4-31b-it-q5km-2xv100-32gb-balanced on orion-llamacpp-host.
+      - If OOM at 64k: lower ctx_size to 49152, then hf_filename gemma-4-31b-it-Q4_K_M.gguf.
+      - For image input on llama.cpp: use gemma4-31b-it-q4km-2xv100-32gb-multimodal (ggml-org + mmproj).
+
+  # Gemma 4 31B IT multimodal — ggml-org LM + mmproj (llama.cpp mtmd, server-cuda-b8740+)
+  gemma4-31b-it-q4km-2xv100-32gb-multimodal:
+    display_name: "Gemma 4 31B IT – Q4_K_M + mmproj (llama.cpp, 2x V100 32GB, text+image)"
+    task_type: multimodal
+    backend: llamacpp
+    model_id: "gemma4-31b-it-q4_k_m"
+
+    supports_tools: true
+    supports_embeddings: false
+    supports_vision: true
+
+    gpu:
+      num_gpus: 2
+      tensor_parallel_size: 1
+      device_ids: [0, 1]
+      max_model_len: 65536
+      max_batch_tokens: 2048
+      max_concurrent_requests: 1
+      gpu_memory_fraction: 0.90
+
+    llamacpp:
+      model_root: "/models/gguf"
+      hf_repo_id: "ggml-org/gemma-4-31B-it-GGUF"
+      hf_filename: "gemma-4-31B-it-Q4_K_M.gguf"
+      mmproj_filename: "mmproj-gemma-4-31B-it-bf16.gguf"
+      host: "0.0.0.0"
+      port: 8080
+
+      ctx_size: 65536
+      n_gpu_layers: 99
+      threads: 16
+      n_parallel: 1
+      batch_size: 2048
+      ubatch_size: 2048
+
+      # Google: 280/560 for general multimodal chat; max budget 1120 (OCR/docs)
+      image_min_tokens: 280
+      image_max_tokens: 560
+
+      chat_template_kwargs:
+        enable_thinking: true
+
+      no_context_shift: true
+      split_mode: "row"
+      tensor_split: "1,1"
+      flash_attn: "on"
+
+      temperature: 1.0
+      top_k: 64
+      top_p: 0.95
+      min_p: 0.0
+      presence_penalty: 0.0
+
+      n_predict: 16384
+
+    notes: |
+      Gemma 4 31B text+image via llama.cpp libmtmd on 2x V100 32GB.
+      - Uses official ggml-org/gemma-4-31B-it-GGUF (Q4_K_M ~17G) + mmproj-gemma-4-31B-it-bf16.gguf (~1G).
+      - Requires pinned image LLAMACPP_IMAGE_TAG=server-cuda-b8740 (mtmd + --mmproj + image token flags).
+      - ubatch_size/batch_size must be >= image_max_tokens (Gemma vision encoder is non-causal).
+      - 64k ctx matches agent-scale prompts (~41k+) proven on Qwen coder depth lane.
+      - Google sampling: temp 1.0, top_k 64, top_p 0.95 — do not cold-temp this model.
+      - Video: no native flag; send frames as a sequence of images in the chat payload.
+      - No audio on 31B dense. For text+image+audio use gemma4-e4b-it-q4km-v100-32gb-multimodal.
+      - Wire: LLM_PROFILE_NAME=gemma4-31b-it-q4km-2xv100-32gb-multimodal
+      - If OOM: lower image_max_tokens to 280, then ctx_size to 49152.
+
+  # Gemma 4 E4B IT — smaller multimodal with native audio (ggml-org)
+  gemma4-e4b-it-q4km-v100-32gb-multimodal:
+    display_name: "Gemma 4 E4B IT – Q4_K_M + mmproj (llama.cpp, 1x V100 32GB, text+image+audio)"
+    task_type: multimodal
+    backend: llamacpp
+    model_id: "gemma4-e4b-it-q4_k_m"
+
+    supports_tools: true
+    supports_embeddings: false
+    supports_vision: true
+
+    gpu:
+      num_gpus: 1
+      tensor_parallel_size: 1
+      device_ids: [0]
+      max_model_len: 131072
+      max_batch_tokens: 2048
+      max_concurrent_requests: 2
+      gpu_memory_fraction: 0.88
+
+    llamacpp:
+      model_root: "/models/gguf"
+      hf_repo_id: "ggml-org/gemma-4-E4B-it-GGUF"
+      hf_filename: "gemma-4-E4B-it-Q4_K_M.gguf"
+      mmproj_filename: "mmproj-gemma-4-E4B-it-bf16.gguf"
+      host: "0.0.0.0"
+      port: 8080
+
+      ctx_size: 131072
+      n_gpu_layers: 99
+      threads: 8
+      n_parallel: 2
+      batch_size: 2048
+      ubatch_size: 2048
+
+      image_min_tokens: 140
+      image_max_tokens: 280
+
+      chat_template_kwargs:
+        enable_thinking: true
+
+      no_context_shift: true
+      flash_attn: "on"
+
+      temperature: 1.0
+      top_k: 64
+      top_p: 0.95
+      min_p: 0.0
+      presence_penalty: 0.0
+
+      n_predict: 8192
+
+    notes: |
+      Smaller Gemma 4 lane for text + image + audio on one V100 32GB (~5G LM + ~1G mmproj).
+      - E4B is the practical sub-31B option when you need audio without vLLM.
+      - Native 128k ctx; profile uses 131072 with headroom for on-device workloads.
+      - Image token budget 140–280 (Google: fast captioning / general chat tier).
+      - Video: send sampled frames as images (max ~60s @ 1fps per Google model card).
+      - Audio: place audio after text in the prompt (Google modality order).
+      - Wire: LLM_PROFILE_NAME=gemma4-e4b-it-q4km-v100-32gb-multimodal
+      - Alternative all-in-one (vision+audio, no Google): Qwen3-Omni-30B-A3B via ggml-org (heavier MoE).
+
+
   # ─────────────────────────────────────────────
   # DeepSeek 70B via llama.cpp on Atlas
   # ─────────────────────────────────────────────

--- a/services/orion-llamacpp-host/app/main.py
+++ b/services/orion-llamacpp-host/app/main.py
@@ -48,6 +48,38 @@ def _shard_filenames_for_download(filename: str) -> list[str]:
     return [f"{prefix_dir}{stem}-{idx:05d}-of-{total}.gguf" for idx in range(1, total_n + 1)]
 
 
+def _ensure_hf_gguf_file(
+    *,
+    model_root: str,
+    repo_id: str,
+    filename: str,
+    label: str,
+) -> Path:
+    """Download a GGUF (or shard set) from HuggingFace when missing locally."""
+    target = Path(model_root) / filename
+    if target.exists():
+        return target
+
+    Path(model_root).mkdir(parents=True, exist_ok=True)
+
+    for shard_filename in _shard_filenames_for_download(filename):
+        shard_path = Path(model_root) / shard_filename
+        if shard_path.exists():
+            continue
+        logger.info("Downloading %s/%s -> %s (%s)", repo_id, shard_filename, model_root, label)
+        hf_hub_download(
+            repo_id=repo_id,
+            filename=shard_filename,
+            local_dir=model_root,
+            local_dir_use_symlinks=False,
+            token=settings.hf_token,
+        )
+
+    if not target.exists():
+        raise FileNotFoundError(f"Download completed but {label} still missing at: {target}")
+    return target
+
+
 def _ensure_model_file(model_path: str, dl: Optional[LlamaCppConfig]) -> None:
     """
     Ensure the GGUF exists at model_path. If not, use dl.{repo_id,filename,model_root}
@@ -62,23 +94,35 @@ def _ensure_model_file(model_path: str, dl: Optional[LlamaCppConfig]) -> None:
             f"Model not found and no download spec available: {model_path}"
         )
 
-    Path(dl.model_root).mkdir(parents=True, exist_ok=True)
-
-    for shard_filename in _shard_filenames_for_download(dl.filename):
-        shard_path = Path(dl.model_root) / shard_filename
-        if shard_path.exists():
-            continue
-        logger.info("Downloading %s/%s -> %s", dl.repo_id, shard_filename, dl.model_root)
-        hf_hub_download(
-            repo_id=dl.repo_id,
-            filename=shard_filename,
-            local_dir=dl.model_root,
-            local_dir_use_symlinks=False,
-            token=settings.hf_token,
-        )
+    _ensure_hf_gguf_file(
+        model_root=dl.model_root,
+        repo_id=dl.repo_id,
+        filename=dl.filename,
+        label="language model",
+    )
 
     if not p.exists():
         raise FileNotFoundError(f"Download completed but model still missing at: {model_path}")
+
+
+def _ensure_mmproj_file(cfg: LlamaCppConfig) -> Optional[str]:
+    """Ensure multimodal projector GGUF exists; return concrete path for --mmproj."""
+    if not cfg.mmproj_filename:
+        return None
+
+    repo_id = cfg.mmproj_repo_id or cfg.repo_id
+    if not repo_id:
+        raise FileNotFoundError(
+            "Profile requests mmproj_filename but no mmproj_repo_id or repo_id is configured"
+        )
+
+    mmproj_path = _ensure_hf_gguf_file(
+        model_root=cfg.model_root,
+        repo_id=repo_id,
+        filename=cfg.mmproj_filename,
+        label="mmproj",
+    )
+    return str(mmproj_path)
 
 
 def _resolve_runtime(profile: LLMProfile) -> Tuple[str, LlamaCppConfig, Dict[str, str]]:
@@ -201,6 +245,7 @@ def build_llama_server_cmd_and_env(profile: LLMProfile) -> Tuple[List[str], Dict
 
     # Ensure GGUF exists (download if needed)
     _ensure_model_file(model_path, cfg)
+    mmproj_path = _ensure_mmproj_file(cfg)
 
     # llama-server binary inside your built image
     server_bin = "/app/llama-server"
@@ -295,6 +340,16 @@ def build_llama_server_cmd_and_env(profile: LLMProfile) -> Tuple[List[str], Dict
         append_flag("--split-mode", cfg.split_mode)
     if cfg.tensor_split is not None:
         append_flag("--tensor-split", cfg.tensor_split)
+
+    if mmproj_path is not None:
+        ensure_jinja()
+        append_flag("--mmproj", mmproj_path)
+    if cfg.ubatch_size is not None:
+        append_flag("--ubatch-size", str(cfg.ubatch_size))
+    if cfg.image_min_tokens is not None:
+        append_flag("--image-min-tokens", str(cfg.image_min_tokens))
+    if cfg.image_max_tokens is not None:
+        append_flag("--image-max-tokens", str(cfg.image_max_tokens))
 
     if cfg.n_predict is not None:
         append_flag("--n-predict", str(cfg.n_predict))

--- a/services/orion-llamacpp-host/app/profiles.py
+++ b/services/orion-llamacpp-host/app/profiles.py
@@ -35,6 +35,16 @@ class LlamaCppConfig(BaseModel):
         validation_alias=AliasChoices("filename", "hf_filename"),
         description="GGUF filename in repo",
     )
+    mmproj_filename: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("mmproj_filename", "hf_mmproj_filename"),
+        description="Multimodal projector GGUF filename (llama-server --mmproj)",
+    )
+    mmproj_repo_id: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("mmproj_repo_id", "hf_mmproj_repo_id"),
+        description="HF repo for mmproj; defaults to repo_id when omitted",
+    )
 
     host: str = "0.0.0.0"
     port: int = 8080
@@ -43,6 +53,9 @@ class LlamaCppConfig(BaseModel):
     threads: int = 16
     n_parallel: int = 2
     batch_size: int = 512
+    ubatch_size: Optional[int] = None
+    image_min_tokens: Optional[int] = None
+    image_max_tokens: Optional[int] = None
 
     reasoning: Optional[Literal["on", "off", "auto"]] = None
     reasoning_format: Optional[Literal["none", "deepseek", "deepseek-legacy", "auto"]] = None

--- a/services/orion-llamacpp-host/tests/test_profile_forwarding.py
+++ b/services/orion-llamacpp-host/tests/test_profile_forwarding.py
@@ -298,3 +298,67 @@ def test_qwen3_coder_next_profile_uses_hf_shard_paths():
         filename = raw["profiles"][key]["llamacpp"]["hf_filename"]
         assert "-Q4_K_M-" in filename or "-Q5_K_M-" in filename
         assert filename.endswith("-00001-of-00004.gguf")
+
+
+def test_gemma4_31b_multimodal_profile_forwards_mmproj_and_image_flags(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[3]
+    config_path = repo_root / "config" / "llm_profiles.yaml"
+
+    monkeypatch.setenv("LLM_PROFILE_NAME", "gemma4-31b-it-q4km-2xv100-32gb-multimodal")
+    monkeypatch.setenv("LLM_PROFILES_CONFIG_PATH", str(config_path))
+
+    main = importlib.import_module("app.main")
+    settings_mod = importlib.import_module("app.settings")
+    profiles_mod = importlib.import_module("app.profiles")
+
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    profile_cfg = raw["profiles"]["gemma4-31b-it-q4km-2xv100-32gb-multimodal"]
+    profile = profiles_mod.LLMProfile(name="gemma4-31b-it-q4km-2xv100-32gb-multimodal", **profile_cfg)
+
+    monkeypatch.setattr(main, "_ensure_model_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "_ensure_mmproj_file",
+        lambda _cfg: "/models/gguf/mmproj-gemma-4-31B-it-bf16.gguf",
+    )
+    monkeypatch.setattr(
+        main,
+        "_get_supported_llama_server_flags",
+        lambda _server_bin: {
+            "--jinja",
+            "--chat-template-kwargs",
+            "--flash-attn",
+            "--no-context-shift",
+            "--split-mode",
+            "--tensor-split",
+            "--mmproj",
+            "--ubatch-size",
+            "--image-min-tokens",
+            "--image-max-tokens",
+            "--n-predict",
+            "--temp",
+            "--top-k",
+            "--top-p",
+            "--min-p",
+            "--presence-penalty",
+        },
+    )
+    monkeypatch.setattr(main, "_get_llama_server_build", lambda _server_bin: 8740)
+    monkeypatch.setattr(
+        settings_mod.settings,
+        "llamacpp_model_path_override",
+        "/models/gguf/gemma-4-31B-it-Q4_K_M.gguf",
+    )
+
+    cmd, _env = main.build_llama_server_cmd_and_env(profile)
+
+    assert profile.supports_vision is True
+    assert "--jinja" in cmd
+    assert _find_flag_value(cmd, "--mmproj") == "/models/gguf/mmproj-gemma-4-31B-it-bf16.gguf"
+    assert _find_flag_value(cmd, "--ubatch-size") == "2048"
+    assert _find_flag_value(cmd, "--image-min-tokens") == "280"
+    assert _find_flag_value(cmd, "--image-max-tokens") == "560"
+    assert _find_flag_value(cmd, "--ctx-size") == "65536"
+    assert _find_flag_value(cmd, "--temp") == "1.0"
+    assert _find_flag_value(cmd, "--top-k") == "64"
+    assert _find_flag_value(cmd, "--top-p") == "0.95"


### PR DESCRIPTION
Branch is pushed. `gh` isn't authenticated here, so open the PR from the link below (body is ready to paste).

**Branch:** `feat/gemma4-llm-profiles-multimodal`  
**Commit:** `b17ab9dc`  
**Create PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/gemma4-llm-profiles-multimodal

---

## PR title

Add Gemma 4 LLM profiles and llamacpp multimodal wiring

## PR body (paste into GitHub)

```markdown
## Summary

- Add three Gemma 4 profiles to `config/llm_profiles.yaml` for 2× V100 32GB and 1× V100 32GB:
  - `gemma4-31b-it-q5km-2xv100-32gb-balanced` — text-only, Krasnopjorovs imatrix Q5_K_M, 64k ctx, Google sampling (temp 1.0 / top_k 64 / top_p 0.95)
  - `gemma4-31b-it-q4km-2xv100-32gb-multimodal` — text+image via ggml-org Q4_K_M + mmproj, 64k ctx
  - `gemma4-e4b-it-q4km-v100-32gb-multimodal` — smaller text+image+audio lane on one V100
- Extend `orion-llamacpp-host` to download mmproj GGUFs and forward `--mmproj`, `--ubatch-size`, `--image-min-tokens`, `--image-max-tokens` (verified on pinned `server-cuda-b8740`)
- Add regression test for multimodal argv forwarding

## Outcome moved

Operators can stand up Gemma 4 on Atlas V100 hardware with model-card-correct sampling and optional llama.cpp vision (direct curl to worker). 64k ctx aligns with proven Qwen coder depth lane for ~41k agent prompts.

## Architecture touched

- `config/llm_profiles.yaml` — new profile keys only
- `services/orion-llamacpp-host` — profile schema + launch argv (no gateway/bus contract changes)

## Files changed

- `config/llm_profiles.yaml`: Gemma 4 balanced + multimodal profiles
- `services/orion-llamacpp-host/app/profiles.py`: mmproj / image token / ubatch schema fields
- `services/orion-llamacpp-host/app/main.py`: HF download + argv forwarding for multimodal flags
- `services/orion-llamacpp-host/tests/test_profile_forwarding.py`: multimodal argv regression test

## Non-goals (follow-up)

- LLM gateway multimodal passthrough (`LLMMessage.content` is still `str` only)
- Automatic routing by `supports_vision`
- vLLM Gemma 4 path

Multimodal workers are validated via direct OpenAI-compatible calls to `llama-server` until a bus consumer exists.

## Tests run

```text
services/orion-llamacpp-host/tests/test_profile_forwarding.py::test_gemma4_31b_multimodal_profile_forwards_mmproj_and_image_flags
# (pytest not available in this environment; run locally/CI)
```

## Restart required

Rebuild and restart the llamacpp worker with the desired profile:

```bash
LLM_PROFILE_NAME=gemma4-31b-it-q5km-2xv100-32gb-balanced
# or
LLM_PROFILE_NAME=gemma4-31b-it-q4km-2xv100-32gb-multimodal
```

Ensure `LLAMACPP_IMAGE_TAG=server-cuda-b8740` at build time (existing pin).

## Test plan

- [ ] Rebuild `orion-llamacpp-host` with `LLAMACPP_IMAGE_TAG=server-cuda-b8740`
- [ ] Boot text profile; confirm `--ctx-size 65536` and Google sampling in startup argv
- [ ] Boot multimodal profile; confirm `--mmproj`, `--ubatch-size 2048`, `--image-min-tokens 280`, `--image-max-tokens 560`
- [ ] Manual smoke: text chat completion on balanced profile
- [ ] Manual smoke: image+text curl to multimodal worker (not via gateway yet)
- [ ] Run `pytest services/orion-llamacpp-host/tests/test_profile_forwarding.py -q`
```