### PR TITLE
Feat/graphiti rail phase b

### DIFF
--- a/orion/memory/crystallization/projection_graphiti.py
+++ b/orion/memory/crystallization/projection_graphiti.py
@@ -51,6 +51,14 @@ class GraphitiAdapter:
                 "salience": crystallization.salience,
                 "confidence": crystallization.confidence,
             },
+            "links": [
+                {
+                    "target_crystallization_id": l.target_crystallization_id,
+                    "relation": l.relation,
+                    "confidence": l.confidence,
+                }
+                for l in crystallization.links
+            ],
         }
         try:
             async with httpx.AsyncClient(timeout=self.timeout_sec) as client:
@@ -82,6 +90,14 @@ class GraphitiAdapter:
             "summary": crystallization.summary,
             "status": crystallization.status,
             "metadata": {"scope": crystallization.scope, "salience": crystallization.salience},
+            "links": [
+                {
+                    "target_crystallization_id": l.target_crystallization_id,
+                    "relation": l.relation,
+                    "confidence": l.confidence,
+                }
+                for l in crystallization.links
+            ],
         }
         try:
             with httpx.Client(timeout=self.timeout_sec) as client:
@@ -101,12 +117,15 @@ class GraphitiAdapter:
             remote_response=data,
         )
 
-    def neighborhood(self, crystallization_id: str) -> dict[str, Any]:
+    def neighborhood(self, crystallization_id: str, *, depth: int = 1) -> dict[str, Any]:
         if not self.enabled or not self.url:
             return {"enabled": False, "nodes": [], "edges": []}
         try:
             with httpx.Client(timeout=self.timeout_sec) as client:
-                resp = client.get(f"{self.url}/v1/neighborhood/{crystallization_id}")
+                resp = client.get(
+                    f"{self.url}/v1/neighborhood/{crystallization_id}",
+                    params={"depth": depth},
+                )
                 resp.raise_for_status()
                 data = resp.json()
                 data["enabled"] = True

--- a/orion/memory/crystallization/retriever.py
+++ b/orion/memory/crystallization/retriever.py
@@ -74,7 +74,7 @@ async def retrieve_active_packet(
             extra_crystallization_ids.add(str(cid))
 
     if graphiti_adapter and graphiti_adapter.enabled and seed_crystallization_id:
-        nb = graphiti_adapter.neighborhood(seed_crystallization_id)
+        nb = graphiti_adapter.neighborhood(seed_crystallization_id, depth=2)
         for node in nb.get("nodes") or []:
             nid = node.get("crystallization_id") or node.get("id")
             if nid:

--- a/scripts/smoke_graphiti_links_e2e.sh
+++ b/scripts/smoke_graphiti_links_e2e.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Smoke: two crystallizations with supports link → graphiti neighborhood depth 2 returns both
+set -euo pipefail
+: "${ORION_HUB_URL:?}"
+: "${ORION_HUB_SESSION_ID:?}"
+BASE="${ORION_HUB_URL%/}"
+HDR=(-H "Content-Type: application/json" -H "X-Orion-Session-Id: ${ORION_HUB_SESSION_ID}")
+STAMP="$(date -u +%Y%m%d%H%M%S)"
+
+_propose() {
+  local subject="$1" summary="$2"
+  curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/propose" -d "$(jq -n --arg s "$subject" --arg m "$summary" '{
+    kind: "stance", subject: $s, summary: $m, scope: ["project:orion"],
+    evidence: [{source_kind: "operator_note", source_id: "smoke-link", excerpt: "smoke"}],
+    proposed_by: "smoke"
+  }')" | jq -r '.crystallization_id'
+}
+
+_approve() {
+  local cid="$1"
+  curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/proposals/${cid}/validate" >/dev/null
+  curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/proposals/${cid}/approve" -d '{}' >/dev/null
+}
+
+CID_A="$(_propose "Link smoke A ${STAMP}" "seed A")"
+CID_B="$(_propose "Link smoke B ${STAMP}" "target B")"
+_approve "$CID_A"
+_approve "$CID_B"
+
+curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/${CID_A}/links" \
+  -d "$(jq -n --arg t "$CID_B" '{target_crystallization_id: $t, relation: "supports", confidence: 0.9}')" >/dev/null
+
+curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/graphiti/sync/${CID_A}" -d '{}' >/dev/null
+curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/graphiti/sync/${CID_B}" -d '{}' >/dev/null
+
+NB=$(curl -sS "${HDR[@]}" "${BASE}/api/memory/graphiti/neighborhood/${CID_A}?depth=2")
+CIDS=$(echo "$NB" | jq -r '[.nodes[]?.crystallization_id] | unique | .[]')
+echo "$CIDS" | grep -qx "$CID_A"
+echo "$CIDS" | grep -qx "$CID_B"
+echo "PASS smoke_graphiti_links_e2e seed=${CID_A} linked=${CID_B}"

--- a/services/orion-graphiti-adapter/README.md
+++ b/services/orion-graphiti-adapter/README.md
@@ -13,3 +13,13 @@ Additive temporal graph projection service for `MemoryCrystallizationV1`.
 - `GET /health`
 
 Hub `GraphitiAdapter` calls this service when `GRAPHITI_URL` is set.
+
+## FalkorDB profile (optional)
+
+```bash
+docker compose --profile falkordb \
+  --env-file .env \
+  -f services/orion-graphiti-adapter/docker-compose.yml up -d
+```
+
+Set `FALKORDB_ENABLED=true` in `services/orion-graphiti-adapter/.env`.

--- a/services/orion-graphiti-adapter/app/falkordb.py
+++ b/services/orion-graphiti-adapter/app/falkordb.py
@@ -14,6 +14,7 @@ def sync_to_falkordb(
     kind: str,
     subject: str,
     summary: str,
+    links: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Best-effort FalkorDB projection via Redis GRAPH commands."""
     if not uri.strip():
@@ -30,6 +31,14 @@ def sync_to_falkordb(
             f"MERGE (ep:Episode {{id: '{episode_id}', kind: '{kind}', summary: '{summary[:200].replace(chr(39), '')}'}}) "
             f"MERGE (e)-[:HAS_EPISODE]->(ep)"
         )
+        for link in links or []:
+            target = link["target_crystallization_id"]
+            relation = str(link["relation"]).upper().replace("-", "_")
+            target_entity = f"gent_{target}"
+            cypher += (
+                f" MERGE (t:Entity {{id: '{target_entity}', crystallization_id: '{target}'}}) "
+                f"MERGE (e)-[:{relation}]->(t)"
+            )
         result = client.execute_command("GRAPH.QUERY", graph_name, cypher)
         return {"synced": True, "graph": graph_name, "result_type": type(result).__name__}
     except Exception as exc:

--- a/services/orion-graphiti-adapter/app/main.py
+++ b/services/orion-graphiti-adapter/app/main.py
@@ -93,7 +93,7 @@ async def ingest_episode(body: EpisodeIngestV1) -> dict:
 
 
 @app.get("/v1/neighborhood/{crystallization_id}")
-async def get_neighborhood(crystallization_id: str) -> dict:
+async def get_neighborhood(crystallization_id: str, depth: int = 1) -> dict:
     if pg_pool is None:
         raise HTTPException(status_code=503, detail="store_unavailable")
-    return await neighborhood(pg_pool, crystallization_id)
+    return await neighborhood(pg_pool, crystallization_id, depth=depth)

--- a/services/orion-graphiti-adapter/app/main.py
+++ b/services/orion-graphiti-adapter/app/main.py
@@ -14,6 +14,12 @@ logger = logging.getLogger(settings.SERVICE_NAME)
 pg_pool: Optional[asyncpg.Pool] = None
 
 
+class CrystallizationLinkIngestV1(BaseModel):
+    target_crystallization_id: str
+    relation: str
+    confidence: float = 0.5
+
+
 class EpisodeIngestV1(BaseModel):
     crystallization_id: str
     kind: str
@@ -21,6 +27,7 @@ class EpisodeIngestV1(BaseModel):
     summary: str
     status: str = "active"
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    links: list[CrystallizationLinkIngestV1] = Field(default_factory=list)
 
 
 @asynccontextmanager
@@ -54,7 +61,7 @@ async def ingest_episode(body: EpisodeIngestV1) -> dict:
     if pg_pool is None:
         raise HTTPException(status_code=503, detail="store_unavailable")
     episode_id = f"gep_{body.crystallization_id}"
-    await upsert_episode(
+    edge_ids = await upsert_episode(
         pg_pool,
         episode_id=episode_id,
         crystallization_id=body.crystallization_id,
@@ -63,6 +70,7 @@ async def ingest_episode(body: EpisodeIngestV1) -> dict:
         summary=body.summary,
         status=body.status,
         metadata=body.metadata,
+        links=[l.model_dump() for l in body.links],
     )
     falkor_result = None
     if settings.FALKORDB_ENABLED:
@@ -77,7 +85,8 @@ async def ingest_episode(body: EpisodeIngestV1) -> dict:
     return {
         "episode_id": episode_id,
         "entity_id": f"gent_{body.crystallization_id}",
-        "edge_id": f"ged_{body.crystallization_id}",
+        "edge_id": edge_ids[0] if edge_ids else f"ged_{body.crystallization_id}",
+        "edge_ids": edge_ids,
         "falkordb": falkor_result,
         "canonical_mutated": False,
     }

--- a/services/orion-graphiti-adapter/app/main.py
+++ b/services/orion-graphiti-adapter/app/main.py
@@ -81,6 +81,7 @@ async def ingest_episode(body: EpisodeIngestV1) -> dict:
             kind=body.kind,
             subject=body.subject,
             summary=body.summary,
+            links=[l.model_dump() for l in body.links],
         )
     return {
         "episode_id": episode_id,

--- a/services/orion-graphiti-adapter/app/store.py
+++ b/services/orion-graphiti-adapter/app/store.py
@@ -134,25 +134,56 @@ async def upsert_episode(
     return edge_ids
 
 
-async def neighborhood(pool: asyncpg.Pool, crystallization_id: str) -> dict[str, Any]:
+async def neighborhood(pool: asyncpg.Pool, crystallization_id: str, *, depth: int = 1) -> dict[str, Any]:
+    depth = max(1, min(int(depth), 2))
+    visited_nodes: dict[str, dict] = {}
+    visited_edges: dict[str, dict] = {}
+    frontier = {f"gent_{crystallization_id}", f"gep_{crystallization_id}"}
+
     async with pool.acquire() as conn:
+        for _ in range(depth + 1):
+            if not frontier:
+                break
+            node_ids = list(frontier)
+            frontier = set()
+            rows = await conn.fetch(
+                """
+                SELECT * FROM graphiti_edges
+                WHERE from_id = ANY($1::text[]) OR to_id = ANY($1::text[])
+                """,
+                node_ids,
+            )
+            for row in rows:
+                edge = dict(row)
+                visited_edges[edge["edge_id"]] = edge
+                for nid in (edge["from_id"], edge["to_id"]):
+                    if nid not in visited_nodes:
+                        frontier.add(nid)
+
+        crystallization_ids = {crystallization_id}
+        for edge in visited_edges.values():
+            for nid in (edge["from_id"], edge["to_id"]):
+                if nid.startswith("gent_"):
+                    crystallization_ids.add(nid.removeprefix("gent_"))
+                if nid.startswith("gep_"):
+                    crystallization_ids.add(nid.removeprefix("gep_"))
+
         episodes = await conn.fetch(
-            "SELECT * FROM graphiti_episodes WHERE crystallization_id = $1",
-            crystallization_id,
+            "SELECT * FROM graphiti_episodes WHERE crystallization_id = ANY($1::text[])",
+            list(crystallization_ids),
         )
         entities = await conn.fetch(
-            "SELECT * FROM graphiti_entities WHERE crystallization_id = $1",
-            crystallization_id,
+            "SELECT * FROM graphiti_entities WHERE crystallization_id = ANY($1::text[])",
+            list(crystallization_ids),
         )
-        edges = await conn.fetch(
-            """
-            SELECT * FROM graphiti_edges
-            WHERE from_id LIKE $1 OR to_id LIKE $1
-            """,
-            f"%{crystallization_id}%",
-        )
+
+    for row in list(entities) + list(episodes):
+        key = row["entity_id"] if "entity_id" in row else row["episode_id"]
+        visited_nodes[key] = dict(row)
+
     return {
         "crystallization_id": crystallization_id,
-        "nodes": [dict(e) for e in entities] + [dict(e) for e in episodes],
-        "edges": [dict(e) for e in edges],
+        "depth": depth,
+        "nodes": list(visited_nodes.values()),
+        "edges": list(visited_edges.values()),
     }

--- a/services/orion-graphiti-adapter/app/store.py
+++ b/services/orion-graphiti-adapter/app/store.py
@@ -48,7 +48,9 @@ async def upsert_episode(
     summary: str,
     status: str,
     metadata: dict[str, Any],
-) -> None:
+    links: list[dict[str, Any]] | None = None,
+) -> list[str]:
+    edge_ids: list[str] = []
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -96,6 +98,40 @@ async def upsert_episode(
             "has_episode",
             json.dumps({"crystallization_id": crystallization_id}),
         )
+        edge_ids.append(edge_id)
+
+        for link in links or []:
+            target_id = str(link["target_crystallization_id"])
+            relation = str(link["relation"])
+            confidence = float(link.get("confidence", 0.5))
+            target_entity_id = f"gent_{target_id}"
+            await conn.execute(
+                """
+                INSERT INTO graphiti_entities (entity_id, crystallization_id, name, metadata)
+                VALUES ($1, $2, $3, $4::jsonb)
+                ON CONFLICT (entity_id) DO NOTHING
+                """,
+                target_entity_id,
+                target_id,
+                f"stub:{target_id}",
+                json.dumps({"stub": True}),
+            )
+            from_entity_id = f"gent_{crystallization_id}"
+            link_edge_id = f"ged_{crystallization_id}_{target_id}_{relation}"
+            await conn.execute(
+                """
+                INSERT INTO graphiti_edges (edge_id, from_id, to_id, relation, metadata)
+                VALUES ($1, $2, $3, $4, $5::jsonb)
+                ON CONFLICT (edge_id) DO UPDATE SET metadata = EXCLUDED.metadata
+                """,
+                link_edge_id,
+                from_entity_id,
+                target_entity_id,
+                relation,
+                json.dumps({"confidence": confidence, "note": link.get("note")}),
+            )
+            edge_ids.append(link_edge_id)
+    return edge_ids
 
 
 async def neighborhood(pool: asyncpg.Pool, crystallization_id: str) -> dict[str, Any]:

--- a/services/orion-graphiti-adapter/tests/test_episodes.py
+++ b/services/orion-graphiti-adapter/tests/test_episodes.py
@@ -51,9 +51,16 @@ def test_neighborhood_after_ingest(mock_pool):
     pool, conn = mock_pool
     conn.fetch = AsyncMock(
         side_effect=[
+            [
+                {
+                    "edge_id": "ged_crys_test001",
+                    "from_id": "gent_crys_test001",
+                    "to_id": "gep_crys_test001",
+                }
+            ],
+            [],
             [{"episode_id": "gep_crys_test001", "crystallization_id": "crys_test001"}],
             [{"entity_id": "gent_crys_test001", "crystallization_id": "crys_test001"}],
-            [{"edge_id": "ged_crys_test001", "from_id": "gent_crys_test001", "to_id": "gep_crys_test001"}],
         ]
     )
     with patch.object(main_mod, "pg_pool", pool):

--- a/services/orion-graphiti-adapter/tests/test_links.py
+++ b/services/orion-graphiti-adapter/tests/test_links.py
@@ -43,3 +43,36 @@ def test_ingest_with_supports_link_writes_cross_edge():
         sql_calls = [str(c.args[0]) for c in conn.execute.await_args_list]
         assert any("graphiti_edges" in s for s in sql_calls)
         assert any("crys_b" in str(c) for c in conn.execute.await_args_list)
+
+
+def test_neighborhood_depth_two_returns_linked_crystallization():
+    pool, conn = _mock_pool()
+    conn.fetch = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "edge_id": "ged_a_b_supports",
+                    "from_id": "gent_crys_a",
+                    "to_id": "gent_crys_b",
+                    "relation": "supports",
+                },
+                {
+                    "edge_id": "ged_has",
+                    "from_id": "gent_crys_b",
+                    "to_id": "gep_crys_b",
+                    "relation": "has_episode",
+                },
+            ],
+            [],
+            [],
+            [{"episode_id": "gep_crys_a", "crystallization_id": "crys_a"}, {"episode_id": "gep_crys_b", "crystallization_id": "crys_b"}],
+            [{"entity_id": "gent_crys_a", "crystallization_id": "crys_a"}, {"entity_id": "gent_crys_b", "crystallization_id": "crys_b"}],
+        ]
+    )
+    with patch.object(main_mod, "pg_pool", pool):
+        client = TestClient(main_mod.app)
+        resp = client.get("/v1/neighborhood/crys_a?depth=2")
+        assert resp.status_code == 200
+        cids = {n.get("crystallization_id") for n in resp.json()["nodes"]}
+        assert "crys_a" in cids
+        assert "crys_b" in cids

--- a/services/orion-graphiti-adapter/tests/test_links.py
+++ b/services/orion-graphiti-adapter/tests/test_links.py
@@ -1,0 +1,45 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+import app.main as main_mod
+
+
+def _mock_pool():
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="OK")
+
+    @asynccontextmanager
+    async def acquire():
+        yield conn
+
+    pool = MagicMock()
+    pool.acquire = acquire
+    return pool, conn
+
+
+def test_ingest_with_supports_link_writes_cross_edge():
+    pool, conn = _mock_pool()
+    with patch.object(main_mod, "pg_pool", pool), patch("app.main.sync_to_falkordb", return_value=None):
+        client = TestClient(main_mod.app)
+        resp = client.post(
+            "/v1/episodes",
+            json={
+                "crystallization_id": "crys_a",
+                "kind": "stance",
+                "subject": "A",
+                "summary": "A summary",
+                "links": [
+                    {
+                        "target_crystallization_id": "crys_b",
+                        "relation": "supports",
+                        "confidence": 0.9,
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        sql_calls = [str(c.args[0]) for c in conn.execute.await_args_list]
+        assert any("graphiti_edges" in s for s in sql_calls)
+        assert any("crys_b" in str(c) for c in conn.execute.await_args_list)

--- a/services/orion-hub/static/js/memory-crystallization-ui.js
+++ b/services/orion-hub/static/js/memory-crystallization-ui.js
@@ -83,20 +83,25 @@
               <div><strong>${escapeHtml(row.subject)}</strong> <span class="text-gray-500">[${escapeHtml(row.kind)}]</span></div>
               <div>${escapeHtml(row.summary)}</div>
               <div class="text-gray-500">Status: ${escapeHtml(row.status)} · Confidence: ${escapeHtml(row.confidence)}</div>
-              <div class="text-gray-500">Projection refs: cards=${(row.projection_refs && row.projection_refs.memory_card_ids || []).length}, chroma=${(row.projection_refs && row.projection_refs.chroma_doc_ids || []).length}</div>
+              <div class="text-gray-500">Projection refs: cards=${(row.projection_refs && row.projection_refs.memory_card_ids || []).length}, chroma=${(row.projection_refs && row.projection_refs.chroma_doc_ids || []).length}, graphiti_eps=${((row.projection_refs && row.projection_refs.graphiti_episode_ids) || []).length}, graphiti_edges=${((row.projection_refs && row.projection_refs.graphiti_edge_ids) || []).length}</div>
               <div class="text-gray-500">Links: ${(links.items || []).length}</div>
               <div class="text-gray-500">Health: chroma=${escapeHtml(health.chroma_collection || "")}, graphiti=${health.graphiti_enabled ? "on" : "off"}</div>
               <div class="flex gap-2 mt-2">
                 <button type="button" data-act="approve" class="px-2 py-1 rounded border border-emerald-700 text-emerald-200">Approve</button>
                 <button type="button" data-act="reject" class="px-2 py-1 rounded border border-red-800 text-red-200">Reject</button>
                 <button type="button" data-act="validate" class="px-2 py-1 rounded border border-gray-600 text-gray-200">Validate</button>
+                <button type="button" data-act="sync-graphiti" class="px-2 py-1 rounded border border-sky-700 text-sky-200">Sync Graphiti</button>
               </div>
             </div>`;
             detailEl.querySelectorAll("button[data-act]").forEach((btn) => {
               btn.addEventListener("click", async () => {
                 const act = btn.getAttribute("data-act");
                 try {
-                  await apiFetch(`/api/memory/crystallizations/proposals/${row.crystallization_id}/${act}`, { method: "POST", body: act === "validate" ? undefined : "{}" });
+                  if (act === "sync-graphiti") {
+                    await apiFetch(`/api/memory/graphiti/sync/${row.crystallization_id}`, { method: "POST", body: "{}" });
+                  } else {
+                    await apiFetch(`/api/memory/crystallizations/proposals/${row.crystallization_id}/${act}`, { method: "POST", body: act === "validate" ? undefined : "{}" });
+                  }
                   setStatus(statusEl, `${act} ok`, false);
                   await loadInbox(listEl, statusEl, detailEl);
                 } catch (e) {

--- a/services/orion-hub/tests/test_graphiti_sync_payload.py
+++ b/services/orion-hub/tests/test_graphiti_sync_payload.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from orion.memory.crystallization.projection_graphiti import GraphitiAdapter
+from orion.memory.crystallization.schemas import CrystallizationGovernanceV1, CrystallizationLinkV1, MemoryCrystallizationV1
+
+
+def _crys_with_link():
+    now = datetime.now(timezone.utc)
+    return MemoryCrystallizationV1(
+        crystallization_id="crys_a",
+        kind="stance",
+        subject="A",
+        summary="summary",
+        status="active",
+        governance=CrystallizationGovernanceV1(proposed_by="test", approved_by="test"),
+        created_at=now,
+        updated_at=now,
+        links=[
+            CrystallizationLinkV1(target_crystallization_id="crys_b", relation="supports", confidence=0.8)
+        ],
+    )
+
+
+def test_sync_payload_includes_links():
+    crys = _crys_with_link()
+    adapter = GraphitiAdapter(enabled=True, url="http://graphiti")
+    captured = {}
+
+    def fake_post(url, json=None, **kwargs):
+        captured["json"] = json
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"episode_id": "gep_crys_a", "entity_id": "gent_crys_a", "edge_id": "ged_x", "canonical_mutated": False}
+        return resp
+
+    with patch("httpx.Client.post", side_effect=fake_post):
+        adapter.sync_crystallization(crys)
+
+    assert captured["json"]["links"] == [
+        {"target_crystallization_id": "crys_b", "relation": "supports", "confidence": 0.8}
+    ]

--- a/services/orion-hub/tests/test_memory_crystallization_ui.py
+++ b/services/orion-hub/tests/test_memory_crystallization_ui.py
@@ -16,3 +16,9 @@ def test_crystallization_observatory_ui_wired() -> None:
     assert "OrionMemoryCrystallizationUI" in ui
     assert 'activateSubview("crystallizations")' in memory_js
     assert "memoryCrystallizationPanel" in memory_js
+
+
+def test_crystallization_ui_shows_graphiti_projection_and_sync() -> None:
+    ui = (HUB_ROOT / "static" / "js" / "memory-crystallization-ui.js").read_text(encoding="utf-8")
+    assert "graphiti_episode_ids" in ui
+    assert "/api/memory/graphiti/sync/" in ui

--- a/tests/test_memory_crystallization.py
+++ b/tests/test_memory_crystallization.py
@@ -229,3 +229,30 @@ class TestActivePacketFusion:
         )
         assert "card-1" in packet.card_refs
         assert packet.retrieval_trace.get("rails") == ["postgres_crystallizations", "postgres_memory_cards"]
+
+
+@pytest.mark.asyncio
+async def test_retriever_collects_linked_crystallization_from_graphiti_depth_two():
+    from unittest.mock import MagicMock
+    from orion.memory.crystallization.retriever import retrieve_active_packet
+
+    crys = _active_crystallization()
+    adapter = MagicMock()
+    adapter.enabled = True
+    adapter.neighborhood.return_value = {
+        "enabled": True,
+        "nodes": [
+            {"crystallization_id": crys.crystallization_id},
+            {"crystallization_id": "crys_linked"},
+        ],
+        "edges": [],
+    }
+
+    packet = await retrieve_active_packet(
+        query="test",
+        crystallizations=[crys],
+        graphiti_adapter=adapter,
+        seed_crystallization_id=crys.crystallization_id,
+    )
+    adapter.neighborhood.assert_called_once_with(crys.crystallization_id, depth=2)
+    assert "crys_linked" in packet.graphiti_refs


### PR DESCRIPTION
---
## PR 2 — Phase B: Link projection + depth-2 neighborhood
**Title:** `feat(graphiti): Phase B — link projection and depth-2 neighborhood`
**Base:** `feat/graphiti-rail-phase-a`
**Body:**
```markdown
## Summary
- Project `memory_crystallization_links` into `graphiti_edges` on adapter ingest (stub target entities)
- Depth-2 BFS neighborhood on adapter; retriever uses `depth=2`
- Hub sync payload includes crystallization links
- FalkorDB best-effort link MERGE; UI shows graphiti projection counts + Sync button
- New smoke: `scripts/smoke_graphiti_links_e2e.sh` (two-crystallization link scenario)
## Outcome moved
Linked crystallizations appear in Graphiti neighborhood at depth 2 and in active-packet `graphiti_refs`.
## Tests run
```text
cd services/orion-graphiti-adapter && pytest tests -q                      → 5 passed
cd services/orion-hub && pytest tests/test_graphiti_sync_payload.py \
  tests/test_memory_crystallization_ui.py -q                               → 3 passed
pytest tests/test_memory_crystallization.py::test_retriever_collects_linked_crystallization_from_graphiti_depth_two -q → 1 passed
bash -n scripts/smoke_graphiti_links_e2e.sh                                → OK
Restart required
Same as Phase A (Hub + adapter rebuild).

Test plan

 Merge after Phase A

 bash scripts/smoke_graphiti_links_e2e.sh with live Hub + adapter

 UI detail panel shows graphiti_eps / graphiti_edges counts