### PR TITLE
fix: align concept-induction port and host FCC env example

### DIFF
--- a/services/orion-spark-concept-induction/.env_example
+++ b/services/orion-spark-concept-induction/.env_example
@@ -84,9 +84,9 @@ ORION_METABOLISM_MIN_PREDICTIVE_PRESSURE=0.55
 ORION_METABOLISM_MIN_CURIOSITY_STRENGTH=0.5
 ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED=true
 ORION_EPISODE_FETCH_BACKEND=auto
-# Docker compose mounts host ~/.fcc at /root/.fcc and sets ORION_FCC_ENV_PATH=/root/.fcc/.env
-ORION_FCC_ENV_PATH=/root/.fcc/.env
-# Optional direct key; otherwise resolved from ORION_FCC_ENV_PATH (~/.fcc/.env on host)
+# Host path for local pytest/smoke; docker-compose overrides to /root/.fcc/.env with ~/.fcc mount
+ORION_FCC_ENV_PATH=~/.fcc/.env
+# Optional direct key; otherwise resolved from ORION_FCC_ENV_PATH
 FIRECRAWL_API_KEY=
 ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED=true
 JOURNAL_WRITE_CHANNEL=orion:journal:write

--- a/services/orion-spark-concept-induction/README.md
+++ b/services/orion-spark-concept-induction/README.md
@@ -8,7 +8,7 @@ Bus-native Spark capability that consolidates recent Orion experience into conce
 docker compose -f services/orion-spark-concept-induction/docker-compose.yml --env-file .env up -d orion-spark-concept-induction
 ```
 
-Health check: http://localhost:8500/health
+Health check: http://localhost:8510/health
 
 ## Env lineage
 

--- a/services/orion-spark-concept-induction/app/main.py
+++ b/services/orion-spark-concept-induction/app/main.py
@@ -71,4 +71,4 @@ async def concept_induction_debug():
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8500)
+    uvicorn.run(app, host="0.0.0.0", port=8510)


### PR DESCRIPTION
## Status: DONE

Applied review fixes, live verification passed, branch pushed. `gh auth login` is still required to open the PR from CLI.

### Fixes applied (`c24970dc`)

| File | Change |
|------|--------|
| `.env_example` | `ORION_FCC_ENV_PATH=~/.fcc/.env` (host dev); compose still pins `/root/.fcc/.env` |
| `app/main.py` | uvicorn **8510** (matches compose/Dockerfile) |
| `README.md` | Health URL → `http://localhost:8510/health` |

### Live verification (all passed)

```text
curl localhost:8510/health                          → ok
curl localhost:8510/debug/concept-induction        → bus_consumer_started, world_pulse subscribed
/app/config/autonomy/capability_policy.v1.yaml     → present
/root/.fcc/.env                                    → mounted, firecrawl_key_len=35
maybe_execute_readonly_fetch_after_goal (no backend) → allowed, fetched 2 article(s)
maybe_execute_substrate_act_after_metabolism       → fetch_attempted=true
pytest test_policy_act + test_fetch_backend_resolve → 16 passed
```

### Code review

**Ready to merge** — no material code issues on this diff.

### Branch pushed

`fix/substrate-act-live-verify` → `origin/fix/substrate-act-live-verify`

**Open PR:** https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/substrate-act-live-verify

---

## PR description (paste when opening)

Use the body from the `gh pr create` attempt above, or this short version:

**Title:** `fix: concept-induction port alignment and host FCC env parity`

**Summary:**
- Restore host-native `ORION_FCC_ENV_PATH=~/.fcc/.env` in `.env_example` (compose override unchanged)
- Bind uvicorn to 8510 so host health/debug match published port
- Live verified: policy, FCC, Firecrawl fetch, substrate act, 16 pytest

**Restart after merge:**
```bash
docker compose \
  --env-file .env \
  --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml \
  up -d --build
```

**Still open (out of scope):** bus FIFO lag, journal RPC timeout cascade, LLM gateway stall on `journal.compose`.