### PR TITLE
Fix/chat lane duplicate exec

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-chat-lane-duplicate-exec-fix-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-chat-lane-duplicate-exec-fix-pr.md
@@ -1,0 +1,93 @@
+# PR: stop legacy cortex-exec container double-consuming orion:verb:request
+
+Branch: `fix/chat-lane-duplicate-exec` → `main`
+
+## Summary
+
+Direct follow-up to `feat/exec-lane-routing-default-on` (merged earlier today), which fixed duplicate execution for `spark`/`background`-lane verbs. That fix couldn't touch chat-lane traffic by design — `use_direct_exec` explicitly requires `lane != "chat"`. This PR fixes the chat-lane half of the same underlying bug: both `legacy` and `chat` cortex-exec containers were independently subscribed to and fully executing every message on the shared `orion:verb:request` broadcast channel.
+
+## Outcome moved
+
+Chat-lane verbs (`chat_general`, `chat_quick`) now execute exactly once instead of twice. Real duplicate LLM inference cost eliminated on the remaining lane this session's investigation hadn't yet fixed.
+
+## Current architecture
+
+`orion/core/bus/bus_service_chassis.py::Hunter` is documented "Fire-and-forget consumer... Subscribes to patterns" — Redis pub/sub broadcast semantics, not a competing-consumer queue: every subscriber receives and processes every message independently. `services/orion-cortex-exec/app/main.py` (pre-fix, line 922) registered a `Hunter` on `orion:verb:request` for any container whose `_lane in {"chat", "legacy", ""}` — both the `legacy` (base) and `chat` containers matched.
+
+## Investigation (verified, not assumed)
+
+- Confirmed live before the fix, via `request_id` tracing across containers: a real chat_quick request appeared in both `legacy` and `chat` logs with identical `trigger=legacy.plan`, both fully executed.
+- **Corrected a wrong assumption in the original task brief**: the brief claimed unset `EXEC_LANE` "already defaults to acting like chat." Verified this is false — `services/orion-cortex-exec/app/settings.py:28` (`exec_lane: str = Field("legacy", alias="EXEC_LANE")`) and `docker-compose.yml`'s `EXEC_LANE: ${EXEC_LANE:-legacy}` for the `legacy` container both default to `"legacy"`. `main.py`'s own `str(settings.exec_lane or "chat")` fallback only fires for a literal empty string, not an unset env var. Unset `EXEC_LANE` therefore resolves to `_lane == "legacy"` and (post-fix) correctly disables the broadcast listener — tested explicitly as its own case, not conflated with the empty-string case.
+- Confirmed `legacy`'s *other* job — serving direct RPC traffic via the bare `orion:cortex:exec:request` channel through the separate `Rabbit`-backed `svc`/`handle()` registration (e.g. `orion-thought`'s `stance_react` calls) — is real, distinct, and completely untouched by this fix. The diff has exactly one hunk.
+
+## Architecture touched
+
+`orion-cortex-exec` only. No changes to `orion-cortex-orch` (that fix already landed separately), no env/config/schema/bus contract changes.
+
+## Files changed
+
+- `services/orion-cortex-exec/app/main.py` — one-line fix: `if _lane in {"chat", "legacy", ""}:` → `if _lane in {"chat", ""}:`.
+- `services/orion-cortex-exec/tests/test_verb_listener_lane_wiring.py` (new) — 6 parametrized cases (`chat`, explicit `""`, `legacy`, unset, `spark`, `background`), using a guarded fresh-reimport pattern mirroring this directory's existing `_exec_import_guard.py` convention, extended with a targeted `app.main`/`app.settings`-only module purge (not a full `app.*` tree purge) to avoid re-triggering `app.verb_adapters`' `@verb("legacy.plan")` registration into the process-global verb registry across repeated imports in one test file.
+- `services/orion-cortex-exec/README.md` — new "Exec lane containers" section; this whole four-container split and the shared broadcast channel had zero prior documentation.
+
+## Schema / bus / API changes
+
+None. No new channel, no schema change. `orion:verb:request`'s consumer set changes (one fewer subscriber), not its contract.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```
+cd /mnt/scripts/Orion-Sapienform-fix-chat-lane-duplicate-exec
+/tmp/orion-test-venv/bin/python -m pytest services/orion-cortex-exec/tests/test_verb_listener_lane_wiring.py -v
+→ 6 passed
+```
+Regression-proof confirmed directly: re-ran the same 6 tests against unfixed `main.py` (`git stash` on just that file) — the exact two `legacy` cases fail (`AssertionError` on `verb_listener is None`), the other 4 pass unchanged. Confirms the test guards precisely the bug this PR fixes, not a tautology.
+
+Whole-directory `services/orion-cortex-exec/tests` sweep has a pre-existing, unrelated collection-order fragility (several files purge the entire `app.*` module tree at collection time, re-triggering `app.verb_adapters`' verb registration and raising `ValueError: Verb already registered: legacy.plan`) — confirmed identical failure count on `git stash` baseline (60 failed / 488 passed / 12 collection errors) vs. this branch. Not introduced or worsened by this change; the new test file passes cleanly in isolation (6/6) and was deliberately written to *not* trigger that fragility (targeted two-module purge instead of a full tree purge).
+
+## Evals run
+
+Not applicable — routing/wiring fix, no cognition/model component.
+
+## Docker/build/smoke checks
+
+Not deployed as part of this PR (code-level fix; `orion-cortex-orch`'s companion fix was applied live separately). Restart section below has the exact deploy + verification commands.
+
+## Review findings fixed
+
+Two parallel review passes run before this report (correctness/cross-file tracing; cleanup/simplification):
+- Correctness pass: confirmed no other `exec_lane` reader is affected (`llm_lane.py`'s LLM-routing metadata reads `exec_lane` too, but is orthogonal to `verb_listener` wiring — unaffected). Confirmed test isn't a tautology (fails pre-fix). Confirmed bare-channel `Rabbit`/`handle()` path structurally untouched.
+- Cleanup pass: flagged the four-separate-test-functions draft as collapsible — fixed, now one parametrized test with 6 cases and preserved per-case commentary. Flagged the `_exec_import_guard` boilerplate as now copy-pasted a third time — left as-is, matches this directory's established convention and deviating risks reintroducing the exact collection-order fragility documented above.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml up -d --build cortex-exec
+```
+(Only the `legacy`/base `cortex-exec` service needs rebuilding — `chat`/`spark`/`background` are unaffected by this specific line, though a full-stack rebuild is harmless if that's the standard deploy flow.)
+
+**Verification** (mirrors the tracing method used to find the bug):
+```bash
+# After a real chat turn:
+docker logs orion-athena-cortex-exec --since 5m | grep -oP "request_id=\S+" | sort -u > /tmp/legacy_ids.txt
+docker logs orion-athena-cortex-exec-chat --since 5m | grep -oP "request_id=\S+" | sort -u > /tmp/chat_ids.txt
+comm -12 /tmp/legacy_ids.txt /tmp/chat_ids.txt | wc -l   # should be 0 now for chat-lane verbs
+
+# legacy should show zero verb_runtime_intake activity going forward (only its own
+# direct-RPC "Incoming Exec Request" lines from orion-thought etc. should remain):
+docker logs orion-athena-cortex-exec --since 5m | grep -c verb_runtime_intake   # should be 0
+```
+
+## Risks / concerns
+
+- Severity: none identified. `legacy`'s remaining job (bare-channel direct RPC) is structurally separate code (`Rabbit`/`handle()`, not `Hunter`/`handle_verb_request`) and untouched by this diff.
+- Severity: informational. The pre-existing whole-suite collection fragility in `services/orion-cortex-exec/tests` (documented above) is a real, separate issue worth its own fix at some point — not introduced by this PR, not fixed by it either; flagged for visibility.
+
+## PR link
+
+Push and open via: `git push -u origin fix/chat-lane-duplicate-exec`, then open the compare URL GitHub prints (no `gh` auth in this environment).

--- a/services/orion-cortex-exec/README.md
+++ b/services/orion-cortex-exec/README.md
@@ -7,8 +7,15 @@
 ### Consumed Channels
 | Channel | Env Var | Kind | Description |
 | :--- | :--- | :--- | :--- |
-| `orion-cortex-exec:request` | `CHANNEL_EXEC_REQUEST` | `cortex.exec.request` | Request from Orchestrator. |
+| `orion-cortex-exec:request` | `CHANNEL_EXEC_REQUEST` | `cortex.exec.request` | Direct-RPC request from Orchestrator (bare channel, one per `EXEC_LANE` container -- see below). Handled by `handle()`/`svc` (`Rabbit` chassis, single-consumer). |
+| `orion:verb:request` | (fixed) | `verb.request` | Shared verb-dispatch broadcast (`Hunter` chassis -- Redis pub/sub, every subscriber runs every message). Only the `chat`-lane container (and unset/empty `EXEC_LANE`, which falls back to `chat`) subscribes to this -- see "Exec lane containers" below. |
 | `orion:cortex:pre_turn_appraisal:request` | `CHANNEL_PRE_TURN_APPRAISAL_REQUEST` | `pre_turn_appraisal.request.v1` | Pre-turn appraisal RPC from Hub (logprob repair pressure). |
+
+### Exec lane containers
+
+Four containers run in production, distinguished by `EXEC_LANE`: `legacy` (base, unset defaults here), `chat`, `spark`, `background` -- each with its own `CHANNEL_EXEC_REQUEST[_LANE]` bare RPC channel. Only `chat` (and empty-string `EXEC_LANE`, which `app/main.py` maps to `chat`) additionally subscribes to the shared `orion:verb:request` broadcast (`app/main.py`, `_lane in {"chat", ""}`) -- this is where chat-lane verbs (`chat_general`/`chat_quick`) actually land, since orion-cortex-orch's lane routing structurally excludes chat from ever using the direct per-lane RPC path.
+
+`legacy` previously also matched that set, meaning both `legacy` and `chat` independently ran every chat-lane verb request in full -- confirmed live, real duplicate LLM gateway calls, fixed 2026-07-13. `legacy` still serves its own real, distinct direct-RPC traffic (e.g. `orion-thought`'s `stance_react`) on its bare `CHANNEL_EXEC_REQUEST` channel -- that's unrelated and unaffected by this fix. See `docs/superpowers/pr-reports/2026-07-13-chat-lane-duplicate-exec-fix-pr.md`.
 
 ### Pre-turn appraisal RPC (repair pressure v2)
 

--- a/services/orion-cortex-exec/app/main.py
+++ b/services/orion-cortex-exec/app/main.py
@@ -919,7 +919,7 @@ verb_runtime = VerbRuntime(
     allow_backdoor=settings.orion_verb_backdoor_enabled,
 )
 _lane = str(settings.exec_lane or "chat").strip().lower()
-if _lane in {"chat", "legacy", ""}:
+if _lane in {"chat", ""}:
     verb_listener = Hunter(
         _cfg(),
         handler=handle_verb_request,

--- a/services/orion-cortex-exec/tests/test_verb_listener_lane_wiring.py
+++ b/services/orion-cortex-exec/tests/test_verb_listener_lane_wiring.py
@@ -1,0 +1,145 @@
+"""Regression coverage for the chat-lane duplicate-exec fix.
+
+Bug: both the ``legacy`` and ``chat`` orion-cortex-exec containers used to
+register a ``Hunter`` listener on the shared ``orion:verb:request`` broadcast
+channel (Redis pub/sub -> every subscriber gets every message), so every
+chat-lane verb request (``chat_general``/``chat_quick``) was independently
+executed twice -- once by each container, including a real duplicate LLM
+gateway call.
+
+Fix: ``app/main.py`` only wires ``verb_listener`` for lanes in
+``{"chat", ""}``. ``"legacy"`` was removed from that set. The ``legacy``
+container's separate, correct job -- serving direct RPC traffic (e.g.
+``stance_react`` from orion-thought) via the bare
+``orion:cortex:exec:request`` channel through the unrelated ``Rabbit``-backed
+``svc``/``handle()`` registration -- is untouched by this test and by the
+fix (see ``services/orion-cortex-exec/app/main.py`` lines ~884-889).
+
+``verb_listener``/``_lane`` are computed once at module import time from
+``settings.exec_lane``, so each case below needs a *fresh* import of
+``app.main`` (and its transitive ``app.settings``) with the env var set
+beforehand. This mirrors the guarded-fresh-import pattern already used by
+``test_chat_stance_shared_spine.py`` / ``test_mind_handoff_shortcut.py`` in
+this directory (via ``_exec_import_guard.ensure_orion_cortex_exec_app``),
+extended with an explicit purge-before-reimport since those two tests only
+needed a *clean* app import, not a *lane-varying* one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_guard = Path(__file__).resolve().parent / "_exec_import_guard.py"
+_spec = importlib.util.spec_from_file_location("_exec_guard_boot_lane_wiring", _guard)
+assert _spec and _spec.loader
+_guard_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guard_mod)
+
+ROOT = Path(__file__).resolve().parents[3]
+APP_ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from orion.core.bus.bus_service_chassis import Hunter  # noqa: E402
+
+
+def _fresh_exec_main(monkeypatch: pytest.MonkeyPatch, exec_lane: str | None):
+    """Re-import ``app.main`` from scratch with ``EXEC_LANE`` set as given.
+
+    ``exec_lane=None`` means the env var is left unset (exercises
+    ``settings.py``'s field default, which is ``"legacy"`` -- see
+    ``services/orion-cortex-exec/app/settings.py:28``).
+    """
+    if exec_lane is None:
+        monkeypatch.delenv("EXEC_LANE", raising=False)
+    else:
+        monkeypatch.setenv("EXEC_LANE", exec_lane)
+
+    app_mod = sys.modules.get("app")
+    app_loc = (getattr(app_mod, "__file__", "") or "").replace("\\", "/")
+    if app_mod is None or "/orion-cortex-exec/" not in app_loc:
+        # Not yet imported this session, or a sibling service's `app`
+        # currently owns the top-level name -- do the full purge + sys.path
+        # fixup this repo's tests already use for that case.
+        _guard_mod.ensure_orion_cortex_exec_app()
+    else:
+        # `app` already correctly resolves to this service. Only drop
+        # app.main/app.settings so the lane-dependent module-level wiring
+        # under test re-executes against the env just set. Deliberately do
+        # NOT purge the rest of the app.* tree: submodules such as
+        # app.verb_adapters register verb triggers into the process-global
+        # orion.core.verbs.registry singleton at import time, and
+        # re-running that registration raises
+        # "ValueError: Verb already registered: legacy.plan".
+        sys.modules.pop("app.main", None)
+        sys.modules.pop("app.settings", None)
+
+    import app.main as exec_main
+
+    return exec_main
+
+
+# (input EXEC_LANE, expected resolved `_lane`, expect a live verb_listener, case note)
+_LANE_CASES = [
+    pytest.param("chat", "chat", True, id="chat-enabled"),
+    pytest.param(
+        "",
+        "chat",
+        True,
+        # settings.exec_lane == "" is falsy, so main.py's own
+        # `str(settings.exec_lane or "chat")` fallback maps it to "chat".
+        id="explicit-empty-falls-back-to-chat-enabled",
+    ),
+    pytest.param(
+        "legacy",
+        "legacy",
+        False,
+        # The bug this test suite guards against: "legacy" used to be in the
+        # enabled set too, so both legacy and chat independently executed
+        # every chat-lane verb request. Must now be disabled.
+        id="legacy-disabled",
+    ),
+    pytest.param(
+        None,
+        "legacy",
+        False,
+        # settings.py's field default for EXEC_LANE is "legacy" (matching
+        # docker-compose.yml's `EXEC_LANE: ${EXEC_LANE:-legacy}` for the
+        # legacy container), NOT "chat" -- unset behaves identically to
+        # explicit EXEC_LANE=legacy and must not (re-)register the
+        # broadcast listener.
+        id="unset-defaults-to-legacy-disabled",
+    ),
+    pytest.param(
+        "spark",
+        "spark",
+        False,
+        # Regression check: spark/background were already excluded before
+        # this fix (only "legacy" was removed from the enabled set) and
+        # must remain so.
+        id="spark-already-disabled",
+    ),
+    pytest.param("background", "background", False, id="background-already-disabled"),
+]
+
+
+@pytest.mark.parametrize("exec_lane, expected_lane, expect_listener", _LANE_CASES)
+def test_verb_listener_lane_wiring(
+    monkeypatch: pytest.MonkeyPatch,
+    exec_lane: str | None,
+    expected_lane: str,
+    expect_listener: bool,
+) -> None:
+    exec_main = _fresh_exec_main(monkeypatch, exec_lane)
+    assert exec_main._lane == expected_lane
+    if expect_listener:
+        assert exec_main.verb_listener is not None
+        assert isinstance(exec_main.verb_listener, Hunter)
+    else:
+        assert exec_main.verb_listener is None


### PR DESCRIPTION
# PR: stop legacy cortex-exec container double-consuming orion:verb:request

Branch: `fix/chat-lane-duplicate-exec` → `main`

## Summary

Direct follow-up to `feat/exec-lane-routing-default-on` (merged earlier today), which fixed duplicate execution for `spark`/`background`-lane verbs. That fix couldn't touch chat-lane traffic by design — `use_direct_exec` explicitly requires `lane != "chat"`. This PR fixes the chat-lane half of the same underlying bug: both `legacy` and `chat` cortex-exec containers were independently subscribed to and fully executing every message on the shared `orion:verb:request` broadcast channel.

## Outcome moved

Chat-lane verbs (`chat_general`, `chat_quick`) now execute exactly once instead of twice. Real duplicate LLM inference cost eliminated on the remaining lane this session's investigation hadn't yet fixed.

## Current architecture

`orion/core/bus/bus_service_chassis.py::Hunter` is documented "Fire-and-forget consumer... Subscribes to patterns" — Redis pub/sub broadcast semantics, not a competing-consumer queue: every subscriber receives and processes every message independently. `services/orion-cortex-exec/app/main.py` (pre-fix, line 922) registered a `Hunter` on `orion:verb:request` for any container whose `_lane in {"chat", "legacy", ""}` — both the `legacy` (base) and `chat` containers matched.

## Investigation (verified, not assumed)

- Confirmed live before the fix, via `request_id` tracing across containers: a real chat_quick request appeared in both `legacy` and `chat` logs with identical `trigger=legacy.plan`, both fully executed.
- **Corrected a wrong assumption in the original task brief**: the brief claimed unset `EXEC_LANE` "already defaults to acting like chat." Verified this is false — `services/orion-cortex-exec/app/settings.py:28` (`exec_lane: str = Field("legacy", alias="EXEC_LANE")`) and `docker-compose.yml`'s `EXEC_LANE: ${EXEC_LANE:-legacy}` for the `legacy` container both default to `"legacy"`. `main.py`'s own `str(settings.exec_lane or "chat")` fallback only fires for a literal empty string, not an unset env var. Unset `EXEC_LANE` therefore resolves to `_lane == "legacy"` and (post-fix) correctly disables the broadcast listener — tested explicitly as its own case, not conflated with the empty-string case.
- Confirmed `legacy`'s *other* job — serving direct RPC traffic via the bare `orion:cortex:exec:request` channel through the separate `Rabbit`-backed `svc`/`handle()` registration (e.g. `orion-thought`'s `stance_react` calls) — is real, distinct, and completely untouched by this fix. The diff has exactly one hunk.

## Architecture touched

`orion-cortex-exec` only. No changes to `orion-cortex-orch` (that fix already landed separately), no env/config/schema/bus contract changes.

## Files changed

- `services/orion-cortex-exec/app/main.py` — one-line fix: `if _lane in {"chat", "legacy", ""}:` → `if _lane in {"chat", ""}:`.
- `services/orion-cortex-exec/tests/test_verb_listener_lane_wiring.py` (new) — 6 parametrized cases (`chat`, explicit `""`, `legacy`, unset, `spark`, `background`), using a guarded fresh-reimport pattern mirroring this directory's existing `_exec_import_guard.py` convention, extended with a targeted `app.main`/`app.settings`-only module purge (not a full `app.*` tree purge) to avoid re-triggering `app.verb_adapters`' `@verb("legacy.plan")` registration into the process-global verb registry across repeated imports in one test file.
- `services/orion-cortex-exec/README.md` — new "Exec lane containers" section; this whole four-container split and the shared broadcast channel had zero prior documentation.

## Schema / bus / API changes

None. No new channel, no schema change. `orion:verb:request`'s consumer set changes (one fewer subscriber), not its contract.

## Env/config changes

None.

## Tests run

```
cd /mnt/scripts/Orion-Sapienform-fix-chat-lane-duplicate-exec
/tmp/orion-test-venv/bin/python -m pytest services/orion-cortex-exec/tests/test_verb_listener_lane_wiring.py -v
→ 6 passed
```
Regression-proof confirmed directly: re-ran the same 6 tests against unfixed `main.py` (`git stash` on just that file) — the exact two `legacy` cases fail (`AssertionError` on `verb_listener is None`), the other 4 pass unchanged. Confirms the test guards precisely the bug this PR fixes, not a tautology.

Whole-directory `services/orion-cortex-exec/tests` sweep has a pre-existing, unrelated collection-order fragility (several files purge the entire `app.*` module tree at collection time, re-triggering `app.verb_adapters`' verb registration and raising `ValueError: Verb already registered: legacy.plan`) — confirmed identical failure count on `git stash` baseline (60 failed / 488 passed / 12 collection errors) vs. this branch. Not introduced or worsened by this change; the new test file passes cleanly in isolation (6/6) and was deliberately written to *not* trigger that fragility (targeted two-module purge instead of a full tree purge).

## Evals run

Not applicable — routing/wiring fix, no cognition/model component.

## Docker/build/smoke checks

Not deployed as part of this PR (code-level fix; `orion-cortex-orch`'s companion fix was applied live separately). Restart section below has the exact deploy + verification commands.

## Review findings fixed

Two parallel review passes run before this report (correctness/cross-file tracing; cleanup/simplification):
- Correctness pass: confirmed no other `exec_lane` reader is affected (`llm_lane.py`'s LLM-routing metadata reads `exec_lane` too, but is orthogonal to `verb_listener` wiring — unaffected). Confirmed test isn't a tautology (fails pre-fix). Confirmed bare-channel `Rabbit`/`handle()` path structurally untouched.
- Cleanup pass: flagged the four-separate-test-functions draft as collapsible — fixed, now one parametrized test with 6 cases and preserved per-case commentary. Flagged the `_exec_import_guard` boilerplate as now copy-pasted a third time — left as-is, matches this directory's established convention and deviating risks reintroducing the exact collection-order fragility documented above.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml up -d --build cortex-exec
```
(Only the `legacy`/base `cortex-exec` service needs rebuilding — `chat`/`spark`/`background` are unaffected by this specific line, though a full-stack rebuild is harmless if that's the standard deploy flow.)

**Verification** (mirrors the tracing method used to find the bug):
```bash
# After a real chat turn:
docker logs orion-athena-cortex-exec --since 5m | grep -oP "request_id=\S+" | sort -u > /tmp/legacy_ids.txt
docker logs orion-athena-cortex-exec-chat --since 5m | grep -oP "request_id=\S+" | sort -u > /tmp/chat_ids.txt
comm -12 /tmp/legacy_ids.txt /tmp/chat_ids.txt | wc -l   # should be 0 now for chat-lane verbs

# legacy should show zero verb_runtime_intake activity going forward (only its own
# direct-RPC "Incoming Exec Request" lines from orion-thought etc. should remain):
docker logs orion-athena-cortex-exec --since 5m | grep -c verb_runtime_intake   # should be 0
```

## Risks / concerns

- Severity: none identified. `legacy`'s remaining job (bare-channel direct RPC) is structurally separate code (`Rabbit`/`handle()`, not `Hunter`/`handle_verb_request`) and untouched by this diff.
- Severity: informational. The pre-existing whole-suite collection fragility in `services/orion-cortex-exec/tests` (documented above) is a real, separate issue worth its own fix at some point — not introduced by this PR, not fixed by it either; flagged for visibility.
