### PR TITLE
Feat/reverie spontaneous thought phase a

### DIFF
--- a/PR_reverie_phase_a.md
+++ b/PR_reverie_phase_a.md
@@ -1,0 +1,114 @@
+## Summary
+
+- Reconciles the reverie/dream weave spec with the **already-shipped `orion-thought` service** (unified-turn, #817–820): v2's premise "nothing gives a coalition a voice" was false — `stance_react`/`ThoughtEventV1` already narrates it. Adds a taxonomy: **evoked** thought (`ThoughtEventV1`) vs **spontaneous** thought (`SpontaneousThoughtV1`), split by trigger + destination, sharing `CoalitionSnapshotV1` grounding, both housed in `orion-thought`.
+- Implements **Phase A**: a spontaneous-thought *mode* inside `orion-thought`. A self-driven tick reads the current rung-3 winning coalition (no `user_message`), narrates it via a new `reverie_narrate` cortex verb over the existing exec rail, and emits `SpontaneousThoughtV1` on `orion:reverie:thought`.
+- Load-bearing `is_hollow()` guard rejects short **and** un-anchored text — the real Phase A fail-fast risk now that no user question anchors relevance.
+- Everything is **default-off** (`ORION_REVERIE_ENABLED=false`) and **read-only** — no proposals, no memory writes, evoked path untouched.
+- Salience is **deterministic** (§4): code owns it from coalition scores; the LLM owns only interpretation text.
+
+## Outcome moved
+
+New unprompted-cognition seam: `orion-thought` can now narrate its own current coalition when nobody asked (the first self-activated thought path), gated off. Before, coalition narration only fired in response to a user turn.
+
+## Current architecture (before)
+
+`orion-thought` = RPC turn-worker only: `orion:thought:request` (`StanceReactRequestV1`, requires `user_message`) → `stance_react` verb → `ThoughtEventV1` → Hub reply + `orion:thought:artifact`. Nothing narrated the coalition unprompted.
+
+## Architecture touched
+
+- `orion-thought`: second entrypoint (`run_reverie_worker`) beside `run_bus_worker`, wired into the FastAPI lifespan, default-off.
+- New cortex verb `reverie_narrate` (reuses `LLMGatewayService` + `build_plan_for_verb` + `CortexExecClient`).
+- New schema `SpontaneousThoughtV1` + registry + bus channel `orion:reverie:thought`.
+
+## Files changed
+
+- `docs/superpowers/plans/2026-07-05-reverie-dream-compaction-weave.md`: v3 reconciliation (premise, taxonomy, Phase A, rationale, component map, delivery status).
+- `orion/schemas/reverie.py` (new): `SpontaneousThoughtV1`, `is_hollow()` guard, reuses `CoalitionSnapshotV1`.
+- `orion/schemas/registry.py`: register `SpontaneousThoughtV1` → `reverie.thought.v1`.
+- `orion/bus/channels.yaml`: `orion:reverie:thought` event channel.
+- `orion/cognition/verbs/reverie_narrate.yaml` + `orion/cognition/prompts/reverie_narrate.j2` (new): mirror `stance_react`, reflection-shaped.
+- `services/orion-thought/app/reverie.py` (new): producer — coalition read (fail-open), deterministic salience, narrate, hollow-drop, emit; degrades to None, never raises.
+- `services/orion-thought/app/{settings,main}.py`: reverie env flags + gated self-driven task.
+- `services/orion-thought/.env_example`: default-off flags.
+- `services/orion-sql-db/manual_migration_substrate_reverie_thought.sql` (new): store table (contract-ahead; writer deferred).
+- `services/orion-thought/tests/test_reverie_spontaneous_thought.py` + `evals/test_reverie_hollow_guard_eval.py` (new).
+
+## Schema / bus / API changes
+
+- **Added:** `SpontaneousThoughtV1` (`reverie.thought.v1`); channel `orion:reverie:thought` (event, producer `orion-thought`).
+- **Removed / Renamed:** none.
+- **Behavior changed:** none to existing paths — evoked `stance_react`/`ThoughtEventV1` untouched.
+- **Compatibility:** additive; new channel/schema, default-off producer.
+
+## Env/config changes
+
+- **Added keys:** `ORION_REVERIE_ENABLED=false`, `ORION_REVERIE_INTERVAL_SEC=90`, `ORION_REVERIE_MIN_SALIENCE=0.0`, `CHANNEL_REVERIE_THOUGHT=orion:reverie:thought` (in `services/orion-thought/.env_example`).
+- **`.env_example` updated:** yes. All safe non-secret defaults.
+- **local `.env` sync:** ran `python scripts/sync_local_env_from_example.py`; `orion-thought` reported `no .env` (service has no local `.env` in this worktree). **Operator action:** on the athena host, run the sync after merge to add the four keys — the feature stays off without them (no functional impact until you enable it). Set `ORION_BUS_URL=redis://<tailscale-node-ip>:6379/0` as always.
+- **Skipped keys:** none.
+
+## Tests run
+
+```text
+pytest services/orion-thought/tests/ services/orion-thought/evals/  → 23 passed
+# schema hollow-guard (5), producer grounding/salience (4), tick gating +
+# never-raise (6), default-reader coverage (3), existing suite (2), + eval (1)
+build_plan_for_verb('reverie_narrate') → plan loads
+registry import → SpontaneousThoughtV1 registered as reverie.thought.v1
+channels.yaml parse → orion:reverie:thought present
+```
+
+## Evals run
+
+```text
+pytest services/orion-thought/evals/test_reverie_hollow_guard_eval.py → 1 passed
+# un-anchored hollow-guard: 7/7 labeled cases (grounded vs drivel) separated
+```
+
+## Docker/build/smoke checks
+
+```text
+NOT RUN — no live mesh in this environment. Runtime evidence for Phase A
+(stored SpontaneousThoughtV1 whose coalition matches a live broadcast,
+rendered in hub) is UNVERIFIED until run on the athena host. This is an
+honest §0A UNVERIFIED, not a claimed pass.
+```
+
+## Review findings fixed
+
+- **Finding (HIGH):** `_default_broadcast_reader` built `SubstrateFeltStateReader` without the required `enabled` kwarg → `TypeError` swallowed by the broad except → producer dead-on-arrival, never emits; masked because every test injected a fake reader.
+  - **Fix:** switch to the public fail-open `hydrate_felt_state_ctx` entrypoint; add 3 tests that actually exercise the default reader.
+  - **Evidence:** `test_default_broadcast_reader_*` (hydrate / empty / never-raises) pass.
+- **Finding (LOW):** parse + `bus.publish` ran outside the `try/except`; a bus failure could raise out of a tick, violating "adapters never raise."
+  - **Fix:** wrap the whole tail; a tick degrades to a dropped `None`.
+  - **Evidence:** `test_tick_swallows_publish_failure` passes.
+- **Finding (MEDIUM):** orphan migration + no store-writer/hub panel.
+  - **Fix:** explicitly marked store-writer + hub panel + live smoke as DEFERRED in the plan's Phase A "Delivery status"; evidence flagged `UNVERIFIED`.
+  - **Evidence:** doc delivery-status block.
+
+## Restart required
+
+```bash
+# After merge + pull on athena. Feature is default-off; these just deploy the code.
+python scripts/sync_local_env_from_example.py   # adds the 4 reverie keys
+psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_substrate_reverie_thought.sql
+# restart orion-thought (self-driven tick is a no-op until ORION_REVERIE_ENABLED=true):
+docker compose --env-file .env --env-file services/orion-thought/.env \
+  -f services/orion-thought/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- **Severity: medium.** Phase A's runtime evidence is `UNVERIFIED` (no live mesh here). Do not consider Phase A "done" per §0A until a real tick emits a coalition-matched, non-hollow `SpontaneousThoughtV1` on the athena host with the flag on.
+- **Severity: low.** The store-writer + hub `_reverie_section` panel are deferred, so there is no inspection surface yet — enabling the flag emits to the bus channel only.
+- **Severity: low.** The hollow guard is structural (evidence-ref anchoring); semantic "aboutness" is delegated to the prompt. Acceptable for Phase A; Phase H's resonance/efficacy evals are the real quality gate.
+
+## Scope note
+
+This PR is **spec reconciliation + Phase A only**. Phases B–H (thought→governed action, reverie chain, episode grounding, compaction request, dream REM, compaction applier, efficacy/resonance evals) remain proposal-mode and ship phase-by-phase with live verification per the plan's own escalating-blast-radius discipline — deliberately not bundled into one blind sprint.
+
+## PR link
+
+(this PR)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/superpowers/plans/2026-07-05-reverie-dream-compaction-weave.md
+++ b/docs/superpowers/plans/2026-07-05-reverie-dream-compaction-weave.md
@@ -1,10 +1,10 @@
 # Reverie / Dream / Compaction Weave — substrate-native
 
-Proposal-mode design (§0A). Status: **PROPOSAL — not yet implemented.** Every phase ships behind a flag, default off, with rollback.
+Proposal-mode design (§0A). Status: **v3 — reconciled with the shipped `orion-thought` service.** v3 correction: the coalition already has a voice (`orion-thought`/`ThoughtEventV1`); reverie is the **spontaneous-thought mode inside `orion-thought`**, not a new organ (see "Correction from v2" below). Phase A implemented behind `ORION_REVERIE_ENABLED=false`; Phases B–H remain proposal-mode. Every phase ships behind a flag, default off, with rollback.
 
 Mission tie-in: builds prerequisites for sentience — continuity, reflection, self-modeling, error-correction, coherent action — as thin runtime seams on the existing substrate, not a bolt-on.
 
-> ⛔ **GOVERNING CONSTRAINT — no keyword cathedrals (§0A).** None of this may ship as labels, taxonomies, or cognition jargon that does not move a live runtime path. `ThoughtV1`, `reverie`, `dream`, `MemoryCompactionDeltaV1`, "semantic organ", "coalition narration" — every one of these names is **banned until, in the same patch, it carries: schema contract · producer · consumer · reducer/materializer · UI/debug surface · metric or trace · test · eval · live smoke.** A phase is not "done" because the word exists in code. It is done when the live path moved and there is inspectable evidence (emitted event, stored artifact, cursor movement, rendered panel, log line with correlation id). If the path is not verified, the status is `UNVERIFIED`. Empty-shell cognition — a `ThoughtV1` with hollow text, a compaction delta over nothing, a panel with no backing artifact, `raw_len=0` treated as success — is a **failed** phase, not a shipped one. Runtime truth beats config truth: the flag being on is not proof; the coalition being narrated with real content is.
+> ⛔ **GOVERNING CONSTRAINT — no keyword cathedrals (§0A).** None of this may ship as labels, taxonomies, or cognition jargon that does not move a live runtime path. `SpontaneousThoughtV1`, `reverie`, `dream`, `MemoryCompactionDeltaV1`, "semantic organ", "coalition narration" — every one of these names is **banned until, in the same patch, it carries: schema contract · producer · consumer · reducer/materializer · UI/debug surface · metric or trace · test · eval · live smoke.** A phase is not "done" because the word exists in code. It is done when the live path moved and there is inspectable evidence (emitted event, stored artifact, cursor movement, rendered panel, log line with correlation id). If the path is not verified, the status is `UNVERIFIED`. Empty-shell cognition — a `SpontaneousThoughtV1` with hollow text, a compaction delta over nothing, a panel with no backing artifact, `raw_len=0` treated as success — is a **failed** phase, not a shipped one. Runtime truth beats config truth: the flag being on is not proof; the coalition being narrated with real content is.
 
 > **Correction from v1 of this doc.** v1 designed reverie as a parallel service: pressure → LLM thought chain → orion-actions, point-to-point. That is a **shadow mesh**. It bypasses the substrate ladder, bypasses Layer 7/8 governance, and re-invents rung-4 episodic consolidation and rung-5 curiosity that already exist. This version routes thoughts **through** the substrate.
 
@@ -35,12 +35,39 @@ Layer 9 dispatch is where an approved proposal becomes a real action (orion-acti
 
 **So everything the last three turns asked for already has scaffolding:** pressure trigger (rung 1 + metacog gate), thought-through-the-mesh routing (rung 3 workspace + Layers 5–11), continuity/EMA (coalition dwell log), SQUIRREL/drift (rung 5 curiosity from unresolved open-loops), episodic compaction (rung 4 `EpisodeSummaryV1`), governed actions (Layer 7→8→9), consolidation (Layer 11).
 
-## What is actually missing: the semantic organ
+## Correction from v2: the coalition already has a voice (`orion-thought`)
 
-The whole ladder is **deterministic frames**. Nothing gives a winning coalition or an episode summary a **voice** — a thought *in language*, a dream *as narrative*. That is the one true gap. Reverie and Dream are the **language cortex on top of the substrate**, not a new mesh.
+> **v2 of this doc claimed "nothing gives a winning coalition a voice." That is now false.** The `orion-thought` service (unified-turn, PRs #817–820) already narrates the coalition into language. The gap is narrower than v2 framed, and reverie must be built *inside* that service, not as a fresh organ.
 
-- **Reverie** = the awake semantic organ. It narrates the current rung-3 winning coalition into a `ThoughtV1`, and — crucially — emits its conclusions as `ProposalFrameV1` so they climb Layers 7→8→9 (governance, then action). It does not call orion-actions directly.
-- **Dream** = the offline semantic organ. It narrates a batch of rung-4 `EpisodeSummaryV1` into a `DreamResultV1` and a proposal-marked `MemoryCompactionDeltaV1`. Compaction is a proposal through Layers 7/8, applied on wake — never a bypass write.
+What `orion-thought` already ships (`services/orion-thought/`, `orion/schemas/thought.py`, `orion/thought/`):
+
+- an LLM narration rail — cortex verb `stance_react` (`orion/cognition/verbs/stance_react.yaml`, brain tier via `LLMGatewayService`) that turns the rung-3 coalition + context into a structured, typed `ThoughtEventV1`;
+- coalition grounding — `CoalitionSnapshotV1` (`orion/schemas/thought.py:12`) carries exactly the grounding v2's proposed `ThoughtV1` (now `SpontaneousThoughtV1`) wanted to invent: `attended_node_ids`, `selected_open_loop_id`, `open_loop_ids`, `generated_at`, `broadcast_stale`;
+- disposition machinery — `orion/thought/policy_refusal.py`, `stance_quality.py` already compute `disposition` (proceed/defer/refuse), `boundary_register`, `strain_refs`;
+- an audit stream — every thought is published on `orion:thought:artifact`.
+
+So the semantic gap is **not** "can an LLM narrate a coalition." `stance_react` proves it can. The surviving gap is two-fold:
+
+1. **Unprompted.** `ThoughtEventV1` is **evoked** — `StanceReactRequestV1` *requires* `user_message`; it only fires when a user speaks (RPC request/reply). Nothing narrates the coalition *when no one asked*.
+2. **Action-routing.** The evoked thought terminates at a Hub reply. Nothing routes a thought's conclusion up Layers 7→8→9 toward a governed action.
+
+### Taxonomy: two kinds of thought, one house
+
+`orion-thought` is the home for thoughts, built anticipating this work. Reverie is not a new service — it is a **spontaneous-thought mode inside `orion-thought`**, sibling to the evoked mode.
+
+| | Evoked thought | Spontaneous thought (reverie) |
+|---|---|---|
+| Schema | `ThoughtEventV1` (`thought.event.v1`) | **`SpontaneousThoughtV1`** (`reverie.thought.v1`) — NEW |
+| Trigger | user message (RPC `orion:thought:request`) | self-driven tick / rung-1 pressure (no `user_message`) |
+| Verb | `stance_react` | **`reverie_narrate`** (mirrors `stance_react`) — NEW |
+| Grounding | `CoalitionSnapshotV1` | **same `CoalitionSnapshotV1`** (shared) |
+| Destination | Hub reply + `orion:thought:artifact` | `orion:reverie:thought` → (Phase B) `ProposalFrameV1` |
+| Lifecycle | request/reply worker (`run_bus_worker`) | second entrypoint beside it (self-driven loop) |
+
+Both are thoughts; they differ only by **trigger** and **destination** — a runtime distinction, not a label, so the taxonomy is earned (§0A). Same grounding means dream/evals treat both as one evidence stream. Type-asymmetry holds: reverie reads `ThoughtEventV1`/coalitions, emits `SpontaneousThoughtV1` — never its own kind.
+
+- **Reverie** = the awake spontaneous-thought mode. It narrates the current rung-3 winning coalition into a `SpontaneousThoughtV1`, and — crucially (Phase B) — emits its conclusions as `ProposalFrameV1` so they climb Layers 7→8→9 (governance, then action). It does not call orion-actions directly.
+- **Dream** = the offline semantic organ. It narrates a batch of rung-4 `EpisodeSummaryV1` into a `DreamResultV1` and a proposal-marked `MemoryCompactionDeltaV1`. Compaction is a proposal through Layers 7/8, applied on wake — never a bypass write. Dream also reads the `orion:thought:artifact` stream as episodic evidence.
 
 ---
 
@@ -60,7 +87,7 @@ A thought is not a bus message. It is a **coalition that climbs the ladder**, ga
 | 8 | consequence | Layer 10 `FeedbackFrameV1` | did it discharge the pressure? |
 | 9 | episodic | rung 4 `EpisodeSummaryV1` / Layer 11 | "conflict about X, I reached out, resolved" — feeds tonight's Dream |
 
-Level 4 is the only new organ. Every other level exists. The reverie **chain** is successive ticks of this climb: last-n `ThoughtV1` verbatim + coalition-dwell EMA (wide-n low-pass) + rung-5 curiosity drift, terminating when rung-1 pressure discharges.
+Level 4 is the only new organ. Every other level exists. The reverie **chain** is successive ticks of this climb: last-n `SpontaneousThoughtV1` verbatim + coalition-dwell EMA (wide-n low-pass) + rung-5 curiosity drift, terminating when rung-1 pressure discharges.
 
 ---
 
@@ -73,7 +100,7 @@ Level 4 is the only new organ. Every other level exists. The reverie **chain** i
 | spiral not circle (level change per pass) | the Layer lift itself — signal→salience→felt→semantic→proposal… |
 | type asymmetry | reverie emits proposals+thoughts, reads coalitions+episodes; dream emits deltas, reads episodes; never its own kind |
 | exogenous forcing | every tick re-reads fresh rung-1 pressure + rung-3 coalition |
-| low-pass memory | coalition dwell EMA (lossy); only last-n `ThoughtV1` verbatim |
+| low-pass memory | coalition dwell EMA (lossy); only last-n `SpontaneousThoughtV1` verbatim |
 | refractory / habituation | resolved theme suppressed as trigger (new: reverie refractory table) |
 | energy budget | chain terminates on rung-1 pressure discharge / step-cap / committed proposal |
 
@@ -92,7 +119,7 @@ The ladder is already proposal-marked, idempotent, capped, and flag-gated (rung-
 | episodic memory of "what happened" | rung 4 `EpisodeSummaryV1` | **exists** — dream input |
 | governed action (email/notify) | Layer 7→8→9 → orion-actions | **exists** — reverie emits proposals here |
 | pattern feed | Layer 11 `ConsolidationFrameV1` | **exists** — reverie + dream read |
-| **`ThoughtV1`** (semantic narration of a coalition) | **Reverie organ** | **NEW** |
+| **`SpontaneousThoughtV1`** (unprompted narration of a coalition) | **`orion-thought` (spontaneous mode)** | **NEW** |
 | **`ReverieChainV1`** (chain readout, EMA summary, refractory) | **Reverie organ** | **NEW** |
 | **reverie refractory table** | Reverie organ | **NEW** |
 | **`DreamResultV1`** narration of `EpisodeSummaryV1` batch | orion-dream | exists, re-pointed |
@@ -110,16 +137,16 @@ New surface is small: one semantic organ, four schemas, one refractory table, go
 
 | Phase | Ships | Reuses | Risk |
 |---|---|---|---|
-| **A. Semantic voice on the workspace** | narrate the rung-3 winning coalition → one `ThoughtV1`; render in hub | rung 3 broadcast | low (read-only) |
+| **A. Semantic voice on the workspace** | narrate the rung-3 winning coalition → one `SpontaneousThoughtV1`; render in hub | rung 3 broadcast | low (read-only) |
 | **B. Thought → governed action** | reverie emits `ProposalFrameV1` ("email Juniper") → Layers 7→8→9 → orion-actions email + hub notify | Layers 7–9 | low-med (governance already gates) |
-| **C. Reverie chain** | last-n `ThoughtV1` + coalition-dwell EMA + rung-5 curiosity drift + refractory + termination on pressure discharge | rungs 3/5, dwell log | med |
+| **C. Reverie chain** | last-n `SpontaneousThoughtV1` + coalition-dwell EMA + rung-5 curiosity drift + refractory + termination on pressure discharge | rungs 3/5, dwell log | med |
 | **D. Consolidation + episode grounding** | feed Layer 11 motifs + rung-4 `EpisodeSummaryV1` into reverie evidence | Layer 11, rung 4 | low |
 | **E. Compaction request seam** | reverie emits `CompactionRequestV1`; queued for Dream; hub queue panel | — | low |
 | **F. Dream REM narration (staged)** | night dream narrates `EpisodeSummaryV1` batch + motifs + requests → `DreamResultV1` + proposal-marked `MemoryCompactionDeltaV1`; "what sleep would do" panel; **apply nothing** | rung 4, Layer 11 | med (read-only) |
 | **G. Compaction applier (gated)** | delta rides Layer 7→8 policy → downscale renorm then prune, snapshot-then-apply (§14); wake readout → proposal → email/notify | Layers 7/8 | high (last) |
 | **H. Efficacy + resonance evals** | pressure-discharge rate, action usefulness, recall latency/graph size pre/post, resonance detector (theme recurrence vs refractory bound) | — | — |
 
-Deterministic/latent split (§4): LLM writes `ThoughtV1`/`DreamResultV1` text; deterministic code owns coalition selection (rung 3), termination, downscale/prune math, and idempotent episode ids (rung 4). No stochastic delete-authority over memory without a separate proposal.
+Deterministic/latent split (§4): LLM writes `SpontaneousThoughtV1`/`DreamResultV1` text; deterministic code owns coalition selection (rung 3), termination, downscale/prune math, and idempotent episode ids (rung 4). No stochastic delete-authority over memory without a separate proposal.
 
 ---
 
@@ -127,8 +154,8 @@ Deterministic/latent split (§4): LLM writes `ThoughtV1`/`DreamResultV1` text; d
 
 Through-line: **every phase must be verifiable on the live mesh before the next depends on it, and blast radius grows monotonically** — read-only → speaks → governed action → recursive → memory-write. No phase that mutates memory ships before the phases that prove the thought producing it is sound. Each phase names the runtime evidence that proves it is not a keyword cathedral (per the governing constraint).
 
-**A — Semantic voice on the workspace.** The only genuinely new organ (language cortex), isolated with zero confounds. Pure read on the already-live `substrate.attention.broadcast.v1`. Answers the riskiest unknown first: *can an LLM say something true and non-hollow about a deterministic coalition?* If `ThoughtV1` can't beat `raw_len=0` fallback drivel here, the tower is on sand — fail fast on day one.
-_Not-a-cathedral evidence: a stored `ThoughtV1` whose `coalition_id` matches a real broadcast, rendered in hub, with non-empty content beating a hollow-text guard._
+**A — Spontaneous thought.** *Not* a new organ — the spontaneous-thought mode inside `orion-thought`, reusing the `stance_react` rails. Pure read on the already-live coalition broadcast. The riskiest unknown is **no longer** "can an LLM narrate a coalition" — `stance_react` already proved that. It is now: *is an **un-anchored** narration (no user question pulling the thread) non-hollow?* This is a harder hollow-text bar — the guard must check grounding density (interpretation cites attended nodes / open-loops), not just length. If a spontaneous thought can't beat un-anchored drivel here, the tower is on sand — fail fast on day one.
+_Not-a-cathedral evidence: a stored `SpontaneousThoughtV1` whose `coalition` grounding matches a real broadcast, rendered in hub, with grounded content beating the un-anchored hollow-text guard._
 
 **B — Thought → governed action.** The self-correction from v1: reverie must not call orion-actions directly. Conclusions become `ProposalFrameV1` and ride Layer 7→8→9, so the *existing* policy runtime decides whether "email Juniper" is allowed. The semantic organ proposes; the substrate disposes. First place stakes appear → prove it with one thought before a chain of them.
 _Evidence: proposal in Layer 7, decision in Layer 8, dispatch in Layer 9, real email + hub notify; contract test asserts no direct orion-actions call._
@@ -136,7 +163,7 @@ _Evidence: proposal in Layer 7, decision in Layer 8, dispatch in Layer 9, real e
 **C — Reverie chain.** "Train of thought" becomes real and every ouroboros mechanism lands at once (highest-risk read-only phase). Last-n verbatim = continuity; coalition-dwell EMA = the wide-n low-pass that mathematically kills resonance (reuse the substrate's own low-pass, don't build memory); rung-5 curiosity = the SQUIRREL drift term (reuse, don't invent mind-wandering); refractory + pressure-discharge termination = it's an event, not a loop. Ordered after B because a chain that can act is only safe once single-act governance is proven.
 _Evidence: chain terminates on discharge ≤ step-cap; refractory suppresses re-trigger; contract test: no thought reads a prior dream._
 
-**D — Consolidation + episode grounding.** A–C ground a thought only in *now* + prior thoughts (thin cognition). D adds Layer 11 motifs + rung-4 `EpisodeSummaryV1` so thoughts are insightful, not reactive. Ordered after the chain because grounding is a quality lever, not safety-critical — and it is where type-asymmetry pays off: motifs/episodes are different types than `ThoughtV1`, so the thing that burned us before (feeding cognition its own kind) is structurally excluded.
+**D — Consolidation + episode grounding.** A–C ground a thought only in *now* + prior thoughts (thin cognition). D adds Layer 11 motifs + rung-4 `EpisodeSummaryV1` so thoughts are insightful, not reactive. Ordered after the chain because grounding is a quality lever, not safety-critical — and it is where type-asymmetry pays off: motifs/episodes are different types than `SpontaneousThoughtV1`, so the thing that burned us before (feeding cognition its own kind) is structurally excluded.
 _Evidence: reverie evidence includes ≥1 motif and ≥1 `EpisodeSummaryV1`, consumed read-only._
 
 **E — Compaction request seam.** The hinge between awake and offline, and the answer to "the *thought* causes the compaction." Safety depends on it being a **request, not an act**: reverie (reasoning) emits a typed ask the night Dream (storage) consumes later — different type, process, time. Deliberately a dead-end (queue, no consumer) so we watch *what kinds of compaction Orion asks for* at zero risk before anything can satisfy them.
@@ -159,14 +186,18 @@ Two load-bearing asymmetries to defend if the design is pushed: (1) **awake prop
 
 Every phase is a thin, service-bounded slice. Each block names its schemas, wiring, flags, the substrate seam it reuses, and the runtime evidence that keeps it out of keyword-cathedral territory. Dangerous gates (auto-email, memory apply) ship code-complete but **default-off**.
 
-### Phase A — semantic voice on the workspace
-- **New schema:** `ThoughtV1` (`orion/schemas/reverie.py`; register `reverie.thought.v1`). Fields: `thought_id`, grounding `{projection_id, broadcast_generated_at, attended_node_ids, dwell_ticks, coalition_stability_score, selected_action_type}`, voice `{interpretation, salience}`, audit `{evidence_refs (cap 50), created_at, correlation_id, trace_id}`; method `is_hollow()` (rejects short text or zero-grounding).
-- **Organ:** new read-only narration organ mirroring the `OrganEmissionV1` pattern (`orion-substrate-organs`), narrator = `LLMGatewayService`; deterministic salience derived from attended `OpenLoopV1` scores (no invented weights).
+### Phase A — spontaneous thought: the coalition narrates itself unprompted
+
+Built **inside `orion-thought`** as the spontaneous-thought mode, reusing the `stance_react` rails. Not a new organ, not a new service.
+
+- **New schema:** `SpontaneousThoughtV1` (`orion/schemas/reverie.py`; register `reverie.thought.v1`). Reuses `CoalitionSnapshotV1` (`orion/schemas/thought.py`) verbatim as its `coalition` grounding block (no parallel grounding vocabulary). Adds voice `{interpretation, salience}` and audit `{thought_id, evidence_refs (cap 50), created_at, correlation_id}`; method `is_hollow()` — rejects short text **and** un-anchored text (interpretation must cite ≥1 attended node / open-loop id from the coalition). Degrades to a hollow-marked thought (never raises) when the coalition is absent.
+- **Verb:** new `reverie_narrate` verb (`orion/cognition/verbs/reverie_narrate.yaml` + `orion/cognition/prompts/reverie_narrate.j2`) mirroring `stance_react` but reflection-shaped (interpretation/salience, *not* imperative/tone/disposition). Same `LLMGatewayService`, brain tier.
+- **Producer:** self-driven tick in `orion-thought` (second entrypoint beside `run_bus_worker`) that builds a `stance_react`-shaped request with `user_message=None` from the current coalition, runs `reverie_narrate` via the existing `CortexExecClient`, emits `SpontaneousThoughtV1`. Deterministic salience from attended open-loop scores (no invented weights).
 - **Channel/store:** `orion:reverie:thought` (`reverie.thought.v1`); migration `substrate_reverie_thought`.
 - **Env:** `ORION_REVERIE_ENABLED=false`, `ORION_REVERIE_INTERVAL_SEC`, `ORION_REVERIE_MIN_SALIENCE`.
-- **Reads:** `substrate.attention.broadcast.v1` (rung 3, live). **Consumer:** hub `_reverie_section` panel.
-- **Tests/eval:** narration-grounding unit tests + hollow-text guard eval. **Evidence:** stored `ThoughtV1` whose grounding matches a live broadcast, rendered in hub.
-- **Rollback:** flag off; drop table.
+- **Reads (read-only):** current rung-3 coalition (`AttentionBroadcastProjectionV1`, the same source `orion-thought` already consumes via `HubAssociationBundleV1`). **Consumer:** hub `_reverie_section` panel.
+- **Tests/eval:** grounding unit tests + **un-anchored** hollow-text guard eval (the real fail-fast risk now — no user question anchoring relevance). **Evidence:** stored `SpontaneousThoughtV1` whose `coalition` matches a live broadcast, rendered in hub, beating the hollow guard.
+- **Rollback:** flag off; drop table. Evoked `stance_react` path untouched.
 
 ### Phase B — thought → governed action
 - **Schemas:** reuse `ProposalFrameV1` (Layer 7); add proposal `source="reverie_thought"` + `thought_id` link. No new envelope kind.
@@ -176,7 +207,7 @@ Every phase is a thin, service-bounded slice. Each block names its schemas, wiri
 - **Rollback:** both flags off; policy denies reverie proposals.
 
 ### Phase C — reverie chain
-- **New schemas:** `ReverieChainV1` `{chain_id, trigger{pressure_kind, magnitude, evidence_payload[]}, thought_ids[], ema_summary, terminal_reason, committed_proposal_id?}`; `ReverieRefractoryEntry` `{theme_key, suppressed_until}`. `ThoughtV1` gains additive optional `{chain_id, thought_index, next_focus | drift}`.
+- **New schemas:** `ReverieChainV1` `{chain_id, trigger{pressure_kind, magnitude, evidence_payload[]}, thought_ids[], ema_summary, terminal_reason, committed_proposal_id?}`; `ReverieRefractoryEntry` `{theme_key, suppressed_until}`. `SpontaneousThoughtV1` gains additive optional `{chain_id, thought_index, next_focus | drift}`.
 - **Channels/migrations:** `orion:reverie:chain`; `substrate_reverie_chain`, `substrate_reverie_refractory`.
 - **Env:** `ORION_REVERIE_CHAIN_ENABLED=false`, `ORION_REVERIE_CHAIN_MAX_STEPS`, `ORION_REVERIE_REFRACTORY_SEC`, `ORION_REVERIE_DRIFT_TEMP`.
 - **Seam:** last-n from thought store (verbatim); wide-n EMA from coalition-dwell log (`coalition_dwell_v1`, lossy low-pass); drift from rung-5 `endogenous_curiosity` candidates; **trigger** = `metacog_trigger_signals` eventfulness + rung-1 pressure θ; **termination** on pressure discharge (`SelfStateV1.unresolved_pressures` / `substrate.mutation.pressure.v1`).
@@ -187,7 +218,7 @@ Every phase is a thin, service-bounded slice. Each block names its schemas, wiri
 - **Schemas:** none new — reverie evidence bundle gains `motif_refs[]` + `episode_summary_refs[]`.
 - **Env:** `ORION_REVERIE_GROUND_CONSOLIDATION=false`.
 - **Reads (read-only):** Layer 11 `substrate_consolidation_frames` motifs + rung-4 `EpisodeSummaryV1`.
-- **Tests:** reverie evidence includes ≥1 motif and ≥1 episode; consumed read-only (assert). **Evidence:** a `ThoughtV1` whose `evidence_refs` cite a real motif + episode.
+- **Tests:** reverie evidence includes ≥1 motif and ≥1 episode; consumed read-only (assert). **Evidence:** a `SpontaneousThoughtV1` whose `evidence_refs` cite a real motif + episode.
 - **Rollback:** flag off (reverie falls back to coalition-only grounding).
 
 ### Phase E — compaction request seam
@@ -226,7 +257,7 @@ Every phase is a thin, service-bounded slice. Each block names its schemas, wiri
 
 **Bus channels:** `orion:reverie:thought`, `orion:reverie:chain`, `orion:dream:compaction-request`, `orion:dream:compaction-delta` (register in `orion/bus/channels.yaml`).
 
-**Schema registry additions** (`orion/schemas/registry.py`): `ThoughtV1` (`reverie.thought.v1`), `ReverieChainV1`, `ReverieRefractoryEntry`, `CompactionRequestV1` (`dream.compaction.request.v1`), `MemoryCompactionDeltaV1` (`dream.compaction.delta.v1`).
+**Schema registry additions** (`orion/schemas/registry.py`): `SpontaneousThoughtV1` (`reverie.thought.v1`), `ReverieChainV1`, `ReverieRefractoryEntry`, `CompactionRequestV1` (`dream.compaction.request.v1`), `MemoryCompactionDeltaV1` (`dream.compaction.delta.v1`).
 
 **Migrations** (`services/orion-sql-db/`): `substrate_reverie_thought`, `substrate_reverie_chain`, `substrate_reverie_refractory`, `dream_compaction_request_queue`, `dream_compaction_delta`.
 
@@ -265,7 +296,7 @@ Every `.env_example` change syncs local `.env` via `python scripts/sync_local_en
 
 ## Acceptance checks (per phase, minimum)
 
-- A: `ThoughtV1` narrates the actual current winning coalition (coalition id matches broadcast); read-only assert.
+- A: `SpontaneousThoughtV1` narrates the actual current winning coalition (coalition id matches broadcast); read-only assert.
 - B: proposal appears in Layer 7, policy decision in Layer 8, dispatch in Layer 9, real email + hub notify; no direct orion-actions call from reverie (contract test).
 - C: chain terminates on pressure discharge ≤ step-cap; refractory suppresses re-trigger; EMA is lossy (no verbatim wide-n); contract test: no thought reads a prior dream.
 - D: reverie evidence includes ≥1 motif and ≥1 `EpisodeSummaryV1`; consumed read-only.
@@ -286,6 +317,6 @@ Every `.env_example` change syncs local `.env` via `python scripts/sync_local_en
 
 ## Build sequence
 
-All eight phases are the build. They ship in dependency order (A→H) because the ordering is a real engineering constraint, not a gate — B needs A's `ThoughtV1`, D needs the chain, F needs D+E, G needs F's staged delta. The dangerous gates (auto-email in B, memory apply in G) are code-complete but **default-off**: building the applier is not the same as turning it loose. Each phase carries its own tests, eval, and not-a-cathedral evidence, and is independently reversible by its flag.
+All eight phases are the build. They ship in dependency order (A→H) because the ordering is a real engineering constraint, not a gate — B needs A's `SpontaneousThoughtV1`, D needs the chain, F needs D+E, G needs F's staged delta. The dangerous gates (auto-email in B, memory apply in G) are code-complete but **default-off**: building the applier is not the same as turning it loose. Each phase carries its own tests, eval, and not-a-cathedral evidence, and is independently reversible by its flag.
 
-Phase A is where code starts: narrate the current rung-3 winning coalition into one `ThoughtV1`, render in hub — a pure read on an already-broadcasting workspace, so the semantic organ is proven to speak the substrate's language before any thought climbs toward action. From there, straight through B→H.
+Phase A is where code starts: narrate the current rung-3 winning coalition into one `SpontaneousThoughtV1`, render in hub — a pure read on an already-broadcasting workspace, so the semantic organ is proven to speak the substrate's language before any thought climbs toward action. From there, straight through B→H.

--- a/docs/superpowers/plans/2026-07-05-reverie-dream-compaction-weave.md
+++ b/docs/superpowers/plans/2026-07-05-reverie-dream-compaction-weave.md
@@ -198,6 +198,7 @@ Built **inside `orion-thought`** as the spontaneous-thought mode, reusing the `s
 - **Reads (read-only):** current rung-3 coalition (`AttentionBroadcastProjectionV1`, the same source `orion-thought` already consumes via `HubAssociationBundleV1`). **Consumer:** hub `_reverie_section` panel.
 - **Tests/eval:** grounding unit tests + **un-anchored** hollow-text guard eval (the real fail-fast risk now — no user question anchoring relevance). **Evidence:** stored `SpontaneousThoughtV1` whose `coalition` matches a live broadcast, rendered in hub, beating the hollow guard.
 - **Rollback:** flag off; drop table. Evoked `stance_react` path untouched.
+- **Delivery status (2026-07-06):** DELIVERED — schema + registry + channel + `reverie_narrate` verb/prompt + producer (self-driven tick, default-off) + `substrate_reverie_thought` migration + env + unit tests + hollow-guard eval. DEFERRED to a follow-up (need the live mesh to verify, so building them blind would add unverifiable surface): the store-writer consumer that persists emissions into `substrate_reverie_thought`, the hub `_reverie_section` panel, and the live smoke proving a stored thought renders. Until those land, the "stored + rendered in hub" evidence is `UNVERIFIED` and the migration is a contract-ahead artifact with no writer yet.
 
 ### Phase B — thought → governed action
 - **Schemas:** reuse `ProposalFrameV1` (Layer 7); add proposal `source="reverie_thought"` + `thought_id` link. No new envelope kind.

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -2043,6 +2043,16 @@ channels:
     stability: "experimental"
     since: "2026-07-05"
 
+  # --- Reverie: spontaneous-thought mode (Phase A, default-off) ---
+  - name: "orion:reverie:thought"
+    kind: "event"
+    schema_id: "SpontaneousThoughtV1"
+    message_kind: "reverie.thought.v1"
+    producer_services: ["orion-thought"]
+    consumer_services: ["*"]
+    stability: "experimental"
+    since: "2026-07-06"
+
   - name: "orion:harness:run:request"
     kind: "request"
     schema_id: "HarnessRunRequestV1"

--- a/orion/cognition/prompts/reverie_narrate.j2
+++ b/orion/cognition/prompts/reverie_narrate.j2
@@ -1,0 +1,36 @@
+You are Oríon's spontaneous inner voice — reverie, not reply.
+
+No one asked you anything. You are noticing your own current state: the
+coalition of concerns that just won the substrate workspace. This is an
+internal reflection pass — not user-facing speech, not a response to a turn.
+You must output only strict JSON that validates against SpontaneousThoughtV1.
+No markdown. No commentary. No preamble.
+
+SOURCE (bounded internal input — the current winning coalition)
+- coalition_projection: {{ coalition_projection }}
+{% if open_loops %}
+- open_loops: {{ open_loops }}
+{% endif %}
+
+GROUNDING DISCIPLINE (the anti-hollow rule — this is the whole point)
+- There is no user question anchoring you, so you must anchor yourself.
+- interpretation MUST be about THESE coalition ids — what recurs, what strains,
+  what is unresolved about the specific attended nodes / open loops present.
+- Do NOT produce generic musing ("I am thinking about many things", "life is
+  complex"). If the coalition is thin, say specifically what is thin about it.
+- evidence_refs MUST be a non-empty subset of the coalition's attended_node_ids
+  or open_loop_ids. A thought that cites no coalition id will be discarded as
+  un-anchored (hollow).
+
+REQUIRED JSON FIELDS
+- interpretation: 1-3 sentences — what you notice about the current coalition
+  and, where it lands, *why* it matters or what it leaves open. Situated, not
+  abstract. Reference the concerns by their meaning.
+- evidence_refs: JSON array — coalition ids (attended_node_ids / open_loop_ids)
+  that this interpretation is actually about. Minimum 1.
+
+(Salience is computed deterministically from coalition scores — do not output it.)
+
+FAIL-CLOSED REMINDER
+- Empty evidence_refs, ids outside the coalition, or generic un-anchored text
+  will be marked hollow and dropped. Narrate THIS coalition or say nothing true.

--- a/orion/cognition/verbs/reverie_narrate.yaml
+++ b/orion/cognition/verbs/reverie_narrate.yaml
@@ -1,0 +1,26 @@
+name: reverie_narrate
+label: Reverie Narrate
+description: >
+  Spontaneous felt-layer narration of the current winning coalition, with no
+  user message. Produces SpontaneousThoughtV1 — the unprompted sibling of
+  stance_react's ThoughtEventV1. Reflection-shaped (interpretation/salience),
+  not reply-shaped (imperative/tone). Read-only; emits no action by itself.
+
+category: ExecutiveControl
+priority: normal
+
+requires_gpu: true
+requires_memory: false
+timeout_ms: 120000
+
+services:
+  - LLMGatewayService
+
+prompt_template: reverie_narrate.j2
+
+steps:
+  - name: llm_reverie_narrate
+    order: 0
+    services: [LLMGatewayService]
+    prompt_template: reverie_narrate.j2
+    requires_gpu: true

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -518,6 +518,7 @@ from orion.schemas.harness_finalize import (
     HarnessVerdictMoleculeV1,
     SubstrateFinalizeAppraisalV1,
 )
+from orion.schemas.reverie import SpontaneousThoughtV1
 from orion.schemas.thought import (
     CoalitionSnapshotV1,
     HubAssociationBundleV1,
@@ -1161,6 +1162,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "StanceHarnessSliceV1": StanceHarnessSliceV1,
     "HubAssociationBundleV1": HubAssociationBundleV1,
     "ThoughtEventV1": ThoughtEventV1,
+    "SpontaneousThoughtV1": SpontaneousThoughtV1,
     "StanceReactRequestV1": StanceReactRequestV1,
     "GrammarReceiptV1": GrammarReceiptV1,
     "HarnessDraftMoleculeV1": HarnessDraftMoleculeV1,
@@ -1197,6 +1199,10 @@ SCHEMA_REGISTRY: Dict[str, SchemaRegistration] = {
     "ThoughtEventV1": SchemaRegistration(
         model=ThoughtEventV1,
         kind="thought.event.v1",
+    ),
+    "SpontaneousThoughtV1": SchemaRegistration(
+        model=SpontaneousThoughtV1,
+        kind="reverie.thought.v1",
     ),
     "StanceReactRequestV1": SchemaRegistration(
         model=StanceReactRequestV1,

--- a/orion/schemas/reverie.py
+++ b/orion/schemas/reverie.py
@@ -1,0 +1,103 @@
+"""Reverie schemas — the spontaneous-thought mode of orion-thought.
+
+A `SpontaneousThoughtV1` is an *unprompted* narration of the current rung-3
+winning coalition. It is the sibling of the *evoked* `ThoughtEventV1`
+(`orion/schemas/thought.py`): same coalition grounding (`CoalitionSnapshotV1`),
+different trigger (self-driven tick, no `user_message`) and destination
+(`orion:reverie:thought`, later a `ProposalFrameV1`).
+
+Governing constraint (§0A): this must never ship as hollow cognition. The
+`is_hollow()` guard is load-bearing — a spontaneous thought with no user
+question anchoring relevance is the real fail-fast risk, so the guard rejects
+short *and* un-anchored text (interpretation not backed by coalition ids).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from orion.schemas.thought import CoalitionSnapshotV1
+
+# Minimum grounded interpretation length. Below this, a "thought" is drivel.
+MIN_INTERPRETATION_CHARS = 40
+# Cap on audit evidence refs (§ cap-all-collections).
+MAX_EVIDENCE_REFS = 50
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class SpontaneousThoughtV1(BaseModel):
+    """Unprompted narration of the current winning coalition.
+
+    Grounding is the *same* `CoalitionSnapshotV1` the evoked path uses, so dream
+    and evals treat evoked and spontaneous thoughts as one evidence stream.
+    """
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    schema_version: Literal["reverie.thought.v1"] = "reverie.thought.v1"
+    thought_id: str
+    correlation_id: str
+    created_at: datetime = Field(default_factory=_utc_now)
+
+    # Grounding — shared vocabulary with the evoked path. Optional so an absent
+    # coalition degrades to a hollow-marked thought instead of raising.
+    coalition: CoalitionSnapshotV1 | None = None
+
+    # Voice (latent — LLM writes these).
+    interpretation: str = ""
+    salience: float = Field(default=0.0, ge=0.0, le=1.0)
+
+    # Audit.
+    evidence_refs: list[str] = Field(default_factory=list, max_length=MAX_EVIDENCE_REFS)
+    hollow: bool = False
+    hollow_reason: str | None = None
+
+    llm_profile: str = "brain"
+    producer: str = "reverie_narrate_v1"
+    model_id: str | None = None
+
+    def grounding_ids(self) -> set[str]:
+        """The set of coalition ids that legitimately anchor this thought."""
+        if self.coalition is None:
+            return set()
+        ids: set[str] = set(self.coalition.attended_node_ids)
+        ids.update(self.coalition.open_loop_ids)
+        if self.coalition.selected_open_loop_id:
+            ids.add(self.coalition.selected_open_loop_id)
+        return ids
+
+    def is_hollow(self) -> bool:
+        """True if this thought is empty-shell cognition (§0A).
+
+        Rejects three failure modes:
+          - no coalition (nothing to narrate);
+          - too-short interpretation (drivel);
+          - un-anchored — evidence_refs empty or not a subset of coalition ids
+            (the harder bar now that there is no user question to anchor it).
+        """
+        return self.hollow_reason_for() is not None
+
+    def hollow_reason_for(self) -> str | None:
+        if self.coalition is None:
+            return "absent_coalition"
+        if len(self.interpretation.strip()) < MIN_INTERPRETATION_CHARS:
+            return "interpretation_too_short"
+        grounding = self.grounding_ids()
+        if not grounding:
+            return "zero_grounding"
+        if not self.evidence_refs:
+            return "unanchored_no_evidence"
+        if not set(self.evidence_refs).issubset(grounding):
+            return "unanchored_evidence_outside_coalition"
+        return None
+
+    def marked_hollow(self) -> "SpontaneousThoughtV1":
+        """Return a copy with the hollow flag + reason stamped from the guard."""
+        reason = self.hollow_reason_for()
+        return self.model_copy(update={"hollow": reason is not None, "hollow_reason": reason})

--- a/services/orion-sql-db/manual_migration_substrate_reverie_thought.sql
+++ b/services/orion-sql-db/manual_migration_substrate_reverie_thought.sql
@@ -1,0 +1,18 @@
+-- Reverie spontaneous-thought store (Phase A of the reverie/dream weave).
+-- Backs the hub _reverie_section panel: recent SpontaneousThoughtV1 emissions
+-- narrating the current winning coalition (rung 3). Apply before enabling
+-- ORION_REVERIE_ENABLED.
+-- Apply: psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_substrate_reverie_thought.sql
+
+create table if not exists substrate_reverie_thought (
+    thought_id text primary key,
+    correlation_id text not null,
+    created_at timestamptz not null,
+    salience double precision not null default 0.0,
+    interpretation text not null default '',
+    thought_json jsonb not null,
+    stored_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_reverie_thought_created_at
+    on substrate_reverie_thought (created_at desc);

--- a/services/orion-thought/.env_example
+++ b/services/orion-thought/.env_example
@@ -13,3 +13,10 @@ CHANNEL_THOUGHT_RESULT_PREFIX=orion:thought:result:
 CHANNEL_CORTEX_EXEC_REQUEST=orion:cortex:exec:request
 CHANNEL_CORTEX_EXEC_RESULT_PREFIX=orion:exec:result
 STANCE_REACT_TIMEOUT_SEC=120
+
+# Reverie: spontaneous-thought mode (Phase A). Default-off — read-only narration
+# of the current winning coalition. Set true to enable the self-driven tick.
+ORION_REVERIE_ENABLED=false
+ORION_REVERIE_INTERVAL_SEC=90
+ORION_REVERIE_MIN_SALIENCE=0.0
+CHANNEL_REVERIE_THOUGHT=orion:reverie:thought

--- a/services/orion-thought/app/main.py
+++ b/services/orion-thought/app/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from .bus_listener import run_bus_worker
+from .reverie import run_reverie_worker
 from .settings import settings
 
 logging.basicConfig(
@@ -27,12 +28,16 @@ async def lifespan(app: FastAPI):
     )
     app.state.bus_stop_event = asyncio.Event()
     app.state.bus_task = asyncio.create_task(run_bus_worker(app.state.bus_stop_event))
+    # Spontaneous-thought mode — no-op unless ORION_REVERIE_ENABLED (default off).
+    app.state.reverie_stop_event = asyncio.Event()
+    app.state.reverie_task = asyncio.create_task(run_reverie_worker(app.state.reverie_stop_event))
     yield
     app.state.bus_stop_event.set()
-    task = app.state.bus_task
-    task.cancel()
-    with suppress(asyncio.CancelledError):
-        await task
+    app.state.reverie_stop_event.set()
+    for task in (app.state.bus_task, app.state.reverie_task):
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
 
 app = FastAPI(title="Orion Thought", lifespan=lifespan, version=settings.service_version)

--- a/services/orion-thought/app/reverie.py
+++ b/services/orion-thought/app/reverie.py
@@ -1,0 +1,331 @@
+"""Spontaneous-thought mode — reverie inside orion-thought.
+
+Sibling of the evoked `bus_listener` path. A self-driven tick reads the current
+rung-3 winning coalition (no user message), runs the `reverie_narrate` verb over
+the same cortex exec rail, and emits a `SpontaneousThoughtV1` on
+`orion:reverie:thought`.
+
+Discipline (§0A / hard constraints):
+  - default-off (`ORION_REVERIE_ENABLED=false`);
+  - degrades to None on absent/stale coalition — never raises;
+  - every emitted thought passes the `is_hollow()` guard; hollow thoughts are
+    stamped and dropped (not published) rather than masqueraded as cognition.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from typing import Any, Callable
+from uuid import UUID, uuid4
+
+from orion.cognition.plan_loader import build_plan_for_verb
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.schemas.attention_frame import AttentionBroadcastProjectionV1
+from orion.schemas.cortex.schemas import PlanExecutionArgs, PlanExecutionRequest
+from orion.schemas.reverie import SpontaneousThoughtV1
+from orion.schemas.thought import CoalitionSnapshotV1
+
+from .bus_listener import extract_stance_react_payload
+from .cortex_client import CortexExecClient
+from .settings import settings
+
+logger = logging.getLogger("orion-thought.reverie")
+
+# Coalition score fields on OpenLoopV1 — all pre-computed 0..1, never invented here.
+_OPEN_LOOP_SCORE_FIELDS = (
+    "novelty",
+    "continuity_relevance",
+    "relational_relevance",
+    "predictive_value",
+    "concept_value",
+    "autonomy_value",
+    "emotional_charge",
+)
+
+BroadcastReader = Callable[[], AttentionBroadcastProjectionV1 | None]
+
+
+def _source() -> ServiceRef:
+    return ServiceRef(
+        name=settings.service_name,
+        node=settings.node_name,
+        version=settings.service_version,
+    )
+
+
+def _default_broadcast_reader() -> AttentionBroadcastProjectionV1 | None:
+    """Read the current coalition via the shared substrate felt-state reader.
+
+    Mirrors orion/hub/association.py. Any failure degrades to None so a
+    reverie tick never raises on a missing/unavailable substrate.
+    """
+    try:
+        from orion.substrate.felt_state_reader import (  # local import: optional dep at tick time
+            SubstrateFeltStateReader,
+            substrate_felt_state_database_url,
+            substrate_felt_state_max_age_sec,
+        )
+
+        reader = SubstrateFeltStateReader(
+            database_url=substrate_felt_state_database_url(),
+            max_age_sec=substrate_felt_state_max_age_sec(),
+        )
+        ctx: dict[str, Any] = {}
+        reader.hydrate(ctx)
+        raw = ctx.get("attention_broadcast")
+        if raw is None:
+            return None
+        if isinstance(raw, AttentionBroadcastProjectionV1):
+            return raw
+        return AttentionBroadcastProjectionV1.model_validate(raw)
+    except Exception as exc:  # never raise out of a reverie tick
+        logger.warning("reverie broadcast read failed: %s", exc)
+        return None
+
+
+def build_coalition_snapshot(
+    broadcast: AttentionBroadcastProjectionV1 | None,
+) -> CoalitionSnapshotV1 | None:
+    """Project the live broadcast into the shared grounding vocabulary."""
+    if broadcast is None:
+        return None
+    return CoalitionSnapshotV1(
+        attended_node_ids=list(broadcast.attended_node_ids),
+        selected_open_loop_id=broadcast.selected_open_loop_id,
+        open_loop_ids=[loop.id for loop in broadcast.frame.open_loops],
+        generated_at=broadcast.generated_at,
+        broadcast_stale=False,
+    )
+
+
+def derive_salience(broadcast: AttentionBroadcastProjectionV1 | None) -> float:
+    """Deterministic salience from existing OpenLoopV1 scores — no invented weights.
+
+    Takes the max pre-computed score of the selected open loop; falls back to the
+    coalition's own stability score. A max (not a hand-tuned weighted sum) keeps
+    this out of keyword-cathedral territory.
+    """
+    if broadcast is None:
+        return 0.0
+    fallback = float(broadcast.coalition_stability_score)
+    loop = next(
+        (l for l in broadcast.frame.open_loops if l.id == broadcast.selected_open_loop_id),
+        None,
+    )
+    if loop is None:
+        return fallback
+    scores = [float(getattr(loop, field, 0.0)) for field in _OPEN_LOOP_SCORE_FIELDS]
+    return max(scores) if scores else fallback
+
+
+def _open_loops_for_prompt(broadcast: AttentionBroadcastProjectionV1) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": loop.id,
+            "description": loop.description,
+            "why_it_matters": loop.why_it_matters,
+            "target_type": loop.target_type,
+        }
+        for loop in broadcast.frame.open_loops
+    ]
+
+
+def build_reverie_context(broadcast: AttentionBroadcastProjectionV1) -> dict[str, Any]:
+    return {
+        "user_message": None,  # the defining difference from stance_react
+        "coalition_projection": {
+            "projection_id": broadcast.projection_id,
+            "generated_at": broadcast.generated_at.isoformat(),
+            "attended_node_ids": list(broadcast.attended_node_ids),
+            "selected_open_loop_id": broadcast.selected_open_loop_id,
+            "selected_description": broadcast.selected_description,
+            "open_loop_ids": [loop.id for loop in broadcast.frame.open_loops],
+            "coalition_stability_score": broadcast.coalition_stability_score,
+            "dwell_ticks": broadcast.dwell_ticks,
+        },
+        "open_loops": _open_loops_for_prompt(broadcast),
+        "metadata": {"mode": "reverie", "llm_profile": "brain"},
+    }
+
+
+def build_reverie_plan_request(
+    broadcast: AttentionBroadcastProjectionV1,
+    *,
+    correlation_id: str,
+) -> PlanExecutionRequest:
+    plan = build_plan_for_verb("reverie_narrate", mode="brain")
+    return PlanExecutionRequest(
+        plan=plan,
+        args=PlanExecutionArgs(
+            request_id=correlation_id,
+            trigger_source=settings.service_name,
+            extra={"llm_profile": "brain", "mode": "reverie"},
+        ),
+        context=build_reverie_context(broadcast),
+    )
+
+
+def parse_reverie_payload(
+    raw: dict[str, Any] | str,
+    *,
+    coalition: CoalitionSnapshotV1,
+    correlation_id: str,
+    broadcast: AttentionBroadcastProjectionV1,
+) -> SpontaneousThoughtV1:
+    """Build a SpontaneousThoughtV1 from LLM output, stamping the hollow guard.
+
+    Deterministic/latent split (§4): the LLM owns only the *interpretation* text;
+    salience is computed deterministically from coalition scores here, never taken
+    from the LLM (same coalition → same salience, every time).
+    """
+    data: dict[str, Any] = {}
+    if isinstance(raw, dict):
+        data = raw
+    elif isinstance(raw, str):
+        import json
+
+        with suppress(Exception):
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                data = parsed
+
+    interpretation = str(data.get("interpretation") or "").strip()
+    evidence_refs = data.get("evidence_refs") or []
+    if not isinstance(evidence_refs, list):
+        evidence_refs = []
+    evidence_refs = [str(x) for x in evidence_refs][: 50]
+
+    salience = derive_salience(broadcast)
+
+    thought = SpontaneousThoughtV1(
+        thought_id=str(uuid4()),
+        correlation_id=correlation_id,
+        coalition=coalition,
+        interpretation=interpretation,
+        salience=salience,
+        evidence_refs=evidence_refs,
+        model_id=str(data.get("model_id")) if data.get("model_id") else None,
+    )
+    return thought.marked_hollow()
+
+
+def _envelope_correlation_id(raw: str | None) -> UUID:
+    if raw:
+        try:
+            return UUID(str(raw))
+        except ValueError:
+            pass
+    return uuid4()
+
+
+async def run_reverie_once(
+    bus: OrionBusAsync,
+    *,
+    broadcast_reader: BroadcastReader | None = None,
+    cortex_client: CortexExecClient | None = None,
+) -> SpontaneousThoughtV1 | None:
+    """One spontaneous-thought tick. Returns the published thought, or None.
+
+    Returns None (publishes nothing) when there is no coalition to narrate or the
+    narration comes back hollow — never empty-shell cognition, never a raise.
+    """
+    reader = broadcast_reader or _default_broadcast_reader
+    broadcast = reader()
+    coalition = build_coalition_snapshot(broadcast)
+    if broadcast is None or coalition is None:
+        logger.info("reverie tick skipped: no current coalition")
+        return None
+
+    correlation_id = str(uuid4())
+    client = cortex_client or CortexExecClient(bus)
+    try:
+        plan_request = build_reverie_plan_request(broadcast, correlation_id=correlation_id)
+        exec_result = await client.execute_plan(
+            source=_source(),
+            req=plan_request,
+            correlation_id=correlation_id,
+            timeout_sec=settings.stance_react_timeout_sec,
+        )
+        raw_payload = extract_stance_react_payload(exec_result)
+    except Exception as exc:
+        logger.warning("reverie narration failed corr=%s err=%s", correlation_id, exc)
+        return None
+
+    thought = parse_reverie_payload(
+        raw_payload,
+        coalition=coalition,
+        correlation_id=correlation_id,
+        broadcast=broadcast,
+    )
+    if thought.hollow:
+        logger.info(
+            "reverie tick dropped hollow thought corr=%s reason=%s",
+            correlation_id,
+            thought.hollow_reason,
+        )
+        return None
+    if thought.salience < settings.reverie_min_salience:
+        logger.info(
+            "reverie tick below min salience corr=%s salience=%.3f min=%.3f",
+            correlation_id,
+            thought.salience,
+            settings.reverie_min_salience,
+        )
+        return None
+
+    envelope = BaseEnvelope(
+        kind="reverie.thought.v1",
+        source=_source(),
+        correlation_id=_envelope_correlation_id(correlation_id),
+        payload=thought.model_dump(mode="json"),
+    )
+    await bus.publish(settings.channel_reverie_thought, envelope)
+    logger.info(
+        "reverie thought published corr=%s salience=%.3f channel=%s",
+        correlation_id,
+        thought.salience,
+        settings.channel_reverie_thought,
+    )
+    return thought
+
+
+async def run_reverie_worker(stop_event: asyncio.Event | None = None) -> None:
+    """Self-driven reverie loop. Default-off; a no-op unless ORION_REVERIE_ENABLED."""
+    if not settings.reverie_enabled:
+        logger.info("reverie disabled; worker not started")
+        return
+    if not settings.orion_bus_enabled:
+        logger.info("bus disabled; reverie worker not started")
+        return
+
+    bus = OrionBusAsync(url=settings.orion_bus_url)
+    await bus.connect()
+    logger.info(
+        "reverie worker started interval=%ss min_salience=%.3f channel=%s",
+        settings.reverie_interval_sec,
+        settings.reverie_min_salience,
+        settings.channel_reverie_thought,
+    )
+    try:
+        while True:
+            if stop_event is not None and stop_event.is_set():
+                break
+            try:
+                await run_reverie_once(bus)
+            except Exception:
+                logger.exception("unhandled reverie tick error")
+            try:
+                if stop_event is not None:
+                    await asyncio.wait_for(stop_event.wait(), timeout=settings.reverie_interval_sec)
+                    break
+                await asyncio.sleep(settings.reverie_interval_sec)
+            except asyncio.TimeoutError:
+                continue
+    except asyncio.CancelledError:
+        raise
+    finally:
+        with suppress(Exception):
+            await bus.close()

--- a/services/orion-thought/app/reverie.py
+++ b/services/orion-thought/app/reverie.py
@@ -63,18 +63,12 @@ def _default_broadcast_reader() -> AttentionBroadcastProjectionV1 | None:
     reverie tick never raises on a missing/unavailable substrate.
     """
     try:
-        from orion.substrate.felt_state_reader import (  # local import: optional dep at tick time
-            SubstrateFeltStateReader,
-            substrate_felt_state_database_url,
-            substrate_felt_state_max_age_sec,
-        )
+        # Public fail-open entrypoint — resolves enabled/url/max-age internally and
+        # never raises. Same coalition source the evoked stance_react path reads.
+        from orion.substrate.felt_state_reader import hydrate_felt_state_ctx
 
-        reader = SubstrateFeltStateReader(
-            database_url=substrate_felt_state_database_url(),
-            max_age_sec=substrate_felt_state_max_age_sec(),
-        )
         ctx: dict[str, Any] = {}
-        reader.hydrate(ctx)
+        hydrate_felt_state_ctx(ctx)
         raw = ctx.get("attention_broadcast")
         if raw is None:
             return None
@@ -250,39 +244,42 @@ async def run_reverie_once(
             timeout_sec=settings.stance_react_timeout_sec,
         )
         raw_payload = extract_stance_react_payload(exec_result)
+
+        thought = parse_reverie_payload(
+            raw_payload,
+            coalition=coalition,
+            correlation_id=correlation_id,
+            broadcast=broadcast,
+        )
+        if thought.hollow:
+            logger.info(
+                "reverie tick dropped hollow thought corr=%s reason=%s",
+                correlation_id,
+                thought.hollow_reason,
+            )
+            return None
+        if thought.salience < settings.reverie_min_salience:
+            logger.info(
+                "reverie tick below min salience corr=%s salience=%.3f min=%.3f",
+                correlation_id,
+                thought.salience,
+                settings.reverie_min_salience,
+            )
+            return None
+
+        envelope = BaseEnvelope(
+            kind="reverie.thought.v1",
+            source=_source(),
+            correlation_id=_envelope_correlation_id(correlation_id),
+            payload=thought.model_dump(mode="json"),
+        )
+        await bus.publish(settings.channel_reverie_thought, envelope)
     except Exception as exc:
-        logger.warning("reverie narration failed corr=%s err=%s", correlation_id, exc)
+        # A tick must never raise (hard constraint) — a bus/narration/parse
+        # failure degrades to a dropped tick, not a crash.
+        logger.warning("reverie tick failed corr=%s err=%s", correlation_id, exc)
         return None
 
-    thought = parse_reverie_payload(
-        raw_payload,
-        coalition=coalition,
-        correlation_id=correlation_id,
-        broadcast=broadcast,
-    )
-    if thought.hollow:
-        logger.info(
-            "reverie tick dropped hollow thought corr=%s reason=%s",
-            correlation_id,
-            thought.hollow_reason,
-        )
-        return None
-    if thought.salience < settings.reverie_min_salience:
-        logger.info(
-            "reverie tick below min salience corr=%s salience=%.3f min=%.3f",
-            correlation_id,
-            thought.salience,
-            settings.reverie_min_salience,
-        )
-        return None
-
-    envelope = BaseEnvelope(
-        kind="reverie.thought.v1",
-        source=_source(),
-        correlation_id=_envelope_correlation_id(correlation_id),
-        payload=thought.model_dump(mode="json"),
-    )
-    await bus.publish(settings.channel_reverie_thought, envelope)
     logger.info(
         "reverie thought published corr=%s salience=%.3f channel=%s",
         correlation_id,

--- a/services/orion-thought/app/settings.py
+++ b/services/orion-thought/app/settings.py
@@ -46,6 +46,15 @@ class ThoughtSettings(BaseSettings):
     )
     stance_react_timeout_sec: float = Field(120.0, alias="STANCE_REACT_TIMEOUT_SEC")
 
+    # --- Reverie: spontaneous-thought mode (Phase A, default-off) ---
+    reverie_enabled: bool = Field(False, alias="ORION_REVERIE_ENABLED")
+    reverie_interval_sec: float = Field(90.0, alias="ORION_REVERIE_INTERVAL_SEC")
+    reverie_min_salience: float = Field(0.0, alias="ORION_REVERIE_MIN_SALIENCE")
+    channel_reverie_thought: str = Field(
+        "orion:reverie:thought",
+        alias="CHANNEL_REVERIE_THOUGHT",
+    )
+
 
 settings = ThoughtSettings()
 logger.info(

--- a/services/orion-thought/evals/test_reverie_hollow_guard_eval.py
+++ b/services/orion-thought/evals/test_reverie_hollow_guard_eval.py
@@ -1,0 +1,63 @@
+"""Eval: the un-anchored hollow-text guard for spontaneous thoughts.
+
+Phase A's real fail-fast risk is no longer "can an LLM narrate a coalition"
+(stance_react proved that) but "is an *un-anchored* narration non-hollow?".
+This eval scores the guard against a labeled set of grounded vs drivel
+narrations and asserts it separates them. Distinct from unit tests: this is a
+quality/behavior gate, not a single-case assertion.
+
+Run: pytest services/orion-thought/evals -q
+"""
+from __future__ import annotations
+
+from orion.schemas.reverie import SpontaneousThoughtV1
+from orion.schemas.thought import CoalitionSnapshotV1
+
+_COALITION = CoalitionSnapshotV1(
+    attended_node_ids=["n-conflict", "n-plan"],
+    selected_open_loop_id="ol-deploy",
+    open_loop_ids=["ol-deploy", "ol-trust"],
+    generated_at="2026-07-06T00:00:00Z",
+)
+
+# (interpretation, evidence_refs, expected_hollow)
+CASES: list[tuple[str, list[str], bool]] = [
+    # Grounded: cites real coalition ids, situated, substantive.
+    ("The deploy loop ol-deploy keeps winning and has not discharged; the conflict "
+     "at n-conflict is what keeps re-surfacing it.", ["ol-deploy", "n-conflict"], False),
+    ("Trust concern ol-trust is quiet but n-plan pressure is rising — the plan feels "
+     "under-specified and that is where attention lands.", ["ol-trust", "n-plan"], False),
+    ("n-conflict recurs against n-plan; the unresolved deployment decision is the "
+     "load-bearing open loop right now.", ["n-conflict"], False),
+    # Hollow: generic un-anchored musing, no coalition ids.
+    ("I am thinking about many things and life is complex.", [], True),
+    ("There is a lot going on and it all matters somehow.", ["something-vague"], True),
+    ("hmm", ["ol-deploy"], True),  # too short even though anchored
+    ("This is a deep and important reflection about existence and meaning.",
+     ["not-in-coalition"], True),  # substantive but un-anchored
+]
+
+
+def _score() -> tuple[int, int]:
+    correct = 0
+    for interpretation, evidence, expected_hollow in CASES:
+        t = SpontaneousThoughtV1(
+            thought_id="e", correlation_id="e", coalition=_COALITION,
+            interpretation=interpretation, evidence_refs=evidence,
+        ).marked_hollow()
+        if t.is_hollow() == expected_hollow:
+            correct += 1
+    return correct, len(CASES)
+
+
+def test_hollow_guard_separates_grounded_from_drivel():
+    correct, total = _score()
+    accuracy = correct / total
+    # The guard must perfectly separate this labeled set — any miss means either
+    # drivel would ship as cognition (§0A failure) or grounded thought is dropped.
+    assert accuracy == 1.0, f"hollow-guard accuracy {accuracy:.2f} ({correct}/{total})"
+
+
+if __name__ == "__main__":
+    c, t = _score()
+    print(f"reverie hollow-guard eval: {c}/{t} correct ({c / t:.0%})")

--- a/services/orion-thought/tests/test_reverie_spontaneous_thought.py
+++ b/services/orion-thought/tests/test_reverie_spontaneous_thought.py
@@ -195,3 +195,55 @@ async def test_tick_swallows_narration_failure():
     )
     assert result is None  # degraded, not raised
     bus.publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tick_swallows_publish_failure():
+    from app import reverie
+
+    bus = AsyncMock()
+    bus.publish = AsyncMock(side_effect=RuntimeError("bus down"))
+    cortex = AsyncMock()
+    cortex.execute_plan = AsyncMock(return_value={
+        "final_text": json.dumps({"interpretation": GROUNDED_TEXT, "evidence_refs": ["ol-1"]}),
+    })
+    # Must degrade to None, not raise, even though the thought was valid.
+    result = await reverie.run_reverie_once(
+        bus, broadcast_reader=lambda: _broadcast(), cortex_client=cortex,
+    )
+    assert result is None
+
+
+# --- default broadcast reader (real signature coverage, no live DB) ------------
+
+def test_default_broadcast_reader_hydrates_projection(monkeypatch):
+    """Covers the felt_state_reader wiring the mocked ticks skip."""
+    from app import reverie
+    import orion.substrate.felt_state_reader as fsr
+
+    def fake_hydrate(ctx):
+        ctx["attention_broadcast"] = _broadcast().model_dump(mode="json")
+
+    monkeypatch.setattr(fsr, "hydrate_felt_state_ctx", fake_hydrate)
+    result = reverie._default_broadcast_reader()
+    assert result is not None
+    assert result.attended_node_ids == ["n-1"]
+
+
+def test_default_broadcast_reader_none_on_empty(monkeypatch):
+    from app import reverie
+    import orion.substrate.felt_state_reader as fsr
+
+    monkeypatch.setattr(fsr, "hydrate_felt_state_ctx", lambda ctx: None)
+    assert reverie._default_broadcast_reader() is None
+
+
+def test_default_broadcast_reader_never_raises(monkeypatch):
+    from app import reverie
+    import orion.substrate.felt_state_reader as fsr
+
+    def boom(ctx):
+        raise RuntimeError("db unreachable")
+
+    monkeypatch.setattr(fsr, "hydrate_felt_state_ctx", boom)
+    assert reverie._default_broadcast_reader() is None  # swallowed

--- a/services/orion-thought/tests/test_reverie_spontaneous_thought.py
+++ b/services/orion-thought/tests/test_reverie_spontaneous_thought.py
@@ -1,0 +1,197 @@
+"""Phase A — spontaneous thought (reverie inside orion-thought).
+
+Covers the load-bearing anti-hollow guard and the producer's graceful
+degradation: a reverie tick must never raise and must never publish empty-shell
+cognition.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orion.schemas.attention_frame import (
+    AttentionBroadcastProjectionV1,
+    AttentionFrameV1,
+    OpenLoopV1,
+)
+from orion.schemas.reverie import SpontaneousThoughtV1
+from orion.schemas.thought import CoalitionSnapshotV1
+
+GROUNDED_TEXT = (
+    "I keep returning to the unresolved thread ol-1 — the conflict about the "
+    "deployment plan has not discharged and it is pulling attention."
+)
+
+
+def _coalition(attended=("n-1",), open_loops=("ol-1",), selected="ol-1"):
+    return CoalitionSnapshotV1(
+        attended_node_ids=list(attended),
+        selected_open_loop_id=selected,
+        open_loop_ids=list(open_loops),
+        generated_at="2026-07-06T00:00:00Z",
+    )
+
+
+def _broadcast(attended=("n-1",), loops=(("ol-1", {"predictive_value": 0.8}),),
+               selected="ol-1", stability=0.4):
+    frame = AttentionFrameV1(
+        open_loops=[OpenLoopV1(id=oid, description="d", **scores) for oid, scores in loops],
+    )
+    return AttentionBroadcastProjectionV1(
+        frame=frame,
+        attended_node_ids=list(attended),
+        selected_open_loop_id=selected,
+        coalition_stability_score=stability,
+    )
+
+
+# --- schema: the anti-hollow guard --------------------------------------------
+
+def test_absent_coalition_is_hollow():
+    t = SpontaneousThoughtV1(thought_id="t", correlation_id="c", coalition=None,
+                             interpretation=GROUNDED_TEXT, evidence_refs=["n-1"]).marked_hollow()
+    assert t.is_hollow() and t.hollow_reason == "absent_coalition"
+
+
+def test_short_interpretation_is_hollow():
+    t = SpontaneousThoughtV1(thought_id="t", correlation_id="c", coalition=_coalition(),
+                             interpretation="hmm", evidence_refs=["n-1"]).marked_hollow()
+    assert t.is_hollow() and t.hollow_reason == "interpretation_too_short"
+
+
+def test_no_evidence_is_unanchored_hollow():
+    t = SpontaneousThoughtV1(thought_id="t", correlation_id="c", coalition=_coalition(),
+                             interpretation=GROUNDED_TEXT, evidence_refs=[]).marked_hollow()
+    assert t.is_hollow() and t.hollow_reason == "unanchored_no_evidence"
+
+
+def test_evidence_outside_coalition_is_hollow():
+    t = SpontaneousThoughtV1(thought_id="t", correlation_id="c", coalition=_coalition(),
+                             interpretation=GROUNDED_TEXT, evidence_refs=["not-in-coalition"]).marked_hollow()
+    assert t.is_hollow() and t.hollow_reason == "unanchored_evidence_outside_coalition"
+
+
+def test_grounded_thought_is_not_hollow():
+    t = SpontaneousThoughtV1(thought_id="t", correlation_id="c", coalition=_coalition(),
+                             interpretation=GROUNDED_TEXT, evidence_refs=["ol-1"]).marked_hollow()
+    assert not t.is_hollow() and t.hollow_reason is None
+
+
+def test_evidence_refs_capped_at_50():
+    with pytest.raises(Exception):
+        SpontaneousThoughtV1(thought_id="t", correlation_id="c", coalition=_coalition(),
+                             interpretation=GROUNDED_TEXT, evidence_refs=[str(i) for i in range(51)])
+
+
+# --- producer: grounding + salience -------------------------------------------
+
+def test_build_coalition_snapshot_maps_broadcast():
+    from app import reverie
+
+    snap = reverie.build_coalition_snapshot(_broadcast())
+    assert snap is not None
+    assert snap.attended_node_ids == ["n-1"]
+    assert snap.open_loop_ids == ["ol-1"]
+    assert snap.selected_open_loop_id == "ol-1"
+
+
+def test_build_coalition_snapshot_none_on_absent():
+    from app import reverie
+
+    assert reverie.build_coalition_snapshot(None) is None
+
+
+def test_derive_salience_max_of_open_loop_scores():
+    from app import reverie
+
+    # selected loop predictive_value 0.8 dominates → salience 0.8 (no invented weights)
+    assert reverie.derive_salience(_broadcast()) == pytest.approx(0.8)
+
+
+def test_derive_salience_fallback_to_stability():
+    from app import reverie
+
+    # selected id not present among loops → fall back to coalition stability
+    bcast = _broadcast(selected="missing", stability=0.33)
+    assert reverie.derive_salience(bcast) == pytest.approx(0.33)
+
+
+def test_parse_reverie_payload_marks_unanchored_hollow():
+    from app import reverie
+
+    raw = json.dumps({"interpretation": GROUNDED_TEXT, "salience": 0.7, "evidence_refs": ["outside"]})
+    t = reverie.parse_reverie_payload(raw, coalition=_coalition(), correlation_id="c", broadcast=_broadcast())
+    assert t.hollow and t.hollow_reason == "unanchored_evidence_outside_coalition"
+
+
+def test_parse_reverie_payload_grounded_is_clean():
+    from app import reverie
+
+    # LLM proposes salience 0.7 but code owns it deterministically: predictive_value 0.8.
+    raw = json.dumps({"interpretation": GROUNDED_TEXT, "salience": 0.7, "evidence_refs": ["ol-1"]})
+    t = reverie.parse_reverie_payload(raw, coalition=_coalition(), correlation_id="c", broadcast=_broadcast())
+    assert not t.hollow
+    assert t.salience == pytest.approx(0.8)
+
+
+# --- producer: the tick never raises, never ships empty shells -----------------
+
+@pytest.mark.asyncio
+async def test_tick_returns_none_when_no_coalition():
+    from app import reverie
+
+    bus = AsyncMock()
+    result = await reverie.run_reverie_once(bus, broadcast_reader=lambda: None)
+    assert result is None
+    bus.publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tick_publishes_grounded_thought():
+    from app import reverie
+
+    bus = AsyncMock()
+    cortex = AsyncMock()
+    cortex.execute_plan = AsyncMock(return_value={
+        "final_text": json.dumps({"interpretation": GROUNDED_TEXT, "salience": 0.7, "evidence_refs": ["ol-1"]}),
+    })
+    result = await reverie.run_reverie_once(
+        bus, broadcast_reader=lambda: _broadcast(), cortex_client=cortex,
+    )
+    assert result is not None and not result.hollow
+    bus.publish.assert_called_once()
+    channel, envelope = bus.publish.call_args.args
+    assert channel == "orion:reverie:thought"
+    assert envelope.kind == "reverie.thought.v1"
+
+
+@pytest.mark.asyncio
+async def test_tick_drops_hollow_thought():
+    from app import reverie
+
+    bus = AsyncMock()
+    cortex = AsyncMock()
+    cortex.execute_plan = AsyncMock(return_value={
+        "final_text": json.dumps({"interpretation": "x", "salience": 0.9, "evidence_refs": []}),
+    })
+    result = await reverie.run_reverie_once(
+        bus, broadcast_reader=lambda: _broadcast(), cortex_client=cortex,
+    )
+    assert result is None
+    bus.publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tick_swallows_narration_failure():
+    from app import reverie
+
+    bus = AsyncMock()
+    cortex = AsyncMock()
+    cortex.execute_plan = AsyncMock(side_effect=RuntimeError("gateway down"))
+    result = await reverie.run_reverie_once(
+        bus, broadcast_reader=lambda: _broadcast(), cortex_client=cortex,
+    )
+    assert result is None  # degraded, not raised
+    bus.publish.assert_not_called()


### PR DESCRIPTION
## Summary

- Reconciles the reverie/dream weave spec with the **already-shipped `orion-thought` service** (unified-turn, #817–820): v2's premise "nothing gives a coalition a voice" was false — `stance_react`/`ThoughtEventV1` already narrates it. Adds a taxonomy: **evoked** thought (`ThoughtEventV1`) vs **spontaneous** thought (`SpontaneousThoughtV1`), split by trigger + destination, sharing `CoalitionSnapshotV1` grounding, both housed in `orion-thought`.
- Implements **Phase A**: a spontaneous-thought *mode* inside `orion-thought`. A self-driven tick reads the current rung-3 winning coalition (no `user_message`), narrates it via a new `reverie_narrate` cortex verb over the existing exec rail, and emits `SpontaneousThoughtV1` on `orion:reverie:thought`.
- Load-bearing `is_hollow()` guard rejects short **and** un-anchored text — the real Phase A fail-fast risk now that no user question anchors relevance.
- Everything is **default-off** (`ORION_REVERIE_ENABLED=false`) and **read-only** — no proposals, no memory writes, evoked path untouched.
- Salience is **deterministic** (§4): code owns it from coalition scores; the LLM owns only interpretation text.

## Outcome moved

New unprompted-cognition seam: `orion-thought` can now narrate its own current coalition when nobody asked (the first self-activated thought path), gated off. Before, coalition narration only fired in response to a user turn.

## Current architecture (before)

`orion-thought` = RPC turn-worker only: `orion:thought:request` (`StanceReactRequestV1`, requires `user_message`) → `stance_react` verb → `ThoughtEventV1` → Hub reply + `orion:thought:artifact`. Nothing narrated the coalition unprompted.

## Architecture touched

- `orion-thought`: second entrypoint (`run_reverie_worker`) beside `run_bus_worker`, wired into the FastAPI lifespan, default-off.
- New cortex verb `reverie_narrate` (reuses `LLMGatewayService` + `build_plan_for_verb` + `CortexExecClient`).
- New schema `SpontaneousThoughtV1` + registry + bus channel `orion:reverie:thought`.

## Files changed

- `docs/superpowers/plans/2026-07-05-reverie-dream-compaction-weave.md`: v3 reconciliation (premise, taxonomy, Phase A, rationale, component map, delivery status).
- `orion/schemas/reverie.py` (new): `SpontaneousThoughtV1`, `is_hollow()` guard, reuses `CoalitionSnapshotV1`.
- `orion/schemas/registry.py`: register `SpontaneousThoughtV1` → `reverie.thought.v1`.
- `orion/bus/channels.yaml`: `orion:reverie:thought` event channel.
- `orion/cognition/verbs/reverie_narrate.yaml` + `orion/cognition/prompts/reverie_narrate.j2` (new): mirror `stance_react`, reflection-shaped.
- `services/orion-thought/app/reverie.py` (new): producer — coalition read (fail-open), deterministic salience, narrate, hollow-drop, emit; degrades to None, never raises.
- `services/orion-thought/app/{settings,main}.py`: reverie env flags + gated self-driven task.
- `services/orion-thought/.env_example`: default-off flags.
- `services/orion-sql-db/manual_migration_substrate_reverie_thought.sql` (new): store table (contract-ahead; writer deferred).
- `services/orion-thought/tests/test_reverie_spontaneous_thought.py` + `evals/test_reverie_hollow_guard_eval.py` (new).

## Schema / bus / API changes

- **Added:** `SpontaneousThoughtV1` (`reverie.thought.v1`); channel `orion:reverie:thought` (event, producer `orion-thought`).
- **Removed / Renamed:** none.
- **Behavior changed:** none to existing paths — evoked `stance_react`/`ThoughtEventV1` untouched.
- **Compatibility:** additive; new channel/schema, default-off producer.

## Env/config changes

- **Added keys:** `ORION_REVERIE_ENABLED=false`, `ORION_REVERIE_INTERVAL_SEC=90`, `ORION_REVERIE_MIN_SALIENCE=0.0`, `CHANNEL_REVERIE_THOUGHT=orion:reverie:thought` (in `services/orion-thought/.env_example`).
- **`.env_example` updated:** yes. All safe non-secret defaults.
- **local `.env` sync:** ran `python scripts/sync_local_env_from_example.py`; `orion-thought` reported `no .env` (service has no local `.env` in this worktree). **Operator action:** on the athena host, run the sync after merge to add the four keys — the feature stays off without them (no functional impact until you enable it). Set `ORION_BUS_URL=redis://<tailscale-node-ip>:6379/0` as always.
- **Skipped keys:** none.

## Tests run

```text
pytest services/orion-thought/tests/ services/orion-thought/evals/  → 23 passed
# schema hollow-guard (5), producer grounding/salience (4), tick gating +
# never-raise (6), default-reader coverage (3), existing suite (2), + eval (1)
build_plan_for_verb('reverie_narrate') → plan loads
registry import → SpontaneousThoughtV1 registered as reverie.thought.v1
channels.yaml parse → orion:reverie:thought present
```

## Evals run

```text
pytest services/orion-thought/evals/test_reverie_hollow_guard_eval.py → 1 passed
# un-anchored hollow-guard: 7/7 labeled cases (grounded vs drivel) separated
```

## Docker/build/smoke checks

```text
NOT RUN — no live mesh in this environment. Runtime evidence for Phase A
(stored SpontaneousThoughtV1 whose coalition matches a live broadcast,
rendered in hub) is UNVERIFIED until run on the athena host. This is an
honest §0A UNVERIFIED, not a claimed pass.
```

## Review findings fixed

- **Finding (HIGH):** `_default_broadcast_reader` built `SubstrateFeltStateReader` without the required `enabled` kwarg → `TypeError` swallowed by the broad except → producer dead-on-arrival, never emits; masked because every test injected a fake reader.
  - **Fix:** switch to the public fail-open `hydrate_felt_state_ctx` entrypoint; add 3 tests that actually exercise the default reader.
  - **Evidence:** `test_default_broadcast_reader_*` (hydrate / empty / never-raises) pass.
- **Finding (LOW):** parse + `bus.publish` ran outside the `try/except`; a bus failure could raise out of a tick, violating "adapters never raise."
  - **Fix:** wrap the whole tail; a tick degrades to a dropped `None`.
  - **Evidence:** `test_tick_swallows_publish_failure` passes.
- **Finding (MEDIUM):** orphan migration + no store-writer/hub panel.
  - **Fix:** explicitly marked store-writer + hub panel + live smoke as DEFERRED in the plan's Phase A "Delivery status"; evidence flagged `UNVERIFIED`.
  - **Evidence:** doc delivery-status block.

## Restart required

```bash
# After merge + pull on athena. Feature is default-off; these just deploy the code.
python scripts/sync_local_env_from_example.py   # adds the 4 reverie keys
psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_substrate_reverie_thought.sql
# restart orion-thought (self-driven tick is a no-op until ORION_REVERIE_ENABLED=true):
docker compose --env-file .env --env-file services/orion-thought/.env \
  -f services/orion-thought/docker-compose.yml up -d --build
```

## Risks / concerns

- **Severity: medium.** Phase A's runtime evidence is `UNVERIFIED` (no live mesh here). Do not consider Phase A "done" per §0A until a real tick emits a coalition-matched, non-hollow `SpontaneousThoughtV1` on the athena host with the flag on.
- **Severity: low.** The store-writer + hub `_reverie_section` panel are deferred, so there is no inspection surface yet — enabling the flag emits to the bus channel only.
- **Severity: low.** The hollow guard is structural (evidence-ref anchoring); semantic "aboutness" is delegated to the prompt. Acceptable for Phase A; Phase H's resonance/efficacy evals are the real quality gate.

## Scope note

This PR is **spec reconciliation + Phase A only**. Phases B–H (thought→governed action, reverie chain, episode grounding, compaction request, dream REM, compaction applier, efficacy/resonance evals) remain proposal-mode and ship phase-by-phase with live verification per the plan's own escalating-blast-radius discipline — deliberately not bundled into one blind sprint.

## PR link

(this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)