### PR TITLE
Fix/autonomy episode journal reliability

### DIFF
--- a/docs/superpowers/specs/2026-07-07-computed-salience-actionable-attention-design.md
+++ b/docs/superpowers/specs/2026-07-07-computed-salience-actionable-attention-design.md
@@ -1,0 +1,297 @@
+# Computed/Learned Salience + Actionable Pending Attention — Design
+
+- Date: 2026-07-07
+- Status: Design (approved for implementation planning)
+- Owner: Juniper / Orion
+- Related review: choke-point review of reverie salience + rumination lock (this chat)
+- Depends on: recommendation #1 (salience discrimination eval) — built as part of this spec
+
+## Arsonist summary
+
+Orion's attention salience is a lie. Reverie salience has been pinned at exactly
+`0.72` for hours because `derive_salience` takes `max()` of an `OpenLoopV1` whose
+score fields are set by a hand-tuned regex/keyword ladder in `build_open_loops`
+(`orion/substrate/attention/scoring.py`), where `predictive = 0.72 if
+target_type in {"plan","future_event","anomaly"}`. The same constant ladder feeds
+`score_loop` → `select_actions` → the substrate coalition competition
+(`orion/substrate/attention_broadcast.py`), which is what keeps re-electing the
+same open loop and drives the observed rumination lock
+(`loop:open-loop-2eb998452183`, resonance violations 32→69, refractory only
+pausing not resolving).
+
+This spec replaces the constant ladder with a single **evidence-derived salience**
+module used everywhere a loop is scored, adds a **habituation/decay** feature so a
+repeatedly-attended loop loses the coalition on its own, and gives Juniper an
+**operator-grade Pending Attention surface** in the Hub to Resolve/Dismiss loops.
+Each human close emits a feedback label; those labels are the seam that later
+upgrades the deterministic combiner into a learned one (hybrid → learned) without
+re-plumbing.
+
+This violates nothing new and fixes three standing rule violations: no-regex-swamp,
+no-keyword-cathedrals, and the §4 miscategorization of a latent judgment (salience)
+hard-coded as deterministic bookkeeping.
+
+## Decisions (locked during brainstorming)
+
+1. **Approach: Hybrid.** Deterministic computed salience now, with a learning seam
+   (feature + outcome telemetry) so a learned combiner can drop in later.
+2. **Scope: one shared salience module** consumed by coalition selection AND reverie.
+   Single source of salience truth; addresses the coupling.
+3. **All-in-one spec:** shared salience + habituation/decay + interactive human
+   close-the-loop + per-loop outcome/label events.
+4. **Closer: human-only.** Juniper Resolves/Dismisses from the Hub. Orion never
+   self-closes this round. Decay self-breaks rumination when Juniper is away.
+5. **Labels:** `Resolve` (positive), `Dismiss` (negative), implicit
+   `decayed_unattended` (weak negative).
+6. **Operator-actionable rows:** plain-language context + metadata, never raw
+   trace ids. Hard UX requirement.
+7. **Combiner form: Approach 2** — feature vector + tiny linear combiner object
+   with hand-seeded weights, refit-able later (same code path becomes learned).
+8. Keep the 7 legacy `OpenLoopV1` score fields for one deprecation release.
+9. Reuse the existing Hub Pending Attention panel; tag cognitive-loop rows as a
+   distinct source from ops notify items.
+10. **Shadow-first rollout**, flag-gated, default-off.
+
+## Current architecture
+
+- Signal detection is a real pipeline: `orion/substrate/attention/detectors/`
+  (`current_turn`, `autonomy`, `concept_induction`, `situation`, `legacy_regex`)
+  each emit `AttentionSignalV1` carrying `salience`, `confidence`, `evidence_refs`,
+  `provenance`. Some carry real upstream salience (e.g. autonomy attention_items),
+  some emit their own constants.
+- `orion/substrate/attention/scoring.py`
+  - `build_open_loops()` converts merged signals → `OpenLoopV1`, **overwriting**
+    signal evidence with a regex/keyword constant ladder
+    (`novelty/continuity/relational/predictive/concept/emotional/askability`).
+  - `score_loop()` = fixed weighted sum of those constant fields.
+- `orion/substrate/attention/policy.py` `select_actions()` ranks loops by
+  `score_loop` and picks one winner.
+- `orion/substrate/attention_frame.py` `build_attention_frame()` — chat-turn scope
+  (consumed by `services/orion-cortex-exec/app/chat_stance.py`).
+- `orion/substrate/attention_broadcast.py`
+  `build_substrate_attention_frame()` + `broadcast_projection_from_frame()` —
+  substrate-wide competition producing `AttentionBroadcastProjectionV1`
+  (`selected_open_loop_id`, `dwell_ticks`, `coalition_stability_score`). This is
+  the reverie's input and the rumination producer.
+- `services/orion-thought/app/reverie.py` `derive_salience()` = `max()` of the
+  selected loop's constant fields, else `coalition_stability_score`.
+- Hub Pending Attention panel exists: `services/orion-hub/templates/index.html`
+  (`#attentionList`, `#attentionCount`, line ~809), currently rendering
+  `orion-notify` `/attention` operational items.
+
+Score consumers of the constant ladder (three call sites, one module to replace):
+`chat_stance.py` (chat turn), `attention_broadcast.py` (substrate broadcast),
+`reverie.py` (`derive_salience`).
+
+Out of scope subsystem: `orion/attention/field_attention/builder.py` (self-state
+attention) is a different pipeline — not touched here.
+
+## Missing questions (resolved)
+
+- Learning label source: no clean per-loop label exists today (only turn-level
+  `turn_outcome.surprise_resolved`). Resolved by making human Resolve/Dismiss the
+  label source; sparse but clean, accumulates for later fitting.
+- Where habituation lives: in the shared salience feature vector (graded), with
+  refractory kept as a coarse backstop.
+
+## Proposed architecture
+
+### A. Shared salience module — `orion/substrate/attention/salience.py`
+
+Pure, import-light (no heavy `requests`/graph deps) so `orion-thought` may import it,
+matching the existing thin-import discipline in reverie/store.
+
+- `SalienceFeaturesV1` (pydantic, registered) — evidence feature vector:
+  - `evidence_strength: float` — max(`signal.salience * signal.confidence`) over
+    the signals backing the loop.
+  - `evidence_breadth: float` — normalized count of distinct detectors /
+    `evidence_refs` backing the loop.
+  - `recurrence: float` — normalized count of recent frames/chains where this
+    loop id / theme key appeared.
+  - `recency: float` — freshness decay since first observation.
+  - `novelty_vs_known: float` — inverse of `already_known` / `known_blob` overlap.
+  - `dwell: float` — normalized `dwell_ticks` from the broadcast.
+  - `habituation: float` — penalty term from repeated recent attendance +
+    resonance-alert history for the theme (higher = more habituated).
+- `LinearSalienceCombiner`:
+  - `weights: dict[str, float]` + `weights_version: str`.
+  - `score(features) -> float` = bounded weighted sum with `habituation` applied
+    as a subtractive/penalty term.
+  - Hand-seeded defaults (documented rationale per weight). No training now.
+- `compute_salience(*, loop, signals, history, now) -> tuple[float, SalienceFeaturesV1]`.
+- `default_combiner()` factory reading optional weights override from config.
+
+### B. Wire the combiner into the three consumers
+
+- `scoring.py`:
+  - `build_open_loops()` stops inventing target-type constants; instead computes
+    `SalienceFeaturesV1` per loop and stores it in `OpenLoopV1.salience_features`.
+    Legacy 7 fields retained one release, populated from evidence (best-effort),
+    marked deprecated in docstring/schema comment.
+  - `score_loop(loop)` → `default_combiner().score(loop.salience_features)`.
+- `attention_broadcast.py`: unchanged selection *mechanism* (still `select_actions`
+  with `max_asks=0`), but now selecting on real salience; habituation flows through
+  `score_loop`, so a high-dwell loop is demoted over ticks.
+- `reverie.py` `derive_salience(broadcast)` → build features for the selected loop
+  and call the same combiner (delete the `max()` logic). Same salience for the same
+  coalition still holds (deterministic), but now it discriminates.
+
+`OpenLoopV1` schema change: add `salience: float = 0.0` and
+`salience_features: dict = {}`. Update `orion/schemas/registry.py`.
+
+### C. Habituation / breaking the rumination lock
+
+`habituation` rises with `dwell_ticks`, recent re-selection count of the theme
+(`substrate_reverie_chain` theme events / a lightweight attention-visit ledger),
+and resonance-alert presence for the theme. As it rises, combiner salience for the
+stuck loop falls until a competitor wins `select_actions`. Inhibition-of-return.
+Refractory (`substrate_reverie_refractory`) stays as a coarse backstop.
+Flag: `ORION_ATTENTION_HABITUATION_ENABLED`.
+
+### D. Operator-actionable Pending Attention
+
+- `PendingAttentionCardV1` (registered) — human-readable card per surfaced loop:
+  - `loop_id`, `theme_key`
+  - `title` — plain phrase (never a bare id)
+  - `why_it_matters` — plain language
+  - `what_triggered` — evidence in words (detectors/signals + count)
+  - `age_seconds`, `recurrence_count`, `salience`, `weights_version`
+  - `top_contributing_features: list[str]` — features rendered in words
+  - `narrative` — reuse reverie `interpretation` for the theme when present;
+    deterministic template fallback otherwise. Never id-only.
+  - `status` — `pending` / `resolved` / `dismissed`
+- Surfacing policy: only loops worth a human's time (resonance-flagged OR
+  high-salience-unresolved beyond an age threshold), to keep the panel quiet.
+- Hub render: existing Pending Attention panel; cognitive-loop rows tagged with a
+  distinct source badge vs ops notify items. Resolve / Dismiss buttons per row.
+- Privacy: cards carry only plain summaries; no raw private trace material,
+  journal text, or blocked material. Summaries preserve privacy boundaries.
+- Flag: `ORION_ATTENTION_PENDING_CARDS_ENABLED`.
+
+### E. Learning seam (hybrid → learned later)
+
+Event-substrate path (`event → schema → trace → reducer → projection → eval → UI`):
+
+- `AttentionSalienceTraceV1` on `orion:attention:salience:trace` — every scored
+  loop logs feature vector + score + `weights_version` → reducer →
+  `attention_salience_trace` table.
+- `AttentionLoopOutcomeV1` on `orion:attention:loop_outcome` — verdict
+  `resolved` / `dismissed` / `decayed_unattended`, actor, `salience_at_close`,
+  feature snapshot → reducer → `attention_loop_outcome` table (the labels).
+- Closing a loop also writes resolved/suppressed state so it exits the coalition
+  and won't re-ignite (resolves, not just pauses).
+- `scripts/refit_salience_weights.py` — documented, **not run now**. Joins traces +
+  labels, emits candidate weights + `weights_version`. Ships as a stub with a unit
+  test proving it consumes the label table; production weights stay seeded.
+
+## Data flow
+
+```text
+detectors → AttentionSignalV1
+  → build_open_loops (compute SalienceFeaturesV1, no constants)
+  → score_loop = LinearSalienceCombiner.score(features)   [habituation applied]
+  → select_actions → coalition winner
+      ├─ chat: chat_stance.py
+      ├─ broadcast: attention_broadcast.py → AttentionBroadcastProjectionV1
+      │     → reverie derive_salience (same combiner)
+      └─ surfacing: PendingAttentionCardV1 → Hub Pending Attention panel
+  → telemetry: AttentionSalienceTraceV1
+  → human Resolve/Dismiss → AttentionLoopOutcomeV1 (label) + suppress loop
+  → reducers → attention_salience_trace / attention_loop_outcome tables
+  → (later) refit_salience_weights.py → new weights_version
+```
+
+## Schema / bus / API changes
+
+- Added schemas: `SalienceFeaturesV1`, `PendingAttentionCardV1`,
+  `AttentionLoopOutcomeV1`, `AttentionSalienceTraceV1`.
+- Changed schema: `OpenLoopV1` + `salience`, `salience_features` (additive,
+  back-compatible; legacy 7 fields deprecated for one release).
+- Registry: register the four new schemas (`orion/schemas/registry.py`).
+- Channels (`orion/bus/channels.yaml`): `orion:attention:salience:trace`,
+  `orion:attention:loop_outcome`. Pending cards exposed via Hub API projection
+  (no new consumed bus channel required for rendering; publish trace/outcome only).
+- Hub API (`services/orion-hub`): `GET /api/attention/loops`,
+  `POST /api/attention/loops/{id}/resolve`, `POST /api/attention/loops/{id}/dismiss`.
+- Tables: `attention_salience_trace`, `attention_loop_outcome` (+ loop
+  resolved/suppressed state; may reuse `substrate_reverie_refractory` for suppress).
+
+## Env / config changes
+
+- `ORION_ATTENTION_SALIENCE_V2_ENABLED` (default false) — shadow vs live switch.
+- `ORION_ATTENTION_HABITUATION_ENABLED` (default false).
+- `ORION_ATTENTION_PENDING_CARDS_ENABLED` (default false).
+- Optional `ORION_ATTENTION_SALIENCE_WEIGHTS` (JSON override; empty = seeded).
+- Update every touched service `.env_example` and run
+  `python scripts/sync_local_env_from_example.py`.
+
+## Rollout (shadow-first)
+
+1. Land module + schemas + telemetry with `SALIENCE_V2` off: compute new salience
+   in shadow, log `AttentionSalienceTraceV1` for both old and new, do not change
+   selection.
+2. Run the #1 discrimination eval + inspect shadow traces for parity/discrimination.
+3. Flip `SALIENCE_V2` on for selection; enable habituation; watch the rumination
+   replay + live resonance counts drop.
+4. Enable pending cards + closure.
+
+Rollback = flip flags off → old constant path. Each stage independently reversible.
+
+## Non-goals
+
+- Training/fitting the model now (weights stay seeded; refit documented, not run).
+- Orion autonomous closure (human-only this round).
+- Approach-3 embedding/similarity salience.
+- Rewriting the detectors' internal constants (separate cleanup).
+- `orion/attention/field_attention/` self-state pipeline.
+
+## Tests & evals
+
+Gate tests (fast, deterministic):
+- `test_salience_discrimination_eval` (**recommendation #1**, built here first):
+  distinct coalitions → distinct salience; fails on today's constants.
+- Combiner unit tests: per-feature monotonicity; habituation strictly lowers
+  salience across repeated visits; bounded [0,1]; deterministic for same input.
+- Rumination replay test: same high-pressure node over N ticks → a competitor wins
+  once habituation engages (lock breaks). Uses injected clock/history.
+- Card legibility test: a `PendingAttentionCardV1` never renders an id-only string;
+  `why_it_matters` and `title` always plain text.
+- Closure e2e test: resolve/dismiss emits `AttentionLoopOutcomeV1` + suppresses
+  the loop (won't re-select).
+- Learning-seam test: outcomes land in `attention_loop_outcome`; refit stub reads
+  them and returns candidate weights.
+- Contract tests: new channels registered; schemas in registry; producer/consumer
+  round-trip for trace + outcome.
+
+Evals:
+- Salience discrimination eval (above) as the acceptance gate for the flip.
+- Reverie quality unaffected/improved (existing reverie evals still pass).
+
+## Acceptance checks
+
+- #1 discrimination eval passes.
+- Rumination replay proves the lock breaks with habituation on.
+- Shadow parity/discrimination reviewed before the live flip.
+- Hub shows legible, actionable rows; Resolve/Dismiss works end-to-end and writes
+  labels to `attention_loop_outcome`.
+- No raw private trace material in cards.
+- All flags default-off; old path intact when off.
+
+## Risks / concerns
+
+- Severity medium: changing coalition selection is system-wide (chat + broadcast).
+  Mitigation: shadow-first + independent flags + replay test.
+- Severity medium: seeded weights are still human-chosen; "computed" not "learned"
+  until labels accumulate. Mitigation: explicit hybrid framing; telemetry from day
+  one; refit path documented.
+- Severity low: sparse human labels. Mitigation: implicit `decayed_unattended`
+  weak-negative + traces give feature distributions even without labels.
+- Severity low: surfacing noise. Mitigation: strict surfacing policy (resonance /
+  high-salience-unresolved + age threshold).
+
+## Recommended next patch
+
+Phase 1 (contract + module, shadow): `salience.py` + `SalienceFeaturesV1` +
+`OpenLoopV1` fields + registry + the #1 discrimination eval + combiner unit tests,
+all behind `SALIENCE_V2` off. Smallest slice that creates the seam and proves the
+stub with a failing-then-passing eval.

--- a/orion/autonomy/policy_act.py
+++ b/orion/autonomy/policy_act.py
@@ -244,15 +244,27 @@ async def maybe_execute_substrate_act_after_metabolism(
     if not episode_journal_enabled or fetch_outcome is None:
         return result
 
-    journal_decision, journal_payload = await maybe_compose_autonomy_episode_after_fetch(
-        goal=synthetic_goal,
-        drive_state=drive_state,
-        curiosity_signals=curiosity_signals,
-        spawned_correlation_id=run_id,
-        fetch_outcome=fetch_outcome,
-        journal_dispatch=journal_dispatch,
-        budget_used=budget_used,
-    )
+    # The journal compose step issues an RPC (cortex-exec) that can time out. A journal
+    # failure must NOT discard an already-successful fetch outcome: isolate it so the
+    # caller still receives `result` (with fetch_outcome) and can persist the fetch.
+    try:
+        journal_decision, journal_payload = await maybe_compose_autonomy_episode_after_fetch(
+            goal=synthetic_goal,
+            drive_state=drive_state,
+            curiosity_signals=curiosity_signals,
+            spawned_correlation_id=run_id,
+            fetch_outcome=fetch_outcome,
+            journal_dispatch=journal_dispatch,
+            budget_used=budget_used,
+        )
+    except Exception:
+        logger.warning(
+            "substrate_episode_journal_failed goal=%s spawned=%s",
+            synthetic_goal.artifact_id,
+            run_id,
+            exc_info=True,
+        )
+        return result
     if journal_decision.outcome == "allowed" and journal_payload is not None:
         entry_id = None
         if isinstance(journal_payload.get("write"), dict):

--- a/orion/autonomy/tests/test_episode_journal.py
+++ b/orion/autonomy/tests/test_episode_journal.py
@@ -48,10 +48,13 @@ async def test_dispatch_autonomy_episode_journal_publishes_write() -> None:
             cortex_request_channel="orion:cortex:request",
             cortex_result_prefix="orion:cortex:result",
             journal_write_channel="orion:journal:write",
-            timeout_sec=12.0,
+            timeout_sec=120.0,
         )
 
     bus.rpc_request.assert_awaited_once()
+    # The compose RPC (~16s observed) must honor the caller's timeout budget, not
+    # a hard-coded value; a too-tight timeout silently drops the episode journal.
+    assert bus.rpc_request.await_args.kwargs["timeout_sec"] == 120.0
     bus.publish.assert_awaited_once()
     publish_channel, publish_env = bus.publish.await_args.args
     assert publish_channel == "orion:journal:write"

--- a/orion/autonomy/tests/test_policy_act.py
+++ b/orion/autonomy/tests/test_policy_act.py
@@ -267,3 +267,29 @@ async def test_substrate_act_denied_without_gap_signal(monkeypatch) -> None:
         fetch_backend=AsyncMock(),
     )
     assert result.fetch_attempted is False
+
+
+@pytest.mark.asyncio
+async def test_substrate_act_preserves_fetch_when_journal_dispatch_fails(monkeypatch, tmp_path) -> None:
+    """Regression: a journal-compose RPC failure (e.g. cortex-exec timeout) must NOT
+    discard an already-successful fetch outcome, so the caller can still persist it."""
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED", "true")
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    backend = AsyncMock(return_value={"success": True, "urls": ["https://example.com/a"]})
+    journal_dispatch = AsyncMock(side_effect=TimeoutError("cortex journal rpc timed out"))
+    result = await maybe_execute_substrate_act_after_metabolism(
+        episode_intent=_intent(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        fetch_backend=backend,
+        journal_dispatch=journal_dispatch,
+        episode_journal_enabled=True,
+    )
+    # Fetch still succeeded and is returned despite the journal failure.
+    assert result.fetch_attempted is True
+    assert result.fetch_outcome is not None
+    assert result.fetch_outcome.success is True
+    # Journal was attempted but failed, so no journal entry recorded.
+    assert result.journal_attempted is False
+    journal_dispatch.assert_awaited_once()

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -166,7 +166,7 @@ class ConceptWorker:
             cortex_request_channel=self.cfg.cortex_request_channel,
             cortex_result_prefix=self.cfg.cortex_result_prefix,
             journal_write_channel=self.cfg.journal_write_channel,
-            timeout_sec=self.cfg.cortex_timeout_sec,
+            timeout_sec=self.cfg.autonomy_episode_journal_timeout_sec,
             session_id=self.cfg.journal_session_id,
             user_id=self.cfg.journal_user_id,
             author=self.cfg.journal_author,

--- a/orion/spark/concept_induction/settings.py
+++ b/orion/spark/concept_induction/settings.py
@@ -142,6 +142,13 @@ class ConceptSettings(BaseSettings):
         False,
         alias="ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED",
     )
+    # Journal compose is an LLM RPC to cortex-exec (~16s observed). The generic
+    # cortex_timeout_sec (12s) is too tight and silently drops the episode journal,
+    # so give the compose its own generous budget.
+    autonomy_episode_journal_timeout_sec: float = Field(
+        120.0,
+        alias="ORION_AUTONOMY_EPISODE_JOURNAL_TIMEOUT_SEC",
+    )
     episode_fetch_backend: str = Field("auto", alias="ORION_EPISODE_FETCH_BACKEND")
     orion_fcc_env_path: str = Field("~/.fcc/.env", alias="ORION_FCC_ENV_PATH")
     firecrawl_api_key: str = Field("", alias="FIRECRAWL_API_KEY")
@@ -216,6 +223,9 @@ class ConceptSettings(BaseSettings):
 
     # Heartbeat
     heartbeat_interval_sec: float = Field(10.0, alias="HEARTBEAT_INTERVAL_SEC")
+
+    # Logging
+    log_level: str = Field("INFO", alias="LOG_LEVEL")
 
     class Config:
         env_file = ".env"

--- a/orion/spark/concept_induction/tests/test_metabolism_hook.py
+++ b/orion/spark/concept_induction/tests/test_metabolism_hook.py
@@ -256,3 +256,32 @@ async def test_substrate_act_runs_when_goal_suppressed(monkeypatch) -> None:
     substrate_act_mock.assert_awaited_once()
     call_kwargs = substrate_act_mock.await_args.kwargs
     assert call_kwargs["spawned_correlation_id"] == "wp-run-hook"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_journal_timeout_not_cortex_timeout(monkeypatch) -> None:
+    # Guard against regressing bus_worker back to cfg.cortex_timeout_sec: the
+    # journal compose (~16s) must get the generous dedicated budget, not the tight
+    # generic cortex timeout, or the episode journal silently times out.
+    monkeypatch.setenv("CORTEX_TIMEOUT_SEC", "12")
+    monkeypatch.setenv("ORION_AUTONOMY_EPISODE_JOURNAL_TIMEOUT_SEC", "120")
+    cfg = ConceptSettings()
+    worker = ConceptWorker(cfg)
+
+    dispatch_mock = AsyncMock(return_value={"write": {"entry_id": "e1"}})
+    monkeypatch.setattr(
+        "orion.spark.concept_induction.bus_worker.dispatch_autonomy_episode_journal",
+        dispatch_mock,
+    )
+
+    await worker._dispatch_autonomy_episode_journal(
+        _world_pulse_envelope(),
+        goal_artifact_id="goal-x",
+        spawned_correlation_id="wp-run-hook",
+        narrative_seed="seed",
+    )
+
+    dispatch_mock.assert_awaited_once()
+    passed = dispatch_mock.await_args.kwargs["timeout_sec"]
+    assert passed == cfg.autonomy_episode_journal_timeout_sec == 120.0
+    assert passed != cfg.cortex_timeout_sec

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -137,6 +137,8 @@ SYNC_EXACT = frozenset(
         "ORION_DREAM_COMPACTION_DOWNSCALE_ONLY",
         "DREAM_COMPACTION_SNAPSHOT_DIR",
         "GOAL_DRIVE_ORIGIN_SOURCE",
+        # Worker log level (stdlib->loguru bridge) — must stay in sync so traces are visible.
+        "LOG_LEVEL",
     }
 )
 

--- a/services/orion-spark-concept-induction/.env_example
+++ b/services/orion-spark-concept-induction/.env_example
@@ -12,6 +12,9 @@ ORION_BUS_ENFORCE_CATALOG=true
 ORION_BUS_ENABLED=true
 HEARTBEAT_INTERVAL_SEC=10
 
+# Logging (stdlib->loguru bridge level for worker traces e.g. substrate_policy_act)
+LOG_LEVEL=INFO
+
 # Channels
 BUS_INTAKE_CHANNELS=["orion:chat:history:log","orion:chat:history:turn","orion:chat:social:turn","orion:chat:social:stored","orion:chat:gpt:turn","orion:chat:gpt:message:log","orion:collapse:sql-write","orion:spark:telemetry","orion:metacognition:tick","orion:cognition:trace","orion:substrate:self_state","orion:feedback:frame","orion:world_pulse:run:result"]
 BUS_PROFILE_OUT=orion:spark:concepts:profile
@@ -90,6 +93,8 @@ ORION_FCC_ENV_PATH=~/.fcc/.env
 # Optional direct key; otherwise resolved from ORION_FCC_ENV_PATH
 FIRECRAWL_API_KEY=
 ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED=true
+# Journal compose LLM RPC budget (~16s observed); keep well above CORTEX_TIMEOUT_SEC.
+ORION_AUTONOMY_EPISODE_JOURNAL_TIMEOUT_SEC=120
 JOURNAL_WRITE_CHANNEL=orion:journal:write
 JOURNAL_SESSION_ID=orion
 JOURNAL_USER_ID=juniper

--- a/services/orion-spark-concept-induction/app/main.py
+++ b/services/orion-spark-concept-induction/app/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -10,8 +11,43 @@ from orion.spark.concept_induction.bus_worker import ConceptWorker
 from .settings import settings
 
 
+class _InterceptHandler(logging.Handler):
+    """Route stdlib logging records into loguru.
+
+    The worker (`orion.spark.concept_induction.*`, `orion.autonomy.*`) logs via
+    stdlib `logging`, while this service logs via loguru. Without this bridge the
+    stdlib loggers have no handler and INFO records fall through to stdlib's
+    WARNING-only lastResort handler, silently dropping worker traces such as
+    `substrate_policy_act`.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+        frame, depth = logging.currentframe(), 2
+        while frame is not None and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+
+def _install_stdlib_logging_bridge(level: str = "INFO") -> None:
+    log_level = logging.getLevelName(str(level).strip().upper())
+    if not isinstance(log_level, int):
+        log_level = logging.INFO
+    logging.basicConfig(handlers=[_InterceptHandler()], level=log_level, force=True)
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "orion", "orion.autonomy"):
+        std_logger = logging.getLogger(name)
+        std_logger.handlers = [_InterceptHandler()]
+        std_logger.propagate = False
+        std_logger.setLevel(log_level)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    _install_stdlib_logging_bridge(settings.log_level)
     worker = ConceptWorker(settings)
     app.state.worker = worker
     app.state.concept_worker = worker


### PR DESCRIPTION
## Summary

- **Logging bridge**: route stdlib `logging` → `loguru` in `orion-spark-concept-induction` so worker traces (`substrate_policy_act`, episode fetch/journal) actually emit. Previously suppressed, hiding the loop's behavior.
- **Journal-timeout isolation**: wrap the `journal.compose` RPC in `policy_act` so a compose failure/timeout no longer discards an already-successful fetch outcome.
- **Journal-compose timeout fix (headline)**: the compose RPC to `cortex-exec` takes ~16s but was given only `CORTEX_TIMEOUT_SEC=12`s, so the episode journal timed out **every run**. Added a dedicated `ORION_AUTONOMY_EPISODE_JOURNAL_TIMEOUT_SEC` (default 120s) wired into the dispatch instead of overloading the tight generic cortex timeout.

## Outcome moved

Autonomy episode journals now compose successfully end-to-end. Before: `substrate_episode_journal_failed` (timeout) every cycle, and the loop was invisible in logs. After: `substrate_episode_journal_dispatched` with a real `entry_id`, and the whole fetch→journal path is traceable.

## Architecture touched

- `orion-spark-concept-induction` worker logging + journal dispatch timeout.
- Shared `orion/autonomy/policy_act.py` substrate-act flow (journal isolation).
- No bus channel / schema changes.

## Files changed

- `orion/spark/concept_induction/settings.py`: add `autonomy_episode_journal_timeout_sec` (120s) + `log_level`.
- `orion/spark/concept_induction/bus_worker.py`: dispatch uses the dedicated journal timeout, not `cortex_timeout_sec`.
- `orion/spark/concept_induction/app/main.py`: stdlib→loguru intercept handler, hardened LOG_LEVEL parsing.
- `orion/autonomy/policy_act.py`: isolate `journal.compose` so its failure preserves the fetch outcome.
- `scripts/sync_local_env_from_example.py`: add `LOG_LEVEL` to `SYNC_EXACT`.
- `services/orion-spark-concept-induction/.env_example`: add `LOG_LEVEL`, `ORION_AUTONOMY_EPISODE_JOURNAL_TIMEOUT_SEC`.
- Tests: `test_episode_journal.py`, `test_policy_act.py`, `test_metabolism_hook.py`.

## Env/config changes

- Added keys: `ORION_AUTONOMY_EPISODE_JOURNAL_TIMEOUT_SEC=120`, `LOG_LEVEL=INFO` (concept-induction).
- `.env_example` updated: yes. Local `.env` synced via `python3 scripts/sync_local_env_from_example.py`: yes.
- Skipped keys: none.

## Tests run

​```text
test_episode_journal.py + test_policy_act.py: 13 passed
test_metabolism_hook.py: 8 passed   (includes wiring guard)
​```

## Docker/build/smoke checks

​```text
build -> OK; up -d -> runtime env confirms ORION_AUTONOMY_EPISODE_JOURNAL_TIMEOUT_SEC=120
Live world-pulse run:
  08:14:24 world_pulse:run:result received
  08:14:28 substrate_policy_act web.fetch.readonly outcome=allowed auto_execute=True
  08:14:29 substrate_policy_act journal.compose.episode outcome=allowed
  08:14:42 substrate_episode_journal_dispatched entry_id=5ba4a11f-0008-4ead-9402-cc17bbf54b7e
compose ~13s, within new 120s budget (would fail under old 12s).
​```

## Review findings fixed

- Finding: no guard that the worker wires the new timeout (could regress to `cortex_timeout_sec`).
  - Fix: added `test_dispatch_uses_journal_timeout_not_cortex_timeout`. Evidence: 8 passed.

## Restart required

​```bash
docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
​```

## Risks / concerns

- Severity: low. Follow-up (separate spec, already written): episode journals are grounding-starved — they don't yet carry the fetched articles or the curiosity that drove the fetch. See `docs/superpowers/specs/2026-07-07-grounded-episode-journal-design.md`.