### PR TITLE
fix(thought): pubsub resilience for stance_react RPC delivery

### DIFF
--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -248,26 +248,22 @@ async def execute_unified_turn(
     from scripts.harness_governor_client import HarnessGovernorClient
     from scripts.thought_client import ThoughtClient
 
-    surface_context = payload.get("surface_context") if isinstance(payload.get("surface_context"), dict) else {}
-    surface_context = {**surface_context, "hub_chat_lane": "orion"}
     stance_req = StanceReactRequestV1(
         correlation_id=correlation_id,
         session_id=session_id,
         user_message=user_message,
         association=association,
         repair_bundle=repair_bundle,
-        stance_inputs={
-            "user_message": user_message,
-            "surface_context": surface_context,
-        },
+        stance_inputs={"user_message": user_message},
     )
-    thought = await ThoughtClient(bus).react(stance_req, correlation_id=correlation_id)
+    react_result = await ThoughtClient(bus).react(stance_req, correlation_id=correlation_id)
+    thought = react_result.thought
     if thought is None:
         return [
             {
                 "type": "turn_deferred",
                 "correlation_id": correlation_id,
-                "reason": "stance_react_timeout",
+                "reason": react_result.failure_reason or "stance_react_timeout",
             }
         ]
     if thought.disposition in ("defer", "refuse"):

--- a/services/orion-bus/README.md
+++ b/services/orion-bus/README.md
@@ -48,6 +48,19 @@ make logs
 make down
 ```
 
+### Redis pubsub output buffers
+
+`bus-core` sets a raised pubsub client output buffer limit so slow subscribers are less
+likely to be disconnected by Redis during long RPC handlers:
+
+```text
+client-output-buffer-limit pubsub 64mb 32mb 120
+```
+
+If production uses an external Redis (for example the Tailscale-hosted bus node), apply
+the same setting in `redis.conf` and restart Redis there. Recreating only the compose
+`bus-core` container does not change an external broker.
+
 ---
 
 ## 🔍 Monitoring

--- a/services/orion-bus/docker-compose.yml
+++ b/services/orion-bus/docker-compose.yml
@@ -7,7 +7,19 @@ services:
   bus-core:
     image: redis:7-alpine
     container_name: orion-${PROJECT}-bus-core
-    command: ["redis-server", "--appendonly", "yes", "--maxmemory-policy", "allkeys-lru"]
+    command:
+      [
+        "redis-server",
+        "--appendonly",
+        "yes",
+        "--maxmemory-policy",
+        "allkeys-lru",
+        "--client-output-buffer-limit",
+        "pubsub",
+        "64mb",
+        "32mb",
+        "120",
+      ]
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:

--- a/services/orion-bus/tests/test_redis_pubsub_buffer_config.py
+++ b/services/orion-bus/tests/test_redis_pubsub_buffer_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def test_bus_core_redis_pubsub_output_buffer_limit() -> None:
+    compose_path = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+    doc = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    command = doc["services"]["bus-core"]["command"]
+    assert "redis-server" in command
+    idx = command.index("--client-output-buffer-limit")
+    assert command[idx : idx + 5] == [
+        "--client-output-buffer-limit",
+        "pubsub",
+        "64mb",
+        "32mb",
+        "120",
+    ]

--- a/services/orion-hub/scripts/thought_client.py
+++ b/services/orion-hub/scripts/thought_client.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
+from dataclasses import dataclass
 from typing import Optional
 
 from orion.core.bus.async_service import OrionBusAsync
@@ -10,6 +12,60 @@ from orion.schemas.thought import StanceReactRequestV1, ThoughtEventV1
 from scripts.settings import settings
 
 logger = logging.getLogger("hub.bus.thought")
+
+_THOUGHT_SUBSCRIBER_WAIT_ATTEMPTS = 3
+_THOUGHT_SUBSCRIBER_WAIT_SEC = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class ThoughtReactResult:
+    thought: ThoughtEventV1 | None = None
+    failure_reason: str | None = None
+
+
+async def _thought_request_subscribers(bus: OrionBusAsync, channel: str) -> int:
+    """Return subscriber count for channel, or -1 when the probe itself fails."""
+    try:
+        pairs = await bus.redis.pubsub_numsub(channel)
+    except Exception as exc:  # noqa: BLE001 — probe must not fail the turn
+        logger.warning("thought subscriber probe failed channel=%s err=%s", channel, exc)
+        return -1
+    for name, count in pairs:
+        key = name.decode() if isinstance(name, bytes) else str(name)
+        if key == channel:
+            return int(count)
+    return 0
+
+
+async def _wait_for_thought_subscriber(
+    bus: OrionBusAsync,
+    channel: str,
+    *,
+    correlation_id: str,
+) -> bool:
+    saw_zero_subscribers = False
+    for attempt in range(_THOUGHT_SUBSCRIBER_WAIT_ATTEMPTS):
+        subs = await _thought_request_subscribers(bus, channel)
+        if subs > 0:
+            return True
+        if subs < 0:
+            logger.warning(
+                "[%s] thought subscriber probe failed attempt=%s/%s; proceeding fail-open",
+                correlation_id,
+                attempt + 1,
+                _THOUGHT_SUBSCRIBER_WAIT_ATTEMPTS,
+            )
+            return True
+        saw_zero_subscribers = True
+        logger.warning(
+            "[%s] thought request channel has no subscriber attempt=%s/%s",
+            correlation_id,
+            attempt + 1,
+            _THOUGHT_SUBSCRIBER_WAIT_ATTEMPTS,
+        )
+        if attempt + 1 < _THOUGHT_SUBSCRIBER_WAIT_ATTEMPTS:
+            await asyncio.sleep(_THOUGHT_SUBSCRIBER_WAIT_SEC)
+    return not saw_zero_subscribers
 
 
 class ThoughtClient:
@@ -23,7 +79,7 @@ class ThoughtClient:
         *,
         correlation_id: Optional[str] = None,
         timeout_sec: float | None = None,
-    ) -> ThoughtEventV1 | None:
+    ) -> ThoughtReactResult:
         correlation_id = correlation_id or request.correlation_id or str(uuid.uuid4())
         reply_to = f"{settings.CHANNEL_THOUGHT_RESULT_PREFIX}{correlation_id}"
         wait_sec = max(0.1, float(timeout_sec if timeout_sec is not None else settings.TIMEOUT_SEC))
@@ -34,6 +90,13 @@ class ThoughtClient:
             reply_to=reply_to,
             payload=request.model_dump(mode="json"),
         )
+        if not await _wait_for_thought_subscriber(
+            self.bus,
+            settings.CHANNEL_THOUGHT_REQUEST,
+            correlation_id=correlation_id,
+        ):
+            logger.warning("[%s] thought RPC skipped: no subscriber on request channel", correlation_id)
+            return ThoughtReactResult(failure_reason="thought_no_subscriber")
         try:
             msg = await self.bus.rpc_request(
                 settings.CHANNEL_THOUGHT_REQUEST,
@@ -43,19 +106,19 @@ class ThoughtClient:
             )
         except TimeoutError:
             logger.warning("[%s] thought RPC timeout", correlation_id)
-            return None
+            return ThoughtReactResult(failure_reason="stance_react_timeout")
         decoded = self.bus.codec.decode(msg.get("data"))
         if not decoded.ok:
-            return None
+            return ThoughtReactResult(failure_reason="thought_rpc_decode_failed")
         if decoded.envelope.kind == "system.error":
             payload = decoded.envelope.payload
             detail = payload.get("details") if isinstance(payload, dict) else payload
             logger.warning("[%s] thought RPC system.error detail=%s", correlation_id, detail)
-            return None
+            return ThoughtReactResult(failure_reason="thought_rpc_system_error")
         payload = decoded.envelope.payload
         if isinstance(payload, dict) and payload.get("error"):
             logger.warning("[%s] thought RPC error payload=%s", correlation_id, payload.get("error"))
-            return None
+            return ThoughtReactResult(failure_reason="thought_rpc_error_payload")
         if isinstance(payload, dict):
-            return ThoughtEventV1.model_validate(payload)
-        return None
+            return ThoughtReactResult(thought=ThoughtEventV1.model_validate(payload))
+        return ThoughtReactResult(failure_reason="thought_rpc_empty_payload")

--- a/services/orion-hub/scripts/unified_turn_stub.py
+++ b/services/orion-hub/scripts/unified_turn_stub.py
@@ -42,8 +42,8 @@ async def run_orion_unified_turn_stub(
             stance_inputs={"user_message": user_message},
         )
         try:
-            thought = await ThoughtClient(bus).react(stance_req, correlation_id=correlation_id)
-            thought_received = thought is not None
+            react_result = await ThoughtClient(bus).react(stance_req, correlation_id=correlation_id)
+            thought_received = react_result.thought is not None
         except Exception:
             logger.debug("unified turn stub thought RPC failed", exc_info=True)
     return {

--- a/services/orion-hub/tests/test_thought_client.py
+++ b/services/orion-hub/tests/test_thought_client.py
@@ -42,7 +42,7 @@ from orion.schemas.thought import (
     ThoughtEventV1,
 )
 from scripts.settings import settings
-from scripts.thought_client import ThoughtClient
+from scripts.thought_client import ThoughtClient, ThoughtReactResult
 
 
 _CORR_ID = "00000000-0000-4000-8000-000000000101"
@@ -86,6 +86,7 @@ def _thought_event() -> ThoughtEventV1:
 async def test_thought_client_react_returns_thought_event() -> None:
     bus = MagicMock()
     thought = _thought_event()
+    bus.redis.pubsub_numsub = AsyncMock(return_value=[(settings.CHANNEL_THOUGHT_REQUEST, 1)])
     bus.codec.decode.return_value = MagicMock(
         ok=True,
         envelope=BaseEnvelope(
@@ -100,8 +101,8 @@ async def test_thought_client_react_returns_thought_event() -> None:
 
     result = await client.react(_stance_request())
 
-    assert result is not None
-    assert result.event_id == "t-1"
+    assert result.thought is not None
+    assert result.thought.event_id == "t-1"
     bus.rpc_request.assert_awaited_once()
     call_kwargs = bus.rpc_request.await_args.kwargs
     assert call_kwargs["reply_channel"] == f"{settings.CHANNEL_THOUGHT_RESULT_PREFIX}{_CORR_ID}"
@@ -113,9 +114,81 @@ async def test_thought_client_react_returns_thought_event() -> None:
 @pytest.mark.asyncio
 async def test_thought_client_react_timeout_returns_none() -> None:
     bus = MagicMock()
+    bus.redis.pubsub_numsub = AsyncMock(return_value=[(settings.CHANNEL_THOUGHT_REQUEST, 1)])
     bus.rpc_request = AsyncMock(side_effect=TimeoutError())
     client = ThoughtClient(bus)
 
     result = await client.react(_stance_request(), timeout_sec=0.2)
 
-    assert result is None
+    assert result.thought is None
+    assert result.failure_reason == "stance_react_timeout"
+
+
+@pytest.mark.asyncio
+async def test_thought_client_react_waits_for_subscriber(monkeypatch) -> None:
+    bus = MagicMock()
+    thought = _thought_event()
+    bus.codec.decode.return_value = MagicMock(
+        ok=True,
+        envelope=BaseEnvelope(
+            kind="thought.event.v1",
+            source=ServiceRef(name="orion-thought", version="0.1.0"),
+            correlation_id=_CORR_ID,
+            payload=thought.model_dump(mode="json"),
+        ),
+    )
+    bus.rpc_request = AsyncMock(return_value={"data": b"x"})
+    bus.redis.pubsub_numsub = AsyncMock(
+        side_effect=[
+            [(settings.CHANNEL_THOUGHT_REQUEST, 0)],
+            [(settings.CHANNEL_THOUGHT_REQUEST, 0)],
+            [(settings.CHANNEL_THOUGHT_REQUEST, 1)],
+        ]
+    )
+    monkeypatch.setattr("scripts.thought_client._THOUGHT_SUBSCRIBER_WAIT_SEC", 0.0)
+    client = ThoughtClient(bus)
+
+    result = await client.react(_stance_request())
+
+    assert result.thought is not None
+    assert bus.redis.pubsub_numsub.await_count == 3
+    bus.rpc_request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_thought_client_react_skips_rpc_when_no_subscriber(monkeypatch) -> None:
+    bus = MagicMock()
+    bus.redis.pubsub_numsub = AsyncMock(return_value=[(settings.CHANNEL_THOUGHT_REQUEST, 0)])
+    bus.rpc_request = AsyncMock()
+    monkeypatch.setattr("scripts.thought_client._THOUGHT_SUBSCRIBER_WAIT_SEC", 0.0)
+    client = ThoughtClient(bus)
+
+    result = await client.react(_stance_request(), timeout_sec=0.2)
+
+    assert result.thought is None
+    assert result.failure_reason == "thought_no_subscriber"
+    assert bus.redis.pubsub_numsub.await_count == 3
+    bus.rpc_request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_thought_client_react_proceeds_when_subscriber_probe_fails() -> None:
+    bus = MagicMock()
+    thought = _thought_event()
+    bus.redis.pubsub_numsub = AsyncMock(side_effect=ConnectionError("redis down"))
+    bus.codec.decode.return_value = MagicMock(
+        ok=True,
+        envelope=BaseEnvelope(
+            kind="thought.event.v1",
+            source=ServiceRef(name="orion-thought", version="0.1.0"),
+            correlation_id=_CORR_ID,
+            payload=thought.model_dump(mode="json"),
+        ),
+    )
+    bus.rpc_request = AsyncMock(return_value={"data": b"x"})
+    client = ThoughtClient(bus)
+
+    result = await client.react(_stance_request())
+
+    assert result.thought is not None
+    bus.rpc_request.assert_awaited_once()

--- a/services/orion-thought/app/bus_listener.py
+++ b/services/orion-thought/app/bus_listener.py
@@ -35,6 +35,40 @@ logger = logging.getLogger("orion-thought.bus")
 # but PUBSUB NUMSUB returns 0 — hub RPC then hangs until timeout and the message
 # is lost (pubsub is not durable).
 _PUBSUB_IDLE_POLLS_BEFORE_HEALTH = 30
+_HANDLER_DRAIN_TIMEOUT_SEC = 120.0
+
+_pending_handler_tasks: set[asyncio.Task[None]] = set()
+
+
+async def _run_bus_message_handler(raw_msg: dict[str, Any]) -> None:
+    """Handle one request on a dedicated bus connection so pubsub can keep draining."""
+    bus = OrionBusAsync(url=settings.orion_bus_url)
+    try:
+        await bus.connect()
+        await _handle_bus_message(bus, raw_msg)
+    except Exception:
+        logger.exception("bus message handler failed")
+    finally:
+        with suppress(Exception):
+            await bus.close()
+
+
+def _dispatch_bus_message(raw_msg: dict[str, Any]) -> None:
+    task = asyncio.create_task(_run_bus_message_handler(raw_msg))
+    _pending_handler_tasks.add(task)
+    task.add_done_callback(_pending_handler_tasks.discard)
+
+
+async def _drain_pending_handler_tasks(*, timeout_sec: float = _HANDLER_DRAIN_TIMEOUT_SEC) -> None:
+    if not _pending_handler_tasks:
+        return
+    pending = set(_pending_handler_tasks)
+    done, still = await asyncio.wait(pending, timeout=timeout_sec)
+    if still:
+        for task in still:
+            task.cancel()
+        await asyncio.gather(*still, return_exceptions=True)
+    _ = done
 
 
 async def _thought_channel_subscribers(bus: OrionBusAsync, channel: str) -> int:
@@ -288,6 +322,7 @@ async def run_bus_worker(stop_event: asyncio.Event | None = None) -> None:
 
     while True:
         if stop_event is not None and stop_event.is_set():
+            await asyncio.shield(_drain_pending_handler_tasks())
             return
 
         bus = OrionBusAsync(url=settings.orion_bus_url)
@@ -300,7 +335,7 @@ async def run_bus_worker(stop_event: asyncio.Event | None = None) -> None:
                 backoff_sec = 1.0
                 while True:
                     if stop_event is not None and stop_event.is_set():
-                        return
+                        break
                     try:
                         msg = await asyncio.wait_for(
                             pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
@@ -332,7 +367,7 @@ async def run_bus_worker(stop_event: asyncio.Event | None = None) -> None:
                         continue
                     idle_polls = 0
                     try:
-                        await _handle_bus_message(bus, msg)
+                        _dispatch_bus_message(msg)
                     except Exception:
                         logger.exception("unhandled bus worker error")
         except asyncio.CancelledError:
@@ -341,6 +376,8 @@ async def run_bus_worker(stop_event: asyncio.Event | None = None) -> None:
             logger.exception("bus worker disconnect channel=%s", channel)
             reconnect = True
         finally:
+            if stop_event is not None and stop_event.is_set():
+                await asyncio.shield(_drain_pending_handler_tasks())
             with suppress(Exception):
                 await bus.close()
 

--- a/services/orion-thought/app/main.py
+++ b/services/orion-thought/app/main.py
@@ -41,7 +41,13 @@ async def lifespan(app: FastAPI):
     app.state.bus_stop_event.set()
     app.state.reverie_stop_event.set()
     app.state.reverie_chain_stop_event.set()
-    for task in (app.state.bus_task, app.state.reverie_task, app.state.reverie_chain_task):
+    with suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(app.state.bus_task, timeout=125.0)
+    if not app.state.bus_task.done():
+        app.state.bus_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await app.state.bus_task
+    for task in (app.state.reverie_task, app.state.reverie_chain_task):
         task.cancel()
         with suppress(asyncio.CancelledError):
             await task

--- a/services/orion-thought/tests/test_bus_listener_nonblocking_dispatch.py
+++ b/services/orion-thought/tests/test_bus_listener_nonblocking_dispatch.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app import bus_listener
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending_handler_tasks() -> None:
+    bus_listener._pending_handler_tasks.clear()
+    yield
+    bus_listener._pending_handler_tasks.clear()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_bus_message_runs_handler_in_background() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_handler(raw_msg: dict) -> None:
+        started.set()
+        await release.wait()
+
+    original = bus_listener._run_bus_message_handler
+    bus_listener._run_bus_message_handler = slow_handler  # type: ignore[assignment]
+    try:
+        bus_listener._dispatch_bus_message({"data": b"x"})
+        await asyncio.sleep(0)
+        assert started.is_set()
+        assert bus_listener._pending_handler_tasks
+        release.set()
+        await bus_listener._drain_pending_handler_tasks(timeout_sec=1.0)
+        assert not bus_listener._pending_handler_tasks
+    finally:
+        bus_listener._run_bus_message_handler = original
+
+
+@pytest.mark.asyncio
+async def test_drain_pending_handler_tasks_waits_for_in_flight_work() -> None:
+    release = asyncio.Event()
+
+    async def slow_handler(raw_msg: dict) -> None:
+        await release.wait()
+
+    original = bus_listener._run_bus_message_handler
+    bus_listener._run_bus_message_handler = slow_handler  # type: ignore[assignment]
+    try:
+        bus_listener._dispatch_bus_message({"data": b"x"})
+        await asyncio.sleep(0)
+        assert bus_listener._pending_handler_tasks
+        release.set()
+        await bus_listener._drain_pending_handler_tasks(timeout_sec=1.0)
+        assert not bus_listener._pending_handler_tasks
+    finally:
+        bus_listener._run_bus_message_handler = original


### PR DESCRIPTION
## Summary

- Raised Redis pubsub client output buffer limits in `orion-bus` compose (`64mb / 32mb / 120s`).
- Thought bus worker now dispatches stance handlers as background tasks with dedicated bus connections so the pubsub read loop keeps draining during 30–120s `stance_react`.
- Hub `ThoughtClient.react()` waits up to 3×1s for a thought subscriber before RPC; skips publish on confirmed zero subs; fail-open on probe errors.
- Turn orchestrator now surfaces distinct defer reasons (`thought_no_subscriber` vs `stance_react_timeout`).

## Outcome moved

Intermittent `Turn deferred: stance_react_timeout` caused by Redis killing the thought pubsub client during long stance handling (output buffer overrun while read loop blocked).

## Current architecture

Hub publishes `stance.react.request.v1` to `orion:thought:request` and waits on a per-correlation reply channel. Thought's bus worker subscribed via pubsub and **awaited** the full stance pipeline inline, starving `get_message` during long cortex RPC. Redis disconnected slow subscribers; hub then hung 400s with no reply.

## Architecture touched

- `services/orion-bus` — Redis compose tuning + README rollout note
- `services/orion-thought` — non-blocking dispatch, graceful shutdown drain
- `services/orion-hub` — subscriber-gated thought RPC + structured `ThoughtReactResult`
- `orion/hub/turn_orchestrator.py` — distinct defer reasons

## Files changed

- `services/orion-bus/docker-compose.yml`: pubsub output buffer limit
- `services/orion-bus/README.md`: external Redis rollout note
- `services/orion-bus/tests/test_redis_pubsub_buffer_config.py`: compose contract test
- `services/orion-thought/app/bus_listener.py`: background handler dispatch + shielded drain
- `services/orion-thought/app/main.py`: graceful bus worker shutdown (await drain before cancel)
- `services/orion-thought/tests/test_bus_listener_nonblocking_dispatch.py`: dispatch/drain tests
- `services/orion-hub/scripts/thought_client.py`: subscriber wait + `ThoughtReactResult`
- `services/orion-hub/tests/test_thought_client.py`: subscriber gate + fail-open tests
- `orion/hub/turn_orchestrator.py`: map failure reasons to turn defer frames
- `services/orion-hub/scripts/unified_turn_stub.py`: adapt to `ThoughtReactResult`

## Schema / bus / API changes

- Added: `ThoughtReactResult` dataclass (hub client return type)
- Behavior changed: `ThoughtClient.react()` returns `ThoughtReactResult` instead of `ThoughtEventV1 | None`
- Behavior changed: turn defer reason may be `thought_no_subscriber` (new) or `stance_react_timeout`
- Compatibility notes: only `turn_orchestrator` and `unified_turn_stub` call sites updated

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no
- local `.env` synced: N/A

## Tests run

```text
PYTHONPATH=services/orion-bus:. pytest services/orion-bus/tests/test_redis_pubsub_buffer_config.py -q  → 1 passed
PYTHONPATH=services/orion-thought:. pytest services/orion-thought/tests/test_bus_listener_nonblocking_dispatch.py services/orion-thought/tests/test_bus_listener_pubsub_health.py services/orion-thought/tests/test_bus_listener_errors.py -q  → 6 passed
PYTHONPATH=services/orion-hub:. pytest services/orion-hub/tests/test_thought_client.py -q  → 5 passed
```

## Evals run

```text
None (infra/listener seam; gate tests only)
```

## Docker/build/smoke checks

```text
Not run in CI agent environment. Compose config change validated by unit test.
```

## Review findings fixed

- Finding: Hub fail-closed on `PUBSUB NUMSUB` probe errors
  - Fix: fail-open when `subs < 0`
  - Evidence: `test_thought_client_react_proceeds_when_subscriber_probe_fails`

- Finding: Shutdown drain cut short by task cancellation
  - Fix: `asyncio.shield` on drain; inner loop `break` not `return`; main awaits bus worker before cancel
  - Evidence: `main.py` lifespan + `bus_listener.py` stop path

- Finding: Skipped RPC and timeout shared same defer reason
  - Fix: `ThoughtReactResult.failure_reason` propagated to orchestrator
  - Evidence: `test_thought_client_react_skips_rpc_when_no_subscriber` asserts `thought_no_subscriber`

- Finding: External Redis buffer not documented
  - Fix: `services/orion-bus/README.md` rollout note
  - Evidence: README section added

## Restart required

```bash
# Layer 1 — if using compose bus-core (recreate for redis-server args)
docker compose --env-file .env --env-file services/orion-bus/.env \
  -f services/orion-bus/docker-compose.yml up -d --force-recreate bus-core

# If production uses Tailscale-hosted Redis, apply equivalent buffer limit there and restart Redis manually.

# Layers 2 & 3
docker compose --env-file .env --env-file services/orion-thought/.env \
  -f services/orion-thought/docker-compose.yml up -d --build

docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: Unbounded concurrent stance handlers under burst (each spawns task + Redis connection)
- Mitigation: acceptable for current single-operator turn rate; semaphore follow-up if needed