### PR TITLE
fix: make github_compactor_pass runnable from Hub Skill Runner

### DIFF
--- a/orion/cognition/github_compactor/constants.py
+++ b/orion/cognition/github_compactor/constants.py
@@ -9,3 +9,7 @@ JOURNAL_TITLE_MAX_CHARS = 120
 JOURNAL_BODY_MAX_CHARS = 4000
 
 DEFAULT_LOOKBACK_DAYS = 1
+# Cap PR rows passed to the digest LLM (bodies are already truncated per-PR at fetch).
+MAX_DIGEST_INPUT_PRS = 8
+# Digest prompt uses a tighter body cap than fetch to keep LLM context bounded.
+DIGEST_INPUT_BODY_MAX_CHARS = 600

--- a/orion/cognition/github_compactor/digest.py
+++ b/orion/cognition/github_compactor/digest.py
@@ -5,12 +5,45 @@ from uuid import NAMESPACE_URL, uuid5
 
 from orion.cognition.github_compactor.constants import (
     CARD_SUMMARY_MAX_CHARS,
+    DIGEST_INPUT_BODY_MAX_CHARS,
     JOURNAL_BODY_MAX_CHARS,
     JOURNAL_TITLE_MAX_CHARS,
+    MAX_DIGEST_INPUT_PRS,
 )
 from orion.schemas.actions.github_compactor import GithubCompactorDigestV1
 
 _COMPACTOR_JOURNAL_ENTRY_NS = NAMESPACE_URL
+
+
+def trim_github_compactor_input(fetch_payload: dict, *, max_items: int = MAX_DIGEST_INPUT_PRS) -> dict:
+    """Bound digest LLM input size while preserving total merge count metadata."""
+    if not isinstance(fetch_payload, dict):
+        return {}
+    trimmed = dict(fetch_payload)
+    items = list(fetch_payload.get("items") or [])
+    total = len(items)
+    compact_items = []
+    for item in items[:max_items]:
+        if not isinstance(item, dict):
+            continue
+        body = str(item.get("body") or "").strip()
+        if len(body) > DIGEST_INPUT_BODY_MAX_CHARS:
+            body = body[:DIGEST_INPUT_BODY_MAX_CHARS].rstrip() + "…"
+        compact_items.append(
+            {
+                "number": item.get("number"),
+                "title": item.get("title"),
+                "body": body,
+                "merged_at": item.get("merged_at"),
+                "url": item.get("url"),
+            }
+        )
+    trimmed["items"] = compact_items
+    if total > max_items:
+        trimmed["items_truncated_for_digest"] = True
+        trimmed["items_total"] = total
+    trimmed.pop("grouped_summary", None)
+    return trimmed
 
 
 def assert_digest_within_budget(digest: GithubCompactorDigestV1) -> None:

--- a/orion/cognition/github_compactor/tests/test_digest.py
+++ b/orion/cognition/github_compactor/tests/test_digest.py
@@ -15,6 +15,7 @@ from orion.cognition.github_compactor.digest import (
     build_quiet_day_digest,
     parse_github_compactor_digest_json,
     stable_github_compactor_journal_entry_id,
+    trim_github_compactor_input,
 )
 from orion.schemas.actions.github_compactor import GithubCompactorDigestV1
 
@@ -76,3 +77,21 @@ def test_parse_github_compactor_digest_json() -> None:
     digest = parse_github_compactor_digest_json(raw)
     assert digest.card_summary == "Card"
     assert digest.pr_refs == ["#9"]
+
+
+def test_trim_github_compactor_input_caps_items_for_digest() -> None:
+    payload = {
+        "repo": "acme/widgets",
+        "merged_pr_count": 20,
+        "items": [
+            {"number": i, "title": f"PR {i}", "body": "x" * 900, "touched_paths": ["a"] * 50}
+            for i in range(20)
+        ],
+    }
+    trimmed = trim_github_compactor_input(payload, max_items=12)
+    assert len(trimmed["items"]) == 12
+    assert trimmed["items"][0]["body"] == "x" * 600 + "…"
+    assert "grouped_summary" not in trimmed
+    assert trimmed["items_truncated_for_digest"] is True
+    assert trimmed["items_total"] == 20
+    assert trimmed["merged_pr_count"] == 20

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -392,6 +392,9 @@ def _resolve_llm_chat_max_tokens(step: ExecutionStep, ctx: Dict[str, Any]) -> Tu
     if step.verb_name == "journal.compose" and step.step_name == "draft_journal_entry":
         return int(settings.llm_chat_general_max_tokens), requested, "settings.llm_chat_general_max_tokens_journal_compose"
 
+    if step.verb_name == "github_compactor_digest_v1":
+        return int(settings.llm_chat_general_max_tokens), requested, "settings.llm_chat_general_max_tokens_github_compactor_digest"
+
     if step.verb_name == "memory_graph_suggest" and step.step_name == "llm_memory_graph_suggest":
         return int(settings.llm_memory_graph_suggest_max_tokens), requested, "settings.llm_memory_graph_suggest_max_tokens"
 

--- a/services/orion-cortex-orch/app/workflow_runtime.py
+++ b/services/orion-cortex-orch/app/workflow_runtime.py
@@ -5,7 +5,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Literal, Tuple
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 from orion.cognition.workflows import get_workflow_definition, workflow_registry_payload
 from orion.cognition.github_compactor.constants import DEFAULT_LOOKBACK_DAYS
@@ -14,6 +14,7 @@ from orion.cognition.github_compactor.digest import (
     build_quiet_day_digest,
     parse_github_compactor_digest_json,
     stable_github_compactor_journal_entry_id,
+    trim_github_compactor_input,
 )
 from orion.schemas.actions.github_compactor import GithubCompactorDigestV1
 from orion.core.bus.async_service import OrionBusAsync
@@ -203,6 +204,11 @@ def _ensure_trace(trace: dict | None, *, correlation_id: str, workflow_id: str) 
     base.setdefault("trace_id", correlation_id)
     base.setdefault("workflow_id", workflow_id)
     return base
+
+
+def _workflow_sub_correlation_id(parent_correlation_id: str, step_key: str) -> str:
+    """Stable UUID for workflow sub-steps (BaseEnvelope requires UUID correlation_id)."""
+    return str(uuid5(NAMESPACE_URL, f"orion:workflow:{parent_correlation_id}:{step_key}"))
 
 
 def _resolve_personality_file(metadata: Dict[str, Any] | None) -> str | None:
@@ -825,7 +831,7 @@ async def _execute_journal_discussion_window_pass(
         bus,
         source=source,
         client_request=skill_client,
-        correlation_id=f"{correlation_id}:discussion_window",
+        correlation_id=_workflow_sub_correlation_id(correlation_id, "discussion_window"),
         causality_chain=causality_chain,
         trace=_ensure_trace(trace, correlation_id=correlation_id, workflow_id=workflow_id),
         timeout_sec=float((skill_client.options or {}).get("timeout_sec", 120.0)),
@@ -1917,7 +1923,7 @@ async def _run_github_compactor_digest(
     synth_req.context.metadata = dict(synth_req.context.metadata or {})
     synth_req.context.metadata["workflow_subverb"] = "github_compactor_digest_v1"
     synth_req.context.metadata["workflow_id"] = workflow_id
-    synth_req.context.metadata["github_compactor_input"] = fetch_payload
+    synth_req.context.metadata["github_compactor_input"] = trim_github_compactor_input(fetch_payload)
     synth_req.context.metadata.update(
         _workflow_execution_envelope(
             req=req,
@@ -2023,7 +2029,7 @@ async def _execute_github_compactor_pass(
         bus,
         source=source,
         client_request=fetch_req,
-        correlation_id=f"{correlation_id}:github_fetch",
+        correlation_id=_workflow_sub_correlation_id(correlation_id, "github_fetch"),
         causality_chain=causality_chain,
         trace=_ensure_trace(trace, correlation_id=correlation_id, workflow_id=workflow_id),
         timeout_sec=float((fetch_req.options or {}).get("timeout_sec", 120.0)),

--- a/services/orion-cortex-orch/tests/test_workflow_lane.py
+++ b/services/orion-cortex-orch/tests/test_workflow_lane.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from pathlib import Path
+from uuid import UUID
 import sys
 import pytest
 
@@ -30,7 +31,7 @@ from orion.journaler.worker import (
 )
 
 from app import main as orch_main
-from app.workflow_runtime import execute_chat_workflow
+from app.workflow_runtime import _workflow_sub_correlation_id, execute_chat_workflow
 from orion.spark.introspection_metadata import build_introspection_context
 from orion.spark.concept_induction.parity_evidence import (
     ParityReadinessThresholds,
@@ -1955,12 +1956,22 @@ def test_concept_induction_prompt_contract_contains_noise_suppression_guidance()
     assert "Cross-subject pattern only when explicitly supported" in prompt
 
 
+def test_workflow_sub_correlation_id_is_valid_uuid() -> None:
+    parent = "00000000-0000-0000-0000-000000000099"
+    fetch = _workflow_sub_correlation_id(parent, "github_fetch")
+    UUID(fetch)
+    assert fetch == _workflow_sub_correlation_id(parent, "github_fetch")
+    assert fetch != _workflow_sub_correlation_id(parent, "discussion_window")
+
+
 def test_github_compactor_pass_writes_journal_and_supersedes_card(monkeypatch) -> None:
     bus = DummyBus()
     card_calls: dict = {}
+    sub_corr_ids: list[str] = []
 
     async def _fake_call_verb_runtime(*args, **kwargs):
         req = kwargs["client_request"]
+        sub_corr_ids.append(str(kwargs.get("correlation_id") or ""))
         if req.verb == "skills.repo.github_recent_prs.v1":
             payload = {
                 "available": True,
@@ -2025,6 +2036,9 @@ def test_github_compactor_pass_writes_journal_and_supersedes_card(monkeypatch) -
     assert result.metadata["workflow"]["merged_pr_count"] == 1
     assert card_calls.get("digest") is not None
     assert any(ch == "orion:journal:write" for ch, _ in bus.published)
+    fetch_corr = next(c for c in sub_corr_ids if c)
+    UUID(fetch_corr)
+    assert fetch_corr != "00000000-0000-0000-0000-000000000099"
 
 
 def test_github_compactor_pass_quiet_day_skips_card_persist(monkeypatch) -> None:


### PR DESCRIPTION
PR branch is pushed. GitHub CLI can't open the PR from here (PAT lacks `createPullRequest`), so use the link below.

**Branch:** `fix/github-compactor-runtime`  
**Commit:** `44ef9da3`  
**Open PR:** https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/github-compactor-runtime?expand=1

**Title:** `fix: make github_compactor_pass runnable from Hub Skill Runner`

---

## Summary

- Fix `github_compactor_pass` failing immediately from Hub Skill Runner due to invalid sub-step correlation ids (`:github_fetch` suffix is not a UUID)
- Bound digest LLM input (8 PRs, compact fields, 600-char bodies) so the digest verb fits model context
- Give `github_compactor_digest_v1` the general-lane token budget (8000) instead of default 512

## Outcome moved

Hub Skill Runner → **Run github compactor.** now completes end-to-end: fetch merged PRs → digest → memory card supersede → journal write.

## Current architecture

Merged `github_compactor_pass` worked in unit tests (mocked verb runtime) but failed live because `_execute_github_compactor_pass` passed `f"{correlation_id}:github_fetch"` into `call_verb_runtime`, which constructs `BaseEnvelope` requiring strict UUID correlation ids.

Secondary failure after UUID fix: digest LLM received ~48–78k char prompts and returned `structured_output_rejected` (llamacpp 400).

## Architecture touched

- `services/orion-cortex-orch/app/workflow_runtime.py` — UUID sub-step ids via `uuid5`; trim digest input before LLM
- `orion/cognition/github_compactor/digest.py` — `trim_github_compactor_input()` helper
- `services/orion-cortex-exec/app/executor.py` — token budget for digest verb

## Files changed (6 only)

- `services/orion-cortex-orch/app/workflow_runtime.py`
- `services/orion-cortex-orch/tests/test_workflow_lane.py`
- `orion/cognition/github_compactor/digest.py`
- `orion/cognition/github_compactor/constants.py`
- `orion/cognition/github_compactor/tests/test_digest.py`
- `services/orion-cortex-exec/app/executor.py`

## Schema / bus / API changes

None — same workflow id and outputs.

## Tests run

```text
pytest orion/cognition/github_compactor/tests/test_digest.py services/orion-cortex-orch/tests/test_workflow_lane.py -k 'github_compactor or workflow_sub_correlation or trim_github' -q
# 18 passed
```

## Docker/smoke

Live smoke after rebuild: **completed** — 20 merged PRs, memory card + journal persisted.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml up -d --build cortex-exec

docker compose --env-file .env --env-file services/orion-cortex-orch/.env \
  -f services/orion-cortex-orch/docker-compose.yml up -d --build cortex-orchestrator
```

## Risks / concerns

- Digest LLM sees at most 8 PRs per run (full merge count still recorded in metadata)
- Typing "Run github compactor" in **Orion unified turn mode** still won't route to this workflow — use Skill Runner (separate Hub routing gap)

---

Your unrelated WIP on `fix/mind-semantic-array-root` was stashed as `wip-unrelated-mind-crystallization`. Restore with `git stash pop` when you're back on that branch.