### PR TITLE
feat(harness): cancel FCC motor on Hub WS disconnect

### DIFF
--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -2178,6 +2178,15 @@ channels:
     stability: "experimental"
     since: "2026-07-05"
 
+  - name: "orion:harness:run:cancel"
+    kind: "event"
+    schema_id: "HarnessRunCancelV1"
+    message_kind: "harness.run.cancel.v1"
+    producer_services: ["orion-hub"]
+    consumer_services: ["orion-harness-governor"]
+    stability: "experimental"
+    since: "2026-07-10"
+
   - name: "orion:harness:run:result:*"
     kind: "result"
     schema_id: "HarnessRunV1"

--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -30,6 +30,55 @@ logger = logging.getLogger("orion.harness.fcc_motor")
 DEFAULT_STREAM_READ_LIMIT = 8 * 1024 * 1024
 DEFAULT_FCC_MODEL_LABEL = "MODEL_SONNET"
 
+# Live FCC claude subprocesses keyed by correlation_id (harness cancel path).
+_ACTIVE: Dict[str, asyncio.subprocess.Process] = {}
+# Cancel arrived before spawn finished — kill immediately on register.
+_PENDING_CANCEL: set[str] = set()
+
+
+def _register_process(correlation_id: str, proc: asyncio.subprocess.Process) -> None:
+    cid = str(correlation_id)
+    if cid in _PENDING_CANCEL:
+        _PENDING_CANCEL.discard(cid)
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        logger.info("fcc_motor_cancelled_on_register corr=%s", cid)
+        return
+    _ACTIVE[cid] = proc
+
+
+def _unregister_process(correlation_id: str) -> None:
+    cid = str(correlation_id)
+    _ACTIVE.pop(cid, None)
+    _PENDING_CANCEL.discard(cid)
+
+
+def active_fcc_turns() -> list[dict[str, str]]:
+    return [{"correlation_id": cid} for cid in sorted(_ACTIVE.keys())]
+
+
+def cancel_fcc_turn(correlation_id: str) -> bool:
+    """SIGKILL a live FCC claude subprocess for this correlation_id, if any.
+
+    If the process is not registered yet, arm a pending cancel so spawn registration
+    kills immediately (covers Hub disconnect during preflight/spawn).
+    """
+    cid = str(correlation_id)
+    proc = _ACTIVE.get(cid)
+    if proc is None:
+        _PENDING_CANCEL.add(cid)
+        logger.info("fcc_motor_cancel_pending corr=%s", cid)
+        return True
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        pass
+    _unregister_process(cid)
+    logger.info("fcc_motor_cancelled corr=%s", cid)
+    return True
+
 
 def parse_stream_json_line(line: str) -> Optional[Dict[str, Any]]:
     stripped = str(line or "").strip()
@@ -381,6 +430,7 @@ async def run_fcc_turn(
             limit=stream_read_limit,
         )
         assert proc.stdout is not None
+        _register_process(correlation_id, proc)
 
         while True:
             try:
@@ -444,6 +494,7 @@ async def run_fcc_turn(
         }
         return
     finally:
+        _unregister_process(correlation_id)
         if mcp_config_path is not None:
             from orion.fcc.mcp_config import cleanup_mcp_config
 

--- a/orion/harness/tests/test_fcc_motor_cancel.py
+++ b/orion/harness/tests/test_fcc_motor_cancel.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+from orion.harness import fcc_motor as motor
+
+
+class _FakeStream:
+    def __init__(self, lines: List[bytes], *, hang: bool = False) -> None:
+        self._lines = list(lines)
+        self._idx = 0
+        self._hang = hang
+
+    async def readline(self) -> bytes:
+        if self._hang:
+            await asyncio.sleep(3600)
+            return b""
+        if self._idx >= len(self._lines):
+            return b""
+        line = self._lines[self._idx]
+        self._idx += 1
+        await asyncio.sleep(0)
+        return line
+
+    async def read(self) -> bytes:
+        return b""
+
+
+class _FakeProc:
+    def __init__(self, stdout_lines: List[str], *, hang: bool = False, returncode: int = -15) -> None:
+        self.stdout = _FakeStream(
+            [ln.encode("utf-8") + b"\n" for ln in stdout_lines],
+            hang=hang,
+        )
+        self.stderr = _FakeStream([])
+        self.returncode = returncode
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+def test_cancel_fcc_turn_kills_registered_process() -> None:
+    proc = _FakeProc([], hang=True)
+    motor._register_process("corr-cancel-1", proc)  # type: ignore[arg-type]
+    try:
+        assert motor.cancel_fcc_turn("corr-cancel-1") is True
+        assert proc.killed is True
+        # Second cancel arms pending (no live proc) — still True.
+        assert motor.cancel_fcc_turn("corr-cancel-1") is True
+        assert "corr-cancel-1" in motor._PENDING_CANCEL
+    finally:
+        motor._unregister_process("corr-cancel-1")
+
+
+def test_cancel_before_register_kills_on_spawn() -> None:
+    assert motor.cancel_fcc_turn("corr-pending-1") is True
+    assert "corr-pending-1" in motor._PENDING_CANCEL
+    proc = _FakeProc([], hang=True)
+    motor._register_process("corr-pending-1", proc)  # type: ignore[arg-type]
+    assert proc.killed is True
+    assert "corr-pending-1" not in motor._PENDING_CANCEL
+    assert "corr-pending-1" not in {t["correlation_id"] for t in motor.active_fcc_turns()}
+
+
+@pytest.mark.asyncio
+async def test_run_fcc_turn_registers_and_unregisters_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proc = _FakeProc(
+        ['{"type":"result","result":"ok","session_id":"s1"}'],
+        hang=False,
+        returncode=0,
+    )
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProc:
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(motor, "_preflight_fcc_server", lambda *a, **k: None)
+    monkeypatch.setattr(motor, "load_fcc_env", lambda _p: {"MODEL_CHAT": "x"})
+    monkeypatch.setattr(motor, "label_to_claude_model_id", lambda *_a, **_k: "llamacpp/chat")
+    monkeypatch.setattr(motor, "_maybe_render_mcp_config", lambda **_k: None)
+
+    events = []
+    async for ev in motor.run_fcc_turn(
+        prompt="hi",
+        correlation_id="corr-reg-1",
+        workspace="/tmp",
+        fcc_server_url="http://127.0.0.1:8082",
+        auth_token="tok",
+        claude_bin="claude",
+        timeout_sec=5.0,
+    ):
+        # Mid-turn the process must be registered.
+        if not events:
+            assert "corr-reg-1" in {t["correlation_id"] for t in motor.active_fcc_turns()}
+        events.append(ev)
+
+    assert events[-1]["type"] == "final"
+    assert "corr-reg-1" not in {t["correlation_id"] for t in motor.active_fcc_turns()}

--- a/orion/schemas/harness_finalize.py
+++ b/orion/schemas/harness_finalize.py
@@ -131,6 +131,14 @@ class HarnessRunRequestV1(BaseModel):
     fcc_model_label: str | None = None
 
 
+class HarnessRunCancelV1(BaseModel):
+    """Fire-and-forget cancel for an in-flight FCC motor turn (Hub disconnect / abort)."""
+
+    schema_version: Literal["harness.run.cancel.v1"] = "harness.run.cancel.v1"
+    correlation_id: str
+    reason: str = "client_disconnect"
+
+
 class HarnessRunStepV1(BaseModel):
     schema_version: Literal["harness.run.step.v1"] = "harness.run.step.v1"
     correlation_id: str

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -516,6 +516,7 @@ from orion.schemas.harness_finalize import (
     HarnessDraftMoleculeV1,
     HarnessPostTurnClosureV1,
     HarnessRepairOverlayV1,
+    HarnessRunCancelV1,
     HarnessRunRequestV1,
     HarnessRunStepV1,
     HarnessRunV1,
@@ -1227,6 +1228,7 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "HarnessPostTurnClosureV1": HarnessPostTurnClosureV1,
     "HarnessRepairOverlayV1": HarnessRepairOverlayV1,
     "HarnessRunRequestV1": HarnessRunRequestV1,
+    "HarnessRunCancelV1": HarnessRunCancelV1,
     "HarnessRunStepV1": HarnessRunStepV1,
     "HarnessRunV1": HarnessRunV1,
     "EmbodimentIntentV1": EmbodimentIntentV1,
@@ -1345,6 +1347,10 @@ SCHEMA_REGISTRY: Dict[str, SchemaRegistration] = {
     "HarnessRunRequestV1": SchemaRegistration(
         model=HarnessRunRequestV1,
         kind="harness.run.request.v1",
+    ),
+    "HarnessRunCancelV1": SchemaRegistration(
+        model=HarnessRunCancelV1,
+        kind="harness.run.cancel.v1",
     ),
     "HarnessRunStepV1": SchemaRegistration(
         model=HarnessRunStepV1,

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -13,6 +13,8 @@ CHANNEL_HARNESS_RUN_REQUEST=orion:harness:run:request
 CHANNEL_HARNESS_RUN_ARTIFACT=orion:harness:run:artifact
 CHANNEL_HARNESS_RESULT_PREFIX=orion:harness:run:result:
 CHANNEL_HARNESS_RUN_STEP=orion:harness:run:step
+# Hub publishes here on WS disconnect / turn abort so orphaned FCC claude motors die.
+CHANNEL_HARNESS_RUN_CANCEL=orion:harness:run:cancel
 CHANNEL_GRAMMAR_EVENT=orion:grammar:event
 # Background exec lane — finalize must not queue behind interactive chat on legacy intake.
 CHANNEL_CORTEX_EXEC_REQUEST=orion:cortex:exec:request:background

--- a/services/orion-harness-governor/app/cancel_listener.py
+++ b/services/orion-harness-governor/app/cancel_listener.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from typing import Any
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.harness.fcc_motor import cancel_fcc_turn
+from orion.schemas.harness_finalize import HarnessRunCancelV1
+
+from .settings import settings
+
+logger = logging.getLogger("orion-harness-governor.cancel")
+
+
+def apply_harness_run_cancel(payload: dict[str, Any] | HarnessRunCancelV1) -> bool:
+    """Validate cancel payload and kill the matching FCC subprocess if live."""
+    if isinstance(payload, HarnessRunCancelV1):
+        cancel = payload
+    else:
+        cancel = HarnessRunCancelV1.model_validate(payload)
+    killed = cancel_fcc_turn(cancel.correlation_id)
+    logger.info(
+        "harness_run_cancel corr=%s reason=%s killed=%s",
+        cancel.correlation_id,
+        cancel.reason,
+        killed,
+    )
+    return killed
+
+
+async def handle_cancel_bus_message(bus: OrionBusAsync, raw_msg: dict[str, Any]) -> None:
+    decoded = bus.codec.decode(raw_msg.get("data"))
+    if not decoded.ok:
+        logger.warning("harness cancel decode failed: %s", decoded.error)
+        return
+    env = decoded.envelope
+    kind = env.kind or ""
+    if kind not in ("harness.run.cancel.v1", "legacy.message"):
+        logger.warning("harness cancel unsupported kind=%s", kind)
+        return
+    payload = env.payload or {}
+    try:
+        apply_harness_run_cancel(payload if isinstance(payload, dict) else {})
+    except Exception:
+        logger.exception("harness cancel apply failed corr=%s", env.correlation_id)
+
+
+async def run_cancel_worker(stop_event: Any | None = None) -> None:
+    """Subscribe to harness run cancel events and kill matching FCC motors."""
+    if not settings.orion_bus_enabled or not settings.orion_harness_governor_enabled:
+        logger.info("harness cancel worker idle (bus/governor disabled)")
+        return
+
+    bus = OrionBusAsync(url=settings.orion_bus_url)
+    channel = settings.channel_harness_run_cancel
+    await bus.connect()
+    logger.info("subscribed cancel channel=%s", channel)
+
+    try:
+        async with bus.subscribe(channel) as pubsub:
+            while True:
+                if stop_event is not None and stop_event.is_set():
+                    break
+                try:
+                    msg = await asyncio.wait_for(
+                        pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
+                        timeout=1.2,
+                    )
+                except asyncio.TimeoutError:
+                    continue
+                if not msg or msg.get("type") not in ("message", "pmessage"):
+                    continue
+                try:
+                    await handle_cancel_bus_message(bus, msg)
+                except Exception:
+                    logger.exception("unhandled harness cancel worker error")
+    except asyncio.CancelledError:
+        raise
+    finally:
+        with suppress(Exception):
+            await bus.close()

--- a/services/orion-harness-governor/app/main.py
+++ b/services/orion-harness-governor/app/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from .bus_listener import run_bus_worker
+from .cancel_listener import run_cancel_worker
 from .settings import settings
 
 logging.basicConfig(
@@ -27,12 +28,15 @@ async def lifespan(app: FastAPI):
     )
     app.state.bus_stop_event = asyncio.Event()
     app.state.bus_task = asyncio.create_task(run_bus_worker(app.state.bus_stop_event))
+    app.state.cancel_task = asyncio.create_task(run_cancel_worker(app.state.bus_stop_event))
     yield
     app.state.bus_stop_event.set()
-    task = app.state.bus_task
-    task.cancel()
-    with suppress(asyncio.CancelledError):
-        await task
+    for task in (app.state.bus_task, getattr(app.state, "cancel_task", None)):
+        if task is None:
+            continue
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
 
 app = FastAPI(title="Orion Harness Governor", lifespan=lifespan, version=settings.service_version)

--- a/services/orion-harness-governor/app/settings.py
+++ b/services/orion-harness-governor/app/settings.py
@@ -70,6 +70,10 @@ class HarnessGovernorSettings(BaseSettings):
         "orion:harness:run:step",
         alias="CHANNEL_HARNESS_RUN_STEP",
     )
+    channel_harness_run_cancel: str = Field(
+        "orion:harness:run:cancel",
+        alias="CHANNEL_HARNESS_RUN_CANCEL",
+    )
 
     fcc_timeout_sec: float = Field(900.0, alias="HARNESS_FCC_TIMEOUT_SEC")
     finalize_reflect_timeout_sec: float = Field(180.0, alias="FINALIZE_REFLECT_TIMEOUT_SEC")

--- a/services/orion-harness-governor/docker-compose.yml
+++ b/services/orion-harness-governor/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - CHANNEL_HARNESS_RUN_ARTIFACT=${CHANNEL_HARNESS_RUN_ARTIFACT:-orion:harness:run:artifact}
       - CHANNEL_HARNESS_RESULT_PREFIX=${CHANNEL_HARNESS_RESULT_PREFIX:-orion:harness:run:result:}
       - CHANNEL_HARNESS_RUN_STEP=${CHANNEL_HARNESS_RUN_STEP:-orion:harness:run:step}
+      - CHANNEL_HARNESS_RUN_CANCEL=${CHANNEL_HARNESS_RUN_CANCEL:-orion:harness:run:cancel}
       - CHANNEL_GRAMMAR_EVENT=${CHANNEL_GRAMMAR_EVENT:-orion:grammar:event}
       - CHANNEL_CORTEX_EXEC_REQUEST=${CHANNEL_CORTEX_EXEC_REQUEST:-orion:cortex:exec:request:background}
       - CHANNEL_CORTEX_EXEC_RESULT_PREFIX=${CHANNEL_CORTEX_EXEC_RESULT_PREFIX:-orion:exec:result}

--- a/services/orion-harness-governor/tests/conftest.py
+++ b/services/orion-harness-governor/tests/conftest.py
@@ -23,6 +23,9 @@ def _ensure_governor_paths() -> None:
     sys.path.insert(0, str(_GOVERNOR_ROOT))
 
 
+_ensure_governor_paths()
+
+
 @pytest.fixture(autouse=True)
 def _governor_service_isolation() -> None:
     _ensure_governor_paths()

--- a/services/orion-harness-governor/tests/test_harness_run_cancel.py
+++ b/services/orion-harness-governor/tests/test_harness_run_cancel.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+from orion.harness.fcc_motor import cancel_fcc_turn
+
+
+def test_apply_harness_run_cancel_kills_registered(monkeypatch: Any) -> None:
+    from app.cancel_listener import apply_harness_run_cancel
+    from orion.schemas.harness_finalize import HarnessRunCancelV1
+
+    calls: list[str] = []
+
+    def fake_cancel(corr: str) -> bool:
+        calls.append(corr)
+        return True
+
+    monkeypatch.setattr("orion.harness.fcc_motor.cancel_fcc_turn", fake_cancel)
+    monkeypatch.setattr("app.cancel_listener.cancel_fcc_turn", fake_cancel)
+    killed = apply_harness_run_cancel(
+        HarnessRunCancelV1(correlation_id="corr-x", reason="client_disconnect")
+    )
+    assert killed is True
+    assert calls == ["corr-x"]
+
+
+def test_apply_harness_run_cancel_dict_payload(monkeypatch: Any) -> None:
+    from app.cancel_listener import apply_harness_run_cancel
+
+    monkeypatch.setattr(
+        "app.cancel_listener.cancel_fcc_turn",
+        lambda corr: corr == "corr-y",
+    )
+    assert apply_harness_run_cancel(
+        {"correlation_id": "corr-y", "reason": "ws_disconnect"}
+    ) is True
+
+
+def test_cancel_fcc_turn_missing_arms_pending() -> None:
+    from orion.harness import fcc_motor as motor
+
+    try:
+        assert cancel_fcc_turn("no-such-corr") is True
+        assert "no-such-corr" in motor._PENDING_CANCEL
+    finally:
+        motor._unregister_process("no-such-corr")

--- a/services/orion-hub/.env_example
+++ b/services/orion-hub/.env_example
@@ -355,6 +355,8 @@ CHANNEL_THOUGHT_RESULT_PREFIX=orion:thought:result:
 CHANNEL_HARNESS_RUN_REQUEST=orion:harness:run:request
 CHANNEL_HARNESS_RESULT_PREFIX=orion:harness:run:result:
 CHANNEL_HARNESS_RUN_STEP=orion:harness:run:step
+# Fire-and-forget: kill in-flight FCC motor when Hub WS disconnects mid-turn.
+CHANNEL_HARNESS_RUN_CANCEL=orion:harness:run:cancel
 
 # Unified turn association: read substrate attention broadcast + felt-state lanes.
 ORION_ATTENTION_BROADCAST_ENABLED=true

--- a/services/orion-hub/app/settings.py
+++ b/services/orion-hub/app/settings.py
@@ -454,6 +454,10 @@ class Settings(BaseSettings):
         default="orion:harness:run:step",
         alias="CHANNEL_HARNESS_RUN_STEP",
     )
+    CHANNEL_HARNESS_RUN_CANCEL: str = Field(
+        default="orion:harness:run:cancel",
+        alias="CHANNEL_HARNESS_RUN_CANCEL",
+    )
 
     ENABLE_PRE_TURN_APPRAISAL: bool = Field(default=False, alias="ENABLE_PRE_TURN_APPRAISAL")
     PRE_TURN_APPRAISAL_PARADIGMS: str = Field(default="repair_pressure", alias="PRE_TURN_APPRAISAL_PARADIGMS")

--- a/services/orion-hub/scripts/harness_governor_client.py
+++ b/services/orion-hub/scripts/harness_governor_client.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
-from orion.schemas.harness_finalize import HarnessRunRequestV1, HarnessRunV1
+from orion.schemas.harness_finalize import HarnessRunCancelV1, HarnessRunRequestV1, HarnessRunV1
 from scripts.settings import settings
 
 logger = logging.getLogger("hub.bus.harness_governor")
@@ -65,3 +65,26 @@ class HarnessGovernorClient:
         if isinstance(payload, dict):
             return HarnessRunV1.model_validate(payload)
         return None
+
+    async def cancel(
+        self,
+        *,
+        correlation_id: str,
+        reason: str = "client_disconnect",
+    ) -> None:
+        """Fire-and-forget cancel for an in-flight FCC motor (no reply expected)."""
+        channel = str(
+            getattr(settings, "CHANNEL_HARNESS_RUN_CANCEL", None) or "orion:harness:run:cancel"
+        )
+        cancel = HarnessRunCancelV1(correlation_id=str(correlation_id), reason=str(reason or "client_disconnect"))
+        envelope = BaseEnvelope(
+            kind="harness.run.cancel.v1",
+            source=self._source,
+            correlation_id=str(correlation_id),
+            payload=cancel.model_dump(mode="json"),
+        )
+        try:
+            await self.bus.publish(channel, envelope)
+            logger.info("[%s] harness run cancel published reason=%s", correlation_id, cancel.reason)
+        except Exception:
+            logger.warning("[%s] harness run cancel publish failed", correlation_id, exc_info=True)

--- a/services/orion-hub/scripts/turn_cancel.py
+++ b/services/orion-hub/scripts/turn_cancel.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, TypeVar
+
+from fastapi import WebSocketDisconnect
+from starlette.websockets import WebSocket, WebSocketState
+
+logger = logging.getLogger("hub.turn_cancel")
+
+T = TypeVar("T")
+
+
+async def publish_harness_run_cancel(
+    bus: Any,
+    *,
+    correlation_id: str,
+    reason: str = "client_disconnect",
+) -> None:
+    if bus is None or not correlation_id:
+        return
+    try:
+        from scripts.harness_governor_client import HarnessGovernorClient
+
+        await HarnessGovernorClient(bus).cancel(
+            correlation_id=str(correlation_id),
+            reason=str(reason or "client_disconnect"),
+        )
+    except Exception:
+        logger.warning(
+            "publish_harness_run_cancel failed corr=%s",
+            correlation_id,
+            exc_info=True,
+        )
+
+
+async def cancel_agent_claude_turn(correlation_id: str) -> bool:
+    try:
+        from scripts.fcc_claude_bridge import cancel_turn
+
+        return bool(await cancel_turn(str(correlation_id)))
+    except Exception:
+        logger.warning(
+            "cancel_agent_claude_turn failed corr=%s",
+            correlation_id,
+            exc_info=True,
+        )
+        return False
+
+
+async def cancel_in_flight_turn(
+    *,
+    bus: Any,
+    correlation_id: str,
+    kind: str,
+    reason: str = "client_disconnect",
+) -> None:
+    """Cancel whichever motor owns this correlation_id."""
+    corr = str(correlation_id or "").strip()
+    if not corr:
+        return
+    mode = str(kind or "").strip().lower()
+    if mode in {"agent-claude", "agent_claude"}:
+        await cancel_agent_claude_turn(corr)
+        return
+    # Default: Orion unified harness motor (and any other FCC-via-governor path).
+    await publish_harness_run_cancel(bus, correlation_id=corr, reason=reason)
+
+
+async def run_awaitable_cancel_on_ws_disconnect(
+    websocket: WebSocket,
+    awaitable: Awaitable[T],
+    *,
+    bus: Any,
+    correlation_id: str,
+    kind: str,
+    poll_sec: float = 0.5,
+) -> T:
+    """
+    Await a turn while polling websocket.client_state.
+    On disconnect (poll or WebSocketDisconnect from send), cancel the in-flight
+    FCC/harness motor so it does not orphan.
+    """
+    cancelled = False
+
+    async def _cancel_once() -> None:
+        nonlocal cancelled
+        if cancelled:
+            return
+        cancelled = True
+        logger.info(
+            "ws_disconnect_cancel corr=%s kind=%s state=%s",
+            correlation_id,
+            kind,
+            getattr(websocket, "client_state", None),
+        )
+        await cancel_in_flight_turn(
+            bus=bus,
+            correlation_id=correlation_id,
+            kind=kind,
+            reason="client_disconnect",
+        )
+
+    async def _watch() -> None:
+        while True:
+            if websocket.client_state != WebSocketState.CONNECTED:
+                await _cancel_once()
+                return
+            await asyncio.sleep(poll_sec)
+
+    watcher = asyncio.create_task(_watch(), name=f"ws-cancel-{correlation_id}")
+    try:
+        return await awaitable
+    except WebSocketDisconnect:
+        await _cancel_once()
+        raise
+    finally:
+        watcher.cancel()
+        try:
+            await watcher
+        except asyncio.CancelledError:
+            pass

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -44,6 +44,7 @@ from scripts.fcc_claude_bridge import (
     is_context_overflow_text,
     run_turn_from_settings,
 )
+from scripts.turn_cancel import cancel_in_flight_turn, run_awaitable_cancel_on_ws_disconnect
 from scripts.settings import settings
 from scripts.fcc_model_mapping import DEFAULT_FCC_MODEL_LABEL
 from scripts.trace_payloads import extract_agent_trace_payload
@@ -538,52 +539,62 @@ async def _run_agent_claude_turn_ws(
     final_text = ""
     final_meta: Dict[str, Any] = {}
     harness_steps: List[Dict[str, Any]] = []
-    async for event in run_turn_from_settings(
-        prompt=turn.prompt,
-        fcc_model_label=fcc_label,
-        correlation_id=trace_id,
-    ):
-        etype = str(event.get("type") or "")
-        if etype == "step":
-            step = event.get("step") if isinstance(event.get("step"), dict) else {}
-            harness_steps.append(step)
-            await websocket.send_json(
-                await _with_biometrics(
-                    {
-                        "kind": "claude_step",
-                        "correlation_id": trace_id,
-                        "mode": "agent-claude",
-                        "step": step,
-                    },
-                    cache=biometrics_cache,
-                )
-            )
-        elif etype == "error":
-            partial = str(event.get("llm_response") or "")
-            await websocket.send_json(
-                await _with_biometrics(
-                    {
-                        "error": str(event.get("error") or "agent-claude failed"),
-                        "error_code": str(event.get("error_code") or "fcc_claude_nonzero_exit"),
-                        "mode": "agent-claude",
-                        "correlation_id": trace_id,
-                        "llm_response": partial or None,
-                        "metadata": event.get("metadata"),
-                    },
-                    cache=biometrics_cache,
-                )
-            )
-            return None
-        elif etype == "final":
-            final_text = str(event.get("llm_response") or "")
-            final_meta = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
 
-    return {
-        "llm_response": final_text,
-        "metadata": final_meta,
-        "fcc_model_label": fcc_label,
-        "harness_steps": harness_steps,
-    }
+    async def _consume() -> Optional[Dict[str, Any]]:
+        nonlocal final_text, final_meta
+        async for event in run_turn_from_settings(
+            prompt=turn.prompt,
+            fcc_model_label=fcc_label,
+            correlation_id=trace_id,
+        ):
+            etype = str(event.get("type") or "")
+            if etype == "step":
+                step = event.get("step") if isinstance(event.get("step"), dict) else {}
+                harness_steps.append(step)
+                await websocket.send_json(
+                    await _with_biometrics(
+                        {
+                            "kind": "claude_step",
+                            "correlation_id": trace_id,
+                            "mode": "agent-claude",
+                            "step": step,
+                        },
+                        cache=biometrics_cache,
+                    )
+                )
+            elif etype == "error":
+                partial = str(event.get("llm_response") or "")
+                await websocket.send_json(
+                    await _with_biometrics(
+                        {
+                            "error": str(event.get("error") or "agent-claude failed"),
+                            "error_code": str(event.get("error_code") or "fcc_claude_nonzero_exit"),
+                            "mode": "agent-claude",
+                            "correlation_id": trace_id,
+                            "llm_response": partial or None,
+                            "metadata": event.get("metadata"),
+                        },
+                        cache=biometrics_cache,
+                    )
+                )
+                return None
+            elif etype == "final":
+                final_text = str(event.get("llm_response") or "")
+                final_meta = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+        return {
+            "llm_response": final_text,
+            "fcc_model_label": fcc_label,
+            "metadata": final_meta,
+            "harness_steps": harness_steps,
+        }
+
+    return await run_awaitable_cancel_on_ws_disconnect(
+        websocket,
+        _consume(),
+        bus=None,
+        correlation_id=trace_id,
+        kind="agent-claude",
+    )
 
 
 async def websocket_endpoint(websocket: WebSocket):
@@ -635,6 +646,8 @@ async def websocket_endpoint(websocket: WebSocket):
             interval_sec=float(getattr(settings, "BIOMETRICS_PUSH_INTERVAL_SEC", 5.0)),
         )
     )
+    # Active FCC / harness turn for this socket — cancelled on WS disconnect.
+    active_turn: Dict[str, Optional[str]] = {"correlation_id": None, "kind": None}
 
     try:
         while True:
@@ -871,23 +884,35 @@ async def websocket_endpoint(websocket: WebSocket):
                     continue
                 from orion.hub.turn_orchestrator import run_unified_turn
 
-                await run_unified_turn(
-                    websocket,
-                    bus=bus,
-                    correlation_id=trace_id,
-                    session_id=session_id,
-                    user_message=transcript,
-                    payload=data,
-                    continuity_messages=build_continuity_messages(
-                        history=history,
-                        latest_user_prompt=transcript,
-                        turns=turns,
-                    ),
-                    with_biometrics=_with_biometrics,
-                    biometrics_cache=biometrics_cache,
-                    harness_rpc_bus=rpc_bus or bus,
-                    harness_step_relay=harness_step_relay,
-                )
+                active_turn["correlation_id"] = trace_id
+                active_turn["kind"] = "orion"
+                try:
+                    await run_awaitable_cancel_on_ws_disconnect(
+                        websocket,
+                        run_unified_turn(
+                            websocket,
+                            bus=bus,
+                            correlation_id=trace_id,
+                            session_id=session_id,
+                            user_message=transcript,
+                            payload=data,
+                            continuity_messages=build_continuity_messages(
+                                history=history,
+                                latest_user_prompt=transcript,
+                                turns=turns,
+                            ),
+                            with_biometrics=_with_biometrics,
+                            biometrics_cache=biometrics_cache,
+                            harness_rpc_bus=rpc_bus or bus,
+                            harness_step_relay=harness_step_relay,
+                        ),
+                        bus=rpc_bus or bus,
+                        correlation_id=trace_id,
+                        kind="orion",
+                    )
+                finally:
+                    active_turn["correlation_id"] = None
+                    active_turn["kind"] = None
                 continue
 
             # Build outbound chat request through shared builder to keep WS/HTTP identical
@@ -1143,13 +1168,19 @@ async def websocket_endpoint(websocket: WebSocket):
                 logger.info("voice.chat.start corr=%s session_id=%s", trace_id, session_id)
                 if client_mode == "agent-claude":
                     used_agent_claude_lane = True
-                    agent_claude_out = await _run_agent_claude_turn_ws(
-                        websocket=websocket,
-                        data=data,
-                        transcript=transcript or "",
-                        trace_id=trace_id,
-                        biometrics_cache=biometrics_cache,
-                    )
+                    active_turn["correlation_id"] = trace_id
+                    active_turn["kind"] = "agent-claude"
+                    try:
+                        agent_claude_out = await _run_agent_claude_turn_ws(
+                            websocket=websocket,
+                            data=data,
+                            transcript=transcript or "",
+                            trace_id=trace_id,
+                            biometrics_cache=biometrics_cache,
+                        )
+                    finally:
+                        active_turn["correlation_id"] = None
+                        active_turn["kind"] = None
                     if agent_claude_out is None:
                         continue
                     orion_response_text = str(agent_claude_out.get("llm_response") or "")
@@ -1774,8 +1805,26 @@ async def websocket_endpoint(websocket: WebSocket):
 
     except WebSocketDisconnect:
         logger.info("Client disconnected.")
+        corr = active_turn.get("correlation_id")
+        kind = active_turn.get("kind")
+        if corr:
+            await cancel_in_flight_turn(
+                bus=rpc_bus or bus,
+                correlation_id=str(corr),
+                kind=str(kind or "orion"),
+                reason="client_disconnect",
+            )
     except Exception as e:
         logger.error(f"WebSocket error: {e}", exc_info=True)
+        corr = active_turn.get("correlation_id")
+        kind = active_turn.get("kind")
+        if corr:
+            await cancel_in_flight_turn(
+                bus=rpc_bus or bus,
+                correlation_id=str(corr),
+                kind=str(kind or "orion"),
+                reason="ws_error",
+            )
     finally:
         drain_task.cancel()
         biometrics_task.cancel()

--- a/services/orion-hub/tests/test_turn_cancel.py
+++ b/services/orion-hub/tests/test_turn_cancel.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import WebSocketDisconnect
+from starlette.websockets import WebSocketState
+
+
+@pytest.mark.asyncio
+async def test_cancel_in_flight_turn_agent_claude(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.turn_cancel as turn_cancel
+
+    calls: list[str] = []
+
+    async def fake_cancel(corr: str) -> bool:
+        calls.append(corr)
+        return True
+
+    monkeypatch.setattr(turn_cancel, "cancel_agent_claude_turn", fake_cancel)
+    await turn_cancel.cancel_in_flight_turn(
+        bus=None,
+        correlation_id="corr-ac",
+        kind="agent-claude",
+        reason="client_disconnect",
+    )
+    assert calls == ["corr-ac"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_in_flight_turn_orion_publishes(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.turn_cancel as turn_cancel
+
+    published: list[tuple[str, str]] = []
+
+    async def fake_publish(bus: Any, *, correlation_id: str, reason: str = "client_disconnect") -> None:
+        published.append((correlation_id, reason))
+
+    monkeypatch.setattr(turn_cancel, "publish_harness_run_cancel", fake_publish)
+    await turn_cancel.cancel_in_flight_turn(
+        bus=object(),
+        correlation_id="corr-orion",
+        kind="orion",
+        reason="client_disconnect",
+    )
+    assert published == [("corr-orion", "client_disconnect")]
+
+
+@pytest.mark.asyncio
+async def test_run_awaitable_cancel_on_ws_disconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.turn_cancel as turn_cancel
+
+    cancelled: list[str] = []
+
+    async def fake_cancel(*, bus: Any, correlation_id: str, kind: str, reason: str = "client_disconnect") -> None:
+        cancelled.append(correlation_id)
+
+    monkeypatch.setattr(turn_cancel, "cancel_in_flight_turn", fake_cancel)
+
+    class _WS:
+        def __init__(self) -> None:
+            self._state = WebSocketState.CONNECTED
+
+        @property
+        def client_state(self) -> WebSocketState:
+            return self._state
+
+    ws = _WS()
+
+    async def _work() -> str:
+        await asyncio.sleep(0.05)
+        ws._state = WebSocketState.DISCONNECTED
+        await asyncio.sleep(0.25)
+        return "done"
+
+    out = await turn_cancel.run_awaitable_cancel_on_ws_disconnect(
+        ws,  # type: ignore[arg-type]
+        _work(),
+        bus=None,
+        correlation_id="corr-watch",
+        kind="orion",
+        poll_sec=0.05,
+    )
+    assert out == "done"
+    assert cancelled == ["corr-watch"]
+
+
+@pytest.mark.asyncio
+async def test_run_awaitable_cancel_on_websocket_disconnect_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mid-turn send raising WebSocketDisconnect must still cancel (not only poller)."""
+    import scripts.turn_cancel as turn_cancel
+
+    cancelled: list[str] = []
+
+    async def fake_cancel(*, bus: Any, correlation_id: str, kind: str, reason: str = "client_disconnect") -> None:
+        cancelled.append(correlation_id)
+
+    monkeypatch.setattr(turn_cancel, "cancel_in_flight_turn", fake_cancel)
+
+    class _WS:
+        client_state = WebSocketState.CONNECTED
+
+    async def _work() -> str:
+        await asyncio.sleep(0.01)
+        raise WebSocketDisconnect()
+
+    with pytest.raises(WebSocketDisconnect):
+        await turn_cancel.run_awaitable_cancel_on_ws_disconnect(
+            _WS(),  # type: ignore[arg-type]
+            _work(),
+            bus=None,
+            correlation_id="corr-exc",
+            kind="orion",
+            poll_sec=5.0,
+        )
+    assert cancelled == ["corr-exc"]


### PR DESCRIPTION
## Summary

- Hub WebSocket disconnect now cancels in-flight FCC motors so orphaned `claude -p` processes do not keep running after the client leaves mid-turn.
- Adds `HarnessRunCancelV1` on bus channel `orion:harness:run:cancel`; harness-governor subscribes and kills the matching FCC subprocess.
- Agent-claude path uses existing `cancel_turn`; Orion unified turn publishes cancel via harness governor client.
- Pending-cancel covers the spawn race; `WebSocketDisconnect` from mid-turn send also cancels (not only the poll watcher).
- **Does not change** `HARNESS_FCC_TIMEOUT_SEC` (stays 900).

## Outcome moved

Leaving Hub mid-turn no longer leaves an orphaned FCC motor that blocks the next turn until the 900s idle timeout.

## Current architecture

Hub WS disconnect only logged and cancelled local drain/biometrics. Unified Orion turns went Hub → harness-governor → `fcc_motor` with no cancel bus path. FCC kill-on-idle used `HARNESS_FCC_TIMEOUT_SEC=900`.

## Architecture touched

- Contract: `HarnessRunCancelV1`, `orion:harness:run:cancel`
- Producer: `orion-hub` (`turn_cancel.py`, `websocket_handler.py`, `HarnessGovernorClient.cancel`)
- Consumer: `orion-harness-governor` (`cancel_listener.py`)
- Motor: `orion/harness/fcc_motor.py` active-process registry + pending cancel

## Files changed

- `orion/schemas/harness_finalize.py`: `HarnessRunCancelV1`
- `orion/bus/channels.yaml` / `orion/schemas/registry.py`: channel + registry
- `orion/harness/fcc_motor.py`: register/cancel/pending-cancel
- `services/orion-harness-governor/app/cancel_listener.py`: cancel subscriber
- `services/orion-hub/scripts/turn_cancel.py`: disconnect cancel helpers
- `services/orion-hub/scripts/websocket_handler.py`: wire cancel on disconnect
- Hub + governor `.env_example`, settings, governor compose: `CHANNEL_HARNESS_RUN_CANCEL`
- Tests: motor, governor apply, hub turn_cancel

## Schema / bus / API changes

- Added: `HarnessRunCancelV1`, channel `orion:harness:run:cancel`, message kind `harness.run.cancel.v1`
- Removed: none
- Renamed: none
- Behavior changed: Hub disconnect publishes cancel; governor kills matching FCC proc
- Compatibility notes: fire-and-forget event; no reply channel

## Env/config changes

- Added keys: `CHANNEL_HARNESS_RUN_CANCEL=orion:harness:run:cancel` (hub + harness-governor)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: yes (hub + harness-governor)
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: yes (key present on operator machine)
- skipped keys requiring operator action: none
- `HARNESS_FCC_TIMEOUT_SEC`: **unchanged** (900)

## Tests run

```text
PYTHONPATH=.:services/orion-harness-governor pytest \
  orion/harness/tests/test_fcc_motor_cancel.py \
  services/orion-harness-governor/tests/test_harness_run_cancel.py -q
# 6 passed

PYTHONPATH=.:services/orion-hub pytest \
  services/orion-hub/tests/test_turn_cancel.py -q
# 4 passed (incl. WebSocketDisconnect cancel path)
```

## Evals run

```text
No new eval harness for this seam; gate tests cover motor cancel, governor apply, and hub disconnect cancel.
```

## Docker/build/smoke checks

```text
Governor compose updated with CHANNEL_HARNESS_RUN_CANCEL.
Live rebuild/smoke deferred to operator restart below (UNVERIFIED until restart).
```

## Review findings fixed

- Finding: Mid-turn `WebSocketDisconnect` could clear `active_turn` / cancel poller before cancel published
  - Fix: `run_awaitable_cancel_on_ws_disconnect` cancels on `WebSocketDisconnect` (idempotent `_cancel_once`)
  - Evidence: `test_run_awaitable_cancel_on_websocket_disconnect_exception`
- Finding: Governor compose missing cancel channel
  - Fix: added `CHANNEL_HARNESS_RUN_CANCEL` to docker-compose.yml
  - Evidence: compose diff
- Finding: Cancel-before-register race
  - Fix: `_PENDING_CANCEL` in `fcc_motor`; kill on register if pending
  - Evidence: `test_cancel_before_register_kills_on_spawn`

## Restart required

```bash
cd /mnt/scripts/Orion-Sapienform/services/orion-harness-governor
docker compose --env-file ../../.env --env-file .env -f docker-compose.yml up -d --build

cd /mnt/scripts/Orion-Sapienform/services/orion-hub
docker compose --env-file ../../.env --env-file .env -f docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: SIGKILL may leave rare grandchild processes; spawn-window pending cancel is best-effort until register
- Mitigation: pending-cancel set + disconnect exception path; follow up if orphans persist after restart

## Test plan

- [ ] Rebuild hub + harness-governor with synced `.env`
- [ ] Start Orion unified turn, disconnect Hub mid-turn → FCC `claude -p` dies promptly (not after 900s)
- [ ] Agent-claude mid-turn disconnect cancels via existing bridge path
- [ ] Confirm `HARNESS_FCC_TIMEOUT_SEC` still 900 in governor container env
