### PR TITLE
fix(unified-turn): harden 5b finalize and motor read discipline

### DIFF
--- a/orion/cognition/cortex_payload_extract.py
+++ b/orion/cognition/cortex_payload_extract.py
@@ -1,0 +1,142 @@
+"""Extract model text / JSON-bearing strings from Cortex PlanExecutionResult-shaped dicts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _openai_choice_message_text(raw: Any) -> list[str]:
+    out: list[str] = []
+    if not isinstance(raw, dict):
+        return out
+    choices = raw.get("choices")
+    if not isinstance(choices, list):
+        return out
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        msg = choice.get("message")
+        if not isinstance(msg, dict):
+            continue
+        for field in ("content", "reasoning_content", "reasoning", "reasoning_text"):
+            val = msg.get(field)
+            if isinstance(val, str) and val.strip():
+                out.append(val.strip())
+    return out
+
+
+def _service_block_text_candidates(block: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for field in (
+        "content",
+        "final_text",
+        "text",
+        "reasoning_content",
+        "inline_think_content",
+        "structured",
+        "json",
+        "payload",
+    ):
+        val = block.get(field)
+        if isinstance(val, str) and val.strip():
+            out.append(val.strip())
+        elif isinstance(val, dict):
+            out.append(str(val))
+    raw = block.get("raw")
+    if isinstance(raw, dict):
+        out.extend(_openai_choice_message_text(raw))
+    return out
+
+
+def _step_text_candidates(step: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for container_key in ("result", "detail"):
+        container = step.get(container_key)
+        if not isinstance(container, dict):
+            continue
+        for block in container.values():
+            if isinstance(block, dict):
+                out.extend(_service_block_text_candidates(block))
+            elif isinstance(block, str) and block.strip():
+                out.append(block.strip())
+        output = container.get("output") if isinstance(container.get("output"), dict) else None
+        if output is not None:
+            out.extend(_service_block_text_candidates(output))
+        for field in ("text", "content", "final_text", "structured", "json", "payload"):
+            val = container.get(field)
+            if isinstance(val, str) and val.strip():
+                out.append(val.strip())
+    return out
+
+
+def _sorted_steps(steps: list[Any]) -> list[dict[str, Any]]:
+    typed: list[dict[str, Any]] = [s for s in steps if isinstance(s, dict)]
+
+    def _rank(step: dict[str, Any]) -> tuple[int, int]:
+        order = step.get("order")
+        return 0, int(order) if isinstance(order, int) else 0
+
+    return sorted(typed, key=_rank)
+
+
+def extract_cortex_payload_text(raw: dict[str, Any]) -> str:
+    """Return best-effort model text from a cortex exec payload (may be JSON-ish prose)."""
+    if not isinstance(raw, dict):
+        return ""
+
+    for field in ("final_text", "text", "content"):
+        val = raw.get(field)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+
+    steps = _sorted_steps(list(raw.get("steps") or raw.get("step_results") or []))
+    for step in reversed(steps):
+        candidates = _step_text_candidates(step)
+        if candidates:
+            return candidates[-1]
+
+    nested = raw.get("result")
+    if isinstance(nested, dict):
+        nested_text = extract_cortex_payload_text(nested)
+        if nested_text:
+            return nested_text
+
+    meta = raw.get("metadata")
+    if isinstance(meta, dict):
+        preview = meta.get("structured_rejection_preview")
+        if isinstance(preview, str) and preview.strip():
+            return preview.strip()
+
+    return ""
+
+
+def cortex_exec_failure_detail(result: dict[str, Any]) -> str | None:
+    """Summarize why a cortex exec payload has no usable model text."""
+    if not isinstance(result, dict):
+        return "cortex exec returned non-dict payload"
+
+    status = str(result.get("status") or "").strip().lower()
+    error = result.get("error")
+    if isinstance(error, str) and error.strip():
+        return error.strip()
+
+    steps = list(result.get("steps") or [])
+    step_errors: list[str] = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        step_error = step.get("error")
+        if isinstance(step_error, str) and step_error.strip():
+            step_errors.append(step_error.strip())
+    if step_errors:
+        return step_errors[-1]
+
+    meta = result.get("metadata")
+    if isinstance(meta, dict) and meta.get("structured_output_rejected"):
+        preview = str(meta.get("structured_rejection_preview") or "")[:240]
+        return f"structured_output_rejected preview={preview!r}"
+
+    if status in {"fail", "partial", "error"}:
+        return f"cortex exec status={status or 'unknown'} with empty final_text"
+
+    return None

--- a/orion/harness/finalize.py
+++ b/orion/harness/finalize.py
@@ -8,7 +8,9 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
+from orion.cognition.cortex_payload_extract import cortex_exec_failure_detail, extract_cortex_payload_text
 from orion.cognition.plan_loader import build_plan_for_verb
+from orion.core.llm_json import parse_json_object
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.cortex.schemas import PlanExecutionArgs, PlanExecutionRequest
 from orion.schemas.harness_finalize import (
@@ -189,30 +191,18 @@ def build_finalize_reflect_plan_request(
 
 def parse_finalize_reflection_payload(raw: dict[str, Any] | str) -> FinalizeReflectionV1:
     if isinstance(raw, str):
-        raw = json.loads(raw)
+        raw = parse_json_object(raw)
     return FinalizeReflectionV1.model_validate(raw)
 
 
 def extract_finalize_reflection_payload(result: dict[str, Any]) -> dict[str, Any] | str:
-    final_text = result.get("final_text")
-    if isinstance(final_text, str) and final_text.strip():
-        return final_text
+    text = extract_cortex_payload_text(result)
+    if text:
+        return text
 
-    steps = result.get("steps") or []
-    for step in reversed(steps):
-        if not isinstance(step, dict):
-            continue
-        step_result = step.get("result")
-        if not isinstance(step_result, dict):
-            continue
-        for key in ("structured", "json", "payload", "final_text", "text", "content"):
-            value = step_result.get(key)
-            if value is None:
-                continue
-            if isinstance(value, str) and not value.strip():
-                continue
-            return value
-
+    detail = cortex_exec_failure_detail(result)
+    if detail:
+        raise ValueError(f"harness_finalize_reflect exec failed: {detail}")
     raise ValueError("harness_finalize_reflect exec result missing reflection payload")
 
 
@@ -379,22 +369,13 @@ def build_voice_finalize_plan_request(
 
 
 def extract_voice_finalize_text(result: dict[str, Any]) -> str:
-    final_text = result.get("final_text")
-    if isinstance(final_text, str) and final_text.strip():
-        return final_text.strip()
+    text = extract_cortex_payload_text(result)
+    if text:
+        return text
 
-    steps = result.get("steps") or []
-    for step in reversed(steps):
-        if not isinstance(step, dict):
-            continue
-        step_result = step.get("result")
-        if not isinstance(step_result, dict):
-            continue
-        for key in ("final_text", "text", "content"):
-            value = step_result.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-
+    detail = cortex_exec_failure_detail(result)
+    if detail:
+        raise ValueError(f"orion_voice_finalize exec failed: {detail}")
     raise ValueError("orion_voice_finalize exec result missing final_text")
 
 

--- a/orion/harness/operator_brief.py
+++ b/orion/harness/operator_brief.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
-HARNESS_REPO_OPERATOR_BRIEF = """\
+# Motor FCC sessions share one context window across all tool steps; full-file reads
+# can blow the budget before the turn finishes (see unified-turn live runs).
+HARNESS_MOTOR_MAX_READ_LINES = 200
+
+_READ_DISCIPLINE = (
+    f"Before Read on any file: prefer rg/Grep with a path or pattern. "
+    f"Never Read an entire file longer than {HARNESS_MOTOR_MAX_READ_LINES} lines — "
+    f"use Read offset/limit in chunks or rg for symbols and log lines."
+)
+
+HARNESS_REPO_OPERATOR_BRIEF = f"""\
 Orion harness motor — repo/technical turn.
 Use tools from the start when the answer depends on code, config, or runtime facts.
-Before Read on any file: prefer rg/Grep with a path or pattern. For large files, use Read offset/limit in chunks.
+{_READ_DISCIPLINE}
 Cite concrete file paths, symbols, and commands in the draft. Do not guess repo structure from memory.
 """
 
@@ -14,11 +24,10 @@ Orion harness motor — runtime/debug turn.
 Verify live state with tools (logs, docker, bus traces) before diagnosing. Name exact services, channels, and commands.
 """
 
-HARNESS_UNIFIED_OPERATOR_BRIEF = """\
+HARNESS_UNIFIED_OPERATOR_BRIEF = f"""\
 Orion harness motor.
 Tools are available from the start. Your imperative states what this turn requires.
 When the imperative calls for facts from the codebase or live runtime, use tools before
 answering. Record each meaningful step. Do not guess repo structure or service state from memory.
-Before Read on any file: prefer rg/Grep with a path or pattern. For live failures, inspect logs,
-docker, and bus traces before diagnosing.
+{_READ_DISCIPLINE} For live failures, inspect logs, docker, and bus traces before diagnosing.
 """

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from orion.harness.operator_brief import HARNESS_UNIFIED_OPERATOR_BRIEF
+from orion.harness.operator_brief import (
+    HARNESS_MOTOR_MAX_READ_LINES,
+    HARNESS_UNIFIED_OPERATOR_BRIEF,
+)
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import HarnessRepairOverlayV1
 from orion.schemas.thought import StanceHarnessSliceV1, ThoughtEventV1
@@ -30,7 +33,9 @@ def harness_motor_instruction(
     _ = answer_contract  # deprecated on unified motor path; kept for signature compat
     return (
         "Execute your imperative. Use tools when the turn requires verified facts "
-        "from the repo or runtime."
+        "from the repo or runtime. "
+        f"Do not Read whole files over {HARNESS_MOTOR_MAX_READ_LINES} lines — "
+        "use rg/Grep or Read offset/limit."
     )
 
 

--- a/orion/harness/tests/test_finalize_cortex_payload_extract.py
+++ b/orion/harness/tests/test_finalize_cortex_payload_extract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from orion.cognition.cortex_payload_extract import (
+    cortex_exec_failure_detail,
+    extract_cortex_payload_text,
+)
+from orion.harness.finalize import extract_finalize_reflection_payload, parse_finalize_reflection_payload
+
+
+def test_extract_cortex_payload_text_from_nested_llm_gateway_service() -> None:
+    payload = {
+        "status": "success",
+        "final_text": "",
+        "steps": [
+            {
+                "step_name": "llm_harness_finalize_reflect",
+                "order": 0,
+                "result": {
+                    "LLMGatewayService": {
+                        "content": '{"correlation_id":"c-1","alignment_verdict":"aligned"}',
+                    }
+                },
+            }
+        ],
+    }
+    assert "alignment_verdict" in extract_cortex_payload_text(payload)
+
+
+def test_extract_finalize_reflection_payload_surfaces_step_error() -> None:
+    payload = {
+        "status": "fail",
+        "final_text": "",
+        "steps": [
+            {
+                "error": "API returned an empty or malformed response (HTTP 200)",
+                "result": {"LLMGatewayService": {}},
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="harness_finalize_reflect exec failed"):
+        extract_finalize_reflection_payload(payload)
+
+
+def test_parse_finalize_reflection_payload_from_nested_step_content() -> None:
+    raw = extract_finalize_reflection_payload(
+        {
+            "steps": [
+                {
+                    "result": {
+                        "LLMGatewayService": {
+                            "content": """{
+  "correlation_id": "c-1",
+  "thought_event_id": "t-1",
+  "substrate_appraisal_id": "a-1",
+  "draft_hash": "d-1",
+  "imperative": "explain",
+  "tone": "curious",
+  "strain_refs": [],
+  "alignment_verdict": "aligned",
+  "alignment_notes": [],
+  "strain_unresolved": false
+}"""
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    reflection = parse_finalize_reflection_payload(raw)
+    assert reflection.alignment_verdict == "aligned"
+
+
+def test_cortex_exec_failure_detail_reads_structured_rejection_preview() -> None:
+    detail = cortex_exec_failure_detail(
+        {
+            "status": "fail",
+            "metadata": {
+                "structured_output_rejected": True,
+                "structured_rejection_preview": '{"correlation_id":"c-1"',
+            },
+        }
+    )
+    assert detail is not None
+    assert "structured_output_rejected" in detail

--- a/orion/harness/tests/test_finalize_reflection_json_parse.py
+++ b/orion/harness/tests/test_finalize_reflection_json_parse.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from orion.harness.finalize import parse_finalize_reflection_payload
+
+
+def _minimal_reflection_json() -> str:
+    return """{
+  "correlation_id": "c-1",
+  "thought_event_id": "t-1",
+  "substrate_appraisal_id": "a-1",
+  "draft_hash": "d-1",
+  "imperative": "explain",
+  "tone": "curious",
+  "strain_refs": [],
+  "alignment_verdict": "aligned",
+  "alignment_notes": [],
+  "strain_unresolved": false
+}"""
+
+
+def test_parse_finalize_reflection_payload_accepts_wrapped_json() -> None:
+    raw = f"Here is the reflection JSON:\n```json\n{_minimal_reflection_json()}\n```"
+    reflection = parse_finalize_reflection_payload(raw)
+    assert reflection.correlation_id == "c-1"
+    assert reflection.alignment_verdict == "aligned"
+
+
+def test_parse_finalize_reflection_payload_accepts_prose_prefix() -> None:
+    raw = f"Integrative check complete.\n{_minimal_reflection_json()}"
+    reflection = parse_finalize_reflection_payload(raw)
+    assert reflection.thought_event_id == "t-1"
+
+
+def test_parse_finalize_reflection_payload_rejects_garbage() -> None:
+    with pytest.raises(ValueError, match="Could not parse JSON object"):
+        parse_finalize_reflection_payload("not json at all")

--- a/orion/harness/tests/test_harness_prefix.py
+++ b/orion/harness/tests/test_harness_prefix.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from orion.harness.operator_brief import HARNESS_MOTOR_MAX_READ_LINES
 from orion.harness.prefix import compile_harness_prefix, harness_motor_instruction
 from orion.harness.tests.fixtures import make_thought
 from orion.schemas.cognition.answer_contract import AnswerContract
@@ -35,6 +36,7 @@ def test_compile_harness_prefix_imperative_first_unified_brief() -> None:
     assert "Answer contract:" not in prompt
     assert "Orion harness motor — repo/technical turn" not in prompt  # old gated brief
     assert "prefer rg/Grep" in prompt  # unified brief includes tool guidance
+    assert f"longer than {HARNESS_MOTOR_MAX_READ_LINES} lines" in prompt
 
 
 def test_compile_harness_prefix_ignores_answer_contract() -> None:
@@ -55,7 +57,6 @@ def test_compile_harness_prefix_ignores_answer_contract() -> None:
 def test_harness_motor_instruction_imperative_forward() -> None:
     thought = make_thought(imperative="Inspect docker logs for orion-hub.")
     instruction = harness_motor_instruction(thought=thought, answer_contract=None)
-    assert instruction == (
-        "Execute your imperative. Use tools when the turn requires verified facts "
-        "from the repo or runtime."
-    )
+    assert "Execute your imperative" in instruction
+    assert f"over {HARNESS_MOTOR_MAX_READ_LINES} lines" in instruction
+    assert "rg/Grep" in instruction

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -395,6 +395,10 @@ def _resolve_llm_chat_max_tokens(step: ExecutionStep, ctx: Dict[str, Any]) -> Tu
     if step.verb_name == "memory_graph_suggest" and step.step_name == "llm_memory_graph_suggest":
         return int(settings.llm_memory_graph_suggest_max_tokens), requested, "settings.llm_memory_graph_suggest_max_tokens"
 
+    # Unified turn 5b/5c return strict JSON; default 512 truncates mid-object (finish_reason=length).
+    if step.verb_name in {"harness_finalize_reflect", "orion_voice_finalize"}:
+        return int(settings.llm_chat_general_max_tokens), requested, "settings.llm_chat_general_max_tokens_harness_finalize"
+
     return int(settings.llm_chat_max_tokens_default), requested, "settings.llm_chat_max_tokens_default"
 
 
@@ -1603,6 +1607,8 @@ def _resolve_llm_max_tokens(*, ctx: Dict[str, Any], step: ExecutionStep) -> tupl
         return max(1, int(settings.llm_chat_general_max_tokens)), "general_default", requested
     if step.verb_name == "memory_graph_suggest" and step.step_name == "llm_memory_graph_suggest":
         return max(1, int(settings.llm_memory_graph_suggest_max_tokens)), "memory_graph_suggest_default", requested
+    if step.verb_name in {"harness_finalize_reflect", "orion_voice_finalize"}:
+        return max(1, int(settings.llm_chat_general_max_tokens)), "harness_finalize_default", requested
     return max(1, int(settings.llm_chat_fallback_max_tokens)), "fallback_default", requested
 
 

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -82,6 +82,7 @@ def _structured_output_expected(verb_name: str | None) -> bool:
         "concept_induction_journal_synthesize",
         "memory_graph_suggest",
         "stance_react",
+        "harness_finalize_reflect",
     }
 
 
@@ -308,13 +309,12 @@ def _extract_final_text(steps: List[StepExecutionResult], *, verb_name: str | No
                         ("final_text", payload.get("final_text")),
                     )
                     json_text = _extract_first_json_object_text(cleaned)
-                    if not json_text and str(verb_name or "").strip().lower() == "memory_graph_suggest":
+                    if not json_text and provider_meta.get("finish_reason") == "length" and cleaned.lstrip().startswith("{"):
                         from orion.memory_graph.json_extract import salvage_truncated_json_object_text
 
-                        if provider_meta.get("finish_reason") == "length" and cleaned.lstrip().startswith("{"):
-                            json_text = salvage_truncated_json_object_text(cleaned)
-                            if json_text:
-                                diagnostics["structured_output_salvaged"] = True
+                        json_text = salvage_truncated_json_object_text(cleaned)
+                        if json_text:
+                            diagnostics["structured_output_salvaged"] = True
                     if not json_text:
                         for extra_field, extra_val in extra_fields:
                             if extra_field == field:
@@ -328,7 +328,7 @@ def _extract_final_text(steps: List[StepExecutionResult], *, verb_name: str | No
                                 candidate_diag["raw_len"] = len(extra_val.strip())
                                 break
                     if json_text:
-                        diagnostics["source_field"] = field
+                        diagnostics["source_field"] = candidate_diag.get("field", field)
                         diagnostics["source_service"] = service_name
                         diagnostics["think_tags_detected"] = bool(think_diag["has_think_tags"])
                         diagnostics["think_stripping_applied"] = bool(think_diag["think_stripped"])

--- a/services/orion-cortex-exec/tests/test_harness_finalize_max_tokens.py
+++ b/services/orion-cortex-exec/tests/test_harness_finalize_max_tokens.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.executor import _resolve_llm_chat_max_tokens, _resolve_llm_max_tokens
+from orion.schemas.cortex.types import ExecutionStep
+
+
+def _step(*, verb_name: str, step_name: str) -> ExecutionStep:
+    return ExecutionStep(
+        verb_name=verb_name,
+        step_name=step_name,
+        order=0,
+        services=["LLMGatewayService"],
+        prompt_template="x.j2",
+    )
+
+
+def test_harness_finalize_reflect_uses_general_max_tokens_budget(monkeypatch) -> None:
+    import app.executor as executor_mod
+
+    monkeypatch.setattr(
+        executor_mod,
+        "settings",
+        SimpleNamespace(
+            llm_chat_general_max_tokens=8000,
+            llm_chat_max_tokens_default=512,
+            llm_dream_max_tokens=32768,
+            llm_chat_quick_max_tokens=384,
+            llm_memory_graph_suggest_max_tokens=4096,
+        ),
+    )
+    step = _step(verb_name="harness_finalize_reflect", step_name="llm_harness_finalize_reflect")
+    eff, _req, src = _resolve_llm_chat_max_tokens(step, {})
+    assert eff == 8000
+    assert src == "settings.llm_chat_general_max_tokens_harness_finalize"
+
+
+def test_orion_voice_finalize_uses_general_max_tokens_budget(monkeypatch) -> None:
+    import app.executor as executor_mod
+
+    monkeypatch.setattr(
+        executor_mod,
+        "settings",
+        SimpleNamespace(
+            llm_chat_general_max_tokens=8000,
+            llm_chat_max_tokens_default=512,
+            llm_dream_max_tokens=32768,
+            llm_chat_quick_max_tokens=384,
+            llm_memory_graph_suggest_max_tokens=4096,
+            llm_chat_fallback_max_tokens=512,
+        ),
+    )
+    step = _step(verb_name="orion_voice_finalize", step_name="llm_orion_voice_finalize")
+    eff, src, _ = _resolve_llm_max_tokens(ctx={}, step=step)
+    assert eff == 8000
+    assert src == "harness_finalize_default"

--- a/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
+++ b/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
@@ -56,6 +56,19 @@ def test_stance_react_structured_verb_extracts_json_object() -> None:
     assert diag["structured_json_extraction_attempted"] is True
 
 
+def test_harness_finalize_reflect_structured_verb_extracts_json_object() -> None:
+    payload = (
+        '{"correlation_id":"c-1","thought_event_id":"t-1","substrate_appraisal_id":"a-1",'
+        '"draft_hash":"d-1","imperative":"x","tone":"y","strain_refs":[],"alignment_verdict":"aligned",'
+        '"alignment_notes":[],"strain_unresolved":false}'
+    )
+    final_text, diag = _extract_final_text([
+        _step({"content": f"Reflection:\\n```json\\n{payload}\\n```"})
+    ], verb_name="harness_finalize_reflect")
+    assert '"alignment_verdict":"aligned"' in final_text
+    assert diag["structured_json_extraction_attempted"] is True
+
+
 def test_structured_verb_uses_clean_final_answer_not_reasoning_fields() -> None:
     final_text, diag = _extract_final_text([
         _step(
@@ -101,7 +114,7 @@ def test_concept_induction_regression_strips_think_and_returns_json() -> None:
     assert final_text == '{"mode":"manual","title":"Synthesis","body":"Stable output."}'
 
 
-def test_structured_verb_keeps_scanning_candidates_after_rejecting_first() -> None:
+def test_structured_verb_recovers_json_from_sibling_payload_field() -> None:
     final_text, diag = _extract_final_text([
         _step(
             {
@@ -109,6 +122,17 @@ def test_structured_verb_keeps_scanning_candidates_after_rejecting_first() -> No
                 "text": '{"mode":"manual","title":"Recovered","body":"From text field."}',
             }
         )
+    ], verb_name="concept_induction_journal_synthesize")
+    assert final_text == '{"mode":"manual","title":"Recovered","body":"From text field."}'
+    assert diag["source_field"] == "text"
+    assert diag["candidate_count"] == 1
+    assert diag["rejected_candidate_count"] == 0
+
+
+def test_structured_verb_keeps_scanning_candidates_after_rejecting_first() -> None:
+    final_text, diag = _extract_final_text([
+        _step({"text": '{"mode":"manual","title":"Recovered","body":"From text field."}'}),
+        _step({"content": "not json at all"}),
     ], verb_name="concept_induction_journal_synthesize")
     assert final_text == '{"mode":"manual","title":"Recovered","body":"From text field."}'
     assert diag["source_field"] == "text"


### PR DESCRIPTION
## DONE_WITH_CONCERNS

Branch pushed: `fix/harness-finalize-reflect-json-parse` (`3f6e51cb`)

`gh pr create` failed (no `gh auth`). Open manually:

**https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/harness-finalize-reflect-json-parse**

---

### What shipped

**5b finalize hardening**
- `parse_json_object()` instead of naive `json.loads` in `orion/harness/finalize.py`
- Shared `orion/cognition/cortex_payload_extract.py` for 5b/5c payload extraction
- `harness_finalize_reflect` + `orion_voice_finalize` use 8000 max tokens (not 512)
- Router: truncation salvage on `finish_reason=length` for structured verbs

**Motor read discipline**
- `HARNESS_MOTOR_MAX_READ_LINES = 200` in `orion/harness/operator_brief.py`
- Unified brief + `harness_motor_instruction()` tell motor: prefer `rg`/Grep, never Read whole files >200 lines

**Tests:** 64 passed

---

### Restart

```bash
docker compose --env-file .env --env-file services/orion-harness-governor/.env -f services/orion-harness-governor/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-cortex-exec/.env -f services/orion-cortex-exec/docker-compose.yml up -d --build
```

---

### Concerns

- Motor read limit is **prompt-level only** — no hard FCC guard yet. A motor can still blow context on a full `worker.py` read; this reduces likelihood via the operator brief choke point.