### PR TITLE
Fix/finalize reflect metacog lane

### DIFF
--- a/orion/harness/finalize.py
+++ b/orion/harness/finalize.py
@@ -259,6 +259,12 @@ def build_finalize_reflect_context(
         "repair_overlay": repair_overlay.model_dump(mode="json"),
         "finalize_overlay": repair_overlay.finalize_overlay,
         "user_message": user_message,
+        # Route the 5b integrative reflection off the saturated `chat` worker onto the
+        # background/metacog lane (unsaturated, long read timeout). This is an internal
+        # reflection pass (not user-visible speech), so the lighter lane is acceptable.
+        # allow_chat_fallback keeps resilience if the metacog route is ever absent.
+        "llm_lane": "background",
+        "allow_chat_fallback": True,
         "metadata": {
             "correlation_id": correlation_id,
             "mode": "brain",

--- a/orion/harness/tests/test_finalize_reflect_lane.py
+++ b/orion/harness/tests/test_finalize_reflect_lane.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from orion.harness.finalize import build_finalize_reflect_context
+from orion.harness.tests.fixtures import (
+    make_appraisal,
+    make_repair_overlay,
+    make_thought,
+)
+
+
+def test_finalize_reflect_context_routes_to_background_lane() -> None:
+    """5b reflection must leave the saturated `chat` worker for the metacog/background lane."""
+    ctx = build_finalize_reflect_context(
+        correlation_id="c-1",
+        draft_text="draft",
+        thought=make_thought(),
+        substrate_appraisal=make_appraisal(),
+        repair_overlay=make_repair_overlay(),
+        user_message="How are you?",
+    )
+    assert ctx["llm_lane"] == "background"
+    # Keep resilience: fall back to chat only if the metacog route is ever absent.
+    assert ctx["allow_chat_fallback"] is True
+
+
+def test_finalize_reflect_context_lane_is_top_level_for_cortex_ctx_merge() -> None:
+    """cortex-exec spreads request.context into ctx at top level (main.py), and
+    resolve_llm_lane_for_step reads ctx.get("llm_lane"). Guard the key placement."""
+    ctx = build_finalize_reflect_context(
+        correlation_id="c-1",
+        draft_text="draft",
+        thought=make_thought(),
+        substrate_appraisal=make_appraisal(),
+        repair_overlay=make_repair_overlay(),
+        user_message="",
+    )
+    assert "llm_lane" in ctx
+    assert "options" not in ctx or "llm_lane" not in ctx.get("options", {})

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -1322,6 +1322,7 @@ SCHEMA_REGISTRY: Dict[str, SchemaRegistration] = {
     ),
     "OrionTownPersonaV1": SchemaRegistration(
         model=OrionTownPersonaV1, kind="embodiment.persona.v1"
+    ),
     "AttentionSalienceTraceV1": SchemaRegistration(
         model=AttentionSalienceTraceV1,
         kind="attention.salience.trace.v1",

--- a/services/orion-cortex-exec/tests/test_llm_lane_propagation.py
+++ b/services/orion-cortex-exec/tests/test_llm_lane_propagation.py
@@ -79,3 +79,16 @@ def test_chat_lane_allow_chat_fallback_can_be_false() -> None:
     )
     assert out["llm_lane"] == "chat"
     assert out["allow_chat_fallback"] is False
+
+
+def test_finalize_reflect_ctx_llm_lane_resolves_background() -> None:
+    """Mirror the finalize_reflect context (top-level llm_lane) as cortex-exec merges it
+    into ctx; the 5b reflection must resolve to the background/metacog lane, not chat."""
+    step = SimpleNamespace(verb_name="harness_finalize_reflect", step_name="llm_harness_finalize_reflect")
+    out = resolve_llm_lane_for_step(
+        step=step,
+        ctx={"llm_lane": "background", "allow_chat_fallback": True, "metadata": {"mode": "brain"}},
+        settings=_settings(),
+    )
+    assert out["llm_lane"] == "background"
+    assert out["allow_chat_fallback"] is True


### PR DESCRIPTION
## Summary

- The FCC harness 5b reflection (`harness_finalize_reflect`) defaulted to the `chat` LLM lane, served by a single saturated GGUF worker (`atlas-worker-1`, 115s read timeout). Under load it exceeded the harness 180s finalize budget and raised `RPC timeout waiting on orion:exec:result:...`, dropping the turn to its unvoiced draft.
- Route only that internal (non-user-visible) reflection pass to the `background`/`metacog` lane (`atlas-worker-2`, qwen3-8b, 700s read timeout) by setting `llm_lane=background` in `build_finalize_reflect_context`. `orion_voice_finalize` (user-visible speech) intentionally stays on `chat`.
- Fix a committed `SyntaxError` in `orion/schemas/registry.py` (missing `),` on `OrionTownPersonaV1` from bad merge `28be6e99`) that broke importing the schema registry repo-wide for fresh processes.

## Outcome moved

Finalize/reflect turns no longer serialize behind the saturated chat worker; the reflection pass runs on the unsaturated metacog worker with a 700s read timeout, removing the intermittent 180s finalize RPC timeout. Repo-wide `orion.schemas.registry` import restored.

## Current architecture

Harness governor builds `PlanExecutionRequest` for `harness_finalize_reflect` and RPCs cortex-exec (`HarnessCortexClient`), which calls the LLM gateway. Lane was unset → `resolve_llm_lane_for_step` fell through to `chat` (`services/orion-cortex-exec/app/llm_lane.py:54`) → gateway routed to `atlas-worker-1`.

## Architecture touched

- Finalize context builder (harness) now declares its LLM lane.
- No bus/schema/channel contract changes.

## Files changed

- `orion/harness/finalize.py`: set `llm_lane=background` + `allow_chat_fallback=True` in `build_finalize_reflect_context`.
- `orion/schemas/registry.py`: close `OrionTownPersonaV1` registration (syntax fix).
- `orion/harness/tests/test_finalize_reflect_lane.py`: new — assert context carries background lane at top level.
- `services/orion-cortex-exec/tests/test_llm_lane_propagation.py`: new case — finalize-shaped ctx resolves to background lane.

## Schema / bus / API changes

- None. (Registry fix restores existing entries; no new schemas.)

## Env/config changes

- None. No `.env_example` keys added/removed.

## Tests run

```text
pytest orion/harness/tests -q                          -> 67 passed
pytest services/orion-cortex-exec/tests/test_llm_lane_propagation.py -q -> 9 passed
python -c "import orion.schemas.registry"              -> OK (563 entries)