### PR TITLE
fix(cortex-exec): route orion_voice_finalize to Circe chat lane

### DIFF
--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -4085,9 +4085,10 @@ async def call_step_services(
                     llm_route = llm_route_override
                 else:
                     # Default lane mapping:
-                    # - harness_finalize_reflect: DEEP lane ("chat") — fat prompts
-                    #   exceed metacog's multi-slot 4k ctx; runs after FCC motor on
-                    #   the same turn (sequential; one Hub FCC at a time).
+                    # - harness_finalize_reflect / orion_voice_finalize: DEEP lane
+                    #   ("chat" / Circe) — fat prompts exceed quick/fast ctx (400);
+                    #   runs after FCC motor on the same turn (sequential; one Hub
+                    #   chat at a time, so chat-lane contention is not a risk).
                     # - chat_general stance brief: FAST lane ("quick")
                     # - chat_general final response: DEEP lane ("chat")
                     # - chat_quick single-pass: FAST lane ("quick")
@@ -4095,9 +4096,7 @@ async def call_step_services(
                     # - metacog mode: METACOG lane
                     llm_route = (
                         "chat"
-                        if step.verb_name == "harness_finalize_reflect"
-                        else "quick"
-                        if step.verb_name == "orion_voice_finalize"
+                        if step.verb_name in {"harness_finalize_reflect", "orion_voice_finalize"}
                         else "quick"
                         if step.verb_name == "chat_general" and step.step_name == "synthesize_chat_stance_brief"
                         else "chat"

--- a/services/orion-cortex-exec/tests/test_harness_finalize_route.py
+++ b/services/orion-cortex-exec/tests/test_harness_finalize_route.py
@@ -47,7 +47,10 @@ def test_harness_finalize_reflect_uses_chat_route() -> None:
     assert sent_req.route == "chat"
 
 
-def test_orion_voice_finalize_uses_quick_route() -> None:
+def test_orion_voice_finalize_uses_chat_route() -> None:
+    """Voice finalize packs draft + reflection + tool residue; quick/fast ctx
+    400s on long harness turns. Chat lane (Circe) has 131k and Hub FCC is
+    sequential, so one voice finalize at a time is safe on chat."""
     step = ExecutionStep(
         step_name="llm_orion_voice_finalize",
         verb_name="orion_voice_finalize",
@@ -73,4 +76,4 @@ def test_orion_voice_finalize_uses_quick_route() -> None:
 
     assert result.status == "success"
     sent_req = llm_chat.await_args.kwargs["req"]
-    assert sent_req.route == "quick"
+    assert sent_req.route == "chat"


### PR DESCRIPTION
## Summary

- Route `orion_voice_finalize` to the Circe **chat** LLM gateway lane (same as `harness_finalize_reflect`) instead of **quick**/fast.
- Long harness turns pack draft + reflection + tool residue into voice finalize; quick (~small ctx on `:8013`) returned HTTP 400 and the error string was published as the hub reply.
- Hub chats are sequential (one FCC/harness turn at a time), so chat-lane contention is not a practical risk.

## Outcome moved

Voice finalize after long anatomy/tool harness turns no longer dies on quick-lane context limits; user-visible speech uses Circe's deep chat worker.

## Current architecture

`call_step_services` in cortex-exec maps verbs to gateway routes (`chat` / `quick` / `metacog`). `harness_finalize_reflect` already used `chat` for fat prompts; `orion_voice_finalize` still defaulted to `quick`.

## Architecture touched

- Service: `orion-cortex-exec` (route default in executor)
- Contracts: none
- Config/env: none

## Files changed

- `services/orion-cortex-exec/app/executor.py`: default `orion_voice_finalize` route → `chat`
- `services/orion-cortex-exec/tests/test_harness_finalize_route.py`: assert chat route

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: `orion_voice_finalize` LLM requests use `route=chat` (Circe) by default
- Compatibility notes: caller `llm_route` override still honored

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: n/a
- skipped keys requiring operator action: none

## Tests run

```text
PYTHONPATH=services/orion-cortex-exec:. pytest \
  services/orion-cortex-exec/tests/test_harness_finalize_route.py -q
# 2 passed
```

## Evals run

```text
No eval harness for this route-mapping seam; unit gate covers the contract.
```

## Docker/build/smoke checks

```text
Not rebuilt in this session. Live failure evidence: corr b90803fb-b261-419c-bce9-2a7f6631ae82
(voice finalize ~27k-char prompt → quick :8013 → 400 → error string in chat_history_log).
```

## Review findings fixed

- Finding: code-reviewer subagent unavailable (usage limit)
- Fix: n/a — thin one-line route set change; self-checked no other quick hardcodes for voice finalize
- Evidence: `rg` for voice_finalize/quick hardcodes clean after patch

## Restart required

```bash
cd /mnt/scripts/Orion-Sapienform/services/orion-cortex-exec
docker compose --env-file .env --env-file ../../.env -f docker-compose.yml up -d --build \
  orion-cortex-exec-background
# If compose service names differ, rebuild the background lane container that
# consumes orion:cortex:exec:request:background (live: orion-athena-cortex-exec-background).
```

## Risks / concerns

- Severity: low
- Concern: voice finalize now shares Circe chat with other chat-route work
- Mitigation: hub turns are sequential; finalize runs after motor on the same turn

## Test plan

- [ ] Restart cortex-exec background lane with this image
- [ ] Re-run a long harness hub turn that previously 400'd on voice finalize
- [ ] Confirm logs show `llm_route_selected ... verb=orion_voice_finalize route=chat`
- [ ] Confirm hub reply is speech, not a llamacpp 400 error string
