### PR TITLE
fix(harness): emit substrate closure on voice finalize failure

### DIFF
--- a/orion/harness/finalize.py
+++ b/orion/harness/finalize.py
@@ -42,6 +42,7 @@ REPAIR_PRESSURE_MAX = 0.3
 VERDICT_CHANNEL = "orion:harness:verdict:artifact"
 OUTCOME_CHANNEL = "orion:substrate:turn_outcome"
 POST_TURN_CLOSURE_CHANNEL = "orion:substrate:post_turn_closure"
+SYSTEM_ERROR_CHANNEL = "orion:system:error"
 EMBODIMENT_INTENT_CHANNEL = "orion:embodiment:intent"
 
 # Interlocutor the finalized (relational) turn should approach in the town when
@@ -585,6 +586,8 @@ async def emit_turn_outcome_molecule(
     final_text: str,
     finalize_changed: bool,
     grammar_receipts: list[GrammarReceiptV1] | None = None,
+    finalize_failed: bool = False,
+    failure_reason: str | None = None,
     channel: str = OUTCOME_CHANNEL,
     publish_fn: PublishFn | None = None,
     bus: Any = None,
@@ -594,7 +597,8 @@ async def emit_turn_outcome_molecule(
         receipt.grammar_event_id for receipt in receipts if receipt.grammar_event_id
     ]
     surprise_resolved = (
-        reflection.alignment_verdict == "aligned"
+        not finalize_failed
+        and reflection.alignment_verdict == "aligned"
         and not reflection.strain_unresolved
         and (finalize_changed or substrate_appraisal.surprise_level < _quick_gate_epsilon())
     )
@@ -612,14 +616,18 @@ async def emit_turn_outcome_molecule(
         surprise_resolved=surprise_resolved,
         grammar_event_ids=grammar_event_ids,
         final_text=final_text,
+        finalize_failed=finalize_failed,
+        failure_reason=failure_reason,
+        draft_text_excerpt=_excerpt(draft_text) if finalize_failed else None,
     )
     if publish_fn is not None:
         await publish_fn(molecule, channel=channel)
         logger.info(
-            "harness_turn_outcome_published corr=%s channel=%s surprise_resolved=%s grammar_events=%d",
+            "harness_turn_outcome_published corr=%s channel=%s surprise_resolved=%s finalize_failed=%s grammar_events=%d",
             correlation_id,
             channel,
             surprise_resolved,
+            finalize_failed,
             len(grammar_event_ids),
         )
     elif bus is not None:
@@ -633,10 +641,11 @@ async def emit_turn_outcome_molecule(
         )
         await bus.publish(channel, envelope)
         logger.info(
-            "harness_turn_outcome_published corr=%s channel=%s surprise_resolved=%s grammar_events=%d",
+            "harness_turn_outcome_published corr=%s channel=%s surprise_resolved=%s finalize_failed=%s grammar_events=%d",
             correlation_id,
             channel,
             surprise_resolved,
+            finalize_failed,
             len(grammar_event_ids),
         )
     return molecule
@@ -682,6 +691,143 @@ class HarnessFinalizeChainResult:
     verdict_molecule_id: str
 
 
+@dataclass
+class HarnessFinalizePartialState:
+    substrate_appraisal: SubstrateFinalizeAppraisalV1
+    reflection: FinalizeReflectionV1
+    verdict_molecule: HarnessVerdictMoleculeV1
+    outcome_molecule: HarnessTurnOutcomeMoleculeV1
+    quick_lane_skipped_5b: bool
+    verdict_molecule_id: str
+
+
+class HarnessFinalizeFailedError(Exception):
+    """Voice finalize (5c) failed after substrate appraisal + reflection completed."""
+
+    def __init__(self, message: str, *, partial: HarnessFinalizePartialState) -> None:
+        super().__init__(message)
+        self.partial = partial
+
+
+async def emit_harness_finalize_system_error(
+    *,
+    correlation_id: str,
+    error: str,
+    phase: str = "orion_voice_finalize",
+    channel: str = SYSTEM_ERROR_CHANNEL,
+    publish_fn: PublishFn | None = None,
+    bus: Any = None,
+) -> None:
+    payload = {
+        "error": error,
+        "phase": phase,
+        "source": "orion-harness-governor",
+        "correlation_id": correlation_id,
+    }
+    if publish_fn is not None:
+        await publish_fn(payload, channel=channel)
+        logger.info(
+            "harness_finalize_system_error_published corr=%s channel=%s phase=%s",
+            correlation_id,
+            channel,
+            phase,
+        )
+    elif bus is not None:
+        from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+
+        envelope = BaseEnvelope(
+            kind="system.error.v1",
+            source=ServiceRef(name="orion-harness-governor"),
+            correlation_id=uuid.UUID(correlation_id) if _is_uuid(correlation_id) else uuid.uuid4(),
+            payload=payload,
+        )
+        await bus.publish(channel, envelope)
+        logger.info(
+            "harness_finalize_system_error_published corr=%s channel=%s phase=%s",
+            correlation_id,
+            channel,
+            phase,
+        )
+    else:
+        logger.warning(
+            "harness_finalize_system_error_skipped corr=%s reason=no_bus_or_publish_fn phase=%s",
+            correlation_id,
+            phase,
+        )
+
+
+async def emit_finalize_failure_artifacts(
+    *,
+    correlation_id: str,
+    error: str,
+    draft_text: str,
+    thought: ThoughtEventV1,
+    substrate_appraisal: SubstrateFinalizeAppraisalV1,
+    reflection: FinalizeReflectionV1,
+    verdict_molecule: HarnessVerdictMoleculeV1,
+    verdict_molecule_id: str,
+    grammar_receipts: list[GrammarReceiptV1] | None,
+    user_message: str,
+    quick_lane_skipped_5b: bool,
+    bus: Any = None,
+    outcome_publish_fn: PublishFn | None = None,
+    closure_channel: str = POST_TURN_CLOSURE_CHANNEL,
+    closure_publish_fn: PublishFn | None = None,
+    system_error_channel: str = SYSTEM_ERROR_CHANNEL,
+    system_error_publish_fn: PublishFn | None = None,
+) -> HarnessFinalizePartialState:
+    """Emit degraded 6b outcome + 7 closure + homeostatic system error on 5c failure."""
+    outcome_molecule = await emit_turn_outcome_molecule(
+        correlation_id=correlation_id,
+        thought=thought,
+        substrate_appraisal=substrate_appraisal,
+        reflection=reflection,
+        verdict_molecule=verdict_molecule,
+        draft_text=draft_text,
+        final_text="",
+        finalize_changed=False,
+        grammar_receipts=grammar_receipts,
+        finalize_failed=True,
+        failure_reason=_excerpt(error, max_len=500),
+        publish_fn=outcome_publish_fn,
+        bus=bus,
+    )
+    closure = await emit_post_turn_closure(
+        correlation_id=correlation_id,
+        outcome_molecule=outcome_molecule,
+        verdict_molecule_id=verdict_molecule_id,
+        grammar_event_ids=outcome_molecule.grammar_event_ids,
+        user_message=user_message,
+        thought_event=thought,
+        reflection_imperative=reflection.imperative,
+        channel=closure_channel,
+        publish_fn=closure_publish_fn,
+        bus=bus,
+    )
+    logger.info(
+        "harness_post_turn_closure_emitted corr=%s channel=%s surprise_unresolved=%s outcome_id=%s finalize_failed=true",
+        correlation_id,
+        closure_channel,
+        closure.surprise_unresolved,
+        closure.outcome_molecule_id,
+    )
+    await emit_harness_finalize_system_error(
+        correlation_id=correlation_id,
+        error=error,
+        channel=system_error_channel,
+        publish_fn=system_error_publish_fn,
+        bus=bus,
+    )
+    return HarnessFinalizePartialState(
+        substrate_appraisal=substrate_appraisal,
+        reflection=reflection,
+        verdict_molecule=verdict_molecule,
+        outcome_molecule=outcome_molecule,
+        quick_lane_skipped_5b=quick_lane_skipped_5b,
+        verdict_molecule_id=verdict_molecule_id,
+    )
+
+
 async def run_harness_finalize_chain(
     *,
     correlation_id: str,
@@ -700,6 +846,10 @@ async def run_harness_finalize_chain(
     embodiment_relational: bool = False,
     embodiment_interlocutor_ref: str | None = None,
     embodiment_publish_fn: PublishFn | None = None,
+    closure_channel: str = POST_TURN_CLOSURE_CHANNEL,
+    closure_publish_fn: PublishFn | None = None,
+    system_error_channel: str = SYSTEM_ERROR_CHANNEL,
+    system_error_publish_fn: PublishFn | None = None,
 ) -> HarnessFinalizeChainResult:
     """Orchestrate finalize beats 5a → 5b → 5c → 6b."""
     substrate_appraisal = await run_substrate_finalize_appraisal(
@@ -727,18 +877,40 @@ async def run_harness_finalize_chain(
     )
     verdict_molecule_id = _verdict_molecule_id(verdict_molecule)
 
-    final_text, voice_meta = await run_orion_voice_finalize(
-        correlation_id=correlation_id,
-        draft_text=draft_text,
-        thought=thought,
-        substrate_appraisal=substrate_appraisal,
-        reflection=reflection,
-        voice_contract=voice_contract,
-        repair_overlay=repair_overlay,
-        user_message=user_message,
-        grammar_receipts=grammar_receipts,
-        cortex_client=cortex_client,
-    )
+    try:
+        final_text, voice_meta = await run_orion_voice_finalize(
+            correlation_id=correlation_id,
+            draft_text=draft_text,
+            thought=thought,
+            substrate_appraisal=substrate_appraisal,
+            reflection=reflection,
+            voice_contract=voice_contract,
+            repair_overlay=repair_overlay,
+            user_message=user_message,
+            grammar_receipts=grammar_receipts,
+            cortex_client=cortex_client,
+        )
+    except Exception as exc:
+        partial = await emit_finalize_failure_artifacts(
+            correlation_id=correlation_id,
+            error=str(exc),
+            draft_text=draft_text,
+            thought=thought,
+            substrate_appraisal=substrate_appraisal,
+            reflection=reflection,
+            verdict_molecule=verdict_molecule,
+            verdict_molecule_id=verdict_molecule_id,
+            grammar_receipts=grammar_receipts,
+            user_message=user_message,
+            quick_lane_skipped_5b=quick_lane_skipped_5b,
+            bus=bus,
+            outcome_publish_fn=outcome_publish_fn,
+            closure_channel=closure_channel,
+            closure_publish_fn=closure_publish_fn,
+            system_error_channel=system_error_channel,
+            system_error_publish_fn=system_error_publish_fn,
+        )
+        raise HarnessFinalizeFailedError(str(exc), partial=partial) from exc
     finalize_changed = bool(voice_meta.get("finalize_changed"))
 
     outcome_molecule = await emit_turn_outcome_molecule(

--- a/orion/harness/tests/test_finalize_failure_closure.py
+++ b/orion/harness/tests/test_finalize_failure_closure.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import pytest
+
+from orion.harness.finalize import (
+    HarnessFinalizeFailedError,
+    emit_finalize_failure_artifacts,
+    emit_turn_outcome_molecule,
+    emit_verdict_molecule,
+    run_harness_finalize_chain,
+)
+from orion.harness.runner import build_coalition_snapshot, build_draft_molecule
+from orion.harness.tests.fixtures import (
+    make_appraisal,
+    make_reflection,
+    make_repair_overlay,
+    make_thought,
+)
+from orion.schemas.harness_finalize import GrammarReceiptV1, HarnessPostTurnClosureV1
+
+
+@pytest.mark.asyncio
+async def test_finalize_failed_outcome_forces_surprise_unresolved_on_quick_lane() -> None:
+    """Aligned quick-lane would resolve surprise; finalize_failed must not."""
+    thought = make_thought()
+    appraisal = make_appraisal(surprise_level=0.02)
+    reflection = make_reflection(alignment_verdict="aligned", strain_unresolved=False)
+    verdict = await emit_verdict_molecule(correlation_id="c-fail", reflection=reflection)
+    outcome = await emit_turn_outcome_molecule(
+        correlation_id="c-fail",
+        thought=thought,
+        substrate_appraisal=appraisal,
+        reflection=reflection,
+        verdict_molecule=verdict,
+        draft_text="motor draft body",
+        final_text="",
+        finalize_changed=False,
+        finalize_failed=True,
+        failure_reason="RPC timeout",
+    )
+    assert outcome.finalize_failed is True
+    assert outcome.surprise_resolved is False
+    assert outcome.draft_text_excerpt == "motor draft body"
+
+
+@pytest.mark.asyncio
+async def test_emit_finalize_failure_artifacts_publishes_outcome_closure_and_system_error() -> None:
+    thought = make_thought()
+    appraisal = make_appraisal(surprise_level=0.02)
+    reflection = make_reflection(alignment_verdict="aligned")
+    verdict = await emit_verdict_molecule(correlation_id="c-artifacts", reflection=reflection)
+    verdict_id = "verdict-artifacts"
+
+    outcomes: list[object] = []
+    closures: list[HarnessPostTurnClosureV1] = []
+    errors: list[dict[str, object]] = []
+
+    async def outcome_publish(molecule: object, **_: object) -> None:
+        outcomes.append(molecule)
+
+    async def closure_publish(closure: HarnessPostTurnClosureV1, **_: object) -> None:
+        closures.append(closure)
+
+    async def error_publish(payload: dict[str, object], **_: object) -> None:
+        errors.append(payload)
+
+    partial = await emit_finalize_failure_artifacts(
+        correlation_id="c-artifacts",
+        error="orion_voice_finalize exec failed: LLMGatewayService: RPC timeout",
+        draft_text="motor draft before timeout",
+        thought=thought,
+        substrate_appraisal=appraisal,
+        reflection=reflection,
+        verdict_molecule=verdict,
+        verdict_molecule_id=verdict_id,
+        grammar_receipts=[],
+        user_message="hello juniper",
+        quick_lane_skipped_5b=True,
+        outcome_publish_fn=outcome_publish,
+        closure_publish_fn=closure_publish,
+        system_error_publish_fn=error_publish,
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].finalize_failed is True  # type: ignore[attr-defined]
+    assert len(closures) == 1
+    assert closures[0].surprise_unresolved is True
+    assert closures[0].user_message_excerpt == "hello juniper"
+    assert len(errors) == 1
+    assert errors[0]["phase"] == "orion_voice_finalize"
+    assert partial.verdict_molecule_id == verdict_id
+    assert partial.quick_lane_skipped_5b is True
+
+
+@pytest.mark.asyncio
+async def test_run_harness_finalize_chain_voice_failure_raises_with_partial_state() -> None:
+    thought = make_thought()
+    coalition = build_coalition_snapshot(thought)
+    receipts = [GrammarReceiptV1(step_index=0, summary="step", grammar_event_id="g-1")]
+    draft_text = "internal draft"
+    molecule = build_draft_molecule(
+        correlation_id="c-voice-fail",
+        thought=thought,
+        draft_text=draft_text,
+        grammar_receipts=receipts,
+        coalition_snapshot=coalition,
+        repair_overlay=make_repair_overlay(),
+    )
+    appraisal = make_appraisal(surprise_level=0.02)
+    reflection = make_reflection(alignment_verdict="aligned")
+    closures: list[HarnessPostTurnClosureV1] = []
+    errors: list[dict[str, object]] = []
+    cortex_calls: list[object] = []
+
+    async def substrate_client(_mol: object):
+        return appraisal
+
+    async def cortex_client(req: object):
+        cortex_calls.append(req)
+        if len(cortex_calls) == 1:
+            return {"final_text": reflection.model_dump(mode="json"), "trace_id": "trace-1"}
+        raise ValueError("orion_voice_finalize exec failed: LLMGatewayService: RPC timeout")
+
+    async def closure_publish(closure: HarnessPostTurnClosureV1, **_: object) -> None:
+        closures.append(closure)
+
+    async def error_publish(payload: dict[str, object], **_: object) -> None:
+        errors.append(payload)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "orion.harness.finalize.extract_finalize_reflection_payload",
+            lambda result: reflection.model_dump(mode="json"),
+        )
+        with pytest.raises(HarnessFinalizeFailedError) as exc_info:
+            await run_harness_finalize_chain(
+                correlation_id="c-voice-fail",
+                draft_text=draft_text,
+                draft_molecule=molecule,
+                thought=thought,
+                grammar_receipts=receipts,
+                repair_overlay=make_repair_overlay(),
+                user_message="hello",
+                voice_contract=None,
+                cortex_client=cortex_client,
+                substrate_client=substrate_client,
+                closure_publish_fn=closure_publish,
+                system_error_publish_fn=error_publish,
+            )
+
+    partial = exc_info.value.partial
+    assert partial.outcome_molecule.finalize_failed is True
+    assert partial.outcome_molecule.surprise_resolved is False
+    assert len(closures) == 1
+    assert closures[0].surprise_unresolved is True
+    assert len(errors) == 1

--- a/orion/schemas/harness_finalize.py
+++ b/orion/schemas/harness_finalize.py
@@ -90,6 +90,9 @@ class HarnessTurnOutcomeMoleculeV1(BaseModel):
     surprise_resolved: bool
     grammar_event_ids: list[str] = Field(default_factory=list)
     final_text: str
+    finalize_failed: bool = False
+    failure_reason: str | None = Field(default=None, max_length=500)
+    draft_text_excerpt: str | None = Field(default=None, max_length=300)
 
 
 class HarnessPostTurnClosureV1(BaseModel):

--- a/scripts/trace_unified_turn.py
+++ b/scripts/trace_unified_turn.py
@@ -62,7 +62,9 @@ _HOP_PATTERNS: dict[str, re.Pattern[str]] = {
         re.I,
     ),
     "outcome": re.compile(
-        r"harness_turn_outcome_published\s+corr=.*surprise_resolved=(?P<surprise_resolved>\S+).*grammar_events=(?P<grammar_events>\d+)",
+        r"harness_turn_outcome_published\s+corr=.*surprise_resolved=(?P<surprise_resolved>\S+)"
+        r"(?:\s+finalize_failed=(?P<finalize_failed>\S+))?"
+        r".*grammar_events=(?P<grammar_events>\d+)",
         re.I,
     ),
     "harness_complete": re.compile(
@@ -70,7 +72,12 @@ _HOP_PATTERNS: dict[str, re.Pattern[str]] = {
         re.I,
     ),
     "closure_publish": re.compile(
-        r"harness_post_turn_closure_(?:published|emitted)\s+corr=.*surprise_unresolved=(?P<surprise_unresolved>\S+)",
+        r"harness_post_turn_closure_(?:published|emitted)\s+corr=.*surprise_unresolved=(?P<surprise_unresolved>\S+)"
+        r"(?:.*finalize_failed=(?P<finalize_failed>\S+))?",
+        re.I,
+    ),
+    "system_error": re.compile(
+        r"harness_finalize_system_error_published\s+corr=.*channel=(?P<channel>\S+)\s+phase=(?P<phase>\S+)",
         re.I,
     ),
     "closure_received": re.compile(
@@ -133,6 +140,7 @@ class TurnTrace:
             "verdict",
             "cortex_5c",
             "outcome",
+            "system_error",
             "harness_complete",
             "closure_publish",
             "closure_received",
@@ -324,6 +332,7 @@ def format_turn_trace(trace: TurnTrace, *, verbose: bool = False) -> str:
         "verdict": "5b. Verdict molecule",
         "cortex_5c": "5c. Orion voice",
         "outcome": "6b. Outcome molecule",
+        "system_error": "Homeostatic system error (finalize failure)",
         "harness_complete": "HarnessRunV1 reply",
         "closure_publish": "7. Post-turn closure (publish)",
         "closure_received": "7. Post-turn closure (substrate)",

--- a/services/orion-harness-governor/app/bus_listener.py
+++ b/services/orion-harness-governor/app/bus_listener.py
@@ -11,6 +11,7 @@ from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.harness.cortex_client import HarnessCortexClient
 from orion.harness.finalize import (
     DEFAULT_FINALIZE_INTERLOCUTOR,
+    HarnessFinalizeFailedError,
     emit_post_turn_closure,
     run_harness_finalize_chain,
 )
@@ -171,7 +172,32 @@ async def handle_harness_run_request(
             # (request.thought_event / answer_contract) before enabling in a multi-human town.
             embodiment_relational=True,
             embodiment_interlocutor_ref=DEFAULT_FINALIZE_INTERLOCUTOR,
+            closure_channel=settings.channel_post_turn_closure,
+            system_error_channel=settings.channel_system_error,
         )
+    except HarnessFinalizeFailedError as exc:
+        logger.error("harness finalize chain error corr=%s err=%s", corr, exc)
+        partial = exc.partial
+        run = HarnessRunV1(
+            correlation_id=corr,
+            final_text=None,
+            draft_text=motor.draft_text,
+            substrate_appraisal=partial.substrate_appraisal,
+            reflection=partial.reflection,
+            verdict_molecule_id=partial.verdict_molecule_id,
+            finalize_ran=False,
+            finalize_changed=False,
+            quick_lane_skipped_5b=partial.quick_lane_skipped_5b,
+            step_count=motor.step_count,
+            exit_code=motor.exit_code,
+            compliance_verdict="failed",
+            grounding_status=str(exc),
+            grammar_event_ids=_grammar_event_ids(motor.grammar_receipts),
+            recall_debug=recall_debug,
+            memory_digest=memory_digest,
+        )
+        await _reply_and_artifact(bus, run, reply_to=reply_to, corr=corr, causality=causality)
+        return run
     except Exception as exc:
         logger.error("harness finalize chain error corr=%s err=%s", corr, exc)
         run = HarnessRunV1(

--- a/services/orion-harness-governor/app/settings.py
+++ b/services/orion-harness-governor/app/settings.py
@@ -61,6 +61,11 @@ class HarnessGovernorSettings(BaseSettings):
         "orion:substrate:post_turn_closure",
         alias="CHANNEL_POST_TURN_CLOSURE",
     )
+    channel_system_error: str = Field(
+        "orion:system:error",
+        validation_alias=AliasChoices("CHANNEL_SYSTEM_ERROR", "ORION_ERROR_CHANNEL"),
+        alias="CHANNEL_SYSTEM_ERROR",
+    )
     channel_harness_run_step: str = Field(
         "orion:harness:run:step",
         alias="CHANNEL_HARNESS_RUN_STEP",

--- a/services/orion-harness-governor/tests/test_harness_governor_rpc.py
+++ b/services/orion-harness-governor/tests/test_harness_governor_rpc.py
@@ -114,8 +114,14 @@ async def test_harness_run_artifact_published() -> None:
 
 
 @pytest.mark.asyncio
-async def test_harness_finalize_chain_failure_preserves_draft() -> None:
+async def test_harness_finalize_chain_failure_preserves_draft_and_partial_finalize() -> None:
     from app import bus_listener
+    from orion.harness.finalize import (
+        HarnessFinalizeFailedError,
+        HarnessFinalizePartialState,
+        emit_turn_outcome_molecule,
+        emit_verdict_molecule,
+    )
 
     thought = make_thought()
     req = HarnessRunRequestV1(
@@ -126,6 +132,29 @@ async def test_harness_finalize_chain_failure_preserves_draft() -> None:
         answer_contract=AnswerContract(),
     )
     motor = _motor_result(thought)
+    appraisal = make_appraisal()
+    reflection = make_reflection()
+    verdict = await emit_verdict_molecule(correlation_id="c-finalize-fail", reflection=reflection)
+    outcome = await emit_turn_outcome_molecule(
+        correlation_id="c-finalize-fail",
+        thought=thought,
+        substrate_appraisal=appraisal,
+        reflection=reflection,
+        verdict_molecule=verdict,
+        draft_text=motor.draft_text,
+        final_text="",
+        finalize_changed=False,
+        finalize_failed=True,
+        failure_reason="RPC timeout",
+    )
+    partial = HarnessFinalizePartialState(
+        substrate_appraisal=appraisal,
+        reflection=reflection,
+        verdict_molecule=verdict,
+        outcome_molecule=outcome,
+        quick_lane_skipped_5b=True,
+        verdict_molecule_id="verdict-fail",
+    )
 
     bus = AsyncMock()
     with patch.object(
@@ -136,8 +165,9 @@ async def test_harness_finalize_chain_failure_preserves_draft() -> None:
         bus_listener,
         "run_harness_finalize_chain",
         AsyncMock(
-            side_effect=ValueError(
-                "orion_voice_finalize exec failed: LLMGatewayService: RPC timeout"
+            side_effect=HarnessFinalizeFailedError(
+                "orion_voice_finalize exec failed: LLMGatewayService: RPC timeout",
+                partial=partial,
             )
         ),
     ):
@@ -151,6 +181,10 @@ async def test_harness_finalize_chain_failure_preserves_draft() -> None:
     assert run.final_text is None
     assert run.draft_text == "internal draft"
     assert run.step_count == 1
+    assert run.substrate_appraisal is appraisal
+    assert run.reflection is reflection
+    assert run.verdict_molecule_id == "verdict-fail"
+    assert run.quick_lane_skipped_5b is True
     assert "orion_voice_finalize" in (run.grounding_status or "")
 
 

--- a/tests/test_unified_turn_schemas.py
+++ b/tests/test_unified_turn_schemas.py
@@ -205,11 +205,15 @@ def test_harness_turn_outcome_molecule_roundtrip() -> None:
         finalize_changed=False,
         alignment_verdict="aligned",
         surprise_level_at_draft=0.1,
-        surprise_resolved=True,
-        final_text="Shipped answer.",
+        surprise_resolved=False,
+        final_text="",
+        finalize_failed=True,
+        failure_reason="orion_voice_finalize exec failed: timeout",
+        draft_text_excerpt="partial motor draft",
     )
     restored = HarnessTurnOutcomeMoleculeV1.model_validate(outcome.model_dump(mode="json"))
-    assert restored.final_text == "Shipped answer."
+    assert restored.finalize_failed is True
+    assert restored.failure_reason.startswith("orion_voice_finalize")
 
 
 def test_harness_post_turn_closure_roundtrip() -> None:


### PR DESCRIPTION
## Summary

- Route Orion embodiment speech through cortex-exec `chat_general` with `hub_chat_lane=grounded_small` (quick fallback), non-blocking so invites/movement don't freeze.
- Fix stale `AITOWN_WORLD_ID` after game wipe by refreshing `~/.fcc/.env` each perception tick (Orion unfreezes without container restart).
- Add AI Town upstream patches for **conversation proximity** (6-tile invite gate, walk-up on accept, invite timeout only while pending).
- Add AI Town **chat turns** patch: human speaks first, short in-character replies (`clampTownReply`), no NPC auto-leave in human chats, 3 min reply grace.
- Gate tests for patches + embodiment world-id regressions (11 focused tests on touched seams).
- Design-only: integrated memory cognition loop spec (unrelated runtime; bundled on branch).

## Outcome moved

- Orion accepts invites, walks to partners, and speaks in town after world wipe.
- NPCs stop cross-map invite spam and observation-lounge monologues over Juniper's lines.
- Human↔NPC conversations stay open until the human leaves; accepted walk-ups don't expire mid-path.

## Current architecture

- Orion joins AI Town externally via embodiment worker + Convex HTTP (`orion/embodiment/aitown_client.py`).
- Stock AI Town engine invited nearest player globally, fired synthetic `start` LLM messages over humans, and auto-left at 8 messages.
- Embodiment worker cached `AITOWN_*` from boot env; world wipe changed IDs → `Invalid world ID` every tick.

## Architecture touched

- `services/orion-embodiment/app/worker.py` — speech dispatcher, AITOWN runtime refresh, non-blocking speak
- `services/orion-ai-town/patches/orion-conversation-proximity.patch` — engine invite distance + walk contract
- `services/orion-ai-town/patches/orion-town-chat-turns.patch` — NPC-human turn-taking + reply clamp
- `services/orion-ai-town/scripts/apply_upstream_patches.sh` — registers new patches

## Files changed

- `services/orion-embodiment/app/worker.py`: grounded_small cortex speech, live world-id refresh, async speak
- `services/orion-embodiment/.env_example`: speech hub / unified timeout keys
- `services/orion-embodiment/tests/test_worker_aitown_world_id_regression.py`: stale world-id regressions
- `services/orion-ai-town/patches/orion-conversation-proximity.patch`: proximity + invite timeout semantics
- `services/orion-ai-town/patches/orion-town-chat-turns.patch`: human-first chat + clamped replies
- `services/orion-ai-town/tests/test_*_patch.py`: deterministic patch contract gates
- `docs/superpowers/specs/2026-07-08-integrated-memory-cognition-loop-design.md`: design artifact only

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: AI Town Convex functions (upstream patches only); embodiment speech path (cortex-direct)
- Compatibility notes: redeploy Convex after merge (`npx convex dev --once` from `services/orion-ai-town/upstream`)

## Env/config changes

- Added keys: `EMBODIMENT_SPEECH_HUB_ENABLED`, `EMBODIMENT_SPEECH_HUB_LLM_ROUTE`, `EMBODIMENT_UNIFIED_TIMEOUT_SEC` (embodiment `.env_example`)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: yes (embodiment)
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: operator should run if keys missing
- skipped keys requiring operator action: none for embodiment speech keys

## Tests run

```text
.venv/bin/pytest services/orion-ai-town/tests/test_conversation_proximity_patch.py \
  services/orion-ai-town/tests/test_town_chat_turns_patch.py \
  services/orion-embodiment/tests/test_worker_aitown_world_id_regression.py -q
# 11 passed
```

## Evals run

```text
Not run — no periodic eval harness for ai-town patch contracts; gate tests cover patch content.
```

## Docker/build/smoke checks

```text
cd services/orion-ai-town/upstream && ./node_modules/.bin/convex dev --once
# ✔ Convex functions ready! (deployed to http://127.0.0.1:3210)

./node_modules/.bin/convex run testing:debugEngineState
# processed=7126 pending=0 (engine healthy)
```

## Review findings fixed

- Finding: NPCs invited across entire map / talked over human / narrated scene prose
  - Fix: `orion-conversation-proximity.patch` + `orion-town-chat-turns.patch`
  - Evidence: gate tests + live Convex deploy on mesh node
- Finding: Orion frozen after world wipe (stale `AITOWN_WORLD_ID`)
  - Fix: `_refresh_aitown_runtime()` each perception tick
  - Evidence: `test_worker_aitown_world_id_regression.py` (3 tests)

## Restart required

```bash
# After merge — redeploy Convex functions
cd services/orion-ai-town && bash scripts/apply_upstream_patches.sh
cd upstream && npx convex dev --once

# Restart embodiment if speech env keys changed
cd services/orion-embodiment
docker compose --env-file ../../.env --env-file .env up -d --build embodiment
```

## Risks / concerns

- Severity: low
- Concern: `orion-human-juniper.patch` may fail apply on upstream drift (`DEFAULT_NAME`); conversation patches apply cleanly after hub/character/engine-recovery.
- Mitigation: regenerate juniper patch when bumping `AITOWN_UPSTREAM_REF`.