### PR TITLE
Feat/journal consolidate world pulse episode

### DIFF
--- a/orion/journaler/worker.py
+++ b/orion/journaler/worker.py
@@ -207,6 +207,21 @@ def build_world_pulse_prompt_seed(result: WorldPulseRunResultV1) -> str:
             parts.append("worth_reading:")
             for reading in digest.things_worth_reading[:5]:
                 parts.append(f"  - {reading.title}")
+        if digest.curiosity_followups:
+            # Fold the autonomy gap-fill ("Orion went looking") into this single
+            # world-pulse journal so it narrates both the news read AND what Orion
+            # chased on its own. This is why the standalone autonomy_episode journal
+            # is retired (ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED=false) — one run,
+            # one grounded journal, one email.
+            parts.append("orion_went_looking (autonomy gap-fill — gaps our sources missed):")
+            for followup in digest.curiosity_followups[:6]:
+                label = followup.section.replace("_", " ")
+                parts.append(f'  - {label} — gap={followup.driving_gap} query="{followup.query}"')
+                if not followup.articles:
+                    parts.append("    (looked, found nothing)")
+                for art in followup.articles[:4]:
+                    title = art.title or "(untitled)"
+                    parts.append(f"    - [{art.salience:.2f}] {title} — {art.url}")
     capsule = result.capsule
     if capsule is not None:
         for topic in capsule.salient_topics[:8]:

--- a/services/orion-spark-concept-induction/.env_example
+++ b/services/orion-spark-concept-induction/.env_example
@@ -112,7 +112,14 @@ ORION_EPISODE_FETCH_BACKEND=auto
 ORION_FCC_ENV_PATH=~/.fcc/.env
 # Optional direct key; otherwise resolved from ORION_FCC_ENV_PATH
 FIRECRAWL_API_KEY=
-ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED=true
+# Retired: the standalone autonomy-episode journal produced a SECOND daily email
+# (Source: autonomy_episode) that duplicated the world-pulse "daily news pulse".
+# The gap-fill / "Orion went looking" narrative is now folded into the single
+# world-pulse journal seed (orion/journaler/worker.py:build_world_pulse_prompt_seed),
+# so one world-pulse run = one grounded journal = one email. The substrate ACT
+# (Firecrawl gap-fill fetch) still runs; only the duplicate journal compose is off.
+# Flip back to true to re-enable the separate episode journal + its email.
+ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED=false
 # Journal compose LLM RPC budget (~16s observed); keep well above CORTEX_TIMEOUT_SEC.
 ORION_AUTONOMY_EPISODE_JOURNAL_TIMEOUT_SEC=120
 # Durable world-pulse run-result consumption (Redis Stream + consumer group). When

--- a/services/orion-thought/.env_example
+++ b/services/orion-thought/.env_example
@@ -61,13 +61,13 @@ ORION_ATTENTION_SALIENCE_WEIGHTS=
 # Salience trace telemetry channel — emitted per reverie tick when SALIENCE_V2 on.
 CHANNEL_ATTENTION_SALIENCE_TRACE=orion:attention:salience:trace
 
-# --- Mind stance enrichment (unified turn; default-off) ---
+# --- Mind stance enrichment (unified turn; enabled) ---
 # Run orion-mind before stance_react and inject an advisory self/attention
 # coloring into the verb context. Fail-open, flag-gated.
 # NOTE: This is a silent no-op unless orion-mind has MIND_LLM_SYNTHESIS_ENABLED=true
 # (that key lives on the orion-mind service, not here) AND orion-thought can reach
 # ORION_MIND_BASE_URL. Verify both operationally at rollout.
-ORION_THOUGHT_MIND_ENRICHMENT_ENABLED=false
+ORION_THOUGHT_MIND_ENRICHMENT_ENABLED=true
 ORION_MIND_BASE_URL=http://orion-mind:6611
 # Budget: orion-mind runs 3 sequential LLM phases (semantic → appraisal → stance),
 # each capped by MIND_LLM_TIMEOUT_SEC (default 25s, on the orion-mind service).
@@ -78,6 +78,6 @@ ORION_THOUGHT_MIND_TIMEOUT_SEC=100
 ORION_THOUGHT_MIND_WALL_MS=90000
 ORION_THOUGHT_MIND_ROUTER_PROFILE=default
 ORION_THOUGHT_MIND_MAX_RESPONSE_BYTES=2000000
-ORION_THOUGHT_MIND_ARTIFACT_PUBLISH_ENABLED=false
+ORION_THOUGHT_MIND_ARTIFACT_PUBLISH_ENABLED=true
 ORION_THOUGHT_MIND_COLORING_MAX_ITEMS=3
 CHANNEL_MIND_ARTIFACT=orion:mind:artifact

--- a/services/orion-world-pulse/.env_example
+++ b/services/orion-world-pulse/.env_example
@@ -16,8 +16,8 @@ WORLD_PULSE_FETCH_ENABLED=true
 WORLD_PULSE_CURIOSITY_FETCH_ENABLED=false
 WORLD_PULSE_CURIOSITY_MAX_ARTICLES_PER_SECTION=5
 WORLD_PULSE_CURIOSITY_MAX_SECTIONS=9
-# Capability gate for the readonly fetch above (billable). Off by default.
-ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED=false
+# Capability gate for the readonly fetch above (billable). Enabled by default.
+ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED=true
 # Fetch backend: "auto" uses Firecrawl when a key resolves, else the stub.
 ORION_EPISODE_FETCH_BACKEND=auto
 # Firecrawl key is NOT stored here. It is derived from the read-only FCC mount

--- a/tests/test_world_pulse_reflective_journal.py
+++ b/tests/test_world_pulse_reflective_journal.py
@@ -9,6 +9,8 @@ from orion.journaler import (
     journal_mode_for_trigger,
 )
 from orion.schemas.world_pulse import (
+    CuriosityFindingV1,
+    CuriosityFollowupV1,
     DailyWorldPulseItemV1,
     DailyWorldPulseSectionsV1,
     DailyWorldPulseV1,
@@ -18,7 +20,9 @@ from orion.schemas.world_pulse import (
 )
 
 
-def _sample_run_result(*, dry_run: bool = False) -> WorldPulseRunResultV1:
+def _sample_run_result(
+    *, dry_run: bool = False, curiosity_followups: list[CuriosityFollowupV1] | None = None
+) -> WorldPulseRunResultV1:
     run_id = "wp-run-1"
     now = datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc)
     digest = DailyWorldPulseV1(
@@ -45,6 +49,7 @@ def _sample_run_result(*, dry_run: bool = False) -> WorldPulseRunResultV1:
         section_rollups=[
             SectionRollupV1(section="infrastructure", status="covered", article_count=3, digest_item_count=1)
         ],
+        curiosity_followups=curiosity_followups or [],
         created_at=now,
     )
     return WorldPulseRunResultV1(
@@ -74,6 +79,55 @@ def test_world_pulse_cooldown_key_uses_run_id() -> None:
     trigger = build_world_pulse_reflective_trigger(_sample_run_result())
     key = cooldown_key_for_trigger(trigger)
     assert key == "actions:journal:world_pulse_digest:world_pulse:wp-run-1"
+
+
+def test_world_pulse_seed_folds_in_autonomy_gap_fill_when_present() -> None:
+    # Consolidation: the "Orion went looking" autonomy gap-fill narrative is folded
+    # into the single world-pulse journal seed so the standalone autonomy_episode
+    # journal (and its duplicate email) can be retired.
+    followups = [
+        CuriosityFollowupV1(
+            section="hardware_compute_gpu",
+            driving_gap="missing",
+            query="new datacenter GPU supply",
+            articles=[
+                CuriosityFindingV1(
+                    url="https://ex/1",
+                    title="Fab ramps output",
+                    description="capacity note",
+                    salience=0.71,
+                )
+            ],
+            action_id="goal-afe6211f",
+        )
+    ]
+    trigger = build_world_pulse_reflective_trigger(_sample_run_result(curiosity_followups=followups))
+    seed = trigger.prompt_seed or ""
+    assert "orion_went_looking" in seed
+    assert "hardware compute gpu" in seed
+    assert "new datacenter GPU supply" in seed
+    assert "Fab ramps output" in seed
+    assert "https://ex/1" in seed
+
+
+def test_world_pulse_seed_marks_empty_gap_fill_and_renders_salience() -> None:
+    followups = [
+        CuriosityFollowupV1(section="policy_regulation", driving_gap="no_articles", query="tariff rule", articles=[]),
+        CuriosityFollowupV1(
+            section="hardware_compute_gpu",
+            driving_gap="missing",
+            query="gpu supply",
+            articles=[CuriosityFindingV1(url="https://ex/2", title="Fab note", salience=0.5)],
+        ),
+    ]
+    seed = build_world_pulse_reflective_trigger(_sample_run_result(curiosity_followups=followups)).prompt_seed or ""
+    assert "(looked, found nothing)" in seed
+    assert "[0.50] Fab note" in seed
+
+
+def test_world_pulse_seed_omits_gap_fill_section_when_no_followups() -> None:
+    trigger = build_world_pulse_reflective_trigger(_sample_run_result())
+    assert "orion_went_looking" not in (trigger.prompt_seed or "")
 
 
 def test_world_pulse_compose_request_carries_trigger_metadata() -> None:


### PR DESCRIPTION
`gh` is still not authenticated, so I can't open the PR from here. Here's the full PR description covering both commits on `feat/journal-consolidate-world-pulse-episode` — copy-paste ready:

```markdown
## Summary

- One `world.pulse.run.result.v1` event was fanning out to **two** journal entries → **two** "Orion — Journal Pass" emails per run: `source_kind=world_pulse` (the daily news pulse) **and** `source_kind=autonomy_episode` (`goal-…`). That is the "journals are still disconnected" symptom.
- Fold the autonomy gap-fill ("Orion went looking") narrative into the **single** world-pulse journal compose seed (`build_world_pulse_prompt_seed`) from `digest.curiosity_followups`.
- Retire the standalone autonomy_episode journal dispatch by defaulting `ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED=false`. The substrate **act** (Firecrawl gap-fill fetch) still runs — only the duplicate journal compose/email dies.
- Also closes a `.env_example` drift gap: three enable-by-default flags whose live `.env` was `true` but whose committed example said `false`.
- Result: one world-pulse run = one grounded journal = one email that narrates both the news read and what Orion chased on its own.

## Outcome moved

Daily emails for a world-pulse run drop from 2 → 1, and the surviving journal now contains the "Orion went looking" content instead of it living in a separate, disconnected entry. `.env_example` parity restored so the sync script stops silently flipping live flags off.

## Current architecture (before)

`world.pulse.run.result.v1` →
- orion-actions `handle_world_pulse_run_result_journal` → `source_kind=world_pulse` journal write
- orion-spark-concept-induction `bus_worker.py` → `dispatch_autonomy_episode_journal` → `source_kind=autonomy_episode` journal write

Both → sql-writer → `journal.entry.created.v1` → orion-actions `_handle_journal_created` (`main.py:1629`) emails every entry not in the exclude list → two emails.

## Architecture touched

- `orion/journaler/worker.py::build_world_pulse_prompt_seed` — seed now carries an `orion_went_looking` section.
- concept-induction runtime flag `ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED` — default off (honored by `policy_act.py:309` and `capability_policy.py:99`; fetch/act preserved).
- `.env_example` operator contract aligned to live for three drifted flags.

## Files changed

- `orion/journaler/worker.py`: fold `digest.curiosity_followups` (section / driving_gap / query / articles+salience) into the world-pulse journal seed.
- `services/orion-spark-concept-induction/.env_example`: `ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED` `true` → `false` with rationale comment.
- `tests/test_world_pulse_reflective_journal.py`: 3 new tests (folds gap-fill when present, empty-followup + salience render, omits section when absent).
- `services/orion-world-pulse/.env_example`: `ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED` `false` → `true` (+ comment).
- `services/orion-thought/.env_example`: `ORION_THOUGHT_MIND_ENRICHMENT_ENABLED` and `ORION_THOUGHT_MIND_ARTIFACT_PUBLISH_ENABLED` `false` → `true` (+ comments).

## Schema / bus / API changes

- Added: none. Removed: none. Renamed: none.
- Behavior changed: world-pulse journal seed content now includes gap-fill narrative. No schema/channel/payload contract change (`curiosity_followups` already on `DailyWorldPulseV1`).

## Env/config changes

- Added keys: none. Removed keys: none. Renamed keys: none.
- Changed defaults:
  - `ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED` `true` → `false` (concept-induction)
  - `ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED` `false` → `true` (world-pulse)
  - `ORION_THOUGHT_MIND_ENRICHMENT_ENABLED` `false` → `true` (thought)
  - `ORION_THOUGHT_MIND_ARTIFACT_PUBLISH_ENABLED` `false` → `true` (thought)
- `.env_example` updated: yes. Local `.env` synced via `python scripts/sync_local_env_from_example.py`: yes (example == live for all four).
- Skipped keys requiring operator action: none.

## Tests run

```text
.venv/bin/python -m pytest tests/test_world_pulse_reflective_journal.py -q  -> 6 passed
.venv/bin/python -m pytest tests/test_journaler_worker.py tests/test_world_pulse_reflective_journal.py orion/journaler/tests/ orion/autonomy/tests/test_policy_act.py orion/autonomy/tests/test_policy_act_prefetched.py services/orion-spark-concept-induction/tests/test_curiosity_reuse_wiring.py -q
  -> 45 passed, 1 pre-existing failure
```

## Evals run

```text
No world-pulse-journal eval harness exists for this seam; covered by the new unit tests on build_world_pulse_prompt_seed. Follow-up: add a journal-compose eval asserting the merged seed produces a single grounded entry.
```

## Docker/build/smoke checks

```text
Not run — change is a prompt-seed edit + env default flips. Requires concept-induction restart to take effect (below).
```

## Review findings fixed

- Finding (minor): missing test for the empty-articles "(looked, found nothing)" branch + salience render.
  - Fix: added `test_world_pulse_seed_marks_empty_gap_fill_and_renders_salience`.
  - Evidence: `6 passed`.
- Reviewer confirmed no blocking/material issues; flag honored by both gates; article field names match the only other reader (`renderers.py`).

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml \
  up -d --force-recreate
```

## Risks / concerns

- Severity: low. Concern: `source_kind=autonomy_episode` journal entries stop being produced (in-app + persisted). Mitigation: "Orion Went Looking" content is preserved on the hub world-pulse digest (PR #880) and now inside the world-pulse journal; flip `ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED=true` to restore.
- Pre-existing test failures (NOT caused by this change; both fail with this diff stashed): `tests/test_journaler_worker.py::...test_draft_from_cortex_result_raises_structured_parse_error` and `services/orion-actions/tests/test_handle_envelope_world_pulse_journal.py::test_handle_envelope_routes_world_pulse_run_result_to_dispatch_journal`.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/journal-consolidate-world-pulse-episode
```

Once you run `gh auth login` (or set `GH_TOKEN`), I can open the PR with this body automatically — just say go.