### PR TITLE
Feat/spark introspector golden phi replaces heuristic

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-12-spark-introspector-golden-phi-replaces-heuristic-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-spark-introspector-golden-phi-replaces-heuristic-pr.md
@@ -1,0 +1,95 @@
+## Summary
+
+- The only "phi" ever reaching orion-cortex-exec's live metacognition prompts (`log_orion_metacognition_draft.j2`/`_enrich.j2`, via `spark_narrative.py`'s `spark_phi_hint`/`spark_phi_narrative`) was `_phi_from_self_state()` — a hand-tuned, untrained heuristic, not the trained MLP autoencoder retrained earlier today. The trained encoder's real output (`PhiIntrinsicRewardV1`) had zero consumers beyond a SQL sink (`orion-sql-writer`) and a debug WebSocket EKG panel.
+- Wired the trained encoder's output into `phi_now`'s `coherence`/`energy`/`novelty` axes whenever it's enabled and healthy this tick, so the golden (trained) phi is what actually reaches cognition.
+- `valence` deliberately left on the heuristic — the active encoder's latent probes show zero correlation between any latent dim and any hedonic-adjacent felt dimension, so there is no trained analog to source it from; fabricating one would be exactly the empty-shell-cognition pattern this change exists to remove.
+- Code review caught and I fixed a real bug in the first draft: without resetting the encoder's tick-to-tick delta tracking on every skip/failure path, a resumed tick after any gap would compute a delta spanning multiple skipped ticks, landing a misleadingly large value in a now-prompt-facing field.
+- Also fixed a pre-existing, unrelated test bug (stale `features_version` in a test fixture, silently no-opping the encoder in that test).
+
+## Outcome moved
+
+`SparkStateSnapshotV1.phi` (and therefore the live metacognition prompt's coherence/arousal/novelty framing) now reflects the actual trained autoencoder — the same encoder just retrained today on post-fix data and confirmed non-collapsed — instead of an untrained hand-written formula that happened to be the only thing ever wired to real cognition.
+
+## Current architecture
+
+`services/orion-spark-introspector/app/worker.py`'s `handle_self_state()` computed `phi_now = _phi_from_self_state(ss)` (4-key dict: coherence/energy/novelty/valence) every self-state tick, published it as `SparkStateSnapshotV1.phi`, and separately — when the trained encoder was enabled and healthy — computed `out.phi`/`out.recon_error`/`delta_phi` and published them only as `PhiIntrinsicRewardV1` to a SQL-sink-only channel. Two independent phi computations, only one of which reached cognition.
+
+## Architecture touched
+
+`orion-spark-introspector` only. `orion-cortex-exec`'s `spark_narrative.py` needed zero changes — it already reads `snapshot.phi.get(...)` generically, so overriding the dict's values at the source was a thin, single-service seam.
+
+## Files changed
+
+- `services/orion-spark-introspector/app/worker.py`:
+  - New `_golden_phi_overrides()` — pure function mapping trained-encoder output to the 3 axes with principled analogs, with a documented rationale for why `valence` is excluded.
+  - `handle_self_state()`: overrides `phi_now`'s coherence/energy/novelty when the encoder tick succeeds; introduces `encoder_tick_ok` flag (set only at the end of a fully successful try block) so `_PHI_PREV_PHI`/`_PHI_PREV_RECON` reset to `None` on any skip or mid-inference exception, preventing a stale multi-tick delta from landing in the now-prompt-facing `energy` field.
+- `services/orion-spark-introspector/tests/test_phi_reward_emit.py`:
+  - New `test_golden_phi_overrides_coherence_energy_novelty_not_valence` — asserts the snapshot's coherence/energy/novelty match the trained encoder's output and valence still matches the heuristic.
+  - New `test_phi_prev_resets_across_a_skipped_tick` — 3-tick regression: healthy → skipped (grammar-degraded) → healthy, asserting `delta_phi` on the third tick is a fresh `0.0`, not `tick3.phi - tick1.phi`.
+  - Fixed `test_phi_reward_emitted_when_encoder_ok` (pre-existing, unrelated failure — confirmed via `git stash` against main before this branch existed): `settings.inner_features_version` defaults to `"seed-v3"` but the test's tiny encoder manifest declares `features_version="seed-v2"`, so `PhiEncoderRuntime.load()` silently returned `None` and the test's own assertion always failed. Added the missing monkeypatch.
+
+## Schema / bus / API changes
+
+None. `PhiIntrinsicRewardV1`/`SparkStateSnapshotV1` schemas unchanged; only which values populate existing fields changed.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=. :services/orion-spark-introspector pytest services/orion-spark-introspector/tests -q
+135 passed, 1 skipped  (repeated 5x for the nondeterministic tiny-encoder fixture — stable every run)
+
+PYTHONPATH=. pytest tests/test_phi_encoder_mlp.py tests/test_phi_encoder_fit_script.py \
+  tests/test_spark_introspector_publish_guard.py tests/test_phi_encoder_schema.py -q
+all passed
+
+tests/test_spark_introspector_no_legacy.py::test_worker_has_no_legacy_kind -- FAILS,
+confirmed pre-existing and unrelated via `git stash` against clean main
+(checks worker.py doesn't contain the literal string "spark.introspection";
+already true before this branch, not touched by this change)
+```
+
+## Evals run
+
+None applicable — this is a wiring/logic change covered by unit tests, not a training-quality question (the encoder itself was already trained/evaluated/promoted in an earlier session turn).
+
+## Docker/build/smoke checks
+
+Not run — not deployed. Restart commands below, left for Juniper to trigger.
+
+## Review findings fixed
+
+- Finding: `_PHI_PREV_PHI`/`_PHI_PREV_RECON` only reset on the two skip paths I initially patched (encoder disabled/degraded, `enc is None`) — missed the case of an exception occurring mid-inference (between `enc.forward(x)` and the final assignment), which would leave the globals stale exactly like the original bug, just triggered a different way.
+  - Fix: restructured around an `encoder_tick_ok` flag, set only at the true end of a fully successful try block wrapping the entire encoder-inference section; the reset check now lives after the whole `if settings.inner_features_enabled:` block, so it fires on every skip/failure path uniformly, including `inner_features_enabled=False` itself.
+  - Evidence: new test `test_phi_prev_resets_across_a_skipped_tick`, verified independently by a second review pass confirming no remaining path leaves `encoder_tick_ok` unset or lets an exception escape without resetting.
+- Finding: the first version of `test_golden_phi_overrides_...`'s energy assertion was trivially `0.0 == 0.0` since `_reset_inner_state` leaves `_PHI_PREV_PHI=None`, forcing `delta_phi=0.0` by the cold-start convention — a broken energy mapping (wrong source variable, missing `abs()`, wrong clamp) would have passed silently.
+  - Fix: set `_PHI_PREV_PHI` to a known nonzero baseline before the tick under test, plus an explicit `assert reward.delta_phi != 0.0` guarding the test setup itself.
+  - Evidence: test now genuinely exercises a nonzero delta; re-ran 5x to confirm stability against the encoder fixture's unseeded random weights.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml \
+  up -d --build spark-introspector
+```
+
+Not run — deliberately left for Juniper to trigger.
+
+## Risks / concerns
+
+- Severity: medium
+- Concern: this changes the actual content of Orion's live metacognition prompt (coherence/energy/novelty framing) the moment it's deployed — a real behavior change to a chat-facing cognition surface, not just a metrics/telemetry fix like the rest of today's work.
+- Mitigation: `valence` (the one axis with genuine domain-specific hand-tuning and no honest trained replacement) is untouched; coherence/energy/novelty all have principled, documented 1:1 analogs in the trained encoder's actual output, not arbitrary relabeling. Recommend watching a chat session or two post-deploy to sanity-check the narrative reads coherently before treating this as fully settled.
+- Severity: low
+- Concern: `energy`'s scale (`|delta_phi|`, bounded [0,1] by construction) and `novelty`'s scale (`recon_error / recon_error_p95`, clamped to [0,1]) are new value distributions the prompt-banding functions (`_arousal_band`, `_overload_band` in `spark_narrative.py`) haven't been tuned against — they assume roughly-uniform [0,1] inputs, which these should satisfy, but the actual banding thresholds (0.33/0.66) were tuned against the OLD heuristic's distribution, not the new one.
+- Mitigation: none built in this patch — worth revisiting the banding thresholds once a real traffic window of the new distribution exists, same "measure before assuming" principle used everywhere else in today's work.
+
+## PR link
+
+Branch pushed: `feat/spark-introspector-golden-phi-replaces-heuristic`

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -300,6 +300,54 @@ def _phi_from_self_state(ss: SelfStateV1) -> Dict[str, float]:
     }
 
 
+def _golden_phi_overrides(
+    *,
+    phi: float,
+    delta_phi: float,
+    recon_error: float,
+    recon_error_p95_reference: float,
+) -> Dict[str, float]:
+    """Trained-encoder-derived replacements for 3 of _phi_from_self_state's 4
+    axes, used whenever the encoder is enabled and healthy this tick (2026-07-12).
+
+    _phi_from_self_state is a hand-tuned, untrained heuristic -- real
+    engineering, but not the trained autoencoder. It was the only thing ever
+    reaching orion-cortex-exec's metacognition prompts
+    (log_orion_metacognition_draft.j2 / _enrich.j2, via
+    spark_narrative.spark_phi_hint/spark_phi_narrative); the trained encoder's
+    actual output (PhiIntrinsicRewardV1) had zero consumers beyond a SQL sink
+    and a debug WebSocket EKG panel. This closes that gap for coherence/energy/
+    novelty, which have principled trained analogs:
+
+    - coherence <- phi (the encoder's own sigmoid output; this IS phi, the
+      thing the heuristic's coherence axis was already trying to approximate
+      via an untrained geometric-mean IIT-flavored formula).
+    - energy <- |delta_phi| (tick-to-tick rate of change in the trained phi;
+      arousal/activation is fundamentally about magnitude of change, not a
+      static level).
+    - novelty <- recon_error scaled by the active encoder's own training-time
+      recon_error_p95 (how anomalous this tick's reconstruction is relative to
+      what the encoder considers "normal" from its own training distribution
+      -- a real surprise signal, unlike the heuristic's novelty axis, which
+      leans on `uncertainty`, a dimension structurally near-zero whenever
+      coherence is healthy).
+
+    valence is deliberately NOT overridden here: the active encoder's latent
+    probes (probes.json) show zero correlation between any z_i and any
+    social/hedonic-adjacent felt dimension (social_pressure, agency_readiness
+    aside, which coherence/energy already draw on) -- there is no trained
+    analog to source it from. Inventing one would be exactly the fabricated-
+    signal pattern this change exists to remove. valence keeps coming from
+    _phi_from_self_state until a real trained signal for it exists.
+    """
+    scale = max(float(recon_error_p95_reference), 1e-6)
+    return {
+        "coherence": round(float(phi), 4),
+        "energy": round(min(1.0, abs(float(delta_phi))), 4),
+        "novelty": round(min(1.0, float(recon_error) / scale), 4),
+    }
+
+
 def _get_phi_stats() -> Dict[str, float]:
     """Return phi dimensions from substrate self-state when available, tissue otherwise."""
     ss = _LATEST_SELF_STATE
@@ -2522,6 +2570,17 @@ async def handle_self_state(env: BaseEnvelope) -> None:
     _PREV_PHI = phi_now
     set_latest_self_state(ss)
 
+    # Whether the trained encoder actually completed this tick. Checked at
+    # the end of this function (after every possible skip/failure path --
+    # disabled, degraded, frozen, missing weights, or an exception during
+    # inference) to decide whether _PHI_PREV_PHI/_PHI_PREV_RECON should carry
+    # forward or reset to None. Without this, a resumed tick after any gap
+    # would compute delta_phi/delta_recon spanning however many ticks were
+    # skipped, landing a stale, misleadingly large value in
+    # phi_now["energy"] -- which now reaches a live LLM metacognition prompt,
+    # not just a SQL sink (found by code review, 2026-07-12).
+    encoder_tick_ok = False
+
     global _INNER_PREV_FELT, _INNER_PREV_HEADLINE, _INNER_DEGENERATE_STREAK, _INNER_LAST_HEADLINE
     if settings.inner_features_enabled:
         gt = await _fetch_substrate_grammar_truth()
@@ -2562,44 +2621,61 @@ async def handle_self_state(env: BaseEnvelope) -> None:
         ):
             enc = _load_phi_encoder()
             if enc is not None:
-                x = enc.feature_vector_from_inner(inner)
-                out = enc.forward(x)
-                inner.headline = round(out.phi, 4)
-                inner.headline_source = "encoder"
-                inner.metadata.update({
-                    "recon_error": out.recon_error,
-                    "latent": out.latent,
-                    "encoder_version": enc.encoder_version,
-                })
-                delta_phi = 0.0 if _PHI_PREV_PHI is None else out.phi - _PHI_PREV_PHI
-                delta_recon = 0.0 if _PHI_PREV_RECON is None else out.recon_error - _PHI_PREV_RECON
-                reward = PhiIntrinsicRewardV1(
-                    generated_at=inner.generated_at,
-                    self_state_id=inner.self_state_id,
-                    encoder_version=enc.encoder_version,
-                    features_version=inner.features_version,
-                    phi=out.phi,
-                    delta_phi=delta_phi,
-                    recon_error=out.recon_error,
-                    delta_recon_error=delta_recon,
-                    latent=out.latent,
-                    attribution_top=out.attribution_top,
-                    grammar_truth_degraded=inner.grammar_truth_degraded,
-                )
-                if _pub_bus and _pub_bus.enabled:
-                    try:
-                        await _pub_bus.publish(
-                            settings.channel_phi_reward,
-                            PhiIntrinsicRewardEnvelope(
-                                source=_svc_ref(),
-                                correlation_id=uuid4(),
-                                payload=reward,
-                            ),
-                        )
-                    except Exception as exc:
-                        logger.warning("Failed to publish phi_reward: %s", exc)
-                _PHI_PREV_PHI = out.phi
-                _PHI_PREV_RECON = out.recon_error
+                try:
+                    x = enc.feature_vector_from_inner(inner)
+                    out = enc.forward(x)
+                    inner.headline = round(out.phi, 4)
+                    inner.headline_source = "encoder"
+                    inner.metadata.update({
+                        "recon_error": out.recon_error,
+                        "latent": out.latent,
+                        "encoder_version": enc.encoder_version,
+                    })
+                    delta_phi = 0.0 if _PHI_PREV_PHI is None else out.phi - _PHI_PREV_PHI
+                    delta_recon = 0.0 if _PHI_PREV_RECON is None else out.recon_error - _PHI_PREV_RECON
+                    phi_now = {
+                        **phi_now,
+                        **_golden_phi_overrides(
+                            phi=out.phi,
+                            delta_phi=delta_phi,
+                            recon_error=out.recon_error,
+                            recon_error_p95_reference=enc.manifest.training.recon_error_p95,
+                        ),
+                    }
+                    _PREV_PHI = phi_now
+                    reward = PhiIntrinsicRewardV1(
+                        generated_at=inner.generated_at,
+                        self_state_id=inner.self_state_id,
+                        encoder_version=enc.encoder_version,
+                        features_version=inner.features_version,
+                        phi=out.phi,
+                        delta_phi=delta_phi,
+                        recon_error=out.recon_error,
+                        delta_recon_error=delta_recon,
+                        latent=out.latent,
+                        attribution_top=out.attribution_top,
+                        grammar_truth_degraded=inner.grammar_truth_degraded,
+                    )
+                    if _pub_bus and _pub_bus.enabled:
+                        try:
+                            await _pub_bus.publish(
+                                settings.channel_phi_reward,
+                                PhiIntrinsicRewardEnvelope(
+                                    source=_svc_ref(),
+                                    correlation_id=uuid4(),
+                                    payload=reward,
+                                ),
+                            )
+                        except Exception as exc:
+                            logger.warning("Failed to publish phi_reward: %s", exc)
+                    _PHI_PREV_PHI = out.phi
+                    _PHI_PREV_RECON = out.recon_error
+                    encoder_tick_ok = True
+                except Exception as exc:
+                    # Any failure here (including mid-inference) must NOT
+                    # leave _PHI_PREV_PHI/_PHI_PREV_RECON at a stale value --
+                    # encoder_tick_ok stays False, so the reset below fires.
+                    logger.warning("phi_encoder_tick_failed error=%s", exc)
         _INNER_PREV_HEADLINE = inner.headline
         _INNER_LAST_HEADLINE = inner.headline
         # Corpus-health gate reads the cognitive names that actually match this
@@ -2629,6 +2705,10 @@ async def handle_self_state(env: BaseEnvelope) -> None:
                 )
             except Exception as exc:
                 logger.warning("Failed to publish inner_features: %s", exc)
+
+    if not encoder_tick_ok:
+        _PHI_PREV_PHI = None
+        _PHI_PREV_RECON = None
 
     # Compute real inter-tick delta — two genuinely time-separated substrate snapshots.
     turn_effect: Optional[Dict[str, float]] = None

--- a/services/orion-spark-introspector/tests/test_phi_reward_emit.py
+++ b/services/orion-spark-introspector/tests/test_phi_reward_emit.py
@@ -98,6 +98,13 @@ async def test_phi_reward_emitted_when_encoder_ok(monkeypatch, tmp_path) -> None
 
     monkeypatch.setattr(worker.settings, "orion_phi_encoder_enabled", True, raising=False)
     monkeypatch.setattr(worker.settings, "orion_phi_encoder_weights", str(tmp_path), raising=False)
+    # Regression (pre-existing, found 2026-07-12 alongside the golden-phi
+    # change below): settings.inner_features_version defaults to "seed-v3",
+    # but _write_tiny_encoder's manifest declares features_version="seed-v2".
+    # PhiEncoderRuntime.load() silently returns None on that mismatch, so the
+    # encoder block never ran and this test always failed before this fix,
+    # independent of anything else in this file.
+    monkeypatch.setattr(worker.settings, "inner_features_version", "seed-v2", raising=False)
     _write_tiny_encoder(tmp_path)
     monkeypatch.setattr(worker, "_pub_bus", _Bus(), raising=False)
     monkeypatch.setattr(worker.manager, "broadcast", AsyncMock(), raising=False)
@@ -157,3 +164,124 @@ async def test_phi_reward_suppressed_when_frozen(monkeypatch, tmp_path) -> None:
     await worker.handle_self_state(_envelope())
 
     assert worker.settings.channel_phi_reward not in published
+
+
+@pytest.mark.asyncio
+async def test_golden_phi_overrides_coherence_energy_novelty_not_valence(monkeypatch, tmp_path) -> None:
+    # 2026-07-12: the trained encoder's output must replace
+    # _phi_from_self_state's untrained heuristic for coherence/energy/novelty
+    # wherever it reaches orion-cortex-exec's metacognition prompts (via
+    # SparkStateSnapshotV1.phi -> spark_narrative.py). valence has no trained
+    # analog and must be left untouched.
+    published: dict[str, object] = {}
+
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel, env):
+            published[channel] = env
+
+    monkeypatch.setattr(worker.settings, "orion_phi_encoder_enabled", True, raising=False)
+    monkeypatch.setattr(worker.settings, "orion_phi_encoder_weights", str(tmp_path), raising=False)
+    # _write_tiny_encoder's manifest uses features_version="seed-v2"; settings'
+    # default ("seed-v3") would make PhiEncoderRuntime.load() silently return
+    # None on a version mismatch, skipping the encoder block entirely.
+    monkeypatch.setattr(worker.settings, "inner_features_version", "seed-v2", raising=False)
+    _write_tiny_encoder(tmp_path)
+    monkeypatch.setattr(worker, "_pub_bus", _Bus(), raising=False)
+    monkeypatch.setattr(worker.manager, "broadcast", AsyncMock(), raising=False)
+    _reset_inner_state(monkeypatch, tmp_path)
+    # A known, nonzero previous-tick phi so delta_phi (and therefore the
+    # "energy" mapping) is actually exercised -- _reset_inner_state alone
+    # leaves _PHI_PREV_PHI=None, which forces delta_phi=0.0 by the cold-start
+    # convention and would let a broken energy mapping pass trivially
+    # (found by code review, 2026-07-12).
+    monkeypatch.setattr(worker, "_PHI_PREV_PHI", 0.2, raising=False)
+    _mock_healthy_substrate_reads(monkeypatch)
+
+    await worker.handle_self_state(_envelope())
+
+    reward_env = published[worker.settings.channel_phi_reward]
+    reward = PhiIntrinsicRewardV1.model_validate(reward_env.payload)
+    assert reward.delta_phi != 0.0, "test setup must exercise a nonzero delta_phi"
+
+    snap_env = published[worker.settings.channel_spark_state_snapshot]
+    snap_payload = snap_env.payload
+    phi_dict = snap_payload.phi if hasattr(snap_payload, "phi") else snap_payload["phi"]
+
+    assert phi_dict["coherence"] == round(reward.phi, 4)
+    assert phi_dict["energy"] == round(min(1.0, abs(reward.delta_phi)), 4)
+    expected_novelty = round(min(1.0, reward.recon_error / max(0.2, 1e-6)), 4)
+    assert phi_dict["novelty"] == expected_novelty
+    # valence has no trained analog -- must still be the heuristic's value,
+    # not overridden or zeroed.
+    heuristic_valence = worker._phi_from_self_state(
+        worker.SelfStateV1.model_validate(_self_state_payload())
+    )["valence"]
+    assert phi_dict["valence"] == heuristic_valence
+
+
+@pytest.mark.asyncio
+async def test_phi_prev_resets_across_a_skipped_tick(monkeypatch, tmp_path) -> None:
+    # Regression for the gap-reset fix (found by code review, 2026-07-12): a
+    # skipped tick (grammar-truth degraded here) between two healthy encoder
+    # ticks must NOT leave delta_phi spanning both ticks on the next healthy
+    # one -- _PHI_PREV_PHI must reset to None during the skip, so the next
+    # healthy tick's delta_phi is a fresh 0.0 (cold-start convention), not
+    # tick3.phi - tick1.phi.
+    published: dict[str, object] = {}
+
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel, env):
+            published[channel] = env
+
+    monkeypatch.setattr(worker.settings, "orion_phi_encoder_enabled", True, raising=False)
+    monkeypatch.setattr(worker.settings, "orion_phi_encoder_weights", str(tmp_path), raising=False)
+    monkeypatch.setattr(worker.settings, "inner_features_version", "seed-v2", raising=False)
+    _write_tiny_encoder(tmp_path)
+    monkeypatch.setattr(worker, "_pub_bus", _Bus(), raising=False)
+    monkeypatch.setattr(worker.manager, "broadcast", AsyncMock(), raising=False)
+    _reset_inner_state(monkeypatch, tmp_path)
+
+    # Tick 1: healthy.
+    _mock_healthy_substrate_reads(monkeypatch)
+    await worker.handle_self_state(_envelope())
+    assert worker._PHI_PREV_PHI is not None, "tick 1 should have set a baseline"
+
+    # Tick 2: skipped (grammar-truth degraded) -- must reset the baseline.
+    # _SUBSTRATE_CACHE must be cleared again here (not just at the top of the
+    # test): tick 1 populated it with a "healthy" result via
+    # _mock_healthy_substrate_reads, and _fetch_substrate_grammar_truth
+    # serves from that cache before ever calling the (re-)mocked
+    # fetch_grammar_truth below -- without this, tick 2 would silently reuse
+    # tick 1's cached healthy read instead of the degraded one being set up.
+    monkeypatch.setattr(worker, "_SUBSTRATE_CACHE", None, raising=False)
+    monkeypatch.setattr(
+        worker,
+        "fetch_grammar_truth",
+        AsyncMock(
+            return_value=GrammarTruthSnapshot(
+                degraded=True,
+                degraded_reasons=["cursor_lag:execution_grammar_reducer"],
+                enabled_reducers={"execution_trajectory": True},
+                reducer_health_by_name={},
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        worker,
+        "fetch_execution_trajectory",
+        AsyncMock(return_value=ExecutionTrajectorySnapshot(ok=False, projection=None)),
+    )
+    await worker.handle_self_state(_envelope())
+    assert worker._PHI_PREV_PHI is None, "skipped tick must reset the baseline"
+
+    # Tick 3: healthy again -- delta_phi must be a fresh 0.0, not spanning tick 2.
+    _mock_healthy_substrate_reads(monkeypatch)
+    await worker.handle_self_state(_envelope())
+
+    reward_env = published[worker.settings.channel_phi_reward]
+    reward = PhiIntrinsicRewardV1.model_validate(reward_env.payload)
+    assert reward.delta_phi == 0.0


### PR DESCRIPTION
## Summary

- The only "phi" ever reaching orion-cortex-exec's live metacognition prompts (`log_orion_metacognition_draft.j2`/`_enrich.j2`, via `spark_narrative.py`'s `spark_phi_hint`/`spark_phi_narrative`) was `_phi_from_self_state()` — a hand-tuned, untrained heuristic, not the trained MLP autoencoder retrained earlier today. The trained encoder's real output (`PhiIntrinsicRewardV1`) had zero consumers beyond a SQL sink (`orion-sql-writer`) and a debug WebSocket EKG panel.
- Wired the trained encoder's output into `phi_now`'s `coherence`/`energy`/`novelty` axes whenever it's enabled and healthy this tick, so the golden (trained) phi is what actually reaches cognition.
- `valence` deliberately left on the heuristic — the active encoder's latent probes show zero correlation between any latent dim and any hedonic-adjacent felt dimension, so there is no trained analog to source it from; fabricating one would be exactly the empty-shell-cognition pattern this change exists to remove.
- Code review caught and I fixed a real bug in the first draft: without resetting the encoder's tick-to-tick delta tracking on every skip/failure path, a resumed tick after any gap would compute a delta spanning multiple skipped ticks, landing a misleadingly large value in a now-prompt-facing field.
- Also fixed a pre-existing, unrelated test bug (stale `features_version` in a test fixture, silently no-opping the encoder in that test).

## Outcome moved

`SparkStateSnapshotV1.phi` (and therefore the live metacognition prompt's coherence/arousal/novelty framing) now reflects the actual trained autoencoder — the same encoder just retrained today on post-fix data and confirmed non-collapsed — instead of an untrained hand-written formula that happened to be the only thing ever wired to real cognition.

## Current architecture

`services/orion-spark-introspector/app/worker.py`'s `handle_self_state()` computed `phi_now = _phi_from_self_state(ss)` (4-key dict: coherence/energy/novelty/valence) every self-state tick, published it as `SparkStateSnapshotV1.phi`, and separately — when the trained encoder was enabled and healthy — computed `out.phi`/`out.recon_error`/`delta_phi` and published them only as `PhiIntrinsicRewardV1` to a SQL-sink-only channel. Two independent phi computations, only one of which reached cognition.

## Architecture touched

`orion-spark-introspector` only. `orion-cortex-exec`'s `spark_narrative.py` needed zero changes — it already reads `snapshot.phi.get(...)` generically, so overriding the dict's values at the source was a thin, single-service seam.

## Files changed

- `services/orion-spark-introspector/app/worker.py`:
  - New `_golden_phi_overrides()` — pure function mapping trained-encoder output to the 3 axes with principled analogs, with a documented rationale for why `valence` is excluded.
  - `handle_self_state()`: overrides `phi_now`'s coherence/energy/novelty when the encoder tick succeeds; introduces `encoder_tick_ok` flag (set only at the end of a fully successful try block) so `_PHI_PREV_PHI`/`_PHI_PREV_RECON` reset to `None` on any skip or mid-inference exception, preventing a stale multi-tick delta from landing in the now-prompt-facing `energy` field.
- `services/orion-spark-introspector/tests/test_phi_reward_emit.py`:
  - New `test_golden_phi_overrides_coherence_energy_novelty_not_valence` — asserts the snapshot's coherence/energy/novelty match the trained encoder's output and valence still matches the heuristic.
  - New `test_phi_prev_resets_across_a_skipped_tick` — 3-tick regression: healthy → skipped (grammar-degraded) → healthy, asserting `delta_phi` on the third tick is a fresh `0.0`, not `tick3.phi - tick1.phi`.
  - Fixed `test_phi_reward_emitted_when_encoder_ok` (pre-existing, unrelated failure — confirmed via `git stash` against main before this branch existed): `settings.inner_features_version` defaults to `"seed-v3"` but the test's tiny encoder manifest declares `features_version="seed-v2"`, so `PhiEncoderRuntime.load()` silently returned `None` and the test's own assertion always failed. Added the missing monkeypatch.

## Schema / bus / API changes

None. `PhiIntrinsicRewardV1`/`SparkStateSnapshotV1` schemas unchanged; only which values populate existing fields changed.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. :services/orion-spark-introspector pytest services/orion-spark-introspector/tests -q
135 passed, 1 skipped  (repeated 5x for the nondeterministic tiny-encoder fixture — stable every run)

PYTHONPATH=. pytest tests/test_phi_encoder_mlp.py tests/test_phi_encoder_fit_script.py \
  tests/test_spark_introspector_publish_guard.py tests/test_phi_encoder_schema.py -q
all passed

tests/test_spark_introspector_no_legacy.py::test_worker_has_no_legacy_kind -- FAILS,
confirmed pre-existing and unrelated via `git stash` against clean main
(checks worker.py doesn't contain the literal string "spark.introspection";
already true before this branch, not touched by this change)
```

## Evals run

None applicable — this is a wiring/logic change covered by unit tests, not a training-quality question (the encoder itself was already trained/evaluated/promoted in an earlier session turn).

## Docker/build/smoke checks

Not run — not deployed. Restart commands below, left for Juniper to trigger.

## Review findings fixed

- Finding: `_PHI_PREV_PHI`/`_PHI_PREV_RECON` only reset on the two skip paths I initially patched (encoder disabled/degraded, `enc is None`) — missed the case of an exception occurring mid-inference (between `enc.forward(x)` and the final assignment), which would leave the globals stale exactly like the original bug, just triggered a different way.
  - Fix: restructured around an `encoder_tick_ok` flag, set only at the true end of a fully successful try block wrapping the entire encoder-inference section; the reset check now lives after the whole `if settings.inner_features_enabled:` block, so it fires on every skip/failure path uniformly, including `inner_features_enabled=False` itself.
  - Evidence: new test `test_phi_prev_resets_across_a_skipped_tick`, verified independently by a second review pass confirming no remaining path leaves `encoder_tick_ok` unset or lets an exception escape without resetting.
- Finding: the first version of `test_golden_phi_overrides_...`'s energy assertion was trivially `0.0 == 0.0` since `_reset_inner_state` leaves `_PHI_PREV_PHI=None`, forcing `delta_phi=0.0` by the cold-start convention — a broken energy mapping (wrong source variable, missing `abs()`, wrong clamp) would have passed silently.
  - Fix: set `_PHI_PREV_PHI` to a known nonzero baseline before the tick under test, plus an explicit `assert reward.delta_phi != 0.0` guarding the test setup itself.
  - Evidence: test now genuinely exercises a nonzero delta; re-ran 5x to confirm stability against the encoder fixture's unseeded random weights.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml \
  up -d --build spark-introspector
```

Not run — deliberately left for Juniper to trigger.

## Risks / concerns

- Severity: medium
- Concern: this changes the actual content of Orion's live metacognition prompt (coherence/energy/novelty framing) the moment it's deployed — a real behavior change to a chat-facing cognition surface, not just a metrics/telemetry fix like the rest of today's work.
- Mitigation: `valence` (the one axis with genuine domain-specific hand-tuning and no honest trained replacement) is untouched; coherence/energy/novelty all have principled, documented 1:1 analogs in the trained encoder's actual output, not arbitrary relabeling. Recommend watching a chat session or two post-deploy to sanity-check the narrative reads coherently before treating this as fully settled.
- Severity: low
- Concern: `energy`'s scale (`|delta_phi|`, bounded [0,1] by construction) and `novelty`'s scale (`recon_error / recon_error_p95`, clamped to [0,1]) are new value distributions the prompt-banding functions (`_arousal_band`, `_overload_band` in `spark_narrative.py`) haven't been tuned against — they assume roughly-uniform [0,1] inputs, which these should satisfy, but the actual banding thresholds (0.33/0.66) were tuned against the OLD heuristic's distribution, not the new one.
- Mitigation: none built in this patch — worth revisiting the banding thresholds once a real traffic window of the new distribution exists, same "measure before assuming" principle used everywhere else in today's work.
