### PR TITLE
Feat/self state deviation gate instrumentation

### DIFF
--- a/config/self_state/self_state_policy.v1.yaml
+++ b/config/self_state/self_state_policy.v1.yaml
@@ -112,6 +112,26 @@ context_channels:
   - recent_perturbation_count
   - overall_salience
 
+dimension_worse_direction:
+  # Phase 2 (2026-07-12) deviation probe (orion/self_state/deviation.py,
+  # measurement-only, no gating behavior yet): which direction is the
+  # notable one per dimension, mirroring the sign conventions already
+  # implicit in orion/self_state/scoring.py's formulas -- coherence_score/
+  # agency_readiness_score treat high=good; every *_pressure dimension,
+  # uncertainty, and field_intensity treat high=bad.
+  field_intensity: up
+  coherence: down
+  uncertainty: up
+  agency_readiness: down
+  resource_pressure: up
+  execution_pressure: up
+  reasoning_pressure: up
+  reliability_pressure: up
+  continuity_pressure: up
+  introspection_pressure: up
+  social_pressure: up
+  transport_integrity: down
+
 unresolved_pressure_threshold: 0.60
 dominant_channel_threshold: 0.25
 trajectory_threshold: 0.03

--- a/docs/superpowers/pr-reports/2026-07-12-self-state-deviation-probe-phase-2-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-self-state-deviation-probe-phase-2-pr.md
@@ -1,0 +1,109 @@
+# PR: Self-state Phase 2 — deviation-probe measurement instrumentation
+
+## Summary
+
+- Ports `orion.autonomy.deviation_gate.DeviationGate` (proven EWMA-baseline + z-threshold mechanism, already live for chat/biometric tensions) into `orion-self-state-runtime`, per the recommended starting point from the 2026-07-12 brainstorm continuing the self-state/mesh substrate redesign.
+- Each tick, every real `SelfStateV1` dimension is observed against its own learned baseline; the resulting deviation impulse is logged alongside the dimension's confidence value so the two can be compared on live data before deciding whether `channel_dimension_confidence()`'s cruder max-min-spread formula should be replaced.
+- Deliberately log-only: no new schema field yet ("measure before you name it"), no gated behavior, no score changes.
+- Medium-effort code review (3 angles) caught one real issue before it shipped and two smaller ones; all fixed in the same commit.
+
+## Outcome moved
+
+Layer 6 gains a real, proven mechanism for answering "has this dimension been sustained or is this a momentary spike," without inventing new statistics or duplicating `DriveEngine`'s already-fixed cadence-artifact bugs. Nothing is named yet — the point of this patch is to generate real data before shaping a schema field around it.
+
+## Current architecture
+
+Before this PR: Layer 6's only notion of history was a single-previous-tick diff (`dimension_trajectory`, age-gated at 300s) — no sense of "how long has this been true" beyond that. `DeviationGate` already existed and was proven elsewhere (`orion/spark/concept_induction/bus_worker.py`'s chat/biometric tension extraction) but had never been applied to self-state's own dimensions.
+
+## Architecture touched
+
+- `orion/self_state/` — new `deviation.py` module
+- `services/orion-self-state-runtime/` — worker wiring, settings, env
+- `config/self_state/self_state_policy.v1.yaml` — new `dimension_worse_direction` section
+- `orion/self_state/policy.py` — new policy schema field
+
+## Files changed
+
+- `orion/self_state/deviation.py`: new — `observe_dimension_deviation(gate, state, policy)`, reuses `DeviationGate` directly, reads per-dimension "worse" direction from policy config (not a hardcoded table — see Review findings)
+- `orion/self_state/policy.py`: new `dimension_worse_direction: dict[str, Literal["up","down"]]` field on `SelfStatePolicyV1`
+- `config/self_state/self_state_policy.v1.yaml`: new `dimension_worse_direction` section, all 12 dimensions
+- `services/orion-self-state-runtime/app/worker.py`: `DeviationGate` instantiated once in `__init__` (in-memory, per-process, dies with the process — same accepted limitation as `DriveEngine`'s pressure store); new `_log_deviation_probe()` called once per tick, gated by a settings flag
+- `services/orion-self-state-runtime/app/settings.py`: new `self_state_deviation_probe_enabled` (default `True`)
+- `services/orion-self-state-runtime/.env_example` + local `.env`: new `SELF_STATE_DEVIATION_PROBE_ENABLED=true`
+- `tests/test_self_state_deviation.py`, `services/orion-self-state-runtime/tests/test_worker_deviation_probe.py`: new
+
+## Schema / bus / API changes
+
+- Added: `SelfStatePolicyV1.dimension_worse_direction` (config schema, not a bus/API contract)
+- No changes to `SelfStateV1` itself — this PR is deliberately schema-silent per its own stated goal
+- No bus channel or schema-registry changes
+
+## Env/config changes
+
+- Added keys: `SELF_STATE_DEVIATION_PROBE_ENABLED=true` (`services/orion-self-state-runtime/.env_example` + local `.env`, synced)
+- Removed keys: none
+- skipped keys requiring operator action: none
+
+## Tests run
+
+```text
+pytest tests/test_self_state_builder.py tests/test_self_state_builder_hardening.py \
+  tests/test_self_state_schemas.py tests/test_self_state_scoring.py \
+  tests/test_self_state_policy_loader.py tests/test_self_state_prediction.py \
+  tests/test_self_state_reliability_decontamination.py tests/test_self_state_runtime_store.py \
+  tests/test_self_state_transport_dimension.py tests/test_self_state_deviation.py \
+  tests/test_proposal_transport_readonly_candidates.py -q
+→ 54 passed, 0 failed
+
+pytest services/orion-self-state-runtime/tests/ -q
+→ 23 passed, 0 failed
+```
+
+`git diff --check`: clean.
+
+## Evals run
+
+None — measurement-only instrumentation, no eval harness applicable yet. The point of this patch is itself to generate a measurement window before any eval-worthy schema/behavior exists.
+
+## Docker/build/smoke checks
+
+Not run — no live Docker environment available in this session. Restart command below is for the operator.
+
+## Review findings fixed
+
+Medium-effort code review (3 of 8 angles: line-by-line scan, removed-behavior/cross-file tracer, reuse/conventions — scoped down from the full 8-angle high-effort pass given this diff's small size).
+
+- Finding: the per-dimension "worse" direction table (`WORSE_DIRECTION`) was a hardcoded Python dict, a second, independently-maintained source of a fact the repo already has an established config-driven pattern for (`config/autonomy/signal_drive_map.yaml`, whose own header states "This is the WHOLE mapping surface" for the same kind of fact) — exactly the "create another place for config to drift" bad seam named in `CLAUDE.md`.
+  - Fix: moved to `config/self_state/self_state_policy.v1.yaml`'s new `dimension_worse_direction` section; `observe_dimension_deviation()` now takes `policy` as a parameter instead of importing a module-level table.
+  - Evidence: `test_policy_dimension_worse_direction_covers_every_real_dimension` loads the real live YAML, not a Python constant.
+- Finding: `DeviationGate.observe()`'s own `float(confidence)` coercion isn't guarded by its internal try/except (only the `x`/score coercion is), contradicting its module docstring's "never raises" claim — a pre-existing gap in the shared primitive, not introduced by this diff, but the new call site should defend anyway, matching the existing `orion/autonomy/signal_tension.py` caller's pattern for this same gate.
+  - Fix: defensive `float(dim.confidence)` cast at the call site in `orion/self_state/deviation.py`, falling back to `1.0` on failure.
+  - Evidence: `test_observe_dimension_deviation_defensively_casts_bad_confidence`.
+- Finding: no way to disable the new per-tick log without a code change/redeploy if it proves noisy at production volume, unlike the sibling perception-input feature documented as explicitly toggleable.
+  - Fix: new `SELF_STATE_DEVIATION_PROBE_ENABLED` setting (default `true`), checked at the top of `_log_deviation_probe()`.
+  - Evidence: `test_log_deviation_probe_disabled_via_settings_does_not_log`.
+- Finding: `test_worse_direction_matches_scoring_conventions` only re-asserted the hardcoded up/down values already in the table it was testing, rather than independently deriving them from real gate behavior — only one of 12 dimensions was actually behaviorally verified.
+  - Fix: rewrote as `test_worse_direction_behaviorally_matches_scoring_conventions_for_every_dimension`, driving a real rise and a real fall through a fresh gate for all 12 dimensions.
+  - Evidence: the new test itself; would have caught a flipped direction on any of the 11 previously-unverified dimensions.
+- 1 finding considered and not implemented (documented, non-blocking): resetting `self._deviation_gate`'s baselines when the self-state policy changes, mirroring how `previous` (the stored prior self-state) is invalidated on a `policy_id` mismatch. Checked and confirmed inapplicable: `self._policy` is assigned exactly once, in `SelfStateRuntimeWorker.__init__`, with no reload path — the gate and the policy always construct and die together on process restart, unlike `previous`, which is loaded from Postgres and genuinely crosses restarts. The analogy doesn't transfer to this case.
+- 1 pre-existing issue found but explicitly out of scope: `DeviationGate.observe()`'s own unguarded confidence coercion (see above) is a latent gap in a shared module used elsewhere too (`orion/spark/concept_induction/bus_worker.py`) — flagged as a candidate follow-up, not fixed here, since it's unrelated to this PR's actual integration and touching shared code beyond the new call site would widen scope unnecessarily.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-self-state-runtime/.env \
+  -f services/orion-self-state-runtime/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: low
+  Concern: `DeviationGate`'s baselines are in-memory only; a worker restart resets every dimension's learned baseline to cold-start (first observation only, zero warmup progress). Given the default `warmup=5`, the first ~5 ticks (~10s at the 2s poll interval) after any restart produce no impulses.
+  Mitigation: accepted for this measurement-only pass, same as `DriveEngine`'s own pressure store; persistence is a candidate follow-up if this graduates past instrumentation.
+- Severity: low
+  Concern: `DeviationGate.observe()`'s own confidence-coercion gap (see Review findings) remains unfixed at the shared-module level.
+  Mitigation: flagged as a follow-up; this PR's own call site defends against it, so no live risk from this integration specifically.
+
+## PR link
+
+<!-- filled in after push -->

--- a/orion/self_state/deviation.py
+++ b/orion/self_state/deviation.py
@@ -1,0 +1,68 @@
+"""Per-dimension deviation instrumentation for SelfStateV1 (2026-07-12,
+self-state/mesh substrate redesign Phase 2).
+
+Measurement-only: this module logs how much each dimension deviates from its
+own learned baseline this tick. It does not add a schema field, gate any
+behavior, or change any score -- "measure before you name it" (see the
+2026-07-12 brainstorm's recommended starting point). Once a live measurement
+window shows what these values actually look like, a schema field can be
+shaped around real data instead of guessed upfront.
+
+Reuses orion.autonomy.deviation_gate.DeviationGate directly (the same EWMA
+baseline + z-threshold mechanism already proven for chat/biometric tensions,
+DEVIATION_EWMA_ALPHA=0.1/DEVIATION_Z_THRESHOLD=1.5/DEVIATION_SIGMA_FLOOR=0.02
+live in services/orion-spark-concept-induction/.env -- identical to
+DeviationGate's own dataclass defaults) rather than inventing a second
+baseline-tracking mechanism.
+
+The per-dimension "worse" direction lives in
+config/self_state/self_state_policy.v1.yaml's `dimension_worse_direction`
+(config, not a hardcoded table here) -- this repo already has an established
+pattern for exactly this kind of fact (config/autonomy/signal_drive_map.yaml),
+and a second, independently-maintained Python source of the same semantic
+fact is exactly the kind of drift risk this redesign exists to eliminate.
+"""
+
+from __future__ import annotations
+
+from orion.autonomy.deviation_gate import DeviationGate
+from orion.schemas.self_state import SelfStateV1
+from orion.self_state.policy import SelfStatePolicyV1
+
+_SIGNAL_KIND = "self_state"
+
+
+def observe_dimension_deviation(
+    gate: DeviationGate,
+    state: SelfStateV1,
+    policy: SelfStatePolicyV1,
+) -> dict[str, float]:
+    """Feed every dimension present on `state` through `gate`, keyed by
+    dimension id. Returns the resulting impulses (>=0; 0.0 during warmup or
+    for a dimension whose |z| hasn't crossed the gate's threshold in its
+    worse direction). Never raises -- DeviationGate.observe() already
+    degrades to 0.0 on bad input for its `x` argument, and a dimension_id
+    absent from policy.dimension_worse_direction (should not happen for a
+    live SelfStateV1, but config and code can drift) is skipped rather than
+    guessed. score/confidence are defensively cast to float, matching the
+    existing orion/autonomy/signal_tension.py caller's pattern for this same
+    shared gate -- DeviationGate.observe()'s own confidence coercion isn't
+    guarded the way its score coercion is.
+    """
+    impulses: dict[str, float] = {}
+    for dim_id, dim in state.dimensions.items():
+        worse = policy.dimension_worse_direction.get(dim_id)
+        if worse is None:
+            continue
+        try:
+            confidence = float(dim.confidence)
+        except (TypeError, ValueError):
+            confidence = 1.0
+        impulses[dim_id] = gate.observe(
+            _SIGNAL_KIND,
+            dim_id,
+            dim.score,
+            confidence=confidence,
+            worse=worse,
+        )
+    return impulses

--- a/orion/self_state/policy.py
+++ b/orion/self_state/policy.py
@@ -41,6 +41,13 @@ class SelfStatePolicyV1(BaseModel):
     stabilizing_channels: dict[str, float] = Field(default_factory=dict)
     pressure_channels: list[str] = Field(default_factory=list)
     context_channels: list[str] = Field(default_factory=list)
+    # Per-dimension "worse" direction for the Phase 2 deviation probe
+    # (orion/self_state/deviation.py): "up" if a rising score is the notable
+    # direction, "down" if falling is. Config, not code, per this redesign's
+    # own design invariant -- config/self_state/self_state_policy.v1.yaml is
+    # the single place this fact lives, matching the house pattern already
+    # established for the same concept in config/autonomy/signal_drive_map.yaml.
+    dimension_worse_direction: dict[str, Literal["up", "down"]] = Field(default_factory=dict)
 
     unresolved_pressure_threshold: float = 0.60
     dominant_channel_threshold: float = 0.25

--- a/services/orion-self-state-runtime/.env_example
+++ b/services/orion-self-state-runtime/.env_example
@@ -28,3 +28,8 @@ SELF_STATE_PRUNE_INTERVAL_SEC=3600.0
 # "I am embodied near X" signal into hub_presence-style grounding.
 EMBODIMENT_PERCEPTION_SELFSTATE_ENABLED=false
 EMBODIMENT_CHANNEL_PERCEPTION=orion:embodiment:perception
+
+# Phase 2 (2026-07-12) deviation probe -- measurement-only, log-only, no
+# schema field or gated behavior yet. Default on; flip to false without a
+# redeploy if it proves noisy at production tick volume.
+SELF_STATE_DEVIATION_PROBE_ENABLED=true

--- a/services/orion-self-state-runtime/app/settings.py
+++ b/services/orion-self-state-runtime/app/settings.py
@@ -45,6 +45,14 @@ class Settings(BaseSettings):
         "orion:embodiment:perception", alias="EMBODIMENT_CHANNEL_PERCEPTION"
     )
 
+    # Phase 2 (2026-07-12) deviation probe -- measurement-only, log-only,
+    # no schema field or gated behavior. Default on (cheap, in-memory,
+    # fail-open on its own errors) but toggleable without a redeploy in case
+    # it proves noisy at production tick volume.
+    self_state_deviation_probe_enabled: bool = Field(
+        True, alias="SELF_STATE_DEVIATION_PROBE_ENABLED"
+    )
+
 
 _settings: Settings | None = None
 

--- a/services/orion-self-state-runtime/app/worker.py
+++ b/services/orion-self-state-runtime/app/worker.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional
 from uuid import uuid4
 
+from orion.autonomy.deviation_gate import DeviationGate
 from orion.core.bus.async_service import OrionBusAsync
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.core.bus.resilience import publish_with_reconnect
@@ -14,6 +15,7 @@ from orion.identity.snapshot import build_identity_snapshot
 from orion.schemas.embodiment import WorldPerceptionV1
 from orion.schemas.self_state import SelfStateV1
 from orion.self_state.builder import build_self_state
+from orion.self_state.deviation import observe_dimension_deviation
 from orion.self_state.policy import load_self_state_policy
 from orion.self_state.prediction import (
     build_next_cycle_prediction,
@@ -53,6 +55,11 @@ class SelfStateRuntimeWorker:
         # age-gated observability input). Default-off; None until observed.
         self._latest_perception: Optional[WorldPerceptionV1] = None
         self._latest_perception_at: Optional[datetime] = None
+        # Per-dimension deviation baseline (2026-07-12, Phase 2 measurement
+        # pass -- log-only, no schema field yet). In-memory, per-process:
+        # a restart resets every dimension's learned baseline to cold-start,
+        # same accepted limitation as DriveEngine's pressure store elsewhere.
+        self._deviation_gate = DeviationGate()
 
     async def start(self) -> None:
         asyncio.create_task(self._poll_loop(), name="self-state-runtime-poll")
@@ -278,6 +285,8 @@ class SelfStateRuntimeWorker:
             state.prediction_error_scores = compute_prediction_errors(state, prev_prediction)
             state.overall_surprise = compute_overall_surprise(state.prediction_error_scores)
 
+        self._log_deviation_probe(state)
+
         self._store.save_self_state(state)
 
         next_prediction = build_next_cycle_prediction(state)
@@ -295,6 +304,34 @@ class SelfStateRuntimeWorker:
             self._maybe_emit_identity_snapshot(state)
 
         return state
+
+    def _log_deviation_probe(self, state: SelfStateV1) -> None:
+        """Measurement-only (Phase 2, 2026-07-12): log each dimension's
+        deviation-from-its-own-baseline impulse alongside the confidence
+        value already on the wire, so the two can be compared on real live
+        data before deciding whether channel_dimension_confidence() should
+        be replaced by this variance-based mechanism instead
+        (orion/self_state/scoring.py's spread-based formula was flagged as
+        cruder than DeviationGate's approach in the Phase 1 PR report).
+        Never raises: a failure here must not block persisting self_state.
+        Toggleable via SELF_STATE_DEVIATION_PROBE_ENABLED without a redeploy
+        in case this proves noisy at production tick volume.
+        """
+        if not self._settings.self_state_deviation_probe_enabled:
+            return
+        try:
+            impulses = observe_dimension_deviation(self._deviation_gate, state, self._policy)
+            confidences = {
+                dim_id: round(state.dimensions[dim_id].confidence, 4) for dim_id in impulses
+            }
+            logger.info(
+                "self_state_deviation_probe self_state_id=%s deviation=%s confidence=%s",
+                state.self_state_id,
+                {k: round(v, 4) for k, v in impulses.items()},
+                confidences,
+            )
+        except Exception:
+            logger.exception("self_state_deviation_probe_failed")
 
     def _maybe_emit_identity_snapshot(self, state) -> None:  # type: ignore[type-arg]
         try:

--- a/services/orion-self-state-runtime/tests/test_worker_deviation_probe.py
+++ b/services/orion-self-state-runtime/tests/test_worker_deviation_probe.py
@@ -1,0 +1,108 @@
+"""Unit tests for the Phase 2 deviation-probe logging hook (2026-07-12,
+measurement-only, no schema field yet).
+
+Mirrors the __new__-and-hand-wire pattern in test_worker_prune.py /
+test_embodiment_perception_input.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.autonomy.deviation_gate import DeviationGate
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+from orion.self_state.policy import load_self_state_policy
+
+from app.worker import SelfStateRuntimeWorker
+
+REPO = Path(__file__).resolve().parents[3]
+POLICY = load_self_state_policy(REPO / "config" / "self_state" / "self_state_policy.v1.yaml")
+NOW = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def _make_worker(monkeypatch, *, probe_enabled: bool = True) -> SelfStateRuntimeWorker:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://unused/unused")
+    monkeypatch.setenv("SELF_STATE_DEVIATION_PROBE_ENABLED", "true" if probe_enabled else "false")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+
+    worker = SelfStateRuntimeWorker.__new__(SelfStateRuntimeWorker)
+    worker._settings = settings_mod.get_settings()
+    worker._policy = POLICY
+    worker._deviation_gate = DeviationGate()
+    return worker
+
+
+def _state() -> SelfStateV1:
+    dims = {
+        "resource_pressure": SelfStateDimensionV1(
+            dimension_id="resource_pressure", score=0.6, confidence=0.7
+        ),
+        "coherence": SelfStateDimensionV1(dimension_id="coherence", score=0.8, confidence=0.9),
+    }
+    return SelfStateV1(
+        self_state_id="self.state:probe_test",
+        generated_at=NOW,
+        source_field_tick_id="tick",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="frame",
+        source_attention_generated_at=NOW,
+        overall_condition="steady",
+        overall_intensity=0.4,
+        overall_confidence=0.8,
+        dimensions=dims,
+    )
+
+
+def test_log_deviation_probe_logs_impulses_and_confidence(monkeypatch, caplog) -> None:
+    worker = _make_worker(monkeypatch)
+    with caplog.at_level(logging.INFO, logger="orion.self_state.runtime"):
+        worker._log_deviation_probe(_state())
+
+    records = [r for r in caplog.records if r.message.startswith("self_state_deviation_probe")]
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "self.state:probe_test" in msg
+    assert "resource_pressure" in msg
+    assert "coherence" in msg
+
+
+def test_log_deviation_probe_disabled_via_settings_does_not_log(monkeypatch, caplog) -> None:
+    # 2026-07-12 review finding: no way to disable a per-tick log without a
+    # redeploy -- SELF_STATE_DEVIATION_PROBE_ENABLED=false must be a real
+    # no-op, not just a documented intent.
+    worker = _make_worker(monkeypatch, probe_enabled=False)
+    with caplog.at_level(logging.INFO, logger="orion.self_state.runtime"):
+        worker._log_deviation_probe(_state())
+
+    assert not any(r.message.startswith("self_state_deviation_probe") for r in caplog.records)
+
+
+def test_log_deviation_probe_never_raises_on_gate_failure(monkeypatch, caplog) -> None:
+    worker = _make_worker(monkeypatch)
+
+    class _ExplodingGate:
+        def observe(self, *_a, **_kw):
+            raise RuntimeError("boom")
+
+    worker._deviation_gate = _ExplodingGate()
+    with caplog.at_level(logging.ERROR, logger="orion.self_state.runtime"):
+        # Must not raise -- a probe failure must never block persisting self_state.
+        worker._log_deviation_probe(_state())
+
+    assert any("self_state_deviation_probe_failed" in r.message for r in caplog.records)
+
+
+def test_log_deviation_probe_carries_state_across_ticks(monkeypatch) -> None:
+    # Same worker instance (same gate) across two ticks should build up a
+    # baseline -- proving the gate is a per-process, cross-tick object, not
+    # reconstructed fresh every tick (which would defeat its whole purpose).
+    worker = _make_worker(monkeypatch)
+    stable = _state()
+    for _ in range(6):
+        worker._log_deviation_probe(stable)
+
+    assert worker._deviation_gate.baseline_count() == 2  # resource_pressure + coherence

--- a/tests/test_self_state_deviation.py
+++ b/tests/test_self_state_deviation.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from orion.autonomy.deviation_gate import DeviationGate
+from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+from orion.self_state.deviation import observe_dimension_deviation
+from orion.self_state.policy import load_self_state_policy
+
+REPO = Path(__file__).resolve().parents[1]
+POLICY = load_self_state_policy(REPO / "config" / "self_state" / "self_state_policy.v1.yaml")
+NOW = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def _state(scores: dict[str, float]) -> SelfStateV1:
+    dims = {
+        dim_id: SelfStateDimensionV1(dimension_id=dim_id, score=score, confidence=0.8)
+        for dim_id, score in scores.items()
+    }
+    return SelfStateV1(
+        self_state_id="self.state:test",
+        generated_at=NOW,
+        source_field_tick_id="tick",
+        source_field_generated_at=NOW,
+        source_attention_frame_id="frame",
+        source_attention_generated_at=NOW,
+        overall_condition="steady",
+        overall_intensity=0.4,
+        overall_confidence=0.8,
+        dimensions=dims,
+    )
+
+
+def test_policy_dimension_worse_direction_covers_every_real_dimension() -> None:
+    # 11 core ALL_DIMENSION_IDS + transport_integrity (conditional 13th) --
+    # policy_pressure is gone (Phase 0), so 12 total. Loaded from the real,
+    # live config/self_state/self_state_policy.v1.yaml, not a hardcoded
+    # Python table (2026-07-12 review: a second, independently-maintained
+    # source of the same fact is a drift risk this redesign exists to kill).
+    assert set(POLICY.dimension_worse_direction) == {
+        "field_intensity",
+        "coherence",
+        "uncertainty",
+        "agency_readiness",
+        "resource_pressure",
+        "execution_pressure",
+        "reasoning_pressure",
+        "reliability_pressure",
+        "continuity_pressure",
+        "introspection_pressure",
+        "social_pressure",
+        "transport_integrity",
+    }
+
+
+def test_worse_direction_behaviorally_matches_scoring_conventions_for_every_dimension() -> None:
+    # 2026-07-12 review finding: a prior version of this test only re-asserted
+    # the hardcoded up/down values without independently driving real scores
+    # through the gate -- only one dimension was behaviorally verified. This
+    # version drives a real rise and a real fall through a fresh gate for
+    # EVERY dimension and checks the impulse only fires in the declared
+    # worse direction, for all 12.
+    for dim_id, worse in POLICY.dimension_worse_direction.items():
+        gate = DeviationGate(warmup=3)
+        for _ in range(4):
+            observe_dimension_deviation(gate, _state({dim_id: 0.50}), POLICY)
+
+        rise = observe_dimension_deviation(gate, _state({dim_id: 0.99}), POLICY)[dim_id]
+        gate2 = DeviationGate(warmup=3)
+        for _ in range(4):
+            observe_dimension_deviation(gate2, _state({dim_id: 0.50}), POLICY)
+        fall = observe_dimension_deviation(gate2, _state({dim_id: 0.01}), POLICY)[dim_id]
+
+        if worse == "up":
+            assert rise > 0.0, f"{dim_id} (worse=up) should impulse on rise"
+            assert fall == 0.0, f"{dim_id} (worse=up) should not impulse on fall"
+        else:
+            assert fall > 0.0, f"{dim_id} (worse=down) should impulse on fall"
+            assert rise == 0.0, f"{dim_id} (worse=down) should not impulse on rise"
+
+
+def test_observe_dimension_deviation_warms_up_then_fires_on_real_deviation() -> None:
+    gate = DeviationGate(warmup=3)
+    # Warm up resource_pressure on a stable baseline (~0.20).
+    for _ in range(4):
+        observe_dimension_deviation(gate, _state({"resource_pressure": 0.20}), POLICY)
+
+    # A sharp rise past the learned baseline should now fire an impulse
+    # (resource_pressure is worse=up).
+    impulses = observe_dimension_deviation(gate, _state({"resource_pressure": 0.95}), POLICY)
+    assert impulses["resource_pressure"] > 0.0
+
+
+def test_observe_dimension_deviation_no_impulse_within_normal_range() -> None:
+    gate = DeviationGate(warmup=3)
+    for _ in range(4):
+        observe_dimension_deviation(gate, _state({"coherence": 0.80}), POLICY)
+
+    # A tiny wobble within normal noise must not fire.
+    impulses = observe_dimension_deviation(gate, _state({"coherence": 0.81}), POLICY)
+    assert impulses["coherence"] == 0.0
+
+
+def test_observe_dimension_deviation_defensively_casts_bad_confidence() -> None:
+    # Mirrors orion/autonomy/signal_tension.py's existing defensive cast
+    # pattern for this same shared gate (2026-07-12 review finding):
+    # DeviationGate.observe()'s own float(confidence) coercion isn't guarded
+    # the way its x/score coercion is, so the caller must defend instead.
+    # SelfStateDimensionV1.confidence is normally Pydantic-validated, but
+    # model_config doesn't set validate_assignment=True, so a plain
+    # attribute set bypasses that validation -- exercising the same
+    # bypass path a deserialization edge case could hit.
+    gate = DeviationGate(warmup=3)
+    state = _state({"resource_pressure": 0.5})
+    state.dimensions["resource_pressure"].confidence = "not-a-number"  # type: ignore[assignment]
+    # Must not raise even with a non-numeric confidence value.
+    impulses = observe_dimension_deviation(gate, state, POLICY)
+    assert "resource_pressure" in impulses
+
+
+def test_observe_dimension_deviation_never_raises_on_unknown_dimension() -> None:
+    gate = DeviationGate()
+    state = _state({"resource_pressure": 0.5})
+    # Inject a dimension id the policy's dimension_worse_direction doesn't
+    # know about -- must be skipped, not raise.
+    state.dimensions["made_up_dimension"] = SelfStateDimensionV1(
+        dimension_id="resource_pressure",  # valid literal, arbitrary key name
+        score=0.5,
+        confidence=0.5,
+    )
+    impulses = observe_dimension_deviation(gate, state, POLICY)
+    assert "made_up_dimension" not in impulses
+    assert "resource_pressure" in impulses


### PR DESCRIPTION
# PR: Self-state Phase 2 — deviation-probe measurement instrumentation

## Summary

- Ports `orion.autonomy.deviation_gate.DeviationGate` (proven EWMA-baseline + z-threshold mechanism, already live for chat/biometric tensions) into `orion-self-state-runtime`, per the recommended starting point from the 2026-07-12 brainstorm continuing the self-state/mesh substrate redesign.
- Each tick, every real `SelfStateV1` dimension is observed against its own learned baseline; the resulting deviation impulse is logged alongside the dimension's confidence value so the two can be compared on live data before deciding whether `channel_dimension_confidence()`'s cruder max-min-spread formula should be replaced.
- Deliberately log-only: no new schema field yet ("measure before you name it"), no gated behavior, no score changes.
- Medium-effort code review (3 angles) caught one real issue before it shipped and two smaller ones; all fixed in the same commit.

## Outcome moved

Layer 6 gains a real, proven mechanism for answering "has this dimension been sustained or is this a momentary spike," without inventing new statistics or duplicating `DriveEngine`'s already-fixed cadence-artifact bugs. Nothing is named yet — the point of this patch is to generate real data before shaping a schema field around it.

## Current architecture

Before this PR: Layer 6's only notion of history was a single-previous-tick diff (`dimension_trajectory`, age-gated at 300s) — no sense of "how long has this been true" beyond that. `DeviationGate` already existed and was proven elsewhere (`orion/spark/concept_induction/bus_worker.py`'s chat/biometric tension extraction) but had never been applied to self-state's own dimensions.

## Architecture touched

- `orion/self_state/` — new `deviation.py` module
- `services/orion-self-state-runtime/` — worker wiring, settings, env
- `config/self_state/self_state_policy.v1.yaml` — new `dimension_worse_direction` section
- `orion/self_state/policy.py` — new policy schema field

## Files changed

- `orion/self_state/deviation.py`: new — `observe_dimension_deviation(gate, state, policy)`, reuses `DeviationGate` directly, reads per-dimension "worse" direction from policy config (not a hardcoded table — see Review findings)
- `orion/self_state/policy.py`: new `dimension_worse_direction: dict[str, Literal["up","down"]]` field on `SelfStatePolicyV1`
- `config/self_state/self_state_policy.v1.yaml`: new `dimension_worse_direction` section, all 12 dimensions
- `services/orion-self-state-runtime/app/worker.py`: `DeviationGate` instantiated once in `__init__` (in-memory, per-process, dies with the process — same accepted limitation as `DriveEngine`'s pressure store); new `_log_deviation_probe()` called once per tick, gated by a settings flag
- `services/orion-self-state-runtime/app/settings.py`: new `self_state_deviation_probe_enabled` (default `True`)
- `services/orion-self-state-runtime/.env_example` + local `.env`: new `SELF_STATE_DEVIATION_PROBE_ENABLED=true`
- `tests/test_self_state_deviation.py`, `services/orion-self-state-runtime/tests/test_worker_deviation_probe.py`: new

## Schema / bus / API changes

- Added: `SelfStatePolicyV1.dimension_worse_direction` (config schema, not a bus/API contract)
- No changes to `SelfStateV1` itself — this PR is deliberately schema-silent per its own stated goal
- No bus channel or schema-registry changes

## Env/config changes

- Added keys: `SELF_STATE_DEVIATION_PROBE_ENABLED=true` (`services/orion-self-state-runtime/.env_example` + local `.env`, synced)
- Removed keys: none
- skipped keys requiring operator action: none

## Tests run

```text
pytest tests/test_self_state_builder.py tests/test_self_state_builder_hardening.py \
  tests/test_self_state_schemas.py tests/test_self_state_scoring.py \
  tests/test_self_state_policy_loader.py tests/test_self_state_prediction.py \
  tests/test_self_state_reliability_decontamination.py tests/test_self_state_runtime_store.py \
  tests/test_self_state_transport_dimension.py tests/test_self_state_deviation.py \
  tests/test_proposal_transport_readonly_candidates.py -q
→ 54 passed, 0 failed

pytest services/orion-self-state-runtime/tests/ -q
→ 23 passed, 0 failed
```

`git diff --check`: clean.

## Evals run

None — measurement-only instrumentation, no eval harness applicable yet. The point of this patch is itself to generate a measurement window before any eval-worthy schema/behavior exists.

## Docker/build/smoke checks

Not run — no live Docker environment available in this session. Restart command below is for the operator.

## Review findings fixed

Medium-effort code review (3 of 8 angles: line-by-line scan, removed-behavior/cross-file tracer, reuse/conventions — scoped down from the full 8-angle high-effort pass given this diff's small size).

- Finding: the per-dimension "worse" direction table (`WORSE_DIRECTION`) was a hardcoded Python dict, a second, independently-maintained source of a fact the repo already has an established config-driven pattern for (`config/autonomy/signal_drive_map.yaml`, whose own header states "This is the WHOLE mapping surface" for the same kind of fact) — exactly the "create another place for config to drift" bad seam named in `CLAUDE.md`.
  - Fix: moved to `config/self_state/self_state_policy.v1.yaml`'s new `dimension_worse_direction` section; `observe_dimension_deviation()` now takes `policy` as a parameter instead of importing a module-level table.
  - Evidence: `test_policy_dimension_worse_direction_covers_every_real_dimension` loads the real live YAML, not a Python constant.
- Finding: `DeviationGate.observe()`'s own `float(confidence)` coercion isn't guarded by its internal try/except (only the `x`/score coercion is), contradicting its module docstring's "never raises" claim — a pre-existing gap in the shared primitive, not introduced by this diff, but the new call site should defend anyway, matching the existing `orion/autonomy/signal_tension.py` caller's pattern for this same gate.
  - Fix: defensive `float(dim.confidence)` cast at the call site in `orion/self_state/deviation.py`, falling back to `1.0` on failure.
  - Evidence: `test_observe_dimension_deviation_defensively_casts_bad_confidence`.
- Finding: no way to disable the new per-tick log without a code change/redeploy if it proves noisy at production volume, unlike the sibling perception-input feature documented as explicitly toggleable.
  - Fix: new `SELF_STATE_DEVIATION_PROBE_ENABLED` setting (default `true`), checked at the top of `_log_deviation_probe()`.
  - Evidence: `test_log_deviation_probe_disabled_via_settings_does_not_log`.
- Finding: `test_worse_direction_matches_scoring_conventions` only re-asserted the hardcoded up/down values already in the table it was testing, rather than independently deriving them from real gate behavior — only one of 12 dimensions was actually behaviorally verified.
  - Fix: rewrote as `test_worse_direction_behaviorally_matches_scoring_conventions_for_every_dimension`, driving a real rise and a real fall through a fresh gate for all 12 dimensions.
  - Evidence: the new test itself; would have caught a flipped direction on any of the 11 previously-unverified dimensions.
- 1 finding considered and not implemented (documented, non-blocking): resetting `self._deviation_gate`'s baselines when the self-state policy changes, mirroring how `previous` (the stored prior self-state) is invalidated on a `policy_id` mismatch. Checked and confirmed inapplicable: `self._policy` is assigned exactly once, in `SelfStateRuntimeWorker.__init__`, with no reload path — the gate and the policy always construct and die together on process restart, unlike `previous`, which is loaded from Postgres and genuinely crosses restarts. The analogy doesn't transfer to this case.
- 1 pre-existing issue found but explicitly out of scope: `DeviationGate.observe()`'s own unguarded confidence coercion (see above) is a latent gap in a shared module used elsewhere too (`orion/spark/concept_induction/bus_worker.py`) — flagged as a candidate follow-up, not fixed here, since it's unrelated to this PR's actual integration and touching shared code beyond the new call site would widen scope unnecessarily.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-self-state-runtime/.env \
  -f services/orion-self-state-runtime/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
  Concern: `DeviationGate`'s baselines are in-memory only; a worker restart resets every dimension's learned baseline to cold-start (first observation only, zero warmup progress). Given the default `warmup=5`, the first ~5 ticks (~10s at the 2s poll interval) after any restart produce no impulses.
  Mitigation: accepted for this measurement-only pass, same as `DriveEngine`'s own pressure store; persistence is a candidate follow-up if this graduates past instrumentation.
- Severity: low
  Concern: `DeviationGate.observe()`'s own confidence-coercion gap (see Review findings) remains unfixed at the shared-module level.
  Mitigation: flagged as a follow-up; this PR's own call site defends against it, so no live risk from this integration specifically.
