### PR TITLE
fix(recall): window RDF chat-turn recall to the profile time window

### DIFF
--- a/services/orion-recall/.env_example
+++ b/services/orion-recall/.env_example
@@ -55,6 +55,12 @@ RECALL_SQL_CHAT_TABLE=chat_history_log
 RECALL_SQL_CHAT_TEXT_COL=prompt
 RECALL_SQL_CHAT_RESPONSE_COL=response
 RECALL_SQL_CHAT_CREATED_AT_COL=created_at
+RECALL_SQL_CHAT_ID_COL=id
+# RDF chat-turn recall carries no usable graph timestamp, so it ignored the per-profile
+# time window and surfaced months-old turns into reflective recall. When true, RDF chat-turn
+# candidates are joined back to chat_history_log and dropped when older than the profile's
+# sql_since_minutes (same window the SQL chat/timeline backends already honor).
+RECALL_RDF_CHAT_WINDOW_ENABLED=true
 
 # Collapse Mirror base + semantics
 RECALL_SQL_MIRROR_TABLE=collapse_mirror

--- a/services/orion-recall/app/settings.py
+++ b/services/orion-recall/app/settings.py
@@ -91,6 +91,17 @@ class Settings(BaseSettings):
     RECALL_SQL_CHAT_CREATED_AT_COL: str = Field(
         default="created_at", validation_alias=AliasChoices("RECALL_SQL_CHAT_CREATED_AT_COL")
     )
+    RECALL_SQL_CHAT_ID_COL: str = Field(
+        default="id", validation_alias=AliasChoices("RECALL_SQL_CHAT_ID_COL")
+    )
+    # RDF chat-turn recall carries no usable graph timestamp (turns are written without one),
+    # so it ignored the per-profile time window and surfaced months-old turns into reflective
+    # recall. When enabled, RDF chat-turn candidates are joined back to chat_history_log and
+    # dropped when older than the profile's sql_since_minutes (giving them the same window the
+    # SQL chat/timeline backends already honor).
+    RECALL_RDF_CHAT_WINDOW_ENABLED: bool = Field(
+        default=True, validation_alias=AliasChoices("RECALL_RDF_CHAT_WINDOW_ENABLED")
+    )
 
     # Collapse mirror base + semantic fields
     RECALL_SQL_MIRROR_TABLE: str = Field(default="collapse_mirror", validation_alias=AliasChoices("RECALL_SQL_MIRROR_TABLE"))

--- a/services/orion-recall/app/sql_chat.py
+++ b/services/orion-recall/app/sql_chat.py
@@ -40,6 +40,47 @@ def _to_epoch(value: Any) -> float:
         return 0.0
 
 
+async def fetch_chat_turn_timestamps(
+    turn_ids: List[str],
+    since_minutes: int,
+) -> Dict[str, float]:
+    """Resolve created_at (epoch) for chat turns by id, bounded to the last ``since_minutes``.
+
+    Used to window RDF chat-turn recall, which carries no usable timestamp in the graph
+    (turns are joined back to ``chat_history_log`` on the turn id). Ids outside the window,
+    or not present in the chat table, are simply absent from the returned map so callers can
+    drop them.
+    """
+    if asyncpg is None:
+        return {}
+    ids = [str(t).strip() for t in (turn_ids or []) if str(t).strip()]
+    if not ids:
+        return {}
+    id_col = settings.RECALL_SQL_CHAT_ID_COL
+    query = f"""
+        SELECT {id_col} AS id,
+               {settings.RECALL_SQL_CHAT_CREATED_AT_COL} AS created_at
+        FROM {settings.RECALL_SQL_CHAT_TABLE}
+        WHERE {id_col} = ANY($1::text[])
+          AND {settings.RECALL_SQL_CHAT_CREATED_AT_COL} >= NOW() - INTERVAL '{int(since_minutes)} minutes'
+    """
+    try:
+        conn = await asyncpg.connect(settings.RECALL_PG_DSN)
+        try:
+            rows = await conn.fetch(query, ids)
+        finally:
+            await conn.close()
+    except Exception:
+        return {}
+
+    out: Dict[str, float] = {}
+    for row in rows:
+        rid = str(row.get("id") or "").strip()
+        if rid:
+            out[rid] = _to_epoch(row.get("created_at"))
+    return out
+
+
 def _normalize_text(value: Any) -> str:
     text = str(value or "").strip().lower()
     return " ".join(text.split())

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import re
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 try:
@@ -37,7 +37,7 @@ try:
         fetch_rdf_chatturn_exact_matches,
     )
     from .sql_timeline import fetch_recent_fragments, fetch_related_by_entities, fetch_exact_fragments
-    from .sql_chat import fetch_chat_history_pairs, fetch_chat_messages
+    from .sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps
     from .cards_adapter import fetch_card_fragments_guarded
     try:
         from .storage.graph_compression_adapter import fetch_graph_compression_fragments
@@ -63,7 +63,7 @@ except ImportError as _e:  # pragma: no cover - fallback for runtime pathing
             fetch_rdf_chatturn_exact_matches,
         )
         from app.sql_timeline import fetch_recent_fragments, fetch_related_by_entities, fetch_exact_fragments  # type: ignore
-        from app.sql_chat import fetch_chat_history_pairs, fetch_chat_messages  # type: ignore
+        from app.sql_chat import fetch_chat_history_pairs, fetch_chat_messages, fetch_chat_turn_timestamps  # type: ignore
         from app.cards_adapter import fetch_card_fragments_guarded  # type: ignore
         try:
             from app.storage.graph_compression_adapter import fetch_graph_compression_fragments  # type: ignore
@@ -545,6 +545,81 @@ def _sql_chat_enabled_for_profile(profile: Dict[str, Any]) -> bool:
     profile_name = str(profile.get("profile") or "")
     default_enabled = not profile_name.startswith("chat.general")
     return bool(profile.get("enable_sql_chat", default_enabled))
+
+
+_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+
+def _is_rdf_chatturn(frag: Dict[str, Any]) -> bool:
+    if "chatturn" in {str(t).lower() for t in (frag.get("tags") or [])}:
+        return True
+    ref = str(frag.get("uri") or frag.get("id") or "")
+    return "/chatTurn/" in ref
+
+
+def _chatturn_id_from_fragment(frag: Dict[str, Any]) -> Optional[str]:
+    """Recover the chat_history_log id from an RDF chat-turn fragment.
+
+    RDF turn IRIs look like ``.../chatTurn/<uuid-with-underscores>`` because the writer
+    sanitizes ``-`` to ``_``. Reverse that and validate the UUID shape so we only join
+    ids we can trust.
+    """
+    ref = str(frag.get("uri") or frag.get("id") or "")
+    if "/chatTurn/" not in ref:
+        return None
+    tail = ref.rsplit("/chatTurn/", 1)[-1].strip()
+    if not tail:
+        return None
+    candidate = tail.replace("_", "-")
+    return candidate if _UUID_RE.match(candidate) else None
+
+
+async def _window_rdf_chatturn_candidates(
+    candidates: List[Dict[str, Any]],
+    *,
+    since_minutes: int,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Drop RDF chat-turn candidates older than ``since_minutes``, stamping real timestamps.
+
+    The graph stores no usable ChatTurn timestamp, so these rails otherwise leak months-old
+    turns into reflective recall regardless of the profile window. We resolve each turn's
+    created_at from chat_history_log and keep only those inside the window. Non chat-turn
+    candidates (SQL, cards, RDF claims, etc.) are returned untouched. Memory cards are never
+    touched here.
+    """
+    if since_minutes <= 0:
+        return candidates, 0
+    turn_ids: Dict[int, str] = {}
+    for idx, frag in enumerate(candidates):
+        if not _is_rdf_chatturn(frag):
+            continue
+        cid = _chatturn_id_from_fragment(frag)
+        if cid is not None:
+            turn_ids[idx] = cid
+    if not turn_ids:
+        return candidates, 0
+
+    try:
+        ts_map = await fetch_chat_turn_timestamps(list(set(turn_ids.values())), since_minutes)
+    except Exception as exc:  # pragma: no cover - defensive; never fail recall on this
+        logger.debug("rdf chat-turn windowing skipped: %s", exc)
+        return candidates, 0
+
+    kept: List[Dict[str, Any]] = []
+    dropped = 0
+    for idx, frag in enumerate(candidates):
+        if idx not in turn_ids:
+            kept.append(frag)
+            continue
+        ts = ts_map.get(turn_ids[idx])
+        if ts is None:
+            # Outside the window or not resolvable to a chat row → drop from reflective recall.
+            dropped += 1
+            continue
+        frag = dict(frag)
+        frag["ts"] = ts
+        kept.append(frag)
+    return kept, dropped
 
 
 async def _fetch_anchor_candidates(
@@ -1362,6 +1437,24 @@ async def process_recall(
             backend_counts_total["memory_graph_sparql"] = len(mg_extra)
         except Exception as exc:
             logger.debug("memory_graph_sparql augment skipped: %s", exc)
+
+    if settings.RECALL_RDF_CHAT_WINDOW_ENABLED:
+        rdf_chat_window_min = int(
+            profile.get("rdf_chat_since_minutes")
+            or profile.get("sql_since_minutes")
+            or settings.RECALL_SQL_SINCE_MINUTES
+        )
+        candidates, rdf_chat_dropped = await _window_rdf_chatturn_candidates(
+            candidates, since_minutes=rdf_chat_window_min
+        )
+        if rdf_chat_dropped:
+            backend_counts_total["rdf_chat_out_of_window_dropped"] = rdf_chat_dropped
+            logger.info(
+                "rdf chat-turn windowing profile=%s window_min=%s dropped=%s",
+                profile.get("profile"),
+                rdf_chat_window_min,
+                rdf_chat_dropped,
+            )
 
     suppression_start = time.time()
     candidates, suppressed = _suppress_self_hits(

--- a/services/orion-recall/tests/test_rdf_chatturn_windowing.py
+++ b/services/orion-recall/tests/test_rdf_chatturn_windowing.py
@@ -1,0 +1,89 @@
+"""RDF chat-turn recall must honor the profile time window.
+
+The graph stores no usable ChatTurn timestamp, so these rails otherwise leak months-old
+turns into reflective recall. worker resolves each turn's created_at from chat_history_log
+and drops turns outside the window. Memory cards / SQL / RDF-claim candidates are untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from app import worker
+
+
+def test_chatturn_id_from_fragment_reverses_sanitized_uuid() -> None:
+    frag = {"id": "http://conjourney.net/orion/chatTurn/497229f6_12da_4ffa_9f92_95aa950db58f"}
+    assert worker._chatturn_id_from_fragment(frag) == "497229f6-12da-4ffa-9f92-95aa950db58f"
+
+
+def test_chatturn_id_from_fragment_rejects_non_chatturn_and_non_uuid() -> None:
+    assert worker._chatturn_id_from_fragment({"id": "http://conjourney.net/orion/claim/abc"}) is None
+    assert worker._chatturn_id_from_fragment({"id": "http://conjourney.net/orion/chatTurn/not_a_uuid"}) is None
+    assert worker._chatturn_id_from_fragment({}) is None
+
+
+def _run_window(candidates, since_minutes, ts_map):
+    async def _fake_fetch(turn_ids, since):
+        # Only ids the caller asked for, filtered to what the "DB" returns for the window.
+        return {tid: ts_map[tid] for tid in turn_ids if tid in ts_map}
+
+    original = worker.fetch_chat_turn_timestamps
+    worker.fetch_chat_turn_timestamps = _fake_fetch  # type: ignore[assignment]
+    try:
+        return asyncio.run(
+            worker._window_rdf_chatturn_candidates(candidates, since_minutes=since_minutes)
+        )
+    finally:
+        worker.fetch_chat_turn_timestamps = original  # type: ignore[assignment]
+
+
+def test_windowing_drops_out_of_window_and_stamps_kept() -> None:
+    in_window = "497229f6-12da-4ffa-9f92-95aa950db58f"
+    out_window = "181c2c85-da7a-4de8-a475-4291ae290e0e"
+    candidates = [
+        {"id": f"http://conjourney.net/orion/chatTurn/{in_window.replace('-', '_')}",
+         "source": "rdf_chat", "tags": ["rdf", "chat", "chatturn"], "ts": 0.0, "text": "recent"},
+        {"id": f"http://conjourney.net/orion/chatTurn/{out_window.replace('-', '_')}",
+         "source": "rdf_chat", "tags": ["rdf", "chat", "chatturn"], "ts": 0.0, "text": "months old"},
+        {"id": "chat_history_log:abc", "source": "sql_chat", "tags": ["sql"], "ts": 1783220298.0, "text": "sql row"},
+    ]
+    # Only the in-window turn is returned by the DB (out-of-window filtered by the SQL query).
+    kept, dropped = _run_window(candidates, 1440, {in_window: 1783300000.0})
+
+    assert dropped == 1
+    sources = [c["source"] for c in kept]
+    assert sources == ["rdf_chat", "sql_chat"]  # out-of-window rdf_chat gone, sql untouched
+    kept_rdf = next(c for c in kept if c["source"] == "rdf_chat")
+    assert kept_rdf["ts"] == 1783300000.0  # real timestamp stamped in
+    kept_sql = next(c for c in kept if c["source"] == "sql_chat")
+    assert kept_sql["ts"] == 1783220298.0  # non chat-turn candidate untouched
+
+
+def test_windowing_noop_when_since_minutes_non_positive() -> None:
+    candidates = [
+        {"id": "http://conjourney.net/orion/chatTurn/497229f6_12da_4ffa_9f92_95aa950db58f",
+         "source": "rdf_chat", "tags": ["chatturn"], "ts": 0.0},
+    ]
+    kept, dropped = _run_window(candidates, 0, {})
+    assert dropped == 0
+    assert kept == candidates
+
+
+def test_windowing_skips_db_when_no_chatturn_candidates() -> None:
+    candidates = [{"id": "x", "source": "cards", "tags": ["card"], "ts": 5.0}]
+
+    async def _boom(*_a, **_k):  # must not be called
+        raise AssertionError("DB lookup should be skipped when no chat-turn candidates")
+
+    original = worker.fetch_chat_turn_timestamps
+    worker.fetch_chat_turn_timestamps = _boom  # type: ignore[assignment]
+    try:
+        kept, dropped = asyncio.run(
+            worker._window_rdf_chatturn_candidates(candidates, since_minutes=1440)
+        )
+    finally:
+        worker.fetch_chat_turn_timestamps = original  # type: ignore[assignment]
+
+    assert dropped == 0
+    assert kept == candidates


### PR DESCRIPTION
RDF chat-turn rails (rdf_chat, rdf_connected_chat, rdf_chat_anchor) ignored the per-profile time window that the SQL chat/timeline backends honor, and handed fusion ts=0.0, so months-old turns surfaced into reflective recall (journals/metacogs kept re-reflecting on days-old topics). The graph stores no usable ChatTurn timestamp (1 of 748 turns), so the fix resolves each turn's created_at from chat_history_log by turn id and drops turns older than the profile's sql_since_minutes, stamping real recency on the survivors.

Memory cards are intentionally not touched.

- recall/sql_chat: add fetch_chat_turn_timestamps (batched PG lookup, windowed)
- recall/worker: window rdf chat-turn candidates before suppression/fusion
- recall/settings+.env_example: RECALL_RDF_CHAT_WINDOW_ENABLED, RECALL_SQL_CHAT_ID_COL
- tests: id reversal + windowing (drop old, stamp kept, leave non-chat untouched)

Live-verified against conjourney: a 2026-01-18 turn is dropped from a 24h window; a recent turn is kept with a real timestamp.