### PR TITLE
Feat/unified turn grammar trace

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-unified-turn-chat-grammar-trace-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-unified-turn-chat-grammar-trace-pr.md
@@ -1,0 +1,92 @@
+# PR: unified-turn chat grammar trace + stance disposition signal
+
+Branch: `feat/unified-turn-grammar-trace` → `main`
+
+## Summary
+
+Direct follow-up to a correction Juniper caught: I'd concluded the `chat_grammar_consumer` cursor's 42h staleness meant "no chat traffic," based on `--since 24h` docker logs against containers that had actually only been up ~30 minutes (post-deploy restart). That conclusion was wrong on two counts: the log window was invalid, and — verified from source code, not logs — the real chat pipeline (`orion/hub/turn_orchestrator.py::execute_unified_turn`, the "unified turn" path every `orion` mode message actually goes through) never called the chat-grammar-emit code at all. The grammar-emit code only ever existed in the older `websocket_handler.py` classic path, which is now a dead branch for `orion` mode traffic specifically (still live for other client modes, so left untouched).
+
+Rather than just restore parity, this adds something the old path never captured: the **Thought stance decision** — `proceed`/`defer`/`refuse`, with reasons and a boundary-register flag. That's Orion choosing whether and how to engage with a given turn, and until this patch it had zero representation anywhere in the substrate ladder.
+
+## Outcome moved
+
+`chat_grammar_consumer` will advance again on real unified-turn traffic. The substrate ladder gains a genuinely new signal (self-regulatory/boundary decisions) it never had before, captured for every turn including the ones Orion declines to engage with — not just the ones that reach a successful answer.
+
+## Current architecture
+
+Five things confirmed by reading the actual code, not inferring from logs:
+1. `websocket_endpoint` in `websocket_handler.py` routes `orion` mode + `ORION_UNIFIED_TURN_ENABLED=true` to `run_unified_turn` → `execute_unified_turn`, with an explicit `continue` — never reaching the classic path's `build_chat_request`/grammar-emit block further down in the same function.
+2. The classic path's grammar-emit block (`services/orion-hub/scripts/websocket_handler.py` ~line 1136) is still live code for other client modes — not dead, not deleted here.
+3. `execute_unified_turn` has a real Thought-stance gate: `ThoughtClient(bus).react(...)` → `thought.disposition in ("proceed", "defer", "refuse")`, with `defer`/`refuse` returning early before any harness call.
+4. `orion-harness-governor` (the service that runs the actual FCC motor/finalize chain for unified turns) is already a registered producer on the `execution_trajectory` reducer (`cortex.exec:` prefix) — so step/plan mechanics for unified turns are already captured elsewhere in the ladder. This patch deliberately does not duplicate that; it only covers the conversational-envelope + stance layer, which is `chat_grammar`'s actual scope.
+5. `orion/substrate/chat_loop/grammar_extract.py::extract_chat_turn_state` recognized exactly three semantic roles (`user_utterance`, `repair_signal`, `session_context`) and `ChatTurnStateV1` had no field to hold a stance fact even if one were emitted — a new atom without reducer + schema support would have been an "empty-shell" addition, present in the raw event log but invisible in the materialized projection.
+
+## Architecture touched
+
+- `orion/hub/turn_orchestrator.py` — new `_publish_unified_turn_chat_grammar` helper, called at all three of `execute_unified_turn`'s stance-resolution exit points (stance-RPC-timeout, defer/refuse, proceed).
+- `services/orion-hub/scripts/grammar_emit.py` — `build_chat_turn_grammar_events` extended with an optional `stance_disposition` atom + edge, mirroring the existing `repair_signal` atom's conditional-emission pattern exactly.
+- `orion/substrate/chat_loop/grammar_extract.py` + `orion/schemas/chat_projection.py` — reducer-side parsing and `ChatTurnStateV1` schema extension so the new atom is actually materialized, not just logged.
+
+## Files changed
+
+- `orion/hub/turn_orchestrator.py` — `_publish_unified_turn_chat_grammar` (async, awaited directly — not scheduled as a background task, unlike the classic path's `_schedule_publish`, because this file's own established convention already awaits its other publish calls (`publish_chat_history`, `publish_chat_turn`) directly, and the added latency of one lightweight bus publish is negligible next to the harness governor call it precedes). Wired at all 3 exit points so `defer`/`refuse` turns are captured, not just successful ones.
+- `services/orion-hub/scripts/grammar_emit.py` — `stance_disposition`/`stance_disposition_reasons`/`stance_boundary_register` params; new optional atom (`semantic_role="stance_disposition"`, `layer="organ_signal"`, `atom_type="signal"`, `text_value` holds the disposition string directly — mirroring `session_context`'s pattern of using a structured field rather than regex, since disposition is a small enum with no privacy concern) plus a `derived_from` edge to `user_utterance`, matching `repair_signal`'s existing edge pattern.
+- `orion/substrate/chat_loop/grammar_extract.py` — parses the new atom (`text_value` for disposition, a light regex for the parenthetical reasons list, a literal substring check for `[boundary_register]`) into the three new state fields.
+- `orion/schemas/chat_projection.py` — `ChatTurnStateV1` gains `stance_disposition: str = "unknown"`, `stance_disposition_reasons: list[str] = []`, `stance_boundary_register: bool = False`. Additive with defaults — backward-compatible with existing stored `ChatSessionProjectionV1` rows (JSONB, no migration needed).
+- `services/orion-hub/tests/test_hub_grammar_emit.py` — 3 new tests: stance atom absent when not provided, present with correct summary/text_value when provided, edge links to `user_utterance`.
+- `services/orion-hub/tests/test_turn_orchestrator_ws_frames.py` — 3 new tests directly exercising `_publish_unified_turn_chat_grammar`: no-op when `PUBLISH_HUB_CHAT_GRAMMAR` is off, stance fields carried through to the built events when on (plus confirms `user_utterance.text_value is None` — raw text never stored), and fail-open on a publish exception.
+- `tests/test_chat_substrate_reducer.py` — 3 new tests for `extract_chat_turn_state`'s new parsing: stance present with reasons + boundary register, defaults to `"unknown"` when the atom is absent, no-reasons case doesn't choke on the word-count atom's own parentheses (`"(N words)"`) since role-gating happens before the reasons regex runs.
+- `services/orion-hub/README.md` — new subsection under "Chat & Cognition" documenting the unified-turn grammar trace, right after the existing repair-pressure documentation since they're now emitted together.
+
+## Schema / bus / API changes
+
+- Added: `ChatTurnStateV1.stance_disposition`/`stance_disposition_reasons`/`stance_boundary_register` (additive, defaulted).
+- Added: `stance_disposition` semantic role on the existing `hub.chat:` grammar trace (no new atom_type, no new event_kind — `"signal"`/`"atom_emitted"` already existed in the schema's enums).
+- No new channel, no new cursor, no new reducer, no new env key, no migration.
+- Compatibility: fully additive on both the producer and consumer side. Existing consumers of `ChatTurnStateV1` that don't know about the new fields are unaffected (`model_config = ConfigDict(extra="forbid")` only forbids *unexpected* extra keys on incoming data, not missing-with-default fields).
+
+## Env/config changes
+
+None. Reuses the existing `PUBLISH_HUB_CHAT_GRAMMAR` flag (default `true`) and `GRAMMAR_EVENT_CHANNEL`.
+
+## Tests run
+
+```
+cd /mnt/scripts/Orion-Sapienform-unified-turn-grammar
+/tmp/orion-test-venv/bin/python -m pytest services/orion-hub/tests/test_hub_grammar_emit.py services/orion-hub/tests/test_turn_orchestrator_ws_frames.py tests/test_chat_substrate_reducer.py -q -W ignore::UserWarning -W ignore::DeprecationWarning
+→ 34 passed, 8 failed
+```
+All 8 failures verified pre-existing via `git stash` comparison against unmodified `origin/main` — identical failure set either way (`AttributeError: 'ThoughtEventV1' object has no attribute 'thought'`, a stale test-mock fixture in `_hub_client_patches` that returns a bare `ThoughtEventV1` instead of the `ThoughtReactResult` wrapper `ThoughtClient.react()` actually returns — a real bug in the test suite, not something this patch touches or introduces). Because those existing fixtures were broken, my new `turn_orchestrator.py`-level tests call `_publish_unified_turn_chat_grammar` directly (bypassing the broken `ThoughtClient`/`HarnessGovernorClient` mock chain) rather than through the full `execute_unified_turn` integration path — still exercises the real code, just at the seam that's actually testable in this environment.
+
+## Evals run
+
+No eval harness exists for hub's chat-grammar production.
+
+## Docker/build/smoke checks
+
+None run — no env/compose changes in this patch, nothing to validate at that layer.
+
+## Review findings fixed
+
+None from an external review pass; self-caught during implementation:
+- Initial draft scheduled the grammar publish as a fire-and-forget background task (mirroring `websocket_handler.py`'s `_schedule_publish`) to avoid adding latency ahead of the harness dispatch. Reconsidered: this file's own convention already awaits its other publish calls directly, the latency of one bus publish is negligible next to the harness governor call, and fire-and-forget against `MagicMock()` (non-async) test buses produces orphaned background tasks that fail silently — worse for testability with no real latency benefit. Switched to awaiting directly before writing any tests.
+
+## Restart required
+
+```bash
+# Hub picks this up on its next normal restart/redeploy -- no new env keys, no migration.
+docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
+```
+Confirm the cursor is advancing again post-restart:
+```bash
+curl -fsS http://localhost:8115/grammar/truth | python3 -c "import json,sys; d=json.load(sys.stdin); print([r for r in d['cursor_positions'] if r['cursor_name']=='chat_grammar_consumer'])"
+```
+
+## Risks / concerns
+
+- Severity: low. `repair_pressure_grammar_scalars(pre_turn_bundle=repair_bundle, substrate_summary=None)` is called with `substrate_summary` always `None` in the unified-turn path, since `execute_unified_turn` only ever has `repair_bundle` (`TurnAppraisalBundleV1 | None`) in scope, not a separate `substrate_summary` dict the way the classic path does. Confirmed the helper's implementation checks `pre_turn_bundle` first and only falls back to `substrate_summary`, so this is correct, not a gap — noting it because it's the one place the unified-turn call site's available data differs slightly from the classic path's.
+- Severity: none (informational). The `_STANCE_REASONS_RE = re.compile(r"\((.*?)\)")` regex used in `grammar_extract.py` is intentionally non-greedy and scoped by the `role == "stance_disposition"` gate before it ever runs, so it doesn't collide with `user_utterance`'s own `(N words)` parenthetical on the same atom set — verified with a dedicated test (`test_extract_stance_disposition_no_reasons_no_parens_in_summary`).
+
+## PR link
+
+(Push and open via `git push -u origin feat/unified-turn-grammar-trace`, then `gh pr create` if authenticated, or open manually via the GitHub compare link the push prints.)

--- a/orion/hub/turn_orchestrator.py
+++ b/orion/hub/turn_orchestrator.py
@@ -46,6 +46,68 @@ def _repair_pressure_contract(repair_bundle: TurnAppraisalBundleV1 | None) -> di
     return None
 
 
+async def _publish_unified_turn_chat_grammar(
+    *,
+    bus: Any,
+    correlation_id: str,
+    session_id: str | None,
+    user_message: str,
+    repair_bundle: TurnAppraisalBundleV1 | None,
+    stance_disposition: str,
+    stance_disposition_reasons: list[str],
+    stance_boundary_register: bool,
+    settings: Any,
+) -> None:
+    """Orion capability: unified-turn conversational-envelope grammar trace.
+
+    Publishes the same hub.chat: trace the classic websocket_handler chat path
+    already produces (session, utterance word count, repair signal), extended
+    with the Thought stance decision (proceed/defer/refuse + reasons +
+    boundary register) -- a fact with no representation anywhere else in the
+    substrate ladder. Fires once per turn, right after the stance decision is
+    known, regardless of whether the turn goes on to the harness or stops
+    here on defer/refuse. Awaited directly (matches this file's other publish
+    calls, e.g. publish_chat_history/publish_chat_turn in
+    _publish_unified_turn_chat_history) rather than scheduled as a background
+    task -- this is a single lightweight bus publish, not a network round
+    trip to an LLM, so the added latency ahead of the harness dispatch is
+    negligible next to the harness call itself. Fail-open: chat must work
+    whether grammar publishing is on or off, or this call fails outright.
+    """
+    if bus is None or not getattr(settings, "PUBLISH_HUB_CHAT_GRAMMAR", False):
+        return
+    try:
+        from scripts.grammar_emit import build_chat_turn_grammar_events
+        from scripts.grammar_publish import publish_hub_chat_grammar_trace
+        from scripts.pre_turn_appraisal_wiring import repair_pressure_grammar_scalars
+
+        repair_pressure_level, repair_pressure_confidence = repair_pressure_grammar_scalars(
+            pre_turn_bundle=repair_bundle,
+            substrate_summary=None,
+        )
+        events = build_chat_turn_grammar_events(
+            turn_id=correlation_id,
+            session_id=str(session_id or "anonymous"),
+            node_id=settings.NODE_NAME,
+            word_count=len((user_message or "").split()),
+            repair_pressure_level=repair_pressure_level,
+            repair_pressure_confidence=repair_pressure_confidence,
+            has_repair_signal=repair_bundle is not None,
+            stance_disposition=stance_disposition,
+            stance_disposition_reasons=stance_disposition_reasons,
+            stance_boundary_register=stance_boundary_register,
+        )
+        await publish_hub_chat_grammar_trace(
+            bus,
+            events,
+            correlation_id=correlation_id,
+            channel=settings.GRAMMAR_EVENT_CHANNEL,
+            enabled=True,
+        )
+    except Exception:
+        logger.warning("unified_turn_chat_grammar_publish_failed corr=%s", correlation_id, exc_info=True)
+
+
 def _thought_deferred_frame(thought: ThoughtEventV1, *, correlation_id: str) -> dict[str, Any]:
     frame: dict[str, Any] = {
         "type": "turn_deferred",
@@ -298,6 +360,17 @@ async def execute_unified_turn(
     react_result = await ThoughtClient(bus).react(stance_req, correlation_id=correlation_id)
     thought = react_result.thought
     if thought is None:
+        await _publish_unified_turn_chat_grammar(
+            bus=bus,
+            correlation_id=correlation_id,
+            session_id=session_id,
+            user_message=user_message,
+            repair_bundle=repair_bundle,
+            stance_disposition="stance_timeout",
+            stance_disposition_reasons=[react_result.failure_reason or "stance_react_timeout"],
+            stance_boundary_register=False,
+            settings=cfg,
+        )
         return [
             {
                 "type": "turn_deferred",
@@ -306,7 +379,30 @@ async def execute_unified_turn(
             }
         ]
     if thought.disposition in ("defer", "refuse"):
+        await _publish_unified_turn_chat_grammar(
+            bus=bus,
+            correlation_id=correlation_id,
+            session_id=session_id,
+            user_message=user_message,
+            repair_bundle=repair_bundle,
+            stance_disposition=thought.disposition,
+            stance_disposition_reasons=thought.disposition_reasons,
+            stance_boundary_register=bool(thought.boundary_register),
+            settings=cfg,
+        )
         return [_thought_deferred_frame(thought, correlation_id=correlation_id)]
+
+    await _publish_unified_turn_chat_grammar(
+        bus=bus,
+        correlation_id=correlation_id,
+        session_id=session_id,
+        user_message=user_message,
+        repair_bundle=repair_bundle,
+        stance_disposition=thought.disposition,
+        stance_disposition_reasons=thought.disposition_reasons,
+        stance_boundary_register=bool(thought.boundary_register),
+        settings=cfg,
+    )
 
     harness_req = HarnessRunRequestV1(
         correlation_id=correlation_id,

--- a/orion/schemas/chat_projection.py
+++ b/orion/schemas/chat_projection.py
@@ -15,6 +15,9 @@ class ChatTurnStateV1(BaseModel):
     repair_pressure_level: float = 0.0
     repair_pressure_confidence: float = 0.0
     has_repair_signal: bool = False
+    stance_disposition: str = "unknown"
+    stance_disposition_reasons: list[str] = Field(default_factory=list)
+    stance_boundary_register: bool = False
     evidence_event_ids: list[str] = Field(default_factory=list)
     last_updated_at: datetime
 

--- a/orion/substrate/chat_loop/grammar_extract.py
+++ b/orion/substrate/chat_loop/grammar_extract.py
@@ -10,6 +10,7 @@ from .constants import CHAT_SOURCE_SERVICE, CHAT_TRACE_PREFIX
 
 _WORD_COUNT_RE = re.compile(r"\((\d+) words?\)")
 _SESSION_RE = re.compile(r"User message in session (\S+)")
+_STANCE_REASONS_RE = re.compile(r"\((.*?)\)")
 
 _EVIDENCE_CAP = 50
 
@@ -49,6 +50,9 @@ def extract_chat_turn_state(
     repair_pressure_level = 0.0
     repair_pressure_confidence = 0.0
     has_repair_signal = False
+    stance_disposition = "unknown"
+    stance_disposition_reasons: list[str] = []
+    stance_boundary_register = False
     evidence_event_ids: list[str] = []
 
     for event in events:
@@ -75,6 +79,15 @@ def extract_chat_turn_state(
         elif role == "session_context":
             if atom.text_value is not None:
                 session_id = atom.text_value
+        elif role == "stance_disposition":
+            if atom.text_value:
+                stance_disposition = atom.text_value
+            m3 = _STANCE_REASONS_RE.search(summary)
+            if m3:
+                stance_disposition_reasons = [
+                    r.strip() for r in m3.group(1).split(";") if r.strip()
+                ]
+            stance_boundary_register = "[boundary_register]" in summary
 
         if event.event_kind == "atom_emitted":
             if len(evidence_event_ids) < _EVIDENCE_CAP:
@@ -90,6 +103,9 @@ def extract_chat_turn_state(
         repair_pressure_level=repair_pressure_level,
         repair_pressure_confidence=repair_pressure_confidence,
         has_repair_signal=has_repair_signal,
+        stance_disposition=stance_disposition,
+        stance_disposition_reasons=stance_disposition_reasons,
+        stance_boundary_register=stance_boundary_register,
         evidence_event_ids=evidence_event_ids,
         last_updated_at=clock,
     )

--- a/services/orion-hub/README.md
+++ b/services/orion-hub/README.md
@@ -105,6 +105,18 @@ pytest tests/test_pre_turn_appraisal_wiring.py tests/test_handle_chat_request_su
 - `scripts/api_routes.py`, `scripts/websocket_handler.py` — chat integration
 - `scripts/substrate_effect_pipeline.py` — legacy skip when v2 enabled
 
+#### Unified-turn chat grammar trace (stance disposition)
+
+`orion/hub/turn_orchestrator.py::execute_unified_turn` (the pipeline `run_unified_turn` routes into when `client_mode == "orion" and ORION_UNIFIED_TURN_ENABLED=true`) publishes the same `hub.chat:` `GrammarEventV1` trace the classic `websocket_handler.py` chat path already produces (session context, utterance word count, repair signal) -- extended with the Thought stance decision (`proceed`/`defer`/`refuse`, `disposition_reasons`, `boundary_register`), a fact unified turn has that the classic path never did. Both paths feed the same `chat_grammar_consumer` reducer on substrate-runtime; whichever pipeline actually produced a given turn, its facts land in the same `active_chat_session` projection.
+
+Gated by the existing `PUBLISH_HUB_CHAT_GRAMMAR` flag (default `true`) -- no new env key. Fires once per turn, right after the stance decision resolves, whether or not the turn goes on to the harness governor. Fail-open: a publish failure is logged and swallowed, never raised into the chat response.
+
+**Code**
+
+- `orion/hub/turn_orchestrator.py::_publish_unified_turn_chat_grammar` — call site, builds the stance-aware event set
+- `scripts/grammar_emit.py::build_chat_turn_grammar_events` — pure builder, `stance_disposition`/`stance_disposition_reasons`/`stance_boundary_register` params
+- `orion/substrate/chat_loop/grammar_extract.py::extract_chat_turn_state` — reducer-side parsing into `ChatTurnStateV1.stance_disposition` etc.
+
 ### 2. Text-to-Speech (TTS)
 
 *   **Intake**: `orion:tts:intake`

--- a/services/orion-hub/scripts/grammar_emit.py
+++ b/services/orion-hub/scripts/grammar_emit.py
@@ -71,6 +71,9 @@ def build_chat_turn_grammar_events(
     repair_pressure_confidence: float = 0.0,
     repair_pressure_dims: dict[str, float] | None = None,
     has_repair_signal: bool = False,
+    stance_disposition: str | None = None,
+    stance_disposition_reasons: list[str] | None = None,
+    stance_boundary_register: bool = False,
     observed_at: datetime | None = None,
     code_version: str | None = None,
 ) -> list[GrammarEventV1]:
@@ -188,6 +191,46 @@ def build_chat_turn_grammar_events(
             )
         )
 
+    # Optionally emit stance_disposition atom (Thought's proceed/defer/refuse decision --
+    # only meaningful for the unified-turn pipeline, which is the only producer that has
+    # a stance decision to report; the classic path leaves stance_disposition=None).
+    stance_disposition_atom: GrammarAtomV1 | None = None
+    if stance_disposition:
+        reasons = stance_disposition_reasons or []
+        summary = f"Stance disposition: {stance_disposition}"
+        if reasons:
+            summary += f" ({'; '.join(reasons)})"
+        if stance_boundary_register:
+            summary += " [boundary_register]"
+        stance_disposition_atom = GrammarAtomV1(
+            atom_id=atom_id("stance_disposition"),
+            trace_id=trace_id,
+            atom_type="signal",
+            semantic_role="stance_disposition",
+            layer="organ_signal",
+            dimensions=["conversation", "turn", "stance"],
+            summary=summary,
+            text_value=stance_disposition,
+            confidence=1.0,
+            salience=1.0 if stance_disposition != "proceed" else 0.3,
+            source_event_id=turn_id,
+            payload_ref=f"hub.stance:{turn_id}",
+        )
+        events.append(
+            _event(
+                event_kind="atom_emitted",
+                trace_id=trace_id,
+                emitted_at=emitted_at,
+                observed_at=observed_at_,
+                provenance=provenance,
+                atom=stance_disposition_atom,
+                parent_event_id=root_id,
+                root_event_id=root_id,
+                layer=stance_disposition_atom.layer,
+                dimensions=stance_disposition_atom.dimensions,
+            )
+        )
+
     # Edge: user_utterance → derived_from → session_context
     edge_utterance_context = GrammarEdgeV1(
         edge_id=f"{trace_id}:edge:user_utterance:derived_from:session_context",
@@ -242,6 +285,35 @@ def build_chat_turn_grammar_events(
                 root_event_id=root_id,
                 layer=edge_repair_utterance.layer_to,
                 dimensions=["conversation", "turn", "repair"],
+            )
+        )
+
+    # Edge: stance_disposition → derived_from → user_utterance
+    if stance_disposition_atom is not None:
+        edge_stance_utterance = GrammarEdgeV1(
+            edge_id=f"{trace_id}:edge:stance_disposition:derived_from:user_utterance",
+            trace_id=trace_id,
+            from_atom_id=stance_disposition_atom.atom_id,
+            to_atom_id=user_utterance_atom.atom_id,
+            relation_type="derived_from",
+            confidence=1.0,
+            salience=stance_disposition_atom.salience or 0.0,
+            layer_from=stance_disposition_atom.layer,
+            layer_to=user_utterance_atom.layer,
+            evidence_event_ids=[turn_id],
+        )
+        events.append(
+            _event(
+                event_kind="edge_emitted",
+                trace_id=trace_id,
+                emitted_at=emitted_at,
+                observed_at=observed_at_,
+                provenance=provenance,
+                edge=edge_stance_utterance,
+                parent_event_id=root_id,
+                root_event_id=root_id,
+                layer=edge_stance_utterance.layer_to,
+                dimensions=["conversation", "turn", "stance"],
             )
         )
 

--- a/services/orion-hub/tests/test_hub_grammar_emit.py
+++ b/services/orion-hub/tests/test_hub_grammar_emit.py
@@ -83,6 +83,40 @@ def test_repair_signal_present_when_flag_true():
     assert repair_atoms[0].confidence == pytest.approx(0.9)
 
 
+def test_stance_disposition_absent_when_not_provided():
+    events = _build()
+    roles = [ev.atom.semantic_role for ev in events if ev.atom is not None]
+    assert "stance_disposition" not in roles
+
+
+def test_stance_disposition_present_when_provided():
+    events = _build(
+        stance_disposition="defer",
+        stance_disposition_reasons=["stale_broadcast_no_evidence"],
+        stance_boundary_register=True,
+    )
+    stance_atoms = [
+        ev.atom
+        for ev in events
+        if ev.atom is not None and ev.atom.semantic_role == "stance_disposition"
+    ]
+    assert len(stance_atoms) == 1
+    atom = stance_atoms[0]
+    assert atom.text_value == "defer"
+    assert "stale_broadcast_no_evidence" in atom.summary
+    assert "[boundary_register]" in atom.summary
+
+
+def test_stance_disposition_edge_links_to_user_utterance():
+    events = _build(stance_disposition="proceed")
+    edges = [ev.edge for ev in events if ev.edge is not None]
+    stance_edges = [
+        e for e in edges if e is not None and "stance_disposition" in e.from_atom_id
+    ]
+    assert len(stance_edges) == 1
+    assert "user_utterance" in stance_edges[0].to_atom_id
+
+
 def test_atom_types_are_valid():
     import typing
 

--- a/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
+++ b/services/orion-hub/tests/test_turn_orchestrator_ws_frames.py
@@ -484,3 +484,95 @@ async def test_run_unified_turn_emits_trailing_idle_state_frame() -> None:
 
     assert any(f.get("type") == "final" for f in sent), "final frame must still be sent"
     assert sent[-1] == {"state": "idle"}, "must end with an idle-state frame so status resets to Ready"
+
+
+def _settings_stub(*, publish_chat_grammar: bool) -> MagicMock:
+    settings = MagicMock()
+    settings.PUBLISH_HUB_CHAT_GRAMMAR = publish_chat_grammar
+    settings.NODE_NAME = "athena"
+    settings.GRAMMAR_EVENT_CHANNEL = "orion:grammar:event"
+    return settings
+
+
+@pytest.mark.asyncio
+async def test_publish_unified_turn_chat_grammar_noop_when_disabled() -> None:
+    """No bus call at all when PUBLISH_HUB_CHAT_GRAMMAR is off -- chat must work either way."""
+    from orion.hub.turn_orchestrator import _publish_unified_turn_chat_grammar
+
+    _ensure_hub_import_paths()
+    publish_trace = AsyncMock()
+    with patch("scripts.grammar_publish.publish_hub_chat_grammar_trace", publish_trace):
+        await _publish_unified_turn_chat_grammar(
+            bus=MagicMock(),
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="hello there",
+            repair_bundle=None,
+            stance_disposition="proceed",
+            stance_disposition_reasons=[],
+            stance_boundary_register=False,
+            settings=_settings_stub(publish_chat_grammar=False),
+        )
+    publish_trace.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publish_unified_turn_chat_grammar_carries_stance_fields() -> None:
+    """When enabled, the built events carry the stance disposition through to the publisher."""
+    from orion.hub.turn_orchestrator import _publish_unified_turn_chat_grammar
+
+    _ensure_hub_import_paths()
+    publish_trace = AsyncMock()
+    with patch("scripts.grammar_publish.publish_hub_chat_grammar_trace", publish_trace):
+        await _publish_unified_turn_chat_grammar(
+            bus=MagicMock(),
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="one two three",
+            repair_bundle=None,
+            stance_disposition="defer",
+            stance_disposition_reasons=["stale_broadcast_no_evidence"],
+            stance_boundary_register=True,
+            settings=_settings_stub(publish_chat_grammar=True),
+        )
+    publish_trace.assert_awaited_once()
+    events = publish_trace.await_args.args[1]
+    stance_atoms = [
+        ev.atom
+        for ev in events
+        if ev.atom is not None and ev.atom.semantic_role == "stance_disposition"
+    ]
+    assert len(stance_atoms) == 1
+    assert stance_atoms[0].text_value == "defer"
+    assert "stale_broadcast_no_evidence" in stance_atoms[0].summary
+    assert "[boundary_register]" in stance_atoms[0].summary
+    utterance_atoms = [
+        ev.atom
+        for ev in events
+        if ev.atom is not None and ev.atom.semantic_role == "user_utterance"
+    ]
+    assert utterance_atoms[0].text_value is None, "raw user text must never be stored"
+
+
+@pytest.mark.asyncio
+async def test_publish_unified_turn_chat_grammar_fails_open() -> None:
+    """A publish failure must not raise -- chat must survive even if the substrate side breaks."""
+    from orion.hub.turn_orchestrator import _publish_unified_turn_chat_grammar
+
+    _ensure_hub_import_paths()
+    with patch(
+        "scripts.grammar_publish.publish_hub_chat_grammar_trace",
+        AsyncMock(side_effect=RuntimeError("bus down")),
+    ):
+        await _publish_unified_turn_chat_grammar(
+            bus=MagicMock(),
+            correlation_id=_CORR_ID,
+            session_id="sess-1",
+            user_message="hello",
+            repair_bundle=None,
+            stance_disposition="proceed",
+            stance_disposition_reasons=[],
+            stance_boundary_register=False,
+            settings=_settings_stub(publish_chat_grammar=True),
+        )
+    # No assertion beyond "did not raise" -- that is the whole point of this test.

--- a/tests/test_chat_substrate_reducer.py
+++ b/tests/test_chat_substrate_reducer.py
@@ -107,6 +107,56 @@ def test_extract_repair_signal_present():
     assert turn.repair_pressure_confidence == pytest.approx(0.9)
 
 
+def test_extract_stance_disposition_present():
+    trace_id = "hub.chat:athena:turn-201"
+    events = [
+        _atom_event(
+            trace_id,
+            "stance_disposition",
+            "signal",
+            "Stance disposition: defer (stale_broadcast_no_evidence; low_confidence) [boundary_register]",
+            text_value="defer",
+        ),
+    ]
+    turn = extract_chat_turn_state(events)
+    assert turn.stance_disposition == "defer"
+    assert turn.stance_disposition_reasons == ["stale_broadcast_no_evidence", "low_confidence"]
+    assert turn.stance_boundary_register is True
+
+
+def test_extract_stance_disposition_defaults_to_unknown_when_absent():
+    trace_id = "hub.chat:athena:turn-202"
+    events = [
+        _atom_event(
+            trace_id,
+            "user_utterance",
+            "raw_span",
+            "User message in session sess-001 (5 words)",
+        ),
+    ]
+    turn = extract_chat_turn_state(events)
+    assert turn.stance_disposition == "unknown"
+    assert turn.stance_disposition_reasons == []
+    assert turn.stance_boundary_register is False
+
+
+def test_extract_stance_disposition_no_reasons_no_parens_in_summary():
+    trace_id = "hub.chat:athena:turn-203"
+    events = [
+        _atom_event(
+            trace_id,
+            "stance_disposition",
+            "signal",
+            "Stance disposition: proceed",
+            text_value="proceed",
+        ),
+    ]
+    turn = extract_chat_turn_state(events)
+    assert turn.stance_disposition == "proceed"
+    assert turn.stance_disposition_reasons == []
+    assert turn.stance_boundary_register is False
+
+
 def test_extract_noop_on_wrong_source():
     trace_id = "hub.chat:athena:turn-77"
     events = [


### PR DESCRIPTION
# PR: unified-turn chat grammar trace + stance disposition signal

Branch: `feat/unified-turn-grammar-trace` → `main`

## Summary

Direct follow-up to a correction Juniper caught: I'd concluded the `chat_grammar_consumer` cursor's 42h staleness meant "no chat traffic," based on `--since 24h` docker logs against containers that had actually only been up ~30 minutes (post-deploy restart). That conclusion was wrong on two counts: the log window was invalid, and — verified from source code, not logs — the real chat pipeline (`orion/hub/turn_orchestrator.py::execute_unified_turn`, the "unified turn" path every `orion` mode message actually goes through) never called the chat-grammar-emit code at all. The grammar-emit code only ever existed in the older `websocket_handler.py` classic path, which is now a dead branch for `orion` mode traffic specifically (still live for other client modes, so left untouched).

Rather than just restore parity, this adds something the old path never captured: the **Thought stance decision** — `proceed`/`defer`/`refuse`, with reasons and a boundary-register flag. That's Orion choosing whether and how to engage with a given turn, and until this patch it had zero representation anywhere in the substrate ladder.

## Outcome moved

`chat_grammar_consumer` will advance again on real unified-turn traffic. The substrate ladder gains a genuinely new signal (self-regulatory/boundary decisions) it never had before, captured for every turn including the ones Orion declines to engage with — not just the ones that reach a successful answer.

## Current architecture

Five things confirmed by reading the actual code, not inferring from logs:
1. `websocket_endpoint` in `websocket_handler.py` routes `orion` mode + `ORION_UNIFIED_TURN_ENABLED=true` to `run_unified_turn` → `execute_unified_turn`, with an explicit `continue` — never reaching the classic path's `build_chat_request`/grammar-emit block further down in the same function.
2. The classic path's grammar-emit block (`services/orion-hub/scripts/websocket_handler.py` ~line 1136) is still live code for other client modes — not dead, not deleted here.
3. `execute_unified_turn` has a real Thought-stance gate: `ThoughtClient(bus).react(...)` → `thought.disposition in ("proceed", "defer", "refuse")`, with `defer`/`refuse` returning early before any harness call.
4. `orion-harness-governor` (the service that runs the actual FCC motor/finalize chain for unified turns) is already a registered producer on the `execution_trajectory` reducer (`cortex.exec:` prefix) — so step/plan mechanics for unified turns are already captured elsewhere in the ladder. This patch deliberately does not duplicate that; it only covers the conversational-envelope + stance layer, which is `chat_grammar`'s actual scope.
5. `orion/substrate/chat_loop/grammar_extract.py::extract_chat_turn_state` recognized exactly three semantic roles (`user_utterance`, `repair_signal`, `session_context`) and `ChatTurnStateV1` had no field to hold a stance fact even if one were emitted — a new atom without reducer + schema support would have been an "empty-shell" addition, present in the raw event log but invisible in the materialized projection.

## Architecture touched

- `orion/hub/turn_orchestrator.py` — new `_publish_unified_turn_chat_grammar` helper, called at all three of `execute_unified_turn`'s stance-resolution exit points (stance-RPC-timeout, defer/refuse, proceed).
- `services/orion-hub/scripts/grammar_emit.py` — `build_chat_turn_grammar_events` extended with an optional `stance_disposition` atom + edge, mirroring the existing `repair_signal` atom's conditional-emission pattern exactly.
- `orion/substrate/chat_loop/grammar_extract.py` + `orion/schemas/chat_projection.py` — reducer-side parsing and `ChatTurnStateV1` schema extension so the new atom is actually materialized, not just logged.

## Files changed

- `orion/hub/turn_orchestrator.py` — `_publish_unified_turn_chat_grammar` (async, awaited directly — not scheduled as a background task, unlike the classic path's `_schedule_publish`, because this file's own established convention already awaits its other publish calls (`publish_chat_history`, `publish_chat_turn`) directly, and the added latency of one lightweight bus publish is negligible next to the harness governor call it precedes). Wired at all 3 exit points so `defer`/`refuse` turns are captured, not just successful ones.
- `services/orion-hub/scripts/grammar_emit.py` — `stance_disposition`/`stance_disposition_reasons`/`stance_boundary_register` params; new optional atom (`semantic_role="stance_disposition"`, `layer="organ_signal"`, `atom_type="signal"`, `text_value` holds the disposition string directly — mirroring `session_context`'s pattern of using a structured field rather than regex, since disposition is a small enum with no privacy concern) plus a `derived_from` edge to `user_utterance`, matching `repair_signal`'s existing edge pattern.
- `orion/substrate/chat_loop/grammar_extract.py` — parses the new atom (`text_value` for disposition, a light regex for the parenthetical reasons list, a literal substring check for `[boundary_register]`) into the three new state fields.
- `orion/schemas/chat_projection.py` — `ChatTurnStateV1` gains `stance_disposition: str = "unknown"`, `stance_disposition_reasons: list[str] = []`, `stance_boundary_register: bool = False`. Additive with defaults — backward-compatible with existing stored `ChatSessionProjectionV1` rows (JSONB, no migration needed).
- `services/orion-hub/tests/test_hub_grammar_emit.py` — 3 new tests: stance atom absent when not provided, present with correct summary/text_value when provided, edge links to `user_utterance`.
- `services/orion-hub/tests/test_turn_orchestrator_ws_frames.py` — 3 new tests directly exercising `_publish_unified_turn_chat_grammar`: no-op when `PUBLISH_HUB_CHAT_GRAMMAR` is off, stance fields carried through to the built events when on (plus confirms `user_utterance.text_value is None` — raw text never stored), and fail-open on a publish exception.
- `tests/test_chat_substrate_reducer.py` — 3 new tests for `extract_chat_turn_state`'s new parsing: stance present with reasons + boundary register, defaults to `"unknown"` when the atom is absent, no-reasons case doesn't choke on the word-count atom's own parentheses (`"(N words)"`) since role-gating happens before the reasons regex runs.
- `services/orion-hub/README.md` — new subsection under "Chat & Cognition" documenting the unified-turn grammar trace, right after the existing repair-pressure documentation since they're now emitted together.

## Schema / bus / API changes

- Added: `ChatTurnStateV1.stance_disposition`/`stance_disposition_reasons`/`stance_boundary_register` (additive, defaulted).
- Added: `stance_disposition` semantic role on the existing `hub.chat:` grammar trace (no new atom_type, no new event_kind — `"signal"`/`"atom_emitted"` already existed in the schema's enums).
- No new channel, no new cursor, no new reducer, no new env key, no migration.
- Compatibility: fully additive on both the producer and consumer side. Existing consumers of `ChatTurnStateV1` that don't know about the new fields are unaffected (`model_config = ConfigDict(extra="forbid")` only forbids *unexpected* extra keys on incoming data, not missing-with-default fields).

## Env/config changes

None. Reuses the existing `PUBLISH_HUB_CHAT_GRAMMAR` flag (default `true`) and `GRAMMAR_EVENT_CHANNEL`.

## Tests run

```
cd /mnt/scripts/Orion-Sapienform-unified-turn-grammar
/tmp/orion-test-venv/bin/python -m pytest services/orion-hub/tests/test_hub_grammar_emit.py services/orion-hub/tests/test_turn_orchestrator_ws_frames.py tests/test_chat_substrate_reducer.py -q -W ignore::UserWarning -W ignore::DeprecationWarning
→ 34 passed, 8 failed
```
All 8 failures verified pre-existing via `git stash` comparison against unmodified `origin/main` — identical failure set either way (`AttributeError: 'ThoughtEventV1' object has no attribute 'thought'`, a stale test-mock fixture in `_hub_client_patches` that returns a bare `ThoughtEventV1` instead of the `ThoughtReactResult` wrapper `ThoughtClient.react()` actually returns — a real bug in the test suite, not something this patch touches or introduces). Because those existing fixtures were broken, my new `turn_orchestrator.py`-level tests call `_publish_unified_turn_chat_grammar` directly (bypassing the broken `ThoughtClient`/`HarnessGovernorClient` mock chain) rather than through the full `execute_unified_turn` integration path — still exercises the real code, just at the seam that's actually testable in this environment.

## Evals run

No eval harness exists for hub's chat-grammar production.

## Docker/build/smoke checks

None run — no env/compose changes in this patch, nothing to validate at that layer.

## Review findings fixed

None from an external review pass; self-caught during implementation:
- Initial draft scheduled the grammar publish as a fire-and-forget background task (mirroring `websocket_handler.py`'s `_schedule_publish`) to avoid adding latency ahead of the harness dispatch. Reconsidered: this file's own convention already awaits its other publish calls directly, the latency of one bus publish is negligible next to the harness governor call, and fire-and-forget against `MagicMock()` (non-async) test buses produces orphaned background tasks that fail silently — worse for testability with no real latency benefit. Switched to awaiting directly before writing any tests.

## Restart required

```bash
# Hub picks this up on its next normal restart/redeploy -- no new env keys, no migration.
docker compose --env-file .env --env-file services/orion-hub/.env -f services/orion-hub/docker-compose.yml up -d --build
```
Confirm the cursor is advancing again post-restart:
```bash
curl -fsS http://localhost:8115/grammar/truth | python3 -c "import json,sys; d=json.load(sys.stdin); print([r for r in d['cursor_positions'] if r['cursor_name']=='chat_grammar_consumer'])"
```

## Risks / concerns

- Severity: low. `repair_pressure_grammar_scalars(pre_turn_bundle=repair_bundle, substrate_summary=None)` is called with `substrate_summary` always `None` in the unified-turn path, since `execute_unified_turn` only ever has `repair_bundle` (`TurnAppraisalBundleV1 | None`) in scope, not a separate `substrate_summary` dict the way the classic path does. Confirmed the helper's implementation checks `pre_turn_bundle` first and only falls back to `substrate_summary`, so this is correct, not a gap — noting it because it's the one place the unified-turn call site's available data differs slightly from the classic path's.
- Severity: none (informational). The `_STANCE_REASONS_RE = re.compile(r"\((.*?)\)")` regex used in `grammar_extract.py` is intentionally non-greedy and scoped by the `role == "stance_disposition"` gate before it ever runs, so it doesn't collide with `user_utterance`'s own `(N words)` parenthetical on the same atom set — verified with a dedicated test (`test_extract_stance_disposition_no_reasons_no_parens_in_summary`).
