### PR TITLE
Feat/self state attention target composition

### DIFF
--- a/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
+++ b/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
@@ -23,16 +23,18 @@ Companion to `docs/superpowers/specs/2026-07-12-inner-state-unification-design.m
 
 ## Phase 1 — Widen `dominant_attention_targets` (brainstorm idea #1, now a registry-governed extension)
 
+**Status: implemented, not yet deployed** (branch `feat/self-state-attention-target-composition`).
+
 **Gate to start:** Phase 0 merged (this is the first signal added *through* the registry, proving the pattern works before anything else uses it).
 
-- [ ] `orion/schemas/self_state.py`: additive field carrying structured attention-target data (pressure_score, dominant_channels top-1, reasons top-1) for the top-N targets, alongside (not replacing) the existing bare-string list.
-- [ ] `orion/self_state/builder.py`: populate from `attention.dominant_targets` (already in scope at the point this is currently discarded, `builder.py:279`).
-- [ ] Registry entry added in the same PR — this is the acceptance check for Phase 0's gate actually working, not a separate afterthought.
-- [ ] Log-only for a real traffic window before anything downstream (Phase 2/3) reads it: does the dominant target actually vary tick-to-tick, or is it dominated by one or two nodes constantly? (Flagged as a missing question in the brainstorm — answer it with data, not assumption, before building the narrative layer.)
+- [x] `orion/schemas/self_state.py`: additive `AttentionTargetSummaryV1` (`target_id`, `target_kind`, `pressure_score`, top `dominant_channel`, top `reason`) + `SelfStateV1.dominant_attention_target_details: list[AttentionTargetSummaryV1]`, alongside (not replacing) the existing bare-string `dominant_attention_targets`.
+- [x] `orion/self_state/builder.py`: new `_attention_target_summary()` helper, populated from `attention.dominant_targets[:5]` (the same slice already used for the bare-string list, `builder.py:302` — same target_ids, same order).
+- [x] Registry entry updated in the same PR: `field_attention_frame.v1` flipped from `SHADOW` to `COMPOSED`.
+- [ ] Log-only for a real traffic window before anything downstream (Phase 2/3) reads it: does the dominant target actually vary tick-to-tick, or is it dominated by one or two nodes constantly? **Blocked on deployment** — not yet observable.
 
-**Tests:** schema round-trip; builder unit test asserting the new field is populated from a fixture `FieldAttentionFrameV1` with known target scores.
+**Tests:** schema unchanged behavior for existing consumers (full self-state suite green, 63 tests); new builder test (`test_dominant_attention_target_details_carries_structured_data`) asserting real, non-fixture end-to-end data (via `build_attention_frame()` + `build_self_state()` on a synthetic `FieldStateV1`) — target_id/order parity with the existing list, valid `target_kind`, `pressure_score` in range, and the top target's `dominant_channel`/`reason` populated.
 
-**Acceptance:** the field carries real per-target data in at least one live tick, verified against Postgres, not just a fixture.
+**Acceptance:** the field carries real per-target data in at least one live tick, verified against Postgres, not just a fixture. **Not yet verified — requires merge + redeploy of `orion-self-state-runtime`, not done as of this patch.**
 
 ---
 

--- a/docs/superpowers/pr-reports/2026-07-12-self-state-attention-target-composition-phase1-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-self-state-attention-target-composition-phase1-pr.md
@@ -1,0 +1,94 @@
+## Summary
+
+- Phase 1 of the inner-state unification plan: `orion/self_state/builder.py` read the full per-node/per-capability `FieldAttentionTargetV1` list every tick — real, non-theater scoring from `orion-attention-runtime` (`weighted_pressure`/`urgency_score`/`confidence_from_vector`) — and kept only the top-5 bare `target_id` strings on `SelfStateV1.dominant_attention_targets`, discarding `pressure_score`/`dominant_channels`/`reasons` one hop downstream.
+- New additive field `SelfStateV1.dominant_attention_target_details: list[AttentionTargetSummaryV1]` carries that structured data through, alongside (not replacing) the existing bare-string list — same target_ids, same order.
+- `inner_state_registry.py`'s `field_attention_frame.v1` entry flipped from `SHADOW` to `COMPOSED` in the same PR — this is the actual proof the registry contract (Phase 0) works, not a separate afterthought.
+- Code review caught a real gap in my own first test draft (checked presence, not correctness of the "top-1" selection) — fixed with an order-distinguishable fixture test, verified it actually fails against an injected regression before confirming it passes against the real code.
+- README updates: `orion/self_state/README.md`, `services/orion-self-state-runtime/README.md`.
+
+## Outcome moved
+
+Node-attributed attention data that was computed for real and thrown away now survives into `SelfStateV1` — the schema-level prerequisite for Phase 2 (node-attributed phi) and Phase 3 (embodiment narrative), both still gated on this phase's real-traffic variation check post-deploy.
+
+## Current architecture
+
+`orion/self_state/builder.py:302` (`dominant_targets = [t.target_id for t in attention.dominant_targets[:5]]`) was the exact discard point. `FieldAttentionTargetV1` (produced by `orion/attention/field_attention/selectors.py`) already carries `salience_score`, `pressure_score`, `novelty_score`, `urgency_score`, `confidence_score`, `dominant_channels: dict[str, float]` (pre-sorted descending by `weighted_pressure()`), and `reasons: list[str]` (pre-sorted the same way by `_reasons_from_dominant()`).
+
+## Architecture touched
+
+`orion/schemas/self_state.py`, `orion/self_state/builder.py`, `orion/self_state/inner_state_registry.py`. No service code changed — `orion-self-state-runtime` picks this up on its next rebuild, no new dependency or migration.
+
+## Files changed
+
+- `orion/schemas/self_state.py`: new `AttentionTargetSummaryV1` (`target_id`, `target_kind`, `pressure_score`, `dominant_channel: str | None`, `reason: str | None`) + `SelfStateV1.dominant_attention_target_details`.
+- `orion/self_state/builder.py`: new `_attention_target_summary()` pure helper (top-1 extraction via `next(iter(...))` / `reasons[0]`, trusting the upstream pre-sort rather than re-sorting); wired into `build_self_state()` alongside the existing `dominant_targets` extraction, same slice, same order.
+- `orion/self_state/inner_state_registry.py`: `field_attention_frame.v1` `SHADOW` → `COMPOSED`, with the composition documented in `notes`.
+- `tests/test_self_state_builder.py`: 3 new tests — end-to-end (real `build_attention_frame()` + `build_self_state()` pipeline), and 2 direct unit tests on `_attention_target_summary()` (correct top-1 selection with an order-distinguishable fixture; graceful `None`/`None` when a target has no channels/reasons).
+- `orion/self_state/README.md`, `services/orion-self-state-runtime/README.md`: documentation.
+- `docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md`: Phase 1 checkboxes updated — 3 of 4 items done, the traffic-window question and the "verified against Postgres" acceptance check explicitly marked as blocked on deployment, not silently checked off.
+
+## Schema / bus / API changes
+
+- Added: `SelfStateV1.dominant_attention_target_details: list[AttentionTargetSummaryV1]` (additive, defaults to empty list — no existing consumer breaks; `extra="forbid"` on `SelfStateV1` means old rows without this key still validate fine via the field's default).
+- Removed: none.
+- Renamed: none.
+- Behavior changed: none for existing consumers — `dominant_attention_targets` (read by `orion/proposals/builder.py`'s `motivating_targets`) is untouched.
+- Compatibility notes: fully backward compatible in both directions (old code reading new rows: unknown-but-unused field; new code reading old rows: field defaults to `[]`).
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=. pytest tests/test_self_state_builder.py tests/test_self_state_schemas.py \
+  tests/test_self_state_builder_hardening.py tests/test_self_state_runtime_store.py \
+  tests/test_self_state_deviation.py tests/test_self_state_transport_dimension.py \
+  tests/test_self_state_reliability_decontamination.py tests/test_self_state_prediction.py \
+  tests/test_self_state_policy_loader.py tests/test_self_state_scoring.py \
+  tests/test_inner_state_registry_gate.py tests/test_proposal_frame_builder.py \
+  tests/test_proposal_frame_schemas.py -q
+79 passed
+
+python scripts/check_inner_state_registry.py
+inner_state_registry gate OK (9 entries checked)
+```
+
+Regression-confirmed: temporarily broke `_attention_target_summary()`'s channel-selection logic (picked last instead of first) — the new unit test failed correctly (`assert 'thermal_pressure' == 'gpu_pressure'`), then reverted and re-confirmed green.
+
+## Evals run
+
+None applicable.
+
+## Docker/build/smoke checks
+
+Not run — not deployed. This is a schema/builder change with no runtime behavior for existing fields; `orion-self-state-runtime` needs a rebuild to pick it up, but nothing breaks if it doesn't (the new field just won't populate until redeployed).
+
+## Review findings fixed
+
+- Finding: the first draft of `test_dominant_attention_target_details_carries_structured_data` only asserted `dominant_channel is not None` / `reason is not None` — a bug that picked the wrong channel/reason (e.g. lowest instead of highest, or a stale/cached one) would have passed silently.
+  - Fix: added `test_attention_target_summary_picks_first_channel_and_reason`, a direct unit test on the helper with a hand-built `FieldAttentionTargetV1` fixture whose channels/reasons are deliberately order-distinguishable.
+  - Evidence: verified the new test actually fails when the selection logic is broken (temporarily changed `next(iter(...))` to pick the last entry instead — test failed with `AssertionError: assert 'thermal_pressure' == 'gpu_pressure'`), then reverted and confirmed the suite is green again.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-self-state-runtime/.env \
+  -f services/orion-self-state-runtime/docker-compose.yml \
+  up -d --build self-state-runtime
+```
+
+Not run — deliberately left for Juniper (per "merged but didn't pull/redeploy" — this PR isn't merged yet either, listed here for when it is).
+
+## Risks / concerns
+
+- Severity: low
+- Concern: the "does the dominant target actually vary tick-to-tick, or get dominated by one or two nodes constantly" question from the plan's Phase 1 acceptance criteria is genuinely unanswered — requires a real post-deploy traffic window, not something a unit test or this PR can verify.
+- Mitigation: explicitly left unchecked in the plan doc rather than assumed; Phase 2 (node-attributed phi) is already gated on this being answered first, per the plan.
+
+## PR link
+
+Branch pushed: `feat/self-state-attention-target-composition`

--- a/orion/schemas/self_state.py
+++ b/orion/schemas/self_state.py
@@ -31,6 +31,27 @@ class SelfStateDimensionV1(BaseModel):
     reasons: list[str] = Field(default_factory=list)
 
 
+class AttentionTargetSummaryV1(BaseModel):
+    """Structured per-target attention data (2026-07-12, inner-state
+    unification Phase 1). Previously orion/self_state/builder.py read the
+    full FieldAttentionTargetV1 objects and kept only bare target_id strings
+    on dominant_attention_targets -- pressure_score/dominant_channels/reasons
+    were computed by orion-attention-runtime's real, non-theater scoring
+    (weighted_pressure/urgency_score/confidence_from_vector) and discarded
+    one hop downstream. This is additive alongside dominant_attention_targets,
+    not a replacement -- existing consumers of the bare-string list are
+    unaffected.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_id: str
+    target_kind: Literal["node", "capability", "channel", "edge", "field", "system"]
+    pressure_score: float = Field(ge=0.0, le=1.0)
+    dominant_channel: str | None = None
+    reason: str | None = None
+
+
 class SelfStateV1(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -62,6 +83,7 @@ class SelfStateV1(BaseModel):
     dimensions: dict[str, SelfStateDimensionV1] = Field(default_factory=dict)
 
     dominant_attention_targets: list[str] = Field(default_factory=list)
+    dominant_attention_target_details: list[AttentionTargetSummaryV1] = Field(default_factory=list)
     dominant_field_channels: dict[str, float] = Field(default_factory=dict)
 
     unresolved_pressures: list[str] = Field(default_factory=list)

--- a/orion/self_state/README.md
+++ b/orion/self_state/README.md
@@ -28,7 +28,16 @@ Each `InnerStateSignal` entry names its producer service, cadence, and one
 of four composition statuses:
 
 - `COMPOSED` — has a named field on `SelfStateV1` (or, for phi, is wired
-  into a cognition-facing narrative).
+  into a cognition-facing narrative). `field_attention_frame.v1` moved from
+  `SHADOW` to `COMPOSED` in Phase 1 (2026-07-12): `builder.py` previously
+  read the full per-node/per-capability `FieldAttentionTargetV1` list and
+  kept only bare `target_id` strings on `dominant_attention_targets`,
+  discarding `pressure_score`/`dominant_channels`/`reasons`. Structured
+  per-target data now survives, additively, on
+  `SelfStateV1.dominant_attention_target_details`
+  (`AttentionTargetSummaryV1`: `target_id`, `target_kind`, `pressure_score`,
+  top `dominant_channel`, top `reason`) — same target_ids, same order, as
+  the existing bare-string list.
 - `SHADOW` — real, live, deliberately **not** composed, with a required,
   stated reason (`shadow_reason`). The model case: phi's surviving
   `valence` heuristic, explicitly justified because no trained latent

--- a/orion/self_state/builder.py
+++ b/orion/self_state/builder.py
@@ -26,9 +26,13 @@ from orion.self_state.scoring import (
     weighted_overall_intensity,
 )
 from orion.schemas.attention_frame import AttentionBroadcastProjectionV1
-from orion.schemas.field_attention_frame import FieldAttentionFrameV1
+from orion.schemas.field_attention_frame import FieldAttentionFrameV1, FieldAttentionTargetV1
 from orion.schemas.field_state import FieldStateV1
-from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+from orion.schemas.self_state import (
+    AttentionTargetSummaryV1,
+    SelfStateDimensionV1,
+    SelfStateV1,
+)
 
 DimensionId = Literal[
     "field_intensity",
@@ -105,6 +109,25 @@ def stable_self_state_id(
     policy_id: str,
 ) -> str:
     return f"self.state:{source_field_tick_id}:{source_attention_frame_id}:{policy_id}"
+
+
+def _attention_target_summary(target: FieldAttentionTargetV1) -> AttentionTargetSummaryV1:
+    """Structured summary of one FieldAttentionTargetV1 (2026-07-12, inner-state
+    unification Phase 1). dominant_channel/reason take the top-1 entry --
+    dominant_channels is already sorted descending by contribution
+    (orion/attention/field_attention/scoring.py's weighted_pressure), and
+    reasons is already ordered the same way (_reasons_from_dominant), so
+    the first entry of each is the single most significant one this tick.
+    """
+    dominant_channel = next(iter(target.dominant_channels), None)
+    reason = target.reasons[0] if target.reasons else None
+    return AttentionTargetSummaryV1(
+        target_id=target.target_id,
+        target_kind=target.target_kind,
+        pressure_score=target.pressure_score,
+        dominant_channel=dominant_channel,
+        reason=reason,
+    )
 
 
 def _emit_summary_labels(
@@ -276,7 +299,11 @@ def build_self_state(
         condition_from_intensity(overall_intensity, policy.condition_thresholds),
     )
 
-    dominant_targets = [t.target_id for t in attention.dominant_targets[:5]]
+    top_attention_targets = attention.dominant_targets[:5]
+    dominant_targets = [t.target_id for t in top_attention_targets]
+    dominant_attention_target_details = [
+        _attention_target_summary(t) for t in top_attention_targets
+    ]
     evidence_density = clamp01(len(dominant_targets) / 5.0)
     overall_confidence = clamp01(0.5 + 0.5 * evidence_density)
 
@@ -413,6 +440,7 @@ def build_self_state(
         overall_confidence=overall_confidence,
         dimensions=dimensions,
         dominant_attention_targets=dominant_targets,
+        dominant_attention_target_details=dominant_attention_target_details,
         dominant_field_channels=dominant_field_channels,
         unresolved_pressures=unresolved,
         stabilizing_factors=stabilizing,

--- a/orion/self_state/inner_state_registry.py
+++ b/orion/self_state/inner_state_registry.py
@@ -95,18 +95,20 @@ REGISTRY: tuple[InnerStateSignal, ...] = (
         schema=FieldAttentionFrameV1,
         producer_service="orion-attention-runtime",
         cadence=Cadence.PER_TICK,
-        composition_status=CompositionStatus.SHADOW,
+        composition_status=CompositionStatus.COMPOSED,
         cognition_consumers=(),
-        shadow_reason=(
-            "orion/self_state/builder.py reads the full FieldAttentionTargetV1 "
-            "list (pressure_score, dominant_channels, reasons per node/capability) "
-            "but keeps only the top-5 target_id strings on "
-            "SelfStateV1.dominant_attention_targets -- every other field is "
-            "discarded at builder.py's dominant_targets extraction. Real, "
-            "non-theater engineering (see field_attention/scoring.py's "
-            "weighted_pressure/urgency_score/confidence_from_vector), thrown "
-            "away one hop downstream. Phase 1 of the companion plan widens "
-            "this to COMPOSED."
+        notes=(
+            "Phase 1 of the companion plan (2026-07-12): widened from SHADOW "
+            "to COMPOSED. orion/self_state/builder.py previously kept only "
+            "the top-5 target_id strings on SelfStateV1."
+            "dominant_attention_targets, discarding pressure_score/"
+            "dominant_channels/reasons -- real, non-theater engineering (see "
+            "field_attention/scoring.py's weighted_pressure/urgency_score/"
+            "confidence_from_vector) thrown away one hop downstream. Now "
+            "structured per-target data (target_kind, pressure_score, top "
+            "dominant_channel, top reason) survives on the additive "
+            "SelfStateV1.dominant_attention_target_details field via "
+            "AttentionTargetSummaryV1 (orion/schemas/self_state.py)."
         ),
     ),
     InnerStateSignal(

--- a/services/orion-self-state-runtime/README.md
+++ b/services/orion-self-state-runtime/README.md
@@ -16,6 +16,16 @@ substrate_attention_frames + substrate_field_state
 - `orion-attention-runtime` writing `substrate_attention_frames`
 - Apply migration: `services/orion-sql-db/manual_migration_self_state_v1.sql`
 
+### Attention target detail (Phase 1, 2026-07-12)
+
+`SelfStateV1.dominant_attention_target_details` carries structured per-target
+data (`target_kind`, `pressure_score`, top `dominant_channel`, top `reason`)
+for the same top-5 targets already named on `dominant_attention_targets` —
+additive, same target_ids/order, not a replacement. Previously this data
+(computed for real by `orion-attention-runtime`'s
+`weighted_pressure`/`urgency_score`/`confidence_from_vector`) was read in
+full and discarded down to bare ID strings.
+
 ### Optional self-observability inputs (v2)
 
 Best-effort, never blocking: when the rows exist and are fresh, `SelfStateV1`

--- a/tests/test_self_state_builder.py
+++ b/tests/test_self_state_builder.py
@@ -3,8 +3,9 @@ from pathlib import Path
 
 from orion.attention.field_attention.builder import build_attention_frame
 from orion.attention.field_attention.policy import load_attention_policy
-from orion.self_state.builder import build_self_state
+from orion.self_state.builder import _attention_target_summary, build_self_state
 from orion.self_state.policy import load_self_state_policy
+from orion.schemas.field_attention_frame import FieldAttentionTargetV1
 from orion.schemas.field_state import FieldStateV1
 
 REPO = Path(__file__).resolve().parents[1]
@@ -63,6 +64,78 @@ def test_dominant_attention_targets() -> None:
     state = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
     ids = set(state.dominant_attention_targets)
     assert "node:athena" in ids or "capability:orchestration" in ids
+
+
+def test_dominant_attention_target_details_carries_structured_data() -> None:
+    # 2026-07-12, inner-state unification Phase 1: dominant_attention_targets
+    # (bare ID strings) previously discarded pressure_score/dominant_channels/
+    # reasons one hop after orion-attention-runtime computed them for real.
+    # This must now survive, additively, alongside the bare-string list.
+    field = _synthetic_field()
+    attention = build_attention_frame(field=field, policy=ATTENTION_POLICY, now=NOW)
+    state = build_self_state(field=field, attention=attention, policy=SELF_POLICY, now=NOW)
+
+    assert state.dominant_attention_target_details
+    # Same target_ids, same order, as the existing bare-string list -- additive,
+    # not a divergent second source of truth.
+    assert [d.target_id for d in state.dominant_attention_target_details] == (
+        state.dominant_attention_targets
+    )
+    for detail in state.dominant_attention_target_details:
+        assert detail.target_kind in ("node", "capability", "channel", "edge", "field", "system")
+        assert 0.0 <= detail.pressure_score <= 1.0
+
+    top = state.dominant_attention_target_details[0]
+    assert top.pressure_score > 0.0
+    assert top.dominant_channel is not None
+    assert top.reason is not None
+
+
+def test_attention_target_summary_picks_first_channel_and_reason() -> None:
+    # 2026-07-12 review finding: the end-to-end test above only checks
+    # presence, not that the "top-1" pick is actually the first entry (the
+    # documented contract -- upstream, weighted_pressure/_reasons_from_dominant
+    # already sort descending before returning; this helper trusts that
+    # ordering rather than re-sorting). A direct unit test on
+    # _attention_target_summary() with an explicit, order-distinguishable
+    # fixture is the only way to catch a regression that silently picked a
+    # different entry (e.g. min instead of max, or last instead of first).
+    target = FieldAttentionTargetV1(
+        target_id="node:atlas",
+        target_kind="node",
+        salience_score=0.9,
+        pressure_score=0.72,
+        novelty_score=0.1,
+        urgency_score=0.5,
+        confidence_score=0.6,
+        dominant_channels={"gpu_pressure": 0.85, "thermal_pressure": 0.40},
+        reasons=["node gpu_pressure is elevated", "node thermal_pressure is elevated"],
+    )
+
+    summary = _attention_target_summary(target)
+
+    assert summary.target_id == "node:atlas"
+    assert summary.target_kind == "node"
+    assert summary.pressure_score == 0.72
+    assert summary.dominant_channel == "gpu_pressure"
+    assert summary.reason == "node gpu_pressure is elevated"
+
+
+def test_attention_target_summary_handles_no_channels_or_reasons() -> None:
+    target = FieldAttentionTargetV1(
+        target_id="field:recent_perturbations",
+        target_kind="system",
+        salience_score=0.2,
+        pressure_score=0.2,
+        novelty_score=0.0,
+        urgency_score=0.0,
+        confidence_score=0.0,
+    )
+
+    summary = _attention_target_summary(target)
+
+    assert summary.dominant_channel is None
+    assert summary.reason is None
 
 
 def test_summary_labels_execution_loaded() -> None:


### PR DESCRIPTION
## Summary

- Phase 1 of the inner-state unification plan: `orion/self_state/builder.py` read the full per-node/per-capability `FieldAttentionTargetV1` list every tick — real, non-theater scoring from `orion-attention-runtime` (`weighted_pressure`/`urgency_score`/`confidence_from_vector`) — and kept only the top-5 bare `target_id` strings on `SelfStateV1.dominant_attention_targets`, discarding `pressure_score`/`dominant_channels`/`reasons` one hop downstream.
- New additive field `SelfStateV1.dominant_attention_target_details: list[AttentionTargetSummaryV1]` carries that structured data through, alongside (not replacing) the existing bare-string list — same target_ids, same order.
- `inner_state_registry.py`'s `field_attention_frame.v1` entry flipped from `SHADOW` to `COMPOSED` in the same PR — this is the actual proof the registry contract (Phase 0) works, not a separate afterthought.
- Code review caught a real gap in my own first test draft (checked presence, not correctness of the "top-1" selection) — fixed with an order-distinguishable fixture test, verified it actually fails against an injected regression before confirming it passes against the real code.
- README updates: `orion/self_state/README.md`, `services/orion-self-state-runtime/README.md`.

## Outcome moved

Node-attributed attention data that was computed for real and thrown away now survives into `SelfStateV1` — the schema-level prerequisite for Phase 2 (node-attributed phi) and Phase 3 (embodiment narrative), both still gated on this phase's real-traffic variation check post-deploy.

## Current architecture

`orion/self_state/builder.py:302` (`dominant_targets = [t.target_id for t in attention.dominant_targets[:5]]`) was the exact discard point. `FieldAttentionTargetV1` (produced by `orion/attention/field_attention/selectors.py`) already carries `salience_score`, `pressure_score`, `novelty_score`, `urgency_score`, `confidence_score`, `dominant_channels: dict[str, float]` (pre-sorted descending by `weighted_pressure()`), and `reasons: list[str]` (pre-sorted the same way by `_reasons_from_dominant()`).

## Architecture touched

`orion/schemas/self_state.py`, `orion/self_state/builder.py`, `orion/self_state/inner_state_registry.py`. No service code changed — `orion-self-state-runtime` picks this up on its next rebuild, no new dependency or migration.

## Files changed

- `orion/schemas/self_state.py`: new `AttentionTargetSummaryV1` (`target_id`, `target_kind`, `pressure_score`, `dominant_channel: str | None`, `reason: str | None`) + `SelfStateV1.dominant_attention_target_details`.
- `orion/self_state/builder.py`: new `_attention_target_summary()` pure helper (top-1 extraction via `next(iter(...))` / `reasons[0]`, trusting the upstream pre-sort rather than re-sorting); wired into `build_self_state()` alongside the existing `dominant_targets` extraction, same slice, same order.
- `orion/self_state/inner_state_registry.py`: `field_attention_frame.v1` `SHADOW` → `COMPOSED`, with the composition documented in `notes`.
- `tests/test_self_state_builder.py`: 3 new tests — end-to-end (real `build_attention_frame()` + `build_self_state()` pipeline), and 2 direct unit tests on `_attention_target_summary()` (correct top-1 selection with an order-distinguishable fixture; graceful `None`/`None` when a target has no channels/reasons).
- `orion/self_state/README.md`, `services/orion-self-state-runtime/README.md`: documentation.
- `docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md`: Phase 1 checkboxes updated — 3 of 4 items done, the traffic-window question and the "verified against Postgres" acceptance check explicitly marked as blocked on deployment, not silently checked off.

## Schema / bus / API changes

- Added: `SelfStateV1.dominant_attention_target_details: list[AttentionTargetSummaryV1]` (additive, defaults to empty list — no existing consumer breaks; `extra="forbid"` on `SelfStateV1` means old rows without this key still validate fine via the field's default).
- Removed: none.
- Renamed: none.
- Behavior changed: none for existing consumers — `dominant_attention_targets` (read by `orion/proposals/builder.py`'s `motivating_targets`) is untouched.
- Compatibility notes: fully backward compatible in both directions (old code reading new rows: unknown-but-unused field; new code reading old rows: field defaults to `[]`).

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. pytest tests/test_self_state_builder.py tests/test_self_state_schemas.py \
  tests/test_self_state_builder_hardening.py tests/test_self_state_runtime_store.py \
  tests/test_self_state_deviation.py tests/test_self_state_transport_dimension.py \
  tests/test_self_state_reliability_decontamination.py tests/test_self_state_prediction.py \
  tests/test_self_state_policy_loader.py tests/test_self_state_scoring.py \
  tests/test_inner_state_registry_gate.py tests/test_proposal_frame_builder.py \
  tests/test_proposal_frame_schemas.py -q
79 passed

python scripts/check_inner_state_registry.py
inner_state_registry gate OK (9 entries checked)
```

Regression-confirmed: temporarily broke `_attention_target_summary()`'s channel-selection logic (picked last instead of first) — the new unit test failed correctly (`assert 'thermal_pressure' == 'gpu_pressure'`), then reverted and re-confirmed green.

## Evals run

None applicable.

## Docker/build/smoke checks

Not run — not deployed. This is a schema/builder change with no runtime behavior for existing fields; `orion-self-state-runtime` needs a rebuild to pick it up, but nothing breaks if it doesn't (the new field just won't populate until redeployed).

## Review findings fixed

- Finding: the first draft of `test_dominant_attention_target_details_carries_structured_data` only asserted `dominant_channel is not None` / `reason is not None` — a bug that picked the wrong channel/reason (e.g. lowest instead of highest, or a stale/cached one) would have passed silently.
  - Fix: added `test_attention_target_summary_picks_first_channel_and_reason`, a direct unit test on the helper with a hand-built `FieldAttentionTargetV1` fixture whose channels/reasons are deliberately order-distinguishable.
  - Evidence: verified the new test actually fails when the selection logic is broken (temporarily changed `next(iter(...))` to pick the last entry instead — test failed with `AssertionError: assert 'thermal_pressure' == 'gpu_pressure'`), then reverted and confirmed the suite is green again.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-self-state-runtime/.env \
  -f services/orion-self-state-runtime/docker-compose.yml \
  up -d --build self-state-runtime
```

Not run — deliberately left for Juniper (per "merged but didn't pull/redeploy" — this PR isn't merged yet either, listed here for when it is).

## Risks / concerns

- Severity: low
- Concern: the "does the dominant target actually vary tick-to-tick, or get dominated by one or two nodes constantly" question from the plan's Phase 1 acceptance criteria is genuinely unanswered — requires a real post-deploy traffic window, not something a unit test or this PR can verify.
- Mitigation: explicitly left unchecked in the plan doc rather than assumed; Phase 2 (node-attributed phi) is already gated on this being answered first, per the plan.