### PR TITLE
Fix/reverie thought db read recover

### DIFF
--- a/docs/superpowers/plans/2026-07-06-reverie-thought-db-read-fix-PR.md
+++ b/docs/superpowers/plans/2026-07-06-reverie-thought-db-read-fix-PR.md
@@ -1,0 +1,126 @@
+# PR: fix(orion-thought) — reverie reads attention broadcast via direct DSN, not heavy substrate
+
+Branch: `fix/reverie-thought-db-read-recover` → `main`
+Commit: `91f400aa`
+
+## Summary
+
+Reverie was **inert in production**. `_default_broadcast_reader` imported
+`orion.substrate.felt_state_reader`, whose package `__init__` drags
+`materializer → graphdb_store → import requests`. orion-thought is a thin bus
+service that ships neither `requests` nor the graph engine, so **every 90s
+reverie tick raised `ModuleNotFoundError: No module named 'requests'`**, read no
+coalition, and produced zero thoughts (the code looked wired; the runtime was
+dead — config-truth ≠ runtime-truth, §0A).
+
+- Add `services/orion-thought/app/broadcast_reader.py`: minimal fail-open direct
+  query of `substrate_attention_broadcast_projection` (jsonb `projection_json` +
+  tz-aware `generated_at`), sqlalchemy + psycopg2 only, 300s staleness guard.
+- `reverie.py` / `store.py` now use a direct `POSTGRES_URI` DSN (→ `conjourney`)
+  instead of `felt_state_reader`.
+- Add `SQLAlchemy==2.0.36` + `psycopg2-binary==2.9.10` pins.
+- Add `POSTGRES_URI` to `.env_example`.
+- Rewrite the three reader unit tests onto the new path + add an empty-table
+  fail-open test.
+
+## Outcome moved
+
+Reverie went from **0 thoughts/tick (crash-looping)** to live: post-rebuild logs
+show consecutive `reverie thought published ... salience=0.720` with no
+`No module` errors; `substrate_reverie_thought` grew 24 → 27 within a minute of
+restart.
+
+## Current architecture (before)
+
+- `services/orion-thought/` — thin bus service (fastapi/uvicorn/pydantic/redis/
+  PyYAML). Evoked path gets its coalition from the request payload
+  (`request.association.broadcast`).
+- Reverie is self-driven with no incoming payload, so it must fetch the coalition
+  itself — it did so via `orion.substrate.felt_state_reader.hydrate_felt_state_ctx`,
+  which pulls the heavy `orion.substrate` package.
+
+## Architecture touched
+
+- New thin seam `app/broadcast_reader.py` isolates the broadcast read behind a
+  direct DSN, so the service never imports `orion.substrate.*`.
+- `store.py` `_database_url()` switched to the same direct DSN.
+
+## Files changed
+
+- `services/orion-thought/app/broadcast_reader.py`: new fail-open direct reader.
+- `services/orion-thought/app/reverie.py`: `_default_broadcast_reader` → direct reader.
+- `services/orion-thought/app/store.py`: `_database_url` → direct DSN, no substrate import.
+- `services/orion-thought/requirements.txt`: add SQLAlchemy + psycopg2-binary pins.
+- `services/orion-thought/.env_example`: add `POSTGRES_URI`.
+- `services/orion-thought/tests/test_reverie_spontaneous_thought.py`: reader tests → new path + empty-table test.
+
+## Schema / bus / API changes
+
+- None. No channel, schema, or payload changes. Reads an existing table.
+
+## Env/config changes
+
+- Added key: `POSTGRES_URI` (orion-thought `.env_example`), form
+  `postgresql://postgres:postgres@${PROJECT}-sql-db:5432/conjourney`.
+- Local `.env` already carries the resolved `orion-athena-sql-db` value + reverie
+  flags (`ORION_REVERIE_ENABLED=true`, resonance flags). `.env` remains gitignored.
+- No skipped keys.
+
+## Tests run
+
+```
+.venv/bin/python -m pytest services/orion-thought/tests -q
+55 passed, 13 warnings in 2.83s
+```
+
+## Runtime / smoke checks
+
+```
+# broadcast projection table confirmed
+\d substrate_attention_broadcast_projection
+  generated_at    | timestamp with time zone | not null
+  projection_json | jsonb                    | not null
+# latest broadcast ~4s old (substrate ticking)
+
+# in-container reader, no requests
+docker exec orion-athena-thought python -c "from app.broadcast_reader import read_latest_broadcast; print(read_latest_broadcast())"
+  read ok, broadcast: present substrate.attention.broadcast.v1
+
+# live logs after rebuild
+reverie thought published corr=95bfd496-... salience=0.720 channel=orion:reverie:thought
+reverie thought published corr=ec515c69-... salience=0.720 channel=orion:reverie:thought
+reverie thought published corr=475ec9b7-... salience=0.720 channel=orion:reverie:thought
+# zero "No module" / "broadcast read failed" lines post-restart
+
+# substrate_reverie_thought count: 24 → 27 within a minute
+```
+
+## Review findings fixed
+
+- Code review (high effort) over the 6-file diff: no material findings. Imports
+  (`Any`, `os`, `AttentionBroadcastProjectionV1`) all still used after edits; all
+  paths fail-open to None/False, never raise; static SQL (no injection).
+
+## Restart required
+
+```bash
+docker compose -p orion-thought \
+  --env-file .env \
+  --env-file services/orion-thought/.env \
+  -f services/orion-thought/docker-compose.yml \
+  up -d --build thought
+```
+
+Already applied — reverie is live.
+
+## Risks / concerns
+
+- Severity: low. `broadcast_reader` keeps its own sqlalchemy engine (separate pool
+  from `store.py`) — negligible at 90s cadence.
+- Durability depends on this branch being merged to local `main`; a full `--build`
+  from unmerged `main` would revert reverie to the broken state.
+
+## Status
+
+DONE_WITH_CONCERNS — landed, pushed, runtime-verified. Open items: browser PR +
+merge to local `main`.

--- a/services/orion-thought/.env_example
+++ b/services/orion-thought/.env_example
@@ -44,3 +44,6 @@ CHANNEL_DREAM_COMPACTION_REQUEST=orion:dream:compaction-request
 ORION_REVERIE_RESONANCE_ALERT_ENABLED=true
 CHANNEL_REVERIE_RESONANCE_ALERT=orion:reverie:resonance-alert
 ORION_REVERIE_RESONANCE_WINDOW=200
+
+# Reverie: direct read of attention broadcast + reverie-table persistence
+POSTGRES_URI=postgresql://postgres:postgres@${PROJECT}-sql-db:5432/conjourney

--- a/services/orion-thought/app/broadcast_reader.py
+++ b/services/orion-thought/app/broadcast_reader.py
@@ -1,0 +1,88 @@
+"""Direct read of the current attention-broadcast projection from Postgres.
+
+orion-thought is a bus service, but reverie is *self-driven* and has no incoming
+request payload (unlike the evoked path, which gets the coalition from
+`request.association.broadcast`). So reverie reads the latest broadcast the same
+place hub/self-state read it — `substrate_attention_broadcast_projection` — via a
+minimal direct query.
+
+Deliberately does NOT import `orion.substrate.felt_state_reader`: that runs the
+heavy `orion.substrate` package `__init__`, which pulls the full graph engine
+(`requests` etc.) that this thin service does not ship. Here we need only
+sqlalchemy + a psycopg driver.
+
+Fail-open: any failure (missing table, unavailable DB, stale row) returns None so
+a reverie tick degrades to "no coalition" — never raises.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+from orion.schemas.attention_frame import AttentionBroadcastProjectionV1
+
+logger = logging.getLogger("orion-thought.broadcast_reader")
+
+# Reverie may narrate a slightly-aged coalition, but not a dead one. Broadcasts
+# tick ~30s; reverie ~90s. Skip anything older than this (substrate not ticking).
+DEFAULT_MAX_AGE_SEC = 300.0
+
+_engine = None
+
+
+def _database_url() -> str:
+    return (
+        os.getenv("POSTGRES_URI", "").strip()
+        or "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+    )
+
+
+def _get_engine():
+    global _engine
+    if _engine is None:
+        from sqlalchemy import create_engine
+
+        _engine = create_engine(_database_url(), pool_pre_ping=True)
+    return _engine
+
+
+def read_latest_broadcast(
+    max_age_sec: float = DEFAULT_MAX_AGE_SEC,
+) -> AttentionBroadcastProjectionV1 | None:
+    """Latest fresh attention-broadcast projection, or None. Never raises."""
+    try:
+        from sqlalchemy import text
+
+        engine = _get_engine()
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        "SELECT projection_json, generated_at "
+                        "FROM substrate_attention_broadcast_projection "
+                        "ORDER BY generated_at DESC LIMIT 1"
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            logger.info("no attention broadcast row yet; reverie skips")
+            return None
+        gen = row.get("generated_at")
+        if isinstance(gen, datetime):
+            ts = gen if gen.tzinfo else gen.replace(tzinfo=timezone.utc)
+            age = (datetime.now(timezone.utc) - ts).total_seconds()
+            if age > max_age_sec:
+                logger.info("attention broadcast stale (%.0fs > %.0fs); reverie skips", age, max_age_sec)
+                return None
+        payload = row["projection_json"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return AttentionBroadcastProjectionV1.model_validate(payload)
+    except Exception as exc:
+        logger.warning("attention broadcast read failed: %s", exc)
+        return None

--- a/services/orion-thought/app/reverie.py
+++ b/services/orion-thought/app/reverie.py
@@ -58,24 +58,17 @@ def _source() -> ServiceRef:
 
 
 def _default_broadcast_reader() -> AttentionBroadcastProjectionV1 | None:
-    """Read the current coalition via the shared substrate felt-state reader.
+    """Read the current coalition directly from the broadcast projection table.
 
-    Mirrors orion/hub/association.py. Any failure degrades to None so a
-    reverie tick never raises on a missing/unavailable substrate.
+    Uses a minimal direct query (`app.broadcast_reader`) rather than the heavy
+    `orion.substrate.felt_state_reader`, which would drag the full graph engine
+    (`requests` etc.) that this thin bus service does not ship. Fail-open: any
+    failure degrades to None so a reverie tick never raises.
     """
     try:
-        # Public fail-open entrypoint — resolves enabled/url/max-age internally and
-        # never raises. Same coalition source the evoked stance_react path reads.
-        from orion.substrate.felt_state_reader import hydrate_felt_state_ctx
+        from .broadcast_reader import read_latest_broadcast
 
-        ctx: dict[str, Any] = {}
-        hydrate_felt_state_ctx(ctx)
-        raw = ctx.get("attention_broadcast")
-        if raw is None:
-            return None
-        if isinstance(raw, AttentionBroadcastProjectionV1):
-            return raw
-        return AttentionBroadcastProjectionV1.model_validate(raw)
+        return read_latest_broadcast()
     except Exception as exc:  # never raise out of a reverie tick
         logger.warning("reverie broadcast read failed: %s", exc)
         return None

--- a/services/orion-thought/app/store.py
+++ b/services/orion-thought/app/store.py
@@ -2,8 +2,8 @@
 
 Best-effort writer for `SpontaneousThoughtV1` into `substrate_reverie_thought`
 (migration `manual_migration_substrate_reverie_thought.sql`). Backs the hub
-`_reverie_section` panel. Reuses the sqlalchemy engine pattern already pulled in
-by `felt_state_reader` — no new dependency.
+`_reverie_section` panel. Uses a direct sqlalchemy DSN (see `_database_url`) —
+never the heavy `orion.substrate` package this thin service does not ship.
 
 Discipline: persistence is best-effort. A DB failure degrades to a logged miss
 (returns False) and never breaks the reverie tick. Idempotent on `thought_id`.
@@ -25,11 +25,13 @@ _engine = None
 
 
 def _database_url() -> str:
-    # Prefer the URI the hub observability panel reads, so writes land where the
-    # panel looks; fall back to the substrate felt-state DB the reader uses.
-    from orion.substrate.felt_state_reader import substrate_felt_state_database_url
-
-    return os.getenv("POSTGRES_URI", "").strip() or substrate_felt_state_database_url()
+    # Direct DSN — deliberately NOT via orion.substrate.felt_state_reader, whose
+    # package __init__ drags the full graph engine (requests etc.) this thin
+    # service does not ship. Writes land where the hub panel reads (conjourney).
+    return (
+        os.getenv("POSTGRES_URI", "").strip()
+        or "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+    )
 
 
 def _get_engine():

--- a/services/orion-thought/requirements.txt
+++ b/services/orion-thought/requirements.txt
@@ -5,3 +5,7 @@ pydantic-settings>=2.2.0
 python-dotenv>=1.0.0
 redis>=5.0.0
 PyYAML>=6.0.0
+# Reverie reads the attention-broadcast projection + persists reverie tables via a
+# direct DSN (no heavy orion.substrate package). Matches sibling service pins.
+SQLAlchemy==2.0.36
+psycopg2-binary==2.9.10

--- a/services/orion-thought/tests/test_reverie_spontaneous_thought.py
+++ b/services/orion-thought/tests/test_reverie_spontaneous_thought.py
@@ -245,34 +245,48 @@ async def test_tick_swallows_publish_failure():
 
 # --- default broadcast reader (real signature coverage, no live DB) ------------
 
-def test_default_broadcast_reader_hydrates_projection(monkeypatch):
-    """Covers the felt_state_reader wiring the mocked ticks skip."""
-    from app import reverie
-    import orion.substrate.felt_state_reader as fsr
+def test_default_broadcast_reader_returns_projection(monkeypatch):
+    """Covers the direct-DB reader wiring the mocked ticks skip."""
+    from app import broadcast_reader, reverie
 
-    def fake_hydrate(ctx):
-        ctx["attention_broadcast"] = _broadcast().model_dump(mode="json")
-
-    monkeypatch.setattr(fsr, "hydrate_felt_state_ctx", fake_hydrate)
+    monkeypatch.setattr(broadcast_reader, "read_latest_broadcast", lambda *a, **k: _broadcast())
     result = reverie._default_broadcast_reader()
     assert result is not None
     assert result.attended_node_ids == ["n-1"]
 
 
 def test_default_broadcast_reader_none_on_empty(monkeypatch):
-    from app import reverie
-    import orion.substrate.felt_state_reader as fsr
+    from app import broadcast_reader, reverie
 
-    monkeypatch.setattr(fsr, "hydrate_felt_state_ctx", lambda ctx: None)
+    monkeypatch.setattr(broadcast_reader, "read_latest_broadcast", lambda *a, **k: None)
     assert reverie._default_broadcast_reader() is None
 
 
 def test_default_broadcast_reader_never_raises(monkeypatch):
-    from app import reverie
-    import orion.substrate.felt_state_reader as fsr
+    from app import broadcast_reader, reverie
 
-    def boom(ctx):
+    def boom(*a, **k):
         raise RuntimeError("db unreachable")
 
-    monkeypatch.setattr(fsr, "hydrate_felt_state_ctx", boom)
+    monkeypatch.setattr(broadcast_reader, "read_latest_broadcast", boom)
     assert reverie._default_broadcast_reader() is None  # swallowed
+
+
+def test_broadcast_reader_none_when_no_row(monkeypatch):
+    """The direct reader itself is fail-open on an empty/absent table."""
+    from app import broadcast_reader
+
+    class _Conn:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def execute(self, *a, **k):
+            class _R:
+                def mappings(self_): return self_
+                def first(self_): return None
+            return _R()
+
+    class _Engine:
+        def connect(self): return _Conn()
+
+    monkeypatch.setattr(broadcast_reader, "_get_engine", lambda: _Engine())
+    assert broadcast_reader.read_latest_broadcast() is None


### PR DESCRIPTION
# PR: fix(orion-thought) — reverie reads attention broadcast via direct DSN, not heavy substrate

Branch: `fix/reverie-thought-db-read-recover` → `main`
Commit: `91f400aa`

## Summary

Reverie was **inert in production**. `_default_broadcast_reader` imported
`orion.substrate.felt_state_reader`, whose package `__init__` drags
`materializer → graphdb_store → import requests`. orion-thought is a thin bus
service that ships neither `requests` nor the graph engine, so **every 90s
reverie tick raised `ModuleNotFoundError: No module named 'requests'`**, read no
coalition, and produced zero thoughts (the code looked wired; the runtime was
dead — config-truth ≠ runtime-truth, §0A).

- Add `services/orion-thought/app/broadcast_reader.py`: minimal fail-open direct
  query of `substrate_attention_broadcast_projection` (jsonb `projection_json` +
  tz-aware `generated_at`), sqlalchemy + psycopg2 only, 300s staleness guard.
- `reverie.py` / `store.py` now use a direct `POSTGRES_URI` DSN (→ `conjourney`)
  instead of `felt_state_reader`.
- Add `SQLAlchemy==2.0.36` + `psycopg2-binary==2.9.10` pins.
- Add `POSTGRES_URI` to `.env_example`.
- Rewrite the three reader unit tests onto the new path + add an empty-table
  fail-open test.

## Outcome moved

Reverie went from **0 thoughts/tick (crash-looping)** to live: post-rebuild logs
show consecutive `reverie thought published ... salience=0.720` with no
`No module` errors; `substrate_reverie_thought` grew 24 → 27 within a minute of
restart.

## Current architecture (before)

- `services/orion-thought/` — thin bus service (fastapi/uvicorn/pydantic/redis/
  PyYAML). Evoked path gets its coalition from the request payload
  (`request.association.broadcast`).
- Reverie is self-driven with no incoming payload, so it must fetch the coalition
  itself — it did so via `orion.substrate.felt_state_reader.hydrate_felt_state_ctx`,
  which pulls the heavy `orion.substrate` package.

## Architecture touched

- New thin seam `app/broadcast_reader.py` isolates the broadcast read behind a
  direct DSN, so the service never imports `orion.substrate.*`.
- `store.py` `_database_url()` switched to the same direct DSN.

## Files changed

- `services/orion-thought/app/broadcast_reader.py`: new fail-open direct reader.
- `services/orion-thought/app/reverie.py`: `_default_broadcast_reader` → direct reader.
- `services/orion-thought/app/store.py`: `_database_url` → direct DSN, no substrate import.
- `services/orion-thought/requirements.txt`: add SQLAlchemy + psycopg2-binary pins.
- `services/orion-thought/.env_example`: add `POSTGRES_URI`.
- `services/orion-thought/tests/test_reverie_spontaneous_thought.py`: reader tests → new path + empty-table test.

## Schema / bus / API changes

- None. No channel, schema, or payload changes. Reads an existing table.

## Env/config changes

- Added key: `POSTGRES_URI` (orion-thought `.env_example`), form
  `postgresql://postgres:postgres@${PROJECT}-sql-db:5432/conjourney`.
- Local `.env` already carries the resolved `orion-athena-sql-db` value + reverie
  flags (`ORION_REVERIE_ENABLED=true`, resonance flags). `.env` remains gitignored.
- No skipped keys.

## Tests run

```
.venv/bin/python -m pytest services/orion-thought/tests -q
55 passed, 13 warnings in 2.83s
```

## Runtime / smoke checks

```
# broadcast projection table confirmed
\d substrate_attention_broadcast_projection
  generated_at    | timestamp with time zone | not null
  projection_json | jsonb                    | not null
# latest broadcast ~4s old (substrate ticking)

# in-container reader, no requests
docker exec orion-athena-thought python -c "from app.broadcast_reader import read_latest_broadcast; print(read_latest_broadcast())"
  read ok, broadcast: present substrate.attention.broadcast.v1

# live logs after rebuild
reverie thought published corr=95bfd496-... salience=0.720 channel=orion:reverie:thought
reverie thought published corr=ec515c69-... salience=0.720 channel=orion:reverie:thought
reverie thought published corr=475ec9b7-... salience=0.720 channel=orion:reverie:thought
# zero "No module" / "broadcast read failed" lines post-restart

# substrate_reverie_thought count: 24 → 27 within a minute
```

## Review findings fixed

- Code review (high effort) over the 6-file diff: no material findings. Imports
  (`Any`, `os`, `AttentionBroadcastProjectionV1`) all still used after edits; all
  paths fail-open to None/False, never raise; static SQL (no injection).

## Restart required

```bash
docker compose -p orion-thought \
  --env-file .env \
  --env-file services/orion-thought/.env \
  -f services/orion-thought/docker-compose.yml \
  up -d --build thought
```

Already applied — reverie is live.

## Risks / concerns

- Severity: low. `broadcast_reader` keeps its own sqlalchemy engine (separate pool
  from `store.py`) — negligible at 90s cadence.
- Durability depends on this branch being merged to local `main`; a full `--build`
  from unmerged `main` would revert reverie to the broken state.

## Status

DONE_WITH_CONCERNS — landed, pushed, runtime-verified. Open items: browser PR +
merge to local `main`.