### PR TITLE
fix(fcc): Claude 2.1 root permissions and per-server MCP allow patterns

### DIFF
--- a/orion/fcc/claude_spawn.py
+++ b/orion/fcc/claude_spawn.py
@@ -1,0 +1,45 @@
+"""Shared ``claude -p`` argv helpers for FCC harness bridges."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, List, Mapping
+
+
+def mcp_allowed_tool_patterns(mcp_servers: Mapping[str, Any]) -> List[str]:
+    """Per-server allow patterns for Claude Code 2.1+ (``mcp__*`` is rejected)."""
+    return [f"mcp__{name}__*" for name in mcp_servers]
+
+
+def extend_mcp_argv(argv: List[str], mcp_config_path: Path) -> None:
+    data = json.loads(mcp_config_path.read_text(encoding="utf-8"))
+    patterns = mcp_allowed_tool_patterns(data.get("mcpServers") or {})
+    argv.extend(["--mcp-config", str(mcp_config_path)])
+    if patterns:
+        argv.append("--allowedTools")
+        argv.extend(patterns)
+
+
+def claude_permission_argv(*, auto_approve: bool) -> List[str]:
+    """Auto-approve tool permissions for non-interactive FCC turns."""
+    if not auto_approve:
+        return []
+    # Claude Code 2.1+ rejects --dangerously-skip-permissions under root.
+    if os.geteuid() == 0:
+        return ["--permission-mode", "dontAsk"]
+    return ["--dangerously-skip-permissions"]
+
+
+def auto_approve_from_env(env_key: str | None = None) -> bool:
+    """Whether to auto-approve when env is unset: root containers yes, host non-root yes."""
+    if env_key:
+        raw = os.environ.get(env_key, "").strip().lower()
+        if raw in {"0", "false", "no", "off"}:
+            return False
+        if raw in {"1", "true", "yes", "on"}:
+            return True
+    if os.geteuid() == 0:
+        return True
+    return True

--- a/orion/fcc/tests/test_claude_spawn.py
+++ b/orion/fcc/tests/test_claude_spawn.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orion.fcc import claude_spawn
+
+
+def test_mcp_allowed_tool_patterns_per_server() -> None:
+    patterns = claude_spawn.mcp_allowed_tool_patterns({"github": {}, "firecrawl": {}})
+    assert patterns == ["mcp__github__*", "mcp__firecrawl__*"]
+
+
+def test_extend_mcp_argv_uses_per_server_patterns(tmp_path: Path) -> None:
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(
+        json.dumps({"mcpServers": {"github": {"type": "stdio"}, "firecrawl": {"type": "stdio"}}}),
+        encoding="utf-8",
+    )
+    argv: list[str] = ["claude", "-p", "hi"]
+    claude_spawn.extend_mcp_argv(argv, cfg)
+    assert argv == [
+        "claude",
+        "-p",
+        "hi",
+        "--mcp-config",
+        str(cfg),
+        "--allowedTools",
+        "mcp__github__*",
+        "mcp__firecrawl__*",
+    ]
+
+
+def test_claude_permission_argv_root_uses_dont_ask(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(claude_spawn.os, "geteuid", lambda: 0)
+    assert claude_spawn.claude_permission_argv(auto_approve=True) == [
+        "--permission-mode",
+        "dontAsk",
+    ]
+
+
+def test_claude_permission_argv_non_root_uses_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(claude_spawn.os, "geteuid", lambda: 1000)
+    assert claude_spawn.claude_permission_argv(auto_approve=True) == [
+        "--dangerously-skip-permissions",
+    ]

--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -12,6 +12,8 @@ import urllib.request
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
+from orion.fcc.claude_spawn import claude_permission_argv, extend_mcp_argv
+
 logger = logging.getLogger("orion.harness.fcc_motor")
 
 DEFAULT_STREAM_READ_LIMIT = 8 * 1024 * 1024
@@ -259,10 +261,13 @@ async def run_fcc_turn(
         model_id,
     ]
     if mcp_config_path is not None:
-        argv.extend(["--mcp-config", str(mcp_config_path), "--allowedTools", "mcp__*"])
+        extend_mcp_argv(argv, mcp_config_path)
     if _should_skip_claude_permissions():
-        model_idx = argv.index("--model")
-        argv.insert(model_idx, "--dangerously-skip-permissions")
+        perm = claude_permission_argv(auto_approve=True)
+        if perm:
+            model_idx = argv.index("--model")
+            for offset, token in enumerate(perm):
+                argv.insert(model_idx + offset, token)
 
     started = time.monotonic()
     proc: Optional[asyncio.subprocess.Process] = None

--- a/orion/harness/tests/test_fcc_motor_mcp.py
+++ b/orion/harness/tests/test_fcc_motor_mcp.py
@@ -55,6 +55,11 @@ async def test_run_fcc_turn_adds_mcp_config_when_enabled(monkeypatch: pytest.Mon
     monkeypatch.setattr(motor, "load_fcc_env", _fake_fcc_env)
     monkeypatch.setattr(motor, "_maybe_render_mcp_config", lambda **k: Path("/tmp/fake-mcp.json"))
     monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    fake_cfg = Path("/tmp/fake-mcp.json")
+    fake_cfg.write_text(
+        '{"mcpServers":{"github":{},"firecrawl":{}}}',
+        encoding="utf-8",
+    )
 
     async for _ in motor.run_fcc_turn(
         prompt="hello",
@@ -72,7 +77,8 @@ async def test_run_fcc_turn_adds_mcp_config_when_enabled(monkeypatch: pytest.Mon
     assert "/tmp/fake-mcp.json" in [str(x) for x in captured_argv]
     assert "--allowedTools" in captured_argv
     idx = captured_argv.index("--allowedTools")
-    assert captured_argv[idx + 1] == "mcp__*"
+    assert captured_argv[idx + 1] == "mcp__github__*"
+    assert captured_argv[idx + 2] == "mcp__firecrawl__*"
 
 
 @pytest.mark.asyncio
@@ -181,7 +187,7 @@ def test_harness_aitown_env_overrides_convex_url(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
-async def test_run_fcc_turn_skip_permissions_when_env_true_as_root(
+async def test_run_fcc_turn_root_uses_dont_ask_permission_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured_argv: list = []
@@ -201,7 +207,7 @@ async def test_run_fcc_turn_skip_permissions_when_env_true_as_root(
     async for _ in motor.run_fcc_turn(
         prompt="hello",
         fcc_model_label="MODEL_HAIKU",
-        correlation_id="corr-skip",
+        correlation_id="corr-dontask",
         workspace="/tmp",
         fcc_server_url="http://127.0.0.1:8082",
         auth_token="tok",
@@ -210,7 +216,9 @@ async def test_run_fcc_turn_skip_permissions_when_env_true_as_root(
     ):
         pass
 
-    assert "--dangerously-skip-permissions" in captured_argv
+    assert "--permission-mode" in captured_argv
+    assert "dontAsk" in captured_argv
+    assert "--dangerously-skip-permissions" not in captured_argv
 
 
 def test_should_skip_claude_permissions_env_false_overrides_non_root(

--- a/services/orion-hub/scripts/fcc_claude_bridge.py
+++ b/services/orion-hub/scripts/fcc_claude_bridge.py
@@ -13,6 +13,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
 from scripts.fcc_env_catalog import load_fcc_env, resolve_auth_token
 from scripts.fcc_model_mapping import DEFAULT_FCC_MODEL_LABEL, label_to_claude_model_id
+from orion.fcc.claude_spawn import auto_approve_from_env, claude_permission_argv, extend_mcp_argv
 
 logger = logging.getLogger("orion-hub.fcc_claude_bridge")
 
@@ -284,10 +285,14 @@ async def run_turn(
         model_id,
     ]
     if mcp_config_path is not None:
-        argv.extend(["--mcp-config", str(mcp_config_path), "--allowedTools", "mcp__*"])
-    if os.geteuid() != 0:
+        extend_mcp_argv(argv, mcp_config_path)
+    perm = claude_permission_argv(
+        auto_approve=auto_approve_from_env("HUB_AGENT_CLAUDE_SKIP_PERMISSIONS")
+    )
+    if perm:
         model_idx = argv.index("--model")
-        argv.insert(model_idx, "--dangerously-skip-permissions")
+        for offset, token in enumerate(perm):
+            argv.insert(model_idx + offset, token)
     started = time.monotonic()
     proc: Optional[asyncio.subprocess.Process] = None
     accumulated = ""

--- a/services/orion-hub/tests/test_fcc_claude_bridge_mcp.py
+++ b/services/orion-hub/tests/test_fcc_claude_bridge_mcp.py
@@ -59,6 +59,10 @@ async def test_run_turn_adds_mcp_config_when_enabled(monkeypatch: pytest.MonkeyP
 
     from scripts.settings import settings
     monkeypatch.setattr(settings, "HUB_AGENT_CLAUDE_MCP_ENABLED", True, raising=False)
+    Path("/tmp/fake-mcp.json").write_text(
+        '{"mcpServers":{"github":{},"firecrawl":{}}}',
+        encoding="utf-8",
+    )
 
     async for _ in bridge.run_turn(
         prompt="hello",
@@ -76,7 +80,8 @@ async def test_run_turn_adds_mcp_config_when_enabled(monkeypatch: pytest.MonkeyP
     assert "/tmp/fake-mcp.json" in [str(x) for x in captured_argv]
     assert "--allowedTools" in captured_argv
     idx = captured_argv.index("--allowedTools")
-    assert captured_argv[idx + 1] == "mcp__*"
+    assert captured_argv[idx + 1] == "mcp__github__*"
+    assert captured_argv[idx + 2] == "mcp__firecrawl__*"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Branch is pushed. `gh` isn’t authenticated here, so I couldn’t open the PR — use the link below or run `gh auth login` and I can create it.

**Branch:** `fix/harness-fcc-claude-21-argv`  
**Create PR:** https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/harness-fcc-claude-21-argv?expand=1

**Title:** `fix(fcc): Claude 2.1 root permissions and per-server MCP allow patterns`

---

## Summary

- Add shared `orion/fcc/claude_spawn.py` helpers for FCC `claude -p` argv construction.
- Replace invalid Claude 2.1 `--allowedTools mcp__*` with per-server patterns (`mcp__github__*`, `mcp__firecrawl__*`, …).
- Use `--permission-mode dontAsk` when spawning as root (Docker Hub / harness governor); keep `--dangerously-skip-permissions` on non-root host dev.
- Wire helpers through Hub `fcc_claude_bridge` and harness `fcc_motor`.

## Outcome moved

Hub Agent Claude turns with `HUB_AGENT_CLAUDE_MCP_ENABLED=true` can invoke GitHub MCP instead of falling back to `gh` Bash (which `dontAsk` denies in root containers). Fixes the live trace: Bash denied → FCC HTTP 200 malformed retry loop.

## Current architecture

- Hub Docker runs as **root** (`orion-athena-hub`, euid 0).
- `fcc_claude_bridge.py` on `main` passes `--allowedTools mcp__*` and only adds `--dangerously-skip-permissions` when `euid != 0`.
- Claude Code **2.1.202** rejects `mcp__*` wildcards and rejects `--dangerously-skip-permissions` under root.
- Result: MCP tools never enter the allowlist; the model tries `gh pr list` via Bash; `dontAsk` blocks it.

## Architecture touched

- `orion/fcc/claude_spawn.py` — new shared spawn contract
- `orion/harness/fcc_motor.py` — harness governor FCC turns
- `services/orion-hub/scripts/fcc_claude_bridge.py` — Hub Agent Claude turns

## Files changed

- `orion/fcc/claude_spawn.py`: MCP allow-pattern derivation + root/non-root permission argv
- `orion/fcc/tests/test_claude_spawn.py`: unit tests for patterns and permission mode
- `orion/harness/fcc_motor.py`: use shared helpers
- `orion/harness/tests/test_fcc_motor_mcp.py`: expect per-server patterns + `dontAsk` as root
- `services/orion-hub/scripts/fcc_claude_bridge.py`: use shared helpers; auto-approve in root containers
- `services/orion-hub/tests/test_fcc_claude_bridge_mcp.py`: expect per-server patterns

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: FCC subprocess argv only (Claude CLI flags)
- Compatibility notes: requires Claude Code 2.1+; non-root host behavior unchanged (`--dangerously-skip-permissions`)

## Env/config changes

- Added keys: optional `HUB_AGENT_CLAUDE_SKIP_PERMISSIONS` (read by `auto_approve_from_env`; defaults on when unset)
- `.env_example` updated: no (optional key only; mirrors harness `HARNESS_FCC_SKIP_PERMISSIONS` pattern)

## Tests run

```text
PYTHONPATH=services/orion-hub:. .venv/bin/pytest \
  orion/fcc/tests/test_claude_spawn.py \
  orion/harness/tests/test_fcc_motor_mcp.py \
  services/orion-hub/tests/test_fcc_claude_bridge_mcp.py -q
# 15 passed in 0.43s
```

## Restart required

```bash
docker compose --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build
```

## Test plan

- [ ] Merge and rebuild `orion-athena-hub`
- [ ] Hub → Agent Claude → ask "what's my last PR title?"
- [ ] Live trace shows `mcp__github__*` tool use, not `Bash gh …`
- [ ] No `don't ask mode` Bash denial or FCC HTTP 200 malformed errors

---

After merge, rebuild hub. If you `gh auth login`, I can run `gh pr create` for you.