### PR TITLE
Feat/autonomy v2 evidence signal tension

### DIFF
--- a/config/autonomy/signal_drive_map.yaml
+++ b/config/autonomy/signal_drive_map.yaml
@@ -49,3 +49,21 @@ signal_kinds:
     severity:
       worse: up
       drives: {capability: 0.5, coherence: 0.3}
+
+  # Chat AutonomyStateV2 evidence (direct adapter; no DeviationGate).
+  # Exact hazard keys only — prefix hazards like context_excluded:* are audit-only in v1.
+  chat_social_hazard:
+    cooldown_active:
+      worse: up
+      drives: {relational: 0.5, capability: 0.2}
+    duplicate_message:
+      worse: up
+      drives: {relational: 0.4}
+    self_message_loop:
+      worse: up
+      drives: {relational: 0.5, capability: 0.3}
+
+  chat_reasoning_quality:
+    fallback:
+      worse: up
+      drives: {coherence: 0.5, predictive: 0.3}

--- a/docs/autonomy_state_v2_reducer.md
+++ b/docs/autonomy_state_v2_reducer.md
@@ -2,43 +2,51 @@
 
 ## What this is
 
-An optional, **env-gated** deterministic reducer that combines graph-loaded autonomy (`AutonomyStateV1`), turn-level evidence (user message, infra availability, reasoning fallback, social-bridge hazards), and optional action outcomes into **`AutonomyStateV2`** plus a **`AutonomyStateDeltaV1`** for one chat turn. Exported compact previews flow through cortex router metadata and Hub `extract_autonomy_payload` for observability.
+An optional, **env-gated** deterministic reducer that combines graph-loaded autonomy (`AutonomyStateV1`), turn-level **typed** evidence (user message, infra availability, reasoning quality when upstream artifacts exist, social hazards from stance locals), and optional action outcomes into **`AutonomyStateV2`** plus a **`AutonomyStateDeltaV1`** for one chat turn.
+
+Pressure math uses the shared `signal_drive_map` via `chat_evidence_to_tension` (same family as endogenous `failure_to_tension`). Keyword substring matching is **removed**.
 
 ## What this is **not**
 
 - **Not** sentience, consciousness, or moral status.
-- **Not** durable persistence: V2 exists in **request context only**; nothing is written back to the graph as V2.
-- **Phi / spark / proxy telemetry** are **non-canonical**: they may appear as `proxy_telemetry` evidence and trigger inhibition and summary hazards; they must **not** be treated as ground-truth inner state.
+- **Not** durable persistence: V2 exists in **request context only**.
+- **Not** an input to phi features, `build_self_state`, or homeostatic `DriveEngine`.
+- Empty reasoning repositories do **not** emit `reasoning_quality` theater.
 
-## Causal loop (ASCII)
+## Evidence contract (omit-when-empty)
 
-```
-Graph (V1)                    Turn evidence (ctx)
-    \                               /
-     ---- upgrade V1 -> V2 ---------+
-                  \
-                   --> reduce_autonomy_state --> AutonomyStateV2 + Delta
-                                  |
-                    chat stance inputs["autonomy"]["state_v2"] / ["delta"]
-                                  |
-                    router metadata (preview + delta)
-                                  |
-                    Hub autonomy_payload whitelist
-```
+| Kind | Emit when | Moves pressures? |
+|------|-----------|------------------|
+| `user_turn` | non-empty user message | No |
+| `infra_health` | availability ∈ {available, degraded, empty, unavailable} | No |
+| `reasoning_quality` | upstream repo/artifacts non-empty **and** `fallback_recommended` | Yes (`chat_reasoning_quality`/`fallback`) |
+| `relational_signal` | hazards on social/social_bridge locals | Yes only for mapped exact keys |
+
+Mapped social dimensions (v1): `cooldown_active`, `duplicate_message`, `self_message_loop`.  
+Prefix hazards (`context_excluded:*`, etc.) are audit-only unless YAML + test grow.
+
+Confidence values on evidence are **kind-literal constants (uncalibrated)** in v1.
 
 ## Environment flag
 
-Default **off**. Enable:
+Default **off**. Enable only after the movement eval is green:
 
 ```bash
+python orion/autonomy/evals/run_autonomy_v2_movement_eval.py
+# exit 0 required before considering:
 AUTONOMY_STATE_V2_REDUCER_ENABLED=true
 ```
 
-When unset or not `true`, cortex skips the reducer entirely (no new `ctx` keys).
+When unset or not `true`, cortex skips the reducer entirely.
+
+## Debug keys (when flag on)
+
+- `ctx["chat_autonomy_evidence_debug"]` — emitted/omitted kinds + reasons
+- `ctx["chat_autonomy_tension_debug"]` — minted tensions
+- `ctx["chat_autonomy_movement_debug"]` — pressures / dominant_drive before vs after
 
 ## Known limitations
 
-1. **Polarity-blind text heuristics** — substring checks can fire on negated phrases (e.g. “no contradiction” still matches “contradiction”). Confidence caps mitigate but do not eliminate false signal.
-2. **No durable state** — each turn rebuilds prior state from graph V1; delta `changed_fields` is relative to the **upgrade baseline at turn start**, not a stored prior-turn V2 snapshot.
-3. **Mixed evidence** — user turns and infra health are excluded from **drive pressure** deltas but still occupy evidence slots and can influence confidence and summaries.
-4. **`entity_id` / bindings** — subjects resolve via `SUBJECT_BINDINGS`; unknown subjects fall back to a safe default.
+1. **No durable state** — each turn rebuilds prior state from graph V1; delta is relative to the upgrade baseline at turn start.
+2. **Sparse map** — unmapped hazards record evidence but do not move pressures (preferred over fake motion).
+3. **Dual pipelines** — chat reducer and endogenous tick both use `signal_drive_map` helpers but chat does not feed `DriveEngine`.

--- a/docs/autonomy_state_v2_reducer.md
+++ b/docs/autonomy_state_v2_reducer.md
@@ -23,7 +23,7 @@ Pressure math uses the shared `signal_drive_map` via `chat_evidence_to_tension` 
 | `relational_signal` | hazards on social/social_bridge locals | Yes only for mapped exact keys |
 
 Mapped social dimensions (v1): `cooldown_active`, `duplicate_message`, `self_message_loop`.  
-Prefix hazards (`context_excluded:*`, etc.) are audit-only unless YAML + test grow.
+Unmapped hazards still carry typed `signal_kind` / `dimension` / `value`; `SignalDriveMap.match` is the sole pressure gate (miss → no tension).
 
 Confidence values on evidence are **kind-literal constants (uncalibrated)** in v1.
 
@@ -48,5 +48,5 @@ When unset or not `true`, cortex skips the reducer entirely.
 ## Known limitations
 
 1. **No durable state** — each turn rebuilds prior state from graph V1; delta is relative to the upgrade baseline at turn start.
-2. **Sparse map** — unmapped hazards record evidence but do not move pressures (preferred over fake motion).
+2. **Sparse map** — unmapped hazards still emit typed evidence but do not move pressures (preferred over fake motion).
 3. **Dual pipelines** — chat reducer and endogenous tick both use `signal_drive_map` helpers but chat does not feed `DriveEngine`.

--- a/docs/superpowers/plans/2026-07-10-autonomy-v2-evidence-signal-tension.md
+++ b/docs/superpowers/plans/2026-07-10-autonomy-v2-evidence-signal-tension.md
@@ -1,0 +1,1707 @@
+# AutonomyStateV2 Evidence Redesign via `signal_tension` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace AutonomyStateV2 keyword/theater evidence with a typed omit-when-empty compiler and map-driven `chat_evidence_to_tension` pressure math, proven by a movement fixture, while keeping the reducer flag default-off and hard-isolating phi / SelfState / DriveEngine.
+
+**Architecture:** Chat locals (`social` / `social_bridge` / reasoning upstream / infra / user message) feed `AutonomyEvidenceCompiler`, which emits `AutonomyEvidenceRefV1` only when upstream is proven non-empty (with optional `signal_kind` / `dimension` / `value` / `observed_at`). Pressure-eligible refs mint `TensionEventV1` via `chat_evidence_to_tension` (same family as `failure_to_tension`: map lookup, no DeviationGate/EWMA). The reducer folds `magnitude * drive_impacts` into `drive_pressures` and derives tension kinds from pressure thresholds only. Stance wires locals **before** writing `ctx["chat_social_bridge_summary"]`.
+
+**Tech Stack:** Python 3.12, Pydantic v2, pytest, YAML (`config/autonomy/signal_drive_map.yaml`), existing `orion.autonomy.signal_tension` / `SignalDriveMap`.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-autonomy-v2-evidence-signal-tension-design.md`
+
+**Worktree (create before implementing):**
+```bash
+cd /mnt/scripts/Orion-Sapienform
+git fetch origin
+git worktree add .worktrees/autonomy-v2-evidence-signal-tension -b feat/autonomy-v2-evidence-signal-tension origin/main
+cd .worktrees/autonomy-v2-evidence-signal-tension
+```
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `orion/autonomy/models.py` | Modify | Optional `signal_kind` / `dimension` / `value` on `AutonomyEvidenceRefV1` |
+| `orion/autonomy/evidence_compiler.py` | Create | Proven-non-empty gates → evidence refs + omit debug |
+| `orion/autonomy/signal_tension.py` | Modify | Add `chat_evidence_to_tension` (direct map adapter) |
+| `orion/autonomy/reducer.py` | Modify | Tension fold; delete keyword pressure / blob keyword OR paths |
+| `config/autonomy/signal_drive_map.yaml` | Modify | Add `chat_social_hazard` + `chat_reasoning_quality` rows |
+| `services/orion-cortex-exec/app/chat_stance.py` | Modify | Locals → compiler → reducer; stop reading ctx bridge for this turn |
+| `docs/autonomy_state_v2_reducer.md` | Modify | Evidence contract + enable bar; remove polarity-blind limitation claim |
+| `orion/autonomy/tests/test_evidence_compiler.py` | Create | Omit/emit gates |
+| `orion/autonomy/tests/test_signal_tension.py` | Modify | Chat adapter cases |
+| `orion/autonomy/tests/test_signal_drive_map.py` | Modify | Assert new kinds present |
+| `orion/autonomy/tests/test_autonomy_reducer.py` | Modify | Rewrite keyword-based tests; add map-driven movement |
+| `orion/autonomy/tests/test_autonomy_isolation.py` | Create | No AutonomyStateV2 → phi / SelfState wire |
+| `orion/autonomy/evals/run_autonomy_v2_movement_eval.py` | Create | Trace-proven pressure / dominant_drive movement |
+| `services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py` | Modify | Locals ordering + omit empty-repo + debug ctx |
+
+**Out of scope (do not touch):** `DriveEngine`, `build_self_state`, spark introspector phi corpus, DeviationGate warm-up for chat, Hub UI, live reasoning-repository producer.
+
+---
+
+### Task 1: Extend `AutonomyEvidenceRefV1` schema
+
+**Files:**
+- Modify: `orion/autonomy/models.py` (`AutonomyEvidenceRefV1`)
+- Test: `orion/autonomy/tests/test_evidence_ref_schema.py` (create)
+
+- [ ] **Step 1: Write the failing schema test**
+
+```python
+# orion/autonomy/tests/test_evidence_ref_schema.py
+from __future__ import annotations
+
+from datetime import datetime
+
+from orion.autonomy.models import AutonomyEvidenceRefV1
+
+
+def test_evidence_ref_accepts_optional_signal_fields() -> None:
+    fixed = datetime(2026, 7, 10, 12, 0, 0)
+    ev = AutonomyEvidenceRefV1(
+        evidence_id="social_bridge:abc",
+        source="social_bridge",
+        kind="relational_signal",
+        summary="cooldown_active",
+        confidence=0.6,
+        observed_at=fixed,
+        signal_kind="chat_social_hazard",
+        dimension="cooldown_active",
+        value=1.0,
+    )
+    assert ev.signal_kind == "chat_social_hazard"
+    assert ev.dimension == "cooldown_active"
+    assert ev.value == 1.0
+
+
+def test_evidence_ref_defaults_signal_fields_to_none() -> None:
+    ev = AutonomyEvidenceRefV1(
+        evidence_id="user_turn:x",
+        source="user_message",
+        kind="user_turn",
+        summary="hi",
+    )
+    assert ev.signal_kind is None
+    assert ev.dimension is None
+    assert ev.value is None
+    assert ev.observed_at is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest orion/autonomy/tests/test_evidence_ref_schema.py -v`  
+Expected: FAIL with unexpected keyword argument `signal_kind` (or similar Pydantic validation error).
+
+- [ ] **Step 3: Minimal schema change**
+
+In `orion/autonomy/models.py`, update `AutonomyEvidenceRefV1` to:
+
+```python
+class AutonomyEvidenceRefV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    evidence_id: str
+    source: str
+    kind: str
+    summary: str | None = None
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    observed_at: datetime | None = None
+    # Optional typed pressure fields. Audit-only refs may omit these.
+    # Confidence values remain kind-literal constants in v1 (uncalibrated).
+    signal_kind: str | None = None
+    dimension: str | None = None
+    value: float | None = Field(default=None, ge=0.0, le=1.0)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest orion/autonomy/tests/test_evidence_ref_schema.py -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/autonomy/models.py orion/autonomy/tests/test_evidence_ref_schema.py
+git commit -m "$(cat <<'EOF'
+feat(autonomy): optional signal fields on AutonomyEvidenceRefV1
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Grow `signal_drive_map.yaml` for chat kinds
+
+**Files:**
+- Modify: `config/autonomy/signal_drive_map.yaml`
+- Modify: `orion/autonomy/tests/test_signal_drive_map.py`
+
+- [ ] **Step 1: Write failing map assertions**
+
+Append to `orion/autonomy/tests/test_signal_drive_map.py`:
+
+```python
+def test_chat_social_hazard_exact_dims_present() -> None:
+    m = load_signal_drive_map()
+    assert "chat_social_hazard" in m.signal_kinds()
+    for dim in ("cooldown_active", "duplicate_message", "self_message_loop"):
+        rule = m.match("chat_social_hazard", dim)
+        assert rule is not None, dim
+        assert rule.worse == "up"
+        assert "relational" in rule.drives
+
+
+def test_chat_reasoning_quality_fallback_present() -> None:
+    m = load_signal_drive_map()
+    rule = m.match("chat_reasoning_quality", "fallback")
+    assert rule is not None
+    assert rule.worse == "up"
+    assert "coherence" in rule.drives
+    assert "predictive" in rule.drives
+
+
+def test_unmapped_chat_hazard_dimension_is_none() -> None:
+    m = load_signal_drive_map()
+    assert m.match("chat_social_hazard", "context_excluded:foo") is None
+    assert m.match("chat_social_hazard", "peer_targeted_elsewhere") is None
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `pytest orion/autonomy/tests/test_signal_drive_map.py::test_chat_social_hazard_exact_dims_present orion/autonomy/tests/test_signal_drive_map.py::test_chat_reasoning_quality_fallback_present -v`  
+Expected: FAIL (`chat_social_hazard` not in signal_kinds).
+
+- [ ] **Step 3: Add YAML rows**
+
+Append under `signal_kinds:` in `config/autonomy/signal_drive_map.yaml`:
+
+```yaml
+  # Chat AutonomyStateV2 evidence (direct adapter; no DeviationGate).
+  # Exact hazard keys only — prefix hazards like context_excluded:* are audit-only in v1.
+  chat_social_hazard:
+    cooldown_active:
+      worse: up
+      drives: {relational: 0.5, capability: 0.2}
+    duplicate_message:
+      worse: up
+      drives: {relational: 0.4}
+    self_message_loop:
+      worse: up
+      drives: {relational: 0.5, capability: 0.3}
+
+  chat_reasoning_quality:
+    fallback:
+      worse: up
+      drives: {coherence: 0.5, predictive: 0.3}
+```
+
+- [ ] **Step 4: Run map tests**
+
+Run: `pytest orion/autonomy/tests/test_signal_drive_map.py -q`  
+Expected: PASS (including existing biometrics/failure cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config/autonomy/signal_drive_map.yaml orion/autonomy/tests/test_signal_drive_map.py
+git commit -m "$(cat <<'EOF'
+feat(autonomy): map chat_social_hazard and chat_reasoning_quality
+
+EOF
+)"
+```
+
+---
+
+### Task 3: `chat_evidence_to_tension` adapter
+
+**Files:**
+- Modify: `orion/autonomy/signal_tension.py`
+- Modify: `orion/autonomy/tests/test_signal_tension.py`
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Append to `orion/autonomy/tests/test_signal_tension.py`:
+
+```python
+from datetime import datetime
+
+from orion.autonomy.models import AutonomyEvidenceRefV1
+from orion.autonomy.signal_tension import chat_evidence_to_tension
+
+
+def test_chat_evidence_mapped_hazard_mints_tension() -> None:
+    ev = AutonomyEvidenceRefV1(
+        evidence_id="h1",
+        source="social_bridge",
+        kind="relational_signal",
+        summary="cooldown_active",
+        confidence=0.6,
+        observed_at=datetime(2026, 7, 10, 12, 0, 0),
+        signal_kind="chat_social_hazard",
+        dimension="cooldown_active",
+        value=1.0,
+    )
+    t = chat_evidence_to_tension(ev, SDM)
+    assert t is not None
+    assert t.kind == "tension.chat_evidence.v1"
+    assert t.magnitude > 0.0
+    assert t.drive_impacts.get("relational", 0.0) > 0.0
+
+
+def test_chat_evidence_unmapped_or_missing_fields_returns_none() -> None:
+    bare = AutonomyEvidenceRefV1(
+        evidence_id="h2",
+        source="social_bridge",
+        kind="relational_signal",
+        summary="context_excluded:memory",
+        confidence=0.6,
+    )
+    assert chat_evidence_to_tension(bare, SDM) is None
+
+    unmapped = AutonomyEvidenceRefV1(
+        evidence_id="h3",
+        source="social_bridge",
+        kind="relational_signal",
+        summary="peer_targeted_elsewhere",
+        signal_kind="chat_social_hazard",
+        dimension="peer_targeted_elsewhere",
+        value=1.0,
+    )
+    assert chat_evidence_to_tension(unmapped, SDM) is None
+
+
+def test_chat_evidence_zero_value_returns_none() -> None:
+    ev = AutonomyEvidenceRefV1(
+        evidence_id="h4",
+        source="reasoning",
+        kind="reasoning_quality",
+        summary="fallback",
+        signal_kind="chat_reasoning_quality",
+        dimension="fallback",
+        value=0.0,
+    )
+    assert chat_evidence_to_tension(ev, SDM) is None
+
+
+def test_chat_evidence_never_raises_on_garbage() -> None:
+    class Boom:
+        signal_kind = "chat_social_hazard"
+        dimension = "cooldown_active"
+        value = 1.0
+        evidence_id = "x"
+        summary = "x"
+
+        @property
+        def kind(self):
+            raise RuntimeError("boom")
+
+    assert chat_evidence_to_tension(Boom(), SDM) is None  # type: ignore[arg-type]
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `pytest orion/autonomy/tests/test_signal_tension.py::test_chat_evidence_mapped_hazard_mints_tension -v`  
+Expected: FAIL (`ImportError` / `chat_evidence_to_tension` not defined).
+
+- [ ] **Step 3: Implement adapter**
+
+Add to `orion/autonomy/signal_tension.py` (near the other adapters; update module docstring to list the fourth entry point):
+
+```python
+CHAT_EVIDENCE_TENSION_KIND = "tension.chat_evidence.v1"
+
+
+def chat_evidence_to_tension(
+    ev: "AutonomyEvidenceRefV1",
+    sdm: SignalDriveMap,
+    *,
+    channel: str = "orion:cortex_exec:chat_stance",
+) -> Optional[TensionEventV1]:
+    """Map a pressure-eligible AutonomyEvidenceRefV1 directly (no EWMA).
+
+    Requires signal_kind + dimension + value. Unmapped / missing → None.
+    Never raises.
+    """
+    try:
+        signal_kind = getattr(ev, "signal_kind", None)
+        dimension = getattr(ev, "dimension", None)
+        value = getattr(ev, "value", None)
+        if not signal_kind or not dimension or value is None:
+            return None
+        rule = sdm.match(str(signal_kind), str(dimension))
+        if rule is None:
+            return None
+        v = _clamp01(float(value))
+        if v <= 0.0:
+            return None
+        raw_by_drive = {d: v * w for d, w in rule.drives.items()}
+        summary = (getattr(ev, "summary", None) or f"{signal_kind}.{dimension}")[:240]
+        return _build_tension(
+            kind=CHAT_EVIDENCE_TENSION_KIND,
+            raw_by_drive=raw_by_drive,
+            channel=channel,
+            correlation_id=getattr(ev, "evidence_id", None),
+            summary=str(summary),
+        )
+    except Exception:
+        return None
+```
+
+Add a TYPE_CHECKING import for `AutonomyEvidenceRefV1` if needed to avoid cycles, or import it at runtime from `orion.autonomy.models` (models does not import signal_tension — runtime import is fine).
+
+- [ ] **Step 4: Run adapter + existing tension tests**
+
+Run: `pytest orion/autonomy/tests/test_signal_tension.py -q`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/autonomy/signal_tension.py orion/autonomy/tests/test_signal_tension.py
+git commit -m "$(cat <<'EOF'
+feat(autonomy): add chat_evidence_to_tension direct adapter
+
+EOF
+)"
+```
+
+---
+
+### Task 4: `AutonomyEvidenceCompiler` (proven-non-empty gates)
+
+**Files:**
+- Create: `orion/autonomy/evidence_compiler.py`
+- Create: `orion/autonomy/tests/test_evidence_compiler.py`
+
+- [ ] **Step 1: Write failing compiler tests**
+
+```python
+# orion/autonomy/tests/test_evidence_compiler.py
+from __future__ import annotations
+
+from datetime import datetime
+
+from orion.autonomy.evidence_compiler import compile_autonomy_evidence
+
+
+FIXED = datetime(2026, 7, 10, 15, 0, 0)
+
+
+def test_empty_reasoning_repo_omits_reasoning_quality() -> None:
+    result = compile_autonomy_evidence(
+        user_message="hi",
+        social={"hazards": []},
+        social_bridge={"hazards": []},
+        reasoning_summary={"fallback_recommended": True},
+        reasoning_upstream_nonempty=False,
+        autonomy_debug={"orion": {"availability": "available"}},
+        now=FIXED,
+    )
+    kinds = [e.kind for e in result.evidence]
+    assert "reasoning_quality" not in kinds
+    assert any(o.get("kind") == "reasoning_quality" for o in result.omitted)
+    omit = next(o for o in result.omitted if o["kind"] == "reasoning_quality")
+    assert omit["reason"] == "empty_upstream"
+
+
+def test_reasoning_quality_emits_only_with_upstream_and_fallback() -> None:
+    result = compile_autonomy_evidence(
+        user_message=None,
+        social={},
+        social_bridge={},
+        reasoning_summary={"fallback_recommended": True},
+        reasoning_upstream_nonempty=True,
+        autonomy_debug={},
+        now=FIXED,
+    )
+    rq = [e for e in result.evidence if e.kind == "reasoning_quality"]
+    assert len(rq) == 1
+    assert rq[0].signal_kind == "chat_reasoning_quality"
+    assert rq[0].dimension == "fallback"
+    assert rq[0].value == 1.0
+    assert rq[0].observed_at == FIXED
+
+
+def test_hazards_from_social_locals_not_ctx() -> None:
+    result = compile_autonomy_evidence(
+        user_message="x",
+        social={"hazards": ["cooldown_active", "context_excluded:memory"]},
+        social_bridge={"hazards": ["duplicate_message"]},
+        reasoning_summary={"fallback_recommended": False},
+        reasoning_upstream_nonempty=False,
+        autonomy_debug={"orion": {"availability": "degraded"}},
+        now=FIXED,
+    )
+    rel = [e for e in result.evidence if e.kind == "relational_signal"]
+    summaries = {e.summary for e in rel}
+    assert "cooldown_active" in summaries
+    assert "duplicate_message" in summaries
+    assert "context_excluded:memory" in summaries
+
+    mapped = {e.summary: e for e in rel}
+    assert mapped["cooldown_active"].signal_kind == "chat_social_hazard"
+    assert mapped["cooldown_active"].dimension == "cooldown_active"
+    assert mapped["cooldown_active"].value == 1.0
+    # Unmapped prefix hazard is audit-only (no pressure fields).
+    assert mapped["context_excluded:memory"].signal_kind is None
+    assert mapped["context_excluded:memory"].dimension is None
+
+    infra = [e for e in result.evidence if e.kind == "infra_health"]
+    assert len(infra) == 1
+    assert infra[0].observed_at == FIXED
+    assert all(e.observed_at == FIXED for e in result.evidence)
+
+
+def test_user_turn_and_infra_emitted_without_pressure_fields() -> None:
+    result = compile_autonomy_evidence(
+        user_message="hello there",
+        social={},
+        social_bridge={},
+        reasoning_summary={},
+        reasoning_upstream_nonempty=False,
+        autonomy_debug={"orion": {"availability": "available"}},
+        now=FIXED,
+    )
+    user = next(e for e in result.evidence if e.kind == "user_turn")
+    assert user.signal_kind is None
+    assert user.source == "user_message"
+    infra = next(e for e in result.evidence if e.kind == "infra_health")
+    assert infra.signal_kind is None
+
+
+def test_infra_omitted_when_availability_unknown() -> None:
+    result = compile_autonomy_evidence(
+        user_message=None,
+        social={},
+        social_bridge={},
+        reasoning_summary={},
+        reasoning_upstream_nonempty=False,
+        autonomy_debug={"orion": {"availability": "weird"}},
+        now=FIXED,
+    )
+    assert not any(e.kind == "infra_health" for e in result.evidence)
+    assert any(o.get("reason") == "availability_not_recognized" for o in result.omitted)
+
+
+def test_compiler_never_raises() -> None:
+    result = compile_autonomy_evidence(
+        user_message=object(),  # type: ignore[arg-type]
+        social="bad",  # type: ignore[arg-type]
+        social_bridge=None,
+        reasoning_summary=None,
+        reasoning_upstream_nonempty=True,
+        autonomy_debug=None,
+        now=FIXED,
+    )
+    assert isinstance(result.evidence, list)
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `pytest orion/autonomy/tests/test_evidence_compiler.py -v`  
+Expected: FAIL (`ModuleNotFoundError: orion.autonomy.evidence_compiler`).
+
+- [ ] **Step 3: Implement compiler**
+
+Create `orion/autonomy/evidence_compiler.py`:
+
+```python
+"""Compile turn-local AutonomyStateV2 evidence with proven-non-empty gates.
+
+Must be called with explicit locals (social / social_bridge / reasoning flags).
+Never reads ctx["chat_social_bridge_summary"] — that key is written after the
+reducer runs on the live chat path.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from orion.autonomy.models import AutonomyEvidenceRefV1
+
+_INFRA_AVAIL = frozenset({"available", "degraded", "empty", "unavailable"})
+_MAPPED_SOCIAL_HAZARDS = frozenset(
+    {"cooldown_active", "duplicate_message", "self_message_loop"}
+)
+
+# Kind-literal confidences (uncalibrated v1 constants).
+_CONF_USER = 0.9
+_CONF_INFRA = 1.0
+_CONF_REASONING = 0.6
+_CONF_RELATIONAL = 0.6
+
+
+@dataclass
+class AutonomyEvidenceCompileResult:
+    evidence: list[AutonomyEvidenceRefV1] = field(default_factory=list)
+    omitted: list[dict[str, str]] = field(default_factory=list)
+    debug: dict[str, Any] = field(default_factory=dict)
+
+
+def _unique_hazards(*groups: Any) -> list[str]:
+    out: list[str] = []
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        raw = group.get("hazards") or []
+        if not isinstance(raw, (list, tuple)):
+            continue
+        for h in raw:
+            s = str(h).strip()
+            if s and s not in out:
+                out.append(s)
+    return out
+
+
+def compile_autonomy_evidence(
+    *,
+    user_message: Any,
+    social: Any,
+    social_bridge: Any,
+    reasoning_summary: Any,
+    reasoning_upstream_nonempty: bool,
+    autonomy_debug: Any,
+    now: datetime,
+) -> AutonomyEvidenceCompileResult:
+    """Emit evidence only when upstream is proven non-empty. Never raises."""
+    result = AutonomyEvidenceCompileResult()
+    try:
+        msg = ""
+        try:
+            msg = str(user_message or "").strip()
+        except Exception:
+            msg = ""
+        if msg:
+            digest = hashlib.sha256(msg[:200].encode()).hexdigest()[:16]
+            result.evidence.append(
+                AutonomyEvidenceRefV1(
+                    evidence_id=f"user_turn:{digest}",
+                    source="user_message",
+                    kind="user_turn",
+                    summary=msg[:200],
+                    confidence=_CONF_USER,
+                    observed_at=now,
+                )
+            )
+        else:
+            result.omitted.append({"kind": "user_turn", "reason": "empty_message"})
+
+        debug = autonomy_debug if isinstance(autonomy_debug, dict) else {}
+        orion_dbg = debug.get("orion") if isinstance(debug.get("orion"), dict) else {}
+        avail = str(orion_dbg.get("availability") or "").strip()
+        if avail in _INFRA_AVAIL:
+            result.evidence.append(
+                AutonomyEvidenceRefV1(
+                    evidence_id=f"infra_health:autonomy_graph:{avail}",
+                    source="infra",
+                    kind="infra_health",
+                    summary=f"autonomy graph availability={avail}",
+                    confidence=_CONF_INFRA,
+                    observed_at=now,
+                )
+            )
+        elif avail:
+            result.omitted.append(
+                {"kind": "infra_health", "reason": "availability_not_recognized"}
+            )
+        else:
+            result.omitted.append({"kind": "infra_health", "reason": "missing_availability"})
+
+        rs = reasoning_summary if isinstance(reasoning_summary, dict) else {}
+        fallback = bool(rs.get("fallback_recommended"))
+        if not reasoning_upstream_nonempty:
+            result.omitted.append({"kind": "reasoning_quality", "reason": "empty_upstream"})
+        elif not fallback:
+            result.omitted.append(
+                {"kind": "reasoning_quality", "reason": "no_quality_signal"}
+            )
+        else:
+            result.evidence.append(
+                AutonomyEvidenceRefV1(
+                    evidence_id="reasoning:fallback_recommended",
+                    source="reasoning",
+                    kind="reasoning_quality",
+                    summary="reasoning fallback recommended",
+                    confidence=_CONF_REASONING,
+                    observed_at=now,
+                    signal_kind="chat_reasoning_quality",
+                    dimension="fallback",
+                    value=1.0,
+                )
+            )
+
+        hazards = _unique_hazards(social, social_bridge)
+        if not hazards:
+            result.omitted.append({"kind": "relational_signal", "reason": "no_hazards"})
+        for hazard in hazards:
+            hid = hashlib.sha256(hazard[:80].encode()).hexdigest()[:12]
+            mapped = hazard in _MAPPED_SOCIAL_HAZARDS
+            result.evidence.append(
+                AutonomyEvidenceRefV1(
+                    evidence_id=f"social_bridge:{hid}",
+                    source="social_bridge",
+                    kind="relational_signal",
+                    summary=hazard[:200],
+                    confidence=_CONF_RELATIONAL,
+                    observed_at=now,
+                    signal_kind="chat_social_hazard" if mapped else None,
+                    dimension=hazard if mapped else None,
+                    value=1.0 if mapped else None,
+                )
+            )
+
+        result.debug = {
+            "emitted_kinds": [e.kind for e in result.evidence],
+            "omitted": list(result.omitted),
+            "hazard_count": len(hazards),
+            "reasoning_upstream_nonempty": bool(reasoning_upstream_nonempty),
+        }
+    except Exception as exc:
+        result.omitted.append({"kind": "_compiler", "reason": f"degraded:{type(exc).__name__}"})
+        result.debug = {"error": type(exc).__name__}
+    return result
+```
+
+- [ ] **Step 4: Run compiler tests**
+
+Run: `pytest orion/autonomy/tests/test_evidence_compiler.py -q`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/autonomy/evidence_compiler.py orion/autonomy/tests/test_evidence_compiler.py
+git commit -m "$(cat <<'EOF'
+feat(autonomy): add AutonomyEvidenceCompiler with omit-when-empty gates
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Reducer — tension fold; delete keyword cathedral
+
+**Files:**
+- Modify: `orion/autonomy/reducer.py`
+- Modify: `orion/autonomy/tests/test_autonomy_reducer.py`
+
+- [ ] **Step 1: Rewrite / add failing reducer tests**
+
+Replace keyword-era tests in `orion/autonomy/tests/test_autonomy_reducer.py` as follows.
+
+**Delete or rewrite** these existing tests (they encode the banned keyword path):
+
+- `test_reducer_capability_timeout_unavailable`
+- `test_reducer_polarity_blind_no_contradiction_still_raises_coherence`
+- `test_reducer_determinism_fixed_now` (uses `"regression detected"` prose)
+
+Add / replace with:
+
+```python
+from orion.autonomy.signal_drive_map import load_signal_drive_map
+
+
+def test_reducer_mapped_hazard_moves_relational_pressure() -> None:
+    prior = _base_v2(drive_pressures={"relational": 0.05, "coherence": 0.1})
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=prior,
+            evidence=[
+                AutonomyEvidenceRefV1(
+                    evidence_id="h1",
+                    source="social_bridge",
+                    kind="relational_signal",
+                    summary="cooldown_active",
+                    confidence=0.6,
+                    observed_at=fixed,
+                    signal_kind="chat_social_hazard",
+                    dimension="cooldown_active",
+                    value=1.0,
+                )
+            ],
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    assert r.state.drive_pressures["relational"] > 0.05
+    assert abs(r.delta.drive_deltas.get("relational", 0.0)) > 0.0
+    assert "latest_direct_evidence_at" in r.state.freshness
+
+
+def test_reducer_unmapped_hazard_does_not_move_pressures() -> None:
+    prior = _base_v2(drive_pressures={"relational": 0.2, "coherence": 0.2})
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    before = dict(prior.drive_pressures)
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=prior,
+            evidence=[
+                AutonomyEvidenceRefV1(
+                    evidence_id="h1",
+                    source="social_bridge",
+                    kind="relational_signal",
+                    summary="context_excluded:memory",
+                    confidence=0.6,
+                    observed_at=fixed,
+                )
+            ],
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    for k in before:
+        assert r.state.drive_pressures.get(k, 0.0) == before.get(k, 0.0)
+
+
+def test_reducer_prose_keywords_no_longer_move_pressures() -> None:
+    """Acceptance: keyword tokens must not move pressures."""
+    prior = _base_v2(drive_pressures={"coherence": 0.1, "capability": 0.1, "relational": 0.1})
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=prior,
+            evidence=[
+                AutonomyEvidenceRefV1(
+                    evidence_id="e1",
+                    source="graph",
+                    kind="note",
+                    summary="frustration repair contradiction timeout unavailable stale",
+                    confidence=0.8,
+                    observed_at=fixed,
+                )
+            ],
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    assert r.state.drive_pressures["coherence"] == 0.1
+    assert r.state.drive_pressures["capability"] == 0.1
+    assert r.state.drive_pressures["relational"] == 0.1
+    # Tension kinds must not OR in from the prose blob either.
+    assert "tension.coherence_break.v1" not in r.state.tension_kinds
+    assert "tension.capability_gap.v1" not in r.state.tension_kinds
+    assert "tension.relational_repair.v1" not in r.state.tension_kinds
+
+
+def test_reducer_reasoning_fallback_moves_coherence() -> None:
+    prior = _base_v2(drive_pressures={"coherence": 0.05, "predictive": 0.05})
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=prior,
+            evidence=[
+                AutonomyEvidenceRefV1(
+                    evidence_id="reasoning:fallback_recommended",
+                    source="reasoning",
+                    kind="reasoning_quality",
+                    summary="reasoning fallback recommended",
+                    confidence=0.6,
+                    observed_at=fixed,
+                    signal_kind="chat_reasoning_quality",
+                    dimension="fallback",
+                    value=1.0,
+                )
+            ],
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    assert r.state.drive_pressures["coherence"] > 0.05
+    assert r.state.drive_pressures["predictive"] > 0.05
+
+
+def test_reducer_tension_kinds_from_pressure_thresholds_only() -> None:
+    prior = _base_v2(drive_pressures={"coherence": 0.30})
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    # No incoming evidence; prior pressure already at threshold.
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=prior,
+            evidence=[],
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    assert "tension.coherence_break.v1" in r.state.tension_kinds
+
+
+def test_reducer_no_keyword_helpers_in_module() -> None:
+    import inspect
+    from orion.autonomy import reducer as reducer_mod
+
+    src = inspect.getsource(reducer_mod)
+    for banned in (
+        '_apply_single_evidence_pressures',
+        '"contradiction"',
+        '"frustration"',
+        '"stale" in blob',
+        '"timeout" in blob',
+    ):
+        assert banned not in src, banned
+
+
+def test_reducer_determinism_fixed_now_typed() -> None:
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    prior = _base_v2(drive_pressures={"relational": 0.0})
+    inp = AutonomyReducerInputV1(
+        subject="orion",
+        previous_state=prior,
+        evidence=[
+            AutonomyEvidenceRefV1(
+                evidence_id="z1",
+                source="social_bridge",
+                kind="relational_signal",
+                summary="self_message_loop",
+                confidence=0.6,
+                observed_at=fixed,
+                signal_kind="chat_social_hazard",
+                dimension="self_message_loop",
+                value=1.0,
+            )
+        ],
+        action_outcomes=[],
+        now=fixed,
+    )
+    a = reduce_autonomy_state(inp).state.model_dump(mode="json")
+    b = reduce_autonomy_state(inp).state.model_dump(mode="json")
+    assert a == b
+```
+
+Keep existing tests that still apply: cold start, user/infra no pressure, proxy inhibition, surprise confidence, evidence trim, no_fresh_evidence.
+
+- [ ] **Step 2: Run to verify new tests fail / old keyword tests fail against new intent**
+
+Run: `pytest orion/autonomy/tests/test_autonomy_reducer.py::test_reducer_mapped_hazard_moves_relational_pressure orion/autonomy/tests/test_autonomy_reducer.py::test_reducer_prose_keywords_no_longer_move_pressures -v`  
+Expected: FAIL (mapped hazard does not move yet; prose still moves until keyword path deleted).
+
+- [ ] **Step 3: Implement reducer changes**
+
+In `orion/autonomy/reducer.py`:
+
+1. Add imports:
+
+```python
+from orion.autonomy.signal_drive_map import SignalDriveMap, load_signal_drive_map
+from orion.autonomy.signal_tension import chat_evidence_to_tension
+from orion.core.schemas.drives import TensionEventV1
+```
+
+2. **Delete** `_evidence_text`, `_apply_single_evidence_pressures`, `_combined_evidence_text`.
+
+3. Replace pressure application + tension derivation + confidence blob penalties:
+
+```python
+_MAX_PRESSURE_STEP = 0.15
+
+
+def _fold_tension_into_pressures(
+    pressures: dict[str, float], tension: TensionEventV1
+) -> dict[str, float]:
+    out = dict(pressures)
+    mag = float(tension.magnitude or 0.0)
+    for drive, impact in (tension.drive_impacts or {}).items():
+        if drive not in _DRIVE_KEYS:
+            continue
+        added = min(_MAX_PRESSURE_STEP, mag * float(impact or 0.0))
+        if added > 0.0:
+            out[drive] = min(1.0, out[drive] + added)
+    return out
+
+
+def _derive_tension_kinds(pressures: dict[str, float]) -> list[str]:
+    kinds: list[str] = []
+
+    def add(name: str) -> None:
+        if name not in kinds:
+            kinds.append(name)
+
+    if pressures.get("coherence", 0.0) >= 0.25:
+        add("tension.coherence_break.v1")
+    if pressures.get("continuity", 0.0) >= 0.25:
+        add("tension.continuity_gap.v1")
+    if pressures.get("capability", 0.0) >= 0.25:
+        add("tension.capability_gap.v1")
+    if pressures.get("relational", 0.0) >= 0.25:
+        add("tension.relational_repair.v1")
+
+    ranked = sorted(_DRIVE_KEYS, key=lambda k: pressures.get(k, 0.0), reverse=True)
+    if len(ranked) >= 2:
+        p1 = pressures.get(ranked[0], 0.0)
+        p2 = pressures.get(ranked[1], 0.0)
+        if p1 >= 0.25 and p2 >= 0.25 and abs(p1 - p2) < 0.08:
+            add("tension.drive_competition.v1")
+    return kinds
+
+
+def _infra_unavailable(evidence: list[AutonomyEvidenceRefV1]) -> bool:
+    for ev in evidence:
+        if ev.kind != "infra_health":
+            continue
+        summary = (ev.summary or "").lower()
+        if "availability=unavailable" in summary or "availability=degraded" in summary:
+            return True
+    return False
+```
+
+4. In `reduce_autonomy_state`, replace the pressure loop and blob usage:
+
+```python
+    pressures = _normalize_pressures(dict(working.drive_pressures))
+    prev_dom = working.dominant_drive
+
+    sdm: SignalDriveMap = load_signal_drive_map()
+    minted: list[dict[str, Any]] = []
+    for ev in inp.evidence:
+        # user_turn / infra_health are never pressure-eligible (no signal fields).
+        tension = chat_evidence_to_tension(ev, sdm)
+        if tension is None:
+            continue
+        pressures = _fold_tension_into_pressures(pressures, tension)
+        minted.append(
+            {
+                "kind": tension.kind,
+                "signal_kind": ev.signal_kind,
+                "dimension": ev.dimension,
+                "drives": sorted((tension.drive_impacts or {}).keys()),
+            }
+        )
+
+    working.drive_pressures = {k: pressures[k] for k in _DRIVE_KEYS}
+    dominant, active_drives = _dominant_and_active(pressures, prev_dom)
+    working.dominant_drive = dominant
+    working.active_drives = active_drives
+    working.tension_kinds = _derive_tension_kinds(pressures)
+```
+
+5. Confidence: **remove** these lines:
+
+```python
+    if "stale" in blob or "missing context" in blob:
+        conf -= 0.05
+    if "timeout" in blob or "unavailable" in blob:
+        conf -= 0.05
+```
+
+Optional typed replacement (allowed by spec):
+
+```python
+    if _infra_unavailable(working.evidence_refs):
+        conf -= 0.05
+```
+
+6. Inhibition `dependency_unavailable`: replace blob check with:
+
+```python
+            elif c.kind == "triage_capability_gap" and pressures.get("capability", 0.0) >= 0.35:
+                if _infra_unavailable(working.evidence_refs):
+                    reason = "dependency_unavailable"
+```
+
+7. Attach mint debug onto delta notes or leave for stance debug (stance Task 6 records compiler + mint debug in ctx). Optionally append a short note:
+
+```python
+        notes=[
+            "delta compares against upgraded V1 or copied V2 baseline at turn start",
+            "changed_fields are surface diffs vs that baseline, not a persisted prior-turn snapshot",
+            f"tensions_minted={len(minted)}",
+        ],
+```
+
+Do **not** call `SignalTensionSource`, DeviationGate, or `DriveEngine`.
+
+- [ ] **Step 4: Run reducer tests**
+
+Run: `pytest orion/autonomy/tests/test_autonomy_reducer.py -q`  
+Expected: PASS
+
+Also confirm keyword helpers are gone:
+
+Run: `rg -n "_apply_single_evidence_pressures|frustration|contradiction" orion/autonomy/reducer.py`  
+Expected: no pressure-path keyword hits (comments about deletion are fine; prefer zero hits).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add orion/autonomy/reducer.py orion/autonomy/tests/test_autonomy_reducer.py
+git commit -m "$(cat <<'EOF'
+feat(autonomy): fold chat tensions into drive_pressures; drop keyword path
+
+EOF
+)"
+```
+
+---
+
+### Task 6: Stance wiring — locals before ctx write
+
+**Files:**
+- Modify: `services/orion-cortex-exec/app/chat_stance.py`
+- Modify: `services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py`
+
+- [ ] **Step 1: Write failing stance tests**
+
+Append to `services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py`:
+
+```python
+from datetime import datetime, timezone
+
+from orion.core.schemas.reasoning import ClaimV1
+from orion.core.schemas.reasoning_io import ReasoningWriteContextV1, ReasoningWriteRequestV1
+from orion.reasoning import InMemoryReasoningRepository
+
+
+def _claim() -> ClaimV1:
+    return ClaimV1(
+        anchor_scope="orion",
+        subject_ref="project:orion_sapienform",
+        status="canonical",
+        authority="local_inferred",
+        confidence=0.9,
+        salience=0.8,
+        novelty=0.4,
+        risk_tier="low",
+        observed_at=datetime.now(timezone.utc),
+        provenance={
+            "evidence_refs": ["ev:1"],
+            "source_channel": "orion:test",
+            "source_kind": "unit",
+            "producer": "pytest",
+        },
+        claim_text="Reasoning continuity is strong.",
+        claim_kind="identity_signal",
+    )
+
+
+def test_chat_stance_empty_repo_omits_reasoning_quality_evidence(monkeypatch) -> None:
+    state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive="coherence",
+        drive_pressures={"coherence": 0.05},
+        active_drives=["coherence"],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+    )
+    monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
+    monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
+    ctx: dict = {"user_message": "hello", "correlation_id": "c-omit"}
+    chat_stance.build_chat_stance_inputs(ctx)
+    debug = ctx.get("chat_autonomy_evidence_debug") or {}
+    omitted = debug.get("omitted") or []
+    assert any(o.get("kind") == "reasoning_quality" and o.get("reason") == "empty_upstream" for o in omitted)
+    v2 = ctx.get("chat_autonomy_state_v2") or {}
+    kinds = [e.get("kind") for e in (v2.get("evidence_refs") or [])]
+    assert "reasoning_quality" not in kinds
+
+
+def test_chat_stance_social_locals_reach_reducer(monkeypatch) -> None:
+    state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive=None,
+        drive_pressures={"relational": 0.0, "coherence": 0.0},
+        active_drives=[],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+    )
+    monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
+
+    def _fake_social(_beliefs, _ctx):
+        return (
+            {"social_posture": [], "hazards": ["cooldown_active"], "relationship_facets": []},
+            {"posture": [], "hazards": ["cooldown_active"], "framing": [], "summary": []},
+        )
+
+    monkeypatch.setattr(chat_stance, "_project_social_from_beliefs", _fake_social)
+    monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
+    ctx: dict = {"user_message": "ping", "correlation_id": "c-haz"}
+    # Intentionally do NOT pre-seed chat_social_bridge_summary — ordering bug regression.
+    assert "chat_social_bridge_summary" not in ctx
+    chat_stance.build_chat_stance_inputs(ctx)
+    v2 = ctx["chat_autonomy_state_v2"]
+    summaries = [e.get("summary") for e in (v2.get("evidence_refs") or []) if e.get("kind") == "relational_signal"]
+    assert "cooldown_active" in summaries
+    assert v2["drive_pressures"]["relational"] > 0.0
+    assert isinstance(ctx.get("chat_autonomy_evidence_debug"), dict)
+    assert isinstance(ctx.get("chat_autonomy_tension_debug"), dict)
+
+
+def test_chat_stance_reasoning_upstream_emits_quality(monkeypatch) -> None:
+    state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive="coherence",
+        drive_pressures={"coherence": 0.05, "predictive": 0.05},
+        active_drives=["coherence"],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+    )
+    monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
+    monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
+
+    repo = InMemoryReasoningRepository()
+    # Empty-ish path that still has an artifact but compiler may still recommend fallback
+    # depending on subject_refs — force fallback via monkeypatch after compile if needed.
+    repo.write_artifacts(
+        ReasoningWriteRequestV1(
+            context=ReasoningWriteContextV1(
+                source_family="manual",
+                source_kind="unit",
+                source_channel="orion:test",
+                producer="pytest",
+            ),
+            artifacts=[_claim()],
+        )
+    )
+
+    original_compile = chat_stance._compile_reasoning_summary
+
+    def _compile_force_fallback(ctx):
+        out = original_compile(ctx)
+        summary = dict(out.get("summary") or {})
+        summary["fallback_recommended"] = True
+        out = dict(out)
+        out["summary"] = summary
+        return out
+
+    monkeypatch.setattr(chat_stance, "_compile_reasoning_summary", _compile_force_fallback)
+    ctx: dict = {"user_message": "who?", "reasoning_repository": repo}
+    chat_stance.build_chat_stance_inputs(ctx)
+    v2 = ctx["chat_autonomy_state_v2"]
+    kinds = [e.get("kind") for e in (v2.get("evidence_refs") or [])]
+    assert "reasoning_quality" in kinds
+    assert v2["drive_pressures"]["coherence"] > 0.05
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `PYTHONPATH=services/orion-cortex-exec:services/orion-cortex-exec/app:. pytest services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py::test_chat_stance_social_locals_reach_reducer -v`  
+(Use the service’s normal pytest invocation if a conftest already sets `PYTHONPATH`.)  
+Expected: FAIL (`chat_autonomy_evidence_debug` missing and/or relational pressure still 0 because evidence builder still reads empty ctx).
+
+- [ ] **Step 3: Wire stance**
+
+In `services/orion-cortex-exec/app/chat_stance.py`:
+
+1. Replace import of only `AutonomyEvidenceRefV1` usage for the old builder — add:
+
+```python
+from orion.autonomy.evidence_compiler import compile_autonomy_evidence
+from orion.autonomy.signal_drive_map import load_signal_drive_map
+from orion.autonomy.signal_tension import chat_evidence_to_tension
+```
+
+2. Add helper:
+
+```python
+def _reasoning_upstream_nonempty(ctx: Dict[str, Any]) -> bool:
+    raw = ctx.get("reasoning_artifacts")
+    if isinstance(raw, list) and raw:
+        return True
+    repo = ctx.get("reasoning_repository")
+    if repo is None:
+        return False
+    try:
+        latest = repo.list_latest(limit=1)
+        return bool(latest)
+    except Exception:
+        return False
+```
+
+3. **Delete** `_build_autonomy_reducer_evidence`.
+
+4. Replace `_run_autonomy_reducer` with a locals-aware version:
+
+```python
+def _run_autonomy_reducer(
+    ctx: Dict[str, Any],
+    autonomy: Dict[str, Any],
+    *,
+    social: Dict[str, Any],
+    social_bridge: Dict[str, Any],
+    reasoning: Dict[str, Any],
+):
+    now = datetime.utcnow()
+    compile_result = compile_autonomy_evidence(
+        user_message=ctx.get("user_message") or ctx.get("message") or "",
+        social=social,
+        social_bridge=social_bridge,
+        reasoning_summary=(reasoning.get("summary") if isinstance(reasoning, dict) else {}) or {},
+        reasoning_upstream_nonempty=_reasoning_upstream_nonempty(ctx),
+        autonomy_debug=autonomy.get("debug") if isinstance(autonomy.get("debug"), dict) else {},
+        now=now,
+    )
+    ctx["chat_autonomy_evidence_debug"] = {
+        "emitted_kinds": [e.kind for e in compile_result.evidence],
+        "omitted": list(compile_result.omitted),
+        **(compile_result.debug or {}),
+    }
+    # Trace tensions that will be minted (same map the reducer uses).
+    sdm = load_signal_drive_map()
+    tension_debug = []
+    for ev in compile_result.evidence:
+        t = chat_evidence_to_tension(ev, sdm)
+        if t is None:
+            continue
+        tension_debug.append(
+            {
+                "kind": t.kind,
+                "signal_kind": ev.signal_kind,
+                "dimension": ev.dimension,
+                "drives": sorted((t.drive_impacts or {}).keys()),
+                "magnitude": t.magnitude,
+            }
+        )
+    ctx["chat_autonomy_tension_debug"] = {"minted": tension_debug}
+
+    state_obj = autonomy.get("state")
+    subj = getattr(state_obj, "subject", None) if state_obj is not None else None
+    subject = str(subj or "orion")
+    return reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject=subject,
+            previous_state=state_obj,
+            evidence=compile_result.evidence,
+            action_outcomes=load_action_outcomes(subject=subject),
+            now=now,
+        )
+    )
+```
+
+Add `from datetime import datetime` near the top of `chat_stance.py` if missing (current file does not import it).
+
+5. In `build_chat_stance_inputs`, change the gated call to pass locals **that already exist** at that point (`social`, `social_bridge`, `reasoning`):
+
+```python
+    if os.getenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "").strip().lower() == "true":
+        try:
+            before_pressures = None
+            if autonomy.get("state") is not None:
+                before_pressures = dict(getattr(autonomy["state"], "drive_pressures", None) or {})
+            v2_result = _run_autonomy_reducer(
+                ctx,
+                autonomy,
+                social=social,
+                social_bridge=social_bridge,
+                reasoning=reasoning,
+            )
+            ctx["chat_autonomy_state_v2"] = v2_result.state.model_dump(mode="json")
+            ctx["chat_autonomy_state_delta"] = v2_result.delta.model_dump(mode="json")
+            ctx["chat_autonomy_movement_debug"] = {
+                "dominant_drive_before": getattr(autonomy.get("state"), "dominant_drive", None),
+                "dominant_drive_after": v2_result.state.dominant_drive,
+                "pressures_before": before_pressures,
+                "pressures_after": dict(v2_result.state.drive_pressures or {}),
+                "new_tensions": list(v2_result.delta.new_tensions or []),
+                "resolved_tensions": list(v2_result.delta.resolved_tensions or []),
+            }
+            inputs["autonomy"]["state_v2"] = ctx["chat_autonomy_state_v2"]
+            inputs["autonomy"]["delta"] = ctx["chat_autonomy_state_delta"]
+        except Exception as exc:
+            logger.warning("autonomy_reducer_v2_failed error=%s", exc)
+```
+
+Confirm this block still runs **before** `ctx["chat_social_bridge_summary"] = social_bridge` (today the write is ~line 2347; reducer is ~2308 — keep that order).
+
+6. Env gate stays default-off (`AUTONOMY_STATE_V2_REDUCER_ENABLED=` empty in `.env_example`). **Do not** flip the default.
+
+- [ ] **Step 4: Run stance autonomy tests**
+
+Run: `pytest services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py -q`  
+Expected: PASS (including prior enable/disable/exception tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/orion-cortex-exec/app/chat_stance.py services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
+git commit -m "$(cat <<'EOF'
+feat(cortex): wire AutonomyEvidenceCompiler locals into V2 reducer
+
+EOF
+)"
+```
+
+---
+
+### Task 7: Movement eval (enable bar)
+
+**Files:**
+- Create: `orion/autonomy/evals/run_autonomy_v2_movement_eval.py`
+
+- [ ] **Step 1: Write the eval (fails until Task 5–6 green; run as gate)**
+
+```python
+#!/usr/bin/env python3
+"""Trace-proven AutonomyStateV2 pressure movement from typed chat evidence.
+
+Enable bar for AUTONOMY_STATE_V2_REDUCER_ENABLED: do not flip production until
+this eval exits 0.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+
+from orion.autonomy.evidence_compiler import compile_autonomy_evidence
+from orion.autonomy.models import AutonomyStateV2
+from orion.autonomy.reducer import AutonomyReducerInputV1, reduce_autonomy_state
+
+
+def _cold(**overrides: object) -> AutonomyStateV2:
+    base = AutonomyStateV2(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        source="eval",
+        generated_at=datetime(2026, 7, 10, 12, 0, 0),
+        schema_version="autonomy.state.v2",
+        confidence=0.5,
+        unknowns=[],
+        evidence_refs=[],
+        freshness={},
+        attention_items=[],
+        candidate_impulses=[],
+        inhibited_impulses=[],
+        last_action_outcomes=[],
+        drive_pressures={
+            "coherence": 0.05,
+            "continuity": 0.05,
+            "relational": 0.05,
+            "autonomy": 0.05,
+            "capability": 0.05,
+            "predictive": 0.05,
+        },
+        dominant_drive=None,
+        active_drives=[],
+        tension_kinds=[],
+    )
+    return base.model_copy(update=overrides)
+
+
+def main() -> int:
+    fixed = datetime(2026, 7, 10, 16, 0, 0)
+    compiled = compile_autonomy_evidence(
+        user_message="are you looping?",
+        social={"hazards": ["self_message_loop", "context_excluded:x"]},
+        social_bridge={"hazards": ["cooldown_active"]},
+        reasoning_summary={"fallback_recommended": True},
+        reasoning_upstream_nonempty=True,
+        autonomy_debug={"orion": {"availability": "available"}},
+        now=fixed,
+    )
+    assert any(e.kind == "reasoning_quality" for e in compiled.evidence)
+    assert any(e.dimension == "self_message_loop" for e in compiled.evidence)
+    assert any(e.summary == "context_excluded:x" and e.signal_kind is None for e in compiled.evidence)
+
+    baseline = _cold()
+    before = dict(baseline.drive_pressures)
+    before_dom = baseline.dominant_drive
+
+    result = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=baseline,
+            evidence=compiled.evidence,
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    after = result.state.drive_pressures
+    moved = {
+        k: round(after[k] - before[k], 6)
+        for k in before
+        if abs(after[k] - before[k]) > 1e-9
+    }
+    print("omitted=", compiled.omitted)
+    print("moved=", moved)
+    print("dominant_before=", before_dom, "dominant_after=", result.state.dominant_drive)
+    print("new_tensions=", result.delta.new_tensions)
+
+    if not moved:
+        print("FAIL: no drive_pressures movement")
+        return 1
+    if after.get("relational", 0.0) <= before.get("relational", 0.0):
+        print("FAIL: relational did not increase from mapped hazards")
+        return 1
+    if after.get("coherence", 0.0) <= before.get("coherence", 0.0):
+        print("FAIL: coherence did not increase from reasoning fallback")
+        return 1
+    # Dominant may change once pressures clear the 0.15 threshold.
+    if result.state.dominant_drive is None and max(after.values()) >= 0.15:
+        print("FAIL: expected dominant_drive once pressure >= 0.15")
+        return 1
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Run eval**
+
+Run: `python orion/autonomy/evals/run_autonomy_v2_movement_eval.py`  
+Expected: `PASS` / exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add orion/autonomy/evals/run_autonomy_v2_movement_eval.py
+git commit -m "$(cat <<'EOF'
+test(autonomy): add AutonomyStateV2 movement eval enable bar
+
+EOF
+)"
+```
+
+---
+
+### Task 8: Isolation check (hard ban)
+
+**Files:**
+- Create: `orion/autonomy/tests/test_autonomy_isolation.py`
+
+- [ ] **Step 1: Write isolation test**
+
+```python
+# orion/autonomy/tests/test_autonomy_isolation.py
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]  # orion/autonomy/tests → repo root
+
+# Modules that must not import AutonomyStateV2 / reduce_autonomy_state.
+_BANNED_ROOTS = [
+    REPO / "orion" / "self_state",
+    REPO / "services" / "orion-spark-introspector",
+]
+
+
+def _python_files(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return [p for p in root.rglob("*.py") if p.is_file()]
+
+
+def _imports_autonomy_v2(path: Path) -> list[str]:
+    hits: list[str] = []
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError:
+        return hits
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            names = {a.name for a in node.names}
+            if "AutonomyStateV2" in names or "reduce_autonomy_state" in names:
+                hits.append(f"{path}: from {mod} import {sorted(names)}")
+            if mod in {"orion.autonomy.models", "orion.autonomy.reducer", "orion.autonomy"}:
+                if names & {"AutonomyStateV2", "reduce_autonomy_state", "AutonomyEvidenceRefV1"}:
+                    hits.append(f"{path}: from {mod} import {sorted(names)}")
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name in {"orion.autonomy.reducer", "orion.autonomy.models"}:
+                    hits.append(f"{path}: import {a.name}")
+    return hits
+
+
+def test_autonomy_state_v2_not_wired_into_phi_or_self_state() -> None:
+    hits: list[str] = []
+    for root in _BANNED_ROOTS:
+        for path in _python_files(root):
+            hits.extend(_imports_autonomy_v2(path))
+    assert hits == [], "AutonomyStateV2 isolation violated:\n" + "\n".join(hits)
+```
+
+- [ ] **Step 2: Run isolation test**
+
+Run: `pytest orion/autonomy/tests/test_autonomy_isolation.py -v`  
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add orion/autonomy/tests/test_autonomy_isolation.py
+git commit -m "$(cat <<'EOF'
+test(autonomy): ban AutonomyStateV2 imports into self_state/phi paths
+
+EOF
+)"
+```
+
+---
+
+### Task 9: Operator docs
+
+**Files:**
+- Modify: `docs/autonomy_state_v2_reducer.md`
+
+- [ ] **Step 1: Update operator notes**
+
+Replace the “Known limitations” polarity-blind item and document the new evidence contract. Final doc body should include:
+
+```markdown
+# AutonomyStateV2 reducer (operator notes)
+
+## What this is
+
+An optional, **env-gated** deterministic reducer that combines graph-loaded autonomy (`AutonomyStateV1`), turn-level **typed** evidence (user message, infra availability, reasoning quality when upstream artifacts exist, social hazards from stance locals), and optional action outcomes into **`AutonomyStateV2`** plus a **`AutonomyStateDeltaV1`** for one chat turn.
+
+Pressure math uses the shared `signal_drive_map` via `chat_evidence_to_tension` (same family as endogenous `failure_to_tension`). Keyword substring matching is **removed**.
+
+## What this is **not**
+
+- **Not** sentience, consciousness, or moral status.
+- **Not** durable persistence: V2 exists in **request context only**.
+- **Not** an input to phi features, `build_self_state`, or homeostatic `DriveEngine`.
+- Empty reasoning repositories do **not** emit `reasoning_quality` theater.
+
+## Evidence contract (omit-when-empty)
+
+| Kind | Emit when | Moves pressures? |
+|------|-----------|------------------|
+| `user_turn` | non-empty user message | No |
+| `infra_health` | availability ∈ {available, degraded, empty, unavailable} | No |
+| `reasoning_quality` | upstream repo/artifacts non-empty **and** `fallback_recommended` | Yes (`chat_reasoning_quality`/`fallback`) |
+| `relational_signal` | hazards on social/social_bridge locals | Yes only for mapped exact keys |
+
+Mapped social dimensions (v1): `cooldown_active`, `duplicate_message`, `self_message_loop`.  
+Prefix hazards (`context_excluded:*`, etc.) are audit-only unless YAML + test grow.
+
+Confidence values on evidence are **kind-literal constants (uncalibrated)** in v1.
+
+## Environment flag
+
+Default **off**. Enable only after the movement eval is green:
+
+```bash
+python orion/autonomy/evals/run_autonomy_v2_movement_eval.py
+# exit 0 required before considering:
+AUTONOMY_STATE_V2_REDUCER_ENABLED=true
+```
+
+When unset or not `true`, cortex skips the reducer entirely.
+
+## Debug keys (when flag on)
+
+- `ctx["chat_autonomy_evidence_debug"]` — emitted/omitted kinds + reasons
+- `ctx["chat_autonomy_tension_debug"]` — minted tensions
+- `ctx["chat_autonomy_movement_debug"]` — pressures / dominant_drive before vs after
+
+## Known limitations
+
+1. **No durable state** — each turn rebuilds prior state from graph V1; delta is relative to the upgrade baseline at turn start.
+2. **Sparse map** — unmapped hazards record evidence but do not move pressures (preferred over fake motion).
+3. **Dual pipelines** — chat reducer and endogenous tick both use `signal_drive_map` helpers but chat does not feed `DriveEngine`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/autonomy_state_v2_reducer.md
+git commit -m "$(cat <<'EOF'
+docs(autonomy): document typed evidence contract and enable bar
+
+EOF
+)"
+```
+
+---
+
+### Task 10: Full gate + self-check
+
+- [ ] **Step 1: Run focused suite**
+
+```bash
+pytest orion/autonomy/tests/test_evidence_ref_schema.py \
+  orion/autonomy/tests/test_evidence_compiler.py \
+  orion/autonomy/tests/test_signal_drive_map.py \
+  orion/autonomy/tests/test_signal_tension.py \
+  orion/autonomy/tests/test_autonomy_reducer.py \
+  orion/autonomy/tests/test_autonomy_isolation.py \
+  services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py -q
+
+python orion/autonomy/evals/run_autonomy_v2_movement_eval.py
+```
+
+Expected: all green; eval prints `PASS`.
+
+- [ ] **Step 2: Grep guards**
+
+```bash
+rg -n "_build_autonomy_reducer_evidence|_apply_single_evidence_pressures" \
+  orion/autonomy services/orion-cortex-exec/app/chat_stance.py
+
+rg -n 'hit\(\(|"frustration"|"contradiction".*coherence' orion/autonomy/reducer.py
+
+rg -n "AUTONOMY_STATE_V2_REDUCER_ENABLED" services/orion-cortex-exec/.env_example
+```
+
+Expected: no old builder/keyword pressure helpers; `.env_example` still has empty / default-off value.
+
+- [ ] **Step 3: Confirm no env template key changes** (this patch should not add keys). If any `.env_example` comment-only edit happened, run:
+
+```bash
+python scripts/sync_local_env_from_example.py
+```
+
+- [ ] **Step 4: Final commit if any leftover doc/test fixes**
+
+```bash
+git status --short
+git diff --check
+```
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec acceptance | Task |
+|-----------------|------|
+| 1. Empty reasoning repo does not emit `reasoning_quality` | Task 4 + Task 6 |
+| 2. Hazards from social/social_bridge locals | Task 4 + Task 6 |
+| 3. Mapped hazard bumps drives; unmapped does not | Task 2 + Task 5 + Task 7 |
+| 4. Keyword tokens gone from pressure / tension_kinds / confidence blob | Task 5 |
+| 5. `observed_at` → freshness | Task 4 + Task 5 |
+| 6. Movement fixture/eval with flag-on proof path | Task 7 (+ Task 6 tests) |
+| 7. Isolation AutonomyStateV2 ↛ phi/self-state | Task 8 |
+| 8. Default env remains disabled; operator doc | Task 6 + Task 9 |
+
+**Placeholder scan:** none intentional — all steps include concrete code/commands.  
+**Type consistency:** `compile_autonomy_evidence(...)`, `chat_evidence_to_tension(ev, sdm)`, optional fields `signal_kind` / `dimension` / `value` / `observed_at` used uniformly.  
+**Hard ban:** Tasks 5–6 explicitly forbid DriveEngine / DeviationGate / SelfState wiring; Task 8 enforces.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-10-autonomy-v2-evidence-signal-tension.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-07-10-autonomy-v2-evidence-signal-tension-design.md
+++ b/docs/superpowers/specs/2026-07-10-autonomy-v2-evidence-signal-tension-design.md
@@ -1,0 +1,215 @@
+# Design: AutonomyStateV2 evidence redesign via signal_tension
+
+**Date:** 2026-07-10  
+**Status:** Approved for implementation planning  
+**Scope:** `orion/autonomy/` + `config/autonomy/signal_drive_map.yaml` + `services/orion-cortex-exec/app/chat_stance.py` (+ focused tests/evals)  
+**Supersedes (partial):** keyword pressure path in `orion/autonomy/reducer.py`; does not replace the 2026-05-01 AutonomyStateV2 reducer design — it repairs its upstream evidence contract and drive-pressure math.
+
+---
+
+## Arsonist summary
+
+AutonomyStateV2 looks like live appraisal but is structurally inert on the only channel that can move `drive_pressures`: relational evidence is read from `ctx` before it is written; reasoning quality fires as constant fallback theater against an empty repository; keyword substring matching has zero overlap with real hazard vocabulary. Turning the env flag on today would ship empty-shell cognition.
+
+This design replaces that theater with a typed, omit-when-empty evidence contract whose pressure math goes through the same closed surface as endogenous drives (`signal_drive_map` + a direct `signal_tension` adapter). Phi / SelfState / homeostatic DriveEngine stay hard-isolated. The flag stays off until a same-PR movement eval proves `dominant_drive` / pressures actually change.
+
+---
+
+## Problem (verified in tree)
+
+Single producer: `_build_autonomy_reducer_evidence` in `services/orion-cortex-exec/app/chat_stance.py`.
+
+| Evidence | Issue |
+|----------|--------|
+| `user_turn` | Fine; excluded from pressure math by design |
+| `infra_health` | Fine; excluded from pressure math by design |
+| `reasoning_quality` | Emits when `fallback_recommended`; live path never writes `reasoning_repository` / non-empty `reasoning_artifacts`, so empty-repo compile almost always recommends fallback → constant, not signal |
+| `relational_signal` | Reads `ctx["chat_social_bridge_summary"]` ~37 lines before that key is written → empty or stale every turn |
+| Keyword pressures | Tokens like `frustration` / `repair` / `contradiction` do not appear in real hazards (`cooldown_active`, `duplicate_message`, `self_message_loop`, `context_excluded:*`, …) |
+| `observed_at` | Never set → freshness fields never populate |
+| `proxy_telemetry` guard | No producer emits that kind → untested dead rail |
+
+Phi multicollinearity: **no coupling today**. AutonomyStateV2 is request-scoped only. Risk is future: same-named drives (`coherence`, etc.) from independent unreliable estimators. Pending idea “bridge drives → self-state” is explicitly rejected by this design.
+
+---
+
+## Goals
+
+1. Typed evidence contract: emit a kind only when upstream is proven non-empty.
+2. One drive-weight table: extend `config/autonomy/signal_drive_map.yaml`; delete keyword pressure matching.
+3. Unify pressure application with the `signal_tension` family via a **direct** chat adapter (no DeviationGate / EWMA).
+4. Hard ban: AutonomyStateV2 must not feed phi features, SelfState channels, or homeostatic `DriveEngine`.
+5. Trace-proven movement in the same PR before calling enable “safe”; default remains flag-off.
+
+## Non-goals
+
+- Graph persistence of AutonomyStateV2
+- Confidence recalibration beyond omit-when-empty (kind-literal confidences stay documented as uncalibrated)
+- DeviationGate / EWMA for chat evidence
+- Wiring chat tensions into the endogenous tick DriveEngine loop (shared map + adapters only)
+- Phi / SelfState merge or namespaced drive bridge
+- Hub UI redesign
+- Building a live reasoning repository producer (only: stop emitting theater until one exists)
+
+---
+
+## Architecture
+
+```text
+chat locals (social/hazards, reasoning repo|artifacts, infra avail, user msg)
+  → AutonomyEvidenceCompiler (proven-non-empty gates only)
+  → AutonomyEvidenceRefV1 (+ optional signal_kind, dimension, value, observed_at)
+  → chat_evidence_to_tension()   // same family as failure_to_tension
+  → SignalDriveMap weights
+  → fold TensionEventV1 into AutonomyStateV2.drive_pressures
+  → existing attention / impulse / inhibition / delta tail
+  → ctx + Hub preview only
+  ✗ never → phi / SelfState / DriveEngine
+```
+
+### Why direct tension, not `signal_to_tension`
+
+Chat hazards and reasoning fallback are discrete events. `signal_to_tension` requires `DeviationGate` warm-up and would swallow first occurrences. Follow `failure_to_tension`: map lookup + severity/value → `drive_impacts`, no EWMA.
+
+---
+
+## Components
+
+### 1. `AutonomyEvidenceCompiler` (`orion/autonomy/`)
+
+Called from `build_chat_stance_inputs` with **explicit locals** (`social`, `social_bridge`, reasoning compile result + whether repo/artifacts were non-empty, autonomy debug availability, user message, `now`). Must not read `ctx["chat_social_bridge_summary"]` for this turn’s evidence.
+
+| Kind | Proven-non-empty rule | Pressure-eligible |
+|------|----------------------|-------------------|
+| `user_turn` | non-empty user message | No |
+| `infra_health` | autonomy debug `availability` ∈ `{available, degraded, empty, unavailable}` | No |
+| `reasoning_quality` | repository or `reasoning_artifacts` had artifacts this turn **and** compiler produced a usable quality signal (e.g. `fallback_recommended` with non-empty upstream). Empty-repo cold compile → **omit** | Yes |
+| `relational_signal` | hazards from merged `social` + `social_bridge` locals | Yes when mapped (`signal_kind=chat_social_hazard`) |
+
+Every emitted ref sets `observed_at`. Confidence remains kind-literal constants for v1 (document as uncalibrated).
+
+### 2. Schema: `AutonomyEvidenceRefV1`
+
+Add optional fields (backward compatible defaults):
+
+- `signal_kind: str | None`
+- `dimension: str | None`
+- `value: float | None` (0–1)
+
+Audit evidence without these fields is allowed; it never moves pressures. Unmapped hazards may still be recorded as evidence with summary only.
+
+### 3. `chat_evidence_to_tension()` (`orion/autonomy/signal_tension.py`)
+
+- Input: pressure-eligible `AutonomyEvidenceRefV1` with `signal_kind` + `dimension` + `value`
+- Lookup: `SignalDriveMap.match(signal_kind, dimension)`
+- Unmapped / missing fields → `None` (no keyword rescue)
+- Build `TensionEventV1` via existing `_build_tension` helper
+- Never raises; degrade to `None`
+
+### 4. `signal_drive_map.yaml` growth
+
+Pinned `signal_kind` names for this patch:
+
+| signal_kind | dimension(s) | Intent |
+|-------------|--------------|--------|
+| `chat_social_hazard` | exact keys: `cooldown_active`, `duplicate_message`, `self_message_loop` | relational (+ capability where loop/cooldown implies stuck channel) |
+| `chat_reasoning_quality` | `fallback` | coherence / predictive pressure when real artifacts still recommend fallback |
+
+Prefix hazards like `context_excluded:*` / `context_softened:*` are **audit-only in v1** unless an exact or `*` suffix rule is added with a test. No prose matching.
+
+Unlisted hazard strings → evidence ok, pressure zero. Growth requires YAML entry + producer + test (existing map contract).
+
+### 5. Reducer (`orion/autonomy/reducer.py`)
+
+- **Delete** `_apply_single_evidence_pressures` keyword matching (and related token helpers used only for that path).
+- For each incoming evidence: mint tension via `chat_evidence_to_tension`; fold `magnitude * drive_impacts[drive]` into `drive_pressures` (clamped).
+- **Also in scope:** `_derive_tension_kinds` and confidence adjustments that currently OR in keyword hits on an evidence text blob must stop using those keyword OR-clauses. Tension kinds derive from pressure thresholds (and typed evidence if needed); confidence blob keyword penalties (`"stale" in blob`, etc.) are removed or replaced with typed evidence/outcome fields only.
+- Keep attention / candidate impulses / inhibition / freshness / delta logic, adjusted so freshness uses `observed_at`.
+- Do not call endogenous `SignalTensionSource` rate limiter or DeviationGate from the chat turn path.
+
+### 6. Stance wiring (`chat_stance.py`)
+
+- Replace `_build_autonomy_reducer_evidence` with compiler call using locals available **before** the reducer runs (same function already has `social` / `social_bridge`).
+- Pass compiler debug into ctx for observability when flag is on.
+- Env gate unchanged: `AUTONOMY_STATE_V2_REDUCER_ENABLED` default off.
+
+---
+
+## Isolation constraint (hard ban)
+
+This patch must not:
+
+- Import or consume AutonomyStateV2 in `services/orion-spark-introspector` / phi corpus builders
+- Pass `drive_pressures` into `build_self_state` / SelfState channel maps
+- Feed chat tensions into homeostatic `DriveEngine.update`
+
+Explicitly reject the pending brainstorm idea “Bridge autonomy drive pressures → self-state” until a separate proposal with damping analysis is approved.
+
+Acceptance: focused test or import-graph check that AutonomyStateV2 is not referenced from phi/self-state builder modules.
+
+---
+
+## Tracing & enable criteria
+
+Structured debug (ctx and/or delta-adjacent fields) must record:
+
+- evidence kinds emitted vs omitted + omit reason
+- tensions minted (kind, signal_kind, dimension, drives)
+- `dominant_drive` / pressures before vs after
+- `tension_kinds` new / resolved counts
+
+**Enable bar (same PR):** fixture eval or integration test that feeds real mapped hazards and non-empty reasoning artifacts and asserts non-zero pressure movement and/or `dominant_drive` change vs baseline. Docs state: do not flip the flag in production until that proof is green; default remains false.
+
+---
+
+## Error handling
+
+- Compiler and `chat_evidence_to_tension`: degrade to omit / `None`, never raise into chat.
+- Existing stance `try/except` around reducer remains; failure leaves V1 path intact.
+- Unmapped hazard: evidence without pressure, not an error.
+
+---
+
+## Files likely to touch
+
+| Path | Change |
+|------|--------|
+| `orion/autonomy/models.py` | Optional `signal_kind` / `dimension` / `value` on evidence |
+| `orion/autonomy/evidence_compiler.py` (new) | Proven-gate compiler |
+| `orion/autonomy/signal_tension.py` | `chat_evidence_to_tension` |
+| `orion/autonomy/reducer.py` | Map/tension fold; remove keyword pressures |
+| `config/autonomy/signal_drive_map.yaml` | Chat signal_kind rows |
+| `services/orion-cortex-exec/app/chat_stance.py` | Locals → compiler → reducer |
+| `docs/autonomy_state_v2_reducer.md` | Operator notes: evidence contract + enable bar |
+| Tests under `orion/autonomy/tests/` and `services/orion-cortex-exec/tests/` | Gates, map, movement, isolation |
+| Eval or fixture under `orion/autonomy/evals/` or cortex tests | Trace-proven movement |
+
+---
+
+## Acceptance checks
+
+1. Empty reasoning repo does **not** emit `reasoning_quality` evidence.
+2. Hazards from `social`/`social_bridge` locals appear as evidence when present (ordering bug fixed).
+3. Mapped hazard bumps expected drive(s) via `signal_drive_map`; unmapped hazard does not.
+4. Keyword tokens no longer appear in reducer pressure path, `_derive_tension_kinds`, or confidence blob penalties.
+5. `observed_at` set → freshness populates when evidence exists.
+6. Movement fixture/eval passes with flag on in test.
+7. Isolation check: no AutonomyStateV2 → phi/self-state wire.
+8. Default env remains reducer disabled; operator doc updated.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Dual pressure pipelines (chat reducer vs endogenous tick) still exist | Shared map + shared tension helpers; DriveEngine wiring explicitly out of scope |
+| Sparse map → pressures still often frozen | Movement eval uses mapped fixtures; omit-empty is preferred over fake motion |
+| Hazard string drift vs YAML keys | Exact/suffix rules only; no prose matching; tests pin vocabulary |
+| Future phi merge temptation | Hard ban + rejection of self-state bridge in this spec |
+
+---
+
+## Recommended next patch
+
+Implement per this design (Approach: full `signal_tension`-family unify for chat pressure math, direct adapter). Start with failing tests for empty-repo omit + ordering + map-driven pressure movement, then compiler → tension → reducer → stance wiring → docs.

--- a/orion/autonomy/evals/run_autonomy_v2_movement_eval.py
+++ b/orion/autonomy/evals/run_autonomy_v2_movement_eval.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Trace-proven AutonomyStateV2 pressure movement from typed chat evidence.
+
+Enable bar for AUTONOMY_STATE_V2_REDUCER_ENABLED: do not flip production until
+this eval exits 0.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+
+from orion.autonomy.evidence_compiler import compile_autonomy_evidence
+from orion.autonomy.models import AutonomyStateV2
+from orion.autonomy.reducer import AutonomyReducerInputV1, reduce_autonomy_state
+
+
+def _cold(**overrides: object) -> AutonomyStateV2:
+    base = AutonomyStateV2(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        source="eval",
+        generated_at=datetime(2026, 7, 10, 12, 0, 0),
+        schema_version="autonomy.state.v2",
+        confidence=0.5,
+        unknowns=[],
+        evidence_refs=[],
+        freshness={},
+        attention_items=[],
+        candidate_impulses=[],
+        inhibited_impulses=[],
+        last_action_outcomes=[],
+        drive_pressures={
+            "coherence": 0.05,
+            "continuity": 0.05,
+            "relational": 0.05,
+            "autonomy": 0.05,
+            "capability": 0.05,
+            "predictive": 0.05,
+        },
+        dominant_drive=None,
+        active_drives=[],
+        tension_kinds=[],
+    )
+    return base.model_copy(update=overrides)
+
+
+def main() -> int:
+    fixed = datetime(2026, 7, 10, 16, 0, 0)
+    compiled = compile_autonomy_evidence(
+        user_message="are you looping?",
+        social={"hazards": ["self_message_loop", "context_excluded:x"]},
+        social_bridge={"hazards": ["cooldown_active"]},
+        reasoning_summary={"fallback_recommended": True},
+        reasoning_upstream_nonempty=True,
+        autonomy_debug={"orion": {"availability": "available"}},
+        now=fixed,
+    )
+    assert any(e.kind == "reasoning_quality" for e in compiled.evidence)
+    assert any(e.dimension == "self_message_loop" for e in compiled.evidence)
+    assert any(e.summary == "context_excluded:x" and e.signal_kind is None for e in compiled.evidence)
+
+    baseline = _cold()
+    before = dict(baseline.drive_pressures)
+    before_dom = baseline.dominant_drive
+
+    result = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=baseline,
+            evidence=compiled.evidence,
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    after = result.state.drive_pressures
+    moved = {
+        k: round(after[k] - before[k], 6)
+        for k in before
+        if abs(after[k] - before[k]) > 1e-9
+    }
+    print("omitted=", compiled.omitted)
+    print("moved=", moved)
+    print("dominant_before=", before_dom, "dominant_after=", result.state.dominant_drive)
+    print("new_tensions=", result.delta.new_tensions)
+
+    if not moved:
+        print("FAIL: no drive_pressures movement")
+        return 1
+    if after.get("relational", 0.0) <= before.get("relational", 0.0):
+        print("FAIL: relational did not increase from mapped hazards")
+        return 1
+    if after.get("coherence", 0.0) <= before.get("coherence", 0.0):
+        print("FAIL: coherence did not increase from reasoning fallback")
+        return 1
+    # Dominant may change once pressures clear the 0.15 threshold.
+    if result.state.dominant_drive is None and max(after.values()) >= 0.15:
+        print("FAIL: expected dominant_drive once pressure >= 0.15")
+        return 1
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/orion/autonomy/evals/run_autonomy_v2_movement_eval.py
+++ b/orion/autonomy/evals/run_autonomy_v2_movement_eval.py
@@ -58,7 +58,12 @@ def main() -> int:
     )
     assert any(e.kind == "reasoning_quality" for e in compiled.evidence)
     assert any(e.dimension == "self_message_loop" for e in compiled.evidence)
-    assert any(e.summary == "context_excluded:x" and e.signal_kind is None for e in compiled.evidence)
+    assert any(
+        e.summary == "context_excluded:x"
+        and e.signal_kind == "chat_social_hazard"
+        and e.dimension == "context_excluded:x"
+        for e in compiled.evidence
+    )
 
     baseline = _cold()
     before = dict(baseline.drive_pressures)

--- a/orion/autonomy/evidence_compiler.py
+++ b/orion/autonomy/evidence_compiler.py
@@ -14,9 +14,6 @@ from typing import Any
 from orion.autonomy.models import AutonomyEvidenceRefV1
 
 _INFRA_AVAIL = frozenset({"available", "degraded", "empty", "unavailable"})
-_MAPPED_SOCIAL_HAZARDS = frozenset(
-    {"cooldown_active", "duplicate_message", "self_message_loop"}
-)
 
 # Kind-literal confidences (uncalibrated v1 constants).
 _CONF_USER = 0.9
@@ -129,7 +126,7 @@ def compile_autonomy_evidence(
             result.omitted.append({"kind": "relational_signal", "reason": "no_hazards"})
         for hazard in hazards:
             hid = hashlib.sha256(hazard[:80].encode()).hexdigest()[:12]
-            mapped = hazard in _MAPPED_SOCIAL_HAZARDS
+            # Always stamp typed fields; SignalDriveMap.match is the sole pressure gate.
             result.evidence.append(
                 AutonomyEvidenceRefV1(
                     evidence_id=f"social_bridge:{hid}",
@@ -138,9 +135,9 @@ def compile_autonomy_evidence(
                     summary=hazard[:200],
                     confidence=_CONF_RELATIONAL,
                     observed_at=now,
-                    signal_kind="chat_social_hazard" if mapped else None,
-                    dimension=hazard if mapped else None,
-                    value=1.0 if mapped else None,
+                    signal_kind="chat_social_hazard",
+                    dimension=hazard,
+                    value=1.0,
                 )
             )
 

--- a/orion/autonomy/evidence_compiler.py
+++ b/orion/autonomy/evidence_compiler.py
@@ -1,0 +1,156 @@
+"""Compile turn-local AutonomyStateV2 evidence with proven-non-empty gates.
+
+Must be called with explicit locals (social / social_bridge / reasoning flags).
+Never reads ctx["chat_social_bridge_summary"] — that key is written after the
+reducer runs on the live chat path.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from orion.autonomy.models import AutonomyEvidenceRefV1
+
+_INFRA_AVAIL = frozenset({"available", "degraded", "empty", "unavailable"})
+_MAPPED_SOCIAL_HAZARDS = frozenset(
+    {"cooldown_active", "duplicate_message", "self_message_loop"}
+)
+
+# Kind-literal confidences (uncalibrated v1 constants).
+_CONF_USER = 0.9
+_CONF_INFRA = 1.0
+_CONF_REASONING = 0.6
+_CONF_RELATIONAL = 0.6
+
+
+@dataclass
+class AutonomyEvidenceCompileResult:
+    evidence: list[AutonomyEvidenceRefV1] = field(default_factory=list)
+    omitted: list[dict[str, str]] = field(default_factory=list)
+    debug: dict[str, Any] = field(default_factory=dict)
+
+
+def _unique_hazards(*groups: Any) -> list[str]:
+    out: list[str] = []
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        raw = group.get("hazards") or []
+        if not isinstance(raw, (list, tuple)):
+            continue
+        for h in raw:
+            s = str(h).strip()
+            if s and s not in out:
+                out.append(s)
+    return out
+
+
+def compile_autonomy_evidence(
+    *,
+    user_message: Any,
+    social: Any,
+    social_bridge: Any,
+    reasoning_summary: Any,
+    reasoning_upstream_nonempty: bool,
+    autonomy_debug: Any,
+    now: datetime,
+) -> AutonomyEvidenceCompileResult:
+    """Emit evidence only when upstream is proven non-empty. Never raises."""
+    result = AutonomyEvidenceCompileResult()
+    try:
+        msg = ""
+        try:
+            msg = str(user_message or "").strip()
+        except Exception:
+            msg = ""
+        if msg:
+            digest = hashlib.sha256(msg[:200].encode()).hexdigest()[:16]
+            result.evidence.append(
+                AutonomyEvidenceRefV1(
+                    evidence_id=f"user_turn:{digest}",
+                    source="user_message",
+                    kind="user_turn",
+                    summary=msg[:200],
+                    confidence=_CONF_USER,
+                    observed_at=now,
+                )
+            )
+        else:
+            result.omitted.append({"kind": "user_turn", "reason": "empty_message"})
+
+        debug = autonomy_debug if isinstance(autonomy_debug, dict) else {}
+        orion_dbg = debug.get("orion") if isinstance(debug.get("orion"), dict) else {}
+        avail = str(orion_dbg.get("availability") or "").strip()
+        if avail in _INFRA_AVAIL:
+            result.evidence.append(
+                AutonomyEvidenceRefV1(
+                    evidence_id=f"infra_health:autonomy_graph:{avail}",
+                    source="infra",
+                    kind="infra_health",
+                    summary=f"autonomy graph availability={avail}",
+                    confidence=_CONF_INFRA,
+                    observed_at=now,
+                )
+            )
+        elif avail:
+            result.omitted.append(
+                {"kind": "infra_health", "reason": "availability_not_recognized"}
+            )
+        else:
+            result.omitted.append({"kind": "infra_health", "reason": "missing_availability"})
+
+        rs = reasoning_summary if isinstance(reasoning_summary, dict) else {}
+        fallback = bool(rs.get("fallback_recommended"))
+        if not reasoning_upstream_nonempty:
+            result.omitted.append({"kind": "reasoning_quality", "reason": "empty_upstream"})
+        elif not fallback:
+            result.omitted.append(
+                {"kind": "reasoning_quality", "reason": "no_quality_signal"}
+            )
+        else:
+            result.evidence.append(
+                AutonomyEvidenceRefV1(
+                    evidence_id="reasoning:fallback_recommended",
+                    source="reasoning",
+                    kind="reasoning_quality",
+                    summary="reasoning fallback recommended",
+                    confidence=_CONF_REASONING,
+                    observed_at=now,
+                    signal_kind="chat_reasoning_quality",
+                    dimension="fallback",
+                    value=1.0,
+                )
+            )
+
+        hazards = _unique_hazards(social, social_bridge)
+        if not hazards:
+            result.omitted.append({"kind": "relational_signal", "reason": "no_hazards"})
+        for hazard in hazards:
+            hid = hashlib.sha256(hazard[:80].encode()).hexdigest()[:12]
+            mapped = hazard in _MAPPED_SOCIAL_HAZARDS
+            result.evidence.append(
+                AutonomyEvidenceRefV1(
+                    evidence_id=f"social_bridge:{hid}",
+                    source="social_bridge",
+                    kind="relational_signal",
+                    summary=hazard[:200],
+                    confidence=_CONF_RELATIONAL,
+                    observed_at=now,
+                    signal_kind="chat_social_hazard" if mapped else None,
+                    dimension=hazard if mapped else None,
+                    value=1.0 if mapped else None,
+                )
+            )
+
+        result.debug = {
+            "emitted_kinds": [e.kind for e in result.evidence],
+            "omitted": list(result.omitted),
+            "hazard_count": len(hazards),
+            "reasoning_upstream_nonempty": bool(reasoning_upstream_nonempty),
+        }
+    except Exception as exc:
+        result.omitted.append({"kind": "_compiler", "reason": f"degraded:{type(exc).__name__}"})
+        result.debug = {"error": type(exc).__name__}
+    return result

--- a/orion/autonomy/models.py
+++ b/orion/autonomy/models.py
@@ -112,6 +112,11 @@ class AutonomyEvidenceRefV1(BaseModel):
     summary: str | None = None
     confidence: float = Field(default=0.5, ge=0.0, le=1.0)
     observed_at: datetime | None = None
+    # Optional typed pressure fields. Audit-only refs may omit these.
+    # Confidence values remain kind-literal constants in v1 (uncalibrated).
+    signal_kind: str | None = None
+    dimension: str | None = None
+    value: float | None = Field(default=None, ge=0.0, le=1.0)
 
 
 class AttentionItemV1(BaseModel):

--- a/orion/autonomy/reducer.py
+++ b/orion/autonomy/reducer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from datetime import datetime
-from typing import Iterable
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -18,6 +18,9 @@ from orion.autonomy.models import (
     upgrade_autonomy_state_v1_to_v2,
 )
 from orion.autonomy.repository import SUBJECT_BINDINGS, SubjectBinding
+from orion.autonomy.signal_drive_map import SignalDriveMap, load_signal_drive_map
+from orion.autonomy.signal_tension import chat_evidence_to_tension
+from orion.core.schemas.drives import TensionEventV1
 
 _MAX_EVIDENCE = 20
 _MAX_ATTENTION = 8
@@ -25,6 +28,7 @@ _MAX_CANDIDATE_IMPULSES = 8
 _MAX_INHIBITED_IMPULSES = 8
 _MAX_OUTCOMES = 12
 _MAX_UNKNOWNS = 12
+_MAX_PRESSURE_STEP = 0.15
 
 _DRIVE_KEYS = ("coherence", "continuity", "relational", "autonomy", "capability", "predictive")
 
@@ -74,33 +78,17 @@ def _normalize_pressures(raw: dict[str, float]) -> dict[str, float]:
     return {k: min(1.0, max(0.0, out[k])) for k in _DRIVE_KEYS}
 
 
-def _evidence_text(ev: AutonomyEvidenceRefV1) -> str:
-    return f"{ev.kind} {(ev.summary or '')}".lower()
-
-
-def _apply_single_evidence_pressures(pressures: dict[str, float], ev: AutonomyEvidenceRefV1) -> dict[str, float]:
-    if ev.source == "user_message" or ev.kind == "infra_health":
-        return pressures
-    text = _evidence_text(ev)
-    weight = 0.5 if ev.kind == "proxy_telemetry" else 1.0
-    inc: dict[str, float] = {k: 0.0 for k in _DRIVE_KEYS}
-
-    def hit(tokens: tuple[str, ...], drive: str, delta: float) -> None:
-        if any(t in text for t in tokens):
-            inc[drive] += delta * weight
-
-    hit(("contradiction", "inconsistency", "failure", "bug", "broken", "drift", "confusion"), "coherence", 0.12)
-    hit(("memory", "recall", "thread", "history", "stale", "missing context"), "continuity", 0.10)
-    hit(("frustration", "repair", "trust", "relationship", "social", "apology"), "relational", 0.10)
-    hit(("proposal", "self-modification", "workflow", "autonomous", "action"), "autonomy", 0.08)
-    hit(("tool failure", "missing capability", "timeout", "unavailable", "error"), "capability", 0.10)
-    hit(("surprise", "unexpected", "regression", "mismatch"), "predictive", 0.08)
-
+def _fold_tension_into_pressures(
+    pressures: dict[str, float], tension: TensionEventV1
+) -> dict[str, float]:
     out = dict(pressures)
-    for k in _DRIVE_KEYS:
-        added = min(0.15, inc[k])
-        if added:
-            out[k] = min(1.0, out[k] + added)
+    mag = float(tension.magnitude or 0.0)
+    for drive, impact in (tension.drive_impacts or {}).items():
+        if drive not in _DRIVE_KEYS:
+            continue
+        added = min(_MAX_PRESSURE_STEP, mag * float(impact or 0.0))
+        if added > 0.0:
+            out[drive] = min(1.0, out[drive] + added)
     return out
 
 
@@ -116,30 +104,20 @@ def _dominant_and_active(pressures: dict[str, float], prev_dominant: str | None)
     return dominant, active
 
 
-def _combined_evidence_text(evs: Iterable[AutonomyEvidenceRefV1]) -> str:
-    return " ".join(_evidence_text(e) for e in evs)
-
-
-def _derive_tension_kinds(pressures: dict[str, float], evidence_blob: str) -> list[str]:
+def _derive_tension_kinds(pressures: dict[str, float]) -> list[str]:
     kinds: list[str] = []
-    coh = pressures.get("coherence", 0.0)
-    cont = pressures.get("continuity", 0.0)
-    cap = pressures.get("capability", 0.0)
-    rel = pressures.get("relational", 0.0)
 
     def add(name: str) -> None:
         if name not in kinds:
             kinds.append(name)
 
-    if coh >= 0.25 or any(
-        x in evidence_blob for x in ("contradiction", "inconsistency", "bug", "broken", "confusion")
-    ):
+    if pressures.get("coherence", 0.0) >= 0.25:
         add("tension.coherence_break.v1")
-    if cont >= 0.25 or any(x in evidence_blob for x in ("stale", "missing context", "recall", "memory failure")):
+    if pressures.get("continuity", 0.0) >= 0.25:
         add("tension.continuity_gap.v1")
-    if cap >= 0.25 or any(x in evidence_blob for x in ("unavailable", "timeout", "error", "tool failure")):
+    if pressures.get("capability", 0.0) >= 0.25:
         add("tension.capability_gap.v1")
-    if rel >= 0.25 or any(x in evidence_blob for x in ("frustration", "trust", "apology", "repair")):
+    if pressures.get("relational", 0.0) >= 0.25:
         add("tension.relational_repair.v1")
 
     ranked = sorted(_DRIVE_KEYS, key=lambda k: pressures.get(k, 0.0), reverse=True)
@@ -148,8 +126,17 @@ def _derive_tension_kinds(pressures: dict[str, float], evidence_blob: str) -> li
         p2 = pressures.get(ranked[1], 0.0)
         if p1 >= 0.25 and p2 >= 0.25 and abs(p1 - p2) < 0.08:
             add("tension.drive_competition.v1")
-
     return kinds
+
+
+def _infra_unavailable(evidence: list[AutonomyEvidenceRefV1]) -> bool:
+    for ev in evidence:
+        if ev.kind != "infra_health":
+            continue
+        summary = (ev.summary or "").lower()
+        if "availability=unavailable" in summary or "availability=degraded" in summary:
+            return True
+    return False
 
 
 def _merge_evidence(
@@ -272,15 +259,28 @@ def reduce_autonomy_state(inp: AutonomyReducerInputV1) -> AutonomyReducerResultV
     pressures = _normalize_pressures(dict(working.drive_pressures))
     prev_dom = working.dominant_drive
 
+    sdm: SignalDriveMap = load_signal_drive_map()
+    minted: list[dict[str, Any]] = []
     for ev in inp.evidence:
-        pressures = _apply_single_evidence_pressures(pressures, ev)
+        # user_turn / infra_health are never pressure-eligible (no signal fields).
+        tension = chat_evidence_to_tension(ev, sdm)
+        if tension is None:
+            continue
+        pressures = _fold_tension_into_pressures(pressures, tension)
+        minted.append(
+            {
+                "kind": tension.kind,
+                "signal_kind": ev.signal_kind,
+                "dimension": ev.dimension,
+                "drives": sorted((tension.drive_impacts or {}).keys()),
+            }
+        )
 
     working.drive_pressures = {k: pressures[k] for k in _DRIVE_KEYS}
-    blob = _combined_evidence_text(working.evidence_refs)
     dominant, active_drives = _dominant_and_active(pressures, prev_dom)
     working.dominant_drive = dominant
     working.active_drives = active_drives
-    working.tension_kinds = _derive_tension_kinds(pressures, blob)
+    working.tension_kinds = _derive_tension_kinds(pressures)
 
     attn = _maybe_attention_items(
         subject,
@@ -350,9 +350,7 @@ def reduce_autonomy_state(inp: AutonomyReducerInputV1) -> AutonomyReducerResultV
         conf -= 0.10
     if "no_previous_state" in working.unknowns:
         conf -= 0.05
-    if "stale" in blob or "missing context" in blob:
-        conf -= 0.05
-    if "timeout" in blob or "unavailable" in blob:
+    if _infra_unavailable(working.evidence_refs):
         conf -= 0.05
 
     surprise_budget = 0.0
@@ -394,7 +392,7 @@ def reduce_autonomy_state(inp: AutonomyReducerInputV1) -> AutonomyReducerResultV
             if c.kind == "propose_bounded_action" and pressures.get("autonomy", 0.0) >= 0.35 and working.confidence < 0.45:
                 reason = "low_confidence_for_autonomous_action"
             elif c.kind == "triage_capability_gap" and pressures.get("capability", 0.0) >= 0.35:
-                if "timeout" in blob or "unavailable" in blob:
+                if _infra_unavailable(working.evidence_refs):
                     reason = "dependency_unavailable"
             if reason:
                 inhibited.append(
@@ -453,6 +451,7 @@ def reduce_autonomy_state(inp: AutonomyReducerInputV1) -> AutonomyReducerResultV
         notes=[
             "delta compares against upgraded V1 or copied V2 baseline at turn start",
             "changed_fields are surface diffs vs that baseline, not a persisted prior-turn snapshot",
+            f"tensions_minted={len(minted)}",
         ],
     )
 

--- a/orion/autonomy/reducer.py
+++ b/orion/autonomy/reducer.py
@@ -133,8 +133,10 @@ def _infra_unavailable(evidence: list[AutonomyEvidenceRefV1]) -> bool:
     for ev in evidence:
         if ev.kind != "infra_health":
             continue
-        summary = (ev.summary or "").lower()
-        if "availability=unavailable" in summary or "availability=degraded" in summary:
+        # evidence_id shape from compiler: infra_health:autonomy_graph:{avail}
+        eid = str(ev.evidence_id or "")
+        avail = eid.rsplit(":", 1)[-1].strip().lower() if eid else ""
+        if avail in {"unavailable", "degraded"}:
             return True
     return False
 
@@ -233,6 +235,8 @@ class AutonomyReducerInputV1(BaseModel):
 class AutonomyReducerResultV1(BaseModel):
     state: AutonomyStateV2
     delta: AutonomyStateDeltaV1
+    # Trace of tensions minted this turn (same objects the pressure fold used).
+    tensions_minted: list[dict[str, Any]] = Field(default_factory=list)
 
 
 def reduce_autonomy_state(inp: AutonomyReducerInputV1) -> AutonomyReducerResultV1:
@@ -273,6 +277,7 @@ def reduce_autonomy_state(inp: AutonomyReducerInputV1) -> AutonomyReducerResultV
                 "signal_kind": ev.signal_kind,
                 "dimension": ev.dimension,
                 "drives": sorted((tension.drive_impacts or {}).keys()),
+                "magnitude": tension.magnitude,
             }
         )
 
@@ -455,5 +460,5 @@ def reduce_autonomy_state(inp: AutonomyReducerInputV1) -> AutonomyReducerResultV
         ],
     )
 
-    return AutonomyReducerResultV1(state=working, delta=delta)
+    return AutonomyReducerResultV1(state=working, delta=delta, tensions_minted=minted)
 

--- a/orion/autonomy/reducer.py
+++ b/orion/autonomy/reducer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -31,12 +31,22 @@ _MAX_UNKNOWNS = 12
 _MAX_PRESSURE_STEP = 0.15
 
 _DRIVE_KEYS = ("coherence", "continuity", "relational", "autonomy", "capability", "predictive")
+_EPOCH_UTC = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _as_utc(dt: datetime | None) -> datetime | None:
+    """Normalize naive/aware datetimes to UTC-aware for safe comparisons."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
 
 
 def _utc_now(inp_now: datetime | None) -> datetime:
     if inp_now is not None:
-        return inp_now
-    return datetime.utcnow()
+        return _as_utc(inp_now) or datetime.now(timezone.utc)
+    return datetime.now(timezone.utc)
 
 
 def _binding_for_subject(subject: str) -> SubjectBinding:
@@ -155,8 +165,7 @@ def _merge_evidence(
         seq += 1
     ordered = sorted(bucket.items(), key=lambda kv: kv[1][0])
     items = [t[1] for _, t in ordered]
-    epoch = datetime(1970, 1, 1)
-    stamped = [(i, ev.observed_at or epoch, ev) for i, ev in enumerate(items)]
+    stamped = [(i, _as_utc(ev.observed_at) or _EPOCH_UTC, ev) for i, ev in enumerate(items)]
     stamped.sort(key=lambda x: (x[1], x[0]))
     if len(stamped) > _MAX_EVIDENCE:
         stamped = stamped[-_MAX_EVIDENCE:]
@@ -422,12 +431,22 @@ def reduce_autonomy_state(inp: AutonomyReducerInputV1) -> AutonomyReducerResultV
     working.generated_at = now
 
     fresh: dict[str, str] = {"state_generated_at": now.isoformat()}
-    direct_times = [e.observed_at for e in working.evidence_refs if e.kind != "proxy_telemetry" and e.observed_at]
-    proxy_times = [e.observed_at for e in working.evidence_refs if e.kind == "proxy_telemetry" and e.observed_at]
-    if direct_times:
-        fresh["latest_direct_evidence_at"] = max(direct_times).isoformat()
-    if proxy_times:
-        fresh["latest_proxy_evidence_at"] = max(proxy_times).isoformat()
+    direct_times = [
+        _as_utc(e.observed_at)
+        for e in working.evidence_refs
+        if e.kind != "proxy_telemetry" and e.observed_at
+    ]
+    proxy_times = [
+        _as_utc(e.observed_at)
+        for e in working.evidence_refs
+        if e.kind == "proxy_telemetry" and e.observed_at
+    ]
+    direct_times_n = [t for t in direct_times if t is not None]
+    proxy_times_n = [t for t in proxy_times if t is not None]
+    if direct_times_n:
+        fresh["latest_direct_evidence_at"] = max(direct_times_n).isoformat()
+    if proxy_times_n:
+        fresh["latest_proxy_evidence_at"] = max(proxy_times_n).isoformat()
     working.freshness = fresh
 
     base_dump = baseline.model_dump(mode="json")

--- a/orion/autonomy/signal_tension.py
+++ b/orion/autonomy/signal_tension.py
@@ -1,6 +1,6 @@
 """Adapt real bus events into deviation-driven TensionEventV1 (spec §4).
 
-Three entry points, all degrade to ``None`` (never raise) on absent/garbage
+Four entry points, all degrade to ``None`` (never raise) on absent/garbage
 input:
 
 * ``signal_to_tension`` — an ``OrionSignalV1`` through the deviation gate + map.
@@ -12,6 +12,8 @@ input:
   real errors. Severity sizes the magnitude; the map supplies drive weights.
 * ``equilibrium_to_tension`` — edge-triggered health transition (ok -> degraded
   mints once; degraded -> degraded mints nothing).
+* ``chat_evidence_to_tension`` — a pressure-eligible ``AutonomyEvidenceRefV1``
+  maps *directly* (no EWMA / DeviationGate), same family as ``failure_to_tension``.
 
 The per-drive contribution is encoded as ``magnitude * drive_impacts[drive]`` so
 the existing ``compute_tick_attribution`` and ``DriveEngine.update`` (which both
@@ -19,7 +21,7 @@ multiply magnitude by the impact weight) reproduce the intended impulse.
 """
 from __future__ import annotations
 
-from typing import Dict, Mapping, Optional
+from typing import TYPE_CHECKING, Dict, Mapping, Optional
 
 from orion.autonomy.deviation_gate import DeviationGate
 from orion.autonomy.signal_drive_map import SignalDriveMap
@@ -28,9 +30,13 @@ from orion.signals.models import OrionSignalV1
 from orion.signals.stub_detection import is_stub_signal
 from orion.spark.concept_induction.drives import DRIVE_KEYS
 
+if TYPE_CHECKING:
+    from orion.autonomy.models import AutonomyEvidenceRefV1
+
 SIGNAL_TENSION_KIND = "tension.signal.v1"
 FAILURE_TENSION_KIND = "tension.failure.v1"
 HEALTH_TENSION_KIND = "tension.health.v1"
+CHAT_EVIDENCE_TENSION_KIND = "tension.chat_evidence.v1"
 
 
 def _clamp01(x: float) -> float:
@@ -208,6 +214,42 @@ def equilibrium_to_tension(
             channel=channel,
             correlation_id=correlation_id,
             summary="equilibrium degraded",
+        )
+    except Exception:
+        return None
+
+
+def chat_evidence_to_tension(
+    ev: "AutonomyEvidenceRefV1",
+    sdm: SignalDriveMap,
+    *,
+    channel: str = "orion:cortex_exec:chat_stance",
+) -> Optional[TensionEventV1]:
+    """Map a pressure-eligible AutonomyEvidenceRefV1 directly (no EWMA).
+
+    Requires signal_kind + dimension + value. Unmapped / missing → None.
+    Never raises.
+    """
+    try:
+        signal_kind = getattr(ev, "signal_kind", None)
+        dimension = getattr(ev, "dimension", None)
+        value = getattr(ev, "value", None)
+        if not signal_kind or not dimension or value is None:
+            return None
+        rule = sdm.match(str(signal_kind), str(dimension))
+        if rule is None:
+            return None
+        v = _clamp01(float(value))
+        if v <= 0.0:
+            return None
+        raw_by_drive = {d: v * w for d, w in rule.drives.items()}
+        summary = (getattr(ev, "summary", None) or f"{signal_kind}.{dimension}")[:240]
+        return _build_tension(
+            kind=CHAT_EVIDENCE_TENSION_KIND,
+            raw_by_drive=raw_by_drive,
+            channel=channel,
+            correlation_id=getattr(ev, "evidence_id", None),
+            summary=str(summary),
         )
     except Exception:
         return None

--- a/orion/autonomy/tests/test_autonomy_isolation.py
+++ b/orion/autonomy/tests/test_autonomy_isolation.py
@@ -10,6 +10,7 @@ REPO = Path(__file__).resolve().parents[3]  # orion/autonomy/tests → repo root
 _BANNED_ROOTS = [
     REPO / "orion" / "self_state",
     REPO / "services" / "orion-spark-introspector",
+    REPO / "services" / "orion-self-state-runtime",
 ]
 
 

--- a/orion/autonomy/tests/test_autonomy_isolation.py
+++ b/orion/autonomy/tests/test_autonomy_isolation.py
@@ -1,0 +1,49 @@
+# orion/autonomy/tests/test_autonomy_isolation.py
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]  # orion/autonomy/tests → repo root
+
+# Modules that must not import AutonomyStateV2 / reduce_autonomy_state.
+_BANNED_ROOTS = [
+    REPO / "orion" / "self_state",
+    REPO / "services" / "orion-spark-introspector",
+]
+
+
+def _python_files(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return [p for p in root.rglob("*.py") if p.is_file()]
+
+
+def _imports_autonomy_v2(path: Path) -> list[str]:
+    hits: list[str] = []
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError:
+        return hits
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            names = {a.name for a in node.names}
+            if "AutonomyStateV2" in names or "reduce_autonomy_state" in names:
+                hits.append(f"{path}: from {mod} import {sorted(names)}")
+            if mod in {"orion.autonomy.models", "orion.autonomy.reducer", "orion.autonomy"}:
+                if names & {"AutonomyStateV2", "reduce_autonomy_state", "AutonomyEvidenceRefV1"}:
+                    hits.append(f"{path}: from {mod} import {sorted(names)}")
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name in {"orion.autonomy.reducer", "orion.autonomy.models"}:
+                    hits.append(f"{path}: import {a.name}")
+    return hits
+
+
+def test_autonomy_state_v2_not_wired_into_phi_or_self_state() -> None:
+    hits: list[str] = []
+    for root in _BANNED_ROOTS:
+        for path in _python_files(root):
+            hits.extend(_imports_autonomy_v2(path))
+    assert hits == [], "AutonomyStateV2 isolation violated:\n" + "\n".join(hits)

--- a/orion/autonomy/tests/test_autonomy_reducer.py
+++ b/orion/autonomy/tests/test_autonomy_reducer.py
@@ -161,6 +161,9 @@ def test_reducer_unmapped_hazard_does_not_move_pressures() -> None:
                     summary="context_excluded:memory",
                     confidence=0.6,
                     observed_at=fixed,
+                    signal_kind="chat_social_hazard",
+                    dimension="context_excluded:memory",
+                    value=1.0,
                 )
             ],
             action_outcomes=[],
@@ -169,6 +172,32 @@ def test_reducer_unmapped_hazard_does_not_move_pressures() -> None:
     )
     for k in before:
         assert r.state.drive_pressures.get(k, 0.0) == before.get(k, 0.0)
+    assert r.tensions_minted == []
+
+
+def test_reducer_infra_unavailable_from_evidence_id() -> None:
+    prior = _base_v2(confidence=0.8, drive_pressures={"capability": 0.4})
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=prior,
+            evidence=[
+                AutonomyEvidenceRefV1(
+                    evidence_id="infra_health:autonomy_graph:degraded",
+                    source="infra",
+                    kind="infra_health",
+                    # Summary wording must not be required for the penalty.
+                    summary="wording can change freely",
+                    confidence=0.5,
+                    observed_at=fixed,
+                )
+            ],
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    assert r.state.confidence == 0.75
 
 
 def test_reducer_prose_keywords_no_longer_move_pressures() -> None:

--- a/orion/autonomy/tests/test_autonomy_reducer.py
+++ b/orion/autonomy/tests/test_autonomy_reducer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from orion.autonomy.models import ActionOutcomeRefV1, AutonomyEvidenceRefV1, AutonomyStateV1, AutonomyStateV2
 from orion.autonomy.reducer import AutonomyReducerInputV1, reduce_autonomy_state
@@ -398,3 +398,51 @@ def test_reducer_evidence_trim_twenty() -> None:
         )
     )
     assert len(r.state.evidence_refs) <= 20
+
+
+def test_reducer_v1_upgrade_mixes_naive_and_aware_observed_at() -> None:
+    """Graph V1 synthetic evidence is often naive; chat compiler stamps aware UTC.
+
+    Sorting/freshness must not TypeError (live path when flag is on).
+    """
+    naive = datetime(2026, 5, 2, 12, 0, 0)
+    aware = datetime(2026, 7, 10, 16, 0, 0, tzinfo=timezone.utc)
+    v1 = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        latest_identity_snapshot_id="snap-1",
+        latest_drive_audit_id="audit-1",
+        dominant_drive="coherence",
+        active_drives=["coherence"],
+        drive_pressures={"coherence": 0.3, "relational": 0.0},
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+        generated_at=naive,
+    )
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=v1,
+            evidence=[
+                AutonomyEvidenceRefV1(
+                    evidence_id="h1",
+                    source="social_bridge",
+                    kind="relational_signal",
+                    summary="cooldown_active",
+                    confidence=0.6,
+                    observed_at=aware,
+                    signal_kind="chat_social_hazard",
+                    dimension="cooldown_active",
+                    value=1.0,
+                )
+            ],
+            action_outcomes=[],
+            now=aware,
+        )
+    )
+    assert r.state.schema_version == "autonomy.state.v2"
+    assert "latest_direct_evidence_at" in r.state.freshness
+    assert r.state.drive_pressures["relational"] > 0.0
+    assert any(m.get("dimension") == "cooldown_active" for m in r.tensions_minted)

--- a/orion/autonomy/tests/test_autonomy_reducer.py
+++ b/orion/autonomy/tests/test_autonomy_reducer.py
@@ -116,8 +116,8 @@ def test_reducer_user_message_and_infra_no_drive_pressure() -> None:
     assert r.state.drive_pressures.get("continuity", 0.0) == 0.2
 
 
-def test_reducer_capability_timeout_unavailable() -> None:
-    prior = _base_v2(drive_pressures={"capability": 0.1})
+def test_reducer_mapped_hazard_moves_relational_pressure() -> None:
+    prior = _base_v2(drive_pressures={"relational": 0.05, "coherence": 0.1})
     fixed = datetime(2026, 5, 2, 12, 0, 0)
     r = reduce_autonomy_state(
         AutonomyReducerInputV1(
@@ -125,11 +125,41 @@ def test_reducer_capability_timeout_unavailable() -> None:
             previous_state=prior,
             evidence=[
                 AutonomyEvidenceRefV1(
-                    evidence_id="e1",
-                    source="graph",
-                    kind="incident",
-                    summary="GraphDB timeout unavailable",
-                    confidence=0.8,
+                    evidence_id="h1",
+                    source="social_bridge",
+                    kind="relational_signal",
+                    summary="cooldown_active",
+                    confidence=0.6,
+                    observed_at=fixed,
+                    signal_kind="chat_social_hazard",
+                    dimension="cooldown_active",
+                    value=1.0,
+                )
+            ],
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    assert r.state.drive_pressures["relational"] > 0.05
+    assert abs(r.delta.drive_deltas.get("relational", 0.0)) > 0.0
+    assert "latest_direct_evidence_at" in r.state.freshness
+
+
+def test_reducer_unmapped_hazard_does_not_move_pressures() -> None:
+    prior = _base_v2(drive_pressures={"relational": 0.2, "coherence": 0.2})
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    before = dict(prior.drive_pressures)
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=prior,
+            evidence=[
+                AutonomyEvidenceRefV1(
+                    evidence_id="h1",
+                    source="social_bridge",
+                    kind="relational_signal",
+                    summary="context_excluded:memory",
+                    confidence=0.6,
                     observed_at=fixed,
                 )
             ],
@@ -137,13 +167,13 @@ def test_reducer_capability_timeout_unavailable() -> None:
             now=fixed,
         )
     )
-    assert r.state.drive_pressures.get("capability", 0.0) > 0.1
-    assert "tension.capability_gap.v1" in r.state.tension_kinds
+    for k in before:
+        assert r.state.drive_pressures.get(k, 0.0) == before.get(k, 0.0)
 
 
-def test_reducer_polarity_blind_no_contradiction_still_raises_coherence() -> None:
-    """Polarity-blind token match: 'contradiction' hits inside 'no contradiction'."""
-    prior = _base_v2(drive_pressures={"coherence": 0.1})
+def test_reducer_prose_keywords_no_longer_move_pressures() -> None:
+    """Acceptance: keyword tokens must not move pressures."""
+    prior = _base_v2(drive_pressures={"coherence": 0.1, "capability": 0.1, "relational": 0.1})
     fixed = datetime(2026, 5, 2, 12, 0, 0)
     r = reduce_autonomy_state(
         AutonomyReducerInputV1(
@@ -154,8 +184,8 @@ def test_reducer_polarity_blind_no_contradiction_still_raises_coherence() -> Non
                     evidence_id="e1",
                     source="graph",
                     kind="note",
-                    summary="no contradiction",
-                    confidence=0.6,
+                    summary="frustration repair contradiction timeout unavailable stale",
+                    confidence=0.8,
                     observed_at=fixed,
                 )
             ],
@@ -163,7 +193,72 @@ def test_reducer_polarity_blind_no_contradiction_still_raises_coherence() -> Non
             now=fixed,
         )
     )
-    assert r.state.drive_pressures.get("coherence", 0.0) > 0.1
+    assert r.state.drive_pressures["coherence"] == 0.1
+    assert r.state.drive_pressures["capability"] == 0.1
+    assert r.state.drive_pressures["relational"] == 0.1
+    # Tension kinds must not OR in from the prose blob either.
+    assert "tension.coherence_break.v1" not in r.state.tension_kinds
+    assert "tension.capability_gap.v1" not in r.state.tension_kinds
+    assert "tension.relational_repair.v1" not in r.state.tension_kinds
+
+
+def test_reducer_reasoning_fallback_moves_coherence() -> None:
+    prior = _base_v2(drive_pressures={"coherence": 0.05, "predictive": 0.05})
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=prior,
+            evidence=[
+                AutonomyEvidenceRefV1(
+                    evidence_id="reasoning:fallback_recommended",
+                    source="reasoning",
+                    kind="reasoning_quality",
+                    summary="reasoning fallback recommended",
+                    confidence=0.6,
+                    observed_at=fixed,
+                    signal_kind="chat_reasoning_quality",
+                    dimension="fallback",
+                    value=1.0,
+                )
+            ],
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    assert r.state.drive_pressures["coherence"] > 0.05
+    assert r.state.drive_pressures["predictive"] > 0.05
+
+
+def test_reducer_tension_kinds_from_pressure_thresholds_only() -> None:
+    prior = _base_v2(drive_pressures={"coherence": 0.30})
+    fixed = datetime(2026, 5, 2, 12, 0, 0)
+    # No incoming evidence; prior pressure already at threshold.
+    r = reduce_autonomy_state(
+        AutonomyReducerInputV1(
+            subject="orion",
+            previous_state=prior,
+            evidence=[],
+            action_outcomes=[],
+            now=fixed,
+        )
+    )
+    assert "tension.coherence_break.v1" in r.state.tension_kinds
+
+
+def test_reducer_no_keyword_helpers_in_module() -> None:
+    import inspect
+    from orion.autonomy import reducer as reducer_mod
+
+    src = inspect.getsource(reducer_mod)
+    for banned in (
+        "_apply_single_evidence_pressures",
+        '"contradiction"',
+        '"frustration"',
+        '"stale" in blob',
+        '"timeout" in blob',
+    ):
+        assert banned not in src, banned
 
 
 def test_reducer_all_proxy_inhibition_and_unknown() -> None:
@@ -224,31 +319,23 @@ def test_reducer_high_surprise_outcome_reduces_confidence() -> None:
     assert r.state.confidence < 0.8
 
 
-def test_reducer_determinism_fixed_now() -> None:
+def test_reducer_determinism_fixed_now_typed() -> None:
     fixed = datetime(2026, 5, 2, 12, 0, 0)
-    v1 = AutonomyStateV1(
-        subject="orion",
-        model_layer="self-model",
-        entity_id="self:orion",
-        dominant_drive="coherence",
-        active_drives=["coherence"],
-        drive_pressures={"coherence": 0.3},
-        tension_kinds=[],
-        goal_headlines=[],
-        source="graph",
-        generated_at=fixed,
-    )
+    prior = _base_v2(drive_pressures={"relational": 0.0})
     inp = AutonomyReducerInputV1(
         subject="orion",
-        previous_state=v1,
+        previous_state=prior,
         evidence=[
             AutonomyEvidenceRefV1(
                 evidence_id="z1",
-                source="graph",
-                kind="note",
-                summary="regression detected",
-                confidence=0.8,
+                source="social_bridge",
+                kind="relational_signal",
+                summary="self_message_loop",
+                confidence=0.6,
                 observed_at=fixed,
+                signal_kind="chat_social_hazard",
+                dimension="self_message_loop",
+                value=1.0,
             )
         ],
         action_outcomes=[],

--- a/orion/autonomy/tests/test_evidence_compiler.py
+++ b/orion/autonomy/tests/test_evidence_compiler.py
@@ -64,9 +64,10 @@ def test_hazards_from_social_locals_not_ctx() -> None:
     assert mapped["cooldown_active"].signal_kind == "chat_social_hazard"
     assert mapped["cooldown_active"].dimension == "cooldown_active"
     assert mapped["cooldown_active"].value == 1.0
-    # Unmapped prefix hazard is audit-only (no pressure fields).
-    assert mapped["context_excluded:memory"].signal_kind is None
-    assert mapped["context_excluded:memory"].dimension is None
+    # Unmapped prefix hazard still typed; SignalDriveMap.match is the sole pressure gate.
+    assert mapped["context_excluded:memory"].signal_kind == "chat_social_hazard"
+    assert mapped["context_excluded:memory"].dimension == "context_excluded:memory"
+    assert mapped["context_excluded:memory"].value == 1.0
 
     infra = [e for e in result.evidence if e.kind == "infra_health"]
     assert len(infra) == 1

--- a/orion/autonomy/tests/test_evidence_compiler.py
+++ b/orion/autonomy/tests/test_evidence_compiler.py
@@ -1,0 +1,118 @@
+# orion/autonomy/tests/test_evidence_compiler.py
+from __future__ import annotations
+
+from datetime import datetime
+
+from orion.autonomy.evidence_compiler import compile_autonomy_evidence
+
+
+FIXED = datetime(2026, 7, 10, 15, 0, 0)
+
+
+def test_empty_reasoning_repo_omits_reasoning_quality() -> None:
+    result = compile_autonomy_evidence(
+        user_message="hi",
+        social={"hazards": []},
+        social_bridge={"hazards": []},
+        reasoning_summary={"fallback_recommended": True},
+        reasoning_upstream_nonempty=False,
+        autonomy_debug={"orion": {"availability": "available"}},
+        now=FIXED,
+    )
+    kinds = [e.kind for e in result.evidence]
+    assert "reasoning_quality" not in kinds
+    assert any(o.get("kind") == "reasoning_quality" for o in result.omitted)
+    omit = next(o for o in result.omitted if o["kind"] == "reasoning_quality")
+    assert omit["reason"] == "empty_upstream"
+
+
+def test_reasoning_quality_emits_only_with_upstream_and_fallback() -> None:
+    result = compile_autonomy_evidence(
+        user_message=None,
+        social={},
+        social_bridge={},
+        reasoning_summary={"fallback_recommended": True},
+        reasoning_upstream_nonempty=True,
+        autonomy_debug={},
+        now=FIXED,
+    )
+    rq = [e for e in result.evidence if e.kind == "reasoning_quality"]
+    assert len(rq) == 1
+    assert rq[0].signal_kind == "chat_reasoning_quality"
+    assert rq[0].dimension == "fallback"
+    assert rq[0].value == 1.0
+    assert rq[0].observed_at == FIXED
+
+
+def test_hazards_from_social_locals_not_ctx() -> None:
+    result = compile_autonomy_evidence(
+        user_message="x",
+        social={"hazards": ["cooldown_active", "context_excluded:memory"]},
+        social_bridge={"hazards": ["duplicate_message"]},
+        reasoning_summary={"fallback_recommended": False},
+        reasoning_upstream_nonempty=False,
+        autonomy_debug={"orion": {"availability": "degraded"}},
+        now=FIXED,
+    )
+    rel = [e for e in result.evidence if e.kind == "relational_signal"]
+    summaries = {e.summary for e in rel}
+    assert "cooldown_active" in summaries
+    assert "duplicate_message" in summaries
+    assert "context_excluded:memory" in summaries
+
+    mapped = {e.summary: e for e in rel}
+    assert mapped["cooldown_active"].signal_kind == "chat_social_hazard"
+    assert mapped["cooldown_active"].dimension == "cooldown_active"
+    assert mapped["cooldown_active"].value == 1.0
+    # Unmapped prefix hazard is audit-only (no pressure fields).
+    assert mapped["context_excluded:memory"].signal_kind is None
+    assert mapped["context_excluded:memory"].dimension is None
+
+    infra = [e for e in result.evidence if e.kind == "infra_health"]
+    assert len(infra) == 1
+    assert infra[0].observed_at == FIXED
+    assert all(e.observed_at == FIXED for e in result.evidence)
+
+
+def test_user_turn_and_infra_emitted_without_pressure_fields() -> None:
+    result = compile_autonomy_evidence(
+        user_message="hello there",
+        social={},
+        social_bridge={},
+        reasoning_summary={},
+        reasoning_upstream_nonempty=False,
+        autonomy_debug={"orion": {"availability": "available"}},
+        now=FIXED,
+    )
+    user = next(e for e in result.evidence if e.kind == "user_turn")
+    assert user.signal_kind is None
+    assert user.source == "user_message"
+    infra = next(e for e in result.evidence if e.kind == "infra_health")
+    assert infra.signal_kind is None
+
+
+def test_infra_omitted_when_availability_unknown() -> None:
+    result = compile_autonomy_evidence(
+        user_message=None,
+        social={},
+        social_bridge={},
+        reasoning_summary={},
+        reasoning_upstream_nonempty=False,
+        autonomy_debug={"orion": {"availability": "weird"}},
+        now=FIXED,
+    )
+    assert not any(e.kind == "infra_health" for e in result.evidence)
+    assert any(o.get("reason") == "availability_not_recognized" for o in result.omitted)
+
+
+def test_compiler_never_raises() -> None:
+    result = compile_autonomy_evidence(
+        user_message=object(),  # type: ignore[arg-type]
+        social="bad",  # type: ignore[arg-type]
+        social_bridge=None,
+        reasoning_summary=None,
+        reasoning_upstream_nonempty=True,
+        autonomy_debug=None,
+        now=FIXED,
+    )
+    assert isinstance(result.evidence, list)

--- a/orion/autonomy/tests/test_evidence_ref_schema.py
+++ b/orion/autonomy/tests/test_evidence_ref_schema.py
@@ -1,0 +1,37 @@
+# orion/autonomy/tests/test_evidence_ref_schema.py
+from __future__ import annotations
+
+from datetime import datetime
+
+from orion.autonomy.models import AutonomyEvidenceRefV1
+
+
+def test_evidence_ref_accepts_optional_signal_fields() -> None:
+    fixed = datetime(2026, 7, 10, 12, 0, 0)
+    ev = AutonomyEvidenceRefV1(
+        evidence_id="social_bridge:abc",
+        source="social_bridge",
+        kind="relational_signal",
+        summary="cooldown_active",
+        confidence=0.6,
+        observed_at=fixed,
+        signal_kind="chat_social_hazard",
+        dimension="cooldown_active",
+        value=1.0,
+    )
+    assert ev.signal_kind == "chat_social_hazard"
+    assert ev.dimension == "cooldown_active"
+    assert ev.value == 1.0
+
+
+def test_evidence_ref_defaults_signal_fields_to_none() -> None:
+    ev = AutonomyEvidenceRefV1(
+        evidence_id="user_turn:x",
+        source="user_message",
+        kind="user_turn",
+        summary="hi",
+    )
+    assert ev.signal_kind is None
+    assert ev.dimension is None
+    assert ev.value is None
+    assert ev.observed_at is None

--- a/orion/autonomy/tests/test_signal_drive_map.py
+++ b/orion/autonomy/tests/test_signal_drive_map.py
@@ -84,3 +84,28 @@ def test_no_text_matching_in_module() -> None:
     src = inspect.getsource(sdm_mod)
     for banned in (".summary", ".notes", "re.search", "re.match", "lower()", "keyword"):
         assert banned not in src, f"map module must not touch {banned!r}"
+
+
+def test_chat_social_hazard_exact_dims_present() -> None:
+    m = load_signal_drive_map()
+    assert "chat_social_hazard" in m.signal_kinds()
+    for dim in ("cooldown_active", "duplicate_message", "self_message_loop"):
+        rule = m.match("chat_social_hazard", dim)
+        assert rule is not None, dim
+        assert rule.worse == "up"
+        assert "relational" in rule.drives
+
+
+def test_chat_reasoning_quality_fallback_present() -> None:
+    m = load_signal_drive_map()
+    rule = m.match("chat_reasoning_quality", "fallback")
+    assert rule is not None
+    assert rule.worse == "up"
+    assert "coherence" in rule.drives
+    assert "predictive" in rule.drives
+
+
+def test_unmapped_chat_hazard_dimension_is_none() -> None:
+    m = load_signal_drive_map()
+    assert m.match("chat_social_hazard", "context_excluded:foo") is None
+    assert m.match("chat_social_hazard", "peer_targeted_elsewhere") is None

--- a/orion/autonomy/tests/test_signal_tension.py
+++ b/orion/autonomy/tests/test_signal_tension.py
@@ -95,3 +95,77 @@ def test_equilibrium_edge_triggered() -> None:
 
 def test_never_raises_on_garbage() -> None:
     assert signal_to_tension(_sig("spark_signal", {}), _gate(), SDM) is None
+
+
+from datetime import datetime
+
+from orion.autonomy.models import AutonomyEvidenceRefV1
+from orion.autonomy.signal_tension import chat_evidence_to_tension
+
+
+def test_chat_evidence_mapped_hazard_mints_tension() -> None:
+    ev = AutonomyEvidenceRefV1(
+        evidence_id="h1",
+        source="social_bridge",
+        kind="relational_signal",
+        summary="cooldown_active",
+        confidence=0.6,
+        observed_at=datetime(2026, 7, 10, 12, 0, 0),
+        signal_kind="chat_social_hazard",
+        dimension="cooldown_active",
+        value=1.0,
+    )
+    t = chat_evidence_to_tension(ev, SDM)
+    assert t is not None
+    assert t.kind == "tension.chat_evidence.v1"
+    assert t.magnitude > 0.0
+    assert t.drive_impacts.get("relational", 0.0) > 0.0
+
+
+def test_chat_evidence_unmapped_or_missing_fields_returns_none() -> None:
+    bare = AutonomyEvidenceRefV1(
+        evidence_id="h2",
+        source="social_bridge",
+        kind="relational_signal",
+        summary="context_excluded:memory",
+        confidence=0.6,
+    )
+    assert chat_evidence_to_tension(bare, SDM) is None
+
+    unmapped = AutonomyEvidenceRefV1(
+        evidence_id="h3",
+        source="social_bridge",
+        kind="relational_signal",
+        summary="peer_targeted_elsewhere",
+        signal_kind="chat_social_hazard",
+        dimension="peer_targeted_elsewhere",
+        value=1.0,
+    )
+    assert chat_evidence_to_tension(unmapped, SDM) is None
+
+
+def test_chat_evidence_zero_value_returns_none() -> None:
+    ev = AutonomyEvidenceRefV1(
+        evidence_id="h4",
+        source="reasoning",
+        kind="reasoning_quality",
+        summary="fallback",
+        signal_kind="chat_reasoning_quality",
+        dimension="fallback",
+        value=0.0,
+    )
+    assert chat_evidence_to_tension(ev, SDM) is None
+
+
+def test_chat_evidence_never_raises_on_garbage() -> None:
+    class Boom:
+        signal_kind = "chat_social_hazard"
+        dimension = "cooldown_active"
+        evidence_id = "x"
+        summary = "x"
+
+        @property
+        def value(self):
+            raise RuntimeError("boom")
+
+    assert chat_evidence_to_tension(Boom(), SDM) is None  # type: ignore[arg-type]

--- a/orion/autonomy/tests/test_signal_tension.py
+++ b/orion/autonomy/tests/test_signal_tension.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from orion.autonomy.deviation_gate import DeviationGate
+from orion.autonomy.models import AutonomyEvidenceRefV1
 from orion.autonomy.signal_drive_map import load_signal_drive_map
 from orion.autonomy.signal_tension import (
+    chat_evidence_to_tension,
     equilibrium_to_tension,
     failure_to_tension,
     signal_to_tension,
@@ -95,12 +97,6 @@ def test_equilibrium_edge_triggered() -> None:
 
 def test_never_raises_on_garbage() -> None:
     assert signal_to_tension(_sig("spark_signal", {}), _gate(), SDM) is None
-
-
-from datetime import datetime
-
-from orion.autonomy.models import AutonomyEvidenceRefV1
-from orion.autonomy.signal_tension import chat_evidence_to_tension
 
 
 def test_chat_evidence_mapped_hazard_mints_tension() -> None:

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List
 
 from orion.autonomy.action_outcomes import load_action_outcomes
@@ -18,8 +18,6 @@ from orion.autonomy.graph_gate import (
     resolve_autonomy_graph_read_plan,
 )
 from orion.autonomy.reducer import AutonomyReducerInputV1, reduce_autonomy_state
-from orion.autonomy.signal_drive_map import load_signal_drive_map
-from orion.autonomy.signal_tension import chat_evidence_to_tension
 from orion.autonomy.summary import summarize_autonomy_lookup, summarize_autonomy_state
 from orion.autonomy.repository import (
     AutonomyLookupV1,
@@ -2186,7 +2184,7 @@ def _run_autonomy_reducer(
     social_bridge: Dict[str, Any],
     reasoning: Dict[str, Any],
 ):
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     compile_result = compile_autonomy_evidence(
         user_message=ctx.get("user_message") or ctx.get("message") or "",
         social=social,
@@ -2201,28 +2199,11 @@ def _run_autonomy_reducer(
         "omitted": list(compile_result.omitted),
         **(compile_result.debug or {}),
     }
-    # Trace tensions that will be minted (same map the reducer uses).
-    sdm = load_signal_drive_map()
-    tension_debug = []
-    for ev in compile_result.evidence:
-        t = chat_evidence_to_tension(ev, sdm)
-        if t is None:
-            continue
-        tension_debug.append(
-            {
-                "kind": t.kind,
-                "signal_kind": ev.signal_kind,
-                "dimension": ev.dimension,
-                "drives": sorted((t.drive_impacts or {}).keys()),
-                "magnitude": t.magnitude,
-            }
-        )
-    ctx["chat_autonomy_tension_debug"] = {"minted": tension_debug}
 
     state_obj = autonomy.get("state")
     subj = getattr(state_obj, "subject", None) if state_obj is not None else None
     subject = str(subj or "orion")
-    return reduce_autonomy_state(
+    result = reduce_autonomy_state(
         AutonomyReducerInputV1(
             subject=subject,
             previous_state=state_obj,
@@ -2231,6 +2212,9 @@ def _run_autonomy_reducer(
             now=now,
         )
     )
+    # Single mint path: reuse what the reducer actually folded.
+    ctx["chat_autonomy_tension_debug"] = {"minted": list(result.tensions_minted or [])}
+    return result
 
 
 def _inject_prior_stance_to_inputs(ctx: Dict[str, Any], inputs: Dict[str, Any]) -> None:

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
 import re
 import time
+from datetime import datetime
 from typing import Any, Dict, Iterable, List
 
 from orion.autonomy.action_outcomes import load_action_outcomes
+from orion.autonomy.evidence_compiler import compile_autonomy_evidence
 from orion.autonomy.fanout_policy import autonomy_subject_fanout_from_runtime_ctx
 from orion.autonomy.graph_gate import (
     AutonomyGraphReadPlan,
@@ -16,8 +17,9 @@ from orion.autonomy.graph_gate import (
     log_autonomy_graph_backend_decision,
     resolve_autonomy_graph_read_plan,
 )
-from orion.autonomy.models import AutonomyEvidenceRefV1
 from orion.autonomy.reducer import AutonomyReducerInputV1, reduce_autonomy_state
+from orion.autonomy.signal_drive_map import load_signal_drive_map
+from orion.autonomy.signal_tension import chat_evidence_to_tension
 from orion.autonomy.summary import summarize_autonomy_lookup, summarize_autonomy_state
 from orion.autonomy.repository import (
     AutonomyLookupV1,
@@ -2162,61 +2164,61 @@ def _situation_summary_from_ctx(ctx: Dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _build_autonomy_reducer_evidence(ctx: Dict[str, Any], autonomy: Dict[str, Any]) -> List[AutonomyEvidenceRefV1]:
-    evidence: List[AutonomyEvidenceRefV1] = []
-    msg = ctx.get("user_message") or ctx.get("message") or ""
-    if msg:
-        digest = hashlib.sha256(str(msg)[:200].encode()).hexdigest()[:16]
-        evidence.append(
-            AutonomyEvidenceRefV1(
-                evidence_id=f"user_turn:{digest}",
-                source="user_message",
-                kind="user_turn",
-                summary=str(msg)[:200],
-                confidence=0.9,
-            )
-        )
-    debug = autonomy.get("debug") if isinstance(autonomy.get("debug"), dict) else {}
-    orion_dbg = debug.get("orion") if isinstance(debug.get("orion"), dict) else {}
-    avail = str(orion_dbg.get("availability") or "").strip()
-    if avail:
-        evidence.append(
-            AutonomyEvidenceRefV1(
-                evidence_id=f"infra_health:autonomy_graph:{avail}",
-                source="infra",
-                kind="infra_health",
-                summary=f"autonomy graph availability={avail}",
-                confidence=1.0,
-            )
-        )
-    rs = ctx.get("chat_reasoning_summary") if isinstance(ctx.get("chat_reasoning_summary"), dict) else {}
-    if rs.get("fallback_recommended"):
-        evidence.append(
-            AutonomyEvidenceRefV1(
-                evidence_id="reasoning:fallback_recommended",
-                source="reasoning",
-                kind="reasoning_quality",
-                summary="reasoning fallback recommended",
-                confidence=0.6,
-            )
-        )
-    social = ctx.get("chat_social_bridge_summary") if isinstance(ctx.get("chat_social_bridge_summary"), dict) else {}
-    for hazard in social.get("hazards") or []:
-        hid = hashlib.sha256(str(hazard)[:80].encode()).hexdigest()[:12]
-        evidence.append(
-            AutonomyEvidenceRefV1(
-                evidence_id=f"social_bridge:{hid}",
-                source="social_bridge",
-                kind="relational_signal",
-                summary=str(hazard)[:200],
-                confidence=0.6,
-            )
-        )
-    return evidence
+def _reasoning_upstream_nonempty(ctx: Dict[str, Any]) -> bool:
+    raw = ctx.get("reasoning_artifacts")
+    if isinstance(raw, list) and raw:
+        return True
+    repo = ctx.get("reasoning_repository")
+    if repo is None:
+        return False
+    try:
+        latest = repo.list_latest(limit=1)
+        return bool(latest)
+    except Exception:
+        return False
 
 
-def _run_autonomy_reducer(ctx: Dict[str, Any], autonomy: Dict[str, Any]):
-    evidence = _build_autonomy_reducer_evidence(ctx, autonomy)
+def _run_autonomy_reducer(
+    ctx: Dict[str, Any],
+    autonomy: Dict[str, Any],
+    *,
+    social: Dict[str, Any],
+    social_bridge: Dict[str, Any],
+    reasoning: Dict[str, Any],
+):
+    now = datetime.utcnow()
+    compile_result = compile_autonomy_evidence(
+        user_message=ctx.get("user_message") or ctx.get("message") or "",
+        social=social,
+        social_bridge=social_bridge,
+        reasoning_summary=(reasoning.get("summary") if isinstance(reasoning, dict) else {}) or {},
+        reasoning_upstream_nonempty=_reasoning_upstream_nonempty(ctx),
+        autonomy_debug=autonomy.get("debug") if isinstance(autonomy.get("debug"), dict) else {},
+        now=now,
+    )
+    ctx["chat_autonomy_evidence_debug"] = {
+        "emitted_kinds": [e.kind for e in compile_result.evidence],
+        "omitted": list(compile_result.omitted),
+        **(compile_result.debug or {}),
+    }
+    # Trace tensions that will be minted (same map the reducer uses).
+    sdm = load_signal_drive_map()
+    tension_debug = []
+    for ev in compile_result.evidence:
+        t = chat_evidence_to_tension(ev, sdm)
+        if t is None:
+            continue
+        tension_debug.append(
+            {
+                "kind": t.kind,
+                "signal_kind": ev.signal_kind,
+                "dimension": ev.dimension,
+                "drives": sorted((t.drive_impacts or {}).keys()),
+                "magnitude": t.magnitude,
+            }
+        )
+    ctx["chat_autonomy_tension_debug"] = {"minted": tension_debug}
+
     state_obj = autonomy.get("state")
     subj = getattr(state_obj, "subject", None) if state_obj is not None else None
     subject = str(subj or "orion")
@@ -2224,8 +2226,9 @@ def _run_autonomy_reducer(ctx: Dict[str, Any], autonomy: Dict[str, Any]):
         AutonomyReducerInputV1(
             subject=subject,
             previous_state=state_obj,
-            evidence=evidence,
+            evidence=compile_result.evidence,
             action_outcomes=load_action_outcomes(subject=subject),
+            now=now,
         )
     )
 
@@ -2307,9 +2310,26 @@ def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
 
     if os.getenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "").strip().lower() == "true":
         try:
-            v2_result = _run_autonomy_reducer(ctx, autonomy)
+            before_pressures = None
+            if autonomy.get("state") is not None:
+                before_pressures = dict(getattr(autonomy["state"], "drive_pressures", None) or {})
+            v2_result = _run_autonomy_reducer(
+                ctx,
+                autonomy,
+                social=social,
+                social_bridge=social_bridge,
+                reasoning=reasoning,
+            )
             ctx["chat_autonomy_state_v2"] = v2_result.state.model_dump(mode="json")
             ctx["chat_autonomy_state_delta"] = v2_result.delta.model_dump(mode="json")
+            ctx["chat_autonomy_movement_debug"] = {
+                "dominant_drive_before": getattr(autonomy.get("state"), "dominant_drive", None),
+                "dominant_drive_after": v2_result.state.dominant_drive,
+                "pressures_before": before_pressures,
+                "pressures_after": dict(v2_result.state.drive_pressures or {}),
+                "new_tensions": list(v2_result.delta.new_tensions or []),
+                "resolved_tensions": list(v2_result.delta.resolved_tensions or []),
+            }
             inputs["autonomy"]["state_v2"] = ctx["chat_autonomy_state_v2"]
             inputs["autonomy"]["delta"] = ctx["chat_autonomy_state_delta"]
         except Exception as exc:

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
@@ -93,3 +93,139 @@ def test_chat_stance_autonomy_v2_reducer_exception_swallowed(monkeypatch) -> Non
     assert "delta" not in built["autonomy"]
     assert isinstance(ctx.get("chat_autonomy_state"), dict)
     assert isinstance(ctx.get("chat_autonomy_summary"), dict)
+
+
+from datetime import datetime, timezone
+
+from orion.core.schemas.reasoning import ClaimV1
+from orion.core.schemas.reasoning_io import ReasoningWriteContextV1, ReasoningWriteRequestV1
+from orion.reasoning import InMemoryReasoningRepository
+
+
+def _claim() -> ClaimV1:
+    return ClaimV1(
+        anchor_scope="orion",
+        subject_ref="project:orion_sapienform",
+        status="canonical",
+        authority="local_inferred",
+        confidence=0.9,
+        salience=0.8,
+        novelty=0.4,
+        risk_tier="low",
+        observed_at=datetime.now(timezone.utc),
+        provenance={
+            "evidence_refs": ["ev:1"],
+            "source_channel": "orion:test",
+            "source_kind": "unit",
+            "producer": "pytest",
+        },
+        claim_text="Reasoning continuity is strong.",
+        claim_kind="identity_signal",
+    )
+
+
+def test_chat_stance_empty_repo_omits_reasoning_quality_evidence(monkeypatch) -> None:
+    state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive="coherence",
+        drive_pressures={"coherence": 0.05},
+        active_drives=["coherence"],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+    )
+    monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
+    monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
+    ctx: dict = {"user_message": "hello", "correlation_id": "c-omit"}
+    chat_stance.build_chat_stance_inputs(ctx)
+    debug = ctx.get("chat_autonomy_evidence_debug") or {}
+    omitted = debug.get("omitted") or []
+    assert any(o.get("kind") == "reasoning_quality" and o.get("reason") == "empty_upstream" for o in omitted)
+    v2 = ctx.get("chat_autonomy_state_v2") or {}
+    kinds = [e.get("kind") for e in (v2.get("evidence_refs") or [])]
+    assert "reasoning_quality" not in kinds
+
+
+def test_chat_stance_social_locals_reach_reducer(monkeypatch) -> None:
+    state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive=None,
+        drive_pressures={"relational": 0.0, "coherence": 0.0},
+        active_drives=[],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+    )
+    monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
+
+    def _fake_social(_beliefs, _ctx):
+        return (
+            {"social_posture": [], "hazards": ["cooldown_active"], "relationship_facets": []},
+            {"posture": [], "hazards": ["cooldown_active"], "framing": [], "summary": []},
+        )
+
+    monkeypatch.setattr(chat_stance, "_project_social_from_beliefs", _fake_social)
+    monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
+    ctx: dict = {"user_message": "ping", "correlation_id": "c-haz"}
+    # Intentionally do NOT pre-seed chat_social_bridge_summary — ordering bug regression.
+    assert "chat_social_bridge_summary" not in ctx
+    chat_stance.build_chat_stance_inputs(ctx)
+    v2 = ctx["chat_autonomy_state_v2"]
+    summaries = [e.get("summary") for e in (v2.get("evidence_refs") or []) if e.get("kind") == "relational_signal"]
+    assert "cooldown_active" in summaries
+    assert v2["drive_pressures"]["relational"] > 0.0
+    assert isinstance(ctx.get("chat_autonomy_evidence_debug"), dict)
+    assert isinstance(ctx.get("chat_autonomy_tension_debug"), dict)
+
+
+def test_chat_stance_reasoning_upstream_emits_quality(monkeypatch) -> None:
+    state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive="coherence",
+        drive_pressures={"coherence": 0.05, "predictive": 0.05},
+        active_drives=["coherence"],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+    )
+    monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
+    monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
+
+    repo = InMemoryReasoningRepository()
+    # Empty-ish path that still has an artifact but compiler may still recommend fallback
+    # depending on subject_refs — force fallback via monkeypatch after compile if needed.
+    repo.write_artifacts(
+        ReasoningWriteRequestV1(
+            context=ReasoningWriteContextV1(
+                source_family="manual",
+                source_kind="unit",
+                source_channel="orion:test",
+                producer="pytest",
+            ),
+            artifacts=[_claim()],
+        )
+    )
+
+    original_compile = chat_stance._compile_reasoning_summary
+
+    def _compile_force_fallback(ctx):
+        out = original_compile(ctx)
+        summary = dict(out.get("summary") or {})
+        summary["fallback_recommended"] = True
+        out = dict(out)
+        out["summary"] = summary
+        return out
+
+    monkeypatch.setattr(chat_stance, "_compile_reasoning_summary", _compile_force_fallback)
+    ctx: dict = {"user_message": "who?", "reasoning_repository": repo}
+    chat_stance.build_chat_stance_inputs(ctx)
+    v2 = ctx["chat_autonomy_state_v2"]
+    kinds = [e.get("kind") for e in (v2.get("evidence_refs") or [])]
+    assert "reasoning_quality" in kinds
+    assert v2["drive_pressures"]["coherence"] > 0.05

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from orion.autonomy.models import AutonomyStateV1
 from orion.autonomy.summary import summarize_autonomy_state
+from orion.core.schemas.reasoning import ClaimV1
+from orion.core.schemas.reasoning_io import ReasoningWriteContextV1, ReasoningWriteRequestV1
+from orion.reasoning import InMemoryReasoningRepository
 
 from app import chat_stance
 
@@ -20,6 +25,28 @@ def _fake_autonomy_bundle(state: AutonomyStateV1):
             "_runtime": {},
         },
     }
+
+
+def _claim() -> ClaimV1:
+    return ClaimV1(
+        anchor_scope="orion",
+        subject_ref="project:orion_sapienform",
+        status="canonical",
+        authority="local_inferred",
+        confidence=0.9,
+        salience=0.8,
+        novelty=0.4,
+        risk_tier="low",
+        observed_at=datetime.now(timezone.utc),
+        provenance={
+            "evidence_refs": ["ev:1"],
+            "source_channel": "orion:test",
+            "source_kind": "unit",
+            "producer": "pytest",
+        },
+        claim_text="Reasoning continuity is strong.",
+        claim_kind="identity_signal",
+    )
 
 
 def test_chat_stance_autonomy_v2_ctx_and_inputs_when_enabled(monkeypatch) -> None:
@@ -95,35 +122,6 @@ def test_chat_stance_autonomy_v2_reducer_exception_swallowed(monkeypatch) -> Non
     assert isinstance(ctx.get("chat_autonomy_summary"), dict)
 
 
-from datetime import datetime, timezone
-
-from orion.core.schemas.reasoning import ClaimV1
-from orion.core.schemas.reasoning_io import ReasoningWriteContextV1, ReasoningWriteRequestV1
-from orion.reasoning import InMemoryReasoningRepository
-
-
-def _claim() -> ClaimV1:
-    return ClaimV1(
-        anchor_scope="orion",
-        subject_ref="project:orion_sapienform",
-        status="canonical",
-        authority="local_inferred",
-        confidence=0.9,
-        salience=0.8,
-        novelty=0.4,
-        risk_tier="low",
-        observed_at=datetime.now(timezone.utc),
-        provenance={
-            "evidence_refs": ["ev:1"],
-            "source_channel": "orion:test",
-            "source_kind": "unit",
-            "producer": "pytest",
-        },
-        claim_text="Reasoning continuity is strong.",
-        claim_kind="identity_signal",
-    )
-
-
 def test_chat_stance_empty_repo_omits_reasoning_quality_evidence(monkeypatch) -> None:
     state = AutonomyStateV1(
         subject="orion",
@@ -179,7 +177,44 @@ def test_chat_stance_social_locals_reach_reducer(monkeypatch) -> None:
     assert "cooldown_active" in summaries
     assert v2["drive_pressures"]["relational"] > 0.0
     assert isinstance(ctx.get("chat_autonomy_evidence_debug"), dict)
-    assert isinstance(ctx.get("chat_autonomy_tension_debug"), dict)
+    tension_debug = ctx.get("chat_autonomy_tension_debug") or {}
+    minted = tension_debug.get("minted") or []
+    assert any(m.get("dimension") == "cooldown_active" for m in minted)
+    assert any(m.get("signal_kind") == "chat_social_hazard" for m in minted)
+
+
+def test_chat_stance_v1_with_snapshots_survives_aware_compiler_now(monkeypatch) -> None:
+    """Live graph V1 carries naive generated_at + snapshot IDs; stance now is aware UTC."""
+    state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        latest_identity_snapshot_id="snap-live",
+        latest_drive_audit_id="audit-live",
+        dominant_drive="coherence",
+        drive_pressures={"coherence": 0.2, "relational": 0.0},
+        active_drives=["coherence"],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+        generated_at=datetime(2026, 5, 2, 12, 0, 0),  # naive
+    )
+    monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
+
+    def _fake_social(_beliefs, _ctx):
+        return (
+            {"social_posture": [], "hazards": ["duplicate_message"], "relationship_facets": []},
+            {"posture": [], "hazards": ["duplicate_message"], "framing": [], "summary": []},
+        )
+
+    monkeypatch.setattr(chat_stance, "_project_social_from_beliefs", _fake_social)
+    monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
+    ctx: dict = {"user_message": "hi", "correlation_id": "c-tz"}
+    chat_stance.build_chat_stance_inputs(ctx)
+    assert isinstance(ctx.get("chat_autonomy_state_v2"), dict)
+    assert ctx["chat_autonomy_state_v2"].get("schema_version") == "autonomy.state.v2"
+    assert "latest_direct_evidence_at" in (ctx["chat_autonomy_state_v2"].get("freshness") or {})
+    assert ctx["chat_autonomy_state_v2"]["drive_pressures"]["relational"] > 0.0
 
 
 def test_chat_stance_reasoning_upstream_emits_quality(monkeypatch) -> None:
@@ -198,8 +233,6 @@ def test_chat_stance_reasoning_upstream_emits_quality(monkeypatch) -> None:
     monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
 
     repo = InMemoryReasoningRepository()
-    # Empty-ish path that still has an artifact but compiler may still recommend fallback
-    # depending on subject_refs — force fallback via monkeypatch after compile if needed.
     repo.write_artifacts(
         ReasoningWriteRequestV1(
             context=ReasoningWriteContextV1(


### PR DESCRIPTION
## Summary

- Replace AutonomyStateV2 keyword/theater evidence with typed omit-when-empty `AutonomyEvidenceCompiler` and map-driven `chat_evidence_to_tension` pressure math
- Wire stance to pass social/social_bridge/reasoning **locals** into the reducer before `ctx["chat_social_bridge_summary"]` is written
- Delete keyword pressure / blob OR paths from the reducer; derive tension kinds from pressure thresholds only
- Keep `AUTONOMY_STATE_V2_REDUCER_ENABLED` default-off; prove movement with eval + isolation ban for phi/SelfState paths

## Outcome moved

Chat AutonomyStateV2 pressures now move only from typed, map-matched evidence (mapped social hazards + reasoning fallback when upstream is non-empty). Empty reasoning repos no longer emit `reasoning_quality` theater; unmapped hazards no longer fake motion via keyword substrings.

## Current architecture

Previously, `_build_autonomy_reducer_evidence` read `ctx["chat_social_bridge_summary"]` after it was often still empty, and the reducer applied polarity-blind keyword hits on evidence summaries to bump `drive_pressures` / OR tension kinds.

## Architecture touched

- Package: `orion/autonomy` (models, compiler, signal_tension, reducer, map YAML, tests, eval)
- Service: `orion-cortex-exec` (`chat_stance.py` V2 gate path)
- Docs: operator notes + design/plan under `docs/superpowers/`
- Hard isolation: no DriveEngine / DeviationGate / SelfState / phi wiring from this path

## Files changed

- `orion/autonomy/models.py`: optional `signal_kind` / `dimension` / `value` on `AutonomyEvidenceRefV1`
- `orion/autonomy/evidence_compiler.py`: proven-non-empty gates; hazards always stamp typed fields
- `orion/autonomy/signal_tension.py`: `chat_evidence_to_tension` direct adapter
- `orion/autonomy/reducer.py`: tension fold; keyword path deleted; `tensions_minted`; UTC-aware timestamp normalize
- `config/autonomy/signal_drive_map.yaml`: `chat_social_hazard` + `chat_reasoning_quality` rows
- `services/orion-cortex-exec/app/chat_stance.py`: locals → compiler → reducer; debug from reducer mint list
- `docs/autonomy_state_v2_reducer.md`: typed evidence contract + enable bar
- `orion/autonomy/evals/run_autonomy_v2_movement_eval.py`: enable-bar movement fixture
- `orion/autonomy/tests/*` + `services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py`: gates/regressions
- `docs/superpowers/specs/2026-07-10-autonomy-v2-evidence-signal-tension-design.md` + plan

## Schema / bus / API changes

- Added: optional fields on `AutonomyEvidenceRefV1` (`signal_kind`, `dimension`, `value`); `AutonomyReducerResultV1.tensions_minted`
- Removed: keyword pressure helpers (`_apply_single_evidence_pressures`, evidence blob OR tension derivation)
- Renamed: none
- Behavior changed: V2 pressure math is map-driven when flag is on; default remains off
- Compatibility notes: additive optional fields (`extra=forbid` still satisfied); flag-off path unchanged

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no (still `AUTONOMY_STATE_V2_REDUCER_ENABLED=` empty / default-off)
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: n/a (no template key change)
- skipped keys requiring operator action: none

## Tests run

```text
PYTHONPATH=services/orion-cortex-exec:services/orion-cortex-exec/app:. \
  .venv/bin/pytest \
  orion/autonomy/tests/test_evidence_ref_schema.py \
  orion/autonomy/tests/test_evidence_compiler.py \
  orion/autonomy/tests/test_signal_drive_map.py \
  orion/autonomy/tests/test_signal_tension.py \
  orion/autonomy/tests/test_autonomy_reducer.py \
  orion/autonomy/tests/test_autonomy_isolation.py \
  services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py -q
# 55 passed
```

## Evals run

```text
PYTHONPATH=. .venv/bin/python orion/autonomy/evals/run_autonomy_v2_movement_eval.py
# PASS (relational/coherence move; dominant_drive becomes relational)
```

## Docker/build/smoke checks

```text
No Docker rebuild required for merge (library + cortex stance path; flag default-off).
Compose config not required for this patch.
```

## Review findings fixed

- Finding: dual allowlist (`_MAPPED_SOCIAL_HAZARDS` vs YAML)
  - Fix: always stamp typed hazard fields; `SignalDriveMap.match` is sole pressure gate
  - Evidence: `evidence_compiler.py` + compiler/reducer tests
- Finding: stance reminted tensions for debug
  - Fix: `AutonomyReducerResultV1.tensions_minted`; stance reuses reducer list
  - Evidence: `chat_stance.py` + stance tension debug asserts
- Finding: `_infra_unavailable` parsed summary prose
  - Fix: parse `evidence_id` `infra_health:autonomy_graph:{avail}`
  - Evidence: `test_reducer_infra_unavailable_from_evidence_id`
- Finding: aware/naive datetime mix TypeError on live V1 upgrade
  - Fix: `_as_utc` normalize in `_utc_now`, merge sort, freshness max
  - Evidence: `test_reducer_v1_upgrade_mixes_naive_and_aware_observed_at`, `test_chat_stance_v1_with_snapshots_survives_aware_compiler_now`
- Finding: isolation missed `orion-self-state-runtime`
  - Fix: added to banned roots
  - Evidence: `test_autonomy_isolation.py`

## Restart required

```text
No restart required for default-off merge.

To enable after movement eval is green on the target host:

  # in services/orion-cortex-exec/.env
  AUTONOMY_STATE_V2_REDUCER_ENABLED=true

Then restart cortex-exec (operator):
  docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
    -f services/orion-cortex-exec/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: SelfState hazards still merge into `social` before the reducer (one-way, allowed); can become V2 evidence strings
- Mitigation: documented; map remains sole pressure gate; flag default-off
- Severity: low
- Concern: sparse map means many hazards are typed but do not move pressures
- Mitigation: intentional; grow YAML + tests when adding dimensions

## Test plan

- [ ] Run focused pytest suite above (expect 55 passed)
- [ ] Run `python orion/autonomy/evals/run_autonomy_v2_movement_eval.py` (expect PASS)
- [ ] Confirm `.env_example` still has empty `AUTONOMY_STATE_V2_REDUCER_ENABLED=`
- [ ] With flag off: chat stance has no `chat_autonomy_state_v2`
- [ ] With flag on (staging only): mapped hazard moves relational; empty reasoning repo omits `reasoning_quality`
