### PR TITLE
docs(autonomy): document V2 evidence path in autonomy and cortex READMEs

### DIFF
--- a/orion/autonomy/README.md
+++ b/orion/autonomy/README.md
@@ -4,6 +4,32 @@ Autonomy goals and drives are keyed by subject (`orion`, `relationship`, `junipe
 
 - [Autonomy subject routing contract](../../docs/architecture/autonomy_subjects.md)
 
+## AutonomyStateV2 evidence (chat, env-gated)
+
+Optional turn-local reducer that upgrades graph `AutonomyStateV1` with **typed** evidence and map-driven pressure math. Keyword substring pressure is **removed**.
+
+| Piece | Path | Role |
+|-------|------|------|
+| Schema | `orion/autonomy/models.py` | `AutonomyEvidenceRefV1` optional `signal_kind` / `dimension` / `value` |
+| Compiler | `orion/autonomy/evidence_compiler.py` | Omit-when-empty gates from stance locals (not `ctx["chat_social_bridge_summary"]`) |
+| Adapter | `orion/autonomy/signal_tension.py` | `chat_evidence_to_tension` — direct map lookup, no DeviationGate/EWMA |
+| Map | `config/autonomy/signal_drive_map.yaml` | `chat_social_hazard` + `chat_reasoning_quality` rows |
+| Reducer | `orion/autonomy/reducer.py` | Fold `magnitude * drive_impacts` into `drive_pressures`; return `tensions_minted` |
+
+**Hard isolation:** this path must not wire into phi, `build_self_state`, or homeostatic `DriveEngine`.
+
+Operator contract + enable bar: [docs/autonomy_state_v2_reducer.md](../../docs/autonomy_state_v2_reducer.md)
+
+```bash
+# Enable bar (must exit 0 before flipping the flag in cortex-exec)
+PYTHONPATH=. python orion/autonomy/evals/run_autonomy_v2_movement_eval.py
+
+pytest orion/autonomy/tests/test_evidence_compiler.py \
+  orion/autonomy/tests/test_signal_tension.py \
+  orion/autonomy/tests/test_autonomy_reducer.py \
+  orion/autonomy/tests/test_autonomy_isolation.py -q
+```
+
 ## Chat stance drives (Hub compact card)
 
 On `chat_stance`, Orion’s drives graph is large and often exceeds SPARQL budgets. Defaults:

--- a/services/orion-cortex-exec/README.md
+++ b/services/orion-cortex-exec/README.md
@@ -86,6 +86,33 @@ Provenance: `.env_example` → `docker-compose.yml` → `settings.py`
 | `ORION_REPO_ROOT` | auto-detected | Optional override for self-study repo-root resolution when the container layout differs from local dev. |
 | `ORION_ACTION_OUTCOME_DB_URL` | `postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney` | Shared SQL store for autonomous action outcomes. When set, chat-stance `load_action_outcomes` reads the `action_outcomes` table (written by sql-writer from `action.outcome.emit.v1`); when blank it falls back to the per-container JSON file `ORION_ACTION_OUTCOME_STORE_PATH`. |
 
+### AutonomyStateV2 on chat stance (default off)
+
+`app/chat_stance.py` can run the AutonomyStateV2 reducer after social/reasoning locals are built and **before** writing `ctx["chat_social_bridge_summary"]`.
+
+| Variable | Default (`.env_example`) | Description |
+| :--- | :--- | :--- |
+| `AUTONOMY_STATE_V2_REDUCER_ENABLED` | empty / not `true` | When `true`, compile typed evidence from stance locals → `reduce_autonomy_state` → `ctx["chat_autonomy_state_v2"]` + delta + debug keys. |
+
+**Flow (flag on)**
+
+1. `_project_social_from_beliefs` / `_compile_reasoning_summary` produce locals.
+2. `compile_autonomy_evidence(...)` (omit-when-empty) stamps optional `signal_kind` / `dimension` / `value`.
+3. `reduce_autonomy_state` mints tensions via `chat_evidence_to_tension` + `signal_drive_map` (no keyword pressure).
+4. Debug: `chat_autonomy_evidence_debug`, `chat_autonomy_tension_debug` (from reducer `tensions_minted`), `chat_autonomy_movement_debug`.
+
+**Do not enable** until the movement eval is green:
+
+```bash
+PYTHONPATH=. python orion/autonomy/evals/run_autonomy_v2_movement_eval.py
+```
+
+Operator notes: [docs/autonomy_state_v2_reducer.md](../../docs/autonomy_state_v2_reducer.md). Package README: [orion/autonomy/README.md](../../orion/autonomy/README.md).
+
+```bash
+pytest services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py -q
+```
+
 ### Turn effect and drive tensions (bus)
 
 When the executor computes `turn_effect` / `turn_effect_evidence`, they are included in `PlanExecutionResult.metadata`. Hub merges that metadata into each chat turn `spark_meta`, so `orion-spark-concept-induction` can derive `extract_tensions` from `spark_meta.turn_effect`. For graph-backed tension kinds on `DriveAudit`, `orion-rdf-writer` must still consume `memory.drives.audit.v1` after concept-induction publishes it.


### PR DESCRIPTION
## Summary

- Replace AutonomyStateV2 keyword/theater evidence with typed omit-when-empty `AutonomyEvidenceCompiler` and map-driven `chat_evidence_to_tension` pressure math
- Wire stance to pass social/social_bridge/reasoning **locals** into the reducer before `ctx["chat_social_bridge_summary"]` is written
- Delete keyword pressure / blob OR paths from the reducer; derive tension kinds from pressure thresholds only
- Keep `AUTONOMY_STATE_V2_REDUCER_ENABLED` default-off; prove movement with eval + isolation ban for phi/SelfState paths

## Outcome moved

Chat AutonomyStateV2 pressures now move only from typed, map-matched evidence (mapped social hazards + reasoning fallback when upstream is non-empty). Empty reasoning repos no longer emit `reasoning_quality` theater; unmapped hazards no longer fake motion via keyword substrings.

## Current architecture

Previously, `_build_autonomy_reducer_evidence` read `ctx["chat_social_bridge_summary"]` after it was often still empty, and the reducer applied polarity-blind keyword hits on evidence summaries to bump `drive_pressures` / OR tension kinds.

## Architecture touched

- Package: `orion/autonomy` (models, compiler, signal_tension, reducer, map YAML, tests, eval)
- Service: `orion-cortex-exec` (`chat_stance.py` V2 gate path)
- Docs: operator notes + design/plan under `docs/superpowers/`
- Hard isolation: no DriveEngine / DeviationGate / SelfState / phi wiring from this path

## Files changed

- `orion/autonomy/models.py`: optional `signal_kind` / `dimension` / `value` on `AutonomyEvidenceRefV1`
- `orion/autonomy/evidence_compiler.py`: proven-non-empty gates; hazards always stamp typed fields
- `orion/autonomy/signal_tension.py`: `chat_evidence_to_tension` direct adapter
- `orion/autonomy/reducer.py`: tension fold; keyword path deleted; `tensions_minted`; UTC-aware timestamp normalize
- `config/autonomy/signal_drive_map.yaml`: `chat_social_hazard` + `chat_reasoning_quality` rows
- `services/orion-cortex-exec/app/chat_stance.py`: locals → compiler → reducer; debug from reducer mint list
- `docs/autonomy_state_v2_reducer.md`: typed evidence contract + enable bar
- `orion/autonomy/evals/run_autonomy_v2_movement_eval.py`: enable-bar movement fixture
- `orion/autonomy/tests/*` + `services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py`: gates/regressions
- `docs/superpowers/specs/2026-07-10-autonomy-v2-evidence-signal-tension-design.md` + plan

## Schema / bus / API changes

- Added: optional fields on `AutonomyEvidenceRefV1` (`signal_kind`, `dimension`, `value`); `AutonomyReducerResultV1.tensions_minted`
- Removed: keyword pressure helpers (`_apply_single_evidence_pressures`, evidence blob OR tension derivation)
- Renamed: none
- Behavior changed: V2 pressure math is map-driven when flag is on; default remains off
- Compatibility notes: additive optional fields (`extra=forbid` still satisfied); flag-off path unchanged

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no (still `AUTONOMY_STATE_V2_REDUCER_ENABLED=` empty / default-off)
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: n/a (no template key change)
- skipped keys requiring operator action: none

## Tests run

```text
PYTHONPATH=services/orion-cortex-exec:services/orion-cortex-exec/app:. \
  .venv/bin/pytest \
  orion/autonomy/tests/test_evidence_ref_schema.py \
  orion/autonomy/tests/test_evidence_compiler.py \
  orion/autonomy/tests/test_signal_drive_map.py \
  orion/autonomy/tests/test_signal_tension.py \
  orion/autonomy/tests/test_autonomy_reducer.py \
  orion/autonomy/tests/test_autonomy_isolation.py \
  services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py -q
# 55 passed
```

## Evals run

```text
PYTHONPATH=. .venv/bin/python orion/autonomy/evals/run_autonomy_v2_movement_eval.py
# PASS (relational/coherence move; dominant_drive becomes relational)
```

## Docker/build/smoke checks

```text
No Docker rebuild required for merge (library + cortex stance path; flag default-off).
Compose config not required for this patch.
```

## Review findings fixed

- Finding: dual allowlist (`_MAPPED_SOCIAL_HAZARDS` vs YAML)
  - Fix: always stamp typed hazard fields; `SignalDriveMap.match` is sole pressure gate
  - Evidence: `evidence_compiler.py` + compiler/reducer tests
- Finding: stance reminted tensions for debug
  - Fix: `AutonomyReducerResultV1.tensions_minted`; stance reuses reducer list
  - Evidence: `chat_stance.py` + stance tension debug asserts
- Finding: `_infra_unavailable` parsed summary prose
  - Fix: parse `evidence_id` `infra_health:autonomy_graph:{avail}`
  - Evidence: `test_reducer_infra_unavailable_from_evidence_id`
- Finding: aware/naive datetime mix TypeError on live V1 upgrade
  - Fix: `_as_utc` normalize in `_utc_now`, merge sort, freshness max
  - Evidence: `test_reducer_v1_upgrade_mixes_naive_and_aware_observed_at`, `test_chat_stance_v1_with_snapshots_survives_aware_compiler_now`
- Finding: isolation missed `orion-self-state-runtime`
  - Fix: added to banned roots
  - Evidence: `test_autonomy_isolation.py`

## Restart required

```text
No restart required for default-off merge.

To enable after movement eval is green on the target host:

  # in services/orion-cortex-exec/.env
  AUTONOMY_STATE_V2_REDUCER_ENABLED=true

Then restart cortex-exec (operator):
  docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
    -f services/orion-cortex-exec/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
- Concern: SelfState hazards still merge into `social` before the reducer (one-way, allowed); can become V2 evidence strings
- Mitigation: documented; map remains sole pressure gate; flag default-off
- Severity: low
- Concern: sparse map means many hazards are typed but do not move pressures
- Mitigation: intentional; grow YAML + tests when adding dimensions

## Test plan

- [ ] Run focused pytest suite above (expect 55 passed)
- [ ] Run `python orion/autonomy/evals/run_autonomy_v2_movement_eval.py` (expect PASS)
- [ ] Confirm `.env_example` still has empty `AUTONOMY_STATE_V2_REDUCER_ENABLED=`
- [ ] With flag off: chat stance has no `chat_autonomy_state_v2`
- [ ] With flag on (staging only): mapped hazard moves relational; empty reasoning repo omits `reasoning_quality`
