### PR TITLE
Feat/voluntary attention override

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-08-voluntary-attention-override-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-08-voluntary-attention-override-pr.md
@@ -1,0 +1,96 @@
+# PR: Voluntary attention override — Step 2 (DEFAULT-OFF)
+
+**Status:** IMPLEMENTED + reviewed, default-OFF. "Choosing to attend against your
+own salience." Ships behind `ORION_ATTENTION_TOPDOWN_ENABLED=false`; off = pure
+bottom-up, byte-identical to today. Not gated on the measurement (0(a)/0(b) gate
+only Steps 1 & 4) and independent of φ — the one arc rung buildable now.
+
+## Summary
+
+- **Top-down bias combiner** (`orion/substrate/attention/top_down.py`): an active
+  goal projects a bias `b(c) = priority × relevance(drive_origin, loop)` onto
+  attention candidates, competing with bottom-up salience under a bounded **effort
+  budget** (`combined = s + gain·applied_b`, `applied_b ≤ remaining_E`). Biased
+  competition (Desimone & Duncan), not override-by-fiat. Pure, never raises.
+- **Goal→attention wire** (the scope-doubler): `orion/substrate/attention/goal_context.py`
+  — a module-level active-goal store (`GoalProposalV1 → GoalContext`), mirroring
+  the existing `_recent_selected_counts` module-state pattern. The substrate had
+  **zero** goal references before this.
+- **Override trace**: when top-down flips the winner, `VoluntaryOverrideV1` records
+  what won, what it beat, both bottom-up scores, applied bias, effort spent — an
+  inspectable act of will (or a measured 0 if it never fires).
+- Layered onto `build_substrate_attention_frame` via `_apply_voluntary_attention`;
+  all 10+ callers unchanged.
+
+## Pre-build verification (before spawning)
+
+- All 5 cited seams confirmed current: `LinearSalienceCombiner`/`SEED_WEIGHTS`,
+  `OpenLoopV1` relevance fields, `scoring.py` populates them, the zero-goal-refs
+  gap is real, `attention_broadcast` exists.
+- Both in-flight attention branches (`computed-salience-actionable-attention`,
+  `attention-frame-v1`) are **already merged** — no collision.
+
+## Architecture / deviation
+
+Uses the goal-context **module store** (not a new param threaded through 10
+callers) to stay back-compatible, consistent with the file's existing module
+state. Real agency-readiness scaling is stubbed at 1.0 (frame builder has no
+self-state input) — a documented follow-on wire.
+
+## Contracts (all additive / back-compat)
+
+- `OpenLoopV1.top_down_bias`, `OpenLoopV1.combined_salience` (default 0.0).
+- `VoluntaryOverrideV1` (new, embedded — no new channel).
+- `AttentionFrameV1.voluntary_override` (None), `effort_budget_used` (0.0).
+- No registry churn (additive optional fields on already-registered models).
+
+## Env/config
+
+- `ORION_ATTENTION_TOPDOWN_ENABLED=false` + `ATTENTION_TOPDOWN_GAIN/EFFORT_MAX/
+  EFFORT_SCALE_BY_AGENCY/TOPDOWN_WEIGHTS_VERSION` in substrate-runtime `.env_example`.
+  Read via `os.getenv` (same pattern as the salience flags).
+
+## Tests / eval
+
+```text
+tests/test_top_down.py (10) + tests/test_voluntary_attention_wiring.py (8) → 18 passed
+regression (attention frame/schema/builder + substrate + relational) → 319 passed
+run_topdown_eval.py → PASS: override rate rises with priority (1.0), falls under
+  effort scarcity (0.0), strong bottom-up beats weak bias, no-goal→no-override.
+```
+
+## Review findings fixed (Task 9, subagent)
+
+- **MAJOR** — the goal store never cleared a terminal goal → a completed/failed
+  goal would bias attention forever. **Fixed**: clears when the held goal's
+  `artifact_id` goes terminal. Regression test added.
+- **MINOR** — top-down now gated on `salience_v2_enabled()` (its bottom-up basis
+  is `loop.salience`, the v2 output; with v2 off the override winner could
+  disagree with real selection).
+- **MINOR** — import block moved inside the never-raise `try`.
+- **MINOR** — override trace recorded only when the winner has an action to
+  re-point to (so `chosen_loop_id` can't disagree with `selected_action`).
+
+## Enable / rollback
+
+- Enable only after review: `ORION_ATTENTION_TOPDOWN_ENABLED=true` (+ verify with
+  `salience_v2` on) and restart substrate-runtime. Off → pure bottom-up, exact
+  current behavior.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
+# (only if/when the flag is enabled)
+```
+
+## Risks / concerns
+
+- Low while flag off (default). Inert until enabled.
+- Real agency-readiness scaling stubbed at 1.0 (follow-on); the goal store is a
+  latest-active-goal MVP proxy (a full priority-ranked live-goal set is a follow-on).
+
+## PR link
+
+<to be filled by `gh pr create` / GitHub UI>

--- a/orion/schemas/attention_frame.py
+++ b/orion/schemas/attention_frame.py
@@ -82,6 +82,27 @@ class OpenLoopV1(BaseModel):
     # remain populated for one deprecation release; new code reads these.
     salience: float = Field(default=0.0, ge=0.0, le=1.0)
     salience_features: dict[str, Any] = Field(default_factory=dict)
+    # Voluntary attention (additive, back-compatible). top_down_bias is the
+    # goal-derived bias applied to this loop; combined_salience = salience +
+    # gain·applied_bias. Both default 0.0 -> pure bottom-up when the feature is off.
+    top_down_bias: float = Field(default=0.0, ge=0.0, le=1.0)
+    combined_salience: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class VoluntaryOverrideV1(BaseModel):
+    """Recorded when top-down goal bias makes a lower-bottom-up loop win — an
+    inspectable act of volitional attention (Desimone & Duncan biased competition)."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    goal_artifact_id: str | None = None
+    goal_drive_origin: str | None = None
+    chosen_loop_id: str
+    beat_loop_id: str
+    chosen_bottom_up: float = Field(ge=0.0, le=1.0)
+    beat_bottom_up: float = Field(ge=0.0, le=1.0)
+    applied_bias: float = Field(ge=0.0, le=1.0)
+    effort_spent: float = Field(ge=0.0)
 
 
 class CuriosityCandidateActionV1(BaseModel):
@@ -131,6 +152,10 @@ class AttentionFrameV1(BaseModel):
     selected_action: CuriosityCandidateActionV1 | None = None
     suppressions: list[CuriositySuppressionV1] = Field(default_factory=list)
     deferred_items: list[str] = Field(default_factory=list)
+    # Voluntary attention (additive). Set when top-down goal bias flipped the
+    # winner; None when selection was pure bottom-up (default -> current behavior).
+    voluntary_override: VoluntaryOverrideV1 | None = None
+    effort_budget_used: float = Field(default=0.0, ge=0.0)
     debug: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("generated_at")

--- a/orion/substrate/attention/evals/run_topdown_eval.py
+++ b/orion/substrate/attention/evals/run_topdown_eval.py
@@ -1,0 +1,80 @@
+"""Eval: voluntary attention override dynamics (spec Step 2).
+
+Replays synthetic candidate sets through the real TopDownBiasCombiner and asserts:
+  (a) override rate RISES with goal priority,
+  (b) override rate FALLS as effort budget shrinks,
+  (c) a strongly-salient loop still wins over weak bias (bottom-up reasserts),
+  (d) no goal -> zero overrides (pure bottom-up).
+
+No bus, no Docker. Run: python orion/substrate/attention/evals/run_topdown_eval.py
+"""
+from __future__ import annotations
+
+import sys
+
+from orion.schemas.attention_frame import OpenLoopV1
+from orion.substrate.attention.top_down import (
+    GoalContext,
+    TopDownBiasCombiner,
+    TopDownConfig,
+)
+
+
+def _candidates(n: int) -> list[OpenLoopV1]:
+    # One dominant bottom-up loop + n aligned low-salience loops (predictive).
+    loops = [OpenLoopV1(id="dom", description="dominant", salience=0.75, predictive_value=0.0)]
+    for i in range(n):
+        loops.append(OpenLoopV1(id=f"g{i}", description=f"goal-aligned {i}",
+                                salience=0.30, predictive_value=0.9))
+    return loops
+
+
+def _override_rate(*, priority: float, effort_max: float, trials: int = 20) -> float:
+    combiner = TopDownBiasCombiner(TopDownConfig(gain=0.6, effort_max=effort_max))
+    goal = GoalContext(drive_origin="predictive", priority=priority, goal_artifact_id="g")
+    overrides = 0
+    for _ in range(trials):
+        loops = _candidates(3)
+        bottom_up = {l.id: l.salience for l in loops}
+        res = combiner.apply(goal=goal, loops=loops, bottom_up=bottom_up, agency_readiness=1.0)
+        if res.override is not None:
+            overrides += 1
+    return overrides / trials
+
+
+def run() -> int:
+    rate_hi = _override_rate(priority=0.9, effort_max=1.0)
+    rate_lo = _override_rate(priority=0.2, effort_max=1.0)
+    rate_starved = _override_rate(priority=0.9, effort_max=0.05)
+
+    # (c) strong bottom-up beats weak bias
+    combiner = TopDownBiasCombiner(TopDownConfig())
+    strong = [OpenLoopV1(id="dom", description="d", salience=0.98, predictive_value=0.0),
+              OpenLoopV1(id="g0", description="g", salience=0.30, predictive_value=0.9)]
+    strong_res = combiner.apply(goal=GoalContext("predictive", 0.3), loops=strong,
+                                bottom_up={"dom": 0.98, "g0": 0.30})
+    # (d) no goal -> no override
+    none_res = combiner.apply(goal=None, loops=strong, bottom_up={"dom": 0.98, "g0": 0.30})
+
+    checks = [
+        ("(a) override rate rises with priority", rate_hi > rate_lo, f"hi={rate_hi} lo={rate_lo}"),
+        ("(b) override rate falls under effort scarcity", rate_starved < rate_hi, f"starved={rate_starved} hi={rate_hi}"),
+        ("(c) strong bottom-up beats weak bias", strong_res.override is None, f"override={strong_res.override is not None}"),
+        ("(d) no goal -> no override", none_res.override is None, "override=None"),
+    ]
+
+    print("\n=== Voluntary attention override eval ===")
+    print(f"override rate  priority=0.9: {rate_hi:.2f}")
+    print(f"override rate  priority=0.2: {rate_lo:.2f}")
+    print(f"override rate  effort=0.05 : {rate_starved:.2f}")
+    print("checks:")
+    ok = True
+    for name, passed, detail in checks:
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name}  ({detail})")
+        ok = ok and passed
+    print(f"\nRESULT: {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/orion/substrate/attention/goal_context.py
+++ b/orion/substrate/attention/goal_context.py
@@ -1,0 +1,72 @@
+"""Goal → attention wire (spec 2026-07-07 Step 2, the scope-doubler).
+
+The substrate attention path has no goal awareness by design gap. This module is
+the minimal contract that lets an active ``GoalProposalV1`` reach the top-down
+bias combiner: a small module-level store holding the current active goal as a
+``GoalContext``, mirroring the existing module-level state pattern in
+``attention_broadcast`` (``_recent_selected_counts``).
+
+Populated by a consumer of the goal channel (``set_active_goal``); read by
+``build_substrate_attention_frame`` only when ``ORION_ATTENTION_TOPDOWN_ENABLED``.
+Never raises; when empty, attention is pure bottom-up (current behavior).
+
+MVP proxy: the store keeps the most-recent *active* goal (latest wins), carrying
+its priority for the bias magnitude. A full "highest-priority among all live
+goals" query needs a goal set with expiry — a documented follow-on.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from orion.core.schemas.drives import GoalProposalV1
+from orion.substrate.attention.top_down import GoalContext
+
+# proposal_status values (ProposalStatus literal) that count as an active want
+# worth biasing attention toward. Terminal/inactive states (superseded, archived,
+# completed, failed) are ignored.
+_ACTIVE_STATES = {"proposed", "active", "planned", "executing"}
+
+
+class GoalContextStore:
+    def __init__(self) -> None:
+        self._current: Optional[GoalContext] = None
+
+    def update_from_goal(self, goal: GoalProposalV1) -> None:
+        """Adopt this goal as the current active context (latest active wins).
+        Non-active statuses are ignored; malformed input is a no-op."""
+        try:
+            status = str(getattr(goal, "proposal_status", "proposed"))
+            if status not in _ACTIVE_STATES:
+                return
+            drive_origin = getattr(goal, "drive_origin", None)
+            if not drive_origin:
+                return
+            self._current = GoalContext(
+                drive_origin=str(drive_origin),
+                priority=max(0.0, min(1.0, float(getattr(goal, "priority", 0.0) or 0.0))),
+                goal_artifact_id=getattr(goal, "artifact_id", None),
+            )
+        except Exception:
+            return
+
+    def current(self) -> Optional[GoalContext]:
+        return self._current
+
+    def clear(self) -> None:
+        self._current = None
+
+
+# Module-level default store (see module docstring).
+_default_store = GoalContextStore()
+
+
+def set_active_goal(goal: GoalProposalV1) -> None:
+    _default_store.update_from_goal(goal)
+
+
+def get_active_goal() -> Optional[GoalContext]:
+    return _default_store.current()
+
+
+def clear_active_goal() -> None:
+    _default_store.clear()

--- a/orion/substrate/attention/goal_context.py
+++ b/orion/substrate/attention/goal_context.py
@@ -33,10 +33,18 @@ class GoalContextStore:
 
     def update_from_goal(self, goal: GoalProposalV1) -> None:
         """Adopt this goal as the current active context (latest active wins).
-        Non-active statuses are ignored; malformed input is a no-op."""
+
+        A terminal/inactive status for the *currently held* goal CLEARS the store
+        (so a completed/failed goal stops steering attention); other non-active
+        statuses are ignored. Malformed input is a no-op."""
         try:
             status = str(getattr(goal, "proposal_status", "proposed"))
+            artifact_id = getattr(goal, "artifact_id", None)
             if status not in _ACTIVE_STATES:
+                # If the goal that just went terminal is the one we're holding,
+                # clear it — otherwise it would bias attention forever.
+                if self._current is not None and self._current.goal_artifact_id == artifact_id:
+                    self._current = None
                 return
             drive_origin = getattr(goal, "drive_origin", None)
             if not drive_origin:
@@ -44,7 +52,7 @@ class GoalContextStore:
             self._current = GoalContext(
                 drive_origin=str(drive_origin),
                 priority=max(0.0, min(1.0, float(getattr(goal, "priority", 0.0) or 0.0))),
-                goal_artifact_id=getattr(goal, "artifact_id", None),
+                goal_artifact_id=artifact_id,
             )
         except Exception:
             return

--- a/orion/substrate/attention/top_down.py
+++ b/orion/substrate/attention/top_down.py
@@ -1,0 +1,287 @@
+"""Voluntary attention override (biased competition, Desimone & Duncan).
+
+An active goal projects a *top-down bias* onto attention candidates (open loops)
+and competes against bottom-up salience under a bounded *effort budget*. This is
+pure math: deterministic, no LLM, no bus, no I/O. It degrades to a no-op (pure
+bottom-up selection = current behavior) when there is no goal, and it NEVER
+raises — on any internal error it falls back to the pure-bottom-up result.
+
+Contract:
+
+    result = TopDownBiasCombiner(cfg).apply(
+        goal=GoalContext(...) | None,
+        loops=[OpenLoopV1, ...],
+        bottom_up={loop_id: salience_in_[0,1]},
+        agency_readiness=0.0..1.0,
+    )
+
+`bottom_up` maps loop.id -> salience in [0,1]; a loop missing from `bottom_up`
+is treated as 0.0. The winner is the argmax of the RAW combined salience
+(s + gain*applied_bias); an override is recorded only when top-down bias flips
+the winner away from the pure bottom-up winner (competition, not fiat).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from orion.schemas.attention_frame import OpenLoopV1, VoluntaryOverrideV1
+
+# Proposal-mode master switch + config env (mirrors salience.py flag pattern).
+TOPDOWN_FLAG = "ORION_ATTENTION_TOPDOWN_ENABLED"
+TOPDOWN_GAIN_ENV = "ATTENTION_TOPDOWN_GAIN"
+TOPDOWN_EFFORT_MAX_ENV = "ATTENTION_EFFORT_MAX"
+TOPDOWN_SCALE_BY_AGENCY_ENV = "ATTENTION_EFFORT_SCALE_BY_AGENCY"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def top_down_enabled() -> bool:
+    """Default OFF (proposal mode): voluntary attention is inert until enabled."""
+    return str(os.getenv(TOPDOWN_FLAG, "false")).strip().lower() in _TRUTHY
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, "").strip() or default)
+    except (TypeError, ValueError):
+        return default
+
+
+# Deterministic map: goal drive_origin -> aligned OpenLoopV1 relevance field.
+# Unknown / unmapped drive origins fall back to "concept_value".
+_RELEVANCE_FIELD_BY_DRIVE: dict[str, str] = {
+    "predictive": "predictive_value",
+    "relational": "relational_relevance",
+    "continuity": "continuity_relevance",
+    "autonomy": "autonomy_value",
+    "coherence": "concept_value",
+    "capability": "concept_value",
+}
+_RELEVANCE_FALLBACK_FIELD = "concept_value"
+
+
+def _clamp01(value: float) -> float:
+    """Clamp a value into [0, 1]. Treats non-finite/None as 0.0."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if v != v:  # NaN
+        return 0.0
+    if v < 0.0:
+        return 0.0
+    if v > 1.0:
+        return 1.0
+    return v
+
+
+@dataclass
+class TopDownConfig:
+    gain: float = 0.6           # ATTENTION_TOPDOWN_GAIN
+    effort_max: float = 1.0     # ATTENTION_EFFORT_MAX
+    scale_by_agency: bool = True
+
+    @classmethod
+    def from_env(cls) -> "TopDownConfig":
+        scale = str(os.getenv(TOPDOWN_SCALE_BY_AGENCY_ENV, "true")).strip().lower() in _TRUTHY
+        return cls(
+            gain=_env_float(TOPDOWN_GAIN_ENV, 0.6),
+            effort_max=_env_float(TOPDOWN_EFFORT_MAX_ENV, 1.0),
+            scale_by_agency=scale,
+        )
+
+
+@dataclass
+class GoalContext:
+    drive_origin: str
+    priority: float             # [0,1]
+    goal_artifact_id: Optional[str] = None
+
+
+@dataclass
+class LoopScore:
+    top_down_bias: float        # b(c) = priority * relevance
+    applied_bias: float         # min(b, remaining_effort) when this loop was processed
+    combined_salience: float    # clamp01(s + gain*applied_bias)
+
+
+@dataclass
+class TopDownResult:
+    per_loop: dict            # loop_id -> LoopScore
+    override: Optional[VoluntaryOverrideV1]
+    effort_used: float
+    winner_loop_id: Optional[str]   # argmax by RAW combined (s + gain*applied_bias)
+
+
+def relevance(goal: GoalContext, loop: OpenLoopV1) -> float:
+    """Map the goal's drive_origin to the aligned OpenLoopV1 relevance field.
+
+    Returns a value in [0,1]. Returns 0.0 if the field is missing/None. Unknown
+    drive origins fall back to ``concept_value`` (documented).
+    """
+    try:
+        field = _RELEVANCE_FIELD_BY_DRIVE.get(
+            getattr(goal, "drive_origin", None), _RELEVANCE_FALLBACK_FIELD
+        )
+        raw = getattr(loop, field, None)
+        if raw is None:
+            return 0.0
+        return _clamp01(raw)
+    except Exception:
+        return 0.0
+
+
+class TopDownBiasCombiner:
+    def __init__(self, cfg: Optional[TopDownConfig] = None) -> None:
+        self.cfg = cfg if cfg is not None else TopDownConfig()
+
+    def _bottom_up(self, bottom_up: dict[str, float], loop_id: str) -> float:
+        return _clamp01(bottom_up.get(loop_id, 0.0))
+
+    def _pure_bottom_up(
+        self, loops: list[OpenLoopV1], bottom_up: dict[str, float]
+    ) -> TopDownResult:
+        """Rule 1 result: no top-down bias applied anywhere."""
+        per_loop: dict[str, LoopScore] = {}
+        for loop in loops:
+            s = self._bottom_up(bottom_up, loop.id)
+            per_loop[loop.id] = LoopScore(
+                top_down_bias=0.0, applied_bias=0.0, combined_salience=s
+            )
+        winner = self._argmax_bottom_up(loops, bottom_up)
+        return TopDownResult(
+            per_loop=per_loop, override=None, effort_used=0.0, winner_loop_id=winner
+        )
+
+    def _argmax_bottom_up(
+        self, loops: list[OpenLoopV1], bottom_up: dict[str, float]
+    ) -> Optional[str]:
+        """argmax bottom_up salience; tie-break by loop id (ascending)."""
+        best_id: Optional[str] = None
+        best_s = float("-inf")
+        for loop in loops:
+            s = self._bottom_up(bottom_up, loop.id)
+            if s > best_s or (s == best_s and (best_id is None or loop.id < best_id)):
+                best_s = s
+                best_id = loop.id
+        return best_id
+
+    def apply(
+        self,
+        *,
+        goal: Optional[GoalContext],
+        loops: list[OpenLoopV1],
+        bottom_up: dict[str, float],
+        agency_readiness: float = 1.0,
+    ) -> TopDownResult:
+        try:
+            loops = list(loops or [])
+            bottom_up = bottom_up or {}
+
+            # Rule 1: no goal or no loops -> pure bottom-up.
+            if goal is None or not loops:
+                return self._pure_bottom_up(loops, bottom_up)
+
+            # Rule 2: effort budget.
+            agency = _clamp01(agency_readiness)
+            effort_max = float(self.cfg.effort_max)
+            E = effort_max * (agency if self.cfg.scale_by_agency else 1.0)
+            remaining_E = E
+            gain = float(self.cfg.gain)
+            priority = _clamp01(goal.priority)
+
+            # Rule 3: raw top-down bias per loop.
+            bias_by_id: dict[str, float] = {}
+            s_by_id: dict[str, float] = {}
+            for loop in loops:
+                s_by_id[loop.id] = self._bottom_up(bottom_up, loop.id)
+                bias_by_id[loop.id] = _clamp01(priority * relevance(goal, loop))
+
+            # Rule 4: iterate loops in DESCENDING b; tie-break bottom_up desc, then id asc.
+            order = sorted(
+                loops,
+                key=lambda lp: (-bias_by_id[lp.id], -s_by_id[lp.id], lp.id),
+            )
+            per_loop: dict[str, LoopScore] = {}
+            combined_raw_by_id: dict[str, float] = {}
+            for loop in order:
+                b = bias_by_id[loop.id]
+                applied = b if b < remaining_E else remaining_E
+                if applied < 0.0:
+                    applied = 0.0
+                remaining_E -= applied
+                s = s_by_id[loop.id]
+                combined_raw = s + gain * applied
+                combined_raw_by_id[loop.id] = combined_raw
+                per_loop[loop.id] = LoopScore(
+                    top_down_bias=b,
+                    applied_bias=applied,
+                    combined_salience=_clamp01(combined_raw),
+                )
+
+            # Rule 5: winners.
+            winner_bottom_up = self._argmax_bottom_up(loops, bottom_up)
+            winner_combined = self._argmax_combined(
+                loops, combined_raw_by_id, s_by_id
+            )
+
+            # Rule 7: total effort spent.
+            effort_used = sum(ls.applied_bias for ls in per_loop.values())
+
+            # Rule 6: override only when top-down flipped the winner.
+            override: Optional[VoluntaryOverrideV1] = None
+            if (
+                winner_combined is not None
+                and winner_bottom_up is not None
+                and winner_combined != winner_bottom_up
+            ):
+                override = VoluntaryOverrideV1(
+                    goal_artifact_id=goal.goal_artifact_id,
+                    goal_drive_origin=goal.drive_origin,
+                    chosen_loop_id=winner_combined,
+                    beat_loop_id=winner_bottom_up,
+                    chosen_bottom_up=s_by_id[winner_combined],
+                    beat_bottom_up=s_by_id[winner_bottom_up],
+                    applied_bias=per_loop[winner_combined].applied_bias,
+                    effort_spent=effort_used,
+                )
+
+            return TopDownResult(
+                per_loop=per_loop,
+                override=override,
+                effort_used=effort_used,
+                winner_loop_id=winner_combined,
+            )
+        except Exception:
+            # Rule 8: never raise. Fall back to pure bottom-up.
+            try:
+                return self._pure_bottom_up(list(loops or []), bottom_up or {})
+            except Exception:
+                return TopDownResult(
+                    per_loop={}, override=None, effort_used=0.0, winner_loop_id=None
+                )
+
+    def _argmax_combined(
+        self,
+        loops: list[OpenLoopV1],
+        combined_raw_by_id: dict[str, float],
+        s_by_id: dict[str, float],
+    ) -> Optional[str]:
+        """argmax combined_raw; tie-break bottom_up desc, then loop id asc."""
+        best_id: Optional[str] = None
+        best_key: Optional[tuple[float, float, str]] = None
+        for loop in loops:
+            c = combined_raw_by_id.get(loop.id, 0.0)
+            s = s_by_id.get(loop.id, 0.0)
+            # Higher combined, then higher bottom_up, then lower id wins.
+            if best_id is None:
+                best_id = loop.id
+                best_key = (c, s)
+                continue
+            assert best_key is not None
+            if (c, s) > best_key or ((c, s) == best_key and loop.id < best_id):
+                best_id = loop.id
+                best_key = (c, s)
+        return best_id

--- a/orion/substrate/attention_broadcast.py
+++ b/orion/substrate/attention_broadcast.py
@@ -15,6 +15,7 @@ action is taken from the broadcast (that is rung 5's governed territory).
 
 from __future__ import annotations
 
+import logging
 import os
 from collections import deque
 from datetime import datetime, timezone
@@ -184,7 +185,7 @@ def build_substrate_attention_frame(
         generic_reversal=False,
         stale_thread_active=False,
     )
-    return AttentionFrameV1(
+    frame = AttentionFrameV1(
         generated_at=now or datetime.now(timezone.utc),
         open_loops=open_loops,
         live_unknowns=[loop.description for loop in open_loops if not loop.already_known],
@@ -201,6 +202,61 @@ def build_substrate_attention_frame(
             "belief_lineage": lineage[:8],
         },
     )
+    return _apply_voluntary_attention(frame)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_voluntary_attention(
+    frame: AttentionFrameV1, agency_readiness: float = 1.0
+) -> AttentionFrameV1:
+    """Layer top-down goal bias onto the bottom-up frame (spec Step 2).
+
+    Default-off and never-raises: when the flag is off or there is no active goal,
+    the frame is returned byte-identical to bottom-up selection. When an active
+    goal flips the winner, fill each loop's top_down_bias/combined_salience,
+    re-point ``selected_action`` to the combined winner, and record the
+    ``voluntary_override`` trace.
+    """
+    from orion.substrate.attention.top_down import (
+        TopDownBiasCombiner,
+        TopDownConfig,
+        top_down_enabled,
+    )
+    from orion.substrate.attention.goal_context import get_active_goal
+
+    try:
+        if not top_down_enabled():
+            return frame
+        goal = get_active_goal()
+        if goal is None or not frame.open_loops:
+            return frame
+        bottom_up = {loop.id: float(loop.salience) for loop in frame.open_loops}
+        result = TopDownBiasCombiner(TopDownConfig.from_env()).apply(
+            goal=goal, loops=frame.open_loops, bottom_up=bottom_up,
+            agency_readiness=agency_readiness,
+        )
+        for loop in frame.open_loops:
+            score = result.per_loop.get(loop.id)
+            if score is not None:
+                loop.top_down_bias = score.top_down_bias
+                loop.combined_salience = score.combined_salience
+        frame.effort_budget_used = result.effort_used
+        if result.override is not None:
+            frame.voluntary_override = result.override
+            # Re-point the selected action to the combined winner when it has one.
+            winner = result.winner_loop_id
+            winner_action = next(
+                (a for a in frame.candidate_actions if getattr(a, "open_loop_id", None) == winner),
+                None,
+            )
+            if winner_action is not None:
+                frame.selected_action = winner_action
+        return frame
+    except Exception:
+        logger.warning("voluntary_attention_apply_failed", exc_info=True)
+        return frame
 
 
 def broadcast_projection_from_frame(frame: AttentionFrameV1) -> AttentionBroadcastProjectionV1:

--- a/orion/substrate/attention_broadcast.py
+++ b/orion/substrate/attention_broadcast.py
@@ -219,15 +219,22 @@ def _apply_voluntary_attention(
     re-point ``selected_action`` to the combined winner, and record the
     ``voluntary_override`` trace.
     """
-    from orion.substrate.attention.top_down import (
-        TopDownBiasCombiner,
-        TopDownConfig,
-        top_down_enabled,
-    )
-    from orion.substrate.attention.goal_context import get_active_goal
-
     try:
+        from orion.substrate.attention.top_down import (
+            TopDownBiasCombiner,
+            TopDownConfig,
+            top_down_enabled,
+        )
+        from orion.substrate.attention.goal_context import get_active_goal
+        from orion.substrate.attention.salience import salience_v2_enabled
+
         if not top_down_enabled():
+            return frame
+        # The bottom-up basis here is loop.salience (the v2 combined-salience
+        # output). With salience_v2 OFF, select_actions ranks by a legacy weighted
+        # sum, so our bottom-up winner could disagree with the real selection —
+        # only layer top-down when v2 is the active selection basis (spec target).
+        if not salience_v2_enabled():
             return frame
         goal = get_active_goal()
         if goal is None or not frame.open_loops:
@@ -244,14 +251,16 @@ def _apply_voluntary_attention(
                 loop.combined_salience = score.combined_salience
         frame.effort_budget_used = result.effort_used
         if result.override is not None:
-            frame.voluntary_override = result.override
-            # Re-point the selected action to the combined winner when it has one.
-            winner = result.winner_loop_id
+            # Only record the override when the winner actually has an action to
+            # re-point to — otherwise the frame would claim an override it can't
+            # enact (chosen_loop_id disagreeing with selected_action).
             winner_action = next(
-                (a for a in frame.candidate_actions if getattr(a, "open_loop_id", None) == winner),
+                (a for a in frame.candidate_actions
+                 if getattr(a, "open_loop_id", None) == result.winner_loop_id),
                 None,
             )
             if winner_action is not None:
+                frame.voluntary_override = result.override
                 frame.selected_action = winner_action
         return frame
     except Exception:

--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -118,6 +118,15 @@ ORION_ATTENTION_SALIENCE_V2_ENABLED=true
 ORION_ATTENTION_HABITUATION_ENABLED=true
 # Optional JSON override for combiner weights; empty = hand-seeded seed-v1.
 ORION_ATTENTION_SALIENCE_WEIGHTS=
+# Voluntary attention override (spec 2026-07-07 Step 2) — DEFAULT-OFF proposal
+# mode. Lets an active goal bias attention against bottom-up salience under a
+# bounded effort budget (biased competition). Enable only after review; off =
+# pure bottom-up, byte-identical to today.
+ORION_ATTENTION_TOPDOWN_ENABLED=false
+ATTENTION_TOPDOWN_GAIN=0.6
+ATTENTION_EFFORT_MAX=1.0
+ATTENTION_EFFORT_SCALE_BY_AGENCY=true
+ATTENTION_TOPDOWN_WEIGHTS_VERSION=seed-v1
 
 # --- Self-tab brain-EKG frame producer ---
 SUBSTRATE_BRAIN_FRAME_ENABLED=true

--- a/tests/test_top_down.py
+++ b/tests/test_top_down.py
@@ -1,0 +1,197 @@
+"""Unit tests for voluntary attention override (biased competition)."""
+
+from __future__ import annotations
+
+from orion.schemas.attention_frame import OpenLoopV1, VoluntaryOverrideV1
+from orion.substrate.attention.top_down import (
+    GoalContext,
+    LoopScore,
+    TopDownBiasCombiner,
+    TopDownConfig,
+    TopDownResult,
+    relevance,
+)
+
+
+def _loop(id: str, **relevance_fields: float) -> OpenLoopV1:
+    """Construct an OpenLoopV1 with the given id and relevance field overrides."""
+    return OpenLoopV1(id=id, description="d", **relevance_fields)
+
+
+def _all_bounded(res: TopDownResult) -> bool:
+    for ls in res.per_loop.values():
+        if not (0.0 <= ls.top_down_bias <= 1.0):
+            return False
+        if not (0.0 <= ls.combined_salience <= 1.0):
+            return False
+    return True
+
+
+def test_1_no_goal_is_pure_bottom_up():
+    loops = [_loop("a"), _loop("b"), _loop("c")]
+    bottom_up = {"a": 0.2, "b": 0.9, "c": 0.5}
+    res = TopDownBiasCombiner().apply(goal=None, loops=loops, bottom_up=bottom_up)
+
+    assert all(ls.top_down_bias == 0.0 for ls in res.per_loop.values())
+    assert res.winner_loop_id == "b"  # argmax bottom_up
+    assert res.override is None
+    assert res.effort_used == 0.0
+
+
+def test_2_goal_flips_low_salience_loop_to_winner():
+    # loop "hi" is the bottom-up winner; loop "goal" is low bottom-up but highly
+    # relevant to a predictive goal.
+    loops = [
+        _loop("hi", predictive_value=0.0),
+        _loop("goal", predictive_value=1.0),
+    ]
+    bottom_up = {"hi": 0.6, "goal": 0.1}
+    goal = GoalContext(drive_origin="predictive", priority=0.9, goal_artifact_id="g1")
+    res = TopDownBiasCombiner(TopDownConfig(gain=0.6, effort_max=1.0)).apply(
+        goal=goal, loops=loops, bottom_up=bottom_up
+    )
+
+    assert res.winner_loop_id == "goal"
+    assert res.override is not None
+    assert res.override.beat_loop_id == "hi"
+    assert res.override.chosen_loop_id == "goal"
+    assert res.override.goal_artifact_id == "g1"
+    assert res.override.goal_drive_origin == "predictive"
+
+
+def test_3_effort_budget_exhausted_second_loop_gets_zero():
+    loops = [
+        _loop("top", predictive_value=1.0),
+        _loop("second", predictive_value=0.9),
+    ]
+    bottom_up = {"top": 0.3, "second": 0.3}
+    goal = GoalContext(drive_origin="predictive", priority=1.0)
+    res = TopDownBiasCombiner(TopDownConfig(gain=0.6, effort_max=0.2)).apply(
+        goal=goal, loops=loops, bottom_up=bottom_up
+    )
+
+    assert res.per_loop["top"].applied_bias > 0.0
+    assert res.per_loop["second"].applied_bias == 0.0
+    # top-b loop's applied bias is capped by the small effort budget.
+    assert abs(res.per_loop["top"].applied_bias - 0.2) < 1e-9
+
+
+def test_4_strong_salience_beats_weak_goal_no_override():
+    loops = [
+        _loop("salient", predictive_value=0.0),
+        _loop("weak_goal", predictive_value=0.2),
+    ]
+    bottom_up = {"salient": 0.95, "weak_goal": 0.1}
+    # weak goal: low priority, small relevance -> small bias, cannot flip winner.
+    goal = GoalContext(drive_origin="predictive", priority=0.2)
+    res = TopDownBiasCombiner(TopDownConfig(gain=0.6, effort_max=1.0)).apply(
+        goal=goal, loops=loops, bottom_up=bottom_up
+    )
+
+    assert res.winner_loop_id == "salient"
+    assert res.override is None
+
+
+def test_5_relevance_mapping_table():
+    goal_and_field = [
+        ("predictive", "predictive_value"),
+        ("relational", "relational_relevance"),
+        ("continuity", "continuity_relevance"),
+        ("autonomy", "autonomy_value"),
+        ("coherence", "concept_value"),
+        ("capability", "concept_value"),
+    ]
+    for drive_origin, field in goal_and_field:
+        loop = _loop("x", **{field: 0.8})
+        goal = GoalContext(drive_origin=drive_origin, priority=1.0)
+        assert relevance(goal, loop) > 0.0, drive_origin
+        # A loop with that field zero (and others zero) reads 0.
+        zero_loop = _loop("y")
+        assert relevance(goal, zero_loop) == 0.0, drive_origin
+
+    # Unknown drive_origin falls back to concept_value.
+    unknown_goal = GoalContext(drive_origin="banana", priority=1.0)
+    loop = _loop("z", concept_value=0.7)
+    assert relevance(unknown_goal, loop) == 0.7
+    # ...and reads 0 when concept_value is 0 even if other fields are high.
+    other_high = _loop("w", predictive_value=1.0)
+    assert relevance(unknown_goal, other_high) == 0.0
+
+
+def test_6_agency_gates_effort():
+    loops = [
+        _loop("hi", predictive_value=0.0),
+        _loop("goal", predictive_value=1.0),
+    ]
+    bottom_up = {"hi": 0.6, "goal": 0.1}
+    goal = GoalContext(drive_origin="predictive", priority=0.9)
+    cfg = TopDownConfig(gain=0.6, effort_max=1.0, scale_by_agency=True)
+
+    # agency_readiness=0 -> E=0 -> no bias applied, no override.
+    res0 = TopDownBiasCombiner(cfg).apply(
+        goal=goal, loops=loops, bottom_up=bottom_up, agency_readiness=0.0
+    )
+    assert res0.effort_used == 0.0
+    assert all(ls.applied_bias == 0.0 for ls in res0.per_loop.values())
+    assert res0.override is None
+    assert res0.winner_loop_id == "hi"
+
+    # agency_readiness=1 -> full effort -> override can fire.
+    res1 = TopDownBiasCombiner(cfg).apply(
+        goal=goal, loops=loops, bottom_up=bottom_up, agency_readiness=1.0
+    )
+    assert res1.override is not None
+    assert res1.winner_loop_id == "goal"
+
+
+def test_7_scores_clamped_to_unit_interval():
+    # s=0.9 + gain*applied could exceed 1 -> must clamp.
+    loops = [_loop("a", predictive_value=1.0), _loop("b", predictive_value=0.0)]
+    bottom_up = {"a": 0.9, "b": 0.1}
+    goal = GoalContext(drive_origin="predictive", priority=1.0)
+    res = TopDownBiasCombiner(TopDownConfig(gain=0.6, effort_max=1.0)).apply(
+        goal=goal, loops=loops, bottom_up=bottom_up
+    )
+    assert _all_bounded(res)
+    # 0.9 + 0.6*1.0 = 1.5 -> clamped to 1.0
+    assert res.per_loop["a"].combined_salience == 1.0
+
+
+def test_8_no_goal_combined_equals_bottom_up():
+    loops = [_loop("a"), _loop("b"), _loop("c")]
+    bottom_up = {"a": 0.2, "b": 0.9, "c": 0.5}
+    res = TopDownBiasCombiner().apply(goal=None, loops=loops, bottom_up=bottom_up)
+    for lid, s in bottom_up.items():
+        assert res.per_loop[lid].combined_salience == s
+    # missing-from-bottom_up loop -> 0.0
+    loops2 = loops + [_loop("d")]
+    res2 = TopDownBiasCombiner().apply(goal=None, loops=loops2, bottom_up=bottom_up)
+    assert res2.per_loop["d"].combined_salience == 0.0
+
+
+def test_9_override_roundtrips_through_pydantic():
+    loops = [
+        _loop("hi", predictive_value=0.0),
+        _loop("goal", predictive_value=1.0),
+    ]
+    bottom_up = {"hi": 0.6, "goal": 0.1}
+    goal = GoalContext(drive_origin="predictive", priority=0.9, goal_artifact_id="g1")
+    res = TopDownBiasCombiner(TopDownConfig(gain=0.6, effort_max=1.0)).apply(
+        goal=goal, loops=loops, bottom_up=bottom_up
+    )
+    assert res.override is not None
+    restored = VoluntaryOverrideV1.model_validate(res.override.model_dump())
+    assert restored == res.override
+
+
+def test_never_raises_on_bad_input():
+    # bottom_up missing keys, empty loops, weird agency -> no exception.
+    res = TopDownBiasCombiner().apply(
+        goal=GoalContext(drive_origin="predictive", priority=0.5),
+        loops=[],
+        bottom_up={},
+        agency_readiness=5.0,
+    )
+    assert isinstance(res, TopDownResult)
+    assert res.override is None
+    assert res.winner_loop_id is None

--- a/tests/test_voluntary_attention_wiring.py
+++ b/tests/test_voluntary_attention_wiring.py
@@ -1,0 +1,100 @@
+"""Wiring: goal-context store + _apply_voluntary_attention over a real frame."""
+from __future__ import annotations
+
+import pytest
+
+from orion.schemas.attention_frame import (
+    AttentionFrameV1,
+    CuriosityCandidateActionV1,
+    OpenLoopV1,
+    VoluntaryOverrideV1,
+)
+from orion.core.schemas.drives import GoalProposalV1
+from orion.substrate.attention_broadcast import _apply_voluntary_attention
+from orion.substrate.attention import goal_context as gc
+
+
+def _loop(id: str, salience: float, **rel) -> OpenLoopV1:
+    return OpenLoopV1(id=id, description=f"loop {id}", salience=salience, **rel)
+
+
+def _frame() -> AttentionFrameV1:
+    # loop A: high bottom-up, no goal relevance. loop B: low bottom-up, high predictive_value.
+    loops = [
+        _loop("A", 0.80, predictive_value=0.0),
+        _loop("B", 0.30, predictive_value=0.95),
+    ]
+    actions = [
+        CuriosityCandidateActionV1(action_type="watch", open_loop_id="A", score=0.80),
+        CuriosityCandidateActionV1(action_type="watch", open_loop_id="B", score=0.30),
+    ]
+    return AttentionFrameV1(open_loops=loops, candidate_actions=actions, selected_action=actions[0])
+
+
+def _goal(drive="predictive", priority=0.9, status="proposed") -> GoalProposalV1:
+    return GoalProposalV1(
+        artifact_id="goal-1", subject="orion", model_layer="self-model",
+        entity_id="self:orion", kind="autonomy.goal.proposed.v1",
+        goal_statement="pursue predictive", proposal_signature="sig-1",
+        drive_origin=drive, priority=priority,
+        proposal_status=status, provenance={"intake_channel": "x"},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_goal():
+    gc.clear_active_goal()
+    yield
+    gc.clear_active_goal()
+
+
+def test_flag_off_frame_unchanged(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_ATTENTION_TOPDOWN_ENABLED", "false")
+    gc.set_active_goal(_goal())
+    frame = _apply_voluntary_attention(_frame())
+    assert frame.voluntary_override is None
+    assert all(loop.top_down_bias == 0.0 for loop in frame.open_loops)
+    assert frame.selected_action.open_loop_id == "A"  # bottom-up winner
+
+
+def test_flag_on_no_goal_unchanged(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_ATTENTION_TOPDOWN_ENABLED", "true")
+    frame = _apply_voluntary_attention(_frame())
+    assert frame.voluntary_override is None
+    assert frame.selected_action.open_loop_id == "A"
+
+
+def test_goal_overrides_low_salience_loop(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_ATTENTION_TOPDOWN_ENABLED", "true")
+    gc.set_active_goal(_goal(drive="predictive", priority=0.9))
+    frame = _apply_voluntary_attention(_frame())
+    # b(B) = 0.9*0.95 = 0.855; combined(B) = 0.30 + 0.6*0.855 = 0.813 > 0.80 (A).
+    assert frame.voluntary_override is not None
+    assert frame.voluntary_override.chosen_loop_id == "B"
+    assert frame.voluntary_override.beat_loop_id == "A"
+    assert frame.selected_action.open_loop_id == "B"  # re-pointed to winner
+    assert frame.effort_budget_used > 0.0
+    b_loop = next(l for l in frame.open_loops if l.id == "B")
+    assert 0.0 <= b_loop.combined_salience <= 1.0 and b_loop.top_down_bias > 0.0
+
+
+def test_strong_bottom_up_beats_weak_goal(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_ATTENTION_TOPDOWN_ENABLED", "true")
+    gc.set_active_goal(_goal(drive="predictive", priority=0.2))  # weak
+    frame = _apply_voluntary_attention(_frame())
+    # b(B)=0.2*0.95=0.19; combined(B)=0.30+0.6*0.19=0.414 < 0.80 (A). No flip.
+    assert frame.voluntary_override is None
+    assert frame.selected_action.open_loop_id == "A"
+
+
+def test_goal_store_ignores_non_active_status() -> None:
+    gc.set_active_goal(_goal(status="archived"))  # terminal -> ignored
+    assert gc.get_active_goal() is None
+    gc.set_active_goal(_goal(status="proposed"))
+    assert gc.get_active_goal() is not None
+
+
+def test_override_roundtrips() -> None:
+    ov = VoluntaryOverrideV1(chosen_loop_id="B", beat_loop_id="A", chosen_bottom_up=0.3,
+                             beat_bottom_up=0.8, applied_bias=0.5, effort_spent=0.5)
+    assert VoluntaryOverrideV1.model_validate(ov.model_dump()).chosen_loop_id == "B"

--- a/tests/test_voluntary_attention_wiring.py
+++ b/tests/test_voluntary_attention_wiring.py
@@ -66,6 +66,7 @@ def test_flag_on_no_goal_unchanged(monkeypatch) -> None:
 
 def test_goal_overrides_low_salience_loop(monkeypatch) -> None:
     monkeypatch.setenv("ORION_ATTENTION_TOPDOWN_ENABLED", "true")
+    monkeypatch.setenv("ORION_ATTENTION_SALIENCE_V2_ENABLED", "true")
     gc.set_active_goal(_goal(drive="predictive", priority=0.9))
     frame = _apply_voluntary_attention(_frame())
     # b(B) = 0.9*0.95 = 0.855; combined(B) = 0.30 + 0.6*0.855 = 0.813 > 0.80 (A).
@@ -78,8 +79,27 @@ def test_goal_overrides_low_salience_loop(monkeypatch) -> None:
     assert 0.0 <= b_loop.combined_salience <= 1.0 and b_loop.top_down_bias > 0.0
 
 
+def test_salience_v2_off_no_topdown(monkeypatch) -> None:
+    # top-down gated on v2 (its selection basis); v2 off -> pure bottom-up.
+    monkeypatch.setenv("ORION_ATTENTION_TOPDOWN_ENABLED", "true")
+    monkeypatch.setenv("ORION_ATTENTION_SALIENCE_V2_ENABLED", "false")
+    gc.set_active_goal(_goal(drive="predictive", priority=0.9))
+    frame = _apply_voluntary_attention(_frame())
+    assert frame.voluntary_override is None
+    assert frame.selected_action.open_loop_id == "A"
+
+
+def test_terminal_goal_clears_store() -> None:
+    gc.set_active_goal(_goal(drive="predictive", priority=0.9, status="active"))
+    assert gc.get_active_goal() is not None
+    # same goal (artifact_id) goes terminal -> store clears.
+    gc.set_active_goal(_goal(drive="predictive", priority=0.9, status="completed"))
+    assert gc.get_active_goal() is None
+
+
 def test_strong_bottom_up_beats_weak_goal(monkeypatch) -> None:
     monkeypatch.setenv("ORION_ATTENTION_TOPDOWN_ENABLED", "true")
+    monkeypatch.setenv("ORION_ATTENTION_SALIENCE_V2_ENABLED", "true")
     gc.set_active_goal(_goal(drive="predictive", priority=0.2))  # weak
     frame = _apply_voluntary_attention(_frame())
     # b(B)=0.2*0.95=0.19; combined(B)=0.30+0.6*0.19=0.414 < 0.80 (A). No flip.


### PR DESCRIPTION
# PR: Voluntary attention override — Step 2 (DEFAULT-OFF)

**Status:** IMPLEMENTED + reviewed, default-OFF. "Choosing to attend against your
own salience." Ships behind `ORION_ATTENTION_TOPDOWN_ENABLED=false`; off = pure
bottom-up, byte-identical to today. Not gated on the measurement (0(a)/0(b) gate
only Steps 1 & 4) and independent of φ — the one arc rung buildable now.

## Summary

- **Top-down bias combiner** (`orion/substrate/attention/top_down.py`): an active
  goal projects a bias `b(c) = priority × relevance(drive_origin, loop)` onto
  attention candidates, competing with bottom-up salience under a bounded **effort
  budget** (`combined = s + gain·applied_b`, `applied_b ≤ remaining_E`). Biased
  competition (Desimone & Duncan), not override-by-fiat. Pure, never raises.
- **Goal→attention wire** (the scope-doubler): `orion/substrate/attention/goal_context.py`
  — a module-level active-goal store (`GoalProposalV1 → GoalContext`), mirroring
  the existing `_recent_selected_counts` module-state pattern. The substrate had
  **zero** goal references before this.
- **Override trace**: when top-down flips the winner, `VoluntaryOverrideV1` records
  what won, what it beat, both bottom-up scores, applied bias, effort spent — an
  inspectable act of will (or a measured 0 if it never fires).
- Layered onto `build_substrate_attention_frame` via `_apply_voluntary_attention`;
  all 10+ callers unchanged.

## Pre-build verification (before spawning)

- All 5 cited seams confirmed current: `LinearSalienceCombiner`/`SEED_WEIGHTS`,
  `OpenLoopV1` relevance fields, `scoring.py` populates them, the zero-goal-refs
  gap is real, `attention_broadcast` exists.
- Both in-flight attention branches (`computed-salience-actionable-attention`,
  `attention-frame-v1`) are **already merged** — no collision.

## Architecture / deviation

Uses the goal-context **module store** (not a new param threaded through 10
callers) to stay back-compatible, consistent with the file's existing module
state. Real agency-readiness scaling is stubbed at 1.0 (frame builder has no
self-state input) — a documented follow-on wire.

## Contracts (all additive / back-compat)

- `OpenLoopV1.top_down_bias`, `OpenLoopV1.combined_salience` (default 0.0).
- `VoluntaryOverrideV1` (new, embedded — no new channel).
- `AttentionFrameV1.voluntary_override` (None), `effort_budget_used` (0.0).
- No registry churn (additive optional fields on already-registered models).

## Env/config

- `ORION_ATTENTION_TOPDOWN_ENABLED=false` + `ATTENTION_TOPDOWN_GAIN/EFFORT_MAX/
  EFFORT_SCALE_BY_AGENCY/TOPDOWN_WEIGHTS_VERSION` in substrate-runtime `.env_example`.
  Read via `os.getenv` (same pattern as the salience flags).

## Tests / eval

```text
tests/test_top_down.py (10) + tests/test_voluntary_attention_wiring.py (8) → 18 passed
regression (attention frame/schema/builder + substrate + relational) → 319 passed
run_topdown_eval.py → PASS: override rate rises with priority (1.0), falls under
  effort scarcity (0.0), strong bottom-up beats weak bias, no-goal→no-override.
```

## Review findings fixed (Task 9, subagent)

- **MAJOR** — the goal store never cleared a terminal goal → a completed/failed
  goal would bias attention forever. **Fixed**: clears when the held goal's
  `artifact_id` goes terminal. Regression test added.
- **MINOR** — top-down now gated on `salience_v2_enabled()` (its bottom-up basis
  is `loop.salience`, the v2 output; with v2 off the override winner could
  disagree with real selection).
- **MINOR** — import block moved inside the never-raise `try`.
- **MINOR** — override trace recorded only when the winner has an action to
  re-point to (so `chosen_loop_id` can't disagree with `selected_action`).

## Enable / rollback

- Enable only after review: `ORION_ATTENTION_TOPDOWN_ENABLED=true` (+ verify with
  `salience_v2` on) and restart substrate-runtime. Off → pure bottom-up, exact
  current behavior.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
# (only if/when the flag is enabled)
```

## Risks / concerns

- Low while flag off (default). Inert until enabled.
- Real agency-readiness scaling stubbed at 1.0 (follow-on); the goal store is a
  latest-active-goal MVP proxy (a full priority-ranked live-goal set is a follow-on).
