### PR TITLE
fix(hub): restore unified-turn FCC motor live streaming

### DIFF
--- a/orion/hub/harness_step_stream.py
+++ b/orion/hub/harness_step_stream.py
@@ -22,18 +22,12 @@ async def relay_harness_run_steps(
     """Forward harness governor FCC steps to Hub WS as claude_step frames."""
     if bus is None:
         return
+    forwarded = 0
     try:
         async with bus.subscribe(channel) as pubsub:
-            while not stop_event.is_set():
-                try:
-                    msg = await asyncio.wait_for(
-                        pubsub.get_message(ignore_subscribe_messages=True, timeout=0.5),
-                        timeout=0.6,
-                    )
-                except asyncio.TimeoutError:
-                    continue
-                if not msg or msg.get("type") not in ("message", "pmessage"):
-                    continue
+            async for msg in bus.iter_messages(pubsub):
+                if stop_event.is_set():
+                    break
                 decoded = bus.codec.decode(msg.get("data"))
                 if not decoded.ok:
                     continue
@@ -55,7 +49,19 @@ async def relay_harness_run_steps(
                         "step_index": step_event.step_index,
                     }
                 )
+                forwarded += 1
     except asyncio.CancelledError:
         raise
     except Exception:
-        logger.warning("harness step relay failed corr=%s", correlation_id, exc_info=True)
+        logger.warning(
+            "harness step relay failed corr=%s forwarded=%s",
+            correlation_id,
+            forwarded,
+            exc_info=True,
+        )
+    else:
+        logger.debug(
+            "harness step relay stopped corr=%s forwarded=%s",
+            correlation_id,
+            forwarded,
+        )

--- a/orion/hub/tests/test_harness_step_relay.py
+++ b/orion/hub/tests/test_harness_step_relay.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+import contextlib
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -24,12 +26,6 @@ async def test_relay_harness_run_steps_forwards_matching_correlation() -> None:
             self.envelope = MagicMock(payload=payload)
 
     class _FakePubSub:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return False
-
         async def get_message(self, **kwargs):
             nonlocal delivered
             if delivered:
@@ -38,7 +34,16 @@ async def test_relay_harness_run_steps_forwards_matching_correlation() -> None:
             delivered = True
             return {"type": "message", "data": b"x"}
 
-    bus = AsyncMock()
+        async def listen(self):
+            msg = await self.get_message(ignore_subscribe_messages=True, timeout=0.5)
+            if msg:
+                yield msg
+
+    @asynccontextmanager
+    async def _subscribe(_channel: str):
+        yield _FakePubSub()
+
+    bus = MagicMock()
     bus.codec.decode.return_value = _Decoded(
         {
             "schema_version": "harness.run.step.v1",
@@ -47,7 +52,8 @@ async def test_relay_harness_run_steps_forwards_matching_correlation() -> None:
             "step": {"type": "assistant", "raw": {"type": "assistant"}},
         }
     )
-    bus.subscribe.return_value = _FakePubSub()
+    bus.subscribe = _subscribe
+    bus.iter_messages = lambda pubsub: pubsub.listen()
 
     task = asyncio.create_task(
         relay_harness_run_steps(
@@ -61,7 +67,7 @@ async def test_relay_harness_run_steps_forwards_matching_correlation() -> None:
     await asyncio.wait_for(stop.wait(), timeout=2.0)
     stop.set()
     task.cancel()
-    with pytest.raises(asyncio.CancelledError):
+    with contextlib.suppress(asyncio.CancelledError):
         await task
 
     assert len(frames) == 1

--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -7,7 +7,6 @@ from typing import Any, Awaitable, Callable, Protocol
 
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.hub.association import build_hub_association_bundle
-from orion.hub.harness_step_stream import relay_harness_run_steps
 from orion.hub.turn_request import build_orion_turn_request
 from orion.schemas.context_exec import ContextExecPermissionV1
 from orion.schemas.harness_finalize import HarnessRunRequestV1, HarnessRunV1
@@ -24,7 +23,6 @@ logger = logging.getLogger("orion.hub.turn_orchestrator")
 DEFAULT_UNIFIED_TURN_FCC_MODEL_LABEL = "MODEL_SONNET"
 
 EmitObservationFn = Callable[..., Any]
-FrameSender = Callable[[dict[str, Any]], Awaitable[None]]
 
 
 class _WebSocketLike(Protocol):
@@ -195,7 +193,9 @@ async def execute_unified_turn(
     continuity_messages: list[dict[str, Any]] | None = None,
     emit_observation_fn: EmitObservationFn | None = None,
     settings: Any | None = None,
-    send_frame: FrameSender | None = None,
+    harness_rpc_bus: Any | None = None,
+    harness_step_relay: Any | None = None,
+    harness_step_queue: asyncio.Queue | None = None,
 ) -> list[dict[str, Any]]:
     """Run the unified Orion turn saga and return WS frames (never includes draft_text)."""
     from scripts.settings import settings as hub_settings
@@ -289,27 +289,14 @@ async def execute_unified_turn(
         repair_pressure_contract=_repair_pressure_contract(repair_bundle),
         fcc_model_label=payload.get("fcc_model_label") or DEFAULT_UNIFIED_TURN_FCC_MODEL_LABEL,
     )
-    step_stop = asyncio.Event()
-    step_task = None
-    if send_frame is not None and bus is not None:
-        step_channel = getattr(cfg, "CHANNEL_HARNESS_RUN_STEP", "orion:harness:run:step")
-        step_task = asyncio.create_task(
-            relay_harness_run_steps(
-                bus,
-                correlation_id=correlation_id,
-                channel=step_channel,
-                send_frame=send_frame,
-                stop_event=step_stop,
-            )
-        )
+    harness_bus = harness_rpc_bus or bus
+    if harness_step_relay is not None and harness_step_queue is not None:
+        harness_step_relay.register_queue(correlation_id, harness_step_queue)
     try:
-        run = await HarnessGovernorClient(bus).run(harness_req, correlation_id=correlation_id)
+        run = await HarnessGovernorClient(harness_bus).run(harness_req, correlation_id=correlation_id)
     finally:
-        step_stop.set()
-        if step_task is not None:
-            step_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await step_task
+        if harness_step_relay is not None and harness_step_queue is not None:
+            harness_step_relay.unregister_queue(correlation_id, harness_step_queue)
     if run is None:
         return [
             {
@@ -488,23 +475,59 @@ async def run_unified_turn(
     continuity_messages: list[dict[str, Any]] | None = None,
     with_biometrics: Callable[[dict[str, Any], Any], Awaitable[dict[str, Any]]] | None = None,
     biometrics_cache: Any = None,
+    harness_rpc_bus: Any | None = None,
+    harness_step_relay: Any | None = None,
 ) -> list[dict[str, Any]]:
     """Execute unified turn and emit WS frames."""
-    async def _send_live_frame(frame: dict[str, Any]) -> None:
-        outbound = frame
-        if with_biometrics is not None:
-            outbound = await with_biometrics(frame, cache=biometrics_cache)
-        await websocket.send_json(outbound)
+    step_queue: asyncio.Queue | None = None
+    drain_task: asyncio.Task | None = None
+    if harness_step_relay is not None:
+        step_queue = asyncio.Queue(maxsize=256)
 
-    frames = await execute_unified_turn(
-        bus=bus,
-        correlation_id=correlation_id,
-        session_id=session_id,
-        user_message=user_message,
-        payload=payload,
-        continuity_messages=continuity_messages,
-        send_frame=_send_live_frame,
-    )
+        async def _drain_harness_steps() -> None:
+            assert step_queue is not None
+            try:
+                while True:
+                    frame = await step_queue.get()
+                    outbound = frame
+                    if with_biometrics is not None:
+                        outbound = await with_biometrics(frame, cache=biometrics_cache)
+                    await websocket.send_json(outbound)
+            except asyncio.CancelledError:
+                pass
+
+        drain_task = asyncio.create_task(
+            _drain_harness_steps(),
+            name=f"harness-steps-{correlation_id}",
+        )
+
+    try:
+        frames = await execute_unified_turn(
+            bus=bus,
+            correlation_id=correlation_id,
+            session_id=session_id,
+            user_message=user_message,
+            payload=payload,
+            continuity_messages=continuity_messages,
+            harness_rpc_bus=harness_rpc_bus,
+            harness_step_relay=harness_step_relay,
+            harness_step_queue=step_queue,
+        )
+    finally:
+        if harness_step_relay is not None and step_queue is not None:
+            while not step_queue.empty():
+                try:
+                    frame = step_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                outbound = frame
+                if with_biometrics is not None:
+                    outbound = await with_biometrics(frame, cache=biometrics_cache)
+                await websocket.send_json(outbound)
+        if drain_task is not None:
+            drain_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await drain_task
     for frame in frames:
         outbound = frame
         if with_biometrics is not None:

--- a/services/orion-hub/scripts/harness_step_relay.py
+++ b/services/orion-hub/scripts/harness_step_relay.py
@@ -1,0 +1,98 @@
+"""Relay harness governor FCC steps to per-correlation WebSocket queues."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from typing import Any, Dict, Optional, Set
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.schemas.harness_finalize import HarnessRunStepV1
+
+logger = logging.getLogger("orion-hub.harness_step_relay")
+
+HARNESS_RUN_STEP_KIND = "harness.run.step.v1"
+
+
+class HarnessStepRelay:
+    def __init__(self, *, channel: str) -> None:
+        self.channel = channel
+        self._bus: Optional[OrionBusAsync] = None
+        self._task: Optional[asyncio.Task] = None
+        self._queues: Dict[str, Set[asyncio.Queue]] = defaultdict(set)
+
+    async def start(self, bus: OrionBusAsync) -> None:
+        if self._task and not self._task.done():
+            return
+        self._bus = bus
+        self._task = asyncio.create_task(self._run(), name="hub-harness-step-relay")
+
+    async def stop(self) -> None:
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+
+    def register_queue(self, correlation_id: str, queue: asyncio.Queue) -> None:
+        self._queues[str(correlation_id)].add(queue)
+
+    def unregister_queue(self, correlation_id: str, queue: asyncio.Queue) -> None:
+        cid = str(correlation_id)
+        self._queues.get(cid, set()).discard(queue)
+        if cid in self._queues and not self._queues[cid]:
+            self._queues.pop(cid, None)
+
+    async def _run(self) -> None:
+        if not self._bus:
+            return
+        logger.info("Subscribing to harness FCC steps: %s", self.channel)
+        try:
+            async with self._bus.subscribe(self.channel) as pubsub:
+                async for msg in self._bus.iter_messages(pubsub):
+                    decoded = self._bus.codec.decode(msg.get("data"))
+                    if not decoded.ok:
+                        continue
+                    env = decoded.envelope
+                    if str(env.kind) != HARNESS_RUN_STEP_KIND:
+                        continue
+                    payload = env.payload
+                    if not isinstance(payload, dict):
+                        continue
+                    try:
+                        step_event = HarnessRunStepV1.model_validate(payload)
+                    except Exception:
+                        logger.debug(
+                            "harness step relay skipped invalid payload corr=%s",
+                            payload.get("correlation_id"),
+                            exc_info=True,
+                        )
+                        continue
+                    await self._dispatch_step(step_event)
+        except asyncio.CancelledError:
+            logger.info("Harness step relay cancelled.")
+        except Exception as exc:
+            logger.error("Harness step relay loop failed: %s", exc, exc_info=True)
+
+    async def _dispatch_step(self, step_event: HarnessRunStepV1) -> None:
+        cid = str(step_event.correlation_id)
+        queues = self._queues.get(cid)
+        if not queues:
+            return
+        item = {
+            "kind": "claude_step",
+            "mode": "orion",
+            "correlation_id": cid,
+            "step": step_event.step,
+            "step_index": step_event.step_index,
+        }
+        for queue in list(queues):
+            try:
+                queue.put_nowait(item)
+            except asyncio.QueueFull:
+                logger.debug(
+                    "harness_step relay queue full corr=%s; dropping frame",
+                    cid,
+                )

--- a/services/orion-hub/scripts/main.py
+++ b/services/orion-hub/scripts/main.py
@@ -28,6 +28,7 @@ from scripts.service_logs_ws import service_logs_websocket_endpoint
 from scripts.biometrics_cache import BiometricsCache
 from scripts.notification_cache import NotificationCache
 from scripts.agent_step_relay import AgentStepRelay
+from scripts.harness_step_relay import HarnessStepRelay
 from scripts.signals_inspect_cache import SignalsInspectCache
 from scripts.cognition_trace_cache import CognitionTraceCache
 from scripts.embodiment_outcome_cache import EmbodimentOutcomeCache
@@ -258,6 +259,7 @@ html_content: str = "<html><body><h1>Error loading UI</h1></body></html>"
 biometrics_cache: Optional[BiometricsCache] = None
 notification_cache: Optional[NotificationCache] = None
 agent_step_relay: Optional[AgentStepRelay] = None
+harness_step_relay: Optional[HarnessStepRelay] = None
 signals_inspect_cache: Optional[SignalsInspectCache] = None
 cognition_trace_cache: Optional[CognitionTraceCache] = None
 embodiment_outcome_cache: Optional[EmbodimentOutcomeCache] = None
@@ -336,7 +338,7 @@ async def startup_event():
     Initializes all shared services at application startup.
     OrionBus + Clients + UI template.
     """
-    global bus, rpc_bus, cortex_client, tts_client, html_content, biometrics_cache, notification_cache, agent_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, presence_state, presence_context_store, substrate_autonomy_task
+    global bus, rpc_bus, cortex_client, tts_client, html_content, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, presence_state, presence_context_store, substrate_autonomy_task
 
     # ------------------------------------------------------------
     # Orion Bus Initialization
@@ -379,6 +381,9 @@ async def startup_event():
 
             agent_step_relay = AgentStepRelay(channel=settings.HUB_CONTEXT_EXEC_EVENT_CHANNEL)
             await agent_step_relay.start(bus)
+
+            harness_step_relay = HarnessStepRelay(channel=settings.CHANNEL_HARNESS_RUN_STEP)
+            await harness_step_relay.start(bus)
 
             sic: Optional[SignalsInspectCache] = None
             try:
@@ -540,7 +545,7 @@ async def startup_event():
 
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
-    global bus, rpc_bus, biometrics_cache, notification_cache, agent_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, substrate_autonomy_task
+    global bus, rpc_bus, biometrics_cache, notification_cache, agent_step_relay, harness_step_relay, signals_inspect_cache, cognition_trace_cache, embodiment_outcome_cache, substrate_autonomy_task
     pool = getattr(app.state, "memory_pg_pool", None)
     if pool is not None:
         try:
@@ -563,6 +568,11 @@ async def shutdown_event() -> None:
     if agent_step_relay is not None:
         try:
             await agent_step_relay.stop()
+        except Exception:
+            pass
+    if harness_step_relay is not None:
+        try:
+            await harness_step_relay.stop()
         except Exception:
             pass
     if signals_inspect_cache is not None:

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -594,6 +594,8 @@ async def websocket_endpoint(websocket: WebSocket):
     biometrics_cache = scripts.main.biometrics_cache
     notification_cache = scripts.main.notification_cache
     agent_step_relay = scripts.main.agent_step_relay
+    harness_step_relay = scripts.main.harness_step_relay
+    rpc_bus = scripts.main.rpc_bus
     presence_state = scripts.main.presence_state
     presence_context_store = getattr(scripts.main, "presence_context_store", None)
 
@@ -883,6 +885,8 @@ async def websocket_endpoint(websocket: WebSocket):
                     ),
                     with_biometrics=_with_biometrics,
                     biometrics_cache=biometrics_cache,
+                    harness_rpc_bus=rpc_bus or bus,
+                    harness_step_relay=harness_step_relay,
                 )
                 continue
 

--- a/services/orion-hub/static/css/style.css
+++ b/services/orion-hub/static/css/style.css
@@ -57,12 +57,17 @@ input[type=range]::-moz-range-thumb {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  max-height: 12rem;
+  max-height: 20rem;
   margin-bottom: 0.5rem;
   padding: 0.5rem 0.75rem;
   border: 1px solid rgba(55, 65, 81, 0.85);
   border-radius: 0.75rem;
   background: rgba(3, 7, 18, 0.75);
+}
+
+.agent-live-trace.is-streaming {
+  border-color: rgba(99, 102, 241, 0.55);
+  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.15);
 }
 
 .agent-live-trace__heading {

--- a/services/orion-hub/static/js/agent-claude-trace.js
+++ b/services/orion-hub/static/js/agent-claude-trace.js
@@ -129,7 +129,7 @@
     if (panel) return panel;
     panel = (doc || document).createElement('div');
     panel.id = panelId;
-    panel.className = 'agent-live-trace claude-live-trace';
+    panel.className = 'agent-live-trace claude-live-trace is-streaming';
     const heading = (doc || document).createElement('div');
     heading.className = 'agent-live-trace__heading';
     heading.textContent = 'FCC harness (live)';
@@ -137,7 +137,7 @@
     const steps = (doc || document).createElement('div');
     steps.className = 'agent-live-trace__steps';
     panel.appendChild(steps);
-    anchor.appendChild(panel);
+    anchor.insertBefore(panel, anchor.firstChild);
     return panel;
   }
 
@@ -155,6 +155,10 @@
     row.textContent = `#${list.length - 1} ${summarizeStep(step)}`;
     host.appendChild(row);
     host.scrollTop = host.scrollHeight;
+    const heading = panel.querySelector('.agent-live-trace__heading');
+    if (heading) {
+      heading.textContent = `FCC harness (live) · ${list.length} step${list.length === 1 ? '' : 's'}`;
+    }
   }
 
   global.appendLiveClaudeStep = appendLiveClaudeStep;

--- a/services/orion-hub/tests/test_hub_harness_step_relay.py
+++ b/services/orion-hub/tests/test_hub_harness_step_relay.py
@@ -1,0 +1,39 @@
+"""HarnessStepRelay fans harness.run.step events to per-correlation queues."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.harness_step_relay import HarnessStepRelay
+
+
+@pytest.mark.asyncio
+async def test_harness_step_relay_dispatches_matching_correlation() -> None:
+    relay = HarnessStepRelay(channel="orion:harness:run:step")
+    queue: asyncio.Queue = asyncio.Queue()
+    relay.register_queue("corr-1", queue)
+
+    step_event = MagicMock()
+    step_event.correlation_id = "corr-1"
+    step_event.step_index = 0
+    step_event.step = {"type": "assistant", "raw": {"type": "assistant"}}
+
+    await relay._dispatch_step(step_event)
+
+    item = queue.get_nowait()
+    assert item["kind"] == "claude_step"
+    assert item["mode"] == "orion"
+    assert item["correlation_id"] == "corr-1"
+    assert item["step_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_harness_step_relay_ignores_unregistered_correlation() -> None:
+    relay = HarnessStepRelay(channel="orion:harness:run:step")
+    step_event = MagicMock()
+    step_event.correlation_id = "missing"
+    step_event.step_index = 0
+    step_event.step = {"type": "assistant"}
+    await relay._dispatch_step(step_event)


### PR DESCRIPTION
Pushed to **`fix/hub-unified-turn-fcc-live-stream`**.

**Branch:** `fix/hub-unified-turn-fcc-live-stream`  
**Commit:** `663a8aa7` — `fix(hub): restore unified-turn FCC motor live streaming`

`gh` isn’t authenticated here, so open the PR manually:  
https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/hub-unified-turn-fcc-live-stream

---

## Summary

- Add persistent `HarnessStepRelay` at Hub startup to fan `orion:harness:run:step` into per-turn WS queues (same pattern as `AgentStepRelay`)
- Wire `run_unified_turn` to drain `claude_step` frames live while the harness motor runs
- Route harness governor RPC through `rpc_bus` so the long inline wait doesn’t compete with main-bus subscribers
- Improve FCC live panel UX: pin to top of chat, taller scroll, step count, streaming highlight

## Outcome moved

Orion unified-mode turns stream FCC motor steps into the “FCC harness (live)” panel again during the turn, instead of staying empty until the final reply.

## Tests run

```text
PYTHONPATH=services/orion-hub:. pytest \
  orion/hub/tests/test_harness_step_relay.py \
  services/orion-hub/tests/test_hub_harness_step_relay.py \
  services/orion-hub/tests/test_turn_orchestrator_ws_frames.py -q
# 17 passed
```

## Restart required

```bash
PROJECT=orion-athena docker compose \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build hub-app
```

Hard-refresh Hub (Ctrl+Shift+R) after merge/deploy.

## Test plan

- [ ] Hard-refresh Hub
- [ ] Send an Orion unified-mode message
- [ ] Confirm “FCC harness (live) · N steps” fills during motor phase
- [ ] Confirm final reply lands and status returns to Ready

---

Unrelated local WIP is stashed as `unrelated local WIP` on the old branch if you need it back (`git stash list`).