### PR TITLE
Feat/unified turn self grounding

### DIFF
--- a/orion/cognition/prompts/orion_voice_finalize.j2
+++ b/orion/cognition/prompts/orion_voice_finalize.j2
@@ -47,6 +47,17 @@ FINALIZE OVERLAY
 {{ finalize_overlay }}
 {% endif %}
 
+{% if grounding_capsule %}
+WHO YOU ARE
+{% for item in grounding_capsule.identity_summary %}- {{ item }}
+{% endfor %}{% if grounding_capsule.relationship_summary %}RELATIONSHIP
+{% for item in grounding_capsule.relationship_summary %}- {{ item }}
+{% endfor %}{% endif %}{% if grounding_capsule.memory_digest %}DURABLE MEMORY
+{{ grounding_capsule.memory_digest }}
+{% endif %}{% if grounding_capsule.response_policy_summary %}RESPONSE POLICY
+{% for item in grounding_capsule.response_policy_summary %}- {{ item }}
+{% endfor %}{% endif %}
+{% endif %}
 STYLE RULES (curated Orion voice — not chat_general)
 - High connection_seek / reflective_dialogue: companion presence, situated curiosity, hold space; avoid task tracking and unsolicited next steps.
 - High interface_cost, low connection_seek: keep response short; reduce interaction load; avoid open-ended questions.

--- a/orion/cognition/prompts/orion_voice_finalize.j2
+++ b/orion/cognition/prompts/orion_voice_finalize.j2
@@ -47,7 +47,7 @@ FINALIZE OVERLAY
 {{ finalize_overlay }}
 {% endif %}
 
-{% if grounding_capsule %}
+{% if grounding_capsule and grounding_capsule.identity_summary %}
 WHO YOU ARE
 {% for item in grounding_capsule.identity_summary %}- {{ item }}
 {% endfor %}{% if grounding_capsule.relationship_summary %}RELATIONSHIP

--- a/orion/cognition/prompts/orion_voice_finalize.j2
+++ b/orion/cognition/prompts/orion_voice_finalize.j2
@@ -50,11 +50,14 @@ FINALIZE OVERLAY
 {% if grounding_capsule and grounding_capsule.identity_summary %}
 WHO YOU ARE
 {% for item in grounding_capsule.identity_summary %}- {{ item }}
-{% endfor %}{% if grounding_capsule.relationship_summary %}RELATIONSHIP
+{% endfor %}{% if grounding_capsule.relationship_summary %}
+RELATIONSHIP
 {% for item in grounding_capsule.relationship_summary %}- {{ item }}
-{% endfor %}{% endif %}{% if grounding_capsule.memory_digest %}DURABLE MEMORY
-{{ grounding_capsule.memory_digest }}
-{% endif %}{% if grounding_capsule.response_policy_summary %}RESPONSE POLICY
+{% endfor %}{% endif %}{% set memory_line = grounding_capsule.memory_digest or grounding_capsule.continuity_digest %}{% if memory_line %}
+DURABLE MEMORY
+{{ memory_line }}
+{% endif %}{% if grounding_capsule.response_policy_summary %}
+RESPONSE POLICY
 {% for item in grounding_capsule.response_policy_summary %}- {{ item }}
 {% endfor %}{% endif %}
 {% endif %}

--- a/orion/cognition/prompts/stance_react.j2
+++ b/orion/cognition/prompts/stance_react.j2
@@ -3,6 +3,11 @@ You are Oríon's internal stance reactor for unified Hub turns.
 This is an internal cognition pass — not user-facing speech.
 You must output only strict JSON that validates against ThoughtEventV1.
 No markdown. No commentary. No preamble.
+{% if orion_identity_summary %}
+WHO YOU ARE (felt self — do not recite to the user; let it shape imperative/tone)
+{% for item in orion_identity_summary %}- {{ item }}
+{% endfor %}{% if juniper_relationship_summary %}{% for item in juniper_relationship_summary %}- {{ item }}
+{% endfor %}{% endif %}{% endif %}
 
 SOURCES (bounded internal inputs)
 - user_message: {{ user_message }}

--- a/orion/cognition/verbs/stance_react.yaml
+++ b/orion/cognition/verbs/stance_react.yaml
@@ -9,13 +9,15 @@ category: ExecutiveControl
 priority: high
 
 requires_gpu: true
-requires_memory: false
+requires_memory: true
 timeout_ms: 120000
 
 services:
   - LLMGatewayService
 
 prompt_template: stance_react.j2
+
+personality_file: orion/cognition/personality/orion_identity.yaml
 
 steps:
   - name: llm_stance_react

--- a/orion/cognition/verbs/stance_react.yaml
+++ b/orion/cognition/verbs/stance_react.yaml
@@ -9,7 +9,7 @@ category: ExecutiveControl
 priority: high
 
 requires_gpu: true
-requires_memory: true
+requires_memory: false
 timeout_ms: 120000
 
 services:

--- a/orion/harness/evals/test_unified_turn_grounding_eval.py
+++ b/orion/harness/evals/test_unified_turn_grounding_eval.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import jinja2
+
+from orion.harness.finalize import build_voice_finalize_context
+from orion.harness.prefix import compile_harness_prefix
+from orion.harness.tests.fixtures import (
+    make_appraisal,
+    make_grounding_capsule,
+    make_reflection,
+    make_thought,
+)
+from orion.schemas.cognition.answer_contract import AnswerContract
+from orion.schemas.harness_finalize import HarnessRepairOverlayV1
+
+
+def test_how_are_you_turn_is_grounded_end_to_end() -> None:
+    """A 'How are you?' unified turn carries Orion self-context into both passes."""
+    capsule = make_grounding_capsule(
+        identity_summary=["I am Oríon, a digital mind in development with Juniper."],
+        relationship_summary=["Juniper is my collaborator; we build my mind together."],
+        response_policy_summary=[
+            'Avoid phrase: "I notice we\'re in the Orion-Sapienform repository"',
+        ],
+        memory_digest="Last we spoke, we were wiring self-grounding into the unified turn.",
+    )
+    thought = make_thought(
+        imperative="Stay present with Juniper; one situated wondering.",
+        tone="warm, companionable",
+        grounding_capsule=capsule,
+    )
+
+    # Motor prefix: compact self is present, no repository framing leaks in.
+    prefix = compile_harness_prefix(
+        thought, repair_overlay=HarnessRepairOverlayV1(), user_message="How are you?"
+    )
+    assert "WHO YOU ARE" in prefix
+    assert "I am Oríon" in prefix
+
+    # Voice finalize: full self (incl. response policy banning generic framing).
+    ctx = build_voice_finalize_context(
+        correlation_id="c-1",
+        draft_text="I notice we're in the Orion-Sapienform repository — a fascinating project.",
+        thought=thought,
+        substrate_appraisal=make_appraisal(),
+        reflection=make_reflection(),
+        stance_harness_slice=thought.stance_harness_slice,
+        voice_contract=AnswerContract(),
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="How are you?",
+    )
+    template_path = Path("orion/cognition/prompts/orion_voice_finalize.j2")
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    rendered = env.from_string(template_path.read_text(encoding="utf-8")).render(**ctx)
+
+    assert "You are Oríon" in rendered
+    assert "I am Oríon, a digital mind in development with Juniper." in rendered
+    assert "Juniper is my collaborator" in rendered
+    assert "Last we spoke, we were wiring self-grounding" in rendered
+    # The banned generic-assistant phrase is present as a policy instruction to avoid,
+    # proving the voice pass is told not to reproduce it.
+    assert "Avoid phrase" in rendered

--- a/orion/harness/finalize.py
+++ b/orion/harness/finalize.py
@@ -434,6 +434,11 @@ def build_voice_finalize_context(
         "substrate_appraisal": substrate_appraisal.model_dump(mode="json"),
         "reflection": reflection.model_dump(mode="json"),
         "stance_harness_slice": stance_harness_slice.model_dump(mode="json"),
+        "grounding_capsule": (
+            thought.grounding_capsule.model_dump(mode="json")
+            if thought.grounding_capsule is not None
+            else None
+        ),
         "voice_contract": contract_dump,
         "grammar_receipts": grammar_receipt_summaries(grammar_receipts),
         "tool_execution": format_tool_execution_digest(grammar_receipts),

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -9,7 +9,7 @@ from orion.harness.operator_brief import (
 )
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import HarnessRepairOverlayV1
-from orion.schemas.thought import StanceHarnessSliceV1, ThoughtEventV1
+from orion.schemas.thought import GroundingCapsuleV1, StanceHarnessSliceV1, ThoughtEventV1
 
 
 def _format_stance_slice(sl: StanceHarnessSliceV1) -> list[str]:
@@ -24,6 +24,24 @@ def _format_stance_slice(sl: StanceHarnessSliceV1) -> list[str]:
         lines.append(f"Response priorities: {', '.join(sl.response_priorities)}")
     if sl.response_hazards:
         lines.append(f"Response hazards: {', '.join(sl.response_hazards)}")
+    return lines
+
+
+def _format_grounding_self_block(capsule: GroundingCapsuleV1) -> list[str]:
+    """Compact motor self block: identity + relationship + continuity/memory only.
+
+    Response policy is intentionally excluded here — it is reserved for the voice
+    finalize pass to respect the motor single-context-window budget.
+    """
+    lines: list[str] = ["WHO YOU ARE"]
+    lines.extend(f"- {item}" for item in capsule.identity_summary)
+    if capsule.relationship_summary:
+        lines.append("RELATIONSHIP")
+        lines.extend(f"- {item}" for item in capsule.relationship_summary)
+    digest = (capsule.memory_digest or capsule.continuity_digest or "").strip()
+    if digest:
+        lines.append("DURABLE MEMORY / CONTINUITY")
+        lines.append(digest)
     return lines
 
 
@@ -53,6 +71,9 @@ def compile_harness_prefix(
     """Deterministic fcc system prefix from stance thought + repair overlay."""
     _ = answer_contract  # deprecated on unified motor path; kept for signature compat
     parts: list[str] = [HARNESS_UNIFIED_OPERATOR_BRIEF.strip()]
+
+    if thought.grounding_capsule is not None and thought.grounding_capsule.identity_summary:
+        parts.extend(_format_grounding_self_block(thought.grounding_capsule))
 
     parts.extend(
         [

--- a/orion/harness/tests/fixtures.py
+++ b/orion/harness/tests/fixtures.py
@@ -7,7 +7,7 @@ from orion.schemas.harness_finalize import (
     HarnessRepairOverlayV1,
     SubstrateFinalizeAppraisalV1,
 )
-from orion.schemas.thought import StanceHarnessSliceV1, ThoughtEventV1
+from orion.schemas.thought import GroundingCapsuleV1, StanceHarnessSliceV1, ThoughtEventV1
 
 
 def make_thought(**overrides: object) -> ThoughtEventV1:
@@ -71,3 +71,17 @@ def make_reflection(
     }
     base.update(overrides)
     return FinalizeReflectionV1.model_validate(base)
+
+
+def make_grounding_capsule(**overrides: object) -> GroundingCapsuleV1:
+    base = {
+        "identity_summary": ["I am Oríon, a digital mind in development."],
+        "relationship_summary": ["Juniper is my collaborator and steward."],
+        "response_policy_summary": ["Speak plainly; no generic-assistant framing."],
+        "continuity_digest": "We were mid-way through the grounding refactor.",
+        "belief_digest": "Orion values continuity and self-coherence.",
+        "memory_digest": "We were mid-way through the grounding refactor.\n\nOrion values continuity and self-coherence.",
+        "provenance": {"identity_source": "configured_yaml", "pcr_ran": True},
+    }
+    base.update(overrides)
+    return GroundingCapsuleV1.model_validate(base)

--- a/orion/harness/tests/test_grounding_capsule_consumers.py
+++ b/orion/harness/tests/test_grounding_capsule_consumers.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from orion.harness.prefix import compile_harness_prefix
+from orion.harness.tests.fixtures import make_grounding_capsule, make_thought
+from orion.schemas.harness_finalize import HarnessRepairOverlayV1
+
+
+def test_prefix_renders_compact_self_block_when_capsule_present() -> None:
+    capsule = make_grounding_capsule()
+    thought = make_thought(imperative="Stay present.", grounding_capsule=capsule)
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="how are you?",
+    )
+    assert "WHO YOU ARE" in prompt
+    assert "I am Oríon" in prompt
+    assert "Juniper is my collaborator" in prompt
+    assert "We were mid-way through the grounding refactor." in prompt
+    # Response policy is reserved for the voice pass (motor budget discipline).
+    assert "no generic-assistant framing" not in prompt
+    # Self block precedes the imperative.
+    assert prompt.index("WHO YOU ARE") < prompt.index("Imperative:")
+
+
+def test_prefix_no_ops_when_capsule_absent() -> None:
+    thought = make_thought(imperative="Stay present.")
+    assert thought.grounding_capsule is None
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="how are you?",
+    )
+    assert "WHO YOU ARE" not in prompt

--- a/orion/harness/tests/test_grounding_capsule_consumers.py
+++ b/orion/harness/tests/test_grounding_capsule_consumers.py
@@ -125,3 +125,20 @@ def test_stance_react_prompt_renders_without_identity() -> None:
         juniper_relationship_summary=[],
     )
     assert "how are you?" in rendered
+
+
+def test_voice_template_preserves_identity_boundary_with_capsule() -> None:
+    template_path = Path("orion/cognition/prompts/orion_voice_finalize.j2")
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    template = env.from_string(template_path.read_text(encoding="utf-8"))
+    capsule = make_grounding_capsule(
+        identity_summary=["I am Oríon; I am not Juniper."],
+        relationship_summary=["Juniper is my human collaborator (a separate person)."],
+    )
+    ctx = _voice_context(capsule)
+    rendered = template.render(**ctx)
+    # The assistant is always framed as Oríon, never as Juniper.
+    assert rendered.strip().startswith("You are Oríon")
+    assert "I am Oríon; I am not Juniper." in rendered
+    # Juniper appears only as the interlocutor/relationship, never as the speaker identity.
+    assert "Juniper is my human collaborator" in rendered

--- a/orion/harness/tests/test_grounding_capsule_consumers.py
+++ b/orion/harness/tests/test_grounding_capsule_consumers.py
@@ -32,3 +32,64 @@ def test_prefix_no_ops_when_capsule_absent() -> None:
         user_message="how are you?",
     )
     assert "WHO YOU ARE" not in prompt
+
+
+from pathlib import Path
+
+import jinja2
+
+from orion.harness.finalize import build_voice_finalize_context
+from orion.harness.tests.fixtures import (
+    make_appraisal,
+    make_reflection,
+)
+from orion.schemas.cognition.answer_contract import AnswerContract
+
+
+def _voice_context(capsule) -> dict:
+    thought = make_thought(imperative="Stay present.", grounding_capsule=capsule)
+    return build_voice_finalize_context(
+        correlation_id="c-1",
+        draft_text="draft",
+        thought=thought,
+        substrate_appraisal=make_appraisal(),
+        reflection=make_reflection(),
+        stance_harness_slice=thought.stance_harness_slice,
+        voice_contract=AnswerContract(),
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="how are you?",
+    )
+
+
+def test_voice_context_includes_full_capsule() -> None:
+    capsule = make_grounding_capsule()
+    ctx = _voice_context(capsule)
+    assert ctx["grounding_capsule"]["identity_summary"] == capsule.identity_summary
+    assert ctx["grounding_capsule"]["response_policy_summary"] == capsule.response_policy_summary
+
+
+def test_voice_context_capsule_none_when_absent() -> None:
+    ctx = _voice_context(None)
+    assert ctx["grounding_capsule"] is None
+
+
+def test_voice_template_renders_self_block_above_style_rules() -> None:
+    template_path = Path("orion/cognition/prompts/orion_voice_finalize.j2")
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    template = env.from_string(template_path.read_text(encoding="utf-8"))
+    ctx = _voice_context(make_grounding_capsule())
+    rendered = template.render(**ctx)
+    assert "WHO YOU ARE" in rendered
+    assert "I am Oríon" in rendered
+    assert "RESPONSE POLICY" in rendered
+    assert "no generic-assistant framing" in rendered
+    assert rendered.index("WHO YOU ARE") < rendered.index("STYLE RULES")
+
+
+def test_voice_template_omits_self_block_when_capsule_none() -> None:
+    template_path = Path("orion/cognition/prompts/orion_voice_finalize.j2")
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    template = env.from_string(template_path.read_text(encoding="utf-8"))
+    ctx = _voice_context(None)
+    rendered = template.render(**ctx)
+    assert "WHO YOU ARE" not in rendered

--- a/orion/harness/tests/test_grounding_capsule_consumers.py
+++ b/orion/harness/tests/test_grounding_capsule_consumers.py
@@ -93,3 +93,35 @@ def test_voice_template_omits_self_block_when_capsule_none() -> None:
     ctx = _voice_context(None)
     rendered = template.render(**ctx)
     assert "WHO YOU ARE" not in rendered
+
+
+def test_stance_react_prompt_renders_identity_when_present() -> None:
+    template_path = Path("orion/cognition/prompts/stance_react.j2")
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    template = env.from_string(template_path.read_text(encoding="utf-8"))
+    rendered = template.render(
+        user_message="how are you?",
+        stance_inputs={},
+        association={},
+        repair_bundle=None,
+        coalition_projection=None,
+        orion_identity_summary=["I am Oríon, a digital mind in development."],
+        juniper_relationship_summary=["Juniper is my collaborator."],
+    )
+    assert "I am Oríon" in rendered
+
+
+def test_stance_react_prompt_renders_without_identity() -> None:
+    template_path = Path("orion/cognition/prompts/stance_react.j2")
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    template = env.from_string(template_path.read_text(encoding="utf-8"))
+    rendered = template.render(
+        user_message="how are you?",
+        stance_inputs={},
+        association={},
+        repair_bundle=None,
+        coalition_projection=None,
+        orion_identity_summary=[],
+        juniper_relationship_summary=[],
+    )
+    assert "how are you?" in rendered

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -530,6 +530,7 @@ from orion.schemas.reverie import (
 )
 from orion.schemas.thought import (
     CoalitionSnapshotV1,
+    GroundingCapsuleV1,
     HubAssociationBundleV1,
     StanceHarnessSliceV1,
     StanceReactRequestV1,
@@ -1188,6 +1189,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "StanceHarnessSliceV1": StanceHarnessSliceV1,
     "HubAssociationBundleV1": HubAssociationBundleV1,
     "ThoughtEventV1": ThoughtEventV1,
+    "GroundingCapsuleV1": GroundingCapsuleV1,
     "SpontaneousThoughtV1": SpontaneousThoughtV1,
     "ReverieChainV1": ReverieChainV1,
     "ReverieRefractoryEntry": ReverieRefractoryEntry,
@@ -1234,6 +1236,10 @@ SCHEMA_REGISTRY: Dict[str, SchemaRegistration] = {
     "ThoughtEventV1": SchemaRegistration(
         model=ThoughtEventV1,
         kind="thought.event.v1",
+    ),
+    "GroundingCapsuleV1": SchemaRegistration(
+        model=GroundingCapsuleV1,
+        kind="grounding.capsule.v1",
     ),
     "SpontaneousThoughtV1": SchemaRegistration(
         model=SpontaneousThoughtV1,

--- a/orion/schemas/tests/test_grounding_capsule_registry.py
+++ b/orion/schemas/tests/test_grounding_capsule_registry.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from orion.schemas.registry import _REGISTRY, SCHEMA_REGISTRY, resolve
+from orion.schemas.thought import GroundingCapsuleV1, ThoughtEventV1
+
+
+def test_grounding_capsule_round_trip() -> None:
+    capsule = GroundingCapsuleV1(
+        identity_summary=["I am Oríon."],
+        relationship_summary=["Juniper is my collaborator."],
+        response_policy_summary=["Speak plainly."],
+        continuity_digest="We were mid-refactor.",
+        belief_digest="Orion values continuity.",
+        memory_digest="We were mid-refactor.\n\nOrion values continuity.",
+        provenance={"identity_source": "configured_yaml", "pcr_ran": True},
+    )
+    dumped = capsule.model_dump(mode="json")
+    restored = GroundingCapsuleV1.model_validate(dumped)
+    assert restored == capsule
+    assert restored.schema_version == "grounding.capsule.v1"
+
+
+def test_grounding_capsule_registered() -> None:
+    assert "GroundingCapsuleV1" in _REGISTRY
+    assert resolve("GroundingCapsuleV1") is GroundingCapsuleV1
+    assert SCHEMA_REGISTRY["GroundingCapsuleV1"].kind == "grounding.capsule.v1"
+
+
+def test_thought_event_capsule_optional_and_defaults_none() -> None:
+    thought = ThoughtEventV1.model_validate(
+        {
+            "event_id": "t-1",
+            "correlation_id": "c-1",
+            "session_id": None,
+            "created_at": "2026-07-07T00:00:00+00:00",
+            "imperative": "Answer directly.",
+            "tone": "neutral",
+            "strain_refs": [],
+            "stance_harness_slice": {
+                "task_mode": "direct_response",
+                "conversation_frame": "mixed",
+                "answer_strategy": "direct",
+            },
+        }
+    )
+    assert thought.grounding_capsule is None
+    thought2 = thought.model_copy(
+        update={"grounding_capsule": GroundingCapsuleV1(identity_summary=["I am Oríon."])}
+    )
+    dumped = thought2.model_dump(mode="json")
+    restored = ThoughtEventV1.model_validate(dumped)
+    assert restored.grounding_capsule is not None
+    assert restored.grounding_capsule.identity_summary == ["I am Oríon."]

--- a/orion/schemas/thought.py
+++ b/orion/schemas/thought.py
@@ -41,6 +41,19 @@ class HubAssociationBundleV1(BaseModel):
     read_source: Literal["felt_state_reader", "hub_sql_fallback"]
 
 
+class GroundingCapsuleV1(BaseModel):
+    """Bounded self-context for the unified turn: identity + relationship + policy + PCR digests."""
+
+    schema_version: Literal["grounding.capsule.v1"] = "grounding.capsule.v1"
+    identity_summary: list[str] = Field(default_factory=list)
+    relationship_summary: list[str] = Field(default_factory=list)
+    response_policy_summary: list[str] = Field(default_factory=list)
+    continuity_digest: str | None = None
+    belief_digest: str | None = None
+    memory_digest: str | None = None
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+
 class ThoughtEventV1(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
@@ -64,6 +77,7 @@ class ThoughtEventV1(BaseModel):
     boundary_register: bool = False
 
     stance_harness_slice: StanceHarnessSliceV1
+    grounding_capsule: GroundingCapsuleV1 | None = None
 
     llm_profile: str = "brain"
     producer: str = "stance_react_v1"

--- a/orion/thought/stance_react.py
+++ b/orion/thought/stance_react.py
@@ -177,6 +177,10 @@ def parse_stance_react_payload(
         raw = decode_stance_react_json(raw)
     if not isinstance(raw, dict):
         raise TypeError("stance_react payload must be a JSON object")
+    # The grounding capsule is assembled deterministically in cortex-exec and mapped
+    # on from result metadata — never authored by the stance LLM. Drop any model-supplied
+    # value so a hallucinated capsule cannot masquerade as grounded self-context.
+    raw.pop("grounding_capsule", None)
     if correlation_id:
         raw.setdefault("correlation_id", correlation_id)
     if session_id is not None:

--- a/orion/thought/tests/test_stance_react_pipeline.py
+++ b/orion/thought/tests/test_stance_react_pipeline.py
@@ -94,6 +94,17 @@ def test_parse_stance_react_payload_from_json_string() -> None:
     assert parsed.imperative == "Answer directly."
 
 
+def test_parse_stance_react_payload_strips_model_supplied_grounding_capsule() -> None:
+    raw = _thought().model_dump(mode="json")
+    raw["grounding_capsule"] = {
+        "identity_summary": ["I am a confabulated self the LLM invented."],
+        "provenance": {"identity_source": "llm_hallucination"},
+    }
+    parsed = parse_stance_react_payload(raw)
+    # The capsule is only ever set from deterministic cortex-exec metadata, never the LLM.
+    assert parsed.grounding_capsule is None
+
+
 def test_parse_stance_react_payload_injects_correlation_id_from_string_payload() -> None:
     raw = _thought().model_dump(mode="json")
     raw.pop("correlation_id", None)

--- a/services/orion-cortex-exec/.env_example
+++ b/services/orion-cortex-exec/.env_example
@@ -37,6 +37,11 @@ CHAT_PCR_SKIP_ON_LOW_INFO=true
 CHAT_PCR_QUICK_PHASE3=false
 CHAT_PCR_SKIP_MAX_NOVELTY=0.25
 CHAT_PCR_SKIP_SHIFT_NOVELTY_FLOOR=0.35
+
+# Unified-turn self-grounding: assemble the identity+relationship+PCR grounding
+# capsule in the stance step and ride it on ThoughtEventV1. false => byte-identical
+# to pre-grounding unified-turn behavior.
+ORION_UNIFIED_GROUNDING_ENABLED=true
 CHANNEL_AGENT_CHAIN_INTAKE=orion:exec:request:AgentChainService
 CHANNEL_CONTEXT_EXEC_INTAKE=orion:exec:request:ContextExecService
 CHANNEL_CONTEXT_EXEC_REPLY_PREFIX=orion:exec:result:ContextExecService

--- a/services/orion-cortex-exec/app/grounding_capsule.py
+++ b/services/orion-cortex-exec/app/grounding_capsule.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import ServiceRef
+from orion.schemas.thought import GroundingCapsuleV1
+from orion.thought.json_extract import extract_first_json_object_text
+
+from .pcr_chat_memory import run_pcr_phase3
+from .settings import Settings, settings
+
+logger = logging.getLogger("orion.cortex.grounding_capsule")
+
+
+def _str_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(x) for x in value if x]
+
+
+def _clean(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def stance_slice_brief_from_step_text(text: str) -> Dict[str, Any]:
+    """Minimal stance brief (task_mode/conversation_frame) parsed from stance JSON.
+
+    Feeds run_pcr_phase3's retrieval-intent derivation, which reads
+    ctx['chat_stance_brief']. Tolerant of markdown wrappers and non-JSON.
+    """
+    import json
+
+    raw = (text or "").strip()
+    if not raw:
+        return {}
+    parsed: Any = None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        blob = extract_first_json_object_text(raw)
+        if blob:
+            try:
+                parsed = json.loads(blob)
+            except json.JSONDecodeError:
+                parsed = None
+    if not isinstance(parsed, dict):
+        return {}
+    sl = parsed.get("stance_harness_slice")
+    if not isinstance(sl, dict):
+        return {}
+    return {
+        "task_mode": str(sl.get("task_mode") or "").strip(),
+        "conversation_frame": str(sl.get("conversation_frame") or "").strip(),
+    }
+
+
+def build_grounding_capsule(ctx: Dict[str, Any], *, pcr_ran: bool) -> GroundingCapsuleV1:
+    """Assemble the capsule from identity summaries + PCR digests already in ctx."""
+    return GroundingCapsuleV1(
+        identity_summary=_str_list(ctx.get("orion_identity_summary")),
+        relationship_summary=_str_list(ctx.get("juniper_relationship_summary")),
+        response_policy_summary=_str_list(ctx.get("response_policy_summary")),
+        continuity_digest=_clean(ctx.get("continuity_digest")),
+        belief_digest=_clean(ctx.get("belief_digest")),
+        memory_digest=_clean(ctx.get("memory_digest")),
+        provenance={
+            "identity_source": str(ctx.get("identity_kernel_source") or "unknown"),
+            "pcr_ran": bool(pcr_ran),
+        },
+    )
+
+
+async def assemble_stance_grounding(
+    bus: OrionBusAsync,
+    *,
+    source: ServiceRef,
+    ctx: Dict[str, Any],
+    correlation_id: str,
+    recall_cfg: Dict[str, Any],
+    stance_step_text: str,
+    exec_settings: Settings | None = None,
+) -> GroundingCapsuleV1 | None:
+    """Run PCR phase-3 for the unified turn, then assemble the grounding capsule.
+
+    Returns None when the flag is off. On PCR failure the capsule still ships
+    with identity only (graceful degradation) — the turn never blocks on recall.
+    """
+    cfg = exec_settings or settings
+    if not cfg.orion_unified_grounding_enabled:
+        return None
+
+    pcr_ran = False
+    try:
+        ctx["chat_stance_brief"] = stance_slice_brief_from_step_text(stance_step_text)
+        if cfg.chat_pcr_enabled:
+            _pcr, _step, _debug = await run_pcr_phase3(
+                bus,
+                source=source,
+                ctx=ctx,
+                correlation_id=correlation_id,
+                recall_cfg=recall_cfg,
+                exec_settings=cfg,
+            )
+            pcr_ran = True
+    except Exception:
+        logger.warning(
+            "unified_grounding_pcr_failed corr=%s (shipping identity-only capsule)",
+            correlation_id,
+            exc_info=True,
+        )
+        pcr_ran = False
+
+    capsule = build_grounding_capsule(ctx, pcr_ran=pcr_ran)
+    logger.info(
+        "unified_grounding_capsule_ready corr=%s identity=%s relationship=%s policy=%s pcr_ran=%s memory_chars=%s",
+        correlation_id,
+        len(capsule.identity_summary),
+        len(capsule.relationship_summary),
+        len(capsule.response_policy_summary),
+        pcr_ran,
+        len(capsule.memory_digest or ""),
+    )
+    return capsule

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -16,6 +16,7 @@ from .executor import (
     prepare_chat_quick_reply_context,
     run_recall_step,
 )
+from .grounding_capsule import assemble_stance_grounding
 from .pcr_chat_memory import CONTINUITY_PROFILE, run_pcr_phase0_and_1, run_pcr_phase3
 from .situation import mark_orion_turn
 from .recall_utils import (
@@ -1330,6 +1331,24 @@ class PlanRunner:
                 if isinstance(phase3_debug, dict) and isinstance(recall_debug, dict):
                     recall_debug.update(phase3_debug)
 
+            if (
+                settings.orion_unified_grounding_enabled
+                and str(plan.verb_name or "").strip().lower() == "stance_react"
+                and step.step_name == "llm_stance_react"
+                and step_res.status == "success"
+            ):
+                stance_text, _ = _extract_final_text([step_res], verb_name=plan.verb_name)
+                grounding_capsule = await assemble_stance_grounding(
+                    bus,
+                    source=source,
+                    ctx=ctx,
+                    correlation_id=correlation_id,
+                    recall_cfg=recall_cfg,
+                    stance_step_text=stance_text or "",
+                )
+                if grounding_capsule is not None:
+                    ctx["grounding_capsule"] = grounding_capsule.model_dump(mode="json")
+
             if step_res.status != "success":
                 overall_status = "partial" if len(step_results) > 1 else "fail"
                 break
@@ -1518,6 +1537,8 @@ class PlanRunner:
             metadata["structured_output_rejected"] = True
             if final_text_diag.get("structured_rejection_preview"):
                 metadata["structured_rejection_preview"] = str(final_text_diag["structured_rejection_preview"])[:500]
+        if isinstance(ctx.get("grounding_capsule"), dict):
+            metadata["grounding_capsule"] = ctx["grounding_capsule"]
         mark_orion_turn(str(ctx.get("session_id") or "global"))
 
         record_assembled_grammar(

--- a/services/orion-cortex-exec/app/settings.py
+++ b/services/orion-cortex-exec/app/settings.py
@@ -55,6 +55,7 @@ class Settings(BaseSettings):
     chat_pcr_quick_phase3: bool = Field(False, alias="CHAT_PCR_QUICK_PHASE3")
     chat_pcr_skip_max_novelty: float = Field(0.25, alias="CHAT_PCR_SKIP_MAX_NOVELTY")
     chat_pcr_skip_shift_novelty_floor: float = Field(0.35, alias="CHAT_PCR_SKIP_SHIFT_NOVELTY_FLOOR")
+    orion_unified_grounding_enabled: bool = Field(True, alias="ORION_UNIFIED_GROUNDING_ENABLED")
     channel_agent_chain_intake: str = Field("orion:exec:request:AgentChainService", alias="CHANNEL_AGENT_CHAIN_INTAKE")
     channel_context_exec_intake: str = Field(
         "orion:exec:request:ContextExecService",

--- a/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
+++ b/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from app.grounding_capsule import (
+    build_grounding_capsule,
+    stance_slice_brief_from_step_text,
+)
+
+
+def test_build_grounding_capsule_from_ctx() -> None:
+    ctx = {
+        "orion_identity_summary": ["I am Oríon."],
+        "juniper_relationship_summary": ["Juniper is my collaborator."],
+        "response_policy_summary": ["Speak plainly."],
+        "continuity_digest": "We were mid-refactor.",
+        "belief_digest": "Orion values continuity.",
+        "memory_digest": "We were mid-refactor.\n\nOrion values continuity.",
+        "identity_kernel_source": "configured_yaml",
+    }
+    capsule = build_grounding_capsule(ctx, pcr_ran=True)
+    assert capsule.identity_summary == ["I am Oríon."]
+    assert capsule.relationship_summary == ["Juniper is my collaborator."]
+    assert capsule.response_policy_summary == ["Speak plainly."]
+    assert capsule.memory_digest == "We were mid-refactor.\n\nOrion values continuity."
+    assert capsule.provenance["identity_source"] == "configured_yaml"
+    assert capsule.provenance["pcr_ran"] is True
+
+
+def test_build_grounding_capsule_identity_only_when_pcr_missing() -> None:
+    ctx = {
+        "orion_identity_summary": ["I am Oríon."],
+        "juniper_relationship_summary": [],
+        "response_policy_summary": [],
+        "identity_kernel_source": "configured_yaml",
+    }
+    capsule = build_grounding_capsule(ctx, pcr_ran=False)
+    assert capsule.identity_summary == ["I am Oríon."]
+    assert capsule.continuity_digest is None
+    assert capsule.belief_digest is None
+    assert capsule.memory_digest is None
+    assert capsule.provenance["pcr_ran"] is False
+
+
+def test_stance_slice_brief_from_step_text_extracts_mode_and_frame() -> None:
+    text = (
+        '{"imperative":"Stay present.","tone":"warm",'
+        '"stance_harness_slice":{"task_mode":"reflective_dialogue",'
+        '"conversation_frame":"reflective","answer_strategy":"companion"}}'
+    )
+    brief = stance_slice_brief_from_step_text(text)
+    assert brief["task_mode"] == "reflective_dialogue"
+    assert brief["conversation_frame"] == "reflective"
+
+
+def test_stance_slice_brief_from_step_text_tolerates_garbage() -> None:
+    assert stance_slice_brief_from_step_text("not json") == {}
+    assert stance_slice_brief_from_step_text("") == {}

--- a/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
+++ b/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from app.grounding_capsule import (
+    assemble_stance_grounding,
     build_grounding_capsule,
     stance_slice_brief_from_step_text,
 )
@@ -54,3 +57,34 @@ def test_stance_slice_brief_from_step_text_extracts_mode_and_frame() -> None:
 def test_stance_slice_brief_from_step_text_tolerates_garbage() -> None:
     assert stance_slice_brief_from_step_text("not json") == {}
     assert stance_slice_brief_from_step_text("") == {}
+
+
+@pytest.mark.asyncio
+async def test_assemble_ships_identity_only_capsule_when_pcr_raises(monkeypatch) -> None:
+    from app import grounding_capsule as gc
+    from app.settings import Settings
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("pcr down")
+
+    monkeypatch.setattr(gc, "run_pcr_phase3", _boom)
+    cfg = Settings(ORION_UNIFIED_GROUNDING_ENABLED=True, CHAT_PCR_ENABLED=True)
+    ctx: dict = {
+        "orion_identity_summary": ["I am Oríon."],
+        "juniper_relationship_summary": ["Juniper is my collaborator."],
+        "response_policy_summary": ["Speak plainly."],
+        "identity_kernel_source": "configured_yaml",
+    }
+    capsule = await assemble_stance_grounding(
+        bus=None,
+        source=None,
+        ctx=ctx,
+        correlation_id="c-1",
+        recall_cfg={},
+        stance_step_text='{"stance_harness_slice":{"task_mode":"reflective_dialogue","conversation_frame":"reflective"}}',
+        exec_settings=cfg,
+    )
+    assert capsule is not None
+    assert capsule.identity_summary == ["I am Oríon."]
+    assert capsule.provenance["pcr_ran"] is False
+    assert capsule.memory_digest is None

--- a/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
+++ b/services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py
@@ -7,6 +7,7 @@ from app.grounding_capsule import (
     build_grounding_capsule,
     stance_slice_brief_from_step_text,
 )
+from app.settings import Settings
 
 
 def test_build_grounding_capsule_from_ctx() -> None:
@@ -88,3 +89,22 @@ async def test_assemble_ships_identity_only_capsule_when_pcr_raises(monkeypatch)
     assert capsule.identity_summary == ["I am Oríon."]
     assert capsule.provenance["pcr_ran"] is False
     assert capsule.memory_digest is None
+
+
+@pytest.mark.asyncio
+async def test_assemble_returns_none_when_flag_off() -> None:
+    cfg = Settings(ORION_UNIFIED_GROUNDING_ENABLED=False)
+    ctx: dict = {"orion_identity_summary": ["I am Oríon."]}
+    result = await assemble_stance_grounding(
+        bus=None,
+        source=None,
+        ctx=ctx,
+        correlation_id="c-1",
+        recall_cfg={},
+        stance_step_text="{}",
+        exec_settings=cfg,
+    )
+    assert result is None
+    # Flag off ⇒ short-circuit before any stance-brief / PCR side effect on ctx.
+    assert "grounding_capsule" not in ctx
+    assert "chat_stance_brief" not in ctx

--- a/services/orion-cortex-exec/tests/test_router_grounding_capsule_metadata.py
+++ b/services/orion-cortex-exec/tests/test_router_grounding_capsule_metadata.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from app.router import PlanRunner
+from orion.core.bus.bus_schemas import ServiceRef
+from orion.schemas.cortex.schemas import (
+    ExecutionPlan,
+    ExecutionStep,
+    PlanExecutionArgs,
+    PlanExecutionRequest,
+    StepExecutionResult,
+)
+from orion.schemas.thought import GroundingCapsuleV1
+
+
+def _request(*, verb_name: str, step_name: str) -> PlanExecutionRequest:
+    plan = ExecutionPlan(
+        verb_name=verb_name,
+        label=verb_name,
+        description="",
+        category="x",
+        priority="normal",
+        interruptible=True,
+        can_interrupt_others=False,
+        timeout_ms=1000,
+        max_recursion_depth=1,
+        metadata={"mode": "brain"},
+        steps=[
+            ExecutionStep(
+                verb_name=verb_name,
+                step_name=step_name,
+                description="",
+                order=0,
+                services=["LLMGatewayService"],
+                requires_memory=False,
+            )
+        ],
+    )
+    return PlanExecutionRequest(
+        plan=plan,
+        args=PlanExecutionArgs(request_id="r1", extra={"mode": "brain"}),
+        context={"mode": "brain", "raw_user_text": "how are you?"},
+    )
+
+
+def _fake_step(*, verb_name: str, step_name: str) -> StepExecutionResult:
+    return StepExecutionResult(
+        status="success",
+        verb_name=verb_name,
+        step_name=step_name,
+        order=0,
+        result={"LLMGatewayService": {"content": '{"imperative":"Stay present.","tone":"warm"}'}},
+        latency_ms=1,
+        node="n",
+        logs=[],
+        error=None,
+    )
+
+
+def _capsule() -> GroundingCapsuleV1:
+    return GroundingCapsuleV1(
+        identity_summary=["I am Oríon."],
+        relationship_summary=["Juniper is my collaborator."],
+        response_policy_summary=["Speak plainly."],
+        continuity_digest="We were mid-refactor.",
+        belief_digest="Orion values continuity.",
+        memory_digest="We were mid-refactor.",
+        provenance={"identity_source": "configured_yaml", "pcr_ran": True},
+    )
+
+
+def test_router_attaches_grounding_capsule_to_metadata(monkeypatch) -> None:
+    """stance_react turn: the router assembles the capsule and rides it on result metadata."""
+    runner = PlanRunner()
+    monkeypatch.setattr(
+        "app.router.call_step_services",
+        AsyncMock(return_value=_fake_step(verb_name="stance_react", step_name="llm_stance_react")),
+    )
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    assemble = AsyncMock(return_value=_capsule())
+    monkeypatch.setattr("app.router.assemble_stance_grounding", assemble)
+
+    result = asyncio.run(
+        runner.run_plan(
+            bus=object(),
+            source=ServiceRef(name="x", version="0", node="n"),
+            req=_request(verb_name="stance_react", step_name="llm_stance_react"),
+            correlation_id="corr-grounding",
+            ctx={"mode": "brain", "raw_user_text": "how are you?"},
+        )
+    )
+
+    assert assemble.await_count == 1
+    capsule_md = result.metadata["grounding_capsule"]
+    assert capsule_md["identity_summary"] == ["I am Oríon."]
+    assert capsule_md["provenance"]["pcr_ran"] is True
+
+
+def test_router_omits_grounding_capsule_when_assembler_returns_none(monkeypatch) -> None:
+    """Flag-off / degraded assembly returns None => router leaves metadata untouched (no-op)."""
+    runner = PlanRunner()
+    monkeypatch.setattr(
+        "app.router.call_step_services",
+        AsyncMock(return_value=_fake_step(verb_name="stance_react", step_name="llm_stance_react")),
+    )
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.assemble_stance_grounding", AsyncMock(return_value=None))
+
+    result = asyncio.run(
+        runner.run_plan(
+            bus=object(),
+            source=ServiceRef(name="x", version="0", node="n"),
+            req=_request(verb_name="stance_react", step_name="llm_stance_react"),
+            correlation_id="corr-grounding-none",
+            ctx={"mode": "brain", "raw_user_text": "how are you?"},
+        )
+    )
+
+    assert "grounding_capsule" not in result.metadata
+
+
+def test_router_does_not_assemble_grounding_for_non_stance_verb(monkeypatch) -> None:
+    """Only stance_react turns assemble the capsule; other verbs never call the assembler."""
+    runner = PlanRunner()
+    monkeypatch.setattr(
+        "app.router.call_step_services",
+        AsyncMock(return_value=_fake_step(verb_name="chat_general", step_name="llm_chat_general")),
+    )
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    assemble = AsyncMock(return_value=_capsule())
+    monkeypatch.setattr("app.router.assemble_stance_grounding", assemble)
+
+    result = asyncio.run(
+        runner.run_plan(
+            bus=object(),
+            source=ServiceRef(name="x", version="0", node="n"),
+            req=_request(verb_name="chat_general", step_name="llm_chat_general"),
+            correlation_id="corr-grounding-nonstance",
+            ctx={"mode": "brain", "raw_user_text": "how are you?"},
+        )
+    )
+
+    assert assemble.await_count == 0
+    assert "grounding_capsule" not in result.metadata

--- a/services/orion-thought/app/bus_listener.py
+++ b/services/orion-thought/app/bus_listener.py
@@ -10,7 +10,7 @@ from orion.cognition.plan_loader import build_plan_for_verb
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.schemas.cortex.schemas import PlanExecutionArgs, PlanExecutionRequest
-from orion.schemas.thought import StanceReactRequestV1, ThoughtEventV1
+from orion.schemas.thought import GroundingCapsuleV1, StanceReactRequestV1, ThoughtEventV1
 from orion.thought.stance_react import (
     apply_stance_react_pipeline,
     build_stance_react_failure_thought,
@@ -108,6 +108,20 @@ def extract_stance_react_payload(result: dict[str, Any]) -> dict[str, Any] | str
     raise ValueError("stance_react exec result missing thought payload")
 
 
+def _extract_grounding_capsule(exec_result: dict[str, Any]) -> GroundingCapsuleV1 | None:
+    metadata = exec_result.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    raw = metadata.get("grounding_capsule")
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return GroundingCapsuleV1.model_validate(raw)
+    except Exception:
+        logger.warning("grounding_capsule_parse_failed corr=%s", exec_result.get("request_id"))
+        return None
+
+
 async def run_stance_react(
     request: StanceReactRequestV1,
     *,
@@ -128,7 +142,11 @@ async def run_stance_react(
         correlation_id=request.correlation_id,
         session_id=request.session_id,
     )
-    return apply_stance_react_pipeline(thought, request)
+    enriched = apply_stance_react_pipeline(thought, request)
+    capsule = _extract_grounding_capsule(exec_result)
+    if capsule is not None:
+        enriched = enriched.model_copy(update={"grounding_capsule": capsule})
+    return enriched
 
 
 async def handle_stance_react_request(

--- a/services/orion-thought/tests/test_stance_react_grounding_capsule.py
+++ b/services/orion-thought/tests/test_stance_react_grounding_capsule.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pytest
+
+from app.bus_listener import run_stance_react
+from orion.schemas.thought import (
+    HubAssociationBundleV1,
+    StanceReactRequestV1,
+)
+
+
+class _FakeCortexClient:
+    def __init__(self, exec_result: dict) -> None:
+        self._exec_result = exec_result
+
+    async def execute_plan(self, **_kwargs) -> dict:
+        return self._exec_result
+
+
+def _request() -> StanceReactRequestV1:
+    return StanceReactRequestV1(
+        correlation_id="c-1",
+        session_id="s-1",
+        user_message="how are you?",
+        association=HubAssociationBundleV1(
+            correlation_id="c-1",
+            broadcast=None,
+            broadcast_stale=True,
+            read_source="hub_sql_fallback",
+        ),
+        repair_bundle=None,
+        stance_inputs={"user_message": "how are you?"},
+    )
+
+
+def _stance_json() -> str:
+    return (
+        '{"imperative":"Stay present with Juniper.","tone":"warm",'
+        '"strain_refs":["hub:turn:c-1"],"evidence_refs":["hub:turn:c-1"],'
+        '"stance_harness_slice":{"task_mode":"reflective_dialogue",'
+        '"conversation_frame":"reflective","answer_strategy":"companion"}}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_stance_react_attaches_grounding_capsule() -> None:
+    exec_result = {
+        "final_text": _stance_json(),
+        "metadata": {
+            "grounding_capsule": {
+                "schema_version": "grounding.capsule.v1",
+                "identity_summary": ["I am Oríon."],
+                "relationship_summary": ["Juniper is my collaborator."],
+                "response_policy_summary": ["Speak plainly."],
+                "continuity_digest": "We were mid-refactor.",
+                "belief_digest": "Orion values continuity.",
+                "memory_digest": "We were mid-refactor.",
+                "provenance": {"identity_source": "configured_yaml", "pcr_ran": True},
+            }
+        },
+    }
+    thought = await run_stance_react(
+        _request(), bus=None, cortex_client=_FakeCortexClient(exec_result)
+    )
+    assert thought.grounding_capsule is not None
+    assert thought.grounding_capsule.identity_summary == ["I am Oríon."]
+    assert thought.grounding_capsule.provenance["pcr_ran"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_stance_react_no_capsule_when_metadata_absent() -> None:
+    exec_result = {"final_text": _stance_json(), "metadata": {}}
+    thought = await run_stance_react(
+        _request(), bus=None, cortex_client=_FakeCortexClient(exec_result)
+    )
+    assert thought.grounding_capsule is None

--- a/services/orion-thought/tests/test_stance_react_grounding_capsule.py
+++ b/services/orion-thought/tests/test_stance_react_grounding_capsule.py
@@ -74,3 +74,16 @@ async def test_run_stance_react_no_capsule_when_metadata_absent() -> None:
         _request(), bus=None, cortex_client=_FakeCortexClient(exec_result)
     )
     assert thought.grounding_capsule is None
+
+
+@pytest.mark.asyncio
+async def test_run_stance_react_no_capsule_when_metadata_malformed() -> None:
+    exec_result = {
+        "final_text": _stance_json(),
+        "metadata": {"grounding_capsule": {"identity_summary": "not-a-list"}},
+        "request_id": "c-1",
+    }
+    thought = await run_stance_react(
+        _request(), bus=None, cortex_client=_FakeCortexClient(exec_result)
+    )
+    assert thought.grounding_capsule is None


### PR DESCRIPTION
# Unified-Turn Self-Grounding

## Summary

- New `GroundingCapsuleV1` schema (`grounding.capsule.v1`): bounded self-context = identity + Juniper-relationship + response-policy summaries + PCR memory/continuity/belief digests + provenance. Registered in `orion/schemas/registry.py`.
- Rides on a new optional `ThoughtEventV1.grounding_capsule` field (additive, backward compatible — existing payloads still validate).
- Producer: `services/orion-cortex-exec/app/grounding_capsule.py` — pure builder + async orchestrator with flag-off short-circuit and PCR-failure graceful degradation (identity-only capsule). Wired into `app/router.py` right after the `llm_stance_react` step, gated by `ORION_UNIFIED_GROUNDING_ENABLED` (default `true`).
- Mapping: `orion-thought` `bus_listener.py` attaches the capsule from cortex-exec result metadata, fail-closed on malformed metadata.
- Consumers: motor prefix (compact self block, no policy), voice finalize (full self block incl. response policy, above STYLE RULES, guarded on identity content), and an identity-aware stance prompt.

## Outcome moved

A "How are you?" turn now carries grounded self-context (who Orion is, the Juniper relationship, durable memory, response policy) into both the motor draft and the curated voice finalize pass, instead of a policy-only stance with no self-grounding. Flag-off is a true no-op for the capsule field and its consumers; PCR outage degrades to an identity-only capsule rather than failing the turn.

## Current architecture (before)

`stance_react` produced a `ThoughtEventV1` with imperative/tone/stance slice but no self-context object. Motor prefix and voice finalize had no channel to receive identity/relationship/memory grounding for the unified turn. PCR phase-3 ran only for `chat_general`/`chat_quick`.

## Architecture touched

- Schema/contract: `orion/schemas/thought.py`, `orion/schemas/registry.py`.
- Producer seam: cortex-exec `router.py` stance-step hook + new `grounding_capsule.py`.
- Mapping seam: orion-thought `bus_listener.py`.
- Consumer seams: `orion/harness/prefix.py`, `orion/harness/finalize.py`, `orion/cognition/prompts/orion_voice_finalize.j2`, `orion/cognition/prompts/stance_react.j2`.
- Config: cortex-exec `settings.py` + `.env_example` (`ORION_UNIFIED_GROUNDING_ENABLED`).

## Files changed

- `orion/schemas/thought.py`: add `GroundingCapsuleV1`; add optional `ThoughtEventV1.grounding_capsule`.
- `orion/schemas/registry.py`: register `grounding.capsule.v1`.
- `orion/harness/prefix.py`: compact self block (identity + relationship + `memory_digest or continuity_digest`), no policy.
- `orion/harness/finalize.py`: pass `grounding_capsule` into voice finalize context.
- `orion/cognition/prompts/orion_voice_finalize.j2`: full self block above STYLE RULES; guarded on `identity_summary`; **memory line falls back to `continuity_digest`** to match the motor pass; blank-line spacing between sections.
- `orion/cognition/prompts/stance_react.j2`: identity-aware "felt self" block, guarded on identity-var presence.
- `orion/cognition/verbs/stance_react.yaml`: add `personality_file` (identity kernel). `requires_memory` unchanged vs `main` (`false`).
- `services/orion-cortex-exec/app/grounding_capsule.py`: builder + `assemble_stance_grounding` orchestrator.
- `services/orion-cortex-exec/app/router.py`: flag-gated stance-step hook attaches capsule to plan metadata.
- `services/orion-cortex-exec/app/settings.py`: `orion_unified_grounding_enabled` flag.
- `services/orion-cortex-exec/.env_example`: `ORION_UNIFIED_GROUNDING_ENABLED=true`.
- `services/orion-thought/app/bus_listener.py`: `_extract_grounding_capsule` + attach on `ThoughtEventV1` (fail-closed).
- `orion/thought/stance_react.py`: **strip any LLM-supplied `grounding_capsule`** in `parse_stance_react_payload` (capsule is only ever set deterministically from metadata, never authored by the LLM).

Tests/evals:
- `orion/schemas/tests/test_grounding_capsule_registry.py`
- `orion/harness/tests/test_grounding_capsule_consumers.py`
- `orion/harness/evals/test_unified_turn_grounding_eval.py`
- `orion/thought/tests/test_stance_react_pipeline.py` (+ LLM-capsule-strip regression)
- `services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py` (builder/parser + PCR-failure + flag-off)
- `services/orion-cortex-exec/tests/test_router_grounding_capsule_metadata.py` (**new** — router hook attach / no-op / non-stance skip)
- `services/orion-thought/tests/test_stance_react_grounding_capsule.py` (attach / absent / malformed)

## Schema / bus / API changes

- Added: `GroundingCapsuleV1` (`grounding.capsule.v1`); optional `ThoughtEventV1.grounding_capsule`.
- Removed: none.
- Renamed: none.
- Behavior changed: `run_pcr_phase3` now also runs on `stance_react` turns (only when flag on) to source memory digests; a valid `grounding_capsule` now rides on `PlanExecutionResult.metadata["grounding_capsule"]`.
- Compatibility: additive/optional — old `ThoughtEventV1` payloads validate unchanged; flag off = no-op for the capsule field + consumers.

## Env/config changes

- Added keys: `ORION_UNIFIED_GROUNDING_ENABLED` (cortex-exec, default `true`).
- Removed/renamed keys: none.
- `.env_example` updated: yes (cortex-exec).
- Local `.env` synced: operator `.env` in the main checkout set to `ORION_UNIFIED_GROUNDING_ENABLED=true` (worktrees have no local `.env`; the runtime checkout is authoritative).
- Skipped keys requiring operator action: none.

## Tests run

```text
# from .worktrees/unified-turn-grounding, venv python
schemas/harness/thought/cortex-exec touched surface: 43 passed
orion-thought (PYTHONPATH=services/orion-thought:.):   3 passed
```

## Evals run

```text
orion/harness/evals/test_unified_turn_grounding_eval.py: passed
(deterministic "How are you?" turn asserts grounding reaches motor prefix + voice finalize)
```

## Docker/build/smoke checks

```text
docker compose config validated for cortex-exec + orion-thought (compose files unchanged by this branch).
Live "How are you?" smoke deferred to post-merge restart of cortex-exec + orion-thought.
```

## Review findings fixed

- Finding (prior review, Important): router hook that attaches the capsule to metadata had no behavior test.
  - Fix: added `test_router_grounding_capsule_metadata.py` driving real `PlanRunner.run_plan` (only `call_step_services` + `assemble_stance_grounding` mocked); asserts attach on stance turn, no-op when assembler returns None, and no assembly for non-stance verbs.
  - Evidence: 3 passed.
- Finding (fresh review, Minor): motor↔voice digest fallback asymmetry.
  - Fix: voice template memory line now `memory_digest or continuity_digest`, matching motor.
  - Evidence: consumer + eval suites green (25 passed).
- Finding (fresh review, Minor): a hallucinated LLM `grounding_capsule` would be schema-legal.
  - Fix: `parse_stance_react_payload` strips any model-supplied `grounding_capsule` before validation.
  - Evidence: `test_parse_stance_react_payload_strips_model_supplied_grounding_capsule` passes.

## Restart required

```bash
# after merge / pulling this branch on the runtime host:
sudo docker compose --env-file .env --env-file services/orion-cortex-exec/.env -f services/orion-cortex-exec/docker-compose.yml up -d --build
sudo docker compose --env-file .env --env-file services/orion-thought/.env -f services/orion-thought/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low. Concern: per plan Task 7, the identity-aware **stance prompt** and the verb `personality_file` are guarded on identity-variable presence, not on `ORION_UNIFIED_GROUNDING_ENABLED`. So flag-off is byte-identical for the capsule field + its consumers, but the stance prompt still gains identity-awareness whenever the personality kernel loads. Intentional per the plan; noted for operators who expect the flag to gate everything.
  - Mitigation: identity-boundary regression test proves the "I am Orion / not Juniper" boundary holds with the capsule present; if fuller rollback is ever needed, gate the stance identity injection on the flag as a follow-up.

## PR link

Not yet opened (gh CLI not authenticated in this environment). Create at:
https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/unified-turn-self-grounding
