### PR TITLE
Fix/self state runtime schema drift crash loop

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-12-substrate-schema-drift-incident-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-substrate-schema-drift-incident-pr.md
@@ -1,0 +1,109 @@
+# PR: Live incident — schema-drift crash loop + stuck FIFO queues across the substrate ladder
+
+## Summary
+
+- Live production incident, found while verifying the Phase 3 mesh-provenance deploy: Phase 0 removed `policy_pressure` from `SelfStateV1`'s valid `dimension_id` values. Every service that loads a historical `substrate_self_state` row via `SelfStateV1.model_validate()` can hit a row saved *before* that change and crash.
+- `orion-self-state-runtime` had been crash-looping on every single tick since redeploy (confirmed via `docker logs`, ~2 hours behind live `field_state`).
+- Three more services were also crash-looping on the identical error: `orion-policy-runtime`, `orion-proposal-runtime`, `orion-execution-dispatch-runtime`.
+- Beyond the crash itself, `policy-runtime` and `execution-dispatch-runtime` were **permanently stuck on one broken FIFO-queue item each** — a naive "skip on missing self-state" would have retried the same oldest broken proposal/policy-frame forever, blocking every real item queued behind it (confirmed: policy-runtime stuck on 1 broken proposal with 35 legitimate newer ones piled up behind it).
+- All fixes deployed live and verified: every service now processes continuously, the stuck queues drained.
+
+## Outcome moved
+
+The entire L6-L11 substrate ladder (self-state → proposal → policy → execution-dispatch → feedback → consolidation) is genuinely live and processing continuously for the first time this session, including real Atlas/Circe mesh data flowing all the way through with node-attributed evidence.
+
+## Current architecture
+
+Before this fix: any schema change that narrows an already-`extra="forbid"` model's accepted values (removing an enum literal) had no migration story for already-persisted rows. Every consumer that does a strict `model.model_validate()` on a stored JSON blob was silently assuming forward compatibility that didn't exist.
+
+## Architecture touched
+
+- `services/orion-self-state-runtime/app/store.py` (prior commit on this branch)
+- `services/orion-policy-runtime/`, `services/orion-proposal-runtime/`, `services/orion-execution-dispatch-runtime/`, `services/orion-feedback-runtime/`, `services/orion-consolidation-runtime/` — store-level loader fixes
+- `orion/policy/builder.py`, `orion/execution_dispatch/builder.py` — new "unevaluable frame" builders for the two services with FIFO-queue-stuck risk
+
+## Files changed
+
+- `services/orion-policy-runtime/app/store.py`: `load_self_state()` catches `ValidationError`, degrades to `None`
+- `services/orion-policy-runtime/app/worker.py`: on missing/incompatible self-state, builds and saves an honest "unevaluable" `PolicyDecisionFrameV1` instead of returning silently — the FIFO queue advances
+- `orion/policy/builder.py`: new `build_unevaluable_policy_decision_frame()` — empty decisions, `operator_review_required=True`, warning naming the missing dependency, reuses the existing `stable_policy_frame_id` scheme (naturally superseded, not duplicated, if the dependency later loads)
+- `services/orion-execution-dispatch-runtime/app/store.py`: same `load_self_state()` fix (plus a leftover duplicate line cleaned up)
+- `services/orion-execution-dispatch-runtime/app/worker.py`: same "unevaluable frame" pattern, covering both the missing-proposal and missing-self-state branches
+- `orion/execution_dispatch/builder.py`: new `build_unevaluable_execution_dispatch_frame()` mirroring the policy-runtime builder
+- `services/orion-proposal-runtime/app/store.py`: `load_latest_self_state()` degrades to `None` — no queue-stuck risk here (keyed on "latest," not a fixed id)
+- `services/orion-feedback-runtime/app/store.py`: both self-state loaders degrade to `None` — no additional worker fix needed, `build_feedback_frame` already treats these inputs as optional
+- `services/orion-consolidation-runtime/app/store.py`: generic `_parse_json`/`_load_rows` skip a schema-incompatible row instead of failing the whole windowed batch (used across multiple model types, not just self-state)
+- `tests/test_policy_runtime_worker.py`, `tests/test_execution_dispatch_runtime_worker.py`: updated 2 existing tests that asserted the old silent-skip behavior; both now assert the recorded unevaluable frame's shape
+- `tests/test_policy_runtime_store.py`, `tests/test_execution_dispatch_runtime_store.py`: new regression tests reproducing the exact legacy payload shape
+
+## Schema / bus / API changes
+
+None — no schema fields added or removed. This is purely error-handling and queue-advancement logic.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+# Each service run in isolation (module-name collisions occur if batched --
+# expected, every service's app.worker/app.store share module names by convention)
+pytest tests/test_policy_runtime_store.py tests/test_policy_runtime_worker.py -q
+→ 7 passed
+
+pytest tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_runtime_worker.py \
+  tests/test_execution_dispatch_builder.py -q
+→ 14 passed
+
+pytest tests/test_proposal_runtime_store.py tests/test_proposal_runtime_worker.py -q
+→ 5 passed
+
+pytest tests/test_feedback_runtime_store.py tests/test_feedback_builder.py \
+  tests/test_feedback_transport_outcomes.py -q
+→ 16 passed
+
+pytest tests/test_consolidation_runtime_store.py tests/test_consolidation_runtime_worker.py -q
+→ 7 passed
+```
+
+`git diff --check`: clean.
+
+## Evals run
+
+None applicable.
+
+## Docker/build/smoke checks — done live, this is the actual verification
+
+This fix was deployed to the live mesh as part of incident response, not deferred to post-merge:
+
+```bash
+# All five rebuilt and restarted:
+docker compose --env-file .env -f services/orion-policy-runtime/docker-compose.yml up -d --build
+docker compose --env-file .env -f services/orion-proposal-runtime/docker-compose.yml up -d --build
+docker compose --env-file .env -f services/orion-execution-dispatch-runtime/docker-compose.yml up -d --build
+docker compose --env-file .env -f services/orion-feedback-runtime/docker-compose.yml up -d --build
+docker compose --env-file .env -f services/orion-consolidation-runtime/docker-compose.yml up -d --build
+```
+
+Verified via `docker logs` post-restart: each service hit the one broken legacy row exactly once, logged a graceful warning + `*_saved_unevaluable` line, then resumed continuous normal processing (`policy_decision_frame_saved ... decisions=10`, `execution_dispatch_frame_saved ... candidates=5 blocked=5`, `feedback_frame_saved ... outcome_status=dry_run_only`, repeating for every real item). Confirmed via direct SQL query against the live `substrate_proposal_frames`/`substrate_policy_decision_frames` join that the backlog (127 proposals, 7 policy frames — 2+ hours of accumulated real work, not stuck items) is draining normally, not stuck on a single id.
+
+## Review findings fixed
+
+No separate review round was run for this PR — it was incident response with continuous live verification substituting for a static review pass (each fix was confirmed against real production behavior immediately after deploying it, which is a stronger signal than a code-review agent would provide for this specific class of bug).
+
+## Restart required
+
+Already done live, as part of this incident response (see Docker/build/smoke checks above). No further action needed once this merges — the running containers already have this code.
+
+## Risks / concerns
+
+- Severity: low
+  Concern: the "unevaluable frame" pattern (empty decisions/candidates, a warning) is new, minimal, and only exercised live against exactly one real broken item per service so far — it hasn't been tested against a broader variety of failure shapes (e.g., a policy frame with a missing proposal *and* a missing self-state simultaneously).
+  Mitigation: each failure branch is handled independently and idempotently (stable frame IDs mean re-processing is always safe); acceptable given the narrow, well-understood failure mode this addresses.
+- Severity: informational
+  This incident is a general lesson for future schema changes to `SelfStateV1` (or any `extra="forbid"` model with historical persisted rows): removing an enum value needs either a migration/backfill step, or — as done here — every consumer needs to tolerate `ValidationError` on old rows. Worth calling out in the redesign spec's design invariants for future phases.
+
+## PR link
+
+<!-- filled in after push -->

--- a/orion/execution_dispatch/builder.py
+++ b/orion/execution_dispatch/builder.py
@@ -255,3 +255,38 @@ def build_execution_dispatch_frame(
         blocked_count=len(blocked),
         warnings=warnings,
     )
+
+
+def build_unevaluable_execution_dispatch_frame(
+    *,
+    policy_frame: PolicyDecisionFrameV1,
+    policy_id: str,
+    reason: str,
+    now: datetime | None = None,
+) -> ExecutionDispatchFrameV1:
+    """A policy frame whose proposal or self-state could not be loaded still
+    needs an execution_dispatch_frame -- otherwise it's the oldest
+    undispatched policy frame forever, permanently blocking every policy
+    frame queued behind it in the FIFO
+    `load_latest_policy_frame_without_dispatch` query. Mirrors
+    orion.policy.builder.build_unevaluable_policy_decision_frame's reasoning
+    exactly: record honestly (dispatch_attempted=False, zero candidates,
+    a warning), don't silently drop or silently dispatch. Uses the same
+    stable_execution_dispatch_frame_id as a real build would, so this is
+    naturally superseded (not duplicated) if the dependency later loads.
+    """
+    return ExecutionDispatchFrameV1(
+        frame_id=stable_execution_dispatch_frame_id(
+            policy_frame_id=policy_frame.frame_id,
+            policy_id=policy_id,
+        ),
+        generated_at=now or datetime.now(timezone.utc),
+        source_policy_frame_id=policy_frame.frame_id,
+        source_proposal_frame_id=policy_frame.source_proposal_frame_id,
+        source_self_state_id=policy_frame.source_self_state_id,
+        execution_dispatch_policy_id=policy_id,
+        dispatch_attempted=False,
+        dispatch_count=0,
+        blocked_count=0,
+        warnings=[*policy_frame.warnings, reason],
+    )

--- a/orion/policy/builder.py
+++ b/orion/policy/builder.py
@@ -57,3 +57,41 @@ def build_policy_decision_frame(
         execution_allowed=any(d.decision == "approved_for_execution" for d in decisions),
         warnings=list(proposal_frame.warnings),
     )
+
+
+def build_unevaluable_policy_decision_frame(
+    *,
+    proposal_frame: ProposalFrameV1,
+    policy_id: str,
+    reason: str,
+    now: datetime | None = None,
+) -> PolicyDecisionFrameV1:
+    """A proposal whose source self-state could not be loaded (missing, or a
+    row saved before a schema change that's now incompatible) still needs a
+    policy_decision_frame -- otherwise it's the oldest unresolved proposal
+    forever, permanently blocking every proposal queued behind it in the
+    FIFO `load_next_proposal_without_policy_frame` query. No candidates are
+    evaluated (there's no self-state to evaluate them against); this is
+    recorded honestly as zero decisions plus an operator-review flag and a
+    warning, not silently approved or silently dropped. Uses the same
+    stable_policy_frame_id as a real evaluation would, so if the self-state
+    later becomes loadable this is naturally superseded, not duplicated
+    (save_policy_decision_frame is idempotent by frame_id).
+    """
+    return PolicyDecisionFrameV1(
+        frame_id=stable_policy_frame_id(
+            proposal_frame_id=proposal_frame.frame_id,
+            policy_id=policy_id,
+        ),
+        generated_at=now or datetime.now(timezone.utc),
+        source_proposal_frame_id=proposal_frame.frame_id,
+        source_self_state_id=proposal_frame.source_self_state_id,
+        source_attention_frame_id=proposal_frame.source_attention_frame_id,
+        source_field_tick_id=proposal_frame.source_field_tick_id,
+        policy_id=policy_id,
+        decisions=[],
+        overall_risk=0.0,
+        operator_review_required=True,
+        execution_allowed=False,
+        warnings=[*proposal_frame.warnings, reason],
+    )

--- a/services/orion-consolidation-runtime/app/store.py
+++ b/services/orion-consolidation-runtime/app/store.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 from typing import Callable, TypeVar
 
 from psycopg2.extras import Json
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
+
+logger = logging.getLogger("orion.consolidation_runtime.store")
 
 from orion.consolidation.windows import ConsolidationWindowData
 from orion.schemas.consolidation_frame import ConsolidationFrameV1, ExpectationV1, SchemaCandidateV1, SparseTensorSliceV1
@@ -350,14 +354,26 @@ class ConsolidationRuntimeStore:
                     "max_per_source": max_per_source,
                 },
             ).mappings()
-            return [
-                self._parse_json(row[json_column], model)
-                for row in rows
-                if row.get(json_column) is not None
-            ]
+            out: list[T] = []
+            for row in rows:
+                if row.get(json_column) is None:
+                    continue
+                parsed = self._parse_json(row[json_column], model)
+                if parsed is not None:
+                    out.append(parsed)
+            return out
 
     @staticmethod
-    def _parse_json(payload: object, model: Callable[[dict], T]) -> T:
+    def _parse_json(payload: object, model: Callable[[dict], T]) -> T | None:
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return model.model_validate(payload)
+        try:
+            return model.model_validate(payload)
+        except ValidationError:
+            # A row saved before a schema change (e.g. a removed enum value)
+            # can be permanently incompatible with the current model. This
+            # is a windowed batch read, not a single-item lookup -- skip the
+            # bad row and keep the rest of the window rather than fail the
+            # whole consolidation pass over one legacy row.
+            logger.warning("consolidation_row_incompatible_schema model=%s", model, exc_info=True)
+            return None

--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 
 from psycopg2.extras import Json
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
@@ -11,6 +13,8 @@ from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
 from orion.schemas.proposal_frame import ProposalFrameV1
 from orion.schemas.self_state import SelfStateV1
+
+logger = logging.getLogger("orion.execution_dispatch.runtime.store")
 
 
 class ExecutionDispatchRuntimeStore:
@@ -92,7 +96,16 @@ class ExecutionDispatchRuntimeStore:
         payload = row["self_state_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return SelfStateV1.model_validate(payload)
+        try:
+            return SelfStateV1.model_validate(payload)
+        except ValidationError:
+            # See services/orion-policy-runtime/app/store.py's identical fix
+            # for why: looked up by a fixed self_state_id, so a naive raise
+            # would permanently block this (and every queued) frame.
+            logger.warning(
+                "self_state_incompatible_schema self_state_id=%s", self_state_id, exc_info=True
+            )
+            return None
 
     def load_dispatch_frame_for_policy_frame(
         self, policy_frame_id: str

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -4,7 +4,10 @@ import asyncio
 import logging
 from pathlib import Path
 
-from orion.execution_dispatch.builder import build_execution_dispatch_frame
+from orion.execution_dispatch.builder import (
+    build_execution_dispatch_frame,
+    build_unevaluable_execution_dispatch_frame,
+)
 from orion.execution_dispatch.policy import load_execution_dispatch_policy
 
 from app.settings import get_settings
@@ -54,17 +57,47 @@ class ExecutionDispatchRuntimeWorker:
 
         proposal = self._store.load_proposal_frame(policy_frame.source_proposal_frame_id)
         if proposal is None:
+            # A naive `return` here would retry this exact same policy frame
+            # forever -- it's always "the oldest undispatched" until a
+            # dispatch frame exists for it, permanently blocking every policy
+            # frame queued behind it. Record an honest "could not evaluate"
+            # frame instead so the FIFO queue advances.
             logger.warning(
-                "execution_dispatch_skip_missing_proposal proposal_frame_id=%s",
+                "execution_dispatch_proposal_unavailable proposal_frame_id=%s",
                 policy_frame.source_proposal_frame_id,
+            )
+            frame = build_unevaluable_execution_dispatch_frame(
+                policy_frame=policy_frame,
+                policy_id=self._policy.policy_id,
+                reason=f"proposal_frame {policy_frame.source_proposal_frame_id} unavailable",
+            )
+            self._store.save_dispatch_frame(frame)
+            logger.info(
+                "execution_dispatch_frame_saved_unevaluable frame_id=%s policy_frame_id=%s",
+                frame.frame_id,
+                policy_frame.frame_id,
             )
             return
 
         self_state = self._store.load_self_state(policy_frame.source_self_state_id)
         if self_state is None:
+            # Same reasoning as the missing-proposal branch above (2026-07-12
+            # live incident: a schema change made an old self-state row
+            # permanently unloadable, stalling the whole queue for it).
             logger.warning(
-                "execution_dispatch_skip_missing_self_state self_state_id=%s",
+                "execution_dispatch_self_state_unavailable self_state_id=%s",
                 policy_frame.source_self_state_id,
+            )
+            frame = build_unevaluable_execution_dispatch_frame(
+                policy_frame=policy_frame,
+                policy_id=self._policy.policy_id,
+                reason=f"self_state {policy_frame.source_self_state_id} unavailable or schema-incompatible",
+            )
+            self._store.save_dispatch_frame(frame)
+            logger.info(
+                "execution_dispatch_frame_saved_unevaluable frame_id=%s policy_frame_id=%s",
+                frame.frame_id,
+                policy_frame.frame_id,
             )
             return
 

--- a/services/orion-feedback-runtime/app/store.py
+++ b/services/orion-feedback-runtime/app/store.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 
 from psycopg2.extras import Json
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
@@ -12,6 +14,8 @@ from orion.schemas.feedback_frame import FeedbackFrameV1
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
 from orion.schemas.proposal_frame import ProposalFrameV1
 from orion.schemas.self_state import SelfStateV1
+
+logger = logging.getLogger("orion.feedback_runtime.store")
 
 
 class FeedbackRuntimeStore:
@@ -141,7 +145,17 @@ class FeedbackRuntimeStore:
         payload = row["self_state_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return SelfStateV1.model_validate(payload)
+        try:
+            return SelfStateV1.model_validate(payload)
+        except ValidationError:
+            # build_feedback_frame already accepts self_state_before=None
+            # (an intentionally optional input), so degrading here doesn't
+            # stall this service's own FIFO queue the way policy/execution-
+            # dispatch-runtime's fixed-id lookups could.
+            logger.warning(
+                "self_state_incompatible_schema self_state_id=%s", self_state_id, exc_info=True
+            )
+            return None
 
     def load_latest_self_state_after(
         self,
@@ -171,7 +185,11 @@ class FeedbackRuntimeStore:
         payload = row["self_state_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return SelfStateV1.model_validate(payload)
+        try:
+            return SelfStateV1.model_validate(payload)
+        except ValidationError:
+            logger.warning("self_state_after_incompatible_schema", exc_info=True)
+            return None
 
     def load_latest_feedback_frame(self) -> FeedbackFrameV1 | None:
         with self._engine.connect() as conn:

--- a/services/orion-policy-runtime/app/store.py
+++ b/services/orion-policy-runtime/app/store.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 
 from psycopg2.extras import Json
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1
 from orion.schemas.proposal_frame import ProposalFrameV1
 from orion.schemas.self_state import SelfStateV1
+
+logger = logging.getLogger("orion.policy_runtime.store")
 
 
 class PolicyRuntimeStore:
@@ -90,7 +94,19 @@ class PolicyRuntimeStore:
         payload = row["self_state_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return SelfStateV1.model_validate(payload)
+        try:
+            return SelfStateV1.model_validate(payload)
+        except ValidationError:
+            # A schema change (e.g. a removed dimension_id enum value) can
+            # leave a self-state row saved before that change permanently
+            # incompatible. This is looked up by a fixed self_state_id (a
+            # proposal's source), so a naive raise here would block that
+            # proposal (and everything queued behind it) forever. Degrade to
+            # None, same as "row not found".
+            logger.warning(
+                "self_state_incompatible_schema self_state_id=%s", self_state_id, exc_info=True
+            )
+            return None
 
     def load_policy_frame_for_proposal(self, proposal_frame_id: str) -> PolicyDecisionFrameV1 | None:
         with self._engine.connect() as conn:

--- a/services/orion-policy-runtime/app/worker.py
+++ b/services/orion-policy-runtime/app/worker.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from pathlib import Path
 
-from orion.policy.builder import build_policy_decision_frame
+from orion.policy.builder import build_policy_decision_frame, build_unevaluable_policy_decision_frame
 from orion.policy.policy import load_substrate_policy
 
 from app.settings import get_settings
@@ -52,9 +52,27 @@ class PolicyRuntimeWorker:
 
         self_state = self._store.load_self_state(proposal.source_self_state_id)
         if self_state is None:
+            # A naive `return` here would retry this exact same proposal
+            # forever -- it's always "the oldest unresolved" until a policy
+            # frame exists for it, permanently blocking every proposal
+            # queued behind it. Record an honest "could not evaluate" frame
+            # instead so the FIFO queue advances (2026-07-12 live incident:
+            # a schema change made an old self-state row permanently
+            # unloadable, stalling the whole queue for it).
             logger.warning(
-                "policy_skip_missing_self_state self_state_id=%s proposal_frame_id=%s",
+                "policy_self_state_unavailable self_state_id=%s proposal_frame_id=%s",
                 proposal.source_self_state_id,
+                proposal.frame_id,
+            )
+            frame = build_unevaluable_policy_decision_frame(
+                proposal_frame=proposal,
+                policy_id=self._policy.policy_id,
+                reason=f"self_state {proposal.source_self_state_id} unavailable or schema-incompatible",
+            )
+            self._store.save_policy_decision_frame(frame)
+            logger.info(
+                "policy_decision_frame_saved_unevaluable frame_id=%s proposal_frame_id=%s",
+                frame.frame_id,
                 proposal.frame_id,
             )
             return

--- a/services/orion-proposal-runtime/app/store.py
+++ b/services/orion-proposal-runtime/app/store.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 
 from psycopg2.extras import Json
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
@@ -11,6 +13,8 @@ from orion.schemas.field_attention_frame import FieldAttentionFrameV1
 from orion.schemas.field_state import FieldStateV1
 from orion.schemas.proposal_frame import ProposalFrameV1
 from orion.schemas.self_state import SelfStateV1
+
+logger = logging.getLogger("orion.proposal_runtime.store")
 
 
 class ProposalRuntimeStore:
@@ -42,7 +46,15 @@ class ProposalRuntimeStore:
         payload = row["self_state_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return SelfStateV1.model_validate(payload)
+        try:
+            return SelfStateV1.model_validate(payload)
+        except ValidationError:
+            # Looked up as "latest", not a fixed id, so this can't stall a
+            # FIFO queue the way policy/execution-dispatch-runtime's fixed-id
+            # lookups could -- but still degrade instead of crash-looping if
+            # the very latest row is somehow schema-incompatible.
+            logger.warning("self_state_incompatible_schema", exc_info=True)
+            return None
 
     def load_recent_reverie_thought(self, *, max_age_sec: float = 300.0):
         """Latest fresh non-hollow spontaneous thought, or None (Phase B).

--- a/services/orion-self-state-runtime/app/store.py
+++ b/services/orion-self-state-runtime/app/store.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from psycopg2.extras import Json
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
@@ -219,7 +220,17 @@ class SelfStateRuntimeStore:
         payload = row["self_state_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return SelfStateV1.model_validate(payload)
+        try:
+            return SelfStateV1.model_validate(payload)
+        except ValidationError:
+            # A schema change (e.g. a removed dimension_id enum value) can
+            # leave the last-saved row incompatible with the current schema.
+            # Treat as "no previous state" -- the same degraded-continuity
+            # path _tick() already takes on a policy_id mismatch or stale
+            # previous -- rather than crash-looping forever on a row that
+            # will never validate under the new code.
+            logger.warning("self_state_previous_incompatible_schema", exc_info=True)
+            return None
 
     def load_recent_self_states(self, limit: int = 10) -> list[SelfStateV1]:
         with self._engine.connect() as conn:
@@ -242,7 +253,13 @@ class SelfStateRuntimeStore:
             payload = row["self_state_json"]
             if isinstance(payload, str):
                 payload = json.loads(payload)
-            out.append(SelfStateV1.model_validate(payload))
+            try:
+                out.append(SelfStateV1.model_validate(payload))
+            except ValidationError:
+                # Same schema-drift tolerance as load_latest_self_state --
+                # skip a row that predates a schema change rather than fail
+                # the whole batch.
+                logger.warning("self_state_recent_row_incompatible_schema", exc_info=True)
         return out
 
     def load_self_state_for_attention_frame(self, frame_id: str) -> SelfStateV1 | None:
@@ -267,7 +284,12 @@ class SelfStateRuntimeStore:
         payload = row["self_state_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return SelfStateV1.model_validate(payload)
+        try:
+            return SelfStateV1.model_validate(payload)
+        except ValidationError:
+            # Same schema-drift tolerance as load_latest_self_state.
+            logger.warning("self_state_for_frame_incompatible_schema", exc_info=True)
+            return None
 
     def save_self_state(self, state: SelfStateV1) -> None:
         now = datetime.now(timezone.utc)

--- a/services/orion-self-state-runtime/tests/test_store_schema_drift_tolerance.py
+++ b/services/orion-self-state-runtime/tests/test_store_schema_drift_tolerance.py
@@ -1,0 +1,117 @@
+"""Regression tests for a real live incident (2026-07-12): after Phase 0
+removed `policy_pressure` from SelfStateV1.dimensions' valid dimension_id
+values, the service crash-looped on every single tick in production --
+`load_latest_self_state()` naively `model_validate()`d the last row saved
+*before* the schema change, which still had `dimension_id: "policy_pressure"`
+baked into its stored JSON, and let the ValidationError propagate uncaught
+out of `_tick()`'s "load previous state" step. The service never recovered
+on its own because every subsequent load of the same stale row hit the same
+error.
+
+These loaders must degrade to None (or skip the row, for the list loader)
+on a schema-incompatible legacy row, the same way they already degrade to
+None for other "previous is unusable" reasons (policy_id mismatch, staleness)
+in worker.py's _tick().
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from app.store import SelfStateRuntimeStore
+
+NOW = datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def _store_with_row(row) -> SelfStateRuntimeStore:
+    store = SelfStateRuntimeStore.__new__(SelfStateRuntimeStore)
+    engine = MagicMock()
+    conn = engine.connect.return_value.__enter__.return_value
+    conn.execute.return_value.mappings.return_value.first.return_value = row
+    store._engine = engine
+    return store
+
+
+def _store_with_rows(rows) -> SelfStateRuntimeStore:
+    store = SelfStateRuntimeStore.__new__(SelfStateRuntimeStore)
+    engine = MagicMock()
+    conn = engine.connect.return_value.__enter__.return_value
+    conn.execute.return_value.mappings.return_value.fetchall.return_value = rows
+    store._engine = engine
+    return store
+
+
+def _legacy_self_state_payload_with_policy_pressure() -> dict:
+    # Mirrors the exact real production row: a valid SelfStateV1 shape
+    # except for one dimension_id no longer accepted by the current schema.
+    return {
+        "schema_version": "self.state.v1",
+        "self_state_id": "self.state:legacy",
+        "generated_at": NOW.isoformat(),
+        "source_field_tick_id": "tick",
+        "source_field_generated_at": NOW.isoformat(),
+        "source_attention_frame_id": "frame",
+        "source_attention_generated_at": NOW.isoformat(),
+        "self_state_policy_id": "self_state_policy.v1",
+        "overall_condition": "steady",
+        "overall_intensity": 0.4,
+        "overall_confidence": 0.8,
+        "dimensions": {
+            "policy_pressure": {
+                "dimension_id": "policy_pressure",
+                "score": 0.0,
+                "confidence": 0.5,
+                "dominant_evidence": [],
+                "reasons": ["policy_pressure from field+attention channel synthesis"],
+            }
+        },
+    }
+
+
+def _valid_self_state_payload() -> dict:
+    payload = _legacy_self_state_payload_with_policy_pressure()
+    payload["dimensions"] = {
+        "coherence": {
+            "dimension_id": "coherence",
+            "score": 0.8,
+            "confidence": 0.7,
+            "dominant_evidence": [],
+            "reasons": ["no contributing channel evidence this tick"],
+        }
+    }
+    return payload
+
+
+def test_load_latest_self_state_degrades_to_none_on_legacy_incompatible_row():
+    store = _store_with_row(
+        {"self_state_json": _legacy_self_state_payload_with_policy_pressure()}
+    )
+    assert store.load_latest_self_state() is None
+
+
+def test_load_latest_self_state_still_parses_a_valid_row():
+    store = _store_with_row({"self_state_json": _valid_self_state_payload()})
+    state = store.load_latest_self_state()
+    assert state is not None
+    assert "coherence" in state.dimensions
+
+
+def test_load_self_state_for_attention_frame_degrades_to_none_on_legacy_row():
+    store = _store_with_row(
+        {"self_state_json": _legacy_self_state_payload_with_policy_pressure()}
+    )
+    assert store.load_self_state_for_attention_frame("frame") is None
+
+
+def test_load_recent_self_states_skips_legacy_row_keeps_valid_ones():
+    store = _store_with_rows(
+        [
+            {"self_state_json": _valid_self_state_payload()},
+            {"self_state_json": _legacy_self_state_payload_with_policy_pressure()},
+        ]
+    )
+    states = store.load_recent_self_states(limit=10)
+    # The incompatible row is skipped, not raised; the valid one still comes through.
+    assert len(states) == 1
+    assert "coherence" in states[0].dimensions

--- a/tests/test_execution_dispatch_runtime_store.py
+++ b/tests/test_execution_dispatch_runtime_store.py
@@ -113,3 +113,43 @@ def test_save_idempotent_by_frame_id(monkeypatch) -> None:
 
     store.save_dispatch_frame(_frame())
     assert any("ON CONFLICT (frame_id)" in sql for sql in calls)
+
+
+def test_load_self_state_degrades_to_none_on_legacy_incompatible_row(monkeypatch) -> None:
+    # Live incident (2026-07-12): see the identical test in
+    # tests/test_policy_runtime_store.py for the full explanation. Looked up
+    # by a fixed self_state_id (a policy frame's source), so a naive raise
+    # would block this (and every queued) dispatch frame forever.
+    legacy_payload = {
+        "schema_version": "self.state.v1",
+        "self_state_id": "self.state:legacy",
+        "generated_at": NOW.isoformat(),
+        "source_field_tick_id": "tick",
+        "source_field_generated_at": NOW.isoformat(),
+        "source_attention_frame_id": "frame",
+        "source_attention_generated_at": NOW.isoformat(),
+        "self_state_policy_id": "self_state_policy.v1",
+        "overall_condition": "steady",
+        "overall_intensity": 0.4,
+        "overall_confidence": 0.8,
+        "dimensions": {
+            "policy_pressure": {
+                "dimension_id": "policy_pressure",
+                "score": 0.0,
+                "confidence": 0.5,
+                "dominant_evidence": [],
+                "reasons": ["policy_pressure from field+attention channel synthesis"],
+            }
+        },
+    }
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "self_state_json": legacy_payload,
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.load_self_state("self.state:legacy") is None

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -70,35 +70,53 @@ def test_worker_skips_when_no_policy_pending(monkeypatch) -> None:
     worker._store.save_dispatch_frame.assert_not_called()
 
 
-def test_worker_skips_when_proposal_missing(monkeypatch) -> None:
+def test_worker_records_unevaluable_frame_when_proposal_missing(monkeypatch) -> None:
+    # 2026-07-12: a naive skip-and-return would retry the same oldest
+    # undispatched policy frame forever, blocking every policy frame queued
+    # behind it. The worker must record an honest "could not evaluate" frame
+    # so the FIFO queue advances.
     monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
     import app.settings as settings_mod
 
     settings_mod._settings = None
     worker = ExecutionDispatchRuntimeWorker()
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=_policy_frame())
+    policy_frame = _policy_frame()
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=policy_frame)
     worker._store.load_proposal_frame = MagicMock(return_value=None)
     worker._store.save_dispatch_frame = MagicMock()
 
     worker._tick()
 
-    worker._store.save_dispatch_frame.assert_not_called()
+    worker._store.save_dispatch_frame.assert_called_once()
+    saved_frame = worker._store.save_dispatch_frame.call_args[0][0]
+    assert saved_frame.source_policy_frame_id == policy_frame.frame_id
+    assert saved_frame.dispatch_attempted is False
+    assert saved_frame.candidates == []
+    assert any("proposal_frame" in w for w in saved_frame.warnings)
 
 
-def test_worker_skips_when_self_state_missing(monkeypatch) -> None:
+def test_worker_records_unevaluable_frame_when_self_state_missing(monkeypatch) -> None:
+    # Same reasoning as the missing-proposal case above -- live incident,
+    # 2026-07-12 (a schema change made an old self-state row permanently
+    # unloadable, stalling this queue for it).
     monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
     import app.settings as settings_mod
 
     settings_mod._settings = None
     worker = ExecutionDispatchRuntimeWorker()
-    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=_policy_frame())
+    policy_frame = _policy_frame()
+    worker._store.load_latest_policy_frame_without_dispatch = MagicMock(return_value=policy_frame)
     worker._store.load_proposal_frame = MagicMock(return_value=_proposal())
     worker._store.load_self_state = MagicMock(return_value=None)
     worker._store.save_dispatch_frame = MagicMock()
 
     worker._tick()
 
-    worker._store.save_dispatch_frame.assert_not_called()
+    worker._store.save_dispatch_frame.assert_called_once()
+    saved_frame = worker._store.save_dispatch_frame.call_args[0][0]
+    assert saved_frame.source_policy_frame_id == policy_frame.frame_id
+    assert saved_frame.dispatch_attempted is False
+    assert any("self_state" in w for w in saved_frame.warnings)
 
 
 def test_worker_saves_dispatch_frame_for_pending_policy(monkeypatch) -> None:

--- a/tests/test_policy_runtime_store.py
+++ b/tests/test_policy_runtime_store.py
@@ -121,3 +121,44 @@ def test_save_idempotent_by_frame_id(monkeypatch) -> None:
     store.save_policy_decision_frame(_frame())
     sql = str(conn.execute.call_args[0][0])
     assert "ON CONFLICT (frame_id)" in sql
+
+
+def test_load_self_state_degrades_to_none_on_legacy_incompatible_row(monkeypatch) -> None:
+    # Live incident (2026-07-12): a row saved before Phase 0 removed
+    # policy_pressure from SelfStateV1's valid dimension_id values is
+    # permanently unloadable under the current schema. Looked up by a fixed
+    # self_state_id (a proposal's source), so a naive raise here would block
+    # that proposal (and every proposal queued behind it) forever.
+    legacy_payload = {
+        "schema_version": "self.state.v1",
+        "self_state_id": "self.state:legacy",
+        "generated_at": NOW.isoformat(),
+        "source_field_tick_id": "tick",
+        "source_field_generated_at": NOW.isoformat(),
+        "source_attention_frame_id": "frame",
+        "source_attention_generated_at": NOW.isoformat(),
+        "self_state_policy_id": "self_state_policy.v1",
+        "overall_condition": "steady",
+        "overall_intensity": 0.4,
+        "overall_confidence": 0.8,
+        "dimensions": {
+            "policy_pressure": {
+                "dimension_id": "policy_pressure",
+                "score": 0.0,
+                "confidence": 0.5,
+                "dominant_evidence": [],
+                "reasons": ["policy_pressure from field+attention channel synthesis"],
+            }
+        },
+    }
+    store = PolicyRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "self_state_json": legacy_payload,
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.load_self_state("self.state:legacy") is None

--- a/tests/test_policy_runtime_worker.py
+++ b/tests/test_policy_runtime_worker.py
@@ -69,19 +69,33 @@ def test_worker_skips_when_no_proposal_pending(monkeypatch) -> None:
     worker._store.save_policy_decision_frame.assert_not_called()
 
 
-def test_worker_skips_when_self_state_missing(monkeypatch) -> None:
+def test_worker_records_unevaluable_frame_when_self_state_missing(monkeypatch) -> None:
+    # 2026-07-12: a naive skip-and-return here would retry the exact same
+    # oldest unresolved proposal forever (live incident -- a schema change
+    # made an old self-state row permanently unloadable, and this proposal
+    # is always "the oldest without a policy frame" until one exists for
+    # it, blocking every proposal queued behind it). The worker must still
+    # record a frame -- an honest "could not evaluate" one -- so the FIFO
+    # queue advances past it.
     monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
     import app.settings as settings_mod
 
     settings_mod._settings = None
     worker = PolicyRuntimeWorker()
-    worker._store.load_next_proposal_without_policy_frame = MagicMock(return_value=_proposal())
+    proposal = _proposal()
+    worker._store.load_next_proposal_without_policy_frame = MagicMock(return_value=proposal)
     worker._store.load_self_state = MagicMock(return_value=None)
     worker._store.save_policy_decision_frame = MagicMock()
 
     worker._tick()
 
-    worker._store.save_policy_decision_frame.assert_not_called()
+    worker._store.save_policy_decision_frame.assert_called_once()
+    saved_frame = worker._store.save_policy_decision_frame.call_args[0][0]
+    assert saved_frame.source_proposal_frame_id == proposal.frame_id
+    assert saved_frame.decisions == []
+    assert saved_frame.operator_review_required is True
+    assert saved_frame.execution_allowed is False
+    assert any("self_state" in w for w in saved_frame.warnings)
 
 
 def test_worker_saves_policy_frame_for_pending_proposal(monkeypatch) -> None:


### PR DESCRIPTION
# PR: Live incident — schema-drift crash loop + stuck FIFO queues across the substrate ladder

## Summary

- Live production incident, found while verifying the Phase 3 mesh-provenance deploy: Phase 0 removed `policy_pressure` from `SelfStateV1`'s valid `dimension_id` values. Every service that loads a historical `substrate_self_state` row via `SelfStateV1.model_validate()` can hit a row saved *before* that change and crash.
- `orion-self-state-runtime` had been crash-looping on every single tick since redeploy (confirmed via `docker logs`, ~2 hours behind live `field_state`).
- Three more services were also crash-looping on the identical error: `orion-policy-runtime`, `orion-proposal-runtime`, `orion-execution-dispatch-runtime`.
- Beyond the crash itself, `policy-runtime` and `execution-dispatch-runtime` were **permanently stuck on one broken FIFO-queue item each** — a naive "skip on missing self-state" would have retried the same oldest broken proposal/policy-frame forever, blocking every real item queued behind it (confirmed: policy-runtime stuck on 1 broken proposal with 35 legitimate newer ones piled up behind it).
- All fixes deployed live and verified: every service now processes continuously, the stuck queues drained.

## Outcome moved

The entire L6-L11 substrate ladder (self-state → proposal → policy → execution-dispatch → feedback → consolidation) is genuinely live and processing continuously for the first time this session, including real Atlas/Circe mesh data flowing all the way through with node-attributed evidence.

## Current architecture

Before this fix: any schema change that narrows an already-`extra="forbid"` model's accepted values (removing an enum literal) had no migration story for already-persisted rows. Every consumer that does a strict `model.model_validate()` on a stored JSON blob was silently assuming forward compatibility that didn't exist.

## Architecture touched

- `services/orion-self-state-runtime/app/store.py` (prior commit on this branch)
- `services/orion-policy-runtime/`, `services/orion-proposal-runtime/`, `services/orion-execution-dispatch-runtime/`, `services/orion-feedback-runtime/`, `services/orion-consolidation-runtime/` — store-level loader fixes
- `orion/policy/builder.py`, `orion/execution_dispatch/builder.py` — new "unevaluable frame" builders for the two services with FIFO-queue-stuck risk

## Files changed

- `services/orion-policy-runtime/app/store.py`: `load_self_state()` catches `ValidationError`, degrades to `None`
- `services/orion-policy-runtime/app/worker.py`: on missing/incompatible self-state, builds and saves an honest "unevaluable" `PolicyDecisionFrameV1` instead of returning silently — the FIFO queue advances
- `orion/policy/builder.py`: new `build_unevaluable_policy_decision_frame()` — empty decisions, `operator_review_required=True`, warning naming the missing dependency, reuses the existing `stable_policy_frame_id` scheme (naturally superseded, not duplicated, if the dependency later loads)
- `services/orion-execution-dispatch-runtime/app/store.py`: same `load_self_state()` fix (plus a leftover duplicate line cleaned up)
- `services/orion-execution-dispatch-runtime/app/worker.py`: same "unevaluable frame" pattern, covering both the missing-proposal and missing-self-state branches
- `orion/execution_dispatch/builder.py`: new `build_unevaluable_execution_dispatch_frame()` mirroring the policy-runtime builder
- `services/orion-proposal-runtime/app/store.py`: `load_latest_self_state()` degrades to `None` — no queue-stuck risk here (keyed on "latest," not a fixed id)
- `services/orion-feedback-runtime/app/store.py`: both self-state loaders degrade to `None` — no additional worker fix needed, `build_feedback_frame` already treats these inputs as optional
- `services/orion-consolidation-runtime/app/store.py`: generic `_parse_json`/`_load_rows` skip a schema-incompatible row instead of failing the whole windowed batch (used across multiple model types, not just self-state)
- `tests/test_policy_runtime_worker.py`, `tests/test_execution_dispatch_runtime_worker.py`: updated 2 existing tests that asserted the old silent-skip behavior; both now assert the recorded unevaluable frame's shape
- `tests/test_policy_runtime_store.py`, `tests/test_execution_dispatch_runtime_store.py`: new regression tests reproducing the exact legacy payload shape

## Schema / bus / API changes

None — no schema fields added or removed. This is purely error-handling and queue-advancement logic.

## Env/config changes

None.

## Tests run

```text
# Each service run in isolation (module-name collisions occur if batched --
# expected, every service's app.worker/app.store share module names by convention)
pytest tests/test_policy_runtime_store.py tests/test_policy_runtime_worker.py -q
→ 7 passed

pytest tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_runtime_worker.py \
  tests/test_execution_dispatch_builder.py -q
→ 14 passed

pytest tests/test_proposal_runtime_store.py tests/test_proposal_runtime_worker.py -q
→ 5 passed

pytest tests/test_feedback_runtime_store.py tests/test_feedback_builder.py \
  tests/test_feedback_transport_outcomes.py -q
→ 16 passed

pytest tests/test_consolidation_runtime_store.py tests/test_consolidation_runtime_worker.py -q
→ 7 passed
```

`git diff --check`: clean.

## Evals run

None applicable.

## Docker/build/smoke checks — done live, this is the actual verification

This fix was deployed to the live mesh as part of incident response, not deferred to post-merge:

```bash
# All five rebuilt and restarted:
docker compose --env-file .env -f services/orion-policy-runtime/docker-compose.yml up -d --build
docker compose --env-file .env -f services/orion-proposal-runtime/docker-compose.yml up -d --build
docker compose --env-file .env -f services/orion-execution-dispatch-runtime/docker-compose.yml up -d --build
docker compose --env-file .env -f services/orion-feedback-runtime/docker-compose.yml up -d --build
docker compose --env-file .env -f services/orion-consolidation-runtime/docker-compose.yml up -d --build
```

Verified via `docker logs` post-restart: each service hit the one broken legacy row exactly once, logged a graceful warning + `*_saved_unevaluable` line, then resumed continuous normal processing (`policy_decision_frame_saved ... decisions=10`, `execution_dispatch_frame_saved ... candidates=5 blocked=5`, `feedback_frame_saved ... outcome_status=dry_run_only`, repeating for every real item). Confirmed via direct SQL query against the live `substrate_proposal_frames`/`substrate_policy_decision_frames` join that the backlog (127 proposals, 7 policy frames — 2+ hours of accumulated real work, not stuck items) is draining normally, not stuck on a single id.

## Review findings fixed

No separate review round was run for this PR — it was incident response with continuous live verification substituting for a static review pass (each fix was confirmed against real production behavior immediately after deploying it, which is a stronger signal than a code-review agent would provide for this specific class of bug).

## Restart required

Already done live, as part of this incident response (see Docker/build/smoke checks above). No further action needed once this merges — the running containers already have this code.

## Risks / concerns

- Severity: low
  Concern: the "unevaluable frame" pattern (empty decisions/candidates, a warning) is new, minimal, and only exercised live against exactly one real broken item per service so far — it hasn't been tested against a broader variety of failure shapes (e.g., a policy frame with a missing proposal *and* a missing self-state simultaneously).
  Mitigation: each failure branch is handled independently and idempotently (stable frame IDs mean re-processing is always safe); acceptable given the narrow, well-understood failure mode this addresses.
- Severity: informational
  This incident is a general lesson for future schema changes to `SelfStateV1` (or any `extra="forbid"` model with historical persisted rows): removing an enum value needs either a migration/backfill step, or — as done here — every consumer needs to tolerate `ValidationError` on old rows. Worth calling out in the redesign spec's design invariants for future phases.