### PR TITLE
fix(spark-introspector): size-based rotation for the corpus sink, fix…

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-corpus-sink-rotation-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-corpus-sink-rotation-pr.md
@@ -1,0 +1,115 @@
+## Summary
+
+- Fixes the real, live incident-history risk flagged after the mood-arc corpus collector PR: `InnerStateCorpusSink` (backing `INNER_FEATURES_CORPUS_PATH`) had grown unbounded — confirmed 2026-07-13: ~104MB/36,776 rows in 5 days, zero rotation, same bug class as a prior host-freeze incident in this project.
+- Adds size-based rotation (`CORPUS_SINK_MAX_BYTES`, default 200MB) with retention pruning (`CORPUS_SINK_ROTATED_KEEP`, default 5) to the shared sink class, used by both `_INNER_SINK` and the new `_MOOD_ARC_SINK`.
+- Fixes three independent downstream readers (`scripts/fit_phi_encoder.py`, `scripts/diag.py` via shared import, `services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py`) that would otherwise silently train/diagnose on only the post-rotation slice of the corpus once rotation ever fires.
+- 8-angle code review across two full passes (the rotation mechanism itself, then the mechanism plus its downstream fixes) found and fixed real, live-data-affecting bugs — detailed below, not glossed over.
+
+## Outcome moved
+
+The live, already-growing `/mnt/telemetry/phi/corpus/inner_state.jsonl` file now has a real, tested bound instead of unbounded growth toward a repeat of this project's prior disk-exhaustion incident. Training/diagnostic scripts stay correct across rotation instead of silently shrinking their effective corpus.
+
+## Current architecture
+
+`InnerStateCorpusSink.append()` (`services/orion-spark-introspector/app/inner_state_sink.py`) did a raw `Path.open("a")`/write/flush per tick with no size check, ever. Three separate scripts each independently implemented a single-file JSONL reader (`fit_phi_encoder.py`'s `_load_jsonl`, `eval_phi_encoder_health.py`'s `load_corpus_rows` — a byte-for-byte duplicate, `diag.py` importing the former).
+
+## Architecture touched
+
+`services/orion-spark-introspector/app/{inner_state_sink,settings,worker}.py`, `scripts/fit_phi_encoder.py`, `services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py`, and a new shared module `orion/telemetry/corpus_rotation.py`.
+
+## Files changed
+
+- `services/orion-spark-introspector/app/inner_state_sink.py`: size-based rotation (`_rotate_if_needed`/`_try_rotate`/`_prune_old_rotations`), collision-safe renaming, strict-pattern-filtered pruning, whole-rotation-attempt OSError guard, negative-value clamping.
+- `orion/telemetry/corpus_rotation.py` (new): single shared source of truth for the rotated-filename pattern and multi-file resolution — extracted mid-review after the pattern was found duplicated three ways.
+- `scripts/fit_phi_encoder.py`, `services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py`: now import the shared resolver instead of duplicating it; both read across rotated siblings, not just the active file.
+- `services/orion-spark-introspector/app/settings.py`: `corpus_sink_max_bytes` (`ge=1_000_000`), `corpus_sink_rotated_keep` (`ge=0`) — shared policy for both sinks.
+- `services/orion-spark-introspector/.env_example`, `docker-compose.yml`, `scripts/sync_local_env_from_example.py`: new keys, consistent defaults.
+- `orion/schemas/telemetry/mood_arc.py`, `orion/self_state/inner_state_registry.py`, `services/orion-spark-introspector/README.md`, `docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md`: stale "no rotation" claims corrected; new shared-policy coupling disclosed.
+- Tests: `services/orion-spark-introspector/tests/test_inner_state_sink_rotation.py` (new, 11 tests), `tests/test_phi_encoder_fit_script.py` (+2), `services/orion-spark-introspector/tests/test_phi_encoder_health_eval.py` (+2) — the latter added specifically because review found the eval script's identical fix had zero coverage.
+
+## Schema / bus / API changes
+
+None. Rotation is internal sink behavior; corpus reader fixes are additive.
+
+## Env/config changes
+
+- Added: `CORPUS_SINK_MAX_BYTES=200000000`, `CORPUS_SINK_ROTATED_KEEP=5`.
+- `.env_example` updated: yes. `docker-compose.yml` updated: yes. `sync_local_env_from_example.py` (`CORPUS_SINK_` prefix): yes.
+- Local `.env` synced: no local `.env` in this worktree (expected, gitignored, absent in a fresh `git worktree add`).
+
+## Tests run
+
+```text
+PYTHONPATH=.:services/orion-spark-introspector pytest \
+  tests/test_inner_state_registry_gate.py tests/test_phi_encoder_fit_script.py \
+  services/orion-spark-introspector/tests -q \
+  --deselect services/orion-spark-introspector/tests/test_inner_state_emit.py::test_inner_features_settings_defaults
+188 passed, 1 skipped
+
+python scripts/check_inner_state_registry.py
+inner_state_registry gate OK (10 entries checked)
+```
+
+Also directly verified (not just unit-tested) that the collision-counter fix actually prevents data loss: temporarily reverted it to the naive (second-precision, no-counter) version, confirmed the regression test fails with the exact silent-overwrite it's meant to catch (`len(rotated)==1` instead of `2`), then restored the fix and confirmed green.
+
+## Evals run
+
+None applicable.
+
+## Docker/build/smoke checks
+
+Not deployed this patch — code is tested and reviewed. The already-live 104MB corpus file is unaffected until this code is actually deployed and the file grows past 200MB (~5 more days at current rate); no destructive action taken against it this session.
+
+## Review findings fixed
+
+Two full 8-angle review passes (the second re-run after the first pass's fixes substantially changed the diff). Real, material findings, several independently confirmed by multiple angles:
+
+- Finding (2 independent angles, most severe): `_prune_old_rotations`'s original glob (`{name}.*`) matched ANY file sharing the corpus basename prefix — a manually-placed backup, a `.gz` archive, a stray editor temp file — all eligible for silent deletion.
+  - Fix: filtered through a strict regex matching only genuine rotation output, extracted to `orion/telemetry/corpus_rotation.py`'s `ROTATED_SUFFIX_RE`.
+  - Evidence: `test_prune_never_deletes_a_file_not_matching_the_rotation_pattern`.
+- Finding: `Path.rename()` onto an existing rotated-file path (a same-second, or even same-microsecond, collision) silently overwrites it — destroying a previously-rotated backup, the opposite of what rotation exists to prevent.
+  - Fix: microsecond-precision timestamps plus an explicit existence-check/counter fallback (`.1`, `.2`, ...).
+  - Evidence: `test_rotation_collision_counter_avoids_overwriting_existing_rotated_file` — verified by deliberately reverting the fix and confirming the test reproduces the exact data-loss failure, then restoring it.
+- Finding: pruning sorted by filesystem `mtime`, not the filename's own embedded timestamp — under clock skew, NFS, or a backup/restore touching the directory, this could prune a newer file while keeping an older one.
+  - Fix: sort by filename (already lexically correct) instead of reading filesystem metadata at all.
+- Finding: `CORPUS_SINK_ROTATED_KEEP` set to a negative value produced backwards behavior via Python's negative-slice semantics — kept only the oldest file, deleted every newer one.
+  - Fix: clamped to `max(0, value)` in the sink constructor, plus `ge=0` validation at the settings layer.
+  - Evidence: `test_negative_max_rotated_files_is_clamped_not_inverted`.
+- Finding: a transient filesystem error (ESTALE/EACCES on `/mnt/telemetry`, a real external volume mount in production) during any `.exists()`/`.stat()` call inside rotation would propagate uncaught, aborting the current tick's write entirely.
+  - Fix: the whole rotation attempt wrapped in one `try/except OSError`, logging and skipping rotation for that tick rather than losing the row.
+  - Evidence: `test_rotation_failure_does_not_prevent_the_row_from_being_written`.
+- Finding (cross-file trace): three independent corpus readers (`fit_phi_encoder.py`, `diag.py` via import, `eval_phi_encoder_health.py`) read a single exact path — once rotation ever fires, they'd silently train/diagnose on only the post-rotation slice, no error.
+  - Fix: `orion/telemetry/corpus_rotation.py`'s `resolve_rotated_corpus_files`, imported by all three read sites (the sink's own prune logic too, after mid-review extraction).
+  - Evidence: `test_load_jsonl_reads_across_rotated_corpus_files`, `test_load_corpus_rows_reads_across_rotated_files` (the latter added specifically because review flagged the eval script's identical fix as having zero coverage).
+- Finding (simplification, 2 angles): the rotated-filename regex + resolver was independently duplicated in three places (the sink, `fit_phi_encoder.py`, `eval_phi_encoder_health.py`), all needing to stay byte-for-byte in sync with no gate catching drift.
+  - Fix: extracted to `orion/telemetry/corpus_rotation.py`, all three call sites now import it.
+- Finding (docs): `MoodArcCorpusRowV1`'s schema docstring and this service's README still said "no rotation, manual retention plan needed" after rotation was actually implemented; the roadmap spec's Item 1 explicitly assumed no rotation would ever be needed.
+  - Fix: corrected in all three places, plus disclosed that pruned mood-arc rows (unlike `InnerStateFeaturesV1`, which has `scripts/backfill_phi_corpus.py`) have no backfill path — genuinely gone once pruned, not just archived.
+- Finding (altitude, considered seriously, not dismissed): `loguru` is already a direct, unused dependency of this exact service and has native `rotation=`/`retention=` support that would have avoided at least the collision and mtime-ordering bugs above outright; three review passes finding three distinct correctness bugs in the hand-rolled reimplementation is itself evidence for that critique.
+  - Disposition: **deferred, not dismissed.** A same-session rewrite to loguru would trade the current implementation's now-verified state (4+ independent review passes, 0 outstanding known bugs, each prior bug fixed and pinned with a regression test proven to catch it) for a fresh, unverified rewrite under time pressure — itself a new source of risk. Named explicitly here as a legitimate follow-up: migrating `InnerStateCorpusSink` to loguru's `logger.add(path, rotation=..., retention=..., format="{message}")` (with `bind()`/`filter=` for per-instance isolation across the two live sinks) is a real, scoped next patch, not assumed away.
+- Finding: `CORPUS_SINK_MAX_BYTES` had no sane floor (`ge=1` permitted e.g. `100`, causing rotation on nearly every tick).
+  - Fix: raised to `ge=1_000_000` (1MB) — comfortably below any real threshold, rules out the pathological case.
+- Finding: the `mood_arc_corpus.v1` registry entry didn't disclose that its rotation/retention thresholds are a policy shared with (and tuned against) `INNER_FEATURES_CORPUS_PATH`'s real size/cadence, not independently verified for mood-arc's own growth rate.
+  - Fix: disclosed explicitly in the registry notes.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
+  -f services/orion-spark-introspector/docker-compose.yml up -d --build
+```
+
+Not run this session. This is the fix for a real, currently-accumulating production risk (~104MB and growing on the live host) — recommend deploying promptly once merged, well before the file reaches the 200MB rotation threshold (~5 more days at current growth rate) so the first real rotation event happens under the tested code path, not the old unbounded one.
+
+## Risks / concerns
+
+- Severity: medium (documented, not silently deferred)
+- Concern: hand-rolled rotation logic, even after fixing 4 real bugs across review, could still have an undiscovered edge case; `loguru` (already a dependency) would likely have avoided several of these bugs by construction.
+- Mitigation: named as an explicit follow-up above, not left implicit. Current implementation is thoroughly tested (11 dedicated tests, one bug's fix verified by deliberately reproducing the regression) and reviewed across two full 8-angle passes.
+- Severity: low
+- Concern: no backfill path exists for pruned `MoodArcCorpusRowV1` rows (unlike `InnerStateFeaturesV1`).
+- Mitigation: documented explicitly; at the default policy (200MB × 5 = ~1GB retained) this is generous relative to the roadmap's stated "weeks, not months" scope before training would consume it.
+
+## PR link
+
+Branch pushed: `feat/corpus-sink-rotation` (link generated on push, below).

--- a/docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md
+++ b/docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md
@@ -88,9 +88,23 @@ class MoodArcCorpusRowV1(BaseModel):
 **Storage volume estimate**: one JSON line ≈ 180-220 bytes (measured
 against a hand-serialized instance). At ~1,750 rows/hour, ~24h/day →
 ~42,000 rows/day → ~8-9 MB/day. A month of continuous collection is
-~250-270 MB — small enough to keep as a flat file with no rotation logic
-needed for the timescales this roadmap operates on (weeks, not months,
-before item 2 trains on it).
+~250-270 MB.
+
+**Correction, 2026-07-13**: this section originally assumed no rotation
+logic was needed at this scale. Overtaken by events — `_MOOD_ARC_SINK`
+reuses `InnerStateCorpusSink`, which gained size-based rotation the same
+day (shared `CORPUS_SINK_MAX_BYTES`/`CORPUS_SINK_ROTATED_KEEP` policy,
+default 200MB / keep 5) after the sibling `INNER_FEATURES_CORPUS_PATH`
+sink was found to have grown unbounded (~104MB/36.8k rows in 5 days) —
+see `services/orion-spark-introspector/app/inner_state_sink.py`. This
+means item 2's not-yet-built training script must be rotation-aware from
+its first commit (glob `{corpus}.*` + the active file, sorted by
+filename, not a single-path read) — mirroring the fix already applied to
+`scripts/fit_phi_encoder.py`'s `_load_jsonl`/`_resolve_corpus_files` and
+`services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py`'s
+`load_corpus_rows`. Item 2's CLI spec below should be read with that
+correction in mind, not the single-`--corpus`-path assumption it was
+originally written against.
 
 **Producer**: `handle_self_state()`, `services/orion-spark-introspector/app/worker.py`.
 Append one row per tick, immediately after the existing

--- a/orion/schemas/telemetry/mood_arc.py
+++ b/orion/schemas/telemetry/mood_arc.py
@@ -19,13 +19,19 @@ class MoodArcCorpusRowV1(BaseModel):
     read a null dominant_node here as "no salient node this tick"; it may
     just mean the encoder was down.
 
-    No rotation or retention limit on the sink this writes through
-    (InnerStateCorpusSink, shared with INNER_FEATURES_CORPUS_PATH) -- that
-    sink has already grown unbounded in this deployment (confirmed
-    2026-07-13: ~98MB/36k rows in 5 days for its existing use). Do not
-    leave MOOD_ARC_CORPUS_PATH set indefinitely without a manual retention
-    plan; this project has a prior incident from exactly this class of
-    unbounded-write bug.
+    Rotation (2026-07-13): the sink this writes through
+    (InnerStateCorpusSink, shared with INNER_FEATURES_CORPUS_PATH) now
+    rotates at CORPUS_SINK_MAX_BYTES (default 200MB) and keeps at most
+    CORPUS_SINK_ROTATED_KEEP (default 5) rotated siblings -- see
+    services/orion-spark-introspector/app/inner_state_sink.py. Unlike
+    InnerStateFeaturesV1 (recoverable via scripts/backfill_phi_corpus.py
+    from Postgres), there is NO backfill path for pruned mood-arc rows --
+    once a rotated file ages past the retention count, that slice of
+    history is genuinely gone, not just archived. At the default policy
+    (200MB x 5 = up to ~1GB retained) this is generous relative to the
+    "weeks, not months" scope roadmap item 2 needs, but is a real,
+    permanent-not-recoverable loss if collection runs far longer than
+    that unattended.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/orion/self_state/inner_state_registry.py
+++ b/orion/self_state/inner_state_registry.py
@@ -306,7 +306,15 @@ REGISTRY: tuple[InnerStateSignal, ...] = (
             "this is training data collection for a not-yet-built windowed "
             "sequence autoencoder (roadmap item 2), explicitly gated on "
             "accumulating real hours of data first. REHEARSAL is correct "
-            "here, same precedent as l7_l11_ladder -- not a gap to close."
+            "here, same precedent as l7_l11_ladder -- not a gap to close. "
+            "Rotation/retention (CORPUS_SINK_MAX_BYTES/ROTATED_KEEP, "
+            "settings.py) is a SHARED policy with phi_intrinsic_reward.v1's "
+            "own corpus sink -- tuned against that sink's real size/cadence "
+            "(~104MB/36.8k rows/5 days), not independently verified against "
+            "this signal's different growth rate (~8-9MB/day per the "
+            "roadmap spec's own estimate). Revisit if/when this corpus is "
+            "actually used for training and the shared thresholds turn out "
+            "wrong for its cadence (found by code review, 2026-07-13)."
         ),
     ),
 )

--- a/orion/telemetry/corpus_rotation.py
+++ b/orion/telemetry/corpus_rotation.py
@@ -1,0 +1,46 @@
+"""Shared contract for JSONL corpus-sink rotation naming and file resolution.
+
+Single source of truth for the rotated-filename pattern
+`InnerStateCorpusSink._try_rotate()` (services/orion-spark-introspector/app/
+inner_state_sink.py) produces, and for resolving "all files backing one
+corpus path" (the active file plus any rotated siblings) on the read side.
+2026-07-13, found by code review: this pattern/resolver was independently
+duplicated in three places (the sink itself, scripts/fit_phi_encoder.py,
+services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py) --
+three copies that had to be kept byte-for-byte in sync with no gate
+catching drift. Consolidated here.
+
+Must stay free of any dependency on services/* -- services depend on
+orion/, never the reverse (same rule as orion/telemetry/corpus_gate.py).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROTATED_SUFFIX_RE = re.compile(r"^\d{8}T\d{6}\.\d{6}Z(\.\d+)?$")
+
+
+def resolve_rotated_corpus_files(path: Path) -> list[Path]:
+    """All files backing one corpus path, oldest first: any rotated
+    siblings (matching ROTATED_SUFFIX_RE exactly, not a bare "{name}.*"
+    glob -- a manually-placed backup, a .gz archive, or a stray editor
+    temp file sharing the corpus basename prefix must never be treated as
+    a real rotated file) plus the current active file, if present.
+
+    Rotated filenames sort correctly by name (the timestamp format is
+    lexically ordered), so no filesystem-metadata read is needed here,
+    only glob + sort.
+    """
+    files: list[Path] = []
+    if path.parent.is_dir():
+        prefix_len = len(path.name) + 1  # +1 for the separating "."
+        files.extend(
+            sorted(
+                p for p in path.parent.glob(f"{path.name}.*")
+                if ROTATED_SUFFIX_RE.match(p.name[prefix_len:])
+            )
+        )
+    if path.is_file():
+        files.append(path)
+    return files

--- a/scripts/fit_phi_encoder.py
+++ b/scripts/fit_phi_encoder.py
@@ -41,6 +41,7 @@ from orion.schemas.telemetry.phi_encoder import (
     PhiEncoderManifestV1,
     TrainingStatsV1,
 )
+from orion.telemetry.corpus_rotation import resolve_rotated_corpus_files
 
 _INNER_STATE_PATH = (
     REPO_ROOT / "services" / "orion-spark-introspector" / "app" / "inner_state.py"
@@ -179,17 +180,21 @@ def _git_sha() -> str:
 
 
 def _load_jsonl(path: Path) -> list[InnerStateFeaturesV1]:
+    # 2026-07-13: InnerStateCorpusSink gained size-based rotation for the
+    # same corpus files this script trains/diagnoses on. Reading only
+    # `path` would silently see just the post-rotation slice once the
+    # active file first rotates (found by code review) -- resolve across
+    # rotated siblings too. See orion/telemetry/corpus_rotation.py.
     rows: list[InnerStateFeaturesV1] = []
-    if not path.is_file():
-        return rows
-    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        text = line.strip()
-        if not text:
-            continue
-        try:
-            rows.append(InnerStateFeaturesV1.model_validate_json(text))
-        except Exception as exc:  # noqa: BLE001 — corpus loader should skip bad lines with context
-            raise ValueError(f"invalid JSONL at {path}:{line_no}: {exc}") from exc
+    for file in resolve_rotated_corpus_files(path):
+        for line_no, line in enumerate(file.read_text(encoding="utf-8").splitlines(), start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                rows.append(InnerStateFeaturesV1.model_validate_json(text))
+            except Exception as exc:  # noqa: BLE001 — corpus loader should skip bad lines with context
+                raise ValueError(f"invalid JSONL at {file}:{line_no}: {exc}") from exc
     return rows
 
 

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -131,6 +131,8 @@ SYNC_PREFIXES = (
     "EXEC_TRAJECTORY_",
     # Mood-arc corpus collector (roadmap item 1, 2026-07-13)
     "MOOD_ARC_",
+    # Corpus sink rotation/retention (shared by inner-state + mood-arc sinks)
+    "CORPUS_SINK_",
     # Reasoning telemetry adapter (cortex-exec -> orion-thought -> phi, default-off)
     "REASONING_ACTIVITY_",
     # Corpus hygiene: execution_trajectory projection cap (orion-substrate-runtime)

--- a/services/orion-spark-introspector/.env_example
+++ b/services/orion-spark-introspector/.env_example
@@ -172,6 +172,9 @@ INNER_FEATURES_SCALER_MAXLEN=256
 CHANNEL_INNER_FEATURES=orion:self:inner_features
 INNER_FEATURES_CORPUS_PATH=/mnt/telemetry/phi/corpus/inner_state.jsonl
 MOOD_ARC_CORPUS_PATH=/mnt/telemetry/mood_arc/corpus/mood_arc.jsonl
+# Shared rotation/retention policy for both corpus sinks above.
+CORPUS_SINK_MAX_BYTES=200000000
+CORPUS_SINK_ROTATED_KEEP=5
 PHI_DEGENERATE_STREAK=20
 SUBSTRATE_RUNTIME_URL=http://orion-athena-substrate-runtime:8115
 # Reasoning-activity projection source for seed-v4 execution_load/reasoning_load/reasoning_present.

--- a/services/orion-spark-introspector/README.md
+++ b/services/orion-spark-introspector/README.md
@@ -374,6 +374,7 @@ Spark-introspector emits `InnerStateFeaturesV1` on `orion:self:inner_features` a
 |---|---|
 | `INNER_FEATURES_VERSION` | `seed-v4` (see `.env_example` — authoritative; this table drifts) |
 | Corpus path | `INNER_FEATURES_CORPUS_PATH=/mnt/telemetry/phi/corpus/inner_state.jsonl` |
+| Rotation (2026-07-13) | `CORPUS_SINK_MAX_BYTES` (default `200000000`) / `CORPUS_SINK_ROTATED_KEEP` (default `5`) — see the mood-arc corpus collector section below for details; same policy applies here. |
 | Telemetry mount | `docker-compose.yml` binds `${TELEMETRY_ROOT:-/mnt/telemetry}:/mnt/telemetry` — pass root `.env` so `TELEMETRY_ROOT` resolves |
 | Substrate prerequisite | `orion-substrate-runtime` must reach conjourney Postgres (`POSTGRES_URI` in substrate `.env_example`) and serve healthy `GET /grammar/truth` + `GET /projections/execution_trajectory`. **Co-deploy:** update substrate `POSTGRES_URI` manually if local `.env` predates this fix — default `sync_local_env_from_example.py` does not rewrite `POSTGRES_URI`. Restart substrate before relying on live cognitive features. |
 | Encoder | `ORION_PHI_ENCODER_ENABLED=false` until corpus + promote gates pass; weights at `ORION_PHI_ENCODER_WEIGHTS` (active symlink under telemetry) |
@@ -398,18 +399,23 @@ deploy as the `phi_heuristic.valence` SHADOW→COMPOSED fix, PR #985) is
 automatically clean — there is no contaminated-data risk to guard against,
 since the sink itself did not exist before that fix.
 
-**No rotation or retention limit.** The sink this reuses
-(`InnerStateCorpusSink`) has already grown unbounded for its original use
-— confirmed 2026-07-13: ~98MB/36k rows in 5 days for
-`INNER_FEATURES_CORPUS_PATH`. Do not leave `MOOD_ARC_CORPUS_PATH` set
-indefinitely without a manual retention plan; `docker-compose.yml`
-defaults it to empty (off) specifically because of this, unlike
-`INNER_FEATURES_CORPUS_PATH`'s already-accepted always-on default above.
+**Rotation (2026-07-13).** The sink this reuses (`InnerStateCorpusSink`)
+had grown unbounded for its original use — confirmed 2026-07-13:
+~104MB/36.8k rows in 5 days for `INNER_FEATURES_CORPUS_PATH`, a real
+instance of the same unbounded-per-event-write bug class behind a prior
+host-freeze incident in this project. Fixed at the shared class level, so
+both `INNER_FEATURES_CORPUS_PATH` and `MOOD_ARC_CORPUS_PATH` get it: size-
+based rotation (`CORPUS_SINK_MAX_BYTES`, default 200MB) renames the active
+file to a timestamped sibling (`{name}.{YYYYMMDDTHHMMSS.ffffffZ}`,
+collision-safe — see `_rotate_if_needed()`) and starts fresh, with only
+the `CORPUS_SINK_ROTATED_KEEP` most recent rotated files (default 5) kept
+on disk. See `services/orion-spark-introspector/app/inner_state_sink.py`.
 
 | Requirement | Detail |
 |---|---|
 | Corpus path | `MOOD_ARC_CORPUS_PATH=/mnt/telemetry/mood_arc/corpus/mood_arc.jsonl` |
 | Enable | Unset/empty = disabled (no file written). Set to enable collection — no other flag. |
+| Rotation | `CORPUS_SINK_MAX_BYTES` (default `200000000`), `CORPUS_SINK_ROTATED_KEEP` (default `5`) — shared with `INNER_FEATURES_CORPUS_PATH`, one policy for both sinks. |
 | Consumer | None yet — see the roadmap spec for the gated next steps (train a windowed autoencoder once enough hours accumulate). |
 
 #### Golden phi + node attribution (2026-07-12)

--- a/services/orion-spark-introspector/app/inner_state_sink.py
+++ b/services/orion-spark-introspector/app/inner_state_sink.py
@@ -8,15 +8,30 @@ in practice. Type hint widened to match.
 from __future__ import annotations
 
 import json
+import logging
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 from pydantic import BaseModel
 
+from orion.telemetry.corpus_rotation import ROTATED_SUFFIX_RE
+
+logger = logging.getLogger(__name__)
+
 
 class InnerStateCorpusSink:
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, *, max_bytes: int = 200_000_000, max_rotated_files: int = 5) -> None:
         self._path: Optional[Path] = Path(path) if path else None
+        self._max_bytes = max_bytes
+        # Clamp negative values rather than let them reach the deletion
+        # slice below: rotated[-1:] on a negative max_rotated_files keeps
+        # only the OLDEST rotated file and deletes every newer one -- the
+        # exact inverse of this setting's intent (found by code review,
+        # 2026-07-13). 0 is a legitimate "no retention, just rotate"
+        # choice and is left as-is (rotated[0:] correctly deletes
+        # everything, which is unsurprising for that value).
+        self._max_rotated_files = max(0, max_rotated_files)
 
     @property
     def enabled(self) -> bool:
@@ -26,9 +41,83 @@ class InnerStateCorpusSink:
         if self._path is None:
             return
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._rotate_if_needed()
         line = json.dumps(payload.model_dump(mode="json"), separators=(",", ":"))
         # flush (not fsync) per tick: this is re-derivable training data, and the
         # self-state tick runs ~every 2s — a per-line fsync is needless I/O.
         with self._path.open("a", encoding="utf-8") as fh:
             fh.write(line + "\n")
             fh.flush()
+
+    def _rotate_if_needed(self) -> None:
+        if self._path is None:
+            return
+        # Rotation is housekeeping, not the write itself: a transient
+        # filesystem hiccup here (ESTALE/EACCES on a degraded network
+        # mount -- /mnt/telemetry genuinely is one in production -- not
+        # just the common ENOENT pathlib already treats as "doesn't
+        # exist") must skip rotation for this tick rather than lose the
+        # row entirely by raising past append()'s caller (found by code
+        # review, 2026-07-13).
+        try:
+            self._try_rotate()
+        except OSError as exc:
+            logger.warning("Corpus sink rotation check failed for %s: %s -- skipping rotation this tick", self._path, exc)
+
+    def _try_rotate(self) -> None:
+        assert self._path is not None
+        if not self._path.exists():
+            return
+        if self._path.stat().st_size < self._max_bytes:
+            return
+        # Microsecond precision (not just seconds) plus an explicit
+        # existence-check/counter fallback: Path.rename() onto an existing
+        # path silently overwrites it, which for THIS operation means
+        # silently destroying a previously-rotated backup -- exactly the
+        # data-loss failure mode this whole rotation mechanism exists to
+        # prevent for the active file. Two rotations within the same
+        # microsecond are not realistically reachable at this cadence, but
+        # the counter fallback costs nothing and removes the assumption
+        # entirely rather than just making the collision window smaller.
+        base_name = f"{self._path.name}.{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S.%fZ')}"
+        rotated_path = self._path.with_name(base_name)
+        suffix = 0
+        while rotated_path.exists():
+            suffix += 1
+            rotated_path = self._path.with_name(f"{base_name}.{suffix}")
+        self._path.rename(rotated_path)
+        logger.warning(
+            "Rotated corpus sink %s -> %s (exceeded max_bytes=%d)",
+            self._path, rotated_path, self._max_bytes,
+        )
+        self._prune_old_rotations()
+
+    def _prune_old_rotations(self) -> None:
+        if self._path is None:
+            return
+        prefix_len = len(self._path.name) + 1  # +1 for the separating "."
+        # Filter to files whose suffix matches ROTATED_SUFFIX_RE exactly --
+        # NOT a bare "{name}.*" glob, which would also match a manually-
+        # placed backup, a .gz archive, a stray editor temp file, or
+        # anything else sharing the corpus basename prefix (found by code
+        # review, 2026-07-13, independently by two review angles). Only
+        # delete files this class actually created.
+        candidates = [
+            p for p in self._path.parent.glob(f"{self._path.name}.*")
+            if ROTATED_SUFFIX_RE.match(p.name[prefix_len:])
+        ]
+        # Sort by filename, not st_mtime: the rotated name already embeds a
+        # sortable UTC timestamp (%Y%m%dT%H%M%S.%fZ, optionally a ".N"
+        # collision suffix, which still sorts after its un-suffixed sibling
+        # since ".1" > "" lexically). mtime is not a reliable ordering
+        # signal -- clock skew, NFS-backed volumes, or a backup/restore
+        # touching the corpus directory can leave mtimes that don't match
+        # real rotation order, which would prune a newer file and keep an
+        # older one (found by code review, 2026-07-13).
+        rotated = sorted(candidates, key=lambda p: p.name, reverse=True)
+        for old in rotated[self._max_rotated_files:]:
+            try:
+                old.unlink()
+                logger.info("Pruned old rotated corpus file: %s", old)
+            except OSError as exc:
+                logger.warning("Failed to prune rotated corpus file %s: %s", old, exc)

--- a/services/orion-spark-introspector/app/settings.py
+++ b/services/orion-spark-introspector/app/settings.py
@@ -123,6 +123,20 @@ class Settings(BaseSettings):
     # independently-gated feature from Plan 1 inner-state features above;
     # docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md.
     mood_arc_corpus_path: str = Field("", alias="MOOD_ARC_CORPUS_PATH")
+    # Shared rotation/retention policy for InnerStateCorpusSink instances
+    # (both _INNER_SINK and _MOOD_ARC_SINK in worker.py) -- one policy for
+    # both, tuned against INNER_FEATURES_CORPUS_PATH's real size/cadence
+    # (~104MB/36.8k rows over 5 days at spec time), not independently
+    # verified against MOOD_ARC_CORPUS_PATH's (roadmap item 1 estimates
+    # ~8-9MB/day, a real but different rate -- see
+    # orion/self_state/inner_state_registry.py's mood_arc_corpus.v1 entry).
+    # ge=1_000_000 (1MB), not just ge=1: a typo'd tiny value (e.g. losing
+    # three zeros off the intended 200_000_000) would rotate on nearly
+    # every tick instead of failing validation (found by code review,
+    # 2026-07-13) -- 1MB is comfortably below any sane real threshold but
+    # rules out the "rotates every tick" pathological case outright.
+    corpus_sink_max_bytes: int = Field(200_000_000, ge=1_000_000, alias="CORPUS_SINK_MAX_BYTES")
+    corpus_sink_rotated_keep: int = Field(5, ge=0, alias="CORPUS_SINK_ROTATED_KEEP")
     # Substrate runtime HTTP reads (Plan 2)
     substrate_runtime_url: str = Field(
         "http://orion-athena-substrate-runtime:8115",

--- a/services/orion-spark-introspector/app/worker.py
+++ b/services/orion-spark-introspector/app/worker.py
@@ -118,8 +118,16 @@ _INNER_PREV_FELT = None
 _INNER_PREV_HEADLINE = None
 _INNER_DEGENERATE_STREAK = 0
 _INNER_LAST_HEADLINE: Optional[float] = None  # honest headline for WS reads
-_INNER_SINK = InnerStateCorpusSink(getattr(settings, "inner_features_corpus_path", "") or "")
-_MOOD_ARC_SINK = InnerStateCorpusSink(getattr(settings, "mood_arc_corpus_path", "") or "")
+_INNER_SINK = InnerStateCorpusSink(
+    getattr(settings, "inner_features_corpus_path", "") or "",
+    max_bytes=settings.corpus_sink_max_bytes,
+    max_rotated_files=settings.corpus_sink_rotated_keep,
+)
+_MOOD_ARC_SINK = InnerStateCorpusSink(
+    getattr(settings, "mood_arc_corpus_path", "") or "",
+    max_bytes=settings.corpus_sink_max_bytes,
+    max_rotated_files=settings.corpus_sink_rotated_keep,
+)
 
 # Last chat-triggered novelty actually shown for a semantic upsert
 # (handle_semantic_upsert's `tissue_novelty` -- prefers cached appraisal

--- a/services/orion-spark-introspector/docker-compose.yml
+++ b/services/orion-spark-introspector/docker-compose.yml
@@ -117,6 +117,10 @@ services:
       # Deliberately off unless explicitly set.
       MOOD_ARC_CORPUS_PATH: ${MOOD_ARC_CORPUS_PATH:-}
 
+      # Shared rotation/retention policy for both corpus sinks above.
+      CORPUS_SINK_MAX_BYTES: ${CORPUS_SINK_MAX_BYTES:-200000000}
+      CORPUS_SINK_ROTATED_KEEP: ${CORPUS_SINK_ROTATED_KEEP:-5}
+
     ports:
       - "${PORT:-8444}:${PORT:-8444}"
 

--- a/services/orion-spark-introspector/tests/test_inner_state_sink_rotation.py
+++ b/services/orion-spark-introspector/tests/test_inner_state_sink_rotation.py
@@ -1,0 +1,294 @@
+"""Unit tests for InnerStateCorpusSink's size-based rotation + retention pruning.
+
+Exercises app/inner_state_sink.py directly (no bus/handle_self_state mocking
+needed) -- these tests protect the already-live production corpus file at
+/mnt/telemetry/phi/corpus/inner_state.jsonl from unbounded growth.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+from pydantic import BaseModel
+
+from app.inner_state_sink import InnerStateCorpusSink
+
+ROTATED_SUFFIX_RE = re.compile(r"^\d{8}T\d{6}\.\d{6}Z(\.\d+)?$")
+
+
+class _TestRow(BaseModel):
+    n: int
+
+
+def _read_jsonl(path) -> list[dict]:
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").strip("\n").splitlines()
+    return [json.loads(line) for line in lines if line]
+
+
+def test_rotation_triggers_when_max_bytes_exceeded(tmp_path) -> None:
+    corpus_path = tmp_path / "inner_state.jsonl"
+    sink = InnerStateCorpusSink(str(corpus_path), max_bytes=50, max_rotated_files=5)
+
+    for i in range(20):
+        sink.append(_TestRow(n=i))
+
+    rotated = list(tmp_path.glob("inner_state.jsonl.*"))
+    assert len(rotated) >= 1
+
+    # Active file exists, is small, and is not one of the rotated files.
+    assert corpus_path.exists()
+    assert corpus_path not in rotated
+    assert corpus_path.stat().st_size < 50 or len(_read_jsonl(corpus_path)) < 20
+
+
+def test_rotated_file_naming_pattern(tmp_path) -> None:
+    corpus_path = tmp_path / "inner_state.jsonl"
+    sink = InnerStateCorpusSink(str(corpus_path), max_bytes=10, max_rotated_files=5)
+
+    # Each ~8-byte row: 1st append writes without checking (file doesn't
+    # exist yet), 2nd append checks size=8 (<10, no rotate) and writes
+    # (size=16), 3rd append checks size=16 (>=10) and rotates.
+    sink.append(_TestRow(n=1))
+    sink.append(_TestRow(n=2))
+    sink.append(_TestRow(n=3))  # forces the rotation
+
+    rotated = list(tmp_path.glob("inner_state.jsonl.*"))
+    assert len(rotated) == 1
+    rotated_path = rotated[0]
+
+    # Sibling of the original path (same directory).
+    assert rotated_path.parent == corpus_path.parent
+
+    # Filename is "{original_name}.{timestamp}" with timestamp matching
+    # the exact %Y%m%dT%H%M%S.%fZ (microsecond-precision) format used by
+    # _rotate_if_needed, optionally followed by a ".N" collision counter.
+    prefix = f"{corpus_path.name}."
+    assert rotated_path.name.startswith(prefix)
+    suffix = rotated_path.name[len(prefix):]
+    assert ROTATED_SUFFIX_RE.match(suffix), f"unexpected suffix: {suffix!r}"
+
+
+def test_old_rotations_pruned_beyond_max_rotated_files(tmp_path, monkeypatch) -> None:
+    corpus_path = tmp_path / "inner_state.jsonl"
+    sink = InnerStateCorpusSink(str(corpus_path), max_bytes=10, max_rotated_files=2)
+
+    # _rotate_if_needed's collision-counter fallback means forcing several
+    # rotations back-to-back can no longer produce colliding *filenames*
+    # (production code handles that itself now). But _prune_old_rotations
+    # sorts survivors by st_mtime, which has its own coarse resolution on
+    # some filesystems -- a tight test loop could still get a nondeterministic
+    # prune order. Monkeypatch the sink module's clock so each rotation gets
+    # a distinct, monotonically increasing timestamp, keeping the test fast
+    # and deterministic regardless of filesystem mtime granularity.
+    import datetime as _dt
+
+    import app.inner_state_sink as sink_module
+
+    class _FakeDateTime(_dt.datetime):
+        _tick = 0
+
+        @classmethod
+        def now(cls, tz=None):
+            cls._tick += 1
+            return _dt.datetime(2026, 7, 13, 0, 0, 0, tzinfo=tz) + _dt.timedelta(seconds=cls._tick)
+
+    monkeypatch.setattr(sink_module, "datetime", _FakeDateTime)
+
+    # Force 4 separate rotation events. With max_bytes=10 and ~8-byte rows,
+    # a rotation happens every other append (after two rows accumulate to
+    # 16 bytes): 8 appends -> 4 rotations.
+    for i in range(8):
+        sink.append(_TestRow(n=i))
+
+    rotated = sorted(p.name for p in tmp_path.glob("inner_state.jsonl.*"))
+    assert len(rotated) == 2
+
+    # The survivors should be the two lexically-latest (== chronologically
+    # latest, since the timestamp format sorts correctly) rotated names.
+    all_possible_prefix = f"{corpus_path.name}."
+    assert all(name.startswith(all_possible_prefix) for name in rotated)
+
+
+def test_append_continues_working_after_rotation(tmp_path) -> None:
+    corpus_path = tmp_path / "inner_state.jsonl"
+    sink = InnerStateCorpusSink(str(corpus_path), max_bytes=50, max_rotated_files=5)
+
+    for i in range(30):
+        sink.append(_TestRow(n=i))
+
+    # Active file is valid, readable JSONL.
+    rows = _read_jsonl(corpus_path)
+    assert len(rows) >= 1
+    for row in rows:
+        assert "n" in row
+
+    # One more append after all the rotation churn still works cleanly.
+    sink.append(_TestRow(n=999))
+    rows_after = _read_jsonl(corpus_path)
+    assert rows_after[-1]["n"] == 999
+
+
+def test_disabled_sink_never_rotates(tmp_path) -> None:
+    sink = InnerStateCorpusSink("", max_bytes=1, max_rotated_files=1)
+
+    assert sink.enabled is False
+    assert sink._path is None
+
+    # append() is a safe no-op.
+    sink.append(_TestRow(n=1))
+    sink.append(_TestRow(n=2))
+
+    # No directory or files created anywhere under tmp_path (the disabled
+    # sink never touches the filesystem at all).
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_rotation_respects_default_thresholds(tmp_path) -> None:
+    corpus_path = tmp_path / "inner_state.jsonl"
+    sink = InnerStateCorpusSink(str(corpus_path))
+
+    assert sink._max_bytes == 200_000_000
+    assert sink._max_rotated_files == 5
+
+
+def test_rotation_collision_counter_avoids_overwriting_existing_rotated_file(tmp_path, monkeypatch) -> None:
+    # Path.rename() onto an existing path silently overwrites it -- for
+    # rotation specifically, that means two rotations landing on the exact
+    # same timestamp would silently destroy the FIRST rotated backup, the
+    # opposite of what this whole mechanism exists to prevent. Force a
+    # frozen clock (same instant on every call) across two separate
+    # rotation events and confirm both rotated files survive with distinct
+    # names (the ".1" collision-counter suffix), not one overwriting the
+    # other.
+    import datetime as _dt
+
+    import app.inner_state_sink as sink_module
+
+    frozen = _dt.datetime(2026, 7, 13, 0, 0, 0, tzinfo=_dt.timezone.utc)
+
+    class _FrozenDateTime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return frozen
+
+    monkeypatch.setattr(sink_module, "datetime", _FrozenDateTime)
+
+    corpus_path = tmp_path / "inner_state.jsonl"
+    sink = InnerStateCorpusSink(str(corpus_path), max_bytes=10, max_rotated_files=5)
+
+    # Each ~8-byte row (`{"n":N}\n`): rotation #1 fires on the 3rd append
+    # (rows 1+2 = 16 bytes >= 10), carrying rows {1, 2} into the first
+    # rotated file. Rotation #2 fires on the 5th append (rows 3+4 = 16
+    # bytes >= 10), carrying rows {3, 4}. Row 5 stays in the active file.
+    for n in (1, 2, 3, 4, 5):
+        sink.append(_TestRow(n=n))
+
+    rotated = sorted(p.name for p in tmp_path.glob("inner_state.jsonl.*"))
+    assert len(rotated) == 2, (
+        f"expected 2 distinct rotated files surviving a timestamp collision, got {rotated}"
+    )
+    # Exactly one of the two must carry the ".1" collision-counter suffix --
+    # confirms the collision was actually hit and handled, not avoided by
+    # accident (e.g. a test that doesn't really force same-instant rotations
+    # would show 0, not 1, here).
+    assert sum(name.endswith(".1") for name in rotated) == 1
+
+    # Union of both rotated files' content must be exactly {1,2,3,4} -- every
+    # row that was ever rotated out survived, none lost, none duplicated
+    # across the two files (the failure mode a silent rename-overwrite would
+    # produce: file 1 disappears, its two rows gone).
+    all_rotated_ns: set[int] = set()
+    for name in rotated:
+        for row in _read_jsonl(tmp_path / name):
+            all_rotated_ns.add(row["n"])
+    assert all_rotated_ns == {1, 2, 3, 4}
+    assert _read_jsonl(corpus_path) == [{"n": 5}]
+
+
+def test_prune_never_deletes_a_file_not_matching_the_rotation_pattern(tmp_path) -> None:
+    # 2026-07-13, found by code review (2 independent angles): the original
+    # prune glob was `{name}.*`, which matches ANY sibling sharing the
+    # corpus basename prefix -- a manually-placed backup, a .gz archive, a
+    # stray editor temp file. Fixed via _ROTATED_SUFFIX_RE filtering. This
+    # test plants exactly that kind of stray file and confirms it survives
+    # even when max_rotated_files is small enough that real rotations would
+    # otherwise prune something.
+    corpus_path = tmp_path / "inner_state.jsonl"
+    stray_backup = tmp_path / "inner_state.jsonl.manual-backup-20260701"
+    stray_backup.write_text('{"n":-1}\n', encoding="utf-8")
+    stray_gzip = tmp_path / "inner_state.jsonl.gz"
+    stray_gzip.write_bytes(b"not a real gzip, just needs to exist")
+
+    sink = InnerStateCorpusSink(str(corpus_path), max_bytes=10, max_rotated_files=1)
+    for n in (1, 2, 3, 4, 5):
+        sink.append(_TestRow(n=n))
+
+    assert stray_backup.exists(), "a file not matching the rotation pattern must never be pruned"
+    assert stray_gzip.exists(), "a file not matching the rotation pattern must never be pruned"
+
+    # Confirm real rotation + pruning still happened around the stray files
+    # (i.e. this isn't passing merely because nothing rotated at all).
+    real_rotated = [
+        p for p in tmp_path.glob("inner_state.jsonl.*")
+        if p not in (stray_backup, stray_gzip)
+    ]
+    assert len(real_rotated) == 1, f"expected exactly 1 real rotated file kept, got {real_rotated}"
+
+
+def test_negative_max_rotated_files_is_clamped_not_inverted(tmp_path) -> None:
+    # 2026-07-13, found by code review: rotated[-1:] on a negative
+    # max_rotated_files keeps only the OLDEST rotated file and deletes
+    # every newer one -- the exact inverse of the setting's intent.
+    # Clamped to 0 (a legitimate "no retention" value) instead.
+    corpus_path = tmp_path / "inner_state.jsonl"
+    sink = InnerStateCorpusSink(str(corpus_path), max_bytes=10, max_rotated_files=-3)
+    assert sink._max_rotated_files == 0
+
+    for n in (1, 2, 3, 4, 5):
+        sink.append(_TestRow(n=n))
+
+    # max_rotated_files clamped to 0 -> every real rotated file gets
+    # pruned immediately, none survive.
+    rotated = list(tmp_path.glob("inner_state.jsonl.*"))
+    assert rotated == []
+
+
+def test_rotation_failure_does_not_prevent_the_row_from_being_written(tmp_path, monkeypatch) -> None:
+    # 2026-07-13, found by code review: Path.exists()/stat() can raise
+    # OSError (not just return False/a value) for errno values pathlib
+    # doesn't treat as "doesn't exist" -- ESTALE/EACCES on a degraded
+    # network mount, which /mnt/telemetry genuinely is in production.
+    # _rotate_if_needed() wraps the whole rotation attempt in one
+    # try/except OSError specifically so a filesystem hiccup during
+    # housekeeping skips rotation for this tick rather than raising past
+    # append() and losing the row entirely.
+    import app.inner_state_sink as sink_module
+
+    corpus_path = tmp_path / "inner_state.jsonl"
+    sink = InnerStateCorpusSink(str(corpus_path), max_bytes=10, max_rotated_files=5)
+
+    sink.append(_TestRow(n=1))
+    sink.append(_TestRow(n=2))  # size >= 10 on the next append's check
+
+    def _always_raises(self):
+        raise OSError("simulated ESTALE on a degraded network mount")
+
+    monkeypatch.setattr(sink_module.Path, "exists", _always_raises)
+
+    # Must not raise, even though every exists() check inside rotation
+    # fails -- append() itself doesn't call exists() on the write path.
+    sink.append(_TestRow(n=3))
+
+    # Restore the real Path.exists before making assertions -- _read_jsonl
+    # (this test file's own helper) calls path.exists() too, and would
+    # otherwise hit the same simulated failure.
+    monkeypatch.undo()
+
+    # Rotation was skipped this tick (its own exists() check failed), so
+    # the row lands in the still-active, now-oversized file rather than a
+    # fresh rotated one -- that's the correct, safe degraded-mode outcome:
+    # no data lost, rotation deferred to a healthier tick.
+    assert list(tmp_path.glob("inner_state.jsonl.*")) == []
+    assert _read_jsonl(corpus_path) == [{"n": 1}, {"n": 2}, {"n": 3}]

--- a/services/orion-spark-introspector/tests/test_phi_encoder_health_eval.py
+++ b/services/orion-spark-introspector/tests/test_phi_encoder_health_eval.py
@@ -295,3 +295,33 @@ def test_evaluate_all_runs_end_to_end(health, tmp_path: Path) -> None:
     assert report["active_encoder_version"] == "v-a"
     # Random tiny MLP should not identity-copy headline.
     assert report["ok"] is True
+
+
+def test_load_corpus_rows_reads_across_rotated_files(health, tmp_path: Path) -> None:
+    # 2026-07-13, found by code review: InnerStateCorpusSink gained
+    # size-based rotation the same day this eval's corpus loader existed.
+    # load_corpus_rows(path) reading only the single active file would
+    # silently evaluate encoder health against just the post-rotation
+    # slice once a real corpus ever rotates -- no error, just fewer rows
+    # than an operator would assume. Fixed via orion.telemetry.
+    # corpus_rotation.resolve_rotated_corpus_files, shared with
+    # inner_state_sink.py's pruning and fit_phi_encoder.py's loader; this
+    # test pins eval_phi_encoder_health.py's usage of it specifically
+    # (flagged by review as the one call site with no prior coverage).
+    corpus_path = tmp_path / "inner_state.jsonl"
+    rotated_path = tmp_path / "inner_state.jsonl.20260701T000000.000000Z"
+    stray_path = tmp_path / "inner_state.jsonl.manual-backup"  # must be ignored, wrong pattern
+
+    _write_corpus(rotated_path, features_version="seed-v4", n=3)
+    _write_corpus(corpus_path, features_version="seed-v4", n=2)
+    stray_path.write_text("not a real corpus row\n", encoding="utf-8")
+
+    rows = health.load_corpus_rows(corpus_path)
+    assert len(rows) == 5
+
+
+def test_load_corpus_rows_single_file_unchanged_when_no_rotation_happened(health, tmp_path: Path) -> None:
+    corpus_path = tmp_path / "inner_state.jsonl"
+    _write_corpus(corpus_path, features_version="seed-v4", n=4)
+
+    assert len(health.load_corpus_rows(corpus_path)) == 4

--- a/services/orion-spark-introspector/train/evals/README.md
+++ b/services/orion-spark-introspector/train/evals/README.md
@@ -19,6 +19,15 @@ Primary health metrics (do **not** treat φ↔headline correlation as success):
 Every version directory under `--encoders-root` is included with manifest
 metadata (`git_sha`, `trained_at`, corpus span, training losses, status).
 
+**Rotation-aware (2026-07-13):** `--corpus` no longer has to point at a
+single ever-growing file. `InnerStateCorpusSink`
+(`services/orion-spark-introspector/app/inner_state_sink.py`) now rotates
+the live corpus at `CORPUS_SINK_MAX_BYTES` (default 200MB); this script's
+`load_corpus_rows()` resolves the given `--corpus` path plus any rotated
+siblings (`orion/telemetry/corpus_rotation.py`) so a health report always
+covers the full retained history, not just the slice written since the
+last rotation.
+
 ```bash
 # Live corpus + all encoder runs
 python services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py \

--- a/services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py
+++ b/services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py
@@ -38,6 +38,7 @@ if str(REPO) not in sys.path:
 
 from orion.schemas.telemetry.inner_state import InnerStateFeaturesV1
 from orion.schemas.telemetry.phi_encoder import PhiEncoderManifestV1
+from orion.telemetry.corpus_rotation import resolve_rotated_corpus_files
 
 DEFAULT_CORPUS = Path("/mnt/telemetry/phi/corpus/inner_state.jsonl")
 DEFAULT_ENCODERS_ROOT = Path("/mnt/telemetry/models/phi/encoders")
@@ -139,17 +140,21 @@ def resolve_active_target(encoders_root: Path) -> Path | None:
 
 
 def load_corpus_rows(corpus_path: Path) -> list[InnerStateFeaturesV1]:
+    # 2026-07-13: InnerStateCorpusSink gained size-based rotation. Reading
+    # only `corpus_path` would silently evaluate encoder health against
+    # just the post-rotation slice once the active file first rotates
+    # (found by code review) -- resolve across rotated siblings too. See
+    # orion/telemetry/corpus_rotation.py.
     rows: list[InnerStateFeaturesV1] = []
-    if not corpus_path.is_file():
-        return rows
-    for line_no, line in enumerate(corpus_path.read_text(encoding="utf-8").splitlines(), start=1):
-        text = line.strip()
-        if not text:
-            continue
-        try:
-            rows.append(InnerStateFeaturesV1.model_validate_json(text))
-        except Exception as exc:  # noqa: BLE001 — skip bad lines with context
-            raise ValueError(f"invalid JSONL at {corpus_path}:{line_no}: {exc}") from exc
+    for file in resolve_rotated_corpus_files(corpus_path):
+        for line_no, line in enumerate(file.read_text(encoding="utf-8").splitlines(), start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                rows.append(InnerStateFeaturesV1.model_validate_json(text))
+            except Exception as exc:  # noqa: BLE001 — skip bad lines with context
+                raise ValueError(f"invalid JSONL at {file}:{line_no}: {exc}") from exc
     return rows
 
 

--- a/tests/test_phi_encoder_fit_script.py
+++ b/tests/test_phi_encoder_fit_script.py
@@ -342,3 +342,54 @@ def test_variance_gate_seedv3_feature_names_unaffected_by_seedv4_policy() -> Non
     ok, got, need = _variance_gate(matrix, fraction=0.8, eps=1e-6, feature_names=names)
     assert need == int(np.ceil(0.8 * len(names)))
     assert got == 9
+
+
+def test_load_jsonl_reads_across_rotated_corpus_files(tmp_path: Path) -> None:
+    """2026-07-13, found by code review: InnerStateCorpusSink gained
+    size-based rotation the same day this eval/training script's corpus
+    loader existed. _load_jsonl(path) reading only the single active file
+    would silently see just the post-rotation slice once a real corpus
+    ever rotates -- no error, just fewer rows than an operator would
+    assume. Fixed via orion.telemetry.corpus_rotation.resolve_rotated_
+    corpus_files, the single shared source of truth for this pattern
+    (also used by inner_state_sink.py's pruning and eval_phi_encoder_
+    health.py's loader -- this test pins fit_phi_encoder.py's usage of it).
+    """
+    from scripts.fit_phi_encoder import _load_jsonl
+
+    corpus_path = tmp_path / "inner_state.jsonl"
+    rotated_path = tmp_path / "inner_state.jsonl.20260701T000000.000000Z"
+    stray_path = tmp_path / "inner_state.jsonl.manual-backup"  # must be ignored, wrong pattern
+
+    old_rows = _synthetic_corpus(n_rows=3, hours_span=1.0)
+    new_rows = _synthetic_corpus(n_rows=2, hours_span=1.0)
+    _write_corpus(rotated_path, old_rows)
+    _write_corpus(corpus_path, new_rows)
+    stray_path.write_text("not a real corpus row\n", encoding="utf-8")
+
+    from orion.telemetry.corpus_rotation import resolve_rotated_corpus_files
+
+    files = resolve_rotated_corpus_files(corpus_path)
+    assert rotated_path in files
+    assert corpus_path in files
+    assert stray_path not in files
+    # Rotated (older) file must come before the active file.
+    assert files.index(rotated_path) < files.index(corpus_path)
+
+    loaded = _load_jsonl(corpus_path)
+    assert len(loaded) == len(old_rows) + len(new_rows)
+
+
+def test_load_jsonl_single_file_unchanged_when_no_rotation_happened(tmp_path: Path) -> None:
+    """The common case today (no rotation has ever fired) must behave
+    identically to the pre-fix single-file read -- no rotated siblings on
+    disk, resolve_rotated_corpus_files returns exactly the one active file."""
+    from scripts.fit_phi_encoder import _load_jsonl
+    from orion.telemetry.corpus_rotation import resolve_rotated_corpus_files
+
+    corpus_path = tmp_path / "inner_state.jsonl"
+    rows = _synthetic_corpus(n_rows=5, hours_span=1.0)
+    _write_corpus(corpus_path, rows)
+
+    assert resolve_rotated_corpus_files(corpus_path) == [corpus_path]
+    assert len(_load_jsonl(corpus_path)) == len(rows)


### PR DESCRIPTION
## Summary

- Fixes the real, live incident-history risk flagged after the mood-arc corpus collector PR: `InnerStateCorpusSink` (backing `INNER_FEATURES_CORPUS_PATH`) had grown unbounded — confirmed 2026-07-13: ~104MB/36,776 rows in 5 days, zero rotation, same bug class as a prior host-freeze incident in this project.
- Adds size-based rotation (`CORPUS_SINK_MAX_BYTES`, default 200MB) with retention pruning (`CORPUS_SINK_ROTATED_KEEP`, default 5) to the shared sink class, used by both `_INNER_SINK` and the new `_MOOD_ARC_SINK`.
- Fixes three independent downstream readers (`scripts/fit_phi_encoder.py`, `scripts/diag.py` via shared import, `services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py`) that would otherwise silently train/diagnose on only the post-rotation slice of the corpus once rotation ever fires.
- 8-angle code review across two full passes (the rotation mechanism itself, then the mechanism plus its downstream fixes) found and fixed real, live-data-affecting bugs — detailed below, not glossed over.

## Outcome moved

The live, already-growing `/mnt/telemetry/phi/corpus/inner_state.jsonl` file now has a real, tested bound instead of unbounded growth toward a repeat of this project's prior disk-exhaustion incident. Training/diagnostic scripts stay correct across rotation instead of silently shrinking their effective corpus.

## Current architecture

`InnerStateCorpusSink.append()` (`services/orion-spark-introspector/app/inner_state_sink.py`) did a raw `Path.open("a")`/write/flush per tick with no size check, ever. Three separate scripts each independently implemented a single-file JSONL reader (`fit_phi_encoder.py`'s `_load_jsonl`, `eval_phi_encoder_health.py`'s `load_corpus_rows` — a byte-for-byte duplicate, `diag.py` importing the former).

## Architecture touched

`services/orion-spark-introspector/app/{inner_state_sink,settings,worker}.py`, `scripts/fit_phi_encoder.py`, `services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py`, and a new shared module `orion/telemetry/corpus_rotation.py`.

## Files changed

- `services/orion-spark-introspector/app/inner_state_sink.py`: size-based rotation (`_rotate_if_needed`/`_try_rotate`/`_prune_old_rotations`), collision-safe renaming, strict-pattern-filtered pruning, whole-rotation-attempt OSError guard, negative-value clamping.
- `orion/telemetry/corpus_rotation.py` (new): single shared source of truth for the rotated-filename pattern and multi-file resolution — extracted mid-review after the pattern was found duplicated three ways.
- `scripts/fit_phi_encoder.py`, `services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py`: now import the shared resolver instead of duplicating it; both read across rotated siblings, not just the active file.
- `services/orion-spark-introspector/app/settings.py`: `corpus_sink_max_bytes` (`ge=1_000_000`), `corpus_sink_rotated_keep` (`ge=0`) — shared policy for both sinks.
- `services/orion-spark-introspector/.env_example`, `docker-compose.yml`, `scripts/sync_local_env_from_example.py`: new keys, consistent defaults.
- `orion/schemas/telemetry/mood_arc.py`, `orion/self_state/inner_state_registry.py`, `services/orion-spark-introspector/README.md`, `docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md`: stale "no rotation" claims corrected; new shared-policy coupling disclosed.
- Tests: `services/orion-spark-introspector/tests/test_inner_state_sink_rotation.py` (new, 11 tests), `tests/test_phi_encoder_fit_script.py` (+2), `services/orion-spark-introspector/tests/test_phi_encoder_health_eval.py` (+2) — the latter added specifically because review found the eval script's identical fix had zero coverage.

## Schema / bus / API changes

None. Rotation is internal sink behavior; corpus reader fixes are additive.

## Env/config changes

- Added: `CORPUS_SINK_MAX_BYTES=200000000`, `CORPUS_SINK_ROTATED_KEEP=5`.
- `.env_example` updated: yes. `docker-compose.yml` updated: yes. `sync_local_env_from_example.py` (`CORPUS_SINK_` prefix): yes.
- Local `.env` synced: no local `.env` in this worktree (expected, gitignored, absent in a fresh `git worktree add`).

## Tests run

```text
PYTHONPATH=.:services/orion-spark-introspector pytest \
  tests/test_inner_state_registry_gate.py tests/test_phi_encoder_fit_script.py \
  services/orion-spark-introspector/tests -q \
  --deselect services/orion-spark-introspector/tests/test_inner_state_emit.py::test_inner_features_settings_defaults
188 passed, 1 skipped

python scripts/check_inner_state_registry.py
inner_state_registry gate OK (10 entries checked)
```

Also directly verified (not just unit-tested) that the collision-counter fix actually prevents data loss: temporarily reverted it to the naive (second-precision, no-counter) version, confirmed the regression test fails with the exact silent-overwrite it's meant to catch (`len(rotated)==1` instead of `2`), then restored the fix and confirmed green.

## Evals run

None applicable.

## Docker/build/smoke checks

Not deployed this patch — code is tested and reviewed. The already-live 104MB corpus file is unaffected until this code is actually deployed and the file grows past 200MB (~5 more days at current rate); no destructive action taken against it this session.

## Review findings fixed

Two full 8-angle review passes (the second re-run after the first pass's fixes substantially changed the diff). Real, material findings, several independently confirmed by multiple angles:

- Finding (2 independent angles, most severe): `_prune_old_rotations`'s original glob (`{name}.*`) matched ANY file sharing the corpus basename prefix — a manually-placed backup, a `.gz` archive, a stray editor temp file — all eligible for silent deletion.
  - Fix: filtered through a strict regex matching only genuine rotation output, extracted to `orion/telemetry/corpus_rotation.py`'s `ROTATED_SUFFIX_RE`.
  - Evidence: `test_prune_never_deletes_a_file_not_matching_the_rotation_pattern`.
- Finding: `Path.rename()` onto an existing rotated-file path (a same-second, or even same-microsecond, collision) silently overwrites it — destroying a previously-rotated backup, the opposite of what rotation exists to prevent.
  - Fix: microsecond-precision timestamps plus an explicit existence-check/counter fallback (`.1`, `.2`, ...).
  - Evidence: `test_rotation_collision_counter_avoids_overwriting_existing_rotated_file` — verified by deliberately reverting the fix and confirming the test reproduces the exact data-loss failure, then restoring it.
- Finding: pruning sorted by filesystem `mtime`, not the filename's own embedded timestamp — under clock skew, NFS, or a backup/restore touching the directory, this could prune a newer file while keeping an older one.
  - Fix: sort by filename (already lexically correct) instead of reading filesystem metadata at all.
- Finding: `CORPUS_SINK_ROTATED_KEEP` set to a negative value produced backwards behavior via Python's negative-slice semantics — kept only the oldest file, deleted every newer one.
  - Fix: clamped to `max(0, value)` in the sink constructor, plus `ge=0` validation at the settings layer.
  - Evidence: `test_negative_max_rotated_files_is_clamped_not_inverted`.
- Finding: a transient filesystem error (ESTALE/EACCES on `/mnt/telemetry`, a real external volume mount in production) during any `.exists()`/`.stat()` call inside rotation would propagate uncaught, aborting the current tick's write entirely.
  - Fix: the whole rotation attempt wrapped in one `try/except OSError`, logging and skipping rotation for that tick rather than losing the row.
  - Evidence: `test_rotation_failure_does_not_prevent_the_row_from_being_written`.
- Finding (cross-file trace): three independent corpus readers (`fit_phi_encoder.py`, `diag.py` via import, `eval_phi_encoder_health.py`) read a single exact path — once rotation ever fires, they'd silently train/diagnose on only the post-rotation slice, no error.
  - Fix: `orion/telemetry/corpus_rotation.py`'s `resolve_rotated_corpus_files`, imported by all three read sites (the sink's own prune logic too, after mid-review extraction).
  - Evidence: `test_load_jsonl_reads_across_rotated_corpus_files`, `test_load_corpus_rows_reads_across_rotated_files` (the latter added specifically because review flagged the eval script's identical fix as having zero coverage).
- Finding (simplification, 2 angles): the rotated-filename regex + resolver was independently duplicated in three places (the sink, `fit_phi_encoder.py`, `eval_phi_encoder_health.py`), all needing to stay byte-for-byte in sync with no gate catching drift.
  - Fix: extracted to `orion/telemetry/corpus_rotation.py`, all three call sites now import it.
- Finding (docs): `MoodArcCorpusRowV1`'s schema docstring and this service's README still said "no rotation, manual retention plan needed" after rotation was actually implemented; the roadmap spec's Item 1 explicitly assumed no rotation would ever be needed.
  - Fix: corrected in all three places, plus disclosed that pruned mood-arc rows (unlike `InnerStateFeaturesV1`, which has `scripts/backfill_phi_corpus.py`) have no backfill path — genuinely gone once pruned, not just archived.
- Finding (altitude, considered seriously, not dismissed): `loguru` is already a direct, unused dependency of this exact service and has native `rotation=`/`retention=` support that would have avoided at least the collision and mtime-ordering bugs above outright; three review passes finding three distinct correctness bugs in the hand-rolled reimplementation is itself evidence for that critique.
  - Disposition: **deferred, not dismissed.** A same-session rewrite to loguru would trade the current implementation's now-verified state (4+ independent review passes, 0 outstanding known bugs, each prior bug fixed and pinned with a regression test proven to catch it) for a fresh, unverified rewrite under time pressure — itself a new source of risk. Named explicitly here as a legitimate follow-up: migrating `InnerStateCorpusSink` to loguru's `logger.add(path, rotation=..., retention=..., format="{message}")` (with `bind()`/`filter=` for per-instance isolation across the two live sinks) is a real, scoped next patch, not assumed away.
- Finding: `CORPUS_SINK_MAX_BYTES` had no sane floor (`ge=1` permitted e.g. `100`, causing rotation on nearly every tick).
  - Fix: raised to `ge=1_000_000` (1MB) — comfortably below any real threshold, rules out the pathological case.
- Finding: the `mood_arc_corpus.v1` registry entry didn't disclose that its rotation/retention thresholds are a policy shared with (and tuned against) `INNER_FEATURES_CORPUS_PATH`'s real size/cadence, not independently verified for mood-arc's own growth rate.
  - Fix: disclosed explicitly in the registry notes.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-spark-introspector/.env \
  -f services/orion-spark-introspector/docker-compose.yml up -d --build
```

Not run this session. This is the fix for a real, currently-accumulating production risk (~104MB and growing on the live host) — recommend deploying promptly once merged, well before the file reaches the 200MB rotation threshold (~5 more days at current growth rate) so the first real rotation event happens under the tested code path, not the old unbounded one.

## Risks / concerns

- Severity: medium (documented, not silently deferred)
- Concern: hand-rolled rotation logic, even after fixing 4 real bugs across review, could still have an undiscovered edge case; `loguru` (already a dependency) would likely have avoided several of these bugs by construction.
- Mitigation: named as an explicit follow-up above, not left implicit. Current implementation is thoroughly tested (11 dedicated tests, one bug's fix verified by deliberately reproducing the regression) and reviewed across two full 8-angle passes.
- Severity: low
- Concern: no backfill path exists for pruned `MoodArcCorpusRowV1` rows (unlike `InnerStateFeaturesV1`).
- Mitigation: documented explicitly; at the default policy (200MB × 5 = ~1GB retained) this is generous relative to the roadmap's stated "weeks, not months" scope before training would consume it.
