### PR TITLE
Feat/inner state registry gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-hub test-actions bootstrap-test-envs
+.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry
 
 SERVICE ?=
 ARGS ?=
@@ -18,3 +18,13 @@ test-hub:
 
 test-actions:
 	@./scripts/test_orion_actions.sh $(ARGS)
+
+# NOTE: CLAUDE.md §17 describes a `make agent-check` target chaining
+# check_env_template_parity.py, check_schema_registry.py, check_bus_channels.py,
+# and this check -- confirmed 2026-07-12 that `agent-check` itself and the
+# first two of those three scripts do not exist in this repo. Not built here
+# (out of scope for this patch); this target is the one real piece of that
+# promised chain, added standalone until Juniper decides whether to build the
+# rest.
+check-inner-state-registry:
+	@python scripts/check_inner_state_registry.py

--- a/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
+++ b/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
@@ -1,0 +1,100 @@
+# Inner-State Unification — Implementation Plan
+
+Companion to `docs/superpowers/specs/2026-07-12-inner-state-unification-design.md`. Read that first — this is the phased build-out: the foundational registry/gate, then the field-attention brainstorm ideas correctly sequenced *through* it instead of around it.
+
+**Cross-cutting rule for every phase below**: no phase merges a service into another. Every phase either (a) adds a registry entry for something that already exists, or (b) adds a new signal that is a registry entry *from its first commit*, never added after the fact.
+
+---
+
+## Phase 0 — The registry and the gate (foundational, blocks nothing downstream from starting late)
+
+**Gate to start:** none — this is the first patch, can start immediately. The design spec now specifies this down to the field level (dataclass, all nine entries populated, gate algorithm) — this phase implements that spec, it does not redesign it.
+
+- [ ] `orion/self_state/inner_state_registry.py`: the `Cadence`/`CompositionStatus` enums, the `InnerStateSignal` frozen dataclass, and the populated `REGISTRY` tuple with all nine entries — verbatim starting point in the design spec. `drive_state.v1` and `autonomy_state_v2` are registered as `DUPLICATE` (`duplicate_of` pointing at each other), **not** composed into `self_state.v1` — traced this session: they read a disjoint, closed `signal_kind` evidence map (`config/autonomy/signal_drive_map.yaml`), not `SelfStateV1.dimensions`, with exactly one narrow, event-gated overlap point (`spark_signal` on `turn_effect_alert`). Do not build a drives→self-state crosswalk; the design spec traced this and rejected it as fabricating a relationship the data doesn't have.
+- [ ] `scripts/check_inner_state_registry.py`: two-part gate, both parts specified in the design spec — (1) rot check: import every non-`None` `schema` in `REGISTRY`, confirm it's still valid; (2) new-duplicate heuristic: scan `orion/bus/channels.yaml` and `orion/schemas/registry.py`'s flat name dict for new entries matching a small, explicit, hand-maintained keyword list (`self_state`, `drive`, `autonomy_state`, `attention`, `phi_reward`, `mood`, `felt_state`, `cluster`) with no `REGISTRY` entry. State the heuristic's real limitation in the code comment (a cleverly-named new schema can evade it) — do not oversell it as complete.
+- [ ] Register the *existing* CLAUDE.md-promised-but-missing gates (`scripts/check_schema_registry.py`, `scripts/check_bus_channels.py` — confirmed absent, referenced in CLAUDE.md §11/§17) as a separate, explicit finding in the PR — do not silently fix them as scope creep; name them, let Juniper decide if they're this patch's job or a separate one.
+- [ ] Wire the new gate into `make agent-check` (per CLAUDE.md §17), alongside a note that the other two promised checks still don't exist.
+
+**Tests:** (1) rot-check regression: a `REGISTRY` entry pointing at a renamed/deleted class must fail. (2) Heuristic regression: a synthetic new channel named `orion:test:mood_state` added to a test fixture of `channels.yaml` with no registry entry must fail, by name, in the gate's error message.
+
+**Acceptance:** all nine entries from the design spec's per-signal deep-dive are present, with real (not placeholder) `producer_service`/`cadence`/`composition_status`/`cognition_consumers` values; the gate is wired into `agent-check`; CLAUDE.md's pre-existing missing-gate gap is documented, not silently absorbed into this patch's scope.
+
+---
+
+## Phase 1 — Widen `dominant_attention_targets` (brainstorm idea #1, now a registry-governed extension)
+
+**Gate to start:** Phase 0 merged (this is the first signal added *through* the registry, proving the pattern works before anything else uses it).
+
+- [ ] `orion/schemas/self_state.py`: additive field carrying structured attention-target data (pressure_score, dominant_channels top-1, reasons top-1) for the top-N targets, alongside (not replacing) the existing bare-string list.
+- [ ] `orion/self_state/builder.py`: populate from `attention.dominant_targets` (already in scope at the point this is currently discarded, `builder.py:279`).
+- [ ] Registry entry added in the same PR — this is the acceptance check for Phase 0's gate actually working, not a separate afterthought.
+- [ ] Log-only for a real traffic window before anything downstream (Phase 2/3) reads it: does the dominant target actually vary tick-to-tick, or is it dominated by one or two nodes constantly? (Flagged as a missing question in the brainstorm — answer it with data, not assumption, before building the narrative layer.)
+
+**Tests:** schema round-trip; builder unit test asserting the new field is populated from a fixture `FieldAttentionFrameV1` with known target scores.
+
+**Acceptance:** the field carries real per-target data in at least one live tick, verified against Postgres, not just a fixture.
+
+---
+
+## Phase 2 — Node-attributed phi (brainstorm idea #2)
+
+**Gate to start:** Phase 1 merged AND its log-only traffic window shows real (non-degenerate) variation in dominant targets — do not build this on top of a signal that turns out to be flat.
+
+- [ ] `orion/schemas/telemetry/phi_encoder.py`: additive `dominant_node`/`dominant_node_reason` fields on `PhiIntrinsicRewardV1`.
+- [ ] `services/orion-spark-introspector/app/worker.py`: populate from `ss.dominant_attention_targets`'s widened form (Phase 1) inside `handle_self_state`, alongside the existing golden-phi overrides — same function, same seam, not a new pipeline.
+- [ ] Registry entry updated: `PhiIntrinsicRewardV1` now explicitly composes attention data, not just self-state's dimension scores.
+- [ ] Explicitly filter the two synthetic pseudo-nodes (`node:substrate.execution`, `node:substrate.transport`) from ever being the reported `dominant_node` — named in the brainstorm as a real risk (they aren't bodies, they're derived subsystem metrics; surfacing them as "the body part under stress" would be a category error, not a bug fixed by more data).
+
+**Tests:** unit test asserting a fixture with a clear dominant node produces the matching `dominant_node`/reason; a second test asserting a pseudo-node is never selected even when it has the highest raw pressure score.
+
+**Acceptance:** `PhiIntrinsicRewardV1.dominant_node` reflects a real hardware node (not a pseudo-node) in live traffic.
+
+---
+
+## Phase 3 — `spark_embodiment_narrative` (brainstorm idea #3)
+
+**Gate to start:** Phase 2 merged AND deployed for a real traffic window (this is the one phase that changes prompt content — needs its own confirmation the metacog surface reads coherently, per the design spec's acceptance checks on prompt-builder discipline).
+
+- [ ] `services/orion-cortex-exec/app/spark_narrative.py`: new `spark_embodiment_hint`/`spark_embodiment_narrative`, mirroring `spark_phi_hint`/`spark_phi_narrative`'s existing shape exactly.
+- [ ] `orion/cognition/prompts/log_orion_metacognition_{draft,enrich}.j2`: one new template line.
+- [ ] Registry entry: this is the first prompt-builder addition made *through* the contract from day one — the model entry for what "declared cognition consumer" should look like everywhere else.
+- [ ] Before merging: the design spec's outstanding acceptance check ("does an existing prompt-builder bypass the contract?") gets answered concretely for this new addition specifically — it must not.
+
+**Tests:** template rendering test with a fixture snapshot; confirm the narrative string names a real hardware node, not a pseudo-node (same guard as Phase 2, at the render layer too — defense in depth).
+
+**Acceptance:** a real chat/metacog turn post-deploy produces a narrative that correctly names the actual stressed node, cross-checked against the live `substrate_field_state` row for that tick.
+
+---
+
+## Phase 4 — `capability_provenance` cross-check (brainstorm idea #6, research-only)
+
+**Gate to start:** can run any time in parallel with Phases 1-3 — read-only, no code path shared with them.
+
+- [ ] One research doc (`docs/notes/`), no code: correlate `dominant_attention_targets` (attention's salience-based node attribution) against `capability_provenance` (diffusion's separate, provenance-based node attribution) over a real traffic window. Do they agree? If they diverge, why — different weighting philosophy, different update cadence, or one of them being wrong?
+
+**Tests:** none — read-only research.
+
+**Acceptance:** a documented answer to whether these two independently-computed attribution mechanisms corroborate each other, informing whether Phase 5+ (if pursued) should unify them or keep them as intentionally distinct signals.
+
+---
+
+## Explicitly deferred (not phases — non-goals for this plan)
+
+- **Trained per-node encoder** (brainstorm idea #4): only worth building once Phases 1-3 show the *heuristic* node-attribution signal actually moves cognition. Building a trained encoder for a signal nobody's shown matters yet repeats today's original phi mistake (train something, wire it to nothing) at a new layer.
+- **`FieldAttentionFrameV1` bus publish** (brainstorm idea #5): only pursued if Phase 1's Postgres-read pattern (mirroring `orion-self-state-runtime`'s existing `load_self_state_for_attention_frame`) proves insufficient for whatever needs it.
+- **First-class node/body-schema object** (brainstorm idea #7): a consumer of this contract once it's real, not part of building it.
+- **DriveEngine/AutonomyStateV2 merge decision**: still gated on real AutonomyStateV2 traffic (Phase 4 of the earlier mesh-substrate-redesign plan), unaffected by this plan. The registry (this plan's Phase 0) makes their unresolved duplication a visible, checked fact — it does not force the answer.
+- **`CLUSTER_ROLE_WEIGHTS` retirement**: already researched and recommended (docs/notes/2026-07-12-phase4-cluster-weighting-research.md); registered as a known duplicate here, resolved on its own separate timeline.
+
+---
+
+## Full gate before calling this initiative done
+
+```bash
+python scripts/check_inner_state_registry.py
+pytest orion/self_state -q
+pytest services/orion-spark-introspector/tests -q
+pytest services/orion-cortex-exec/tests -k spark_narrative -q
+```
+
+Run the code-review skill in a subagent per phase before merging, not once at the end — same discipline as every other multi-phase initiative this session. Each phase gets its own PR and PR report.

--- a/docs/superpowers/pr-reports/2026-07-12-inner-state-registry-gate-phase0-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-inner-state-registry-gate-phase0-pr.md
@@ -1,0 +1,98 @@
+## Summary
+
+- Phase 0 of the inner-state unification plan: a registry (`orion/self_state/inner_state_registry.py`) enumerating every "what does Orion currently feel/perceive" signal in the repo, plus a deterministic gate (`scripts/check_inner_state_registry.py`) that fails if the registry goes stale or a new inner-state-shaped schema/channel appears unregistered.
+- This is the foundational fix for a failure mode independently rediscovered five separate times in one session: a real, computed signal silently duplicating another one, or never reaching cognition (DriveEngine/AutonomyStateV2, `CLUSTER_ROLE_WEIGHTS` x3, the phi/heuristic split, `FieldAttentionFrameV1`'s discarded per-node scores).
+- Running the gate for the first time against the real repo surfaced 16 real findings, each individually triaged (not blanket-suppressed) — see "Review findings fixed" below.
+- Also found, documented, and explicitly NOT fixed as scope creep: `make agent-check` and 2 of its 3 referenced scripts don't exist despite CLAUDE.md describing them as real.
+- README updates: new `orion/self_state/README.md` (the package had none); a new section in `services/orion-self-state-runtime/README.md`.
+
+## Outcome moved
+
+The next inner-state-shaped signal added anywhere in the repo either gets a registry entry or fails a deterministic gate — not a sixth manual grep-archaeology discovery weeks later.
+
+## Current architecture
+
+Nine signals across six services (`orion-field-digester`, `orion-attention-runtime`, `orion-self-state-runtime`, `orion.spark.concept_induction`, `orion.autonomy`, `orion-spark-introspector`, `orion-biometrics`, plus the 5-service L7-L11 ladder) each independently answer some version of "what does Orion currently feel." No prior mechanism declared which was canonical, which reached cognition, or which duplicated another.
+
+## Architecture touched
+
+`orion/self_state/` (new registry module + README), `scripts/` (new gate script), `tests/` (new gate tests), `Makefile` (new target), `services/orion-self-state-runtime/README.md`. No runtime behavior changed — this is bookkeeping infrastructure, not a code path any service executes.
+
+## Files changed
+
+- `orion/self_state/inner_state_registry.py` (new): `Cadence`/`CompositionStatus` enums, `InnerStateSignal` frozen dataclass with validation (`DUPLICATE` requires `duplicate_of`, `SHADOW` requires `shadow_reason`), and all 9 current signals populated with real producer/cadence/consumer data traced from the design spec.
+- `scripts/check_inner_state_registry.py` (new): rot check (every registered schema still imports as a real `BaseModel`) + new-duplicate heuristic (keyword scan of `orion/bus/channels.yaml` and `orion/schemas/registry.py`'s flat name dict, cross-checked against the registry plus a documented `_EXTRA_COVERED_SCHEMA_NAMES` exclusion list).
+- `tests/test_inner_state_registry_gate.py` (new): 8 tests — rot-check pass/fail, heuristic pass/fail against both the real repo and synthetic fixtures, `InnerStateSignal` validation, full gate exit code.
+- `Makefile`: new `check-inner-state-registry` target.
+- `orion/self_state/README.md` (new), `services/orion-self-state-runtime/README.md`: documentation.
+- `docs/superpowers/specs/2026-07-12-inner-state-unification-design.md`, `docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md`: the design spec and phased plan this implements (written earlier this session, committed here for the first time).
+
+## Schema / bus / API changes
+
+None. No existing schema, channel, or API changed shape.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=. pytest tests/test_inner_state_registry_gate.py -q
+8 passed
+
+PYTHONPATH=. pytest tests/test_self_state_runtime_store.py tests/test_self_state_deviation.py \
+  tests/test_self_state_transport_dimension.py tests/test_self_state_builder.py \
+  tests/test_self_state_reliability_decontamination.py tests/test_self_state_prediction.py \
+  tests/test_self_state_policy_loader.py tests/test_self_state_builder_hardening.py \
+  tests/test_self_state_scoring.py tests/test_self_state_schemas.py \
+  tests/test_inner_state_registry_gate.py -q
+62 passed
+
+python scripts/check_inner_state_registry.py
+inner_state_registry gate OK (9 entries checked)
+```
+
+## Evals run
+
+None applicable — this is deterministic bookkeeping infrastructure, not a behavior/quality question.
+
+## Docker/build/smoke checks
+
+Not applicable — no service, no runtime behavior change, nothing to deploy.
+
+## Review findings fixed
+
+The gate's first real run against the repo surfaced 16 matches with no registry entry. Each was individually traced and resolved, not blanket-suppressed:
+
+- Finding: `SelfStateDimensionV1`, `FieldAttentionTargetV1`, `DriveAuditV1`, `DriveNodeV1` matched keywords with no registry entry.
+  - Resolution: confirmed each is a sub-object/companion of an existing registry entry (per-dimension row, per-target row, audit-trail companion, graph-node projection respectively) — added to `_EXTRA_COVERED_SCHEMA_NAMES` with the specific relationship documented, not just suppressed.
+- Finding: `ArticleClusterV1` matched the `cluster` keyword.
+  - Resolution: traced to `orion/schemas/world_pulse.py` — news-article clustering for topic-foundry, a genuine keyword collision unrelated to node-health clustering. Documented as a false positive, not silently ignored.
+- Finding: `AttentionFrameV1`, `AttentionSignalV1`, `AttentionSalienceTraceV1`, `AttentionLoopOutcomeV1`, `PendingAttentionCardV1`, `ChatAttentionRequest`, `ChatAttentionAck`, `ChatAttentionState` all matched the `attention` keyword.
+  - Resolution: traced these to two distinct, real, already-existing subsystems (`orion/schemas/attention_frame.py` + `orion/schemas/attention_salience.py` — conversational curiosity/open-loop attention allocation; `orion/schemas/notify.py` — chat-notification attention) structurally different from `FieldAttentionFrameV1`'s per-node/capability salience scoring. Explicitly excluded as out of scope for this registry's felt-state focus, with a note flagging them as worth their own future audit — not silently dismissed as noise.
+- Finding: `PhiEncoderManifestV1`, and the five L7-L11 ladder frame schemas (`ProposalFrameV1` etc.) matched keywords.
+  - Resolution: confirmed as direct lineage companions of `phi_intrinsic_reward.v1` and `l7_l11_ladder` respectively, added to the exclusion list with that reasoning.
+
+Separately, code review confirmed: `orion/schemas/registry.py:660`'s `_REGISTRY` really is `Dict[str, Type[BaseModel]]` as the gate script assumes; the `scripts/platform/`-shadows-stdlib-`platform` import ordering issue (same class of bug documented in `scripts/fit_phi_encoder.py`) was pre-emptively worked around in the new script; all `InnerStateSignal.__post_init__` validation invariants hold across all 9 entries; Makefile recipe uses a real tab, not spaces.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+No service reads this registry at runtime — it's a static bookkeeping module and a CI-style gate script.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: the new-duplicate heuristic is a maintained keyword list, not a formal proof — documented explicitly in the script's own docstring and in `orion/self_state/README.md`. A cleverly-named 10th duplicate could evade it.
+- Mitigation: a shared marker base class was considered and rejected (real migration cost across 6+ existing schemas for marginal precision gain); the keyword list is easy to extend when the next miss is found, same discipline as `config/autonomy/signal_drive_map.yaml`'s own closed-list approach.
+- Severity: low
+- Concern: this patch surfaces (but does not resolve) that `make agent-check`, `check_schema_registry.py`, `check_bus_channels.py`, and `check_env_template_parity.py` — all referenced in CLAUDE.md §11/§17 as if they exist — do not.
+- Mitigation: named explicitly here rather than silently fixed as scope creep or silently ignored. Juniper's call whether this is a follow-up patch.
+
+## PR link
+
+Branch pushed: `feat/inner-state-registry-gate`

--- a/docs/superpowers/specs/2026-07-12-inner-state-unification-design.md
+++ b/docs/superpowers/specs/2026-07-12-inner-state-unification-design.md
@@ -1,0 +1,269 @@
+# Inner-State Unification — Design Spec (v2, substantive rewrite)
+
+**Date:** 2026-07-12
+**Context:** v1 of this spec was a thin table-and-gesture pass over everything found today. This version does the actual tracing: real formulas, real file:line citations, real live numbers, and a registry/gate design specified down to the field level, not described in prose and punted.
+
+---
+
+## Arsonist summary — deep dive per signal, not a table
+
+### 1. `FieldStateV1` — the body (foundation, correct as of today)
+
+`services/orion-field-digester/app/digestion/{decay,diffusion,suppression}.py`, per-tick. Four real hardware nodes (`atlas`, `circe`, `athena`, `prometheus`, ~23 channels each: cpu/gpu/memory/disk/thermal pressure, execution/reasoning load, failure/repair pressure, transport/contract/catalog-drift pressure, delivery_confidence, bus_health, availability, staleness) plus two thin synthetic pseudo-nodes (`node:substrate.execution`, `node:substrate.transport`, 1 derived channel each — not bodies, derived subsystem aggregates). Seven capabilities (`llm_inference`, `orchestration`, `transport`, `storage`, `graph`, `memory`, `vision`) computed from nodes via `config/field/orion_field_topology.v1.yaml`'s weighted edges.
+
+Confirmed live right now: `capability:llm_inference` reads `pressure=0.719, confidence=0.640, available_capacity=0.281` — genuinely differentiated, non-collapsed, for the first time in this project's history as of the diffusion fix shipped earlier today (`9d367d4f`, `4dc965f2`).
+
+`apply_suppression()` (`services/orion-field-digester/app/digestion/suppression.py`) is a small, correct mechanic: a node with `expected_offline_suppression >= 1.0` (scheduled/expected offline) gets `availability` floored at 0.85 and `staleness` zeroed — so a known, intentional power-down doesn't register as a failure. Three-line function, no theater.
+
+### 2. `FieldAttentionFrameV1` — real node-attributed salience, discarded one hop later
+
+`orion/attention/field_attention/{selectors,scoring}.py`, per-tick, produced by `orion-attention-runtime`. This is genuinely well-designed, non-theater engineering — traced the actual math:
+
+```python
+# scoring.py — weighted_pressure()
+raw = sum(value * channel_weights.get(channel, 0.0) for channel, value in vector.items())
+# only POSITIVE contributions recorded as "dominant" reasons — a negative-weighted
+# channel like availability (-0.40) can lower raw pressure but is never cited as
+# a reason pressure is elevated. Correct semantics, not an oversight.
+```
+
+`confidence_from_vector()` reuses the SAME `channel_weights` table, but sums only the NEGATIVE-weighted channels (`availability: -0.40`, `bus_health: -0.30`, `expected_offline_suppression: -0.70`, capability's `confidence: -0.35`, `available_capacity: -0.45`) — one weight table serves two purposes (what raises pressure, what raises confidence) by sign. `urgency_score()` takes a MAX (not sum) over a fixed 5-channel set (`failure_pressure`, `reliability_pressure`, `thermal_pressure`, `staleness`, `execution_friction`) — same max-not-sum discipline I enforced in today's diffusion fix, already independently present here. `novelty_for_target()` diffs this tick's salience against the SAME target_id's salience in the previous `FieldAttentionFrameV1` — genuinely memoryless-with-one-step-lookback, not accumulating.
+
+`config/attention/field_attention_policy.v1.yaml` (read in full for this rewrite, not summarized secondhand): `weights: {pressure: 0.45, novelty: 0.20, urgency: 0.25, confidence: 0.10}`; `node_channel_weights` and `capability_channel_weights` are per-CHANNEL importance weights (e.g. `thermal_pressure: 0.75` vs `cpu_pressure: 0.50` — thermal matters more for salience), applied identically regardless of which node reports them.
+
+**Important distinction, stated precisely so it isn't over-claimed**: `node_channel_weights`/`capability_channel_weights` weight *which channel type* is alarming — they are NOT a fourth reimplementation of "how much should Atlas's readings count vs Circe's" (that's `CLUSTER_ROLE_WEIGHTS`/`BIOMETRICS_ROLE_WEIGHTS_JSON`/the field-topology edges, a different axis entirely, already documented as a 3-way duplicate). Conflating these two would itself be a sloppy, unearned finding. They are not the same question.
+
+The loss: `orion/self_state/builder.py:189` takes `attention: FieldAttentionFrameV1` as a full parameter and only ever does `dominant_targets = [t.target_id for t in attention.dominant_targets[:5]]` (`builder.py:279`) — every other field on each `FieldAttentionTargetV1` (`pressure_score`, `novelty_score`, `urgency_score`, `confidence_score`, `dominant_channels`, `reasons`) is read into scope, used to compute the top-5, and discarded. `SelfStateV1.dominant_attention_targets: list[str]` (`orion/schemas/self_state.py:64`) is the only trace that survives.
+
+### 3. `SelfStateV1` — the mood (legitimate compression, incomplete composition)
+
+`orion/self_state/builder.py`, per-tick. ~12 dimension scores (`coherence`, `field_intensity`, `agency_readiness`, `execution_pressure`, `reasoning_pressure`, `resource_pressure`, `reliability_pressure`, `continuity_pressure`, `social_pressure`, `introspection_pressure`, `uncertainty`) via `channel_dimension_map` in `config/self_state/self_state_policy.v1.yaml` — a real, curated max-merge over `FieldStateV1` channels, correctly de-duplicated against diffusion double-counting as of this session's Phase 1 fix. Each dimension carries `.score`, `.confidence` (real per-dimension confidence as of Phase 1, not a uniform constant), `.reasons`, `.dominant_evidence`.
+
+This is the one signal that feeds phi (`InnerStateFeaturesV1`) and the L7 ladder. It is a real, working compression layer — the audit finding here is not "this is broken," it's "this composes field+attention only partially, and composes drives/phi not at all."
+
+### 4. `DriveEngine` — real, live, structurally disjoint from self-state
+
+`orion/spark/concept_induction/drives.py`, `DRIVE_KEYS = ("coherence", "continuity", "capability", "relational", "predictive", "autonomy")`. Confirmed live 24h ago: 363 samples, real variance (`coherence≈0.20, continuity≈0.35, capability≈0.47, relational/predictive/autonomy≈0.0`).
+
+**Traced the actual input mechanism for this rewrite** (this is the load-bearing correction to v1 of this spec): drives are computed from `config/autonomy/signal_drive_map.yaml` — a small (69-line), closed, typed `signal_kind → dimension → drive` map, explicitly NOT reading `SelfStateV1.dimensions` at all. The six `signal_kind`s it maps: `biometrics_state` (per-metric `*_level`/`*_volatility` suffix rules → capability/continuity), `mesh_health` (→ capability/continuity), `spark_signal` (`coherence`→coherence, `valence`→relational, `novelty`→predictive), `failure_event` (→ capability/coherence), `chat_social_hazard` (→ relational/capability), `chat_reasoning_quality` (`fallback`→coherence/predictive).
+
+The ONE overlap point with the phi/self-state territory: `spark_signal.coherence/valence/novelty`. Traced where `SparkSignalV1` gets published from `orion-spark-introspector` (`worker.py:1276-1284`): **only on a `turn_effect_alert`** — a rare, cooldown-gated event fired when `evaluate_turn_effect_alert()` detects a significant tick-to-tick coherence_drop/valence_drop/novelty_spike, not a continuous per-tick publish. So the drive engine's exposure to phi-adjacent signal is narrow and event-gated, not the continuous channel I assumed when I first proposed "compose drives into self-state" last turn.
+
+**Conclusion, stated plainly**: self-state and drives are **siblings over disjoint evidence streams with one narrow, alert-gated overlap point.** There is no clean 1:1 crosswalk between the 12 self-state dimensions and the 6 drives to build — attempting one would be inventing a taxonomy that doesn't exist in the data. This corrects v1's framing (which treated the mapping as a deferred-but-doable exercise).
+
+### 5. `AutonomyStateV2` — the same 6-drive taxonomy, independently reduced, structurally starved
+
+`orion/autonomy/reducer.py`, gated by `AUTONOMY_STATE_V2_REDUCER_ENABLED=true` (confirmed in `services/orion-cortex-exec/.env:234`), invoked only inside `_run_autonomy_reducer()` (`services/orion-cortex-exec/app/chat_stance.py:2182`) — **on real chat turns only**, not on a tick cadence at all. Confirmed live: 9 samples in 24h (vs. DriveEngine's 363), every one showing `{coherence:0.0, continuity:0.0, relational:0.0, autonomy:0.0, capability:0.0, predictive:0.0}` — flat zero, not because of a bug (the Docker config gap that used to cause this was already fixed), but because `compile_autonomy_evidence()`'s evidence compiler found no qualifying signal in those 9 particular turns. Genuinely too little traffic to compare against DriveEngine yet — unresolved by design, not by oversight (Phase 4 of the mesh-substrate-redesign plan already says so).
+
+### 6. `_phi_from_self_state()` (heuristic remnant) — the model for what "declared, justified duplication" looks like
+
+`services/orion-spark-introspector/app/worker.py:222-300`. Post today's golden-phi patch, only `valence` still comes from this hand-tuned formula (`raw_valence = 0.5*agency + 0.3*social_ease + 0.2*policy_ease`, modulated by coherence, ±0.12 for trajectory direction) — confirmed via the active encoder's latent probes (`probes.json`) that no trained latent dimension correlates with anything hedonic-adjacent, so there's genuinely no golden analog to replace it with. This is the ONE place in the whole audit where a duplicate is *correctly* justified and *explicitly documented in code* (see `_golden_phi_overrides`'s docstring, `worker.py:303-343`) rather than silently coexisting. Every other duplicate in this audit lacks this.
+
+### 7. `PhiIntrinsicRewardV1` (trained encoder) — fixed today, was dark for weeks
+
+`services/orion-spark-introspector/app/phi_encoder.py`, `PhiEncoderRuntime`. Trained offline (`scripts/fit_phi_encoder.py`), promoted via symlink flip. As of today: retrained on post-diffusion-fix data (`v20260712-seedv4-postfix`, 3,833 rows, `near_identity_frac=0.010` — not collapsed, unlike the previous active encoder's `0.659`), promoted, deployed, and wired into `phi_now`'s coherence/energy/novelty via `_golden_phi_overrides()`. Confirmed live post-deploy: `spark_state_rollups` 60s window showing `avg_arousal=0.0034, avg_coherence=0.650, avg_novelty=0.634` — plausible, non-degenerate values.
+
+### 8. `CLUSTER_ROLE_WEIGHTS` / `BIOMETRICS_ROLE_WEIGHTS_JSON` / field-topology edges — three answers to "how much should each node's health count," one dark, one live-by-fallback
+
+Already fully researched (`docs/notes/2026-07-12-phase4-cluster-weighting-research.md`, not re-traced here). `CLUSTER_ROLE_WEIGHTS` (`orion-biometrics`) never fires (`BIOMETRICS_MODE=agent` live, its own code path gated off). `BIOMETRICS_ROLE_WEIGHTS_JSON` (`orion-hub`) is the one actually active, as a fallback, reaching `orion-cortex-exec`'s metacog biometrics cue — real, non-display reach. Field-topology edges (`orion_field_topology.v1.yaml`) answer the same question a third way, already live for diffusion. Recommendation already on record: derive one from the topology file, delete the other two. Not re-litigated here — registered as a known duplicate.
+
+### 9. L7–L11 ladder — rehearsal, not cognition (already documented, not re-litigated)
+
+`ProposalFrameV1 → PolicyDecisionFrameV1 → ExecutionDispatchFrameV1 → FeedbackFrameV1 → ConsolidationV1`. Confirmed this session (`docs/notes/2026-07-12-phase5-research-findings.md`): `EXECUTION_DISPATCH_MODE=dry_run` live, every reader outside the ladder itself is a self-labeled Hub debug route, the one non-Hub reader (`orion-thought` reverie grounding) only appends an inert ID tag to an already-generated thought. Included in this audit for completeness; its resolution is out of scope here.
+
+## The pattern, stated precisely
+
+Of nine signals, exactly three genuinely reach cognition today (`SelfStateV1` → phi's inputs; the golden-phi coherence/energy/novelty; the `valence` heuristic remnant, correctly justified). Two are real, live, structurally disjoint, unreconciled duplicates of one taxonomy (#4/#5). One is real work computed and thrown away one hop downstream (#2). One is a three-way reimplementation with two dark and one live-by-accident (#8). One is full rehearsal (#9). **No two of these problems have the same shape or the same fix** — which is exactly why "put it all in one service" was the wrong diagnosis: a single service can't hold "per-tick reducer," "chat-turn-gated reducer," "offline-trained encoder with a promotion pipeline," and "5-service dry-run ladder" without becoming the least-scoped, worst-boundaried thing in the codebase.
+
+## The architectural decision, specified to the field level
+
+**Not a service. A registry — specified concretely below, not gestured at — plus a gate that actually runs against real code.**
+
+### Why not extend `orion/schemas/registry.py`
+
+That file already contains every relevant class (`SelfStateV1`, `FieldStateV1`, `FieldAttentionFrameV1`, `PhiIntrinsicRewardV1`, `DriveStateV1`, `BiometricsClusterV1` — confirmed present, grepped directly) across two structures: a giant flat `name -> ModelClass` dict (hundreds of entries, general dynamic lookup) and a smaller `_REGISTRY: dict[str, SchemaRegistration]` (bus-envelope `schema_id -> (model, kind)` resolution, used by `resolve()`). Neither structure carries producer/consumer/composition metadata, and both are the wrong blast radius for a change this specific — hundreds of unrelated schemas share that file. Building a new, small, purpose-scoped registry that *imports classes from where they already live* (not duplicating schema definitions) is the correct, non-cathedral move: it adds one new concern (inner-state bookkeeping) without touching the general-purpose one.
+
+### The registry, specified
+
+`orion/self_state/inner_state_registry.py`:
+
+```python
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Type
+from pydantic import BaseModel
+
+class Cadence(str, Enum):
+    PER_TICK = "per_tick"
+    CHAT_TURN_GATED = "chat_turn_gated"
+    OFFLINE_TRAINED = "offline_trained"
+    EVENT_GATED = "event_gated"  # e.g. turn_effect_alert-triggered
+
+class CompositionStatus(str, Enum):
+    COMPOSED = "composed_into_self_state"        # a named SelfStateV1 field carries it
+    SHADOW = "shadow_declared_not_composed"       # real, live, deliberately not merged (must cite why)
+    DUPLICATE = "unresolved_duplicate"            # known overlap with another entry, not yet reconciled
+    REHEARSAL = "no_cognition_consumer"           # computed, verified to reach nothing real
+
+@dataclass(frozen=True)
+class InnerStateSignal:
+    signal_id: str                     # stable key, e.g. "self_state.v1"
+    schema: Type[BaseModel]             # imported directly from its home module
+    producer_service: str
+    cadence: Cadence
+    composition_status: CompositionStatus
+    cognition_consumers: tuple[str, ...]   # dotted paths, e.g. "services.orion-cortex-exec.app.spark_narrative:spark_phi_narrative"
+    duplicate_of: str | None = None    # signal_id this overlaps with, if DUPLICATE
+    shadow_reason: str | None = None   # required if SHADOW
+    notes: str = ""
+
+REGISTRY: tuple[InnerStateSignal, ...] = (
+    InnerStateSignal(
+        signal_id="field_state.v1",
+        schema=FieldStateV1,  # imported from orion.schemas.field_state
+        producer_service="orion-field-digester",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.COMPOSED,
+        cognition_consumers=(),  # foundation layer; composed via self_state/builder.py, not read directly by cognition
+        notes="Body. Diffusion fixed 2026-07-12 (9d367d4f, 4dc965f2).",
+    ),
+    InnerStateSignal(
+        signal_id="field_attention_frame.v1",
+        schema=FieldAttentionFrameV1,
+        producer_service="orion-attention-runtime",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.SHADOW,
+        cognition_consumers=(),
+        shadow_reason="Only top-5 target_id strings survive into SelfStateV1.dominant_attention_targets; "
+                       "pressure_score/dominant_channels/reasons discarded at builder.py:279. Phase 1 of the "
+                       "companion plan widens this to COMPOSED.",
+    ),
+    InnerStateSignal(
+        signal_id="self_state.v1",
+        schema=SelfStateV1,
+        producer_service="orion-self-state-runtime",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.COMPOSED,
+        cognition_consumers=(
+            "services.orion-spark-introspector.app.inner_state:build_inner_state_features",
+        ),
+        notes="The mood. Composes field_state + field_attention_frame (partially, see above).",
+    ),
+    InnerStateSignal(
+        signal_id="drive_state.v1",
+        schema=DriveStateV1,
+        producer_service="orion.spark.concept_induction.drives",
+        cadence=Cadence.EVENT_GATED,
+        composition_status=CompositionStatus.DUPLICATE,
+        duplicate_of="autonomy_state_v2",
+        cognition_consumers=("services.orion-cortex-exec.app.chat_stance:<concept-induction consumer, needs confirming>",),
+        notes="Computed from config/autonomy/signal_drive_map.yaml, a CLOSED map over "
+              "biometrics_state/mesh_health/spark_signal/failure_event/chat_social_hazard/"
+              "chat_reasoning_quality -- NOT from self_state.dimensions. Only overlap with "
+              "self-state/phi territory: spark_signal.{coherence,valence,novelty}, itself only "
+              "published on a turn_effect_alert (event-gated, not continuous). Live: 363 "
+              "samples/24h, real variance.",
+    ),
+    InnerStateSignal(
+        signal_id="autonomy_state_v2",
+        schema=AutonomyStateV2,
+        producer_service="orion.autonomy.reducer",
+        cadence=Cadence.CHAT_TURN_GATED,
+        composition_status=CompositionStatus.DUPLICATE,
+        duplicate_of="drive_state.v1",
+        cognition_consumers=("services.orion-cortex-exec.app.chat_stance:_run_autonomy_reducer",),
+        notes="Same 6-drive taxonomy as drive_state.v1, independently reduced. 9 samples/24h, "
+              "all zero -- too little traffic to compare (Phase 4, mesh-substrate-redesign plan, "
+              "already on record; NOT resolved by this registry).",
+    ),
+    InnerStateSignal(
+        signal_id="phi_heuristic.valence",  # the surviving slice of _phi_from_self_state
+        schema=None,  # not a schema -- a formula, tracked here anyway because it reaches cognition
+        producer_service="orion-spark-introspector",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.SHADOW,
+        cognition_consumers=(
+            "services.orion-cortex-exec.app.spark_narrative:spark_phi_narrative",
+        ),
+        shadow_reason="No trained latent dimension correlates with any hedonic-adjacent felt "
+                      "dimension per probes.json -- correctly, explicitly justified duplication, "
+                      "the model case for what every SHADOW entry above should look like.",
+    ),
+    InnerStateSignal(
+        signal_id="phi_intrinsic_reward.v1",
+        schema=PhiIntrinsicRewardV1,
+        producer_service="orion-spark-introspector",
+        cadence=Cadence.OFFLINE_TRAINED,
+        composition_status=CompositionStatus.COMPOSED,
+        cognition_consumers=(
+            "services.orion-cortex-exec.app.spark_narrative:spark_phi_narrative",
+        ),
+        notes="Golden phi. Fixed + deployed 2026-07-12 (654a9803, 79a6d966). Was dark "
+              "(SQL sink + debug WebSocket only) for weeks before that.",
+    ),
+    InnerStateSignal(
+        signal_id="biometrics_cluster.v1",
+        schema=BiometricsClusterV1,
+        producer_service="orion-biometrics",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.DUPLICATE,
+        duplicate_of="field_state.v1",  # same underlying question: node-health weighting
+        cognition_consumers=("services.orion-cortex-exec.app.executor:_metacog_biometrics_cue",),
+        notes="Dark in orion-biometrics (BIOMETRICS_MODE=agent); orion-hub's "
+              "BIOMETRICS_ROLE_WEIGHTS_JSON fallback is what's actually live. Three-way "
+              "duplicate with field-topology edges. Resolution already recommended "
+              "(docs/notes/2026-07-12-phase4-cluster-weighting-research.md), not this registry's job.",
+    ),
+    InnerStateSignal(
+        signal_id="l7_l11_ladder",
+        schema=None,  # five schemas, tracked as one row -- see notes
+        producer_service="orion-proposal-runtime, orion-policy-runtime, orion-execution-dispatch-runtime, "
+                          "orion-feedback-runtime, orion-consolidation-runtime",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.REHEARSAL,
+        cognition_consumers=(),
+        notes="Confirmed rehearsal, docs/notes/2026-07-12-phase5-research-findings.md. "
+              "Out of scope for resolution here.",
+    ),
+)
+```
+
+Every field above is filled with a real value from today's tracing, not a placeholder — this is what "meat" means concretely: the registry is not an abstraction, it's nine populated rows a reviewer can check against the actual code.
+
+### The gate, specified
+
+`scripts/check_inner_state_registry.py` does two real, distinct, deterministic things — stated with their actual limitations, not oversold:
+
+1. **Rot check (100% reliable)**: for every `InnerStateSignal` in `REGISTRY`, import `signal.schema` (where not `None`) and confirm it's still a valid, importable `BaseModel` subclass at the path implied by its home module. Confirms the registry doesn't silently go stale as schemas move/rename — this alone is worth building even if the second check below is imperfect.
+2. **New-duplicate heuristic (best-effort, not perfect — stated honestly)**: scan `orion/bus/channels.yaml` and the `message_kind`/schema names in `orion/schemas/registry.py`'s flat dict for new entries whose name matches an inner-state-adjacent naming pattern (substring match against a small, explicit, hand-maintained keyword list: `self_state`, `drive`, `autonomy_state`, `attention`, `phi_reward`, `mood`, `felt_state`, `cluster` — same spirit as the six `signal_kind`s already closed and typed in `signal_drive_map.yaml`, not a fuzzy NLP guess). Any match not present in `REGISTRY` fails the gate with a message naming the exact new schema/channel.
+
+Stated honestly: check #2 is a naming-convention heuristic, not a formal proof — a cleverly-named tenth duplicate that avoids every keyword in the list would evade it. This is the same class of limitation `signal_drive_map.yaml`'s own docstring accepts ("closed... typed... grown by prose is disallowed" — a closed list is exactly this trade-off, deliberately). The alternative (a shared marker base class across `SelfStateV1`/`DriveStateV1`/etc.) was considered and rejected: none of these schemas currently share a common non-`BaseModel` parent, and retrofitting one across 6+ files to gain a slightly more precise heuristic is a real migration cost for a marginal precision gain over a maintained keyword list. Named here so the tradeoff is visible, not silently assumed away.
+
+## Non-goals
+
+- Merging `orion-spark-introspector`, `orion/autonomy`, `orion/spark/concept_induction`, or `orion-attention-runtime` into `orion-self-state-runtime` as one service or codebase — argued above from the actual cadence/lifecycle mismatch (per-tick vs. chat-turn-gated vs. offline-trained vs. 5-service dry-run ladder), not asserted.
+- Building a crosswalk between `DriveEngine`'s 6 drives and `SelfStateV1`'s 12 dimensions. Traced and rejected: they're siblings over disjoint evidence with one narrow, event-gated overlap point (`spark_signal` alerts). Forcing a mapping would fabricate a relationship the data doesn't have.
+- Resolving the `DriveEngine`/`AutonomyStateV2` merge-or-keep-separate question. Still gated on real `AutonomyStateV2` traffic (9 samples/24h is not enough), per the already-on-record Phase 4 decision. The registry makes this a visible, checked `DUPLICATE` entry — it does not force the answer.
+- Retiring `CLUSTER_ROLE_WEIGHTS`/`BIOMETRICS_ROLE_WEIGHTS_JSON`. Already researched and recommended elsewhere; registered here as a known `DUPLICATE`, resolved on its own timeline.
+- A shared marker base class across the six-plus schemas, considered and rejected above in favor of a maintained keyword list.
+- Idea #7 from the prior brainstorm (first-class node/body-schema object) — a future consumer of this contract, not part of building it.
+
+## Files likely to touch
+
+- `orion/self_state/inner_state_registry.py` (new) — the dataclass + populated `REGISTRY` tuple above, verbatim starting point.
+- `scripts/check_inner_state_registry.py` (new) — the two-part gate above.
+- `orion/schemas/self_state.py`, `orion/self_state/builder.py` — widen `dominant_attention_targets` (Phase 1 of the companion plan; flips `field_attention_frame.v1`'s registry entry from `SHADOW` to `COMPOSED`).
+- `services/orion-spark-introspector/app/worker.py`, `orion/schemas/telemetry/phi_encoder.py` — Phases 2/3 of the companion plan.
+- `Makefile` — wire `check_inner_state_registry.py` into `agent-check`, alongside a note that `check_schema_registry.py`/`check_bus_channels.py` are still missing (separate, pre-existing gap, not silently absorbed into this patch).
+
+## Acceptance checks
+
+- `scripts/check_inner_state_registry.py --rot-check` passes against all nine current entries (proves the registry isn't already stale on day one).
+- A synthetic test: add a fake new bus channel named `orion:test:mood_state` to a test fixture of `channels.yaml` with no registry entry — the heuristic check must fail on it, by name, in the error message.
+- `field_attention_frame.v1`'s registry entry is updated from `SHADOW` to `COMPOSED` in the same PR that widens `dominant_attention_targets` (Phase 1) — the registry changing is the actual proof the contract works, not a separate afterthought.
+- At least one prompt-builder is audited against the registry's `cognition_consumers` field for accuracy: does `spark_narrative.py` really only read what the registry claims it reads? (Expected: yes for phi paths, confirmed by today's tracing; `executor.py`'s biometrics cue is already known to read `BiometricsClusterV1`'s fallback path directly — that's a pre-existing, already-documented gap, not new.)
+
+## Recommended next patch
+
+Phase 0 of the companion plan, verbatim against the registry code above — not a redesign, an implementation of what's already fully specified here.

--- a/orion/self_state/README.md
+++ b/orion/self_state/README.md
@@ -1,0 +1,62 @@
+# orion/self_state
+
+Builds `SelfStateV1` (Layer 6: the mood) from `FieldStateV1` (the body,
+`orion-field-digester`) and `FieldAttentionFrameV1` (per-node/per-capability
+attention scoring, `orion-attention-runtime`). Consumed by the
+`orion-self-state-runtime` service.
+
+- `builder.py` — `build_self_state()`, the per-tick composer.
+- `scoring.py` — per-dimension scoring formulas, channel merge/max rules.
+- `policy.py` — loads `config/self_state/self_state_policy.v1.yaml`
+  (`channel_dimension_map`, `evidence_channel_map`, `dimension_worse_direction`).
+- `deviation.py` — Phase 2 deviation-probe instrumentation (measurement only,
+  reuses `DeviationGate`'s EWMA-baseline mechanism).
+- `prediction.py` — inter-tick prediction/surprise loop.
+- `transport.py` — `transport_integrity` dimension helpers.
+
+## `inner_state_registry.py`
+
+`SelfStateV1` is the one schema every cognition-facing prompt-builder
+(metacog templates, chat prompts) is expected to read from — directly, or
+via phi's `InnerStateFeaturesV1`. This module is the registry of every
+"what does Orion currently feel/perceive" signal in the repo, not just the
+ones `SelfStateV1` itself composes: `FieldStateV1`, `FieldAttentionFrameV1`,
+`DriveStateV1`, `AutonomyStateV2`, phi (both the trained encoder and the
+surviving heuristic slice), `BiometricsClusterV1`, and the L7–L11 ladder.
+
+Each `InnerStateSignal` entry names its producer service, cadence, and one
+of four composition statuses:
+
+- `COMPOSED` — has a named field on `SelfStateV1` (or, for phi, is wired
+  into a cognition-facing narrative).
+- `SHADOW` — real, live, deliberately **not** composed, with a required,
+  stated reason (`shadow_reason`). The model case: phi's surviving
+  `valence` heuristic, explicitly justified because no trained latent
+  correlates with anything hedonic-adjacent.
+- `DUPLICATE` — an unresolved overlap with another entry (`duplicate_of`),
+  e.g. `drive_state.v1`/`autonomy_state_v2` — same 6-drive taxonomy, two
+  independent reducers, not yet reconciled (traffic-gated decision, on
+  record separately — this registry makes the fact visible, it doesn't
+  force the answer).
+- `REHEARSAL` — computed, verified to reach no cognition consumer at all
+  (the L7–L11 ladder).
+
+This was built because the same failure mode — a real signal silently
+duplicating another, or never reaching cognition — was independently
+rediscovered five times by manual grep-archaeology in one session
+(`docs/superpowers/specs/2026-07-12-inner-state-unification-design.md`).
+It is deliberately **not** a merge into `orion/schemas/registry.py` (that
+file is a general-purpose name→class lookup with hundreds of unrelated
+entries; wrong blast radius for this) and deliberately **not** a service —
+merging `orion-spark-introspector` (offline-trained), `orion/autonomy`
+(chat-turn-gated), and `orion-attention-runtime` (per-tick) into one
+codebase would trade five duplicated computations for one badly-scoped
+service.
+
+`scripts/check_inner_state_registry.py` (`make check-inner-state-registry`)
+runs two checks against this module: a rot check (every registered schema
+still imports and is a real `BaseModel`) and a best-effort new-duplicate
+heuristic (a new bus channel or schema whose name matches an inner-state
+keyword, with no registry entry, fails the gate by name). The heuristic's
+real limitation is documented in the script itself — it is a maintained
+keyword list, not a formal proof.

--- a/orion/self_state/inner_state_registry.py
+++ b/orion/self_state/inner_state_registry.py
@@ -1,0 +1,262 @@
+"""Registry of every "what does Orion currently feel/perceive" signal in the
+repo (2026-07-12, inner-state unification).
+
+Context: five independent times in one session, a real, computed inner-state
+signal turned out to either silently duplicate another one, or never reach a
+cognition consumer at all (DriveEngine/AutonomyStateV2, CLUSTER_ROLE_WEIGHTS
+x3, the phi/heuristic split, FieldAttentionFrameV1's discarded per-node
+scores). Each was found by manual grep-archaeology. This registry is the
+deterministic alternative: every inner-state-shaped schema gets one entry
+naming its producer, cadence, composition status, and cognition consumer(s)
+(or an explicit, dated reason it has none yet) -- so the next one is a
+registry entry, not a sixth rediscovery.
+
+See docs/superpowers/specs/2026-07-12-inner-state-unification-design.md for
+the full per-signal tracing this registry is populated from.
+
+This is deliberately NOT a merge into orion/schemas/registry.py: that file is
+a general-purpose name->class lookup with hundreds of unrelated entries (bus
+envelope resolution, dynamic dispatch). This registry is narrow and
+purpose-built -- it imports classes from where they already live, it does
+not redefine or duplicate them.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Type
+
+from pydantic import BaseModel
+
+from orion.autonomy.models import AutonomyStateV2
+from orion.core.schemas.drives import DriveStateV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.field_state import FieldStateV1
+from orion.schemas.self_state import SelfStateV1
+from orion.schemas.telemetry.biometrics import BiometricsClusterV1
+from orion.schemas.telemetry.phi_encoder import PhiIntrinsicRewardV1
+
+
+class Cadence(str, Enum):
+    """How often a signal is (re)computed."""
+
+    PER_TICK = "per_tick"
+    CHAT_TURN_GATED = "chat_turn_gated"
+    OFFLINE_TRAINED = "offline_trained"
+    EVENT_GATED = "event_gated"  # e.g. only on a turn_effect_alert
+    MULTI_SERVICE = "multi_service"  # spans several per-tick services (the L7-L11 ladder)
+
+
+class CompositionStatus(str, Enum):
+    """Where a signal stands relative to SelfStateV1, the one schema every
+    cognition-facing prompt-builder is expected to read from."""
+
+    COMPOSED = "composed_into_self_state"
+    SHADOW = "shadow_declared_not_composed"
+    DUPLICATE = "unresolved_duplicate"
+    REHEARSAL = "no_cognition_consumer"
+
+
+@dataclass(frozen=True)
+class InnerStateSignal:
+    signal_id: str
+    schema: Optional[Type[BaseModel]]
+    producer_service: str
+    cadence: Cadence
+    composition_status: CompositionStatus
+    cognition_consumers: tuple[str, ...] = ()
+    duplicate_of: Optional[str] = None
+    shadow_reason: Optional[str] = None
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if self.composition_status is CompositionStatus.DUPLICATE and not self.duplicate_of:
+            raise ValueError(f"{self.signal_id}: DUPLICATE status requires duplicate_of")
+        if self.composition_status is CompositionStatus.SHADOW and not self.shadow_reason:
+            raise ValueError(f"{self.signal_id}: SHADOW status requires shadow_reason")
+
+
+REGISTRY: tuple[InnerStateSignal, ...] = (
+    InnerStateSignal(
+        signal_id="field_state.v1",
+        schema=FieldStateV1,
+        producer_service="orion-field-digester",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.COMPOSED,
+        cognition_consumers=(),
+        notes=(
+            "The body. Per-node/per-capability raw channel vectors. Diffusion "
+            "fixed 2026-07-12 (9d367d4f, 4dc965f2) after a permanent-saturation "
+            "bug; not read by cognition directly, composed into self_state.v1."
+        ),
+    ),
+    InnerStateSignal(
+        signal_id="field_attention_frame.v1",
+        schema=FieldAttentionFrameV1,
+        producer_service="orion-attention-runtime",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.SHADOW,
+        cognition_consumers=(),
+        shadow_reason=(
+            "orion/self_state/builder.py reads the full FieldAttentionTargetV1 "
+            "list (pressure_score, dominant_channels, reasons per node/capability) "
+            "but keeps only the top-5 target_id strings on "
+            "SelfStateV1.dominant_attention_targets -- every other field is "
+            "discarded at builder.py's dominant_targets extraction. Real, "
+            "non-theater engineering (see field_attention/scoring.py's "
+            "weighted_pressure/urgency_score/confidence_from_vector), thrown "
+            "away one hop downstream. Phase 1 of the companion plan widens "
+            "this to COMPOSED."
+        ),
+    ),
+    InnerStateSignal(
+        signal_id="self_state.v1",
+        schema=SelfStateV1,
+        producer_service="orion-self-state-runtime",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.COMPOSED,
+        cognition_consumers=(
+            "services.orion-spark-introspector.app.inner_state:build_inner_state_features",
+        ),
+        notes=(
+            "The mood. ~12 dimension scores + confidence + reasons, composed "
+            "from field_state.v1 + field_attention_frame.v1 (partially -- see "
+            "that entry). Feeds phi's InnerStateFeaturesV1 and the L7 ladder."
+        ),
+    ),
+    InnerStateSignal(
+        signal_id="drive_state.v1",
+        schema=DriveStateV1,
+        producer_service="orion.spark.concept_induction.drives",
+        cadence=Cadence.EVENT_GATED,
+        composition_status=CompositionStatus.DUPLICATE,
+        duplicate_of="autonomy_state_v2",
+        cognition_consumers=(),
+        notes=(
+            "Computed from config/autonomy/signal_drive_map.yaml, a CLOSED "
+            "typed map over biometrics_state/mesh_health/spark_signal/"
+            "failure_event/chat_social_hazard/chat_reasoning_quality -- NOT "
+            "from self_state.v1.dimensions. Do not build a drives<->self-state "
+            "crosswalk: traced and rejected in the design spec, they are "
+            "siblings over disjoint evidence with exactly one narrow, "
+            "event-gated overlap point (spark_signal.{coherence,valence,"
+            "novelty}, itself only published by orion-spark-introspector on a "
+            "turn_effect_alert, not continuously). Live: 363 samples/24h "
+            "confirmed 2026-07-12, real variance "
+            "(coherence~0.20, continuity~0.35, capability~0.47)."
+        ),
+    ),
+    InnerStateSignal(
+        signal_id="autonomy_state_v2",
+        schema=AutonomyStateV2,
+        producer_service="orion.autonomy.reducer",
+        cadence=Cadence.CHAT_TURN_GATED,
+        composition_status=CompositionStatus.DUPLICATE,
+        duplicate_of="drive_state.v1",
+        cognition_consumers=(
+            "services.orion-cortex-exec.app.chat_stance:_run_autonomy_reducer",
+        ),
+        notes=(
+            "Same 6-drive taxonomy (DRIVE_KEYS) as drive_state.v1, "
+            "independently reduced, gated behind AUTONOMY_STATE_V2_REDUCER_ENABLED. "
+            "9 samples/24h confirmed 2026-07-12, all zero -- too little traffic "
+            "to compare against drive_state.v1 yet. Merge-or-keep-separate "
+            "decision is Phase 4 of the mesh-substrate-redesign plan, already "
+            "on record; NOT resolved by this registry."
+        ),
+    ),
+    InnerStateSignal(
+        signal_id="phi_heuristic.valence",
+        schema=None,
+        producer_service="orion-spark-introspector",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.SHADOW,
+        cognition_consumers=(
+            "services.orion-cortex-exec.app.spark_narrative:spark_phi_narrative",
+        ),
+        shadow_reason=(
+            "_phi_from_self_state()'s valence formula is the only surviving "
+            "slice of the pre-2026-07-12 untrained EKG heuristic. No trained "
+            "phi-encoder latent dimension correlates with any hedonic-adjacent "
+            "felt dimension per the active encoder's probes.json -- explicitly "
+            "verified, not assumed. This is the model case for a correctly "
+            "justified, documented SHADOW entry (see "
+            "_golden_phi_overrides()'s docstring in "
+            "services/orion-spark-introspector/app/worker.py)."
+        ),
+        notes="Not a schema -- a formula. Tracked here because it reaches cognition.",
+    ),
+    InnerStateSignal(
+        signal_id="phi_intrinsic_reward.v1",
+        schema=PhiIntrinsicRewardV1,
+        producer_service="orion-spark-introspector",
+        cadence=Cadence.OFFLINE_TRAINED,
+        composition_status=CompositionStatus.COMPOSED,
+        cognition_consumers=(
+            "services.orion-cortex-exec.app.spark_narrative:spark_phi_narrative",
+        ),
+        notes=(
+            "Golden phi. Trained MLP autoencoder over InnerStateFeaturesV1. "
+            "Fixed + deployed 2026-07-12 (654a9803, 79a6d966) -- was dark "
+            "(SQL sink + debug WebSocket EKG panel only) for weeks before that."
+        ),
+    ),
+    InnerStateSignal(
+        signal_id="biometrics_cluster.v1",
+        schema=BiometricsClusterV1,
+        producer_service="orion-biometrics",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.DUPLICATE,
+        duplicate_of="field_state.v1",
+        cognition_consumers=(
+            "services.orion-cortex-exec.app.executor:_metacog_biometrics_cue",
+        ),
+        notes=(
+            "Third independent reimplementation of 'how much should each "
+            "node's health count' alongside field-topology edges and "
+            "orion-hub's BIOMETRICS_ROLE_WEIGHTS_JSON fallback. Dark in "
+            "orion-biometrics (BIOMETRICS_MODE=agent); the hub fallback is "
+            "what's actually live. Resolution already recommended "
+            "(docs/notes/2026-07-12-phase4-cluster-weighting-research.md), "
+            "not this registry's job."
+        ),
+    ),
+    InnerStateSignal(
+        signal_id="l7_l11_ladder",
+        schema=None,
+        producer_service=(
+            "orion-proposal-runtime, orion-policy-runtime, "
+            "orion-execution-dispatch-runtime, orion-feedback-runtime, "
+            "orion-consolidation-runtime"
+        ),
+        cadence=Cadence.MULTI_SERVICE,
+        composition_status=CompositionStatus.REHEARSAL,
+        cognition_consumers=(),
+        notes=(
+            "Five schemas (ProposalFrameV1 -> ConsolidationV1), tracked as one "
+            "row. Confirmed rehearsal: docs/notes/2026-07-12-phase5-research-"
+            "findings.md -- EXECUTION_DISPATCH_MODE=dry_run live, every reader "
+            "outside the ladder is a self-labeled Hub debug route, the one "
+            "non-Hub reader (orion-thought reverie grounding) only appends an "
+            "inert ID tag to an already-generated thought. Out of scope for "
+            "resolution here."
+        ),
+    ),
+)
+
+
+def get(signal_id: str) -> InnerStateSignal:
+    for entry in REGISTRY:
+        if entry.signal_id == signal_id:
+            return entry
+    raise KeyError(f"No inner-state registry entry for {signal_id!r}")
+
+
+def duplicates() -> tuple[InnerStateSignal, ...]:
+    """All entries currently flagged as unresolved duplicates of another entry."""
+    return tuple(e for e in REGISTRY if e.composition_status is CompositionStatus.DUPLICATE)
+
+
+def shadows() -> tuple[InnerStateSignal, ...]:
+    """All entries deliberately not composed into self_state.v1, with a reason."""
+    return tuple(e for e in REGISTRY if e.composition_status is CompositionStatus.SHADOW)

--- a/scripts/check_inner_state_registry.py
+++ b/scripts/check_inner_state_registry.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Deterministic gate for orion/self_state/inner_state_registry.py.
+
+Two distinct, independent checks:
+
+1. Rot check (reliable): every InnerStateSignal.schema in REGISTRY must still
+   import and be a real pydantic BaseModel subclass. Catches the registry
+   silently going stale as schemas move/rename/get deleted.
+
+2. New-duplicate heuristic (best-effort, NOT a proof): scans orion/bus/
+   channels.yaml's schema_id fields and orion/schemas/registry.py's flat
+   name->class dict for entries whose name matches a small, explicit,
+   hand-maintained keyword list associated with "this looks like an
+   inner-state-shaped signal" -- and fails if a match has no corresponding
+   REGISTRY entry (by schema class name).
+
+   Real, stated limitation: this is a naming-convention heuristic, not a
+   formal proof. A new schema named around the keyword list can evade it.
+   A shared marker base class across every inner-state schema was considered
+   and rejected (see docs/superpowers/specs/2026-07-12-inner-state-
+   unification-design.md) -- none of the existing six schemas currently
+   share a common non-BaseModel parent, and retrofitting one purely to gain
+   a slightly more precise heuristic is a real migration cost for a marginal
+   precision gain over a maintained keyword list.
+
+Usage:
+    python scripts/check_inner_state_registry.py
+    python scripts/check_inner_state_registry.py --channels-file <path>  # test override
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/check_inner_state_registry.py` puts scripts/ on
+# sys.path[0], which shadows stdlib `platform` via scripts/platform/ and
+# breaks pydantic (same issue documented in scripts/fit_phi_encoder.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+import yaml
+from pydantic import BaseModel
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from orion.self_state.inner_state_registry import REGISTRY  # noqa: E402
+
+# Deliberately small, explicit, hand-maintained -- grown by editing this list,
+# not by a fuzzy classifier. Mirrors the same closed-list discipline already
+# used by config/autonomy/signal_drive_map.yaml.
+INNER_STATE_KEYWORDS: tuple[str, ...] = (
+    "self_state",
+    "selfstate",
+    "drive",
+    "autonomy_state",
+    "autonomystate",
+    "attention",
+    "phi_reward",
+    "phi_intrinsic",
+    "mood",
+    "felt_state",
+    "cluster",
+)
+
+DEFAULT_CHANNELS_FILE = REPO_ROOT / "orion" / "bus" / "channels.yaml"
+
+# schema class names deliberately excluded from the "needs its own REGISTRY
+# entry" requirement, each with a real reason found while first running this
+# gate (2026-07-12) -- not a blanket allowlist, every name here was traced.
+_EXTRA_COVERED_SCHEMA_NAMES: dict[str, str] = {
+    # --- companions/sub-objects of an existing REGISTRY entry ---
+    "ProposalFrameV1": "l7_l11_ladder",
+    "PolicyDecisionFrameV1": "l7_l11_ladder",
+    "ExecutionDispatchFrameV1": "l7_l11_ladder",
+    "FeedbackFrameV1": "l7_l11_ladder",
+    "ConsolidationV1": "l7_l11_ladder",
+    "PhiEncoderManifestV1": "phi_intrinsic_reward.v1 (training-artifact manifest, same lineage)",
+    "SelfStateDimensionV1": "self_state.v1 (per-dimension row)",
+    "FieldAttentionTargetV1": "field_attention_frame.v1 (per-target row, orion/schemas/field_attention_frame.py)",
+    "DriveAuditV1": "drive_state.v1 (audit-trail companion, orion/core/schemas/drives.py)",
+    "DriveNodeV1": "drive_state.v1 (cognitive-substrate graph-node projection, orion/core/schemas/cognitive_substrate.py -- static drive-kind node, not a live per-tick pressure reading)",
+    # --- genuine keyword-collision false positives, unrelated domain ---
+    "ArticleClusterV1": "false positive -- orion/schemas/world_pulse.py, news-article clustering, unrelated to node-health 'cluster'",
+    # --- a distinct, real, adjacent subsystem NOT audited by this registry pass:
+    #     conversational curiosity/attention-allocation (open loops, curiosity
+    #     candidate actions, voluntary override), structurally different from
+    #     field_attention_frame.v1's per-node/capability salience. Excluded
+    #     here because this registry's scope (per the design spec) is felt-
+    #     state signals, not attention-allocation mechanics -- flagged as
+    #     worth its own future audit, not silently dismissed.
+    "AttentionFrameV1": "distinct conversational-attention/curiosity subsystem (orion/schemas/attention_frame.py), not audited by this registry pass",
+    "AttentionSignalV1": "distinct conversational-attention/curiosity subsystem (orion/schemas/attention_frame.py), not audited by this registry pass",
+    "AttentionSalienceTraceV1": "distinct conversational-attention/curiosity subsystem (orion/schemas/attention_salience.py), not audited by this registry pass",
+    "AttentionLoopOutcomeV1": "distinct conversational-attention/curiosity subsystem (orion/schemas/attention_salience.py), not audited by this registry pass",
+    "PendingAttentionCardV1": "distinct conversational-attention/curiosity subsystem (orion/schemas/attention_salience.py), not audited by this registry pass",
+    "ChatAttentionRequest": "distinct chat-notification-attention subsystem (orion/schemas/notify.py), not audited by this registry pass",
+    "ChatAttentionAck": "distinct chat-notification-attention subsystem (orion/schemas/notify.py), not audited by this registry pass",
+    "ChatAttentionState": "distinct chat-notification-attention subsystem (orion/schemas/notify.py), not audited by this registry pass",
+}
+
+
+def rot_check() -> list[str]:
+    """Returns a list of failure messages; empty means all entries are healthy."""
+    failures: list[str] = []
+    for entry in REGISTRY:
+        if entry.schema is None:
+            continue
+        if not isinstance(entry.schema, type) or not issubclass(entry.schema, BaseModel):
+            failures.append(
+                f"{entry.signal_id}: schema={entry.schema!r} is not a BaseModel subclass"
+            )
+    return failures
+
+
+def _covered_schema_names() -> set[str]:
+    names = {entry.schema.__name__ for entry in REGISTRY if entry.schema is not None}
+    return names.union(_EXTRA_COVERED_SCHEMA_NAMES)
+
+
+def _matches_keyword(name: str) -> bool:
+    lowered = name.lower()
+    return any(kw in lowered for kw in INNER_STATE_KEYWORDS)
+
+
+def _channel_schema_ids(channels_file: Path) -> Iterable[str]:
+    if not channels_file.is_file():
+        return ()
+    data = yaml.safe_load(channels_file.read_text(encoding="utf-8")) or {}
+    channels = data.get("channels") or []
+    seen: set[str] = set()
+    for channel in channels:
+        schema_id = channel.get("schema_id")
+        if isinstance(schema_id, str) and schema_id not in seen:
+            seen.add(schema_id)
+            yield schema_id
+
+
+def _registry_py_schema_names() -> Iterable[str]:
+    from orion.schemas import registry as generic_registry  # local import: heavy module
+
+    flat = getattr(generic_registry, "_REGISTRY", None)
+    if isinstance(flat, dict):
+        for name in flat:
+            yield name
+
+
+def new_duplicate_heuristic_check(*, channels_file: Path) -> list[str]:
+    covered = _covered_schema_names()
+    failures: list[str] = []
+
+    for schema_id in _channel_schema_ids(channels_file):
+        if _matches_keyword(schema_id) and schema_id not in covered:
+            failures.append(
+                f"orion/bus/channels.yaml declares schema_id={schema_id!r}, which matches an "
+                f"inner-state keyword and has no orion/self_state/inner_state_registry.py entry"
+            )
+
+    for name in _registry_py_schema_names():
+        if _matches_keyword(name) and name not in covered:
+            failures.append(
+                f"orion/schemas/registry.py declares {name!r}, which matches an inner-state "
+                f"keyword and has no orion/self_state/inner_state_registry.py entry"
+            )
+
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--channels-file",
+        type=Path,
+        default=DEFAULT_CHANNELS_FILE,
+        help="override for testing against a fixture channels.yaml",
+    )
+    args = parser.parse_args(argv)
+
+    failures = rot_check() + new_duplicate_heuristic_check(channels_file=args.channels_file)
+
+    if failures:
+        print("inner_state_registry gate FAILED:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print(f"inner_state_registry gate OK ({len(REGISTRY)} entries checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-self-state-runtime/README.md
+++ b/services/orion-self-state-runtime/README.md
@@ -38,3 +38,17 @@ curl -s http://localhost:8118/latest | jq .
 ## Non-goals (v1)
 
 No bus publish, proposals, policy gates, cortex-exec steering, or LLM interpretation.
+
+## Inner-state registry
+
+`SelfStateV1` is the one schema every cognition-facing prompt-builder is
+expected to read from (directly, or via phi's `InnerStateFeaturesV1`).
+`orion/self_state/inner_state_registry.py` tracks every "what does Orion
+currently feel/perceive" signal in the repo — producer, cadence, whether
+it's composed into `SelfStateV1`, an unresolved duplicate of another signal,
+or a declared, justified shadow — so a new one is a registry entry, not a
+silent duplicate discovered by grep-archaeology (see
+`docs/superpowers/specs/2026-07-12-inner-state-unification-design.md`).
+`python scripts/check_inner_state_registry.py` (`make check-inner-state-registry`)
+gates against the registry going stale or a new inner-state-shaped
+schema/channel appearing unregistered.

--- a/tests/test_inner_state_registry_gate.py
+++ b/tests/test_inner_state_registry_gate.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+SCRIPTS = REPO / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import pytest
+
+import check_inner_state_registry as gate
+from orion.self_state.inner_state_registry import (
+    Cadence,
+    CompositionStatus,
+    InnerStateSignal,
+)
+
+
+def test_rot_check_passes_against_real_registry() -> None:
+    # The regression this gate exists to prevent: if this ever fails, a
+    # REGISTRY entry's schema has gone stale (renamed/deleted/no longer a
+    # BaseModel) and nobody noticed.
+    assert gate.rot_check() == []
+
+
+def test_rot_check_fails_on_a_non_basemodel_schema(monkeypatch) -> None:
+    class NotAModel:
+        pass
+
+    stale_entry = InnerStateSignal(
+        signal_id="test.stale",
+        schema=NotAModel,  # type: ignore[arg-type]
+        producer_service="test",
+        cadence=Cadence.PER_TICK,
+        composition_status=CompositionStatus.COMPOSED,
+    )
+    monkeypatch.setattr(gate, "REGISTRY", gate.REGISTRY + (stale_entry,))
+
+    failures = gate.rot_check()
+
+    assert any("test.stale" in f for f in failures)
+
+
+def test_new_duplicate_heuristic_passes_against_real_channels_yaml() -> None:
+    # Confirms the current, real orion/bus/channels.yaml + orion/schemas/
+    # registry.py produce zero unaccounted inner-state-keyword matches, given
+    # today's REGISTRY + _EXTRA_COVERED_SCHEMA_NAMES triage.
+    assert gate.new_duplicate_heuristic_check(channels_file=gate.DEFAULT_CHANNELS_FILE) == []
+
+
+def test_new_duplicate_heuristic_fails_on_an_unregistered_new_channel(tmp_path) -> None:
+    fixture = tmp_path / "channels.yaml"
+    fixture.write_text(
+        """
+channels:
+  - name: "orion:test:mood_state"
+    kind: "event"
+    schema_id: "MoodStateV1"
+    producer_services: ["orion-test-service"]
+    consumer_services: ["orion-test-consumer"]
+    stability: "experimental"
+    since: "2026-07-12"
+"""
+    )
+
+    failures = gate.new_duplicate_heuristic_check(channels_file=fixture)
+
+    assert any("MoodStateV1" in f for f in failures)
+
+
+def test_new_duplicate_heuristic_ignores_a_channel_with_no_keyword_match(tmp_path) -> None:
+    fixture = tmp_path / "channels.yaml"
+    fixture.write_text(
+        """
+channels:
+  - name: "orion:test:unrelated"
+    kind: "event"
+    schema_id: "UnrelatedPayloadV1"
+    producer_services: ["orion-test-service"]
+    consumer_services: ["orion-test-consumer"]
+    stability: "experimental"
+    since: "2026-07-12"
+"""
+    )
+
+    failures = gate.new_duplicate_heuristic_check(channels_file=fixture)
+
+    assert failures == []
+
+
+def test_innerstate_signal_requires_duplicate_of_when_duplicate() -> None:
+    with pytest.raises(ValueError, match="DUPLICATE status requires duplicate_of"):
+        InnerStateSignal(
+            signal_id="test.bad",
+            schema=None,
+            producer_service="test",
+            cadence=Cadence.PER_TICK,
+            composition_status=CompositionStatus.DUPLICATE,
+        )
+
+
+def test_innerstate_signal_requires_shadow_reason_when_shadow() -> None:
+    with pytest.raises(ValueError, match="SHADOW status requires shadow_reason"):
+        InnerStateSignal(
+            signal_id="test.bad",
+            schema=None,
+            producer_service="test",
+            cadence=Cadence.PER_TICK,
+            composition_status=CompositionStatus.SHADOW,
+        )
+
+
+def test_main_exits_zero_against_real_repo() -> None:
+    assert gate.main([]) == 0


### PR DESCRIPTION
## Summary

- Phase 0 of the inner-state unification plan: a registry (`orion/self_state/inner_state_registry.py`) enumerating every "what does Orion currently feel/perceive" signal in the repo, plus a deterministic gate (`scripts/check_inner_state_registry.py`) that fails if the registry goes stale or a new inner-state-shaped schema/channel appears unregistered.
- This is the foundational fix for a failure mode independently rediscovered five separate times in one session: a real, computed signal silently duplicating another one, or never reaching cognition (DriveEngine/AutonomyStateV2, `CLUSTER_ROLE_WEIGHTS` x3, the phi/heuristic split, `FieldAttentionFrameV1`'s discarded per-node scores).
- Running the gate for the first time against the real repo surfaced 16 real findings, each individually triaged (not blanket-suppressed) — see "Review findings fixed" below.
- Also found, documented, and explicitly NOT fixed as scope creep: `make agent-check` and 2 of its 3 referenced scripts don't exist despite CLAUDE.md describing them as real.
- README updates: new `orion/self_state/README.md` (the package had none); a new section in `services/orion-self-state-runtime/README.md`.

## Outcome moved

The next inner-state-shaped signal added anywhere in the repo either gets a registry entry or fails a deterministic gate — not a sixth manual grep-archaeology discovery weeks later.

## Current architecture

Nine signals across six services (`orion-field-digester`, `orion-attention-runtime`, `orion-self-state-runtime`, `orion.spark.concept_induction`, `orion.autonomy`, `orion-spark-introspector`, `orion-biometrics`, plus the 5-service L7-L11 ladder) each independently answer some version of "what does Orion currently feel." No prior mechanism declared which was canonical, which reached cognition, or which duplicated another.

## Architecture touched

`orion/self_state/` (new registry module + README), `scripts/` (new gate script), `tests/` (new gate tests), `Makefile` (new target), `services/orion-self-state-runtime/README.md`. No runtime behavior changed — this is bookkeeping infrastructure, not a code path any service executes.

## Files changed

- `orion/self_state/inner_state_registry.py` (new): `Cadence`/`CompositionStatus` enums, `InnerStateSignal` frozen dataclass with validation (`DUPLICATE` requires `duplicate_of`, `SHADOW` requires `shadow_reason`), and all 9 current signals populated with real producer/cadence/consumer data traced from the design spec.
- `scripts/check_inner_state_registry.py` (new): rot check (every registered schema still imports as a real `BaseModel`) + new-duplicate heuristic (keyword scan of `orion/bus/channels.yaml` and `orion/schemas/registry.py`'s flat name dict, cross-checked against the registry plus a documented `_EXTRA_COVERED_SCHEMA_NAMES` exclusion list).
- `tests/test_inner_state_registry_gate.py` (new): 8 tests — rot-check pass/fail, heuristic pass/fail against both the real repo and synthetic fixtures, `InnerStateSignal` validation, full gate exit code.
- `Makefile`: new `check-inner-state-registry` target.
- `orion/self_state/README.md` (new), `services/orion-self-state-runtime/README.md`: documentation.
- `docs/superpowers/specs/2026-07-12-inner-state-unification-design.md`, `docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md`: the design spec and phased plan this implements (written earlier this session, committed here for the first time).

## Schema / bus / API changes

None. No existing schema, channel, or API changed shape.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. pytest tests/test_inner_state_registry_gate.py -q
8 passed

PYTHONPATH=. pytest tests/test_self_state_runtime_store.py tests/test_self_state_deviation.py \
  tests/test_self_state_transport_dimension.py tests/test_self_state_builder.py \
  tests/test_self_state_reliability_decontamination.py tests/test_self_state_prediction.py \
  tests/test_self_state_policy_loader.py tests/test_self_state_builder_hardening.py \
  tests/test_self_state_scoring.py tests/test_self_state_schemas.py \
  tests/test_inner_state_registry_gate.py -q
62 passed

python scripts/check_inner_state_registry.py
inner_state_registry gate OK (9 entries checked)
```

## Evals run

None applicable — this is deterministic bookkeeping infrastructure, not a behavior/quality question.

## Docker/build/smoke checks

Not applicable — no service, no runtime behavior change, nothing to deploy.

## Review findings fixed

The gate's first real run against the repo surfaced 16 matches with no registry entry. Each was individually traced and resolved, not blanket-suppressed:

- Finding: `SelfStateDimensionV1`, `FieldAttentionTargetV1`, `DriveAuditV1`, `DriveNodeV1` matched keywords with no registry entry.
  - Resolution: confirmed each is a sub-object/companion of an existing registry entry (per-dimension row, per-target row, audit-trail companion, graph-node projection respectively) — added to `_EXTRA_COVERED_SCHEMA_NAMES` with the specific relationship documented, not just suppressed.
- Finding: `ArticleClusterV1` matched the `cluster` keyword.
  - Resolution: traced to `orion/schemas/world_pulse.py` — news-article clustering for topic-foundry, a genuine keyword collision unrelated to node-health clustering. Documented as a false positive, not silently ignored.
- Finding: `AttentionFrameV1`, `AttentionSignalV1`, `AttentionSalienceTraceV1`, `AttentionLoopOutcomeV1`, `PendingAttentionCardV1`, `ChatAttentionRequest`, `ChatAttentionAck`, `ChatAttentionState` all matched the `attention` keyword.
  - Resolution: traced these to two distinct, real, already-existing subsystems (`orion/schemas/attention_frame.py` + `orion/schemas/attention_salience.py` — conversational curiosity/open-loop attention allocation; `orion/schemas/notify.py` — chat-notification attention) structurally different from `FieldAttentionFrameV1`'s per-node/capability salience scoring. Explicitly excluded as out of scope for this registry's felt-state focus, with a note flagging them as worth their own future audit — not silently dismissed as noise.
- Finding: `PhiEncoderManifestV1`, and the five L7-L11 ladder frame schemas (`ProposalFrameV1` etc.) matched keywords.
  - Resolution: confirmed as direct lineage companions of `phi_intrinsic_reward.v1` and `l7_l11_ladder` respectively, added to the exclusion list with that reasoning.

Separately, code review confirmed: `orion/schemas/registry.py:660`'s `_REGISTRY` really is `Dict[str, Type[BaseModel]]` as the gate script assumes; the `scripts/platform/`-shadows-stdlib-`platform` import ordering issue (same class of bug documented in `scripts/fit_phi_encoder.py`) was pre-emptively worked around in the new script; all `InnerStateSignal.__post_init__` validation invariants hold across all 9 entries; Makefile recipe uses a real tab, not spaces.

## Restart required

```text
No restart required.
```

No service reads this registry at runtime — it's a static bookkeeping module and a CI-style gate script.

## Risks / concerns

- Severity: low
- Concern: the new-duplicate heuristic is a maintained keyword list, not a formal proof — documented explicitly in the script's own docstring and in `orion/self_state/README.md`. A cleverly-named 10th duplicate could evade it.
- Mitigation: a shared marker base class was considered and rejected (real migration cost across 6+ existing schemas for marginal precision gain); the keyword list is easy to extend when the next miss is found, same discipline as `config/autonomy/signal_drive_map.yaml`'s own closed-list approach.
- Severity: low
- Concern: this patch surfaces (but does not resolve) that `make agent-check`, `check_schema_registry.py`, `check_bus_channels.py`, and `check_env_template_parity.py` — all referenced in CLAUDE.md §11/§17 as if they exist — do not.
- Mitigation: named explicitly here rather than silently fixed as scope creep or silently ignored. Juniper's call whether this is a follow-up patch.