### PR TITLE
fix(hub): harden agent-claude for production Docker and long repo turns

### DIFF
--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -59,13 +59,20 @@ HUB_CONTEXT_EXEC_TIMEOUT_SEC=600
 HUB_AGENT_REPL_ENABLED=true
 # Hub Agent Claude — FCC harness in chat (host-network dev; disabled in Docker by default)
 HUB_AGENT_CLAUDE_ENABLED=true
-HUB_FCC_ENV_PATH=~/.fcc/.env
+HUB_FCC_ENV_PATH=/root/.fcc/.env
 HUB_FCC_SERVER_URL=http://127.0.0.1:8082
 HUB_FCC_AUTH_TOKEN=
 HUB_AGENT_CLAUDE_BIN=claude
-HUB_AGENT_CLAUDE_WORKSPACE=/mnt/scripts/Orion-Sapienform
+# Host path: /mnt/scripts/Orion-Sapienform — Hub Docker (repo mount): /repo
+HUB_AGENT_CLAUDE_WORKSPACE=/repo
 HUB_AGENT_CLAUDE_TIMEOUT_SEC=900
 HUB_AGENT_CLAUDE_MAX_CONCURRENT=1
+# Max bytes for one claude stream-json stdout line (tool/file payloads can be large)
+HUB_AGENT_CLAUDE_STREAM_READ_LIMIT=8388608
+# Match llamacpp chat profile ctx_size; passed into claude subprocess env
+HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS=65536
+# Cap single Read tool payload so multi-step repo sweeps stay under ctx
+HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS=8192
 HUB_CONTEXT_EXEC_EVENT_CHANNEL=orion:context_exec:event
 # Profile-derived investigation_v2 path (Hub Agent lane). Must match context-exec.
 CONTEXT_EXEC_INVESTIGATION_V2_ENABLED=false

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -515,9 +515,11 @@ Bridge env keys `SOCIAL_BRIDGE_HUB_MODE` / `SOCIAL_BRIDGE_HUB_VERB` affect **Cal
 
 ### Agent Claude mode (FCC harness)
 
-When `HUB_AGENT_CLAUDE_ENABLED=true`, Hub exposes **Agent Claude** mode. Each message spawns one `claude -p … --output-format stream-json` turn with `ANTHROPIC_BASE_URL` set to `HUB_FCC_SERVER_URL` (default `http://127.0.0.1:8082`). The **FCC Model** dropdown lists env key labels from `HUB_FCC_ENV_PATH` (`MODEL`, `MODEL_HAIKU`, …), not resolved gateway values. **Compute** lane is ignored for this mode.
+When `HUB_AGENT_CLAUDE_ENABLED=true`, Hub exposes **Agent Claude - Opus / Sonnet / Haiku** modes in the Mode dropdown. Each message spawns one `claude -p … --output-format stream-json` turn with `ANTHROPIC_BASE_URL` set to `HUB_FCC_SERVER_URL` (default `http://127.0.0.1:8082`). Tier selection maps to FCC env keys (`MODEL_OPUS`, `MODEL_SONNET`, `MODEL_HAIKU`). **Compute** lane is ignored for these modes.
 
 **Requirements (v1):** Hub process on host (or container with `claude` on PATH + mounted repo + mounted `~/.fcc/.env`). `fcc-server` running. Default Docker compose keeps `HUB_AGENT_CLAUDE_ENABLED=false`.
+
+**Context limits (llamacpp):** Local `MODEL_*` lanes often use `ctx_size: 65536` (`config/llm_profiles.yaml`). Multi-step repo reads can exceed that (e.g. reading all of `orion/bus/channels.yaml`). Hub passes `CLAUDE_CODE_MAX_CONTEXT_TOKENS` and `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS` (see `HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS`, `HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS`) into the claude subprocess, and prepends a repo-exploration brief (`prepare_agent_claude_input`). For deep sweeps, raise llamacpp `ctx_size`, route `~/.fcc/.env` to a larger backend, or ask narrower questions.
 
 **Live smoke:**
 

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -139,6 +139,21 @@ class Settings(BaseSettings):
         default=1,
         alias="HUB_AGENT_CLAUDE_MAX_CONCURRENT",
     )
+    HUB_AGENT_CLAUDE_STREAM_READ_LIMIT: int = Field(
+        default=8 * 1024 * 1024,
+        alias="HUB_AGENT_CLAUDE_STREAM_READ_LIMIT",
+        description="asyncio StreamReader limit for one claude stream-json line (bytes). Default 8MB.",
+    )
+    HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS: int = Field(
+        default=65536,
+        alias="HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS",
+        description="Passed to claude as CLAUDE_CODE_MAX_CONTEXT_TOKENS for llamacpp parity.",
+    )
+    HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS: int = Field(
+        default=8192,
+        alias="HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS",
+        description="Passed to claude as CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS to cap single Read payloads.",
+    )
     HUB_CONTEXT_EXEC_EVENT_CHANNEL: str = Field(
         default="orion:context_exec:event",
         alias="HUB_CONTEXT_EXEC_EVENT_CHANNEL",

--- a/services/orion-hub/docker-compose.yml
+++ b/services/orion-hub/docker-compose.yml
@@ -27,6 +27,10 @@ services:
       - ./templates:/app/templates
       - ./static:/app/static
       - ../..:/repo:ro
+      - ../..:/mnt/scripts/Orion-Sapienform:ro
+      - ${HOME}/.fcc:/root/.fcc:ro
+      - ${HOME}/.claude.json:/root/.claude.json:ro
+      - ${HUB_AGENT_CLAUDE_BIN_HOST:-${HOME}/.local/bin/claude}:/usr/local/bin/claude:ro
       - /var/run/docker.sock:/var/run/docker.sock
       #- /mnt/telemetry/models/whisper/${WHISPER_MODEL_SIZE}:/root/.cache/huggingface/hub/models--distil-whisper--${WHISPER_MODEL_SIZE}
     environment:
@@ -83,13 +87,16 @@ services:
       - HUB_CONTEXT_EXEC_TIMEOUT_SEC=${HUB_CONTEXT_EXEC_TIMEOUT_SEC:-600}
       - HUB_AGENT_REPL_ENABLED=${HUB_AGENT_REPL_ENABLED:-true}
       - HUB_AGENT_CLAUDE_ENABLED=${HUB_AGENT_CLAUDE_ENABLED:-false}
-      - HUB_FCC_ENV_PATH=${HUB_FCC_ENV_PATH:-~/.fcc/.env}
+      - HUB_FCC_ENV_PATH=/root/.fcc/.env
       - HUB_FCC_SERVER_URL=${HUB_FCC_SERVER_URL:-http://127.0.0.1:8082}
       - HUB_FCC_AUTH_TOKEN=${HUB_FCC_AUTH_TOKEN:-}
-      - HUB_AGENT_CLAUDE_BIN=${HUB_AGENT_CLAUDE_BIN:-claude}
-      - HUB_AGENT_CLAUDE_WORKSPACE=${HUB_AGENT_CLAUDE_WORKSPACE:-/mnt/scripts/Orion-Sapienform}
+      - HUB_AGENT_CLAUDE_BIN=claude
+      - HUB_AGENT_CLAUDE_WORKSPACE=/mnt/scripts/Orion-Sapienform
       - HUB_AGENT_CLAUDE_TIMEOUT_SEC=${HUB_AGENT_CLAUDE_TIMEOUT_SEC:-900}
       - HUB_AGENT_CLAUDE_MAX_CONCURRENT=${HUB_AGENT_CLAUDE_MAX_CONCURRENT:-1}
+      - HUB_AGENT_CLAUDE_STREAM_READ_LIMIT=${HUB_AGENT_CLAUDE_STREAM_READ_LIMIT:-8388608}
+      - HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS=${HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS:-65536}
+      - HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS=${HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS:-8192}
       - HUB_CONTEXT_EXEC_EVENT_CHANNEL=${HUB_CONTEXT_EXEC_EVENT_CHANNEL:-orion:context_exec:event}
       - CONTEXT_EXEC_INVESTIGATION_V2_ENABLED=${CONTEXT_EXEC_INVESTIGATION_V2_ENABLED:-false}
       - SUBSTRATE_TELEMETRY_BASE_URL=${SUBSTRATE_TELEMETRY_BASE_URL:-}

--- a/services/orion-hub/scripts/agent_claude_input.py
+++ b/services/orion-hub/scripts/agent_claude_input.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+# Operational contract for local llamacpp (~64k ctx). Not conversational stance routing.
+AGENT_CLAUDE_OPERATOR_BRIEF = """\
+Hub agent-claude runs against a local gateway with a finite context window (~64k tokens).
+Before Read on any file: prefer rg/Grep with a path or pattern. For large files (e.g. orion/bus/channels.yaml), use Read offset/limit in chunks — never load whole contract YAML in one read.
+"""
+
 
 @dataclass(frozen=True)
 class TurnRequest:
@@ -10,4 +16,9 @@ class TurnRequest:
 
 
 def prepare_agent_claude_input(text: str) -> TurnRequest:
-    return TurnRequest(prompt=str(text or "").strip())
+    user_text = str(text or "").strip()
+    if not user_text:
+        return TurnRequest(prompt="")
+    return TurnRequest(
+        prompt=f"{AGENT_CLAUDE_OPERATOR_BRIEF.strip()}\n\nOperator request:\n{user_text}"
+    )

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -46,7 +46,7 @@ from .cortex_request_builder import (
 from .mutation_cognition_context import build_mutation_cognition_context
 from .context_exec_agent_bridge import run_hub_agent_via_context_exec, should_use_context_exec_agent_lane
 from .agent_claude_input import prepare_agent_claude_input
-from .fcc_claude_bridge import run_turn_from_settings
+from .fcc_claude_bridge import build_harness_reasoning_trace, run_turn_from_settings
 from .fcc_env_catalog import catalog_from_settings
 from .fcc_model_mapping import DEFAULT_FCC_MODEL_LABEL
 from .substrate_effect_pipeline import run_substrate_effect_pipeline
@@ -1930,7 +1930,11 @@ def _http_chat_turn_context_from_result(result: Dict[str, Any]) -> Dict[str, Any
         or ""
     ).strip() or None
     explicit_reasoning_trace = (
-        raw.get("reasoning_trace") if isinstance(raw.get("reasoning_trace"), dict) else None
+        result.get("reasoning_trace")
+        if isinstance(result.get("reasoning_trace"), dict)
+        else raw.get("reasoning_trace")
+        if isinstance(raw.get("reasoning_trace"), dict)
+        else None
     )
     reasoning_content = (
         gateway_meta.get("reasoning_content")
@@ -1945,7 +1949,11 @@ def _http_chat_turn_context_from_result(result: Dict[str, Any]) -> Dict[str, Any
         gateway_meta.get("inline_think_content")
         or raw.get("inline_think_content")
     )
-    raw_thinking_source = gateway_meta.get("thinking_source") or raw.get("thinking_source")
+    raw_thinking_source = (
+        result.get("thinking_source")
+        or gateway_meta.get("thinking_source")
+        or raw.get("thinking_source")
+    )
     thinking_source = "none"
     if isinstance(raw_thinking_source, str) and raw_thinking_source.strip():
         thinking_source = raw_thinking_source.strip()
@@ -2111,6 +2119,11 @@ async def _run_agent_claude_http(
                 "metadata": event.get("metadata"),
             }
         elif etype == "final":
+            harness_trace = build_harness_reasoning_trace(
+                steps=[s for s in steps if isinstance(s, dict)],
+                correlation_id=correlation_id,
+                model_label=fcc_model_label,
+            )
             return {
                 "mode": "agent-claude",
                 "correlation_id": correlation_id,
@@ -2119,6 +2132,8 @@ async def _run_agent_claude_http(
                 "claude_steps": steps,
                 "metadata": event.get("metadata"),
                 "fcc_model_label": fcc_model_label,
+                "reasoning_trace": harness_trace,
+                "thinking_source": "agent_claude_harness" if harness_trace else "none",
             }
     return {
         "error": "agent-claude produced no final frame",

--- a/services/orion-hub/scripts/fcc_claude_bridge.py
+++ b/services/orion-hub/scripts/fcc_claude_bridge.py
@@ -15,6 +15,10 @@ from scripts.fcc_model_mapping import DEFAULT_FCC_MODEL_LABEL, label_to_claude_m
 
 logger = logging.getLogger("orion-hub.fcc_claude_bridge")
 
+# asyncio subprocess stdout defaults to 64KiB; claude stream-json lines can exceed that
+# when tool results embed large file reads.
+DEFAULT_STREAM_READ_LIMIT = 8 * 1024 * 1024
+
 
 def parse_stream_json_line(line: str) -> Optional[Dict[str, Any]]:
     stripped = str(line or "").strip()
@@ -40,6 +44,60 @@ def parse_stream_json_lines(lines: List[str]) -> List[Dict[str, Any]]:
 
 def build_step_frame(raw: Dict[str, Any]) -> Dict[str, Any]:
     return {"type": str(raw.get("type") or "unknown"), "raw": raw}
+
+
+def summarize_harness_step(step: Dict[str, Any], *, index: int) -> str:
+    """One-line summary of a harness step for chat history / thought_process."""
+    if not isinstance(step, dict):
+        return f"[{index}] step"
+    stype = str(step.get("type") or "event")
+    raw = step.get("raw") if isinstance(step.get("raw"), dict) else step
+    if not isinstance(raw, dict):
+        return f"[{index}] {stype}"
+
+    if stype == "assistant" or raw.get("type") == "assistant":
+        text = _text_blocks_from_assistant(raw)
+        if text.strip():
+            return f"[{index}] assistant: {text.strip()[:2000]}"
+    if stype == "result" or raw.get("type") == "result":
+        result = raw.get("result")
+        if isinstance(result, str) and result.strip():
+            return f"[{index}] result: {result.strip()[:500]}"
+    return f"[{index}] {stype}"
+
+
+def summarize_harness_steps_for_history(steps: List[Dict[str, Any]]) -> str:
+    """Deterministic harness transcript for reasoning_trace.content → thought_process."""
+    lines = [
+        summarize_harness_step(step, index=i)
+        for i, step in enumerate(steps or [])
+        if isinstance(step, dict)
+    ]
+    return "\n".join(lines).strip()
+
+
+def build_harness_reasoning_trace(
+    *,
+    steps: List[Dict[str, Any]],
+    correlation_id: str,
+    session_id: Optional[str] = None,
+    model_label: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    content = summarize_harness_steps_for_history(steps)
+    if not content:
+        return None
+    return {
+        "trace_role": "reasoning",
+        "trace_stage": "mid_answer",
+        "content": content,
+        "correlation_id": str(correlation_id),
+        "session_id": session_id,
+        "model": str(model_label or "").strip() or None,
+        "metadata": {
+            "source": "agent_claude_harness",
+            "step_count": len(steps or []),
+        },
+    }
 
 
 def _text_blocks_from_assistant(event: Dict[str, Any]) -> str:
@@ -111,12 +169,38 @@ def _preflight_fcc_server(url: str, *, timeout_sec: float = 3.0) -> None:
 
 
 def _build_subprocess_env(*, fcc_server_url: str, auth_token: str) -> Dict[str, str]:
+    from scripts.settings import settings
+
     env = os.environ.copy()
     env["ANTHROPIC_BASE_URL"] = str(fcc_server_url).rstrip("/")
     env["ANTHROPIC_AUTH_TOKEN"] = auth_token
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
     env["TERM"] = "dumb"
+    max_ctx = int(getattr(settings, "HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS", 65536))
+    read_max = int(getattr(settings, "HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS", 8192))
+    if max_ctx > 0:
+        env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] = str(max_ctx)
+    if read_max > 0:
+        env["CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS"] = str(read_max)
     return env
+
+
+def is_context_overflow_text(text: str) -> bool:
+    lowered = str(text or "").lower()
+    return (
+        "exceed_context_size_error" in lowered
+        or "exceeds the available context size" in lowered
+    )
+
+
+def context_overflow_operator_hint(*, n_ctx: int | None = None) -> str:
+    ctx = int(n_ctx or 65536)
+    return (
+        f"\n\n---\nHub: context window full (~{ctx} tokens on llamacpp). "
+        "Prefer rg/Grep before Read; use Read offset/limit on large files "
+        "(orion/bus/channels.yaml is ~65KB). Raise ctx_size in config/llm_profiles.yaml "
+        "or route ~/.fcc/.env MODEL_* to a backend with more headroom."
+    )
 
 
 async def run_turn(
@@ -159,16 +243,20 @@ async def run_turn(
         prompt,
         "--output-format",
         "stream-json",
-        "--dangerously-skip-permissions",
         "--verbose",
         "--model",
         model_id,
     ]
+    if os.geteuid() != 0:
+        argv.insert(-2, "--dangerously-skip-permissions")
     started = time.monotonic()
     proc: Optional[asyncio.subprocess.Process] = None
     accumulated = ""
     claude_session_id: Optional[str] = None
     exit_code = 1
+    read_limit = int(getattr(settings, "HUB_AGENT_CLAUDE_STREAM_READ_LIMIT", DEFAULT_STREAM_READ_LIMIT))
+    if read_limit < 65536:
+        read_limit = 65536
 
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -177,6 +265,7 @@ async def run_turn(
             env=_build_subprocess_env(fcc_server_url=fcc_server_url, auth_token=auth_token),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            limit=read_limit,
         )
         _register_process(correlation_id, proc)
         assert proc.stdout is not None
@@ -190,6 +279,24 @@ async def run_turn(
                     "type": "error",
                     "error": f"agent-claude turn timed out after {timeout_sec}s",
                     "error_code": "fcc_claude_timeout",
+                }
+                return
+            except asyncio.LimitOverrunError as exc:
+                proc.kill()
+                yield {
+                    "type": "error",
+                    "error": (
+                        "claude stream-json line exceeded read limit "
+                        f"({read_limit} bytes): {exc}. "
+                        "Try a narrower prompt or raise HUB_AGENT_CLAUDE_STREAM_READ_LIMIT."
+                    ),
+                    "error_code": "fcc_claude_stream_line_limit",
+                    "llm_response": accumulated or None,
+                    "metadata": {
+                        "fcc_model_label": label,
+                        "claude_session_id": claude_session_id,
+                        "stream_read_limit": read_limit,
+                    },
                 }
                 return
 

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -360,6 +360,7 @@ async def startup_event():
             "apiBaseOverride": settings.HUB_API_BASE_OVERRIDE or "",
             "wsBaseOverride": settings.HUB_WS_BASE_OVERRIDE or "",
             "autoDefaultEnabled": bool(settings.HUB_AUTO_DEFAULT_ENABLED),
+            "agentClaudeEnabled": bool(getattr(settings, "HUB_AGENT_CLAUDE_ENABLED", False)),
             "worldPulseFixtureRunEnabled": bool(settings.WORLD_PULSE_UI_FIXTURE_RUN_ENABLED),
             "memoryGraphSuggestFetchTimeoutMs": hub_client_fetch_timeout_ms(
                 settings, escalation_enabled=mg_escalation
@@ -368,6 +369,18 @@ async def startup_event():
         html_content = html_content.replace(
             "{{HUB_CFG}}",
             json.dumps(hub_cfg),
+        )
+        if bool(getattr(settings, "HUB_AGENT_CLAUDE_ENABLED", False)):
+            agent_claude_mode_options = (
+                '<option value="agent_claude_opus">Agent Claude - Opus</option>'
+                '<option value="agent_claude_sonnet">Agent Claude - Sonnet</option>'
+                '<option value="agent_claude_haiku">Agent Claude - Haiku</option>'
+            )
+        else:
+            agent_claude_mode_options = ""
+        html_content = html_content.replace(
+            "{{HUB_AGENT_CLAUDE_MODE_OPTIONS}}",
+            agent_claude_mode_options,
         )
         from scripts.api_routes import resolve_hub_autonomy_subject_display
 

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -38,8 +38,13 @@ from scripts import social_room_inspection_cache
 from scripts.cortex_chat_display import hub_effective_chat_text
 from scripts.context_exec_agent_bridge import run_hub_agent_via_context_exec, should_use_context_exec_agent_lane
 from scripts.agent_claude_input import prepare_agent_claude_input
-from scripts.fcc_claude_bridge import run_turn_from_settings
-from scripts.fcc_env_catalog import catalog_from_settings
+from scripts.fcc_claude_bridge import (
+    build_harness_reasoning_trace,
+    context_overflow_operator_hint,
+    is_context_overflow_text,
+    run_turn_from_settings,
+)
+from scripts.settings import settings
 from scripts.fcc_model_mapping import DEFAULT_FCC_MODEL_LABEL
 from scripts.trace_payloads import extract_agent_trace_payload
 from scripts.voice_stt_errors import (
@@ -528,11 +533,11 @@ async def _run_agent_claude_turn_ws(
         return None
 
     turn = prepare_agent_claude_input(transcript)
-    catalog = catalog_from_settings(env_path=settings.HUB_FCC_ENV_PATH, auth_override=settings.HUB_FCC_AUTH_TOKEN)
-    fcc_label = str(data.get("fcc_model_label") or catalog.get("default_label") or DEFAULT_FCC_MODEL_LABEL)
+    fcc_label = str(data.get("fcc_model_label") or DEFAULT_FCC_MODEL_LABEL).strip() or DEFAULT_FCC_MODEL_LABEL
 
     final_text = ""
     final_meta: Dict[str, Any] = {}
+    harness_steps: List[Dict[str, Any]] = []
     async for event in run_turn_from_settings(
         prompt=turn.prompt,
         fcc_model_label=fcc_label,
@@ -541,6 +546,7 @@ async def _run_agent_claude_turn_ws(
         etype = str(event.get("type") or "")
         if etype == "step":
             step = event.get("step") if isinstance(event.get("step"), dict) else {}
+            harness_steps.append(step)
             await websocket.send_json(
                 await _with_biometrics(
                     {
@@ -572,7 +578,12 @@ async def _run_agent_claude_turn_ws(
             final_text = str(event.get("llm_response") or "")
             final_meta = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
 
-    return {"llm_response": final_text, "metadata": final_meta, "fcc_model_label": fcc_label}
+    return {
+        "llm_response": final_text,
+        "metadata": final_meta,
+        "fcc_model_label": fcc_label,
+        "harness_steps": harness_steps,
+    }
 
 
 async def websocket_endpoint(websocket: WebSocket):
@@ -634,6 +645,7 @@ async def websocket_endpoint(websocket: WebSocket):
                 continue
 
             mode = data.get("mode") or ("auto" if settings.HUB_AUTO_DEFAULT_ENABLED else "brain")
+            client_mode = str(mode or "").strip().lower()
             disable_tts = data.get("disable_tts", False)
             diagnostic = bool(
                 data.get("diagnostic")
@@ -1092,7 +1104,7 @@ async def websocket_endpoint(websocket: WebSocket):
             cortex_result_dump: Dict[str, Any] = {}
             try:
                 logger.info("voice.chat.start corr=%s session_id=%s", trace_id, session_id)
-                if str(mode or "").strip().lower() == "agent-claude":
+                if client_mode == "agent-claude":
                     used_agent_claude_lane = True
                     agent_claude_out = await _run_agent_claude_turn_ws(
                         websocket=websocket,
@@ -1107,10 +1119,27 @@ async def websocket_endpoint(websocket: WebSocket):
                     agent_trace = None
                     cortex_result_dump = {}
                     route_debug = route_debug if isinstance(route_debug, dict) else {}
-                    route_debug["agent_claude"] = {
+                    agent_meta: Dict[str, Any] = {
                         "fcc_model_label": agent_claude_out.get("fcc_model_label"),
                         **(agent_claude_out.get("metadata") or {}),
                     }
+                    if is_context_overflow_text(orion_response_text):
+                        n_ctx = int(getattr(settings, "HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS", 65536))
+                        hint = context_overflow_operator_hint(n_ctx=n_ctx)
+                        if hint.strip() not in orion_response_text:
+                            orion_response_text = f"{orion_response_text.rstrip()}{hint}"
+                        agent_meta["context_overflow"] = True
+                    route_debug["agent_claude"] = agent_meta
+                    harness_steps = agent_claude_out.get("harness_steps") or []
+                    harness_trace = build_harness_reasoning_trace(
+                        steps=harness_steps if isinstance(harness_steps, list) else [],
+                        correlation_id=trace_id,
+                        session_id=publish_session_id,
+                        model_label=str(agent_claude_out.get("fcc_model_label") or ""),
+                    )
+                    if harness_trace:
+                        explicit_reasoning_trace = harness_trace
+                        thinking_source = "agent_claude_harness"
                 else:
                     used_context_exec_lane = should_use_context_exec_agent_lane(chat_req)
                     if used_context_exec_lane:
@@ -1454,7 +1483,10 @@ async def websocket_endpoint(websocket: WebSocket):
 
                     # Extract rich metadata
                     gateway_meta = {}
-                    if hasattr(resp, "cortex_result") and resp.cortex_result:
+                    if used_agent_claude_lane:
+                        agent_meta = route_debug.get("agent_claude") if isinstance(route_debug, dict) else {}
+                        gateway_meta = agent_meta if isinstance(agent_meta, dict) else {}
+                    elif resp is not None and hasattr(resp, "cortex_result") and resp.cortex_result:
                         gateway_meta = resp.cortex_result.metadata or {}
 
                     # Include trace_verb in spark_meta for the Visualizer
@@ -1608,8 +1640,16 @@ async def websocket_endpoint(websocket: WebSocket):
                 # Publish assistant reply into chat history
                 try:
                     gateway_meta = {}
-                    if hasattr(resp, "cortex_result") and resp.cortex_result:
+                    if used_agent_claude_lane:
+                        agent_meta = route_debug.get("agent_claude") if isinstance(route_debug, dict) else {}
+                        gateway_meta = agent_meta if isinstance(agent_meta, dict) else {}
+                    elif resp is not None and hasattr(resp, "cortex_result") and resp.cortex_result:
                         gateway_meta = resp.cortex_result.metadata or {}
+                    history_correlation_id = trace_id
+                    if resp is not None and hasattr(resp, "cortex_result") and resp.cortex_result:
+                        history_correlation_id = (
+                            getattr(resp.cortex_result, "correlation_id", None) or trace_id
+                        )
                     selected_reasoning_trace, _ = select_reasoning_trace_for_history(
                         correlation_id=trace_id,
                         reasoning_trace=explicit_reasoning_trace,
@@ -1617,17 +1657,23 @@ async def websocket_endpoint(websocket: WebSocket):
                         reasoning_content=reasoning_content,
                         session_id=publish_session_id,
                         message_id=f"{trace_id}:assistant",
-                        model=((gateway_meta or {}).get("model") if isinstance(gateway_meta, dict) else None),
+                        model=((gateway_meta or {}).get("model") if isinstance(gateway_meta, dict) else None)
+                        or (
+                            route_debug.get("agent_claude", {}).get("fcc_model_label")
+                            if isinstance(route_debug, dict)
+                            and isinstance(route_debug.get("agent_claude"), dict)
+                            else None
+                        ),
                     )
                     assistant_env = build_chat_history_envelope(
                         content=orion_response_text,
                         role="assistant",
                         session_id=publish_session_id,
-                        correlation_id=getattr(resp.cortex_result, "correlation_id", None) or trace_id,
+                        correlation_id=history_correlation_id,
                         speaker=gateway_meta.get("speaker") or settings.SERVICE_NAME,
-                        model=gateway_meta.get("model"),
+                        model=gateway_meta.get("model") or gateway_meta.get("fcc_model_label"),
                         provider=gateway_meta.get("provider"),
-                        tags=[mode, trace_verb],
+                        tags=[client_mode if used_agent_claude_lane else mode, trace_verb],
                         message_id=f"{trace_id}:assistant",
                         memory_status="accepted",
                         memory_tier="ephemeral",

--- a/services/orion-hub/static/js/agent-claude-trace.js
+++ b/services/orion-hub/static/js/agent-claude-trace.js
@@ -1,10 +1,124 @@
 (function (global) {
   const _liveClaudeSteps = new Map();
   const LIVE_ANCHOR_ID = 'conversation';
+  const PREVIEW_MAX = 240;
 
   function resolveAnchor(doc) {
     const root = doc || (typeof document !== 'undefined' ? document : null);
     return root && root.getElementById ? root.getElementById(LIVE_ANCHOR_ID) : null;
+  }
+
+  function clip(text, maxLen) {
+    const limit = Number.isFinite(maxLen) ? maxLen : PREVIEW_MAX;
+    const value = String(text || '').replace(/\s+/g, ' ').trim();
+    if (!value) return '';
+    return value.length <= limit ? value : `${value.slice(0, limit - 1)}…`;
+  }
+
+  function basename(path) {
+    const raw = String(path || '').trim();
+    if (!raw) return '';
+    const parts = raw.split(/[/\\]/);
+    return parts[parts.length - 1] || raw;
+  }
+
+  function formatToolInput(name, input) {
+    const tool = String(name || 'tool').trim() || 'tool';
+    const args = input && typeof input === 'object' ? input : {};
+    if (tool === 'Read' || tool === 'Write' || tool === 'Edit') {
+      const path = args.file_path || args.path || args.notebook_path;
+      return path ? `${tool} ${basename(path)}` : tool;
+    }
+    if (tool === 'Glob') {
+      return args.pattern ? `Glob ${clip(args.pattern, 80)}` : 'Glob';
+    }
+    if (tool === 'Grep') {
+      const bits = [];
+      if (args.pattern) bits.push(`"${clip(args.pattern, 60)}"`);
+      if (args.path) bits.push(`in ${basename(args.path)}`);
+      return bits.length ? `Grep ${bits.join(' ')}` : 'Grep';
+    }
+    if (tool === 'Bash') {
+      const cmd = args.command || args.cmd || args.script;
+      return cmd ? `Bash ${clip(cmd, 120)}` : 'Bash';
+    }
+    if (tool === 'Task') {
+      return args.description ? `Task ${clip(args.description, 100)}` : 'Task';
+    }
+    const firstKey = Object.keys(args)[0];
+    if (firstKey) {
+      return `${tool} ${clip(String(args[firstKey]), 100)}`;
+    }
+    return tool;
+  }
+
+  function summarizeContentBlocks(content) {
+    if (!Array.isArray(content)) return '';
+    const parts = [];
+    content.forEach((block) => {
+      if (!block || typeof block !== 'object') return;
+      const blockType = String(block.type || '').trim();
+      if (blockType === 'text' && block.text) {
+        parts.push(clip(block.text));
+        return;
+      }
+      if (blockType === 'tool_use') {
+        parts.push(formatToolInput(block.name, block.input));
+        return;
+      }
+      if (blockType === 'tool_result') {
+        const body = typeof block.content === 'string'
+          ? block.content
+          : Array.isArray(block.content)
+            ? block.content.filter((b) => b && b.type === 'text').map((b) => b.text).join('\n')
+            : '';
+        const size = body ? ` (${body.length} chars)` : '';
+        parts.push(`tool result${size}${body ? `: ${clip(body, 120)}` : ''}`);
+      }
+    });
+    return parts.filter(Boolean).join(' | ');
+  }
+
+  function summarizeStep(step) {
+    if (!step || typeof step !== 'object') return 'step';
+    const raw = step.raw && typeof step.raw === 'object' ? step.raw : step;
+    const type = String(step.type || raw.type || 'event').trim() || 'event';
+
+    if (type === 'assistant') {
+      const msg = raw.message && typeof raw.message === 'object' ? raw.message : raw;
+      const summary = summarizeContentBlocks(msg.content);
+      if (summary) return summary;
+      return 'assistant';
+    }
+
+    if (type === 'user') {
+      const msg = raw.message && typeof raw.message === 'object' ? raw.message : raw;
+      const summary = summarizeContentBlocks(msg.content);
+      if (summary) return summary;
+      const text = typeof msg.content === 'string' ? msg.content : raw.content;
+      if (text) return clip(text);
+      return 'user';
+    }
+
+    if (type === 'system') {
+      const subtype = raw.subtype || raw.system_subtype;
+      return subtype ? `system ${subtype}` : 'system';
+    }
+
+    if (type === 'tool_use') {
+      return formatToolInput(raw.name, raw.input);
+    }
+
+    if (type === 'tool_result') {
+      const body = typeof raw.content === 'string' ? raw.content : '';
+      return body ? `tool result: ${clip(body, 160)}` : 'tool result';
+    }
+
+    if (type === 'result') {
+      return clip(String(raw.result || 'result'), PREVIEW_MAX) || 'result';
+    }
+
+    return type;
   }
 
   function ensurePanel(correlationId, doc) {
@@ -27,21 +141,6 @@
     return panel;
   }
 
-  function summarizeStep(step) {
-    if (!step || typeof step !== 'object') return 'step';
-    const raw = step.raw && typeof step.raw === 'object' ? step.raw : step;
-    const type = String(step.type || raw.type || 'event');
-    if (type === 'assistant') {
-      const msg = raw.message && raw.message.content;
-      if (Array.isArray(msg)) {
-        const text = msg.filter((b) => b && b.type === 'text').map((b) => b.text).join('');
-        if (text) return text.slice(0, 240);
-      }
-    }
-    if (type === 'result') return String(raw.result || 'result').slice(0, 240);
-    return type;
-  }
-
   function appendLiveClaudeStep(correlationId, step, doc) {
     if (!correlationId || !step) return;
     const list = _liveClaudeSteps.get(correlationId) || [];
@@ -59,5 +158,5 @@
   }
 
   global.appendLiveClaudeStep = appendLiveClaudeStep;
-  global.OrionClaudeTrace = { appendLiveClaudeStep };
+  global.OrionClaudeTrace = { appendLiveClaudeStep, summarizeStep };
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -9372,9 +9372,24 @@ loadDismissedIds();
     quick: { mode: 'brain', verb: 'chat_quick', lane: 'quick', label: 'Quick' },
     story: { mode: 'brain', verb: 'chat_kids_story', lane: null, label: 'Story' },
     agent: { mode: 'agent', verb: null, lane: null, label: 'Agent' },
-    agent_claude: { mode: 'agent-claude', verb: null, lane: null, label: 'Agent Claude', skipComputeConfirm: true },
+    agent_claude_opus: { mode: 'agent-claude', fccModelLabel: 'MODEL_OPUS', verb: null, lane: null, label: 'Agent Claude - Opus', skipComputeConfirm: true },
+    agent_claude_sonnet: { mode: 'agent-claude', fccModelLabel: 'MODEL_SONNET', verb: null, lane: null, label: 'Agent Claude - Sonnet', skipComputeConfirm: true },
+    agent_claude_haiku: { mode: 'agent-claude', fccModelLabel: 'MODEL_HAIKU', verb: null, lane: null, label: 'Agent Claude - Haiku', skipComputeConfirm: true },
     council: { mode: 'council', verb: null, lane: null, label: 'Council' },
   };
+
+  function hubModeSpec(modeKey) {
+    const key = String(modeKey || hubModeSelect?.value || 'grounded_small').trim().toLowerCase();
+    return HUB_MODE_SPECS[key] || HUB_MODE_SPECS.grounded_small;
+  }
+
+  function applyAgentClaudePayloadFields(payload) {
+    const spec = hubModeSpec();
+    if (spec.mode !== 'agent-claude') return;
+    payload.fcc_model_label = spec.fccModelLabel || 'MODEL_SONNET';
+    payload.use_recall = false;
+    payload.llm_route = null;
+  }
 
   function applyHubModeSelection(modeKey, { silent = false } = {}) {
     const key = String(modeKey || 'grounded_small').trim().toLowerCase();
@@ -9395,10 +9410,6 @@ loadDismissedIds();
     }
     if (!silent) {
       updateStatus(`Mode: ${spec.label}`);
-    }
-    const fccRow = document.getElementById('hubFccModelRow');
-    if (fccRow) {
-      fccRow.classList.toggle('hidden', key !== 'agent_claude');
     }
   }
 
@@ -9507,42 +9518,6 @@ loadDismissedIds();
       loadLlmRouteCatalog();
     }, 30000);
   }
-
-  let fccModelLabels = [];
-  let fccDefaultLabel = null;
-  let agentClaudeEnabled = false;
-
-  async function loadFccModelLabels() {
-    const opt = document.getElementById('hubModeAgentClaudeOption');
-    const row = document.getElementById('hubFccModelRow');
-    const sel = document.getElementById('hubFccModelSelect');
-    try {
-      const r = await fetch(`${API_BASE_URL}/api/fcc-model-labels`);
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const body = await r.json();
-      agentClaudeEnabled = Boolean(body.enabled);
-      fccModelLabels = Array.isArray(body.labels) ? body.labels : [];
-      fccDefaultLabel = body.default_label || fccModelLabels[0] || null;
-      if (opt) opt.hidden = !agentClaudeEnabled;
-      if (sel) {
-        sel.innerHTML = '';
-        fccModelLabels.forEach((label) => {
-          const o = document.createElement('option');
-          o.value = label;
-          o.textContent = label;
-          sel.appendChild(o);
-        });
-        if (fccDefaultLabel) sel.value = fccDefaultLabel;
-      }
-      if (row && hubModeSelect && hubModeSelect.value === 'agent_claude') {
-        row.classList.remove('hidden');
-      }
-    } catch (err) {
-      console.warn('fcc model labels load failed', err);
-      if (opt) opt.hidden = true;
-    }
-  }
-  loadFccModelLabels();
 
   // --- 4. Logic Functions ---
 
@@ -10811,7 +10786,7 @@ loadDismissedIds();
     const requestModePreview = forceAgentPath
       ? 'agent'
       : (opts && opts.mode ? String(opts.mode) : currentMode);
-    const skipCompute = requestModePreview === 'agent-claude' || (HUB_MODE_SPECS[hubModeSelect?.value]?.skipComputeConfirm);
+    const skipCompute = Boolean(hubModeSpec().skipComputeConfirm);
     if (!(opts && opts.skipRouteDownCheck) && !skipCompute) {
       const confirmedRoute = await confirmDownRouteOrProceed(effectiveRoute);
       if (confirmedRoute === null) {
@@ -10872,12 +10847,7 @@ loadDismissedIds();
     if (!omitChatUiMode) {
       payload.mode = requestMode;
     }
-    if (requestMode === 'agent-claude') {
-      const fccSel = document.getElementById('hubFccModelSelect');
-      payload.fcc_model_label = (fccSel && fccSel.value) ? fccSel.value : (fccDefaultLabel || 'MODEL');
-      payload.use_recall = false;
-      payload.llm_route = null;
-    }
+    applyAgentClaudePayloadFields(payload);
     const optFromOpts = opts && opts.options && typeof opts.options === 'object' ? { ...opts.options } : {};
     if (isChatQuickSend) {
       payload.options = { ...optFromOpts, chat_quick_full_stance: chatQuickVariant === 'stance' };
@@ -11193,7 +11163,7 @@ loadDismissedIds();
     if (audioMeta.client_gate === 'low_peak_warn') {
       updateStatus('Low mic level, sending anyway...');
     }
-    const voiceRouteSkipCompute = currentMode === 'agent-claude' || (HUB_MODE_SPECS[hubModeSelect?.value]?.skipComputeConfirm);
+    const voiceRouteSkipCompute = Boolean(hubModeSpec().skipComputeConfirm);
     const voiceRoute = voiceRouteSkipCompute
       ? (selectedLlmRoute || HUB_COMPUTE_DEFAULT)
       : await confirmDownRouteOrProceed(
@@ -11236,12 +11206,7 @@ loadDismissedIds();
             ? socialRedactionPostureSelect.value
             : null,
         };
-        if (currentMode === 'agent-claude') {
-          const fccSel = document.getElementById('hubFccModelSelect');
-          audioPayload.fcc_model_label = (fccSel && fccSel.value) ? fccSel.value : (fccDefaultLabel || 'MODEL');
-          audioPayload.use_recall = false;
-          audioPayload.llm_route = null;
-        }
+        applyAgentClaudePayloadFields(audioPayload);
         const audioLaneVerbs = modeVerbOverride ? [modeVerbOverride] : selectedVerbs;
         const audioIsChatQuick =
           Array.isArray(audioLaneVerbs) &&

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -248,7 +248,7 @@
               <option value="quick">Quick</option>
               <option value="story">Story</option>
               <option value="agent">Agent</option>
-              <option value="agent_claude" id="hubModeAgentClaudeOption" hidden>Agent Claude</option>
+              {{HUB_AGENT_CLAUDE_MODE_OPTIONS}}
               <option value="council">Council</option>
             </select>
           </div>
@@ -261,17 +261,6 @@
               title="GPU/model lane (llm_route): chat, quick, agent, metacog. Still applies when Social room is ON."
             >
               <option value="quick">quick — loading…</option>
-            </select>
-          </div>
-          <div id="hubFccModelRow" class="flex items-center gap-2 pt-1 border-t border-gray-700/80 hidden">
-            <label for="hubFccModelSelect" class="uppercase text-gray-500 font-bold text-[10px] shrink-0">FCC Model</label>
-            <select
-              id="hubFccModelSelect"
-              class="flex-1 min-w-0 bg-gray-900/80 text-gray-100 text-xs rounded border border-gray-700 px-2 py-1.5 focus:outline-none focus:border-indigo-500 font-mono"
-              aria-label="FCC model env label"
-              title="FCC ~/.fcc/.env key label (MODEL, MODEL_HAIKU, …)"
-            >
-              <option value="">loading…</option>
             </select>
           </div>
           <div class="flex items-center gap-3 pt-1 border-t border-gray-700/80">

--- a/services/orion-hub/tests/test_agent_claude_chat_history.py
+++ b/services/orion-hub/tests/test_agent_claude_chat_history.py
@@ -1,0 +1,41 @@
+"""Agent-claude harness steps must land in chat history thought_process seam."""
+
+from scripts.fcc_claude_bridge import (
+    build_harness_reasoning_trace,
+    summarize_harness_steps_for_history,
+)
+
+
+def test_summarize_harness_steps_for_history_includes_assistant_lines() -> None:
+    steps = [
+        {"type": "system", "raw": {"type": "system"}},
+        {
+            "type": "assistant",
+            "raw": {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "Checking repo layout."}]},
+            },
+        },
+        {"type": "result", "raw": {"type": "result", "result": "done"}},
+    ]
+    text = summarize_harness_steps_for_history(steps)
+    assert "[0] system" in text
+    assert "assistant: Checking repo layout." in text
+    assert "[2] result: done" in text
+
+
+def test_build_harness_reasoning_trace_shape_for_sql_writer() -> None:
+    trace = build_harness_reasoning_trace(
+        steps=[{"type": "system", "raw": {"type": "system"}}],
+        correlation_id="corr-1",
+        session_id="sess-1",
+        model_label="MODEL_HAIKU",
+    )
+    assert trace is not None
+    assert trace["trace_role"] == "reasoning"
+    assert trace["metadata"]["source"] == "agent_claude_harness"
+    assert trace["content"] == "[0] system"
+
+
+def test_build_harness_reasoning_trace_empty_when_no_steps() -> None:
+    assert build_harness_reasoning_trace(steps=[], correlation_id="x") is None

--- a/services/orion-hub/tests/test_agent_claude_input.py
+++ b/services/orion-hub/tests/test_agent_claude_input.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from scripts.agent_claude_input import TurnRequest, prepare_agent_claude_input
+from scripts.agent_claude_input import AGENT_CLAUDE_OPERATOR_BRIEF, TurnRequest, prepare_agent_claude_input
 
 
-def test_v1_pass_through_prompt() -> None:
+def test_operator_brief_prepended_to_prompt() -> None:
     result = prepare_agent_claude_input("  explain websocket_handler  ")
     assert isinstance(result, TurnRequest)
-    assert result.prompt == "explain websocket_handler"
+    assert "explain websocket_handler" in result.prompt
+    assert AGENT_CLAUDE_OPERATOR_BRIEF.strip() in result.prompt
+    assert "Operator request:" in result.prompt
 
 
 def test_v1_empty_becomes_empty_string() -> None:

--- a/services/orion-hub/tests/test_agent_claude_trace_js.py
+++ b/services/orion-hub/tests/test_agent_claude_trace_js.py
@@ -1,0 +1,19 @@
+"""Gate: agent-claude live trace panel summarizes tool/file steps."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TRACE_JS = REPO_ROOT / "services" / "orion-hub" / "static" / "js" / "agent-claude-trace.js"
+
+
+def test_agent_claude_trace_summarizes_tool_use_and_results() -> None:
+    source = TRACE_JS.read_text(encoding="utf-8")
+    assert "function formatToolInput(name, input)" in source
+    assert "function summarizeContentBlocks(content)" in source
+    assert "tool result" in source
+    assert "OrionClaudeTrace = { appendLiveClaudeStep, summarizeStep }" in source
+    assert "basename(path)" in source
+    assert "Grep" in source
+    assert "Bash" in source

--- a/services/orion-hub/tests/test_fcc_claude_bridge_run.py
+++ b/services/orion-hub/tests/test_fcc_claude_bridge_run.py
@@ -69,6 +69,88 @@ async def test_run_turn_yields_steps_and_final(monkeypatch: pytest.MonkeyPatch) 
 
 
 @pytest.mark.asyncio
+async def test_run_turn_passes_stream_read_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProc:
+        captured.update(kwargs)
+        return _FakeProc([])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(bridge, "_preflight_fcc_server", lambda *a, **k: None)
+
+    async for _ in bridge.run_turn(
+        prompt="hello",
+        fcc_model_label="MODEL_HAIKU",
+        correlation_id="corr-limit",
+        workspace="/tmp",
+        fcc_server_url="http://127.0.0.1:8082",
+        auth_token="tok",
+        claude_bin="claude",
+        timeout_sec=30.0,
+    ):
+        pass
+
+    assert captured.get("limit") == bridge.DEFAULT_STREAM_READ_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_run_turn_limit_overrun_returns_partial(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _OverrunStream:
+        async def readline(self) -> bytes:
+            raise asyncio.LimitOverrunError("Separator is not found, and chunk exceed the limit", 70000)
+
+    class _OverrunProc:
+        stdout = _OverrunStream()
+
+        def kill(self) -> None:
+            return None
+
+        async def wait(self) -> int:
+            return -9
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> _OverrunProc:
+        return _OverrunProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(bridge, "_preflight_fcc_server", lambda *a, **k: None)
+
+    events = []
+    async for ev in bridge.run_turn(
+        prompt="big file",
+        fcc_model_label="MODEL_HAIKU",
+        correlation_id="corr-overrun",
+        workspace="/tmp",
+        fcc_server_url="http://127.0.0.1:8082",
+        auth_token="tok",
+        claude_bin="claude",
+        timeout_sec=30.0,
+    ):
+        events.append(ev)
+
+    assert len(events) == 1
+    assert events[0]["type"] == "error"
+    assert events[0]["error_code"] == "fcc_claude_stream_line_limit"
+
+
+@pytest.mark.asyncio
+async def test_build_subprocess_env_sets_claude_context_limits(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import settings as hub_settings
+
+    monkeypatch.setattr(hub_settings.settings, "HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS", 65536, raising=False)
+    monkeypatch.setattr(hub_settings.settings, "HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS", 8192, raising=False)
+    env = bridge._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "65536"
+    assert env["CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS"] == "8192"
+
+
+def test_is_context_overflow_text_detects_llamacpp_error() -> None:
+    sample = 'exceed_context_size_error n_ctx":65536'
+    assert bridge.is_context_overflow_text(sample) is True
+    assert bridge.is_context_overflow_text("all good") is False
+
+
+@pytest.mark.asyncio
 async def test_cancel_turn_sigterms_active(monkeypatch: pytest.MonkeyPatch) -> None:
     proc = _FakeProc([], returncode=-15)
 

--- a/services/orion-hub/tests/test_http_agent_claude.py
+++ b/services/orion-hub/tests/test_http_agent_claude.py
@@ -23,4 +23,4 @@ async def test_http_agent_claude_collects_events(monkeypatch: pytest.MonkeyPatch
     )
     assert result["llm_response"] == "HTTP done."
     assert len(result["claude_steps"]) == 1
-    assert prepare_agent_claude_input("x").prompt == "x"
+    assert "hello" in prepare_agent_claude_input("hello").prompt


### PR DESCRIPTION
Branch is pushed; `gh auth login` isn’t configured here so the PR wasn’t created automatically.

**Branch:** `fix/hub-agent-claude-production-hardening`  
**Commit:** `4eea41fe`  
**Create PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/hub-agent-claude-production-hardening

---

## PR title

`fix(hub): agent-claude production hardening (Docker, ctx, history, UI)`

---

## PR description (paste into GitHub)

## Summary

Follow-up to #812 (`feat/hub-agent-claude`). Makes Agent Claude mode work on the live Docker Hub stack and survive long repo-exploration turns without silent mis-routing, chat-history crashes, or opaque asyncio/gateway failures.

- Fix WebSocket routing: branch on `client_mode == agent-claude` before `chat_req.mode` is normalized to `brain`
- Replace FCC model dropdown with **Agent Claude - Opus / Sonnet / Haiku** mode options; tier maps to `fcc_model_label` on the payload
- Docker compose: mount `claude` binary, `~/.fcc`, `~/.claude.json`, repo at `/mnt/scripts/Orion-Sapienform`; skip `--dangerously-skip-permissions` when running as root
- Bridge: 8 MiB stdout `readline` limit (fixes `LimitOverrunError` on large stream-json lines); catch overrun with `fcc_claude_stream_line_limit`
- Bridge: pass `CLAUDE_CODE_MAX_CONTEXT_TOKENS` + `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS` into claude subprocess (65536 / 8192 defaults)
- Operator brief in `prepare_agent_claude_input`: grep-first, Read offset/limit for large YAML
- Chat history: fix assistant publish when `resp is None` on harness lane; wire harness steps → `reasoning_trace.content` → sql-writer `thought_process`
- Live panel: summarize tool names, paths, bash commands, truncated tool results (not bare `system`/`assistant` labels)
- Context overflow detection: append Hub operator hint + `route_debug.agent_claude.context_overflow`

## Outcome moved

Agent-claude turns on `orion_journal` now route through the FCC harness (verified: palindrome LeetCode answer in ~2m; collapse-mirror sweeps stream 130+ steps without Hub crash). Failures surface as actionable gateway/ctx messages instead of brain/cortex mis-routes or `NoneType.cortex_result` history errors.

## Current architecture

#812 shipped the thin subprocess bridge + stream-json WS frames. Production Docker still logged `mode=brain`, skipped harness on WS turns, lacked mounts for `claude`/`~/.fcc`, and chat history assumed cortex `resp`. Long turns hit 64 KiB asyncio read limits and 64k llamacpp ctx with full-file reads.

## Architecture touched

- `services/orion-hub` only (settings, bridge, websocket_handler, api_routes, UI, docker-compose, tests, README)

## Files changed

- `websocket_handler.py`: `client_mode` routing, harness thought trace, safe assistant history publish, overflow hint
- `fcc_claude_bridge.py`: stream read limit, ctx/read env injection, harness step summarizers, overflow helpers
- `agent_claude_input.py`: repo-exploration operator brief
- `api_routes.py`: HTTP harness reasoning_trace parity
- `app/settings.py` + `.env_example` + `docker-compose.yml`: new env keys
- `app.js` / `main.py` / `index.html`: tier modes, no FCC dropdown
- `agent-claude-trace.js`: rich step labels
- Tests: bridge overrun, chat history trace shape, trace JS gate, input brief

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: WS/HTTP agent-claude turns publish assistant chat history + turn-level `reasoning_trace` with harness step transcript
- Compatibility notes: `_normalize_mode` still logs `brain` for agent-claude in ingress logs; use `client_mode` / `route_debug.agent_claude` for truth

## Env/config changes

- Added keys:
  - `HUB_AGENT_CLAUDE_STREAM_READ_LIMIT` (default 8388608)
  - `HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS` (default 65536)
  - `HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS` (default 8192)
- `.env_example` updated: yes
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: yes
- skipped keys requiring operator action: none

## Tests run

```text
PYTHONPATH=services/orion-hub:. pytest \
  services/orion-hub/tests/test_agent_claude_input.py \
  services/orion-hub/tests/test_agent_claude_chat_history.py \
  services/orion-hub/tests/test_agent_claude_trace_js.py \
  services/orion-hub/tests/test_fcc_claude_bridge_run.py \
  services/orion-hub/tests/test_http_agent_claude.py \
  services/orion-hub/tests/test_websocket_agent_claude_routing.py \
  services/orion-hub/tests/test_fcc_model_label_mapping.py \
  services/orion-hub/tests/test_reasoning_trace_selection.py -q
# 22 passed
```

## Evals run

```text
No agent-claude eval harness beyond live smoke script (verify_agent_claude_stream_live.py).
Manual smoke + production journal turns used as runtime evidence.
```

## Docker/build/smoke checks

```text
docker compose --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build hub-app
# Verified: harness steps stream, palindrome turn completes, collapse-mirror turn streams 130+ steps
# (ctx overflow at ~74k/65536 on llamacpp/chat — expected without ctx bump)
```

## Review findings fixed

- Finding: WS `mode = chat_req.mode` overwrote agent-claude before harness branch  
  - Fix: capture `client_mode` early; branch harness on that  
  - Evidence: no cortex RPC on agent-claude corr ids; subprocess runs in logs

- Finding: assistant chat history dereferenced `resp.cortex_result` when `resp is None`  
  - Fix: use `trace_id` + agent metadata on harness lane  
  - Evidence: `Failed to publish assistant chat history` warning eliminated on smoke turns

- Finding: 64 KiB asyncio readline limit on stream-json  
  - Fix: `limit=8MiB` on subprocess + `LimitOverrunError` handler  
  - Evidence: `test_run_turn_limit_overrun_returns_partial`; collapse-mirror turn reached step 136 without Hub crash

## Restart required

```bash
docker compose --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build hub-app
```

Hard-refresh Hub UI after deploy.

## Risks / concerns

- Severity: medium
- Concern: llamacpp `ctx_size: 65536` still caps multi-step repo sweeps (~74k tokens observed after read cap). Operator must raise ctx, route `~/.fcc/.env` to larger backend, or scope prompts.
- Mitigation: read cap + operator brief + overflow hint; documented in README

---

## Status: DONE (pending PR open)

Run `gh auth login` locally, then:

```bash
gh pr create --base main \
  --head fix/hub-agent-claude-production-hardening \
  --title "fix(hub): agent-claude production hardening (Docker, ctx, history, UI)" \
  --body-file /path/to/above.md
```

Or use the “Create PR” link above and paste the description.