### PR TITLE
fix(hub): keep FCC harness live trace readable and anchored to turn

### DIFF
--- a/services/orion-hub/static/css/style.css
+++ b/services/orion-hub/static/css/style.css
@@ -56,7 +56,7 @@ input[type=range]::-moz-range-thumb {
 .agent-live-trace {
   display: flex;
   flex-direction: column;
-  min-height: 0;
+  flex-shrink: 0;
   max-height: 20rem;
   margin-bottom: 0.5rem;
   padding: 0.5rem 0.75rem;
@@ -70,6 +70,11 @@ input[type=range]::-moz-range-thumb {
   box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.15);
 }
 
+.agent-live-trace.is-complete {
+  border-color: rgba(55, 65, 81, 0.85);
+  box-shadow: none;
+}
+
 .agent-live-trace__heading {
   flex-shrink: 0;
   margin-bottom: 0.35rem;
@@ -81,8 +86,7 @@ input[type=range]::-moz-range-thumb {
 }
 
 .agent-live-trace__steps {
-  flex: 1;
-  min-height: 0;
+  max-height: 17rem;
   overflow-y: auto;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.68rem;

--- a/services/orion-hub/static/js/agent-claude-trace.js
+++ b/services/orion-hub/static/js/agent-claude-trace.js
@@ -130,6 +130,7 @@
     panel = (doc || document).createElement('div');
     panel.id = panelId;
     panel.className = 'agent-live-trace claude-live-trace is-streaming';
+    panel.dataset.correlationId = String(correlationId);
     const heading = (doc || document).createElement('div');
     heading.className = 'agent-live-trace__heading';
     heading.textContent = 'FCC harness (live)';
@@ -137,8 +138,20 @@
     const steps = (doc || document).createElement('div');
     steps.className = 'agent-live-trace__steps';
     panel.appendChild(steps);
-    anchor.insertBefore(panel, anchor.firstChild);
+    anchor.appendChild(panel);
     return panel;
+  }
+
+  function formatHarnessHeading(stepCount, live) {
+    const suffix = stepCount === 1 ? '' : 's';
+    if (live) {
+      return stepCount
+        ? `FCC harness (live) · ${stepCount} step${suffix}`
+        : 'FCC harness (live)';
+    }
+    return stepCount
+      ? `FCC harness · ${stepCount} step${suffix}`
+      : 'FCC harness';
   }
 
   function appendLiveClaudeStep(correlationId, step, doc) {
@@ -157,10 +170,39 @@
     host.scrollTop = host.scrollHeight;
     const heading = panel.querySelector('.agent-live-trace__heading');
     if (heading) {
-      heading.textContent = `FCC harness (live) · ${list.length} step${list.length === 1 ? '' : 's'}`;
+      heading.textContent = formatHarnessHeading(list.length, true);
+    }
+    const anchor = resolveAnchor(doc);
+    if (anchor && typeof anchor.scrollTop === 'number') {
+      anchor.scrollTop = anchor.scrollHeight;
     }
   }
 
+  function finalizeLiveClaudeTrace(correlationId, doc, beforeEl) {
+    if (!correlationId) return null;
+    const root = doc || (typeof document !== 'undefined' ? document : null);
+    if (!root || typeof root.getElementById !== 'function') return null;
+    const panelId = `claude-live-${correlationId}`;
+    const panel = root.getElementById(panelId);
+    if (!panel) return null;
+
+    panel.classList.remove('is-streaming');
+    panel.classList.add('is-complete');
+
+    const list = _liveClaudeSteps.get(correlationId) || [];
+    const heading = panel.querySelector('.agent-live-trace__heading');
+    if (heading) {
+      heading.textContent = formatHarnessHeading(list.length, false);
+    }
+
+    if (beforeEl && beforeEl.parentNode && panel.parentNode === beforeEl.parentNode) {
+      beforeEl.parentNode.insertBefore(panel, beforeEl);
+    }
+
+    return panel;
+  }
+
   global.appendLiveClaudeStep = appendLiveClaudeStep;
-  global.OrionClaudeTrace = { appendLiveClaudeStep, summarizeStep };
+  global.finalizeLiveClaudeTrace = finalizeLiveClaudeTrace;
+  global.OrionClaudeTrace = { appendLiveClaudeStep, finalizeLiveClaudeTrace, summarizeStep };
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -7176,6 +7176,17 @@ document.addEventListener("DOMContentLoaded", () => {
     return merged.filter((v, i, a) => a.indexOf(v) === i).join(' · ');
   }
 
+  function pinLiveClaudeTraceToMessage(meta, messageEl) {
+    if (!meta || !messageEl) return;
+    const corr = meta.correlationId || meta.correlation_id;
+    if (!corr || typeof finalizeLiveClaudeTrace !== 'function') return;
+    try {
+      finalizeLiveClaudeTrace(corr, document, messageEl);
+    } catch (err) {
+      console.warn('claude trace finalize failed', err);
+    }
+  }
+
   function appendMessage(sender, text, colorClass = 'text-white') {
     if (!conversationDiv) return;
     const meta = arguments.length > 3 && arguments[3] && typeof arguments[3] === 'object' ? arguments[3] : {};
@@ -7222,6 +7233,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (workflowPanel) div.appendChild(workflowPanel);
     if (!workflowOnlyTurn) div.appendChild(body);
     conversationDiv.appendChild(div);
+    if (sender === 'Orion') {
+      pinLiveClaudeTraceToMessage(meta, div);
+    }
     conversationDiv.scrollTop = conversationDiv.scrollHeight;
 
     if (sender === 'Orion') {

--- a/services/orion-hub/tests/test_agent_claude_trace_js.py
+++ b/services/orion-hub/tests/test_agent_claude_trace_js.py
@@ -13,7 +13,10 @@ def test_agent_claude_trace_summarizes_tool_use_and_results() -> None:
     assert "function formatToolInput(name, input)" in source
     assert "function summarizeContentBlocks(content)" in source
     assert "tool result" in source
-    assert "OrionClaudeTrace = { appendLiveClaudeStep, summarizeStep }" in source
+    assert "OrionClaudeTrace = { appendLiveClaudeStep, finalizeLiveClaudeTrace, summarizeStep }" in source
+    assert "function finalizeLiveClaudeTrace" in source
+    assert "anchor.appendChild(panel)" in source
+    assert "insertBefore(panel, anchor.firstChild)" not in source
     assert "basename(path)" in source
     assert "Grep" in source
     assert "Bash" in source


### PR DESCRIPTION
## PR title

`fix(hub): FCC harness live trace layout and turn anchoring`

## PR description

```markdown
## Summary

- Fix FCC harness live trace panel collapsing into an unreadable sliver after runs (flex `min-height: 0` + `flex: 1` inside scrollable `#conversation`)
- Stream the live panel at the **bottom** of the active turn (after the user message), not pinned to chat top
- On Orion reply, finalize the panel: drop `(live)` styling, mark complete, and insert directly above the assistant message
- Extend JS gate test to assert bottom append + finalize export

## Outcome moved

FCC harness steps stay readable during and after unified-turn / agent-claude runs instead of compressing into a heading-only mush or floating at the top of history.

## Current architecture

`claude_step` WS frames render via `agent-claude-trace.js` into `#conversation`. Previously the panel used `insertBefore(..., firstChild)` and flex-shrink rules that collapsed the steps list once streaming stopped.

## Architecture touched

- `services/orion-hub/static/js/agent-claude-trace.js` — live append, finalize, heading helpers
- `services/orion-hub/static/js/app.js` — pin finalized trace to Orion message by correlation id
- `services/orion-hub/static/css/style.css` — non-collapsing live trace layout
- `services/orion-hub/tests/test_agent_claude_trace_js.py` — structural gate

## Files changed

- `services/orion-hub/static/css/style.css`: prevent flex collapse; add `is-complete` style; steps use `max-height` scroll
- `services/orion-hub/static/js/agent-claude-trace.js`: append live panel to bottom; `finalizeLiveClaudeTrace()` on turn completion
- `services/orion-hub/static/js/app.js`: call finalize when Orion message lands
- `services/orion-hub/tests/test_agent_claude_trace_js.py`: gate bottom append + finalize export

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: Hub chat UI only (client-side trace panel placement/styling)
- Compatibility notes: hard refresh may be needed if static assets are cached

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no
- local `.env` synced: N/A

## Tests run

```text
pytest services/orion-hub/tests/test_agent_claude_trace_js.py -q
(UNVERIFIED in this environment — pytest module unavailable locally)
```

## Evals run

```text
None — UI layout fix; no eval harness for trace panel placement.
```

## Docker/build/smoke checks

```text
Not run — static asset change only; no container rebuild required beyond hub restart if serving cached JS.
```

## Restart required

```bash
# Hard refresh browser, or restart hub if static assets are cached:
docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml restart orion-hub
```

## Risks / concerns

- Severity: low
- Concern: browser cache may serve old `agent-claude-trace.js` until refresh
- Mitigation: bump `HUB_UI_ASSET_VERSION` if stale assets reported in prod

## Test plan

- [ ] Send a unified-turn or agent-claude message that emits `claude_step` frames
- [ ] Confirm live panel appears **below** the user message while streaming (not at chat top)
- [ ] Confirm steps remain readable (not collapsed to heading-only mush)
- [ ] Confirm on Orion reply the panel sits directly above the assistant message with `FCC harness · N steps` (no `(live)`)
```
