### PR TITLE
Feat/goal context listener production

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-10-goal-context-listener-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-10-goal-context-listener-pr.md
@@ -1,0 +1,138 @@
+# feat(orion-substrate-runtime): wire goal-context listener for voluntary attention
+
+**Status:** IMPLEMENTED, tested, reviewed. Closes the last-mile gap in the
+already-merged voluntary-attention-override feature (PR #891).
+
+## Summary
+
+`orion/substrate/attention/top_down.py` (biased competition / voluntary
+attention) has been merged, fully wired into the live attention-frame
+pipeline, and gated off by `ORION_ATTENTION_TOPDOWN_ENABLED=false` since
+PR #891. Traced the entire codebase and found `set_active_goal()` — the only
+function that populates the goal-context store the feature reads from — was
+never called anywhere except its own definition and a unit test. Even with
+the flag enabled, voluntary attention would have been a permanent no-op.
+
+This adds the missing bus consumer: `orion-substrate-runtime` now subscribes
+to `orion:memory:goals:proposed` (`GoalProposalV1`, already producer-wired by
+`orion-spark-concept-induction`, already permitted for any consumer via the
+channel's wildcard) and calls `set_active_goal()` on every valid proposal.
+
+**`ORION_ATTENTION_TOPDOWN_ENABLED` stays `false`** — this patch only makes
+the store have real data ready; enabling voluntary attention is a separate,
+later decision.
+
+## Architecture touched
+
+- New live bus-pubsub consumer in `orion-substrate-runtime`, mirroring the
+  existing `post_turn_closure_listener.py` pattern almost 1:1 (same
+  decode→kind-check→validate→dispatch shape, same never-raise discipline,
+  same lifespan start/stop wiring).
+- No changes to `orion/substrate/attention/goal_context.py`,
+  `top_down.py`, or `attention_broadcast.py` — those were already correct.
+
+## Files changed
+
+- `services/orion-substrate-runtime/app/goal_context_listener.py` (new) —
+  the consumer. No separate enable flag (always runs when the bus is
+  enabled) — harmless when idle, since nothing reads the store unless
+  `ORION_ATTENTION_TOPDOWN_ENABLED` is also true.
+- `services/orion-substrate-runtime/app/settings.py` — `channel_goal_proposal`
+  field.
+- `services/orion-substrate-runtime/.env_example` — `CHANNEL_GOAL_PROPOSAL`
+  key.
+- `services/orion-substrate-runtime/app/main.py` — third listener wired into
+  `lifespan()` alongside the two existing ones (finalize-appraisal,
+  post-turn-closure), same start/stop pattern.
+- `orion/bus/channels.yaml` — added `orion-substrate-runtime` to the
+  `orion:memory:goals:proposed` entry's `consumer_services` (documentation
+  clarity; the wildcard already permitted this, no contract change).
+- `scripts/sync_local_env_from_example.py` — `CHANNEL_GOAL_PROPOSAL` added
+  to `SYNC_EXACT` (this exact allowlist gap has bitten this repo's
+  config-sync workflow repeatedly this week — closed proactively this time).
+- `services/orion-substrate-runtime/tests/test_goal_context_listener.py`
+  (new) — 5 tests: valid envelope → `set_active_goal` called with decoded
+  goal; decode failure → no-op; wrong `kind` → no-op + warning logged;
+  malformed payload → no-op; bus disabled → returns before ever calling
+  `subscribe()`.
+
+## Schema / bus / API changes
+
+- Added: none (reuses the existing `GoalProposalV1` schema and
+  `orion:memory:goals:proposed` channel, both already registered).
+- Compatibility: purely additive — `orion-substrate-runtime` added as an
+  explicit consumer of an already-wildcard-permitted channel.
+
+## Env/config changes
+
+- Added key: `CHANNEL_GOAL_PROPOSAL=orion:memory:goals:proposed`
+  (`orion-substrate-runtime`).
+- `.env_example` updated; local `.env` synced via
+  `python scripts/sync_local_env_from_example.py` (not committed,
+  gitignored, confirmed via `git status --short`).
+
+## Tests run
+
+```text
+pytest services/orion-substrate-runtime/tests/test_goal_context_listener.py \
+       services/orion-substrate-runtime/tests/test_post_turn_closure_listener.py \
+       services/orion-substrate-runtime/tests/test_execution_trajectory_endpoint.py -q
+  → 13 passed
+
+pytest services/orion-substrate-runtime/tests --ignore=.../test_grammar_consumer_integration.py -q
+  → 93 passed, 14 failed — same 14 pre-existing unrelated failures confirmed
+    identical (via git-stash comparison) multiple times this session; this
+    is a known cross-test module-global-state artifact in this suite, not
+    caused by this patch.
+
+pytest tests/test_autonomy_goals_bus_catalog.py -q
+  → 3 passed (confirms the channels.yaml edit doesn't break the existing
+    catalog contract test, which only checks producer_services/schema_id,
+    not an exact consumer_services list).
+```
+
+## Review findings fixed
+
+- One stylistic note from the build agent's own review pass: the
+  function-local `from orion.substrate.attention.goal_context import
+  set_active_goal` import (inside `_handle_bus_message`, not at module
+  top-level) lacked a comment explaining why — it's there specifically so
+  `monkeypatch.setattr("orion.substrate.attention.goal_context.set_active_goal", ...)`
+  in tests actually takes effect (a module-level import would bind the
+  original function object at import time, making the monkeypatch a no-op
+  for this module's already-bound reference). Comment added.
+- Orchestrator re-review (code-review skill, medium effort): no further
+  findings. Verified no other test snapshot-asserts the exact
+  `consumer_services` list for this channel (only checks membership), so
+  the `channels.yaml` edit is safe.
+
+## Docker/build/smoke checks
+
+Not run against live containers in this environment. No restart is required
+for this branch by itself to be inert-safe (the listener is always-on but
+the feature it feeds stays gated off); restart `orion-substrate-runtime` to
+pick up the new consumer once merged:
+```bash
+docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: low. New consumer only writes to an in-memory store nothing
+  reads unless a separate, still-off flag is also flipped. Never raises
+  (decode failure, wrong kind, malformed payload all log-and-return).
+- Note for whoever eventually flips `ORION_ATTENTION_TOPDOWN_ENABLED`: the
+  actual producer (`GoalEngine.propose()`) only ever emits `proposal_status`
+  `"proposed"` or `"active"` on this channel — never terminal states like
+  `"completed"`/`"failed"`. The store's terminal-clear branch
+  (`goal_context.py`'s `_ACTIVE_STATES` check) will essentially never fire
+  in practice; behavior will be "latest-goal-wins" rather than clean
+  clearing on completion. This matches `goal_context.py`'s own documented
+  "MVP proxy" design intent — not a bug introduced by this patch, just worth
+  knowing before enabling.
+
+## PR link
+
+Branch pushed: `feat/goal-context-listener-production`.
+Compare: https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/goal-context-listener-production

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1686,7 +1686,7 @@ channels:
     schema_id: "GoalProposalV1"
     message_kind: "memory.goals.proposed.v1"
     producer_services: ["orion-spark-concept-induction"]
-    consumer_services: ["orion-rdf-writer", "orion-sql-writer", "*"]
+    consumer_services: ["orion-rdf-writer", "orion-sql-writer", "orion-substrate-runtime", "*"]
     stability: "experimental"
     since: "2026-03-19"
 

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -177,6 +177,8 @@ SYNC_EXACT = frozenset(
         "CHANNEL_REASONING_CALL",
         # Seed-v4 feature set: spark-introspector reads orion-thought's reasoning_activity projection
         "ORION_THOUGHT_BASE_URL",
+        # Voluntary attention goal-context listener (orion-substrate-runtime)
+        "CHANNEL_GOAL_PROPOSAL",
     }
 )
 

--- a/services/orion-substrate-runtime/.env_example
+++ b/services/orion-substrate-runtime/.env_example
@@ -28,6 +28,9 @@ CHANNEL_FINALIZE_APPRAISAL_RESULT_PREFIX=orion:substrate:finalize_appraisal:resu
 # Unified turn step 7: harness post-turn closure consumer (HarnessPostTurnClosureV1)
 CHANNEL_POST_TURN_CLOSURE=orion:substrate:post_turn_closure
 ENABLE_POST_TURN_CLOSURE_LISTENER=true
+# Voluntary attention (ORION_ATTENTION_TOPDOWN_ENABLED) goal-context feed: always-on
+# consumer that populates the in-memory active-goal store from GoalProposalV1 events.
+CHANNEL_GOAL_PROPOSAL=orion:memory:goals:proposed
 # Accepted pressure candidates publish to a separate channel (not orion:grammar:event).
 PUBLISH_ACCEPTED_PRESSURE_GRAMMAR=true
 ACCEPTED_PRESSURE_GRAMMAR_CHANNEL=orion:grammar:accepted-pressure

--- a/services/orion-substrate-runtime/app/goal_context_listener.py
+++ b/services/orion-substrate-runtime/app/goal_context_listener.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from typing import Any
+from uuid import uuid4
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.schemas.drives import GoalProposalV1
+
+from .settings import Settings, get_settings
+
+logger = logging.getLogger("orion.substrate.runtime.goal_context_listener")
+
+_GOAL_PROPOSAL_KIND = "memory.goals.proposed.v1"
+
+
+async def _handle_bus_message(
+    bus: OrionBusAsync,
+    raw_msg: dict[str, Any],
+    *,
+    settings: Settings,
+) -> None:
+    decoded = bus.codec.decode(raw_msg.get("data"))
+    if not decoded.ok:
+        logger.warning("goal_context decode failed: %s", decoded.error)
+        return
+
+    env = decoded.envelope
+    corr = str(env.correlation_id or uuid4())
+    kind = env.kind or ""
+    if kind not in (_GOAL_PROPOSAL_KIND, "legacy.message"):
+        logger.warning("goal_context unsupported kind=%s corr=%s", kind, corr)
+        return
+
+    try:
+        goal = GoalProposalV1.model_validate(env.payload or {})
+    except ValueError as exc:
+        logger.error("goal_context invalid payload corr=%s err=%s", corr, exc)
+        return
+
+    # Imported locally (not at module top-level) so tests can monkeypatch
+    # orion.substrate.attention.goal_context.set_active_goal per-call without a
+    # stale module-level binding.
+    from orion.substrate.attention.goal_context import set_active_goal
+
+    set_active_goal(goal)
+    logger.info(
+        "goal_context updated corr=%s artifact_id=%s drive_origin=%s priority=%.3f status=%s",
+        corr,
+        goal.artifact_id,
+        goal.drive_origin,
+        goal.priority,
+        goal.proposal_status,
+    )
+
+
+async def run_goal_context_listener(
+    bus: OrionBusAsync,
+    stop_event: asyncio.Event | None = None,
+    *,
+    settings: Settings | None = None,
+) -> None:
+    """Subscribe to the goal-proposal channel and keep the attention goal-context store current.
+
+    Always runs whenever the bus is enabled (no separate feature flag): it only
+    updates an in-memory store that nothing reads unless
+    ``ORION_ATTENTION_TOPDOWN_ENABLED`` is separately true, so it is harmless
+    when idle.
+    """
+    s = settings or get_settings()
+    if not s.orion_bus_enabled:
+        logger.info("Bus disabled; goal_context listener not started")
+        return
+
+    channel = s.channel_goal_proposal
+    logger.info("goal_context listener subscribing channel=%s", channel)
+
+    try:
+        async with bus.subscribe(channel) as pubsub:
+            while True:
+                if stop_event is not None and stop_event.is_set():
+                    break
+                try:
+                    msg = await asyncio.wait_for(
+                        pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
+                        timeout=1.2,
+                    )
+                except asyncio.TimeoutError:
+                    continue
+                if not msg or msg.get("type") not in ("message", "pmessage"):
+                    continue
+                try:
+                    await _handle_bus_message(bus, msg, settings=s)
+                except Exception:
+                    logger.exception("goal_context unhandled bus worker error")
+    except asyncio.CancelledError:
+        raise
+    finally:
+        logger.info("goal_context listener stopped channel=%s", channel)
+
+
+async def start_goal_context_listener(
+    bus: OrionBusAsync,
+    stop_event: asyncio.Event,
+    *,
+    settings: Settings | None = None,
+) -> asyncio.Task[None]:
+    return asyncio.create_task(
+        run_goal_context_listener(bus, stop_event, settings=settings),
+        name="substrate-goal-context-listener",
+    )
+
+
+async def stop_goal_context_listener(task: asyncio.Task[None] | None) -> None:
+    if task is None or task.done():
+        return
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task

--- a/services/orion-substrate-runtime/app/main.py
+++ b/services/orion-substrate-runtime/app/main.py
@@ -28,6 +28,10 @@ from .post_turn_closure_listener import (
     start_post_turn_closure_listener,
     stop_post_turn_closure_listener,
 )
+from .goal_context_listener import (
+    start_goal_context_listener,
+    stop_goal_context_listener,
+)
 from orion.substrate.execution_loop.constants import EXECUTION_TRAJECTORY_PROJECTION_ID
 
 from .settings import get_settings
@@ -40,11 +44,12 @@ logging.basicConfig(level=getattr(logging, _settings.log_level.upper(), logging.
 worker = BiometricsSubstrateWorker()
 _finalize_listener_task = None
 _closure_listener_task = None
+_goal_context_listener_task = None
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global _finalize_listener_task, _closure_listener_task
+    global _finalize_listener_task, _closure_listener_task, _goal_context_listener_task
     await worker.start()
     if worker.bus is not None:
         _finalize_listener_task = await start_finalize_appraisal_listener(
@@ -56,6 +61,10 @@ async def lifespan(app: FastAPI):
             worker.stop_event,
             on_closure=worker.handle_post_turn_closure,
         )
+        _goal_context_listener_task = await start_goal_context_listener(
+            worker.bus,
+            worker.stop_event,
+        )
     try:
         yield
     finally:
@@ -63,6 +72,8 @@ async def lifespan(app: FastAPI):
         _finalize_listener_task = None
         await stop_post_turn_closure_listener(_closure_listener_task)
         _closure_listener_task = None
+        await stop_goal_context_listener(_goal_context_listener_task)
+        _goal_context_listener_task = None
         await worker.stop()
 
 

--- a/services/orion-substrate-runtime/app/settings.py
+++ b/services/orion-substrate-runtime/app/settings.py
@@ -110,6 +110,12 @@ class Settings(BaseSettings):
         True,
         alias="ENABLE_POST_TURN_CLOSURE_LISTENER",
     )
+    # Voluntary attention (ORION_ATTENTION_TOPDOWN_ENABLED) goal-context feed:
+    # populates the in-memory active-goal store from GoalProposalV1 events.
+    channel_goal_proposal: str = Field(
+        "orion:memory:goals:proposed",
+        alias="CHANNEL_GOAL_PROPOSAL",
+    )
     grammar_event_channel: str = Field("orion:grammar:event", alias="GRAMMAR_EVENT_CHANNEL")
     accepted_pressure_grammar_channel: str = Field(
         "orion:grammar:accepted-pressure",

--- a/services/orion-substrate-runtime/tests/test_goal_context_listener.py
+++ b/services/orion-substrate-runtime/tests/test_goal_context_listener.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from orion.core.schemas.drives import ArtifactProvenance, GoalProposalV1
+
+
+def _sample_goal_proposal(
+    *,
+    artifact_id: str = "goal-1",
+    correlation_id: str = "c-1",
+    priority: float = 0.5,
+    proposal_status: str = "proposed",
+) -> GoalProposalV1:
+    return GoalProposalV1(
+        artifact_id=artifact_id,
+        subject="orion",
+        model_layer="drives",
+        entity_id="orion",
+        kind="memory.goals.proposed.v1",
+        correlation_id=correlation_id,
+        provenance=ArtifactProvenance(intake_channel="orion:memory:drives:state"),
+        goal_statement="investigate the anomaly",
+        proposal_signature="sig-1",
+        drive_origin="curiosity",
+        priority=priority,
+        proposal_status=proposal_status,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_bus_message_valid_envelope_sets_active_goal(monkeypatch) -> None:
+    from app.goal_context_listener import _handle_bus_message
+    from app.settings import Settings
+    from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+
+    goal = _sample_goal_proposal(correlation_id="corr-bus")
+    corr = str(uuid4())
+    envelope = BaseEnvelope(
+        kind="memory.goals.proposed.v1",
+        source=ServiceRef(name="orion-spark-concept-induction"),
+        correlation_id=corr,
+        payload=goal.model_copy(update={"correlation_id": corr}).model_dump(mode="json"),
+    )
+    bus = MagicMock()
+    bus.codec.decode.return_value = MagicMock(ok=True, envelope=envelope, error=None)
+
+    seen: list[GoalProposalV1] = []
+    monkeypatch.setattr(
+        "orion.substrate.attention.goal_context.set_active_goal",
+        lambda g: seen.append(g),
+    )
+
+    await _handle_bus_message(
+        bus,
+        {"data": b"ignored"},
+        settings=Settings(POSTGRES_URI="postgresql://orion:orion@localhost:5432/orion"),
+    )
+
+    assert len(seen) == 1
+    assert seen[0].correlation_id == corr
+    assert seen[0].drive_origin == "curiosity"
+
+
+@pytest.mark.asyncio
+async def test_handle_bus_message_decode_failure_is_noop(monkeypatch) -> None:
+    from app.goal_context_listener import _handle_bus_message
+    from app.settings import Settings
+
+    bus = MagicMock()
+    bus.codec.decode.return_value = MagicMock(ok=False, envelope=None, error="bad payload")
+
+    called = []
+    monkeypatch.setattr(
+        "orion.substrate.attention.goal_context.set_active_goal",
+        lambda g: called.append(g),
+    )
+
+    await _handle_bus_message(
+        bus,
+        {"data": b"ignored"},
+        settings=Settings(POSTGRES_URI="postgresql://orion:orion@localhost:5432/orion"),
+    )
+
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_handle_bus_message_wrong_kind_is_noop(monkeypatch, caplog) -> None:
+    import logging
+
+    from app.goal_context_listener import _handle_bus_message
+    from app.settings import Settings
+    from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+
+    goal = _sample_goal_proposal()
+    envelope = BaseEnvelope(
+        kind="some.other.kind.v1",
+        source=ServiceRef(name="orion-spark-concept-induction"),
+        correlation_id=str(uuid4()),
+        payload=goal.model_dump(mode="json"),
+    )
+    bus = MagicMock()
+    bus.codec.decode.return_value = MagicMock(ok=True, envelope=envelope, error=None)
+
+    called = []
+    monkeypatch.setattr(
+        "orion.substrate.attention.goal_context.set_active_goal",
+        lambda g: called.append(g),
+    )
+
+    caplog.set_level(logging.WARNING, logger="orion.substrate.runtime.goal_context_listener")
+    await _handle_bus_message(
+        bus,
+        {"data": b"ignored"},
+        settings=Settings(POSTGRES_URI="postgresql://orion:orion@localhost:5432/orion"),
+    )
+
+    assert called == []
+    assert "unsupported kind" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_bus_message_malformed_payload_is_noop(monkeypatch) -> None:
+    from app.goal_context_listener import _handle_bus_message
+    from app.settings import Settings
+    from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+
+    envelope = BaseEnvelope(
+        kind="memory.goals.proposed.v1",
+        source=ServiceRef(name="orion-spark-concept-induction"),
+        correlation_id=str(uuid4()),
+        payload={"not": "a valid goal proposal"},
+    )
+    bus = MagicMock()
+    bus.codec.decode.return_value = MagicMock(ok=True, envelope=envelope, error=None)
+
+    called = []
+    monkeypatch.setattr(
+        "orion.substrate.attention.goal_context.set_active_goal",
+        lambda g: called.append(g),
+    )
+
+    await _handle_bus_message(
+        bus,
+        {"data": b"ignored"},
+        settings=Settings(POSTGRES_URI="postgresql://orion:orion@localhost:5432/orion"),
+    )
+
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_run_goal_context_listener_returns_when_bus_disabled() -> None:
+    from app.goal_context_listener import run_goal_context_listener
+    from app.settings import Settings
+
+    settings = Settings(
+        POSTGRES_URI="postgresql://orion:orion@localhost:5432/orion",
+        ORION_BUS_ENABLED=False,
+    )
+    bus = MagicMock()
+
+    await run_goal_context_listener(bus, settings=settings)
+
+    bus.subscribe.assert_not_called()


### PR DESCRIPTION
# feat(orion-substrate-runtime): wire goal-context listener for voluntary attention

**Status:** IMPLEMENTED, tested, reviewed. Closes the last-mile gap in the
already-merged voluntary-attention-override feature (PR #891).

## Summary

`orion/substrate/attention/top_down.py` (biased competition / voluntary
attention) has been merged, fully wired into the live attention-frame
pipeline, and gated off by `ORION_ATTENTION_TOPDOWN_ENABLED=false` since
PR #891. Traced the entire codebase and found `set_active_goal()` — the only
function that populates the goal-context store the feature reads from — was
never called anywhere except its own definition and a unit test. Even with
the flag enabled, voluntary attention would have been a permanent no-op.

This adds the missing bus consumer: `orion-substrate-runtime` now subscribes
to `orion:memory:goals:proposed` (`GoalProposalV1`, already producer-wired by
`orion-spark-concept-induction`, already permitted for any consumer via the
channel's wildcard) and calls `set_active_goal()` on every valid proposal.

**`ORION_ATTENTION_TOPDOWN_ENABLED` stays `false`** — this patch only makes
the store have real data ready; enabling voluntary attention is a separate,
later decision.

## Architecture touched

- New live bus-pubsub consumer in `orion-substrate-runtime`, mirroring the
  existing `post_turn_closure_listener.py` pattern almost 1:1 (same
  decode→kind-check→validate→dispatch shape, same never-raise discipline,
  same lifespan start/stop wiring).
- No changes to `orion/substrate/attention/goal_context.py`,
  `top_down.py`, or `attention_broadcast.py` — those were already correct.

## Files changed

- `services/orion-substrate-runtime/app/goal_context_listener.py` (new) —
  the consumer. No separate enable flag (always runs when the bus is
  enabled) — harmless when idle, since nothing reads the store unless
  `ORION_ATTENTION_TOPDOWN_ENABLED` is also true.
- `services/orion-substrate-runtime/app/settings.py` — `channel_goal_proposal`
  field.
- `services/orion-substrate-runtime/.env_example` — `CHANNEL_GOAL_PROPOSAL`
  key.
- `services/orion-substrate-runtime/app/main.py` — third listener wired into
  `lifespan()` alongside the two existing ones (finalize-appraisal,
  post-turn-closure), same start/stop pattern.
- `orion/bus/channels.yaml` — added `orion-substrate-runtime` to the
  `orion:memory:goals:proposed` entry's `consumer_services` (documentation
  clarity; the wildcard already permitted this, no contract change).
- `scripts/sync_local_env_from_example.py` — `CHANNEL_GOAL_PROPOSAL` added
  to `SYNC_EXACT` (this exact allowlist gap has bitten this repo's
  config-sync workflow repeatedly this week — closed proactively this time).
- `services/orion-substrate-runtime/tests/test_goal_context_listener.py`
  (new) — 5 tests: valid envelope → `set_active_goal` called with decoded
  goal; decode failure → no-op; wrong `kind` → no-op + warning logged;
  malformed payload → no-op; bus disabled → returns before ever calling
  `subscribe()`.

## Schema / bus / API changes

- Added: none (reuses the existing `GoalProposalV1` schema and
  `orion:memory:goals:proposed` channel, both already registered).
- Compatibility: purely additive — `orion-substrate-runtime` added as an
  explicit consumer of an already-wildcard-permitted channel.

## Env/config changes

- Added key: `CHANNEL_GOAL_PROPOSAL=orion:memory:goals:proposed`
  (`orion-substrate-runtime`).
- `.env_example` updated; local `.env` synced via
  `python scripts/sync_local_env_from_example.py` (not committed,
  gitignored, confirmed via `git status --short`).

## Tests run

```text
pytest services/orion-substrate-runtime/tests/test_goal_context_listener.py \
       services/orion-substrate-runtime/tests/test_post_turn_closure_listener.py \
       services/orion-substrate-runtime/tests/test_execution_trajectory_endpoint.py -q
  → 13 passed

pytest services/orion-substrate-runtime/tests --ignore=.../test_grammar_consumer_integration.py -q
  → 93 passed, 14 failed — same 14 pre-existing unrelated failures confirmed
    identical (via git-stash comparison) multiple times this session; this
    is a known cross-test module-global-state artifact in this suite, not
    caused by this patch.

pytest tests/test_autonomy_goals_bus_catalog.py -q
  → 3 passed (confirms the channels.yaml edit doesn't break the existing
    catalog contract test, which only checks producer_services/schema_id,
    not an exact consumer_services list).
```

## Review findings fixed

- One stylistic note from the build agent's own review pass: the
  function-local `from orion.substrate.attention.goal_context import
  set_active_goal` import (inside `_handle_bus_message`, not at module
  top-level) lacked a comment explaining why — it's there specifically so
  `monkeypatch.setattr("orion.substrate.attention.goal_context.set_active_goal", ...)`
  in tests actually takes effect (a module-level import would bind the
  original function object at import time, making the monkeypatch a no-op
  for this module's already-bound reference). Comment added.
- Orchestrator re-review (code-review skill, medium effort): no further
  findings. Verified no other test snapshot-asserts the exact
  `consumer_services` list for this channel (only checks membership), so
  the `channels.yaml` edit is safe.

## Docker/build/smoke checks

Not run against live containers in this environment. No restart is required
for this branch by itself to be inert-safe (the listener is always-on but
the feature it feeds stays gated off); restart `orion-substrate-runtime` to
pick up the new consumer once merged:
```bash
docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low. New consumer only writes to an in-memory store nothing
  reads unless a separate, still-off flag is also flipped. Never raises
  (decode failure, wrong kind, malformed payload all log-and-return).
- Note for whoever eventually flips `ORION_ATTENTION_TOPDOWN_ENABLED`: the
  actual producer (`GoalEngine.propose()`) only ever emits `proposal_status`
  `"proposed"` or `"active"` on this channel — never terminal states like
  `"completed"`/`"failed"`. The store's terminal-clear branch
  (`goal_context.py`'s `_ACTIVE_STATES` check) will essentially never fire
  in practice; behavior will be "latest-goal-wins" rather than clean
  clearing on completion. This matches `goal_context.py`'s own documented
  "MVP proxy" design intent — not a bug introduced by this patch, just worth
  knowing before enabling.

## PR link

Branch pushed: `feat/goal-context-listener-production`.
Compare: https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/goal-context-listener-production