### PR TITLE
chore(world-pulse): default WP_RUN_RESULT_STREAM_ENABLED=true

### DIFF
--- a/services/orion-spark-concept-induction/.env_example
+++ b/services/orion-spark-concept-induction/.env_example
@@ -102,7 +102,7 @@ ORION_AUTONOMY_EPISODE_JOURNAL_TIMEOUT_SEC=120
 # ROLLOUT ORDER: enable THIS consumer first (creates the consumer group at start_id="$"),
 # then enable the producer flag on orion-world-pulse. Runs published before the group
 # exists are not replayed to the group.
-WP_RUN_RESULT_STREAM_ENABLED=false
+WP_RUN_RESULT_STREAM_ENABLED=true
 WP_RUN_RESULT_STREAM_KEY=orion:stream:world_pulse:run:result
 WP_RUN_RESULT_STREAM_GROUP=cg:concept-induction
 WP_RUN_RESULT_DLQ_KEY=orion:stream:world_pulse:run:result:dlq

--- a/services/orion-world-pulse/.env_example
+++ b/services/orion-world-pulse/.env_example
@@ -40,7 +40,7 @@ WORLD_PULSE_RUN_RESULT_CHANNEL=orion:world_pulse:run:result
 # consumer group is created (group start_id="$"). Runs XADD'd before the group exists
 # are not delivered to the group. Enable this producer flag only after the consumer
 # has started at least once.
-WP_RUN_RESULT_STREAM_ENABLED=false
+WP_RUN_RESULT_STREAM_ENABLED=true
 WP_RUN_RESULT_STREAM_KEY=orion:stream:world_pulse:run:result
 WP_RUN_RESULT_STREAM_MAXLEN=1000
 WORLD_PULSE_DIGEST_CREATED_CHANNEL=orion:world_pulse:digest:created


### PR DESCRIPTION
## Summary

- Flip operator-contract defaults for two verified-live cognitive flag sets from off → on.
- `chore(attention)`: enable computed salience v2 + habituation + pending-attention cards (`ORION_ATTENTION_SALIENCE_V2_ENABLED`, `ORION_ATTENTION_HABITUATION_ENABLED`, `ORION_ATTENTION_PENDING_CARDS_ENABLED`) across the services that read them, plus the substrate-runtime compose passthrough for the salience env keys.
- `chore(world-pulse)`: enable durable `world_pulse:run:result` stream consumption (`WP_RUN_RESULT_STREAM_ENABLED`) on producer (`orion-world-pulse`) and consumer (`orion-spark-concept-induction`).

## Outcome moved

- The grounded autonomy **episode journal** now fires reliably. Previously the once-per-run `world.pulse.run.result.v1` event was dropped on the fire-and-forget pub/sub path while `concept-induction` was busy, so no episode was composed. It now rides a durable Redis Stream with a consumer group, at-least-once delivery, DLQ, and an idempotency guard.
- Computed salience v2 + habituation + pending cards move from shadow/off to live.

## Live verification (world-pulse durable path)

Run `2822e2ed-e740-4439-9b25-12687f561763`:

```text
producer: world_pulse_run_result_stream_enqueued message_id=1783454409241-0
consumer: substrate_policy_act capability=web.fetch.readonly  spawned=2822e2ed…
consumer: substrate_policy_act capability=journal.compose.episode spawned=2822e2ed…
consumer: substrate_episode_journal_dispatched entry_id=0f0221a8-6879-4163-8dbb-85e8ae360d92
consumer: action_outcome_emitted success=True spawned=2822e2ed…
consumer: work_queue_ack message_id=1783454409241-0 acked=1
consumer: wp_stream_processed run_id=2822e2ed…
redis:    group cg:concept-induction pending=0 lag=0 ; DLQ len=0
store:    episode_runs_processed: ['2822e2ed-…']