### PR TITLE
Fix/phi corpus gate scoped grammar health

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-09-phi-corpus-gate-scoped-grammar-health-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-09-phi-corpus-gate-scoped-grammar-health-pr.md
@@ -1,0 +1,118 @@
+# fix(spark-introspector): scope grammar-degraded check to execution_trajectory lane
+
+**Status:** IMPLEMENTED, tested, reviewed. Fixes a live production incident
+discovered ~45 minutes after deploying specs 1-3 + the enable-switches PR
+(#922) — corpus accrual was completely stalled.
+
+## Summary
+
+`orion-spark-introspector`'s `handle_self_state` computed
+`grammar_degraded = gt.degraded or cognitive_lane_dark(gt)` — the blanket
+`gt.degraded` flag trips whenever **any** substrate reducer's cursor lags,
+including `chat_grammar_consumer`, which has nothing to do with φ's
+execution/reasoning signals. In production this froze `phi_health` on every
+single row (`chat_grammar_consumer` was ~19.4h stale simply because no chat
+had occurred), and spec 3's corpus-hygiene gate correctly rejected every
+frozen row at write time — the net effect was **zero seed-v4 rows accruing
+at all**, silently, with the service otherwise running and ticking normally.
+
+`cognitive_lane_dark(gt)` already existed as the properly-scoped check (only
+cares about `execution_trajectory`, the reducer φ's cognitive features
+actually depend on) — it just wasn't being trusted on its own; the blanket
+flag was still OR'd in alongside it, defeating the point.
+
+## Fix
+
+- `worker.py`: `grammar_degraded = cognitive_lane_dark(gt)`. Dropped the
+  blanket `gt.degraded` OR entirely. `cognitive_lane_dark` already fails
+  closed on total fetch failure (`enabled_reducers={}`, from
+  `_grammar_http_error`) and on `execution_trajectory` being disabled — so
+  nothing is lost by removing the blanket flag.
+- `substrate_reads.py`: `cognitive_lane_dark()` needed a second check added.
+  It originally only looked at `reducer_health_by_name["execution_trajectory"]
+  ["classification"]`, but that field — computed server-side by
+  `ReducerHealthSnapshot.classify()` — only reflects heartbeat/stream-backlog
+  state and **never reflects wall-clock cursor lag** (`cursor_wall_lag_sec`)
+  at all. That means `execution_trajectory`'s own cursor going genuinely
+  stale would have been invisible to the old scoped check, and was only ever
+  caught (incidentally) via the blanket `gt.degraded` OR. Added a targeted
+  read of `degraded_reasons` for an entry starting with
+  `"cursor_lag:execution_grammar_reducer"` (its own cursor name), so
+  execution_trajectory's own lag still freezes correctly, without pulling in
+  unrelated reducers.
+
+Confirmed this preserves the existing
+`test_handle_self_state_grammar_truth_freeze` test's original intent
+byte-for-byte, without modifying that test at all.
+
+## Files changed
+
+- `services/orion-spark-introspector/app/substrate_reads.py` —
+  `cognitive_lane_dark()` gains the cursor-lag check; new
+  `_EXECUTION_TRAJECTORY_CURSOR_NAME` local constant (duplicated as a stable
+  literal rather than importing `orion.substrate.*` into this service).
+- `services/orion-spark-introspector/app/worker.py` — one-line change plus
+  comment explaining why.
+- `services/orion-spark-introspector/tests/test_substrate_reads.py` — 6 new
+  unit tests directly on `cognitive_lane_dark`: reproduces the exact bug
+  (unrelated lag doesn't trip it), confirms execution_trajectory's own lag
+  still does, multiple-reducers-lagging-including-own, dark classification
+  still works, reducer-disabled still works, fully-healthy stays clean.
+- `services/orion-spark-introspector/tests/test_inner_state_emit.py` — 1 new
+  end-to-end test reproducing the live incident exactly through
+  `handle_self_state`: `chat_grammar_consumer` lagging + `execution_trajectory`
+  healthy → `phi_health == "ok"`, `grammar_truth_degraded is False`, corpus
+  sink `.append()` called.
+
+## Tests run
+
+```text
+pytest services/orion-spark-introspector/tests -q
+  → 104 passed, 1 pre-existing unrelated failure (test_phi_reward_emitted_when_encoder_ok)
+```
+
+Every new test verified to fail without the fix and pass with it (reverted
+the fix, confirmed the exact expected failures, reapplied).
+
+## Review findings fixed
+
+Self-reviewed (medium effort). No findings — the fix reuses the existing,
+already-scoped `cognitive_lane_dark` mechanism rather than inventing a new
+health model; confirmed no accidental widening (biometrics/transport_bus
+reducer lag still correctly ignored, matching φ's actual dependency surface).
+
+## Docker/build/smoke checks
+
+Not run against containers in this environment. Live-verified the *bug*
+directly against the running deployment (`docker logs`, `/grammar/truth`
+endpoint) before writing the fix; the fix itself is unit/integration tested
+only pending redeploy.
+
+## Restart required
+
+**This is blocking live corpus accrual right now.** Restart
+`orion-spark-introspector` to pick up the fix:
+```bash
+docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml up -d --build
+```
+After restart, confirm with:
+```bash
+docker logs orion-athena-spark-introspector --since 2m | grep inner_state_corpus_row_rejected
+python scripts/diag.py --corpus /mnt/telemetry/phi/corpus/inner_state.jsonl
+```
+Rejection log lines should stop appearing (or only appear when
+execution_trajectory is genuinely down), and `diag.py`'s `rows_matching_version_and_healthy`
+should start climbing from 0.
+
+## Risks / concerns
+
+- Severity: low. Narrows a health check, doesn't widen anything — the only
+  behavior change is that an unrelated reducer's lag no longer blocks phi
+  corpus writes. execution_trajectory's own degradation (both
+  classification-based and wall-clock-lag-based) still freezes correctly.
+
+## PR link
+
+Branch pushed: `fix/phi-corpus-gate-scoped-grammar-health`.
+Compare: https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/phi-corpus-gate-scoped-grammar-health

--- a/services/orion-spark-introspector/app/substrate_reads.py
+++ b/services/orion-spark-introspector/app/substrate_reads.py
@@ -16,6 +16,15 @@ _DARK_CLASSIFICATIONS = frozenset(
     }
 )
 
+# Cursor name execution_trajectory's reducer commits under (see
+# orion.substrate.execution_loop.constants.EXECUTION_GRAMMAR_CURSOR_NAME --
+# duplicated here as a stable literal rather than importing orion.substrate.*
+# into this service). Used to scope wall-clock cursor-lag detection to just
+# this lane; substrate's own reducer_health `classification` field never
+# reflects cursor_wall_lag_sec (only heartbeat/stream-backlog state), so that
+# signal has to be read from `degraded_reasons` directly.
+_EXECUTION_TRAJECTORY_CURSOR_NAME = "execution_grammar_reducer"
+
 
 @dataclass(frozen=True)
 class GrammarTruthSnapshot:
@@ -102,7 +111,13 @@ def cognitive_lane_dark(snapshot: GrammarTruthSnapshot) -> bool:
     if not snapshot.enabled_reducers.get("execution_trajectory"):
         return True
     health = snapshot.reducer_health_by_name.get("execution_trajectory") or {}
-    return health.get("classification") in _DARK_CLASSIFICATIONS
+    if health.get("classification") in _DARK_CLASSIFICATIONS:
+        return True
+    reasons = snapshot.degraded_reasons if isinstance(snapshot.degraded_reasons, list) else []
+    return any(
+        isinstance(reason, str) and reason.startswith(f"cursor_lag:{_EXECUTION_TRAJECTORY_CURSOR_NAME}")
+        for reason in reasons
+    )
 
 
 class SubstrateReadCache:

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -2395,7 +2395,17 @@ async def handle_self_state(env: BaseEnvelope) -> None:
         gt = await _fetch_substrate_grammar_truth()
         traj = await _fetch_substrate_execution_trajectory()
         reasoning_activity = await _fetch_orion_thought_reasoning_activity()
-        grammar_degraded = gt.degraded or cognitive_lane_dark(gt)
+        # Scope phi_health to the reducer lane that actually feeds this row's
+        # cognitive features (execution_trajectory) rather than substrate's
+        # blanket `degraded` flag, which trips on ANY reducer's cursor lag --
+        # including chat_grammar_consumer, whose lag just means "no chat
+        # happened recently" and has nothing to do with phi's signals. A
+        # blanket check freezes every row (and, since spec 3, rejects it at
+        # the corpus-hygiene gate) for an unrelated subsystem being quiet.
+        # cognitive_lane_dark already covers the "fetch failed entirely" case
+        # too: a failed fetch returns enabled_reducers={}, which it treats as
+        # dark.
+        grammar_degraded = cognitive_lane_dark(gt)
         projection = traj.projection if traj.ok else None
         reasoning_activity_projection = reasoning_activity.projection if reasoning_activity.ok else None
 

--- a/services/orion-spark-introspector/tests/test_inner_state_emit.py
+++ b/services/orion-spark-introspector/tests/test_inner_state_emit.py
@@ -612,3 +612,78 @@ async def test_handle_self_state_corpus_gate_uses_seedv4_cognitive_names(monkeyp
 
     assert captured_names["names"] == worker.SEEDV4_COGNITIVE_FEATURE_NAMES
     assert "exec_step_fail_rate" not in captured_names["names"]
+
+
+@pytest.mark.asyncio
+async def test_handle_self_state_unrelated_cursor_lag_does_not_freeze_or_reject(monkeypatch) -> None:
+    """Regression for the live incident: substrate reporting degraded=True
+    solely because chat_grammar_consumer (unrelated to phi) is lagging must
+    NOT freeze phi_health or trip the corpus-hygiene gate, as long as
+    execution_trajectory (the reducer phi's cognitive features depend on) is
+    itself healthy."""
+    monkeypatch.setattr(worker, "_SUBSTRATE_CACHE", None, raising=False)
+    monkeypatch.setattr(worker, "fetch_grammar_truth", AsyncMock(
+        return_value=GrammarTruthSnapshot(
+            degraded=True,
+            degraded_reasons=["cursor_lag:chat_grammar_consumer"],
+            enabled_reducers={"execution_trajectory": True},
+            reducer_health_by_name={"execution_trajectory": {"classification": "healthy"}},
+        )
+    ))
+    monkeypatch.setattr(worker, "fetch_execution_trajectory", AsyncMock(
+        return_value=ExecutionTrajectorySnapshot(
+            ok=True,
+            projection={
+                "runs": {
+                    "a": {
+                        "reasoning_present": True,
+                        "recall_observed": True,
+                        "step_count": 4,
+                        "failed_step_count": 0,
+                        "pressure_hints": {},
+                        "last_updated_at": _NOW.isoformat(),
+                    }
+                }
+            },
+        )
+    ))
+    monkeypatch.setattr(worker, "fetch_reasoning_activity", AsyncMock(
+        return_value=ReasoningActivitySnapshot(
+            ok=True,
+            projection={
+                "call_count": 8,
+                "reasoning_present_rate": 0.5,
+                "completion_tokens_sum": 200,
+                "thinking_tokens_sum": None,
+            },
+        )
+    ))
+    captured = {}
+
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel, env):
+            if channel == worker.settings.channel_inner_features:
+                captured["payload"] = env.payload
+
+    monkeypatch.setattr(worker, "_pub_bus", _Bus(), raising=False)
+    monkeypatch.setattr(worker.manager, "broadcast", AsyncMock(), raising=False)
+    monkeypatch.setattr(worker, "_INNER_SCALER", worker._new_inner_scaler(), raising=False)
+    monkeypatch.setattr(worker, "_INNER_PREV_FELT", None, raising=False)
+    monkeypatch.setattr(worker, "_INNER_PREV_HEADLINE", None, raising=False)
+    monkeypatch.setattr(worker, "_INNER_DEGENERATE_STREAK", 0, raising=False)
+
+    mock_sink = MagicMock()
+    monkeypatch.setattr(worker, "_INNER_SINK", mock_sink, raising=False)
+
+    env = BaseEnvelope(
+        kind="substrate.self_state.v1",
+        source=ServiceRef(name="substrate-runtime", node="athena"),
+        payload=_self_state_payload(),
+    )
+    await worker.handle_self_state(env)
+
+    assert captured["payload"].phi_health == "ok"
+    assert captured["payload"].grammar_truth_degraded is False
+    mock_sink.append.assert_called_once()

--- a/services/orion-spark-introspector/tests/test_substrate_reads.py
+++ b/services/orion-spark-introspector/tests/test_substrate_reads.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.substrate_reads import (
+    GrammarTruthSnapshot,
     SubstrateReadCache,
+    cognitive_lane_dark,
     fetch_execution_trajectory,
     fetch_grammar_truth,
     fetch_reasoning_activity,
@@ -84,3 +86,64 @@ def test_cache_reasoning_activity_expires_past_ttl() -> None:
     cache.put_reasoning_activity({"ok": True, "projection": {}})
     time.sleep(0.01)
     assert cache.get_reasoning_activity() is None
+
+
+# --- cognitive_lane_dark ------------------------------------------------------
+# Regression coverage for the live bug where an UNRELATED reducer's cursor lag
+# (chat_grammar_consumer going quiet because no chat happened) tripped
+# substrate's blanket `degraded` flag, which spark-introspector used to OR
+# into grammar_degraded -- freezing phi_health, and therefore rejecting every
+# corpus row at spec 3's ingestion-time health gate, even though
+# execution_trajectory (the only reducer phi's cognitive features actually
+# depend on) was fully healthy.
+
+
+def _snapshot(
+    *,
+    degraded_reasons: list[str] | None = None,
+    enabled: bool = True,
+    classification: str | None = "healthy",
+) -> GrammarTruthSnapshot:
+    reducer_health_by_name = {"execution_trajectory": {"classification": classification}} if classification else {}
+    return GrammarTruthSnapshot(
+        degraded=bool(degraded_reasons),
+        degraded_reasons=degraded_reasons or [],
+        enabled_reducers={"execution_trajectory": enabled},
+        reducer_health_by_name=reducer_health_by_name,
+    )
+
+
+def test_cognitive_lane_dark_false_when_unrelated_reducer_lags() -> None:
+    """The exact live bug: chat_grammar_consumer lagging must NOT freeze phi."""
+    snap = _snapshot(degraded_reasons=["cursor_lag:chat_grammar_consumer"])
+    assert cognitive_lane_dark(snap) is False
+
+
+def test_cognitive_lane_dark_true_when_execution_trajectory_cursor_lags() -> None:
+    """execution_trajectory's OWN cursor lagging must still freeze phi, even
+    though `classification` (heartbeat/stream-backlog only) doesn't reflect
+    wall-clock cursor lag at all."""
+    snap = _snapshot(degraded_reasons=["cursor_lag:execution_grammar_reducer"])
+    assert cognitive_lane_dark(snap) is True
+
+
+def test_cognitive_lane_dark_true_when_multiple_reducers_lag_including_own() -> None:
+    snap = _snapshot(
+        degraded_reasons=["cursor_lag:chat_grammar_consumer", "cursor_lag:execution_grammar_reducer"]
+    )
+    assert cognitive_lane_dark(snap) is True
+
+
+def test_cognitive_lane_dark_true_on_dark_classification_even_without_lag_reason() -> None:
+    snap = _snapshot(degraded_reasons=[], classification="dead_no_heartbeat")
+    assert cognitive_lane_dark(snap) is True
+
+
+def test_cognitive_lane_dark_true_when_execution_trajectory_reducer_disabled() -> None:
+    snap = _snapshot(degraded_reasons=[], enabled=False)
+    assert cognitive_lane_dark(snap) is True
+
+
+def test_cognitive_lane_dark_false_when_fully_healthy_no_reasons() -> None:
+    snap = _snapshot(degraded_reasons=[])
+    assert cognitive_lane_dark(snap) is False


### PR DESCRIPTION
# fix(spark-introspector): scope grammar-degraded check to execution_trajectory lane

**Status:** IMPLEMENTED, tested, reviewed. Fixes a live production incident
discovered ~45 minutes after deploying specs 1-3 + the enable-switches PR
(#922) — corpus accrual was completely stalled.

## Summary

`orion-spark-introspector`'s `handle_self_state` computed
`grammar_degraded = gt.degraded or cognitive_lane_dark(gt)` — the blanket
`gt.degraded` flag trips whenever **any** substrate reducer's cursor lags,
including `chat_grammar_consumer`, which has nothing to do with φ's
execution/reasoning signals. In production this froze `phi_health` on every
single row (`chat_grammar_consumer` was ~19.4h stale simply because no chat
had occurred), and spec 3's corpus-hygiene gate correctly rejected every
frozen row at write time — the net effect was **zero seed-v4 rows accruing
at all**, silently, with the service otherwise running and ticking normally.

`cognitive_lane_dark(gt)` already existed as the properly-scoped check (only
cares about `execution_trajectory`, the reducer φ's cognitive features
actually depend on) — it just wasn't being trusted on its own; the blanket
flag was still OR'd in alongside it, defeating the point.

## Fix

- `worker.py`: `grammar_degraded = cognitive_lane_dark(gt)`. Dropped the
  blanket `gt.degraded` OR entirely. `cognitive_lane_dark` already fails
  closed on total fetch failure (`enabled_reducers={}`, from
  `_grammar_http_error`) and on `execution_trajectory` being disabled — so
  nothing is lost by removing the blanket flag.
- `substrate_reads.py`: `cognitive_lane_dark()` needed a second check added.
  It originally only looked at `reducer_health_by_name["execution_trajectory"]
  ["classification"]`, but that field — computed server-side by
  `ReducerHealthSnapshot.classify()` — only reflects heartbeat/stream-backlog
  state and **never reflects wall-clock cursor lag** (`cursor_wall_lag_sec`)
  at all. That means `execution_trajectory`'s own cursor going genuinely
  stale would have been invisible to the old scoped check, and was only ever
  caught (incidentally) via the blanket `gt.degraded` OR. Added a targeted
  read of `degraded_reasons` for an entry starting with
  `"cursor_lag:execution_grammar_reducer"` (its own cursor name), so
  execution_trajectory's own lag still freezes correctly, without pulling in
  unrelated reducers.

Confirmed this preserves the existing
`test_handle_self_state_grammar_truth_freeze` test's original intent
byte-for-byte, without modifying that test at all.

## Files changed

- `services/orion-spark-introspector/app/substrate_reads.py` —
  `cognitive_lane_dark()` gains the cursor-lag check; new
  `_EXECUTION_TRAJECTORY_CURSOR_NAME` local constant (duplicated as a stable
  literal rather than importing `orion.substrate.*` into this service).
- `services/orion-spark-introspector/app/worker.py` — one-line change plus
  comment explaining why.
- `services/orion-spark-introspector/tests/test_substrate_reads.py` — 6 new
  unit tests directly on `cognitive_lane_dark`: reproduces the exact bug
  (unrelated lag doesn't trip it), confirms execution_trajectory's own lag
  still does, multiple-reducers-lagging-including-own, dark classification
  still works, reducer-disabled still works, fully-healthy stays clean.
- `services/orion-spark-introspector/tests/test_inner_state_emit.py` — 1 new
  end-to-end test reproducing the live incident exactly through
  `handle_self_state`: `chat_grammar_consumer` lagging + `execution_trajectory`
  healthy → `phi_health == "ok"`, `grammar_truth_degraded is False`, corpus
  sink `.append()` called.

## Tests run

```text
pytest services/orion-spark-introspector/tests -q
  → 104 passed, 1 pre-existing unrelated failure (test_phi_reward_emitted_when_encoder_ok)
```

Every new test verified to fail without the fix and pass with it (reverted
the fix, confirmed the exact expected failures, reapplied).

## Review findings fixed

Self-reviewed (medium effort). No findings — the fix reuses the existing,
already-scoped `cognitive_lane_dark` mechanism rather than inventing a new
health model; confirmed no accidental widening (biometrics/transport_bus
reducer lag still correctly ignored, matching φ's actual dependency surface).

## Docker/build/smoke checks

Not run against containers in this environment. Live-verified the *bug*
directly against the running deployment (`docker logs`, `/grammar/truth`
endpoint) before writing the fix; the fix itself is unit/integration tested
only pending redeploy.

## Restart required

**This is blocking live corpus accrual right now.** Restart
`orion-spark-introspector` to pick up the fix:
```bash
docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml up -d --build
```
After restart, confirm with:
```bash
docker logs orion-athena-spark-introspector --since 2m | grep inner_state_corpus_row_rejected
python scripts/diag.py --corpus /mnt/telemetry/phi/corpus/inner_state.jsonl
```
Rejection log lines should stop appearing (or only appear when
execution_trajectory is genuinely down), and `diag.py`'s `rows_matching_version_and_healthy`
should start climbing from 0.

## Risks / concerns

- Severity: low. Narrows a health check, doesn't widen anything — the only
  behavior change is that an unrelated reducer's lag no longer blocks phi
  corpus writes. execution_trajectory's own degradation (both
  classification-based and wall-clock-lag-based) still freezes correctly.