### PR TITLE
Fix/world pulse nasa hardware category

### DIFF
--- a/config/world_pulse/sources.yaml
+++ b/config/world_pulse/sources.yaml
@@ -204,7 +204,7 @@ sources:
     url: https://www.nasa.gov/news-release/feed/
     domains: ["www.nasa.gov", "nasa.gov"]
     allowed_path_prefixes: ["/news-release/"]
-    categories: ["science_climate_energy", "hardware_compute_gpu"]
+    categories: ["science_climate_energy"]
     region_scope: science
     trust_tier: 1
     factuality: high

--- a/docs/superpowers/pr-reports/2026-07-13-world-pulse-nasa-hardware-category-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-world-pulse-nasa-hardware-category-pr.md
@@ -1,0 +1,81 @@
+## Summary
+
+- Root-caused a silent regression in World Pulse's "curiosity autonomy": `hardware_compute_gpu` (a `recommended` digest section) has permanently shown `status="covered"` since 2026-07-09 20:17 UTC, which suppressed the live-search gap-fill (`build_curiosity_followups`) that's supposed to fire when a section has zero accepted articles.
+- Confirmed via the `world_pulse_article`/`world_pulse_digest` tables in the `conjourney` Postgres DB that every article ever counted toward `hardware_compute_gpu` coverage was a `nasa_news` press release (launches, contract awards, Mars missions) — never actual GPU/hardware/compute content.
+- `nasa_news` was the only source in `config/world_pulse/sources.yaml` tagged with `hardware_compute_gpu` (alongside its correct `science_climate_energy` tag). Since NASA publishes near-daily, `_compute_coverage()`'s rule — a section is `covered` if `digest_count > 0 or accepted_articles > 0`, with no topical check — has marked the section covered on every run since, killing a gap-fill that fired ~22 times historically before that.
+- Fix: drop the `hardware_compute_gpu` tag from `nasa_news`. Bare fix per explicit decision — no replacement source added. `hardware_compute_gpu` now has zero passive sources and relies entirely on the curiosity gap-fill firing on every run where it's uncovered.
+- Added a regression test that loads the real `sources.yaml` and asserts no source tagged `hardware_compute_gpu` matches the known off-topic `nasa_news` source_id/domain. Documented the zero-source tradeoff in `docs/world_pulse_dev.md` so nobody "fixes" the resulting gap by re-tagging an off-topic source.
+
+## Outcome moved
+
+`hardware_compute_gpu` stops being permanently (and silently) marked covered by off-topic NASA press releases. The section will now correctly show `missing`/`no_articles` when it has no genuine hardware/GPU content, which re-enables the curiosity live-search gap-fill (`build_curiosity_followups`) and its downstream fold into the daily journal ("Orion went looking...", via `merge_world_pulse_curiosity_into_draft` in `orion/journaler/worker.py`).
+
+## Current architecture
+
+`services/orion-world-pulse`'s pipeline (`app/services/pipeline.py`) computes per-section coverage in `_compute_coverage()`, then calls `build_curiosity_followups()` (`app/services/curiosity.py`) for any section not `status="covered"`, up to `world_pulse_curiosity_max_sections`. Findings are attached to `digest.curiosity_followups`, rendered in the plaintext/hub digest (`app/services/renderers.py`), and — for the journal path — either included by the LLM compose step or deterministically appended by `merge_world_pulse_curiosity_into_draft` if the LLM omitted them. None of that machinery was broken; it simply never had a genuine gap to fill because `hardware_compute_gpu` looked "covered" every run.
+
+## Architecture touched
+
+`config/world_pulse/sources.yaml` only (source-category data). No schema, bus, Docker, or env changes.
+
+## Files changed
+
+- `config/world_pulse/sources.yaml`: `nasa_news.categories` changed from `["science_climate_energy", "hardware_compute_gpu"]` to `["science_climate_energy"]`.
+- `docs/world_pulse_dev.md`: added a "Known zero-source sections" note explaining `hardware_compute_gpu` has zero passive sources as of 2026-07-13, why, and that this is an accepted, intentional tradeoff — not a bug to "fix" by re-tagging an off-topic source.
+- `services/orion-world-pulse/tests/test_source_registry_config.py` (new): loads the real `sources.yaml` via `load_source_registry()` and asserts (1) `nasa_news` no longer carries `hardware_compute_gpu`, (2) no source tagged `hardware_compute_gpu` matches the known off-topic `nasa_news` source_id/domain.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None. Pure source-registry YAML data change — no `.env`/`.env_example` keys added, removed, or renamed.
+
+## Tests run
+
+```text
+/mnt/scripts/Orion-Sapienform/.venv-world-pulse/bin/python -m pytest services/orion-world-pulse/tests -q
+72 passed, 15 warnings in 2.65s   (70 pre-existing + 2 new)
+```
+
+Verified the new tests are a real regression guard by temporarily reverting the `sources.yaml` change and re-running: both new tests failed as expected. Re-applied the fix; full suite green.
+
+## Evals run
+
+None applicable — this is a source-registry data fix, not a model or ranking change. No eval harness exists for `orion-world-pulse` source-category correctness; a topical-relevance eval (e.g. flagging sources whose categories don't match their actual content) would be a reasonable follow-up but is out of scope for this bare fix.
+
+## Docker/build/smoke checks
+
+Not rebuilt/deployed this session. `config/world_pulse/sources.yaml` is baked into the `orion-world-pulse` image at build time (`COPY config/world_pulse /app/config/world_pulse` in the Dockerfile), so the fix has no runtime effect until the image is rebuilt and the container restarted — see Restart required below.
+
+## Review findings fixed
+
+Diff-scoped correctness review performed: traced every `hardware_compute_gpu` reference repo-wide via `rg` to confirm no other coupling to `nasa_news` exists. All other hits are synthetic test fixtures (`orion/autonomy`, `orion/spark/concept_induction`, `orion/substrate` tests) and unrelated design docs — none reference the real source registry. No material findings.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-world-pulse/.env \
+  -f services/orion-world-pulse/docker-compose.yml \
+  up -d --build
+
+curl -fsS http://localhost:8628/health
+```
+
+Required for this fix to take effect on the live system — `sources.yaml` is read at image-build time, not at runtime, so the currently-running container will keep mistagging `nasa_news` until rebuilt.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `hardware_compute_gpu` now has zero passive sources and depends entirely on the curiosity live-search gap-fill firing every run it's uncovered — this means a live web-fetch call (via `resolve_fetch_backend()`) on every digest run instead of only when a stable feed goes quiet, with associated cost/rate-limit exposure on whatever fetch backend is configured (Firecrawl per `.fcc` mount).
+- Mitigation: this is the user's explicit choice (declined the alternative of adding a real GPU/hardware RSS source); the fetch is capability-gated (`web.fetch.readonly`, `budget_per_cycle: 2` in `config/autonomy/capability_policy.v1.yaml`) and degrades gracefully to an empty followup on any fetch/mapping failure (never fails the run). Documented in `docs/world_pulse_dev.md` as an accepted tradeoff.
+- Severity: low
+- Concern: every journal/digest email sent between 2026-07-09 20:17 UTC and this fix's deployment went out without the GPU gap-fill it should have had — unrecoverable, content already sent.
+- Mitigation: none possible retroactively; going forward, once deployed, the next run with a genuine `hardware_compute_gpu` gap will trigger curiosity correctly. Recommend a live smoke run post-deploy to confirm end-to-end (coverage → gate → fetch → journal merge) before considering this closed.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/world-pulse-nasa-hardware-category

--- a/docs/world_pulse_dev.md
+++ b/docs/world_pulse_dev.md
@@ -91,6 +91,12 @@ ACTIONS_WORLD_PULSE_ENABLED=false
 - Keep `required: false` during expansion unless the source is operationally critical and stable.
 - If a source fails in this environment, set `enabled: false` with a clear `notes` entry instead of deleting it.
 
+## Known zero-source sections
+
+- `hardware_compute_gpu` (a `recommended`, not `required`, section) has zero passive/RSS sources tagged to it as of 2026-07-13.
+- `nasa_news` previously carried a `hardware_compute_gpu` tag alongside `science_climate_energy`, but NASA press releases (launches, contract awards, Mars missions) are not GPU/hardware/compute content. Since NASA publishes near-daily, that mistagging permanently marked the section `covered` and silently suppressed the curiosity gap-fill (see `_compute_coverage` in `app/services/pipeline.py`) for months. The tag was removed; do not re-add `nasa_news` (or any other off-topic source) to `hardware_compute_gpu` to "fix" the resulting gap.
+- This is an accepted, intentional tradeoff: `hardware_compute_gpu` now relies entirely on the curiosity live-search gap-fill (`build_curiosity_followups` in `app/services/curiosity.py`) firing on every run where the section has zero accepted articles, instead of on a passive feed. Do not add a replacement source for this section without an explicit decision to do so.
+
 ## Source quality guidance
 
 - Prefer official/public-interest sources, wire-style reporting, and stable metadata-rich feeds.

--- a/services/orion-world-pulse/tests/test_source_registry_config.py
+++ b/services/orion-world-pulse/tests/test_source_registry_config.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.source_registry import load_source_registry
+
+# Repo root: services/orion-world-pulse/tests/.. /.. /..
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SOURCES_YAML = REPO_ROOT / "config" / "world_pulse" / "sources.yaml"
+
+# Regression guard: nasa_news was mistagged with hardware_compute_gpu even though
+# NASA press releases (launches, contract awards, Mars missions) have nothing to
+# do with GPU/hardware/compute tech. Because NASA publishes near-daily, that tag
+# permanently marked hardware_compute_gpu as "covered" and silently suppressed
+# the curiosity gap-fill (`build_curiosity_followups`) for that section for
+# months. Do not re-add nasa_news, or any other off-topic source, to this
+# category.
+KNOWN_OFF_TOPIC_SOURCE_IDS_FOR_HARDWARE_COMPUTE_GPU = {"nasa_news"}
+KNOWN_OFF_TOPIC_DOMAINS_FOR_HARDWARE_COMPUTE_GPU = {"nasa.gov", "www.nasa.gov"}
+
+
+def _load_real_registry():
+    return load_source_registry(str(SOURCES_YAML))
+
+
+def test_nasa_news_is_not_tagged_hardware_compute_gpu():
+    registry = _load_real_registry()
+    nasa_sources = [s for s in registry.sources if s.source_id == "nasa_news"]
+    assert nasa_sources, "expected nasa_news source to exist in sources.yaml"
+    for source in nasa_sources:
+        assert "hardware_compute_gpu" not in source.categories, (
+            "nasa_news must not be tagged hardware_compute_gpu: NASA press "
+            "releases are not GPU/hardware/compute content, and NASA's "
+            "near-daily publication cadence permanently masks the curiosity "
+            "gap-fill for this section (see docs/world_pulse_dev.md, "
+            "'Known zero-source sections')."
+        )
+
+
+def test_no_known_off_topic_source_tagged_hardware_compute_gpu():
+    """Thin regression guard, not a topic classifier.
+
+    Asserts that none of the sources currently tagged hardware_compute_gpu
+    match the known off-topic source_id/domain set that previously caused a
+    months-long silent suppression of the curiosity gap-fill for this
+    section. This intentionally does not attempt to judge topical relevance
+    for arbitrary future sources.
+    """
+    registry = _load_real_registry()
+    tagged = [s for s in registry.sources if "hardware_compute_gpu" in s.categories]
+    for source in tagged:
+        assert source.source_id not in KNOWN_OFF_TOPIC_SOURCE_IDS_FOR_HARDWARE_COMPUTE_GPU, (
+            f"source {source.source_id!r} is a known off-topic source for "
+            "hardware_compute_gpu and must not be re-tagged"
+        )
+        off_topic_domains = set(source.domains) & KNOWN_OFF_TOPIC_DOMAINS_FOR_HARDWARE_COMPUTE_GPU
+        assert not off_topic_domains, (
+            f"source {source.source_id!r} has known off-topic domain(s) "
+            f"{off_topic_domains} for hardware_compute_gpu"
+        )


### PR DESCRIPTION
## Summary

- Root-caused a silent regression in World Pulse's "curiosity autonomy": `hardware_compute_gpu` (a `recommended` digest section) has permanently shown `status="covered"` since 2026-07-09 20:17 UTC, which suppressed the live-search gap-fill (`build_curiosity_followups`) that's supposed to fire when a section has zero accepted articles.
- Confirmed via the `world_pulse_article`/`world_pulse_digest` tables in the `conjourney` Postgres DB that every article ever counted toward `hardware_compute_gpu` coverage was a `nasa_news` press release (launches, contract awards, Mars missions) — never actual GPU/hardware/compute content.
- `nasa_news` was the only source in `config/world_pulse/sources.yaml` tagged with `hardware_compute_gpu` (alongside its correct `science_climate_energy` tag). Since NASA publishes near-daily, `_compute_coverage()`'s rule — a section is `covered` if `digest_count > 0 or accepted_articles > 0`, with no topical check — has marked the section covered on every run since, killing a gap-fill that fired ~22 times historically before that.
- Fix: drop the `hardware_compute_gpu` tag from `nasa_news`. Bare fix per explicit decision — no replacement source added. `hardware_compute_gpu` now has zero passive sources and relies entirely on the curiosity gap-fill firing on every run where it's uncovered.
- Added a regression test that loads the real `sources.yaml` and asserts no source tagged `hardware_compute_gpu` matches the known off-topic `nasa_news` source_id/domain. Documented the zero-source tradeoff in `docs/world_pulse_dev.md` so nobody "fixes" the resulting gap by re-tagging an off-topic source.

## Outcome moved

`hardware_compute_gpu` stops being permanently (and silently) marked covered by off-topic NASA press releases. The section will now correctly show `missing`/`no_articles` when it has no genuine hardware/GPU content, which re-enables the curiosity live-search gap-fill (`build_curiosity_followups`) and its downstream fold into the daily journal ("Orion went looking...", via `merge_world_pulse_curiosity_into_draft` in `orion/journaler/worker.py`).

## Current architecture

`services/orion-world-pulse`'s pipeline (`app/services/pipeline.py`) computes per-section coverage in `_compute_coverage()`, then calls `build_curiosity_followups()` (`app/services/curiosity.py`) for any section not `status="covered"`, up to `world_pulse_curiosity_max_sections`. Findings are attached to `digest.curiosity_followups`, rendered in the plaintext/hub digest (`app/services/renderers.py`), and — for the journal path — either included by the LLM compose step or deterministically appended by `merge_world_pulse_curiosity_into_draft` if the LLM omitted them. None of that machinery was broken; it simply never had a genuine gap to fill because `hardware_compute_gpu` looked "covered" every run.

## Architecture touched

`config/world_pulse/sources.yaml` only (source-category data). No schema, bus, Docker, or env changes.

## Files changed

- `config/world_pulse/sources.yaml`: `nasa_news.categories` changed from `["science_climate_energy", "hardware_compute_gpu"]` to `["science_climate_energy"]`.
- `docs/world_pulse_dev.md`: added a "Known zero-source sections" note explaining `hardware_compute_gpu` has zero passive sources as of 2026-07-13, why, and that this is an accepted, intentional tradeoff — not a bug to "fix" by re-tagging an off-topic source.
- `services/orion-world-pulse/tests/test_source_registry_config.py` (new): loads the real `sources.yaml` via `load_source_registry()` and asserts (1) `nasa_news` no longer carries `hardware_compute_gpu`, (2) no source tagged `hardware_compute_gpu` matches the known off-topic `nasa_news` source_id/domain.

## Schema / bus / API changes

None.

## Env/config changes

None. Pure source-registry YAML data change — no `.env`/`.env_example` keys added, removed, or renamed.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/.venv-world-pulse/bin/python -m pytest services/orion-world-pulse/tests -q
72 passed, 15 warnings in 2.65s   (70 pre-existing + 2 new)
```

Verified the new tests are a real regression guard by temporarily reverting the `sources.yaml` change and re-running: both new tests failed as expected. Re-applied the fix; full suite green.

## Evals run

None applicable — this is a source-registry data fix, not a model or ranking change. No eval harness exists for `orion-world-pulse` source-category correctness; a topical-relevance eval (e.g. flagging sources whose categories don't match their actual content) would be a reasonable follow-up but is out of scope for this bare fix.

## Docker/build/smoke checks

Not rebuilt/deployed this session. `config/world_pulse/sources.yaml` is baked into the `orion-world-pulse` image at build time (`COPY config/world_pulse /app/config/world_pulse` in the Dockerfile), so the fix has no runtime effect until the image is rebuilt and the container restarted — see Restart required below.

## Review findings fixed

Diff-scoped correctness review performed: traced every `hardware_compute_gpu` reference repo-wide via `rg` to confirm no other coupling to `nasa_news` exists. All other hits are synthetic test fixtures (`orion/autonomy`, `orion/spark/concept_induction`, `orion/substrate` tests) and unrelated design docs — none reference the real source registry. No material findings.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-world-pulse/.env \
  -f services/orion-world-pulse/docker-compose.yml \
  up -d --build

curl -fsS http://localhost:8628/health
```

Required for this fix to take effect on the live system — `sources.yaml` is read at image-build time, not at runtime, so the currently-running container will keep mistagging `nasa_news` until rebuilt.

## Risks / concerns

- Severity: low
- Concern: `hardware_compute_gpu` now has zero passive sources and depends entirely on the curiosity live-search gap-fill firing every run it's uncovered — this means a live web-fetch call (via `resolve_fetch_backend()`) on every digest run instead of only when a stable feed goes quiet, with associated cost/rate-limit exposure on whatever fetch backend is configured (Firecrawl per `.fcc` mount).
- Mitigation: this is the user's explicit choice (declined the alternative of adding a real GPU/hardware RSS source); the fetch is capability-gated (`web.fetch.readonly`, `budget_per_cycle: 2` in `config/autonomy/capability_policy.v1.yaml`) and degrades gracefully to an empty followup on any fetch/mapping failure (never fails the run). Documented in `docs/world_pulse_dev.md` as an accepted tradeoff.
- Severity: low
- Concern: every journal/digest email sent between 2026-07-09 20:17 UTC and this fix's deployment went out without the GPU gap-fill it should have had — unrecoverable, content already sent.
- Mitigation: none possible retroactively; going forward, once deployed, the next run with a genuine `hardware_compute_gpu` gap will trigger curiosity correctly. Recommend a live smoke run post-deploy to confirm end-to-end (coverage → gate → fetch → journal merge) before considering this closed.