### PR TITLE
Feat/phase4 drive pressure measurement

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-12-phase4-drive-pressure-measurement-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-phase4-drive-pressure-measurement-pr.md
@@ -1,0 +1,78 @@
+# PR: Phase 4 — DriveEngine vs AutonomyStateV2 pressure measurement probes
+
+## Summary
+
+- Measurement-only, log-only instrumentation (no schema change, no behavior change) comparing `DriveEngine`'s and `AutonomyStateV2`'s independently-computed drive-pressure vectors, per `docs/superpowers/plans/2026-07-12-self-state-mesh-substrate-redesign.md`'s Phase 4 ("Drive unification") first step: "log side-by-side on the same live traffic window... before deciding merge vs. keep-separate."
+- Both computations key off the same six-drive taxonomy (`coherence, continuity, capability, relational, predictive, autonomy`) but are fed by completely different inputs (`DriveEngine`: self-state tensions + biometrics via `orion/spark/concept_induction/bus_worker.py`; `AutonomyStateV2`: chat-turn evidence only, via `services/orion-cortex-exec/app/chat_stance.py`, test-banned from touching self-state) — this is the first time either has been directly comparable.
+
+## Outcome moved
+
+The merge-vs-keep-separate decision from the redesign spec can now be made from real correlated data (grep both services' logs, join on `subject` + nearby timestamp) instead of the assumption either direction currently rests on.
+
+## Architecture touched
+
+- `orion/spark/concept_induction/bus_worker.py`
+- `services/orion-cortex-exec/app/chat_stance.py`
+
+## Files changed
+
+- `orion/spark/concept_induction/bus_worker.py`: new `_log_drive_pressure_probe(self, subject, pressures)`, try/except-guarded (never breaks the drive-update rail, which runs on live bus traffic), called right after both `save_drive_state` call sites (~line 745, ~874)
+- `services/orion-cortex-exec/app/chat_stance.py`: new module-level `_log_autonomy_pressure_probe(subject, pressures)`, same guard pattern, called right after `_run_autonomy_reducer`'s existing `save_autonomy_state_v2` try/except (mirrors that block's defensive style directly)
+- `orion/spark/concept_induction/tests/test_drive_pressure_probe.py`: new, 5 tests (helper behavior, both call sites, never-raises for each)
+- `services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_pressure_probe.py`: new, 4 tests (probe fires with correct subject/pressures, pressures match the folded state exactly, never-raises through the full call path and directly on the helper)
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+pytest orion/spark/concept_induction/tests/ -q
+→ 119 passed (114 pre-existing + 5 new)
+
+pytest services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_pressure_probe.py -q
+→ 4 passed
+```
+
+Both verified directly by the orchestrator (not just the implementing agent) on the actual committed branch. `git diff --check`: clean.
+
+Note: a broader `-k autonomy_v2`/`-k chat_stance` sweep across the whole `services/orion-cortex-exec/tests/` directory shows pre-existing collection errors (`ValueError: Verb already registered: legacy.plan`) and 2 pre-existing test failures unrelated to this change — confirmed present on `main` with this patch fully reverted, not introduced here.
+
+## Evals run
+
+None applicable — pure logging instrumentation.
+
+## Docker/build/smoke checks
+
+Not run this session. Restart commands below for when this merges.
+
+## Review findings fixed
+
+No dedicated code-review round for this PR — small, self-contained, measurement-only addition following an already-established pattern (mirrors `orion-self-state-runtime`'s Phase 2 deviation-probe logging exactly in style and defensive guarding). Verified directly instead: read both diffs in full, confirmed the try/except placement matches the existing defensive pattern immediately above each new call site, ran both test suites myself.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
+  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build
+
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: low
+  Concern: this is pure `logger.info` output on hot paths (every accepted bus event for `DriveEngine`, every chat turn for `AutonomyStateV2`) — adds log volume with no way to disable short of a redeploy, matching the same tradeoff already accepted for Phase 2's deviation probe (no feature flag was added there either, by the same reasoning: cheap, in-memory, fail-open).
+  Mitigation: none needed yet; add a settings flag if it proves noisy in practice, same escalation path as Phase 2.
+- Severity: informational
+  This PR only produces the *data*; it does not decide merge-vs-keep-separate. That decision is Phase 4's next step, gated on actually collecting and comparing a real traffic window's worth of both logs.
+
+## PR link
+
+<!-- filled in after push -->

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -545,6 +545,24 @@ class ConceptWorker:
         )
         return True
 
+    def _log_drive_pressure_probe(self, subject: str, pressures: dict) -> None:
+        """Measurement-only (Phase 4, 2026-07-12): log `DriveEngine`'s pressure
+        vector right after every `save_drive_state` so it can be compared
+        offline against `AutonomyStateV2`'s independently-computed pressures
+        (logged from `chat_stance._run_autonomy_reducer`) by grepping both
+        services' logs and correlating on `subject` + nearby timestamp. Never
+        raises: a logging failure here must not break the drive-update rail,
+        which runs on live bus traffic.
+        """
+        try:
+            logger.info(
+                "drive_engine_pressure_probe subject=%s pressures=%s",
+                subject,
+                {k: round(v, 4) for k, v in dict(pressures or {}).items()},
+            )
+        except Exception:
+            logger.warning("drive_engine_pressure_probe_failed subject=%s", subject, exc_info=True)
+
     async def _publish_drive_state(self, payload, corr_id) -> None:
         env = BaseEnvelope(
             kind="memory.drives.state.v1",
@@ -724,6 +742,7 @@ class ConceptWorker:
             self.store.save_drive_state(
                 subject, pressures=pressures, activations=activations, updated_at=now
             )
+            self._log_drive_pressure_probe(subject, pressures)
 
             trace_id = extract_trace_id(env)
             turn_id = extract_turn_id(env)
@@ -852,6 +871,7 @@ class ConceptWorker:
             previous_ts=previous_ts,
         )
         self.store.save_drive_state(subject, pressures=pressures, activations=activations, updated_at=now)
+        self._log_drive_pressure_probe(subject, pressures)
 
         pressure_tensions = derive_pressure_competition_tensions(
             envelope=env,

--- a/orion/spark/concept_induction/tests/test_drive_pressure_probe.py
+++ b/orion/spark/concept_induction/tests/test_drive_pressure_probe.py
@@ -1,0 +1,205 @@
+"""Unit tests for the Phase 4 drive-pressure measurement probe (2026-07-12).
+
+Measurement-only: logs `DriveEngine`'s pressure vector right after every
+`save_drive_state` call so it can be compared offline (by grepping logs and
+correlating on subject + nearby timestamp) against `AutonomyStateV2`'s
+independently-computed pressures, logged from
+`services/orion-cortex-exec/app/chat_stance.py`'s `_run_autonomy_reducer`.
+No schema change, no behavior change -- see
+docs/superpowers/plans/2026-07-12-self-state-mesh-substrate-redesign.md Phase 4.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.signals.models import OrganClass, OrionSignalV1
+from orion.spark.concept_induction.bus_worker import ConceptWorker
+from orion.spark.concept_induction.settings import ConceptSettings
+
+LOGGER_NAME = "orion.spark.concept.worker"
+
+
+def _signal_env(kind: str, dims: dict, *, channel_kind: str = "signal.biometrics.biometrics_state") -> BaseEnvelope:
+    now = datetime.now(timezone.utc)
+    sig = OrionSignalV1(
+        signal_id=str(uuid4()), organ_id="biometrics", organ_class=OrganClass.exogenous,
+        signal_kind=kind, dimensions=dims, source_event_id="src-1",
+        observed_at=now, emitted_at=now,
+    )
+    return BaseEnvelope(
+        id=uuid4(), kind=channel_kind, correlation_id=uuid4(), created_at=now,
+        source=ServiceRef(name="orion-signal-gateway", version="0.1.0", node="athena"),
+        payload=sig.model_dump(mode="json"),
+    )
+
+
+def _world_pulse_envelope() -> BaseEnvelope:
+    now = datetime(2026, 7, 6, 12, 0, tzinfo=timezone.utc)
+    return BaseEnvelope(
+        id=uuid4(),
+        kind="world.pulse.run.result.v1",
+        correlation_id=uuid4(),
+        created_at=now,
+        source=ServiceRef(name="orion-world-pulse", version="0.1.0", node="athena"),
+        payload={
+            "run": {
+                "run_id": "wp-run-probe",
+                "date": "2026-07-06",
+                "started_at": now.isoformat(),
+                "completed_at": now.isoformat(),
+                "status": "completed",
+                "dry_run": False,
+            },
+            "digest": {
+                "run_id": "wp-run-probe",
+                "date": "2026-07-06",
+                "generated_at": now.isoformat(),
+                "title": "t",
+                "executive_summary": "e",
+                "sections": {},
+                "items": [],
+                "orion_analysis_layer": "deterministic",
+                "coverage_status": "sparse",
+                "section_rollups": [],
+                "created_at": now.isoformat(),
+            },
+        },
+    )
+
+
+def _worker() -> ConceptWorker:
+    worker = ConceptWorker(ConceptSettings())
+    worker.store = MagicMock()
+    worker.store.load_drive_state.return_value = {}
+    worker.store.save_drive_state = MagicMock()
+    worker._publish_tension_event = AsyncMock(return_value=None)
+    worker._publish_drive_state = AsyncMock(return_value=None)
+    worker._publish_artifact = AsyncMock(return_value=None)
+    worker._publish_dossier = AsyncMock(return_value=None)
+    return worker
+
+
+def _probe_records(caplog) -> list:
+    return [r for r in caplog.records if r.message.startswith("drive_engine_pressure_probe")]
+
+
+def test_log_drive_pressure_probe_logs_subject_and_pressures(caplog) -> None:
+    worker = _worker()
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        worker._log_drive_pressure_probe("orion", {"coherence": 0.50001, "continuity": 0.2})
+
+    records = _probe_records(caplog)
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "orion" in msg
+    assert "coherence" in msg
+    assert "0.5" in msg  # rounded to 4dp, confirms the value round-trips through the log
+
+
+def test_log_drive_pressure_probe_never_raises_on_logging_failure(caplog) -> None:
+    worker = _worker()
+    import orion.spark.concept_induction.bus_worker as bus_worker_mod
+
+    class _ExplodingLogger:
+        def info(self, *_a, **_kw):
+            raise RuntimeError("boom")
+
+        def warning(self, *args, **kwargs):
+            logging.getLogger(LOGGER_NAME).warning(*args, **kwargs)
+
+    original_logger = bus_worker_mod.logger
+    bus_worker_mod.logger = _ExplodingLogger()
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            # Must not raise.
+            worker._log_drive_pressure_probe("orion", {"coherence": 0.5})
+    finally:
+        bus_worker_mod.logger = original_logger
+
+    assert any("drive_engine_pressure_probe_failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_signal_drive_tick_call_site_logs_probe(caplog) -> None:
+    """Call site 1 (~line 717, _handle_signal_drive_tick via handle_envelope)."""
+    worker = _worker()
+
+    # Warm the deviation baseline with steady hrv, then a real drop -- same
+    # warm-up pattern as test_signal_drive_consumer.py's homeostatic tests.
+    for _ in range(30):
+        await worker.handle_envelope(
+            _signal_env("biometrics_state", {"hrv_level": 0.8, "confidence": 0.9}),
+            "orion:signals:biometrics",
+        )
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        await worker.handle_envelope(
+            _signal_env("biometrics_state", {"hrv_level": 0.4, "confidence": 0.9}),
+            "orion:signals:biometrics",
+        )
+
+    worker.store.save_drive_state.assert_called()
+    records = _probe_records(caplog)
+    assert len(records) == 1
+    assert "orion" in records[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_handle_envelope_call_site_logs_probe(caplog) -> None:
+    """Call site 2 (~line 847, handle_envelope's non-homeostatic drive-update rail)."""
+    worker = _worker()
+    worker.drive_engine.update = MagicMock(
+        return_value=({"predictive": 0.6001, "coherence": 0.5}, {"predictive": True})
+    )
+    worker.goal_engine.propose = MagicMock(return_value=MagicMock(proposal=None, suppressed_signature=None))
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        await worker.handle_envelope(_world_pulse_envelope(), "orion:world_pulse:run:result")
+
+    worker.store.save_drive_state.assert_called_once()
+    records = _probe_records(caplog)
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "orion" in msg
+    assert "predictive" in msg
+    assert "0.6" in msg
+
+
+@pytest.mark.asyncio
+async def test_handle_envelope_call_site_survives_probe_failure(caplog) -> None:
+    """A probe logging failure at call site 2 must not break save_drive_state or
+    propagate out of handle_envelope -- unlike call site 1 (which sits inside the
+    broader homeostatic try/except), call site 2 has no outer guard, so the
+    helper's own internal try/except is the only thing protecting this path."""
+    worker = _worker()
+    worker.drive_engine.update = MagicMock(return_value=({"predictive": 0.6}, {"predictive": True}))
+    worker.goal_engine.propose = MagicMock(return_value=MagicMock(proposal=None, suppressed_signature=None))
+
+    import orion.spark.concept_induction.bus_worker as bus_worker_mod
+
+    # Raise ONLY on the probe's own info call, not on every other logger.info
+    # call downstream in handle_envelope -- otherwise this test would prove
+    # nothing about the probe specifically.
+    original_info = bus_worker_mod.logger.info
+
+    def _raise_on_probe(msg, *args, **kwargs):
+        if isinstance(msg, str) and msg.startswith("drive_engine_pressure_probe"):
+            raise RuntimeError("boom")
+        return original_info(msg, *args, **kwargs)
+
+    bus_worker_mod.logger.info = _raise_on_probe
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            # Must not raise.
+            await worker.handle_envelope(_world_pulse_envelope(), "orion:world_pulse:run:result")
+    finally:
+        bus_worker_mod.logger.info = original_info
+
+    worker.store.save_drive_state.assert_called_once()
+    assert any("drive_engine_pressure_probe_failed" in r.message for r in caplog.records)

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -2259,7 +2259,29 @@ async def _run_autonomy_reducer(
     except Exception as exc:
         logger.warning("autonomy_state_v2_write_failed subject=%s error=%s", subject, exc)
 
+    _log_autonomy_pressure_probe(subject, dict(result.state.drive_pressures or {}))
+
     return result
+
+
+def _log_autonomy_pressure_probe(subject: str, pressures: dict) -> None:
+    """Measurement-only (Phase 4, 2026-07-12): log `AutonomyStateV2`'s pressure
+    vector right after every `_run_autonomy_reducer` fold so it can be compared
+    offline against `DriveEngine`'s independently-computed pressures (logged
+    from `orion.spark.concept_induction.bus_worker`) by grepping both
+    services' logs and correlating on `subject` + nearby timestamp. Never
+    raises: this is a hot chat-turn path and a logging failure here must not
+    break it, mirroring the guard around the `save_autonomy_state_v2` call
+    directly above.
+    """
+    try:
+        logger.info(
+            "autonomy_state_v2_pressure_probe subject=%s pressures=%s",
+            subject,
+            {k: round(v, 4) for k, v in pressures.items()},
+        )
+    except Exception as exc:
+        logger.warning("autonomy_state_v2_pressure_probe_failed subject=%s error=%s", subject, exc)
 
 
 def _inject_prior_stance_to_inputs(ctx: Dict[str, Any], inputs: Dict[str, Any]) -> None:

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_pressure_probe.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_pressure_probe.py
@@ -1,0 +1,137 @@
+"""Unit tests for the Phase 4 drive-pressure measurement probe (2026-07-12).
+
+Measurement-only: logs `AutonomyStateV2`'s pressure vector right after every
+`_run_autonomy_reducer` fold so it can be compared offline (by grepping logs
+and correlating on subject + nearby timestamp) against `DriveEngine`'s
+independently-computed pressures, logged from
+`orion/spark/concept_induction/bus_worker.py`. No schema change, no behavior
+change -- see
+docs/superpowers/plans/2026-07-12-self-state-mesh-substrate-redesign.md Phase 4.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from orion.autonomy.models import AutonomyStateV1
+from orion.autonomy.reducer import reduce_autonomy_state as real_reduce_autonomy_state
+
+from app import chat_stance
+
+
+def _v1_baseline() -> AutonomyStateV1:
+    return AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive="coherence",
+        drive_pressures={"coherence": 0.4},
+        active_drives=["coherence"],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+    )
+
+
+def _wire_common_mocks(monkeypatch, *, store: dict) -> None:
+    monkeypatch.setattr(chat_stance, "load_autonomy_state_v2", lambda subject: store.get(subject))
+    monkeypatch.setattr(chat_stance, "save_autonomy_state_v2", lambda subject, state: store.__setitem__(subject, state))
+    monkeypatch.setattr(chat_stance, "load_action_outcomes", lambda subject: [])
+
+
+@pytest.mark.asyncio
+async def test_run_autonomy_reducer_logs_pressure_probe(monkeypatch, caplog) -> None:
+    store: dict = {}
+    _wire_common_mocks(monkeypatch, store=store)
+
+    v1_baseline = _v1_baseline()
+    autonomy = {"state": v1_baseline}
+    ctx: dict = {"user_message": "hello", "correlation_id": "c-1"}
+
+    caplog.set_level(logging.INFO)
+    result = await chat_stance._run_autonomy_reducer(ctx, autonomy, social={}, social_bridge={}, reasoning={})
+
+    assert "autonomy_state_v2_pressure_probe" in caplog.text
+    assert "subject=orion" in caplog.text
+    for drive_id, value in dict(result.state.drive_pressures or {}).items():
+        assert drive_id in caplog.text
+        assert f"{round(value, 4)}" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_autonomy_reducer_pressure_probe_matches_folded_state(monkeypatch, caplog) -> None:
+    """The logged pressures must be the SAME dict the reducer actually folded
+    into result.state -- not e.g. the before-pressures or the V1 baseline."""
+    store: dict = {}
+    _wire_common_mocks(monkeypatch, store=store)
+
+    def spy_reduce(inp):
+        return real_reduce_autonomy_state(inp)
+
+    monkeypatch.setattr(chat_stance, "reduce_autonomy_state", spy_reduce)
+
+    v1_baseline = _v1_baseline()
+    autonomy = {"state": v1_baseline}
+    ctx: dict = {"user_message": "first turn, feeling curious", "correlation_id": "c-1"}
+
+    caplog.set_level(logging.INFO)
+    result = await chat_stance._run_autonomy_reducer(ctx, autonomy, social={}, social_bridge={}, reasoning={})
+
+    probe_lines = [line for line in caplog.text.splitlines() if "autonomy_state_v2_pressure_probe" in line]
+    assert len(probe_lines) == 1
+    for drive_id, value in dict(result.state.drive_pressures or {}).items():
+        assert f"'{drive_id}': {round(value, 4)}" in probe_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_pressure_probe_failure_is_swallowed_and_reducer_still_completes(monkeypatch, caplog) -> None:
+    """A probe logging failure must never break the hot chat-turn path. The
+    call site in `_run_autonomy_reducer` has NO outer try/except around
+    `_log_autonomy_pressure_probe` -- the helper's own internal try/except is
+    the only thing protecting this path, so raise from inside the real
+    logger.info call (not by replacing the whole helper, which would bypass
+    that internal guard and prove nothing)."""
+    store: dict = {}
+    _wire_common_mocks(monkeypatch, store=store)
+
+    original_info = chat_stance.logger.info
+
+    def _raise_on_probe(msg, *args, **kwargs):
+        if isinstance(msg, str) and msg.startswith("autonomy_state_v2_pressure_probe"):
+            raise RuntimeError("logging exploded")
+        return original_info(msg, *args, **kwargs)
+
+    monkeypatch.setattr(chat_stance.logger, "info", _raise_on_probe)
+
+    v1_baseline = _v1_baseline()
+    autonomy = {"state": v1_baseline}
+    ctx: dict = {"user_message": "hello", "correlation_id": "c-1"}
+
+    # Must not raise, and must still return a real result / write-back.
+    result = await chat_stance._run_autonomy_reducer(ctx, autonomy, social={}, social_bridge={}, reasoning={})
+    assert result is not None
+    assert "orion" in store
+
+
+def test_log_autonomy_pressure_probe_never_raises_on_logging_failure(monkeypatch, caplog) -> None:
+    """Direct unit test of the helper itself: a raising logger.info must be
+    caught and turned into a warning, never propagate."""
+
+    class _ExplodingLogger:
+        def info(self, *_a, **_kw):
+            raise RuntimeError("boom")
+
+        def warning(self, *args, **kwargs):
+            logging.getLogger("orion.cortex.exec.chat_stance").warning(*args, **kwargs)
+
+    original_logger = chat_stance.logger
+    chat_stance.logger = _ExplodingLogger()
+    try:
+        caplog.set_level(logging.WARNING)
+        # Must not raise.
+        chat_stance._log_autonomy_pressure_probe("orion", {"coherence": 0.5})
+    finally:
+        chat_stance.logger = original_logger
+
+    assert "autonomy_state_v2_pressure_probe_failed" in caplog.text


### PR DESCRIPTION
# PR: Phase 4 — DriveEngine vs AutonomyStateV2 pressure measurement probes

## Summary

- Measurement-only, log-only instrumentation (no schema change, no behavior change) comparing `DriveEngine`'s and `AutonomyStateV2`'s independently-computed drive-pressure vectors, per `docs/superpowers/plans/2026-07-12-self-state-mesh-substrate-redesign.md`'s Phase 4 ("Drive unification") first step: "log side-by-side on the same live traffic window... before deciding merge vs. keep-separate."
- Both computations key off the same six-drive taxonomy (`coherence, continuity, capability, relational, predictive, autonomy`) but are fed by completely different inputs (`DriveEngine`: self-state tensions + biometrics via `orion/spark/concept_induction/bus_worker.py`; `AutonomyStateV2`: chat-turn evidence only, via `services/orion-cortex-exec/app/chat_stance.py`, test-banned from touching self-state) — this is the first time either has been directly comparable.

## Outcome moved

The merge-vs-keep-separate decision from the redesign spec can now be made from real correlated data (grep both services' logs, join on `subject` + nearby timestamp) instead of the assumption either direction currently rests on.

## Architecture touched

- `orion/spark/concept_induction/bus_worker.py`
- `services/orion-cortex-exec/app/chat_stance.py`

## Files changed

- `orion/spark/concept_induction/bus_worker.py`: new `_log_drive_pressure_probe(self, subject, pressures)`, try/except-guarded (never breaks the drive-update rail, which runs on live bus traffic), called right after both `save_drive_state` call sites (~line 745, ~874)
- `services/orion-cortex-exec/app/chat_stance.py`: new module-level `_log_autonomy_pressure_probe(subject, pressures)`, same guard pattern, called right after `_run_autonomy_reducer`'s existing `save_autonomy_state_v2` try/except (mirrors that block's defensive style directly)
- `orion/spark/concept_induction/tests/test_drive_pressure_probe.py`: new, 5 tests (helper behavior, both call sites, never-raises for each)
- `services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_pressure_probe.py`: new, 4 tests (probe fires with correct subject/pressures, pressures match the folded state exactly, never-raises through the full call path and directly on the helper)

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```text
pytest orion/spark/concept_induction/tests/ -q
→ 119 passed (114 pre-existing + 5 new)

pytest services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_pressure_probe.py -q
→ 4 passed
```

Both verified directly by the orchestrator (not just the implementing agent) on the actual committed branch. `git diff --check`: clean.

Note: a broader `-k autonomy_v2`/`-k chat_stance` sweep across the whole `services/orion-cortex-exec/tests/` directory shows pre-existing collection errors (`ValueError: Verb already registered: legacy.plan`) and 2 pre-existing test failures unrelated to this change — confirmed present on `main` with this patch fully reverted, not introduced here.

## Evals run

None applicable — pure logging instrumentation.

## Docker/build/smoke checks

Not run this session. Restart commands below for when this merges.

## Review findings fixed

No dedicated code-review round for this PR — small, self-contained, measurement-only addition following an already-established pattern (mirrors `orion-self-state-runtime`'s Phase 2 deviation-probe logging exactly in style and defensive guarding). Verified directly instead: read both diffs in full, confirmed the try/except placement matches the existing defensive pattern immediately above each new call site, ran both test suites myself.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml up -d --build

docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
  Concern: this is pure `logger.info` output on hot paths (every accepted bus event for `DriveEngine`, every chat turn for `AutonomyStateV2`) — adds log volume with no way to disable short of a redeploy, matching the same tradeoff already accepted for Phase 2's deviation probe (no feature flag was added there either, by the same reasoning: cheap, in-memory, fail-open).
  Mitigation: none needed yet; add a settings flag if it proves noisy in practice, same escalation path as Phase 2.
- Severity: informational
  This PR only produces the *data*; it does not decide merge-vs-keep-separate. That decision is Phase 4's next step, gated on actually collecting and comparing a real traffic window's worth of both logs.
