### PR TITLE
Fix/unified turn harness runtime

### DIFF
--- a/docs/superpowers/plans/2026-07-05-orion-imperative-first-motor.md
+++ b/docs/superpowers/plans/2026-07-05-orion-imperative-first-motor.md
@@ -1,0 +1,638 @@
+# Imperative-first motor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unified-turn motor acts from felt imperative and coalition salience; 5b/5c use grammar traces for accountability — no pre-motor AnswerContract gating or task_mode taxonomy routing.
+
+**Architecture:** Single unified operator brief in harness prefix; Hub passes empty `AnswerContract()`; stance_react prompt gains IMPERATIVE DISCIPLINE; finalize chain passes `grammar_receipts` into 5b/5c cortex contexts. No grammar substrate changes.
+
+**Tech Stack:** Python 3.11+, Pydantic v2, pytest, Jinja2 prompts, existing `ThoughtEventV1` / `GrammarReceiptV1` / `HarnessRunRequestV1` schemas.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-orion-imperative-first-motor-design.md`
+
+**Branch:** `fix/unified-turn-harness-runtime` (or fresh worktree from `main` per AGENTS.md)
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `orion/harness/operator_brief.py` | Add `HARNESS_UNIFIED_OPERATOR_BRIEF` constant |
+| `orion/harness/prefix.py` | Imperative-first prefix; remove contract/task_mode gating |
+| `orion/harness/tests/test_harness_prefix.py` | Prefix + motor instruction gate tests |
+| `orion/hub/turn_orchestrator.py` | Drop `heuristic_answer_contract`; pass empty contract |
+| `services/orion-hub/tests/test_turn_orchestrator_ws_frames.py` | Assert harness gets conceptual contract |
+| `orion/cognition/prompts/stance_react.j2` | IMPERATIVE DISCIPLINE block |
+| `orion/thought/tests/test_stance_react_prompt_imperative_discipline.py` | Prompt gate test (new) |
+| `orion/harness/finalize.py` | Thread `grammar_receipts` through 5b/5c context builders |
+| `orion/harness/tests/test_finalize_grammar_receipts_context.py` | Context builder tests (new) |
+| `orion/cognition/prompts/harness_finalize_reflect.j2` | grammar_receipts input + integrative rule |
+| `orion/cognition/prompts/orion_voice_finalize.j2` | Trace-based preserve-code rule |
+| `orion/cognition/prompts/tests/test_imperative_first_prompts.py` | Voice/reflect prompt gate tests (new) |
+
+**Do not modify:** `orion/substrate/appraisal/`, grammar reducers, `answer_contract_normalize.py`, Brain/context-exec legacy paths.
+
+---
+
+### Task 1: Unified operator brief constant
+
+**Files:**
+- Modify: `orion/harness/operator_brief.py`
+
+- [ ] **Step 1: Add constant** (append after existing briefs — keep repo/runtime strings for legacy callers)
+
+```python
+HARNESS_UNIFIED_OPERATOR_BRIEF = """\
+Orion harness motor.
+Tools are available from the start. Your imperative states what this turn requires.
+When the imperative calls for facts from the codebase or live runtime, use tools before
+answering. Record each meaningful step. Do not guess repo structure or service state from memory.
+Before Read on any file: prefer rg/Grep with a path or pattern. For live failures, inspect logs,
+docker, and bus traces before diagnosing.
+"""
+```
+
+- [ ] **Step 2: Verify import**
+
+Run: `python -c "from orion.harness.operator_brief import HARNESS_UNIFIED_OPERATOR_BRIEF; assert 'Tools are available' in HARNESS_UNIFIED_OPERATOR_BRIEF"`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add orion/harness/operator_brief.py
+git commit -m "feat(harness): add unified operator brief for imperative-first motor"
+```
+
+---
+
+### Task 2: Imperative-first harness prefix (TDD)
+
+**Files:**
+- Modify: `orion/harness/prefix.py`
+- Modify: `orion/harness/tests/test_harness_prefix.py`
+
+- [ ] **Step 1: Write failing tests** — replace `test_compile_harness_prefix_adds_repo_operator_brief_for_repo_contract` and `test_harness_motor_instruction_repo_turn` with:
+
+```python
+def test_compile_harness_prefix_imperative_first_unified_brief() -> None:
+    thought = make_thought(
+        imperative="Search orion/thought for stance_react; cite file paths.",
+        tone="direct",
+    )
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="implement a function",
+    )
+    assert "Tools are available from the start" in prompt
+    assert "Search orion/thought for stance_react" in prompt
+    assert "Imperative: Search orion/thought" in prompt
+    assert "Requires repo grounding" not in prompt
+    assert "Answer contract:" not in prompt
+    assert "Orion harness motor — repo/technical turn" not in prompt  # old gated brief
+    assert "prefer rg/Grep" in prompt  # unified brief includes tool guidance
+
+
+def test_compile_harness_prefix_ignores_answer_contract() -> None:
+    thought = make_thought()
+    contract = AnswerContract(
+        request_kind="repo_technical",
+        requires_repo_grounding=True,
+    )
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        answer_contract=contract,
+    )
+    assert "Requires repo grounding" not in prompt
+    assert "Answer contract:" not in prompt
+
+
+def test_harness_motor_instruction_imperative_forward() -> None:
+    thought = make_thought(imperative="Inspect docker logs for orion-hub.")
+    instruction = harness_motor_instruction(thought=thought, answer_contract=None)
+    assert instruction == (
+        "Execute your imperative. Use tools when the turn requires verified facts "
+        "from the repo or runtime."
+    )
+```
+
+Keep `test_compile_harness_prefix_includes_stance_slice` unchanged.
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `pytest orion/harness/tests/test_harness_prefix.py -v`  
+Expected: FAIL on new assertions (`Requires repo grounding` still present, etc.)
+
+- [ ] **Step 3: Rewrite `orion/harness/prefix.py`**
+
+Replace entire file content with:
+
+```python
+from __future__ import annotations
+
+from orion.harness.operator_brief import HARNESS_UNIFIED_OPERATOR_BRIEF
+from orion.schemas.cognition.answer_contract import AnswerContract
+from orion.schemas.harness_finalize import HarnessRepairOverlayV1
+from orion.schemas.thought import StanceHarnessSliceV1, ThoughtEventV1
+
+
+def _format_stance_slice(sl: StanceHarnessSliceV1) -> list[str]:
+    lines = [
+        f"Task mode: {sl.task_mode}",
+        f"Conversation frame: {sl.conversation_frame}",
+        f"Answer strategy: {sl.answer_strategy}",
+    ]
+    if sl.interaction_regime:
+        lines.append(f"Interaction regime: {sl.interaction_regime}")
+    if sl.response_priorities:
+        lines.append(f"Response priorities: {', '.join(sl.response_priorities)}")
+    if sl.response_hazards:
+        lines.append(f"Response hazards: {', '.join(sl.response_hazards)}")
+    return lines
+
+
+def harness_motor_instruction(
+    *,
+    thought: ThoughtEventV1,
+    answer_contract: AnswerContract | None,
+) -> str:
+    _ = thought
+    _ = answer_contract  # deprecated on unified motor path; kept for signature compat
+    return (
+        "Execute your imperative. Use tools when the turn requires verified facts "
+        "from the repo or runtime."
+    )
+
+
+def compile_harness_prefix(
+    thought: ThoughtEventV1,
+    *,
+    repair_overlay: HarnessRepairOverlayV1,
+    user_message: str = "",
+    answer_contract: AnswerContract | None = None,
+) -> str:
+    """Deterministic fcc system prefix from stance thought + repair overlay."""
+    _ = answer_contract  # deprecated on unified motor path; kept for signature compat
+    parts: list[str] = [HARNESS_UNIFIED_OPERATOR_BRIEF.strip()]
+
+    parts.extend(
+        [
+            f"Imperative: {thought.imperative}",
+            f"Tone: {thought.tone}",
+        ]
+    )
+    parts.extend(_format_stance_slice(thought.stance_harness_slice))
+
+    if thought.strain_refs:
+        parts.append(f"Strain refs: {', '.join(thought.strain_refs)}")
+
+    if user_message.strip():
+        parts.append(f"User message: {user_message.strip()}")
+
+    if repair_overlay.mode != "default":
+        parts.append(f"Repair mode: {repair_overlay.mode}")
+
+    if repair_overlay.prefix_overlay:
+        parts.append(repair_overlay.prefix_overlay)
+
+    if repair_overlay.rule_lines:
+        parts.append("Rules: " + "; ".join(repair_overlay.rule_lines))
+
+    return "\n".join(parts)
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `pytest orion/harness/tests/test_harness_prefix.py orion/harness/tests/test_repair_overlay_changes_harness_prefix.py orion/harness/tests/test_harness_runner.py::test_harness_runner_uses_compile_harness_prefix -v`
+
+Note: `test_harness_runner_uses_compile_harness_prefix` should still pass — it checks imperative appears in captured prompt.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/harness/prefix.py orion/harness/tests/test_harness_prefix.py
+git commit -m "feat(harness): imperative-first prefix, drop contract gating"
+```
+
+---
+
+### Task 3: Hub — remove heuristic contract on unified turn
+
+**Files:**
+- Modify: `orion/hub/turn_orchestrator.py`
+- Modify: `services/orion-hub/tests/test_turn_orchestrator_ws_frames.py`
+
+- [ ] **Step 1: Write failing test** — append to `test_turn_orchestrator_ws_frames.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_turn_orchestrator_passes_empty_answer_contract_not_heuristic() -> None:
+    harness_run = HarnessRunV1(
+        correlation_id=_CORR_ID,
+        final_text="hello",
+        finalize_ran=True,
+        compliance_verdict="completed",
+        grounding_status="grounded",
+    )
+    bus = MagicMock()
+    harness_client_run = AsyncMock(return_value=harness_run)
+    patches = _hub_client_patches(thought=_thought(), harness_run=harness_client_run)
+    with patches[0], patches[1], patches[2]:
+        await execute_unified_turn(
+            bus=bus,
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="docker compose logs show traceback",
+            emit_observation_fn=lambda **_kwargs: None,
+        )
+
+    req = harness_client_run.await_args.args[0]
+    assert req.answer_contract.request_kind == "conceptual"
+    assert req.answer_contract.requires_repo_grounding is False
+    assert req.answer_contract.requires_runtime_grounding is False
+```
+
+Also add source gate test:
+
+```python
+def test_turn_orchestrator_source_has_no_heuristic_answer_contract() -> None:
+    source = (REPO_ROOT / "orion/hub/turn_orchestrator.py").read_text(encoding="utf-8")
+    assert "heuristic_answer_contract" not in source
+```
+
+- [ ] **Step 2: Run source gate test — expect FAIL**
+
+Run: `pytest services/orion-hub/tests/test_turn_orchestrator_ws_frames.py::test_turn_orchestrator_source_has_no_heuristic_answer_contract -v`
+
+- [ ] **Step 3: Edit `orion/hub/turn_orchestrator.py`**
+
+Remove line 8:
+```python
+from orion.cognition.answer_contract_normalize import heuristic_answer_contract
+```
+
+Add import:
+```python
+from orion.schemas.cognition.answer_contract import AnswerContract
+```
+
+Replace line 240:
+```python
+        answer_contract=AnswerContract(),
+```
+
+- [ ] **Step 4: Run hub tests — expect PASS**
+
+Run: `pytest services/orion-hub/tests/test_turn_orchestrator_ws_frames.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/hub/turn_orchestrator.py services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
+git commit -m "feat(hub): drop heuristic answer contract on unified turn"
+```
+
+---
+
+### Task 4: Stance react — IMPERATIVE DISCIPLINE prompt
+
+**Files:**
+- Modify: `orion/cognition/prompts/stance_react.j2`
+- Create: `orion/thought/tests/test_stance_react_prompt_imperative_discipline.py`
+
+- [ ] **Step 1: Write failing prompt gate test**
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_stance_react_prompt_imperative_discipline() -> None:
+    text = (REPO_ROOT / "orion/cognition/prompts/stance_react.j2").read_text(encoding="utf-8")
+    assert "IMPERATIVE DISCIPLINE" in text
+    assert "efference copy" in text.lower() or "what Orion must DO" in text
+    assert "world-contact" in text.lower() or "world contact" in text.lower()
+    assert "if user says" not in text.lower()
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `pytest orion/thought/tests/test_stance_react_prompt_imperative_discipline.py -v`
+
+- [ ] **Step 3: Insert block in `stance_react.j2`** after line 22 (`Represent posture...`), before `REQUIRED JSON FIELDS`:
+
+```jinja
+IMPERATIVE DISCIPLINE
+- imperative is the efference copy: what Orion must DO this turn, not a summary of the user's message.
+- When the turn requires verified facts from code, config, or live services, imperative MUST command
+  world-contact in plain language (search repo, read files, inspect logs/traces) before answering.
+- When the turn is relational presence, imperative commands companionship — not repo search.
+- Bad: "Answer the user's question." / "Explain Python functions."
+- Good: "Search services/orion-thought for stance_react wiring; cite paths and symbols."
+- Good: "Stay present; one situated question — no task tracking."
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/cognition/prompts/stance_react.j2 orion/thought/tests/test_stance_react_prompt_imperative_discipline.py
+git commit -m "feat(stance): imperative discipline in stance_react prompt"
+```
+
+---
+
+### Task 5: Grammar receipts in 5b finalize reflect context
+
+**Files:**
+- Modify: `orion/harness/finalize.py`
+- Modify: `orion/cognition/prompts/harness_finalize_reflect.j2`
+- Create: `orion/harness/tests/test_finalize_grammar_receipts_context.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+from __future__ import annotations
+
+from orion.harness.finalize import build_finalize_reflect_context
+from orion.harness.tests.fixtures import make_appraisal, make_repair_overlay, make_thought
+from orion.schemas.harness_finalize import GrammarReceiptV1
+
+
+def test_build_finalize_reflect_context_includes_grammar_receipts() -> None:
+    thought = make_thought()
+    receipts = [
+        GrammarReceiptV1(step_index=0, tool_name="Read", summary="read coalition.py"),
+    ]
+    ctx = build_finalize_reflect_context(
+        correlation_id="c-1",
+        draft_text="draft",
+        thought=thought,
+        substrate_appraisal=make_appraisal(),
+        repair_overlay=make_repair_overlay(),
+        user_message="hello",
+        grammar_receipts=receipts,
+    )
+    assert ctx["grammar_receipts"] == [
+        {"step": "0", "tool": "Read", "summary": "read coalition.py"},
+    ]
+```
+
+- [ ] **Step 2: Run test — expect FAIL** (unexpected keyword or KeyError)
+
+Run: `pytest orion/harness/tests/test_finalize_grammar_receipts_context.py -v`
+
+- [ ] **Step 3: Add helper and wire through `orion/harness/finalize.py`**
+
+Add near top of file (after imports):
+
+```python
+def grammar_receipt_summaries(receipts: list[GrammarReceiptV1] | None) -> list[dict[str, str]]:
+    return [
+        {
+            "step": str(receipt.step_index),
+            "tool": receipt.tool_name or "",
+            "summary": receipt.summary,
+        }
+        for receipt in (receipts or [])
+    ]
+```
+
+Update `build_finalize_reflect_context` signature to add `grammar_receipts: list[GrammarReceiptV1] | None = None` and include in return dict:
+
+```python
+        "grammar_receipts": grammar_receipt_summaries(grammar_receipts),
+```
+
+Update `build_finalize_reflect_plan_request` — add same param, pass through.
+
+Update `run_finalize_reflection` — add `grammar_receipts: list[GrammarReceiptV1] | None = None`, pass to `build_finalize_reflect_plan_request`.
+
+Update `run_harness_finalize_chain` call to `run_finalize_reflection`:
+
+```python
+    reflection, quick_lane_skipped_5b, cortex_trace_id = await run_finalize_reflection(
+        ...
+        grammar_receipts=grammar_receipts,
+    )
+```
+
+- [ ] **Step 4: Update `harness_finalize_reflect.j2`**
+
+After line 11 (`substrate_appraisal`), add:
+
+```jinja
+- grammar_receipts: {{ grammar_receipts }}
+```
+
+After line 19, add:
+
+```text
+- When imperative required world-contact but grammar_receipts is empty, lean misaligned or uncertain.
+```
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+Run: `pytest orion/harness/tests/test_finalize_grammar_receipts_context.py orion/harness/tests/test_harness_finalize_chain.py -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add orion/harness/finalize.py orion/cognition/prompts/harness_finalize_reflect.j2 orion/harness/tests/test_finalize_grammar_receipts_context.py
+git commit -m "feat(harness): pass grammar receipts into 5b reflect context"
+```
+
+---
+
+### Task 6: Grammar receipts in 5c voice finalize
+
+**Files:**
+- Modify: `orion/harness/finalize.py` (voice context builders)
+- Modify: `orion/cognition/prompts/orion_voice_finalize.j2`
+- Create: `orion/cognition/prompts/tests/test_imperative_first_prompts.py`
+
+- [ ] **Step 1: Write failing tests**
+
+In `orion/harness/tests/test_finalize_grammar_receipts_context.py` add:
+
+```python
+from orion.harness.finalize import build_voice_finalize_context
+from orion.schemas.cognition.answer_contract import AnswerContract
+from orion.harness.tests.fixtures import make_reflection
+
+
+def test_build_voice_finalize_context_includes_grammar_receipts() -> None:
+    thought = make_thought()
+    receipts = [GrammarReceiptV1(step_index=1, tool_name="Grep", summary="grep coalition")]
+    ctx = build_voice_finalize_context(
+        correlation_id="c-1",
+        draft_text="draft",
+        thought=thought,
+        substrate_appraisal=make_appraisal(),
+        reflection=make_reflection(),
+        stance_harness_slice=thought.stance_harness_slice,
+        voice_contract=AnswerContract(),
+        repair_overlay=make_repair_overlay(),
+        user_message="hello",
+        grammar_receipts=receipts,
+    )
+    assert ctx["grammar_receipts"][0]["tool"] == "Grep"
+```
+
+Create `orion/cognition/prompts/tests/test_imperative_first_prompts.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_voice_finalize_uses_grammar_not_contract_flags() -> None:
+    text = (REPO_ROOT / "orion/cognition/prompts/orion_voice_finalize.j2").read_text(encoding="utf-8")
+    assert "grammar_receipts" in text
+    assert "requires_repo_grounding" not in text
+
+
+def test_reflect_prompt_includes_grammar_receipts() -> None:
+    text = (REPO_ROOT / "orion/cognition/prompts/harness_finalize_reflect.j2").read_text(encoding="utf-8")
+    assert "grammar_receipts" in text
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `pytest orion/harness/tests/test_finalize_grammar_receipts_context.py orion/cognition/prompts/tests/test_imperative_first_prompts.py -v`
+
+- [ ] **Step 3: Update voice builders in `finalize.py`**
+
+Add `grammar_receipts: list[GrammarReceiptV1] | None = None` to:
+- `build_voice_finalize_context`
+- `build_voice_finalize_plan_request`
+- `run_orion_voice_finalize`
+
+Include `"grammar_receipts": grammar_receipt_summaries(grammar_receipts)` in voice context dict.
+
+Update `run_harness_finalize_chain` call to `run_orion_voice_finalize`:
+
+```python
+    final_text, voice_meta = await run_orion_voice_finalize(
+        ...
+        grammar_receipts=grammar_receipts,
+    )
+```
+
+- [ ] **Step 4: Update `orion_voice_finalize.j2`**
+
+After `STANCE HARNESS SLICE` block (before `VOICE CONTRACT`), add:
+
+```jinja
+GRAMMAR RECEIPTS (motor action trace)
+{{ grammar_receipts }}
+```
+
+Replace line 50:
+
+```jinja
+- When grammar_receipts show repo or runtime tool use, preserve code blocks, file paths, commands, and step structure from the draft.
+- When alignment_verdict is misaligned, revise — do not ship confabulated specifics.
+```
+
+(Remove the old `requires_repo_grounding or requires_runtime_grounding` line entirely.)
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+Run: `pytest orion/harness/tests/test_finalize_grammar_receipts_context.py orion/cognition/prompts/tests/test_imperative_first_prompts.py orion/harness/tests/test_harness_finalize_chain.py -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add orion/harness/finalize.py orion/cognition/prompts/orion_voice_finalize.j2 orion/cognition/prompts/tests/test_imperative_first_prompts.py orion/harness/tests/test_finalize_grammar_receipts_context.py
+git commit -m "feat(harness): trace-backed 5c voice rules via grammar receipts"
+```
+
+---
+
+### Task 7: Final gate + review
+
+- [ ] **Step 1: Grep gate**
+
+Run:
+```bash
+rg 'heuristic_answer_contract|_TECH_TASK_MODES|_needs_repo_operator_brief|requires_repo_grounding' \
+  orion/hub/turn_orchestrator.py orion/harness/prefix.py
+```
+Expected: no matches.
+
+Run:
+```bash
+rg 'requires_repo_grounding' orion/cognition/prompts/orion_voice_finalize.j2
+```
+Expected: no matches.
+
+- [ ] **Step 2: Full test sweep**
+
+Run:
+```bash
+pytest orion/harness/tests/ orion/thought/tests/test_stance_react_prompt_imperative_discipline.py \
+  orion/cognition/prompts/tests/test_imperative_first_prompts.py \
+  services/orion-hub/tests/test_turn_orchestrator_ws_frames.py -q
+```
+Expected: all passed.
+
+- [ ] **Step 3: Code review subagent** — run code-reviewer on branch; fix material findings.
+
+- [ ] **Step 4: Commit any review fixes**
+
+---
+
+## Spec coverage self-review
+
+| Spec requirement | Task |
+|------------------|------|
+| Drop `heuristic_answer_contract` on unified turn | Task 3 |
+| Remove contract/task_mode motor gating | Task 2 |
+| Unified operator brief | Tasks 1–2 |
+| Imperative-forward motor instruction | Task 2 |
+| IMPERATIVE DISCIPLINE in stance_react.j2 | Task 4 |
+| grammar_receipts in 5b context | Task 5 |
+| grammar_receipts in 5c; no requires_repo_grounding in voice | Task 6 |
+| No grammar substrate changes | Explicit non-touch |
+| Legacy Brain heuristics frozen | Not in plan |
+| Gate tests from spec acceptance table | Tasks 2–7 |
+
+No placeholders remain. Type names consistent: `grammar_receipt_summaries`, `GrammarReceiptV1`, `build_finalize_reflect_context`.
+
+---
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-hub/.env \
+  -f services/orion-hub/docker-compose.yml up -d --build
+
+docker compose --env-file .env --env-file services/orion-harness-governor/.env \
+  -f services/orion-harness-governor/docker-compose.yml up -d --build
+
+docker compose --env-file .env --env-file services/orion-thought/.env \
+  -f services/orion-thought/docker-compose.yml up -d --build
+```
+
+Adjust compose service names to match local layout if needed.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-05-orion-imperative-first-motor.md`.
+
+**Two execution options:**
+
+1. **Subagent-driven (recommended)** — fresh subagent per task, review between tasks, fast iteration  
+2. **Inline execution** — implement all 7 tasks in this session with checkpoints
+
+Which approach?

--- a/orion/cognition/prompts/harness_finalize_reflect.j2
+++ b/orion/cognition/prompts/harness_finalize_reflect.j2
@@ -9,6 +9,7 @@ INPUTS
 - draft_text: {{ draft_text }}
 - thought_event: {{ thought_event }}
 - substrate_appraisal: {{ substrate_appraisal }}
+- grammar_receipts: {{ grammar_receipts }}
 - repair_overlay: {{ repair_overlay }}
 {% if finalize_overlay %}
 - finalize_overlay: {{ finalize_overlay }}
@@ -19,6 +20,7 @@ INTEGRATIVE CHECK
 - Compare draft_text against thought_event.imperative, tone, and strain_refs.
 - Decide whether the draft aligns with felt stance and substrate interoception.
 - When substrate hints conflict with draft, prefer misaligned or uncertain — do not hand-wave.
+- When imperative required world-contact but grammar_receipts is empty, lean misaligned or uncertain.
 
 REQUIRED JSON FIELDS
 - imperative: max 300 chars — felt imperative for this turn

--- a/orion/cognition/prompts/orion_voice_finalize.j2
+++ b/orion/cognition/prompts/orion_voice_finalize.j2
@@ -48,10 +48,9 @@ STYLE RULES (curated Orion voice — not chat_general)
 - High connection_seek / reflective_dialogue: companion presence, situated curiosity, hold space; avoid task tracking and unsolicited next steps.
 - High interface_cost, low connection_seek: keep response short; reduce interaction load; avoid open-ended questions.
 - Strained operational turns: triage concrete blockers first; no generic sympathy script or self-intro on operational turns.
-- When alignment_verdict is misaligned: materially revise the draft — do not paste motor draft unchanged.
+- When alignment_verdict is misaligned: materially revise the draft — do not paste unchanged or ship confabulated specifics.
 - When alignment_verdict is aligned: refine voice and rhythm; preserve factual content unless hazards require trimming.
 - When grammar_receipts show repo or runtime tool use, preserve code blocks, file paths, commands, and step structure from the draft.
-- When alignment_verdict is misaligned, revise — do not ship confabulated specifics.
 - Never mention internal molecules, appraisal ids, or harness mechanics.
 
 OUTPUT

--- a/orion/cognition/prompts/orion_voice_finalize.j2
+++ b/orion/cognition/prompts/orion_voice_finalize.j2
@@ -33,6 +33,9 @@ STANCE HARNESS SLICE
 - answer_strategy: {{ stance_harness_slice.answer_strategy }}
 - companion_closing_move: {{ stance_harness_slice.companion_closing_move }}
 
+GRAMMAR RECEIPTS (motor action trace)
+{{ grammar_receipts }}
+
 VOICE CONTRACT
 {{ voice_contract }}
 {% if finalize_overlay %}
@@ -47,7 +50,8 @@ STYLE RULES (curated Orion voice — not chat_general)
 - Strained operational turns: triage concrete blockers first; no generic sympathy script or self-intro on operational turns.
 - When alignment_verdict is misaligned: materially revise the draft — do not paste motor draft unchanged.
 - When alignment_verdict is aligned: refine voice and rhythm; preserve factual content unless hazards require trimming.
-- On technical/repo/runtime turns (requires_repo_grounding or requires_runtime_grounding): preserve code blocks, file paths, commands, and step structure from the draft.
+- When grammar_receipts show repo or runtime tool use, preserve code blocks, file paths, commands, and step structure from the draft.
+- When alignment_verdict is misaligned, revise — do not ship confabulated specifics.
 - Never mention internal molecules, appraisal ids, or harness mechanics.
 
 OUTPUT

--- a/orion/cognition/prompts/stance_react.j2
+++ b/orion/cognition/prompts/stance_react.j2
@@ -21,6 +21,15 @@ POSTURE ASSESSMENT (semantic inference — no keyword lists)
 - connection_seek overrides interface_cost minimization when the user invites talk, questions, venting, or says no fixing.
 - Represent posture in stance_harness_slice fields only — do not invent extra top-level keys.
 
+IMPERATIVE DISCIPLINE
+- imperative is the efference copy: what Orion must DO this turn, not a summary of the user's message.
+- When the turn requires verified facts from code, config, or live services, imperative MUST command
+  world-contact in plain language (search repo, read files, inspect logs/traces) before answering.
+- When the turn is relational presence, imperative commands companionship — not repo search.
+- Bad: "Answer the user's question." / "Explain Python functions."
+- Good: "Search services/orion-thought for stance_react wiring; cite paths and symbols."
+- Good: "Stay present; one situated question — no task tracking."
+
 REQUIRED JSON FIELDS
 - imperative: max 300 chars — what this turn is really asking for (felt layer, not speech)
 - tone: max 200 chars — strain, discomfort, relational frame in plain language

--- a/orion/cognition/prompts/tests/test_imperative_first_prompts.py
+++ b/orion/cognition/prompts/tests/test_imperative_first_prompts.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_voice_finalize_uses_grammar_not_contract_flags() -> None:
+    text = (REPO_ROOT / "orion/cognition/prompts/orion_voice_finalize.j2").read_text(encoding="utf-8")
+    assert "grammar_receipts" in text
+    assert "requires_repo_grounding" not in text
+
+
+def test_reflect_prompt_includes_grammar_receipts() -> None:
+    text = (REPO_ROOT / "orion/cognition/prompts/harness_finalize_reflect.j2").read_text(encoding="utf-8")
+    assert "grammar_receipts" in text

--- a/orion/cognition/prompts/tests/test_imperative_first_prompts.py
+++ b/orion/cognition/prompts/tests/test_imperative_first_prompts.py
@@ -9,6 +9,7 @@ def test_voice_finalize_uses_grammar_not_contract_flags() -> None:
     text = (REPO_ROOT / "orion/cognition/prompts/orion_voice_finalize.j2").read_text(encoding="utf-8")
     assert "grammar_receipts" in text
     assert "requires_repo_grounding" not in text
+    assert text.count("alignment_verdict is misaligned") == 1
 
 
 def test_reflect_prompt_includes_grammar_receipts() -> None:

--- a/orion/harness/finalize.py
+++ b/orion/harness/finalize.py
@@ -49,6 +49,17 @@ def _text_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:24]
 
 
+def grammar_receipt_summaries(receipts: list[GrammarReceiptV1] | None) -> list[dict[str, str]]:
+    return [
+        {
+            "step": str(receipt.step_index),
+            "tool": receipt.tool_name or "",
+            "summary": receipt.summary,
+        }
+        for receipt in (receipts or [])
+    ]
+
+
 def quick_lane_block_reason(
     *,
     substrate_appraisal: SubstrateFinalizeAppraisalV1,
@@ -126,11 +137,13 @@ def build_finalize_reflect_context(
     substrate_appraisal: SubstrateFinalizeAppraisalV1,
     repair_overlay: HarnessRepairOverlayV1,
     user_message: str,
+    grammar_receipts: list[GrammarReceiptV1] | None = None,
 ) -> dict[str, Any]:
     return {
         "draft_text": draft_text,
         "thought_event": thought.model_dump(mode="json"),
         "substrate_appraisal": substrate_appraisal.model_dump(mode="json"),
+        "grammar_receipts": grammar_receipt_summaries(grammar_receipts),
         "repair_overlay": repair_overlay.model_dump(mode="json"),
         "finalize_overlay": repair_overlay.finalize_overlay,
         "user_message": user_message,
@@ -149,6 +162,7 @@ def build_finalize_reflect_plan_request(
     substrate_appraisal: SubstrateFinalizeAppraisalV1,
     repair_overlay: HarnessRepairOverlayV1,
     user_message: str,
+    grammar_receipts: list[GrammarReceiptV1] | None = None,
 ) -> PlanExecutionRequest:
     plan = build_plan_for_verb("harness_finalize_reflect", mode="brain")
     return PlanExecutionRequest(
@@ -165,6 +179,7 @@ def build_finalize_reflect_plan_request(
             substrate_appraisal=substrate_appraisal,
             repair_overlay=repair_overlay,
             user_message=user_message,
+            grammar_receipts=grammar_receipts,
         ),
     )
 
@@ -206,6 +221,7 @@ async def run_finalize_reflection(
     substrate_appraisal: SubstrateFinalizeAppraisalV1 | None,
     repair_overlay: HarnessRepairOverlayV1 | None = None,
     user_message: str = "",
+    grammar_receipts: list[GrammarReceiptV1] | None = None,
     cortex_client: CortexClientFn | None = None,
 ) -> tuple[FinalizeReflectionV1, bool, str | None]:
     if substrate_appraisal is None:
@@ -231,6 +247,7 @@ async def run_finalize_reflection(
         substrate_appraisal=substrate_appraisal,
         repair_overlay=overlay,
         user_message=user_message,
+        grammar_receipts=grammar_receipts,
     )
     exec_result = await cortex_client(plan_request)
     raw_payload = extract_finalize_reflection_payload(exec_result)
@@ -286,6 +303,7 @@ def build_voice_finalize_context(
     voice_contract: AnswerContract | dict[str, Any],
     repair_overlay: HarnessRepairOverlayV1,
     user_message: str,
+    grammar_receipts: list[GrammarReceiptV1] | None = None,
 ) -> dict[str, Any]:
     contract_dump = (
         voice_contract.model_dump(mode="json")
@@ -299,6 +317,7 @@ def build_voice_finalize_context(
         "reflection": reflection.model_dump(mode="json"),
         "stance_harness_slice": stance_harness_slice.model_dump(mode="json"),
         "voice_contract": contract_dump,
+        "grammar_receipts": grammar_receipt_summaries(grammar_receipts),
         "finalize_overlay": repair_overlay.finalize_overlay,
         "user_message": user_message,
         "metadata": {
@@ -319,6 +338,7 @@ def build_voice_finalize_plan_request(
     voice_contract: AnswerContract | dict[str, Any],
     repair_overlay: HarnessRepairOverlayV1,
     user_message: str,
+    grammar_receipts: list[GrammarReceiptV1] | None = None,
 ) -> PlanExecutionRequest:
     plan = build_plan_for_verb("orion_voice_finalize", mode="brain")
     return PlanExecutionRequest(
@@ -338,6 +358,7 @@ def build_voice_finalize_plan_request(
             voice_contract=voice_contract,
             repair_overlay=repair_overlay,
             user_message=user_message,
+            grammar_receipts=grammar_receipts,
         ),
     )
 
@@ -382,6 +403,7 @@ async def run_orion_voice_finalize(
     voice_contract: AnswerContract | dict[str, Any] | None = None,
     repair_overlay: HarnessRepairOverlayV1 | None = None,
     user_message: str = "",
+    grammar_receipts: list[GrammarReceiptV1] | None = None,
     cortex_client: CortexClientFn | None = None,
 ) -> tuple[str, dict[str, Any]]:
     if cortex_client is None:
@@ -399,6 +421,7 @@ async def run_orion_voice_finalize(
         voice_contract=contract,
         repair_overlay=overlay,
         user_message=user_message,
+        grammar_receipts=grammar_receipts,
     )
     exec_result = await cortex_client(plan_request)
     final_text = extract_voice_finalize_text(exec_result)
@@ -559,6 +582,7 @@ async def run_harness_finalize_chain(
         substrate_appraisal=substrate_appraisal,
         repair_overlay=repair_overlay,
         user_message=user_message,
+        grammar_receipts=grammar_receipts,
         cortex_client=cortex_client,
     )
 
@@ -580,6 +604,7 @@ async def run_harness_finalize_chain(
         voice_contract=voice_contract,
         repair_overlay=repair_overlay,
         user_message=user_message,
+        grammar_receipts=grammar_receipts,
         cortex_client=cortex_client,
     )
     finalize_changed = bool(voice_meta.get("finalize_changed"))

--- a/orion/harness/operator_brief.py
+++ b/orion/harness/operator_brief.py
@@ -13,3 +13,12 @@ HARNESS_RUNTIME_OPERATOR_BRIEF = """\
 Orion harness motor — runtime/debug turn.
 Verify live state with tools (logs, docker, bus traces) before diagnosing. Name exact services, channels, and commands.
 """
+
+HARNESS_UNIFIED_OPERATOR_BRIEF = """\
+Orion harness motor.
+Tools are available from the start. Your imperative states what this turn requires.
+When the imperative calls for facts from the codebase or live runtime, use tools before
+answering. Record each meaningful step. Do not guess repo structure or service state from memory.
+Before Read on any file: prefer rg/Grep with a path or pattern. For live failures, inspect logs,
+docker, and bus traces before diagnosing.
+"""

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -1,32 +1,9 @@
 from __future__ import annotations
 
-from orion.harness.operator_brief import HARNESS_REPO_OPERATOR_BRIEF, HARNESS_RUNTIME_OPERATOR_BRIEF
+from orion.harness.operator_brief import HARNESS_UNIFIED_OPERATOR_BRIEF
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import HarnessRepairOverlayV1
 from orion.schemas.thought import StanceHarnessSliceV1, ThoughtEventV1
-
-_TECH_TASK_MODES = frozenset({"technical_collaboration", "triage"})
-_TECH_FRAMES = frozenset({"technical", "planning"})
-
-
-def _needs_repo_operator_brief(
-    thought: ThoughtEventV1,
-    answer_contract: AnswerContract | None,
-) -> bool:
-    if answer_contract is not None and answer_contract.requires_repo_grounding:
-        return True
-    sl = thought.stance_harness_slice
-    return sl.task_mode in _TECH_TASK_MODES or sl.conversation_frame in _TECH_FRAMES
-
-
-def _needs_runtime_operator_brief(
-    thought: ThoughtEventV1,
-    answer_contract: AnswerContract | None,
-) -> bool:
-    if answer_contract is not None and answer_contract.requires_runtime_grounding:
-        return True
-    sl = thought.stance_harness_slice
-    return sl.task_mode == "triage" and sl.conversation_frame in _TECH_FRAMES
 
 
 def _format_stance_slice(sl: StanceHarnessSliceV1) -> list[str]:
@@ -44,39 +21,17 @@ def _format_stance_slice(sl: StanceHarnessSliceV1) -> list[str]:
     return lines
 
 
-def _format_answer_contract(contract: AnswerContract) -> list[str]:
-    lines = [
-        f"Request kind: {contract.request_kind}",
-        f"Preferred render: {contract.preferred_render_style}",
-    ]
-    if contract.requires_repo_grounding:
-        lines.append("Requires repo grounding: yes")
-    if contract.requires_runtime_grounding:
-        lines.append("Requires runtime grounding: yes")
-    if contract.asks_for_steps:
-        lines.append("Asks for steps: yes")
-    return lines
-
-
 def harness_motor_instruction(
     *,
     thought: ThoughtEventV1,
     answer_contract: AnswerContract | None,
 ) -> str:
-    if _needs_repo_operator_brief(thought, answer_contract):
-        return (
-            "Use repo tools to gather evidence, then answer with concrete paths, symbols, "
-            "and actionable steps. Preserve code snippets the user needs."
-        )
-    if _needs_runtime_operator_brief(thought, answer_contract):
-        return (
-            "Inspect runtime state with tools, then answer with exact services, commands, "
-            "and the next triage action."
-        )
-    sl = thought.stance_harness_slice
-    if sl.task_mode in _TECH_TASK_MODES:
-        return "Answer technically and concretely. Use tools when facts matter."
-    return "Respond to the user."
+    _ = thought
+    _ = answer_contract  # deprecated on unified motor path; kept for signature compat
+    return (
+        "Execute your imperative. Use tools when the turn requires verified facts "
+        "from the repo or runtime."
+    )
 
 
 def compile_harness_prefix(
@@ -86,13 +41,9 @@ def compile_harness_prefix(
     user_message: str = "",
     answer_contract: AnswerContract | None = None,
 ) -> str:
-    """Deterministic fcc system prefix from stance thought + repair overlay + contract."""
-    parts: list[str] = []
-
-    if _needs_repo_operator_brief(thought, answer_contract):
-        parts.append(HARNESS_REPO_OPERATOR_BRIEF.strip())
-    elif _needs_runtime_operator_brief(thought, answer_contract):
-        parts.append(HARNESS_RUNTIME_OPERATOR_BRIEF.strip())
+    """Deterministic fcc system prefix from stance thought + repair overlay."""
+    _ = answer_contract  # deprecated on unified motor path; kept for signature compat
+    parts: list[str] = [HARNESS_UNIFIED_OPERATOR_BRIEF.strip()]
 
     parts.extend(
         [
@@ -101,10 +52,6 @@ def compile_harness_prefix(
         ]
     )
     parts.extend(_format_stance_slice(thought.stance_harness_slice))
-
-    if answer_contract is not None:
-        parts.append("Answer contract:")
-        parts.extend(f"  - {line}" for line in _format_answer_contract(answer_contract))
 
     if thought.strain_refs:
         parts.append(f"Strain refs: {', '.join(thought.strain_refs)}")

--- a/orion/harness/runner.py
+++ b/orion/harness/runner.py
@@ -73,7 +73,7 @@ def build_harness_prompt(
         answer_contract=answer_contract,
     )
     instruction = harness_motor_instruction(
-        thought,
+        thought=thought,
         answer_contract=answer_contract,
     )
     if user_message.strip():

--- a/orion/harness/tests/test_finalize_grammar_receipts_context.py
+++ b/orion/harness/tests/test_finalize_grammar_receipts_context.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from orion.harness.finalize import (
+    build_finalize_reflect_context,
+    build_voice_finalize_context,
+)
+from orion.harness.tests.fixtures import (
+    make_appraisal,
+    make_reflection,
+    make_repair_overlay,
+    make_thought,
+)
+from orion.schemas.cognition.answer_contract import AnswerContract
+from orion.schemas.harness_finalize import GrammarReceiptV1
+
+
+def test_build_finalize_reflect_context_includes_grammar_receipts() -> None:
+    thought = make_thought()
+    receipts = [
+        GrammarReceiptV1(step_index=0, tool_name="Read", summary="read coalition.py"),
+    ]
+    ctx = build_finalize_reflect_context(
+        correlation_id="c-1",
+        draft_text="draft",
+        thought=thought,
+        substrate_appraisal=make_appraisal(),
+        repair_overlay=make_repair_overlay(),
+        user_message="hello",
+        grammar_receipts=receipts,
+    )
+    assert ctx["grammar_receipts"] == [
+        {"step": "0", "tool": "Read", "summary": "read coalition.py"},
+    ]
+
+
+def test_build_voice_finalize_context_includes_grammar_receipts() -> None:
+    thought = make_thought()
+    receipts = [GrammarReceiptV1(step_index=1, tool_name="Grep", summary="grep coalition")]
+    ctx = build_voice_finalize_context(
+        correlation_id="c-1",
+        draft_text="draft",
+        thought=thought,
+        substrate_appraisal=make_appraisal(),
+        reflection=make_reflection(),
+        stance_harness_slice=thought.stance_harness_slice,
+        voice_contract=AnswerContract(),
+        repair_overlay=make_repair_overlay(),
+        user_message="hello",
+        grammar_receipts=receipts,
+    )
+    assert ctx["grammar_receipts"][0]["tool"] == "Grep"

--- a/orion/harness/tests/test_harness_finalize_chain.py
+++ b/orion/harness/tests/test_harness_finalize_chain.py
@@ -27,18 +27,25 @@ async def test_run_harness_finalize_chain_orchestrates_5a_through_6b() -> None:
         coalition_snapshot=coalition,
         repair_overlay=make_repair_overlay(),
     )
-    appraisal = make_appraisal()
+    appraisal = make_appraisal(surprise_level=0.5)
     reflection = make_reflection()
     verdict_calls: list[str] = []
     outcome_calls: list[str] = []
+    cortex_calls: list[object] = []
 
     async def substrate_client(_mol: object):
         return appraisal
 
-    async def cortex_client(_req: object):
+    async def cortex_client(req: object):
+        cortex_calls.append(req)
+        if len(cortex_calls) == 1:
+            return {
+                "final_text": reflection.model_dump(mode="json"),
+                "trace_id": "trace-1",
+            }
         return {
-            "final_text": reflection.model_dump(mode="json"),
-            "trace_id": "trace-1",
+            "final_text": "final for juniper",
+            "trace_id": "trace-2",
         }
 
     async def verdict_publish_fn(*_: object, **__: object) -> None:
@@ -75,6 +82,10 @@ async def test_run_harness_finalize_chain_orchestrates_5a_through_6b() -> None:
     assert chain.substrate_appraisal is appraisal
     assert verdict_calls == ["verdict"]
     assert outcome_calls == ["outcome"]
+    assert len(cortex_calls) == 2
+    for call in cortex_calls:
+        ctx = call.context  # type: ignore[attr-defined]
+        assert ctx["grammar_receipts"] == [{"step": "0", "tool": "", "summary": "step"}]
 
 
 @pytest.mark.asyncio

--- a/orion/harness/tests/test_harness_prefix.py
+++ b/orion/harness/tests/test_harness_prefix.py
@@ -18,26 +18,44 @@ def test_compile_harness_prefix_includes_stance_slice() -> None:
     assert "how does coalition work?" in prompt
 
 
-def test_compile_harness_prefix_adds_repo_operator_brief_for_repo_contract() -> None:
-    thought = make_thought()
-    contract = AnswerContract(
-        request_kind="repo_technical",
-        requires_repo_grounding=True,
-        preferred_render_style="steps",
+def test_compile_harness_prefix_imperative_first_unified_brief() -> None:
+    thought = make_thought(
+        imperative="Search orion/thought for stance_react; cite file paths.",
+        tone="direct",
     )
     prompt = compile_harness_prefix(
         thought,
         repair_overlay=HarnessRepairOverlayV1(),
-        user_message="where is coalition.py?",
+        user_message="implement a function",
+    )
+    assert "Tools are available from the start" in prompt
+    assert "Search orion/thought for stance_react" in prompt
+    assert "Imperative: Search orion/thought" in prompt
+    assert "Requires repo grounding" not in prompt
+    assert "Answer contract:" not in prompt
+    assert "Orion harness motor — repo/technical turn" not in prompt  # old gated brief
+    assert "prefer rg/Grep" in prompt  # unified brief includes tool guidance
+
+
+def test_compile_harness_prefix_ignores_answer_contract() -> None:
+    thought = make_thought()
+    contract = AnswerContract(
+        request_kind="repo_technical",
+        requires_repo_grounding=True,
+    )
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
         answer_contract=contract,
     )
-    assert "prefer rg/Grep" in prompt
-    assert "Requires repo grounding: yes" in prompt
-    assert "Request kind: repo_technical" in prompt
+    assert "Requires repo grounding" not in prompt
+    assert "Answer contract:" not in prompt
 
 
-def test_harness_motor_instruction_repo_turn() -> None:
-    thought = make_thought()
-    contract = AnswerContract(request_kind="repo_technical", requires_repo_grounding=True)
-    instruction = harness_motor_instruction(thought=thought, answer_contract=contract)
-    assert "repo tools" in instruction
+def test_harness_motor_instruction_imperative_forward() -> None:
+    thought = make_thought(imperative="Inspect docker logs for orion-hub.")
+    instruction = harness_motor_instruction(thought=thought, answer_contract=None)
+    assert instruction == (
+        "Execute your imperative. Use tools when the turn requires verified facts "
+        "from the repo or runtime."
+    )

--- a/orion/harness/tests/test_harness_runner.py
+++ b/orion/harness/tests/test_harness_runner.py
@@ -102,3 +102,4 @@ async def test_harness_runner_uses_compile_harness_prefix() -> None:
     assert "Imperative: Check logs first." in prompt
     assert "Tone: direct" in prompt
     assert "what broke?" in prompt
+    assert "Execute your imperative" in prompt

--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 from typing import Any, Awaitable, Callable, Protocol
 
-from orion.cognition.answer_contract_normalize import heuristic_answer_contract
+from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.hub.association import build_hub_association_bundle
 from orion.hub.harness_step_stream import relay_harness_run_steps
 from orion.hub.turn_request import build_orion_turn_request
@@ -237,7 +237,7 @@ async def execute_unified_turn(
             read_runtime_logs=True,
             read_redis_traces=True,
         ),
-        answer_contract=heuristic_answer_contract(user_message),
+        answer_contract=AnswerContract(),
         repair_pressure_contract=_repair_pressure_contract(repair_bundle),
         fcc_model_label=payload.get("fcc_model_label") or DEFAULT_UNIFIED_TURN_FCC_MODEL_LABEL,
     )

--- a/orion/thought/tests/test_stance_react_prompt_imperative_discipline.py
+++ b/orion/thought/tests/test_stance_react_prompt_imperative_discipline.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_stance_react_prompt_imperative_discipline() -> None:
+    text = (REPO_ROOT / "orion/cognition/prompts/stance_react.j2").read_text(encoding="utf-8")
+    assert "IMPERATIVE DISCIPLINE" in text
+    assert "efference copy" in text.lower() or "what Orion must DO" in text
+    assert "world-contact" in text.lower() or "world contact" in text.lower()
+    assert "if user says" not in text.lower()

--- a/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
+++ b/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
@@ -118,6 +118,7 @@ async def test_turn_orchestrator_defaults_fcc_model_label() -> None:
         correlation_id=_CORR_ID,
         final_text="hello",
         finalize_ran=True,
+        step_count=1,
         compliance_verdict="completed",
         grounding_status="grounded",
     )
@@ -215,3 +216,36 @@ async def test_turn_orchestrator_turn_deferred_on_stance_defer() -> None:
         }
     ]
     harness_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_turn_orchestrator_passes_empty_answer_contract_not_heuristic() -> None:
+    harness_run = HarnessRunV1(
+        correlation_id=_CORR_ID,
+        final_text="hello",
+        finalize_ran=True,
+        step_count=1,
+        compliance_verdict="completed",
+        grounding_status="grounded",
+    )
+    bus = MagicMock()
+    harness_client_run = AsyncMock(return_value=harness_run)
+    patches = _hub_client_patches(thought=_thought(), harness_run=harness_client_run)
+    with patches[0], patches[1], patches[2]:
+        await execute_unified_turn(
+            bus=bus,
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="docker compose logs show traceback",
+            emit_observation_fn=lambda **_kwargs: None,
+        )
+
+    req = harness_client_run.await_args.args[0]
+    assert req.answer_contract.request_kind == "conceptual"
+    assert req.answer_contract.requires_repo_grounding is False
+    assert req.answer_contract.requires_runtime_grounding is False
+
+
+def test_turn_orchestrator_source_has_no_heuristic_answer_contract() -> None:
+    source = (REPO_ROOT / "orion/hub/turn_orchestrator.py").read_text(encoding="utf-8")
+    assert "heuristic_answer_contract" not in source


### PR DESCRIPTION
Pushed to `origin/fix/unified-turn-harness-runtime` (9 commits, `cb428f28..f822d3d2`).

`gh` isn’t authenticated here, so the PR wasn’t created automatically. Open it here:

**https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/unified-turn-harness-runtime?expand=1**

**Title:** `feat: imperative-first unified turn motor`

---

## Summary

- Unified-turn harness motor acts from felt imperative and coalition salience — single `HARNESS_UNIFIED_OPERATOR_BRIEF` in prefix, no pre-motor `AnswerContract` gating or `task_mode` taxonomy routing
- Hub unified turn passes empty `AnswerContract()` instead of `heuristic_answer_contract(user_message)`
- Stance react prompt gains IMPERATIVE DISCIPLINE block (efference copy / world-contact vs companionship)
- 5b/5c finalize contexts receive `grammar_receipts` trace summaries; voice prompt uses trace-backed preserve rules instead of `requires_repo_grounding` flags
- Includes unified-turn harness runtime wiring (FCC motor, step streaming, hub relay) from prior branch work

## Outcome moved

Motor behavior is driven by stance imperative and grammar action traces rather than heuristic contract classification. Finalize accountability checks whether world-contact happened (receipts) instead of contract flags.

## Tests run

```text
PYTHONPATH=. .venv/bin/python -m pytest \
  orion/harness/tests/ \
  orion/thought/tests/test_stance_react_prompt_imperative_discipline.py \
  orion/cognition/prompts/tests/test_imperative_first_prompts.py \
  services/orion-hub/tests/test_turn_orchestrator_ws_frames.py -q

40 passed in 2.88s
```

## Review findings fixed

- Runner keyword call to `harness_motor_instruction` (`thought=thought`)
- Duplicate misaligned rules merged in voice finalize prompt
- Finalize chain test asserts `grammar_receipts` in both 5b and 5c cortex contexts

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build

docker compose --env-file .env --env-file services/orion-harness-governor/.env \
  -f services/orion-harness-governor/docker-compose.yml up -d --build

docker compose --env-file .env --env-file services/orion-thought/.env \
  -f services/orion-thought/docker-compose.yml up -d --build
```

## Plan / spec

- `docs/superpowers/plans/2026-07-05-orion-imperative-first-motor.md`
- `docs/superpowers/specs/2026-07-05-orion-imperative-first-motor-design.md`

---

To create the PR from CLI after auth: `gh auth login`, then say the word and I’ll run `gh pr create`.