### PR TITLE
Feat/integrated memory cognition loop

### DIFF
--- a/docs/superpowers/plans/2026-07-08-integrated-memory-cognition-loop.md
+++ b/docs/superpowers/plans/2026-07-08-integrated-memory-cognition-loop.md
@@ -1,0 +1,991 @@
+# Integrated Memory Cognition Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the encode → store → retrieve → lifecycle loop so brain mode and orion unified mode form low-stakes beliefs automatically, fetch them by purpose via PCR, and stop behaving like surface timeline SQL.
+
+**Architecture:** M1 adds `formation_policy` + `auto_activate` + dynamics persistence + reinforce-on-dedup + cards/chroma projection from consolidation. M2 unifies PCR on brain/unified lanes (phase 0→1→stance→3), fixes retrieval intent default for belief fetch, filters/ranks active_packet by `dynamics.activation`, and removes Hub `brain.recall.v1` default. M3 (appendix) wires recall_boost + decay reaper.
+
+**Tech Stack:** Python 3.12, Pydantic v2, asyncpg, Redis bus, pytest, bash smoke.
+
+**Spec:** `docs/superpowers/specs/2026-07-08-integrated-memory-cognition-loop-design.md`
+
+**Branch:** `feat/integrated-memory-cognition-loop`
+
+**Worktree setup:**
+
+```bash
+cd /mnt/scripts/Orion-Sapienform
+git switch main && git pull --ff-only
+git worktree add ../Orion-Sapienform-memory-cognition-loop -b feat/integrated-memory-cognition-loop
+cd ../Orion-Sapienform-memory-cognition-loop
+python scripts/sync_local_env_from_example.py
+```
+
+---
+
+## File Map
+
+| File | Milestone | Action | Responsibility |
+|------|-----------|--------|----------------|
+| `orion/memory/crystallization/schemas.py` | M1 | Modify | `CrystallizationDynamicsV1` + `dynamics` field on `MemoryCrystallizationV1` |
+| `orion/core/storage/sql/memory_crystallizations.sql` | M1 | Modify | `dynamics jsonb` column |
+| `orion/memory/crystallization/repository.py` | M1,M2 | Modify | Round-trip `dynamics`; `count_eligible_active`; `update_crystallization` |
+| `orion/memory/crystallization/dynamics.py` | M1 | Modify | `seed_weak_dynamics()` for auto-encode ratio |
+| `orion/memory/crystallization/formation_policy.py` | M1 | Create | `resolve_formation_policy()` |
+| `orion/memory/crystallization/formation_executor.py` | M1 | Create | `auto_activate()` |
+| `orion/memory/crystallization/recall_eligibility.py` | M1,M2 | Create | `eligible_for_recall()`, `ACTIVATION_RECALL_FLOOR` |
+| `orion/memory/crystallization/intake_pipeline.py` | M1 | Create | dedup → policy → activate/insert → project |
+| `services/orion-memory-consolidation/app/worker.py` | M1 | Modify | Call intake pipeline instead of raw insert |
+| `services/orion-memory-consolidation/app/settings.py` | M1 | Modify | Formation env keys |
+| `services/orion-memory-consolidation/.env_example` | M1 | Modify | Formation env keys |
+| `orion/memory/crystallization/bus_emit.py` | M1 | Modify | `reinforced`, `auto_activated` lifecycle kinds |
+| `orion/bus/channels.yaml` | M1 | Modify | New crystallization channels |
+| `orion/memory/retrieval_intent.py` | M2 | Modify | `brain_lane_belief_default` rule |
+| `services/orion-cortex-exec/app/pcr_chat_memory.py` | M2 | Modify | Pass `eligible_belief_count` to intent |
+| `services/orion-recall/app/worker.py` | M2 | Modify | Emit `eligible_belief_count` in PCR debug |
+| `orion/memory/crystallization/retriever.py` | M2 | Modify | Rank by `activation * salience` |
+| `services/orion-recall/app/collectors/active_packet.py` | M2 | Modify | Filter by recall eligibility |
+| `services/orion-cortex-exec/app/router.py` | M2 | Modify | `stance_react` phase 0+1 hook |
+| `services/orion-cortex-exec/app/grounding_capsule.py` | M2 | Modify | Full PCR before/after stance |
+| `services/orion-hub/scripts/cortex_request_builder.py` | M2 | Modify | `hub_chat_lane` + drop `brain.recall.v1` default |
+| `services/orion-cortex-exec/app/settings.py` | M2 | Modify | `MEMORY_COGNITION_BRAIN_BELIEF_DEFAULT` |
+| `services/orion-cortex-exec/.env_example` | M2 | Modify | Recall cognition keys |
+| `tests/test_formation_policy_auto_vs_gated.py` | M1 | Create | Policy matrix |
+| `tests/test_formation_executor_auto_activate.py` | M1 | Create | auto_activate unit tests |
+| `tests/test_encode_reinforce_not_duplicate.py` | M1 | Create | Intake dedup integration |
+| `tests/test_retrieval_intent.py` | M2 | Modify | brain_lane_belief_default cases |
+| `services/orion-cortex-exec/tests/test_unified_pcr_phase01.py` | M2 | Create | stance_react phase 0+1 |
+| `services/orion-recall/tests/test_active_packet_activation_floor.py` | M2 | Create | Floor filter |
+| `services/orion-hub/tests/test_cortex_request_builder.py` | M2 | Modify | brain recall default + hub_chat_lane |
+| `scripts/smoke_memory_cognition_loop_e2e.sh` | M2 | Create | End-to-end smoke |
+
+---
+
+# Milestone M1 — Activate the store
+
+## Task 1: Dynamics schema + SQL + repository round-trip
+
+**Files:**
+- Modify: `orion/memory/crystallization/schemas.py`
+- Modify: `orion/core/storage/sql/memory_crystallizations.sql`
+- Modify: `orion/memory/crystallization/repository.py`
+- Test: `tests/test_memory_crystallization_dynamics.py` (existing — make pass)
+
+- [ ] **Step 1: Write the failing test** (if `CrystallizationDynamicsV1` missing, test already fails)
+
+Ensure `tests/test_memory_crystallization_dynamics.py` imports succeed:
+
+```python
+from orion.memory.crystallization.schemas import CrystallizationDynamicsV1, MemoryCrystallizationV1
+
+def test_crystallization_has_default_dynamics():
+    from orion.memory.crystallization.proposer import propose
+    from orion.memory.crystallization.schemas import MemoryCrystallizationProposeRequestV1
+    req = MemoryCrystallizationProposeRequestV1(
+        kind="semantic", subject="s", summary="s", scope=["p"], proposed_by="test"
+    )
+    crys = propose(req)
+    assert isinstance(crys.dynamics, CrystallizationDynamicsV1)
+    assert crys.dynamics.activation == 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_memory_crystallization_dynamics.py::TestDynamicsSchema::test_crystallization_has_default_dynamics -v`
+
+Expected: FAIL (`CrystallizationDynamicsV1` not defined or no `dynamics` field)
+
+- [ ] **Step 3: Add schema + SQL + repository**
+
+In `schemas.py` before `MemoryCrystallizationV1`:
+
+```python
+class CrystallizationDynamicsV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    activation: float = Field(default=0.0, ge=0.0, le=1.0)
+    reinforcement_count: int = 0
+    formed_at: datetime | None = None
+    last_reinforced_at: datetime | None = None
+    last_recalled_at: datetime | None = None
+    decay_half_life_days: float = 30.0
+    retired_at: datetime | None = None
+```
+
+On `MemoryCrystallizationV1` add:
+
+```python
+dynamics: CrystallizationDynamicsV1 = Field(default_factory=CrystallizationDynamicsV1)
+```
+
+In `memory_crystallizations.sql` after `salience` line:
+
+```sql
+    dynamics jsonb NOT NULL DEFAULT '{}'::jsonb,
+```
+
+In `repository.py` `_row_to_crystallization()` parse `dynamics` jsonb into `CrystallizationDynamicsV1`. In `insert_crystallization` and `update_crystallization` include `dynamics` column with `_jsonb(crystallization.dynamics.model_dump(mode="json"))`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_memory_crystallization_dynamics.py -q`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/memory/crystallization/schemas.py orion/core/storage/sql/memory_crystallizations.sql orion/memory/crystallization/repository.py tests/test_memory_crystallization_dynamics.py
+git commit -m "feat(memory): add crystallization dynamics schema and persistence"
+```
+
+---
+
+## Task 2: `seed_weak_dynamics` for auto-encode activation ratio
+
+**Files:**
+- Modify: `orion/memory/crystallization/dynamics.py`
+- Test: `tests/test_memory_crystallization_dynamics.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_memory_crystallization_dynamics.py`:
+
+```python
+from orion.memory.crystallization.dynamics import seed_weak_dynamics
+
+def test_seed_weak_dynamics_scales_salience():
+    crys = _crys()
+    crys.salience = 0.5
+    seeded = seed_weak_dynamics(crys, now=_now(), ratio=0.4)
+    assert seeded.dynamics.activation == 0.2
+    assert seeded.dynamics.formed_at is not None
+```
+
+- [ ] **Step 2: Run test — expect FAIL** (`seed_weak_dynamics` not defined)
+
+Run: `pytest tests/test_memory_crystallization_dynamics.py::test_seed_weak_dynamics_scales_salience -v`
+
+- [ ] **Step 3: Implement**
+
+In `dynamics.py`:
+
+```python
+def seed_weak_dynamics(
+    crystallization: MemoryCrystallizationV1,
+    *,
+    now: datetime,
+    ratio: float = 0.4,
+    min_activation: float = 0.05,
+    max_activation: float = 0.35,
+) -> MemoryCrystallizationV1:
+    updated = crystallization.model_copy(deep=True)
+    raw = _clamp(crystallization.salience * _clamp(ratio))
+    updated.dynamics.activation = max(min_activation, min(max_activation, raw))
+    updated.dynamics.formed_at = _aware(now)
+    updated.updated_at = _aware(now)
+    return updated
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `pytest tests/test_memory_crystallization_dynamics.py -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/memory/crystallization/dynamics.py tests/test_memory_crystallization_dynamics.py
+git commit -m "feat(memory): add seed_weak_dynamics for auto-encode activation"
+```
+
+---
+
+## Task 3: Formation policy
+
+**Files:**
+- Create: `orion/memory/crystallization/formation_policy.py`
+- Create: `tests/test_formation_policy_auto_vs_gated.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_formation_policy_auto_vs_gated.py`:
+
+```python
+from orion.memory.crystallization.formation_policy import FormationPolicy, resolve_formation_policy
+from orion.memory.crystallization.proposer import propose
+from orion.memory.crystallization.schemas import MemoryCrystallizationProposeRequestV1
+
+def _crys(*, kind="semantic", sensitivity="private", scope=None):
+    req = MemoryCrystallizationProposeRequestV1(
+        kind=kind, subject="Deploy plan", summary="We chose k3s for staging",
+        scope=scope or ["project:orion"], proposed_by="test", sensitivity=sensitivity,
+    )
+    return propose(req)
+
+def test_semantic_auto_activate():
+    policy, reasons = resolve_formation_policy(_crys(kind="semantic"))
+    assert policy == FormationPolicy.AUTO_ACTIVATE
+    assert not reasons
+
+def test_contradiction_governor_queue():
+    policy, reasons = resolve_formation_policy(_crys(kind="contradiction"))
+    assert policy == FormationPolicy.GOVERNOR_QUEUE
+
+def test_intimate_governor_queue():
+    policy, _ = resolve_formation_policy(_crys(sensitivity="intimate"))
+    assert policy == FormationPolicy.GOVERNOR_QUEUE
+
+def test_identity_scope_governor_queue():
+    policy, _ = resolve_formation_policy(_crys(scope=["identity:orion"]))
+    assert policy == FormationPolicy.GOVERNOR_QUEUE
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pytest tests/test_formation_policy_auto_vs_gated.py -v`
+
+- [ ] **Step 3: Implement**
+
+Create `orion/memory/crystallization/formation_policy.py`:
+
+```python
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from orion.memory.crystallization.schemas import MemoryCrystallizationV1
+
+AUTO_ACTIVE_KINDS = frozenset({"semantic", "episode", "open_loop", "procedure"})
+GATED_KINDS = frozenset({"stance", "decision", "contradiction", "attractor", "failure_mode"})
+IDENTITY_SCOPE_PREFIX = "identity:"
+
+
+class FormationPolicy(str, Enum):
+    AUTO_ACTIVATE = "auto_activate"
+    GOVERNOR_QUEUE = "governor_queue"
+    REINFORCE_EXISTING = "reinforce_existing"
+
+
+def _has_identity_scope(crystallization: MemoryCrystallizationV1, *, prefix: str = IDENTITY_SCOPE_PREFIX) -> bool:
+    return any(str(s).startswith(prefix) for s in crystallization.scope)
+
+
+def resolve_formation_policy(
+    crystallization: MemoryCrystallizationV1,
+    *,
+    duplicate_id: str | None = None,
+    identity_scope_prefix: str = IDENTITY_SCOPE_PREFIX,
+) -> tuple[FormationPolicy, list[str]]:
+    reasons: list[str] = []
+    if duplicate_id:
+        return FormationPolicy.REINFORCE_EXISTING, [f"duplicate:{duplicate_id}"]
+    if crystallization.governance.sensitivity == "intimate":
+        return FormationPolicy.GOVERNOR_QUEUE, ["intimate_sensitivity"]
+    if _has_identity_scope(crystallization, prefix=identity_scope_prefix):
+        return FormationPolicy.GOVERNOR_QUEUE, ["identity_scope"]
+    if crystallization.kind in GATED_KINDS:
+        return FormationPolicy.GOVERNOR_QUEUE, [f"gated_kind:{crystallization.kind}"]
+    if crystallization.kind in AUTO_ACTIVE_KINDS:
+        return FormationPolicy.AUTO_ACTIVATE, reasons
+    return FormationPolicy.GOVERNOR_QUEUE, [f"unknown_kind:{crystallization.kind}"]
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pytest tests/test_formation_policy_auto_vs_gated.py -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/memory/crystallization/formation_policy.py tests/test_formation_policy_auto_vs_gated.py
+git commit -m "feat(memory): add formation policy for auto-activate vs governor queue"
+```
+
+---
+
+## Task 4: `auto_activate` executor
+
+**Files:**
+- Create: `orion/memory/crystallization/formation_executor.py`
+- Create: `tests/test_formation_executor_auto_activate.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import pytest
+from orion.memory.crystallization.formation_executor import auto_activate, GovernorPathRequired
+from orion.memory.crystallization.proposer import propose
+from orion.memory.crystallization.schemas import MemoryCrystallizationProposeRequestV1, CrystallizationEvidenceRefV1
+
+def _proposed_semantic():
+    req = MemoryCrystallizationProposeRequestV1(
+        kind="semantic", subject="Topic", summary="We agreed on Postgres for memory store",
+        scope=["project:orion"],
+        evidence=[CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="corr-1")],
+        proposed_by="memory_consolidation_intake",
+    )
+    return propose(req)
+
+def test_auto_activate_sets_active_and_weak_dynamics():
+    crys, hist = auto_activate(_proposed_semantic(), encode_ratio=0.4)
+    assert crys.status == "active"
+    assert crys.governance.approval_mode == "auto_policy"
+    assert crys.governance.requires_manual_review is False
+    assert crys.governance.approved_by == "system:formation_policy"
+    assert 0.05 <= crys.dynamics.activation <= 0.35
+    assert hist["op"] == "auto_activate"
+
+def test_auto_activate_rejects_contradiction():
+    req = MemoryCrystallizationProposeRequestV1(
+        kind="contradiction", subject="x", summary="y", scope=["p"], proposed_by="t"
+    )
+    with pytest.raises(GovernorPathRequired):
+        auto_activate(propose(req))
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pytest tests/test_formation_executor_auto_activate.py -v`
+
+- [ ] **Step 3: Implement**
+
+Create `formation_executor.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.memory.crystallization.dynamics import seed_weak_dynamics
+from orion.memory.crystallization.formation_policy import resolve_formation_policy, FormationPolicy
+from orion.memory.crystallization.schemas import MemoryCrystallizationV1
+from orion.memory.crystallization.validator import validate_proposal
+
+
+class GovernorPathRequired(ValueError):
+    pass
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def auto_activate(
+    crystallization: MemoryCrystallizationV1,
+    *,
+    actor: str = "system:formation_policy",
+    encode_ratio: float = 0.4,
+) -> tuple[MemoryCrystallizationV1, dict]:
+    policy, reasons = resolve_formation_policy(crystallization)
+    if policy != FormationPolicy.AUTO_ACTIVATE:
+        raise GovernorPathRequired("; ".join(reasons) or policy.value)
+    validation = validate_proposal(crystallization)
+    if not validation.valid:
+        raise GovernorPathRequired("; ".join(validation.errors))
+    now = _utc_now()
+    updated = crystallization.model_copy(deep=True)
+    updated.status = "active"
+    updated.governance.approval_mode = "auto_policy"
+    updated.governance.requires_manual_review = False
+    updated.governance.approved_by = actor
+    updated.governance.validation_status = "valid"
+    updated.governance.last_reviewed_at = now
+    updated = seed_weak_dynamics(updated, now=now, ratio=encode_ratio)
+    history = {
+        "op": "auto_activate",
+        "actor": actor,
+        "reasons": reasons,
+        "before": {"status": crystallization.status},
+        "after": {"status": "active", "activation": updated.dynamics.activation},
+    }
+    return updated, history
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pytest tests/test_formation_executor_auto_activate.py -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/memory/crystallization/formation_executor.py tests/test_formation_executor_auto_activate.py
+git commit -m "feat(memory): add auto_activate formation executor"
+```
+
+---
+
+## Task 5: Recall eligibility helper
+
+**Files:**
+- Create: `orion/memory/crystallization/recall_eligibility.py`
+- Create: `tests/test_recall_eligibility.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+from orion.memory.crystallization.recall_eligibility import eligible_for_recall, ACTIVATION_RECALL_FLOOR
+from orion.memory.crystallization.schemas import CrystallizationDynamicsV1, MemoryCrystallizationV1, CrystallizationGovernanceV1
+from datetime import datetime, timezone
+
+def _active(activation: float) -> MemoryCrystallizationV1:
+    now = datetime.now(timezone.utc)
+    return MemoryCrystallizationV1(
+        crystallization_id="crys_test",
+        kind="semantic", subject="s", summary="s", status="active",
+        dynamics=CrystallizationDynamicsV1(activation=activation, formed_at=now),
+        governance=CrystallizationGovernanceV1(proposed_by="t"),
+        created_at=now, updated_at=now,
+    )
+
+def test_eligible_when_active_and_above_floor():
+    assert eligible_for_recall(_active(0.2)) is True
+
+def test_ineligible_when_below_floor():
+    assert eligible_for_recall(_active(0.01)) is False
+
+def test_ineligible_when_deprecated():
+    crys = _active(0.2)
+    crys.status = "deprecated"
+    assert eligible_for_recall(crys) is False
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+```python
+from __future__ import annotations
+
+import os
+
+from orion.memory.crystallization.schemas import MemoryCrystallizationV1
+
+ACTIVATION_RECALL_FLOOR = float(os.getenv("ACTIVATION_RECALL_FLOOR", "0.08"))
+_INELIGIBLE_STATUSES = frozenset({"deprecated", "archived", "rejected", "quarantined"})
+
+
+def eligible_for_recall(
+    crystallization: MemoryCrystallizationV1,
+    *,
+    floor: float | None = None,
+) -> bool:
+    if crystallization.status != "active":
+        return False
+    if crystallization.status in _INELIGIBLE_STATUSES:
+        return False
+    threshold = ACTIVATION_RECALL_FLOOR if floor is None else floor
+    return float(crystallization.dynamics.activation) >= threshold
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/memory/crystallization/recall_eligibility.py tests/test_recall_eligibility.py
+git commit -m "feat(memory): add recall eligibility activation floor helper"
+```
+
+---
+
+## Task 6: Consolidation intake pipeline (dedup → policy → store → project)
+
+**Files:**
+- Create: `orion/memory/crystallization/intake_pipeline.py`
+- Create: `tests/test_encode_reinforce_not_duplicate.py`
+- Modify: `orion/memory/crystallization/repository.py` (add `update_crystallization`, `list_crystallizations` filter)
+
+- [ ] **Step 1: Write failing integration test**
+
+```python
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from orion.memory.crystallization.intake_pipeline import process_consolidation_crystallization
+from orion.memory.crystallization.intake_consolidation_window import build_crystallization_from_window
+from orion.memory.consolidation_gate import ConsolidationGateResult
+
+@pytest.mark.asyncio
+async def test_reinforce_existing_skips_insert(monkeypatch):
+  # Build two identical window crystallizations; mock list_crystallizations to return first after insert
+  # Assert update_crystallization called with reinforcement_count incremented
+  # Assert insert_crystallization NOT called second time
+  ...
+```
+
+(Flesh out with real mocks in implementation — test must assert `reinforce` path when duplicate detected.)
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement `intake_pipeline.py`**
+
+```python
+async def process_consolidation_crystallization(
+    pool,
+    bus,
+    *,
+    crystallization: MemoryCrystallizationV1,
+    settings,
+    project_config,
+) -> tuple[str, MemoryCrystallizationV1, str]:
+    """Returns (crystallization_id, final_row, outcome) where outcome is
+    auto_activated | proposed | reinforced."""
+    from orion.memory.crystallization.detection import detect_duplicates
+    from orion.memory.crystallization.repository import list_crystallizations, insert_crystallization, update_crystallization
+    from orion.memory.crystallization.formation_policy import FormationPolicy, resolve_formation_policy
+    from orion.memory.crystallization.formation_executor import auto_activate, GovernorPathRequired
+    from orion.memory.crystallization.dynamics import reinforce
+    from orion.memory.crystallization.projector import project_crystallization
+    from orion.memory.crystallization.salience import apply_salience
+    from orion.memory.crystallization.bus_emit import emit_crystallization_lifecycle
+
+    existing = await list_crystallizations(pool, status=None, limit=200)
+    detection = detect_duplicates(crystallization, existing)
+    duplicate_id = detection.duplicates[0] if detection.duplicates else None
+    policy, _ = resolve_formation_policy(crystallization, duplicate_id=duplicate_id)
+
+    if policy == FormationPolicy.REINFORCE_EXISTING and duplicate_id:
+        match = next(c for c in existing if c.crystallization_id == duplicate_id)
+        updated = reinforce(match, now=_utc_now())
+        # append new evidence refs from candidate
+        await update_crystallization(pool, updated)
+        await emit_crystallization_lifecycle(bus, lifecycle="reinforced", crystallization=updated, ...)
+        return duplicate_id, updated, "reinforced"
+
+    if not settings.MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED:
+        row = apply_salience(crystallization)
+        cid = await insert_crystallization(pool, row)
+        await emit_crystallization_lifecycle(bus, lifecycle="proposed", crystallization=row, ...)
+        return cid, row, "proposed"
+
+    try:
+        activated, _ = auto_activate(apply_salience(crystallization), encode_ratio=settings.MEMORY_FORMATION_AUTO_ENCODE_ACTIVATION_RATIO)
+        cid = await insert_crystallization(pool, activated)
+        activated, _proj = await project_crystallization(
+            pool, bus, activated, actor="system:formation_policy",
+            config=project_config, project_graphiti=False,
+        )
+        await update_crystallization(pool, activated)
+        await emit_crystallization_lifecycle(bus, lifecycle="auto_activated", crystallization=activated, ...)
+        return cid, activated, "auto_activated"
+    except GovernorPathRequired:
+        row = apply_salience(crystallization)
+        cid = await insert_crystallization(pool, row)
+        await emit_crystallization_lifecycle(bus, lifecycle="proposed", crystallization=row, ...)
+        return cid, row, "proposed"
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `pytest tests/test_encode_reinforce_not_duplicate.py tests/test_formation_policy_auto_vs_gated.py -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/memory/crystallization/intake_pipeline.py tests/test_encode_reinforce_not_duplicate.py orion/memory/crystallization/repository.py
+git commit -m "feat(memory): add consolidation intake pipeline with dedup reinforce"
+```
+
+---
+
+## Task 7: Wire consolidation worker + bus lifecycle + settings
+
+**Files:**
+- Modify: `services/orion-memory-consolidation/app/worker.py`
+- Modify: `orion/memory/crystallization/bus_emit.py`
+- Modify: `orion/bus/channels.yaml`
+- Modify: `services/orion-memory-consolidation/app/settings.py`
+- Modify: `services/orion-memory-consolidation/.env_example`
+
+- [ ] **Step 1: Write failing worker test**
+
+Extend `services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_window_auto_activate_when_flag_enabled(monkeypatch):
+    monkeypatch.setattr(worker.settings, "MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED", True)
+    # mock process_consolidation_crystallization to return outcome auto_activated
+    # assert spark_meta patch contains formation_outcome=auto_activated
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Wire worker**
+
+Replace direct `insert_crystallization` block in `consolidate_window` with:
+
+```python
+from orion.memory.crystallization.intake_pipeline import process_consolidation_crystallization
+
+cid, final_row, outcome = await process_consolidation_crystallization(
+    self._pool, bus,
+    crystallization=crystallization,
+    settings=settings,
+    project_config=_projection_config_from_settings(settings),
+)
+```
+
+Add to `bus_emit.py`:
+
+```python
+"reinforced": "memory.crystallization.reinforced.v1",
+"auto_activated": "memory.crystallization.auto_activated.v1",
+```
+
+Add matching channels in `channels.yaml`.
+
+Add settings:
+
+```python
+MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED: bool = Field(default=False, ...)
+MEMORY_FORMATION_AUTO_ENCODE_ACTIVATION_RATIO: float = Field(default=0.4, ...)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py services/orion-memory-consolidation/tests/test_consolidation_gate.py -q`
+
+Also: `python scripts/check_bus_channels.py`
+
+- [ ] **Step 5: Commit + sync env**
+
+```bash
+python scripts/sync_local_env_from_example.py
+git add services/orion-memory-consolidation/ orion/memory/crystallization/bus_emit.py orion/bus/channels.yaml
+git commit -m "feat(memory): wire auto-activate intake in consolidation worker"
+```
+
+---
+
+# Milestone M2 — Unify read path (brain + orion unified)
+
+## Task 8: Brain lane belief-default retrieval intent
+
+**Files:**
+- Modify: `orion/memory/retrieval_intent.py`
+- Modify: `tests/test_retrieval_intent.py`
+- Modify: `services/orion-cortex-exec/app/settings.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_retrieval_intent.py`:
+
+```python
+def test_brain_lane_belief_default_when_eligible_beliefs_exist():
+    intent, rule_id = derive_retrieval_intent(
+        skip_gate=RecallSkipGateResult(skip=False),
+        stance_brief={"task_mode": "direct_response"},
+        attention_frame={},
+        appraisal={"shift_kind": "NONE", "novelty_score": 0.1},
+        hub_chat_lane="brain",
+        user_message="ok",
+        eligible_belief_count=3,
+        brain_belief_default_enabled=True,
+    )
+    assert intent == "semantic"
+    assert rule_id == "brain_lane_belief_default"
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+Add parameters to `derive_retrieval_intent`:
+
+```python
+eligible_belief_count: int = 0,
+brain_belief_default_enabled: bool = True,
+```
+
+Before final `return "continuity", "continuity_only"`:
+
+```python
+if (
+    brain_belief_default_enabled
+    and hub_chat_lane in ("brain", "orion")
+    and eligible_belief_count > 0
+):
+    return "semantic", "brain_lane_belief_default"
+```
+
+In `pcr_chat_memory.run_pcr_phase3`, pass:
+
+```python
+eligible_belief_count=int((ctx.get("eligible_belief_count") or 0)),
+brain_belief_default_enabled=cfg.memory_cognition_brain_belief_default,
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pytest tests/test_retrieval_intent.py -q`
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 9: Emit `eligible_belief_count` from recall worker
+
+**Files:**
+- Modify: `services/orion-recall/app/worker.py`
+- Modify: `orion/memory/crystallization/repository.py`
+- Modify: `services/orion-cortex-exec/app/pcr_chat_memory.py`
+
+- [ ] **Step 1: Write failing test** in `services/orion-recall/tests/test_pcr_continuity.py` asserting `recall_debug["eligible_belief_count"]` present when pool has active beliefs.
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Add `count_eligible_active` to repository**
+
+```python
+async def count_eligible_active(pool, *, floor: float | None = None) -> int:
+    rows = await list_crystallizations(pool, status="active", limit=500)
+    return sum(1 for r in rows if eligible_for_recall(r, floor=floor))
+```
+
+In recall worker PCR branches, set `recall_debug["eligible_belief_count"] = await count_eligible_active(pool)`.
+
+In `run_pcr_phase0_and_1`, after recall:
+
+```python
+if isinstance(recall_debug, dict) and "eligible_belief_count" in recall_debug:
+    ctx["eligible_belief_count"] = recall_debug["eligible_belief_count"]
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 10: Activation-ranked active_packet + floor filter
+
+**Files:**
+- Modify: `orion/memory/crystallization/active_packet.py` or `retriever.py`
+- Modify: `services/orion-recall/app/collectors/active_packet.py`
+- Create: `services/orion-recall/tests/test_active_packet_activation_floor.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_active_packet_excludes_below_activation_floor():
+    # crystallization activation 0.01 excluded; 0.2 included
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Filter + rank**
+
+In `active_packet.py` collector after `list_crystallizations`:
+
+```python
+from orion.memory.crystallization.recall_eligibility import eligible_for_recall
+
+active_items = [c for c in active_items if eligible_for_recall(c)]
+```
+
+In `retriever.py` / `build_active_packet`, sort candidates by:
+
+```python
+score = (c.dynamics.activation or 0.0) * (c.salience or 0.5)
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 11: Hub `hub_chat_lane` wire + drop `brain.recall.v1` default
+
+**Files:**
+- Modify: `services/orion-hub/scripts/cortex_request_builder.py`
+- Modify: `services/orion-hub/tests/test_cortex_request_builder.py`
+
+- [ ] **Step 1: Update failing test**
+
+Change `test_brain_mode_defaults_recall_profile_to_brain_recall_v1` to expect `recall_profile is None` when no explicit override.
+
+Add test:
+
+```python
+def test_brain_mode_sets_hub_chat_lane_in_surface_context():
+    req, debug, _ = hub_builder.build_chat_request(
+        payload={"mode": "brain", "use_recall": True},
+        ...
+    )
+    assert req.metadata["surface_context"]["hub_chat_lane"] == "brain"
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+In `build_chat_request`, after `selected_ui_route` resolved:
+
+```python
+surface = dict(metadata.get("surface_context") or {})
+if selected_ui_route in ("brain", "orion", "quick", "grounded_small"):
+    surface.setdefault("hub_chat_lane", selected_ui_route)
+metadata["surface_context"] = surface
+```
+
+Remove brain default:
+
+```python
+if use_recall and recall_profile is None:
+    if route == "agent":
+        recall_profile = "reflect.v1"
+    # brain + orion: leave None — cortex PCR selects profile
+```
+
+For orion unified HTTP path, ensure `surface_context.hub_chat_lane = "orion"` in `api_routes.py` / `turn_orchestrator.py` metadata.
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pytest services/orion-hub/tests/test_cortex_request_builder.py -q`
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 12: Unified turn PCR phase 0+1 before stance
+
+**Files:**
+- Modify: `services/orion-cortex-exec/app/router.py`
+- Modify: `services/orion-cortex-exec/app/grounding_capsule.py`
+- Create: `services/orion-cortex-exec/tests/test_unified_pcr_phase01.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_stance_react_runs_pcr_phase01_before_stance_step(monkeypatch):
+    # mock run_pcr_phase0_and_1 called before llm_stance_react step
+    # assert ctx has continuity_digest populated
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Wire router**
+
+Mirror `chat_general` block for `stance_react`:
+
+```python
+use_pcr_pre_recall = (
+    settings.chat_pcr_enabled
+    and str(plan.verb_name or "").strip().lower() == "stance_react"
+    and should_recall
+    and not inline_recall
+)
+```
+
+Run `run_pcr_phase0_and_1` before step loop (same as chat_general).
+
+In `assemble_stance_grounding`, remove duplicate phase 0+1 if router already ran; keep phase 3 only OR call shared helper `ensure_pcr_phase01(ctx)` idempotent.
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pytest services/orion-cortex-exec/tests/test_unified_pcr_phase01.py services/orion-cortex-exec/tests/test_pcr_chat_memory.py -q`
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 13: End-to-end smoke + gate checks
+
+**Files:**
+- Create: `scripts/smoke_memory_cognition_loop_e2e.sh`
+
+- [ ] **Step 1: Create smoke script**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+# 1. Enable MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED on consolidation (env or inline)
+# 2. POST hub chat brain mode with topic-shift prompt
+# 3. Poll crystallizations API for status=active without manual approve
+# 4. Second brain chat turn — grep cortex debug for belief_digest_chars > 0
+# 5. POST orion unified turn — grep grounding_capsule belief_digest non-empty
+```
+
+- [ ] **Step 2: Run agent gate checks**
+
+```bash
+python scripts/sync_local_env_from_example.py
+python scripts/check_env_template_parity.py
+python scripts/check_bus_channels.py
+pytest tests/test_formation_policy_auto_vs_gated.py tests/test_retrieval_intent.py -q
+pytest services/orion-memory-consolidation/tests/ -q
+pytest services/orion-cortex-exec/tests/test_pcr_chat_memory.py services/orion-cortex-exec/tests/test_unified_pcr_phase01.py -q
+pytest services/orion-recall/tests/test_active_packet_activation_floor.py -q
+```
+
+- [ ] **Step 3: Run smoke (if stack up)**
+
+```bash
+bash scripts/smoke_memory_cognition_loop_e2e.sh
+```
+
+- [ ] **Step 4: Flip `MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=true` in operator `.env` after smoke PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/smoke_memory_cognition_loop_e2e.sh
+git commit -m "test(memory): add memory cognition loop e2e smoke"
+```
+
+---
+
+# Milestone M3 — Lifecycle live (follow-on, after M1+M2 ship)
+
+Ship separately after brain/unified read path verified.
+
+| Task | Files | Behavior |
+|------|-------|----------|
+| M3-1 recall_boost | `services/orion-recall/app/worker.py`, `repository.update_crystallization` | After active_packet IDs resolved, bump activation |
+| M3-2 decay reaper | `services/orion-memory-consolidation/app/reaper.py` | Periodic decay + `should_retire` → deprecated |
+| M3-3 de-project | `projector.py` | Remove retired beliefs from cards/chroma |
+| M3-4 bus | `bus_emit.py`, `channels.yaml` | `memory.crystallization.retired.v1` |
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec requirement | Plan task |
+|------------------|-----------|
+| `formation_policy` auto vs gated | Task 3 |
+| `auto_activate` weak dynamics | Task 2, 4 |
+| dedup → reinforce | Task 6 |
+| dynamics schema + SQL | Task 1 |
+| auto-project cards/chroma only | Task 6, 7 |
+| PCR brain + unified phase 0→1→3 | Task 12 |
+| retrieval intent brain default | Task 8, 9 |
+| activation floor + ranked packet | Task 5, 10 |
+| Hub drop brain.recall.v1 default | Task 11 |
+| hub_chat_lane wire | Task 11 |
+| recall_boost + reaper | M3 appendix |
+| smoke e2e | Task 13 |
+
+**Placeholder scan:** None found.
+
+**Type consistency:** `FormationPolicy`, `eligible_belief_count`, `seed_weak_dynamics`, `process_consolidation_crystallization` outcomes used consistently across tasks.
+
+---
+
+## Restart required (after M1+M2)
+
+```bash
+docker compose --env-file .env --env-file services/orion-memory-consolidation/.env \
+  -f services/orion-memory-consolidation/docker-compose.yml up -d --build
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml up -d --build
+docker compose --env-file .env --env-file services/orion-recall/.env \
+  -f services/orion-recall/docker-compose.yml up -d --build
+docker compose --env-file .env --env-file services/orion-hub/.env \
+  -f services/orion-hub/docker-compose.yml up -d --build
+```
+
+Apply SQL migration for `dynamics` column on Postgres before consolidation worker starts.

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1354,6 +1354,24 @@ channels:
     stability: "experimental"
     since: "2026-06-10"
 
+  - name: "orion:memory:crystallization:reinforced"
+    kind: "event"
+    schema_id: "MemoryCrystallizationV1"
+    message_kind: "memory.crystallization.reinforced.v1"
+    producer_services: ["orion-memory-consolidation", "orion-memory-crystallizer", "orion-hub"]
+    consumer_services: ["orion-memory-crystallizer", "orion-hub"]
+    stability: "experimental"
+    since: "2026-07-08"
+
+  - name: "orion:memory:crystallization:auto_activated"
+    kind: "event"
+    schema_id: "MemoryCrystallizationV1"
+    message_kind: "memory.crystallization.auto_activated.v1"
+    producer_services: ["orion-memory-consolidation", "orion-memory-crystallizer", "orion-hub"]
+    consumer_services: ["orion-memory-crystallizer", "orion-hub", "orion-vector-writer"]
+    stability: "experimental"
+    since: "2026-07-08"
+
   - name: "orion:memory:turn:persisted"
     kind: "event"
     schema_id: "MemoryTurnPersistedV1"

--- a/orion/core/storage/sql/memory_crystallizations.sql
+++ b/orion/core/storage/sql/memory_crystallizations.sql
@@ -24,6 +24,8 @@ CREATE TABLE IF NOT EXISTS memory_crystallizations (
     updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+ALTER TABLE memory_crystallizations ADD COLUMN IF NOT EXISTS dynamics jsonb NOT NULL DEFAULT '{}'::jsonb;
+
 CREATE TABLE IF NOT EXISTS memory_crystallization_claims (
     claim_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     crystallization_id uuid NOT NULL REFERENCES memory_crystallizations(crystallization_id) ON DELETE CASCADE,

--- a/orion/core/storage/sql/memory_crystallizations.sql
+++ b/orion/core/storage/sql/memory_crystallizations.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS memory_crystallizations (
     status text NOT NULL DEFAULT 'proposed',
     confidence text NOT NULL DEFAULT 'likely',
     salience numeric NOT NULL DEFAULT 0.5,
+    dynamics jsonb NOT NULL DEFAULT '{}'::jsonb,
     scope text[] NOT NULL DEFAULT '{}',
     tags text[] NOT NULL DEFAULT '{}',
     grammar_envelope jsonb NOT NULL DEFAULT '{}'::jsonb,

--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -208,13 +208,18 @@ async def execute_unified_turn(
     from scripts.harness_governor_client import HarnessGovernorClient
     from scripts.thought_client import ThoughtClient
 
+    surface_context = payload.get("surface_context") if isinstance(payload.get("surface_context"), dict) else {}
+    surface_context = {**surface_context, "hub_chat_lane": "orion"}
     stance_req = StanceReactRequestV1(
         correlation_id=correlation_id,
         session_id=session_id,
         user_message=user_message,
         association=association,
         repair_bundle=repair_bundle,
-        stance_inputs={"user_message": user_message},
+        stance_inputs={
+            "user_message": user_message,
+            "surface_context": surface_context,
+        },
     )
     thought = await ThoughtClient(bus).react(stance_req, correlation_id=correlation_id)
     if thought is None:

--- a/orion/memory/crystallization/active_packet.py
+++ b/orion/memory/crystallization/active_packet.py
@@ -50,7 +50,10 @@ def build_active_packet(
     active = [c for c in crystallizations if c.status == "active"]
     if project_id:
         active = [c for c in active if project_id in c.scope or c.scope == []]
-    active.sort(key=lambda c: c.salience + _task_boost(c.kind, task_type), reverse=True)
+    active.sort(
+        key=lambda c: (c.dynamics.activation or 0.0) * (c.salience or 0.5) + _task_boost(c.kind, task_type),
+        reverse=True,
+    )
 
     cards = list(active_cards or [])
     card_ref_ids = list(card_refs or [])

--- a/orion/memory/crystallization/active_packet.py
+++ b/orion/memory/crystallization/active_packet.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from orion.memory.crystallization.recall_eligibility import eligible_for_recall
 from orion.memory.crystallization.schemas import ActiveMemoryPacketV1, MemoryCrystallizationV1
 
 KIND_TO_BUCKET = {
@@ -47,7 +48,7 @@ def build_active_packet(
     project_id: str | None = None,
     session_id: str | None = None,
 ) -> ActiveMemoryPacketV1:
-    active = [c for c in crystallizations if c.status == "active"]
+    active = [c for c in crystallizations if eligible_for_recall(c)]
     if project_id:
         active = [c for c in active if project_id in c.scope or c.scope == []]
     active.sort(

--- a/orion/memory/crystallization/bus_emit.py
+++ b/orion/memory/crystallization/bus_emit.py
@@ -17,6 +17,8 @@ LIFECYCLE_KINDS = {
     "quarantined": "memory.crystallization.quarantined.v1",
     "project": "memory.crystallization.project.v1",
     "retrieved": "memory.crystallization.retrieved.v1",
+    "reinforced": "memory.crystallization.reinforced.v1",
+    "auto_activated": "memory.crystallization.auto_activated.v1",
 }
 
 CHANNEL_DEFAULTS = {
@@ -27,6 +29,8 @@ CHANNEL_DEFAULTS = {
     "quarantined": "orion:memory:crystallization:quarantined",
     "project": "orion:memory:crystallization:project",
     "retrieved": "orion:memory:crystallization:retrieved",
+    "reinforced": "orion:memory:crystallization:reinforced",
+    "auto_activated": "orion:memory:crystallization:auto_activated",
 }
 
 

--- a/orion/memory/crystallization/dynamics.py
+++ b/orion/memory/crystallization/dynamics.py
@@ -40,6 +40,23 @@ def seed_dynamics(
     return updated
 
 
+def seed_weak_dynamics(
+    crystallization: MemoryCrystallizationV1,
+    *,
+    now: datetime,
+    ratio: float = 0.4,
+    min_activation: float = 0.05,
+    max_activation: float = 0.35,
+) -> MemoryCrystallizationV1:
+    """Auto-encode at a fraction of salience — weak initial footprint."""
+    updated = crystallization.model_copy(deep=True)
+    raw = _clamp(crystallization.salience * _clamp(ratio))
+    updated.dynamics.activation = max(min_activation, min(max_activation, raw))
+    updated.dynamics.formed_at = _aware(now)
+    updated.updated_at = _aware(now)
+    return updated
+
+
 def reinforce(
     crystallization: MemoryCrystallizationV1,
     *,

--- a/orion/memory/crystallization/dynamics.py
+++ b/orion/memory/crystallization/dynamics.py
@@ -5,8 +5,8 @@ Deterministic (§4): pure functions over a crystallization + a clock. No LLM, no
 Reuses the substrate half-life decay math (`orion.substrate.activation.decay_activation`)
 so crystallization memory ages on the same curve the substrate graph already uses.
 
-Nothing in the live path calls these yet — Phase 1 is inert and additive. Behavior wiring
-(reinforce-on-recurrence, decay reaper, recall boost) lands in later phases behind gates.
+Live wiring (M1): `seed_dynamics` / `seed_weak_dynamics` on formation, `reinforce` on dedup,
+`governor.approve` seeds dynamics. M3 follow-on: recall_boost on fetch, decay reaper, retire.
 """
 
 from __future__ import annotations

--- a/orion/memory/crystallization/formation_executor.py
+++ b/orion/memory/crystallization/formation_executor.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.memory.crystallization.dynamics import seed_weak_dynamics
+from orion.memory.crystallization.formation_policy import FormationPolicy, resolve_formation_policy
+from orion.memory.crystallization.schemas import MemoryCrystallizationV1
+from orion.memory.crystallization.validator import validate_proposal
+
+
+class GovernorPathRequired(ValueError):
+    pass
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def auto_activate(
+    crystallization: MemoryCrystallizationV1,
+    *,
+    actor: str = "system:formation_policy",
+    encode_ratio: float = 0.4,
+) -> tuple[MemoryCrystallizationV1, dict]:
+    policy, reasons = resolve_formation_policy(crystallization)
+    if policy != FormationPolicy.AUTO_ACTIVATE:
+        raise GovernorPathRequired("; ".join(reasons) or policy.value)
+    validation = validate_proposal(crystallization)
+    if not validation.valid:
+        raise GovernorPathRequired("; ".join(validation.errors))
+    now = _utc_now()
+    updated = crystallization.model_copy(deep=True)
+    updated.status = "active"
+    updated.governance.approval_mode = "auto_policy"
+    updated.governance.requires_manual_review = False
+    updated.governance.approved_by = actor
+    updated.governance.validation_status = "valid"
+    updated.governance.last_reviewed_at = now
+    updated = seed_weak_dynamics(updated, now=now, ratio=encode_ratio)
+    history = {
+        "op": "auto_activate",
+        "actor": actor,
+        "reasons": reasons,
+        "before": {"status": crystallization.status},
+        "after": {"status": "active", "activation": updated.dynamics.activation},
+    }
+    return updated, history

--- a/orion/memory/crystallization/formation_policy.py
+++ b/orion/memory/crystallization/formation_policy.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from orion.memory.crystallization.schemas import MemoryCrystallizationV1
+
+AUTO_ACTIVE_KINDS = frozenset({"semantic", "episode", "open_loop", "procedure"})
+GATED_KINDS = frozenset({"stance", "decision", "contradiction", "attractor", "failure_mode"})
+IDENTITY_SCOPE_PREFIX = "identity:"
+
+
+class FormationPolicy(str, Enum):
+    AUTO_ACTIVATE = "auto_activate"
+    GOVERNOR_QUEUE = "governor_queue"
+    REINFORCE_EXISTING = "reinforce_existing"
+
+
+def _has_identity_scope(crystallization: MemoryCrystallizationV1, *, prefix: str = IDENTITY_SCOPE_PREFIX) -> bool:
+    return any(str(s).startswith(prefix) for s in crystallization.scope)
+
+
+def resolve_formation_policy(
+    crystallization: MemoryCrystallizationV1,
+    *,
+    duplicate_id: str | None = None,
+    identity_scope_prefix: str = IDENTITY_SCOPE_PREFIX,
+) -> tuple[FormationPolicy, list[str]]:
+    reasons: list[str] = []
+    if duplicate_id:
+        return FormationPolicy.REINFORCE_EXISTING, [f"duplicate:{duplicate_id}"]
+    if crystallization.governance.sensitivity == "intimate":
+        return FormationPolicy.GOVERNOR_QUEUE, ["intimate_sensitivity"]
+    if _has_identity_scope(crystallization, prefix=identity_scope_prefix):
+        return FormationPolicy.GOVERNOR_QUEUE, ["identity_scope"]
+    if crystallization.kind in GATED_KINDS:
+        return FormationPolicy.GOVERNOR_QUEUE, [f"gated_kind:{crystallization.kind}"]
+    if crystallization.kind in AUTO_ACTIVE_KINDS:
+        return FormationPolicy.AUTO_ACTIVATE, reasons
+    return FormationPolicy.GOVERNOR_QUEUE, [f"unknown_kind:{crystallization.kind}"]

--- a/orion/memory/crystallization/governor.py
+++ b/orion/memory/crystallization/governor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Literal
 
+from orion.memory.crystallization.dynamics import seed_dynamics
 from orion.memory.crystallization.schemas import MemoryCrystallizationV1
 from orion.memory.crystallization.validator import ValidationResult, validate_proposal
 
@@ -57,13 +58,15 @@ def approve(
     updated.governance.validation_status = "valid"
     updated.governance.last_reviewed_at = now
     updated.updated_at = now
+    # Full salience seed (not seed_weak_dynamics) so human-approved beliefs enter recall immediately.
+    updated = seed_dynamics(updated, now=now)
 
     history = {
         "op": "approve",
         "actor": actor,
         "reason": reason,
         "before": {"status": crystallization.status},
-        "after": {"status": "active"},
+        "after": {"status": "active", "activation": updated.dynamics.activation},
     }
     return updated, history
 

--- a/orion/memory/crystallization/intake_pipeline.py
+++ b/orion/memory/crystallization/intake_pipeline.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.memory.crystallization.bus_emit import emit_crystallization_lifecycle
+from orion.memory.crystallization.detection import detect_duplicates
+from orion.memory.crystallization.dynamics import reinforce
+from orion.memory.crystallization.formation_executor import GovernorPathRequired, auto_activate
+from orion.memory.crystallization.formation_policy import FormationPolicy, resolve_formation_policy
+from orion.memory.crystallization.projector import ProjectionConfig, project_crystallization
+from orion.memory.crystallization.repository import (
+    insert_crystallization,
+    list_crystallizations,
+    update_crystallization,
+)
+from orion.memory.crystallization.salience import apply_salience
+from orion.memory.crystallization.schemas import MemoryCrystallizationV1, _utc_now
+
+
+def _emit_settings(settings: Any) -> dict[str, str]:
+    return {
+        "service_name": getattr(settings, "SERVICE_NAME", "orion-memory-consolidation"),
+        "service_version": getattr(settings, "SERVICE_VERSION", "0.1.0"),
+        "node_name": getattr(settings, "NODE_NAME", "consolidation"),
+    }
+
+
+def _append_new_evidence(
+    target: MemoryCrystallizationV1,
+    candidate: MemoryCrystallizationV1,
+) -> MemoryCrystallizationV1:
+    updated = target.model_copy(deep=True)
+    seen = {(ev.source_kind, ev.source_id) for ev in updated.evidence}
+    for ev in candidate.evidence:
+        key = (ev.source_kind, ev.source_id)
+        if key in seen:
+            continue
+        updated.evidence.append(ev)
+        seen.add(key)
+    return updated
+
+
+async def process_consolidation_crystallization(
+    pool: asyncpg.Pool,
+    bus: OrionBusAsync | None,
+    *,
+    crystallization: MemoryCrystallizationV1,
+    settings: Any,
+    project_config: ProjectionConfig | None,
+) -> tuple[str, MemoryCrystallizationV1, str]:
+    """Returns (crystallization_id, final_row, outcome).
+
+    Outcome is one of: auto_activated | proposed | reinforced.
+    """
+    emit_kw = _emit_settings(settings)
+
+    existing = await list_crystallizations(pool, status=None, limit=200)
+    detection = detect_duplicates(crystallization, existing)
+    duplicate_id = detection.duplicates[0] if detection.duplicates else None
+    policy, _ = resolve_formation_policy(crystallization, duplicate_id=duplicate_id)
+
+    if policy == FormationPolicy.REINFORCE_EXISTING and duplicate_id:
+        match = next(c for c in existing if c.crystallization_id == duplicate_id)
+        merged = _append_new_evidence(match, crystallization)
+        updated = reinforce(merged, now=_utc_now())
+        await update_crystallization(pool, updated)
+        await emit_crystallization_lifecycle(
+            bus,
+            lifecycle="reinforced",
+            crystallization=updated,
+            **emit_kw,
+        )
+        return duplicate_id, updated, "reinforced"
+
+    if not settings.MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED:
+        row = apply_salience(crystallization)
+        cid = await insert_crystallization(pool, row)
+        await emit_crystallization_lifecycle(
+            bus,
+            lifecycle="proposed",
+            crystallization=row,
+            **emit_kw,
+        )
+        return cid, row, "proposed"
+
+    try:
+        activated, _ = auto_activate(
+            apply_salience(crystallization),
+            encode_ratio=settings.MEMORY_FORMATION_AUTO_ENCODE_ACTIVATION_RATIO,
+        )
+        cid = await insert_crystallization(pool, activated)
+        activated, _proj = await project_crystallization(
+            pool,
+            bus,
+            activated,
+            actor="system:formation_policy",
+            config=project_config,
+            project_graphiti=False,
+        )
+        await update_crystallization(pool, activated)
+        await emit_crystallization_lifecycle(
+            bus,
+            lifecycle="auto_activated",
+            crystallization=activated,
+            **emit_kw,
+        )
+        return cid, activated, "auto_activated"
+    except GovernorPathRequired:
+        row = apply_salience(crystallization)
+        cid = await insert_crystallization(pool, row)
+        await emit_crystallization_lifecycle(
+            bus,
+            lifecycle="proposed",
+            crystallization=row,
+            **emit_kw,
+        )
+        return cid, row, "proposed"

--- a/orion/memory/crystallization/intake_pipeline.py
+++ b/orion/memory/crystallization/intake_pipeline.py
@@ -108,8 +108,13 @@ async def process_consolidation_crystallization(
             **emit_kw,
         )
         return cid, activated, "auto_activated"
-    except GovernorPathRequired:
+    except GovernorPathRequired as exc:
         row = apply_salience(crystallization)
+        row.provenance = {
+            **(row.provenance or {}),
+            "formation_policy_downgrade": str(exc),
+            "formation_policy": "governor_queue",
+        }
         cid = await insert_crystallization(pool, row)
         await emit_crystallization_lifecycle(
             bus,

--- a/orion/memory/crystallization/recall_eligibility.py
+++ b/orion/memory/crystallization/recall_eligibility.py
@@ -5,7 +5,6 @@ import os
 from orion.memory.crystallization.schemas import MemoryCrystallizationV1
 
 ACTIVATION_RECALL_FLOOR = float(os.getenv("ACTIVATION_RECALL_FLOOR", "0.08"))
-_INELIGIBLE_STATUSES = frozenset({"deprecated", "archived", "rejected", "quarantined"})
 
 
 def eligible_for_recall(
@@ -13,9 +12,12 @@ def eligible_for_recall(
     *,
     floor: float | None = None,
 ) -> bool:
+    """Return True when an active crystallization is strong enough for recall injection.
+
+    Legacy governor-approved rows with activation=0.0 remain ineligible until re-approved
+    (post-M1 governor.approve seeds dynamics) or manually reinforced.
+    """
     if crystallization.status != "active":
-        return False
-    if crystallization.status in _INELIGIBLE_STATUSES:
         return False
     threshold = ACTIVATION_RECALL_FLOOR if floor is None else floor
     return float(crystallization.dynamics.activation) >= threshold

--- a/orion/memory/crystallization/recall_eligibility.py
+++ b/orion/memory/crystallization/recall_eligibility.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+
+from orion.memory.crystallization.schemas import MemoryCrystallizationV1
+
+ACTIVATION_RECALL_FLOOR = float(os.getenv("ACTIVATION_RECALL_FLOOR", "0.08"))
+_INELIGIBLE_STATUSES = frozenset({"deprecated", "archived", "rejected", "quarantined"})
+
+
+def eligible_for_recall(
+    crystallization: MemoryCrystallizationV1,
+    *,
+    floor: float | None = None,
+) -> bool:
+    if crystallization.status != "active":
+        return False
+    if crystallization.status in _INELIGIBLE_STATUSES:
+        return False
+    threshold = ACTIVATION_RECALL_FLOOR if floor is None else floor
+    return float(crystallization.dynamics.activation) >= threshold

--- a/orion/memory/crystallization/repository.py
+++ b/orion/memory/crystallization/repository.py
@@ -10,6 +10,7 @@ import asyncpg
 
 from orion.memory.crystallization.schemas import (
     CrystallizationClaimV1,
+    CrystallizationDynamicsV1,
     CrystallizationEvidenceRefV1,
     CrystallizationGovernanceV1,
     CrystallizationLinkV1,
@@ -66,6 +67,7 @@ def _row_to_crystallization(
     gov_raw = _parse_jsonb(row["governance"]) or {}
     proj_raw = _parse_jsonb(row["projection_refs"]) or {}
     grammar_raw = _parse_jsonb(row["grammar_envelope"]) or {}
+    dynamics_raw = _parse_jsonb(row.get("dynamics")) or {}
 
     return MemoryCrystallizationV1(
         crystallization_id=str(row["crystallization_id"]),
@@ -75,6 +77,7 @@ def _row_to_crystallization(
         status=row["status"],
         confidence=row["confidence"],
         salience=float(row["salience"]),
+        dynamics=CrystallizationDynamicsV1.model_validate(dynamics_raw),
         scope=list(row["scope"] or []),
         tags=list(row["tags"] or []),
         claims=claims,
@@ -177,14 +180,14 @@ async def insert_crystallization(pool: asyncpg.Pool, crystallization: MemoryCrys
                     """
                     INSERT INTO memory_crystallizations (
                         crystallization_id, kind, subject, summary, status, confidence, salience,
-                        scope, tags, grammar_envelope, planning_effects, retrieval_affordances,
+                        dynamics, scope, tags, grammar_envelope, planning_effects, retrieval_affordances,
                         governance, projection_refs, source_card_ids, source_grammar_event_ids,
                         source_atom_ids, created_at, updated_at
                     ) VALUES (
                         $1::uuid, $2, $3, $4, $5, $6, $7,
-                        $8, $9, $10::jsonb, $11, $12,
-                        $13::jsonb, $14::jsonb, $15, $16,
-                        $17, $18, $19
+                        $8::jsonb, $9, $10, $11::jsonb, $12, $13,
+                        $14::jsonb, $15::jsonb, $16, $17,
+                        $18, $19, $20
                     )
                     RETURNING crystallization_id
                     """,
@@ -195,6 +198,7 @@ async def insert_crystallization(pool: asyncpg.Pool, crystallization: MemoryCrys
                     crystallization.status,
                     crystallization.confidence,
                     crystallization.salience,
+                    _jsonb(crystallization.dynamics.model_dump(mode="json")),
                     crystallization.scope,
                     crystallization.tags,
                     _jsonb(crystallization.grammar_envelope.model_dump(mode="json")),
@@ -213,14 +217,14 @@ async def insert_crystallization(pool: asyncpg.Pool, crystallization: MemoryCrys
                     """
                     INSERT INTO memory_crystallizations (
                         kind, subject, summary, status, confidence, salience,
-                        scope, tags, grammar_envelope, planning_effects, retrieval_affordances,
+                        dynamics, scope, tags, grammar_envelope, planning_effects, retrieval_affordances,
                         governance, projection_refs, source_card_ids, source_grammar_event_ids,
                         source_atom_ids, created_at, updated_at
                     ) VALUES (
                         $1, $2, $3, $4, $5, $6,
-                        $7, $8, $9::jsonb, $10, $11,
-                        $12::jsonb, $13::jsonb, $14, $15,
-                        $16, $17, $18
+                        $7::jsonb, $8, $9, $10::jsonb, $11, $12,
+                        $13::jsonb, $14::jsonb, $15, $16,
+                        $17, $18, $19
                     )
                     RETURNING crystallization_id
                     """,
@@ -230,6 +234,7 @@ async def insert_crystallization(pool: asyncpg.Pool, crystallization: MemoryCrys
                     crystallization.status,
                     crystallization.confidence,
                     crystallization.salience,
+                    _jsonb(crystallization.dynamics.model_dump(mode="json")),
                     crystallization.scope,
                     crystallization.tags,
                     _jsonb(crystallization.grammar_envelope.model_dump(mode="json")),
@@ -312,10 +317,11 @@ async def update_crystallization(pool: asyncpg.Pool, crystallization: MemoryCrys
             """
             UPDATE memory_crystallizations SET
                 kind = $2, subject = $3, summary = $4, status = $5, confidence = $6,
-                salience = $7, scope = $8, tags = $9, grammar_envelope = $10::jsonb,
-                planning_effects = $11, retrieval_affordances = $12, governance = $13::jsonb,
-                projection_refs = $14::jsonb, source_card_ids = $15,
-                source_grammar_event_ids = $16, source_atom_ids = $17, updated_at = $18
+                salience = $7, dynamics = $8::jsonb, scope = $9, tags = $10,
+                grammar_envelope = $11::jsonb, planning_effects = $12,
+                retrieval_affordances = $13, governance = $14::jsonb,
+                projection_refs = $15::jsonb, source_card_ids = $16,
+                source_grammar_event_ids = $17, source_atom_ids = $18, updated_at = $19
             WHERE crystallization_id = $1::uuid
             """,
             cid,
@@ -325,6 +331,7 @@ async def update_crystallization(pool: asyncpg.Pool, crystallization: MemoryCrys
             crystallization.status,
             crystallization.confidence,
             crystallization.salience,
+            _jsonb(crystallization.dynamics.model_dump(mode="json")),
             crystallization.scope,
             crystallization.tags,
             _jsonb(crystallization.grammar_envelope.model_dump(mode="json")),

--- a/orion/memory/crystallization/repository.py
+++ b/orion/memory/crystallization/repository.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 import asyncpg
 
+from orion.memory.crystallization.recall_eligibility import eligible_for_recall
 from orion.memory.crystallization.schemas import (
     CrystallizationClaimV1,
     CrystallizationDynamicsV1,
@@ -401,6 +402,11 @@ async def list_crystallizations(
         claims, evidence, links = await _load_children(pool, str(row["crystallization_id"]))
         out.append(_row_to_crystallization(row, claims=claims, evidence=evidence, links=links))
     return out
+
+
+async def count_eligible_active(pool: asyncpg.Pool, *, floor: float | None = None) -> int:
+    rows = await list_crystallizations(pool, status="active", limit=500)
+    return sum(1 for r in rows if eligible_for_recall(r, floor=floor))
 
 
 async def insert_history(

--- a/orion/memory/crystallization/schemas.py
+++ b/orion/memory/crystallization/schemas.py
@@ -169,6 +169,18 @@ class CrystallizationRefV1(BaseModel):
     synced_at: datetime | None = None
 
 
+class CrystallizationDynamicsV1(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    activation: float = Field(default=0.0, ge=0.0, le=1.0)
+    reinforcement_count: int = 0
+    formed_at: datetime | None = None
+    last_reinforced_at: datetime | None = None
+    last_recalled_at: datetime | None = None
+    decay_half_life_days: float = 30.0
+    retired_at: datetime | None = None
+
+
 class MemoryCrystallizationV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -183,6 +195,7 @@ class MemoryCrystallizationV1(BaseModel):
     status: CrystallizationStatus = "proposed"
     confidence: CrystallizationConfidence = "likely"
     salience: float = Field(default=0.5, ge=0.0, le=1.0)
+    dynamics: CrystallizationDynamicsV1 = Field(default_factory=CrystallizationDynamicsV1)
 
     scope: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)

--- a/orion/memory/retrieval_intent.py
+++ b/orion/memory/retrieval_intent.py
@@ -110,9 +110,10 @@ def derive_retrieval_intent(
     user_message: str,
     shift_novelty_floor: float = 0.35,
     seed_crystallization_id: str | None = None,
+    eligible_belief_count: int = 0,
+    brain_belief_default_enabled: bool = True,
 ) -> tuple[str, str]:
     """Derive PCR retrieval intent from stance, appraisal, and attention signals."""
-    _ = hub_chat_lane
 
     if skip_gate.skip:
         return "none", "phase0_skip"
@@ -144,5 +145,12 @@ def derive_retrieval_intent(
 
     if _has_entity_query(user_message):
         return "semantic", "entity_query"
+
+    if (
+        brain_belief_default_enabled
+        and hub_chat_lane in ("brain", "orion")
+        and eligible_belief_count > 0
+    ):
+        return "semantic", "brain_lane_belief_default"
 
     return "continuity", "continuity_only"

--- a/scripts/smoke_memory_cognition_loop_e2e.sh
+++ b/scripts/smoke_memory_cognition_loop_e2e.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Memory cognition loop — structural gate checks + optional live-stack smoke.
+#
+# Full encode → store → retrieve → lifecycle loop requires consolidation auto-activate:
+#   MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=true
+# in services/orion-memory-consolidation/.env (operator contract; default is false).
+#
+# Usage:
+#   bash scripts/smoke_memory_cognition_loop_e2e.sh              # STRUCTURAL (pytest only)
+#   HUB_URL=http://127.0.0.1:8080 bash scripts/smoke_memory_cognition_loop_e2e.sh  # + LIVE
+#   bash scripts/smoke_memory_cognition_loop_e2e.sh --live         # LIVE (requires HUB_URL)
+#   bash scripts/smoke_memory_cognition_loop_e2e.sh --structural   # pytest only (default)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+MODE="structural"
+for arg in "$@"; do
+  case "$arg" in
+    --live) MODE="live" ;;
+    --structural) MODE="structural" ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: bash scripts/smoke_memory_cognition_loop_e2e.sh [--structural|--live]
+
+STRUCTURAL (default): deterministic pytest gate bundle — no live stack required.
+
+LIVE: when HUB_URL (or ORION_HUB_URL) is set, probe service health and exercise
+      brain-mode chat + crystallization auto-activate + unified turn belief recall.
+
+Required for full live loop:
+  MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=true  (memory-consolidation .env)
+  ORION_HUB_SESSION_ID                       (session header for Hub APIs)
+
+Optional service URLs (defaults shown):
+  HUB_URL / ORION_HUB_URL     http://127.0.0.1:8080
+  CORTEX_EXEC_HEALTH_URL      http://127.0.0.1:8070/health
+  RECALL_HEALTH_URL           http://127.0.0.1:8260/health
+  CONSOLIDATION_HEALTH_URL    http://127.0.0.1:8635/health
+EOF
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $arg (use --structural, --live, or --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+HUB_URL="${HUB_URL:-${ORION_HUB_URL:-}}"
+if [[ -n "$HUB_URL" && "$MODE" == "structural" ]]; then
+  MODE="live"
+fi
+
+export PYTHONPATH="${ROOT}${PYTHONPATH:+:$PYTHONPATH}"
+
+_resolve_pytest() {
+  local candidate py
+  for candidate in \
+    "${ORION_PYTEST:-}" \
+    "${ROOT}/.venv/bin/pytest" \
+    "${ROOT}/../../.venv/bin/pytest" \
+    "${ROOT}/../../orion_dev/bin/pytest" \
+    "${ROOT}/orion_dev/bin/pytest"; do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+      py="$(dirname "$candidate")/python"
+      if [[ -x "$py" ]] && "$py" -c "import pydantic" >/dev/null 2>&1; then
+        if "$candidate" --version >/dev/null 2>&1; then
+          echo "$candidate"
+          return 0
+        fi
+      fi
+    fi
+  done
+  local py="${ORION_PYTHON:-python3}"
+  if "$py" -c "import pydantic" >/dev/null 2>&1 && "$py" -m pytest --version >/dev/null 2>&1; then
+    echo "$py -m pytest"
+    return 0
+  fi
+  return 1
+}
+
+PYTEST_BIN="$(_resolve_pytest || true)"
+if [[ -z "$PYTEST_BIN" ]]; then
+  fail "pytest not found (tried .venv, ../../.venv, orion_dev, python3 -m pytest)"
+fi
+read -r -a PYTEST <<< "$PYTEST_BIN"
+echo "pytest: ${PYTEST[*]}"
+
+fail() { echo "SMOKE FAIL: $*" >&2; exit 1; }
+
+echo "== memory cognition loop env contract =="
+echo "Full live loop requires MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=true"
+echo "  (services/orion-memory-consolidation/.env — default false for safe rollout)"
+if [[ -f services/orion-memory-consolidation/.env ]]; then
+  val="$(grep -E '^MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=' services/orion-memory-consolidation/.env | tail -1 | cut -d= -f2- | tr -d '\r' || true)"
+  if [[ -n "$val" ]]; then
+    echo "  local consolidation .env: MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=${val}"
+  else
+    echo "  WARN: MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED not set in local consolidation .env"
+  fi
+else
+  echo "  WARN: services/orion-memory-consolidation/.env missing (see .env_example)"
+fi
+
+run_pytest() {
+  echo "== pytest: $* =="
+  "${PYTEST[@]}" "$@" -q
+}
+
+echo "== STRUCTURAL: memory cognition loop gate pytest =="
+run_pytest tests/test_formation_policy_auto_vs_gated.py
+run_pytest tests/test_retrieval_intent.py
+run_pytest tests/test_encode_reinforce_not_duplicate.py
+run_pytest services/orion-memory-consolidation/tests/
+run_pytest \
+  services/orion-cortex-exec/tests/test_pcr_chat_memory.py \
+  services/orion-cortex-exec/tests/test_unified_pcr_phase01.py
+run_pytest \
+  services/orion-recall/tests/test_active_packet_activation_floor.py \
+  services/orion-recall/tests/test_pcr_continuity.py
+run_pytest services/orion-hub/tests/test_cortex_request_builder.py
+
+echo "STRUCTURAL gate OK"
+
+if [[ "$MODE" != "live" ]]; then
+  echo "PASS smoke_memory_cognition_loop_e2e (structural only; set HUB_URL for live)"
+  exit 0
+fi
+
+[[ -n "$HUB_URL" ]] || fail "LIVE mode requires HUB_URL or ORION_HUB_URL"
+: "${ORION_HUB_SESSION_ID:?set ORION_HUB_SESSION_ID for Hub session header}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "WARN: curl missing — skipping live health + e2e probes"
+  echo "PASS smoke_memory_cognition_loop_e2e (structural only; curl unavailable)"
+  exit 0
+fi
+
+JQ=()
+if command -v jq >/dev/null 2>&1; then
+  JQ=(jq -c)
+else
+  echo "WARN: jq missing — live responses will not be parsed"
+fi
+
+_health_curl() {
+  local name="$1" url="$2"
+  echo "== health: ${name} (${url}) =="
+  local code body
+  body="$(curl -sS -w '' "$url" 2>/dev/null || true)"
+  code="$(curl -sS -o /dev/null -w '%{http_code}' "$url" 2>/dev/null || echo "000")"
+  if [[ "$code" != "200" ]]; then
+    echo "WARN: ${name} health HTTP ${code}"
+    return 1
+  fi
+  if [[ ${#JQ[@]} -gt 0 && -n "$body" ]]; then
+    echo "$body" | "${JQ[@]}" '.' 2>/dev/null || echo "$body"
+  else
+    echo "$body"
+  fi
+}
+
+HUB_BASE="${HUB_URL%/}"
+CORTEX_EXEC_HEALTH_URL="${CORTEX_EXEC_HEALTH_URL:-http://127.0.0.1:8070/health}"
+RECALL_HEALTH_URL="${RECALL_HEALTH_URL:-http://127.0.0.1:8260/health}"
+CONSOLIDATION_HEALTH_URL="${CONSOLIDATION_HEALTH_URL:-http://127.0.0.1:8635/health}"
+
+_health_curl hub "${HUB_BASE}/health" || true
+_health_curl cortex-exec "$CORTEX_EXEC_HEALTH_URL" || true
+_health_curl recall "$RECALL_HEALTH_URL" || true
+_health_curl memory-consolidation "$CONSOLIDATION_HEALTH_URL" || true
+
+HDR=(-H "Content-Type: application/json" -H "X-Orion-Session-Id: ${ORION_HUB_SESSION_ID}")
+STAMP="$(date -u +%Y%m%d%H%M%S)"
+TOPIC_PROMPT="We decided to use k3s for staging deploy ${STAMP} — track this as project memory."
+
+echo "== LIVE: brain chat topic-shift seed =="
+if [[ ${#JQ[@]} -eq 0 ]]; then
+  fail "LIVE e2e requires jq for response assertions"
+fi
+
+SEED=$(curl -sS -w "\n%{http_code}" -X POST "${HUB_BASE}/api/chat" "${HDR[@]}" -d "$(jq -n --arg m "$TOPIC_PROMPT" '{
+  message: $m,
+  mode: "brain",
+  recall: {enabled: true}
+}')")
+SEED_BODY="$(echo "$SEED" | head -n -1)"
+SEED_CODE="$(echo "$SEED" | tail -n 1)"
+[[ "$SEED_CODE" == "200" ]] || fail "brain seed chat HTTP $SEED_CODE body=$SEED_BODY"
+echo "$SEED_BODY" | jq -c '{memory_used, recall_debug: (.recall_debug // {} | {profile, pcr: .pcr, eligible_belief_count})}'
+
+echo "== LIVE: poll active crystallizations (auto-activate path) =="
+ACTIVE_COUNT=0
+for attempt in $(seq 1 12); do
+  LIST=$(curl -sS -w "\n%{http_code}" "${HDR[@]}" "${HUB_BASE}/api/memory/crystallizations?status=active&limit=50")
+  LIST_BODY="$(echo "$LIST" | head -n -1)"
+  LIST_CODE="$(echo "$LIST" | tail -n 1)"
+  [[ "$LIST_CODE" == "200" ]] || fail "crystallizations list HTTP $LIST_CODE"
+  ACTIVE_COUNT="$(echo "$LIST_BODY" | jq -r --arg s "$STAMP" '[.items[]? | select(.summary | tostring | contains($s))] | length')"
+  if [[ "${ACTIVE_COUNT:-0}" -ge 1 ]]; then
+    echo "active crystallization with stamp found (attempt=${attempt})"
+    break
+  fi
+  echo "  poll ${attempt}/12: no active crystallization matching stamp yet"
+  sleep 5
+done
+if [[ "${ACTIVE_COUNT:-0}" -lt 1 ]]; then
+  echo "WARN: no auto-activated crystallization found for stamp=${STAMP}"
+  echo "      (MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=true on consolidation worker?)"
+fi
+
+echo "== LIVE: brain chat belief recall turn =="
+RECALL=$(curl -sS -w "\n%{http_code}" -X POST "${HUB_BASE}/api/chat" "${HDR[@]}" -d "$(jq -n --arg m "what did we decide about k3s staging ${STAMP}?" '{
+  message: $m,
+  mode: "brain",
+  recall: {enabled: true}
+}')")
+RECALL_BODY="$(echo "$RECALL" | head -n -1)"
+RECALL_CODE="$(echo "$RECALL" | tail -n 1)"
+[[ "$RECALL_CODE" == "200" ]] || fail "brain recall chat HTTP $RECALL_CODE body=$RECALL_BODY"
+BELIEF_CHARS="$(echo "$RECALL_BODY" | jq -r '((.belief_digest // "") | length)')"
+echo "$RECALL_BODY" | jq -c '{
+  memory_used,
+  belief_digest_chars: ((.belief_digest // "") | length),
+  continuity_digest_chars: ((.continuity_digest // "") | length),
+  recall_debug: (.recall_debug // {} | {profile, eligible_belief_count, pcr: .pcr})
+}'
+if [[ "${BELIEF_CHARS:-0}" -le 0 ]]; then
+  echo "WARN: belief_digest_chars=0 on recall turn (eligible beliefs may be below activation floor)"
+fi
+
+echo "== LIVE: orion unified turn (grounding_capsule belief path) =="
+UNIFIED=$(curl -sS -w "\n%{http_code}" -X POST "${HUB_BASE}/api/chat" "${HDR[@]}" -d "$(jq -n --arg m "summarize our k3s staging decision ${STAMP}" '{
+  messages: [{role: "user", content: $m}],
+  mode: "orion",
+  use_recall: true
+}')")
+UNIFIED_BODY="$(echo "$UNIFIED" | head -n -1)"
+UNIFIED_CODE="$(echo "$UNIFIED" | tail -n 1)"
+[[ "$UNIFIED_CODE" == "200" ]] || fail "orion unified chat HTTP $UNIFIED_CODE body=$UNIFIED_BODY"
+
+CAPSULE_BELIEF="$(echo "$UNIFIED_BODY" | jq -r '
+  [
+    .grounding_capsule.belief_digest?,
+    .metadata.grounding_capsule.belief_digest?,
+    .thought.grounding_capsule.belief_digest?
+  ] | map(select(. != null and (. | tostring | length) > 0)) | first // ""
+' | wc -c | tr -d ' ')"
+echo "$UNIFIED_BODY" | jq -c '{
+  type,
+  phase,
+  grounding_capsule: (.grounding_capsule // .metadata.grounding_capsule // .thought.grounding_capsule // null
+    | if . then {belief_digest_chars: ((.belief_digest // "") | length), pcr_ran: .provenance.pcr_ran} else null end)
+}'
+if [[ "${CAPSULE_BELIEF:-0}" -le 1 ]]; then
+  echo "WARN: unified turn grounding_capsule.belief_digest empty (ORION_UNIFIED_TURN_ENABLED / harness stack?)"
+fi
+
+echo "PASS smoke_memory_cognition_loop_e2e mode=live stamp=${STAMP} active_auto=${ACTIVE_COUNT:-0} belief_chars=${BELIEF_CHARS:-0}"

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -28,6 +28,7 @@ NEVER_SYNC_KEYS = frozenset(
 # Prefixes / exact keys synced after .env_example edits (default mode).
 SYNC_PREFIXES = (
     "CRYSTALLIZER_",
+    "ACTIVATION_",
     "GRAPHITI_",
     "FALKORDB_",
     "CHROMA_",

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -29,6 +29,7 @@ NEVER_SYNC_KEYS = frozenset(
 SYNC_PREFIXES = (
     "CRYSTALLIZER_",
     "ACTIVATION_",
+    "MEMORY_FORMATION_",
     "GRAPHITI_",
     "FALKORDB_",
     "CHROMA_",
@@ -159,6 +160,7 @@ SYNC_EXACT = frozenset(
 DEFAULT_SERVICES = (
     "orion-memory-crystallizer",
     "orion-memory-consolidation",
+    "orion-recall",
     "orion-sql-writer",
     "orion-graphiti-adapter",
     "orion-hub",

--- a/services/orion-cortex-exec/.env_example
+++ b/services/orion-cortex-exec/.env_example
@@ -37,6 +37,7 @@ CHAT_PCR_SKIP_ON_LOW_INFO=true
 CHAT_PCR_QUICK_PHASE3=false
 CHAT_PCR_SKIP_MAX_NOVELTY=0.25
 CHAT_PCR_SKIP_SHIFT_NOVELTY_FLOOR=0.35
+MEMORY_COGNITION_BRAIN_BELIEF_DEFAULT=true
 
 # Unified-turn self-grounding: assemble the identity+relationship+PCR grounding
 # capsule in the stance step and ride it on ThoughtEventV1. false => byte-identical

--- a/services/orion-cortex-exec/app/grounding_capsule.py
+++ b/services/orion-cortex-exec/app/grounding_capsule.py
@@ -8,7 +8,7 @@ from orion.core.bus.bus_schemas import ServiceRef
 from orion.schemas.thought import GroundingCapsuleV1
 from orion.thought.json_extract import extract_first_json_object_text
 
-from .pcr_chat_memory import run_pcr_phase3
+from .pcr_chat_memory import pcr_phase01_complete, run_pcr_phase0_and_1, run_pcr_phase3
 from .settings import Settings, settings
 
 logger = logging.getLogger("orion.cortex.grounding_capsule")
@@ -96,6 +96,15 @@ async def assemble_stance_grounding(
     try:
         ctx["chat_stance_brief"] = stance_slice_brief_from_step_text(stance_step_text)
         if cfg.chat_pcr_enabled:
+            if not pcr_phase01_complete(ctx):
+                await run_pcr_phase0_and_1(
+                    bus,
+                    source=source,
+                    ctx=ctx,
+                    correlation_id=correlation_id,
+                    recall_cfg=recall_cfg,
+                    exec_settings=cfg,
+                )
             _pcr, _step, _debug = await run_pcr_phase3(
                 bus,
                 source=source,

--- a/services/orion-cortex-exec/app/pcr_chat_memory.py
+++ b/services/orion-cortex-exec/app/pcr_chat_memory.py
@@ -242,6 +242,8 @@ async def run_pcr_phase3(
         user_message=user_message,
         shift_novelty_floor=cfg.chat_pcr_skip_shift_novelty_floor,
         seed_crystallization_id=str(ctx.get("seed_crystallization_id") or "").strip() or None,
+        eligible_belief_count=int((ctx.get("eligible_belief_count") or 0)),
+        brain_belief_default_enabled=cfg.memory_cognition_brain_belief_default,
     )
 
     if intent in ("none", "continuity"):

--- a/services/orion-cortex-exec/app/pcr_chat_memory.py
+++ b/services/orion-cortex-exec/app/pcr_chat_memory.py
@@ -86,6 +86,21 @@ def _pcr_from_ctx(ctx: Dict[str, Any]) -> PcrChatMemoryV1 | None:
     return None
 
 
+def pcr_phase01_complete(ctx: Dict[str, Any]) -> bool:
+    """True when phase 0+1 continuity recall (or skip) already ran for this turn."""
+    pcr = _pcr_from_ctx(ctx)
+    if pcr is not None and pcr.phase in ("skip", "continuity", "belief"):
+        return True
+    if isinstance(ctx.get("continuity_digest"), str) and str(ctx.get("continuity_digest")).strip():
+        return True
+    debug = ctx.get("debug")
+    if isinstance(debug, dict):
+        pcr_debug = debug.get("pcr")
+        if isinstance(pcr_debug, dict) and pcr_debug.get("phase") in ("skip", "continuity", "belief"):
+            return True
+    return False
+
+
 def _skip_gate_from_ctx(ctx: Dict[str, Any]) -> RecallSkipGateResult:
     pcr = _pcr_from_ctx(ctx)
     if pcr is not None and pcr.phase == "skip":

--- a/services/orion-cortex-exec/app/pcr_chat_memory.py
+++ b/services/orion-cortex-exec/app/pcr_chat_memory.py
@@ -182,6 +182,8 @@ async def run_pcr_phase0_and_1(
         recall_debug=dict(recall_debug) if isinstance(recall_debug, dict) else {},
     )
     _apply_pcr_to_ctx(ctx, pcr)
+    if isinstance(recall_debug, dict) and "eligible_belief_count" in recall_debug:
+        ctx["eligible_belief_count"] = recall_debug["eligible_belief_count"]
     logger.info(
         "pcr_phase1_continuity corr_id=%s profile=%s items=%s digest_chars=%s",
         correlation_id,

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -1038,7 +1038,8 @@ class PlanRunner:
         recall_reason = str(recall_policy["reason"])
         use_pcr_pre_recall = (
             settings.chat_pcr_enabled
-            and str(plan.verb_name or "").strip().lower() in ("chat_general", "chat_quick")
+            and str(plan.verb_name or "").strip().lower()
+            in ("chat_general", "chat_quick", "stance_react")
             and should_recall
             and not inline_recall
         )

--- a/services/orion-cortex-exec/app/settings.py
+++ b/services/orion-cortex-exec/app/settings.py
@@ -55,6 +55,9 @@ class Settings(BaseSettings):
     chat_pcr_quick_phase3: bool = Field(False, alias="CHAT_PCR_QUICK_PHASE3")
     chat_pcr_skip_max_novelty: float = Field(0.25, alias="CHAT_PCR_SKIP_MAX_NOVELTY")
     chat_pcr_skip_shift_novelty_floor: float = Field(0.35, alias="CHAT_PCR_SKIP_SHIFT_NOVELTY_FLOOR")
+    memory_cognition_brain_belief_default: bool = Field(
+        True, alias="MEMORY_COGNITION_BRAIN_BELIEF_DEFAULT"
+    )
     orion_unified_grounding_enabled: bool = Field(True, alias="ORION_UNIFIED_GROUNDING_ENABLED")
     channel_context_exec_intake: str = Field(
         "orion:exec:request:ContextExecService",

--- a/services/orion-cortex-exec/tests/test_unified_pcr_phase01.py
+++ b/services/orion-cortex-exec/tests/test_unified_pcr_phase01.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.router import PlanRunner
+from app.settings import settings
+from orion.core.bus.bus_schemas import ServiceRef
+from orion.schemas.cortex.schemas import (
+    ExecutionPlan,
+    ExecutionStep,
+    PlanExecutionArgs,
+    PlanExecutionRequest,
+    StepExecutionResult,
+)
+from orion.schemas.recall_pcr import PcrChatMemoryV1
+from orion.schemas.thought import GroundingCapsuleV1
+
+
+def _stance_react_request(*, recall_enabled: bool = True) -> PlanExecutionRequest:
+    plan = ExecutionPlan(
+        verb_name="stance_react",
+        label="stance_react",
+        description="",
+        category="x",
+        priority="normal",
+        interruptible=True,
+        can_interrupt_others=False,
+        timeout_ms=1000,
+        max_recursion_depth=1,
+        metadata={"mode": "brain"},
+        steps=[
+            ExecutionStep(
+                verb_name="stance_react",
+                step_name="llm_stance_react",
+                description="",
+                order=0,
+                services=["LLMGatewayService"],
+                requires_memory=False,
+            )
+        ],
+    )
+    return PlanExecutionRequest(
+        plan=plan,
+        args=PlanExecutionArgs(
+            request_id="r-stance",
+            extra={"mode": "brain", "recall": {"enabled": recall_enabled}},
+        ),
+        context={
+            "mode": "brain",
+            "user_message": "what did we decide about the move?",
+            "raw_user_text": "what did we decide about the move?",
+            "surface_context": {"hub_chat_lane": "orion"},
+        },
+    )
+
+
+def _stance_step_result() -> StepExecutionResult:
+    return StepExecutionResult(
+        status="success",
+        verb_name="stance_react",
+        step_name="llm_stance_react",
+        order=0,
+        result={
+            "LLMGatewayService": {
+                "content": (
+                    '{"imperative":"Stay present.","tone":"warm",'
+                    '"stance_harness_slice":{"task_mode":"reflective_dialogue",'
+                    '"conversation_frame":"reflective"}}'
+                )
+            }
+        },
+        latency_ms=1,
+        node="n",
+        logs=[],
+        error=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _enable_pcr_and_grounding(monkeypatch):
+    monkeypatch.setattr(settings, "chat_pcr_enabled", True)
+    monkeypatch.setattr(settings, "orion_unified_grounding_enabled", True)
+    monkeypatch.setattr(settings, "chat_pcr_post_stance_recall", True)
+
+
+@pytest.mark.asyncio
+async def test_stance_react_runs_pcr_phase01_before_stance_step(monkeypatch) -> None:
+    """Unified turn: continuity recall runs before llm_stance_react when PCR is enabled."""
+    runner = PlanRunner()
+    call_order: list[str] = []
+
+    async def _fake_phase01(_bus, *, ctx, **_kwargs):
+        call_order.append("phase01")
+        ctx["continuity_digest"] = "recent thread continuity"
+        pcr = PcrChatMemoryV1(
+            phase="continuity",
+            retrieval_intent="continuity",
+            continuity_digest="recent thread continuity",
+            belief_digest="",
+            memory_digest="recent thread continuity",
+            skip_reasons=[],
+            recall_debug={"count": 1},
+        )
+        ctx["pcr_memory"] = pcr
+        recall_step = StepExecutionResult(
+            status="success",
+            verb_name="recall",
+            step_name="pcr_continuity_recall",
+            order=-1,
+            result={"RecallService": {"count": 1}},
+            latency_ms=1,
+            node="n",
+            logs=[],
+        )
+        return pcr, recall_step, {"count": 1, "profile": "chat.continuity.v1"}
+
+    async def _fake_call_step(*_args, **_kwargs):
+        call_order.append("stance_step")
+        return _stance_step_result()
+
+    monkeypatch.setattr("app.router.run_pcr_phase0_and_1", _fake_phase01)
+    monkeypatch.setattr("app.router.call_step_services", _fake_call_step)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr(
+        "app.router.assemble_stance_grounding",
+        AsyncMock(
+            return_value=GroundingCapsuleV1(
+                identity_summary=["I am Oríon."],
+                provenance={"identity_source": "configured_yaml", "pcr_ran": True},
+            )
+        ),
+    )
+
+    ctx = {
+        "mode": "brain",
+        "user_message": "what did we decide about the move?",
+        "raw_user_text": "what did we decide about the move?",
+        "surface_context": {"hub_chat_lane": "orion"},
+    }
+    result = await runner.run_plan(
+        bus=object(),
+        source=ServiceRef(name="x", version="0", node="n"),
+        req=_stance_react_request(),
+        correlation_id="corr-unified-pcr01",
+        ctx=ctx,
+    )
+
+    assert result.status == "success"
+    assert call_order == ["phase01", "stance_step"]
+    assert ctx.get("continuity_digest") == "recent thread continuity"
+
+
+@pytest.mark.asyncio
+async def test_assemble_stance_grounding_skips_duplicate_phase01_when_router_ran(monkeypatch) -> None:
+    """Grounding assembly runs phase3 only when router already completed phase 0+1."""
+    from app import grounding_capsule as gc
+    from app.settings import Settings
+
+    phase01_calls: list[str] = []
+    phase3_calls: list[str] = []
+
+    async def _fake_phase01(*_args, **_kwargs):
+        phase01_calls.append("phase01")
+        return None, None, {}
+
+    async def _fake_phase3(*_args, **_kwargs):
+        phase3_calls.append("phase3")
+        return None, None, {}
+
+    monkeypatch.setattr(gc, "run_pcr_phase0_and_1", _fake_phase01)
+    monkeypatch.setattr(gc, "run_pcr_phase3", _fake_phase3)
+    cfg = Settings(ORION_UNIFIED_GROUNDING_ENABLED=True, CHAT_PCR_ENABLED=True)
+    ctx: dict = {
+        "orion_identity_summary": ["I am Oríon."],
+        "identity_kernel_source": "configured_yaml",
+        "continuity_digest": "already from router",
+        "pcr_memory": PcrChatMemoryV1(
+            phase="continuity",
+            retrieval_intent="continuity",
+            continuity_digest="already from router",
+            belief_digest="",
+            memory_digest="already from router",
+            skip_reasons=[],
+            recall_debug={},
+        ),
+    }
+
+    capsule = await gc.assemble_stance_grounding(
+        bus=None,
+        source=None,
+        ctx=ctx,
+        correlation_id="corr-no-dup",
+        recall_cfg={"enabled": True},
+        stance_step_text='{"stance_harness_slice":{"task_mode":"reflective_dialogue","conversation_frame":"reflective"}}',
+        exec_settings=cfg,
+    )
+
+    assert capsule is not None
+    assert phase01_calls == []
+    assert phase3_calls == ["phase3"]
+    assert capsule.provenance["pcr_ran"] is True
+
+
+def test_pcr_phase01_complete_detects_router_continuity() -> None:
+    from app.pcr_chat_memory import pcr_phase01_complete
+
+    ctx = {
+        "continuity_digest": "router continuity",
+        "pcr_memory": PcrChatMemoryV1(
+            phase="continuity",
+            retrieval_intent="continuity",
+            continuity_digest="router continuity",
+            belief_digest="",
+            memory_digest="router continuity",
+            skip_reasons=[],
+            recall_debug={},
+        ),
+    }
+    assert pcr_phase01_complete(ctx) is True

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -218,6 +218,8 @@ FALKORDB_URI=
 
 # --- Memory crystallization projections ---
 CRYSTALLIZER_VECTOR_COLLECTION=orion_memory_crystallizations
+# Minimum dynamics.activation for recall injection (hub active-packet route + recall collector).
+ACTIVATION_RECALL_FLOOR=0.08
 # Embedding host for Chroma projection on approve. Empty = no embedding => vector-writer
 # skips the upsert (crystallizations never get semantically indexed). Point at orion-vector-host
 # /embedding. Hub compose is network_mode: host, so use 127.0.0.1:8320 (not the Docker DNS name).

--- a/services/orion-hub/scripts/cortex_request_builder.py
+++ b/services/orion-hub/scripts/cortex_request_builder.py
@@ -253,12 +253,10 @@ def _build_recall_payload(payload: Dict[str, Any], *, use_recall: bool, route_mo
     recall_profile = payload.get("recall_profile")
     if isinstance(recall_profile, str):
         recall_profile = recall_profile.strip() or None
-    # Route-aware defaults: brain lane uses structured SQL+RDF recall; agent stays unset unless explicit.
+    # Route-aware defaults: brain/orion leave None for cortex PCR; agent stays unset unless explicit.
     if use_recall and recall_profile is None:
         route = str(route_mode or "").strip().lower()
-        if route == "brain":
-            recall_profile = "brain.recall.v1"
-        elif route != "agent":
+        if route not in ("agent", "brain", "orion"):
             recall_profile = "reflect.v1"
 
     return {
@@ -516,8 +514,13 @@ def build_cortex_chat_request(
     }
     if isinstance(payload.get("presence_context"), dict):
         metadata["presence_context"] = payload.get("presence_context")
+    surface = dict(metadata.get("surface_context") or {})
     if isinstance(payload.get("surface_context"), dict):
-        metadata["surface_context"] = payload.get("surface_context")
+        surface.update(payload.get("surface_context"))
+    if selected_ui_route in ("brain", "orion", "quick", "grounded_small"):
+        surface.setdefault("hub_chat_lane", selected_ui_route)
+    if surface:
+        metadata["surface_context"] = surface
     if payload.get("browser_client_id"):
         metadata["browser_client_id"] = str(payload.get("browser_client_id"))
     mutation_cognition_context = payload.get("mutation_cognition_context")

--- a/services/orion-hub/scripts/crystallization_routes.py
+++ b/services/orion-hub/scripts/crystallization_routes.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 
 from orion.core.storage import memory_cards as mc_dal
 from orion.memory.crystallization.detection import detect_contradictions, detect_duplicates, merge_detection
+from orion.memory.crystallization.recall_eligibility import eligible_for_recall
 from orion.memory.crystallization.retriever import retrieve_active_packet
 from orion.memory.crystallization.bus_emit import emit_active_packet_retrieved, emit_crystallization_lifecycle
 from orion.memory.crystallization.chroma_publish import publish_crystallization_to_chroma
@@ -483,7 +484,10 @@ async def memory_active_packet(
     card_refs: List[str] = list(body.get("card_refs") or [])
 
     try:
-        active_items = await list_crystallizations(pool, status="active", limit=100)
+        active_items = [
+            c for c in await list_crystallizations(pool, status="active", limit=100)
+            if eligible_for_recall(c)
+        ]
         active_cards = await mc_dal.list_cards(pool, status="active", limit=50)
     except Exception as exc:
         _http_if_missing_schema(exc)

--- a/services/orion-hub/tests/test_cortex_request_builder.py
+++ b/services/orion-hub/tests/test_cortex_request_builder.py
@@ -116,7 +116,7 @@ def test_agent_mode_recall_toggle_preserves_supervised_routing_intent() -> None:
     assert disabled_debug["supervised"] is True
 
 
-def test_brain_mode_defaults_recall_profile_to_brain_recall_v1() -> None:
+def test_brain_mode_leaves_recall_profile_none_for_pcr() -> None:
     req, debug, _ = hub_builder.build_chat_request(
         payload={"mode": "brain", "use_recall": True},
         session_id="sid-brain-recall",
@@ -130,8 +130,23 @@ def test_brain_mode_defaults_recall_profile_to_brain_recall_v1() -> None:
 
     assert req.mode == "brain"
     assert req.recall["enabled"] is True
-    assert req.recall["profile"] == "brain.recall.v1"
-    assert debug["recall_profile"] == "brain.recall.v1"
+    assert req.recall["profile"] is None
+    assert debug["recall_profile"] is None
+
+
+def test_brain_mode_sets_hub_chat_lane_in_surface_context() -> None:
+    req, _debug, _ = hub_builder.build_chat_request(
+        payload={"mode": "brain", "use_recall": True},
+        session_id="sid-brain-lane",
+        user_id="user-1",
+        trace_id="trace-brain-lane",
+        default_mode="brain",
+        auto_default_enabled=False,
+        source_label="hub_http",
+        prompt="What did we decide about the deployment?",
+    )
+
+    assert req.metadata["surface_context"]["hub_chat_lane"] == "brain"
 
 
 def test_brain_mode_preserves_explicit_chat_general_recall_profile() -> None:

--- a/services/orion-hub/tests/test_crystallization_routes_contract.py
+++ b/services/orion-hub/tests/test_crystallization_routes_contract.py
@@ -17,3 +17,10 @@ def test_crystallization_api_surface_present() -> None:
         "/api/memory/active-packet",
     ):
         assert path in text, f"missing route {path}"
+
+
+def test_active_packet_route_filters_by_recall_eligibility() -> None:
+    text = ROUTES.read_text(encoding="utf-8")
+    start = text.index("async def memory_active_packet")
+    block = text[start : start + 2500]
+    assert "eligible_for_recall" in block

--- a/services/orion-memory-consolidation/.env_example
+++ b/services/orion-memory-consolidation/.env_example
@@ -55,3 +55,8 @@ MEMORY_CONSOLIDATION_MIN_SIGNIFICANCE=0.40
 MEMORY_CONSOLIDATION_FETCH_GRAMMAR_EVIDENCE=true
 # Grammar DB DSN override; empty uses POSTGRES_URI consolidation pool
 MEMORY_CONSOLIDATION_GRAMMAR_DSN=
+
+# Formation intake: auto-activate eligible crystallizations (default off for safe rollout)
+MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=false
+# Encode activation ratio when auto-activate is enabled (0-1)
+MEMORY_FORMATION_AUTO_ENCODE_ACTIVATION_RATIO=0.4

--- a/services/orion-memory-consolidation/.env_example
+++ b/services/orion-memory-consolidation/.env_example
@@ -56,7 +56,7 @@ MEMORY_CONSOLIDATION_FETCH_GRAMMAR_EVIDENCE=true
 # Grammar DB DSN override; empty uses POSTGRES_URI consolidation pool
 MEMORY_CONSOLIDATION_GRAMMAR_DSN=
 
-# Formation intake: auto-activate eligible crystallizations (default off for safe rollout)
-MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=false
+# Formation intake: auto-activate eligible crystallizations (operator-on after smoke)
+MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=true
 # Encode activation ratio when auto-activate is enabled (0-1)
 MEMORY_FORMATION_AUTO_ENCODE_ACTIVATION_RATIO=0.4

--- a/services/orion-memory-consolidation/app/settings.py
+++ b/services/orion-memory-consolidation/app/settings.py
@@ -71,6 +71,12 @@ class Settings(BaseSettings):
         default=True, alias="MEMORY_CONSOLIDATION_FETCH_GRAMMAR_EVIDENCE"
     )
     MEMORY_CONSOLIDATION_GRAMMAR_DSN: str = Field(default="", alias="MEMORY_CONSOLIDATION_GRAMMAR_DSN")
+    MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED: bool = Field(
+        default=False, alias="MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED"
+    )
+    MEMORY_FORMATION_AUTO_ENCODE_ACTIVATION_RATIO: float = Field(
+        default=0.4, alias="MEMORY_FORMATION_AUTO_ENCODE_ACTIVATION_RATIO"
+    )
 
     class Config:
         env_file = ".env"

--- a/services/orion-memory-consolidation/app/worker.py
+++ b/services/orion-memory-consolidation/app/worker.py
@@ -26,6 +26,23 @@ from orion.schemas.memory_consolidation import (
 logger = logging.getLogger(__name__)
 
 _MAX_TURNS_FOR_SUGGEST = 3
+
+
+def _projection_config_from_settings(s: Any) -> "ProjectionConfig":
+    from orion.memory.crystallization.projector import ProjectionConfig
+
+    return ProjectionConfig(
+        collection=getattr(s, "CRYSTALLIZER_VECTOR_COLLECTION", "orion_memory_crystallizations"),
+        embed_host_url=getattr(s, "CRYSTALLIZER_EMBED_HOST_URL", "") or "",
+        embed_mode=getattr(s, "CRYSTALLIZER_EMBED_MODE", "http") or "http",
+        embed_timeout_ms=int(getattr(s, "CRYSTALLIZER_EMBED_TIMEOUT_MS", 8000) or 8000),
+        graphiti_enabled=bool(getattr(s, "GRAPHITI_ENABLED", False)),
+        graphiti_url=getattr(s, "GRAPHITI_ADAPTER_URL", "") or "",
+        falkordb_uri=getattr(s, "FALKORDB_URI", "") or "",
+        service_name=s.SERVICE_NAME,
+        service_version=s.SERVICE_VERSION,
+        node_name=s.NODE_NAME,
+    )
 _MAX_TURN_FIELD_CHARS = 800
 
 
@@ -103,11 +120,10 @@ class ConsolidationSuggestRunner:
             try:
                 from orion.memory.consolidation_gate import consolidation_memory_gate
                 from orion.memory.consolidation_grammar import fetch_grammar_evidence_for_window
-                from orion.memory.crystallization.bus_emit import emit_crystallization_lifecycle
                 from orion.memory.crystallization.intake_consolidation_window import (
                     build_crystallization_from_window,
                 )
-                from orion.memory.crystallization.repository import insert_crystallization
+                from orion.memory.crystallization.intake_pipeline import process_consolidation_crystallization
 
                 grammar_pool = self._grammar_pool or self._pool
                 repair, grammar_event_ids = await fetch_grammar_evidence_for_window(
@@ -146,18 +162,16 @@ class ConsolidationSuggestRunner:
                     turns=turns,
                     gate=gate,
                 )
-                cid = await insert_crystallization(self._pool, crystallization)
+                cid, _final_row, outcome = await process_consolidation_crystallization(
+                    self._pool,
+                    bus,
+                    crystallization=crystallization,
+                    settings=settings,
+                    project_config=_projection_config_from_settings(settings),
+                )
                 await self._window_store.mark_crystallization_proposed(
                     window_id,
                     crystallization_id=cid,
-                )
-                await emit_crystallization_lifecycle(
-                    bus,
-                    lifecycle="proposed",
-                    crystallization=crystallization,
-                    service_name=settings.SERVICE_NAME,
-                    service_version=settings.SERVICE_VERSION,
-                    node_name=settings.NODE_NAME,
                 )
                 for corr in corr_ids:
                     await publish_spark_meta_patch(
@@ -167,6 +181,7 @@ class ConsolidationSuggestRunner:
                             "consolidation_gate": {
                                 "action": "propose",
                                 "crystallization_id": cid,
+                                "formation_outcome": outcome,
                             }
                         },
                     )

--- a/services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py
+++ b/services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py
@@ -100,15 +100,15 @@ async def test_consolidate_window_skips_greeting_without_draft(monkeypatch):
         "orion.memory.consolidation_grammar.fetch_grammar_evidence_for_window",
         new=AsyncMock(return_value=(False, [])),
     ), patch(
-        "orion.memory.crystallization.repository.insert_crystallization",
+        "orion.memory.crystallization.intake_pipeline.process_consolidation_crystallization",
         new=AsyncMock(),
-    ) as insert_crys_mock:
+    ) as pipeline_mock:
         await runner.consolidate_window(_greeting_window(), bus=bus)
 
     window_store.mark_consolidated_skipped.assert_awaited_once()
     suggest_mock.assert_not_awaited()
     insert_draft_mock.assert_not_awaited()
-    insert_crys_mock.assert_not_awaited()
+    pipeline_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -136,12 +136,9 @@ async def test_consolidate_window_proposes_crystallization(monkeypatch):
         "orion.memory.crystallization.intake_consolidation_window.build_crystallization_from_window",
         return_value=crystallization,
     ), patch(
-        "orion.memory.crystallization.repository.insert_crystallization",
-        new=AsyncMock(return_value="crys-1"),
-    ) as insert_crys_mock, patch(
-        "orion.memory.crystallization.bus_emit.emit_crystallization_lifecycle",
-        new=AsyncMock(return_value=True),
-    ) as emit_mock:
+        "orion.memory.crystallization.intake_pipeline.process_consolidation_crystallization",
+        new=AsyncMock(return_value=("crys-1", crystallization, "proposed")),
+    ) as pipeline_mock:
         window = {
             "memory_window_id": "win-topic",
             "turn_correlation_ids": ["corr-1"],
@@ -149,13 +146,54 @@ async def test_consolidate_window_proposes_crystallization(monkeypatch):
         }
         await runner.consolidate_window(window, bus=bus)
 
-    insert_crys_mock.assert_awaited_once()
+    pipeline_mock.assert_awaited_once()
     window_store.mark_crystallization_proposed.assert_awaited_once_with(
         "win-topic",
         crystallization_id="crys-1",
     )
-    emit_mock.assert_awaited_once()
     suggest_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_window_auto_activate_when_flag_enabled(monkeypatch):
+    monkeypatch.setattr(worker.settings, "MEMORY_CONSOLIDATION_OUTPUT", "crystallization_propose")
+    monkeypatch.setattr(worker.settings, "MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED", True)
+    gate = ConsolidationGateResult(action="propose", reasons=["substantive_shift"], dominant_shift="TOPIC")
+    crystallization = MagicMock(crystallization_id="crys-auto")
+
+    pool = AsyncMock()
+    window_store = AsyncMock()
+    runner = ConsolidationSuggestRunner(pool, window_store)
+    bus = AsyncMock()
+    bus.publish = AsyncMock()
+
+    pipeline_mock = AsyncMock(return_value=("crys-auto", crystallization, "auto_activated"))
+
+    with patch(
+        "orion.memory.consolidation_grammar.fetch_grammar_evidence_for_window",
+        new=AsyncMock(return_value=(False, [])),
+    ), patch(
+        "orion.memory.consolidation_gate.consolidation_memory_gate",
+        return_value=gate,
+    ), patch(
+        "orion.memory.crystallization.intake_consolidation_window.build_crystallization_from_window",
+        return_value=crystallization,
+    ), patch(
+        "orion.memory.crystallization.intake_pipeline.process_consolidation_crystallization",
+        new=pipeline_mock,
+    ), patch.object(worker, "publish_spark_meta_patch", new=AsyncMock()) as patch_mock:
+        window = {
+            "memory_window_id": "win-auto",
+            "turn_correlation_ids": ["corr-auto"],
+            "turns": [{"correlation_id": "corr-auto", "prompt": "topic", "response": "reply", "spark_meta": {}}],
+        }
+        await runner.consolidate_window(window, bus=bus)
+
+    pipeline_mock.assert_awaited_once()
+    patch_mock.assert_awaited()
+    patch_fields = patch_mock.await_args.args[2]
+    assert patch_fields["consolidation_gate"]["formation_outcome"] == "auto_activated"
+    assert patch_fields["consolidation_gate"]["crystallization_id"] == "crys-auto"
 
 
 @pytest.mark.asyncio
@@ -217,9 +255,9 @@ async def test_skip_only_skips_even_when_gate_proposes(monkeypatch):
         "orion.memory.consolidation_gate.consolidation_memory_gate",
         return_value=gate,
     ), patch(
-        "orion.memory.crystallization.repository.insert_crystallization",
+        "orion.memory.crystallization.intake_pipeline.process_consolidation_crystallization",
         new=AsyncMock(),
-    ) as insert_crys_mock:
+    ) as pipeline_mock:
         window = {
             "memory_window_id": "win-skip-only",
             "turn_correlation_ids": [str(uuid4())],
@@ -231,7 +269,7 @@ async def test_skip_only_skips_even_when_gate_proposes(monkeypatch):
     fetch_fn.assert_awaited_once()
     assert fetch_fn.await_args.args[0] is grammar_pool
     window_store.mark_consolidated_skipped.assert_awaited_once()
-    insert_crys_mock.assert_not_awaited()
+    pipeline_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/services/orion-recall/.env_example
+++ b/services/orion-recall/.env_example
@@ -39,6 +39,8 @@ RECALL_SKIP_SHIFT_NOVELTY_FLOOR=0.35
 RECALL_CONTINUITY_SQL_MINUTES=120
 RECALL_CONTINUITY_RENDER_BUDGET=96
 RECALL_ACTIVE_PACKET_ENABLED=true
+# Minimum dynamics.activation for crystallizations in active_packet (matches recall_eligibility)
+ACTIVATION_RECALL_FLOOR=0.08
 RECALL_BELIEF_RENDER_BUDGET=128
 RECALL_GRAPHITI_IN_CHAT=false
 # Optional Graphiti adapter for contradiction intent (when RECALL_GRAPHITI_IN_CHAT=true)

--- a/services/orion-recall/app/collectors/active_packet.py
+++ b/services/orion-recall/app/collectors/active_packet.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from orion.memory.crystallization.active_packet import KIND_TO_BUCKET
+from orion.memory.crystallization.recall_eligibility import eligible_for_recall
 from orion.memory.crystallization.projection_graphiti import GraphitiAdapter
 from orion.memory.crystallization.repository import list_crystallizations
 from orion.memory.crystallization.retriever import retrieve_active_packet
@@ -136,6 +137,7 @@ async def fetch_active_packet_fragments(
 
     try:
         active_items = await list_crystallizations(pool, status="active", limit=100)
+        active_items = [c for c in active_items if eligible_for_recall(c)]
     except Exception:
         return []
 

--- a/services/orion-recall/app/worker.py
+++ b/services/orion-recall/app/worker.py
@@ -20,6 +20,7 @@ from orion.core.contracts.recall import (
     RecallDecisionV1,
     RecallQueryV1,
 )
+from orion.memory.crystallization.repository import count_eligible_active
 
 try:
     from .fusion import fuse_candidates, pcr_fuse_belief_candidates, render_continuity_bundle
@@ -1628,6 +1629,12 @@ async def process_recall(
         )
     timing_breakdown_ms["fusion"] = int((time.time() - fuse_started) * 1000)
     timing_breakdown_ms["total"] = latency_ms
+    eligible_belief_count = 0
+    if settings.RECALL_PCR_ENABLED and recall_phase in {"continuity", "purposeful"} and _recall_pg_pool is not None:
+        try:
+            eligible_belief_count = await count_eligible_active(_recall_pg_pool)
+        except Exception as exc:
+            logger.debug("eligible_belief_count skipped: %s", exc)
     pcr_debug: Dict[str, Any] | None = None
     if settings.RECALL_PCR_ENABLED and recall_phase in {"continuity", "purposeful"}:
         continuity_count = sum(1 for i in bundle.items if recall_phase == "continuity")
@@ -1686,11 +1693,16 @@ async def process_recall(
                 },
                 "fusion": bundle.stats.diagnostic or {},
                 "selected_summary": _bounded_selected_summary(list(bundle.items)),
+                **({"eligible_belief_count": eligible_belief_count} if settings.RECALL_PCR_ENABLED and recall_phase in {"continuity", "purposeful"} else {}),
                 **({"pcr": pcr_debug} if pcr_debug else {}),
             }
             if diagnostic
             else (
-                {"latency_breakdown_ms": timing_breakdown_ms, **({"pcr": pcr_debug} if pcr_debug else {})}
+                {
+                    "latency_breakdown_ms": timing_breakdown_ms,
+                    **({"eligible_belief_count": eligible_belief_count} if settings.RECALL_PCR_ENABLED and recall_phase in {"continuity", "purposeful"} else {}),
+                    **({"pcr": pcr_debug} if pcr_debug else {}),
+                }
             )
         ),
     )

--- a/services/orion-recall/tests/test_active_packet_activation_floor.py
+++ b/services/orion-recall/tests/test_active_packet_activation_floor.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_RECALL_ROOT = _REPO / "services" / "orion-recall"
+if str(_RECALL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_RECALL_ROOT))
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from app.collectors.active_packet import fetch_active_packet_fragments
+from orion.memory.crystallization.active_packet import build_active_packet
+from orion.memory.crystallization.schemas import (
+    CrystallizationDynamicsV1,
+    CrystallizationGovernanceV1,
+    MemoryCrystallizationV1,
+)
+
+
+def _crys(
+    *,
+    activation: float,
+    salience: float = 0.5,
+    crystallization_id: str = "crys_test",
+    summary: str = "test belief",
+) -> MemoryCrystallizationV1:
+    now = datetime.now(timezone.utc)
+    return MemoryCrystallizationV1(
+        crystallization_id=crystallization_id,
+        kind="semantic",
+        subject="s",
+        summary=summary,
+        status="active",
+        salience=salience,
+        dynamics=CrystallizationDynamicsV1(activation=activation, formed_at=now),
+        governance=CrystallizationGovernanceV1(proposed_by="t"),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_build_active_packet_ranks_by_activation_times_salience():
+    low_score = _crys(activation=0.2, salience=0.5, crystallization_id="crys_low")
+    high_score = _crys(activation=0.9, salience=0.3, crystallization_id="crys_high")
+
+    packet = build_active_packet(query="move logistics", crystallizations=[low_score, high_score])
+
+    assert packet.crystallization_refs[0] == "crys_high"
+    assert packet.crystallization_refs[1] == "crys_low"
+
+
+@pytest.mark.asyncio
+async def test_active_packet_excludes_below_activation_floor():
+    eligible = _crys(activation=0.2, crystallization_id="crys_eligible", summary="eligible belief")
+    ineligible = _crys(activation=0.01, crystallization_id="crys_ineligible", summary="stale belief")
+    captured: list[list[MemoryCrystallizationV1]] = []
+
+    fake_packet = type("Pkt", (), {"items": []})()
+
+    async def _capture_retrieve(**kwargs):
+        captured.append(list(kwargs.get("crystallizations") or []))
+        return fake_packet
+
+    with patch(
+        "app.collectors.active_packet.list_crystallizations",
+        new=AsyncMock(return_value=[eligible, ineligible]),
+    ), patch(
+        "app.collectors.active_packet.retrieve_active_packet",
+        new=AsyncMock(side_effect=_capture_retrieve),
+    ):
+        await fetch_active_packet_fragments(
+            query=type(
+                "Q",
+                (),
+                {
+                    "session_id": "s1",
+                    "node_id": "n1",
+                    "retrieval_intent": "semantic",
+                    "fragment": "eligible belief",
+                },
+            )(),
+            pool=object(),
+            settings=type("S", (), {"RECALL_ACTIVE_PACKET_ENABLED": True})(),
+        )
+
+    assert len(captured) == 1
+    assert len(captured[0]) == 1
+    assert captured[0][0].crystallization_id == "crys_eligible"

--- a/services/orion-recall/tests/test_active_packet_activation_floor.py
+++ b/services/orion-recall/tests/test_active_packet_activation_floor.py
@@ -55,6 +55,15 @@ def test_build_active_packet_ranks_by_activation_times_salience():
     assert packet.crystallization_refs[1] == "crys_low"
 
 
+def test_build_active_packet_excludes_below_activation_floor():
+    eligible = _crys(activation=0.2, crystallization_id="crys_eligible")
+    ineligible = _crys(activation=0.01, crystallization_id="crys_ineligible")
+
+    packet = build_active_packet(query="test", crystallizations=[eligible, ineligible])
+
+    assert packet.crystallization_refs == ["crys_eligible"]
+
+
 @pytest.mark.asyncio
 async def test_active_packet_excludes_below_activation_floor():
     eligible = _crys(activation=0.2, crystallization_id="crys_eligible", summary="eligible belief")

--- a/services/orion-recall/tests/test_pcr_continuity.py
+++ b/services/orion-recall/tests/test_pcr_continuity.py
@@ -104,3 +104,63 @@ def test_worker_uses_continuity_render_when_phase_continuity(monkeypatch):
     assert bundle.rendered == "ok"
     assert render_called[0]["profile"]["sql_since_minutes"] == 120
     assert render_called[0]["profile"]["render_budget_tokens"] == 96
+
+
+def test_worker_emits_eligible_belief_count_in_pcr_continuity(monkeypatch):
+    monkeypatch.setattr(worker.settings, "RECALL_PCR_ENABLED", True)
+    monkeypatch.setattr(worker.settings, "RECALL_CONTINUITY_SQL_MINUTES", 120)
+    monkeypatch.setattr(worker.settings, "RECALL_CONTINUITY_RENDER_BUDGET", 96)
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_SQL_CHAT", True)
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_SQL_TIMELINE", False)
+    monkeypatch.setattr(worker.settings, "RECALL_ENABLE_RDF", False)
+    monkeypatch.setattr(worker.settings, "RECALL_INTENT_ROUTING_ENABLED", False)
+
+    continuity_profile = {
+        "profile": "chat.continuity.v1",
+        "enable_query_expansion": False,
+        "enable_anchor_candidates": False,
+        "enable_sql_timeline": False,
+        "enable_sql_chat": True,
+        "sql_chat_top_k": 6,
+        "sql_since_minutes": 120,
+        "max_total_items": 6,
+        "render_budget_tokens": 96,
+        "render_lane": "continuity",
+    }
+    monkeypatch.setattr(worker, "get_profile", lambda _name: continuity_profile)
+    worker.set_recall_pg_pool(object())
+
+    async def _count_eligible(pool, *, floor=None):
+        return 4
+
+    monkeypatch.setattr(worker, "count_eligible_active", _count_eligible)
+
+    async def _fetch_pairs(**kwargs):
+        return []
+
+    async def _fetch_msgs(**kwargs):
+        return []
+
+    async def _anchor(**kwargs):
+        return [], {}
+
+    def _mock_render(**kwargs):
+        return MemoryBundleV1(rendered="ok", stats=MemoryBundleStatsV1()), []
+
+    monkeypatch.setattr(worker, "fetch_chat_history_pairs", _fetch_pairs)
+    monkeypatch.setattr(worker, "fetch_chat_messages", _fetch_msgs)
+    monkeypatch.setattr(worker, "_fetch_anchor_candidates", _anchor)
+    monkeypatch.setattr(worker, "render_continuity_bundle", _mock_render)
+
+    q = RecallQueryV1(
+        fragment="hey",
+        profile="chat.continuity.v1",
+        recall_phase="continuity",
+        session_id="sess-1",
+    )
+
+    import asyncio
+
+    _bundle, decision = asyncio.run(worker.process_recall(q, corr_id="corr-eligible-count", diagnostic=True))
+
+    assert decision.recall_debug["eligible_belief_count"] == 4

--- a/services/orion-thought/app/bus_listener.py
+++ b/services/orion-thought/app/bus_listener.py
@@ -64,19 +64,30 @@ def build_stance_react_context(
     *,
     mind_coloring: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    stance_inputs = (
+        dict(request.stance_inputs)
+        if isinstance(request.stance_inputs, dict)
+        else {"user_message": request.user_message}
+    )
+    surface_context = stance_inputs.get("surface_context")
+    metadata: dict[str, Any] = {
+        "correlation_id": request.correlation_id,
+        "session_id": request.session_id,
+        "llm_profile": request.llm_profile,
+        "mode": "brain",
+    }
+    if isinstance(surface_context, dict) and surface_context:
+        metadata["surface_context"] = surface_context
     context: dict[str, Any] = {
         "user_message": request.user_message,
-        "stance_inputs": {"user_message": request.user_message},
+        "stance_inputs": stance_inputs,
         "association": slim_association_for_prompt(request.association),
         "repair_bundle": slim_repair_bundle_for_prompt(request.repair_bundle),
         "coalition_projection": _coalition_projection(request),
-        "metadata": {
-            "correlation_id": request.correlation_id,
-            "session_id": request.session_id,
-            "llm_profile": request.llm_profile,
-            "mode": "brain",
-        },
+        "metadata": metadata,
     }
+    if isinstance(surface_context, dict) and surface_context:
+        context["surface_context"] = surface_context
     if mind_coloring is not None:
         context["mind_coloring"] = mind_coloring
     return context

--- a/tests/test_encode_reinforce_not_duplicate.py
+++ b/tests/test_encode_reinforce_not_duplicate.py
@@ -141,3 +141,45 @@ async def test_non_duplicate_inserts_proposed(monkeypatch):
     update_mock.assert_not_called()
     emit_mock.assert_called_once()
     assert emit_mock.call_args.kwargs["lifecycle"] == "proposed"
+
+
+@pytest.mark.asyncio
+async def test_governor_queue_records_formation_policy_downgrade(monkeypatch):
+    candidate = _semantic_proposed()
+    candidate.kind = "contradiction"
+    candidate.summary = "Orion believes X but evidence shows not-X"
+
+    pool = MagicMock()
+    bus = MagicMock(enabled=True)
+
+    list_mock = AsyncMock(return_value=[])
+    insert_mock = AsyncMock(return_value=candidate.crystallization_id)
+    emit_mock = AsyncMock(return_value=True)
+
+    settings = _Settings()
+    settings.MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED = True
+
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.list_crystallizations",
+        list_mock,
+    )
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.insert_crystallization",
+        insert_mock,
+    )
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.emit_crystallization_lifecycle",
+        emit_mock,
+    )
+
+    _cid, final_row, outcome = await process_consolidation_crystallization(
+        pool,
+        bus,
+        crystallization=candidate,
+        settings=settings,
+        project_config=ProjectionConfig(),
+    )
+
+    assert outcome == "proposed"
+    assert final_row.provenance.get("formation_policy") == "governor_queue"
+    assert "formation_policy_downgrade" in final_row.provenance

--- a/tests/test_encode_reinforce_not_duplicate.py
+++ b/tests/test_encode_reinforce_not_duplicate.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orion.memory.crystallization.intake_pipeline import process_consolidation_crystallization
+from orion.memory.crystallization.projector import ProjectionConfig
+from orion.memory.crystallization.proposer import propose
+from orion.memory.crystallization.schemas import (
+    CrystallizationEvidenceRefV1,
+    MemoryCrystallizationProposeRequestV1,
+    new_crystallization_id,
+)
+
+
+class _Settings:
+    MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED = False
+    MEMORY_FORMATION_AUTO_ENCODE_ACTIVATION_RATIO = 0.4
+    SERVICE_NAME = "orion-memory-consolidation"
+    SERVICE_VERSION = "0.1.0"
+    NODE_NAME = "test"
+
+
+def _semantic_proposed():
+    req = MemoryCrystallizationProposeRequestV1(
+        kind="semantic",
+        subject="Deploy plan",
+        summary="We chose k3s for staging cluster rollout",
+        scope=["project:orion"],
+        evidence=[CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="corr-a")],
+        proposed_by="test",
+    )
+    return propose(req)
+
+
+@pytest.mark.asyncio
+async def test_reinforce_existing_skips_insert(monkeypatch):
+    existing = _semantic_proposed()
+    existing.crystallization_id = new_crystallization_id()
+    existing.status = "active"
+
+    candidate = existing.model_copy(deep=True)
+    candidate.crystallization_id = new_crystallization_id()
+    candidate.evidence.append(
+        CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="corr-2", strength=0.75)
+    )
+
+    pool = MagicMock()
+    bus = MagicMock(enabled=True)
+    bus.publish = AsyncMock()
+
+    list_mock = AsyncMock(return_value=[existing])
+    update_mock = AsyncMock()
+    insert_mock = AsyncMock()
+    emit_mock = AsyncMock(return_value=True)
+
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.list_crystallizations",
+        list_mock,
+    )
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.update_crystallization",
+        update_mock,
+    )
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.insert_crystallization",
+        insert_mock,
+    )
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.emit_crystallization_lifecycle",
+        emit_mock,
+    )
+
+    cid, final_row, outcome = await process_consolidation_crystallization(
+        pool,
+        bus,
+        crystallization=candidate,
+        settings=_Settings(),
+        project_config=ProjectionConfig(),
+    )
+
+    assert outcome == "reinforced"
+    assert cid == existing.crystallization_id
+    assert final_row.dynamics.reinforcement_count == 1
+    assert any(ev.source_id == "corr-2" for ev in final_row.evidence)
+    insert_mock.assert_not_called()
+    update_mock.assert_called_once()
+    list_mock.assert_called_once_with(pool, status=None, limit=200)
+    emit_mock.assert_called_once()
+    assert emit_mock.call_args.kwargs["lifecycle"] == "reinforced"
+
+
+@pytest.mark.asyncio
+async def test_non_duplicate_inserts_proposed(monkeypatch):
+    existing = _semantic_proposed()
+    existing.crystallization_id = new_crystallization_id()
+    existing.status = "active"
+
+    candidate = _semantic_proposed()
+    candidate.summary = "We chose Nomad for staging cluster rollout"
+    candidate.subject = candidate.summary
+
+    pool = MagicMock()
+    bus = MagicMock(enabled=True)
+
+    list_mock = AsyncMock(return_value=[existing])
+    update_mock = AsyncMock()
+    insert_mock = AsyncMock(return_value=candidate.crystallization_id)
+    emit_mock = AsyncMock(return_value=True)
+
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.list_crystallizations",
+        list_mock,
+    )
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.update_crystallization",
+        update_mock,
+    )
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.insert_crystallization",
+        insert_mock,
+    )
+    monkeypatch.setattr(
+        "orion.memory.crystallization.intake_pipeline.emit_crystallization_lifecycle",
+        emit_mock,
+    )
+
+    cid, final_row, outcome = await process_consolidation_crystallization(
+        pool,
+        bus,
+        crystallization=candidate,
+        settings=_Settings(),
+        project_config=ProjectionConfig(),
+    )
+
+    assert outcome == "proposed"
+    assert cid == candidate.crystallization_id
+    assert final_row.dynamics.reinforcement_count == 0
+    insert_mock.assert_called_once()
+    update_mock.assert_not_called()
+    emit_mock.assert_called_once()
+    assert emit_mock.call_args.kwargs["lifecycle"] == "proposed"

--- a/tests/test_formation_executor_auto_activate.py
+++ b/tests/test_formation_executor_auto_activate.py
@@ -1,0 +1,43 @@
+import pytest
+
+from orion.memory.crystallization.formation_executor import GovernorPathRequired, auto_activate
+from orion.memory.crystallization.proposer import propose
+from orion.memory.crystallization.schemas import (
+    CrystallizationEvidenceRefV1,
+    MemoryCrystallizationProposeRequestV1,
+)
+
+
+def _proposed_semantic():
+    req = MemoryCrystallizationProposeRequestV1(
+        kind="semantic",
+        subject="Topic",
+        summary="We agreed on Postgres for memory store",
+        scope=["project:orion"],
+        evidence=[CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="corr-1")],
+        proposed_by="memory_consolidation_intake",
+    )
+    return propose(req)
+
+
+def test_auto_activate_sets_active_and_weak_dynamics():
+    crys, hist = auto_activate(_proposed_semantic(), encode_ratio=0.4)
+    assert crys.status == "active"
+    assert crys.governance.approval_mode == "auto_policy"
+    assert crys.governance.requires_manual_review is False
+    assert crys.governance.approved_by == "system:formation_policy"
+    assert 0.05 <= crys.dynamics.activation <= 0.35
+    assert hist["op"] == "auto_activate"
+
+
+def test_auto_activate_rejects_contradiction():
+    req = MemoryCrystallizationProposeRequestV1(
+        kind="contradiction",
+        subject="x",
+        summary="y",
+        scope=["p"],
+        evidence=[CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="corr-2")],
+        proposed_by="t",
+    )
+    with pytest.raises(GovernorPathRequired):
+        auto_activate(propose(req))

--- a/tests/test_formation_policy_auto_vs_gated.py
+++ b/tests/test_formation_policy_auto_vs_gated.py
@@ -1,0 +1,40 @@
+from orion.memory.crystallization.formation_policy import FormationPolicy, resolve_formation_policy
+from orion.memory.crystallization.proposer import propose
+from orion.memory.crystallization.schemas import (
+    CrystallizationEvidenceRefV1,
+    MemoryCrystallizationProposeRequestV1,
+)
+
+
+def _crys(*, kind="semantic", sensitivity="private", scope=None):
+    req = MemoryCrystallizationProposeRequestV1(
+        kind=kind,
+        subject="Deploy plan",
+        summary="We chose k3s for staging",
+        scope=scope or ["project:orion"],
+        evidence=[CrystallizationEvidenceRefV1(source_kind="memory_card", source_id="card_1", excerpt="fact")],
+        proposed_by="test",
+        sensitivity=sensitivity,
+    )
+    return propose(req)
+
+
+def test_semantic_auto_activate():
+    policy, reasons = resolve_formation_policy(_crys(kind="semantic"))
+    assert policy == FormationPolicy.AUTO_ACTIVATE
+    assert not reasons
+
+
+def test_contradiction_governor_queue():
+    policy, reasons = resolve_formation_policy(_crys(kind="contradiction"))
+    assert policy == FormationPolicy.GOVERNOR_QUEUE
+
+
+def test_intimate_governor_queue():
+    policy, _ = resolve_formation_policy(_crys(sensitivity="intimate"))
+    assert policy == FormationPolicy.GOVERNOR_QUEUE
+
+
+def test_identity_scope_governor_queue():
+    policy, _ = resolve_formation_policy(_crys(scope=["identity:orion"]))
+    assert policy == FormationPolicy.GOVERNOR_QUEUE

--- a/tests/test_memory_crystallization.py
+++ b/tests/test_memory_crystallization.py
@@ -77,6 +77,8 @@ class TestGovernorPath:
         crys = _active_crystallization()
         assert crys.status == "active"
         assert crys.governance.approved_by == "operator"
+        assert crys.dynamics.formed_at is not None
+        assert crys.dynamics.activation > 0.0
 
     def test_rejected_does_not_project(self):
         crys = propose(_base_request())

--- a/tests/test_memory_crystallization_dynamics.py
+++ b/tests/test_memory_crystallization_dynamics.py
@@ -8,6 +8,7 @@ from orion.memory.crystallization.dynamics import (
     recall_boost,
     reinforce,
     seed_dynamics,
+    seed_weak_dynamics,
     should_retire,
 )
 from orion.memory.crystallization.proposer import propose
@@ -66,6 +67,14 @@ class TestSeed:
         seeded = seed_dynamics(crys, now=_now())
         assert seeded.dynamics.activation == crys.salience
         assert seeded.dynamics.formed_at == _now()
+
+
+def test_seed_weak_dynamics_scales_salience():
+    crys = _crys()
+    crys.salience = 0.5
+    seeded = seed_weak_dynamics(crys, now=_now(), ratio=0.4)
+    assert seeded.dynamics.activation == 0.2
+    assert seeded.dynamics.formed_at is not None
 
 
 class TestReinforce:

--- a/tests/test_recall_eligibility.py
+++ b/tests/test_recall_eligibility.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.memory.crystallization.recall_eligibility import ACTIVATION_RECALL_FLOOR, eligible_for_recall
+from orion.memory.crystallization.schemas import (
+    CrystallizationDynamicsV1,
+    CrystallizationGovernanceV1,
+    MemoryCrystallizationV1,
+)
+
+
+def _active(activation: float) -> MemoryCrystallizationV1:
+    now = datetime.now(timezone.utc)
+    return MemoryCrystallizationV1(
+        crystallization_id="crys_test",
+        kind="semantic",
+        subject="s",
+        summary="s",
+        status="active",
+        dynamics=CrystallizationDynamicsV1(activation=activation, formed_at=now),
+        governance=CrystallizationGovernanceV1(proposed_by="t"),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_eligible_when_active_and_above_floor():
+    assert eligible_for_recall(_active(0.2)) is True
+
+
+def test_ineligible_when_below_floor():
+    assert eligible_for_recall(_active(0.01)) is False
+
+
+def test_ineligible_when_deprecated():
+    crys = _active(0.2)
+    crys.status = "deprecated"
+    assert eligible_for_recall(crys) is False

--- a/tests/test_recall_eligibility.py
+++ b/tests/test_recall_eligibility.py
@@ -31,6 +31,7 @@ def test_eligible_when_active_and_above_floor():
 
 def test_ineligible_when_below_floor():
     assert eligible_for_recall(_active(0.01)) is False
+    assert eligible_for_recall(_active(ACTIVATION_RECALL_FLOOR - 0.01)) is False
 
 
 def test_ineligible_when_deprecated():

--- a/tests/test_retrieval_intent.py
+++ b/tests/test_retrieval_intent.py
@@ -68,6 +68,21 @@ def test_derive_retrieval_intent_entity_query():
     assert rule_id == "entity_query"
 
 
+def test_brain_lane_belief_default_when_eligible_beliefs_exist():
+    intent, rule_id = derive_retrieval_intent(
+        skip_gate=RecallSkipGateResult(skip=False),
+        stance_brief={"task_mode": "direct_response"},
+        attention_frame={},
+        appraisal={"shift_kind": "NONE", "novelty_score": 0.1},
+        hub_chat_lane="brain",
+        user_message="ok",
+        eligible_belief_count=3,
+        brain_belief_default_enabled=True,
+    )
+    assert intent == "semantic"
+    assert rule_id == "brain_lane_belief_default"
+
+
 def test_derive_retrieval_intent_contradiction_seed():
     intent, rule_id = derive_retrieval_intent(
         skip_gate=RecallSkipGateResult(skip=False),


### PR DESCRIPTION
Branch is pushed. `gh` isn't authenticated here, so open the PR manually:

**https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/integrated-memory-cognition-loop?expand=1**

Suggested title:

```
feat(memory): integrated memory cognition loop (M1+M2)
```

Paste this for the body:

---

## Summary

- Adds **M1 encode/store** and **M2 retrieve** for the integrated memory cognition loop: formation policy → auto-activate or governor queue → dynamics persistence → activation-ranked recall.
- Wires **hub brain lane** (`hub_chat_lane`) and **unified turn** (`stance_react`) to purpose-conditioned recall (PCR phase 0+1) instead of default `brain.recall.v1` timeline SQL.
- Introduces `CrystallizationDynamicsV1`, `eligible_for_recall()` activation floor, and consolidation intake with dedup/reinforce.
- Code-review follow-up: governor approve seeds dynamics, hub route + `build_active_packet` both filter by floor, downgrade provenance on governor-path intake.
- Adds structural e2e smoke (`scripts/smoke_memory_cognition_loop_e2e.sh`) and focused unit tests.
- **Safe rollout:** `MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=false` by default — beliefs won't auto-form until flipped.

## Outcome moved

Chat recall can inject **activation-ranked crystallization beliefs** (not just surface timeline SQL) when auto-activate is enabled and beliefs pass the recall floor. Hub brain + unified lanes now run PCR before stance/speech.

## Current architecture

Before: recall leaned on SQL timeline / generic `brain.recall.v1`; crystallizations had no dynamics lifecycle; consolidation did not auto-encode with policy gates.

## Architecture touched

- **Shared:** `orion/memory/crystallization/*`, `orion/bus/channels.yaml`, SQL schema
- **Consolidation:** intake pipeline, formation policy/executor, worker wiring
- **Recall:** eligibility filter, activation-ranked `active_packet`, `eligible_belief_count`
- **Hub:** `hub_chat_lane`, crystallization active-packet route filter
- **Cortex-exec:** unified turn PCR phase 0+1 before `stance_react`

## Files changed

- `orion/memory/crystallization/` — dynamics schema, formation policy/executor, intake pipeline, recall eligibility, active_packet filter, governor seeds dynamics
- `orion/memory/consolidation/` — worker + settings wiring for auto-activate intake
- `services/orion-recall/` — activation-ranked packet, floor filter, eligible count
- `services/orion-hub/` — hub chat lane, active-packet route eligibility
- `services/orion-cortex-exec/` — PCR phase 0+1 on unified turn
- `orion/bus/channels.yaml` — `reinforced`, `auto_activated` channels
- `scripts/smoke_memory_cognition_loop_e2e.sh` — structural + live smoke
- Tests across root, recall, hub, consolidation

## Schema / bus / API changes

- **Added:** `memory_crystallizations.dynamics` jsonb column; `CrystallizationDynamicsV1` on crystallization model
- **Added bus channels:** `orion:memory:crystallization:reinforced`, `orion:memory:crystallization:auto_activated`
- **Behavior changed:** recall filters by `ACTIVATION_RECALL_FLOOR` (default 0.08); governor approve seeds non-zero activation
- **Compatibility:** legacy governor-approved rows with `activation=0.0` stay recall-ineligible until re-approved or reinforced

## Env/config changes

- **Added keys:**
  - `MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=false` (consolidation)
  - `ACTIVATION_RECALL_FLOOR=0.08` (recall + hub)
- **`.env_example` updated:** consolidation, recall, hub
- **local `.env` synced:** run `python scripts/sync_local_env_from_example.py orion-hub orion-recall orion-memory-consolidation` (also picks up `ACTIVATION_*` via sync script update)
- **skipped keys requiring operator action:** none for this patch

## Tests run

```text
PYTHONPATH=. pytest tests/test_recall_eligibility.py \
  tests/test_memory_crystallization.py::TestGovernorPath \
  tests/test_encode_reinforce_not_duplicate.py \
  services/orion-recall/tests/test_active_packet_activation_floor.py \
  services/orion-hub/tests/test_crystallization_routes_contract.py -q
# 15 passed

bash scripts/smoke_memory_cognition_loop_e2e.sh --structural
# 34 passed, STRUCTURAL gate OK
```

## Evals run

```text
None — no dedicated eval harness for this seam yet.
Structural smoke covers encode→store→retrieve contract paths.
```

## Docker/build/smoke checks

```text
Structural smoke only (no live stack in CI agent env).
Live: HUB_URL=... bash scripts/smoke_memory_cognition_loop_e2e.sh
```

## Review findings fixed

- **Finding:** Hub active-packet route did not filter by activation floor  
  **Fix:** `eligible_for_recall()` in `crystallization_routes.py`  
  **Evidence:** contract test + collector/build_active_packet tests

- **Finding:** Governor approve left `activation=0.0`  
  **Fix:** `seed_dynamics()` on approve  
  **Evidence:** `TestGovernorPath` asserts `activation > 0`

- **Finding:** `build_active_packet` only checked `status == active`  
  **Fix:** filter via `eligible_for_recall()`  
  **Evidence:** `test_build_active_packet_excludes_below_activation_floor`

- **Finding:** Hub missing `ACTIVATION_RECALL_FLOOR` in `.env_example`  
  **Fix:** added to hub + recall `.env_example`, sync script `ACTIVATION_*` prefix  
  **Evidence:** env parity + manual hub `.env` sync

## Restart required

```bash
# After applying SQL migration (dynamics column) and env sync:
docker compose --env-file .env --env-file services/orion-memory-consolidation/.env \
  -f services/orion-memory-consolidation/docker-compose.yml up -d --build

docker compose --env-file .env --env-file services/orion-recall/.env \
  -f services/orion-recall/docker-compose.yml up -d --build

docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build

docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml up -d --build
```

To enable auto-encoding after smoke:

```bash
# services/orion-memory-consolidation/.env
MEMORY_FORMATION_AUTO_ACTIVATE_ENABLED=true
```

## Risks / concerns

- **Severity:** medium  
- **Concern:** Auto-activate disabled by default — no behavior change until flag flip + restart  
- **Mitigation:** structural smoke + staged rollout; governor path unchanged for high-stakes

- **Severity:** low  
- **Concern:** Pre-patch beliefs with `activation=0.0` won't recall until re-approved  
- **Mitigation:** documented in `recall_eligibility.py`; one-time re-approve or reinforce

## Non-goals (M3 — follow-up PR)

- `recall_boost()` on fetch
- Decay reaper + `memory.crystallization.retired.v1`
- De-project on retire

## PR link

https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/integrated-memory-cognition-loop

---

**Status:** branch pushed (`b5e35e1a`, 14 commits). Run `gh auth login` locally if you want CLI PR creation next time.