### PR TITLE
Fix/tissue viz arousal hardware evidence

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-10-tissue-viz-arousal-hardware-evidence-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-10-tissue-viz-arousal-hardware-evidence-pr.md
@@ -1,0 +1,190 @@
+# fix(spark-introspector): source tissue-viz arousal from hardware pressure evidence, not saturated resource_pressure
+
+**Status:** IMPLEMENTED, tested, reviewed. Fixes the arousal half of the
+"novelty and arousal in Hub are showing 0 and sticking to it" incident —
+novelty was fixed in `389e049f`; arousal was diagnosed but explicitly
+deferred at Juniper's direction ("diagnose further"). This patch replaces
+the deferred diagnosis with a real fix per explicit direction: "we need to
+replace it with something that isn't bullshit."
+
+## Summary
+
+Hub's tissue-viz `energy`/`arousal` stat was permanently stuck at `0.0`.
+
+- `_phi_from_self_state()` in `services/orion-spark-introspector/app/worker.py`
+  computes `energy = intensity * (resource_cap * execution_cap) ** 0.5`,
+  where `resource_cap = 1.0 - resource_pressure.score`.
+- `resource_pressure` (`orion/self_state/scoring.py::map_channels_to_dimensions`)
+  MAX-aggregates 7 heterogeneous channels: real hardware load
+  (`cpu_pressure`, `gpu_pressure`, `memory_pressure`, `disk_pressure`,
+  `thermal_pressure`) alongside `transport_pressure` and a generic
+  capability-graph `pressure` channel.
+- Live evidence (this session): `cpu_pressure=0.92` (real, high but not
+  maxed) while a separate `pressure=1.00` channel — sourced from an
+  untraced capability in `orion-field-digester`'s field graph — dominates
+  via `max()`, permanently pinning `resource_pressure.score` at `1.0`.
+  `resource_cap` hard-zeroes to `0`, and multiplication zeroes `energy`
+  regardless of what `intensity` or `execution_cap` read.
+- The exact stuck capability was **not** traced to completion (field-digester
+  has no debug/snapshot endpoint to inspect the raw graph — noted as a gap
+  in the original diagnosis and still true).
+
+## Fix
+
+worker.py only receives the already-built `SelfStateV1` payload, not the raw
+per-channel pressures internal to self-state-runtime's scoring — so this is
+a display-layer fix, same scope discipline as the novelty fix (`scoring.py`
+and `builder.py` untouched; still shared cognition machinery feeding
+`agency_readiness_score`).
+
+`orion/self_state/builder.py::evidence_for_dimension()` already puts a raw
+per-channel breakdown on the wire via `SelfStateDimensionV1.dominant_evidence`
+— up to 3 `"channel=value"` strings, sorted by value, for whichever channels
+map to that dimension. New `_hardware_resource_pressure()` helper parses
+`resource_pressure.dominant_evidence`, keeps only the 5 genuine hardware
+channels (ignoring the generic `pressure` and `transport_pressure` entries
+that can stick saturated), and returns their max. `_phi_from_self_state()`
+uses that value for `resource_cap` when present, falling back to the old
+(possibly-saturated) raw score when no hardware channel appears in the
+evidence — honest no-signal, never fabricated.
+
+**Known limitation, disclosed not fixed:** `dominant_evidence` only carries
+the top 3 channels by value. In an edge case where `pressure` and 2+ other
+non-hardware/noisier channels simultaneously outrank a real hardware channel,
+that hardware channel falls out of the evidence list and the code falls back
+to the old saturated score — no worse than before, but not a guaranteed fix
+in that case. A complete fix means widening `evidence_for_dimension()`'s
+limit or exposing raw channel pressures on the wire — a `builder.py`/schema
+change, out of scope for this display-layer patch.
+
+## Review findings fixed
+
+Ran the code-review skill in a subagent (medium effort); it stalled twice on
+its own internal finder-angle orchestration and had to be resumed via
+SendMessage before it produced results. Once it did, 3 findings came back —
+1 confirmed and unconditional, 2 real but currently guarded upstream:
+
+- **Finding:** Trajectory momentum term (`energy += ... - 0.1 * max(0.0,
+  _t("resource_pressure"))`) still read `dimension_trajectory["resource_pressure"]`
+  — the delta of the raw, still-saturated aggregate score — even after the
+  base term switched to hardware-evidence-derived pressure. If the generic
+  `pressure` channel swings, the momentum term would move energy in response
+  to it even though the base term no longer reflects it at all —
+  reintroducing the same stuck-channel theater into the trajectory
+  component alone.
+  - **Fix:** the resource_pressure trajectory delta is now only applied when
+    `hardware_pressure is None` (i.e. when the base term is also using the
+    raw score). When hardware evidence drives the base term, that momentum
+    component is omitted rather than mixing units.
+  - **Evidence:** new test
+    `test_energy_momentum_ignores_raw_resource_pressure_trajectory_when_hardware_evidence_used`
+    sets `dimension_trajectory["resource_pressure"]=1.0` alongside hardware
+    evidence and asserts `energy` is unaffected by it; a second test
+    (`test_energy_momentum_still_uses_raw_trajectory_in_fallback_path`)
+    confirms the trajectory term still applies in the no-evidence fallback
+    path.
+- **Finding:** `dominant_evidence` is an unvalidated `list[str]` crossing a
+  service boundary (unlike `dim.score`, schema-bounded to `[0, 1]`). A
+  NaN/inf string would pass `float()` without raising, and Python's
+  `min(1.0, nan)`/`(negative)**0.5` semantics could silently fabricate
+  `energy=1.0` or crash with a `TypeError` on a complex number, depending on
+  the value. Currently guarded in practice by `clamp01()` calls upstream in
+  `scoring.py` (the only known producer), but that invariant isn't enforced
+  locally or by the schema.
+  - **Fix:** parsed values are now checked with `math.isfinite()` and
+    clamped to `[0, 1]` at this boundary, rather than trusting the upstream
+    guarantee to hold forever.
+  - **Evidence:** new tests
+    `test_hardware_resource_pressure_ignores_non_finite_values` and
+    `test_hardware_resource_pressure_clamps_out_of_range_values`.
+
+## Files changed
+
+- `services/orion-spark-introspector/app/worker.py` — `math` import;
+  `_HARDWARE_RESOURCE_CHANNELS` frozenset; `_hardware_resource_pressure()`
+  helper; `_phi_from_self_state()`'s energy calculation updated to use it
+  with the trajectory-term fix.
+- `services/orion-spark-introspector/tests/test_tissue_viz_arousal.py` (new)
+  — 10 tests: helper unit tests (missing dim, generic-only evidence, mixed
+  evidence, multiple hardware channels, non-finite values, out-of-range
+  clamping); end-to-end regression reproducing the live incident's exact
+  saturated-score-with-real-hardware-evidence case; honest-fallback
+  regression (no hardware evidence → unchanged old behavior); both
+  trajectory-term regressions from the review fix.
+
+## Tests run
+
+```text
+/tmp/orion-test-venv/bin/pytest services/orion-spark-introspector/tests/test_tissue_viz_arousal.py -q
+  → 10 passed
+
+/tmp/orion-test-venv/bin/pytest services/orion-spark-introspector/tests -q
+  → 119 passed, 1 pre-existing unrelated failure (test_phi_reward_emitted_when_encoder_ok,
+    same failure already present on main before this branch, confirmed in the
+    prior novelty-fix PR)
+```
+
+Regression verified by stashing the worker.py change and confirming 5 of 6
+first-commit tests fail (missing attribute / dead-value assertion), then
+restoring.
+
+Note: the shared `/tmp/orion-test-venv` was missing `scipy` (a pre-existing
+`orion-spark-introspector` dependency, unrelated to this change — the whole
+module already imports it via `orion.spark.orion_tissue`); installed it into
+that scratch venv to make tests importable at all. Not a project dependency
+change (already in `requirements.txt`), no repo files touched for this.
+
+## Evals run
+
+No dedicated eval harness for `orion-spark-introspector`'s tissue-viz stats.
+Not adding one in this patch — same disclosed gap as the novelty fix PR.
+
+## Docker/build/smoke checks
+
+Not run against live containers in this environment. This fix could not be
+live-verified against `/ws/tissue` the way the novelty bug was (that
+required an active incident with a live saturated `resource_pressure`
+reading); verification is via the unit tests reproducing the exact
+dimension/evidence shapes observed live in this session's earlier
+investigation (`cpu_pressure=0.92`, `pressure=1.00`).
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml up -d --build
+```
+After restart, reconnect to `/ws/tissue` (or reload the tissue-viz page)
+during a period of real CPU/memory load and confirm `arousal`/`energy`
+varies instead of holding at 0. Note: if the untraced field-digester
+capability channel is not currently saturated, or if hardware load happens
+to fall outside `dominant_evidence`'s top-3 cutoff at a given moment,
+`energy` may still occasionally read low/zero — that's the disclosed
+known limitation above, not a regression.
+
+## Risks / concerns
+
+- Severity: low. Additive display-layer fix; `orion/self_state/scoring.py`
+  and every other consumer of `resource_pressure` (φ, `agency_readiness_score`)
+  are completely untouched.
+- Known limitation: top-3 `dominant_evidence` truncation can occasionally
+  still mask a real hardware channel (see above) — disclosed, not silently
+  left unaddressed. A full fix requires a `builder.py`/schema change.
+- The root stuck capability in `orion-field-digester`'s graph is still
+  untraced. This patch makes arousal resilient to that channel's saturation
+  rather than fixing the saturation itself — `resource_pressure` (as seen by
+  φ and `agency_readiness_score`) remains pinned at 1.0 until that's found.
+
+## PR link
+
+Branch pushed: `fix/tissue-viz-arousal-hardware-evidence`.
+Compare: https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/tissue-viz-arousal-hardware-evidence
+
+`gh` CLI unauthenticated in this environment (same as the rest of this
+session) — PR not opened via API. To open:
+
+```bash
+gh pr create --title "fix(spark-introspector): source tissue-viz arousal from hardware pressure evidence" \
+  --base main --head fix/tissue-viz-arousal-hardware-evidence \
+  --body-file docs/superpowers/pr-reports/2026-07-10-tissue-viz-arousal-hardware-evidence-pr.md
+```

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
 from collections import OrderedDict, deque
 from datetime import datetime, timezone
@@ -173,9 +174,18 @@ def _hardware_resource_pressure(dim: Optional[SelfStateDimensionV1]) -> Optional
         if name not in _HARDWARE_RESOURCE_CHANNELS:
             continue
         try:
-            values.append(float(raw))
+            v = float(raw)
         except ValueError:
             continue
+        # dominant_evidence is an unvalidated list[str] crossing a service
+        # boundary (unlike dim.score, which the schema bounds to [0, 1]) --
+        # NaN/out-of-range would otherwise poison resource_cap ** 0.5 into a
+        # complex number downstream. Upstream clamp01() calls in scoring.py
+        # already keep this in range today, but this boundary shouldn't rely
+        # on that holding forever.
+        if not math.isfinite(v):
+            continue
+        values.append(max(0.0, min(1.0, v)))
     return max(values) if values else None
 
 
@@ -215,7 +225,16 @@ def _phi_from_self_state(ss: SelfStateV1) -> Dict[str, float]:
     execution_cap = 1.0 - _s("execution_pressure", 0.3)
     energy = intensity * (resource_cap * execution_cap) ** 0.5
     # Trajectory: rising intensity or recovering capacity builds energy momentum.
-    energy += 0.1 * max(0.0, _t("field_intensity")) - 0.1 * max(0.0, _t("resource_pressure"))
+    # dimension_trajectory["resource_pressure"] tracks the delta of the raw,
+    # possibly-still-saturated aggregate score -- the same untraced channel
+    # resource_pressure_for_energy was built to bypass above. Only apply that
+    # delta when the base term is also using the raw score (no hardware
+    # evidence available); mixing a hardware-filtered base with a
+    # raw-aggregate momentum term would reintroduce the same stuck-channel
+    # theater into the trajectory component alone.
+    energy += 0.1 * max(0.0, _t("field_intensity"))
+    if hardware_pressure is None:
+        energy -= 0.1 * max(0.0, _t("resource_pressure"))
     energy = max(0.0, min(1.0, energy))
 
     # Novelty: genuine surprise requires a stable ground to notice it against.

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -19,7 +19,7 @@ from orion.core.bus.bus_schemas import BaseEnvelope, Envelope, ServiceRef
 from orion.core.bus.codec import OrionCodec
 from orion.core.bus.work_queue import RedisStreamWorkQueue
 from orion.schemas.platform import CoreEventV1
-from orion.schemas.self_state import SelfStateV1
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
 from orion.schemas.telemetry.cognition_trace import CognitionTracePayload
 from orion.schemas.telemetry.inner_state import InnerStateFeaturesV1
 from orion.schemas.telemetry.phi_encoder import PhiIntrinsicRewardV1
@@ -135,6 +135,49 @@ _PHI_ENCODER: PhiEncoderRuntime | None = None
 _PHI_PREV_PHI: float | None = None
 _PHI_PREV_RECON: float | None = None
 
+# resource_pressure.score is a max() over 7 heterogeneous channels (see
+# config/self_state/self_state_policy.v1.yaml channel_dimension_map): real
+# hardware load (cpu/gpu/memory/disk/thermal_pressure) alongside a generic
+# capability-graph `pressure` channel and `transport_pressure`. Live incident
+# 2026-07-10: the generic `pressure` channel sticks saturated at 1.00 from an
+# untraced orion-field-digester capability (see
+# project_tissue_viz_novelty_arousal_theater memory), permanently pinning
+# resource_pressure.score at 1.0 regardless of actual hardware load and
+# hard-zeroing tissue-viz arousal (`energy = intensity * (resource_cap *
+# execution_cap)**0.5` with resource_cap = 1 - resource_pressure = 0).
+# builder.py already puts the raw per-channel breakdown on the wire via
+# SelfStateDimensionV1.dominant_evidence ("channel=value" strings, top 3 by
+# value) -- filtering that to only the real hardware channels bypasses the
+# stuck generic channel without touching orion/self_state/scoring.py, which
+# also feeds agency_readiness_score and stays out of scope for this
+# display-layer fix.
+_HARDWARE_RESOURCE_CHANNELS = frozenset({
+    "cpu_pressure",
+    "gpu_pressure",
+    "memory_pressure",
+    "disk_pressure",
+    "thermal_pressure",
+})
+
+
+def _hardware_resource_pressure(dim: Optional[SelfStateDimensionV1]) -> Optional[float]:
+    """Real resource load from resource_pressure's dominant_evidence, ignoring
+    the generic capability-graph `pressure` and `transport_pressure` channels
+    that can stick saturated. Returns None (honest no-signal) when no hardware
+    channel appears in the evidence -- never fabricates a value."""
+    if dim is None:
+        return None
+    values: List[float] = []
+    for entry in dim.dominant_evidence:
+        name, _, raw = entry.partition("=")
+        if name not in _HARDWARE_RESOURCE_CHANNELS:
+            continue
+        try:
+            values.append(float(raw))
+        except ValueError:
+            continue
+    return max(values) if values else None
+
 
 def set_latest_self_state(ss: SelfStateV1) -> None:
     global _LATEST_SELF_STATE
@@ -163,8 +206,12 @@ def _phi_from_self_state(ss: SelfStateV1) -> Dict[str, float]:
 
     # Energy: activation × available capacity (multiplicative, not additive).
     # Being highly active with no room left isn't energy — it's grinding.
-    intensity     = _s("field_intensity", 0.5)
-    resource_cap  = 1.0 - _s("resource_pressure", 0.5)
+    intensity = _s("field_intensity", 0.5)
+    hardware_pressure = _hardware_resource_pressure(d.get("resource_pressure"))
+    resource_pressure_for_energy = (
+        hardware_pressure if hardware_pressure is not None else _s("resource_pressure", 0.5)
+    )
+    resource_cap  = 1.0 - resource_pressure_for_energy
     execution_cap = 1.0 - _s("execution_pressure", 0.3)
     energy = intensity * (resource_cap * execution_cap) ** 0.5
     # Trajectory: rising intensity or recovering capacity builds energy momentum.

--- a/services/orion-spark-introspector/tests/test_tissue_viz_arousal.py
+++ b/services/orion-spark-introspector/tests/test_tissue_viz_arousal.py
@@ -17,7 +17,9 @@ def _dim(name: str, score: float, *, dominant_evidence: list[str] | None = None)
     )
 
 
-def _self_state_payload(*, resource_dim: SelfStateDimensionV1) -> dict:
+def _self_state_payload(
+    *, resource_dim: SelfStateDimensionV1, dimension_trajectory: dict[str, float] | None = None
+) -> dict:
     dims = {
         name: _dim(name, score)
         for name, score in (
@@ -47,7 +49,7 @@ def _self_state_payload(*, resource_dim: SelfStateDimensionV1) -> dict:
         overall_confidence=0.8,
         overall_condition="steady",
         dimensions=dims,
-        dimension_trajectory={},
+        dimension_trajectory=dimension_trajectory or {},
     ).model_dump(mode="json")
 
 
@@ -107,3 +109,62 @@ def test_arousal_still_zero_when_no_hardware_evidence_present() -> None:
     ss = SelfStateV1.model_validate(_self_state_payload(resource_dim=resource_dim))
     phi = worker._phi_from_self_state(ss)
     assert phi["energy"] == 0.0
+
+
+def test_hardware_resource_pressure_ignores_non_finite_values() -> None:
+    """dominant_evidence is an unvalidated list[str] crossing a service
+    boundary. A NaN/inf entry must be dropped, not silently pass float()
+    and later poison resource_cap ** 0.5 into a complex number."""
+    dim = _dim(
+        "resource_pressure",
+        1.0,
+        dominant_evidence=["cpu_pressure=nan", "gpu_pressure=inf", "memory_pressure=0.30"],
+    )
+    assert worker._hardware_resource_pressure(dim) == 0.30
+
+
+def test_hardware_resource_pressure_clamps_out_of_range_values() -> None:
+    """A malformed >1.0 hardware value must be clamped, not passed through
+    raw -- an unclamped value would drive resource_cap negative and
+    (resource_cap * execution_cap) ** 0.5 into complex-number territory."""
+    dim = _dim("resource_pressure", 1.0, dominant_evidence=["cpu_pressure=1.50"])
+    assert worker._hardware_resource_pressure(dim) == 1.0
+
+
+def test_energy_momentum_ignores_raw_resource_pressure_trajectory_when_hardware_evidence_used() -> None:
+    """Regression: dimension_trajectory["resource_pressure"] tracks the delta
+    of the raw, still-poisoned aggregate score -- the same untraced channel
+    the base term was fixed to bypass. When hardware evidence drives the base
+    term, the raw trajectory delta must NOT also feed the momentum term, or
+    the stuck channel's theater re-enters through the back door."""
+    resource_dim = _dim(
+        "resource_pressure",
+        1.0,
+        dominant_evidence=["pressure=1.00", "cpu_pressure=0.92"],
+    )
+    payload = _self_state_payload(
+        resource_dim=resource_dim,
+        dimension_trajectory={"resource_pressure": 1.0, "field_intensity": 0.0},
+    )
+    ss = SelfStateV1.model_validate(payload)
+    phi = worker._phi_from_self_state(ss)
+    # Same 0.2828 as the no-trajectory case: the large resource_pressure
+    # trajectory delta must be ignored while hardware evidence is in use.
+    assert phi["energy"] == 0.2828
+
+
+def test_energy_momentum_still_uses_raw_trajectory_in_fallback_path() -> None:
+    """When there's no hardware evidence (fallback to the raw score), the
+    trajectory momentum term still applies as before this fix -- only the
+    hardware-evidence path skips it."""
+    resource_dim = _dim("resource_pressure", 0.5, dominant_evidence=[])
+    payload = _self_state_payload(
+        resource_dim=resource_dim,
+        dimension_trajectory={"resource_pressure": 0.2, "field_intensity": 0.0},
+    )
+    ss = SelfStateV1.model_validate(payload)
+    phi = worker._phi_from_self_state(ss)
+    # intensity=1.0, resource_cap=1-0.5=0.5, execution_cap=1.0
+    # base = 1.0 * (0.5 * 1.0) ** 0.5 ~= 0.7071
+    # momentum = -0.1 * max(0, 0.2) = -0.02 -> 0.6871
+    assert phi["energy"] == 0.6871

--- a/services/orion-spark-introspector/tests/test_tissue_viz_arousal.py
+++ b/services/orion-spark-introspector/tests/test_tissue_viz_arousal.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import app.worker as worker
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+
+_NOW = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+
+
+def _dim(name: str, score: float, *, dominant_evidence: list[str] | None = None) -> SelfStateDimensionV1:
+    return SelfStateDimensionV1(
+        dimension_id=name,
+        score=score,
+        confidence=1.0,
+        dominant_evidence=dominant_evidence or [],
+    )
+
+
+def _self_state_payload(*, resource_dim: SelfStateDimensionV1) -> dict:
+    dims = {
+        name: _dim(name, score)
+        for name, score in (
+            ("coherence", 1.0),
+            ("field_intensity", 1.0),
+            ("agency_readiness", 0.5),
+            ("execution_pressure", 0.0),
+            ("reasoning_pressure", 0.1),
+            ("reliability_pressure", 0.0),
+            ("continuity_pressure", 0.0),
+            ("social_pressure", 0.0),
+            ("introspection_pressure", 0.0),
+            ("uncertainty", 0.0),
+            ("policy_pressure", 0.0),
+            ("transport_integrity", 1.0),
+        )
+    }
+    dims["resource_pressure"] = resource_dim
+    return SelfStateV1(
+        self_state_id="self.state:tick_arousal_test:policy.v1",
+        generated_at=_NOW,
+        source_field_tick_id="tick_arousal_test",
+        source_field_generated_at=_NOW,
+        source_attention_frame_id="frame_arousal_test",
+        source_attention_generated_at=_NOW,
+        overall_intensity=0.5,
+        overall_confidence=0.8,
+        overall_condition="steady",
+        dimensions=dims,
+        dimension_trajectory={},
+    ).model_dump(mode="json")
+
+
+def test_hardware_resource_pressure_none_when_dim_missing() -> None:
+    assert worker._hardware_resource_pressure(None) is None
+
+
+def test_hardware_resource_pressure_none_when_only_generic_channel_present() -> None:
+    dim = _dim("resource_pressure", 1.0, dominant_evidence=["pressure=1.00"])
+    assert worker._hardware_resource_pressure(dim) is None
+
+
+def test_hardware_resource_pressure_ignores_generic_and_transport_channels() -> None:
+    dim = _dim(
+        "resource_pressure",
+        1.0,
+        dominant_evidence=["pressure=1.00", "cpu_pressure=0.92", "transport_pressure=0.10"],
+    )
+    assert worker._hardware_resource_pressure(dim) == 0.92
+
+
+def test_hardware_resource_pressure_takes_max_of_multiple_hardware_channels() -> None:
+    dim = _dim(
+        "resource_pressure",
+        1.0,
+        dominant_evidence=["gpu_pressure=0.40", "cpu_pressure=0.92", "memory_pressure=0.10"],
+    )
+    assert worker._hardware_resource_pressure(dim) == 0.92
+
+
+def test_arousal_no_longer_hard_zeroed_by_saturated_generic_pressure_channel() -> None:
+    """Regression for the live incident: resource_pressure.score pinned at 1.0
+    by the untraced capability-graph `pressure` channel used to hard-zero
+    tissue-viz energy/arousal regardless of real hardware load. With real
+    cpu_pressure=0.92 present in dominant_evidence, energy must reflect the
+    genuine 8% headroom instead of 0."""
+    resource_dim = _dim(
+        "resource_pressure",
+        1.0,
+        dominant_evidence=["pressure=1.00", "cpu_pressure=0.92", "memory_pressure=0.05"],
+    )
+    ss = SelfStateV1.model_validate(_self_state_payload(resource_dim=resource_dim))
+    phi = worker._phi_from_self_state(ss)
+    assert phi["energy"] > 0.0
+    # intensity=1.0, resource_cap=1-0.92=0.08, execution_cap=1-0.0=1.0
+    # energy = 1.0 * (0.08 * 1.0) ** 0.5 ~= 0.2828 (trajectory terms are 0
+    # here since dimension_trajectory is empty).
+    assert phi["energy"] == 0.2828
+
+
+def test_arousal_still_zero_when_no_hardware_evidence_present() -> None:
+    """Honest no-signal fallback: when resource_pressure carries no hardware
+    channel in its evidence (e.g. a leaner payload), behavior is unchanged
+    from before this fix -- uses the raw (possibly saturated) score rather
+    than fabricating a value."""
+    resource_dim = _dim("resource_pressure", 1.0, dominant_evidence=[])
+    ss = SelfStateV1.model_validate(_self_state_payload(resource_dim=resource_dim))
+    phi = worker._phi_from_self_state(ss)
+    assert phi["energy"] == 0.0


### PR DESCRIPTION
## Summary

Hub's tissue-viz `energy`/`arousal` stat was permanently stuck at `0.0`.

- `_phi_from_self_state()` in `services/orion-spark-introspector/app/worker.py`
  computes `energy = intensity * (resource_cap * execution_cap) ** 0.5`,
  where `resource_cap = 1.0 - resource_pressure.score`.
- `resource_pressure` (`orion/self_state/scoring.py::map_channels_to_dimensions`)
  MAX-aggregates 7 heterogeneous channels: real hardware load
  (`cpu_pressure`, `gpu_pressure`, `memory_pressure`, `disk_pressure`,
  `thermal_pressure`) alongside `transport_pressure` and a generic
  capability-graph `pressure` channel.
- Live evidence (this session): `cpu_pressure=0.92` (real, high but not
  maxed) while a separate `pressure=1.00` channel — sourced from an
  untraced capability in `orion-field-digester`'s field graph — dominates
  via `max()`, permanently pinning `resource_pressure.score` at `1.0`.
  `resource_cap` hard-zeroes to `0`, and multiplication zeroes `energy`
  regardless of what `intensity` or `execution_cap` read.
- The exact stuck capability was **not** traced to completion (field-digester
  has no debug/snapshot endpoint to inspect the raw graph — noted as a gap
  in the original diagnosis and still true).

## Fix

worker.py only receives the already-built `SelfStateV1` payload, not the raw
per-channel pressures internal to self-state-runtime's scoring — so this is
a display-layer fix, same scope discipline as the novelty fix (`scoring.py`
and `builder.py` untouched; still shared cognition machinery feeding
`agency_readiness_score`).

`orion/self_state/builder.py::evidence_for_dimension()` already puts a raw
per-channel breakdown on the wire via `SelfStateDimensionV1.dominant_evidence`
— up to 3 `"channel=value"` strings, sorted by value, for whichever channels
map to that dimension. New `_hardware_resource_pressure()` helper parses
`resource_pressure.dominant_evidence`, keeps only the 5 genuine hardware
channels (ignoring the generic `pressure` and `transport_pressure` entries
that can stick saturated), and returns their max. `_phi_from_self_state()`
uses that value for `resource_cap` when present, falling back to the old
(possibly-saturated) raw score when no hardware channel appears in the
evidence — honest no-signal, never fabricated.

**Known limitation, disclosed not fixed:** `dominant_evidence` only carries
the top 3 channels by value. In an edge case where `pressure` and 2+ other
non-hardware/noisier channels simultaneously outrank a real hardware channel,
that hardware channel falls out of the evidence list and the code falls back
to the old saturated score — no worse than before, but not a guaranteed fix
in that case. A complete fix means widening `evidence_for_dimension()`'s
limit or exposing raw channel pressures on the wire — a `builder.py`/schema
change, out of scope for this display-layer patch.

## Review findings fixed

Ran the code-review skill in a subagent (medium effort); it stalled twice on
its own internal finder-angle orchestration and had to be resumed via
SendMessage before it produced results. Once it did, 3 findings came back —
1 confirmed and unconditional, 2 real but currently guarded upstream:

- **Finding:** Trajectory momentum term (`energy += ... - 0.1 * max(0.0,
  _t("resource_pressure"))`) still read `dimension_trajectory["resource_pressure"]`
  — the delta of the raw, still-saturated aggregate score — even after the
  base term switched to hardware-evidence-derived pressure. If the generic
  `pressure` channel swings, the momentum term would move energy in response
  to it even though the base term no longer reflects it at all —
  reintroducing the same stuck-channel theater into the trajectory
  component alone.
  - **Fix:** the resource_pressure trajectory delta is now only applied when
    `hardware_pressure is None` (i.e. when the base term is also using the
    raw score). When hardware evidence drives the base term, that momentum
    component is omitted rather than mixing units.
  - **Evidence:** new test
    `test_energy_momentum_ignores_raw_resource_pressure_trajectory_when_hardware_evidence_used`
    sets `dimension_trajectory["resource_pressure"]=1.0` alongside hardware
    evidence and asserts `energy` is unaffected by it; a second test
    (`test_energy_momentum_still_uses_raw_trajectory_in_fallback_path`)
    confirms the trajectory term still applies in the no-evidence fallback
    path.
- **Finding:** `dominant_evidence` is an unvalidated `list[str]` crossing a
  service boundary (unlike `dim.score`, schema-bounded to `[0, 1]`). A
  NaN/inf string would pass `float()` without raising, and Python's
  `min(1.0, nan)`/`(negative)**0.5` semantics could silently fabricate
  `energy=1.0` or crash with a `TypeError` on a complex number, depending on
  the value. Currently guarded in practice by `clamp01()` calls upstream in
  `scoring.py` (the only known producer), but that invariant isn't enforced
  locally or by the schema.
  - **Fix:** parsed values are now checked with `math.isfinite()` and
    clamped to `[0, 1]` at this boundary, rather than trusting the upstream
    guarantee to hold forever.
  - **Evidence:** new tests
    `test_hardware_resource_pressure_ignores_non_finite_values` and
    `test_hardware_resource_pressure_clamps_out_of_range_values`.

## Files changed

- `services/orion-spark-introspector/app/worker.py` — `math` import;
  `_HARDWARE_RESOURCE_CHANNELS` frozenset; `_hardware_resource_pressure()`
  helper; `_phi_from_self_state()`'s energy calculation updated to use it
  with the trajectory-term fix.
- `services/orion-spark-introspector/tests/test_tissue_viz_arousal.py` (new)
  — 10 tests: helper unit tests (missing dim, generic-only evidence, mixed
  evidence, multiple hardware channels, non-finite values, out-of-range
  clamping); end-to-end regression reproducing the live incident's exact
  saturated-score-with-real-hardware-evidence case; honest-fallback
  regression (no hardware evidence → unchanged old behavior); both
  trajectory-term regressions from the review fix.

## Tests run

```text
/tmp/orion-test-venv/bin/pytest services/orion-spark-introspector/tests/test_tissue_viz_arousal.py -q
  → 10 passed

/tmp/orion-test-venv/bin/pytest services/orion-spark-introspector/tests -q
  → 119 passed, 1 pre-existing unrelated failure (test_phi_reward_emitted_when_encoder_ok,
    same failure already present on main before this branch, confirmed in the
    prior novelty-fix PR)
```

Regression verified by stashing the worker.py change and confirming 5 of 6
first-commit tests fail (missing attribute / dead-value assertion), then
restoring.

Note: the shared `/tmp/orion-test-venv` was missing `scipy` (a pre-existing
`orion-spark-introspector` dependency, unrelated to this change — the whole
module already imports it via `orion.spark.orion_tissue`); installed it into
that scratch venv to make tests importable at all. Not a project dependency
change (already in `requirements.txt`), no repo files touched for this.

## Evals run

No dedicated eval harness for `orion-spark-introspector`'s tissue-viz stats.
Not adding one in this patch — same disclosed gap as the novelty fix PR.

## Docker/build/smoke checks

Not run against live containers in this environment. This fix could not be
live-verified against `/ws/tissue` the way the novelty bug was (that
required an active incident with a live saturated `resource_pressure`
reading); verification is via the unit tests reproducing the exact
dimension/evidence shapes observed live in this session's earlier
investigation (`cpu_pressure=0.92`, `pressure=1.00`).

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml up -d --build
```
After restart, reconnect to `/ws/tissue` (or reload the tissue-viz page)
during a period of real CPU/memory load and confirm `arousal`/`energy`
varies instead of holding at 0. Note: if the untraced field-digester
capability channel is not currently saturated, or if hardware load happens
to fall outside `dominant_evidence`'s top-3 cutoff at a given moment,
`energy` may still occasionally read low/zero — that's the disclosed
known limitation above, not a regression.

## Risks / concerns

- Severity: low. Additive display-layer fix; `orion/self_state/scoring.py`
  and every other consumer of `resource_pressure` (φ, `agency_readiness_score`)
  are completely untouched.
- Known limitation: top-3 `dominant_evidence` truncation can occasionally
  still mask a real hardware channel (see above) — disclosed, not silently
  left unaddressed. A full fix requires a `builder.py`/schema change.
- The root stuck capability in `orion-field-digester`'s graph is still
  untraced. This patch makes arousal resilient to that channel's saturation
  rather than fixing the saturation itself — `resource_pressure` (as seen by
  φ and `agency_readiness_score`) remains pinned at 1.0 until that's found.