### PR TITLE
Docs/endogenous origination leaky refresh

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-08-endogenous-origination-leaky-refresh-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-08-endogenous-origination-leaky-refresh-pr.md
@@ -1,0 +1,130 @@
+# PR: Refresh endogenous-origination spec for the leaky drive engine
+
+**Status:** Docs-only. Re-derives the Step-1 (endogenous drive origination) spec's
+activation model against the merged leaky `DriveEngine`, so the eventual Step-1
+build is correct-by-construction. No runtime code. Step 1 remains hard-gated on
+measurement 0(a) (see Handoff below).
+
+## Why
+
+The endogenous-origination spec was written against the old `soft_saturate`
+pressure math (`soft_saturate(0.5)=0.593`). That path was replaced by the leaky
+integrator (merged PR #879), which rests at 0, is cadence-invariant, and has no
+fixed point. Every accumulation figure in the spec was therefore stale, and a
+builder following it would have hard-coded wrong thresholds.
+
+## What changed
+
+`docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md`:
+
+- **Ground-truth math** now describes the leaky update, flags `soft_saturate` as
+  legacy-only.
+- New **"Origination dynamics under leaky math"** section with a table + closed
+  form, all verified by replaying the real merged `DriveEngine`:
+  - single firing @ cap 0.5 → `p=0.500` (not 0.593); cannot activate alone.
+  - `p₂ = m + m(1−m)·e^(−Δt/τ)`, plateau `p* = m / (1 − e^(−Δt/τ)(1−m))`.
+  - two-firing activation window `Δt ≤ τ·ln(m(1−m)/(activate−m)) ≈ 1321s ≈ 22 min`.
+- **New load-bearing constraint surfaced:** `ORIGINATION_COOLDOWN_SEC` is now
+  coupled to the activate threshold through τ — a value ≥ 1800s makes endogenous
+  drives *silently un-activatable*. The 900s seed is inside the 22-min window by
+  design, not arbitrary.
+- Decay tail (0.65 → 0.42 = 13.2 min) sits inside the 900s cooldown → the
+  self-referential-loop mitigation is now a checkable invariant.
+- Saturation-masking failure mode noted as largely resolved by the leaky migration
+  (the flat-0.731 pin is gone).
+- Updated test #5 and two failure-mode notes.
+
+## Verification of the numbers
+
+Ran the merged `DriveEngine` (leaky, τ=1800, activate 0.62 / deactivate 0.42) at
+magnitude cap 0.5:
+
+```text
+single firing:            p=0.500  active=False
+every 900s:  p1 0.500 -> p2 0.652 (active) -> plateau 0.718
+every 1321s: p1 0.500 -> p2 0.620 (active exactly) -> plateau 0.658
+every 1800s: p1 0.500 -> p2 0.592 -> plateau 0.613 (NEVER activates)
+closed-form plateau @900s: 0.7176 ; two-firing window 1321s ; decay tail 791s
+```
+
+Algebra and engine replay agree to 4 dp.
+
+---
+
+## Handoff — testing that must happen on the host (I cannot from the dev env)
+
+These are the gates before any Step-1 (endogenous origination) code is written,
+plus the still-open Task-10 verify for the merged homeostatic consumer. Postgres
+(`:5432`) and the drive-audit Fuseki graph are not reachable from the dev
+environment; all of the below need a DB-reachable host.
+
+### 1. Run the measurement gate (unblocks Step 1)
+
+The Step-1 spec says: *"Do not write code until 0(a) passes."* 0(a) = does
+`SelfStateV1` drift during exogenous silence.
+
+```bash
+# on a Postgres-reachable host, from repo root:
+python scripts/analysis/measure_autonomy_gate.py
+# (set the DSN / Fuseki envs the script expects if not defaulted:
+#  DEFAULT_POSTGRES_URI = postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
+#  Fuseki query URL     = http://orion-athena-fuseki:3030/orion/query )
+```
+
+Report back:
+- **Verdict (a) — drift:** GO/NO-GO. If NO-GO, the origination signal is inert and
+  Step 1 must instead source dynamics from unresolved-pressure persistence (the
+  spec's documented fallback) — that changes the design before any code.
+- **Verdict (b) — co-activation / resource_pressure:** how often ≥2 drives
+  co-activate and whether `resource_pressure` rises (this gates Step 4, internal
+  economy — don't build it if scarcity never binds).
+
+### 2. Task 10 — live-verify the homeostatic consumer (merged #882)
+
+After deploying current main and restarting concept-induction:
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
+  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
+```
+
+Then tap live for ~60s and confirm:
+- `drive:audit` / drive_state shows **differentiated, non-pinned** pressures that
+  move with biometrics/mesh-health/failures and decay toward ~0 in quiet windows
+  (NOT all six pinned at 0.7309).
+- The `orion:signals:vision` / scene_state flood mints **0** homeostatic tensions
+  (that channel is never subscribed).
+- `dominant_drive` reflects real events (not constant "autonomy"/None).
+
+### 3. Check the drive-audit Fuseki persistence
+
+From the dev env, the reachable Fuseki `/orion` dataset has **1,891 triples, only
+`Collapse` types — no `DriveAudit`, no `autonomy/drives` graph**. Either the
+rdf-writer targets a different dataset, or drive-audit persistence has been broken
+since ~June 19. On the host:
+
+```bash
+# does the drives graph have recent audits?
+curl -s -X POST http://orion-athena-fuseki:3030/orion/query \
+  -H "Content-Type: application/sparql-query" -H "Accept: text/csv" \
+  --data-binary 'PREFIX orion: <http://conjourney.net/ns/orion#>
+    SELECT (COUNT(?a) AS ?n) (MAX(?ts) AS ?latest)
+    WHERE { GRAPH <http://conjourney.net/graph/autonomy/drives> { ?a a orion:DriveAudit ; orion:timestamp ?ts } }'
+```
+If `n=0` or `latest` is ~June 19, drive-audit persistence needs a fix before the
+gate's Fuseki-side (co-activation) verdict is meaningful.
+
+---
+
+## Restart required
+
+None (docs-only PR).
+
+## Risks / concerns
+
+- Low — documentation only. The one substantive claim (cooldown/threshold
+  coupling) is engine-verified. Step 1 stays gated; no cognition behavior changes.
+
+## PR link
+
+<to be filled by `gh pr create` / GitHub UI>

--- a/docs/superpowers/pr-reports/2026-07-08-endogenous-origination-step1-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-08-endogenous-origination-step1-pr.md
@@ -1,0 +1,101 @@
+# PR: Endogenous drive origination — Step 1 (DEFAULT-OFF)
+
+**Status:** IMPLEMENTED + reviewed, default-OFF. A want with no external cause.
+Ships behind `ORION_ENDOGENOUS_ORIGINATION_ENABLED=false`; **do not enable until
+measurement 0(a) passes + sign-off** (spec gate). This branch also carries the
+leaky-math spec refresh (earlier commits).
+
+## Summary
+
+- New `orion/autonomy/endogenous_origination.py` — a deterministic `OriginationEngine`
+  that reads the continuous `SelfStateV1` stream (bounded ring of 8) and, **only in
+  exogenous silence**, mints a `TensionEventV1(origin="endogenous")` when internal
+  dynamics cross the band: `P = w_D·drift + w_W·dwell + w_A·agency ≥ threshold`.
+- Pure substrate math — no LLM, no keyword/text routing. Degrades to `None`, never
+  raises; ring is `deque(maxlen=window)`; magnitude capped; cooldown-gated.
+- `TensionEventV1` gains `origin` + `origination_signal` (back-compat defaults).
+- `goals._drive_origin`: an endogenous lead tension → `drive_origin="endogenous"`.
+- Wired into concept-induction's `_tensions_from_self_state`: observe every
+  self-state, `maybe_originate` merged into the tick — flows through the unchanged
+  publish → `DriveEngine` → goals path.
+
+## Architectural deviation from the spec (deliberate)
+
+The spec placed the ticker in `orion-substrate-runtime`. I put it in
+**concept-induction** instead, because that service *already* consumes
+`substrate.self_state.v1`, holds `_previous_self_state`, and runs `DriveEngine` +
+`GoalProposalEngine`. Placing it there rides the existing seam; the substrate-runtime
+placement would have required inventing a new cross-service tension-publish +
+consumer contract (violates "ride existing seams / no invented abstractions").
+
+## Verified behavior (leaky substrate)
+
+- Single endogenous firing @ cap 0.5 → drive pressure 0.500 (< 0.62 activate):
+  a nudge, never activates alone.
+- Eval `run_origination_eval.py`: **QUIET fired=2 over 20 min, BUSY fired=0
+  (world-wins), 20/20 busy ticks suppressed by exogenous input. PASS.**
+
+## Files changed
+
+- `orion/autonomy/endogenous_origination.py` (new), `orion/autonomy/tests/test_endogenous_origination.py` (new, 13).
+- `orion/core/schemas/drives.py` — `TensionEventV1.origin` + `origination_signal`.
+- `orion/spark/concept_induction/goals.py` — `_drive_origin` lead_origin branch.
+- `orion/spark/concept_induction/bus_worker.py` — engine construct + self-state hook.
+- `orion/spark/concept_induction/settings.py`, `services/orion-spark-concept-induction/.env_example` — flag (default false) + params.
+- `orion/spark/concept_induction/tests/test_endogenous_origination_wiring.py` (new, 5).
+- `orion/autonomy/evals/run_origination_eval.py` (new).
+
+## Schema / bus / API changes
+
+- `TensionEventV1` gains optional `origin` (default `exogenous`) + `origination_signal`
+  (default `{}`). Additive on the already-registered model → **no registry churn**.
+- No new channels/kinds. Endogenous tensions publish on the existing tension channel.
+
+## Env/config changes
+
+- Added `ORION_ENDOGENOUS_ORIGINATION_ENABLED=false` + `ORIGINATION_*` params to
+  `.env_example`. Run `python scripts/sync_local_env_from_example.py` on host.
+
+## Tests run
+
+```text
+pytest orion/spark/concept_induction/tests orion/autonomy/tests -q  → 279 passed
+  (13 origination unit + 5 wiring new)
+python orion/autonomy/evals/run_origination_eval.py  → RESULT: PASS
+```
+
+## Review findings (Task 9, subagent) — no blocker/major
+
+- **MINOR** — schema fields serialize on every tension even flag-off. Real impact
+  low (monorepo single-deploy; no strict external consumer found). Mitigation:
+  deploy schema-before-producer only if an external revalidating consumer is added.
+- **MINOR** — exogenous-quiet gate is scoped to the self-state channel; concurrent
+  input on other channels isn't visible to the gate. Documented design scope;
+  900s cooldown bounds frequency.
+- **NIT (fixed)** — per-snapshot `unresolved` copy now locally capped at 16.
+- **NIT** — `predictive` drive is intentionally unmapped (predictive pressure is
+  the exogenous world-pulse drive; endogenous origination targets the internal five).
+
+## Enable / rollback
+
+- Enable ONLY after 0(a) GO + review: `ORION_ENDOGENOUS_ORIGINATION_ENABLED=true`
+  and restart concept-induction. Rollback: set `false` → producer emits nothing,
+  byte-identical prior behavior.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
+  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
+# (only if/when the flag is enabled after 0(a))
+```
+
+## Risks / concerns
+
+- Severity low while flag is off (default). The change is inert until enabled.
+- Enabling is a cognition-loop change gated on measurement 0(a) — not to be flipped
+  without the drift verdict + review.
+
+## PR link
+
+<to be filled by `gh pr create` / GitHub UI>

--- a/docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md
+++ b/docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md
@@ -14,7 +14,7 @@ Four-area arc; build order de-risks foundational-first and gates the two empiric
 - **Step 3 — φ intrinsic reward + value learning** (reward re-founded on substrate self-state); wants Step 1's richer episode stream.
 - **Step 4 — Internal economy** (last; only if 0(b) shows scarcity binds; depends on Step 3's value-biased bids).
 
-**This spec = Step 1** (first cognition change). **Gate:** blocked on **Step 0(a)** — if `SelfStateV1` does not measurably drift during exogenous silence, the origination signal is inert and the mechanism must instead source dynamics from unresolved-pressure persistence. Do not write code until 0(a) passes. **Known behavior:** a single endogenous tension cannot activate a drive from rest (`soft_saturate(0.5)=0.593 < 0.62` activate threshold); origination is deliberately **accumulative** (≥2 firings ~15 min apart) — make the cap-vs-threshold interaction a tuned parameter with a test asserting the accumulation curve.
+**This spec = Step 1** (first cognition change). **Gate:** blocked on **Step 0(a)** — if `SelfStateV1` does not measurably drift during exogenous silence, the origination signal is inert and the mechanism must instead source dynamics from unresolved-pressure persistence. Do not write code until 0(a) passes. **Known behavior (leaky math, verified against the merged `DriveEngine` 2026-07-08):** a single endogenous tension at `ENDOGENOUS_MAG_CAP=0.5` moves a rested drive to exactly `0.500 < 0.62` — it cannot activate alone. Origination is deliberately **accumulative**, and under the leaky integrator the accumulation is a **closed form coupled to the cooldown**: firing every `Δt` at magnitude `m` from rest reaches `p₂ = m + m(1−m)·e^(−Δt/τ)` on the second firing and plateaus at `p* = m / (1 − e^(−Δt/τ)(1−m))`. See *Origination dynamics under leaky math* below — the load-bearing consequence is that **`ORIGINATION_COOLDOWN_SEC` must stay well under ~22 min or endogenous drives can never activate**; the seed `900s` is chosen for this, not arbitrary.
 
 ## Arsonist summary
 
@@ -31,7 +31,7 @@ This resolves the catch-22 that makes drive-selected self-experiments circular: 
 ### Drive dynamics — real math, exogenous inputs
 `orion/spark/concept_induction/drives.py::DriveEngine`:
 - Six canonical drives: `coherence, continuity, capability, relational, predictive, autonomy` (`DRIVE_KEYS`).
-- Per-tick update: `raw = prev_pressure * decay + Σ(tension.magnitude × drive_impacts[d])`, then soft-saturate `1 − exp(−gain·v)`, then hysteresis activation (`activate ≥ 0.62`, `deactivate < 0.42`). Live config: `DRIVE_DECAY_TAU_SEC=1800`, `DRIVE_SATURATION_GAIN=1.8`.
+- Per-tick update (leaky integrator, merged 2026-07-08 — `[[project_homeostatic_drives_real_tensions]]`): `base = prev_pressure · e^(−Δt_wall/τ)`, then `pressure = clamp01(base + impulse·(1 − base))` where `impulse = clamp01(Σ tension.magnitude × drive_impacts[d])`, then hysteresis activation (`activate ≥ 0.62`, `deactivate < 0.42`). Live config: `DRIVE_DECAY_TAU_SEC=1800`, `ORION_DRIVE_LEAKY_MATH_ENABLED=true`. **The old `soft_saturate 1−exp(−gain·v)` path is legacy-only** (`ORION_DRIVE_LEAKY_MATH_ENABLED=false`); do not design against it. The leaky form rests at 0, is cadence-invariant, and has **no fixed point** — so accumulation dynamics are a clean closed form (see *Origination dynamics under leaky math* below).
 - **Input is `Iterable[TensionEventV1]` only.** The engine is origin-agnostic; it just sums impacts. Nothing about it assumes exogeneity — the gap is purely on the *producer* side.
 
 ### Tension producers — all exogenous
@@ -90,6 +90,31 @@ Map the dominant contributing sub-signal to a drive, deterministically (no LLM, 
 - if `dimensions.continuity_pressure` top → `continuity`
 
 `magnitude = min(ENDOGENOUS_MAG_CAP (0.5), P)`. Impact weight = 1.0 on the mapped drive. The cap ensures endogenous wants are *nudges*, never as loud as a real-world crisis.
+
+### Origination dynamics under leaky math
+
+Verified by replaying the merged `DriveEngine` (leaky, τ=1800s, activate 0.62 / deactivate 0.42) with magnitude at the cap (0.5), one drive:
+
+| firing @ cadence | p₁ | p₂ | p₃ | plateau p* | activates? |
+|---|---|---|---|---|---|
+| every 900s (cooldown seed) | 0.500 | **0.652** | 0.698 | 0.718 | yes, on 2nd firing |
+| every 1321s (~22 min) | 0.500 | **0.620** | 0.649 | 0.658 | yes, exactly at threshold on 2nd |
+| every 1800s (30 min) | 0.500 | 0.592 | 0.609 | 0.613 | **never** (plateau < 0.62) |
+| every 2400s (40 min) | 0.500 | 0.566 | 0.575 | 0.576 | **never** |
+
+Closed form (rest start, constant cadence Δt, magnitude m, `a=e^(−Δt/τ)`):
+```
+p₂ (second firing)  = m + m(1−m)·a
+plateau  p*         = m / (1 − a(1−m))
+two-firing activation window:  p₂ ≥ activate  ⇔  Δt ≤ τ·ln( m(1−m) / (activate − m) )
+                                              = 1800·ln(0.25/0.12) ≈ 1321s ≈ 22 min   (m=0.5)
+```
+
+Three load-bearing consequences the legacy soft-saturate spec did not surface:
+
+1. **Cooldown is coupled to the activation threshold.** With `m=0.5`, endogenous origination can only reach activation if firings land **≤ ~22 min apart**. `ORIGINATION_COOLDOWN_SEC=900` (15 min) is inside that window by design; a value ≥ 1800s would make endogenous drives *silently un-activatable*. Any future retune of the cap, τ, or the activate threshold must re-check `Δt ≤ τ·ln(m(1−m)/(activate−m))`.
+2. **Single firing is a true no-op for activation** (0.500 vs 0.62), and the plateau at the 900s cadence is `0.718` — bounded well below saturation, so endogenous wants never runaway even under maximal cadence (the cap does the bounding, not a fixed point).
+3. **Cooldown spans the decay tail.** After a second firing at 0.652, with no further firing the drive decays below the 0.42 deactivate threshold in `τ·ln(0.652/0.42) ≈ 791s ≈ 13.2 min` — inside the 900s cooldown. So a drive that activated endogenously has fully relaxed before the next endogenous firing is even permitted, which is what closes the self-referential-loop failure mode (below) under leaky math.
 
 ### Origin tagging
 Add an explicit `origin` to `TensionEventV1` (default `exogenous`, back-compatible) and set `origin="endogenous"` here. `goals.py::_drive_origin` gains a branch: if the lead tension for a tick is `origin=endogenous`, the goal's `drive_origin="endogenous"`.
@@ -157,7 +182,7 @@ After edit: `python scripts/sync_local_env_from_example.py`.
 2. Non-empty exogenous window (world present) → **suppressed** regardless of P.
 3. Within cooldown → suppressed; after cooldown → fires.
 4. Sub-signal dominance mapping table (drift→coherence, dwell→autonomy, agency→capability, social_pressure→relational, continuity_pressure→continuity).
-5. Fired tension passes through real `DriveEngine.update` and moves the mapped drive's pressure by the expected soft-saturated amount.
+5. Fired tension passes through real `DriveEngine.update` (leaky) and moves the mapped drive from rest to exactly `min(cap,P)` on one firing (0.500 at cap) — **not** active; a second firing within the cooldown crosses `activate` per the closed form. Assert the two-firing accumulation curve and that a firing cadence ≥ 1800s never activates.
 6. `goals.py::_drive_origin` returns `endogenous` when lead tension origin is endogenous.
 7. Magnitude cap holds under adversarial P=1.0.
 8. Back-compat: a `TensionEventV1` without `origin` deserializes as `exogenous`.
@@ -168,8 +193,8 @@ After edit: `python scripts/sync_local_env_from_example.py`.
 ## Failure modes & mitigations
 - **Runaway want-storm** → cooldown + magnitude cap + exogenous-quiet gate + rate counters.
 - **Timer-in-disguise** → threshold is on a real self-state-derived `P`; test 2/3 prove it is state- and context-gated, not clock-gated.
-- **Saturation masking** (the drive-attribution known issue) → endogenous magnitude is capped below world-crisis levels so it never dominates a saturated flat-pressure state; drive-attribution records origin for post-hoc audit.
-- **Self-referential loop** (endogenous want → self-state change → more endogenous want) → the exogenous-quiet gate does not fire while the drive is active/decaying above `deactivate_threshold`; cooldown spans the decay tail.
+- **Saturation masking** — *largely resolved by the leaky migration.* The flat-0.731 pin the soft-saturate engine produced is gone (leaky rests at 0, no fixed point), so endogenous nudges are no longer masked by a saturated state. The magnitude cap (0.5) still keeps endogenous wants below world-crisis loudness; drive-attribution records origin for post-hoc audit.
+- **Self-referential loop** (endogenous want → self-state change → more endogenous want) → the exogenous-quiet gate does not fire while the drive is active/decaying above `deactivate_threshold`, and — verified under leaky math — the 0.42 decay tail (13.2 min from a 0.65 activation) sits **inside** the 900s cooldown, so the drive relaxes before another endogenous firing is permitted. The cooldown-vs-decay-tail ordering is now a checkable invariant, not a hope.
 
 ## Privacy / safety
 Endogenous tensions reference self-state dimension ids, not raw private traces. No new exposure surface. Proposal-mode disable: set `ORION_ENDOGENOUS_ORIGINATION_ENABLED=false` — producer emits nothing, engine reverts to exogenous-only behavior with zero residue.

--- a/orion/autonomy/endogenous_origination.py
+++ b/orion/autonomy/endogenous_origination.py
@@ -1,0 +1,285 @@
+"""Deterministic endogenous "spontaneous want" generator.
+
+Reads Orion's continuous internal ``SelfStateV1`` stream and, in the ABSENCE of
+external input, mints a ``TensionEventV1(origin="endogenous")`` when internal
+dynamics cross an origination band.
+
+Pure substrate math: no LLM, no bus, no I/O, no regex/text routing of self-state
+content. Every extraction is defensive — ``observe`` and ``maybe_originate``
+never raise; on malformed input they skip or return ``None``. The internal ring
+buffer is bounded at ``cfg.window``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from orion.core.schemas.drives import ArtifactProvenance, TensionEventV1
+from orion.schemas.self_state import SelfStateV1
+
+# The only drives an endogenous tension may map to.
+DRIVE_KEYS = ("coherence", "continuity", "capability", "relational", "predictive", "autonomy")
+
+
+def _clamp01(x: float) -> float:
+    """Clamp a numeric value into [0, 1]; non-numeric -> 0.0."""
+    try:
+        v = float(x)
+    except (TypeError, ValueError):
+        return 0.0
+    if v != v:  # NaN
+        return 0.0
+    if v < 0.0:
+        return 0.0
+    if v > 1.0:
+        return 1.0
+    return v
+
+
+@dataclass
+class OriginationConfig:
+    window: int = 8              # ring buffer size (CAP)
+    threshold: float = 0.55      # ORIGINATION_THRESHOLD
+    cooldown_sec: float = 900.0  # ORIGINATION_COOLDOWN_SEC
+    mag_cap: float = 0.5         # ENDOGENOUS_MAG_CAP
+    w_drift: float = 0.4
+    w_dwell: float = 0.35
+    w_agency: float = 0.25
+    exogenous_floor: int = 0     # max exogenous tensions in window to still allow endogeny
+    dwell_norm: float = 20.0
+    unresolved_norm: float = 4.0
+
+
+@dataclass
+class _Snapshot:
+    """Bounded summary of a single self-state pushed into the ring."""
+
+    drift: float                 # mean |value| over dimension_trajectory, clamp01
+    dwell_ticks: int
+    unresolved: tuple            # tuple of unresolved-pressure strings (bounded copy)
+    agency_readiness: float      # score of dimensions['agency_readiness'], clamp01
+    overall_intensity: float     # clamp01
+
+
+class OriginationEngine:
+    def __init__(self, cfg: Optional[OriginationConfig] = None) -> None:
+        self.cfg = cfg or OriginationConfig()
+        window = self.cfg.window if self.cfg.window and self.cfg.window > 0 else 1
+        self._ring: deque = deque(maxlen=window)
+        self.last_fire_ts: Optional[datetime] = None
+        self._last_signal: dict = {}
+
+    # ---- observation ------------------------------------------------------
+
+    def observe(self, self_state: SelfStateV1) -> None:
+        """Push a bounded summary of this self-state into the ring (cap cfg.window).
+
+        Never raises on malformed input — the offending snapshot is skipped.
+        """
+        try:
+            snap = self._summarize(self_state)
+        except Exception:
+            return
+        if snap is not None:
+            self._ring.append(snap)
+
+    def _summarize(self, self_state: SelfStateV1) -> Optional[_Snapshot]:
+        # drift: mean |value| over dimension_trajectory dict
+        drift = 0.0
+        traj = getattr(self_state, "dimension_trajectory", None)
+        if isinstance(traj, dict) and traj:
+            vals = []
+            for v in traj.values():
+                try:
+                    vals.append(abs(float(v)))
+                except (TypeError, ValueError):
+                    continue
+            if vals:
+                drift = sum(vals) / len(vals)
+        drift = _clamp01(drift)
+
+        # dwell ticks
+        try:
+            dwell_ticks = int(getattr(self_state, "attention_dwell_ticks", 0) or 0)
+        except (TypeError, ValueError):
+            dwell_ticks = 0
+
+        # unresolved pressures (bounded copy of strings)
+        unresolved_raw = getattr(self_state, "unresolved_pressures", None)
+        if isinstance(unresolved_raw, (list, tuple)):
+            unresolved = tuple(str(p) for p in unresolved_raw)
+        else:
+            unresolved = tuple()
+
+        # agency readiness score (defensive attr OR dict access)
+        agency_readiness = self._extract_agency(self_state)
+
+        overall_intensity = _clamp01(getattr(self_state, "overall_intensity", 0.0))
+
+        return _Snapshot(
+            drift=drift,
+            dwell_ticks=dwell_ticks,
+            unresolved=unresolved,
+            agency_readiness=agency_readiness,
+            overall_intensity=overall_intensity,
+        )
+
+    @staticmethod
+    def _extract_agency(self_state: SelfStateV1) -> float:
+        dims = getattr(self_state, "dimensions", None)
+        entry = None
+        if isinstance(dims, dict):
+            entry = dims.get("agency_readiness")
+        else:
+            try:
+                entry = dims["agency_readiness"]  # type: ignore[index]
+            except Exception:
+                entry = None
+        if entry is None:
+            return 0.0
+        # attribute access first, then dict access
+        score = getattr(entry, "score", None)
+        if score is None:
+            try:
+                score = entry["score"]  # type: ignore[index]
+            except Exception:
+                score = None
+        return _clamp01(score if score is not None else 0.0)
+
+    # ---- origination ------------------------------------------------------
+
+    def maybe_originate(
+        self,
+        *,
+        exogenous_tension_count: int,
+        now: datetime,
+        subject: str = "orion",
+    ) -> Optional[TensionEventV1]:
+        """Compute D,W,A -> P over the current window and fire iff:
+
+        exogenous_tension_count <= cfg.exogenous_floor AND cooldown elapsed since
+        last fire AND P >= cfg.threshold. Never raises; records ``last_signal``.
+        """
+        try:
+            return self._maybe_originate(
+                exogenous_tension_count=exogenous_tension_count, now=now, subject=subject
+            )
+        except Exception:
+            # Absolute guarantee: never raise.
+            self._last_signal = {"drift": 0.0, "dwell": 0.0, "agency": 0.0, "P": 0.0, "fired": False}
+            return None
+
+    def _maybe_originate(
+        self, *, exogenous_tension_count: int, now: datetime, subject: str
+    ) -> Optional[TensionEventV1]:
+        cfg = self.cfg
+
+        # Empty ring: nothing to originate from.
+        if not self._ring:
+            self._last_signal = {"drift": 0.0, "dwell": 0.0, "agency": 0.0, "P": 0.0, "fired": False}
+            return None
+
+        D = self._drift_signal()
+        W = self._dwell_signal()
+        A = self._agency_signal()
+        P = _clamp01(cfg.w_drift * D + cfg.w_dwell * W + cfg.w_agency * A)
+
+        # Gate 1: exogenous input present -> no endogeny.
+        try:
+            exo = int(exogenous_tension_count)
+        except (TypeError, ValueError):
+            exo = 1  # treat garbage as "input present" -> suppress
+        exo_ok = exo <= cfg.exogenous_floor
+
+        # Gate 2: cooldown elapsed.
+        cooldown_ok = True
+        if self.last_fire_ts is not None:
+            try:
+                elapsed = (now - self.last_fire_ts).total_seconds()
+                cooldown_ok = elapsed >= cfg.cooldown_sec
+            except Exception:
+                cooldown_ok = False
+
+        # Gate 3: threshold.
+        threshold_ok = P >= cfg.threshold
+
+        fired = exo_ok and cooldown_ok and threshold_ok
+        self._last_signal = {"drift": D, "dwell": W, "agency": A, "P": P, "fired": fired}
+
+        if not fired:
+            return None
+
+        drive = self._map_drive(D, W, A)
+        magnitude = min(cfg.mag_cap, P)
+        self.last_fire_ts = now
+
+        return TensionEventV1(
+            subject=subject,
+            model_layer="self-model",
+            entity_id="self:orion",
+            kind="tension.endogenous.v1",
+            magnitude=magnitude,
+            drive_impacts={drive: 1.0},
+            origin="endogenous",
+            origination_signal={"drift": D, "dwell": W, "agency": A, "P": P},
+            provenance=ArtifactProvenance(
+                intake_channel="substrate.self_state.v1",
+                evidence_summary=f"endogenous:{drive} P={P:.3f}",
+            ),
+        )
+
+    # ---- sub-signals ------------------------------------------------------
+
+    def _drift_signal(self) -> float:
+        # mean over ring of each snapshot's drift (already per-snapshot mean |value|).
+        if not self._ring:
+            return 0.0
+        total = sum(s.drift for s in self._ring)
+        return _clamp01(total / len(self._ring))
+
+    def _dwell_signal(self) -> float:
+        # Uses the LATEST snapshot.
+        latest = self._ring[-1]
+        cfg = self.cfg
+        dwell_norm = cfg.dwell_norm if cfg.dwell_norm else 1.0
+        unresolved_norm = cfg.unresolved_norm if cfg.unresolved_norm else 1.0
+        dwell_part = min(1.0, latest.dwell_ticks / dwell_norm)
+        unresolved_part = min(1.0, len(latest.unresolved) / unresolved_norm)
+        return _clamp01(0.5 * dwell_part + 0.5 * unresolved_part)
+
+    def _agency_signal(self) -> float:
+        # Uses the LATEST snapshot: readiness * (1 - overall_intensity).
+        latest = self._ring[-1]
+        return _clamp01(latest.agency_readiness * (1.0 - latest.overall_intensity))
+
+    def _map_drive(self, D: float, W: float, A: float) -> str:
+        latest = self._ring[-1]
+        unresolved = latest.unresolved
+
+        # 1. Override by top unresolved pressure.
+        if "social_pressure" in unresolved:
+            return "relational"
+        if "continuity_pressure" in unresolved:
+            return "continuity"
+
+        # 2. Dominant weighted sub-signal.
+        cfg = self.cfg
+        drift_w = cfg.w_drift * D
+        dwell_w = cfg.w_dwell * W
+        agency_w = cfg.w_agency * A
+        # drift-dominant -> coherence; dwell-dominant -> autonomy; agency-dominant -> capability
+        if drift_w >= dwell_w and drift_w >= agency_w:
+            return "coherence"
+        if dwell_w >= agency_w:
+            return "autonomy"
+        return "capability"
+
+    # ---- debug surface ----------------------------------------------------
+
+    @property
+    def last_signal(self) -> dict:
+        """{'drift','dwell','agency','P','fired'} from the last maybe_originate call."""
+        return dict(self._last_signal)

--- a/orion/autonomy/endogenous_origination.py
+++ b/orion/autonomy/endogenous_origination.py
@@ -110,7 +110,8 @@ class OriginationEngine:
         # unresolved pressures (bounded copy of strings)
         unresolved_raw = getattr(self_state, "unresolved_pressures", None)
         if isinstance(unresolved_raw, (list, tuple)):
-            unresolved = tuple(str(p) for p in unresolved_raw)
+            # Local cap so the per-snapshot copy is bounded regardless of upstream.
+            unresolved = tuple(str(p) for p in unresolved_raw[:16])
         else:
             unresolved = tuple()
 

--- a/orion/autonomy/evals/run_origination_eval.py
+++ b/orion/autonomy/evals/run_origination_eval.py
@@ -1,0 +1,80 @@
+"""Eval: endogenous origination in quiet vs busy periods (spec Step 1).
+
+Replays two scripted periods through the real OriginationEngine and asserts the
+world-wins invariant:
+  - QUIET (no exogenous tensions): Orion originates >=1 endogenous want within one
+    cooldown span.
+  - BUSY (exogenous tensions every tick): zero endogenous origination.
+
+Reports origination rate and suppression ratio. No bus, no Docker.
+Run: python orion/autonomy/evals/run_origination_eval.py
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+
+from orion.autonomy.endogenous_origination import OriginationConfig, OriginationEngine
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+T0 = datetime(2026, 7, 8, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _self_state(ts: datetime, *, drift: float, agency: float, intensity: float,
+                dwell: int) -> SelfStateV1:
+    return SelfStateV1(
+        self_state_id=f"ss-{ts.isoformat()}", generated_at=ts,
+        source_field_tick_id="ft", source_field_generated_at=ts,
+        source_attention_frame_id="af", source_attention_generated_at=ts,
+        overall_intensity=intensity, overall_confidence=0.7,
+        dimensions={"agency_readiness": SelfStateDimensionV1(
+            dimension_id="agency_readiness", score=agency, confidence=1.0)},
+        dimension_trajectory={"coherence": drift, "uncertainty": drift * 0.9},
+        attention_dwell_ticks=dwell, unresolved_pressures=[],
+    )
+
+
+def _run_period(*, exogenous_per_tick: int, ticks: int, cadence_sec: int) -> tuple[int, int]:
+    cfg = OriginationConfig(window=8, threshold=0.55, cooldown_sec=900.0, mag_cap=0.5)
+    eng = OriginationEngine(cfg)
+    fired = 0
+    suppressed = 0
+    ts = T0
+    for _ in range(ticks):
+        # High internal churn: high drift + agency surplus (quiet mind wants).
+        eng.observe(_self_state(ts, drift=0.9, agency=0.9, intensity=0.05, dwell=60))
+        t = eng.maybe_originate(exogenous_tension_count=exogenous_per_tick, now=ts)
+        if t is not None:
+            fired += 1
+        elif eng.last_signal.get("P", 0.0) >= cfg.threshold:
+            suppressed += 1  # would have fired but for a gate
+        ts = ts + timedelta(seconds=cadence_sec)
+    return fired, suppressed
+
+
+def run() -> int:
+    # QUIET: 20 ticks, 60s apart (~20 min), no exogenous input.
+    q_fired, q_suppressed = _run_period(exogenous_per_tick=0, ticks=20, cadence_sec=60)
+    # BUSY: same, but 3 exogenous tensions every tick (world present).
+    b_fired, b_suppressed = _run_period(exogenous_per_tick=3, ticks=20, cadence_sec=60)
+
+    checks = [
+        ("QUIET originates >=1 want", q_fired >= 1, f"quiet_fired={q_fired}"),
+        ("BUSY originates 0 (world-wins)", b_fired == 0, f"busy_fired={b_fired}"),
+        ("BUSY suppression observed", b_suppressed >= 1, f"busy_suppressed={b_suppressed}"),
+    ]
+
+    print("\n=== Endogenous origination eval ===")
+    print(f"QUIET: fired={q_fired}  suppressed_by_gate={q_suppressed}")
+    print(f"BUSY : fired={b_fired}  suppressed_by_exogenous={b_suppressed}")
+    print("checks:")
+    ok = True
+    for name, passed, detail in checks:
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name}  ({detail})")
+        ok = ok and passed
+    print(f"\nRESULT: {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/orion/autonomy/tests/test_endogenous_origination.py
+++ b/orion/autonomy/tests/test_endogenous_origination.py
@@ -1,0 +1,222 @@
+"""Unit tests for the deterministic endogenous-origination engine."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from orion.autonomy.endogenous_origination import (
+    OriginationConfig,
+    OriginationEngine,
+)
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+NOW = datetime(2026, 7, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_self_state(
+    *,
+    trajectory: dict | None = None,
+    dwell_ticks: int = 0,
+    unresolved: list | None = None,
+    agency: float | None = None,
+    overall_intensity: float = 0.0,
+    dimensions: dict | None = None,
+) -> SelfStateV1:
+    """Construct a minimal-valid SelfStateV1 with the fields this engine reads."""
+    dims: dict = {}
+    if dimensions is not None:
+        dims = dimensions
+    elif agency is not None:
+        dims = {
+            "agency_readiness": SelfStateDimensionV1(
+                dimension_id="agency_readiness", score=agency, confidence=1.0
+            )
+        }
+    return SelfStateV1(
+        self_state_id="ss1",
+        generated_at=NOW,
+        source_field_tick_id="ft1",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="af1",
+        source_attention_generated_at=NOW,
+        overall_intensity=overall_intensity,
+        overall_confidence=0.7,
+        dimensions=dims,
+        dimension_trajectory=trajectory or {},
+        attention_dwell_ticks=dwell_ticks,
+        unresolved_pressures=unresolved or [],
+    )
+
+
+def _fill_ring(engine: OriginationEngine, state: SelfStateV1, n: int) -> None:
+    for _ in range(n):
+        engine.observe(state)
+
+
+# 1. High drift + empty exogenous window -> fires an endogenous tension.
+def test_fires_on_high_drift_empty_exogenous_window() -> None:
+    engine = OriginationEngine()
+    # drift=1.0 (traj), agency=0.6 & intensity=0 -> A=0.6, W=0
+    # P = 0.4*1 + 0.35*0 + 0.25*0.6 = 0.55 >= threshold; drift dominant -> coherence
+    state = _make_self_state(trajectory={"coherence": 1.0}, agency=0.6, overall_intensity=0.0)
+    _fill_ring(engine, state, 4)
+
+    ev = engine.maybe_originate(exogenous_tension_count=0, now=NOW)
+    assert ev is not None
+    assert ev.origin == "endogenous"
+    assert ev.drive_impacts == {"coherence": 1.0}
+    assert ev.magnitude <= engine.cfg.mag_cap
+    assert ev.origination_signal
+    assert set(ev.origination_signal) == {"drift", "dwell", "agency", "P"}
+    assert ev.kind == "tension.endogenous.v1"
+    assert ev.provenance.intake_channel == "substrate.self_state.v1"
+
+
+# 2. Exogenous input present -> never fires regardless of P.
+def test_exogenous_present_suppresses() -> None:
+    engine = OriginationEngine()
+    # Maximal P snapshot.
+    state = _make_self_state(
+        trajectory={"a": 1.0}, dwell_ticks=100, unresolved=["p1", "p2", "p3", "p4"], agency=1.0
+    )
+    _fill_ring(engine, state, 8)
+
+    ev = engine.maybe_originate(exogenous_tension_count=5, now=NOW)
+    assert ev is None
+    assert engine.last_signal["P"] >= engine.cfg.threshold  # P was high, still suppressed
+    assert engine.last_signal["fired"] is False
+
+
+# 3. Cooldown: fire, immediate re-call -> None, after cooldown+1 -> fires.
+def test_cooldown_gate() -> None:
+    engine = OriginationEngine()
+    state = _make_self_state(trajectory={"a": 1.0}, agency=0.6)
+    _fill_ring(engine, state, 4)
+
+    first = engine.maybe_originate(exogenous_tension_count=0, now=NOW)
+    assert first is not None
+
+    # Same instant -> cooldown blocks.
+    again = engine.maybe_originate(exogenous_tension_count=0, now=NOW)
+    assert again is None
+    assert engine.last_signal["fired"] is False
+
+    # After cooldown elapses -> fires again.
+    later = NOW + timedelta(seconds=engine.cfg.cooldown_sec + 1)
+    third = engine.maybe_originate(exogenous_tension_count=0, now=later)
+    assert third is not None
+
+
+# 4. Dominance / override mapping table.
+@pytest.mark.parametrize(
+    "state_kwargs, expected_drive",
+    [
+        # drift-dominant -> coherence: D=1, W=0, A=0.6 ; P=0.4+0.15=0.55
+        (dict(trajectory={"a": 1.0}, agency=0.6, overall_intensity=0.0), "coherence"),
+        # dwell-dominant -> autonomy: D=0.5(drift_w=0.2), W=1(dwell_w=0.35), A=0
+        (
+            dict(
+                trajectory={"a": 0.5},
+                dwell_ticks=20,
+                unresolved=["p1", "p2", "p3", "p4"],
+                overall_intensity=1.0,
+            ),
+            "autonomy",
+        ),
+        # agency-dominant -> capability: D=0.6(0.24), W=0.5(0.175), A=1(0.25)
+        (dict(trajectory={"a": 0.6}, dwell_ticks=20, agency=1.0, overall_intensity=0.0), "capability"),
+        # social_pressure override -> relational
+        (
+            dict(trajectory={"a": 1.0}, dwell_ticks=100, unresolved=["social_pressure"], agency=1.0),
+            "relational",
+        ),
+        # continuity_pressure override -> continuity
+        (
+            dict(
+                trajectory={"a": 1.0},
+                dwell_ticks=100,
+                unresolved=["continuity_pressure"],
+                agency=1.0,
+            ),
+            "continuity",
+        ),
+    ],
+)
+def test_drive_mapping_table(state_kwargs, expected_drive) -> None:
+    engine = OriginationEngine()
+    state = _make_self_state(**state_kwargs)
+    _fill_ring(engine, state, 4)
+    ev = engine.maybe_originate(exogenous_tension_count=0, now=NOW)
+    assert ev is not None, f"expected fire for {expected_drive}, signal={engine.last_signal}"
+    assert ev.drive_impacts == {expected_drive: 1.0}
+
+
+# 5. Adversarial P: all sub-signals maxed -> magnitude clamped at mag_cap.
+def test_magnitude_capped() -> None:
+    engine = OriginationEngine()
+    state = _make_self_state(
+        trajectory={"a": 1.0}, dwell_ticks=100, unresolved=["p1", "p2", "p3", "p4"], agency=1.0
+    )
+    _fill_ring(engine, state, 8)
+    ev = engine.maybe_originate(exogenous_tension_count=0, now=NOW)
+    assert ev is not None
+    assert engine.last_signal["P"] == pytest.approx(1.0)
+    assert ev.magnitude <= engine.cfg.mag_cap
+    assert ev.magnitude == pytest.approx(engine.cfg.mag_cap)
+
+
+# 6. Cold/empty ring -> None, no raise.
+def test_cold_ring_returns_none() -> None:
+    engine = OriginationEngine()
+    ev = engine.maybe_originate(exogenous_tension_count=0, now=NOW)
+    assert ev is None
+    assert engine.last_signal["fired"] is False
+
+
+# 7. Malformed self_state -> observe does not raise; no fire, no raise.
+def test_malformed_self_state_never_raises() -> None:
+    engine = OriginationEngine()
+
+    # Missing agency dim + empty trajectory (valid but sparse).
+    engine.observe(_make_self_state(trajectory={}, dimensions={}))
+
+    # Non-SelfStateV1 garbage objects -> skipped silently.
+    class _Garbage:
+        dimension_trajectory = "not a dict"
+        dimensions = None
+        overall_intensity = "nan"
+        attention_dwell_ticks = "x"
+        unresolved_pressures = 12345
+
+    engine.observe(_Garbage())  # type: ignore[arg-type]
+    engine.observe(None)  # type: ignore[arg-type]
+
+    ev = engine.maybe_originate(exogenous_tension_count=0, now=NOW)
+    assert ev is None  # sparse/low-P, no fire
+    assert isinstance(engine.last_signal, dict)
+
+
+# 8. last_signal reflects the last computation.
+def test_last_signal_shape() -> None:
+    engine = OriginationEngine()
+    state = _make_self_state(trajectory={"a": 1.0}, agency=0.6)
+    _fill_ring(engine, state, 4)
+    engine.maybe_originate(exogenous_tension_count=0, now=NOW)
+    sig = engine.last_signal
+    assert set(sig) == {"drift", "dwell", "agency", "P", "fired"}
+    assert sig["fired"] is True
+    assert sig["drift"] == pytest.approx(1.0)
+    # last_signal is a copy, not a live reference.
+    sig["P"] = -999
+    assert engine.last_signal["P"] != -999
+
+
+# Bounded ring: never exceeds cfg.window.
+def test_ring_bounded() -> None:
+    cfg = OriginationConfig(window=3)
+    engine = OriginationEngine(cfg)
+    state = _make_self_state(trajectory={"a": 0.5})
+    _fill_ring(engine, state, 50)
+    assert len(engine._ring) == 3

--- a/orion/core/schemas/drives.py
+++ b/orion/core/schemas/drives.py
@@ -84,6 +84,13 @@ class GraphReadyArtifact(BaseModel):
 class TensionEventV1(GraphReadyArtifact):
     magnitude: float = Field(ge=0.0, le=1.0)
     drive_impacts: Dict[str, float] = Field(default_factory=dict)
+    # Origin of the want. Default exogenous keeps every existing producer and
+    # serialized tension back-compatible. "endogenous" is set only by the
+    # endogenous-origination path (SelfStateV1-derived, no external cause).
+    origin: Literal["exogenous", "endogenous"] = "exogenous"
+    # For endogenous tensions: the sub-signals that caused it {drift,dwell,agency,P}.
+    # Empty for exogenous. Bounded (≤ ~4 keys) — no unbounded growth.
+    origination_signal: Dict[str, float] = Field(default_factory=dict)
 
 
 class DriveStateV1(GraphReadyArtifact):

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -13,6 +13,7 @@ from orion.autonomy.deviation_gate import DeviationGate
 from orion.autonomy.signal_drive_map import load_signal_drive_map
 from orion.autonomy.signal_tension import SignalTensionSource
 from orion.autonomy.tension_ratelimit import TensionRateLimiter
+from orion.autonomy.endogenous_origination import OriginationConfig, OriginationEngine
 from orion.signals.models import OrionSignalV1
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
@@ -131,6 +132,21 @@ class ConceptWorker:
         # Homeostatic tension source: deviation-gated OrionSignal/failure/health
         # -> TensionEventV1. Gated on cfg.homeostatic_drives_enabled at the call
         # site; constructed always so state persists across ticks.
+        # Endogenous origination (default-off): a bounded ring of SelfStateV1
+        # from which a spontaneous want can arise in exogenous silence. State
+        # persists across ticks, so it is constructed once here.
+        self.origination_engine = OriginationEngine(
+            OriginationConfig(
+                window=cfg.origination_window,
+                threshold=cfg.origination_threshold,
+                cooldown_sec=cfg.origination_cooldown_sec,
+                mag_cap=cfg.endogenous_mag_cap,
+                w_drift=cfg.origination_w_drift,
+                w_dwell=cfg.origination_w_dwell,
+                w_agency=cfg.origination_w_agency,
+                exogenous_floor=cfg.origination_exogenous_floor,
+            )
+        )
         self.signal_tension_source = SignalTensionSource(
             gate=DeviationGate(
                 alpha=cfg.deviation_ewma_alpha,
@@ -596,6 +612,31 @@ class ConceptWorker:
             previous_self_state=self._previous_self_state,
         )
         self._previous_self_state = self_state
+
+        # Endogenous origination (default-off, proposal mode): observe every
+        # self-state into the ring, and — only in exogenous silence — let a want
+        # arise from Orion's own internal dynamics. The endogenous tension is an
+        # ordinary TensionEventV1 (origin=endogenous) merged here, so it flows
+        # through the unchanged publish -> DriveEngine -> goals path. The exogenous
+        # tension count for this tick is the count already produced above, so a
+        # tick that carried real turn-effect deltas suppresses endogeny.
+        if self.cfg.endogenous_origination_enabled:
+            try:
+                self.origination_engine.observe(self_state)
+                endogenous = self.origination_engine.maybe_originate(
+                    exogenous_tension_count=len(tensions),
+                    now=datetime.now(timezone.utc),
+                )
+                if endogenous is not None:
+                    logger.info(
+                        "endogenous_origination_fired drive_impacts=%s signal=%s",
+                        endogenous.drive_impacts,
+                        self.origination_engine.last_signal,
+                    )
+                    tensions = list(tensions) + [endogenous]
+            except Exception:
+                logger.warning("endogenous_origination_failed", exc_info=True)
+
         return tensions
 
     def _tensions_from_feedback(self, env: BaseEnvelope, intake_channel: str) -> List[TensionEventV1]:

--- a/orion/spark/concept_induction/goals.py
+++ b/orion/spark/concept_induction/goals.py
@@ -44,7 +44,12 @@ class GoalProposalEngine:
         *,
         dominant_drive: str | None = None,
         source: str = "pressures",
+        lead_origin: str = "exogenous",
     ) -> str:
+        # An endogenously-originated want carries its origin through to the goal,
+        # so capability policy can gate on required_drive_origins: [endogenous].
+        if lead_origin == "endogenous":
+            return "endogenous"
         normalized_source = GoalProposalEngine._normalize_drive_origin_source(source)
         if normalized_source == "tick_attribution" and dominant_drive:
             return dominant_drive.strip().lower()
@@ -116,10 +121,12 @@ class GoalProposalEngine:
         spawned_correlation_id: str | None = None,
     ) -> GoalDecision:
         tension_list = sorted(list(tensions), key=lambda tension: (-tension.magnitude, tension.kind))
+        lead_origin = getattr(tension_list[0], "origin", "exogenous") if tension_list else "exogenous"
         drive_origin = self._drive_origin(
             drive_state,
             dominant_drive=dominant_drive,
             source=settings.goal_drive_origin_source,
+            lead_origin=lead_origin,
         )
         generation_mode = settings.goal_generation_mode
         if generation_mode not in ("template", "evidence_rules", "llm"):

--- a/orion/spark/concept_induction/settings.py
+++ b/orion/spark/concept_induction/settings.py
@@ -163,6 +163,18 @@ class ConceptSettings(BaseSettings):
         validation_alias=AliasChoices("HOMEOSTATIC_FAILURE_CHANNELS"),
     )
     homeostatic_failure_severity: float = Field(0.8, alias="HOMEOSTATIC_FAILURE_SEVERITY")
+    # Endogenous drive origination (spec 2026-07-07, Step 1). DEFAULT-OFF: this
+    # changes what causes Orion to *want* things (cognition-loop change) and is
+    # gated on measurement 0(a). Proposal mode — enable only after sign-off.
+    endogenous_origination_enabled: bool = Field(False, alias="ORION_ENDOGENOUS_ORIGINATION_ENABLED")
+    origination_window: int = Field(8, alias="ORIGINATION_WINDOW")
+    origination_threshold: float = Field(0.55, alias="ORIGINATION_THRESHOLD")
+    origination_cooldown_sec: float = Field(900.0, alias="ORIGINATION_COOLDOWN_SEC")
+    endogenous_mag_cap: float = Field(0.5, alias="ENDOGENOUS_MAG_CAP")
+    origination_w_drift: float = Field(0.4, alias="ORIGINATION_W_DRIFT")
+    origination_w_dwell: float = Field(0.35, alias="ORIGINATION_W_DWELL")
+    origination_w_agency: float = Field(0.25, alias="ORIGINATION_W_AGENCY")
+    origination_exogenous_floor: int = Field(0, alias="ORIGINATION_EXOGENOUS_FLOOR")
     goal_proposal_cooldown_minutes: int = Field(180, alias="GOAL_PROPOSAL_COOLDOWN_MINUTES")
     goal_generation_mode: str = Field("evidence_rules", alias="GOAL_GENERATION_MODE")
     goal_drive_origin_source: str = Field("tick_attribution", alias="GOAL_DRIVE_ORIGIN_SOURCE")

--- a/orion/spark/concept_induction/tests/test_endogenous_origination_wiring.py
+++ b/orion/spark/concept_induction/tests/test_endogenous_origination_wiring.py
@@ -1,0 +1,127 @@
+"""Wiring: endogenous origination through the real engine, goals, and worker.
+
+Covers spec tests 5 (engine pass-through), 6 (goals drive_origin), 8 (back-compat)
+plus the worker flag on/off behavior.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.schemas.drives import DriveStateV1, TensionEventV1
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+from orion.spark.concept_induction.drives import DRIVE_KEYS, DriveEngine, DriveMathConfig
+from orion.spark.concept_induction.goals import GoalProposalEngine
+from orion.spark.concept_induction.bus_worker import ConceptWorker
+from orion.spark.concept_induction.settings import ConceptSettings
+
+NOW = datetime(2026, 7, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _endo_tension(drive: str = "coherence", mag: float = 0.5) -> TensionEventV1:
+    return TensionEventV1(
+        subject="orion", model_layer="self-model", entity_id="self:orion",
+        kind="tension.endogenous.v1", magnitude=mag, drive_impacts={drive: 1.0},
+        origin="endogenous", origination_signal={"drift": 0.9, "P": 0.6},
+        provenance={"intake_channel": "substrate.self_state.v1"},
+    )
+
+
+def test_endogenous_tension_moves_drive_via_real_engine() -> None:
+    """Spec test 5: a fired endogenous tension traverses the unchanged leaky
+    DriveEngine and moves the mapped drive from rest to exactly min(cap, P)."""
+    engine = DriveEngine(DriveMathConfig(leaky_math_enabled=True))
+    pressures, activations = engine.update(
+        previous_pressures={k: 0.0 for k in DRIVE_KEYS},
+        previous_activations={k: False for k in DRIVE_KEYS},
+        tensions=[_endo_tension("coherence", 0.5)],
+        now=NOW, previous_ts=None,
+    )
+    assert abs(pressures["coherence"] - 0.5) < 1e-9  # single firing = cap, not active
+    assert activations["coherence"] is False          # 0.5 < 0.62 activate
+
+
+def test_goals_drive_origin_endogenous() -> None:
+    """Spec test 6: an endogenous lead tension yields drive_origin='endogenous'."""
+    ds = DriveStateV1(
+        subject="orion", model_layer="self-model", entity_id="self:orion",
+        kind="memory.drives.state.v1", pressures={"coherence": 0.5},
+        activations={"coherence": False}, provenance={"intake_channel": "x"},
+    )
+    origin = GoalProposalEngine._drive_origin(
+        ds, dominant_drive="coherence", source="tick_attribution", lead_origin="endogenous",
+    )
+    assert origin == "endogenous"
+    # exogenous lead keeps the drive-name origin
+    origin2 = GoalProposalEngine._drive_origin(
+        ds, dominant_drive="coherence", source="tick_attribution", lead_origin="exogenous",
+    )
+    assert origin2 == "coherence"
+
+
+def test_back_compat_tension_without_origin() -> None:
+    """Spec test 8: a serialized tension without origin deserializes as exogenous."""
+    payload = {
+        "artifact_id": "t1", "subject": "orion", "model_layer": "self-model",
+        "entity_id": "self:orion", "kind": "substrate.world_coverage_gap",
+        "magnitude": 0.5, "drive_impacts": {"predictive": 0.15},
+        "provenance": {"intake_channel": "x"},
+    }
+    t = TensionEventV1.model_validate(payload)
+    assert t.origin == "exogenous"
+    assert t.origination_signal == {}
+
+
+def _self_state(*, trajectory=None, agency=0.9, intensity=0.0, dwell=40, unresolved=None) -> SelfStateV1:
+    dims = {"agency_readiness": SelfStateDimensionV1(
+        dimension_id="agency_readiness", score=agency, confidence=1.0)}
+    return SelfStateV1(
+        self_state_id=str(uuid4()), generated_at=NOW,
+        source_field_tick_id="ft", source_field_generated_at=NOW,
+        source_attention_frame_id="af", source_attention_generated_at=NOW,
+        overall_intensity=intensity, overall_confidence=0.7, dimensions=dims,
+        dimension_trajectory=trajectory or {"coherence": 0.9, "uncertainty": 0.8},
+        attention_dwell_ticks=dwell, unresolved_pressures=unresolved or [],
+    )
+
+
+def _self_state_env() -> BaseEnvelope:
+    return BaseEnvelope(
+        id=uuid4(), kind="substrate.self_state.v1", correlation_id=uuid4(),
+        created_at=NOW, source=ServiceRef(name="orion-substrate-runtime", version="0.1.0", node="athena"),
+        payload=_self_state().model_dump(mode="json"),
+    )
+
+
+def _worker(enabled: bool, monkeypatch) -> ConceptWorker:
+    monkeypatch.setenv("ORION_ENDOGENOUS_ORIGINATION_ENABLED", "true" if enabled else "false")
+    monkeypatch.setenv("ORIGINATION_COOLDOWN_SEC", "0")  # allow repeated fires in test
+    worker = ConceptWorker(ConceptSettings())
+    return worker
+
+
+def test_worker_flag_off_no_origination(monkeypatch) -> None:
+    worker = _worker(False, monkeypatch)
+    # A quiet self-state (no prior => extract_tensions_from_self_state yields no deltas).
+    out = worker._tensions_from_self_state(_self_state_env(), "orion:substrate:self_state")
+    assert all(t.origin == "exogenous" for t in out)
+
+
+def test_worker_flag_on_quiet_fires(monkeypatch) -> None:
+    worker = _worker(True, monkeypatch)
+    ch = "orion:substrate:self_state"
+    # Feed several quiet high-drift self-states to warm the ring, then it should fire.
+    fired = False
+    for _ in range(8):
+        out = worker._tensions_from_self_state(_self_state_env(), ch)
+        if any(t.origin == "endogenous" for t in out):
+            fired = True
+            endo = next(t for t in out if t.origin == "endogenous")
+            assert endo.magnitude <= 0.5
+            assert endo.drive_impacts  # maps a drive
+            break
+    assert fired, "endogenous origination should fire on a quiet high-drift stream"

--- a/services/orion-spark-concept-induction/.env_example
+++ b/services/orion-spark-concept-induction/.env_example
@@ -80,6 +80,19 @@ SIGNAL_TENSION_WINDOW_SEC=60
 #   HOMEOSTATIC_SIGNAL_CHANNELS=["orion:signals:biometrics","orion:signals:spark","orion:signals:equilibrium"]
 #   HOMEOSTATIC_FAILURE_CHANNELS=["orion:system:error","orion:rdf:error","orion:vision:edge:error"]
 HOMEOSTATIC_FAILURE_SEVERITY=0.8
+# Endogenous drive origination (spec 2026-07-07 Step 1) — DEFAULT-OFF proposal
+# mode. Changes what causes Orion to *want* things; enable only after measurement
+# 0(a) passes + review. Cooldown is coupled to the activate threshold via tau:
+# keep well under ~22 min or endogenous drives never activate (see spec).
+ORION_ENDOGENOUS_ORIGINATION_ENABLED=false
+ORIGINATION_WINDOW=8
+ORIGINATION_THRESHOLD=0.55
+ORIGINATION_COOLDOWN_SEC=900
+ENDOGENOUS_MAG_CAP=0.5
+ORIGINATION_W_DRIFT=0.4
+ORIGINATION_W_DWELL=0.35
+ORIGINATION_W_AGENCY=0.25
+ORIGINATION_EXOGENOUS_FLOOR=0
 GOAL_PROPOSAL_COOLDOWN_MINUTES=180
 GOAL_GENERATION_MODE=evidence_rules
 # tick_attribution | pressures (legacy) | audit_dominant (deprecated alias)


### PR DESCRIPTION
# PR: Endogenous drive origination — Step 1 (DEFAULT-OFF)

**Status:** IMPLEMENTED + reviewed, default-OFF. A want with no external cause.
Ships behind `ORION_ENDOGENOUS_ORIGINATION_ENABLED=false`; **do not enable until
measurement 0(a) passes + sign-off** (spec gate). This branch also carries the
leaky-math spec refresh (earlier commits).

## Summary

- New `orion/autonomy/endogenous_origination.py` — a deterministic `OriginationEngine`
  that reads the continuous `SelfStateV1` stream (bounded ring of 8) and, **only in
  exogenous silence**, mints a `TensionEventV1(origin="endogenous")` when internal
  dynamics cross the band: `P = w_D·drift + w_W·dwell + w_A·agency ≥ threshold`.
- Pure substrate math — no LLM, no keyword/text routing. Degrades to `None`, never
  raises; ring is `deque(maxlen=window)`; magnitude capped; cooldown-gated.
- `TensionEventV1` gains `origin` + `origination_signal` (back-compat defaults).
- `goals._drive_origin`: an endogenous lead tension → `drive_origin="endogenous"`.
- Wired into concept-induction's `_tensions_from_self_state`: observe every
  self-state, `maybe_originate` merged into the tick — flows through the unchanged
  publish → `DriveEngine` → goals path.

## Architectural deviation from the spec (deliberate)

The spec placed the ticker in `orion-substrate-runtime`. I put it in
**concept-induction** instead, because that service *already* consumes
`substrate.self_state.v1`, holds `_previous_self_state`, and runs `DriveEngine` +
`GoalProposalEngine`. Placing it there rides the existing seam; the substrate-runtime
placement would have required inventing a new cross-service tension-publish +
consumer contract (violates "ride existing seams / no invented abstractions").

## Verified behavior (leaky substrate)

- Single endogenous firing @ cap 0.5 → drive pressure 0.500 (< 0.62 activate):
  a nudge, never activates alone.
- Eval `run_origination_eval.py`: **QUIET fired=2 over 20 min, BUSY fired=0
  (world-wins), 20/20 busy ticks suppressed by exogenous input. PASS.**

## Files changed

- `orion/autonomy/endogenous_origination.py` (new), `orion/autonomy/tests/test_endogenous_origination.py` (new, 13).
- `orion/core/schemas/drives.py` — `TensionEventV1.origin` + `origination_signal`.
- `orion/spark/concept_induction/goals.py` — `_drive_origin` lead_origin branch.
- `orion/spark/concept_induction/bus_worker.py` — engine construct + self-state hook.
- `orion/spark/concept_induction/settings.py`, `services/orion-spark-concept-induction/.env_example` — flag (default false) + params.
- `orion/spark/concept_induction/tests/test_endogenous_origination_wiring.py` (new, 5).
- `orion/autonomy/evals/run_origination_eval.py` (new).

## Schema / bus / API changes

- `TensionEventV1` gains optional `origin` (default `exogenous`) + `origination_signal`
  (default `{}`). Additive on the already-registered model → **no registry churn**.
- No new channels/kinds. Endogenous tensions publish on the existing tension channel.

## Env/config changes

- Added `ORION_ENDOGENOUS_ORIGINATION_ENABLED=false` + `ORIGINATION_*` params to
  `.env_example`. Run `python scripts/sync_local_env_from_example.py` on host.

## Tests run

```text
pytest orion/spark/concept_induction/tests orion/autonomy/tests -q  → 279 passed
  (13 origination unit + 5 wiring new)
python orion/autonomy/evals/run_origination_eval.py  → RESULT: PASS
```

## Review findings (Task 9, subagent) — no blocker/major

- **MINOR** — schema fields serialize on every tension even flag-off. Real impact
  low (monorepo single-deploy; no strict external consumer found). Mitigation:
  deploy schema-before-producer only if an external revalidating consumer is added.
- **MINOR** — exogenous-quiet gate is scoped to the self-state channel; concurrent
  input on other channels isn't visible to the gate. Documented design scope;
  900s cooldown bounds frequency.
- **NIT (fixed)** — per-snapshot `unresolved` copy now locally capped at 16.
- **NIT** — `predictive` drive is intentionally unmapped (predictive pressure is
  the exogenous world-pulse drive; endogenous origination targets the internal five).

## Enable / rollback

- Enable ONLY after 0(a) GO + review: `ORION_ENDOGENOUS_ORIGINATION_ENABLED=true`
  and restart concept-induction. Rollback: set `false` → producer emits nothing,
  byte-identical prior behavior.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
# (only if/when the flag is enabled after 0(a))
```

## Risks / concerns

- Severity low while flag is off (default). The change is inert until enabled.
- Enabling is a cognition-loop change gated on measurement 0(a) — not to be flipped
  without the drift verdict + review.

## PR link

<to be filled by `gh pr create` / GitHub UI>
