### PR TITLE
fix(orion-hub): wire crystallizer embed host so Chroma projection lands

### DIFF
--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -220,7 +220,11 @@ FALKORDB_URI=
 
 # --- Memory crystallization projections ---
 CRYSTALLIZER_VECTOR_COLLECTION=orion_memory_crystallizations
-CRYSTALLIZER_EMBED_HOST_URL=
+# Embedding host for Chroma projection on approve. Empty = no embedding => vector-writer
+# skips the upsert (crystallizations never get semantically indexed). Point at orion-vector-host
+# /embedding. Hub compose is network_mode: host, so use 127.0.0.1:8320 (not the Docker DNS name).
+# In a bridge-network Hub, use http://orion-athena-vector-host:8320/embedding instead.
+CRYSTALLIZER_EMBED_HOST_URL=http://127.0.0.1:8320/embedding
 CRYSTALLIZER_EMBED_MODE=http
 CRYSTALLIZER_EMBED_TIMEOUT_MS=8000
 CRYSTALLIZER_AUTO_PROJECT_ON_APPROVE=true


### PR DESCRIPTION
Approved crystallizations projected with skipped:no_embedding because CRYSTALLIZER_EMBED_HOST_URL was empty (and mode=http never falls back to the bus path), so the emitted VectorDocumentUpsertV1 had no embedding and orion-vector-writer silently skipped it (REQUIRE_EMBEDDINGS=false).

Point the hub at the live orion-vector-host /embedding endpoint. Hub compose is network_mode: host, so 127.0.0.1:8320 (mirrors RECALL_PG_DSN 127.0.0.1 precedent), with a bridge-network alternative documented in the comment.

Verified end-to-end against the live stack: publish_crystallization_to_chroma embeds (1024-d BAAI/bge-large-en-v1.5), emits on orion:memory:vector:upsert, vector-writer consumes, and the doc is retrievable from Chroma collection orion_memory_crystallizations with its embedding metadata.