### PR TITLE
Fix/reverie semantic lift thin import

### DIFF
--- a/orion/reverie/proposal.py
+++ b/orion/reverie/proposal.py
@@ -49,7 +49,10 @@ def spontaneous_thought_to_candidate(
     a reverie can never auto-dispatch on the propose side. Arming auto-action only
     signals intent; a human still gates it at policy/dispatch.
     """
-    if thought is None or thought.is_hollow():
+    # Trust the stamped hollow decision (set by the guard at generation with the
+    # correct grounding context, incl. semantic-lift audit refs). Recomputing via
+    # is_hollow() here would lose that context and falsely drop valid thoughts.
+    if thought is None or thought.hollow:
         return None
     if thought.salience < min_salience:
         return None

--- a/orion/reverie/semantic_lift.py
+++ b/orion/reverie/semantic_lift.py
@@ -131,11 +131,21 @@ def referent_overlap(interpretation: str, cards: list[ConcernCardV1]) -> bool:
 def enforce_semantic_quality(
     thought: SpontaneousThoughtV1,
     cards: list[ConcernCardV1],
+    *,
+    allowed_refs: list[str] | None = None,
 ) -> SpontaneousThoughtV1:
+    """Stamp the hollow guard for the semantic-lift path.
+
+    `allowed_refs` are the coalition audit refs the concern-card prompt authorized
+    the LLM to cite (loop ids + `source_refs`). They widen the base hollow guard's
+    evidence anchor set so a thought citing the concern's own `harness_closure`
+    ref is not falsely dropped as `unanchored_evidence_outside_coalition`.
+    """
     if infra_vocabulary_hit(thought.interpretation):
         return thought.model_copy(update={"hollow": True, "hollow_reason": "infra_vocabulary"})
     if not referent_overlap(thought.interpretation, cards):
         return thought.model_copy(
             update={"hollow": True, "hollow_reason": "unanchored_no_referent_overlap"}
         )
-    return thought.marked_hollow()
+    extra = set(allowed_refs) if allowed_refs else None
+    return thought.marked_hollow(extra_grounding=extra)

--- a/orion/reverie/tests/test_proposal.py
+++ b/orion/reverie/tests/test_proposal.py
@@ -87,6 +87,25 @@ def test_evidence_refs_capped():
     assert len(c.evidence_refs) <= 200
 
 
+def test_semantic_lift_audit_ref_thought_survives_proposal_path():
+    # A semantic-lift thought cites an audit ref (a loop source_ref) that is NOT
+    # in strict grounding_ids(). It was stamped non-hollow via extra_grounding.
+    # The proposal path must trust that stamp, not recompute strictly and drop it.
+    t = SpontaneousThoughtV1(
+        thought_id="th-2", correlation_id="c-2",
+        coalition=_coalition(),
+        interpretation=GROUNDED,
+        salience=0.8,
+        evidence_refs=["harness_closure:corr-2"],  # outside strict grounding_ids()
+    ).marked_hollow(extra_grounding={"harness_closure:corr-2"})
+    assert not t.hollow
+    # Sanity: without the stamp's extra_grounding, a strict recompute would drop it.
+    assert t.hollow_reason_for() == "unanchored_evidence_outside_coalition"
+    c = spontaneous_thought_to_candidate(t, self_state_id="ss-1")
+    assert c is not None
+    assert c.thought_id == "th-2"
+
+
 # --- contract: the reverie proposal path must never touch orion-actions --------
 
 def test_reverie_proposal_never_imports_orion_actions():

--- a/orion/reverie/tests/test_semantic_lift.py
+++ b/orion/reverie/tests/test_semantic_lift.py
@@ -137,3 +137,28 @@ def test_enforce_semantic_quality_stamps_infra_vocabulary_hollow() -> None:
     )
     out = enforce_semantic_quality(thought, [card])
     assert out.hollow and out.hollow_reason == "infra_vocabulary"
+
+
+def test_enforce_semantic_quality_accepts_audit_ref_evidence() -> None:
+    card = ConcernCardV1.from_harness_turn(
+        coalition_ref="harness_closure:corr-2",
+        user_message_excerpt="What's my last PR title?",
+        stance_imperative="Search PR metadata for the most recent pull request title.",
+        created_at=datetime(2026, 7, 7, tzinfo=timezone.utc),
+    )
+    assert card is not None
+    thought = SpontaneousThoughtV1(
+        thought_id="t",
+        correlation_id="c",
+        coalition=_COALITION,
+        interpretation="I keep circling the request for the latest PR title and whether it resolved.",
+        evidence_refs=["harness_closure:corr-2"],
+    )
+    # harness_closure:corr-2 is a non-selected loop source_ref: in the audit list
+    # but NOT in grounding_ids() — must be accepted when passed as allowed_refs.
+    dropped = enforce_semantic_quality(thought, [card])
+    assert dropped.hollow and dropped.hollow_reason == "unanchored_evidence_outside_coalition"
+    kept = enforce_semantic_quality(
+        thought, [card], allowed_refs=["ol-1", "harness_closure:corr-2"]
+    )
+    assert not kept.hollow

--- a/orion/schemas/reverie.py
+++ b/orion/schemas/reverie.py
@@ -98,12 +98,14 @@ class SpontaneousThoughtV1(BaseModel):
         """
         return self.hollow_reason_for() is not None
 
-    def hollow_reason_for(self) -> str | None:
+    def hollow_reason_for(self, extra_grounding: set[str] | None = None) -> str | None:
         if self.coalition is None:
             return "absent_coalition"
         if len(self.interpretation.strip()) < MIN_INTERPRETATION_CHARS:
             return "interpretation_too_short"
         grounding = self.grounding_ids()
+        if extra_grounding:
+            grounding = grounding | set(extra_grounding)
         if not grounding:
             return "zero_grounding"
         if not self.evidence_refs:
@@ -112,9 +114,15 @@ class SpontaneousThoughtV1(BaseModel):
             return "unanchored_evidence_outside_coalition"
         return None
 
-    def marked_hollow(self) -> "SpontaneousThoughtV1":
-        """Return a copy with the hollow flag + reason stamped from the guard."""
-        reason = self.hollow_reason_for()
+    def marked_hollow(self, extra_grounding: set[str] | None = None) -> "SpontaneousThoughtV1":
+        """Return a copy with the hollow flag + reason stamped from the guard.
+
+        `extra_grounding` widens the accepted evidence anchor set. The semantic-
+        lift path passes the coalition audit refs the prompt authorizes (loop
+        `source_refs` / non-selected loops), which the base `grounding_ids()`
+        deliberately excludes for the legacy coalition-narration path.
+        """
+        reason = self.hollow_reason_for(extra_grounding)
         return self.model_copy(update={"hollow": reason is not None, "hollow_reason": reason})
 
 

--- a/services/orion-proposal-runtime/app/store.py
+++ b/services/orion-proposal-runtime/app/store.py
@@ -80,7 +80,10 @@ class ProposalRuntimeStore:
             if isinstance(payload, str):
                 payload = json.loads(payload)
             thought = SpontaneousThoughtV1.model_validate(payload)
-            return None if thought.is_hollow() else thought
+            # Trust the stamped hollow decision persisted at generation (incl.
+            # semantic-lift audit-ref grounding); recomputing here would lose that
+            # context and falsely drop a valid thought.
+            return None if thought.hollow else thought
         except Exception:
             return None
 

--- a/services/orion-thought/app/reverie.py
+++ b/services/orion-thought/app/reverie.py
@@ -306,7 +306,11 @@ async def run_reverie_once(
             broadcast=broadcast,
         )
         if settings.reverie_semantic_lift_enabled and concern_cards:
-            thought = enforce_semantic_quality(thought, concern_cards)
+            thought = enforce_semantic_quality(
+                thought,
+                concern_cards,
+                allowed_refs=coalition_audit_refs(broadcast),
+            )
             thought = thought.model_copy(update={"llm_profile": "metacog"})
         if chain_context is not None:
             thought = thought.model_copy(


### PR DESCRIPTION
`gh` still isn't authenticated, so I can't auto-open the PR — but everything else is done, isolated in the worktree, and live-verified.

## DONE_WITH_CONCERNS

### What landed (branch `fix/reverie-semantic-lift-thin-import`, pushed)

3 commits, isolated in worktree `/.worktrees/fix-reverie-semantic-lift-thin-import` so the concurrent FCC/consolidation work in the main tree was never touched (no stash, no clobber):

| Commit | Fix |
|--------|-----|
| `ede50515` | Thin-import: `stable_hash_id` → `orion/core/ids.py`, fail-open wraps, `.env_example` default-off |
| `86f7400d` | Widen semantic-lift hollow guard to accept coalition audit refs (`extra_grounding`) |
| `95b4bf3d` | Trust stamped `.hollow` in reverie→proposal consumers (review follow-up) |

### Reviews (subagent-driven)

- **Grounding fix review:** Ready to merge (Yes). Flagged one Important finding → proposal consumers recomputed `is_hollow()` strictly.
- **Fixed that finding** in commit `95b4bf3d` with a regression test (`test_semantic_lift_audit_ref_thought_survives_proposal_path`).

### Tests

```text
60 passed  (orion-thought reverie suite)
20 passed  (orion/reverie proposal + semantic_lift)
18 passed  (thin-import / fail-open / audit-ref grounding)
```

### Live verification (running container)

- 4-step chains published at **05:54** and **06:09 UTC**
- **0 hollow drops, 0 `requests` errors**
- DB thoughts are semantic (concern text), not coalition meta-narration

## Concerns

- **Severity: low — PR not created.** `gh` is unauthenticated. Open it with:
  ```bash
  cd /mnt/scripts/Orion-Sapienform/.worktrees/fix-reverie-semantic-lift-thin-import
  gh auth login   # then:
  gh pr create --base main --head fix/reverie-semantic-lift-thin-import \
    --title "fix(reverie): thin-import boundary + semantic-lift grounding for orion-thought"
  ```
  Or via the browser: https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/reverie-semantic-lift-thin-import (full PR body is ready in commit `95b4bf3d`'s context / my draft above).
- **Severity: low — proposal-runtime rebuild.** The `store.py` change only matters if `ORION_REVERIE_PROPOSE_ENABLED` is on; if so, rebuild `orion-proposal-runtime` too.

## Restart (if redeploying from source)

```bash
docker compose --env-file .env --env-file services/orion-thought/.env \
  -f services/orion-thought/docker-compose.yml up -d --build thought
```

**Next action:** authenticate `gh` (or use the browser link) to open the PR against `main`.