### PR TITLE
fix(phi-motor): isolate cortex finalize verbs on lane-suffixed traces

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,104 +1,132 @@
 ## Summary
 
-- Add `services/orion-signals/` — thin mesh launcher for the organ-signal causal spine (not a runtime service).
-- Machine-readable `roster.v1.yaml` with tiers: `core`, `tier1`, `tier2`, `routing`, `full`.
-- Deterministic `up.sh` / `down.sh` / `smoke.sh` scripts with Redis dedupe when `bus-core` is already running.
-- 13 gate tests validating roster compose paths, service names, and script contracts.
-- Register `orion-signals` in `scripts/sync_local_env_from_example.py` for env parity.
+- Widen substrate execution trajectory reducer to accept `orion-harness-governor` lifecycle grammar alongside `orion-cortex-exec` (shared `cortex.exec:` trace IDs).
+- Add harness lifecycle grammar collector and wire motor + finalize publish points (fail-open; finalize emits assembled+egress delta only).
+- Spark emits `features_version=seed-v3`: `reliability_pressure` in infra only, 11-dim honest encoder trainable subset; saturated felt dims retained in corpus for audit.
+- `fit_phi_encoder.py` versioned input (`--features-version seed-v3` default) with 9/11 variance gate @ 80%.
+- Default `INNER_FEATURES_VERSION=seed-v3`; encoder stays off until operator promotes on seed-v3 corpus.
+- **(uncommitted)** Isolate auxiliary cortex-exec verbs (`harness_finalize_reflect`, `orion_voice_finalize`) onto lane-suffixed trace IDs so they cannot pollute the primary unified-turn motor projection; add lifecycle publish INFO logging.
 
 ## Outcome moved
 
-Operators can bring up the organ-signal mesh (bus + gateway + tier1 producers + homeostatic consumer) with one command instead of ad-hoc per-service compose invocations.
+Unified Orion turns (`mode=orion` / harness-governor FCC motor) now populate `ExecutionTrajectoryProjectionV1` cognitive features (`reasoning_present`, step counters) that spark reads — unblocking honest φ encoder variance gates on an 11-dim trainable subset instead of structurally flat felt dims.
 
 ## Current architecture
 
-Each organ producer had its own `docker-compose.yml` and `.env`. There was no tiered roster or cumulative launcher for the `orion:signals:*` causal spine around `orion-signal-gateway`.
+- Only `orion-cortex-exec` grammar reached the execution trajectory reducer; harness `harness_fcc_step` events were no-oped.
+- Spark `seed-v2` trained on 15 dims including saturated `field_intensity` / `resource_pressure` / flat `introspection_pressure` — variance gate stuck at 11/15.
 
 ## Architecture touched
 
-- `services/orion-signals/` — new orchestration seam (roster + scripts + tests + README)
-- `scripts/sync_local_env_from_example.py` — `orion-signals` in `DEFAULT_SERVICES`
-- Root `README.md` — cross-link to orion-signals operator guide
+- `orion/substrate/execution_loop/` — reducer widening, shared trace ID
+- `orion/harness/grammar_emit.py` — new lifecycle collector + finalize delta builder
+- `orion/harness/runner.py` + `services/orion-harness-governor/app/bus_listener.py` — publish seams
+- `services/orion-spark-introspector/app/inner_state.py` — seed-v3 feature contract
+- `scripts/fit_phi_encoder.py` — versioned trainable dims
 
 ## Files changed
 
-- `services/orion-signals/roster.v1.yaml`: tier → compose service mapping with organ_ids
-- `services/orion-signals/scripts/up.sh`: cumulative tier launcher; optional `--env-file`; gateway `--no-deps` redis dedupe
-- `services/orion-signals/scripts/down.sh`: reverse-order stop with optional env files
-- `services/orion-signals/scripts/smoke.sh`: bus-core ping + gateway HTTP checks
-- `services/orion-signals/.env_example`: operator contract (`ORION_BUS_URL`, `SIGNALS_TIER`, `SIGNALS_USE_BUNDLED_REDIS`)
-- `services/orion-signals/README.md`: operator guide
-- `services/orion-signals/tests/`: roster + script gate tests
-- `scripts/sync_local_env_from_example.py`: include orion-signals in default sync
-- `README.md`: pointer to orion-signals README
+- `orion/substrate/execution_loop/{constants,ids,grammar_extract,reducer}.py`: motor-agnostic source filter + fcc noop handling
+- `orion/harness/grammar_emit.py`: lifecycle grammar producer + `build_harness_grammar_finalize_events`
+- `orion/harness/runner.py`: motor lifecycle publish
+- `services/orion-harness-governor/app/bus_listener.py`: finalize egress publish
+- `services/orion-spark-introspector/app/inner_state.py`: seed-v3 felt/infra split
+- `scripts/fit_phi_encoder.py`: versioned encoder input + corpus filter
+- Tests across substrate, harness, spark, fit script
+- `services/orion-cortex-exec/app/grammar_emit.py`: `trace_lane_for_verb` + lane-suffixed `trace_id` for isolated finalize verbs
+- `orion/substrate/execution_loop/ids.py`: optional `lane` on `cortex_exec_trace_id`
+- `orion/harness/{grammar_emit.py,runner.py}`: lifecycle publish INFO logs
 
 ## Schema / bus / API changes
 
-- Added: none
-- Removed: none
-- Renamed: none
-- Behavior changed: none (launcher only)
-- Compatibility notes: Hub remains external (host network); start separately for Organ Signals UI
+- Added: harness lifecycle grammar roles (`exec_request_received` … `exec_result_emitted`) from `orion-harness-governor`
+- Removed: nothing
+- Renamed: nothing
+- Behavior changed: reducer accepts both execution motors; `harness_fcc_step` ignored; spark default features_version seed-v3; auxiliary cortex finalize verbs publish to `cortex.exec:{node}:{corr}:{lane}` traces
+- Compatibility: cortex-exec path unchanged; seed-v2 corpus replay via `--features-version seed-v2`
 
 ## Env/config changes
 
-- Added keys: `SIGNALS_TIER`, `SIGNALS_USE_BUNDLED_REDIS` in `services/orion-signals/.env_example`
+- Added keys: none
 - Removed keys: none
 - Renamed keys: none
-- `.env_example` updated: yes (`services/orion-signals/.env_example`)
-- local `.env` synced with `python scripts/sync_local_env_from_example.py`: yes
-- skipped keys requiring operator action: `ORION_BUS_URL` (host-specific Tailscale IP — set manually)
+- `.env_example` updated: `INNER_FEATURES_VERSION=seed-v3` in `services/orion-spark-introspector/.env_example`
+- local `.env` synced: operator `services/orion-spark-introspector/.env` set to `seed-v3` on this machine
+- skipped keys requiring operator action: none
 
 ## Tests run
 
 ```text
-bash -n services/orion-signals/scripts/*.sh  → OK
-PYTHONPATH=. orion_dev/bin/python -m pytest services/orion-signals/tests -q  → 13 passed
+PYTHONPATH=. pytest \
+  tests/test_execution_loop_ids.py \
+  tests/test_execution_substrate_reducer.py \
+  orion/harness/tests/test_harness_grammar_emit.py \
+  orion/harness/tests/test_harness_runner.py \
+  services/orion-cortex-exec/tests/test_exec_grammar_emit.py \
+  services/orion-spark-introspector/tests/test_inner_state_seed_v3.py \
+  tests/test_phi_encoder_fit_script.py \
+  services/orion-spark-introspector/tests/test_compose_seed_v2_telemetry_mount.py -q
+→ 40 passed (35 trace-isolation slice + prior 37 minus overlap)
 ```
 
 ## Evals run
 
 ```text
-None (orchestration/operator tooling; no eval harness for this seam)
+Not run — operator eval: strict fit on seed-v3 corpus post-deploy.
 ```
 
 ## Docker/build/smoke checks
 
 ```text
-Not run in CI agent session (requires live bus + per-service .env on operator host).
-Operator smoke: ./services/orion-signals/scripts/smoke.sh
+Compose default validated via test_compose_seed_v2_telemetry_mount.
+Unified-turn projection smoke UNVERIFIED — operator step below.
 ```
 
 ## Review findings fixed
 
-- Finding: `docker compose --env-file` fails when per-service `.env` missing
-  - Fix: up.sh/down.sh only pass `--env-file` when file exists; warn otherwise
-  - Evidence: `test_compose_helpers_skip_missing_env_file`, manual review
-- Finding: duplicate log line after gateway `--no-deps` bring-up
-  - Fix: echo before command only (consistent with `compose_up`)
-  - Evidence: up.sh review
-- Finding: `orion-signals` absent from env sync default list
-  - Fix: added to `DEFAULT_SERVICES` + `SIGNALS_`/`SIGNAL_GATEWAY_` sync prefixes
-  - Evidence: sync script diff
+- Finding: Finalize replayed full harness lifecycle trace (duplicate bus events)
+  - Fix: `build_harness_grammar_finalize_events()` emits only assembled+egress atoms
+  - Evidence: `test_finalize_events_emit_only_assembled_and_egress`
+
+- Finding: Empty-draft path double-published lifecycle
+  - Fix: Removed redundant bus_listener publish when motor already emitted
+  - Evidence: harness tests pass
+
+- Finding: Mixed-batch `harness_fcc_step` noop IDs missing from reducer receipt
+  - Fix: `noop_event_ids` includes filtered fcc step IDs
+  - Evidence: `test_reducer_noops_harness_fcc_step_in_mixed_batch`
+
+- Finding: Live turn `9ac4f7e5` — cortex finalize verbs shared correlation trace with harness motor, fragmenting projection (`verb=unknown`, `reasoning_present=false`)
+  - Fix: `trace_lane_for_verb` → lane-suffixed `cortex.exec:` trace for `harness_finalize_reflect` / `orion_voice_finalize`
+  - Evidence: `test_trace_lane_isolates_harness_finalize_verbs`, `test_isolated_lane_trace_does_not_merge_with_primary_motor_trace`
 
 ## Restart required
 
-```text
-No restart required for merge itself.
-After deploy, bring up mesh:
-  cp services/orion-signals/.env_example services/orion-signals/.env
-  # Set ORION_BUS_URL=redis://<tailscale-node-ip>:6379/0
-  python scripts/sync_local_env_from_example.py
-  ./services/orion-signals/scripts/up.sh tier1
-  ./services/orion-signals/scripts/smoke.sh
+```bash
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml up -d --build
+
+docker compose --env-file .env --env-file services/orion-harness-governor/.env \
+  -f services/orion-harness-governor/docker-compose.yml up -d --build
+
+docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
+
+docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml up -d --build
 ```
 
 ## Risks / concerns
 
-- Severity: low
-- Concern: Per-service `.env` files must exist (sync script or manual copy) before `up.sh` can substitute variables
-- Mitigation: WARN logs + README prerequisites; optional env-file handling prevents hard fail on missing launcher `.env`
+- Severity: Medium — Live unified-turn projection smoke not verified after trace-isolation patch
+- Mitigation: Redeploy cortex-exec + harness-governor + substrate; re-run unified turn; check logs for `harness_lifecycle_grammar_published` and projection `verb=orion_unified`
 
-## PR link
+- Severity: Low — Encoder off until seed-v3 corpus accrues
+- Mitigation: Operator strict fit + promote gates
 
-(filled after push)
+## Test plan
+
+- [ ] Hub unified turn → projection `verb=orion_unified`, `reasoning_present=true` when FCC steps > 0
+- [ ] Classic cortex-exec regression
+- [ ] Spark corpus `features_version=seed-v3`, reliability in infra
+- [ ] Strict fit ≥9/11 variance on seed-v3 corpus

--- a/orion/harness/grammar_emit.py
+++ b/orion/harness/grammar_emit.py
@@ -537,8 +537,16 @@ async def publish_harness_lifecycle_grammar(
     events: list[GrammarEventV1],
     publish_fn: PublishFn | None = None,
 ) -> None:
+    corr = events[0].correlation_id if events else "unknown"
     if not events:
+        logger.info(
+            "harness_lifecycle_grammar_publish_skipped corr=%s channel=%s reason=empty_events",
+            corr,
+            channel,
+        )
         return
+    roles = sorted({e.atom.semantic_role for e in events if e.atom})
+    published = 0
     for event in events:
         try:
             if publish_fn is not None:
@@ -552,10 +560,19 @@ async def publish_harness_lifecycle_grammar(
                     source_name="orion-harness-governor",
                     channel=channel,
                 )
+            published += 1
         except Exception:
             logger.warning(
                 "harness_lifecycle_grammar_publish_failed corr=%s event_kind=%s",
-                event.correlation_id or "unknown",
+                event.correlation_id or corr,
                 event.event_kind,
                 exc_info=True,
             )
+    logger.info(
+        "harness_lifecycle_grammar_published corr=%s channel=%s trace_id=%s events=%s roles=%s",
+        corr,
+        channel,
+        events[0].trace_id,
+        published,
+        roles,
+    )

--- a/orion/harness/runner.py
+++ b/orion/harness/runner.py
@@ -294,11 +294,18 @@ class HarnessRunner:
                 reflection_ran=False,
                 quick_lane_skipped_5b=True,
             )
+            events = build_harness_grammar_events(collector)
+            logger.info(
+                "harness_motor_lifecycle_publish_begin corr=%s trace_id=%s events=%s",
+                request.correlation_id,
+                collector.trace_id,
+                len(events),
+            )
             try:
                 await publish_harness_lifecycle_grammar(
                     self.bus,
                     channel=self.grammar_channel,
-                    events=build_harness_grammar_events(collector),
+                    events=events,
                 )
             except Exception:
                 logger.warning(

--- a/orion/substrate/execution_loop/ids.py
+++ b/orion/substrate/execution_loop/ids.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
 
-def cortex_exec_trace_id(node_name: str, correlation_id: str) -> str:
-    return f"cortex.exec:{node_name}:{correlation_id}"
+def cortex_exec_trace_id(
+    node_name: str,
+    correlation_id: str,
+    *,
+    lane: str | None = None,
+) -> str:
+    """Build a cortex.exec trace id.
+
+    ``lane`` isolates auxiliary cortex-exec runs (e.g. harness finalize reflect)
+    from the primary unified-turn motor trace that shares the same correlation_id.
+    """
+    base = f"cortex.exec:{node_name}:{correlation_id}"
+    if lane:
+        return f"{base}:{lane}"
+    return base
 
 
 def parse_execution_trace_id(trace_id: str) -> tuple[str, str] | None:

--- a/services/orion-cortex-exec/app/grammar_emit.py
+++ b/services/orion-cortex-exec/app/grammar_emit.py
@@ -29,6 +29,19 @@ def _hash_id(*parts: object, prefix: str) -> str:
     return f"{prefix}_{hashlib.sha1(raw.encode('utf-8')).hexdigest()[:16]}"
 
 
+CORTEX_EXEC_ISOLATED_TRACE_LANES = frozenset({
+    "harness_finalize_reflect",
+    "orion_voice_finalize",
+})
+
+
+def trace_lane_for_verb(verb_name: str | None) -> str | None:
+    verb = (verb_name or "").strip()
+    if verb in CORTEX_EXEC_ISOLATED_TRACE_LANES:
+        return verb
+    return None
+
+
 @dataclass
 class CortexExecGrammarCollector:
     node_name: str
@@ -37,13 +50,14 @@ class CortexExecGrammarCollector:
     observed_at: datetime
     session_id: str | None = None
     turn_id: str | None = None
+    trace_lane: str | None = None
     _atoms: dict[str, GrammarAtomV1] = field(default_factory=dict)
     _edge_specs: list[tuple[str, str, str]] = field(default_factory=list)
     _last_completed_atom_id: str | None = None
 
     @property
     def trace_id(self) -> str:
-        return cortex_exec_trace_id(self.node_name, self.correlation_id)
+        return cortex_exec_trace_id(self.node_name, self.correlation_id, lane=self.trace_lane)
 
     def _provenance(self, payload_ref: str) -> GrammarProvenanceV1:
         return GrammarProvenanceV1(
@@ -376,6 +390,7 @@ def get_or_create_collector(
     correlation_id: str,
     node_name: str,
     code_version: str | None,
+    trace_lane: str | None = None,
 ) -> CortexExecGrammarCollector:
     collector = ctx.get("_cortex_exec_grammar_collector")
     if collector is None:
@@ -384,6 +399,7 @@ def get_or_create_collector(
             ctx=ctx,
             code_version=code_version,
             node_name=node_name,
+            trace_lane=trace_lane,
         )
         ctx["_cortex_exec_grammar_collector"] = collector
     return collector
@@ -402,11 +418,13 @@ def begin_plan_grammar(
     node_name: str,
     code_version: str | None,
 ) -> CortexExecGrammarCollector:
+    lane = trace_lane_for_verb(req.plan.verb_name)
     collector = get_or_create_collector(
         ctx,
         correlation_id=correlation_id,
         node_name=node_name,
         code_version=code_version,
+        trace_lane=lane,
     )
     if not ctx.get("_cortex_exec_grammar_request_recorded"):
         collector.record_request_received(req=req, mode=mode)
@@ -445,6 +463,7 @@ def new_cortex_exec_collector(
     ctx: dict[str, Any],
     code_version: str | None,
     node_name: str,
+    trace_lane: str | None = None,
 ) -> CortexExecGrammarCollector:
     session_id = str(ctx.get("session_id") or ctx.get("sessionId") or "") or None
     turn_id = str(ctx.get("turn_id") or ctx.get("message_id") or ctx.get("messageId") or "") or None
@@ -455,6 +474,7 @@ def new_cortex_exec_collector(
         observed_at=datetime.now(timezone.utc),
         session_id=session_id,
         turn_id=turn_id,
+        trace_lane=trace_lane,
     )
 
 

--- a/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
+++ b/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
@@ -39,6 +39,23 @@ def test_trace_id_stable_for_node_and_correlation() -> None:
     assert cortex_exec_trace_id(NODE, CORR) == f"cortex.exec:{NODE}:{CORR}"
 
 
+def test_trace_lane_isolates_harness_finalize_verbs() -> None:
+    from app.grammar_emit import trace_lane_for_verb
+
+    assert trace_lane_for_verb("harness_finalize_reflect") == "harness_finalize_reflect"
+    assert trace_lane_for_verb("orion_voice_finalize") == "orion_voice_finalize"
+    assert trace_lane_for_verb("chat_general") is None
+
+    collector = CortexExecGrammarCollector(
+        node_name=NODE,
+        correlation_id=CORR,
+        code_version="0.2.0",
+        observed_at=FIXED_OBS,
+        trace_lane="harness_finalize_reflect",
+    )
+    assert collector.trace_id == f"cortex.exec:{NODE}:{CORR}:harness_finalize_reflect"
+
+
 def test_builds_valid_grammar_events_with_required_semantic_roles() -> None:
     collector = CortexExecGrammarCollector(
         node_name=NODE,

--- a/tests/test_execution_loop_ids.py
+++ b/tests/test_execution_loop_ids.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from orion.substrate.execution_loop.ids import cortex_exec_trace_id, parse_execution_trace_id
+
+
+def test_cortex_exec_trace_id_without_lane() -> None:
+    assert cortex_exec_trace_id("athena", "corr-1") == "cortex.exec:athena:corr-1"
+
+
+def test_cortex_exec_trace_id_with_lane_suffix() -> None:
+    assert (
+        cortex_exec_trace_id("athena", "corr-1", lane="harness_finalize_reflect")
+        == "cortex.exec:athena:corr-1:harness_finalize_reflect"
+    )
+
+
+def test_parse_execution_trace_id_accepts_lane_suffix() -> None:
+    parsed = parse_execution_trace_id("cortex.exec:athena:corr-1:harness_finalize_reflect")
+    assert parsed == ("athena", "corr-1:harness_finalize_reflect")

--- a/tests/test_execution_substrate_reducer.py
+++ b/tests/test_execution_substrate_reducer.py
@@ -402,3 +402,43 @@ def test_reducer_noops_harness_fcc_step_in_mixed_batch() -> None:
     assert receipt.noop_event_ids == ["noop-fcc"]
     assert receipt.accepted_event_ids == ["h2"]
     assert proj.runs[TRACE].started_step_count == 1
+
+
+def test_isolated_lane_trace_does_not_merge_with_primary_motor_trace() -> None:
+    primary = _harness_atom(
+        "exec_result_assembled",
+        "Result assembled: status=ok, final_text_present=true, reasoning_present=true, thinking_source=harness_fcc",
+        event_id="primary-assembled",
+    )
+    isolated_trace = f"{TRACE}:harness_finalize_reflect"
+    isolated = GrammarEventV1(
+        event_id="isolated-step",
+        event_kind="atom_emitted",
+        trace_id=isolated_trace,
+        emitted_at=FIXED_TS,
+        atom=GrammarAtomV1(
+            atom_id=f"{isolated_trace}:exec_step_started",
+            trace_id=isolated_trace,
+            atom_type="observation",
+            semantic_role="exec_step_started",
+            layer="execution",
+            summary="Step started: order=1, step=reflect, verb=harness_finalize_reflect, services=none",
+        ),
+        provenance=GrammarProvenanceV1(source_service="orion-cortex-exec"),
+    )
+    proj, receipt_primary = reduce_execution_trace_events(
+        events=[primary],
+        projection=_empty_projection(),
+        now=FIXED_TS,
+    )
+    proj, receipt_isolated = reduce_execution_trace_events(
+        events=[isolated],
+        projection=proj,
+        now=FIXED_TS,
+    )
+    assert receipt_primary.accepted_event_ids == ["primary-assembled"]
+    assert receipt_isolated.accepted_event_ids == ["isolated-step"]
+    assert set(proj.runs) == {TRACE, isolated_trace}
+    assert proj.runs[TRACE].reasoning_present is True
+    assert proj.runs[isolated_trace].started_step_count == 1
+    assert proj.runs[isolated_trace].reasoning_present is False


### PR DESCRIPTION
Auxiliary harness_finalize_reflect and orion_voice_finalize grammar was polluting the primary unified-turn motor projection. Route those verbs to cortex.exec:{node}:{corr}:{lane} and add lifecycle publish INFO logs.