### PR TITLE
fix(spark): bind telemetry volume for Plan 2 phi corpus accrual

### DIFF
--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -121,6 +121,13 @@ SYNC_PREFIXES = (
     "EMBODIMENT_",
     # Durable world-pulse run-result stream (producer dual-write + consumer group)
     "WP_RUN_RESULT_",
+    # Plan 2 phi encoder / inner-state features (seed-v2)
+    "INNER_FEATURES_",
+    "PHI_DEGENERATE_",
+    "PHI_ENCODER_",
+    "ORION_PHI_ENCODER_",
+    "SUBSTRATE_READ_",
+    "EXEC_TRAJECTORY_",
 )
 
 SYNC_EXACT = frozenset(
@@ -156,6 +163,10 @@ SYNC_EXACT = frozenset(
         "ACTIONS_JOURNAL_POST_PERSIST_EMAIL_EXCLUDE_SOURCE_KINDS",
         # Worker log level (stdlib->loguru bridge) — must stay in sync so traces are visible.
         "LOG_LEVEL",
+        # Plan 2 phi encoder / inner-state features
+        "SUBSTRATE_RUNTIME_URL",
+        "CHANNEL_INNER_FEATURES",
+        "CHANNEL_PHI_REWARD",
     }
 )
 

--- a/services/orion-spark-introspector/README.md
+++ b/services/orion-spark-introspector/README.md
@@ -366,6 +366,29 @@ Spark-introspector settings (fields) and their env wiring:
 | `channel_spark_state_snapshot` | `CHANNEL_SPARK_STATE_SNAPSHOT`          | state snapshot channel for UI                       |
 | `channel_spark_signal`         | `CHANNEL_SPARK_SIGNAL`                  | `orion:spark:signal`                                |
 | `channel_vector_semantic_upsert` | `CHANNEL_VECTOR_SEMANTIC_UPSERT`      | **NEW**: defaults to `orion:vector:semantic:upsert` |
+#### Plan 2 inner features (`seed-v2`) + phi encoder corpus
+
+Spark-introspector emits `InnerStateFeaturesV1` on `orion:self:inner_features` and (when enabled) `PhiIntrinsicRewardV1` on `orion:self:phi_reward`. Deployment requirements:
+
+| Requirement | Detail |
+|---|---|
+| `INNER_FEATURES_VERSION` | `seed-v2` (see `.env_example`) |
+| Corpus path | `INNER_FEATURES_CORPUS_PATH=/mnt/telemetry/phi/corpus/inner_state.jsonl` |
+| Telemetry mount | `docker-compose.yml` binds `${TELEMETRY_ROOT:-/mnt/telemetry}:/mnt/telemetry` — pass root `.env` so `TELEMETRY_ROOT` resolves |
+| Substrate prerequisite | `orion-substrate-runtime` must reach conjourney Postgres (`POSTGRES_URI` in substrate `.env_example`) and serve healthy `GET /grammar/truth` + `GET /projections/execution_trajectory`. **Co-deploy:** update substrate `POSTGRES_URI` manually if local `.env` predates this fix — default `sync_local_env_from_example.py` does not rewrite `POSTGRES_URI`. Restart substrate before relying on live cognitive features. |
+| Encoder | `ORION_PHI_ENCODER_ENABLED=false` until corpus + promote gates pass; weights at `ORION_PHI_ENCODER_WEIGHTS` (active symlink under telemetry) |
+
+After `.env_example` edits: `python scripts/sync_local_env_from_example.py orion-spark-introspector`
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml up -d --build
+
+# Prerequisite (same session if substrate DSN was stale):
+docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
+```
+
 
 Make sure `CHANNEL_VECTOR_SEMANTIC_UPSERT` is defined in:
 

--- a/services/orion-spark-introspector/docker-compose.yml
+++ b/services/orion-spark-introspector/docker-compose.yml
@@ -95,6 +95,8 @@ services:
       INNER_FEATURES_ENABLED: ${INNER_FEATURES_ENABLED:-true}
       INNER_FEATURES_VERSION: ${INNER_FEATURES_VERSION:-seed-v2}
       INNER_FEATURES_CORPUS_PATH: ${INNER_FEATURES_CORPUS_PATH:-/mnt/telemetry/phi/corpus/inner_state.jsonl}
+      INNER_FEATURES_SCALER_WINDOW_SEC: ${INNER_FEATURES_SCALER_WINDOW_SEC:-900}
+      INNER_FEATURES_SCALER_MAXLEN: ${INNER_FEATURES_SCALER_MAXLEN:-256}
       CHANNEL_INNER_FEATURES: ${CHANNEL_INNER_FEATURES:-orion:self:inner_features}
       CHANNEL_PHI_REWARD: ${CHANNEL_PHI_REWARD:-orion:self:phi_reward}
       SUBSTRATE_RUNTIME_URL: ${SUBSTRATE_RUNTIME_URL:-http://orion-athena-substrate-runtime:8115}
@@ -103,6 +105,7 @@ services:
       EXEC_TRAJECTORY_MAX_AGE_SEC: ${EXEC_TRAJECTORY_MAX_AGE_SEC:-120}
       ORION_PHI_ENCODER_ENABLED: ${ORION_PHI_ENCODER_ENABLED:-false}
       ORION_PHI_ENCODER_WEIGHTS: ${ORION_PHI_ENCODER_WEIGHTS:-/mnt/telemetry/models/phi/encoders/active}
+      PHI_DEGENERATE_STREAK: ${PHI_DEGENERATE_STREAK:-20}
       PHI_ENCODER_HIDDEN_DIM: ${PHI_ENCODER_HIDDEN_DIM:-16}
       PHI_ENCODER_LATENT_DIM: ${PHI_ENCODER_LATENT_DIM:-8}
 
@@ -111,6 +114,8 @@ services:
 
     volumes:
       - ${ORION_DATA_ROOT:-/mnt/graphdb}/orion/spark:/mnt/graphdb/orion/spark
+      # Plan 2 corpus + encoder weights (INNER_FEATURES_CORPUS_PATH, ORION_PHI_ENCODER_WEIGHTS)
+      - ${TELEMETRY_ROOT:-/mnt/telemetry}:/mnt/telemetry
 
 networks:
   app-net:

--- a/services/orion-spark-introspector/tests/test_compose_seed_v2_telemetry_mount.py
+++ b/services/orion-spark-introspector/tests/test_compose_seed_v2_telemetry_mount.py
@@ -1,0 +1,37 @@
+"""Gate: spark-introspector compose mounts telemetry for Plan 2 corpus + encoder weights."""
+from __future__ import annotations
+
+from pathlib import Path
+
+COMPOSE = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+
+
+def test_compose_mounts_telemetry_root_for_plan2() -> None:
+    text = COMPOSE.read_text(encoding="utf-8")
+    assert "${TELEMETRY_ROOT:-/mnt/telemetry}:/mnt/telemetry" in text
+
+
+def test_compose_defaults_inner_features_to_seed_v2() -> None:
+    text = COMPOSE.read_text(encoding="utf-8")
+    assert "INNER_FEATURES_VERSION: ${INNER_FEATURES_VERSION:-seed-v2}" in text
+    assert "INNER_FEATURES_CORPUS_PATH: ${INNER_FEATURES_CORPUS_PATH:-/mnt/telemetry/phi/corpus/inner_state.jsonl}" in text
+    assert "ORION_PHI_ENCODER_ENABLED: ${ORION_PHI_ENCODER_ENABLED:-false}" in text
+    assert "ORION_PHI_ENCODER_WEIGHTS: ${ORION_PHI_ENCODER_WEIGHTS:-/mnt/telemetry/models/phi/encoders/active}" in text
+    assert "INNER_FEATURES_SCALER_WINDOW_SEC: ${INNER_FEATURES_SCALER_WINDOW_SEC:-900}" in text
+    assert "PHI_DEGENERATE_STREAK: ${PHI_DEGENERATE_STREAK:-20}" in text
+    assert "SUBSTRATE_RUNTIME_URL: ${SUBSTRATE_RUNTIME_URL:-http://orion-athena-substrate-runtime:8115}" in text
+
+
+def test_sync_script_includes_plan2_phi_keys() -> None:
+    from scripts.sync_local_env_from_example import SYNC_EXACT, SYNC_PREFIXES
+
+    prefixes = set(SYNC_PREFIXES)
+    assert "INNER_FEATURES_" in prefixes
+    assert "ORION_PHI_ENCODER_" in prefixes
+    assert "PHI_DEGENERATE_" in prefixes
+    assert "SUBSTRATE_READ_" in prefixes
+    assert "EXEC_TRAJECTORY_" in prefixes
+    exact = set(SYNC_EXACT)
+    assert "SUBSTRATE_RUNTIME_URL" in exact
+    assert "CHANNEL_INNER_FEATURES" in exact
+    assert "CHANNEL_PHI_REWARD" in exact

--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -3,7 +3,8 @@ SERVICE_NAME=orion-substrate-runtime
 SERVICE_VERSION=0.1.0
 NODE_NAME=athena
 
-POSTGRES_URI=postgresql://orion:orion@postgres:5432/orion
+# Athena stack: conjourney DB on orion-athena-sql-db (not the legacy orion@postgres DSN).
+POSTGRES_URI=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
 ORION_BUS_URL=redis://100.92.216.81:6379/0
 ORION_BUS_ENABLED=true
 

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -26,11 +26,14 @@ psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_substrate_reducer
 psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_coalition_dwell_v1.sql
 psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_endogenous_curiosity_candidates_v1.sql
 cp services/orion-substrate-runtime/.env_example services/orion-substrate-runtime/.env
+python scripts/sync_local_env_from_example.py orion-substrate-runtime
 ```
 
-Set `ENABLE_EXECUTION_TRAJECTORY_REDUCER=true` after cortex-exec grammar publish is enabled (`PUBLISH_CORTEX_EXEC_GRAMMAR=true` on orion-cortex-exec). Default is `false` for safe rollout.
+`POSTGRES_URI` must reach the **conjourney** database (`orion-athena-sql-db:5432`). A stale `orion:orion@postgres:5432/orion` DSN breaks `/grammar/truth` and all reducers.
 
-Set `ENABLE_TRANSPORT_BUS_REDUCER=true` after orion-bus transport traces are publishing (`PUBLISH_ORION_BUS_GRAMMAR=true`). Default is `false`.
+Set `ENABLE_EXECUTION_TRAJECTORY_REDUCER=true` after cortex-exec grammar publish is enabled (`PUBLISH_CORTEX_EXEC_GRAMMAR=true` on orion-cortex-exec). Checked-in `.env_example` default is `true`.
+
+Set `ENABLE_TRANSPORT_BUS_REDUCER=true` after orion-bus transport traces are publishing (`PUBLISH_ORION_BUS_GRAMMAR=true`). Checked-in `.env_example` default is `true`.
 
 ## Run
 


### PR DESCRIPTION
## Summary

- Add `${TELEMETRY_ROOT:-/mnt/telemetry}:/mnt/telemetry` bind mount to `orion-spark-introspector` compose so `INNER_FEATURES_CORPUS_PATH` and `ORION_PHI_ENCODER_WEIGHTS` resolve on the host
- Extend `sync_local_env_from_example.py` with Plan 2 phi/inner-state sync prefixes and exact keys
- Add gate tests for compose mount + sync registration
- Document Plan 2 seed-v2 deployment in spark README (dual `--env-file`, substrate co-deploy)
- Fix substrate `.env_example` `POSTGRES_URI` to Athena conjourney DSN (prerequisite for grammar-truth + execution trajectory)

## Outcome moved

Live `InnerStateFeaturesV1` corpus accrual now writes to host `/mnt/telemetry/phi/corpus/inner_state.jsonl` instead of orphaned container-local storage after restarts.

## Current architecture

Plan 2 compose/env pointed corpus and encoder weights at `/mnt/telemetry/...` but only mounted `/mnt/graphdb/orion/spark`. After container recreate, spark accrued ~820KB of seed-v2 rows inside the container while the host training corpus (~9MB) froze.

## Architecture touched

- `services/orion-spark-introspector` — compose volume + README
- `scripts/sync_local_env_from_example.py` — Plan 2 env parity
- `services/orion-substrate-runtime` — `.env_example` DSN + README operator note

## Files changed

- `services/orion-spark-introspector/docker-compose.yml`: telemetry bind + Plan 2 env parity keys
- `services/orion-spark-introspector/tests/test_compose_seed_v2_telemetry_mount.py`: gate tests
- `services/orion-spark-introspector/README.md`: Plan 2 deployment section
- `scripts/sync_local_env_from_example.py`: INNER_FEATURES_/PHI_/SUBSTRATE_READ_ sync
- `services/orion-substrate-runtime/.env_example`: conjourney POSTGRES_URI
- `services/orion-substrate-runtime/README.md`: DSN + reducer default notes

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: none (deployment wiring only)
- Compatibility notes: operators must recreate spark-introspector container for mount to apply

## Env/config changes

- Added keys: none (existing Plan 2 keys now synced by default)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: substrate `POSTGRES_URI`
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: spark + substrate (no key changes needed)
- skipped keys requiring operator action: `POSTGRES_URI` on substrate is **not** auto-synced — update manually if local `.env` predates this fix

## Tests run

```text
pytest services/orion-spark-introspector/tests/test_compose_seed_v2_telemetry_mount.py -q → 3 passed
docker compose ... config -q → OK
```

## Evals run

```text
Not run (deployment wiring only; no encoder inference behavior change)
```

## Docker/build/smoke checks

```text
docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml up -d --force-recreate → OK

Runtime verified:
- Mounts: /mnt/telemetry -> /mnt/telemetry
- Host corpus accruing: 3410 → 3430 rows in 15s post-recreate
```

## Review findings fixed

- Finding: Telemetry mount never committed; restarts wrote corpus to container-local path
  - Fix: compose bind + gate test
  - Evidence: `docker inspect` shows `/mnt/telemetry` mount; host file mtime advancing

- Finding: Plan 2 env keys not in default sync script
  - Fix: SYNC_PREFIXES + SYNC_EXACT entries
  - Evidence: gate test `test_sync_script_includes_plan2_phi_keys`

- Finding: Substrate stale DSN breaks grammar-truth prerequisite
  - Fix: `.env_example` conjourney URI + README note
  - Evidence: documented co-deploy; manual POSTGRES_URI step called out

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml up -d --force-recreate

# If substrate POSTGRES_URI was stale:
docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: medium
- Concern: `POSTGRES_URI` not in sync script — stale operator `.env` won't auto-heal
- Mitigation: README + PR callout; manual verify before relying on cognitive features

- Severity: low
- Concern: ~35 min of container-local corpus rows may not be on host if recreate happened before merge
- Mitigation: host corpus resumed accrual after fix; orphan rows were small (~820KB)