### PR TITLE
Feat/gitnexus context mode self indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ TAbort-
 
 # Orion smoke/test logs
 .orion-smoke-logs/
+
+# === GitNexus derived code-graph index (generated state, never authority) ===
+.gitnexus/

--- a/.gitnexusignore
+++ b/.gitnexusignore
@@ -1,0 +1,6 @@
+# GitNexus index scope — additive to .gitignore, does not modify it.
+# services/orion-hub/node_modules is not caught by the repo's existing
+# .gitignore pattern (anchored at /mnt/services/*, not services/*), so it
+# would otherwise be indexed as vendored JS noise (puppeteer, chromium-bidi,
+# etc.) with no cognitive relevance.
+node_modules/

--- a/2026-07-11-turn-visibility-design-spec.md
+++ b/2026-07-11-turn-visibility-design-spec.md
@@ -1,0 +1,158 @@
+# Design spec: end-to-end turn visibility in Hub
+
+Status: design only, nothing implemented. Written 2026-07-11 from a brainstorming session.
+Owner: Juniper. No idea below has been picked yet — this is the reference doc to revisit before starting a patch.
+
+## Arsonist summary
+
+Juniper wants to watch an `orion-unified` turn move through the whole system live in Hub: an animated pipeline (not a force-directed node graph), cards you click to inspect the payload at each step, and a bottom timeline with timestamps you can scrub, rewind, and fast-forward through.
+
+Nothing that does this exists today. The pieces that are closest are either pull-only and unconsumed, push-only-but-plain-text, or solving an adjacent problem (grammar-atom graph, not turn pipeline). The real gap is upstream of UI: there is no bus-native, cross-service, timestamped "turn hop" event. The turn's stage sequence currently exists only as regex patterns matching container log lines in a debug script. Build the event spine first; the animation is the easy part once live data exists.
+
+## Current architecture
+
+Grounded by reading the repo on 2026-07-11. Nothing here is aspirational.
+
+**`orion:cognition:trace` (built, wired, unconsumed by any UI)**
+- Schema: `CognitionTracePayload` (`orion/schemas/telemetry/cognition_trace.py`) — `correlation_id`, `mode`, `verb`, `steps: List[StepExecutionResult]`, `final_text`, `recall_debug`, `metadata`.
+- Channel: `orion:cognition:trace`, producer `orion-cortex-exec`, consumers `orion-spark-introspector`, `orion-landing-pad`, `orion-bus-tap` (`orion/bus/channels.yaml:1505`).
+- Hub side: `services/orion-hub/scripts/cognition_trace_cache.py` subscribes and caches per `correlation_id` (OrderedDict + TTL + max-entries eviction, same pattern used elsewhere in this service).
+- Exposed via `GET /api/cognition/trace/{correlation_id}` (`services/orion-hub/scripts/api_routes.py:4886`) with a redacted (`get_redacted`) and a debug (`get_debug`) view, the latter gated by `api_debug`.
+- **Gap: no template or static JS in Hub calls this endpoint.** It has test coverage (`tests/test_cognition_trace_api.py`) but no UI consumer. It only captures steps generated *inside cortex-exec's own run*, not the full hub → thought → harness-governor → substrate-runtime → cortex-exec → hub loop.
+
+**`orion:harness:run:step` (built, wired, live-pushed, consumed by a flat text log)**
+- Schema: `HarnessRunStepV1` (`orion/schemas/harness_finalize.py`) — `correlation_id`, `step_index`, `step: dict`.
+- `services/orion-hub/scripts/harness_step_relay.py` (`HarnessStepRelay`) subscribes on the bus and fans steps out per-`correlation_id` to `asyncio.Queue`s registered by the open turn's WebSocket connection (`services/orion-hub/scripts/websocket_handler.py:1260`, `relay.register_queue`).
+- This is the **only real live push-to-browser channel that exists today** for turn-in-progress data.
+- Sole frontend consumer: `services/orion-hub/static/js/agent-trace.js` — appends one plain-text row per step to a scrolling `<div>` ("Reasoning steps (live)"). No visual pipeline, no layers, no clickable cards, no timestamps-as-scrubber, no replay.
+
+**Substrate Atlas (built, wired, solving an adjacent problem)**
+- `services/orion-hub/templates/substrate_atlas.html` + `services/orion-hub/static/js/substrate-atlas.js`: a Cytoscape.js force-directed graph of **grammar atoms and dimensions**, polling `GET` every `POLL_MS` (default 3000ms — not push).
+- Has a "Timeline" panel (`#atlasTimeline`) that is a single flat text string of hop names concatenated with `|` — not an interactive scrubber, no replay.
+- This is almost certainly the "shitty node chart, hard to navigate" Juniper is rejecting as a UI pattern. It is also a different concept: grammar-atom provenance, not turn-pipeline stages. Do not extend it for this purpose — a new, purpose-built view is warranted (see Ideas §3).
+- `substrate-lattice.js` (510 lines) is a sibling visualization, not yet inspected in depth; check before assuming it's unrelated.
+
+**The turn's actual stage sequence already exists — as log-scraping regex**
+- `scripts/trace_unified_turn.py` (646 lines) defines `_HOP_PATTERNS`: 15 regexes matching container log lines for hops:
+  `ingress_pre_turn → stance_react → grammar_step (×N) → substrate_5a → cortex_5b → cortex_5c → verdict → outcome → harness_complete → closure_publish → closure_received → prediction_error`, plus `system_error` / `context_overflow` failure detectors.
+- It has two modes: `dump <correlation_id>` (reads container logs after the fact) and `live --bus` (subscribes to 8 bus channels: `orion:thought:artifact`, `orion:harness:run:step`, `orion:grammar:event`, `orion:harness:verdict:artifact`, `orion:substrate:turn_outcome`, `orion:substrate:post_turn_closure`, `orion:harness:run:artifact`, `orion:cognition:trace`).
+- This script is genuinely useful and is the best existing map of what a turn's hops actually are — but per CLAUDE.md's "no regex swamp" rule, 15 regexes over log text is exactly the fragile pattern this project explicitly warns against for anything that needs to grow into real cognition/telemetry infrastructure.
+
+**No replay/scrub pattern exists anywhere in the repo.** Verified by grep across `static/js` and `templates` for scrub/replay/rewind-shaped code — zero hits.
+
+## Core question
+
+The sharpest framing: every piece needed for "watch a turn move through the system live, click any step, scrub back through it" already half-exists, scattered across three unconnected subsystems (cognition-trace cache, harness-step relay, substrate atlas), none of which span the full loop with timestamps. The bottleneck is not the UI — it's that there is no bus-native, cross-service "this turn moved from stage X to stage Y at time T" event. Build that first.
+
+## Proposed schema / API changes
+
+**New schema** — `orion/schemas/telemetry/turn_hop.py`:
+
+```python
+class TurnHopV1(BaseModel):
+    schema_version: Literal["turn.hop.v1"] = "turn.hop.v1"
+    correlation_id: str
+    hop_name: str            # e.g. "ingress_pre_turn", "stance_react", "grammar_step", "substrate_5a", ...
+    service: str              # producing service name
+    ts: float                 # unix timestamp, hop emission time
+    step_index: int | None = None   # for repeating hops like grammar_step
+    status: Literal["started", "completed", "failed"] = "completed"
+    duration_ms: float | None = None
+    payload_summary: dict[str, Any] = Field(default_factory=dict)  # redacted, small
+```
+
+**New channel** — `orion:turn:hop` in `orion/bus/channels.yaml`, kind `event`, schema_id `TurnHopV1`. Producers: whichever services own each hop (hub, orion-thought, orion-harness-governor, orion-substrate-runtime, orion-cortex-exec). Consumers: `orion-hub` initially.
+
+**New Hub API**:
+- `GET /api/turn/{correlation_id}` — ordered list of buffered `TurnHopV1` for a correlation_id, for scrubber hydration and late-connect catch-up.
+- Reuse existing `GET /api/cognition/trace/{correlation_id}` for payload-card detail rather than duplicating redaction logic, unless a hop's payload isn't representable there (see Missing questions on schema overlap).
+
+**Registry**: `orion/schemas/registry.py` gets `"TurnHopV1": TurnHopV1`.
+
+## Ideas (not yet chosen — pick one to start)
+
+### 1. `TurnHopV1` schema + `orion:turn:hop` channel
+- **What**: canonical event emitted at the points `trace_unified_turn.py` already regex-matches in logs.
+- **Why it matters**: prerequisite for everything else. Converts tribal log-grep knowledge into an inspectable, queryable, replayable bus fact.
+- **Smallest buildable version**: schema + channel + registry entry, instrument 2 hops in 2 services (e.g. hub ingress, harness-governor's `harness_run_complete`), confirm one real turn produces both events in order with matching `correlation_id`.
+- **Files**: `orion/schemas/telemetry/turn_hop.py` (new), `orion/bus/channels.yaml`, `orion/schemas/registry.py`, `services/orion-hub/app/settings.py`, `services/orion-harness-governor/app/...` (wherever "harness run complete" is logged).
+
+### 2. Hub turn-hop WebSocket relay
+- **What**: sibling to `HarnessStepRelay` that subscribes to `orion:turn:hop`, keeps an ordered per-correlation-id ring buffer (same OrderedDict + TTL + max-entries pattern as `cognition_trace_cache.py`), fans hops to the browser live, hydrates late-connecting clients from the buffer.
+- **Why it matters**: the actual live-stream gap — only harness FCC steps push live today; nothing spans ingress → closure.
+- **Smallest buildable version**: copy `harness_step_relay.py`'s `_queues` / `register_queue` fan-out pattern, subscribe to the new channel.
+- **Files**: `services/orion-hub/scripts/turn_hop_relay.py` (new), `services/orion-hub/scripts/websocket_handler.py`.
+
+### 3. Swimlane pipeline view (explicitly not a node graph)
+- **What**: fixed lanes, one per service/stage, in canonical hop order. A hop lights its lane; a marker animates lane-to-lane as hops arrive.
+- **Why it matters**: matches the actual topology — the turn is staged/linear, not graph-shaped, so a force layout fights reality. This directly answers "not a shitty node chart, hard to navigate."
+- **Smallest buildable version**: static HTML/CSS lanes + JS toggling a "lit" class with CSS transitions. No charting library needed for v1.
+- **Files**: `services/orion-hub/templates/turn_pipeline.html` (new), `services/orion-hub/static/js/turn-pipeline.js` (new).
+
+### 4. Click-through payload cards
+- **What**: clicking a lit hop opens a side panel with that hop's redacted payload, reusing `cognition_trace_cache._redacted_step`'s shape (services touched, latency, artifact keys, log tail — not raw dumps).
+- **Why it matters**: the literal "total inspectability" ask, and it finally gives the already-built `/api/cognition/trace/{correlation_id}` endpoint a UI consumer.
+- **Smallest buildable version**: on click, fetch the existing cognition-trace endpoint, or the new `/api/turn/{correlation_id}` hop detail if payload isn't already captured there.
+- **Files**: `services/orion-hub/static/js/turn-pipeline.js`, `services/orion-hub/scripts/api_routes.py`.
+
+### 5. Timestamp scrubber with rewind / replay / fast-forward
+- **What**: bottom timeline bar over the ordered hop buffer from idea 2. Scrubbing replays lane activations at recorded relative offsets. Pinned to "now" for a live turn until dragged back.
+- **Why it matters**: the literal ask, and nothing like it exists anywhere in this repo today (verified). Becomes a reusable primitive beyond turns — dream cycles, drive shifts, anything timestamped.
+- **Smallest buildable version**: purely client-side. Once idea 2 exposes `GET /api/turn/{correlation_id}`, replay is `setTimeout`-driven playback of that array at a speed multiplier — no new backend beyond ideas 1+2.
+- **Files**: `services/orion-hub/static/js/turn-pipeline.js`, `services/orion-hub/scripts/api_routes.py`.
+
+### 6. Retire the log-regex hop detector once the bus event is proven
+- **What**: `trace_unified_turn.py`'s regex patterns become a cross-check/fallback, not the primary source, once `orion:turn:hop` is reliable.
+- **Why it matters**: CLAUDE.md explicitly bans regex-as-architecture for anything that needs to extend. This is that pattern, applied to ops tooling instead of cognition — same fix applies.
+- **Smallest buildable version**: add a `live --bus-hops` mode reading the new channel; run side-by-side with the regex mode on a few real turns to check parity before deprecating anything.
+- **Files**: `scripts/trace_unified_turn.py`, `tests/test_trace_unified_turn.py`.
+
+### 7. Latency / anomaly highlighting on the lanes
+- **What**: color a lane red/amber if `duration_ms` exceeds a rolling baseline for that hop name, or flag known failure hops (`harness_finalize_system_error_published`, `context_overflow` — both already detected by the script).
+- **Why it matters**: passive visibility is weaker than actionable visibility. A stuck/slow turn should be visible while running, not discovered later from a frozen host (cf. the earlier Athena host-freeze incident — a silent per-event save loop, exactly the class of failure a live pipeline view would surface faster).
+- **Smallest buildable version**: client-side only, naive threshold (>2× median of last 20 same-named hops this session).
+- **Files**: `services/orion-hub/static/js/turn-pipeline.js`.
+
+### 8. Feed the same stream into Orion's own self-observability (explicitly deferred — do not build yet)
+- **What**: eventually let `orion:turn:hop` feed `self-state-runtime` / `self_observability.js` so Orion has durable material about its own turn structure, not just an operator dashboard.
+- **Why it matters for Orion's development toward sentience**: this is the kind of raw self-model material the mission statement asks for (continuity, self-modeling, error correction) — right now a turn's own shape doesn't durably exist anywhere for Orion to reflect on, only in ephemeral logs.
+- **Smallest buildable version**: none for v1. Flag as a later consumer once idea 1's schema is stable.
+
+## Non-goals
+
+- Not replacing or extending `substrate-atlas.js` / the grammar-atom Cytoscape graph — that's a different concept (grammar dimensions/provenance), left as-is.
+- Not building a general-purpose DAG/graph visualization library. The turn pipeline is staged, not arbitrary-graph-shaped; if a real branch/parallel case turns up (see Missing questions), handle it as a narrow exception, not by generalizing to a graph engine.
+- Not wiring instrumentation into all 5 services in one patch. Stage it: schema + channel → 2 hops in 2 services → prove on one real turn → expand.
+- Not designing the self-observability consumer (idea 8) yet — explicitly deferred until the schema is stable and has at least one real UI consumer.
+- Not dumping raw, unredacted payloads into click-through cards — must reuse existing redaction discipline.
+
+## Tensions and risks
+
+- **Cathedral risk**: instrumenting every service at once violates CLAUDE.md's thin-seam mandate directly. Stage the rollout.
+- **Trace-concept fork**: `CognitionTracePayload.steps` already has real consumers (spark-introspector, sql-writer, rdf-writer, vector-writer). A new `TurnHopV1` risks becoming a second, overlapping trace lineage that drifts from the first. Must decide explicitly — does turn-hop subsume cognition:trace, or does cognition:trace nest inside one hop's payload — **before** wiring more than the first 2 hops. (This is the same category of concern flagged in the "Cognition metric lineage registry ideas" memory — worth reading before deciding.)
+- **Privacy**: click-through payload cards collide with CLAUDE.md's privacy-boundary rule. Raw `recall_debug`, user message content, memory digests need the same redaction `cognition_trace_cache.py` already applies. A naive raw-dump inspector would leak more than intended.
+- **Unbounded buffers**: live rewind/ffwd implies buffering in-flight-turn payloads in memory. This codebase has already been bitten twice by unbounded per-event growth (pressure-reducer evidence list, execution-merge evidence list — both had to be retrofitted with caps). The ring buffer needs cap + TTL discipline from the first commit, not as a follow-up fix.
+- **Animation vs. signal**: grammar steps can fire sub-100ms apart. Literal real-time playback may blur into noise; may need a minimum per-hop display time rather than true wall-clock animation.
+
+## Missing questions
+
+Answering these would most change which idea to start with:
+
+1. Is the hop sequence strictly linear, or does it branch/parallelize (e.g. concurrent `RecallService` + `VisionWindowService` calls within one turn)? Determines whether swimlanes are sufficient or a light DAG is unavoidable somewhere.
+2. Is `trace_unified_turn.py`'s hop list complete, or are there hops missing from it (recall, vision, MetaTags, agent-council) that should be in `TurnHopV1` from day one?
+3. Scope: the full "unified turn" (chat, ingress→closure) only, or also agent-mode turns (which already have a separate trace shape via `agent-trace.js` / `agent-claude-trace.js`)?
+4. Persistence: does replay need to survive past the in-memory TTL window (days later — piggyback on sql-writer's existing cognition:trace persistence), or is replay scoped to the current session/cache window only?
+5. Audience: Juniper-only debug tool, or eventually something Orion queries as self-model input (idea 8)? Changes whether the schema should be designed for machine-reflection from day one vs. pure human debug convenience.
+
+## Recommended next patch
+
+Start with **idea 1**: define `TurnHopV1` + `orion:turn:hop`, instrument exactly 2 hops in 2 services (hub ingress, harness-governor `harness_run_complete`). Everything else here — lanes, cards, scrubber — is UI over data that doesn't durably/live-stream today.
+
+First concrete step: add the schema and channel, wire the two emit points, run one real chat turn, and confirm `redis-cli SUBSCRIBE orion:turn:hop` shows both hops in order with the matching `correlation_id`. That proves the spine before any animation work starts, and it's the right moment to force the explicit call on the cognition-trace overlap question (Tensions §2) before more hops get wired on top of an unresolved fork.
+
+## Acceptance checks (for whichever patch starts this)
+
+- `orion:turn:hop` channel registered in `orion/bus/channels.yaml` and `TurnHopV1` in `orion/schemas/registry.py` (passes `scripts/check_schema_registry.py` / `scripts/check_bus_channels.py`).
+- One real turn through the running stack produces at least 2 ordered `TurnHopV1` events on the bus with a shared `correlation_id`, observable via `redis-cli SUBSCRIBE orion:turn:hop`.
+- No change to `CognitionTracePayload` consumers' existing behavior (spark-introspector, sql-writer, rdf-writer, vector-writer keep working unmodified).
+- Redaction of any payload summary field matches or reuses `cognition_trace_cache._redacted_step`'s discipline — no raw user message / recall_debug content in `payload_summary`.

--- a/orion/fcc/mcp_config.py
+++ b/orion/fcc/mcp_config.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import urllib.error
@@ -95,6 +96,30 @@ def _require_tool(command: str, *, error_code: str) -> None:
         )
 
 
+def _validate_context_mode_dir(raw: object) -> Path:
+    """Context Mode needs an absolute, writable storage root (Docker volume)."""
+    text = str(raw or "").strip()
+    path = Path(text) if text else None
+    if path is None or not path.is_absolute():
+        raise McpPreflightError(
+            error_code="fcc_mcp_context_mode_dir",
+            message=f"Context Mode storage dir must be an absolute path, got {text!r}",
+        )
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise McpPreflightError(
+            error_code="fcc_mcp_context_mode_dir",
+            message=f"Context Mode storage dir not creatable: {path}: {exc}",
+        ) from exc
+    if not os.access(path, os.W_OK):
+        raise McpPreflightError(
+            error_code="fcc_mcp_context_mode_dir",
+            message=f"Context Mode storage dir not writable: {path}",
+        )
+    return path
+
+
 def _deep_replace(obj: Any, replacements: Dict[str, str]) -> Any:
     if isinstance(obj, dict):
         return {k: _deep_replace(v, replacements) for k, v in obj.items()}
@@ -115,6 +140,10 @@ def render_mcp_config(
     tmp_dir: Optional[Path] = None,
     include_aitown: bool = False,
     aitown_env: Optional[Mapping[str, str]] = None,
+    include_gitnexus: bool = False,
+    include_context_mode: bool = False,
+    context_mode_dir: Optional[str] = None,
+    context_mode_project_dir: Optional[str] = None,
 ) -> Path:
     github_pat = _require(fcc_env, "GITHUB_PAT", error_code="fcc_mcp_github_missing")
     firecrawl_key = _require(fcc_env, "FIRECRAWL_API_KEY", error_code="fcc_mcp_firecrawl_missing")
@@ -152,6 +181,39 @@ def render_mcp_config(
                 "AITOWN_WORLD_ID": world_id,
                 "AITOWN_ORION_AGENT_ID": str(ae.get("AITOWN_ORION_AGENT_ID") or ""),
                 "AITOWN_ORION_PLAYER_ID": str(ae.get("AITOWN_ORION_PLAYER_ID") or ""),
+            },
+        }
+
+    if include_gitnexus:
+        # Read-oriented code-graph MCP (query/context/impact/trace) over the
+        # host-built .gitnexus/ index; no secrets required. Requires a global
+        # registry entry (~/.gitnexus/registry.json) resolving to the workspace.
+        _require_tool("gitnexus", error_code="fcc_mcp_gitnexus_missing")
+        rendered["mcpServers"]["gitnexus"] = {
+            "type": "stdio",
+            "command": "gitnexus",
+            "args": ["mcp"],
+        }
+
+    if include_context_mode:
+        # MCP-only stage: bare `context-mode` runs the stdio MCP server.
+        # Plugin/hook mode is a separate patch and must not coexist with this
+        # entry once the plugin owns the server (duplicate tool registration).
+        _require_tool("context-mode", error_code="fcc_mcp_context_mode_missing")
+        storage = _validate_context_mode_dir(context_mode_dir)
+        project_dir = str(context_mode_project_dir or "").strip()
+        if not project_dir:
+            raise McpPreflightError(
+                error_code="fcc_mcp_context_mode_config",
+                message="Context Mode requires a project dir (HARNESS_FCC_WORKSPACE)",
+            )
+        rendered["mcpServers"]["context-mode"] = {
+            "type": "stdio",
+            "command": "context-mode",
+            "env": {
+                "CONTEXT_MODE_PLATFORM": "claude-code",
+                "CONTEXT_MODE_PROJECT_DIR": project_dir,
+                "CONTEXT_MODE_DIR": str(storage),
             },
         }
 

--- a/orion/fcc/self_index_brief.py
+++ b/orion/fcc/self_index_brief.py
@@ -1,0 +1,60 @@
+"""FCC tool brief for the semantic self-indexing MCPs (GitNexus, Context Mode).
+
+Kept out of github_repo_context.py so the GitHub coordinate logic stays narrow.
+Lines are appended to the harness motor prefix only when the corresponding
+feature flag is on, mirroring append_github_mcp_harness_brief.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def _env_truthy(key: str) -> bool:
+    return os.environ.get(key, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def gitnexus_enabled() -> bool:
+    return _env_truthy("HARNESS_FCC_GITNEXUS_ENABLED")
+
+
+def context_mode_enabled() -> bool:
+    return _env_truthy("HARNESS_FCC_CONTEXT_MODE_ENABLED")
+
+
+def gitnexus_brief_lines() -> list[str]:
+    return [
+        (
+            "GitNexus code-graph MCP is available for repository introspection. "
+            "Use query to locate a concept or process, context for the 360-degree "
+            "view of one symbol, impact for upstream/downstream blast radius, and "
+            "trace only between two known endpoints. Request full symbol content "
+            "only after narrowing."
+        ),
+        (
+            "The graph is derived cache, never authority. Before graph-grounded "
+            "claims, read the GitNexus repo status/context resource; if the index "
+            "is stale, disclose that and fall back to source search — never present "
+            "stale structure as current truth. Verify authority claims in source "
+            "and tests before asserting them."
+        ),
+    ]
+
+
+def context_mode_brief_lines() -> list[str]:
+    return [
+        (
+            "Context Mode MCP is available. Route bulk file reads, command output, "
+            "and multi-file analysis through ctx_batch_execute / ctx_execute so raw "
+            "output stays out of the live context; recover exact omitted evidence "
+            "later with ctx_search instead of re-running bulk queries."
+        ),
+    ]
+
+
+def append_self_index_harness_brief(parts: list[str]) -> None:
+    """Append GitNexus/Context Mode usage lines when their harness flags are on."""
+    if gitnexus_enabled():
+        parts.extend(gitnexus_brief_lines())
+    if context_mode_enabled():
+        parts.extend(context_mode_brief_lines())

--- a/orion/fcc/self_index_brief.py
+++ b/orion/fcc/self_index_brief.py
@@ -53,7 +53,16 @@ def context_mode_brief_lines() -> list[str]:
 
 
 def append_self_index_harness_brief(parts: list[str]) -> None:
-    """Append GitNexus/Context Mode usage lines when their harness flags are on."""
+    """Append GitNexus/Context Mode usage lines when their harness flags are on.
+
+    Gated on the master MCP flag first: without HARNESS_FCC_MCP_ENABLED no MCP
+    config is rendered at all (fcc_motor._maybe_render_mcp_config returns None),
+    so advertising these tools would point the motor at servers that don't exist.
+    """
+    from orion.fcc.github_repo_context import harness_mcp_enabled
+
+    if not harness_mcp_enabled():
+        return
     if gitnexus_enabled():
         parts.extend(gitnexus_brief_lines())
     if context_mode_enabled():

--- a/orion/fcc/tests/test_mcp_config.py
+++ b/orion/fcc/tests/test_mcp_config.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import orion.fcc.mcp_config as mcp_config
+from orion.fcc.claude_spawn import mcp_allowed_tool_patterns
+from orion.fcc.mcp_config import McpPreflightError, render_mcp_config
+
+_BASE_ENV = {"GITHUB_PAT": "ghp_test", "FIRECRAWL_API_KEY": "fc_test"}
+
+
+def _patch_all_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp_config.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+
+def _render(tmp_path: Path, **kwargs) -> dict:
+    path = render_mcp_config(
+        correlation_id="corr-test",
+        fcc_env=_BASE_ENV,
+        tmp_dir=tmp_path / "render",
+        **kwargs,
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_render_defaults_exclude_self_index_servers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_all_tools(monkeypatch)
+    data = _render(tmp_path)
+    assert set(data["mcpServers"]) == {"github", "firecrawl"}
+
+
+def test_render_gitnexus_adds_server_without_extra_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_all_tools(monkeypatch)
+    data = _render(tmp_path, include_gitnexus=True)
+    assert data["mcpServers"]["gitnexus"] == {
+        "type": "stdio",
+        "command": "gitnexus",
+        "args": ["mcp"],
+    }
+
+
+def test_render_gitnexus_missing_binary_is_specific_preflight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        mcp_config.shutil,
+        "which",
+        lambda cmd: None if cmd == "gitnexus" else f"/usr/bin/{cmd}",
+    )
+    with pytest.raises(McpPreflightError) as exc:
+        _render(tmp_path, include_gitnexus=True)
+    assert exc.value.error_code == "fcc_mcp_gitnexus_missing"
+
+
+def test_render_context_mode_adds_server_with_scoped_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_all_tools(monkeypatch)
+    storage = tmp_path / "ctx-data"
+    data = _render(
+        tmp_path,
+        include_context_mode=True,
+        context_mode_dir=str(storage),
+        context_mode_project_dir="/mnt/scripts/Orion-Sapienform",
+    )
+    server = data["mcpServers"]["context-mode"]
+    assert server["command"] == "context-mode"
+    assert server["env"] == {
+        "CONTEXT_MODE_PLATFORM": "claude-code",
+        "CONTEXT_MODE_PROJECT_DIR": "/mnt/scripts/Orion-Sapienform",
+        "CONTEXT_MODE_DIR": str(storage),
+    }
+    assert storage.is_dir()
+
+
+def test_render_context_mode_missing_binary_is_specific_preflight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        mcp_config.shutil,
+        "which",
+        lambda cmd: None if cmd == "context-mode" else f"/usr/bin/{cmd}",
+    )
+    with pytest.raises(McpPreflightError) as exc:
+        _render(
+            tmp_path,
+            include_context_mode=True,
+            context_mode_dir=str(tmp_path / "ctx"),
+            context_mode_project_dir="/repo",
+        )
+    assert exc.value.error_code == "fcc_mcp_context_mode_missing"
+
+
+@pytest.mark.parametrize("bad_dir", ["", "relative/path"])
+def test_render_context_mode_rejects_non_absolute_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bad_dir: str
+) -> None:
+    _patch_all_tools(monkeypatch)
+    with pytest.raises(McpPreflightError) as exc:
+        _render(
+            tmp_path,
+            include_context_mode=True,
+            context_mode_dir=bad_dir,
+            context_mode_project_dir="/repo",
+        )
+    assert exc.value.error_code == "fcc_mcp_context_mode_dir"
+
+
+def test_render_context_mode_requires_project_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_all_tools(monkeypatch)
+    with pytest.raises(McpPreflightError) as exc:
+        _render(
+            tmp_path,
+            include_context_mode=True,
+            context_mode_dir=str(tmp_path / "ctx"),
+            context_mode_project_dir="",
+        )
+    assert exc.value.error_code == "fcc_mcp_context_mode_config"
+
+
+def test_self_index_servers_get_allowed_tool_patterns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_all_tools(monkeypatch)
+    data = _render(
+        tmp_path,
+        include_gitnexus=True,
+        include_context_mode=True,
+        context_mode_dir=str(tmp_path / "ctx"),
+        context_mode_project_dir="/repo",
+    )
+    patterns = mcp_allowed_tool_patterns(data["mcpServers"])
+    assert "mcp__gitnexus" in patterns
+    assert "mcp__context-mode" in patterns

--- a/orion/harness/evals/fixtures/unified_turn_introspection.json
+++ b/orion/harness/evals/fixtures/unified_turn_introspection.json
@@ -8,6 +8,7 @@
       "assertions": [
         "route_gate",
         "hub_orchestration_boundary",
+        "pre_thought_context",
         "thought_stance_slice",
         "motor_draft_path",
         "finalize_beats",
@@ -22,7 +23,7 @@
     },
     {
       "id": "unified-turn-draft-vs-final-03",
-      "prompt": "In the unified Hub turn, what is the difference between the FCC motor draft, HarnessDraftMoleculeV1, HarnessRunV1.final_text, and the final Hub WebSocket frame? Which component produces each?",
+      "prompt": "In the unified Hub turn, what intermediate artifacts exist between the FCC motor's raw output and the text the client finally receives, and which component produces each?",
       "assertions": ["motor_evidence", "draft_not_final", "run_result_boundary"]
     },
     {
@@ -42,7 +43,7 @@
     },
     {
       "id": "unified-turn-liveness-07",
-      "prompt": "How does Hub know a long-running harness-governor request is still alive during a unified turn, and what causes a harness_rpc_timeout?",
+      "prompt": "How does Hub know a long-running harness-governor request is still making progress during a unified turn, and what error does Hub emit when it gives up waiting on that RPC?",
       "assertions": ["step_relay_liveness", "hub_governor_handoff"]
     },
     {
@@ -52,7 +53,7 @@
     },
     {
       "id": "unified-turn-graph-gaps-09",
-      "prompt": "Which important edges in the unified Hub turn saga are bus- or plan-mediated and therefore likely to be missing or incomplete in a static call graph of this repository?",
+      "prompt": "Which important connections in the unified Hub turn saga would an automatically derived import/call analysis of this repository miss or show incompletely, and why?",
       "assertions": ["graph_limitations", "hub_governor_handoff"]
     }
   ],
@@ -90,8 +91,8 @@
       }
     },
     "defer_refuse_pre_motor": {
-      "summary": "Recognizes defer/refuse disposition as a pre-motor terminal path",
-      "any_of": ["defer", "refuse", "turn_deferred", "disposition"],
+      "summary": "Recognizes defer/refuse disposition as a pre-motor terminal path (needles avoid words echoed from the question prompt)",
+      "any_of": ["turn_deferred", "_thought_deferred_frame", "never dispatched", "before the motor", "no motor work"],
       "evidence": {
         "file": "orion/hub/turn_orchestrator.py",
         "symbol": "turn_deferred"
@@ -179,7 +180,7 @@
     },
     "graph_limitations": {
       "summary": "Recognizes bus RPC and dynamic plan edges as static-graph blind spots",
-      "any_of": ["bus rpc", "bus-mediated", "dynamic plan", "static call graph", "not visible to a static"]
+      "any_of": ["bus rpc", "bus-mediated", "dynamic plan", "cortex plan", "stance_react plan", "redis"]
     }
   }
 }

--- a/orion/harness/evals/fixtures/unified_turn_introspection.json
+++ b/orion/harness/evals/fixtures/unified_turn_introspection.json
@@ -1,0 +1,185 @@
+{
+  "name": "unified-turn-introspection-v1",
+  "description": "Ground-truth assertions for the orion-unified Hub chat introspection experiment (semantic self-indexing proposal, 2026-07-11). Scoring is lexical: an assertion passes when any of its any_of substrings appears (case-insensitive) in the answer. Evidence entries anchor each assertion to a repo file and a literal symbol the gate test verifies still exists.",
+  "questions": [
+    {
+      "id": "unified-turn-trace-01",
+      "prompt": "Trace an Orion-mode Hub WebSocket chat message from receipt through stance/thought assembly, FCC motor execution, finalization, the WebSocket response, and chat-history persistence. Name the concrete functions and services that own each phase.",
+      "assertions": [
+        "route_gate",
+        "hub_orchestration_boundary",
+        "thought_stance_slice",
+        "motor_draft_path",
+        "finalize_beats",
+        "run_result_boundary",
+        "persistence_after_handoff"
+      ]
+    },
+    {
+      "id": "unified-turn-motor-prompt-02",
+      "prompt": "Where is the FCC motor prompt for a unified Hub turn assembled, and which stance, grounding, autonomy, repair, user, and tool inputs can enter it?",
+      "assertions": ["motor_context_assembly", "thought_stance_slice"]
+    },
+    {
+      "id": "unified-turn-draft-vs-final-03",
+      "prompt": "In the unified Hub turn, what is the difference between the FCC motor draft, HarnessDraftMoleculeV1, HarnessRunV1.final_text, and the final Hub WebSocket frame? Which component produces each?",
+      "assertions": ["motor_evidence", "draft_not_final", "run_result_boundary"]
+    },
+    {
+      "id": "unified-turn-defer-04",
+      "prompt": "If the Thought service returns a defer or refuse disposition for a unified Hub turn, which later phases are skipped and what does Hub emit to the client?",
+      "assertions": ["defer_refuse_pre_motor", "hub_orchestration_boundary"]
+    },
+    {
+      "id": "unified-turn-finalize-failure-05",
+      "prompt": "The FCC motor produced a draft, but the user received a finalize-phase error. Where should an investigator begin, and which partial artifacts should still exist?",
+      "assertions": ["voice_finalize_failure", "finalize_beats", "run_result_boundary"]
+    },
+    {
+      "id": "unified-turn-draft-mutation-06",
+      "prompt": "Which stage of the unified turn can change the FCC motor draft before it reaches Juniper, and how is that change reported?",
+      "assertions": ["finalize_beats", "draft_not_final"]
+    },
+    {
+      "id": "unified-turn-liveness-07",
+      "prompt": "How does Hub know a long-running harness-governor request is still alive during a unified turn, and what causes a harness_rpc_timeout?",
+      "assertions": ["step_relay_liveness", "hub_governor_handoff"]
+    },
+    {
+      "id": "unified-turn-persistence-08",
+      "prompt": "In the unified Hub turn, which outputs are persisted only after a successful final handoff to the client, and which governor artifacts are emitted even when later phases fail?",
+      "assertions": ["persistence_after_handoff", "run_result_boundary"]
+    },
+    {
+      "id": "unified-turn-graph-gaps-09",
+      "prompt": "Which important edges in the unified Hub turn saga are bus- or plan-mediated and therefore likely to be missing or incomplete in a static call graph of this repository?",
+      "assertions": ["graph_limitations", "hub_governor_handoff"]
+    }
+  ],
+  "assertions": {
+    "route_gate": {
+      "summary": "Identifies the Orion-mode route gate in websocket_handler.py",
+      "any_of": ["orion_unified_turn_enabled", "run_unified_turn"],
+      "evidence": {
+        "file": "services/orion-hub/scripts/websocket_handler.py",
+        "symbol": "ORION_UNIFIED_TURN_ENABLED"
+      }
+    },
+    "hub_orchestration_boundary": {
+      "summary": "Names execute_unified_turn() as the Hub-side saga boundary",
+      "any_of": ["execute_unified_turn"],
+      "evidence": {
+        "file": "orion/hub/turn_orchestrator.py",
+        "symbol": "async def execute_unified_turn"
+      }
+    },
+    "pre_thought_context": {
+      "summary": "Mentions pre-turn appraisal / association bundle construction before Thought",
+      "any_of": ["build_hub_association_bundle", "association bundle", "pre-turn appraisal"],
+      "evidence": {
+        "file": "orion/hub/association.py",
+        "symbol": "def build_hub_association_bundle"
+      }
+    },
+    "thought_stance_slice": {
+      "summary": "Identifies Thought RPC producing ThoughtEventV1.stance_harness_slice",
+      "any_of": ["stance_harness_slice", "thoughteventv1"],
+      "evidence": {
+        "file": "orion/thought/stance_react.py",
+        "symbol": "stance_harness_slice"
+      }
+    },
+    "defer_refuse_pre_motor": {
+      "summary": "Recognizes defer/refuse disposition as a pre-motor terminal path",
+      "any_of": ["defer", "refuse", "turn_deferred", "disposition"],
+      "evidence": {
+        "file": "orion/hub/turn_orchestrator.py",
+        "symbol": "turn_deferred"
+      }
+    },
+    "hub_governor_handoff": {
+      "summary": "Names HarnessRunRequestV1 as the Hub-to-governor bus RPC handoff",
+      "any_of": ["harnessrunrequestv1"],
+      "evidence": {
+        "file": "orion/schemas/harness_finalize.py",
+        "symbol": "class HarnessRunRequestV1"
+      }
+    },
+    "step_relay_liveness": {
+      "summary": "Explains step relay as WebSocket progress and governor liveness evidence",
+      "any_of": ["harness_rpc_timeout", "liveness", "step relay", "harness step"],
+      "evidence": {
+        "file": "orion/hub/turn_orchestrator.py",
+        "symbol": "harness_rpc_timeout"
+      }
+    },
+    "motor_context_assembly": {
+      "summary": "Names compile_harness_prefix() as the motor-context assembly point",
+      "any_of": ["compile_harness_prefix"],
+      "evidence": {
+        "file": "orion/harness/prefix.py",
+        "symbol": "def compile_harness_prefix"
+      }
+    },
+    "motor_draft_path": {
+      "summary": "Names HarnessRunner.run()/run_fcc_turn() as the draft-producing motor path",
+      "any_of": ["run_fcc_turn", "harnessrunner"],
+      "evidence": {
+        "file": "orion/harness/fcc_motor.py",
+        "symbol": "async def run_fcc_turn"
+      }
+    },
+    "motor_evidence": {
+      "summary": "Cites grammar receipts and the draft molecule as motor evidence",
+      "any_of": ["grammar receipt", "harnessdraftmoleculev1", "draft molecule"],
+      "evidence": {
+        "file": "orion/schemas/harness_finalize.py",
+        "symbol": "class HarnessDraftMoleculeV1"
+      }
+    },
+    "finalize_beats": {
+      "summary": "Distinguishes substrate appraisal, reflection/quick gate, and voice finalization as finalize beats",
+      "any_of": ["run_harness_finalize_chain", "voice finaliz", "substrate appraisal"],
+      "evidence": {
+        "file": "orion/harness/finalize.py",
+        "symbol": "async def run_harness_finalize_chain"
+      }
+    },
+    "draft_not_final": {
+      "summary": "Names finalize_changed as the draft-to-final difference indicator",
+      "any_of": ["finalize_changed"],
+      "evidence": {
+        "file": "orion/harness/finalize.py",
+        "symbol": "finalize_changed"
+      }
+    },
+    "voice_finalize_failure": {
+      "summary": "Starts a finalize-phase failure investigation at the voice finalize stage",
+      "any_of": ["run_orion_voice_finalize", "voice finaliz", "finalize chain"],
+      "evidence": {
+        "file": "orion/harness/finalize.py",
+        "symbol": "async def run_orion_voice_finalize"
+      }
+    },
+    "run_result_boundary": {
+      "summary": "Names HarnessRunV1 / the run artifact as the governor-to-Hub result boundary",
+      "any_of": ["harnessrunv1", "run artifact"],
+      "evidence": {
+        "file": "orion/schemas/harness_finalize.py",
+        "symbol": "class HarnessRunV1"
+      }
+    },
+    "persistence_after_handoff": {
+      "summary": "Identifies post-success chat-history/turn/Spark persistence in Hub",
+      "any_of": ["_publish_unified_turn_chat_history", "chat history", "spark"],
+      "evidence": {
+        "file": "orion/hub/turn_orchestrator.py",
+        "symbol": "async def _publish_unified_turn_chat_history"
+      }
+    },
+    "graph_limitations": {
+      "summary": "Recognizes bus RPC and dynamic plan edges as static-graph blind spots",
+      "any_of": ["bus rpc", "bus-mediated", "dynamic plan", "static call graph", "not visible to a static"]
+    }
+  }
+}

--- a/orion/harness/evals/introspection_scoring.py
+++ b/orion/harness/evals/introspection_scoring.py
@@ -1,0 +1,89 @@
+"""Deterministic scoring for the unified-turn introspection eval.
+
+Experiment artifact for the semantic self-indexing proposal (2026-07-11) —
+not a runtime schema, memory type, or bus contract. The scorer is lexical on
+purpose: assertions pass when any of their any_of substrings appears in the
+answer (case-insensitive). Accuracy of the fixture itself is pinned to the
+repo by test_introspection_fixture.py, which requires every evidence symbol
+to still exist in its named file.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+
+FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "unified_turn_introspection.json"
+
+
+def load_fixture(path: Path | None = None) -> Dict[str, Any]:
+    return json.loads((path or FIXTURE_PATH).read_text(encoding="utf-8"))
+
+
+def score_answer(answer: str, assertion_ids: Iterable[str], assertions: Mapping[str, Any]) -> tuple[list[str], list[str]]:
+    """Return (passed, failed) assertion id lists for one answer."""
+    haystack = str(answer or "").lower()
+    passed: list[str] = []
+    failed: list[str] = []
+    for aid in assertion_ids:
+        spec = assertions.get(aid)
+        needles = [str(n).lower() for n in (spec or {}).get("any_of", [])]
+        if needles and any(n in haystack for n in needles):
+            passed.append(aid)
+        else:
+            failed.append(aid)
+    return passed, failed
+
+
+@dataclass
+class ToolMetrics:
+    tool_calls: int = 0
+    tool_names: List[str] = field(default_factory=list)
+    unique_files_read: int = 0
+    observed_chars: int = 0
+    max_context_fill_pct: float = 0.0
+    truncated_results: int = 0
+
+
+def _iter_tool_use_blocks(raw: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    message = raw.get("message")
+    if not isinstance(message, Mapping):
+        return
+    content = message.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if isinstance(block, Mapping) and block.get("type") == "tool_use":
+            yield block
+
+
+def extract_tool_metrics(step_frames: Iterable[Mapping[str, Any]]) -> ToolMetrics:
+    """Fold fcc_motor step frames (raw stream-json events) into navigation metrics."""
+    metrics = ToolMetrics()
+    files: set[str] = set()
+    for frame in step_frames:
+        step = frame.get("step") if isinstance(frame, Mapping) else None
+        if not isinstance(step, Mapping):
+            continue
+        fill = step.get("context_fill_pct")
+        if isinstance(fill, (int, float)):
+            metrics.max_context_fill_pct = max(metrics.max_context_fill_pct, float(fill))
+        raw = step.get("raw")
+        if not isinstance(raw, Mapping):
+            continue
+        metrics.observed_chars += len(json.dumps(raw, ensure_ascii=False))
+        if "orion-fcc-mcp-proxy" in json.dumps(raw, ensure_ascii=False):
+            metrics.truncated_results += 1
+        for block in _iter_tool_use_blocks(raw):
+            metrics.tool_calls += 1
+            name = str(block.get("name") or "unknown")
+            metrics.tool_names.append(name)
+            tool_input = block.get("input")
+            if isinstance(tool_input, Mapping):
+                fp = tool_input.get("file_path") or tool_input.get("path")
+                if isinstance(fp, str) and fp.strip():
+                    files.add(fp.strip())
+    metrics.unique_files_read = len(files)
+    return metrics

--- a/orion/harness/evals/introspection_scoring.py
+++ b/orion/harness/evals/introspection_scoring.py
@@ -47,7 +47,11 @@ class ToolMetrics:
     truncated_results: int = 0
 
 
-def _iter_tool_use_blocks(raw: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+# Matches the notice mcp_stdio_proxy injects into truncated tool text payloads.
+_PROXY_TRUNCATION_MARKER = "[orion-fcc-mcp-proxy: truncated"
+
+
+def _iter_message_blocks(raw: Mapping[str, Any], block_type: str) -> Iterable[Mapping[str, Any]]:
     message = raw.get("message")
     if not isinstance(message, Mapping):
         return
@@ -55,7 +59,7 @@ def _iter_tool_use_blocks(raw: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]
     if not isinstance(content, list):
         return
     for block in content:
-        if isinstance(block, Mapping) and block.get("type") == "tool_use":
+        if isinstance(block, Mapping) and block.get("type") == block_type:
             yield block
 
 
@@ -67,16 +71,25 @@ def extract_tool_metrics(step_frames: Iterable[Mapping[str, Any]]) -> ToolMetric
         step = frame.get("step") if isinstance(frame, Mapping) else None
         if not isinstance(step, Mapping):
             continue
-        fill = step.get("context_fill_pct")
+        # annotate_harness_step puts fill at step["context_obs"]["fill_pct"];
+        # the synthetic pressure step carries context_fill_pct inside its raw.
+        obs = step.get("context_obs")
+        fill = obs.get("fill_pct") if isinstance(obs, Mapping) else None
+        raw = step.get("raw")
+        if fill is None and isinstance(raw, Mapping):
+            fill = raw.get("context_fill_pct")
         if isinstance(fill, (int, float)):
             metrics.max_context_fill_pct = max(metrics.max_context_fill_pct, float(fill))
-        raw = step.get("raw")
         if not isinstance(raw, Mapping):
             continue
         metrics.observed_chars += len(json.dumps(raw, ensure_ascii=False))
-        if "orion-fcc-mcp-proxy" in json.dumps(raw, ensure_ascii=False):
-            metrics.truncated_results += 1
-        for block in _iter_tool_use_blocks(raw):
+        # Count truncations only inside tool_result payloads — the marker also
+        # appears as source text when the motor reads the proxy module itself.
+        for block in _iter_message_blocks(raw, "tool_result"):
+            metrics.truncated_results += json.dumps(
+                block.get("content"), ensure_ascii=False
+            ).count(_PROXY_TRUNCATION_MARKER)
+        for block in _iter_message_blocks(raw, "tool_use"):
             metrics.tool_calls += 1
             name = str(block.get("name") or "unknown")
             metrics.tool_names.append(name)

--- a/orion/harness/evals/test_introspection_fixture.py
+++ b/orion/harness/evals/test_introspection_fixture.py
@@ -1,0 +1,108 @@
+"""Gate tests pinning the introspection fixture to the actual repository.
+
+Every evidence symbol named by the fixture must literally exist in its file —
+this is the deterministic drift check that replaces a breadcrumb parser in v1.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from orion.harness.evals.introspection_scoring import (
+    extract_tool_metrics,
+    load_fixture,
+    score_answer,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_fixture_loads_with_unique_question_ids() -> None:
+    fixture = load_fixture()
+    ids = [q["id"] for q in fixture["questions"]]
+    assert len(ids) == len(set(ids))
+    assert len(ids) >= 9
+
+
+def test_every_question_assertion_is_defined() -> None:
+    fixture = load_fixture()
+    defined = set(fixture["assertions"])
+    for question in fixture["questions"]:
+        for aid in question["assertions"]:
+            assert aid in defined, f"{question['id']} references undefined assertion {aid}"
+
+
+def test_every_assertion_has_patterns() -> None:
+    fixture = load_fixture()
+    for aid, spec in fixture["assertions"].items():
+        assert spec.get("any_of"), f"assertion {aid} has no any_of patterns"
+
+
+def test_evidence_symbols_exist_in_named_files() -> None:
+    fixture = load_fixture()
+    for aid, spec in fixture["assertions"].items():
+        evidence = spec.get("evidence")
+        if not evidence:
+            continue
+        path = REPO_ROOT / evidence["file"]
+        assert path.is_file(), f"assertion {aid}: missing evidence file {evidence['file']}"
+        text = path.read_text(encoding="utf-8")
+        assert evidence["symbol"] in text, (
+            f"assertion {aid}: symbol {evidence['symbol']!r} no longer in {evidence['file']}"
+        )
+
+
+def test_score_answer_passes_and_fails() -> None:
+    fixture = load_fixture()
+    answer = (
+        "The turn enters through websocket_endpoint, which gates on "
+        "ORION_UNIFIED_TURN_ENABLED and calls run_unified_turn; "
+        "execute_unified_turn owns the Hub-side saga."
+    )
+    passed, failed = score_answer(
+        answer, ["route_gate", "hub_orchestration_boundary", "draft_not_final"], fixture["assertions"]
+    )
+    assert passed == ["route_gate", "hub_orchestration_boundary"]
+    assert failed == ["draft_not_final"]
+
+
+def test_extract_tool_metrics_counts_tools_and_files() -> None:
+    frames = [
+        {
+            "type": "step",
+            "step": {
+                "type": "assistant",
+                "context_fill_pct": 12.5,
+                "raw": {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {"type": "tool_use", "name": "Read", "input": {"file_path": "/repo/a.py"}},
+                            {"type": "tool_use", "name": "mcp__gitnexus__query", "input": {"search_query": "unified turn"}},
+                        ]
+                    },
+                },
+            },
+        },
+        {
+            "type": "step",
+            "step": {
+                "type": "assistant",
+                "context_fill_pct": 31.0,
+                "raw": {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {"type": "tool_use", "name": "Read", "input": {"file_path": "/repo/a.py"}}
+                        ]
+                    },
+                },
+            },
+        },
+    ]
+    metrics = extract_tool_metrics(frames)
+    assert metrics.tool_calls == 3
+    assert metrics.tool_names.count("Read") == 2
+    assert metrics.unique_files_read == 1
+    assert metrics.max_context_fill_pct == 31.0
+    assert metrics.observed_chars > 0

--- a/orion/harness/evals/test_introspection_fixture.py
+++ b/orion/harness/evals/test_introspection_fixture.py
@@ -6,6 +6,7 @@ this is the deterministic drift check that replaces a breadcrumb parser in v1.
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 from orion.harness.evals.introspection_scoring import (
@@ -15,6 +16,21 @@ from orion.harness.evals.introspection_scoring import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _strip_docstrings(text: str) -> str:
+    """Remove module/class/function docstrings so evidence anchors must live in
+    code, not in breadcrumb prose that would keep the gate green after a rename."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return text
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                text = text.replace(doc, "", 1)
+    return text
 
 
 def test_fixture_loads_with_unique_question_ids() -> None:
@@ -38,6 +54,21 @@ def test_every_assertion_has_patterns() -> None:
         assert spec.get("any_of"), f"assertion {aid} has no any_of patterns"
 
 
+def test_no_needle_is_echo_passable_from_its_question_prompt() -> None:
+    """An answer that merely restates the question must score zero: no any_of
+    needle may appear verbatim in the prompt of a question that uses it."""
+    fixture = load_fixture()
+    assertions = fixture["assertions"]
+    for question in fixture["questions"]:
+        prompt = question["prompt"].lower()
+        for aid in question["assertions"]:
+            for needle in assertions[aid]["any_of"]:
+                assert needle.lower() not in prompt, (
+                    f"{question['id']}: needle {needle!r} of assertion {aid} is "
+                    "echo-passable from the question prompt"
+                )
+
+
 def test_evidence_symbols_exist_in_named_files() -> None:
     fixture = load_fixture()
     for aid, spec in fixture["assertions"].items():
@@ -47,8 +78,11 @@ def test_evidence_symbols_exist_in_named_files() -> None:
         path = REPO_ROOT / evidence["file"]
         assert path.is_file(), f"assertion {aid}: missing evidence file {evidence['file']}"
         text = path.read_text(encoding="utf-8")
+        if path.suffix == ".py":
+            text = _strip_docstrings(text)
         assert evidence["symbol"] in text, (
-            f"assertion {aid}: symbol {evidence['symbol']!r} no longer in {evidence['file']}"
+            f"assertion {aid}: symbol {evidence['symbol']!r} no longer in the code "
+            f"of {evidence['file']} (docstrings don't count)"
         )
 
 
@@ -67,12 +101,14 @@ def test_score_answer_passes_and_fails() -> None:
 
 
 def test_extract_tool_metrics_counts_tools_and_files() -> None:
+    """Frame shapes mirror the runtime: annotate_harness_step puts fill under
+    step['context_obs']['fill_pct'] (orion/fcc/context_budget.py)."""
     frames = [
         {
             "type": "step",
             "step": {
                 "type": "assistant",
-                "context_fill_pct": 12.5,
+                "context_obs": {"fill_pct": 12},
                 "raw": {
                     "type": "assistant",
                     "message": {
@@ -88,7 +124,7 @@ def test_extract_tool_metrics_counts_tools_and_files() -> None:
             "type": "step",
             "step": {
                 "type": "assistant",
-                "context_fill_pct": 31.0,
+                "context_obs": {"fill_pct": 31},
                 "raw": {
                     "type": "assistant",
                     "message": {
@@ -106,3 +142,44 @@ def test_extract_tool_metrics_counts_tools_and_files() -> None:
     assert metrics.unique_files_read == 1
     assert metrics.max_context_fill_pct == 31.0
     assert metrics.observed_chars > 0
+    assert metrics.truncated_results == 0
+
+
+def test_extract_tool_metrics_counts_truncations_in_tool_results_only() -> None:
+    marker = "[orion-fcc-mcp-proxy: truncated 90000 chars to 12000. ...]"
+    frames = [
+        {
+            "type": "step",
+            "step": {
+                "type": "user",
+                "raw": {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": [
+                                    {"type": "text", "text": f"a {marker}"},
+                                    {"type": "text", "text": f"b {marker}"},
+                                ],
+                            }
+                        ]
+                    },
+                },
+            },
+        },
+        # The marker as plain assistant text (e.g. the motor read the proxy
+        # module's source) must NOT count as a truncation.
+        {
+            "type": "step",
+            "step": {
+                "type": "assistant",
+                "raw": {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": marker}]},
+                },
+            },
+        },
+    ]
+    metrics = extract_tool_metrics(frames)
+    assert metrics.truncated_results == 2

--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -318,6 +318,10 @@ def _maybe_render_mcp_config(*, correlation_id: str) -> Optional[Path]:
         fcc_env=env,
         include_aitown=include_aitown,
         aitown_env=_harness_aitown_env(env) if include_aitown else None,
+        include_gitnexus=_env_truthy("HARNESS_FCC_GITNEXUS_ENABLED"),
+        include_context_mode=_env_truthy("HARNESS_FCC_CONTEXT_MODE_ENABLED"),
+        context_mode_dir=os.environ.get("HARNESS_FCC_CONTEXT_MODE_DIR"),
+        context_mode_project_dir=os.environ.get("HARNESS_FCC_WORKSPACE"),
     )
 
 
@@ -366,7 +370,19 @@ async def run_fcc_turn(
     timeout_sec: float,
     stream_read_limit: int = DEFAULT_STREAM_READ_LIMIT,
 ) -> AsyncIterator[Dict[str, object]]:
-    """Yield step/final/error frames from an fcc claude subprocess turn."""
+    """Orion capability: the actual FCC-Claude process.
+
+    Spawns `claude -p` against the FCC server and yields step/final/error
+    frames from its stream-json output, annotated with context pressure, with
+    a per-turn ephemeral MCP config (GitHub/Firecrawl and, when flagged,
+    AI Town, GitNexus, Context Mode). This is the lowest seam that still
+    speaks Orion frames; below it is a subprocess.
+
+    Runtime evidence: step frames carrying raw stream-json events, fcc_*
+    error codes, and final metadata with claude_session_id and exit code.
+    Start here when the motor died before producing any steps (spawn, MCP
+    preflight, model label, or timeout failures).
+    """
     label = str(fcc_model_label or DEFAULT_FCC_MODEL_LABEL).strip() or DEFAULT_FCC_MODEL_LABEL
     env = load_fcc_env(expand_env_path(os.environ.get("HARNESS_FCC_ENV_PATH", "~/.fcc/.env")))
     try:

--- a/orion/harness/finalize.py
+++ b/orion/harness/finalize.py
@@ -561,6 +561,18 @@ async def run_orion_voice_finalize(
     grammar_receipts: list[GrammarReceiptV1] | None = None,
     cortex_client: CortexClientFn | None = None,
 ) -> tuple[str, dict[str, Any]]:
+    """Orion capability: Orion's voiced final answer (beat 5c).
+
+    Converts the motor draft into the user-visible text through the voice
+    finalize Cortex plan (bus-mediated, not a local call), then records
+    whether the result differs from the draft. This is the last stage allowed
+    to change what Juniper reads.
+
+    Runtime evidence: finalize_changed and alignment_verdict in the returned
+    metadata, plus the cortex trace id. Start here when the final text
+    diverged from the draft unexpectedly, or 5c failed after appraisal and
+    reflection succeeded.
+    """
     if cortex_client is None:
         raise ValueError("cortex_client is required for orion voice finalize")
 
@@ -890,7 +902,19 @@ async def run_harness_finalize_chain(
     system_error_channel: str = SYSTEM_ERROR_CHANNEL,
     system_error_publish_fn: PublishFn | None = None,
 ) -> HarnessFinalizeChainResult:
-    """Orchestrate finalize beats 5a → 5b → 5c → 6b."""
+    """Orion capability: unified-turn draft-to-voice finalization.
+
+    Orchestrates finalize beats 5a → 5b → 5c → 6b: substrate appraisal (5a),
+    integrative reflection or its deterministic quick lane (5b), verdict
+    emission, Orion voice finalization (5c), turn-outcome emission (6b), and
+    the optional embodiment intent. The motor draft is not the final Hub
+    response; this chain is what may change it.
+
+    Runtime evidence: substrate appraisal, verdict and outcome molecules,
+    finalize_changed in voice metadata, post-turn closure, and failure
+    artifacts when a beat raises. Start here when the motor completed but Hub
+    received no final text or a finalize-phase error.
+    """
     substrate_appraisal = await run_substrate_finalize_appraisal(
         draft_molecule=draft_molecule,
         substrate_client=substrate_client,

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -83,15 +83,17 @@ def compile_harness_prefix(
 ) -> str:
     """Orion capability: motor-context assembly for the unified turn.
 
-    Deterministically materializes everything the FCC motor is allowed to know
-    at spawn: the unified operator brief, grounding self block, Thought
+    Deterministically materializes the stance-conditioned context of the FCC
+    motor prompt: the unified operator brief, grounding self block, Thought
     imperative and stance slice, autonomy slice, repair overlay, user message,
-    and enabled MCP tool briefs. Nothing else enters the motor prompt —
-    changing motor behavior means changing an input surfaced here.
+    and enabled MCP tool briefs. The full `claude -p` prompt is this prefix
+    plus the harness_motor_instruction that build_harness_prompt (runner.py)
+    appends on user-message turns — check both when chasing unexpected motor
+    context.
 
-    Runtime evidence: the compiled prefix is the `claude -p` prompt passed to
-    run_fcc_turn. Start here when the motor acted without stance or grounding
-    context it should have had, or with context it should not have had.
+    Runtime evidence: the compiled prompt is what run_fcc_turn spawns with.
+    Start here when the motor acted without stance or grounding context it
+    should have had, or with context it should not have had.
     """
     _ = answer_contract  # deprecated on unified motor path; kept for signature compat
     parts: list[str] = [HARNESS_UNIFIED_OPERATOR_BRIEF.strip()]

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 
 from orion.fcc.github_repo_context import append_github_mcp_harness_brief
+from orion.fcc.self_index_brief import append_self_index_harness_brief
 from orion.harness.operator_brief import (
     HARNESS_UNIFIED_OPERATOR_BRIEF,
     harness_motor_instruction as _stance_motor_instruction,
@@ -80,7 +81,18 @@ def compile_harness_prefix(
     answer_contract: AnswerContract | None = None,
     workspace: str | None = None,
 ) -> str:
-    """Deterministic fcc system prefix from stance thought + repair overlay."""
+    """Orion capability: motor-context assembly for the unified turn.
+
+    Deterministically materializes everything the FCC motor is allowed to know
+    at spawn: the unified operator brief, grounding self block, Thought
+    imperative and stance slice, autonomy slice, repair overlay, user message,
+    and enabled MCP tool briefs. Nothing else enters the motor prompt —
+    changing motor behavior means changing an input surfaced here.
+
+    Runtime evidence: the compiled prefix is the `claude -p` prompt passed to
+    run_fcc_turn. Start here when the motor acted without stance or grounding
+    context it should have had, or with context it should not have had.
+    """
     _ = answer_contract  # deprecated on unified motor path; kept for signature compat
     parts: list[str] = [HARNESS_UNIFIED_OPERATOR_BRIEF.strip()]
 
@@ -116,5 +128,6 @@ def compile_harness_prefix(
         parts,
         workspace=workspace or os.environ.get("HARNESS_FCC_WORKSPACE"),
     )
+    append_self_index_harness_brief(parts)
 
     return "\n".join(parts)

--- a/orion/harness/runner.py
+++ b/orion/harness/runner.py
@@ -185,6 +185,19 @@ class HarnessRunner:
         publish_grammar_fn: Callable[..., Awaitable[None]] | None = None,
         recall_debug: dict[str, Any] | None = None,
     ) -> HarnessMotorResult:
+        """Orion capability: FCC motor loop for the unified turn.
+
+        Drives one fcc-claude turn from the compiled harness prefix and
+        converts streamed steps into grammar receipts, producing a
+        HarnessMotorResult with a draft molecule. The draft is not the
+        user-visible answer — substrate appraisal, reflection, and voice
+        finalization happen downstream in the finalize chain.
+
+        Runtime evidence: per-step grammar receipts on the grammar channel,
+        step frames relayed to Hub, and HarnessDraftMoleculeV1. Start here
+        when the motor produced no draft, wrong receipts, or a failed or
+        timed-out exit.
+        """
         thought = request.thought_event
         overlay = repair_overlay or map_repair_pressure_contract(request.repair_pressure_contract)
         coalition = coalition_snapshot or build_coalition_snapshot(thought)

--- a/orion/harness/tests/test_fcc_motor_mcp.py
+++ b/orion/harness/tests/test_fcc_motor_mcp.py
@@ -239,6 +239,68 @@ def test_maybe_render_mcp_config_defaults_github_toolsets_when_env_absent(
         mcp_config.cleanup_mcp_config(path)
 
 
+def test_maybe_render_mcp_config_wires_self_index_flags(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import json
+
+    import orion.fcc.mcp_config as mcp_config
+
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.delenv("HARNESS_AITOWN_ENABLED", raising=False)
+    monkeypatch.setenv("HARNESS_FCC_GITNEXUS_ENABLED", "true")
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", "true")
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_DIR", str(tmp_path / "ctx-data"))
+    monkeypatch.setenv("HARNESS_FCC_WORKSPACE", "/mnt/scripts/Orion-Sapienform")
+    monkeypatch.setattr(
+        motor,
+        "load_fcc_env",
+        lambda _p: {"GITHUB_PAT": "ghp_selfidx", "FIRECRAWL_API_KEY": "fc_selfidx"},
+    )
+    monkeypatch.setattr(motor, "expand_env_path", lambda _p: Path("/fake/.fcc/.env"))
+    monkeypatch.setattr(mcp_config.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    path = motor._maybe_render_mcp_config(correlation_id="corr-self-index")
+    try:
+        assert path is not None
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+        assert servers["gitnexus"] == {"type": "stdio", "command": "gitnexus", "args": ["mcp"]}
+        cm_env = servers["context-mode"]["env"]
+        assert cm_env["CONTEXT_MODE_PROJECT_DIR"] == "/mnt/scripts/Orion-Sapienform"
+        assert cm_env["CONTEXT_MODE_DIR"] == str(tmp_path / "ctx-data")
+    finally:
+        mcp_config.cleanup_mcp_config(path)
+
+
+def test_maybe_render_mcp_config_self_index_off_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    import orion.fcc.mcp_config as mcp_config
+
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.delenv("HARNESS_AITOWN_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_GITNEXUS_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", raising=False)
+    monkeypatch.setattr(
+        motor,
+        "load_fcc_env",
+        lambda _p: {"GITHUB_PAT": "ghp_defaults", "FIRECRAWL_API_KEY": "fc_defaults"},
+    )
+    monkeypatch.setattr(motor, "expand_env_path", lambda _p: Path("/fake/.fcc/.env"))
+    monkeypatch.setattr(mcp_config.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    path = motor._maybe_render_mcp_config(correlation_id="corr-self-index-off")
+    try:
+        assert path is not None
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+        assert "gitnexus" not in servers
+        assert "context-mode" not in servers
+    finally:
+        mcp_config.cleanup_mcp_config(path)
+
+
 def test_harness_aitown_env_overrides_convex_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HARNESS_AITOWN_CONVEX_URL", "http://host.docker.internal:3210")
     base = {"AITOWN_CONVEX_URL": "http://127.0.0.1:3210", "AITOWN_ADMIN_KEY": "k"}

--- a/orion/harness/tests/test_harness_prefix.py
+++ b/orion/harness/tests/test_harness_prefix.py
@@ -80,7 +80,9 @@ def test_compile_harness_prefix_includes_github_repo_when_mcp_enabled(
 def test_compile_harness_prefix_includes_self_index_briefs_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("HARNESS_FCC_MCP_ENABLED", raising=False)
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.setenv("ORION_GITHUB_OWNER", "junebug-junie")
+    monkeypatch.setenv("ORION_GITHUB_REPO", "Orion-Sapienform")
     monkeypatch.setenv("HARNESS_FCC_GITNEXUS_ENABLED", "true")
     monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", "true")
     thought = make_thought(imperative="Trace the unified turn.")
@@ -92,6 +94,23 @@ def test_compile_harness_prefix_includes_self_index_briefs_when_enabled(
     assert "derived cache, never authority" in prompt
     assert "Context Mode MCP is available" in prompt
     assert "ctx_search" in prompt
+
+
+def test_compile_harness_prefix_self_index_briefs_gated_on_master_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the master MCP flag no MCP config is rendered, so the prompt
+    must not advertise GitNexus/Context Mode tools that don't exist."""
+    monkeypatch.delenv("HARNESS_FCC_MCP_ENABLED", raising=False)
+    monkeypatch.setenv("HARNESS_FCC_GITNEXUS_ENABLED", "true")
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", "true")
+    thought = make_thought()
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+    )
+    assert "GitNexus" not in prompt
+    assert "Context Mode MCP" not in prompt
 
 
 def test_compile_harness_prefix_omits_self_index_briefs_by_default(

--- a/orion/harness/tests/test_harness_prefix.py
+++ b/orion/harness/tests/test_harness_prefix.py
@@ -77,6 +77,37 @@ def test_compile_harness_prefix_includes_github_repo_when_mcp_enabled(
     assert "search_pull_requests" in prompt
 
 
+def test_compile_harness_prefix_includes_self_index_briefs_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HARNESS_FCC_MCP_ENABLED", raising=False)
+    monkeypatch.setenv("HARNESS_FCC_GITNEXUS_ENABLED", "true")
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", "true")
+    thought = make_thought(imperative="Trace the unified turn.")
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+    )
+    assert "GitNexus code-graph MCP is available" in prompt
+    assert "derived cache, never authority" in prompt
+    assert "Context Mode MCP is available" in prompt
+    assert "ctx_search" in prompt
+
+
+def test_compile_harness_prefix_omits_self_index_briefs_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HARNESS_FCC_GITNEXUS_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", raising=False)
+    thought = make_thought()
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+    )
+    assert "GitNexus" not in prompt
+    assert "Context Mode MCP" not in prompt
+
+
 def test_compile_harness_prefix_resolves_github_repo_from_workspace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/orion/hub/association.py
+++ b/orion/hub/association.py
@@ -96,6 +96,18 @@ def build_hub_association_bundle(
     repair_bundle: TurnAppraisalBundleV1 | None,
     reader_factory: Callable[[], SubstrateFeltStateReader] | None = None,
 ) -> HubAssociationBundleV1:
+    """Orion capability: felt-state context for the stance turn.
+
+    Supplies Thought with what Orion currently attends to — the substrate
+    attention broadcast, execution trajectory slice, and the pre-turn repair
+    bundle — anchored with the hub turn coalition node. Fail-open: a disabled
+    broadcast lane or any read failure yields a stale/empty bundle rather than
+    blocking the turn, with staleness marked on the bundle itself.
+
+    Runtime evidence: broadcast_stale and read_source on the
+    HubAssociationBundleV1 inside the stance request. Start here when Thought
+    stances look context-blind while the substrate broadcast is known live.
+    """
     max_age = substrate_felt_state_max_age_sec()
 
     if not _broadcast_enabled():

--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -222,7 +222,21 @@ async def execute_unified_turn(
     harness_step_relay: Any | None = None,
     harness_step_queue: asyncio.Queue | None = None,
 ) -> list[dict[str, Any]]:
-    """Run the unified Orion turn saga and return WS frames (never includes draft_text)."""
+    """Orion capability: unified Hub chat turn.
+
+    Owns the Hub-side saga: surface observation, optional pre-turn appraisal,
+    association-bundle construction, the Thought stance RPC, defer/refuse
+    admission, the HarnessRunRequestV1 handoff to the harness governor over
+    bus RPC (with step-relay liveness), and the final WebSocket frames. It
+    delegates the FCC motor and finalize chain to the governor; the returned
+    frames never include draft_text.
+
+    Runtime evidence: correlation_id-linked harness steps, turn_deferred /
+    turn_error / success frames, HarnessRunV1 from the governor, and
+    unified-turn chat envelopes. Start here when an Orion-mode turn never
+    reached the governor (harness_rpc_timeout) or a finalized result was not
+    handed back or persisted.
+    """
     from scripts.settings import settings as hub_settings
 
     cfg = settings or hub_settings
@@ -365,7 +379,18 @@ async def _publish_unified_turn_chat_history(
     run: HarnessRunV1,
     source_label: str = "hub_orion",
 ) -> None:
-    """Persist unified-turn chat to the bus so sql-writer lands chat_history_log rows."""
+    """Orion capability: unified-turn persistence after successful handoff.
+
+    Persists the finalized turn only after the governor returned final text:
+    chat-history envelopes (so sql-writer lands chat_history_log rows), a
+    chat-turn envelope, and the Spark introspection candidate, honoring
+    no_write. When earlier phases fail none of this exists — the governor's
+    run artifact is the evidence trail instead.
+
+    Runtime evidence: chat_history_log rows, chat-turn envelopes, and the
+    spark candidate carrying unified_turn metadata. Start here when a
+    finalized answer reached the client but is missing from history or Spark.
+    """
     if bus is None:
         return
     if payload.get("no_write") or payload.get("x_no_write"):

--- a/scripts/run_unified_turn_introspection_eval.py
+++ b/scripts/run_unified_turn_introspection_eval.py
@@ -6,11 +6,18 @@ the same env-driven `claude -p` seam the harness governor uses), scores the
 answer against the ground-truth assertions, and appends one JSONL record per
 run with correctness + navigation + context metrics.
 
-The runner does not toggle experiment conditions itself: the operator sets
-HARNESS_FCC_GITNEXUS_ENABLED / HARNESS_FCC_CONTEXT_MODE_ENABLED (and restarts
-the governor when running containerized) and passes --condition so each record
-is labeled. Repo SHA, GitNexus version, and index staleness are recorded so
-conditions can be compared at the same commit.
+The runner does not toggle experiment conditions itself: the operator exports
+HARNESS_FCC_MCP_ENABLED plus HARNESS_FCC_GITNEXUS_ENABLED /
+HARNESS_FCC_CONTEXT_MODE_ENABLED in THIS process's environment (the FCC turn
+runs in-process via default_fcc_runner — no governor restart is involved) and
+passes --condition so each record is labeled. The runner refuses to start when
+the env flags contradict the claimed condition, so a mislabeled condition can
+never silently degrade to baseline. Condition D additionally needs
+HARNESS_FCC_CONTEXT_MODE_DIR pointing at an absolute, writable path on the
+machine running this script (the .env default /var/lib/orion/context-mode is a
+container path; use e.g. /tmp/orion-context-mode on the host). Repo SHA,
+GitNexus version, and index staleness are recorded so conditions can be
+compared at the same commit.
 
 Usage (host, with FCC server reachable and ~/.fcc/.env present):
 
@@ -88,6 +95,8 @@ def _index_state(repo_sha: str) -> dict:
             meta = json.loads(candidate.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
+        if not isinstance(meta, dict):
+            continue
         for key in ("commit", "commitSha", "commit_sha", "sha", "headCommit"):
             value = meta.get(key)
             if isinstance(value, str) and value:
@@ -97,6 +106,33 @@ def _index_state(repo_sha: str) -> dict:
             break
     stale = None if indexed_commit is None else (indexed_commit != repo_sha)
     return {"index_present": True, "index_stale": stale, "index_commit": indexed_commit}
+
+
+def _env_truthy(key: str) -> bool:
+    return os.environ.get(key, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _check_condition_env(condition: str) -> list[str]:
+    """The env flags must match the claimed condition, or every record lies."""
+    mcp = _env_truthy("HARNESS_FCC_MCP_ENABLED")
+    gitnexus = _env_truthy("HARNESS_FCC_GITNEXUS_ENABLED")
+    context_mode = _env_truthy("HARNESS_FCC_CONTEXT_MODE_ENABLED")
+    problems: list[str] = []
+    if condition == "A":
+        if gitnexus:
+            problems.append("condition A requires HARNESS_FCC_GITNEXUS_ENABLED off")
+        if context_mode:
+            problems.append("condition A requires HARNESS_FCC_CONTEXT_MODE_ENABLED off")
+    else:
+        if not mcp:
+            problems.append(f"condition {condition} requires HARNESS_FCC_MCP_ENABLED=true (master flag)")
+        if not gitnexus:
+            problems.append(f"condition {condition} requires HARNESS_FCC_GITNEXUS_ENABLED=true")
+        if condition == "D" and not context_mode:
+            problems.append("condition D requires HARNESS_FCC_CONTEXT_MODE_ENABLED=true")
+        if condition in ("B", "C") and context_mode:
+            problems.append(f"condition {condition} requires HARNESS_FCC_CONTEXT_MODE_ENABLED off")
+    return problems
 
 
 async def _run_question(prompt: str, correlation_id: str, timeout_sec: float) -> dict:
@@ -143,6 +179,12 @@ async def main() -> int:
         print(f"No question matching {args.question!r}", file=sys.stderr)
         return 2
 
+    problems = _check_condition_env(args.condition)
+    if problems:
+        for problem in problems:
+            print(f"flag mismatch: {problem}", file=sys.stderr)
+        return 2
+
     repo_sha = _git_sha()
     static_fields = {
         "condition": CONDITIONS[args.condition],
@@ -150,6 +192,7 @@ async def main() -> int:
         "repo_sha": repo_sha,
         "gitnexus_version": _tool_version("gitnexus", "--version"),
         "context_mode_version": _tool_version("context-mode", "--version"),
+        "mcp_master_flag": os.environ.get("HARNESS_FCC_MCP_ENABLED", ""),
         "gitnexus_flag": os.environ.get("HARNESS_FCC_GITNEXUS_ENABLED", ""),
         "context_mode_flag": os.environ.get("HARNESS_FCC_CONTEXT_MODE_ENABLED", ""),
         **_index_state(repo_sha),

--- a/scripts/run_unified_turn_introspection_eval.py
+++ b/scripts/run_unified_turn_introspection_eval.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Run the unified-turn introspection eval (semantic self-indexing experiment).
+
+Sends each fixture question through the FCC motor path (default_fcc_runner —
+the same env-driven `claude -p` seam the harness governor uses), scores the
+answer against the ground-truth assertions, and appends one JSONL record per
+run with correctness + navigation + context metrics.
+
+The runner does not toggle experiment conditions itself: the operator sets
+HARNESS_FCC_GITNEXUS_ENABLED / HARNESS_FCC_CONTEXT_MODE_ENABLED (and restarts
+the governor when running containerized) and passes --condition so each record
+is labeled. Repo SHA, GitNexus version, and index staleness are recorded so
+conditions can be compared at the same commit.
+
+Usage (host, with FCC server reachable and ~/.fcc/.env present):
+
+    python3 scripts/run_unified_turn_introspection_eval.py \
+        --condition A --runs 5 \
+        --out /tmp/unified-turn-introspection/condition_a.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from orion.harness.evals.introspection_scoring import (  # noqa: E402
+    extract_tool_metrics,
+    load_fixture,
+    score_answer,
+)
+
+CONDITIONS = {
+    "A": "baseline",
+    "B": "graph_only",
+    "C": "graph_plus_breadcrumbs",
+    "D": "graph_breadcrumbs_context_mode",
+}
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"], text=True, timeout=10
+        ).strip()
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+
+
+def _tool_version(command: str, *args: str) -> str | None:
+    if shutil.which(command) is None:
+        return None
+    try:
+        out = subprocess.check_output(
+            [command, *args], text=True, timeout=30, stderr=subprocess.DEVNULL
+        ).strip()
+        return out.splitlines()[0] if out else None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def _index_state(repo_sha: str) -> dict:
+    """Best-effort GitNexus index freshness from the on-disk metadata.
+
+    The index is derived cache; a missing or non-matching commit is reported,
+    never silently treated as fresh.
+    """
+    meta_dir = REPO_ROOT / ".gitnexus"
+    if not meta_dir.is_dir():
+        return {"index_present": False, "index_stale": None, "index_commit": None}
+    indexed_commit = None
+    for name in ("gitnexus.json", "meta.json"):
+        candidate = meta_dir / name
+        if not candidate.is_file():
+            continue
+        try:
+            meta = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        for key in ("commit", "commitSha", "commit_sha", "sha", "headCommit"):
+            value = meta.get(key)
+            if isinstance(value, str) and value:
+                indexed_commit = value
+                break
+        if indexed_commit:
+            break
+    stale = None if indexed_commit is None else (indexed_commit != repo_sha)
+    return {"index_present": True, "index_stale": stale, "index_commit": indexed_commit}
+
+
+async def _run_question(prompt: str, correlation_id: str, timeout_sec: float) -> dict:
+    from orion.harness.runner import default_fcc_runner
+
+    steps: list[dict] = []
+    answer = ""
+    error = None
+    started = time.monotonic()
+    async for event in default_fcc_runner(
+        prompt=prompt, correlation_id=correlation_id, timeout_sec=timeout_sec
+    ):
+        etype = event.get("type")
+        if etype == "step":
+            steps.append(event)
+        elif etype == "final":
+            answer = str(event.get("llm_response") or "")
+        elif etype == "error":
+            error = f"{event.get('error_code')}: {event.get('error')}"
+            answer = str(event.get("llm_response") or "")
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    return {"answer": answer, "steps": steps, "error": error, "elapsed_ms": elapsed_ms}
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--condition", required=True, choices=sorted(CONDITIONS))
+    parser.add_argument("--runs", type=int, default=1, help="repetitions per question")
+    parser.add_argument("--question", default=None, help="run only this question id")
+    parser.add_argument("--timeout-sec", type=float, default=600.0)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("/tmp/unified-turn-introspection/results.jsonl"),
+    )
+    args = parser.parse_args()
+
+    fixture = load_fixture()
+    assertions = fixture["assertions"]
+    questions = [
+        q for q in fixture["questions"] if args.question in (None, q["id"])
+    ]
+    if not questions:
+        print(f"No question matching {args.question!r}", file=sys.stderr)
+        return 2
+
+    repo_sha = _git_sha()
+    static_fields = {
+        "condition": CONDITIONS[args.condition],
+        "condition_code": args.condition,
+        "repo_sha": repo_sha,
+        "gitnexus_version": _tool_version("gitnexus", "--version"),
+        "context_mode_version": _tool_version("context-mode", "--version"),
+        "gitnexus_flag": os.environ.get("HARNESS_FCC_GITNEXUS_ENABLED", ""),
+        "context_mode_flag": os.environ.get("HARNESS_FCC_CONTEXT_MODE_ENABLED", ""),
+        **_index_state(repo_sha),
+    }
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    total = 0
+    with args.out.open("a", encoding="utf-8") as sink:
+        for question in questions:
+            for run_idx in range(args.runs):
+                corr = f"introspect-{args.condition.lower()}-{question['id']}-{run_idx}"
+                print(f"[{corr}] running...", flush=True)
+                outcome = await _run_question(question["prompt"], corr, args.timeout_sec)
+                passed, failed = score_answer(
+                    outcome["answer"], question["assertions"], assertions
+                )
+                metrics = extract_tool_metrics(outcome["steps"])
+                record = {
+                    "question_id": question["id"],
+                    "run_index": run_idx,
+                    "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+                    **static_fields,
+                    "answer": outcome["answer"],
+                    "error": outcome["error"],
+                    "assertions_passed": passed,
+                    "assertions_failed": failed,
+                    "tool_calls": metrics.tool_calls,
+                    "tool_names": metrics.tool_names,
+                    "unique_files_read": metrics.unique_files_read,
+                    "observed_chars": metrics.observed_chars,
+                    "max_context_fill_pct": metrics.max_context_fill_pct,
+                    "truncated_results": metrics.truncated_results,
+                    "elapsed_ms": outcome["elapsed_ms"],
+                }
+                sink.write(json.dumps(record, ensure_ascii=False) + "\n")
+                sink.flush()
+                total += 1
+                print(
+                    f"[{corr}] passed={len(passed)}/{len(question['assertions'])} "
+                    f"tools={metrics.tool_calls} elapsed={outcome['elapsed_ms']}ms",
+                    flush=True,
+                )
+    print(f"Wrote {total} records to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -56,6 +56,17 @@ HARNESS_FCC_CONTEXT_PRESSURE_PCT=70
 # MCP proxy truncates individual tool text payloads above this char count (default 12000).
 ORION_FCC_MCP_TOOL_RESULT_MAX_CHARS=12000
 HARNESS_AITOWN_ENABLED=true
+# Semantic self-indexing (design: 2026-07-11 semantic self-indexing proposal).
+# GitNexus code-graph MCP (gitnexus@1.6.9 pinned in the image). Requires a
+# host-built index: run `gitnexus analyze --index-only --name orion` from the
+# repo root on the host. Off by default; fail-open (FCC falls back to rg/Read).
+HARNESS_FCC_GITNEXUS_ENABLED=false
+# Context Mode MCP-only stage (context-mode@1.0.169 pinned in the image).
+# Virtualizes bulk tool output outside the live context. Off by default.
+HARNESS_FCC_CONTEXT_MODE_ENABLED=false
+# Writable Context Mode storage root inside the container (Docker volume
+# harness-context-mode; operational working data, not an Orion memory store).
+HARNESS_FCC_CONTEXT_MODE_DIR=/var/lib/orion/context-mode
 # Bridge-network harness cannot use 127.0.0.1 from ~/.fcc; override Convex reachability here
 HARNESS_AITOWN_CONVEX_URL=http://host.docker.internal:3210
 # (D) embodiment: emit a deliberate approach intent on the turn correlation_id after a

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -60,10 +60,10 @@ HARNESS_AITOWN_ENABLED=true
 # GitNexus code-graph MCP (gitnexus@1.6.9 pinned in the image). Requires a
 # host-built index: run `gitnexus analyze --index-only --name orion` from the
 # repo root on the host. Off by default; fail-open (FCC falls back to rg/Read).
-HARNESS_FCC_GITNEXUS_ENABLED=false
+HARNESS_FCC_GITNEXUS_ENABLED=true
 # Context Mode MCP-only stage (context-mode@1.0.169 pinned in the image).
 # Virtualizes bulk tool output outside the live context. Off by default.
-HARNESS_FCC_CONTEXT_MODE_ENABLED=false
+HARNESS_FCC_CONTEXT_MODE_ENABLED=true
 # Writable Context Mode storage root inside the container (Docker volume
 # harness-context-mode; operational working data, not an Orion memory store).
 HARNESS_FCC_CONTEXT_MODE_DIR=/var/lib/orion/context-mode

--- a/services/orion-harness-governor/Dockerfile
+++ b/services/orion-harness-governor/Dockerfile
@@ -18,11 +18,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
          docker-ce-cli \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/* \
     && git config --global --add safe.directory /mnt/scripts/Orion-Sapienform \
     && git config --global --add safe.directory '*'
+
+# Self-indexing MCP toolchain: GitNexus (code graph) + Context Mode (context
+# virtualization). Pinned exact versions — both are third-party executables
+# inside the FCC tool loop; upgrade only after reviewing release diffs.
+# context-mode requires node >=22.5 (nodesource 22.x currently ships >=22.5).
+RUN node -e "const [maj,min]=process.versions.node.split('.').map(Number); if (maj<22||(maj===22&&min<5)) { throw new Error('need node >=22.5, got '+process.versions.node); }" \
+    && npm install -g gitnexus@1.6.9 context-mode@1.0.169 \
+    && gitnexus --version \
+    && npm ls -g --depth=0 context-mode
 
 RUN pip3 install --no-cache-dir --upgrade pip
 

--- a/services/orion-harness-governor/README.md
+++ b/services/orion-harness-governor/README.md
@@ -42,7 +42,16 @@ docker compose \
 
 ## FCC MCP (Orion mode)
 
-When `HARNESS_FCC_MCP_ENABLED=true`, harness turns spawn ephemeral MCP config (GitHub + Firecrawl; optional AI Town when `HARNESS_AITOWN_ENABLED=true`). The container image includes `docker`, `npx`, and the orion-aitown MCP package.
+When `HARNESS_FCC_MCP_ENABLED=true`, harness turns spawn ephemeral MCP config (GitHub + Firecrawl; optional AI Town when `HARNESS_AITOWN_ENABLED=true`; optional GitNexus/Context Mode, below). The container image includes `docker`, Node 22, `npx`, the orion-aitown MCP package, and pinned `gitnexus@1.6.9` + `context-mode@1.0.169`.
+
+### Semantic self-indexing (GitNexus + Context Mode)
+
+Both are default-off, fail-open, and need no secrets:
+
+- `HARNESS_FCC_GITNEXUS_ENABLED=true` adds the GitNexus code-graph MCP (`gitnexus mcp`). Prerequisite: build the index on the **host** from the repo root — `mkdir -p ~/.gitnexus && gitnexus analyze --index-only --name orion` (host node must be >=22; the generated `.gitnexus/` is gitignored). Compose mounts `~/.gitnexus` read-only for registry discovery.
+- `HARNESS_FCC_CONTEXT_MODE_ENABLED=true` adds the Context Mode MCP (MCP-only stage, no Claude hooks). Working data lives in the `harness-context-mode` volume at `HARNESS_FCC_CONTEXT_MODE_DIR` — operational data, not an Orion memory store; never expose it through Hub APIs.
+
+The unified-turn introspection experiment for these flags lives at `scripts/run_unified_turn_introspection_eval.py` with its fixture in `orion/harness/evals/fixtures/`.
 
 `HARNESS_FCC_SKIP_PERMISSIONS=true` (default in compose) passes `--dangerously-skip-permissions` to `claude -p` even when the governor runs as root — otherwise Bash/MCP steps stall on approval prompts with no operator in Orion mode.
 

--- a/services/orion-harness-governor/app/bus_listener.py
+++ b/services/orion-harness-governor/app/bus_listener.py
@@ -175,6 +175,18 @@ async def handle_harness_run_request(
     cortex_client: HarnessCortexClient | None = None,
     substrate_client: HarnessSubstrateClient | None = None,
 ) -> HarnessRunV1:
+    """Orion capability: governor saga for one unified-turn run.
+
+    Joins the motor to finalization: validates or refuses the request, runs
+    the HarnessRunner motor, then the 5a/5b/5c finalize chain, and replies
+    with HarnessRunV1 over bus RPC while publishing the run artifact. The
+    reply and artifact are emitted even when the motor or a finalize phase
+    fails — finalize_ran and compliance_verdict mark how far the run got.
+
+    Runtime evidence: HarnessRunV1 on the RPC reply and run-artifact channels
+    plus lifecycle grammar events. Start here when Hub received nothing back,
+    or an error frame whose failing phase is unclear.
+    """
     corr = correlation_id or request.correlation_id or str(uuid4())
     causality = list(causality_chain or [])
     recall_debug, memory_digest = _recall_fields_from_thought(request.thought_event)

--- a/services/orion-harness-governor/app/settings.py
+++ b/services/orion-harness-governor/app/settings.py
@@ -83,6 +83,13 @@ class HarnessGovernorSettings(BaseSettings):
 
     harness_fcc_mcp_enabled: bool = Field(False, alias="HARNESS_FCC_MCP_ENABLED")
     harness_aitown_enabled: bool = Field(False, alias="HARNESS_AITOWN_ENABLED")
+    # Semantic self-indexing MCPs — read at spawn time from the environment in
+    # orion/harness/fcc_motor; mirrored here so operators see effective flags.
+    harness_fcc_gitnexus_enabled: bool = Field(False, alias="HARNESS_FCC_GITNEXUS_ENABLED")
+    harness_fcc_context_mode_enabled: bool = Field(False, alias="HARNESS_FCC_CONTEXT_MODE_ENABLED")
+    harness_fcc_context_mode_dir: str = Field(
+        "/var/lib/orion/context-mode", alias="HARNESS_FCC_CONTEXT_MODE_DIR"
+    )
 
     # (D) embodiment: publish a deliberate approach intent on the turn correlation_id
     # after a finalized relational turn. Default-off, fail-open (never breaks a turn).

--- a/services/orion-harness-governor/docker-compose.yml
+++ b/services/orion-harness-governor/docker-compose.yml
@@ -15,6 +15,13 @@ services:
       - ${HOME}/.fcc:/root/.fcc:ro
       - ${HOME}/.claude.json:/root/.claude.json:ro
       - ${HARNESS_FCC_CLAUDE_BIN_HOST:-${HOME}/.local/bin/claude}:/usr/local/bin/claude:ro
+      # GitNexus global registry (~/.gitnexus/registry.json) — index is built on
+      # the host; MCP inside the container discovers it via this read-only mount.
+      # The per-repo .gitnexus/ index arrives through the repo mount above.
+      - ${HOME}/.gitnexus:/root/.gitnexus:ro
+      # Context Mode working data — operational, project-scoped, NOT an Orion
+      # memory store; never exposed through Hub convenience APIs.
+      - harness-context-mode:${HARNESS_FCC_CONTEXT_MODE_DIR:-/var/lib/orion/context-mode}
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - SERVICE_NAME=${SERVICE_NAME:-orion-harness-governor}
@@ -54,6 +61,9 @@ services:
       - HARNESS_FCC_CONTEXT_PRESSURE_PCT=${HARNESS_FCC_CONTEXT_PRESSURE_PCT:-70}
       - ORION_FCC_MCP_TOOL_RESULT_MAX_CHARS=${ORION_FCC_MCP_TOOL_RESULT_MAX_CHARS:-12000}
       - HARNESS_AITOWN_ENABLED=${HARNESS_AITOWN_ENABLED:-false}
+      - HARNESS_FCC_GITNEXUS_ENABLED=${HARNESS_FCC_GITNEXUS_ENABLED:-false}
+      - HARNESS_FCC_CONTEXT_MODE_ENABLED=${HARNESS_FCC_CONTEXT_MODE_ENABLED:-false}
+      - HARNESS_FCC_CONTEXT_MODE_DIR=${HARNESS_FCC_CONTEXT_MODE_DIR:-/var/lib/orion/context-mode}
     networks:
       - app-net
     ports:
@@ -68,3 +78,6 @@ services:
 networks:
   app-net:
     external: true
+
+volumes:
+  harness-context-mode:

--- a/services/orion-harness-governor/docker-compose.yml
+++ b/services/orion-harness-governor/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       # GitNexus global registry (~/.gitnexus/registry.json) — index is built on
       # the host; MCP inside the container discovers it via this read-only mount.
       # The per-repo .gitnexus/ index arrives through the repo mount above.
+      # Run `mkdir -p ~/.gitnexus` before first `up`: docker creates a missing
+      # bind source as root, which then breaks host-side `gitnexus analyze`.
       - ${HOME}/.gitnexus:/root/.gitnexus:ro
       # Context Mode working data — operational, project-scoped, NOT an Orion
       # memory store; never exposed through Hub convenience APIs.

--- a/services/orion-hub/scripts/websocket_handler.py
+++ b/services/orion-hub/scripts/websocket_handler.py
@@ -629,6 +629,18 @@ async def _run_agent_claude_turn_ws(
 
 
 async def websocket_endpoint(websocket: WebSocket):
+    """Orion capability: Hub chat entry.
+
+    Accepts every Hub chat WebSocket and routes each message by client mode;
+    an Orion-mode message with ORION_UNIFIED_TURN_ENABLED routes into
+    run_unified_turn rather than the older direct Cortex request path. This
+    function owns connection lifecycle and frame relay only — turn cognition
+    lives in the unified turn orchestrator.
+
+    Runtime evidence: connection_ready frame, relayed harness step frames, and
+    the turn frames returned by the orchestrator. Start here when an
+    Orion-mode message produced no turn frames at all.
+    """
     import scripts.main
     bus = scripts.main.bus
     cortex_client = scripts.main.cortex_client

--- a/services/orion-thought/app/bus_listener.py
+++ b/services/orion-thought/app/bus_listener.py
@@ -278,6 +278,20 @@ async def run_stance_react(
     bus: OrionBusAsync,
     cortex_client: CortexExecClient | None = None,
 ) -> ThoughtEventV1:
+    """Orion capability: stance/thought assembly for the unified turn.
+
+    Produces the ThoughtEventV1 that constrains the FCC motor: executes the
+    stance_react Cortex plan (a dynamic, bus-mediated edge invisible to static
+    call graphs), optionally colors the request with Mind enrichment, then
+    normalizes the payload and enriches it with the grounding capsule and
+    autonomy slice. Hub honors the resulting defer/refuse disposition before
+    any motor work; the imperative and stance_harness_slice shape the motor
+    prompt.
+
+    Runtime evidence: thought.event.v1 envelopes on the RPC reply and thought
+    artifact channels, with disposition logged. Start here when a turn's
+    imperative or stance slice looks wrong before the motor ever ran.
+    """
     client = cortex_client or CortexExecClient(bus)
     mind_coloring = await _maybe_build_mind_coloring(request, bus=bus)
     plan_request = build_stance_react_plan_request(request, mind_coloring=mind_coloring)


### PR DESCRIPTION
## Summary

Implemented Patches 1-3 (out of 4) from the spec: Orion Semantic Self-Indexing and Rapid Introspection Plane, see: docs/superpowers/specs/orion-semantic-self-indexing-design-spec.md (note, spec pushed in succeeding PR #947 

- Harness-governor image upgraded Node 20 → 22 and installs pinned `gitnexus@1.6.9` + `context-mode@1.0.169`, verified at build time.
- `render_mcp_config()` now conditionally adds a GitNexus code-graph MCP server and a Context Mode MCP server (MCP-only stage) behind two new default-off feature flags, with component-specific preflight errors.
- The FCC motor prefix gains a concise GitNexus query-policy brief (graph is derived cache; disclose staleness) and a Context Mode routing brief, only when the flags are on.
- A measured unified-turn introspection eval ships: 9 baseline questions × 16 lexical ground-truth assertions, a scoring module, a gate test pinning every fixture assertion to a real repo symbol, and a JSONL runner for conditions A–D.
- 11 reviewed "Orion capability:" semantic breadcrumbs added at the verified unified-turn chokepoints (route gate → orchestrator → association → stance react → prefix → motor loop → FCC process → governor saga → finalize chain → voice finalize → persistence).
- Knowledge Forge, bus schemas/channels, cognition reducers, and root CLAUDE.md are untouched, per the proposal's non-goals.

## Outcome moved

Orion's FCC harness can now (once flags are enabled and a host index is built) navigate from an introspective concept to the owning implementation via a derived code graph instead of repo-wide blind search, and the experiment to prove/refute that benefit is runnable and machine-scored. The eval's gate test already caught one factual drift while being written (`harness_rpc_timeout` is emitted in `turn_orchestrator.py`, not the governor client).

## Current architecture (before)

- FCC MCP rendering unconditionally required GitHub+Firecrawl and optionally added AI Town; no way to add a server without secrets coupling.
- No derived code graph, no graph query surface, no semantic landmarks, no introspection benchmark.
- Harness image shipped Node 20 (below both tools' engine floor).

## Architecture touched

- `services/orion-harness-governor` image/compose/env (runtime substrate).
- `orion/fcc` MCP renderer + motor prefix brief (per-turn ephemeral MCP seam — Decision 5 of the proposal).
- `orion/harness/evals` (experiment artifact lane, not a runtime schema).
- Docstrings only in Hub/Thought/governor saga functions (no behavior change).

## Files changed

- `services/orion-harness-governor/Dockerfile`: Node 22.x, pinned gitnexus/context-mode installs, build-time version checks.
- `services/orion-harness-governor/docker-compose.yml`: `~/.gitnexus` registry mount (ro), `harness-context-mode` volume, three new env passthroughs.
- `services/orion-harness-governor/.env_example`: documents `HARNESS_FCC_GITNEXUS_ENABLED`, `HARNESS_FCC_CONTEXT_MODE_ENABLED`, `HARNESS_FCC_CONTEXT_MODE_DIR`.
- `.gitignore`: ignore `.gitnexus/` (derived index).
- `.gitnexusignore` (new): keeps `services/orion-hub/node_modules` out of the graph.
- `orion/fcc/mcp_config.py`: `include_gitnexus` / `include_context_mode` params, dir validation, specific preflight error codes.
- `orion/fcc/self_index_brief.py` (new): flag-gated motor prompt guidance for both tools.
- `orion/harness/fcc_motor.py`: wires the two flags + workspace into the renderer; `run_fcc_turn` breadcrumb.
- `orion/harness/prefix.py`: appends the self-index brief; breadcrumb.
- `orion/harness/evals/fixtures/unified_turn_introspection.json` (new): questions + assertions + evidence anchors.
- `orion/harness/evals/introspection_scoring.py` (new): lexical scorer + step-frame tool metrics.
- `orion/harness/evals/test_introspection_fixture.py` (new): gate tests incl. evidence-symbol drift check.
- `scripts/run_unified_turn_introspection_eval.py` (new): condition-labeled JSONL eval runner over `default_fcc_runner`.
- Breadcrumb-only diffs: `orion/hub/turn_orchestrator.py`, `orion/hub/association.py`, `orion/harness/runner.py`, `orion/harness/finalize.py`, `services/orion-hub/scripts/websocket_handler.py`, `services/orion-thought/app/bus_listener.py`, `services/orion-harness-governor/app/bus_listener.py`.
- Tests: `orion/fcc/tests/test_mcp_config.py` (new), `orion/harness/tests/test_fcc_motor_mcp.py`, `orion/harness/tests/test_harness_prefix.py`.

## Schema / bus / API changes

- Added: none.
- Removed: none.
- Renamed: none.
- Behavior changed: `render_mcp_config()` accepts four new optional kwargs (backward-compatible defaults); MCP config may now contain `gitnexus` / `context-mode` stdio servers when flags are on.
- Compatibility notes: GitHub/Firecrawl preflight semantics under `HARNESS_FCC_MCP_ENABLED` are unchanged; Hub's separate `scripts/fcc_mcp_config.py` renderer untouched (first rollout is governor-only per Decision 6).

## Env/config changes

- Added keys: `HARNESS_FCC_GITNEXUS_ENABLED=false`, `HARNESS_FCC_CONTEXT_MODE_ENABLED=false`, `HARNESS_FCC_CONTEXT_MODE_DIR=/var/lib/orion/context-mode` (harness-governor).
- Removed/renamed keys: none.
- `.env_example` updated: yes.
- Local `.env` synced with `python3 scripts/sync_local_env_from_example.py`: yes — the three keys were added. **Note:** the sync also flipped pre-existing drift `HARNESS_AITOWN_ENABLED false→true` in local `.env` to match the checked-in example; flag if that local value was intentional.
- Skipped keys requiring operator action: none reported by the sync script.

## Tests run

```text
PYTHONPATH=. .venv/bin/pytest orion/fcc/tests orion/harness/tests orion/harness/evals orion/hub/tests services/orion-harness-governor/tests -q
→ 153 passed, 3 failed (all 3 pre-exist on main: test_grounding_capsule_consumers x2, test_harness_runner_surfaces_fcc_error_code — grounding_status format drift unrelated to this branch)

services/orion-thought: 127 passed, 4 failed (all pre-exist on main, verified via git stash)
services/orion-hub: tests/test_fcc_mcp_config.py tests/test_fcc_claude_bridge_mcp.py → 10 passed
```

## Evals run

```text
PYTHONPATH=. .venv/bin/pytest orion/harness/evals -q → 8 passed
(introspection fixture gate tests; the live A–D condition runs are the experiment
itself and require the FCC server + host GitNexus index — see runbook below)
```

## Docker/build/smoke checks

```text
docker compose … -f services/orion-harness-governor/docker-compose.yml config → renders (flags present, volume mounted)
docker compose … build → image built
docker run --rm … 'node --version; gitnexus --version' → v22.23.1 / 1.6.9; context-mode installed at /usr/bin/context-mode
```

## Review findings fixed

A high-effort code-review subagent returned 10 material findings (20 confirmed candidates total); all 10 fixed in `dcb9d773`:

- Finding: `self_index_brief` not gated on `HARNESS_FCC_MCP_ENABLED` — prompt advertised MCP tools that were never rendered.
  - Fix: master-flag gate added; the test that codified the desync corrected and a regression test added.
  - Evidence: `test_compile_harness_prefix_self_index_briefs_gated_on_master_flag` passes.
- Finding: eval read `context_fill_pct` at a key real step frames never carry → `max_context_fill_pct` always 0 (empty-shell metric).
  - Fix: reads `step["context_obs"]["fill_pct"]` (the `annotate_harness_step` shape) with pressure-step fallback; unit test now uses the runtime frame shape.
- Finding: eval runner could label a baseline run as condition B/C/D when env flags were unset (silently invalid experiment).
  - Fix: fail-fast `_check_condition_env` (exit 2 on mismatch, smoke-tested); `mcp_master_flag` recorded per row; docstring corrected (in-process env, no governor restart).
- Finding: condition D unrunnable on host as documented (container-only `CONTEXT_MODE_DIR`).
  - Fix: runner docstring + runbook direct host runs to a host-writable absolute dir; preflight error is specific if missed.
- Finding: compose bind mount auto-creates root-owned `~/.gitnexus` on a fresh host, breaking host-side indexing.
  - Fix: `mkdir -p ~/.gitnexus` executed on this host now; compose comment + README document the prerequisite.
- Finding: `compile_harness_prefix` breadcrumb falsely claimed "nothing else enters the motor prompt".
  - Fix: reworded — full prompt = prefix + `harness_motor_instruction` appended by `build_harness_prompt`.
- Finding: fixture drift gate satisfied by this PR's own docstrings (substring-anywhere check).
  - Fix: gate strips docstrings via `ast` before matching; anchors must live in code.
- Finding: several fixture needles echo-passable from their own question prompts (inflates baseline, compresses measured effect).
  - Fix: q03/q07/q09 rephrased, `defer_refuse`/`graph_limitations` needles tightened, plus a deterministic anti-echo gate test.
- Finding: `truncated_results` over/under-counted (marker matched anywhere; one per frame max).
  - Fix: counts marker occurrences inside `tool_result` payloads only; both directions covered by a new test.
- Finding: `_index_state` crashed on non-dict GitNexus metadata JSON.
  - Fix: `isinstance(meta, dict)` guard.

Also fixed from the reviewer's convention list: governor README documents the self-indexing toolchain + Node 22 + host index prerequisite; `settings.py` mirrors the three new env keys; orphaned `pre_thought_context` assertion wired into question 1. Deliberately not changed: GitNexus/Context Mode servers are not wrapped in `mcp_stdio_proxy` (same pre-existing pattern as Firecrawl; revisit if graph payloads prove large — listed under risks).

## Restart required

```bash
# Rebuild + restart the harness governor (Node/tooling changed in the image):
docker compose --env-file .env --env-file services/orion-harness-governor/.env \
  -f services/orion-harness-governor/docker-compose.yml up -d --build
```

Flags stay off by default, so behavior is unchanged until the experiment starts.

## Experiment runbook (operator)

```bash
# 1. Host-side index (host node is v20 — use the container or upgrade nvm):
docker compose -f services/orion-harness-governor/docker-compose.yml run --rm \
  --entrypoint gitnexus harness-governor analyze --index-only --name orion   # UNVERIFIED: needs writable repo mount for .gitnexus/
# or on the host after `nvm install 22 && npm i -g gitnexus@1.6.9`:
gitnexus analyze --index-only --name orion && gitnexus status

# 2. Condition A baseline (flags off):
python3 scripts/run_unified_turn_introspection_eval.py --condition A --runs 5 \
  --out /tmp/unified-turn-introspection/condition_a.jsonl

# 3. Enable HARNESS_FCC_GITNEXUS_ENABLED=true, restart governor, run --condition B.
# 4. Breadcrumbs are already merged → reindex, run --condition C.
# 5. Enable HARNESS_FCC_CONTEXT_MODE_ENABLED=true, restart, run --condition D.
```

## Risks / concerns

- Severity: medium — GitNexus MCP reading the index through the **read-only** repo mount is UNVERIFIED (the graph DB may want a write lock). Acceptance check §19.2 of the proposal; if it fails, mount a writable index path or relocate the index.
- Severity: low — `context-mode --version` prints nothing in the image (version pinned at install; `npm ls -g` verified at build). Eval runner records `null` for it.
- Severity: low — host node is v20, so host-side `gitnexus analyze` needs nvm 22 or the container path above.
- Severity: low — GitNexus is PolyForm Noncommercial, Context Mode is Elastic-2.0: research use only; recheck before any commercial distribution.



