### PR TITLE
Feat/llamacpp speculative decoding profile

### DIFF
--- a/config/llm_profiles.yaml
+++ b/config/llm_profiles.yaml
@@ -371,15 +371,31 @@ profiles:
 
       n_predict: 16384
 
+      # --- Speculative decoding (OPTIONAL; leave commented until Circe VRAM/tg bench) ---
+      # Draft competes with the 131k KV window on 2xV100. Do NOT lower ctx_size / FCC
+      # budgets in the same change as enabling draft — see revisit forks A/B/C/D in
+      # docs/superpowers/specs/2026-07-09-llamacpp-speculative-decoding-profile-design.md
+      # Candidate: same Qwen3 tokenizer family, tiny draft (~0.6B Q4_K_M).
+      #hf_draft_repo_id: "unsloth/Qwen3-0.6B-GGUF"
+      #hf_draft_filename: "Qwen3-0.6B-Q4_K_M.gguf"
+      #n_gpu_layers_draft: 99
+      #draft_min: 4
+      #draft_max: 16
+
     notes: |
       Deep-cognition Qwen 3.6 35B-A3B profile for two V100 32GB GPUs (monster FCC).
       - Target lane: Cortex / planner / introspection / deep repo reasoning / FCC motor.
       - Uses Unsloth dynamic GGUF UD-Q5_K_M (~25GB) — prefer over Q6 so KV headroom survives.
       - 131k ctx (n_parallel=1) must match HARNESS_FCC_MAX_CONTEXT_TOKENS / Hub agent Claude budget.
-      - tensor_split 1,0 + layer: park weights on primary V100; second card absorbs overflow/KV.
+      - tensor_split 3,1 + layer: park weights on primary V100; second card absorbs overflow/KV.
       - flash_attn off (Volta); sampling kept cooler than Unsloth chat card for agent stability.
       - If OOM at 131k: try tensor_split 3,1 then 2,1, then lower ctx_size to 98304 / 65536.
       - Do not enable YaRN until native 262k is proven and still insufficient.
+      - Speculative decoding: host supports hf_draft_* / draft_min / draft_max / n_gpu_layers_draft.
+        Uncomment the draft block above only after a live Circe VRAM + tg/s check. Draft VRAM
+        competes with KV. Do not change FCC/Hub context budgets without an explicit follow-up
+        (revisit forks A/B/C/D in the speculative-decoding profile design spec). MTP / draft-mtp
+        is out of scope for this profile annotation.
 
 
   qwen3-30b-a3b-q4km-atlas-agent-64k-think:

--- a/config/llm_profiles.yaml
+++ b/config/llm_profiles.yaml
@@ -373,8 +373,8 @@ profiles:
 
       # --- Speculative decoding (OPTIONAL; leave commented until Circe VRAM/tg bench) ---
       # Draft competes with the 131k KV window on 2xV100. Do NOT lower ctx_size / FCC
-      # budgets in the same change as enabling draft — see revisit forks A/B/C/D in
-      # docs/superpowers/specs/2026-07-09-llamacpp-speculative-decoding-profile-design.md
+      # budgets in the same change as enabling draft — treat Circe VRAM/tg evidence and
+      # any FCC/Hub budget change as an explicit follow-up, not this annotation.
       # Candidate: same Qwen3 tokenizer family, tiny draft (~0.6B Q4_K_M).
       #hf_draft_repo_id: "unsloth/Qwen3-0.6B-GGUF"
       #hf_draft_filename: "Qwen3-0.6B-Q4_K_M.gguf"
@@ -393,9 +393,8 @@ profiles:
       - Do not enable YaRN until native 262k is proven and still insufficient.
       - Speculative decoding: host supports hf_draft_* / draft_min / draft_max / n_gpu_layers_draft.
         Uncomment the draft block above only after a live Circe VRAM + tg/s check. Draft VRAM
-        competes with KV. Do not change FCC/Hub context budgets without an explicit follow-up
-        (revisit forks A/B/C/D in the speculative-decoding profile design spec). MTP / draft-mtp
-        is out of scope for this profile annotation.
+        competes with KV. Do not change FCC/Hub context budgets without an explicit follow-up.
+        MTP / draft-mtp is out of scope for this profile annotation.
 
 
   qwen3-30b-a3b-q4km-atlas-agent-64k-think:

--- a/services/orion-llamacpp-host/README.md
+++ b/services/orion-llamacpp-host/README.md
@@ -359,7 +359,7 @@ Operator caveats:
 
 - Draft and target should share a tokenizer family; poor family match tanks acceptance rate.
 - On Volta / tight multi-GPU layouts (e.g. deep-cognition 131k + `tensor_split: "3,1"`), draft VRAM competes with KV — enable only after a live VRAM + tg/s check.
-- Do not change `HARNESS_FCC_MAX_CONTEXT_TOKENS` / Hub agent-claude budgets just to free VRAM for draft without an explicit follow-up (see design spec revisit forks A/B/C/D).
+- Do not change `HARNESS_FCC_MAX_CONTEXT_TOKENS` / Hub agent-claude budgets just to free VRAM for draft without an explicit follow-up.
 - MTP / `--spec-type draft-mtp` is out of scope for this profile contract.
 
 ---

--- a/services/orion-llamacpp-host/README.md
+++ b/services/orion-llamacpp-host/README.md
@@ -340,6 +340,28 @@ ${LLM_CACHE_DIR}/gguf/
 
 The compose files mount that cache into the container at `/models`.
 
+## Speculative decoding (draft model)
+
+Optional profile fields under `llamacpp:`:
+
+- `hf_draft_filename` / `draft_filename` — draft GGUF under `model_root` (enables speculative decoding)
+- `hf_draft_repo_id` / `draft_repo_id` — HF repo for download; defaults to main `hf_repo_id` when omitted
+- `n_gpu_layers_draft` — draft GPU offload (`--n-gpu-layers-draft`)
+- `draft_min` / `draft_max` — `--draft-min` / `--draft-max`
+
+Behavior:
+
+- Unset `draft_filename` → launch argv matches today’s non-draft behavior.
+- Set `draft_filename` → wrapper ensures the GGUF (mmproj-style HF download) and emits long-form flags supported by the pinned `server-cuda-b8740` image (`--model-draft`, `--draft-min`, `--draft-max`, `--n-gpu-layers-draft`).
+- If the binary’s `--help` lacks `--model-draft`, the host logs an error, omits draft flags, and still launches the main model.
+
+Operator caveats:
+
+- Draft and target should share a tokenizer family; poor family match tanks acceptance rate.
+- On Volta / tight multi-GPU layouts (e.g. deep-cognition 131k + `tensor_split: "3,1"`), draft VRAM competes with KV — enable only after a live VRAM + tg/s check.
+- Do not change `HARNESS_FCC_MAX_CONTEXT_TOKENS` / Hub agent-claude budgets just to free VRAM for draft without an explicit follow-up (see design spec revisit forks A/B/C/D).
+- MTP / `--spec-type draft-mtp` is out of scope for this profile contract.
+
 ---
 
 ## GPU pinning model

--- a/services/orion-llamacpp-host/app/main.py
+++ b/services/orion-llamacpp-host/app/main.py
@@ -125,6 +125,26 @@ def _ensure_mmproj_file(cfg: LlamaCppConfig) -> Optional[str]:
     return str(mmproj_path)
 
 
+def _ensure_draft_file(cfg: LlamaCppConfig) -> Optional[str]:
+    """Ensure draft GGUF exists; return concrete path for --model-draft."""
+    if not cfg.draft_filename:
+        return None
+
+    repo_id = cfg.draft_repo_id or cfg.repo_id
+    if not repo_id:
+        raise FileNotFoundError(
+            "Profile requests draft_filename but no draft_repo_id or repo_id is configured"
+        )
+
+    draft_path = _ensure_hf_gguf_file(
+        model_root=cfg.model_root,
+        repo_id=repo_id,
+        filename=cfg.draft_filename,
+        label="draft model",
+    )
+    return str(draft_path)
+
+
 def _resolve_runtime(profile: LLMProfile) -> Tuple[str, LlamaCppConfig, Dict[str, str]]:
     """
     Returns: (model_path, runtime_cfg, env)
@@ -363,6 +383,41 @@ def build_llama_server_cmd_and_env(profile: LLMProfile) -> Tuple[List[str], Dict
         append_flag("--min-p", str(cfg.min_p))
     if cfg.presence_penalty is not None:
         append_flag("--presence-penalty", str(cfg.presence_penalty))
+
+    # Speculative decoding (draft model). Optional; omit cleanly when unsupported.
+    if cfg.draft_filename:
+        draft_supported = (
+            supported_flags is None or "--model-draft" in supported_flags
+        )
+        if not draft_supported:
+            logger.error(
+                "Profile requested draft_filename=%s but this llama-server does not advertise "
+                "--model-draft in --help; omitting draft speculative decoding and launching "
+                "the main model only. Upgrade LLAMACPP_IMAGE_TAG or unset draft_filename.",
+                cfg.draft_filename,
+            )
+        else:
+            draft_path = _ensure_draft_file(cfg)
+            if draft_path is None:
+                logger.error(
+                    "Profile requested draft_filename=%s but draft path resolved to None; "
+                    "omitting draft speculative decoding.",
+                    cfg.draft_filename,
+                )
+            else:
+                append_flag("--model-draft", draft_path)
+                if cfg.n_gpu_layers_draft is not None:
+                    append_flag("--n-gpu-layers-draft", str(int(cfg.n_gpu_layers_draft)))
+                if cfg.draft_min is not None:
+                    append_flag("--draft-min", str(int(cfg.draft_min)))
+                if cfg.draft_max is not None:
+                    append_flag("--draft-max", str(int(cfg.draft_max)))
+                if "--model-draft" not in cmd:
+                    logger.error(
+                        "Profile requested draft_filename=%s but --model-draft was not emitted; "
+                        "omitting draft speculative decoding.",
+                        cfg.draft_filename,
+                    )
 
     if cfg.chat_template_kwargs is not None and "--chat-template-kwargs" not in cmd:
         logger.error(

--- a/services/orion-llamacpp-host/app/profiles.py
+++ b/services/orion-llamacpp-host/app/profiles.py
@@ -45,6 +45,28 @@ class LlamaCppConfig(BaseModel):
         validation_alias=AliasChoices("mmproj_repo_id", "hf_mmproj_repo_id"),
         description="HF repo for mmproj; defaults to repo_id when omitted",
     )
+    draft_filename: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("draft_filename", "hf_draft_filename"),
+        description="Draft GGUF filename for llama-server speculative decoding (--model-draft)",
+    )
+    draft_repo_id: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("draft_repo_id", "hf_draft_repo_id"),
+        description="HF repo for draft GGUF; defaults to repo_id when omitted",
+    )
+    n_gpu_layers_draft: Optional[int] = Field(
+        default=None,
+        description="Draft model GPU offload layers (--n-gpu-layers-draft)",
+    )
+    draft_min: Optional[int] = Field(
+        default=None,
+        description="Minimum draft tokens before verify (--draft-min)",
+    )
+    draft_max: Optional[int] = Field(
+        default=None,
+        description="Maximum draft tokens per speculation step (--draft-max)",
+    )
 
     host: str = "0.0.0.0"
     port: int = 8080

--- a/services/orion-llamacpp-host/tests/test_profile_forwarding.py
+++ b/services/orion-llamacpp-host/tests/test_profile_forwarding.py
@@ -367,6 +367,8 @@ def test_gemma4_31b_multimodal_profile_forwards_mmproj_and_image_flags(monkeypat
 def test_draft_fields_emit_speculative_decoding_flags(monkeypatch, caplog):
     import logging
 
+    monkeypatch.setenv("LLM_PROFILE_NAME", "unit-test")
+
     main = importlib.import_module("app.main")
     profiles_mod = importlib.import_module("app.profiles")
     settings_mod = importlib.import_module("app.settings")
@@ -431,6 +433,8 @@ def test_draft_fields_emit_speculative_decoding_flags(monkeypatch, caplog):
 
 
 def test_draft_unset_emits_no_draft_flags(monkeypatch):
+    monkeypatch.setenv("LLM_PROFILE_NAME", "unit-test")
+
     main = importlib.import_module("app.main")
     profiles_mod = importlib.import_module("app.profiles")
     settings_mod = importlib.import_module("app.settings")
@@ -491,6 +495,8 @@ def test_draft_unset_emits_no_draft_flags(monkeypatch):
 
 def test_draft_requested_but_flags_unsupported_omits_draft_without_crash(monkeypatch, caplog):
     import logging
+
+    monkeypatch.setenv("LLM_PROFILE_NAME", "unit-test")
 
     main = importlib.import_module("app.main")
     profiles_mod = importlib.import_module("app.profiles")

--- a/services/orion-llamacpp-host/tests/test_profile_forwarding.py
+++ b/services/orion-llamacpp-host/tests/test_profile_forwarding.py
@@ -362,3 +362,194 @@ def test_gemma4_31b_multimodal_profile_forwards_mmproj_and_image_flags(monkeypat
     assert _find_flag_value(cmd, "--temp") == "1.0"
     assert _find_flag_value(cmd, "--top-k") == "64"
     assert _find_flag_value(cmd, "--top-p") == "0.95"
+
+
+def test_draft_fields_emit_speculative_decoding_flags(monkeypatch, caplog):
+    import logging
+
+    main = importlib.import_module("app.main")
+    profiles_mod = importlib.import_module("app.profiles")
+    settings_mod = importlib.import_module("app.settings")
+
+    profile = profiles_mod.LLMProfile(
+        name="unit-draft-enabled",
+        backend="llamacpp",
+        model_id="unit-target",
+        gpu=profiles_mod.GPUConfig(num_gpus=1, tensor_parallel_size=1, device_ids=[0]),
+        llamacpp=profiles_mod.LlamaCppConfig(
+            model_root="/models/gguf",
+            repo_id="example/target",
+            filename="target.gguf",
+            draft_filename="Qwen3-0.6B-Q4_K_M.gguf",
+            draft_repo_id="unsloth/Qwen3-0.6B-GGUF",
+            n_gpu_layers_draft=99,
+            draft_min=4,
+            draft_max=16,
+            host="0.0.0.0",
+            port=8080,
+            ctx_size=8192,
+            n_gpu_layers=99,
+            threads=8,
+            n_parallel=1,
+            batch_size=512,
+        ),
+    )
+
+    monkeypatch.setattr(main, "_ensure_model_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "_ensure_draft_file",
+        lambda _cfg: "/models/gguf/Qwen3-0.6B-Q4_K_M.gguf",
+    )
+    monkeypatch.setattr(
+        main,
+        "_get_supported_llama_server_flags",
+        lambda _server_bin: {
+            "--model-draft",
+            "--draft-min",
+            "--draft-max",
+            "--n-gpu-layers-draft",
+            "--n-predict",
+            "--temp",
+        },
+    )
+    monkeypatch.setattr(main, "_get_llama_server_build", lambda _server_bin: 8740)
+    monkeypatch.setattr(
+        settings_mod.settings,
+        "llamacpp_model_path_override",
+        "/models/gguf/target.gguf",
+    )
+
+    with caplog.at_level(logging.ERROR):
+        cmd, _env = main.build_llama_server_cmd_and_env(profile)
+
+    assert _find_flag_value(cmd, "--model-draft") == "/models/gguf/Qwen3-0.6B-Q4_K_M.gguf"
+    assert _find_flag_value(cmd, "--n-gpu-layers-draft") == "99"
+    assert _find_flag_value(cmd, "--draft-min") == "4"
+    assert _find_flag_value(cmd, "--draft-max") == "16"
+    assert not any("draft" in rec.message.lower() and rec.levelno >= logging.ERROR for rec in caplog.records)
+
+
+def test_draft_unset_emits_no_draft_flags(monkeypatch):
+    main = importlib.import_module("app.main")
+    profiles_mod = importlib.import_module("app.profiles")
+    settings_mod = importlib.import_module("app.settings")
+
+    profile = profiles_mod.LLMProfile(
+        name="unit-draft-unset",
+        backend="llamacpp",
+        model_id="unit-target",
+        gpu=profiles_mod.GPUConfig(num_gpus=1, tensor_parallel_size=1, device_ids=[0]),
+        llamacpp=profiles_mod.LlamaCppConfig(
+            model_root="/models/gguf",
+            repo_id="example/target",
+            filename="target.gguf",
+            host="0.0.0.0",
+            port=8080,
+            ctx_size=8192,
+            n_gpu_layers=99,
+            threads=8,
+            n_parallel=1,
+            batch_size=512,
+        ),
+    )
+
+    monkeypatch.setattr(main, "_ensure_model_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "_get_supported_llama_server_flags",
+        lambda _server_bin: {
+            "--model-draft",
+            "--draft-min",
+            "--draft-max",
+            "--n-gpu-layers-draft",
+        },
+    )
+    monkeypatch.setattr(main, "_get_llama_server_build", lambda _server_bin: 8740)
+    monkeypatch.setattr(
+        settings_mod.settings,
+        "llamacpp_model_path_override",
+        "/models/gguf/target.gguf",
+    )
+
+    ensure_calls: list[object] = []
+
+    def _unexpected_ensure(cfg):
+        ensure_calls.append(cfg)
+        raise AssertionError("_ensure_draft_file must not run when draft_filename is unset")
+
+    monkeypatch.setattr(main, "_ensure_draft_file", _unexpected_ensure)
+
+    cmd, _env = main.build_llama_server_cmd_and_env(profile)
+
+    assert "--model-draft" not in cmd
+    assert "--draft-min" not in cmd
+    assert "--draft-max" not in cmd
+    assert "--n-gpu-layers-draft" not in cmd
+    assert ensure_calls == []
+
+
+def test_draft_requested_but_flags_unsupported_omits_draft_without_crash(monkeypatch, caplog):
+    import logging
+
+    main = importlib.import_module("app.main")
+    profiles_mod = importlib.import_module("app.profiles")
+    settings_mod = importlib.import_module("app.settings")
+
+    profile = profiles_mod.LLMProfile(
+        name="unit-draft-unsupported",
+        backend="llamacpp",
+        model_id="unit-target",
+        gpu=profiles_mod.GPUConfig(num_gpus=1, tensor_parallel_size=1, device_ids=[0]),
+        llamacpp=profiles_mod.LlamaCppConfig(
+            model_root="/models/gguf",
+            repo_id="example/target",
+            filename="target.gguf",
+            draft_filename="Qwen3-0.6B-Q4_K_M.gguf",
+            draft_repo_id="unsloth/Qwen3-0.6B-GGUF",
+            n_gpu_layers_draft=99,
+            draft_min=4,
+            draft_max=16,
+            host="0.0.0.0",
+            port=8080,
+            ctx_size=8192,
+            n_gpu_layers=99,
+            threads=8,
+            n_parallel=1,
+            batch_size=512,
+        ),
+    )
+
+    monkeypatch.setattr(main, "_ensure_model_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "_ensure_draft_file",
+        lambda _cfg: "/models/gguf/Qwen3-0.6B-Q4_K_M.gguf",
+    )
+    # Probe succeeded but draft flags absent (old binary).
+    monkeypatch.setattr(
+        main,
+        "_get_supported_llama_server_flags",
+        lambda _server_bin: {"--temp", "--top-k"},
+    )
+    monkeypatch.setattr(main, "_get_llama_server_build", lambda _server_bin: 4719)
+    monkeypatch.setattr(
+        settings_mod.settings,
+        "llamacpp_model_path_override",
+        "/models/gguf/target.gguf",
+    )
+
+    with caplog.at_level(logging.ERROR):
+        cmd, _env = main.build_llama_server_cmd_and_env(profile)
+
+    assert cmd[0].endswith("llama-server") or "llama-server" in cmd[0]
+    assert "-m" in cmd
+    assert "--model-draft" not in cmd
+    assert "--draft-min" not in cmd
+    assert "--draft-max" not in cmd
+    assert "--n-gpu-layers-draft" not in cmd
+    assert any(
+        "draft" in rec.message.lower() and "model-draft" in rec.message.lower()
+        for rec in caplog.records
+        if rec.levelno >= logging.ERROR
+    )


### PR DESCRIPTION
## Summary

- Teach `orion-llamacpp-host` optional `LlamaCppConfig` draft fields (`hf_draft_*` / `draft_*`, `n_gpu_layers_draft`, `draft_min` / `draft_max`) and emit long-form `server-cuda-b8740` flags (`--model-draft`, `--draft-min`, `--draft-max`, `--n-gpu-layers-draft`) via the existing `append_flag` seam.
- Soft-degrade when `--model-draft` is absent from `--help`: error log, omit draft flags, still launch the main model; unset draft stays boot-identical.
- Annotate deep-cognition with a **commented** draft candidate block; keep `ctx_size: 131072` and do not touch FCC/Hub budgets. Document operator caveats in the host README.
- Review follow-up: set `LLM_PROFILE_NAME` in isolated draft tests; remove dangling citations to a missing design-spec path.

## Outcome moved

Operators can enable llama.cpp draft speculative decoding from profile YAML without new env overrides, without changing the 131k FCC context contract, and without crashing on older binaries that lack `--model-draft`.

## Current architecture

`orion-llamacpp-host` already mirrored mmproj as optional profile fields → HF ensure helper → `append_flag`-gated argv. Speculative decoding had no profile contract; deep-cognition ran target-only at 131k.

## Architecture touched

- Service: `orion-llamacpp-host` (`profiles.py`, `main.py`, tests, README)
- Config: `config/llm_profiles.yaml` (deep-cognition annotation only)
- Contracts: none (no bus/schema/env key changes)

## Files changed

- `services/orion-llamacpp-host/app/profiles.py`: optional draft fields + `hf_*` aliases
- `services/orion-llamacpp-host/app/main.py`: `_ensure_draft_file` + draft argv emission / soft degrade
- `services/orion-llamacpp-host/tests/test_profile_forwarding.py`: set / unset / unsupported cases (+ env hygiene)
- `config/llm_profiles.yaml`: commented deep-cognition draft block + notes
- `services/orion-llamacpp-host/README.md`: speculative decoding operator section

## Schema / bus / API changes

- Added: none (bus/schema)
- Removed: none
- Renamed: none
- Behavior changed: profile-driven llama-server argv may include draft flags when configured and supported
- Compatibility notes: unset draft → identical argv to today; unsupported binary → main model only

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no
- local `.env` synced: n/a (no template change)
- skipped keys requiring operator action: none

## Tests run

```text
.venv/bin/python -m pytest \
  services/orion-llamacpp-host/tests/test_profile_forwarding.py::test_draft_fields_emit_speculative_decoding_flags \
  services/orion-llamacpp-host/tests/test_profile_forwarding.py::test_draft_unset_emits_no_draft_flags \
  services/orion-llamacpp-host/tests/test_profile_forwarding.py::test_draft_requested_but_flags_unsupported_omits_draft_without_crash -v
→ 3 passed (isolated; tests set LLM_PROFILE_NAME themselves)

Full host suite: 21 passed, 1 failed (pre-existing atlas metacog n_parallel 4 vs expect 1; also fails on main)
```

## Evals run

```text
No eval harness for this host argv seam; unit tests cover the contract.
```

## Docker/build/smoke checks

```text
docker run --rm --entrypoint /app/llama-server \
  ghcr.io/ggml-org/llama.cpp:server-cuda-b8740 --help \
  | rg 'model-draft|draft-max|draft-min|n-gpu-layers-draft'
→ all four long-form names present

Circe live draft enable + VRAM/tg bench: UNVERIFIED (out of band)
```

## Review findings fixed

- Finding: Draft tests omitted `LLM_PROFILE_NAME` before importing `app.main`, so isolated pytest failed on Settings validation
  - Fix: `monkeypatch.setenv("LLM_PROFILE_NAME", "unit-test")` in all three draft tests
  - Evidence: isolated three-test run passes without external env
- Finding: YAML/README cited missing `docs/superpowers/specs/2026-07-09-llamacpp-speculative-decoding-profile-design.md` and “forks A/B/C/D”
  - Fix: Removed dangling path; kept explicit follow-up / no-FCC-budget-change guidance
  - Evidence: grep shows no design-spec path in branch YAML/README

## Restart required

```bash
# Only if/when an operator uncomments draft fields on a live profile:
docker compose --env-file .env --env-file services/orion-llamacpp-host/.env \
  -f services/orion-llamacpp-host/docker-compose.yml up -d --build
```

Deep-cognition stays draft-unset → no restart required for merge alone.

## Risks / concerns

- Severity: Low
- Concern: Pre-existing `test_qwen3_8b_atlas_metacog_profile_q5km_single_lane_16k` expects `--parallel=1` but YAML has `n_parallel: 4` (unrelated to this PR)
- Mitigation: Track as separate fix; do not block this branch
- Severity: Medium (ops)
- Concern: Circe draft enable at 131k is UNVERIFIED; draft VRAM competes with KV
- Mitigation: Keep draft commented until live VRAM + tg/s check

## Test plan

- [ ] Confirm three draft unit tests pass in isolation
- [ ] Confirm deep-cognition still has no live draft keys and `ctx_size: 131072`
- [ ] Optional: on Circe, uncomment draft on a throwaway profile and compare VRAM/tg/s (out of band)
