### PR TITLE
fix(action-outcome): reconcile index ownership + add merge-idempotenc…

### DIFF
--- a/orion/autonomy/action_outcomes.py
+++ b/orion/autonomy/action_outcomes.py
@@ -73,7 +73,13 @@ def _load_from_sql(subject: str) -> list[ActionOutcomeRefV1]:
                     observed_at=row["observed_at"],
                 )
             )
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "action_outcome_row_skipped subject=%s action_id=%s error=%s",
+                subject,
+                row.get("action_id"),
+                exc,
+            )
             continue
     return out
 

--- a/services/orion-sql-db/manual_migration_action_outcomes_v1.sql
+++ b/services/orion-sql-db/manual_migration_action_outcomes_v1.sql
@@ -2,9 +2,16 @@
 -- Producer: orion-spark-concept-induction (action.outcome.emit.v1)
 -- Consumer: orion-cortex-exec chat stance (load_action_outcomes)
 --
--- sql-writer applies this automatically on boot via app/main.py lifespan
--- (CREATE TABLE / CREATE INDEX IF NOT EXISTS). This file is the equivalent
--- standalone DDL for manual application against a running Postgres.
+-- On boot, sql-writer creates the table via Base.metadata.create_all (from the
+-- ActionOutcomeSQL model) and creates these indexes via the equivalent DDL in
+-- app/main.py lifespan (CREATE INDEX IF NOT EXISTS). This file is the standalone
+-- equivalent for manual application against a running Postgres; the CREATE TABLE
+-- here is a harmless no-op once the model has already created it.
+--
+-- Indexes are owned here (not via model index=True) to keep a single source of
+-- truth: a composite (subject, observed_at DESC) matching the read query plus a
+-- correlation_id lookup index. A standalone subject index is intentionally omitted
+-- because the composite covers subject-prefix lookups.
 
 CREATE TABLE IF NOT EXISTS action_outcomes (
     action_id TEXT PRIMARY KEY,
@@ -18,6 +25,5 @@ CREATE TABLE IF NOT EXISTS action_outcomes (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_action_outcomes_subject ON action_outcomes (subject);
 CREATE INDEX IF NOT EXISTS idx_action_outcomes_subject_observed_at ON action_outcomes (subject, observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_action_outcomes_correlation_id ON action_outcomes (correlation_id);

--- a/services/orion-sql-writer/app/main.py
+++ b/services/orion-sql-writer/app/main.py
@@ -632,9 +632,8 @@ async def lifespan(app: FastAPI):
                 );
                 """
             )
-            conn.exec_driver_sql(
-                "CREATE INDEX IF NOT EXISTS idx_action_outcomes_subject ON action_outcomes (subject);"
-            )
+            # Composite covers the read query (WHERE subject=? ORDER BY observed_at DESC);
+            # a standalone subject index would be redundant with this prefix.
             conn.exec_driver_sql(
                 "CREATE INDEX IF NOT EXISTS idx_action_outcomes_subject_observed_at ON action_outcomes (subject, observed_at DESC);"
             )

--- a/services/orion-sql-writer/app/models/action_outcome.py
+++ b/services/orion-sql-writer/app/models/action_outcome.py
@@ -10,16 +10,24 @@ class ActionOutcomeSQL(Base):
     Produced by orion-spark-concept-induction via `action.outcome.emit.v1` and
     read back per-subject by orion-cortex-exec's chat stance pipeline. `action_id`
     is the primary key so re-delivered events upsert idempotently.
+
+    Secondary indexes are intentionally NOT declared here via `index=True`. They are
+    owned by the boot DDL in `app/main.py` (and the standalone migration
+    `services/orion-sql-db/manual_migration_action_outcomes_v1.sql`) so there is a
+    single source of truth: a composite `(subject, observed_at DESC)` matching the
+    read query plus a `correlation_id` lookup index. Declaring them here too would
+    make `Base.metadata.create_all` emit duplicate `ix_*` indexes alongside the DDL's
+    `idx_*` indexes on this write-hot table.
     """
 
     __tablename__ = "action_outcomes"
 
     action_id = Column(String, primary_key=True)
-    subject = Column(String, index=True, nullable=False)
+    subject = Column(String, nullable=False)
     kind = Column(String, nullable=False)
     summary = Column(String, nullable=False)
     success = Column(Boolean, nullable=True)
     surprise = Column(Float, nullable=False, default=0.0)
-    observed_at = Column(DateTime(timezone=True), index=True, nullable=True)
-    correlation_id = Column(String, index=True, nullable=True)
+    observed_at = Column(DateTime(timezone=True), nullable=True)
+    correlation_id = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/services/orion-sql-writer/tests/test_action_outcome_sql_shape.py
+++ b/services/orion-sql-writer/tests/test_action_outcome_sql_shape.py
@@ -11,7 +11,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from sqlalchemy import inspect
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
@@ -67,6 +68,51 @@ def test_emit_data_constructs_action_outcome_sql_without_raising() -> None:
     assert row.subject == emit.subject
     assert row.success is True
     assert row.surprise == 0.0
+
+
+def test_merge_redelivery_upserts_one_row_and_preserves_created_at() -> None:
+    """Re-delivery of the same action_id must upsert (one row), not duplicate.
+
+    Mirrors the sql-writer generic write path (`sess.merge(Model(**filtered))`)
+    against in-memory SQLite. Asserts the idempotency claim in the model docstring
+    and that server-defaulted `created_at` survives a re-merge that omits it.
+    """
+    engine = create_engine("sqlite://")
+    ActionOutcomeSQL.__table__.create(bind=engine)
+    Session = sessionmaker(bind=engine)
+
+    def _merge(emit: ActionOutcomeEmitV1) -> None:
+        # Only payload-mapped columns are passed, exactly like _write_row filtering:
+        # created_at is never in the emit payload and relies on the server default.
+        sess = Session()
+        try:
+            sess.merge(ActionOutcomeSQL(**emit.model_dump()))
+            sess.commit()
+        finally:
+            sess.close()
+
+    _merge(_make_emit(summary="first delivery"))
+
+    sess = Session()
+    try:
+        first = sess.get(ActionOutcomeSQL, "fetch-abc-123")
+        original_created_at = first.created_at
+    finally:
+        sess.close()
+    assert original_created_at is not None
+
+    _merge(_make_emit(summary="second delivery", success=False))
+
+    sess = Session()
+    try:
+        rows = sess.query(ActionOutcomeSQL).all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.summary == "second delivery"
+        assert row.success is False
+        assert row.created_at == original_created_at
+    finally:
+        sess.close()
 
 
 def test_emit_roundtrips_from_outcome() -> None:


### PR DESCRIPTION
Option C is implemented, tested, reviewed, migrated, and pushed.

## What I built

Replaced the isolated `/tmp/orion-action-outcomes.json` store with the Orion event-substrate path: **bus event → sql-writer → shared SQL table → SQL read**.

- **Contract** — `ActionOutcomeEmitV1` schema on channel `orion:autonomy:action:outcome` (kind `action.outcome.emit.v1`), registered in `orion/schemas/registry.py` and `orion/bus/channels.yaml`. `SubstrateActResultV1` now carries the full `fetch_outcome`.
- **Producer** — `orion/spark/concept_induction/bus_worker.py` publishes the outcome after a substrate act (exception-isolated) via new `_publish_action_outcome` + `action_outcome_channel`.
- **sql-writer** — new `ActionOutcomeSQL` model / `action_outcomes` table (PK `action_id`, idempotent upsert), `MODEL_MAP` + `DEFAULT_ROUTE_MAP` + subscribe channel + boot DDL, plus standalone `manual_migration_action_outcomes_v1.sql`.
- **Consumer** — `load_action_outcomes` reads the shared SQL store when `ORION_ACTION_OUTCOME_DB_URL` is set, chronological order, with graceful file fallback.

## Migration applied + live-verified

```text
docker exec -i orion-athena-sql-db psql -U postgres -d conjourney < .../manual_migration_action_outcomes_v1.sql
-> CREATE TABLE + 3 indexes; \d action_outcomes confirms schema
-> probe row inserted, read back via load_action_outcomes('orion') (rows_read=1), then deleted (remaining=0)
```

## Tests

97 autonomy + 7 metabolism-hook + 10 sql-writer route/shape tests pass, including new coverage for SQL read ordering/filtering/fallback, producer emit, and column-shape mapping.

## Review

A `code-reviewer` subagent returned **APPROVE** with no Critical/Important issues. I fixed the Minor/Nit items: guaranteed the subscribe channel in `effective_subscribe_channels` (prevents silent drops), `setdefault` engine cache + unset-URL guard, correlation_id clarifying comment, and README entries.

## Env sync

Live `.env` updated for the running deployment: sql-writer subscribe list + route map, cortex-exec `ORION_ACTION_OUTCOME_DB_URL`, concept-induction `BUS_ACTION_OUTCOME_OUT`. `.env` files remain gitignored and unstaged.

## Restart required (rebuild to run new code — DDL alone is inert)

```bash
docker compose --env-file .env --env-file services/orion-sql-writer/.env -f services/orion-sql-writer/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-cortex-exec/.env -f services/orion-cortex-exec/docker-compose.yml up -d --build
```

## PR

Branch `feat/action-outcome-sql-persistence` is pushed. `gh` isn't authenticated in this environment, so open the PR here:

https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/action-outcome-sql-persistence

Work was done in an isolated worktree at `/mnt/scripts/Orion-Sapienform-action-outcome` (your main checkout's unrelated dirty reverie files were left untouched). The full PR body is ready — tell me if you'd like me to drop it into a file or authenticate `gh` to create the PR.

Status: **DONE_WITH_CONCERNS** — the only open item is that the three services must be rebuilt/restarted (a sudo-level deploy I don't run myself) before the live bus path moves; until then the migration and code are in place but the running containers still use the old JSON path.