### PR TITLE
fix(harness): bake LadybugDB FTS extension into governor image

### DIFF
--- a/services/orion-harness-governor/Dockerfile
+++ b/services/orion-harness-governor/Dockerfile
@@ -33,6 +33,14 @@ RUN node -e "const [maj,min]=process.versions.node.split('.').map(Number); if (m
     && gitnexus --version \
     && npm ls -g --depth=0 context-mode
 
+# Bake the LadybugDB FTS extension into the image (lands in /root/.lbdb).
+# GitNexus query paths are offline-first (load-only): without a pre-installed
+# extension the MCP degrades to "FTS indexes missing" and keyword search over
+# an FTS-built index returns nothing. --verify-only proves a fresh process can
+# LOAD it so a HOME mismatch fails the build instead of silently degrading.
+RUN node /usr/lib/node_modules/gitnexus/scripts/install-duckdb-extension.mjs fts 4294967296 \
+    && node /usr/lib/node_modules/gitnexus/scripts/install-duckdb-extension.mjs fts 4294967296 --verify-only
+
 RUN pip3 install --no-cache-dir --upgrade pip
 
 COPY services/orion-harness-governor/requirements.txt ./requirements.txt

--- a/services/orion-harness-governor/README.md
+++ b/services/orion-harness-governor/README.md
@@ -48,7 +48,19 @@ When `HARNESS_FCC_MCP_ENABLED=true`, harness turns spawn ephemeral MCP config (G
 
 Both are default-off, fail-open, and need no secrets:
 
-- `HARNESS_FCC_GITNEXUS_ENABLED=true` adds the GitNexus code-graph MCP (`gitnexus mcp`). Prerequisite: build the index on the **host** from the repo root — `mkdir -p ~/.gitnexus && gitnexus analyze --index-only --name orion` (host node must be >=22; the generated `.gitnexus/` is gitignored). Compose mounts `~/.gitnexus` read-only for registry discovery.
+- `HARNESS_FCC_GITNEXUS_ENABLED=true` adds the GitNexus code-graph MCP (`gitnexus mcp`). Prerequisite: build the index against the host checkout. The reliable path is the governor image itself (it bakes the LadybugDB FTS extension; without it search silently degrades to "FTS indexes missing"):
+
+  ```bash
+  mkdir -p ~/.gitnexus   # BEFORE first compose up, or docker root-owns it
+  docker run --rm \
+    -v /mnt/scripts/Orion-Sapienform:/mnt/scripts/Orion-Sapienform \
+    -v $HOME/.gitnexus:/root/.gitnexus \
+    -w /mnt/scripts/Orion-Sapienform \
+    --entrypoint gitnexus orion-harness-governor-harness-governor \
+    analyze --index-only --name orion
+  ```
+
+  The generated `.gitnexus/` is gitignored; compose mounts `~/.gitnexus` read-only for registry discovery. Re-run after merges so `gitnexus status` reports up-to-date (the MCP discloses staleness but stale structure is never authority).
 - `HARNESS_FCC_CONTEXT_MODE_ENABLED=true` adds the Context Mode MCP (MCP-only stage, no Claude hooks). Working data lives in the `harness-context-mode` volume at `HARNESS_FCC_CONTEXT_MODE_DIR` — operational data, not an Orion memory store; never expose it through Hub APIs.
 
 The unified-turn introspection experiment for these flags lives at `scripts/run_unified_turn_introspection_eval.py` with its fixture in `orion/harness/evals/fixtures/`.


### PR DESCRIPTION
Live deployment surfaced this: GitNexus query paths are offline-first (load-only extension policy), so without a pre-installed FTS extension in /root/.lbdb the MCP degrades to 'FTS indexes missing' and keyword search over an FTS-built index returns zero results — and incremental analyze against an FTS-indexed DB hard-fails on COPY. Install the extension at build time and gate the build with the installer's --verify-only LOAD check. README now documents the image-based index build (host node is v20, below the tools' engine floor) and the mkdir-before-up guard for ~/.gitnexus.

Verified live: FTS query in the read-only governor returns definitions with no degradation warning; breadcrumb-only vocabulary retrieves the intended chokepoints; a real HarnessRunRequestV1 over the bus answered via one mcp__gitnexus__query with the full finalize chain completing.