### PR TITLE
Feat/graphiti rail phase c

### DIFF
--- a/orion/memory/crystallization/projection_graphiti.py
+++ b/orion/memory/crystallization/projection_graphiti.py
@@ -80,7 +80,8 @@ class GraphitiAdapter:
         return GraphitiProjectionResult(
             episode_ids=[str(data.get("episode_id"))] if data.get("episode_id") else [],
             entity_ids=[str(data.get("entity_id"))] if data.get("entity_id") else [],
-            edge_ids=[str(data.get("edge_id"))] if data.get("edge_id") else [],
+            edge_ids=[str(e) for e in (data.get("edge_ids") or [])]
+            or ([str(data.get("edge_id"))] if data.get("edge_id") else []),
             synced_at=now,
             canonical_mutated=bool(data.get("canonical_mutated")),
             remote_response=data,
@@ -130,7 +131,8 @@ class GraphitiAdapter:
         return GraphitiProjectionResult(
             episode_ids=[str(data.get("episode_id"))] if data.get("episode_id") else [],
             entity_ids=[str(data.get("entity_id"))] if data.get("entity_id") else [],
-            edge_ids=[str(data.get("edge_id"))] if data.get("edge_id") else [],
+            edge_ids=[str(e) for e in (data.get("edge_ids") or [])]
+            or ([str(data.get("edge_id"))] if data.get("edge_id") else []),
             synced_at=now,
             canonical_mutated=bool(data.get("canonical_mutated")),
             remote_response=data,

--- a/orion/memory/crystallization/projection_graphiti.py
+++ b/orion/memory/crystallization/projection_graphiti.py
@@ -50,6 +50,7 @@ class GraphitiAdapter:
                 "scope": crystallization.scope,
                 "salience": crystallization.salience,
                 "confidence": crystallization.confidence,
+                "sensitivity": crystallization.governance.sensitivity,
             },
             "links": [
                 {
@@ -68,6 +69,12 @@ class GraphitiAdapter:
         except Exception as exc:
             logger.warning("graphiti_sync_failed id=%s error=%s", crystallization.crystallization_id, exc)
             return GraphitiProjectionResult()
+
+        if data.get("skipped"):
+            return GraphitiProjectionResult(
+                canonical_mutated=bool(data.get("canonical_mutated")),
+                remote_response=data,
+            )
 
         now = datetime.now(timezone.utc)
         return GraphitiProjectionResult(
@@ -89,7 +96,12 @@ class GraphitiAdapter:
             "subject": crystallization.subject,
             "summary": crystallization.summary,
             "status": crystallization.status,
-            "metadata": {"scope": crystallization.scope, "salience": crystallization.salience},
+            "metadata": {
+                "scope": crystallization.scope,
+                "salience": crystallization.salience,
+                "confidence": crystallization.confidence,
+                "sensitivity": crystallization.governance.sensitivity,
+            },
             "links": [
                 {
                     "target_crystallization_id": l.target_crystallization_id,
@@ -107,6 +119,13 @@ class GraphitiAdapter:
         except Exception as exc:
             logger.warning("graphiti_sync_failed id=%s error=%s", crystallization.crystallization_id, exc)
             return GraphitiProjectionResult()
+
+        if data.get("skipped"):
+            return GraphitiProjectionResult(
+                canonical_mutated=bool(data.get("canonical_mutated")),
+                remote_response=data,
+            )
+
         now = datetime.now(timezone.utc)
         return GraphitiProjectionResult(
             episode_ids=[str(data.get("episode_id"))] if data.get("episode_id") else [],
@@ -116,6 +135,43 @@ class GraphitiAdapter:
             canonical_mutated=bool(data.get("canonical_mutated")),
             remote_response=data,
         )
+
+    def health(self) -> dict[str, Any]:
+        if not self.enabled or not self.url:
+            return {"enabled": False, "backend": "unknown"}
+        try:
+            with httpx.Client(timeout=self.timeout_sec) as client:
+                resp = client.get(f"{self.url}/health")
+                resp.raise_for_status()
+                return resp.json()
+        except Exception as exc:
+            logger.warning("graphiti_health_failed error=%s", exc)
+            return {"enabled": True, "backend": "unknown", "error": str(exc)}
+
+    def search(
+        self,
+        query: str,
+        *,
+        seed_crystallization_id: str | None = None,
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        if not self.enabled or not self.url:
+            return {"crystallization_ids": [], "trace": {}}
+        try:
+            with httpx.Client(timeout=self.timeout_sec) as client:
+                resp = client.post(
+                    f"{self.url}/v1/search",
+                    json={
+                        "query": query,
+                        "seed_crystallization_id": seed_crystallization_id,
+                        "limit": limit,
+                    },
+                )
+                resp.raise_for_status()
+                return resp.json()
+        except Exception as exc:
+            logger.warning("graphiti_search_failed query=%s error=%s", query, exc)
+            return {"crystallization_ids": [], "trace": {"error": str(exc)}}
 
     def neighborhood(self, crystallization_id: str, *, depth: int = 1) -> dict[str, Any]:
         if not self.enabled or not self.url:

--- a/orion/memory/crystallization/projector.py
+++ b/orion/memory/crystallization/projector.py
@@ -95,7 +95,9 @@ async def project_crystallization(
             logger.warning("chroma_projection_failed id=%s error=%s", updated.crystallization_id, exc)
             result.errors.append(f"chroma_projection_failed:{exc}")
 
-    if project_graphiti and cfg.graphiti_enabled:
+    if updated.governance.sensitivity == "intimate":
+        result.errors.append("graphiti_projection_skipped:intimate_sensitivity")
+    elif project_graphiti and cfg.graphiti_enabled:
         try:
             adapter = GraphitiAdapter(enabled=True, url=cfg.graphiti_url, falkordb_uri=cfg.falkordb_uri)
             gresult = adapter.sync_crystallization(updated)

--- a/orion/memory/crystallization/retriever.py
+++ b/orion/memory/crystallization/retriever.py
@@ -74,12 +74,23 @@ async def retrieve_active_packet(
             extra_crystallization_ids.add(str(cid))
 
     if graphiti_adapter and graphiti_adapter.enabled and seed_crystallization_id:
-        nb = graphiti_adapter.neighborhood(seed_crystallization_id, depth=2)
-        for node in nb.get("nodes") or []:
-            nid = node.get("crystallization_id") or node.get("id")
-            if nid:
-                graphiti_refs.append(str(nid))
-                extra_crystallization_ids.add(str(nid))
+        health = graphiti_adapter.health()
+        graphiti_rail = "graphiti_neighborhood"
+        if health.get("backend") == "graphiti_core":
+            graphiti_rail = "graphiti_search"
+            sr = graphiti_adapter.search(query, seed_crystallization_id=seed_crystallization_id)
+            for cid in sr.get("crystallization_ids") or []:
+                graphiti_refs.append(str(cid))
+                extra_crystallization_ids.add(str(cid))
+        else:
+            nb = graphiti_adapter.neighborhood(seed_crystallization_id, depth=2)
+            for node in nb.get("nodes") or []:
+                nid = node.get("crystallization_id") or node.get("id")
+                if nid:
+                    graphiti_refs.append(str(nid))
+                    extra_crystallization_ids.add(str(nid))
+    else:
+        graphiti_rail = None
 
     merged = {c.crystallization_id: c for c in crystallizations}
     packet = build_active_packet(
@@ -95,7 +106,11 @@ async def retrieve_active_packet(
     packet.chroma_refs = chroma_refs
     packet.graphiti_refs = graphiti_refs
     trace = dict(packet.retrieval_trace)
-    trace["rails"] = list(trace.get("rails") or []) + ["chroma_semantic", "graphiti_neighborhood"]
+    rails = list(trace.get("rails") or [])
+    rails.extend(["chroma_semantic"])
+    if graphiti_rail:
+        rails.append(graphiti_rail)
+    trace["rails"] = rails
     trace["chroma_hits"] = len(chroma_hits)
     trace["graphiti_refs"] = len(graphiti_refs)
     trace["extra_crystallization_ids_from_chroma"] = sorted(extra_crystallization_ids)

--- a/orion/memory/crystallization/retriever.py
+++ b/orion/memory/crystallization/retriever.py
@@ -73,24 +73,34 @@ async def retrieve_active_packet(
         if cid:
             extra_crystallization_ids.add(str(cid))
 
+    graphiti_rails: list[str] = []
     if graphiti_adapter and graphiti_adapter.enabled and seed_crystallization_id:
         health = graphiti_adapter.health()
-        graphiti_rail = "graphiti_neighborhood"
         if health.get("backend") == "graphiti_core":
-            graphiti_rail = "graphiti_search"
+            graphiti_rails.append("graphiti_search")
             sr = graphiti_adapter.search(query, seed_crystallization_id=seed_crystallization_id)
             for cid in sr.get("crystallization_ids") or []:
-                graphiti_refs.append(str(cid))
-                extra_crystallization_ids.add(str(cid))
+                cid_str = str(cid)
+                if cid_str not in graphiti_refs:
+                    graphiti_refs.append(cid_str)
+                extra_crystallization_ids.add(cid_str)
+            graphiti_rails.append("graphiti_neighborhood")
+            nb = graphiti_adapter.neighborhood(seed_crystallization_id, depth=2)
+            for node in nb.get("nodes") or []:
+                nid = node.get("crystallization_id") or node.get("id")
+                if nid:
+                    nid_str = str(nid)
+                    if nid_str not in graphiti_refs:
+                        graphiti_refs.append(nid_str)
+                    extra_crystallization_ids.add(nid_str)
         else:
+            graphiti_rails.append("graphiti_neighborhood")
             nb = graphiti_adapter.neighborhood(seed_crystallization_id, depth=2)
             for node in nb.get("nodes") or []:
                 nid = node.get("crystallization_id") or node.get("id")
                 if nid:
                     graphiti_refs.append(str(nid))
                     extra_crystallization_ids.add(str(nid))
-    else:
-        graphiti_rail = None
 
     merged = {c.crystallization_id: c for c in crystallizations}
     packet = build_active_packet(
@@ -108,8 +118,7 @@ async def retrieve_active_packet(
     trace = dict(packet.retrieval_trace)
     rails = list(trace.get("rails") or [])
     rails.extend(["chroma_semantic"])
-    if graphiti_rail:
-        rails.append(graphiti_rail)
+    rails.extend(graphiti_rails)
     trace["rails"] = rails
     trace["chroma_hits"] = len(chroma_hits)
     trace["graphiti_refs"] = len(graphiti_refs)

--- a/services/orion-graphiti-adapter/.env_example
+++ b/services/orion-graphiti-adapter/.env_example
@@ -14,4 +14,8 @@ FALKORDB_URI=redis://orion-athena-falkordb:6379
 FALKORDB_GRAPH=graphiti_temporal
 FALKORDB_ENABLED=false
 
+GRAPHITI_BACKEND=orion_postgres
+# Required when GRAPHITI_BACKEND=graphiti_core
+CRYSTALLIZER_EMBED_HOST_URL=
+
 LOG_LEVEL=INFO

--- a/services/orion-graphiti-adapter/README.md
+++ b/services/orion-graphiti-adapter/README.md
@@ -9,10 +9,22 @@ Additive temporal graph projection service for `MemoryCrystallizationV1`.
 ## API
 
 - `POST /v1/episodes` — ingest crystallization as temporal episode
+- `POST /v1/rebuild` — batch ingest crystallizations (same path as episodes)
 - `GET /v1/neighborhood/{crystallization_id}` — graph neighborhood
+- `POST /v1/search` — hybrid search (requires `GRAPHITI_BACKEND=graphiti_core`)
 - `GET /health`
 
 Hub `GraphitiAdapter` calls this service when `GRAPHITI_URL` is set.
+
+## graphiti_core backend smoke
+
+```bash
+GRAPHITI_BACKEND=graphiti_core FALKORDB_ENABLED=true \
+docker compose --profile falkordb --env-file services/orion-graphiti-adapter/.env \
+  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
+```
+
+Rollback: `GRAPHITI_BACKEND=orion_postgres` and restart adapter.
 
 ## FalkorDB profile (optional)
 

--- a/services/orion-graphiti-adapter/app/backends/__init__.py
+++ b/services/orion-graphiti-adapter/app/backends/__init__.py
@@ -1,0 +1,3 @@
+from app.backends import graphiti_core, orion_postgres
+
+__all__ = ["graphiti_core", "orion_postgres"]

--- a/services/orion-graphiti-adapter/app/backends/graphiti_core.py
+++ b/services/orion-graphiti-adapter/app/backends/graphiti_core.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+import asyncpg
+
+from app.store import neighborhood as pg_neighborhood
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_falkordb_uri(uri: str) -> tuple[str, int]:
+    parsed = urlparse(uri or "redis://localhost:6379")
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6379
+    return host, port
+
+
+def _falkor_driver(falkordb_uri: str, graph_name: str):
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+
+    host, port = _parse_falkordb_uri(falkordb_uri)
+    return FalkorDriver(host=host, port=port, database=graph_name)
+
+
+def _extract_crystallization_ids(results: Any) -> list[str]:
+    ids: list[str] = []
+    seen: set[str] = set()
+
+    def _maybe_add(value: Any) -> None:
+        if not value:
+            return
+        cid = str(value).strip()
+        if cid and cid not in seen:
+            seen.add(cid)
+            ids.append(cid)
+
+    items = results if isinstance(results, list) else getattr(results, "edges", None) or []
+    for item in items:
+        if isinstance(item, dict):
+            _maybe_add(item.get("crystallization_id"))
+            node = item.get("node") or item.get("entity") or {}
+            if isinstance(node, dict):
+                _maybe_add(node.get("crystallization_id"))
+                node_id = node.get("id") or node.get("uuid") or ""
+                if isinstance(node_id, str):
+                    if node_id.startswith("gent_"):
+                        _maybe_add(node_id.removeprefix("gent_"))
+                    elif node_id.startswith("gep_"):
+                        _maybe_add(node_id.removeprefix("gep_"))
+            continue
+        node = getattr(item, "source_node", None) or getattr(item, "target_node", None)
+        if node is not None:
+            _maybe_add(getattr(node, "crystallization_id", None))
+            node_id = getattr(node, "uuid", None) or getattr(node, "id", None)
+            if isinstance(node_id, str):
+                if node_id.startswith("gent_"):
+                    _maybe_add(node_id.removeprefix("gent_"))
+                elif node_id.startswith("gep_"):
+                    _maybe_add(node_id.removeprefix("gep_"))
+    return ids
+
+
+async def ingest_episode(
+    pool: asyncpg.Pool | None,
+    *,
+    crystallization_id: str,
+    kind: str,
+    subject: str,
+    summary: str,
+    status: str,
+    metadata: dict[str, Any],
+    links: list[dict[str, Any]] | None,
+    falkordb_uri: str,
+    graph_name: str,
+) -> dict[str, list[str]]:
+    del pool, summary, status, metadata  # prescribed MERGE only; no add_episode / LLM extraction
+    driver = _falkor_driver(falkordb_uri, graph_name)
+    entity_id = f"gent_{crystallization_id}"
+    episode_id = f"gep_{crystallization_id}"
+    edge_ids: list[str] = []
+
+    await driver.execute_query(
+        (
+            f"MERGE (e:Entity {{id: '{entity_id}', crystallization_id: '{crystallization_id}'}}) "
+            "SET e.name = $name "
+            f"MERGE (ep:Episode {{id: '{episode_id}', crystallization_id: '{crystallization_id}'}}) "
+            "SET ep.kind = $kind "
+            "MERGE (e)-[:HAS_EPISODE]->(ep)"
+        ),
+        {"name": subject, "kind": kind},
+    )
+    edge_ids.append(f"ged_{crystallization_id}")
+
+    for link in links or []:
+        target_id = str(link["target_crystallization_id"])
+        relation = str(link["relation"])
+        confidence = float(link.get("confidence", 0.5))
+        target_entity_id = f"gent_{target_id}"
+        await driver.execute_query(
+            (
+                f"MERGE (t:Entity {{id: '{target_entity_id}', crystallization_id: '{target_id}'}}) "
+                f"MERGE (e:Entity {{id: '{entity_id}'}}) "
+                "MERGE (e)-[r:RELATED]->(t) "
+                "SET r.relation = $relation, r.confidence = $confidence"
+            ),
+            {"relation": relation, "confidence": confidence},
+        )
+        edge_ids.append(f"ged_{crystallization_id}_{target_id}_{relation}")
+
+    return {"edge_ids": edge_ids}
+
+
+async def get_neighborhood(
+    pool: asyncpg.Pool | None, crystallization_id: str, *, depth: int = 1
+) -> dict[str, Any]:
+    if pool is None:
+        raise RuntimeError("store_unavailable")
+    return await pg_neighborhood(pool, crystallization_id, depth=depth)
+
+
+async def search(
+    query: str,
+    *,
+    seed_crystallization_id: str,
+    limit: int,
+    embed_url: str,
+    falkordb_uri: str,
+    graph_name: str,
+) -> dict[str, Any]:
+    del embed_url  # reserved for embed host wiring; search uses graphiti hybrid retrieval only
+    from graphiti_core import Graphiti
+
+    driver = _falkor_driver(falkordb_uri, graph_name)
+    graphiti = Graphiti(graph_driver=driver)
+    results = await graphiti.search(query=query, num_results=limit)
+    crystallization_ids = _extract_crystallization_ids(results)
+    if seed_crystallization_id and seed_crystallization_id not in crystallization_ids:
+        crystallization_ids.insert(0, seed_crystallization_id)
+    return {
+        "crystallization_ids": crystallization_ids[:limit],
+        "trace": {
+            "backend": "graphiti_core",
+            "rails": ["vector", "graph"],
+            "query": query,
+            "result_count": len(crystallization_ids),
+            "raw_type": type(results).__name__,
+        },
+    }

--- a/services/orion-graphiti-adapter/app/backends/graphiti_core.py
+++ b/services/orion-graphiti-adapter/app/backends/graphiti_core.py
@@ -76,7 +76,9 @@ async def ingest_episode(
     falkordb_uri: str,
     graph_name: str,
 ) -> dict[str, list[str]]:
-    del pool, summary, status, metadata  # prescribed MERGE only; no add_episode / LLM extraction
+    if metadata.get("sensitivity") == "intimate":
+        return {"edge_ids": [], "skipped": True, "reason": "intimate_sensitivity"}
+    del pool, summary, status  # prescribed MERGE only; no add_episode / LLM extraction
     driver = _falkor_driver(falkordb_uri, graph_name)
     entity_id = f"gent_{crystallization_id}"
     episode_id = f"gep_{crystallization_id}"

--- a/services/orion-graphiti-adapter/app/backends/graphiti_core.py
+++ b/services/orion-graphiti-adapter/app/backends/graphiti_core.py
@@ -6,7 +6,9 @@ from urllib.parse import urlparse
 
 import asyncpg
 
+from app.crystallization_ids import validate_crystallization_id
 from app.store import neighborhood as pg_neighborhood
+from app.store import upsert_episode as pg_upsert_episode
 
 logger = logging.getLogger(__name__)
 
@@ -63,9 +65,56 @@ def _extract_crystallization_ids(results: Any) -> list[str]:
     return ids
 
 
+async def _embed_query(query: str, embed_url: str) -> list[float] | None:
+    if not embed_url.strip():
+        return None
+    try:
+        import httpx
+        from orion.schemas.vector.schemas import EmbeddingGenerateV1, EmbeddingResultV1
+
+        req = EmbeddingGenerateV1(
+            doc_id="graphiti_search_query",
+            text=query,
+            embedding_profile="default",
+        )
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(embed_url.rstrip("/"), json=req.model_dump(mode="json"))
+            resp.raise_for_status()
+            data = resp.json()
+            if isinstance(data, dict):
+                return EmbeddingResultV1.model_validate(data).embedding
+    except Exception as exc:
+        logger.warning("graphiti_search_embed_failed error=%s", exc)
+    return None
+
+
+async def _filter_intimate_crystallization_ids(
+    driver: Any,
+    crystallization_ids: list[str],
+) -> list[str]:
+    if not crystallization_ids:
+        return crystallization_ids
+    try:
+        rows, _ = await driver.execute_query(
+            """
+            UNWIND $ids AS cid
+            MATCH (n)
+            WHERE n.crystallization_id = cid AND n.sensitivity = 'intimate'
+            RETURN DISTINCT n.crystallization_id AS cid
+            """,
+            {"ids": crystallization_ids},
+        )
+        intimate = {str(row.get("cid") if isinstance(row, dict) else row[0]) for row in (rows or [])}
+        return [cid for cid in crystallization_ids if cid not in intimate]
+    except Exception as exc:
+        logger.warning("graphiti_search_intimate_filter_failed error=%s", exc)
+        return crystallization_ids
+
+
 async def ingest_episode(
     pool: asyncpg.Pool | None,
     *,
+    episode_id: str,
     crystallization_id: str,
     kind: str,
     subject: str,
@@ -78,39 +127,70 @@ async def ingest_episode(
 ) -> dict[str, list[str]]:
     if metadata.get("sensitivity") == "intimate":
         return {"edge_ids": [], "skipped": True, "reason": "intimate_sensitivity"}
-    del pool, summary, status  # prescribed MERGE only; no add_episode / LLM extraction
+
+    crystallization_id = validate_crystallization_id(crystallization_id)
+    sensitivity = str(metadata.get("sensitivity") or "public")
     driver = _falkor_driver(falkordb_uri, graph_name)
     entity_id = f"gent_{crystallization_id}"
-    episode_id = f"gep_{crystallization_id}"
     edge_ids: list[str] = []
 
     await driver.execute_query(
-        (
-            f"MERGE (e:Entity {{id: '{entity_id}', crystallization_id: '{crystallization_id}'}}) "
-            "SET e.name = $name "
-            f"MERGE (ep:Episode {{id: '{episode_id}', crystallization_id: '{crystallization_id}'}}) "
-            "SET ep.kind = $kind "
-            "MERGE (e)-[:HAS_EPISODE]->(ep)"
-        ),
-        {"name": subject, "kind": kind},
+        """
+        MERGE (e:Entity {id: $entity_id, crystallization_id: $crystallization_id})
+        SET e.name = $name, e.sensitivity = $sensitivity
+        MERGE (ep:Episode {id: $episode_id, crystallization_id: $crystallization_id})
+        SET ep.kind = $kind, ep.sensitivity = $sensitivity
+        MERGE (e)-[:HAS_EPISODE]->(ep)
+        """,
+        {
+            "entity_id": entity_id,
+            "crystallization_id": crystallization_id,
+            "episode_id": episode_id,
+            "name": subject,
+            "kind": kind,
+            "sensitivity": sensitivity,
+        },
     )
     edge_ids.append(f"ged_{crystallization_id}")
 
     for link in links or []:
-        target_id = str(link["target_crystallization_id"])
+        target_id = validate_crystallization_id(str(link["target_crystallization_id"]))
         relation = str(link["relation"])
         confidence = float(link.get("confidence", 0.5))
         target_entity_id = f"gent_{target_id}"
         await driver.execute_query(
-            (
-                f"MERGE (t:Entity {{id: '{target_entity_id}', crystallization_id: '{target_id}'}}) "
-                f"MERGE (e:Entity {{id: '{entity_id}'}}) "
-                "MERGE (e)-[r:RELATED]->(t) "
-                "SET r.relation = $relation, r.confidence = $confidence"
-            ),
-            {"relation": relation, "confidence": confidence},
+            """
+            MERGE (t:Entity {id: $target_entity_id, crystallization_id: $target_id})
+            SET t.sensitivity = $target_sensitivity
+            MERGE (e:Entity {id: $entity_id})
+            MERGE (e)-[r:RELATED]->(t)
+            SET r.relation = $relation, r.confidence = $confidence
+            """,
+            {
+                "target_entity_id": target_entity_id,
+                "target_id": target_id,
+                "target_sensitivity": str(link.get("sensitivity") or "public"),
+                "entity_id": entity_id,
+                "relation": relation,
+                "confidence": confidence,
+            },
         )
         edge_ids.append(f"ged_{crystallization_id}_{target_id}_{relation}")
+
+    # Dual-write Postgres so neighborhood/search callers stay consistent with Phase B.
+    if pool is not None:
+        pg_edge_ids = await pg_upsert_episode(
+            pool,
+            episode_id=episode_id,
+            crystallization_id=crystallization_id,
+            kind=kind,
+            subject=subject,
+            summary=summary,
+            status=status,
+            metadata=metadata,
+            links=links,
+        )
+        return {"edge_ids": pg_edge_ids or edge_ids}
 
     return {"edge_ids": edge_ids}
 
@@ -132,13 +212,24 @@ async def search(
     falkordb_uri: str,
     graph_name: str,
 ) -> dict[str, Any]:
-    del embed_url  # reserved for embed host wiring; search uses graphiti hybrid retrieval only
     from graphiti_core import Graphiti
 
     driver = _falkor_driver(falkordb_uri, graph_name)
     graphiti = Graphiti(graph_driver=driver)
-    results = await graphiti.search(query=query, num_results=limit)
+    embedding = await _embed_query(query, embed_url)
+
+    search_kwargs: dict[str, Any] = {"query": query, "num_results": limit}
+    if embedding is not None:
+        search_kwargs["query_vector"] = embedding
+
+    try:
+        results = await graphiti.search(**search_kwargs)
+    except TypeError:
+        # Older graphiti-core builds may not accept query_vector.
+        results = await graphiti.search(query=query, num_results=limit)
+
     crystallization_ids = _extract_crystallization_ids(results)
+    crystallization_ids = await _filter_intimate_crystallization_ids(driver, crystallization_ids)
     if seed_crystallization_id and seed_crystallization_id not in crystallization_ids:
         crystallization_ids.insert(0, seed_crystallization_id)
     return {
@@ -147,6 +238,7 @@ async def search(
             "backend": "graphiti_core",
             "rails": ["vector", "graph"],
             "query": query,
+            "embed_used": embedding is not None,
             "result_count": len(crystallization_ids),
             "raw_type": type(results).__name__,
         },

--- a/services/orion-graphiti-adapter/app/backends/orion_postgres.py
+++ b/services/orion-graphiti-adapter/app/backends/orion_postgres.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from app.store import neighborhood as pg_neighborhood
+from app.store import upsert_episode as pg_upsert_episode
+
+
+async def ingest_episode(pool: asyncpg.Pool, **kwargs: Any) -> dict[str, list[str]]:
+    edge_ids = await pg_upsert_episode(pool, **kwargs)
+    return {"edge_ids": edge_ids}
+
+
+async def get_neighborhood(
+    pool: asyncpg.Pool, crystallization_id: str, *, depth: int = 1
+) -> dict[str, Any]:
+    return await pg_neighborhood(pool, crystallization_id, depth=depth)

--- a/services/orion-graphiti-adapter/app/crystallization_ids.py
+++ b/services/orion-graphiti-adapter/app/crystallization_ids.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import re
+
+_CRYSTALLIZATION_ID = re.compile(r"^crys_[a-zA-Z0-9_-]+$")
+
+
+def validate_crystallization_id(crystallization_id: str) -> str:
+    """Reject IDs that would break parameterized or legacy Cypher construction."""
+    cid = str(crystallization_id).strip()
+    if not _CRYSTALLIZATION_ID.match(cid):
+        raise ValueError(f"invalid_crystallization_id:{cid}")
+    return cid

--- a/services/orion-graphiti-adapter/app/falkordb.py
+++ b/services/orion-graphiti-adapter/app/falkordb.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from app.crystallization_ids import validate_crystallization_id
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,17 +25,22 @@ def sync_to_falkordb(
     try:
         import redis
 
+        crystallization_id = validate_crystallization_id(crystallization_id)
         client = redis.from_url(uri)
         entity_id = f"gent_{crystallization_id}"
         episode_id = f"gep_{crystallization_id}"
+        safe_subject = subject.replace("'", "")
+        safe_summary = summary[:200].replace("'", "")
         cypher = (
-            f"MERGE (e:Entity {{id: '{entity_id}', crystallization_id: '{crystallization_id}', name: '{subject.replace(chr(39), '')}'}}) "
-            f"MERGE (ep:Episode {{id: '{episode_id}', kind: '{kind}', summary: '{summary[:200].replace(chr(39), '')}'}}) "
+            f"MERGE (e:Entity {{id: '{entity_id}', crystallization_id: '{crystallization_id}', name: '{safe_subject}'}}) "
+            f"MERGE (ep:Episode {{id: '{episode_id}', kind: '{kind}', summary: '{safe_summary}'}}) "
             f"MERGE (e)-[:HAS_EPISODE]->(ep)"
         )
         for link in links or []:
-            target = link["target_crystallization_id"]
+            target = validate_crystallization_id(str(link["target_crystallization_id"]))
             relation = str(link["relation"]).upper().replace("-", "_")
+            if not relation.replace("_", "").isalnum():
+                continue
             target_entity = f"gent_{target}"
             cypher += (
                 f" MERGE (t:Entity {{id: '{target_entity}', crystallization_id: '{target}'}}) "
@@ -41,6 +48,9 @@ def sync_to_falkordb(
             )
         result = client.execute_command("GRAPH.QUERY", graph_name, cypher)
         return {"synced": True, "graph": graph_name, "result_type": type(result).__name__}
+    except ValueError as exc:
+        logger.warning("falkordb_sync_invalid_id id=%s error=%s", crystallization_id, exc)
+        return {"synced": False, "reason": str(exc)}
     except Exception as exc:
         logger.warning("falkordb_sync_failed id=%s error=%s", crystallization_id, exc)
         return {"synced": False, "reason": str(exc)}

--- a/services/orion-graphiti-adapter/app/main.py
+++ b/services/orion-graphiti-adapter/app/main.py
@@ -88,8 +88,11 @@ async def ingest_episode(body: EpisodeIngestV1) -> dict:
     falkor_result = None
 
     if settings.GRAPHITI_BACKEND == "graphiti_core":
+        if pg_pool is None:
+            raise HTTPException(status_code=503, detail="store_unavailable")
         result = await backend.ingest_episode(
             pg_pool,
+            episode_id=episode_id,
             crystallization_id=body.crystallization_id,
             kind=body.kind,
             subject=body.subject,

--- a/services/orion-graphiti-adapter/app/main.py
+++ b/services/orion-graphiti-adapter/app/main.py
@@ -6,9 +6,11 @@ import asyncpg
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from app.backends import graphiti_core as core_backend
+from app.backends import orion_postgres as pg_backend
 from app.falkordb import sync_to_falkordb
 from app.settings import settings
-from app.store import apply_graphiti_schema, neighborhood, upsert_episode
+from app.store import apply_graphiti_schema
 
 logger = logging.getLogger(settings.SERVICE_NAME)
 pg_pool: Optional[asyncpg.Pool] = None
@@ -28,6 +30,16 @@ class EpisodeIngestV1(BaseModel):
     status: str = "active"
     metadata: Dict[str, Any] = Field(default_factory=dict)
     links: list[CrystallizationLinkIngestV1] = Field(default_factory=list)
+
+
+class SearchRequestV1(BaseModel):
+    query: str
+    seed_crystallization_id: str | None = None
+    limit: int = 10
+
+
+def _backend():
+    return core_backend if settings.GRAPHITI_BACKEND == "graphiti_core" else pg_backend
 
 
 @asynccontextmanager
@@ -53,36 +65,56 @@ async def health() -> dict:
         "service": settings.SERVICE_NAME,
         "postgres": pg_pool is not None,
         "falkordb_enabled": settings.FALKORDB_ENABLED,
+        "backend": settings.GRAPHITI_BACKEND,
     }
 
 
 @app.post("/v1/episodes")
 async def ingest_episode(body: EpisodeIngestV1) -> dict:
-    if pg_pool is None:
-        raise HTTPException(status_code=503, detail="store_unavailable")
+    backend = _backend()
     episode_id = f"gep_{body.crystallization_id}"
-    edge_ids = await upsert_episode(
-        pg_pool,
-        episode_id=episode_id,
-        crystallization_id=body.crystallization_id,
-        kind=body.kind,
-        subject=body.subject,
-        summary=body.summary,
-        status=body.status,
-        metadata=body.metadata,
-        links=[l.model_dump() for l in body.links],
-    )
+    link_payload = [l.model_dump() for l in body.links]
     falkor_result = None
-    if settings.FALKORDB_ENABLED:
-        falkor_result = sync_to_falkordb(
-            uri=settings.FALKORDB_URI,
-            graph_name=settings.FALKORDB_GRAPH,
+
+    if settings.GRAPHITI_BACKEND == "graphiti_core":
+        result = await backend.ingest_episode(
+            pg_pool,
             crystallization_id=body.crystallization_id,
             kind=body.kind,
             subject=body.subject,
             summary=body.summary,
-            links=[l.model_dump() for l in body.links],
+            status=body.status,
+            metadata=body.metadata,
+            links=link_payload,
+            falkordb_uri=settings.FALKORDB_URI,
+            graph_name=settings.FALKORDB_GRAPH,
         )
+    else:
+        if pg_pool is None:
+            raise HTTPException(status_code=503, detail="store_unavailable")
+        result = await backend.ingest_episode(
+            pg_pool,
+            episode_id=episode_id,
+            crystallization_id=body.crystallization_id,
+            kind=body.kind,
+            subject=body.subject,
+            summary=body.summary,
+            status=body.status,
+            metadata=body.metadata,
+            links=link_payload,
+        )
+        if settings.FALKORDB_ENABLED:
+            falkor_result = sync_to_falkordb(
+                uri=settings.FALKORDB_URI,
+                graph_name=settings.FALKORDB_GRAPH,
+                crystallization_id=body.crystallization_id,
+                kind=body.kind,
+                subject=body.subject,
+                summary=body.summary,
+                links=link_payload,
+            )
+
+    edge_ids = result["edge_ids"]
     return {
         "episode_id": episode_id,
         "entity_id": f"gent_{body.crystallization_id}",
@@ -97,4 +129,18 @@ async def ingest_episode(body: EpisodeIngestV1) -> dict:
 async def get_neighborhood(crystallization_id: str, depth: int = 1) -> dict:
     if pg_pool is None:
         raise HTTPException(status_code=503, detail="store_unavailable")
-    return await neighborhood(pg_pool, crystallization_id, depth=depth)
+    return await _backend().get_neighborhood(pg_pool, crystallization_id, depth=depth)
+
+
+@app.post("/v1/search")
+async def search_episodes(body: SearchRequestV1) -> dict:
+    if settings.GRAPHITI_BACKEND != "graphiti_core":
+        raise HTTPException(status_code=501, detail="search_requires_graphiti_core_backend")
+    return await core_backend.search(
+        body.query,
+        seed_crystallization_id=body.seed_crystallization_id or "",
+        limit=body.limit,
+        embed_url=settings.CRYSTALLIZER_EMBED_HOST_URL,
+        falkordb_uri=settings.FALKORDB_URI,
+        graph_name=settings.FALKORDB_GRAPH,
+    )

--- a/services/orion-graphiti-adapter/app/main.py
+++ b/services/orion-graphiti-adapter/app/main.py
@@ -38,6 +38,14 @@ class SearchRequestV1(BaseModel):
     limit: int = 10
 
 
+class RebuildItemV1(EpisodeIngestV1):
+    pass
+
+
+class RebuildRequestV1(BaseModel):
+    items: list[RebuildItemV1]
+
+
 def _backend():
     return core_backend if settings.GRAPHITI_BACKEND == "graphiti_core" else pg_backend
 
@@ -71,6 +79,9 @@ async def health() -> dict:
 
 @app.post("/v1/episodes")
 async def ingest_episode(body: EpisodeIngestV1) -> dict:
+    if body.metadata.get("sensitivity") == "intimate":
+        return {"skipped": True, "reason": "intimate_sensitivity", "canonical_mutated": False}
+
     backend = _backend()
     episode_id = f"gep_{body.crystallization_id}"
     link_payload = [l.model_dump() for l in body.links]
@@ -89,6 +100,8 @@ async def ingest_episode(body: EpisodeIngestV1) -> dict:
             falkordb_uri=settings.FALKORDB_URI,
             graph_name=settings.FALKORDB_GRAPH,
         )
+        if result.get("skipped"):
+            return {"skipped": True, "reason": result.get("reason", "intimate_sensitivity"), "canonical_mutated": False}
     else:
         if pg_pool is None:
             raise HTTPException(status_code=503, detail="store_unavailable")
@@ -121,6 +134,23 @@ async def ingest_episode(body: EpisodeIngestV1) -> dict:
         "edge_id": edge_ids[0] if edge_ids else f"ged_{body.crystallization_id}",
         "edge_ids": edge_ids,
         "falkordb": falkor_result,
+        "canonical_mutated": False,
+    }
+
+
+@app.post("/v1/rebuild")
+async def rebuild(body: RebuildRequestV1) -> dict:
+    results: list[dict] = []
+    skip_count = 0
+    for item in body.items:
+        result = await ingest_episode(item)
+        if result.get("skipped"):
+            skip_count += 1
+        else:
+            results.append(result)
+    return {
+        "ingested": len(results),
+        "skipped_intimate": skip_count,
         "canonical_mutated": False,
     }
 

--- a/services/orion-graphiti-adapter/app/settings.py
+++ b/services/orion-graphiti-adapter/app/settings.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
@@ -14,6 +16,11 @@ class Settings(BaseSettings):
     FALKORDB_URI: str = Field(default="", alias="FALKORDB_URI")
     FALKORDB_GRAPH: str = Field(default="graphiti_temporal", alias="FALKORDB_GRAPH")
     FALKORDB_ENABLED: bool = Field(default=False, alias="FALKORDB_ENABLED")
+
+    GRAPHITI_BACKEND: Literal["orion_postgres", "graphiti_core"] = Field(
+        default="orion_postgres", alias="GRAPHITI_BACKEND"
+    )
+    CRYSTALLIZER_EMBED_HOST_URL: str = Field(default="", alias="CRYSTALLIZER_EMBED_HOST_URL")
 
     class Config:
         env_file = ".env"

--- a/services/orion-graphiti-adapter/requirements.txt
+++ b/services/orion-graphiti-adapter/requirements.txt
@@ -5,3 +5,4 @@ asyncpg==0.29.0
 psycopg2-binary==2.9.9
 httpx==0.27.0
 redis==5.0.7
+graphiti-core[falkordb]==0.19.10

--- a/services/orion-graphiti-adapter/tests/test_crystallization_ids.py
+++ b/services/orion-graphiti-adapter/tests/test_crystallization_ids.py
@@ -1,0 +1,12 @@
+import pytest
+
+from app.crystallization_ids import validate_crystallization_id
+
+
+def test_validate_accepts_crys_prefix():
+    assert validate_crystallization_id("crys_test001") == "crys_test001"
+
+
+def test_validate_rejects_injection():
+    with pytest.raises(ValueError, match="invalid_crystallization_id"):
+        validate_crystallization_id("crys_x'} ) DELETE n //")

--- a/services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py
+++ b/services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py
@@ -1,0 +1,74 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.backends import graphiti_core as core_backend
+
+
+@pytest.mark.asyncio
+async def test_graphiti_core_ingest_dual_writes_postgres():
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="OK")
+
+    @asynccontextmanager
+    async def acquire():
+        yield conn
+
+    pool = MagicMock()
+    pool.acquire = acquire
+    mock_driver = AsyncMock()
+    mock_driver.execute_query = AsyncMock(return_value=([], None))
+
+    with patch.object(core_backend, "_falkor_driver", return_value=mock_driver):
+        result = await core_backend.ingest_episode(
+            pool,
+            episode_id="gep_crys_a",
+            crystallization_id="crys_a",
+            kind="stance",
+            subject="A",
+            summary="summary",
+            status="active",
+            metadata={"sensitivity": "public"},
+            links=[],
+            falkordb_uri="redis://localhost:6379/0",
+            graph_name="orion_graphiti",
+        )
+
+    assert result["edge_ids"]
+    assert mock_driver.execute_query.await_count >= 1
+    assert conn.execute.await_count >= 3
+
+
+@pytest.mark.asyncio
+async def test_search_filters_intimate_crystallization_ids(monkeypatch):
+    async def fake_filter(driver, ids):
+        return [cid for cid in ids if cid != "crys_intimate"]
+
+    monkeypatch.setattr(core_backend, "_embed_query", AsyncMock(return_value=None))
+    monkeypatch.setattr(core_backend, "_filter_intimate_crystallization_ids", fake_filter)
+
+    class FakeGraphiti:
+        def __init__(self, graph_driver):
+            pass
+
+        async def search(self, **kwargs):
+            return [{"crystallization_id": "crys_a"}, {"crystallization_id": "crys_intimate"}]
+
+    fake_graphiti_mod = MagicMock()
+    fake_graphiti_mod.Graphiti = FakeGraphiti
+
+    with patch.object(core_backend, "_falkor_driver", return_value=MagicMock()), patch.dict(
+        "sys.modules", {"graphiti_core": fake_graphiti_mod}
+    ):
+        out = await core_backend.search(
+            "memory",
+            seed_crystallization_id="crys_seed",
+            limit=10,
+            embed_url="",
+            falkordb_uri="redis://localhost:6379/0",
+            graph_name="orion_graphiti",
+        )
+
+    assert "crys_a" in out["crystallization_ids"]
+    assert "crys_intimate" not in out["crystallization_ids"]

--- a/services/orion-graphiti-adapter/tests/test_health.py
+++ b/services/orion-graphiti-adapter/tests/test_health.py
@@ -13,3 +13,4 @@ def test_health_without_postgres():
         data = resp.json()
         assert data["postgres"] is False
         assert data["service"] == "orion-graphiti-adapter"
+        assert data["backend"] == "orion_postgres"

--- a/services/orion-graphiti-adapter/tests/test_rebuild.py
+++ b/services/orion-graphiti-adapter/tests/test_rebuild.py
@@ -1,0 +1,111 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+import app.main as main_mod
+
+
+def _mock_pool():
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="OK")
+
+    @asynccontextmanager
+    async def acquire():
+        yield conn
+
+    pool = MagicMock()
+    pool.acquire = acquire
+    return pool, conn
+
+
+def test_rebuild_batch_ingests_items():
+    pool, conn = _mock_pool()
+    with patch.object(main_mod, "pg_pool", pool), patch(
+        "app.main.sync_to_falkordb", return_value=None
+    ):
+        client = TestClient(main_mod.app)
+        resp = client.post(
+            "/v1/rebuild",
+            json={
+                "items": [
+                    {
+                        "crystallization_id": "crys_rebuild_a",
+                        "kind": "stance",
+                        "subject": "A",
+                        "summary": "Summary A",
+                        "status": "active",
+                        "metadata": {"scope": ["project:orion"]},
+                    },
+                    {
+                        "crystallization_id": "crys_rebuild_b",
+                        "kind": "stance",
+                        "subject": "B",
+                        "summary": "Summary B",
+                        "status": "active",
+                        "metadata": {"scope": ["project:orion"]},
+                    },
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ingested"] == 2
+        assert data["skipped_intimate"] == 0
+        assert data["canonical_mutated"] is False
+        assert conn.execute.await_count >= 6
+
+
+def test_rebuild_skips_intimate_items():
+    pool, _conn = _mock_pool()
+    with patch.object(main_mod, "pg_pool", pool):
+        client = TestClient(main_mod.app)
+        resp = client.post(
+            "/v1/rebuild",
+            json={
+                "items": [
+                    {
+                        "crystallization_id": "crys_intimate",
+                        "kind": "stance",
+                        "subject": "Private",
+                        "summary": "Private summary",
+                        "status": "active",
+                        "metadata": {"sensitivity": "intimate"},
+                    },
+                    {
+                        "crystallization_id": "crys_public",
+                        "kind": "stance",
+                        "subject": "Public",
+                        "summary": "Public summary",
+                        "status": "active",
+                        "metadata": {"sensitivity": "public"},
+                    },
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ingested"] == 1
+        assert data["skipped_intimate"] == 1
+        assert data["canonical_mutated"] is False
+
+
+def test_ingest_skips_intimate_sensitivity():
+    with patch.object(main_mod, "pg_pool", None):
+        client = TestClient(main_mod.app)
+        resp = client.post(
+            "/v1/episodes",
+            json={
+                "crystallization_id": "crys_intimate_only",
+                "kind": "stance",
+                "subject": "Private",
+                "summary": "Private summary",
+                "status": "active",
+                "metadata": {"sensitivity": "intimate"},
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["skipped"] is True
+        assert data["reason"] == "intimate_sensitivity"
+        assert data["canonical_mutated"] is False

--- a/services/orion-graphiti-adapter/tests/test_search.py
+++ b/services/orion-graphiti-adapter/tests/test_search.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main as main_mod
+
+
+@pytest.mark.asyncio
+async def test_search_returns_crystallization_ids(monkeypatch):
+    async def fake_search(query, **kwargs):
+        assert query == "stance on memory"
+        return {
+            "crystallization_ids": ["crys_a", "crys_b"],
+            "trace": {"backend": "graphiti_core", "rails": ["vector", "graph"]},
+        }
+
+    monkeypatch.setattr("app.backends.graphiti_core.search", fake_search)
+    with patch.object(main_mod.settings, "GRAPHITI_BACKEND", "graphiti_core"):
+        client = TestClient(main_mod.app)
+        resp = client.post(
+            "/v1/search",
+            json={
+                "query": "stance on memory",
+                "seed_crystallization_id": "crys_seed",
+                "limit": 5,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["crystallization_ids"] == ["crys_a", "crys_b"]
+        assert data["trace"]["backend"] == "graphiti_core"
+        assert data["trace"]["rails"] == ["vector", "graph"]
+
+
+def test_search_returns_501_for_orion_postgres_backend():
+    with patch.object(main_mod.settings, "GRAPHITI_BACKEND", "orion_postgres"):
+        client = TestClient(main_mod.app)
+        resp = client.post(
+            "/v1/search",
+            json={"query": "stance on memory", "limit": 5},
+        )
+        assert resp.status_code == 501
+        assert resp.json()["detail"] == "search_requires_graphiti_core_backend"

--- a/services/orion-hub/tests/test_graphiti_sync_payload.py
+++ b/services/orion-hub/tests/test_graphiti_sync_payload.py
@@ -40,3 +40,4 @@ def test_sync_payload_includes_links():
     assert captured["json"]["links"] == [
         {"target_crystallization_id": "crys_b", "relation": "supports", "confidence": 0.8}
     ]
+    assert captured["json"]["metadata"]["sensitivity"] == "private"

--- a/tests/test_memory_crystallization.py
+++ b/tests/test_memory_crystallization.py
@@ -239,6 +239,7 @@ async def test_retriever_collects_linked_crystallization_from_graphiti_depth_two
     crys = _active_crystallization()
     adapter = MagicMock()
     adapter.enabled = True
+    adapter.health.return_value = {"backend": "orion_postgres"}
     adapter.neighborhood.return_value = {
         "enabled": True,
         "nodes": [
@@ -256,3 +257,32 @@ async def test_retriever_collects_linked_crystallization_from_graphiti_depth_two
     )
     adapter.neighborhood.assert_called_once_with(crys.crystallization_id, depth=2)
     assert "crys_linked" in packet.graphiti_refs
+
+
+@pytest.mark.asyncio
+async def test_retriever_uses_graphiti_search_when_backend_is_graphiti_core():
+    from unittest.mock import MagicMock
+    from orion.memory.crystallization.retriever import retrieve_active_packet
+
+    crys = _active_crystallization()
+    adapter = MagicMock()
+    adapter.enabled = True
+    adapter.health.return_value = {"backend": "graphiti_core"}
+    adapter.search.return_value = {
+        "crystallization_ids": [crys.crystallization_id, "crys_search_hit"],
+        "trace": {"backend": "graphiti_core"},
+    }
+
+    packet = await retrieve_active_packet(
+        query="stance on memory",
+        crystallizations=[crys],
+        graphiti_adapter=adapter,
+        seed_crystallization_id=crys.crystallization_id,
+    )
+    adapter.search.assert_called_once_with(
+        "stance on memory",
+        seed_crystallization_id=crys.crystallization_id,
+    )
+    adapter.neighborhood.assert_not_called()
+    assert "crys_search_hit" in packet.graphiti_refs
+    assert "graphiti_search" in packet.retrieval_trace.get("rails", [])

--- a/tests/test_memory_crystallization.py
+++ b/tests/test_memory_crystallization.py
@@ -283,6 +283,8 @@ async def test_retriever_uses_graphiti_search_when_backend_is_graphiti_core():
         "stance on memory",
         seed_crystallization_id=crys.crystallization_id,
     )
-    adapter.neighborhood.assert_not_called()
+    adapter.neighborhood.assert_called_once_with(crys.crystallization_id, depth=2)
     assert "crys_search_hit" in packet.graphiti_refs
-    assert "graphiti_search" in packet.retrieval_trace.get("rails", [])
+    rails = packet.retrieval_trace.get("rails", [])
+    assert "graphiti_search" in rails
+    assert "graphiti_neighborhood" in rails


### PR DESCRIPTION
## PR 3 — Phase C: `graphiti_core` backend (flag-gated)
**Title:** `feat(graphiti): Phase C — graphiti_core hybrid backend`
**Base:** `feat/graphiti-rail-phase-b`
**Body:**
```markdown
## Summary
- Add `GRAPHITI_BACKEND=orion_postgres|graphiti_core` with backend module split
- Pin `graphiti-core[falkordb]==0.19.10`; prescribed FalkorDriver MERGE ingest (no LLM `add_episode`)
- `POST /v1/search` hybrid retrieval; retriever uses search **and** neighborhood when backend is `graphiti_core`
- Intimate sensitivity skip at projector + adapter ingress; search post-filters intimate IDs
- Dual-write Postgres on `graphiti_core` ingest for neighborhood consistency
- Parameterized Cypher + crystallization ID validation; `POST /v1/rebuild` batch ingest
- Code review fixes: embed HTTP wiring, full `edge_ids` in projection refs
## Outcome moved
Optional `graphiti_core` hybrid search rail behind flag; default `orion_postgres` unchanged.
## Tests run
```text
cd services/orion-graphiti-adapter && pytest tests -q                      → 14 passed
pytest tests/test_memory_crystallization.py -k graphiti -q                 → 2 passed
Review findings fixed
Split-brain neighborhood → dual-write Postgres on graphiti_core ingest
Cypher injection → parameterized queries + ID validation
Retriever OR → search + neighborhood dual-rail per spec C3
Embed unwired → Orion embed HTTP in search path
Search intimate filter → FalkorDB sensitivity property + post-filter
edge_ids dropped → full list preserved in projection_graphiti
Restart required
# Default (orion_postgres) — same as Phase A/B
# graphiti_core + FalkorDB:
GRAPHITI_BACKEND=graphiti_core FALKORDB_ENABLED=true \
docker compose --profile falkordb \
  --env-file .env --env-file services/orion-graphiti-adapter/.env \
  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
Risks / concerns
Severity: medium
Concern: graphiti_core flag should stay off until FalkorDB profile smoke with real graphiti-core install
Mitigation: default remains orion_postgres; rollback = flip env + restart
Test plan

 Merge after Phase B

 Confirm default backend smoke unchanged (orion_postgres)

 Optional: FalkorDB profile smoke with GRAPHITI_BACKEND=graphiti_core