### PR TITLE
Feat/drive attribution substrate act v1.1

### DIFF
--- a/orion/autonomy/models.py
+++ b/orion/autonomy/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
@@ -166,6 +167,23 @@ class MetabolismResultV1(BaseModel):
     drive_deltas: dict[str, float] = Field(default_factory=dict)
     tensions: list[TensionEventV1] = Field(default_factory=list)
     curiosity_signals: list[FrontierInvocationSignalV1] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SubstrateEpisodeIntentV1:
+    goal_artifact_id: str
+    drive_origin: str
+    spawned_correlation_id: str
+    subject: str
+
+
+class SubstrateActResultV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    fetch_attempted: bool = False
+    journal_attempted: bool = False
+    fetch_outcome_id: str | None = None
+    journal_entry_id: str | None = None
 
 
 class AutonomyStateDeltaV1(BaseModel):

--- a/orion/autonomy/policy_act.py
+++ b/orion/autonomy/policy_act.py
@@ -5,7 +5,7 @@ from typing import Any, Awaitable, Callable, Sequence
 
 from orion.autonomy.capability_policy import CapabilityEvaluationContext, evaluate_capability
 from orion.autonomy.episode_fetch import EpisodeFetchRequest, execute_readonly_fetch
-from orion.autonomy.models import ActionOutcomeRefV1, CapabilityDecisionV1
+from orion.autonomy.models import ActionOutcomeRefV1, CapabilityDecisionV1, SubstrateActResultV1, SubstrateEpisodeIntentV1
 from orion.core.schemas.drives import DriveStateV1, GoalProposalV1
 from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
 
@@ -166,3 +166,90 @@ async def maybe_compose_autonomy_episode_after_fetch(
     if budget_used is not None:
         budget_used[_EPISODE_JOURNAL_CAPABILITY] = budget_used.get(_EPISODE_JOURNAL_CAPABILITY, 0) + 1
     return decision, result
+
+
+def resolve_episode_intent(
+    *,
+    store,
+    subject: str,
+    run_id: str,
+    drive_origin: str = "predictive",
+) -> SubstrateEpisodeIntentV1:
+    slot = store.load_goal_slot(subject, drive_origin)
+    artifact_id = slot.get("artifact_id") if isinstance(slot, dict) else None
+    if isinstance(artifact_id, str) and artifact_id.strip():
+        return SubstrateEpisodeIntentV1(
+            goal_artifact_id=artifact_id.strip(),
+            drive_origin=drive_origin,
+            spawned_correlation_id=run_id,
+            subject=subject,
+        )
+    return SubstrateEpisodeIntentV1(
+        goal_artifact_id=f"episode-{run_id}",
+        drive_origin="predictive",
+        spawned_correlation_id=run_id,
+        subject=subject,
+    )
+
+
+def goal_proposal_from_episode_intent(intent: SubstrateEpisodeIntentV1) -> GoalProposalV1:
+    return GoalProposalV1.model_validate(
+        {
+            "artifact_id": intent.goal_artifact_id,
+            "subject": intent.subject,
+            "model_layer": "self-model",
+            "entity_id": f"self:{intent.subject}",
+            "kind": "memory.goals.proposed.v1",
+            "goal_statement": "Substrate episode intent (synthetic goal for policy).",
+            "proposal_signature": f"episode-{intent.spawned_correlation_id}",
+            "drive_origin": intent.drive_origin,
+            "proposal_status": "proposed",
+            "provenance": {"intake_channel": "orion:world_pulse:run:result"},
+        }
+    )
+
+
+async def maybe_execute_substrate_act_after_metabolism(
+    *,
+    episode_intent: SubstrateEpisodeIntentV1,
+    drive_state: DriveStateV1,
+    curiosity_signals: Sequence[FrontierInvocationSignalV1],
+    spawned_correlation_id: str | None = None,
+    fetch_backend: Callable[..., Awaitable[dict]] | None = None,
+    journal_dispatch: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+    budget_used: dict[str, int] | None = None,
+    episode_journal_enabled: bool = False,
+) -> SubstrateActResultV1:
+    run_id = spawned_correlation_id or episode_intent.spawned_correlation_id
+    synthetic_goal = goal_proposal_from_episode_intent(episode_intent)
+    result = SubstrateActResultV1()
+
+    fetch_decision, fetch_outcome = await maybe_execute_readonly_fetch_after_goal(
+        goal=synthetic_goal,
+        drive_state=drive_state,
+        curiosity_signals=curiosity_signals,
+        spawned_correlation_id=run_id,
+        fetch_backend=fetch_backend,
+        budget_used=budget_used,
+    )
+    if fetch_decision.outcome == "allowed" and fetch_outcome is not None:
+        result = result.model_copy(update={"fetch_attempted": True, "fetch_outcome_id": fetch_outcome.action_id})
+
+    if not episode_journal_enabled or fetch_outcome is None:
+        return result
+
+    journal_decision, journal_payload = await maybe_compose_autonomy_episode_after_fetch(
+        goal=synthetic_goal,
+        drive_state=drive_state,
+        curiosity_signals=curiosity_signals,
+        spawned_correlation_id=run_id,
+        fetch_outcome=fetch_outcome,
+        journal_dispatch=journal_dispatch,
+        budget_used=budget_used,
+    )
+    if journal_decision.outcome == "allowed" and journal_payload is not None:
+        entry_id = None
+        if isinstance(journal_payload.get("write"), dict):
+            entry_id = journal_payload["write"].get("entry_id")
+        result = result.model_copy(update={"journal_attempted": True, "journal_entry_id": entry_id})
+    return result

--- a/orion/autonomy/tests/test_policy_act.py
+++ b/orion/autonomy/tests/test_policy_act.py
@@ -6,12 +6,14 @@ from uuid import uuid4
 
 import pytest
 
+from orion.autonomy.models import ActionOutcomeRefV1, SubstrateEpisodeIntentV1
 from orion.autonomy.policy_act import (
     build_readonly_fetch_query,
     maybe_compose_autonomy_episode_after_fetch,
     maybe_execute_readonly_fetch_after_goal,
+    maybe_execute_substrate_act_after_metabolism,
+    resolve_episode_intent,
 )
-from orion.autonomy.models import ActionOutcomeRefV1
 from orion.core.schemas.drives import DriveStateV1, GoalProposalV1
 from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
 
@@ -182,3 +184,62 @@ async def test_policy_act_composes_episode_journal_on_fetch_failure(monkeypatch)
     assert decision.outcome == "allowed"
     assert result is not None
     assert "fetch failed" in journal_dispatch.await_args.kwargs["narrative_seed"]
+
+
+def _intent() -> SubstrateEpisodeIntentV1:
+    return SubstrateEpisodeIntentV1(
+        goal_artifact_id="episode-wp-run-gap-gpu",
+        drive_origin="predictive",
+        spawned_correlation_id="wp-run-gap-gpu",
+        subject="orion",
+    )
+
+
+class _FakeStore:
+    def __init__(self, slot: dict | None = None) -> None:
+        self._slot = slot or {}
+
+    def load_goal_slot(self, subject: str, drive_origin: str) -> dict:
+        return dict(self._slot)
+
+
+def test_resolve_episode_intent_uses_predictive_slot() -> None:
+    store = _FakeStore({"artifact_id": "goal-predictive-slot", "signature": "sig"})
+    intent = resolve_episode_intent(store=store, subject="orion", run_id="wp-run-1")
+    assert intent.goal_artifact_id == "goal-predictive-slot"
+    assert intent.drive_origin == "predictive"
+
+
+def test_resolve_episode_intent_synthetic_when_slot_empty() -> None:
+    intent = resolve_episode_intent(store=_FakeStore(), subject="orion", run_id="wp-run-1")
+    assert intent.goal_artifact_id == "episode-wp-run-1"
+    assert intent.spawned_correlation_id == "wp-run-1"
+
+
+@pytest.mark.asyncio
+async def test_substrate_act_runs_when_goal_suppressed(monkeypatch, tmp_path) -> None:
+    """Spec acceptance 4: proposal=None path still executes fetch."""
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    backend = AsyncMock(return_value={"success": True, "urls": ["https://example.com/a"]})
+    result = await maybe_execute_substrate_act_after_metabolism(
+        episode_intent=_intent(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        fetch_backend=backend,
+    )
+    assert result.fetch_attempted is True
+    backend.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_substrate_act_denied_without_gap_signal(monkeypatch) -> None:
+    """Spec acceptance 5."""
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    result = await maybe_execute_substrate_act_after_metabolism(
+        episode_intent=_intent(),
+        drive_state=_drive_state(),
+        curiosity_signals=[],
+        fetch_backend=AsyncMock(),
+    )
+    assert result.fetch_attempted is False

--- a/orion/autonomy/tests/test_substrate_act_models.py
+++ b/orion/autonomy/tests/test_substrate_act_models.py
@@ -1,0 +1,17 @@
+from orion.autonomy.models import SubstrateActResultV1, SubstrateEpisodeIntentV1
+
+
+def test_substrate_episode_intent_v1_fields() -> None:
+    intent = SubstrateEpisodeIntentV1(
+        goal_artifact_id="episode-wp-run-1",
+        drive_origin="predictive",
+        spawned_correlation_id="wp-run-1",
+        subject="orion",
+    )
+    assert intent.drive_origin == "predictive"
+    assert intent.spawned_correlation_id == "wp-run-1"
+
+
+def test_substrate_act_result_v1_optional_outcomes() -> None:
+    result = SubstrateActResultV1(fetch_attempted=True, journal_attempted=False)
+    assert result.fetch_attempted is True

--- a/orion/core/schemas/drives.py
+++ b/orion/core/schemas/drives.py
@@ -104,6 +104,7 @@ class DriveAuditV1(GraphReadyArtifact):
     drive_activations: Dict[str, bool] = Field(default_factory=dict)
     active_drives: List[str] = Field(default_factory=list)
     dominant_drive: Optional[str] = None
+    tick_attribution: Dict[str, float] = Field(default_factory=dict)
     tension_kinds: List[str] = Field(default_factory=list)
     source_event_refs: List[ArtifactEventRef] = Field(default_factory=list)
     evidence_items: List[ArtifactEvidence] = Field(default_factory=list)

--- a/orion/spark/concept_induction/audit.py
+++ b/orion/spark/concept_induction/audit.py
@@ -19,11 +19,23 @@ def build_drive_audit(
     intake_channel: str,
     drive_state: DriveStateV1,
     tensions: Iterable[TensionEventV1],
+    tick_attribution: dict[str, float] | None = None,
+    dominant_drive: str | None = None,
 ) -> DriveAuditV1:
     tension_list = list(tensions)
-    dominant_drive = None
-    if drive_state.pressures:
-        dominant_drive = max(sorted(drive_state.pressures), key=lambda key: drive_state.pressures.get(key, 0.0))
+    if dominant_drive is None:
+        if tick_attribution:
+            from .drive_attribution import dominant_drive_from_attribution, select_lead_tension
+
+            dominant_drive = dominant_drive_from_attribution(
+                tick_attribution,
+                lead_tension=select_lead_tension(tension_list),
+            )
+        elif drive_state.pressures:
+            dominant_drive = max(
+                sorted(drive_state.pressures),
+                key=lambda key: drive_state.pressures.get(key, 0.0),
+            )
     active_drives = [key for key, active in sorted(drive_state.activations.items()) if active]
     evidence_items = build_evidence_items(env, intake_channel, drive_state.provenance.evidence_text)
     source_event_ref = build_source_event_ref(env, intake_channel)
@@ -53,6 +65,7 @@ def build_drive_audit(
         drive_activations=drive_state.activations,
         active_drives=active_drives,
         dominant_drive=dominant_drive,
+        tick_attribution=dict(tick_attribution or {}),
         tension_kinds=tension_kinds,
         source_event_refs=[source_event_ref],
         evidence_items=evidence_items,

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -27,8 +27,8 @@ from orion.autonomy.episode_journal import dispatch_autonomy_episode_journal
 from orion.autonomy.fetch_backend_resolve import resolve_fetch_backend
 from orion.autonomy.goal_archive import maybe_archive_after_goal_publish
 from orion.autonomy.policy_act import (
-    maybe_compose_autonomy_episode_after_fetch,
-    maybe_execute_readonly_fetch_after_goal,
+    maybe_execute_substrate_act_after_metabolism,
+    resolve_episode_intent,
 )
 from orion.autonomy.substrate_metabolism import metabolize_substrate_signals, metabolism_enabled
 from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
@@ -675,53 +675,42 @@ class ConceptWorker:
             await self._publish_artifact(goal_decision.proposal, self.cfg.goal_proposal_channel, env.correlation_id)
             published_artifacts.append(goal_decision.proposal)
             maybe_archive_after_goal_publish(subject=subject)
-            if (
-                env.kind == "world.pulse.run.result.v1"
-                and metabolism_enabled()
-                and metabolism_curiosity_signals
-            ):
-                policy_budget: dict[str, int] = {}
-                fetch_outcome = None
-                try:
-                    _fetch_decision, fetch_outcome = await maybe_execute_readonly_fetch_after_goal(
-                        goal=goal_decision.proposal,
-                        drive_state=drive_state,
-                        curiosity_signals=metabolism_curiosity_signals,
-                        spawned_correlation_id=spawned_correlation_id,
-                        fetch_backend=self._fetch_backend,
-                        budget_used=policy_budget,
-                    )
-                except Exception:
-                    logger.warning(
-                        "substrate_policy_fetch_failed goal=%s spawned=%s",
-                        goal_decision.proposal.artifact_id,
-                        spawned_correlation_id,
-                        exc_info=True,
-                    )
-                if fetch_outcome is not None and self.cfg.autonomy_episode_journal_enabled:
-                    try:
-
-                        async def _journal_dispatch(**kwargs):
-                            return await self._dispatch_autonomy_episode_journal(env, **kwargs)
-
-                        await maybe_compose_autonomy_episode_after_fetch(
-                            goal=goal_decision.proposal,
-                            drive_state=drive_state,
-                            curiosity_signals=metabolism_curiosity_signals,
-                            spawned_correlation_id=spawned_correlation_id,
-                            fetch_outcome=fetch_outcome,
-                            budget_used=policy_budget,
-                            journal_dispatch=_journal_dispatch,
-                        )
-                    except Exception:
-                        logger.warning(
-                            "substrate_policy_journal_failed goal=%s spawned=%s",
-                            goal_decision.proposal.artifact_id,
-                            spawned_correlation_id,
-                            exc_info=True,
-                        )
         elif goal_decision.suppressed_signature:
             suppressed_signatures.append(goal_decision.suppressed_signature)
+
+        if (
+            env.kind == "world.pulse.run.result.v1"
+            and metabolism_enabled()
+            and metabolism_curiosity_signals
+            and spawned_correlation_id
+        ):
+            policy_budget: dict[str, int] = {}
+            try:
+
+                async def _journal_dispatch(**kwargs):
+                    return await self._dispatch_autonomy_episode_journal(env, **kwargs)
+
+                await maybe_execute_substrate_act_after_metabolism(
+                    episode_intent=resolve_episode_intent(
+                        store=self.store,
+                        subject=subject,
+                        run_id=spawned_correlation_id,
+                    ),
+                    drive_state=drive_state,
+                    curiosity_signals=metabolism_curiosity_signals,
+                    spawned_correlation_id=spawned_correlation_id,
+                    fetch_backend=self._fetch_backend,
+                    journal_dispatch=_journal_dispatch,
+                    budget_used=policy_budget,
+                    episode_journal_enabled=self.cfg.autonomy_episode_journal_enabled,
+                )
+            except Exception:
+                logger.warning(
+                    "substrate_act_after_metabolism_failed subject=%s spawned=%s",
+                    subject,
+                    spawned_correlation_id,
+                    exc_info=True,
+                )
 
         dossier = build_turn_dossier(
             env=env,

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -16,6 +16,11 @@ from orion.schemas.self_state import SelfStateV1
 from orion.schemas.vector.schemas import VectorWriteRequest
 
 from .audit import build_drive_audit
+from .drive_attribution import (
+    compute_tick_attribution,
+    dominant_drive_from_attribution,
+    select_lead_tension,
+)
 from .drives import DriveEngine, DriveMathConfig, drive_state_from_values
 from .dossier import build_evidence_items, build_source_event_ref, build_turn_dossier, extract_trace_id, extract_turn_id
 from orion.autonomy.episode_journal import dispatch_autonomy_episode_journal
@@ -533,6 +538,7 @@ class ConceptWorker:
             published_artifacts.append(tension)
 
         metabolism_tensions: List[TensionEventV1] = []
+        metabolism_drive_deltas: dict[str, float] = {}
         metabolism_curiosity_signals: List[FrontierInvocationSignalV1] = []
         metabolism_curiosity_notes: List[str] = []
         spawned_correlation_id: str | None = None
@@ -543,6 +549,7 @@ class ConceptWorker:
                 if metabolism_enabled():
                     metabolism = metabolize_substrate_signals(world_pulse_result=wp_result)
                     metabolism_tensions = list(metabolism.tensions)
+                    metabolism_drive_deltas = dict(metabolism.drive_deltas)
                     metabolism_curiosity_signals = list(metabolism.curiosity_signals)
                     metabolism_curiosity_notes = [
                         str(sig.evidence_summary or "").strip()
@@ -618,7 +625,23 @@ class ConceptWorker:
         )
         await self._publish_drive_state(drive_state, env.correlation_id)
 
-        drive_audit = build_drive_audit(env=env, intake_channel=intake_channel, drive_state=drive_state, tensions=all_tensions)
+        tick_attribution = compute_tick_attribution(
+            all_tensions,
+            metabolism_deltas=metabolism_drive_deltas or None,
+        )
+        lead_tension = select_lead_tension(all_tensions)
+        dominant_drive = dominant_drive_from_attribution(
+            tick_attribution,
+            lead_tension=lead_tension,
+        )
+        drive_audit = build_drive_audit(
+            env=env,
+            intake_channel=intake_channel,
+            drive_state=drive_state,
+            tensions=all_tensions,
+            tick_attribution=tick_attribution,
+            dominant_drive=dominant_drive,
+        )
         await self._publish_artifact(drive_audit, self.cfg.drive_audit_channel, env.correlation_id)
         published_artifacts.append(drive_audit)
 

--- a/orion/spark/concept_induction/drive_attribution.py
+++ b/orion/spark/concept_induction/drive_attribution.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from typing import Sequence
 
 from orion.core.schemas.drives import TensionEventV1
+from orion.spark.concept_induction.drives import DRIVE_KEYS
 from orion.spark.concept_induction.tensions import clamp01
-
-DRIVE_KEYS = ("coherence", "continuity", "capability", "relational", "predictive", "autonomy")
 
 _GAP_KIND = "substrate.world_coverage_gap"
 
@@ -63,7 +62,13 @@ def dominant_drive_from_attribution(
     *,
     lead_tension: TensionEventV1 | None = None,
 ) -> str | None:
-    """Argmax attribution; tie-break via primary_drive(lead_tension.kind)."""
+    """Argmax attribution; tie-break cascade when multiple drives share the max.
+
+    1. If ``lead_tension`` is set: ``primary_drive_for_tension_kind(lead_tension.kind)`` when
+       that drive is among the tied maxima.
+    2. Else among tied drives: highest ``lead_tension.drive_impacts`` weight (alphabetical on tie).
+    3. Else: first tied drive in alphabetical order (``lead_tension`` absent or inconclusive).
+    """
     tied = _tied_at_max(attribution)
     if not tied:
         return None

--- a/orion/spark/concept_induction/drive_attribution.py
+++ b/orion/spark/concept_induction/drive_attribution.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from orion.core.schemas.drives import TensionEventV1
+from orion.spark.concept_induction.tensions import clamp01
+
+DRIVE_KEYS = ("coherence", "continuity", "capability", "relational", "predictive", "autonomy")
+
+_GAP_KIND = "substrate.world_coverage_gap"
+
+_PRIMARY_DRIVE_BY_KIND: dict[str, str] = {
+    _GAP_KIND: "predictive",
+    "tension.contradiction.v1": "coherence",
+    "tension.distress.v1": "relational",
+    "tension.identity_drift.v1": "continuity",
+    "tension.cognitive_load.v1": "capability",
+}
+
+
+def compute_tick_attribution(
+    tensions: Sequence[TensionEventV1],
+    *,
+    metabolism_deltas: dict[str, float] | None = None,
+) -> dict[str, float]:
+    """Sum magnitude × drive_impact weight per drive for THIS tick only."""
+    attribution: dict[str, float] = {key: 0.0 for key in DRIVE_KEYS}
+    for tension in tensions:
+        mag = clamp01(tension.magnitude)
+        for drive, weight in (tension.drive_impacts or {}).items():
+            if drive not in attribution:
+                continue
+            attribution[drive] += mag * clamp01(float(weight))
+    for drive, delta in (metabolism_deltas or {}).items():
+        if drive in attribution:
+            attribution[drive] += float(delta)
+    return attribution
+
+
+def primary_drive_for_tension_kind(
+    kind: str,
+    *,
+    drive_impacts: dict[str, float] | None = None,
+) -> str | None:
+    """Structural map for tie-break; not digest keyword matching."""
+    if kind == "tension.drive_competition.v1" and drive_impacts:
+        ranked = sorted(drive_impacts.items(), key=lambda item: (-float(item[1]), item[0]))
+        return ranked[0][0] if ranked else None
+    return _PRIMARY_DRIVE_BY_KIND.get(kind)
+
+
+def _tied_at_max(attribution: dict[str, float]) -> list[str]:
+    if not attribution:
+        return []
+    max_val = max(attribution.values())
+    if max_val <= 0.0:
+        return []
+    return sorted([drive for drive, val in attribution.items() if val == max_val])
+
+
+def dominant_drive_from_attribution(
+    attribution: dict[str, float],
+    *,
+    lead_tension: TensionEventV1 | None = None,
+) -> str | None:
+    """Argmax attribution; tie-break via primary_drive(lead_tension.kind)."""
+    tied = _tied_at_max(attribution)
+    if not tied:
+        return None
+    if len(tied) == 1:
+        return tied[0]
+
+    if lead_tension is not None:
+        primary = primary_drive_for_tension_kind(
+            lead_tension.kind,
+            drive_impacts=lead_tension.drive_impacts,
+        )
+        if primary and primary in tied:
+            return primary
+        impacts = lead_tension.drive_impacts or {}
+        ranked = sorted(
+            ((drive, float(impacts.get(drive, 0.0))) for drive in tied),
+            key=lambda item: (-item[1], item[0]),
+        )
+        if ranked and ranked[0][1] > 0.0:
+            return ranked[0][0]
+
+    return tied[0]
+
+
+def select_lead_tension(tensions: Sequence[TensionEventV1]) -> TensionEventV1 | None:
+    """Highest magnitude this tick; substrate gap preferred on magnitude tie."""
+    if not tensions:
+        return None
+
+    def _sort_key(t: TensionEventV1) -> tuple[float, int, str]:
+        gap_bias = 1 if t.kind == _GAP_KIND else 0
+        return (-float(t.magnitude), -gap_bias, t.kind)
+
+    return sorted(tensions, key=_sort_key)[0]

--- a/orion/spark/concept_induction/goals.py
+++ b/orion/spark/concept_induction/goals.py
@@ -32,13 +32,21 @@ class GoalProposalEngine:
         self.cooldown = timedelta(minutes=max(0, cooldown_minutes))
 
     @staticmethod
+    def _normalize_drive_origin_source(source: str) -> str:
+        normalized = source.strip().lower()
+        if normalized == "audit_dominant":
+            return "tick_attribution"
+        return normalized
+
+    @staticmethod
     def _drive_origin(
         drive_state: DriveStateV1,
         *,
         dominant_drive: str | None = None,
         source: str = "pressures",
     ) -> str:
-        if source == "audit_dominant" and dominant_drive:
+        normalized_source = GoalProposalEngine._normalize_drive_origin_source(source)
+        if normalized_source == "tick_attribution" and dominant_drive:
             return dominant_drive.strip().lower()
         if not drive_state.pressures:
             return "continuity"

--- a/orion/spark/concept_induction/settings.py
+++ b/orion/spark/concept_induction/settings.py
@@ -129,7 +129,7 @@ class ConceptSettings(BaseSettings):
     drive_activation_off: float = Field(0.42, alias="DRIVE_ACTIVATION_OFF")
     goal_proposal_cooldown_minutes: int = Field(180, alias="GOAL_PROPOSAL_COOLDOWN_MINUTES")
     goal_generation_mode: str = Field("evidence_rules", alias="GOAL_GENERATION_MODE")
-    goal_drive_origin_source: str = Field("audit_dominant", alias="GOAL_DRIVE_ORIGIN_SOURCE")
+    goal_drive_origin_source: str = Field("tick_attribution", alias="GOAL_DRIVE_ORIGIN_SOURCE")
     substrate_autonomy_metabolism_enabled: bool = Field(
         False,
         alias="ORION_SUBSTRATE_AUTONOMY_METABOLISM_ENABLED",

--- a/orion/spark/concept_induction/tests/test_drive_attribution.py
+++ b/orion/spark/concept_induction/tests/test_drive_attribution.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.core.schemas.drives import TensionEventV1
+from orion.spark.concept_induction.drive_attribution import (
+    DRIVE_KEYS,
+    compute_tick_attribution,
+    dominant_drive_from_attribution,
+    select_lead_tension,
+)
+
+
+def _gap_tension() -> TensionEventV1:
+    return TensionEventV1.model_validate(
+        {
+            "artifact_id": "tension-gap-gpu",
+            "subject": "orion",
+            "model_layer": "self-model",
+            "entity_id": "self:orion",
+            "kind": "substrate.world_coverage_gap",
+            "magnitude": 0.65,
+            "drive_impacts": {"predictive": 0.15},
+            "provenance": {"intake_channel": "orion:world_pulse:run:result"},
+        }
+    )
+
+
+def _contradiction_tension() -> TensionEventV1:
+    return TensionEventV1.model_validate(
+        {
+            "artifact_id": "tension-coh",
+            "subject": "orion",
+            "model_layer": "self-model",
+            "entity_id": "self:orion",
+            "kind": "tension.contradiction.v1",
+            "magnitude": 0.5,
+            "drive_impacts": {"coherence": 0.4, "autonomy": 0.4},
+            "provenance": {"intake_channel": "orion:metacognition:tick"},
+        }
+    )
+
+
+def test_attribution_gpu_gap_predictive_dominant() -> None:
+    """Spec acceptance 1: saturated pressures irrelevant; gap → predictive."""
+    gap = _gap_tension()
+    attribution = compute_tick_attribution(
+        [gap],
+        metabolism_deltas={"predictive": 0.15},
+    )
+    dominant = dominant_drive_from_attribution(attribution, lead_tension=gap)
+    assert dominant == "predictive"
+    assert attribution["predictive"] > attribution.get("autonomy", 0.0)
+
+
+def test_attribution_no_alphabetical_autonomy() -> None:
+    """Spec acceptance 2: equal attribution ties break on lead tension kind, not 'autonomy'."""
+    tension = _contradiction_tension()
+    attribution = {key: 0.1 for key in DRIVE_KEYS}
+    dominant = dominant_drive_from_attribution(attribution, lead_tension=tension)
+    assert dominant == "coherence"
+    assert dominant != "autonomy"
+
+
+def test_metabolism_deltas_merge_into_attribution() -> None:
+    """Spec acceptance 3: drive_deltas alone shift dominance when tensions empty."""
+    attribution = compute_tick_attribution([], metabolism_deltas={"predictive": 0.2})
+    dominant = dominant_drive_from_attribution(attribution, lead_tension=None)
+    assert dominant == "predictive"
+    assert attribution["predictive"] == 0.2
+
+
+def test_select_lead_tension_prefers_gap_on_magnitude_tie() -> None:
+    gap = _gap_tension()
+    other = _contradiction_tension().model_copy(update={"magnitude": gap.magnitude})
+    lead = select_lead_tension([other, gap])
+    assert lead is not None
+    assert lead.kind == "substrate.world_coverage_gap"

--- a/orion/spark/concept_induction/tests/test_drive_attribution.py
+++ b/orion/spark/concept_induction/tests/test_drive_attribution.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 from orion.core.schemas.drives import TensionEventV1
 from orion.spark.concept_induction.drive_attribution import (
     DRIVE_KEYS,
@@ -76,3 +74,27 @@ def test_select_lead_tension_prefers_gap_on_magnitude_tie() -> None:
     lead = select_lead_tension([other, gap])
     assert lead is not None
     assert lead.kind == "substrate.world_coverage_gap"
+
+
+def test_dominant_drive_none_when_all_zero() -> None:
+    attribution = {key: 0.0 for key in DRIVE_KEYS}
+    assert dominant_drive_from_attribution(attribution, lead_tension=None) is None
+
+
+def test_dominant_drive_alphabetical_fallback_without_lead() -> None:
+    attribution = {key: 0.2 for key in DRIVE_KEYS}
+    dominant = dominant_drive_from_attribution(attribution, lead_tension=None)
+    assert dominant == "autonomy"
+
+
+def test_select_lead_tension_empty() -> None:
+    assert select_lead_tension([]) is None
+
+
+def test_select_lead_tension_highest_magnitude() -> None:
+    gap = _gap_tension()
+    other = _contradiction_tension()
+    lead = select_lead_tension([other, gap])
+    assert lead is not None
+    assert lead.kind == gap.kind
+    assert lead.magnitude >= other.magnitude

--- a/orion/spark/concept_induction/tests/test_drive_attribution.py
+++ b/orion/spark/concept_induction/tests/test_drive_attribution.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from orion.core.schemas.drives import DriveAuditV1, TensionEventV1
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.schemas.drives import DriveAuditV1, DriveStateV1, TensionEventV1
+from orion.spark.concept_induction.audit import build_drive_audit
 from orion.spark.concept_induction.drive_attribution import (
     DRIVE_KEYS,
     compute_tick_attribution,
@@ -113,4 +118,39 @@ def test_drive_audit_v1_accepts_tick_attribution() -> None:
         }
     )
     assert audit.tick_attribution["predictive"] == 0.25
+    assert audit.dominant_drive == "predictive"
+
+
+def test_audit_emits_tick_attribution() -> None:
+    """Spec acceptance 6."""
+    gap = _gap_tension()
+    env = BaseEnvelope(
+        kind="world.pulse.run.result.v1",
+        source=ServiceRef(name="test", version="0"),
+        correlation_id=uuid4(),
+        payload={},
+    )
+    drive_state = DriveStateV1.model_validate(
+        {
+            "subject": "orion",
+            "model_layer": "self-model",
+            "entity_id": "self:orion",
+            "kind": "memory.drives.state.v1",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "pressures": {k: 0.73 for k in DRIVE_KEYS},
+            "activations": {k: True for k in DRIVE_KEYS},
+            "provenance": {"intake_channel": "orion:world_pulse:run:result"},
+        }
+    )
+    attribution = compute_tick_attribution([gap], metabolism_deltas={"predictive": 0.15})
+    dominant = dominant_drive_from_attribution(attribution, lead_tension=gap)
+    audit = build_drive_audit(
+        env=env,
+        intake_channel="orion:world_pulse:run:result",
+        drive_state=drive_state,
+        tensions=[gap],
+        tick_attribution=attribution,
+        dominant_drive=dominant,
+    )
+    assert audit.tick_attribution["predictive"] > 0.0
     assert audit.dominant_drive == "predictive"

--- a/orion/spark/concept_induction/tests/test_drive_attribution.py
+++ b/orion/spark/concept_induction/tests/test_drive_attribution.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from orion.core.schemas.drives import TensionEventV1
+from orion.core.schemas.drives import DriveAuditV1, TensionEventV1
 from orion.spark.concept_induction.drive_attribution import (
     DRIVE_KEYS,
     compute_tick_attribution,
@@ -98,3 +98,19 @@ def test_select_lead_tension_highest_magnitude() -> None:
     assert lead is not None
     assert lead.kind == gap.kind
     assert lead.magnitude >= other.magnitude
+
+
+def test_drive_audit_v1_accepts_tick_attribution() -> None:
+    audit = DriveAuditV1.model_validate(
+        {
+            "subject": "orion",
+            "model_layer": "self-model",
+            "entity_id": "self:orion",
+            "kind": "memory.drives.audit.v1",
+            "dominant_drive": "predictive",
+            "tick_attribution": {"predictive": 0.25, "autonomy": 0.1},
+            "provenance": {"intake_channel": "orion:world_pulse:run:result"},
+        }
+    )
+    assert audit.tick_attribution["predictive"] == 0.25
+    assert audit.dominant_drive == "predictive"

--- a/orion/spark/concept_induction/tests/test_goals.py
+++ b/orion/spark/concept_induction/tests/test_goals.py
@@ -89,14 +89,13 @@ def _drive_state(trace_id: str) -> DriveStateV1:
     })
 
 
-def test_drive_origin_from_audit_dominant():
-    engine = GoalProposalEngine(cooldown_minutes=0)
-    drive_state = DriveStateV1.model_validate({
+def _drive_state_with_pressures(pressures: dict[str, float]) -> DriveStateV1:
+    return DriveStateV1.model_validate({
         "subject": "orion",
         "model_layer": "self-model",
         "entity_id": "self:orion",
         "kind": "memory.drives.state.v1",
-        "pressures": {"autonomy": 0.95, "relational": 0.4},
+        "pressures": pressures,
         "activations": {},
         "updated_at": datetime.now(timezone.utc),
         "provenance": {
@@ -106,8 +105,28 @@ def test_drive_origin_from_audit_dominant():
             "tension_refs": [],
         },
     })
+
+
+def test_drive_origin_from_audit_dominant():
+    engine = GoalProposalEngine(cooldown_minutes=0)
+    drive_state = _drive_state_with_pressures({"autonomy": 0.95, "relational": 0.4})
     origin = engine._drive_origin(drive_state, dominant_drive="relational", source="audit_dominant")
     assert origin == "relational"
+
+
+def test_drive_origin_from_tick_attribution_dominant():
+    engine = GoalProposalEngine(cooldown_minutes=0)
+    drive_state = _drive_state_with_pressures({"autonomy": 0.95, "relational": 0.4})
+    origin = engine._drive_origin(drive_state, dominant_drive="relational", source="tick_attribution")
+    assert origin == "relational"
+
+
+def test_audit_dominant_alias_maps_to_tick_attribution():
+    engine = GoalProposalEngine(cooldown_minutes=0)
+    drive_state = _drive_state_with_pressures({"autonomy": 0.95, "relational": 0.4})
+    tick_origin = engine._drive_origin(drive_state, dominant_drive="Relational", source="tick_attribution")
+    audit_origin = engine._drive_origin(drive_state, dominant_drive="Relational", source="audit_dominant")
+    assert tick_origin == audit_origin == "relational"
 
 
 def test_signature_stable_when_trace_changes():

--- a/orion/spark/concept_induction/tests/test_metabolism_hook.py
+++ b/orion/spark/concept_induction/tests/test_metabolism_hook.py
@@ -135,16 +135,10 @@ async def test_metabolism_enriches_goal_window_summary(monkeypatch) -> None:
 async def test_policy_fetch_runs_after_goal_publish(monkeypatch) -> None:
     monkeypatch.setenv("ORION_SUBSTRATE_AUTONOMY_METABOLISM_ENABLED", "true")
     monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
-    episode_mock = AsyncMock(return_value=(MagicMock(outcome="allowed", auto_execute=True), {"write": {}}))
-    fetch_outcome = MagicMock(success=True)
-    policy_mock = AsyncMock(return_value=(MagicMock(outcome="allowed", auto_execute=True), fetch_outcome))
+    substrate_act_mock = AsyncMock(return_value=MagicMock(fetch_attempted=True))
     monkeypatch.setattr(
-        "orion.spark.concept_induction.bus_worker.maybe_execute_readonly_fetch_after_goal",
-        policy_mock,
-    )
-    monkeypatch.setattr(
-        "orion.spark.concept_induction.bus_worker.maybe_compose_autonomy_episode_after_fetch",
-        episode_mock,
+        "orion.spark.concept_induction.bus_worker.maybe_execute_substrate_act_after_metabolism",
+        substrate_act_mock,
     )
     cfg = ConceptSettings()
     cfg.autonomy_episode_journal_enabled = True
@@ -174,8 +168,35 @@ async def test_policy_fetch_runs_after_goal_publish(monkeypatch) -> None:
 
     await worker.handle_envelope(_world_pulse_envelope(), "orion:world_pulse:run:result")
 
-    policy_mock.assert_awaited_once()
-    call_kwargs = policy_mock.await_args.kwargs
+    substrate_act_mock.assert_awaited_once()
+    call_kwargs = substrate_act_mock.await_args.kwargs
     assert call_kwargs["spawned_correlation_id"] == "wp-run-hook"
-    assert call_kwargs["goal"] is proposal
-    episode_mock.assert_awaited_once()
+    assert call_kwargs["episode_journal_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_substrate_act_runs_when_goal_suppressed(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_SUBSTRATE_AUTONOMY_METABOLISM_ENABLED", "true")
+    substrate_act_mock = AsyncMock(return_value=MagicMock(fetch_attempted=True))
+    monkeypatch.setattr(
+        "orion.spark.concept_induction.bus_worker.maybe_execute_substrate_act_after_metabolism",
+        substrate_act_mock,
+    )
+    cfg = ConceptSettings()
+    worker = ConceptWorker(cfg)
+    worker.store = MagicMock()
+    worker.store.load_drive_state.return_value = {}
+    worker.drive_engine.update = MagicMock(return_value=({"predictive": 0.2}, {"predictive": False}))
+    worker._publish_tension_event = AsyncMock(return_value=None)
+    worker._publish_drive_state = AsyncMock(return_value=None)
+    worker._publish_artifact = AsyncMock(return_value=None)
+    worker._publish_dossier = AsyncMock(return_value=None)
+    worker.goal_engine.propose = MagicMock(
+        return_value=MagicMock(proposal=None, suppressed_signature="sig-cooldown")
+    )
+
+    await worker.handle_envelope(_world_pulse_envelope(), "orion:world_pulse:run:result")
+
+    substrate_act_mock.assert_awaited_once()
+    call_kwargs = substrate_act_mock.await_args.kwargs
+    assert call_kwargs["spawned_correlation_id"] == "wp-run-hook"

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -88,6 +88,12 @@ SYNC_PREFIXES = (
     "ORION_ATTENTION_",
     "ORION_REVERIE_",
     "SUBSTRATE_FELT_STATE_",
+    # Drive attribution + substrate act (PR drive-attribution-substrate-act)
+    "ORION_SUBSTRATE_",
+    "ORION_AUTONOMY_",
+    "ORION_METABOLISM_",
+    "ORION_CAPABILITY_POLICY_",
+    "ORION_EPISODE_",
     "STANCE_REACT_",
     "HARNESS_FCC_",
     "HARNESS_AITOWN_",
@@ -130,6 +136,7 @@ SYNC_EXACT = frozenset(
         "ORION_DREAM_COMPACTION_APPLY_ENABLED",
         "ORION_DREAM_COMPACTION_DOWNSCALE_ONLY",
         "DREAM_COMPACTION_SNAPSHOT_DIR",
+        "GOAL_DRIVE_ORIGIN_SOURCE",
     }
 )
 

--- a/services/orion-spark-concept-induction/.env_example
+++ b/services/orion-spark-concept-induction/.env_example
@@ -58,7 +58,8 @@ DRIVE_ACTIVATION_ON=0.62
 DRIVE_ACTIVATION_OFF=0.42
 GOAL_PROPOSAL_COOLDOWN_MINUTES=180
 GOAL_GENERATION_MODE=evidence_rules
-GOAL_DRIVE_ORIGIN_SOURCE=audit_dominant
+# tick_attribution | pressures (legacy) | audit_dominant (deprecated alias)
+GOAL_DRIVE_ORIGIN_SOURCE=tick_attribution
 
 # Concept profile repository backend (Phase 2)
 CONCEPT_PROFILE_REPOSITORY_BACKEND=local


### PR DESCRIPTION
Branch pushed. `gh` isn’t authenticated here, so the PR wasn’t created automatically.

**Branch:** `feat/drive-attribution-substrate-act-v1.1` → `origin`  
**Open PR:** https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/drive-attribution-substrate-act-v1.1?expand=1

**Title:** `feat: drive tick attribution + substrate act (v1.1)`

Paste this as the PR body (or run `gh auth login` and I can create it):

---

## Summary

- Add per-tick drive attribution (`drive_attribution.py`) so dominance and goal `drive_origin` follow this event's tensions + metabolism `drive_deltas`, not saturated flat pressures
- Emit `DriveAuditV1.tick_attribution`; default `GOAL_DRIVE_ORIGIN_SOURCE=tick_attribution`
- Decouple Tier B readonly fetch + episode journal from fresh goal publish via `maybe_execute_substrate_act_after_metabolism` (cooldown-suppressed goals no longer block substrate act)

## Outcome moved

World-pulse GPU gap ticks should produce `dominant_drive=predictive` and run readonly fetch/journal even when the 180min goal cooldown suppresses publish.

## Current architecture

Substrate-fed motivation v1 shipped metabolism, capability policy, and fetch/journal — but live dominance read `max(sorted(pressures))` (~0.73 on all drives → `autonomy` alphabetically), `metabolism.drive_deltas` were never applied, and fetch ran only inside `if goal_decision.proposal`.

## Architecture touched

- `orion/spark/concept_induction/` — attribution module, audit/goals/bus_worker wiring
- `orion/autonomy/policy_act.py` — substrate episode intent + act orchestration
- `orion/core/schemas/drives.py` — `DriveAuditV1.tick_attribution`
- `services/orion-spark-concept-induction/.env_example` + `scripts/sync_local_env_from_example.py`

## Files changed

- `orion/spark/concept_induction/drive_attribution.py`: per-tick attribution + structural tie-break
- `orion/spark/concept_induction/audit.py`: dominance from attribution
- `orion/spark/concept_induction/bus_worker.py`: wire deltas; substrate act outside goal-publish gate
- `orion/spark/concept_induction/goals.py` + `settings.py`: `tick_attribution` drive origin default
- `orion/autonomy/policy_act.py` + `models.py`: episode intent + substrate act entry
- Tests across `test_drive_attribution`, `test_metabolism_hook`, `test_goals`, `test_policy_act`

## Schema / bus / API changes

- **Added:** `DriveAuditV1.tick_attribution: dict[str, float]`
- **Added:** `SubstrateEpisodeIntentV1`, `SubstrateActResultV1` (internal autonomy models)
- **Behavior changed:** `dominant_drive` on audit computed from tick attribution on bus worker path
- **Behavior changed:** substrate fetch/journal runs on world-pulse metabolism when gap signals present, regardless of goal publish
- **Compatibility:** `audit_dominant` env value aliases to `tick_attribution`; `pressures` legacy source unchanged

## Env/config changes

- `.env_example` updated: `GOAL_DRIVE_ORIGIN_SOURCE=tick_attribution` (was `audit_dominant`)
- Sync script: `GOAL_DRIVE_ORIGIN_SOURCE` in `SYNC_EXACT`; `ORION_SUBSTRATE_*`, `ORION_AUTONOMY_*`, `ORION_METABOLISM_*`, `ORION_CAPABILITY_POLICY_*`, `ORION_EPISODE_*` prefixes
- After merge: `python3 scripts/sync_local_env_from_example.py` (skips `ORION_BUS_URL`)

## Tests run

```text
34 passed (drive_attribution, metabolism_hook, goals, policy_act, substrate_act_models)
```

## Evals run

```text
Not run — golden-path smoke recommended post-deploy
```

## Review findings fixed

- `DRIVE_KEYS` deduped via import from `drives.py` (`9c668c3d`)
- Gap tie-break sort key fixed (`-gap_bias`)
- Edge-case tests for zero attribution / empty lead tension

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- **Low:** zero-attribution ticks still fall back to `max(sorted(pressures))` for goal origin; world-pulse gaps unaffected
- **Low:** live golden-path smoke UNVERIFIED — run `scripts/smoke_substrate_motivation_golden_path.py` after deploy

## Test plan

- [ ] World-pulse GPU gap → `dominant_drive=predictive`, `tick_attribution.predictive > 0`
- [ ] Goal cooldown suppresses publish → fetch still evaluated
- [ ] No gap signal → no fetch
- [ ] Env sync + container restart picks up `GOAL_DRIVE_ORIGIN_SOURCE=tick_attribution`

---

To create via CLI after auth:

```bash
gh auth login
cd /mnt/scripts/Orion-Sapienform-drive-attribution
gh pr create --title "feat: drive tick attribution + substrate act (v1.1)" --body-file /tmp/pr-body.md
```