### PR TITLE
fix(fcc): make GitHub MCP harness brief passive/optional

### DIFF
--- a/orion/fcc/github_repo_context.py
+++ b/orion/fcc/github_repo_context.py
@@ -82,15 +82,17 @@ def github_mcp_brief_lines(*, workspace: Path | str | None = None) -> list[str]:
     owner, repo = coord
     return [
         (
-            f"GitHub MCP: pass owner={owner!r} and repo={repo!r} to list_pull_requests "
-            f"(both required; never use the repo name as owner)."
+            f"GitHub MCP is available (owner={owner!r}, repo={repo!r}). "
+            "Use it only when this turn's imperative needs PR/issue/repo facts and you judge "
+            "it appropriate — do not fetch GitHub data for unrelated turns."
         ),
         (
-            "For latest PR title/number: list_pull_requests with state=all, sort=updated, "
-            "direction=desc, perPage=1. Default state=open returns [] when nothing is open "
-            "(the newest PR is usually merged). Do not use search_pull_requests (blows ~65k ctx)."
+            "If you do query PRs: list_pull_requests requires both owner and repo (never use "
+            "the repo name as owner). For the latest PR, pass state=all, sort=updated, "
+            "direction=desc, perPage=1 (default state=open returns [] when nothing is open). "
+            "Avoid search_pull_requests (blows ~65k ctx). Report the PR title only; never paste "
+            "raw MCP JSON into the reply."
         ),
-        "Answer with the PR title string only; never paste raw MCP JSON into the reply.",
     ]
 
 

--- a/orion/fcc/tests/test_github_repo_context.py
+++ b/orion/fcc/tests/test_github_repo_context.py
@@ -29,17 +29,24 @@ def test_resolve_github_repo_coordinate_from_env(monkeypatch: pytest.MonkeyPatch
     assert resolve_github_repo_coordinate(workspace="/tmp") == ("env-owner", "env-repo")
 
 
-def test_github_mcp_brief_lines_include_narrow_pr_guidance(
+def test_github_mcp_brief_lines_are_passive_and_optional(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("ORION_GITHUB_OWNER", "junebug-junie")
     monkeypatch.setenv("ORION_GITHUB_REPO", "Orion-Sapienform")
     lines = github_mcp_brief_lines(workspace=Path("/tmp"))
-    assert len(lines) == 3
-    assert "perPage=1" in lines[1]
-    assert "state=all" in lines[1]
-    assert "search_pull_requests" in lines[1]
-    assert "never paste raw MCP JSON" in lines[2]
+    assert len(lines) == 2
+    # First line frames the tool as an optional capability, not a directive to run it.
+    capability = lines[0]
+    assert "available" in capability
+    assert "only when" in capability
+    assert "unrelated turns" in capability
+    # Operational guardrails are preserved for the case where the model does use it.
+    guardrail = lines[1]
+    assert "perPage=1" in guardrail
+    assert "state=all" in guardrail
+    assert "search_pull_requests" in guardrail
+    assert "never paste raw MCP JSON" in guardrail
 
 
 def test_append_github_mcp_harness_brief_warns_when_unresolved(


### PR DESCRIPTION
The FCC/unified-turn harness injected an imperative GitHub MCP brief ("For latest PR title/number: list_pull_requests with...") into every motor turn, causing the model to front-run list_pull_requests on unrelated turns and blow the local llamacpp context. Reword the brief in github_mcp_brief_lines as an optional capability the model uses only when the turn's imperative needs PR/issue/repo facts, while preserving the operational guardrails (owner/repo args, avoid search_pull_requests, no raw MCP JSON) for when it does. Update tests to lock the passive framing.