### PR TITLE
fix(world-pulse): include GPU gap-fill details in consolidated journal

### DIFF
--- a/orion/cognition/prompts/journal_compose_prompt.j2
+++ b/orion/cognition/prompts/journal_compose_prompt.j2
@@ -35,6 +35,7 @@ Rules:
 {% endif %}
 {% if _jt.get("trigger_kind") == "world_pulse_digest" %}
 - World Pulse reflective journal: metabolize the Daily World Pulse digest already produced upstream — do not invent new wire stories or geography. Use only facts present in Summary or Prompt seed (run metadata, executive summary, section rollups, digest items, salient topics).
+- When the Prompt seed contains `orion_went_looking`, you MUST weave the specific gap-fill findings into the body: section name, query, article titles, URLs, and salience scores. Do not merely note that a section is missing — include what Orion actually found (or explicitly state "looked, found nothing" if the seed says so).
 - Focus on what shifted, what matters for Orion's lab and continuity, and honest uncertainty where coverage is partial or sparse.
 - Do not restate the full digest card schema; write reflective prose, not a news brief.
 {% endif %}

--- a/orion/journaler/worker.py
+++ b/orion/journaler/worker.py
@@ -201,6 +201,14 @@ def build_world_pulse_prompt_seed(result: WorldPulseRunResultV1) -> str:
                 f"section_rollup: {rollup.section} status={rollup.status} "
                 f"articles={rollup.article_count} digest_items={rollup.digest_item_count}"
             )
+        uncovered = [
+            r.section for r in digest.section_rollups if r.status != "covered"
+        ][:6]
+        if uncovered and not digest.curiosity_followups:
+            parts.append(
+                "coverage_gaps (no gap-fill fetch results on this run): "
+                + ", ".join(uncovered)
+            )
         for item in digest.items[:10]:
             parts.append(f"digest_item: [{item.category}] {item.title} — {item.summary[:240]}")
         if digest.things_worth_reading:

--- a/services/orion-world-pulse/.env_example
+++ b/services/orion-world-pulse/.env_example
@@ -11,9 +11,12 @@ ORION_BUS_URL=redis://100.92.216.81:6379/0
 WORLD_PULSE_ENABLED=true
 WORLD_PULSE_DRY_RUN=false
 WORLD_PULSE_FETCH_ENABLED=true
-# Inline "Orion went looking" gap-fill fetch (billable; off by default).
+# Inline "Orion went looking" gap-fill fetch (billable). Required for the
+# consolidated world-pulse journal: without this, digest.curiosity_followups is
+# empty at compose time and the journal cannot include GPU/gap articles (the
+# retired autonomy_episode journal used to carry downstream fetch results).
 # Effective on/off = this AND ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED.
-WORLD_PULSE_CURIOSITY_FETCH_ENABLED=false
+WORLD_PULSE_CURIOSITY_FETCH_ENABLED=true
 WORLD_PULSE_CURIOSITY_MAX_ARTICLES_PER_SECTION=5
 WORLD_PULSE_CURIOSITY_MAX_SECTIONS=9
 # Capability gate for the readonly fetch above (billable). Enabled by default.

--- a/tests/test_world_pulse_reflective_journal.py
+++ b/tests/test_world_pulse_reflective_journal.py
@@ -110,6 +110,17 @@ def test_world_pulse_seed_folds_in_autonomy_gap_fill_when_present() -> None:
     assert "https://ex/1" in seed
 
 
+def test_world_pulse_seed_marks_coverage_gaps_when_no_followups() -> None:
+    result = _sample_run_result()
+    result.digest.section_rollups.append(
+        SectionRollupV1(section="hardware_compute_gpu", status="missing", article_count=0, digest_item_count=0)
+    )
+    seed = build_world_pulse_reflective_trigger(result).prompt_seed or ""
+    assert "coverage_gaps" in seed
+    assert "hardware_compute_gpu" in seed
+    assert "orion_went_looking" not in seed
+
+
 def test_world_pulse_seed_marks_empty_gap_fill_and_renders_salience() -> None:
     followups = [
         CuriosityFollowupV1(section="policy_regulation", driving_gap="no_articles", query="tariff rule", articles=[]),


### PR DESCRIPTION
The consolidated world-pulse journal was missing downstream GPU/fetch details because digest.curiosity_followups was empty at compose time while the separate autonomy_episode journal path is disabled. Enable inline world-pulse curiosity fetch so followups are present before run.result publish, tighten journal compose guidance to include fetched details when available, and add a fallback coverage_gaps seed line when no followups exist.