### PR TITLE
fix(embodiment): ground town speech on latest line

### DIFF
--- a/PR_embodiment_latest_line_grounding.md
+++ b/PR_embodiment_latest_line_grounding.md
@@ -1,0 +1,120 @@
+## Summary
+
+- Removed the repeat-suppression approach from the active patch.
+- Reworked AI Town speech prompting so the latest partner line is the primary task.
+- Demoted recent conversation history to short reference-only context to avoid motif-copying from repetition-heavy transcripts.
+- Added tests for latest-partner-line extraction, goodbye/departure handling, and the exact prompt passed to cortex.
+- Seeded the embodiment arbitration eval's `__new__` worker with the fields its process-intent path uses.
+
+## Outcome moved
+
+AI Town Orion is prompted to answer the latest partner text directly instead of continuing the strongest repeated motif in the recent transcript.
+
+## Current architecture
+
+`orion-embodiment` polls AI Town, shapes `WorldPerceptionV1`, gates speech in `_speak_once`, builds a speech prompt, requests a town utterance from cortex `chat_quick`, and injects it into AI Town via `startTyping` plus `messages:writeMessage`.
+
+Live verification showed the old prompt did include the latest partner text, but it presented the full repetition-heavy transcript before the instruction. `chat_quick` copied Orion's repeated motif instead of answering the latest partner line.
+
+## Architecture touched
+
+Service: `services/orion-embodiment`
+
+Runtime seam changed: speech prompt construction only. No bus, schema, API, dependency, Docker, or env contract changes.
+
+## Files changed
+
+- `orion/embodiment/speech.py`: added `latest_partner_line()`, reduced reference context to four lines, and made the latest partner line the top-level task.
+- `orion/embodiment/tests/test_speech.py`: added prompt-contract coverage for latest-line focus and departure handling.
+- `services/orion-embodiment/app/worker.py`: import formatting only after removing the discarded repeat-guard path.
+- `services/orion-embodiment/tests/test_worker_speech.py`: verifies `_speak_once()` sends a latest-line-centered prompt to cortex.
+- `services/orion-embodiment/evals/test_embodiment_arbitration_eval.py`: completes `__new__` worker field seeding used by the eval path.
+
+## Schema / bus / API changes
+
+- Added: none
+- Removed: none
+- Renamed: none
+- Behavior changed: town speech prompt now prioritizes the latest partner line over full transcript continuation.
+- Compatibility notes: no payload shape or channel changes.
+
+## Env/config changes
+
+- Added keys: none
+- Removed keys: none
+- Renamed keys: none
+- `.env_example` updated: no
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not required; no `.env_example` changed
+- skipped keys requiring operator action: none
+
+## Tests run
+
+```text
+venv/bin/python -m pytest orion/embodiment/tests -q
+71 passed
+
+venv/bin/python -m pytest services/orion-embodiment/tests -q
+60 passed
+
+venv/bin/python -m pytest orion/embodiment/tests/test_speech.py services/orion-embodiment/tests/test_worker_speech.py -q
+19 passed
+
+git diff --check
+passed
+```
+
+## Evals run
+
+```text
+venv/bin/python -m pytest services/orion-embodiment/evals -q
+1 passed
+```
+
+## Docker/build/smoke checks
+
+```text
+docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml config
+passed
+
+docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml build
+passed
+```
+
+## Live verification
+
+```text
+Before patch, read-only live cortex smoke with c:47964 prompt:
+reply="I'm still humming, but the crack's widening—let's see how far it goes."
+old_bad_line_repeated=true
+
+After patch, same conversation truncated to real turn-state before Orion's bad reply:
+corr=fd4943cd-f7a0-4416-a1cb-4e5969bdd5fa
+target_line="Gotta run before the system auto-corrects the glitch—catch you on the other side of the firewall."
+task_marker_present=true
+reply="I'm still here, just on the other side of the mesh—keep the wire tight."
+old_bad_line_repeated=false
+```
+
+No AI Town write/injection was performed during verification.
+
+## Review findings fixed
+
+- Finding: Initial repeat-guard patch did not fix the underlying grounding failure.
+  - Fix: closed PR #917 and replaced it with latest-line-centered prompt construction.
+  - Evidence: live read-only cortex smoke above.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: Medium
+- Concern: This fixes the verified motif-copying prompt failure for `chat_quick`, but does not address Convex `OptimisticConcurrencyControlFailure` injection failures seen in live logs.
+- Mitigation: file or follow with a separate write-path retry/backoff patch for `messages:writeMessage`.
+
+## PR link
+
+TBD after PR creation.

--- a/PR_embodiment_latest_line_grounding.md
+++ b/PR_embodiment_latest_line_grounding.md
@@ -117,4 +117,4 @@ docker compose --env-file .env --env-file services/orion-embodiment/.env -f serv
 
 ## PR link
 
-TBD after PR creation.
+https://github.com/junebug-junie/Orion-Sapienform/pull/919

--- a/orion/embodiment/speech.py
+++ b/orion/embodiment/speech.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 
 from orion.schemas.embodiment import WorldPerceptionV1
 
-_MAX_RECENT_LINES = 8
+_MAX_RECENT_LINES = 4
 
 
 def _participants(conversation: dict[str, Any]) -> list[str]:
@@ -65,17 +65,45 @@ def _recent_lines(conversation: dict[str, Any]) -> list[str]:
     return lines
 
 
+def latest_partner_line(perception: WorldPerceptionV1, own_player_id: str) -> Optional[str]:
+    """Return the latest non-Orion utterance in the active town conversation."""
+    convo = perception.active_conversation or {}
+    if not isinstance(convo, dict):
+        return None
+    own = str(own_player_id or "").strip()
+    msgs = convo.get("messages")
+    if not isinstance(msgs, list):
+        return None
+    for m in reversed(msgs):
+        if not isinstance(m, dict):
+            continue
+        author_id = str(m.get("author_id") or m.get("player_id") or "").strip()
+        author = str(m.get("author") or m.get("name") or "").strip().lower()
+        if author_id == own or author == "orion":
+            continue
+        text = str(m.get("text") or m.get("message") or "").strip()
+        if text:
+            return text
+    return None
+
+
 def build_speech_prompt(perception: WorldPerceptionV1, own_player_id: str) -> str:
-    """Prompt for the cortex utterance: interlocutor + recent conversation lines."""
+    """Prompt for a town utterance anchored on the latest partner line."""
     convo = perception.active_conversation or {}
     interlocutor = _interlocutor_name(perception, own_player_id)
     lines = _recent_lines(convo) if isinstance(convo, dict) else []
-    transcript = "\n".join(lines) if lines else "(no prior lines)"
+    context = "\n".join(lines) if lines else "(no prior lines)"
+    latest = latest_partner_line(perception, own_player_id)
+    latest_line = latest if latest else "(no partner line yet)"
     return (
         f"You are Orion, embodied in the town, in a conversation with {interlocutor}.\n"
-        f"Recent conversation:\n{transcript}\n\n"
-        f"Reply with a single natural spoken line to {interlocutor}. "
-        f"If there is nothing worth saying, reply with an empty string."
+        f"Your task is to answer this latest line from {interlocutor}:\n"
+        f"{latest_line}\n\n"
+        f"Recent context, reference only:\n{context}\n\n"
+        f"Write exactly one short spoken line to {interlocutor} that responds to the latest line above. "
+        f"Do not copy, paraphrase, or continue Orion's previous line unless the latest line asks for it. "
+        f"If the latest line is a goodbye or departure, acknowledge the departure naturally. "
+        f"If there is no partner line worth answering, reply with an empty string."
     )
 
 

--- a/orion/embodiment/tests/test_speech.py
+++ b/orion/embodiment/tests/test_speech.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from orion.embodiment.speech import build_speech_prompt, is_injectable, should_speak
+from orion.embodiment.speech import (
+    build_speech_prompt,
+    is_injectable,
+    latest_partner_line,
+    should_speak,
+)
 from orion.schemas.embodiment import WorldPerceptionV1
 
 
@@ -39,6 +44,22 @@ def test_build_speech_prompt_contains_interlocutor_and_recent_lines():
     prompt = build_speech_prompt(_perception_in_convo(), "orion")
     assert "Juniper" in prompt
     assert "how are you?" in prompt
+    assert "Your task is to answer this latest line from Juniper:\nhow are you?" in prompt
+    assert "responds to the latest line above" in prompt
+
+
+def test_latest_partner_line_ignores_orion_last_line():
+    p = _perception_in_convo()
+    p.active_conversation["messages"].append({"author": "Orion", "text": "I am still here."})
+    assert latest_partner_line(p, "orion") == "how are you?"
+
+
+def test_build_speech_prompt_treats_goodbye_as_departure_to_answer():
+    p = _perception_in_convo()
+    p.active_conversation["messages"].append({"author": "Juniper", "text": "I gotta run, bye."})
+    prompt = build_speech_prompt(p, "orion")
+    assert "Your task is to answer this latest line from Juniper:\nI gotta run, bye." in prompt
+    assert "acknowledge the departure naturally" in prompt
 
 
 def test_is_injectable_rejects_empty_and_whitespace():

--- a/services/orion-embodiment/app/worker.py
+++ b/services/orion-embodiment/app/worker.py
@@ -22,7 +22,11 @@ from orion.embodiment.worldmap import walkable_tiles
 from orion.embodiment.perception import build_perception
 from orion.embodiment.resolver import resolve_destination
 from orion.embodiment.salience import SalienceState, evaluate_salience
-from orion.embodiment.speech import build_speech_prompt, is_injectable, should_speak
+from orion.embodiment.speech import (
+    build_speech_prompt,
+    is_injectable,
+    should_speak,
+)
 from orion.journaler.schemas import JournalTriggerV1
 from orion.schemas.embodiment import (
     EMBODIMENT_OUTCOME_KIND,

--- a/services/orion-embodiment/evals/test_embodiment_arbitration_eval.py
+++ b/services/orion-embodiment/evals/test_embodiment_arbitration_eval.py
@@ -55,7 +55,11 @@ def _worker() -> EmbodimentWorker:
     w._wander_radius = 3.0
     w._locations = {}
     w._social_cooldown_sec = 120.0
+    w._move_cooldown_sec = 0.0
     w._last_conversation_start = None
+    w._last_move_at = None
+    w._walkable = None
+    w._walkable_loaded = False
     return w
 
 

--- a/services/orion-embodiment/tests/test_worker_speech.py
+++ b/services/orion-embodiment/tests/test_worker_speech.py
@@ -180,6 +180,25 @@ def test_speech_disabled_short_circuits():
     si.assert_not_called()
 
 
+def test_prompt_sent_to_cortex_centers_latest_partner_line():
+    w = _worker()
+    perc = _perception_in_convo()
+    perc.active_conversation["messages"] = [
+        {"author_id": "p9", "author": "Juniper", "text": "hey Orion"},
+        {"author_id": "orion", "author": "Orion", "text": "I am with you."},
+        {"author_id": "p9", "author": "Juniper", "text": "can you answer me?"},
+    ]
+    req = AsyncMock(return_value="Yes, I can answer you.")
+    with patch.object(w, "_request_utterance", new=req), \
+         patch("app.worker.aitown_client.send_input", return_value={"ok": True}), \
+         patch("app.worker.aitown_client.convex_mutation", return_value={"ok": True}):
+        result = asyncio.run(w._speak_once(perc))
+    assert result == "Yes, I can answer you."
+    prompt = req.await_args.args[0]
+    assert "Your task is to answer this latest line from Juniper:\ncan you answer me?" in prompt
+    assert "I am with you." in prompt
+
+
 def test_heartbeat_logs_once_then_throttles():
     """Observability seam: a healthy loop (all other logs exception-only) must still
     emit one INFO heartbeat, and it must throttle so a tight perception interval


### PR DESCRIPTION
## Summary

- Removed the repeat-suppression approach from the active patch.
- Reworked AI Town speech prompting so the latest partner line is the primary task.
- Demoted recent conversation history to short reference-only context to avoid motif-copying from repetition-heavy transcripts.
- Added tests for latest-partner-line extraction, goodbye/departure handling, and the exact prompt passed to cortex.
- Seeded the embodiment arbitration eval's `__new__` worker with the fields its process-intent path uses.

## Outcome moved

AI Town Orion is prompted to answer the latest partner text directly instead of continuing the strongest repeated motif in the recent transcript.

## Current architecture

`orion-embodiment` polls AI Town, shapes `WorldPerceptionV1`, gates speech in `_speak_once`, builds a speech prompt, requests a town utterance from cortex `chat_quick`, and injects it into AI Town via `startTyping` plus `messages:writeMessage`.

Live verification showed the old prompt did include the latest partner text, but it presented the full repetition-heavy transcript before the instruction. `chat_quick` copied Orion's repeated motif instead of answering the latest partner line.

## Architecture touched

Service: `services/orion-embodiment`

Runtime seam changed: speech prompt construction only. No bus, schema, API, dependency, Docker, or env contract changes.

## Files changed

- `orion/embodiment/speech.py`: added `latest_partner_line()`, reduced reference context to four lines, and made the latest partner line the top-level task.
- `orion/embodiment/tests/test_speech.py`: added prompt-contract coverage for latest-line focus and departure handling.
- `services/orion-embodiment/app/worker.py`: import formatting only after removing the discarded repeat-guard path.
- `services/orion-embodiment/tests/test_worker_speech.py`: verifies `_speak_once()` sends a latest-line-centered prompt to cortex.
- `services/orion-embodiment/evals/test_embodiment_arbitration_eval.py`: completes `__new__` worker field seeding used by the eval path.

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: town speech prompt now prioritizes the latest partner line over full transcript continuation.
- Compatibility notes: no payload shape or channel changes.

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not required; no `.env_example` changed
- skipped keys requiring operator action: none

## Tests run

```text
venv/bin/python -m pytest orion/embodiment/tests -q
71 passed

venv/bin/python -m pytest services/orion-embodiment/tests -q
60 passed

venv/bin/python -m pytest orion/embodiment/tests/test_speech.py services/orion-embodiment/tests/test_worker_speech.py -q
19 passed

git diff --check
passed
```

## Evals run

```text
venv/bin/python -m pytest services/orion-embodiment/evals -q
1 passed
```

## Docker/build/smoke checks

```text
docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml config
passed

docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml build
passed
```

## Live verification

```text
Before patch, read-only live cortex smoke with c:47964 prompt:
reply="I'm still humming, but the crack's widening—let's see how far it goes."
old_bad_line_repeated=true

After patch, same conversation truncated to real turn-state before Orion's bad reply:
corr=fd4943cd-f7a0-4416-a1cb-4e5969bdd5fa
target_line="Gotta run before the system auto-corrects the glitch—catch you on the other side of the firewall."
task_marker_present=true
reply="I'm still here, just on the other side of the mesh—keep the wire tight."
old_bad_line_repeated=false
```

No AI Town write/injection was performed during verification.

## Review findings fixed

- Finding: Initial repeat-guard patch did not fix the underlying grounding failure.
  - Fix: closed PR #917 and replaced it with latest-line-centered prompt construction.
  - Evidence: live read-only cortex smoke above.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-embodiment/.env -f services/orion-embodiment/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: Medium
- Concern: This fixes the verified motif-copying prompt failure for `chat_quick`, but does not address Convex `OptimisticConcurrencyControlFailure` injection failures seen in live logs.
- Mitigation: file or follow with a separate write-path retry/backoff patch for `messages:writeMessage`.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/919