### PR TITLE
fix(harness): carry tool evidence into finalize so grounded answers s…

### DIFF
--- a/orion/cognition/prompts/harness_finalize_reflect.j2
+++ b/orion/cognition/prompts/harness_finalize_reflect.j2
@@ -10,6 +10,8 @@ INPUTS
 - thought_event: {{ thought_event }}
 - substrate_appraisal: {{ substrate_appraisal }}
 - grammar_receipts: {{ grammar_receipts }}
+- tool_execution (deterministic — tool calls executed this turn):
+{{ tool_execution }}
 - repair_overlay: {{ repair_overlay }}
 {% if finalize_overlay %}
 - finalize_overlay: {{ finalize_overlay }}
@@ -21,6 +23,7 @@ INTEGRATIVE CHECK
 - Decide whether the draft aligns with felt stance and substrate interoception.
 - When substrate hints conflict with draft, prefer misaligned or uncertain — do not hand-wave.
 - When imperative required world-contact but grammar_receipts is empty, lean misaligned or uncertain.
+- When tool_execution lists executed calls, world-contact DID happen: verify the draft against the returned data in grammar_receipts. Do not rule misaligned for "no world contact" or treat a tool-derived answer as ungrounded confabulation when the tool result supports it.
 
 REQUIRED JSON FIELDS
 - imperative: max 300 chars — felt imperative for this turn

--- a/orion/cognition/prompts/orion_voice_finalize.j2
+++ b/orion/cognition/prompts/orion_voice_finalize.j2
@@ -36,6 +36,9 @@ STANCE HARNESS SLICE
 GRAMMAR RECEIPTS (motor action trace)
 {{ grammar_receipts }}
 
+TOOL EXECUTION THIS TURN (deterministic)
+{{ tool_execution }}
+
 VOICE CONTRACT
 {{ voice_contract }}
 {% if finalize_overlay %}
@@ -51,6 +54,7 @@ STYLE RULES (curated Orion voice — not chat_general)
 - When alignment_verdict is misaligned: materially revise the draft — do not paste unchanged or ship confabulated specifics.
 - When alignment_verdict is aligned: refine voice and rhythm; preserve factual content unless hazards require trimming.
 - When grammar_receipts show repo or runtime tool use, preserve code blocks, file paths, commands, and step structure from the draft.
+- Never claim a tool, repo, or data source was unavailable — or that no call was made — when TOOL EXECUTION lists an executed call. Ground the answer in those results; do not confabulate a denial. A misaligned verdict means revise phrasing/framing, not erase tool-derived facts.
 - Never mention internal molecules, appraisal ids, or harness mechanics.
 
 OUTPUT

--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -80,6 +80,56 @@ def extract_final_from_stream_event(
     return accumulated, sid, dur
 
 
+def _tool_result_body_text(body: Any) -> str:
+    if isinstance(body, str):
+        return body
+    if isinstance(body, list):
+        parts = [
+            str(b.get("text"))
+            for b in body
+            if isinstance(b, dict) and b.get("type") == "text" and isinstance(b.get("text"), str)
+        ]
+        return "\n".join(parts)
+    return ""
+
+
+def _summarize_content_blocks(
+    content: Any,
+    *,
+    text_cap: int = 500,
+    tool_result_cap: int = 600,
+) -> str:
+    """Compact one-line summary of a claude message's content blocks.
+
+    Covers text, tool_use, and tool_result so downstream finalize/reflect
+    passes can see that (and what) tools returned — not just an empty role tag.
+    """
+    if not isinstance(content, list):
+        return ""
+    parts: List[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = str(block.get("type") or "")
+        if btype == "text" and isinstance(block.get("text"), str) and block["text"].strip():
+            parts.append(block["text"].strip()[:text_cap])
+        elif btype == "tool_use":
+            name = str(block.get("name") or "tool")
+            args = block.get("input")
+            arg_str = ""
+            if isinstance(args, dict) and args:
+                bits = [f"{k}={str(v)[:60]}" for k, v in list(args.items())[:4]]
+                arg_str = "(" + ", ".join(bits) + ")"
+            parts.append(f"tool_use {name}{arg_str}")
+        elif btype == "tool_result":
+            text = _tool_result_body_text(block.get("content"))
+            err = " [error]" if block.get("is_error") else ""
+            size = f" ({len(text)} chars)" if text else ""
+            snippet = f": {text.strip()[:tool_result_cap]}" if text.strip() else ""
+            parts.append(f"tool_result{err}{size}{snippet}")
+    return " | ".join(p for p in parts if p)
+
+
 def summarize_harness_step(step: Dict[str, Any], *, index: int) -> str:
     if not isinstance(step, dict):
         return f"[{index}] step"
@@ -87,16 +137,22 @@ def summarize_harness_step(step: Dict[str, Any], *, index: int) -> str:
     raw = step.get("raw") if isinstance(step.get("raw"), dict) else step
     if not isinstance(raw, dict):
         return f"[{index}] {stype}"
+    rtype = str(raw.get("type") or stype)
 
-    if stype == "assistant" or raw.get("type") == "assistant":
-        text = _text_blocks_from_assistant(raw)
-        if text.strip():
-            return f"[{index}] assistant: {text.strip()[:500]}"
-    if stype == "result" or raw.get("type") == "result":
+    if rtype in ("assistant", "user"):
+        message = raw.get("message") if isinstance(raw.get("message"), dict) else raw
+        summary = _summarize_content_blocks(message.get("content"))
+        if summary:
+            return f"[{index}] {rtype}: {summary}"
+        return f"[{index}] {rtype}"
+    if rtype == "result":
         result = raw.get("result")
         if isinstance(result, str) and result.strip():
             return f"[{index}] result: {result.strip()[:500]}"
-    return f"[{index}] {stype}"
+    if rtype == "system":
+        subtype = raw.get("subtype") or raw.get("system_subtype")
+        return f"[{index}] system {subtype}" if subtype else f"[{index}] system"
+    return f"[{index}] {rtype}"
 
 
 def _extract_tool_name(step: Dict[str, Any]) -> str | None:

--- a/orion/harness/finalize.py
+++ b/orion/harness/finalize.py
@@ -65,6 +65,30 @@ def grammar_receipt_summaries(receipts: list[GrammarReceiptV1] | None) -> list[d
     ]
 
 
+def tools_called_this_turn(receipts: list[GrammarReceiptV1] | None) -> list[dict[str, str]]:
+    """Deterministic list of tool calls executed this turn (from grammar receipts)."""
+    return [
+        {"step": str(r.step_index), "tool": r.tool_name}
+        for r in (receipts or [])
+        if r.tool_name
+    ]
+
+
+def format_tool_execution_digest(receipts: list[GrammarReceiptV1] | None) -> str:
+    """Human-readable tool-execution digest for finalize prompts.
+
+    Surfaces the deterministic fact that world-contact happened this turn so the
+    reflect/voice passes cannot confabulate "no tool call succeeded" when one did.
+    """
+    calls = tools_called_this_turn(receipts)
+    if not calls:
+        return "none — no tools were called this turn"
+    return "\n".join(
+        f"- step {c['step']}: {c['tool']} (executed; results are in grammar_receipts)"
+        for c in calls
+    )
+
+
 def quick_lane_block_reason(
     *,
     substrate_appraisal: SubstrateFinalizeAppraisalV1,
@@ -149,6 +173,7 @@ def build_finalize_reflect_context(
         "thought_event": thought.model_dump(mode="json"),
         "substrate_appraisal": substrate_appraisal.model_dump(mode="json"),
         "grammar_receipts": grammar_receipt_summaries(grammar_receipts),
+        "tool_execution": format_tool_execution_digest(grammar_receipts),
         "repair_overlay": repair_overlay.model_dump(mode="json"),
         "finalize_overlay": repair_overlay.finalize_overlay,
         "user_message": user_message,
@@ -323,6 +348,7 @@ def build_voice_finalize_context(
         "stance_harness_slice": stance_harness_slice.model_dump(mode="json"),
         "voice_contract": contract_dump,
         "grammar_receipts": grammar_receipt_summaries(grammar_receipts),
+        "tool_execution": format_tool_execution_digest(grammar_receipts),
         "finalize_overlay": repair_overlay.finalize_overlay,
         "user_message": user_message,
         "metadata": {

--- a/orion/harness/tests/test_fcc_motor_summarize.py
+++ b/orion/harness/tests/test_fcc_motor_summarize.py
@@ -1,0 +1,144 @@
+"""Regression: harness step summaries must carry tool_use names and tool_result bodies.
+
+Root cause of the "orion dropped the PR title" bug (corr 9eb363c9): the FCC motor
+drove list_pull_requests correctly (draft_len=70, grounded), but
+`summarize_harness_step` collapsed the tool call to "[N] assistant" and the tool
+result (the PR JSON) to "[N] user". The finalize/reflect pass then saw no evidence
+of world-contact and ruled the grounded draft misaligned, so voice-finalize
+confabulated "no GitHub MCP call succeeded".
+"""
+
+from __future__ import annotations
+
+from orion.harness.fcc_motor import summarize_harness_step
+
+
+def _step(raw: dict) -> dict:
+    return {"type": raw.get("type"), "raw": raw}
+
+
+def test_summarize_tool_use_carries_tool_name_and_args() -> None:
+    step = _step(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "mcp__github__list_pull_requests",
+                        "input": {"owner": "junebug-junie", "repo": "some-repo"},
+                    }
+                ]
+            },
+        }
+    )
+    summary = summarize_harness_step(step, index=1)
+    assert "mcp__github__list_pull_requests" in summary
+    assert "owner=junebug-junie" in summary
+
+
+def test_summarize_tool_result_carries_body() -> None:
+    body = '[{"number":854,"title":"fix(action-outcome): reconcile index ownership"}]'
+    step = _step(
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {"type": "tool_result", "content": body, "tool_use_id": "t1"}
+                ]
+            },
+        }
+    )
+    summary = summarize_harness_step(step, index=2)
+    assert "tool_result" in summary
+    assert "854" in summary
+    assert "fix(action-outcome)" in summary
+
+
+def test_summarize_tool_result_list_content_and_error_flag() -> None:
+    step = _step(
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "is_error": True,
+                        "content": [{"type": "text", "text": "boom"}],
+                    }
+                ]
+            },
+        }
+    )
+    summary = summarize_harness_step(step, index=3)
+    assert "tool_result [error]" in summary
+    assert "boom" in summary
+
+
+def test_summarize_system_subtype() -> None:
+    assert summarize_harness_step(
+        _step({"type": "system", "subtype": "init"}), index=0
+    ) == "[0] system init"
+    assert summarize_harness_step(_step({"type": "system"}), index=0) == "[0] system"
+
+
+def test_summarize_assistant_text_preserved() -> None:
+    step = _step(
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "Checking repo."}]}}
+    )
+    assert summarize_harness_step(step, index=5) == "[5] assistant: Checking repo."
+
+
+def test_pr_title_stream_receipts_carry_tool_evidence() -> None:
+    """Replay the failing turn's stream: tool evidence must survive into summaries."""
+    stream = [
+        _step({"type": "system", "subtype": "init"}),
+        _step(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "mcp__github__list_pull_requests",
+                            "input": {"owner": "junebug-junie"},
+                        }
+                    ]
+                },
+            }
+        ),
+        _step(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": '[{"number":854,"title":"fix(action-outcome): reconcile index ownership"}]',
+                        }
+                    ]
+                },
+            }
+        ),
+        _step({"type": "system", "subtype": "status"}),
+        _step(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "fix(action-outcome): reconcile index ownership"}
+                    ]
+                },
+            }
+        ),
+        _step(
+            {"type": "result", "result": "fix(action-outcome): reconcile index ownership"}
+        ),
+    ]
+    summaries = [summarize_harness_step(s, index=i) for i, s in enumerate(stream)]
+    joined = "\n".join(summaries)
+    # Tool call name survives.
+    assert "mcp__github__list_pull_requests" in joined
+    # The PR JSON (number + title) survives — the reflect pass can now see grounding.
+    assert "854" in joined
+    assert joined.count("fix(action-outcome)") >= 2

--- a/orion/harness/tests/test_finalize_tool_execution.py
+++ b/orion/harness/tests/test_finalize_tool_execution.py
@@ -1,0 +1,91 @@
+"""Option B guard: finalize contexts surface a deterministic tool-execution digest.
+
+This is the anti-confabulation seam. When grammar receipts show a tool call was
+executed, both the reflect (5b) and voice (5c) prompts receive an explicit
+tool_execution digest so the LLM cannot claim "no tool call succeeded".
+"""
+
+from __future__ import annotations
+
+from orion.harness.finalize import (
+    build_finalize_reflect_context,
+    build_voice_finalize_context,
+    format_tool_execution_digest,
+    tools_called_this_turn,
+)
+from orion.harness.tests.fixtures import (
+    make_appraisal,
+    make_reflection,
+    make_repair_overlay,
+    make_thought,
+)
+from orion.schemas.cognition.answer_contract import AnswerContract
+from orion.schemas.harness_finalize import GrammarReceiptV1
+
+
+def _receipts() -> list[GrammarReceiptV1]:
+    return [
+        GrammarReceiptV1(step_index=0, tool_name=None, summary="[0] system init", grammar_event_id="g0"),
+        GrammarReceiptV1(
+            step_index=1,
+            tool_name="mcp__github__list_pull_requests",
+            summary="[1] assistant: tool_use mcp__github__list_pull_requests(owner=junebug-junie)",
+            grammar_event_id="g1",
+        ),
+        GrammarReceiptV1(
+            step_index=2,
+            tool_name=None,
+            summary='[2] user: tool_result (72 chars): [{"number":854,"title":"fix(action-outcome)"}]',
+            grammar_event_id="g2",
+        ),
+    ]
+
+
+def test_tools_called_this_turn_lists_only_tool_steps() -> None:
+    calls = tools_called_this_turn(_receipts())
+    assert calls == [{"step": "1", "tool": "mcp__github__list_pull_requests"}]
+
+
+def test_format_tool_execution_digest_lists_calls() -> None:
+    digest = format_tool_execution_digest(_receipts())
+    assert "mcp__github__list_pull_requests" in digest
+    assert "step 1" in digest
+
+
+def test_format_tool_execution_digest_none_when_no_tools() -> None:
+    digest = format_tool_execution_digest(
+        [GrammarReceiptV1(step_index=0, tool_name=None, summary="s", grammar_event_id="g")]
+    )
+    assert "none" in digest.lower()
+
+
+def test_reflect_context_includes_tool_execution() -> None:
+    ctx = build_finalize_reflect_context(
+        correlation_id="c-1",
+        draft_text="fix(action-outcome): reconcile index ownership",
+        thought=make_thought(),
+        substrate_appraisal=make_appraisal(),
+        repair_overlay=make_repair_overlay(),
+        user_message="grab the latest pr title; skip bash",
+        grammar_receipts=_receipts(),
+    )
+    assert "tool_execution" in ctx
+    assert "mcp__github__list_pull_requests" in ctx["tool_execution"]
+
+
+def test_voice_context_includes_tool_execution() -> None:
+    thought = make_thought()
+    ctx = build_voice_finalize_context(
+        correlation_id="c-1",
+        draft_text="fix(action-outcome): reconcile index ownership",
+        thought=thought,
+        substrate_appraisal=make_appraisal(),
+        reflection=make_reflection(alignment_verdict="misaligned"),
+        stance_harness_slice=thought.stance_harness_slice,
+        voice_contract=AnswerContract(),
+        repair_overlay=make_repair_overlay(),
+        user_message="grab the latest pr title; skip bash",
+        grammar_receipts=_receipts(),
+    )
+    assert "tool_execution" in ctx
+    assert "mcp__github__list_pull_requests" in ctx["tool_execution"]

--- a/services/orion-hub/scripts/fcc_claude_bridge.py
+++ b/services/orion-hub/scripts/fcc_claude_bridge.py
@@ -48,6 +48,52 @@ def build_step_frame(raw: Dict[str, Any]) -> Dict[str, Any]:
     return {"type": str(raw.get("type") or "unknown"), "raw": raw}
 
 
+def _tool_result_body_text(body: Any) -> str:
+    if isinstance(body, str):
+        return body
+    if isinstance(body, list):
+        parts = [
+            str(b.get("text"))
+            for b in body
+            if isinstance(b, dict) and b.get("type") == "text" and isinstance(b.get("text"), str)
+        ]
+        return "\n".join(parts)
+    return ""
+
+
+def _summarize_content_blocks(
+    content: Any,
+    *,
+    text_cap: int = 2000,
+    tool_result_cap: int = 600,
+) -> str:
+    """Compact summary of a claude message's content blocks (text/tool_use/tool_result)."""
+    if not isinstance(content, list):
+        return ""
+    parts: List[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = str(block.get("type") or "")
+        if btype == "text" and isinstance(block.get("text"), str) and block["text"].strip():
+            parts.append(block["text"].strip()[:text_cap])
+        elif btype == "tool_use":
+            name = str(block.get("name") or "tool")
+            args = block.get("input")
+            arg_str = ""
+            if isinstance(args, dict) and args:
+                bits = [f"{k}={str(v)[:60]}" for k, v in list(args.items())[:4]]
+                arg_str = "(" + ", ".join(bits) + ")"
+            parts.append(f"tool_use {name}{arg_str}")
+        elif btype == "tool_result":
+            text = _tool_result_body_text(block.get("content"))
+            err = " [error]" if block.get("is_error") else ""
+            size = f" ({len(text)} chars)" if text else ""
+            snippet = f": {text.strip()[:tool_result_cap]}" if text.strip() else ""
+            parts.append(f"tool_result{err}{size}{snippet}")
+    return " | ".join(p for p in parts if p)
+
+
 def summarize_harness_step(step: Dict[str, Any], *, index: int) -> str:
     """One-line summary of a harness step for chat history / thought_process."""
     if not isinstance(step, dict):
@@ -56,16 +102,22 @@ def summarize_harness_step(step: Dict[str, Any], *, index: int) -> str:
     raw = step.get("raw") if isinstance(step.get("raw"), dict) else step
     if not isinstance(raw, dict):
         return f"[{index}] {stype}"
+    rtype = str(raw.get("type") or stype)
 
-    if stype == "assistant" or raw.get("type") == "assistant":
-        text = _text_blocks_from_assistant(raw)
-        if text.strip():
-            return f"[{index}] assistant: {text.strip()[:2000]}"
-    if stype == "result" or raw.get("type") == "result":
+    if rtype in ("assistant", "user"):
+        message = raw.get("message") if isinstance(raw.get("message"), dict) else raw
+        summary = _summarize_content_blocks(message.get("content"))
+        if summary:
+            return f"[{index}] {rtype}: {summary}"
+        return f"[{index}] {rtype}"
+    if rtype == "result":
         result = raw.get("result")
         if isinstance(result, str) and result.strip():
             return f"[{index}] result: {result.strip()[:500]}"
-    return f"[{index}] {stype}"
+    if rtype == "system":
+        subtype = raw.get("subtype") or raw.get("system_subtype")
+        return f"[{index}] system {subtype}" if subtype else f"[{index}] system"
+    return f"[{index}] {rtype}"
 
 
 def summarize_harness_steps_for_history(steps: List[Dict[str, Any]]) -> str:


### PR DESCRIPTION
Done. Here's the wrap-up.

## What was wrong

You were in **"orion" (unified-turn) mode**, not the raw `agent-claude` lane. The FCC harness did its job — runtime logs for the failing turn (`corr 9eb363c9`) show `grounding=grounded draft_len=70`: the 70-char draft *was* the PR title. Then the finalize chain threw it away:

```
harness_motor_complete ... grounding=grounded draft_len=70
harness_verdict_published alignment=misaligned          ← 5b killed it
orion_voice_finalize ... emitted_chars=283               ← 5c confabulated the hedge
```

**Root cause:** `summarize_harness_step` only pulled text from `assistant` text-blocks and `result` events. Claude emits a tool call as an `assistant` message whose only block is `tool_use`, and the tool result as a `user` message with a `tool_result` block — neither had a branch. So the grammar receipts fed to the finalize LLMs collapsed to content-free `[1] assistant` / `[2] user`, dropping the tool name and the PR JSON. The 5b reflect pass saw no evidence of world-contact, ruled the grounded draft `misaligned` ("commit message prefix, not a PR title retrieval result"), and 5c voice-finalize (misaligned ⇒ revise) invented "no GitHub MCP call succeeded."

## The fix (A + B, as you chose)

- **A** — `summarize_harness_step` now summarizes `tool_use` (name+args), `tool_result` (body, capped, error flag), and `system` subtype. In the motor (`orion/harness/fcc_motor.py`) and the hub twin (`services/orion-hub/scripts/fcc_claude_bridge.py`).
- **B** — deterministic `format_tool_execution_digest` (keyed off the real `tool_name` from receipts, not output regex) injected into both finalize contexts, plus prompt contracts: reflect must *verify* tool-derived drafts instead of rejecting them, and voice must never deny a tool the receipts show ran.
- Regression tests replay the exact failing PR-title stream through receipts + both finalize contexts.

## Verification

- 92 + 27 harness/prompt/cortex tests pass; 3 evals pass; hub parity test (`test_agent_claude_chat_history.py`) unchanged; no lint.
- Code review: **APPROVE**, no material findings.

## Status: DONE_WITH_CONCERNS

Committed and pushed on `fix/unified-turn-tool-grounded-finalize`. One blocker on the last mile:

**Concern**
- Severity: low (process, not code)
- Issue: `gh` is not authenticated here, so I couldn't open the PR. Create it at: https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/unified-turn-tool-grounded-finalize (run `gh auth login` or set `GH_TOKEN`, then `gh pr create` — full body is ready in my commit/PR text above).

**Restart required** (both prompts and Python changed):
```bash
docker compose ... up -d --build orion-athena-harness-governor orion-athena-cortex-exec orion-athena-hub
```

Next action: authenticate `gh` and open the PR, then rebuild the three services and re-run "grab the latest pr title" in orion mode to confirm the title survives to the final response.