### PR TITLE
fix(reverie): stop importing orion.substrate at tick time (thin conta…

### DIFF
--- a/services/orion-thought/app/reverie.py
+++ b/services/orion-thought/app/reverie.py
@@ -15,7 +15,9 @@ Discipline (§0A / hard constraints):
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import os
 from contextlib import suppress
 from typing import Any, Callable
 from uuid import UUID, uuid4
@@ -97,16 +99,50 @@ def build_coalition_snapshot(
     )
 
 
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _salience_v2_enabled() -> bool:
+    """Thin-service read of the salience-v2 flag.
+
+    Deliberately does NOT import `orion.substrate.attention.salience`: importing
+    any `orion.substrate` submodule runs `orion/substrate/__init__.py`, which
+    eagerly loads the graph engine (`requests` etc.) that this thin bus service
+    does not install. Mirrors `salience_v2_enabled()` in that module.
+    """
+    return os.getenv("ORION_ATTENTION_SALIENCE_V2_ENABLED", "false").strip().lower() in _TRUTHY
+
+
+def _bounded(value: float) -> float:
+    """Clamp to [0,1] — local copy of `orion.substrate.attention.common.bounded`
+    to keep reverie off the `orion.substrate` import graph (no `requests`)."""
+    return max(0.0, min(1.0, float(value)))
+
+
+def _weights_version() -> str:
+    """Provenance string mirroring `default_combiner().weights_version` without
+    importing the combiner (thin service: no `orion.substrate` at runtime)."""
+    raw = os.getenv("ORION_ATTENTION_SALIENCE_WEIGHTS", "").strip()
+    if raw:
+        try:
+            if isinstance(json.loads(raw), dict):
+                return "seed-v1+override"
+        except (ValueError, TypeError):
+            pass
+    return "seed-v1"
+
+
 def derive_salience(broadcast: AttentionBroadcastProjectionV1 | None) -> float:
     """Salience of the selected coalition.
 
     v2 (`ORION_ATTENTION_SALIENCE_V2_ENABLED`): read the loop's precomputed
-    `salience` (same combiner used by selection — one source of salience truth).
-    Legacy: max of the seven constant score fields, else stability score.
+    `salience` (computed upstream by the same combiner selection uses — one
+    source of salience truth). Legacy: max of the seven constant score fields,
+    else stability score.
 
-    The `orion.substrate.attention` imports are local: importing that package at
-    module scope drags the graph engine (`requests` etc.), which this thin bus
-    service must not load (see `test_reverie_thin_import_boundary`).
+    Uses only thin local helpers (no `orion.substrate` import): importing that
+    package drags the graph engine (`requests`), which this thin bus service must
+    not load (see `test_reverie_thin_import_boundary`).
     """
     if broadcast is None:
         return 0.0
@@ -117,12 +153,8 @@ def derive_salience(broadcast: AttentionBroadcastProjectionV1 | None) -> float:
     )
     if loop is None:
         return fallback
-    from orion.substrate.attention.salience import salience_v2_enabled
-
-    if salience_v2_enabled():
-        from orion.substrate.attention.common import bounded
-
-        return bounded(float(loop.salience)) if loop.salience else fallback
+    if _salience_v2_enabled():
+        return _bounded(float(loop.salience)) if loop.salience else fallback
     scores = [float(getattr(loop, field, 0.0)) for field in _OPEN_LOOP_SCORE_FIELDS]
     return max(scores) if scores else fallback
 
@@ -134,9 +166,10 @@ def build_salience_trace(
 ) -> AttentionSalienceTraceV1 | None:
     """Trace the selected loop's feature vector + salience. None if no selection.
 
-    Local imports (`stable_hash_id`, `WEIGHTS_VERSION`, `bounded`) keep the thin
-    bus service off `orion.substrate.__init__`'s graph engine at module scope —
-    same discipline as `derive_salience` (see `test_reverie_thin_import_boundary`).
+    Reads the loop's precomputed salience/features (computed upstream) and packages
+    them — reverie does not recompute, so it needs no combiner. Uses thin local
+    helpers only (no `orion.substrate` import; that would drag `requests`). Only
+    `orion.core.ids` is imported locally, which is light.
     """
     if broadcast is None or not broadcast.selected_open_loop_id:
         return None
@@ -147,8 +180,6 @@ def build_salience_trace(
     if loop is None:
         return None
     from orion.core.ids import stable_hash_id
-    from orion.substrate.attention.common import bounded
-    from orion.substrate.attention.salience import default_combiner
 
     return AttentionSalienceTraceV1(
         trace_id=stable_hash_id("saltrace", [correlation_id, loop.id]),
@@ -156,8 +187,8 @@ def build_salience_trace(
         theme_key=loop.id,
         description=(loop.description or "")[:200],
         correlation_id=correlation_id,
-        salience=bounded(float(loop.salience)),
-        weights_version=default_combiner().weights_version,
+        salience=_bounded(float(loop.salience)),
+        weights_version=_weights_version(),
         features=dict(loop.salience_features or {}),
         scope="reverie",
     )

--- a/services/orion-thought/tests/test_reverie_thin_import_boundary.py
+++ b/services/orion-thought/tests/test_reverie_thin_import_boundary.py
@@ -46,6 +46,55 @@ def test_importing_reverie_does_not_load_substrate_or_requests() -> None:
     assert "ok" in result.stdout
 
 
+def test_calling_reverie_tick_helpers_does_not_load_substrate() -> None:
+    """Real teeth: the tick path (`derive_salience`, `build_salience_trace`) must
+    not import `orion.substrate` at CALL time either.
+
+    The prior module-scope-only check passed in a venv that has `requests`, but in
+    the thin `orion-thought` container (no `requests`) a call-time
+    `from orion.substrate.attention...` crashed every reverie tick. This exercises
+    both the v2-on and v2-off branches and asserts `orion.substrate` never loads.
+    """
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    service_root = Path(__file__).resolve().parents[1]
+    repo_root = Path(__file__).resolve().parents[3]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(service_root), str(repo_root)])
+    env["ORION_ATTENTION_SALIENCE_V2_ENABLED"] = "true"
+    code = (
+        "import sys\n"
+        "from datetime import datetime, timezone\n"
+        "from orion.schemas.attention_frame import ("
+        " AttentionBroadcastProjectionV1, AttentionFrameV1, OpenLoopV1)\n"
+        "import app.reverie as r\n"
+        "loop = OpenLoopV1(id='ol-1', description='x', salience=0.7,"
+        " salience_features={'evidence_strength': 0.8})\n"
+        "b = AttentionBroadcastProjectionV1("
+        " frame=AttentionFrameV1(open_loops=[loop]),"
+        " selected_open_loop_id='ol-1', coalition_stability_score=0.4)\n"
+        "assert r.derive_salience(b) > 0\n"
+        "t = r.build_salience_trace(b, correlation_id='c1')\n"
+        "assert t is not None and t.weights_version == 'seed-v1'\n"
+        "sub=[m for m in sys.modules if m.startswith('orion.substrate')]\n"
+        "assert not sub, sub\n"
+        "assert 'requests' not in sys.modules\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(service_root),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
 def test_stable_hash_id_deterministic() -> None:
     from orion.core.ids import stable_hash_id
 


### PR DESCRIPTION
- [ ] …iner has no requests)

PR #858 added runtime 'from orion.substrate.attention...' imports inside derive_salience (called every tick) and build_salience_trace. Importing any orion.substrate submodule runs orion/substrate/__init__.py -> graphdb_store -> 'import requests', which the thin orion-thought container does not install, so every reverie tick crashed with ModuleNotFoundError. Replace with thin local helpers (_salience_v2_enabled, _bounded, _weights_version) and add a call-time boundary test that would have caught this.