### PR TITLE
Fix/fcc GitHub mcp toolset bloat

### DIFF
--- a/config/fcc.env_example
+++ b/config/fcc.env_example
@@ -21,6 +21,11 @@ MODEL_OPUS=chat
 # --- MCP secrets (required when MCP enabled) ---
 GITHUB_PAT=
 FIRECRAWL_API_KEY=
+# github-mcp-server toolset scope — lean default keeps the tool schema small enough
+# for the llamacpp context window. Widen (e.g. repos,pull_requests,issues,actions) as needed.
+# Read-only by default; set GITHUB_READ_ONLY=0 to enable write tools (create_pull_request, etc).
+GITHUB_TOOLSETS=repos,pull_requests
+GITHUB_READ_ONLY=1
 
 # --- AI Town gameplay MCP (optional; needs mesh bootstrap) ---
 # Use mesh-reachable URL (not 127.0.0.1) if read from bridge-network containers.

--- a/orion/fcc/fcc_claude_mcp.template.json
+++ b/orion/fcc/fcc_claude_mcp.template.json
@@ -6,10 +6,14 @@
       "args": [
         "run", "-i", "--rm",
         "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "-e", "GITHUB_TOOLSETS",
+        "-e", "GITHUB_READ_ONLY",
         "ghcr.io/github/github-mcp-server"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "__GITHUB_PAT__"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "__GITHUB_PAT__",
+        "GITHUB_TOOLSETS": "__GITHUB_TOOLSETS__",
+        "GITHUB_READ_ONLY": "__GITHUB_READ_ONLY__"
       }
     },
     "firecrawl": {

--- a/orion/fcc/github_repo_context.py
+++ b/orion/fcc/github_repo_context.py
@@ -86,8 +86,9 @@ def github_mcp_brief_lines(*, workspace: Path | str | None = None) -> list[str]:
             f"(both required; never use the repo name as owner)."
         ),
         (
-            "For latest PR title/number: list_pull_requests with perPage=1, sort=updated, "
-            "direction=desc — not search_pull_requests (returns hundreds of PRs and blows ~65k ctx)."
+            "For latest PR title/number: list_pull_requests with state=all, sort=updated, "
+            "direction=desc, perPage=1. Default state=open returns [] when nothing is open "
+            "(the newest PR is usually merged). Do not use search_pull_requests (blows ~65k ctx)."
         ),
         "Answer with the PR title string only; never paste raw MCP JSON into the reply.",
     ]

--- a/orion/fcc/mcp_config.py
+++ b/orion/fcc/mcp_config.py
@@ -121,10 +121,17 @@ def render_mcp_config(
     _require_tool("docker", error_code="fcc_mcp_docker_missing")
     _require_tool("npx", error_code="fcc_mcp_node_missing")
 
+    # github-mcp-server loads all toolsets by default (~80 tools) which blows the
+    # llamacpp system-prompt budget. Restrict toolsets + read-only to keep init small.
+    github_toolsets = str(fcc_env.get("GITHUB_TOOLSETS") or "repos,pull_requests").strip()
+    github_read_only = str(fcc_env.get("GITHUB_READ_ONLY") or "1").strip()
+
     template = json.loads(_TEMPLATE_PATH.read_text(encoding="utf-8"))
     replacements = {
         "__GITHUB_PAT__": github_pat,
         "__FIRECRAWL_API_KEY__": firecrawl_key,
+        "__GITHUB_TOOLSETS__": github_toolsets,
+        "__GITHUB_READ_ONLY__": github_read_only,
     }
     rendered = _deep_replace(template, replacements)
 

--- a/orion/fcc/tests/test_github_repo_context.py
+++ b/orion/fcc/tests/test_github_repo_context.py
@@ -37,6 +37,7 @@ def test_github_mcp_brief_lines_include_narrow_pr_guidance(
     lines = github_mcp_brief_lines(workspace=Path("/tmp"))
     assert len(lines) == 3
     assert "perPage=1" in lines[1]
+    assert "state=all" in lines[1]
     assert "search_pull_requests" in lines[1]
     assert "never paste raw MCP JSON" in lines[2]
 

--- a/orion/harness/tests/test_fcc_motor_mcp.py
+++ b/orion/harness/tests/test_fcc_motor_mcp.py
@@ -180,6 +180,65 @@ def test_maybe_render_mcp_config_wires_orion_fcc_render(monkeypatch: pytest.Monk
         mcp_config.cleanup_mcp_config(path)
 
 
+def test_maybe_render_mcp_config_passes_github_toolsets_from_fcc_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    import orion.fcc.mcp_config as mcp_config
+
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.delenv("HARNESS_AITOWN_ENABLED", raising=False)
+    monkeypatch.setattr(
+        motor,
+        "load_fcc_env",
+        lambda _p: {
+            "GITHUB_PAT": "ghp_motor_ts",
+            "FIRECRAWL_API_KEY": "fc_motor_ts",
+            "GITHUB_TOOLSETS": "repos,pull_requests,issues",
+            "GITHUB_READ_ONLY": "0",
+        },
+    )
+    monkeypatch.setattr(motor, "expand_env_path", lambda _p: Path("/fake/.fcc/.env"))
+    monkeypatch.setattr(mcp_config.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    path = motor._maybe_render_mcp_config(correlation_id="corr-motor-toolsets")
+    try:
+        assert path is not None
+        github_env = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["github"]["env"]
+        assert github_env["GITHUB_TOOLSETS"] == "repos,pull_requests,issues"
+        assert github_env["GITHUB_READ_ONLY"] == "0"
+    finally:
+        mcp_config.cleanup_mcp_config(path)
+
+
+def test_maybe_render_mcp_config_defaults_github_toolsets_when_env_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    import orion.fcc.mcp_config as mcp_config
+
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.delenv("HARNESS_AITOWN_ENABLED", raising=False)
+    monkeypatch.setattr(
+        motor,
+        "load_fcc_env",
+        lambda _p: {"GITHUB_PAT": "ghp_motor_def", "FIRECRAWL_API_KEY": "fc_motor_def"},
+    )
+    monkeypatch.setattr(motor, "expand_env_path", lambda _p: Path("/fake/.fcc/.env"))
+    monkeypatch.setattr(mcp_config.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    path = motor._maybe_render_mcp_config(correlation_id="corr-motor-toolset-default")
+    try:
+        assert path is not None
+        github_env = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["github"]["env"]
+        assert github_env["GITHUB_TOOLSETS"] == "repos,pull_requests"
+        assert github_env["GITHUB_READ_ONLY"] == "1"
+    finally:
+        mcp_config.cleanup_mcp_config(path)
+
+
 def test_harness_aitown_env_overrides_convex_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HARNESS_AITOWN_CONVEX_URL", "http://host.docker.internal:3210")
     base = {"AITOWN_CONVEX_URL": "http://127.0.0.1:3210", "AITOWN_ADMIN_KEY": "k"}

--- a/services/orion-hub/tests/test_fcc_mcp_config.py
+++ b/services/orion-hub/tests/test_fcc_mcp_config.py
@@ -39,6 +39,42 @@ def test_render_injects_github_and_firecrawl_secrets(mcp_config: Any, tmp_path: 
     assert "orion-aitown" not in data["mcpServers"]
 
 
+def test_render_defaults_github_toolsets_lean_and_read_only(mcp_config: Any, tmp_path: Path) -> None:
+    out = mcp_config.render_mcp_config(
+        correlation_id="corr-toolsets",
+        fcc_env={"GITHUB_PAT": "ghp_test", "FIRECRAWL_API_KEY": "fc_test"},
+        tmp_dir=tmp_path,
+        include_aitown=False,
+    )
+    data = json.loads(out.read_text(encoding="utf-8"))
+    github_env = data["mcpServers"]["github"]["env"]
+    assert github_env["GITHUB_TOOLSETS"] == "repos,pull_requests"
+    assert github_env["GITHUB_READ_ONLY"] == "1"
+    # -e passthrough must be present so the container actually receives the vars.
+    github_args = data["mcpServers"]["github"]["args"]
+    assert "GITHUB_TOOLSETS" in github_args
+    assert "GITHUB_READ_ONLY" in github_args
+
+
+def test_render_github_toolsets_override_from_env(mcp_config: Any, tmp_path: Path) -> None:
+    out = mcp_config.render_mcp_config(
+        correlation_id="corr-toolsets-override",
+        fcc_env={
+            "GITHUB_PAT": "ghp_test",
+            "FIRECRAWL_API_KEY": "fc_test",
+            "GITHUB_TOOLSETS": "repos,pull_requests,issues,actions",
+            "GITHUB_READ_ONLY": "",
+        },
+        tmp_dir=tmp_path,
+        include_aitown=False,
+    )
+    data = json.loads(out.read_text(encoding="utf-8"))
+    github_env = data["mcpServers"]["github"]["env"]
+    assert github_env["GITHUB_TOOLSETS"] == "repos,pull_requests,issues,actions"
+    # Empty override falls back to the read-only default (writes stay off unless explicitly widened).
+    assert github_env["GITHUB_READ_ONLY"] == "1"
+
+
 def test_render_fails_without_github_pat(mcp_config: Any, tmp_path: Path) -> None:
     with pytest.raises(mcp_config.McpPreflightError) as exc:
         mcp_config.render_mcp_config(


### PR DESCRIPTION
## Summary

- Fix the FCC harness "grab the latest PR title" turn, which failed two ways: `list_pull_requests` returned `[]`, then the turn died with `Prompt is too long`.
- Root cause 1 (empty result): the injected GitHub MCP brief told the model to call `list_pull_requests` with `perPage=1, sort=updated, direction=desc` but omitted `state=all`. The tool defaults to `state=open`; with no open PRs, the newest (merged) PR is never returned.
- Root cause 2 (prompt too long): `github-mcp-server` loads all ~80 tools by default. That tool schema overflows the llamacpp context window at `system init`, before any tool call runs.
- Pin the GitHub MCP toolset to `repos,pull_requests` (read-only) via env, wired through the harness read path and proven with tests.

## Outcome moved

- Latest-PR queries hit a merged PR instead of returning `[]`.
- MCP `system init` prompt shrinks from the full ~80-tool GitHub schema to `repos` + `pull_requests` (read-only), so the turn no longer trips `Prompt is too long`.

## Architecture touched

- `orion/fcc` MCP config rendering + GitHub repo brief.
- FCC MCP stdio template (docker `-e` passthrough into the github-mcp-server container).
- Harness read path (`fcc_motor._maybe_render_mcp_config` → `render_mcp_config`).

## Files changed

- `orion/fcc/fcc_claude_mcp.template.json`: pass `GITHUB_TOOLSETS` and `GITHUB_READ_ONLY` into the github-mcp-server container via `-e` + env.
- `orion/fcc/mcp_config.py`: resolve toolsets/read-only from FCC env with lean defaults (`repos,pull_requests`, read-only) and render them.
- `orion/fcc/github_repo_context.py`: brief now requests `state=all, sort=updated, direction=desc, perPage=1` and explains why `state=open` returns `[]`.
- `config/fcc.env_example`: document `GITHUB_TOOLSETS` / `GITHUB_READ_ONLY` operator knobs.
- `services/orion-hub/tests/test_fcc_mcp_config.py`: assert lean toolset defaults + env override.
- `orion/fcc/tests/test_github_repo_context.py`: assert brief includes `state=all`.
- `orion/harness/tests/test_fcc_motor_mcp.py`: prove the harness propagates `GITHUB_TOOLSETS`/`GITHUB_READ_ONLY` from `~/.fcc/.env` into the rendered config, and that defaults apply when absent.

## Env/config changes

- Added operator keys (in `config/fcc.env_example`, i.e. `~/.fcc/.env`): `GITHUB_TOOLSETS=repos,pull_requests`, `GITHUB_READ_ONLY=1`.
- Both optional with safe code defaults, so existing `~/.fcc/.env` files keep working. Add them to widen scope or enable writes (`GITHUB_READ_ONLY=0`).
- Note: `~/.fcc/.env` is the operator FCC secret file, not a `services/*/.env`, so `scripts/sync_local_env_from_example.py` does not manage it — operator hand-adds the two keys only if overriding defaults.

## Tests run

```text
.venv/bin/python -m pytest services/orion-hub/tests/test_fcc_mcp_config.py \
  orion/fcc/tests/test_github_repo_context.py orion/fcc/tests/test_claude_spawn.py -q
# 17 passed

.venv/bin/python -m pytest orion/harness/tests/test_harness_prefix.py \
  services/orion-hub/tests/test_agent_claude_input.py -q
# 9 passed

.venv/bin/python -m pytest orion/harness/tests/test_fcc_motor_mcp.py -q
# 11 passed