### PR TITLE
fix(thought): inject correlation_id for string stance_react payloads

### DIFF
--- a/orion/thought/stance_react.py
+++ b/orion/thought/stance_react.py
@@ -166,12 +166,21 @@ def slim_repair_bundle_for_prompt(bundle: TurnAppraisalBundleV1 | None) -> dict[
     return slim
 
 
-def parse_stance_react_payload(raw: dict[str, Any] | str) -> ThoughtEventV1:
+def parse_stance_react_payload(
+    raw: dict[str, Any] | str,
+    *,
+    correlation_id: str | None = None,
+    session_id: str | None = None,
+) -> ThoughtEventV1:
     """Validate JSON from cortex stance_react step into ThoughtEventV1."""
     if isinstance(raw, str):
         raw = decode_stance_react_json(raw)
     if not isinstance(raw, dict):
         raise TypeError("stance_react payload must be a JSON object")
+    if correlation_id:
+        raw.setdefault("correlation_id", correlation_id)
+    if session_id is not None:
+        raw.setdefault("session_id", session_id)
     return ThoughtEventV1.model_validate(normalize_stance_react_raw(raw))
 
 

--- a/orion/thought/tests/test_stance_react_pipeline.py
+++ b/orion/thought/tests/test_stance_react_pipeline.py
@@ -94,6 +94,19 @@ def test_parse_stance_react_payload_from_json_string() -> None:
     assert parsed.imperative == "Answer directly."
 
 
+def test_parse_stance_react_payload_injects_correlation_id_from_string_payload() -> None:
+    raw = _thought().model_dump(mode="json")
+    raw.pop("correlation_id", None)
+    raw.pop("session_id", None)
+    parsed = parse_stance_react_payload(
+        json.dumps(raw),
+        correlation_id="c-injected",
+        session_id="sess-injected",
+    )
+    assert parsed.correlation_id == "c-injected"
+    assert parsed.session_id == "sess-injected"
+
+
 def test_parse_stance_react_payload_from_markdown_wrapped_json() -> None:
     inner = _thought().model_dump(mode="json")
     wrapped = f"Here is the stance JSON:\n```json\n{json.dumps(inner)}\n```"

--- a/services/orion-thought/app/bus_listener.py
+++ b/services/orion-thought/app/bus_listener.py
@@ -123,10 +123,11 @@ async def run_stance_react(
         timeout_sec=settings.stance_react_timeout_sec,
     )
     raw_payload = extract_stance_react_payload(exec_result)
-    if isinstance(raw_payload, dict):
-        raw_payload.setdefault("correlation_id", request.correlation_id)
-        raw_payload.setdefault("session_id", request.session_id)
-    thought = parse_stance_react_payload(raw_payload)
+    thought = parse_stance_react_payload(
+        raw_payload,
+        correlation_id=request.correlation_id,
+        session_id=request.session_id,
+    )
     return apply_stance_react_pipeline(thought, request)
 
 


### PR DESCRIPTION
Branch is pushed. `gh pr create` failed — `GITHUB_PAT` in `~/.fcc/.env` doesn't have pull-request write scope. Open the PR here:

**https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/stance-react-correlation-id-inject?expand=1**

**Title:** `fix(thought): inject correlation_id for string stance_react payloads`

---

## Summary

- `parse_stance_react_payload` now accepts `correlation_id` / `session_id` and injects them after decoding string JSON from cortex.
- `orion-thought` bus listener always passes request identity into parse — no longer gated on `isinstance(raw_payload, dict)`.
- Regression test covers string payloads missing `correlation_id`.

## Outcome moved

Unified Orion Hub turns no longer defer at `stance_react_failed: correlation_id Field required` before harness/FCC runs. Fixes the trace where "grab the latest pr desc; skip bash" died in stance before reaching GitHub MCP.

## Current architecture

`orion-thought` runs `stance_react` via cortex, extracts `final_text` (usually a JSON **string**), and validates into `ThoughtEventV1`. The bus listener only backfilled `correlation_id` when the extract result was already a `dict`, so string payloads failed validation and Hub showed `Turn deferred: stance_react_failed`.

## Architecture touched

- `orion/thought/stance_react.py` — parse contract
- `services/orion-thought/app/bus_listener.py` — RPC handler
- `orion/thought/tests/test_stance_react_pipeline.py` — regression

## Schema / bus / API changes

- Behavior changed: identity fields injected at parse time (no schema change)
- Compatibility: explicit LLM-provided `correlation_id` still wins via `setdefault`

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=services/orion-thought:. .venv/bin/pytest \
  orion/thought/tests/test_stance_react_pipeline.py \
  services/orion-thought/tests/test_bus_listener_errors.py -q
# 13 passed
```

## Restart required

```bash
docker compose --env-file services/orion-thought/.env \
  -f services/orion-thought/docker-compose.yml up -d --build
```

## Test plan

- [ ] Merge and rebuild `orion-thought`
- [ ] Hub unified Orion mode → "grab the latest pr desc; skip bash"
- [ ] Turn passes stance (no `correlation_id` validation defer)
- [ ] Harness/FCC proceeds to GitHub MCP (#843 already merged)

---

**Note:** FCC MCP fix is already on `main` via [#843](https://github.com/junebug-junie/Orion-Sapienform/pull/843). This PR is the remaining piece.

To let me create PRs via CLI next time: `gh auth login` or give `GITHUB_PAT` the `repo` / pull-requests scope.