### PR TITLE
fix(phi-motor): isolate stance_react on lane-suffixed cortex trace

### DIFF
--- a/services/orion-cortex-exec/app/grammar_emit.py
+++ b/services/orion-cortex-exec/app/grammar_emit.py
@@ -30,6 +30,8 @@ def _hash_id(*parts: object, prefix: str) -> str:
 
 
 CORTEX_EXEC_ISOLATED_TRACE_LANES = frozenset({
+    # Unified-turn auxiliary cortex runs that share correlation_id with harness motor.
+    "stance_react",
     "harness_finalize_reflect",
     "orion_voice_finalize",
 })

--- a/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
+++ b/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
@@ -42,9 +42,19 @@ def test_trace_id_stable_for_node_and_correlation() -> None:
 def test_trace_lane_isolates_harness_finalize_verbs() -> None:
     from app.grammar_emit import trace_lane_for_verb
 
+    assert trace_lane_for_verb("stance_react") == "stance_react"
     assert trace_lane_for_verb("harness_finalize_reflect") == "harness_finalize_reflect"
     assert trace_lane_for_verb("orion_voice_finalize") == "orion_voice_finalize"
     assert trace_lane_for_verb("chat_general") is None
+
+    stance = CortexExecGrammarCollector(
+        node_name=NODE,
+        correlation_id=CORR,
+        code_version="0.2.0",
+        observed_at=FIXED_OBS,
+        trace_lane="stance_react",
+    )
+    assert stance.trace_id == f"cortex.exec:{NODE}:{CORR}:stance_react"
 
     collector = CortexExecGrammarCollector(
         node_name=NODE,

--- a/tests/test_execution_substrate_reducer.py
+++ b/tests/test_execution_substrate_reducer.py
@@ -404,6 +404,49 @@ def test_reducer_noops_harness_fcc_step_in_mixed_batch() -> None:
     assert proj.runs[TRACE].started_step_count == 1
 
 
+def test_stance_react_lane_does_not_merge_with_primary_motor_trace() -> None:
+    intake = _harness_atom(
+        "exec_request_received",
+        "Harness exec received plan request for verb=orion_unified, mode=orion, steps=0",
+        event_id="motor-intake",
+    )
+    assembled = _harness_atom(
+        "exec_result_assembled",
+        "Result assembled: status=ok, final_text_present=true, reasoning_present=true, thinking_source=harness_fcc",
+        event_id="motor-assembled",
+    )
+    stance_trace = f"{TRACE}:stance_react"
+    stance = GrammarEventV1(
+        event_id="stance-intake",
+        event_kind="atom_emitted",
+        trace_id=stance_trace,
+        emitted_at=FIXED_TS,
+        atom=GrammarAtomV1(
+            atom_id=f"{stance_trace}:exec_request_received",
+            trace_id=stance_trace,
+            atom_type="observation",
+            semantic_role="exec_request_received",
+            layer="intake",
+            summary="Cortex exec received plan request for verb=stance_react, mode=brain, steps=1",
+        ),
+        provenance=GrammarProvenanceV1(source_service="orion-cortex-exec"),
+    )
+    proj, _ = reduce_execution_trace_events(
+        events=[stance],
+        projection=_empty_projection(),
+        now=FIXED_TS,
+    )
+    proj, _ = reduce_execution_trace_events(
+        events=[intake, assembled],
+        projection=proj,
+        now=FIXED_TS,
+    )
+    assert set(proj.runs) == {TRACE, stance_trace}
+    assert proj.runs[TRACE].verb == "orion_unified"
+    assert proj.runs[TRACE].reasoning_present is True
+    assert proj.runs[stance_trace].verb == "stance_react"
+
+
 def test_isolated_lane_trace_does_not_merge_with_primary_motor_trace() -> None:
     primary = _harness_atom(
         "exec_result_assembled",


### PR DESCRIPTION
Thought stance_react grammar shared atom_ids with harness motor lifecycle on the primary cortex.exec trace, so sql-writer dedup dropped harness exec_request_received and exec_result_assembled atoms.