### PR TITLE
Feat/graphiti rail phase a

### DIFF
--- a/orion/memory/crystallization/graphiti_config.py
+++ b/orion/memory/crystallization/graphiti_config.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def resolve_graphiti_adapter_url(settings) -> str:
+    return (
+        getattr(settings, "GRAPHITI_ADAPTER_URL", "") or
+        getattr(settings, "GRAPHITI_URL", "") or
+        ""
+    ).strip()

--- a/scripts/smoke_memory_crystallization_e2e.sh
+++ b/scripts/smoke_memory_crystallization_e2e.sh
@@ -55,4 +55,41 @@ PKT_CODE="$(echo "$PKT" | tail -n 1)"
 [[ "$PKT_CODE" == "200" ]] || { echo "FAIL active-packet HTTP $PKT_CODE"; exit 1; }
 echo "$PKT_BODY" | jq -c '{crystallization_refs, card_refs, chroma_refs, retrieval_trace}'
 
+echo "== projection health (graphiti flag) =="
+PROJ_HEALTH=$(curl -sS "${HDR[@]}" "${BASE}/api/memory/crystallizations/projection/health")
+echo "$PROJ_HEALTH" | jq -c .
+GRAPHITI_ON="$(echo "$PROJ_HEALTH" | jq -r '.graphiti_enabled // false')"
+
+_skip_graphiti() {
+  echo "WARN: skipping Graphiti steps ($1)"
+}
+
+if [[ "${GRAPHITI_SKIP:-0}" == "1" ]]; then
+  _skip_graphiti "GRAPHITI_SKIP=1"
+elif [[ "$GRAPHITI_ON" != "true" ]]; then
+  _skip_graphiti "graphiti_enabled=false"
+else
+  echo "== graphiti sync =="
+  SYNC=$(curl -sS -w "\n%{http_code}" -X POST "${BASE}/api/memory/graphiti/sync/${CID}" "${HDR[@]}" -d '{}')
+  SYNC_BODY="$(echo "$SYNC" | head -n -1)"
+  SYNC_CODE="$(echo "$SYNC" | tail -n 1)"
+  [[ "$SYNC_CODE" == "200" ]] || { echo "FAIL graphiti sync HTTP $SYNC_CODE body=$SYNC_BODY"; exit 1; }
+  EP_COUNT="$(echo "$SYNC_BODY" | jq -r '(.graphiti.episode_ids // []) | length')"
+  [[ "$EP_COUNT" -ge 1 ]] || { echo "FAIL graphiti sync returned no episode_ids"; exit 1; }
+
+  echo "== graphiti neighborhood =="
+  NB=$(curl -sS -w "\n%{http_code}" "${HDR[@]}" "${BASE}/api/memory/graphiti/neighborhood/${CID}")
+  NB_BODY="$(echo "$NB" | head -n -1)"
+  NB_CODE="$(echo "$NB" | tail -n 1)"
+  [[ "$NB_CODE" == "200" ]] || { echo "FAIL neighborhood HTTP $NB_CODE"; exit 1; }
+  NODE_COUNT="$(echo "$NB_BODY" | jq -r '(.nodes // []) | length')"
+  [[ "$NODE_COUNT" -ge 1 ]] || { echo "FAIL neighborhood nodes empty"; exit 1; }
+
+  echo "== graphiti health =="
+  GH=$(curl -sS "${HDR[@]}" "${BASE}/api/memory/graphiti/health")
+  echo "$GH" | jq -c .
+  [[ "$(echo "$GH" | jq -r '.enabled')" == "true" ]] || { echo "FAIL graphiti health enabled!=true"; exit 1; }
+  [[ "$(echo "$GH" | jq -r '.url_configured')" == "true" ]] || { echo "FAIL graphiti health url_configured!=true"; exit 1; }
+fi
+
 echo "PASS smoke_memory_crystallization_e2e crystallization_id=${CID}"

--- a/services/orion-graphiti-adapter/tests/conftest.py
+++ b/services/orion-graphiti-adapter/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("POSTGRES_URI", "")
+os.environ.setdefault("FALKORDB_ENABLED", "false")
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = SERVICE_ROOT.parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))

--- a/services/orion-graphiti-adapter/tests/test_episodes.py
+++ b/services/orion-graphiti-adapter/tests/test_episodes.py
@@ -1,0 +1,65 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main as main_mod
+
+
+@pytest.fixture
+def mock_pool():
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="OK")
+
+    @asynccontextmanager
+    async def acquire():
+        yield conn
+
+    pool = MagicMock()
+    pool.acquire = acquire
+    return pool, conn
+
+
+def test_ingest_episode_returns_ids(mock_pool):
+    pool, conn = mock_pool
+    with patch.object(main_mod, "pg_pool", pool), patch(
+        "app.main.sync_to_falkordb", return_value=None
+    ):
+        client = TestClient(main_mod.app)
+        resp = client.post(
+            "/v1/episodes",
+            json={
+                "crystallization_id": "crys_test001",
+                "kind": "stance",
+                "subject": "Test subject",
+                "summary": "Test summary",
+                "status": "active",
+                "metadata": {"scope": ["project:orion"]},
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["episode_id"] == "gep_crys_test001"
+        assert data["entity_id"] == "gent_crys_test001"
+        assert data["edge_id"] == "ged_crys_test001"
+        assert data["canonical_mutated"] is False
+        assert conn.execute.await_count >= 3
+
+
+def test_neighborhood_after_ingest(mock_pool):
+    pool, conn = mock_pool
+    conn.fetch = AsyncMock(
+        side_effect=[
+            [{"episode_id": "gep_crys_test001", "crystallization_id": "crys_test001"}],
+            [{"entity_id": "gent_crys_test001", "crystallization_id": "crys_test001"}],
+            [{"edge_id": "ged_crys_test001", "from_id": "gent_crys_test001", "to_id": "gep_crys_test001"}],
+        ]
+    )
+    with patch.object(main_mod, "pg_pool", pool):
+        client = TestClient(main_mod.app)
+        resp = client.get("/v1/neighborhood/crys_test001")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["nodes"]) >= 1
+        assert data["crystallization_id"] == "crys_test001"

--- a/services/orion-graphiti-adapter/tests/test_health.py
+++ b/services/orion-graphiti-adapter/tests/test_health.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import app.main as main_mod
+
+
+def test_health_without_postgres():
+    with patch.object(main_mod, "pg_pool", None):
+        client = TestClient(main_mod.app)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["postgres"] is False
+        assert data["service"] == "orion-graphiti-adapter"

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -201,6 +201,7 @@ RECALL_PG_DSN=postgresql://postgres:postgres@127.0.0.1:55432/conjourney
 
 # --- Memory crystallization Graphiti/FalkorDB (additive temporal projection; NOT RDF memory_graph) ---
 GRAPHITI_ENABLED=true
+# Deprecated fallback — prefer GRAPHITI_ADAPTER_URL below
 GRAPHITI_URL=
 FALKORDB_URI=
 
@@ -215,7 +216,7 @@ CRYSTALLIZER_AUTO_PROJECT_ON_APPROVE=true
 CHROMA_HOST=
 CHROMA_PORT=8000
 
-# Graphiti additive adapter (NOT RDF memory_graph)
+# Graphiti additive adapter (NOT RDF memory_graph) — required when GRAPHITI_ENABLED=true
 GRAPHITI_ADAPTER_URL=http://orion-athena-graphiti-adapter:8000
 
 # --- Global graph / RDF store (Fuseki; Hub memory-graph approve + substrate SPARQL) ---

--- a/services/orion-hub/scripts/crystallization_routes.py
+++ b/services/orion-hub/scripts/crystallization_routes.py
@@ -17,6 +17,7 @@ from orion.memory.crystallization.chroma_publish import publish_crystallization_
 from orion.memory.crystallization.governor import GovernorError, approve, quarantine, reject, supersede
 from orion.memory.crystallization.links import insert_link, list_links, neighborhood as link_neighborhood
 from orion.memory.crystallization.projection_cards import build_memory_card_projection
+from orion.memory.crystallization.graphiti_config import resolve_graphiti_adapter_url
 from orion.memory.crystallization.projection_graphiti import GraphitiAdapter
 from orion.memory.crystallization.projection_rdf import build_rdf_projection_hint
 from orion.memory.crystallization.projector import ProjectionConfig, project_crystallization
@@ -71,7 +72,7 @@ def _settings():
 
 def _graphiti(request: Request) -> GraphitiAdapter:
     settings = _settings()
-    adapter_url = (getattr(settings, "GRAPHITI_ADAPTER_URL", "") or getattr(settings, "GRAPHITI_URL", "") or "").strip()
+    adapter_url = resolve_graphiti_adapter_url(settings)
     return GraphitiAdapter(
         enabled=bool(getattr(settings, "GRAPHITI_ENABLED", False)) or bool(adapter_url),
         url=adapter_url or None,
@@ -81,13 +82,14 @@ def _graphiti(request: Request) -> GraphitiAdapter:
 
 def _projection_config() -> ProjectionConfig:
     s = _settings()
+    adapter_url = resolve_graphiti_adapter_url(s)
     return ProjectionConfig(
         collection=getattr(s, "CRYSTALLIZER_VECTOR_COLLECTION", "orion_memory_crystallizations"),
         embed_host_url=getattr(s, "CRYSTALLIZER_EMBED_HOST_URL", "") or "",
         embed_mode=getattr(s, "CRYSTALLIZER_EMBED_MODE", "http") or "http",
         embed_timeout_ms=int(getattr(s, "CRYSTALLIZER_EMBED_TIMEOUT_MS", 8000) or 8000),
-        graphiti_enabled=bool(getattr(s, "GRAPHITI_ENABLED", False)),
-        graphiti_url=getattr(s, "GRAPHITI_URL", "") or "",
+        graphiti_enabled=bool(getattr(s, "GRAPHITI_ENABLED", False)) or bool(adapter_url),
+        graphiti_url=adapter_url,
         falkordb_uri=getattr(s, "FALKORDB_URI", "") or "",
         service_name=getattr(s, "SERVICE_NAME", "orion-hub"),
         service_version=getattr(s, "SERVICE_VERSION", "0.1.0"),

--- a/services/orion-hub/tests/test_graphiti_config_parity.py
+++ b/services/orion-hub/tests/test_graphiti_config_parity.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import Request
+
+from scripts import crystallization_routes as routes
+
+
+@pytest.fixture
+def adapter_url_only_settings(monkeypatch):
+    fake = SimpleNamespace(
+        GRAPHITI_ENABLED=False,
+        GRAPHITI_ADAPTER_URL="http://orion-athena-graphiti-adapter:8000",
+        GRAPHITI_URL="",
+        FALKORDB_URI="",
+        CRYSTALLIZER_VECTOR_COLLECTION="orion_memory_crystallizations",
+        CRYSTALLIZER_EMBED_HOST_URL="",
+        CRYSTALLIZER_EMBED_MODE="http",
+        CRYSTALLIZER_EMBED_TIMEOUT_MS=8000,
+        SERVICE_NAME="orion-hub",
+        SERVICE_VERSION="0.1.0",
+        NODE_NAME="hub",
+    )
+    monkeypatch.setattr(routes, "_settings", lambda: fake)
+    return fake
+
+
+def test_projection_config_url_matches_graphiti_adapter(adapter_url_only_settings):
+    cfg = routes._projection_config()
+    request = MagicMock(spec=Request)
+    adapter = routes._graphiti(request)
+
+    assert cfg.graphiti_url == "http://orion-athena-graphiti-adapter:8000"
+    assert adapter.url == "http://orion-athena-graphiti-adapter:8000"
+    assert cfg.graphiti_enabled is True
+    assert adapter.enabled is True

--- a/tests/test_graphiti_config.py
+++ b/tests/test_graphiti_config.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+
+from orion.memory.crystallization.graphiti_config import resolve_graphiti_adapter_url
+
+
+def test_resolve_prefers_adapter_url_over_graphiti_url():
+    settings = SimpleNamespace(
+        GRAPHITI_ADAPTER_URL="http://adapter:8000",
+        GRAPHITI_URL="http://legacy:8000",
+    )
+    assert resolve_graphiti_adapter_url(settings) == "http://adapter:8000"
+
+
+def test_resolve_falls_back_to_graphiti_url():
+    settings = SimpleNamespace(GRAPHITI_ADAPTER_URL="", GRAPHITI_URL="http://legacy:8000")
+    assert resolve_graphiti_adapter_url(settings) == "http://legacy:8000"
+
+
+def test_resolve_empty_when_both_unset():
+    settings = SimpleNamespace(GRAPHITI_ADAPTER_URL="", GRAPHITI_URL="")
+    assert resolve_graphiti_adapter_url(settings) == ""


### PR DESCRIPTION
## Summary
- Add `resolve_graphiti_adapter_url()` — single resolver preferring `GRAPHITI_ADAPTER_URL` over legacy `GRAPHITI_URL`
- Wire Hub `_graphiti()` and `_projection_config()` through the resolver so adapter URL alone enables projection
- Document `GRAPHITI_ADAPTER_URL` as primary in `services/orion-hub/.env_example`
- Add adapter test harness (conftest, health-without-postgres, ingest + neighborhood)
- Extend `scripts/smoke_memory_crystallization_e2e.sh` with Graphiti sync/neighborhood/health steps (`GRAPHITI_SKIP=1` warn path)
## Outcome moved
Approve auto-projects to Graphiti when `GRAPHITI_ADAPTER_URL` is set, even if `GRAPHITI_ENABLED=false`. Hub projection config and route adapter now agree on URL and enabled state.
## Tests run
```text
pytest tests/test_graphiti_config.py -q                                    → 3 passed
cd services/orion-hub && pytest tests/test_graphiti_config_parity.py -q     → 1 passed
cd services/orion-graphiti-adapter && pytest tests -q                      → 3 passed
Restart required
docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-graphiti-adapter/.env \
  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
Test plan

 CI green

 Smoke with adapter running (or GRAPHITI_SKIP=1 for crystallization-only)

 Approve response projection.graphiti non-empty when adapter URL set
