### PR TITLE
Feat/single consumer channel gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry
+.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels
 
 SERVICE ?=
 ARGS ?=
@@ -28,3 +28,10 @@ test-actions:
 # rest.
 check-inner-state-registry:
 	@python scripts/check_inner_state_registry.py
+
+# Live-bus gate: every channel marked single_consumer: true in
+# orion/bus/channels.yaml must have exactly one live subscriber
+# (Redis pub/sub duplicates execution otherwise -- see PR #994).
+# Requires ORION_BUS_URL=redis://<tailscale-ip>:6379/0.
+check-single-consumer-channels:
+	@python scripts/check_single_consumer_channels.py

--- a/docs/platform_routing_wiring_map.md
+++ b/docs/platform_routing_wiring_map.md
@@ -16,7 +16,7 @@
 
 ### Direct/bypass paths discovered
 - Legacy direct equilibrium → `orion:verb:request` path is intentionally disabled behind `EQUILIBRIUM_METACOG_PUBLISH_VERB_REQUEST`; code logs an error instead of publishing.
-- `services/orion-equilibrium-service/app/settings.py` still defaults `CHANNEL_CORTEX_ORCH_REQUEST` to `orion:verb:request`, which is drift-prone and misleading even though runtime flow currently uses trigger channel.
+- `services/orion-equilibrium-service/app/settings.py` previously defaulted `CHANNEL_CORTEX_ORCH_REQUEST` to `orion:verb:request`; the key was never read by any code and was removed on 2026-07-13 (runtime flow uses the trigger channel).
 
 ---
 

--- a/docs/superpowers/pr-reports/2026-07-13-single-consumer-channel-gate-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-single-consumer-channel-gate-pr.md
@@ -1,0 +1,131 @@
+# PR report — single-consumer channel gate + dead equilibrium config removal
+
+Date: 2026-07-13
+Branch: `feat/single-consumer-channel-gate`
+
+## Summary
+
+- New deterministic live-bus gate: every channel marked `single_consumer: true` in `orion/bus/channels.yaml` must have exactly one live subscriber, or the gate fails. This turns the PR #994 class of bug (two containers both subscribed to `orion:verb:request`, every LLM call executed twice) into a failing check instead of a live incident.
+- 31 request/dispatch channels annotated `single_consumer: true`, including one channel that was live on the bus but missing from the catalog entirely (`orion:exec:request:CollapseMirrorService`).
+- A catalog test enforces the annotation going forward: any `kind: request` entry with one consumer and a concrete name must be annotated (empty exemption list), so new request channels cannot drift out of coverage.
+- Code review found the first cut of the gate failed open (redis-cli error replies and parse drift degraded to benign 0-subscriber warnings); fixed fail-closed at the fetch seam.
+- Removed the dead `channel_cortex_orch_request` / `CHANNEL_CORTEX_ORCH_REQUEST` config key from orion-equilibrium-service — defined since inception, never read by any code, and misleadingly implied equilibrium touches `orion:verb:request`.
+
+## Outcome moved
+
+The duplicate-LLM-execution failure mode is now regression-gated. Before: a second subscriber on any execute-once channel was invisible until someone traced duplicate `request_id`s in production (as happened in PR #994). After: `make check-single-consumer-channels` fails with the exact channel and count. First live run verified the whole mesh clean: 31 channels, 28 at exactly 1 subscriber, 3 warnings for idle services, 0 violations.
+
+## Current architecture
+
+The bus is Redis pub/sub — every subscriber executes every message; there are no competing-consumer queues. Execute-once semantics (RPC request channels served by `Rabbit`, dispatch channels consumed by a single `Hunter`) are purely conventional: nothing declared which channels carry those semantics and nothing checked subscriber counts. The catalog (`orion/bus/channels.yaml`) documented producers/consumers but had no single-consumer concept, and one live RPC channel was missing from it. `scripts/platform/audit_channels.py` exists but is static analysis only — it never touches the live bus.
+
+## Architecture touched
+
+- Contract: `orion/bus/channels.yaml` (new `single_consumer: true` field, 31 entries + 1 new entry)
+- Gate: `scripts/check_single_consumer_channels.py` (new), `Makefile` target `check-single-consumer-channels`
+- Tests: `tests/test_single_consumer_channels_gate.py` (new, 19 tests)
+- Service config hygiene: `services/orion-equilibrium-service` (dead key removed)
+
+## Files changed
+
+- `orion/bus/channels.yaml`: 31 channels annotated `single_consumer: true`; added missing `orion:exec:request:CollapseMirrorService` entry (producer orion-cortex-exec, consumer orion-collapse-mirror, mirrors the MetaTagsService entry convention).
+- `scripts/check_single_consumer_channels.py`: new gate. Reads the catalog (plain `yaml.safe_load`; missing PyYAML is a loud exit 2), queries live counts via `redis-cli PUBSUB NUMSUB` subprocess (no new Python dependency), fails on >1 subscriber, warns on 0 (`--strict-zero` promotes to failure). Fail-closed: Redis error replies (NOAUTH/ERR/LOADING/…) and any requested channel absent from the parsed reply are infra errors (exit 2) — never counted as 0. Exit codes: 0 clean, 1 violation, 2 infra.
+- `tests/test_single_consumer_channels_gate.py`: pure decision core, NUMSUB parsing, fail-closed contract, main() exit paths, catalog wiring, and the annotation-coverage enforcement test. No live bus needed.
+- `Makefile`: `check-single-consumer-channels` target beside `check-inner-state-registry`.
+- `scripts/README.md`: gate documented (what it guards, how to run, expected output).
+- `services/orion-equilibrium-service/app/settings.py`: removed dead `channel_cortex_orch_request` field.
+- `services/orion-equilibrium-service/.env_example`: removed `CHANNEL_CORTEX_ORCH_REQUEST` line; comment trimmed accordingly.
+- `docs/platform_routing_wiring_map.md`: bullet that flagged the key as drift-prone now records its removal.
+
+## Schema / bus / API changes
+
+- Added: `single_consumer: true` catalog field (documentation + gate input; no runtime payload change). New catalog entry `orion:exec:request:CollapseMirrorService` (channel already live; `GenericPayloadV1`, already registered in `orion/schemas/registry.py`).
+- Removed: none at runtime.
+- Renamed: none.
+- Behavior changed: none at runtime — the gate is read-only against the bus (`PUBSUB NUMSUB` only).
+- Compatibility notes: unknown catalog fields are ignored by existing consumers of channels.yaml (verified `scripts/platform/_common.load_channels_catalog` and audit scripts tolerate it; `tests/test_inner_state_registry_gate.py` still passes).
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: `CHANNEL_CORTEX_ORCH_REQUEST` (orion-equilibrium-service; dead, never read).
+- Renamed keys: none.
+- `.env_example` updated: yes (`services/orion-equilibrium-service/.env_example`).
+- local `.env` synced: yes — targeted removal of the dead line from `services/orion-equilibrium-service/.env` (deliberately not via `sync_local_env_from_example.py`, which is additive-oriented and has previously reverted intentional live overrides; a one-key deletion is safer done surgically). Verified 0 matches remain.
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+orion_dev/bin/python -m pytest tests/test_single_consumer_channels_gate.py \
+  tests/test_inner_state_registry_gate.py \
+  services/orion-equilibrium-service/tests -q
+34 passed, 6 warnings in 5.68s
+  (19 gate tests + 8 inner-state gate regression + 7 equilibrium)
+```
+
+## Evals run
+
+```text
+No eval harness applies: the gate is fully deterministic (catalog parse +
+subscriber-count arithmetic); there is no model-quality surface to eval.
+The live smoke below is the behavioral proof.
+```
+
+## Docker/build/smoke checks
+
+```text
+ORION_BUS_URL=redis://100.92.216.81:6379/0 python3 scripts/check_single_consumer_channels.py
+→ 31 channels checked: 28 OK at exactly 1 subscriber; WARN 0 for
+  orion:conversation:request, orion:exec:request:ContextExecService,
+  orion:exec:request:CouncilService (services idle/down — liveness, not
+  duplication); 0 violations; exit 0.
+
+No Docker changes: no service runtime code touched (equilibrium change is a
+dead-field deletion; settings use extra="ignore" so stale env values are
+harmless).
+```
+
+## Review findings fixed
+
+- Finding: gate failed open — redis-cli exits 0 on Redis error replies (NOAUTH/WRONGPASS/ERR/LOADING) with the error on stdout; the parse yielded `{}`, every channel was backfilled to 0, and the gate printed all-WARN and exited 0 while checking nothing (empirically confirmed by reviewer on redis-cli 7.0.15).
+  - Fix: error-reply first lines raise; any requested channel absent from the parsed reply raises (NUMSUB always echoes every requested channel, so absence proves a non-NUMSUB reply). Both exit 2.
+  - Evidence: `test_fetch_live_counts_error_reply_raises_not_zero_counts`, `test_fetch_live_counts_missing_channel_in_reply_raises`.
+- Finding: one stray stdout line shifted the fixed-offset pair parsing, converting a real 2-subscriber violation into a benign 0-subscriber warning (confirmed by reviewer simulation).
+  - Fix: same seam — the missing-channel check makes any parse drift an infra error; the `setdefault(ch, 0)` backfill was removed.
+  - Evidence: the noisy-banner test above feeds exactly that scenario.
+- Finding: 11 structurally identical request channels left unannotated, and nothing enforced the annotation for future channels.
+  - Fix: annotated all 11 (verified each: `kind: request`, exactly one consumer, concrete name); added `test_every_request_kind_single_consumer_channel_is_annotated` with an empty exemption list.
+  - Evidence: live run now covers 31 channels; enforcement test passes with zero exemptions.
+- Finding (nit): `main()` re-derived FAIL/WARN/OK by hand, so printed status and exit code could drift.
+  - Fix: `evaluate_counts` returns per-channel statuses; both derive from the one function.
+- Finding (nit): shared catalog loader's regex fallback silently drops `single_consumer` when PyYAML is absent, producing a misleading "annotation missing?" diagnostic.
+  - Fix: plain `yaml.safe_load` only; missing PyYAML is a clear exit-2 infra error.
+- Finding (nit): TTY-only redis-cli output-format parsing branches were unreachable under `capture_output=True`.
+  - Fix: removed, with their test.
+- Finding (nit, not fixed here): the `scripts/platform/` stdlib-shadow `sys.path.pop` workaround is hand-copied across ~12 scripts, this one included. Repo-wide cleanup (rename `scripts/platform/` or a shared helper) is a separate chore — out of scope for this patch.
+
+## Restart required
+
+```text
+No restart required. The gate is a repo script; no running service reads the
+removed equilibrium key (never read by code) or the new catalog field. The
+equilibrium container will simply boot without the dead field on its next
+scheduled rebuild — no action needed now.
+```
+
+## Risks / concerns
+
+- Severity: low
+  - Concern: `single_consumer: true` semantics could drift if a channel legitimately gains a second, role-distinct consumer (fan-out by design).
+  - Mitigation: that change must flip the annotation in the same patch — the gate failing is exactly the review conversation we want; the enforcement test's exemption list is the documented escape hatch.
+- Severity: low
+  - Concern: the 3 WARN-at-0 channels (conversation, context-exec, council) will keep warning while those services stay idle; warning fatigue could hide a real new WARN.
+  - Mitigation: `--strict-zero` exists for a full-mesh-up check; warnings are listed per channel so new ones are visible in diffs of gate output.
+- Severity: low
+  - Concern: gate requires `redis-cli` on the runner.
+  - Mitigation: missing binary is a loud exit-2 with an install hint; no silent pass.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/single-consumer-channel-gate

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -61,6 +61,7 @@ channels:
     schema_id: "ChatRequestPayload"
     producer_services: ["orion-hub"]
     consumer_services: ["orion-cortex-orch"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -548,6 +549,7 @@ channels:
     schema_id: "WorkflowScheduleManageRequestV1"
     producer_services: ["orion-cortex-orch"]
     consumer_services: ["orion-actions"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-03-24"
 
@@ -680,6 +682,7 @@ channels:
     schema_id: "RdfBuildRequest"
     producer_services: ["orion-cortex-exec"]
     consumer_services: ["orion-rdf-writer"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -879,6 +882,7 @@ channels:
     schema_id: "PadRpcRequestV1"
     producer_services: ["*"]
     consumer_services: ["orion-landing-pad"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-10"
 
@@ -1437,6 +1441,7 @@ channels:
     schema_id: "EmbeddingGenerateV1"
     producer_services: ["orion-vector-writer", "orion-hub", "orion-cortex-exec", "*"]
     consumer_services: ["orion-vector-host"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-10"
 
@@ -1453,6 +1458,7 @@ channels:
     schema_id: "StateGetLatestRequest"
     producer_services: ["*"]
     consumer_services: ["orion-state-service"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-10"
 
@@ -1551,6 +1557,7 @@ channels:
     schema_id: "TTSRequestPayload"
     producer_services: ["orion-hub"]
     consumer_services: ["orion-whisper-tts"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-14"
 
@@ -1567,6 +1574,7 @@ channels:
     schema_id: "STTRequestPayload"
     producer_services: ["orion-hub"]
     consumer_services: ["orion-whisper-tts"]
+    single_consumer: true
 
   - name: "orion:stt:result:*"
     kind: "result"
@@ -2106,6 +2114,7 @@ channels:
     message_kind: "stance.react.request.v1"
     producer_services: ["orion-hub"]
     consumer_services: ["orion-thought"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-07-05"
 
@@ -2204,6 +2213,7 @@ channels:
     message_kind: "harness.run.request.v1"
     producer_services: ["orion-hub"]
     consumer_services: ["orion-harness-governor"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-07-05"
 
@@ -2248,6 +2258,7 @@ channels:
     message_kind: "harness.draft.molecule.v1"
     producer_services: ["orion-harness-governor"]
     consumer_services: ["orion-substrate-runtime"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-07-05"
 

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -4,6 +4,7 @@ channels:
     schema_id: "VerbRequestV1"
     producer_services: ["orion-cortex-orch"]
     consumer_services: ["orion-cortex-exec"]
+    single_consumer: true
     stability: "stable"
     since: "2026-01-08"
 
@@ -76,6 +77,7 @@ channels:
     schema_id: "CortexClientRequest"
     producer_services: ["orion-hub", "orion-cortex-gateway", "orion-actions", "orion-memory-consolidation"]
     consumer_services: ["orion-cortex-orch"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -100,6 +102,7 @@ channels:
     schema_id: "DreamTriggerPayload"
     producer_services: ["orion-dream"]
     consumer_services: ["orion-cortex-orch"]
+    single_consumer: true
     stability: "stable"
     since: "2026-03-23"
 
@@ -116,6 +119,7 @@ channels:
     schema_id: "CortexChatRequest"
     producer_services: ["orion-hub"]
     consumer_services: ["orion-cortex-gateway"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -134,6 +138,7 @@ channels:
       - orion-cortex-orch
       - orion-thought
     consumer_services: ["orion-cortex-exec"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -142,6 +147,7 @@ channels:
     schema_id: "CortexExecRequestPayload"
     producer_services: ["orion-cortex-orch"]
     consumer_services: ["orion-cortex-exec"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-05-13"
 
@@ -150,6 +156,7 @@ channels:
     schema_id: "CortexExecRequestPayload"
     producer_services: ["orion-cortex-orch"]
     consumer_services: ["orion-cortex-exec"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-05-13"
 
@@ -158,6 +165,7 @@ channels:
     schema_id: "CortexExecRequestPayload"
     producer_services: ["orion-cortex-orch", "orion-actions", "orion-harness-governor"]
     consumer_services: ["orion-cortex-exec"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-05-13"
 
@@ -166,6 +174,7 @@ channels:
     schema_id: "PreTurnAppraisalRequestV1"
     producer_services: ["orion-hub"]
     consumer_services: ["orion-cortex-exec"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-07-03"
 
@@ -188,6 +197,7 @@ channels:
       - "orion-mind"
       - "orion-memory-consolidation"
     consumer_services: ["orion-llm-gateway"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -249,6 +259,7 @@ channels:
     schema_id: "RecallQueryV1"
     producer_services: ["orion-cortex-exec", "orion-cortex-orch", "orion-hub", "orion-context-exec"]
     consumer_services: ["orion-recall"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -265,6 +276,7 @@ channels:
     schema_id: "ContextExecRequestV1"
     producer_services: ["orion-cortex-exec", "orion-self-experiments"]
     consumer_services: ["orion-context-exec"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-06-10"
 
@@ -297,6 +309,7 @@ channels:
     schema_id: "GenericPayloadV1"
     producer_services: ["orion-hub"]
     consumer_services: ["orion-agent-council"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -345,6 +358,7 @@ channels:
     schema_id: "GenericPayloadV1"
     producer_services: ["orion-hub", "orion-cortex-exec"]
     consumer_services: ["orion-agent-council"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -370,6 +384,7 @@ channels:
     schema_id: "VisionWindowRequestPayload"
     producer_services: ["orion-vision-window"]
     consumer_services: ["orion-vision-council"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -386,6 +401,7 @@ channels:
     schema_id: "VisionCouncilRequestPayload"
     producer_services: ["orion-vision-window"]
     consumer_services: ["orion-vision-council"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -403,6 +419,7 @@ channels:
     schema_id: "VisionScribeRequestPayload"
     producer_services: ["orion-vision-council"]
     consumer_services: ["orion-vision-scribe"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -420,6 +437,7 @@ channels:
     schema_id: "VisionTaskRequestPayload"
     producer_services: ["orion-cortex-exec", "orion-hub", "orion-vision-host", "orion-vision-frame-router"]
     consumer_services: ["orion-vision-host"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-08"
 
@@ -1491,6 +1509,7 @@ channels:
     schema_id: "MetaTagsRequestV1"
     producer_services: ["orion-cortex-exec"]
     consumer_services: ["orion-meta-tags"]
+    single_consumer: true
     stability: "experimental"
     since: "2026-01-10"
 
@@ -1501,6 +1520,15 @@ channels:
     consumer_services: ["orion-cortex-exec"]
     stability: "experimental"
     since: "2026-01-10"
+
+  - name: "orion:exec:request:CollapseMirrorService"
+    kind: "request"
+    schema_id: "GenericPayloadV1"
+    producer_services: ["orion-cortex-exec"]
+    consumer_services: ["orion-collapse-mirror"]
+    single_consumer: true
+    stability: "experimental"
+    since: "2026-07-13"
 
   - name: "orion:cognition:trace"
     kind: "event"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,6 +39,19 @@ Expected output when live generation prerequisites are healthy:
 collapse_mirror_live_path_truth: PASS
 ```
 
+## Single-Consumer Channel Gate (duplicate-execution guard)
+The bus is Redis pub/sub, so every subscriber executes every message. Channels with execute-once semantics (RPC request / work dispatch) are marked `single_consumer: true` in `orion/bus/channels.yaml`; this gate fails if any of them has more than one live subscriber — the failure mode behind the duplicate-LLM-execution bug fixed in PR #994. Zero subscribers is a warning (consumer down = liveness, not duplication) unless `--strict-zero`. Requires `redis-cli`.
+```bash
+ORION_BUS_URL=redis://<tailscale-ip>:6379/0 python scripts/check_single_consumer_channels.py
+# or: make check-single-consumer-channels
+```
+Expected output when the mesh is clean:
+```
+OK 1 orion:verb:request
+...
+single_consumer gate OK: 20 channel(s) checked, 0 warning(s)
+```
+
 ## ChatGPT Export Import (Bus Fanout)
 
 ### What this does

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,7 +49,7 @@ Expected output when the mesh is clean:
 ```
 OK 1 orion:verb:request
 ...
-single_consumer gate OK: 20 channel(s) checked, 0 warning(s)
+single_consumer gate OK: 31 channel(s) checked, 0 warning(s)
 ```
 
 ## ChatGPT Export Import (Bus Fanout)

--- a/scripts/check_single_consumer_channels.py
+++ b/scripts/check_single_consumer_channels.py
@@ -51,21 +51,17 @@ def load_single_consumer_channels(channels_file: Path = DEFAULT_CHANNELS_FILE) -
     Glob-shaped names (e.g. reply patterns like `orion:llm:reply*`) cannot be a
     single concrete pub/sub channel, so a subscriber count is meaningless.
     """
-    entries: list[dict] | None = None
-    if channels_file == DEFAULT_CHANNELS_FILE:
-        # Prefer the shared catalog loader so this gate reads the catalog the
-        # same way scripts/platform/audit_channels.py does.
-        try:
-            from scripts.platform._common import load_channels_catalog
-
-            entries = list(load_channels_catalog(REPO_ROOT).values())
-        except Exception:
-            entries = None  # fall through to plain yaml
-    if entries is None:
+    # Plain yaml only: the shared load_channels_catalog helper falls back to a
+    # regex parse when PyYAML is absent, which silently drops single_consumer
+    # flags -- for a gate, a missing parser must be a loud infra error, not an
+    # empty result.
+    try:
         import yaml
+    except ImportError as exc:
+        raise RuntimeError("PyYAML is required to read channels.yaml") from exc
 
-        data = yaml.safe_load(channels_file.read_text(encoding="utf-8")) or {}
-        entries = [e for e in (data.get("channels") or []) if isinstance(e, dict)]
+    data = yaml.safe_load(channels_file.read_text(encoding="utf-8")) or {}
+    entries = [e for e in (data.get("channels") or []) if isinstance(e, dict)]
 
     names: list[str] = []
     for entry in entries:
@@ -80,26 +76,21 @@ def load_single_consumer_channels(channels_file: Path = DEFAULT_CHANNELS_FILE) -
     return names
 
 
+_REDIS_ERROR_PREFIXES = ("ERR", "NOAUTH", "WRONGPASS", "NOPERM", "LOADING", "MOVED", "CLUSTERDOWN")
+
+
 def parse_numsub_output(stdout: str) -> dict[str, int]:
-    """Parse `redis-cli PUBSUB NUMSUB ch1 ch2 ...` output.
+    """Parse `redis-cli PUBSUB NUMSUB ch1 ch2 ...` piped (non-TTY) output.
 
     redis-cli prints alternating lines: channel name, subscriber count.
-    Parses defensively -- non-integer count lines are skipped rather than
-    crashing, so one weird line cannot take down the whole gate run.
+    Unparseable pairs are skipped here; the caller decides whether missing
+    channels are an infra error (they are -- NUMSUB always echoes every
+    requested channel, so absence means the reply was not a NUMSUB reply).
     """
     lines = [ln.strip() for ln in stdout.splitlines() if ln.strip()]
     counts: dict[str, int] = {}
     for i in range(0, len(lines) - 1, 2):
-        channel, raw_count = lines[i], lines[i + 1]
-        # Some redis-cli versions prefix list output with "N) ".
-        if ") " in channel:
-            channel = channel.split(") ", 1)[1].strip()
-        if ") " in raw_count:
-            raw_count = raw_count.split(") ", 1)[1].strip()
-        channel = channel.strip('"')
-        # "(integer) 2" form appears in non-raw interactive output.
-        if raw_count.startswith("(integer)"):
-            raw_count = raw_count[len("(integer)"):].strip()
+        channel, raw_count = lines[i].strip('"'), lines[i + 1]
         try:
             counts[channel] = int(raw_count)
         except ValueError:
@@ -109,15 +100,18 @@ def parse_numsub_output(stdout: str) -> dict[str, int]:
 
 def evaluate_counts(
     counts: dict[str, int], *, strict_zero: bool = False
-) -> tuple[list[str], list[str]]:
-    """Pure decision core: (violations, warnings) from channel -> subscriber count.
+) -> tuple[list[str], list[str], dict[str, str]]:
+    """Pure decision core: (violations, warnings, status_by_channel).
 
-    count > 1  -> violation (duplicate execution: the PR #994 class of bug)
-    count == 0 -> warning (consumer down = liveness issue, not duplication),
-                  promoted to violation under strict_zero.
+    count > 1  -> FAIL (duplicate execution: the PR #994 class of bug)
+    count == 0 -> WARN (consumer down = liveness issue, not duplication),
+                  promoted to FAIL under strict_zero.
+    The printed per-channel status and the exit code both derive from this
+    one function so they cannot drift apart.
     """
     violations: list[str] = []
     warnings: list[str] = []
+    statuses: dict[str, str] = {}
     for channel in sorted(counts):
         count = counts[channel]
         if count > 1:
@@ -125,13 +119,18 @@ def evaluate_counts(
                 f"{channel} has {count} subscribers, expected exactly 1 "
                 f"(duplicate execution risk)"
             )
+            statuses[channel] = "FAIL"
         elif count == 0:
             msg = f"{channel} has 0 subscribers, expected exactly 1 (consumer down?)"
             if strict_zero:
                 violations.append(msg)
+                statuses[channel] = "FAIL"
             else:
                 warnings.append(msg)
-    return violations, warnings
+                statuses[channel] = "WARN"
+        else:
+            statuses[channel] = "OK"
+    return violations, warnings, statuses
 
 
 def fetch_live_counts(bus_url: str, channels: list[str]) -> dict[str, int]:
@@ -146,11 +145,28 @@ def fetch_live_counts(bus_url: str, channels: list[str]) -> dict[str, int]:
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or "").strip()
         raise RuntimeError(f"redis-cli failed (exit {proc.returncode}): {detail}")
-    # redis-cli sometimes exits 0 but prints the error to stdout/stderr.
+    # redis-cli exits 0 on Redis error replies (NOAUTH, ERR, LOADING, ...)
+    # with the error text on stdout -- a reply that is not a NUMSUB reply.
+    first_line = next((ln.strip() for ln in proc.stdout.splitlines() if ln.strip()), "")
+    if any(first_line.startswith(p) for p in _REDIS_ERROR_PREFIXES):
+        raise RuntimeError(f"redis error reply: {first_line}")
     combined = (proc.stdout + proc.stderr).lower()
     if "could not connect" in combined or "connection refused" in combined:
         raise RuntimeError(f"redis-cli could not connect: {(proc.stderr or proc.stdout).strip()}")
-    return parse_numsub_output(proc.stdout)
+
+    counts = parse_numsub_output(proc.stdout)
+    # NUMSUB echoes every requested channel (0 if no subscribers). A channel
+    # missing from the parsed reply therefore means the output was not a
+    # NUMSUB reply (auth error, banner noise, format drift) -- infra error,
+    # never "0 subscribers". This is what keeps the gate fail-closed.
+    missing = [ch for ch in channels if ch not in counts]
+    if missing:
+        raise RuntimeError(
+            f"{len(missing)} requested channel(s) absent from NUMSUB reply "
+            f"(unparseable redis-cli output?): {', '.join(missing[:5])}"
+            + ("..." if len(missing) > 5 else "")
+        )
+    return counts
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -183,7 +199,11 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    channels = load_single_consumer_channels(args.channels_file)
+    try:
+        channels = load_single_consumer_channels(args.channels_file)
+    except RuntimeError as exc:
+        print(f"single_consumer gate: infra error (not a violation): {exc}", file=sys.stderr)
+        return 2
     if not channels:
         print(
             "single_consumer gate: no channels marked single_consumer: true in "
@@ -198,20 +218,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"single_consumer gate: infra error (not a violation): {exc}", file=sys.stderr)
         return 2
 
-    # Channels redis-cli did not echo back are reported as 0 rather than dropped.
-    for ch in channels:
-        counts.setdefault(ch, 0)
-
-    violations, warnings = evaluate_counts(counts, strict_zero=args.strict_zero)
+    violations, warnings, statuses = evaluate_counts(counts, strict_zero=args.strict_zero)
     for ch in sorted(counts):
-        count = counts[ch]
-        if count > 1 or (count == 0 and args.strict_zero):
-            status = "FAIL"
-        elif count == 0:
-            status = "WARN"
-        else:
-            status = "OK"
-        print(f"{status} {count} {ch}")
+        print(f"{statuses[ch]} {counts[ch]} {ch}")
 
     if violations:
         print(

--- a/scripts/check_single_consumer_channels.py
+++ b/scripts/check_single_consumer_channels.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Deterministic gate: single-consumer channels must have exactly one subscriber.
+
+The Orion bus is Redis pub/sub, so every subscriber executes every message.
+Any channel with execute-once semantics (RPC request / work dispatch) therefore
+must have exactly one live subscriber. Two subscribers means duplicated
+execution -- the exact failure mode behind the duplicate-LLM-execution bug
+fixed in PR #994, where two containers both subscribed to orion:verb:request.
+
+This gate reads every channel marked `single_consumer: true` in
+orion/bus/channels.yaml, asks the live bus for subscriber counts via
+`redis-cli PUBSUB NUMSUB`, and fails if any such channel has more than one
+subscriber. Zero subscribers is a warning by default (consumer down is a
+liveness problem, not a duplication problem) unless --strict-zero is passed.
+
+Infra problems (redis-cli missing, connection refused, no bus URL) exit 2 --
+an unreachable bus is not evidence of a violation.
+
+Usage:
+    ORION_BUS_URL=redis://<tailscale-ip>:6379/0 python scripts/check_single_consumer_channels.py
+    python scripts/check_single_consumer_channels.py --bus-url redis://<host>:6379/0
+    python scripts/check_single_consumer_channels.py --strict-zero
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/check_single_consumer_channels.py` puts scripts/
+# on sys.path[0], which shadows stdlib `platform` via scripts/platform/ (same
+# issue documented in scripts/check_inner_state_registry.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_CHANNELS_FILE = REPO_ROOT / "orion" / "bus" / "channels.yaml"
+
+_GLOB_CHARS = ("*", "?", "[")
+
+
+def load_single_consumer_channels(channels_file: Path = DEFAULT_CHANNELS_FILE) -> list[str]:
+    """All catalog channel names marked single_consumer: true, glob names skipped.
+
+    Glob-shaped names (e.g. reply patterns like `orion:llm:reply*`) cannot be a
+    single concrete pub/sub channel, so a subscriber count is meaningless.
+    """
+    entries: list[dict] | None = None
+    if channels_file == DEFAULT_CHANNELS_FILE:
+        # Prefer the shared catalog loader so this gate reads the catalog the
+        # same way scripts/platform/audit_channels.py does.
+        try:
+            from scripts.platform._common import load_channels_catalog
+
+            entries = list(load_channels_catalog(REPO_ROOT).values())
+        except Exception:
+            entries = None  # fall through to plain yaml
+    if entries is None:
+        import yaml
+
+        data = yaml.safe_load(channels_file.read_text(encoding="utf-8")) or {}
+        entries = [e for e in (data.get("channels") or []) if isinstance(e, dict)]
+
+    names: list[str] = []
+    for entry in entries:
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        if entry.get("single_consumer") is not True:
+            continue
+        if any(ch in name for ch in _GLOB_CHARS):
+            continue
+        names.append(name)
+    return names
+
+
+def parse_numsub_output(stdout: str) -> dict[str, int]:
+    """Parse `redis-cli PUBSUB NUMSUB ch1 ch2 ...` output.
+
+    redis-cli prints alternating lines: channel name, subscriber count.
+    Parses defensively -- non-integer count lines are skipped rather than
+    crashing, so one weird line cannot take down the whole gate run.
+    """
+    lines = [ln.strip() for ln in stdout.splitlines() if ln.strip()]
+    counts: dict[str, int] = {}
+    for i in range(0, len(lines) - 1, 2):
+        channel, raw_count = lines[i], lines[i + 1]
+        # Some redis-cli versions prefix list output with "N) ".
+        if ") " in channel:
+            channel = channel.split(") ", 1)[1].strip()
+        if ") " in raw_count:
+            raw_count = raw_count.split(") ", 1)[1].strip()
+        channel = channel.strip('"')
+        # "(integer) 2" form appears in non-raw interactive output.
+        if raw_count.startswith("(integer)"):
+            raw_count = raw_count[len("(integer)"):].strip()
+        try:
+            counts[channel] = int(raw_count)
+        except ValueError:
+            continue
+    return counts
+
+
+def evaluate_counts(
+    counts: dict[str, int], *, strict_zero: bool = False
+) -> tuple[list[str], list[str]]:
+    """Pure decision core: (violations, warnings) from channel -> subscriber count.
+
+    count > 1  -> violation (duplicate execution: the PR #994 class of bug)
+    count == 0 -> warning (consumer down = liveness issue, not duplication),
+                  promoted to violation under strict_zero.
+    """
+    violations: list[str] = []
+    warnings: list[str] = []
+    for channel in sorted(counts):
+        count = counts[channel]
+        if count > 1:
+            violations.append(
+                f"{channel} has {count} subscribers, expected exactly 1 "
+                f"(duplicate execution risk)"
+            )
+        elif count == 0:
+            msg = f"{channel} has 0 subscribers, expected exactly 1 (consumer down?)"
+            if strict_zero:
+                violations.append(msg)
+            else:
+                warnings.append(msg)
+    return violations, warnings
+
+
+def fetch_live_counts(bus_url: str, channels: list[str]) -> dict[str, int]:
+    """Query live subscriber counts via redis-cli. Raises RuntimeError on infra failure."""
+    cmd = ["redis-cli", "-u", bus_url, "PUBSUB", "NUMSUB", *channels]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except FileNotFoundError:
+        raise RuntimeError("redis-cli not found on PATH; install redis-tools")
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"redis-cli timed out after 15s connecting to {bus_url}")
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise RuntimeError(f"redis-cli failed (exit {proc.returncode}): {detail}")
+    # redis-cli sometimes exits 0 but prints the error to stdout/stderr.
+    combined = (proc.stdout + proc.stderr).lower()
+    if "could not connect" in combined or "connection refused" in combined:
+        raise RuntimeError(f"redis-cli could not connect: {(proc.stderr or proc.stdout).strip()}")
+    return parse_numsub_output(proc.stdout)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--bus-url",
+        default=os.environ.get("ORION_BUS_URL") or None,
+        help="Redis bus URL (default: ORION_BUS_URL env var)",
+    )
+    parser.add_argument(
+        "--strict-zero",
+        action="store_true",
+        help="treat 0 subscribers as a violation instead of a warning",
+    )
+    parser.add_argument(
+        "--channels-file",
+        type=Path,
+        default=DEFAULT_CHANNELS_FILE,
+        help="override for testing against a fixture channels.yaml",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.bus_url:
+        print(
+            "single_consumer gate: no bus URL. "
+            "set ORION_BUS_URL=redis://<tailscale-ip>:6379/0 or pass --bus-url",
+            file=sys.stderr,
+        )
+        return 2
+
+    channels = load_single_consumer_channels(args.channels_file)
+    if not channels:
+        print(
+            "single_consumer gate: no channels marked single_consumer: true in "
+            f"{args.channels_file} -- catalog annotation missing?",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        counts = fetch_live_counts(args.bus_url, channels)
+    except RuntimeError as exc:
+        print(f"single_consumer gate: infra error (not a violation): {exc}", file=sys.stderr)
+        return 2
+
+    # Channels redis-cli did not echo back are reported as 0 rather than dropped.
+    for ch in channels:
+        counts.setdefault(ch, 0)
+
+    violations, warnings = evaluate_counts(counts, strict_zero=args.strict_zero)
+    for ch in sorted(counts):
+        count = counts[ch]
+        if count > 1 or (count == 0 and args.strict_zero):
+            status = "FAIL"
+        elif count == 0:
+            status = "WARN"
+        else:
+            status = "OK"
+        print(f"{status} {count} {ch}")
+
+    if violations:
+        print(
+            f"single_consumer gate FAILED: {len(violations)} violation(s), "
+            f"{len(warnings)} warning(s) across {len(counts)} channel(s)",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+
+    print(
+        f"single_consumer gate OK: {len(counts)} channel(s) checked, "
+        f"{len(warnings)} warning(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-equilibrium-service/.env_example
+++ b/services/orion-equilibrium-service/.env_example
@@ -49,8 +49,7 @@ EQUILIBRIUM_WINDOWS_SEC=[60,300,3600]
 EQUILIBRIUM_STATE_KEY=equilibrium:state
 EQUILIBRIUM_STATE_RETENTION_SEC=3600
 
-# Metacognition / collapse channels (settings defaults; override when wiring orch/collapse)
-CHANNEL_CORTEX_ORCH_REQUEST=orion:verb:request
+# Metacognition / collapse channels (settings defaults; override when wiring collapse)
 CHANNEL_COLLAPSE_MIRROR_USER_EVENT=orion:collapse:intake
 CHANNEL_PAD_SIGNAL=orion:pad:signal
 EQUILIBRIUM_METACOG_RECALL_ENABLED=false

--- a/services/orion-equilibrium-service/app/settings.py
+++ b/services/orion-equilibrium-service/app/settings.py
@@ -78,7 +78,6 @@ class Settings(BaseSettings):
     )
 
     channel_metacog_trigger: str = Field("orion:equilibrium:metacog:trigger", alias="CHANNEL_EQUILIBRIUM_METACOG_TRIGGER")
-    channel_cortex_orch_request: str = Field("orion:verb:request", alias="CHANNEL_CORTEX_ORCH_REQUEST")
     channel_collapse_mirror_user_event: str = Field("orion:collapse:intake", alias="CHANNEL_COLLAPSE_MIRROR_USER_EVENT")
     channel_pad_signal: str = Field("orion:pad:signal", alias="CHANNEL_PAD_SIGNAL")
 

--- a/tests/test_single_consumer_channels_gate.py
+++ b/tests/test_single_consumer_channels_gate.py
@@ -28,41 +28,46 @@ CORTEX_EXEC_LANES = (
 def test_evaluate_counts_all_ones_is_clean() -> None:
     counts = {"orion:verb:request": 1, "orion:cortex:exec:request": 1}
 
-    violations, warnings = gate.evaluate_counts(counts)
+    violations, warnings, statuses = gate.evaluate_counts(counts)
 
     assert violations == []
     assert warnings == []
+    assert set(statuses.values()) == {"OK"}
 
 
 def test_evaluate_counts_two_subscribers_is_a_violation_naming_the_channel() -> None:
     counts = {"orion:verb:request": 2, "orion:cortex:exec:request": 1}
 
-    violations, warnings = gate.evaluate_counts(counts)
+    violations, warnings, statuses = gate.evaluate_counts(counts)
 
     assert len(violations) == 1
     assert "orion:verb:request" in violations[0]
     assert "2 subscribers" in violations[0]
     assert warnings == []
+    assert statuses["orion:verb:request"] == "FAIL"
+    assert statuses["orion:cortex:exec:request"] == "OK"
 
 
 def test_evaluate_counts_zero_is_a_warning_by_default() -> None:
     counts = {"orion:dream:trigger": 0}
 
-    violations, warnings = gate.evaluate_counts(counts)
+    violations, warnings, statuses = gate.evaluate_counts(counts)
 
     assert violations == []
     assert len(warnings) == 1
     assert "orion:dream:trigger" in warnings[0]
+    assert statuses["orion:dream:trigger"] == "WARN"
 
 
 def test_evaluate_counts_zero_is_a_violation_under_strict_zero() -> None:
     counts = {"orion:dream:trigger": 0}
 
-    violations, warnings = gate.evaluate_counts(counts, strict_zero=True)
+    violations, warnings, statuses = gate.evaluate_counts(counts, strict_zero=True)
 
     assert len(violations) == 1
     assert "orion:dream:trigger" in violations[0]
     assert warnings == []
+    assert statuses["orion:dream:trigger"] == "FAIL"
 
 
 # --- catalog wiring: the real channels.yaml carries the annotations ----------
@@ -157,22 +162,6 @@ def test_parse_numsub_output_plain_raw_form() -> None:
     }
 
 
-def test_parse_numsub_output_numbered_interactive_form() -> None:
-    stdout = (
-        '1) "orion:verb:request"\n'
-        "2) (integer) 1\n"
-        '3) "orion:cortex:exec:request"\n'
-        "4) (integer) 3\n"
-    )
-
-    counts = gate.parse_numsub_output(stdout)
-
-    assert counts == {
-        "orion:verb:request": 1,
-        "orion:cortex:exec:request": 3,
-    }
-
-
 def test_parse_numsub_output_empty_and_garbage_are_safe() -> None:
     assert gate.parse_numsub_output("") == {}
     assert gate.parse_numsub_output("\n\n") == {}
@@ -230,3 +219,89 @@ def test_main_all_single_subscribers_exits_zero(monkeypatch, capsys) -> None:
 
     assert rc == 0
     assert "gate OK" in capsys.readouterr().out
+
+
+# --- fetch_live_counts fail-closed behavior ------------------------------------
+# redis-cli exits 0 on Redis error replies (NOAUTH, ERR, LOADING, ...) with the
+# error text on stdout. If the gate parsed that as "no counts", every channel
+# would degrade to a benign 0-subscriber warning and the gate would pass while
+# checking nothing. These tests pin the fail-closed contract: a reply that is
+# not a NUMSUB reply is an infra error (RuntimeError -> exit 2), never count 0.
+
+
+class _FakeProc:
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_fetch_live_counts_error_reply_raises_not_zero_counts(monkeypatch) -> None:
+    import pytest
+
+    monkeypatch.setattr(
+        gate.subprocess,
+        "run",
+        lambda *a, **kw: _FakeProc(stdout="NOAUTH Authentication required.\n"),
+    )
+
+    with pytest.raises(RuntimeError, match="NOAUTH"):
+        gate.fetch_live_counts("redis://fake:6379/0", ["orion:verb:request"])
+
+
+def test_fetch_live_counts_missing_channel_in_reply_raises(monkeypatch) -> None:
+    import pytest
+
+    # One stray noise line shifts every channel/count pair; a channel with 2
+    # subscribers must surface as an infra error, never as "0 subscribers".
+    noisy = "Warning: banner line\norion:verb:request\n2\n"
+    monkeypatch.setattr(gate.subprocess, "run", lambda *a, **kw: _FakeProc(stdout=noisy))
+
+    with pytest.raises(RuntimeError, match="absent from NUMSUB reply"):
+        gate.fetch_live_counts("redis://fake:6379/0", ["orion:verb:request"])
+
+
+def test_fetch_live_counts_clean_reply_returns_all_channels(monkeypatch) -> None:
+    stdout = "orion:verb:request\n1\norion:dream:trigger\n0\n"
+    monkeypatch.setattr(gate.subprocess, "run", lambda *a, **kw: _FakeProc(stdout=stdout))
+
+    counts = gate.fetch_live_counts(
+        "redis://fake:6379/0", ["orion:verb:request", "orion:dream:trigger"]
+    )
+
+    assert counts == {"orion:verb:request": 1, "orion:dream:trigger": 0}
+
+
+# --- catalog enforcement: annotation cannot silently drift ---------------------
+
+
+def test_every_request_kind_single_consumer_channel_is_annotated() -> None:
+    """Deterministic guard against annotation drift.
+
+    Any catalog entry with kind: request, a concrete (non-glob) name, and
+    exactly one consumer service has execute-once semantics and MUST carry
+    single_consumer: true. A new request channel added without the annotation
+    fails here instead of silently escaping the live gate's coverage.
+    Intentional exceptions go in EXEMPT with a reason.
+    """
+    EXEMPT: set[str] = set()
+
+    import yaml
+
+    data = yaml.safe_load((REPO / "orion" / "bus" / "channels.yaml").read_text())
+    unannotated = []
+    for entry in data["channels"]:
+        name = entry.get("name", "")
+        if (
+            entry.get("kind") == "request"
+            and not any(c in name for c in "*?[")
+            and isinstance(entry.get("consumer_services"), list)
+            and len(entry["consumer_services"]) == 1
+            and entry.get("single_consumer") is not True
+            and name not in EXEMPT
+        ):
+            unannotated.append(name)
+
+    assert unannotated == [], (
+        f"request channels with one consumer missing single_consumer: true: {unannotated}"
+    )

--- a/tests/test_single_consumer_channels_gate.py
+++ b/tests/test_single_consumer_channels_gate.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+SCRIPTS = REPO / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import check_single_consumer_channels as gate
+
+# The four cortex-exec request lane channels (the seam behind the PR #994
+# duplicate-execution bug this gate exists to prevent).
+CORTEX_EXEC_LANES = (
+    "orion:cortex:exec:request",
+    "orion:cortex:exec:request:chat",
+    "orion:cortex:exec:request:spark",
+    "orion:cortex:exec:request:background",
+)
+
+
+# --- evaluate_counts: the pure decision core, no Redis, no I/O ---------------
+
+
+def test_evaluate_counts_all_ones_is_clean() -> None:
+    counts = {"orion:verb:request": 1, "orion:cortex:exec:request": 1}
+
+    violations, warnings = gate.evaluate_counts(counts)
+
+    assert violations == []
+    assert warnings == []
+
+
+def test_evaluate_counts_two_subscribers_is_a_violation_naming_the_channel() -> None:
+    counts = {"orion:verb:request": 2, "orion:cortex:exec:request": 1}
+
+    violations, warnings = gate.evaluate_counts(counts)
+
+    assert len(violations) == 1
+    assert "orion:verb:request" in violations[0]
+    assert "2 subscribers" in violations[0]
+    assert warnings == []
+
+
+def test_evaluate_counts_zero_is_a_warning_by_default() -> None:
+    counts = {"orion:dream:trigger": 0}
+
+    violations, warnings = gate.evaluate_counts(counts)
+
+    assert violations == []
+    assert len(warnings) == 1
+    assert "orion:dream:trigger" in warnings[0]
+
+
+def test_evaluate_counts_zero_is_a_violation_under_strict_zero() -> None:
+    counts = {"orion:dream:trigger": 0}
+
+    violations, warnings = gate.evaluate_counts(counts, strict_zero=True)
+
+    assert len(violations) == 1
+    assert "orion:dream:trigger" in violations[0]
+    assert warnings == []
+
+
+# --- catalog wiring: the real channels.yaml carries the annotations ----------
+
+
+def test_verb_request_is_marked_single_consumer() -> None:
+    channels = gate.load_single_consumer_channels()
+
+    assert "orion:verb:request" in channels
+
+
+def test_all_four_cortex_exec_request_lanes_are_marked() -> None:
+    channels = set(gate.load_single_consumer_channels())
+
+    missing = [ch for ch in CORTEX_EXEC_LANES if ch not in channels]
+    assert missing == []
+
+
+def test_no_single_consumer_channel_contains_a_glob_char() -> None:
+    channels = gate.load_single_consumer_channels()
+
+    globby = [ch for ch in channels if any(c in ch for c in "*?[")]
+    assert globby == []
+
+
+def test_collapse_mirror_service_entry_exists_and_is_marked() -> None:
+    # Regression for the catalog gap: orion-collapse-mirror registers a Rabbit
+    # RPC on this channel (services/orion-collapse-mirror/app/bus_runtime.py)
+    # but the channel was missing from orion/bus/channels.yaml entirely.
+    channels = gate.load_single_consumer_channels()
+
+    assert "orion:exec:request:CollapseMirrorService" in channels
+
+
+def test_fixture_catalog_glob_names_are_skipped(tmp_path) -> None:
+    fixture = tmp_path / "channels.yaml"
+    fixture.write_text(
+        """
+channels:
+  - name: "orion:test:reply*"
+    kind: "result"
+    schema_id: "GenericPayloadV1"
+    producer_services: ["orion-test"]
+    consumer_services: ["orion-test"]
+    single_consumer: true
+    stability: "experimental"
+    since: "2026-07-13"
+
+  - name: "orion:test:request"
+    kind: "request"
+    schema_id: "GenericPayloadV1"
+    producer_services: ["orion-test"]
+    consumer_services: ["orion-test"]
+    single_consumer: true
+    stability: "experimental"
+    since: "2026-07-13"
+
+  - name: "orion:test:unmarked"
+    kind: "request"
+    schema_id: "GenericPayloadV1"
+    producer_services: ["orion-test"]
+    consumer_services: ["orion-test"]
+    stability: "experimental"
+    since: "2026-07-13"
+"""
+    )
+
+    channels = gate.load_single_consumer_channels(fixture)
+
+    assert channels == ["orion:test:request"]
+
+
+# --- redis-cli NUMSUB output parsing ------------------------------------------
+
+
+def test_parse_numsub_output_plain_raw_form() -> None:
+    stdout = (
+        "orion:verb:request\n"
+        "1\n"
+        "orion:cortex:exec:request\n"
+        "2\n"
+        "orion:dream:trigger\n"
+        "0\n"
+    )
+
+    counts = gate.parse_numsub_output(stdout)
+
+    assert counts == {
+        "orion:verb:request": 1,
+        "orion:cortex:exec:request": 2,
+        "orion:dream:trigger": 0,
+    }
+
+
+def test_parse_numsub_output_numbered_interactive_form() -> None:
+    stdout = (
+        '1) "orion:verb:request"\n'
+        "2) (integer) 1\n"
+        '3) "orion:cortex:exec:request"\n'
+        "4) (integer) 3\n"
+    )
+
+    counts = gate.parse_numsub_output(stdout)
+
+    assert counts == {
+        "orion:verb:request": 1,
+        "orion:cortex:exec:request": 3,
+    }
+
+
+def test_parse_numsub_output_empty_and_garbage_are_safe() -> None:
+    assert gate.parse_numsub_output("") == {}
+    assert gate.parse_numsub_output("\n\n") == {}
+    # A dangling channel line with no count line is dropped, not crashed on.
+    assert gate.parse_numsub_output("orion:verb:request\n") == {}
+
+
+# --- main() infra-error paths: exit 2, never a false violation ----------------
+
+
+def test_main_without_bus_url_exits_two(monkeypatch, capsys) -> None:
+    monkeypatch.delenv("ORION_BUS_URL", raising=False)
+
+    rc = gate.main(["--bus-url", ""])
+
+    assert rc == 2
+    assert "ORION_BUS_URL" in capsys.readouterr().err
+
+
+def test_main_infra_failure_exits_two_not_one(monkeypatch, capsys) -> None:
+    def boom(bus_url, channels):
+        raise RuntimeError("Could not connect to Redis at nope:6379")
+
+    monkeypatch.setattr(gate, "fetch_live_counts", boom)
+
+    rc = gate.main(["--bus-url", "redis://nope:6379/0"])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "infra error" in err
+    assert "Could not connect" in err
+
+
+def test_main_duplicate_subscriber_exits_one(monkeypatch, capsys) -> None:
+    def fake_counts(bus_url, channels):
+        return {ch: 1 for ch in channels} | {"orion:verb:request": 2}
+
+    monkeypatch.setattr(gate, "fetch_live_counts", fake_counts)
+
+    rc = gate.main(["--bus-url", "redis://fake:6379/0"])
+
+    assert rc == 1
+    out, err = capsys.readouterr()
+    assert "FAIL 2 orion:verb:request" in out
+    assert "gate FAILED" in err
+
+
+def test_main_all_single_subscribers_exits_zero(monkeypatch, capsys) -> None:
+    def fake_counts(bus_url, channels):
+        return {ch: 1 for ch in channels}
+
+    monkeypatch.setattr(gate, "fetch_live_counts", fake_counts)
+
+    rc = gate.main(["--bus-url", "redis://fake:6379/0"])
+
+    assert rc == 0
+    assert "gate OK" in capsys.readouterr().out


### PR DESCRIPTION
# PR report — single-consumer channel gate + dead equilibrium config removal

Date: 2026-07-13
Branch: `feat/single-consumer-channel-gate`

## Summary

- New deterministic live-bus gate: every channel marked `single_consumer: true` in `orion/bus/channels.yaml` must have exactly one live subscriber, or the gate fails. This turns the PR #994 class of bug (two containers both subscribed to `orion:verb:request`, every LLM call executed twice) into a failing check instead of a live incident.
- 31 request/dispatch channels annotated `single_consumer: true`, including one channel that was live on the bus but missing from the catalog entirely (`orion:exec:request:CollapseMirrorService`).
- A catalog test enforces the annotation going forward: any `kind: request` entry with one consumer and a concrete name must be annotated (empty exemption list), so new request channels cannot drift out of coverage.
- Code review found the first cut of the gate failed open (redis-cli error replies and parse drift degraded to benign 0-subscriber warnings); fixed fail-closed at the fetch seam.
- Removed the dead `channel_cortex_orch_request` / `CHANNEL_CORTEX_ORCH_REQUEST` config key from orion-equilibrium-service — defined since inception, never read by any code, and misleadingly implied equilibrium touches `orion:verb:request`.

## Outcome moved

The duplicate-LLM-execution failure mode is now regression-gated. Before: a second subscriber on any execute-once channel was invisible until someone traced duplicate `request_id`s in production (as happened in PR #994). After: `make check-single-consumer-channels` fails with the exact channel and count. First live run verified the whole mesh clean: 31 channels, 28 at exactly 1 subscriber, 3 warnings for idle services, 0 violations.

## Current architecture

The bus is Redis pub/sub — every subscriber executes every message; there are no competing-consumer queues. Execute-once semantics (RPC request channels served by `Rabbit`, dispatch channels consumed by a single `Hunter`) are purely conventional: nothing declared which channels carry those semantics and nothing checked subscriber counts. The catalog (`orion/bus/channels.yaml`) documented producers/consumers but had no single-consumer concept, and one live RPC channel was missing from it. `scripts/platform/audit_channels.py` exists but is static analysis only — it never touches the live bus.

## Architecture touched

- Contract: `orion/bus/channels.yaml` (new `single_consumer: true` field, 31 entries + 1 new entry)
- Gate: `scripts/check_single_consumer_channels.py` (new), `Makefile` target `check-single-consumer-channels`
- Tests: `tests/test_single_consumer_channels_gate.py` (new, 19 tests)
- Service config hygiene: `services/orion-equilibrium-service` (dead key removed)

## Files changed

- `orion/bus/channels.yaml`: 31 channels annotated `single_consumer: true`; added missing `orion:exec:request:CollapseMirrorService` entry (producer orion-cortex-exec, consumer orion-collapse-mirror, mirrors the MetaTagsService entry convention).
- `scripts/check_single_consumer_channels.py`: new gate. Reads the catalog (plain `yaml.safe_load`; missing PyYAML is a loud exit 2), queries live counts via `redis-cli PUBSUB NUMSUB` subprocess (no new Python dependency), fails on >1 subscriber, warns on 0 (`--strict-zero` promotes to failure). Fail-closed: Redis error replies (NOAUTH/ERR/LOADING/…) and any requested channel absent from the parsed reply are infra errors (exit 2) — never counted as 0. Exit codes: 0 clean, 1 violation, 2 infra.
- `tests/test_single_consumer_channels_gate.py`: pure decision core, NUMSUB parsing, fail-closed contract, main() exit paths, catalog wiring, and the annotation-coverage enforcement test. No live bus needed.
- `Makefile`: `check-single-consumer-channels` target beside `check-inner-state-registry`.
- `scripts/README.md`: gate documented (what it guards, how to run, expected output).
- `services/orion-equilibrium-service/app/settings.py`: removed dead `channel_cortex_orch_request` field.
- `services/orion-equilibrium-service/.env_example`: removed `CHANNEL_CORTEX_ORCH_REQUEST` line; comment trimmed accordingly.
- `docs/platform_routing_wiring_map.md`: bullet that flagged the key as drift-prone now records its removal.

## Schema / bus / API changes

- Added: `single_consumer: true` catalog field (documentation + gate input; no runtime payload change). New catalog entry `orion:exec:request:CollapseMirrorService` (channel already live; `GenericPayloadV1`, already registered in `orion/schemas/registry.py`).
- Removed: none at runtime.
- Renamed: none.
- Behavior changed: none at runtime — the gate is read-only against the bus (`PUBSUB NUMSUB` only).
- Compatibility notes: unknown catalog fields are ignored by existing consumers of channels.yaml (verified `scripts/platform/_common.load_channels_catalog` and audit scripts tolerate it; `tests/test_inner_state_registry_gate.py` still passes).

## Env/config changes

- Added keys: none.
- Removed keys: `CHANNEL_CORTEX_ORCH_REQUEST` (orion-equilibrium-service; dead, never read).
- Renamed keys: none.
- `.env_example` updated: yes (`services/orion-equilibrium-service/.env_example`).
- local `.env` synced: yes — targeted removal of the dead line from `services/orion-equilibrium-service/.env` (deliberately not via `sync_local_env_from_example.py`, which is additive-oriented and has previously reverted intentional live overrides; a one-key deletion is safer done surgically). Verified 0 matches remain.
- skipped keys requiring operator action: none.

## Tests run

```text
orion_dev/bin/python -m pytest tests/test_single_consumer_channels_gate.py \
  tests/test_inner_state_registry_gate.py \
  services/orion-equilibrium-service/tests -q
34 passed, 6 warnings in 5.68s
  (19 gate tests + 8 inner-state gate regression + 7 equilibrium)
```

## Evals run

```text
No eval harness applies: the gate is fully deterministic (catalog parse +
subscriber-count arithmetic); there is no model-quality surface to eval.
The live smoke below is the behavioral proof.
```

## Docker/build/smoke checks

```text
ORION_BUS_URL=redis://100.92.216.81:6379/0 python3 scripts/check_single_consumer_channels.py
→ 31 channels checked: 28 OK at exactly 1 subscriber; WARN 0 for
  orion:conversation:request, orion:exec:request:ContextExecService,
  orion:exec:request:CouncilService (services idle/down — liveness, not
  duplication); 0 violations; exit 0.

No Docker changes: no service runtime code touched (equilibrium change is a
dead-field deletion; settings use extra="ignore" so stale env values are
harmless).
```

## Review findings fixed

- Finding: gate failed open — redis-cli exits 0 on Redis error replies (NOAUTH/WRONGPASS/ERR/LOADING) with the error on stdout; the parse yielded `{}`, every channel was backfilled to 0, and the gate printed all-WARN and exited 0 while checking nothing (empirically confirmed by reviewer on redis-cli 7.0.15).
  - Fix: error-reply first lines raise; any requested channel absent from the parsed reply raises (NUMSUB always echoes every requested channel, so absence proves a non-NUMSUB reply). Both exit 2.
  - Evidence: `test_fetch_live_counts_error_reply_raises_not_zero_counts`, `test_fetch_live_counts_missing_channel_in_reply_raises`.
- Finding: one stray stdout line shifted the fixed-offset pair parsing, converting a real 2-subscriber violation into a benign 0-subscriber warning (confirmed by reviewer simulation).
  - Fix: same seam — the missing-channel check makes any parse drift an infra error; the `setdefault(ch, 0)` backfill was removed.
  - Evidence: the noisy-banner test above feeds exactly that scenario.
- Finding: 11 structurally identical request channels left unannotated, and nothing enforced the annotation for future channels.
  - Fix: annotated all 11 (verified each: `kind: request`, exactly one consumer, concrete name); added `test_every_request_kind_single_consumer_channel_is_annotated` with an empty exemption list.
  - Evidence: live run now covers 31 channels; enforcement test passes with zero exemptions.
- Finding (nit): `main()` re-derived FAIL/WARN/OK by hand, so printed status and exit code could drift.
  - Fix: `evaluate_counts` returns per-channel statuses; both derive from the one function.
- Finding (nit): shared catalog loader's regex fallback silently drops `single_consumer` when PyYAML is absent, producing a misleading "annotation missing?" diagnostic.
  - Fix: plain `yaml.safe_load` only; missing PyYAML is a clear exit-2 infra error.
- Finding (nit): TTY-only redis-cli output-format parsing branches were unreachable under `capture_output=True`.
  - Fix: removed, with their test.
- Finding (nit, not fixed here): the `scripts/platform/` stdlib-shadow `sys.path.pop` workaround is hand-copied across ~12 scripts, this one included. Repo-wide cleanup (rename `scripts/platform/` or a shared helper) is a separate chore — out of scope for this patch.

## Restart required

```text
No restart required. The gate is a repo script; no running service reads the
removed equilibrium key (never read by code) or the new catalog field. The
equilibrium container will simply boot without the dead field on its next
scheduled rebuild — no action needed now.
```

## Risks / concerns

- Severity: low
  - Concern: `single_consumer: true` semantics could drift if a channel legitimately gains a second, role-distinct consumer (fan-out by design).
  - Mitigation: that change must flip the annotation in the same patch — the gate failing is exactly the review conversation we want; the enforcement test's exemption list is the documented escape hatch.
- Severity: low
  - Concern: the 3 WARN-at-0 channels (conversation, context-exec, council) will keep warning while those services stay idle; warning fatigue could hide a real new WARN.
  - Mitigation: `--strict-zero` exists for a full-mesh-up check; warnings are listed per channel so new ones are visible in diffs of gate output.
- Severity: low
  - Concern: gate requires `redis-cli` on the runner.
  - Mitigation: missing binary is a loud exit-2 with an install hint; no silent pass.