### PR TITLE
Feat/aitown grounded small speech

### DIFF
--- a/docs/superpowers/specs/2026-07-08-integrated-memory-cognition-loop-design.md
+++ b/docs/superpowers/specs/2026-07-08-integrated-memory-cognition-loop-design.md
@@ -1,0 +1,481 @@
+# Integrated Memory Cognition Loop — Design
+
+**Date:** 2026-07-08  
+**Status:** Approved for implementation planning (operator review gate)  
+**Authors:** Juniper + agent (brainstorming session)  
+**Supersedes as north star:** Treats write gate, PCR, and weight/decay as **one program**, not three isolated patches.
+
+**Program partners (existing specs, absorbed here):**
+
+- [`2026-07-07-consolidation-crystallization-gate-design.md`](./2026-07-07-consolidation-crystallization-gate-design.md) — encode gate
+- [`2026-07-07-purpose-conditioned-recall-design.md`](./2026-07-07-purpose-conditioned-recall-design.md) — retrieve by purpose
+- [`2026-07-07-memory-weight-reinforcement-decay-design.md`](./2026-07-07-memory-weight-reinforcement-decay-design.md) — lifecycle
+- [`2026-07-07-unified-turn-self-grounding-design.md`](./2026-07-07-unified-turn-self-grounding-design.md) — orion unified lane carrier
+
+---
+
+## Arsonist summary
+
+Orion built crystallizations, PCR, active-packet, and dynamics math — then chat still feels like **surface timeline SQL**. The loop is open at both ends: encoding stalls at `proposed` awaiting human clicks, and retrieval defaults to `continuity_only` with an empty belief store.
+
+This spec closes one integrated cognition loop for **brain mode** and **orion unified mode**:
+
+```text
+ENCODE (cheap, weak) → STORE (canonical belief) → PROJECT (cards/chroma)
+                              ↓ reinforce / recall_boost       ↓
+                         LIFECYCLE (activation/decay)  ←── RETRIEVE (PCR by purpose)
+```
+
+Human gates stay for graph/RDF structural edits and high-stakes crystallizations (identity, intimate, contradiction, gated kinds). Routine memory forms automatically, strengthens on use, and fades on disuse.
+
+---
+
+## Executive summary
+
+| Gap | Symptom today | Fix in this spec |
+|-----|---------------|------------------|
+| **Encoding** | Proposals pile up in `proposed`; nothing becomes active without operator click | `formation_policy` auto-activates low-stakes kinds at weak activation |
+| **Storage** | Canonical beliefs thin; cards/chroma disconnected from live encode path | Auto-project on `auto_activate`; recall eligibility uses `activation` floor |
+| **Retrieval** | PCR shipped but brain defaults to timeline SQL; unified gets Phase 3 only | Full PCR 0→1→stance→3 on both lanes; intent rule fetches beliefs when store has signal |
+| **Lifecycle** | `dynamics.py` exists, nothing calls it | Wire reinforce/recall_boost/decay reaper |
+
+**v1 lane scope:** Hub `brain` (`chat_general`) and `orion` unified turn (`stance_react`). Quick, grounded_small, agent, council unchanged.
+
+---
+
+## Current architecture
+
+### Write path (shipped, blocked at governor)
+
+```text
+sql-writer → memory.turn.persisted → orion-memory-consolidation
+  → turn_change_appraisal + window close
+  → consolidation_memory_gate (skip | propose)
+  → MemoryCrystallizationV1 status=proposed, requires_manual_review=True
+  → Hub governor approve → project (cards/chroma/graphiti/rdf)
+```
+
+**Choke point:** `orion/memory/crystallization/governor.py::can_activate` requires `approved_by` when `requires_manual_review=True`. All consolidation intake sets that flag.
+
+### Read path (shipped, starved)
+
+```text
+chat_general: PCR phase0+1 (sql_chat continuity) → stance → phase3 (often skipped)
+stance_react: stance → phase3 only via grounding_capsule (no pre-stance continuity)
+active_packet: list_crystallizations(status=active) — empty when store is proposed-only
+```
+
+**Choke points:**
+
+- `orion/memory/retrieval_intent.py` — default `continuity_only` on most turns
+- `orion/recall/profiles/chat.continuity.v1.yaml` — sql_chat only, 2hr window
+- Hub `brain.recall.v1` — legacy score-soup profile (sql_chat + sql_timeline + rdf) when PCR off
+
+### Lifecycle (inert)
+
+- `orion/memory/crystallization/dynamics.py` — pure functions, unit-tested
+- `salience` frozen at creation; no reinforce-on-recurrence in consolidation intake
+- `detection.detect_duplicates()` — warning on Hub validate only
+
+---
+
+## Target architecture — the closed loop
+
+```text
+                    ENCODE                    STORE                 RETRIEVE              LIFECYCLE
+                      │                         │                      │                     │
+Turn persisted ──► consolidation gate ──► crystallization ──► projections ──► PCR by intent ──► reinforce/decay
+                      │                         │                 (cards/chroma)              │
+                      │                    canonical belief          │                     │
+                      └──────────────── skip (low signal) ──────────┴─────────────────────┘
+```
+
+### Deterministic choke points
+
+| Phase | Owner | Function / module |
+|-------|-------|-------------------|
+| Encode | `orion-memory-consolidation` | `consolidation_memory_gate` → `resolve_formation_policy` |
+| Store | `orion/memory/crystallization/formation_executor.py` (new) | `auto_activate` or `governor_queue` + `seed_dynamics` |
+| Project | `orion-hub` / crystallization projector | cards + chroma on auto_activate (not/rdf/graphiti) |
+| Retrieve | `orion-cortex-exec` + `orion-recall` | `pcr_chat_memory` + `retrieval_intent` + `active_packet` |
+| Lifecycle | `dynamics.py` + reaper tick | reinforce, recall_boost, decay, retire |
+
+---
+
+## Section 1 — Encoding
+
+### When to encode
+
+No change to consolidation gate inputs:
+
+- `turn_change_appraisal` (novelty, shift_kind)
+- `memory_significance_score`
+- `is_low_info_social` skip
+- Read-only grammar event refs (repair signal)
+
+Gate output remains `skip` or `propose`. Formation policy decides what happens **after** propose.
+
+### Granularity (one belief per closed window)
+
+Kind from dominant shift in window (existing proposer logic):
+
+| Signal | Kind | Summary shape |
+|--------|------|-----------------|
+| TOPIC | `semantic` | Subject + 1–3 sentences |
+| STANCE / relational | `stance` or `episode` | Relational frame or bounded episode |
+| REPAIR | `open_loop` | Unresolved thread |
+| Planning markers in stance | `procedure` | Steps / decision path |
+| Contradiction seed in attention | `contradiction` | Always gated |
+
+### Formation policy (new)
+
+**File:** `orion/memory/crystallization/formation_policy.py`
+
+```python
+AUTO_ACTIVE_KINDS = frozenset({"semantic", "episode", "open_loop", "procedure"})
+GATED_KINDS = frozenset({"stance", "decision", "contradiction", "attractor", "failure_mode"})
+IDENTITY_SCOPE_PREFIX = "identity:"  # scope tags requiring governor
+```
+
+| Condition | Policy | Result |
+|-----------|--------|--------|
+| Duplicate (Jaccard ≥ threshold) | `reinforce_existing` | `reinforce()` on existing row; append evidence ref |
+| `kind in AUTO_ACTIVE_KINDS` AND `sensitivity != intimate` AND no identity scope tag | `auto_activate` | `status=active`, `seed_dynamics`, weak activation |
+| `kind in GATED_KINDS` OR `sensitivity == intimate` OR identity scope | `governor_queue` | `status=proposed`, `requires_manual_review=True` (current behavior) |
+| Validation fails on auto path | `governor_queue` | Downgrade; emit `formation_policy_downgrade` trace |
+
+**Initial activation on auto_activate:**
+
+```text
+activation = clamp(salience * AUTO_ENCODE_ACTIVATION_RATIO, 0.05, 0.35)
+# AUTO_ENCODE_ACTIVATION_RATIO default 0.4
+```
+
+Beliefs enter cognition weakly and must earn strength through recurrence and recall.
+
+### Recurrence (dedup → reinforce)
+
+Wire `detection.detect_duplicates()` into consolidation intake **before** insert:
+
+1. Match found → `reinforce(existing, boost=0.2)` + append window evidence
+2. Emit `memory.crystallization.reinforced.v1` (new lifecycle kind)
+3. No new row
+
+---
+
+## Section 2 — Storage and projections
+
+### Canonical
+
+`memory_crystallizations` Postgres — source of truth. Add / complete `dynamics jsonb` column per weight/decay spec.
+
+**Schema addition (if not already merged):**
+
+```python
+class CrystallizationDynamicsV1(BaseModel):
+    activation: float = 0.0
+    reinforcement_count: int = 0
+    formed_at: datetime | None = None
+    last_reinforced_at: datetime | None = None
+    last_recalled_at: datetime | None = None
+    decay_half_life_days: float = 30.0
+    retired_at: datetime | None = None
+```
+
+### Recall eligibility
+
+```text
+eligible_for_recall(crys) :=
+  crys.status == "active"
+  AND crys.dynamics.activation >= ACTIVATION_RECALL_FLOOR  # default 0.08
+  AND crys.status not in (deprecated, archived, rejected)
+```
+
+`list_crystallizations` and `active_packet` must filter on activation, not status alone.
+
+### Projections on auto_activate
+
+| Projection | Auto? | Notes |
+|------------|-------|-------|
+| Memory card | Yes | `build_memory_card_projection()` — chat injection surface |
+| Chroma | Yes | crystallization vector collection |
+| RDF memory_graph | No | Human graph editor (existing C) |
+| Graphiti | No | Human / explicit activation spec |
+
+### auto_activate executor (new)
+
+**File:** `orion/memory/crystallization/formation_executor.py`
+
+Parallel to `governor.approve()`:
+
+```python
+def auto_activate(crystallization, *, actor: str = "system:formation_policy") -> tuple[MemoryCrystallizationV1, dict]:
+    # validate_proposal must pass
+    # status → active
+    # governance.approval_mode → auto_policy
+    # governance.requires_manual_review → False
+    # governance.approved_by → actor
+    # seed_dynamics()
+    # trigger project_crystallization(cards + chroma only)
+```
+
+Governor `approve()` unchanged for gated items.
+
+---
+
+## Section 3 — Retrieval (PCR, breadth and depth)
+
+### Lane wiring (v1 scope)
+
+| Hub mode | Cortex verb | PCR phases | Change |
+|----------|-------------|------------|--------|
+| `brain` | `chat_general` | 0 → 1 → stance → 3 | Hub stops defaulting `brain.recall.v1`; PCR only |
+| `orion` | `stance_react` | 0 → 1 → stance → 3 | Add phase 0+1 before stance (today: phase 3 only in `grounding_capsule`) |
+| `quick`, `grounded_small` | `chat_quick`, etc. | unchanged | Out of scope v1 |
+
+### Hub recall default change
+
+`services/orion-hub/scripts/cortex_request_builder.py`:
+
+- Brain mode with `use_recall=true` and no explicit profile → omit legacy `brain.recall.v1`
+- Cortex-exec PCR path owns profile selection via phase/intent
+- Explicit `recall_profile` overrides preserved
+
+Deprecate `brain.recall.v1` in docs; remove as default in M4 (profile file may remain for explicit override during transition).
+
+### Intent rule fix
+
+**File:** `orion/memory/retrieval_intent.py`
+
+Add rule **before** `continuity_only` fallback:
+
+```text
+IF hub_chat_lane IN ("brain", "orion")
+AND phase0 did not skip
+AND session has eligible crystallizations (activation >= floor)
+AND no higher-priority rule fired
+THEN return ("semantic", "brain_lane_belief_default")
+```
+
+Higher-priority rules unchanged: `open_loop`, `relational`, `contradiction`, `procedural`, topic shift, entity query.
+
+`hub_chat_lane` must be passed from Hub surface_context into cortex ctx (verify wire; add if missing for brain/orion modes).
+
+### Depth per intent (existing profiles, activation-ranked packet)
+
+| Intent | Backends | max items | render budget |
+|--------|----------|-----------|---------------|
+| `continuity` | sql_chat | 6 | 96 tokens |
+| `semantic` | active_packet, cards, rdf_chat | 8 | 128 tokens |
+| `relational` | active_packet(stance), cards, rdf | 6 | 128 tokens |
+| `open_loop` | active_packet(open_loops), rdf_chat | 6 | 128 tokens |
+| `procedural` | active_packet(procedures), cards | 6 | 128 tokens |
+| `contradiction` | active_packet, cards, graphiti (if enabled) | 6 | 128 tokens |
+
+**active_packet ranking:** `score = dynamics.activation * salience` (replace salience-only sort in `retriever.py`).
+
+### Unified grounding capsule
+
+`assemble_stance_grounding` runs full PCR (phase 0+1 before stance slice parse, phase 3 after). `GroundingCapsuleV1` carries `continuity_digest` + `belief_digest` (parity with brain mode per unified-turn self-grounding spec).
+
+### CHAT_PCR_QUICK_PHASE3
+
+Unchanged for quick lane. Brain lane is not quick — phase 3 always runs when intent warrants.
+
+---
+
+## Section 4 — Lifecycle
+
+Wire `orion/memory/crystallization/dynamics.py` (deterministic, no LLM):
+
+| Event | Function | Trigger |
+|-------|----------|---------|
+| Formation | `seed_dynamics()` | `auto_activate` or `governor.approve` |
+| Recurrence | `reinforce(boost=0.2)` | dedup match on encode |
+| Recall | `recall_boost(boost=0.08)` | crystallization included in active_packet response |
+| Decay | `decay()` | reaper tick |
+| Retire | `should_retire(floor=0.05)` | activation below floor after decay |
+
+**Retire behavior:**
+
+- `status → deprecated`
+- `dynamics.retired_at → now`
+- De-project from cards/chroma (not hard delete)
+- Emit `memory.crystallization.retired.v1`
+
+**Reaper:** New function in `orion-memory-consolidation` worker or `orion-dream` tick (every 6h, env `MEMORY_COGNITION_REAPER_ENABLED`). Batch scan `status=active`, apply decay, retire eligible, log counts.
+
+**Privacy:** Intimate and gated kinds never `auto_activate`. Dynamics apply only after human approval for those.
+
+---
+
+## Section 5 — Error handling and degradation
+
+| Failure | Behavior |
+|---------|----------|
+| PCR RPC timeout | Turn continues; continuity-only or identity-only capsule |
+| active_packet empty | Fallback: cards + sql_chat continuity; metric `belief_store_thin` |
+| auto_activate validation fail | Downgrade to `proposed`; trace `formation_policy_downgrade` |
+| Chroma project fail | Belief remains in Postgres; recall uses cards/sql |
+| reaper row error | Skip row, increment error count; never hard-delete canonical |
+
+**Telemetry** (extend existing `recall.decision.v1` / cortex debug):
+
+- `formation_policy`, `activation_floor`, `belief_count`, `continuity_count`
+- `retrieval_intent`, `rule_id`, `pcr_phase`
+- `recall_boost_applied` (list of crystallization_ids)
+
+---
+
+## Proposed schema / bus changes
+
+### Additive only
+
+| Change | Location |
+|--------|----------|
+| `CrystallizationDynamicsV1` + `dynamics` field | `orion/memory/crystallization/schemas.py` |
+| `dynamics jsonb` column | `orion/core/storage/sql/memory_crystallizations.sql` |
+| `memory.crystallization.reinforced.v1` | `orion/bus/channels.yaml`, registry |
+| `memory.crystallization.retired.v1` | `orion/bus/channels.yaml`, registry |
+| `memory.crystallization.auto_activated.v1` | optional lifecycle event for debug UI |
+| Env keys | See below |
+
+### Env keys (new)
+
+```text
+# Formation
+MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=false  # flip true after M1 smoke passes
+MEMORY_FORMATION_AUTO_ENCODE_ACTIVATION_RATIO=0.4
+MEMORY_FORMATION_IDENTITY_SCOPE_PREFIX=identity:
+
+# Recall
+ACTIVATION_RECALL_FLOOR=0.08
+MEMORY_COGNITION_BRAIN_BELIEF_DEFAULT=true
+
+# Lifecycle
+MEMORY_COGNITION_REAPER_ENABLED=true
+MEMORY_COGNITION_REAPER_INTERVAL_HOURS=6
+MEMORY_COGNITION_RETIRE_ACTIVATION_FLOOR=0.05
+```
+
+Update `.env_example` for: `orion-memory-consolidation`, `orion-cortex-exec`, `orion-recall`, `orion-hub` as touched.
+
+---
+
+## Files likely to touch
+
+### Encode + store
+
+- `orion/memory/crystallization/formation_policy.py` (new)
+- `orion/memory/crystallization/formation_executor.py` (new)
+- `orion/memory/crystallization/intake_consolidation_window.py`
+- `orion/memory/crystallization/detection.py` — wire dedup into intake
+- `orion/memory/crystallization/schemas.py`, `repository.py`
+- `services/orion-memory-consolidation/app/worker.py`
+- `services/orion-hub/scripts/crystallization_routes.py` — project on auto_activate
+
+### Retrieve
+
+- `orion/memory/retrieval_intent.py`
+- `services/orion-cortex-exec/app/pcr_chat_memory.py`
+- `services/orion-cortex-exec/app/router.py` — stance_react phase 0+1
+- `services/orion-cortex-exec/app/grounding_capsule.py`
+- `orion/memory/crystallization/retriever.py`, `active_packet.py`
+- `services/orion-recall/app/collectors/active_packet.py`
+- `services/orion-hub/scripts/cortex_request_builder.py`
+
+### Lifecycle
+
+- `orion/memory/crystallization/dynamics.py` (existing)
+- `services/orion-recall/app/worker.py` — recall_boost after fetch
+- `services/orion-memory-consolidation/app/reaper.py` (new) or dream tick
+
+### Tests + smoke
+
+- `tests/test_formation_policy_auto_vs_gated.py` (new)
+- `tests/test_encode_reinforce_not_duplicate.py` (new)
+- `services/orion-cortex-exec/tests/test_pcr_chat_memory.py` — brain belief default
+- `services/orion-cortex-exec/tests/test_unified_pcr_phase01.py` (new)
+- `services/orion-recall/tests/test_active_packet_activation_floor.py` (new)
+- `scripts/smoke_memory_cognition_loop_e2e.sh` (new)
+
+---
+
+## Non-goals
+
+- No new memory stores, ontology nodes, or keyword cathedrals
+- No vector recall re-enablement for chat turns (Chroma for crystallization neighborhood only)
+- No auto RDF / Graphiti projection
+- No grammar substrate schema changes
+- Quick / grounded_small / agent / council lane changes in v1
+- No LLM in formation policy, weight path, or retrieval intent
+- No hard deletion of canonical crystallizations
+
+---
+
+## Acceptance checks
+
+### Encoding
+
+- [ ] Topic-shift window with `semantic` kind → `status=active` without Hub click when `MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=true`
+- [ ] `contradiction` or `intimate` → `status=proposed`, governor queue unchanged
+- [ ] Duplicate subject/summary → one row, `reinforcement_count` incremented, no second insert
+
+### Storage
+
+- [ ] Auto-activated belief has `dynamics.activation` in `[0.05, 0.35]` range
+- [ ] Card + Chroma projections exist after auto_activate
+- [ ] No RDF/Graphiti projection on auto_activate
+
+### Retrieval (brain mode)
+
+- [ ] Brain turn with active beliefs → `retrieval_intent=semantic`, `belief_digest` non-empty
+- [ ] Greeting / low-info → phase 0 skip, empty belief_digest
+- [ ] `brain.recall.v1` not used as Hub default
+
+### Retrieval (orion unified)
+
+- [ ] `stance_react` turn runs phase 0+1 before stance
+- [ ] `GroundingCapsuleV1` has non-empty `belief_digest` when store has eligible beliefs
+
+### Lifecycle
+
+- [ ] Recall of crystallization sets `last_recalled_at` and bumps activation
+- [ ] Simulated 90-day decay on untouched low-stakes belief → `deprecated`, excluded from active_packet
+- [ ] Reaper emits `memory.crystallization.retired.v1`
+
+### Smoke
+
+- [ ] `scripts/smoke_memory_cognition_loop_e2e.sh` PASS on live stack
+
+---
+
+## Phased rollout
+
+| Milestone | Ships | Operator-visible |
+|-----------|-------|------------------|
+| **M1 — Activate the store** | `formation_policy`, `auto_activate`, dynamics schema, reinforce-on-dedup, auto-project cards/chroma | Beliefs appear without clicks |
+| **M2 — Unify read path** | PCR lane fixes, intent brain default, unified phase 0+1, activation-ranked packet | Chat stops being timeline-only |
+| **M3 — Lifecycle live** | recall_boost, decay reaper, retire + de-project | Repetition strengthens; disuse fades |
+| **M4 — Deprecate legacy** | Hub default recall change, `brain.recall.v1` docs marked deprecated | Brain fully on PCR |
+
+**Recommended ship:** M1 + M2 together for maximum impact on brain and orion unified lanes.
+
+---
+
+## Risks and mitigations
+
+| Severity | Risk | Mitigation |
+|----------|------|------------|
+| Medium | Auto-activate produces low-quality beliefs | Weak initial activation + decay retires noise; gated kinds unchanged |
+| Medium | Belief default rule over-fetches | Activation floor + render budgets; intent priority rules unchanged |
+| Low | Chroma projection lag | Postgres + cards fallback; metric alerts |
+| Low | Reaper retires still-useful belief | Floor tunable via env; reinforce on recall |
+
+---
+
+## Recommended next patch
+
+**M1 Task 1:** `formation_policy.py` + unit tests + wire into `intake_consolidation_window.py` behind `MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED` (default false until smoke passes, then flip true).
+
+Invoke implementation plan via `writing-plans` after operator approves this spec file.

--- a/services/orion-ai-town/README.md
+++ b/services/orion-ai-town/README.md
@@ -188,6 +188,27 @@ npx convex run testing:stop && npx convex run testing:resume
 
 The embodiment worker no longer sends `finishSendingMessage` itself (`messages:writeMessage` enqueues a well-formed one), so this poison cannot recur; the patch is kept for operator recovery and diagnosis.
 
+### Conversation proximity (`patches/orion-conversation-proximity.patch`)
+
+Stock AI Town picks the **nearest free player on the entire map** as a conversation invitee, so NPCs lock each other (and humans) into cross-map chats. This patch:
+
+- Adds `MAX_INVITE_DISTANCE = 6` (aligned with Orion embodiment `EMBODIMENT_SOCIAL_INITIATE_DISTANCE`)
+- Filters `findConversationCandidate` to players within that range
+- Rejects `Conversation.start` when initiator and invitee are too far apart
+- Nudges the initiator toward the invitee immediately on invite (stock engine only walked on the next agent tick)
+- **`INVITE_TIMEOUT` applies only to pending `invited` status** — once a player accepts (`walkingOver`), agents keep walking until they're in range; accepted invites no longer expire mid-walk
+
+### Town chat turns (`patches/orion-town-chat-turns.patch`)
+
+Fixes NPC-human chats where agents talk over the human, narrate scene prose instead of replying, or auto-leave mid-conversation:
+
+- NPCs **wait for the human's first line** (no synthetic `start` message over Juniper)
+- Replies are **in-character dialogue** with `clampTownReply` (no observation-lounge narration)
+- NPCs **do not auto-leave** human conversations (message cap / duration only applies NPC-NPC)
+- **3 minute grace** after an NPC speaks before it considers speaking again (`HUMAN_REPLY_GRACE_MS`)
+
+Orion's external embodiment worker already walks on `walkingOver` via `approach_player` intents in `services/orion-embodiment/app/worker.py`.
+
 ## MCP integration
 
 Gameplay MCP lives in `mcp/orion_aitown_mcp/`. Hub fcc-claude includes it when `HUB_AITOWN_ENABLED=true` and MCP is enabled.

--- a/services/orion-ai-town/patches/orion-conversation-proximity.patch
+++ b/services/orion-ai-town/patches/orion-conversation-proximity.patch
@@ -1,0 +1,129 @@
+diff --git a/convex/aiTown/agent.ts b/convex/aiTown/agent.ts
+index ae49157..b34c57b 100644
+--- a/convex/aiTown/agent.ts
++++ b/convex/aiTown/agent.ts
+@@ -10,6 +10,7 @@ import {
+   CONVERSATION_DISTANCE,
+   INVITE_ACCEPT_PROBABILITY,
+   INVITE_TIMEOUT,
++  MAX_INVITE_DISTANCE,
+   MAX_CONVERSATION_DURATION,
+   MAX_CONVERSATION_MESSAGES,
+   MESSAGE_COOLDOWN,
+@@ -109,6 +110,11 @@ export class Agent {
+       )!;
+       const otherPlayer = game.world.players.get(otherPlayerId)!;
+       if (member.status.kind === 'invited') {
++        if (member.invited + INVITE_TIMEOUT < now) {
++          console.log(`Agent ${player.id} timing out stale invite from ${otherPlayer.id}`);
++          conversation.rejectInvite(game, now, player);
++          return;
++        }
+         // Accept a conversation with another agent with some probability and with
+         // a human unconditionally.
+         if (otherPlayer.human || Math.random() < INVITE_ACCEPT_PROBABILITY) {
+@@ -125,9 +131,13 @@ export class Agent {
+         return;
+       }
+       if (member.status.kind === 'walkingOver') {
+-        // Leave a conversation if we've been waiting for too long.
+-        if (member.invited + INVITE_TIMEOUT < now) {
+-          console.log(`Giving up on invite to ${otherPlayer.id}`);
++        // Only abandon if the other player never accepted. Once both are
++        // walkingOver, the accepted invite is a contract to meet and chat.
++        if (
++          otherMember.status.kind === 'invited' &&
++          member.invited + INVITE_TIMEOUT < now
++        ) {
++          console.log(`Giving up on unanswered invite to ${otherPlayer.id}`);
+           conversation.leave(game, now, player);
+           return;
+         }
+@@ -358,11 +368,15 @@ export const findConversationCandidate = internalQuery({
+           continue;
+         }
+       }
+-      candidates.push({ id: otherPlayer.id, position });
++      const d = distance(otherPlayer.position, position);
++      if (d > MAX_INVITE_DISTANCE) {
++        continue;
++      }
++      candidates.push({ id: otherPlayer.id, position, distance: d });
+     }
+ 
+     // Sort by distance and take the nearest candidate.
+-    candidates.sort((a, b) => distance(a.position, position) - distance(b.position, position));
++    candidates.sort((a, b) => a.distance - b.distance);
+     return candidates[0]?.id;
+   },
+ });
+diff --git a/convex/aiTown/conversation.ts b/convex/aiTown/conversation.ts
+index fc93d56..9cd6c9a 100644
+--- a/convex/aiTown/conversation.ts
++++ b/convex/aiTown/conversation.ts
+@@ -4,7 +4,7 @@ import { conversationId, playerId } from './ids';
+ import { Player } from './player';
+ import { inputHandler } from './inputHandler';
+ 
+-import { TYPING_TIMEOUT, CONVERSATION_DISTANCE } from '../constants';
++import { TYPING_TIMEOUT, CONVERSATION_DISTANCE, MAX_INVITE_DISTANCE, MIDPOINT_THRESHOLD } from '../constants';
+ import { distance, normalize, vector } from '../util/geometry';
+ import { Point } from '../util/types';
+ import { Game } from './game';
+@@ -134,6 +134,12 @@ export class Conversation {
+       console.log(reason);
+       return { error: reason };
+     }
++    const inviteDistance = distance(player.position, invitee.position);
++    if (inviteDistance > MAX_INVITE_DISTANCE) {
++      const reason = `Players too far apart to start a conversation (${inviteDistance.toFixed(1)} > ${MAX_INVITE_DISTANCE})`;
++      console.log(reason);
++      return { error: reason };
++    }
+     const conversationId = game.allocId('conversations');
+     console.log(`Creating conversation ${conversationId}`);
+     game.world.conversations.set(
+@@ -149,6 +155,18 @@ export class Conversation {
+         ],
+       }),
+     );
++    // Nudge the initiator toward the invitee immediately so both players visibly
++    // walk up before participating (not only on the next agent tick).
++    if (inviteDistance >= CONVERSATION_DISTANCE) {
++      const destination =
++        inviteDistance < MIDPOINT_THRESHOLD
++          ? { x: Math.floor(invitee.position.x), y: Math.floor(invitee.position.y) }
++          : {
++              x: Math.floor((player.position.x + invitee.position.x) / 2),
++              y: Math.floor((player.position.y + invitee.position.y) / 2),
++            };
++      movePlayer(game, now, player, destination);
++    }
+     return { conversationId };
+   }
+ 
+diff --git a/convex/constants.ts b/convex/constants.ts
+index 4e84750..9700211 100644
+--- a/convex/constants.ts
++++ b/convex/constants.ts
+@@ -11,6 +11,10 @@ export const STEP_INTERVAL = 1000;
+ export const PATHFINDING_TIMEOUT = 60 * 1000;
+ export const PATHFINDING_BACKOFF = 1000;
+ export const CONVERSATION_DISTANCE = 1.3;
++// Max tile distance for starting/accepting a conversation invite. Prevents NPCs
++// (and humans) from locking the whole town into cross-map chats. Aligns with
++// Orion embodiment EMBODIMENT_SOCIAL_INITIATE_DISTANCE default (6).
++export const MAX_INVITE_DISTANCE = 6;
+ export const MIDPOINT_THRESHOLD = 4;
+ export const TYPING_TIMEOUT = 15 * 1000;
+ export const COLLISION_THRESHOLD = 0.75;
+@@ -30,7 +34,7 @@ export const PLAYER_CONVERSATION_COOLDOWN = 60000;
+ // Invite 80% of invites that come from other agents.
+ export const INVITE_ACCEPT_PROBABILITY = 0.8;
+ 
+-// Wait for 1m for invites to be accepted.
++// Pending invites (status invited) expire after this window. walkingOver does not.
+ export const INVITE_TIMEOUT = 60000;
+ 
+ // Wait for another player to say something before jumping in.
+ export const AWKWARD_CONVERSATION_TIMEOUT = 60_000; // more time locally

--- a/services/orion-ai-town/patches/orion-town-chat-turns.patch
+++ b/services/orion-ai-town/patches/orion-town-chat-turns.patch
@@ -1,0 +1,186 @@
+diff --git a/convex/agent/conversation.ts b/convex/agent/conversation.ts
+index 7ab0ad1..0ca01dd 100644
+--- a/convex/agent/conversation.ts
++++ b/convex/agent/conversation.ts
+@@ -10,6 +10,21 @@ import { NUM_MEMORIES_TO_SEARCH } from '../constants';
+ 
+ const selfInternal = internal.agent.conversation;
+ 
++const TOWN_REPLY_MAX_CHARS = 320;
++
++function clampTownReply(text: string, maxChars: number = TOWN_REPLY_MAX_CHARS): string {
++  const trimmed = text.trim();
++  if (trimmed.length <= maxChars) {
++    return trimmed;
++  }
++  const cut = trimmed.slice(0, maxChars);
++  const lastStop = Math.max(cut.lastIndexOf('.'), cut.lastIndexOf('?'), cut.lastIndexOf('!'));
++  if (lastStop > maxChars * 0.5) {
++    return cut.slice(0, lastStop + 1).trim();
++  }
++  return `${cut.trim()}…`;
++}
++
+ export async function startConversationMessage(
+   ctx: ActionCtx,
+   worldId: Id<'worlds'>,
+@@ -43,6 +58,9 @@ export async function startConversationMessage(
+   );
+   const prompt = [
+     `You are ${player.name}, and you just started a conversation with ${otherPlayer.name}.`,
++    `You are in a small pixel-art town. Speak in first person as ${player.name}.`,
++    `Give a short in-character greeting (1-2 sentences, under 220 characters).`,
++    `No scene description, narration, stage directions, or markdown.`,
+   ];
+   prompt.push(...agentPrompts(otherPlayer, agent, otherAgent ?? null));
+   prompt.push(...previousConversationPrompt(otherPlayer, lastConversation));
+@@ -62,10 +80,10 @@ export async function startConversationMessage(
+         content: prompt.join('\n'),
+       },
+     ],
+-    max_tokens: 300,
++    max_tokens: 120,
+     stop: stopWords(otherPlayer.name, player.name),
+   });
+-  return trimContentPrefx(content, lastPrompt);
++  return clampTownReply(trimContentPrefx(content, lastPrompt));
+ }
+ 
+ function trimContentPrefx(content: string, prompt: string) {
+@@ -106,7 +124,9 @@ export async function continueConversationMessage(
+   prompt.push(...relatedMemoriesPrompt(memories));
+   prompt.push(
+     `Below is the current chat history between you and ${otherPlayer.name}.`,
+-    `DO NOT greet them again. Do NOT use the word "Hey" too often. Your response should be brief and within 200 characters.`,
++    `Respond directly to what they just said. Speak in first person as ${player.name}.`,
++    `Short in-character reply only: 1-3 sentences, under 220 characters.`,
++    `No scene description, narration, stage directions, or markdown. Do NOT greet again.`,
+   );
+ 
+   const llmMessages: LLMMessage[] = [
+@@ -127,10 +147,10 @@ export async function continueConversationMessage(
+ 
+   const { content } = await chatCompletion({
+     messages: llmMessages,
+-    max_tokens: 300,
++    max_tokens: 120,
+     stop: stopWords(otherPlayer.name, player.name),
+   });
+-  return trimContentPrefx(content, lastPrompt);
++  return clampTownReply(trimContentPrefx(content, lastPrompt));
+ }
+ 
+ export async function leaveConversationMessage(
+@@ -151,12 +171,12 @@ export async function leaveConversationMessage(
+   );
+   const prompt = [
+     `You are ${player.name}, and you're currently in a conversation with ${otherPlayer.name}.`,
+-    `You've decided to leave the question and would like to politely tell them you're leaving the conversation.`,
++    `You've decided to leave and want to politely say goodbye.`,
+   ];
+   prompt.push(...agentPrompts(otherPlayer, agent, otherAgent ?? null));
+   prompt.push(
+     `Below is the current chat history between you and ${otherPlayer.name}.`,
+-    `How would you like to tell them that you're leaving? Your response should be brief and within 200 characters.`,
++    `One short goodbye line in first person, under 220 characters. No narration.`,
+   );
+   const llmMessages: LLMMessage[] = [
+     {
+@@ -176,10 +196,10 @@ export async function leaveConversationMessage(
+ 
+   const { content } = await chatCompletion({
+     messages: llmMessages,
+-    max_tokens: 300,
++    max_tokens: 80,
+     stop: stopWords(otherPlayer.name, player.name),
+   });
+-  return trimContentPrefx(content, lastPrompt);
++  return clampTownReply(trimContentPrefx(content, lastPrompt));
+ }
+ 
+ function agentPrompts(
+diff --git a/convex/aiTown/agent.ts b/convex/aiTown/agent.ts
+index b34c57b..66786ec 100644
+--- a/convex/aiTown/agent.ts
++++ b/convex/aiTown/agent.ts
+@@ -7,6 +7,7 @@ import {
+   AWKWARD_CONVERSATION_TIMEOUT,
+   CONVERSATION_COOLDOWN,
+   CONVERSATION_DISTANCE,
++  HUMAN_REPLY_GRACE_MS,
+   INVITE_ACCEPT_PROBABILITY,
+   INVITE_TIMEOUT,
+   MAX_INVITE_DISTANCE,
+@@ -175,6 +176,10 @@ export class Agent {
+           return;
+         }
+         if (!conversation.lastMessage) {
++          // Humans speak through the UI. Never talk over them with a synthetic opener.
++          if (otherPlayer.human) {
++            return;
++          }
+           const isInitiator = conversation.creator === player.id;
+           const awkwardDeadline = started + AWKWARD_CONVERSATION_TIMEOUT;
+           // Send the first message if we're the initiator or if we've been waiting for too long.
+@@ -198,26 +203,31 @@ export class Agent {
+             return;
+           }
+         }
+-        // See if the conversation has been going on too long and decide to leave.
+-        const tooLongDeadline = started + MAX_CONVERSATION_DURATION;
+-        if (tooLongDeadline < now || conversation.numMessages > MAX_CONVERSATION_MESSAGES) {
+-          console.log(`${player.id} leaving conversation with ${otherPlayer.id}.`);
+-          const messageUuid = crypto.randomUUID();
+-          conversation.setIsTyping(now, player, messageUuid);
+-          this.startOperation(game, now, 'agentGenerateMessage', {
+-            worldId: game.worldId,
+-            playerId: player.id,
+-            agentId: this.id,
+-            conversationId: conversation.id,
+-            otherPlayerId: otherPlayer.id,
+-            messageUuid,
+-            type: 'leave',
+-          });
+-          return;
++        // NPC-NPC chats wind down on their own. With a human partner, stay until they leave.
++        if (!otherPlayer.human) {
++          const tooLongDeadline = started + MAX_CONVERSATION_DURATION;
++          if (tooLongDeadline < now || conversation.numMessages > MAX_CONVERSATION_MESSAGES) {
++            console.log(`${player.id} leaving conversation with ${otherPlayer.id}.`);
++            const messageUuid = crypto.randomUUID();
++            conversation.setIsTyping(now, player, messageUuid);
++            this.startOperation(game, now, 'agentGenerateMessage', {
++              worldId: game.worldId,
++              playerId: player.id,
++              agentId: this.id,
++              conversationId: conversation.id,
++              otherPlayerId: otherPlayer.id,
++              messageUuid,
++              type: 'leave',
++            });
++            return;
++          }
+         }
+         // Wait for the awkward deadline if we sent the last message.
+         if (conversation.lastMessage.author === player.id) {
+-          const awkwardDeadline = conversation.lastMessage.timestamp + AWKWARD_CONVERSATION_TIMEOUT;
++          const awkwardTimeout = otherPlayer.human
++            ? HUMAN_REPLY_GRACE_MS
++            : AWKWARD_CONVERSATION_TIMEOUT;
++          const awkwardDeadline = conversation.lastMessage.timestamp + awkwardTimeout;
+           if (now < awkwardDeadline) {
+             return;
+           }
+diff --git a/convex/constants.ts b/convex/constants.ts
+index 9700211..98c8d79 100644
+--- a/convex/constants.ts
++++ b/convex/constants.ts
+@@ -38,6 +38,8 @@ export const INVITE_TIMEOUT = 60000;
+ // Wait for another player to say something before jumping in.
+ export const AWKWARD_CONVERSATION_TIMEOUT = 60_000; // more time locally
+ // export const AWKWARD_CONVERSATION_TIMEOUT = 20_000;
++// After an NPC speaks in a human conversation, wait longer before speaking again.
++export const HUMAN_REPLY_GRACE_MS = 3 * 60_000;
+ 
+ // Leave a conversation after participating too long.
+ export const MAX_CONVERSATION_DURATION = 10 * 60_000; // more time locally

--- a/services/orion-ai-town/scripts/apply_upstream_patches.sh
+++ b/services/orion-ai-town/scripts/apply_upstream_patches.sh
@@ -3,7 +3,14 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 UPSTREAM="${ROOT}/upstream"
-PATCHES=("orion-hub-embed.patch" "orion-character.patch" "orion-human-juniper.patch" "orion-engine-recovery.patch")
+PATCHES=(
+  "orion-hub-embed.patch"
+  "orion-character.patch"
+  "orion-human-juniper.patch"
+  "orion-engine-recovery.patch"
+  "orion-conversation-proximity.patch"
+  "orion-town-chat-turns.patch"
+)
 
 if [[ ! -d "${UPSTREAM}/.git" ]]; then
   echo "Missing ${UPSTREAM} — clone upstream first (see README.md)" >&2

--- a/services/orion-ai-town/tests/test_conversation_proximity_patch.py
+++ b/services/orion-ai-town/tests/test_conversation_proximity_patch.py
@@ -1,0 +1,36 @@
+"""Gate tests for conversation proximity patch (NPC walk-up before chat)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SERVICE = Path(__file__).resolve().parents[1]
+_PATCH = _SERVICE / "patches" / "orion-conversation-proximity.patch"
+_APPLY = _SERVICE / "scripts" / "apply_upstream_patches.sh"
+
+
+def test_proximity_patch_registered_in_apply_script():
+    text = _APPLY.read_text(encoding="utf-8")
+    assert "orion-conversation-proximity.patch" in text
+
+
+def test_proximity_patch_defines_max_invite_distance():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "MAX_INVITE_DISTANCE = 6" in patch
+    assert "CONVERSATION_DISTANCE" in patch
+
+
+def test_proximity_patch_limits_candidate_search_and_start():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "findConversationCandidate" in patch
+    assert "d > MAX_INVITE_DISTANCE" in patch
+    assert "Players too far apart to start a conversation" in patch
+    assert "movePlayer(game, now, player, destination)" in patch
+
+
+def test_accepted_walking_over_does_not_expire_on_invite_timeout():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "walkingOver, the accepted invite is a contract" in patch
+    assert "otherMember.status.kind === 'invited'" in patch
+    assert "timing out stale invite" in patch
+    assert "walkingOver does not" in patch

--- a/services/orion-ai-town/tests/test_town_chat_turns_patch.py
+++ b/services/orion-ai-town/tests/test_town_chat_turns_patch.py
@@ -1,0 +1,33 @@
+"""Gate tests for town NPC chat turn-taking and reply quality patch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SERVICE = Path(__file__).resolve().parents[1]
+_PATCH = _SERVICE / "patches" / "orion-town-chat-turns.patch"
+_APPLY = _SERVICE / "scripts" / "apply_upstream_patches.sh"
+
+
+def test_chat_turns_patch_registered_in_apply_script():
+    text = _APPLY.read_text(encoding="utf-8")
+    assert "orion-town-chat-turns.patch" in text
+
+
+def test_chat_turns_waits_for_human_before_npc_opener():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "Never talk over them with a synthetic opener" in patch
+    assert "otherPlayer.human" in patch
+
+
+def test_chat_turns_npc_stays_in_human_conversation():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "With a human partner, stay until they leave" in patch
+    assert "HUMAN_REPLY_GRACE_MS" in patch
+
+
+def test_chat_turns_clamps_narration_and_reply_length():
+    patch = _PATCH.read_text(encoding="utf-8")
+    assert "clampTownReply" in patch
+    assert "No scene description, narration" in patch
+    assert "max_tokens: 120" in patch

--- a/services/orion-embodiment/.env_example
+++ b/services/orion-embodiment/.env_example
@@ -42,18 +42,12 @@ EMBODIMENT_SPEECH_TIMEOUT_SEC=30
 # Cortex exec RPC rail reused for speech (do not invent a new schema).
 EMBODIMENT_CORTEX_REQUEST_CHANNEL=orion:cortex:exec:request
 EMBODIMENT_CORTEX_RESULT_PREFIX=orion:exec:result
-# Prefer the unified turn (full cognition pass) for town speech; fall back to the
-# quick cortex rail above on timeout/error. false = quick-only legacy behavior.
-EMBODIMENT_SPEECH_UNIFIED_ENABLED=true
-# Hub unified-turn endpoint. The hub runs network_mode=host, so its Docker service DNS
-# name does NOT resolve from this app-net container — use the node's host-reachable
-# (Tailscale) IP, like ORION_BUS_URL. Hub must have ORION_UNIFIED_TURN_ENABLED=true and
-# ORION_HARNESS_GOVERNOR_ENABLED=true or the path always falls back to quick.
-EMBODIMENT_HUB_CHAT_URL=http://100.92.216.81:8080/api/chat
-# Unified turn HTTP timeout (sec). Longer than quick — full cognition pass.
-EMBODIMENT_UNIFIED_TIMEOUT_SEC=120
-# Session id prefix for unified town turns: session_id = "<prefix>:<conversation_id>".
-EMBODIMENT_UNIFIED_SESSION_PREFIX=aitown
+# Prefer grounded_small via cortex chat_general on the chat lane; fall back to quick.
+EMBODIMENT_SPEECH_HUB_ENABLED=true
+# Deprecated alias: EMBODIMENT_SPEECH_UNIFIED_ENABLED
+EMBODIMENT_SPEECH_HUB_LLM_ROUTE=chat
+# Grounded_small cortex RPC timeout (sec); then falls back to quick.
+EMBODIMENT_UNIFIED_TIMEOUT_SEC=45
 EMBODIMENT_MEMORY_ENABLED=false
 # Conversation engagement: accept invites, walk to partner, reach participating.
 EMBODIMENT_SOCIAL_ENABLED=false

--- a/services/orion-embodiment/app/worker.py
+++ b/services/orion-embodiment/app/worker.py
@@ -118,11 +118,31 @@ class EmbodimentWorker:
 
     def _load_fcc_env(self) -> None:
         for k, v in load_fcc_env(expand_env_path(self._settings.fcc_env_path)).items():
-            os.environ.setdefault(k, v)
+            # AITOWN_* keys must track ~/.fcc/.env updates (world wipe/bootstrap)
+            # without requiring a container restart.
+            if k.startswith("AITOWN_"):
+                os.environ[k] = v
+            else:
+                os.environ.setdefault(k, v)
         # Explicit override wins over the ~/.fcc/.env value (bridge reachability).
         override = self._settings.aitown_convex_url.strip()
         if override:
             os.environ["AITOWN_CONVEX_URL"] = override
+
+    def _refresh_aitown_runtime(self) -> None:
+        """Re-read AI Town ids from the mounted FCC env each perception tick."""
+        prev_world = self._world_id
+        self._load_fcc_env()
+        self._world_id = str(os.environ.get("AITOWN_WORLD_ID") or "").strip()
+        self._orion_player_id = str(os.environ.get("AITOWN_ORION_PLAYER_ID") or "").strip()
+        if self._world_id != prev_world:
+            self._walkable_loaded = False
+            self._walkable = None
+            logger.info(
+                "embodiment_aitown_runtime_refresh world_id=%s player_id=%s",
+                self._world_id,
+                self._orion_player_id,
+            )
 
     def _service_ref(self) -> ServiceRef:
         return ServiceRef(
@@ -597,6 +617,7 @@ class EmbodimentWorker:
     async def _perception_loop(self) -> None:
         interval = self._settings.perception_interval_sec
         while not self._stop.is_set():
+            self._refresh_aitown_runtime()
             try:
                 perception = await self._emit_perception_once()
             except Exception:
@@ -614,10 +635,10 @@ class EmbodimentWorker:
                 except Exception:
                     logger.exception("embodiment_social_loop_failed")
             if perception is not None and getattr(self._settings, "speech_enabled", False):
-                try:
-                    await self._speak_once(perception)
-                except Exception:
-                    logger.exception("embodiment_speech_loop_failed")
+                asyncio.create_task(
+                    self._speak_once_safe(perception),
+                    name=f"embodiment-speech-{uuid4()}",
+                )
             # Don't wander off while engaging a conversation — but only when social
             # engagement is enabled. With it off, a town-initiated invite would
             # otherwise freeze Orion (suppressed wander + no engagement).
@@ -684,6 +705,13 @@ class EmbodimentWorker:
         )
         await self._actuate(intent, now=now)
 
+    async def _speak_once_safe(self, perception: WorldPerceptionV1) -> None:
+        """Fire-and-forget wrapper so a slow utterance RPC cannot stall perception."""
+        try:
+            await self._speak_once(perception)
+        except Exception:
+            logger.exception("embodiment_speech_loop_failed")
+
     # --- speech (cortex-generated town utterances) --------------------------
     async def _speak_once(self, perception: WorldPerceptionV1) -> Optional[str]:
         """Gated, fail-open speech pass. Own-agent only; one utterance per convo."""
@@ -748,75 +776,85 @@ class EmbodimentWorker:
     async def _request_utterance(
         self, prompt: str, *, correlation_id: str, convo_id: Optional[str] = None
     ) -> str:
-        """Generate a town utterance. Dispatcher: prefer the unified turn (full
-        cognition pass over the hub saga); fall back to the quick cortex rail on
-        timeout/error/empty. Fail-open -> ''.
+        """Generate a town utterance. Dispatcher: prefer grounded_small on the chat
+        cortex rail; fall back to quick on timeout/error/empty. Fail-open -> ''.
 
-        Set ``speech_unified_enabled`` false to force the legacy quick-only path.
+        Hub HTTP is intentionally avoided here — ``mode=orion`` on the hub often
+        falls through to the full brain/appraisal stack and can block town turns
+        for minutes.
         """
         if getattr(self._settings, "speech_unified_enabled", False):
-            session_id = f"{self._settings.unified_session_prefix}:{convo_id or 'orion'}"
             try:
-                unified = await self._request_utterance_unified(
-                    prompt, correlation_id=correlation_id, session_id=session_id
+                grounded = await self._request_utterance_cortex(
+                    prompt,
+                    correlation_id=correlation_id,
+                    verb="chat_general",
+                    lane=str(getattr(self._settings, "speech_hub_llm_route", "chat") or "chat"),
+                    hub_chat_lane="grounded_small",
+                    timeout_sec=float(self._settings.unified_timeout_sec),
                 )
-                if unified.strip():
-                    return unified
-                # A non-final/empty frame already logged its discriminating reason.
+                if grounded.strip():
+                    return grounded
             except Exception as exc:
                 logger.info(
-                    "embodiment_speech_unified_fallback reason=%s corr=%s",
+                    "embodiment_speech_grounded_fallback reason=%s corr=%s",
                     type(exc).__name__, correlation_id,
                 )
         return await self._request_utterance_quick(prompt, correlation_id=correlation_id)
 
-    async def _request_utterance_unified(
-        self, prompt: str, *, correlation_id: str, session_id: str
+    async def _request_utterance_cortex(
+        self,
+        prompt: str,
+        *,
+        correlation_id: str,
+        verb: str,
+        lane: str,
+        hub_chat_lane: str,
+        timeout_sec: float,
     ) -> str:
-        """Route the utterance through the hub-only unified turn saga
-        (``POST /api/chat`` with ``mode=orion``). Returns the final text on success;
-        returns "" to signal fallback on any non-final/empty frame, logging a
-        discriminating ``reason`` (``turn_error`` vs ``turn_deferred`` vs
-        ``non_final:<type>`` vs ``empty``) so an operator can tell a real cognition
-        failure from a benign quiet turn. Network/JSON errors propagate to the
-        dispatcher, which logs one fallback line."""
-        import urllib.request
+        """Cortex-exec RPC for town speech with grounded_small surface context."""
+        from orion.cognition.cortex_payload_extract import extract_cortex_payload_text
+        from orion.cognition.plan_loader import build_plan_for_verb
+        from orion.schemas.cortex.schemas import PlanExecutionArgs, PlanExecutionRequest
 
-        body = json.dumps(
-            {
-                "mode": "orion",
-                "session_id": session_id,
-                "messages": [{"role": "user", "content": prompt}],
-            }
-        ).encode("utf-8")
-
-        def _post() -> dict:
-            req = urllib.request.Request(
-                self._settings.hub_chat_url,
-                data=body,
-                headers={"Content-Type": "application/json"},
-                method="POST",
-            )
-            with urllib.request.urlopen(
-                req, timeout=float(self._settings.unified_timeout_sec)
-            ) as resp:
-                raw = resp.read().decode("utf-8")
-            return json.loads(raw)
-
-        frame = await asyncio.to_thread(_post)
-        frame_type = frame.get("type") if isinstance(frame, dict) else None
-        if frame_type != "final":
-            reason = frame_type if frame_type in ("turn_error", "turn_deferred") else f"non_final:{frame_type}"
-            logger.info(
-                "embodiment_speech_unified_fallback reason=%s corr=%s", reason, correlation_id
-            )
+        plan = build_plan_for_verb(verb, mode=lane)
+        req = PlanExecutionRequest(
+            plan=plan,
+            args=PlanExecutionArgs(
+                request_id=correlation_id,
+                trigger_source=self._settings.service_name,
+                extra={"lane": lane, "llm_route": lane},
+            ),
+            context={
+                "user_message": prompt,
+                "metadata": {"correlation_id": correlation_id, "mind_enabled": True},
+                "surface_context": {
+                    "hub_chat_lane": hub_chat_lane,
+                    "surface": "aitown",
+                },
+            },
+        )
+        reply_channel = f"{self._settings.cortex_result_prefix}:{uuid4()}"
+        env = BaseEnvelope(
+            kind=req.kind,
+            source=self._service_ref(),
+            correlation_id=correlation_id,
+            reply_to=reply_channel,
+            payload=req.model_dump(mode="json"),
+        )
+        msg = await self._bus.rpc_request(
+            self._settings.cortex_request_channel,
+            env,
+            reply_channel=reply_channel,
+            timeout_sec=timeout_sec,
+        )
+        decoded = self._bus.codec.decode(msg.get("data"))
+        if not decoded.ok:
             return ""
-        text = str(frame.get("llm_response") or "").strip()
-        if not text:
-            logger.info(
-                "embodiment_speech_unified_fallback reason=empty corr=%s", correlation_id
-            )
-        return text
+        payload = decoded.envelope.payload
+        result = payload.get("result") if isinstance(payload, dict) else None
+        text = extract_cortex_payload_text(result if isinstance(result, dict) else (payload or {}))
+        return str(text or "")
 
     async def _request_utterance_quick(self, prompt: str, *, correlation_id: str) -> str:
         """Reuse the cortex exec rail to generate an utterance. Fail-open -> ''."""

--- a/services/orion-embodiment/tests/test_worker_aitown_world_id_regression.py
+++ b/services/orion-embodiment/tests/test_worker_aitown_world_id_regression.py
@@ -1,0 +1,141 @@
+"""Regression tests for stale AITOWN_WORLD_ID after a fresh AI Town game.
+
+Live incident (2026-07-08): the embodiment worker cached a deleted world id at
+boot while ~/.fcc/.env already pointed at the new world. Every perception tick
+failed with ``Invalid world ID``, so Orion could not accept invites, move, or
+speak until the container was restarted.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
+from app.settings import get_settings
+from app.worker import EmbodimentWorker
+from orion.embodiment.aitown_client import AitownClientError
+
+
+_DELETED_WORLD_ID = "m173cy1e74gt2e06g9js1eq24s8a0b1b"
+_LIVE_WORLD_ID = "m174spk0rd4namch9qvt53fs4x8a4f62"
+
+
+def _worker() -> EmbodimentWorker:
+    w = EmbodimentWorker.__new__(EmbodimentWorker)
+    w._settings = get_settings()
+    w._bus = object()
+    w._stop = asyncio.Event()
+    w._walkable_loaded = False
+    w._walkable = None
+    return w
+
+
+def test_load_fcc_env_overwrites_stale_aitown_world_id_in_process_env(
+    tmp_path, monkeypatch,
+) -> None:
+    """AITOWN_* must not use setdefault — a stale process env must lose to ~/.fcc/.env."""
+    monkeypatch.setenv("AITOWN_WORLD_ID", _DELETED_WORLD_ID)
+    fcc = tmp_path / ".fcc.env"
+    fcc.write_text(f"AITOWN_WORLD_ID={_LIVE_WORLD_ID}\n", encoding="utf-8")
+
+    w = _worker()
+    w._settings.fcc_env_path = str(fcc)
+    w._load_fcc_env()
+
+    assert os.environ["AITOWN_WORLD_ID"] == _LIVE_WORLD_ID
+
+
+def test_stale_boot_world_id_recovers_after_fresh_game_wipe_without_restart(
+    tmp_path, monkeypatch,
+) -> None:
+    """After bootstrap writes a new world id, perception must query the live world."""
+    monkeypatch.setenv("AITOWN_WORLD_ID", _DELETED_WORLD_ID)
+    monkeypatch.setenv("AITOWN_ORION_PLAYER_ID", "p:24")
+
+    fcc = tmp_path / ".fcc.env"
+    fcc.write_text(
+        f"AITOWN_WORLD_ID={_LIVE_WORLD_ID}\nAITOWN_ORION_PLAYER_ID=p:24\n",
+        encoding="utf-8",
+    )
+
+    w = _worker()
+    w._settings.fcc_env_path = str(fcc)
+    w._world_id = _DELETED_WORLD_ID
+    w._orion_player_id = "p:24"
+
+    queried: list[str | None] = []
+
+    def list_players(*, world_id: str | None = None):
+        queried.append(world_id)
+        if world_id == _DELETED_WORLD_ID:
+            raise AitownClientError(f"Invalid world ID: {world_id}")
+        return [{"id": "p:24", "position": {"x": 63.0, "y": 27.0}}]
+
+    with patch("app.worker.aitown_client.list_players", side_effect=list_players), \
+         patch("app.worker.aitown_client.list_conversations", return_value=[]), \
+         patch("app.worker.publish_with_reconnect", new=AsyncMock()):
+        stale_perception = asyncio.run(w._emit_perception_once())
+
+    assert stale_perception is None
+    assert queried == [_DELETED_WORLD_ID]
+
+    queried.clear()
+    w._refresh_aitown_runtime()
+
+    with patch("app.worker.aitown_client.list_players", side_effect=list_players), \
+         patch("app.worker.aitown_client.list_conversations", return_value=[]), \
+         patch("app.worker.publish_with_reconnect", new=AsyncMock()):
+        live_perception = asyncio.run(w._emit_perception_once())
+
+    assert live_perception is not None
+    assert live_perception.player_id == "p:24"
+    assert queried == [_LIVE_WORLD_ID]
+
+
+def test_perception_loop_refreshes_aitown_runtime_before_each_emit(
+    tmp_path, monkeypatch,
+) -> None:
+    """The live loop must re-read ~/.fcc/.env every tick, not only at container boot."""
+    monkeypatch.setenv("AITOWN_WORLD_ID", _DELETED_WORLD_ID)
+    monkeypatch.setenv("AITOWN_ORION_PLAYER_ID", "p:24")
+
+    fcc = tmp_path / ".fcc.env"
+    fcc.write_text(
+        f"AITOWN_WORLD_ID={_LIVE_WORLD_ID}\nAITOWN_ORION_PLAYER_ID=p:24\n",
+        encoding="utf-8",
+    )
+
+    w = _worker()
+    w._settings.fcc_env_path = str(fcc)
+    w._settings.perception_interval_sec = 0.01
+    w._world_id = _DELETED_WORLD_ID
+    w._orion_player_id = "p:24"
+    w._last_heartbeat_log_at = None
+
+    refresh_calls = 0
+    emit_world_ids: list[str] = []
+
+    real_refresh = w._refresh_aitown_runtime
+
+    def counting_refresh() -> None:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        real_refresh()
+
+    async def capture_emit():
+        emit_world_ids.append(w._world_id)
+        w._stop.set()
+        return None
+
+    async def run_loop() -> None:
+        with patch.object(w, "_refresh_aitown_runtime", side_effect=counting_refresh), \
+             patch.object(w, "_emit_perception_once", side_effect=capture_emit), \
+             patch.object(w, "_maybe_log_heartbeat"):
+            loop_task = asyncio.create_task(w._perception_loop())
+            await asyncio.wait_for(w._stop.wait(), timeout=2.0)
+            await asyncio.wait_for(loop_task, timeout=2.0)
+
+    asyncio.run(run_loop())
+
+    assert refresh_calls >= 1
+    assert emit_world_ids == [_LIVE_WORLD_ID]

--- a/services/orion-embodiment/tests/test_worker_perception.py
+++ b/services/orion-embodiment/tests/test_worker_perception.py
@@ -73,6 +73,27 @@ def test_emit_perception_once_fail_open_on_malformed_row():
     pub.assert_not_awaited()
 
 
+def test_refresh_aitown_runtime_picks_up_updated_fcc_world_id(tmp_path, monkeypatch):
+    w = _worker()
+    w._walkable_loaded = True
+    w._walkable = {(1, 1)}
+    fcc = tmp_path / ".fcc.env"
+    fcc.write_text(
+        "AITOWN_WORLD_ID=new-world\nAITOWN_ORION_PLAYER_ID=p:99\n",
+        encoding="utf-8",
+    )
+    w._settings.fcc_env_path = str(fcc)
+    w._world_id = "old-world"
+    w._orion_player_id = "p:1"
+
+    w._refresh_aitown_runtime()
+
+    assert w._world_id == "new-world"
+    assert w._orion_player_id == "p:99"
+    assert w._walkable_loaded is False
+    assert w._walkable is None
+
+
 def test_emit_perception_once_fail_open_on_publish_error():
     w = _worker()
     players = [{"id": "orion", "position": {"x": 0.0, "y": 0.0}}]

--- a/services/orion-embodiment/tests/test_worker_speech_unified.py
+++ b/services/orion-embodiment/tests/test_worker_speech_unified.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
-import urllib.error
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -10,7 +8,7 @@ from app.worker import EmbodimentWorker
 from orion.schemas.embodiment import WorldPerceptionV1
 
 
-def _worker(*, unified: bool = True) -> EmbodimentWorker:
+def _worker(*, grounded_enabled: bool = True) -> EmbodimentWorker:
     w = EmbodimentWorker.__new__(EmbodimentWorker)
     w._orion_player_id = "orion"
     w._world_id = "w1"
@@ -23,10 +21,9 @@ def _worker(*, unified: bool = True) -> EmbodimentWorker:
         speech_timeout_sec=30.0,
         cortex_request_channel="orion:cortex:exec:request",
         cortex_result_prefix="orion:exec:result",
-        speech_unified_enabled=unified,
-        hub_chat_url="http://orion-athena-hub:8080/api/chat",
-        unified_timeout_sec=120.0,
-        unified_session_prefix="aitown",
+        speech_unified_enabled=grounded_enabled,
+        speech_hub_llm_route="chat",
+        unified_timeout_sec=45.0,
     )
     return w
 
@@ -45,49 +42,30 @@ def _perception_in_convo() -> WorldPerceptionV1:
     )
 
 
-class _FakeResp:
-    """Minimal urlopen context-manager stand-in returning a JSON body."""
-
-    def __init__(self, payload) -> None:
-        self._body = json.dumps(payload).encode("utf-8")
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        return False
-
-    def read(self):
-        return self._body
-
-
-def _final_frame(text: str) -> dict:
-    return {"type": "final", "correlation_id": "c1", "mode": "orion", "llm_response": text, "finalize_ran": True}
-
-
-def test_unified_success_injects_hub_response_and_skips_quick():
-    w = _worker(unified=True)
+def test_grounded_cortex_success_skips_quick():
+    w = _worker(grounded_enabled=True)
+    grounded = AsyncMock(return_value="Hello from grounded_small")
     quick = AsyncMock(return_value="QUICK_SHOULD_NOT_BE_USED")
-    with patch.object(w, "_request_utterance_quick", new=quick), \
-         patch("urllib.request.urlopen", return_value=_FakeResp(_final_frame("Hello from unified"))) as uo, \
+    with patch.object(w, "_request_utterance_cortex", new=grounded), \
+         patch.object(w, "_request_utterance_quick", new=quick), \
          patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
          patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
         result = asyncio.run(w._speak_once(_perception_in_convo()))
-    assert result == "Hello from unified"
+    assert result == "Hello from grounded_small"
     quick.assert_not_awaited()
-    # session_id is built from the active conversation id.
-    posted = uo.call_args.args[0]
-    body = json.loads(posted.data.decode("utf-8"))
-    assert body["mode"] == "orion"
-    assert body["session_id"] == "aitown:conv1"
-    assert body["messages"][0]["role"] == "user"
+    grounded.assert_awaited_once()
+    kwargs = grounded.await_args.kwargs
+    assert kwargs["verb"] == "chat_general"
+    assert kwargs["lane"] == "chat"
+    assert kwargs["hub_chat_lane"] == "grounded_small"
 
 
-def test_unified_timeout_falls_back_to_quick():
-    w = _worker(unified=True)
+def test_grounded_cortex_error_falls_back_to_quick():
+    w = _worker(grounded_enabled=True)
+    grounded = AsyncMock(side_effect=TimeoutError("slow"))
     quick = AsyncMock(return_value="Quick fallback reply")
-    with patch.object(w, "_request_utterance_quick", new=quick), \
-         patch("urllib.request.urlopen", side_effect=urllib.error.URLError("timed out")), \
+    with patch.object(w, "_request_utterance_cortex", new=grounded), \
+         patch.object(w, "_request_utterance_quick", new=quick), \
          patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
          patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
         result = asyncio.run(w._speak_once(_perception_in_convo()))
@@ -95,93 +73,15 @@ def test_unified_timeout_falls_back_to_quick():
     quick.assert_awaited_once()
 
 
-def test_unified_turn_error_frame_falls_back_to_quick():
-    w = _worker(unified=True)
-    quick = AsyncMock(return_value="Quick fallback reply")
-    with patch.object(w, "_request_utterance_quick", new=quick), \
-         patch("urllib.request.urlopen", return_value=_FakeResp({"type": "turn_error", "detail": "boom"})), \
-         patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
-         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
-        result = asyncio.run(w._speak_once(_perception_in_convo()))
-    assert result == "Quick fallback reply"
-    quick.assert_awaited_once()
-
-
-def test_unified_turn_deferred_frame_falls_back_to_quick():
-    w = _worker(unified=True)
-    quick = AsyncMock(return_value="Quick fallback reply")
-    with patch.object(w, "_request_utterance_quick", new=quick), \
-         patch("urllib.request.urlopen", return_value=_FakeResp({"type": "turn_deferred", "reason": "cooldown"})), \
-         patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
-         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
-        result = asyncio.run(w._speak_once(_perception_in_convo()))
-    assert result == "Quick fallback reply"
-    quick.assert_awaited_once()
-
-
-def test_unified_empty_llm_response_falls_back_to_quick():
-    w = _worker(unified=True)
-    quick = AsyncMock(return_value="Quick fallback reply")
-    with patch.object(w, "_request_utterance_quick", new=quick), \
-         patch("urllib.request.urlopen", return_value=_FakeResp(_final_frame("   "))), \
-         patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
-         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
-        result = asyncio.run(w._speak_once(_perception_in_convo()))
-    assert result == "Quick fallback reply"
-    quick.assert_awaited_once()
-
-
-def test_unified_bad_json_falls_back_to_quick():
-    w = _worker(unified=True)
-    quick = AsyncMock(return_value="Quick fallback reply")
-
-    class _BadResp(_FakeResp):
-        def __init__(self):
-            self._body = b"not json"
-
-    with patch.object(w, "_request_utterance_quick", new=quick), \
-         patch("urllib.request.urlopen", return_value=_BadResp()), \
-         patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
-         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
-        result = asyncio.run(w._speak_once(_perception_in_convo()))
-    assert result == "Quick fallback reply"
-    quick.assert_awaited_once()
-
-
-def test_unified_fallback_logs_distinguishable_reason():
-    """A hub cognition failure (turn_error) must be logged with a reason distinct
-    from a benign empty reply, so an operator can tell them apart (anti silent-failure)."""
-    w = _worker(unified=True)
-    quick = AsyncMock(return_value="Quick fallback reply")
-    with patch.object(w, "_request_utterance_quick", new=quick), \
-         patch("urllib.request.urlopen", return_value=_FakeResp({"type": "turn_error"})), \
-         patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
-         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}), \
-         patch("app.worker.logger.info") as info:
-        asyncio.run(w._speak_once(_perception_in_convo()))
-    reasons = [c for c in info.call_args_list if "embodiment_speech_unified_fallback" in str(c.args[0])]
-    assert reasons, "expected a fallback log line"
-    assert any("turn_error" in str(c.args) for c in reasons), "turn_error must be logged as its own reason, not collapsed to empty"
-
-    w2 = _worker(unified=True)
-    with patch.object(w2, "_request_utterance_quick", new=AsyncMock(return_value="q")), \
-         patch("urllib.request.urlopen", return_value=_FakeResp(_final_frame("   "))), \
-         patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
-         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}), \
-         patch("app.worker.logger.info") as info2:
-        asyncio.run(w2._speak_once(_perception_in_convo()))
-    empty_reasons = [c for c in info2.call_args_list if "embodiment_speech_unified_fallback" in str(c.args[0])]
-    assert any("empty" in str(c.args) for c in empty_reasons), "empty final reply must log reason=empty"
-
-
-def test_unified_disabled_uses_quick_directly():
-    w = _worker(unified=False)
+def test_grounded_disabled_uses_quick_directly():
+    w = _worker(grounded_enabled=False)
+    grounded = AsyncMock(return_value="nope")
     quick = AsyncMock(return_value="Quick direct reply")
-    with patch.object(w, "_request_utterance_quick", new=quick), \
-         patch("urllib.request.urlopen") as uo, \
+    with patch.object(w, "_request_utterance_cortex", new=grounded), \
+         patch.object(w, "_request_utterance_quick", new=quick), \
          patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
          patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
         result = asyncio.run(w._speak_once(_perception_in_convo()))
     assert result == "Quick direct reply"
+    grounded.assert_not_awaited()
     quick.assert_awaited_once()
-    uo.assert_not_called()


### PR DESCRIPTION
## Summary

- Route Orion embodiment speech through cortex-exec `chat_general` with `hub_chat_lane=grounded_small` (quick fallback), non-blocking so invites/movement don't freeze.
- Fix stale `AITOWN_WORLD_ID` after game wipe by refreshing `~/.fcc/.env` each perception tick (Orion unfreezes without container restart).
- Add AI Town upstream patches for **conversation proximity** (6-tile invite gate, walk-up on accept, invite timeout only while pending).
- Add AI Town **chat turns** patch: human speaks first, short in-character replies (`clampTownReply`), no NPC auto-leave in human chats, 3 min reply grace.
- Gate tests for patches + embodiment world-id regressions (11 focused tests on touched seams).
- Design-only: integrated memory cognition loop spec (unrelated runtime; bundled on branch).

## Outcome moved

- Orion accepts invites, walks to partners, and speaks in town after world wipe.
- NPCs stop cross-map invite spam and observation-lounge monologues over Juniper's lines.
- Human↔NPC conversations stay open until the human leaves; accepted walk-ups don't expire mid-path.

## Current architecture

- Orion joins AI Town externally via embodiment worker + Convex HTTP (`orion/embodiment/aitown_client.py`).
- Stock AI Town engine invited nearest player globally, fired synthetic `start` LLM messages over humans, and auto-left at 8 messages.
- Embodiment worker cached `AITOWN_*` from boot env; world wipe changed IDs → `Invalid world ID` every tick.

## Architecture touched

- `services/orion-embodiment/app/worker.py` — speech dispatcher, AITOWN runtime refresh, non-blocking speak
- `services/orion-ai-town/patches/orion-conversation-proximity.patch` — engine invite distance + walk contract
- `services/orion-ai-town/patches/orion-town-chat-turns.patch` — NPC-human turn-taking + reply clamp
- `services/orion-ai-town/scripts/apply_upstream_patches.sh` — registers new patches

## Files changed

- `services/orion-embodiment/app/worker.py`: grounded_small cortex speech, live world-id refresh, async speak
- `services/orion-embodiment/.env_example`: speech hub / unified timeout keys
- `services/orion-embodiment/tests/test_worker_aitown_world_id_regression.py`: stale world-id regressions
- `services/orion-ai-town/patches/orion-conversation-proximity.patch`: proximity + invite timeout semantics
- `services/orion-ai-town/patches/orion-town-chat-turns.patch`: human-first chat + clamped replies
- `services/orion-ai-town/tests/test_*_patch.py`: deterministic patch contract gates
- `docs/superpowers/specs/2026-07-08-integrated-memory-cognition-loop-design.md`: design artifact only

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: AI Town Convex functions (upstream patches only); embodiment speech path (cortex-direct)
- Compatibility notes: redeploy Convex after merge (`npx convex dev --once` from `services/orion-ai-town/upstream`)

## Env/config changes

- Added keys: `EMBODIMENT_SPEECH_HUB_ENABLED`, `EMBODIMENT_SPEECH_HUB_LLM_ROUTE`, `EMBODIMENT_UNIFIED_TIMEOUT_SEC` (embodiment `.env_example`)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: yes (embodiment)
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: operator should run if keys missing
- skipped keys requiring operator action: none for embodiment speech keys

## Tests run

```text
.venv/bin/pytest services/orion-ai-town/tests/test_conversation_proximity_patch.py \
  services/orion-ai-town/tests/test_town_chat_turns_patch.py \
  services/orion-embodiment/tests/test_worker_aitown_world_id_regression.py -q
# 11 passed
```

## Evals run

```text
Not run — no periodic eval harness for ai-town patch contracts; gate tests cover patch content.
```

## Docker/build/smoke checks

```text
cd services/orion-ai-town/upstream && ./node_modules/.bin/convex dev --once
# ✔ Convex functions ready! (deployed to http://127.0.0.1:3210)

./node_modules/.bin/convex run testing:debugEngineState
# processed=7126 pending=0 (engine healthy)
```

## Review findings fixed

- Finding: NPCs invited across entire map / talked over human / narrated scene prose
  - Fix: `orion-conversation-proximity.patch` + `orion-town-chat-turns.patch`
  - Evidence: gate tests + live Convex deploy on mesh node
- Finding: Orion frozen after world wipe (stale `AITOWN_WORLD_ID`)
  - Fix: `_refresh_aitown_runtime()` each perception tick
  - Evidence: `test_worker_aitown_world_id_regression.py` (3 tests)

## Restart required

```bash
# After merge — redeploy Convex functions
cd services/orion-ai-town && bash scripts/apply_upstream_patches.sh
cd upstream && npx convex dev --once

# Restart embodiment if speech env keys changed
cd services/orion-embodiment
docker compose --env-file ../../.env --env-file .env up -d --build embodiment
```

## Risks / concerns

- Severity: low
- Concern: `orion-human-juniper.patch` may fail apply on upstream drift (`DEFAULT_NAME`); conversation patches apply cleanly after hub/character/engine-recovery.
- Mitigation: regenerate juniper patch when bumping `AITOWN_UPSTREAM_REF`.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/aitown-grounded-small-speech?expand=1
