### PR TITLE
Feat/self state mesh provenance drive measurement

### DIFF
--- a/docs/notes/2026-07-12-phase4-cluster-weighting-research.md
+++ b/docs/notes/2026-07-12-phase4-cluster-weighting-research.md
@@ -1,0 +1,240 @@
+# Phase 4 research — CLUSTER_ROLE_WEIGHTS / orion-state-service node-weighting — 2026-07-12
+
+Context: Phase 4 ("Drive unification") of
+`docs/superpowers/plans/2026-07-12-self-state-mesh-substrate-redesign.md` requires resolving
+whether `CLUSTER_ROLE_WEIGHTS` (`services/orion-biometrics/.env`) and
+`orion-state-service`'s aggregation are a legitimate separate "ops health" concern or a
+fourth duplicate of the field-topology node-weighting question (per the arsonist doc's mesh
+addendum). Answered here from live code, live `.env` values, and live `docker logs`/`docker
+exec` evidence on the running mesh — not from README claims.
+
+**Verdict: neither answer in the arsonist doc's framing is quite right.** `CLUSTER_ROLE_WEIGHTS`
+is architecturally a duplicate of the field-topology node-weighting question (same question:
+"how much should each node's health count"), computed a different, undocumented way, with
+weights that are internally inconsistent across three separate implementations. But unlike
+the L7-L11 ladder, its output is *not* Hub-display-only when it fires — it's wired into a real
+LLM prompt (`orion-cortex-exec`'s metacognition draft/enrich templates). Right now, however,
+it never fires at all: `orion-biometrics` runs in `BIOMETRICS_MODE=agent` live, so the
+`BiometricsHub`/`publish_cluster` code path that reads `CLUSTER_ROLE_WEIGHTS` never starts.
+Confirmed over a 6-hour live log window: zero `biometrics.cluster.v1` messages ingested by
+`orion-state-service`, despite it actively subscribing. This is a "loaded gun, safety on"
+situation, not a duplicate that's already firing, and not a legitimate separate concern with
+its own clean rationale either — it's an unfired, three-times-reimplemented weighting scheme
+whose real reach (when enabled) is narrower and different in kind from field-topology's.
+
+---
+
+## Q1 — Where is `CLUSTER_ROLE_WEIGHTS` used, and what does the aggregate represent?
+
+`services/orion-biometrics/app/main.py:282-328`, method `BiometricsHub.publish_cluster`:
+
+```python
+weights = settings.role_weights                                    # main.py:285
+for node, summary in self._latest_summary.items():
+    role = "atlas" if "atlas" in node else "athena" if "athena" in node else "other"  # :293
+    weight = float(weights.get(role, 1.0))                          # :294
+    weight_total += weight
+    for k, v in summary.pressures.items():
+        weighted_pressures[k] = weighted_pressures.get(k, 0.0) + weight * float(v)   # :298
+    ...
+pressures = {k: min(1.0, v / weight_total) for k, v in weighted_pressures.items()}   # :307
+```
+
+This is a **weighted average of each node's `BiometricsSummaryV1.pressures/headroom/
+composites` dict**, bucketed by a crude substring match on node name into `atlas`/`athena`/
+`other` roles, then normalized by total weight (`main.py:293-309`). It is genuinely a
+"how much should each node's health count" computation — same question as the field-topology
+edges, computed completely differently (role-bucket weighted mean vs. per-capability edge
+diffusion).
+
+The result feeds two things:
+1. `BiometricsClusterV1` published to `orion:biometrics:cluster` (`main.py:317-328`).
+2. A `spark.signal.v1` envelope with `signal_type="resource"`, `intensity=composites["strain"]`
+   published to `orion:spark:signal` (`main.py:330-340`) — this looks like a DriveEngine
+   feed, but **it is a dead end**: `orion/signals/adapters/spark.py:37-107` converts any
+   `spark.signal.v1` envelope into an `OrionSignalV1` with `signal_kind="spark_signal"` and
+   dimensions `{level, valence, arousal, coherence, novelty, confidence}` — `intensity` lands
+   on `level` (`spark.py:58,94`). But `config/autonomy/signal_drive_map.yaml`'s `spark_signal`
+   entry only maps `coherence`, `valence`, `novelty` to drives (lines 33-39) — **`level` is
+   unmapped**, and the map's own header comment says unmapped `(signal_kind, dimension)` pairs
+   "contribute nothing" (`signal_drive_map.yaml:9-10`). Since the cluster's `SparkSignalV1`
+   never sets `valence_delta`/`coherence_delta`/`novelty_delta`, those three dims default to a
+   constant neutral `0.5` (`spark.py:59-62`, `_delta_dim` default) every tick — no deviation,
+   no tension event, no drive contribution. **The one place `CLUSTER_ROLE_WEIGHTS`'s number
+   touches the DriveEngine/signal_drive_map pipeline is a wire that's connected to nothing.**
+
+## Q2 — What does `orion-state-service`'s "per-node/global... authoritative node if configured" mean, and is it configured?
+
+`services/orion-state-service/app/store.py:81-118` (`StateStore.ingest_snapshot`):
+
+```python
+if node == self.primary_node:
+    self._latest_global = snap                     # store.py:104 — authoritative node wins
+else:
+    if self._latest_global is None:
+        self._latest_global = snap
+    else:
+        if snap.snapshot_ts >= self._latest_global.snapshot_ts:
+            self._latest_global = snap              # store.py:110-111 — else most-recent wins
+```
+
+`primary_state_node` is configured live: `services/orion-state-service/.env:34` →
+`PRIMARY_STATE_NODE=athena` (settings default is also `athena`,
+`services/orion-state-service/app/settings.py:53`). **This is answering a different question
+than "node health weighting."** It applies only to `SparkStateSnapshotV1` (the Layer-6/spark
+self-state snapshot object, one per producer), not to biometrics pressures/composites — it's
+"which node's *self-state snapshot* is truthful right now," a single-writer-vs-most-recent
+policy, not a weighted blend. In practice this is close to moot today: only Athena runs
+`orion-self-state-runtime`/`spark-introspector` (confirmed live —
+`docker logs orion-athena-state-service` shows every `spark.state.snapshot.v1` ingestion is
+`node=athena`), so the "authoritative vs most-recent" branch never diverges from a trivial
+single-node case.
+
+Separately, `store.py:171-177` (`_pick_latest`, used only for **biometrics summary/induction**,
+not for the spark snapshot rollup) picks `primary_node`'s biometrics summary if present, else
+most-recent-by-timestamp across nodes — this is used in `get_latest` for `scope="global"`
+(`store.py:212-221`). This, too, is "pick one node's raw reading," not a weighted blend — it
+does not use `CLUSTER_ROLE_WEIGHTS` or any weight at all. `orion-state-service` does not
+compute its own node-weighted aggregate anywhere; it only caches/serves whatever
+`BiometricsClusterV1` the biometrics service already computed (`store.py:167-169`,
+`ingest_biometrics_cluster` — pure passthrough), plus this pick-one-or-newest logic for
+summary/induction.
+
+## Q3 — Real consumers of `orion:biometrics:cluster`
+
+- **`services/orion-state-service/app/main.py:191-213`** (`_handle_biometrics`) and
+  **`app/store.py:167-169`** — ingest and cache the cluster payload verbatim (no
+  transformation), exposed via `state.latest.reply.v1`'s `biometrics.cluster` field and the
+  HTTP `/state/latest` debug route. Confirmed: `orion-state-service/app/settings.py:36-39`
+  only defines the channel name constant — no weighting logic of its own.
+- **`services/orion-hub/scripts/biometrics_cache.py`** — subscribes directly to
+  `orion:biometrics:cluster` (line 110) and, when a cluster message *is* present, uses its
+  `composites`/`constraint` verbatim (`_cluster_composite`: lines 267-273, `_cluster_constraint`:
+  lines 347-350). **When no cluster message has arrived** (the live condition today), it falls
+  back to computing its *own*, third independent role-weighting scheme keyed by literal node
+  name (not role-bucket substring matching) from `BIOMETRICS_ROLE_WEIGHTS_JSON`
+  (`services/orion-hub/.env:70` → `{"atlas":0.6,"athena":0.4}` — yet a third, different set of
+  numbers from `CLUSTER_ROLE_WEIGHTS`'s `{"atlas":0.7,"athena":0.3,"other":0.5}`) —
+  `biometrics_cache.py:262-307,309-340,375-389`. This cache's `get_snapshot()` output is
+  consumed **exclusively** via `enriched["biometrics"] = await cache.get_snapshot()`
+  (`websocket_handler.py:438`) inside `_with_biometrics(...)`, whose only call sites are
+  `websocket.send_json(...)` to the browser (`websocket_handler.py:464,527,678,970,1582,1853`,
+  etc.) — **this path is genuinely Hub-UI-display-only**, no gating/control-flow use found.
+- **`orion/signals/registry.py`** — lists `orion:biometrics:cluster` as a bus channel in the
+  static `biometrics` organ's catalog entry (line 21). This is metadata only — grepping
+  `orion/signals/`, `orion/autonomy/`, `orion/spark/` for `BiometricsClusterV1`/
+  `biometrics.cluster` finds **zero** real adapters or consumers beyond this declarative
+  listing. It does not drive behavior.
+- **`services/orion-cortex-exec/app/executor.py`** (`MetacogContextService`, ~lines 3712-3935)
+  — the one consumer that is **not** display-only. It calls the `state.get_latest.v1` bus RPC
+  (line 3714-3735), pulls `state_res.biometrics.cluster` (the `CLUSTER_ROLE_WEIGHTS`-weighted
+  composite/constraint, lines 3763-3770), and formats it via `_metacog_biometrics_cue`
+  (lines 848-885) into `ctx["metacog_biometrics_cue"]` / `ctx["metacog_biometrics_cue_enrich"]`
+  (lines 3918-3919). These are rendered directly into the metacognition LLM prompt templates:
+  `{{ metacog_biometrics_cue }}` appears in both
+  `orion/cognition/prompts/log_orion_metacognition_draft.j2:49` and
+  `log_orion_metacognition_enrich.j2:40`. **This is real reach — it shapes actual LLM prompt
+  content for Orion's metacognition lane, not a debug/display sink.** Note, however: the
+  `biometrics_line` text used in the human-readable `context_summary` (lines 3883-3897, e.g.
+  "Biometrics: status=..., strain=...") reads `biometrics_context["summary"]`, which for
+  `scope="global"` is the **pick-one-node raw summary** (`_pick_latest`, unweighted), not the
+  cluster composite — only the `constraint` field and the JSON cue's `cluster.composite`
+  numbers come from the actual `CLUSTER_ROLE_WEIGHTS`-weighted `BiometricsClusterV1`.
+
+## Q4 — Live mesh check: is any of this actually firing?
+
+Confirmed via `docker ps` (real, running containers) and `docker logs`/`docker exec`
+(read-only):
+
+- **`orion-athena-biometrics` runs with `BIOMETRICS_MODE=agent`**
+  (`services/orion-biometrics/.env:35`, matches live container). Per
+  `services/orion-biometrics/app/main.py:352-376` (`lifespan`), the `BiometricsHub` /
+  `BiometricsHubWorker` / `publish_cluster` machinery — the *only* code path that reads
+  `CLUSTER_ROLE_WEIGHTS` — is gated behind `settings.BIOMETRICS_MODE in {"hub", "both"}`
+  (line 365). **In `agent`-only mode this never starts.** `docker logs orion-athena-biometrics`
+  shows no cluster-related output at all in the observed window.
+- **`orion-athena-state-service` subscribes to `orion:biometrics:cluster`** (confirmed:
+  `Hunter subscribing patterns=['orion:biometrics:summary', 'orion:biometrics:induction',
+  'orion:biometrics:cluster']`, log line at service startup) **but received zero
+  `biometrics.cluster.v1` messages over a 6-hour log window** (`grep -ci
+  "biometrics.cluster"` → `1`, and that one hit was the subscription-announcement log line,
+  not an ingested message). Meanwhile `orion:biometrics:summary`/`orion:biometrics:induction`
+  messages from `node=athena` arrive continuously (~every 30s), and only ever from `athena` —
+  no `atlas`/`circe` node in this mesh's biometrics traffic today (`docker ps` shows no
+  atlas/circe containers on this host at all, consistent with Phase 3 of the plan — enabling
+  Atlas/Circe biometrics — not yet done).
+- **`state.get_latest.v1` RPC is genuinely live and called repeatedly** by real services —
+  confirmed in `orion-athena-state-service` logs: `source=name='cortex-exec'` and
+  `source=name='cortex-orch'` requests firing roughly every 20-30s, each getting a
+  `state.latest.reply.v1` with a `biometrics` key in the payload. This corroborates Q3: the
+  RPC path is not a dead/test-only surface, cortex-exec's metacog step really calls it on a
+  live cadence.
+- **Even with zero live nodes to weight, the math would currently be a no-op anyway.** With
+  only Athena reporting, `publish_cluster`'s weighted average degenerates to
+  `weight × raw_value / weight` = `raw_value` — the weight cancels out identically regardless
+  of what `CLUSTER_ROLE_WEIGHTS` says. So even if `BIOMETRICS_MODE` were flipped to `hub`
+  today, `CLUSTER_ROLE_WEIGHTS` would have **zero numerical effect** until a second node
+  (Atlas/Circe, per Phase 3) starts reporting — the weighting question is entirely
+  future-facing, not a live discrepancy today.
+- **Bonus finding, incidental but relevant to "has this ever been exercised":** the HTTP
+  debug endpoint this service exposes is currently broken —
+  `GET /state/latest` throws `TypeError: StateStore.get_latest() missing 1 required
+  keyword-only argument: 'biometrics_stale_after_sec'` (confirmed live via `docker exec
+  orion-athena-state-service curl ...`, traceback rooted at
+  `services/orion-state-service/app/main.py:292`, `http_get_latest` calling
+  `STORE.get_latest(req)` without the `biometrics_stale_after_sec` kwarg that
+  `_handle_get_latest`, the bus RPC path, does pass at `main.py:181`). This confirms the HTTP
+  surface is dead/unexercised — only the bus RPC path is real — and is a separate, small,
+  pre-existing bug worth a one-line fix independent of this research question.
+
+## Verdict table
+
+| System | Weights | Fires today? | Real reach when it fires | Same question as field-topology? |
+|---|---|---|---|---|
+| Field-topology edges (`config/field/orion_field_topology.v1.yaml`) | Per-capability, e.g. `atlas→llm_inference: 0.85`, `athena→orchestration: 0.90` | Yes (`apply_diffusion`) | Layer 6 `SelfStateV1` dimension scores → drives/policy | — (this is the reference) |
+| `CLUSTER_ROLE_WEIGHTS` (`services/orion-biometrics/.env:37`) | `{"atlas":0.7,"athena":0.3,"other":0.5}`, uniform across all pressure/headroom/composite keys | **No** — `BIOMETRICS_MODE=agent` live, `BiometricsHub`/`publish_cluster` never starts; confirmed 0 `biometrics.cluster.v1` messages ingested in 6h of live logs | When enabled: `constraint` + `composite` numbers reach `orion-cortex-exec`'s metacognition LLM prompt (`log_orion_metacognition_{draft,enrich}.j2`) via `metacog_biometrics_cue` — real, not display-only. The `spark.signal.v1`/DriveEngine path is a dead end (unmapped `level` dimension). | **Yes, same underlying question** ("how much should each node's health count"), computed a structurally different way (uniform per-node scalar vs. per-capability edge weight), with **opposite implied emphasis** from the topology edges for the same two nodes (topology: athena=0.90 orchestration / atlas=0.85 llm_inference, i.e. both weighted high in their own domain; `CLUSTER_ROLE_WEIGHTS`: atlas=0.7 > athena=0.3 uniformly, undocumented reasoning) |
+| `orion-hub`'s own fallback (`BIOMETRICS_ROLE_WEIGHTS_JSON`, `services/orion-hub/.env:70`) | `{"atlas":0.6,"athena":0.4}` — a **third**, different set of numbers, keyed by literal node name not role-bucket | Yes, active right now (fallback branch is exactly what's exercised while no cluster message ever arrives) | Hub WebSocket JSON only (`websocket_handler.py:438`, `_with_biometrics` → `send_json`) — confirmed display-only, no gating logic found | Same question again — **a third independent reimplementation**, not previously flagged in the arsonist doc's mesh addendum table |
+| `orion-state-service` "authoritative node / most-recent" (`store.py:102-113`) | N/A — single-writer-vs-newest policy, not a weighted blend | Yes, but the branch is currently trivial (only Athena ever produces `spark.state.snapshot.v1`) | Feeds `state.get_latest.v1` RPC replies to `cortex-exec`/`cortex-orch` (confirmed live, real reach) | **No** — different question. This concerns "whose *self-state snapshot* wins," not "how much does each node's health count toward a blended metric." Its biometrics-specific `_pick_latest` (`store.py:171-177`) is "pick one node's raw reading," also not a weighted blend, and also not connected to `CLUSTER_ROLE_WEIGHTS`. |
+
+## Recommendation
+
+This isn't a clean "keep both" or "retire" — it's two different findings bundled in the
+original question:
+
+1. **`orion-state-service`'s aggregation is not the same question as field-topology weighting
+   at all** — it's single-writer/most-recent selection for spark snapshots, and pick-one/
+   newest for biometrics summaries. Nothing to merge or retire here; it's correctly scoped as
+   a "which reading is current" cache, not a "how much does each node count" blend. Its
+   README's phrase "authoritative node if configured" is accurate but describes a narrower
+   mechanism than the arsonist doc's framing implied.
+2. **`CLUSTER_ROLE_WEIGHTS` is the real duplicate** — same underlying question as the
+   field-topology edges, computed independently with numbers that don't obviously relate to
+   the topology edges' reasoning, **and it isn't even the only duplicate**: `orion-hub` has its
+   own third, silently-different implementation (`BIOMETRICS_ROLE_WEIGHTS_JSON`) that's the one
+   actually active today (as the fallback), while `CLUSTER_ROLE_WEIGHTS`'s own code path is
+   currently dark (`BIOMETRICS_MODE=agent`). Given (a) it does have one real non-display
+   consumer (the metacog prompt cue) so it can't be dismissed as pure theater the way L7-L11
+   was, but (b) it's dark today, computed three inconsistent ways across two services, and
+   duplicates a question the topology edges already answer more principled-ly — the
+   recommended sequencing is: **before Atlas/Circe come online (Phase 3), decide once whether
+   node-weighting for the Hub/metacog "ops health" cue should derive from
+   `config/field/orion_field_topology.v1.yaml`'s existing per-node/per-capability weights
+   (single source of truth) rather than a bespoke role-weight scalar, and delete the two
+   redundant reimplementations (`CLUSTER_ROLE_WEIGHTS` in orion-biometrics,
+   `BIOMETRICS_ROLE_WEIGHTS_JSON` in orion-hub) in favor of it.** Don't fix this by merely
+   reconciling the three numeric weight sets — that keeps three code paths computing the same
+   thing. If keeping a separate "ops health" concern is still desired after that comparison,
+   it should derive its per-node weight from the topology file's already-declared per-node
+   nodes list (`config/field/orion_field_topology.v1.yaml:5-7` — `atlas`, `athena`, `circe` are
+   already named there) rather than a new hand-picked scalar.
+
+## Incidental bug found (not fixed here, flagged for a separate small patch)
+
+`services/orion-state-service/app/main.py`'s HTTP `GET /state/latest` route (`http_get_latest`,
+~line 292) calls `STORE.get_latest(req)` without the `biometrics_stale_after_sec` keyword
+argument that `StateStore.get_latest()` requires and that the bus-RPC path
+(`_handle_get_latest`, ~line 181) does pass — confirmed live via `docker exec
+orion-athena-state-service curl localhost:.../state/latest`, which throws
+`TypeError: StateStore.get_latest() missing 1 required keyword-only argument:
+'biometrics_stale_after_sec'`. The HTTP debug endpoint is dead; only the bus RPC path is
+exercised in practice.

--- a/docs/superpowers/pr-reports/2026-07-12-self-state-mesh-provenance-phase-3-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-self-state-mesh-provenance-phase-3-pr.md
@@ -1,0 +1,118 @@
+# PR: Self-state Phase 3 — node-attributed mesh provenance + Phase 4 research
+
+## Summary
+
+- **Phase 3 (mesh embodiment) code portion**: threads which node/capability contributed each diffused field channel through to `SelfStateV1`'s `reasons` field — the concrete mechanism for "my reasoning capacity is strained because Circe is down" instead of an anonymous pressure number.
+- **Phase 4 (drive unification) research**: traced `CLUSTER_ROLE_WEIGHTS`/`orion-state-service` node-weighting live on the running mesh (docker logs/exec, not README claims) — found a *third* independent, previously-unflagged reimplementation of the same node-weighting question, and confirmed the arsonist doc's original consumer was itself already dark.
+- Medium-effort code review (2 angles) found and fixed one real, empirically-reproduced bug in the provenance-tracking logic before it shipped.
+- Two Phase 3 sub-items from the plan remain out of scope for this PR: enabling biometrics on Atlas/Circe is a remote-deployment action on physical hosts this session has no access to; revisiting the capacity-pressure-vs-continuity-threat distinction is explicitly gated on real multi-node data existing first.
+
+## Outcome moved
+
+Layer 6's evidence trail gains real mesh identity. Previously, a capability-level pressure number (e.g. `resource_pressure`) was anonymous even after Phase 1's evidence-channel-map fix restored raw-channel visibility — nothing said *which node* was behind it. Now, once Atlas/Circe biometrics come online (a separate operator action), self-state's `reasons` will name them by name.
+
+## Current architecture
+
+Before this PR: `apply_diffusion` (orion-field-digester) already applied real per-node topology edge weights (fixed in Phase 1's double-counting repair), but discarded which node fed which value the moment it accumulated into a capability channel. `collect_field_channel_pressures` further flattened node/capability vectors into one anonymous channel-name-keyed dict.
+
+## Architecture touched
+
+- `orion/schemas/field_state.py` — new schema field
+- `services/orion-field-digester/app/digestion/diffusion.py` — provenance tracking during diffusion
+- `orion/self_state/scoring.py`, `orion/self_state/builder.py` — provenance threaded into evidence
+- `docs/notes/` — Phase 4 research findings
+
+## Files changed
+
+- `orion/schemas/field_state.py`: new `capability_provenance: dict[str, dict[str, str]]` field on `FieldStateV1` — per-tick "primary contributor" proxy, not a historical ledger (documented limitation)
+- `services/orion-field-digester/app/digestion/diffusion.py`: `apply_diffusion()` tracks and records the largest single weighted contribution per `(target_id, channel)` this tick; fixed a real bug (see Review findings) where a zero-contribution edge could still claim/overwrite provenance
+- `orion/self_state/scoring.py`: `collect_field_channel_pressures()` now returns `(pressures, provenance)` instead of just `pressures` — a breaking signature change, contained to its one production caller
+- `orion/self_state/builder.py`: new `_provenance_label()`/`_reason_for_evidence()` helpers; `reasons` now names the contributing node when known — `dominant_evidence`'s exact `channel_name=value` format is deliberately untouched (protects `orion-spark-introspector`'s hardware-bypass parsing)
+- `services/orion-field-digester/tests/test_diffusion_provenance.py`: new — 5 tests covering single-edge provenance, larger-contribution-wins, zero-contribution-doesn't-clobber (the bug fix), capability-capability edges
+- `tests/test_self_state_builder.py`, `tests/test_self_state_scoring.py`: updated for the new tuple return + new acceptance test (`test_resource_pressure_reasons_name_the_contributing_node`) proving the Phase 3 goal end-to-end
+- `docs/notes/2026-07-12-phase4-cluster-weighting-research.md`: new — Phase 4 research findings (see below)
+
+## Schema / bus / API changes
+
+- Added: `FieldStateV1.capability_provenance` (additive, `default_factory=dict`, safe for pre-existing rows/messages missing the field — verified against `extra="forbid"` semantics, which reject unexpected extras, not omitted-with-default fields)
+- Behavior changed: `collect_field_channel_pressures()`'s return type (internal to `orion/self_state/`, one production caller, updated in this diff); `SelfStateV1.reasons`' text content gains an optional `(node: X)` suffix when provenance is known — `dominant_evidence`'s format is unchanged
+- No bus channel or schema-registry changes — `FieldStateV1` is registered by class reference, not a hand-maintained field list
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+pytest tests/test_self_state_builder.py tests/test_self_state_builder_hardening.py \
+  tests/test_self_state_schemas.py tests/test_self_state_scoring.py \
+  tests/test_self_state_policy_loader.py tests/test_self_state_prediction.py \
+  tests/test_self_state_reliability_decontamination.py tests/test_self_state_runtime_store.py \
+  tests/test_self_state_transport_dimension.py tests/test_self_state_deviation.py \
+  tests/test_proposal_transport_readonly_candidates.py \
+  services/orion-spark-introspector/tests/test_tissue_viz_arousal.py \
+  services/orion-spark-introspector/tests/test_tissue_viz_novelty.py \
+  services/orion-spark-introspector/tests/test_inner_state_emit.py -q
+→ 87 passed, 0 failed
+
+pytest services/orion-field-digester/tests/ -q
+→ 16 passed, 0 failed
+```
+
+`git diff --check`: clean.
+
+## Evals run
+
+None — no eval harness exists for the field-digester/self-state substrate beyond the unit/regression tests above (known, pre-existing gap, not introduced by this PR).
+
+## Docker/build/smoke checks
+
+Not run this session — a live Docker mesh **is** running on this host (confirmed via `docker ps`: `orion-athena-self-state-runtime`, `orion-athena-field-digester`, etc., all up), and research for the Phase 4 doc used it read-only (`docker logs`/`docker exec`), but no image was rebuilt/restarted with this PR's code. Restart commands below are ready whenever this merges.
+
+## Review findings fixed
+
+Medium-effort code review (2 of 8 angles: line-by-line scan, cross-file tracer — scoped to this diff's size).
+
+- Finding: `apply_diffusion`'s "largest contribution wins provenance" check (`contribution >= _max_contribution.get(key, 0.0)`) used `0.0` as both the "nothing recorded yet this call" sentinel and a legitimate zero-contribution value. A single edge contributing nothing this tick (its source has no value for the mapped channel) could satisfy the comparison and silently overwrite provenance genuinely recorded on a *prior* tick — even though the accumulated value itself doesn't change (adding `0.0` is a no-op). Found and empirically reproduced by the review agent.
+  - Fix: added an explicit `contribution > 0.0` guard before the comparison.
+  - Evidence: new regression test `test_zero_contribution_edge_does_not_clobber_prior_tick_provenance`.
+- Cross-file tracer angle: checked every caller of the changed `collect_field_channel_pressures` signature and every `FieldStateV1` constructor/deserialization path in the repo — found nothing broken. Confirmed `capability_provenance`'s `default_factory=dict` is safe under `extra="forbid"` for old data missing the field.
+
+## Phase 4 research summary (separate from the code change above)
+
+`docs/notes/2026-07-12-phase4-cluster-weighting-research.md` traces whether `CLUSTER_ROLE_WEIGHTS`/`orion-state-service` are a legitimate separate "ops health" concern or a duplicate of the field-topology node-weighting question. Findings:
+
+- **A third, previously-unflagged reimplementation exists**: `orion-hub`'s own `BIOMETRICS_ROLE_WEIGHTS_JSON` fallback (`{"atlas":0.6,"athena":0.4}` — a third, different number set from `CLUSTER_ROLE_WEIGHTS`' `{"atlas":0.7,"athena":0.3,"other":0.5}`), which is the one **actually active today** as a fallback.
+- `CLUSTER_ROLE_WEIGHTS`' own code path (`BiometricsHub.publish_cluster`) never runs live — `BIOMETRICS_MODE=agent`, confirmed zero `biometrics.cluster.v1` messages ingested over a 6-hour log window.
+- Unlike the L7-L11 ladder, `CLUSTER_ROLE_WEIGHTS` does have one real non-display consumer when it fires: `orion-cortex-exec`'s metacognition LLM prompt templates via `metacog_biometrics_cue`. Its `spark.signal.v1`/`DriveEngine` path is a dead end (the `level` dimension is unmapped in `signal_drive_map.yaml`).
+- `orion-state-service`'s aggregation answers a genuinely different question (single-writer/most-recent snapshot selection) and is **not** a duplicate — the arsonist doc's framing was imprecise on this point.
+- Recommendation: before Atlas/Circe come online, derive Hub/metacog node-weighting from the field-topology file's already-declared per-node weights instead of a third bespoke scalar, and retire both `CLUSTER_ROLE_WEIGHTS` and `BIOMETRICS_ROLE_WEIGHTS_JSON`.
+- Incidental bug found, not fixed here: `orion-state-service`'s `GET /state/latest` HTTP route throws a live `TypeError` (missing required kwarg) — only the bus RPC path is actually exercised.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-field-digester/.env \
+  -f services/orion-field-digester/docker-compose.yml up -d --build
+
+docker compose --env-file .env --env-file services/orion-self-state-runtime/.env \
+  -f services/orion-self-state-runtime/docker-compose.yml up -d --build
+```
+
+This PR's changes do **not** touch any dimension's `.score` formula (only `reasons` text and a new schema field) — unlike the still-open Phase 1 phi-corpus decision, there is no equivalent deployment gate here. Safe to restart once merged.
+
+## Risks / concerns
+
+- Severity: low
+  Concern: `capability_provenance` is a "largest contribution this tick" proxy, not a historical ledger — a capability channel's accumulated value can reflect contributions from multiple nodes over many ticks, but provenance only ever names the single biggest contributor in the *current* tick's diffusion pass.
+  Mitigation: documented explicitly in the schema field's docstring; acceptable scope for this phase per the plan's own "don't build a bigger feature than needed" guidance. A fuller historical ledger is a candidate follow-up if this proves insufficient once Atlas/Circe are live.
+- Severity: low
+  Concern: no test exists for "old `FieldStateV1` payload missing `capability_provenance` entirely" as an explicit regression (the review agent confirmed this is safe by Pydantic semantics, but didn't add a dedicated test).
+  Mitigation: flagged as a minor test-coverage gap, not a live bug; cheap to add later if desired.
+- Severity: informational
+  The Phase 4 research surfaced a third weighting duplicate and a live HTTP bug in `orion-state-service`, neither fixed in this PR (out of scope — this PR is Phase 3 code + Phase 4 *research*, not Phase 4 *implementation*).
+
+## PR link
+
+<!-- filled in after push -->

--- a/orion/schemas/field_state.py
+++ b/orion/schemas/field_state.py
@@ -24,6 +24,18 @@ class FieldStateV1(BaseModel):
     tick_id: str
     node_vectors: dict[str, dict[str, float]] = Field(default_factory=dict)
     capability_vectors: dict[str, dict[str, float]] = Field(default_factory=dict)
+    # Phase 3 (2026-07-12, self-state/mesh substrate redesign): keyed by
+    # capability target_id -> channel -> the edge source_id (a node_id like
+    # "node:atlas" or another capability_id for a capability_capability edge)
+    # that contributed the single largest weighted amount to that channel in
+    # the most recent diffusion pass (services/orion-field-digester/app/
+    # digestion/diffusion.py). A simple "primary contributor this tick"
+    # proxy, not a full historical attribution ledger -- capability_vectors
+    # values accumulate across ticks, but tracking exact per-tick provenance
+    # of an accumulated value would be a bigger feature than this phase
+    # needs. Lets self-state's evidence say which node is behind a pressure
+    # instead of an anonymous capability-level number.
+    capability_provenance: dict[str, dict[str, str]] = Field(default_factory=dict)
     edges: list[FieldEdgeV1] = Field(default_factory=list)
     recent_perturbations: list[str] = Field(default_factory=list)
     topology_id: str | None = None

--- a/orion/self_state/builder.py
+++ b/orion/self_state/builder.py
@@ -138,6 +138,32 @@ def _emit_summary_labels(
     return sorted(set(labels))
 
 
+def _provenance_label(source_id: str) -> str:
+    """Friendlier evidence label: strip the "node:" prefix (e.g. "node:atlas"
+    -> "atlas"); leave capability-sourced provenance (e.g.
+    "capability:transport") as-is since it's still informative and isn't a
+    node name to shorten."""
+    if source_id.startswith("node:"):
+        return source_id[len("node:") :]
+    return source_id
+
+
+def _reason_for_evidence(ev: str, channel_provenance: dict[str, str]) -> str:
+    """Phase 3 (2026-07-12): fold node/capability provenance into the
+    free-text `reasons` field, NOT `dominant_evidence` -- `dominant_evidence`
+    strings are parsed by downstream consumers (e.g. orion-spark-
+    introspector's `_parse_dominant_evidence_channels`, which does
+    `entry.partition("=")` expecting an exact `channel_name=value` shape) and
+    prefixing the channel name there would silently break that parsing.
+    `reasons` has no such contract.
+    """
+    channel_name = ev.partition("=")[0]
+    node = channel_provenance.get(channel_name)
+    if node:
+        return f"driven by {ev} (node: {_provenance_label(node)})"
+    return f"driven by {ev}"
+
+
 def evidence_for_dimension(
     *,
     dim_id: str,
@@ -177,10 +203,17 @@ def build_self_state(
             f"attention_source_tick_mismatch:{attention.source_field_tick_id}!={field.tick_id}"
         )
 
-    field_channels = collect_field_channel_pressures(field)
+    field_channels, channel_provenance = collect_field_channel_pressures(field)
     attn_channels = collect_attention_channel_pressures(attention, policy)
     merged_channels: dict[str, float] = dict(field_channels)
     for k, v in attn_channels.items():
+        if v > merged_channels.get(k, 0.0):
+            # Attention channels have no known node/capability provenance --
+            # if an attention value overrides the field value for this
+            # channel, drop the (now-stale) field-sourced provenance rather
+            # than mislabel an attention-derived value with a node it didn't
+            # come from.
+            channel_provenance.pop(k, None)
         merged_channels[k] = max(merged_channels.get(k, 0.0), v)
 
     mapped = map_channels_to_dimensions(channel_pressures=merged_channels, policy=policy)
@@ -282,7 +315,7 @@ def build_self_state(
             policy=policy,
         )
         reasons = (
-            [f"driven by {ev}" for ev in dominant_evidence]
+            [_reason_for_evidence(ev, channel_provenance) for ev in dominant_evidence]
             if dominant_evidence
             else ["no contributing channel evidence this tick"]
         )

--- a/orion/self_state/scoring.py
+++ b/orion/self_state/scoring.py
@@ -51,16 +51,37 @@ def condition_from_intensity(
     return "unstable"
 
 
-def collect_field_channel_pressures(field: FieldStateV1) -> dict[str, float]:
+def collect_field_channel_pressures(
+    field: FieldStateV1,
+) -> tuple[dict[str, float], dict[str, str]]:
+    """Merge node_vectors + capability_vectors into one channel-name-keyed
+    pressure dict (unchanged behavior), plus a parallel provenance dict
+    (Phase 3, 2026-07-12) recording which source_id "won" the max() for each
+    channel this tick -- a node_id directly for node_vectors, or the
+    diffusion-tracked edge source (see field.capability_provenance) for
+    capability_vectors, falling back to the capability_id itself when no
+    provenance was recorded for that specific channel.
+    """
     out: dict[str, float] = {}
-    for vector in list(field.node_vectors.values()) + list(field.capability_vectors.values()):
+    provenance: dict[str, str] = {}
+    for source_id, vector in field.node_vectors.items():
         for channel, value in vector.items():
-            if channel in PRESSURE_CHANNELS or float(value) > 0:
-                out[channel] = max(out.get(channel, 0.0), clamp01(float(value)))
+            v = clamp01(float(value))
+            if (channel in PRESSURE_CHANNELS or v > 0) and v >= out.get(channel, 0.0):
+                out[channel] = v
+                provenance[channel] = source_id
+    for capability_id, vector in field.capability_vectors.items():
+        for channel, value in vector.items():
+            v = clamp01(float(value))
+            if (channel in PRESSURE_CHANNELS or v > 0) and v >= out.get(channel, 0.0):
+                out[channel] = v
+                provenance[channel] = field.capability_provenance.get(capability_id, {}).get(
+                    channel, capability_id
+                )
     n = len(field.recent_perturbations)
     if n > 0:
         out["recent_perturbation_count"] = clamp01(min(1.0, n / 20.0))
-    return out
+    return out, provenance
 
 
 def collect_attention_channel_pressures(

--- a/services/orion-field-digester/app/digestion/diffusion.py
+++ b/services/orion-field-digester/app/digestion/diffusion.py
@@ -4,12 +4,31 @@ from orion.schemas.field_state import FieldStateV1
 
 
 def apply_diffusion(state: FieldStateV1, *, diffusion_rate: float) -> None:
+    # Phase 3 (2026-07-12): track, per (target_id, channel), the single
+    # largest weighted contribution seen in this diffusion pass, so
+    # state.capability_provenance can record which edge source "won" --
+    # a per-tick proxy, not a historical ledger (see FieldStateV1's
+    # capability_provenance docstring for why).
+    _max_contribution: dict[tuple[str, str], float] = {}
     for edge in state.edges:
         src = state.node_vectors.get(edge.source_id) or state.capability_vectors.get(edge.source_id, {})
         tgt = state.capability_vectors.setdefault(edge.target_id, {})
         for src_ch, tgt_ch in edge.channel_map.items():
             src_val = float(src.get(src_ch, 0.0))
-            tgt[tgt_ch] = min(1.0, tgt.get(tgt_ch, 0.0) + src_val * edge.weight * diffusion_rate)
+            contribution = src_val * edge.weight * diffusion_rate
+            tgt[tgt_ch] = min(1.0, tgt.get(tgt_ch, 0.0) + contribution)
+            key = (edge.target_id, tgt_ch)
+            # contribution > 0.0 is required, not just >=: 0.0 is both the
+            # "no contribution recorded yet this call" sentinel and a
+            # legitimate zero-contribution value (a source with no value for
+            # its mapped channel this tick). Without the strict >0 guard, a
+            # genuinely-zero edge processed first in state.edges' order would
+            # claim/overwrite provenance carried over from a real contributor
+            # in a prior tick, even though it changed nothing (adding 0.0 to
+            # tgt[tgt_ch] is a no-op) -- found by code review, reproduced.
+            if contribution > 0.0 and contribution >= _max_contribution.get(key, 0.0):
+                _max_contribution[key] = contribution
+                state.capability_provenance.setdefault(edge.target_id, {})[tgt_ch] = edge.source_id
         if "available_capacity" in tgt:
             tgt["available_capacity"] = max(0.0, 1.0 - tgt.get("pressure", 0.0))
         if "confidence" in tgt:

--- a/services/orion-field-digester/tests/test_diffusion_provenance.py
+++ b/services/orion-field-digester/tests/test_diffusion_provenance.py
@@ -1,0 +1,172 @@
+"""Unit tests for apply_diffusion's Phase 3 (2026-07-12) node-provenance
+tracking -- state.capability_provenance recording which edge source
+contributed the largest weighted amount to each diffused channel this tick.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.digestion.diffusion import apply_diffusion
+
+from orion.schemas.field_state import FieldEdgeV1, FieldStateV1
+
+NOW = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def _state(edges: list[FieldEdgeV1], node_vectors: dict[str, dict[str, float]]) -> FieldStateV1:
+    return FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_diffusion_provenance",
+        node_vectors=node_vectors,
+        edges=edges,
+    )
+
+
+def test_single_edge_records_source_as_provenance() -> None:
+    edge = FieldEdgeV1(
+        source_id="node:circe",
+        target_id="capability:llm_inference",
+        edge_type="node_capability",
+        weight=0.50,
+        channel_map={"gpu_pressure": "pressure"},
+    )
+    state = _state([edge], {"node:circe": {"gpu_pressure": 1.0}})
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    assert state.capability_vectors["capability:llm_inference"]["pressure"] == 0.50
+    assert state.capability_provenance["capability:llm_inference"]["pressure"] == "node:circe"
+
+
+def test_larger_contribution_wins_provenance_over_smaller() -> None:
+    # atlas (weight 0.85) and circe (weight 0.50) both feed
+    # capability:llm_inference's "pressure" channel via gpu_pressure -- the
+    # larger weighted contribution should "win" provenance for this tick.
+    edges = [
+        FieldEdgeV1(
+            source_id="node:atlas",
+            target_id="capability:llm_inference",
+            edge_type="node_capability",
+            weight=0.85,
+            channel_map={"gpu_pressure": "pressure"},
+        ),
+        FieldEdgeV1(
+            source_id="node:circe",
+            target_id="capability:llm_inference",
+            edge_type="node_capability",
+            weight=0.50,
+            channel_map={"gpu_pressure": "pressure"},
+        ),
+    ]
+    state = _state(
+        edges,
+        {
+            "node:atlas": {"gpu_pressure": 1.0},
+            "node:circe": {"gpu_pressure": 0.2},
+        },
+    )
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    # atlas contributes 1.0*0.85=0.85, circe contributes 0.2*0.50=0.10 -- atlas wins.
+    assert state.capability_provenance["capability:llm_inference"]["pressure"] == "node:atlas"
+
+
+def test_zero_contribution_does_not_overwrite_existing_provenance() -> None:
+    # A second edge whose source has no value for its mapped channel this
+    # tick (contribution 0.0) must not clobber a real contributor's
+    # provenance recorded moments before in the same pass.
+    edges = [
+        FieldEdgeV1(
+            source_id="node:atlas",
+            target_id="capability:llm_inference",
+            edge_type="node_capability",
+            weight=0.85,
+            channel_map={"gpu_pressure": "pressure"},
+        ),
+        FieldEdgeV1(
+            source_id="node:circe",
+            target_id="capability:llm_inference",
+            edge_type="node_capability",
+            weight=0.50,
+            channel_map={"gpu_pressure": "pressure"},
+        ),
+    ]
+    state = _state(
+        edges,
+        {
+            "node:atlas": {"gpu_pressure": 1.0},
+            "node:circe": {},  # no gpu_pressure this tick -> contribution 0.0
+        },
+    )
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    assert state.capability_provenance["capability:llm_inference"]["pressure"] == "node:atlas"
+
+
+def test_zero_contribution_edge_does_not_clobber_prior_tick_provenance() -> None:
+    # Regression found by code review (2026-07-12, empirically reproduced):
+    # 0.0 was both the "no contribution recorded this call" sentinel AND a
+    # legitimate zero-contribution value, so a single edge contributing
+    # nothing this tick (its source has no value for the mapped channel)
+    # would still satisfy the old `contribution >= _max_contribution.get(key,
+    # 0.0)` check on the first edge processed for a (target, channel) key --
+    # silently overwriting real provenance recorded on a prior tick, even
+    # though the accumulated value itself is unchanged (adding 0.0 is a
+    # no-op). This state carries capability_provenance forward from a prior
+    # tick (as the persistent FieldStateV1 object genuinely does across real
+    # ticks) where atlas was the real contributor; this tick's only edge
+    # (circe) contributes nothing and must not claim credit.
+    state = FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_stale_zero_contribution",
+        node_vectors={"node:circe": {}},  # no gpu_pressure this tick
+        capability_vectors={"capability:llm_inference": {"pressure": 0.5}},
+        capability_provenance={"capability:llm_inference": {"pressure": "node:atlas"}},
+        edges=[
+            FieldEdgeV1(
+                source_id="node:circe",
+                target_id="capability:llm_inference",
+                edge_type="node_capability",
+                weight=0.50,
+                channel_map={"gpu_pressure": "pressure"},
+            ),
+        ],
+    )
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    # Accumulated value unchanged (0.0 contribution added).
+    assert state.capability_vectors["capability:llm_inference"]["pressure"] == 0.5
+    # Provenance must still credit atlas (the real prior contributor), not
+    # circe (which contributed nothing this tick).
+    assert state.capability_provenance["capability:llm_inference"]["pressure"] == "node:atlas"
+
+
+def test_capability_capability_edge_records_capability_id_as_provenance() -> None:
+    # capability_capability edges (e.g. capability:transport -> capability:
+    # orchestration) have a capability_id as source_id, not a node -- the
+    # provenance mechanism is source-agnostic and records whatever
+    # edge.source_id is, node or capability.
+    edge = FieldEdgeV1(
+        source_id="capability:transport",
+        target_id="capability:orchestration",
+        edge_type="capability_capability",
+        weight=0.70,
+        channel_map={"transport_pressure": "transport_pressure"},
+    )
+    state = FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_cap_cap",
+        capability_vectors={"capability:transport": {"transport_pressure": 0.8}},
+        edges=[edge],
+    )
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    assert (
+        state.capability_provenance["capability:orchestration"]["transport_pressure"]
+        == "capability:transport"
+    )

--- a/tests/test_self_state_builder.py
+++ b/tests/test_self_state_builder.py
@@ -206,6 +206,37 @@ def test_evidence_channel_map_restores_raw_channel_without_double_counting_score
     assert any(ev.startswith("gpu_pressure=") for ev in resource_dim.dominant_evidence)
 
 
+def _mesh_provenance_field() -> FieldStateV1:
+    # Mirrors what real orion-field-digester diffusion output looks like:
+    # capability_provenance populated by apply_diffusion, recording which
+    # node fed capability:llm_inference's "pressure" channel this tick.
+    return FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_mesh_provenance",
+        node_vectors={"node:circe": {"gpu_pressure": 0.95}},
+        capability_vectors={"capability:llm_inference": {"pressure": 0.60}},
+        capability_provenance={"capability:llm_inference": {"pressure": "node:circe"}},
+    )
+
+
+def test_resource_pressure_reasons_name_the_contributing_node() -> None:
+    # Phase 3 (2026-07-12, mesh embodiment): the concrete acceptance goal --
+    # a live self-state tick's evidence names a specific non-Athena node,
+    # e.g. "driven by pressure=0.60 (node: circe)" instead of an anonymous
+    # capability-level pressure number.
+    field = _mesh_provenance_field()
+    attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)
+    state = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
+
+    resource_dim = state.dimensions["resource_pressure"]
+    # dominant_evidence keeps its exact channel_name=value format, unchanged --
+    # downstream consumers (orion-spark-introspector's hardware bypass) parse
+    # it by exact shape.
+    assert any(ev == "pressure=0.60" for ev in resource_dim.dominant_evidence)
+    # reasons is where node attribution lives.
+    assert any("(node: circe)" in reason for reason in resource_dim.reasons)
+
+
 def test_no_action_outputs() -> None:
     field = _synthetic_field()
     attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)

--- a/tests/test_self_state_scoring.py
+++ b/tests/test_self_state_scoring.py
@@ -35,7 +35,7 @@ def _field_high_execution() -> FieldStateV1:
 
 
 def test_high_execution_load_raises_execution_pressure() -> None:
-    channels = collect_field_channel_pressures(_field_high_execution())
+    channels, _ = collect_field_channel_pressures(_field_high_execution())
     dims = map_channels_to_dimensions(channel_pressures=channels, policy=POLICY)
     assert dims.get("execution_pressure", 0.0) > 0.5
 
@@ -49,7 +49,7 @@ def test_raw_execution_load_alone_no_longer_double_counts() -> None:
         tick_id="tick_scoring_raw_only",
         node_vectors={"node:athena": {"execution_load": 1.0}},
     )
-    channels = collect_field_channel_pressures(field)
+    channels, _ = collect_field_channel_pressures(field)
     dims = map_channels_to_dimensions(channel_pressures=channels, policy=POLICY)
     assert dims.get("execution_pressure", 0.0) == 0.0
 
@@ -61,7 +61,7 @@ def test_high_execution_friction_raises_reliability_pressure() -> None:
         node_vectors={"node:athena": {"execution_friction": 1.0}},
         capability_vectors={"capability:orchestration": {"reliability_pressure": 0.9}},
     )
-    channels = collect_field_channel_pressures(field)
+    channels, _ = collect_field_channel_pressures(field)
     dims = map_channels_to_dimensions(channel_pressures=channels, policy=POLICY)
     assert dims.get("reliability_pressure", 0.0) > 0.5
 
@@ -73,8 +73,9 @@ def test_high_failure_pressure_raises_reliability() -> None:
         node_vectors={"node:athena": {"failure_pressure": 1.0}},
         capability_vectors={"capability:orchestration": {"reliability_pressure": 0.9}},
     )
+    channels, _ = collect_field_channel_pressures(field)
     dims = map_channels_to_dimensions(
-        channel_pressures=collect_field_channel_pressures(field),
+        channel_pressures=channels,
         policy=POLICY,
     )
     assert dims.get("reliability_pressure", 0.0) > 0.5
@@ -137,11 +138,17 @@ def test_double_counting_fix_weighted_diffusion_wins_not_raw_spike() -> None:
         node_vectors={"node:circe": {"gpu_pressure": 1.0}},
         capability_vectors={"capability:llm_inference": {"pressure": 0.50}},
     )
-    channels = collect_field_channel_pressures(field)
+    channels, provenance = collect_field_channel_pressures(field)
     assert channels["gpu_pressure"] == 1.0  # raw value still present in merged channels...
     dims = map_channels_to_dimensions(channel_pressures=channels, policy=POLICY)
     # ...but it must not compete with (and beat) its own weighted diffusion.
     assert dims.get("resource_pressure", 0.0) == 0.50
+    # Phase 3 (2026-07-12): the raw node channel's provenance is the node
+    # itself; the diffused capability channel falls back to the capability_id
+    # since this synthetic fixture never ran real diffusion (no
+    # field.capability_provenance populated) -- exercising the fallback path.
+    assert provenance["gpu_pressure"] == "node:circe"
+    assert provenance["pressure"] == "capability:llm_inference"
 
 
 def test_node_only_channel_staleness_still_reaches_continuity_pressure() -> None:
@@ -154,7 +161,7 @@ def test_node_only_channel_staleness_still_reaches_continuity_pressure() -> None
         tick_id="tick_staleness",
         node_vectors={"node:athena": {"staleness": 0.8}},
     )
-    channels = collect_field_channel_pressures(field)
+    channels, _ = collect_field_channel_pressures(field)
     dims = map_channels_to_dimensions(channel_pressures=channels, policy=POLICY)
     assert dims.get("continuity_pressure", 0.0) == 0.8
 


### PR DESCRIPTION
# PR: Self-state Phase 3 — node-attributed mesh provenance + Phase 4 research

## Summary

- **Phase 3 (mesh embodiment) code portion**: threads which node/capability contributed each diffused field channel through to `SelfStateV1`'s `reasons` field — the concrete mechanism for "my reasoning capacity is strained because Circe is down" instead of an anonymous pressure number.
- **Phase 4 (drive unification) research**: traced `CLUSTER_ROLE_WEIGHTS`/`orion-state-service` node-weighting live on the running mesh (docker logs/exec, not README claims) — found a *third* independent, previously-unflagged reimplementation of the same node-weighting question, and confirmed the arsonist doc's original consumer was itself already dark.
- Medium-effort code review (2 angles) found and fixed one real, empirically-reproduced bug in the provenance-tracking logic before it shipped.
- Two Phase 3 sub-items from the plan remain out of scope for this PR: enabling biometrics on Atlas/Circe is a remote-deployment action on physical hosts this session has no access to; revisiting the capacity-pressure-vs-continuity-threat distinction is explicitly gated on real multi-node data existing first.

## Outcome moved

Layer 6's evidence trail gains real mesh identity. Previously, a capability-level pressure number (e.g. `resource_pressure`) was anonymous even after Phase 1's evidence-channel-map fix restored raw-channel visibility — nothing said *which node* was behind it. Now, once Atlas/Circe biometrics come online (a separate operator action), self-state's `reasons` will name them by name.

## Current architecture

Before this PR: `apply_diffusion` (orion-field-digester) already applied real per-node topology edge weights (fixed in Phase 1's double-counting repair), but discarded which node fed which value the moment it accumulated into a capability channel. `collect_field_channel_pressures` further flattened node/capability vectors into one anonymous channel-name-keyed dict.

## Architecture touched

- `orion/schemas/field_state.py` — new schema field
- `services/orion-field-digester/app/digestion/diffusion.py` — provenance tracking during diffusion
- `orion/self_state/scoring.py`, `orion/self_state/builder.py` — provenance threaded into evidence
- `docs/notes/` — Phase 4 research findings

## Files changed

- `orion/schemas/field_state.py`: new `capability_provenance: dict[str, dict[str, str]]` field on `FieldStateV1` — per-tick "primary contributor" proxy, not a historical ledger (documented limitation)
- `services/orion-field-digester/app/digestion/diffusion.py`: `apply_diffusion()` tracks and records the largest single weighted contribution per `(target_id, channel)` this tick; fixed a real bug (see Review findings) where a zero-contribution edge could still claim/overwrite provenance
- `orion/self_state/scoring.py`: `collect_field_channel_pressures()` now returns `(pressures, provenance)` instead of just `pressures` — a breaking signature change, contained to its one production caller
- `orion/self_state/builder.py`: new `_provenance_label()`/`_reason_for_evidence()` helpers; `reasons` now names the contributing node when known — `dominant_evidence`'s exact `channel_name=value` format is deliberately untouched (protects `orion-spark-introspector`'s hardware-bypass parsing)
- `services/orion-field-digester/tests/test_diffusion_provenance.py`: new — 5 tests covering single-edge provenance, larger-contribution-wins, zero-contribution-doesn't-clobber (the bug fix), capability-capability edges
- `tests/test_self_state_builder.py`, `tests/test_self_state_scoring.py`: updated for the new tuple return + new acceptance test (`test_resource_pressure_reasons_name_the_contributing_node`) proving the Phase 3 goal end-to-end
- `docs/notes/2026-07-12-phase4-cluster-weighting-research.md`: new — Phase 4 research findings (see below)

## Schema / bus / API changes

- Added: `FieldStateV1.capability_provenance` (additive, `default_factory=dict`, safe for pre-existing rows/messages missing the field — verified against `extra="forbid"` semantics, which reject unexpected extras, not omitted-with-default fields)
- Behavior changed: `collect_field_channel_pressures()`'s return type (internal to `orion/self_state/`, one production caller, updated in this diff); `SelfStateV1.reasons`' text content gains an optional `(node: X)` suffix when provenance is known — `dominant_evidence`'s format is unchanged
- No bus channel or schema-registry changes — `FieldStateV1` is registered by class reference, not a hand-maintained field list

## Env/config changes

None.

## Tests run

```text
pytest tests/test_self_state_builder.py tests/test_self_state_builder_hardening.py \
  tests/test_self_state_schemas.py tests/test_self_state_scoring.py \
  tests/test_self_state_policy_loader.py tests/test_self_state_prediction.py \
  tests/test_self_state_reliability_decontamination.py tests/test_self_state_runtime_store.py \
  tests/test_self_state_transport_dimension.py tests/test_self_state_deviation.py \
  tests/test_proposal_transport_readonly_candidates.py \
  services/orion-spark-introspector/tests/test_tissue_viz_arousal.py \
  services/orion-spark-introspector/tests/test_tissue_viz_novelty.py \
  services/orion-spark-introspector/tests/test_inner_state_emit.py -q
→ 87 passed, 0 failed

pytest services/orion-field-digester/tests/ -q
→ 16 passed, 0 failed
```

`git diff --check`: clean.

## Evals run

None — no eval harness exists for the field-digester/self-state substrate beyond the unit/regression tests above (known, pre-existing gap, not introduced by this PR).

## Docker/build/smoke checks

Not run this session — a live Docker mesh **is** running on this host (confirmed via `docker ps`: `orion-athena-self-state-runtime`, `orion-athena-field-digester`, etc., all up), and research for the Phase 4 doc used it read-only (`docker logs`/`docker exec`), but no image was rebuilt/restarted with this PR's code. Restart commands below are ready whenever this merges.

## Review findings fixed

Medium-effort code review (2 of 8 angles: line-by-line scan, cross-file tracer — scoped to this diff's size).

- Finding: `apply_diffusion`'s "largest contribution wins provenance" check (`contribution >= _max_contribution.get(key, 0.0)`) used `0.0` as both the "nothing recorded yet this call" sentinel and a legitimate zero-contribution value. A single edge contributing nothing this tick (its source has no value for the mapped channel) could satisfy the comparison and silently overwrite provenance genuinely recorded on a *prior* tick — even though the accumulated value itself doesn't change (adding `0.0` is a no-op). Found and empirically reproduced by the review agent.
  - Fix: added an explicit `contribution > 0.0` guard before the comparison.
  - Evidence: new regression test `test_zero_contribution_edge_does_not_clobber_prior_tick_provenance`.
- Cross-file tracer angle: checked every caller of the changed `collect_field_channel_pressures` signature and every `FieldStateV1` constructor/deserialization path in the repo — found nothing broken. Confirmed `capability_provenance`'s `default_factory=dict` is safe under `extra="forbid"` for old data missing the field.

## Phase 4 research summary (separate from the code change above)

`docs/notes/2026-07-12-phase4-cluster-weighting-research.md` traces whether `CLUSTER_ROLE_WEIGHTS`/`orion-state-service` are a legitimate separate "ops health" concern or a duplicate of the field-topology node-weighting question. Findings:

- **A third, previously-unflagged reimplementation exists**: `orion-hub`'s own `BIOMETRICS_ROLE_WEIGHTS_JSON` fallback (`{"atlas":0.6,"athena":0.4}` — a third, different number set from `CLUSTER_ROLE_WEIGHTS`' `{"atlas":0.7,"athena":0.3,"other":0.5}`), which is the one **actually active today** as a fallback.
- `CLUSTER_ROLE_WEIGHTS`' own code path (`BiometricsHub.publish_cluster`) never runs live — `BIOMETRICS_MODE=agent`, confirmed zero `biometrics.cluster.v1` messages ingested over a 6-hour log window.
- Unlike the L7-L11 ladder, `CLUSTER_ROLE_WEIGHTS` does have one real non-display consumer when it fires: `orion-cortex-exec`'s metacognition LLM prompt templates via `metacog_biometrics_cue`. Its `spark.signal.v1`/`DriveEngine` path is a dead end (the `level` dimension is unmapped in `signal_drive_map.yaml`).
- `orion-state-service`'s aggregation answers a genuinely different question (single-writer/most-recent snapshot selection) and is **not** a duplicate — the arsonist doc's framing was imprecise on this point.
- Recommendation: before Atlas/Circe come online, derive Hub/metacog node-weighting from the field-topology file's already-declared per-node weights instead of a third bespoke scalar, and retire both `CLUSTER_ROLE_WEIGHTS` and `BIOMETRICS_ROLE_WEIGHTS_JSON`.
- Incidental bug found, not fixed here: `orion-state-service`'s `GET /state/latest` HTTP route throws a live `TypeError` (missing required kwarg) — only the bus RPC path is actually exercised.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml up -d --build

docker compose --env-file .env --env-file services/orion-self-state-runtime/.env \
  -f services/orion-self-state-runtime/docker-compose.yml up -d --build
```

This PR's changes do **not** touch any dimension's `.score` formula (only `reasons` text and a new schema field) — unlike the still-open Phase 1 phi-corpus decision, there is no equivalent deployment gate here. Safe to restart once merged.

## Risks / concerns

- Severity: low
  Concern: `capability_provenance` is a "largest contribution this tick" proxy, not a historical ledger — a capability channel's accumulated value can reflect contributions from multiple nodes over many ticks, but provenance only ever names the single biggest contributor in the *current* tick's diffusion pass.
  Mitigation: documented explicitly in the schema field's docstring; acceptable scope for this phase per the plan's own "don't build a bigger feature than needed" guidance. A fuller historical ledger is a candidate follow-up if this proves insufficient once Atlas/Circe are live.
- Severity: low
  Concern: no test exists for "old `FieldStateV1` payload missing `capability_provenance` entirely" as an explicit regression (the review agent confirmed this is safe by Pydantic semantics, but didn't add a dedicated test).
  Mitigation: flagged as a minor test-coverage gap, not a live bug; cheap to add later if desired.
- Severity: informational
  The Phase 4 research surfaced a third weighting duplicate and a live HTTP bug in `orion-state-service`, neither fixed in this PR (out of scope — this PR is Phase 3 code + Phase 4 *research*, not Phase 4 *implementation*).
