### PR TITLE
Feat/self tab brain ekg

### DIFF
--- a/services/orion-hub/static/js/self-brain.js
+++ b/services/orion-hub/static/js/self-brain.js
@@ -42,12 +42,108 @@ function stateColor(regionState, intensity) {
   return `rgba(96,165,250,${0.35 + 0.5 * intensity})`;
 }
 
+let spotlightPulseRAF = null;
+
+function drawSpotlight(ctx, canvas, frame) {
+  const sp = frame.spotlight;
+  ctx.textAlign = "left";
+  if (!sp) {
+    ctx.fillStyle = "#94a3b8";
+    ctx.font = "13px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("No active spotlight (no coalition selected yet).", canvas.width / 2, canvas.height / 2);
+    return;
+  }
+  const stability = Math.max(0, Math.min(1, sp.coalition_stability));
+  const stabPct = (stability * 100) | 0;
+  ctx.fillStyle = "#f0abfc";
+  ctx.font = "13px sans-serif";
+  ctx.fillText(
+    `Spotlight · ${sp.attended_node_ids.length} nodes · dwell ${sp.dwell_ticks} · stability ${stabPct}%${sp.stale ? " (held)" : ""}`,
+    12, 20,
+  );
+  if (sp.description) {
+    ctx.fillStyle = "#cbd5e1";
+    ctx.font = "12px sans-serif";
+    ctx.fillText(String(sp.description).slice(0, 96), 12, 38);
+  }
+
+  const ids = sp.attended_node_ids || [];
+  if (!ids.length) {
+    ctx.fillStyle = "#94a3b8";
+    ctx.font = "13px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("Coalition present but no attended nodes.", canvas.width / 2, canvas.height / 2);
+    return;
+  }
+
+  const byId = new Map((frame.nodes || []).map((n) => [n.node_id, n]));
+  const top = 54;
+  const areaH = canvas.height - top - 8;
+  const cols = Math.ceil(Math.sqrt(ids.length));
+  const rows = Math.ceil(ids.length / cols) || 1;
+  const cw = canvas.width / cols;
+  const chh = areaH / rows;
+  const pulse = 0.5 + 0.5 * Math.sin(Date.now() / 380); // 0..1
+
+  ids.forEach((id, i) => {
+    const cx = (i % cols) * cw + cw / 2;
+    const cy = top + Math.floor(i / cols) * chh + chh / 2;
+    const node = byId.get(id);
+    const act = node ? Math.max(0, Math.min(1, node.activation)) : 0.4;
+    const baseR = Math.min(cw, chh) * (0.16 + 0.16 * act);
+    // Coalition-stability halo: larger, softer ring when the coalition holds.
+    const haloR = baseR + 6 + 12 * stability * (0.6 + 0.4 * pulse);
+    ctx.beginPath();
+    ctx.arc(cx, cy, haloR, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(240,171,252,${0.05 + 0.15 * stability})`;
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(cx, cy, baseR, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(232,121,249,${0.45 + 0.45 * act})`;
+    ctx.fill();
+    ctx.strokeStyle = `rgba(240,171,252,${0.45 + 0.5 * pulse})`;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+    const label = node && node.label ? node.label : (id.split(":").slice(-1)[0] || id);
+    ctx.fillStyle = "#e5e7eb";
+    ctx.font = "10px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText(String(label).slice(0, 24), cx, cy + baseR + 12);
+  });
+}
+
+function startSpotlightPulse() {
+  if (spotlightPulseRAF) return;
+  const loop = () => {
+    if (state.dim !== "spotlight") { spotlightPulseRAF = null; return; }
+    const canvas = document.getElementById("brainCanvas");
+    const ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const frame = state.frames[state.frames.length - 1];
+    if (frame) drawSpotlight(ctx, canvas, frame);
+    else setStatus("no frames");
+    spotlightPulseRAF = requestAnimationFrame(loop);
+  };
+  spotlightPulseRAF = requestAnimationFrame(loop);
+}
+
+function stopSpotlightPulse() {
+  if (spotlightPulseRAF) { cancelAnimationFrame(spotlightPulseRAF); spotlightPulseRAF = null; }
+}
+
 function drawBrain() {
   const canvas = document.getElementById("brainCanvas");
   const ctx = canvas.getContext("2d");
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   const frame = state.frames[state.frames.length - 1];
   if (!frame) { setStatus("no frames"); return; }
+
+  if (state.dim === "spotlight") {
+    drawSpotlight(ctx, canvas, frame);
+    setStatus(`${frame.phase} · tick ${frame.tick_seq} · spotlight`);
+    return;
+  }
 
   const regions = regionsFor(frame, state.dim);
   // Fixed grid layout = stable, always-labeled anatomical zones.
@@ -79,17 +175,6 @@ function drawBrain() {
     ctx.fillText(`${(r.intensity * 100) | 0}%${ageTxt}`, cx, cy + 4);
   });
 
-  // Spotlight overlay: dashed hull label if present + spotlight dim selected.
-  if (state.dim === "spotlight" && frame.spotlight) {
-    ctx.fillStyle = "#f0abfc";
-    ctx.font = "13px sans-serif";
-    ctx.textAlign = "left";
-    ctx.fillText(
-      `Spotlight: ${frame.spotlight.attended_node_ids.length} nodes, dwell ${frame.spotlight.dwell_ticks}, stability ${(frame.spotlight.coalition_stability * 100 | 0)}%${frame.spotlight.stale ? " (held)" : ""}`,
-      12, 24,
-    );
-    if (frame.spotlight.description) ctx.fillText(frame.spotlight.description, 12, 44);
-  }
   setStatus(`${frame.phase} · tick ${frame.tick_seq} · ${regions.length} regions`);
 }
 
@@ -99,7 +184,31 @@ function drawEkg() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   const legend = document.getElementById("ekgLegend");
   legend.innerHTML = "";
-  if (state.dim === "spotlight") { legend.textContent = "Select a region dimension for EKG."; return; }
+  if (state.dim === "spotlight") {
+    // Coalition-stability sparkline over the loaded window.
+    const pts = state.frames.map((f) => (f.spotlight ? Math.max(0, Math.min(1, f.spotlight.coalition_stability)) : null));
+    if (!pts.some((v) => v !== null)) { legend.textContent = "No spotlight history in window."; return; }
+    const n2 = Math.max(1, pts.length - 1);
+    ctx.beginPath();
+    let started = false;
+    pts.forEach((v, xi) => {
+      if (v === null) return;
+      const x = (xi / n2) * canvas.width;
+      const y = canvas.height - v * (canvas.height - 8) - 4;
+      if (!started) { ctx.moveTo(x, y); started = true; } else ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = "#f0abfc";
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+    const row = document.createElement("div");
+    const sw = document.createElement("span");
+    sw.style.color = "#f0abfc";
+    sw.textContent = "■ ";
+    row.appendChild(sw);
+    row.append("coalition stability");
+    legend.appendChild(row);
+    return;
+  }
 
   // Build per-region series over the loaded window (regions are the stable series).
   const ids = new Set();
@@ -199,6 +308,7 @@ function buildDimRail() {
     btn.addEventListener("click", () => {
       state.dim = d.key;
       [...rail.children].forEach((c) => c.classList.toggle("bg-indigo-800", c.dataset.key === d.key));
+      if (d.key === "spotlight") startSpotlightPulse(); else stopSpotlightPulse();
       render();
     });
     rail.appendChild(btn);

--- a/services/orion-hub/static/js/self_observability.js
+++ b/services/orion-hub/static/js/self_observability.js
@@ -1,155 +1,16 @@
 (function () {
-  const pathSegments = window.location.pathname.split('/').filter((p) => p.length > 0);
-  const URL_PREFIX = pathSegments.length > 0 ? `/${pathSegments[0]}` : "";
-  const API_BASE_URL = window.location.origin + URL_PREFIX;
-
-  const SUMMARY_ENDPOINT = "/api/substrate/observability/summary";
+  // The Self tab body is a self-brain iframe (/static/self-brain.html) that
+  // fetches and renders its own data. app.js's tab router does not know about
+  // #self-observability, so this script's only job is panel show/hide + hash
+  // lifecycle. No summary fetch / card rendering lives here anymore.
   const PANEL_HASH = "#self-observability";
-  const AUTO_REFRESH_MS = 30000;
-  const MAX_GAP_SIGNALS = 5;
-  const NO_DATA_TEXT = "no data yet";
 
   document.addEventListener("DOMContentLoaded", () => {
     const panel = document.getElementById("self-observability");
     const tabButton = document.getElementById("selfObservabilityTabButton");
-    const statusEl = document.getElementById("selfObsStatus");
-    const refreshBtn = document.getElementById("selfObsRefresh");
-    const attentionTypeEl = document.getElementById("selfObsAttentionType");
-    const dwellTicksEl = document.getElementById("selfObsDwellTicks");
-    const nodeCountEl = document.getElementById("selfObsNodeCount");
-    const coalitionDescEl = document.getElementById("selfObsCoalitionDesc");
-    const stabilityEl = document.getElementById("selfObsStability");
-    const attendedCountEl = document.getElementById("selfObsAttendedCount");
-    const gapCountEl = document.getElementById("selfObsGapCount");
-    const gapListEl = document.getElementById("selfObsGapList");
-    const presenceHealthEl = document.getElementById("selfObsPresenceHealth");
-    const lastTurnAgeEl = document.getElementById("selfObsLastTurnAge");
-    const turnsPerMinEl = document.getElementById("selfObsTurnsPerMin");
 
-    if (!panel || !tabButton || !statusEl) {
+    if (!panel || !tabButton) {
       return;
-    }
-
-    let autoRefreshTimer = null;
-    let fetchInFlight = false;
-
-    function setStatus(text, isError) {
-      statusEl.textContent = text;
-      statusEl.classList.toggle("text-red-400", Boolean(isError));
-      statusEl.classList.toggle("text-gray-400", !isError);
-    }
-
-    function setText(el, value) {
-      if (el) el.textContent = value;
-    }
-
-    function truncate(text, maxLen) {
-      const raw = typeof text === "string" ? text : "";
-      if (raw.length <= maxLen) return raw;
-      return `${raw.slice(0, maxLen - 1)}…`;
-    }
-
-    function humanizeAgeSeconds(seconds) {
-      const value = Number(seconds);
-      if (!Number.isFinite(value) || value < 0) return "—";
-      if (value < 90) return `${Math.round(value)}s`;
-      return `${(value / 60).toFixed(1)}m`;
-    }
-
-    function renderGapListPlaceholder(text) {
-      if (!gapListEl) return;
-      gapListEl.innerHTML = "";
-      const li = document.createElement("li");
-      li.className = "text-gray-500 list-none";
-      li.textContent = text;
-      gapListEl.appendChild(li);
-    }
-
-    function renderAttentionSchema(selfState) {
-      if (!selfState || typeof selfState !== "object") {
-        setText(attentionTypeEl, NO_DATA_TEXT);
-        setText(dwellTicksEl, "—");
-        setText(nodeCountEl, "—");
-        return;
-      }
-      setText(attentionTypeEl, selfState.attention_schema_type || "none");
-      setText(dwellTicksEl, String(selfState.attention_dwell_ticks ?? "—"));
-      setText(nodeCountEl, String(selfState.attention_node_count ?? "—"));
-    }
-
-    function renderCoalitionFocus(broadcast) {
-      if (!broadcast || typeof broadcast !== "object") {
-        setText(coalitionDescEl, NO_DATA_TEXT);
-        setText(stabilityEl, "—");
-        setText(attendedCountEl, "—");
-        return;
-      }
-      setText(coalitionDescEl, broadcast.selected_description || "(no selected coalition)");
-      const stability = Number(broadcast.coalition_stability_score);
-      setText(stabilityEl, Number.isFinite(stability) ? stability.toFixed(2) : "—");
-      const attended = Array.isArray(broadcast.attended_node_ids) ? broadcast.attended_node_ids.length : 0;
-      setText(attendedCountEl, String(attended));
-    }
-
-    function renderCuriosityGaps(curiosity) {
-      if (!curiosity || typeof curiosity !== "object") {
-        setText(gapCountEl, "—");
-        renderGapListPlaceholder(NO_DATA_TEXT);
-        return;
-      }
-      setText(gapCountEl, String(curiosity.gap_count ?? 0));
-      const signals = Array.isArray(curiosity.signals) ? curiosity.signals : [];
-      if (signals.length === 0) {
-        renderGapListPlaceholder("no open curiosity signals");
-        return;
-      }
-      gapListEl.innerHTML = "";
-      signals.slice(0, MAX_GAP_SIGNALS).forEach((signal) => {
-        const li = document.createElement("li");
-        const strength = Number(signal && signal.signal_strength);
-        const strengthLabel = Number.isFinite(strength) ? strength.toFixed(2) : "?";
-        const signalType = (signal && signal.signal_type) || "unknown";
-        const summary = truncate((signal && signal.evidence_summary) || "", 96);
-        li.textContent = summary ? `${signalType} · ${strengthLabel} — ${summary}` : `${signalType} · ${strengthLabel}`;
-        gapListEl.appendChild(li);
-      });
-    }
-
-    function renderHubPresence(presence) {
-      if (!presence || typeof presence !== "object") {
-        setText(presenceHealthEl, NO_DATA_TEXT);
-        setText(lastTurnAgeEl, "—");
-        setText(turnsPerMinEl, "—");
-        return;
-      }
-      setText(presenceHealthEl, presence.connection_health || "unknown");
-      setText(lastTurnAgeEl, humanizeAgeSeconds(presence.last_turn_age_sec));
-      const tpm = Number(presence.turns_per_minute);
-      setText(turnsPerMinEl, Number.isFinite(tpm) ? tpm.toFixed(1) : "—");
-    }
-
-    async function refreshSummary() {
-      if (fetchInFlight) return;
-      fetchInFlight = true;
-      setStatus("Loading self-observability summary...", false);
-      try {
-        const response = await fetch(`${API_BASE_URL}${SUMMARY_ENDPOINT}`);
-        if (!response.ok) {
-          throw new Error(`status=${response.status}`);
-        }
-        const payload = await response.json();
-        renderAttentionSchema(payload && payload.self_state);
-        renderCoalitionFocus(payload && payload.attention_broadcast);
-        renderCuriosityGaps(payload && payload.curiosity);
-        renderHubPresence(payload && payload.hub_presence);
-        const generatedAt = payload && payload.generated_at ? ` (generated ${payload.generated_at})` : "";
-        setStatus(`Updated ${new Date().toLocaleTimeString()}${generatedAt}`, false);
-      } catch (err) {
-        console.warn("[SelfObservability] summary fetch failed", err);
-        setStatus(`Self-observability fetch failed: ${err.message || err}`, true);
-      } finally {
-        fetchInFlight = false;
-      }
     }
 
     function styleTabButton(button, isActive) {
@@ -162,20 +23,6 @@
       button.classList.toggle("border-gray-700", !isActive);
     }
 
-    function startAutoRefresh() {
-      if (autoRefreshTimer) return;
-      autoRefreshTimer = setInterval(() => {
-        if (panel.classList.contains("hidden")) return;
-        refreshSummary();
-      }, AUTO_REFRESH_MS);
-    }
-
-    function stopAutoRefresh() {
-      if (!autoRefreshTimer) return;
-      clearInterval(autoRefreshTimer);
-      autoRefreshTimer = null;
-    }
-
     function activatePanel() {
       document.querySelectorAll("#appPanels section[data-panel]").forEach((section) => {
         const key = section.getAttribute("data-panel");
@@ -185,12 +32,9 @@
         styleTabButton(anchor, anchor === tabButton);
       });
       history.replaceState(null, "", PANEL_HASH);
-      startAutoRefresh();
-      refreshSummary();
     }
 
     function deactivatePanel() {
-      stopAutoRefresh();
       panel.classList.add("hidden");
       styleTabButton(tabButton, false);
     }

--- a/services/orion-hub/static/self-brain.html
+++ b/services/orion-hub/static/self-brain.html
@@ -20,14 +20,15 @@
     <span id="brainStatus" class="ml-auto text-gray-500"></span>
   </div>
 
-  <div class="grid grid-cols-1 xl:grid-cols-3 gap-3">
-    <div class="xl:col-span-2 rounded-xl border border-gray-800 bg-gray-900/40 p-2">
+  <div class="flex flex-col gap-3">
+    <div class="rounded-xl border border-gray-800 bg-gray-900/40 p-2">
+      <div class="text-[10px] uppercase tracking-wide text-gray-500 mb-1">Brain map</div>
       <canvas id="brainCanvas" width="720" height="440" class="w-full"></canvas>
     </div>
     <div class="rounded-xl border border-gray-800 bg-gray-900/40 p-2">
       <div class="text-[10px] uppercase tracking-wide text-gray-500 mb-1">Region EKG (loaded window)</div>
-      <canvas id="ekgCanvas" width="360" height="360" class="w-full"></canvas>
-      <div id="ekgLegend" class="mt-2 text-[11px] space-y-0.5"></div>
+      <canvas id="ekgCanvas" width="720" height="240" class="w-full"></canvas>
+      <div id="ekgLegend" class="mt-2 text-[11px] flex flex-wrap gap-x-4 gap-y-0.5"></div>
     </div>
   </div>
 

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -1347,14 +1347,10 @@
           <div>
             <h2 class="text-xl font-bold text-white">Self-Observability — Orion visible to itself</h2>
             <p class="text-xs text-gray-400">
-              Live self-model snapshot from Hub <code class="text-gray-500">/api/substrate/observability/summary</code> (attention schema, coalition focus, curiosity gaps, hub presence).
+              Live substrate brain-frame: regions fire, hold steady, or starve as attention, reducer lane health, and self-state move. Streamed from <code class="text-gray-500">/api/self-brain</code>.
             </p>
           </div>
-          <div class="flex items-center gap-2 text-xs">
-            <button type="button" id="selfObsRefresh" class="px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 hover:bg-gray-700">Refresh</button>
-          </div>
         </div>
-        <div id="selfObsStatus" class="text-xs text-gray-400 min-h-[1.25rem]">Open this tab to load self-observability.</div>
         <div class="rounded-xl border border-gray-800 bg-gray-950/40 overflow-hidden flex-1 min-h-[40rem]">
           <iframe
             id="selfBrainFrame"

--- a/services/orion-hub/tests/test_self_observability_ui_panel.py
+++ b/services/orion-hub/tests/test_self_observability_ui_panel.py
@@ -1,4 +1,4 @@
-"""Static-content tests for the Hub Self-Observability panel (self-observability v2)."""
+"""Static-content tests for the Hub Self tab (self-brain iframe)."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -7,7 +7,10 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 TEMPLATE_PATH = REPO_ROOT / "services" / "orion-hub" / "templates" / "index.html"
 PANEL_JS_PATH = REPO_ROOT / "services" / "orion-hub" / "static" / "js" / "self_observability.js"
 
-PANEL_ELEMENT_IDS = (
+# DOM hooks + endpoint from the legacy 4-card summary body. These were migrated
+# to the standalone brain page; if the panel script or template references any
+# of them again it will crash at runtime (the elements no longer exist).
+REMOVED_SUMMARY_IDS = (
     "selfObsStatus",
     "selfObsRefresh",
     "selfObsAttentionType",
@@ -21,20 +24,25 @@ PANEL_ELEMENT_IDS = (
     "selfObsLastTurnAge",
     "selfObsTurnsPerMin",
 )
+LEGACY_SUMMARY_ENDPOINT = "/api/substrate/observability/summary"
 
 
-def test_template_declares_self_observability_tab_and_panel() -> None:
+def test_template_declares_self_tab_and_brain_iframe() -> None:
     template = TEMPLATE_PATH.read_text(encoding="utf-8")
 
     assert 'id="selfObservabilityTabButton"' in template
     assert 'data-hash-target="#self-observability"' in template
     assert '<section id="self-observability" data-panel="self-observability"' in template
-    # Self-tab body is now a self-brain iframe (cards migrated to the standalone
-    # brain page); the section retains its status line and refresh control.
-    assert 'id="selfObsStatus"' in template
-    assert 'id="selfObsRefresh"' in template
     assert 'id="selfBrainFrame"' in template
     assert '/static/self-brain.html?v={{HUB_UI_ASSET_VERSION}}' in template
+
+
+def test_template_dropped_legacy_summary_cards() -> None:
+    template = TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert LEGACY_SUMMARY_ENDPOINT not in template
+    for element_id in REMOVED_SUMMARY_IDS:
+        assert f'id="{element_id}"' not in template, element_id
 
 
 def test_template_includes_cache_busted_panel_script() -> None:
@@ -46,15 +54,16 @@ def test_template_includes_cache_busted_panel_script() -> None:
     )
 
 
-def test_panel_js_fetches_summary_and_renders_all_cards() -> None:
+def test_panel_js_is_tab_controller_only() -> None:
     panel_js = PANEL_JS_PATH.read_text(encoding="utf-8")
 
-    assert '"/api/substrate/observability/summary"' in panel_js
-    for element_id in PANEL_ELEMENT_IDS:
-        assert f'"{element_id}"' in panel_js, element_id
-    # Null-degrading sections and tab lifecycle.
-    assert "no data yet" in panel_js
+    # Tab lifecycle retained (app.js does not route #self-observability).
     assert "function activatePanel()" in panel_js
     assert "function deactivatePanel()" in panel_js
-    assert "startAutoRefresh" in panel_js
-    assert "stopAutoRefresh" in panel_js
+    assert "#self-observability" in panel_js
+
+    # No dead summary fetch / card rendering that would crash against the
+    # removed DOM elements.
+    assert LEGACY_SUMMARY_ENDPOINT not in panel_js
+    for element_id in REMOVED_SUMMARY_IDS:
+        assert element_id not in panel_js, element_id

--- a/services/orion-substrate-runtime/app/brain_frame_producer.py
+++ b/services/orion-substrate-runtime/app/brain_frame_producer.py
@@ -43,6 +43,23 @@ def _state_for(intensity: float, firing: float, starving: float) -> str:
     return "steady"
 
 
+def _node_activation(node: Any) -> float:
+    """Real activation lives at ``node.signals.activation.activation`` (nested).
+
+    ``BaseSubstrateNodeV1`` forbids extra fields and has no flat ``activation``
+    attribute, so reading ``node.activation`` always yields the 0.0 default and
+    makes every node look dormant. Read the nested bundle; only fall back to a
+    flat ``activation`` attr for foreign/legacy shapes that lack ``signals``.
+    """
+    signals = getattr(node, "signals", None)
+    if signals is not None:
+        activation_bundle = getattr(signals, "activation", None)
+        val = getattr(activation_bundle, "activation", None)
+        if val is not None:
+            return _clamp01(val)
+    return _clamp01(getattr(node, "activation", 0.0) or 0.0)
+
+
 def _node_pressure(node: Any) -> float:
     md = getattr(node, "metadata", None) or {}
     val = md.get("dynamic_pressure")
@@ -55,7 +72,7 @@ def _node_dormant(node: Any) -> bool:
     md = getattr(node, "metadata", None) or {}
     if md.get("dormant") is True:
         return True
-    return _clamp01(getattr(node, "activation", 0.0)) <= 0.0
+    return _node_activation(node) <= 0.0
 
 
 def _parse_dt(value: Any) -> datetime | None:
@@ -78,7 +95,7 @@ def _node_kind_regions(nodes, now, firing, starving) -> list[BrainRegionV1]:
     buckets: dict[str, list[float]] = {}
     for node in nodes:
         kind = str(getattr(node, "node_kind", "") or "unknown")
-        buckets.setdefault(kind, []).append(_clamp01(getattr(node, "activation", 0.0)))
+        buckets.setdefault(kind, []).append(_node_activation(node))
     regions: list[BrainRegionV1] = []
     for kind, activations in sorted(buckets.items()):
         intensity = max(activations) if activations else 0.0
@@ -173,12 +190,12 @@ def _spotlight(attention, now, cadence_sec) -> BrainSpotlightV1 | None:
 
 
 def _samples(nodes, edges, max_nodes, max_edges) -> tuple[list[BrainNodeSampleV1], list[BrainEdgeSampleV1]]:
-    ranked = sorted(nodes, key=lambda n: _clamp01(getattr(n, "activation", 0.0)), reverse=True)
+    ranked = sorted(nodes, key=_node_activation, reverse=True)
     node_samples = [
         BrainNodeSampleV1(
             node_id=str(getattr(n, "node_id", "") or ""),
             node_kind=str(getattr(n, "node_kind", "") or "unknown"),
-            activation=_clamp01(getattr(n, "activation", 0.0)),
+            activation=_node_activation(n),
             pressure=_node_pressure(n),
             dormant=_node_dormant(n),
             label=str(getattr(n, "label", "") or "")[:120],
@@ -226,7 +243,7 @@ def assemble_brain_frame(
         nodes, list(edges), settings.brain_frame_sample_nodes, settings.brain_frame_sample_edges
     )
 
-    max_activation = max((_clamp01(getattr(n, "activation", 0.0)) for n in nodes), default=0.0)
+    max_activation = max((_node_activation(n) for n in nodes), default=0.0)
     phase = "live" if max_activation > 0.0 else "warming"
 
     frame_id = hashlib.sha256(f"{now.isoformat()}|{tick_seq}".encode("utf-8")).hexdigest()[:24]

--- a/services/orion-substrate-runtime/evals/test_brain_frame_substance_eval.py
+++ b/services/orion-substrate-runtime/evals/test_brain_frame_substance_eval.py
@@ -16,9 +16,14 @@ from app.brain_frame_producer import assemble_brain_frame
 
 
 def _node(node_id, kind, activation, pressure=0.0):
+    # Real node shape: activation nested at signals.activation.activation.
     return SimpleNamespace(
         node_id=node_id, node_kind=kind, label=f"{kind}:{node_id}",
-        activation=activation, metadata={"dynamic_pressure": pressure},
+        signals=SimpleNamespace(
+            salience=activation,
+            activation=SimpleNamespace(activation=activation),
+        ),
+        metadata={"dynamic_pressure": pressure},
     )
 
 

--- a/services/orion-substrate-runtime/tests/test_brain_frame_producer.py
+++ b/services/orion-substrate-runtime/tests/test_brain_frame_producer.py
@@ -42,11 +42,16 @@ from types import SimpleNamespace
 
 
 def _node(node_id, kind, activation, pressure=0.0, dormant=False):
+    # Mirror the real BaseSubstrateNodeV1 shape: activation is nested at
+    # signals.activation.activation (there is NO flat `activation` attribute).
     return SimpleNamespace(
         node_id=node_id,
         node_kind=kind,
         label=f"{kind}:{node_id}",
-        activation=activation,
+        signals=SimpleNamespace(
+            salience=activation,
+            activation=SimpleNamespace(activation=activation),
+        ),
         metadata={"dynamic_pressure": pressure, "dormant": dormant},
     )
 
@@ -208,3 +213,65 @@ def test_edge_sample_cap_zero_yields_no_edges():
         tick_seq=5,
     )
     assert frame.edges == []
+
+
+def test_activation_read_from_nested_signals_not_flat_attr():
+    """Regression: activation must come from signals.activation.activation.
+
+    Real SubstrateNodeV1 nodes have no flat ``activation`` attribute, so reading
+    ``node.activation`` yields 0.0 and stalls the frame at phase=warming with
+    every node_kind starving. This node carries a MISLEADING flat activation=0.9
+    but a real nested activation of 0.9; if the producer ever regresses to the
+    flat read, dropping the nested bundle would flip these assertions.
+    """
+    from datetime import datetime, timezone
+
+    from app.brain_frame_producer import assemble_brain_frame
+
+    now = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Nested-only active node (no flat attr): must fire + drive phase live.
+    active = SimpleNamespace(
+        node_id="t1",
+        node_kind="tension",
+        label="tension:t1",
+        signals=SimpleNamespace(
+            salience=0.9,
+            activation=SimpleNamespace(activation=0.9),
+        ),
+        metadata={"dynamic_pressure": 0.8},
+    )
+    # Node whose FLAT activation lies high (0.95) but nested says dormant (0.0):
+    # the producer must honor the nested 0.0 and treat it as starving.
+    flat_liar = SimpleNamespace(
+        node_id="c1",
+        node_kind="concept",
+        label="concept:c1",
+        activation=0.95,  # must be ignored
+        signals=SimpleNamespace(
+            salience=0.0,
+            activation=SimpleNamespace(activation=0.0),
+        ),
+        metadata={"dynamic_pressure": 0.0},
+    )
+    frame = assemble_brain_frame(
+        nodes=[active, flat_liar],
+        edges=[],
+        lane_health={"cursor_lag_by_reducer": {}, "pending_backlog_by_reducer": {}, "quarantine_by_reducer": {}},
+        self_state=None,
+        attention=None,
+        settings=_settings(),
+        now=now,
+        tick_seq=9,
+    )
+    assert frame.phase == "live"  # nested activation present, not flat-attr driven
+    kinds = {r.region_id: r for r in frame.regions if r.dimension == "node_kind"}
+    assert kinds["node_kind:tension"].state == "firing"
+    assert kinds["node_kind:tension"].intensity == 0.9
+    # Flat-attr liar is honored as dormant via nested 0.0.
+    assert kinds["node_kind:concept"].state == "starving"
+    assert kinds["node_kind:concept"].intensity == 0.0
+    samples = {n.node_id: n for n in frame.nodes}
+    assert samples["t1"].activation == 0.9
+    assert samples["c1"].activation == 0.0
+    assert samples["c1"].dormant is True

--- a/services/orion-substrate-runtime/tests/test_brain_frame_worker.py
+++ b/services/orion-substrate-runtime/tests/test_brain_frame_worker.py
@@ -16,9 +16,14 @@ from app.worker import BiometricsSubstrateWorker
 
 
 def _node(node_id, kind, activation, pressure=0.0):
+    # Real node shape: activation nested at signals.activation.activation.
     return SimpleNamespace(
         node_id=node_id, node_kind=kind, label=kind,
-        activation=activation, metadata={"dynamic_pressure": pressure},
+        signals=SimpleNamespace(
+            salience=activation,
+            activation=SimpleNamespace(activation=activation),
+        ),
+        metadata={"dynamic_pressure": pressure},
     )
 
 


### PR DESCRIPTION
# AI Town: Orion unified-turn speech + facing guarantee + Juniper human + fresh 8-NPC cast

Branch: `feat/aitown-orion-unified-cast` → `main`
Open PR: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/aitown-orion-unified-cast

## Summary

- **Orion town speech → full unified turn.** `orion-embodiment` now generates Orion's AI-Town utterances via the hub's unified-turn saga (`POST /api/chat` `mode=orion`) instead of the lightweight `chat_quick` cortex rail, with automatic **fallback to the quick lane** on timeout/error/`turn_error`/`turn_deferred`/empty. NPCs are unchanged (still on the `chat` lane via Convex `LLM_MODEL`).
- **Facing guarantee + inspectability.** `WorldPerceptionV1` now exposes Orion's own `facing`/`pathfinding`; perception computes `facing_partner`; the worker issues a single zero-length stop when Orion is `participating` with residual pathfinding, so the engine's `Conversation.tick` orients Orion toward its partner.
- **Juniper Feld is the human player** (`DEFAULT_NAME` + join description) via a tracked upstream patch.
- **Fresh 8-NPC town cast** (Mara Vale, Nico Sable, Dr. Elian Cross, Juno Park, Tessa Quinn, Vale Moreno, Sofia Bell, Cam Lin) via a tracked upstream patch; Orion joins externally and Juniper is the human (neither is in `Descriptions`).

## Env/config changes

- Added (orion-embodiment): `EMBODIMENT_SPEECH_UNIFIED_ENABLED=true`, `EMBODIMENT_HUB_CHAT_URL=http://100.92.216.81:8080/api/chat`, `EMBODIMENT_UNIFIED_TIMEOUT_SEC=120`, `EMBODIMENT_UNIFIED_SESSION_PREFIX=aitown`.
- `.env_example` updated; `python scripts/sync_local_env_from_example.py` ran → `skip orion-embodiment: no .env` (no local env on this box).

## Tests

```
.venv/bin/python -m pytest services/orion-embodiment/tests orion/embodiment/tests -q  →  122 passed
```
Deterministic AI Town checks: upstream patches reverse-check clean; `apply_upstream_patches.sh` idempotent (exit 0); `tsc --noEmit` on `data/characters.ts` exit 0.

## Review findings fixed

- Task 1 spec: double fallback log → single line.
- Task 1 quality: fallback reason now discriminates `turn_error`/`turn_deferred`/`non_final:<t>`/`empty` (+corr id, +test) — anti silent-failure.
- Task 2 quality: stop now targets exact current position (zero-length) instead of tile-center micro-move.
- Final review: `EMBODIMENT_HUB_CHAT_URL` default fixed to host-reachable Tailscale IP (hub is `network_mode: host`, Docker DNS name would not resolve → silent quick-only); dead `import math` removed; README facing/log wording corrected.

## Restart / operator commands

On the node running orion-embodiment (only when `ORION_EMBODIMENT_ENABLED=true`):
```bash
python scripts/sync_local_env_from_example.py
# set EMBODIMENT_HUB_CHAT_URL to this node's host-reachable hub IP if not the default
docker compose --env-file .env --env-file services/orion-embodiment/.env \
  -f services/orion-embodiment/docker-compose.yml up -d --build
```
Fresh game (destructive; node with `upstream/` cloned):
```bash
cd services/orion-ai-town && bash scripts/apply_upstream_patches.sh
cd upstream && npx convex dev --once
npx convex run testing:stop
npx convex run testing:wipeAllTables
npx convex run init
npx convex run testing:resume
cd ../../.. && python services/orion-embodiment/scripts/bootstrap_orion_agent.py --write
```

## Risks / concerns

- Medium — **UNVERIFIED at runtime**: live town + hub run on a mesh node; unified town speech and Orion's visual facing not observed end-to-end. 122 unit tests + deterministic checks pass. Operator should confirm (1) a town utterance with hub correlation and no fallback spam, (2) Orion visibly faces its partner.
- Low — hub URL default assumes hub at athena Tailscale IP (`100.92.216.81:8080`); override per node. Requires hub `ORION_UNIFIED_TURN_ENABLED=true` + `ORION_HARNESS_GOVERNOR_ENABLED=true`, else always falls back to quick.
- Low — unified town speech publishes into Orion's main cognition rail; `aitown:` session prefix keeps it separable from Juniper↔Orion continuity.
- Note — AI Town conversations are hard 2-party; no group-chat facing case.
