### PR TITLE
Fix/tissue viz novelty decouple uncertainty

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-10-tissue-viz-novelty-decouple-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-10-tissue-viz-novelty-decouple-pr.md
@@ -1,0 +1,145 @@
+# fix(spark-introspector): decouple tissue-viz novelty from dead SelfStateV1 uncertainty
+
+**Status:** IMPLEMENTED, tested, reviewed. Fixes a live production symptom
+reported directly ("novelty and arousal in Hub are showing 0 and sticking to
+it") — novelty half fixed here; arousal diagnosed but deliberately not fixed
+yet (see below).
+
+## Summary
+
+Hub's tissue-viz (the novelty/arousal/valence/phi EKG display, served from
+`services/orion-spark-introspector/app/static/tissue_viz.js`) showed novelty
+stuck at exactly `0.0`. Verified live via a direct websocket connection to
+`/ws/tissue` — confirmed across multiple consecutive ticks.
+
+Traced the full chain:
+
+- `_phi_from_self_state()` computes
+  `novelty = (0.6*uncertainty + 0.4*introspection_pressure) * (0.3 + 0.7*coherence)`
+  from the incoming `SelfStateV1` payload.
+- Live `/latest` snapshot from `orion-self-state-runtime` confirmed:
+  `uncertainty.score = 0.0` and `introspection_pressure.score = 0.0` — both
+  **real, correctly-computed readings**, not missing/defaulted.
+- `uncertainty` comes from `orion/self_state/scoring.py::uncertainty_score()`
+  = `salience * (1 - coherence)` — zeroed because that service's own
+  `coherence` was saturated at `1.0` (its own formula only drops on active
+  failure/friction channels).
+- `introspection_pressure` is fed solely by `egress_confidence_deficit`
+  (`1 - egress_confidence`), which only registers nonzero when an execution
+  **fails to emit** — the same "0.3% signal" structural sparsity already
+  found and excised from φ's `exec_step_fail_rate`/`execution_friction` pair
+  earlier in this initiative.
+
+**This is not dead/fake code** — `uncertainty` and `introspection_pressure`
+are real alarm-style signals (quiet during health, spike on trouble) being
+repurposed for a display that wants continuous ambient variation. Wrong tool
+for the job, not theater.
+
+## Fix
+
+Per explicit direction ("excise the fake math theater and find a real
+replacement" → "decouple novelty from coherence entirely" → source it from
+the already-correct embedding-cosine-distance novelty): tissue-viz novelty
+now comes from `handle_semantic_upsert`'s real chat-triggered novelty
+(confirmed live: healthy 0.1–0.5 variance), held in a new module-level
+`_LAST_EMBEDDING_NOVELTY` and read through a new `_novelty_stat()` helper —
+mirroring the exact existing `_INNER_LAST_HEADLINE`/`_headline_stat()`
+precedent already in this file.
+
+Applied to **both** broadcast sites that were reading the dead value:
+- `handle_self_state`'s self-state-tick broadcast (fires continuously, every
+  tick — the dominant source of the "stuck" symptom since it fires far more
+  often than actual chat activity).
+- `handle_trace`'s heartbeat branch (same `_get_phi_stats()` →
+  `_phi_from_self_state()` chain, same bug).
+
+The other two `tissue.update` broadcast sites (`_broadcast_tissue_update`,
+and the trace-path candidate broadcast) already correctly used real
+appraisal/embedding-based novelty with skip-if-unknown guards — untouched.
+
+**Deliberately not touched:** `orion/self_state/scoring.py` — the shared
+formulas themselves are correct for their original alarm-signal purpose and
+also feed `agency_readiness_score`; changing them would be a much larger,
+cognition-touching change out of scope for this display-layer fix.
+
+## Arousal — diagnosed, not fixed (explicit scope decision)
+
+Also traced why `arousal` sticks at 0: `resource_pressure` MAX-aggregates 7
+heterogeneous channels (`transport_pressure`, `cpu_pressure`, `gpu_pressure`,
+`memory_pressure`, `disk_pressure`, `thermal_pressure`, and a generic
+`pressure` channel from the capability field graph). Live evidence:
+`cpu_pressure=0.92` (real, high) but a separate `pressure=1.00` channel
+(sourced from a specific capability's saturation in `orion-field-digester`'s
+field graph, exact producer not traced to completion this pass) dominates
+via `max()`, permanently zeroing `resource_cap = 1 - resource_pressure` and
+therefore the whole `energy` formula regardless of what any other channel
+reads. Presented three fix options (weighted-average aggregation, exclude
+the untraced generic channel, diagnose further); Juniper chose "diagnose
+further" — not implemented in this patch.
+
+## Files changed
+
+- `services/orion-spark-introspector/app/worker.py` — `_LAST_EMBEDDING_NOVELTY`
+  global, `_novelty_stat()` helper, both broadcast sites updated.
+- `services/orion-spark-introspector/tests/test_tissue_viz_novelty.py` (new)
+  — 5 tests: `_novelty_stat()` defaults/reflects the held value;
+  `_phi_from_self_state()` reproduces the exact live-incident zero (direct
+  proof of the bug mechanism); `handle_semantic_upsert` updates the held
+  value; end-to-end regression proving `handle_self_state`'s broadcast uses
+  the embedding novelty instead of the dead SelfStateV1-derived one even when
+  coherence is saturated.
+- `services/orion-spark-introspector/tests/test_inner_state_emit.py` — one
+  unrelated pre-existing test fixed in passing:
+  `test_inner_features_settings_defaults` asserted
+  `orion_phi_encoder_enabled is False`, stale since the seed-v4 encoder was
+  promoted and the flag flipped `true` earlier this session (same
+  live-`.env`-reading fragility already patched once this session for
+  `inner_features_version`).
+
+## Tests run
+
+```text
+pytest services/orion-spark-introspector/tests -q
+  → 109 passed, 1 pre-existing unrelated failure (test_phi_reward_emitted_when_encoder_ok,
+    confirmed present on main before this branch)
+```
+
+Regression verified by reverting the fix and confirming 4 of 5 new tests
+fail (missing attribute / dead-value assertion), then reapplying.
+
+## Review findings fixed
+
+Self-reviewed (medium effort). No correctness findings. One accuracy
+nitpick in my own comments, fixed before commit: `_LAST_EMBEDDING_NOVELTY`'s
+docstring initially said "embedding-cosine-distance novelty" but the value
+actually stored is `handle_semantic_upsert`'s *display* novelty (prefers
+cached appraisal score via `_display_novelty_for_corr`, falls back to raw
+embedding cosine distance) — comment corrected for precision.
+
+## Docker/build/smoke checks
+
+Not run against live containers in this environment. Live-verified the
+*bug* directly against the running deployment (`/ws/tissue` websocket, three
+consecutive ticks all showing `novelty: 0.0`) before writing the fix.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml up -d --build
+```
+After restart, reconnect to `/ws/tissue` (or reload the tissue-viz page) and
+confirm `novelty` varies with real chat activity instead of holding at 0.
+
+## Risks / concerns
+
+- Severity: low. Additive display-layer fix; the underlying `uncertainty`/
+  `introspection_pressure`/`coherence` formulas and every other consumer of
+  them (φ, `agency_readiness_score`) are completely untouched.
+- `arousal` is still stuck at 0 pending the resource_pressure aggregation
+  redesign decision — known, disclosed, not silently left unaddressed.
+
+## PR link
+
+Branch pushed: `fix/tissue-viz-novelty-decouple-uncertainty`.
+Compare: https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/tissue-viz-novelty-decouple-uncertainty

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -118,6 +118,19 @@ _INNER_DEGENERATE_STREAK = 0
 _INNER_LAST_HEADLINE: Optional[float] = None  # honest headline for WS reads
 _INNER_SINK = InnerStateCorpusSink(getattr(settings, "inner_features_corpus_path", "") or "")
 
+# Last chat-triggered novelty actually shown for a semantic upsert
+# (handle_semantic_upsert's `tissue_novelty` -- prefers cached appraisal
+# novelty via _display_novelty_for_corr, falls back to raw embedding cosine
+# distance), held and reused by the self-state tick's tissue.update broadcast
+# instead of the SelfStateV1 `uncertainty` dimension. `uncertainty` is
+# structurally pinned at 0 whenever coherence is healthy (see
+# orion/self_state/scoring.py::uncertainty_score = salience * (1 - coherence);
+# coherence only drops on active failure/friction), so it can never register
+# the continuous, ambient variation the tissue-viz display wants. None until
+# the first real chat message this process lifetime; read-only fallback to
+# 0.0 (honest "no signal yet"), never a fabricated value.
+_LAST_EMBEDDING_NOVELTY: Optional[float] = None
+
 _PHI_ENCODER: PhiEncoderRuntime | None = None
 _PHI_PREV_PHI: float | None = None
 _PHI_PREV_RECON: float | None = None
@@ -200,6 +213,17 @@ def _headline_stat(phi_stats: Dict[str, float]) -> float:
     if _INNER_LAST_HEADLINE is not None:
         return float(_INNER_LAST_HEADLINE)
     return float(phi_stats.get("coherence", 0.0))
+
+
+def _novelty_stat() -> float:
+    """Last real chat-triggered novelty for WS EKG (see _LAST_EMBEDDING_NOVELTY).
+
+    Never reads phi_stats["novelty"] (SelfStateV1 `uncertainty` dimension,
+    structurally pinned at 0 whenever coherence is healthy -- see
+    orion/self_state/scoring.py::uncertainty_score). Falls back to 0.0
+    (honest "no chat yet this process lifetime") rather than a fabricated value.
+    """
+    return float(_LAST_EMBEDDING_NOVELTY) if _LAST_EMBEDDING_NOVELTY is not None else 0.0
 
 
 def set_publisher_bus(bus: OrionBusAsync):
@@ -1417,7 +1441,7 @@ async def handle_trace(env: BaseEnvelope) -> None:
                     "timestamp": iso_ts,
                     "stats": {
                         "phi": _headline_stat(phi_stats),
-                        "novelty": float(phi_stats.get("novelty", 0.0)),
+                        "novelty": _novelty_stat(),
                         "valence": valence,
                         "arousal": arousal,
                     },
@@ -1591,7 +1615,7 @@ async def handle_trace(env: BaseEnvelope) -> None:
 
 
 async def handle_semantic_upsert(env: BaseEnvelope) -> None:
-    global _VALENCE_INIT_TASK
+    global _VALENCE_INIT_TASK, _LAST_EMBEDDING_NOVELTY
     payload_obj = env.payload if isinstance(env.payload, dict) else {}
     try:
         upsert = VectorUpsertV1.model_validate(payload_obj)
@@ -1689,6 +1713,7 @@ async def handle_semantic_upsert(env: BaseEnvelope) -> None:
     tissue_novelty = _display_novelty_for_corr(corr_key, embedding_novelty=float(novelty))
     if tissue_novelty is None:
         tissue_novelty = float(novelty)
+    _LAST_EMBEDDING_NOVELTY = tissue_novelty
     TISSUE.snapshot()
 
     try:
@@ -2565,7 +2590,7 @@ async def handle_self_state(env: BaseEnvelope) -> None:
             "timestamp": ss.generated_at.isoformat(),
             "stats": {
                 "phi": float(_INNER_LAST_HEADLINE if _INNER_LAST_HEADLINE is not None else phi_now.get("coherence", 0.5)),
-                "novelty": float(phi_now.get("novelty", 0.0)),
+                "novelty": _novelty_stat(),
                 "valence": float(phi_now.get("valence", 0.0)),
                 "arousal": float(phi_now.get("energy", 0.5)),
             },

--- a/services/orion-spark-introspector/tests/test_inner_state_emit.py
+++ b/services/orion-spark-introspector/tests/test_inner_state_emit.py
@@ -124,7 +124,9 @@ def test_inner_features_settings_defaults() -> None:
     assert s.inner_features_version == "seed-v4"
     assert s.channel_inner_features == "orion:self:inner_features"
     assert s.phi_degenerate_streak == 20
-    assert s.orion_phi_encoder_enabled is False
+    # Flipped false -> true once the seed-v4 candidate encoder passed its
+    # promote gate and was promoted to active (v20260710-seedv4).
+    assert s.orion_phi_encoder_enabled is True
 
 
 @pytest.mark.asyncio

--- a/services/orion-spark-introspector/tests/test_tissue_viz_novelty.py
+++ b/services/orion-spark-introspector/tests/test_tissue_viz_novelty.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+import app.worker as worker
+from app.substrate_reads import (
+    ExecutionTrajectorySnapshot,
+    GrammarTruthSnapshot,
+    ReasoningActivitySnapshot,
+)
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+_NOW = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+
+
+def _dim(name: str, score: float) -> SelfStateDimensionV1:
+    return SelfStateDimensionV1(dimension_id=name, score=score, confidence=1.0)
+
+
+def _self_state_payload(*, coherence: float = 1.0) -> dict:
+    """Reproduces the live incident's exact dimension readings.
+
+    The `uncertainty` dimension score here is set directly to 0.0, matching
+    what orion-self-state-runtime actually publishes: its own
+    uncertainty_score(overall_salience, coherence) = salience * (1 -
+    coherence) formula already computed to exactly 0 upstream (that service's
+    internal coherence was saturated at 1.0). _phi_from_self_state() in THIS
+    service just consumes that already-zero raw score directly -- it does not
+    re-derive uncertainty from coherence itself. Its own local `coherence`
+    variable (field_coh * (1-continuity_pressure) * (1-reliability_pressure)
+    * transport, all ** 0.25) is a separate recomputation used only as a
+    0.3-1.0 scaling multiplier on (0.6*uncertainty + 0.4*introspection) --
+    it cannot zero novelty on its own (floor 0.3), so it's not the
+    mechanism under test here; introspection_pressure=0.0 is the second
+    always-dead input (no channel ever feeds it, see
+    docs/superpowers -- structurally sparse, not wired to anything)."""
+    dims = {
+        name: _dim(name, score)
+        for name, score in (
+            ("coherence", coherence),
+            ("field_intensity", 0.6),
+            ("agency_readiness", 0.5),
+            ("execution_pressure", 0.2),
+            ("reasoning_pressure", 0.1),
+            ("resource_pressure", 0.3),
+            ("reliability_pressure", 0.0),
+            ("continuity_pressure", 0.0),
+            ("social_pressure", 0.0),
+            ("introspection_pressure", 0.0),
+            ("uncertainty", 0.0),
+            ("policy_pressure", 0.0),
+            ("transport_integrity", 1.0),
+        )
+    }
+    return SelfStateV1(
+        self_state_id="self.state:tick_novelty_test:policy.v1",
+        generated_at=_NOW,
+        source_field_tick_id="tick_novelty_test",
+        source_field_generated_at=_NOW,
+        source_attention_frame_id="frame_novelty_test",
+        source_attention_generated_at=_NOW,
+        overall_intensity=0.5,
+        overall_confidence=0.8,
+        overall_condition="steady",
+        dimensions=dims,
+        dimension_trajectory={},
+    ).model_dump(mode="json")
+
+
+def _mock_healthy_substrate_reads(monkeypatch) -> None:
+    monkeypatch.setattr(worker, "_SUBSTRATE_CACHE", None, raising=False)
+    monkeypatch.setattr(
+        worker,
+        "fetch_grammar_truth",
+        AsyncMock(
+            return_value=GrammarTruthSnapshot(
+                degraded=False,
+                degraded_reasons=[],
+                enabled_reducers={"execution_trajectory": True},
+                reducer_health_by_name={"execution_trajectory": {"classification": "healthy"}},
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        worker,
+        "fetch_execution_trajectory",
+        AsyncMock(return_value=ExecutionTrajectorySnapshot(ok=True, projection=None)),
+    )
+    monkeypatch.setattr(
+        worker,
+        "fetch_reasoning_activity",
+        AsyncMock(return_value=ReasoningActivitySnapshot(ok=False, projection=None)),
+    )
+
+
+def setup_function(_fn) -> None:
+    worker._LAST_EMBEDDING_NOVELTY = None
+
+
+def teardown_function(_fn) -> None:
+    worker._LAST_EMBEDDING_NOVELTY = None
+
+
+def test_novelty_stat_defaults_to_zero_when_never_set() -> None:
+    assert worker._LAST_EMBEDDING_NOVELTY is None
+    assert worker._novelty_stat() == 0.0
+
+
+def test_novelty_stat_reflects_last_embedding_value() -> None:
+    worker._LAST_EMBEDDING_NOVELTY = 0.42
+    assert worker._novelty_stat() == pytest.approx(0.42)
+
+
+def test_phi_from_self_state_novelty_is_zero_with_live_incident_dimensions() -> None:
+    """Confirms the actual bug mechanism directly, with the exact dimension
+    readings observed in the live incident: _phi_from_self_state()["novelty"]
+    = (0.6*uncertainty + 0.4*introspection_pressure) * (0.3 + 0.7*coherence).
+    With uncertainty=0.0 and introspection_pressure=0.0 (both real upstream
+    readings, not missing/defaulted -- see _self_state_payload's docstring),
+    the weighted-sum term is exactly 0 regardless of the coherence multiplier,
+    which is why _phi_from_self_state()["novelty"] must never be used for the
+    live tissue-viz display."""
+    ss = SelfStateV1.model_validate(_self_state_payload(coherence=1.0))
+    phi = worker._phi_from_self_state(ss)
+    assert phi["novelty"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_handle_semantic_upsert_updates_last_embedding_novelty(monkeypatch) -> None:
+    monkeypatch.setattr(worker, "_EXPECTED_EMB", {}, raising=False)
+    monkeypatch.setattr(worker, "_SEEN_DOC", {}, raising=False)
+    monkeypatch.setattr(worker, "_pub_bus", None, raising=False)
+    broadcasts = []
+
+    async def _capture_broadcast(payload):
+        broadcasts.append(payload)
+
+    monkeypatch.setattr(worker.manager, "broadcast", _capture_broadcast, raising=False)
+
+    env = BaseEnvelope(
+        kind="vector.upsert.v1",
+        source=ServiceRef(name="orion-vector-host", node="n1"),
+        correlation_id=uuid4(),
+        payload={
+            "doc_id": "turn-novelty-1",
+            "collection": "orion_chat_turns",
+            "embedding": [1.0, 0.0, 0.0, 0.0],
+            "embedding_kind": "semantic",
+            "text": "hello world",
+            "meta": {},
+        },
+    )
+
+    assert worker._LAST_EMBEDDING_NOVELTY is None
+    await worker.handle_semantic_upsert(env)
+
+    # First embedding on a fresh channel_key is the cold-start branch:
+    # novelty=1.0 (no prior expectation to compare against).
+    assert worker._LAST_EMBEDDING_NOVELTY == pytest.approx(1.0)
+    tissue = [b for b in broadcasts if b.get("type") == "tissue.update"]
+    assert tissue, "expected a tissue.update broadcast"
+    assert tissue[-1]["stats"]["novelty"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_handle_self_state_tissue_update_uses_embedding_novelty_not_uncertainty(
+    monkeypatch,
+) -> None:
+    """Regression for the live incident: with coherence saturated at 1.0 (so
+    the SelfStateV1-derived novelty is structurally 0), the self-state-tick
+    tissue.update broadcast must show the last real chat-triggered embedding
+    novelty instead -- not 0."""
+    monkeypatch.setattr(worker, "_SUBSTRATE_CACHE", None, raising=False)
+    _mock_healthy_substrate_reads(monkeypatch)
+    monkeypatch.setattr(worker, "_LAST_EMBEDDING_NOVELTY", 0.37, raising=False)
+
+    broadcasts = []
+
+    async def _capture_broadcast(payload):
+        broadcasts.append(payload)
+
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel, env):
+            pass
+
+    monkeypatch.setattr(worker, "_pub_bus", _Bus(), raising=False)
+    monkeypatch.setattr(worker.manager, "broadcast", _capture_broadcast, raising=False)
+    monkeypatch.setattr(worker, "_INNER_SCALER", worker._new_inner_scaler(), raising=False)
+    monkeypatch.setattr(worker, "_INNER_PREV_FELT", None, raising=False)
+    monkeypatch.setattr(worker, "_INNER_PREV_HEADLINE", None, raising=False)
+    monkeypatch.setattr(worker, "_INNER_DEGENERATE_STREAK", 0, raising=False)
+    monkeypatch.setattr(worker, "_INNER_SINK", AsyncMock(append=lambda *_a, **_k: None), raising=False)
+
+    env = BaseEnvelope(
+        kind="substrate.self_state.v1",
+        source=ServiceRef(name="substrate-runtime", node="athena"),
+        payload=_self_state_payload(coherence=1.0),
+    )
+    await worker.handle_self_state(env)
+
+    tissue = [b for b in broadcasts if b.get("type") == "tissue.update"]
+    assert tissue, "expected a tissue.update broadcast"
+    assert tissue[-1]["stats"]["novelty"] == pytest.approx(0.37)


### PR DESCRIPTION
# fix(spark-introspector): decouple tissue-viz novelty from dead SelfStateV1 uncertainty

**Status:** IMPLEMENTED, tested, reviewed. Fixes a live production symptom
reported directly ("novelty and arousal in Hub are showing 0 and sticking to
it") — novelty half fixed here; arousal diagnosed but deliberately not fixed
yet (see below).

## Summary

Hub's tissue-viz (the novelty/arousal/valence/phi EKG display, served from
`services/orion-spark-introspector/app/static/tissue_viz.js`) showed novelty
stuck at exactly `0.0`. Verified live via a direct websocket connection to
`/ws/tissue` — confirmed across multiple consecutive ticks.

Traced the full chain:

- `_phi_from_self_state()` computes
  `novelty = (0.6*uncertainty + 0.4*introspection_pressure) * (0.3 + 0.7*coherence)`
  from the incoming `SelfStateV1` payload.
- Live `/latest` snapshot from `orion-self-state-runtime` confirmed:
  `uncertainty.score = 0.0` and `introspection_pressure.score = 0.0` — both
  **real, correctly-computed readings**, not missing/defaulted.
- `uncertainty` comes from `orion/self_state/scoring.py::uncertainty_score()`
  = `salience * (1 - coherence)` — zeroed because that service's own
  `coherence` was saturated at `1.0` (its own formula only drops on active
  failure/friction channels).
- `introspection_pressure` is fed solely by `egress_confidence_deficit`
  (`1 - egress_confidence`), which only registers nonzero when an execution
  **fails to emit** — the same "0.3% signal" structural sparsity already
  found and excised from φ's `exec_step_fail_rate`/`execution_friction` pair
  earlier in this initiative.

**This is not dead/fake code** — `uncertainty` and `introspection_pressure`
are real alarm-style signals (quiet during health, spike on trouble) being
repurposed for a display that wants continuous ambient variation. Wrong tool
for the job, not theater.

## Fix

Per explicit direction ("excise the fake math theater and find a real
replacement" → "decouple novelty from coherence entirely" → source it from
the already-correct embedding-cosine-distance novelty): tissue-viz novelty
now comes from `handle_semantic_upsert`'s real chat-triggered novelty
(confirmed live: healthy 0.1–0.5 variance), held in a new module-level
`_LAST_EMBEDDING_NOVELTY` and read through a new `_novelty_stat()` helper —
mirroring the exact existing `_INNER_LAST_HEADLINE`/`_headline_stat()`
precedent already in this file.

Applied to **both** broadcast sites that were reading the dead value:
- `handle_self_state`'s self-state-tick broadcast (fires continuously, every
  tick — the dominant source of the "stuck" symptom since it fires far more
  often than actual chat activity).
- `handle_trace`'s heartbeat branch (same `_get_phi_stats()` →
  `_phi_from_self_state()` chain, same bug).

The other two `tissue.update` broadcast sites (`_broadcast_tissue_update`,
and the trace-path candidate broadcast) already correctly used real
appraisal/embedding-based novelty with skip-if-unknown guards — untouched.

**Deliberately not touched:** `orion/self_state/scoring.py` — the shared
formulas themselves are correct for their original alarm-signal purpose and
also feed `agency_readiness_score`; changing them would be a much larger,
cognition-touching change out of scope for this display-layer fix.

## Arousal — diagnosed, not fixed (explicit scope decision)

Also traced why `arousal` sticks at 0: `resource_pressure` MAX-aggregates 7
heterogeneous channels (`transport_pressure`, `cpu_pressure`, `gpu_pressure`,
`memory_pressure`, `disk_pressure`, `thermal_pressure`, and a generic
`pressure` channel from the capability field graph). Live evidence:
`cpu_pressure=0.92` (real, high) but a separate `pressure=1.00` channel
(sourced from a specific capability's saturation in `orion-field-digester`'s
field graph, exact producer not traced to completion this pass) dominates
via `max()`, permanently zeroing `resource_cap = 1 - resource_pressure` and
therefore the whole `energy` formula regardless of what any other channel
reads. Presented three fix options (weighted-average aggregation, exclude
the untraced generic channel, diagnose further); Juniper chose "diagnose
further" — not implemented in this patch.

## Files changed

- `services/orion-spark-introspector/app/worker.py` — `_LAST_EMBEDDING_NOVELTY`
  global, `_novelty_stat()` helper, both broadcast sites updated.
- `services/orion-spark-introspector/tests/test_tissue_viz_novelty.py` (new)
  — 5 tests: `_novelty_stat()` defaults/reflects the held value;
  `_phi_from_self_state()` reproduces the exact live-incident zero (direct
  proof of the bug mechanism); `handle_semantic_upsert` updates the held
  value; end-to-end regression proving `handle_self_state`'s broadcast uses
  the embedding novelty instead of the dead SelfStateV1-derived one even when
  coherence is saturated.
- `services/orion-spark-introspector/tests/test_inner_state_emit.py` — one
  unrelated pre-existing test fixed in passing:
  `test_inner_features_settings_defaults` asserted
  `orion_phi_encoder_enabled is False`, stale since the seed-v4 encoder was
  promoted and the flag flipped `true` earlier this session (same
  live-`.env`-reading fragility already patched once this session for
  `inner_features_version`).

## Tests run

```text
pytest services/orion-spark-introspector/tests -q
  → 109 passed, 1 pre-existing unrelated failure (test_phi_reward_emitted_when_encoder_ok,
    confirmed present on main before this branch)
```

Regression verified by reverting the fix and confirming 4 of 5 new tests
fail (missing attribute / dead-value assertion), then reapplying.

## Review findings fixed

Self-reviewed (medium effort). No correctness findings. One accuracy
nitpick in my own comments, fixed before commit: `_LAST_EMBEDDING_NOVELTY`'s
docstring initially said "embedding-cosine-distance novelty" but the value
actually stored is `handle_semantic_upsert`'s *display* novelty (prefers
cached appraisal score via `_display_novelty_for_corr`, falls back to raw
embedding cosine distance) — comment corrected for precision.

## Docker/build/smoke checks

Not run against live containers in this environment. Live-verified the
*bug* directly against the running deployment (`/ws/tissue` websocket, three
consecutive ticks all showing `novelty: 0.0`) before writing the fix.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml up -d --build
```
After restart, reconnect to `/ws/tissue` (or reload the tissue-viz page) and
confirm `novelty` varies with real chat activity instead of holding at 0.

## Risks / concerns

- Severity: low. Additive display-layer fix; the underlying `uncertainty`/
  `introspection_pressure`/`coherence` formulas and every other consumer of
  them (φ, `agency_readiness_score`) are completely untouched.
- `arousal` is still stuck at 0 pending the resource_pressure aggregation
  redesign decision — known, disclosed, not silently left unaddressed.

## PR link

Branch pushed: `fix/tissue-viz-novelty-decouple-uncertainty`.
Compare: https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/tissue-viz-novelty-decouple-uncertainty