### PR TITLE
Feat/phi corpus diag script

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-09-phi-corpus-diag-script-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-09-phi-corpus-diag-script-pr.md
@@ -1,0 +1,92 @@
+# feat(scripts): add scripts/diag.py — phi corpus variance/gate diagnostic
+
+**Status:** IMPLEMENTED, tested, reviewed. Builds a tool referenced by two
+spec docs' acceptance checks that was never actually created — a gap
+discovered when the operator went to run it and it didn't exist.
+
+## Summary
+
+- New `scripts/diag.py`: read-only diagnostic for the phi training corpus.
+  Reports per-dimension variance/liveness and the three corpus gates
+  (`min_rows`, `min_hours`, `variance_fraction`) as JSON, exit code 0/1.
+- Reuses `scripts/fit_phi_encoder.py`'s row loading/filtering/variance-gate
+  logic directly (`_load_jsonl`, `_filter_training_rows`, `_hours_span`,
+  `_variance_gate`, `features_version`, `input_features`) — no duplicated
+  logic. Never trains, never writes artifacts.
+- Default `--features-version` is `seed-v4` (the currently-live corpus-write
+  version), distinct from `fit_phi_encoder.py`'s own conservative
+  `DEFAULT_FEATURES_VERSION` (stays `seed-v3` until a seed-v4 encoder passes
+  the promote gate).
+
+## Why this was needed
+
+`docs/superpowers/specs/2026-07-09-phi-truthful-corpus-overview.md` and
+`2026-07-09-phi-seedv4-feature-set-design.md` both name `scripts/diag.py` as
+an acceptance check ("≥8 dims var>1e-6 on ≥4h fresh corpus"). It never
+existed as a real, committed script — an earlier session's ad hoc scratchpad
+reproduction of the same logic was referenced in the spec but never made it
+into the repo. Now that `PUBLISH_REASONING_TELEMETRY` and
+`INNER_FEATURES_VERSION=seed-v4` are both live (PR #922) and the corpus is
+starting to accrue seed-v4 rows, this is the actual next tool needed.
+
+## Review finding fixed (self-caught before commit)
+
+- Finding: `run_diag()`'s docstring claimed "never raises," but it called
+  `_load_jsonl()` unguarded — that function raises `ValueError` on a
+  malformed JSONL line, which would crash the whole diagnostic instead of
+  reporting a clean failure.
+  - Fix: wrapped the call in `try/except`, degrading to
+    `{"ok": False, "reason": "corpus load failed: ..."}`.
+  - Evidence: `test_diag_never_raises_on_malformed_jsonl_line`, passing.
+
+## Files changed
+
+- `scripts/diag.py` (new)
+- `tests/test_phi_corpus_diag_script.py` (new) — 7 tests: missing corpus,
+  fully-live seed-v4 corpus passes all gates, mostly-frozen corpus fails the
+  variance gate with correct got/need counts, too-few-rows fails min_rows,
+  CLI subprocess exit code matches gate result (0/1), default features
+  version, malformed-JSONL-line never raises.
+
+## Tests run
+
+```text
+pytest tests/test_phi_corpus_diag_script.py tests/test_phi_encoder_fit_script.py tests/test_corpus_gate.py -q
+  → 22 passed
+```
+
+Also manually verified against the real corpus:
+```bash
+python scripts/diag.py --corpus /mnt/telemetry/phi/corpus/inner_state.jsonl
+```
+→ correctly reports 12,100 total rows, 0 matching `seed-v4` (expected — the
+version flip only just landed), all three gates failing with an honest
+reason each. No crash, no false-positive readiness claim.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Docker/build/smoke checks
+
+N/A — CLI script, no service/runtime change.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+## Risks / concerns
+
+None — additive, read-only tooling; does not touch any live service or the
+corpus itself.
+
+## PR link
+
+Branch pushed: `feat/phi-corpus-diag-script`.
+Compare: https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/phi-corpus-diag-script

--- a/scripts/diag.py
+++ b/scripts/diag.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Read-only phi corpus diagnostic: per-dimension variance + corpus gate status.
+
+Referenced as an acceptance check in
+docs/superpowers/specs/2026-07-09-phi-truthful-corpus-overview.md and
+2026-07-09-phi-seedv4-feature-set-design.md ("scripts/diag.py on >=4h
+seed-v4 corpus: >=8 dims var>1e-6"). Reuses fit_phi_encoder.py's row
+loading/filtering/variance-gate logic directly rather than duplicating it --
+this script never trains and never writes artifacts, it only reports.
+
+Usage:
+    python scripts/diag.py --corpus /mnt/telemetry/phi/corpus/inner_state.jsonl
+    python scripts/diag.py --corpus <path> --features-version seed-v3
+
+Exit code 0 when all corpus gates (rows, hours, variance) pass; 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/diag.py` puts scripts/ on sys.path[0], which
+# shadows stdlib `platform` via scripts/platform/ and breaks pydantic (same
+# guard as fit_phi_encoder.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import numpy as np  # noqa: E402
+
+from scripts.fit_phi_encoder import (  # noqa: E402
+    DEFAULT_MIN_HOURS,
+    DEFAULT_MIN_ROWS,
+    DEFAULT_VARIANCE_EPS,
+    DEFAULT_VARIANCE_FRACTION,
+    _filter_training_rows,
+    _hours_span,
+    _load_jsonl,
+    _variance_gate,
+    features_version,
+    input_features,
+)
+
+DEFAULT_CORPUS_PATH = Path("/mnt/telemetry/phi/corpus/inner_state.jsonl")
+# Diagnostic default checks the currently-live corpus-write version, not
+# fit_phi_encoder.py's own conservative DEFAULT_FEATURES_VERSION (which stays
+# seed-v3 until a seed-v4 encoder has actually passed the promote gate).
+DEFAULT_DIAG_FEATURES_VERSION = "seed-v4"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS_PATH)
+    parser.add_argument("--features-version", type=str, default=DEFAULT_DIAG_FEATURES_VERSION)
+    parser.add_argument("--legacy-corpus", action="store_true", help="seed-v1 felt-only rows")
+    parser.add_argument("--min-rows", type=int, default=DEFAULT_MIN_ROWS)
+    parser.add_argument("--min-hours", type=float, default=DEFAULT_MIN_HOURS)
+    parser.add_argument("--variance-fraction", type=float, default=DEFAULT_VARIANCE_FRACTION)
+    parser.add_argument("--variance-eps", type=float, default=DEFAULT_VARIANCE_EPS)
+    return parser.parse_args(argv)
+
+
+def run_diag(args: argparse.Namespace) -> dict:
+    """Pure: load + gate-check a corpus, return the full report dict. Never raises."""
+    fv = features_version(legacy_corpus=args.legacy_corpus, features_version_arg=args.features_version)
+    feature_names = input_features(legacy_corpus=args.legacy_corpus, features_version=fv)
+
+    if not args.corpus.is_file():
+        return {"ok": False, "reason": f"corpus not found: {args.corpus}"}
+
+    try:
+        raw_rows = _load_jsonl(args.corpus)
+    except Exception as exc:
+        # _load_jsonl raises ValueError on a malformed JSONL line -- a
+        # diagnostic must report that, not crash the process.
+        return {"ok": False, "reason": f"corpus load failed: {exc}"}
+    loaded, excluded = _filter_training_rows(
+        raw_rows,
+        feature_names=feature_names,
+        features_version=fv,
+        legacy_corpus=args.legacy_corpus,
+    )
+    matrix = np.stack([r.x for r in loaded], axis=0) if loaded else np.zeros((0, len(feature_names)))
+    hours = _hours_span(loaded)
+    variance_ok, var_ok_count, var_needed = _variance_gate(
+        matrix, fraction=args.variance_fraction, eps=args.variance_eps
+    )
+    variances = np.var(matrix, axis=0) if matrix.size else np.zeros(len(feature_names))
+    dims = [
+        {"name": name, "variance": round(float(var), 8), "live": bool(var > args.variance_eps)}
+        for name, var in zip(feature_names, variances)
+    ]
+
+    rows_ok = len(loaded) >= args.min_rows
+    hours_ok = hours >= args.min_hours
+    overall_ok = rows_ok and hours_ok and variance_ok
+
+    return {
+        "ok": overall_ok,
+        "corpus": str(args.corpus),
+        "features_version": fv,
+        "rows_total": len(raw_rows),
+        "rows_matching_version_and_healthy": len(loaded),
+        "rows_excluded": excluded,
+        "hours_span": round(hours, 3),
+        "gates": {
+            "min_rows": {"need": args.min_rows, "got": len(loaded), "ok": rows_ok},
+            "min_hours": {"need": args.min_hours, "got": round(hours, 3), "ok": hours_ok},
+            "variance": {"need": var_needed, "got": var_ok_count, "ok": variance_ok},
+        },
+        "dims": dims,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    result = run_diag(args)
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_phi_corpus_diag_script.py
+++ b/tests/test_phi_corpus_diag_script.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+
+from orion.schemas.telemetry.inner_state import InnerFeatureV1, InnerStateFeaturesV1
+
+REPO = Path(__file__).resolve().parents[1]
+DIAG_SCRIPT = REPO / "scripts" / "diag.py"
+
+SEEDV4_NAMES = (
+    "agency_readiness",
+    "execution_pressure",
+    "reasoning_pressure",
+    "overall_intensity",
+    "recall_gate_fired",
+    "reasoning_present",
+    "execution_load",
+    "reasoning_load",
+)
+
+
+def _run_diag(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(DIAG_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+
+
+def _feature(name: str, value: float) -> InnerFeatureV1:
+    return InnerFeatureV1(name=name, raw_value=value, scaled_value=value, source=f"test.{name}")
+
+
+def _seedv4_row(*, t: datetime, scaled_by_name: dict[str, float]) -> InnerStateFeaturesV1:
+    features = [_feature(name, scaled_by_name.get(name, 0.0)) for name in SEEDV4_NAMES]
+    return InnerStateFeaturesV1(
+        features_version="seed-v4",
+        generated_at=t,
+        features=features,
+        headline=0.5,
+        phi_health="ok",
+        grammar_truth_degraded=False,
+    )
+
+
+def _write_corpus(path: Path, rows: list[InnerStateFeaturesV1]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row.model_dump(mode="json"), separators=(",", ":")) + "\n")
+
+
+def _live_corpus(n_rows: int = 60, hours_span: float = 5.0, live_dims: int = 8) -> list[InnerStateFeaturesV1]:
+    start = datetime(2026, 7, 9, 0, 0, tzinfo=timezone.utc)
+    step = timedelta(hours=hours_span / max(1, n_rows - 1))
+    rng = np.random.default_rng(0)
+    rows: list[InnerStateFeaturesV1] = []
+    for i in range(n_rows):
+        t = start + step * i
+        scaled = {}
+        for j, name in enumerate(SEEDV4_NAMES):
+            scaled[name] = float(rng.standard_normal()) if j < live_dims else 0.0
+        rows.append(_seedv4_row(t=t, scaled_by_name=scaled))
+    return rows
+
+
+def test_diag_reports_missing_corpus(tmp_path: Path) -> None:
+    from scripts.diag import _parse_args, run_diag
+
+    args = _parse_args(["--corpus", str(tmp_path / "nope.jsonl")])
+    result = run_diag(args)
+    assert result["ok"] is False
+    assert "not found" in result["reason"]
+
+
+def test_diag_passes_on_fully_live_seed_v4_corpus(tmp_path: Path) -> None:
+    from scripts.diag import _parse_args, run_diag
+
+    corpus = tmp_path / "corpus.jsonl"
+    _write_corpus(corpus, _live_corpus(n_rows=60, hours_span=5.0, live_dims=8))
+    args = _parse_args([
+        "--corpus", str(corpus),
+        "--features-version", "seed-v4",
+        "--min-rows", "50",
+        "--min-hours", "4.0",
+    ])
+    result = run_diag(args)
+    assert result["ok"] is True
+    assert result["gates"]["min_rows"]["ok"] is True
+    assert result["gates"]["min_hours"]["ok"] is True
+    assert result["gates"]["variance"]["ok"] is True
+    assert result["gates"]["variance"]["got"] == 8
+    live_names = {d["name"] for d in result["dims"] if d["live"]}
+    assert live_names == set(SEEDV4_NAMES)
+
+
+def test_diag_fails_variance_gate_when_dims_mostly_frozen(tmp_path: Path) -> None:
+    from scripts.diag import _parse_args, run_diag
+
+    corpus = tmp_path / "corpus.jsonl"
+    # Only 3 of 8 dims carry variance -- needs ceil(0.8*8)=7, so this must fail.
+    _write_corpus(corpus, _live_corpus(n_rows=60, hours_span=5.0, live_dims=3))
+    args = _parse_args([
+        "--corpus", str(corpus),
+        "--features-version", "seed-v4",
+        "--min-rows", "50",
+        "--min-hours", "4.0",
+    ])
+    result = run_diag(args)
+    assert result["ok"] is False
+    assert result["gates"]["variance"]["ok"] is False
+    assert result["gates"]["variance"]["got"] == 3
+    assert result["gates"]["variance"]["need"] == 7
+    frozen = [d for d in result["dims"] if not d["live"]]
+    assert len(frozen) == 5
+
+
+def test_diag_fails_on_too_few_rows(tmp_path: Path) -> None:
+    from scripts.diag import _parse_args, run_diag
+
+    corpus = tmp_path / "corpus.jsonl"
+    _write_corpus(corpus, _live_corpus(n_rows=10, hours_span=5.0, live_dims=8))
+    args = _parse_args([
+        "--corpus", str(corpus),
+        "--features-version", "seed-v4",
+        "--min-rows", "500",
+        "--min-hours", "4.0",
+    ])
+    result = run_diag(args)
+    assert result["ok"] is False
+    assert result["gates"]["min_rows"]["ok"] is False
+    assert result["gates"]["min_rows"]["got"] == 10
+
+
+def test_diag_cli_exit_code_matches_gate_result(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus.jsonl"
+    _write_corpus(corpus, _live_corpus(n_rows=60, hours_span=5.0, live_dims=8))
+
+    passing = _run_diag(
+        "--corpus", str(corpus),
+        "--features-version", "seed-v4",
+        "--min-rows", "50",
+        "--min-hours", "4.0",
+    )
+    assert passing.returncode == 0, passing.stderr or passing.stdout
+    payload = json.loads(passing.stdout)
+    assert payload["ok"] is True
+
+    failing = _run_diag(
+        "--corpus", str(corpus),
+        "--features-version", "seed-v4",
+        "--min-rows", "5000",
+        "--min-hours", "4.0",
+    )
+    assert failing.returncode == 1
+    payload2 = json.loads(failing.stdout)
+    assert payload2["ok"] is False
+
+
+def test_diag_default_features_version_is_seed_v4(tmp_path: Path) -> None:
+    from scripts.diag import _parse_args
+
+    args = _parse_args(["--corpus", str(tmp_path / "x.jsonl")])
+    assert args.features_version == "seed-v4"
+
+
+def test_diag_never_raises_on_malformed_jsonl_line(tmp_path: Path) -> None:
+    """_load_jsonl raises ValueError on a malformed line -- run_diag must
+    degrade to a reported failure, not propagate the crash."""
+    from scripts.diag import _parse_args, run_diag
+
+    corpus = tmp_path / "corpus.jsonl"
+    corpus.write_text('{"not": "valid inner state json"\n')  # missing closing brace
+    args = _parse_args(["--corpus", str(corpus), "--features-version", "seed-v4"])
+    result = run_diag(args)
+    assert result["ok"] is False
+    assert "corpus load failed" in result["reason"]


### PR DESCRIPTION
# feat(scripts): add scripts/diag.py — phi corpus variance/gate diagnostic

**Status:** IMPLEMENTED, tested, reviewed. Builds a tool referenced by two
spec docs' acceptance checks that was never actually created — a gap
discovered when the operator went to run it and it didn't exist.

## Summary

- New `scripts/diag.py`: read-only diagnostic for the phi training corpus.
  Reports per-dimension variance/liveness and the three corpus gates
  (`min_rows`, `min_hours`, `variance_fraction`) as JSON, exit code 0/1.
- Reuses `scripts/fit_phi_encoder.py`'s row loading/filtering/variance-gate
  logic directly (`_load_jsonl`, `_filter_training_rows`, `_hours_span`,
  `_variance_gate`, `features_version`, `input_features`) — no duplicated
  logic. Never trains, never writes artifacts.
- Default `--features-version` is `seed-v4` (the currently-live corpus-write
  version), distinct from `fit_phi_encoder.py`'s own conservative
  `DEFAULT_FEATURES_VERSION` (stays `seed-v3` until a seed-v4 encoder passes
  the promote gate).

## Why this was needed

`docs/superpowers/specs/2026-07-09-phi-truthful-corpus-overview.md` and
`2026-07-09-phi-seedv4-feature-set-design.md` both name `scripts/diag.py` as
an acceptance check ("≥8 dims var>1e-6 on ≥4h fresh corpus"). It never
existed as a real, committed script — an earlier session's ad hoc scratchpad
reproduction of the same logic was referenced in the spec but never made it
into the repo. Now that `PUBLISH_REASONING_TELEMETRY` and
`INNER_FEATURES_VERSION=seed-v4` are both live (PR #922) and the corpus is
starting to accrue seed-v4 rows, this is the actual next tool needed.

## Review finding fixed (self-caught before commit)

- Finding: `run_diag()`'s docstring claimed "never raises," but it called
  `_load_jsonl()` unguarded — that function raises `ValueError` on a
  malformed JSONL line, which would crash the whole diagnostic instead of
  reporting a clean failure.
  - Fix: wrapped the call in `try/except`, degrading to
    `{"ok": False, "reason": "corpus load failed: ..."}`.
  - Evidence: `test_diag_never_raises_on_malformed_jsonl_line`, passing.

## Files changed

- `scripts/diag.py` (new)
- `tests/test_phi_corpus_diag_script.py` (new) — 7 tests: missing corpus,
  fully-live seed-v4 corpus passes all gates, mostly-frozen corpus fails the
  variance gate with correct got/need counts, too-few-rows fails min_rows,
  CLI subprocess exit code matches gate result (0/1), default features
  version, malformed-JSONL-line never raises.

## Tests run

```text
pytest tests/test_phi_corpus_diag_script.py tests/test_phi_encoder_fit_script.py tests/test_corpus_gate.py -q
  → 22 passed
```

Also manually verified against the real corpus:
```bash
python scripts/diag.py --corpus /mnt/telemetry/phi/corpus/inner_state.jsonl
```
→ correctly reports 12,100 total rows, 0 matching `seed-v4` (expected — the
version flip only just landed), all three gates failing with an honest
reason each. No crash, no false-positive readiness claim.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Docker/build/smoke checks

N/A — CLI script, no service/runtime change.

## Restart required

```text
No restart required.
```

## Risks / concerns

None — additive, read-only tooling; does not touch any live service or the
corpus itself.
