### PR TITLE
fix(reverie): break substrate import chain for semantic lift in orion…

### DIFF
--- a/orion/core/ids.py
+++ b/orion/core/ids.py
@@ -1,0 +1,17 @@
+"""Dependency-free stable identifiers (hashlib only).
+
+Use from thin services (orion-thought, orion.schemas) instead of importing
+``orion.substrate.ids``, which loads the full substrate package graph stack.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def stable_hash_id(prefix: str, parts: list[str]) -> str:
+    """Return ``{prefix}_{sha256(preimage)[:24]}`` from ordered semantic parts."""
+    normalized = [str(p).strip() for p in parts if p is not None and str(p).strip()]
+    preimage = "|".join(normalized)
+    digest = hashlib.sha256(preimage.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}_{digest}"

--- a/orion/reverie/semantic_lift.py
+++ b/orion/reverie/semantic_lift.py
@@ -72,7 +72,11 @@ def resolve_concern_cards(
             continue
         if corr:
             seen_corr.add(corr)
-        card = row.to_concern_card()
+        try:
+            card = row.to_concern_card()
+        except Exception as exc:
+            logger.warning("concern_card_build_failed ref=%s err=%s", ref, exc)
+            continue
         if card is not None:
             cards.append(card)
         if len(cards) >= MAX_CARDS_PER_TICK:

--- a/orion/schemas/reverie.py
+++ b/orion/schemas/reverie.py
@@ -19,6 +19,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from orion.core.ids import stable_hash_id
 from orion.schemas.thought import CoalitionSnapshotV1
 
 # Minimum grounded interpretation length. Below this, a "thought" is drivel.
@@ -155,7 +156,6 @@ class ConcernCardV1(BaseModel):
             return None
         ref_now = now or datetime.now(timezone.utc)
         age = max(0.0, (ref_now - created_at).total_seconds())
-        from orion.substrate.ids import stable_hash_id
 
         return cls(
             card_id=stable_hash_id("concern", [coalition_ref]),

--- a/orion/substrate/ids.py
+++ b/orion/substrate/ids.py
@@ -2,19 +2,13 @@
 
 from __future__ import annotations
 
-import hashlib
+from orion.core.ids import stable_hash_id
+
+__all__ = ["stable_hash_id", "stable_delta_id", "stable_receipt_id"]
 
 
 def _sorted_join(values: list[str]) -> str:
     return ",".join(sorted(v.strip() for v in values if v and str(v).strip()))
-
-
-def stable_hash_id(prefix: str, parts: list[str]) -> str:
-    """Return ``{prefix}_{sha256(preimage)[:24]}`` from ordered semantic parts."""
-    normalized = [str(p).strip() for p in parts if p is not None and str(p).strip()]
-    preimage = "|".join(normalized)
-    digest = hashlib.sha256(preimage.encode("utf-8")).hexdigest()[:24]
-    return f"{prefix}_{digest}"
 
 
 def stable_delta_id(

--- a/services/orion-thought/.env_example
+++ b/services/orion-thought/.env_example
@@ -22,7 +22,7 @@ ORION_REVERIE_MIN_SALIENCE=0.0
 CHANNEL_REVERIE_THOUGHT=orion:reverie:thought
 
 # Reverie semantic lift (v1). Requires substrate_turn_referent migration + referent rows.
-ORION_REVERIE_SEMANTIC_LIFT_ENABLED=true
+ORION_REVERIE_SEMANTIC_LIFT_ENABLED=false
 ORION_REVERIE_REFERENT_MAX_AGE_HOURS=24
 CHANNEL_REVERIE_CORTEX_EXEC_REQUEST=orion:cortex:exec:request:background
 

--- a/services/orion-thought/app/reverie.py
+++ b/services/orion-thought/app/reverie.py
@@ -263,10 +263,18 @@ async def run_reverie_once(
     correlation_id = str(uuid4())
     concern_cards: list[ConcernCardV1] | None = None
     if settings.reverie_semantic_lift_enabled:
-        loader = default_referent_loader(max_age_hours=settings.reverie_referent_max_age_hours)
-        concern_cards = resolve_concern_cards(broadcast, referent_loader=loader)
-        if reverie_semantic_gate(concern_cards) == "skip":
-            logger.info("reverie tick skipped: reverie_skipped_no_semantic_referent")
+        try:
+            loader = default_referent_loader(max_age_hours=settings.reverie_referent_max_age_hours)
+            concern_cards = resolve_concern_cards(broadcast, referent_loader=loader)
+            if reverie_semantic_gate(concern_cards) == "skip":
+                logger.info("reverie tick skipped: reverie_skipped_no_semantic_referent")
+                return None
+        except Exception as exc:
+            logger.warning(
+                "reverie semantic lift failed corr=%s err=%s; tick skipped",
+                correlation_id,
+                exc,
+            )
             return None
 
     client = cortex_client or CortexExecClient(

--- a/services/orion-thought/tests/test_reverie_semantic_lift_failopen.py
+++ b/services/orion-thought/tests/test_reverie_semantic_lift_failopen.py
@@ -1,0 +1,41 @@
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+from orion.schemas.attention_frame import AttentionBroadcastProjectionV1, AttentionFrameV1, OpenLoopV1
+
+
+def _broadcast():
+    return AttentionBroadcastProjectionV1(
+        frame=AttentionFrameV1(
+            open_loops=[
+                OpenLoopV1(
+                    id="ol-1",
+                    description="deploy",
+                    source_refs=["harness_closure:corr-1"],
+                )
+            ]
+        ),
+        attended_node_ids=["harness_closure:corr-1"],
+        selected_open_loop_id="ol-1",
+        coalition_stability_score=0.6,
+    )
+
+
+@pytest.mark.asyncio
+async def test_semantic_lift_resolver_error_fail_open(monkeypatch):
+    from app import reverie
+
+    monkeypatch.setattr(reverie.settings, "reverie_semantic_lift_enabled", True)
+    bus = AsyncMock()
+    cortex = AsyncMock()
+    with patch.object(
+        reverie,
+        "resolve_concern_cards",
+        side_effect=RuntimeError("resolver boom"),
+    ):
+        result = await reverie.run_reverie_once(
+            bus, broadcast_reader=lambda: _broadcast(), cortex_client=cortex,
+        )
+    assert result is None
+    cortex.execute_plan.assert_not_called()

--- a/services/orion-thought/tests/test_reverie_thin_import_boundary.py
+++ b/services/orion-thought/tests/test_reverie_thin_import_boundary.py
@@ -1,0 +1,60 @@
+"""Import-boundary tests: orion-thought must not load orion.substrate."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from orion.reverie.referent_loader import TurnReferentRow
+from orion.reverie.semantic_lift import resolve_concern_cards
+from orion.schemas.attention_frame import AttentionBroadcastProjectionV1, AttentionFrameV1, OpenLoopV1
+from orion.schemas.reverie import ConcernCardV1
+
+
+def test_stable_hash_id_deterministic() -> None:
+    from orion.core.ids import stable_hash_id
+
+    a = stable_hash_id("concern", ["harness_closure:abc"])
+    b = stable_hash_id("concern", ["harness_closure:abc"])
+    assert a == b
+    assert a == "concern_0ebb4258d3d772159cf641a6"
+
+
+def test_concern_card_from_harness_turn_without_substrate_import() -> None:
+    card = ConcernCardV1.from_harness_turn(
+        coalition_ref="harness_closure:corr-thin",
+        user_message_excerpt="Will the deploy slip if we cut testing?",
+        stance_imperative="Name the testing tradeoff before reassuring.",
+        created_at=datetime(2026, 7, 7, tzinfo=timezone.utc),
+    )
+    assert card is not None
+    assert card.card_id.startswith("concern_")
+
+
+def test_resolve_concern_cards_builds_real_cards_unmocked() -> None:
+    row = TurnReferentRow(
+        correlation_id="corr-thin",
+        coalition_ref="harness_closure:corr-thin",
+        user_message_excerpt="What's my last PR title?",
+        stance_imperative="Search PR metadata for the most recent pull request title.",
+        created_at=datetime(2026, 7, 7, tzinfo=timezone.utc),
+    )
+    loader = MagicMock()
+    loader.load_by_coalition_ref.return_value = row
+    broadcast = AttentionBroadcastProjectionV1(
+        frame=AttentionFrameV1(
+            open_loops=[
+                OpenLoopV1(
+                    id="ol-1",
+                    description="pr title",
+                    source_refs=["harness_closure:corr-thin"],
+                )
+            ]
+        ),
+        attended_node_ids=["harness_closure:corr-thin"],
+        selected_open_loop_id="ol-1",
+        coalition_stability_score=0.5,
+    )
+    cards = resolve_concern_cards(broadcast, referent_loader=loader)
+    assert len(cards) == 1
+    assert "PR title" in cards[0].human_text


### PR DESCRIPTION
## DONE_WITH_CONCERNS

Fix applied, live-verified, branch pushed. `gh pr create` failed (no GitHub auth on this machine).

### Fix applied

| Change | Purpose |
|--------|---------|
| `orion/core/ids.py` | hashlib-only `stable_hash_id` — no substrate import |
| `orion/schemas/reverie.py` | import from `orion.core.ids` |
| `orion/substrate/ids.py` | delegate to core (same hashes) |
| `semantic_lift.py` | fail-open per-row `to_concern_card()` |
| `reverie.py` | fail-open wrap on semantic-lift block |
| `.env_example` | `ORION_REVERIE_SEMANTIC_LIFT_ENABLED=false` |
| 2 new test files | import boundary + resolver fail-safe |

**17 tests passed.**

### Live verification (post-rebuild)

1. **Import path:** `cards 2 gate proceed` — no `requests` error
2. **Cortex:** `RPC emit -> orion:cortex:exec:request:background verb=reverie_narrate`
3. **Published:** `reverie thought published salience=0.720` at 05:30:35 UTC
4. **DB thought (semantic, not meta-narration):**
   > *"The user is concerned about retrieving their latest PR title..."*
5. **Errors since deploy:** 0× `requests`, 0× `chain step failed`

### Branch & PR

- **Branch:** `fix/reverie-semantic-lift-thin-import` → pushed to origin
- **Commit:** `ede50515`
- **Open PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/reverie-semantic-lift-thin-import

Run locally after `gh auth login`:

```bash
gh pr create --base main --head fix/reverie-semantic-lift-thin-import \
  --title "fix(reverie): thin-import boundary for semantic lift in orion-thought"
```

(Full PR body is in the commit message / my draft above.)

### Restart (already done on this machine)

```bash
docker compose --env-file .env --env-file services/orion-thought/.env \
  -f services/orion-thought/docker-compose.yml up -d --build thought
```

### Note

Local `main` may be 1 commit ahead of `origin/main` from an accidental commit-on-main; the fix lives on the feature branch. After merge: `git switch main && git pull --ff-only`.

**Next action:** open the PR link above (or `gh auth login` then re-run `gh pr create`).