### PR TITLE
Fix/stance react imperative clamp

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-12-stance-react-imperative-clamp-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-stance-react-imperative-clamp-pr.md
@@ -1,0 +1,84 @@
+# PR: Clamp overlong stance_react imperative/tone instead of fail-closing the turn
+
+## Summary
+
+- `ThoughtEventV1.imperative` enforced a hard `Field(max_length=300)`. When the stance_react LLM overshot it, `ThoughtEventV1.model_validate` raised inside `parse_stance_react_payload`, and `services/orion-thought/app/bus_listener.py`'s generic `except Exception` converted the whole turn into a fail-closed defer via `build_stance_react_failure_thought` — discarding an entire already-paid brain-tier LLM turn over a few stray characters.
+- `imperative` is not the user's message — it's an LLM-generated "efference copy" felt-layer directive (`orion/cognition/prompts/stance_react.j2:69`), concatenated directly into the FCC motor prompt alongside the full, uncapped `user_message` (`orion/harness/prefix.py:106,118`). The cap itself is a deliberate design constraint to keep it terse, not a content-loss bug — confirmed during review that raw user input was never at risk.
+- `normalize_stance_react_raw` now clamps `imperative`/`tone` (logging a warning when it fires) before Pydantic validation runs, so overflow degrades gracefully instead of dropping the turn.
+- Schema cap bumped 300→400 as headroom (the prompt still instructs the LLM to target 300 chars — 400 is enforcement slack, not a new target).
+- Added a regression test pinning the clamp constants (`IMPERATIVE_MAX_LEN`, `TONE_MAX_LEN`) to the schema's actual `max_length`, so the two can't silently drift apart and reintroduce the bug.
+
+## Outcome moved
+
+An oversized `imperative`/`tone` field from the stance_react LLM call no longer discards the whole turn's stance output (fail-closed defer, empty imperative, dropped stance slice); it truncates and logs instead, preserving the rest of the already-computed turn.
+
+## Current architecture
+
+`orion/thought/stance_react.py:normalize_stance_react_raw` coerces LLM JSON into typed strings before `ThoughtEventV1.model_validate` runs — handling nulls, bools, wrong types — but previously did no length clamping, relying entirely on Pydantic's hard `max_length` to reject rather than truncate. `stance_react` runs on the full brain-tier "chat" LLM lane (`services/orion-cortex-exec/app/llm_lane.py:34-92` resolves it to `llm_lane="chat"`, high priority), never the deterministic quick lane (`docs/superpowers/specs/2026-07-05-orion-unified-turn-design.md:51,765` — quick lane is explicitly disallowed for stance_react), so a rejected turn here always throws away a real paid LLM call.
+
+## Files changed
+
+- `orion/schemas/thought.py`: `ThoughtEventV1.imperative` max_length 300→400.
+- `orion/thought/stance_react.py`: new `_coerce_and_clamp_str` helper (wraps `_coerce_required_str`, truncates and logs on overflow); wired into `normalize_stance_react_raw` for `imperative` (400) and `tone` (200); `correlation_id` extracted up front for log correlation.
+- `orion/thought/tests/test_stance_react_pipeline.py`: 3 new tests — clamp behavior for overlong `imperative`, clamp behavior for overlong `tone`, and a drift guard asserting the clamp constants match `ThoughtEventV1.model_fields[...]`'s live schema constraint.
+
+## Schema / bus / API changes
+
+- Behavior changed: `ThoughtEventV1.imperative` max_length 300 → 400 (schema-level cap; not a bus channel or event-shape change).
+- Compatibility notes: checked `orion/schemas/harness_finalize.py:111`'s `stance_imperative` field (also capped at 300) — its only writer, `orion/harness/finalize.py:1036-1039`, independently truncates via its own `_excerpt(text, max_len=300)` before assignment, so it can't overflow regardless of this change. No other consumer in the codebase assumes `imperative` stays ≤300 chars.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+.venv/bin/python -m pytest orion/thought/tests orion/schemas/tests/test_thought.py -q
+→ 39 passed
+```
+
+Confirmed via `git stash` that these pre-existing failures on `main` are unrelated to this diff:
+```text
+services/orion-thought/tests/test_reverie_spontaneous_thought.py (3 tests)
+services/orion-thought/tests/test_settings_salience_flags.py::test_salience_flags_default_off
+orion/harness/tests/test_grounding_capsule_consumers.py (2 tests)
+orion/harness/tests/test_harness_runner.py::test_harness_runner_surfaces_fcc_error_code
+```
+
+`git diff --check`: clean.
+
+## Evals run
+
+None applicable — no eval harness exists for this seam; this is a schema-validation clamp fix with deterministic unit coverage, not a quality/behavior judgment call.
+
+## Docker/build/smoke checks
+
+Not applicable — pure Python logic change in `orion/thought` and `orion/schemas`, no config, dependency, or runtime-boot surface touched.
+
+## Review findings fixed
+
+Two-angle subagent review (correctness: line-scan/removed-behavior/cross-file-tracing; cleanup/altitude/conventions) plus self-verification.
+
+- Finding: `IMPERATIVE_MAX_LEN`/`TONE_MAX_LEN` in `stance_react.py` duplicated the schema's `Field(max_length=...)` in `thought.py` as two independent hardcoded numbers.
+  - Fix: added `test_stance_react_clamp_lens_match_schema_max_length`, which introspects `ThoughtEventV1.model_fields[...]` at test time and asserts the clamp constants match the live schema constraint — a future edit to one without the other now fails CI instead of silently reintroducing the fail-closed bug.
+  - Evidence: `.venv/bin/python -m pytest orion/thought/tests/test_stance_react_pipeline.py -q` → 16 passed, including the new drift-guard test.
+- Finding: `_coerce_and_clamp_str`'s truncation duplicates `orion/harness/finalize.py`'s `_excerpt` helper (same `text[:max_len]` idea, different field).
+  - Fix: not changed — the two live in different layers (`orion.harness` vs `orion.thought`) with different signatures (logging, field name, correlation id vs a bare default), and sharing a one-line slice across modules would add cross-layer coupling for no real benefit. Judged not material.
+  - Evidence: confirmed both call sites and signatures directly; no existing shared string-clamp utility module in the repo to route through instead.
+- Finding: verified `correlation_id` is actually populated at the point `normalize_stance_react_raw` reads it (not `None` in the real path).
+  - Fix: not needed — confirmed `parse_stance_react_payload` calls `raw.setdefault("correlation_id", correlation_id)` before `normalize_stance_react_raw(raw)` runs, so the log line sees the real correlation id on the only production call site (`services/orion-thought/app/bus_listener.py:305`).
+
+## Restart required
+
+No restart required. This changes pure Python validation/coercion logic in a library module consumed at request time by `services/orion-thought`; the running service picks it up on its next normal deploy/restart cycle, no forced restart needed for correctness.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `_coerce_and_clamp_str` truncation is a plain character-count slice; if `imperative`/`tone` ever carry meaningful trailing content (e.g. a closing instruction), it could be cut mid-thought.
+- Mitigation: this only fires when the LLM already exceeded the prompt's instructed 300-char target — already a prompt-discipline miss — and truncation is strictly better than the prior behavior of discarding the entire turn. The new `logger.warning` gives visibility if this starts firing often, which would be a signal to revisit the prompt rather than the clamp.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/stance-react-imperative-clamp

--- a/orion/schemas/thought.py
+++ b/orion/schemas/thought.py
@@ -76,7 +76,7 @@ class ThoughtEventV1(BaseModel):
     created_at: datetime
     profile: Literal["stance_react"] = "stance_react"
 
-    imperative: str = Field(max_length=300)
+    imperative: str = Field(max_length=400)
     tone: str = Field(max_length=200)
     strain_refs: list[str]
 

--- a/orion/thought/stance_react.py
+++ b/orion/thought/stance_react.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 from typing import Any, Literal, cast
 from uuid import uuid4
@@ -14,6 +15,11 @@ from orion.thought.coalition import (
 )
 from orion.thought.policy_refusal import evaluate_thought_disposition
 from orion.thought.stance_quality import enforce_thought_stance_quality
+
+logger = logging.getLogger(__name__)
+
+IMPERATIVE_MAX_LEN = 400
+TONE_MAX_LEN = 200
 
 
 def _coerce_optional_str(value: Any) -> str | None:
@@ -57,9 +63,33 @@ def _coerce_required_str(value: Any, *, default: str) -> str:
     return text or default
 
 
+def _coerce_and_clamp_str(
+    value: Any,
+    *,
+    default: str,
+    max_len: int,
+    field: str,
+    correlation_id: str | None,
+) -> str:
+    """Coerce like _coerce_required_str, then clamp overlong LLM output instead of
+    letting ThoughtEventV1's Field(max_length=...) reject the whole turn."""
+    text = _coerce_required_str(value, default=default)
+    if len(text) > max_len:
+        logger.warning(
+            "stance_react_field_overflow field=%s len=%d max=%d corr=%s — clamping",
+            field,
+            len(text),
+            max_len,
+            correlation_id,
+        )
+        text = text[:max_len]
+    return text
+
+
 def normalize_stance_react_raw(raw: dict[str, Any]) -> dict[str, Any]:
     """Coerce common LLM JSON mistakes before ThoughtEventV1 validation."""
     data = dict(raw)
+    correlation_id = _coerce_optional_str(data.get("correlation_id"))
     data["event_id"] = _coerce_required_str(data.get("event_id"), default=str(uuid4()))
     data["created_at"] = _coerce_required_str(
         data.get("created_at"),
@@ -68,8 +98,20 @@ def normalize_stance_react_raw(raw: dict[str, Any]) -> dict[str, Any]:
     data["profile"] = _coerce_required_str(data.get("profile"), default="stance_react")
     data["producer"] = _coerce_required_str(data.get("producer"), default="stance_react_v1")
     data["llm_profile"] = _coerce_required_str(data.get("llm_profile"), default="brain")
-    data["imperative"] = _coerce_required_str(data.get("imperative"), default="")
-    data["tone"] = _coerce_required_str(data.get("tone"), default="neutral")
+    data["imperative"] = _coerce_and_clamp_str(
+        data.get("imperative"),
+        default="",
+        max_len=IMPERATIVE_MAX_LEN,
+        field="imperative",
+        correlation_id=correlation_id,
+    )
+    data["tone"] = _coerce_and_clamp_str(
+        data.get("tone"),
+        default="neutral",
+        max_len=TONE_MAX_LEN,
+        field="tone",
+        correlation_id=correlation_id,
+    )
     data["strain_refs"] = _coerce_str_list(data.get("strain_refs"))
     data["evidence_refs"] = _coerce_str_list(data.get("evidence_refs"))
     data["disposition_reasons"] = _coerce_str_list(data.get("disposition_reasons"))

--- a/orion/thought/tests/test_stance_react_pipeline.py
+++ b/orion/thought/tests/test_stance_react_pipeline.py
@@ -16,7 +16,12 @@ from orion.schemas.thought import (
 )
 from orion.thought.coalition import coalition_ids_from_association
 from orion.thought.policy_refusal import TRUST_RUPTURE_DEFER_THRESHOLD
-from orion.thought.stance_react import apply_stance_react_pipeline, parse_stance_react_payload
+from orion.thought.stance_react import (
+    IMPERATIVE_MAX_LEN,
+    TONE_MAX_LEN,
+    apply_stance_react_pipeline,
+    parse_stance_react_payload,
+)
 
 
 def _broadcast(
@@ -137,6 +142,37 @@ def test_parse_stance_react_payload_coerces_null_event_id() -> None:
     raw["event_id"] = None
     parsed = parse_stance_react_payload(raw)
     assert parsed.event_id
+
+
+def test_stance_react_clamp_lens_match_schema_max_length() -> None:
+    # Guards against the clamp constants drifting from ThoughtEventV1's Field(max_length=...).
+    # If they drift apart (clamp allows more than the schema accepts), overlong LLM output
+    # would pass the clamp but still raise on ThoughtEventV1.model_validate — reintroducing
+    # the exact fail-closed-defer bug this clamp exists to prevent.
+    imperative_field = ThoughtEventV1.model_fields["imperative"]
+    tone_field = ThoughtEventV1.model_fields["tone"]
+    imperative_max = next(m.max_length for m in imperative_field.metadata if hasattr(m, "max_length"))
+    tone_max = next(m.max_length for m in tone_field.metadata if hasattr(m, "max_length"))
+    assert IMPERATIVE_MAX_LEN == imperative_max
+    assert TONE_MAX_LEN == tone_max
+
+
+def test_parse_stance_react_payload_clamps_overlong_imperative() -> None:
+    raw = _thought().model_dump(mode="json")
+    overlong = "x" * 500
+    raw["imperative"] = overlong
+    parsed = parse_stance_react_payload(raw)
+    assert len(parsed.imperative) == 400
+    assert parsed.imperative == overlong[:400]
+
+
+def test_parse_stance_react_payload_clamps_overlong_tone() -> None:
+    raw = _thought().model_dump(mode="json")
+    overlong_tone = "y" * 300
+    raw["tone"] = overlong_tone
+    parsed = parse_stance_react_payload(raw)
+    assert len(parsed.tone) == 200
+    assert parsed.tone == overlong_tone[:200]
 
 
 def test_apply_stance_react_pipeline_proceed() -> None:


### PR DESCRIPTION
# PR: Clamp overlong stance_react imperative/tone instead of fail-closing the turn

## Summary

- `ThoughtEventV1.imperative` enforced a hard `Field(max_length=300)`. When the stance_react LLM overshot it, `ThoughtEventV1.model_validate` raised inside `parse_stance_react_payload`, and `services/orion-thought/app/bus_listener.py`'s generic `except Exception` converted the whole turn into a fail-closed defer via `build_stance_react_failure_thought` — discarding an entire already-paid brain-tier LLM turn over a few stray characters.
- `imperative` is not the user's message — it's an LLM-generated "efference copy" felt-layer directive (`orion/cognition/prompts/stance_react.j2:69`), concatenated directly into the FCC motor prompt alongside the full, uncapped `user_message` (`orion/harness/prefix.py:106,118`). The cap itself is a deliberate design constraint to keep it terse, not a content-loss bug — confirmed during review that raw user input was never at risk.
- `normalize_stance_react_raw` now clamps `imperative`/`tone` (logging a warning when it fires) before Pydantic validation runs, so overflow degrades gracefully instead of dropping the turn.
- Schema cap bumped 300→400 as headroom (the prompt still instructs the LLM to target 300 chars — 400 is enforcement slack, not a new target).
- Added a regression test pinning the clamp constants (`IMPERATIVE_MAX_LEN`, `TONE_MAX_LEN`) to the schema's actual `max_length`, so the two can't silently drift apart and reintroduce the bug.

## Outcome moved

An oversized `imperative`/`tone` field from the stance_react LLM call no longer discards the whole turn's stance output (fail-closed defer, empty imperative, dropped stance slice); it truncates and logs instead, preserving the rest of the already-computed turn.

## Current architecture

`orion/thought/stance_react.py:normalize_stance_react_raw` coerces LLM JSON into typed strings before `ThoughtEventV1.model_validate` runs — handling nulls, bools, wrong types — but previously did no length clamping, relying entirely on Pydantic's hard `max_length` to reject rather than truncate. `stance_react` runs on the full brain-tier "chat" LLM lane (`services/orion-cortex-exec/app/llm_lane.py:34-92` resolves it to `llm_lane="chat"`, high priority), never the deterministic quick lane (`docs/superpowers/specs/2026-07-05-orion-unified-turn-design.md:51,765` — quick lane is explicitly disallowed for stance_react), so a rejected turn here always throws away a real paid LLM call.

## Files changed

- `orion/schemas/thought.py`: `ThoughtEventV1.imperative` max_length 300→400.
- `orion/thought/stance_react.py`: new `_coerce_and_clamp_str` helper (wraps `_coerce_required_str`, truncates and logs on overflow); wired into `normalize_stance_react_raw` for `imperative` (400) and `tone` (200); `correlation_id` extracted up front for log correlation.
- `orion/thought/tests/test_stance_react_pipeline.py`: 3 new tests — clamp behavior for overlong `imperative`, clamp behavior for overlong `tone`, and a drift guard asserting the clamp constants match `ThoughtEventV1.model_fields[...]`'s live schema constraint.

## Schema / bus / API changes

- Behavior changed: `ThoughtEventV1.imperative` max_length 300 → 400 (schema-level cap; not a bus channel or event-shape change).
- Compatibility notes: checked `orion/schemas/harness_finalize.py:111`'s `stance_imperative` field (also capped at 300) — its only writer, `orion/harness/finalize.py:1036-1039`, independently truncates via its own `_excerpt(text, max_len=300)` before assignment, so it can't overflow regardless of this change. No other consumer in the codebase assumes `imperative` stays ≤300 chars.

## Env/config changes

None.

## Tests run

```text
.venv/bin/python -m pytest orion/thought/tests orion/schemas/tests/test_thought.py -q
→ 39 passed
```

Confirmed via `git stash` that these pre-existing failures on `main` are unrelated to this diff:
```text
services/orion-thought/tests/test_reverie_spontaneous_thought.py (3 tests)
services/orion-thought/tests/test_settings_salience_flags.py::test_salience_flags_default_off
orion/harness/tests/test_grounding_capsule_consumers.py (2 tests)
orion/harness/tests/test_harness_runner.py::test_harness_runner_surfaces_fcc_error_code
```

`git diff --check`: clean.

## Evals run

None applicable — no eval harness exists for this seam; this is a schema-validation clamp fix with deterministic unit coverage, not a quality/behavior judgment call.

## Docker/build/smoke checks

Not applicable — pure Python logic change in `orion/thought` and `orion/schemas`, no config, dependency, or runtime-boot surface touched.

## Review findings fixed

Two-angle subagent review (correctness: line-scan/removed-behavior/cross-file-tracing; cleanup/altitude/conventions) plus self-verification.

- Finding: `IMPERATIVE_MAX_LEN`/`TONE_MAX_LEN` in `stance_react.py` duplicated the schema's `Field(max_length=...)` in `thought.py` as two independent hardcoded numbers.
  - Fix: added `test_stance_react_clamp_lens_match_schema_max_length`, which introspects `ThoughtEventV1.model_fields[...]` at test time and asserts the clamp constants match the live schema constraint — a future edit to one without the other now fails CI instead of silently reintroducing the fail-closed bug.
  - Evidence: `.venv/bin/python -m pytest orion/thought/tests/test_stance_react_pipeline.py -q` → 16 passed, including the new drift-guard test.
- Finding: `_coerce_and_clamp_str`'s truncation duplicates `orion/harness/finalize.py`'s `_excerpt` helper (same `text[:max_len]` idea, different field).
  - Fix: not changed — the two live in different layers (`orion.harness` vs `orion.thought`) with different signatures (logging, field name, correlation id vs a bare default), and sharing a one-line slice across modules would add cross-layer coupling for no real benefit. Judged not material.
  - Evidence: confirmed both call sites and signatures directly; no existing shared string-clamp utility module in the repo to route through instead.
- Finding: verified `correlation_id` is actually populated at the point `normalize_stance_react_raw` reads it (not `None` in the real path).
  - Fix: not needed — confirmed `parse_stance_react_payload` calls `raw.setdefault("correlation_id", correlation_id)` before `normalize_stance_react_raw(raw)` runs, so the log line sees the real correlation id on the only production call site (`services/orion-thought/app/bus_listener.py:305`).

## Restart required

No restart required. This changes pure Python validation/coercion logic in a library module consumed at request time by `services/orion-thought`; the running service picks it up on its next normal deploy/restart cycle, no forced restart needed for correctness.

## Risks / concerns

- Severity: low
- Concern: `_coerce_and_clamp_str` truncation is a plain character-count slice; if `imperative`/`tone` ever carry meaningful trailing content (e.g. a closing instruction), it could be cut mid-thought.
- Mitigation: this only fires when the LLM already exceeded the prompt's instructed 300-char target — already a prompt-discipline miss — and truncation is strictly better than the prior behavior of discarding the entire turn. The new `logger.warning` gives visibility if this starts firing often, which would be a signal to revisit the prompt rather than the clamp.
