### PR TITLE
fix(journal): deterministically append world-pulse gap-fill findings

### DIFF
--- a/orion/journaler/__init__.py
+++ b/orion/journaler/__init__.py
@@ -18,7 +18,9 @@ from .worker import (
     build_write_payload,
     cooldown_key_for_trigger,
     draft_from_cortex_result,
+    format_world_pulse_curiosity_block,
     journal_mode_for_trigger,
+    merge_world_pulse_curiosity_into_draft,
 )
 
 __all__ = [
@@ -43,6 +45,8 @@ __all__ = [
     "build_write_payload",
     "cooldown_key_for_trigger",
     "draft_from_cortex_result",
+    "format_world_pulse_curiosity_block",
     "journal_mode_for_trigger",
+    "merge_world_pulse_curiosity_into_draft",
     "build_journal_entry_index_payload",
 ]

--- a/orion/journaler/worker.py
+++ b/orion/journaler/worker.py
@@ -13,7 +13,7 @@ from orion.schemas.collapse_mirror import CollapseMirrorEntryV2, CollapseMirrorS
 from orion.schemas.cortex.contracts import CortexClientContext, CortexClientRequest, RecallDirective
 from orion.schemas.notify import NotificationRecord
 from orion.schemas.telemetry.metacog_trigger import MetacogTriggerV1
-from orion.schemas.world_pulse import WorldPulseRunResultV1
+from orion.schemas.world_pulse import CuriosityFollowupV1, WorldPulseRunResultV1
 
 from .schemas import JournalEntryDraftV1, JournalEntryWriteV1, JournalMode, JournalTriggerV1
 
@@ -298,6 +298,46 @@ def build_world_pulse_reflective_trigger(result: WorldPulseRunResultV1) -> Journ
         summary=summary[:500],
         prompt_seed=build_world_pulse_prompt_seed(result),
     )
+
+
+def format_world_pulse_curiosity_block(followups: list[CuriosityFollowupV1]) -> str:
+    """Deterministic gap-fill section for journal body (not LLM-dependent)."""
+    if not followups:
+        return ""
+    lines = ["## Orion went looking", "", "Gaps our sources missed:"]
+    for followup in followups[:6]:
+        label = followup.section.replace("_", " ")
+        lines.append(f'- {label} — "{followup.query}" (gap: {followup.driving_gap})')
+        if not followup.articles:
+            lines.append("  (looked, found nothing)")
+        for art in followup.articles[:5]:
+            title = art.title or "(untitled)"
+            lines.append(f"  • [{art.salience:.2f}] {title} — {art.url}")
+    return "\n".join(lines).strip()
+
+
+def merge_world_pulse_curiosity_into_draft(
+    draft: JournalEntryDraftV1,
+    result: WorldPulseRunResultV1,
+) -> JournalEntryDraftV1:
+    """Append concrete gap-fill findings when compose omitted them from the body."""
+    digest = result.digest
+    if digest is None or not digest.curiosity_followups:
+        return draft
+    followups = digest.curiosity_followups
+    body = str(draft.body or "").strip()
+    urls = [str(a.url).strip() for f in followups for a in f.articles if str(a.url or "").strip()]
+    if urls:
+        if all(url in body for url in urls):
+            return draft
+    elif all(not f.articles for f in followups):
+        if "looked, found nothing" in body.lower():
+            return draft
+    block = format_world_pulse_curiosity_block(followups)
+    if not block:
+        return draft
+    merged = f"{body}\n\n{block}".strip()
+    return draft.model_copy(update={"body": merged})
 
 
 def build_metacog_trigger(trigger: MetacogTriggerV1) -> JournalTriggerV1:

--- a/services/orion-actions/app/main.py
+++ b/services/orion-actions/app/main.py
@@ -36,12 +36,14 @@ from orion.journaler import (
     build_write_payload,
     cooldown_key_for_trigger,
     draft_from_cortex_result,
+    merge_world_pulse_curiosity_into_draft,
 )
 from orion.schemas.actions.daily import DailyMetacogV1, DailyPulseV1
 from orion.schemas.collapse_mirror import CollapseMirrorEntryV2, CollapseMirrorStoredV1
 from orion.schemas.cortex.schemas import PlanExecutionArgs, PlanExecutionRequest
 from orion.schemas.notify import NotificationRecord, NotificationRequest
 from orion.schemas.telemetry.metacog_trigger import MetacogTriggerV1
+from orion.schemas.world_pulse import WorldPulseRunResultV1
 from .world_pulse_journal import handle_world_pulse_run_result_journal
 from .logic import (
     ACTION_RESPOND_TO_JUNIPER_COLLAPSE_V1,
@@ -1049,7 +1051,12 @@ async def lifespan(app: FastAPI):
             raise RuntimeError("cortex_exec_missing_final_text")
         return final_text, payload
 
-    async def _run_journal(parent: BaseEnvelope, *, trigger) -> dict[str, Any]:
+    async def _run_journal(
+        parent: BaseEnvelope,
+        *,
+        trigger,
+        world_pulse_result: WorldPulseRunResultV1 | None = None,
+    ) -> dict[str, Any]:
         journal_llm_route = _normalized_llm_route(settings.actions_journal_llm_route, settings.actions_llm_route)
         tk = str(getattr(trigger, "trigger_kind", "") or "")
         sk = str(getattr(trigger, "source_kind", "") or "")
@@ -1097,6 +1104,8 @@ async def lifespan(app: FastAPI):
         if not orch_payload.get("ok", False):
             raise RuntimeError(f"journal_compose_failed:{orch_payload.get('error') or orch_payload.get('status')}")
         draft = draft_from_cortex_result(orch_payload)
+        if world_pulse_result is not None:
+            draft = merge_world_pulse_curiosity_into_draft(draft, world_pulse_result)
         write = build_write_payload(
             draft,
             trigger=trigger,
@@ -1111,7 +1120,15 @@ async def lifespan(app: FastAPI):
             "orch_payload": orch_payload,
         }
 
-    async def _dispatch_journal(parent: BaseEnvelope, *, trigger, audit_action: str, dedupe_key: str, reason: str | None = None) -> bool:
+    async def _dispatch_journal(
+        parent: BaseEnvelope,
+        *,
+        trigger,
+        audit_action: str,
+        dedupe_key: str,
+        reason: str | None = None,
+        world_pulse_result: WorldPulseRunResultV1 | None = None,
+    ) -> bool:
         if not settings.actions_journaling_enabled:
             await _audit(parent, status="skipped", event_id=dedupe_key, action_name=audit_action, reason="journaling_disabled")
             return False
@@ -1124,7 +1141,11 @@ async def lifespan(app: FastAPI):
         try:
             await sem.acquire()
             acquired = True
-            result = await _run_journal(parent, trigger=trigger)
+            result = await _run_journal(
+                parent,
+                trigger=trigger,
+                world_pulse_result=world_pulse_result,
+            )
             draft = result.get("draft") if isinstance(result, dict) else {}
             write_payload = result.get("write") if isinstance(result, dict) else {}
             scheduler_daily = _is_scheduler_daily_journal(trigger=trigger, write_payload=write_payload, draft=draft)

--- a/services/orion-actions/app/world_pulse_journal.py
+++ b/services/orion-actions/app/world_pulse_journal.py
@@ -77,5 +77,6 @@ async def handle_world_pulse_run_result_journal(
         trigger=trigger,
         audit_action="journal.world_pulse_digest",
         dedupe_key=cooldown_key_for_trigger(trigger),
+        world_pulse_result=result,
     )
     return True

--- a/tests/test_world_pulse_reflective_journal.py
+++ b/tests/test_world_pulse_reflective_journal.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from orion.journaler import (
+    JournalEntryDraftV1,
     build_compose_request,
     build_world_pulse_reflective_trigger,
     cooldown_key_for_trigger,
     journal_mode_for_trigger,
+    merge_world_pulse_curiosity_into_draft,
 )
 from orion.schemas.world_pulse import (
     CuriosityFindingV1,
@@ -147,3 +149,46 @@ def test_world_pulse_compose_request_carries_trigger_metadata() -> None:
     assert req.verb == "journal.compose"
     assert req.context.metadata["journal_mode"] == "digest"
     assert req.context.metadata["journal_trigger"]["trigger_kind"] == "world_pulse_digest"
+
+
+def test_merge_world_pulse_curiosity_appends_missing_urls() -> None:
+    followups = [
+        CuriosityFollowupV1(
+            section="hardware_compute_gpu",
+            driving_gap="missing",
+            query="hardware compute gpu recent news coverage",
+            articles=[
+                CuriosityFindingV1(
+                    url="https://nvidianews.nvidia.com/news/nvidia-blackwell",
+                    title="NVIDIA Blackwell Platform",
+                    salience=0.67,
+                )
+            ],
+        )
+    ]
+    result = _sample_run_result(curiosity_followups=followups)
+    vague = JournalEntryDraftV1(
+        mode="digest",
+        title="Journal Pass",
+        body="Orion looked and found some NVIDIA-related content, but details were vague.",
+    )
+    merged = merge_world_pulse_curiosity_into_draft(vague, result)
+    assert "https://nvidianews.nvidia.com/news/nvidia-blackwell" in merged.body
+    assert "NVIDIA Blackwell Platform" in merged.body
+    assert "## Orion went looking" in merged.body
+
+
+def test_merge_world_pulse_curiosity_noop_when_urls_already_present() -> None:
+    followups = [
+        CuriosityFollowupV1(
+            section="hardware_compute_gpu",
+            driving_gap="missing",
+            query="gpu",
+            articles=[CuriosityFindingV1(url="https://ex/1", title="Fab", salience=0.5)],
+        )
+    ]
+    result = _sample_run_result(curiosity_followups=followups)
+    body = "Already included https://ex/1 in prose."
+    draft = JournalEntryDraftV1(mode="digest", title="Journal Pass", body=body)
+    merged = merge_world_pulse_curiosity_into_draft(draft, result)
+    assert merged.body == body


### PR DESCRIPTION
You were right — this was a **real fail**, but not where we thought.

## What actually happened on run `4951edcd`

The gap-fill **did work**. That run has:

- `curiosity_followups: 1` (`hardware_compute_gpu`)
- **5 articles**, including Blackwell / Network World / PMC links

The journal compose LLM got them in the prompt seed, then **hand-waved** them: *"found some NVIDIA-related content"* without titles/URLs. Prompt-only enforcement wasn't enough.

## Fix (pushed)

**Branch:** `fix/world-pulse-journal-deterministic-gap-fill`  
**Commit:** `ebbd5377`  
**PR:** https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/world-pulse-journal-deterministic-gap-fill

After `journal.compose`, `merge_world_pulse_curiosity_into_draft` now **deterministically appends** an `## Orion went looking` block with section, query, article titles, URLs, and salience — but only when those URLs aren't already in the body.

Choke point: `services/orion-actions/app/main.py::_run_journal` (post-compose, pre-write).

**Tests:** 14 passed (including regression for vague LLM body → concrete URLs appended).

## Restart

```bash
docker compose --env-file services/orion-actions/.env \
  -f services/orion-actions/docker-compose.yml up -d --force-recreate
```

Tomorrow's journal should end with something like:

```text
## Orion went looking

Gaps our sources missed:
- hardware compute gpu — "hardware compute gpu recent news coverage" (gap: missing)
  • [0.67] NVIDIA Blackwell Platform Arrives... — https://nvidianews.nvidia.com/...
  ...
```

## PR body

```markdown
## Summary

- Fix world-pulse journal emails that mention gap-fill vaguely but omit concrete GPU/article details.
- Root cause: `digest.curiosity_followups` was present in compose seed, but LLM summarized instead of including URLs/titles.
- Add deterministic post-compose merge: `merge_world_pulse_curiosity_into_draft` appends `## Orion went looking` with section/query/articles when URLs are missing from draft body.
- Wire world-pulse handler to pass full `WorldPulseRunResultV1` into journal dispatch.

## Outcome moved

Consolidated world-pulse journal emails now include grounded gap-fill evidence (titles + URLs), not just "Orion looked and found some NVIDIA-related content."

## Tests run

```text
.venv/bin/python -m pytest tests/test_world_pulse_reflective_journal.py services/orion-actions/tests/test_world_pulse_reflective_journal_handler.py -q
14 passed
```

## Restart required

```bash
docker compose --env-file services/orion-actions/.env -f services/orion-actions/docker-compose.yml up -d --force-recreate
```
```