### PR TITLE
fix(cortex-exec): route harness_finalize_reflect to chat lane

### DIFF
--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -4085,13 +4085,16 @@ async def call_step_services(
                     llm_route = llm_route_override
                 else:
                     # Default lane mapping:
+                    # - harness_finalize_reflect: DEEP lane ("chat") — fat prompts
+                    #   exceed metacog's multi-slot 4k ctx; runs after FCC motor on
+                    #   the same turn (sequential; one Hub FCC at a time).
                     # - chat_general stance brief: FAST lane ("quick")
                     # - chat_general final response: DEEP lane ("chat")
                     # - chat_quick single-pass: FAST lane ("quick")
                     # - introspect_spark internal analysis: FAST lane ("quick")
                     # - metacog mode: METACOG lane
                     llm_route = (
-                        "metacog"
+                        "chat"
                         if step.verb_name == "harness_finalize_reflect"
                         else "quick"
                         if step.verb_name == "orion_voice_finalize"

--- a/services/orion-cortex-exec/tests/test_harness_finalize_route.py
+++ b/services/orion-cortex-exec/tests/test_harness_finalize_route.py
@@ -16,7 +16,9 @@ def _base_ctx(mode: str = "brain") -> dict:
     }
 
 
-def test_harness_finalize_reflect_uses_metacog_route() -> None:
+def test_harness_finalize_reflect_uses_chat_route() -> None:
+    """Fat finalize prompts exceed metacog's 4k/slot; chat lane has 131k and
+    runs after the FCC motor on the same turn (sequential, one Hub FCC at a time)."""
     step = ExecutionStep(
         step_name="llm_harness_finalize_reflect",
         verb_name="harness_finalize_reflect",
@@ -42,7 +44,7 @@ def test_harness_finalize_reflect_uses_metacog_route() -> None:
 
     assert result.status == "success"
     sent_req = llm_chat.await_args.kwargs["req"]
-    assert sent_req.route == "metacog"
+    assert sent_req.route == "chat"
 
 
 def test_orion_voice_finalize_uses_quick_route() -> None:


### PR DESCRIPTION
## Summary

- Route `harness_finalize_reflect` from gateway `metacog` (4k/slot) to `chat` (131k single-slot).
- Fat finalize prompts (~14k chars + high `max_tokens`) were hitting llama.cpp `exceed_context_size_error` → gateway 400 on metacog.
- Voice finalize stays on `quick`. Caller `llm_route` override still wins when set.

## Outcome moved

Unified-turn finalize no longer fails on long FCC motor drafts when metacog slots are 4k. Reflect uses the deep chat worker after the motor completes.

## Current architecture

`call_step_services` in cortex-exec maps verb → default LLM gateway route. `harness_finalize_reflect` defaulted to `metacog` (atlas-worker-2, multi-slot 4k). FCC motor already uses `chat` (atlas-worker-1, 131k, 1 slot).

## Architecture touched

- Service: `orion-cortex-exec` only (default route selection)
- No bus/schema/API contract changes
- No env keys added/removed/renamed

## Files changed

- `services/orion-cortex-exec/app/executor.py`: default route `metacog` → `chat` for `harness_finalize_reflect`
- `services/orion-cortex-exec/tests/test_harness_finalize_route.py`: assert `route == "chat"`

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: default LLM route for harness finalize reflect only
- Compatibility notes: explicit `ctx.llm_route` / `options.llm_route` override still applies

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no
- local `.env` synced: N/A (no env template change)
- skipped keys requiring operator action: none

## Tests run

```text
PYTHONPATH=services/orion-cortex-exec:. pytest \
  services/orion-cortex-exec/tests/test_harness_finalize_route.py \
  services/orion-cortex-exec/tests/test_harness_finalize_max_tokens.py \
  services/orion-cortex-exec/tests/test_llm_lane_propagation.py -q
→ 13 passed
```

## Evals run

```text
No cortex-exec eval harness for this seam; gate test covers route selection.
```

## Docker/build/smoke checks

```text
Not run (code-path default only; no compose/env change). Restart cortex-exec to pick up.
```

## Review findings fixed

- Finding: automated code-review subagent unavailable (usage limit)
- Fix: manual review — override path unchanged; no leftover metacog hardcodes for this verb; max_tokens tests unchanged
- Evidence: grep + test green

## Restart required

```bash
cd /mnt/scripts/Orion-Sapienform/services/orion-cortex-exec
docker compose --env-file .env --env-file ../../.env -f docker-compose.yml up -d --build
```

(Exact compose invocation may match your usual cortex-exec restart; rebuild so the image picks up `executor.py`.)

## Risks / concerns

- Severity: low
- Concern: chat is a single 131k slot; a second Hub FCC / agent-claude turn during finalize can queue/block (latency), not 400
- Mitigation: one Hub FCC at a time in normal use; motor and finalize are sequential on the same turn

## Test plan

- [ ] Restart cortex-exec with this branch
- [ ] Run a long FCC Hub turn (tool-heavy / large draft) and confirm finalize succeeds (`llm_route_selected ... verb=harness_finalize_reflect route=chat`)
- [ ] Confirm short turns still finalize
- [ ] Confirm voice finalize still logs `route=quick`
