### PR TITLE
fix(embodiment): suppress repeated town speech

### DIFF
--- a/PR_embodiment_speech_repeat_guard.md
+++ b/PR_embodiment_speech_repeat_guard.md
@@ -1,0 +1,101 @@
+## Summary
+
+- Added normalized town-speech repeat detection for AI Town Orion utterances.
+- Taught the embodiment worker to compare a candidate reply against both the in-memory last injected line and Orion's latest transcript line.
+- Blocked punctuation/case/spacing-only repeats before AI Town message injection.
+- Added regression tests for same-process repeats, post-restart transcript repeats, and stale-memory transcript precedence.
+- Seeded the embodiment arbitration eval's `__new__` worker with the fields its process-intent path uses.
+
+## Outcome moved
+
+Orion no longer injects the same canned AI Town line over and over when the model returns an unchanged reply to later partner turns.
+
+## Current architecture
+
+`orion-embodiment` polls AI Town, shapes `WorldPerceptionV1`, gates speech in `_speak_once`, requests an utterance from cortex, and injects it via `startTyping` plus `messages:writeMessage`. Before this patch, speech avoided empty replies and obvious self-echo when Orion authored the last town message, but it did not reject a repeated generated line after a newer partner response.
+
+## Architecture touched
+
+Service: `services/orion-embodiment`
+
+Runtime seam changed: town speech injection gate only. No bus, schema, API, dependency, Docker, or env contract changes.
+
+## Files changed
+
+- `orion/embodiment/speech.py`: added normalized utterance comparison helpers.
+- `orion/embodiment/tests/test_speech.py`: covered whitespace/case/punctuation repeat normalization.
+- `services/orion-embodiment/app/worker.py`: tracked last injected line per conversation and compared candidate replies against memory plus transcript before injection.
+- `services/orion-embodiment/tests/test_worker_speech.py`: added repeated-reply regression coverage.
+- `services/orion-embodiment/evals/test_embodiment_arbitration_eval.py`: completed `__new__` worker field seeding used by the eval path.
+
+## Schema / bus / API changes
+
+- Added: none
+- Removed: none
+- Renamed: none
+- Behavior changed: repeated AI Town speech candidates are skipped before injection.
+- Compatibility notes: no payload shape or channel changes.
+
+## Env/config changes
+
+- Added keys: none
+- Removed keys: none
+- Renamed keys: none
+- `.env_example` updated: no
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not required; no `.env_example` changed
+- skipped keys requiring operator action: none
+
+## Tests run
+
+```text
+venv/bin/python -m pytest orion/embodiment/tests -q
+70 passed
+
+venv/bin/python -m pytest services/orion-embodiment/tests -q
+62 passed
+
+git diff --check
+passed
+```
+
+## Evals run
+
+```text
+venv/bin/python -m pytest services/orion-embodiment/evals -q
+1 passed
+```
+
+## Docker/build/smoke checks
+
+```text
+docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml config
+passed
+
+docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml build
+passed
+```
+
+## Review findings fixed
+
+- Finding: Repeat detection preferred stale in-memory state over a newer transcript line.
+  - Fix: compare candidate replies against both in-memory and transcript last-spoken text.
+  - Evidence: `test_repeated_reply_checks_transcript_even_with_stale_memory`; `services/orion-embodiment/tests` passed.
+- Finding: punctuation-only variants could repeat.
+  - Fix: normalize punctuation out for repeat comparison.
+  - Evidence: `test_repeated_utterance_normalizes_case_and_spacing`; `orion/embodiment/tests` passed.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: Low
+- Concern: This blocks exact normalized repeats only, not paraphrased canned variants.
+- Mitigation: The guard is deterministic and narrow; paraphrase-level suppression can be added later with a small similarity threshold if live traces show that pattern.
+
+## PR link
+
+TBD after push/PR creation.

--- a/PR_embodiment_speech_repeat_guard.md
+++ b/PR_embodiment_speech_repeat_guard.md
@@ -98,4 +98,4 @@ docker compose --env-file .env --env-file services/orion-embodiment/.env -f serv
 
 ## PR link
 
-TBD after push/PR creation.
+https://github.com/junebug-junie/Orion-Sapienform/pull/917

--- a/orion/embodiment/speech.py
+++ b/orion/embodiment/speech.py
@@ -6,6 +6,7 @@ decide *whether* Orion should speak, *what* to prompt the cortex with, and
 """
 from __future__ import annotations
 
+import re
 from typing import Any, Optional
 
 from orion.schemas.embodiment import WorldPerceptionV1
@@ -82,3 +83,18 @@ def build_speech_prompt(perception: WorldPerceptionV1, own_player_id: str) -> st
 def is_injectable(reply_text: Optional[str]) -> bool:
     """Anti empty-shell guard: only non-empty, non-whitespace replies are injectable."""
     return bool(reply_text and str(reply_text).strip())
+
+
+def normalize_utterance(reply_text: Optional[str]) -> str:
+    """Normalize an utterance for repeat detection without changing injected text."""
+    text = str(reply_text or "").strip().lower()
+    text = re.sub(r"[^\w\s]", "", text)
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+def is_repeated_utterance(reply_text: Optional[str], previous_reply_text: Optional[str]) -> bool:
+    """True when a candidate would repeat the last injected line for a conversation."""
+    current = normalize_utterance(reply_text)
+    previous = normalize_utterance(previous_reply_text)
+    return bool(current and previous and current == previous)

--- a/orion/embodiment/tests/test_speech.py
+++ b/orion/embodiment/tests/test_speech.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from orion.embodiment.speech import build_speech_prompt, is_injectable, should_speak
+from orion.embodiment.speech import (
+    build_speech_prompt,
+    is_injectable,
+    is_repeated_utterance,
+    should_speak,
+)
 from orion.schemas.embodiment import WorldPerceptionV1
 
 
@@ -46,3 +51,10 @@ def test_is_injectable_rejects_empty_and_whitespace():
     assert is_injectable("") is False
     assert is_injectable("   \n  ") is False
     assert is_injectable(None) is False  # type: ignore[arg-type]
+
+
+def test_repeated_utterance_normalizes_case_and_spacing():
+    assert is_repeated_utterance("  I am with you.\n", "i am  with you.") is True
+    assert is_repeated_utterance("I am with you", "I am with you.") is True
+    assert is_repeated_utterance("I hear you.", "Tell me more.") is False
+    assert is_repeated_utterance("", "i am with you.") is False

--- a/services/orion-embodiment/app/worker.py
+++ b/services/orion-embodiment/app/worker.py
@@ -22,7 +22,12 @@ from orion.embodiment.worldmap import walkable_tiles
 from orion.embodiment.perception import build_perception
 from orion.embodiment.resolver import resolve_destination
 from orion.embodiment.salience import SalienceState, evaluate_salience
-from orion.embodiment.speech import build_speech_prompt, is_injectable, should_speak
+from orion.embodiment.speech import (
+    build_speech_prompt,
+    is_injectable,
+    is_repeated_utterance,
+    should_speak,
+)
 from orion.journaler.schemas import JournalTriggerV1
 from orion.schemas.embodiment import (
     EMBODIMENT_OUTCOME_KIND,
@@ -77,6 +82,7 @@ class EmbodimentWorker:
         # idle-wander loop) so the move-cooldown read-then-write cannot double-fire.
         self._actuate_lock = asyncio.Lock()
         self._speaking_conversations: set[str] = set()
+        self._last_spoken_by_conversation: dict[str, str] = {}
         # Conversations Orion has already opened (spoken first in). Guards the
         # "no messages yet -> open" speech path so a persistently failing message
         # fetch (which looks like an empty transcript) can't re-trigger an opener
@@ -102,6 +108,22 @@ class EmbodimentWorker:
         # or unavailable -> resolver falls back to unconstrained wander.
         self._walkable: Optional[set[tuple[int, int]]] = None
         self._walkable_loaded = False
+
+    @staticmethod
+    def _last_own_message_text(messages: list, own_player_id: str) -> Optional[str]:
+        """Return Orion's latest transcript line, if the town message author is known."""
+        own = str(own_player_id or "").strip()
+        if not own:
+            return None
+        for message in reversed(messages or []):
+            if not isinstance(message, dict):
+                continue
+            author_id = str(message.get("author_id") or "").strip()
+            author = str(message.get("author") or "").strip().lower()
+            if author_id == own or author == "orion":
+                text = str(message.get("text") or "").strip()
+                return text or None
+        return None
 
     def _walkable_tiles(self) -> Optional[set[tuple[int, int]]]:
         """Fail-open, cached walkable set from the AI Town map. Fetched once."""
@@ -754,6 +776,13 @@ class EmbodimentWorker:
             if not is_injectable(reply):
                 logger.info("embodiment_speech_empty_reply_skipped convo=%s", convo_id)
                 return None
+            memory_last_spoken = getattr(self, "_last_spoken_by_conversation", {}).get(convo_id)
+            transcript_last_spoken = self._last_own_message_text(messages, own)
+            if is_repeated_utterance(reply, memory_last_spoken) or is_repeated_utterance(
+                reply, transcript_last_spoken
+            ):
+                logger.info("embodiment_speech_repeat_reply_skipped convo=%s", convo_id)
+                return None
 
             try:
                 await asyncio.to_thread(self._inject_utterance, own, convo_id, reply)
@@ -769,6 +798,9 @@ class EmbodimentWorker:
                 self._active_conversation_utterances = (
                     getattr(self, "_active_conversation_utterances", 0) + 1
                 )
+            if not hasattr(self, "_last_spoken_by_conversation"):
+                self._last_spoken_by_conversation = {}
+            self._last_spoken_by_conversation[convo_id] = reply
             return reply
         finally:
             self._speaking_conversations.discard(convo_id)

--- a/services/orion-embodiment/evals/test_embodiment_arbitration_eval.py
+++ b/services/orion-embodiment/evals/test_embodiment_arbitration_eval.py
@@ -55,7 +55,11 @@ def _worker() -> EmbodimentWorker:
     w._wander_radius = 3.0
     w._locations = {}
     w._social_cooldown_sec = 120.0
+    w._move_cooldown_sec = 0.0
     w._last_conversation_start = None
+    w._last_move_at = None
+    w._walkable = None
+    w._walkable_loaded = False
     return w
 
 

--- a/services/orion-embodiment/tests/test_worker_speech.py
+++ b/services/orion-embodiment/tests/test_worker_speech.py
@@ -13,6 +13,7 @@ def _worker() -> EmbodimentWorker:
     w._orion_player_id = "orion"
     w._world_id = "w1"
     w._speaking_conversations = set()
+    w._last_spoken_by_conversation = {}
     w._opened_conversations = set()
     w._settings = SimpleNamespace(
         speech_enabled=True,
@@ -178,6 +179,61 @@ def test_speech_disabled_short_circuits():
     assert result is None
     req.assert_not_awaited()
     si.assert_not_called()
+
+
+def test_repeated_reply_is_not_injected_again():
+    w = _worker()
+    perc = _perception_in_convo()
+    replies = AsyncMock(side_effect=["I am with you.", "  i am   with you.  "])
+    with patch.object(w, "_request_utterance", new=replies), \
+         patch("app.worker.aitown_client.send_input", return_value={"ok": True}) as si, \
+         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}) as cm:
+        first = asyncio.run(w._speak_once(perc))
+        perc.active_conversation["messages"] = [
+            {"author_id": "p9", "author": "Juniper", "text": "hey Orion"},
+            {"author_id": "orion", "author": "Orion", "text": "I am with you."},
+            {"author_id": "p9", "author": "Juniper", "text": "are you still there?"},
+        ]
+        second = asyncio.run(w._speak_once(perc))
+    assert first == "I am with you."
+    assert second is None
+    assert si.call_count == 1
+    assert cm.call_count == 1
+
+
+def test_repeated_reply_matches_transcript_after_worker_restart():
+    w = _worker()
+    perc = _perception_in_convo()
+    perc.active_conversation["messages"] = [
+        {"author_id": "p9", "author": "Juniper", "text": "hey Orion"},
+        {"author_id": "orion", "author": "Orion", "text": "I am with you."},
+        {"author_id": "p9", "author": "Juniper", "text": "can you answer me?"},
+    ]
+    with patch.object(w, "_request_utterance", new=AsyncMock(return_value="i am   with you.")), \
+         patch("app.worker.aitown_client.send_input") as si, \
+         patch("app.worker.aitown_client.convex_mutation") as cm:
+        result = asyncio.run(w._speak_once(perc))
+    assert result is None
+    si.assert_not_called()
+    cm.assert_not_called()
+
+
+def test_repeated_reply_checks_transcript_even_with_stale_memory():
+    w = _worker()
+    w._last_spoken_by_conversation["conv1"] = "older line"
+    perc = _perception_in_convo()
+    perc.active_conversation["messages"] = [
+        {"author_id": "p9", "author": "Juniper", "text": "hey Orion"},
+        {"author_id": "orion", "author": "Orion", "text": "I am with you."},
+        {"author_id": "p9", "author": "Juniper", "text": "can you answer me?"},
+    ]
+    with patch.object(w, "_request_utterance", new=AsyncMock(return_value="I am with you")), \
+         patch("app.worker.aitown_client.send_input") as si, \
+         patch("app.worker.aitown_client.convex_mutation") as cm:
+        result = asyncio.run(w._speak_once(perc))
+    assert result is None
+    si.assert_not_called()
+    cm.assert_not_called()
 
 
 def test_heartbeat_logs_once_then_throttles():


### PR DESCRIPTION
Superseded and closed by root-cause work. This PR contained repeat-suppression guards, which were not the underlying fix for AI Town Orion failing to react to the latest partner text.

Replacement branch: `fix/embodiment-latest-line-grounding`.

Live verification showed the real issue was that `chat_quick` could see the transcript but still continue the repeated motif when the prompt emphasized the full repetition-heavy conversation. The replacement patch centers the latest partner line as the task and demotes recent context to reference-only text.