### PR TITLE
Feat/context mode hooks spike

### DIFF
--- a/orion/fcc/claude_spawn.py
+++ b/orion/fcc/claude_spawn.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, Sequence
 
 
 def mcp_allowed_tool_patterns(mcp_servers: Mapping[str, Any]) -> List[str]:
@@ -25,14 +25,21 @@ def mcp_disallowed_tool_patterns(mcp_servers: Mapping[str, Any]) -> List[str]:
     return blocked
 
 
-def extend_mcp_argv(argv: List[str], mcp_config_path: Path) -> None:
+def extend_mcp_argv(
+    argv: List[str],
+    mcp_config_path: Path,
+    *,
+    extra_allowed_tools: Sequence[str] | None = None,
+) -> None:
     data = json.loads(mcp_config_path.read_text(encoding="utf-8"))
     servers = data.get("mcpServers") or {}
     patterns = mcp_allowed_tool_patterns(servers)
+    extra = list(extra_allowed_tools or [])
     argv.extend(["--mcp-config", str(mcp_config_path)])
-    if patterns:
+    if patterns or extra:
         argv.append("--allowedTools")
         argv.extend(patterns)
+        argv.extend(extra)
     disallowed = mcp_disallowed_tool_patterns(servers)
     if disallowed:
         argv.append("--disallowedTools")

--- a/orion/fcc/self_index_brief.py
+++ b/orion/fcc/self_index_brief.py
@@ -22,6 +22,11 @@ def context_mode_enabled() -> bool:
     return _env_truthy("HARNESS_FCC_CONTEXT_MODE_ENABLED")
 
 
+def context_mode_hooks_enabled() -> bool:
+    """Context Mode as a Claude Code plugin that owns its own MCP server."""
+    return _env_truthy("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED")
+
+
 def gitnexus_brief_lines() -> list[str]:
     return [
         (
@@ -65,5 +70,7 @@ def append_self_index_harness_brief(parts: list[str]) -> None:
         return
     if gitnexus_enabled():
         parts.extend(gitnexus_brief_lines())
-    if context_mode_enabled():
+    # Hook mode serves the same ctx_* tools via the context-mode plugin's own
+    # MCP server, so the brief text is identical in both modes.
+    if context_mode_enabled() or context_mode_hooks_enabled():
         parts.extend(context_mode_brief_lines())

--- a/orion/fcc/tests/test_claude_spawn.py
+++ b/orion/fcc/tests/test_claude_spawn.py
@@ -40,6 +40,77 @@ def test_extend_mcp_argv_uses_per_server_patterns(tmp_path: Path) -> None:
     ]
 
 
+def test_extend_mcp_argv_appends_extra_allowed_tools_after_server_patterns(
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(
+        json.dumps({"mcpServers": {"github": {"type": "stdio"}, "firecrawl": {"type": "stdio"}}}),
+        encoding="utf-8",
+    )
+    argv: list[str] = ["claude", "-p", "hi"]
+    claude_spawn.extend_mcp_argv(
+        argv, cfg, extra_allowed_tools=["mcp__plugin_context-mode_context-mode"]
+    )
+    assert argv == [
+        "claude",
+        "-p",
+        "hi",
+        "--mcp-config",
+        str(cfg),
+        "--allowedTools",
+        "mcp__github",
+        "mcp__firecrawl",
+        "mcp__plugin_context-mode_context-mode",
+        "--disallowedTools",
+        "Bash(gh *)",
+    ]
+
+
+def test_extend_mcp_argv_extra_none_or_empty_keeps_argv_identical(tmp_path: Path) -> None:
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(
+        json.dumps({"mcpServers": {"github": {"type": "stdio"}, "firecrawl": {"type": "stdio"}}}),
+        encoding="utf-8",
+    )
+    baseline: list[str] = ["claude", "-p", "hi"]
+    claude_spawn.extend_mcp_argv(baseline, cfg)
+    with_none: list[str] = ["claude", "-p", "hi"]
+    claude_spawn.extend_mcp_argv(with_none, cfg, extra_allowed_tools=None)
+    with_empty: list[str] = ["claude", "-p", "hi"]
+    claude_spawn.extend_mcp_argv(with_empty, cfg, extra_allowed_tools=[])
+    assert with_none == baseline
+    assert with_empty == baseline
+
+
+def test_extend_mcp_argv_extra_with_zero_servers_still_emits_allowed_tools(
+    tmp_path: Path,
+) -> None:
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+    argv: list[str] = ["claude", "-p", "hi"]
+    claude_spawn.extend_mcp_argv(
+        argv, cfg, extra_allowed_tools=["mcp__plugin_context-mode_context-mode"]
+    )
+    assert argv == [
+        "claude",
+        "-p",
+        "hi",
+        "--mcp-config",
+        str(cfg),
+        "--allowedTools",
+        "mcp__plugin_context-mode_context-mode",
+    ]
+
+
+def test_extend_mcp_argv_zero_servers_no_extra_omits_allowed_tools(tmp_path: Path) -> None:
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+    argv: list[str] = ["claude", "-p", "hi"]
+    claude_spawn.extend_mcp_argv(argv, cfg)
+    assert argv == ["claude", "-p", "hi", "--mcp-config", str(cfg)]
+
+
 def test_claude_permission_argv_root_uses_dont_ask(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(claude_spawn.os, "geteuid", lambda: 0)
     assert claude_spawn.claude_permission_argv(auto_approve=True) == [

--- a/orion/fcc/tests/test_context_mode_hooks_smoke.py
+++ b/orion/fcc/tests/test_context_mode_hooks_smoke.py
@@ -1,0 +1,153 @@
+"""Unit tests for the pure helpers in scripts/context_mode_hooks_smoke.py.
+
+These never spawn claude — they only exercise stream-json parsing, dir
+snapshot diffing, and status/exit-code aggregation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from scripts.context_mode_hooks_smoke import (
+    FAIL,
+    PASS,
+    PLUGIN_TOOL_PREFIX,
+    UNVERIFIED,
+    CheckResult,
+    dir_diff,
+    exit_code_for,
+    extract_final_text,
+    extract_session_id,
+    extract_tool_use_names,
+    has_compact_event,
+    is_truthy,
+    parse_stream_lines,
+    snapshot_dir,
+    worst_status,
+)
+
+_PLUGIN_TOOL = "mcp__plugin_context-mode_context-mode__ctx_stats"
+
+_ASSISTANT_EVENT = {
+    "type": "assistant",
+    "message": {
+        "content": [
+            {"type": "text", "text": "Calling the stats tool now."},
+            {"type": "tool_use", "name": _PLUGIN_TOOL, "input": {}},
+            {"type": "tool_use", "name": "Read", "input": {"file_path": "/tmp/x"}},
+        ]
+    },
+    "session_id": "sess-assistant",
+}
+
+_RESULT_EVENT = {
+    "type": "result",
+    "result": "DONE",
+    "session_id": "sess-final-123",
+    "duration_ms": 4200,
+}
+
+
+def _stream_lines() -> list[str]:
+    return [
+        json.dumps({"type": "system", "subtype": "init"}),
+        "",
+        "not-json garbage line",
+        json.dumps(_ASSISTANT_EVENT),
+        json.dumps(["a", "bare", "list"]),
+        json.dumps(_RESULT_EVENT),
+    ]
+
+
+def test_parse_stream_lines_skips_blank_nonjson_and_nondict() -> None:
+    events = parse_stream_lines(_stream_lines())
+    assert [e["type"] for e in events] == ["system", "assistant", "result"]
+
+
+def test_extract_tool_use_names_includes_plugin_tool() -> None:
+    events = parse_stream_lines(_stream_lines())
+    names = extract_tool_use_names(events)
+    assert names == [_PLUGIN_TOOL, "Read"]
+    assert names[0].startswith(PLUGIN_TOOL_PREFIX)
+
+
+def test_extract_session_id_prefers_result_event() -> None:
+    events = parse_stream_lines(_stream_lines())
+    assert extract_session_id(events) == "sess-final-123"
+
+
+def test_extract_session_id_falls_back_to_assistant_event() -> None:
+    assert extract_session_id([_ASSISTANT_EVENT]) == "sess-assistant"
+    assert extract_session_id([{"type": "system"}]) is None
+
+
+def test_extract_final_text_prefers_result_string() -> None:
+    events = parse_stream_lines(_stream_lines())
+    assert extract_final_text(events) == "DONE"
+
+
+def test_extract_final_text_falls_back_to_assistant_text() -> None:
+    assert extract_final_text([_ASSISTANT_EVENT]) == "Calling the stats tool now."
+    assert extract_final_text([]) == ""
+
+
+def test_has_compact_event_matches_type_and_subtype() -> None:
+    assert has_compact_event([{"type": "system", "subtype": "compact_boundary"}])
+    assert has_compact_event([{"type": "compact", "trigger": "auto"}])
+    assert not has_compact_event(parse_stream_lines(_stream_lines()))
+
+
+def test_snapshot_dir_missing_root_is_empty(tmp_path: Path) -> None:
+    assert snapshot_dir(tmp_path / "does-not-exist") == {}
+
+
+def test_dir_diff_detects_added_file(tmp_path: Path) -> None:
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    (sessions / "old.json").write_text("{}", encoding="utf-8")
+    before = snapshot_dir(sessions)
+    (sessions / "snap-1.json").write_text("{}", encoding="utf-8")
+    diff = dir_diff(before, snapshot_dir(sessions))
+    assert diff["added"] == ["snap-1.json"]
+    assert diff["modified"] == []
+
+
+def test_dir_diff_detects_modified_file(tmp_path: Path) -> None:
+    target = tmp_path / "sessions" / "snap.json"
+    target.parent.mkdir()
+    target.write_text("{}", encoding="utf-8")
+    before = snapshot_dir(target.parent)
+    mtime = target.stat().st_mtime
+    os.utime(target, (mtime + 5, mtime + 5))
+    diff = dir_diff(before, snapshot_dir(target.parent))
+    assert diff["added"] == []
+    assert diff["modified"] == ["snap.json"]
+
+
+def test_worst_status_fail_beats_unverified_beats_pass() -> None:
+    assert worst_status([]) == PASS
+    assert worst_status([PASS, PASS]) == PASS
+    assert worst_status([PASS, UNVERIFIED]) == UNVERIFIED
+    assert worst_status([UNVERIFIED, FAIL, PASS]) == FAIL
+
+
+def test_exit_code_zero_only_without_fail() -> None:
+    assert exit_code_for([PASS, UNVERIFIED, PASS]) == 0
+    assert exit_code_for([PASS, FAIL, UNVERIFIED]) == 1
+    assert exit_code_for([]) == 0
+
+
+def test_check_result_json_line_round_trips() -> None:
+    line = CheckResult("plugin_installed", PASS, {"matches": ["context-mode"]}).to_json_line()
+    assert json.loads(line) == {
+        "check": "plugin_installed",
+        "status": "PASS",
+        "evidence": {"matches": ["context-mode"]},
+    }
+
+
+def test_is_truthy_matches_harness_convention() -> None:
+    assert is_truthy("1") and is_truthy("true") and is_truthy("YES") and is_truthy(" on ")
+    assert not is_truthy("") and not is_truthy(None) and not is_truthy("false")

--- a/orion/harness/fcc_motor.py
+++ b/orion/harness/fcc_motor.py
@@ -313,13 +313,26 @@ def _maybe_render_mcp_config(*, correlation_id: str) -> Optional[Path]:
         return None
     env = load_fcc_env(expand_env_path(os.environ.get("HARNESS_FCC_ENV_PATH", "~/.fcc/.env")))
     include_aitown = _env_truthy("HARNESS_AITOWN_ENABLED")
+    include_context_mode = _env_truthy("HARNESS_FCC_CONTEXT_MODE_ENABLED")
+    if _env_truthy("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED"):
+        # Hook mode: the context-mode Claude Code plugin owns its MCP server;
+        # a standalone entry would double-register the ctx_* tools.
+        if include_context_mode:
+            logger.warning(
+                "context_mode_hooks_mode_wins corr=%s: both "
+                "HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED and "
+                "HARNESS_FCC_CONTEXT_MODE_ENABLED are set; hook mode wins, "
+                "skipping the standalone context-mode MCP server",
+                correlation_id,
+            )
+        include_context_mode = False
     return render_mcp_config(
         correlation_id=correlation_id,
         fcc_env=env,
         include_aitown=include_aitown,
         aitown_env=_harness_aitown_env(env) if include_aitown else None,
         include_gitnexus=_env_truthy("HARNESS_FCC_GITNEXUS_ENABLED"),
-        include_context_mode=_env_truthy("HARNESS_FCC_CONTEXT_MODE_ENABLED"),
+        include_context_mode=include_context_mode,
         context_mode_dir=os.environ.get("HARNESS_FCC_CONTEXT_MODE_DIR"),
         context_mode_project_dir=os.environ.get("HARNESS_FCC_WORKSPACE"),
     )
@@ -353,6 +366,16 @@ def _build_subprocess_env(*, fcc_server_url: str, auth_token: str) -> Dict[str, 
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
     env["TERM"] = "dumb"
     _fcc_context_env(env)
+    if _env_truthy("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED"):
+        # Point the context-mode plugin's hooks + MCP server at the same
+        # storage root the standalone stage would use.
+        env["CONTEXT_MODE_PLATFORM"] = "claude-code"
+        env["CONTEXT_MODE_PROJECT_DIR"] = (
+            os.environ.get("HARNESS_FCC_WORKSPACE") or os.getcwd()
+        )
+        env["CONTEXT_MODE_DIR"] = (
+            os.environ.get("HARNESS_FCC_CONTEXT_MODE_DIR") or "/var/lib/orion/context-mode"
+        )
     env.pop("DISABLE_COMPACT", None)
     env.pop("DISABLE_AUTO_COMPACT", None)
     return env
@@ -417,7 +440,13 @@ async def run_fcc_turn(
         model_id,
     ]
     if mcp_config_path is not None:
-        extend_mcp_argv(argv, mcp_config_path)
+        extra_allowed_tools: Optional[List[str]] = None
+        if _env_truthy("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED"):
+            # Claude Code 2.1 pre-approval pattern is the bare server name,
+            # mirroring mcp_allowed_tool_patterns; the plugin-owned server is
+            # not in the rendered config, so pre-approve it explicitly.
+            extra_allowed_tools = ["mcp__plugin_context-mode_context-mode"]
+        extend_mcp_argv(argv, mcp_config_path, extra_allowed_tools=extra_allowed_tools)
     if _should_skip_claude_permissions():
         perm = claude_permission_argv(auto_approve=True)
         if perm:

--- a/orion/harness/tests/test_fcc_motor_mcp.py
+++ b/orion/harness/tests/test_fcc_motor_mcp.py
@@ -115,6 +115,51 @@ async def test_run_fcc_turn_omits_mcp_config_when_disabled(monkeypatch: pytest.M
 
 
 @pytest.mark.asyncio
+async def test_run_fcc_turn_hook_mode_allows_context_mode_plugin_server(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured_argv: list = []
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProc:
+        captured_argv.extend(args)
+        return _FakeProc([
+            '{"type":"result","result":"Done.","session_id":"s1"}',
+        ])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(motor, "_preflight_fcc_server", lambda *a, **k: None)
+    monkeypatch.setattr(motor, "load_fcc_env", _fake_fcc_env)
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.delenv("HARNESS_FCC_GITNEXUS_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", raising=False)
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED", "true")
+    fake_cfg = tmp_path / "hooks-mcp.json"
+    fake_cfg.write_text(
+        '{"mcpServers":{"github":{},"firecrawl":{}}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(motor, "_maybe_render_mcp_config", lambda **k: fake_cfg)
+
+    async for _ in motor.run_fcc_turn(
+        prompt="hello",
+        fcc_model_label="MODEL_HAIKU",
+        correlation_id="corr-hooks-argv",
+        workspace="/tmp",
+        fcc_server_url="http://127.0.0.1:8082",
+        auth_token="tok",
+        claude_bin="claude",
+        timeout_sec=30.0,
+    ):
+        pass
+
+    assert "--allowedTools" in captured_argv
+    idx = captured_argv.index("--allowedTools")
+    assert captured_argv[idx + 1] == "mcp__github"
+    assert captured_argv[idx + 2] == "mcp__firecrawl"
+    assert captured_argv[idx + 3] == "mcp__plugin_context-mode_context-mode"
+
+
+@pytest.mark.asyncio
 async def test_run_fcc_turn_surfaces_mcp_preflight_error_code(monkeypatch: pytest.MonkeyPatch) -> None:
     from orion.fcc.mcp_config import McpPreflightError
 
@@ -272,6 +317,38 @@ def test_maybe_render_mcp_config_wires_self_index_flags(
         mcp_config.cleanup_mcp_config(path)
 
 
+def test_maybe_render_mcp_config_hook_mode_skips_standalone_context_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import json
+
+    import orion.fcc.mcp_config as mcp_config
+
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.delenv("HARNESS_AITOWN_ENABLED", raising=False)
+    monkeypatch.setenv("HARNESS_FCC_GITNEXUS_ENABLED", "true")
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", "true")
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED", "true")
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_DIR", str(tmp_path / "ctx-data"))
+    monkeypatch.setenv("HARNESS_FCC_WORKSPACE", "/mnt/scripts/Orion-Sapienform")
+    monkeypatch.setattr(
+        motor,
+        "load_fcc_env",
+        lambda _p: {"GITHUB_PAT": "ghp_hooks", "FIRECRAWL_API_KEY": "fc_hooks"},
+    )
+    monkeypatch.setattr(motor, "expand_env_path", lambda _p: Path("/fake/.fcc/.env"))
+    monkeypatch.setattr(mcp_config.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    path = motor._maybe_render_mcp_config(correlation_id="corr-hooks-mode")
+    try:
+        assert path is not None
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+        assert "context-mode" not in servers
+        assert "gitnexus" in servers
+    finally:
+        mcp_config.cleanup_mcp_config(path)
+
+
 def test_maybe_render_mcp_config_self_index_off_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -317,6 +394,46 @@ def test_build_subprocess_env_sets_context_ceiling(monkeypatch: pytest.MonkeyPat
     assert env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "65536"
     assert env["CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS"] == "8192"
     assert env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] == "70"
+
+
+def test_build_subprocess_env_hook_mode_sets_context_mode_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.delenv("HARNESS_FCC_GITNEXUS_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", raising=False)
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED", "true")
+    monkeypatch.setenv("HARNESS_FCC_WORKSPACE", "/mnt/scripts/Orion-Sapienform")
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_DIR", str(tmp_path / "ctx-data"))
+    env = motor._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["CONTEXT_MODE_PLATFORM"] == "claude-code"
+    assert env["CONTEXT_MODE_PROJECT_DIR"] == "/mnt/scripts/Orion-Sapienform"
+    assert env["CONTEXT_MODE_DIR"] == str(tmp_path / "ctx-data")
+
+
+def test_build_subprocess_env_hook_mode_uses_fallback_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED", "true")
+    monkeypatch.delenv("HARNESS_FCC_WORKSPACE", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_DIR", raising=False)
+    env = motor._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert env["CONTEXT_MODE_PLATFORM"] == "claude-code"
+    assert env["CONTEXT_MODE_PROJECT_DIR"] == motor.os.getcwd()
+    assert env["CONTEXT_MODE_DIR"] == "/var/lib/orion/context-mode"
+
+
+def test_build_subprocess_env_no_context_mode_keys_without_hook_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED", raising=False)
+    monkeypatch.delenv("CONTEXT_MODE_PLATFORM", raising=False)
+    monkeypatch.delenv("CONTEXT_MODE_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("CONTEXT_MODE_DIR", raising=False)
+    env = motor._build_subprocess_env(fcc_server_url="http://127.0.0.1:8082", auth_token="tok")
+    assert "CONTEXT_MODE_PLATFORM" not in env
+    assert "CONTEXT_MODE_PROJECT_DIR" not in env
+    assert "CONTEXT_MODE_DIR" not in env
 
 
 def test_build_subprocess_env_enables_tool_search(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/orion/harness/tests/test_harness_prefix.py
+++ b/orion/harness/tests/test_harness_prefix.py
@@ -113,11 +113,65 @@ def test_compile_harness_prefix_self_index_briefs_gated_on_master_flag(
     assert "Context Mode MCP" not in prompt
 
 
+def test_compile_harness_prefix_includes_context_mode_brief_in_hook_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hook mode (plugin-owned MCP server) advertises the same ctx_* brief,
+    even with the standalone context-mode flag off."""
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.setenv("ORION_GITHUB_OWNER", "junebug-junie")
+    monkeypatch.setenv("ORION_GITHUB_REPO", "Orion-Sapienform")
+    monkeypatch.delenv("HARNESS_FCC_GITNEXUS_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", raising=False)
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED", "true")
+    thought = make_thought(imperative="Trace the unified turn.")
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+    )
+    assert "Context Mode MCP is available" in prompt
+    assert "ctx_search" in prompt
+    assert "GitNexus" not in prompt
+
+
+def test_compile_harness_prefix_omits_context_mode_brief_when_both_modes_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HARNESS_FCC_MCP_ENABLED", "true")
+    monkeypatch.setenv("ORION_GITHUB_OWNER", "junebug-junie")
+    monkeypatch.setenv("ORION_GITHUB_REPO", "Orion-Sapienform")
+    monkeypatch.delenv("HARNESS_FCC_GITNEXUS_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED", raising=False)
+    thought = make_thought()
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+    )
+    assert "Context Mode MCP" not in prompt
+
+
+def test_compile_harness_prefix_hook_mode_brief_gated_on_master_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HARNESS_FCC_MCP_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_GITNEXUS_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", raising=False)
+    monkeypatch.setenv("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED", "true")
+    thought = make_thought()
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+    )
+    assert "Context Mode MCP" not in prompt
+
+
 def test_compile_harness_prefix_omits_self_index_briefs_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("HARNESS_FCC_GITNEXUS_ENABLED", raising=False)
     monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_ENABLED", raising=False)
+    monkeypatch.delenv("HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED", raising=False)
     thought = make_thought()
     prompt = compile_harness_prefix(
         thought,

--- a/scripts/context_mode_hooks_smoke.py
+++ b/scripts/context_mode_hooks_smoke.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""Headless Context Mode hook-validation smoke for the harness governor.
+
+Stage B of the semantic self-indexing proposal (§9.3): prove — or honestly
+fail — each hook-mode requirement before HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED
+is turned on for ordinary Orion turns.
+
+Runs INSIDE the harness-governor container (python3 + claude on PATH,
+/root/.claude persistent volume with the context-mode plugin installed).
+It never modifies repo files and is safe to re-run.
+
+Each check emits one JSON line on stdout:
+
+    {"check": <name>, "status": "PASS"|"FAIL"|"UNVERIFIED", "evidence": ...}
+
+Exit code is 0 only when no check FAILed; UNVERIFIED is allowed but visible.
+
+Raw claude stream output for every spawned turn is kept under
+/tmp/context-mode-hooks-smoke/<run-id>/ for evidence.
+
+Usage (inside the governor container):
+
+    python3 scripts/context_mode_hooks_smoke.py
+    python3 scripts/context_mode_hooks_smoke.py --checks plugin_installed,no_duplicate_mcp
+    python3 scripts/context_mode_hooks_smoke.py --timeout-sec 300 --out /tmp/smoke.jsonl
+
+Check 7 (disable_restores_baseline) only runs for real when the operator
+re-runs the script with HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED off.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+# Allow running as `python3 scripts/context_mode_hooks_smoke.py` from repo root
+# (or anywhere) without an installed orion package.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from orion.fcc.claude_spawn import claude_permission_argv  # noqa: E402
+from orion.harness.fcc_motor import (  # noqa: E402
+    _build_subprocess_env,
+    _preflight_fcc_server,
+    expand_env_path,
+    label_to_claude_model_id,
+    load_fcc_env,
+    resolve_auth_token,
+)
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNVERIFIED = "UNVERIFIED"
+_STATUS_RANK = {PASS: 0, UNVERIFIED: 1, FAIL: 2}
+
+HOOKS_FLAG_KEY = "HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED"
+PLUGIN_MCP_SERVER = "mcp__plugin_context-mode_context-mode"
+PLUGIN_TOOL_PREFIX = PLUGIN_MCP_SERVER + "__"
+DEFAULT_CONTEXT_MODE_DIR = "/var/lib/orion/context-mode"
+EVIDENCE_ROOT = Path("/tmp/context-mode-hooks-smoke")
+# Smoke turns are read-only by contract: the script must never modify repo files.
+SAFE_DISALLOWED_TOOLS = ["--disallowedTools", "Write", "Edit", "NotebookEdit", "Bash"]
+
+CHECK_ORDER = [
+    "plugin_installed",
+    "no_duplicate_mcp",
+    "plugin_tools_callable_headless",
+    "precompact_fires",
+    "sessionstart_restore",
+    "fresh_session_isolation",
+    "disable_restores_baseline",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested; no subprocess, no environment access)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    check: str
+    status: str
+    evidence: Any
+
+    def to_json_line(self) -> str:
+        return json.dumps(
+            {"check": self.check, "status": self.status, "evidence": self.evidence},
+            ensure_ascii=False,
+        )
+
+
+def is_truthy(raw: Optional[str]) -> bool:
+    return str(raw or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def parse_stream_lines(lines: Iterable[str]) -> List[Dict[str, Any]]:
+    """Parse claude --output-format stream-json lines into dict events."""
+    events: List[Dict[str, Any]] = []
+    for line in lines:
+        stripped = str(line or "").strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            events.append(parsed)
+    return events
+
+
+def extract_tool_use_names(events: Sequence[Mapping[str, Any]]) -> List[str]:
+    """Tool names from assistant events' message.content[] tool_use blocks."""
+    names: List[str] = []
+    for event in events:
+        message = event.get("message")
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and isinstance(block.get("name"), str)
+            ):
+                names.append(block["name"])
+    return names
+
+
+def extract_session_id(events: Sequence[Mapping[str, Any]]) -> Optional[str]:
+    """session_id from the result event (fall back to any event carrying one)."""
+    fallback: Optional[str] = None
+    for event in events:
+        sid = event.get("session_id")
+        if not sid:
+            continue
+        if str(event.get("type") or "") == "result":
+            return str(sid)
+        if fallback is None:
+            fallback = str(sid)
+    return fallback
+
+
+def extract_final_text(events: Sequence[Mapping[str, Any]]) -> str:
+    """Final reply text: prefer the result event, else last assistant text."""
+    assistant_text = ""
+    for event in events:
+        if str(event.get("type") or "") == "result":
+            result = event.get("result")
+            if isinstance(result, str) and result.strip():
+                return result.strip()
+        message = event.get("message")
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        parts = [
+            block["text"]
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and isinstance(block.get("text"), str)
+        ]
+        if parts:
+            assistant_text = "".join(parts).strip() or assistant_text
+    return assistant_text
+
+
+def has_compact_event(events: Sequence[Mapping[str, Any]]) -> bool:
+    """Any stream event whose type/subtype mentions compaction."""
+    for event in events:
+        etype = str(event.get("type") or "").lower()
+        subtype = str(event.get("subtype") or event.get("system_subtype") or "").lower()
+        if "compact" in etype or "compact" in subtype:
+            return True
+    return False
+
+
+def snapshot_dir(root: Path) -> Dict[str, float]:
+    """relative-path -> mtime for every file under root ({} if missing)."""
+    if not root.is_dir():
+        return {}
+    out: Dict[str, float] = {}
+    for path in root.rglob("*"):
+        try:
+            if path.is_file():
+                out[str(path.relative_to(root))] = path.stat().st_mtime
+        except OSError:
+            continue
+    return out
+
+
+def dir_diff(before: Mapping[str, float], after: Mapping[str, float]) -> Dict[str, List[str]]:
+    added = sorted(name for name in after if name not in before)
+    modified = sorted(
+        name for name in after if name in before and after[name] > before[name]
+    )
+    return {"added": added, "modified": modified}
+
+
+def worst_status(statuses: Iterable[str]) -> str:
+    """FAIL beats UNVERIFIED beats PASS; empty input is PASS."""
+    worst = PASS
+    for status in statuses:
+        rank = _STATUS_RANK.get(status, _STATUS_RANK[FAIL])
+        if rank > _STATUS_RANK[worst]:
+            worst = FAIL if rank == _STATUS_RANK[FAIL] else UNVERIFIED
+    return worst
+
+
+def exit_code_for(statuses: Iterable[str]) -> int:
+    """0 only when no FAIL; UNVERIFIED does not fail the run."""
+    return 1 if worst_status(statuses) == FAIL else 0
+
+
+# ---------------------------------------------------------------------------
+# Subprocess orchestration (container-only; never exercised by unit tests)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SmokeConfig:
+    claude_bin: str
+    workspace: str
+    context_mode_dir: Path
+    env_path: Path
+    evidence_dir: Path
+    timeout_sec: float
+    fcc_server_url: str = ""
+    auth_token: str = ""
+    model_id: str = ""
+    turn_blocker: Optional[str] = None  # reason claude turns cannot be spawned
+
+
+@dataclass
+class TurnResult:
+    events: List[Dict[str, Any]] = field(default_factory=list)
+    exit_code: int = 1
+    stderr_tail: str = ""
+    stdout_path: Optional[Path] = None
+    timed_out: bool = False
+
+    def summary(self) -> Dict[str, Any]:
+        return {
+            "exit_code": self.exit_code,
+            "timed_out": self.timed_out,
+            "stderr_tail": self.stderr_tail[-500:],
+            "raw_stream": str(self.stdout_path) if self.stdout_path else None,
+        }
+
+
+def build_config(args: argparse.Namespace) -> SmokeConfig:
+    env_path = expand_env_path(os.environ.get("HARNESS_FCC_ENV_PATH", "~/.fcc/.env"))
+    run_id = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime()) + f"-{os.getpid()}"
+    evidence_dir = EVIDENCE_ROOT / run_id
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    cfg = SmokeConfig(
+        claude_bin=os.environ.get("HARNESS_FCC_CLAUDE_BIN", "claude"),
+        workspace=os.environ.get("HARNESS_FCC_WORKSPACE") or os.getcwd(),
+        context_mode_dir=Path(
+            os.environ.get("HARNESS_FCC_CONTEXT_MODE_DIR") or DEFAULT_CONTEXT_MODE_DIR
+        ),
+        env_path=env_path,
+        evidence_dir=evidence_dir,
+        timeout_sec=args.timeout_sec,
+    )
+
+    fcc_env = load_fcc_env(env_path)
+    cfg.fcc_server_url = str(os.environ.get("HARNESS_FCC_SERVER_URL") or "").strip()
+    cfg.auth_token = resolve_auth_token(fcc_env)
+    problems: List[str] = []
+    if not cfg.fcc_server_url:
+        problems.append("HARNESS_FCC_SERVER_URL is not set")
+    if not cfg.auth_token:
+        problems.append(f"ANTHROPIC_AUTH_TOKEN missing from FCC env at {env_path}")
+    try:
+        cfg.model_id = label_to_claude_model_id(args.model_label, fcc_env)
+    except ValueError as exc:
+        problems.append(str(exc))
+    if not problems:
+        try:
+            _preflight_fcc_server(cfg.fcc_server_url)
+        except RuntimeError as exc:
+            problems.append(str(exc))
+    if problems:
+        cfg.turn_blocker = "; ".join(problems)
+    return cfg
+
+
+def run_claude_turn(
+    cfg: SmokeConfig,
+    *,
+    turn_name: str,
+    prompt: str,
+    allow_plugin_tools: bool = False,
+    extra_argv: Optional[Sequence[str]] = None,
+    env_overrides: Optional[Mapping[str, str]] = None,
+) -> TurnResult:
+    """Mirror the FCC motor spawn shape for one headless claude -p turn."""
+    argv = [cfg.claude_bin, "-p", prompt, "--output-format", "stream-json", "--verbose"]
+    argv += claude_permission_argv(auto_approve=True)  # root container -> dontAsk
+    argv += ["--model", cfg.model_id]
+    if allow_plugin_tools:
+        argv += ["--allowedTools", PLUGIN_MCP_SERVER]
+    argv += SAFE_DISALLOWED_TOOLS
+    if extra_argv:
+        argv += list(extra_argv)
+
+    env = _build_subprocess_env(fcc_server_url=cfg.fcc_server_url, auth_token=cfg.auth_token)
+    if env_overrides:
+        env.update(env_overrides)
+
+    stdout_path = cfg.evidence_dir / f"{turn_name}.stdout.jsonl"
+    stderr_path = cfg.evidence_dir / f"{turn_name}.stderr.txt"
+    timed_out = False
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=cfg.workspace,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=cfg.timeout_sec,
+        )
+        stdout, stderr, exit_code = proc.stdout or "", proc.stderr or "", proc.returncode
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        stderr += f"\n[smoke] turn timed out after {cfg.timeout_sec}s"
+        exit_code, timed_out = 124, True
+    except FileNotFoundError:
+        stdout, stderr, exit_code = "", f"claude binary not found: {cfg.claude_bin!r}", 127
+
+    stdout_path.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+    return TurnResult(
+        events=parse_stream_lines(stdout.splitlines()),
+        exit_code=exit_code,
+        stderr_tail=stderr.strip()[-500:],
+        stdout_path=stdout_path,
+        timed_out=timed_out,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Checks (§9.3)
+# ---------------------------------------------------------------------------
+
+
+def check_plugin_installed(cfg: SmokeConfig, state: Dict[str, Any]) -> CheckResult:
+    """1. `claude plugin list` output contains "context-mode"."""
+    argv = [cfg.claude_bin, "plugin", "list"]
+    try:
+        proc = subprocess.run(
+            argv, capture_output=True, text=True, timeout=min(60.0, cfg.timeout_sec)
+        )
+    except FileNotFoundError:
+        return CheckResult(
+            "plugin_installed", FAIL, f"claude binary not found: {cfg.claude_bin!r}"
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult("plugin_installed", FAIL, "`claude plugin list` timed out")
+    output = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    matches = [line.strip() for line in output.splitlines() if "context-mode" in line.lower()]
+    if proc.returncode == 0 and matches:
+        return CheckResult(
+            "plugin_installed", PASS, {"exit_code": proc.returncode, "matches": matches[:5]}
+        )
+    return CheckResult(
+        "plugin_installed",
+        FAIL,
+        {
+            "exit_code": proc.returncode,
+            "detail": "no 'context-mode' entry in `claude plugin list`",
+            "output_tail": output.strip()[-500:],
+        },
+    )
+
+
+def check_no_duplicate_mcp(cfg: SmokeConfig, state: Dict[str, Any]) -> CheckResult:
+    """2. Hook-mode contract: rendered MCP config has no standalone context-mode."""
+    from orion.fcc.mcp_config import McpPreflightError, cleanup_mcp_config, render_mcp_config
+
+    fcc_env = load_fcc_env(cfg.env_path)
+    try:
+        # Render into the evidence dir but delete immediately: the rendered
+        # config carries secrets (GITHUB_PAT / FIRECRAWL_API_KEY).
+        path = render_mcp_config(
+            correlation_id="context-mode-hooks-smoke",
+            fcc_env=fcc_env,
+            tmp_dir=cfg.evidence_dir / "mcp-render",
+            include_context_mode=False,
+        )
+    except McpPreflightError as exc:
+        return CheckResult(
+            "no_duplicate_mcp",
+            UNVERIFIED,
+            f"could not render harness MCP config ({exc.error_code}): {exc}",
+        )
+    try:
+        servers = sorted((json.loads(path.read_text(encoding="utf-8")).get("mcpServers") or {}))
+    finally:
+        cleanup_mcp_config(path)
+
+    if "context-mode" in servers:
+        return CheckResult(
+            "no_duplicate_mcp",
+            FAIL,
+            {
+                "detail": "standalone context-mode MCP server present despite "
+                "include_context_mode=False (would double-register ctx_* tools)",
+                "mcp_servers": servers,
+            },
+        )
+    flag_raw = os.environ.get(HOOKS_FLAG_KEY)
+    if is_truthy(flag_raw):
+        return CheckResult(
+            "no_duplicate_mcp",
+            PASS,
+            {"mcp_servers": servers, HOOKS_FLAG_KEY: flag_raw},
+        )
+    return CheckResult(
+        "no_duplicate_mcp",
+        UNVERIFIED,
+        {
+            "detail": f"rendered config is clean ({servers}) but {HOOKS_FLAG_KEY} is not "
+            "truthy in this environment, so hook mode is not what live turns exercise. "
+            f"Re-run with {HOOKS_FLAG_KEY}=true exported (governor compose contract).",
+            HOOKS_FLAG_KEY: flag_raw or "",
+        },
+    )
+
+
+def check_plugin_tools_callable(cfg: SmokeConfig, state: Dict[str, Any]) -> CheckResult:
+    """3. A headless turn can call a plugin-owned ctx_* MCP tool."""
+    if cfg.turn_blocker:
+        return CheckResult("plugin_tools_callable_headless", UNVERIFIED, cfg.turn_blocker)
+    turn = run_claude_turn(
+        cfg,
+        turn_name="03_plugin_tools",
+        prompt="Call the ctx_stats tool once and reply DONE.",
+        allow_plugin_tools=True,
+    )
+    names = extract_tool_use_names(turn.events)
+    plugin_calls = [n for n in names if n.startswith(PLUGIN_TOOL_PREFIX)]
+    session_id = extract_session_id(turn.events)
+    if session_id:
+        state["session_id"] = session_id
+    evidence = {
+        "plugin_tool_calls": plugin_calls,
+        "all_tool_calls": names,
+        "session_id": session_id,
+        **turn.summary(),
+    }
+    if plugin_calls:
+        return CheckResult("plugin_tools_callable_headless", PASS, evidence)
+    return CheckResult("plugin_tools_callable_headless", FAIL, evidence)
+
+
+def check_precompact_fires(cfg: SmokeConfig, state: Dict[str, Any]) -> CheckResult:
+    """4. Forced-low context turn triggers PreCompact snapshots (or compact event)."""
+    if cfg.turn_blocker:
+        return CheckResult("precompact_fires", UNVERIFIED, cfg.turn_blocker)
+    sessions_dir = cfg.context_mode_dir / "sessions"
+    before = snapshot_dir(sessions_dir)
+    turn = run_claude_turn(
+        cfg,
+        turn_name="04_precompact",
+        prompt=(
+            "Read README.md in full, then read CLAUDE.md in full, then reply with a "
+            "one-line summary of each."
+        ),
+        allow_plugin_tools=True,
+        env_overrides={
+            "CLAUDE_CODE_MAX_CONTEXT_TOKENS": "16384",
+            "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "16384",
+            "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "10",
+        },
+    )
+    after = snapshot_dir(sessions_dir)
+    diff = dir_diff(before, after)
+    compacted = has_compact_event(turn.events)
+    evidence = {
+        "sessions_dir": str(sessions_dir),
+        "snapshot_diff": diff,
+        "compact_event_in_stream": compacted,
+        **turn.summary(),
+    }
+    if diff["added"] or diff["modified"] or compacted:
+        return CheckResult("precompact_fires", PASS, evidence)
+    evidence["detail"] = (
+        "no new/updated snapshot under sessions/ and no compact event in the stream; "
+        "compaction may not have triggered (context did not fill past the override, "
+        "or the PreCompact hook did not run). Inspect the raw stream for tool_use "
+        "volume and re-run with a heavier prompt if needed."
+    )
+    return CheckResult("precompact_fires", UNVERIFIED, evidence)
+
+
+def check_sessionstart_restore(cfg: SmokeConfig, state: Dict[str, Any]) -> CheckResult:
+    """5. --resume of check 3's session recalls the ctx_stats call."""
+    if cfg.turn_blocker:
+        return CheckResult("sessionstart_restore", UNVERIFIED, cfg.turn_blocker)
+    session_id = state.get("session_id")
+    if not session_id:
+        return CheckResult(
+            "sessionstart_restore",
+            UNVERIFIED,
+            "no session_id captured — run the plugin_tools_callable_headless check "
+            "first (same invocation) so there is a session to resume",
+        )
+    turn = run_claude_turn(
+        cfg,
+        turn_name="05_resume",
+        prompt="In one line, what tool did you call earlier in this session?",
+        allow_plugin_tools=True,
+        extra_argv=["--resume", str(session_id)],
+    )
+    final = extract_final_text(turn.events)
+    evidence = {"resumed_session_id": session_id, "final_text": final[:500], **turn.summary()}
+    if turn.exit_code != 0:
+        evidence["detail"] = (
+            "`claude -p --resume <session_id>` exited nonzero; the flag may be "
+            "rejected in this CLI version — see stderr_tail"
+        )
+        return CheckResult("sessionstart_restore", UNVERIFIED, evidence)
+    if "ctx_stats" in final.lower():
+        return CheckResult("sessionstart_restore", PASS, evidence)
+    evidence["detail"] = "resumed reply does not reference ctx_stats"
+    return CheckResult("sessionstart_restore", FAIL, evidence)
+
+
+def check_fresh_session_isolation(cfg: SmokeConfig, state: Dict[str, Any]) -> CheckResult:
+    """6. A brand-new session must not leak check 3's markers."""
+    if cfg.turn_blocker:
+        return CheckResult("fresh_session_isolation", UNVERIFIED, cfg.turn_blocker)
+    turn = run_claude_turn(
+        cfg,
+        turn_name="06_fresh_session",
+        prompt=(
+            "Without calling any tool, state in one line what task you were working "
+            "on before this message."
+        ),
+    )
+    final = extract_final_text(turn.events)
+    markers = ["ctx_stats", "ctx stats"]
+    leaked = [m for m in markers if m in final.lower()]
+    evidence = {"final_text": final[:500], "leaked_markers": leaked, **turn.summary()}
+    if turn.exit_code != 0 and not final:
+        evidence["detail"] = "fresh turn exited nonzero with no reply — see stderr_tail"
+        return CheckResult("fresh_session_isolation", UNVERIFIED, evidence)
+    if leaked:
+        evidence["detail"] = "fresh session reply mentions markers from the earlier smoke turn"
+        return CheckResult("fresh_session_isolation", FAIL, evidence)
+    return CheckResult("fresh_session_isolation", PASS, evidence)
+
+
+def check_disable_restores_baseline(cfg: SmokeConfig, state: Dict[str, Any]) -> CheckResult:
+    """7. With the hooks flag off, plain turns show no plugin tool_use."""
+    flag_raw = os.environ.get(HOOKS_FLAG_KEY)
+    if is_truthy(flag_raw):
+        return CheckResult(
+            "disable_restores_baseline",
+            UNVERIFIED,
+            f"{HOOKS_FLAG_KEY} is truthy ({flag_raw!r}) in this run; re-run this "
+            f"script with the flag off (e.g. {HOOKS_FLAG_KEY}=false) to verify the "
+            "baseline turn shape is restored",
+        )
+    if cfg.turn_blocker:
+        return CheckResult("disable_restores_baseline", UNVERIFIED, cfg.turn_blocker)
+    turn = run_claude_turn(
+        cfg,
+        turn_name="07_baseline",
+        prompt="Reply with the single word OK.",
+    )
+    names = extract_tool_use_names(turn.events)
+    plugin_calls = [n for n in names if n.startswith("mcp__plugin_context-mode")]
+    evidence = {"plugin_tool_calls": plugin_calls, "all_tool_calls": names, **turn.summary()}
+    if turn.exit_code != 0 and not turn.events:
+        evidence["detail"] = "baseline turn produced no stream — see stderr_tail"
+        return CheckResult("disable_restores_baseline", UNVERIFIED, evidence)
+    if plugin_calls:
+        evidence["detail"] = "plugin-owned context-mode tools still fired with the flag off"
+        return CheckResult("disable_restores_baseline", FAIL, evidence)
+    return CheckResult("disable_restores_baseline", PASS, evidence)
+
+
+CHECKS = {
+    "plugin_installed": check_plugin_installed,
+    "no_duplicate_mcp": check_no_duplicate_mcp,
+    "plugin_tools_callable_headless": check_plugin_tools_callable,
+    "precompact_fires": check_precompact_fires,
+    "sessionstart_restore": check_sessionstart_restore,
+    "fresh_session_isolation": check_fresh_session_isolation,
+    "disable_restores_baseline": check_disable_restores_baseline,
+}
+assert list(CHECKS) == CHECK_ORDER
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Headless Context Mode hook-validation smoke (semantic self-indexing "
+            "§9.3 Stage B). Emits one JSON line per check; exits 0 only if no FAIL."
+        )
+    )
+    parser.add_argument(
+        "--checks",
+        default=",".join(CHECK_ORDER),
+        help=f"comma-separated subset of checks to run (default: all). Known: {', '.join(CHECK_ORDER)}",
+    )
+    parser.add_argument(
+        "--timeout-sec",
+        type=float,
+        default=240.0,
+        help="per-claude-turn timeout in seconds (default: 240)",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="optional path: also append each check's JSON line to this JSONL file",
+    )
+    parser.add_argument(
+        "--model-label",
+        default="MODEL_SONNET",
+        help="FCC env model label used for spawned turns (default: MODEL_SONNET)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    selected = [name.strip() for name in str(args.checks).split(",") if name.strip()]
+    unknown = [name for name in selected if name not in CHECKS]
+    if unknown:
+        print(
+            f"unknown checks: {', '.join(unknown)} (known: {', '.join(CHECK_ORDER)})",
+            file=sys.stderr,
+        )
+        return 2
+    # Preserve canonical order regardless of how --checks was written.
+    selected = [name for name in CHECK_ORDER if name in selected]
+
+    cfg = build_config(args)
+    print(f"[smoke] evidence dir: {cfg.evidence_dir}", file=sys.stderr)
+    if cfg.turn_blocker:
+        print(
+            f"[smoke] claude turns blocked (turn checks will be UNVERIFIED): {cfg.turn_blocker}",
+            file=sys.stderr,
+        )
+
+    out_path = Path(args.out) if args.out else None
+    state: Dict[str, Any] = {}
+    results: List[CheckResult] = []
+    for name in selected:
+        try:
+            result = CHECKS[name](cfg, state)
+        except Exception as exc:  # honest failure beats a crashed smoke
+            result = CheckResult(name, FAIL, f"check crashed: {type(exc).__name__}: {exc}")
+        results.append(result)
+        line = result.to_json_line()
+        print(line, flush=True)
+        if out_path is not None:
+            with out_path.open("a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+
+    statuses = [r.status for r in results]
+    print(
+        f"[smoke] overall: {worst_status(statuses)} "
+        f"({statuses.count(PASS)} PASS / {statuses.count(UNVERIFIED)} UNVERIFIED / "
+        f"{statuses.count(FAIL)} FAIL); evidence dir: {cfg.evidence_dir}",
+        file=sys.stderr,
+    )
+    return exit_code_for(statuses)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -67,6 +67,13 @@ HARNESS_FCC_CONTEXT_MODE_ENABLED=true
 # Writable Context Mode storage root inside the container (Docker volume
 # harness-context-mode; operational working data, not an Orion memory store).
 HARNESS_FCC_CONTEXT_MODE_DIR=/var/lib/orion/context-mode
+# Context Mode hook mode (Stage B): replaces the standalone context-mode MCP
+# server with the Claude Code plugin (PreToolUse/PostToolUse/PreCompact/
+# SessionStart/Stop hooks; session continuity across compaction). Requires the
+# plugin installed in the harness-claude-config volume. When both this and
+# HARNESS_FCC_CONTEXT_MODE_ENABLED are true, hook mode wins and the standalone
+# server is skipped to avoid duplicate tool registration.
+HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED=false
 # Bridge-network harness cannot use 127.0.0.1 from ~/.fcc; override Convex reachability here
 HARNESS_AITOWN_CONVEX_URL=http://host.docker.internal:3210
 # (D) embodiment: emit a deliberate approach intent on the turn correlation_id after a

--- a/services/orion-harness-governor/.env_example
+++ b/services/orion-harness-governor/.env_example
@@ -73,7 +73,7 @@ HARNESS_FCC_CONTEXT_MODE_DIR=/var/lib/orion/context-mode
 # plugin installed in the harness-claude-config volume. When both this and
 # HARNESS_FCC_CONTEXT_MODE_ENABLED are true, hook mode wins and the standalone
 # server is skipped to avoid duplicate tool registration.
-HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED=false
+HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED=true
 # Bridge-network harness cannot use 127.0.0.1 from ~/.fcc; override Convex reachability here
 HARNESS_AITOWN_CONVEX_URL=http://host.docker.internal:3210
 # (D) embodiment: emit a deliberate approach intent on the turn correlation_id after a

--- a/services/orion-harness-governor/README.md
+++ b/services/orion-harness-governor/README.md
@@ -63,6 +63,17 @@ Both are default-off, fail-open, and need no secrets:
   The generated `.gitnexus/` is gitignored; compose mounts `~/.gitnexus` read-only for registry discovery. Re-run after merges so `gitnexus status` reports up-to-date (the MCP discloses staleness but stale structure is never authority).
 - `HARNESS_FCC_CONTEXT_MODE_ENABLED=true` adds the Context Mode MCP (MCP-only stage, no Claude hooks). Working data lives in the `harness-context-mode` volume at `HARNESS_FCC_CONTEXT_MODE_DIR` — operational data, not an Orion memory store; never expose it through Hub APIs.
 
+#### Hook mode (Stage B)
+
+`HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED=true` runs Context Mode as a Claude Code plugin (PreToolUse/PostToolUse/PreCompact/SessionStart/Stop hooks) instead of the standalone MCP server, adding session continuity across compaction. The plugin is installed once by the operator into the persistent `harness-claude-config` volume (mounted at `/root/.claude`), not baked at image build:
+
+```bash
+docker exec -it <container> claude plugin marketplace add mksglu/context-mode
+docker exec -it <container> claude plugin install context-mode@context-mode
+```
+
+The smoke script `scripts/context_mode_hooks_smoke.py` must pass before enabling this on ordinary turns. No duplicate registration: when both `HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED` and `HARNESS_FCC_CONTEXT_MODE_ENABLED` are true, hook mode wins and the standalone server is skipped.
+
 The unified-turn introspection experiment for these flags lives at `scripts/run_unified_turn_introspection_eval.py` with its fixture in `orion/harness/evals/fixtures/`.
 
 `HARNESS_FCC_SKIP_PERMISSIONS=true` (default in compose) passes `--dangerously-skip-permissions` to `claude -p` even when the governor runs as root — otherwise Bash/MCP steps stall on approval prompts with no operator in Orion mode.

--- a/services/orion-harness-governor/app/settings.py
+++ b/services/orion-harness-governor/app/settings.py
@@ -90,6 +90,9 @@ class HarnessGovernorSettings(BaseSettings):
     harness_fcc_context_mode_dir: str = Field(
         "/var/lib/orion/context-mode", alias="HARNESS_FCC_CONTEXT_MODE_DIR"
     )
+    harness_fcc_context_mode_hooks_enabled: bool = Field(
+        False, alias="HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED"
+    )
 
     # (D) embodiment: publish a deliberate approach intent on the turn correlation_id
     # after a finalized relational turn. Default-off, fail-open (never breaks a turn).

--- a/services/orion-harness-governor/docker-compose.yml
+++ b/services/orion-harness-governor/docker-compose.yml
@@ -24,6 +24,12 @@ services:
       # Context Mode working data — operational, project-scoped, NOT an Orion
       # memory store; never exposed through Hub convenience APIs.
       - harness-context-mode:${HARNESS_FCC_CONTEXT_MODE_DIR:-/var/lib/orion/context-mode}
+      # Harness-scoped Claude state (hook mode). Plugin installs persist here:
+      #   claude plugin marketplace add mksglu/context-mode
+      #   claude plugin install context-mode@context-mode
+      # This is NEVER the operator's own ~/.claude; ~/.claude.json stays a
+      # separate read-only mount above.
+      - harness-claude-config:/root/.claude
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - SERVICE_NAME=${SERVICE_NAME:-orion-harness-governor}
@@ -66,6 +72,7 @@ services:
       - HARNESS_FCC_GITNEXUS_ENABLED=${HARNESS_FCC_GITNEXUS_ENABLED:-false}
       - HARNESS_FCC_CONTEXT_MODE_ENABLED=${HARNESS_FCC_CONTEXT_MODE_ENABLED:-false}
       - HARNESS_FCC_CONTEXT_MODE_DIR=${HARNESS_FCC_CONTEXT_MODE_DIR:-/var/lib/orion/context-mode}
+      - HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED=${HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED:-false}
     networks:
       - app-net
     ports:
@@ -83,3 +90,4 @@ networks:
 
 volumes:
   harness-context-mode:
+  harness-claude-config:


### PR DESCRIPTION
## Summary

- Adds Context Mode **hook mode** behind `HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED`: the context-mode Claude Code plugin (PreToolUse/PostToolUse/PreCompact/SessionStart/Stop) replaces the standalone MCP server on FCC turns.
- New `harness-claude-config` volume at `/root/.claude` — harness-scoped Claude state for plugin installs, never the operator's own `~/.claude`.
- Hook mode skips the standalone `context-mode` server in the rendered MCP config (no duplicate ctx_* registration; single warning when both flags set), exports `CONTEXT_MODE_PLATFORM/PROJECT_DIR/DIR` into the claude subprocess, and pre-approves `mcp__plugin_context-mode_context-mode` via a new `extra_allowed_tools` seam in `extend_mcp_argv`.
- Ships `scripts/context_mode_hooks_smoke.py`: seven §9.3 checks with honest PASS/FAIL/UNVERIFIED JSON verdicts, read-only turns, raw streams kept as evidence.
- Flag flipped **on** in `.env_example` after the smoke passed 7/7 in the deployed governor; local `.env` synced; governor recreated with hook mode live.

## Outcome moved

Orion's FCC turns now get session continuity across compaction (PreCompact snapshot → SessionStart restore) and context virtualization via plugin hooks, with the no-duplicate-registration contract proven on the live rail rather than assumed.

## Current architecture (before)

Stage A only: standalone `context-mode` stdio MCP server per turn; no hooks, so nothing survived compaction and nothing restored session state; no dedicated Claude config surface in the harness container.

## Architecture touched

- `services/orion-harness-governor` compose/env/settings/README (config seam).
- `orion/fcc` claude_spawn + self_index_brief, `orion/harness/fcc_motor.py` (per-turn spawn seam).
- `scripts/` + `orion/fcc/tests/` (validation lane).

## Files changed

- `services/orion-harness-governor/docker-compose.yml`: `harness-claude-config:/root/.claude` volume + flag passthrough.
- `services/orion-harness-governor/.env_example`: `HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED=true` (flipped after smoke) with the hook-mode contract comment.
- `services/orion-harness-governor/app/settings.py`: mirror field.
- `services/orion-harness-governor/README.md`: hook-mode section — one-time plugin install pair, smoke gate before enabling.
- `orion/harness/fcc_motor.py`: hook mode forces `include_context_mode=False` (warns once per render if both flags set); `_build_subprocess_env` exports the three `CONTEXT_MODE_*` keys; `run_fcc_turn` pre-approves the plugin server pattern.
- `orion/fcc/claude_spawn.py`: `extend_mcp_argv(..., extra_allowed_tools=)` — baseline argv byte-identical when unused.
- `orion/fcc/self_index_brief.py`: Context Mode brief appended in either mode (still behind the master MCP gate).
- `scripts/context_mode_hooks_smoke.py` (new): the seven-check headless smoke.
- Tests: `orion/fcc/tests/test_claude_spawn.py`, `orion/fcc/tests/test_context_mode_hooks_smoke.py` (new), `orion/harness/tests/test_fcc_motor_mcp.py`, `orion/harness/tests/test_harness_prefix.py`.

## Schema / bus / API changes

None. `extend_mcp_argv` gains an optional kwarg (backward compatible).

## Env/config changes

- Added key: `HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED` — **true** in `.env_example` (operator decision after smoke pass).
- `.env_example` updated: yes. Local `.env` synced via `python3 scripts/sync_local_env_from_example.py` (`false -> true`). No skipped keys.
- One-time operator state: `claude plugin marketplace add mksglu/context-mode` + `claude plugin install context-mode@context-mode` executed inside the container; persists in the `harness-claude-config` volume.

## Tests run

```text
PYTHONPATH=. .venv/bin/pytest orion/fcc/tests orion/harness/tests orion/harness/evals orion/hub/tests services/orion-harness-governor/tests -q
→ 182 passed, 3 failed (the 3 pre-exist on main: grounding_capsule x2, harness_runner error-code drift)
```

## Evals run

```text
Live hook smoke in the deployed governor (evidence: /tmp/context-mode-hooks-smoke/20260711T214152Z-140/):
plugin_installed PASS · no_duplicate_mcp PASS (servers: firecrawl, github) ·
plugin_tools_callable_headless PASS (mcp__plugin_context-mode_context-mode__ctx_stats fired) ·
precompact_fires PASS (new snapshot DB files under sessions/) ·
sessionstart_restore PASS (--resume reply named ctx_stats) ·
fresh_session_isolation PASS (no marker leak) ·
disable_restores_baseline PASS (flag-off turn: zero plugin tool calls)
```

## Docker/build/smoke checks

```text
docker compose config renders; governor recreated twice (volume add, flag flip); health-ok;
container env shows HARNESS_FCC_CONTEXT_MODE_HOOKS_ENABLED=true
```

## Review findings fixed

Built by three scoped subagents; orchestrator verified every diff against the fixed contract before commit. No material findings surfaced in orchestrator review; agent test suites green.

## Restart required

Already done: governor recreated with the flag live. For other operators:

```bash
docker compose --env-file .env --env-file services/orion-harness-governor/.env \
  -f services/orion-harness-governor/docker-compose.yml up -d
```

## Risks / concerns

- Severity: medium — **the flag does not fully disable the plugin.** Once installed, its hooks load for every claude spawn in the container; the flag only gates Orion-side wiring. True disablement: `docker exec <container> claude plugin disable context-mode`.
- Severity: medium — **fresh sessions rehydrate prior working state by design** (check 6 passed its marker test, but the fresh session accurately described prior smoke work). Proposal §9.4 / open question 6: if fresh-turn isolation is wanted, evaluate `CONTEXT_MODE_SESSION_SUFFIX` per-correlation-id scoping as a follow-up.
- Severity: low — with both context flags true, each render logs the documented hook-mode-wins warning.

