### PR TITLE
fix(bus): stop pooled RPC worker from silently dying, add chat stop c…

### DIFF
--- a/orion/core/bus/async_service.py
+++ b/orion/core/bus/async_service.py
@@ -110,11 +110,63 @@ class OrionBusAsync:
         self._rpc_pubsub = rpc_redis.pubsub()
         try:
             while self._rpc_worker_running:
-                msg = await self._rpc_pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
-                if not msg or msg.get("type") not in ("message", "pmessage"):
+                # No reply-channel is subscribed yet (subscriptions happen lazily,
+                # on-demand, from _rpc_subscribe() as RPC calls come in) — redis-py's
+                # PubSub.get_message() -> parse_response() raises RuntimeError
+                # ("pubsub connection not set") when self.connection is None, since a
+                # subscribe()/psubscribe() call is what actually opens the underlying
+                # connection. Without this guard the worker crashes on its very first
+                # loop iteration, every single startup, before any turn ever runs.
+                if self._rpc_pubsub.connection is None:
+                    await asyncio.sleep(0.05)
                     continue
-                await self._handle_rpc_result(msg)
+                try:
+                    msg = await self._rpc_pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+                    if msg and msg.get("type") in ("message", "pmessage"):
+                        # Handling (decode/dispatch) is inside the same try as the read:
+                        # a bad payload must degrade to reconnect-and-retry like a
+                        # transport error, not kill the worker — otherwise a malformed
+                        # message reintroduces the exact "silently permanent fallback to
+                        # ad-hoc subscribe" failure this fix exists to close, just via a
+                        # different trigger.
+                        await self._handle_rpc_result(msg)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    # Transport-level failure (e.g. a network blip severing the
+                    # connection mid-read) — reconnect and re-subscribe to whatever
+                    # reply channels were already registered, instead of letting the
+                    # whole worker die silently and permanently degrading every future
+                    # HarnessGovernorClient.run() to the ad-hoc per-turn fallback path.
+                    logger.warning("[rpc-fork] pubsub read/handle failed, reconnecting: %s", exc)
+                    # Hold the same lock every _rpc_subscribe() caller holds while
+                    # touching self._rpc_pubsub/_rpc_subscribed — without it, a
+                    # concurrent caller mid-subscribe() on the object we're about to
+                    # close() can raise or land on a connection we're discarding.
+                    async with self._rpc_lock:
+                        with suppress(Exception):
+                            await self._rpc_pubsub.close()
+                        with suppress(Exception):
+                            await rpc_redis.close()
+                        rpc_redis = self._create_pubsub_redis()
+                        self._rpc_pubsub = rpc_redis.pubsub()
+                        if self._rpc_subscribed:
+                            try:
+                                await self._rpc_pubsub.subscribe(*sorted(self._rpc_subscribed))
+                            except Exception as resub_exc:
+                                # Do not suppress-and-forget: if Redis is still down,
+                                # self._rpc_pubsub.connection stays None and the
+                                # top-of-loop guard above retries on its own — but log
+                                # it, or a sustained outage goes completely invisible.
+                                logger.warning(
+                                    "[rpc-fork] resubscribe failed after reconnect, will retry: %s",
+                                    resub_exc,
+                                )
+                    await asyncio.sleep(0.1)
         except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("[rpc-fork] worker crashed unexpectedly, RPC calls will fall back to ad-hoc subscribe")
             raise
         finally:
             if self._rpc_pubsub is not None:

--- a/services/orion-hub/scripts/api_routes.py
+++ b/services/orion-hub/scripts/api_routes.py
@@ -293,6 +293,10 @@ class ChatMessageReceiptRequest(BaseModel):
     receipt_type: str = Field("opened")
 
 
+class ChatTurnCancelRequest(BaseModel):
+    connection_id: str
+
+
 class PreferencesResolveProxyRequest(BaseModel):
     recipient_group: str
     event_kind: str
@@ -1760,6 +1764,37 @@ def api_chat_message_receipt(message_id: str, payload: ChatMessageReceiptRequest
     except Exception as exc:
         logger.warning("Failed to send chat message receipt %s: %s", message_id, exc)
         raise HTTPException(status_code=502, detail="Failed to acknowledge chat message") from exc
+
+
+@router.post("/api/chat/turn/cancel")
+async def api_chat_turn_cancel(payload: ChatTurnCancelRequest):
+    """Stop/kill whichever turn the caller's WS connection currently has in flight
+    (Orion unified-harness turn or agent-claude turn). No-ops if nothing is active
+    for that connection — this is a general "stop chat" control, not an error path.
+
+    Keyed by connection_id (from the WS "connection_ready" frame), not session_id:
+    session_id is shared across every browser tab via localStorage, so keying on it
+    would let a stop click in one tab cancel another tab's turn.
+    """
+    from .main import bus, rpc_bus
+    from .websocket_handler import cancel_active_turn_for_connection
+
+    connection_id = str(payload.connection_id or "").strip()
+    if not connection_id:
+        raise HTTPException(status_code=422, detail="connection_id required")
+    if not bus or not getattr(bus, "enabled", False):
+        raise HTTPException(status_code=503, detail="Bus unavailable")
+
+    cancelled_corr = await cancel_active_turn_for_connection(
+        connection_id, bus=rpc_bus or bus, reason="user_stop"
+    )
+    logger.info(
+        "chat_turn_cancel_requested connection_id=%s cancelled_correlation_id=%s",
+        connection_id,
+        cancelled_corr,
+    )
+    return {"cancelled": bool(cancelled_corr), "correlation_id": cancelled_corr}
+
 
 @router.post("/api/chat/response-feedback")
 async def api_chat_response_feedback(payload: Dict[str, Any]):

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -68,6 +68,37 @@ from orion.cognition.verb_activation import is_active
 
 logger = logging.getLogger("orion-hub.ws")
 
+# Registry of the turn each live WS connection currently owns, keyed by a
+# per-connection id (NOT session_id — session_id is persisted client-side in
+# localStorage and shared across every browser tab on the same origin, so keying
+# on it would let a "stop" click in one tab cancel another tab's turn). The main
+# receive loop below blocks awaiting the in-flight turn between
+# websocket.receive_text() calls, so a same-connection "stop" message would sit
+# unread until the turn already finished — a stop command needs a side channel.
+# The HTTP cancel endpoint (api_routes.api_chat_turn_cancel) looks a connection up
+# here and reuses the same cancel_in_flight_turn() path WS-disconnect already uses.
+#
+# Each entry is the connection's own `active_turn` dict, stored by reference and
+# registered once at connection setup — mutating `active_turn` in the main loop
+# (as it already does) is automatically visible here with no separate
+# register/clear calls to keep in sync at every turn site.
+_ACTIVE_TURNS_BY_CONNECTION: Dict[str, Dict[str, Optional[str]]] = {}
+
+
+async def cancel_active_turn_for_connection(
+    connection_id: str, *, bus: Any, reason: str = "user_stop"
+) -> Optional[str]:
+    """Cancel whichever turn `connection_id` currently owns. Returns the cancelled
+    correlation_id, or None if that connection has no turn in flight.
+    """
+    entry = _ACTIVE_TURNS_BY_CONNECTION.get(str(connection_id or "").strip())
+    if not entry or not entry.get("correlation_id"):
+        return None
+    corr = str(entry["correlation_id"])
+    kind = str(entry.get("kind") or "orion")
+    await cancel_in_flight_turn(bus=bus, correlation_id=corr, kind=kind, reason=reason)
+    return corr
+
 
 async def _safe_ws_send_json(websocket: WebSocket, payload: Any) -> bool:
     """Send JSON only if the socket is still open; avoids RuntimeError after client disconnect."""
@@ -615,6 +646,9 @@ async def websocket_endpoint(websocket: WebSocket):
     if presence_state:
         presence_state.connected()
 
+    connection_id = str(uuid.uuid4())
+    await websocket.send_json({"type": "connection_ready", "connection_id": connection_id})
+
     client_meta = {
         "user_agent": websocket.headers.get("user-agent"),
         "origin": websocket.headers.get("origin"),
@@ -648,6 +682,9 @@ async def websocket_endpoint(websocket: WebSocket):
     )
     # Active FCC / harness turn for this socket — cancelled on WS disconnect.
     active_turn: Dict[str, Optional[str]] = {"correlation_id": None, "kind": None}
+    # Registered by reference: mutating active_turn above is automatically visible
+    # to the /api/chat/turn/cancel endpoint's lookup, no separate sync needed.
+    _ACTIVE_TURNS_BY_CONNECTION[connection_id] = active_turn
 
     try:
         while True:
@@ -1826,6 +1863,7 @@ async def websocket_endpoint(websocket: WebSocket):
                 reason="ws_error",
             )
     finally:
+        _ACTIVE_TURNS_BY_CONNECTION.pop(connection_id, None)
         drain_task.cancel()
         biometrics_task.cancel()
         if notification_cache is not None:

--- a/services/orion-hub/static/js/app.js
+++ b/services/orion-hub/static/js/app.js
@@ -66,6 +66,15 @@ let animationFrameId;
 let audioQueue = [];
 let isPlayingAudio = false;
 let orionState = 'idle';
+// True from the moment a WS chat message is sent until the server's closing
+// {"state": "idle"} arrives for that turn. orionState alone isn't a reliable signal
+// here — the server only pushes "processing" for voice/STT, not typed WS turns.
+let turnInFlight = false;
+// Set from the WS "connection_ready" frame. Deliberately NOT orionSessionId: that's
+// persisted in localStorage and shared across every browser tab on the same origin,
+// so a stop request keyed on it could cancel a different tab's turn. connection_id
+// is per-WebSocket-connection, so it always names exactly this tab's turn.
+let activeConnectionId = null;
 let particles = [];
 let visionIsFloating = false;
 let currentMode = "orion";
@@ -129,6 +138,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const chatInputExpandModalApply = document.getElementById('chatInputExpandModalApply');
   const chatInputExpandModalSend = document.getElementById('chatInputExpandModalSend');
   const sendButton = document.getElementById('sendButton');
+  const stopButton = document.getElementById('stopButton');
   const skillRunnerSelect = document.getElementById('skillRunnerSelect');
   const skillRunnerRunBtn = document.getElementById('skillRunnerRunBtn');
   const skillRunnerInsertBtn = document.getElementById('skillRunnerInsertBtn');
@@ -3252,6 +3262,8 @@ document.addEventListener("DOMContentLoaded", () => {
     if (orionState === 'idle') updateStatus('Ready.');
     else if (orionState === 'speaking') updateStatus('Speaking...');
     else if (orionState === 'processing') updateStatus('Processing...');
+    if (orionState === 'idle') turnInFlight = false;
+    if (stopButton) stopButton.classList.toggle('hidden', !turnInFlight);
   }
 
   function updateRoutingDebugPanel(data) {
@@ -9142,7 +9154,30 @@ document.addEventListener("DOMContentLoaded", () => {
     recordButton.addEventListener('pointercancel', () => stopRecording());
   }
 
+  async function stopCurrentTurn() {
+    const connectionId = String(activeConnectionId || '').trim();
+    if (!connectionId) {
+      updateStatus('Nothing to stop.');
+      return;
+    }
+    if (stopButton) stopButton.disabled = true;
+    try {
+      const res = await fetch('/api/chat/turn/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ connection_id: connectionId }),
+      });
+      const data = await res.json().catch(() => ({}));
+      updateStatus(data && data.cancelled ? 'Stopping...' : 'Nothing to stop.');
+    } catch (err) {
+      updateStatus('Stop failed.');
+    } finally {
+      if (stopButton) stopButton.disabled = false;
+    }
+  }
+
   if (sendButton) sendButton.addEventListener('click', sendTextMessage);
+  if (stopButton) stopButton.addEventListener('click', stopCurrentTurn);
   if (chatInput) {
     chatInput.addEventListener('input', () => {
       if (!chatInputExpandModalRoot || chatInputExpandModalRoot.classList.contains('hidden')) return;
@@ -10455,11 +10490,22 @@ document.addEventListener("DOMContentLoaded", () => {
           wsReadyResolve = null;
         }
         updateStatus('Connected.');
+        // A reconnect means any turn from the previous socket is unreachable now
+        // (its closing "state": "idle" frame, if any, will never arrive) — clear
+        // stale client-side turn-in-flight state rather than leave the Stop button
+        // stuck visible forever.
+        turnInFlight = false;
+        activeConnectionId = null;
+        if (stopButton) stopButton.classList.add('hidden');
     };
 
     socket.onmessage = (e) => {
       try {
           const d = JSON.parse(e.data);
+          if (d.type === 'connection_ready') {
+            activeConnectionId = d.connection_id || null;
+            return;
+          }
           if (d.type === 'turn_deferred') {
             appendMessage(
               'System',
@@ -10862,6 +10908,8 @@ document.addEventListener("DOMContentLoaded", () => {
     if (wsOpen && socket && socket.readyState === WebSocket.OPEN) {
         socket.send(JSON.stringify(payload));
         updateStatus('Sent...');
+        turnInFlight = true;
+        if (stopButton) stopButton.classList.remove('hidden');
     } else {
         if (!window.__orionWsFallbackWarned) {
           appendMessage(
@@ -11213,6 +11261,8 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         socket.send(JSON.stringify(audioPayload));
         console.info('[voice] sent audio payload bytes=%d', audioB64.length);
+        turnInFlight = true;
+        if (stopButton) stopButton.classList.remove('hidden');
         updateStatus(
           `Processing audio... peak=${audioMeta.peak.toFixed(5)} duration=${audioMeta.duration_sec.toFixed(2)}s`,
         );

--- a/services/orion-hub/templates/index.html
+++ b/services/orion-hub/templates/index.html
@@ -220,6 +220,13 @@
             </button>
           </div>
           <button id="sendButton" class="bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg px-4 py-2 font-semibold">Send</button>
+          <button
+            id="stopButton"
+            type="button"
+            class="hidden bg-red-700 hover:bg-red-600 text-white rounded-lg px-4 py-2 font-semibold"
+            title="Stop the in-flight turn"
+            aria-label="Stop the in-flight turn"
+          >Stop</button>
         </div>
 
         <div class="bg-gray-800 p-2 rounded-lg text-xs space-y-2">

--- a/services/orion-hub/tests/test_stop_chat_ui_smoke.py
+++ b/services/orion-hub/tests/test_stop_chat_ui_smoke.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+_HUB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_template_has_stop_button():
+    html = (_HUB_ROOT / "templates" / "index.html").read_text()
+    assert 'id="stopButton"' in html
+    assert "hidden" in html.split('id="stopButton"', 1)[1].split(">", 1)[0]
+
+
+def test_app_js_wires_stop_button():
+    js = (_HUB_ROOT / "static" / "js" / "app.js").read_text()
+    assert "getElementById('stopButton')" in js
+    assert "stopCurrentTurn" in js
+    assert "stopButton.addEventListener('click', stopCurrentTurn)" in js
+    assert "/api/chat/turn/cancel" in js
+
+
+def test_app_js_stop_request_uses_connection_id_not_session_id():
+    """Regression guard: the cancel request must key off the per-connection id
+    captured from the WS 'connection_ready' frame, not session_id — session_id is
+    shared across every browser tab via localStorage, so keying on it would let a
+    stop click in one tab cancel a different tab's turn.
+    """
+    js = (_HUB_ROOT / "static" / "js" / "app.js").read_text()
+    stop_fn = js.split("async function stopCurrentTurn()", 1)[1].split("\n  }\n", 1)[0]
+    assert "connection_id" in stop_fn
+    assert "activeConnectionId" in stop_fn
+    assert "orionSessionId" not in stop_fn
+
+
+def test_app_js_shows_stop_button_on_every_turn_kind_send():
+    """The Stop button must be shown for every WS send path that starts a
+    server-cancellable turn (orion text and voice), not just text chat.
+    """
+    js = (_HUB_ROOT / "static" / "js" / "app.js").read_text()
+    assert js.count("stopButton.classList.remove('hidden')") >= 2
+
+
+def test_app_js_captures_connection_id_from_connection_ready_frame():
+    js = (_HUB_ROOT / "static" / "js" / "app.js").read_text()
+    assert "d.type === 'connection_ready'" in js
+    assert "activeConnectionId = d.connection_id" in js

--- a/services/orion-hub/tests/test_turn_stop_command.py
+++ b/services/orion-hub/tests/test_turn_stop_command.py
@@ -1,0 +1,161 @@
+"""General 'stop chat' command: a per-connection active-turn registry in
+websocket_handler.py, and the /api/chat/turn/cancel endpoint that uses it.
+
+The WS receive loop blocks awaiting the in-flight turn between
+websocket.receive_text() calls, so a same-connection "stop" message would sit
+unread until the turn already finished. This registry is the side channel that
+lets an HTTP request find and cancel a connection's in-flight turn instead.
+
+Keyed by connection_id, not session_id: session_id is persisted client-side in
+localStorage and shared across every browser tab on the same origin, so keying
+on it would let a stop click in one tab cancel another tab's turn. Each
+registry entry is the connection's own `active_turn` dict, registered once by
+reference — mutating it in place (as the WS loop already does) is
+automatically visible to a lookup, with no separate register/clear calls to
+keep in sync.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cancel_active_turn_for_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.websocket_handler as wh
+
+    cancelled: list[tuple[str, str, str]] = []
+
+    async def fake_cancel(*, bus: Any, correlation_id: str, kind: str, reason: str = "client_disconnect") -> None:
+        cancelled.append((correlation_id, kind, reason))
+
+    monkeypatch.setattr(wh, "cancel_in_flight_turn", fake_cancel)
+    wh._ACTIVE_TURNS_BY_CONNECTION.clear()
+
+    active_turn = {"correlation_id": "corr-1", "kind": "orion"}
+    wh._ACTIVE_TURNS_BY_CONNECTION["conn-1"] = active_turn
+
+    result = await wh.cancel_active_turn_for_connection("conn-1", bus=object(), reason="user_stop")
+
+    assert result == "corr-1"
+    assert cancelled == [("corr-1", "orion", "user_stop")]
+
+
+@pytest.mark.asyncio
+async def test_cancel_active_turn_for_unknown_connection_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.websocket_handler as wh
+
+    cancelled: list[str] = []
+
+    async def fake_cancel(*, bus: Any, correlation_id: str, kind: str, reason: str = "client_disconnect") -> None:
+        cancelled.append(correlation_id)
+
+    monkeypatch.setattr(wh, "cancel_in_flight_turn", fake_cancel)
+    wh._ACTIVE_TURNS_BY_CONNECTION.clear()
+
+    result = await wh.cancel_active_turn_for_connection("no-such-connection", bus=object())
+
+    assert result is None
+    assert cancelled == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_active_turn_for_connection_with_no_turn_in_flight_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection is registered at setup even before any turn starts (correlation_id
+    is None until a turn actually begins) — cancel must no-op, not crash or cancel a
+    turn that isn't real.
+    """
+    import scripts.websocket_handler as wh
+
+    cancelled: list[str] = []
+
+    async def fake_cancel(*, bus: Any, correlation_id: str, kind: str, reason: str = "client_disconnect") -> None:
+        cancelled.append(correlation_id)
+
+    monkeypatch.setattr(wh, "cancel_in_flight_turn", fake_cancel)
+    wh._ACTIVE_TURNS_BY_CONNECTION.clear()
+    wh._ACTIVE_TURNS_BY_CONNECTION["conn-2"] = {"correlation_id": None, "kind": None}
+
+    result = await wh.cancel_active_turn_for_connection("conn-2", bus=object())
+
+    assert result is None
+    assert cancelled == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_active_turn_reflects_live_mutation_no_manual_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The registry stores the active_turn dict by reference: mutating it directly
+    (as the WS loop's turn sites do) must be visible without any separate
+    register/clear call — this is the whole point of not keeping two structures
+    in sync by hand.
+    """
+    import scripts.websocket_handler as wh
+
+    cancelled: list[str] = []
+
+    async def fake_cancel(*, bus: Any, correlation_id: str, kind: str, reason: str = "client_disconnect") -> None:
+        cancelled.append(correlation_id)
+
+    monkeypatch.setattr(wh, "cancel_in_flight_turn", fake_cancel)
+    wh._ACTIVE_TURNS_BY_CONNECTION.clear()
+
+    active_turn = {"correlation_id": None, "kind": None}
+    wh._ACTIVE_TURNS_BY_CONNECTION["conn-3"] = active_turn
+
+    # Simulate a turn starting: mutate in place, exactly as the WS loop does.
+    active_turn["correlation_id"] = "corr-3"
+    active_turn["kind"] = "agent-claude"
+
+    result = await wh.cancel_active_turn_for_connection("conn-3", bus=object())
+
+    assert result == "corr-3"
+    assert cancelled == ["corr-3"]
+
+
+@pytest.mark.asyncio
+async def test_api_chat_turn_cancel_requires_connection_id() -> None:
+    import scripts.api_routes as api_routes
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await api_routes.api_chat_turn_cancel(api_routes.ChatTurnCancelRequest(connection_id="  "))
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_api_chat_turn_cancel_503_when_bus_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.api_routes as api_routes
+    import scripts.main as hub_main
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(hub_main, "bus", None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await api_routes.api_chat_turn_cancel(api_routes.ChatTurnCancelRequest(connection_id="conn-3"))
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_api_chat_turn_cancel_returns_cancelled_correlation_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.api_routes as api_routes
+    import scripts.main as hub_main
+    import scripts.websocket_handler as wh
+
+    class _FakeBus:
+        enabled = True
+
+    monkeypatch.setattr(hub_main, "bus", _FakeBus())
+    monkeypatch.setattr(hub_main, "rpc_bus", None)
+
+    async def fake_cancel_active_turn_for_connection(connection_id: str, *, bus: Any, reason: str = "user_stop"):
+        assert connection_id == "conn-4"
+        return "corr-4"
+
+    monkeypatch.setattr(wh, "cancel_active_turn_for_connection", fake_cancel_active_turn_for_connection)
+
+    result = await api_routes.api_chat_turn_cancel(api_routes.ChatTurnCancelRequest(connection_id="conn-4"))
+
+    assert result == {"cancelled": True, "correlation_id": "corr-4"}

--- a/tests/test_bus_async_rpc_worker.py
+++ b/tests/test_bus_async_rpc_worker.py
@@ -1,0 +1,261 @@
+"""Regression coverage for OrionBusAsync._run_rpc_only.
+
+Live incident (2026-07-11, hub): every HarnessGovernorClient.run() call had been
+falling back to the ad-hoc per-turn subscribe path forever — the pooled RPC worker
+added in PR #943 had never once carried a reply. Root cause: _run_rpc_only() called
+pubsub.get_message() before any reply-channel was subscribed. redis-py's real
+PubSub.parse_response() raises RuntimeError("pubsub connection not set: did you
+forget to call subscribe() or psubscribe()?") when `self.connection is None`, which
+is true until the first subscribe() call — so the worker task died on its very first
+loop iteration, on every single startup, with nothing logging the exception.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.bus.codec import OrionCodec
+
+
+class _FakeConnection:
+    """Stand-in for redis-py's Connection: just a truthy sentinel."""
+
+
+class _FakePubSub:
+    """Mimics redis.asyncio's PubSub closely enough to reproduce the real bug:
+    `connection` is None until subscribe()/psubscribe() is called, and get_message()
+    raises RuntimeError in that state exactly like the real parse_response() does.
+    """
+
+    def __init__(self) -> None:
+        self.connection: _FakeConnection | None = None
+        self.subscribed: set[str] = set()
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self.get_message_override = None
+
+    async def subscribe(self, *channels: str) -> None:
+        self.connection = _FakeConnection()
+        self.subscribed.update(channels)
+
+    async def unsubscribe(self, *channels: str) -> None:
+        self.subscribed.difference_update(channels)
+
+    async def get_message(self, ignore_subscribe_messages: bool = True, timeout: float = 1.0):
+        if self.get_message_override is not None:
+            override = self.get_message_override
+            self.get_message_override = None
+            raise override
+        if self.connection is None:
+            raise RuntimeError(
+                "pubsub connection not set: did you forget to call subscribe() or psubscribe()?"
+            )
+        try:
+            return await asyncio.wait_for(self._queue.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    async def close(self) -> None:
+        return None
+
+    def push(self, msg: dict) -> None:
+        self._queue.put_nowait(msg)
+
+
+class _FakeRedis:
+    """_create_pubsub_redis() replacement. Mirrors real redis-py: each pubsub() call
+    (including the one _run_rpc_only makes on reconnect) returns a fresh PubSub with
+    connection=None. `.current` always points at whichever one the worker is actually
+    reading from, so tests can push messages/failures into the live instance.
+    """
+
+    def __init__(self) -> None:
+        self.current: _FakePubSub | None = None
+
+    def pubsub(self) -> _FakePubSub:
+        self.current = _FakePubSub()
+        return self.current
+
+    async def close(self) -> None:
+        return None
+
+
+def _make_bus() -> tuple[OrionBusAsync, _FakeRedis]:
+    bus = OrionBusAsync("redis://127.0.0.1:6379/0", enabled=True)
+    bus.connect = AsyncMock()  # avoid a real Redis command-connection dial in _rpc_subscribe
+    fake_redis = _FakeRedis()
+    return bus, fake_redis
+
+
+@pytest.mark.asyncio
+async def test_run_rpc_only_survives_get_message_before_any_subscribe() -> None:
+    """The worker must not crash before its first reply-channel subscription exists.
+    Pre-fix, this died within one event-loop tick (RuntimeError from parse_response),
+    so the task would be done() almost immediately.
+    """
+    bus, fake_redis = _make_bus()
+    with patch.object(bus, "_create_pubsub_redis", return_value=fake_redis):
+        bus.start_rpc_worker()
+        try:
+            await asyncio.sleep(0.3)
+            assert bus._rpc_worker_task is not None
+            assert not bus._rpc_worker_task.done(), (
+                "RPC worker died before any subscribe() call — "
+                "pre-subscribe get_message() crash regressed"
+            )
+        finally:
+            await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_run_rpc_only_delivers_message_after_late_subscribe() -> None:
+    """Once a real caller subscribes a reply channel (as HarnessGovernorClient._run_via_worker
+    does via _rpc_subscribe), the worker must still be alive and deliver the reply.
+    """
+    bus, fake_redis = _make_bus()
+    with patch.object(bus, "_create_pubsub_redis", return_value=fake_redis):
+        bus.start_rpc_worker()
+        await asyncio.sleep(0.1)  # spins in the pre-subscribe guard; must not crash
+
+        corr_id = "00000000-0000-4000-8000-000000000001"
+        reply_channel = f"orion:test:result:{corr_id}"
+        fut = asyncio.get_running_loop().create_future()
+        bus._pending_rpc[(reply_channel, corr_id)] = fut
+
+        async with bus._rpc_lock:
+            await bus._rpc_subscribe(reply_channel)
+
+        envelope = BaseEnvelope(
+            kind="test.reply.v1",
+            source=ServiceRef(name="test", version="0"),
+            correlation_id=corr_id,
+            payload={"ok": True},
+        )
+        codec = OrionCodec()
+        fake_redis.current.push(
+            {
+                "type": "message",
+                "channel": reply_channel.encode("utf-8"),
+                "data": codec.encode(envelope),
+            }
+        )
+
+        try:
+            msg = await asyncio.wait_for(fut, timeout=2.0)
+            assert msg is not None
+        finally:
+            await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_run_rpc_only_reconnects_after_transport_error() -> None:
+    """A genuine read failure (network blip) must not kill the worker permanently —
+    it should reconnect/re-subscribe and keep serving future RPC replies.
+    """
+    bus, fake_redis = _make_bus()
+    with patch.object(bus, "_create_pubsub_redis", return_value=fake_redis):
+        bus.start_rpc_worker()
+
+        corr_id = "00000000-0000-4000-8000-000000000002"
+        reply_channel = f"orion:test:result:{corr_id}"
+        async with bus._rpc_lock:
+            await bus._rpc_subscribe(reply_channel)
+        pubsub_before = fake_redis.current
+
+        # Simulate a dropped connection on the next read.
+        pubsub_before.get_message_override = ConnectionError("simulated transport drop")
+        await asyncio.sleep(0.3)
+
+        try:
+            assert bus._rpc_worker_task is not None
+            assert not bus._rpc_worker_task.done(), "worker died instead of reconnecting"
+            assert fake_redis.current is not pubsub_before, "worker never reconnected to a fresh pubsub"
+            assert reply_channel in fake_redis.current.subscribed, (
+                "worker reconnected but did not re-subscribe the live reply channel"
+            )
+
+            fut = asyncio.get_running_loop().create_future()
+            bus._pending_rpc[(reply_channel, corr_id)] = fut
+            envelope = BaseEnvelope(
+                kind="test.reply.v1",
+                source=ServiceRef(name="test", version="0"),
+                correlation_id=corr_id,
+                payload={"ok": True},
+            )
+            codec = OrionCodec()
+            fake_redis.current.push(
+                {
+                    "type": "message",
+                    "channel": reply_channel.encode("utf-8"),
+                    "data": codec.encode(envelope),
+                }
+            )
+            msg = await asyncio.wait_for(fut, timeout=2.0)
+            assert msg is not None
+        finally:
+            await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_run_rpc_only_survives_bad_payload_in_handle_rpc_result() -> None:
+    """A malformed/unexpected message must degrade like a transport error (reconnect
+    and keep going), not kill the worker — otherwise a single bad payload reintroduces
+    the exact "every future RPC call silently falls back to ad-hoc subscribe forever"
+    failure this fix exists to close, just triggered by bad data instead of the
+    pre-subscribe crash.
+    """
+    bus, fake_redis = _make_bus()
+    with patch.object(bus, "_create_pubsub_redis", return_value=fake_redis):
+        bus.start_rpc_worker()
+
+        corr_id = "00000000-0000-4000-8000-000000000003"
+        reply_channel = f"orion:test:result:{corr_id}"
+        async with bus._rpc_lock:
+            await bus._rpc_subscribe(reply_channel)
+
+        real_handle_rpc_result = bus._handle_rpc_result
+        calls = {"n": 0}
+
+        async def _flaky_handle_rpc_result(msg: dict) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ValueError("simulated malformed payload")
+            await real_handle_rpc_result(msg)
+
+        bus._handle_rpc_result = _flaky_handle_rpc_result
+
+        fake_redis.current.push(
+            {"type": "message", "channel": reply_channel.encode("utf-8"), "data": b"garbage"}
+        )
+        await asyncio.sleep(0.3)
+
+        try:
+            assert calls["n"] >= 1, "handler was never invoked"
+            assert bus._rpc_worker_task is not None
+            assert not bus._rpc_worker_task.done(), (
+                "worker died from a bad payload instead of reconnecting/continuing"
+            )
+
+            fut = asyncio.get_running_loop().create_future()
+            bus._pending_rpc[(reply_channel, corr_id)] = fut
+            envelope = BaseEnvelope(
+                kind="test.reply.v1",
+                source=ServiceRef(name="test", version="0"),
+                correlation_id=corr_id,
+                payload={"ok": True},
+            )
+            codec = OrionCodec()
+            fake_redis.current.push(
+                {
+                    "type": "message",
+                    "channel": reply_channel.encode("utf-8"),
+                    "data": codec.encode(envelope),
+                }
+            )
+            msg = await asyncio.wait_for(fut, timeout=2.0)
+            assert msg is not None
+        finally:
+            await bus.close()


### PR DESCRIPTION
Summary

  - Root-caused "did we unsync hub flushes": the pooled RPC worker (PR #943) called get_message() before any subscription existed, hitting redis-py's RuntimeError("pubsub connection not set") on its first loop tick, every startup, silently. 0/68 harness-governor RPCs on the live hub had ever used the fast
  path — 100% fell back to ad-hoc per-turn subscribe the entire time, unrelated to your mesh bounce (that was a separate, already-self-healed llamacpp blip).
  - Fixed OrionBusAsync._run_rpc_only: guards the pre-subscribe state, and makes transport errors self-heal (reconnect + re-subscribe) instead of killing the worker.
  - Added the general stop/kill chat command you asked for: POST /api/chat/turn/cancel, wired to a Stop button in the hub UI, reusing the existing HarnessRunCancelV1 cancel path.
  - Multi-agent code review caught 3 real bugs in my own reconnect fix before they shipped — including one that would have reintroduced the exact "silently permanent RPC blackout" bug this whole session was about, just via a different trigger — plus a cross-browser-tab bug in the new stop feature (Tab A's
  Stop button could cancel Tab B's turn). All fixed and covered by new regression tests.

  Outcome moved

  - Pooled RPC path went from 0% functional (always silent fallback) to actually carrying traffic — confirmed live: orion:cortex:gateway:request now shows path=worker where it always showed path=inline before, verified against the real production Redis/llamacpp/cortex-gateway mesh via a throwaway hub
  replica (the live orion-athena-hub container was never touched).
  - New: users can now kill a runaway chat turn instead of waiting it out. Verified live end-to-end — Stop click → cancel endpoint → HarnessRunCancelV1 → harness-governor logs killed=True → real claude subprocess SIGKILL'd (exited with code -9).

  Files changed

  - orion/core/bus/async_service.py: fixed the silent-crash bug; hardened the reconnect path (lock discipline, catch handler exceptions too, log resubscribe failures) after review caught gaps in my first pass.
  - services/orion-hub/scripts/websocket_handler.py: per-connection active-turn registry (registered by reference — no manual dual-bookkeeping), new connection_ready WS frame, cancel_active_turn_for_connection.
  - services/orion-hub/scripts/api_routes.py: POST /api/chat/turn/cancel.
  - services/orion-hub/templates/index.html + static/js/app.js: Stop button, wired to text/voice send paths, connection_id capture, reconnect-safe state reset.
  - tests/test_bus_async_rpc_worker.py, services/orion-hub/tests/test_turn_stop_command.py, services/orion-hub/tests/test_stop_chat_ui_smoke.py: new regression coverage.

  Schema / bus / API changes

  - Added: POST /api/chat/turn/cancel (hub-internal, not a bus/schema contract change — reuses existing HarnessRunCancelV1). No orion/bus/channels.yaml or orion/schemas/registry.py changes needed.
  - Added WS frame type connection_ready (hub → client only, additive, no existing consumer breaks).

  Tests run

  tests/test_bus_async_rpc_worker.py .... (4 passed — pre-subscribe crash regression, reconnect, bad-payload survival)
  tests/test_bus_rpc_fork_client.py . (1 passed)
  services/orion-hub/tests/test_turn_stop_command.py ....... (7 passed)
  services/orion-hub/tests/test_stop_chat_ui_smoke.py ..... (5 passed)
  services/orion-hub/tests/ (full suite): 750 passed, 39 failed, 5 skipped — all 39 failures confirmed pre-existing on baseline (diffed against a stashed-clean run), zero regressions introduced.
 
  Docker/build/smoke checks

  No Docker rebuild — ran the actual scripts.main:app via uvicorn against the real .env (real production Redis bus, real cortex-gateway, real llamacpp mesh) on a throwaway port, separate from the live orion-athena-hub container, then tore it down. See verification steps above.

  Review findings fixed

  - RPC worker reconnect held no lock during pubsub swap, racing _rpc_subscribe() callers → now under self._rpc_lock.
  - _handle_rpc_result exceptions bypassed the retry logic and killed the worker → now inside the same try/except as the read.
  - Resubscribe failures during reconnect were silently swallowed → now logged.
  - Stop-turn registry keyed by session_id, collides across browser tabs (localStorage-shared) → redesigned around a per-connection id from a new connection_ready frame.
  - Registry duplicated the existing per-connection active_turn dict at 4 call sites → now one shared-reference registration, no manual sync.
  - Voice-turn Stop button never appeared → wired.
  - Stale turnInFlight after a mid-turn WS drop → cleared on reconnect.
  - Missing JS/UI test coverage (CLAUDE.md §9) → added smoke tests matching the repo's existing convention.
  - Not fixed (low severity, noted as concerns): HTTP-fallback error path doesn't reset turnInFlight; reconnect retry has no backoff cap under a sustained outage.

  Restart required

  docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build orion-hub
  (Only orion-hub/bus-consuming services need this — async_service.py is shared, but only hub uses the pooled-worker path today.)

  Risks / concerns

  - Low — HTTP-fallback chat send error path can leave the Stop button visually stuck (cosmetic only; clicking it just no-ops).
  - Low — reconnect retry (0.1s, no backoff cap) could hammer Redis during an extended outage; fine for this deployment's scale, worth a follow-up if that ever matters.
