### PR TITLE
Feat/graphiti core backend activation

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-graphiti-core-backend-activation-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-graphiti-core-backend-activation-pr.md
@@ -1,0 +1,131 @@
+# PR report: graphiti-core backend activation
+
+## Summary
+
+- Live-activated the already-merged `graphiti_core` backend on `orion-graphiti-adapter` (`GRAPHITI_BACKEND=graphiti_core`, `FALKORDB_ENABLED=true`) against a real FalkorDB container — this had never been run against live infrastructure before, only mocked unit tests.
+- Found and fixed 3 crash bugs in `backends/graphiti_core.py` / `crystallization_ids.py` that made `/v1/episodes`, `/v1/rebuild`, and `/v1/search` 500 against real data and a real `graphiti-core==0.19.0` driver — invisible to the existing fully-mocked test suite.
+- Backfilled all 59 `status=active` crystallizations into FalkorDB (58 landed; the 1 excluded is a real `sensitivity=intimate` row, correctly filtered — verified directly, not just via the synthetic unit test).
+- Added `scripts/smoke_graphiti_search_e2e.sh`, a live (non-mocked) search smoke. It intentionally documents a **known FAIL**: `/v1/search` runs cleanly and calls the real embed host, but returns zero results for real ingested data — `graphiti-core==0.19.0`'s own search only reads its `RELATES_TO`-shaped edges, which this adapter's raw-Cypher `ingest_episode()` never writes. Root cause fully documented in the script header and README; not fixed here (out of scope — needs a follow-up decision on write path).
+- Confirmed backend-agnostic neighborhood/BFS traversal (Phase B, `smoke_graphiti_links_e2e.sh`) is unaffected either direction.
+- Confirmed rollback (`GRAPHITI_BACKEND=orion_postgres`) restores `/v1/search` → 501 with neighborhood unaffected, then re-forwarded to leave the live system in the activated state.
+
+## Outcome moved
+
+The `graphiti_core` backend went from "code exists, zero runtime evidence" to "running live against real FalkorDB with real Orion belief data, with the one broken capability (`/v1/search` result matching) explicitly failing loud instead of silently returning empty and looking fine." Per AGENTS.md's "runtime truth beats config truth" — this is the first real evidence this backend does or doesn't work, in either direction.
+
+## Current architecture (before this patch)
+
+`orion-graphiti-adapter` ran with `GRAPHITI_BACKEND=orion_postgres`, `FALKORDB_ENABLED=false`. The `graphiti_core` backend module existed and had 100% mocked test coverage (driver, `graphiti_core.Graphiti` class, and module import were all patched out — never touched a real FalkorDB instance or a real `graphiti-core` package call).
+
+## Architecture touched
+
+- `services/orion-graphiti-adapter` runtime env (live `.env`, not committed — gitignored, see Env/config below)
+- `services/orion-graphiti-adapter/app/backends/graphiti_core.py` — bug fixes, no new capability added
+- `services/orion-graphiti-adapter/app/crystallization_ids.py` — validation bug fix
+- `scripts/` — one new live smoke, one existing smoke's propose payload fixed (pre-existing validator drift, unrelated to graphiti, but blocking this task's "when done" checklist)
+
+## Files changed
+
+- `docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md`: the spec this PR implements
+- `scripts/smoke_graphiti_search_e2e.sh` (new): live, non-mocked `/v1/search` verification; documents the known-failing root cause in its header
+- `scripts/smoke_graphiti_links_e2e.sh`: propose payload was missing `planning_effects`/`retrieval_affordances`, so `validate_proposal()` auto-quarantined every crystallization the script created (pre-existing drift in `orion/memory/crystallization/validator.py`, unrelated to this task; fixed because it silently broke this Phase B regression smoke)
+- `services/orion-graphiti-adapter/README.md`: documents live runtime state, the search-smoke's known-fail, and clarifies neighborhood is backend-agnostic
+- `services/orion-graphiti-adapter/app/backends/graphiti_core.py`:
+  - `validate_crystallization_id()` call sites no longer reject bare-UUID `crystallization_id` values (real data shape; the `crys_` prefix is only used for derived ids)
+  - `driver.execute_query()` calls fixed to pass a single params dict as keyword args, matching `graphiti-core==0.19.0`'s `FalkorDriver.execute_query(self, cypher_query_, **kwargs)` signature (previously passed a second positional dict, raising `TypeError` against the real driver)
+  - Added `_no_op_llm_client()`, `_no_op_cross_encoder()`, `_orion_embedder_client()` — `Graphiti()` eagerly builds OpenAI-backed clients unless given explicit ones; there is no `OPENAI_API_KEY` configured and none of this adapter's usage needs an LLM (writes are raw Cypher, not `add_episode()` entity extraction). The embedder stub bridges to Orion's own `CRYSTALLIZER_EMBED_HOST_URL` instead of OpenAI.
+- `services/orion-graphiti-adapter/app/crystallization_ids.py`: `validate_crystallization_id()` now accepts bare UUIDs (real shape) in addition to `crys_`-prefixed ids (derived-id shape); still rejects anything that isn't `[a-zA-Z0-9_-]+` (injection guard — moot in practice since all Cypher calls are parameterized, but kept as defense in depth)
+- `services/orion-graphiti-adapter/tests/test_crystallization_ids.py`: regression test for the bare-UUID fix
+- `services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py`: regression test asserting `execute_query` call args match the real driver's calling convention; updated the search test's fakes for the new stub-client constructor signature
+
+## Schema / bus / API changes
+
+- Added: none
+- Removed: none
+- Renamed: none
+- Behavior changed: `/v1/episodes`, `/v1/rebuild`, and `/v1/search` on `orion-graphiti-adapter` now work against real data when `GRAPHITI_BACKEND=graphiti_core` (previously crashed). `/v1/search` still returns empty `crystallization_ids` for real data — a pre-existing, now-documented gap, not a regression from this patch (there was no working `/v1/search` before this patch to regress from).
+- Compatibility notes: `orion_postgres` backend and Phase B neighborhood/link behavior are byte-for-byte unchanged; rollback verified.
+
+## Env/config changes
+
+- Added keys: none (all keys already existed in `.env_example`)
+- Removed keys: none
+- Renamed keys: none
+- `.env_example` updated: no (key shapes unchanged)
+- Live runtime `.env` changes (gitignored, not committed, host-level only):
+  - `services/orion-graphiti-adapter/.env`: `GRAPHITI_BACKEND=orion_postgres` → `graphiti_core`; `FALKORDB_ENABLED=false` → `true`; `CRYSTALLIZER_EMBED_HOST_URL=` → `http://orion-athena-vector-host:8320/embedding`
+  - `services/orion-hub/.env`: `GRAPHITI_ADAPTER_URL` changed from `http://orion-athena-graphiti-adapter:8000` to `http://127.0.0.1:8640` — pre-existing bug unrelated to this task's plan, found because Hub runs `network_mode: host` and cannot resolve the adapter's container DNS name; the fix matches the pattern already used for `CRYSTALLIZER_EMBED_HOST_URL`/`RECALL_PG_DSN` in the same file. Without this fix, Hub-mediated smokes (`smoke_graphiti_links_e2e.sh`, `smoke_graphiti_search_e2e.sh`, the active-packet check) could not reach the adapter at all.
+- skipped keys requiring operator action: none
+
+## Tests run
+
+```text
+$ source venv/bin/activate && python -m pytest services/orion-graphiti-adapter/tests -q
+15 passed, 2 warnings in 0.72s
+```
+(Independently re-run by orchestrator after the implementing agent's session, not just taken on report.)
+
+## Evals run
+
+No eval harness exists for `orion-graphiti-adapter`. The two live e2e smokes below are the closest equivalent and are the deterministic gate for this capability going forward.
+
+## Docker/build/smoke checks
+
+```text
+$ curl -sS http://localhost:8640/health
+{"service":"orion-graphiti-adapter","postgres":true,"falkordb_enabled":true,"backend":"graphiti_core"}
+
+$ bash scripts/smoke_graphiti_links_e2e.sh
+PASS smoke_graphiti_links_e2e seed=53d31c3a-e308-456c-bad9-33e6c11b1480 linked=b2918b5e-e8e1-40f2-820b-fccae45a7e52
+
+$ bash scripts/smoke_graphiti_search_e2e.sh
+FAIL smoke_graphiti_search_e2e: crystallization_ids missing seed=4c45a09e-e796-47cf-801d-0a6c310755e3
+response={"crystallization_ids":[],"trace":{"backend":"graphiti_core","rails":["vector","graph"],
+"query":"Graphiti search smoke subject zz20260713051855","embed_used":true,"result_count":0,
+"raw_type":"list"}}
+(expected FAIL — documented root cause in script header and README; exit 1 is correct, not flaky)
+
+# Backfill verification (orchestrator, independent of agent's report):
+$ psql -c "select count(*) from memory_crystallizations where status='active'"        -> 59
+$ psql -c "select count(*) from memory_crystallizations where status='active' and
+           governance->>'sensitivity'='intimate'"                                      -> 1
+$ redis-cli GRAPH.QUERY graphiti_temporal "MATCH (n:Entity) RETURN count(n)"           -> 58
+# 59 active - 1 correctly-excluded intimate = 58 in FalkorDB. Exact match.
+
+# Privacy check (orchestrator, independent — corrects an inaccuracy in the implementing
+# agent's own report, which claimed "0 intimate active crystallizations" when there is
+# actually 1; the exclusion itself is verified correct on that real row):
+$ redis-cli GRAPH.QUERY graphiti_temporal \
+    "MATCH (n) WHERE n.crystallization_id = '0fc34990-541e-48f0-adca-aa8686bb1521' RETURN n.id"
+(empty result — confirmed absent from FalkorDB)
+```
+
+All smoke/test output above was re-run independently by the orchestrator after the implementing subagent's session ended, not taken on the subagent's report alone.
+
+## Review findings fixed
+
+Code review skill was not run as a separate subagent pass for this PR — the orchestrator directly read every changed file (`graphiti_core.py`, `crystallization_ids.py`, both smoke scripts, README, both test files) and independently re-ran tests and both live smokes rather than trusting the implementing agent's self-report. One material inaccuracy was caught this way: the implementing agent's report claimed "0 intimate active crystallizations" in real data; there is actually 1, and the report is corrected above. No other discrepancies found between the agent's claims and independently observed behavior.
+
+## Restart required
+
+Already executed live as part of this activation (not pending):
+
+```bash
+docker compose --profile falkordb \
+  --env-file .env --env-file services/orion-graphiti-adapter/.env \
+  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
+```
+
+If this PR is merged and redeployed on a different host/environment, the same command plus the three `.env` key changes listed above under Env/config changes must be applied there — they are runtime-only and do not travel with the git merge.
+
+## Risks / concerns
+
+- Severity: Medium — `/v1/search` (the headline new capability) does not find real data today. `scripts/smoke_graphiti_search_e2e.sh` is committed in a known-FAIL state on purpose (a failing gate is the correct signal per AGENTS.md, not a passing-but-lying test). Closing this requires a follow-up decision: either wire a real LLM client into `graphiti-core`'s own `add_episode()`/`add_triplet()` write path, or hand-write `RELATES_TO`-shaped edges with a synthesized fact + embedding to match what `graphiti-core`'s search actually reads. Both are larger patches with real design tradeoffs, out of scope here.
+- Severity: Medium — this host had multiple concurrent Claude Code sessions active during implementation; one was observed rebuilding `orion-graphiti-adapter` from `main` mid-task, twice reverting the implementing agent's live fixes until redeployed. Final state is verified correct at time of this report (re-verified independently by the orchestrator after the fact), but the live container's correctness is not guaranteed to persist without this branch being merged and redeployed as the new baseline.
+- Severity: Low — `search()` rebuilds the FalkorDB driver and stub `Graphiti`/embedder/llm/cross-encoder clients fresh on every `/v1/search` request. Not a correctness bug, flagged as a legitimate follow-up (connection reuse) not addressed here to keep this patch to the activation's actual scope.
+
+## PR link
+
+Not opened via `gh` (no `GH_TOKEN`/`.netrc` credential exists in this environment and the git remote is SSH-only, so there is no way to call the GitHub REST API to create a PR object without `gh`). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/graphiti-core-backend-activation?expand=1`

--- a/docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md
+++ b/docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md
@@ -1,0 +1,134 @@
+# Graphiti-core backend activation (search rail only)
+
+**Date:** 2026-07-13
+**Status:** Approved for implementation — activation, not a build
+**Scope:** Flip already-built `graphiti_core` backend live. **Do not touch** `orion/memory/consolidation_gate.py`, `low_info_social.py`, or any `MEMORY_CONSOLIDATION_*` threshold. That system is live and correct (48 active / 10 proposed / 27 rejected crystallizations) and is out of scope.
+
+---
+
+## Ground truth (verified, not assumed)
+
+| Claim | Evidence |
+|---|---|
+| Graphiti Phase A/B/C already merged to `main` | `services/orion-graphiti-adapter/app/backends/{orion_postgres,graphiti_core}.py` exist, tested |
+| Adapter is running now | `orion-athena-graphiti-adapter` container `Up`, backend=`orion_postgres` |
+| Neighborhood/BFS is backend-agnostic | `graphiti_core.get_neighborhood()` (`backends/graphiti_core.py:198-203`) delegates to `pg_neighborhood` regardless of `GRAPHITI_BACKEND` — traversal already works today |
+| **Only `/v1/search` is gated** by `GRAPHITI_BACKEND` | `main.py:170-172` — returns HTTP 501 unless `graphiti_core` |
+| `graphiti_core` backend untested against real FalkorDB | `test_graphiti_core_backend.py` mocks the driver and the `graphiti_core` module entirely |
+| Embed URL empty on adapter | `services/orion-graphiti-adapter/.env:21` `CRYSTALLIZER_EMBED_HOST_URL=` (siblings use `http://orion-athena-vector-host:8320/embedding`) |
+| Approve already auto-projects to Graphiti | `crystallization_approve_proposal` → `project_crystallization(config=_projection_config())`, `graphiti_enabled=True` since `GRAPHITI_ENABLED=true`; `project_graphiti` defaults `True` unless overridden — **future approvals need no backfill action** |
+| Env is unblocked | port 6380 free, `app-net` network exists, `falkordb/falkordb:latest` pulls clean |
+| Real belief data exists | Postgres `memory_crystallizations`: 48 `active` |
+
+**Reframed problem:** this is not "turn on graph memory" (graph traversal is already live). It is "turn on hybrid vector+graph search, verify it's real against real FalkorDB, and backfill it with Orion's 48 existing beliefs so it isn't an empty shell."
+
+---
+
+## Non-goals
+
+- No change to `consolidation_gate.py`, `low_info_social.py`, `MEMORY_CONSOLIDATION_OUTPUT`/`MIN_NOVELTY`/`MIN_SIGNIFICANCE`
+- No change to `orion_postgres` backend code, neighborhood BFS, or link projection (Phase B)
+- No new schema, no new bus channel, no new crystallization kind
+- No pinning/upgrading `graphiti-core` version in this pass (flag if 0.19.0 breaks against real FalkorDB — separate patch)
+
+---
+
+## Steps (execute in order; each has a verify)
+
+### 1. Config flip
+`services/orion-graphiti-adapter/.env` (+ mirror in `.env_example` if any key shape changes — it doesn't, keys already exist):
+```
+GRAPHITI_BACKEND=graphiti_core
+FALKORDB_ENABLED=true
+CRYSTALLIZER_EMBED_HOST_URL=http://orion-athena-vector-host:8320/embedding
+```
+Run `python scripts/sync_local_env_from_example.py`.
+**Verify:** `git diff services/orion-graphiti-adapter/.env` shows exactly these 3 lines changed.
+
+### 2. Bring up FalkorDB + restart adapter
+```bash
+docker compose --profile falkordb \
+  --env-file .env --env-file services/orion-graphiti-adapter/.env \
+  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
+```
+**Verify:** `curl -fsS http://localhost:8640/health | jq '.backend'` → `"graphiti_core"`
+
+### 3. Backfill 48 active crystallizations (one-time)
+Call Hub rebuild route (or adapter `/v1/rebuild` directly) over all `status=active` rows.
+**Verify:** FalkorDB entity node count == `select count(*) from memory_crystallizations where status='active'` (48). Query via adapter debug/Cypher count, not assumption.
+
+### 4. Live search smoke (new, non-mocked)
+New script `scripts/smoke_graphiti_search_e2e.sh`, permanent (matches existing `smoke_graphiti_links_e2e.sh` convention — no special-casing):
+- propose+approve 1 crystallization with a known subject string
+- `POST /v1/search {"query": "<subject>"}`
+- assert `crystallization_ids` non-empty AND `trace.embed_used == true`
+**Verify:** script exits 0.
+
+### 5. Chat-visible effect (not just adapter health)
+Pick 2 already-linked crystallizations where the link (not either alone) answers a question. Call `retrieve_active_packet()` path (existing wiring, `retriever.py:79-81` already calls `/v1/search` when `health.backend == graphiti_core`).
+**Verify:** response `graphiti_refs` contains both crystallization IDs.
+
+### 6. Privacy check on real data
+```sql
+select crystallization_id from memory_crystallizations
+where status='active' and metadata->>'sensitivity' = 'intimate';
+```
+**Verify:** none of these IDs appear in FalkorDB nodes or in any `/v1/search` result (existing skip logic at `graphiti_core.py:128-129`, `_filter_intimate_crystallization_ids`).
+
+### 7. Rollback rehearsal
+Flip `GRAPHITI_BACKEND=orion_postgres`, restart, confirm `/v1/search` → 501 again, neighborhood endpoint unaffected (never depended on the flag). Flip forward again.
+**Verify:** both states produce expected status codes.
+
+---
+
+## Acceptance checks
+
+- [ ] `/health` reports `backend: graphiti_core`, `embed_used: true` on search trace
+- [ ] FalkorDB node count matches active crystallization count post-backfill
+- [ ] `smoke_graphiti_search_e2e.sh` passes and is committed to `scripts/`
+- [ ] `smoke_graphiti_links_e2e.sh` still passes (Phase B neighborhood unaffected)
+- [ ] Active-packet fusion demonstrably surfaces a graph-only-reachable belief
+- [ ] Zero `intimate` crystallizations reachable via FalkorDB or `/v1/search`
+- [ ] Rollback to `orion_postgres` verified clean
+- [ ] `consolidation_gate.py` / worker.py diff: empty
+
+---
+
+## Env/config changes
+
+| Key | File | Before → After |
+|---|---|---|
+| `GRAPHITI_BACKEND` | `services/orion-graphiti-adapter/.env` | `orion_postgres` → `graphiti_core` |
+| `FALKORDB_ENABLED` | `services/orion-graphiti-adapter/.env` | `false` → `true` |
+| `CRYSTALLIZER_EMBED_HOST_URL` | `services/orion-graphiti-adapter/.env` | `` → `http://orion-athena-vector-host:8320/embedding` |
+
+No `.env_example` shape changes (keys pre-exist). Local `.env` sync required per key change.
+
+---
+
+## Risks
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| Medium | `graphiti-core==0.19.0` API drift vs `falkordb/falkordb:latest` (unpinned image tag) | Step 4 is the real test; pin image tag if it breaks |
+| Medium | Dual-write divergence: FalkorDB write silently fails while Postgres dual-write in `ingest_episode` succeeds | Step 3 count-match check surfaces this; no code fix in this pass unless found |
+| Low | Backfill misses future approvals | Not a risk — approve path already auto-projects (verified in Ground truth) |
+
+---
+
+## Restart required
+
+```bash
+docker compose --profile falkordb \
+  --env-file .env --env-file services/orion-graphiti-adapter/.env \
+  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
+```
+
+## Rollback
+
+```bash
+# set GRAPHITI_BACKEND=orion_postgres in services/orion-graphiti-adapter/.env
+docker compose --env-file .env --env-file services/orion-graphiti-adapter/.env \
+  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
+```
+No canonical Postgres crystallization data is touched by any step above (`canonical_mutated` invariant holds throughout).

--- a/scripts/smoke_graphiti_links_e2e.sh
+++ b/scripts/smoke_graphiti_links_e2e.sh
@@ -9,10 +9,15 @@ STAMP="$(date -u +%Y%m%d%H%M%S)"
 
 _propose() {
   local subject="$1" summary="$2"
+  # planning_effects/retrieval_affordances required for kind=stance since
+  # orion/memory/crystallization/validator.py::validate_proposal was tightened -- without
+  # them propose() auto-quarantines (status=quarantined) and everything downstream 404s.
   curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/propose" -d "$(jq -n --arg s "$subject" --arg m "$summary" '{
     kind: "stance", subject: $s, summary: $m, scope: ["project:orion"],
     evidence: [{source_kind: "operator_note", source_id: "smoke-link", excerpt: "smoke"}],
-    proposed_by: "smoke"
+    proposed_by: "smoke",
+    planning_effects: ["smoke_test_context"],
+    retrieval_affordances: ["smoke_test_lookup"]
   }')" | jq -r '.crystallization_id'
 }
 

--- a/scripts/smoke_graphiti_search_e2e.sh
+++ b/scripts/smoke_graphiti_search_e2e.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Smoke: propose+approve a crystallization with a distinctive subject, then confirm
+# POST /v1/search (graphiti_core backend, hybrid vector+graph rail) finds it for real
+# against a live FalkorDB — not a mock. Requires GRAPHITI_BACKEND=graphiti_core on the
+# adapter (health.backend == "graphiti_core"); otherwise /v1/search returns HTTP 501.
+#
+# KNOWN FAILING as of 2026-07-13 activation pass (see PR/spec 2026-07-13-graphiti-core-
+# backend-activation): /v1/search runs without crashing and does call the real embed host
+# (trace.embed_used=true), but crystallization_ids comes back empty for data written by
+# this adapter's own ingest_episode(). Root cause: ingest_episode() writes raw Cypher
+# (:Entity)-[:HAS_EPISODE]->(:Episode) and (:Entity)-[:RELATED]->(:Entity) shapes, but
+# graphiti-core==0.19.0's Graphiti.search() only queries (:Entity)-[:RELATES_TO {uuid,
+# fact, fact_embedding, group_id}]->(:Entity) edges (confirmed via
+# graphiti_core.search.search_utils.edge_fulltext_search source) plus a fulltext index
+# this adapter never creates. The write path and graphiti-core's own read path are two
+# different, incompatible graph schemas. Populating the RELATES_TO schema natively means
+# either wiring a real LLM client for graphiti-core's add_episode()/add_triplet() (which
+# internally call resolve_extracted_edge(self.llm_client, ...) even for the no-LLM-needed
+# add_triplet path), or hand-writing RELATES_TO-shaped edges with a synthesized fact +
+# fact_embedding — both larger, separate-decision-required patches, not this activation's
+# scope. Left failing intentionally rather than deleted or weakened: this is the correct,
+# honest signal until a human decides how to close the gap. Neighborhood/BFS (backend-
+# agnostic, scripts/smoke_graphiti_links_e2e.sh) is unaffected and still finds linked
+# crystallizations; so does the graphiti_neighborhood rail inside retrieve_active_packet().
+set -euo pipefail
+: "${ORION_HUB_URL:?}"
+: "${ORION_HUB_SESSION_ID:?}"
+: "${GRAPHITI_ADAPTER_URL:?}"
+BASE="${ORION_HUB_URL%/}"
+ADAPTER="${GRAPHITI_ADAPTER_URL%/}"
+HDR=(-H "Content-Type: application/json" -H "X-Orion-Session-Id: ${ORION_HUB_SESSION_ID}")
+STAMP="$(date -u +%Y%m%d%H%M%S)"
+SUBJECT="Graphiti search smoke subject zz${STAMP}"
+
+BACKEND=$(curl -sS "${ADAPTER}/health" | jq -r '.backend')
+if [[ "$BACKEND" != "graphiti_core" ]]; then
+  echo "FAIL smoke_graphiti_search_e2e: adapter backend=${BACKEND}, expected graphiti_core" >&2
+  exit 1
+fi
+
+_propose() {
+  local subject="$1" summary="$2"
+  curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/propose" -d "$(jq -n --arg s "$subject" --arg m "$summary" '{
+    kind: "stance", subject: $s, summary: $m, scope: ["project:orion"],
+    evidence: [{source_kind: "operator_note", source_id: "smoke-search", excerpt: "smoke"}],
+    proposed_by: "smoke",
+    planning_effects: ["smoke_test_context"],
+    retrieval_affordances: ["smoke_test_lookup"]
+  }')" | jq -r '.crystallization_id'
+}
+
+_approve() {
+  local cid="$1"
+  curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/proposals/${cid}/validate" >/dev/null
+  curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/proposals/${cid}/approve" -d '{}' >/dev/null
+}
+
+CID="$(_propose "$SUBJECT" "smoke summary for graphiti search")"
+_approve "$CID"
+
+curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/graphiti/sync/${CID}" -d '{}' >/dev/null
+
+SR=$(curl -sS -H "Content-Type: application/json" -X POST "${ADAPTER}/v1/search" -d "$(jq -n --arg q "$SUBJECT" '{query: $q, limit: 10}')")
+CIDS=$(echo "$SR" | jq -r '.crystallization_ids[]?')
+EMBED_USED=$(echo "$SR" | jq -r '.trace.embed_used')
+
+echo "$CIDS" | grep -qx "$CID" || { echo "FAIL smoke_graphiti_search_e2e: crystallization_ids missing seed=${CID} response=${SR}" >&2; exit 1; }
+[[ "$EMBED_USED" == "true" ]] || { echo "FAIL smoke_graphiti_search_e2e: trace.embed_used=${EMBED_USED} response=${SR}" >&2; exit 1; }
+
+echo "PASS smoke_graphiti_search_e2e seed=${CID} embed_used=${EMBED_USED}"

--- a/services/orion-graphiti-adapter/README.md
+++ b/services/orion-graphiti-adapter/README.md
@@ -16,15 +16,30 @@ Additive temporal graph projection service for `MemoryCrystallizationV1`.
 
 Hub `GraphitiAdapter` calls this service when `GRAPHITI_URL` is set.
 
-## graphiti_core backend smoke
+## graphiti_core backend
+
+`GRAPHITI_BACKEND=graphiti_core` is the deployed runtime state for this Orion node's live
+adapter container as of the 2026-07-13 activation pass (see
+`docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md`); `settings.py`'s
+and `.env_example`'s code-level default remains `orion_postgres` and stays that way for fresh
+deployments until `/v1/search` is proven to find real data end to end (see the smoke table
+below — it currently does not). `orion_postgres` is the fallback/rollback backend;
+neighborhood/BFS traversal is backend-agnostic and identical either way (`get_neighborhood()`
+always delegates to the Postgres projection). Only `POST /v1/search` (hybrid vector+graph) is
+gated by this flag.
 
 ```bash
-GRAPHITI_BACKEND=graphiti_core FALKORDB_ENABLED=true \
-docker compose --profile falkordb --env-file services/orion-graphiti-adapter/.env \
+docker compose --profile falkordb \
+  --env-file .env --env-file services/orion-graphiti-adapter/.env \
   -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
 ```
 
-Rollback: `GRAPHITI_BACKEND=orion_postgres` and restart adapter.
+Rollback: `GRAPHITI_BACKEND=orion_postgres` and restart adapter (`/v1/search` → 501).
+
+| Live smoke | Covers |
+|---|---|
+| `scripts/smoke_graphiti_links_e2e.sh` | Phase B link ingest + neighborhood BFS (backend-agnostic) |
+| `scripts/smoke_graphiti_search_e2e.sh` | `/v1/search` against real FalkorDB — **currently known-failing**: `graphiti-core==0.19.0`'s `Graphiti.search()` only matches its own `RELATES_TO`-shaped edges, which this adapter's raw-Cypher `ingest_episode()` does not write (see script header for full root cause) |
 
 ## FalkorDB profile (optional)
 

--- a/services/orion-graphiti-adapter/app/backends/graphiti_core.py
+++ b/services/orion-graphiti-adapter/app/backends/graphiti_core.py
@@ -95,14 +95,14 @@ async def _filter_intimate_crystallization_ids(
     if not crystallization_ids:
         return crystallization_ids
     try:
-        rows, _ = await driver.execute_query(
+        rows, _header, _summary = await driver.execute_query(
             """
             UNWIND $ids AS cid
             MATCH (n)
             WHERE n.crystallization_id = cid AND n.sensitivity = 'intimate'
             RETURN DISTINCT n.crystallization_id AS cid
             """,
-            {"ids": crystallization_ids},
+            ids=crystallization_ids,
         )
         intimate = {str(row.get("cid") if isinstance(row, dict) else row[0]) for row in (rows or [])}
         return [cid for cid in crystallization_ids if cid not in intimate]
@@ -142,14 +142,12 @@ async def ingest_episode(
         SET ep.kind = $kind, ep.sensitivity = $sensitivity
         MERGE (e)-[:HAS_EPISODE]->(ep)
         """,
-        {
-            "entity_id": entity_id,
-            "crystallization_id": crystallization_id,
-            "episode_id": episode_id,
-            "name": subject,
-            "kind": kind,
-            "sensitivity": sensitivity,
-        },
+        entity_id=entity_id,
+        crystallization_id=crystallization_id,
+        episode_id=episode_id,
+        name=subject,
+        kind=kind,
+        sensitivity=sensitivity,
     )
     edge_ids.append(f"ged_{crystallization_id}")
 
@@ -166,14 +164,12 @@ async def ingest_episode(
             MERGE (e)-[r:RELATED]->(t)
             SET r.relation = $relation, r.confidence = $confidence
             """,
-            {
-                "target_entity_id": target_entity_id,
-                "target_id": target_id,
-                "target_sensitivity": str(link.get("sensitivity") or "public"),
-                "entity_id": entity_id,
-                "relation": relation,
-                "confidence": confidence,
-            },
+            target_entity_id=target_entity_id,
+            target_id=target_id,
+            target_sensitivity=str(link.get("sensitivity") or "public"),
+            entity_id=entity_id,
+            relation=relation,
+            confidence=confidence,
         )
         edge_ids.append(f"ged_{crystallization_id}_{target_id}_{relation}")
 
@@ -203,6 +199,67 @@ async def get_neighborhood(
     return await pg_neighborhood(pool, crystallization_id, depth=depth)
 
 
+def _no_op_llm_client() -> Any:
+    """graphiti-core's Graphiti() eagerly builds an OpenAIClient() for llm_client if one
+    isn't supplied, which raises at import time without OPENAI_API_KEY. Orion never calls
+    add_episode()/entity-extraction through graphiti-core (nodes are written via raw Cypher
+    in ingest_episode above), so search() never actually invokes the LLM client -- this stub
+    only exists to satisfy Graphiti's constructor.
+    """
+    from graphiti_core.llm_client.client import LLMClient
+    from graphiti_core.llm_client.config import LLMConfig
+
+    class _NullLLMClient(LLMClient):
+        def __init__(self) -> None:
+            super().__init__(config=LLMConfig(), cache=False)
+
+        async def _generate_response(self, messages, response_model=None, max_tokens=8192, model_size=None):  # type: ignore[override]
+            return {}
+
+    return _NullLLMClient()
+
+
+def _no_op_cross_encoder() -> Any:
+    """RRF (Orion's search config) doesn't invoke the cross-encoder reranker, but Graphiti()
+    still eagerly builds an OpenAIRerankerClient() by default without one supplied. Identity
+    stub only; never exercised by the reciprocal-rank-fusion search path used here.
+    """
+    from graphiti_core.cross_encoder.client import CrossEncoderClient
+
+    class _NullCrossEncoder(CrossEncoderClient):
+        async def rank(self, query: str, passages: list[str]) -> list[tuple[str, float]]:  # type: ignore[override]
+            return [(p, 0.0) for p in passages]
+
+    return _NullCrossEncoder()
+
+
+def _orion_embedder_client(embed_url: str) -> Any:
+    """Bridges graphiti-core's cosine-similarity search rail to Orion's own embedding host
+    (CRYSTALLIZER_EMBED_HOST_URL) instead of the library's default OpenAIEmbedder.
+
+    Tracks whether a call actually produced a vector on the instance itself (`.used`) so
+    callers can report an honest embed_used trace field without a second, redundant HTTP
+    call to the embed host for the same query text.
+    """
+    from graphiti_core.embedder.client import EmbedderClient
+
+    class _OrionEmbedderClient(EmbedderClient):
+        def __init__(self) -> None:
+            self.used = False
+
+        async def create(self, input_data) -> list[float]:  # type: ignore[override]
+            text = input_data[0] if isinstance(input_data, list) and input_data else str(input_data)
+            vector = await _embed_query(str(text), embed_url)
+            if vector:
+                self.used = True
+            return vector or []
+
+        async def create_batch(self, input_data_list: list[str]) -> list[list[float]]:  # type: ignore[override]
+            return [await self.create(item) for item in input_data_list]
+
+    return _OrionEmbedderClient()
+
+
 async def search(
     query: str,
     *,
@@ -215,18 +272,15 @@ async def search(
     from graphiti_core import Graphiti
 
     driver = _falkor_driver(falkordb_uri, graph_name)
-    graphiti = Graphiti(graph_driver=driver)
-    embedding = await _embed_query(query, embed_url)
+    embedder = _orion_embedder_client(embed_url)
+    graphiti = Graphiti(
+        graph_driver=driver,
+        llm_client=_no_op_llm_client(),
+        embedder=embedder,
+        cross_encoder=_no_op_cross_encoder(),
+    )
 
-    search_kwargs: dict[str, Any] = {"query": query, "num_results": limit}
-    if embedding is not None:
-        search_kwargs["query_vector"] = embedding
-
-    try:
-        results = await graphiti.search(**search_kwargs)
-    except TypeError:
-        # Older graphiti-core builds may not accept query_vector.
-        results = await graphiti.search(query=query, num_results=limit)
+    results = await graphiti.search(query=query, num_results=limit)
 
     crystallization_ids = _extract_crystallization_ids(results)
     crystallization_ids = await _filter_intimate_crystallization_ids(driver, crystallization_ids)
@@ -238,7 +292,7 @@ async def search(
             "backend": "graphiti_core",
             "rails": ["vector", "graph"],
             "query": query,
-            "embed_used": embedding is not None,
+            "embed_used": embedder.used,
             "result_count": len(crystallization_ids),
             "raw_type": type(results).__name__,
         },

--- a/services/orion-graphiti-adapter/app/crystallization_ids.py
+++ b/services/orion-graphiti-adapter/app/crystallization_ids.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import re
 
-_CRYSTALLIZATION_ID = re.compile(r"^crys_[a-zA-Z0-9_-]+$")
+_CRYSTALLIZATION_ID = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def validate_crystallization_id(crystallization_id: str) -> str:
-    """Reject IDs that would break parameterized or legacy Cypher construction."""
+    """Reject IDs that would break parameterized or legacy Cypher construction.
+
+    Real crystallization_id values are raw UUIDs (`memory_crystallizations.crystallization_id`),
+    not `crys_`-prefixed strings (that prefix is only used for derived ids: chroma doc_id,
+    graphiti entity_id `gent_<id>`, episode_id `gep_<id>`). This only guards against characters
+    that would be unsafe if ever interpolated outside a parameterized query.
+    """
     cid = str(crystallization_id).strip()
     if not _CRYSTALLIZATION_ID.match(cid):
         raise ValueError(f"invalid_crystallization_id:{cid}")

--- a/services/orion-graphiti-adapter/tests/test_crystallization_ids.py
+++ b/services/orion-graphiti-adapter/tests/test_crystallization_ids.py
@@ -7,6 +7,16 @@ def test_validate_accepts_crys_prefix():
     assert validate_crystallization_id("crys_test001") == "crys_test001"
 
 
+def test_validate_accepts_raw_uuid():
+    # Regression: real memory_crystallizations.crystallization_id values are bare UUIDs
+    # (no crys_ prefix -- that prefix is only used for derived ids like chroma doc_id /
+    # graphiti entity_id). The graphiti_core backend's ingest_episode() previously rejected
+    # every real crystallization_id with invalid_crystallization_id, making /v1/episodes and
+    # /v1/rebuild 500 for all live data (caught only by testing against real Postgres rows).
+    cid = "191fdf0e-6e86-42e7-a661-86a517d491e1"
+    assert validate_crystallization_id(cid) == cid
+
+
 def test_validate_rejects_injection():
     with pytest.raises(ValueError, match="invalid_crystallization_id"):
         validate_crystallization_id("crys_x'} ) DELETE n //")

--- a/services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py
+++ b/services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py
@@ -39,17 +39,39 @@ async def test_graphiti_core_ingest_dual_writes_postgres():
     assert mock_driver.execute_query.await_count >= 1
     assert conn.execute.await_count >= 3
 
+    # Regression: graphiti-core==0.19.0's FalkorDriver.execute_query(self, cypher_query_,
+    # **kwargs) only accepts one positional arg beyond the query string; the previous
+    # ingest_episode() called execute_query(query, {"a": 1, ...}) -- a second positional
+    # dict -- which raised "takes 2 positional arguments but 3 were given" against the real
+    # driver (AsyncMock doesn't care about calling convention, so only an explicit call_args
+    # check catches this).
+    for call in mock_driver.execute_query.await_args_list:
+        assert len(call.args) == 1, f"execute_query got extra positional args: {call.args[1:]}"
+
 
 @pytest.mark.asyncio
 async def test_search_filters_intimate_crystallization_ids(monkeypatch):
     async def fake_filter(driver, ids):
         return [cid for cid in ids if cid != "crys_intimate"]
 
-    monkeypatch.setattr(core_backend, "_embed_query", AsyncMock(return_value=None))
     monkeypatch.setattr(core_backend, "_filter_intimate_crystallization_ids", fake_filter)
+    # graphiti_core.Graphiti() eagerly builds OpenAI-backed llm_client/embedder/cross_encoder
+    # unless supplied; core_backend.search() passes its own no-OpenAI stubs (see
+    # _no_op_llm_client/_no_op_cross_encoder/_orion_embedder_client). Those stubs do a deep
+    # `from graphiti_core.<submodule>.client import ...` import, which the bare Graphiti-only
+    # mock below can't satisfy -- so stub the three helper functions directly instead of trying
+    # to fake graphiti_core's whole submodule tree via sys.modules. search() reads
+    # embedder.used (set by the real _OrionEmbedderClient.create()) for the trace, so the
+    # fake embedder needs a `.used` attribute too.
+    class _FakeEmbedder:
+        used = False
+
+    monkeypatch.setattr(core_backend, "_no_op_llm_client", lambda: object())
+    monkeypatch.setattr(core_backend, "_no_op_cross_encoder", lambda: object())
+    monkeypatch.setattr(core_backend, "_orion_embedder_client", lambda embed_url: _FakeEmbedder())
 
     class FakeGraphiti:
-        def __init__(self, graph_driver):
+        def __init__(self, graph_driver, llm_client=None, embedder=None, cross_encoder=None):
             pass
 
         async def search(self, **kwargs):


### PR DESCRIPTION
# PR report: graphiti-core backend activation

## Summary

- Live-activated the already-merged `graphiti_core` backend on `orion-graphiti-adapter` (`GRAPHITI_BACKEND=graphiti_core`, `FALKORDB_ENABLED=true`) against a real FalkorDB container — this had never been run against live infrastructure before, only mocked unit tests.
- Found and fixed 3 crash bugs in `backends/graphiti_core.py` / `crystallization_ids.py` that made `/v1/episodes`, `/v1/rebuild`, and `/v1/search` 500 against real data and a real `graphiti-core==0.19.0` driver — invisible to the existing fully-mocked test suite.
- Backfilled all 59 `status=active` crystallizations into FalkorDB (58 landed; the 1 excluded is a real `sensitivity=intimate` row, correctly filtered — verified directly, not just via the synthetic unit test).
- Added `scripts/smoke_graphiti_search_e2e.sh`, a live (non-mocked) search smoke. It intentionally documents a **known FAIL**: `/v1/search` runs cleanly and calls the real embed host, but returns zero results for real ingested data — `graphiti-core==0.19.0`'s own search only reads its `RELATES_TO`-shaped edges, which this adapter's raw-Cypher `ingest_episode()` never writes. Root cause fully documented in the script header and README; not fixed here (out of scope — needs a follow-up decision on write path).
- Confirmed backend-agnostic neighborhood/BFS traversal (Phase B, `smoke_graphiti_links_e2e.sh`) is unaffected either direction.
- Confirmed rollback (`GRAPHITI_BACKEND=orion_postgres`) restores `/v1/search` → 501 with neighborhood unaffected, then re-forwarded to leave the live system in the activated state.

## Outcome moved

The `graphiti_core` backend went from "code exists, zero runtime evidence" to "running live against real FalkorDB with real Orion belief data, with the one broken capability (`/v1/search` result matching) explicitly failing loud instead of silently returning empty and looking fine." Per AGENTS.md's "runtime truth beats config truth" — this is the first real evidence this backend does or doesn't work, in either direction.

## Current architecture (before this patch)

`orion-graphiti-adapter` ran with `GRAPHITI_BACKEND=orion_postgres`, `FALKORDB_ENABLED=false`. The `graphiti_core` backend module existed and had 100% mocked test coverage (driver, `graphiti_core.Graphiti` class, and module import were all patched out — never touched a real FalkorDB instance or a real `graphiti-core` package call).

## Architecture touched

- `services/orion-graphiti-adapter` runtime env (live `.env`, not committed — gitignored, see Env/config below)
- `services/orion-graphiti-adapter/app/backends/graphiti_core.py` — bug fixes, no new capability added
- `services/orion-graphiti-adapter/app/crystallization_ids.py` — validation bug fix
- `scripts/` — one new live smoke, one existing smoke's propose payload fixed (pre-existing validator drift, unrelated to graphiti, but blocking this task's "when done" checklist)

## Files changed

- `docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md`: the spec this PR implements
- `scripts/smoke_graphiti_search_e2e.sh` (new): live, non-mocked `/v1/search` verification; documents the known-failing root cause in its header
- `scripts/smoke_graphiti_links_e2e.sh`: propose payload was missing `planning_effects`/`retrieval_affordances`, so `validate_proposal()` auto-quarantined every crystallization the script created (pre-existing drift in `orion/memory/crystallization/validator.py`, unrelated to this task; fixed because it silently broke this Phase B regression smoke)
- `services/orion-graphiti-adapter/README.md`: documents live runtime state, the search-smoke's known-fail, and clarifies neighborhood is backend-agnostic
- `services/orion-graphiti-adapter/app/backends/graphiti_core.py`:
  - `validate_crystallization_id()` call sites no longer reject bare-UUID `crystallization_id` values (real data shape; the `crys_` prefix is only used for derived ids)
  - `driver.execute_query()` calls fixed to pass a single params dict as keyword args, matching `graphiti-core==0.19.0`'s `FalkorDriver.execute_query(self, cypher_query_, **kwargs)` signature (previously passed a second positional dict, raising `TypeError` against the real driver)
  - Added `_no_op_llm_client()`, `_no_op_cross_encoder()`, `_orion_embedder_client()` — `Graphiti()` eagerly builds OpenAI-backed clients unless given explicit ones; there is no `OPENAI_API_KEY` configured and none of this adapter's usage needs an LLM (writes are raw Cypher, not `add_episode()` entity extraction). The embedder stub bridges to Orion's own `CRYSTALLIZER_EMBED_HOST_URL` instead of OpenAI.
- `services/orion-graphiti-adapter/app/crystallization_ids.py`: `validate_crystallization_id()` now accepts bare UUIDs (real shape) in addition to `crys_`-prefixed ids (derived-id shape); still rejects anything that isn't `[a-zA-Z0-9_-]+` (injection guard — moot in practice since all Cypher calls are parameterized, but kept as defense in depth)
- `services/orion-graphiti-adapter/tests/test_crystallization_ids.py`: regression test for the bare-UUID fix
- `services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py`: regression test asserting `execute_query` call args match the real driver's calling convention; updated the search test's fakes for the new stub-client constructor signature

## Schema / bus / API changes

- Added: none
- Removed: none
- Renamed: none
- Behavior changed: `/v1/episodes`, `/v1/rebuild`, and `/v1/search` on `orion-graphiti-adapter` now work against real data when `GRAPHITI_BACKEND=graphiti_core` (previously crashed). `/v1/search` still returns empty `crystallization_ids` for real data — a pre-existing, now-documented gap, not a regression from this patch (there was no working `/v1/search` before this patch to regress from).
- Compatibility notes: `orion_postgres` backend and Phase B neighborhood/link behavior are byte-for-byte unchanged; rollback verified.

## Env/config changes

- Added keys: none (all keys already existed in `.env_example`)
- Removed keys: none
- Renamed keys: none
- `.env_example` updated: no (key shapes unchanged)
- Live runtime `.env` changes (gitignored, not committed, host-level only):
  - `services/orion-graphiti-adapter/.env`: `GRAPHITI_BACKEND=orion_postgres` → `graphiti_core`; `FALKORDB_ENABLED=false` → `true`; `CRYSTALLIZER_EMBED_HOST_URL=` → `http://orion-athena-vector-host:8320/embedding`
  - `services/orion-hub/.env`: `GRAPHITI_ADAPTER_URL` changed from `http://orion-athena-graphiti-adapter:8000` to `http://127.0.0.1:8640` — pre-existing bug unrelated to this task's plan, found because Hub runs `network_mode: host` and cannot resolve the adapter's container DNS name; the fix matches the pattern already used for `CRYSTALLIZER_EMBED_HOST_URL`/`RECALL_PG_DSN` in the same file. Without this fix, Hub-mediated smokes (`smoke_graphiti_links_e2e.sh`, `smoke_graphiti_search_e2e.sh`, the active-packet check) could not reach the adapter at all.
- skipped keys requiring operator action: none

## Tests run

```text
$ source venv/bin/activate && python -m pytest services/orion-graphiti-adapter/tests -q
15 passed, 2 warnings in 0.72s
```
(Independently re-run by orchestrator after the implementing agent's session, not just taken on report.)

## Evals run

No eval harness exists for `orion-graphiti-adapter`. The two live e2e smokes below are the closest equivalent and are the deterministic gate for this capability going forward.

## Docker/build/smoke checks

```text
$ curl -sS http://localhost:8640/health
{"service":"orion-graphiti-adapter","postgres":true,"falkordb_enabled":true,"backend":"graphiti_core"}

$ bash scripts/smoke_graphiti_links_e2e.sh
PASS smoke_graphiti_links_e2e seed=53d31c3a-e308-456c-bad9-33e6c11b1480 linked=b2918b5e-e8e1-40f2-820b-fccae45a7e52

$ bash scripts/smoke_graphiti_search_e2e.sh
FAIL smoke_graphiti_search_e2e: crystallization_ids missing seed=4c45a09e-e796-47cf-801d-0a6c310755e3
response={"crystallization_ids":[],"trace":{"backend":"graphiti_core","rails":["vector","graph"],
"query":"Graphiti search smoke subject zz20260713051855","embed_used":true,"result_count":0,
"raw_type":"list"}}
(expected FAIL — documented root cause in script header and README; exit 1 is correct, not flaky)

# Backfill verification (orchestrator, independent of agent's report):
$ psql -c "select count(*) from memory_crystallizations where status='active'"        -> 59
$ psql -c "select count(*) from memory_crystallizations where status='active' and
           governance->>'sensitivity'='intimate'"                                      -> 1
$ redis-cli GRAPH.QUERY graphiti_temporal "MATCH (n:Entity) RETURN count(n)"           -> 58
# 59 active - 1 correctly-excluded intimate = 58 in FalkorDB. Exact match.

# Privacy check (orchestrator, independent — corrects an inaccuracy in the implementing
# agent's own report, which claimed "0 intimate active crystallizations" when there is
# actually 1; the exclusion itself is verified correct on that real row):
$ redis-cli GRAPH.QUERY graphiti_temporal \
    "MATCH (n) WHERE n.crystallization_id = '0fc34990-541e-48f0-adca-aa8686bb1521' RETURN n.id"
(empty result — confirmed absent from FalkorDB)
```

All smoke/test output above was re-run independently by the orchestrator after the implementing subagent's session ended, not taken on the subagent's report alone.

## Review findings fixed

Code review skill was not run as a separate subagent pass for this PR — the orchestrator directly read every changed file (`graphiti_core.py`, `crystallization_ids.py`, both smoke scripts, README, both test files) and independently re-ran tests and both live smokes rather than trusting the implementing agent's self-report. One material inaccuracy was caught this way: the implementing agent's report claimed "0 intimate active crystallizations" in real data; there is actually 1, and the report is corrected above. No other discrepancies found between the agent's claims and independently observed behavior.

## Restart required

Already executed live as part of this activation (not pending):

```bash
docker compose --profile falkordb \
  --env-file .env --env-file services/orion-graphiti-adapter/.env \
  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
```

If this PR is merged and redeployed on a different host/environment, the same command plus the three `.env` key changes listed above under Env/config changes must be applied there — they are runtime-only and do not travel with the git merge.

## Risks / concerns

- Severity: Medium — `/v1/search` (the headline new capability) does not find real data today. `scripts/smoke_graphiti_search_e2e.sh` is committed in a known-FAIL state on purpose (a failing gate is the correct signal per AGENTS.md, not a passing-but-lying test). Closing this requires a follow-up decision: either wire a real LLM client into `graphiti-core`'s own `add_episode()`/`add_triplet()` write path, or hand-write `RELATES_TO`-shaped edges with a synthesized fact + embedding to match what `graphiti-core`'s search actually reads. Both are larger patches with real design tradeoffs, out of scope here.
- Severity: Medium — this host had multiple concurrent Claude Code sessions active during implementation; one was observed rebuilding `orion-graphiti-adapter` from `main` mid-task, twice reverting the implementing agent's live fixes until redeployed. Final state is verified correct at time of this report (re-verified independently by the orchestrator after the fact), but the live container's correctness is not guaranteed to persist without this branch being merged and redeployed as the new baseline.
- Severity: Low — `search()` rebuilds the FalkorDB driver and stub `Graphiti`/embedder/llm/cross-encoder clients fresh on every `/v1/search` request. Not a correctness bug, flagged as a legitimate follow-up (connection reuse) not addressed here to keep this patch to the activation's actual scope.