### PR TITLE
Add orion-fcc service so fcc-server no longer needs a manual terminal.

### DIFF
--- a/config/fcc.env_example
+++ b/config/fcc.env_example
@@ -1,4 +1,6 @@
 # Operator FCC secrets — copy to ~/.fcc/.env (NOT services/*/.env).
+# Mounted read-only into orion-fcc container at /root/.fcc/.env.
+# Service operator surface (port, mount path, container LLAMACPP override): services/orion-fcc/.env_example
 # Used by Hub Agent Claude AND Orion unified-turn harness (same file, two paths):
 #   Hub:     HUB_FCC_ENV_PATH      → /root/.fcc/.env in hub container
 #   Harness: HARNESS_FCC_ENV_PATH  → /root/.fcc/.env in harness-governor container
@@ -8,6 +10,8 @@
 #   Orion mode:        HARNESS_FCC_MCP_ENABLED + HARNESS_AITOWN_ENABLED (orion-harness-governor)
 
 # --- LLM gateway / FCC ---
+# Hub container uses host networking — 127.0.0.1:8210 reaches orion-llm-gateway on the host.
+LLAMACPP_BASE_URL=http://127.0.0.1:8210/v1
 ANTHROPIC_AUTH_TOKEN=
 MODEL=chat
 MODEL_SONNET=chat

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -92,6 +92,7 @@ SYNC_PREFIXES = (
     "HARNESS_FCC_",
     "HARNESS_AITOWN_",
     "HARNESS_GOVERNOR_",
+    "FCC_",
     "FINALIZE_REFLECT_",
     "VOICE_FINALIZE_",
     "SUBSTRATE_FINALIZE_",
@@ -154,6 +155,7 @@ DEFAULT_SERVICES = (
     "orion-harness-governor",
     "orion-dream",
     "orion-llm-gateway",
+    "orion-fcc",
     "orion-vector-host",
 )
 

--- a/services/orion-fcc/.env_example
+++ b/services/orion-fcc/.env_example
@@ -1,0 +1,24 @@
+# -----------------------------------------------------------------------------
+# orion-fcc — thin operator surface (ports, mounts, container networking)
+# -----------------------------------------------------------------------------
+# FCC secrets and model routing live in ONE place: ~/.fcc/.env
+# Template: config/fcc.env_example  (copy to ~/.fcc/.env — never duplicate here)
+# -----------------------------------------------------------------------------
+
+PROJECT=orion-athena
+SERVICE_NAME=fcc
+
+# Published host port (Hub host-network + harness host.docker.internal both use this)
+FCC_PORT=8082
+FCC_INTERNAL_PORT=8082
+
+# Host directory mounted read-only at /root/.fcc inside the container
+FCC_CONFIG_DIR=${HOME}/.fcc
+
+# Upstream LLM gateway as seen from inside the fcc container (overrides ~/.fcc/.env LLAMACPP_BASE_URL)
+FCC_LLAMACPP_BASE_URL=http://orion-llm-gateway:8210/v1
+
+FCC_OPEN_BROWSER=false
+FCC_LOG_FILE=/tmp/fcc-server.log
+# Set to 1 to skip gateway health wait on boot (dev only)
+# FCC_SKIP_GATEWAY_WAIT=

--- a/services/orion-fcc/Dockerfile
+++ b/services/orion-fcc/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.14-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir --upgrade pip
+
+COPY services/orion-fcc/requirements.txt ./requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY services/orion-fcc/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 8082
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["fcc-server"]

--- a/services/orion-fcc/README.md
+++ b/services/orion-fcc/README.md
@@ -1,0 +1,60 @@
+# orion-fcc
+
+Anthropic-compatible **FCC proxy** (`free-claude-code` `fcc-server`) as a managed Orion service. Hub Agent Claude and Orion harness motor both point `ANTHROPIC_BASE_URL` at this service on host port **8082**.
+
+## One secrets file — not two
+
+| File | Purpose |
+|------|---------|
+| **`~/.fcc/.env`** | **Single operator contract** — `MODEL_*`, `GITHUB_PAT`, `FIRECRAWL_API_KEY`, `AITOWN_*`, `ANTHROPIC_AUTH_TOKEN`, etc. Template: `config/fcc.env_example` |
+| **`services/orion-fcc/.env`** | **Thin service surface only** — published port, config mount path, container networking override for `LLAMACPP_BASE_URL`. **No secrets.** |
+
+`fcc-server` loads `~/.fcc/.env` from the mounted volume. Compose `environment:` vars (e.g. `FCC_LLAMACPP_BASE_URL` → `LLAMACPP_BASE_URL`) override file values **only inside the container** so bridge-network routing to `orion-llm-gateway` works without editing your secrets file.
+
+## Topology
+
+```text
+claude CLI (Hub / harness)  →  orion-fcc :8082  →  orion-llm-gateway :8210/v1  →  Atlas llama.cpp
+```
+
+Consumers:
+
+| Consumer | URL |
+|----------|-----|
+| Hub (host network) | `HUB_FCC_SERVER_URL=http://127.0.0.1:8082` |
+| Harness governor | `HARNESS_FCC_SERVER_URL=http://host.docker.internal:8082` |
+
+## Run
+
+```bash
+# 1. Operator secrets (once)
+mkdir -p ~/.fcc
+cp config/fcc.env_example ~/.fcc/.env
+# edit ~/.fcc/.env — MODEL_*, tokens, AITOWN_*, etc.
+
+# 2. Service operator surface
+cp services/orion-fcc/.env_example services/orion-fcc/.env
+
+# 3. Start (after orion-llm-gateway is up)
+docker compose \
+  --env-file services/orion-fcc/.env \
+  -f services/orion-fcc/docker-compose.yml \
+  up -d --build
+
+curl -fsS http://127.0.0.1:8082/health
+```
+
+## Env keys (service `.env` only)
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `FCC_PORT` | `8082` | Host-published port |
+| `FCC_CONFIG_DIR` | `${HOME}/.fcc` | Mount source for operator FCC config |
+| `FCC_LLAMACPP_BASE_URL` | `http://orion-llm-gateway:8210/v1` | Container upstream override |
+| `FCC_OPEN_BROWSER` | `false` | Suppress admin UI browser open |
+| `FCC_LOG_FILE` | `/tmp/fcc-server.log` | Server log path (writable; config mount stays ro) |
+
+## Health
+
+- `GET http://127.0.0.1:8082/health`
+- Admin UI (local): `http://127.0.0.1:8082/admin`

--- a/services/orion-fcc/docker-compose.yml
+++ b/services/orion-fcc/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  fcc:
+    build:
+      context: ../..
+      dockerfile: services/orion-fcc/Dockerfile
+    container_name: ${PROJECT}-fcc
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - PROJECT=${PROJECT}
+      - SERVICE_NAME=${SERVICE_NAME:-fcc}
+      - FCC_OPEN_BROWSER=${FCC_OPEN_BROWSER:-false}
+      - FCC_LOG_FILE=${FCC_LOG_FILE:-/tmp/fcc-server.log}
+      # Container-only upstream override (pydantic env beats ~/.fcc/.env). Secrets stay in ~/.fcc/.env.
+      - LLAMACPP_BASE_URL=${FCC_LLAMACPP_BASE_URL:-http://orion-llm-gateway:8210/v1}
+      - PORT=${FCC_INTERNAL_PORT:-8082}
+    volumes:
+      - ${FCC_CONFIG_DIR:-${HOME}/.fcc}:/root/.fcc:ro
+    ports:
+      - "${FCC_PORT:-8082}:${FCC_INTERNAL_PORT:-8082}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8082/health"]
+      start_period: 15s
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - app-net
+
+networks:
+  app-net:
+    external: true

--- a/services/orion-fcc/entrypoint.sh
+++ b/services/orion-fcc/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+GATEWAY_URL="${FCC_LLAMACPP_BASE_URL:-http://orion-llm-gateway:8210/v1}"
+GATEWAY_HEALTH="${GATEWAY_URL%/v1}/health"
+
+if [ -z "${FCC_SKIP_GATEWAY_WAIT:-}" ]; then
+  echo "Waiting for LLM gateway at ${GATEWAY_HEALTH} ..."
+  i=0
+  while [ "$i" -lt 60 ]; do
+    if curl -fsS --max-time 2 "$GATEWAY_HEALTH" >/dev/null 2>&1; then
+      echo "LLM gateway reachable"
+      break
+    fi
+    sleep 2
+    i=$((i + 1))
+  done
+fi
+
+export FCC_OPEN_BROWSER="${FCC_OPEN_BROWSER:-false}"
+export LOG_FILE="${FCC_LOG_FILE:-/tmp/fcc-server.log}"
+
+if [ ! -f /root/.fcc/.env ]; then
+  echo "Missing /root/.fcc/.env — mount operator config (see config/fcc.env_example)"
+  exit 1
+fi
+
+echo "Starting fcc-server on :${PORT:-8082} (secrets from mounted ~/.fcc/.env)"
+exec "$@"

--- a/services/orion-fcc/requirements.txt
+++ b/services/orion-fcc/requirements.txt
@@ -1,0 +1,2 @@
+# Installed from upstream git (not on PyPI). Pin matches Athena uv tool receipt 2.4.4.
+free-claude-code @ git+https://github.com/Alishahryar1/free-claude-code.git@763333797246357f6678c1b4c67fe18ef247c2cb

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -517,14 +517,12 @@ Bridge env keys `SOCIAL_BRIDGE_HUB_MODE` / `SOCIAL_BRIDGE_HUB_VERB` affect **Cal
 
 When `HUB_AGENT_CLAUDE_ENABLED=true`, Hub exposes **Agent Claude - Opus / Sonnet / Haiku** modes in the Mode dropdown. Each message spawns one `claude -p … --output-format stream-json` turn with `ANTHROPIC_BASE_URL` set to `HUB_FCC_SERVER_URL` (default `http://127.0.0.1:8082`). Tier selection maps to FCC env keys (`MODEL_OPUS`, `MODEL_SONNET`, `MODEL_HAIKU`). **Compute** lane is ignored for these modes.
 
-**Requirements (v1):** Hub process on host (or container with `claude` on PATH + mounted repo + mounted `~/.fcc/.env`). `fcc-server` running. Default Docker compose keeps `HUB_AGENT_CLAUDE_ENABLED=false`.
-
-**Context limits (llamacpp):** Local `MODEL_*` lanes often use `ctx_size: 65536` (`config/llm_profiles.yaml`). Multi-step repo reads can exceed that (e.g. reading all of `orion/bus/channels.yaml`). Hub passes `CLAUDE_CODE_MAX_CONTEXT_TOKENS`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS`, and `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` (see `HUB_AGENT_CLAUDE_MAX_CONTEXT_TOKENS`, `HUB_AGENT_CLAUDE_FILE_READ_MAX_TOKENS`, `HUB_AGENT_CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`) into the claude subprocess, and prepends a repo-exploration brief (`prepare_agent_claude_input`). Auto-compact triggers earlier than Claude Code default (~83%) so long repo turns summarize before hard overflow. Set `HUB_AGENT_CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=0` to omit. For deep sweeps, raise llamacpp `ctx_size`, route `~/.fcc/.env` to a larger backend, or ask narrower questions.
+**Requirements:** `claude` on PATH (Hub container mount), repo mount, `~/.fcc/.env` (see `config/fcc.env_example`), and **`orion-fcc`** running on host port **8082** (`services/orion-fcc`). Hub uses `HUB_FCC_SERVER_URL=http://127.0.0.1:8082`; Orion harness uses `HARNESS_FCC_SERVER_URL=http://host.docker.internal:8082`.
 
 **Live smoke:**
 
 ```bash
-HUB_AGENT_CLAUDE_ENABLED=true fcc-server  # separate terminal
+docker compose -f services/orion-fcc/docker-compose.yml up -d --build
 PYTHONPATH=services/orion-hub:. python services/orion-hub/scripts/verify_agent_claude_stream_live.py \
   --ws ws://127.0.0.1:8080/ws \
   --text "list files in services/orion-hub/scripts" \


### PR DESCRIPTION
## Summary

- Adds `services/orion-fcc` — a managed `free-claude-code` `fcc-server` sidecar on host port **8082**
- Operator secrets remain in **one file**: `~/.fcc/.env` (template: `config/fcc.env_example`)
- Service `.env` is thin only: port, config mount path, container `LLAMACPP_BASE_URL` override for bridge-network routing to `orion-llm-gateway`
- Hub README updated: no more manual `fcc-server` terminal prerequisite

## Outcome moved

Fixes `fcc_spawn_failed` / `Connection refused` on `:8082` for Agent Claude and Orion harness motor without a second manual process.

## Current architecture

`fcc-server` was an external binary (`uv tool install free-claude-code`) run manually in a separate terminal. Hub Agent Claude and Orion harness motor both preflight `HUB_FCC_SERVER_URL` / `HARNESS_FCC_SERVER_URL` on `:8082` before spawning `claude`.

## Architecture touched

```text
claude CLI (Hub / harness) → orion-fcc :8082 → orion-llm-gateway :8210/v1 → Atlas llama.cpp
```

| Consumer | URL |
|----------|-----|
| Hub (host network) | `HUB_FCC_SERVER_URL=http://127.0.0.1:8082` |
| Harness governor | `HARNESS_FCC_SERVER_URL=http://host.docker.internal:8082` |

## Files changed

- `services/orion-fcc/` — new service (Dockerfile, compose, entrypoint, README, `.env_example`)
- `config/fcc.env_example` — documents single secrets file + `LLAMACPP_BASE_URL`
- `services/orion-hub/README.md` — points at `orion-fcc` instead of manual `fcc-server`
- `scripts/sync_local_env_from_example.py` — adds `orion-fcc` to sync list

## Env model (not two secrets files)

| File | Purpose |
|------|---------|
| `~/.fcc/.env` | `MODEL_*`, `GITHUB_PAT`, `FIRECRAWL_API_KEY`, `AITOWN_*`, `ANTHROPIC_AUTH_TOKEN` |
| `services/orion-fcc/.env` | `FCC_PORT`, `FCC_CONFIG_DIR`, `FCC_LLAMACPP_BASE_URL` — **no secrets** |

Compose sets `LLAMACPP_BASE_URL` from `FCC_LLAMACPP_BASE_URL` inside the container so bridge-network routing to `orion-llm-gateway` works without editing `~/.fcc/.env`.

## Schema / bus / API changes

None.

## Tests run

```text
docker compose --env-file services/orion-fcc/.env -f services/orion-fcc/docker-compose.yml config  # OK
docker compose --env-file services/orion-fcc/.env -f services/orion-fcc/docker-compose.yml build  # OK (python:3.14-slim, free-claude-code @ git pin)
```

## Docker/build/smoke checks

```text
docker compose --env-file services/orion-fcc/.env -f services/orion-fcc/docker-compose.yml build  # passed
```

## Restart required

```bash
# Stop any manual fcc-server on :8082 first, then:
cp services/orion-fcc/.env_example services/orion-fcc/.env
docker compose --env-file services/orion-fcc/.env -f services/orion-fcc/docker-compose.yml up -d --build
curl -fsS http://127.0.0.1:8082/health
```

Hub and harness-governor do not need URL changes if already pointing at `:8082`.

## Risks / concerns

- **Severity:** low
- **Concern:** Port conflict if manual `fcc-server` still running on host `:8082`
- **Mitigation:** Stop manual process before `docker compose up`; healthcheck fails loudly on bind conflict

## Test plan

- [ ] Stop manual `fcc-server` if running on host `:8082`
- [ ] `docker compose -f services/orion-fcc/docker-compose.yml up -d --build`
- [ ] `curl http://127.0.0.1:8082/health` returns healthy
- [ ] Agent Claude mode in Hub completes a turn
- [ ] Orion unified turn harness no longer hits `fcc_spawn_failed`