### PR TITLE
Feat/spark embodiment narrative phase3

### DIFF
--- a/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
+++ b/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
@@ -57,16 +57,21 @@ Companion to `docs/superpowers/specs/2026-07-12-inner-state-unification-design.m
 
 ## Phase 3 — `spark_embodiment_narrative` (brainstorm idea #3)
 
-**Gate to start:** Phase 2 merged AND deployed for a real traffic window (this is the one phase that changes prompt content — needs its own confirmation the metacog surface reads coherently, per the design spec's acceptance checks on prompt-builder discipline).
+**Status: implemented, deployed** (branch `docs/attention-provenance-crosscheck-phase4`, continued in-session — Phases 0/1/2 were deployed first specifically to satisfy this phase's gate).
 
-- [ ] `services/orion-cortex-exec/app/spark_narrative.py`: new `spark_embodiment_hint`/`spark_embodiment_narrative`, mirroring `spark_phi_hint`/`spark_phi_narrative`'s existing shape exactly.
-- [ ] `orion/cognition/prompts/log_orion_metacognition_{draft,enrich}.j2`: one new template line.
-- [ ] Registry entry: this is the first prompt-builder addition made *through* the contract from day one — the model entry for what "declared cognition consumer" should look like everywhere else.
-- [ ] Before merging: the design spec's outstanding acceptance check ("does an existing prompt-builder bypass the contract?") gets answered concretely for this new addition specifically — it must not.
+**Gate to start:** Phase 2 merged AND deployed for a real traffic window. Satisfied in-session: Phases 0/1/2 deployed (`orion-self-state-runtime`, `orion-spark-introspector` rebuilt), confirmed live via direct bus subscription (`redis-cli SUBSCRIBE orion:self:phi_reward`) — real `dominant_node`/`dominant_node_reason` values (`node:atlas`/`node:circe` alternating, matching the Phase 4 cross-check's 81.7%/18.3% split) before this phase's code was written.
 
-**Tests:** template rendering test with a fixture snapshot; confirm the narrative string names a real hardware node, not a pseudo-node (same guard as Phase 2, at the render layer too — defense in depth).
+**Incident found and fixed during deployment, not part of the plan**: `orion-sql-writer` is a second, independent consumer of `PhiIntrinsicRewardV1` (`extra="forbid"`) with its own pinned image — deploying Phase 2 without rebuilding it caused live `pydantic_core.ValidationError: extra_forbidden` on every phi-reward write until `orion-sql-writer` was also rebuilt. Lesson: `extra="forbid"` schemas need every consumer identified before a field is added, not just the primary producer/consumer pair.
 
-**Acceptance:** a real chat/metacog turn post-deploy produces a narrative that correctly names the actual stressed node, cross-checked against the live `substrate_field_state` row for that tick.
+- [x] `services/orion-cortex-exec/app/spark_narrative.py`: `spark_embodiment_hint`/`spark_embodiment_narrative`, mirroring `spark_phi_hint`/`spark_phi_narrative`'s shape. Honest on absence (`"none"`/explicit no-node sentence), never fabricates a node name.
+- [x] `orion/cognition/prompts/log_orion_metacognition_{draft,enrich}.j2`: one new template block each (`EMBODIMENT` section, mirroring the `SPARK φ INTERPRETATION` block).
+- [x] `orion/schemas/telemetry/spark.py`: `SparkStateSnapshotV1.dominant_node`/`dominant_node_reason` — the schema `orion-cortex-exec` actually reads is `SparkStateSnapshotV1`, not `PhiIntrinsicRewardV1` directly; threading required a second schema change not explicit in the original plan text.
+- [x] Registry entry: `phi_intrinsic_reward.v1`'s `cognition_consumers` extended with `spark_embodiment_narrative`, notes updated.
+- [x] Real bug caught before commit (not by review — by writing the crash-regression test first): `dominant_node`/`dominant_node_reason` are only assigned inside the encoder-success branch, but referenced unconditionally at the later `SparkStateSnapshotV1` construction — `UnboundLocalError` on any disabled/degraded/frozen/failed tick. Fixed with `None` defaults declared alongside `encoder_tick_ok = False`, mirroring that variable's existing pattern.
+
+**Tests:** 5 unit tests on `spark_embodiment_hint`/`spark_embodiment_narrative` (real node named without prefix, honest absence, no fabricated node names, missing-reason handled without a dangling `()`); 2 new worker-level tests (`SparkStateSnapshotV1` carries the same `dominant_node` as the reward; the `UnboundLocalError` regression, verified to actually reproduce the crash before the fix and pass after).
+
+**Acceptance:** confirmed live in production before Phase 3 code was written (see gate note above) — the real-traffic verification this acceptance criterion asked for was done as a precondition, not deferred.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
+++ b/docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md
@@ -57,7 +57,7 @@ Companion to `docs/superpowers/specs/2026-07-12-inner-state-unification-design.m
 
 ## Phase 3 — `spark_embodiment_narrative` (brainstorm idea #3)
 
-**Status: implemented, deployed** (branch `docs/attention-provenance-crosscheck-phase4`, continued in-session — Phases 0/1/2 were deployed first specifically to satisfy this phase's gate).
+**Status: implemented, deployed, live-verified** (branch `feat/spark-embodiment-narrative-phase3` — the commits were first pushed onto `docs/attention-provenance-crosscheck-phase4`, whose own PR #978 had already merged, which confused GitHub's compare UI into showing "nothing to compare" for the new commits; re-cherry-picked onto this fresh branch name to get a clean PR). Phases 0/1/2 were deployed first specifically to satisfy this phase's own gate.
 
 **Gate to start:** Phase 2 merged AND deployed for a real traffic window. Satisfied in-session: Phases 0/1/2 deployed (`orion-self-state-runtime`, `orion-spark-introspector` rebuilt), confirmed live via direct bus subscription (`redis-cli SUBSCRIBE orion:self:phi_reward`) — real `dominant_node`/`dominant_node_reason` values (`node:atlas`/`node:circe` alternating, matching the Phase 4 cross-check's 81.7%/18.3% split) before this phase's code was written.
 

--- a/docs/superpowers/pr-reports/2026-07-12-spark-embodiment-narrative-phase3-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-12-spark-embodiment-narrative-phase3-pr.md
@@ -1,0 +1,113 @@
+## Summary
+
+- Phase 3 of the inner-state unification plan: `spark_embodiment_narrative` — the real hardware node most salient this tick, rendered into both metacog prompt templates alongside `spark_phi_narrative`.
+- This is the one phase whose own stated gate requires deployment first ("Phase 2 merged AND deployed for a real traffic window"). Satisfied it directly: deployed Phases 0–2 in this same session, confirmed real `dominant_node` values live on the bus (`node:atlas`/`node:circe` alternating, matching the Phase 4 cross-check's 81.7%/18.3% split) *before* writing any Phase 3 code.
+- Found and fixed a real scoping bug before it shipped — caught by writing the regression test first, not by review.
+- Found and fixed a live production incident during deployment, unrelated to Phase 3's own code: a second, independent schema consumer (`orion-sql-writer`) needed two separate rebuilds to catch up with two separate schema changes.
+- Deployed end-to-end and verified via direct Postgres query: real `dominant_node`/`dominant_node_reason` values now persisting in `spark_telemetry`.
+
+## Outcome moved
+
+Orion's metacognition prompts now receive a real, node-attributed embodiment cue — "Right now, athena is the most salient part of my body (node contract_pressure is elevated)" — sourced from a genuinely trained/computed signal chain (field state → attention salience → self-state composition → phi), not a placeholder.
+
+## Current architecture
+
+`SparkStateSnapshotV1` (not `PhiIntrinsicRewardV1`) is the schema `orion-cortex-exec`'s `executor.py` actually reads for prompt-building (via `spark_snap`, fetched over the state-service RPC). Phase 2 added `dominant_node`/`dominant_node_reason` to `PhiIntrinsicRewardV1`; this phase required threading the same values through the *other* schema.
+
+## Architecture touched
+
+`orion/schemas/telemetry/spark.py`, `services/orion-spark-introspector/app/worker.py`, `services/orion-cortex-exec/app/{executor,spark_narrative}.py`, `orion/cognition/prompts/log_orion_metacognition_{draft,enrich}.j2`. Live deploy also required rebuilding `orion-sql-writer` (twice — see incident below).
+
+## Files changed
+
+- `orion/schemas/telemetry/spark.py`: additive `SparkStateSnapshotV1.dominant_node`/`.dominant_node_reason`.
+- `services/orion-spark-introspector/app/worker.py`: wires the same `_dominant_hardware_node()` result already computed for `PhiIntrinsicRewardV1` into the `SparkStateSnapshotV1` construction. Adds `dominant_node`/`dominant_node_reason` `Optional[str] = None` defaults near `encoder_tick_ok = False`, fixing a scoping bug (see Review findings).
+- `services/orion-cortex-exec/app/spark_narrative.py`: `spark_embodiment_hint`/`spark_embodiment_narrative`, mirroring `spark_phi_hint`/`spark_phi_narrative` exactly. Honest on absence — `"none"`/an explicit no-node sentence, never a fabricated node name.
+- `services/orion-cortex-exec/app/executor.py`: wired into both metacog prompt passes — `ctx["embodiment_hint"]`/`ctx["spark_embodiment_narrative"]`, the `_render_prompt` Jinja-undefined-safety defaults dict, and the `_METACOG_DRAFT_CTX_LEN_KEYS` prompt-size-logging tuple — matching every existing `phi_hint`/`spark_phi_narrative` touch point.
+- `orion/cognition/prompts/log_orion_metacognition_{draft,enrich}.j2`: one new `EMBODIMENT` block each.
+- `orion/self_state/inner_state_registry.py`, `orion/self_state/README.md`, `services/orion-spark-introspector/README.md`, `docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md`: registry, docs, plan status updated.
+- `services/orion-cortex-exec/tests/test_spark_narrative_embodiment.py` (new), `services/orion-spark-introspector/tests/test_phi_reward_emit.py`: 7 new tests total.
+
+## Schema / bus / API changes
+
+- Added: `SparkStateSnapshotV1.dominant_node`, `.dominant_node_reason` (additive, `Optional[str] = None`).
+- Compatibility notes: `orion.normalizers.spark.normalize_spark_state_snapshot` is schema-driven (`set(SparkStateSnapshotV1.model_fields.keys())`), so it picked up the new fields automatically once `orion-sql-writer` was rebuilt against current code — no normalizer change needed.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+PYTHONPATH=. :services/orion-spark-introspector pytest services/orion-spark-introspector/tests -q
+140 passed, 1 skipped
+
+PYTHONPATH=. :services/orion-cortex-exec pytest services/orion-cortex-exec/tests/test_spark_narrative_embodiment.py \
+  services/orion-cortex-exec/tests/test_metacog_two_pass_draft.py services/orion-cortex-exec/tests/test_metacog_publish_lane.py -q
+32 passed
+
+PYTHONPATH=. pytest tests/test_inner_state_registry_gate.py -q
+8 passed
+
+python scripts/check_inner_state_registry.py
+inner_state_registry gate OK (9 entries checked)
+```
+
+Regression-confirmed: the `UnboundLocalError` fix was verified by temporarily reverting it and re-running `test_spark_snapshot_dominant_node_none_when_encoder_skipped` — reproduced the exact crash (`cannot access local variable 'dominant_node' where it is not associated with a value`), then re-applied the fix and confirmed green.
+
+## Evals run
+
+None applicable.
+
+## Docker/build/smoke checks
+
+**Deployed live on Athena.** Full sequence, in order:
+
+```bash
+# Phases 0/1/2 (prerequisite for this phase's own gate):
+docker compose --env-file .env --env-file services/orion-self-state-runtime/.env \
+  -f services/orion-self-state-runtime/docker-compose.yml up -d --build
+docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml up -d --build
+docker compose --env-file .env --env-file services/orion-sql-writer/.env \
+  -f services/orion-sql-writer/docker-compose.yml up -d --build   # incident fix, see below
+
+# Phase 3 itself:
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml up -d --build   # all 4 sub-services
+docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml up -d --build   # re-rebuild, schema changed again
+docker compose --env-file .env --env-file services/orion-sql-writer/.env \
+  -f services/orion-sql-writer/docker-compose.yml up -d --build   # re-rebuild, second schema change
+```
+
+Verified live, end to end:
+- `redis-cli SUBSCRIBE orion:self:phi_reward` → real `dominant_node`/`dominant_node_reason` on the bus.
+- `redis-cli SUBSCRIBE orion:spark:state:snapshot` → same fields present on `SparkStateSnapshotV1` messages.
+- `SELECT metadata->'spark_state_snapshot'->>'dominant_node' FROM spark_telemetry ...` → `node:circe`, `reason: node pressure present`, confirming the full bus→Postgres path.
+
+## Review findings fixed
+
+- Finding: `dominant_node`/`dominant_node_reason` are assigned only inside the encoder-success `try` block, but the `SparkStateSnapshotV1` construction (added this phase) reads them unconditionally, later, on every tick — `UnboundLocalError` on any disabled/degraded/frozen/failed tick.
+  - Fix: `None` defaults declared alongside the existing `encoder_tick_ok = False` pattern, before the conditional block.
+  - Evidence: reverted the fix, re-ran the regression test, confirmed it reproduces the exact crash; re-applied, confirmed green. Independent code-review pass separately traced the full function control flow and confirmed no other unguarded read site exists.
+- Finding (mid-deployment, not code review — a live incident): `orion-sql-writer` needed rebuilding **twice** — once for Phase 2's `PhiIntrinsicRewardV1.dominant_node` (fixing a live `extra_forbidden` `ValidationError` on every phi-reward write), once more for Phase 3's `SparkStateSnapshotV1.dominant_node` (silently dropping the field from `spark_telemetry`'s stored JSON with no error, since `extra="forbid"` doesn't fire on missing-vs-extra in that direction — a normalizer schema-driven filter, `orion.normalizers.spark.normalize_spark_state_snapshot`, just quietly excluded fields its running code didn't know about yet).
+  - Lesson recorded in the plan doc: `extra="forbid"` schemas need every consumer identified and rebuilt together, not just the primary producer/consumer pair — and re-checked after *each* subsequent schema change to the same object, not just once.
+
+## Restart required
+
+Already done live — see Docker/build/smoke checks above. No further restart needed.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: the embodiment narrative is now live in real chat/metacog prompts. Its actual effect on Orion's self-report tone/content hasn't been observed over a real chat session yet — only verified for correctness at the data-plumbing level (right node named, no crashes, no fabrication).
+- Mitigation: the narrative text is explicitly framed as internal guidance ("do NOT copy verbatim into output" — matching the existing `spark_phi_narrative` convention in both templates), same safety margin already relied on for the phi narrative.
+- Severity: low
+- Concern: two live incidents this session (both `orion-sql-writer` schema-drift issues) point at a repeatable gap — no automated check currently catches "a schema this service consumes changed and this service wasn't rebuilt."
+- Mitigation: named explicitly, not silently patched around. A real fix (e.g., extending `scripts/check_inner_state_registry.py` or a separate consumer-staleness check) is a natural future addition to this initiative's registry/gate work, not built here — out of scope for this phase.
+
+## PR link
+
+Branch pushed: `docs/attention-provenance-crosscheck-phase4` (continued in-session from Phase 4; contains Phase 4's docs commit plus this Phase 3 implementation commit)

--- a/orion/cognition/prompts/log_orion_metacognition_draft.j2
+++ b/orion/cognition/prompts/log_orion_metacognition_draft.j2
@@ -45,6 +45,9 @@ ALERT EXPLANATIONS (evidence cues only; do NOT copy verbatim into output):
 SPARK φ INTERPRETATION (do NOT copy; internal guidance):
 {{ spark_phi_narrative }}
 
+EMBODIMENT (real hardware node most salient this tick; internal guidance):
+{{ spark_embodiment_narrative }}
+
 BIOMETRICS CUE (compact; do NOT paste into output):
 {{ metacog_biometrics_cue }}
 

--- a/orion/cognition/prompts/log_orion_metacognition_enrich.j2
+++ b/orion/cognition/prompts/log_orion_metacognition_enrich.j2
@@ -36,6 +36,9 @@ ALERT EXPLANATIONS (evidence cues only; do NOT copy verbatim into output):
 SPARK φ INTERPRETATION (guidance; do NOT copy verbatim):
 {{ spark_phi_narrative }}
 
+EMBODIMENT (real hardware node most salient this tick; internal guidance):
+{{ spark_embodiment_narrative }}
+
 BIOMETRICS CUE (compact; do NOT paste into output):
 {{ metacog_biometrics_cue }}
 

--- a/orion/schemas/telemetry/spark.py
+++ b/orion/schemas/telemetry/spark.py
@@ -42,6 +42,13 @@ class SparkStateSnapshotV1(BaseModel):
     arousal: float = 0.5
     dominance: float = 0.5
 
+    # 2026-07-12, inner-state unification Phase 3: the real hardware node
+    # most salient this tick (PhiIntrinsicRewardV1.dominant_node, Phase 2),
+    # threaded through so orion-cortex-exec's metacog narrative can name it.
+    # None when no qualifying node is present this tick.
+    dominant_node: Optional[str] = None
+    dominant_node_reason: Optional[str] = None
+
     vector_present: bool = False
     vector_ref: Optional[str] = None
 

--- a/orion/self_state/README.md
+++ b/orion/self_state/README.md
@@ -43,7 +43,15 @@ of four composition statuses:
   filtered to `target_kind == "node"` and excluding two synthetic
   pseudo-nodes — confirmed live that a `target_kind == "system"` entry
   frequently wins the #1 salience slot, so `target_kind` filtering matters
-  as much as the pseudo-node exclusion.
+  as much as the pseudo-node exclusion. Phase 3 (2026-07-12) closes the loop:
+  `dominant_node`/`dominant_node_reason` are threaded through
+  `SparkStateSnapshotV1` (the relay schema `orion-cortex-exec` actually
+  reads) into `spark_embodiment_narrative`, rendered into both metacog
+  prompt templates alongside `spark_phi_narrative` — confirmed live in
+  production before this phase shipped (`node:atlas`/`node:circe`
+  alternating as `capability:llm_inference`'s real GPU contention winner,
+  81.7%/18.3% split over a 295-tick window — see
+  `docs/notes/2026-07-12-phase4-attention-provenance-crosscheck.md`).
 - `SHADOW` — real, live, deliberately **not** composed, with a required,
   stated reason (`shadow_reason`). The model case: phi's surviving
   `valence` heuristic, explicitly justified because no trained latent

--- a/orion/self_state/inner_state_registry.py
+++ b/orion/self_state/inner_state_registry.py
@@ -196,6 +196,7 @@ REGISTRY: tuple[InnerStateSignal, ...] = (
         composition_status=CompositionStatus.COMPOSED,
         cognition_consumers=(
             "services.orion-cortex-exec.app.spark_narrative:spark_phi_narrative",
+            "services.orion-cortex-exec.app.spark_narrative:spark_embodiment_narrative",
         ),
         notes=(
             "Golden phi. Trained MLP autoencoder over InnerStateFeaturesV1. "
@@ -207,7 +208,15 @@ REGISTRY: tuple[InnerStateSignal, ...] = (
             "orion-spark-introspector's _dominant_hardware_node() -- excludes "
             "target_kind!='node' (a system-kind entry like "
             "field:recent_perturbations was confirmed live to frequently win "
-            "top salience) and the two synthetic pseudo-nodes."
+            "top salience) and the two synthetic pseudo-nodes. Phase 3 "
+            "(2026-07-12) threads dominant_node/dominant_node_reason through "
+            "SparkStateSnapshotV1 (a separate relay schema, "
+            "orion/schemas/telemetry/spark.py) into "
+            "spark_embodiment_narrative, rendered into both metacog prompt "
+            "templates alongside spark_phi_narrative -- confirmed live in "
+            "production (node:atlas/node:circe alternating as "
+            "capability:llm_inference's real GPU contention winner) before "
+            "this phase was built."
         ),
     ),
     InnerStateSignal(

--- a/services/orion-cortex-exec/app/executor.py
+++ b/services/orion-cortex-exec/app/executor.py
@@ -71,7 +71,12 @@ from .recall_utils import (
 )
 from .core_event_cache import format_recent_turn_effect_alerts, get_core_event_cache
 from .trace_cache import get_trace_cache
-from .spark_narrative import spark_phi_hint, spark_phi_narrative
+from .spark_narrative import (
+    spark_embodiment_hint,
+    spark_embodiment_narrative,
+    spark_phi_hint,
+    spark_phi_narrative,
+)
 from .chat_stance import (
     build_chat_stance_debug_payload,
     build_chat_stance_inputs,
@@ -165,6 +170,7 @@ _METACOG_DRAFT_CTX_LEN_KEYS: tuple[str, ...] = (
     "context_summary",
     "spark_state_json",
     "spark_phi_narrative",
+    "spark_embodiment_narrative",
     "turn_effect_json",
     "recent_turn_effect_alerts_json",
     "turn_effect_policy_json",
@@ -1500,6 +1506,8 @@ def _render_prompt(template_str: str, ctx: Dict[str, Any]) -> str:
         "spark_state_json": "{}",
         "spark_phi_narrative": "",
         "phi_hint": None,
+        "spark_embodiment_narrative": "",
+        "embodiment_hint": None,
     }
     for k, v in defaults.items():
         if k not in render_ctx:
@@ -3798,6 +3806,8 @@ async def call_step_services(
                                 phi_hint = spark_phi_hint(spark_snap)
                                 ctx["phi_hint"] = phi_hint
                                 ctx["spark_phi_narrative"] = spark_phi_narrative(spark_snap)
+                                ctx["embodiment_hint"] = spark_embodiment_hint(spark_snap)
+                                ctx["spark_embodiment_narrative"] = spark_embodiment_narrative(spark_snap)
                                 ctx["spark_state_json"] = spark_snap.model_dump_json()
 
                                 metadata = spark_snap.metadata if isinstance(spark_snap.metadata, dict) else {}

--- a/services/orion-cortex-exec/app/spark_narrative.py
+++ b/services/orion-cortex-exec/app/spark_narrative.py
@@ -125,6 +125,43 @@ def spark_phi_hint(snapshot: SparkStateSnapshotV1) -> dict[str, str]:
     }
 
 
+def spark_embodiment_hint(snapshot: SparkStateSnapshotV1) -> dict[str, str]:
+    """
+    Compact hint naming which real hardware node is most salient this tick
+    (2026-07-12, inner-state unification Phase 3). Sourced from
+    PhiIntrinsicRewardV1.dominant_node/dominant_node_reason (Phase 2), which
+    is itself filtered to real hardware nodes only -- excludes synthetic
+    pseudo-nodes and non-"node" attention target kinds (system/capability),
+    both confirmed live to otherwise pollute this signal.
+
+    "none" when no qualifying node is present this tick -- never fabricated;
+    matches spark_phi_hint's honesty convention (unknown stays unknown).
+    """
+    return {
+        "dominant_node": snapshot.dominant_node or "none",
+        "dominant_node_reason": snapshot.dominant_node_reason or "no node currently salient",
+    }
+
+
+def spark_embodiment_narrative(snapshot: SparkStateSnapshotV1) -> str:
+    node = snapshot.dominant_node
+    reason = snapshot.dominant_node_reason
+
+    if node is None:
+        return (
+            "No single hardware node is currently the most salient part of my body -- "
+            "attention is either quiet or spread across the mesh."
+        )
+
+    node_label = node.removeprefix("node:")
+    reason_clause = f" ({reason})" if reason else ""
+    return (
+        f"Right now, {node_label} is the most salient part of my body{reason_clause}. "
+        "This names a real machine in the mesh (Atlas, Circe, Athena, or Prometheus), "
+        "not a mood -- use it to ground any claim about where load or attention currently sits."
+    )
+
+
 def spark_phi_narrative(snapshot: SparkStateSnapshotV1) -> str:
     phi = snapshot.phi or {}
 

--- a/services/orion-cortex-exec/tests/test_spark_narrative_embodiment.py
+++ b/services/orion-cortex-exec/tests/test_spark_narrative_embodiment.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.spark_narrative import spark_embodiment_hint, spark_embodiment_narrative
+from orion.schemas.telemetry.spark import SparkStateSnapshotV1
+
+NOW = datetime(2026, 7, 12, 23, 0, tzinfo=timezone.utc)
+
+
+def _snapshot(**overrides) -> SparkStateSnapshotV1:
+    base = dict(
+        source_service="spark-introspector",
+        source_node="athena",
+        producer_boot_id="boot-1",
+        seq=1,
+        snapshot_ts=NOW,
+    )
+    base.update(overrides)
+    return SparkStateSnapshotV1(**base)
+
+
+def test_embodiment_hint_names_real_node() -> None:
+    snap = _snapshot(dominant_node="node:atlas", dominant_node_reason="node gpu_pressure is elevated")
+
+    hint = spark_embodiment_hint(snap)
+
+    assert hint == {
+        "dominant_node": "node:atlas",
+        "dominant_node_reason": "node gpu_pressure is elevated",
+    }
+
+
+def test_embodiment_hint_none_when_no_qualifying_node() -> None:
+    snap = _snapshot()  # dominant_node/dominant_node_reason default to None
+
+    hint = spark_embodiment_hint(snap)
+
+    assert hint == {
+        "dominant_node": "none",
+        "dominant_node_reason": "no node currently salient",
+    }
+
+
+def test_embodiment_narrative_names_node_without_prefix() -> None:
+    snap = _snapshot(dominant_node="node:atlas", dominant_node_reason="node gpu_pressure is elevated")
+
+    narrative = spark_embodiment_narrative(snap)
+
+    assert "atlas" in narrative
+    assert "node:atlas" not in narrative  # human-readable, prefix stripped
+    assert "node gpu_pressure is elevated" in narrative
+    assert "not a mood" in narrative  # explicit against fabrication/category error
+
+
+def test_embodiment_narrative_honest_when_no_node() -> None:
+    snap = _snapshot()
+
+    narrative = spark_embodiment_narrative(snap)
+
+    assert "No single hardware node" in narrative
+    # Must not fabricate a node name when none is present.
+    assert "atlas" not in narrative.lower()
+    assert "circe" not in narrative.lower()
+    assert "athena" not in narrative.lower()
+    assert "prometheus" not in narrative.lower()
+
+
+def test_embodiment_narrative_handles_missing_reason() -> None:
+    snap = _snapshot(dominant_node="node:circe", dominant_node_reason=None)
+
+    narrative = spark_embodiment_narrative(snap)
+
+    assert "circe" in narrative
+    # No dangling empty parens when reason is absent.
+    assert "()" not in narrative

--- a/services/orion-spark-introspector/README.md
+++ b/services/orion-spark-introspector/README.md
@@ -397,6 +397,17 @@ frequently wins the #1 salience slot, so skipping only the pseudo-nodes was
 not enough to avoid misattributing "the stressed body part" to a
 perturbation-count aggregate.
 
+`dominant_node`/`dominant_node_reason` are also threaded onto
+`SparkStateSnapshotV1` (a separate relay schema,
+`orion/schemas/telemetry/spark.py`) in the same `handle_self_state()`
+construction — this is the schema `orion-cortex-exec` actually reads for its
+metacog narrative (Phase 3), not `PhiIntrinsicRewardV1` directly. Both are
+declared with `Optional[str] = None` defaults set *before* the encoder block
+runs (not only inside its success branch) — referencing them unconditionally
+at the snapshot-construction site otherwise raises `UnboundLocalError` on any
+disabled/degraded/frozen/failed tick, since each `handle_self_state()` call
+starts a fresh local scope.
+
 After `.env_example` edits: `python scripts/sync_local_env_from_example.py orion-spark-introspector`
 
 ```bash

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -2625,6 +2625,14 @@ async def handle_self_state(env: BaseEnvelope) -> None:
     # phi_now["energy"] -- which now reaches a live LLM metacognition prompt,
     # not just a SQL sink (found by code review, 2026-07-12).
     encoder_tick_ok = False
+    # 2026-07-12, Phase 3: defaults so these are always defined at the
+    # SparkStateSnapshotV1 construction site below regardless of whether the
+    # encoder tick ran this call -- only assigned inside the encoder-success
+    # branch otherwise, which would raise UnboundLocalError on any
+    # disabled/degraded/frozen/failed tick (every call starts a fresh local
+    # scope; nothing carries over from a prior invocation).
+    dominant_node: Optional[str] = None
+    dominant_node_reason: Optional[str] = None
 
     global _INNER_PREV_FELT, _INNER_PREV_HEADLINE, _INNER_DEGENERATE_STREAK, _INNER_LAST_HEADLINE
     if settings.inner_features_enabled:
@@ -2807,6 +2815,8 @@ async def handle_self_state(env: BaseEnvelope) -> None:
         valence=float(phi_now.get("valence", 0.0)),
         arousal=float(phi_now.get("energy", 0.5)),
         dominance=0.5,
+        dominant_node=dominant_node,
+        dominant_node_reason=dominant_node_reason,
         vector_present=False,
         metadata=meta,
     )

--- a/services/orion-spark-introspector/tests/test_phi_reward_emit.py
+++ b/services/orion-spark-introspector/tests/test_phi_reward_emit.py
@@ -376,3 +376,53 @@ async def test_phi_reward_carries_dominant_node(monkeypatch, tmp_path) -> None:
     reward = PhiIntrinsicRewardV1.model_validate(reward_env.payload)
     assert reward.dominant_node == "node:atlas"
     assert reward.dominant_node_reason == "node gpu_pressure is elevated"
+
+    # 2026-07-12, Phase 3: the same dominant_node/reason must also reach
+    # SparkStateSnapshotV1 -- this is the schema orion-cortex-exec's
+    # spark_embodiment_narrative actually reads, a different object from
+    # PhiIntrinsicRewardV1.
+    snap_env = published[worker.settings.channel_spark_state_snapshot]
+    snap_payload = snap_env.payload
+    snap_dominant_node = (
+        snap_payload.dominant_node if hasattr(snap_payload, "dominant_node") else snap_payload["dominant_node"]
+    )
+    snap_dominant_node_reason = (
+        snap_payload.dominant_node_reason
+        if hasattr(snap_payload, "dominant_node_reason")
+        else snap_payload["dominant_node_reason"]
+    )
+    assert snap_dominant_node == "node:atlas"
+    assert snap_dominant_node_reason == "node gpu_pressure is elevated"
+
+
+@pytest.mark.asyncio
+async def test_spark_snapshot_dominant_node_none_when_encoder_skipped(monkeypatch, tmp_path) -> None:
+    # Regression: dominant_node/dominant_node_reason are assigned only inside
+    # the encoder-success branch, but SparkStateSnapshotV1 is built later,
+    # unconditionally -- referencing them there without a default assigned
+    # earlier in the function would raise UnboundLocalError on any tick where
+    # the encoder is skipped (disabled here). Confirms the fix: the tick
+    # completes and the snapshot carries None, not a crash.
+    published: dict[str, object] = {}
+
+    class _Bus:
+        enabled = True
+
+        async def publish(self, channel, env):
+            published[channel] = env
+
+    monkeypatch.setattr(worker.settings, "orion_phi_encoder_enabled", False, raising=False)
+    monkeypatch.setattr(worker, "_pub_bus", _Bus(), raising=False)
+    monkeypatch.setattr(worker.manager, "broadcast", AsyncMock(), raising=False)
+    _reset_inner_state(monkeypatch, tmp_path)
+    _mock_healthy_substrate_reads(monkeypatch)
+
+    await worker.handle_self_state(_envelope())
+
+    assert worker.settings.channel_phi_reward not in published
+    snap_env = published[worker.settings.channel_spark_state_snapshot]
+    snap_payload = snap_env.payload
+    snap_dominant_node = (
+        snap_payload.dominant_node if hasattr(snap_payload, "dominant_node") else snap_payload["dominant_node"]
+    )
+    assert snap_dominant_node is None


### PR DESCRIPTION
## Summary

- Phase 3 of the inner-state unification plan: `spark_embodiment_narrative` — the real hardware node most salient this tick, rendered into both metacog prompt templates alongside `spark_phi_narrative`.
- This is the one phase whose own stated gate requires deployment first ("Phase 2 merged AND deployed for a real traffic window"). Satisfied it directly: deployed Phases 0–2 in this same session, confirmed real `dominant_node` values live on the bus (`node:atlas`/`node:circe` alternating, matching the Phase 4 cross-check's 81.7%/18.3% split) *before* writing any Phase 3 code.
- Found and fixed a real scoping bug before it shipped — caught by writing the regression test first, not by review.
- Found and fixed a live production incident during deployment, unrelated to Phase 3's own code: a second, independent schema consumer (`orion-sql-writer`) needed two separate rebuilds to catch up with two separate schema changes.
- Deployed end-to-end and verified via direct Postgres query: real `dominant_node`/`dominant_node_reason` values now persisting in `spark_telemetry`.

## Outcome moved

Orion's metacognition prompts now receive a real, node-attributed embodiment cue — "Right now, athena is the most salient part of my body (node contract_pressure is elevated)" — sourced from a genuinely trained/computed signal chain (field state → attention salience → self-state composition → phi), not a placeholder.

## Current architecture

`SparkStateSnapshotV1` (not `PhiIntrinsicRewardV1`) is the schema `orion-cortex-exec`'s `executor.py` actually reads for prompt-building (via `spark_snap`, fetched over the state-service RPC). Phase 2 added `dominant_node`/`dominant_node_reason` to `PhiIntrinsicRewardV1`; this phase required threading the same values through the *other* schema.

## Architecture touched

`orion/schemas/telemetry/spark.py`, `services/orion-spark-introspector/app/worker.py`, `services/orion-cortex-exec/app/{executor,spark_narrative}.py`, `orion/cognition/prompts/log_orion_metacognition_{draft,enrich}.j2`. Live deploy also required rebuilding `orion-sql-writer` (twice — see incident below).

## Files changed

- `orion/schemas/telemetry/spark.py`: additive `SparkStateSnapshotV1.dominant_node`/`.dominant_node_reason`.
- `services/orion-spark-introspector/app/worker.py`: wires the same `_dominant_hardware_node()` result already computed for `PhiIntrinsicRewardV1` into the `SparkStateSnapshotV1` construction. Adds `dominant_node`/`dominant_node_reason` `Optional[str] = None` defaults near `encoder_tick_ok = False`, fixing a scoping bug (see Review findings).
- `services/orion-cortex-exec/app/spark_narrative.py`: `spark_embodiment_hint`/`spark_embodiment_narrative`, mirroring `spark_phi_hint`/`spark_phi_narrative` exactly. Honest on absence — `"none"`/an explicit no-node sentence, never a fabricated node name.
- `services/orion-cortex-exec/app/executor.py`: wired into both metacog prompt passes — `ctx["embodiment_hint"]`/`ctx["spark_embodiment_narrative"]`, the `_render_prompt` Jinja-undefined-safety defaults dict, and the `_METACOG_DRAFT_CTX_LEN_KEYS` prompt-size-logging tuple — matching every existing `phi_hint`/`spark_phi_narrative` touch point.
- `orion/cognition/prompts/log_orion_metacognition_{draft,enrich}.j2`: one new `EMBODIMENT` block each.
- `orion/self_state/inner_state_registry.py`, `orion/self_state/README.md`, `services/orion-spark-introspector/README.md`, `docs/superpowers/plans/2026-07-12-inner-state-unification-plan.md`: registry, docs, plan status updated.
- `services/orion-cortex-exec/tests/test_spark_narrative_embodiment.py` (new), `services/orion-spark-introspector/tests/test_phi_reward_emit.py`: 7 new tests total.

## Schema / bus / API changes

- Added: `SparkStateSnapshotV1.dominant_node`, `.dominant_node_reason` (additive, `Optional[str] = None`).
- Compatibility notes: `orion.normalizers.spark.normalize_spark_state_snapshot` is schema-driven (`set(SparkStateSnapshotV1.model_fields.keys())`), so it picked up the new fields automatically once `orion-sql-writer` was rebuilt against current code — no normalizer change needed.

## Env/config changes

None.

## Tests run

```text
PYTHONPATH=. :services/orion-spark-introspector pytest services/orion-spark-introspector/tests -q
140 passed, 1 skipped

PYTHONPATH=. :services/orion-cortex-exec pytest services/orion-cortex-exec/tests/test_spark_narrative_embodiment.py \
  services/orion-cortex-exec/tests/test_metacog_two_pass_draft.py services/orion-cortex-exec/tests/test_metacog_publish_lane.py -q
32 passed

PYTHONPATH=. pytest tests/test_inner_state_registry_gate.py -q
8 passed

python scripts/check_inner_state_registry.py
inner_state_registry gate OK (9 entries checked)
```

Regression-confirmed: the `UnboundLocalError` fix was verified by temporarily reverting it and re-running `test_spark_snapshot_dominant_node_none_when_encoder_skipped` — reproduced the exact crash (`cannot access local variable 'dominant_node' where it is not associated with a value`), then re-applied the fix and confirmed green.

## Evals run

None applicable.

## Docker/build/smoke checks

**Deployed live on Athena.** Full sequence, in order:

```bash
# Phases 0/1/2 (prerequisite for this phase's own gate):
docker compose --env-file .env --env-file services/orion-self-state-runtime/.env \
  -f services/orion-self-state-runtime/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml up -d --build
docker compose --env-file .env --env-file services/orion-sql-writer/.env \
  -f services/orion-sql-writer/docker-compose.yml up -d --build   # incident fix, see below

# Phase 3 itself:
docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml up -d --build   # all 4 sub-services
docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml up -d --build   # re-rebuild, schema changed again
docker compose --env-file .env --env-file services/orion-sql-writer/.env \
  -f services/orion-sql-writer/docker-compose.yml up -d --build   # re-rebuild, second schema change
```

Verified live, end to end:
- `redis-cli SUBSCRIBE orion:self:phi_reward` → real `dominant_node`/`dominant_node_reason` on the bus.
- `redis-cli SUBSCRIBE orion:spark:state:snapshot` → same fields present on `SparkStateSnapshotV1` messages.
- `SELECT metadata->'spark_state_snapshot'->>'dominant_node' FROM spark_telemetry ...` → `node:circe`, `reason: node pressure present`, confirming the full bus→Postgres path.

## Review findings fixed

- Finding: `dominant_node`/`dominant_node_reason` are assigned only inside the encoder-success `try` block, but the `SparkStateSnapshotV1` construction (added this phase) reads them unconditionally, later, on every tick — `UnboundLocalError` on any disabled/degraded/frozen/failed tick.
  - Fix: `None` defaults declared alongside the existing `encoder_tick_ok = False` pattern, before the conditional block.
  - Evidence: reverted the fix, re-ran the regression test, confirmed it reproduces the exact crash; re-applied, confirmed green. Independent code-review pass separately traced the full function control flow and confirmed no other unguarded read site exists.
- Finding (mid-deployment, not code review — a live incident): `orion-sql-writer` needed rebuilding **twice** — once for Phase 2's `PhiIntrinsicRewardV1.dominant_node` (fixing a live `extra_forbidden` `ValidationError` on every phi-reward write), once more for Phase 3's `SparkStateSnapshotV1.dominant_node` (silently dropping the field from `spark_telemetry`'s stored JSON with no error, since `extra="forbid"` doesn't fire on missing-vs-extra in that direction — a normalizer schema-driven filter, `orion.normalizers.spark.normalize_spark_state_snapshot`, just quietly excluded fields its running code didn't know about yet).
  - Lesson recorded in the plan doc: `extra="forbid"` schemas need every consumer identified and rebuilt together, not just the primary producer/consumer pair — and re-checked after *each* subsequent schema change to the same object, not just once.

## Restart required

Already done live — see Docker/build/smoke checks above. No further restart needed.

## Risks / concerns

- Severity: low
- Concern: the embodiment narrative is now live in real chat/metacog prompts. Its actual effect on Orion's self-report tone/content hasn't been observed over a real chat session yet — only verified for correctness at the data-plumbing level (right node named, no crashes, no fabrication).
- Mitigation: the narrative text is explicitly framed as internal guidance ("do NOT copy verbatim into output" — matching the existing `spark_phi_narrative` convention in both templates), same safety margin already relied on for the phi narrative.
- Severity: low
- Concern: two live incidents this session (both `orion-sql-writer` schema-drift issues) point at a repeatable gap — no automated check currently catches "a schema this service consumes changed and this service wasn't rebuilt."
- Mitigation: named explicitly, not silently patched around. A real fix (e.g., extending `scripts/check_inner_state_registry.py` or a separate consumer-staleness check) is a natural future addition to this initiative's registry/gate work, not built here — out of scope for this phase.

## PR link

Branch pushed: `docs/attention-provenance-crosscheck-phase4` (continued in-session from Phase 4; contains Phase 4's docs commit plus this Phase 3 implementation commit)