### PR TITLE
Feat/consolidation crystallization gate

### DIFF
--- a/orion/memory/consolidation_gate.py
+++ b/orion/memory/consolidation_gate.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from orion.memory.low_info_social import is_low_info_social
+
+_SHIFT_FORCE = frozenset({"TOPIC", "STANCE", "REPAIR"})
+
+
+@dataclass
+class ConsolidationGateResult:
+    action: Literal["skip", "propose"]
+    reasons: list[str] = field(default_factory=list)
+    dominant_shift: str | None = None
+    grammar_event_ids: list[str] = field(default_factory=list)
+    window_novelty_max: float = 0.0
+    window_significance_max: float = 0.0
+
+
+def _appraisal(turn: dict[str, Any]) -> dict[str, Any]:
+    spark = turn.get("spark_meta") if isinstance(turn.get("spark_meta"), dict) else {}
+    appraisal = spark.get("turn_change_appraisal")
+    return appraisal if isinstance(appraisal, dict) else {}
+
+
+def _significance(turn: dict[str, Any]) -> float:
+    spark = turn.get("spark_meta") if isinstance(turn.get("spark_meta"), dict) else {}
+    val = spark.get("memory_significance_score", turn.get("memory_significance_score"))
+    return float(val) if isinstance(val, (int, float)) else 0.0
+
+
+def consolidation_memory_gate(
+    *,
+    turns: list[dict[str, Any]],
+    grammar_repair_signal: bool,
+    grammar_event_ids: list[str] | None = None,
+    min_novelty: float = 0.35,
+    min_significance: float = 0.40,
+) -> ConsolidationGateResult:
+    reasons: list[str] = []
+    novelty_max = 0.0
+    significance_max = 0.0
+    dominant_shift: str | None = None
+    best_novelty = -1.0
+
+    for turn in turns:
+        appraisal = _appraisal(turn)
+        novelty = appraisal.get("novelty_score")
+        n = float(novelty) if isinstance(novelty, (int, float)) else 0.0
+        novelty_max = max(novelty_max, n)
+        significance_max = max(significance_max, _significance(turn))
+        shift = str(appraisal.get("shift_kind") or "NONE").upper()
+        if n > best_novelty and shift in _SHIFT_FORCE:
+            best_novelty = n
+            dominant_shift = shift
+
+    if grammar_repair_signal:
+        return ConsolidationGateResult(
+            action="propose",
+            reasons=["repair_signal"],
+            dominant_shift=dominant_shift or "REPAIR",
+            grammar_event_ids=list(grammar_event_ids or []),
+            window_novelty_max=novelty_max,
+            window_significance_max=significance_max,
+        )
+
+    substantive_shift = any(
+        str(_appraisal(t).get("shift_kind") or "NONE").upper() in _SHIFT_FORCE
+        and float(_appraisal(t).get("novelty_score") or 0) >= min_novelty
+        for t in turns
+    )
+    if substantive_shift:
+        return ConsolidationGateResult(
+            action="propose",
+            reasons=["substantive_shift"],
+            dominant_shift=dominant_shift,
+            grammar_event_ids=list(grammar_event_ids or []),
+            window_novelty_max=novelty_max,
+            window_significance_max=significance_max,
+        )
+
+    if novelty_max >= min_novelty:
+        return ConsolidationGateResult(
+            action="propose",
+            reasons=["novelty_above_floor"],
+            dominant_shift=dominant_shift,
+            grammar_event_ids=list(grammar_event_ids or []),
+            window_novelty_max=novelty_max,
+            window_significance_max=significance_max,
+        )
+
+    if significance_max >= min_significance:
+        return ConsolidationGateResult(
+            action="propose",
+            reasons=["significance_above_floor"],
+            dominant_shift=dominant_shift,
+            grammar_event_ids=list(grammar_event_ids or []),
+            window_novelty_max=novelty_max,
+            window_significance_max=significance_max,
+        )
+
+    all_low_info = all(
+        is_low_info_social(str(t.get("prompt") or ""))
+        and is_low_info_social(str(t.get("response") or ""))
+        for t in turns
+    ) if turns else True
+    if all_low_info:
+        reasons.append("low_info_social")
+
+    if novelty_max < min_novelty:
+        reasons.append("novelty_below_floor")
+    if significance_max < min_significance:
+        reasons.append("significance_below_floor")
+
+    return ConsolidationGateResult(
+        action="skip",
+        reasons=reasons or ["no_substantive_signal"],
+        dominant_shift=None,
+        grammar_event_ids=list(grammar_event_ids or []),
+        window_novelty_max=novelty_max,
+        window_significance_max=significance_max,
+    )

--- a/orion/memory/consolidation_gate.py
+++ b/orion/memory/consolidation_gate.py
@@ -100,6 +100,21 @@ def consolidation_memory_gate(
             window_significance_max=significance_max,
         )
 
+    has_substantive_text = any(
+        not is_low_info_social(str(t.get("prompt") or ""))
+        or not is_low_info_social(str(t.get("response") or ""))
+        for t in turns
+    ) if turns else False
+    if has_substantive_text:
+        return ConsolidationGateResult(
+            action="propose",
+            reasons=["substantive_text"],
+            dominant_shift=dominant_shift,
+            grammar_event_ids=list(grammar_event_ids or []),
+            window_novelty_max=novelty_max,
+            window_significance_max=significance_max,
+        )
+
     all_low_info = all(
         is_low_info_social(str(t.get("prompt") or ""))
         and is_low_info_social(str(t.get("response") or ""))

--- a/orion/memory/consolidation_grammar.py
+++ b/orion/memory/consolidation_grammar.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _parse_event_json(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _atom_semantic_role(event_json: dict[str, Any]) -> str:
+    atom = event_json.get("atom")
+    if not isinstance(atom, dict):
+        return ""
+    return str(atom.get("semantic_role") or "")
+
+
+async def fetch_grammar_evidence_for_window(
+    pool,
+    *,
+    turns: list[dict[str, Any]],
+    node_id: str,
+    enabled: bool,
+) -> tuple[bool, list[str]]:
+    if not enabled or pool is None:
+        return False, []
+    event_ids: list[str] = []
+    repair = False
+    for turn in turns:
+        corr = str(turn.get("correlation_id") or "").strip()
+        if not corr:
+            continue
+        trace_id = f"hub.chat:{node_id}:{corr}"
+        rows = await pool.fetch(
+            """
+            SELECT event_id, event_json
+            FROM grammar_events
+            WHERE trace_id = $1
+            ORDER BY created_at ASC
+            """,
+            trace_id,
+        )
+        for row in rows:
+            eid = str(row["event_id"])
+            event_ids.append(eid)
+            event_json = _parse_event_json(row["event_json"])
+            if _atom_semantic_role(event_json) == "repair_signal":
+                repair = True
+    return repair, event_ids

--- a/orion/memory/crystallization/intake_consolidation_window.py
+++ b/orion/memory/crystallization/intake_consolidation_window.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+from orion.memory.consolidation_gate import ConsolidationGateResult
+from orion.memory.crystallization.schemas import (
+    CrystallizationEvidenceRefV1,
+    CrystallizationGovernanceV1,
+    MemoryCrystallizationV1,
+    _utc_now,
+    new_crystallization_id,
+)
+
+_PROPOSED_BY = "memory_consolidation_intake"
+_POLICY = "consolidation_window_gate_v1"
+
+_KIND_FOR_SHIFT = {
+    "STANCE": "stance",
+    "REPAIR": "open_loop",
+    "TOPIC": "semantic",
+}
+
+
+def _window_summary(turns: list[dict[str, Any]]) -> str:
+    for turn in reversed(turns):
+        prompt = str(turn.get("prompt") or "").strip()
+        if prompt:
+            return prompt[:500]
+    return "Consolidated chat window"
+
+
+def _kind_for_gate(gate: ConsolidationGateResult, turns: list[dict[str, Any]]) -> str:
+    if gate.dominant_shift:
+        return _KIND_FOR_SHIFT.get(gate.dominant_shift, "episode")
+    if len(turns) > 1:
+        return "episode"
+    return "episode"
+
+
+def build_crystallization_from_window(
+    *,
+    memory_window_id: str,
+    turns: list[dict[str, Any]],
+    gate: ConsolidationGateResult,
+    grammar_events: list[dict[str, Any]] | None = None,
+) -> MemoryCrystallizationV1:
+    now = _utc_now()
+    summary = _window_summary(turns)
+    evidence: list[CrystallizationEvidenceRefV1] = []
+    for turn in turns:
+        corr = str(turn.get("correlation_id") or "").strip()
+        if not corr:
+            continue
+        excerpt = f"{turn.get('prompt', '')}\n{turn.get('response', '')}"[:2000] or None
+        evidence.append(
+            CrystallizationEvidenceRefV1(
+                source_kind="chat_turn",
+                source_id=corr,
+                excerpt=excerpt,
+                strength=0.75,
+            )
+        )
+    grammar_ids = list(gate.grammar_event_ids)
+    for event_id in grammar_ids:
+        evidence.append(
+            CrystallizationEvidenceRefV1(
+                source_kind="grammar_event",
+                source_id=event_id,
+                strength=0.6,
+            )
+        )
+    return MemoryCrystallizationV1(
+        crystallization_id=new_crystallization_id(),
+        kind=_kind_for_gate(gate, turns),
+        subject=summary,
+        summary=summary,
+        status="proposed",
+        scope=[f"memory_window:{memory_window_id}"],
+        tags=["consolidation_window"],
+        evidence=evidence,
+        source_grammar_event_ids=grammar_ids,
+        governance=CrystallizationGovernanceV1(
+            proposed_by=_PROPOSED_BY,
+            requires_manual_review=True,
+            sensitivity="private",
+            created_from_policy=_POLICY,
+        ),
+        provenance={
+            "memory_window_id": memory_window_id,
+            "dominant_shift": gate.dominant_shift,
+            "window_novelty_max": gate.window_novelty_max,
+            "window_significance_max": gate.window_significance_max,
+            "gate_reasons": gate.reasons,
+        },
+        created_at=now,
+        updated_at=now,
+    )

--- a/orion/memory/crystallization/intake_consolidation_window.py
+++ b/orion/memory/crystallization/intake_consolidation_window.py
@@ -42,7 +42,6 @@ def build_crystallization_from_window(
     memory_window_id: str,
     turns: list[dict[str, Any]],
     gate: ConsolidationGateResult,
-    grammar_events: list[dict[str, Any]] | None = None,
 ) -> MemoryCrystallizationV1:
     now = _utc_now()
     summary = _window_summary(turns)

--- a/orion/memory/low_info_social.py
+++ b/orion/memory/low_info_social.py
@@ -18,7 +18,7 @@ def is_low_info_social(text: str) -> bool:
         return False
     courtesy_patterns = [
         r"^(hi|hey|hello|yo|sup|hiya|good (morning|afternoon|evening))( there| friend| orion| juniper)?[!. ]*$",
-        r"^(thanks|thank you|awesome|cool|nice|sounds good|all good|doing good|doing well|glad to hear)[!. ]*$",
+        r"^(thanks|thank you|anytime|awesome|cool|nice|sounds good|all good|doing good|doing well|glad to hear)[!. ]*$",
         r"^(how are you|how's it going|hope you're well|hope you are well)[?.! ]*$",
     ]
     if any(re.match(pattern, candidate, flags=re.I) for pattern in courtesy_patterns):

--- a/orion/schemas/memory_consolidation.py
+++ b/orion/schemas/memory_consolidation.py
@@ -34,7 +34,7 @@ class MemoryConsolidationWindowV1(BaseModel):
     turn_correlation_ids: List[str] = Field(default_factory=list)
     status: Literal["open", "closed", "consolidated", "failed"] = "open"
     phase_change_at_close: Optional[str] = None
-    consolidation_status: Optional[Literal["pending", "ok", "failed"]] = None
+    consolidation_status: Optional[Literal["pending", "ok", "failed", "skipped"]] = None
     draft_id: Optional[str] = None
     created_at: datetime
     closed_at: Optional[datetime] = None

--- a/scripts/smoke_memory_consolidation_gate.sh
+++ b/scripts/smoke_memory_consolidation_gate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+PY="${ORION_PYTHON:-}"
+if [[ -z "$PY" ]]; then
+  if [[ -x "$ROOT/orion_dev/bin/python" ]]; then
+    PY="$ROOT/orion_dev/bin/python"
+  elif [[ -x "$ROOT/../../orion_dev/bin/python" ]]; then
+    PY="$ROOT/../../orion_dev/bin/python"
+  else
+    PY="python3"
+  fi
+fi
+
+echo "== consolidation gate: greeting window skip =="
+PYTHONPATH=. "$PY" -m pytest \
+  services/orion-memory-consolidation/tests/test_consolidation_gate.py::test_gate_skips_greeting_window \
+  -q
+
+echo "== consolidation gate: topic window propose =="
+PYTHONPATH=. "$PY" -m pytest \
+  services/orion-memory-consolidation/tests/test_consolidation_gate.py::test_gate_proposes_topic_shift \
+  services/orion-memory-consolidation/tests/test_intake_consolidation_window.py::test_builds_proposed_semantic_crystallization \
+  -q
+
+echo "== consolidation gate: worker skip/propose branches =="
+PYTHONPATH=. "$PY" -m pytest \
+  services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py::test_consolidate_window_skips_greeting_without_draft \
+  services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py::test_consolidate_window_proposes_crystallization \
+  -q
+
+echo "consolidation gate smoke OK"

--- a/services/orion-memory-consolidation/.env_example
+++ b/services/orion-memory-consolidation/.env_example
@@ -42,3 +42,16 @@ MEMORY_GRAPH_SUGGEST_CHARS_PER_TOKEN=3
 MEMORY_GRAPH_SUGGEST_MIN_PROMPT_TOKENS_ESTIMATE=400
 MEMORY_WINDOW_FALLBACK_GAP_SEC=5400
 MEMORY_FAILED_RETRY_INTERVAL_SEC=1800
+
+# Consolidation gate output mode:
+#   crystallization_propose — run gate; skip low-signal windows or propose crystallization (default)
+#   graph_draft — legacy path: LLM suggest + graph draft insert (pre-gate behavior)
+#   skip_only — run gate skip branch only; never propose crystallization or insert graph drafts
+MEMORY_CONSOLIDATION_OUTPUT=crystallization_propose
+# Gate thresholds (0-1) on turn novelty and significance scores
+MEMORY_CONSOLIDATION_MIN_NOVELTY=0.35
+MEMORY_CONSOLIDATION_MIN_SIGNIFICANCE=0.40
+# Fetch read-only grammar event refs to inform gate decisions
+MEMORY_CONSOLIDATION_FETCH_GRAMMAR_EVIDENCE=true
+# Grammar DB DSN override; empty uses POSTGRES_URI consolidation pool
+MEMORY_CONSOLIDATION_GRAMMAR_DSN=

--- a/services/orion-memory-consolidation/README.md
+++ b/services/orion-memory-consolidation/README.md
@@ -1,6 +1,20 @@
 # Orion Memory Consolidation
 
-Subscribes to `orion:memory:turn:persisted` (sql-writer post-commit outbox), classifies each chat turn via LLM gateway quick lane logprobs, patches `chat_history_log.spark_meta`, tracks consolidation windows, and runs `memory_graph_suggest` on boundary closure.
+Subscribes to `orion:memory:turn:persisted` (sql-writer post-commit outbox), classifies each chat turn via LLM gateway quick lane logprobs, patches `chat_history_log.spark_meta`, tracks consolidation windows, and on boundary closure runs a **deterministic consolidation gate** (default) or legacy graph suggest.
+
+## Consolidation output modes
+
+| `MEMORY_CONSOLIDATION_OUTPUT` | Behavior |
+|-------------------------------|----------|
+| `crystallization_propose` (default) | Run `consolidation_memory_gate`; **skip** low-signal windows (`consolidation_status=skipped`) or **propose** `MemoryCrystallizationV1` for governor review |
+| `graph_draft` | Legacy path: LLM `memory_graph_suggest` + pending graph draft insert (manual bridge only) |
+| `skip_only` | Run gate for traceability; always mark window skipped — no crystallization or graph draft |
+
+Gate thresholds: `MEMORY_CONSOLIDATION_MIN_NOVELTY` (default `0.35`), `MEMORY_CONSOLIDATION_MIN_SIGNIFICANCE` (default `0.40`).
+
+Grammar repair evidence (read-only): `MEMORY_CONSOLIDATION_FETCH_GRAMMAR_EVIDENCE=true` queries `grammar_events` by `hub.chat:{NODE_NAME}:{correlation_id}` trace. Optional override DSN: `MEMORY_CONSOLIDATION_GRAMMAR_DSN`.
+
+**Note:** Proposed crystallization IDs are stored in `memory_consolidation_windows.draft_id` until a dedicated `crystallization_id` column migration lands.
 
 ## Channels
 
@@ -9,6 +23,7 @@ Subscribes to `orion:memory:turn:persisted` (sql-writer post-commit outbox), cla
 | In | `orion:memory:turn:persisted` |
 | Out | `orion:chat:history:spark_meta:patch` |
 | Out (threshold) | `orion:signals:memory_consolidation` (`signal.memory_consolidation.turn_change`) |
+| Out (propose) | `orion:memory:crystallization:proposed` (`memory.crystallization.proposed.v1`) |
 
 ## Turn change appraisal
 
@@ -34,6 +49,7 @@ Apply Postgres migration: `services/orion-sql-db/manual_migration_memory_consoli
 
 ```bash
 PYTHONPATH=. python scripts/smoke_memory_consolidation_pipeline.py
+bash scripts/smoke_memory_consolidation_gate.sh
 ```
 
-Requires live stack (bus, sql-writer, postgres, llm-gateway, cortex).
+Gate smoke runs deterministic unit tests (greeting skip + substantive propose). Pipeline smoke requires live stack (bus, sql-writer, postgres, llm-gateway, cortex).

--- a/services/orion-memory-consolidation/app/main.py
+++ b/services/orion-memory-consolidation/app/main.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(settings.SERVICE_NAME)
 
 bus_hunter: Optional[Hunter] = None
 pg_pool: Optional[asyncpg.Pool] = None
+grammar_pg_pool: Optional[asyncpg.Pool] = None
 bus_client: Optional[OrionBusAsync] = None
 _retry_task: Optional[asyncio.Task] = None
 _classify_retry_task: Optional[asyncio.Task] = None
@@ -39,17 +40,25 @@ def _cfg() -> ChassisConfig:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global bus_hunter, pg_pool, bus_client, _retry_task, _classify_retry_task
+    global bus_hunter, pg_pool, grammar_pg_pool, bus_client, _retry_task, _classify_retry_task
 
     dsn = (settings.POSTGRES_URI or "").strip()
     if dsn:
         pg_pool = await asyncpg.create_pool(dsn=dsn, min_size=1, max_size=4)
 
+    grammar_dsn = (settings.MEMORY_CONSOLIDATION_GRAMMAR_DSN or "").strip()
+    if grammar_dsn and grammar_dsn != dsn:
+        grammar_pg_pool = await asyncpg.create_pool(dsn=grammar_dsn, min_size=1, max_size=2)
+
     bus_client = OrionBusAsync(url=settings.ORION_BUS_URL, enabled=settings.ORION_BUS_ENABLED)
     await bus_client.connect()
 
     window_store = WindowStore(pg_pool) if pg_pool is not None else None
-    suggest_runner = ConsolidationSuggestRunner(pg_pool, window_store) if pg_pool and window_store else None
+    suggest_runner = (
+        ConsolidationSuggestRunner(pg_pool, window_store, grammar_pool=grammar_pg_pool or pg_pool)
+        if pg_pool and window_store
+        else None
+    )
 
     async def _handler(env: BaseEnvelope) -> None:
         if not settings.MEMORY_CONSOLIDATION_ENABLED:
@@ -102,6 +111,8 @@ async def lifespan(app: FastAPI):
         await bus_client.close()
     if pg_pool is not None:
         await pg_pool.close()
+    if grammar_pg_pool is not None:
+        await grammar_pg_pool.close()
 
 
 app = FastAPI(title="Orion Memory Consolidation", lifespan=lifespan)

--- a/services/orion-memory-consolidation/app/settings.py
+++ b/services/orion-memory-consolidation/app/settings.py
@@ -60,6 +60,17 @@ class Settings(BaseSettings):
     MEMORY_WINDOW_FALLBACK_GAP_SEC: int = Field(default=5400, alias="MEMORY_WINDOW_FALLBACK_GAP_SEC")
     MEMORY_FAILED_RETRY_INTERVAL_SEC: int = Field(default=1800, alias="MEMORY_FAILED_RETRY_INTERVAL_SEC")
     MEMORY_CLASSIFY_RETRY_INTERVAL_SEC: int = Field(default=120, alias="MEMORY_CLASSIFY_RETRY_INTERVAL_SEC")
+    MEMORY_CONSOLIDATION_OUTPUT: str = Field(
+        default="crystallization_propose", alias="MEMORY_CONSOLIDATION_OUTPUT"
+    )
+    MEMORY_CONSOLIDATION_MIN_NOVELTY: float = Field(default=0.35, alias="MEMORY_CONSOLIDATION_MIN_NOVELTY")
+    MEMORY_CONSOLIDATION_MIN_SIGNIFICANCE: float = Field(
+        default=0.40, alias="MEMORY_CONSOLIDATION_MIN_SIGNIFICANCE"
+    )
+    MEMORY_CONSOLIDATION_FETCH_GRAMMAR_EVIDENCE: bool = Field(
+        default=True, alias="MEMORY_CONSOLIDATION_FETCH_GRAMMAR_EVIDENCE"
+    )
+    MEMORY_CONSOLIDATION_GRAMMAR_DSN: str = Field(default="", alias="MEMORY_CONSOLIDATION_GRAMMAR_DSN")
 
     class Config:
         env_file = ".env"

--- a/services/orion-memory-consolidation/app/window_state.py
+++ b/services/orion-memory-consolidation/app/window_state.py
@@ -27,6 +27,13 @@ class WindowStore:
     async def append_turn(self, turn: MemoryTurnPersistedV1, *, scores: dict[str, Any]) -> None:
         row = await self._get_open_window()
         phase_change = (turn.spark_meta.get("conversation_phase") or {}).get("phase_change")
+        appraisal = scores.get("turn_change_appraisal")
+        spark_meta: dict[str, Any] = {}
+        if isinstance(appraisal, dict):
+            spark_meta["turn_change_appraisal"] = appraisal
+        sig = scores.get("memory_significance_score")
+        if isinstance(sig, (int, float)):
+            spark_meta["memory_significance_score"] = float(sig)
         turn_entry = {
             "correlation_id": turn.correlation_id,
             "prompt": turn.prompt,
@@ -35,6 +42,7 @@ class WindowStore:
             "conversation_boundary_score": scores.get("conversation_boundary_score"),
             "phase_change": phase_change,
             "memory_classify_ts": scores.get("memory_classify_ts"),
+            "spark_meta": spark_meta,
         }
         if row is None:
             window_id = str(uuid4())

--- a/services/orion-memory-consolidation/app/window_state.py
+++ b/services/orion-memory-consolidation/app/window_state.py
@@ -124,6 +124,32 @@ class WindowStore:
             draft_id,
         )
 
+    async def mark_consolidated_skipped(self, memory_window_id: str, *, reasons: list[str]) -> None:
+        await self._pool.execute(
+            """
+            UPDATE memory_consolidation_windows
+            SET status = 'consolidated', consolidation_status = 'skipped'
+            WHERE memory_window_id = $1
+            """,
+            memory_window_id,
+        )
+
+    async def mark_crystallization_proposed(
+        self,
+        memory_window_id: str,
+        *,
+        crystallization_id: str,
+    ) -> None:
+        await self._pool.execute(
+            """
+            UPDATE memory_consolidation_windows
+            SET status = 'consolidated', consolidation_status = 'ok', draft_id = $2
+            WHERE memory_window_id = $1
+            """,
+            memory_window_id,
+            crystallization_id,
+        )
+
     async def mark_failed(self, memory_window_id: str) -> None:
         await self._pool.execute(
             """

--- a/services/orion-memory-consolidation/app/worker.py
+++ b/services/orion-memory-consolidation/app/worker.py
@@ -89,8 +89,9 @@ async def publish_spark_meta_patch(
 
 
 class ConsolidationSuggestRunner:
-    def __init__(self, pool, window_store: WindowStore):
+    def __init__(self, pool, window_store: WindowStore, *, grammar_pool=None):
         self._pool = pool
+        self._grammar_pool = grammar_pool
         self._window_store = window_store
 
     async def consolidate_window(self, window: dict[str, Any], *, bus: OrionBusAsync) -> None:
@@ -108,8 +109,9 @@ class ConsolidationSuggestRunner:
             from orion.memory.crystallization.repository import insert_crystallization
 
             try:
+                grammar_pool = self._grammar_pool or self._pool
                 repair, grammar_event_ids = await fetch_grammar_evidence_for_window(
-                    self._pool,
+                    grammar_pool,
                     turns=turns,
                     node_id=settings.NODE_NAME,
                     enabled=settings.MEMORY_CONSOLIDATION_FETCH_GRAMMAR_EVIDENCE,

--- a/services/orion-memory-consolidation/app/worker.py
+++ b/services/orion-memory-consolidation/app/worker.py
@@ -96,6 +96,84 @@ class ConsolidationSuggestRunner:
     async def consolidate_window(self, window: dict[str, Any], *, bus: OrionBusAsync) -> None:
         window_id = window["memory_window_id"]
         turns = window.get("turns") or []
+        corr_ids = window.get("turn_correlation_ids") or []
+        output_mode = settings.MEMORY_CONSOLIDATION_OUTPUT
+        if output_mode in ("crystallization_propose", "skip_only"):
+            from orion.memory.consolidation_gate import consolidation_memory_gate
+            from orion.memory.consolidation_grammar import fetch_grammar_evidence_for_window
+            from orion.memory.crystallization.bus_emit import emit_crystallization_lifecycle
+            from orion.memory.crystallization.intake_consolidation_window import (
+                build_crystallization_from_window,
+            )
+            from orion.memory.crystallization.repository import insert_crystallization
+
+            try:
+                repair, grammar_event_ids = await fetch_grammar_evidence_for_window(
+                    self._pool,
+                    turns=turns,
+                    node_id=settings.NODE_NAME,
+                    enabled=settings.MEMORY_CONSOLIDATION_FETCH_GRAMMAR_EVIDENCE,
+                )
+                gate = consolidation_memory_gate(
+                    turns=turns,
+                    grammar_repair_signal=repair,
+                    grammar_event_ids=grammar_event_ids,
+                    min_novelty=settings.MEMORY_CONSOLIDATION_MIN_NOVELTY,
+                    min_significance=settings.MEMORY_CONSOLIDATION_MIN_SIGNIFICANCE,
+                )
+                if gate.action == "skip" or output_mode == "skip_only":
+                    await self._window_store.mark_consolidated_skipped(
+                        window_id,
+                        reasons=gate.reasons,
+                    )
+                    for corr in corr_ids:
+                        await publish_spark_meta_patch(
+                            bus,
+                            corr,
+                            {
+                                "consolidation_gate": {
+                                    "action": "skip",
+                                    "reasons": gate.reasons,
+                                }
+                            },
+                        )
+                    return
+
+                crystallization = build_crystallization_from_window(
+                    memory_window_id=window_id,
+                    turns=turns,
+                    gate=gate,
+                )
+                cid = await insert_crystallization(self._pool, crystallization)
+                await self._window_store.mark_crystallization_proposed(
+                    window_id,
+                    crystallization_id=cid,
+                )
+                await emit_crystallization_lifecycle(
+                    bus,
+                    lifecycle="proposed",
+                    crystallization=crystallization,
+                    service_name=settings.SERVICE_NAME,
+                    service_version=settings.SERVICE_VERSION,
+                    node_name=settings.NODE_NAME,
+                )
+                for corr in corr_ids:
+                    await publish_spark_meta_patch(
+                        bus,
+                        corr,
+                        {
+                            "consolidation_gate": {
+                                "action": "propose",
+                                "crystallization_id": cid,
+                            }
+                        },
+                    )
+                return
+            except Exception:
+                logger.exception("memory_consolidation_gate_failed window_id=%s", window_id)
+                await self._window_store.mark_failed(window_id)
+                return
+
         transcript = build_window_transcript(turns)
         try:
             budget_config = suggest_token_budget_config_from_mapping(settings)

--- a/services/orion-memory-consolidation/tests/test_consolidation_gate.py
+++ b/services/orion-memory-consolidation/tests/test_consolidation_gate.py
@@ -52,3 +52,15 @@ def test_gate_proposes_on_repair_signal():
         min_significance=0.40,
     )
     assert result.action == "propose"
+
+
+def test_gate_proposes_substantive_text_below_floors():
+    turns = [_turn("still drowning in move logistics alone", "ok", novelty=0.1, significance=0.2)]
+    result = consolidation_memory_gate(
+        turns=turns,
+        grammar_repair_signal=False,
+        min_novelty=0.35,
+        min_significance=0.40,
+    )
+    assert result.action == "propose"
+    assert "substantive_text" in result.reasons

--- a/services/orion-memory-consolidation/tests/test_consolidation_gate.py
+++ b/services/orion-memory-consolidation/tests/test_consolidation_gate.py
@@ -1,0 +1,54 @@
+from orion.memory.consolidation_gate import consolidation_memory_gate
+
+
+def _turn(prompt, response, novelty=0.1, shift="NONE", significance=0.2):
+    return {
+        "prompt": prompt,
+        "response": response,
+        "spark_meta": {
+            "turn_change_appraisal": {
+                "novelty_score": novelty,
+                "shift_kind": shift,
+                "turn_change_status": "ok",
+            },
+            "memory_significance_score": significance,
+        },
+    }
+
+
+def test_gate_skips_greeting_window():
+    turns = [
+        _turn("hey", "hi there"),
+        _turn("thanks", "anytime"),
+    ]
+    result = consolidation_memory_gate(
+        turns=turns,
+        grammar_repair_signal=False,
+        min_novelty=0.35,
+        min_significance=0.40,
+    )
+    assert result.action == "skip"
+    assert "low_info_social" in result.reasons
+
+
+def test_gate_proposes_topic_shift():
+    turns = [_turn("move logistics alone", "that sounds heavy", novelty=0.72, shift="TOPIC", significance=0.55)]
+    result = consolidation_memory_gate(
+        turns=turns,
+        grammar_repair_signal=False,
+        min_novelty=0.35,
+        min_significance=0.40,
+    )
+    assert result.action == "propose"
+    assert result.dominant_shift == "TOPIC"
+
+
+def test_gate_proposes_on_repair_signal():
+    turns = [_turn("hey", "sorry about earlier")]
+    result = consolidation_memory_gate(
+        turns=turns,
+        grammar_repair_signal=True,
+        min_novelty=0.35,
+        min_significance=0.40,
+    )
+    assert result.action == "propose"

--- a/services/orion-memory-consolidation/tests/test_consolidation_gate.py
+++ b/services/orion-memory-consolidation/tests/test_consolidation_gate.py
@@ -1,4 +1,8 @@
+import pytest
+from unittest.mock import AsyncMock
+
 from orion.memory.consolidation_gate import consolidation_memory_gate
+from orion.memory.consolidation_grammar import fetch_grammar_evidence_for_window
 
 
 def _turn(prompt, response, novelty=0.1, shift="NONE", significance=0.2):
@@ -64,3 +68,34 @@ def test_gate_proposes_substantive_text_below_floors():
     )
     assert result.action == "propose"
     assert "substantive_text" in result.reasons
+
+
+@pytest.mark.asyncio
+async def test_fetch_collects_repair_signal_event_ids():
+    pool = AsyncMock()
+    pool.fetch = AsyncMock(
+        return_value=[
+            {
+                "event_id": "evt-1",
+                "event_json": {"atom": {"semantic_role": "repair_signal"}},
+            }
+        ]
+    )
+    turns = [{"correlation_id": "corr-1"}]
+    repair, event_ids = await fetch_grammar_evidence_for_window(
+        pool,
+        turns=turns,
+        node_id="athena",
+        enabled=True,
+    )
+    assert repair is True
+    assert event_ids == ["evt-1"]
+    pool.fetch.assert_awaited_once_with(
+        """
+            SELECT event_id, event_json
+            FROM grammar_events
+            WHERE trace_id = $1
+            ORDER BY created_at ASC
+            """,
+        "hub.chat:athena:corr-1",
+    )

--- a/services/orion-memory-consolidation/tests/test_intake_consolidation_window.py
+++ b/services/orion-memory-consolidation/tests/test_intake_consolidation_window.py
@@ -1,0 +1,24 @@
+from orion.memory.consolidation_gate import ConsolidationGateResult
+from orion.memory.crystallization.intake_consolidation_window import build_crystallization_from_window
+
+
+def test_builds_proposed_semantic_crystallization():
+    turns = [
+        {
+            "correlation_id": "corr-1",
+            "prompt": "move logistics alone",
+            "response": "that sounds heavy",
+            "spark_meta": {},
+        }
+    ]
+    gate = ConsolidationGateResult(action="propose", dominant_shift="TOPIC", grammar_event_ids=["evt-1"])
+    crys = build_crystallization_from_window(
+        memory_window_id="win-1",
+        turns=turns,
+        gate=gate,
+    )
+    assert crys.status == "proposed"
+    assert crys.kind == "semantic"
+    assert crys.governance.proposed_by == "memory_consolidation_intake"
+    assert "corr-1" in [e.source_id for e in crys.evidence if e.source_kind == "chat_turn"]
+    assert crys.source_grammar_event_ids == ["evt-1"]

--- a/services/orion-memory-consolidation/tests/test_worker_classify_patch.py
+++ b/services/orion-memory-consolidation/tests/test_worker_classify_patch.py
@@ -118,6 +118,7 @@ def test_enrich_spark_meta_patch_skips_degraded():
 
 @pytest.mark.asyncio
 async def test_consolidate_window_persists_draft(monkeypatch):
+    monkeypatch.setattr(worker.settings, "MEMORY_CONSOLIDATION_OUTPUT", "graph_draft")
     draft_data = json.loads(FIXTURE.read_text(encoding="utf-8"))
     pool = AsyncMock()
     window_store = AsyncMock()

--- a/services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py
+++ b/services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py
@@ -192,3 +192,76 @@ async def test_graph_draft_legacy_mode_still_inserts_draft(monkeypatch):
     suggest_mock.assert_awaited_once()
     insert_draft_mock.assert_awaited_once()
     window_store.mark_consolidated.assert_awaited_once_with("win-legacy", draft_id="draft-legacy")
+
+
+@pytest.mark.asyncio
+async def test_skip_only_skips_even_when_gate_proposes(monkeypatch):
+    monkeypatch.setattr(worker.settings, "MEMORY_CONSOLIDATION_OUTPUT", "skip_only")
+    gate = ConsolidationGateResult(
+        action="propose",
+        reasons=["substantive_shift"],
+        dominant_shift="TOPIC",
+    )
+    pool = AsyncMock()
+    grammar_pool = AsyncMock()
+    window_store = AsyncMock()
+    runner = ConsolidationSuggestRunner(pool, window_store, grammar_pool=grammar_pool)
+    bus = AsyncMock()
+    bus.publish = AsyncMock()
+
+    fetch_mock = AsyncMock(return_value=(False, []))
+    with patch(
+        "orion.memory.consolidation_grammar.fetch_grammar_evidence_for_window",
+        new=fetch_mock,
+    ) as fetch_fn, patch(
+        "orion.memory.consolidation_gate.consolidation_memory_gate",
+        return_value=gate,
+    ), patch(
+        "orion.memory.crystallization.repository.insert_crystallization",
+        new=AsyncMock(),
+    ) as insert_crys_mock:
+        window = {
+            "memory_window_id": "win-skip-only",
+            "turn_correlation_ids": [str(uuid4())],
+            "turns": [{"correlation_id": "c", "prompt": "topic", "response": "r", "spark_meta": {}}],
+        }
+        window["turns"][0]["correlation_id"] = window["turn_correlation_ids"][0]
+        await runner.consolidate_window(window, bus=bus)
+
+    fetch_fn.assert_awaited_once()
+    assert fetch_fn.await_args.args[0] is grammar_pool
+    window_store.mark_consolidated_skipped.assert_awaited_once()
+    insert_crys_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_append_turn_persists_turn_change_appraisal_in_spark_meta():
+    import json
+    from datetime import datetime, timezone
+
+    from orion.schemas.memory_consolidation import MemoryTurnPersistedV1
+
+    pool = AsyncMock()
+    pool.fetchrow = AsyncMock(return_value=None)
+    pool.execute = AsyncMock()
+    store = WindowStore(pool)
+    turn = MemoryTurnPersistedV1(
+        correlation_id="corr-appraisal",
+        prompt="move logistics alone",
+        response="that sounds heavy",
+        spark_meta={},
+        created_at=datetime.now(timezone.utc),
+    )
+    scores = {
+        "memory_significance_score": 0.55,
+        "turn_change_appraisal": {
+            "turn_change_status": "ok",
+            "novelty_score": 0.72,
+            "shift_kind": "TOPIC",
+        },
+    }
+    await store.append_turn(turn, scores=scores)
+    turns_json = pool.execute.await_args.args[2]
+    turns = json.loads(turns_json)
+    assert turns[0]["spark_meta"]["turn_change_appraisal"]["shift_kind"] == "TOPIC"
+    assert turns[0]["spark_meta"]["memory_significance_score"] == 0.55

--- a/services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py
+++ b/services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py
@@ -1,0 +1,14 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from app.window_state import WindowStore
+
+
+@pytest.mark.asyncio
+async def test_mark_consolidated_skipped():
+    pool = AsyncMock()
+    pool.execute = AsyncMock()
+    store = WindowStore(pool)
+    await store.mark_consolidated_skipped("win-1", reasons=["low_info_social"])
+    sql = pool.execute.await_args.args[0]
+    assert "skipped" in sql

--- a/services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py
+++ b/services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py
@@ -1,7 +1,75 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
 import pytest
-from unittest.mock import AsyncMock
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = SERVICE_ROOT.parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load(rel_path: str, name: str):
+    for key in list(sys.modules):
+        if key == "app" or key.startswith("app."):
+            del sys.modules[key]
+    sys.path.insert(0, str(SERVICE_ROOT))
+    path = SERVICE_ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+worker = _load("app/worker.py", "memory_consolidation_worker_gate")
+ConsolidationSuggestRunner = worker.ConsolidationSuggestRunner
 
 from app.window_state import WindowStore
+from orion.memory.consolidation_gate import ConsolidationGateResult
+
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "memory_graph" / "joey_cats_draft.json"
+
+
+def _greeting_window():
+    return {
+        "memory_window_id": "win-greet",
+        "turn_correlation_ids": ["corr-1", "corr-2"],
+        "turns": [
+            {
+                "correlation_id": "corr-1",
+                "prompt": "hey",
+                "response": "hi there",
+                "spark_meta": {
+                    "turn_change_appraisal": {
+                        "novelty_score": 0.1,
+                        "shift_kind": "NONE",
+                        "turn_change_status": "ok",
+                    },
+                    "memory_significance_score": 0.2,
+                },
+            },
+            {
+                "correlation_id": "corr-2",
+                "prompt": "thanks",
+                "response": "anytime",
+                "spark_meta": {
+                    "turn_change_appraisal": {
+                        "novelty_score": 0.1,
+                        "shift_kind": "NONE",
+                        "turn_change_status": "ok",
+                    },
+                    "memory_significance_score": 0.2,
+                },
+            },
+        ],
+    }
 
 
 @pytest.mark.asyncio
@@ -12,3 +80,115 @@ async def test_mark_consolidated_skipped():
     await store.mark_consolidated_skipped("win-1", reasons=["low_info_social"])
     sql = pool.execute.await_args.args[0]
     assert "skipped" in sql
+
+
+@pytest.mark.asyncio
+async def test_consolidate_window_skips_greeting_without_draft(monkeypatch):
+    monkeypatch.setattr(worker.settings, "MEMORY_CONSOLIDATION_OUTPUT", "crystallization_propose")
+    pool = AsyncMock()
+    window_store = AsyncMock()
+    runner = ConsolidationSuggestRunner(pool, window_store)
+    bus = AsyncMock()
+    bus.publish = AsyncMock()
+
+    suggest_mock = AsyncMock()
+    monkeypatch.setattr(worker, "suggest_with_escalation", suggest_mock)
+    insert_draft_mock = AsyncMock()
+    monkeypatch.setattr(worker, "insert_pending_draft", insert_draft_mock)
+
+    with patch(
+        "orion.memory.consolidation_grammar.fetch_grammar_evidence_for_window",
+        new=AsyncMock(return_value=(False, [])),
+    ), patch(
+        "orion.memory.crystallization.repository.insert_crystallization",
+        new=AsyncMock(),
+    ) as insert_crys_mock:
+        await runner.consolidate_window(_greeting_window(), bus=bus)
+
+    window_store.mark_consolidated_skipped.assert_awaited_once()
+    suggest_mock.assert_not_awaited()
+    insert_draft_mock.assert_not_awaited()
+    insert_crys_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_consolidate_window_proposes_crystallization(monkeypatch):
+    monkeypatch.setattr(worker.settings, "MEMORY_CONSOLIDATION_OUTPUT", "crystallization_propose")
+    gate = ConsolidationGateResult(action="propose", reasons=["substantive_shift"], dominant_shift="TOPIC")
+    crystallization = MagicMock(crystallization_id="crys-1")
+
+    pool = AsyncMock()
+    window_store = AsyncMock()
+    runner = ConsolidationSuggestRunner(pool, window_store)
+    bus = AsyncMock()
+    bus.publish = AsyncMock()
+
+    suggest_mock = AsyncMock()
+    monkeypatch.setattr(worker, "suggest_with_escalation", suggest_mock)
+
+    with patch(
+        "orion.memory.consolidation_grammar.fetch_grammar_evidence_for_window",
+        new=AsyncMock(return_value=(False, [])),
+    ), patch(
+        "orion.memory.consolidation_gate.consolidation_memory_gate",
+        return_value=gate,
+    ), patch(
+        "orion.memory.crystallization.intake_consolidation_window.build_crystallization_from_window",
+        return_value=crystallization,
+    ), patch(
+        "orion.memory.crystallization.repository.insert_crystallization",
+        new=AsyncMock(return_value="crys-1"),
+    ) as insert_crys_mock, patch(
+        "orion.memory.crystallization.bus_emit.emit_crystallization_lifecycle",
+        new=AsyncMock(return_value=True),
+    ) as emit_mock:
+        window = {
+            "memory_window_id": "win-topic",
+            "turn_correlation_ids": ["corr-1"],
+            "turns": [{"correlation_id": "corr-1", "prompt": "topic", "response": "reply", "spark_meta": {}}],
+        }
+        await runner.consolidate_window(window, bus=bus)
+
+    insert_crys_mock.assert_awaited_once()
+    window_store.mark_crystallization_proposed.assert_awaited_once_with(
+        "win-topic",
+        crystallization_id="crys-1",
+    )
+    emit_mock.assert_awaited_once()
+    suggest_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_graph_draft_legacy_mode_still_inserts_draft(monkeypatch):
+    monkeypatch.setattr(worker.settings, "MEMORY_CONSOLIDATION_OUTPUT", "graph_draft")
+    draft_data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    pool = AsyncMock()
+    window_store = AsyncMock()
+    window_store.mark_consolidated = AsyncMock()
+    runner = ConsolidationSuggestRunner(pool, window_store)
+    bus = AsyncMock()
+    bus.publish = AsyncMock()
+
+    suggest_mock = AsyncMock(return_value={"draft": draft_data})
+    monkeypatch.setattr(worker, "suggest_with_escalation", suggest_mock)
+    insert_draft_mock = AsyncMock(return_value="draft-legacy")
+    monkeypatch.setattr(worker, "insert_pending_draft", insert_draft_mock)
+
+    c1 = str(uuid4())
+    window = {
+        "memory_window_id": "win-legacy",
+        "turn_correlation_ids": [c1],
+        "turns": [
+            {
+                "correlation_id": c1,
+                "prompt": "p",
+                "response": "r",
+                "memory_significance_score": 0.9,
+            }
+        ],
+    }
+    await runner.consolidate_window(window, bus=bus)
+
+    suggest_mock.assert_awaited_once()
+    insert_draft_mock.assert_awaited_once()
+    window_store.mark_consolidated.assert_awaited_once_with("win-legacy", draft_id="draft-legacy")

--- a/tests/test_low_info_social.py
+++ b/tests/test_low_info_social.py
@@ -11,3 +11,7 @@ def test_substantive_is_not_low_info():
 
 def test_thanks_is_low_info():
     assert is_low_info_social("thanks!") is True
+
+
+def test_anytime_is_low_info():
+    assert is_low_info_social("anytime") is True

--- a/tests/test_memory_consolidation_schema_skipped.py
+++ b/tests/test_memory_consolidation_schema_skipped.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timezone
+
+from orion.schemas.memory_consolidation import MemoryConsolidationWindowV1
+
+
+def test_consolidation_status_accepts_skipped():
+    w = MemoryConsolidationWindowV1(
+        memory_window_id="win-1",
+        status="consolidated",
+        consolidation_status="skipped",
+        created_at=datetime.now(timezone.utc),
+    )
+    assert w.consolidation_status == "skipped"


### PR DESCRIPTION
## Code review applied and branch pushed

Review covered the full diff (`8141ed84..47544177`). The code-reviewer subagent hit an API limit, so I ran the review directly and applied the actionable fixes.

### Review fixes applied (`47544177`)

| Issue | Fix |
|-------|-----|
| `MEMORY_CONSOLIDATION_GRAMMAR_DSN` documented but unwired | Optional `grammar_pg_pool` in `main.py`; worker uses `grammar_pool or pool` |
| `skip_only` mode untested | `test_skip_only_skips_even_when_gate_proposes` |
| Appraisal not on window turns at runtime | Already fixed in `b685f413`; added `test_append_turn_persists_turn_change_appraisal_in_spark_meta` |
| Dead `grammar_events` param on intake | Removed from `build_crystallization_from_window` |

### Verification

```text
63 passed (consolidation tests + schema + low_info_social)
bash scripts/smoke_memory_consolidation_gate.sh — OK
```

### Push

Branch pushed: `feat/consolidation-crystallization-gate` → `origin`

Create PR manually (no `gh` auth in this environment):

https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/consolidation-crystallization-gate

Or run locally:

```bash
gh auth login
cd /mnt/scripts/Orion-Sapienform/.worktrees/feat-consolidation-crystallization-gate
gh pr create --title "feat(consolidation): crystallization gate for window closure" --body-file /tmp/pr-body.md
```

### PR description (paste into GitHub)

## Summary

- Add deterministic `consolidation_memory_gate()` — skip low-signal windows or propose `MemoryCrystallizationV1` instead of auto graph drafts
- Wire gate into `consolidate_window` with default `MEMORY_CONSOLIDATION_OUTPUT=crystallization_propose`; legacy `graph_draft` path preserved
- Extend schema with `consolidation_status=skipped`; window store markers for skip and crystallization propose
- Read-only grammar evidence fetch from `grammar_events.event_json`; optional separate grammar Postgres pool via `MEMORY_CONSOLIDATION_GRAMMAR_DSN`
- Persist `turn_change_appraisal` on window turns so gate novelty/shift signals work at runtime

## Outcome moved

Automated consolidation no longer inserts graph drafts for greeting/low-signal windows. Substantive windows produce governor-reviewable crystallization proposals with traceability on `spark_meta.consolidation_gate`.

## Tests run

```text
PYTHONPATH=. orion_dev/bin/python -m pytest \
  services/orion-memory-consolidation/tests \
  tests/test_memory_consolidation_schema_skipped.py \
  tests/test_low_info_social.py -q
# 63 passed

bash scripts/smoke_memory_consolidation_gate.sh
# consolidation gate smoke OK
```

## Review findings fixed

- Substantive text below floors → `substantive_text` propose branch
- Window turns missing appraisal → `append_turn` stores `spark_meta.turn_change_appraisal`
- Grammar DSN unwired → optional grammar pool in `main.py`
- Legacy draft test → pinned to `graph_draft` mode

## Restart required

```bash
docker compose \
  --env-file /mnt/scripts/Orion-Sapienform/.env \
  --env-file /mnt/scripts/Orion-Sapienform/services/orion-memory-consolidation/.env \
  -f /mnt/scripts/Orion-Sapienform/services/orion-memory-consolidation/docker-compose.yml \
  up -d --build orion-memory-consolidation
```

---

**Status: DONE_WITH_CONCERNS** — implementation complete, branch pushed, tests green. PR creation blocked on missing `gh` auth; use the link above to open it.