### PR TITLE
Fix/state service http latest missing kwarg

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-12-state-service-http-latest-kwarg-fix-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-state-service-http-latest-kwarg-fix-pr.md
@@ -1,0 +1,71 @@
+## Summary
+
+- Fixed `GET /state/latest` (orion-state-service's HTTP debug route) throwing `TypeError` on every call.
+- `http_get_latest` called `STORE.get_latest(req)` without the required keyword-only `biometrics_stale_after_sec` argument; the bus-RPC path (`_handle_get_latest`) already passed it correctly.
+- Found during Phase 4 (`CLUSTER_ROLE_WEIGHTS` research, `docs/notes/2026-07-12-phase4-cluster-weighting-research.md`), flagged there as "not fixed here," fixed now as its own small patch.
+
+## Outcome moved
+
+The HTTP debug endpoint is now callable instead of 500ing on every request. Low-stakes (only the bus-RPC path is exercised by real services today), but it's the only externally-curlable way to inspect this service's state without a bus client.
+
+## Current architecture
+
+`services/orion-state-service/app/main.py` exposes both a bus-RPC handler (`_handle_get_latest`, correct) and an HTTP debug route (`http_get_latest`, was broken) over the same `StateStore.get_latest()` method, which requires `biometrics_stale_after_sec` as a keyword-only argument.
+
+## Architecture touched
+
+`orion-state-service` only. No contract changes.
+
+## Files changed
+
+- `services/orion-state-service/app/main.py`: pass `biometrics_stale_after_sec=float(settings.biometrics_stale_after_sec)` in `http_get_latest`, matching `_handle_get_latest`.
+- `tests/test_state_service_http_latest.py` (new): regression test — confirmed it fails against the pre-fix code (`AssertionError: assert 'biometrics_stale_after_sec' in {}`) and passes against the fix.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=. pytest tests/test_state_service_http_latest.py -q
+1 passed
+
+(confirmed regression: same test against pre-fix main.py via git stash -> 1 failed)
+```
+
+## Evals run
+
+None applicable — deterministic one-line kwarg fix.
+
+## Docker/build/smoke checks
+
+Not run — not deployed.
+
+## Review findings fixed
+
+None — single Explore-agent review pass returned PASS with no findings (settings field confirmed to exist, mock realistic, no adjacent bugs).
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-state-service/.env \
+  -f services/orion-state-service/docker-compose.yml \
+  up -d --build orion-athena-state-service
+```
+
+Not run — left for Juniper to trigger.
+
+## Risks / concerns
+
+None — isolated, deterministic, test-covered fix with no behavioral change to the bus-RPC path.
+
+## PR link
+
+Branch pushed: `fix/state-service-http-latest-missing-kwarg`

--- a/services/orion-state-service/app/main.py
+++ b/services/orion-state-service/app/main.py
@@ -289,7 +289,7 @@ async def http_get_latest(
     if STORE is None:
         raise HTTPException(status_code=503, detail="state_store_not_ready")
     req = StateGetLatestRequest(scope=scope, node=node)
-    reply = await STORE.get_latest(req)
+    reply = await STORE.get_latest(req, biometrics_stale_after_sec=float(settings.biometrics_stale_after_sec))
     return JSONResponse(reply.model_dump(mode="json"))
 
 

--- a/tests/test_state_service_http_latest.py
+++ b/tests/test_state_service_http_latest.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+REPO = Path(__file__).resolve().parents[1]
+SVC = REPO / "services" / "orion-state-service"
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(SVC))
+
+from app import main as state_service_main  # noqa: E402
+from orion.schemas.state.contracts import StateLatestReply  # noqa: E402
+
+
+def test_http_get_latest_passes_biometrics_stale_after_sec(monkeypatch) -> None:
+    # Regression: http_get_latest previously called STORE.get_latest(req)
+    # without the required keyword-only biometrics_stale_after_sec argument
+    # that StateStore.get_latest() needs (the bus-RPC path, _handle_get_latest,
+    # already passed it correctly) -- confirmed live via a TypeError on every
+    # GET /state/latest call (2026-07-12 research finding). The HTTP route
+    # must pass it the same way the RPC path does.
+    fake_store = AsyncMock()
+    fake_store.get_latest.return_value = StateLatestReply(status="missing")
+    monkeypatch.setattr(state_service_main, "STORE", fake_store)
+
+    asyncio.run(state_service_main.http_get_latest(scope="global", node=None))
+
+    fake_store.get_latest.assert_awaited_once()
+    _, kwargs = fake_store.get_latest.call_args
+    assert "biometrics_stale_after_sec" in kwargs
+    assert isinstance(kwargs["biometrics_stale_after_sec"], float)


### PR DESCRIPTION
## Summary

- Fixed `GET /state/latest` (orion-state-service's HTTP debug route) throwing `TypeError` on every call.
- `http_get_latest` called `STORE.get_latest(req)` without the required keyword-only `biometrics_stale_after_sec` argument; the bus-RPC path (`_handle_get_latest`) already passed it correctly.
- Found during Phase 4 (`CLUSTER_ROLE_WEIGHTS` research, `docs/notes/2026-07-12-phase4-cluster-weighting-research.md`), flagged there as "not fixed here," fixed now as its own small patch.

## Outcome moved

The HTTP debug endpoint is now callable instead of 500ing on every request. Low-stakes (only the bus-RPC path is exercised by real services today), but it's the only externally-curlable way to inspect this service's state without a bus client.

## Current architecture

`services/orion-state-service/app/main.py` exposes both a bus-RPC handler (`_handle_get_latest`, correct) and an HTTP debug route (`http_get_latest`, was broken) over the same `StateStore.get_latest()` method, which requires `biometrics_stale_after_sec` as a keyword-only argument.

## Architecture touched

`orion-state-service` only. No contract changes.

## Files changed

- `services/orion-state-service/app/main.py`: pass `biometrics_stale_after_sec=float(settings.biometrics_stale_after_sec)` in `http_get_latest`, matching `_handle_get_latest`.
- `tests/test_state_service_http_latest.py` (new): regression test — confirmed it fails against the pre-fix code (`AssertionError: assert 'biometrics_stale_after_sec' in {}`) and passes against the fix.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. pytest tests/test_state_service_http_latest.py -q
1 passed

(confirmed regression: same test against pre-fix main.py via git stash -> 1 failed)
```

## Evals run

None applicable — deterministic one-line kwarg fix.

## Docker/build/smoke checks

Not run — not deployed.

## Review findings fixed

None — single Explore-agent review pass returned PASS with no findings (settings field confirmed to exist, mock realistic, no adjacent bugs).

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-state-service/.env \
  -f services/orion-state-service/docker-compose.yml \
  up -d --build orion-athena-state-service
```

Not run — left for Juniper to trigger.

## Risks / concerns

None — isolated, deterministic, test-covered fix with no behavioral change to the bus-RPC path.

## PR link

Branch pushed: `fix/state-service-http-latest-missing-kwarg`