### PR TITLE
Fix/phi seedv4 variance gate optional reasoning dims

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-09-phi-seedv4-variance-gate-policy-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-09-phi-seedv4-variance-gate-policy-pr.md
@@ -1,0 +1,109 @@
+# feat(fit-phi-encoder): relaxed variance-gate policy for seed-v4's optional reasoning dims
+
+**Status:** IMPLEMENTED, tested, reviewed. Follow-up to the deploy of specs
+1-3 + the grammar-health gate fix — the corpus is now accruing correctly,
+but the promote gate as originally specified can never pass in a deployment
+without an active thinking-capable model.
+
+## Summary
+
+seed-v4's variance gate required ≥7 of 8 trainable dims live
+(`ceil(0.8 * 8)`). Confirmed live (45 min post-deploy): 6 of 8 dims already
+show real variance, but `reasoning_present` and `reasoning_load` are both
+structurally dead here — no thinking-capable model is active, so no call
+ever produces reasoning content, and `reasoning_load` additionally has no
+provider-side thinking-token count to read yet (unrelated to this patch,
+already documented as reserved in the reasoning-telemetry-adapter spec).
+With both permanently dead, the corpus could accrue forever and never reach
+7/8.
+
+**New policy (Juniper's explicit call):**
+- **6/8 required** when both `reasoning_present` and `reasoning_load` are dead.
+- **7/8 required** the moment either one shows real signal — the bar goes
+  back up as soon as it's actually achievable, rather than permanently
+  discounting both.
+
+## Files changed
+
+- `scripts/fit_phi_encoder.py` — `_variance_gate()` gains an optional
+  `feature_names` param. When provided and it contains **both**
+  `reasoning_present` and `reasoning_load` (seed-v4's unique signature —
+  seed-v3 also has `reasoning_present` but never `reasoning_load`, so the
+  policy requires the full set to avoid silently activating for seed-v3
+  too), switches to the fixed 6-or-7 policy. Without `feature_names`, or for
+  any corpus lacking both dims, behavior is byte-identical to the old
+  fraction-based gate (verified by test). `check_corpus_gates()`/`cmd_train()`
+  thread `feature_names` through.
+- `scripts/diag.py` — passes `feature_names` too, so the diagnostic tool's
+  reported gate matches the real promote gate exactly (no more silent
+  drift between what `diag.py` reports and what `fit_phi_encoder.py` would
+  actually do).
+- `tests/test_phi_encoder_fit_script.py` — 6 new tests on `_variance_gate`
+  directly: 6/8 passes when both reasoning dims dead, 7/8 required once one
+  is live, still fails below 6, still passes at 8/8, backward-compat when
+  `feature_names` omitted, and — importantly — seed-v3's own feature names
+  fall through to the plain fraction gate untouched.
+- `tests/test_phi_corpus_diag_script.py` — updated one existing test's
+  expected `need` value (7 → 6) to match the new policy for its fixture
+  (both reasoning dims dead in that synthetic corpus).
+
+## Review finding fixed (self-caught before commit)
+
+- Finding: first draft activated the relaxed policy whenever **any** of the
+  two optional dims appeared in `feature_names` — but seed-v3's own feature
+  set legitimately includes `reasoning_present` (shared cognitive slot name
+  with seed-v4), so the relaxed 6-dim policy would have silently applied to
+  seed-v3 corpora too, weakening its gate without anyone asking for that.
+  - Fix: require the **full set** (`SEEDV4_OPTIONAL_VARIANCE_DIMS.issubset(feature_names)`),
+    which only seed-v4 satisfies (seed-v3 never has `reasoning_load`).
+  - Evidence: `test_variance_gate_seedv3_feature_names_unaffected_by_seedv4_policy`
+    — expects seed-v3's own gate math (`need == ceil(0.8 * 11) == 9`); against
+    the buggy first draft it got `7` (the relaxed seed-v4 policy leaking in),
+    failing the assertion. Passes after the `issubset` fix.
+
+## Tests run
+
+```text
+pytest tests/test_phi_encoder_fit_script.py tests/test_phi_corpus_diag_script.py tests/test_corpus_gate.py -q
+  → 29 passed
+```
+
+Verified against the real live corpus:
+```bash
+python scripts/diag.py --corpus /mnt/telemetry/phi/corpus/inner_state.jsonl
+```
+Before this patch: `{"variance": {"need": 7, "got": 6, "ok": false}}` (stuck,
+unreachable). After: `{"variance": {"need": 6, "got": 6, "ok": true}}`. Only
+`min_hours` remains failing now (needs ≥4h accrual — just time).
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Docker/build/smoke checks
+
+N/A — CLI script logic only, no service/runtime change.
+
+## Restart required
+
+```text
+No restart required. Takes effect the next time scripts/diag.py or
+scripts/fit_phi_encoder.py is run.
+```
+
+## Risks / concerns
+
+- Severity: low. This only relaxes the gate for the two dims that are
+  genuinely unmeasurable in the current deployment; it does not touch the
+  gate for any other dim, and the bar rises back to 7/8 automatically the
+  moment either reasoning dim shows real signal (e.g. after a
+  thinking-capable model is deployed).
+
+## PR link
+
+Branch pushed: `fix/phi-seedv4-variance-gate-optional-reasoning-dims`.
+Compare: https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/phi-seedv4-variance-gate-optional-reasoning-dims

--- a/scripts/diag.py
+++ b/scripts/diag.py
@@ -89,7 +89,7 @@ def run_diag(args: argparse.Namespace) -> dict:
     matrix = np.stack([r.x for r in loaded], axis=0) if loaded else np.zeros((0, len(feature_names)))
     hours = _hours_span(loaded)
     variance_ok, var_ok_count, var_needed = _variance_gate(
-        matrix, fraction=args.variance_fraction, eps=args.variance_eps
+        matrix, fraction=args.variance_fraction, eps=args.variance_eps, feature_names=feature_names
     )
     variances = np.var(matrix, axis=0) if matrix.size else np.zeros(len(feature_names))
     dims = [

--- a/scripts/fit_phi_encoder.py
+++ b/scripts/fit_phi_encoder.py
@@ -72,6 +72,16 @@ DEFAULT_PHI_WEIGHT = 0.25
 DEFAULT_EARLY_STOP_PATIENCE = 15
 DEFAULT_HELD_OUT_FRACTION = 0.15
 
+# seed-v4: reasoning_present/reasoning_load may be structurally dead depending
+# on model/infra deployment (no thinking-capable model active means neither
+# can ever show variance) rather than a corpus-health problem. Gate policy:
+# require 6/8 dims live when BOTH are dead (every other dim must be live);
+# require 7/8 once EITHER shows real signal (holds the bar higher the moment
+# it's actually achievable, rather than permanently discounting both).
+SEEDV4_OPTIONAL_VARIANCE_DIMS: frozenset[str] = frozenset({"reasoning_present", "reasoning_load"})
+SEEDV4_MIN_LIVE_DIMS_BOTH_OPTIONAL_DEAD = 6
+SEEDV4_MIN_LIVE_DIMS_ONE_OPTIONAL_LIVE = 7
+
 
 @dataclass(frozen=True)
 class LoadedRow:
@@ -231,12 +241,36 @@ def _hours_span(rows: list[LoadedRow]) -> float:
     return (end - start).total_seconds() / 3600.0
 
 
-def _variance_gate(matrix: np.ndarray, *, fraction: float, eps: float) -> tuple[bool, int, int]:
+def _variance_gate(
+    matrix: np.ndarray,
+    *,
+    fraction: float,
+    eps: float,
+    feature_names: list[str] | None = None,
+) -> tuple[bool, int, int]:
     if matrix.size == 0:
         return False, 0, matrix.shape[1] if matrix.ndim == 2 else 0
     variances = np.var(matrix, axis=0)
-    ok_count = int(np.sum(variances > eps))
-    needed = int(np.ceil(fraction * matrix.shape[1]))
+    live = variances > eps
+    ok_count = int(np.sum(live))
+    total_dims = matrix.shape[1]
+
+    if feature_names is not None and SEEDV4_OPTIONAL_VARIANCE_DIMS.issubset(feature_names):
+        # Only seed-v4 carries BOTH reasoning_present and reasoning_load --
+        # seed-v3 also has reasoning_present (shared cognitive slot name) but
+        # never reasoning_load, so requiring the full set here keeps this
+        # policy from silently activating for seed-v3's feature set too.
+        optional_idx = [i for i, name in enumerate(feature_names) if name in SEEDV4_OPTIONAL_VARIANCE_DIMS]
+        if optional_idx:
+            optional_live_count = int(np.sum(live[optional_idx]))
+            needed = (
+                SEEDV4_MIN_LIVE_DIMS_ONE_OPTIONAL_LIVE
+                if optional_live_count >= 1
+                else SEEDV4_MIN_LIVE_DIMS_BOTH_OPTIONAL_DEAD
+            )
+            return ok_count >= needed, ok_count, needed
+
+    needed = int(np.ceil(fraction * total_dims))
     return ok_count >= needed, ok_count, needed
 
 
@@ -245,6 +279,7 @@ def check_corpus_gates(
     matrix: np.ndarray,
     *,
     cfg: CorpusGateConfig,
+    feature_names: list[str] | None = None,
 ) -> None:
     if len(rows) < cfg.min_rows:
         raise SystemExit(f"corpus gate failed: min_rows={cfg.min_rows} got={len(rows)}")
@@ -257,6 +292,7 @@ def check_corpus_gates(
         matrix,
         fraction=cfg.variance_fraction,
         eps=cfg.variance_eps,
+        feature_names=feature_names,
     )
     if not ok:
         raise SystemExit(
@@ -552,7 +588,7 @@ def cmd_train(args: argparse.Namespace) -> int:
         variance_fraction=args.variance_fraction,
         variance_eps=args.variance_eps,
     )
-    check_corpus_gates(loaded, matrix, cfg=gate_cfg)
+    check_corpus_gates(loaded, matrix, cfg=gate_cfg, feature_names=feature_names)
 
     train_cfg = TrainConfig(
         hidden_dim=args.hidden_dim,

--- a/tests/test_phi_corpus_diag_script.py
+++ b/tests/test_phi_corpus_diag_script.py
@@ -104,7 +104,9 @@ def test_diag_fails_variance_gate_when_dims_mostly_frozen(tmp_path: Path) -> Non
     from scripts.diag import _parse_args, run_diag
 
     corpus = tmp_path / "corpus.jsonl"
-    # Only 3 of 8 dims carry variance -- needs ceil(0.8*8)=7, so this must fail.
+    # live_dims=3 -> only agency_readiness/execution_pressure/reasoning_pressure
+    # live; reasoning_present AND reasoning_load (indices 5, 7) are both dead,
+    # so the seed-v4 gate policy needs 6 (not the generic ceil(0.8*8)=7).
     _write_corpus(corpus, _live_corpus(n_rows=60, hours_span=5.0, live_dims=3))
     args = _parse_args([
         "--corpus", str(corpus),
@@ -116,7 +118,7 @@ def test_diag_fails_variance_gate_when_dims_mostly_frozen(tmp_path: Path) -> Non
     assert result["ok"] is False
     assert result["gates"]["variance"]["ok"] is False
     assert result["gates"]["variance"]["got"] == 3
-    assert result["gates"]["variance"]["need"] == 7
+    assert result["gates"]["variance"]["need"] == 6
     frozen = [d for d in result["dims"] if not d["live"]]
     assert len(frozen) == 5
 

--- a/tests/test_phi_encoder_fit_script.py
+++ b/tests/test_phi_encoder_fit_script.py
@@ -244,3 +244,101 @@ def test_variance_gate_seed_v3_needs_nine_of_eleven() -> None:
     assert need2 == 9
     assert got2 == 8
     assert ok2 is False
+
+
+SEEDV4_NAMES = [
+    "agency_readiness",
+    "execution_pressure",
+    "reasoning_pressure",
+    "overall_intensity",
+    "recall_gate_fired",
+    "reasoning_present",
+    "execution_load",
+    "reasoning_load",
+]
+
+
+def test_variance_gate_seedv4_needs_six_when_both_reasoning_dims_dead() -> None:
+    from scripts.fit_phi_encoder import _variance_gate
+
+    rng = np.random.default_rng(1)
+    matrix = np.zeros((50, 8), dtype=np.float64)
+    # Live: all 6 non-reasoning dims (indices 0-4, 6). Dead: reasoning_present
+    # (5), reasoning_load (7) -- no thinking-capable model active.
+    for col in (0, 1, 2, 3, 4, 6):
+        matrix[:, col] = rng.standard_normal(50)
+    ok, got, need = _variance_gate(matrix, fraction=0.8, eps=1e-6, feature_names=SEEDV4_NAMES)
+    assert need == 6
+    assert got == 6
+    assert ok is True
+
+
+def test_variance_gate_seedv4_needs_seven_when_one_reasoning_dim_live() -> None:
+    from scripts.fit_phi_encoder import _variance_gate
+
+    rng = np.random.default_rng(2)
+    matrix = np.zeros((50, 8), dtype=np.float64)
+    # Same 6 core dims live, PLUS reasoning_present (index 5) now live too --
+    # got=7. Bar raises to need=7 the moment either reasoning dim shows signal.
+    for col in (0, 1, 2, 3, 4, 5, 6):
+        matrix[:, col] = rng.standard_normal(50)
+    ok, got, need = _variance_gate(matrix, fraction=0.8, eps=1e-6, feature_names=SEEDV4_NAMES)
+    assert need == 7
+    assert got == 7
+    assert ok is True
+
+
+def test_variance_gate_seedv4_fails_below_six_even_with_both_reasoning_dead() -> None:
+    from scripts.fit_phi_encoder import _variance_gate
+
+    rng = np.random.default_rng(3)
+    matrix = np.zeros((50, 8), dtype=np.float64)
+    # Only 5 of the 6 core dims live -> below the relaxed 6/8 floor.
+    for col in (0, 1, 2, 3, 4):
+        matrix[:, col] = rng.standard_normal(50)
+    ok, got, need = _variance_gate(matrix, fraction=0.8, eps=1e-6, feature_names=SEEDV4_NAMES)
+    assert need == 6
+    assert got == 5
+    assert ok is False
+
+
+def test_variance_gate_seedv4_needs_seven_when_both_reasoning_dims_live() -> None:
+    from scripts.fit_phi_encoder import _variance_gate
+
+    rng = np.random.default_rng(4)
+    matrix = rng.standard_normal((50, 8))  # all 8 live
+    ok, got, need = _variance_gate(matrix, fraction=0.8, eps=1e-6, feature_names=SEEDV4_NAMES)
+    assert need == 7
+    assert got == 8
+    assert ok is True
+
+
+def test_variance_gate_ignores_seedv4_policy_without_feature_names() -> None:
+    """Without feature_names, behavior stays the plain fraction-based gate --
+    backward compatible for legacy/seed-v3 callers that never pass names."""
+    from scripts.fit_phi_encoder import _variance_gate
+
+    rng = np.random.default_rng(5)
+    matrix = np.zeros((50, 8), dtype=np.float64)
+    for col in (0, 1, 2, 3, 4, 6):
+        matrix[:, col] = rng.standard_normal(50)
+    ok, got, need = _variance_gate(matrix, fraction=0.8, eps=1e-6)
+    assert need == 7  # ceil(0.8 * 8), not the seed-v4-aware 6
+    assert got == 6
+    assert ok is False
+
+
+def test_variance_gate_seedv3_feature_names_unaffected_by_seedv4_policy() -> None:
+    """seed-v3's feature set doesn't contain reasoning_present/reasoning_load
+    at all, so passing its own feature_names must fall through to the plain
+    fraction-based gate untouched."""
+    from scripts.fit_phi_encoder import _variance_gate, input_features_for_version
+
+    names = input_features_for_version("seed-v3")
+    rng = np.random.default_rng(6)
+    matrix = np.zeros((50, len(names)), dtype=np.float64)
+    for col in range(9):
+        matrix[:, col] = rng.standard_normal(50)
+    ok, got, need = _variance_gate(matrix, fraction=0.8, eps=1e-6, feature_names=names)
+    assert need == int(np.ceil(0.8 * len(names)))
+    assert got == 9


### PR DESCRIPTION
# feat(fit-phi-encoder): relaxed variance-gate policy for seed-v4's optional reasoning dims

**Status:** IMPLEMENTED, tested, reviewed. Follow-up to the deploy of specs
1-3 + the grammar-health gate fix — the corpus is now accruing correctly,
but the promote gate as originally specified can never pass in a deployment
without an active thinking-capable model.

## Summary

seed-v4's variance gate required ≥7 of 8 trainable dims live
(`ceil(0.8 * 8)`). Confirmed live (45 min post-deploy): 6 of 8 dims already
show real variance, but `reasoning_present` and `reasoning_load` are both
structurally dead here — no thinking-capable model is active, so no call
ever produces reasoning content, and `reasoning_load` additionally has no
provider-side thinking-token count to read yet (unrelated to this patch,
already documented as reserved in the reasoning-telemetry-adapter spec).
With both permanently dead, the corpus could accrue forever and never reach
7/8.

**New policy (Juniper's explicit call):**
- **6/8 required** when both `reasoning_present` and `reasoning_load` are dead.
- **7/8 required** the moment either one shows real signal — the bar goes
  back up as soon as it's actually achievable, rather than permanently
  discounting both.

## Files changed

- `scripts/fit_phi_encoder.py` — `_variance_gate()` gains an optional
  `feature_names` param. When provided and it contains **both**
  `reasoning_present` and `reasoning_load` (seed-v4's unique signature —
  seed-v3 also has `reasoning_present` but never `reasoning_load`, so the
  policy requires the full set to avoid silently activating for seed-v3
  too), switches to the fixed 6-or-7 policy. Without `feature_names`, or for
  any corpus lacking both dims, behavior is byte-identical to the old
  fraction-based gate (verified by test). `check_corpus_gates()`/`cmd_train()`
  thread `feature_names` through.
- `scripts/diag.py` — passes `feature_names` too, so the diagnostic tool's
  reported gate matches the real promote gate exactly (no more silent
  drift between what `diag.py` reports and what `fit_phi_encoder.py` would
  actually do).
- `tests/test_phi_encoder_fit_script.py` — 6 new tests on `_variance_gate`
  directly: 6/8 passes when both reasoning dims dead, 7/8 required once one
  is live, still fails below 6, still passes at 8/8, backward-compat when
  `feature_names` omitted, and — importantly — seed-v3's own feature names
  fall through to the plain fraction gate untouched.
- `tests/test_phi_corpus_diag_script.py` — updated one existing test's
  expected `need` value (7 → 6) to match the new policy for its fixture
  (both reasoning dims dead in that synthetic corpus).

## Review finding fixed (self-caught before commit)

- Finding: first draft activated the relaxed policy whenever **any** of the
  two optional dims appeared in `feature_names` — but seed-v3's own feature
  set legitimately includes `reasoning_present` (shared cognitive slot name
  with seed-v4), so the relaxed 6-dim policy would have silently applied to
  seed-v3 corpora too, weakening its gate without anyone asking for that.
  - Fix: require the **full set** (`SEEDV4_OPTIONAL_VARIANCE_DIMS.issubset(feature_names)`),
    which only seed-v4 satisfies (seed-v3 never has `reasoning_load`).
  - Evidence: `test_variance_gate_seedv3_feature_names_unaffected_by_seedv4_policy`
    — expects seed-v3's own gate math (`need == ceil(0.8 * 11) == 9`); against
    the buggy first draft it got `7` (the relaxed seed-v4 policy leaking in),
    failing the assertion. Passes after the `issubset` fix.

## Tests run

```text
pytest tests/test_phi_encoder_fit_script.py tests/test_phi_corpus_diag_script.py tests/test_corpus_gate.py -q
  → 29 passed
```

Verified against the real live corpus:
```bash
python scripts/diag.py --corpus /mnt/telemetry/phi/corpus/inner_state.jsonl
```
Before this patch: `{"variance": {"need": 7, "got": 6, "ok": false}}` (stuck,
unreachable). After: `{"variance": {"need": 6, "got": 6, "ok": true}}`. Only
`min_hours` remains failing now (needs ≥4h accrual — just time).

## Schema / bus / API changes

None.

## Env/config changes

None.

## Docker/build/smoke checks

N/A — CLI script logic only, no service/runtime change.

## Restart required

```text
No restart required. Takes effect the next time scripts/diag.py or
scripts/fit_phi_encoder.py is run.
```

## Risks / concerns

- Severity: low. This only relaxes the gate for the two dims that are
  genuinely unmeasurable in the current deployment; it does not touch the
  gate for any other dim, and the bar rises back to 7/8 automatically the
  moment either reasoning dim shows real signal (e.g. after a
  thinking-capable model is deployed).