### PR TITLE
fix(spark): prefer execution_load for tissue-viz arousal

### DIFF
--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -160,18 +160,28 @@ _HARDWARE_RESOURCE_CHANNELS = frozenset({
     "thermal_pressure",
 })
 
+# execution_pressure dimension max-aggregates `execution_load` (real load) with
+# a same-named generic `execution_pressure` channel that can stick saturated
+# at 1.00 (live 2026-07-10: evidence ["execution_pressure=1.00",
+# "execution_load=0.19"] while dim.score=1.0). Prefer the real load channel
+# for tissue-viz energy, same display-layer pattern as hardware resource
+# filtering above.
+_EXECUTION_LOAD_CHANNELS = frozenset({
+    "execution_load",
+})
 
-def _hardware_resource_pressure(dim: Optional[SelfStateDimensionV1]) -> Optional[float]:
-    """Real resource load from resource_pressure's dominant_evidence, ignoring
-    the generic capability-graph `pressure` and `transport_pressure` channels
-    that can stick saturated. Returns None (honest no-signal) when no hardware
-    channel appears in the evidence -- never fabricates a value."""
+
+def _parse_dominant_evidence_channels(
+    dim: Optional[SelfStateDimensionV1],
+    allowed: frozenset[str],
+) -> Optional[float]:
+    """Max of allowed channel values from dominant_evidence. None if none match."""
     if dim is None:
         return None
     values: List[float] = []
     for entry in dim.dominant_evidence:
         name, _, raw = entry.partition("=")
-        if name not in _HARDWARE_RESOURCE_CHANNELS:
+        if name not in allowed:
             continue
         try:
             v = float(raw)
@@ -187,6 +197,21 @@ def _hardware_resource_pressure(dim: Optional[SelfStateDimensionV1]) -> Optional
             continue
         values.append(max(0.0, min(1.0, v)))
     return max(values) if values else None
+
+
+def _hardware_resource_pressure(dim: Optional[SelfStateDimensionV1]) -> Optional[float]:
+    """Real resource load from resource_pressure's dominant_evidence, ignoring
+    the generic capability-graph `pressure` and `transport_pressure` channels
+    that can stick saturated. Returns None (honest no-signal) when no hardware
+    channel appears in the evidence -- never fabricates a value."""
+    return _parse_dominant_evidence_channels(dim, _HARDWARE_RESOURCE_CHANNELS)
+
+
+def _execution_load_pressure(dim: Optional[SelfStateDimensionV1]) -> Optional[float]:
+    """Real execution load from execution_pressure's dominant_evidence, ignoring
+    the saturated generic `execution_pressure` channel. Returns None when
+    `execution_load` is absent -- never fabricates a value."""
+    return _parse_dominant_evidence_channels(dim, _EXECUTION_LOAD_CHANNELS)
 
 
 def set_latest_self_state(ss: SelfStateV1) -> None:
@@ -222,7 +247,11 @@ def _phi_from_self_state(ss: SelfStateV1) -> Dict[str, float]:
         hardware_pressure if hardware_pressure is not None else _s("resource_pressure", 0.5)
     )
     resource_cap  = 1.0 - resource_pressure_for_energy
-    execution_cap = 1.0 - _s("execution_pressure", 0.3)
+    execution_load = _execution_load_pressure(d.get("execution_pressure"))
+    execution_pressure_for_energy = (
+        execution_load if execution_load is not None else _s("execution_pressure", 0.3)
+    )
+    execution_cap = 1.0 - execution_pressure_for_energy
     energy = intensity * (resource_cap * execution_cap) ** 0.5
     # Trajectory: rising intensity or recovering capacity builds energy momentum.
     # dimension_trajectory["resource_pressure"] tracks the delta of the raw,

--- a/services/orion-spark-introspector/tests/test_tissue_viz_arousal.py
+++ b/services/orion-spark-introspector/tests/test_tissue_viz_arousal.py
@@ -30,7 +30,10 @@ def _dim(name: str, score: float, *, dominant_evidence: list[str] | None = None)
 
 
 def _self_state_payload(
-    *, resource_dim: SelfStateDimensionV1, dimension_trajectory: dict[str, float] | None = None
+    *,
+    resource_dim: SelfStateDimensionV1,
+    execution_dim: SelfStateDimensionV1 | None = None,
+    dimension_trajectory: dict[str, float] | None = None,
 ) -> dict:
     dims = {
         name: _dim(name, score)
@@ -50,6 +53,8 @@ def _self_state_payload(
         )
     }
     dims["resource_pressure"] = resource_dim
+    if execution_dim is not None:
+        dims["execution_pressure"] = execution_dim
     return SelfStateV1(
         self_state_id="self.state:tick_arousal_test:policy.v1",
         generated_at=_NOW,
@@ -232,3 +237,59 @@ async def test_handle_semantic_upsert_arousal_matches_canonical_energy(monkeypat
     # resource_cap=1-0.92=0.08, execution_cap=1.0, no trajectory deltas,
     # no active signals.
     assert tissue[-1]["stats"]["arousal"] == pytest.approx(0.2828, abs=1e-4)
+
+
+def test_execution_load_pressure_none_when_only_generic_channel_present() -> None:
+    dim = _dim("execution_pressure", 1.0, dominant_evidence=["execution_pressure=1.00"])
+    assert worker._execution_load_pressure(dim) is None
+
+
+def test_execution_load_pressure_prefers_execution_load_over_saturated_generic() -> None:
+    dim = _dim(
+        "execution_pressure",
+        1.0,
+        dominant_evidence=["execution_pressure=1.00", "execution_load=0.19"],
+    )
+    assert worker._execution_load_pressure(dim) == 0.19
+
+
+def test_arousal_no_longer_hard_zeroed_by_saturated_execution_pressure_channel() -> None:
+    """Live 2026-07-10 follow-on: after resource_pressure hardware filter,
+    energy was still hard-zeroed because execution_pressure.score=1.0 from a
+    stuck generic `execution_pressure` channel while real execution_load≈0.19.
+    With execution_load in dominant_evidence, energy must reflect real load."""
+    resource_dim = _dim(
+        "resource_pressure",
+        1.0,
+        dominant_evidence=["pressure=1.00", "cpu_pressure=0.92"],
+    )
+    execution_dim = _dim(
+        "execution_pressure",
+        1.0,
+        dominant_evidence=["execution_pressure=1.00", "execution_load=0.19"],
+    )
+    ss = SelfStateV1.model_validate(
+        _self_state_payload(resource_dim=resource_dim, execution_dim=execution_dim)
+    )
+    phi = worker._phi_from_self_state(ss)
+    assert phi["energy"] > 0.0
+    # intensity=1.0, resource_cap=1-0.92=0.08, execution_cap=1-0.19=0.81
+    # energy = 1.0 * (0.08 * 0.81) ** 0.5 ~= 0.2546
+    assert phi["energy"] == pytest.approx(0.2546, abs=1e-4)
+
+
+def test_arousal_still_zero_when_no_execution_load_evidence_and_score_saturated() -> None:
+    """Honest fallback: no execution_load in evidence → use raw dim.score."""
+    resource_dim = _dim(
+        "resource_pressure",
+        1.0,
+        dominant_evidence=["cpu_pressure=0.50"],
+    )
+    execution_dim = _dim(
+        "execution_pressure", 1.0, dominant_evidence=["execution_pressure=1.00"]
+    )
+    ss = SelfStateV1.model_validate(
+        _self_state_payload(resource_dim=resource_dim, execution_dim=execution_dim)
+    )
+    phi = worker._phi_from_self_state(ss)
+    assert phi["energy"] == 0.0


### PR DESCRIPTION
## Summary

- Tissue-viz energy/arousal was hard-zeroed when `execution_pressure.score=1.0` came from a saturated generic `execution_pressure=1.00` channel while real `execution_load≈0.19` sat in `dominant_evidence` (same bug class as #936, different dimension).
- Display-layer fix in `orion-spark-introspector`: prefer `execution_load` from evidence when present; fall back to raw dim score when absent.
- Regression tests cover the live-shaped payload and the honest no-`execution_load` fallback.

## Outcome moved

Hub Cognitive EKG arousal can move again under healthy execution load even when the generic execution_pressure channel is stuck at 1.0.

## Current architecture

`_phi_from_self_state` already filtered hardware channels for `resource_pressure` (#936). `execution_cap` still used raw `execution_pressure.score`.

## Architecture touched

- Service: `orion-spark-introspector` only (display layer)
- No SelfState scoring / agency_readiness changes

## Files changed

- `services/orion-spark-introspector/app/worker.py`: shared evidence parser + `_execution_load_pressure`
- `services/orion-spark-introspector/tests/test_tissue_viz_arousal.py`: live-shaped + fallback regressions

## Schema / bus / API changes

- None

## Env/config changes

- None

## Tests run

```text
PYTHONPATH=services/orion-spark-introspector:services/orion-spark-introspector/app:. \
  pytest services/orion-spark-introspector/tests/test_tissue_viz_arousal.py -q
# 15 passed
```

## Evals run

```text
No eval harness for this display-layer seam; gate tests cover the live incident shape.
```

## Docker/build/smoke checks

```text
Not run in this session (code-only display filter). Restart spark-introspector after merge to pick up.
```

## Review findings fixed

- Subagent review blocked by usage limits; self-check: same pattern as #936, no scoring.py touch, fallback preserves prior behavior when `execution_load` absent.

## Restart required

```bash
cd /mnt/scripts/Orion-Sapienform/services/orion-spark-introspector
docker compose --env-file ../../.env --env-file .env -f docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: root cause (stuck generic channel in SelfState scoring) remains; this only unblocks EKG display
- Mitigation: follow-up can fix scoring aggregation if desired; out of scope here (same as #936)

## Test plan

- [ ] Merge + restart `orion-spark-introspector`
- [ ] Confirm Hub `/spark/ui` arousal is non-zero when live SelfState shows `execution_load` << 1.0 with saturated `execution_pressure=`
