### PR TITLE
fix(mind): normalize semantic synthesis array-root LLM JSON

### DIFF
--- a/services/orion-mind/app/synthesis.py
+++ b/services/orion-mind/app/synthesis.py
@@ -201,6 +201,74 @@ def try_wrap_singleton_semantic_claim(raw: dict[str, Any]) -> tuple[dict[str, An
     return out, True
 
 
+def _coerce_array_claim_item(item: dict[str, Any], *, index: int) -> dict[str, Any] | None:
+    if _has_current_claim_shape(item) or _is_bare_semantic_claim_root(item):
+        return _coerce_semantic_claim_item(item, index=index)
+    if not _is_legacy_claim_shape(item):
+        return None
+    claim_text = str(item.get("claim") or "").strip()
+    evidence_refs = _coerce_evidence_refs(item)
+    source_kinds = item.get("source_kinds")
+    if not isinstance(source_kinds, list) or not source_kinds:
+        source_kinds = ["current_turn"] if evidence_refs else []
+    default_kind = "current_turn_claim" if evidence_refs else "situation_claim"
+    return {
+        "claim_id": _legacy_claim_id(index, claim_text),
+        "label": _short_label(claim_text),
+        "summary": claim_text,
+        "claim_kind": default_kind,
+        "evidence_refs": evidence_refs,
+        "source_kinds": [str(k) for k in source_kinds if str(k).strip()],
+        "anchor": item.get("anchor") or "unknown",
+        "confidence": _float_field(item, "confidence", 0.5),
+        "salience_hint": _float_field(item, "salience_hint", 0.5),
+        "recommended_effect": item.get("recommended_effect") or "no_effect",
+        "metadata": {
+            **(item.get("metadata") if isinstance(item.get("metadata"), dict) else {}),
+            "normalized_from_legacy_claim_shape": True,
+        },
+    }
+
+
+def try_wrap_claims_array_root(raw: list[Any]) -> tuple[dict[str, Any] | None, bool]:
+    """Wrap a top-level JSON array of claim objects into SemanticSynthesisV1."""
+    if not raw:
+        return None, False
+    normalized_claims: list[dict[str, Any]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            return None, False
+        coerced = _coerce_array_claim_item(item, index=index)
+        if coerced is None:
+            return None, False
+        normalized_claims.append(coerced)
+    out: dict[str, Any] = {
+        "schema_version": "mind.semantic_synthesis.v1",
+        "claims": normalized_claims,
+        "suppressed": [],
+        "diagnostics": {"notes": ["normalized_from_claims_array_root"]},
+    }
+    return out, True
+
+
+def coerce_semantic_llm_root(raw: Any) -> tuple[dict[str, Any] | None, bool, str | None]:
+    """Normalize common non-object LLM JSON roots before schema validation.
+
+    Returns (coerced_dict, normalized_from_root, failure_reason).
+    failure_reason is set when raw is a list that could not be coerced.
+    """
+    if isinstance(raw, dict):
+        return raw, False, None
+    if isinstance(raw, list):
+        if not raw or any(not isinstance(item, dict) for item in raw):
+            return None, False, None
+        wrapped, did_wrap = try_wrap_claims_array_root(raw)
+        if did_wrap and wrapped is not None:
+            return wrapped, True, None
+        return None, False, "array_root_not_claims"
+    return None, False, None
+
+
 def try_normalize_legacy_semantic_raw(raw: dict[str, Any]) -> tuple[dict[str, Any] | None, bool]:
     """Convert obvious legacy claim objects into SemanticSynthesisV1 claim shape."""
     claims_in = raw.get("claims")
@@ -344,13 +412,18 @@ def run_semantic_synthesis(
     if raw is None:
         telemetry.status = "failed"
         return None, err or "semantic_synthesis_failed", telemetry
-    if not isinstance(raw, dict):
+    raw, normalized_from_root, coerce_failure = coerce_semantic_llm_root(raw)
+    if raw is None:
         telemetry.validation_ok = False
         telemetry.status = "schema_invalid"
-        telemetry.error = "semantic_schema_invalid:not_object"
+        if coerce_failure == "array_root_not_claims":
+            telemetry.error = "semantic_schema_invalid:array_root_not_claims"
+        else:
+            telemetry.error = "semantic_schema_invalid:not_object"
         return None, "semantic_schema_invalid", telemetry
 
     synthesis, normalized_from_shape = _validate_semantic_raw(raw)
+    normalized_from_shape = normalized_from_shape or normalized_from_root
     if synthesis is None:
         telemetry.validation_ok = False
         telemetry.ok = False

--- a/services/orion-mind/tests/test_mind_llm_pipeline.py
+++ b/services/orion-mind/tests/test_mind_llm_pipeline.py
@@ -324,6 +324,86 @@ def test_singleton_root_semantic_claim_is_wrapped_and_retained() -> None:
     assert telemetry.retained_claim_count == 1
 
 
+def test_claims_array_root_is_wrapped_and_retained() -> None:
+    from app.evidence import build_evidence_pack
+    from app.synthesis import run_semantic_synthesis, try_wrap_claims_array_root
+    from orion.mind.synthesis_v1 import SemanticSynthesisV1
+
+    array_root = [
+        {
+            "claim_id": "c1",
+            "label": "request for repetition",
+            "summary": "User asks to try again and asks for backup.",
+            "claim_kind": "current_turn_claim",
+            "evidence_refs": ["current_turn:0"],
+            "source_kinds": ["current_turn"],
+            "recommended_effect": "acknowledge",
+        },
+        {
+            "claim_id": "c2",
+            "label": "situation retry",
+            "summary": "User wants to retry a prior attempt.",
+            "claim_kind": "situation_claim",
+            "evidence_refs": ["current_turn:0"],
+            "source_kinds": ["current_turn"],
+            "recommended_effect": "no_effect",
+        },
+    ]
+    wrapped, did = try_wrap_claims_array_root(array_root)
+    assert did is True
+    synthesis = SemanticSynthesisV1.model_validate(wrapped)
+    assert len(synthesis.claims) == 2
+    assert "normalized_from_claims_array_root" in synthesis.diagnostics.notes
+
+    pack = build_evidence_pack({"user_text": "let's try that again, you back up?"})
+    result, err, telemetry = run_semantic_synthesis(
+        pack,
+        client=type("_C", (), {"request_json": lambda self, **kw: (array_root, None, {"model_used": "quick"})})(),  # type: ignore[arg-type]
+        route="quick",
+        model_id="quick",
+        max_tokens=512,
+    )
+    assert err is None and result and len(result.claims) == 2
+    assert telemetry.retained_claim_count == 2
+    assert telemetry.error is None
+
+
+def test_non_claim_array_root_still_fails_not_object() -> None:
+    from app.evidence import build_evidence_pack
+    from app.synthesis import run_semantic_synthesis
+
+    pack = build_evidence_pack({"user_text": "hello"})
+    result, err, telemetry = run_semantic_synthesis(
+        pack,
+        client=type("_C", (), {"request_json": lambda self, **kw: (["not", "claims"], None, {"model_used": "quick"})})(),  # type: ignore[arg-type]
+        route="quick",
+        model_id="quick",
+        max_tokens=512,
+    )
+    assert result is None
+    assert err == "semantic_schema_invalid"
+    assert telemetry.error == "semantic_schema_invalid:not_object"
+    assert telemetry.parse_ok is True
+
+
+def test_non_claim_object_array_root_reports_array_failure() -> None:
+    from app.evidence import build_evidence_pack
+    from app.synthesis import run_semantic_synthesis
+
+    pack = build_evidence_pack({"user_text": "hello"})
+    result, err, telemetry = run_semantic_synthesis(
+        pack,
+        client=type("_C", (), {"request_json": lambda self, **kw: ([{"foo": "bar"}], None, {"model_used": "quick"})})(),  # type: ignore[arg-type]
+        route="quick",
+        model_id="quick",
+        max_tokens=512,
+    )
+    assert result is None
+    assert err == "semantic_schema_invalid"
+    assert telemetry.error == "semantic_schema_invalid:array_root_not_claims"
+    assert telemetry.parse_ok is True
+
+
 def test_metacog_frontier_alias_shape_is_normalized() -> None:
     from app.appraisal import run_active_frontier_judge, try_normalize_frontier_raw
     from app.evidence import build_evidence_pack


### PR DESCRIPTION
## PR description (copy-paste)

**Title:** `fix(mind): normalize semantic synthesis array-root LLM JSON`

```markdown
## Summary

- Normalize top-level JSON **array of claim objects** (`[{claim}, …]`) in Mind semantic synthesis before schema validation
- Reuses the same survival pattern as singleton claim-root wrapping (`try_wrap_singleton_semantic_claim`)
- Split schema-invalid telemetry: `array_root_not_claims` vs `not_object` for clearer ops triage
- Regression tests for happy path, bad object arrays, and string arrays

## Outcome moved

Unified-turn Mind runs no longer fail-open to `fallback_contract_only` when `Active-GGUF-Model` on the `quick` route returns a claims array instead of a `SemanticSynthesisV1` envelope (live failure on corr `b6eb6a38`, error `semantic_schema_invalid:not_object`).

## Current architecture

`run_semantic_synthesis()` called `extract_json()` then rejected any non-dict root with `semantic_schema_invalid:not_object`. Singleton bare claim dicts were already wrapped; array roots were not.

## Architecture touched

- `services/orion-mind/app/synthesis.py` — `try_wrap_claims_array_root`, `coerce_semantic_llm_root`, choke point in `run_semantic_synthesis`
- `services/orion-mind/tests/test_mind_llm_pipeline.py` — 3 new regression tests

## Files changed

- `services/orion-mind/app/synthesis.py`: array-root normalization + distinct failure subcodes
- `services/orion-mind/tests/test_mind_llm_pipeline.py`: array success + failure telemetry tests

## Schema / bus / API changes

- Added: telemetry subcode `semantic_schema_invalid:array_root_not_claims`
- Behavior changed: array-of-claims LLM output is coerced instead of immediate fail-open
- Compatibility notes: external API unchanged; phase telemetry error strings may differ for bad arrays

## Tests run

```text
PYTHONPATH=services/orion-mind:orion .venv/bin/pytest services/orion-mind/tests/test_mind_llm_pipeline.py -q
24 passed
```

## Restart required

```bash
docker compose \
  --env-file services/orion-mind/.env \
  -f services/orion-mind/docker-compose.yml \
  up -d --build mind
```

## Risks / concerns

- Severity: low
- Concern: native logprob completion path still bypasses `return_json` json_object enforcement on gateway
- Mitigation: this patch handles the common array-root shape at Mind; gateway alignment is a separate follow-up

## Test plan

- [ ] Rebuild/restart `orion-mind`
- [ ] Run a unified Orion turn with Mind enrichment enabled
- [ ] Confirm Hub Mind provenance shows semantic_synthesis ok (or filtered with claims) instead of `not_object` fail-open
- [ ] Confirm CI passes `pytest services/orion-mind/tests/test_mind_llm_pipeline.py -q`
```

**Status:** DONE (pushed; PR needs manual create unless `gh auth login` is configured)