### PR TITLE
fix(hub): stop harness governor wait from timing out instantly

### DIFF
--- a/services/orion-hub/scripts/harness_governor_client.py
+++ b/services/orion-hub/scripts/harness_governor_client.py
@@ -16,6 +16,23 @@ logger = logging.getLogger("hub.bus.harness_governor")
 LivenessCheckFn = Callable[[float], bool]
 
 
+async def _get_message_within(pubsub, timeout: float) -> dict | None:
+    """pubsub.get_message() performs exactly one read per call: if that single read
+    consumes a non-publish message (most commonly the subscribe confirmation, which
+    arrives immediately after pubsub.subscribe()), it returns None almost instantly
+    instead of waiting out `timeout`. Loop on the remaining budget so a spurious single
+    read can't cut the wait short.
+    """
+    deadline = perf_counter() + timeout
+    while True:
+        remaining = deadline - perf_counter()
+        if remaining <= 0:
+            return None
+        msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=remaining)
+        if msg is not None:
+            return msg
+
+
 class HarnessGovernorClient:
     def __init__(self, bus: OrionBusAsync):
         self.bus = bus
@@ -191,10 +208,10 @@ class HarnessGovernorClient:
             await self.bus.publish(settings.CHANNEL_HARNESS_RUN_REQUEST, envelope)
             wait = poll_sec
             while True:
-                # pubsub.get_message's own timeout (not asyncio.wait_for cancelling an
+                # _get_message_within's own timeout (not asyncio.wait_for cancelling an
                 # in-flight read) so a reply landing right at the poll boundary can't be
                 # silently dropped by task cancellation racing message delivery.
-                msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=wait)
+                msg = await _get_message_within(pubsub, wait)
                 if msg is not None:
                     return msg
                 elapsed = perf_counter() - started

--- a/services/orion-hub/tests/test_harness_governor_client_liveness.py
+++ b/services/orion-hub/tests/test_harness_governor_client_liveness.py
@@ -110,6 +110,47 @@ class _FakeBus:
         yield _FakePubSub(self)
 
 
+class _SubscribeAckThenRealPubSub:
+    """Mimics the REAL redis.asyncio PubSub.get_message() one-read-per-call semantics:
+    the first call drains the subscribe confirmation and returns None almost instantly
+    (NOT after waiting out `timeout`) — a single ad-hoc `get_message(timeout=X)` call
+    would incorrectly read this as "no reply within X", when in reality the real reply
+    wait hasn't even started yet. Every call after the first behaves like the honest
+    bounded wait in _FakePubSub above.
+    """
+
+    def __init__(self, bus: "_FakeBus") -> None:
+        self._bus = bus
+        self._calls = 0
+
+    async def get_message(self, ignore_subscribe_messages: bool = False, timeout: float = 0.0) -> dict | None:
+        self._calls += 1
+        if self._calls == 1:
+            return None  # subscribe ack consumed the one read this call performs
+        assert self._bus._published_at is not None
+        remaining_to_reply = self._bus._reply_after_sec - (
+            asyncio.get_event_loop().time() - self._bus._published_at
+        )
+        if remaining_to_reply > timeout:
+            await asyncio.sleep(timeout)
+            return None
+        if remaining_to_reply > 0:
+            await asyncio.sleep(remaining_to_reply)
+        envelope = BaseEnvelope(
+            kind="harness.run.v1",
+            source=ServiceRef(name="test", version="0"),
+            correlation_id=_CORR_ID,
+            payload=self._bus._reply_payload,
+        )
+        return {"data": self._bus.codec.encode(envelope)}
+
+
+class _SubscribeAckThenRealBus(_FakeBus):
+    @asynccontextmanager
+    async def subscribe(self, *channels: str, patterns: bool = False):
+        yield _SubscribeAckThenRealPubSub(self)
+
+
 def _run_payload() -> dict:
     return HarnessRunV1(
         correlation_id=_CORR_ID,
@@ -229,6 +270,32 @@ async def test_liveness_check_receives_fixed_window_not_shrinking_poll_sec() -> 
     assert seen_windows, "liveness_check was never called"
     assert all(within_sec == 7.0 for within_sec in seen_windows)
     assert poll_sec not in seen_windows
+
+
+@pytest.mark.asyncio
+async def test_run_survives_spurious_instant_none_from_subscribe_ack() -> None:
+    """Regression test: pubsub.get_message() performs exactly ONE read per call. If
+    that read drains the subscribe confirmation (which arrives immediately after
+    pubsub.subscribe()), it returns None almost instantly instead of waiting out the
+    requested timeout. A naive single get_message(timeout=poll_sec) call would
+    misread this as "no reply within poll_sec" and give up on turn 0 instantly — and
+    liveness_check legitimately reads not-alive that early (the governor hasn't had
+    time to emit its first step yet for a turn that just started), so there's no
+    liveness-retry safety net to mask this: it must be fixed at the wait layer itself.
+    """
+    poll_sec = 5.0  # large relative to how fast the reply actually arrives below
+    bus = _SubscribeAckThenRealBus(reply_after_sec=0.05, reply_payload=_run_payload())
+    client = HarnessGovernorClient(bus)
+
+    result = await client.run(
+        _request(),
+        correlation_id=_CORR_ID,
+        timeout_sec=poll_sec,
+        liveness_check=lambda _within_sec: False,
+    )
+
+    assert result is not None
+    assert result.final_text == "done"
 
 
 class _FakeWorkerBus:


### PR DESCRIPTION
CRITICAL: PR #943 (merged) broke every unified turn, not just long tool-heavy ones. Caught live in production immediately after deploy: a plain "hi" chat message returned harness_rpc_timeout with elapsed_sec=0.0 instead of a real answer.

Root cause: redis-py's pubsub.get_message() performs exactly ONE read per call. The very first call after subscribe() drains the subscribe confirmation Redis sends back immediately, so get_message(timeout=poll_sec) returns None almost instantly instead of waiting out poll_sec — it does not loop internally to fill the requested timeout the way pubsub.listen() (used before PR #943) did. Because this happens at essentially t=0, liveness_check also legitimately reports "not alive yet" (the governor hasn't had time to emit its first step), so there was no retry safety net to mask the bug — every turn through _run_via_ad_hoc_subscribe failed immediately.

Fix: _get_message_within() wraps get_message in a loop that recomputes the remaining budget and keeps waiting until either a real message arrives or the full requested timeout has actually elapsed, so a spurious single-read None (subscribe ack, health-check pong, etc.) can't cut the wait short.

Verified against the real Redis bus (not just mocks) inside the running hub-app container: get_message_within correctly waited out a 3s timeout despite the subscribe-ack read. Verified end-to-end via a live POST /api/chat "hi" turn after rebuild+redeploy: completed in ~52s with a real answer and no timeout, where it previously failed in <1s on every attempt.

Added test_run_survives_spurious_instant_none_from_subscribe_ack, which models redis-py's real one-read-per-call semantics (the existing _FakePubSub mock was too lenient and never caught this). Confirmed the new test fails against the pre-fix code and passes against the fix.