### PR TITLE
Fix/field digester diffusion saturation

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-12-field-digester-diffusion-saturation-fix-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-field-digester-diffusion-saturation-fix-pr.md
@@ -1,0 +1,95 @@
+# PR: Fix field-digester diffusion permanently saturating capability channels
+
+## Summary
+
+- Live bug: `apply_diffusion()` accumulated across ticks, and with real edges routinely contributing up to ~0.9/tick against an 8%/tick decay, this drove capability channels like `capability:orchestration`'s `"pressure"` (which `resource_pressure` reads) to a permanent ceiling of 1.0 — confirmed dead-flat for the entire observed `substrate_field_state` history, predating every change made in this session's redesign effort.
+- Two compounding root causes fixed: (1) multiple legitimate source channels feeding the same target (e.g. `cpu_pressure` + `transport_pressure` both → `"pressure"`) were summed instead of combined via `max()`, even within a single tick; (2) the result then carried forward and accumulated further every subsequent tick.
+- `apply_diffusion()` is now fully memoryless per diffusion-target channel, matching the same principle self-state's own `build_self_state()` already uses.
+- Code review found no bugs in the fix itself, but surfaced a significant fact: the endogenous-origination NO-GO verdict was measured against data this exact bug was contaminating, and this fix carries the same (arguably sharper) phi-corpus deployment caution already open from Phase 1.
+
+## Outcome moved
+
+`resource_pressure` (and every other capability-fed dimension) can, for the first time in this substrate's history, actually move. This is the concrete fix for the "garbage in" complaint that started the whole redesign — Phase 1 fixed a real but different bug (raw channel double-counting); this fixes the one that actually explains why the metric never moved.
+
+## Current architecture
+
+Before this fix: `apply_diffusion()` ran `tgt[ch] = min(1.0, tgt.get(ch, 0.0) + contribution)` — additive, cross-tick-persistent. `apply_decay()` ran immediately before it in the same tick and multiplied the same channels by 0.92, but couldn't keep pace with multiple channels each contributing up to `weight × diffusion_rate` (~0.9) every 2-second tick.
+
+## Files changed
+
+- `services/orion-field-digester/app/digestion/diffusion.py`: `apply_diffusion()` rewritten to collect the best (max) real contribution per `(target_id, channel)` across all edges this tick, then set every diffusion-target channel fresh (zeroing channels with no current contributor, clearing their provenance too) instead of accumulating. Full rationale in the function's docstring.
+- `services/orion-field-digester/app/digestion/decay.py`: added a comment (no logic change) documenting that its `capability_vectors` decay loop is now fully superseded by the memoryless diffusion for every channel currently in the topology — found by code review, left in place as a safety net rather than removed, since removing it wasn't necessary to fix the bug and touching it would have widened scope.
+- `services/orion-field-digester/tests/test_diffusion_provenance.py`: rewrote one existing test that asserted the old (buggy) accumulation-preserving behavior; added new tests for the actual regression (`test_sustained_real_contribution_does_not_ratchet_up_across_ticks`), max-not-sum convergence, no-current-contributor reset, and confidence/available_capacity baseline preservation.
+
+## Schema / bus / API changes
+
+None — `FieldStateV1`'s shape is unchanged. Behavior changed: `capability_vectors` values and `capability_provenance` now reflect only the current tick, not a historical blend.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+pytest services/orion-field-digester/tests/ -q
+→ 20 passed
+
+pytest tests/test_field_state_schemas.py tests/test_field_digestion_rules.py \
+  tests/test_field_topology_reconciliation.py tests/test_self_state_builder.py \
+  tests/test_self_state_builder_hardening.py tests/test_self_state_schemas.py \
+  tests/test_self_state_scoring.py tests/test_self_state_policy_loader.py -q
+→ 51 passed
+```
+
+`git diff --check`: clean.
+
+## Evals run
+
+None applicable.
+
+## Docker/build/smoke checks
+
+**Not run — deliberately not deployed this session.** See Risks below; this needs a decision before it goes live, not just a rebuild.
+
+## Review findings fixed
+
+Two-angle review (line-scan, cross-file consumer check).
+
+- Finding: `capability:transport`'s direct diffusion of `delivery_confidence→confidence` and `bus_health→available_capacity` is silently overwritten every tick by the pressure-derived formula.
+  - Fix: not fixed — confirmed pre-existing (same precedence existed before this patch, just computed multiple times per tick with intermediate values instead of once with the final one). Documented in the new docstring as a known quirk needing its own follow-up decision.
+- Finding: `apply_decay()`'s `capability_vectors` loop is now fully dead weight for every channel diffusion touches — a genuinely new consequence of this fix, previously load-bearing (the only counterweight to unbounded accumulation).
+  - Fix: documented with a comment explaining why it's currently inert and why it's kept (a safety net for any future non-diffusion capability-channel writer), rather than removed.
+  - Evidence: full test suite still passes; the comment is directly at the code in question.
+- Finding: `src = state.node_vectors.get(edge.source_id) or state.capability_vectors.get(edge.source_id, {})` uses dict truthiness, which could silently misroute if a node vector is ever genuinely empty or a node/capability id string ever collides.
+  - Fix: not fixed — confirmed byte-for-byte unchanged from before this patch (pre-existing), and currently safe given `reconcile_field_state_with_lattice` always fully populates node vectors and node/capability id prefixes never collide in the current topology. Flagged as a candidate hardening follow-up, not blocking.
+- Finding (significant, not a bug in this diff): the 2026-07-08 endogenous-origination NO-GO verdict (`median_abs_trajectory=0.0000` vs required `≥0.03`) was measured against 120 days of data this exact saturation bug was contaminating — the dimensions that metric reads are fed by the same capability channels that were pinned at 1.0.
+  - Not fixed here — not this PR's decision to make. Flagged clearly: the verdict should be re-measured once this fix is live, before being trusted further. This is not grounds to reverse the NO-GO decision on its own; it's grounds to re-run the measurement.
+- Finding (expected consequence, not a bug): metacog reflection triggers (`orion/substrate/metacog_trigger_signals.py`) and attention-novelty scoring (`orion/attention/field_attention/scoring.py`) both read dimensions that will now show real tick-to-tick variance instead of staying artificially flat — expect these to fire noticeably more often post-deploy. This is the metric finally being honest, not a regression, but worth knowing about before deploying so a sudden increase in trigger volume isn't mistaken for something broken.
+
+## Restart required
+
+**Deliberately not run this session — printed here for when the phi-corpus question below is resolved:**
+
+```bash
+docker compose --env-file .env --env-file services/orion-field-digester/.env \
+  -f services/orion-field-digester/docker-compose.yml up -d --build
+```
+
+`orion-self-state-runtime` does not itself need a rebuild for this fix (it only reads whatever `field_digester` produces), but its behavior will change the moment `field-digester` is restarted with this code.
+
+## Risks / concerns
+
+- Severity: **high — same class of concern as the still-open Phase 1 phi-corpus decision, arguably sharper here.**
+  Concern: `agency_readiness_score()` directly consumes `resource_pressure` (`base -= resource_pressure * 0.15`), and `agency_readiness` is one of the four `SelfStateV1`-sourced features the live phi encoder (seedv4) trains on. Phase 1's fix shifted an already-varying distribution; this fix takes `resource_pressure` from a **constant** (zero variance, pinned at 1.0 for its entire history) to something that will actually vary for the first time ever once deployed — likely a larger distributional jump than Phase 1's.
+  Mitigation: **not resolved.** The three options from Phase 1's phi-corpus flag (accept-and-document / version-pin / retrain) apply here too, and this fix should not be deployed to the live field-digester until that question — still open since Phase 1 — is actually decided. This PR is code-complete and fully tested; it is deliberately not restarted live.
+- Severity: medium
+  Concern: the endogenous-origination NO-GO verdict may have been measured on contaminated data.
+  Mitigation: re-measure `scripts/analysis/measure_autonomy_gate.py` after this fix is live, before treating the existing NO-GO verdict as settled for any future decision.
+- Severity: low
+  Concern: metacog/attention-novelty trigger volume will likely increase post-deploy.
+  Mitigation: none needed beyond awareness; monitor after deploy.
+
+## PR link
+
+<!-- filled in after push -->

--- a/services/orion-field-digester/app/digestion/decay.py
+++ b/services/orion-field-digester/app/digestion/decay.py
@@ -43,6 +43,25 @@ def apply_decay(state: FieldStateV1, *, decay_rate: float) -> None:
         for ch in NODE_DECAY_CHANNELS:
             if ch in vec:
                 vec[ch] = vec[ch] * decay_rate
+    # NOTE (2026-07-12, found by code review on the diffusion memoryless-
+    # recompute fix): this capability_vectors loop -- and its
+    # "available_capacity" recompute below -- is currently dead weight for
+    # every capability in the live topology (config/field/orion_field_topology.v1.yaml).
+    # apply_diffusion() runs immediately after this in the same tick
+    # (app/tensor/update_rules.py) and now unconditionally overwrites every
+    # CAPABILITY_DECAY_CHANNELS entry that is ever a diffusion target for a
+    # capability with a fresh, memoryless recompute -- discarding whatever
+    # this loop just wrote moments earlier. Any CAPABILITY_DECAY_CHANNELS
+    # entry that is NOT a diffusion target for a given capability is never
+    # written by anything else either (perturbation.py only writes
+    # node_vectors), so it stays at its reconcile-seeded 0.0 regardless of
+    # decay. Left in place rather than removed -- this was load-bearing
+    # under the OLD accumulating diffusion model (the only counterweight to
+    # unbounded additive growth) and is a reasonable safety net if a future
+    # change ever writes a capability channel directly, outside diffusion,
+    # without its own decay story. Do not assume this loop is currently
+    # bounding anything live; verify against apply_diffusion() first if this
+    # matters for a future change.
     for vec in state.capability_vectors.values():
         for ch in CAPABILITY_DECAY_CHANNELS:
             if ch in vec:

--- a/services/orion-field-digester/app/digestion/diffusion.py
+++ b/services/orion-field-digester/app/digestion/diffusion.py
@@ -3,33 +3,110 @@ from __future__ import annotations
 from orion.schemas.field_state import FieldStateV1
 
 
+def _clamp01(x: float) -> float:
+    return max(0.0, min(1.0, float(x)))
+
+
 def apply_diffusion(state: FieldStateV1, *, diffusion_rate: float) -> None:
-    # Phase 3 (2026-07-12): track, per (target_id, channel), the single
-    # largest weighted contribution seen in this diffusion pass, so
-    # state.capability_provenance can record which edge source "won" --
-    # a per-tick proxy, not a historical ledger (see FieldStateV1's
-    # capability_provenance docstring for why).
-    _max_contribution: dict[tuple[str, str], float] = {}
+    """Recompute every diffused capability channel fresh from this tick's node/
+    capability state (2026-07-12 fix -- see
+    docs/notes/2026-07-12-metrics-swamp-arsonist-review.md and the redesign
+    plan's Phase 1 for the double-counting bug this is related to but
+    distinct from).
+
+    Previously this accumulated across ticks (`tgt[ch] = min(1.0, tgt.get(ch,
+    0.0) + contribution)`), carrying forward whatever was already there. With
+    `BIOMETRICS_FIELD_DECAY_RATE=0.92` (8% removed per tick) and multiple real
+    edges/channels routinely contributing up to `weight * diffusion_rate`
+    (commonly ~0.9) each tick, the additive carryover overwhelmed decay almost
+    immediately and pinned capability channels like `capability:orchestration`'s
+    "pressure" at exactly 1.0 permanently, regardless of current real load --
+    confirmed live: `resource_pressure` had been dead-flat 1.0 for the entire
+    observed history, including before this fix, unrelated to any actual
+    hardware/transport state.
+
+    Root cause was two compounding issues, both fixed here:
+    1. Multiple source channels legitimately feed the same target channel by
+       design (e.g. node:athena->capability:orchestration maps BOTH
+       cpu_pressure AND transport_pressure onto "pressure" -- orchestration
+       capability is meant to reflect either stressor). These were SUMMED
+       into the target, even within a single tick, rather than combined via
+       max() -- two moderately-stressed channels alone could push a target
+       near ceiling in one tick. Now: whichever contributing channel is
+       currently worse dominates that tick's reading for the shared target,
+       matching the same principle already used everywhere else in this
+       redesign (self-state's own channel merging, the Phase 1 double-count
+       fix).
+    2. The result then carried forward and accumulated further next tick.
+       Now: fully memoryless per diffusion-target channel. Each tick
+       recomputes every such channel from scratch from the current
+       node_vectors/capability_vectors, the same way orion-self-state-
+       runtime's build_self_state() is already memoryless. A capability's
+       pressure now reflects current load, not an ever-ratcheting historical
+       maximum. Channels no edge currently contributes to are explicitly
+       zeroed (not left stale) -- but only the specific channels that are
+       ever a diffusion target for that capability; everything else in the
+       dict (e.g. a confidence/available_capacity baseline the caller already
+       reconciled in) is left untouched, so a capability with no incoming
+       "pressure" edge at all still keeps its sensible 1.0 defaults instead
+       of losing the key entirely.
+
+    capability_provenance (Phase 3) is updated to match: previously it
+    already tracked "which edge source contributed the most THIS tick" (a
+    memoryless computation) while the actual persisted VALUE was a multi-tick
+    accumulated blend from whichever past ticks contributed -- an internal
+    inconsistency (provenance and the score it was explaining described two
+    different things). Both are now memoryless together, so provenance and
+    score are always consistent: provenance names the source that actually
+    produced the score displayed this tick, and is cleared (not left stale)
+    when nobody contributes.
+
+    Known pre-existing quirk, NOT introduced or fixed by this change: two
+    capability channels ("confidence", "available_capacity") are BOTH a
+    direct diffusion target for some edges (e.g. capability:transport's
+    delivery_confidence->confidence, bus_health->available_capacity) AND
+    unconditionally recomputed from a pressure-derived formula below whenever
+    "pressure" is also a target for that capability -- the derived formula
+    always wins for those capabilities, silently making their direct
+    delivery_confidence/bus_health diffusion pointless. This predates this
+    fix (the original code had the same precedence, just computed multiple
+    times per tick with intermediate/partial pressure values instead of once
+    with the final one). Worth a follow-up decision on which should win; not
+    changed here to keep this patch scoped to the saturation bug.
+    """
+    best_contribution: dict[tuple[str, str], float] = {}
+    best_source: dict[tuple[str, str], str] = {}
+    possible_targets: dict[str, set[str]] = {}
+
     for edge in state.edges:
         src = state.node_vectors.get(edge.source_id) or state.capability_vectors.get(edge.source_id, {})
-        tgt = state.capability_vectors.setdefault(edge.target_id, {})
         for src_ch, tgt_ch in edge.channel_map.items():
+            possible_targets.setdefault(edge.target_id, set()).add(tgt_ch)
             src_val = float(src.get(src_ch, 0.0))
-            contribution = src_val * edge.weight * diffusion_rate
-            tgt[tgt_ch] = min(1.0, tgt.get(tgt_ch, 0.0) + contribution)
+            contribution = _clamp01(src_val * edge.weight * diffusion_rate)
             key = (edge.target_id, tgt_ch)
-            # contribution > 0.0 is required, not just >=: 0.0 is both the
-            # "no contribution recorded yet this call" sentinel and a
-            # legitimate zero-contribution value (a source with no value for
-            # its mapped channel this tick). Without the strict >0 guard, a
-            # genuinely-zero edge processed first in state.edges' order would
-            # claim/overwrite provenance carried over from a real contributor
-            # in a prior tick, even though it changed nothing (adding 0.0 to
-            # tgt[tgt_ch] is a no-op) -- found by code review, reproduced.
-            if contribution > 0.0 and contribution >= _max_contribution.get(key, 0.0):
-                _max_contribution[key] = contribution
-                state.capability_provenance.setdefault(edge.target_id, {})[tgt_ch] = edge.source_id
-        if "available_capacity" in tgt:
+            # Only a real (>0) contribution may claim provenance/win the
+            # max -- a zero contribution (source has no value for its mapped
+            # channel this tick) must not overwrite another edge's real one
+            # just by being evaluated later in iteration order.
+            if contribution > 0.0 and contribution >= best_contribution.get(key, 0.0):
+                best_contribution[key] = contribution
+                best_source[key] = edge.source_id
+
+    for target_id, channels in possible_targets.items():
+        tgt = state.capability_vectors.setdefault(target_id, {})
+        provenance = state.capability_provenance.setdefault(target_id, {})
+        for tgt_ch in channels:
+            key = (target_id, tgt_ch)
+            tgt[tgt_ch] = best_contribution.get(key, 0.0)
+            if key in best_source:
+                provenance[tgt_ch] = best_source[key]
+            else:
+                # Nobody contributed this tick -- clear stale provenance too,
+                # not just reset the value, so the two never disagree about
+                # what's currently true.
+                provenance.pop(tgt_ch, None)
+
+        if "pressure" in tgt:
             tgt["available_capacity"] = max(0.0, 1.0 - tgt.get("pressure", 0.0))
-        if "confidence" in tgt:
             tgt["confidence"] = max(0.0, 1.0 - 0.5 * tgt.get("pressure", 0.0))

--- a/services/orion-field-digester/tests/test_diffusion_provenance.py
+++ b/services/orion-field-digester/tests/test_diffusion_provenance.py
@@ -1,6 +1,13 @@
-"""Unit tests for apply_diffusion's Phase 3 (2026-07-12) node-provenance
-tracking -- state.capability_provenance recording which edge source
-contributed the largest weighted amount to each diffused channel this tick.
+"""Unit tests for apply_diffusion's node-provenance tracking (Phase 3,
+2026-07-12) and its memoryless-recompute fix (2026-07-12, later same day):
+state.capability_provenance records which edge source contributed the
+largest weighted amount to each diffused channel THIS TICK, and the
+diffused value itself is now recomputed fresh from current node/capability
+state every tick rather than accumulating across ticks -- see
+orion/self_state/deviation.py sibling module and app/digestion/diffusion.py's
+module docstring for the full incident writeup (resource_pressure was
+dead-flat 1.0 for the entire observed history due to additive cross-tick
+accumulation overwhelming an 8%/tick decay).
 """
 
 from __future__ import annotations
@@ -73,10 +80,13 @@ def test_larger_contribution_wins_provenance_over_smaller() -> None:
     assert state.capability_provenance["capability:llm_inference"]["pressure"] == "node:atlas"
 
 
-def test_zero_contribution_does_not_overwrite_existing_provenance() -> None:
-    # A second edge whose source has no value for its mapped channel this
-    # tick (contribution 0.0) must not clobber a real contributor's
-    # provenance recorded moments before in the same pass.
+def test_zero_contribution_edge_does_not_beat_a_real_contribution_same_tick() -> None:
+    # Both atlas's and circe's edges are present (real topology edges are
+    # static -- always in state.edges, every tick) and both target the same
+    # channel. atlas has a real contribution this tick; circe's node vector
+    # has no gpu_pressure at all (contribution 0). The zero-contribution edge
+    # must not win/clobber the real one just by being evaluated in some
+    # iteration order.
     edges = [
         FieldEdgeV1(
             source_id="node:atlas",
@@ -104,45 +114,87 @@ def test_zero_contribution_does_not_overwrite_existing_provenance() -> None:
     apply_diffusion(state, diffusion_rate=1.0)
 
     assert state.capability_provenance["capability:llm_inference"]["pressure"] == "node:atlas"
+    assert state.capability_vectors["capability:llm_inference"]["pressure"] == 0.85
 
 
-def test_zero_contribution_edge_does_not_clobber_prior_tick_provenance() -> None:
-    # Regression found by code review (2026-07-12, empirically reproduced):
-    # 0.0 was both the "no contribution recorded this call" sentinel AND a
-    # legitimate zero-contribution value, so a single edge contributing
-    # nothing this tick (its source has no value for the mapped channel)
-    # would still satisfy the old `contribution >= _max_contribution.get(key,
-    # 0.0)` check on the first edge processed for a (target, channel) key --
-    # silently overwriting real provenance recorded on a prior tick, even
-    # though the accumulated value itself is unchanged (adding 0.0 is a
-    # no-op). This state carries capability_provenance forward from a prior
-    # tick (as the persistent FieldStateV1 object genuinely does across real
-    # ticks) where atlas was the real contributor; this tick's only edge
-    # (circe) contributes nothing and must not claim credit.
+def test_no_current_contributor_resets_value_and_clears_provenance() -> None:
+    # The actual memoryless-recompute fix: a channel that WAS diffused in a
+    # prior tick (simulated here via pre-seeded capability_vectors/
+    # capability_provenance) but has zero real contributors THIS tick must
+    # reset to 0.0 and drop its provenance, not keep displaying a stale value
+    # attributed to a source that isn't contributing anymore.
+    edge = FieldEdgeV1(
+        source_id="node:circe",
+        target_id="capability:llm_inference",
+        edge_type="node_capability",
+        weight=0.50,
+        channel_map={"gpu_pressure": "pressure"},
+    )
     state = FieldStateV1(
         generated_at=NOW,
-        tick_id="tick_stale_zero_contribution",
-        node_vectors={"node:circe": {}},  # no gpu_pressure this tick
+        tick_id="tick_reset",
+        node_vectors={"node:circe": {}},  # circe reporting, but no gpu_pressure this tick
         capability_vectors={"capability:llm_inference": {"pressure": 0.5}},
         capability_provenance={"capability:llm_inference": {"pressure": "node:atlas"}},
-        edges=[
-            FieldEdgeV1(
-                source_id="node:circe",
-                target_id="capability:llm_inference",
-                edge_type="node_capability",
-                weight=0.50,
-                channel_map={"gpu_pressure": "pressure"},
-            ),
-        ],
+        edges=[edge],
     )
 
     apply_diffusion(state, diffusion_rate=1.0)
 
-    # Accumulated value unchanged (0.0 contribution added).
-    assert state.capability_vectors["capability:llm_inference"]["pressure"] == 0.5
-    # Provenance must still credit atlas (the real prior contributor), not
-    # circe (which contributed nothing this tick).
-    assert state.capability_provenance["capability:llm_inference"]["pressure"] == "node:atlas"
+    assert state.capability_vectors["capability:llm_inference"]["pressure"] == 0.0
+    assert "pressure" not in state.capability_provenance.get("capability:llm_inference", {})
+
+
+def test_sustained_real_contribution_does_not_ratchet_up_across_ticks() -> None:
+    # The actual live incident this fix addresses: resource_pressure was
+    # dead-flat 1.0 for the entire observed history because the OLD
+    # implementation added each tick's contribution onto whatever was already
+    # there (min(1.0, tgt.get(ch, 0.0) + contribution)), which an 8%/tick
+    # decay could never keep up with. Calling apply_diffusion repeatedly with
+    # the SAME steady, moderate input must produce the SAME steady value each
+    # time, not a value that climbs toward (and gets stuck at) 1.0.
+    edge = FieldEdgeV1(
+        source_id="node:atlas",
+        target_id="capability:llm_inference",
+        edge_type="node_capability",
+        weight=0.50,
+        channel_map={"gpu_pressure": "pressure"},
+    )
+    state = _state([edge], {"node:atlas": {"gpu_pressure": 0.6}})
+
+    values = []
+    for _ in range(10):
+        apply_diffusion(state, diffusion_rate=1.0)
+        values.append(state.capability_vectors["capability:llm_inference"]["pressure"])
+
+    # 0.6 * 0.50 = 0.30, every single tick -- never climbs.
+    assert all(v == 0.30 for v in values), values
+
+
+def test_multiple_channels_feeding_same_target_use_max_not_sum() -> None:
+    # node:athena -> capability:orchestration maps BOTH cpu_pressure AND
+    # transport_pressure onto "pressure" (real topology edge,
+    # config/field/orion_field_topology.v1.yaml). Two real, legitimate
+    # stressors must combine via max() -- whichever is worse dominates --
+    # not sum, which would let two only-moderately-stressed channels alone
+    # push the target near/at ceiling in a single tick.
+    edge = FieldEdgeV1(
+        source_id="node:athena",
+        target_id="capability:orchestration",
+        edge_type="node_capability",
+        weight=0.90,
+        channel_map={"cpu_pressure": "pressure", "transport_pressure": "pressure"},
+    )
+    state = _state(
+        [edge],
+        {"node:athena": {"cpu_pressure": 0.5, "transport_pressure": 0.5}},
+    )
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    # Each contributes 0.5*0.90=0.45. Summed, that's 0.90 (near ceiling from
+    # one tick alone); maxed, it's 0.45 -- whichever channel is worse.
+    assert state.capability_vectors["capability:orchestration"]["pressure"] == 0.45
 
 
 def test_capability_capability_edge_records_capability_id_as_provenance() -> None:
@@ -170,3 +222,52 @@ def test_capability_capability_edge_records_capability_id_as_provenance() -> Non
         state.capability_provenance["capability:orchestration"]["transport_pressure"]
         == "capability:transport"
     )
+
+
+def test_confidence_and_available_capacity_derived_from_final_pressure() -> None:
+    edge = FieldEdgeV1(
+        source_id="node:atlas",
+        target_id="capability:llm_inference",
+        edge_type="node_capability",
+        weight=0.80,
+        channel_map={"gpu_pressure": "pressure"},
+    )
+    state = _state([edge], {"node:atlas": {"gpu_pressure": 0.5}})
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    tgt = state.capability_vectors["capability:llm_inference"]
+    assert tgt["pressure"] == 0.40
+    assert tgt["available_capacity"] == 0.60
+    assert tgt["confidence"] == 0.80
+
+
+def test_capability_with_no_pressure_target_keeps_reconciled_baseline() -> None:
+    # A capability whose only diffusion target is NOT "pressure" (e.g. only
+    # receives reliability_pressure) must not have its pre-existing
+    # confidence/available_capacity baseline (set by the caller's lattice
+    # reconciliation before apply_diffusion ever runs) clobbered or dropped --
+    # only channels apply_diffusion actually recomputes should change.
+    edge = FieldEdgeV1(
+        source_id="node:athena",
+        target_id="capability:orchestration",
+        edge_type="node_capability",
+        weight=0.90,
+        channel_map={"execution_friction": "reliability_pressure"},
+    )
+    state = FieldStateV1(
+        generated_at=NOW,
+        tick_id="tick_no_pressure_target",
+        node_vectors={"node:athena": {"execution_friction": 0.5}},
+        capability_vectors={"capability:orchestration": {"confidence": 1.0, "available_capacity": 1.0}},
+        edges=[edge],
+    )
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    tgt = state.capability_vectors["capability:orchestration"]
+    assert tgt["reliability_pressure"] == 0.45
+    # Untouched -- "pressure" was never a target for this capability in this
+    # test, so the derived-formula block never ran.
+    assert tgt["confidence"] == 1.0
+    assert tgt["available_capacity"] == 1.0


### PR DESCRIPTION
# PR: Fix field-digester diffusion permanently saturating capability channels

## Summary

- Live bug: `apply_diffusion()` accumulated across ticks, and with real edges routinely contributing up to ~0.9/tick against an 8%/tick decay, this drove capability channels like `capability:orchestration`'s `"pressure"` (which `resource_pressure` reads) to a permanent ceiling of 1.0 — confirmed dead-flat for the entire observed `substrate_field_state` history, predating every change made in this session's redesign effort.
- Two compounding root causes fixed: (1) multiple legitimate source channels feeding the same target (e.g. `cpu_pressure` + `transport_pressure` both → `"pressure"`) were summed instead of combined via `max()`, even within a single tick; (2) the result then carried forward and accumulated further every subsequent tick.
- `apply_diffusion()` is now fully memoryless per diffusion-target channel, matching the same principle self-state's own `build_self_state()` already uses.
- Code review found no bugs in the fix itself, but surfaced a significant fact: the endogenous-origination NO-GO verdict was measured against data this exact bug was contaminating, and this fix carries the same (arguably sharper) phi-corpus deployment caution already open from Phase 1.

## Outcome moved

`resource_pressure` (and every other capability-fed dimension) can, for the first time in this substrate's history, actually move. This is the concrete fix for the "garbage in" complaint that started the whole redesign — Phase 1 fixed a real but different bug (raw channel double-counting); this fixes the one that actually explains why the metric never moved.

## Current architecture

Before this fix: `apply_diffusion()` ran `tgt[ch] = min(1.0, tgt.get(ch, 0.0) + contribution)` — additive, cross-tick-persistent. `apply_decay()` ran immediately before it in the same tick and multiplied the same channels by 0.92, but couldn't keep pace with multiple channels each contributing up to `weight × diffusion_rate` (~0.9) every 2-second tick.

## Files changed

- `services/orion-field-digester/app/digestion/diffusion.py`: `apply_diffusion()` rewritten to collect the best (max) real contribution per `(target_id, channel)` across all edges this tick, then set every diffusion-target channel fresh (zeroing channels with no current contributor, clearing their provenance too) instead of accumulating. Full rationale in the function's docstring.
- `services/orion-field-digester/app/digestion/decay.py`: added a comment (no logic change) documenting that its `capability_vectors` decay loop is now fully superseded by the memoryless diffusion for every channel currently in the topology — found by code review, left in place as a safety net rather than removed, since removing it wasn't necessary to fix the bug and touching it would have widened scope.
- `services/orion-field-digester/tests/test_diffusion_provenance.py`: rewrote one existing test that asserted the old (buggy) accumulation-preserving behavior; added new tests for the actual regression (`test_sustained_real_contribution_does_not_ratchet_up_across_ticks`), max-not-sum convergence, no-current-contributor reset, and confidence/available_capacity baseline preservation.

## Schema / bus / API changes

None — `FieldStateV1`'s shape is unchanged. Behavior changed: `capability_vectors` values and `capability_provenance` now reflect only the current tick, not a historical blend.

## Env/config changes

None.

## Tests run

```text
pytest services/orion-field-digester/tests/ -q
→ 20 passed

pytest tests/test_field_state_schemas.py tests/test_field_digestion_rules.py \
  tests/test_field_topology_reconciliation.py tests/test_self_state_builder.py \
  tests/test_self_state_builder_hardening.py tests/test_self_state_schemas.py \
  tests/test_self_state_scoring.py tests/test_self_state_policy_loader.py -q
→ 51 passed
```

`git diff --check`: clean.

## Evals run

None applicable.

## Docker/build/smoke checks

**Not run — deliberately not deployed this session.** See Risks below; this needs a decision before it goes live, not just a rebuild.

## Review findings fixed

Two-angle review (line-scan, cross-file consumer check).

- Finding: `capability:transport`'s direct diffusion of `delivery_confidence→confidence` and `bus_health→available_capacity` is silently overwritten every tick by the pressure-derived formula.
  - Fix: not fixed — confirmed pre-existing (same precedence existed before this patch, just computed multiple times per tick with intermediate values instead of once with the final one). Documented in the new docstring as a known quirk needing its own follow-up decision.
- Finding: `apply_decay()`'s `capability_vectors` loop is now fully dead weight for every channel diffusion touches — a genuinely new consequence of this fix, previously load-bearing (the only counterweight to unbounded accumulation).
  - Fix: documented with a comment explaining why it's currently inert and why it's kept (a safety net for any future non-diffusion capability-channel writer), rather than removed.
  - Evidence: full test suite still passes; the comment is directly at the code in question.
- Finding: `src = state.node_vectors.get(edge.source_id) or state.capability_vectors.get(edge.source_id, {})` uses dict truthiness, which could silently misroute if a node vector is ever genuinely empty or a node/capability id string ever collides.
  - Fix: not fixed — confirmed byte-for-byte unchanged from before this patch (pre-existing), and currently safe given `reconcile_field_state_with_lattice` always fully populates node vectors and node/capability id prefixes never collide in the current topology. Flagged as a candidate hardening follow-up, not blocking.
- Finding (significant, not a bug in this diff): the 2026-07-08 endogenous-origination NO-GO verdict (`median_abs_trajectory=0.0000` vs required `≥0.03`) was measured against 120 days of data this exact saturation bug was contaminating — the dimensions that metric reads are fed by the same capability channels that were pinned at 1.0.
  - Not fixed here — not this PR's decision to make. Flagged clearly: the verdict should be re-measured once this fix is live, before being trusted further. This is not grounds to reverse the NO-GO decision on its own; it's grounds to re-run the measurement.
- Finding (expected consequence, not a bug): metacog reflection triggers (`orion/substrate/metacog_trigger_signals.py`) and attention-novelty scoring (`orion/attention/field_attention/scoring.py`) both read dimensions that will now show real tick-to-tick variance instead of staying artificially flat — expect these to fire noticeably more often post-deploy. This is the metric finally being honest, not a regression, but worth knowing about before deploying so a sudden increase in trigger volume isn't mistaken for something broken.

## Restart required

**Deliberately not run this session — printed here for when the phi-corpus question below is resolved:**

```bash
docker compose --env-file .env --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml up -d --build
```

`orion-self-state-runtime` does not itself need a rebuild for this fix (it only reads whatever `field_digester` produces), but its behavior will change the moment `field-digester` is restarted with this code.

## Risks / concerns

- Severity: **high — same class of concern as the still-open Phase 1 phi-corpus decision, arguably sharper here.**
  Concern: `agency_readiness_score()` directly consumes `resource_pressure` (`base -= resource_pressure * 0.15`), and `agency_readiness` is one of the four `SelfStateV1`-sourced features the live phi encoder (seedv4) trains on. Phase 1's fix shifted an already-varying distribution; this fix takes `resource_pressure` from a **constant** (zero variance, pinned at 1.0 for its entire history) to something that will actually vary for the first time ever once deployed — likely a larger distributional jump than Phase 1's.
  Mitigation: **not resolved.** The three options from Phase 1's phi-corpus flag (accept-and-document / version-pin / retrain) apply here too, and this fix should not be deployed to the live field-digester until that question — still open since Phase 1 — is actually decided. This PR is code-complete and fully tested; it is deliberately not restarted live.
- Severity: medium
  Concern: the endogenous-origination NO-GO verdict may have been measured on contaminated data.
  Mitigation: re-measure `scripts/analysis/measure_autonomy_gate.py` after this fix is live, before treating the existing NO-GO verdict as settled for any future decision.
- Severity: low
  Concern: metacog/attention-novelty trigger volume will likely increase post-deploy.
  Mitigation: none needed beyond awareness; monitor after deploy