### PR TITLE
Fix/orion embodiment void doublesend

### DIFF
--- a/services/orion-embodiment/.env_example
+++ b/services/orion-embodiment/.env_example
@@ -3,6 +3,9 @@ PROJECT=orion-athena
 SERVICE_NAME=orion-embodiment
 SERVICE_VERSION=0.1.0
 NODE_NAME=athena
+# Worker log level (DEBUG|INFO|WARNING|ERROR). Configured at boot so the loop's
+# perception/speech/journal decisions surface in `docker logs`.
+EMBODIMENT_LOG_LEVEL=INFO
 # Orion bus (Redis) — pass through from root .env (Tailscale node); never hardcode bus-core here.
 ORION_BUS_URL=${ORION_BUS_URL}
 ORION_BUS_ENABLED=true

--- a/services/orion-embodiment/app/main.py
+++ b/services/orion-embodiment/app/main.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
 from app.settings import get_settings
 from app.worker import EmbodimentWorker
+
+# Configure logging at import (before the worker loop starts) so the loop's
+# perception/speech/journal decisions land in `docker logs`. uvicorn installs its
+# own handlers for its loggers but leaves the root/app loggers unconfigured, so
+# without this the embodiment worker was silent and had to be diagnosed via live
+# DB probing.
+logging.basicConfig(
+    level=getattr(logging, get_settings().log_level.upper(), logging.INFO),
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    force=True,
+)
 
 worker = EmbodimentWorker()
 

--- a/services/orion-embodiment/app/settings.py
+++ b/services/orion-embodiment/app/settings.py
@@ -9,6 +9,10 @@ class Settings(BaseSettings):
     service_name: str = Field("orion-embodiment", alias="SERVICE_NAME")
     service_version: str = Field("0.1.0", alias="SERVICE_VERSION")
     node_name: str = Field("athena", alias="NODE_NAME")
+    # Root log level for the worker loop. Without an explicit handler the loop's
+    # decisions/speech never surface in `docker logs` (only uvicorn access lines),
+    # which forced live DB probing to diagnose the void bug. Configured at boot.
+    log_level: str = Field("INFO", alias="EMBODIMENT_LOG_LEVEL")
 
     bus_url: str = Field(default="redis://100.92.216.81:6379/0", alias="ORION_BUS_URL")
     bus_enabled: bool = Field(True, alias="ORION_BUS_ENABLED")

--- a/services/orion-embodiment/app/worker.py
+++ b/services/orion-embodiment/app/worker.py
@@ -45,7 +45,8 @@ JOURNAL_TRIGGER_KIND = "orion.actions.trigger.journal.v1"
 # TODO(embodiment): confirm names/args against upstream when it is vendored.
 START_CONVERSATION_INPUT = "startConversation"
 START_TYPING_INPUT = "startTyping"
-FINISH_SENDING_MESSAGE_INPUT = "finishSendingMessage"
+# NOTE: the `finishSendingMessage` input is NOT sent directly — `messages:writeMessage`
+# enqueues it server-side with a numeric timestamp. See `_inject_utterance`.
 WRITE_MESSAGE_MUTATION = "messages:writeMessage"
 
 
@@ -737,19 +738,24 @@ class EmbodimentWorker:
             return ""
 
     def _inject_utterance(self, own_player_id: str, conversation_id: str, text: str) -> None:
-        """Inject an utterance into the AI Town conversation (startTyping -> write -> finish).
+        """Inject an utterance into the AI Town conversation (startTyping -> writeMessage).
 
         Input/mutation names follow the AI Town canonical schema (upstream not
         vendored here). See TODO on the input constants above.
 
-        CRITICAL (the "void" fix): the ``finishSendingMessage`` engine input is what
-        advances conversation state (``conversation.lastMessage`` + ``numMessages``),
-        which is what a partner agent's tick reads to decide it's their turn to
-        reply. Upstream's schema is ``{playerId, conversationId, timestamp}`` — NOT
-        ``messageUuid``. Sending the wrong args gets the input dropped, so Orion's
-        message rows land in the DB but the engine never registers that Orion spoke,
-        and the partner waits forever. Runtime evidence: a live conversation held 75
-        Orion message rows with ``numMessages=0``/``lastMessage=null`` until fixed.
+        CRITICAL (the "void" fix): the engine only advances conversation state
+        (``conversation.lastMessage`` + ``numMessages``) — which a partner agent's
+        tick reads to decide it's their turn — on a valid ``finishSendingMessage``
+        input carrying a numeric ``timestamp`` (ms), NOT ``messageUuid``.
+
+        ``messages:writeMessage`` already enqueues that ``finishSendingMessage``
+        server-side with ``timestamp: Date.now()`` (see upstream ``convex/messages.ts``),
+        so we do NOT send a second one from here. Doing so previously (a) double-counted
+        ``numMessages`` for Orion's turns and, when sent with the wrong args
+        (``messageUuid`` and no ``timestamp``), (b) poisoned the shared engine: the
+        malformed input built ``lastMessage={author}`` with no timestamp, which fails
+        the ``serializedConversation`` validator in ``saveWorld`` and crashes every
+        ``runStep`` — freezing the whole town until the stale input backlog was purged.
         """
         message_uuid = str(uuid4())
         wid = self._world_id or None
@@ -758,6 +764,8 @@ class EmbodimentWorker:
             args={"playerId": own_player_id, "conversationId": conversation_id, "messageUuid": message_uuid},
             world_id=wid,
         )
+        # writeMessage writes the row AND enqueues the canonical finishSendingMessage
+        # (with a numeric timestamp) itself — this single call advances the turn.
         aitown_client.convex_mutation(
             WRITE_MESSAGE_MUTATION,
             {
@@ -768,16 +776,4 @@ class EmbodimentWorker:
                 "playerId": own_player_id,
                 "text": text,
             },
-        )
-        aitown_client.send_input(
-            name=FINISH_SENDING_MESSAGE_INPUT,
-            # Upstream conversationInputs.finishSendingMessage expects a numeric
-            # `timestamp` (ms), not `messageUuid`. Wrong args -> input rejected ->
-            # numMessages/lastMessage never advance -> partner never hears Orion.
-            args={
-                "playerId": own_player_id,
-                "conversationId": conversation_id,
-                "timestamp": int(_utcnow().timestamp() * 1000),
-            },
-            world_id=wid,
         )

--- a/services/orion-embodiment/app/worker.py
+++ b/services/orion-embodiment/app/worker.py
@@ -69,6 +69,9 @@ class EmbodimentWorker:
         self._last_move_at: Optional[datetime] = None
         self._last_idle_wander_at: Optional[datetime] = None
         self._last_social_attempt_at: Optional[datetime] = None
+        # Throttle for the loop heartbeat log so a healthy (silent) loop is still
+        # observable in `docker logs` without spamming on a tight perception interval.
+        self._last_heartbeat_log_at: Optional[datetime] = None
         # Serializes the two concurrent process_intent callers (consume loop +
         # idle-wander loop) so the move-cooldown read-then-write cannot double-fire.
         self._actuate_lock = asyncio.Lock()
@@ -551,6 +554,7 @@ class EmbodimentWorker:
             except Exception:
                 logger.exception("embodiment_perception_loop_failed")
                 perception = None
+            self._maybe_log_heartbeat(perception)
             if perception is not None and getattr(self._settings, "memory_enabled", False):
                 try:
                     await self._journal_from_perception(perception)
@@ -583,6 +587,33 @@ class EmbodimentWorker:
                 await asyncio.wait_for(self._stop.wait(), timeout=interval)
             except asyncio.TimeoutError:
                 continue
+
+    def _maybe_log_heartbeat(self, perception: Optional[WorldPerceptionV1]) -> None:
+        """Emit a throttled INFO heartbeat summarizing the loop's current perception.
+
+        A healthy loop otherwise logs nothing (all loop logs are exception-only), so
+        `docker logs` looked dead even while working — which forced live DB probing to
+        diagnose the void bug. This is the smallest observability seam: one line every
+        ~30s with real perceived state, not fabricated cognition.
+        """
+        now = _utcnow()
+        last = self._last_heartbeat_log_at
+        if last is not None and (now - last).total_seconds() < 30.0:
+            return
+        self._last_heartbeat_log_at = now
+        if perception is None:
+            logger.info("embodiment_heartbeat perception=none")
+            return
+        convo = perception.active_conversation or {}
+        other = convo.get("other") or {}
+        logger.info(
+            "embodiment_heartbeat player=%s nearby=%d active_convo=%s status=%s partner=%s",
+            self._orion_player_id or "?",
+            len(perception.nearby_players or []),
+            convo.get("conversation_id") or "-",
+            convo.get("status") or "-",
+            other.get("player_id") or "-",
+        )
 
     async def _maybe_idle_wander(self, *, now: datetime) -> None:
         """Self-driven involuntary wander when no move has actuated within
@@ -710,6 +741,15 @@ class EmbodimentWorker:
 
         Input/mutation names follow the AI Town canonical schema (upstream not
         vendored here). See TODO on the input constants above.
+
+        CRITICAL (the "void" fix): the ``finishSendingMessage`` engine input is what
+        advances conversation state (``conversation.lastMessage`` + ``numMessages``),
+        which is what a partner agent's tick reads to decide it's their turn to
+        reply. Upstream's schema is ``{playerId, conversationId, timestamp}`` — NOT
+        ``messageUuid``. Sending the wrong args gets the input dropped, so Orion's
+        message rows land in the DB but the engine never registers that Orion spoke,
+        and the partner waits forever. Runtime evidence: a live conversation held 75
+        Orion message rows with ``numMessages=0``/``lastMessage=null`` until fixed.
         """
         message_uuid = str(uuid4())
         wid = self._world_id or None
@@ -731,6 +771,13 @@ class EmbodimentWorker:
         )
         aitown_client.send_input(
             name=FINISH_SENDING_MESSAGE_INPUT,
-            args={"playerId": own_player_id, "conversationId": conversation_id, "messageUuid": message_uuid},
+            # Upstream conversationInputs.finishSendingMessage expects a numeric
+            # `timestamp` (ms), not `messageUuid`. Wrong args -> input rejected ->
+            # numMessages/lastMessage never advance -> partner never hears Orion.
+            args={
+                "playerId": own_player_id,
+                "conversationId": conversation_id,
+                "timestamp": int(_utcnow().timestamp() * 1000),
+            },
             world_id=wid,
         )

--- a/services/orion-embodiment/docker-compose.yml
+++ b/services/orion-embodiment/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - EMBODIMENT_CHANNEL_INTENT=${EMBODIMENT_CHANNEL_INTENT:-orion:embodiment:intent}
       - EMBODIMENT_CHANNEL_OUTCOME=${EMBODIMENT_CHANNEL_OUTCOME:-orion:embodiment:outcome}
       - EMBODIMENT_CHANNEL_PERCEPTION=${EMBODIMENT_CHANNEL_PERCEPTION:-orion:embodiment:perception}
-      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - EMBODIMENT_LOG_LEVEL=${EMBODIMENT_LOG_LEVEL:-INFO}
 
 networks:
   app-net:

--- a/services/orion-embodiment/tests/test_worker_speech.py
+++ b/services/orion-embodiment/tests/test_worker_speech.py
@@ -72,6 +72,27 @@ def test_injectable_reply_is_injected():
     assert si.call_count >= 1
 
 
+def test_finish_sending_message_uses_numeric_timestamp_not_uuid():
+    """The 'void' regression: finishSendingMessage must carry a numeric `timestamp`
+    (upstream schema) so the engine advances numMessages/lastMessage and the partner
+    can perceive Orion's turn. `messageUuid` here gets the input dropped."""
+    w = _worker()
+    with patch.object(w, "_request_utterance", new=AsyncMock(return_value="Hi Juniper!")), \
+         patch("app.worker.aitown_client.send_input", return_value={"ok": True}) as si, \
+         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
+        asyncio.run(w._speak_once(_perception_in_convo()))
+    finish_calls = [
+        c for c in si.call_args_list
+        if c.kwargs.get("name") == "finishSendingMessage"
+    ]
+    assert finish_calls, "finishSendingMessage input was never sent"
+    args = finish_calls[-1].kwargs["args"]
+    assert "messageUuid" not in args, "finishSendingMessage must not carry messageUuid"
+    assert isinstance(args.get("timestamp"), int) and args["timestamp"] > 0
+    assert args["playerId"] == "orion"
+    assert args["conversationId"] == "conv1"
+
+
 def test_no_speech_when_orion_spoke_last():
     # Turn-taking: if the last message is Orion's, wait for a reply (no self-echo).
     w = _worker()
@@ -152,3 +173,22 @@ def test_speech_disabled_short_circuits():
     assert result is None
     req.assert_not_awaited()
     si.assert_not_called()
+
+
+def test_heartbeat_logs_once_then_throttles():
+    """Observability seam: a healthy loop (all other logs exception-only) must still
+    emit one INFO heartbeat, and it must throttle so a tight perception interval
+    doesn't spam. This is the gap that forced live DB probing to diagnose the void bug."""
+    w = _worker()
+    w._orion_player_id = "orion"
+    w._last_heartbeat_log_at = None
+    perc = _perception_in_convo()
+    with patch("app.worker.logger.info") as info:
+        w._maybe_log_heartbeat(perc)
+        first = info.call_count
+        w._maybe_log_heartbeat(perc)  # immediate second call -> throttled
+        second = info.call_count
+    assert first == 1, "first heartbeat must log"
+    assert second == 1, "second immediate heartbeat must be throttled"
+    msg = info.call_args_list[0].args[0]
+    assert "embodiment_heartbeat" in msg

--- a/services/orion-embodiment/tests/test_worker_speech.py
+++ b/services/orion-embodiment/tests/test_worker_speech.py
@@ -72,25 +72,24 @@ def test_injectable_reply_is_injected():
     assert si.call_count >= 1
 
 
-def test_finish_sending_message_uses_numeric_timestamp_not_uuid():
-    """The 'void' regression: finishSendingMessage must carry a numeric `timestamp`
-    (upstream schema) so the engine advances numMessages/lastMessage and the partner
-    can perceive Orion's turn. `messageUuid` here gets the input dropped."""
+def test_worker_does_not_send_finish_sending_message_directly():
+    """The 'void' regression, corrected: the worker must NOT send `finishSendingMessage`
+    itself. `messages:writeMessage` already enqueues it server-side with a numeric
+    timestamp. Sending a second one double-counted numMessages, and the pre-fix version
+    (messageUuid, no timestamp) poisoned the shared engine — a malformed lastMessage
+    that crashed every saveWorld/runStep and froze the whole town. writeMessage is the
+    single source of the turn advance."""
     w = _worker()
     with patch.object(w, "_request_utterance", new=AsyncMock(return_value="Hi Juniper!")), \
          patch("app.worker.aitown_client.send_input", return_value={"ok": True}) as si, \
-         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
+         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}) as cm:
         asyncio.run(w._speak_once(_perception_in_convo()))
-    finish_calls = [
-        c for c in si.call_args_list
-        if c.kwargs.get("name") == "finishSendingMessage"
-    ]
-    assert finish_calls, "finishSendingMessage input was never sent"
-    args = finish_calls[-1].kwargs["args"]
-    assert "messageUuid" not in args, "finishSendingMessage must not carry messageUuid"
-    assert isinstance(args.get("timestamp"), int) and args["timestamp"] > 0
-    assert args["playerId"] == "orion"
-    assert args["conversationId"] == "conv1"
+    finish_calls = [c for c in si.call_args_list if c.kwargs.get("name") == "finishSendingMessage"]
+    assert not finish_calls, "worker must not send finishSendingMessage directly (writeMessage enqueues it)"
+    # startTyping is still sent; writeMessage carries the message + turn advance.
+    typing_calls = [c for c in si.call_args_list if c.kwargs.get("name") == "startTyping"]
+    assert typing_calls, "startTyping should still be sent"
+    assert cm.called and cm.call_args.args[0] == "messages:writeMessage"
 
 
 def test_no_speech_when_orion_spoke_last():


### PR DESCRIPTION
# fix(embodiment): Orion two-way dialogue — finishSendingMessage timestamp + no double-send

## Summary

- Fix the "void" bug: Orion's messages landed in the DB but the AI Town engine never registered that he spoke, so partner agents waited forever. `_inject_utterance` now advances conversation state via a well-formed `finishSendingMessage` (numeric `timestamp`, not `messageUuid`).
- Remove the redundant/harmful direct `finishSendingMessage` send entirely: `messages:writeMessage` already enqueues one server-side with `timestamp: Date.now()`. The direct send double-counted `numMessages` and, in its pre-fix form (`messageUuid`, no `timestamp`), poisoned the shared engine.
- Add embodiment worker observability: boot-time logging config + a throttled INFO heartbeat, so loop perception/speech/journal decisions surface in `docker logs` instead of requiring live DB probing.

## Outcome moved

Orion now holds genuine **two-way** conversations in the town. Verified live post-fix: `numMessages` advances **+1 per turn** with cleanly alternating authors (`p:6 ↔ Orion`), where before a live conversation held 75 Orion message rows stuck at `numMessages=0` / `lastMessage=null`.

## Current architecture

`orion-embodiment` worker perceives the AI Town world (Convex) and, when it decides to speak, calls `_inject_utterance`: `startTyping` → `messages:writeMessage` → (previously) a direct `finishSendingMessage` engine input. The direct input carried `messageUuid` and no numeric `timestamp`, so the upstream `finishSendingMessage` handler dropped it and never updated `conversation.lastMessage` / `numMessages` — the signal a partner agent's tick reads to take its turn.

## Architecture touched

- `orion-embodiment` service only (worker speech injection + settings + boot logging). No bus/schema contract changes.

## Files changed

- `services/orion-embodiment/app/worker.py`: `_inject_utterance` sends `startTyping` + `messages:writeMessage` only; dropped the direct `finishSendingMessage` send and the now-unused `FINISH_SENDING_MESSAGE_INPUT` constant; added a throttled `embodiment_heartbeat` INFO log.
- `services/orion-embodiment/app/main.py`: `logging.basicConfig(..., force=True)` at import so worker decisions reach `docker logs`.
- `services/orion-embodiment/app/settings.py`: add `EMBODIMENT_LOG_LEVEL`.
- `services/orion-embodiment/.env_example`: document `EMBODIMENT_LOG_LEVEL`.
- `services/orion-embodiment/docker-compose.yml`: pass through `EMBODIMENT_LOG_LEVEL`.
- `services/orion-embodiment/tests/test_worker_speech.py`: regression tests — worker must NOT send `finishSendingMessage` directly (writeMessage enqueues it), still sends `startTyping`, calls `messages:writeMessage`; heartbeat logs once then throttles.

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: `_inject_utterance` relies on `messages:writeMessage` to enqueue the turn-advancing `finishSendingMessage` (matches upstream `convex/messages.ts`). No wire contract change.
- Compatibility notes: requires the deployed `messages:writeMessage` to enqueue `finishSendingMessage` (upstream default). Confirmed against the running backend.

## Env/config changes

- Added keys: `EMBODIMENT_LOG_LEVEL` (default `INFO`)
- Removed/renamed keys: none
- `.env_example` updated: yes
- local `.env` synced: yes (`python scripts/sync_local_env_from_example.py`)
- skipped keys requiring operator action: none

## Tests run

```text
pytest services/orion-embodiment/tests -q  →  43 passed
```

## Docker/build/smoke checks

```text
docker compose -f services/orion-embodiment/docker-compose.yml up -d --build  →  container recreated
curl -fsS localhost:8130/health  →  {"status":"ok","service":"orion-embodiment","enabled":"True"}
live probe: numMessages advances +1/turn, authors alternate (p:6 ↔ Orion) 2→3→4→5→6→7→8→9
```

## Review findings fixed

- Finding: worker double-sent `finishSendingMessage` (double-counted `numMessages`); pre-fix variant poisoned the engine.
  - Fix: rely solely on `writeMessage`'s server-enqueued `finishSendingMessage`.
  - Evidence: live probe shows +1/turn; code review APPROVE.

## Restart required

```bash
# already applied on the athena node during verification; for other operators:
docker compose --env-file .env --env-file services/orion-embodiment/.env \
  -f services/orion-embodiment/docker-compose.yml up -d --build
```

## Related

Operator recovery tooling for the frozen-engine failure mode this bug caused (poisoned `finishSendingMessage` inputs crashing `saveWorld`/`runStep`) landed separately on `main` as `services/orion-ai-town/patches/orion-engine-recovery.patch` (`testing:debugEngineState` + `testing:recoverFrozenEngine`).

## Risks / concerns

- Severity: low. Concern: depends on deployed `messages:writeMessage` enqueuing `finishSendingMessage`. Mitigation: verified live; regression test pins worker behavior.
