### PR TITLE
Feat/autonomy v2 closed loop wiring

### DIFF
--- a/docs/superpowers/plans/2026-07-11-autonomy-v2-closed-loop-wiring.md
+++ b/docs/superpowers/plans/2026-07-11-autonomy-v2-closed-loop-wiring.md
@@ -1,0 +1,227 @@
+# AutonomyStateV2 closed-loop wiring — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `AutonomyStateV2` non-amnesiac (persist turn-to-turn) and give it two real consumers on the orion-unified (`stance_react`) path only: the stance-decision LLM call itself, and every FCC/Claude harness system prompt. Relocate the never-enabled curiosity/attention-frame injection to the same two consumers. `chat_general`/Lane A is untouched.
+
+**Architecture:** New Postgres-backed `AutonomyStateV2` store (subject-keyed) closes the reducer's own fold loop. A new `autonomy_slice.py` builder (mirrors the existing `grounding_capsule.py` exactly) produces a compact `AutonomySliceV1`. It reaches the stance-decision LLM call via `ctx`/Jinja render (mirrors `mind_coloring`'s prompt-injection path) **and** reaches `ThoughtEventV1` as a real field via the `metadata` → `orion-thought` post-hoc-attach path (mirrors `grounding_capsule`'s path exactly). `compile_harness_prefix()` renders the field into every harness turn.
+
+**Design source:** `docs/superpowers/specs/2026-07-11-autonomy-v2-closed-loop-wiring-design.md` (gitignored, local-only — see that file for full architecture rationale; this plan is self-contained for implementation purposes)
+
+**Builds on:** autonomy-v2-evidence-signal-tension work (PR #939/#941) — that shipped the reducer math; this plan makes its output persist and actually matter.
+
+---
+
+## Context for the implementer (read before starting)
+
+Work in a clean branch/worktree from repo root `/mnt/scripts/Orion-Sapienform`.
+
+Verified facts (confirmed live this session, not assumed):
+
+- Reducer entry point: `services/orion-cortex-exec/app/chat_stance.py:_run_autonomy_reducer()` (~line 2179), called from `build_chat_stance_inputs()` when `AUTONOMY_STATE_V2_REDUCER_ENABLED=true`.
+- `previous_state` currently comes only from `_load_autonomy_state`/`_project_autonomy_from_beliefs` (V1/graph baseline) — no store for V2's own output exists anywhere in the repo.
+- **Two existing, proven patterns to mirror, not invent new ones:**
+  - `grounding_capsule` pattern (`services/orion-cortex-exec/app/grounding_capsule.py` → `router.py:1358-1367,1557-1558` sets `ctx["grounding_capsule"]` and `metadata["grounding_capsule"]` → `orion/thought/stance_react.py:183` defensively pops any LLM-invented copy from raw JSON → `services/orion-thought/app/bus_listener.py:193-203` `_extract_grounding_capsule(exec_result)` + `bus_listener.py:278-280` `model_copy(update={"grounding_capsule": capsule})`). Deterministic data, never rendered into the prompt, attached to `ThoughtEventV1` post-hoc.
+  - `mind_coloring` pattern (`stance_react.j2:22-35`): rendered **into** the prompt as advisory context ("does not add output keys"), colors the LLM's own imperative/tone synthesis, never becomes a `ThoughtEventV1` field.
+  - `autonomy_slice` needs **both halves**: prompt-injection (so the stance decision itself reacts to it) + post-hoc structured attachment (so `compile_harness_prefix` gets a reliable value, not a hoped-for LLM echo).
+- Prompt template lookup is generic via verb registry: `orion/cognition/verbs/stance_react.yaml` → `prompt_template: stance_react.j2`. No hardcoded render call site to touch — adding keys to `ctx` is sufficient, same mechanism already used for `mind_coloring`/`chat_attention_frame` elsewhere.
+- `orion/substrate/attention_frame.py` (`attention_frame_enabled()` reads `ORION_CURIOSITY_FRAME_ENABLED`, default false) is already lane-agnostic — computed inside `build_chat_stance_inputs` regardless of verb, already lands in `ctx["chat_attention_frame"]` today. Relocating it to Lane B is template-only (`stance_react.j2` + `compile_harness_prefix`) — **no code changes to the detector**.
+- Harness prompt injection point: `orion/harness/prefix.py:compile_harness_prefix()`, which currently calls `_format_stance_slice()` and `_format_grounding_self_block()`. New formatters go here, called the same way.
+- **No** changes to `orion/bus/channels.yaml` or `orion/schemas/registry.py` — this is a schema field + a new Postgres table, not a new bus event.
+- **No** goal-pipeline integration, **no** graph-drives unification, **no** `chat_general`/`chat_stance_brief.j2`/`chat_general.j2` changes — deliberately excluded from this patch.
+
+### Test commands
+
+```bash
+pytest orion/autonomy/tests -q
+pytest orion/schemas/tests -k thought -q
+pytest services/orion-cortex-exec/tests -k autonomy_slice -q
+pytest services/orion-cortex-exec/tests -k grounding_capsule -q  # non-regression
+pytest services/orion-thought/tests -k stance_react -q
+pytest orion/harness/tests -k prefix -q
+```
+
+Full gate before PR:
+
+```bash
+pytest orion/autonomy/tests -q
+pytest orion/schemas/tests -q
+pytest services/orion-cortex-exec/tests -q
+pytest services/orion-thought/tests -q
+pytest orion/harness/tests -q
+```
+
+---
+
+## File structure
+
+| File | Responsibility |
+|------|----------------|
+| `orion/autonomy/state_store.py` | New: Postgres read/write for latest `AutonomyStateV2` by subject |
+| `orion/autonomy/tests/test_state_store.py` | Store round-trip tests (mocked asyncpg) |
+| SQL migration (new, under `services/orion-sql-db/` per existing manual-migration convention) | `autonomy_state_v2` table DDL |
+| `services/orion-cortex-exec/app/chat_stance.py` | `_run_autonomy_reducer()` reads/writes via the store |
+| `orion/schemas/thought.py` | New `AutonomySliceV1` model + `ThoughtEventV1.autonomy_slice` field |
+| `services/orion-cortex-exec/app/autonomy_slice.py` | New: `build_autonomy_slice(ctx)` — mirrors `grounding_capsule.py` |
+| `services/orion-cortex-exec/app/router.py` | Set `ctx["autonomy_slice"]` + `metadata["autonomy_slice"]`, mirroring lines 1358-1367 / 1557-1558 |
+| `orion/cognition/prompts/stance_react.j2` | New `{% if autonomy_slice %}` block + new `{% if chat_attention_frame %}` block |
+| `orion/thought/stance_react.py` | Defensive `raw.pop("autonomy_slice", None)`, mirroring line 183 |
+| `services/orion-thought/app/bus_listener.py` | `_extract_autonomy_slice(exec_result)` + `model_copy` attach, mirroring `_extract_grounding_capsule` |
+| `orion/harness/prefix.py` | `_format_autonomy_slice()`, `_format_attention_frame()`, wired into `compile_harness_prefix()` |
+| `.env_example` (whichever service owns the new DSN) | New env key if a dedicated connection is used |
+| tests across the above | Round-trip, render, non-regression |
+
+Build order: store → schema field → cortex-exec builder + wiring → template blocks → orion-thought extraction → harness formatters → attention-frame relocation → full gate.
+
+---
+
+### Task 1: AutonomyStateV2 Postgres store
+
+**Files:**
+- Create: `orion/autonomy/state_store.py`
+- Create: `orion/autonomy/tests/test_state_store.py`
+- Create: SQL migration for `autonomy_state_v2` table (columns: `subject text primary key`, `state jsonb`, `updated_at timestamptz`)
+
+- [ ] **Step 1:** Decide the DSN home — check whether `RECALL_PG_DSN` or the existing action-outcomes shared Postgres connection is reusable before provisioning a new one. Reuse if the table can live there without schema collision risk; otherwise add a dedicated env key.
+- [ ] **Step 2:** Write failing tests in `test_state_store.py` for `load_autonomy_state_v2(subject) -> AutonomyStateV2 | None` and `save_autonomy_state_v2(subject, state: AutonomyStateV2) -> None`, mocked asyncpg connection, asserting the round-trip shape.
+- [ ] **Step 3:** Run tests, confirm `ModuleNotFoundError`.
+- [ ] **Step 4:** Implement `state_store.py` (asyncpg, upsert-on-write, same connection-pool convention as `orion/autonomy/action_outcomes.py`'s SQL path).
+- [ ] **Step 5:** Write the SQL migration, following `services/orion-sql-db/manual_migration_memory_consolidation_v1.sql`'s naming/structure convention.
+- [ ] **Step 6:** Run tests, confirm PASS.
+- [ ] **Step 7:** Commit.
+
+---
+
+### Task 2: Wire persistence into the reducer
+
+**Files:**
+- Modify: `services/orion-cortex-exec/app/chat_stance.py` (`_run_autonomy_reducer`, ~line 2179)
+
+- [ ] **Step 1:** Before calling `reduce_autonomy_state`, attempt `load_autonomy_state_v2(subject)`; if present, this becomes `previous_state` for the reducer input **instead of** the V1/graph-loaded state (the V1 baseline stays the fallback for the first-ever turn for a subject, where no persisted V2 state exists yet).
+- [ ] **Step 2:** After `reduce_autonomy_state` returns, call `save_autonomy_state_v2(subject, result.state)`. Fail-open: log and continue on write failure, never block the turn (matches the existing `autonomy_reducer_v2_failed` try/except pattern already wrapping this call).
+- [ ] **Step 3:** Write a test asserting: two sequential calls to `_run_autonomy_reducer` with different evidence, same subject, produce a second call whose `previous_state` matches the first call's `result.state` (not the V1 baseline). This is the core "non-amnesiac" acceptance check.
+- [ ] **Step 4:** Run `pytest services/orion-cortex-exec/tests -k autonomy_reducer -q`, confirm PASS.
+- [ ] **Step 5:** Commit.
+
+---
+
+### Task 3: `AutonomySliceV1` schema
+
+**Files:**
+- Modify: `orion/schemas/thought.py`
+- Modify/create: `orion/schemas/tests/test_thought.py`
+
+- [ ] **Step 1:** Add:
+
+```python
+class AutonomySliceV1(BaseModel):
+    schema_version: Literal["autonomy.slice.v1"] = "autonomy.slice.v1"
+    dominant_drive: str | None = None
+    active_tensions: list[str] = Field(default_factory=list)
+    pressure_trend: str | None = None
+    confidence: float | None = None
+```
+
+  Add `autonomy_slice: AutonomySliceV1 | None = None` to `ThoughtEventV1`, placed near `grounding_capsule` (same "attached post-hoc, not LLM-required" treatment).
+- [ ] **Step 2:** Test: `ThoughtEventV1` still validates with `autonomy_slice` omitted (back-compat with existing fixtures/tests that construct `ThoughtEventV1` without it).
+- [ ] **Step 3:** Run `pytest orion/schemas/tests -k thought -q`, confirm PASS.
+- [ ] **Step 4:** Commit.
+
+---
+
+### Task 4: `autonomy_slice.py` builder + ctx/metadata wiring
+
+**Files:**
+- Create: `services/orion-cortex-exec/app/autonomy_slice.py`
+- Modify: `services/orion-cortex-exec/app/router.py`
+
+- [ ] **Step 1:** In `autonomy_slice.py`, mirror `grounding_capsule.py`'s shape exactly:
+
+```python
+def build_autonomy_slice(ctx: Dict[str, Any]) -> AutonomySliceV1 | None:
+    """Assemble the compact slice from the V2 reducer output already in ctx.
+
+    Returns None (omit, not empty) when the reducer produced no meaningful
+    signal — never fabricates a dominant_drive or tension."""
+```
+
+  Read from `ctx["chat_autonomy_state_v2"]` / `ctx["chat_autonomy_state_delta"]` (already populated by `_run_autonomy_reducer` per the existing wiring at `chat_stance.py:2307-2308`). Omit-when-empty.
+- [ ] **Step 2:** In `router.py`, mirror lines 1358-1367 / 1557-1558: after the autonomy reducer runs, set `ctx["autonomy_slice"] = slice.model_dump(mode="json")` if not None, and mirror it into `metadata["autonomy_slice"]` at the same point `grounding_capsule` is copied into metadata.
+- [ ] **Step 3:** Test: given a `ctx` with populated `chat_autonomy_state_v2`, `build_autonomy_slice` returns a slice with the right dominant_drive/tensions; given empty/absent state, returns `None`.
+- [ ] **Step 4:** Run tests, confirm PASS.
+- [ ] **Step 5:** Commit.
+
+---
+
+### Task 5: `stance_react.j2` — autonomy_slice block
+
+**Files:**
+- Modify: `orion/cognition/prompts/stance_react.j2`
+
+- [ ] **Step 1:** Add a block styled exactly like the existing `{% if mind_coloring %}` block (lines 22-35): named sub-fields, "advisory — reconcile, do not obey," explicit instruction on how it should bias `imperative`/`tone`/`response_priorities`, and the same "does not add output keys" guard.
+
+```jinja
+{% if autonomy_slice %}
+PRIOR SELF-SIGNAL (advisory — Oríon's own current drive/tension state)
+- This reflects Oríon's own persisted autonomy state, computed before this turn.
+- Use it to color imperative/tone; it is NOT task instruction and never overrides
+  user_message, association, grounding, or the actual task.
+- It does not add output keys — still emit only valid ThoughtEventV1.
+- dominant_drive: {{ autonomy_slice.dominant_drive }}
+- active_tensions: {{ autonomy_slice.active_tensions }}
+- pressure_trend: {{ autonomy_slice.pressure_trend }}
+{% endif %}
+```
+- [ ] **Step 2:** Manual/inspectable check: trigger a live turn with V2 signal present, confirm the rendered prompt (via existing grammar-step logging) contains the block with real values.
+- [ ] **Step 3:** Commit.
+
+---
+
+### Task 6: `orion-thought` extraction + attach
+
+**Files:**
+- Modify: `orion/thought/stance_react.py`
+- Modify: `services/orion-thought/app/bus_listener.py`
+
+- [ ] **Step 1:** In `orion/thought/stance_react.py`, add `raw.pop("autonomy_slice", None)` alongside the existing `raw.pop("grounding_capsule", None)` (line 183) — defensive, discards anything the LLM invents under that key.
+- [ ] **Step 2:** In `bus_listener.py`, add `_extract_autonomy_slice(exec_result)`, mirroring `_extract_grounding_capsule` exactly (reads `metadata["autonomy_slice"]`, validates against `AutonomySliceV1`, warns+returns `None` on parse failure).
+- [ ] **Step 3:** In `run_stance_react`, after the existing `capsule = _extract_grounding_capsule(exec_result)` / `model_copy` block, add the same for autonomy: `slice_ = _extract_autonomy_slice(exec_result); if slice_ is not None: enriched = enriched.model_copy(update={"autonomy_slice": slice_})`.
+- [ ] **Step 4:** Test: `run_stance_react` with a mocked `exec_result` containing `metadata.autonomy_slice` produces a `ThoughtEventV1` with that field populated; missing/malformed metadata produces `None` without raising.
+- [ ] **Step 5:** Run `pytest services/orion-thought/tests -k stance_react -q`, confirm PASS.
+- [ ] **Step 6:** Commit.
+
+---
+
+### Task 7: Harness prefix — autonomy_slice
+
+**Files:**
+- Modify: `orion/harness/prefix.py`
+
+- [ ] **Step 1:** Add `_format_autonomy_slice(sl: AutonomySliceV1) -> list[str]`, mirroring `_format_stance_slice`'s shape (dominant_drive / active_tensions / pressure_trend lines, only emitted when non-empty).
+- [ ] **Step 2:** In `compile_harness_prefix()`, after `parts.extend(_format_stance_slice(...))`, add: `if thought.autonomy_slice is not None: parts.extend(_format_autonomy_slice(thought.autonomy_slice))`.
+- [ ] **Step 3:** Test: `compile_harness_prefix` output contains the autonomy lines when `thought.autonomy_slice` is set, and is unchanged (byte-identical) when it's `None` (non-regression for existing harness-prefix tests).
+- [ ] **Step 4:** Run `pytest orion/harness/tests -k prefix -q`, confirm PASS.
+- [ ] **Step 5:** Commit.
+
+---
+
+### Task 8: Relocate attention-frame to Lane B (template-only)
+
+**Files:**
+- Modify: `orion/cognition/prompts/stance_react.j2`
+- Modify: `orion/harness/prefix.py`
+
+- [ ] **Step 1:** Add `{% if chat_attention_frame %}` to `stance_react.j2`, adapted from `chat_stance_brief.j2:23-24,62-65`'s content/instructions but in `stance_react.j2`'s house style (matching the `mind_coloring`/`autonomy_slice` block format). No code changes needed — `ctx["chat_attention_frame"]` is already populated by `build_chat_stance_inputs` today when `ORION_CURIOSITY_FRAME_ENABLED=true`.
+- [ ] **Step 2:** Add `_format_attention_frame()` to `orion/harness/prefix.py`, adapted from `chat_general.j2:26-27,47,53`'s instructions (advisory only, ask only when `selected_action.action_type == "ask"`, obey suppressions), wired into `compile_harness_prefix()` the same way as Task 7.
+- [ ] **Step 3:** Explicitly confirm `chat_stance_brief.j2` and `chat_general.j2` are untouched (diff check) — this is a relocation of the *unused* wiring's Lane-B equivalent, not a removal from Lane A.
+- [ ] **Step 4:** Commit.
+
+---
+
+### Task 9: Full gate + PR
+
+- [ ] **Step 1:** Run full test suite (see "Test commands" above).
+- [ ] **Step 2:** `python scripts/sync_local_env_from_example.py` if any `.env_example` changed (new DSN key).
+- [ ] **Step 3:** Live smoke: trigger one Hub unified-turn chat message, confirm via logs — reducer runs, state persists (second turn's previous_state check), `stance_react.j2` render contains the autonomy block, and (if a harness/FCC turn is also triggered) the harness prefix contains it too.
+- [ ] **Step 4:** Run code-review skill in a subagent; fix material findings.
+- [ ] **Step 5:** Commit, push, PR description per AGENTS.md §18 template.

--- a/docs/superpowers/pr-reports/2026-07-11-autonomy-v2-closed-loop-wiring-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-11-autonomy-v2-closed-loop-wiring-pr.md
@@ -1,0 +1,123 @@
+## Summary
+
+- AutonomyStateV2 now persists turn-to-turn (Postgres, fail-open) instead of being recomputed and discarded every turn — closes the reducer's own fold loop.
+- A compact `AutonomySliceV1` reaches two real consumers on the orion-unified path: the `stance_react` LLM prompt itself and every FCC/Claude harness system prefix. Verified end-to-end, not just computed-and-dropped.
+- Relocated the never-enabled curiosity/attention-frame prompt injection from Lane A (`chat_general`, untouched) to Lane B (`stance_react.j2`) — template-only, no detector changes.
+- Code review (8-angle) found the prompt-injection half was dead on arrival due to a cross-wave timing bug; fixed directly along with two more correctness bugs and a CLAUDE.md "keyword cathedral" violation.
+- Converted the `_run_autonomy_reducer` → `build_chat_stance_inputs` → `prepare_brain_reply_context`/`ensure_chat_stance_pipeline_ctx` call chain to async so the new Postgres calls run via `asyncio.to_thread` instead of blocking the event loop on every chat turn.
+
+## Outcome moved
+
+`AutonomyStateV2` — Orion's own drive/tension appraisal — now actually reaches things that shape behavior: the stance-decision LLM prompt and every harness/agentic system prefix, with real persisted memory across turns. Previously it was fully computed but unreachable by any consumer.
+
+## Current architecture
+
+Before this PR: `AUTONOMY_STATE_V2_REDUCER_ENABLED=true` ran the reducer every turn, but `previous_state` always came from the V1/graph baseline (never its own prior output), and the result only reached a Hub UI debug preview (`router.py`'s `autonomy_state_v2_preview`) — no prompt or harness consumer read it. `chat_general`/Lane A had its own (also-dead) curiosity-frame wiring; Lane B (`stance_react`) had none.
+
+## Architecture touched
+
+- `orion/autonomy/` — new Postgres-backed state store
+- `orion/schemas/thought.py` — new `AutonomySliceV1`, `ThoughtEventV1.autonomy_slice`
+- `services/orion-cortex-exec/app/` — reducer persistence wiring, `autonomy_slice.py` builder, async conversion of the stance-context prep chain
+- `orion/cognition/prompts/stance_react.j2`, `orion/harness/prefix.py` — the two real consumers
+- `orion/thought/`, `services/orion-thought/app/bus_listener.py` — cross-service extraction/attach (cortex-exec → orion-thought)
+- `services/orion-sql-db/` — new manual migration
+
+## Files changed
+
+- `orion/autonomy/state_store.py`: new — `load_autonomy_state_v2`/`save_autonomy_state_v2`, mirrors `action_outcomes.py`'s SQLAlchemy convention, fail-open
+- `services/orion-sql-db/manual_migration_autonomy_state_v2.sql`: new — `autonomy_state_v2` table (subject PK, jsonb state, updated_at)
+- `orion/schemas/thought.py`: new `AutonomySliceV1` model + `ThoughtEventV1.autonomy_slice` field (optional, back-compatible)
+- `services/orion-cortex-exec/app/autonomy_slice.py`: new — `build_autonomy_slice(ctx)`, mirrors `grounding_capsule.py`'s shape, omit-when-empty
+- `services/orion-cortex-exec/app/chat_stance.py`: `_run_autonomy_reducer` reads/writes the store (via `asyncio.to_thread`), builds `chat_autonomy_movement_debug` from the actual `previous_state` used (not a separately-read baseline), sets `ctx["autonomy_slice"]` before the LLM step renders; `build_chat_stance_inputs` now `async def`
+- `services/orion-cortex-exec/app/executor.py`: `prepare_brain_reply_context`/`ensure_chat_stance_pipeline_ctx` now `async def`, 2 call sites `await`
+- `services/orion-cortex-exec/app/router.py`: removed the post-hoc (too-late) `autonomy_slice` compute; kept the metadata-attach; 2 call sites `await`
+- `orion/cognition/prompts/stance_react.j2`: new `{% if autonomy_slice %}` and `{% if chat_attention_frame %}` blocks, mirroring the existing `mind_coloring` block's advisory framing
+- `orion/harness/prefix.py`: new `_format_autonomy_slice()`, wired into `compile_harness_prefix()`; removed a dead `attention_frame` parameter added earlier in this branch (zero live caller, flagged by review, stripped per operator decision)
+- `orion/thought/stance_react.py`, `services/orion-thought/app/bus_listener.py`: `_extract_autonomy_slice`, mirrors `_extract_grounding_capsule` exactly
+- 14 test files updated for the async conversion (sync mocks → `AsyncMock`, `def test_` → `async def test_` + `@pytest.mark.asyncio` where they call the converted functions)
+- 3 new test files: `orion/autonomy/tests/test_state_store.py`, `orion/schemas/tests/test_thought.py`, `services/orion-cortex-exec/tests/test_autonomy_slice.py`
+- `docs/superpowers/plans/2026-07-11-autonomy-v2-closed-loop-wiring.md`: implementation plan (design doc is gitignored, local-only)
+
+## Schema / bus / API changes
+
+- Added: `AutonomySliceV1` schema, `ThoughtEventV1.autonomy_slice` field (optional)
+- Added: `autonomy_state_v2` Postgres table
+- No bus channel or schema-registry changes — this is a schema field + a new Postgres table, not a new event
+- Compatibility: `ThoughtEventV1` remains valid with `autonomy_slice` omitted; every existing construction site unaffected
+
+## Env/config changes
+
+- Added keys: `ORION_AUTONOMY_STATE_DB_URL` (`services/orion-cortex-exec/.env_example`)
+- `.env_example` updated: yes
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: yes (confirmed in-session)
+- skipped keys requiring operator action: none
+
+## Tests run
+
+```text
+pytest orion/autonomy/tests orion/schemas/tests orion/thought/tests orion/harness/tests -q
+  343 passed, 3 failed (pre-existing on origin/main, confirmed via clean worktree — a
+  mind_coloring StrictUndefined bug and an fcc_timeout error-string mismatch, unrelated)
+
+pytest <14 touched cortex-exec test files> -q
+  107 passed, 2 failed (pre-existing on origin/main, confirmed via same-.env in-place
+  checkout of main's files — a chat_stance._UNIFICATION_LAYER test-order interference bug)
+
+pytest services/orion-thought/tests -k stance_react -q
+  8 passed
+```
+
+New regression tests: `test_chat_stance_autonomy_v2_slice_set_before_llm_render` (ctx["autonomy_slice"] present before the LLM step renders), `test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_state` (before/after pressures compare against the same baseline), `test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_call` (non-amnesiac acceptance check).
+
+## Evals run
+
+None. This service has an existing eval harness for the V2 reducer's own math (`orion/autonomy/evals/`), but no eval was added for the new persistence/prompt/harness wiring — flagged as a known gap in code review, not addressed in this patch.
+
+## Docker/build/smoke checks
+
+Not run — Docker was not exercised in this environment for this patch. `docker compose ... config` validation and a live turn smoke (verifying the rendered `stance_react.j2` prompt and a real harness prefix both contain the autonomy block) are recommended before/after deploy — see Restart required below.
+
+## Review findings fixed
+
+8-angle code review ran twice (first pass hit a session usage limit mid-run with zero findings returned; re-ran clean after a plan upgrade).
+
+- Finding: `stance_react.j2`'s `autonomy_slice` prompt block could never render with real data — `ctx["autonomy_slice"]` was set in router.py's post-step processing, which runs strictly after the single-step `stance_react` plan's LLM call already rendered its prompt.
+  - Fix: moved `build_autonomy_slice(ctx)` + `ctx["autonomy_slice"]` assignment into `chat_stance.py`, synchronously before the LLM step (same place `chat_attention_frame` is already set).
+  - Evidence: new regression test `test_chat_stance_autonomy_v2_slice_set_before_llm_render`; traced the full call chain (`call_step_services` → `prepare_brain_reply_context` → `build_chat_stance_inputs` all run before the step's own `_render_prompt`).
+- Finding: `chat_autonomy_movement_debug`'s "before" pressures were read from `autonomy["state"]` (V1/graph baseline) while "after" came from the actual fold's `previous_state` (persisted V2 once warm) — mismatched baselines once persistence kicks in, corrupting `pressure_trend`.
+  - Fix: moved `chat_autonomy_movement_debug` construction inside `_run_autonomy_reducer`, using the same `previous_state` the fold actually used.
+  - Evidence: new regression test `test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_state`.
+- Finding: `build_autonomy_slice`'s omit-when-empty guard included `confidence is None`, but `confidence` defaults to `0.5` (always present) — empty-signal turns still produced a slice, rendering literal `"- dominant_drive: None"` into the LLM prompt.
+  - Fix: excluded `confidence` from the emptiness check; added per-field Jinja guards as defense in depth.
+  - Evidence: `orion/schemas/tests`, `test_autonomy_slice.py` pass; manual Jinja render check confirmed no `None`/`[]` leaks for partial slices.
+- Finding: `compile_harness_prefix()`'s `attention_frame` parameter + formatter (added earlier in this branch) had zero live callers and a docstring admitting it — CLAUDE.md "No keyword cathedrals" violation.
+  - Fix: removed per explicit operator decision; the live `stance_react.j2` half of that same task is untouched.
+  - Evidence: `orion/harness/tests` unaffected (343 passed, same 3 pre-existing failures).
+- Finding: `_run_autonomy_reducer`'s new Postgres calls ran synchronously inside an async call chain with no thread offload, despite an established `asyncio.to_thread` precedent elsewhere in this service.
+  - Fix: full async conversion of the call chain (see Files changed); calls wrapped in `asyncio.to_thread`.
+  - Evidence: 397+ tests passing after conversion, including 14 test files updated for the new async signatures.
+- 3 findings not fixed (documented, non-blocking): `state_store.py`'s duplicated `_ENGINE_CACHE` pattern vs. `action_outcomes.py` (same DSN, two pools); `_extract_autonomy_slice`/`_extract_grounding_capsule` structural duplication (candidate for a shared helper); `state_store.py`'s docstring overclaims "mirrors action_outcomes.py exactly" but omits its file-backed fallback (silent total data loss if DSN unset/migration never applied, no distinguishing log).
+
+## Restart required
+
+```bash
+# Apply the new migration to the live Postgres (conjourney) before this persists anything:
+psql "$ORION_AUTONOMY_STATE_DB_URL" -f services/orion-sql-db/manual_migration_autonomy_state_v2.sql
+
+# Restart cortex-exec (all 4 lanes share the image) and orion-thought:
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env -f services/orion-cortex-exec/docker-compose.yml up -d --build
+docker compose --env-file .env --env-file services/orion-thought/.env -f services/orion-thought/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: medium
+  Concern: no evidence the `autonomy_state_v2` migration has been applied to the live Postgres — until it is, the reducer silently falls back to the V1 baseline every turn with no distinguishing log (documented in the state_store.py docstring finding above).
+  Mitigation: run the migration command above before considering this "live." Consider adding a startup log line or health-check surfacing whether the table exists.
+- Severity: low
+  Concern: no eval added for the new persistence/prompt/harness behavior, only unit tests.
+  Mitigation: follow-up eval extending `orion/autonomy/evals/` to cover turn-to-turn state carry and prompt/prefix content, if this becomes a priority.
+- Severity: low
+  Concern: `state_store.py` lacks the file-backed degraded-mode fallback that its sibling `action_outcomes.py` has.
+  Mitigation: acceptable as-is (documented, fail-open, matches pre-existing behavior when unset) — revisit only if turn-to-turn persistence proves operationally important enough to need a degraded mode.

--- a/orion/autonomy/state_store.py
+++ b/orion/autonomy/state_store.py
@@ -1,0 +1,107 @@
+"""Postgres-backed persistence for the latest AutonomyStateV2 per subject.
+
+Closes the reducer's own fold loop: `chat_stance.py:_run_autonomy_reducer()`
+currently computes a fresh AutonomyStateV2 every turn and discards it, so
+`previous_state` always falls back to the V1/graph baseline. This module gives
+that reducer output somewhere to live between turns.
+
+Mirrors `orion/autonomy/action_outcomes.py`'s SQL connection convention
+exactly: SQLAlchemy `create_engine`, a process-level engine cache keyed by
+DB URL, and a dedicated env var naming the DSN. This is a separate table from
+the graph/Fuseki-backed homeostatic drives system -- it must not be read from
+or written to here.
+
+Both functions fail open. This store is read/written on the hot chat-turn
+path; a DB hiccup must never block or fail a turn.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from orion.autonomy.models import AutonomyStateV2
+
+logger = logging.getLogger("orion.autonomy.state_store")
+
+# Process-level engine cache keyed by database URL (SQLAlchemy engines are pooled).
+_ENGINE_CACHE: dict[str, object] = {}
+
+
+def _db_url() -> str | None:
+    url = os.getenv("ORION_AUTONOMY_STATE_DB_URL", "").strip()
+    return url or None
+
+
+def _get_engine(url: str):
+    from sqlalchemy import create_engine
+
+    engine = _ENGINE_CACHE.get(url)
+    if engine is None:
+        # setdefault keeps the cache race-free if two callers build concurrently:
+        # the first inserted engine wins and any extra is discarded.
+        engine = _ENGINE_CACHE.setdefault(url, create_engine(url, pool_pre_ping=True))
+    return engine
+
+
+def load_autonomy_state_v2(subject: str) -> AutonomyStateV2 | None:
+    """Load the most recently persisted AutonomyStateV2 for a subject.
+
+    Returns None when no DSN is configured, no row exists yet, or anything
+    goes wrong reading/parsing the row. Never raises -- callers should treat
+    None as "no persisted V2 state yet" and fall back to their own baseline.
+    """
+    url = _db_url()
+    if not url:
+        return None
+    try:
+        from sqlalchemy import text
+
+        engine = _get_engine(url)
+        query = text("SELECT state FROM autonomy_state_v2 WHERE subject = :subject")
+        with engine.connect() as conn:
+            row = conn.execute(query, {"subject": subject}).mappings().first()
+        if row is None:
+            return None
+        raw = row["state"]
+        if isinstance(raw, str):
+            raw = json.loads(raw)
+        if not isinstance(raw, dict):
+            return None
+        return AutonomyStateV2.model_validate(raw)
+    except Exception as exc:
+        logger.warning(
+            "autonomy_state_v2_load_failed subject=%s error=%s", subject, exc
+        )
+        return None
+
+
+def save_autonomy_state_v2(subject: str, state: AutonomyStateV2) -> None:
+    """Upsert the latest AutonomyStateV2 for a subject.
+
+    No-ops when no DSN is configured. Fails open on any write error: logs and
+    returns rather than raising, so a DB hiccup never blocks a chat turn.
+    """
+    url = _db_url()
+    if not url:
+        return
+    try:
+        from sqlalchemy import text
+
+        engine = _get_engine(url)
+        payload = json.dumps(state.model_dump(mode="json"))
+        query = text(
+            """
+            INSERT INTO autonomy_state_v2 (subject, state, updated_at)
+            VALUES (:subject, :state, CURRENT_TIMESTAMP)
+            ON CONFLICT (subject) DO UPDATE
+            SET state = EXCLUDED.state, updated_at = EXCLUDED.updated_at
+            """
+        )
+        with engine.begin() as conn:
+            conn.execute(query, {"subject": subject, "state": payload})
+    except Exception as exc:
+        logger.warning(
+            "autonomy_state_v2_save_failed subject=%s error=%s", subject, exc
+        )
+        return

--- a/orion/autonomy/tests/test_state_store.py
+++ b/orion/autonomy/tests/test_state_store.py
@@ -1,0 +1,126 @@
+"""Round-trip tests for the AutonomyStateV2 Postgres store.
+
+Uses an on-disk SQLite database as a stand-in for the shared Postgres store,
+mirroring `orion/autonomy/tests/test_action_outcomes_sql.py`'s convention.
+Both `load_autonomy_state_v2` and `save_autonomy_state_v2` must fail open
+(never raise) since they sit on the hot chat-turn path.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from orion.autonomy import state_store
+from orion.autonomy.models import AutonomyStateV2
+from orion.autonomy.state_store import load_autonomy_state_v2, save_autonomy_state_v2
+
+
+def _make_db(path) -> str:
+    url = f"sqlite:///{path}"
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE autonomy_state_v2 (
+                subject TEXT PRIMARY KEY,
+                state TEXT NOT NULL,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+    engine.dispose()
+    return url
+
+
+def _make_state(subject: str = "orion", dominant_drive: str | None = "curiosity") -> AutonomyStateV2:
+    return AutonomyStateV2(
+        subject=subject,
+        model_layer="cortex",
+        entity_id="orion-prime",
+        source="reducer",
+        dominant_drive=dominant_drive,
+        active_drives=["curiosity", "coherence"],
+        unknowns=["whether juniper is asleep"],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_engine_cache():
+    state_store._ENGINE_CACHE.clear()
+    yield
+    state_store._ENGINE_CACHE.clear()
+
+
+def test_load_returns_none_when_db_url_unset(monkeypatch) -> None:
+    monkeypatch.delenv("ORION_AUTONOMY_STATE_DB_URL", raising=False)
+    assert load_autonomy_state_v2(subject="orion") is None
+
+
+def test_save_is_noop_when_db_url_unset(monkeypatch) -> None:
+    monkeypatch.delenv("ORION_AUTONOMY_STATE_DB_URL", raising=False)
+    # Must not raise even though there's nowhere to write.
+    save_autonomy_state_v2(subject="orion", state=_make_state())
+
+
+def test_round_trip_save_then_load(tmp_path, monkeypatch) -> None:
+    url = _make_db(tmp_path / "autonomy_state.db")
+    monkeypatch.setenv("ORION_AUTONOMY_STATE_DB_URL", url)
+
+    state = _make_state(subject="orion", dominant_drive="curiosity")
+    save_autonomy_state_v2(subject="orion", state=state)
+
+    loaded = load_autonomy_state_v2(subject="orion")
+    assert loaded is not None
+    assert loaded.subject == "orion"
+    assert loaded.dominant_drive == "curiosity"
+    assert loaded.active_drives == ["curiosity", "coherence"]
+    assert loaded.unknowns == ["whether juniper is asleep"]
+    assert loaded.schema_version == "autonomy.state.v2"
+
+
+def test_save_upserts_existing_subject(tmp_path, monkeypatch) -> None:
+    url = _make_db(tmp_path / "autonomy_state.db")
+    monkeypatch.setenv("ORION_AUTONOMY_STATE_DB_URL", url)
+
+    save_autonomy_state_v2(subject="orion", state=_make_state(dominant_drive="curiosity"))
+    save_autonomy_state_v2(subject="orion", state=_make_state(dominant_drive="coherence"))
+
+    loaded = load_autonomy_state_v2(subject="orion")
+    assert loaded is not None
+    assert loaded.dominant_drive == "coherence"
+
+    engine = create_engine(url)
+    with engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM autonomy_state_v2")).scalar()
+    engine.dispose()
+    assert count == 1
+
+
+def test_round_trip_is_subject_scoped(tmp_path, monkeypatch) -> None:
+    url = _make_db(tmp_path / "autonomy_state.db")
+    monkeypatch.setenv("ORION_AUTONOMY_STATE_DB_URL", url)
+
+    save_autonomy_state_v2(subject="orion", state=_make_state(subject="orion", dominant_drive="curiosity"))
+    save_autonomy_state_v2(subject="juniper", state=_make_state(subject="juniper", dominant_drive="coherence"))
+
+    assert load_autonomy_state_v2(subject="orion").dominant_drive == "curiosity"
+    assert load_autonomy_state_v2(subject="juniper").dominant_drive == "coherence"
+
+
+def test_load_returns_none_for_missing_subject(tmp_path, monkeypatch) -> None:
+    url = _make_db(tmp_path / "autonomy_state.db")
+    monkeypatch.setenv("ORION_AUTONOMY_STATE_DB_URL", url)
+
+    assert load_autonomy_state_v2(subject="nobody") is None
+
+
+def test_load_fails_open_on_connection_error(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ORION_AUTONOMY_STATE_DB_URL", f"sqlite:///{tmp_path / 'missing_table.db'}")
+    # DB exists but has no autonomy_state_v2 table -> read raises internally -> None.
+    assert load_autonomy_state_v2(subject="orion") is None
+
+
+def test_save_fails_open_on_connection_error(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ORION_AUTONOMY_STATE_DB_URL", f"sqlite:///{tmp_path / 'missing_table.db'}")
+    # DB exists but has no autonomy_state_v2 table -> write raises internally -> swallowed.
+    save_autonomy_state_v2(subject="orion", state=_make_state())

--- a/orion/cognition/prompts/stance_react.j2
+++ b/orion/cognition/prompts/stance_react.j2
@@ -54,10 +54,10 @@ PRIOR SELF-SIGNAL (advisory — Oríon's own current drive/tension state)
 - Use it to color imperative/tone; it is NOT task instruction and never overrides
   user_message, association, grounding, or the actual task.
 - It does not add output keys — still emit only valid ThoughtEventV1.
-- dominant_drive: {{ autonomy_slice.dominant_drive }}
-- active_tensions: {{ autonomy_slice.active_tensions }}
-- pressure_trend: {{ autonomy_slice.pressure_trend }}
-{% endif %}
+{% if autonomy_slice.dominant_drive %}- dominant_drive: {{ autonomy_slice.dominant_drive }}
+{% endif %}{% if autonomy_slice.active_tensions %}- active_tensions: {{ autonomy_slice.active_tensions }}
+{% endif %}{% if autonomy_slice.pressure_trend %}- pressure_trend: {{ autonomy_slice.pressure_trend }}
+{% endif %}{% endif %}
 
 POSTURE ASSESSMENT (semantic inference — no keyword lists)
 - Infer interface_cost from whole-turn meaning: costly to type, read, screen-use, act, or continue interaction.

--- a/orion/cognition/prompts/stance_react.j2
+++ b/orion/cognition/prompts/stance_react.j2
@@ -33,6 +33,21 @@ PRIOR SELF-SIGNAL (advisory — from Oríon's Mind; reconcile, do not obey)
 - juniper_relevance: {{ mind_coloring.juniper_relevance }}
 - identity_salience: {{ mind_coloring.identity_salience }}
 {% endif %}
+{% if chat_attention_frame %}
+ATTENTION FRAME (advisory — inspectable curiosity/attention policy, not task instruction)
+- This is a deterministic policy artifact, not a request from the user or from Oríon's own voice.
+- Use selected_action, suppressions, and open_loops to color response_priorities only.
+- Do not invent curiosity from scratch and never let it override user_message, association,
+  grounding, or the actual task (technical/agent/coding).
+- If selected_action.action_type is "ask", it is fine for imperative/response_priorities to
+  reflect a single situated question; otherwise (watch, defer, remember, suppress, none) do not
+  fabricate a question — proceed on the actual task.
+- Obey suppressions; they are fail-closed reasons this turn should not add curiosity.
+- It does not add output keys — still emit only valid ThoughtEventV1.
+- selected_action: {{ chat_attention_frame.selected_action }}
+- suppressions: {{ chat_attention_frame.suppressions }}
+- open_loops: {{ chat_attention_frame.open_loops }}
+{% endif %}
 
 POSTURE ASSESSMENT (semantic inference — no keyword lists)
 - Infer interface_cost from whole-turn meaning: costly to type, read, screen-use, act, or continue interaction.

--- a/orion/cognition/prompts/stance_react.j2
+++ b/orion/cognition/prompts/stance_react.j2
@@ -48,6 +48,16 @@ ATTENTION FRAME (advisory — inspectable curiosity/attention policy, not task i
 - suppressions: {{ chat_attention_frame.suppressions }}
 - open_loops: {{ chat_attention_frame.open_loops }}
 {% endif %}
+{% if autonomy_slice %}
+PRIOR SELF-SIGNAL (advisory — Oríon's own current drive/tension state)
+- This reflects Oríon's own persisted autonomy state, computed before this turn.
+- Use it to color imperative/tone; it is NOT task instruction and never overrides
+  user_message, association, grounding, or the actual task.
+- It does not add output keys — still emit only valid ThoughtEventV1.
+- dominant_drive: {{ autonomy_slice.dominant_drive }}
+- active_tensions: {{ autonomy_slice.active_tensions }}
+- pressure_trend: {{ autonomy_slice.pressure_trend }}
+{% endif %}
 
 POSTURE ASSESSMENT (semantic inference — no keyword lists)
 - Infer interface_cost from whole-turn meaning: costly to type, read, screen-use, act, or continue interaction.

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import os
-from typing import Any
 
 from orion.fcc.github_repo_context import append_github_mcp_harness_brief
 from orion.harness.operator_brief import (
     HARNESS_UNIFIED_OPERATOR_BRIEF,
     harness_motor_instruction as _stance_motor_instruction,
 )
-from orion.schemas.attention_frame import AttentionFrameV1
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import HarnessRepairOverlayV1
 from orion.schemas.thought import (
@@ -65,62 +63,6 @@ def _format_grounding_self_block(capsule: GroundingCapsuleV1) -> list[str]:
     return lines
 
 
-def _format_attention_frame(frame: AttentionFrameV1 | dict[str, Any] | None) -> list[str]:
-    """Advisory curiosity/attention policy block for harness/FCC system prompts.
-
-    Mirrors the Lane-A `chat_general.j2` instructions (advisory only, ask only when
-    `selected_action.action_type == "ask"`, obey suppressions). Deterministic policy
-    artifact — never fabricates curiosity, never overrides the actual task.
-
-    Degrades to `[]` on `None`, empty, or malformed input. Never raises: this is a
-    best-effort prompt seasoning, not a required field.
-    """
-    if not frame:
-        return []
-    try:
-        data = frame.model_dump(mode="json") if isinstance(frame, AttentionFrameV1) else dict(frame)
-    except Exception:
-        return []
-
-    selected_action = data.get("selected_action")
-    selected_action = selected_action if isinstance(selected_action, dict) else {}
-    action_type = selected_action.get("action_type")
-
-    suppressions_raw = data.get("suppressions") or []
-    suppressions = [
-        str(s.get("reason") or "").strip()
-        for s in suppressions_raw
-        if isinstance(s, dict) and s.get("reason")
-    ]
-
-    open_loops_raw = data.get("open_loops") or []
-    open_loop_descriptions = [
-        str(loop.get("description") or "").strip()
-        for loop in open_loops_raw
-        if isinstance(loop, dict) and loop.get("description")
-    ]
-
-    if not action_type and not suppressions and not open_loop_descriptions:
-        return []
-
-    lines = ["ATTENTION FRAME (advisory — inspectable curiosity/attention policy)"]
-    if open_loop_descriptions:
-        lines.append(f"Open loops: {', '.join(open_loop_descriptions[:5])}")
-    if action_type:
-        lines.append(f"Selected action: {action_type}")
-        question_text = selected_action.get("question_text")
-        if action_type == "ask" and question_text:
-            lines.append(f"Candidate question: {question_text}")
-    if suppressions:
-        lines.append(f"Suppressions (obey): {', '.join(suppressions)}")
-    lines.append(
-        "Advisory only: do not invent curiosity from scratch. Ask only when the selected "
-        "action is 'ask' (at most one situated question); otherwise proceed on the actual "
-        "task without adding a question. Obey suppressions."
-    )
-    return lines
-
-
 def harness_motor_instruction(
     *,
     thought: ThoughtEventV1,
@@ -137,16 +79,8 @@ def compile_harness_prefix(
     user_message: str = "",
     answer_contract: AnswerContract | None = None,
     workspace: str | None = None,
-    attention_frame: AttentionFrameV1 | dict[str, Any] | None = None,
 ) -> str:
-    """Deterministic fcc system prefix from stance thought + repair overlay.
-
-    `attention_frame` is optional and defaults to `None` (no-op): `ThoughtEventV1`
-    does not carry attention-frame data today (see `orion/schemas/thought.py`), so
-    this is not read off `thought`. A future caller wires it in explicitly once the
-    curiosity/attention frame is threaded through `HarnessRunRequestV1` or an
-    equivalent request-time input; until then this parameter is dead but harmless.
-    """
+    """Deterministic fcc system prefix from stance thought + repair overlay."""
     _ = answer_contract  # deprecated on unified motor path; kept for signature compat
     parts: list[str] = [HARNESS_UNIFIED_OPERATOR_BRIEF.strip()]
 
@@ -162,7 +96,6 @@ def compile_harness_prefix(
     parts.extend(_format_stance_slice(thought.stance_harness_slice))
     if thought.autonomy_slice is not None:
         parts.extend(_format_autonomy_slice(thought.autonomy_slice))
-    parts.extend(_format_attention_frame(attention_frame))
 
     if thought.strain_refs:
         parts.append(f"Strain refs: {', '.join(thought.strain_refs)}")

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -11,7 +11,12 @@ from orion.harness.operator_brief import (
 from orion.schemas.attention_frame import AttentionFrameV1
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import HarnessRepairOverlayV1
-from orion.schemas.thought import GroundingCapsuleV1, StanceHarnessSliceV1, ThoughtEventV1
+from orion.schemas.thought import (
+    AutonomySliceV1,
+    GroundingCapsuleV1,
+    StanceHarnessSliceV1,
+    ThoughtEventV1,
+)
 
 
 def _format_stance_slice(sl: StanceHarnessSliceV1) -> list[str]:
@@ -26,6 +31,19 @@ def _format_stance_slice(sl: StanceHarnessSliceV1) -> list[str]:
         lines.append(f"Response priorities: {', '.join(sl.response_priorities)}")
     if sl.response_hazards:
         lines.append(f"Response hazards: {', '.join(sl.response_hazards)}")
+    return lines
+
+
+def _format_autonomy_slice(sl: AutonomySliceV1) -> list[str]:
+    """Compact self-signal block for the harness system prefix. Only emits
+    lines for fields that are actually present -- never fabricates content."""
+    lines: list[str] = ["SELF SIGNAL (autonomy)"]
+    if sl.dominant_drive:
+        lines.append(f"Dominant drive: {sl.dominant_drive}")
+    if sl.active_tensions:
+        lines.append(f"Active tensions: {', '.join(sl.active_tensions)}")
+    if sl.pressure_trend:
+        lines.append(f"Pressure trend: {sl.pressure_trend}")
     return lines
 
 
@@ -142,6 +160,8 @@ def compile_harness_prefix(
         ]
     )
     parts.extend(_format_stance_slice(thought.stance_harness_slice))
+    if thought.autonomy_slice is not None:
+        parts.extend(_format_autonomy_slice(thought.autonomy_slice))
     parts.extend(_format_attention_frame(attention_frame))
 
     if thought.strain_refs:

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from orion.fcc.github_repo_context import append_github_mcp_harness_brief
 from orion.harness.operator_brief import (
     HARNESS_UNIFIED_OPERATOR_BRIEF,
     harness_motor_instruction as _stance_motor_instruction,
 )
+from orion.schemas.attention_frame import AttentionFrameV1
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import HarnessRepairOverlayV1
 from orion.schemas.thought import GroundingCapsuleV1, StanceHarnessSliceV1, ThoughtEventV1
@@ -45,6 +47,62 @@ def _format_grounding_self_block(capsule: GroundingCapsuleV1) -> list[str]:
     return lines
 
 
+def _format_attention_frame(frame: AttentionFrameV1 | dict[str, Any] | None) -> list[str]:
+    """Advisory curiosity/attention policy block for harness/FCC system prompts.
+
+    Mirrors the Lane-A `chat_general.j2` instructions (advisory only, ask only when
+    `selected_action.action_type == "ask"`, obey suppressions). Deterministic policy
+    artifact — never fabricates curiosity, never overrides the actual task.
+
+    Degrades to `[]` on `None`, empty, or malformed input. Never raises: this is a
+    best-effort prompt seasoning, not a required field.
+    """
+    if not frame:
+        return []
+    try:
+        data = frame.model_dump(mode="json") if isinstance(frame, AttentionFrameV1) else dict(frame)
+    except Exception:
+        return []
+
+    selected_action = data.get("selected_action")
+    selected_action = selected_action if isinstance(selected_action, dict) else {}
+    action_type = selected_action.get("action_type")
+
+    suppressions_raw = data.get("suppressions") or []
+    suppressions = [
+        str(s.get("reason") or "").strip()
+        for s in suppressions_raw
+        if isinstance(s, dict) and s.get("reason")
+    ]
+
+    open_loops_raw = data.get("open_loops") or []
+    open_loop_descriptions = [
+        str(loop.get("description") or "").strip()
+        for loop in open_loops_raw
+        if isinstance(loop, dict) and loop.get("description")
+    ]
+
+    if not action_type and not suppressions and not open_loop_descriptions:
+        return []
+
+    lines = ["ATTENTION FRAME (advisory — inspectable curiosity/attention policy)"]
+    if open_loop_descriptions:
+        lines.append(f"Open loops: {', '.join(open_loop_descriptions[:5])}")
+    if action_type:
+        lines.append(f"Selected action: {action_type}")
+        question_text = selected_action.get("question_text")
+        if action_type == "ask" and question_text:
+            lines.append(f"Candidate question: {question_text}")
+    if suppressions:
+        lines.append(f"Suppressions (obey): {', '.join(suppressions)}")
+    lines.append(
+        "Advisory only: do not invent curiosity from scratch. Ask only when the selected "
+        "action is 'ask' (at most one situated question); otherwise proceed on the actual "
+        "task without adding a question. Obey suppressions."
+    )
+    return lines
+
+
 def harness_motor_instruction(
     *,
     thought: ThoughtEventV1,
@@ -61,8 +119,16 @@ def compile_harness_prefix(
     user_message: str = "",
     answer_contract: AnswerContract | None = None,
     workspace: str | None = None,
+    attention_frame: AttentionFrameV1 | dict[str, Any] | None = None,
 ) -> str:
-    """Deterministic fcc system prefix from stance thought + repair overlay."""
+    """Deterministic fcc system prefix from stance thought + repair overlay.
+
+    `attention_frame` is optional and defaults to `None` (no-op): `ThoughtEventV1`
+    does not carry attention-frame data today (see `orion/schemas/thought.py`), so
+    this is not read off `thought`. A future caller wires it in explicitly once the
+    curiosity/attention frame is threaded through `HarnessRunRequestV1` or an
+    equivalent request-time input; until then this parameter is dead but harmless.
+    """
     _ = answer_contract  # deprecated on unified motor path; kept for signature compat
     parts: list[str] = [HARNESS_UNIFIED_OPERATOR_BRIEF.strip()]
 
@@ -76,6 +142,7 @@ def compile_harness_prefix(
         ]
     )
     parts.extend(_format_stance_slice(thought.stance_harness_slice))
+    parts.extend(_format_attention_frame(attention_frame))
 
     if thought.strain_refs:
         parts.append(f"Strain refs: {', '.join(thought.strain_refs)}")

--- a/orion/schemas/tests/test_thought.py
+++ b/orion/schemas/tests/test_thought.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.schemas.thought import AutonomySliceV1, StanceHarnessSliceV1, ThoughtEventV1
+
+
+def _base_thought(**overrides: object) -> ThoughtEventV1:
+    kwargs = dict(
+        event_id="t-1",
+        correlation_id="c-1",
+        session_id=None,
+        created_at=datetime.now(timezone.utc),
+        imperative="Stay present; one situated question.",
+        tone="warm",
+        strain_refs=["loop-1"],
+        evidence_refs=["loop-1"],
+        stance_harness_slice=StanceHarnessSliceV1(
+            task_mode="reflective_dialogue",
+            conversation_frame="reflective",
+            response_priorities=["companion_presence"],
+            answer_strategy="RelationalHoldSpace",
+        ),
+    )
+    kwargs.update(overrides)
+    return ThoughtEventV1(**kwargs)
+
+
+def test_thought_event_validates_without_autonomy_slice() -> None:
+    """Back-compat: existing constructors that omit autonomy_slice still validate."""
+    thought = _base_thought()
+    assert thought.autonomy_slice is None
+    assert thought.grounding_capsule is None
+
+
+def test_thought_event_accepts_autonomy_slice() -> None:
+    slice_ = AutonomySliceV1(
+        dominant_drive="curiosity",
+        active_tensions=["novelty_vs_stability", "autonomy_vs_connection"],
+        pressure_trend="rising",
+        confidence=0.72,
+    )
+    thought = _base_thought(autonomy_slice=slice_)
+    assert thought.autonomy_slice is not None
+    assert thought.autonomy_slice.dominant_drive == "curiosity"
+    assert thought.autonomy_slice.active_tensions == [
+        "novelty_vs_stability",
+        "autonomy_vs_connection",
+    ]
+
+
+def test_autonomy_slice_v1_defaults() -> None:
+    slice_ = AutonomySliceV1()
+    assert slice_.schema_version == "autonomy.slice.v1"
+    assert slice_.dominant_drive is None
+    assert slice_.active_tensions == []
+    assert slice_.pressure_trend is None
+    assert slice_.confidence is None
+
+
+def test_autonomy_slice_v1_round_trips_through_json() -> None:
+    slice_ = AutonomySliceV1(
+        dominant_drive="stability",
+        active_tensions=["load_vs_recovery"],
+        pressure_trend="falling",
+        confidence=0.41,
+    )
+    dumped = slice_.model_dump(mode="json")
+    assert dumped == {
+        "schema_version": "autonomy.slice.v1",
+        "dominant_drive": "stability",
+        "active_tensions": ["load_vs_recovery"],
+        "pressure_trend": "falling",
+        "confidence": 0.41,
+    }
+    restored = AutonomySliceV1.model_validate(dumped)
+    assert restored == slice_
+
+
+def test_thought_event_with_autonomy_slice_round_trips_through_json() -> None:
+    thought = _base_thought(
+        autonomy_slice=AutonomySliceV1(
+            dominant_drive="curiosity",
+            active_tensions=["novelty_vs_stability"],
+            pressure_trend="stable",
+            confidence=0.5,
+        )
+    )
+    dumped = thought.model_dump(mode="json")
+    restored = ThoughtEventV1.model_validate(dumped)
+    assert restored.autonomy_slice == thought.autonomy_slice

--- a/orion/schemas/thought.py
+++ b/orion/schemas/thought.py
@@ -54,6 +54,19 @@ class GroundingCapsuleV1(BaseModel):
     provenance: dict[str, Any] = Field(default_factory=dict)
 
 
+class AutonomySliceV1(BaseModel):
+    """Compact, post-hoc-attached projection of Orion's own current drive/tension
+    state (autonomy V2 reducer output), not authored by the LLM."""
+
+    schema_version: Literal["autonomy.slice.v1"] = "autonomy.slice.v1"
+    dominant_drive: str | None = None
+    # Compact projection, not a full evidence dump — callers should pass at
+    # most 2-3 items here (not enforced at this layer).
+    active_tensions: list[str] = Field(default_factory=list)
+    pressure_trend: str | None = None
+    confidence: float | None = None
+
+
 class ThoughtEventV1(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
@@ -78,6 +91,7 @@ class ThoughtEventV1(BaseModel):
 
     stance_harness_slice: StanceHarnessSliceV1
     grounding_capsule: GroundingCapsuleV1 | None = None
+    autonomy_slice: AutonomySliceV1 | None = None
 
     llm_profile: str = "brain"
     producer: str = "stance_react_v1"

--- a/orion/thought/stance_react.py
+++ b/orion/thought/stance_react.py
@@ -181,6 +181,10 @@ def parse_stance_react_payload(
     # on from result metadata — never authored by the stance LLM. Drop any model-supplied
     # value so a hallucinated capsule cannot masquerade as grounded self-context.
     raw.pop("grounding_capsule", None)
+    # Same treatment for the autonomy slice: it is the V2 reducer's own persisted
+    # drive/tension state, assembled deterministically in cortex-exec and mapped on
+    # from result metadata — never authored by the stance LLM.
+    raw.pop("autonomy_slice", None)
     if correlation_id:
         raw.setdefault("correlation_id", correlation_id)
     if session_id is not None:

--- a/services/orion-cortex-exec/.env_example
+++ b/services/orion-cortex-exec/.env_example
@@ -282,6 +282,12 @@ AUTONOMY_GOAL_EXECUTION_ENABLED=true
 GOAL_HINT_PRIORITY_THRESHOLD=0.4
 # AutonomyStateV2 deterministic reducer sidecar in chat stance (export ctx + router preview; default off).
 AUTONOMY_STATE_V2_REDUCER_ENABLED=
+# DSN for the autonomy_state_v2 table (see services/orion-sql-db/manual_migration_autonomy_state_v2.sql).
+# Closes the reducer's own fold loop: _run_autonomy_reducer() reads/writes the latest
+# AutonomyStateV2 per subject here instead of discarding it every turn. Same shared
+# Postgres (conjourney) as ORION_ACTION_OUTCOME_DB_URL below. Leave blank to fail open
+# (reducer falls back to the V1/graph baseline every turn, matching pre-existing behavior).
+ORION_AUTONOMY_STATE_DB_URL=postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney
 # File-backed recent action outcomes fed into autonomy reducer (max 12 per subject).
 # Fallback only; preferred read path is the shared SQL store below.
 ORION_ACTION_OUTCOME_STORE_PATH=/tmp/orion-action-outcomes.json

--- a/services/orion-cortex-exec/app/autonomy_slice.py
+++ b/services/orion-cortex-exec/app/autonomy_slice.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from orion.schemas.thought import AutonomySliceV1
+
+logger = logging.getLogger("orion.cortex.autonomy_slice")
+
+# Compact projection, not a full evidence dump: cap active_tensions hard.
+_MAX_ACTIVE_TENSIONS = 3
+# Minimum |after - before| pressure movement to call a trend rather than "stable".
+_PRESSURE_TREND_EPSILON = 0.02
+
+
+def _bounded_unique_tensions(values: Any, limit: int = _MAX_ACTIVE_TENSIONS) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    out: list[str] = []
+    for v in values:
+        text = str(v or "").strip()
+        if text and text not in out:
+            out.append(text)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _pressure_trend(movement_debug: Any) -> str | None:
+    """Cheap before/after pressure comparison from ctx['chat_autonomy_movement_debug'].
+
+    Never fabricates a trend: returns None unless both before/after pressure
+    dicts are actually present (e.g. first-ever turn for a subject has no
+    'before' pressures to compare against).
+    """
+    if not isinstance(movement_debug, dict):
+        return None
+    before = movement_debug.get("pressures_before")
+    after = movement_debug.get("pressures_after")
+    if not isinstance(before, dict) or not isinstance(after, dict):
+        return None
+    keys = set(before) | set(after)
+    if not keys:
+        return None
+    try:
+        delta_sum = sum(float(after.get(k, 0.0)) - float(before.get(k, 0.0)) for k in keys)
+    except (TypeError, ValueError):
+        return None
+    if delta_sum > _PRESSURE_TREND_EPSILON:
+        return "rising"
+    if delta_sum < -_PRESSURE_TREND_EPSILON:
+        return "falling"
+    return "stable"
+
+
+def build_autonomy_slice(ctx: Dict[str, Any]) -> AutonomySliceV1 | None:
+    """Assemble the compact slice from the V2 reducer output already in ctx.
+
+    Returns None (omit, not empty) when the reducer produced no meaningful
+    signal -- never fabricates a dominant_drive or tension.
+    """
+    state = ctx.get("chat_autonomy_state_v2")
+    if not isinstance(state, dict) or not state:
+        return None
+
+    delta = ctx.get("chat_autonomy_state_delta")
+    if not isinstance(delta, dict):
+        delta = {}
+
+    dominant_drive = str(state.get("dominant_drive") or "").strip() or None
+
+    # tension_kinds is the state's own current-tension set (same field
+    # summarize_autonomy_state() uses to derive AutonomySummaryV1.active_tensions).
+    # Falls back to this turn's newly-minted tensions if tension_kinds is absent.
+    active_tensions = _bounded_unique_tensions(state.get("tension_kinds"))
+    if not active_tensions:
+        active_tensions = _bounded_unique_tensions(delta.get("new_tensions"))
+
+    pressure_trend = _pressure_trend(ctx.get("chat_autonomy_movement_debug"))
+
+    confidence = state.get("confidence")
+    if not isinstance(confidence, (int, float)):
+        confidence = None
+
+    if dominant_drive is None and not active_tensions and pressure_trend is None and confidence is None:
+        return None
+
+    try:
+        return AutonomySliceV1(
+            dominant_drive=dominant_drive,
+            active_tensions=active_tensions,
+            pressure_trend=pressure_trend,
+            confidence=confidence,
+        )
+    except Exception:
+        logger.warning("autonomy_slice_build_failed", exc_info=True)
+        return None

--- a/services/orion-cortex-exec/app/autonomy_slice.py
+++ b/services/orion-cortex-exec/app/autonomy_slice.py
@@ -82,7 +82,12 @@ def build_autonomy_slice(ctx: Dict[str, Any]) -> AutonomySliceV1 | None:
     if not isinstance(confidence, (int, float)):
         confidence = None
 
-    if dominant_drive is None and not active_tensions and pressure_trend is None and confidence is None:
+    # confidence deliberately excluded from this check: AutonomyStateV2.confidence
+    # is a required field defaulting to 0.5, so it is present on essentially every
+    # reducer output and would defeat omit-when-empty if allowed to count as
+    # "signal" on its own -- only real content (drive/tensions/trend) justifies
+    # emitting a slice.
+    if dominant_drive is None and not active_tensions and pressure_trend is None:
         return None
 
     try:

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -2178,7 +2179,7 @@ def _reasoning_upstream_nonempty(ctx: Dict[str, Any]) -> bool:
         return False
 
 
-def _run_autonomy_reducer(
+async def _run_autonomy_reducer(
     ctx: Dict[str, Any],
     autonomy: Dict[str, Any],
     *,
@@ -2210,7 +2211,7 @@ def _run_autonomy_reducer(
     # output over the V1/graph baseline so state carries turn-to-turn. Falls
     # back to the V1 baseline exactly as before when nothing is persisted yet
     # (first-ever turn for this subject, or the store is unreachable).
-    persisted = load_autonomy_state_v2(subject)
+    persisted = await asyncio.to_thread(load_autonomy_state_v2, subject)
     previous_state = persisted if persisted is not None else state_obj
 
     # Snapshot before-pressures from the SAME baseline the fold actually uses
@@ -2254,7 +2255,7 @@ def _run_autonomy_reducer(
     # never raises, but this is a hot chat-turn path, so guard the call site
     # too rather than depend solely on the callee's contract.
     try:
-        save_autonomy_state_v2(subject, result.state)
+        await asyncio.to_thread(save_autonomy_state_v2, subject, result.state)
     except Exception as exc:
         logger.warning("autonomy_state_v2_write_failed subject=%s error=%s", subject, exc)
 
@@ -2270,7 +2271,7 @@ def _inject_prior_stance_to_inputs(ctx: Dict[str, Any], inputs: Dict[str, Any]) 
         ctx["prior_stance"] = prior
 
 
-def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
+async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
     # Single unified beliefs call replaces independent producer fan-outs for
     # identity, orionmem, recall, and social lanes.
     from app.substrate_felt_state_reader import hydrate_felt_state_ctx
@@ -2338,7 +2339,7 @@ def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
 
     if os.getenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "").strip().lower() == "true":
         try:
-            v2_result = _run_autonomy_reducer(
+            v2_result = await _run_autonomy_reducer(
                 ctx,
                 autonomy,
                 social=social,

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -50,6 +50,7 @@ from orion.substrate.relational import (
 from orion.substrate.relational.adapters.spark_ctx import map_spark_ctx_to_substrate
 
 from .attention_frame import attention_frame_enabled, build_attention_frame
+from .autonomy_slice import build_autonomy_slice
 
 from .endogenous_runtime import (
     consume_endogenous_runtime_for_reflective_review,
@@ -2212,6 +2213,18 @@ def _run_autonomy_reducer(
     persisted = load_autonomy_state_v2(subject)
     previous_state = persisted if persisted is not None else state_obj
 
+    # Snapshot before-pressures from the SAME baseline the fold actually uses
+    # (persisted V2 state when present, else the V1/graph baseline) -- not from
+    # autonomy["state"] directly, which can silently diverge from previous_state
+    # once persistence is warm and would otherwise desync movement_debug's
+    # before/after comparison from what the reducer really folded.
+    before_pressures = (
+        dict(getattr(previous_state, "drive_pressures", None) or {})
+        if previous_state is not None
+        else None
+    )
+    dominant_drive_before = getattr(previous_state, "dominant_drive", None) if previous_state is not None else None
+
     result = reduce_autonomy_state(
         AutonomyReducerInputV1(
             subject=subject,
@@ -2223,6 +2236,19 @@ def _run_autonomy_reducer(
     )
     # Single mint path: reuse what the reducer actually folded.
     ctx["chat_autonomy_tension_debug"] = {"minted": list(result.tensions_minted or [])}
+
+    # Built here (not by the caller) so before/after always compare against the
+    # SAME previous_state the fold actually used -- see before_pressures comment
+    # above for why deriving "before" from autonomy["state"] independently would
+    # silently desync once persistence is warm.
+    ctx["chat_autonomy_movement_debug"] = {
+        "dominant_drive_before": dominant_drive_before,
+        "dominant_drive_after": result.state.dominant_drive,
+        "pressures_before": before_pressures,
+        "pressures_after": dict(result.state.drive_pressures or {}),
+        "new_tensions": list(result.delta.new_tensions or []),
+        "resolved_tensions": list(result.delta.resolved_tensions or []),
+    }
 
     # Belt-and-suspenders fail-open write-back: save_autonomy_state_v2 already
     # never raises, but this is a hot chat-turn path, so guard the call site
@@ -2312,9 +2338,6 @@ def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
 
     if os.getenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "").strip().lower() == "true":
         try:
-            before_pressures = None
-            if autonomy.get("state") is not None:
-                before_pressures = dict(getattr(autonomy["state"], "drive_pressures", None) or {})
             v2_result = _run_autonomy_reducer(
                 ctx,
                 autonomy,
@@ -2322,18 +2345,22 @@ def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
                 social_bridge=social_bridge,
                 reasoning=reasoning,
             )
+            # _run_autonomy_reducer already set chat_autonomy_movement_debug on
+            # ctx itself (before/after pressures compared against the same
+            # previous_state the fold actually used); state/delta are set here.
             ctx["chat_autonomy_state_v2"] = v2_result.state.model_dump(mode="json")
             ctx["chat_autonomy_state_delta"] = v2_result.delta.model_dump(mode="json")
-            ctx["chat_autonomy_movement_debug"] = {
-                "dominant_drive_before": getattr(autonomy.get("state"), "dominant_drive", None),
-                "dominant_drive_after": v2_result.state.dominant_drive,
-                "pressures_before": before_pressures,
-                "pressures_after": dict(v2_result.state.drive_pressures or {}),
-                "new_tensions": list(v2_result.delta.new_tensions or []),
-                "resolved_tensions": list(v2_result.delta.resolved_tensions or []),
-            }
             inputs["autonomy"]["state_v2"] = ctx["chat_autonomy_state_v2"]
             inputs["autonomy"]["delta"] = ctx["chat_autonomy_state_delta"]
+
+            # Built here (ctx key "autonomy_slice", matching what stance_react.j2
+            # reads directly) so it's present BEFORE the stance_react LLM step
+            # renders its prompt. router.py's post-hoc metadata attach (for the
+            # harness-prefix/ThoughtEventV1 path) reads this same ctx key later
+            # in the same turn -- it does not need to recompute it.
+            autonomy_slice = build_autonomy_slice(ctx)
+            if autonomy_slice is not None:
+                ctx["autonomy_slice"] = autonomy_slice.model_dump(mode="json")
         except Exception as exc:
             logger.warning("autonomy_reducer_v2_failed error=%s", exc)
 

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -18,6 +18,7 @@ from orion.autonomy.graph_gate import (
     resolve_autonomy_graph_read_plan,
 )
 from orion.autonomy.reducer import AutonomyReducerInputV1, reduce_autonomy_state
+from orion.autonomy.state_store import load_autonomy_state_v2, save_autonomy_state_v2
 from orion.autonomy.summary import summarize_autonomy_lookup, summarize_autonomy_state
 from orion.autonomy.repository import (
     AutonomyLookupV1,
@@ -2203,10 +2204,18 @@ def _run_autonomy_reducer(
     state_obj = autonomy.get("state")
     subj = getattr(state_obj, "subject", None) if state_obj is not None else None
     subject = str(subj or "orion")
+
+    # Close the reducer's own fold loop: prefer the reducer's own persisted
+    # output over the V1/graph baseline so state carries turn-to-turn. Falls
+    # back to the V1 baseline exactly as before when nothing is persisted yet
+    # (first-ever turn for this subject, or the store is unreachable).
+    persisted = load_autonomy_state_v2(subject)
+    previous_state = persisted if persisted is not None else state_obj
+
     result = reduce_autonomy_state(
         AutonomyReducerInputV1(
             subject=subject,
-            previous_state=state_obj,
+            previous_state=previous_state,
             evidence=compile_result.evidence,
             action_outcomes=load_action_outcomes(subject=subject),
             now=now,
@@ -2214,6 +2223,15 @@ def _run_autonomy_reducer(
     )
     # Single mint path: reuse what the reducer actually folded.
     ctx["chat_autonomy_tension_debug"] = {"minted": list(result.tensions_minted or [])}
+
+    # Belt-and-suspenders fail-open write-back: save_autonomy_state_v2 already
+    # never raises, but this is a hot chat-turn path, so guard the call site
+    # too rather than depend solely on the callee's contract.
+    try:
+        save_autonomy_state_v2(subject, result.state)
+    except Exception as exc:
+        logger.warning("autonomy_state_v2_write_failed subject=%s error=%s", subject, exc)
+
     return result
 
 

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -2683,10 +2683,10 @@ async def call_step_services(
         ctx["prior_step_results"] = list(scoped_list)
 
     if _should_prepare_brain_reply_context(step=step, ctx=ctx):
-        prepare_brain_reply_context(ctx)
+        await prepare_brain_reply_context(ctx)
 
     if str(step.verb_name or "") == "chat_general" and str(step.step_name or "") == "synthesize_chat_stance_brief":
-        ensure_chat_stance_pipeline_ctx(ctx)
+        await ensure_chat_stance_pipeline_ctx(ctx)
 
     # Skill YAMLs may list services: [] while the work is implemented as local verb_adapters.
     # Without this branch the service loop runs zero times and final_text assembly sees no candidates.
@@ -4507,7 +4507,7 @@ async def call_step_services(
     )
 
 
-def ensure_chat_stance_pipeline_ctx(ctx: Dict[str, Any]) -> None:
+async def ensure_chat_stance_pipeline_ctx(ctx: Dict[str, Any]) -> None:
     """Populate identity kernel and chat_stance_inputs for chat_general stance synthesis in any exec mode.
 
     Brain-lane uses prepare_brain_reply_context first; this path covers agent (and other) modes where
@@ -4517,7 +4517,7 @@ def ensure_chat_stance_pipeline_ctx(ctx: Dict[str, Any]) -> None:
     if isinstance(existing, dict) and "identity" in existing and "autonomy" in existing:
         return
     _inject_identity_context(ctx)
-    build_chat_stance_inputs(ctx)
+    await build_chat_stance_inputs(ctx)
 
 
 def prepare_chat_quick_reply_context(ctx: Dict[str, Any]) -> None:
@@ -4525,7 +4525,7 @@ def prepare_chat_quick_reply_context(ctx: Dict[str, Any]) -> None:
     _inject_identity_context(ctx)
 
 
-def prepare_brain_reply_context(ctx: Dict[str, Any], *, force_refresh: bool = False) -> Dict[str, Any] | None:
+async def prepare_brain_reply_context(ctx: Dict[str, Any], *, force_refresh: bool = False) -> Dict[str, Any] | None:
     """
     Canonical preparation hook for brain-lane reply context.
     Ensures identity and stance/autonomy inputs are available for downstream reply verbs,
@@ -4538,7 +4538,7 @@ def prepare_brain_reply_context(ctx: Dict[str, Any], *, force_refresh: bool = Fa
         return ctx.get("chat_stance_inputs")
 
     _inject_identity_context(ctx)
-    stance_inputs = build_chat_stance_inputs(ctx)
+    stance_inputs = await build_chat_stance_inputs(ctx)
     logger.info(
         "chat_stance_inputs_ready has_identity_keys=%s orion_count=%s juniper_count=%s policy_count=%s",
         sorted(list((stance_inputs.get("identity") or {}).keys())),

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -16,7 +16,6 @@ from .executor import (
     prepare_chat_quick_reply_context,
     run_recall_step,
 )
-from .autonomy_slice import build_autonomy_slice
 from .grounding_capsule import assemble_stance_grounding
 from .pcr_chat_memory import CONTINUITY_PROFILE, run_pcr_phase0_and_1, run_pcr_phase3
 from .situation import mark_orion_turn
@@ -1366,15 +1365,6 @@ class PlanRunner:
                 )
                 if grounding_capsule is not None:
                     ctx["grounding_capsule"] = grounding_capsule.model_dump(mode="json")
-
-            if (
-                str(plan.verb_name or "").strip().lower() == "stance_react"
-                and step.step_name == "llm_stance_react"
-                and step_res.status == "success"
-            ):
-                autonomy_slice = build_autonomy_slice(ctx)
-                if autonomy_slice is not None:
-                    ctx["autonomy_slice"] = autonomy_slice.model_dump(mode="json")
 
             if step_res.status != "success":
                 overall_status = "partial" if len(step_results) > 1 else "fail"

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -985,7 +985,7 @@ class PlanRunner:
                 opts_now = ctx.get("options") if isinstance(ctx.get("options"), dict) else {}
                 hub_full = bool(opts_now.get("chat_quick_full_stance"))
                 if hub_full:
-                    prepare_brain_reply_context(ctx)
+                    await prepare_brain_reply_context(ctx)
                 else:
                     prepare_chat_quick_reply_context(ctx)
             elif verb_lc == "chat_kids_story":
@@ -1001,7 +1001,7 @@ class PlanRunner:
                     plan.verb_name,
                 )
             else:
-                prepare_brain_reply_context(ctx)
+                await prepare_brain_reply_context(ctx)
         existing_scope = str(ctx.get("_run_scope_corr_id") or "")
         if existing_scope and existing_scope != correlation_id:
             logger.warning(

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -16,6 +16,7 @@ from .executor import (
     prepare_chat_quick_reply_context,
     run_recall_step,
 )
+from .autonomy_slice import build_autonomy_slice
 from .grounding_capsule import assemble_stance_grounding
 from .pcr_chat_memory import CONTINUITY_PROFILE, run_pcr_phase0_and_1, run_pcr_phase3
 from .situation import mark_orion_turn
@@ -1366,6 +1367,15 @@ class PlanRunner:
                 if grounding_capsule is not None:
                     ctx["grounding_capsule"] = grounding_capsule.model_dump(mode="json")
 
+            if (
+                str(plan.verb_name or "").strip().lower() == "stance_react"
+                and step.step_name == "llm_stance_react"
+                and step_res.status == "success"
+            ):
+                autonomy_slice = build_autonomy_slice(ctx)
+                if autonomy_slice is not None:
+                    ctx["autonomy_slice"] = autonomy_slice.model_dump(mode="json")
+
             if step_res.status != "success":
                 overall_status = "partial" if len(step_results) > 1 else "fail"
                 break
@@ -1556,6 +1566,8 @@ class PlanRunner:
                 metadata["structured_rejection_preview"] = str(final_text_diag["structured_rejection_preview"])[:500]
         if isinstance(ctx.get("grounding_capsule"), dict):
             metadata["grounding_capsule"] = ctx["grounding_capsule"]
+        if isinstance(ctx.get("autonomy_slice"), dict):
+            metadata["autonomy_slice"] = ctx["autonomy_slice"]
         mark_orion_turn(str(ctx.get("session_id") or "global"))
 
         record_assembled_grammar(

--- a/services/orion-cortex-exec/tests/test_attention_frame_integration.py
+++ b/services/orion-cortex-exec/tests/test_attention_frame_integration.py
@@ -2,24 +2,28 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from app.chat_stance import build_chat_stance_debug_payload, build_chat_stance_inputs
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-def test_feature_flag_off_preserves_chat_stance_input_shape(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_feature_flag_off_preserves_chat_stance_input_shape(monkeypatch) -> None:
     monkeypatch.delenv("ORION_CURIOSITY_FRAME_ENABLED", raising=False)
     ctx = {"user_message": "I am planning around Zephyr Bridge.", "skip_unified_beliefs": True}
-    built = build_chat_stance_inputs(ctx)
+    built = await build_chat_stance_inputs(ctx)
     assert "attention_frame" not in built
     assert "chat_attention_frame" not in ctx
 
 
-def test_feature_flag_on_adds_attention_frame(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_feature_flag_on_adds_attention_frame(monkeypatch) -> None:
     monkeypatch.setenv("ORION_CURIOSITY_FRAME_ENABLED", "true")
     ctx = {"user_message": "I am planning around Zephyr Bridge.", "skip_unified_beliefs": True}
-    built = build_chat_stance_inputs(ctx)
+    built = await build_chat_stance_inputs(ctx)
     assert "attention_frame" in built
     assert ctx["chat_attention_frame"]["schema_version"] == "attention.frame.v1"
     assert built["attention_frame"]["open_loops"]

--- a/services/orion-cortex-exec/tests/test_autonomy_slice.py
+++ b/services/orion-cortex-exec/tests/test_autonomy_slice.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from app.autonomy_slice import build_autonomy_slice
+from orion.autonomy.models import AutonomyStateDeltaV1, AutonomyStateV2
+
+
+def _state_v2(**overrides) -> dict:
+    base = dict(
+        subject="orion",
+        model_layer="graph",
+        entity_id="orion",
+        dominant_drive="coherence",
+        active_drives=["coherence", "continuity"],
+        drive_pressures={"coherence": 0.72, "continuity": 0.41},
+        tension_kinds=["drive_competition.coherence_continuity", "unresolved_thread", "identity_drift"],
+        goal_headlines=[],
+        source="reducer",
+        confidence=0.63,
+    )
+    base.update(overrides)
+    return AutonomyStateV2.model_validate(base).model_dump(mode="json")
+
+
+def _delta(**overrides) -> dict:
+    base = dict(subject="orion", new_tensions=["fresh_tension"], resolved_tensions=[])
+    base.update(overrides)
+    return AutonomyStateDeltaV1.model_validate(base).model_dump(mode="json")
+
+
+def test_build_autonomy_slice_from_populated_state() -> None:
+    ctx = {
+        "chat_autonomy_state_v2": _state_v2(),
+        "chat_autonomy_state_delta": _delta(),
+        "chat_autonomy_movement_debug": {
+            "pressures_before": {"coherence": 0.5, "continuity": 0.4},
+            "pressures_after": {"coherence": 0.72, "continuity": 0.41},
+        },
+    }
+    slice_ = build_autonomy_slice(ctx)
+    assert slice_ is not None
+    assert slice_.schema_version == "autonomy.slice.v1"
+    assert slice_.dominant_drive == "coherence"
+    # tension_kinds has 3 entries; must be capped, never exceed 3.
+    assert slice_.active_tensions == [
+        "drive_competition.coherence_continuity",
+        "unresolved_thread",
+        "identity_drift",
+    ]
+    assert len(slice_.active_tensions) <= 3
+    assert slice_.pressure_trend == "rising"
+    assert slice_.confidence == 0.63
+
+
+def test_active_tensions_hard_capped_at_three_even_with_more_tension_kinds() -> None:
+    ctx = {
+        "chat_autonomy_state_v2": _state_v2(
+            tension_kinds=["a", "b", "c", "d", "e"],
+        ),
+    }
+    slice_ = build_autonomy_slice(ctx)
+    assert slice_ is not None
+    assert slice_.active_tensions == ["a", "b", "c"]
+
+
+def test_falls_back_to_delta_new_tensions_when_tension_kinds_empty() -> None:
+    ctx = {
+        "chat_autonomy_state_v2": _state_v2(tension_kinds=[], dominant_drive=None),
+        "chat_autonomy_state_delta": _delta(new_tensions=["just_minted"]),
+    }
+    slice_ = build_autonomy_slice(ctx)
+    assert slice_ is not None
+    assert slice_.active_tensions == ["just_minted"]
+
+
+def test_pressure_trend_none_when_before_pressures_missing_first_turn() -> None:
+    ctx = {
+        "chat_autonomy_state_v2": _state_v2(),
+        "chat_autonomy_movement_debug": {
+            "pressures_before": None,
+            "pressures_after": {"coherence": 0.72},
+        },
+    }
+    slice_ = build_autonomy_slice(ctx)
+    assert slice_ is not None
+    assert slice_.pressure_trend is None
+
+
+def test_pressure_trend_stable_when_movement_below_epsilon() -> None:
+    ctx = {
+        "chat_autonomy_state_v2": _state_v2(),
+        "chat_autonomy_movement_debug": {
+            "pressures_before": {"coherence": 0.72, "continuity": 0.41},
+            "pressures_after": {"coherence": 0.725, "continuity": 0.405},
+        },
+    }
+    slice_ = build_autonomy_slice(ctx)
+    assert slice_ is not None
+    assert slice_.pressure_trend == "stable"
+
+
+def test_returns_none_when_state_absent() -> None:
+    assert build_autonomy_slice({}) is None
+    assert build_autonomy_slice({"chat_autonomy_state_v2": None}) is None
+    assert build_autonomy_slice({"chat_autonomy_state_v2": {}}) is None
+
+
+def test_returns_none_when_state_present_but_no_meaningful_signal() -> None:
+    # dominant_drive/tensions empty; confidence explicitly None (not the model's
+    # own 0.5 default) to exercise the true all-empty branch.
+    ctx = {
+        "chat_autonomy_state_v2": {
+            "subject": "orion",
+            "dominant_drive": None,
+            "tension_kinds": [],
+            "confidence": None,
+        },
+    }
+    assert build_autonomy_slice(ctx) is None
+
+
+def test_does_not_raise_on_malformed_ctx() -> None:
+    assert build_autonomy_slice({"chat_autonomy_state_v2": "not-a-dict"}) is None
+    assert build_autonomy_slice({"chat_autonomy_state_v2": _state_v2(), "chat_autonomy_movement_debug": "garbage"}) is not None

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_plumbing.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_plumbing.py
@@ -47,7 +47,8 @@ class _Repo:
         return _Status()
 
 
-def test_chat_stance_inputs_include_autonomy_summary_when_available(monkeypatch, enable_autonomy_graphdb) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_inputs_include_autonomy_summary_when_available(monkeypatch, enable_autonomy_graphdb) -> None:
     from orion.autonomy.models import AutonomyStateV1
 
     state = AutonomyStateV1(
@@ -64,26 +65,28 @@ def test_chat_stance_inputs_include_autonomy_summary_when_available(monkeypatch,
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", lambda **_: repo)
 
     ctx = {"user_message": "help me synthesize this"}
-    built = chat_stance.build_chat_stance_inputs(ctx)
+    built = await chat_stance.build_chat_stance_inputs(ctx)
 
     assert built["autonomy"]["summary"]["stance_hint"] == "favor synthesis and reduction"
     assert ctx["chat_autonomy_state"]["subject"] == "orion"
     assert "chat_autonomy_summary" in ctx
 
 
-def test_chat_stance_unavailable_autonomy_keeps_behavior_stable(monkeypatch, enable_autonomy_graphdb) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_unavailable_autonomy_keeps_behavior_stable(monkeypatch, enable_autonomy_graphdb) -> None:
     repo = _Repo({})
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", lambda **_: repo)
 
     ctx = {"user_message": "can you help"}
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
     fb = chat_stance.fallback_chat_stance_brief(ctx)
 
     assert fb.answer_strategy == "DirectAnswer"
     assert fb.task_mode == "direct_response"
 
 
-def test_chat_stance_inputs_include_mutation_adaptation_context_from_metadata(monkeypatch, enable_autonomy_graphdb) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_inputs_include_mutation_adaptation_context_from_metadata(monkeypatch, enable_autonomy_graphdb) -> None:
     repo = _Repo({})
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", lambda **_: repo)
     ctx = {
@@ -98,14 +101,15 @@ def test_chat_stance_inputs_include_mutation_adaptation_context_from_metadata(mo
             }
         },
     }
-    built = chat_stance.build_chat_stance_inputs(ctx)
+    built = await chat_stance.build_chat_stance_inputs(ctx)
     assert built["mutation_adaptation"]["mutation_scope"] == "routing_threshold_patch_only"
     assert built["mutation_adaptation"]["latest_routing_adoption"]["adoption_id"] == "adopt-1"
     assert built["mutation_adaptation"]["latest_routing_rollback"]["rollback_id"] == "rb-1"
     assert ctx["chat_mutation_cognition_context"]["live_ramp_active"] is True
 
 
-def test_chat_stance_autonomy_debug_contains_unavailable_reason(monkeypatch, enable_autonomy_graphdb) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_autonomy_debug_contains_unavailable_reason(monkeypatch, enable_autonomy_graphdb) -> None:
     monkeypatch.setenv("AUTONOMY_GRAPH_TIMEOUT_SEC", "4.5")
     monkeypatch.setenv("AUTONOMY_SUBJECT_MAX_WORKERS", "2")
     monkeypatch.setenv("AUTONOMY_SUBQUERY_MAX_WORKERS", "3")
@@ -124,7 +128,7 @@ def test_chat_stance_autonomy_debug_contains_unavailable_reason(monkeypatch, ena
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", lambda **_: repo)
 
     ctx = {"user_message": "hello"}
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
 
     assert ctx["chat_autonomy_debug"]["orion"]["availability"] == "unavailable"
     assert ctx["chat_autonomy_debug"]["orion"]["unavailable_reason"] == "timeout"
@@ -138,7 +142,8 @@ def test_chat_stance_autonomy_debug_contains_unavailable_reason(monkeypatch, ena
     assert "chat_autonomy_repository_status" in ctx
 
 
-def test_chat_stance_partial_drives_timeout_falls_back_to_relationship(monkeypatch, enable_autonomy_graphdb) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_partial_drives_timeout_falls_back_to_relationship(monkeypatch, enable_autonomy_graphdb) -> None:
     from orion.autonomy.models import AutonomyGoalHeadlineV1, AutonomyStateV1
 
     orion_state = AutonomyStateV1(
@@ -191,7 +196,7 @@ def test_chat_stance_partial_drives_timeout_falls_back_to_relationship(monkeypat
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", lambda **_: repo)
 
     ctx = {"user_message": "hello", "verb": "chat_general", "mode": "brain"}
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
 
     summary = ctx["chat_autonomy_summary"]
     assert ctx["chat_autonomy_selected_subject"] == "relationship"
@@ -202,7 +207,8 @@ def test_chat_stance_partial_drives_timeout_falls_back_to_relationship(monkeypat
     assert ctx["chat_autonomy_debug"]["_runtime"]["contextual_fallback"] is True
 
 
-def test_merge_orion_goals_dedupes_drive_origin_after_contextual_fallback(monkeypatch, enable_autonomy_graphdb) -> None:
+@pytest.mark.asyncio
+async def test_merge_orion_goals_dedupes_drive_origin_after_contextual_fallback(monkeypatch, enable_autonomy_graphdb) -> None:
     from orion.autonomy.models import AutonomyGoalHeadlineV1, AutonomyStateV1
 
     orion_state = AutonomyStateV1(
@@ -270,7 +276,7 @@ def test_merge_orion_goals_dedupes_drive_origin_after_contextual_fallback(monkey
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", lambda **_: repo)
 
     ctx = {"user_message": "hello", "verb": "chat_general", "mode": "brain"}
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
 
     active = ctx["chat_autonomy_summary"]["active_goals"]
     origins = [g["drive_origin"] for g in active]
@@ -279,7 +285,8 @@ def test_merge_orion_goals_dedupes_drive_origin_after_contextual_fallback(monkey
     assert active[0]["artifact_id"] == "goal-rel-autonomy"
 
 
-def test_chat_stance_partial_drives_timeout_exports_degraded_summary(monkeypatch, enable_autonomy_graphdb) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_partial_drives_timeout_exports_degraded_summary(monkeypatch, enable_autonomy_graphdb) -> None:
     from orion.autonomy.models import AutonomyGoalHeadlineV1, AutonomyStateV1
 
     state = AutonomyStateV1(
@@ -317,7 +324,7 @@ def test_chat_stance_partial_drives_timeout_exports_degraded_summary(monkeypatch
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", lambda **_: repo)
 
     ctx = {"user_message": "hello", "verb": "chat_general", "mode": "brain"}
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
 
     summary = ctx["chat_autonomy_summary"]
     assert summary["state_quality"] == "degraded_drives_timeout"
@@ -326,7 +333,8 @@ def test_chat_stance_partial_drives_timeout_exports_degraded_summary(monkeypatch
     assert ctx["chat_autonomy_debug"]["_runtime"]["state_quality"] == "degraded_drives_timeout"
 
 
-def test_autonomy_lookup_turn_log_distinguishes(monkeypatch, enable_autonomy_graphdb, caplog) -> None:
+@pytest.mark.asyncio
+async def test_autonomy_lookup_turn_log_distinguishes(monkeypatch, enable_autonomy_graphdb, caplog) -> None:
     from orion.autonomy.models import AutonomyStateV1
 
     state = AutonomyStateV1(
@@ -345,7 +353,7 @@ def test_autonomy_lookup_turn_log_distinguishes(monkeypatch, enable_autonomy_gra
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", lambda **_: repo)
     caplog.set_level(logging.INFO)
 
-    chat_stance.build_chat_stance_inputs({"user_message": "hello"})
+    await chat_stance.build_chat_stance_inputs({"user_message": "hello"})
 
     assert "autonomy_lookup_turn" in caplog.text
     assert '"availability_counts": {"available": 1, "degraded": 0, "empty": 1, "partial": 0, "unavailable": 1}' in caplog.text
@@ -435,7 +443,8 @@ def test_autonomy_graphdb_config_prefers_generic_vars(monkeypatch) -> None:
     assert cfg["source"] == "generic_graphdb"
 
 
-def test_autonomy_graph_gate_off_skips_build_autonomy_repository(monkeypatch, caplog) -> None:
+@pytest.mark.asyncio
+async def test_autonomy_graph_gate_off_skips_build_autonomy_repository(monkeypatch, caplog) -> None:
     monkeypatch.setenv("AUTONOMY_GRAPH_BACKEND", "disabled")
     monkeypatch.delenv("RDF_STORE_QUERY_URL", raising=False)
     monkeypatch.delenv("AUTONOMY_GRAPH_QUERY_URL", raising=False)
@@ -450,14 +459,15 @@ def test_autonomy_graph_gate_off_skips_build_autonomy_repository(monkeypatch, ca
 
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", _no_build)
     caplog.set_level(logging.INFO)
-    chat_stance.build_chat_stance_inputs(
+    await chat_stance.build_chat_stance_inputs(
         {"verb": "chat_quick", "mode": "brain", "user_message": "ping", "options": {}}
     )
     assert called["n"] == 0
     assert "autonomy_graph_backend_blocked" in caplog.text
 
 
-def test_explicit_graphdb_without_endpoint_logs_degraded_not_blocked(monkeypatch, caplog) -> None:
+@pytest.mark.asyncio
+async def test_explicit_graphdb_without_endpoint_logs_degraded_not_blocked(monkeypatch, caplog) -> None:
     monkeypatch.setenv("AUTONOMY_GRAPH_BACKEND", "graphdb")
     for key in (
         "GRAPHDB_QUERY_ENDPOINT",
@@ -474,7 +484,7 @@ def test_explicit_graphdb_without_endpoint_logs_degraded_not_blocked(monkeypatch
 
     monkeypatch.setattr(chat_stance, "build_autonomy_repository", _no_build)
     caplog.set_level(logging.INFO)
-    chat_stance.build_chat_stance_inputs({"verb": "chat_quick", "mode": "brain", "user_message": "ping", "options": {}})
+    await chat_stance.build_chat_stance_inputs({"verb": "chat_quick", "mode": "brain", "user_message": "ping", "options": {}})
     assert called["n"] == 0
     assert "autonomy_graph_backend_degraded" in caplog.text
     assert "autonomy_graph_backend_blocked" not in caplog.text

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from orion.autonomy.models import AutonomyStateV1
 from orion.autonomy.summary import summarize_autonomy_state
 from orion.core.schemas.reasoning import ClaimV1
@@ -49,7 +51,8 @@ def _claim() -> ClaimV1:
     )
 
 
-def test_chat_stance_autonomy_v2_ctx_and_inputs_when_enabled(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_autonomy_v2_ctx_and_inputs_when_enabled(monkeypatch) -> None:
     state = AutonomyStateV1(
         subject="orion",
         model_layer="self-model",
@@ -64,7 +67,7 @@ def test_chat_stance_autonomy_v2_ctx_and_inputs_when_enabled(monkeypatch) -> Non
     monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
     monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
     ctx: dict = {"user_message": "hello", "correlation_id": "c-v2"}
-    built = chat_stance.build_chat_stance_inputs(ctx)
+    built = await chat_stance.build_chat_stance_inputs(ctx)
     assert isinstance(ctx.get("chat_autonomy_state_v2"), dict)
     assert ctx["chat_autonomy_state_v2"].get("schema_version") == "autonomy.state.v2"
     assert "confidence" in ctx["chat_autonomy_state_v2"]
@@ -74,7 +77,8 @@ def test_chat_stance_autonomy_v2_ctx_and_inputs_when_enabled(monkeypatch) -> Non
     assert built["autonomy"]["delta"] == ctx["chat_autonomy_state_delta"]
 
 
-def test_chat_stance_autonomy_v2_slice_set_before_llm_render(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_autonomy_v2_slice_set_before_llm_render(monkeypatch) -> None:
     """Regression: ctx['autonomy_slice'] (the key stance_react.j2's
     {% if autonomy_slice %} block reads) must be set synchronously inside
     build_chat_stance_inputs -- i.e. before the stance_react LLM step ever
@@ -97,7 +101,7 @@ def test_chat_stance_autonomy_v2_slice_set_before_llm_render(monkeypatch) -> Non
     monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
     ctx: dict = {"user_message": "hello", "correlation_id": "c-slice"}
 
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
 
     assert isinstance(ctx.get("autonomy_slice"), dict), (
         "autonomy_slice must be present on ctx by the time build_chat_stance_inputs "
@@ -111,7 +115,8 @@ def test_chat_stance_autonomy_v2_slice_set_before_llm_render(monkeypatch) -> Non
     assert ctx["autonomy_slice"].get("active_tensions")
 
 
-def test_chat_stance_autonomy_v2_absent_when_disabled(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_autonomy_v2_absent_when_disabled(monkeypatch) -> None:
     state = AutonomyStateV1(
         subject="orion",
         model_layer="self-model",
@@ -126,12 +131,13 @@ def test_chat_stance_autonomy_v2_absent_when_disabled(monkeypatch) -> None:
     monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
     monkeypatch.delenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", raising=False)
     ctx = {"user_message": "hello"}
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
     assert "chat_autonomy_state_v2" not in ctx
     assert "chat_autonomy_state_delta" not in ctx
 
 
-def test_chat_stance_autonomy_v2_reducer_exception_swallowed(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_autonomy_v2_reducer_exception_swallowed(monkeypatch) -> None:
     state = AutonomyStateV1(
         subject="orion",
         model_layer="self-model",
@@ -151,7 +157,7 @@ def test_chat_stance_autonomy_v2_reducer_exception_swallowed(monkeypatch) -> Non
 
     monkeypatch.setattr(chat_stance, "reduce_autonomy_state", _boom)
     ctx: dict = {"user_message": "hello"}
-    built = chat_stance.build_chat_stance_inputs(ctx)
+    built = await chat_stance.build_chat_stance_inputs(ctx)
     assert "chat_autonomy_state_v2" not in ctx
     assert "state_v2" not in built["autonomy"]
     assert "delta" not in built["autonomy"]
@@ -159,7 +165,8 @@ def test_chat_stance_autonomy_v2_reducer_exception_swallowed(monkeypatch) -> Non
     assert isinstance(ctx.get("chat_autonomy_summary"), dict)
 
 
-def test_chat_stance_empty_repo_omits_reasoning_quality_evidence(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_empty_repo_omits_reasoning_quality_evidence(monkeypatch) -> None:
     state = AutonomyStateV1(
         subject="orion",
         model_layer="self-model",
@@ -174,7 +181,7 @@ def test_chat_stance_empty_repo_omits_reasoning_quality_evidence(monkeypatch) ->
     monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
     monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
     ctx: dict = {"user_message": "hello", "correlation_id": "c-omit"}
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
     debug = ctx.get("chat_autonomy_evidence_debug") or {}
     omitted = debug.get("omitted") or []
     assert any(o.get("kind") == "reasoning_quality" and o.get("reason") == "empty_upstream" for o in omitted)
@@ -183,7 +190,8 @@ def test_chat_stance_empty_repo_omits_reasoning_quality_evidence(monkeypatch) ->
     assert "reasoning_quality" not in kinds
 
 
-def test_chat_stance_social_locals_reach_reducer(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_social_locals_reach_reducer(monkeypatch) -> None:
     state = AutonomyStateV1(
         subject="orion",
         model_layer="self-model",
@@ -208,7 +216,7 @@ def test_chat_stance_social_locals_reach_reducer(monkeypatch) -> None:
     ctx: dict = {"user_message": "ping", "correlation_id": "c-haz"}
     # Intentionally do NOT pre-seed chat_social_bridge_summary — ordering bug regression.
     assert "chat_social_bridge_summary" not in ctx
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
     v2 = ctx["chat_autonomy_state_v2"]
     summaries = [e.get("summary") for e in (v2.get("evidence_refs") or []) if e.get("kind") == "relational_signal"]
     assert "cooldown_active" in summaries
@@ -220,7 +228,8 @@ def test_chat_stance_social_locals_reach_reducer(monkeypatch) -> None:
     assert any(m.get("signal_kind") == "chat_social_hazard" for m in minted)
 
 
-def test_chat_stance_v1_with_snapshots_survives_aware_compiler_now(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_v1_with_snapshots_survives_aware_compiler_now(monkeypatch) -> None:
     """Live graph V1 carries naive generated_at + snapshot IDs; stance now is aware UTC."""
     state = AutonomyStateV1(
         subject="orion",
@@ -247,14 +256,15 @@ def test_chat_stance_v1_with_snapshots_survives_aware_compiler_now(monkeypatch) 
     monkeypatch.setattr(chat_stance, "_project_social_from_beliefs", _fake_social)
     monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
     ctx: dict = {"user_message": "hi", "correlation_id": "c-tz"}
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
     assert isinstance(ctx.get("chat_autonomy_state_v2"), dict)
     assert ctx["chat_autonomy_state_v2"].get("schema_version") == "autonomy.state.v2"
     assert "latest_direct_evidence_at" in (ctx["chat_autonomy_state_v2"].get("freshness") or {})
     assert ctx["chat_autonomy_state_v2"]["drive_pressures"]["relational"] > 0.0
 
 
-def test_chat_stance_reasoning_upstream_emits_quality(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_reasoning_upstream_emits_quality(monkeypatch) -> None:
     state = AutonomyStateV1(
         subject="orion",
         model_layer="self-model",
@@ -294,7 +304,7 @@ def test_chat_stance_reasoning_upstream_emits_quality(monkeypatch) -> None:
 
     monkeypatch.setattr(chat_stance, "_compile_reasoning_summary", _compile_force_fallback)
     ctx: dict = {"user_message": "who?", "reasoning_repository": repo}
-    chat_stance.build_chat_stance_inputs(ctx)
+    await chat_stance.build_chat_stance_inputs(ctx)
     v2 = ctx["chat_autonomy_state_v2"]
     kinds = [e.get("kind") for e in (v2.get("evidence_refs") or [])]
     assert "reasoning_quality" in kinds

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
@@ -74,6 +74,43 @@ def test_chat_stance_autonomy_v2_ctx_and_inputs_when_enabled(monkeypatch) -> Non
     assert built["autonomy"]["delta"] == ctx["chat_autonomy_state_delta"]
 
 
+def test_chat_stance_autonomy_v2_slice_set_before_llm_render(monkeypatch) -> None:
+    """Regression: ctx['autonomy_slice'] (the key stance_react.j2's
+    {% if autonomy_slice %} block reads) must be set synchronously inside
+    build_chat_stance_inputs -- i.e. before the stance_react LLM step ever
+    renders its prompt. It must NOT depend on router.py's post-step
+    processing (which runs strictly after that same step's LLM call already
+    returned, and for the single-step stance_react plan is too late for the
+    prompt that already rendered)."""
+    state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive="coherence",
+        drive_pressures={"coherence": 0.4},
+        active_drives=["coherence"],
+        tension_kinds=["repo_question_unresolved"],
+        goal_headlines=[],
+        source="graph",
+    )
+    monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
+    monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
+    ctx: dict = {"user_message": "hello", "correlation_id": "c-slice"}
+
+    chat_stance.build_chat_stance_inputs(ctx)
+
+    assert isinstance(ctx.get("autonomy_slice"), dict), (
+        "autonomy_slice must be present on ctx by the time build_chat_stance_inputs "
+        "returns -- this is the same ctx object the stance_react.j2 render uses "
+        "moments later in the same step, before router.py's post-step processing runs"
+    )
+    assert ctx["autonomy_slice"].get("dominant_drive") == "coherence"
+    # Exact tension labels are the reducer's own canonical form (it re-derives
+    # tensions, not a passthrough of the seeded V1 tension_kinds) -- this test
+    # only needs to prove the slice carries real, non-empty signal.
+    assert ctx["autonomy_slice"].get("active_tensions")
+
+
 def test_chat_stance_autonomy_v2_absent_when_disabled(monkeypatch) -> None:
     state = AutonomyStateV1(
         subject="orion",

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_persistence.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_persistence.py
@@ -7,6 +7,8 @@ second call's effective `previous_state` must be the first call's own
 """
 from __future__ import annotations
 
+import pytest
+
 from orion.autonomy.models import AutonomyStateV1
 from orion.autonomy.reducer import reduce_autonomy_state as real_reduce_autonomy_state
 
@@ -27,7 +29,8 @@ def _v1_baseline() -> AutonomyStateV1:
     )
 
 
-def test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_call(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_call(monkeypatch) -> None:
     store: dict[str, object] = {}
 
     def fake_load(subject):
@@ -52,12 +55,12 @@ def test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_cal
     autonomy = {"state": v1_baseline}
 
     ctx1: dict = {"user_message": "first turn, feeling curious about the lab", "correlation_id": "c-1"}
-    result1 = chat_stance._run_autonomy_reducer(
+    result1 = await chat_stance._run_autonomy_reducer(
         ctx1, autonomy, social={}, social_bridge={}, reasoning={}
     )
 
     ctx2: dict = {"user_message": "second turn, entirely different evidence", "correlation_id": "c-2"}
-    result2 = chat_stance._run_autonomy_reducer(
+    result2 = await chat_stance._run_autonomy_reducer(
         ctx2, autonomy, social={}, social_bridge={}, reasoning={}
     )
 
@@ -76,7 +79,8 @@ def test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_cal
     assert store["orion"] is result2.state
 
 
-def test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_state(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_state(monkeypatch) -> None:
     """Regression: chat_autonomy_movement_debug['pressures_before'] must reflect
     the SAME previous_state the fold actually used (persisted V2 once warm), not
     autonomy['state'] (the V1/graph baseline) independently -- those two diverge
@@ -92,10 +96,10 @@ def test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_stat
     autonomy = {"state": v1_baseline}
 
     ctx1: dict = {"user_message": "first turn", "correlation_id": "c-1"}
-    result1 = chat_stance._run_autonomy_reducer(ctx1, autonomy, social={}, social_bridge={}, reasoning={})
+    result1 = await chat_stance._run_autonomy_reducer(ctx1, autonomy, social={}, social_bridge={}, reasoning={})
 
     ctx2: dict = {"user_message": "second turn, different evidence entirely", "correlation_id": "c-2"}
-    chat_stance._run_autonomy_reducer(ctx2, autonomy, social={}, social_bridge={}, reasoning={})
+    await chat_stance._run_autonomy_reducer(ctx2, autonomy, social={}, social_bridge={}, reasoning={})
 
     # By turn 2 the store holds result1.state, whose drive_pressures have already
     # moved away from the fixed v1_baseline -- the two are no longer equal.
@@ -106,7 +110,8 @@ def test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_stat
     assert before != dict(v1_baseline.drive_pressures or {})
 
 
-def test_run_autonomy_reducer_falls_back_to_v1_baseline_when_store_unreachable(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_run_autonomy_reducer_falls_back_to_v1_baseline_when_store_unreachable(monkeypatch) -> None:
     """Store returning None (unreachable / no DSN) must not change today's
     fallback behavior: previous_state stays the V1/graph baseline."""
 
@@ -127,13 +132,14 @@ def test_run_autonomy_reducer_falls_back_to_v1_baseline_when_store_unreachable(m
     autonomy = {"state": v1_baseline}
     ctx: dict = {"user_message": "hello", "correlation_id": "c-1"}
 
-    chat_stance._run_autonomy_reducer(ctx, autonomy, social={}, social_bridge={}, reasoning={})
+    await chat_stance._run_autonomy_reducer(ctx, autonomy, social={}, social_bridge={}, reasoning={})
 
     assert captured_previous_states == [v1_baseline]
     assert "orion" in saved  # write-back still attempted even though load returned None
 
 
-def test_run_autonomy_reducer_write_failure_is_swallowed(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_run_autonomy_reducer_write_failure_is_swallowed(monkeypatch) -> None:
     """save_autonomy_state_v2 raising must not propagate out of the reducer --
     belt-and-suspenders fail-open, even though the store already fails open
     internally."""
@@ -151,5 +157,5 @@ def test_run_autonomy_reducer_write_failure_is_swallowed(monkeypatch) -> None:
     ctx: dict = {"user_message": "hello", "correlation_id": "c-1"}
 
     # Must not raise.
-    result = chat_stance._run_autonomy_reducer(ctx, autonomy, social={}, social_bridge={}, reasoning={})
+    result = await chat_stance._run_autonomy_reducer(ctx, autonomy, social={}, social_bridge={}, reasoning={})
     assert result is not None

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_persistence.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_persistence.py
@@ -1,0 +1,125 @@
+"""Non-amnesiac acceptance check for `_run_autonomy_reducer`.
+
+Verifies the reducer's own output now closes its fold loop via
+`orion.autonomy.state_store` instead of being discarded every turn: the
+second call's effective `previous_state` must be the first call's own
+`result.state`, not the V1/graph baseline passed in via `ctx`/`autonomy`.
+"""
+from __future__ import annotations
+
+from orion.autonomy.models import AutonomyStateV1
+from orion.autonomy.reducer import reduce_autonomy_state as real_reduce_autonomy_state
+
+from app import chat_stance
+
+
+def _v1_baseline() -> AutonomyStateV1:
+    return AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive="coherence",
+        drive_pressures={"coherence": 0.4},
+        active_drives=["coherence"],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+    )
+
+
+def test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_call(monkeypatch) -> None:
+    store: dict[str, object] = {}
+
+    def fake_load(subject):
+        return store.get(subject)
+
+    def fake_save(subject, state):
+        store[subject] = state
+
+    monkeypatch.setattr(chat_stance, "load_autonomy_state_v2", fake_load)
+    monkeypatch.setattr(chat_stance, "save_autonomy_state_v2", fake_save)
+    monkeypatch.setattr(chat_stance, "load_action_outcomes", lambda subject: [])
+
+    captured_previous_states: list[object] = []
+
+    def spy_reduce(inp):
+        captured_previous_states.append(inp.previous_state)
+        return real_reduce_autonomy_state(inp)
+
+    monkeypatch.setattr(chat_stance, "reduce_autonomy_state", spy_reduce)
+
+    v1_baseline = _v1_baseline()
+    autonomy = {"state": v1_baseline}
+
+    ctx1: dict = {"user_message": "first turn, feeling curious about the lab", "correlation_id": "c-1"}
+    result1 = chat_stance._run_autonomy_reducer(
+        ctx1, autonomy, social={}, social_bridge={}, reasoning={}
+    )
+
+    ctx2: dict = {"user_message": "second turn, entirely different evidence", "correlation_id": "c-2"}
+    result2 = chat_stance._run_autonomy_reducer(
+        ctx2, autonomy, social={}, social_bridge={}, reasoning={}
+    )
+
+    assert len(captured_previous_states) == 2
+    # First-ever turn for this subject: nothing persisted yet, falls back to
+    # the V1/graph baseline exactly as before.
+    assert captured_previous_states[0] is v1_baseline
+
+    # Second call: previous_state must be the FIRST call's own reducer output
+    # (round-tripped through the store), not the V1 baseline again. This is
+    # the core non-amnesiac acceptance check.
+    assert captured_previous_states[1] is result1.state
+    assert captured_previous_states[1] is not v1_baseline
+
+    # The store now holds the second call's output -- the write-back happened.
+    assert store["orion"] is result2.state
+
+
+def test_run_autonomy_reducer_falls_back_to_v1_baseline_when_store_unreachable(monkeypatch) -> None:
+    """Store returning None (unreachable / no DSN) must not change today's
+    fallback behavior: previous_state stays the V1/graph baseline."""
+
+    monkeypatch.setattr(chat_stance, "load_autonomy_state_v2", lambda subject: None)
+    saved: dict[str, object] = {}
+    monkeypatch.setattr(chat_stance, "save_autonomy_state_v2", lambda subject, state: saved.__setitem__(subject, state))
+    monkeypatch.setattr(chat_stance, "load_action_outcomes", lambda subject: [])
+
+    captured_previous_states: list[object] = []
+
+    def spy_reduce(inp):
+        captured_previous_states.append(inp.previous_state)
+        return real_reduce_autonomy_state(inp)
+
+    monkeypatch.setattr(chat_stance, "reduce_autonomy_state", spy_reduce)
+
+    v1_baseline = _v1_baseline()
+    autonomy = {"state": v1_baseline}
+    ctx: dict = {"user_message": "hello", "correlation_id": "c-1"}
+
+    chat_stance._run_autonomy_reducer(ctx, autonomy, social={}, social_bridge={}, reasoning={})
+
+    assert captured_previous_states == [v1_baseline]
+    assert "orion" in saved  # write-back still attempted even though load returned None
+
+
+def test_run_autonomy_reducer_write_failure_is_swallowed(monkeypatch) -> None:
+    """save_autonomy_state_v2 raising must not propagate out of the reducer --
+    belt-and-suspenders fail-open, even though the store already fails open
+    internally."""
+
+    monkeypatch.setattr(chat_stance, "load_autonomy_state_v2", lambda subject: None)
+
+    def boom(subject, state):
+        raise RuntimeError("db hiccup")
+
+    monkeypatch.setattr(chat_stance, "save_autonomy_state_v2", boom)
+    monkeypatch.setattr(chat_stance, "load_action_outcomes", lambda subject: [])
+
+    v1_baseline = _v1_baseline()
+    autonomy = {"state": v1_baseline}
+    ctx: dict = {"user_message": "hello", "correlation_id": "c-1"}
+
+    # Must not raise.
+    result = chat_stance._run_autonomy_reducer(ctx, autonomy, social={}, social_bridge={}, reasoning={})
+    assert result is not None

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_persistence.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_persistence.py
@@ -76,6 +76,36 @@ def test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_cal
     assert store["orion"] is result2.state
 
 
+def test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_state(monkeypatch) -> None:
+    """Regression: chat_autonomy_movement_debug['pressures_before'] must reflect
+    the SAME previous_state the fold actually used (persisted V2 once warm), not
+    autonomy['state'] (the V1/graph baseline) independently -- those two diverge
+    once persistence kicks in on turn 2+, and the mismatch silently corrupts
+    autonomy_slice.py's pressure_trend derivation (before/after compared against
+    different baselines)."""
+    store: dict[str, object] = {}
+    monkeypatch.setattr(chat_stance, "load_autonomy_state_v2", lambda subject: store.get(subject))
+    monkeypatch.setattr(chat_stance, "save_autonomy_state_v2", lambda subject, state: store.__setitem__(subject, state))
+    monkeypatch.setattr(chat_stance, "load_action_outcomes", lambda subject: [])
+
+    v1_baseline = _v1_baseline()  # drive_pressures={"coherence": 0.4} -- stays fixed all turns
+    autonomy = {"state": v1_baseline}
+
+    ctx1: dict = {"user_message": "first turn", "correlation_id": "c-1"}
+    result1 = chat_stance._run_autonomy_reducer(ctx1, autonomy, social={}, social_bridge={}, reasoning={})
+
+    ctx2: dict = {"user_message": "second turn, different evidence entirely", "correlation_id": "c-2"}
+    chat_stance._run_autonomy_reducer(ctx2, autonomy, social={}, social_bridge={}, reasoning={})
+
+    # By turn 2 the store holds result1.state, whose drive_pressures have already
+    # moved away from the fixed v1_baseline -- the two are no longer equal.
+    assert result1.state.drive_pressures != v1_baseline.drive_pressures
+
+    before = ctx2["chat_autonomy_movement_debug"]["pressures_before"]
+    assert before == dict(result1.state.drive_pressures or {})
+    assert before != dict(v1_baseline.drive_pressures or {})
+
+
 def test_run_autonomy_reducer_falls_back_to_v1_baseline_when_store_unreachable(monkeypatch) -> None:
     """Store returning None (unreachable / no DSN) must not change today's
     fallback behavior: previous_state stays the V1/graph baseline."""

--- a/services/orion-cortex-exec/tests/test_chat_stance_brief.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_brief.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from app.chat_stance import (
     build_chat_stance_debug_payload,
     build_chat_stance_inputs,
@@ -29,7 +31,8 @@ def test_chat_stance_brief_schema_roundtrip() -> None:
     assert reparsed.answer_strategy == "DirectAnswer"
 
 
-def test_build_chat_stance_inputs_maps_social_reflective_and_dream() -> None:
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_maps_social_reflective_and_dream() -> None:
     ctx = {
         "orion_identity_summary": ["Distributed self-model"],
         "juniper_relationship_summary": ["Trusted collaborator"],
@@ -60,7 +63,7 @@ def test_build_chat_stance_inputs_maps_social_reflective_and_dream() -> None:
         },
     }
 
-    built = build_chat_stance_inputs(ctx)
+    built = await build_chat_stance_inputs(ctx)
 
     assert built["identity"]["orion"] == ["Distributed self-model"]
     assert "collaborative build" in built["social"]["relationship_facets"]
@@ -72,7 +75,8 @@ def test_build_chat_stance_inputs_maps_social_reflective_and_dream() -> None:
     assert built["reflective"]["dream_motifs"]
 
 
-def test_build_chat_stance_inputs_includes_situation_category() -> None:
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_includes_situation_category() -> None:
     ctx = {
         "user_message": "My kid asked why the sky is blue.",
         "situation_prompt_fragment": {
@@ -111,7 +115,7 @@ def test_build_chat_stance_inputs_includes_situation_category() -> None:
             "affordances": [{"kind": "kid_friendly_explanation", "trigger_relevance": "active", "suggestion": "Use age-appropriate explanation", "confidence": "medium"}],
         },
     }
-    built = build_chat_stance_inputs(ctx)
+    built = await build_chat_stance_inputs(ctx)
     assert "situation" in built
     assert built["situation"]["presence"]["audience_mode"] == "kid_present"
     assert built["situation"]["conversation_phase"]["phase_change"] == "long_gap"
@@ -130,19 +134,21 @@ def test_parse_chat_stance_brief_and_fallback() -> None:
     assert "generic assistant self-description" in fb.response_hazards
 
 
-def test_build_chat_stance_inputs_falls_back_when_identity_missing() -> None:
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_falls_back_when_identity_missing() -> None:
     from app import chat_stance
 
     chat_stance._UNIFICATION_LAYER = None
     ctx = {"user_message": "who are you and who am i"}
-    built = build_chat_stance_inputs(ctx)
+    built = await build_chat_stance_inputs(ctx)
     assert built["identity"]["orion"]
     assert built["identity"]["juniper"]
     assert built["identity"]["response_policy"]
     assert any("not a generic assistant" in item.lower() for item in built["identity"]["orion"])
 
 
-def test_build_chat_stance_inputs_uses_repository_seam(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_uses_repository_seam(monkeypatch) -> None:
     from app import chat_stance
     import orion.spark.concept_induction.profile_repository as profile_repo
 
@@ -188,11 +194,12 @@ def test_build_chat_stance_inputs_uses_repository_seam(monkeypatch) -> None:
             ]
 
     monkeypatch.setattr(profile_repo, "build_concept_profile_repository", lambda: FakeRepository())
-    built = chat_stance.build_chat_stance_inputs({"user_message": "who are you"})
+    built = await chat_stance.build_chat_stance_inputs({"user_message": "who are you"})
     assert "continuity" in built["concept_induction"]["self"]
 
 
-def test_chat_stance_shadow_mode_uses_local_result_and_passes_observer(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_shadow_mode_uses_local_result_and_passes_observer(monkeypatch) -> None:
     from app import chat_stance
     import orion.spark.concept_induction.profile_repository as profile_repo
 
@@ -245,7 +252,7 @@ def test_chat_stance_shadow_mode_uses_local_result_and_passes_observer(monkeypat
 
     fake_repository = FakeRepository()
     monkeypatch.setattr(profile_repo, "build_concept_profile_repository", lambda: fake_repository)
-    built = chat_stance.build_chat_stance_inputs(
+    built = await chat_stance.build_chat_stance_inputs(
         {
             "user_message": "who are you",
             "session_id": "sid-1",
@@ -439,18 +446,19 @@ def test_semantic_guard_triage_adds_self_intro_suppression_hazard() -> None:
     assert "triage_operational_blockers_first" in enriched.response_priorities
 
 
-def test_ensure_chat_stance_pipeline_ctx_populates_stance_inputs_for_agent_mode(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_ensure_chat_stance_pipeline_ctx_populates_stance_inputs_for_agent_mode(monkeypatch) -> None:
     monkeypatch.setenv("AUTONOMY_REPOSITORY_BACKEND", "local")
     from app.executor import ensure_chat_stance_pipeline_ctx
 
     ctx: dict = {"mode": "agent", "user_message": "hello", "verb": "chat_general", "correlation_id": "pytest-stance-1"}
-    ensure_chat_stance_pipeline_ctx(ctx)
+    await ensure_chat_stance_pipeline_ctx(ctx)
     inputs = ctx.get("chat_stance_inputs")
     assert isinstance(inputs, dict)
     assert inputs.get("identity", {}).get("orion")
     assert "autonomy" in inputs
     first = inputs
-    ensure_chat_stance_pipeline_ctx(ctx)
+    await ensure_chat_stance_pipeline_ctx(ctx)
     assert ctx.get("chat_stance_inputs") is first
 
 

--- a/services/orion-cortex-exec/tests/test_chat_stance_reasoning_summary_phase4.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_reasoning_summary_phase4.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from app.chat_stance import build_chat_stance_inputs, fallback_chat_stance_brief
 from app.endogenous_runtime import EndogenousRuntimeAdoptionService, EndogenousRuntimeConfig
 from orion.core.schemas.reasoning import ClaimV1
@@ -31,7 +33,8 @@ def _claim() -> ClaimV1:
     )
 
 
-def test_chat_stance_uses_reasoning_summary_when_available() -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_uses_reasoning_summary_when_available() -> None:
     repo = InMemoryReasoningRepository()
     repo.write_artifacts(
         ReasoningWriteRequestV1(
@@ -49,20 +52,22 @@ def test_chat_stance_uses_reasoning_summary_when_available() -> None:
         "user_message": "who are you?",
         "reasoning_repository": repo,
     }
-    built = build_chat_stance_inputs(ctx)
+    built = await build_chat_stance_inputs(ctx)
     assert built["reasoning_summary"]["active_claims"]
     assert ctx["chat_reasoning_summary_used"] is True
     assert ctx["chat_reasoning_debug"]["compiler_succeeded"] is True
 
 
-def test_chat_stance_reasoning_fallback_safe_when_unavailable() -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_reasoning_fallback_safe_when_unavailable() -> None:
     ctx = {"user_message": "help me debug"}
-    built = build_chat_stance_inputs(ctx)
+    built = await build_chat_stance_inputs(ctx)
     assert built["reasoning_summary"]["fallback_recommended"] is True
     assert ctx["chat_reasoning_summary_used"] is False
 
 
-def test_chat_stance_records_endogenous_runtime_audit() -> None:
+@pytest.mark.asyncio
+async def test_chat_stance_records_endogenous_runtime_audit() -> None:
     from app import chat_stance as chat_stance_module
 
     original_runtime_service = chat_stance_module.runtime_service
@@ -79,7 +84,7 @@ def test_chat_stance_records_endogenous_runtime_audit() -> None:
     )
     try:
         ctx = {"user_message": "please reflect on contradictions"}
-        _ = build_chat_stance_inputs(ctx)
+        _ = await build_chat_stance_inputs(ctx)
         assert isinstance(ctx.get("chat_endogenous_runtime"), dict)
         assert ctx["chat_endogenous_runtime"]["audit"]["status"] in {"ok", "surface_disabled", "not_selected", "disabled", "sampled_out"}
     finally:

--- a/services/orion-cortex-exec/tests/test_chat_stance_self_state_projection.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_self_state_projection.py
@@ -75,20 +75,22 @@ def _real_beliefs_with_self_nodes(overall_condition: str) -> UnifiedRelationalBe
     return UnifiedRelationalBeliefSetV1(anchors={"orion": anchor_slice})
 
 
-def test_build_chat_stance_inputs_folds_self_state_hazard_when_strained(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_folds_self_state_hazard_when_strained(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(chat_stance, "_unified_beliefs_for_stance", lambda ctx: _real_beliefs_with_self_nodes("strained"))
 
     ctx = {"user_message": "hello"}
-    built = chat_stance.build_chat_stance_inputs(ctx)
+    built = await chat_stance.build_chat_stance_inputs(ctx)
 
     assert any(h.startswith("self_state overall_condition=strained") for h in built["social"]["hazards"])
     assert ctx["chat_self_state_condition"] == "strained"
 
 
-def test_build_chat_stance_inputs_no_self_state_hazard_when_steady(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_no_self_state_hazard_when_steady(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(chat_stance, "_unified_beliefs_for_stance", lambda ctx: _real_beliefs_with_self_nodes("steady"))
 
     ctx = {"user_message": "hello"}
-    built = chat_stance.build_chat_stance_inputs(ctx)
+    built = await chat_stance.build_chat_stance_inputs(ctx)
 
     assert not any(h.startswith("self_state overall_condition=") for h in built["social"]["hazards"])

--- a/services/orion-cortex-exec/tests/test_llm_uncertainty_metadata.py
+++ b/services/orion-cortex-exec/tests/test_llm_uncertainty_metadata.py
@@ -79,7 +79,7 @@ def test_plan_result_metadata_includes_llm_uncertainty(monkeypatch) -> None:
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     req = _request()
     result = asyncio.run(
         runner.run_plan(

--- a/services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py
+++ b/services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py
@@ -85,7 +85,7 @@ def test_router_exports_autonomy_metadata_from_chat_stance_context(monkeypatch) 
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     req = _request()
     ctx = {
         "mode": "brain",
@@ -145,7 +145,7 @@ def test_router_omits_autonomy_metadata_when_absent(monkeypatch) -> None:
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     req = _request()
     result = asyncio.run(
         runner.run_plan(
@@ -177,13 +177,12 @@ def test_router_prepares_brain_autonomy_context_for_non_chat_general_verbs(monke
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
 
-    def _fake_prepare(ctx):
+    async def _fake_prepare(ctx):
         ctx["chat_autonomy_summary"] = {"stance_hint": "stabilize and clarify"}
         ctx["chat_autonomy_debug"] = {"orion": {"availability": "available", "present": True}}
         ctx["chat_autonomy_state"] = {"subject": "orion", "source": "graph"}
         return {"autonomy": {"summary": ctx["chat_autonomy_summary"]}}
 
-    # synchronous helper; keep assertion surface simple
     monkeypatch.setattr("app.router.prepare_brain_reply_context", _fake_prepare)
 
     req = _request(verb_name="analyze_text", step_name="llm_analyze_text")
@@ -215,7 +214,7 @@ def test_router_exports_backend_and_repository_status_when_autonomy_unavailable(
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     req = _request()
     ctx = {
         "mode": "brain",
@@ -258,7 +257,7 @@ def test_router_exports_none_execution_mode_when_healthy_goals_present(monkeypat
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     ctx = {
         "mode": "brain",
         "raw_user_text": "hello",
@@ -295,7 +294,7 @@ def test_router_exports_goal_lineage_and_none_execution_mode(monkeypatch) -> Non
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     req = _request()
     ctx = {
         "mode": "brain",
@@ -341,7 +340,7 @@ def test_router_autonomy_preview_dominant_drive_falls_back_to_top_drive(monkeypa
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     req = _request()
     ctx = {
         "mode": "brain",
@@ -375,7 +374,7 @@ def test_router_autonomy_preview_dominant_drive_falls_back_to_active_drive(monke
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     req = _request()
     ctx = {
         "mode": "brain",
@@ -479,7 +478,7 @@ def test_router_exports_turn_effect_in_plan_metadata(monkeypatch) -> None:
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     req = _request()
     ctx = {
         "mode": "brain",
@@ -515,7 +514,7 @@ def test_router_exports_relationship_fallback_when_orion_drives_deferred(monkeyp
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     ctx = {
         "mode": "brain",
         "raw_user_text": "hello",
@@ -574,7 +573,7 @@ def test_router_exports_turn_effect_status_for_chat_quick_when_missing(monkeypat
         error=None,
     )
     monkeypatch.setattr("app.router.call_step_services", AsyncMock(return_value=fake_step))
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     req = _request(verb_name="chat_quick", step_name="llm_chat_quick")
     result = asyncio.run(
         runner.run_plan(

--- a/services/orion-cortex-exec/tests/test_router_chat_quick_recall_rpc_cap.py
+++ b/services/orion-cortex-exec/tests/test_router_chat_quick_recall_rpc_cap.py
@@ -120,7 +120,7 @@ def test_router_passes_none_recall_rpc_override_chat_quick(monkeypatch) -> None:
     monkeypatch.setattr(router, "run_recall_step", _fake_recall_step)
     monkeypatch.setattr(router, "call_step_services", AsyncMock(return_value=fake_llm))
     monkeypatch.setattr(router, "prepare_chat_quick_reply_context", lambda ctx: None)
-    monkeypatch.setattr(router, "prepare_brain_reply_context", lambda ctx, force_refresh=False: None)
+    monkeypatch.setattr(router, "prepare_brain_reply_context", AsyncMock(return_value=None))
 
     runner = PlanRunner()
     result = asyncio.run(
@@ -172,7 +172,7 @@ def test_router_passes_none_rpc_timeout_for_chat_general(monkeypatch) -> None:
 
     monkeypatch.setattr(router, "run_recall_step", _fake_recall_step)
     monkeypatch.setattr(router, "call_step_services", AsyncMock(return_value=fake_llm))
-    monkeypatch.setattr(router, "prepare_brain_reply_context", lambda ctx, force_refresh=False: None)
+    monkeypatch.setattr(router, "prepare_brain_reply_context", AsyncMock(return_value=None))
 
     runner = PlanRunner()
     result = asyncio.run(

--- a/services/orion-cortex-exec/tests/test_router_grounding_capsule_metadata.py
+++ b/services/orion-cortex-exec/tests/test_router_grounding_capsule_metadata.py
@@ -78,7 +78,7 @@ def test_router_attaches_grounding_capsule_to_metadata(monkeypatch) -> None:
         "app.router.call_step_services",
         AsyncMock(return_value=_fake_step(verb_name="stance_react", step_name="llm_stance_react")),
     )
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     assemble = AsyncMock(return_value=_capsule())
     monkeypatch.setattr("app.router.assemble_stance_grounding", assemble)
 
@@ -105,7 +105,7 @@ def test_router_omits_grounding_capsule_when_assembler_returns_none(monkeypatch)
         "app.router.call_step_services",
         AsyncMock(return_value=_fake_step(verb_name="stance_react", step_name="llm_stance_react")),
     )
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     monkeypatch.setattr("app.router.assemble_stance_grounding", AsyncMock(return_value=None))
 
     result = asyncio.run(
@@ -128,7 +128,7 @@ def test_router_does_not_assemble_grounding_for_non_stance_verb(monkeypatch) -> 
         "app.router.call_step_services",
         AsyncMock(return_value=_fake_step(verb_name="chat_general", step_name="llm_chat_general")),
     )
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     assemble = AsyncMock(return_value=_capsule())
     monkeypatch.setattr("app.router.assemble_stance_grounding", assemble)
 

--- a/services/orion-cortex-exec/tests/test_unified_pcr_phase01.py
+++ b/services/orion-cortex-exec/tests/test_unified_pcr_phase01.py
@@ -123,7 +123,7 @@ async def test_stance_react_runs_pcr_phase01_before_stance_step(monkeypatch) -> 
 
     monkeypatch.setattr("app.router.run_pcr_phase0_and_1", _fake_phase01)
     monkeypatch.setattr("app.router.call_step_services", _fake_call_step)
-    monkeypatch.setattr("app.router.prepare_brain_reply_context", lambda _ctx: None)
+    monkeypatch.setattr("app.router.prepare_brain_reply_context", AsyncMock(return_value=None))
     monkeypatch.setattr(
         "app.router.assemble_stance_grounding",
         AsyncMock(

--- a/services/orion-sql-db/manual_migration_autonomy_state_v2.sql
+++ b/services/orion-sql-db/manual_migration_autonomy_state_v2.sql
@@ -1,0 +1,17 @@
+-- AutonomyStateV2 persistence (closes the reducer's own fold loop).
+-- Producer/consumer: orion/autonomy/state_store.py (load_autonomy_state_v2 /
+-- save_autonomy_state_v2), called from services/orion-cortex-exec/app/chat_stance.py
+-- _run_autonomy_reducer().
+--
+-- Single-row-per-subject latest-state table: the reducer upserts its own output
+-- here every turn instead of only reading the V1/graph baseline, so
+-- previous_state carries forward turn-to-turn.
+--
+-- Deliberately separate from the graph/Fuseki-backed homeostatic drives system --
+-- do not merge or reference that store from here.
+
+CREATE TABLE IF NOT EXISTS autonomy_state_v2 (
+    subject TEXT PRIMARY KEY,
+    state JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/services/orion-thought/app/bus_listener.py
+++ b/services/orion-thought/app/bus_listener.py
@@ -10,7 +10,12 @@ from orion.cognition.plan_loader import build_plan_for_verb
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.schemas.cortex.schemas import PlanExecutionArgs, PlanExecutionRequest
-from orion.schemas.thought import GroundingCapsuleV1, StanceReactRequestV1, ThoughtEventV1
+from orion.schemas.thought import (
+    AutonomySliceV1,
+    GroundingCapsuleV1,
+    StanceReactRequestV1,
+    ThoughtEventV1,
+)
 from orion.thought.stance_react import (
     apply_stance_react_pipeline,
     build_stance_react_failure_thought,
@@ -204,6 +209,20 @@ def _extract_grounding_capsule(exec_result: dict[str, Any]) -> GroundingCapsuleV
         return None
 
 
+def _extract_autonomy_slice(exec_result: dict[str, Any]) -> AutonomySliceV1 | None:
+    metadata = exec_result.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    raw = metadata.get("autonomy_slice")
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return AutonomySliceV1.model_validate(raw)
+    except Exception:
+        logger.warning("autonomy_slice_parse_failed corr=%s", exec_result.get("request_id"))
+        return None
+
+
 async def _maybe_build_mind_coloring(
     request: StanceReactRequestV1,
     *,
@@ -278,6 +297,9 @@ async def run_stance_react(
     capsule = _extract_grounding_capsule(exec_result)
     if capsule is not None:
         enriched = enriched.model_copy(update={"grounding_capsule": capsule})
+    slice_ = _extract_autonomy_slice(exec_result)
+    if slice_ is not None:
+        enriched = enriched.model_copy(update={"autonomy_slice": slice_})
     return enriched
 
 

--- a/services/orion-thought/tests/test_stance_react_grounding_capsule.py
+++ b/services/orion-thought/tests/test_stance_react_grounding_capsule.py
@@ -87,3 +87,81 @@ async def test_run_stance_react_no_capsule_when_metadata_malformed() -> None:
         _request(), bus=None, cortex_client=_FakeCortexClient(exec_result)
     )
     assert thought.grounding_capsule is None
+
+
+@pytest.mark.asyncio
+async def test_run_stance_react_attaches_autonomy_slice() -> None:
+    exec_result = {
+        "final_text": _stance_json(),
+        "metadata": {
+            "autonomy_slice": {
+                "schema_version": "autonomy.slice.v1",
+                "dominant_drive": "curiosity",
+                "active_tensions": ["novelty_vs_stability"],
+                "pressure_trend": "rising",
+                "confidence": 0.7,
+            }
+        },
+    }
+    thought = await run_stance_react(
+        _request(), bus=None, cortex_client=_FakeCortexClient(exec_result)
+    )
+    assert thought.autonomy_slice is not None
+    assert thought.autonomy_slice.dominant_drive == "curiosity"
+    assert thought.autonomy_slice.active_tensions == ["novelty_vs_stability"]
+    assert thought.autonomy_slice.pressure_trend == "rising"
+
+
+@pytest.mark.asyncio
+async def test_run_stance_react_no_autonomy_slice_when_metadata_absent() -> None:
+    exec_result = {"final_text": _stance_json(), "metadata": {}}
+    thought = await run_stance_react(
+        _request(), bus=None, cortex_client=_FakeCortexClient(exec_result)
+    )
+    assert thought.autonomy_slice is None
+
+
+@pytest.mark.asyncio
+async def test_run_stance_react_no_autonomy_slice_when_metadata_malformed() -> None:
+    exec_result = {
+        "final_text": _stance_json(),
+        "metadata": {"autonomy_slice": {"active_tensions": "not-a-list"}},
+        "request_id": "c-1",
+    }
+    thought = await run_stance_react(
+        _request(), bus=None, cortex_client=_FakeCortexClient(exec_result)
+    )
+    assert thought.autonomy_slice is None
+
+
+@pytest.mark.asyncio
+async def test_run_stance_react_attaches_both_capsule_and_autonomy_slice() -> None:
+    exec_result = {
+        "final_text": _stance_json(),
+        "metadata": {
+            "grounding_capsule": {
+                "schema_version": "grounding.capsule.v1",
+                "identity_summary": ["I am Oríon."],
+                "relationship_summary": ["Juniper is my collaborator."],
+                "response_policy_summary": ["Speak plainly."],
+                "continuity_digest": "We were mid-refactor.",
+                "belief_digest": "Orion values continuity.",
+                "memory_digest": "We were mid-refactor.",
+                "provenance": {"identity_source": "configured_yaml", "pcr_ran": True},
+            },
+            "autonomy_slice": {
+                "schema_version": "autonomy.slice.v1",
+                "dominant_drive": "curiosity",
+                "active_tensions": ["novelty_vs_stability"],
+                "pressure_trend": "rising",
+                "confidence": 0.7,
+            },
+        },
+    }
+    thought = await run_stance_react(
+        _request(), bus=None, cortex_client=_FakeCortexClient(exec_result)
+    )
+    assert thought.grounding_capsule is not None
+    assert thought.grounding_capsule.identity_summary == ["I am Oríon."]
+    assert thought.autonomy_slice is not None
+    assert thought.autonomy_slice.dominant_drive == "curiosity"


### PR DESCRIPTION
## Summary

- AutonomyStateV2 now persists turn-to-turn (Postgres, fail-open) instead of being recomputed and discarded every turn — closes the reducer's own fold loop.
- A compact `AutonomySliceV1` reaches two real consumers on the orion-unified path: the `stance_react` LLM prompt itself and every FCC/Claude harness system prefix. Verified end-to-end, not just computed-and-dropped.
- Relocated the never-enabled curiosity/attention-frame prompt injection from Lane A (`chat_general`, untouched) to Lane B (`stance_react.j2`) — template-only, no detector changes.
- Code review (8-angle) found the prompt-injection half was dead on arrival due to a cross-wave timing bug; fixed directly along with two more correctness bugs and a CLAUDE.md "keyword cathedral" violation.
- Converted the `_run_autonomy_reducer` → `build_chat_stance_inputs` → `prepare_brain_reply_context`/`ensure_chat_stance_pipeline_ctx` call chain to async so the new Postgres calls run via `asyncio.to_thread` instead of blocking the event loop on every chat turn.

## Outcome moved

`AutonomyStateV2` — Orion's own drive/tension appraisal — now actually reaches things that shape behavior: the stance-decision LLM prompt and every harness/agentic system prefix, with real persisted memory across turns. Previously it was fully computed but unreachable by any consumer.

## Current architecture

Before this PR: `AUTONOMY_STATE_V2_REDUCER_ENABLED=true` ran the reducer every turn, but `previous_state` always came from the V1/graph baseline (never its own prior output), and the result only reached a Hub UI debug preview (`router.py`'s `autonomy_state_v2_preview`) — no prompt or harness consumer read it. `chat_general`/Lane A had its own (also-dead) curiosity-frame wiring; Lane B (`stance_react`) had none.

## Architecture touched

- `orion/autonomy/` — new Postgres-backed state store
- `orion/schemas/thought.py` — new `AutonomySliceV1`, `ThoughtEventV1.autonomy_slice`
- `services/orion-cortex-exec/app/` — reducer persistence wiring, `autonomy_slice.py` builder, async conversion of the stance-context prep chain
- `orion/cognition/prompts/stance_react.j2`, `orion/harness/prefix.py` — the two real consumers
- `orion/thought/`, `services/orion-thought/app/bus_listener.py` — cross-service extraction/attach (cortex-exec → orion-thought)
- `services/orion-sql-db/` — new manual migration

## Files changed

- `orion/autonomy/state_store.py`: new — `load_autonomy_state_v2`/`save_autonomy_state_v2`, mirrors `action_outcomes.py`'s SQLAlchemy convention, fail-open
- `services/orion-sql-db/manual_migration_autonomy_state_v2.sql`: new — `autonomy_state_v2` table (subject PK, jsonb state, updated_at)
- `orion/schemas/thought.py`: new `AutonomySliceV1` model + `ThoughtEventV1.autonomy_slice` field (optional, back-compatible)
- `services/orion-cortex-exec/app/autonomy_slice.py`: new — `build_autonomy_slice(ctx)`, mirrors `grounding_capsule.py`'s shape, omit-when-empty
- `services/orion-cortex-exec/app/chat_stance.py`: `_run_autonomy_reducer` reads/writes the store (via `asyncio.to_thread`), builds `chat_autonomy_movement_debug` from the actual `previous_state` used (not a separately-read baseline), sets `ctx["autonomy_slice"]` before the LLM step renders; `build_chat_stance_inputs` now `async def`
- `services/orion-cortex-exec/app/executor.py`: `prepare_brain_reply_context`/`ensure_chat_stance_pipeline_ctx` now `async def`, 2 call sites `await`
- `services/orion-cortex-exec/app/router.py`: removed the post-hoc (too-late) `autonomy_slice` compute; kept the metadata-attach; 2 call sites `await`
- `orion/cognition/prompts/stance_react.j2`: new `{% if autonomy_slice %}` and `{% if chat_attention_frame %}` blocks, mirroring the existing `mind_coloring` block's advisory framing
- `orion/harness/prefix.py`: new `_format_autonomy_slice()`, wired into `compile_harness_prefix()`; removed a dead `attention_frame` parameter added earlier in this branch (zero live caller, flagged by review, stripped per operator decision)
- `orion/thought/stance_react.py`, `services/orion-thought/app/bus_listener.py`: `_extract_autonomy_slice`, mirrors `_extract_grounding_capsule` exactly
- 14 test files updated for the async conversion (sync mocks → `AsyncMock`, `def test_` → `async def test_` + `@pytest.mark.asyncio` where they call the converted functions)
- 3 new test files: `orion/autonomy/tests/test_state_store.py`, `orion/schemas/tests/test_thought.py`, `services/orion-cortex-exec/tests/test_autonomy_slice.py`
- `docs/superpowers/plans/2026-07-11-autonomy-v2-closed-loop-wiring.md`: implementation plan (design doc is gitignored, local-only)

## Schema / bus / API changes

- Added: `AutonomySliceV1` schema, `ThoughtEventV1.autonomy_slice` field (optional)
- Added: `autonomy_state_v2` Postgres table
- No bus channel or schema-registry changes — this is a schema field + a new Postgres table, not a new event
- Compatibility: `ThoughtEventV1` remains valid with `autonomy_slice` omitted; every existing construction site unaffected

## Env/config changes

- Added keys: `ORION_AUTONOMY_STATE_DB_URL` (`services/orion-cortex-exec/.env_example`)
- `.env_example` updated: yes
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: yes (confirmed in-session)
- skipped keys requiring operator action: none

## Tests run

```text
pytest orion/autonomy/tests orion/schemas/tests orion/thought/tests orion/harness/tests -q
  343 passed, 3 failed (pre-existing on origin/main, confirmed via clean worktree — a
  mind_coloring StrictUndefined bug and an fcc_timeout error-string mismatch, unrelated)

pytest <14 touched cortex-exec test files> -q
  107 passed, 2 failed (pre-existing on origin/main, confirmed via same-.env in-place
  checkout of main's files — a chat_stance._UNIFICATION_LAYER test-order interference bug)

pytest services/orion-thought/tests -k stance_react -q
  8 passed
```

New regression tests: `test_chat_stance_autonomy_v2_slice_set_before_llm_render` (ctx["autonomy_slice"] present before the LLM step renders), `test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_state` (before/after pressures compare against the same baseline), `test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_call` (non-amnesiac acceptance check).

## Evals run

None. This service has an existing eval harness for the V2 reducer's own math (`orion/autonomy/evals/`), but no eval was added for the new persistence/prompt/harness wiring — flagged as a known gap in code review, not addressed in this patch.

## Docker/build/smoke checks

Not run — Docker was not exercised in this environment for this patch. `docker compose ... config` validation and a live turn smoke (verifying the rendered `stance_react.j2` prompt and a real harness prefix both contain the autonomy block) are recommended before/after deploy — see Restart required below.

## Review findings fixed

8-angle code review ran twice (first pass hit a session usage limit mid-run with zero findings returned; re-ran clean after a plan upgrade).

- Finding: `stance_react.j2`'s `autonomy_slice` prompt block could never render with real data — `ctx["autonomy_slice"]` was set in router.py's post-step processing, which runs strictly after the single-step `stance_react` plan's LLM call already rendered its prompt.
  - Fix: moved `build_autonomy_slice(ctx)` + `ctx["autonomy_slice"]` assignment into `chat_stance.py`, synchronously before the LLM step (same place `chat_attention_frame` is already set).
  - Evidence: new regression test `test_chat_stance_autonomy_v2_slice_set_before_llm_render`; traced the full call chain (`call_step_services` → `prepare_brain_reply_context` → `build_chat_stance_inputs` all run before the step's own `_render_prompt`).
- Finding: `chat_autonomy_movement_debug`'s "before" pressures were read from `autonomy["state"]` (V1/graph baseline) while "after" came from the actual fold's `previous_state` (persisted V2 once warm) — mismatched baselines once persistence kicks in, corrupting `pressure_trend`.
  - Fix: moved `chat_autonomy_movement_debug` construction inside `_run_autonomy_reducer`, using the same `previous_state` the fold actually used.
  - Evidence: new regression test `test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_state`.
- Finding: `build_autonomy_slice`'s omit-when-empty guard included `confidence is None`, but `confidence` defaults to `0.5` (always present) — empty-signal turns still produced a slice, rendering literal `"- dominant_drive: None"` into the LLM prompt.
  - Fix: excluded `confidence` from the emptiness check; added per-field Jinja guards as defense in depth.
  - Evidence: `orion/schemas/tests`, `test_autonomy_slice.py` pass; manual Jinja render check confirmed no `None`/`[]` leaks for partial slices.
- Finding: `compile_harness_prefix()`'s `attention_frame` parameter + formatter (added earlier in this branch) had zero live callers and a docstring admitting it — CLAUDE.md "No keyword cathedrals" violation.
  - Fix: removed per explicit operator decision; the live `stance_react.j2` half of that same task is untouched.
  - Evidence: `orion/harness/tests` unaffected (343 passed, same 3 pre-existing failures).
- Finding: `_run_autonomy_reducer`'s new Postgres calls ran synchronously inside an async call chain with no thread offload, despite an established `asyncio.to_thread` precedent elsewhere in this service.
  - Fix: full async conversion of the call chain (see Files changed); calls wrapped in `asyncio.to_thread`.
  - Evidence: 397+ tests passing after conversion, including 14 test files updated for the new async signatures.
- 3 findings not fixed (documented, non-blocking): `state_store.py`'s duplicated `_ENGINE_CACHE` pattern vs. `action_outcomes.py` (same DSN, two pools); `_extract_autonomy_slice`/`_extract_grounding_capsule` structural duplication (candidate for a shared helper); `state_store.py`'s docstring overclaims "mirrors action_outcomes.py exactly" but omits its file-backed fallback (silent total data loss if DSN unset/migration never applied, no distinguishing log).

## Restart required

```bash
# Apply the new migration to the live Postgres (conjourney) before this persists anything:
psql "$ORION_AUTONOMY_STATE_DB_URL" -f services/orion-sql-db/manual_migration_autonomy_state_v2.sql

# Restart cortex-exec (all 4 lanes share the image) and orion-thought:
docker compose --env-file .env --env-file services/orion-cortex-exec/.env -f services/orion-cortex-exec/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-thought/.env -f services/orion-thought/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: medium
  Concern: no evidence the `autonomy_state_v2` migration has been applied to the live Postgres — until it is, the reducer silently falls back to the V1 baseline every turn with no distinguishing log (documented in the state_store.py docstring finding above).
  Mitigation: run the migration command above before considering this "live." Consider adding a startup log line or health-check surfacing whether the table exists.
- Severity: low
  Concern: no eval added for the new persistence/prompt/harness behavior, only unit tests.
  Mitigation: follow-up eval extending `orion/autonomy/evals/` to cover turn-to-turn state carry and prompt/prefix content, if this becomes a priority.
- Severity: low
  Concern: `state_store.py` lacks the file-backed degraded-mode fallback that its sibling `action_outcomes.py` has.
  Mitigation: acceptable as-is (documented, fail-open, matches pre-existing behavior when unset) — revisit only if turn-to-turn persistence proves operationally important enough to need a degraded mode.