### PR TITLE
Fix/env sync preserve local overrides

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-env-sync-preserve-local-overrides-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-env-sync-preserve-local-overrides-pr.md
@@ -1,0 +1,75 @@
+# PR report: preserve intentional local .env overrides in sync script
+
+Follow-up from the graphiti_core backend activation work (PR #993, #995). Flagged as a High-severity risk in both PR reports: running `python scripts/sync_local_env_from_example.py` mid-session silently reverted `services/orion-graphiti-adapter/.env`'s live-activated `GRAPHITI_BACKEND=graphiti_core` back to the checked-in `.env_example` default `orion_postgres`, along with disabling FalkorDB and clearing the embed URL. Caught and manually corrected in that session; this PR fixes the tool.
+
+## Summary
+
+- `scripts/sync_local_env_from_example.py`'s `sync_file()` treated every local `.env` value that differs from `.env_example` as drift to silently correct — no distinction between genuine drift and an intentional deployment-specific override.
+- Default behavior changed: missing keys still auto-add (nothing to clobber, safe). Keys that exist locally with a differing value are now left untouched and reported under a new "Diverged" section instead of being silently rewritten.
+- New `--force` flag restores the old overwrite-everything behavior, for when a key's meaning genuinely changed upstream and every host's local value should follow.
+- `sync_file()` now returns a `SyncResult(updated, diverged)` dataclass instead of a flat list.
+- `NEVER_SYNC_KEYS` (the existing, stricter "exclude entirely" mechanism for e.g. `ORION_BUS_URL`) is unchanged — this is a separate, softer default that doesn't replace it.
+
+## Outcome moved
+
+The exact incident from this session (silent revert of a live backend flag) can't recur without an explicit `--force`. The script goes from "always trust the example over reality" to "trust reality unless told otherwise."
+
+## Current architecture (before this patch)
+
+`sync_file()` compared each `.env_example` key (filtered by `SYNC_PREFIXES`/`SYNC_EXACT`/`NEVER_SYNC_KEYS`) against local `.env`, and for any existing key with a different value, silently rewrote it to the example's value — no reporting, no opt-out short of adding the key to `NEVER_SYNC_KEYS` (a permanent, per-key exclusion, too blunt for keys that sometimes need to sync and sometimes don't).
+
+## Architecture touched
+
+Single script, `scripts/sync_local_env_from_example.py`, and its test coverage. No service, schema, bus, or Docker surface — this is a dev-time tool, not a running service.
+
+## Files changed
+
+- `scripts/sync_local_env_from_example.py`: `SyncResult` dataclass, `sync_file(..., force: bool = False)`, `--force` CLI flag, `main()` updated to print both `Updated:`/`Would update:` and `Diverged:` sections, module docstring documents the new default behavior
+- `tests/scripts/test_sync_local_env_from_example.py`: extended with diverged/force/missing-key coverage; one pre-existing test updated for the new default (no-longer-silent-overwrite) semantics
+
+## Schema / bus / API changes
+
+None — dev tooling only.
+
+## Env/config changes
+
+None — this PR changes how env *syncing* behaves, not any env key itself.
+
+## Tests run
+
+```text
+$ source venv/bin/activate && python -m pytest tests/scripts/test_sync_local_env_from_example.py -v
+6 passed in 0.09s
+```
+Independently re-run by the orchestrator, not taken from the implementing agent's report alone.
+
+Manual scratch-directory smoke (not run against real `services/*/.env` files, to avoid colliding with the parallel graphiti-hardening task): built a scratch `.env`/`.env_example` pair reproducing the exact incident (`GRAPHITI_BACKEND=graphiti_core` locally vs `orion_postgres` in the example) — confirmed dry-run and real run both report it under "Diverged" and leave the file unchanged; confirmed `--force` on the same scratch data does overwrite it. Full output in the implementing agent's report.
+
+## Evals run
+
+No eval harness applies to a standalone dev script.
+
+## Docker/build/smoke checks
+
+Not applicable — no Docker/service surface. Confirmed via `grep` that the only other call sites (`services/orion-signals/scripts/up.sh`/`down.sh` — informational text only, don't invoke the script; `scripts/repl/orion_fresh_main_smoke.sh` — invokes it via `run_step`, gated on exit code only) are unaffected: exit code remains `0` for a diverged-only report, matching prior behavior for a "changes needed" run.
+
+## Review findings fixed
+
+Implementing agent ran a self-review given the diff's small, purely additive scope: traced all `sync_file()` call sites (only `main()` and the test file), confirmed no other script imports the function directly, verified no regression to the one existing external consumer. No material findings. Orchestrator independently re-read the full diff and re-ran tests rather than trusting the report alone.
+
+## Restart required
+
+```text
+No restart required.
+```
+Dev-time script, not a running service.
+
+## Risks / concerns
+
+- Severity: Low — `--force` still exists and can reproduce the old silent-overwrite behavior if someone reaches for it out of habit. Documented clearly in the module docstring and the flag's `--help` text; no further mitigation attempted (the flag needs to exist for the legitimate "key's meaning changed upstream" case).
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with prior PRs this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/env-sync-preserve-local-overrides?expand=1`

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -3,6 +3,21 @@
 
 Default: only keys we routinely change during feature work (memory graph, autonomy, goal archive).
 Use --all-keys to mirror every example key (skips host-specific overrides below).
+
+Default overwrite behavior:
+- A key missing from local .env but present in .env_example is always auto-added.
+  There is no existing value to clobber, so this is safe.
+- A key that already exists in local .env with a value that differs from
+  .env_example is treated as a possible *intentional* deployment-specific
+  override (e.g. a live backend flipped on for real, a host-specific tuning
+  value) and is NOT silently overwritten. It is reported as "diverged" so an
+  operator can review it by hand.
+- Pass --force to restore the old behavior and overwrite diverged keys too
+  (use this when a key's meaning genuinely changed upstream and every host's
+  local value should follow .env_example).
+
+NEVER_SYNC_KEYS keys are excluded from sync entirely (even with --force) and
+are a separate, stricter mechanism from the diverged/--force behavior above.
 """
 
 from __future__ import annotations
@@ -10,6 +25,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -262,17 +278,34 @@ def parse_kv(path: Path) -> dict[str, str]:
     return out
 
 
+@dataclass
+class SyncResult:
+    """Result of syncing one service's .env from its .env_example.
+
+    updated: keys actually written (missing keys auto-added, plus diverged
+        keys overwritten only when force=True).
+    diverged: keys that exist locally with a value different from
+        .env_example and were left untouched (force=False). Informational —
+        not an error.
+    """
+
+    updated: list[str] = field(default_factory=list)
+    diverged: list[str] = field(default_factory=list)
+
+
 def sync_file(
     env_path: Path,
     example_path: Path,
     *,
     dry_run: bool,
     all_keys: bool,
-) -> list[str]:
+    force: bool = False,
+) -> SyncResult:
+    name = env_path.parent.name
     if not example_path.is_file():
-        return [f"skip {env_path.parent.name}: no .env_example"]
+        return SyncResult(updated=[f"skip {name}: no .env_example"])
     if not env_path.is_file():
-        return [f"skip {env_path.parent.name}: no .env"]
+        return SyncResult(updated=[f"skip {name}: no .env"])
 
     desired = {
         k: v
@@ -280,11 +313,12 @@ def sync_file(
         if should_sync_key(k, all_keys=all_keys) and not example_value_is_host_placeholder(k, v)
     }
     if not desired:
-        return []
+        return SyncResult()
 
     lines = env_path.read_text(encoding="utf-8").splitlines(keepends=True)
     seen: set[str] = set()
-    changed: list[str] = []
+    updated: list[str] = []
+    diverged: list[str] = []
     out_lines: list[str] = []
 
     for raw in lines:
@@ -296,8 +330,12 @@ def sync_file(
         key, old = m.group(1), m.group(2)
         seen.add(key)
         if key in desired and desired[key] != old:
-            changed.append(f"{env_path.parent.name}: {key} {old!r} -> {desired[key]!r}")
-            out_lines.append(f"{key}={desired[key]}\n")
+            if force:
+                updated.append(f"{name}: {key} {old!r} -> {desired[key]!r}")
+                out_lines.append(f"{key}={desired[key]}\n")
+            else:
+                diverged.append(f"{name}: {key} local={old!r} example={desired[key]!r}")
+                out_lines.append(raw if raw.endswith("\n") else raw + "\n")
         else:
             out_lines.append(raw if raw.endswith("\n") else raw + "\n")
 
@@ -305,12 +343,12 @@ def sync_file(
     if missing:
         out_lines.append("\n# synced from .env_example\n")
         for key in missing:
-            changed.append(f"{env_path.parent.name}: +{key}={desired[key]!r}")
+            updated.append(f"{name}: +{key}={desired[key]!r}")
             out_lines.append(f"{key}={desired[key]}\n")
 
-    if changed and not dry_run:
+    if updated and not dry_run:
         env_path.write_text("".join(out_lines), encoding="utf-8")
-    return changed
+    return SyncResult(updated=updated, diverged=diverged)
 
 
 def main() -> int:
@@ -322,27 +360,52 @@ def main() -> int:
         action="store_true",
         help="Sync every .env_example key (still skips NEVER_SYNC_KEYS)",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Overwrite local .env values that diverge from .env_example instead of "
+            "just reporting them. Use when a key's meaning genuinely changed upstream. "
+            "NEVER_SYNC_KEYS are still excluded even with --force."
+        ),
+    )
     args = parser.parse_args()
 
     services_dir = ROOT / "services"
     names = args.services or list(DEFAULT_SERVICES)
-    all_changes: list[str] = []
+    all_updated: list[str] = []
+    all_diverged: list[str] = []
     for name in names:
         svc = services_dir / name
         if not svc.is_dir():
             print(f"unknown service: {name}", file=sys.stderr)
             return 1
-        all_changes.extend(
-            sync_file(svc / ".env", svc / ".env_example", dry_run=args.dry_run, all_keys=args.all_keys)
+        result = sync_file(
+            svc / ".env",
+            svc / ".env_example",
+            dry_run=args.dry_run,
+            all_keys=args.all_keys,
+            force=args.force,
         )
+        all_updated.extend(result.updated)
+        all_diverged.extend(result.diverged)
 
-    if not all_changes:
+    if not all_updated and not all_diverged:
         print("No changes needed (feature keys already match .env_example).")
         return 0
-    prefix = "Would update" if args.dry_run else "Updated"
-    print(prefix + ":")
-    for line in all_changes:
-        print(f"  {line}")
+
+    if all_updated:
+        prefix = "Would update" if args.dry_run else "Updated"
+        print(prefix + ":")
+        for line in all_updated:
+            print(f"  {line}")
+    if all_diverged:
+        print(
+            "Diverged (not changed — local value differs from .env_example, "
+            "review manually or pass --force):"
+        )
+        for line in all_diverged:
+            print(f"  {line}")
     return 0
 
 

--- a/tests/scripts/test_sync_local_env_from_example.py
+++ b/tests/scripts/test_sync_local_env_from_example.py
@@ -37,8 +37,69 @@ def test_sync_file_does_not_clobber_local_bus_url(tmp_path: Path) -> None:
         "ORION_BUS_URL=redis://100.92.216.81:6379/0\nSTANCE_REACT_TIMEOUT_SEC=12\n",
         encoding="utf-8",
     )
-    changes = sync_file(svc / ".env", svc / ".env_example", dry_run=False, all_keys=True)
+    result = sync_file(svc / ".env", svc / ".env_example", dry_run=False, all_keys=True)
     text = (svc / ".env").read_text(encoding="utf-8")
+    # ORION_BUS_URL is in NEVER_SYNC_KEYS: excluded entirely, regardless of divergence.
     assert "ORION_BUS_URL=redis://100.92.216.81:6379/0" in text
-    assert "STANCE_REACT_TIMEOUT_SEC=120" in text
-    assert not any("ORION_BUS_URL" in c for c in changes)
+    assert not any("ORION_BUS_URL" in c for c in result.updated + result.diverged)
+    # STANCE_REACT_TIMEOUT_SEC diverges (12 vs 120) but force defaults to False, so it
+    # must NOT be silently overwritten — this is the bug this module now guards against.
+    assert "STANCE_REACT_TIMEOUT_SEC=12" in text
+    assert "STANCE_REACT_TIMEOUT_SEC=120" not in text
+    assert any("STANCE_REACT_TIMEOUT_SEC" in c for c in result.diverged)
+    assert not any("STANCE_REACT_TIMEOUT_SEC" in c for c in result.updated)
+
+
+def test_sync_file_default_does_not_overwrite_diverged_key(tmp_path: Path) -> None:
+    """Regression test for the graphiti-adapter incident: an existing local value that
+    differs from .env_example (an intentional deployment-specific override) must be
+    left alone by default, and reported as diverged rather than silently reset."""
+    svc = tmp_path / "orion-graphiti-adapter"
+    svc.mkdir()
+    (svc / ".env_example").write_text("GRAPHITI_BACKEND=orion_postgres\n", encoding="utf-8")
+    (svc / ".env").write_text("GRAPHITI_BACKEND=graphiti_core\n", encoding="utf-8")
+
+    result = sync_file(svc / ".env", svc / ".env_example", dry_run=False, all_keys=False)
+
+    text = (svc / ".env").read_text(encoding="utf-8")
+    assert "GRAPHITI_BACKEND=graphiti_core" in text
+    assert not result.updated
+    assert any("GRAPHITI_BACKEND" in c for c in result.diverged)
+    assert "local='graphiti_core'" in result.diverged[0]
+    assert "example='orion_postgres'" in result.diverged[0]
+
+
+def test_sync_file_force_overwrites_diverged_key(tmp_path: Path) -> None:
+    svc = tmp_path / "orion-graphiti-adapter"
+    svc.mkdir()
+    (svc / ".env_example").write_text("GRAPHITI_BACKEND=orion_postgres\n", encoding="utf-8")
+    (svc / ".env").write_text("GRAPHITI_BACKEND=graphiti_core\n", encoding="utf-8")
+
+    result = sync_file(
+        svc / ".env", svc / ".env_example", dry_run=False, all_keys=False, force=True
+    )
+
+    text = (svc / ".env").read_text(encoding="utf-8")
+    assert "GRAPHITI_BACKEND=orion_postgres" in text
+    assert not result.diverged
+    assert any("GRAPHITI_BACKEND" in c for c in result.updated)
+
+
+def test_sync_file_missing_key_auto_added_default_and_force(tmp_path: Path) -> None:
+    for force in (False, True):
+        svc = tmp_path / f"orion-graphiti-adapter-{force}"
+        svc.mkdir()
+        (svc / ".env_example").write_text(
+            "GRAPHITI_BACKEND=orion_postgres\nCRYSTALLIZER_NEW_KEY=example_value\n",
+            encoding="utf-8",
+        )
+        (svc / ".env").write_text("GRAPHITI_BACKEND=orion_postgres\n", encoding="utf-8")
+
+        result = sync_file(
+            svc / ".env", svc / ".env_example", dry_run=False, all_keys=False, force=force
+        )
+
+        text = (svc / ".env").read_text(encoding="utf-8")
+        assert "CRYSTALLIZER_NEW_KEY=example_value" in text
+        assert any("CRYSTALLIZER_NEW_KEY" in c for c in result.updated)
+        assert not result.diverged


### PR DESCRIPTION
# PR report: preserve intentional local .env overrides in sync script

Follow-up from the graphiti_core backend activation work (PR #993, #995). Flagged as a High-severity risk in both PR reports: running `python scripts/sync_local_env_from_example.py` mid-session silently reverted `services/orion-graphiti-adapter/.env`'s live-activated `GRAPHITI_BACKEND=graphiti_core` back to the checked-in `.env_example` default `orion_postgres`, along with disabling FalkorDB and clearing the embed URL. Caught and manually corrected in that session; this PR fixes the tool.

## Summary

- `scripts/sync_local_env_from_example.py`'s `sync_file()` treated every local `.env` value that differs from `.env_example` as drift to silently correct — no distinction between genuine drift and an intentional deployment-specific override.
- Default behavior changed: missing keys still auto-add (nothing to clobber, safe). Keys that exist locally with a differing value are now left untouched and reported under a new "Diverged" section instead of being silently rewritten.
- New `--force` flag restores the old overwrite-everything behavior, for when a key's meaning genuinely changed upstream and every host's local value should follow.
- `sync_file()` now returns a `SyncResult(updated, diverged)` dataclass instead of a flat list.
- `NEVER_SYNC_KEYS` (the existing, stricter "exclude entirely" mechanism for e.g. `ORION_BUS_URL`) is unchanged — this is a separate, softer default that doesn't replace it.

## Outcome moved

The exact incident from this session (silent revert of a live backend flag) can't recur without an explicit `--force`. The script goes from "always trust the example over reality" to "trust reality unless told otherwise."

## Current architecture (before this patch)

`sync_file()` compared each `.env_example` key (filtered by `SYNC_PREFIXES`/`SYNC_EXACT`/`NEVER_SYNC_KEYS`) against local `.env`, and for any existing key with a different value, silently rewrote it to the example's value — no reporting, no opt-out short of adding the key to `NEVER_SYNC_KEYS` (a permanent, per-key exclusion, too blunt for keys that sometimes need to sync and sometimes don't).

## Architecture touched

Single script, `scripts/sync_local_env_from_example.py`, and its test coverage. No service, schema, bus, or Docker surface — this is a dev-time tool, not a running service.

## Files changed

- `scripts/sync_local_env_from_example.py`: `SyncResult` dataclass, `sync_file(..., force: bool = False)`, `--force` CLI flag, `main()` updated to print both `Updated:`/`Would update:` and `Diverged:` sections, module docstring documents the new default behavior
- `tests/scripts/test_sync_local_env_from_example.py`: extended with diverged/force/missing-key coverage; one pre-existing test updated for the new default (no-longer-silent-overwrite) semantics

## Schema / bus / API changes

None — dev tooling only.

## Env/config changes

None — this PR changes how env *syncing* behaves, not any env key itself.

## Tests run

```text
$ source venv/bin/activate && python -m pytest tests/scripts/test_sync_local_env_from_example.py -v
6 passed in 0.09s
```
Independently re-run by the orchestrator, not taken from the implementing agent's report alone.

Manual scratch-directory smoke (not run against real `services/*/.env` files, to avoid colliding with the parallel graphiti-hardening task): built a scratch `.env`/`.env_example` pair reproducing the exact incident (`GRAPHITI_BACKEND=graphiti_core` locally vs `orion_postgres` in the example) — confirmed dry-run and real run both report it under "Diverged" and leave the file unchanged; confirmed `--force` on the same scratch data does overwrite it. Full output in the implementing agent's report.

## Evals run

No eval harness applies to a standalone dev script.

## Docker/build/smoke checks

Not applicable — no Docker/service surface. Confirmed via `grep` that the only other call sites (`services/orion-signals/scripts/up.sh`/`down.sh` — informational text only, don't invoke the script; `scripts/repl/orion_fresh_main_smoke.sh` — invokes it via `run_step`, gated on exit code only) are unaffected: exit code remains `0` for a diverged-only report, matching prior behavior for a "changes needed" run.

## Review findings fixed

Implementing agent ran a self-review given the diff's small, purely additive scope: traced all `sync_file()` call sites (only `main()` and the test file), confirmed no other script imports the function directly, verified no regression to the one existing external consumer. No material findings. Orchestrator independently re-read the full diff and re-ran tests rather than trusting the report alone.

## Restart required

```text
No restart required.
```
Dev-time script, not a running service.

## Risks / concerns

- Severity: Low — `--force` still exists and can reproduce the old silent-overwrite behavior if someone reaches for it out of habit. Documented clearly in the module docstring and the flag's `--help` text; no further mitigation attempted (the flag needs to exist for the legitimate "key's meaning changed upstream" case).