### PR TITLE
Feat/phi seedv4 feature set

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-09-phi-seedv4-feature-set-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-09-phi-seedv4-feature-set-pr.md
@@ -1,0 +1,127 @@
+# feat(phi): add seed-v4 trainable feature set (spec 2/3)
+
+Branch: `feat/phi-seedv4-feature-set`
+Compare: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/phi-seedv4-feature-set
+
+## Summary
+
+- Re-version the phi cognitive-encoder trainable feature set from `seed-v3` to `seed-v4` (additive, opt-in via `INNER_FEATURES_VERSION=seed-v4`; shipped default stays `seed-v3`).
+- Excise the proven-frozen SelfStateV1 theater trio (`coherence`, `continuity_pressure`, `social_pressure`) from the trainable vector — still recorded in `infra` for provenance, never scaled/trained on.
+- Drop the structurally-sparse `exec_step_fail_rate`/`execution_friction` cognitive slots (0.3% signal in production).
+- Add real `execution_load`, `reasoning_load`, `reasoning_present` cognitive slots sourced from orion-thought's `reasoning_activity` projection (spec 1 of this initiative), each independently `.none`-tagged with a truthful zero when its source is dark — never a fake floor.
+- `execution_load` falls back to `log1p(summed execution_trajectory step_count)` when the reasoning_activity projection itself is dark.
+
+## Outcome moved
+
+`encoder_trainable_feature_names("seed-v4")` now resolves to `agency_readiness, execution_pressure, reasoning_pressure, overall_intensity, recall_gate_fired, reasoning_present, execution_load, reasoning_load` — 8 live dims, replacing 2 dead cognitive dims and 3 frozen felt dims with real, currently-live signal.
+
+## Current architecture
+
+`services/orion-spark-introspector/app/inner_state.py` computed a seed-v3 trainable vector = 6 felt dims (incl. 3 now-proven-frozen) + `overall_intensity` + 4 cognitive slots sourced from the `execution_trajectory` projection, 2 of which (`exec_step_fail_rate`, `execution_friction`) carry near-zero live signal.
+
+## Architecture touched
+
+- `services/orion-spark-introspector/app/inner_state.py` — `SEEDV4_THEATER_FELT`, `SEEDV4_COGNITIVE_FEATURE_NAMES`, `encoder_trainable_feature_names()` seed-v4 branch, `_active_trajectory_runs`/`_recall_gate_fired` helpers factored out of `cognitive_features_from_trajectory` (seed-v3 behavior byte-identical, regression-tested), new `cognitive_features_seed_v4()` builder, `build_inner_state_features()` widened infra-routing + `include_cognitive` conditions and new `reasoning_activity_projection` param.
+- `services/orion-spark-introspector/app/substrate_reads.py` — `ReasoningActivitySnapshot`, `fetch_reasoning_activity()` (mirrors `fetch_execution_trajectory`'s fail-closed pattern), `SubstrateReadCache.put_reasoning_activity`/`get_reasoning_activity`.
+- `services/orion-spark-introspector/app/settings.py` + `.env_example` — new `ORION_THOUGHT_BASE_URL` setting (default `http://orion-athena-thought:7155`).
+- `services/orion-spark-introspector/app/worker.py` — cached `_fetch_orion_thought_reasoning_activity()` fetcher, threaded into `handle_self_state`.
+
+## Files changed
+
+- `services/orion-spark-introspector/app/inner_state.py`: seed-v4 feature set, cognitive slot builder, shared helper factoring
+- `services/orion-spark-introspector/app/substrate_reads.py`: `fetch_reasoning_activity` + cache slots
+- `services/orion-spark-introspector/app/settings.py`: `orion_thought_base_url` setting
+- `services/orion-spark-introspector/.env_example`: `ORION_THOUGHT_BASE_URL` key
+- `services/orion-spark-introspector/app/worker.py`: cached reasoning-activity fetch wired into `handle_self_state`
+- `services/orion-spark-introspector/tests/test_inner_state_seed_v4.py`: new — seed-v4 feature set, dark/live/fallback cases, refactor regression
+- `services/orion-spark-introspector/tests/test_substrate_reads.py`: `fetch_reasoning_activity` + cache tests
+- `services/orion-spark-introspector/tests/test_inner_state_emit.py`: `handle_self_state` seed-v4 integration test + reasoning-activity mocks added to existing tests
+
+## Schema / bus / API changes
+
+- Added: none (no schema/bus changes — `InnerFeatureV1`/`InnerStateFeaturesV1` untouched).
+- Removed: none.
+- Renamed: none.
+- Behavior changed: `features_version="seed-v4"` rows carry a different trainable vector shape than `seed-v3`; `seed-v3`/legacy rows unchanged.
+- Compatibility notes: additive re-version. `scripts/fit_phi_encoder.py`'s `input_features_for_version` needed no code change (generic passthrough), verified by test.
+
+## Env/config changes
+
+- Added keys: `ORION_THOUGHT_BASE_URL=http://orion-athena-thought:7155` (spark-introspector)
+- Removed keys: none
+- Renamed keys: none
+- `.env_example` updated: yes
+- local `.env` synced: `python scripts/sync_local_env_from_example.py` did not pick up this key (it's not in the sync script's prefix/exact allowlist, and that script is out of this patch's scope) — added `ORION_THOUGHT_BASE_URL=http://orion-athena-thought:7155` to the local `services/orion-spark-introspector/.env` by hand, mirroring the existing `SUBSTRATE_RUNTIME_URL` line
+- skipped keys requiring operator action: none
+
+## Tests run
+
+```
+venv/bin/python -m pytest services/orion-spark-introspector/tests -q
+# 97 passed, 1 pre-existing failure (test_phi_reward_emitted_when_encoder_ok,
+# confirmed present on main before this branch via git stash — unrelated), 1 skipped
+
+venv/bin/python -m pytest tests/test_corpus_gate.py tests/test_inner_state_trajectory_features.py tests/test_inner_state_features.py tests/test_inner_state_schema.py -q
+# 28 passed
+```
+
+## Orchestrator review pass (post-subagent, before merge)
+
+Read every touched file against the spec, ran the full suite, then closed one
+gap the subagent had correctly flagged but left out of scope:
+
+- **Fixed** (commit `b8feebbe`): `handle_self_state`'s corpus-health gate
+  hardcoded the seed-v3 `COGNITIVE_FEATURE_NAMES` tuple regardless of
+  `features_version`. Now branches on `inner.features_version` and uses
+  `SEEDV4_COGNITIVE_FEATURE_NAMES` for seed-v4 rows. Verified: under today's
+  sourcing logic this was structurally inert (execution_load/reasoning_load's
+  liveness is causally coupled to recall_gate_fired/reasoning_present's, so
+  the two name sets always produced the same accept/reject verdict — proved
+  by reverting the fix and confirming the new regression test
+  `test_handle_self_state_corpus_gate_uses_seedv4_cognitive_names` fails
+  without it, passes with it) — but it's a real latent gap that would
+  silently weaken corpus hygiene the moment either signal's sourcing logic
+  changes independently, so closed now rather than left as a landmine.
+- Also fixed the `scripts/sync_local_env_from_example.py` allowlist gap for
+  `ORION_THOUGHT_BASE_URL` (same recurring failure mode as the two prior
+  pushes on this initiative) and a minor import-order cleanup in `worker.py`.
+
+## Evals run
+
+No dedicated eval harness exists for spark-introspector's phi feature set beyond the corpus/promote gates in `scripts/fit_phi_encoder.py`, which are out of scope for this patch (spec explicitly defers the fit/backfill run to a follow-up once `PUBLISH_REASONING_TELEMETRY` is live and accruing real data).
+
+## Docker/build/smoke checks
+
+Not run — no runtime config/dependency/port changes; pure Python feature-computation logic + one new outbound HTTP read (fail-closed, cached, matches existing `fetch_execution_trajectory` pattern).
+
+## Review findings fixed
+
+- Finding: `cognitive_features_seed_v4`'s `reasoning_load` branch used `isinstance(x, (int, float)) and x` (truthy) to validate `thinking_tokens_sum`, which (a) let a negative value reach `math.log1p`, raising `ValueError: math domain error` and violating the function's own "never raises" contract, and (b) treated Python `bool` (a subclass of `int`) as a valid numeric count, so a JSON `true` would fabricate a nonzero `reasoning_load` instead of the mandated truthful zero.
+  - Fix: replaced with an explicit `isinstance(..., (int, float)) and not isinstance(..., bool) and thinking_tokens_sum > 0` guard.
+  - Evidence: `test_seed_v4_reasoning_load_negative_thinking_tokens_never_raises`, `test_seed_v4_reasoning_load_bool_thinking_tokens_not_treated_as_number` in `test_inner_state_seed_v4.py`, both passing.
+- Finding (fixed by orchestrator, commit `b8feebbe`, after subagent correctly flagged it out of its authorized scope): `handle_self_state`'s `is_corpus_row_healthy(inner, cognitive_feature_names=COGNITIVE_FEATURE_NAMES)` call was hardcoded to the seed-v3 4-name tuple regardless of `features_version`. Now selects `SEEDV4_COGNITIVE_FEATURE_NAMES` when `inner.features_version == "seed-v4"`. See "Orchestrator review pass" above for the inertness analysis and regression test.
+- Finding (reviewed, not changed — deliberate, disclosed): the refactored `_active_trajectory_runs` helper wraps `datetime.fromisoformat` in a `try/except Exception: continue`, where the original inline seed-v3 loop had no such guard (a malformed `last_updated_at` would previously raise and propagate out of `handle_self_state`). This is a genuine behavior difference from strict byte-identical, but it converts a crash into the same truthful-zero degrade-gracefully pattern already used everywhere else in this file (matches CLAUDE.md's "never raise on absent input — degrade gracefully" mandate and the existing fail-closed convention in `substrate_reads.py`). Kept intentionally; noted here rather than silently changed.
+- Finding (reviewed, not changed — matches task's explicit instructions verbatim): `handle_self_state` now calls `_fetch_orion_thought_reasoning_activity()` unconditionally every tick, even for `seed-v3`/`seed-v2` rows that never consume the result. This was specified verbatim in the task brief (no version gate requested) and is low-severity: fail-closed, 2s cache, 2s timeout, matches the existing `fetch_execution_trajectory` pattern.
+
+## Restart required
+
+```text
+No restart required for this PR by itself (seed-v4 is opt-in; default INNER_FEATURES_VERSION stays seed-v3). To exercise seed-v4 in a running deployment, set INNER_FEATURES_VERSION=seed-v4 and ORION_THOUGHT_BASE_URL for the orion-spark-introspector service, then:
+
+docker compose \
+  --env-file .env \
+  --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml \
+  up -d --build orion-spark-introspector
+```
+
+## Risks / concerns
+
+- Severity: low
+  - Concern: unconditional reasoning_activity HTTP fetch on every self-state tick, even when unused (seed-v3 default).
+  - Mitigation: fail-closed, cached (2s TTL), 2s timeout — matches existing pattern; explicit task requirement.
+
+## PR link
+
+Not opened — `gh` CLI is unauthenticated in this environment. Branch pushed to `origin/feat/phi-seedv4-feature-set`; open at:
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/phi-seedv4-feature-set

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -175,6 +175,8 @@ SYNC_EXACT = frozenset(
         # Reasoning telemetry adapter (cortex-exec -> orion-thought -> phi, default-off)
         "PUBLISH_REASONING_TELEMETRY",
         "CHANNEL_REASONING_CALL",
+        # Seed-v4 feature set: spark-introspector reads orion-thought's reasoning_activity projection
+        "ORION_THOUGHT_BASE_URL",
     }
 )
 

--- a/services/orion-spark-introspector/.env_example
+++ b/services/orion-spark-introspector/.env_example
@@ -173,6 +173,8 @@ CHANNEL_INNER_FEATURES=orion:self:inner_features
 INNER_FEATURES_CORPUS_PATH=/mnt/telemetry/phi/corpus/inner_state.jsonl
 PHI_DEGENERATE_STREAK=20
 SUBSTRATE_RUNTIME_URL=http://orion-athena-substrate-runtime:8115
+# Reasoning-activity projection source for seed-v4 execution_load/reasoning_load/reasoning_present.
+ORION_THOUGHT_BASE_URL=http://orion-athena-thought:7155
 SUBSTRATE_READ_TIMEOUT_SEC=2.0
 SUBSTRATE_READ_CACHE_SEC=2.0
 EXEC_TRAJECTORY_MAX_AGE_SEC=120

--- a/services/orion-spark-introspector/app/inner_state.py
+++ b/services/orion-spark-introspector/app/inner_state.py
@@ -6,6 +6,7 @@ cold-start headline and a degeneracy freeze (the GIGO guard).
 """
 from __future__ import annotations
 
+import math
 from collections import deque
 from datetime import datetime, timezone
 from statistics import median as _median
@@ -94,6 +95,11 @@ ENCODER_EXCLUDED_FELT: frozenset[str] = frozenset({
 })
 INFRA_ONLY_FELT: frozenset[str] = frozenset({"reliability_pressure"})
 
+# Proven-frozen SelfStateV1 dims — excised from seed-v4's trainable set. Still
+# recorded in `infra` for provenance (same treatment as INFRA_ONLY_FELT), just
+# never scaled/trained on. See docs/superpowers/specs/2026-07-09-phi-seedv4-feature-set-design.md.
+SEEDV4_THEATER_FELT: frozenset[str] = frozenset({"coherence", "continuity_pressure", "social_pressure"})
+
 # Retained for provenance only; φ never reads these.
 INFRA_CHANNELS: Tuple[str, ...] = (
     "bus_health",
@@ -110,8 +116,26 @@ COGNITIVE_FEATURE_NAMES: Tuple[str, ...] = (
     "execution_friction",
 )
 
+# seed-v4 cognitive slot names: drop the structurally-sparse exec_step_fail_rate
+# / execution_friction pair, add token-based execution_load and real
+# reasoning_activity-sourced reasoning_load.
+SEEDV4_COGNITIVE_FEATURE_NAMES: Tuple[str, ...] = (
+    "recall_gate_fired",
+    "reasoning_present",
+    "execution_load",
+    "reasoning_load",
+)
+
 
 def encoder_trainable_feature_names(features_version: str) -> list[str]:
+    if features_version == "seed-v4":
+        felt = [
+            k for k in FELT_DIMENSIONS
+            if k not in ENCODER_EXCLUDED_FELT
+            and k not in INFRA_ONLY_FELT
+            and k not in SEEDV4_THEATER_FELT
+        ]
+        return felt + ["overall_intensity"] + list(SEEDV4_COGNITIVE_FEATURE_NAMES)
     if features_version == "seed-v3":
         felt = [
             k for k in FELT_DIMENSIONS
@@ -135,6 +159,32 @@ def _mean(vals: List[float]) -> float:
     return sum(vals) / len(vals) if vals else 0.0
 
 
+def _active_trajectory_runs(
+    projection: dict | None,
+    *,
+    now: datetime,
+    max_age_sec: int,
+) -> list[dict]:
+    """Runs from an execution_trajectory projection whose last_updated_at is
+    within max_age_sec of now. Never raises: malformed timestamps/shapes are
+    skipped rather than propagated."""
+    if not projection or not projection.get("runs"):
+        return []
+    active: list[dict] = []
+    for run in projection["runs"].values():
+        try:
+            ts = datetime.fromisoformat(str(run["last_updated_at"]).replace("Z", "+00:00"))
+        except Exception:
+            continue
+        if (now - ts).total_seconds() <= max_age_sec:
+            active.append(run)
+    return active
+
+
+def _recall_gate_fired(active_runs: list[dict]) -> float:
+    return 1.0 if any(r.get("recall_observed") for r in active_runs) else 0.0
+
+
 def cognitive_features_from_trajectory(
     projection: dict | None,
     *,
@@ -148,17 +198,13 @@ def cognitive_features_from_trajectory(
             InnerFeatureV1(name=n, raw_value=0.0, scaled_value=0.0, source=none_source)
             for n in COGNITIVE_FEATURE_NAMES
         ]
-    active = []
-    for run in projection["runs"].values():
-        ts = datetime.fromisoformat(str(run["last_updated_at"]).replace("Z", "+00:00"))
-        if (now - ts).total_seconds() <= max_age_sec:
-            active.append(run)
+    active = _active_trajectory_runs(projection, now=now, max_age_sec=max_age_sec)
     if not active:
         return [
             InnerFeatureV1(name=n, raw_value=0.0, scaled_value=0.0, source=none_source)
             for n in COGNITIVE_FEATURE_NAMES
         ]
-    recall = 1.0 if any(r.get("recall_observed") for r in active) else 0.0
+    recall = _recall_gate_fired(active)
     reasoning_frac = sum(1 for r in active if r.get("reasoning_present")) / len(active)
     steps = sum(int(r.get("step_count") or 0) for r in active)
     fails = sum(int(r.get("failed_step_count") or 0) for r in active)
@@ -179,6 +225,107 @@ def cognitive_features_from_trajectory(
             source=f"execution_trajectory.runs.*.{name}",
         )
         for name in COGNITIVE_FEATURE_NAMES
+    ]
+
+
+def cognitive_features_seed_v4(
+    trajectory_projection: dict | None,
+    reasoning_activity_projection: dict | None,
+    *,
+    now: datetime,
+    exec_trajectory_max_age_sec: int,
+) -> List[InnerFeatureV1]:
+    """Seed-v4 cognitive slots: recall_gate_fired (execution_trajectory),
+    reasoning_present + reasoning_load (reasoning_activity), execution_load
+    (reasoning_activity token throughput, execution_trajectory step-count
+    fallback when the reasoning_activity projection is dark). Raw only —
+    scaling happens uniformly in build_inner_state_features, same contract as
+    cognitive_features_from_trajectory. Never raises: absent/malformed inputs
+    degrade to a truthful 0.0 with a `.none`-suffixed source, per-feature."""
+    active = _active_trajectory_runs(
+        trajectory_projection, now=now, max_age_sec=exec_trajectory_max_age_sec
+    )
+
+    # recall_gate_fired
+    if active:
+        recall_raw = _recall_gate_fired(active)
+        recall_source = "execution_trajectory.runs.*.recall_gate_fired"
+    else:
+        recall_raw = 0.0
+        recall_source = "execution_trajectory.none"
+
+    ra = reasoning_activity_projection if isinstance(reasoning_activity_projection, dict) else None
+    call_count = 0
+    if ra is not None:
+        try:
+            call_count = int(ra.get("call_count") or 0)
+        except Exception:
+            call_count = 0
+    ra_live = ra is not None and call_count > 0
+
+    # reasoning_present: continuous reasoning_present_rate, truthful 0.0 when dark.
+    if ra_live:
+        try:
+            reasoning_present_raw = round(float(ra.get("reasoning_present_rate", 0.0)), 4)
+        except Exception:
+            reasoning_present_raw = 0.0
+        reasoning_present_source = "reasoning_activity.reasoning_present_rate"
+    else:
+        reasoning_present_raw = 0.0
+        reasoning_present_source = "reasoning_activity.none"
+
+    # execution_load: primary = log1p(completion_tokens_sum); fallback =
+    # log1p(summed step_count) from the same active trajectory runs; else 0.0.
+    completion_tokens_sum = 0
+    if ra_live:
+        try:
+            completion_tokens_sum = int(ra.get("completion_tokens_sum") or 0)
+        except Exception:
+            completion_tokens_sum = 0
+    if ra_live and completion_tokens_sum > 0:
+        execution_load_raw = round(math.log1p(float(completion_tokens_sum)), 4)
+        execution_load_source = "reasoning_activity.completion_tokens_sum"
+    else:
+        steps = sum(int(r.get("step_count") or 0) for r in active) if active else 0
+        if active and steps > 0:
+            execution_load_raw = round(math.log1p(float(steps)), 4)
+            execution_load_source = "execution_trajectory.step_count_fallback"
+        else:
+            execution_load_raw = 0.0
+            execution_load_source = "execution_trajectory.none"
+
+    # reasoning_load: log1p(thinking_tokens_sum) only when a real positive int
+    # is present. thinking_tokens_sum is None whenever no call in the window had
+    # thinking_enabled — today, always. Truthful 0.0, never a fake floor.
+    thinking_tokens_sum = None
+    if ra_live:
+        thinking_tokens_sum = ra.get("thinking_tokens_sum")
+    thinking_tokens_valid = (
+        isinstance(thinking_tokens_sum, (int, float))
+        and not isinstance(thinking_tokens_sum, bool)
+        and thinking_tokens_sum > 0
+    )
+    if ra_live and thinking_tokens_valid:
+        reasoning_load_raw = round(math.log1p(float(thinking_tokens_sum)), 4)
+        reasoning_load_source = "reasoning_activity.thinking_tokens_sum"
+    else:
+        reasoning_load_raw = 0.0
+        reasoning_load_source = "reasoning_activity.none"
+
+    raw_and_source = {
+        "recall_gate_fired": (recall_raw, recall_source),
+        "reasoning_present": (reasoning_present_raw, reasoning_present_source),
+        "execution_load": (execution_load_raw, execution_load_source),
+        "reasoning_load": (reasoning_load_raw, reasoning_load_source),
+    }
+    return [
+        InnerFeatureV1(
+            name=name,
+            raw_value=raw_and_source[name][0],
+            scaled_value=0.0,
+            source=raw_and_source[name][1],
+        )
+        for name in SEEDV4_COGNITIVE_FEATURE_NAMES
     ]
 
 
@@ -212,6 +359,7 @@ def build_inner_state_features(
     grammar_degraded: bool,
     degraded_reasons: Optional[List[str]] = None,
     trajectory_projection: Optional[dict] = None,
+    reasoning_activity_projection: Optional[dict] = None,
     exec_trajectory_max_age_sec: int = 120,
     prev_felt: Optional[Tuple[float, ...]] = None,
     prev_headline: Optional[float] = None,
@@ -230,7 +378,9 @@ def build_inner_state_features(
     for key in FELT_DIMENSIONS:
         raw = _dim_score(ss, key)
         raw_map[key] = raw
-        if features_version == "seed-v3" and key in INFRA_ONLY_FELT:
+        if (features_version == "seed-v3" and key in INFRA_ONLY_FELT) or (
+            features_version == "seed-v4" and key in (INFRA_ONLY_FELT | SEEDV4_THEATER_FELT)
+        ):
             infra_only_felt.append(
                 InnerFeatureV1(
                     name=key,
@@ -267,15 +417,25 @@ def build_inner_state_features(
     include_cognitive = (
         features_version.startswith("seed-v2")
         or features_version == "seed-v3"
+        or features_version == "seed-v4"
         or trajectory_projection is not None
     )
     if include_cognitive:
         gen_for_traj = getattr(ss, "generated_at", None) or datetime.now(timezone.utc)
-        for feat in cognitive_features_from_trajectory(
-            trajectory_projection,
-            now=gen_for_traj,
-            max_age_sec=exec_trajectory_max_age_sec,
-        ):
+        if features_version == "seed-v4":
+            cognitive_feats = cognitive_features_seed_v4(
+                trajectory_projection,
+                reasoning_activity_projection,
+                now=gen_for_traj,
+                exec_trajectory_max_age_sec=exec_trajectory_max_age_sec,
+            )
+        else:
+            cognitive_feats = cognitive_features_from_trajectory(
+                trajectory_projection,
+                now=gen_for_traj,
+                max_age_sec=exec_trajectory_max_age_sec,
+            )
+        for feat in cognitive_feats:
             features.append(
                 InnerFeatureV1(
                     name=feat.name,

--- a/services/orion-spark-introspector/app/settings.py
+++ b/services/orion-spark-introspector/app/settings.py
@@ -123,6 +123,11 @@ class Settings(BaseSettings):
         "http://orion-athena-substrate-runtime:8115",
         alias="SUBSTRATE_RUNTIME_URL",
     )
+    # Reasoning-activity projection source for seed-v4 execution_load/reasoning_load/reasoning_present.
+    orion_thought_base_url: str = Field(
+        "http://orion-athena-thought:7155",
+        alias="ORION_THOUGHT_BASE_URL",
+    )
     substrate_read_timeout_sec: float = Field(2.0, alias="SUBSTRATE_READ_TIMEOUT_SEC")
     substrate_read_cache_sec: float = Field(2.0, alias="SUBSTRATE_READ_CACHE_SEC")
     exec_trajectory_max_age_sec: int = Field(120, alias="EXEC_TRAJECTORY_MAX_AGE_SEC")

--- a/services/orion-spark-introspector/app/substrate_reads.py
+++ b/services/orion-spark-introspector/app/substrate_reads.py
@@ -1,4 +1,5 @@
-"""Fail-closed HTTP reads from orion-substrate-runtime (grammar truth + trajectory)."""
+"""Fail-closed HTTP reads from orion-substrate-runtime (grammar truth + trajectory)
+and orion-thought (reasoning activity)."""
 
 from __future__ import annotations
 
@@ -26,6 +27,12 @@ class GrammarTruthSnapshot:
 
 @dataclass(frozen=True)
 class ExecutionTrajectorySnapshot:
+    ok: bool
+    projection: dict | None
+
+
+@dataclass(frozen=True)
+class ReasoningActivitySnapshot:
     ok: bool
     projection: dict | None
 
@@ -77,6 +84,20 @@ async def fetch_execution_trajectory(client: Any, url: str) -> ExecutionTrajecto
         return ExecutionTrajectorySnapshot(ok=False, projection=None)
 
 
+async def fetch_reasoning_activity(client: Any, url: str) -> ReasoningActivitySnapshot:
+    try:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        data = await _response_json(resp)
+        ok = bool(data.get("ok"))
+        projection = data.get("projection")
+        if projection is not None and not isinstance(projection, dict):
+            projection = None
+        return ReasoningActivitySnapshot(ok=ok, projection=projection)
+    except Exception:
+        return ReasoningActivitySnapshot(ok=False, projection=None)
+
+
 def cognitive_lane_dark(snapshot: GrammarTruthSnapshot) -> bool:
     if not snapshot.enabled_reducers.get("execution_trajectory"):
         return True
@@ -93,6 +114,8 @@ class SubstrateReadCache:
         self._grammar_at: float | None = None
         self._trajectory: dict | None = None
         self._trajectory_at: float | None = None
+        self._reasoning_activity: dict | None = None
+        self._reasoning_activity_at: float | None = None
 
     def put_grammar(self, value: dict) -> None:
         self._grammar = value
@@ -115,3 +138,14 @@ class SubstrateReadCache:
         if time.monotonic() - self._trajectory_at > self._ttl_sec:
             return None
         return self._trajectory
+
+    def put_reasoning_activity(self, value: dict) -> None:
+        self._reasoning_activity = value
+        self._reasoning_activity_at = time.monotonic()
+
+    def get_reasoning_activity(self) -> dict | None:
+        if self._reasoning_activity is None or self._reasoning_activity_at is None:
+            return None
+        if time.monotonic() - self._reasoning_activity_at > self._ttl_sec:
+            return None
+        return self._reasoning_activity

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -44,6 +44,7 @@ from . import introspection_guard as ig
 from .inner_state import (
     COGNITIVE_FEATURE_NAMES,
     RollingRobustScaler,
+    SEEDV4_COGNITIVE_FEATURE_NAMES,
     build_inner_state_features,
 )
 from .inner_state_sink import InnerStateCorpusSink
@@ -2459,8 +2460,17 @@ async def handle_self_state(env: BaseEnvelope) -> None:
                 _PHI_PREV_RECON = out.recon_error
         _INNER_PREV_HEADLINE = inner.headline
         _INNER_LAST_HEADLINE = inner.headline
+        # Corpus-health gate reads the cognitive names that actually match this
+        # row's features_version -- seed-v4 replaced exec_step_fail_rate/
+        # execution_friction with execution_load/reasoning_load, so the seed-v3
+        # names alone would miss half the seed-v4 cognitive slots.
+        gate_cognitive_names = (
+            SEEDV4_COGNITIVE_FEATURE_NAMES
+            if inner.features_version == "seed-v4"
+            else COGNITIVE_FEATURE_NAMES
+        )
         healthy, reject_reasons = is_corpus_row_healthy(
-            inner, cognitive_feature_names=COGNITIVE_FEATURE_NAMES
+            inner, cognitive_feature_names=gate_cognitive_names
         )
         if healthy:
             try:

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -51,10 +51,12 @@ from .phi_encoder import PhiEncoderRuntime
 from .substrate_reads import (
     ExecutionTrajectorySnapshot,
     GrammarTruthSnapshot,
+    ReasoningActivitySnapshot,
     SubstrateReadCache,
     cognitive_lane_dark,
     fetch_execution_trajectory,
     fetch_grammar_truth,
+    fetch_reasoning_activity,
 )
 from .queue_jobs import (
     SparkIntrospectionJobV1,
@@ -597,6 +599,23 @@ async def _fetch_substrate_execution_trajectory():
     )
     cache.put_trajectory({"ok": traj.ok, "projection": traj.projection})
     return traj
+
+
+async def _fetch_orion_thought_reasoning_activity():
+    cache = _substrate_read_cache()
+    cached = cache.get_reasoning_activity()
+    if cached is not None:
+        projection = cached.get("projection")
+        if projection is not None and not isinstance(projection, dict):
+            projection = None
+        return ReasoningActivitySnapshot(ok=bool(cached.get("ok")), projection=projection)
+    thought_base = settings.orion_thought_base_url.rstrip("/")
+    ra = await fetch_reasoning_activity(
+        _substrate_http_client(),
+        f"{thought_base}/projections/reasoning_activity",
+    )
+    cache.put_reasoning_activity({"ok": ra.ok, "projection": ra.projection})
+    return ra
 
 
 async def _fetch_cola_understanding(text: str, *, doc_id: str) -> Optional[np.ndarray]:
@@ -2374,8 +2393,10 @@ async def handle_self_state(env: BaseEnvelope) -> None:
     if settings.inner_features_enabled:
         gt = await _fetch_substrate_grammar_truth()
         traj = await _fetch_substrate_execution_trajectory()
+        reasoning_activity = await _fetch_orion_thought_reasoning_activity()
         grammar_degraded = gt.degraded or cognitive_lane_dark(gt)
         projection = traj.projection if traj.ok else None
+        reasoning_activity_projection = reasoning_activity.projection if reasoning_activity.ok else None
 
         inner, _INNER_PREV_FELT, _INNER_DEGENERATE_STREAK = build_inner_state_features(
             ss,
@@ -2384,6 +2405,7 @@ async def handle_self_state(env: BaseEnvelope) -> None:
             grammar_degraded=grammar_degraded,
             degraded_reasons=gt.degraded_reasons,
             trajectory_projection=projection,
+            reasoning_activity_projection=reasoning_activity_projection,
             exec_trajectory_max_age_sec=int(settings.exec_trajectory_max_age_sec),
             prev_felt=_INNER_PREV_FELT,
             prev_headline=_INNER_PREV_HEADLINE,

--- a/services/orion-spark-introspector/tests/test_inner_state_emit.py
+++ b/services/orion-spark-introspector/tests/test_inner_state_emit.py
@@ -554,3 +554,59 @@ async def test_handle_self_state_seed_v4_uses_reasoning_activity_signals(monkeyp
     assert "reasoning_present" in names
     assert "exec_step_fail_rate" not in names
     assert "execution_friction" not in names
+
+
+@pytest.mark.asyncio
+async def test_handle_self_state_corpus_gate_uses_seedv4_cognitive_names(monkeypatch) -> None:
+    """The corpus-health gate must check the cognitive names that actually
+    exist on the row: seed-v4 rows carry execution_load/reasoning_load, not
+    seed-v3's exec_step_fail_rate/execution_friction. Using the wrong name set
+    would silently narrow the "all cognitive features dead" check."""
+    monkeypatch.setattr(worker, "_SUBSTRATE_CACHE", None, raising=False)
+    monkeypatch.setattr(worker.settings, "inner_features_version", "seed-v4", raising=False)
+    monkeypatch.setattr(worker, "fetch_grammar_truth", AsyncMock(
+        return_value=GrammarTruthSnapshot(
+            degraded=False, degraded_reasons=[],
+            enabled_reducers={"execution_trajectory": True},
+            reducer_health_by_name={"execution_trajectory": {"classification": "healthy"}},
+        )
+    ))
+    monkeypatch.setattr(worker, "fetch_execution_trajectory", AsyncMock(
+        return_value=ExecutionTrajectorySnapshot(ok=True, projection=None)
+    ))
+    monkeypatch.setattr(worker, "fetch_reasoning_activity", AsyncMock(
+        return_value=ReasoningActivitySnapshot(ok=False, projection=None)
+    ))
+
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel, env):
+            pass
+
+    monkeypatch.setattr(worker, "_pub_bus", _Bus(), raising=False)
+    monkeypatch.setattr(worker.manager, "broadcast", AsyncMock(), raising=False)
+    monkeypatch.setattr(worker, "_INNER_SCALER", worker._new_inner_scaler(), raising=False)
+    monkeypatch.setattr(worker, "_INNER_PREV_FELT", None, raising=False)
+    monkeypatch.setattr(worker, "_INNER_PREV_HEADLINE", None, raising=False)
+    monkeypatch.setattr(worker, "_INNER_DEGENERATE_STREAK", 0, raising=False)
+    monkeypatch.setattr(worker, "_INNER_SINK", MagicMock(), raising=False)
+
+    captured_names = {}
+    real_gate = worker.is_corpus_row_healthy
+
+    def _spy(inner, *, cognitive_feature_names):
+        captured_names["names"] = cognitive_feature_names
+        return real_gate(inner, cognitive_feature_names=cognitive_feature_names)
+
+    monkeypatch.setattr(worker, "is_corpus_row_healthy", _spy)
+
+    env = BaseEnvelope(
+        kind="substrate.self_state.v1",
+        source=ServiceRef(name="substrate-runtime", node="athena"),
+        payload=_self_state_payload(),
+    )
+    await worker.handle_self_state(env)
+
+    assert captured_names["names"] == worker.SEEDV4_COGNITIVE_FEATURE_NAMES
+    assert "exec_step_fail_rate" not in captured_names["names"]

--- a/services/orion-spark-introspector/tests/test_inner_state_emit.py
+++ b/services/orion-spark-introspector/tests/test_inner_state_emit.py
@@ -7,7 +7,11 @@ from uuid import UUID
 import pytest
 
 import app.worker as worker
-from app.substrate_reads import ExecutionTrajectorySnapshot, GrammarTruthSnapshot
+from app.substrate_reads import (
+    ExecutionTrajectorySnapshot,
+    GrammarTruthSnapshot,
+    ReasoningActivitySnapshot,
+)
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
 
@@ -72,6 +76,11 @@ def _mock_healthy_substrate_reads(monkeypatch) -> None:
         worker,
         "fetch_execution_trajectory",
         AsyncMock(return_value=ExecutionTrajectorySnapshot(ok=True, projection=None)),
+    )
+    monkeypatch.setattr(
+        worker,
+        "fetch_reasoning_activity",
+        AsyncMock(return_value=ReasoningActivitySnapshot(ok=True, projection=None)),
     )
 
 
@@ -241,6 +250,11 @@ async def test_handle_self_state_grammar_truth_freeze(monkeypatch) -> None:
         "fetch_execution_trajectory",
         AsyncMock(return_value=ExecutionTrajectorySnapshot(ok=False, projection=None)),
     )
+    monkeypatch.setattr(
+        worker,
+        "fetch_reasoning_activity",
+        AsyncMock(return_value=ReasoningActivitySnapshot(ok=False, projection=None)),
+    )
     captured = {}
 
     class _Bus:
@@ -300,6 +314,11 @@ async def test_handle_self_state_includes_cognitive_features(monkeypatch) -> Non
                 },
             )
         ),
+    )
+    monkeypatch.setattr(
+        worker,
+        "fetch_reasoning_activity",
+        AsyncMock(return_value=ReasoningActivitySnapshot(ok=False, projection=None)),
     )
     captured = {}
 
@@ -364,6 +383,11 @@ async def test_handle_self_state_healthy_row_appends_to_corpus(monkeypatch) -> N
             )
         ),
     )
+    monkeypatch.setattr(
+        worker,
+        "fetch_reasoning_activity",
+        AsyncMock(return_value=ReasoningActivitySnapshot(ok=False, projection=None)),
+    )
 
     class _Bus:
         enabled = True
@@ -413,6 +437,11 @@ async def test_handle_self_state_unhealthy_row_skips_corpus(monkeypatch) -> None
         "fetch_execution_trajectory",
         AsyncMock(return_value=ExecutionTrajectorySnapshot(ok=False, projection=None)),
     )
+    monkeypatch.setattr(
+        worker,
+        "fetch_reasoning_activity",
+        AsyncMock(return_value=ReasoningActivitySnapshot(ok=False, projection=None)),
+    )
 
     class _Bus:
         enabled = True
@@ -438,3 +467,90 @@ async def test_handle_self_state_unhealthy_row_skips_corpus(monkeypatch) -> None
     await worker.handle_self_state(env)
 
     mock_sink.append.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_self_state_seed_v4_uses_reasoning_activity_signals(monkeypatch) -> None:
+    """With INNER_FEATURES_VERSION=seed-v4 and both substrate + orion-thought
+    reads mocked, the emitted row carries the seed-v4 cognitive slot names
+    (execution_load/reasoning_load/reasoning_present) instead of seed-v3's
+    exec_step_fail_rate/execution_friction pair."""
+    monkeypatch.setattr(worker, "_SUBSTRATE_CACHE", None, raising=False)
+    monkeypatch.setattr(worker.settings, "inner_features_version", "seed-v4", raising=False)
+    monkeypatch.setattr(
+        worker,
+        "fetch_grammar_truth",
+        AsyncMock(
+            return_value=GrammarTruthSnapshot(
+                degraded=False,
+                degraded_reasons=[],
+                enabled_reducers={"execution_trajectory": True},
+                reducer_health_by_name={"execution_trajectory": {"classification": "healthy"}},
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        worker,
+        "fetch_execution_trajectory",
+        AsyncMock(
+            return_value=ExecutionTrajectorySnapshot(
+                ok=True,
+                projection={
+                    "runs": {
+                        "a": {
+                            "reasoning_present": True,
+                            "recall_observed": True,
+                            "step_count": 4,
+                            "failed_step_count": 0,
+                            "pressure_hints": {},
+                            "last_updated_at": _NOW.isoformat(),
+                        }
+                    }
+                },
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        worker,
+        "fetch_reasoning_activity",
+        AsyncMock(
+            return_value=ReasoningActivitySnapshot(
+                ok=True,
+                projection={
+                    "call_count": 8,
+                    "reasoning_present_rate": 0.5,
+                    "completion_tokens_sum": 200,
+                    "thinking_tokens_sum": None,
+                },
+            )
+        ),
+    )
+    captured = {}
+
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel, env):
+            if channel == worker.settings.channel_inner_features:
+                captured["payload"] = env.payload
+
+    monkeypatch.setattr(worker, "_pub_bus", _Bus(), raising=False)
+    monkeypatch.setattr(worker.manager, "broadcast", AsyncMock(), raising=False)
+    monkeypatch.setattr(worker, "_INNER_SCALER", worker._new_inner_scaler(), raising=False)
+    monkeypatch.setattr(worker, "_INNER_PREV_FELT", None, raising=False)
+    monkeypatch.setattr(worker, "_INNER_PREV_HEADLINE", None, raising=False)
+    monkeypatch.setattr(worker, "_INNER_DEGENERATE_STREAK", 0, raising=False)
+
+    env = BaseEnvelope(
+        kind="substrate.self_state.v1",
+        source=ServiceRef(name="substrate-runtime", node="athena"),
+        payload=_self_state_payload(),
+    )
+    await worker.handle_self_state(env)
+
+    names = {f.name for f in captured["payload"].features}
+    assert "execution_load" in names
+    assert "reasoning_load" in names
+    assert "reasoning_present" in names
+    assert "exec_step_fail_rate" not in names
+    assert "execution_friction" not in names

--- a/services/orion-spark-introspector/tests/test_inner_state_seed_v4.py
+++ b/services/orion-spark-introspector/tests/test_inner_state_seed_v4.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import importlib.util
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "spark_inner_state_seed_v4",
+    Path(__file__).resolve().parents[1] / "app" / "inner_state.py",
+)
+inner_state = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(inner_state)
+
+
+class _Dim:
+    def __init__(self, score: float) -> None:
+        self.score = score
+
+
+class _FakeSelfState:
+    def __init__(self, dims: dict, **kw) -> None:
+        self.dimensions = {k: _Dim(v) for k, v in dims.items()}
+        self.self_state_id = kw.get("sid", "self.state:tick_x:policy.v1")
+        self.generated_at = kw.get("gen", datetime(2026, 7, 9, 12, 0, tzinfo=timezone.utc))
+        self.overall_intensity = kw.get("intensity", 0.4)
+        self.overall_condition = kw.get("condition", "steady")
+        self.trajectory_condition = kw.get("trajectory", "stable")
+        self.dominant_field_channels = kw.get("infra", {})
+
+
+def _sample_self_state() -> _FakeSelfState:
+    return _FakeSelfState(
+        {
+            "coherence": 0.8,
+            "field_intensity": 1.0,
+            "agency_readiness": 0.5,
+            "execution_pressure": 0.2,
+            "reasoning_pressure": 0.1,
+            "resource_pressure": 1.0,
+            "reliability_pressure": 0.9,
+            "continuity_pressure": 0.3,
+            "social_pressure": 0.1,
+            "introspection_pressure": 0.0,
+        },
+        infra={"bus_health": 1.0},
+    )
+
+
+scaler = inner_state.RollingRobustScaler(maxlen=8)
+
+
+def test_seed_v4_trainable_encoder_dims() -> None:
+    names = inner_state.encoder_trainable_feature_names("seed-v4")
+    assert names == [
+        "agency_readiness",
+        "execution_pressure",
+        "reasoning_pressure",
+        "overall_intensity",
+        "recall_gate_fired",
+        "reasoning_present",
+        "execution_load",
+        "reasoning_load",
+    ]
+    assert len(names) == 8
+
+
+def test_seed_v4_moves_theater_trio_to_infra_only() -> None:
+    payload, _, _ = inner_state.build_inner_state_features(
+        _sample_self_state(),
+        scaler,
+        features_version="seed-v4",
+        grammar_degraded=False,
+    )
+    feature_names = {f.name for f in payload.features}
+    infra_names = {f.name for f in payload.infra}
+    for theater in ("coherence", "continuity_pressure", "social_pressure"):
+        assert theater not in feature_names
+        assert theater in infra_names
+    # reliability_pressure still routes to infra-only under seed-v4 too.
+    assert "reliability_pressure" not in feature_names
+    assert "reliability_pressure" in infra_names
+    # live felt dims remain trainable.
+    for live in ("agency_readiness", "execution_pressure", "reasoning_pressure"):
+        assert live in feature_names
+
+
+def test_seed_v4_reasoning_activity_live_signals() -> None:
+    reasoning_activity_projection = {
+        "call_count": 10,
+        "reasoning_present_rate": 0.4,
+        "completion_tokens_sum": 500,
+        "thinking_tokens_sum": None,
+    }
+    payload, _, _ = inner_state.build_inner_state_features(
+        _sample_self_state(),
+        scaler,
+        features_version="seed-v4",
+        grammar_degraded=False,
+        trajectory_projection=None,
+        reasoning_activity_projection=reasoning_activity_projection,
+    )
+    by_name = {f.name: f for f in payload.features}
+
+    reasoning_present = by_name["reasoning_present"]
+    assert reasoning_present.raw_value == 0.4
+    assert reasoning_present.source == "reasoning_activity.reasoning_present_rate"
+
+    execution_load = by_name["execution_load"]
+    assert execution_load.raw_value == round(math.log1p(500), 4)
+    assert execution_load.source == "reasoning_activity.completion_tokens_sum"
+
+    # thinking_tokens_sum is None -> truthful zero, no fake floor.
+    reasoning_load = by_name["reasoning_load"]
+    assert reasoning_load.raw_value == 0.0
+    assert reasoning_load.source == "reasoning_activity.none"
+
+
+def test_seed_v4_dark_projections_are_truthful_zero() -> None:
+    payload, _, _ = inner_state.build_inner_state_features(
+        _sample_self_state(),
+        scaler,
+        features_version="seed-v4",
+        grammar_degraded=False,
+        trajectory_projection=None,
+        reasoning_activity_projection=None,
+    )
+    by_name = {f.name: f for f in payload.features}
+
+    for name in ("execution_load", "reasoning_present", "reasoning_load"):
+        feat = by_name[name]
+        assert feat.raw_value == 0.0
+        assert feat.source.endswith(".none")
+
+    recall = by_name["recall_gate_fired"]
+    assert recall.raw_value == 0.0
+    assert recall.source == "execution_trajectory.none"
+
+
+def test_seed_v4_reasoning_load_negative_thinking_tokens_never_raises() -> None:
+    """A malformed/negative thinking_tokens_sum must degrade to a truthful
+    zero, not raise from math.log1p (domain error for values <= -1)."""
+    reasoning_activity_projection = {
+        "call_count": 3,
+        "reasoning_present_rate": 0.1,
+        "completion_tokens_sum": 0,
+        "thinking_tokens_sum": -5,
+    }
+    payload, _, _ = inner_state.build_inner_state_features(
+        _sample_self_state(),
+        scaler,
+        features_version="seed-v4",
+        grammar_degraded=False,
+        trajectory_projection=None,
+        reasoning_activity_projection=reasoning_activity_projection,
+    )
+    by_name = {f.name: f for f in payload.features}
+    reasoning_load = by_name["reasoning_load"]
+    assert reasoning_load.raw_value == 0.0
+    assert reasoning_load.source == "reasoning_activity.none"
+
+
+def test_seed_v4_reasoning_load_bool_thinking_tokens_not_treated_as_number() -> None:
+    """bool is a subclass of int in Python; a JSON `true` for
+    thinking_tokens_sum must not be treated as a real positive count."""
+    reasoning_activity_projection = {
+        "call_count": 3,
+        "reasoning_present_rate": 0.1,
+        "completion_tokens_sum": 0,
+        "thinking_tokens_sum": True,
+    }
+    payload, _, _ = inner_state.build_inner_state_features(
+        _sample_self_state(),
+        scaler,
+        features_version="seed-v4",
+        grammar_degraded=False,
+        trajectory_projection=None,
+        reasoning_activity_projection=reasoning_activity_projection,
+    )
+    by_name = {f.name: f for f in payload.features}
+    reasoning_load = by_name["reasoning_load"]
+    assert reasoning_load.raw_value == 0.0
+    assert reasoning_load.source == "reasoning_activity.none"
+
+
+def test_seed_v4_execution_load_step_count_fallback() -> None:
+    now = datetime(2026, 7, 9, 12, 0, tzinfo=timezone.utc)
+    trajectory_projection = {
+        "runs": {
+            "a": {
+                "reasoning_present": True,
+                "recall_observed": True,
+                "step_count": 7,
+                "failed_step_count": 0,
+                "pressure_hints": {},
+                "last_updated_at": now.isoformat(),
+            },
+            "b": {
+                "reasoning_present": False,
+                "recall_observed": False,
+                "step_count": 3,
+                "failed_step_count": 0,
+                "pressure_hints": {},
+                "last_updated_at": now.isoformat(),
+            },
+        }
+    }
+    ss = _sample_self_state()
+    ss.generated_at = now
+    payload, _, _ = inner_state.build_inner_state_features(
+        ss,
+        scaler,
+        features_version="seed-v4",
+        grammar_degraded=False,
+        trajectory_projection=trajectory_projection,
+        reasoning_activity_projection=None,  # dark -> fall back to step-count
+        exec_trajectory_max_age_sec=120,
+    )
+    by_name = {f.name: f for f in payload.features}
+    execution_load = by_name["execution_load"]
+    assert execution_load.raw_value == round(math.log1p(10.0), 4)
+    assert execution_load.source == "execution_trajectory.step_count_fallback"
+
+    # recall_gate_fired should also read from the same active runs.
+    recall = by_name["recall_gate_fired"]
+    assert recall.raw_value == 1.0
+    assert recall.source == "execution_trajectory.runs.*.recall_gate_fired"
+
+
+def test_seed_v3_cognitive_features_unchanged_after_refactor() -> None:
+    """Regression: the _recall_gate_fired/_active_trajectory_runs factoring
+    must not change seed-v3's cognitive_features_from_trajectory output."""
+    now = datetime(2026, 7, 9, 12, 0, tzinfo=timezone.utc)
+    projection = {
+        "runs": {
+            "a": {
+                "reasoning_present": True,
+                "recall_observed": True,
+                "step_count": 4,
+                "failed_step_count": 1,
+                "pressure_hints": {"execution_friction": 0.2},
+                "last_updated_at": now.isoformat(),
+            }
+        }
+    }
+    feats = inner_state.cognitive_features_from_trajectory(
+        projection, now=now, max_age_sec=120
+    )
+    by_name = {f.name: f for f in feats}
+    assert by_name["recall_gate_fired"].raw_value == 1.0
+    assert by_name["reasoning_present"].raw_value == 1.0
+    assert by_name["exec_step_fail_rate"].raw_value == round(1 / 4, 4)
+    assert by_name["execution_friction"].raw_value == 0.2
+    for feat in feats:
+        assert feat.source == f"execution_trajectory.runs.*.{feat.name}"
+
+
+def test_seed_v3_cognitive_features_none_case_unchanged() -> None:
+    now = datetime(2026, 7, 9, 12, 0, tzinfo=timezone.utc)
+    feats = inner_state.cognitive_features_from_trajectory(None, now=now, max_age_sec=120)
+    assert len(feats) == 4
+    for feat in feats:
+        assert feat.raw_value == 0.0
+        assert feat.source == "execution_trajectory.none"
+
+
+def test_fit_phi_encoder_resolves_seed_v4_names() -> None:
+    """scripts/fit_phi_encoder.py dynamically loads this same inner_state.py
+    module; confirm its wrapper resolves the same 8-name seed-v4 list."""
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[3]
+    fit_script = repo_root / "scripts" / "fit_phi_encoder.py"
+    module_name = "fit_phi_encoder_test_v4"
+    spec = importlib.util.spec_from_file_location(module_name, fit_script)
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules before exec: fit_phi_encoder.py's dataclasses
+    # resolve annotations via sys.modules[cls.__module__], which raises
+    # AttributeError on None if the module was never registered.
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    names = module.input_features_for_version("seed-v4", legacy_corpus=False)
+    assert names == [
+        "agency_readiness",
+        "execution_pressure",
+        "reasoning_pressure",
+        "overall_intensity",
+        "recall_gate_fired",
+        "reasoning_present",
+        "execution_load",
+        "reasoning_load",
+    ]

--- a/services/orion-spark-introspector/tests/test_substrate_reads.py
+++ b/services/orion-spark-introspector/tests/test_substrate_reads.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app.substrate_reads import SubstrateReadCache, fetch_grammar_truth, fetch_execution_trajectory
+from app.substrate_reads import (
+    SubstrateReadCache,
+    fetch_execution_trajectory,
+    fetch_grammar_truth,
+    fetch_reasoning_activity,
+)
 
 
 @pytest.mark.asyncio
@@ -31,3 +36,51 @@ def test_cache_reuses_within_ttl() -> None:
     cache = SubstrateReadCache(ttl_sec=2.0)
     cache.put_grammar({"degraded": False})
     assert cache.get_grammar() == {"degraded": False}
+
+
+@pytest.mark.asyncio
+async def test_fetch_reasoning_activity_happy_path() -> None:
+    client = AsyncMock()
+    projection = {
+        "call_count": 5,
+        "reasoning_present_rate": 0.2,
+        "completion_tokens_sum": 100,
+        "thinking_tokens_sum": None,
+    }
+    client.get.return_value.json.return_value = {"ok": True, "projection": projection}
+    client.get.return_value.raise_for_status = lambda: None
+    out = await fetch_reasoning_activity(client, "http://thought/projections/reasoning_activity")
+    assert out.ok is True
+    assert out.projection == projection
+
+
+@pytest.mark.asyncio
+async def test_fetch_reasoning_activity_http_error_fails_closed() -> None:
+    client = AsyncMock()
+    client.get.side_effect = TimeoutError("slow")
+    out = await fetch_reasoning_activity(client, "http://thought/projections/reasoning_activity")
+    assert out.ok is False
+    assert out.projection is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_reasoning_activity_non_dict_projection_fails_closed() -> None:
+    client = AsyncMock()
+    client.get.return_value.json.return_value = {"ok": True, "projection": "not-a-dict"}
+    client.get.return_value.raise_for_status = lambda: None
+    out = await fetch_reasoning_activity(client, "http://thought/projections/reasoning_activity")
+    assert out.ok is True
+    assert out.projection is None
+
+
+def test_cache_reuses_reasoning_activity_within_ttl() -> None:
+    cache = SubstrateReadCache(ttl_sec=2.0)
+    cache.put_reasoning_activity({"ok": True, "projection": {"call_count": 1}})
+    assert cache.get_reasoning_activity() == {"ok": True, "projection": {"call_count": 1}}
+
+
+def test_cache_reasoning_activity_expires_past_ttl() -> None:
+    cache = SubstrateReadCache(ttl_sec=0.0)
+    cache.put_reasoning_activity({"ok": True, "projection": {}})
+    time.sleep(0.01)
+    assert cache.get_reasoning_activity() is None


### PR DESCRIPTION
# feat(phi): add seed-v4 trainable feature set (spec 2/3)

Branch: `feat/phi-seedv4-feature-set`
Compare: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/phi-seedv4-feature-set

## Summary

- Re-version the phi cognitive-encoder trainable feature set from `seed-v3` to `seed-v4` (additive, opt-in via `INNER_FEATURES_VERSION=seed-v4`; shipped default stays `seed-v3`).
- Excise the proven-frozen SelfStateV1 theater trio (`coherence`, `continuity_pressure`, `social_pressure`) from the trainable vector — still recorded in `infra` for provenance, never scaled/trained on.
- Drop the structurally-sparse `exec_step_fail_rate`/`execution_friction` cognitive slots (0.3% signal in production).
- Add real `execution_load`, `reasoning_load`, `reasoning_present` cognitive slots sourced from orion-thought's `reasoning_activity` projection (spec 1 of this initiative), each independently `.none`-tagged with a truthful zero when its source is dark — never a fake floor.
- `execution_load` falls back to `log1p(summed execution_trajectory step_count)` when the reasoning_activity projection itself is dark.

## Outcome moved

`encoder_trainable_feature_names("seed-v4")` now resolves to `agency_readiness, execution_pressure, reasoning_pressure, overall_intensity, recall_gate_fired, reasoning_present, execution_load, reasoning_load` — 8 live dims, replacing 2 dead cognitive dims and 3 frozen felt dims with real, currently-live signal.

## Current architecture

`services/orion-spark-introspector/app/inner_state.py` computed a seed-v3 trainable vector = 6 felt dims (incl. 3 now-proven-frozen) + `overall_intensity` + 4 cognitive slots sourced from the `execution_trajectory` projection, 2 of which (`exec_step_fail_rate`, `execution_friction`) carry near-zero live signal.

## Architecture touched

- `services/orion-spark-introspector/app/inner_state.py` — `SEEDV4_THEATER_FELT`, `SEEDV4_COGNITIVE_FEATURE_NAMES`, `encoder_trainable_feature_names()` seed-v4 branch, `_active_trajectory_runs`/`_recall_gate_fired` helpers factored out of `cognitive_features_from_trajectory` (seed-v3 behavior byte-identical, regression-tested), new `cognitive_features_seed_v4()` builder, `build_inner_state_features()` widened infra-routing + `include_cognitive` conditions and new `reasoning_activity_projection` param.
- `services/orion-spark-introspector/app/substrate_reads.py` — `ReasoningActivitySnapshot`, `fetch_reasoning_activity()` (mirrors `fetch_execution_trajectory`'s fail-closed pattern), `SubstrateReadCache.put_reasoning_activity`/`get_reasoning_activity`.
- `services/orion-spark-introspector/app/settings.py` + `.env_example` — new `ORION_THOUGHT_BASE_URL` setting (default `http://orion-athena-thought:7155`).
- `services/orion-spark-introspector/app/worker.py` — cached `_fetch_orion_thought_reasoning_activity()` fetcher, threaded into `handle_self_state`.

## Files changed

- `services/orion-spark-introspector/app/inner_state.py`: seed-v4 feature set, cognitive slot builder, shared helper factoring
- `services/orion-spark-introspector/app/substrate_reads.py`: `fetch_reasoning_activity` + cache slots
- `services/orion-spark-introspector/app/settings.py`: `orion_thought_base_url` setting
- `services/orion-spark-introspector/.env_example`: `ORION_THOUGHT_BASE_URL` key
- `services/orion-spark-introspector/app/worker.py`: cached reasoning-activity fetch wired into `handle_self_state`
- `services/orion-spark-introspector/tests/test_inner_state_seed_v4.py`: new — seed-v4 feature set, dark/live/fallback cases, refactor regression
- `services/orion-spark-introspector/tests/test_substrate_reads.py`: `fetch_reasoning_activity` + cache tests
- `services/orion-spark-introspector/tests/test_inner_state_emit.py`: `handle_self_state` seed-v4 integration test + reasoning-activity mocks added to existing tests

## Schema / bus / API changes

- Added: none (no schema/bus changes — `InnerFeatureV1`/`InnerStateFeaturesV1` untouched).
- Removed: none.
- Renamed: none.
- Behavior changed: `features_version="seed-v4"` rows carry a different trainable vector shape than `seed-v3`; `seed-v3`/legacy rows unchanged.
- Compatibility notes: additive re-version. `scripts/fit_phi_encoder.py`'s `input_features_for_version` needed no code change (generic passthrough), verified by test.

## Env/config changes

- Added keys: `ORION_THOUGHT_BASE_URL=http://orion-athena-thought:7155` (spark-introspector)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: yes
- local `.env` synced: `python scripts/sync_local_env_from_example.py` did not pick up this key (it's not in the sync script's prefix/exact allowlist, and that script is out of this patch's scope) — added `ORION_THOUGHT_BASE_URL=http://orion-athena-thought:7155` to the local `services/orion-spark-introspector/.env` by hand, mirroring the existing `SUBSTRATE_RUNTIME_URL` line
- skipped keys requiring operator action: none

## Tests run

```
venv/bin/python -m pytest services/orion-spark-introspector/tests -q
# 97 passed, 1 pre-existing failure (test_phi_reward_emitted_when_encoder_ok,
# confirmed present on main before this branch via git stash — unrelated), 1 skipped

venv/bin/python -m pytest tests/test_corpus_gate.py tests/test_inner_state_trajectory_features.py tests/test_inner_state_features.py tests/test_inner_state_schema.py -q
# 28 passed
```

## Orchestrator review pass (post-subagent, before merge)

Read every touched file against the spec, ran the full suite, then closed one
gap the subagent had correctly flagged but left out of scope:

- **Fixed** (commit `b8feebbe`): `handle_self_state`'s corpus-health gate
  hardcoded the seed-v3 `COGNITIVE_FEATURE_NAMES` tuple regardless of
  `features_version`. Now branches on `inner.features_version` and uses
  `SEEDV4_COGNITIVE_FEATURE_NAMES` for seed-v4 rows. Verified: under today's
  sourcing logic this was structurally inert (execution_load/reasoning_load's
  liveness is causally coupled to recall_gate_fired/reasoning_present's, so
  the two name sets always produced the same accept/reject verdict — proved
  by reverting the fix and confirming the new regression test
  `test_handle_self_state_corpus_gate_uses_seedv4_cognitive_names` fails
  without it, passes with it) — but it's a real latent gap that would
  silently weaken corpus hygiene the moment either signal's sourcing logic
  changes independently, so closed now rather than left as a landmine.
- Also fixed the `scripts/sync_local_env_from_example.py` allowlist gap for
  `ORION_THOUGHT_BASE_URL` (same recurring failure mode as the two prior
  pushes on this initiative) and a minor import-order cleanup in `worker.py`.

## Evals run

No dedicated eval harness exists for spark-introspector's phi feature set beyond the corpus/promote gates in `scripts/fit_phi_encoder.py`, which are out of scope for this patch (spec explicitly defers the fit/backfill run to a follow-up once `PUBLISH_REASONING_TELEMETRY` is live and accruing real data).

## Docker/build/smoke checks

Not run — no runtime config/dependency/port changes; pure Python feature-computation logic + one new outbound HTTP read (fail-closed, cached, matches existing `fetch_execution_trajectory` pattern).

## Review findings fixed

- Finding: `cognitive_features_seed_v4`'s `reasoning_load` branch used `isinstance(x, (int, float)) and x` (truthy) to validate `thinking_tokens_sum`, which (a) let a negative value reach `math.log1p`, raising `ValueError: math domain error` and violating the function's own "never raises" contract, and (b) treated Python `bool` (a subclass of `int`) as a valid numeric count, so a JSON `true` would fabricate a nonzero `reasoning_load` instead of the mandated truthful zero.
  - Fix: replaced with an explicit `isinstance(..., (int, float)) and not isinstance(..., bool) and thinking_tokens_sum > 0` guard.
  - Evidence: `test_seed_v4_reasoning_load_negative_thinking_tokens_never_raises`, `test_seed_v4_reasoning_load_bool_thinking_tokens_not_treated_as_number` in `test_inner_state_seed_v4.py`, both passing.
- Finding (fixed by orchestrator, commit `b8feebbe`, after subagent correctly flagged it out of its authorized scope): `handle_self_state`'s `is_corpus_row_healthy(inner, cognitive_feature_names=COGNITIVE_FEATURE_NAMES)` call was hardcoded to the seed-v3 4-name tuple regardless of `features_version`. Now selects `SEEDV4_COGNITIVE_FEATURE_NAMES` when `inner.features_version == "seed-v4"`. See "Orchestrator review pass" above for the inertness analysis and regression test.
- Finding (reviewed, not changed — deliberate, disclosed): the refactored `_active_trajectory_runs` helper wraps `datetime.fromisoformat` in a `try/except Exception: continue`, where the original inline seed-v3 loop had no such guard (a malformed `last_updated_at` would previously raise and propagate out of `handle_self_state`). This is a genuine behavior difference from strict byte-identical, but it converts a crash into the same truthful-zero degrade-gracefully pattern already used everywhere else in this file (matches CLAUDE.md's "never raise on absent input — degrade gracefully" mandate and the existing fail-closed convention in `substrate_reads.py`). Kept intentionally; noted here rather than silently changed.
- Finding (reviewed, not changed — matches task's explicit instructions verbatim): `handle_self_state` now calls `_fetch_orion_thought_reasoning_activity()` unconditionally every tick, even for `seed-v3`/`seed-v2` rows that never consume the result. This was specified verbatim in the task brief (no version gate requested) and is low-severity: fail-closed, 2s cache, 2s timeout, matches the existing `fetch_execution_trajectory` pattern.

## Restart required

```text
No restart required for this PR by itself (seed-v4 is opt-in; default INNER_FEATURES_VERSION stays seed-v3). To exercise seed-v4 in a running deployment, set INNER_FEATURES_VERSION=seed-v4 and ORION_THOUGHT_BASE_URL for the orion-spark-introspector service, then:

docker compose \
  --env-file .env \
  --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml \
  up -d --build orion-spark-introspector
```

## Risks / concerns

- Severity: low
  - Concern: unconditional reasoning_activity HTTP fetch on every self-state tick, even when unused (seed-v3 default).
  - Mitigation: fail-closed, cached (2s TTL), 2s timeout — matches existing pattern; explicit task requirement.