### PR TITLE
fix(tests): harden cross-service pytest conftests for shared sessions

### DIFF
--- a/services/orion-cortex-exec/tests/conftest.py
+++ b/services/orion-cortex-exec/tests/conftest.py
@@ -14,14 +14,30 @@ def _purge_app_modules_if_wrong_service(expected_subdir: str) -> None:
                 del sys.modules[key]
 
 
-_purge_app_modules_if_wrong_service("/orion-cortex-exec/")
-
-if SERVICE_DIR not in sys.path:
-    sys.path.insert(0, SERVICE_DIR)
-
 REPO_ROOT = os.path.abspath(os.path.join(SERVICE_DIR, "..", ".."))
-if REPO_ROOT not in sys.path:
-    sys.path.insert(0, REPO_ROOT)
+
+
+def _ensure_cortex_exec_paths() -> None:
+    """Make the top-level ``app`` package resolve to orion-cortex-exec.
+
+    In a multi-service pytest session another service's conftest (e.g.
+    orion-hub's ``pytest_configure``) prepends its own root to ``sys.path`` and
+    re-points ``app``. Re-assert this service so ``from app.settings import ...``
+    below never imports the wrong service's Settings.
+    """
+    _purge_app_modules_if_wrong_service("/orion-cortex-exec/")
+    # Insert SERVICE_DIR then REPO_ROOT so the final order is
+    # [REPO_ROOT, SERVICE_DIR, ...] (matches historical priority) while both
+    # sit ahead of any other service root a sibling conftest prepended.
+    for path in (SERVICE_DIR, REPO_ROOT):
+        try:
+            sys.path.remove(path)
+        except ValueError:
+            pass
+        sys.path.insert(0, path)
+
+
+_ensure_cortex_exec_paths()
 
 os.environ.setdefault("SERVICE_NAME", "orion-cortex-exec")
 os.environ.setdefault("SERVICE_VERSION", "0.2.0")
@@ -59,8 +75,24 @@ _stub_spacy_for_router_imports()
 
 
 def pytest_sessionstart(session):
-    """Service .env often sets large LLM_CHAT_* dev budgets; unit tests expect canonical caps."""
-    from app.settings import settings
+    """Service .env often sets large LLM_CHAT_* dev budgets; unit tests expect canonical caps.
+
+    Runs after every collected conftest's ``pytest_configure``, so a sibling
+    service may currently own the top-level ``app`` package. Re-assert this
+    service and guard the import: in a shared session where cortex-exec tests are
+    not actually collected, importing the wrong ``app.settings`` must not abort
+    the run.
+    """
+    _ensure_cortex_exec_paths()
+    try:
+        from app.settings import settings
+    except Exception:
+        return
+    # Confirm we actually imported cortex-exec's settings (not a sibling's that
+    # still owns ``app.settings`` in sys.modules) before mutating it.
+    settings_file = (getattr(sys.modules.get("app.settings"), "__file__", "") or "").replace("\\", "/")
+    if "/orion-cortex-exec/" not in settings_file:
+        return
 
     settings.llm_chat_quick_max_tokens = 384
     settings.llm_chat_general_max_tokens = 768

--- a/services/orion-cortex-exec/tests/test_conftest_cross_service_isolation.py
+++ b/services/orion-cortex-exec/tests/test_conftest_cross_service_isolation.py
@@ -1,0 +1,42 @@
+"""Regression: cortex-exec's ``pytest_sessionstart`` must not abort a shared
+multi-service pytest session.
+
+In a combined session orion-hub's ``pytest_configure`` prepends its own root to
+``sys.path`` and re-points the top-level ``app`` package. If cortex-exec's
+``pytest_sessionstart`` then does a bare ``from app.settings import settings`` it
+imports orion-hub's ``Settings`` (which requires ``CHANNEL_VOICE_*`` keys absent
+from the root ``.env``) and aborts the whole session with an INTERNALERROR before
+any test runs. The conftest must re-assert its own service and guard the import.
+
+Run in a clean subprocess so the in-process conftest state does not mask the bug.
+Note: this asserts only the *no session-abort* property. Fully green combined
+single-invocation runs are a separate, pre-existing cross-service ``scripts``/``app``
+namespace concern that the plan sidesteps by running each service separately.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_combined_session_does_not_abort_on_sibling_settings() -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "services/orion-hub/tests/test_attention_loops_api.py",
+        "services/orion-cortex-exec/tests/test_attention_frame.py",
+        "-q",
+        "-p",
+        "no:cacheprovider",
+        "--co",  # collection only: enough to run pytest_sessionstart
+    ]
+    proc = subprocess.run(cmd, cwd=_REPO_ROOT, capture_output=True, text=True)
+    out = proc.stdout + proc.stderr
+    tail = out[-3000:]
+    assert "INTERNALERROR" not in out, tail
+    assert "CHANNEL_VOICE_TRANSCRIPT" not in out, tail

--- a/services/orion-thought/tests/conftest.py
+++ b/services/orion-thought/tests/conftest.py
@@ -23,6 +23,13 @@ def _ensure_thought_paths() -> None:
     sys.path.insert(0, str(_THOUGHT_ROOT))
 
 
+def pytest_configure() -> None:
+    # Runs before collection, so module-top ``import orion...``/``import app...``
+    # in test files resolve. The autouse fixture below only fires at test
+    # execution, which is too late for collection-time imports.
+    _ensure_thought_paths()
+
+
 @pytest.fixture(autouse=True)
 def _thought_service_isolation() -> None:
     _ensure_thought_paths()


### PR DESCRIPTION
## Summary

- Fix orion-cortex-exec `pytest_sessionstart` aborting a shared multi-service pytest session by importing orion-hub's `Settings` (missing `CHANNEL_VOICE_*`), which crashed collection with an `INTERNALERROR` before any test ran.
- Add orion-thought `pytest_configure` so service paths are set before collection, unblocking the plan-created `test_reverie_salience_v2.py` (previously a collection `ImportError`).
- Add a subprocess regression test proving the cortex-exec session no longer aborts.

## Outcome moved

The computed-salience "Final Verification" sweep no longer blows up on a cross-service settings import; both conftest collection bugs are fixed and covered.

## Files changed

- `services/orion-cortex-exec/tests/conftest.py`: extract `_ensure_cortex_exec_paths()`; call it in `pytest_sessionstart` before importing `app.settings`, and guard the import + verify it resolved to this service before mutating settings.
- `services/orion-cortex-exec/tests/test_conftest_cross_service_isolation.py` (new): subprocess regression asserting a combined hub+cortex-exec session does not abort with `INTERNALERROR`/`CHANNEL_VOICE_*`.
- `services/orion-thought/tests/conftest.py`: add `pytest_configure()` calling `_ensure_thought_paths()` so collection-time imports resolve.

## Schema / bus / API changes

None.

## Env/config changes

None in this PR. (Separately, the salience/attention flags are enabled in all `.env_example` templates and local `.env` synced via `scripts/sync_local_env_from_example.py`.)

## Tests run

- `test_conftest_cross_service_isolation.py` → 1 passed (fails on baseline conftest, passes with fix)
- `orion-thought/tests/test_reverie_salience_v2.py` → 2 passed (now collects)
- `orion-cortex-exec/tests/test_attention_frame.py` → 9 passed (flags off, plan shadow default)
- `orion/substrate/tests/` → 178 passed (unaffected)

## Restart required

No restart required.

## Risks / concerns

- Low severity; changes confined to test conftests.
- With salience flags now default-on, several unit tests that assume flags-default-off fail on ambient `.env` (`test_high_value_open_loop_selects_single_ask`, three in `test_reverie_spontaneous_thought.py`, `test_settings_salience_flags::test_salience_flags_default_off`). Pre-existing flag-flip fallout, not caused by this PR. Follow-up: make those tests hermetic (set the flag per-test via monkeypatch).
- Fully-green single-invocation combined runs remain blocked by the separate cross-service `scripts`/`app` namespace war; the plan runs each service as its own pytest invocation.