### PR TITLE
Wire memory card activation to crystallizer bus rail.

### DIFF
--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1313,6 +1313,15 @@ channels:
     stability: "experimental"
     since: "2026-01-16"
 
+  - name: "orion:memory:cards:active"
+    kind: "event"
+    schema_id: "MemoryCardV1"
+    message_kind: "memory.card.active.v1"
+    producer_services: ["orion-hub"]
+    consumer_services: ["orion-memory-crystallizer"]
+    stability: "experimental"
+    since: "2026-07-06"
+
   - name: "orion:memory:crystallization:proposed"
     kind: "event"
     schema_id: "MemoryCrystallizationV1"

--- a/orion/memory/crystallization/bus_emit_memory_card.py
+++ b/orion/memory/crystallization/bus_emit_memory_card.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.contracts.memory_cards import MemoryCardV1, MemoryPriority
+
+logger = logging.getLogger(__name__)
+
+MEMORY_CARD_ACTIVE_CHANNEL = "orion:memory:cards:active"
+MEMORY_CARD_ACTIVE_KIND = "memory.card.active.v1"
+
+CRYSTALLIZER_CARD_PRIORITIES: frozenset[MemoryPriority] = frozenset({"high_recall", "always_inject"})
+
+
+def card_qualifies_for_crystallizer(card: MemoryCardV1) -> bool:
+    return card.status == "active" and card.priority in CRYSTALLIZER_CARD_PRIORITIES
+
+
+def _source(service_name: str, *, version: str = "0.1.0", node: str = "hub") -> ServiceRef:
+    return ServiceRef(name=service_name, version=version, node=node)
+
+
+async def emit_memory_card_active_for_crystallizer(
+    bus: Optional[OrionBusAsync],
+    card: MemoryCardV1,
+    *,
+    service_name: str = "orion-hub",
+    service_version: str = "0.1.0",
+    node_name: str = "hub",
+) -> bool:
+    """Notify crystallizer when an active card has high-salience priority."""
+    if not card_qualifies_for_crystallizer(card):
+        return False
+    if bus is None or not getattr(bus, "enabled", True):
+        logger.debug(
+            "memory_card_active_emit_skipped bus_unavailable card_id=%s",
+            card.card_id,
+        )
+        return False
+
+    env = BaseEnvelope(
+        kind=MEMORY_CARD_ACTIVE_KIND,
+        source=_source(service_name, version=service_version, node=node_name),
+        payload=card.model_dump(mode="json"),
+    )
+    try:
+        await bus.publish(MEMORY_CARD_ACTIVE_CHANNEL, env)
+        logger.info(
+            "memory_card_active_emitted channel=%s card_id=%s priority=%s",
+            MEMORY_CARD_ACTIVE_CHANNEL,
+            card.card_id,
+            card.priority,
+        )
+        return True
+    except Exception as exc:
+        logger.warning(
+            "memory_card_active_emit_failed card_id=%s error=%s",
+            card.card_id,
+            exc,
+        )
+        return False

--- a/orion/memory/crystallization/tests/test_bus_emit_memory_card.py
+++ b/orion/memory/crystallization/tests/test_bus_emit_memory_card.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from orion.core.contracts.memory_cards import MemoryCardV1
+from orion.memory.crystallization.bus_emit_memory_card import (
+    card_qualifies_for_crystallizer,
+    emit_memory_card_active_for_crystallizer,
+    MEMORY_CARD_ACTIVE_CHANNEL,
+    MEMORY_CARD_ACTIVE_KIND,
+)
+
+
+def _card(*, status: str = "active", priority: str = "high_recall") -> MemoryCardV1:
+    now = datetime.now(timezone.utc)
+    return MemoryCardV1(
+        card_id=uuid4(),
+        slug="test-card",
+        types=["fact"],
+        status=status,  # type: ignore[arg-type]
+        priority=priority,  # type: ignore[arg-type]
+        provenance="operator_highlight",
+        title="Wild card",
+        summary="Operator approved this in Memory tab.",
+        visibility_scope=["project:orion"],
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_card_qualifies_only_active_high_salience() -> None:
+    assert card_qualifies_for_crystallizer(_card(status="active", priority="high_recall"))
+    assert card_qualifies_for_crystallizer(_card(status="active", priority="always_inject"))
+    assert not card_qualifies_for_crystallizer(_card(status="pending_review", priority="high_recall"))
+    assert not card_qualifies_for_crystallizer(_card(status="active", priority="episodic_detail"))
+
+
+@pytest.mark.asyncio
+async def test_emit_publishes_qualifying_card() -> None:
+    published: list[tuple[str, object]] = []
+
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel: str, env: object) -> None:
+            published.append((channel, env))
+
+    card = _card()
+    ok = await emit_memory_card_active_for_crystallizer(_Bus(), card, service_name="orion-hub")
+    assert ok is True
+    assert len(published) == 1
+    channel, env = published[0]
+    assert channel == MEMORY_CARD_ACTIVE_CHANNEL
+    assert env.kind == MEMORY_CARD_ACTIVE_KIND  # type: ignore[attr-defined]
+    assert env.payload["card_id"] == str(card.card_id)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_emit_skips_non_qualifying_card() -> None:
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel: str, env: object) -> None:
+            raise AssertionError("should not publish")
+
+    ok = await emit_memory_card_active_for_crystallizer(_Bus(), _card(priority="archival"))
+    assert ok is False

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -17,6 +17,7 @@ from orion.core.bus.bus_schemas import (
     RecallRequestPayload,
     RecallResultPayload,
 )
+from orion.core.contracts.memory_cards import MemoryCardV1
 from orion.core.contracts.recall import (
     RecallAdapterDiagnosticsV1,
     RecallDebugV1,
@@ -1129,6 +1130,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "CompressionRegionV1": CompressionRegionV1,
     "CompressionStalenessMarkV1": CompressionStalenessMarkV1,
     "GraphCompressionRegionMaterializedV1": GraphCompressionRegionMaterializedV1,
+    "MemoryCardV1": MemoryCardV1,
     "MemoryCrystallizationV1": MemoryCrystallizationV1,
     "ActiveMemoryPacketV1": ActiveMemoryPacketV1,
     "MemoryTurnPersistedV1": MemoryTurnPersistedV1,

--- a/services/orion-hub/scripts/memory_graph_routes.py
+++ b/services/orion-hub/scripts/memory_graph_routes.py
@@ -8,6 +8,8 @@ import requests
 from fastapi import APIRouter, Header, HTTPException, Request
 from pydantic import ValidationError
 
+from orion.core.storage import memory_cards as mc_dal
+from orion.memory.crystallization.bus_emit_memory_card import emit_memory_card_active_for_crystallizer
 from orion.memory_graph.approve import approve_memory_graph_draft, preview_validate_only
 from orion.memory_graph.consolidation_draft_hydrate import hydrate_consolidation_draft_dict
 from orion.memory_graph.dto import CardProjectionDefaultsV1, SuggestDraftV1
@@ -17,6 +19,23 @@ from .mutation_cognition_context import build_mutation_cognition_context
 from .session import ensure_session
 
 logger = logging.getLogger("orion-hub.memory_graph")
+
+
+async def _emit_approved_cards_for_crystallizer(pool, card_ids, *, settings) -> None:
+    from scripts.main import bus
+
+    for cid in card_ids:
+        card = await mc_dal.get_card(pool, str(cid))
+        if card is None:
+            continue
+        await emit_memory_card_active_for_crystallizer(
+            bus,
+            card,
+            service_name=getattr(settings, "SERVICE_NAME", "orion-hub"),
+            service_version=getattr(settings, "SERVICE_VERSION", "0.1.0"),
+            node_name=getattr(settings, "NODE_NAME", "hub"),
+        )
+
 
 router = APIRouter(tags=["memory-graph"])
 
@@ -212,6 +231,7 @@ async def memory_graph_approve(
 
     if not result.ok:
         return {"ok": False, "violations": result.violations, "card_ids": []}
+    await _emit_approved_cards_for_crystallizer(pool, result.card_ids, settings=settings)
     if consolidation_draft_id:
         consolidation_draft_marked = False
         try:

--- a/services/orion-hub/scripts/memory_routes.py
+++ b/services/orion-hub/scripts/memory_routes.py
@@ -12,8 +12,10 @@ from orion.core.contracts.memory_cards import (
     MemoryCardEdgeCreateV1,
     MemoryCardPatchV1,
     MemoryCardStatusChangeV1,
+    MemoryCardV1,
 )
 from orion.core.storage import memory_cards as mc_dal
+from orion.memory.crystallization.bus_emit_memory_card import emit_memory_card_active_for_crystallizer
 
 from .session import ensure_session
 
@@ -64,6 +66,29 @@ async def _need_session(x_orion_session_id: Optional[str]) -> str:
     return await ensure_session(x_orion_session_id, bus)
 
 
+async def _bus():
+    from .main import bus
+
+    return bus
+
+
+def _settings():
+    from scripts.settings import settings
+
+    return settings
+
+
+async def _maybe_emit_card_for_crystallizer(card: MemoryCardV1) -> None:
+    s = _settings()
+    await emit_memory_card_active_for_crystallizer(
+        await _bus(),
+        card,
+        service_name=getattr(s, "SERVICE_NAME", "orion-hub"),
+        service_version=getattr(s, "SERVICE_VERSION", "0.1.0"),
+        node_name=getattr(s, "NODE_NAME", "hub"),
+    )
+
+
 def _parse_csv(value: Optional[str]) -> Optional[List[str]]:
     if value is None or not str(value).strip():
         return None
@@ -104,6 +129,7 @@ async def memory_create_card(
     row = await mc_dal.get_card(pool, str(cid))
     if not row:
         raise HTTPException(status_code=500, detail="create_missing_row")
+    await _maybe_emit_card_for_crystallizer(row)
     return row.model_dump(mode="json")
 
 
@@ -191,6 +217,7 @@ async def memory_patch_card(
         raise HTTPException(status_code=500, detail="patch_failed") from exc
     if not updated:
         raise HTTPException(status_code=404, detail="card_not_found")
+    await _maybe_emit_card_for_crystallizer(updated)
     return updated.model_dump(mode="json")
 
 
@@ -216,6 +243,7 @@ async def memory_change_status(
         raise
     if not updated:
         raise HTTPException(status_code=404, detail="card_not_found")
+    await _maybe_emit_card_for_crystallizer(updated)
     return updated.model_dump(mode="json")
 
 


### PR DESCRIPTION
## Summary

- Add `emit_memory_card_active_for_crystallizer` and register `orion:memory:cards:active` on the bus
- Hub publishes when a memory card is **active** with `high_recall` or `always_inject` (create, patch, status change)
- Graph draft approve emits for each projected card so consolidation → approve → crystallizer inbox works without smoke scripts
- Unit tests for qualify logic and bus publish

## Outcome moved

Crystallization proposals can appear from normal operator flows (Memory tab card approve, graph draft approve) instead of requiring manual `POST /api/memory/crystallizations/propose` or smoke scripts.

## Current architecture

`orion-memory-crystallizer` subscribed to `orion:memory:cards:*` but **nothing published** to that channel — the crystallizations inbox stayed empty after real usage.

## Architecture touched

- `orion/memory/crystallization/bus_emit_memory_card.py` — producer helper
- `services/orion-hub/scripts/memory_routes.py` — emit on card lifecycle
- `services/orion-hub/scripts/memory_graph_routes.py` — emit after graph approve
- `orion/bus/channels.yaml` + `orion/schemas/registry.py` — contract registration

## Files changed

- `orion/memory/crystallization/bus_emit_memory_card.py`: new emit helper
- `orion/memory/crystallization/tests/test_bus_emit_memory_card.py`: gate tests
- `orion/bus/channels.yaml`: register `orion:memory:cards:active`
- `orion/schemas/registry.py`: register `MemoryCardV1`
- `services/orion-hub/scripts/memory_routes.py`: emit on create / patch / status→active
- `services/orion-hub/scripts/memory_graph_routes.py`: emit after graph approve

## Schema / bus / API changes

- **Added:** `orion:memory:cards:active` (`memory.card.active.v1`, payload `MemoryCardV1`)
- **Removed:** —
- **Renamed:** —
- **Behavior changed:** Hub now produces card-active events for crystallizer consumption
- **Compatibility notes:** Crystallizer already listened on `orion:memory:cards:*`; no consumer changes required

## Env/config changes

- **Added keys:** —
- **Removed keys:** —
- **Renamed keys:** —
- **`.env_example` updated:** no
- **local `.env` synced:** N/A
- **skipped keys requiring operator action:** —

## Tests run

```text
pytest orion/memory/crystallization/tests/test_bus_emit_memory_card.py -q
(UNVERIFIED locally — no pytest on host; run in CI or service venv)
```

## Evals run

```text
None — deterministic bus contract + unit tests only
```

## Docker/build/smoke checks

```text
Not run — Hub-only route wiring, no compose/Dockerfile changes
```

## Review findings fixed

- Finding: duplicate `MemoryCardV1` import in `memory_routes.py`
  - Fix: merged into single import block
  - Evidence: commit `29be2681`

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build
```

Crystallizer must have `ORION_BUS_ENABLED=true` and share Postgres with Hub (`RECALL_PG_DSN` / `POSTGRES_URI`).

## Risks / concerns

- **Severity:** low
- **Concern:** Re-approving or re-patching the same qualifying card may emit duplicate bus events
- **Mitigation:** Watch for duplicate proposals; add dedupe by `source_card_ids` if it shows up in the wild

## Wild verification (post-merge)

1. Memory → Graph drafts → Approve (cards default `active` + `high_recall`)
2. Crystallizer logs: `crystallizer_proposed_from_card`
3. Memory → Crystallizations inbox shows proposal
4. Approve crystallization → Graphiti projection on existing approve path

## PR link

https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/memory-card-crystallizer-bus-emit?expand=1