### PR TITLE
Feat/phi dominant node attribution

### DIFF
--- a/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
+++ b/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
@@ -40,16 +40,18 @@ Companion to `docs/superpowers/specs/2026-07-12-inner-state-unification-design.m
 
 ## Phase 2 — Node-attributed phi (brainstorm idea #2)
 
-**Gate to start:** Phase 1 merged AND its log-only traffic window shows real (non-degenerate) variation in dominant targets — do not build this on top of a signal that turns out to be flat.
+**Status: implemented, not yet deployed** (branch `feat/phi-dominant-node-attribution`).
 
-- [ ] `orion/schemas/telemetry/phi_encoder.py`: additive `dominant_node`/`dominant_node_reason` fields on `PhiIntrinsicRewardV1`.
-- [ ] `services/orion-spark-introspector/app/worker.py`: populate from `ss.dominant_attention_targets`'s widened form (Phase 1) inside `handle_self_state`, alongside the existing golden-phi overrides — same function, same seam, not a new pipeline.
-- [ ] Registry entry updated: `PhiIntrinsicRewardV1` now explicitly composes attention data, not just self-state's dimension scores.
-- [ ] Explicitly filter the two synthetic pseudo-nodes (`node:substrate.execution`, `node:substrate.transport`) from ever being the reported `dominant_node` — named in the brainstorm as a real risk (they aren't bodies, they're derived subsystem metrics; surfacing them as "the body part under stress" would be a category error, not a bug fixed by more data).
+**Gate to start:** Phase 1 merged AND its log-only traffic window shows real (non-degenerate) variation in dominant targets. Phase 1 isn't deployed yet, so this was checked against the OLD bare-string `dominant_attention_targets` field instead (live in production well before today): confirmed real compositional variance over a live 20-sample/~40s window — `node:atlas` and `capability:llm_inference`/`capability:orchestration` cycle in and out, not stuck flat. New finding from that same check, not anticipated when this phase was planned: `dominant_targets` is salience-sorted across node/capability/**system** kinds together (`orion/attention/field_attention/builder.py:34,50`), and a `target_kind == "system"` entry (`field:recent_perturbations`) wins the #1 slot in nearly every tick observed — filtering only the two synthetic pseudo-nodes (as originally planned) would not have been enough; `target_kind == "node"` must be filtered too.
 
-**Tests:** unit test asserting a fixture with a clear dominant node produces the matching `dominant_node`/reason; a second test asserting a pseudo-node is never selected even when it has the highest raw pressure score.
+- [x] `orion/schemas/telemetry/phi_encoder.py`: additive `dominant_node`/`dominant_node_reason` fields on `PhiIntrinsicRewardV1`.
+- [x] `services/orion-spark-introspector/app/worker.py`: new `_dominant_hardware_node()` helper, populated from `ss.dominant_attention_target_details` (Phase 1) inside `handle_self_state`, alongside the existing golden-phi overrides — same function, same seam, not a new pipeline.
+- [x] Registry entry updated: `phi_intrinsic_reward.v1` notes now describe the node-attribution composition.
+- [x] Filters BOTH the two synthetic pseudo-nodes AND non-`"node"` target kinds (the system-kind finding above) from ever being the reported `dominant_node`.
 
-**Acceptance:** `PhiIntrinsicRewardV1.dominant_node` reflects a real hardware node (not a pseudo-node) in live traffic.
+**Tests:** 3 unit tests directly on `_dominant_hardware_node()` (correct node selected over system/capability/pseudo-node entries; `None`/`None` when no qualifying node; empty-list edge case) + 1 end-to-end test through the real `handle_self_state()` pipeline with a custom `SelfStateV1` fixture.
+
+**Acceptance:** `PhiIntrinsicRewardV1.dominant_node` reflects a real hardware node (not a pseudo-node, not a system-kind target) — verified in tests; **live-traffic verification blocked on deployment**, not yet done.
 
 ---
 

--- a/docs/superpowers/pr-reports/2026-07-12-phi-dominant-node-attribution-phase2-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-phi-dominant-node-attribution-phase2-pr.md
@@ -1,0 +1,92 @@
+## Summary
+
+- Phase 2 of the inner-state unification plan: `PhiIntrinsicRewardV1.dominant_node`/`dominant_node_reason`, naming the real hardware node most salient this tick — sourced from Phase 1's `SelfStateV1.dominant_attention_target_details`.
+- Phase 1 isn't deployed yet, so the plan's Phase 2 start-gate ("does the dominant target actually vary tick-to-tick") was checked against the pre-existing bare-string `dominant_attention_targets` field (already live in production) instead — confirmed real variance, but also surfaced something the plan hadn't anticipated: a `target_kind == "system"` entry wins the #1 salience slot most ticks, so filtering only the two synthetic pseudo-nodes (as planned) wasn't enough.
+- Code review flagged a third candidate gap (a parameterized `harness_closure:<uuid>` node). Investigated and disproved — traced the actual write path and confirmed it goes to a completely disconnected subsystem, so it can never reach this filter. Documented as a general (not this-specific) known limitation instead of "fixed."
+
+## Outcome moved
+
+`PhiIntrinsicRewardV1` can now name which physical node is under stress, not just that something is — the first genuinely embodied (spatially-attributed) signal in the phi/self-state pipeline.
+
+## Current architecture
+
+`handle_self_state()`'s encoder block (where golden phi was wired in earlier today) already had `ss` (the parsed `SelfStateV1`) in scope. `ss.dominant_attention_target_details` (Phase 1, merged) is a salience-ordered list of `AttentionTargetSummaryV1` spanning node/capability/system target kinds — attention's own sort (`orion/attention/field_attention/builder.py:34,50`) doesn't segregate by kind.
+
+## Architecture touched
+
+`orion/schemas/telemetry/phi_encoder.py`, `services/orion-spark-introspector/app/worker.py`. No new service, no new dependency, no new config mount.
+
+## Files changed
+
+- `orion/schemas/telemetry/phi_encoder.py`: additive `dominant_node: Optional[str]`, `dominant_node_reason: Optional[str]` on `PhiIntrinsicRewardV1`.
+- `services/orion-spark-introspector/app/worker.py`: new `_dominant_hardware_node()` (filters `target_kind == "node"` AND excludes `_SYNTHETIC_PSEUDO_NODES`), wired into the existing encoder-tick reward construction. Extended code comment documenting the blacklist's known limitation and the investigated-and-ruled-out `harness_closure` candidate.
+- `services/orion-spark-introspector/tests/test_phi_reward_emit.py`: 3 unit tests on `_dominant_hardware_node()`, 1 end-to-end test through `handle_self_state()`.
+- `orion/self_state/inner_state_registry.py`, `orion/self_state/README.md`, `services/orion-spark-introspector/README.md`, `docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md`: registry notes + documentation + plan checklist updated.
+
+## Schema / bus / API changes
+
+- Added: `PhiIntrinsicRewardV1.dominant_node`, `.dominant_node_reason` (additive, both `Optional[str] = None`).
+- Removed: none.
+- Compatibility notes: only one other constructor call site exists (`services/orion-sql-writer/tests/test_phi_reward_sql_shape.py`), unaffected — both new fields optional, and the reward is stored as a JSON blob there, not per-field columns.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=. :services/orion-spark-introspector pytest services/orion-spark-introspector/tests -q
+138 passed, 1 skipped
+1 pre-existing FAILED (test_inner_features_settings_defaults -- confirmed via git stash
+against clean main, unrelated to this change: asserts a settings default that
+doesn't match another branch's not-yet-merged work)
+
+PYTHONPATH=. pytest tests/test_inner_state_registry_gate.py -q
+8 passed
+
+python scripts/check_inner_state_registry.py
+inner_state_registry gate OK (9 entries checked)
+```
+
+## Evals run
+
+None applicable.
+
+## Docker/build/smoke checks
+
+Not run — not deployed.
+
+## Review findings fixed
+
+- Finding: attention's `dominant_targets` is salience-sorted across node/capability/system kinds together (confirmed by reading `orion/attention/field_attention/builder.py`), and live data showed a system-kind entry (`field:recent_perturbations`) winning the #1 slot most ticks — the original plan's "filter the two pseudo-nodes" was insufficient.
+  - Fix: `_dominant_hardware_node()` filters `target_kind == "node"` in addition to the pseudo-node exclusion.
+  - Evidence: new test `test_dominant_hardware_node_skips_system_and_pseudo_nodes` asserts the correct node wins over a system entry, a capability entry, and a pseudo-node entry all present in the same fixture.
+- Finding (review, investigated and disproved rather than fixed): a candidate third gap — `orion-substrate-runtime`'s `harness_closure:<uuid>` prediction-error nodes might evade the hardcoded pseudo-node blacklist.
+  - Investigation: traced `_write_prediction_error_node` to confirm it writes exclusively to the cognitive-substrate graph store (`ConceptNodeV1`/`store.upsert_node`), then confirmed `orion-field-digester` (the actual producer of `FieldStateV1.node_vectors`, what this filter operates on) has zero references to that graph store anywhere in its codebase. These nodes structurally cannot reach `FieldAttentionTargetV1`/`dominant_attention_target_details` — the review's claimed connection didn't hold. Documented as a ruled-out candidate, not silently dropped.
+  - Follow-up named, not built: switching `_SYNTHETIC_PSEUDO_NODES` from a hardcoded blacklist to a whitelist against `config/biometrics/node_catalog.yaml` (the authoritative real-node list) would close the general "could a future pseudo-node go unnoticed" risk, but needs a new config mount + settings field on a service that has neither today — out of scope for this phase, documented in the code comment.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml \
+  up -d --build spark-introspector
+```
+
+Not run — deliberately left for Juniper. Depends on Phase 1 also being deployed first (this reads `SelfStateV1.dominant_attention_target_details`, which only populates once `orion-self-state-runtime` is rebuilt with Phase 1's change).
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `_SYNTHETIC_PSEUDO_NODES` is a maintained blacklist (2 known strings), not a whitelist against the authoritative node catalog — a genuinely new pseudo-node type added to the field topology in the future would silently evade this filter until someone adds it here too.
+- Mitigation: documented explicitly in the code comment with the exact fix path (`NodeCatalog` whitelist) and why it wasn't done now (new infrastructure needed). Not a live risk today — no third pseudo-node type currently exists in `config/field/orion_field_topology.v1.yaml`.
+- Severity: low
+- Concern: like Phase 1, live-traffic verification (does `dominant_node` actually name real, varying nodes correctly in production) is blocked on deployment of both this phase and Phase 1.
+- Mitigation: explicitly left as an open acceptance item in the plan doc, not assumed complete.
+
+## PR link
+
+Branch pushed: `feat/phi-dominant-node-attribution`

--- a/orion/schemas/telemetry/phi_encoder.py
+++ b/orion/schemas/telemetry/phi_encoder.py
@@ -72,3 +72,12 @@ class PhiIntrinsicRewardV1(BaseModel):
     phi_health: str = "ok"
     grammar_truth_degraded: bool = False
     attribution_top: List[AttributionV1] = Field(default_factory=list)
+    # 2026-07-12, inner-state unification Phase 2: node-attributed embodiment.
+    # Sourced from SelfStateV1.dominant_attention_target_details, filtered to
+    # real hardware nodes only (excludes synthetic pseudo-nodes and non-node
+    # target kinds like "field:recent_perturbations" -- see
+    # services/orion-spark-introspector/app/worker.py's
+    # _dominant_hardware_node()). None when no qualifying node is present
+    # this tick.
+    dominant_node: Optional[str] = None
+    dominant_node_reason: Optional[str] = None

--- a/orion/self_state/README.md
+++ b/orion/self_state/README.md
@@ -37,7 +37,13 @@ of four composition statuses:
   `SelfStateV1.dominant_attention_target_details`
   (`AttentionTargetSummaryV1`: `target_id`, `target_kind`, `pressure_score`,
   top `dominant_channel`, top `reason`) — same target_ids, same order, as
-  the existing bare-string list.
+  the existing bare-string list. Phase 2 (2026-07-12) builds on this:
+  `PhiIntrinsicRewardV1.dominant_node`/`dominant_node_reason`
+  (`orion-spark-introspector`) name the most salient real hardware node,
+  filtered to `target_kind == "node"` and excluding two synthetic
+  pseudo-nodes — confirmed live that a `target_kind == "system"` entry
+  frequently wins the #1 salience slot, so `target_kind` filtering matters
+  as much as the pseudo-node exclusion.
 - `SHADOW` — real, live, deliberately **not** composed, with a required,
   stated reason (`shadow_reason`). The model case: phi's surviving
   `valence` heuristic, explicitly justified because no trained latent

--- a/orion/self_state/inner_state_registry.py
+++ b/orion/self_state/inner_state_registry.py
@@ -200,7 +200,14 @@ REGISTRY: tuple[InnerStateSignal, ...] = (
         notes=(
             "Golden phi. Trained MLP autoencoder over InnerStateFeaturesV1. "
             "Fixed + deployed 2026-07-12 (654a9803, 79a6d966) -- was dark "
-            "(SQL sink + debug WebSocket EKG panel only) for weeks before that."
+            "(SQL sink + debug WebSocket EKG panel only) for weeks before that. "
+            "Phase 2 (2026-07-12) adds dominant_node/dominant_node_reason, "
+            "sourced from self_state.v1's dominant_attention_target_details "
+            "(Phase 1), filtered to real hardware nodes only via "
+            "orion-spark-introspector's _dominant_hardware_node() -- excludes "
+            "target_kind!='node' (a system-kind entry like "
+            "field:recent_perturbations was confirmed live to frequently win "
+            "top salience) and the two synthetic pseudo-nodes."
         ),
     ),
     InnerStateSignal(

--- a/services/orion-spark-introspector/README.md
+++ b/services/orion-spark-introspector/README.md
@@ -378,6 +378,25 @@ Spark-introspector emits `InnerStateFeaturesV1` on `orion:self:inner_features` a
 | Substrate prerequisite | `orion-substrate-runtime` must reach conjourney Postgres (`POSTGRES_URI` in substrate `.env_example`) and serve healthy `GET /grammar/truth` + `GET /projections/execution_trajectory`. **Co-deploy:** update substrate `POSTGRES_URI` manually if local `.env` predates this fix — default `sync_local_env_from_example.py` does not rewrite `POSTGRES_URI`. Restart substrate before relying on live cognitive features. |
 | Encoder | `ORION_PHI_ENCODER_ENABLED=false` until corpus + promote gates pass; weights at `ORION_PHI_ENCODER_WEIGHTS` (active symlink under telemetry) |
 
+#### Golden phi + node attribution (2026-07-12)
+
+`handle_self_state()` overrides `phi_now`'s coherence/energy/novelty with the
+trained encoder's real output (`_golden_phi_overrides`) whenever it's enabled
+and healthy — see `orion/self_state/inner_state_registry.py`'s
+`phi_intrinsic_reward.v1`/`phi_heuristic.valence` entries for what's trained
+vs. what's still the untrained heuristic (only `valence`, deliberately, no
+trained analog exists).
+
+`PhiIntrinsicRewardV1.dominant_node`/`dominant_node_reason` (Phase 2) name
+which real hardware node is most salient this tick, sourced from
+`SelfStateV1.dominant_attention_target_details`. `_dominant_hardware_node()`
+filters to `target_kind == "node"` and excludes the two synthetic pseudo-nodes
+(`node:substrate.execution`, `node:substrate.transport`) — confirmed live
+that a `target_kind == "system"` entry (`field:recent_perturbations`)
+frequently wins the #1 salience slot, so skipping only the pseudo-nodes was
+not enough to avoid misattributing "the stressed body part" to a
+perturbation-count aggregate.
+
 After `.env_example` edits: `python scripts/sync_local_env_from_example.py orion-spark-introspector`
 
 ```bash

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -20,7 +20,7 @@ from orion.core.bus.bus_schemas import BaseEnvelope, Envelope, ServiceRef
 from orion.core.bus.codec import OrionCodec
 from orion.core.bus.work_queue import RedisStreamWorkQueue
 from orion.schemas.platform import CoreEventV1
-from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+from orion.schemas.self_state import AttentionTargetSummaryV1, SelfStateDimensionV1, SelfStateV1
 from orion.schemas.telemetry.cognition_trace import CognitionTracePayload
 from orion.schemas.telemetry.inner_state import InnerStateFeaturesV1
 from orion.schemas.telemetry.phi_encoder import PhiIntrinsicRewardV1
@@ -346,6 +346,51 @@ def _golden_phi_overrides(
         "energy": round(min(1.0, abs(float(delta_phi))), 4),
         "novelty": round(min(1.0, float(recon_error) / scale), 4),
     }
+
+
+# 2026-07-12, inner-state unification Phase 2: node-attributed phi. These are
+# thin, synthetic subsystem aggregates in FieldStateV1.node_vectors (1 derived
+# channel each, e.g. prediction_error) -- not physical hardware, and never a
+# meaningful answer to "which body part is stressed." Confirmed live: a
+# target_kind="system" entry (field:recent_perturbations) also frequently wins
+# the #1 salience slot in dominant_attention_target_details (attention's
+# dominant_targets is salience-sorted across node/capability/system kinds
+# together, orion/attention/field_attention/builder.py) -- excluding only the
+# two pseudo-nodes is not enough; target_kind must be filtered to "node" too,
+# or dominant_node would frequently report a perturbation-count aggregate
+# instead of a hardware node.
+_SYNTHETIC_PSEUDO_NODES: frozenset[str] = frozenset(
+    {"node:substrate.execution", "node:substrate.transport"}
+)
+# Known limitation (code review, 2026-07-12): this is a maintained blacklist
+# of the two pseudo-nodes known to exist in config/field/orion_field_topology
+# .v1.yaml today, not a whitelist against config/biometrics/node_catalog.yaml
+# (the authoritative real-hardware-node list: atlas/athena/circe/prometheus).
+# A future pseudo-node added to the topology would silently evade this filter
+# until added here too. (One candidate was investigated and ruled out: orion-
+# substrate-runtime's harness_closure:<uuid> prediction-error nodes write to
+# the cognitive-substrate graph store (ConceptNodeV1/ upsert_node) -- a
+# separate subsystem orion-field-digester never reads from, so they can never
+# reach FieldStateV1.node_vectors or this filter in the first place.)
+# Switching to a NodeCatalog whitelist would need a new config mount + setting
+# on this service (it has neither today) -- a real fix, deliberately not done
+# here to keep this phase scoped.
+
+
+def _dominant_hardware_node(
+    details: list[AttentionTargetSummaryV1],
+) -> tuple[Optional[str], Optional[str]]:
+    """First real-hardware-node entry in SelfStateV1.dominant_attention_target_details
+    (already salience-ordered) -- (target_id, reason), or (None, None) if no
+    qualifying node is present this tick.
+    """
+    for detail in details:
+        if detail.target_kind != "node":
+            continue
+        if detail.target_id in _SYNTHETIC_PSEUDO_NODES:
+            continue
+        return detail.target_id, detail.reason
+    return None, None
 
 
 def _get_phi_stats() -> Dict[str, float]:
@@ -2643,6 +2688,9 @@ async def handle_self_state(env: BaseEnvelope) -> None:
                         ),
                     }
                     _PREV_PHI = phi_now
+                    dominant_node, dominant_node_reason = _dominant_hardware_node(
+                        ss.dominant_attention_target_details
+                    )
                     reward = PhiIntrinsicRewardV1(
                         generated_at=inner.generated_at,
                         self_state_id=inner.self_state_id,
@@ -2655,6 +2703,8 @@ async def handle_self_state(env: BaseEnvelope) -> None:
                         latent=out.latent,
                         attribution_top=out.attribution_top,
                         grammar_truth_degraded=inner.grammar_truth_degraded,
+                        dominant_node=dominant_node,
+                        dominant_node_reason=dominant_node_reason,
                     )
                     if _pub_bus and _pub_bus.enabled:
                         try:

--- a/services/orion-spark-introspector/tests/test_phi_reward_emit.py
+++ b/services/orion-spark-introspector/tests/test_phi_reward_emit.py
@@ -10,6 +10,7 @@ import app.worker as worker
 from app.inner_state import COGNITIVE_FEATURE_NAMES, FELT_DIMENSIONS
 from app.substrate_reads import ExecutionTrajectorySnapshot, GrammarTruthSnapshot
 from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.schemas.self_state import AttentionTargetSummaryV1
 from orion.schemas.telemetry.phi_encoder import (
     CorpusStatsV1,
     PhiEncoderManifestV1,
@@ -19,6 +20,7 @@ from orion.schemas.telemetry.phi_encoder import (
 from test_inner_state_emit import (
     _NOW,
     _mock_healthy_substrate_reads,
+    _self_state,
     _self_state_payload,
 )
 
@@ -285,3 +287,92 @@ async def test_phi_prev_resets_across_a_skipped_tick(monkeypatch, tmp_path) -> N
     reward_env = published[worker.settings.channel_phi_reward]
     reward = PhiIntrinsicRewardV1.model_validate(reward_env.payload)
     assert reward.delta_phi == 0.0
+
+
+def _target(target_id: str, target_kind: str, reason: str | None = "elevated") -> AttentionTargetSummaryV1:
+    return AttentionTargetSummaryV1(
+        target_id=target_id,
+        target_kind=target_kind,
+        pressure_score=0.5,
+        dominant_channel="gpu_pressure",
+        reason=reason,
+    )
+
+
+def test_dominant_hardware_node_skips_system_and_pseudo_nodes() -> None:
+    # 2026-07-12, Phase 2: confirmed live that attention's dominant_targets is
+    # salience-sorted across node/capability/system kinds together -- a
+    # target_kind="system" entry (e.g. field:recent_perturbations) frequently
+    # wins the #1 slot. Excluding only the two synthetic pseudo-nodes is not
+    # enough; non-"node" kinds must be skipped too.
+    details = [
+        _target("field:recent_perturbations", "system"),
+        _target("capability:llm_inference", "capability"),
+        _target("node:substrate.transport", "node"),  # synthetic pseudo-node
+        _target("node:atlas", "node", reason="node gpu_pressure is elevated"),
+        _target("node:circe", "node"),
+    ]
+
+    node, reason = worker._dominant_hardware_node(details)
+
+    assert node == "node:atlas"
+    assert reason == "node gpu_pressure is elevated"
+
+
+def test_dominant_hardware_node_none_when_no_qualifying_node() -> None:
+    details = [
+        _target("field:recent_perturbations", "system"),
+        _target("node:substrate.execution", "node"),  # synthetic pseudo-node only
+        _target("capability:orchestration", "capability"),
+    ]
+
+    node, reason = worker._dominant_hardware_node(details)
+
+    assert node is None
+    assert reason is None
+
+
+def test_dominant_hardware_node_empty_list() -> None:
+    assert worker._dominant_hardware_node([]) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_phi_reward_carries_dominant_node(monkeypatch, tmp_path) -> None:
+    published: dict[str, object] = {}
+
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel, env):
+            published[channel] = env
+
+    monkeypatch.setattr(worker.settings, "orion_phi_encoder_enabled", True, raising=False)
+    monkeypatch.setattr(worker.settings, "orion_phi_encoder_weights", str(tmp_path), raising=False)
+    monkeypatch.setattr(worker.settings, "inner_features_version", "seed-v2", raising=False)
+    _write_tiny_encoder(tmp_path)
+    monkeypatch.setattr(worker, "_pub_bus", _Bus(), raising=False)
+    monkeypatch.setattr(worker.manager, "broadcast", AsyncMock(), raising=False)
+    _reset_inner_state(monkeypatch, tmp_path)
+    _mock_healthy_substrate_reads(monkeypatch)
+
+    state = _self_state().model_copy(
+        update={
+            "dominant_attention_target_details": [
+                _target("field:recent_perturbations", "system"),
+                _target("node:substrate.execution", "node"),
+                _target("node:atlas", "node", reason="node gpu_pressure is elevated"),
+            ]
+        }
+    )
+    env = BaseEnvelope(
+        kind="substrate.self_state.v1",
+        source=ServiceRef(name="substrate-runtime", node="athena"),
+        payload=state.model_dump(mode="json"),
+    )
+
+    await worker.handle_self_state(env)
+
+    reward_env = published[worker.settings.channel_phi_reward]
+    reward = PhiIntrinsicRewardV1.model_validate(reward_env.payload)
+    assert reward.dominant_node == "node:atlas"
+    assert reward.dominant_node_reason == "node gpu_pressure is elevated"


### PR DESCRIPTION
## Summary

- Phase 2 of the inner-state unification plan: `PhiIntrinsicRewardV1.dominant_node`/`dominant_node_reason`, naming the real hardware node most salient this tick — sourced from Phase 1's `SelfStateV1.dominant_attention_target_details`.
- Phase 1 isn't deployed yet, so the plan's Phase 2 start-gate ("does the dominant target actually vary tick-to-tick") was checked against the pre-existing bare-string `dominant_attention_targets` field (already live in production) instead — confirmed real variance, but also surfaced something the plan hadn't anticipated: a `target_kind == "system"` entry wins the #1 salience slot most ticks, so filtering only the two synthetic pseudo-nodes (as planned) wasn't enough.
- Code review flagged a third candidate gap (a parameterized `harness_closure:<uuid>` node). Investigated and disproved — traced the actual write path and confirmed it goes to a completely disconnected subsystem, so it can never reach this filter. Documented as a general (not this-specific) known limitation instead of "fixed."

## Outcome moved

`PhiIntrinsicRewardV1` can now name which physical node is under stress, not just that something is — the first genuinely embodied (spatially-attributed) signal in the phi/self-state pipeline.

## Current architecture

`handle_self_state()`'s encoder block (where golden phi was wired in earlier today) already had `ss` (the parsed `SelfStateV1`) in scope. `ss.dominant_attention_target_details` (Phase 1, merged) is a salience-ordered list of `AttentionTargetSummaryV1` spanning node/capability/system target kinds — attention's own sort (`orion/attention/field_attention/builder.py:34,50`) doesn't segregate by kind.

## Architecture touched

`orion/schemas/telemetry/phi_encoder.py`, `services/orion-spark-introspector/app/worker.py`. No new service, no new dependency, no new config mount.

## Files changed

- `orion/schemas/telemetry/phi_encoder.py`: additive `dominant_node: Optional[str]`, `dominant_node_reason: Optional[str]` on `PhiIntrinsicRewardV1`.
- `services/orion-spark-introspector/app/worker.py`: new `_dominant_hardware_node()` (filters `target_kind == "node"` AND excludes `_SYNTHETIC_PSEUDO_NODES`), wired into the existing encoder-tick reward construction. Extended code comment documenting the blacklist's known limitation and the investigated-and-ruled-out `harness_closure` candidate.
- `services/orion-spark-introspector/tests/test_phi_reward_emit.py`: 3 unit tests on `_dominant_hardware_node()`, 1 end-to-end test through `handle_self_state()`.
- `orion/self_state/inner_state_registry.py`, `orion/self_state/README.md`, `services/orion-spark-introspector/README.md`, `docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md`: registry notes + documentation + plan checklist updated.

## Schema / bus / API changes

- Added: `PhiIntrinsicRewardV1.dominant_node`, `.dominant_node_reason` (additive, both `Optional[str] = None`).
- Removed: none.
- Compatibility notes: only one other constructor call site exists (`services/orion-sql-writer/tests/test_phi_reward_sql_shape.py`), unaffected — both new fields optional, and the reward is stored as a JSON blob there, not per-field columns.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. :services/orion-spark-introspector pytest services/orion-spark-introspector/tests -q
138 passed, 1 skipped
1 pre-existing FAILED (test_inner_features_settings_defaults -- confirmed via git stash
against clean main, unrelated to this change: asserts a settings default that
doesn't match another branch's not-yet-merged work)

PYTHONPATH=. pytest tests/test_inner_state_registry_gate.py -q
8 passed

python scripts/check_inner_state_registry.py
inner_state_registry gate OK (9 entries checked)
```

## Evals run

None applicable.

## Docker/build/smoke checks

Not run — not deployed.

## Review findings fixed

- Finding: attention's `dominant_targets` is salience-sorted across node/capability/system kinds together (confirmed by reading `orion/attention/field_attention/builder.py`), and live data showed a system-kind entry (`field:recent_perturbations`) winning the #1 slot most ticks — the original plan's "filter the two pseudo-nodes" was insufficient.
  - Fix: `_dominant_hardware_node()` filters `target_kind == "node"` in addition to the pseudo-node exclusion.
  - Evidence: new test `test_dominant_hardware_node_skips_system_and_pseudo_nodes` asserts the correct node wins over a system entry, a capability entry, and a pseudo-node entry all present in the same fixture.
- Finding (review, investigated and disproved rather than fixed): a candidate third gap — `orion-substrate-runtime`'s `harness_closure:<uuid>` prediction-error nodes might evade the hardcoded pseudo-node blacklist.
  - Investigation: traced `_write_prediction_error_node` to confirm it writes exclusively to the cognitive-substrate graph store (`ConceptNodeV1`/`store.upsert_node`), then confirmed `orion-field-digester` (the actual producer of `FieldStateV1.node_vectors`, what this filter operates on) has zero references to that graph store anywhere in its codebase. These nodes structurally cannot reach `FieldAttentionTargetV1`/`dominant_attention_target_details` — the review's claimed connection didn't hold. Documented as a ruled-out candidate, not silently dropped.
  - Follow-up named, not built: switching `_SYNTHETIC_PSEUDO_NODES` from a hardcoded blacklist to a whitelist against `config/biometrics/node_catalog.yaml` (the authoritative real-node list) would close the general "could a future pseudo-node go unnoticed" risk, but needs a new config mount + settings field on a service that has neither today — out of scope for this phase, documented in the code comment.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml \
  up -d --build spark-introspector
```

Not run — deliberately left for Juniper. Depends on Phase 1 also being deployed first (this reads `SelfStateV1.dominant_attention_target_details`, which only populates once `orion-self-state-runtime` is rebuilt with Phase 1's change).

## Risks / concerns

- Severity: low
- Concern: `_SYNTHETIC_PSEUDO_NODES` is a maintained blacklist (2 known strings), not a whitelist against the authoritative node catalog — a genuinely new pseudo-node type added to the field topology in the future would silently evade this filter until someone adds it here too.
- Mitigation: documented explicitly in the code comment with the exact fix path (`NodeCatalog` whitelist) and why it wasn't done now (new infrastructure needed). Not a live risk today — no third pseudo-node type currently exists in `config/field/orion_field_topology.v1.yaml`.
- Severity: low
- Concern: like Phase 1, live-traffic verification (does `dominant_node` actually name real, varying nodes correctly in production) is blocked on deployment of both this phase and Phase 1.
- Mitigation: explicitly left as an open acceptance item in the plan doc, not assumed complete.