### PR TITLE
Feat/grounded episode journal

### DIFF
--- a/orion/autonomy/episode_fetch.py
+++ b/orion/autonomy/episode_fetch.py
@@ -90,6 +90,13 @@ async def execute_readonly_fetch(
         articles = _parse_articles(result, gap_terms=set(req.gap_terms))
         aggregate_salience = max((a.salience for a in articles), default=0.0)
     except Exception as exc:
+        # Reset every success-path field so a stored outcome can never claim
+        # success=True with a "fetch failed" summary if parsing/scoring raised
+        # after success was assigned.
+        success = False
+        surprise = 1.0
+        articles = []
+        aggregate_salience = 0.0
         summary = f"fetch failed: {exc}"
 
     outcome = ActionOutcomeRefV1(

--- a/orion/autonomy/episode_fetch.py
+++ b/orion/autonomy/episode_fetch.py
@@ -6,7 +6,8 @@ from datetime import datetime, timezone
 from typing import Awaitable, Callable
 
 from orion.autonomy.action_outcomes import append_action_outcome
-from orion.autonomy.models import ActionOutcomeRefV1
+from orion.autonomy.models import ActionOutcomeRefV1, FetchedArticleRefV1
+from orion.autonomy.salience import score_article_salience
 
 _FETCH_KIND = "web.fetch.readonly"
 
@@ -18,6 +19,7 @@ class EpisodeFetchRequest:
     spawned_correlation_id: str
     query: str
     max_articles: int = 2
+    gap_terms: tuple[str, ...] = ()
 
 
 async def default_fetch_backend(query: str, *, max_articles: int) -> dict:
@@ -34,6 +36,37 @@ def _build_summary(result: dict) -> str:
     return "fetch returned no articles"
 
 
+def _parse_articles(result: dict, *, gap_terms: set[str]) -> list[FetchedArticleRefV1]:
+    """Build scored article refs from a backend result.
+
+    Prefers the rich `articles` list; falls back to bare `urls` for older backends.
+    """
+    parsed: list[FetchedArticleRefV1] = []
+    raw = result.get("articles")
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            url = str(item.get("url") or "").strip()
+            if not url:
+                continue
+            title = str(item.get("title") or "")
+            description = str(item.get("description") or "")
+            salience = score_article_salience(f"{title} {description}", gap_terms)
+            parsed.append(
+                FetchedArticleRefV1(url=url, title=title, description=description, salience=salience)
+            )
+    if parsed:
+        return parsed
+    urls = result.get("urls")
+    if isinstance(urls, list):
+        for candidate in urls:
+            url = str(candidate or "").strip()
+            if url:
+                parsed.append(FetchedArticleRefV1(url=url))
+    return parsed
+
+
 async def execute_readonly_fetch(
     req: EpisodeFetchRequest,
     *,
@@ -44,6 +77,8 @@ async def execute_readonly_fetch(
     success = False
     surprise = 1.0
     summary = "fetch failed"
+    articles: list[FetchedArticleRefV1] = []
+    aggregate_salience = 0.0
 
     try:
         result = await fetch_backend(req.query, max_articles=req.max_articles)
@@ -52,6 +87,8 @@ async def execute_readonly_fetch(
         success = bool(result.get("success"))
         summary = _build_summary(result)
         surprise = 0.0 if success else 1.0
+        articles = _parse_articles(result, gap_terms=set(req.gap_terms))
+        aggregate_salience = max((a.salience for a in articles), default=0.0)
     except Exception as exc:
         summary = f"fetch failed: {exc}"
 
@@ -62,6 +99,9 @@ async def execute_readonly_fetch(
         success=success,
         surprise=surprise,
         observed_at=observed_at,
+        query=req.query,
+        articles=articles,
+        salience=aggregate_salience,
     )
     append_action_outcome(subject=req.subject, outcome=outcome)
     return outcome

--- a/orion/autonomy/fetch_backends.py
+++ b/orion/autonomy/fetch_backends.py
@@ -37,13 +37,22 @@ async def firecrawl_search_backend(query: str, *, max_articles: int, api_key: st
 
         data = parsed.get("data") or []
         urls: list[str] = []
+        articles: list[dict] = []
         if isinstance(data, list):
             for item in data:
                 if isinstance(item, dict):
                     url = item.get("url")
                     if url:
-                        urls.append(str(url))
+                        url_str = str(url)
+                        urls.append(url_str)
+                        articles.append(
+                            {
+                                "url": url_str,
+                                "title": str(item.get("title") or ""),
+                                "description": str(item.get("description") or ""),
+                            }
+                        )
         success = bool(parsed.get("success")) and bool(urls)
-        return {"success": success, "urls": urls}
+        return {"success": success, "urls": urls, "articles": articles}
 
     return await asyncio.to_thread(_call)

--- a/orion/autonomy/models.py
+++ b/orion/autonomy/models.py
@@ -150,6 +150,15 @@ class InhibitedImpulseV1(BaseModel):
     evidence_refs: list[str] = Field(default_factory=list)
 
 
+class FetchedArticleRefV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    url: str
+    title: str = ""
+    description: str = ""
+    salience: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
 class ActionOutcomeRefV1(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
@@ -159,6 +168,9 @@ class ActionOutcomeRefV1(BaseModel):
     success: bool | None = None
     surprise: float = Field(default=0.0, ge=0.0, le=1.0)
     observed_at: datetime | None = None
+    query: str | None = None
+    articles: list[FetchedArticleRefV1] = Field(default_factory=list)
+    salience: float = Field(default=0.0, ge=0.0, le=1.0)
 
 
 class ActionOutcomeEmitV1(BaseModel):

--- a/orion/autonomy/policy_act.py
+++ b/orion/autonomy/policy_act.py
@@ -7,6 +7,7 @@ from orion.autonomy.capability_policy import CapabilityEvaluationContext, evalua
 from orion.autonomy.episode_fetch import EpisodeFetchRequest, execute_readonly_fetch
 from orion.autonomy.fetch_backend_resolve import resolve_fetch_backend
 from orion.autonomy.models import ActionOutcomeRefV1, CapabilityDecisionV1, SubstrateActResultV1, SubstrateEpisodeIntentV1
+from orion.autonomy.salience import gap_terms_from_signals
 from orion.core.schemas.drives import DriveStateV1, GoalProposalV1
 from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
 
@@ -87,11 +88,13 @@ async def maybe_execute_readonly_fetch_after_goal(
         return decision, None
 
     query = build_readonly_fetch_query(curiosity_signals)
+    gap_terms = gap_terms_from_signals(curiosity_signals, fallback_query=query)
     req = EpisodeFetchRequest(
         subject=goal.subject,
         goal_artifact_id=goal.artifact_id,
         spawned_correlation_id=spawned_correlation_id,
         query=query,
+        gap_terms=tuple(sorted(gap_terms)),
     )
     if fetch_backend is None:
         fetch_backend = resolve_fetch_backend()
@@ -99,6 +102,67 @@ async def maybe_execute_readonly_fetch_after_goal(
     if budget_used is not None:
         budget_used[_READONLY_CAPABILITY] = budget_used.get(_READONLY_CAPABILITY, 0) + 1
     return decision, outcome
+
+
+_MAX_SEED_DESC_CHARS = 300
+
+
+def _gap_section_label(signals: Sequence[FrontierInvocationSignalV1]) -> str:
+    for sig in signals:
+        if sig.signal_type != _GAP_SIGNAL:
+            continue
+        for ref in sig.focal_node_refs:
+            section = str(ref or "").strip()
+            if section.startswith("section:"):
+                return section.split(":", 1)[1].replace("_", " ")
+    return ""
+
+
+def build_episode_narrative_seed(
+    goal: GoalProposalV1,
+    curiosity_signals: Sequence[FrontierInvocationSignalV1],
+    fetch_outcome: ActionOutcomeRefV1,
+) -> str:
+    """Structured multi-line compose seed: why + what + salience + satiation ask.
+
+    `goal` is part of the stable interface (spec contract + future goal_statement
+    enrichment seam) even though the current body does not read it.
+    """
+    del goal  # part of stable interface; not read yet
+    if not fetch_outcome.success:
+        return f"fetch failed: {fetch_outcome.summary}"
+
+    lines: list[str] = []
+    strength = curiosity_strength_from_signals(curiosity_signals)
+    section = _gap_section_label(curiosity_signals)
+    if section:
+        lines.append(f'Why: predictive coverage gap in "{section}" (strength {strength:.2f}).')
+    else:
+        lines.append(f"Why: predictive coverage gap (strength {strength:.2f}).")
+    if fetch_outcome.query:
+        lines.append(f'Query: "{fetch_outcome.query}"')
+
+    articles = fetch_outcome.articles
+    if articles:
+        lines.append(f"Fetched {len(articles)} article(s):")
+        any_scored = any(a.salience > 0.0 for a in articles)
+        for idx, art in enumerate(articles, start=1):
+            marker = f"salience {art.salience:.2f}" if any_scored else "unscored"
+            title = art.title or "(untitled)"
+            lines.append(f"  {idx}. [{marker}] {title} — {art.url}")
+            desc = (art.description or "").strip()
+            if desc:
+                if len(desc) > _MAX_SEED_DESC_CHARS:
+                    desc = desc[:_MAX_SEED_DESC_CHARS].rstrip() + "…"
+                lines.append(f"     {desc}")
+    else:
+        lines.append(f"fetch outcome: {fetch_outcome.summary}")
+
+    lines.append(
+        "Reflect: summarize each article and assess whether it closes the gap that "
+        "drove this fetch. Name what is still missing. Do not invent sources."
+    )
+    return "\n".join(lines)
 
 
 async def maybe_compose_autonomy_episode_after_fetch(
@@ -112,7 +176,6 @@ async def maybe_compose_autonomy_episode_after_fetch(
     budget_used: dict[str, int] | None = None,
 ) -> tuple[CapabilityDecisionV1, dict[str, Any] | None]:
     """Layer C gate + episode journal compose after successful readonly fetch."""
-    del curiosity_signals
     if fetch_outcome is None:
         decision = CapabilityDecisionV1(
             capability_id=_EPISODE_JOURNAL_CAPABILITY,
@@ -153,11 +216,7 @@ async def maybe_compose_autonomy_episode_after_fetch(
     if journal_dispatch is None:
         return decision, None
 
-    narrative_seed = (
-        f"fetch outcome: {fetch_outcome.summary}"
-        if fetch_outcome.success
-        else f"fetch failed: {fetch_outcome.summary}"
-    )
+    narrative_seed = build_episode_narrative_seed(goal, curiosity_signals, fetch_outcome)
     result = await journal_dispatch(
         goal_artifact_id=goal.artifact_id,
         spawned_correlation_id=spawned_correlation_id,

--- a/orion/autonomy/policy_act.py
+++ b/orion/autonomy/policy_act.py
@@ -7,7 +7,7 @@ from orion.autonomy.capability_policy import CapabilityEvaluationContext, evalua
 from orion.autonomy.episode_fetch import EpisodeFetchRequest, execute_readonly_fetch
 from orion.autonomy.fetch_backend_resolve import resolve_fetch_backend
 from orion.autonomy.models import ActionOutcomeRefV1, CapabilityDecisionV1, SubstrateActResultV1, SubstrateEpisodeIntentV1
-from orion.autonomy.salience import gap_terms_from_signals
+from orion.autonomy.salience import gap_terms_from_signals, iter_gap_section_labels
 from orion.core.schemas.drives import DriveStateV1, GoalProposalV1
 from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
 
@@ -28,14 +28,9 @@ def signal_kinds_from_curiosity(signals: Sequence[FrontierInvocationSignalV1]) -
 
 
 def build_readonly_fetch_query(signals: Sequence[FrontierInvocationSignalV1]) -> str:
-    for sig in signals:
-        if sig.signal_type != _GAP_SIGNAL:
-            continue
-        for ref in sig.focal_node_refs:
-            section = str(ref or "").strip()
-            if section.startswith("section:"):
-                label = section.split(":", 1)[1].replace("_", " ")
-                return f"{label} recent news coverage"
+    label = next(iter_gap_section_labels(signals), None)
+    if label:
+        return f"{label} recent news coverage"
     return "world coverage gap research"
 
 
@@ -108,14 +103,7 @@ _MAX_SEED_DESC_CHARS = 300
 
 
 def _gap_section_label(signals: Sequence[FrontierInvocationSignalV1]) -> str:
-    for sig in signals:
-        if sig.signal_type != _GAP_SIGNAL:
-            continue
-        for ref in sig.focal_node_refs:
-            section = str(ref or "").strip()
-            if section.startswith("section:"):
-                return section.split(":", 1)[1].replace("_", " ")
-    return ""
+    return next(iter_gap_section_labels(signals), "")
 
 
 def build_episode_narrative_seed(
@@ -145,9 +133,14 @@ def build_episode_narrative_seed(
     articles = fetch_outcome.articles
     if articles:
         lines.append(f"Fetched {len(articles)} article(s):")
-        any_scored = any(a.salience > 0.0 for a in articles)
+        # "scored" iff the fetch had gap terms to score against (mirrors the
+        # gap_terms the fetch used). A genuine 0.0 overlap is honestly "salience
+        # 0.00", not "unscored"; "unscored" means there was nothing to score by.
+        scored = bool(
+            gap_terms_from_signals(curiosity_signals, fallback_query=fetch_outcome.query or "")
+        )
         for idx, art in enumerate(articles, start=1):
-            marker = f"salience {art.salience:.2f}" if any_scored else "unscored"
+            marker = f"salience {art.salience:.2f}" if scored else "unscored"
             title = art.title or "(untitled)"
             lines.append(f"  {idx}. [{marker}] {title} — {art.url}")
             desc = (art.description or "").strip()

--- a/orion/autonomy/salience.py
+++ b/orion/autonomy/salience.py
@@ -7,7 +7,7 @@ function over gap terms vs article text. Not a cognition architecture.
 from __future__ import annotations
 
 import re
-from typing import Sequence
+from typing import Iterator, Sequence
 
 from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
 
@@ -20,6 +20,25 @@ def _tokenize(text: str) -> set[str]:
     return set(_TOKEN_RE.findall(text.lower()))
 
 
+def iter_gap_section_labels(
+    signals: Sequence[FrontierInvocationSignalV1],
+) -> Iterator[str]:
+    """Yield normalized section labels from `section:` focal refs across
+    world_coverage_gap signals, in signal/ref order.
+
+    Single source of truth for gap-section parsing (prefix stripped,
+    underscores -> spaces). Consumed by `gap_terms_from_signals` here and by the
+    query/seed builders in `policy_act.py` so the traversal does not drift.
+    """
+    for sig in signals:
+        if getattr(sig, "signal_type", None) != _GAP_SIGNAL:
+            continue
+        for ref in getattr(sig, "focal_node_refs", None) or []:
+            section = str(ref or "").strip()
+            if section.startswith(_SECTION_PREFIX):
+                yield section[len(_SECTION_PREFIX):].replace("_", " ")
+
+
 def gap_terms_from_signals(
     signals: Sequence[FrontierInvocationSignalV1],
     *,
@@ -30,14 +49,8 @@ def gap_terms_from_signals(
     Falls back to query tokens only when no section-derived terms are found.
     """
     terms: set[str] = set()
-    for sig in signals:
-        if getattr(sig, "signal_type", None) != _GAP_SIGNAL:
-            continue
-        for ref in getattr(sig, "focal_node_refs", None) or []:
-            section = str(ref or "").strip()
-            if section.startswith(_SECTION_PREFIX):
-                label = section[len(_SECTION_PREFIX):].replace("_", " ")
-                terms |= _tokenize(label)
+    for label in iter_gap_section_labels(signals):
+        terms |= _tokenize(label)
     if not terms and fallback_query:
         terms |= _tokenize(fallback_query)
     return terms

--- a/orion/autonomy/salience.py
+++ b/orion/autonomy/salience.py
@@ -1,0 +1,59 @@
+"""Deterministic term-overlap salience scorer for readonly-fetch articles.
+
+Narrow deterministic sensor (per repo no-regex-swamp note): a single scoring
+function over gap terms vs article text. Not a cognition architecture.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
+
+_GAP_SIGNAL = "world_coverage_gap"
+_SECTION_PREFIX = "section:"
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def gap_terms_from_signals(
+    signals: Sequence[FrontierInvocationSignalV1],
+    *,
+    fallback_query: str = "",
+) -> set[str]:
+    """Union of tokens from `section:` focal refs across world_coverage_gap signals.
+
+    Falls back to query tokens only when no section-derived terms are found.
+    """
+    terms: set[str] = set()
+    for sig in signals:
+        if getattr(sig, "signal_type", None) != _GAP_SIGNAL:
+            continue
+        for ref in getattr(sig, "focal_node_refs", None) or []:
+            section = str(ref or "").strip()
+            if section.startswith(_SECTION_PREFIX):
+                label = section[len(_SECTION_PREFIX):].replace("_", " ")
+                terms |= _tokenize(label)
+    if not terms and fallback_query:
+        terms |= _tokenize(fallback_query)
+    return terms
+
+
+def score_article_salience(article_text: str, gap_terms: set[str]) -> float:
+    """Fraction of gap terms present in the article text, clamped to [0, 1]."""
+    if not gap_terms:
+        return 0.0
+    tokens = _tokenize(article_text)
+    if not tokens:
+        return 0.0
+    overlap = gap_terms & tokens
+    score = len(overlap) / len(gap_terms)
+    if score < 0.0:
+        return 0.0
+    if score > 1.0:
+        return 1.0
+    return score

--- a/orion/autonomy/tests/test_episode_fetch.py
+++ b/orion/autonomy/tests/test_episode_fetch.py
@@ -85,6 +85,38 @@ async def test_execute_readonly_fetch_carries_articles_and_salience(tmp_path, mo
 
 
 @pytest.mark.asyncio
+async def test_execute_readonly_fetch_exception_after_success_marks_failure(tmp_path, monkeypatch) -> None:
+    """If scoring/parsing raises after the backend reported success, the stored
+    outcome must not be left as success=True with a 'fetch failed' summary."""
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("scorer exploded")
+
+    monkeypatch.setattr("orion.autonomy.episode_fetch.score_article_salience", _boom)
+    backend = AsyncMock(
+        return_value={
+            "success": True,
+            "urls": ["https://example.com/a"],
+            "articles": [{"url": "https://example.com/a", "title": "A", "description": "b"}],
+        }
+    )
+    req = EpisodeFetchRequest(
+        subject="orion",
+        goal_artifact_id="goal-gap-gpu",
+        spawned_correlation_id="wp-run-gap-gpu",
+        query="gpu news",
+        gap_terms=("gpu",),
+    )
+    outcome = await execute_readonly_fetch(req, fetch_backend=backend)
+    assert outcome.success is False
+    assert outcome.surprise == 1.0
+    assert outcome.articles == []
+    assert outcome.salience == 0.0
+    assert outcome.summary.startswith("fetch failed:")
+
+
+@pytest.mark.asyncio
 async def test_execute_readonly_fetch_backcompat_urls_only(tmp_path, monkeypatch) -> None:
     """Older backend returning only urls still yields article refs (salience 0)."""
     monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))

--- a/orion/autonomy/tests/test_episode_fetch.py
+++ b/orion/autonomy/tests/test_episode_fetch.py
@@ -50,3 +50,54 @@ async def test_default_fetch_backend_raises() -> None:
 
     with pytest.raises(RuntimeError, match="episode_fetch_backend_not_configured"):
         await default_fetch_backend("query", max_articles=2)
+
+
+@pytest.mark.asyncio
+async def test_execute_readonly_fetch_carries_articles_and_salience(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    backend = AsyncMock(
+        return_value={
+            "success": True,
+            "urls": ["https://example.com/a", "https://example.com/b"],
+            "articles": [
+                {"url": "https://example.com/a", "title": "GPU compute news", "description": "hardware compute"},
+                {"url": "https://example.com/b", "title": "Cooking", "description": "recipes"},
+            ],
+        }
+    )
+    req = EpisodeFetchRequest(
+        subject="orion",
+        goal_artifact_id="goal-gap-gpu",
+        spawned_correlation_id="wp-run-gap-gpu",
+        query="hardware compute gpu recent news coverage",
+        gap_terms=("hardware", "compute", "gpu"),
+    )
+    outcome = await execute_readonly_fetch(req, fetch_backend=backend)
+
+    assert outcome.query == "hardware compute gpu recent news coverage"
+    assert len(outcome.articles) == 2
+    assert outcome.articles[0].title == "GPU compute news"
+    # article 0 covers all 3 gap terms -> salience 1.0; article 1 covers none -> 0.0
+    assert outcome.articles[0].salience == 1.0
+    assert outcome.articles[1].salience == 0.0
+    # aggregate outcome salience is the max over articles
+    assert outcome.salience == 1.0
+
+
+@pytest.mark.asyncio
+async def test_execute_readonly_fetch_backcompat_urls_only(tmp_path, monkeypatch) -> None:
+    """Older backend returning only urls still yields article refs (salience 0)."""
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    backend = AsyncMock(return_value={"success": True, "urls": ["https://example.com/a"]})
+    req = EpisodeFetchRequest(
+        subject="orion",
+        goal_artifact_id="goal-gap-gpu",
+        spawned_correlation_id="wp-run-gap-gpu",
+        query="gpu news",
+        gap_terms=("gpu",),
+    )
+    outcome = await execute_readonly_fetch(req, fetch_backend=backend)
+    assert [a.url for a in outcome.articles] == ["https://example.com/a"]
+    assert outcome.articles[0].salience == 0.0
+    assert outcome.salience == 0.0
+    assert outcome.query == "gpu news"

--- a/orion/autonomy/tests/test_fetch_backends.py
+++ b/orion/autonomy/tests/test_fetch_backends.py
@@ -36,6 +36,38 @@ async def test_firecrawl_search_backend_parses_urls() -> None:
 
 
 @pytest.mark.asyncio
+async def test_firecrawl_search_backend_parses_articles() -> None:
+    response_body = json.dumps(
+        {
+            "success": True,
+            "data": [
+                {"url": "https://example.com/a", "title": "A", "description": "desc a"},
+                {"url": "https://example.com/b", "title": "B"},
+            ],
+        }
+    )
+
+    def _fake_urlopen(req, timeout=30.0):  # noqa: ARG001
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response_body.encode("utf-8")
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    with patch("orion.autonomy.fetch_backends.urllib.request.urlopen", side_effect=_fake_urlopen):
+        result = await firecrawl_search_backend("gpu news", max_articles=2, api_key="test-key")
+
+    assert result["success"] is True
+    # urls preserved for back-compat
+    assert result["urls"] == ["https://example.com/a", "https://example.com/b"]
+    # articles carry title + description (missing description defaults to "")
+    assert result["articles"] == [
+        {"url": "https://example.com/a", "title": "A", "description": "desc a"},
+        {"url": "https://example.com/b", "title": "B", "description": ""},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_firecrawl_search_backend_http_error() -> None:
     import urllib.error
 

--- a/orion/autonomy/tests/test_policy_act.py
+++ b/orion/autonomy/tests/test_policy_act.py
@@ -143,6 +143,8 @@ async def test_policy_act_denied_when_pressure_low(monkeypatch) -> None:
 async def test_policy_act_dispatches_episode_journal_after_fetch(monkeypatch) -> None:
     monkeypatch.setenv("ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED", "true")
     monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    from orion.autonomy.models import FetchedArticleRefV1
+
     fetch_outcome = ActionOutcomeRefV1(
         action_id="fetch-test",
         kind="web.fetch.readonly",
@@ -150,6 +152,11 @@ async def test_policy_act_dispatches_episode_journal_after_fetch(monkeypatch) ->
         success=True,
         surprise=0.0,
         observed_at=datetime.now(timezone.utc),
+        query="hardware compute gpu recent news coverage",
+        articles=[
+            FetchedArticleRefV1(url="https://example.com/a", title="GPU news", salience=0.67)
+        ],
+        salience=0.67,
     )
     journal_dispatch = AsyncMock(return_value={"write": {"entry_id": "entry-1"}})
     decision, result = await maybe_compose_autonomy_episode_after_fetch(
@@ -163,7 +170,9 @@ async def test_policy_act_dispatches_episode_journal_after_fetch(monkeypatch) ->
     assert decision.outcome == "allowed"
     assert result is not None
     journal_dispatch.assert_awaited_once()
-    assert journal_dispatch.await_args.kwargs["narrative_seed"].startswith("fetch outcome:")
+    seed = journal_dispatch.await_args.kwargs["narrative_seed"]
+    assert "hardware compute gpu" in seed
+    assert "GPU news" in seed
 
 
 @pytest.mark.asyncio
@@ -205,6 +214,87 @@ async def test_policy_act_composes_episode_journal_on_fetch_failure(monkeypatch)
     assert decision.outcome == "allowed"
     assert result is not None
     assert "fetch failed" in journal_dispatch.await_args.kwargs["narrative_seed"]
+
+
+def test_build_episode_narrative_seed_grounds_on_articles() -> None:
+    from orion.autonomy.models import FetchedArticleRefV1
+    from orion.autonomy.policy_act import build_episode_narrative_seed
+
+    outcome = ActionOutcomeRefV1(
+        action_id="fetch-1",
+        kind="web.fetch.readonly",
+        summary="fetched 2 article(s)",
+        success=True,
+        query="hardware compute gpu recent news coverage",
+        articles=[
+            FetchedArticleRefV1(
+                url="https://example.com/a",
+                title="New GPU cluster",
+                description="A big hardware compute launch.",
+                salience=0.67,
+            ),
+            FetchedArticleRefV1(url="https://example.com/b", title="Side note", salience=0.0),
+        ],
+        salience=0.67,
+    )
+    seed = build_episode_narrative_seed(_goal(), [_gap_signal()], outcome)
+
+    assert "hardware compute gpu" in seed          # the "why" (gap section)
+    assert "New GPU cluster" in seed               # a real article title (the "what")
+    assert "salience 0.67" in seed                 # salience marker
+    assert "https://example.com/a" in seed         # real source url
+    assert "Do not invent sources" in seed         # anti-confabulation ask
+    assert "closes the gap" in seed                # satiation-assessment ask
+
+
+def test_build_episode_narrative_seed_marks_unscored_when_no_gap_terms() -> None:
+    from orion.autonomy.models import FetchedArticleRefV1
+    from orion.autonomy.policy_act import build_episode_narrative_seed
+
+    outcome = ActionOutcomeRefV1(
+        action_id="fetch-1",
+        kind="web.fetch.readonly",
+        summary="fetched 1 article(s)",
+        success=True,
+        query="gpu news",
+        articles=[FetchedArticleRefV1(url="https://example.com/a", title="A", salience=0.0)],
+        salience=0.0,
+    )
+    seed = build_episode_narrative_seed(_goal(), [_gap_signal()], outcome)
+    assert "unscored" in seed
+
+
+def test_build_episode_narrative_seed_failure_branch_unchanged() -> None:
+    from orion.autonomy.policy_act import build_episode_narrative_seed
+
+    outcome = ActionOutcomeRefV1(
+        action_id="fetch-1",
+        kind="web.fetch.readonly",
+        summary="fetch failed: timeout",
+        success=False,
+        surprise=1.0,
+    )
+    seed = build_episode_narrative_seed(_goal(), [_gap_signal()], outcome)
+    assert seed == "fetch failed: fetch failed: timeout"
+
+
+def test_build_episode_narrative_seed_truncates_long_description() -> None:
+    from orion.autonomy.models import FetchedArticleRefV1
+    from orion.autonomy.policy_act import build_episode_narrative_seed
+
+    long_desc = "x" * 500
+    outcome = ActionOutcomeRefV1(
+        action_id="fetch-1",
+        kind="web.fetch.readonly",
+        summary="fetched 1 article(s)",
+        success=True,
+        query="gpu news",
+        articles=[FetchedArticleRefV1(url="https://example.com/a", title="A", description=long_desc, salience=0.5)],
+        salience=0.5,
+    )
+    seed = build_episode_narrative_seed(_goal(), [_gap_signal()], outcome)
+    assert "…" in seed
+    assert "x" * 500 not in seed
 
 
 def _intent() -> SubstrateEpisodeIntentV1:

--- a/orion/autonomy/tests/test_policy_act.py
+++ b/orion/autonomy/tests/test_policy_act.py
@@ -251,17 +251,40 @@ def test_build_episode_narrative_seed_marks_unscored_when_no_gap_terms() -> None
     from orion.autonomy.models import FetchedArticleRefV1
     from orion.autonomy.policy_act import build_episode_narrative_seed
 
+    # No section-derived gap terms and no query to fall back on -> there is nothing
+    # to score against, so the marker is honestly "unscored".
+    no_section = _gap_signal().model_copy(update={"focal_node_refs": ["node:not_a_section"]})
     outcome = ActionOutcomeRefV1(
         action_id="fetch-1",
         kind="web.fetch.readonly",
         summary="fetched 1 article(s)",
         success=True,
-        query="gpu news",
+        query=None,
         articles=[FetchedArticleRefV1(url="https://example.com/a", title="A", salience=0.0)],
         salience=0.0,
     )
-    seed = build_episode_narrative_seed(_goal(), [_gap_signal()], outcome)
+    seed = build_episode_narrative_seed(_goal(), [no_section], outcome)
     assert "unscored" in seed
+
+
+def test_build_episode_narrative_seed_shows_zero_salience_when_scored_but_irrelevant() -> None:
+    from orion.autonomy.models import FetchedArticleRefV1
+    from orion.autonomy.policy_act import build_episode_narrative_seed
+
+    # Gap terms exist (section) but the article overlaps none -> honestly
+    # "salience 0.00", NOT the misleading "unscored".
+    outcome = ActionOutcomeRefV1(
+        action_id="fetch-1",
+        kind="web.fetch.readonly",
+        summary="fetched 1 article(s)",
+        success=True,
+        query="hardware compute gpu recent news coverage",
+        articles=[FetchedArticleRefV1(url="https://example.com/a", title="Cooking recipes", salience=0.0)],
+        salience=0.0,
+    )
+    seed = build_episode_narrative_seed(_goal(), [_gap_signal()], outcome)
+    assert "salience 0.00" in seed
+    assert "unscored" not in seed
 
 
 def test_build_episode_narrative_seed_failure_branch_unchanged() -> None:

--- a/orion/autonomy/tests/test_salience.py
+++ b/orion/autonomy/tests/test_salience.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from orion.autonomy.salience import gap_terms_from_signals, score_article_salience
+from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
+
+
+def _gap_signal(section: str = "section:hardware_compute_gpu") -> FrontierInvocationSignalV1:
+    return FrontierInvocationSignalV1(
+        signal_type="world_coverage_gap",
+        anchor_scope="orion",
+        subject_ref="entity:orion",
+        target_zone="concept_graph",
+        task_type_candidate="concept_expand",
+        focal_node_refs=[section],
+        signal_strength=0.65,
+        evidence_summary="gap",
+        confidence=0.65,
+    )
+
+
+def test_gap_terms_from_section_refs() -> None:
+    terms = gap_terms_from_signals([_gap_signal()])
+    assert terms == {"hardware", "compute", "gpu"}
+
+
+def test_gap_terms_ignores_non_gap_signals() -> None:
+    sig = _gap_signal()
+    other = sig.model_copy(update={"signal_type": "curiosity_candidate"})
+    assert gap_terms_from_signals([other]) == set()
+
+
+def test_gap_terms_falls_back_to_query_when_no_section() -> None:
+    sig = _gap_signal(section="node:not_a_section")
+    terms = gap_terms_from_signals([sig], fallback_query="GPU supply chain news")
+    assert terms == {"gpu", "supply", "chain", "news"}
+
+
+def test_score_article_salience_fraction() -> None:
+    gap = {"hardware", "compute", "gpu"}
+    # 2 of 3 gap terms present.
+    score = score_article_salience("New GPU compute cluster launches", gap)
+    assert abs(score - (2 / 3)) < 1e-9
+
+
+def test_score_article_salience_empty_gap_is_zero() -> None:
+    assert score_article_salience("anything at all", set()) == 0.0
+
+
+def test_score_article_salience_empty_text_is_zero() -> None:
+    assert score_article_salience("", {"gpu"}) == 0.0
+
+
+def test_score_article_salience_clamped_to_one() -> None:
+    gap = {"gpu"}
+    assert score_article_salience("gpu gpu gpu", gap) == 1.0

--- a/orion/autonomy/tests/test_substrate_act_models.py
+++ b/orion/autonomy/tests/test_substrate_act_models.py
@@ -15,3 +15,47 @@ def test_substrate_episode_intent_v1_fields() -> None:
 def test_substrate_act_result_v1_optional_outcomes() -> None:
     result = SubstrateActResultV1(fetch_attempted=True, journal_attempted=False)
     assert result.fetch_attempted is True
+
+
+def test_fetched_article_ref_defaults() -> None:
+    from orion.autonomy.models import FetchedArticleRefV1
+
+    art = FetchedArticleRefV1(url="https://example.com/a")
+    assert art.title == ""
+    assert art.description == ""
+    assert art.salience == 0.0
+
+
+def test_action_outcome_ref_carries_articles_and_query() -> None:
+    from orion.autonomy.models import ActionOutcomeRefV1, FetchedArticleRefV1
+
+    outcome = ActionOutcomeRefV1(
+        action_id="fetch-1",
+        kind="web.fetch.readonly",
+        summary="fetched 1 article(s)",
+        success=True,
+        query="gpu recent news coverage",
+        articles=[FetchedArticleRefV1(url="https://example.com/a", title="A", salience=0.5)],
+        salience=0.5,
+    )
+    assert outcome.query == "gpu recent news coverage"
+    assert outcome.articles[0].title == "A"
+    assert outcome.salience == 0.5
+
+
+def test_action_outcome_ref_backward_compatible_without_new_fields() -> None:
+    from orion.autonomy.models import ActionOutcomeRefV1
+
+    # Persisted JSON from before this patch (no query/articles/salience).
+    outcome = ActionOutcomeRefV1.model_validate(
+        {
+            "action_id": "fetch-old",
+            "kind": "web.fetch.readonly",
+            "summary": "fetched 2 article(s)",
+            "success": True,
+            "surprise": 0.0,
+        }
+    )
+    assert outcome.query is None
+    assert outcome.articles == []
+    assert outcome.salience == 0.0


### PR DESCRIPTION
## Summary
- New `orion/autonomy/salience.py`: pure deterministic gap-term → article-text overlap scorer, with `iter_gap_section_labels` as the single source of truth for `section:` gap parsing.
- `ActionOutcomeRefV1` gains defaulted `query`, `articles: list[FetchedArticleRefV1]`, aggregate `salience`; new nested `FetchedArticleRefV1`. Flat SQL projection `ActionOutcomeEmitV1` untouched.
- Firecrawl backend now returns per-article `title`/`description` (`articles` list) alongside `urls` (back-compat preserved).
- `execute_readonly_fetch` scores each article against the driving gap terms and carries query + scored articles + max-aggregate salience into the outcome; failure/exception paths always yield a self-consistent outcome.
- `policy_act.build_episode_narrative_seed` composes a grounded multi-line seed (why/gap + query + per-article title/url/honest-salience marker + anti-confabulation & satiation ask); compose no longer discards curiosity signals.

## Outcome moved
The episode journal seed now names why Orion fetched (predictive coverage gap + strength) and what it read (real article titles/urls with an honest salience marker), and asks the composer to assess satiation and not invent sources. Previously it was a content-free `"fetch outcome: fetched N article(s)"` one-liner that discarded curiosity signals.

## Schema / bus / API changes
- Added: `FetchedArticleRefV1`; `ActionOutcomeRefV1.query/articles/salience`; backend `articles` key; `EpisodeFetchRequest.gap_terms`; `salience.iter_gap_section_labels`.
- Behavior changed: narrative seed is now multi-line grounded text.
- Compatibility: all new model fields defaulted, so pre-patch persisted JSON validates under `extra="forbid"`. `ActionOutcomeEmitV1` (flat SQL row) unchanged; new fields ride only in the local JSON store. No `orion/schemas/registry.py` change (`ActionOutcomeRefV1` is not registered).

## Env/config changes
None (pure `orion/autonomy/*` library work; no `.env_example`/Docker/bus change).

## Tests run
```text
pytest orion/autonomy/tests orion/spark/concept_induction/tests -q -> 200 passed
ReadLints on all changed files -> no errors ; git diff --check -> clean