### PR TITLE
Feat/world pulse combined curiosity digest

### DIFF
--- a/orion/schemas/world_pulse.py
+++ b/orion/schemas/world_pulse.py
@@ -562,6 +562,7 @@ class HubWorldPulseMessageV1(_WPBase):
     cards: list[DailyWorldPulseItemV1] = Field(default_factory=list)
     worth_reading: list[WorthReadingItemV1] = Field(default_factory=list)
     worth_watching: list[WorthWatchingItemV1] = Field(default_factory=list)
+    curiosity_followups: list[CuriosityFollowupV1] = Field(default_factory=list)
     rendered_markdown: str = ""
     structured_payload: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -8811,6 +8811,7 @@ loadDismissedIds();
           items: Array.isArray(payload.cards) ? payload.cards : [],
           things_worth_reading: Array.isArray(payload.worth_reading) ? payload.worth_reading : [],
           things_worth_watching: Array.isArray(payload.worth_watching) ? payload.worth_watching : [],
+          curiosity_followups: Array.isArray(payload.curiosity_followups) ? payload.curiosity_followups : [],
         };
     return {
       run: {
@@ -9000,6 +9001,57 @@ loadDismissedIds();
         cardsWrap.appendChild(details);
       });
       worldPulseDetails.appendChild(cardsWrap);
+    }
+
+    const curiosityFollowups = Array.isArray(digest.curiosity_followups) ? digest.curiosity_followups : [];
+    if (curiosityFollowups.length) {
+      const curiosityWrap = document.createElement('div');
+      curiosityWrap.className = 'space-y-2';
+      const curiosityTitle = document.createElement('div');
+      curiosityTitle.className = 'text-[10px] uppercase tracking-wide text-gray-500';
+      curiosityTitle.textContent = 'Orion Went Looking (gaps our sources missed)';
+      curiosityWrap.appendChild(curiosityTitle);
+      curiosityFollowups.forEach((followup) => {
+        const details = document.createElement('details');
+        details.className = 'rounded border border-gray-800 bg-gray-950/40 p-2';
+        const summary = document.createElement('summary');
+        summary.className = 'cursor-pointer text-xs text-gray-200';
+        const sectionLabel = String(followup?.section || 'unknown').replace(/_/g, ' ');
+        const articles = Array.isArray(followup?.articles) ? followup.articles : [];
+        summary.textContent = `${sectionLabel} · "${followup?.query || ''}" · ${articles.length} found`;
+        details.appendChild(summary);
+        if (articles.length) {
+          const list = document.createElement('ul');
+          list.className = 'mt-1 space-y-1';
+          articles.forEach((art) => {
+            const li = document.createElement('li');
+            li.className = 'text-xs text-gray-300';
+            const salience = Number.isFinite(Number(art?.salience)) ? Number(art.salience).toFixed(2) : '--';
+            const title = art?.title || '(untitled)';
+            if (art?.url) {
+              const link = document.createElement('a');
+              link.href = art.url;
+              link.target = '_blank';
+              link.rel = 'noopener noreferrer';
+              link.className = 'text-blue-400 hover:underline';
+              link.textContent = title;
+              li.textContent = `[${salience}] `;
+              li.appendChild(link);
+            } else {
+              li.textContent = `[${salience}] ${title}`;
+            }
+            list.appendChild(li);
+          });
+          details.appendChild(list);
+        } else {
+          const none = document.createElement('div');
+          none.className = 'mt-1 text-xs text-gray-500';
+          none.textContent = 'looked, found nothing';
+          details.appendChild(none);
+        }
+        curiosityWrap.appendChild(details);
+      });
+      worldPulseDetails.appendChild(curiosityWrap);
     }
 
     const worthReading = digest.things_worth_reading || digest.worth_reading || [];

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -8789,6 +8789,10 @@ loadDismissedIds();
     return Array.isArray(item?.source_ids) ? item.source_ids.length : null;
   }
 
+  function worldPulseSafeHttpUrl(url) {
+    return /^https?:\/\//i.test(String(url || '')) ? url : null;
+  }
+
   function normalizeWorldPulsePayload(raw) {
     const payload = raw && typeof raw === 'object' ? raw : {};
     if (payload.digest && payload.run) {
@@ -9028,9 +9032,10 @@ loadDismissedIds();
             li.className = 'text-xs text-gray-300';
             const salience = Number.isFinite(Number(art?.salience)) ? Number(art.salience).toFixed(2) : '--';
             const title = art?.title || '(untitled)';
-            if (art?.url) {
+            const safeUrl = worldPulseSafeHttpUrl(art?.url);
+            if (safeUrl) {
               const link = document.createElement('a');
-              link.href = art.url;
+              link.href = safeUrl;
               link.target = '_blank';
               link.rel = 'noopener noreferrer';
               link.className = 'text-blue-400 hover:underline';
@@ -9069,13 +9074,14 @@ loadDismissedIds();
         const reasonBlock = createWorldPulseBlock('Reason', w.reason_selected);
         if (itemBlock) row.appendChild(itemBlock);
         if (reasonBlock) row.appendChild(reasonBlock);
-        if (w.url) {
+        const safeWorthUrl = worldPulseSafeHttpUrl(w.url);
+        if (safeWorthUrl) {
           const link = document.createElement('a');
-          link.href = w.url;
+          link.href = safeWorthUrl;
           link.target = '_blank';
           link.rel = 'noopener noreferrer';
           link.className = 'text-indigo-300 hover:underline';
-          link.textContent = w.url;
+          link.textContent = safeWorthUrl;
           const linkWrap = document.createElement('div');
           linkWrap.className = 'mt-1';
           linkWrap.appendChild(link);

--- a/services/orion-world-pulse/app/services/renderers.py
+++ b/services/orion-world-pulse/app/services/renderers.py
@@ -166,6 +166,7 @@ def render_hub_digest(digest: DailyWorldPulseV1) -> HubWorldPulseMessageV1:
         cards=digest.items,
         worth_reading=digest.things_worth_reading,
         worth_watching=digest.things_worth_watching,
+        curiosity_followups=digest.curiosity_followups,
         rendered_markdown=render_plaintext_digest(digest),
         structured_payload=structured,
         created_at=digest.created_at,

--- a/services/orion-world-pulse/tests/test_renderers_curiosity.py
+++ b/services/orion-world-pulse/tests/test_renderers_curiosity.py
@@ -56,3 +56,13 @@ def test_hub_structured_payload_carries_followups():
     hub = render_hub_digest(_digest([followup]))
     assert hub.structured_payload["curiosity_followups"][0]["section"] == "hardware_compute_gpu"
     assert "Orion went looking" in hub.rendered_markdown
+    # Combined digest: curiosity rides on the single hub message as a structured field
+    # (alongside cards), not just buried in rendered_markdown/structured_payload.
+    assert len(hub.curiosity_followups) == 1
+    assert hub.curiosity_followups[0].section == "hardware_compute_gpu"
+    assert hub.curiosity_followups[0].articles[0].url == "https://ex/1"
+
+
+def test_hub_curiosity_field_empty_when_no_followups():
+    hub = render_hub_digest(_digest([]))
+    assert hub.curiosity_followups == []


### PR DESCRIPTION
## Summary

- The world-pulse news digest already keeps two separate backend structures — the 12 regular source cards (`digest.items`) and the autonomy gap-fill "curiosity" articles (`digest.curiosity_followups`). This surfaces **both in one combined hub/chat digest**.
- Curiosity was previously invisible on the hub World Pulse panel (it only rode along inside `rendered_markdown`/`structured_payload` and the disabled email body). It now renders as an "Orion Went Looking (gaps our sources missed)" section directly under the digest cards.
- Backend data stays separate: gap-fill articles are **not** merged into the regular cards, and **no new email/delivery** is added — one digest, both sections.
- Hardened external article links (curiosity + worth-reading) to only accept `http(s)` schemes.

## Outcome moved

On the live hub surface the daily digest now shows the 12 curated cards *and* the curiosity gap-fill in a single view. Previously the "Orion went looking" articles never rendered in the panel.

## Current architecture

`orion-world-pulse` builds `DailyWorldPulseV1` with `items` (primary scrape → clustered cards) and a separate `curiosity_followups` field (autonomy web-fetch for missing sections). `render_hub_digest` produced a `HubWorldPulseMessageV1` carrying `cards` structurally but only exposed curiosity via `rendered_markdown`/`structured_payload`. The hub UI `renderWorldPulseDetails` rendered cards / worth-reading / worth-watching / rollups but never curiosity.

## Architecture touched

- Shared schema contract `HubWorldPulseMessageV1` (additive field).
- `orion-world-pulse` hub renderer (producer).
- `orion-hub` static JS panel renderer (consumer/UI).

## Files changed

- `orion/schemas/world_pulse.py`: add `curiosity_followups: list[CuriosityFollowupV1]` to `HubWorldPulseMessageV1` (additive, default empty).
- `services/orion-world-pulse/app/services/renderers.py`: `render_hub_digest` populates the new field from `digest.curiosity_followups`.
- `services/orion-hub/static/js/app.js`: `normalizeWorldPulsePayload` fallback carries `curiosity_followups`; `renderWorldPulseDetails` renders the "Orion Went Looking" section (section label, query, article list with salience + link); added `worldPulseSafeHttpUrl()` scheme guard applied to the curiosity and worth-reading anchors.
- `services/orion-world-pulse/tests/test_renderers_curiosity.py`: assert the hub message carries the structured field (populated + empty-safe).

## Schema / bus / API changes

- Added: `HubWorldPulseMessageV1.curiosity_followups` (list, default `[]`).
- Removed: none.
- Renamed: none.
- Behavior changed: none for existing consumers.
- Compatibility: additive with default; backward-compatible under `extra="forbid"`. No bus channel changes; sql-writer persists the message as a `payload_json` blob so no column mapping breaks.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: no.
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not required (no env template changed).
- skipped keys requiring operator action: none.

## Tests run

```text
.venv/bin/python -m pytest services/orion-world-pulse/tests -q
  -> 70 passed

.venv/bin/python -m pytest services/orion-hub/tests/test_world_pulse_proxy_routes.py -q
  -> 3 passed

.venv/bin/python -m pytest services/orion-world-pulse/tests/test_renderers_curiosity.py -q
  -> 4 passed

node --check services/orion-hub/static/js/app.js  -> JS_OK
HubWorldPulseMessageV1 round-trip with curiosity_followups -> roundtrip_ok
```

## Evals run

```text
No world-pulse eval harness for this render seam; covered by unit tests at
services/orion-world-pulse/tests/test_renderers_curiosity.py.
```

## Docker/build/smoke checks

```text
Not rebuilt in this session. Change is code-only (schema + producer + static JS).
Runtime verified against the live latest run (run 339f9acf): 12 cards + 1 curiosity
followup (5 GPU articles), confirming the digest data the panel now renders.
```

## Review findings fixed

- Finding (Minor): external article `href` not scheme-guarded (`app.js`), URLs come from untrusted search/RSS results.
  - Fix: added `worldPulseSafeHttpUrl()` and applied it to the new curiosity anchor and the sibling worth-reading anchor (only `http(s)` linked; others render as plain text).
  - Evidence: `node --check` OK; anchors still use `textContent` + `rel="noopener noreferrer"`.
- Non-blocking (no action): fallback curiosity carry is dead on the live path but kept for defensive consistency with the worth-reading/watching fallbacks.
- Non-blocking (no action): empty curiosity section is hidden, matching the plaintext renderer which omits the block when empty.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-world-pulse/.env -f services/orion-world-pulse/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
```

(Hard-refresh the hub page to bust the cached `app.js`.)

## Risks / concerns

- Severity: low
- Concern: static JS is cache-busted only by hard refresh; the panel already reads the full digest so the field is present without a schema change on the `/latest` path.
- Mitigation: restart commands above; the schema field is additive/backward-compatible.

## Follow-ups

- No JS test harness exists for `renderWorldPulseDetails`; the curiosity DOM render branch is unit-tested only at the Python schema/renderer seam (matches existing practice — sibling renderers are also untested). Worth a small hub JS test harness later.

## PR link

Branch pushed: `feat/world-pulse-combined-curiosity-digest`
Open PR: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/world-pulse-combined-curiosity-digest
