### PR TITLE
fix(recall,hub): close journal SQL window leak and publish Orion-mode…

### DIFF
--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -158,7 +158,7 @@ async def execute_unified_turn(
     from scripts.settings import settings as hub_settings
 
     cfg = settings or hub_settings
-    payload = payload or {}
+    payload = dict(payload or {})
 
     if emit_observation_fn is not None:
         try:
@@ -274,7 +274,159 @@ async def execute_unified_turn(
         ]
     if not run.finalize_ran or not run.final_text:
         return [_harness_error_frame(run, correlation_id=correlation_id)]
+    await _publish_unified_turn_chat_history(
+        bus=bus,
+        correlation_id=correlation_id,
+        session_id=session_id,
+        user_message=user_message,
+        response_text=str(run.final_text),
+        payload=payload,
+        run=run,
+        source_label=str(payload.get("chat_history_source") or "hub_orion"),
+    )
     return _success_frames(run, correlation_id=correlation_id)
+
+
+async def _publish_unified_turn_chat_history(
+    *,
+    bus: Any,
+    correlation_id: str,
+    session_id: str | None,
+    user_message: str,
+    response_text: str,
+    payload: dict[str, Any],
+    run: HarnessRunV1,
+    source_label: str = "hub_orion",
+) -> None:
+    """Persist unified-turn chat to the bus so sql-writer lands chat_history_log rows."""
+    if bus is None:
+        return
+    if payload.get("no_write") or payload.get("x_no_write"):
+        return
+    if not str(response_text or "").strip():
+        return
+
+    from scripts.chat_history import (
+        build_chat_history_envelope,
+        build_chat_turn_envelope,
+        publish_chat_history,
+        publish_chat_turn,
+    )
+    from scripts.settings import settings as hub_settings
+    from scripts.spark_candidate import publish_spark_introspect_candidate
+
+    session = str(session_id or "anonymous")
+    user_id = payload.get("user_id")
+    mode_tag = "orion"
+    spark_meta = {
+        "mode": mode_tag,
+        "unified_turn": True,
+        "harness_step_count": run.step_count,
+        "harness_grounding_status": run.grounding_status,
+    }
+
+    reasoning_trace: dict[str, Any] | None = None
+    if run.reflection is not None:
+        reflection_bits = [
+            str(run.reflection.imperative or "").strip(),
+            *[str(note).strip() for note in (run.reflection.alignment_notes or []) if str(note).strip()],
+        ]
+        reflection_text = "\n".join(bit for bit in reflection_bits if bit)
+        if reflection_text:
+            reasoning_trace = {
+                "trace_role": "reflection",
+                "trace_stage": "post_answer",
+                "content": reflection_text,
+                "correlation_id": correlation_id,
+                "session_id": session,
+            }
+
+    envelopes = [
+        build_chat_history_envelope(
+            content=user_message,
+            role="user",
+            session_id=session,
+            correlation_id=correlation_id,
+            speaker=str(user_id or "user"),
+            tags=[mode_tag],
+            message_id=f"{correlation_id}:user",
+            memory_status="accepted",
+            memory_tier="ephemeral",
+        ),
+        build_chat_history_envelope(
+            content=response_text,
+            role="assistant",
+            session_id=session,
+            correlation_id=correlation_id,
+            speaker=hub_settings.SERVICE_NAME,
+            tags=[mode_tag],
+            message_id=f"{correlation_id}:assistant",
+            reasoning_trace=reasoning_trace,
+        ),
+    ]
+    await publish_chat_history(bus, envelopes)
+
+    env_turn = build_chat_turn_envelope(
+        prompt=user_message,
+        response=response_text,
+        session_id=session,
+        correlation_id=correlation_id,
+        user_id=str(user_id) if user_id else None,
+        source_label=source_label,
+        spark_meta=spark_meta,
+        turn_id=correlation_id,
+        memory_status="accepted",
+        memory_tier="ephemeral",
+        reasoning_trace=reasoning_trace,
+        thinking_source="orion_unified_turn",
+    )
+    await publish_chat_turn(bus, env_turn)
+
+    if hub_settings.PUBLISH_CHAT_HISTORY_LOG:
+        try:
+            await bus.publish(
+                hub_settings.chat_history_channel,
+                {
+                    "correlation_id": correlation_id,
+                    "source": source_label,
+                    "prompt": user_message,
+                    "response": response_text,
+                    "session_id": session,
+                    "mode": mode_tag,
+                    "spark_meta": spark_meta,
+                    "reasoning_trace": reasoning_trace,
+                },
+            )
+        except Exception:
+            logger.warning(
+                "unified_turn legacy chat_history publish failed corr=%s",
+                correlation_id,
+                exc_info=True,
+            )
+
+    try:
+        await publish_spark_introspect_candidate(
+            bus,
+            trace_id=correlation_id,
+            prompt=user_message,
+            response=response_text,
+            spark_meta=spark_meta,
+            source=source_label,
+            correlation_id=correlation_id,
+        )
+    except Exception:
+        logger.warning(
+            "unified_turn spark candidate publish failed corr=%s",
+            correlation_id,
+            exc_info=True,
+        )
+
+    logger.info(
+        "unified_turn chat_history published corr=%s session=%s source=%s",
+        correlation_id,
+        session,
+        source_label,
+    )
 
 
 async def run_unified_turn(

--- a/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
+++ b/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
@@ -141,6 +141,73 @@ async def test_turn_orchestrator_defaults_fcc_model_label() -> None:
 
 
 @pytest.mark.asyncio
+async def test_turn_orchestrator_publishes_chat_history_on_success() -> None:
+    harness_run = HarnessRunV1(
+        correlation_id=_CORR_ID,
+        final_text="final answer",
+        finalize_ran=True,
+        step_count=2,
+        compliance_verdict="completed",
+        grounding_status="grounded",
+    )
+    bus = MagicMock()
+    bus.enabled = True
+    publish_history = AsyncMock()
+    publish_turn = AsyncMock()
+    publish_spark = AsyncMock()
+    patches = _hub_client_patches(thought=_thought(), harness_run=harness_run)
+    with patches[0], patches[1], patches[2], patch(
+        "scripts.chat_history.publish_chat_history", publish_history
+    ), patch(
+        "scripts.chat_history.publish_chat_turn", publish_turn
+    ), patch(
+        "scripts.spark_candidate.publish_spark_introspect_candidate", publish_spark
+    ):
+        frames = await execute_unified_turn(
+            bus=bus,
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="user asks",
+            payload={},
+            emit_observation_fn=lambda **_kwargs: None,
+        )
+
+    assert frames[-1]["type"] == "final"
+    publish_history.assert_awaited_once()
+    publish_turn.assert_awaited_once()
+    publish_spark.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_turn_orchestrator_skips_chat_history_when_no_write() -> None:
+    harness_run = HarnessRunV1(
+        correlation_id=_CORR_ID,
+        final_text="final answer",
+        finalize_ran=True,
+        step_count=1,
+        compliance_verdict="completed",
+        grounding_status="grounded",
+    )
+    bus = MagicMock()
+    bus.enabled = True
+    publish_turn = AsyncMock()
+    patches = _hub_client_patches(thought=_thought(), harness_run=harness_run)
+    with patches[0], patches[1], patches[2], patch(
+        "scripts.chat_history.publish_chat_turn", publish_turn
+    ):
+        await execute_unified_turn(
+            bus=bus,
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="user asks",
+            payload={"no_write": True},
+            emit_observation_fn=lambda **_kwargs: None,
+        )
+
+    publish_turn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_turn_orchestrator_never_publishes_draft_text() -> None:
     failed_run = HarnessRunV1(
         correlation_id=_CORR_ID,

--- a/services/orion-recall/app/recall_v2.py
+++ b/services/orion-recall/app/recall_v2.py
@@ -151,11 +151,13 @@ async def run_recall_v2_shadow(
     }
 
     if plan.exact_anchor_tokens:
+        since_minutes = max(60, int(plan.time_window_days * 24 * 60))
         sql_exact = await fetch_exact_fragments(
             tokens=list(plan.exact_anchor_tokens),
             session_id=query.session_id,
             node_id=query.node_id,
             limit=10,
+            since_minutes=since_minutes,
         )
         backend_counts["sql_exact_anchor"] = len(sql_exact)
         for row in sql_exact:

--- a/services/orion-recall/app/sql_timeline.py
+++ b/services/orion-recall/app/sql_timeline.py
@@ -115,6 +115,12 @@ def _parse_row(row: Dict[str, Any]) -> TimelineItem:
 def _epoch(ts_val: Any, default: Optional[float] = None) -> float:
     if ts_val is None:
         return default or datetime.utcnow().timestamp()
+    if isinstance(ts_val, datetime):
+        return ts_val.timestamp()
+    try:
+        return datetime.fromisoformat(str(ts_val).replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return default or datetime.utcnow().timestamp()
 
 
 def _normalize_text(value: Any) -> str:
@@ -155,12 +161,6 @@ def _filter_excluded_rows(
     if suppressed:
         logger.info("sql_timeline self-hit suppression suppressed=%s", suppressed)
     return filtered
-    if isinstance(ts_val, datetime):
-        return ts_val.timestamp()
-    try:
-        return datetime.fromisoformat(str(ts_val)).timestamp()
-    except Exception:
-        return default or datetime.utcnow().timestamp()
 
 
 def _split_table_name(table: str) -> tuple[str, str]:
@@ -490,6 +490,7 @@ async def fetch_exact_fragments(
     node_id: Optional[str],
     limit: int,
     *,
+    since_minutes: Optional[int] = None,
     exclude_ids: Optional[List[str]] = None,
     exclude_text: Optional[str] = None,
 ) -> List[TimelineItem]:
@@ -520,6 +521,10 @@ async def fetch_exact_fragments(
                         term_filters.append(f"{response_col} ILIKE %s")
                         params.append(f"%{token}%")
                     filter_clause = " OR ".join(term_filters) if term_filters else "TRUE"
+                    time_clause = ""
+                    if since_minutes is not None and int(since_minutes) > 0:
+                        time_clause = f"AND {ts_col} >= NOW() - INTERVAL '%s minutes'"
+                        params.append(int(since_minutes))
                     params.append(limit)
                     cur.execute(
                         f"""
@@ -531,6 +536,7 @@ async def fetch_exact_fragments(
                             {ts_col} AS created_at
                         FROM {timeline_table}
                         WHERE ({filter_clause})
+                          {time_clause}
                           {memory_clause}
                         ORDER BY {ts_col} DESC
                         LIMIT %s
@@ -581,6 +587,12 @@ async def fetch_exact_fragments(
                 if node_id and settings.RECALL_SQL_TIMELINE_NODE_COL:
                     node_clause = f"AND {settings.RECALL_SQL_TIMELINE_NODE_COL} = %s"
                     params.append(node_id)
+                time_clause = ""
+                if since_minutes is not None and int(since_minutes) > 0:
+                    time_clause = (
+                        f"AND {settings.RECALL_SQL_TIMELINE_TS_COL} >= NOW() - INTERVAL '%s minutes'"
+                    )
+                    params.append(int(since_minutes))
                 params.append(limit)
                 cur.execute(
                     f"""
@@ -593,6 +605,7 @@ async def fetch_exact_fragments(
                     FROM {timeline_table}
                     WHERE ({filter_clause})
                       {node_clause}
+                      {time_clause}
                       {memory_clause}
                     ORDER BY {settings.RECALL_SQL_TIMELINE_TS_COL} DESC
                     LIMIT %s

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -622,6 +622,87 @@ async def _window_rdf_chatturn_candidates(
     return kept, dropped
 
 
+_SQL_CHAT_SOURCES = frozenset({"sql_timeline", "sql_chat"})
+
+
+def _sql_chat_row_id(candidate: Dict[str, Any]) -> Optional[str]:
+    raw = str(candidate.get("id") or "").strip()
+    if not raw:
+        return None
+    if _UUID_RE.match(raw):
+        return raw
+    if raw.startswith("chat_"):
+        return None
+    # chat_history_log rows sometimes use correlation_id-shaped ids
+    if _UUID_RE.match(raw.replace("_", "-")):
+        return raw.replace("_", "-")
+    return None
+
+
+async def _window_sql_chat_candidates(
+    candidates: List[Dict[str, Any]],
+    *,
+    since_minutes: int,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Drop SQL chat/timeline candidates outside ``since_minutes``.
+
+    Mirrors ``_window_rdf_chatturn_candidates``: anchor-exact SQL rails used
+    ``fetch_exact_fragments`` without a temporal filter, so old turns could surface
+    into journal/metacog recall when expansion tokens matched generic words.
+    Memory cards and non-SQL sources are untouched.
+    """
+    if since_minutes <= 0:
+        return candidates, 0
+
+    cutoff = time.time() - (int(since_minutes) * 60)
+    sql_indices: Dict[int, str] = {}
+    for idx, frag in enumerate(candidates):
+        if str(frag.get("source") or "") not in _SQL_CHAT_SOURCES:
+            continue
+        row_id = _sql_chat_row_id(frag)
+        if row_id is not None:
+            sql_indices[idx] = row_id
+
+    ts_map: Dict[str, float] = {}
+    if sql_indices:
+        try:
+            ts_map = await fetch_chat_turn_timestamps(list(set(sql_indices.values())), since_minutes)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("sql chat windowing skipped: %s", exc)
+            return candidates, 0
+
+    kept: List[Dict[str, Any]] = []
+    dropped = 0
+    for idx, frag in enumerate(candidates):
+        source = str(frag.get("source") or "")
+        if source not in _SQL_CHAT_SOURCES:
+            kept.append(frag)
+            continue
+
+        row_id = sql_indices.get(idx)
+        if row_id is not None:
+            ts = ts_map.get(row_id)
+            if ts is None:
+                dropped += 1
+                continue
+            frag = dict(frag)
+            frag["ts"] = ts
+            kept.append(frag)
+            continue
+
+        ts_val = frag.get("ts")
+        try:
+            ts_float = float(ts_val) if ts_val is not None else 0.0
+        except Exception:
+            ts_float = 0.0
+        if ts_float <= 0.0 or ts_float < cutoff:
+            dropped += 1
+            continue
+        kept.append(frag)
+
+    return kept, dropped
+
+
 async def _fetch_anchor_candidates(
     *,
     query_text: str,
@@ -639,6 +720,7 @@ async def _fetch_anchor_candidates(
     counts: Dict[str, int] = {}
     limit = max(3, min(10, int(profile.get("sql_top_k", settings.RECALL_SQL_TOP_K))))
     exclusion = exclusion or {}
+    since_minutes = int(profile.get("sql_since_minutes", settings.RECALL_SQL_SINCE_MINUTES))
 
     try:
         sql_items = await fetch_exact_fragments(
@@ -646,6 +728,7 @@ async def _fetch_anchor_candidates(
             session_id=session_id,
             node_id=node_id,
             limit=limit,
+            since_minutes=since_minutes,
             exclude_ids=exclusion.get("active_turn_ids"),
             exclude_text=exclusion.get("active_turn_text"),
         )
@@ -1455,6 +1538,23 @@ async def process_recall(
                 rdf_chat_window_min,
                 rdf_chat_dropped,
             )
+
+    sql_chat_window_min = int(
+        profile.get("sql_chat_since_minutes")
+        or profile.get("sql_since_minutes")
+        or settings.RECALL_SQL_SINCE_MINUTES
+    )
+    candidates, sql_chat_dropped = await _window_sql_chat_candidates(
+        candidates, since_minutes=sql_chat_window_min
+    )
+    if sql_chat_dropped:
+        backend_counts_total["sql_chat_out_of_window_dropped"] = sql_chat_dropped
+        logger.info(
+            "sql chat windowing profile=%s window_min=%s dropped=%s",
+            profile.get("profile"),
+            sql_chat_window_min,
+            sql_chat_dropped,
+        )
 
     suppression_start = time.time()
     candidates, suppressed = _suppress_self_hits(

--- a/services/orion-recall/tests/test_sql_anchor_since_minutes.py
+++ b/services/orion-recall/tests/test_sql_anchor_since_minutes.py
@@ -1,0 +1,31 @@
+"""Anchor rail must pass the profile sql_since_minutes into fetch_exact_fragments."""
+
+from __future__ import annotations
+
+import asyncio
+
+from app import worker
+
+
+def test_fetch_anchor_candidates_forwards_sql_since_minutes(monkeypatch) -> None:
+    captured: dict = {}
+
+    async def _fake_exact(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(worker, "fetch_exact_fragments", _fake_exact)
+    monkeypatch.setattr(worker, "_anchor_tokens", lambda _text, **_: ["connection123"])
+
+    asyncio.run(
+        worker._fetch_anchor_candidates(
+            query_text="anything",
+            profile={"profile": "journal.daily.grounded.v1", "sql_since_minutes": 1440, "sql_top_k": 50},
+            session_id=None,
+            node_id=None,
+            diagnostic=False,
+            exclusion={},
+        )
+    )
+
+    assert captured.get("since_minutes") == 1440

--- a/services/orion-recall/tests/test_sql_chat_windowing.py
+++ b/services/orion-recall/tests/test_sql_chat_windowing.py
@@ -1,0 +1,48 @@
+"""Post-fetch SQL chat windowing drops stale sql_timeline/sql_chat rows."""
+
+from __future__ import annotations
+
+import asyncio
+
+from app import worker
+
+
+def _run_window(candidates, since_minutes, ts_map):
+    async def _fake_fetch(turn_ids, since):
+        return {tid: ts_map[tid] for tid in turn_ids if tid in ts_map}
+
+    original = worker.fetch_chat_turn_timestamps
+    worker.fetch_chat_turn_timestamps = _fake_fetch  # type: ignore[assignment]
+    try:
+        return asyncio.run(
+            worker._window_sql_chat_candidates(candidates, since_minutes=since_minutes)
+        )
+    finally:
+        worker.fetch_chat_turn_timestamps = original  # type: ignore[assignment]
+
+
+def test_sql_windowing_drops_out_of_window_uuid_rows() -> None:
+    in_window = "497229f6-12da-4ffa-9f92-95aa950db58f"
+    out_window = "181c2c85-da7a-4de8-a475-4291ae290e0e"
+    candidates = [
+        {"id": in_window, "source": "sql_timeline", "tags": ["anchor_exact"], "ts": 0.0, "text": "recent"},
+        {"id": out_window, "source": "sql_chat", "tags": ["sql"], "ts": 0.0, "text": "months old"},
+        {"id": "card-1", "source": "cards", "tags": ["card"], "ts": 5.0, "text": "card"},
+    ]
+    kept, dropped = _run_window(candidates, 1440, {in_window: 1_783_300_000.0})
+
+    assert dropped == 1
+    assert [c["source"] for c in kept] == ["sql_timeline", "cards"]
+    assert kept[0]["ts"] == 1_783_300_000.0
+
+
+def test_sql_windowing_keeps_recent_rows_with_real_ts_when_id_not_uuid() -> None:
+    import time
+
+    recent_ts = time.time() - 3600
+    candidates = [
+        {"id": "chat_123", "source": "sql_timeline", "tags": ["chat_timeline"], "ts": recent_ts, "text": "ok"},
+    ]
+    kept, dropped = _run_window(candidates, 1440, {})
+    assert dropped == 0
+    assert kept == candidates

--- a/services/orion-recall/tests/test_sql_exact_windowing.py
+++ b/services/orion-recall/tests/test_sql_exact_windowing.py
@@ -1,0 +1,72 @@
+"""SQL anchor exact-match recall must honor the profile time window.
+
+fetch_exact_fragments had no temporal filter, so anchor rails (sql_timeline_anchor)
+could surface months-old chat turns into journal/metacog recall when query expansion
+tokens matched generic words (connection, coding, etc.). RDF chat-turn windowing was
+fixed in PR #815; this closes the parallel SQL leak.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+from app.sql_timeline import _epoch, fetch_exact_fragments
+
+
+def test_epoch_parses_datetime_objects() -> None:
+    ts = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert _epoch(ts) == ts.timestamp()
+
+
+def test_epoch_parses_iso_strings() -> None:
+    assert _epoch("2026-07-01T12:00:00+00:00") > 1_700_000_000
+
+
+def test_fetch_exact_fragments_passes_since_minutes_to_query(monkeypatch) -> None:
+    captured: dict = {}
+
+    class _FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, sql, params):
+            captured["sql"] = sql
+            captured["params"] = params
+
+        @property
+        def description(self):
+            return []
+
+        def fetchall(self):
+            return []
+
+    class _FakeConn:
+        def cursor(self):
+            return _FakeCursor()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("app.sql_timeline._connect", lambda: _FakeConn())
+    monkeypatch.setattr("app.sql_timeline.settings.RECALL_SQL_TIMELINE_TABLE", "chat_history_log")
+    monkeypatch.setattr("app.sql_timeline.settings.RECALL_SQL_CHAT_TABLE", "chat_history_log")
+    monkeypatch.setattr("app.sql_timeline._pick_id_col", lambda *_a, **_k: "id")
+    monkeypatch.setattr("app.sql_timeline._pick_session_col", lambda *_a, **_k: None)
+    monkeypatch.setattr("app.sql_timeline._memory_filter_clause", lambda *_a, **_k: "")
+
+    asyncio.run(
+        fetch_exact_fragments(
+            tokens=["connection"],
+            session_id=None,
+            node_id=None,
+            limit=5,
+            since_minutes=1440,
+        )
+    )
+
+    assert "INTERVAL" in captured["sql"]
+    assert 1440 in captured["params"]


### PR DESCRIPTION
Pushed to `fix/journal-sql-anchor-window` (rebased on current `main`, single commit `d8fe6ea8`). `gh` isn’t authenticated here, so create the PR from:

**https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/journal-sql-anchor-window**

---

**Title:** `fix(recall,hub): journal SQL 24h window + Orion-mode chat persistence`

**Body:**

## Summary

- Close the remaining SQL-side journal recall leak: `fetch_exact_fragments` (anchor rail) had no temporal filter, and `_epoch()` datetime parsing was broken after a bad merge.
- Add post-fetch `_window_sql_chat_candidates()` mirroring the RDF chat-turn windowing from PR #815.
- Wire unified Orion turns (`mode=orion` + `ORION_UNIFIED_TURN_ENABLED`) to publish `orion:chat:history:*` bus events so sql-writer lands `chat_history_log` rows again.

## Outcome moved

- Daily journal / metacog recall should stop surfacing days-old connection/coding chat from SQL anchor paths.
- Orion-mode Hub chats persist to Postgres via sql-writer like Brain/Quick modes.

## Current architecture

- Journal profiles set `sql_since_minutes: 1440` and enable `sql_timeline`.
- PR #815 windowed RDF chat-turn candidates; SQL `fetch_exact_fragments` stayed unbounded.
- Unified turn orchestrator returned WS frames without `publish_chat_history` / `publish_chat_turn`.

## Architecture touched

- `services/orion-recall` — `sql_timeline.py`, `worker.py`, `recall_v2.py`
- `orion/hub/turn_orchestrator.py` — post-success chat history publish seam

## Files changed

- `services/orion-recall/app/sql_timeline.py`: restore `_epoch()`, add `since_minutes` to `fetch_exact_fragments`
- `services/orion-recall/app/worker.py`: forward profile window to anchor fetch; `_window_sql_chat_candidates()`
- `services/orion-recall/app/recall_v2.py`: pass window into exact fetch
- `orion/hub/turn_orchestrator.py`: `_publish_unified_turn_chat_history()` after successful harness
- Tests for SQL windowing, anchor forwarding, and Orion turn publish

## Schema / bus / API changes

- None (uses existing `orion:chat:history:log`, `orion:chat:history:turn`, legacy log channel, `spark.candidate`)

## Tests run

```text
19 passed (recall windowing + turn orchestrator publish tests)
```

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-recall/.env \
  -f services/orion-recall/docker-compose.yml \
  up -d --build recall

docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build hub
```

## Test plan

- [ ] Run daily journal; confirm recall digest has no SQL snippets older than 24h
- [ ] Send Orion-mode chat turn; confirm Hub log `unified_turn chat_history published`
- [ ] Confirm sql-writer consumes `orion:chat:history:turn` and row appears in `chat_history_log`

---

**DONE** — branch pushed; run `gh auth login` then `gh pr create` with the body above, or use the GitHub link. Unrelated aitown env edits are still in stash (`git stash list`) on the old worktree branch.