### PR TITLE
Feat/fcc motor toolsearch

### DIFF
--- a/docs/superpowers/plans/2026-07-09-fcc-motor-toolsearch.md
+++ b/docs/superpowers/plans/2026-07-09-fcc-motor-toolsearch.md
@@ -1,0 +1,378 @@
+# FCC motor ToolSearch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Set `ENABLE_TOOL_SEARCH=true` on every FCC Claude spawn via the shared subprocess env helper so MCP schemas stay deferred until ToolSearch pulls them, without changing MCP attachment or adding stance/intent gates.
+
+**Architecture:** One `setdefault` in `orion/fcc/context_budget.extend_fcc_subprocess_env` covers both consumers (harness motor + hub agent-claude). Tests assert the helper and both `_build_subprocess_env` paths. Docs note the override; GitHub toolset defaults are re-verified, not redesigned.
+
+**Tech Stack:** Python 3.11+, pytest, existing FCC MCP render path (`orion/fcc/mcp_config.py`), Claude Code env contract (`ENABLE_TOOL_SEARCH`).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-fcc-motor-toolsearch-design.md`
+
+**Branch:** `feat/fcc-motor-toolsearch` (or fresh worktree from `main` per AGENTS.md)
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `orion/fcc/context_budget.py` | `extend_fcc_subprocess_env`: `setdefault("ENABLE_TOOL_SEARCH", "true")` |
+| `orion/fcc/tests/test_context_budget.py` | Unit: default + override preservation |
+| `orion/harness/tests/test_fcc_motor_mcp.py` | Motor spawn env includes ToolSearch |
+| `services/orion-hub/tests/test_fcc_claude_bridge_run.py` | Hub bridge spawn env includes ToolSearch |
+| `services/orion-hub/.env_example` | Comment near MCP flags |
+| `services/orion-harness-governor/.env_example` | Same |
+| `services/orion-hub/README.md` | Short ToolSearch note on FCC MCP section |
+
+**Do not modify:** MCP template servers, stance/imperative classifiers, mid-turn MCP attach/respawn, Claude built-in tool allowlists, `GITHUB_TOOLSETS` default logic in `mcp_config.py` (already correct — only re-run existing tests).
+
+**Already covered (no new code):** `services/orion-hub/tests/test_fcc_mcp_config.py::test_render_defaults_github_toolsets_lean_and_read_only` and `orion/harness/tests/test_fcc_motor_mcp.py::test_maybe_render_mcp_config_defaults_github_toolsets_when_env_absent` assert `GITHUB_TOOLSETS=repos,pull_requests` when FCC env omits it. Task 4 re-runs them as the acceptance gate.
+
+---
+
+### Task 1: Failing tests for `extend_fcc_subprocess_env` ToolSearch
+
+**Files:**
+- Modify: `orion/fcc/tests/test_context_budget.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `orion/fcc/tests/test_context_budget.py`:
+
+```python
+from orion.fcc.context_budget import extend_fcc_subprocess_env
+
+
+def test_extend_fcc_subprocess_env_sets_enable_tool_search_when_unset() -> None:
+    env: dict[str, str] = {}
+    extend_fcc_subprocess_env(env)
+    assert env["ENABLE_TOOL_SEARCH"] == "true"
+
+
+def test_extend_fcc_subprocess_env_preserves_explicit_tool_search_override() -> None:
+    env = {"ENABLE_TOOL_SEARCH": "false"}
+    extend_fcc_subprocess_env(env)
+    assert env["ENABLE_TOOL_SEARCH"] == "false"
+
+
+def test_extend_fcc_subprocess_env_preserves_auto_tool_search_override() -> None:
+    env = {"ENABLE_TOOL_SEARCH": "auto:5"}
+    extend_fcc_subprocess_env(env)
+    assert env["ENABLE_TOOL_SEARCH"] == "auto:5"
+```
+
+Also add `extend_fcc_subprocess_env` to the existing import block at the top of the file (and remove the duplicate inline import above if you prefer a single import site):
+
+```python
+from orion.fcc.context_budget import (
+    CONTEXT_PRESSURE_NUDGE,
+    annotate_harness_step,
+    apply_context_overflow_hint,
+    build_context_pressure_step,
+    context_risk_level,
+    extend_fcc_subprocess_env,
+    is_context_overflow_text,
+    measure_step_payload_chars,
+)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest orion/fcc/tests/test_context_budget.py::test_extend_fcc_subprocess_env_sets_enable_tool_search_when_unset \
+  orion/fcc/tests/test_context_budget.py::test_extend_fcc_subprocess_env_preserves_explicit_tool_search_override \
+  orion/fcc/tests/test_context_budget.py::test_extend_fcc_subprocess_env_preserves_auto_tool_search_override -v
+```
+
+Expected: FAIL with `KeyError: 'ENABLE_TOOL_SEARCH'` (or AssertionError if the key is missing / wrong) on the unset case.
+
+- [ ] **Step 3: Commit tests**
+
+```bash
+git add orion/fcc/tests/test_context_budget.py
+git commit -m "test(fcc): require ENABLE_TOOL_SEARCH in extend_fcc_subprocess_env"
+```
+
+---
+
+### Task 2: Implement ToolSearch setdefault
+
+**Files:**
+- Modify: `orion/fcc/context_budget.py` (function `extend_fcc_subprocess_env`, after the existing `setdefault` lines ~97–99)
+
+- [ ] **Step 1: Add one line to the helper**
+
+In `extend_fcc_subprocess_env`, after:
+
+```python
+    env.setdefault("ORION_FCC_MCP_TOOL_RESULT_MAX_CHARS", str(mcp_tool_result_max_chars()))
+    env.setdefault("HARNESS_FCC_CONTEXT_PRESSURE_PCT", str(context_pressure_threshold_pct()))
+    env.setdefault("HARNESS_FCC_MAX_CONTEXT_TOKENS", str(max_context_tokens()))
+```
+
+add:
+
+```python
+    # Claude Code: custom ANTHROPIC_BASE_URL disables ToolSearch unless set explicitly.
+    # Keep MCP attached; defer schema load until the model ToolSearches.
+    env.setdefault("ENABLE_TOOL_SEARCH", "true")
+```
+
+Do not set the key with `env["ENABLE_TOOL_SEARCH"] = "true"` — that would clobber operator debug overrides (`false` / `auto` / `auto:N`).
+
+- [ ] **Step 2: Run helper tests to verify they pass**
+
+```bash
+pytest orion/fcc/tests/test_context_budget.py -q
+```
+
+Expected: PASS (all tests in the file, including the three new ones).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add orion/fcc/context_budget.py
+git commit -m "feat(fcc): enable ToolSearch on FCC Claude subprocess env"
+```
+
+---
+
+### Task 3: Consumer spawn-env tests (motor + hub)
+
+**Files:**
+- Modify: `orion/harness/tests/test_fcc_motor_mcp.py`
+- Modify: `services/orion-hub/tests/test_fcc_claude_bridge_run.py`
+
+Both consumers already call `extend_fcc_subprocess_env` from `_build_subprocess_env` / `_fcc_context_env`. These tests lock the contract at the spawn boundary so a future refactor that bypasses the helper fails loudly.
+
+- [ ] **Step 1: Write failing motor test**
+
+Append to `orion/harness/tests/test_fcc_motor_mcp.py` (near `test_build_subprocess_env_sets_context_ceiling`):
+
+```python
+def test_build_subprocess_env_enables_tool_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ENABLE_TOOL_SEARCH", raising=False)
+    env = motor._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["ENABLE_TOOL_SEARCH"] == "true"
+
+
+def test_build_subprocess_env_preserves_tool_search_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENABLE_TOOL_SEARCH", "false")
+    env = motor._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["ENABLE_TOOL_SEARCH"] == "false"
+```
+
+Note: `_build_subprocess_env` starts from `os.environ.copy()`, so the override test must set the process env via `monkeypatch.setenv`, not only a local dict.
+
+- [ ] **Step 2: Write failing hub bridge test**
+
+Append to `services/orion-hub/tests/test_fcc_claude_bridge_run.py` (near the other `_build_subprocess_env` tests):
+
+```python
+@pytest.mark.asyncio
+async def test_build_subprocess_env_enables_tool_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ENABLE_TOOL_SEARCH", raising=False)
+    env = bridge._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["ENABLE_TOOL_SEARCH"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_build_subprocess_env_preserves_tool_search_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENABLE_TOOL_SEARCH", "auto")
+    env = bridge._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["ENABLE_TOOL_SEARCH"] == "auto"
+```
+
+- [ ] **Step 3: Run consumer tests**
+
+```bash
+pytest orion/harness/tests/test_fcc_motor_mcp.py::test_build_subprocess_env_enables_tool_search \
+  orion/harness/tests/test_fcc_motor_mcp.py::test_build_subprocess_env_preserves_tool_search_override \
+  services/orion-hub/tests/test_fcc_claude_bridge_run.py::test_build_subprocess_env_enables_tool_search \
+  services/orion-hub/tests/test_fcc_claude_bridge_run.py::test_build_subprocess_env_preserves_tool_search_override -v
+```
+
+Expected: PASS (Task 2 already landed the helper; these assert the call chain). If either fails with missing key, the consumer is not calling `extend_fcc_subprocess_env` — fix the call site, do not duplicate `ENABLE_TOOL_SEARCH` in motor/hub.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add orion/harness/tests/test_fcc_motor_mcp.py \
+  services/orion-hub/tests/test_fcc_claude_bridge_run.py
+git commit -m "test(fcc): assert ToolSearch on motor and hub spawn env"
+```
+
+---
+
+### Task 4: Re-verify GitHub toolset restriction (no code change)
+
+**Files:**
+- Test only (existing): `services/orion-hub/tests/test_fcc_mcp_config.py`
+- Test only (existing): `orion/harness/tests/test_fcc_motor_mcp.py`
+
+- [ ] **Step 1: Run the existing toolset gates**
+
+```bash
+pytest \
+  services/orion-hub/tests/test_fcc_mcp_config.py::test_render_defaults_github_toolsets_lean_and_read_only \
+  services/orion-hub/tests/test_fcc_mcp_config.py::test_render_github_toolsets_override_from_env \
+  orion/harness/tests/test_fcc_motor_mcp.py::test_maybe_render_mcp_config_defaults_github_toolsets_when_env_absent \
+  orion/harness/tests/test_fcc_motor_mcp.py::test_maybe_render_mcp_config_passes_github_toolsets -v
+```
+
+Expected: PASS. Defaults remain `repos,pull_requests` when `GITHUB_TOOLSETS` is absent from FCC env; explicit FCC env overrides still win; docker `-e GITHUB_TOOLSETS` passthrough still present.
+
+If any fail, stop — that is a regression outside ToolSearch and must be fixed before docs. Do **not** invent a new Orion tool allowlist.
+
+- [ ] **Step 2: No commit if nothing changed**
+
+If all green and no file edits, skip commit. If you had to fix a real regression, commit that fix separately with a clear message.
+
+---
+
+### Task 5: Env example comments + hub README
+
+**Files:**
+- Modify: `services/orion-hub/.env_example`
+- Modify: `services/orion-harness-governor/.env_example`
+- Modify: `services/orion-hub/README.md`
+
+Do **not** add a required `ENABLE_TOOL_SEARCH=` key to `.env_example` (happy path is code-set). Comment-only documentation avoids env sync churn. If you choose to add an optional commented line `# ENABLE_TOOL_SEARCH=true`, that is fine; still no required key and no `settings.py` field.
+
+- [ ] **Step 1: Hub `.env_example` comment**
+
+Immediately after the MCP block around:
+
+```text
+HUB_AGENT_CLAUDE_MCP_ENABLED=true
+```
+
+insert:
+
+```text
+# FCC Claude spawns set ENABLE_TOOL_SEARCH=true via orion.fcc.context_budget.extend_fcc_subprocess_env
+# (defers MCP schema load on custom ANTHROPIC_BASE_URL). Override only for debug: false | auto | auto:N
+```
+
+- [ ] **Step 2: Harness-governor `.env_example` comment**
+
+Immediately after:
+
+```text
+HARNESS_FCC_MCP_ENABLED=true
+```
+
+insert the same two comment lines:
+
+```text
+# FCC Claude spawns set ENABLE_TOOL_SEARCH=true via orion.fcc.context_budget.extend_fcc_subprocess_env
+# (defers MCP schema load on custom ANTHROPIC_BASE_URL). Override only for debug: false | auto | auto:N
+```
+
+- [ ] **Step 3: Hub README note**
+
+In `services/orion-hub/README.md`, in the section `### fcc-claude MCP (GitHub + Firecrawl + AI Town)`, after the paragraph that starts with `When \`HUB_AGENT_CLAUDE_MCP_ENABLED=true\``, add:
+
+```markdown
+**ToolSearch:** FCC Claude subprocesses set `ENABLE_TOOL_SEARCH=true` through `orion.fcc.context_budget.extend_fcc_subprocess_env` (shared with harness-governor). MCP servers stay attached; Claude Code loads tool schemas into context only when ToolSearch pulls them. This counters the custom-`ANTHROPIC_BASE_URL` fallback that otherwise dumps all MCP schemas at spawn. Operators may override `ENABLE_TOOL_SEARCH` in the process environment for debugging (`false` / `auto` / `auto:N`). Optional further GitHub surface tightening: set `GITHUB_TOOLSETS` in `~/.fcc/.env` (code default remains `repos,pull_requests` when unset).
+```
+
+- [ ] **Step 4: Env sync only if a real key was added**
+
+If `.env_example` gained only comments (recommended), skip sync.
+
+If you added an actual `ENABLE_TOOL_SEARCH=` key line, run:
+
+```bash
+python scripts/sync_local_env_from_example.py
+```
+
+and report any skipped keys.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/orion-hub/.env_example \
+  services/orion-harness-governor/.env_example \
+  services/orion-hub/README.md
+git commit -m "docs(fcc): document ToolSearch on FCC MCP spawn path"
+```
+
+---
+
+### Task 6: Full gate + live smoke note
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run focused unit gates**
+
+```bash
+pytest orion/fcc/tests/test_context_budget.py \
+  orion/harness/tests/test_fcc_motor_mcp.py \
+  services/orion-hub/tests/test_fcc_claude_bridge_run.py \
+  services/orion-hub/tests/test_fcc_mcp_config.py \
+  services/orion-hub/tests/test_fcc_claude_bridge_mcp.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Live smoke (when runnable) — else mark UNVERIFIED**
+
+After restarting consumers that spawn FCC Claude:
+
+```bash
+# Restart (print for Juniper; do not sudo from the agent):
+docker compose --env-file .env --env-file services/orion-hub/.env \
+  -f services/orion-hub/docker-compose.yml up -d --build
+docker compose --env-file .env --env-file services/orion-harness-governor/.env \
+  -f services/orion-harness-governor/docker-compose.yml up -d --build
+```
+
+Smoke intent (operator-observed, not a new automated eval in this patch):
+
+1. Ordinary chat turn: context should **not** advertise/load the full ~71 MCP tool schema set at spawn.
+2. A turn that needs GitHub/Firecrawl should still reach those tools via ToolSearch then MCP.
+
+If live smoke cannot run in this environment, PR report must say `UNVERIFIED` for the live path and include the restart + observation steps above. Do **not** add a stance/intent MCP gate as a fallback in this PR. If the proxy rejects `tool_reference` or schemas still dump, status is `DONE_WITH_CONCERNS` with a follow-up on FCC/gateway ToolSearch support.
+
+- [ ] **Step 3: Code review subagent + PR report**
+
+Per AGENTS.md: run code review skill in a subagent, fix material findings, push branch, produce the standard Markdown PR description. Confirm non-goals held: no keyword/stance MCP attach gate.
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec requirement | Task |
+|------------------|------|
+| `ENABLE_TOOL_SEARCH=true` via `setdefault` in `extend_fcc_subprocess_env` | Task 2 |
+| Operator override preserved | Tasks 1, 3 |
+| Keep MCP attachment as-is (no stance/intent gate) | Explicit non-touch list; Task 6 review check |
+| GitHub toolsets default still `repos,pull_requests` | Task 4 (existing tests) |
+| `.env_example` comments hub + harness-governor | Task 5 |
+| Hub README short note | Task 5 |
+| Unit acceptance for helper + both spawn paths | Tasks 1–3 |
+| Live smoke or UNVERIFIED | Task 6 |
+| No new keyword cathedral / tool taxonomy | Non-goals + Task 4 |
+
+**Placeholder scan:** none — all steps have concrete code, commands, and expected results.
+
+**Type consistency:** key name is always `ENABLE_TOOL_SEARCH`; helper is always `extend_fcc_subprocess_env`; consumers remain `_build_subprocess_env`.
+
+---
+
+## Out of scope (do not sneak in)
+
+- Stance-based or imperative-classifier MCP attach/detach
+- Progressive respawn (“bare hop then re-spawn with MCP”)
+- Custom MCP multiplexer / lazy server proxy
+- Changing `fcc_claude_mcp.template.json` server list
+- Changing Claude built-in tools (Bash/Read/…)
+- New Orion tool allowlist / taxonomy
+)

--- a/docs/superpowers/specs/2026-07-09-fcc-motor-toolsearch-design.md
+++ b/docs/superpowers/specs/2026-07-09-fcc-motor-toolsearch-design.md
@@ -1,0 +1,137 @@
+# FCC motor ToolSearch — design spec
+
+**Date:** 2026-07-09  
+**Status:** Approved for implementation  
+**Parent:** FCC motor / hub agent-claude MCP path (`orion/harness/fcc_motor.py`, `services/orion-hub/scripts/fcc_claude_bridge.py`)  
+**Related:** `docs/superpowers/specs/2026-07-05-orion-imperative-first-motor-design.md` (tools available; motor decides depth — no pre-motor classifier)
+
+**One line:** Keep MCP servers attached; stop dumping their schemas into every FCC turn — enable Claude Code ToolSearch so the motor loads a tool library only when it needs it.
+
+---
+
+## Arsonist summary
+
+Casual chat should not pay for GitHub/Firecrawl/AI Town tool schemas.
+
+Orion already attaches MCP on FCC turns when MCP is enabled. That is fine. The bug is **eager schema injection**: Claude Code, when `ANTHROPIC_BASE_URL` points at FCC (a non-first-party host), falls back to loading all MCP tool definitions into context at spawn. Live symptom on a ~137k context window: turns report on the order of **~71 tools** being chewed before useful work starts. Bigger context made the drag more obvious, not less.
+
+Claude Code already has the world-class answer: **ToolSearch** — catalog stays light; the model pulls schemas into the working set when it needs a capability. Orion never sets `ENABLE_TOOL_SEARCH`, so the custom-base-URL fallback wins and dumps everything.
+
+Do not build stance gates, intent classifiers, or mid-turn MCP respawn routers. Flip the library switch. Confirm GitHub toolsets still reach the container so we are not also advertising an oversized GitHub surface.
+
+---
+
+## Current architecture
+
+| Seam | Behavior today |
+|------|----------------|
+| `HARNESS_FCC_MCP_ENABLED` / `HUB_AGENT_CLAUDE_MCP_ENABLED` | When true, render ephemeral MCP config and pass `--mcp-config` + `--allowedTools mcp__<server>` |
+| `orion/fcc/mcp_config.py` | Defaults `GITHUB_TOOLSETS` to `repos,pull_requests` if unset in `~/.fcc/.env` |
+| `orion/fcc/context_budget.extend_fcc_subprocess_env` | Shared subprocess env for motor + hub (PYTHONPATH, MCP result caps, context ceiling) |
+| `ANTHROPIC_BASE_URL` | Set to FCC server URL on every spawn |
+| `ENABLE_TOOL_SEARCH` | **Unset** in Orion — Claude Code therefore falls back to upfront MCP schema load on custom base URL |
+| Operator brief | Prompt discipline only (relational vs instrumental); does not change which schemas enter context |
+
+**Evidence (operator-reported, UNVERIFIED in this design session):** ~137k ctx turns show ~71 tools in play; latency/drag is severe on ordinary chat.
+
+**Operator FCC env note:** `~/.fcc/.env` currently has Firecrawl secrets but no explicit `GITHUB_TOOLSETS` line. Code default should still apply at render time; implementation must verify the rendered MCP JSON actually carries the restricted toolsets into the github-mcp container env.
+
+---
+
+## Problem
+
+1. MCP schemas are loaded into context as soon as a turn starts, including rando chat that never calls them.
+2. Custom `ANTHROPIC_BASE_URL` disables Claude's default ToolSearch deferral unless `ENABLE_TOOL_SEARCH` is set explicitly.
+3. A large advertised tool surface (~71) burns tokens and time before the motor can hop.
+
+This is not a missing Orion abstraction. It is a missing env contract on the existing spawn path.
+
+---
+
+## Design
+
+### 1. Enable ToolSearch on every FCC claude spawn
+
+In `orion/fcc/context_budget.extend_fcc_subprocess_env`, set:
+
+```text
+ENABLE_TOOL_SEARCH=true
+```
+
+Use `setdefault` so an operator can override for debugging (`false` / `auto` / `auto:N`) without a code change.
+
+Both consumers already call this helper:
+
+- harness motor: `orion/harness/fcc_motor.py` → `_build_subprocess_env`
+- hub agent-claude: `services/orion-hub/scripts/fcc_claude_bridge.py` → `_build_subprocess_env`
+
+No duplicate wiring in each bridge beyond tests.
+
+### 2. Keep MCP attachment as-is
+
+- Do **not** remove GitHub/Firecrawl/AI Town from the MCP template.
+- Do **not** gate MCP on stance, imperative keywords, or turn mode.
+- Do **not** add mid-session MCP attach/respawn logic.
+- Motor still decides whether to *use* tools while hopping; ToolSearch decides when schemas enter context.
+
+### 3. Confirm GitHub toolset restriction still applies
+
+Same patch, thin verification only:
+
+- Assert rendered MCP config (or motor render path) still injects `GITHUB_TOOLSETS` (default `repos,pull_requests`) into the github server env.
+- Document that operators may set `GITHUB_TOOLSETS` in `~/.fcc/.env` to tighten further; empty/missing continues to use the code default.
+- Do **not** invent a new Orion tool taxonomy or allowlist cathedral.
+
+### 4. Config / docs surface
+
+- Comment in hub + harness-governor `.env_example` near MCP flags: FCC spawns set `ENABLE_TOOL_SEARCH=true` via shared helper; override only for debug.
+- No new required operator env key for the happy path (code sets it).
+- If a service `.env_example` documents optional override `ENABLE_TOOL_SEARCH`, sync local `.env` via `python scripts/sync_local_env_from_example.py`.
+
+### 5. Failure / compatibility note
+
+ToolSearch requires the model/proxy path to accept `tool_reference` blocks. FCC is a custom `ANTHROPIC_BASE_URL`.
+
+- **Happy path:** `ENABLE_TOOL_SEARCH=true` forces the beta/deferral path through the proxy; casual turns stop dumping full MCP schemas; tool-needing turns ToolSearch then call MCP.
+- **If live smoke fails** (proxy rejects `tool_reference`, Haiku-class model, or schemas still dump): mark live path `UNVERIFIED` / `DONE_WITH_CONCERNS` and open a follow-up on FCC/gateway support — do **not** replace this with a stance router in the same patch.
+
+---
+
+## Non-goals
+
+- Stance-based or imperative-classifier MCP attach/detach
+- Progressive respawn (“bare hop then re-spawn with MCP”)
+- Custom MCP multiplexer / lazy server proxy
+- Changing which MCP servers exist in `fcc_claude_mcp.template.json`
+- Changing Claude built-in tools (Bash/Read/…)
+- Claiming sentience or “smart tool routing” beyond ToolSearch
+
+---
+
+## Files likely to touch
+
+| Path | Change |
+|------|--------|
+| `orion/fcc/context_budget.py` | `ENABLE_TOOL_SEARCH=true` via `setdefault` |
+| `orion/fcc/tests/test_context_budget.py` | Assert env key |
+| `orion/harness/tests/test_fcc_motor_mcp.py` (or sibling) | Spawn env includes ToolSearch |
+| `services/orion-hub/tests/test_fcc_claude_bridge_mcp.py` (or sibling) | Same for hub bridge |
+| `services/orion-hub/.env_example` | Comment / optional override note |
+| `services/orion-harness-governor/.env_example` | Same |
+| `services/orion-hub/README.md` (short) | Document ToolSearch on FCC MCP path |
+
+---
+
+## Acceptance checks
+
+1. Unit: `extend_fcc_subprocess_env` sets `ENABLE_TOOL_SEARCH=true` when unset; preserves explicit override.
+2. Unit: motor and hub FCC spawn env (via shared helper or captured subprocess env) include `ENABLE_TOOL_SEARCH=true`.
+3. Unit: MCP render still defaults `GITHUB_TOOLSETS` to `repos,pull_requests` when FCC env omits it.
+4. Live smoke (when runnable): ordinary chat turn does not advertise/load the full MCP schema set into context; a turn that needs GitHub/Firecrawl still reaches those tools via ToolSearch. If smoke cannot run, report `UNVERIFIED` with exact command for Juniper.
+5. No new keyword/stance MCP gate.
+
+---
+
+## Recommended next patch
+
+Implementation plan via writing-plans: one thin PR — shared env setdefault + tests + env_example comments + short README note. Optional live smoke after restart of hub / harness-governor FCC consumers.

--- a/orion/fcc/context_budget.py
+++ b/orion/fcc/context_budget.py
@@ -96,6 +96,9 @@ def extend_fcc_subprocess_env(env: dict[str, str], *, workspace: str | None = No
     env.setdefault("ORION_FCC_MCP_TOOL_RESULT_MAX_CHARS", str(mcp_tool_result_max_chars()))
     env.setdefault("HARNESS_FCC_CONTEXT_PRESSURE_PCT", str(context_pressure_threshold_pct()))
     env.setdefault("HARNESS_FCC_MAX_CONTEXT_TOKENS", str(max_context_tokens()))
+    # Claude Code: custom ANTHROPIC_BASE_URL disables ToolSearch unless set explicitly.
+    # Keep MCP attached; defer schema load until the model ToolSearches.
+    env.setdefault("ENABLE_TOOL_SEARCH", "true")
 
 
 def context_pressure_threshold_chars() -> int:

--- a/orion/fcc/tests/test_context_budget.py
+++ b/orion/fcc/tests/test_context_budget.py
@@ -10,6 +10,7 @@ from orion.fcc.context_budget import (
     apply_context_overflow_hint,
     build_context_pressure_step,
     context_risk_level,
+    extend_fcc_subprocess_env,
     is_context_overflow_text,
     measure_step_payload_chars,
 )
@@ -72,3 +73,21 @@ def test_mcp_proxy_truncates_large_tool_text() -> None:
     text = parsed["result"]["content"][0]["text"]
     assert len(text) < len(huge)
     assert "orion-fcc-mcp-proxy" in text
+
+
+def test_extend_fcc_subprocess_env_sets_enable_tool_search_when_unset() -> None:
+    env: dict[str, str] = {}
+    extend_fcc_subprocess_env(env)
+    assert env["ENABLE_TOOL_SEARCH"] == "true"
+
+
+def test_extend_fcc_subprocess_env_preserves_explicit_tool_search_override() -> None:
+    env = {"ENABLE_TOOL_SEARCH": "false"}
+    extend_fcc_subprocess_env(env)
+    assert env["ENABLE_TOOL_SEARCH"] == "false"
+
+
+def test_extend_fcc_subprocess_env_preserves_auto_tool_search_override() -> None:
+    env = {"ENABLE_TOOL_SEARCH": "auto:5"}
+    extend_fcc_subprocess_env(env)
+    assert env["ENABLE_TOOL_SEARCH"] == "auto:5"

--- a/orion/harness/tests/test_fcc_motor_mcp.py
+++ b/orion/harness/tests/test_fcc_motor_mcp.py
@@ -257,6 +257,20 @@ def test_build_subprocess_env_sets_context_ceiling(monkeypatch: pytest.MonkeyPat
     assert env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] == "70"
 
 
+def test_build_subprocess_env_enables_tool_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ENABLE_TOOL_SEARCH", raising=False)
+    env = motor._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["ENABLE_TOOL_SEARCH"] == "true"
+
+
+def test_build_subprocess_env_preserves_tool_search_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENABLE_TOOL_SEARCH", "false")
+    env = motor._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["ENABLE_TOOL_SEARCH"] == "false"
+
+
 @pytest.mark.asyncio
 async def test_run_fcc_turn_root_uses_dont_ask_permission_mode(
     monkeypatch: pytest.MonkeyPatch,

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -37,6 +37,8 @@ HARNESS_FCC_CLAUDE_BIN_HOST=
 HARNESS_REPO_MOUNT=/mnt/scripts/Orion-Sapienform
 # Orion-mode FCC MCP — secrets in ~/.fcc/.env (see config/fcc.env_example)
 HARNESS_FCC_MCP_ENABLED=true
+# FCC Claude spawns set ENABLE_TOOL_SEARCH=true via orion.fcc.context_budget.extend_fcc_subprocess_env
+# (defers MCP schema load on custom ANTHROPIC_BASE_URL). Override only for debug: false | auto | auto:N
 # Optional override when git remote is unavailable in workspace mount
 ORION_GITHUB_OWNER=
 ORION_GITHUB_REPO=

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -83,6 +83,8 @@ ORION_FCC_MCP_TOOL_RESULT_MAX_CHARS=12000
 # Secrets ONLY in ~/.fcc/.env — see config/fcc.env_example (never put GITHUB_PAT / FIRECRAWL / AITOWN_* here)
 # Agent Claude mode: flags below. Orion unified turn: HARNESS_FCC_MCP_ENABLED + HARNESS_AITOWN_ENABLED on harness-governor.
 HUB_AGENT_CLAUDE_MCP_ENABLED=true
+# FCC Claude spawns set ENABLE_TOOL_SEARCH=true via orion.fcc.context_budget.extend_fcc_subprocess_env
+# (defers MCP schema load on custom ANTHROPIC_BASE_URL). Override only for debug: false | auto | auto:N
 HUB_AITOWN_ENABLED=true
 HUB_AITOWN_UI_URL=http://127.0.0.1:5173
 # Secrets live in ~/.fcc/.env: GITHUB_PAT, FIRECRAWL_API_KEY, AITOWN_* (template: config/fcc.env_example)

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -533,6 +533,8 @@ PYTHONPATH=services/orion-hub:. python services/orion-hub/scripts/verify_agent_c
 
 When `HUB_AGENT_CLAUDE_MCP_ENABLED=true`, each agent-claude turn renders an ephemeral MCP config from `config/fcc_claude_mcp.template.json` and passes `--mcp-config` + per-server `--allowedTools` (e.g. `mcp__github`, `mcp__firecrawl`) and `--disallowedTools Bash(gh *)` to `claude -p`. Secrets live in operator `~/.fcc/.env` (not Hub `.env`):
 
+**ToolSearch:** FCC Claude subprocesses set `ENABLE_TOOL_SEARCH=true` through `orion.fcc.context_budget.extend_fcc_subprocess_env` (shared with harness-governor). MCP servers stay attached; Claude Code loads tool schemas into context only when ToolSearch pulls them. This counters the custom-`ANTHROPIC_BASE_URL` fallback that otherwise dumps all MCP schemas at spawn. Operators may override `ENABLE_TOOL_SEARCH` in the process environment for debugging (`false` / `auto` / `auto:N`). Optional further GitHub surface tightening: set `GITHUB_TOOLSETS` in `~/.fcc/.env` (code default remains `repos,pull_requests` when unset).
+
 | Key | Required | Purpose |
 |-----|----------|---------|
 | `GITHUB_PAT` | yes | GitHub MCP (`ghcr.io/github/github-mcp-server` via Docker) |

--- a/services/orion-hub/tests/test_fcc_claude_bridge_run.py
+++ b/services/orion-hub/tests/test_fcc_claude_bridge_run.py
@@ -159,6 +159,22 @@ async def test_build_subprocess_env_omits_autocompact_when_zero(monkeypatch: pyt
     assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in env
 
 
+@pytest.mark.asyncio
+async def test_build_subprocess_env_enables_tool_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ENABLE_TOOL_SEARCH", raising=False)
+    env = bridge._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["ENABLE_TOOL_SEARCH"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_build_subprocess_env_preserves_tool_search_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENABLE_TOOL_SEARCH", "auto")
+    env = bridge._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["ENABLE_TOOL_SEARCH"] == "auto"
+
+
 def test_is_context_overflow_text_detects_llamacpp_error() -> None:
     sample = 'exceed_context_size_error n_ctx":65536'
     assert bridge.is_context_overflow_text(sample) is True

--- a/services/orion-hub/tests/test_fcc_claude_bridge_run.py
+++ b/services/orion-hub/tests/test_fcc_claude_bridge_run.py
@@ -159,15 +159,13 @@ async def test_build_subprocess_env_omits_autocompact_when_zero(monkeypatch: pyt
     assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in env
 
 
-@pytest.mark.asyncio
-async def test_build_subprocess_env_enables_tool_search(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_subprocess_env_enables_tool_search(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ENABLE_TOOL_SEARCH", raising=False)
     env = bridge._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
     assert env["ENABLE_TOOL_SEARCH"] == "true"
 
 
-@pytest.mark.asyncio
-async def test_build_subprocess_env_preserves_tool_search_override(
+def test_build_subprocess_env_preserves_tool_search_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("ENABLE_TOOL_SEARCH", "auto")


### PR DESCRIPTION
## Summary

- Set `ENABLE_TOOL_SEARCH=true` via `setdefault` in `orion.fcc.context_budget.extend_fcc_subprocess_env` so Claude Code defers MCP schema load when `ANTHROPIC_BASE_URL` points at FCC.
- Cover helper + motor/hub spawn-env contracts with unit tests (default + operator override).
- Document the behavior in hub/harness-governor `.env_example` comments and hub README (no new required env key).
- Include design spec + implementation plan under `docs/superpowers/`.

## Outcome moved

Casual FCC turns stop paying upfront for the full MCP tool schema dump (~71 tools on large context). MCP servers stay attached; ToolSearch decides when schemas enter context. Motor still decides whether to *use* tools.

## Current architecture

FCC motor (`orion/harness/fcc_motor.py`) and hub agent-claude (`services/orion-hub/scripts/fcc_claude_bridge.py`) already call `extend_fcc_subprocess_env` for PYTHONPATH / MCP result caps / context ceiling. `ENABLE_TOOL_SEARCH` was unset, so Claude Code's custom-base-URL fallback loaded all MCP schemas at spawn.

## Architecture touched

- Shared FCC subprocess env helper (both consumers inherit automatically)
- Docs/operator contract comments only — no bus/schema/API changes
- No stance/intent MCP attach gate; no mid-turn MCP respawn

## Files changed

- `orion/fcc/context_budget.py`: `setdefault("ENABLE_TOOL_SEARCH", "true")`
- `orion/fcc/tests/test_context_budget.py`: helper default + override tests
- `orion/harness/tests/test_fcc_motor_mcp.py`: motor spawn env ToolSearch tests
- `services/orion-hub/tests/test_fcc_claude_bridge_run.py`: hub spawn env ToolSearch tests
- `services/orion-hub/.env_example` / `services/orion-harness-governor/.env_example`: comment notes
- `services/orion-hub/README.md`: ToolSearch note on FCC MCP section
- `docs/superpowers/specs/2026-07-09-fcc-motor-toolsearch-design.md`: design
- `docs/superpowers/plans/2026-07-09-fcc-motor-toolsearch.md`: implementation plan

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: FCC Claude subprocess env now defaults ToolSearch on
- Compatibility notes: operator may override `ENABLE_TOOL_SEARCH` (`false` / `auto` / `auto:N`) via process env; `setdefault` preserves it

## Env/config changes

- Added keys: none (code-set default)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: comment-only (hub + harness-governor)
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: n/a (comments only)
- skipped keys requiring operator action: none

## Tests run

```text
PYTHONPATH=.:services/orion-hub orion_dev/bin/pytest \
  orion/fcc/tests/test_context_budget.py \
  orion/harness/tests/test_fcc_motor_mcp.py \
  services/orion-hub/tests/test_fcc_mcp_config.py \
  services/orion-hub/tests/test_fcc_claude_bridge_mcp.py \
  services/orion-hub/tests/test_fcc_claude_bridge_run.py::test_build_subprocess_env_enables_tool_search \
  services/orion-hub/tests/test_fcc_claude_bridge_run.py::test_build_subprocess_env_preserves_tool_search_override \
  services/orion-hub/tests/test_fcc_claude_bridge_run.py::test_build_subprocess_env_sets_claude_context_limits \
  -q
→ 35 passed
```

GitHub toolset gates also re-run green (`repos,pull_requests` default preserved).

## Evals run

```text
No new eval harness for this env-contract seam. Unit gates cover the deterministic contract.
```

## Docker/build/smoke checks

```text
UNVERIFIED live smoke this session.
After merge/restart, confirm ordinary chat does not dump full MCP schemas, and a GitHub/Firecrawl turn still reaches tools via ToolSearch.
```

## Review findings fixed

- Finding: hub ToolSearch spawn-env tests were incorrectly marked `@pytest.mark.asyncio` / `async def` though `_build_subprocess_env` is sync
  - Fix: converted to sync tests in `test_fcc_claude_bridge_run.py`
  - Evidence: 2 passed after change; commit `4b2d3f49`

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-harness-governor/.env \
  -f services/orion-harness-governor/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: medium (live path)
- Concern: FCC/proxy may reject `tool_reference` or schemas may still dump depending on Claude Code / model path
- Mitigation: mark live path UNVERIFIED until operator smoke; do not add stance MCP gates as fallback; follow up on FCC/gateway if smoke fails

## Test plan

- [ ] Restart hub + harness-governor with the commands above
- [ ] Ordinary chat turn: confirm context does not advertise/load the full ~71 MCP tool schema set at spawn
- [ ] Tool-needing turn (GitHub PR or Firecrawl): confirm ToolSearch then MCP still works
- [ ] Optional: set `ENABLE_TOOL_SEARCH=false` in process env and confirm override is preserved for debug
