### PR TITLE
fix(fcc): use mcp__server allow patterns and block gh Bash fallback

### DIFF
--- a/orion/fcc/claude_spawn.py
+++ b/orion/fcc/claude_spawn.py
@@ -9,17 +9,34 @@ from typing import Any, List, Mapping
 
 
 def mcp_allowed_tool_patterns(mcp_servers: Mapping[str, Any]) -> List[str]:
-    """Per-server allow patterns for Claude Code 2.1+ (``mcp__*`` is rejected)."""
-    return [f"mcp__{name}__*" for name in mcp_servers]
+    """Per-server allow patterns for Claude Code 2.1+ MCP pre-approval.
+
+    Use ``mcp__<server>`` (not ``mcp__<server>__*`` or bare ``mcp__*``).
+    See Claude Code IAM docs + anthropics/claude-code#5004.
+    """
+    return [f"mcp__{name}" for name in mcp_servers]
+
+
+def mcp_disallowed_tool_patterns(mcp_servers: Mapping[str, Any]) -> List[str]:
+    """Block Bash fallbacks that fail in headless Hub (gh not installed)."""
+    blocked: List[str] = []
+    if "github" in mcp_servers:
+        blocked.append("Bash(gh *)")
+    return blocked
 
 
 def extend_mcp_argv(argv: List[str], mcp_config_path: Path) -> None:
     data = json.loads(mcp_config_path.read_text(encoding="utf-8"))
-    patterns = mcp_allowed_tool_patterns(data.get("mcpServers") or {})
+    servers = data.get("mcpServers") or {}
+    patterns = mcp_allowed_tool_patterns(servers)
     argv.extend(["--mcp-config", str(mcp_config_path)])
     if patterns:
         argv.append("--allowedTools")
         argv.extend(patterns)
+    disallowed = mcp_disallowed_tool_patterns(servers)
+    if disallowed:
+        argv.append("--disallowedTools")
+        argv.extend(disallowed)
 
 
 def claude_permission_argv(*, auto_approve: bool) -> List[str]:

--- a/orion/fcc/tests/test_claude_spawn.py
+++ b/orion/fcc/tests/test_claude_spawn.py
@@ -10,7 +10,12 @@ from orion.fcc import claude_spawn
 
 def test_mcp_allowed_tool_patterns_per_server() -> None:
     patterns = claude_spawn.mcp_allowed_tool_patterns({"github": {}, "firecrawl": {}})
-    assert patterns == ["mcp__github__*", "mcp__firecrawl__*"]
+    assert patterns == ["mcp__github", "mcp__firecrawl"]
+
+
+def test_mcp_disallowed_blocks_gh_when_github_present() -> None:
+    blocked = claude_spawn.mcp_disallowed_tool_patterns({"github": {}, "firecrawl": {}})
+    assert blocked == ["Bash(gh *)"]
 
 
 def test_extend_mcp_argv_uses_per_server_patterns(tmp_path: Path) -> None:
@@ -28,8 +33,10 @@ def test_extend_mcp_argv_uses_per_server_patterns(tmp_path: Path) -> None:
         "--mcp-config",
         str(cfg),
         "--allowedTools",
-        "mcp__github__*",
-        "mcp__firecrawl__*",
+        "mcp__github",
+        "mcp__firecrawl",
+        "--disallowedTools",
+        "Bash(gh *)",
     ]
 
 

--- a/orion/harness/tests/test_fcc_motor_mcp.py
+++ b/orion/harness/tests/test_fcc_motor_mcp.py
@@ -77,8 +77,10 @@ async def test_run_fcc_turn_adds_mcp_config_when_enabled(monkeypatch: pytest.Mon
     assert "/tmp/fake-mcp.json" in [str(x) for x in captured_argv]
     assert "--allowedTools" in captured_argv
     idx = captured_argv.index("--allowedTools")
-    assert captured_argv[idx + 1] == "mcp__github__*"
-    assert captured_argv[idx + 2] == "mcp__firecrawl__*"
+    assert captured_argv[idx + 1] == "mcp__github"
+    assert captured_argv[idx + 2] == "mcp__firecrawl"
+    dis_idx = captured_argv.index("--disallowedTools")
+    assert captured_argv[dis_idx + 1] == "Bash(gh *)"
 
 
 @pytest.mark.asyncio

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -531,7 +531,7 @@ PYTHONPATH=services/orion-hub:. python services/orion-hub/scripts/verify_agent_c
 
 ### fcc-claude MCP (GitHub + Firecrawl + AI Town)
 
-When `HUB_AGENT_CLAUDE_MCP_ENABLED=true`, each agent-claude turn renders an ephemeral MCP config from `config/fcc_claude_mcp.template.json` and passes `--mcp-config` + `--allowedTools mcp__*` to `claude -p`. Secrets live in operator `~/.fcc/.env` (not Hub `.env`):
+When `HUB_AGENT_CLAUDE_MCP_ENABLED=true`, each agent-claude turn renders an ephemeral MCP config from `config/fcc_claude_mcp.template.json` and passes `--mcp-config` + per-server `--allowedTools` (e.g. `mcp__github`, `mcp__firecrawl`) and `--disallowedTools Bash(gh *)` to `claude -p`. Secrets live in operator `~/.fcc/.env` (not Hub `.env`):
 
 | Key | Required | Purpose |
 |-----|----------|---------|

--- a/services/orion-hub/scripts/agent_claude_input.py
+++ b/services/orion-hub/scripts/agent_claude_input.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 AGENT_CLAUDE_OPERATOR_BRIEF = """\
 Hub agent-claude runs against a local gateway with a finite context window (~64k tokens).
 Before Read on any file: prefer rg/Grep with a path or pattern. For large files (e.g. orion/bus/channels.yaml), use Read offset/limit in chunks — never load whole contract YAML in one read.
+For GitHub PRs, issues, and repo metadata: use GitHub MCP tools (mcp__github). The gh CLI is not installed in the Hub container.
 """
 
 

--- a/services/orion-hub/tests/test_fcc_claude_bridge_mcp.py
+++ b/services/orion-hub/tests/test_fcc_claude_bridge_mcp.py
@@ -80,8 +80,10 @@ async def test_run_turn_adds_mcp_config_when_enabled(monkeypatch: pytest.MonkeyP
     assert "/tmp/fake-mcp.json" in [str(x) for x in captured_argv]
     assert "--allowedTools" in captured_argv
     idx = captured_argv.index("--allowedTools")
-    assert captured_argv[idx + 1] == "mcp__github__*"
-    assert captured_argv[idx + 2] == "mcp__firecrawl__*"
+    assert captured_argv[idx + 1] == "mcp__github"
+    assert captured_argv[idx + 2] == "mcp__firecrawl"
+    dis_idx = captured_argv.index("--disallowedTools")
+    assert captured_argv[dis_idx + 1] == "Bash(gh *)"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
PR #842 fixed permissions argv but **didn't fix MCP pre-approval**. Your trace is the expected failure mode after that merge.

## What was still broken

The hub container **does** have the #842 fix — I verified live argv:

```text
--permission-mode dontAsk
--allowedTools mcp__github__* mcp__firecrawl__*
```

That's the problem. In Claude Code 2.1, **`mcp__github__*` does not pre-approve MCP tools**. The correct pattern is **`mcp__github`** (server name, no `__*` suffix). Same for firecrawl.

So in `dontAsk` mode:
- GitHub MCP tools load in init but **aren't auto-approved**
- Model falls back to `gh pr list` via Bash
- `gh` isn't in the container and Bash(`gh`) gets denied → your trace

`git branch` still works because local `git` Bash is allowed; `gh` is not.

## Follow-up fix (pushed)

Branch: **`fix/fcc-mcp-server-allow-pattern`**

Changes:
1. `--allowedTools mcp__github mcp__firecrawl` (not `mcp__github__*`)
2. `--disallowedTools Bash(gh *)` when GitHub MCP is configured
3. Operator brief: use GitHub MCP for PRs; `gh` not installed

**Create PR:** https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/fcc-mcp-server-allow-pattern

**Tests:** 18 passed

## After merge — rebuild hub

```bash
docker compose --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build
```

Then retry "what's my last PR title?" — trace should show `mcp__github__list_pull_requests` (or similar), not `Bash gh …`.