### PR TITLE
Feat/phase5 self state evidence trail debug

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-12-phase5-evidence-trail-debug-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-phase5-evidence-trail-debug-pr.md
@@ -1,0 +1,83 @@
+# PR: Phase 5 — self-state evidence-trail debug endpoint + schema-drift fix
+
+## Summary
+
+- Per `docs/superpowers/plans/2026-07-12-self-state-mesh-substrate-redesign.md`'s Phase 5 goal ("a human, or Orion, can pull one self-state tick's full evidence trail, node-attributed, through the debug surface"): two new endpoints on `orion-hub`'s `substrate_self_state_routes.py` joining a self-state row's per-dimension evidence with the raw upstream field-state data (`node_vectors`, `capability_vectors`, `capability_provenance`) it was built from.
+- Also fixes the same schema-drift bug class from the prior incident PR (`docs/superpowers/pr-reports/2026-07-12-substrate-schema-drift-incident-pr.md`), found while reading this file to scope the new endpoints: `_load_latest_self_state()` had the identical unguarded `model_validate()` that crashed 4 other services in that incident.
+
+## Outcome moved
+
+The existing `/latest` endpoint only ever returned the already-summarized top-3-per-dimension `dominant_evidence` strings. The new endpoints expose the full raw field data a tick's evidence was built from, closing the redesign's stated observability goal.
+
+## Files changed
+
+- `services/orion-hub/scripts/substrate_self_state_routes.py`:
+  - `_load_latest_self_state()`: now catches `ValidationError`, degrades to `None` (existing 404 path), instead of 500ing on a legacy row
+  - New `_load_self_state_by_id(self_state_id)`, `_load_field_state_for_tick(tick_id)` — same graceful-degradation pattern
+  - New `_build_evidence_trail(state)` — joins a `SelfStateV1` with its source `FieldStateV1` (by `source_field_tick_id`)
+  - New routes: `GET /api/substrate/self-state/latest/evidence-trail` and `GET /api/substrate/self-state/{self_state_id}/evidence-trail` — the literal `/latest/evidence-trail` route is registered *before* the parameterized `{self_state_id}` route so FastAPI's registration-order matching doesn't let the parameterized route swallow the literal `"latest"` segment
+- `services/orion-hub/tests/test_substrate_self_state_debug_api.py`: new tests for the schema-drift fix (reusing the exact legacy-payload fixture shape from the incident PR) and both new endpoints, including graceful degradation when the self-state exists but its field-state row doesn't (or vice versa)
+
+## Response shape
+
+```json
+{
+  "self_state_id": "...",
+  "source_field_tick_id": "...",
+  "self_state": { /* full SelfStateV1 dump */ },
+  "field_state_available": true,
+  "field_state": {
+    "tick_id": "...", "generated_at": "...",
+    "node_vectors": {...}, "capability_vectors": {...}, "capability_provenance": {...}
+  }
+}
+```
+
+Chosen as a flat join rather than a per-dimension-merged shape: the channel→dimension mapping logic already lives in `orion/self_state/builder.py`, tied to policy config — reimplementing it here would be an unnecessary abstraction for a debug endpoint. `field_state_available: false` / `field_state: null` covers the missing-or-incompatible case without failing the whole request.
+
+## Schema / bus / API changes
+
+- Added: 2 new debug HTTP routes (read-only, no auth beyond whatever the router already has, no new bus/schema contract)
+- Behavior changed: `/latest` no longer 500s on a schema-incompatible legacy row (now 404s, same as "not found")
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+pytest services/orion-hub/tests/test_substrate_self_state_debug_api.py -q
+→ 8 passed
+```
+
+Verified directly by the orchestrator on the actual committed branch (not just the implementing agent's report). `git diff --check`: clean.
+
+## Evals run
+
+None applicable — debug API only.
+
+## Docker/build/smoke checks
+
+Not run this session (no live rebuild). Restart command below for when this merges.
+
+## Review findings fixed
+
+The implementing agent ran the code-review skill against its own staged diff (excluding the parallel Phase 4 agent's untouched files) — no blocking findings. One low-severity nit noted and left as-is: each evidence-trail request opens two separate `_engine()` connections instead of sharing one — a pre-existing per-call pattern in this file already, not worth blocking a low-traffic debug endpoint on.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-hub/.env \
+  -f services/orion-hub/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: low
+  Concern: two DB round-trips per evidence-trail request (self-state lookup, then field-state lookup) instead of a single joined query.
+  Mitigation: acceptable for a low-traffic debug endpoint; not fixed, flagged only.
+
+## PR link
+
+<!-- filled in after push -->

--- a/services/orion-hub/scripts/substrate_self_state_routes.py
+++ b/services/orion-hub/scripts/substrate_self_state_routes.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 
+from orion.schemas.field_state import FieldStateV1
 from orion.schemas.self_state import SelfStateV1
 
 router = APIRouter(prefix="/api/substrate/self-state", tags=["substrate-self-state"])
+
+logger = logging.getLogger(__name__)
 
 
 def _engine():
@@ -37,7 +42,90 @@ def _load_latest_self_state() -> SelfStateV1 | None:
     payload = row["self_state_json"]
     if isinstance(payload, str):
         payload = json.loads(payload)
-    return SelfStateV1.model_validate(payload)
+    try:
+        return SelfStateV1.model_validate(payload)
+    except ValidationError:
+        # A schema change (e.g. a removed dimension_id enum value) can leave
+        # the last-saved row incompatible with the current schema. Treat as
+        # "no snapshot available" -- the same graceful-degradation path every
+        # other SelfStateV1 consumer takes (see the 2026-07-12 schema-drift
+        # incident PR) -- instead of 500ing this debug endpoint forever on a
+        # row that will never validate under the current code.
+        logger.warning("self_state_latest_incompatible_schema", exc_info=True)
+        return None
+
+
+def _load_self_state_by_id(self_state_id: str) -> SelfStateV1 | None:
+    with _engine().connect() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT self_state_json FROM substrate_self_state
+                WHERE self_state_id = :self_state_id
+                LIMIT 1
+                """
+            ),
+            {"self_state_id": self_state_id},
+        ).mappings().first()
+    if not row:
+        return None
+    payload = row["self_state_json"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    try:
+        return SelfStateV1.model_validate(payload)
+    except ValidationError:
+        logger.warning("self_state_by_id_incompatible_schema", exc_info=True)
+        return None
+
+
+def _load_field_state_for_tick(tick_id: str) -> FieldStateV1 | None:
+    with _engine().connect() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT field_json FROM substrate_field_state
+                WHERE tick_id = :tick_id
+                ORDER BY generated_at DESC
+                LIMIT 1
+                """
+            ),
+            {"tick_id": tick_id},
+        ).mappings().first()
+    if not row:
+        return None
+    payload = row["field_json"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    try:
+        return FieldStateV1.model_validate(payload)
+    except ValidationError:
+        # Same schema-drift tolerance as the self-state loaders above --
+        # a field-state row could theoretically go stale under the same
+        # class of enum/shape change.
+        logger.warning("field_state_for_tick_incompatible_schema", exc_info=True)
+        return None
+
+
+def _build_evidence_trail(state: SelfStateV1) -> dict[str, Any]:
+    field_state = _load_field_state_for_tick(state.source_field_tick_id)
+    return {
+        "self_state_id": state.self_state_id,
+        "source_field_tick_id": state.source_field_tick_id,
+        "self_state": state.model_dump(mode="json"),
+        "field_state_available": field_state is not None,
+        "field_state": (
+            {
+                "tick_id": field_state.tick_id,
+                "generated_at": field_state.generated_at.isoformat(),
+                "node_vectors": field_state.node_vectors,
+                "capability_vectors": field_state.capability_vectors,
+                "capability_provenance": field_state.capability_provenance,
+            }
+            if field_state is not None
+            else None
+        ),
+    }
 
 
 @router.get("/latest")
@@ -46,3 +134,19 @@ async def self_state_latest() -> dict[str, Any]:
     if state is None:
         raise HTTPException(status_code=404, detail="not_found")
     return state.model_dump(mode="json")
+
+
+@router.get("/latest/evidence-trail")
+async def self_state_latest_evidence_trail() -> dict[str, Any]:
+    state = _load_latest_self_state()
+    if state is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return _build_evidence_trail(state)
+
+
+@router.get("/{self_state_id}/evidence-trail")
+async def self_state_evidence_trail(self_state_id: str) -> dict[str, Any]:
+    state = _load_self_state_by_id(self_state_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="not_found")
+    return _build_evidence_trail(state)

--- a/services/orion-hub/tests/test_substrate_self_state_debug_api.py
+++ b/services/orion-hub/tests/test_substrate_self_state_debug_api.py
@@ -30,8 +30,8 @@ _ensure_hub_scripts_import_path()
 from scripts import substrate_self_state_routes  # noqa: E402
 
 
-def _sample_self_state() -> dict:
-    return {
+def _sample_self_state(**overrides: object) -> dict:
+    state = {
         "schema_version": "self.state.v1",
         "self_state_id": "self.state:tick_exec:frame_exec:self_state_policy.v1",
         "generated_at": "2026-05-24T12:00:00+00:00",
@@ -43,7 +43,15 @@ def _sample_self_state() -> dict:
         "overall_condition": "loaded",
         "overall_intensity": 0.55,
         "overall_confidence": 0.7,
-        "dimensions": {},
+        "dimensions": {
+            "resource_pressure": {
+                "dimension_id": "resource_pressure",
+                "score": 0.6,
+                "confidence": 0.8,
+                "dominant_evidence": ["execution_load=0.60"],
+                "reasons": ["driven by pressure=0.60 (node: circe)"],
+            }
+        },
         "dominant_attention_targets": ["node:athena"],
         "dominant_field_channels": {"execution_load": 1.0},
         "unresolved_pressures": [],
@@ -51,6 +59,51 @@ def _sample_self_state() -> dict:
         "warnings": [],
         "summary_labels": ["execution_loaded"],
     }
+    state.update(overrides)
+    return state
+
+
+def _legacy_self_state_payload_with_policy_pressure() -> dict:
+    # Mirrors the exact real production row from the 2026-07-12 schema-drift
+    # incident: a valid SelfStateV1 shape except for one dimension_id
+    # ("policy_pressure") no longer accepted by the current schema.
+    return {
+        "schema_version": "self.state.v1",
+        "self_state_id": "self.state:legacy",
+        "generated_at": "2026-07-12T12:00:00+00:00",
+        "source_field_tick_id": "tick",
+        "source_field_generated_at": "2026-07-12T12:00:00+00:00",
+        "source_attention_frame_id": "frame",
+        "source_attention_generated_at": "2026-07-12T12:00:00+00:00",
+        "self_state_policy_id": "self_state_policy.v1",
+        "overall_condition": "steady",
+        "overall_intensity": 0.4,
+        "overall_confidence": 0.8,
+        "dimensions": {
+            "policy_pressure": {
+                "dimension_id": "policy_pressure",
+                "score": 0.0,
+                "confidence": 0.5,
+                "dominant_evidence": [],
+                "reasons": ["policy_pressure from field+attention channel synthesis"],
+            }
+        },
+    }
+
+
+def _sample_field_state(**overrides: object) -> dict:
+    state = {
+        "schema_version": "field.state.v1",
+        "generated_at": "2026-05-24T12:00:00+00:00",
+        "tick_id": "tick_exec",
+        "node_vectors": {"node:circe": {"pressure": 0.6}},
+        "capability_vectors": {"capability:execution": {"pressure": 0.6}},
+        "capability_provenance": {"capability:execution": {"pressure": "node:circe"}},
+        "edges": [],
+        "recent_perturbations": [],
+    }
+    state.update(overrides)
+    return state
 
 
 @pytest.fixture
@@ -79,6 +132,41 @@ def _fake_engine_with_state(state_json: dict | None):
     return fake_engine
 
 
+def _fake_engine_with_joined_rows(
+    *, self_state_json: dict | None, field_json: dict | None
+):
+    """A fake engine that dispatches on which table the query text targets,
+    so both the self-state loader and the field-state loader can be exercised
+    against the same patched `_engine()` within one request (mirrors how the
+    real evidence-trail endpoint issues two separate queries)."""
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def execute(stmt, params=None):
+        m = MagicMock()
+        sql = str(stmt)
+        if "substrate_self_state" in sql:
+            if self_state_json is None:
+                m.mappings.return_value.first.return_value = None
+            else:
+                m.mappings.return_value.first.return_value = {
+                    "self_state_json": self_state_json
+                }
+        elif "substrate_field_state" in sql:
+            if field_json is None:
+                m.mappings.return_value.first.return_value = None
+            else:
+                m.mappings.return_value.first.return_value = {"field_json": field_json}
+        else:
+            raise AssertionError(f"unexpected query: {sql}")
+        return m
+
+    conn.execute.side_effect = execute
+    return fake_engine
+
+
 def test_self_state_latest_returns_state(client):
     state = _sample_self_state()
     fake_engine = _fake_engine_with_state(state)
@@ -97,5 +185,103 @@ def test_self_state_latest_not_found(client):
 
     with patch.object(substrate_self_state_routes, "_engine", return_value=fake_engine):
         r = client.get("/api/substrate/self-state/latest")
+
+    assert r.status_code == 404
+
+
+def test_self_state_latest_degrades_gracefully_on_legacy_incompatible_row(client):
+    """Regression test for the same bug class as the 2026-07-12 schema-drift
+    incident: a row saved before `policy_pressure` was removed from
+    SelfStateV1.dimensions' valid dimension_id values must not 500 this
+    debug endpoint -- it should degrade to a 404 like "no snapshot found"."""
+    fake_engine = _fake_engine_with_state(_legacy_self_state_payload_with_policy_pressure())
+
+    with patch.object(substrate_self_state_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/self-state/latest")
+
+    assert r.status_code == 404
+
+
+def test_evidence_trail_latest_joins_self_state_and_field_state(client):
+    state = _sample_self_state()
+    field = _sample_field_state()
+    fake_engine = _fake_engine_with_joined_rows(self_state_json=state, field_json=field)
+
+    with patch.object(substrate_self_state_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/self-state/latest/evidence-trail")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["self_state_id"] == state["self_state_id"]
+    assert body["source_field_tick_id"] == "tick_exec"
+    assert body["field_state_available"] is True
+    # Self-state's already-summarized per-dimension evidence is preserved.
+    assert (
+        body["self_state"]["dimensions"]["resource_pressure"]["dominant_evidence"]
+        == ["execution_load=0.60"]
+    )
+    assert (
+        body["self_state"]["dimensions"]["resource_pressure"]["reasons"]
+        == ["driven by pressure=0.60 (node: circe)"]
+    )
+    # Raw field data joined in alongside the summary.
+    assert body["field_state"]["node_vectors"] == {"node:circe": {"pressure": 0.6}}
+    assert body["field_state"]["capability_vectors"] == {
+        "capability:execution": {"pressure": 0.6}
+    }
+    assert body["field_state"]["capability_provenance"] == {
+        "capability:execution": {"pressure": "node:circe"}
+    }
+
+
+def test_evidence_trail_by_id_joins_self_state_and_field_state(client):
+    state = _sample_self_state()
+    field = _sample_field_state()
+    fake_engine = _fake_engine_with_joined_rows(self_state_json=state, field_json=field)
+
+    with patch.object(substrate_self_state_routes, "_engine", return_value=fake_engine):
+        r = client.get(
+            f"/api/substrate/self-state/{state['self_state_id']}/evidence-trail"
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["self_state_id"] == state["self_state_id"]
+    assert body["field_state"]["node_vectors"] == {"node:circe": {"pressure": 0.6}}
+
+
+def test_evidence_trail_not_found_when_self_state_missing(client):
+    fake_engine = _fake_engine_with_joined_rows(self_state_json=None, field_json=None)
+
+    with patch.object(substrate_self_state_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/self-state/latest/evidence-trail")
+
+    assert r.status_code == 404
+
+
+def test_evidence_trail_degrades_sensibly_when_field_state_missing(client):
+    """Self-state exists but its source field-state row is gone (e.g. pruned) --
+    the endpoint should still return the self-state's own evidence, with
+    field_state explicitly marked unavailable rather than 404ing/500ing."""
+    state = _sample_self_state()
+    fake_engine = _fake_engine_with_joined_rows(self_state_json=state, field_json=None)
+
+    with patch.object(substrate_self_state_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/self-state/latest/evidence-trail")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["field_state_available"] is False
+    assert body["field_state"] is None
+    assert body["self_state"]["self_state_id"] == state["self_state_id"]
+
+
+def test_evidence_trail_degrades_gracefully_on_legacy_incompatible_self_state(client):
+    fake_engine = _fake_engine_with_joined_rows(
+        self_state_json=_legacy_self_state_payload_with_policy_pressure(), field_json=None
+    )
+
+    with patch.object(substrate_self_state_routes, "_engine", return_value=fake_engine):
+        r = client.get("/api/substrate/self-state/latest/evidence-trail")
 
     assert r.status_code == 404


### PR DESCRIPTION
# PR: Phase 5 — self-state evidence-trail debug endpoint + schema-drift fix

## Summary

- Per `docs/superpowers/plans/2026-07-12-self-state-mesh-substrate-redesign.md`'s Phase 5 goal ("a human, or Orion, can pull one self-state tick's full evidence trail, node-attributed, through the debug surface"): two new endpoints on `orion-hub`'s `substrate_self_state_routes.py` joining a self-state row's per-dimension evidence with the raw upstream field-state data (`node_vectors`, `capability_vectors`, `capability_provenance`) it was built from.
- Also fixes the same schema-drift bug class from the prior incident PR (`docs/superpowers/pr-reports/2026-07-12-substrate-schema-drift-incident-pr.md`), found while reading this file to scope the new endpoints: `_load_latest_self_state()` had the identical unguarded `model_validate()` that crashed 4 other services in that incident.

## Outcome moved

The existing `/latest` endpoint only ever returned the already-summarized top-3-per-dimension `dominant_evidence` strings. The new endpoints expose the full raw field data a tick's evidence was built from, closing the redesign's stated observability goal.

## Files changed

- `services/orion-hub/scripts/substrate_self_state_routes.py`:
  - `_load_latest_self_state()`: now catches `ValidationError`, degrades to `None` (existing 404 path), instead of 500ing on a legacy row
  - New `_load_self_state_by_id(self_state_id)`, `_load_field_state_for_tick(tick_id)` — same graceful-degradation pattern
  - New `_build_evidence_trail(state)` — joins a `SelfStateV1` with its source `FieldStateV1` (by `source_field_tick_id`)
  - New routes: `GET /api/substrate/self-state/latest/evidence-trail` and `GET /api/substrate/self-state/{self_state_id}/evidence-trail` — the literal `/latest/evidence-trail` route is registered *before* the parameterized `{self_state_id}` route so FastAPI's registration-order matching doesn't let the parameterized route swallow the literal `"latest"` segment
- `services/orion-hub/tests/test_substrate_self_state_debug_api.py`: new tests for the schema-drift fix (reusing the exact legacy-payload fixture shape from the incident PR) and both new endpoints, including graceful degradation when the self-state exists but its field-state row doesn't (or vice versa)

## Response shape

```json
{
  "self_state_id": "...",
  "source_field_tick_id": "...",
  "self_state": { /* full SelfStateV1 dump */ },
  "field_state_available": true,
  "field_state": {
    "tick_id": "...", "generated_at": "...",
    "node_vectors": {...}, "capability_vectors": {...}, "capability_provenance": {...}
  }
}
```

Chosen as a flat join rather than a per-dimension-merged shape: the channel→dimension mapping logic already lives in `orion/self_state/builder.py`, tied to policy config — reimplementing it here would be an unnecessary abstraction for a debug endpoint. `field_state_available: false` / `field_state: null` covers the missing-or-incompatible case without failing the whole request.

## Schema / bus / API changes

- Added: 2 new debug HTTP routes (read-only, no auth beyond whatever the router already has, no new bus/schema contract)
- Behavior changed: `/latest` no longer 500s on a schema-incompatible legacy row (now 404s, same as "not found")

## Env/config changes

None.

## Tests run

```text
pytest services/orion-hub/tests/test_substrate_self_state_debug_api.py -q
→ 8 passed
```

Verified directly by the orchestrator on the actual committed branch (not just the implementing agent's report). `git diff --check`: clean.

## Evals run

None applicable — debug API only.

## Docker/build/smoke checks

Not run this session (no live rebuild). Restart command below for when this merges.

## Review findings fixed

The implementing agent ran the code-review skill against its own staged diff (excluding the parallel Phase 4 agent's untouched files) — no blocking findings. One low-severity nit noted and left as-is: each evidence-trail request opens two separate `_engine()` connections instead of sharing one — a pre-existing per-call pattern in this file already, not worth blocking a low-traffic debug endpoint on.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: low
  Concern: two DB round-trips per evidence-trail request (self-state lookup, then field-state lookup) instead of a single joined query.
  Mitigation: acceptable for a low-traffic debug endpoint; not fixed, flagged only.