### PR TITLE
Feat/graphiti core default and search hardening

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-graphiti-core-default-and-search-hardening-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-graphiti-core-default-and-search-hardening-pr.md
@@ -1,0 +1,114 @@
+# PR report: graphiti_core default + search-stack caching + chat-visible proof
+
+Third follow-up in this session's graphiti_core line (#993 activation, #995 RELATES_TO schema fix, this PR: hardening now that #995 is proven). Three independent-but-related items, one PR since all three are scoped to `orion-graphiti-adapter`.
+
+## Summary
+
+- `GRAPHITI_BACKEND` default flipped `orion_postgres` → `graphiti_core`, `FALKORDB_ENABLED` default `false` → `true` (`settings.py`, `.env_example`). This was previously an explicit live-override-only decision ("stays `orion_postgres` until search is proven") — it's proven now (PR #995), so the shipped default follows.
+- `/v1/search` no longer rebuilds its `FalkorDriver`/`Graphiti`/stub-client stack on every single request — memoized in a process-local cache, mirroring the existing `_indices_ready` lazy-init pattern.
+- New `scripts/smoke_graphiti_active_packet_search_e2e.sh`: proves the search-rail fix reaches a real Hub API response (`/api/memory/active-packet`, the same endpoint a live chat turn's recall path consumes), isolated from neighborhood/links by using two crystallizations with no edge between them.
+- Fixed a real regression the default-flip caused: 4 pre-existing tests silently depended on the old default to avoid needing the `graphiti_core` package (Docker-image-only, not in the dev venv) — pinned explicitly rather than weakened.
+- Fixed a real correctness hazard the caching change introduced before it shipped: embed-success tracking moved from embedder instance state to a per-call `ContextVar`, since a cached/reused embedder instance would otherwise leak one request's result into a concurrent request's trace.
+
+## Outcome moved
+
+Fresh deployments now get the proven-working backend by default, not a stale conservative default that predates proof. `/v1/search` no longer pays full driver/client construction cost on every request. And — the most important one — there is now direct evidence the search fix is reachable from the same API surface a live chat turn actually uses, not just the adapter's own internal endpoint.
+
+## Current architecture (before this patch)
+
+`GRAPHITI_BACKEND=orion_postgres` was the code-level default (README: "settings.py's and .env_example's code-level default remains orion_postgres... until /v1/search is proven to find real data end to end") — a hedge from PR #993, before #995 fixed the actual bug. `search()` built its entire driver/client/`Graphiti` stack fresh per call. No test exercised whether the search fix was visible outside the adapter's own `/v1/search` endpoint.
+
+## Architecture touched
+
+Single service, `orion-graphiti-adapter` — settings, one backend module, its tests, and one new top-level smoke script. No schema/bus/API contract changes.
+
+## Files changed
+
+- `services/orion-graphiti-adapter/app/settings.py`, `.env_example`: default flip
+- `services/orion-graphiti-adapter/README.md`: rewrote the paragraph declaring `orion_postgres` the hedge default — that decision is made now
+- `services/orion-graphiti-adapter/app/backends/graphiti_core.py`: `_get_search_stack()` (new, memoized driver/embedder/`Graphiti` build), `_embed_used_ctx` `ContextVar` replacing `_OrionEmbedderClient.used` instance state, `search()` updated to use both
+- `services/orion-graphiti-adapter/tests/conftest.py`: new autouse fixture clearing `_search_stack_cache` before/after every test
+- `services/orion-graphiti-adapter/tests/{test_episodes,test_links,test_rebuild}.py`: pinned `GRAPHITI_BACKEND=orion_postgres` on the specific tests that exercise the generic (non-graphiti_core-specific) ingest/link/rebuild path, since the `graphiti_core` package isn't importable in the bare dev venv
+- `services/orion-graphiti-adapter/tests/test_health.py`: updated a real stale assertion (`backend == "orion_postgres"`) to match the new default
+- `services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py`: 2 new regression tests — driver/`Graphiti` construction happens once across repeated `search()` calls; `embed_used` doesn't leak stale `True` across calls sharing a cached embedder
+- `scripts/smoke_graphiti_active_packet_search_e2e.sh` (new): the chat-visible proof
+- `docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md`: "Hardening pass" addendum documenting all three items and live verification evidence
+
+## Schema / bus / API changes
+
+None. No new env keys, no schema/bus/API surface changes — this PR changes defaults, adds a process-local perf cache, and adds a smoke script.
+
+## Env/config changes
+
+- Added keys: none
+- Removed keys: none
+- Renamed keys: none
+- Changed defaults: `GRAPHITI_BACKEND` (`orion_postgres`→`graphiti_core`), `FALKORDB_ENABLED` (`false`→`true`) in both `settings.py` and `.env_example`
+- `.env_example` updated: yes
+- Local `.env` synced: this host's `services/orion-graphiti-adapter/.env` already had the live-override values set (from #993/#995), unaffected by the default-flip in code — verified unchanged post-deploy (see Docker/smoke checks below)
+- Skipped keys requiring operator action: none — any environment that doesn't already have an explicit `.env` override will now start with `graphiti_core` by default, which is the intended behavior of this PR
+
+## Tests run
+
+```text
+$ source venv/bin/activate && python -m pytest services/orion-graphiti-adapter/tests -q
+23 passed, 2 warnings in 0.76s
+```
+21 baseline + 2 new caching/ContextVar regression tests. Independently re-run by the orchestrator, not taken from the implementing agent's report alone (note: the implementing agent's background session hit an API session-limit error partway through and did not reach the test-fixing, smoke-script, or verification stages — the orchestrator completed items 2 and 3's remaining work directly, including discovering and fixing the 4-test regression above, in the same worktree the agent had already made solid partial progress in).
+
+## Evals run
+
+No eval harness exists for this service (same gap noted in prior PRs this session). The three live e2e smokes below are the deterministic gate.
+
+## Docker/build/smoke checks
+
+```text
+$ curl -sS http://localhost:8640/health
+{"service":"orion-graphiti-adapter","postgres":true,"falkordb_enabled":true,"backend":"graphiti_core"}
+
+$ bash scripts/smoke_graphiti_links_e2e.sh
+PASS smoke_graphiti_links_e2e seed=1a0fafe5-dd1f-4254-b3a1-b6c87330d82b linked=7b1cbb56-2782-4de8-9a3b-0a6da8a1e1ac
+
+$ bash scripts/smoke_graphiti_search_e2e.sh
+PASS smoke_graphiti_search_e2e seed=85ec3f1c-4cbf-4859-a1c9-d1540c9519df embed_used=true
+
+$ bash scripts/smoke_graphiti_active_packet_search_e2e.sh
+PASS smoke_graphiti_active_packet_search_e2e seed=86f4134c-a281-46a9-958d-4d79c7486a74 search_reached=50ab005f-6cf7-49ca-8feb-1d82e9f459f3
+```
+
+All three run after a full rebuild+restart with this PR's code (`docker exec orion-athena-graphiti-adapter grep -c "_get_search_stack\|_embed_used_ctx" /app/app/backends/graphiti_core.py` → 12, confirming the new code is what's actually running, not a stale image).
+
+## Review findings fixed
+
+- Finding: default-flip broke 4 existing tests that silently depended on the old default (`ModuleNotFoundError: graphiti_core` — the package is Docker-image-only).
+  - Fix: pinned `GRAPHITI_BACKEND=orion_postgres` explicitly in `test_ingest_episode_returns_ids`, `test_ingest_with_supports_link_writes_cross_edge`, `test_rebuild_batch_ingests_items`, `test_rebuild_skips_intimate_items` — these test generic ingest/link/rebuild behavior, not anything graphiti_core-specific, so pinning the backend they were implicitly already exercising is correct, not a weakening.
+  - Evidence: `pytest` count went from 21 failed-5/passed-16 immediately after the default flip, to 21/21 passing after the pin, to 23/23 after adding the 2 new caching tests.
+- Finding: `test_health_without_postgres` asserted `backend == "orion_postgres"` — a real stale assertion, not a test-isolation artifact.
+  - Fix: updated to `"graphiti_core"`.
+  - Evidence: test passes; assertion now matches the intentional new default.
+- Finding (design review, before shipping): caching the embedder instance across requests would let `_OrionEmbedderClient.used` (old instance-state tracking) leak one request's embed-success result into a concurrent or later request's trace.
+  - Fix: replaced with `_embed_used_ctx`, an `asyncio.ContextVar` reset at the start of every `search()` call.
+  - Evidence: new regression test `test_search_embed_used_does_not_leak_across_calls_sharing_cached_embedder` — first call embeds successfully (`embed_used: True`), second call (same cached embedder) has embed fail (`embed_used: False`), asserted independently.
+
+## Restart required
+
+Already executed live during this session:
+
+```bash
+docker compose --profile falkordb \
+  --env-file .env --env-file services/orion-graphiti-adapter/.env \
+  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
+```
+
+If merged and redeployed elsewhere with no existing `.env` override: no action needed — the new default (`graphiti_core`) is now correct out of the box, assuming `CRYSTALLIZER_EMBED_HOST_URL` is reachable on that host (already required, unchanged).
+
+## Risks / concerns
+
+- Severity: Medium — the implementing background agent hit an API session-limit error mid-task and stopped before finishing. Its partial work (items 1 fully, item 2's core logic) was solid on inspection (correctly identified the exact `ContextVar` fix needed for the caching hazard, and added the `conftest.py` test-isolation fixture proactively) — the orchestrator verified and completed the remainder directly (the 4-test regression fix, item 3's smoke script, live verification, spec addendum) rather than re-spawning a second agent into the same constraint. Documented here for traceability, not hidden.
+- Severity: Low — `_search_stack_cache` is a single-process, in-memory cache with no TTL or invalidation path if `falkordb_uri`/`graph_name`/`embed_url` ever needed to change without a process restart (they don't today — sourced once from `settings` at process start). Not a bug under current usage; worth knowing if this service ever needs hot config reload.
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/graphiti-core-default-and-search-hardening?expand=1`

--- a/docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md
+++ b/docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md
@@ -218,3 +218,76 @@ few have accumulated — `orion/memory/crystallization/detection.py::detect_dupl
 `validation_status=invalid`, blocking approve with HTTP 400. Not a graphiti-core bug; the
 script now varies two independent random tokens per run (Jaccard ~0.5) and checks the approve
 HTTP status explicitly instead of swallowing failures.
+
+---
+
+## Hardening pass (2026-07-13, same day)
+
+With `/v1/search` proven live, three follow-ups closed the loop:
+
+### 1. `graphiti_core` is now the shipped default
+
+`settings.py`/`.env_example`: `GRAPHITI_BACKEND` default `orion_postgres` → `graphiti_core`,
+`FALKORDB_ENABLED` default `false` → `true`, `.env_example`'s `CRYSTALLIZER_EMBED_HOST_URL`
+filled in. Previously this was a live-override-only decision (code-level default stayed
+`orion_postgres` "until search is proven"); it's proven now, so the default follows.
+`orion_postgres` remains the rollback backend, unchanged.
+
+**Regression this uncovered:** `services/orion-graphiti-adapter/tests/{test_episodes,
+test_links,test_rebuild}.py` predate backend selection and exercise the generic ingest/link/
+rebuild path via `TestClient` without pinning a backend — they silently relied on the *old*
+default (`orion_postgres`) to avoid needing the `graphiti_core` package, which is only
+installed in this service's Docker image, not the bare dev venv. Flipping the default routed
+them through `core_backend.ingest_episode()` instead, which hard-crashes on
+`ModuleNotFoundError: graphiti_core` outside Docker. Fixed by pinning
+`patch.object(main_mod.settings, "GRAPHITI_BACKEND", "orion_postgres")` in those specific
+tests (they test generic behavior, not graphiti_core-specific behavior) rather than installing
+`graphiti-core` into the dev venv or skipping them. `test_health.py`'s
+`assert data["backend"] == "orion_postgres"` was a real assertion on the old default, not a
+test-isolation issue — updated to `"graphiti_core"`.
+
+### 2. `/v1/search` driver/client reuse
+
+`search()` previously built a fresh `FalkorDriver` + `Graphiti` instance + no-op llm/cross-
+encoder/embedder stubs on every single request, discarded after one call. `_get_search_stack()`
+memoizes all of it in a process-local `_search_stack_cache` dict keyed by
+`(falkordb_uri, graph_name, embed_url)`, mirroring the existing `_indices_ready` lazy-init-once
+pattern. `FalkorDriver` is a thin redis-protocol client (`graphiti_core/driver/
+falkordb_driver.py`) — no documented long-lived-reuse hazard, confirmed by reading the
+installed package source in the running container.
+
+**Correctness hazard this introduced, and its fix:** `_OrionEmbedderClient` previously tracked
+embed success as instance state (`self.used`). With the embedder instance now cached and
+reused across requests, that would let one request's result leak into a later (or concurrent)
+request's `trace.embed_used`. Fixed by moving the flag to `_embed_used_ctx`, an
+`asyncio.ContextVar` reset to `False` at the start of every `search()` call — each
+request-handling Task gets its own copy of the current context, so concurrent requests sharing
+one embedder instance can't see each other's writes. Regression tests: `_search_stack_cache`
+grows by exactly one entry across repeated calls with the same key (driver/`Graphiti`
+constructor call counts assert this), and a two-call sequence (embed succeeds, then fails)
+asserts `trace.embed_used` reflects only the current call, not a stale value from the prior
+one. `tests/conftest.py` gained an autouse fixture clearing `_search_stack_cache` before/after
+every test — without it, one test's mocked driver/`Graphiti` stack could leak into another
+test keyed by the same tuple.
+
+### 3. Proof the search fix is chat-visible, not just adapter-API-visible
+
+New: `scripts/smoke_graphiti_active_packet_search_e2e.sh`. Design: propose+approve two
+crystallizations A and B with distinctive, unrelated subjects and **no link between them**.
+Call `POST /api/memory/active-packet` (Hub) seeded on A, querying with B's subject text.
+`graphiti_neighborhood` (depth=2 from A) cannot explain B appearing — there is no edge between
+them — so B surfacing in the response's `graphiti_refs` is only explainable by the
+`graphiti_search` rail matching B's own self-referential `RELATES_TO` fact edge. This isolates
+proof of the search-rail fix specifically from `smoke_graphiti_links_e2e.sh` (neighborhood,
+backend-agnostic, was never broken) and `smoke_graphiti_search_e2e.sh` (adapter API directly,
+not the Hub response a live chat turn actually consumes). **PASS**, live, this host.
+
+### Live verification (hardening pass)
+
+| Check | Result |
+|---|---|
+| `pytest services/orion-graphiti-adapter/tests -q` | 23 passed (21 baseline + 2 new caching/context-var regression tests) |
+| `curl localhost:8640/health` | `backend: graphiti_core` (post default-flip rebuild) |
+| `scripts/smoke_graphiti_links_e2e.sh` | PASS (no regression) |
+| `scripts/smoke_graphiti_search_e2e.sh` | PASS (no regression) |
+| `scripts/smoke_graphiti_active_packet_search_e2e.sh` | PASS — unlinked crystallization reachable via search rail alone, surfaced into a real Hub API response |

--- a/scripts/smoke_graphiti_active_packet_search_e2e.sh
+++ b/scripts/smoke_graphiti_active_packet_search_e2e.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Smoke: prove the /v1/search rail (not neighborhood/links) reaches a real chat-facing
+# API response — POST /api/memory/active-packet on Hub, the same endpoint a live chat
+# turn's recall path consumes.
+#
+# Design: propose+approve two UNLINKED crystallizations A and B with distinctive,
+# unrelated subject text. Call active-packet seeded on A but querying with B's subject.
+# A and B have no CrystallizationLinkV1 link between them, so graphiti_neighborhood
+# (depth=2 from seed A) cannot explain B showing up — retrieve_active_packet() only
+# reaches B via graphiti_adapter.search(query, seed_crystallization_id=A) matching B's
+# own self-referential RELATES_TO fact edge (orion/memory/crystallization/retriever.py
+# ~line 79). This isolates proof of the search-rail fix specifically, distinct from
+# scripts/smoke_graphiti_links_e2e.sh (neighborhood, backend-agnostic, was never broken)
+# and scripts/smoke_graphiti_search_e2e.sh (adapter API directly, not the chat-facing
+# Hub response a live turn actually consumes).
+set -euo pipefail
+: "${ORION_HUB_URL:?}"
+: "${ORION_HUB_SESSION_ID:?}"
+: "${GRAPHITI_ADAPTER_URL:?}"
+BASE="${ORION_HUB_URL%/}"
+ADAPTER="${GRAPHITI_ADAPTER_URL%/}"
+HDR=(-H "Content-Type: application/json" -H "X-Orion-Session-Id: ${ORION_HUB_SESSION_ID}")
+STAMP="$(date -u +%Y%m%d%H%M%S)"
+# See scripts/smoke_graphiti_search_e2e.sh's header for why tokens vary per run
+# (crystallization duplicate-detection Jaccard collision on fixed templates).
+RAND_A="${RANDOM}${RANDOM}"
+RAND_B="${RANDOM}${RANDOM}"
+SUBJECT_A="Active packet probe alpha ${STAMP} token ${RAND_A}"
+SUBJECT_B="Active packet probe bravo ${STAMP} token ${RAND_B}"
+
+BACKEND=$(curl -sS "${ADAPTER}/health" | jq -r '.backend')
+if [[ "$BACKEND" != "graphiti_core" ]]; then
+  echo "FAIL smoke_graphiti_active_packet_search_e2e: adapter backend=${BACKEND}, expected graphiti_core" >&2
+  exit 1
+fi
+
+_propose() {
+  local subject="$1" summary="$2"
+  curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/propose" -d "$(jq -n --arg s "$subject" --arg m "$summary" '{
+    kind: "stance", subject: $s, summary: $m, scope: ["project:orion"],
+    evidence: [{source_kind: "operator_note", source_id: "smoke-active-packet", excerpt: "smoke"}],
+    proposed_by: "smoke",
+    planning_effects: ["smoke_test_context"],
+    retrieval_affordances: ["smoke_test_lookup"]
+  }')" | jq -r '.crystallization_id'
+}
+
+_approve() {
+  local cid="$1"
+  curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/proposals/${cid}/validate" >/dev/null
+  local approve_status
+  approve_status=$(curl -sS -o /tmp/smoke_graphiti_active_packet_approve.json -w '%{http_code}' "${HDR[@]}" -X POST "${BASE}/api/memory/crystallizations/proposals/${cid}/approve" -d '{}')
+  if [[ "$approve_status" != "200" ]]; then
+    echo "FAIL smoke_graphiti_active_packet_search_e2e: approve cid=${cid} http=${approve_status} response=$(cat /tmp/smoke_graphiti_active_packet_approve.json)" >&2
+    exit 1
+  fi
+}
+
+CID_A="$(_propose "$SUBJECT_A" "seed crystallization, unrelated to bravo")"
+CID_B="$(_propose "$SUBJECT_B" "target crystallization, unrelated to alpha, no link to seed")"
+_approve "$CID_A"
+_approve "$CID_B"
+
+# No /api/memory/crystallizations/{id}/links call for either — the whole point is that
+# they are NOT linked, so neighborhood cannot explain what this script asserts.
+curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/graphiti/sync/${CID_A}" -d '{}' >/dev/null
+curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/graphiti/sync/${CID_B}" -d '{}' >/dev/null
+
+AP=$(curl -sS "${HDR[@]}" -X POST "${BASE}/api/memory/active-packet" -d "$(jq -n --arg q "$SUBJECT_B" --arg seed "$CID_A" '{query: $q, seed_crystallization_id: $seed}')")
+REFS=$(echo "$AP" | jq -r '.graphiti_refs[]?')
+
+echo "$REFS" | grep -qx "$CID_B" || {
+  echo "FAIL smoke_graphiti_active_packet_search_e2e: graphiti_refs missing search-only target=${CID_B} seed=${CID_A} response=${AP}" >&2
+  exit 1
+}
+
+echo "PASS smoke_graphiti_active_packet_search_e2e seed=${CID_A} search_reached=${CID_B}"

--- a/services/orion-graphiti-adapter/.env_example
+++ b/services/orion-graphiti-adapter/.env_example
@@ -12,11 +12,11 @@ GRAPHITI_AUTO_APPLY_SCHEMA=true
 # FalkorDB (Redis graph module) — additive temporal projection backend
 FALKORDB_URI=redis://orion-athena-falkordb:6379
 FALKORDB_GRAPH=graphiti_temporal
-FALKORDB_ENABLED=false
+FALKORDB_ENABLED=true
 
-GRAPHITI_BACKEND=orion_postgres
+GRAPHITI_BACKEND=graphiti_core
 # Required when GRAPHITI_BACKEND=graphiti_core
-CRYSTALLIZER_EMBED_HOST_URL=
+CRYSTALLIZER_EMBED_HOST_URL=http://orion-athena-vector-host:8320/embedding
 # Bootstraps graphiti-core's RELATES_TO fulltext+range indices once at adapter startup
 # when GRAPHITI_BACKEND=graphiti_core and FALKORDB_ENABLED=true. Safe to leave true;
 # duplicate-index errors on an already-bootstrapped FalkorDB graph are caught and ignored.

--- a/services/orion-graphiti-adapter/README.md
+++ b/services/orion-graphiti-adapter/README.md
@@ -18,15 +18,17 @@ Hub `GraphitiAdapter` calls this service when `GRAPHITI_URL` is set.
 
 ## graphiti_core backend
 
-`GRAPHITI_BACKEND=graphiti_core` is the deployed runtime state for this Orion node's live
-adapter container as of the 2026-07-13 activation pass (see
-`docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md`). `settings.py`'s
-and `.env_example`'s code-level default remains `orion_postgres` for fresh deployments —
-`/v1/search` is now proven to find real data end to end (see the smoke table below), but
-flipping the shipped default is a separate operator decision, not made in this patch.
-`orion_postgres` is the fallback/rollback backend; neighborhood/BFS traversal is
-backend-agnostic and identical either way (`get_neighborhood()` always delegates to the
-Postgres projection). Only `POST /v1/search` (hybrid vector+graph) is gated by this flag.
+`GRAPHITI_BACKEND=graphiti_core` is the shipped code-level default (`settings.py`,
+`.env_example`) as of the 2026-07-13 hardening pass (see
+`docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md`). `/v1/search` is
+proven to find real data end to end (see the smoke table below), so `graphiti_core` is now the
+default for fresh deployments too — this was previously a live-override-only decision, now
+made. `FALKORDB_ENABLED` defaults to `true` alongside it. `CRYSTALLIZER_EMBED_HOST_URL` is
+still required (`.env_example` ships the real container-DNS value for this node) since
+`graphiti_core` cannot embed without it. `orion_postgres` remains the fallback/rollback
+backend; neighborhood/BFS traversal is backend-agnostic and identical either way
+(`get_neighborhood()` always delegates to the Postgres projection). Only `POST /v1/search`
+(hybrid vector+graph) is gated by this flag.
 
 Entities/edges are written via graphiti-core's own `EntityNode`/`EntityEdge` classes
 (`uuid`-keyed, `RELATES_TO`-shaped, with a self-referential edge per crystallization so

--- a/services/orion-graphiti-adapter/app/backends/graphiti_core.py
+++ b/services/orion-graphiti-adapter/app/backends/graphiti_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 from datetime import datetime, timezone
 from typing import Any
@@ -24,6 +25,26 @@ ORION_GROUP_ID = "orion"
 # Process-local guard so index/constraint bootstrap only runs once per adapter process
 # even if ensure_graphiti_indices() is invoked from more than one call site.
 _indices_ready = False
+
+# Process-local cache for the search() driver/client/Graphiti stack, keyed by the exact
+# constructor inputs. In practice falkordb_uri/graph_name/embed_url all come straight from
+# the process-wide `settings` singleton (see app/main.py's /v1/search route), so they are
+# constant for the life of the process -- but keying by value (instead of a bare global)
+# means a value change (e.g. across tests with different settings) rebuilds instead of
+# silently returning a stale stack. Mirrors the _indices_ready lazy-init-once pattern above.
+_search_stack_cache: dict[tuple[str, str, str], tuple[Any, Any, Any]] = {}
+
+# Tracks whether _OrionEmbedderClient.create() produced a real vector *for the current
+# search() call*, scoped via a ContextVar rather than instance state on the embedder object.
+# The embedder instance is now cached and reused across /v1/search requests (see
+# _get_search_stack) -- a plain `self.used` instance attribute would let one request's
+# result leak into a concurrent request's trace (both share the same embedder object).
+# asyncio gives each request-handling Task its own copy of the current context, so
+# concurrent requests can't see each other's writes here even though they share one
+# _OrionEmbedderClient instance.
+_embed_used_ctx: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_embed_used_ctx", default=False
+)
 
 
 def _parse_falkordb_uri(uri: str) -> tuple[str, int]:
@@ -435,27 +456,59 @@ def _orion_embedder_client(embed_url: str) -> Any:
     """Bridges graphiti-core's cosine-similarity search rail to Orion's own embedding host
     (CRYSTALLIZER_EMBED_HOST_URL) instead of the library's default OpenAIEmbedder.
 
-    Tracks whether a call actually produced a vector on the instance itself (`.used`) so
-    callers can report an honest embed_used trace field without a second, redundant HTTP
-    call to the embed host for the same query text.
+    Records whether a call actually produced a vector via `_embed_used_ctx` (a per-call
+    ContextVar, not instance state) so callers can report an honest embed_used trace field
+    without a second, redundant HTTP call to the embed host for the same query text. This
+    instance is cached and reused across /v1/search requests (see `_get_search_stack`), so
+    tracking success as instance state (`self.used`) would leak one request's result into a
+    concurrent request's trace; the ContextVar is scoped per request-handling asyncio Task
+    instead.
     """
     from graphiti_core.embedder.client import EmbedderClient
 
     class _OrionEmbedderClient(EmbedderClient):
-        def __init__(self) -> None:
-            self.used = False
-
         async def create(self, input_data) -> list[float]:  # type: ignore[override]
             text = input_data[0] if isinstance(input_data, list) and input_data else str(input_data)
             vector = await _embed_query(str(text), embed_url)
             if vector:
-                self.used = True
+                _embed_used_ctx.set(True)
             return vector or []
 
         async def create_batch(self, input_data_list: list[str]) -> list[list[float]]:  # type: ignore[override]
             return [await self.create(item) for item in input_data_list]
 
     return _OrionEmbedderClient()
+
+
+def _get_search_stack(falkordb_uri: str, graph_name: str, embed_url: str) -> tuple[Any, Any, Any]:
+    """Build (or reuse) the FalkorDriver + embedder + Graphiti instance used by search().
+
+    Building this stack fresh on every /v1/search call was pure per-request overhead: a new
+    FalkorDriver (redis-protocol client, graphiti_core/driver/falkordb_driver.py -- thin
+    wrapper over falkordb.asyncio.FalkorDB, no eager connection-pool exhaustion or
+    documented long-lived-reuse hazard) plus a new Graphiti() instance were constructed and
+    thrown away after a single request. Reuse is the intended usage for FalkorDriver; this
+    just stops rebuilding it (and the no-op llm/cross-encoder stubs) every call.
+    """
+    key = (falkordb_uri, graph_name, embed_url)
+    cached = _search_stack_cache.get(key)
+    if cached is not None:
+        return cached
+
+    from graphiti_core import Graphiti
+
+    driver = _falkor_driver(falkordb_uri, graph_name)
+    embedder = _orion_embedder_client(embed_url)
+    graphiti = Graphiti(
+        graph_driver=driver,
+        llm_client=_no_op_llm_client(),
+        embedder=embedder,
+        cross_encoder=_no_op_cross_encoder(),
+    )
+    _search_stack_cache.clear()  # single-entry process cache; drop any stale key first
+    _search_stack_cache[key] = (driver, embedder, graphiti)
+    logger.info("graphiti_search_stack_built falkordb_uri=%s graph=%s", falkordb_uri, graph_name)
+    return driver, embedder, graphiti
 
 
 async def search(
@@ -467,18 +520,17 @@ async def search(
     falkordb_uri: str,
     graph_name: str,
 ) -> dict[str, Any]:
-    from graphiti_core import Graphiti
+    driver, embedder, graphiti = _get_search_stack(falkordb_uri, graph_name, embed_url)
 
-    driver = _falkor_driver(falkordb_uri, graph_name)
-    embedder = _orion_embedder_client(embed_url)
-    graphiti = Graphiti(
-        graph_driver=driver,
-        llm_client=_no_op_llm_client(),
-        embedder=embedder,
-        cross_encoder=_no_op_cross_encoder(),
-    )
-
-    results = await graphiti.search(query=query, num_results=limit)
+    # embedder is cached/reused across requests (see _get_search_stack); _embed_used_ctx is
+    # a per-Task ContextVar (see its definition above) so this reset+read pair can't race
+    # with or leak into a concurrent request's trace even though they share one embedder.
+    ctx_token = _embed_used_ctx.set(False)
+    try:
+        results = await graphiti.search(query=query, num_results=limit)
+        embed_used = _embed_used_ctx.get()
+    finally:
+        _embed_used_ctx.reset(ctx_token)
 
     crystallization_ids = _extract_crystallization_ids(results)
     crystallization_ids = await _filter_intimate_crystallization_ids(driver, crystallization_ids)
@@ -490,7 +542,7 @@ async def search(
             "backend": "graphiti_core",
             "rails": ["vector", "graph"],
             "query": query,
-            "embed_used": embedder.used,
+            "embed_used": embed_used,
             "result_count": len(crystallization_ids),
             "raw_type": type(results).__name__,
         },

--- a/services/orion-graphiti-adapter/app/settings.py
+++ b/services/orion-graphiti-adapter/app/settings.py
@@ -15,10 +15,10 @@ class Settings(BaseSettings):
 
     FALKORDB_URI: str = Field(default="", alias="FALKORDB_URI")
     FALKORDB_GRAPH: str = Field(default="graphiti_temporal", alias="FALKORDB_GRAPH")
-    FALKORDB_ENABLED: bool = Field(default=False, alias="FALKORDB_ENABLED")
+    FALKORDB_ENABLED: bool = Field(default=True, alias="FALKORDB_ENABLED")
 
     GRAPHITI_BACKEND: Literal["orion_postgres", "graphiti_core"] = Field(
-        default="orion_postgres", alias="GRAPHITI_BACKEND"
+        default="graphiti_core", alias="GRAPHITI_BACKEND"
     )
     CRYSTALLIZER_EMBED_HOST_URL: str = Field(default="", alias="CRYSTALLIZER_EMBED_HOST_URL")
     # Bootstraps graphiti-core's RELATES_TO fulltext+range indices once at startup when the

--- a/services/orion-graphiti-adapter/tests/conftest.py
+++ b/services/orion-graphiti-adapter/tests/conftest.py
@@ -2,6 +2,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 os.environ.setdefault("POSTGRES_URI", "")
 os.environ.setdefault("FALKORDB_ENABLED", "false")
 
@@ -11,3 +13,17 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 if str(SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(SERVICE_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _reset_graphiti_core_search_stack_cache():
+    """app.backends.graphiti_core._search_stack_cache is process-local, module-level state
+    (see graphiti_core.py's _get_search_stack). Without a reset, one test's cached
+    driver/embedder/Graphiti stack (often built against a mocked sys.modules["graphiti_core"]
+    that only exists inside that test's `with patch.dict(...)` block) could leak into a
+    later test keyed by the same (falkordb_uri, graph_name, embed_url) tuple."""
+    from app.backends import graphiti_core as core_backend
+
+    core_backend._search_stack_cache.clear()
+    yield
+    core_backend._search_stack_cache.clear()

--- a/services/orion-graphiti-adapter/tests/test_episodes.py
+++ b/services/orion-graphiti-adapter/tests/test_episodes.py
@@ -22,8 +22,15 @@ def mock_pool():
 
 
 def test_ingest_episode_returns_ids(mock_pool):
+    # Exercises the generic orion_postgres ingest path (this test predates backend
+    # selection). graphiti_core is the settings.py/.env_example default as of the
+    # 2026-07-13 hardening pass, but the graphiti_core package itself is only installed
+    # in the service's Docker image, not this bare test venv -- pin the backend so this
+    # test doesn't depend on that package being importable.
     pool, conn = mock_pool
-    with patch.object(main_mod, "pg_pool", pool), patch(
+    with patch.object(main_mod, "pg_pool", pool), patch.object(
+        main_mod.settings, "GRAPHITI_BACKEND", "orion_postgres"
+    ), patch(
         "app.main.sync_to_falkordb", return_value=None
     ):
         client = TestClient(main_mod.app)

--- a/services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py
+++ b/services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py
@@ -428,3 +428,132 @@ async def test_search_filters_intimate_crystallization_ids(monkeypatch):
 
     assert "crys_a" in out["crystallization_ids"]
     assert "crys_intimate" not in out["crystallization_ids"]
+
+
+@pytest.mark.asyncio
+async def test_search_reuses_cached_driver_and_graphiti_across_calls():
+    """_get_search_stack() must build the FalkorDriver/Graphiti stack once and reuse it on
+    subsequent /v1/search calls in the same process -- rebuilding it (and the stub
+    llm/cross-encoder/embedder clients) fresh on every request was pure per-request overhead
+    with no correctness benefit (FalkorDriver is a thin redis-protocol client, safe to reuse)."""
+    driver_calls: list[tuple[str, str]] = []
+
+    def fake_falkor_driver(falkordb_uri, graph_name):
+        driver_calls.append((falkordb_uri, graph_name))
+        return MagicMock()
+
+    graphiti_ctor_calls: list[int] = []
+
+    class FakeGraphiti:
+        def __init__(self, graph_driver, llm_client=None, embedder=None, cross_encoder=None):
+            graphiti_ctor_calls.append(1)
+
+        async def search(self, **kwargs):
+            return []
+
+    fake_graphiti_mod = MagicMock()
+    fake_graphiti_mod.Graphiti = FakeGraphiti
+
+    # Bypass _orion_embedder_client/_no_op_llm_client/_no_op_cross_encoder's own internal
+    # `from graphiti_core.<submodule>.client import ...` imports (same reason as the
+    # pre-existing test_search_filters_intimate_crystallization_ids above) -- a MagicMock
+    # for sys.modules["graphiti_core"] doesn't satisfy real submodule imports.
+    with patch.object(
+        core_backend, "_falkor_driver", side_effect=fake_falkor_driver
+    ), patch.object(core_backend, "_no_op_llm_client", lambda: object()), patch.object(
+        core_backend, "_no_op_cross_encoder", lambda: object()
+    ), patch.object(
+        core_backend, "_orion_embedder_client", lambda embed_url: object()
+    ), patch.dict(
+        "sys.modules", {"graphiti_core": fake_graphiti_mod}
+    ):
+        await core_backend.search(
+            "q1",
+            seed_crystallization_id="",
+            limit=10,
+            embed_url="",
+            falkordb_uri="redis://localhost:6379/0",
+            graph_name="orion_graphiti",
+        )
+        await core_backend.search(
+            "q2",
+            seed_crystallization_id="",
+            limit=10,
+            embed_url="",
+            falkordb_uri="redis://localhost:6379/0",
+            graph_name="orion_graphiti",
+        )
+
+    assert len(driver_calls) == 1, f"expected driver built once, built {len(driver_calls)} times"
+    assert len(graphiti_ctor_calls) == 1, (
+        f"expected Graphiti built once, built {len(graphiti_ctor_calls)} times"
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_embed_used_does_not_leak_across_calls_sharing_cached_embedder():
+    """The embedder instance is cached/reused across requests (see test above). Tracking
+    embed success as instance state (the old `self.used` on _OrionEmbedderClient) would let
+    one call's result leak into a later call's trace since they share one embedder object --
+    embed_used must be tracked per-call via the _embed_used_ctx ContextVar instead."""
+
+    class FakeGraphiti:
+        def __init__(self, graph_driver, llm_client=None, embedder=None, cross_encoder=None):
+            self._embedder = embedder
+
+        async def search(self, **kwargs):
+            # Mirrors graphiti-core's real vector-search rail calling the embedder mid-search.
+            await self._embedder.create(["irrelevant text"])
+            return []
+
+    fake_graphiti_mod = MagicMock()
+    fake_graphiti_mod.Graphiti = FakeGraphiti
+
+    # Fake stand-in for the real _OrionEmbedderClient (see _orion_embedder_client's
+    # docstring): calls core_backend._embed_query and sets _embed_used_ctx on success, same
+    # contract as the real one -- but avoids the real one's internal
+    # `from graphiti_core.embedder.client import EmbedderClient` import, which isn't
+    # satisfiable via a bare MagicMock sys.modules["graphiti_core"] in this dev venv.
+    class _FakeOrionEmbedderClient:
+        async def create(self, input_data):
+            text = input_data[0] if isinstance(input_data, list) and input_data else str(input_data)
+            vector = await core_backend._embed_query(str(text), same_embed_url)
+            if vector:
+                core_backend._embed_used_ctx.set(True)
+            return vector or []
+
+    same_embed_url = "http://embed.example/embed"
+
+    with patch.object(core_backend, "_falkor_driver", return_value=MagicMock()), patch.object(
+        core_backend, "_no_op_llm_client", lambda: object()
+    ), patch.object(core_backend, "_no_op_cross_encoder", lambda: object()), patch.object(
+        core_backend, "_orion_embedder_client", lambda embed_url: _FakeOrionEmbedderClient()
+    ), patch.dict(
+        "sys.modules", {"graphiti_core": fake_graphiti_mod}
+    ):
+        # First call: embed succeeds -> embed_used should be True.
+        with patch.object(core_backend, "_embed_query", AsyncMock(return_value=[0.1, 0.2])):
+            out1 = await core_backend.search(
+                "q1",
+                seed_crystallization_id="",
+                limit=10,
+                embed_url=same_embed_url,
+                falkordb_uri="redis://localhost:6379/0",
+                graph_name="orion_graphiti",
+            )
+        # Second call: same (falkordb_uri, graph_name, embed_url) key -> _get_search_stack
+        # returns the SAME cached embedder instance as call 1. Embed itself fails this time.
+        with patch.object(core_backend, "_embed_query", AsyncMock(return_value=None)):
+            out2 = await core_backend.search(
+                "q2",
+                seed_crystallization_id="",
+                limit=10,
+                embed_url=same_embed_url,
+                falkordb_uri="redis://localhost:6379/0",
+                graph_name="orion_graphiti",
+            )
+
+    assert out1["trace"]["embed_used"] is True
+    assert out2["trace"]["embed_used"] is False, (
+        "stale True from the first call's cached embedder leaked into the second call's trace"
+    )

--- a/services/orion-graphiti-adapter/tests/test_health.py
+++ b/services/orion-graphiti-adapter/tests/test_health.py
@@ -13,4 +13,6 @@ def test_health_without_postgres():
         data = resp.json()
         assert data["postgres"] is False
         assert data["service"] == "orion-graphiti-adapter"
-        assert data["backend"] == "orion_postgres"
+        # graphiti_core is the settings.py/.env_example default as of the 2026-07-13
+        # hardening pass (was orion_postgres before /v1/search was proven live).
+        assert data["backend"] == "graphiti_core"

--- a/services/orion-graphiti-adapter/tests/test_links.py
+++ b/services/orion-graphiti-adapter/tests/test_links.py
@@ -20,8 +20,13 @@ def _mock_pool():
 
 
 def test_ingest_with_supports_link_writes_cross_edge():
+    # Exercises the generic orion_postgres ingest path (this test predates backend
+    # selection); pin the backend so it doesn't depend on the graphiti_core package,
+    # which is only installed in the service's Docker image, not this test venv.
     pool, conn = _mock_pool()
-    with patch.object(main_mod, "pg_pool", pool), patch("app.main.sync_to_falkordb", return_value=None):
+    with patch.object(main_mod, "pg_pool", pool), patch.object(
+        main_mod.settings, "GRAPHITI_BACKEND", "orion_postgres"
+    ), patch("app.main.sync_to_falkordb", return_value=None):
         client = TestClient(main_mod.app)
         resp = client.post(
             "/v1/episodes",

--- a/services/orion-graphiti-adapter/tests/test_rebuild.py
+++ b/services/orion-graphiti-adapter/tests/test_rebuild.py
@@ -20,8 +20,13 @@ def _mock_pool():
 
 
 def test_rebuild_batch_ingests_items():
+    # Exercises the generic orion_postgres ingest path (this test predates backend
+    # selection); pin the backend so it doesn't depend on the graphiti_core package,
+    # which is only installed in the service's Docker image, not this test venv.
     pool, conn = _mock_pool()
-    with patch.object(main_mod, "pg_pool", pool), patch(
+    with patch.object(main_mod, "pg_pool", pool), patch.object(
+        main_mod.settings, "GRAPHITI_BACKEND", "orion_postgres"
+    ), patch(
         "app.main.sync_to_falkordb", return_value=None
     ):
         client = TestClient(main_mod.app)
@@ -58,7 +63,9 @@ def test_rebuild_batch_ingests_items():
 
 def test_rebuild_skips_intimate_items():
     pool, _conn = _mock_pool()
-    with patch.object(main_mod, "pg_pool", pool):
+    with patch.object(main_mod, "pg_pool", pool), patch.object(
+        main_mod.settings, "GRAPHITI_BACKEND", "orion_postgres"
+    ):
         client = TestClient(main_mod.app)
         resp = client.post(
             "/v1/rebuild",


### PR DESCRIPTION
# PR report: graphiti_core default + search-stack caching + chat-visible proof

Third follow-up in this session's graphiti_core line (#993 activation, #995 RELATES_TO schema fix, this PR: hardening now that #995 is proven). Three independent-but-related items, one PR since all three are scoped to `orion-graphiti-adapter`.

## Summary

- `GRAPHITI_BACKEND` default flipped `orion_postgres` → `graphiti_core`, `FALKORDB_ENABLED` default `false` → `true` (`settings.py`, `.env_example`). This was previously an explicit live-override-only decision ("stays `orion_postgres` until search is proven") — it's proven now (PR #995), so the shipped default follows.
- `/v1/search` no longer rebuilds its `FalkorDriver`/`Graphiti`/stub-client stack on every single request — memoized in a process-local cache, mirroring the existing `_indices_ready` lazy-init pattern.
- New `scripts/smoke_graphiti_active_packet_search_e2e.sh`: proves the search-rail fix reaches a real Hub API response (`/api/memory/active-packet`, the same endpoint a live chat turn's recall path consumes), isolated from neighborhood/links by using two crystallizations with no edge between them.
- Fixed a real regression the default-flip caused: 4 pre-existing tests silently depended on the old default to avoid needing the `graphiti_core` package (Docker-image-only, not in the dev venv) — pinned explicitly rather than weakened.
- Fixed a real correctness hazard the caching change introduced before it shipped: embed-success tracking moved from embedder instance state to a per-call `ContextVar`, since a cached/reused embedder instance would otherwise leak one request's result into a concurrent request's trace.

## Outcome moved

Fresh deployments now get the proven-working backend by default, not a stale conservative default that predates proof. `/v1/search` no longer pays full driver/client construction cost on every request. And — the most important one — there is now direct evidence the search fix is reachable from the same API surface a live chat turn actually uses, not just the adapter's own internal endpoint.

## Current architecture (before this patch)

`GRAPHITI_BACKEND=orion_postgres` was the code-level default (README: "settings.py's and .env_example's code-level default remains orion_postgres... until /v1/search is proven to find real data end to end") — a hedge from PR #993, before #995 fixed the actual bug. `search()` built its entire driver/client/`Graphiti` stack fresh per call. No test exercised whether the search fix was visible outside the adapter's own `/v1/search` endpoint.

## Architecture touched

Single service, `orion-graphiti-adapter` — settings, one backend module, its tests, and one new top-level smoke script. No schema/bus/API contract changes.

## Files changed

- `services/orion-graphiti-adapter/app/settings.py`, `.env_example`: default flip
- `services/orion-graphiti-adapter/README.md`: rewrote the paragraph declaring `orion_postgres` the hedge default — that decision is made now
- `services/orion-graphiti-adapter/app/backends/graphiti_core.py`: `_get_search_stack()` (new, memoized driver/embedder/`Graphiti` build), `_embed_used_ctx` `ContextVar` replacing `_OrionEmbedderClient.used` instance state, `search()` updated to use both
- `services/orion-graphiti-adapter/tests/conftest.py`: new autouse fixture clearing `_search_stack_cache` before/after every test
- `services/orion-graphiti-adapter/tests/{test_episodes,test_links,test_rebuild}.py`: pinned `GRAPHITI_BACKEND=orion_postgres` on the specific tests that exercise the generic (non-graphiti_core-specific) ingest/link/rebuild path, since the `graphiti_core` package isn't importable in the bare dev venv
- `services/orion-graphiti-adapter/tests/test_health.py`: updated a real stale assertion (`backend == "orion_postgres"`) to match the new default
- `services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py`: 2 new regression tests — driver/`Graphiti` construction happens once across repeated `search()` calls; `embed_used` doesn't leak stale `True` across calls sharing a cached embedder
- `scripts/smoke_graphiti_active_packet_search_e2e.sh` (new): the chat-visible proof
- `docs/superpowers/specs/2026-07-13-graphiti-core-backend-activation-spec.md`: "Hardening pass" addendum documenting all three items and live verification evidence

## Schema / bus / API changes

None. No new env keys, no schema/bus/API surface changes — this PR changes defaults, adds a process-local perf cache, and adds a smoke script.

## Env/config changes

- Added keys: none
- Removed keys: none
- Renamed keys: none
- Changed defaults: `GRAPHITI_BACKEND` (`orion_postgres`→`graphiti_core`), `FALKORDB_ENABLED` (`false`→`true`) in both `settings.py` and `.env_example`
- `.env_example` updated: yes
- Local `.env` synced: this host's `services/orion-graphiti-adapter/.env` already had the live-override values set (from #993/#995), unaffected by the default-flip in code — verified unchanged post-deploy (see Docker/smoke checks below)
- Skipped keys requiring operator action: none — any environment that doesn't already have an explicit `.env` override will now start with `graphiti_core` by default, which is the intended behavior of this PR

## Tests run

```text
$ source venv/bin/activate && python -m pytest services/orion-graphiti-adapter/tests -q
23 passed, 2 warnings in 0.76s
```
21 baseline + 2 new caching/ContextVar regression tests. Independently re-run by the orchestrator, not taken from the implementing agent's report alone (note: the implementing agent's background session hit an API session-limit error partway through and did not reach the test-fixing, smoke-script, or verification stages — the orchestrator completed items 2 and 3's remaining work directly, including discovering and fixing the 4-test regression above, in the same worktree the agent had already made solid partial progress in).

## Evals run

No eval harness exists for this service (same gap noted in prior PRs this session). The three live e2e smokes below are the deterministic gate.

## Docker/build/smoke checks

```text
$ curl -sS http://localhost:8640/health
{"service":"orion-graphiti-adapter","postgres":true,"falkordb_enabled":true,"backend":"graphiti_core"}

$ bash scripts/smoke_graphiti_links_e2e.sh
PASS smoke_graphiti_links_e2e seed=1a0fafe5-dd1f-4254-b3a1-b6c87330d82b linked=7b1cbb56-2782-4de8-9a3b-0a6da8a1e1ac

$ bash scripts/smoke_graphiti_search_e2e.sh
PASS smoke_graphiti_search_e2e seed=85ec3f1c-4cbf-4859-a1c9-d1540c9519df embed_used=true

$ bash scripts/smoke_graphiti_active_packet_search_e2e.sh
PASS smoke_graphiti_active_packet_search_e2e seed=86f4134c-a281-46a9-958d-4d79c7486a74 search_reached=50ab005f-6cf7-49ca-8feb-1d82e9f459f3
```

All three run after a full rebuild+restart with this PR's code (`docker exec orion-athena-graphiti-adapter grep -c "_get_search_stack\|_embed_used_ctx" /app/app/backends/graphiti_core.py` → 12, confirming the new code is what's actually running, not a stale image).

## Review findings fixed

- Finding: default-flip broke 4 existing tests that silently depended on the old default (`ModuleNotFoundError: graphiti_core` — the package is Docker-image-only).
  - Fix: pinned `GRAPHITI_BACKEND=orion_postgres` explicitly in `test_ingest_episode_returns_ids`, `test_ingest_with_supports_link_writes_cross_edge`, `test_rebuild_batch_ingests_items`, `test_rebuild_skips_intimate_items` — these test generic ingest/link/rebuild behavior, not anything graphiti_core-specific, so pinning the backend they were implicitly already exercising is correct, not a weakening.
  - Evidence: `pytest` count went from 21 failed-5/passed-16 immediately after the default flip, to 21/21 passing after the pin, to 23/23 after adding the 2 new caching tests.
- Finding: `test_health_without_postgres` asserted `backend == "orion_postgres"` — a real stale assertion, not a test-isolation artifact.
  - Fix: updated to `"graphiti_core"`.
  - Evidence: test passes; assertion now matches the intentional new default.
- Finding (design review, before shipping): caching the embedder instance across requests would let `_OrionEmbedderClient.used` (old instance-state tracking) leak one request's embed-success result into a concurrent or later request's trace.
  - Fix: replaced with `_embed_used_ctx`, an `asyncio.ContextVar` reset at the start of every `search()` call.
  - Evidence: new regression test `test_search_embed_used_does_not_leak_across_calls_sharing_cached_embedder` — first call embeds successfully (`embed_used: True`), second call (same cached embedder) has embed fail (`embed_used: False`), asserted independently.

## Restart required

Already executed live during this session:

```bash
docker compose --profile falkordb \
  --env-file .env --env-file services/orion-graphiti-adapter/.env \
  -f services/orion-graphiti-adapter/docker-compose.yml up -d --build
```

If merged and redeployed elsewhere with no existing `.env` override: no action needed — the new default (`graphiti_core`) is now correct out of the box, assuming `CRYSTALLIZER_EMBED_HOST_URL` is reachable on that host (already required, unchanged).

## Risks / concerns

- Severity: Medium — the implementing background agent hit an API session-limit error mid-task and stopped before finishing. Its partial work (items 1 fully, item 2's core logic) was solid on inspection (correctly identified the exact `ContextVar` fix needed for the caching hazard, and added the `conftest.py` test-isolation fixture proactively) — the orchestrator verified and completed the remainder directly (the 4-test regression fix, item 3's smoke script, live verification, spec addendum) rather than re-spawning a second agent into the same constraint. Documented here for traceability, not hidden.
- Severity: Low — `_search_stack_cache` is a single-process, in-memory cache with no TTL or invalidation path if `falkordb_uri`/`graph_name`/`embed_url` ever needed to change without a process restart (they don't today — sourced once from `settings` at process start). Not a bug under current usage; worth knowing if this service ever needs hot config reload.
