### PR TITLE
Fix/field digester transport confidence precedence

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-12-field-digester-transport-confidence-precedence-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-field-digester-transport-confidence-precedence-pr.md
@@ -1,0 +1,81 @@
+## Summary
+
+- Fixed a live-but-masked bug in `apply_diffusion()`: `capability:transport`'s direct diffusion edges into `confidence` (from `delivery_confidence`) and `available_capacity` (from `bus_health`) were unconditionally overwritten by a pressure-derived formula whenever `pressure` was also a target for that capability, silently making the direct edges pointless.
+- This was flagged as a known, unfixed quirk in the previous diffusion-saturation-fix PR (`ed452331`) and is resolved here as its own scoped follow-up.
+- Gated the derived-formula fallback on `best_source` (a real `>0` contribution landing THIS tick for that specific channel) rather than static channel-map membership — this matters because a first draft of the fix (gating on the static `channels` set) would have hard-floored `confidence`/`available_capacity` at `0.0` on any tick where the direct edge's source happened to have no value for that field, which is worse than the original bug. Caught and fixed via code review before commit.
+- Two new regression tests added.
+
+## Outcome moved
+
+`capability:transport`'s `confidence`/`available_capacity` now genuinely reflect `delivery_confidence`/`bus_health` diffusion when real, and fall back gracefully to the pressure-derived formula only when nothing real landed that tick — instead of one formula always winning regardless of what actually happened.
+
+## Current architecture
+
+`services/orion-field-digester/app/digestion/diffusion.py`'s `apply_diffusion()` (rewritten 2026-07-12 in the earlier saturation-fix PR to be memoryless per diffusion-target channel) recomputes every capability channel each tick from `state.edges`. A post-loop block derives `confidence`/`available_capacity` from `pressure` whenever `pressure` is a target for that capability — originally with no awareness that some capabilities also receive those two channels directly from other edges.
+
+## Architecture touched
+
+`orion-field-digester` only — no schema, bus, or cross-service contract changes.
+
+## Files changed
+
+- `services/orion-field-digester/app/digestion/diffusion.py`: gate the pressure-derived `confidence`/`available_capacity` formula on `best_source` (per-tick real contribution) instead of unconditionally overwriting, and instead of the static-membership check that would have hard-floored the channels to `0.0` on a temporarily-missing direct contribution.
+- `services/orion-field-digester/tests/test_diffusion_provenance.py`: added `test_direct_confidence_and_capacity_diffusion_beats_pressure_derived_formula` (direct diffusion wins when it fires) and `test_derived_formula_still_falls_back_when_direct_edge_contributes_nothing_this_tick` (derived formula still runs as a safety net when the direct edge contributes nothing that tick).
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=. :services/orion-field-digester pytest services/orion-field-digester/tests -q
+22 passed
+
+PYTHONPATH=. pytest tests/test_self_state_runtime_store.py tests/test_self_state_deviation.py \
+  tests/test_self_state_transport_dimension.py tests/test_self_state_builder.py \
+  tests/test_self_state_reliability_decontamination.py tests/test_self_state_prediction.py \
+  tests/test_self_state_policy_loader.py tests/test_self_state_builder_hardening.py \
+  tests/test_self_state_scoring.py tests/test_self_state_schemas.py tests/test_field_state_schemas.py -q
+56 passed
+```
+
+## Evals run
+
+None applicable — this is a deterministic formula-precedence fix, covered fully by unit tests.
+
+## Docker/build/smoke checks
+
+Not run for this branch — not deployed. (The prior saturation fix on this same file IS live on Athena; this follow-up fix is a separate, additive change not yet built/deployed.)
+
+## Review findings fixed
+
+- Finding: gating the derived-formula fallback on static `channels` membership (every configured target for a capability, whether or not it fired this tick) instead of per-tick real contribution would hard-floor `confidence`/`available_capacity` at `0.0` whenever `delivery_confidence`/`bus_health` are temporarily absent from the source data — worse than the pre-existing bug.
+  - Fix: gate on `(target_id, channel) not in best_source` instead, which only tracks real (`>0`) contributions from this specific tick.
+  - Evidence: new test `test_derived_formula_still_falls_back_when_direct_edge_contributes_nothing_this_tick` reproduces the missing-source-field scenario and asserts the derived formula still fires; independently re-verified via a second review pass confirming no other capability in `config/field/orion_field_topology.v1.yaml` has any edge feeding `confidence`/`available_capacity` besides `capability:transport`, so the fix cannot wrongly suppress the safety net elsewhere.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-field-digester/.env \
+  -f services/orion-field-digester/docker-compose.yml \
+  up -d --build orion-athena-field-digester
+```
+
+Not run — deliberately left for Juniper to trigger, matching the standing deploy-authorization pattern from this session.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: this changes `capability:transport`'s `confidence`/`available_capacity` values whenever `transport_pressure` is nonzero AND `delivery_confidence`/`bus_health` diverge from what the pressure-derived formula would produce. Currently masked in live traffic (`transport_pressure` has been idle), so the behavioral change will be invisible until real transport pressure occurs.
+- Mitigation: none needed beyond the tests — this is strictly a correctness fix (direct sensor data should win over a derived proxy), not a new behavior needing a flag.
+
+## PR link
+
+Branch pushed: `fix/field-digester-transport-confidence-precedence`

--- a/services/orion-field-digester/app/digestion/diffusion.py
+++ b/services/orion-field-digester/app/digestion/diffusion.py
@@ -61,18 +61,21 @@ def apply_diffusion(state: FieldStateV1, *, diffusion_rate: float) -> None:
     produced the score displayed this tick, and is cleared (not left stale)
     when nobody contributes.
 
-    Known pre-existing quirk, NOT introduced or fixed by this change: two
-    capability channels ("confidence", "available_capacity") are BOTH a
-    direct diffusion target for some edges (e.g. capability:transport's
-    delivery_confidence->confidence, bus_health->available_capacity) AND
-    unconditionally recomputed from a pressure-derived formula below whenever
-    "pressure" is also a target for that capability -- the derived formula
-    always wins for those capabilities, silently making their direct
-    delivery_confidence/bus_health diffusion pointless. This predates this
-    fix (the original code had the same precedence, just computed multiple
-    times per tick with intermediate/partial pressure values instead of once
-    with the final one). Worth a follow-up decision on which should win; not
-    changed here to keep this patch scoped to the saturation bug.
+    Precedence between direct diffusion and the pressure-derived formula
+    (2026-07-12 follow-up): a capability like capability:transport has BOTH a
+    direct diffusion edge into "confidence"/"available_capacity"
+    (delivery_confidence->confidence, bus_health->available_capacity) AND a
+    "pressure" target, whose derived formula below would otherwise
+    unconditionally overwrite them. Direct diffusion wins when it actually
+    contributed a real (>0) value THIS tick (checked via best_source, not via
+    static channel-map membership -- a capability can be configured with a
+    direct confidence/available_capacity edge yet receive nothing from it in
+    a given tick, e.g. its source is temporarily missing that field; in that
+    case the derived formula must still run as a fallback instead of leaving
+    the channel hard-floored at 0.0). Every other capability (no direct edge
+    into either channel) is unaffected. This was previously masked because
+    transport_pressure has been idle (0.0) in observed traffic, making both
+    formulas agree by coincidence.
     """
     best_contribution: dict[tuple[str, str], float] = {}
     best_source: dict[tuple[str, str], str] = {}
@@ -108,5 +111,16 @@ def apply_diffusion(state: FieldStateV1, *, diffusion_rate: float) -> None:
                 provenance.pop(tgt_ch, None)
 
         if "pressure" in tgt:
-            tgt["available_capacity"] = max(0.0, 1.0 - tgt.get("pressure", 0.0))
-            tgt["confidence"] = max(0.0, 1.0 - 0.5 * tgt.get("pressure", 0.0))
+            # Gate on best_source (a real >0 contribution THIS tick), not on
+            # `channels` (every channel ever configured as a target for this
+            # capability, whether or not it fired this tick) -- a capability
+            # can have "available_capacity"/"confidence" as configured
+            # targets yet receive no contribution some tick (e.g. its source
+            # is temporarily missing that field), in which case the derived
+            # fallback must still run instead of leaving the channel
+            # hard-floored at 0.0 by the `best_contribution.get(key, 0.0)`
+            # reset above.
+            if (target_id, "available_capacity") not in best_source:
+                tgt["available_capacity"] = max(0.0, 1.0 - tgt.get("pressure", 0.0))
+            if (target_id, "confidence") not in best_source:
+                tgt["confidence"] = max(0.0, 1.0 - 0.5 * tgt.get("pressure", 0.0))

--- a/services/orion-field-digester/tests/test_diffusion_provenance.py
+++ b/services/orion-field-digester/tests/test_diffusion_provenance.py
@@ -271,3 +271,75 @@ def test_capability_with_no_pressure_target_keeps_reconciled_baseline() -> None:
     # test, so the derived-formula block never ran.
     assert tgt["confidence"] == 1.0
     assert tgt["available_capacity"] == 1.0
+
+
+def test_direct_confidence_and_capacity_diffusion_beats_pressure_derived_formula() -> None:
+    # capability:transport (real topology edge, node:athena -> capability:
+    # transport) has direct edges into "confidence" (from delivery_confidence)
+    # and "available_capacity" (from bus_health) AND a "pressure" target in
+    # the same edge -- the pressure-derived formula must not clobber the
+    # direct diffusion values just because "pressure" is also present.
+    edge = FieldEdgeV1(
+        source_id="node:athena",
+        target_id="capability:transport",
+        edge_type="node_capability",
+        weight=0.85,
+        channel_map={
+            "transport_pressure": "pressure",
+            "delivery_confidence": "confidence",
+            "bus_health": "available_capacity",
+        },
+    )
+    state = _state(
+        [edge],
+        {
+            "node:athena": {
+                "transport_pressure": 0.9,
+                "delivery_confidence": 0.95,
+                "bus_health": 0.7,
+            }
+        },
+    )
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    tgt = state.capability_vectors["capability:transport"]
+    # pressure-derived formula would give confidence=1-0.5*0.765=0.6175 and
+    # available_capacity=1-0.765=0.235 -- direct diffusion must win instead.
+    assert tgt["pressure"] == 0.765
+    assert tgt["confidence"] == round(0.95 * 0.85, 10)
+    assert tgt["available_capacity"] == round(0.7 * 0.85, 10)
+
+
+def test_derived_formula_still_falls_back_when_direct_edge_contributes_nothing_this_tick() -> None:
+    # Regression found by code review (2026-07-12): the precedence guard
+    # must key off "did a real (>0) contribution land THIS tick", not "is
+    # this channel ever configured as a diffusion target for this
+    # capability" -- otherwise a capability:transport tick where
+    # delivery_confidence/bus_health are temporarily absent from the source
+    # (0.0 contribution, no entry in best_source) would hard-floor
+    # confidence/available_capacity at 0.0 instead of falling back to the
+    # pressure-derived formula.
+    edge = FieldEdgeV1(
+        source_id="node:athena",
+        target_id="capability:transport",
+        edge_type="node_capability",
+        weight=0.85,
+        channel_map={
+            "transport_pressure": "pressure",
+            "delivery_confidence": "confidence",
+            "bus_health": "available_capacity",
+        },
+    )
+    state = _state(
+        [edge],
+        {"node:athena": {"transport_pressure": 0.9}},  # no delivery_confidence/bus_health this tick
+    )
+
+    apply_diffusion(state, diffusion_rate=1.0)
+
+    tgt = state.capability_vectors["capability:transport"]
+    assert tgt["pressure"] == 0.765
+    # Fallback to the derived formula, not hard-floored at 0.0.
+    assert tgt["confidence"] == max(0.0, 1.0 - 0.5 * 0.765)
+    assert tgt["available_capacity"] == max(0.0, 1.0 - 0.765)


### PR DESCRIPTION
## Summary

- Fixed a live-but-masked bug in `apply_diffusion()`: `capability:transport`'s direct diffusion edges into `confidence` (from `delivery_confidence`) and `available_capacity` (from `bus_health`) were unconditionally overwritten by a pressure-derived formula whenever `pressure` was also a target for that capability, silently making the direct edges pointless.
- This was flagged as a known, unfixed quirk in the previous diffusion-saturation-fix PR (`ed452331`) and is resolved here as its own scoped follow-up.
- Gated the derived-formula fallback on `best_source` (a real `>0` contribution landing THIS tick for that specific channel) rather than static channel-map membership — this matters because a first draft of the fix (gating on the static `channels` set) would have hard-floored `confidence`/`available_capacity` at `0.0` on any tick where the direct edge's source happened to have no value for that field, which is worse than the original bug. Caught and fixed via code review before commit.
- Two new regression tests added.

## Outcome moved

`capability:transport`'s `confidence`/`available_capacity` now genuinely reflect `delivery_confidence`/`bus_health` diffusion when real, and fall back gracefully to the pressure-derived formula only when nothing real landed that tick — instead of one formula always winning regardless of what actually happened.

## Current architecture

`services/orion-field-digester/app/digestion/diffusion.py`'s `apply_diffusion()` (rewritten 2026-07-12 in the earlier saturation-fix PR to be memoryless per diffusion-target channel) recomputes every capability channel each tick from `state.edges`. A post-loop block derives `confidence`/`available_capacity` from `pressure` whenever `pressure` is a target for that capability — originally with no awareness that some capabilities also receive those two channels directly from other edges.

## Architecture touched

`orion-field-digester` only — no schema, bus, or cross-service contract changes.

## Files changed

- `services/orion-field-digester/app/digestion/diffusion.py`: gate the pressure-derived `confidence`/`available_capacity` formula on `best_source` (per-tick real contribution) instead of unconditionally overwriting, and instead of the static-membership check that would have hard-floored the channels to `0.0` on a temporarily-missing direct contribution.
- `services/orion-field-digester/tests/test_diffusion_provenance.py`: added `test_direct_confidence_and_capacity_diffusion_beats_pressure_derived_formula` (direct diffusion wins when it fires) and `test_derived_formula_still_falls_back_when_direct_edge_contributes_nothing_this_tick` (derived formula still runs as a safety net when the direct edge contributes nothing that tick).

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. :services/orion-field-digester pytest services/orion-field-digester/tests -q
22 passed

PYTHONPATH=. pytest tests/test_self_state_runtime_store.py tests/test_self_state_deviation.py \
  tests/test_self_state_transport_dimension.py tests/test_self_state_builder.py \
  tests/test_self_state_reliability_decontamination.py tests/test_self_state_prediction.py \
  tests/test_self_state_policy_loader.py tests/test_self_state_builder_hardening.py \
  tests/test_self_state_scoring.py tests/test_self_state_schemas.py tests/test_field_state_schemas.py -q
56 passed
```

## Evals run

None applicable — this is a deterministic formula-precedence fix, covered fully by unit tests.

## Docker/build/smoke checks

Not run for this branch — not deployed. (The prior saturation fix on this same file IS live on Athena; this follow-up fix is a separate, additive change not yet built/deployed.)

## Review findings fixed

- Finding: gating the derived-formula fallback on static `channels` membership (every configured target for a capability, whether or not it fired this tick) instead of per-tick real contribution would hard-floor `confidence`/`available_capacity` at `0.0` whenever `delivery_confidence`/`bus_health` are temporarily absent from the source data — worse than the pre-existing bug.
  - Fix: gate on `(target_id, channel) not in best_source` instead, which only tracks real (`>0`) contributions from this specific tick.
  - Evidence: new test `test_derived_formula_still_falls_back_when_direct_edge_contributes_nothing_this_tick` reproduces the missing-source-field scenario and asserts the derived formula still fires; independently re-verified via a second review pass confirming no other capability in `config/field/orion_field_topology.v1.yaml` has any edge feeding `confidence`/`available_capacity` besides `capability:transport`, so the fix cannot wrongly suppress the safety net elsewhere.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-field-digester/.env \
  -f services/orion-field-digester/docker-compose.yml \
  up -d --build orion-athena-field-digester
```

Not run — deliberately left for Juniper to trigger, matching the standing deploy-authorization pattern from this session.

## Risks / concerns

- Severity: low
- Concern: this changes `capability:transport`'s `confidence`/`available_capacity` values whenever `transport_pressure` is nonzero AND `delivery_confidence`/`bus_health` diverge from what the pressure-derived formula would produce. Currently masked in live traffic (`transport_pressure` has been idle), so the behavioral change will be invisible until real transport pressure occurs.
- Mitigation: none needed beyond the tests — this is strictly a correctness fix (direct sensor data should win over a derived proxy), not a new behavior needing a flag.

## PR link

Branch pushed: `fix/field-digester-transport-confidence-precedence`