### PR TITLE
Feat/substrate projection debug endpoints

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-substrate-projection-debug-endpoints-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-substrate-projection-debug-endpoints-pr.md
@@ -1,0 +1,79 @@
+# PR: /projections/chat_session and /projections/route_arbitration debug endpoints
+
+Branch: `feat/substrate-projection-debug-endpoints` → `main`
+
+## Summary
+
+- Adds `GET /projections/chat_session` and `GET /projections/route_arbitration` to `orion-substrate-runtime`, mirroring the existing `GET /projections/execution_trajectory` endpoint's exact response contract.
+- Documents all three endpoints in the service README — `execution_trajectory`'s was never documented either, fixed while touching this section.
+
+This is the smaller, unambiguous half of the "is there a consumer/UI surface for route_grammar and stance_disposition" investigation from earlier today. The bigger half (whether/how `stance_disposition` should ever compose into `SelfStateV1`) was deliberately left undecided — see `docs/superpowers/specs/2026-07-13-stance-disposition-inner-state-path.md` — and this patch doesn't touch that question at all. It only makes projections that already exist and already work inspectable over HTTP, the same way `execution_trajectory` already was.
+
+## Outcome moved
+
+`chat_session` and `route_arbitration` projections go from "only inspectable via direct Postgres query" to "one curl away," matching the existing precedent. No composition decision required to ship this — safe regardless of which path the stance-disposition doc's three candidates eventually take.
+
+## Current architecture
+
+`services/orion-substrate-runtime/app/main.py` had one projection read endpoint (`execution_trajectory`, since `0c5e2a23`). `chat_session` (chat_grammar reducer) and `route_arbitration` (route_grammar reducer) have both been running correctly in production since earlier today with zero HTTP visibility.
+
+## Architecture touched
+
+`orion-substrate-runtime` only — `app/main.py` (two new handlers) and its README.
+
+## Files changed
+
+- `services/orion-substrate-runtime/app/main.py` — two new `@app.get` handlers, byte-for-byte identical contract shape to `execution_trajectory`. No changes to `store.py`/`worker.py`/reducers — both store methods (`load_chat_session_projection`, `load_route_arbitration`) and projection-id constants already existed, already used internally by `_chat_tick`/`_route_tick`. Pure wiring.
+- `services/orion-substrate-runtime/tests/test_chat_session_route_arbitration_endpoints.py` (new) — 4 tests (projection-present / no-projection × 2 endpoints), mirroring the existing `test_execution_trajectory_endpoint.py`'s `httpx.AsyncClient` + `ASGITransport` + mocked-store pattern exactly.
+- `services/orion-substrate-runtime/README.md` — new "Projection debug reads" subsection listing all three endpoints (execution_trajectory's was undocumented before this patch too).
+
+## Schema / bus / API changes
+
+- Added: `GET /projections/chat_session`, `GET /projections/route_arbitration` (internal debug endpoints, no auth, matching `execution_trajectory`'s existing posture — not exposed publicly).
+- Compatibility notes: purely additive, no existing endpoint's behavior changed.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```
+cd /mnt/scripts/Orion-Sapienform-projection-debug-endpoints
+/tmp/orion-test-venv/bin/python -m pytest services/orion-substrate-runtime/tests -k "projection or main or execution_trajectory" --ignore=services/orion-substrate-runtime/tests/test_grammar_consumer_integration.py -q
+→ 7 passed (4 new + 3 pre-existing execution_trajectory tests)
+```
+`test_grammar_consumer_integration.py` excluded — pre-existing `ModuleNotFoundError: No module named 'app.models'` collection failure, confirmed identical on unmodified `main` via `git stash`, unrelated to this patch.
+
+## Evals run
+
+Not applicable — dev-visibility endpoints only, no cognition/model component.
+
+## Docker/build/smoke checks
+
+Not deployed as part of this PR. No env/compose changes to validate.
+
+## Review findings fixed
+
+A focused review pass (correctness, import style, response-shape drift vs. `execution_trajectory`, test correctness, file-scope compliance) found nothing — clean diff.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
+```
+Verification after restart:
+```bash
+curl -fsS http://localhost:8115/projections/chat_session | python3 -m json.tool
+curl -fsS http://localhost:8115/projections/route_arbitration | python3 -m json.tool
+```
+Both should return `{"ok": true, "projection": {...}}` given both reducers are already live and have processed real traffic.
+
+## Risks / concerns
+
+None identified. Purely additive read-only endpoints over data that's already being written; no new write path, no new dependency, no config surface.
+
+## PR link
+
+Push and open via: `git push -u origin feat/substrate-projection-debug-endpoints`, then open the compare URL GitHub prints (no `gh` auth in this environment).

--- a/services/orion-substrate-runtime/README.md
+++ b/services/orion-substrate-runtime/README.md
@@ -69,6 +69,14 @@ Hub debug (node-scoped lineage):
 - `GET /api/substrate/biometrics-node/{node_id}/latest`
 - `GET /api/substrate/receipts/{receipt_id}`
 
+### Projection debug reads (this service, internal)
+
+Same response contract on all three: `{"ok": false, "reason": "no_projection"}` if the reducer hasn't written yet, `{"ok": true, "projection": {...}}` otherwise.
+
+- `GET /projections/execution_trajectory` — `active_execution_trajectory`
+- `GET /projections/chat_session` — `active_chat_session`
+- `GET /projections/route_arbitration` — `active_route_arbitration`
+
 ## Grammar production observe
 
 Truth: `GET http://localhost:8115/grammar/truth`

--- a/services/orion-substrate-runtime/app/main.py
+++ b/services/orion-substrate-runtime/app/main.py
@@ -33,6 +33,8 @@ from .goal_context_listener import (
     stop_goal_context_listener,
 )
 from orion.substrate.execution_loop.constants import EXECUTION_TRAJECTORY_PROJECTION_ID
+from orion.substrate.chat_loop.constants import CHAT_SESSION_PROJECTION_ID
+from orion.substrate.route_loop.constants import ROUTE_ARBITRATION_PROJECTION_ID
 
 from .settings import get_settings
 from .store import GRAMMAR_CURSOR_REGISTRY
@@ -99,6 +101,22 @@ async def grammar_truth() -> dict:
 @app.get("/projections/execution_trajectory")
 async def execution_trajectory() -> dict:
     proj = worker._store.load_execution_trajectory(EXECUTION_TRAJECTORY_PROJECTION_ID)
+    if proj is None:
+        return {"ok": False, "reason": "no_projection"}
+    return {"ok": True, "projection": proj.model_dump(mode="json")}
+
+
+@app.get("/projections/chat_session")
+async def chat_session() -> dict:
+    proj = worker._store.load_chat_session_projection(CHAT_SESSION_PROJECTION_ID)
+    if proj is None:
+        return {"ok": False, "reason": "no_projection"}
+    return {"ok": True, "projection": proj.model_dump(mode="json")}
+
+
+@app.get("/projections/route_arbitration")
+async def route_arbitration() -> dict:
+    proj = worker._store.load_route_arbitration(ROUTE_ARBITRATION_PROJECTION_ID)
     if proj is None:
         return {"ok": False, "reason": "no_projection"}
     return {"ok": True, "projection": proj.model_dump(mode="json")}

--- a/services/orion-substrate-runtime/tests/test_chat_session_route_arbitration_endpoints.py
+++ b/services/orion-substrate-runtime/tests/test_chat_session_route_arbitration_endpoints.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from orion.schemas.chat_projection import ChatSessionProjectionV1, ChatTurnStateV1
+from orion.schemas.route_projection import (
+    RouteArbitrationProjectionV1,
+    RouteArbitrationRunStateV1,
+)
+from orion.substrate.chat_loop.constants import CHAT_SESSION_PROJECTION_ID
+from orion.substrate.route_loop.constants import ROUTE_ARBITRATION_PROJECTION_ID
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _import_main(monkeypatch):
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://unused:5432/unused")
+    monkeypatch.setenv(
+        "NODE_CATALOG_PATH",
+        str(REPO_ROOT / "config" / "biometrics" / "node_catalog.yaml"),
+    )
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    import app.main as main
+
+    return main
+
+
+@pytest.mark.asyncio
+async def test_chat_session_endpoint_returns_projection(monkeypatch) -> None:
+    main = _import_main(monkeypatch)
+
+    now = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+    proj = ChatSessionProjectionV1(
+        projection_id=CHAT_SESSION_PROJECTION_ID,
+        generated_at=now,
+        turns={
+            "turn-1": ChatTurnStateV1(
+                trace_id="trace-1",
+                turn_id="turn-1",
+                session_id="session-1",
+                node_id="athena",
+                observed_at=now,
+                word_count=12,
+                last_updated_at=now,
+            )
+        },
+        total_turn_count=1,
+        sessions=["session-1"],
+    )
+    store = MagicMock()
+    store.load_chat_session_projection.return_value = proj
+    monkeypatch.setattr(main.worker, "_store", store, raising=False)
+
+    transport = ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/projections/chat_session")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["projection"]["turns"]["turn-1"]["session_id"] == "session-1"
+    store.load_chat_session_projection.assert_called_once_with(CHAT_SESSION_PROJECTION_ID)
+
+
+@pytest.mark.asyncio
+async def test_chat_session_endpoint_no_projection(monkeypatch) -> None:
+    main = _import_main(monkeypatch)
+
+    store = MagicMock()
+    store.load_chat_session_projection.return_value = None
+    monkeypatch.setattr(main.worker, "_store", store, raising=False)
+
+    transport = ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/projections/chat_session")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": False, "reason": "no_projection"}
+
+
+@pytest.mark.asyncio
+async def test_route_arbitration_endpoint_returns_projection(monkeypatch) -> None:
+    main = _import_main(monkeypatch)
+
+    now = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+    proj = RouteArbitrationProjectionV1(
+        projection_id=ROUTE_ARBITRATION_PROJECTION_ID,
+        generated_at=now,
+        runs={
+            "trace-1": RouteArbitrationRunStateV1(
+                trace_id="trace-1",
+                correlation_id="corr-1",
+                session_id="session-1",
+                turn_id="turn-1",
+                node_id="athena",
+                lane="mind",
+                lane_reason="high_salience",
+                mind_requested=True,
+                output_mode="stream",
+                last_updated_at=now,
+            )
+        },
+    )
+    store = MagicMock()
+    store.load_route_arbitration.return_value = proj
+    monkeypatch.setattr(main.worker, "_store", store, raising=False)
+
+    transport = ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/projections/route_arbitration")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["projection"]["runs"]["trace-1"]["lane"] == "mind"
+    store.load_route_arbitration.assert_called_once_with(ROUTE_ARBITRATION_PROJECTION_ID)
+
+
+@pytest.mark.asyncio
+async def test_route_arbitration_endpoint_no_projection(monkeypatch) -> None:
+    main = _import_main(monkeypatch)
+
+    store = MagicMock()
+    store.load_route_arbitration.return_value = None
+    monkeypatch.setattr(main.worker, "_store", store, raising=False)
+
+    transport = ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/projections/route_arbitration")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": False, "reason": "no_projection"}


### PR DESCRIPTION
# PR: /projections/chat_session and /projections/route_arbitration debug endpoints

Branch: `feat/substrate-projection-debug-endpoints` → `main`

## Summary

- Adds `GET /projections/chat_session` and `GET /projections/route_arbitration` to `orion-substrate-runtime`, mirroring the existing `GET /projections/execution_trajectory` endpoint's exact response contract.
- Documents all three endpoints in the service README — `execution_trajectory`'s was never documented either, fixed while touching this section.

This is the smaller, unambiguous half of the "is there a consumer/UI surface for route_grammar and stance_disposition" investigation from earlier today. The bigger half (whether/how `stance_disposition` should ever compose into `SelfStateV1`) was deliberately left undecided — see `docs/superpowers/specs/2026-07-13-stance-disposition-inner-state-path.md` — and this patch doesn't touch that question at all. It only makes projections that already exist and already work inspectable over HTTP, the same way `execution_trajectory` already was.

## Outcome moved

`chat_session` and `route_arbitration` projections go from "only inspectable via direct Postgres query" to "one curl away," matching the existing precedent. No composition decision required to ship this — safe regardless of which path the stance-disposition doc's three candidates eventually take.

## Current architecture

`services/orion-substrate-runtime/app/main.py` had one projection read endpoint (`execution_trajectory`, since `0c5e2a23`). `chat_session` (chat_grammar reducer) and `route_arbitration` (route_grammar reducer) have both been running correctly in production since earlier today with zero HTTP visibility.

## Architecture touched

`orion-substrate-runtime` only — `app/main.py` (two new handlers) and its README.

## Files changed

- `services/orion-substrate-runtime/app/main.py` — two new `@app.get` handlers, byte-for-byte identical contract shape to `execution_trajectory`. No changes to `store.py`/`worker.py`/reducers — both store methods (`load_chat_session_projection`, `load_route_arbitration`) and projection-id constants already existed, already used internally by `_chat_tick`/`_route_tick`. Pure wiring.
- `services/orion-substrate-runtime/tests/test_chat_session_route_arbitration_endpoints.py` (new) — 4 tests (projection-present / no-projection × 2 endpoints), mirroring the existing `test_execution_trajectory_endpoint.py`'s `httpx.AsyncClient` + `ASGITransport` + mocked-store pattern exactly.
- `services/orion-substrate-runtime/README.md` — new "Projection debug reads" subsection listing all three endpoints (execution_trajectory's was undocumented before this patch too).

## Schema / bus / API changes

- Added: `GET /projections/chat_session`, `GET /projections/route_arbitration` (internal debug endpoints, no auth, matching `execution_trajectory`'s existing posture — not exposed publicly).
- Compatibility notes: purely additive, no existing endpoint's behavior changed.

## Env/config changes

None.

## Tests run

```
cd /mnt/scripts/Orion-Sapienform-projection-debug-endpoints
/tmp/orion-test-venv/bin/python -m pytest services/orion-substrate-runtime/tests -k "projection or main or execution_trajectory" --ignore=services/orion-substrate-runtime/tests/test_grammar_consumer_integration.py -q
→ 7 passed (4 new + 3 pre-existing execution_trajectory tests)
```
`test_grammar_consumer_integration.py` excluded — pre-existing `ModuleNotFoundError: No module named 'app.models'` collection failure, confirmed identical on unmodified `main` via `git stash`, unrelated to this patch.

## Evals run

Not applicable — dev-visibility endpoints only, no cognition/model component.

## Docker/build/smoke checks

Not deployed as part of this PR. No env/compose changes to validate.

## Review findings fixed

A focused review pass (correctness, import style, response-shape drift vs. `execution_trajectory`, test correctness, file-scope compliance) found nothing — clean diff.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
```
Verification after restart:
```bash
curl -fsS http://localhost:8115/projections/chat_session | python3 -m json.tool
curl -fsS http://localhost:8115/projections/route_arbitration | python3 -m json.tool
```
Both should return `{"ok": true, "projection": {...}}` given both reducers are already live and have processed real traffic.

## Risks / concerns

None identified. Purely additive read-only endpoints over data that's already being written; no new write path, no new dependency, no config surface.
