### PR TITLE
Fix/autonomy gate drive coactivation query

### DIFF
--- a/scripts/analysis/README.md
+++ b/scripts/analysis/README.md
@@ -75,10 +75,18 @@ for Fuseki), as shown in the host command above.
   `silent` (no receipts and no turns) or `busy`.
 - **Fuseki drives graph** `http://conjourney.net/graph/autonomy/drives` — read
   via a read-only SPARQL `SELECT`. `orion-rdf-writer` persists every
-  `DriveAudit` with one `orion:highlightsActiveDrive` triple per active drive,
-  so `COUNT(DISTINCT ?d)` per audit == `len(active_drives)`. The bus audit
-  channel is redis pub/sub with no replayable history, which is why the durable
-  Fuseki time-series is queried instead.
+  `DriveAudit` with the active signal at the assessment level:
+  `DriveAudit --orion:hasDriveAssessment--> DriveAssessment --orion:driveActive-> true`,
+  so an audit's active-drive count == number of its assessments with
+  `driveActive = true`. (An older `orion:highlightsActiveDrive` projection is
+  equivalent — one triple per active drive — but the assessment-level boolean is
+  the primary schema.) The query aggregates this **server-side** into a
+  co-activation histogram via a nested `GROUP BY` (inner: per-audit `SUM`; outer:
+  bin by active-count), so Fuseki returns only ~7 rows regardless of window size
+  rather than transferring hundreds of thousands of per-audit rows (which timed
+  out on large windows). The bus audit channel is redis pub/sub with no
+  replayable history, which is why the durable Fuseki time-series is queried
+  instead.
 
 ### Caveats
 

--- a/scripts/analysis/README.md
+++ b/scripts/analysis/README.md
@@ -1,0 +1,142 @@
+# Autonomy Origination Measurement Gate
+
+`measure_autonomy_gate.py` is a **Step-0, read-only** measurement instrument. It
+answers two empirical questions from durable history and prints two deterministic
+GO / NO-GO verdicts *before* any downstream cognition code is written.
+
+It **writes nothing to the substrate, emits no events, and flips no flags.** It
+is a measurement, not a cognition change.
+
+## Why this gate exists
+
+Two downstream specs are cathedrals if the questions below fail, so we measure
+first:
+
+- **Verdict (a) — endogenous drift.** Does `SelfStateV1` actually drift during
+  exogenous silence? Gates the **endogenous-drive-origination spec (Step 1)**
+  (`docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md`).
+  If self-state is flat when no receipts/turns arrive, spontaneous origination
+  has no signal to fire on.
+- **Verdict (b) — internal economy.** How often do ≥2 drives co-activate, and
+  does `resource_pressure` actually rise? Gates the
+  **internal-economy-scarcity-allocation spec (Step 4)**
+  (`docs/superpowers/specs/2026-07-07-internal-economy-scarcity-allocation-design.md`).
+  If drives rarely co-activate or resource pressure sits near zero, the scarcity
+  allocator never binds and is ornamental.
+
+## How to run
+
+All commands below use `scripts/analysis/...` paths **relative to the repo
+root**, so run them from the repo/worktree root.
+
+On this host, use the repo venv (system `python` lacks `psycopg2`) with the host
+env overrides:
+
+```bash
+POSTGRES_URI=postgresql://postgres:postgres@localhost:55432/conjourney \
+AUTONOMY_GRAPH_QUERY_URL=http://localhost:3030/orion/query \
+/mnt/scripts/Orion-Sapienform/venv/bin/python scripts/analysis/measure_autonomy_gate.py --window-days 7
+```
+
+Generic / in-container form (defaults resolve on the docker `app-net` network):
+
+```bash
+python scripts/analysis/measure_autonomy_gate.py --window-days 7
+```
+
+- `--window-days` defaults to `7` (`DEFAULT_WINDOW_DAYS`). The window is
+  `now - window_days` through `now`.
+- Within the window, activity is bucketed into fixed `300`-second buckets
+  (`WINDOW_SEC`) to classify each interval as `silent` or `busy`.
+- `psycopg2` is required for live DB metrics. If it is unavailable or the DB is
+  unreachable, `open_readonly_connection` degrades gracefully (returns `None`,
+  adds a caveat, and self-state/receipt metrics are empty) — it does not crash.
+
+### Environment variables
+
+`run()` reads two env vars (both have in-container defaults):
+
+| Var | Default (docker `app-net`) | Purpose |
+| --- | --- | --- |
+| `POSTGRES_URI` | `postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney` | read-only Postgres session |
+| `AUTONOMY_GRAPH_QUERY_URL` | `http://orion-athena-fuseki:3030/orion/query` | Fuseki SPARQL query endpoint |
+
+When running **from the host** (outside the docker `app-net` network), override
+both to the published ports (`localhost:55432` for Postgres, `localhost:3030`
+for Fuseki), as shown in the host command above.
+
+## Data sources
+
+- **`substrate_self_state`** — `SelfStateV1` rows (`self_state_json`,
+  `generated_at`). Supplies `dimension_trajectory`, per-dimension scores,
+  `trajectory_condition`, `overall_surprise`, and `resource_pressure`.
+- **`substrate_reduction_receipts`** — receipt `created_at` timestamps. This is
+  the "exogenous input happened" signal used to classify each bucket as
+  `silent` (no receipts and no turns) or `busy`.
+- **Fuseki drives graph** `http://conjourney.net/graph/autonomy/drives` — read
+  via a read-only SPARQL `SELECT`. `orion-rdf-writer` persists every
+  `DriveAudit` with one `orion:highlightsActiveDrive` triple per active drive,
+  so `COUNT(DISTINCT ?d)` per audit == `len(active_drives)`. The bus audit
+  channel is redis pub/sub with no replayable history, which is why the durable
+  Fuseki time-series is queried instead.
+
+### Caveats
+
+- **Turn timestamps are currently unavailable** (`turn_count=0`): no turn store
+  is wired into this measurement, so bucket classification uses receipts only.
+  This is reported as a coverage caveat in the output.
+- Every adapter degrades gracefully: missing DB, unreachable Fuseki, or absent
+  columns produce empty metrics plus a caveat rather than a crash.
+
+## Verdict rules
+
+Thresholds are the **seed decision boundary**. The report always prints the raw
+numbers so a human can override the mechanical verdict.
+
+### (a) Endogenous drift — `verdict_drift`
+
+**GO** iff, in **silent** buckets:
+
+- `median_abs_trajectory >= DRIFT_MIN_MEDIAN_ABS_TRAJECTORY` (**0.03**), **AND**
+- silent `dim_score_variance >= DRIFT_VARIANCE_RATIO` (**0.25**) × busy
+  `dim_score_variance`. When busy variance is `0`, the ratio test passes iff
+  silent variance `> 0`.
+
+**NO-GO** means self-state is input-following / flat; the endogenous spec must
+change its dynamics source before it is built.
+
+### (b) Internal economy — `verdict_economy`
+
+**GO** iff:
+
+- `coactivation_frac >= COACTIVATION_MIN_FRAC` (**0.10**), **AND**
+- fraction of self-state rows with `resource_pressure >= RESOURCE_PRESSURE_LEVEL`
+  (**0.3**) is `>= RESOURCE_PRESSURE_MIN_FRAC` (**0.05**).
+
+**NO-GO** means the economy allocator would be a cathedral at current
+activation / pressure levels — do not build.
+
+## Outputs & monitoring
+
+No data snapshot is required (read-only). All artifacts land under
+`/tmp/autonomy-gate/`:
+
+- `report.md` — the full report (also printed to stdout), with both verdicts and
+  the raw numbers behind each.
+- `before_after.csv` — silent-vs-busy self-state metrics.
+- `progress.log` — streaming progress; each line carries event title, percent
+  done, rows processed / total, rate, and anomaly count.
+
+Monitor a run with:
+
+```bash
+tail -f /tmp/autonomy-gate/progress.log
+```
+
+## Read-only guarantee
+
+`open_readonly_connection` issues `SET default_transaction_read_only = on`, then
+verifies the session is read-only via `SHOW default_transaction_read_only` and
+**refuses to run if it is not `on`**. Drive-audit reads use a SPARQL `SELECT`
+only (no `UPDATE`). No runtime service, schema, channel, env, or substrate row is
+modified.

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -20,9 +20,9 @@ Design contract (see AGENTS.md / task brief):
   exercise. Window classification, metric computation, and the verdict rules
   all live here.
 * I/O ADAPTERS (this module's bottom half) fetch rows over a read-only psycopg2
-  session and replay the drive-audit bus stream via read-only XRANGE. Every
-  adapter degrades gracefully to empty / None on absent input and NEVER raises
-  on missing data or columns.
+  session and read the durable drive-audit time-series via a read-only Fuseki
+  SPARQL SELECT. Every adapter degrades gracefully to empty / None on absent
+  input and NEVER raises on missing data or columns.
 
 Run:
     python scripts/analysis/measure_autonomy_gate.py --window-days 7
@@ -75,8 +75,9 @@ DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/
 
 # Durable drive co-activation source. DriveAuditV1 is ephemeral on the bus
 # (redis pub/sub, no history), but orion-rdf-writer persists every audit to
-# Fuseki with one `orion:highlightsActiveDrive` triple per active drive — so
-# COUNT(highlightsActiveDrive) per audit == len(active_drives). We read that
+# Fuseki as a `orion:DriveAudit` with one `orion:hasDriveAssessment` per drive,
+# each assessment carrying a boolean `orion:driveActive`. An audit's active-drive
+# count == number of its assessments with driveActive == true. We read that
 # durable time-series instead of the un-replayable pub/sub channel.
 ORION_NS = "http://conjourney.net/orion#"
 AUTONOMY_DRIVES_GRAPH = "http://conjourney.net/graph/autonomy/drives"
@@ -334,21 +335,23 @@ def compute_drive_stats(records: list[DriveAuditRecord]) -> DriveStats:
 def build_drive_audit_sparql(since: datetime, graph_uri: str = AUTONOMY_DRIVES_GRAPH) -> str:
     """SPARQL SELECT: active-drive count per DriveAudit artifact since ``since``.
 
-    ``COUNT(DISTINCT highlightsActiveDrive)`` for an audit equals that audit's
-    ``len(active_drives)`` because orion-rdf-writer emits exactly one
-    ``orion:highlightsActiveDrive`` triple per active drive. Pure (returns a
-    string) so it is unit-testable without a SPARQL endpoint.
+    An audit's ``?activeCount`` is the number of its ``orion:hasDriveAssessment``
+    assessments whose ``orion:driveActive`` is boolean ``true``. The assessment
+    join is OPTIONAL and the count uses ``SUM(IF(?act = true, 1, 0))`` so audits
+    with zero active drives (or no assessments at all) still return a row with
+    ``?activeCount = 0``. Pure (returns a string) so it is unit-testable without
+    a SPARQL endpoint.
     """
 
     since_iso = _as_utc(since).isoformat()
     return (
         f"PREFIX orion: <{ORION_NS}>\n"
         "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
-        "SELECT ?audit ?ts (COUNT(DISTINCT ?d) AS ?activeCount) WHERE {\n"
+        "SELECT ?audit ?ts (SUM(IF(?act = true, 1, 0)) AS ?activeCount) WHERE {\n"
         f"  GRAPH <{graph_uri}> {{\n"
         "    ?audit a orion:DriveAudit ;\n"
         "           orion:timestamp ?ts .\n"
-        "    OPTIONAL { ?audit orion:highlightsActiveDrive ?d . }\n"
+        "    OPTIONAL { ?audit orion:hasDriveAssessment ?da . ?da orion:driveActive ?act . }\n"
         f'    FILTER (?ts >= "{since_iso}"^^xsd:dateTime)\n'
         "  }\n"
         "} GROUP BY ?audit ?ts ORDER BY ?ts"
@@ -358,9 +361,10 @@ def build_drive_audit_sparql(since: datetime, graph_uri: str = AUTONOMY_DRIVES_G
 def parse_sparql_drive_bindings(bindings: Iterable[dict]) -> list[DriveAuditRecord]:
     """Parse SPARQL-results-JSON bindings into DriveAuditRecords.
 
-    Each binding carries ``ts`` (dateTime literal) and ``activeCount`` (integer
-    literal). Rows without a parseable timestamp are skipped; a missing/bad
-    count degrades to 0. Never raises. Pure + unit-testable.
+    Each binding carries ``ts`` (dateTime literal) and ``activeCount`` (a SUM
+    result, which Fuseki may return as an integer or decimal literal, e.g.
+    ``"2"`` or ``"2.0"``). Rows without a parseable timestamp are skipped; a
+    missing/bad count degrades to 0. Never raises. Pure + unit-testable.
     """
 
     out: list[DriveAuditRecord] = []
@@ -374,7 +378,7 @@ def parse_sparql_drive_bindings(bindings: Iterable[dict]) -> list[DriveAuditReco
         cnt_node = binding.get("activeCount")
         raw_cnt = cnt_node.get("value") if isinstance(cnt_node, dict) else None
         try:
-            active_count = int(raw_cnt)
+            active_count = int(float(raw_cnt))
         except (TypeError, ValueError):
             active_count = 0
         out.append(DriveAuditRecord(ts=ts, active_count=max(0, active_count)))
@@ -579,9 +583,10 @@ def fetch_drive_audit_records(
     The bus audit channel (``orion:memory:drives:audit``) is redis pub/sub with
     no replayable history, so it is useless for a backward-looking measurement.
     orion-rdf-writer, however, persists every DriveAuditV1 to the Fuseki
-    autonomy/drives graph as a timestamped artifact with one
-    ``orion:highlightsActiveDrive`` triple per active drive — a real historical
-    time-series. We SPARQL-COUNT those to recover per-audit co-activation.
+    autonomy/drives graph as a timestamped ``orion:DriveAudit`` with one
+    ``orion:hasDriveAssessment`` per drive, each carrying a boolean
+    ``orion:driveActive`` — a real historical time-series. We SPARQL-SUM the
+    ``driveActive = true`` assessments to recover per-audit co-activation.
 
     Read-only SPARQL SELECT (no UPDATE). Returns (records, coverage_note);
     degrades to ([], note) on any endpoint/parse failure — never raises.

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -437,7 +437,7 @@ def verdict_economy(drive: DriveStats, pressure: ResourcePressureStats) -> str:
 
 
 # ===========================================================================
-# I/O LAYER — psycopg2 read-only + bus XRANGE. Never exercised by unit tests.
+# I/O LAYER — psycopg2 read-only + Fuseki SPARQL SELECT. Never exercised by unit tests.
 # Every adapter degrades to empty / None on absent input; none raise on
 # missing data or columns.
 # ===========================================================================

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -339,7 +339,9 @@ def build_drive_coactivation_histogram_sparql(
     ``COUNT(DISTINCT ?activeDa)`` where ``?activeDa`` is bound ONLY to that
     audit's active assessments — the pattern matches the boolean literal
     directly (``?activeDa orion:driveActive true``), so no per-assessment IF is
-    needed and the count is bounded by the number of drive keys (max 6).
+    needed. Strictly this counts distinct active *assessment nodes*; that equals
+    the number of active drive keys while the writer emits at most one assessment
+    per drive per audit (live max=6 confirms 1:1 today).
 
     Two subtleties, both verified live against Jena/Fuseki:
 

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -75,14 +75,20 @@ DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/
 
 # Durable drive co-activation source. DriveAuditV1 is ephemeral on the bus
 # (redis pub/sub, no history), but orion-rdf-writer persists every audit to
-# Fuseki as a `orion:DriveAudit` with one `orion:hasDriveAssessment` per drive,
-# each assessment carrying a boolean `orion:driveActive`. An audit's active-drive
-# count == number of its assessments with driveActive == true. We read that
-# durable time-series instead of the un-replayable pub/sub channel.
+# Fuseki as a `orion:DriveAudit` whose active-drive signal lives at the
+# assessment level: DriveAudit --orion:hasDriveAssessment--> DriveAssessment,
+# each assessment carrying a boolean `orion:driveActive`. An audit's
+# active-drive count == number of its assessments with driveActive == true.
+# (An older `orion:highlightsActiveDrive` projection is equivalent — one triple
+# per active drive — but we read the assessment-level boolean as the primary
+# schema.) We aggregate this server-side into a co-activation histogram so
+# Fuseki returns ~7 rows regardless of window size, instead of transferring
+# hundreds of thousands of per-audit rows (which timed out on large windows).
 ORION_NS = "http://conjourney.net/orion#"
 AUTONOMY_DRIVES_GRAPH = "http://conjourney.net/graph/autonomy/drives"
 DEFAULT_FUSEKI_QUERY_URL = "http://orion-athena-fuseki:3030/orion/query"
-FUSEKI_TIMEOUT_SEC = 30.0
+# Server-side aggregation measured ~16s over full history; 60s gives headroom.
+FUSEKI_TIMEOUT_SEC = 60.0
 
 
 # ===========================================================================
@@ -100,14 +106,6 @@ class SelfStateRecord:
     trajectory_condition: str
     overall_surprise: float
     resource_pressure: float
-
-
-@dataclass
-class DriveAuditRecord:
-    """A normalized drive-audit event: timestamp + count of active drives."""
-
-    ts: datetime
-    active_count: int
 
 
 @dataclass
@@ -314,74 +312,80 @@ def compute_resource_pressure_stats(
     )
 
 
-def compute_drive_stats(records: list[DriveAuditRecord]) -> DriveStats:
-    """Q(b) drive co-activation stats. Empty -> zeros."""
+def drive_stats_from_histogram(hist: dict[int, int]) -> DriveStats:
+    """Build Q(b) drive co-activation stats from an active-count histogram.
 
-    if not records:
+    ``hist`` maps active-drive-count -> number of audits with that count. Empty
+    histogram -> all-zero DriveStats. Pure + unit-testable.
+    """
+
+    record_count = sum(hist.values())
+    if record_count == 0:
         return DriveStats()
-    hist: dict[int, int] = {}
-    coactive = 0
-    for rec in records:
-        hist[rec.active_count] = hist.get(rec.active_count, 0) + 1
-        if rec.active_count >= 2:
-            coactive += 1
+    coactive = sum(n for k, n in hist.items() if k >= 2)
     return DriveStats(
-        record_count=len(records),
-        coactivation_frac=coactive / len(records),
-        concurrent_active_hist=hist,
+        record_count=record_count,
+        coactivation_frac=coactive / record_count,
+        concurrent_active_hist=dict(hist),
     )
 
 
-def build_drive_audit_sparql(since: datetime, graph_uri: str = AUTONOMY_DRIVES_GRAPH) -> str:
-    """SPARQL SELECT: active-drive count per DriveAudit artifact since ``since``.
+def build_drive_coactivation_histogram_sparql(
+    since: datetime, graph_uri: str = AUTONOMY_DRIVES_GRAPH
+) -> str:
+    """SPARQL: co-activation histogram (active-count -> #audits) since ``since``.
 
-    An audit's ``?activeCount`` is the number of its ``orion:hasDriveAssessment``
-    assessments whose ``orion:driveActive`` is boolean ``true``. The assessment
-    join is OPTIONAL and the count uses ``SUM(IF(?act = true, 1, 0))`` so audits
-    with zero active drives (or no assessments at all) still return a row with
-    ``?activeCount = 0``. Pure (returns a string) so it is unit-testable without
-    a SPARQL endpoint.
+    The inner query reduces per audit: each ``?audit``'s ``?activeCount`` is the
+    number of its ``orion:hasDriveAssessment`` assessments whose
+    ``orion:driveActive`` is boolean ``true``. The assessment join is OPTIONAL
+    and the count uses ``SUM(IF(?act = true, 1, 0))`` so audits with zero active
+    drives (or no assessments at all) still contribute ``activeCount = 0``. The
+    outer query bins those per-audit counts into a histogram, so Fuseki returns
+    only ~7 rows regardless of window size — no per-audit transfer of hundreds
+    of thousands of rows, no timeout. Pure (returns a string) so it is
+    unit-testable without a SPARQL endpoint.
     """
 
     since_iso = _as_utc(since).isoformat()
     return (
         f"PREFIX orion: <{ORION_NS}>\n"
         "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
-        "SELECT ?audit ?ts (SUM(IF(?act = true, 1, 0)) AS ?activeCount) WHERE {\n"
-        f"  GRAPH <{graph_uri}> {{\n"
-        "    ?audit a orion:DriveAudit ;\n"
-        "           orion:timestamp ?ts .\n"
-        "    OPTIONAL { ?audit orion:hasDriveAssessment ?da . ?da orion:driveActive ?act . }\n"
-        f'    FILTER (?ts >= "{since_iso}"^^xsd:dateTime)\n'
-        "  }\n"
-        "} GROUP BY ?audit ?ts ORDER BY ?ts"
+        "SELECT ?activeCount (COUNT(*) AS ?audits) WHERE {\n"
+        "  SELECT ?audit (SUM(IF(?act = true, 1, 0)) AS ?activeCount) WHERE {\n"
+        f"    GRAPH <{graph_uri}> {{\n"
+        "      ?audit a orion:DriveAudit ;\n"
+        "             orion:timestamp ?ts .\n"
+        "      OPTIONAL { ?audit orion:hasDriveAssessment ?da . ?da orion:driveActive ?act . }\n"
+        f'      FILTER (?ts >= "{since_iso}"^^xsd:dateTime)\n'
+        "    }\n"
+        "  } GROUP BY ?audit\n"
+        "} GROUP BY ?activeCount ORDER BY ?activeCount"
     )
 
 
-def parse_sparql_drive_bindings(bindings: Iterable[dict]) -> list[DriveAuditRecord]:
-    """Parse SPARQL-results-JSON bindings into DriveAuditRecords.
+def parse_sparql_histogram_bindings(bindings: Iterable[dict]) -> dict[int, int]:
+    """Parse SPARQL-results-JSON histogram bindings into ``{activeCount: audits}``.
 
-    Each binding carries ``ts`` (dateTime literal) and ``activeCount`` (a SUM
-    result, which Fuseki may return as an integer or decimal literal, e.g.
-    ``"2"`` or ``"2.0"``). Rows without a parseable timestamp are skipped; a
-    missing/bad count degrades to 0. Never raises. Pure + unit-testable.
+    Each binding carries ``activeCount`` and ``audits``, both SUM/COUNT literals
+    Fuseki may return as integer or decimal strings (e.g. ``"2"`` or ``"2.0"``).
+    Malformed rows (missing/garbage values) are skipped; never raises. Pure +
+    unit-testable.
     """
 
-    out: list[DriveAuditRecord] = []
+    out: dict[int, int] = {}
     for binding in bindings:
         if not isinstance(binding, dict):
             continue
-        ts_node = binding.get("ts")
-        ts = _coerce_dt(ts_node.get("value")) if isinstance(ts_node, dict) else None
-        if ts is None:
-            continue
         cnt_node = binding.get("activeCount")
+        aud_node = binding.get("audits")
         raw_cnt = cnt_node.get("value") if isinstance(cnt_node, dict) else None
+        raw_aud = aud_node.get("value") if isinstance(aud_node, dict) else None
         try:
             active_count = int(float(raw_cnt))
-        except (TypeError, ValueError):
-            active_count = 0
-        out.append(DriveAuditRecord(ts=ts, active_count=max(0, active_count)))
+            audits = int(float(raw_aud))
+        except (TypeError, ValueError, OverflowError):
+            continue
+        out[max(0, active_count)] = max(0, audits)
     return out
 
 
@@ -572,34 +576,37 @@ def fetch_receipt_timestamps(conn, since: datetime, max_rows: int = MAX_ROWS) ->
     return out, len(rows) >= max_rows
 
 
-def fetch_drive_audit_records(
+def fetch_drive_stats(
     query_url: str,
     since: datetime,
     graph_uri: str = AUTONOMY_DRIVES_GRAPH,
     timeout_sec: float = FUSEKI_TIMEOUT_SEC,
-) -> tuple[list[DriveAuditRecord], str]:
-    """Read durable drive co-activation history from Fuseki via read-only SPARQL.
+) -> tuple[DriveStats, str]:
+    """Read durable drive co-activation stats from Fuseki via read-only SPARQL.
 
     The bus audit channel (``orion:memory:drives:audit``) is redis pub/sub with
     no replayable history, so it is useless for a backward-looking measurement.
     orion-rdf-writer, however, persists every DriveAuditV1 to the Fuseki
-    autonomy/drives graph as a timestamped ``orion:DriveAudit`` with one
-    ``orion:hasDriveAssessment`` per drive, each carrying a boolean
-    ``orion:driveActive`` — a real historical time-series. We SPARQL-SUM the
-    ``driveActive = true`` assessments to recover per-audit co-activation.
+    autonomy/drives graph as a timestamped ``orion:DriveAudit`` whose active
+    signal lives at the assessment level: ``orion:hasDriveAssessment`` ->
+    ``DriveAssessment`` with a boolean ``orion:driveActive`` — a real historical
+    time-series. We aggregate ``driveActive = true`` counts per audit into a
+    co-activation histogram *server-side*, so Fuseki returns ~7 rows regardless
+    of window size (transferring all per-audit rows blows the timeout on large
+    windows).
 
-    Read-only SPARQL SELECT (no UPDATE). Returns (records, coverage_note);
-    degrades to ([], note) on any endpoint/parse failure — never raises.
+    Read-only SPARQL SELECT (no UPDATE). Returns (DriveStats, coverage_note);
+    degrades to (DriveStats(), note) on any endpoint/parse failure — never raises.
     """
 
     if not query_url:
-        return [], "drive co-activation unavailable: no AUTONOMY_GRAPH_QUERY_URL configured"
+        return DriveStats(), "drive co-activation unavailable: no AUTONOMY_GRAPH_QUERY_URL configured"
 
     import urllib.error  # lazy imports keep module import I/O-free for tests
     import urllib.parse
     import urllib.request
 
-    sparql = build_drive_audit_sparql(since, graph_uri)
+    sparql = build_drive_coactivation_histogram_sparql(since, graph_uri)
     body = urllib.parse.urlencode({"query": sparql}).encode("utf-8")
     req = urllib.request.Request(
         query_url,
@@ -615,15 +622,18 @@ def fetch_drive_audit_records(
             payload = json.loads(resp.read().decode("utf-8"))
     except Exception:
         logger.error("drive-audit SPARQL query failed", exc_info=True)
-        return [], f"drive co-activation unavailable: SPARQL query to {query_url} failed"
+        return DriveStats(), f"drive co-activation unavailable: SPARQL query to {query_url} failed"
 
     bindings = (((payload or {}).get("results") or {}).get("bindings")) or []
-    records = parse_sparql_drive_bindings(bindings)
-    if not records:
-        return [], f"drive co-activation: Fuseki returned no DriveAudit rows since {since.isoformat()}"
+    hist = parse_sparql_histogram_bindings(bindings)
+    stats = drive_stats_from_histogram(hist)
+    if stats.record_count == 0:
+        return stats, f"drive co-activation: Fuseki returned no DriveAudit rows since {since.isoformat()}"
 
-    span_days = (max(r.ts for r in records) - min(r.ts for r in records)).total_seconds() / 86400.0
-    return records, f"drive co-activation: {len(records)} DriveAudit rows spanning {span_days:.2f} days (Fuseki)"
+    return stats, (
+        f"drive co-activation: {stats.record_count} DriveAudit rows since "
+        f"{since.isoformat()} (Fuseki histogram)"
+    )
 
 
 # ===========================================================================
@@ -792,12 +802,16 @@ def run(window_days: int) -> int:
     turn_timestamps: list[datetime] = []
     caveats.append("turns unavailable, turn_count=0 (no turn store wired into this measurement)")
 
-    drive_records, coverage_note = fetch_drive_audit_records(fuseki_url, window_start)
+    drive_stats, coverage_note = fetch_drive_stats(fuseki_url, window_start)
     caveats.append(coverage_note)
-    if not drive_records:
+    if drive_stats.record_count == 0:
         anomalies += 1
     progress.emit(
-        "drive audit loaded", percent=80.0, processed=len(drive_records), total=len(drive_records), anomalies=anomalies
+        "drive audit loaded",
+        percent=80.0,
+        processed=drive_stats.record_count,
+        total=drive_stats.record_count,
+        anomalies=anomalies,
     )
 
     if conn is not None:
@@ -816,7 +830,6 @@ def run(window_days: int) -> int:
     silent_metrics = compute_self_state_metrics(silent_rows)
     busy_metrics = compute_self_state_metrics(busy_rows)
     pressure = compute_resource_pressure_stats(self_states)
-    drive_stats = compute_drive_stats(drive_records)
 
     verdict_a = verdict_drift(silent_metrics, busy_metrics)
     verdict_b = verdict_economy(drive_stats, pressure)
@@ -840,11 +853,12 @@ def run(window_days: int) -> int:
     except Exception:
         logger.error("failed to write report", exc_info=True)
 
+    total_rows = len(self_states) + len(receipts) + drive_stats.record_count
     progress.emit(
         "done",
         percent=100.0,
-        processed=len(self_states) + len(receipts) + len(drive_records),
-        total=len(self_states) + len(receipts) + len(drive_records),
+        processed=total_rows,
+        total=total_rows,
         anomalies=anomalies,
     )
     progress.close()

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -338,12 +338,15 @@ def build_drive_coactivation_histogram_sparql(
     The inner query reduces per audit: each ``?audit``'s ``?activeCount`` is the
     number of its ``orion:hasDriveAssessment`` assessments whose
     ``orion:driveActive`` is boolean ``true``. The assessment join is OPTIONAL
-    and the count uses ``SUM(IF(?act = true, 1, 0))`` so audits with zero active
-    drives (or no assessments at all) still contribute ``activeCount = 0``. The
-    outer query bins those per-audit counts into a histogram, so Fuseki returns
-    only ~7 rows regardless of window size — no per-audit transfer of hundreds
-    of thousands of rows, no timeout. Pure (returns a string) so it is
-    unit-testable without a SPARQL endpoint.
+    and the count uses ``SUM(IF(BOUND(?act) && ?act = true, 1, 0))``. The
+    ``BOUND(?act)`` guard is required: for an audit whose OPTIONAL matched no
+    assessments, ``?act`` is unbound and a bare ``IF(?act = true, ...)`` makes
+    the SUM itself unbound (Jena/Fuseki), which would drop the audit from the
+    histogram and shrink the denominator. With the guard such audits yield an
+    explicit ``activeCount = 0``. The outer query bins those per-audit counts
+    into a histogram, so Fuseki returns only ~7 rows regardless of window size —
+    no per-audit transfer of hundreds of thousands of rows, no timeout. Pure
+    (returns a string) so it is unit-testable without a SPARQL endpoint.
     """
 
     since_iso = _as_utc(since).isoformat()
@@ -351,7 +354,7 @@ def build_drive_coactivation_histogram_sparql(
         f"PREFIX orion: <{ORION_NS}>\n"
         "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
         "SELECT ?activeCount (COUNT(*) AS ?audits) WHERE {\n"
-        "  SELECT ?audit (SUM(IF(?act = true, 1, 0)) AS ?activeCount) WHERE {\n"
+        "  SELECT ?audit (SUM(IF(BOUND(?act) && ?act = true, 1, 0)) AS ?activeCount) WHERE {\n"
         f"    GRAPH <{graph_uri}> {{\n"
         "      ?audit a orion:DriveAudit ;\n"
         "             orion:timestamp ?ts .\n"

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -335,18 +335,31 @@ def build_drive_coactivation_histogram_sparql(
 ) -> str:
     """SPARQL: co-activation histogram (active-count -> #audits) since ``since``.
 
-    The inner query reduces per audit: each ``?audit``'s ``?activeCount`` is the
-    number of its ``orion:hasDriveAssessment`` assessments whose
-    ``orion:driveActive`` is boolean ``true``. The assessment join is OPTIONAL
-    and the count uses ``SUM(IF(BOUND(?act) && ?act = true, 1, 0))``. The
-    ``BOUND(?act)`` guard is required: for an audit whose OPTIONAL matched no
-    assessments, ``?act`` is unbound and a bare ``IF(?act = true, ...)`` makes
-    the SUM itself unbound (Jena/Fuseki), which would drop the audit from the
-    histogram and shrink the denominator. With the guard such audits yield an
-    explicit ``activeCount = 0``. The outer query bins those per-audit counts
-    into a histogram, so Fuseki returns only ~7 rows regardless of window size —
-    no per-audit transfer of hundreds of thousands of rows, no timeout. Pure
-    (returns a string) so it is unit-testable without a SPARQL endpoint.
+    The inner query reduces per audit: each ``?audit``'s ``?activeCount`` is
+    ``COUNT(DISTINCT ?activeDa)`` where ``?activeDa`` is bound ONLY to that
+    audit's active assessments — the pattern matches the boolean literal
+    directly (``?activeDa orion:driveActive true``), so no per-assessment IF is
+    needed and the count is bounded by the number of drive keys (max 6).
+
+    Two subtleties, both verified live against Jena/Fuseki:
+
+    * ``orion:timestamp`` is MULTI-VALUED (up to 8 per audit). It MUST NOT be
+      bound in the aggregation group: binding ``?ts`` alongside the assessment
+      join cross-products (5 timestamps x 6 active assessments = 30 counted),
+      producing impossible active counts and inflating co-activation. Instead
+      the window is applied with ``FILTER EXISTS { ?audit orion:timestamp ?ts .
+      FILTER(?ts >= since) }`` — an audit is in-window iff ANY of its timestamps
+      is ``>= since``, which is correct for a multi-valued timestamp and cannot
+      fan out the count.
+    * The assessment join is OPTIONAL, so an assessment-less / all-inactive
+      audit has ``?activeDa`` unbound and ``COUNT(DISTINCT ?activeDa) = 0``,
+      landing it in the ``activeCount = 0`` bucket. ``COUNT(DISTINCT ...)`` also
+      dedupes any duplicate assessment edges.
+
+    The outer query bins the per-audit counts into a histogram, so Fuseki
+    returns only ~7 rows regardless of window size — no per-audit transfer of
+    hundreds of thousands of rows, no timeout. Pure (returns a string) so it is
+    unit-testable without a SPARQL endpoint.
     """
 
     since_iso = _as_utc(since).isoformat()
@@ -354,12 +367,11 @@ def build_drive_coactivation_histogram_sparql(
         f"PREFIX orion: <{ORION_NS}>\n"
         "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
         "SELECT ?activeCount (COUNT(*) AS ?audits) WHERE {\n"
-        "  SELECT ?audit (SUM(IF(BOUND(?act) && ?act = true, 1, 0)) AS ?activeCount) WHERE {\n"
+        "  SELECT ?audit (COUNT(DISTINCT ?activeDa) AS ?activeCount) WHERE {\n"
         f"    GRAPH <{graph_uri}> {{\n"
-        "      ?audit a orion:DriveAudit ;\n"
-        "             orion:timestamp ?ts .\n"
-        "      OPTIONAL { ?audit orion:hasDriveAssessment ?da . ?da orion:driveActive ?act . }\n"
-        f'      FILTER (?ts >= "{since_iso}"^^xsd:dateTime)\n'
+        "      ?audit a orion:DriveAudit .\n"
+        f'      FILTER EXISTS {{ ?audit orion:timestamp ?ts . FILTER(?ts >= "{since_iso}"^^xsd:dateTime) }}\n'
+        "      OPTIONAL { ?audit orion:hasDriveAssessment ?activeDa . ?activeDa orion:driveActive true . }\n"
         "    }\n"
         "  } GROUP BY ?audit\n"
         "} GROUP BY ?activeCount ORDER BY ?activeCount"

--- a/scripts/analysis/tests/test_measure_autonomy_gate.py
+++ b/scripts/analysis/tests/test_measure_autonomy_gate.py
@@ -217,7 +217,10 @@ def test_build_drive_coactivation_histogram_sparql_shape():
     # Assessment-level boolean shape.
     assert "hasDriveAssessment" in q
     assert "driveActive" in q
-    assert "SUM(IF(?act = true" in q
+    # BOUND guard: assessment-less audits must yield activeCount=0, not unbound
+    # (otherwise the audit drops from the histogram and biases coactivation_frac).
+    assert "SUM(IF(BOUND(?act) && ?act = true" in q
+    assert "BOUND(?act)" in q
     # Nested aggregation: inner reduces per audit, outer bins into a histogram.
     assert "GROUP BY ?audit" in q
     assert "GROUP BY ?activeCount" in q
@@ -243,6 +246,21 @@ def test_parse_sparql_histogram_bindings_happy():
     stats = mod.drive_stats_from_histogram(hist)
     assert stats.record_count == 444785
     assert stats.coactivation_frac == pytest.approx(51 / 444785)
+
+
+def test_parse_sparql_histogram_bindings_retains_zero_bucket():
+    # The query now emits an explicit bound 0 bucket for assessment-less audits
+    # (BOUND(?act) guard) rather than dropping them; lock in that the parser
+    # keeps a bound-0 row so those audits stay in the record_count denominator.
+    bindings = [
+        {"activeCount": {"value": "0"}, "audits": {"value": "5"}},
+        {"activeCount": {"value": "2"}, "audits": {"value": "3"}},
+    ]
+    hist = mod.parse_sparql_histogram_bindings(bindings)
+    assert hist == {0: 5, 2: 3}
+    stats = mod.drive_stats_from_histogram(hist)
+    assert stats.record_count == 8  # the 5 zero-active audits are counted
+    assert stats.coactivation_frac == pytest.approx(3 / 8)
 
 
 def test_parse_sparql_histogram_bindings_degrades():

--- a/scripts/analysis/tests/test_measure_autonomy_gate.py
+++ b/scripts/analysis/tests/test_measure_autonomy_gate.py
@@ -97,10 +97,9 @@ def test_verdict_a_busy_zero_variance_passes_when_silent_moves():
 # 3. Rare co-activation + flat pressure -> verdict (b) NO-GO
 # ---------------------------------------------------------------------------
 def test_verdict_b_rare_coactivation_is_no_go():
-    drive_records = [mod.DriveAuditRecord(ts=BASE + timedelta(seconds=i), active_count=1) for i in range(20)]
-    drive_records.append(mod.DriveAuditRecord(ts=BASE + timedelta(seconds=99), active_count=2))
+    # 20 audits with 1 active drive, 1 audit with 2 -> 1/21 < 10% co-active.
+    drive = mod.drive_stats_from_histogram({1: 20, 2: 1})
     pressure_rows = [_self_state(i, {"resource_pressure": 0.05}, {}) for i in range(20)]
-    drive = mod.compute_drive_stats(drive_records)
     pressure = mod.compute_resource_pressure_stats(pressure_rows)
     assert drive.coactivation_frac < mod.COACTIVATION_MIN_FRAC
     assert pressure.frac_gt_level < mod.RESOURCE_PRESSURE_MIN_FRAC
@@ -111,32 +110,29 @@ def test_verdict_b_rare_coactivation_is_no_go():
 # 4. Frequent co-activation + real pressure -> verdict (b) GO
 # ---------------------------------------------------------------------------
 def test_verdict_b_frequent_coactivation_is_go():
-    drive_records = []
-    for i in range(20):
-        drive_records.append(mod.DriveAuditRecord(ts=BASE + timedelta(seconds=i), active_count=2 if i % 2 == 0 else 1))
-    # 50% co-active >= 10%.
+    # 10 audits with 2 active drives, 10 with 1 -> 50% co-active >= 10%.
+    drive = mod.drive_stats_from_histogram({2: 10, 1: 10})
     # Resource pressure: 3 of 20 >= 0.3 -> 15% >= 5%.
     pressure_rows = [
         _self_state(i, {"resource_pressure": 0.5 if i < 3 else 0.1}, {})
         for i in range(20)
     ]
-    drive = mod.compute_drive_stats(drive_records)
     pressure = mod.compute_resource_pressure_stats(pressure_rows)
     assert drive.coactivation_frac >= mod.COACTIVATION_MIN_FRAC
     assert pressure.frac_gt_level >= mod.RESOURCE_PRESSURE_MIN_FRAC
     assert mod.verdict_economy(drive, pressure) == "GO"
 
 
-def test_drive_histogram_counts():
-    drive_records = [
-        mod.DriveAuditRecord(ts=BASE, active_count=0),
-        mod.DriveAuditRecord(ts=BASE, active_count=1),
-        mod.DriveAuditRecord(ts=BASE, active_count=1),
-        mod.DriveAuditRecord(ts=BASE, active_count=3),
-    ]
-    stats = mod.compute_drive_stats(drive_records)
-    assert stats.concurrent_active_hist == {0: 1, 1: 2, 3: 1}
-    assert stats.coactivation_frac == 0.25
+def test_drive_stats_from_histogram():
+    stats = mod.drive_stats_from_histogram({0: 100, 2: 5, 3: 5})
+    assert stats.record_count == 110
+    assert stats.coactivation_frac == pytest.approx(10 / 110)
+    assert stats.concurrent_active_hist == {0: 100, 2: 5, 3: 5}
+
+    empty = mod.drive_stats_from_histogram({})
+    assert empty.record_count == 0
+    assert empty.coactivation_frac == 0.0
+    assert empty.concurrent_active_hist == {}
 
 
 # ---------------------------------------------------------------------------
@@ -189,7 +185,7 @@ def test_empty_metrics_do_not_raise():
     assert pressure.p90 is None
     assert pressure.frac_gt_level == 0.0
 
-    drive = mod.compute_drive_stats([])
+    drive = mod.drive_stats_from_histogram({})
     assert drive.record_count == 0
     assert drive.coactivation_frac == 0.0
     assert drive.concurrent_active_hist == {}
@@ -214,75 +210,41 @@ def test_percentile_and_median():
 # ---------------------------------------------------------------------------
 # 7. Durable drive-audit source (Fuseki SPARQL) — pure query + parse layer
 # ---------------------------------------------------------------------------
-def test_build_drive_audit_sparql_shape():
-    q = mod.build_drive_audit_sparql(BASE)
+def test_build_drive_coactivation_histogram_sparql_shape():
+    q = mod.build_drive_coactivation_histogram_sparql(BASE)
     assert mod.AUTONOMY_DRIVES_GRAPH in q
     assert "orion:DriveAudit" in q
-    assert "orion:hasDriveAssessment" in q
-    assert "orion:driveActive" in q
-    assert "orion:timestamp ?ts" in q
-    assert BASE.isoformat() in q  # window bound is applied
-    assert "FILTER" in q
-
-
-def test_build_drive_audit_sparql_uses_real_predicates():
-    q = mod.build_drive_audit_sparql(BASE)
-    # Real graph shape: hasDriveAssessment -> driveActive (boolean true).
+    # Assessment-level boolean shape.
     assert "hasDriveAssessment" in q
     assert "driveActive" in q
-    # The stale/nonexistent predicate must be gone.
-    assert "highlightsActiveDrive" not in q
-    # Still bounds the window on a typed dateTime and groups per audit.
+    assert "SUM(IF(?act = true" in q
+    # Nested aggregation: inner reduces per audit, outer bins into a histogram.
+    assert "GROUP BY ?audit" in q
+    assert "GROUP BY ?activeCount" in q
+    # Window bound applied on a typed dateTime.
     assert f'FILTER (?ts >= "{BASE.isoformat()}"^^xsd:dateTime)' in q
-    assert "GROUP BY ?audit ?ts" in q
+    # Stale / per-audit-transfer shapes must be gone.
+    assert "highlightsActiveDrive" not in q
+    assert "COUNT(DISTINCT ?d)" not in q
 
 
-def _binding(ts_iso: str, count: str) -> dict:
-    return {
-        "audit": {"type": "uri", "value": f"http://x/{ts_iso}"},
-        "ts": {"type": "literal", "value": ts_iso},
-        "activeCount": {"type": "literal", "value": count},
-    }
-
-
-def test_parse_sparql_drive_bindings_happy():
+def test_parse_sparql_histogram_bindings_happy():
     bindings = [
-        _binding("2026-07-01T00:00:00+00:00", "2"),
-        _binding("2026-07-01T00:05:00+00:00", "0"),
-        _binding("2026-07-01T00:10:00+00:00", "3"),
+        {"activeCount": {"value": "0"}, "audits": {"value": "444734"}},
+        {"activeCount": {"value": "2"}, "audits": {"value": "20"}},
+        {"activeCount": {"value": "3.0"}, "audits": {"value": "31"}},
+        "not-a-dict",  # skipped, no crash
+        {"activeCount": {"value": "junk"}, "audits": {"value": "5"}},  # bad count -> skipped
+        {"activeCount": {"value": "1"}},  # missing audits -> skipped
     ]
-    recs = mod.parse_sparql_drive_bindings(bindings)
-    assert [r.active_count for r in recs] == [2, 0, 3]
-    # Feeds the existing pure drive-stats path unchanged.
-    stats = mod.compute_drive_stats(recs)
-    assert stats.coactivation_frac == pytest.approx(2 / 3)
+    hist = mod.parse_sparql_histogram_bindings(bindings)
+    assert hist == {0: 444734, 2: 20, 3: 31}
+    # Feeds the pure drive-stats path.
+    stats = mod.drive_stats_from_histogram(hist)
+    assert stats.record_count == 444785
+    assert stats.coactivation_frac == pytest.approx(51 / 444785)
 
 
-def test_parse_sparql_drive_bindings_degrades():
-    bindings = [
-        {"activeCount": {"value": "2"}},               # no ts -> skipped
-        _binding("2026-07-01T00:00:00+00:00", "notint"),  # bad count -> 0
-        "not-a-dict",                                    # skipped
-        {"ts": {"value": "garbage"}, "activeCount": {"value": "1"}},  # bad ts -> skipped
-    ]
-    recs = mod.parse_sparql_drive_bindings(bindings)
-    assert len(recs) == 1
-    assert recs[0].active_count == 0
-
-    # Empty bindings -> empty, no raise.
-    assert mod.parse_sparql_drive_bindings([]) == []
-
-
-def test_parse_sparql_drive_bindings_handles_sum_literals():
-    # Shaped like real SPARQL-results-JSON from the SUM(IF(driveActive=true,...))
-    # query: counts may come back as integer OR decimal literals.
-    bindings = [
-        {"ts": {"value": "2026-06-19T07:06:29+00:00"}, "activeCount": {"value": "2"}},
-        {"ts": {"value": "2026-06-19T07:07:29+00:00"}, "activeCount": {"value": "0"}},
-        {"ts": {"value": "2026-06-19T07:08:29+00:00"}, "activeCount": {"value": "3.0"}},
-        # Garbage/missing count degrades to 0 (must not crash).
-        {"ts": {"value": "2026-06-19T07:09:29+00:00"}, "activeCount": {"value": "junk"}},
-        {"ts": {"value": "2026-06-19T07:10:29+00:00"}},
-    ]
-    recs = mod.parse_sparql_drive_bindings(bindings)
-    assert [r.active_count for r in recs] == [2, 0, 3, 0, 0]
+def test_parse_sparql_histogram_bindings_degrades():
+    # Empty bindings -> empty dict, no raise.
+    assert mod.parse_sparql_histogram_bindings([]) == {}

--- a/scripts/analysis/tests/test_measure_autonomy_gate.py
+++ b/scripts/analysis/tests/test_measure_autonomy_gate.py
@@ -218,11 +218,23 @@ def test_build_drive_audit_sparql_shape():
     q = mod.build_drive_audit_sparql(BASE)
     assert mod.AUTONOMY_DRIVES_GRAPH in q
     assert "orion:DriveAudit" in q
-    assert "orion:highlightsActiveDrive" in q
-    assert "COUNT(DISTINCT ?d)" in q
+    assert "orion:hasDriveAssessment" in q
+    assert "orion:driveActive" in q
     assert "orion:timestamp ?ts" in q
     assert BASE.isoformat() in q  # window bound is applied
     assert "FILTER" in q
+
+
+def test_build_drive_audit_sparql_uses_real_predicates():
+    q = mod.build_drive_audit_sparql(BASE)
+    # Real graph shape: hasDriveAssessment -> driveActive (boolean true).
+    assert "hasDriveAssessment" in q
+    assert "driveActive" in q
+    # The stale/nonexistent predicate must be gone.
+    assert "highlightsActiveDrive" not in q
+    # Still bounds the window on a typed dateTime and groups per audit.
+    assert f'FILTER (?ts >= "{BASE.isoformat()}"^^xsd:dateTime)' in q
+    assert "GROUP BY ?audit ?ts" in q
 
 
 def _binding(ts_iso: str, count: str) -> dict:
@@ -259,3 +271,18 @@ def test_parse_sparql_drive_bindings_degrades():
 
     # Empty bindings -> empty, no raise.
     assert mod.parse_sparql_drive_bindings([]) == []
+
+
+def test_parse_sparql_drive_bindings_handles_sum_literals():
+    # Shaped like real SPARQL-results-JSON from the SUM(IF(driveActive=true,...))
+    # query: counts may come back as integer OR decimal literals.
+    bindings = [
+        {"ts": {"value": "2026-06-19T07:06:29+00:00"}, "activeCount": {"value": "2"}},
+        {"ts": {"value": "2026-06-19T07:07:29+00:00"}, "activeCount": {"value": "0"}},
+        {"ts": {"value": "2026-06-19T07:08:29+00:00"}, "activeCount": {"value": "3.0"}},
+        # Garbage/missing count degrades to 0 (must not crash).
+        {"ts": {"value": "2026-06-19T07:09:29+00:00"}, "activeCount": {"value": "junk"}},
+        {"ts": {"value": "2026-06-19T07:10:29+00:00"}},
+    ]
+    recs = mod.parse_sparql_drive_bindings(bindings)
+    assert [r.active_count for r in recs] == [2, 0, 3, 0, 0]

--- a/scripts/analysis/tests/test_measure_autonomy_gate.py
+++ b/scripts/analysis/tests/test_measure_autonomy_gate.py
@@ -251,9 +251,9 @@ def test_parse_sparql_histogram_bindings_happy():
 
 
 def test_parse_sparql_histogram_bindings_retains_zero_bucket():
-    # The query now emits an explicit bound 0 bucket for assessment-less audits
-    # (BOUND(?act) guard) rather than dropping them; lock in that the parser
-    # keeps a bound-0 row so those audits stay in the record_count denominator.
+    # The query emits an explicit 0 bucket for assessment-less / all-inactive
+    # audits (OPTIONAL + COUNT(DISTINCT ?activeDa) yields 0, not unbound); lock
+    # in that the parser keeps a 0 row so those audits stay in the denominator.
     bindings = [
         {"activeCount": {"value": "0"}, "audits": {"value": "5"}},
         {"activeCount": {"value": "2"}, "audits": {"value": "3"}},

--- a/scripts/analysis/tests/test_measure_autonomy_gate.py
+++ b/scripts/analysis/tests/test_measure_autonomy_gate.py
@@ -214,19 +214,21 @@ def test_build_drive_coactivation_histogram_sparql_shape():
     q = mod.build_drive_coactivation_histogram_sparql(BASE)
     assert mod.AUTONOMY_DRIVES_GRAPH in q
     assert "orion:DriveAudit" in q
-    # Assessment-level boolean shape.
+    # Assessment-level boolean shape, counted DISTINCT (bounded by drive keys).
     assert "hasDriveAssessment" in q
-    assert "driveActive" in q
-    # BOUND guard: assessment-less audits must yield activeCount=0, not unbound
-    # (otherwise the audit drops from the histogram and biases coactivation_frac).
-    assert "SUM(IF(BOUND(?act) && ?act = true" in q
-    assert "BOUND(?act)" in q
+    assert "orion:driveActive true" in q
+    assert "COUNT(DISTINCT ?activeDa)" in q
+    # ts is multi-valued -> windowed via FILTER EXISTS so it cannot fan out the
+    # assessment count. ?ts must NOT be bound in the aggregation group.
+    assert "FILTER EXISTS" in q
+    assert "orion:timestamp" in q
+    assert f'FILTER(?ts >= "{BASE.isoformat()}"^^xsd:dateTime)' in q
     # Nested aggregation: inner reduces per audit, outer bins into a histogram.
     assert "GROUP BY ?audit" in q
     assert "GROUP BY ?activeCount" in q
-    # Window bound applied on a typed dateTime.
-    assert f'FILTER (?ts >= "{BASE.isoformat()}"^^xsd:dateTime)' in q
-    # Stale / per-audit-transfer shapes must be gone.
+    # Old markers (fan-out / unbound-SUM / stale predicate) must be gone.
+    assert "SUM(IF" not in q
+    assert "BOUND(?act)" not in q
     assert "highlightsActiveDrive" not in q
     assert "COUNT(DISTINCT ?d)" not in q
 


### PR DESCRIPTION
Review passed (no blocking issues), doc precision applied, 15/15 tests green, branch **pushed** to `origin/fix/autonomy-gate-drive-coactivation-query`.

Create-PR URL: https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/autonomy-gate-drive-coactivation-query

Here's the PR description (ready to paste):

---

## Summary

- Adds the plan's missing file-map deliverable: `scripts/analysis/README.md` (operator run guide + verdict meanings) for the already-merged autonomy-origination measurement gate (Step 0).
- Executes the gate against live durable history (plan Task 3) and records two honest GO/NO-GO verdicts.
- Hardens the drive co-activation read: the original per-audit Fuseki fetch pulled the full unbounded result set (~444k rows) and blew the 30s timeout on any large window, silently degrading to `0 records`. Replaced with a server-side nested-`GROUP BY` histogram (~7 rows returned).
- Kills a multi-valued-`orion:timestamp` **fan-out** by counting `COUNT(DISTINCT ?activeDa)` and applying the window via `FILTER EXISTS` (was inflating per-audit active counts to impossible values, e.g. 30 when only 6 drives exist).
- Corrects a false "nonexistent predicate" narrative: the legacy `orion:highlightsActiveDrive` (864 triples) is exactly equivalent to `orion:driveActive=true` (864); the assessment-level boolean is now read as primary.

## Outcome moved

Verdict (b) is now computable and trustworthy on any window (was a timeout-masked false `0 records`). Live run: 444,943 audits, `anomalies=0`, no timeout.

## Verdicts (live, read-only)

- **(a) endogenous drift: NO-GO** — silent-bucket `median_abs_trajectory = 0.0000` (< 0.03) over 128k self-state rows. Self-state is flat in silence.
- **(b) internal economy: NO-GO** — histogram `0:444734, 1:10, 2:20, 3:31, 4:77, 5:13, 6:58` (max 6 = drive keys); `coactivation_frac = 0.0004` (≪ 0.10).

**Gated-spec dispositions:** Step 1 (endogenous origination) **BLOCKED** — no silent-drift signal to fire on. Step 4 (internal economy) **SHELVED** — drives essentially never co-activate; the scarcity allocator would be ornamental.

## Current architecture

Read-only analysis worker (`scripts/analysis/measure_autonomy_gate.py`, merged in `b58e312c`/`de0ad072`) with a pure metrics layer and an IO layer (psycopg2 read-only + Fuseki SPARQL). No README existed; the drive read fetched per-audit rows client-side.

## Architecture touched

Only the drive co-activation read path inside the one worker. Pure/IO split, read-only guarantee, and verdict thresholds unchanged. No service, schema, bus, env, or Docker surface touched.

## Files changed

- `scripts/analysis/README.md`: new operator guide (run, env, data sources, verdict rules, outputs, read-only guarantee).
- `scripts/analysis/measure_autonomy_gate.py`: server-side histogram aggregation (`build_drive_coactivation_histogram_sparql`, `parse_sparql_histogram_bindings`, `drive_stats_from_histogram`, `fetch_drive_stats`); removed dead per-audit path (`DriveAuditRecord`, `compute_drive_stats`, old builder/parser/fetch); `FUSEKI_TIMEOUT_SEC` 30→60; accurate docstrings.
- `scripts/analysis/tests/test_measure_autonomy_gate.py`: regression tests (fan-out reintroduction, predicate drift, parser crash, div-by-zero, zero-bucket denominator).

## Schema / bus / API changes

- None. Read-only SPARQL `SELECT` and read-only Postgres only. No payloads/channels/registry changes.

## Env/config changes

- None. Reads existing `POSTGRES_URI` / `AUTONOMY_GRAPH_QUERY_URL`. No `.env_example` change; nothing to sync.

## Tests run

```text
pytest scripts/analysis/tests/test_measure_autonomy_gate.py -q  →  15 passed
pyflakes  →  clean
```

## Evals run

```text
Live measurement (acts as the gate's eval), --window-days 120:
  drive audit records: 444943
  concurrent_active_hist: 0:444734, 1:10, 2:20, 3:31, 4:77, 5:13, 6:58 (max active = 6)
  coactivation_frac: 0.0004 ; verdict (a): NO-GO ; verdict (b): NO-GO ; anomalies=0
  artifacts: /tmp/autonomy-gate/{report.md,before_after.csv,progress.log}
```

## Docker/build/smoke checks

```text
N/A — read-only analysis script; no container/runtime change. DB/Fuseki reached via published ports (55432/3030).
```

## Review findings fixed

- Finding: SPARQL `SUM(IF(?act=true,...))` returned unbound (not 0) for assessment-less audits, dropping them and biasing `coactivation_frac` up.
  - Fix: switched to `OPTIONAL` + `COUNT(DISTINCT ?activeDa)` (yields 0, retained in denominator).
  - Evidence: `test_parse_sparql_histogram_bindings_retains_zero_bucket`; live 0-bucket = 444,734.
- Finding: multi-valued `orion:timestamp` cross-producted the assessment join (active counts up to 30).
  - Fix: window via `FILTER EXISTS`, never bind `?ts` in the aggregation.
  - Evidence: live histogram now maxes at 6; shape test asserts `FILTER EXISTS` + absence of `SUM(IF`.
- Finding: stale `highlightsActiveDrive`/`XRANGE` narrative.
  - Fix: docstrings + README corrected to the assessment-level shape.
  - Evidence: negative test assertions; README review.

## Restart required

```text
No restart required. Read-only analysis script only.
```

## Risks / concerns

- Severity: medium (data/ops, not this patch). The NO-GO verdicts partly reflect upstream anomalies, filed as follow-ups: (1) **drive-audit persistence to Fuseki stopped 2026-06-19** (default 7-day window is empty); (2) **`resource_pressure` pinned at 1.0** across all self-state rows (`builder.py:194`); (3) **99.95% of audits have 0 active drives**. Mitigation: resolve these before treating Step 1/Step 4 as permanently shelved.
