### PR TITLE
Feat/homeostatic drives consumer wire

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-08-homeostatic-drives-consumer-wire-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-08-homeostatic-drives-consumer-wire-pr.md
@@ -1,0 +1,102 @@
+# PR: Homeostatic drives — live signal consumer (drive-only rail)
+
+**Status:** IMPLEMENTED + reviewed. Completes Task 6 (live consumer) and Task 9
+(review). Task 10 (host live-verify) is the remaining step and needs the running
+host — instructions below.
+
+## Summary
+
+- Concept-induction worker now **subscribes to specific organ/failure channels**
+  (`orion:signals:biometrics|spark|equilibrium`, `orion:system:error`,
+  `orion:rdf:error`, `orion:vision:edge:error`) — **never** the `orion:signals:*`
+  wildcard, so the 55/s `scene_state` flood is excluded at the subscription.
+- Those envelopes route to a new **`_handle_signal_drive_tick`** — a thin
+  drive-only rail: mint deviation/failure tensions → update + publish drive
+  state/audit → **return before concept induction** (no windowing, goals, or
+  identity snapshot on a ~1/s biometric tick).
+- Health degradation arrives as a `mesh_health` `OrionSignal` on the signal rail
+  (deviation-gated `level↓`); no separate unverified-shape `equilibrium:snapshot`
+  branch was wired.
+- Flag-gated on `ORION_HOMEOSTATIC_DRIVES_ENABLED`; degrades to a no-op, never
+  raises into the bus loop.
+
+## Outcome moved
+
+The homeostatic substrate (merged in #879) is now **fed by real bus traffic**.
+Before this PR the leaky-math engine only saw the existing spark/feedback/metabolism
+tensions; now biometrics, spark, mesh-health, and system failures drive pressure
+through the deviation gate — the "make it real, not tick-based" goal.
+
+## Architecture touched
+
+- `orion/spark/concept_induction/bus_worker.py` — `_handle_signal_drive_tick`,
+  `_parse_signal`, `_homeostatic_source`, `_homeostatic_channels`,
+  `_pubsub_patterns` (+homeostatic channels when enabled), `handle_envelope`
+  early-return branch.
+- `orion/spark/concept_induction/settings.py` — `homeostatic_signal_channels`,
+  `homeostatic_failure_channels`, `homeostatic_failure_severity`.
+- `services/orion-spark-concept-induction/.env_example`, `orion/bus/channels.yaml`.
+- Tests: `orion/spark/concept_induction/tests/test_signal_drive_consumer.py`.
+
+## Schema / bus / API changes
+
+- No new schemas. Reuses `OrionSignalV1`, `TensionEventV1`, `SignalTensionSource`.
+- Consumed channels are specific organ/failure channels (documented in channels.yaml).
+
+## Env/config changes
+
+- Added: `HOMEOSTATIC_SIGNAL_CHANNELS` / `HOMEOSTATIC_FAILURE_CHANNELS` (JSON list
+  overrides; defaults apply), `HOMEOSTATIC_FAILURE_SEVERITY=0.8`.
+- `.env_example` updated. Run `python scripts/sync_local_env_from_example.py` on
+  the host post-merge (worktree has no local `.env`).
+
+## Tests run
+
+```text
+pytest orion/spark/concept_induction/tests orion/autonomy/tests -q
+261 passed  (incl. 7 new consumer tests: subscription/no-wildcard, source
+classification, biometric-drop→drives-no-induction, steady=no-op, failure→tension,
+flag-off fall-through, never-raise-on-broken-store)
+```
+
+## Review findings fixed (Task 9, subagent)
+
+- **MAJOR** — `_handle_signal_drive_tick` drive-update/publish section was unwrapped;
+  a tz-naive stored `updated_at` or store fault would raise into the bus loop
+  (which re-raises) and tear down the subscription, contradicting the never-raise
+  contract on a ~1/s rail.
+  - Fix: wrapped the section in `try/except → log + return`; normalize
+    `previous_ts` to tz-aware.
+  - Evidence: new `test_never_raises_when_drive_update_breaks` (tz-naive state +
+    `save_drive_state` raising → no exception). 261 tests green.
+- **NIT** — channels.yaml comment read self-contradictory (service on the wildcard
+  entry vs "never the wildcard"). Reworded to clarify registration vs runtime
+  subscription.
+- **NIT** — flag defaults ON: intended (Juniper authorized flags-on).
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
+  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
+```
+
+## Task 10 — live host verification (remaining)
+
+After restart, tap live for ~60s and confirm:
+- `drive:audit` / drive_state shows **differentiated, non-pinned** pressures that
+  move with biometrics/mesh-health/failures and decay toward ~0 in quiet windows
+  (NOT all six pinned at 0.7309).
+- `orion:signals:vision` / scene_state flood mints **0** homeostatic tensions
+  (channel never subscribed).
+- `dominant_drive` reflects real events (not constant "autonomy"/None).
+
+## Risks / concerns
+
+- Severity: low — consumer degrades to no-op and is flag-gated; scene_state flood
+  structurally excluded; 261 tests + subagent review clean.
+- Live behavior against the real 55/s reality is unverified until Task 10 on host.
+
+## PR link
+
+<to be filled by `gh pr create` / GitHub UI>

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1957,9 +1957,10 @@ channels:
     kind: "event"
     schema_id: "OrionSignalV1"
     producer_services: ["orion-signal-gateway"]
-    # concept-induction consumes ONLY the specific organ channels
-    # (orion:signals:biometrics|spark|equilibrium) for homeostatic drives — never
-    # the wildcard, so the scene_state flood is excluded at subscription.
+    # concept-induction is registered here (the per-organ sub-channels are not
+    # individually catalogued), but at runtime it subscribes ONLY to the specific
+    # organ channels (orion:signals:biometrics|spark|equilibrium) for homeostatic
+    # drives — never this wildcard, so the scene_state flood is excluded.
     consumer_services: ["orion-hub", "orion-cortex-exec", "orion-spark-concept-induction", "*"]
     stability: "experimental"
     since: "2026-05-02"

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1957,7 +1957,10 @@ channels:
     kind: "event"
     schema_id: "OrionSignalV1"
     producer_services: ["orion-signal-gateway"]
-    consumer_services: ["orion-hub", "orion-cortex-exec", "*"]
+    # concept-induction consumes ONLY the specific organ channels
+    # (orion:signals:biometrics|spark|equilibrium) for homeostatic drives — never
+    # the wildcard, so the scene_state flood is excluded at subscription.
+    consumer_services: ["orion-hub", "orion-cortex-exec", "orion-spark-concept-induction", "*"]
     stability: "experimental"
     since: "2026-05-02"
 

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -656,66 +656,78 @@ class ConceptWorker:
             # elapsed at the next update, so skipping here loses no decay.
             return
 
-        for tension in tensions:
-            await self._publish_tension_event(tension, env.correlation_id)
+        # The whole drive-update/publish section is guarded: this rail runs at
+        # ~1/s and the bus loop re-raises, so a single bad prior state (e.g. a
+        # tz-naive updated_at) must degrade to a no-op, never tear down the worker.
+        try:
+            for tension in tensions:
+                await self._publish_tension_event(tension, env.correlation_id)
 
-        prior = self.store.load_drive_state(subject)
-        previous_ts: Optional[datetime] = None
-        if isinstance(prior.get("updated_at"), str):
-            try:
-                previous_ts = datetime.fromisoformat(prior["updated_at"])
-            except ValueError:
-                previous_ts = None
+            prior = self.store.load_drive_state(subject)
+            previous_ts: Optional[datetime] = None
+            if isinstance(prior.get("updated_at"), str):
+                try:
+                    previous_ts = datetime.fromisoformat(prior["updated_at"])
+                    if previous_ts.tzinfo is None:
+                        previous_ts = previous_ts.replace(tzinfo=timezone.utc)
+                except ValueError:
+                    previous_ts = None
 
-        pressures, activations = self.drive_engine.update(
-            previous_pressures=prior.get("pressures"),
-            previous_activations=prior.get("activations"),
-            tensions=tensions,
-            now=now,
-            previous_ts=previous_ts,
-        )
-        self.store.save_drive_state(
-            subject, pressures=pressures, activations=activations, updated_at=now
-        )
+            pressures, activations = self.drive_engine.update(
+                previous_pressures=prior.get("pressures"),
+                previous_activations=prior.get("activations"),
+                tensions=tensions,
+                now=now,
+                previous_ts=previous_ts,
+            )
+            self.store.save_drive_state(
+                subject, pressures=pressures, activations=activations, updated_at=now
+            )
 
-        trace_id = extract_trace_id(env)
-        turn_id = extract_turn_id(env)
-        drive_state = drive_state_from_values(
-            subject=subject,
-            model_layer=model_layer,
-            entity_id=entity_id,
-            ts=now,
-            pressures=pressures,
-            activations=activations,
-            confidence=0.72,
-            correlation_id=str(env.correlation_id),
-            trace_id=trace_id,
-            turn_id=turn_id,
-            provenance=ArtifactProvenance(
-                intake_channel=intake_channel,
+            trace_id = extract_trace_id(env)
+            turn_id = extract_turn_id(env)
+            drive_state = drive_state_from_values(
+                subject=subject,
+                model_layer=model_layer,
+                entity_id=entity_id,
+                ts=now,
+                pressures=pressures,
+                activations=activations,
+                confidence=0.72,
                 correlation_id=str(env.correlation_id),
                 trace_id=trace_id,
                 turn_id=turn_id,
-                tension_refs=[t.artifact_id for t in tensions],
-            ),
-            related_nodes=[f"subject:{subject}"] + [t.artifact_id for t in tensions],
-        )
-        await self._publish_drive_state(drive_state, env.correlation_id)
+                provenance=ArtifactProvenance(
+                    intake_channel=intake_channel,
+                    correlation_id=str(env.correlation_id),
+                    trace_id=trace_id,
+                    turn_id=turn_id,
+                    tension_refs=[t.artifact_id for t in tensions],
+                ),
+                related_nodes=[f"subject:{subject}"] + [t.artifact_id for t in tensions],
+            )
+            await self._publish_drive_state(drive_state, env.correlation_id)
 
-        tick_attribution = compute_tick_attribution(tensions)
-        lead_tension = select_lead_tension(tensions)
-        dominant_drive = dominant_drive_from_attribution(
-            tick_attribution, lead_tension=lead_tension
-        )
-        drive_audit = build_drive_audit(
-            env=env,
-            intake_channel=intake_channel,
-            drive_state=drive_state,
-            tensions=tensions,
-            tick_attribution=tick_attribution,
-            dominant_drive=dominant_drive,
-        )
-        await self._publish_artifact(drive_audit, self.cfg.drive_audit_channel, env.correlation_id)
+            tick_attribution = compute_tick_attribution(tensions)
+            lead_tension = select_lead_tension(tensions)
+            dominant_drive = dominant_drive_from_attribution(
+                tick_attribution, lead_tension=lead_tension
+            )
+            drive_audit = build_drive_audit(
+                env=env,
+                intake_channel=intake_channel,
+                drive_state=drive_state,
+                tensions=tensions,
+                tick_attribution=tick_attribution,
+                dominant_drive=dominant_drive,
+            )
+            await self._publish_artifact(drive_audit, self.cfg.drive_audit_channel, env.correlation_id)
+        except Exception:
+            logger.warning(
+                "homeostatic_drive_update_failed channel=%s source=%s",
+                intake_channel, source, exc_info=True,
+            )
+            return
 
     async def handle_envelope(self, env: BaseEnvelope, intake_channel: str) -> None:
         # Homeostatic sources ride a thin drive-only rail: they update drives and

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -13,6 +13,7 @@ from orion.autonomy.deviation_gate import DeviationGate
 from orion.autonomy.signal_drive_map import load_signal_drive_map
 from orion.autonomy.signal_tension import SignalTensionSource
 from orion.autonomy.tension_ratelimit import TensionRateLimiter
+from orion.signals.models import OrionSignalV1
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.core.bus.work_queue import RedisStreamWorkQueue
@@ -212,7 +213,30 @@ class ConceptWorker:
         patterns = list(self.cfg.intake_channels)
         if self.cfg.wp_run_result_stream_enabled:
             patterns = [p for p in patterns if p != "orion:world_pulse:run:result"]
+        if self.cfg.homeostatic_drives_enabled:
+            # Specific organ/failure/health channels only (never the signals
+            # wildcard). Deduped against intake so we never subscribe twice.
+            for extra in self._homeostatic_channels():
+                if extra not in patterns:
+                    patterns.append(extra)
         return patterns
+
+    def _homeostatic_channels(self) -> List[str]:
+        return [
+            *self.cfg.homeostatic_signal_channels,
+            *self.cfg.homeostatic_failure_channels,
+        ]
+
+    def _homeostatic_source(self, intake_channel: str) -> Optional[str]:
+        """Classify a channel as a homeostatic source: 'signal' | 'failure', or
+        None if it is a normal concept-induction intake. Health degradation
+        arrives as a mesh_health OrionSignal on the 'signal' rail, so there is no
+        separate equilibrium branch."""
+        if intake_channel in self.cfg.homeostatic_signal_channels:
+            return "signal"
+        if intake_channel in self.cfg.homeostatic_failure_channels:
+            return "failure"
+        return None
 
     async def _dispatch_autonomy_episode_journal(
         self,
@@ -586,7 +610,123 @@ class ConceptWorker:
             feedback_frame=frame,
         )
 
+    def _parse_signal(self, env: BaseEnvelope) -> Optional[OrionSignalV1]:
+        try:
+            return OrionSignalV1.model_validate(self._payload_dict(env))
+        except Exception:
+            return None
+
+    async def _handle_signal_drive_tick(
+        self, env: BaseEnvelope, intake_channel: str, source: str
+    ) -> None:
+        """Thin drive-only rail for homeostatic sources: mint deviation tensions,
+        update + publish drive state/audit, and return. No concept induction, no
+        goals, no identity snapshot. Degrades to a no-op (never raises)."""
+        subject = "orion"
+        model_layer = model_layer_for_subject(subject)
+        entity_id = entity_id_for_subject(subject, model_layer)
+        now = datetime.now(timezone.utc)
+        now_mono = now.timestamp()
+
+        tensions: List[TensionEventV1] = []
+        try:
+            if source == "signal":
+                sig = self._parse_signal(env)
+                if sig is not None:
+                    tensions = self.signal_tension_source.from_signal(
+                        sig, now=now_mono, channel=intake_channel
+                    )
+            elif source == "failure":
+                tensions = self.signal_tension_source.from_failure(
+                    severity=self.cfg.homeostatic_failure_severity,
+                    now=now_mono,
+                    channel=intake_channel,
+                    correlation_id=str(env.correlation_id),
+                    summary=env.kind or "failure_event",
+                )
+        except Exception:
+            logger.warning(
+                "homeostatic_signal_tick_failed channel=%s source=%s",
+                intake_channel, source, exc_info=True,
+            )
+            return
+
+        if not tensions:
+            # No deviation this tick. The leaky integrator decays on wall-clock
+            # elapsed at the next update, so skipping here loses no decay.
+            return
+
+        for tension in tensions:
+            await self._publish_tension_event(tension, env.correlation_id)
+
+        prior = self.store.load_drive_state(subject)
+        previous_ts: Optional[datetime] = None
+        if isinstance(prior.get("updated_at"), str):
+            try:
+                previous_ts = datetime.fromisoformat(prior["updated_at"])
+            except ValueError:
+                previous_ts = None
+
+        pressures, activations = self.drive_engine.update(
+            previous_pressures=prior.get("pressures"),
+            previous_activations=prior.get("activations"),
+            tensions=tensions,
+            now=now,
+            previous_ts=previous_ts,
+        )
+        self.store.save_drive_state(
+            subject, pressures=pressures, activations=activations, updated_at=now
+        )
+
+        trace_id = extract_trace_id(env)
+        turn_id = extract_turn_id(env)
+        drive_state = drive_state_from_values(
+            subject=subject,
+            model_layer=model_layer,
+            entity_id=entity_id,
+            ts=now,
+            pressures=pressures,
+            activations=activations,
+            confidence=0.72,
+            correlation_id=str(env.correlation_id),
+            trace_id=trace_id,
+            turn_id=turn_id,
+            provenance=ArtifactProvenance(
+                intake_channel=intake_channel,
+                correlation_id=str(env.correlation_id),
+                trace_id=trace_id,
+                turn_id=turn_id,
+                tension_refs=[t.artifact_id for t in tensions],
+            ),
+            related_nodes=[f"subject:{subject}"] + [t.artifact_id for t in tensions],
+        )
+        await self._publish_drive_state(drive_state, env.correlation_id)
+
+        tick_attribution = compute_tick_attribution(tensions)
+        lead_tension = select_lead_tension(tensions)
+        dominant_drive = dominant_drive_from_attribution(
+            tick_attribution, lead_tension=lead_tension
+        )
+        drive_audit = build_drive_audit(
+            env=env,
+            intake_channel=intake_channel,
+            drive_state=drive_state,
+            tensions=tensions,
+            tick_attribution=tick_attribution,
+            dominant_drive=dominant_drive,
+        )
+        await self._publish_artifact(drive_audit, self.cfg.drive_audit_channel, env.correlation_id)
+
     async def handle_envelope(self, env: BaseEnvelope, intake_channel: str) -> None:
+        # Homeostatic sources ride a thin drive-only rail: they update drives and
+        # return BEFORE concept induction, so a 1/s biometrics tick never triggers
+        # windowing/induction. Gated on the flag; unmapped content mints nothing.
+        if self.cfg.homeostatic_drives_enabled:
+            source = self._homeostatic_source(intake_channel)
+            if source is not None:
+                await self._handle_signal_drive_tick(env, intake_channel, source)
+                return
+
         text = self._extract_text(env)
 
         if env.kind == "substrate.self_state.v1":

--- a/orion/spark/concept_induction/settings.py
+++ b/orion/spark/concept_induction/settings.py
@@ -142,6 +142,27 @@ class ConceptSettings(BaseSettings):
     signal_tension_impulse_k: float = Field(0.25, alias="SIGNAL_TENSION_IMPULSE_K")
     signal_tension_cap_per_window: int = Field(3, alias="SIGNAL_TENSION_CAP_PER_WINDOW")
     signal_tension_window_sec: int = Field(60, alias="SIGNAL_TENSION_WINDOW_SEC")
+    # Homeostatic consumer subscription: SPECIFIC organ/failure channels only —
+    # never the orion:signals:* wildcard, so the 55/s scene_state flood is
+    # excluded at the subscription. These route to a drive-only tick that does
+    # NOT trigger concept induction.
+    homeostatic_signal_channels: List[str] = Field(
+        default_factory=lambda: [
+            "orion:signals:biometrics",
+            "orion:signals:spark",
+            "orion:signals:equilibrium",
+        ],
+        validation_alias=AliasChoices("HOMEOSTATIC_SIGNAL_CHANNELS"),
+    )
+    homeostatic_failure_channels: List[str] = Field(
+        default_factory=lambda: [
+            "orion:system:error",
+            "orion:rdf:error",
+            "orion:vision:edge:error",
+        ],
+        validation_alias=AliasChoices("HOMEOSTATIC_FAILURE_CHANNELS"),
+    )
+    homeostatic_failure_severity: float = Field(0.8, alias="HOMEOSTATIC_FAILURE_SEVERITY")
     goal_proposal_cooldown_minutes: int = Field(180, alias="GOAL_PROPOSAL_COOLDOWN_MINUTES")
     goal_generation_mode: str = Field("evidence_rules", alias="GOAL_GENERATION_MODE")
     goal_drive_origin_source: str = Field("tick_attribution", alias="GOAL_DRIVE_ORIGIN_SOURCE")

--- a/orion/spark/concept_induction/tests/test_signal_drive_consumer.py
+++ b/orion/spark/concept_induction/tests/test_signal_drive_consumer.py
@@ -113,6 +113,28 @@ async def test_failure_channel_mints_tension() -> None:
 
 
 @pytest.mark.asyncio
+async def test_never_raises_when_drive_update_breaks() -> None:
+    """A bad prior state / store fault in the drive-update section must degrade to
+    a no-op, not tear down the bus loop (which re-raises)."""
+    worker = _worker()
+    # tz-naive updated_at is the concrete raise path the reviewer flagged.
+    worker.store.load_drive_state.return_value = {
+        "pressures": {}, "activations": {}, "updated_at": "2026-07-08T00:00:00",  # naive
+    }
+    worker.store.save_drive_state = MagicMock(side_effect=RuntimeError("store down"))
+    # Must not raise.
+    await worker.handle_envelope(
+        BaseEnvelope(
+            id=uuid4(), kind="system.error.v1", correlation_id=uuid4(),
+            created_at=datetime.now(timezone.utc),
+            source=ServiceRef(name="orion-x", version="0.1.0", node="athena"),
+            payload={"error": "boom"},
+        ),
+        "orion:system:error",
+    )
+
+
+@pytest.mark.asyncio
 async def test_disabled_flag_falls_through_to_concept_path(monkeypatch) -> None:
     monkeypatch.setenv("ORION_HOMEOSTATIC_DRIVES_ENABLED", "false")
     worker = ConceptWorker(ConceptSettings())

--- a/orion/spark/concept_induction/tests/test_signal_drive_consumer.py
+++ b/orion/spark/concept_induction/tests/test_signal_drive_consumer.py
@@ -1,0 +1,121 @@
+"""Task 6 live: homeostatic signal channels ride a drive-only rail.
+
+Asserts the worker (a) subscribes to the SPECIFIC organ/failure channels but not
+the scene_state wildcard, (b) classifies homeostatic sources, (c) updates + publishes
+drives from a real biometric drop WITHOUT triggering concept induction, and
+(d) does nothing for a steady/unmapped signal.
+"""
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.signals.models import OrganClass, OrionSignalV1
+from orion.spark.concept_induction.bus_worker import ConceptWorker
+from orion.spark.concept_induction.settings import ConceptSettings
+
+
+def _signal_env(kind: str, dims: dict, *, channel_kind: str = "signal.biometrics.biometrics_state") -> BaseEnvelope:
+    now = datetime.now(timezone.utc)
+    sig = OrionSignalV1(
+        signal_id=str(uuid4()), organ_id="biometrics", organ_class=OrganClass.exogenous,
+        signal_kind=kind, dimensions=dims, source_event_id="src-1",
+        observed_at=now, emitted_at=now,
+    )
+    return BaseEnvelope(
+        id=uuid4(), kind=channel_kind, correlation_id=uuid4(), created_at=now,
+        source=ServiceRef(name="orion-signal-gateway", version="0.1.0", node="athena"),
+        payload=sig.model_dump(mode="json"),
+    )
+
+
+def _worker() -> ConceptWorker:
+    worker = ConceptWorker(ConceptSettings())
+    worker.store = MagicMock()
+    worker.store.load_drive_state.return_value = {}
+    worker.store.save_drive_state = MagicMock()
+    worker._publish_tension_event = AsyncMock(return_value=None)
+    worker._publish_drive_state = AsyncMock(return_value=None)
+    worker._publish_artifact = AsyncMock(return_value=None)
+    return worker
+
+
+def test_pubsub_patterns_include_specific_channels_not_wildcard() -> None:
+    worker = _worker()
+    patterns = worker._pubsub_patterns()
+    assert "orion:signals:biometrics" in patterns
+    assert "orion:signals:spark" in patterns
+    assert "orion:system:error" in patterns
+    # The flood wildcard is NEVER subscribed.
+    assert "orion:signals:*" not in patterns
+    assert "orion:signals:vision" not in patterns
+
+
+def test_homeostatic_source_classification() -> None:
+    worker = _worker()
+    assert worker._homeostatic_source("orion:signals:biometrics") == "signal"
+    assert worker._homeostatic_source("orion:system:error") == "failure"
+    assert worker._homeostatic_source("orion:chat:history:log") is None
+
+
+@pytest.mark.asyncio
+async def test_real_biometric_drop_updates_drives_no_induction() -> None:
+    worker = _worker()
+    worker.inducer = MagicMock()
+    worker.inducer.run = AsyncMock()  # must NOT be called
+    worker._extract_text = MagicMock(side_effect=AssertionError("concept path must not run"))
+
+    # Warm the deviation baseline with steady hrv, then a real drop.
+    for _ in range(30):
+        await worker.handle_envelope(
+            _signal_env("biometrics_state", {"hrv_level": 0.8, "confidence": 0.9}),
+            "orion:signals:biometrics",
+        )
+    worker._publish_drive_state.reset_mock()
+    worker._publish_tension_event.reset_mock()
+    await worker.handle_envelope(
+        _signal_env("biometrics_state", {"hrv_level": 0.4, "confidence": 0.9}),
+        "orion:signals:biometrics",
+    )
+
+    assert worker._publish_tension_event.await_count >= 1
+    assert worker._publish_drive_state.await_count == 1
+    worker.store.save_drive_state.assert_called()
+    worker.inducer.run.assert_not_awaited()  # concept induction never triggered
+
+
+@pytest.mark.asyncio
+async def test_steady_signal_is_noop() -> None:
+    worker = _worker()
+    for _ in range(20):
+        await worker.handle_envelope(
+            _signal_env("biometrics_state", {"hrv_level": 0.8, "confidence": 0.9}),
+            "orion:signals:biometrics",
+        )
+    # Steady input past warm-up mints no tension and publishes no drive state.
+    assert worker._publish_drive_state.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_failure_channel_mints_tension() -> None:
+    worker = _worker()
+    err_env = BaseEnvelope(
+        id=uuid4(), kind="system.error.v1", correlation_id=uuid4(),
+        created_at=datetime.now(timezone.utc),
+        source=ServiceRef(name="orion-x", version="0.1.0", node="athena"),
+        payload={"error": "boom"},
+    )
+    await worker.handle_envelope(err_env, "orion:system:error")
+    assert worker._publish_tension_event.await_count >= 1
+    assert worker._publish_drive_state.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_disabled_flag_falls_through_to_concept_path(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_HOMEOSTATIC_DRIVES_ENABLED", "false")
+    worker = ConceptWorker(ConceptSettings())
+    assert worker._homeostatic_source is not None
+    # With the flag off, the signal channel is not added to patterns.
+    assert "orion:signals:biometrics" not in worker._pubsub_patterns()

--- a/services/orion-spark-concept-induction/.env_example
+++ b/services/orion-spark-concept-induction/.env_example
@@ -73,6 +73,13 @@ DEVIATION_SIGMA_FLOOR=0.02
 SIGNAL_TENSION_IMPULSE_K=0.25
 SIGNAL_TENSION_CAP_PER_WINDOW=3
 SIGNAL_TENSION_WINDOW_SEC=60
+# Homeostatic consumer subscription: SPECIFIC organ/failure channels only (never
+# the orion:signals:* wildcard, so the scene_state flood is excluded). These route
+# to a drive-only tick (no concept induction). Override with JSON arrays if needed;
+# defaults apply when unset:
+#   HOMEOSTATIC_SIGNAL_CHANNELS=["orion:signals:biometrics","orion:signals:spark","orion:signals:equilibrium"]
+#   HOMEOSTATIC_FAILURE_CHANNELS=["orion:system:error","orion:rdf:error","orion:vision:edge:error"]
+HOMEOSTATIC_FAILURE_SEVERITY=0.8
 GOAL_PROPOSAL_COOLDOWN_MINUTES=180
 GOAL_GENERATION_MODE=evidence_rules
 # tick_attribution | pressures (legacy) | audit_dominant (deprecated alias)


### PR DESCRIPTION
# PR: Homeostatic drives — live signal consumer (drive-only rail)

**Status:** IMPLEMENTED + reviewed. Completes Task 6 (live consumer) and Task 9
(review). Task 10 (host live-verify) is the remaining step and needs the running
host — instructions below.

## Summary

- Concept-induction worker now **subscribes to specific organ/failure channels**
  (`orion:signals:biometrics|spark|equilibrium`, `orion:system:error`,
  `orion:rdf:error`, `orion:vision:edge:error`) — **never** the `orion:signals:*`
  wildcard, so the 55/s `scene_state` flood is excluded at the subscription.
- Those envelopes route to a new **`_handle_signal_drive_tick`** — a thin
  drive-only rail: mint deviation/failure tensions → update + publish drive
  state/audit → **return before concept induction** (no windowing, goals, or
  identity snapshot on a ~1/s biometric tick).
- Health degradation arrives as a `mesh_health` `OrionSignal` on the signal rail
  (deviation-gated `level↓`); no separate unverified-shape `equilibrium:snapshot`
  branch was wired.
- Flag-gated on `ORION_HOMEOSTATIC_DRIVES_ENABLED`; degrades to a no-op, never
  raises into the bus loop.

## Outcome moved

The homeostatic substrate (merged in #879) is now **fed by real bus traffic**.
Before this PR the leaky-math engine only saw the existing spark/feedback/metabolism
tensions; now biometrics, spark, mesh-health, and system failures drive pressure
through the deviation gate — the "make it real, not tick-based" goal.

## Architecture touched

- `orion/spark/concept_induction/bus_worker.py` — `_handle_signal_drive_tick`,
  `_parse_signal`, `_homeostatic_source`, `_homeostatic_channels`,
  `_pubsub_patterns` (+homeostatic channels when enabled), `handle_envelope`
  early-return branch.
- `orion/spark/concept_induction/settings.py` — `homeostatic_signal_channels`,
  `homeostatic_failure_channels`, `homeostatic_failure_severity`.
- `services/orion-spark-concept-induction/.env_example`, `orion/bus/channels.yaml`.
- Tests: `orion/spark/concept_induction/tests/test_signal_drive_consumer.py`.

## Schema / bus / API changes

- No new schemas. Reuses `OrionSignalV1`, `TensionEventV1`, `SignalTensionSource`.
- Consumed channels are specific organ/failure channels (documented in channels.yaml).

## Env/config changes

- Added: `HOMEOSTATIC_SIGNAL_CHANNELS` / `HOMEOSTATIC_FAILURE_CHANNELS` (JSON list
  overrides; defaults apply), `HOMEOSTATIC_FAILURE_SEVERITY=0.8`.
- `.env_example` updated. Run `python scripts/sync_local_env_from_example.py` on
  the host post-merge (worktree has no local `.env`).

## Tests run

```text
pytest orion/spark/concept_induction/tests orion/autonomy/tests -q
261 passed  (incl. 7 new consumer tests: subscription/no-wildcard, source
classification, biometric-drop→drives-no-induction, steady=no-op, failure→tension,
flag-off fall-through, never-raise-on-broken-store)
```

## Review findings fixed (Task 9, subagent)

- **MAJOR** — `_handle_signal_drive_tick` drive-update/publish section was unwrapped;
  a tz-naive stored `updated_at` or store fault would raise into the bus loop
  (which re-raises) and tear down the subscription, contradicting the never-raise
  contract on a ~1/s rail.
  - Fix: wrapped the section in `try/except → log + return`; normalize
    `previous_ts` to tz-aware.
  - Evidence: new `test_never_raises_when_drive_update_breaks` (tz-naive state +
    `save_drive_state` raising → no exception). 261 tests green.
- **NIT** — channels.yaml comment read self-contradictory (service on the wildcard
  entry vs "never the wildcard"). Reworded to clarify registration vs runtime
  subscription.
- **NIT** — flag defaults ON: intended (Juniper authorized flags-on).

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
```

## Task 10 — live host verification (remaining)

After restart, tap live for ~60s and confirm:
- `drive:audit` / drive_state shows **differentiated, non-pinned** pressures that
  move with biometrics/mesh-health/failures and decay toward ~0 in quiet windows
  (NOT all six pinned at 0.7309).
- `orion:signals:vision` / scene_state flood mints **0** homeostatic tensions
  (channel never subscribed).
- `dominant_drive` reflects real events (not constant "autonomy"/None).

## Risks / concerns

- Severity: low — consumer degrades to no-op and is flag-gated; scene_state flood
  structurally excluded; 261 tests + subagent review clean.
- Live behavior against the real 55/s reality is unverified until Task 10 on host.

## PR link

<to be filled by `gh pr create` / GitHub UI>
