### PR TITLE
fix(memory-consolidation): install chromadb so contradiction detectio…

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-concept-relation-resolution-missing-chromadb-dep-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-concept-relation-resolution-missing-chromadb-dep-pr.md
@@ -1,0 +1,110 @@
+# PR report: fix concept-relation resolution (contradiction detection) — missing chromadb dependency + build toolchain
+
+## Summary
+
+- `orion-memory-consolidation`'s contradiction/refines/same-belief detection (`maybe_resolve_concept_relation()`) has never worked on this host — zero `contradicts`/`supersedes` links exist anywhere in `memory_crystallization_links`, despite `CONCEPT_RELATION_RESOLUTION_ENABLED=true`.
+- Root-caused by directly invoking the real production function against real infrastructure (not by reading code) and watching it fail, twice, for two independent reasons.
+- **Bug A (config, already self-corrected, not part of this commit):** `CRYSTALLIZER_EMBED_HOST_URL`/`CHROMA_HOST` in `services/orion-memory-consolidation/.env` had been reset to empty by the pre-fix `sync_local_env_from_example.py` overwrite bug (PR #996) earlier this session. Restored live.
+- **Bug B/C (code, this commit):** `chromadb` was never in `requirements.txt`, and the Dockerfile had no C compiler toolchain to build its native `chroma-hnswlib` dependency even if it were added. Both fixed, matching the exact pattern already used by `orion-dream`/`orion-rag`/`orion-vector-writer`.
+- Live-verified end to end: real Chroma search + real embed host + real LLM gateway classification produced a genuine `contradicts` link with confidence 0.95, confirmed by direct Postgres query.
+
+## Outcome moved
+
+Contradiction detection goes from "flag flipped on, silently a no-op since inception" to "verified working against real infrastructure." This was previously misdiagnosed (by me, in an earlier pass this same session) as "not proven broken, insufficient evidence" — that conclusion was wrong because I hadn't yet actually run the function against live data; I only checked whether it was *called*, not whether its own dependencies were satisfiable.
+
+## Current architecture (before this patch)
+
+`maybe_resolve_concept_relation()` (`orion/memory/crystallization/concept_relation.py`) is called from `intake_pipeline.py` on real consolidation-gate ingestion. It calls `fetch_similar_candidates()` (`candidate_retrieval.py`) for vector-similarity candidates before ever attempting an LLM classification. `fetch_similar_candidates()` requires both `CRYSTALLIZER_EMBED_HOST_URL` and `CHROMA_HOST` non-empty, and requires the `chromadb` Python package importable — both were broken independently.
+
+## Architecture touched
+
+Single service, `orion-memory-consolidation` — Dockerfile and requirements.txt only. No schema, bus, or API contract changes. No change to `concept_relation.py`'s logic, thresholds, or LLM prompt.
+
+## Files changed
+
+- `services/orion-memory-consolidation/requirements.txt`: added `chromadb==0.4.24`, `numpy==1.26.4` (pinned to match the three sibling services that already depend on the same package — `numpy==1.26.4` specifically because `chromadb==0.4.24`'s transitive code path uses `np.float_`, removed in numpy 2.0).
+- `services/orion-memory-consolidation/Dockerfile`: added `apt-get install gcc g++ libpq-dev` before `pip install`, matching `orion-dream`'s Dockerfile — `chroma-hnswlib` (chromadb's transitive dependency) builds a native C extension and has no prebuilt wheel for this base image.
+- `docs/superpowers/specs/2026-07-13-recall-epistemic-honesty-and-observability-spec.md`: addendum documenting the corrected finding (this spec originally concluded item 2 was "not confirmed broken" — that was wrong, corrected here with the real root cause and live verification).
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+- Added keys: none (no `.env_example` shape change — `CRYSTALLIZER_EMBED_HOST_URL`/`CHROMA_HOST`/`CONCEPT_RELATION_RESOLUTION_ENABLED` already existed).
+- This host's live `.env` values (`CRYSTALLIZER_EMBED_HOST_URL=http://orion-athena-vector-host:8320/embedding`, `CHROMA_HOST=orion-athena-vector-db`) were restored as part of diagnosing this — gitignored, not part of this commit, already applied live and confirmed working in the verification below.
+- `.env_example` intentionally still ships these two keys empty (existing comment: "even if `CONCEPT_RELATION_RESOLUTION_ENABLED` is flipped true without also configuring these, the feature degrades to a no-op") — that's the correct safe default for fresh deployments and is unchanged by this patch. Any deployment that flips `CONCEPT_RELATION_RESOLUTION_ENABLED=true` now also needs a working `chromadb` install (this patch) *and* real embed/chroma host values (operator's own `.env`, unchanged contract).
+
+## Tests run
+
+```text
+$ source venv/bin/activate && python -m pytest services/orion-memory-consolidation/tests -q
+71 passed, 14 warnings in 4.31s
+```
+No regression. No new unit test added for this fix — it's a dependency/build-toolchain fix, not a logic change; the meaningful verification is the live end-to-end run below, not a mock.
+
+## Evals run
+
+No eval harness exists for `orion-memory-consolidation`'s concept-relation resolution specifically. The live verification below is the closest equivalent and is the standard this fix is held to, matching how the duplicate-detection Jaccard bug was verified earlier this session (empirically, not by inspection).
+
+## Docker/build/smoke checks
+
+```text
+$ docker compose --env-file .env --env-file services/orion-memory-consolidation/.env \
+    -f services/orion-memory-consolidation/docker-compose.yml up -d --build
+Successfully installed ... chroma-hnswlib-0.7.3 chromadb-0.4.24 numpy-2.5.1 ...
+# (first build: numpy 2.5.1 pulled in transitively, chromadb import failed on np.float_ removal)
+
+$ docker exec orion-athena-memory-consolidation python -c "import chromadb"
+AttributeError: `np.float_` was removed in the NumPy 2.0 release.
+# fixed by pinning numpy==1.26.4 explicitly, rebuilt:
+
+$ docker exec orion-athena-memory-consolidation python -c "import chromadb; print(chromadb.__version__)"
+chromadb ok 0.4.24
+
+# Live end-to-end verification (real production function, real infra, not mocked):
+# 1. Proposed+approved seed belief via Hub: "deploy orion services at night, never during the day"
+# 2. Directly invoked process_consolidation_crystallization() inside the running container with a
+#    second crystallization asserting the opposite claim on the same subject.
+$ docker exec orion-athena-memory-consolidation python /tmp/test_contradiction_live.py
+RESULT: (..., MemoryCrystallizationV1(... links=[CrystallizationLinkV1(
+    target_crystallization_id='b65bc9ca-ca05-41fb-bab5-f4c1c2541267',
+    relation='contradicts', confidence=0.95, note='concept_relation_llm')], ...), 'proposed')
+
+# 3. Confirmed persisted (not just returned) via direct Postgres query:
+$ psql -c "select from_crystallization_id, to_crystallization_id, relation, confidence, note
+           from memory_crystallization_links where relation='contradicts';"
+ 429b4c0e-... | b65bc9ca-... | contradicts | 0.9499999999999999... | concept_relation_llm
+
+# 4. Test crystallizations cleaned up (deprecated/rejected) after verification, not left as
+#    permanent pollution:
+$ curl .../crystallizations/429b4c0e.../reject -> 200
+$ curl .../crystallizations/b65bc9ca.../deprecate -> 200
+```
+
+## Review findings fixed
+
+Self-caught, not from a separate review pass: my own first two live-test attempts each surfaced a genuine problem (the numpy incompatibility, and a same-window Jaccard collision with a leftover row from an earlier broken test-harness attempt where a shell-quoting bug had passed an empty subject) — both root-caused and fixed before concluding the underlying feature itself works. No material findings against the actual Dockerfile/requirements.txt diff, which is a two-line, low-risk, purely additive change mirroring an already-established pattern in three sibling services.
+
+## Restart required
+
+Already executed live during this session:
+
+```bash
+docker compose --env-file .env --env-file services/orion-memory-consolidation/.env \
+  -f services/orion-memory-consolidation/docker-compose.yml up -d --build
+```
+
+If merged and redeployed elsewhere: same command. `CONCEPT_RELATION_RESOLUTION_ENABLED` stays operator-controlled per `.env_example`'s existing default (`false`) — this patch only ensures the feature actually works on hosts that choose to enable it, it does not change the default.
+
+## Risks / concerns
+
+- Severity: Low — `chromadb==0.4.24`/`numpy==1.26.4` are the same versions already running in three other services on this host; no new version-compatibility surface introduced beyond what's already proven elsewhere.
+- Severity: Low — this session's earlier env-sync-script bug (now fixed, PR #996) is what caused bug A in the first place. No further action needed here; that fix is already merged.
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...fix/concept-relation-resolution-missing-chromadb-dep?expand=1`

--- a/docs/superpowers/specs/2026-07-13-memory-recall-reinforcement-decay-wiring-spec.md
+++ b/docs/superpowers/specs/2026-07-13-memory-recall-reinforcement-decay-wiring-spec.md
@@ -1,0 +1,99 @@
+# Wire recall reinforcement + decay (Phases 4+5 of the 2026-07-07 dynamics spec)
+
+**Date:** 2026-07-13
+**Status:** Proposed — supersedes/extends `2026-07-07-memory-weight-reinforcement-decay-design.md` Phases 4-5 with live-data findings
+**Scope:** Recall-time only. Phase 1 (schema), Phase 2 (reinforce-on-dedup) are already live. This spec covers Phase 5 (recall reinforces) and the recall-time half of Phase 4 (decay), and explicitly kills/defers three other candidate ideas that live-data checks disqualified.
+
+---
+
+## Arsonist summary
+
+The 2026-07-07 spec built the right skeleton — `CrystallizationDynamicsV1` (`activation`, `reinforcement_count`, `last_reinforced_at`, `last_recalled_at`, `decay_half_life_days`) and pure functions (`reinforce`, `recall_boost`, `decay`, `decayed_activation`, `should_retire`) in `orion/memory/crystallization/dynamics.py` — and wired half of it. `reinforce()` fires on formation-dedup (Phase 2, confirmed live: `intake_pipeline.py`, `concept_relation.py`, `governor.py`, `formation_executor.py` all call it). `recall_boost()` and `decay()` are written, tested in isolation, and **never called from anywhere in the live path**. Ranking (`active_packet.py:55`) reads the raw stored `.dynamics.activation` directly — not `decayed_activation()` — so decay has never been applied, not even implicitly at read time.
+
+This was flagged as a real risk, not a hypothetical one, by querying the live table before writing this spec:
+
+```
+dynamics.activation (100 active crystallizations): 55 at exactly 1.00 (ceiling), 37 at ~0.25, rest scattered
+dynamics.reinforcement_count: 100 at 0 — reinforce() has fired via Phase 2 dedup, but the count field itself shows every row untouched by any recall-time mechanism
+```
+
+55% already sitting at the activation ceiling with zero recall-time reinforcement ever applied is a live precursor to the exact saturation failure this codebase has already shipped once (homeostatic drives pinned flat at 0.731 because a leaky integrator's soft-saturate went stale — see `project_homeostatic_drives_real_tensions` history). Wiring `recall_boost()` without also wiring `decay()` in the same patch would only grow that ceiling-pinned fraction over time, flattening the one dynamics signal that currently has real variance. **They ship together or not at all.**
+
+Three other candidate ideas from this session's brainstorm were checked against live data and are explicitly out of scope here, not deferred-as-good-ideas:
+
+- **Confidence/dispute markup in rendered recall text** — killed. `confidence` is `"likely"` on all 100 active crystallizations (zero variance); `memory_crystallization_links` contains zero `contradicts`/`supersedes` relations (only `supports`, 16 of them). Rendering either field today would be decorative — a label with no measurable runtime behavior. Blocked until governance actually assigns varying confidence and contradiction-detection (exists in code, wired into `intake_pipeline.py`/`concept_relation.py`, has produced zero live contradictions) actually fires on real conflicting input.
+- **Retrieval co-occurrence → implicit graph links** — killed for now, not just risky. `services/orion-recall/` (the real chat-time recall path) writes zero retrieval-event history anywhere (confirmed by grep, no matches). The only writer, `insert_retrieval_event` in Hub's `crystallization_routes.py`, is called from a route real chat doesn't use. There is no real usage data to mine co-occurrence from yet, independent of the popularity-bias / feedback-loop concerns raised separately.
+- **Drive/goal-state-conditioned recall ranking** — deferred, not killed. This is a first-time coupling between the motivational/homeostatic subsystem and memory retrieval; per AGENTS.md's proposal-mode rule for changes touching memory/cognition loops, it needs its own design pass, not a bundle-in here.
+
+---
+
+## Current architecture
+
+- **Schema** (`orion/memory/crystallization/schemas.py`): `CrystallizationDynamicsV1` — live, round-trips via `dynamics jsonb` column, `repository.py`.
+- **Formation** (`dynamics.py::seed_dynamics`): live — `activation = salience` at creation.
+- **Reinforce-on-recurrence** (`dynamics.py::reinforce`, boost=0.2, multiplicative-toward-ceiling): live — called from `intake_pipeline.py`, `concept_relation.py`, `governor.py`, `formation_executor.py` on dedup/approve.
+- **Recall boost** (`dynamics.py::recall_boost`, boost=0.08 — deliberately smaller than `reinforce`'s 0.2, since "was retrieved once" is a weaker signal than "recurred independently"): written, tested, **zero call sites**.
+- **Decay** (`dynamics.py::decay`, `decayed_activation` — pure half-life read, reuses `orion.core.activation_decay.decay_activation`): written, tested, **zero call sites**. `decayed_activation()` is a pure read — it does not require a scheduled job to take effect; it can be applied at the point ranking reads `activation`.
+- **Retirement** (`dynamics.py::should_retire`, floor=0.05 default): written, tested, **zero call sites**. Distinct from decay — this is the heavier, consequential action (drop from active recall entirely), not just deprioritization.
+- **Ranking read site** (`orion/memory/crystallization/active_packet.py:55`): reads `c.dynamics.activation` directly (raw stored value), not `decayed_activation(c, now=...)`.
+- **Retrieval audit log** (`repository.py::insert_retrieval_event`, `crystallization_routes.py:517`): writes to `memory_crystallization_retrieval_events`, called from the Hub `/api/memory/active-packet` route. Nothing reads it back. Real chat-time recall (`services/orion-recall/`) does not call this route and does not write any retrieval log of its own.
+
+---
+
+## Non-goals
+
+- Confidence/dispute rendering (blocked on real variance existing first — see Arsonist summary).
+- Retrieval co-occurrence graph structure (blocked on real retrieval-event data existing first).
+- Drive/goal-conditioned recall ranking (separate proposal-mode design pass).
+- Automatic hard retirement / auto-archival without governor review — `should_retire()` returning `True` produces a review-queue candidate, never a direct status mutation, matching the existing propose/approve/reject pattern and the 2026-07-07 spec's own non-goal ("no hard deletion of canonical artifacts").
+- No change to `reinforce()`'s existing Phase 2 formation-dedup wiring or its boost magnitude — that signal is separate from recall and already live.
+- No LLM anywhere in this path (unchanged from the 2026-07-07 spec's Phase 1 non-goal).
+- No new taxonomy, no new crystallization kind, no new bus channel required for the recall-boost/decay wiring itself.
+
+---
+
+## Proposed changes
+
+### 1. Decay applied at ranking read time (thinnest possible patch — no new service)
+
+Change `active_packet.py:55`'s ranking key from `c.dynamics.activation` to `decayed_activation(c, now=utcnow())`. `decayed_activation()` is already a pure function reusing the substrate's existing half-life math — this is a one-line read-site change, not new infrastructure. No cron job, no worker, no new failure mode. Decay becomes "live" everywhere ranking happens, immediately.
+
+Retirement (`should_retire()`) is explicitly **not** part of this thin patch — surfacing retirement candidates for governor review is a separate, heavier follow-on (own acceptance check below, own recommended timing).
+
+### 2. `recall_boost()` wired at the point a crystallization is actually returned in a real packet
+
+Call site: wherever `retrieve_active_packet()`'s result is finalized with real (non-empty) `crystallization_refs` — either in `orion/memory/crystallization/retriever.py` after `build_active_packet()`, or immediately after `insert_retrieval_event` in `crystallization_routes.py` for the Hub-route path. Apply `recall_boost()` to every crystallization that actually appears in `packet.crystallization_refs` (not every candidate considered — only what actually made the cut into the render budget, since that's the actual "this got recalled" event).
+
+**Hard invariant, must be enforced in code review, not just documented:** `recall_boost()`/`reinforce()` move `activation` (recall priority) only. Neither may touch `confidence`, `salience`, or any field a reader would interpret as "how true is this." Reinforcement changing what surfaces more often is fine; reinforcement changing how certain Orion sounds about it is not — that's the conformity-bias failure mode named in the brainstorm this spec follows from.
+
+---
+
+## Files likely to touch
+
+- `orion/memory/crystallization/active_packet.py` — ranking read site (decay).
+- `orion/memory/crystallization/retriever.py` — `recall_boost()` call site after packet finalization.
+- `orion/memory/crystallization/repository.py` — persist the updated `dynamics` block back to Postgres after `recall_boost()` (currently `reinforce()`'s Phase 2 call sites already do this pattern — mirror it, don't invent a new persistence path).
+- `services/orion-hub/scripts/crystallization_routes.py` — if the Hub-route path is the chosen call site for item 2, wire alongside the existing `insert_retrieval_event` call at line ~517.
+- `tests/test_memory_crystallization_dynamics.py` (exists per 2026-07-07 spec, Phase 1) — extend with the acceptance checks below.
+- No schema, bus, or `.env` changes — every field and function this patch wires already exists.
+
+---
+
+## Acceptance checks
+
+1. **Saturation regression gate (the one that matters most).** Query `count(*) where dynamics.activation >= 0.99` before enabling recall_boost+decay, then again after a real usage window (not a synthetic smoke burst — actual chat/API traffic over at least several days). **If the ceiling-saturated fraction increases, that's a fail — revert, don't ship as-is.** This is one SQL query, runnable by anyone, no eval harness required. Make it a standing check, not a one-time manual query — a small script under `scripts/` that any future session can re-run.
+2. **Head-to-head recall competition test (proves reinforcement actually changes behavior, not just a stored number).** Seed two crystallizations with equal initial `activation` and overlapping eligibility for the same render-budget bucket. Recall one via real repeated `retrieve_active_packet()` calls (distinct queries, not the same call replayed); leave the other untouched. Assert the reinforced one wins the contested bucket slot in a subsequent ambiguous query where both are plausible candidates. A number moving without a demonstrated behavior change is exactly the "reducer alive, cursor stale" failure mode — this check is what rules that out.
+3. **Decay actually reduces rank over time for disused items.** Seed a crystallization, do not touch it, advance the clock (or use a short `decay_half_life_days` in the test) past its half-life, assert `decayed_activation()` at ranking time is measurably lower than the stored value and that it loses a contested bucket slot to a more-recently-recalled equal-salience competitor.
+4. **Invariant check.** Property-based or explicit test: after any number of `recall_boost()`/`decay()` calls in any order, `confidence` and `salience` on the crystallization are provably unchanged — only `dynamics.*` fields move.
+5. **No regression to Phase 2.** `reinforce()`'s existing formation-dedup call sites and boost magnitude (0.2) are untouched; existing tests for those still pass.
+
+---
+
+## Deferred, not in this patch
+
+- **Retirement wiring** (`should_retire()` → governor review queue). Real action here needs its own acceptance check (a retirement candidate must be reviewable/reversible, never auto-applied) and its own call site (likely a periodic tick, since — unlike decay-at-read-time — surfacing retirement candidates needs to happen even for items nobody is currently querying). Recommend as the very next follow-on once items 1-2 above are live and the saturation gate has run clean for at least one real usage window.
+- Confidence/dispute rendering, co-occurrence links, drive-conditioned ranking — per Non-goals above, blocked on prerequisites this patch does not create.
+
+## Recommended next patch
+
+Items 1 + 2 together, exactly as scoped — decay-at-read (one-line ranking change) and recall_boost wiring, shipped in the same PR since shipping reinforcement without decay reproduces a saturation bug this codebase has already hit once. Acceptance check 1 (saturation gate) is the hard ship/no-ship criterion, not a nice-to-have — it should run and pass clean before this is called done, not just before it's called merged.

--- a/docs/superpowers/specs/2026-07-13-recall-epistemic-honesty-and-observability-spec.md
+++ b/docs/superpowers/specs/2026-07-13-recall-epistemic-honesty-and-observability-spec.md
@@ -1,0 +1,111 @@
+# Recall epistemic honesty + observability: confidence assignment, contradiction-detection instrumentation, retrieval-event logging
+
+**Date:** 2026-07-13
+**Status:** Proposed (items 1, 3) — **item 2 fixed and live-verified same day**, see addendum below.
+**Scope:** Three independent thin patches, one spec because they're the direct output of one investigation into whether Orion's memory recall is "bullshit RAG" theater. Companion to `2026-07-13-memory-recall-reinforcement-decay-wiring-spec.md` — that spec covers ranking (`activation`); this one covers what's actually *true* about a memory (`confidence`) and whether the system can prove any of this happened in the wild (`observability`).
+
+---
+
+## Arsonist summary
+
+Three things were flagged as possible theater and investigated against live data, not assumed:
+
+| # | Claim checked | Verdict | Evidence |
+|---|---|---|---|
+| 1 | Confidence field is meaningless | **Confirmed theater — genuine gap, not bad luck** | `CrystallizationConfidence` is a real 4-value enum (`certain/likely/possible/uncertain`) with a real downstream consumer (`salience.py::CONFIDENCE_BOOST`), but **zero code paths in the entire system ever set it explicitly** — Hub manual propose, consolidation-gate window intake, autonomy-episode intake, concept-relation resolution. All 164 rows in `memory_crystallizations` (not just today's 100 active) are `"likely"`. Since `CONFIDENCE_BOOST["likely"] = 0.05` is a flat constant, `score_salience()`'s confidence term has been silently inert since inception — one whole dimension of the salience formula has never varied. |
+| 2 | Contradiction-detection is broken (like the duplicate-detection Jaccard bug found twice this session) | **Confirmed broken, then fixed and live-verified same day** — see addendum. Two independent bugs stacked: a live-`.env` config regression I caused earlier this session, plus a real missing dependency + missing Docker build toolchain that predates this session entirely. | `maybe_resolve_concept_relation()` never had a working candidate-retrieval path to run against on this host. Root-caused by direct live invocation of the real production function, not by reading code. |
+| 3 | Real chat-time recall can't be verified in the wild | **Confirmed, clean gap** | `services/orion-recall/` (the actual chat-time recall path) writes **zero** retrieval-event history anywhere. The only writer, `insert_retrieval_event`, lives on the Hub API route real chat doesn't call. This blocks verifying *everything* built this session — including the reinforcement/decay spec's own acceptance checks — against real traffic instead of synthetic smoke tests. |
+
+---
+
+## Addendum: item 2 root cause and fix (2026-07-13, same day)
+
+Investigated by directly invoking `process_consolidation_crystallization()` — the real production function, real settings, real Postgres pool, real bus RPC to the LLM gateway — with two crystallizations manually constructed to genuinely contradict each other. Not a code read, not a guess: ran it and watched it fail, then fixed each failure and re-ran until it produced a real, persisted `contradicts` link.
+
+**Bug A — config regression, self-inflicted, same session.** `services/orion-memory-consolidation/.env`'s `CRYSTALLIZER_EMBED_HOST_URL` and `CHROMA_HOST` were reset to empty by the *old* (pre-fix) `sync_local_env_from_example.py` run earlier this session — the exact overwrite bug closed by `fix/env-sync-preserve-local-overrides` (PR #996). `fetch_similar_candidates()` returns `[]` immediately when either is empty (`candidate_retrieval.py:29`); `maybe_resolve_concept_relation()` short-circuits the moment candidates are empty — the LLM call never fires. Fixed: restored both values in the live `.env` (config-only, not committed — gitignored, matches the deployment-specific-override pattern already established for `GRAPHITI_BACKEND`).
+
+**Bug B — missing dependency, pre-existing, not caused by anything this session did.** Even with config fixed, `chromadb` was never installed in `orion-memory-consolidation`'s Docker image — `ModuleNotFoundError` on import, silently caught and logged as `"chromadb not installed; skipping chroma query"` (`chroma_query.py:23`), so `fetch_similar_candidates()` degrades to `[]` exactly the same as bug A, just for a different reason. Fixed: added `chromadb==0.4.24` + `numpy==1.26.4` to `requirements.txt` (matching the pinned versions already used by `orion-dream`/`orion-rag`/`orion-vector-writer`, which all depend on the same package). Rebuilding surfaced **bug C**.
+
+**Bug C — missing Docker build toolchain, same root cause as B.** `chromadb`'s transitive dependency `chroma-hnswlib` builds a native C extension; `orion-memory-consolidation`'s Dockerfile had no `gcc`/`g++`/`libpq-dev` installed (unlike the three sibling Dockerfiles that already carry this feature). Fixed: added the same `apt-get install gcc g++ libpq-dev` step already used by `orion-dream`'s Dockerfile.
+
+**Live verification, end to end, real infrastructure:** proposed+approved a seed belief ("deploy at night, never during the day") via Hub. Directly invoked `process_consolidation_crystallization()` with a second crystallization asserting the opposite ("deploy during the day, never at night") on the same subject. Real Chroma vector search found the seed as a candidate; real embed host produced the query embedding; real LLM gateway RPC classified the relation as `contradicts` with confidence `0.95` (well clear of the `0.6` floor); a real `contradicts` row landed in `memory_crystallization_links`, confirmed by direct Postgres query, not by trusting the function's return value alone. Test crystallizations deprecated/rejected afterward — no permanent pollution.
+
+**Fix scope:** `services/orion-memory-consolidation/Dockerfile`, `requirements.txt` — code-level, applies to any deployment that ever flips `CONCEPT_RELATION_RESOLUTION_ENABLED=true`, not just this host. The `.env` config restoration is host-specific and not part of the commit (gitignored).
+
+---
+
+## Non-goals
+
+- No LLM call added anywhere in this patch (item 1's confidence inference is deterministic; item 2 adds logging around an *existing* LLM call, doesn't add a new one).
+- Not changing `concept_relation.py`'s confidence floor (0.6) or its logic — item 2 is observation only, until instrumentation produces evidence a change is warranted.
+- Not building a new metrics/observability service — item 3 reuses the existing `memory_crystallization_retrieval_events` table Hub already writes to; item 2's logging is structured log lines with correlation IDs, not a new store.
+- Not touching `dynamics.reinforcement_count`'s existing recall_boost/reinforce split from the companion spec — item 1 reads `reinforcement_count` as an input, never writes to it.
+- No retroactive backfill of confidence on the 164 existing rows — this patch changes what happens for new/future crystallizations and reinforcement events; existing rows stay `"likely"` until they're naturally reinforced or re-evaluated (backfill is a separate, explicit decision, not bundled here).
+
+---
+
+## Item 1: Confidence assignment (deterministic, at formation + on reinforcement)
+
+**Problem:** confidence is a free field nobody fills in. Fix: compute it from signals that already exist, at the two points a crystallization's evidentiary basis actually changes — formation and `reinforce()` (recurrence). Explicitly **not** at `recall_boost()` (mere retrieval) — being looked up is not evidence the belief is true, only that it's relevant; conflating the two is the conformity-bias failure the companion spec already named as a hard invariant to avoid.
+
+**Proposed heuristic** (`infer_confidence(crystallization) -> CrystallizationConfidence`, deterministic, no LLM):
+
+| Condition | Assigned confidence |
+|---|---|
+| No evidence, or all `evidence.strength` avg < 0.3, `reinforcement_count == 0` | `uncertain` |
+| 1 evidence source, moderate strength, `reinforcement_count == 0` | `possible` |
+| 1-2 evidence sources, or `reinforcement_count` 1-2 | `likely` |
+| 3+ evidence sources, or `reinforcement_count >= 3`, or (evidence_count >= 2 AND `reinforcement_count >= 1`) | `certain` |
+
+This is a first-cut heuristic, not a claimed-correct final formula — thresholds need tuning against real post-deployment data (acceptance check below), same discipline as the companion spec's saturation gate.
+
+**Call sites:**
+- Formation: wherever `apply_salience()` is currently called (crystallization creation) — call `infer_confidence()` immediately before, so `score_salience()` reads a real value on the same pass, not a stale default.
+- `dynamics.py::reinforce()`: after incrementing `reinforcement_count`, recompute confidence via the same function and set it if it changed. This is the one new touch to `dynamics.py`.
+
+**Files:** `orion/memory/crystallization/salience.py` (new `infer_confidence()`, or a sibling module if salience.py shouldn't own it — check for circular import risk with `dynamics.py`), `orion/memory/crystallization/dynamics.py` (`reinforce()` call site), wherever `apply_salience()` is currently invoked at formation (`intake_pipeline.py` and siblings).
+
+---
+
+## Item 2: Contradiction-detection instrumentation (observe, don't fix blind)
+
+**Problem:** zero `contradicts`/`supersedes` links exist. Could be genuine (small, non-conflicting dataset) or a silent threshold/wiring problem (precedent: duplicate-detection's Jaccard threshold, proven broken twice this session). No way to tell which without data.
+
+**Fix:** log every `maybe_resolve_concept_relation()` invocation and its raw decision — relation, confidence, whether it cleared the 0.6 floor — regardless of outcome, including `same`/`unrelated`/below-floor cases that currently vanish silently. One structured log line per call, correlation-id tagged (matches AGENTS.md's own definition of valid runtime evidence: "log line with correlation ID").
+
+**What this answers, that we can't answer today:**
+- Is the function even being called at realistic volume, or rarely triggered (wiring/trigger gap)?
+- When it's called, does it ever land on `contradicts`/`refines` *below* the 0.6 floor (threshold-tuning problem, same shape as the Jaccard bug)?
+- Or does it consistently land on `same`/`unrelated` (genuinely no conflicts in this data — the innocent explanation)?
+
+This is the whole patch for item 2 — no logic change, no threshold change, until the log data says one is warranted.
+
+**Files:** `orion/memory/crystallization/concept_relation.py` (`maybe_resolve_concept_relation()` — add the log line before the branch on `decision.relation`).
+
+---
+
+## Item 3: Retrieval-event logging from real chat-time recall
+
+**Problem:** `services/orion-recall/app/collectors/active_packet.py::fetch_active_packet_fragments()` — the function real chat turns actually call — never writes to `memory_crystallization_retrieval_events`. Only Hub's API route does, and real chat doesn't use that route.
+
+**Fix:** call the same `insert_retrieval_event` write (or a thin wrapper) from `fetch_active_packet_fragments()` after `retrieve_active_packet()` returns, using the same table Hub already writes to — this is a shared conceptual event (a real retrieval happened), not a new schema. `orion-recall` already has Postgres access to the crystallization schema (it already imports `list_crystallizations`/`retrieve_active_packet` from the same package), so this is a query away, not a new connection.
+
+**Why this is the highest-leverage of the three:** without it, the companion spec's acceptance check #1 (saturation gate measured over "a real usage window") and acceptance check #2 (head-to-head recall competition) have no real data to run against once `RECALL_GRAPHITI_IN_CHAT` and normal chat traffic are the source — only synthetic smoke bursts. This item is a prerequisite for verifying the *other* spec in production, not just a nice-to-have.
+
+**Files:** `services/orion-recall/app/collectors/active_packet.py`, `orion/memory/crystallization/repository.py` (reuse `insert_retrieval_event`, don't duplicate it).
+
+---
+
+## Acceptance checks
+
+1. **Item 1 — real variance, not just a different constant.** After deployment, query `select confidence, count(*) from memory_crystallizations where created_at > <deploy time> group by confidence`. Fail condition: 100% still land on one value (formula is degenerate in practice, not just in theory — needs real threshold tuning, not just existing).
+2. **Item 1 — salience actually moves.** Spot-check: two otherwise-identical crystallizations with different evidence counts get different `confidence` and therefore different `salience` post-deploy. Today this is impossible by construction; must be possible after.
+3. **Item 2 — the log answers the question within N days of real traffic.** After a real usage window, query the new log: report (a) call volume, (b) relation-decision distribution including sub-floor cases, (c) whether any sub-floor `contradicts`/`refines` decisions exist (evidence of a tuning problem) vs. none (supports the innocent explanation). This is a diagnostic report, not a pass/fail gate — the acceptance criterion is "we now have an answer," not "the answer is positive."
+4. **Item 3 — real chat retrieval produces a real log row.** Drive one real chat turn through `chat_general` with recall active, then query `memory_crystallization_retrieval_events` for a row with a timestamp matching that turn. This is the actual "runtime truth" proof the whole session has been chasing — a real conversation, not a smoke script, producing an inspectable artifact.
+5. No regression: existing tests for `score_salience()`, `apply_salience()`, `maybe_resolve_concept_relation()`, and Hub's `insert_retrieval_event` call site all still pass unchanged.
+
+---
+
+## Recommended next patch
+
+**Item 3 first, alone if needed.** It's the cleanest, has zero design ambiguity, and every other verification claim this session has made or will make about live chat recall depends on it existing. Items 1 and 2 can follow in the same or a subsequent patch — 1 needs the heuristic thresholds validated against a real deploy (acceptance check 1), 2 needs a real traffic window to produce a verdict (acceptance check 3), and neither of those windows can start meaningfully until item 3 exists to observe them through.

--- a/services/orion-memory-consolidation/Dockerfile
+++ b/services/orion-memory-consolidation/Dockerfile
@@ -2,6 +2,13 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# chroma-hnswlib (transitive dep of chromadb) builds a native C extension -- needs a
+# compiler toolchain, matching the pattern already used by orion-dream/orion-rag/
+# orion-vector-writer's Dockerfiles for the same dependency.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc g++ libpq-dev && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir --upgrade pip
 
 COPY services/orion-memory-consolidation/requirements.txt .

--- a/services/orion-memory-consolidation/requirements.txt
+++ b/services/orion-memory-consolidation/requirements.txt
@@ -6,3 +6,5 @@ httpx==0.27.0
 asyncpg==0.29.0
 psycopg2-binary==2.9.9
 rdflib==7.0.0
+chromadb==0.4.24
+numpy==1.26.4


### PR DESCRIPTION
# PR report: fix concept-relation resolution (contradiction detection) — missing chromadb dependency + build toolchain

## Summary

- `orion-memory-consolidation`'s contradiction/refines/same-belief detection (`maybe_resolve_concept_relation()`) has never worked on this host — zero `contradicts`/`supersedes` links exist anywhere in `memory_crystallization_links`, despite `CONCEPT_RELATION_RESOLUTION_ENABLED=true`.
- Root-caused by directly invoking the real production function against real infrastructure (not by reading code) and watching it fail, twice, for two independent reasons.
- **Bug A (config, already self-corrected, not part of this commit):** `CRYSTALLIZER_EMBED_HOST_URL`/`CHROMA_HOST` in `services/orion-memory-consolidation/.env` had been reset to empty by the pre-fix `sync_local_env_from_example.py` overwrite bug (PR #996) earlier this session. Restored live.
- **Bug B/C (code, this commit):** `chromadb` was never in `requirements.txt`, and the Dockerfile had no C compiler toolchain to build its native `chroma-hnswlib` dependency even if it were added. Both fixed, matching the exact pattern already used by `orion-dream`/`orion-rag`/`orion-vector-writer`.
- Live-verified end to end: real Chroma search + real embed host + real LLM gateway classification produced a genuine `contradicts` link with confidence 0.95, confirmed by direct Postgres query.

## Outcome moved

Contradiction detection goes from "flag flipped on, silently a no-op since inception" to "verified working against real infrastructure." This was previously misdiagnosed (by me, in an earlier pass this same session) as "not proven broken, insufficient evidence" — that conclusion was wrong because I hadn't yet actually run the function against live data; I only checked whether it was *called*, not whether its own dependencies were satisfiable.

## Current architecture (before this patch)

`maybe_resolve_concept_relation()` (`orion/memory/crystallization/concept_relation.py`) is called from `intake_pipeline.py` on real consolidation-gate ingestion. It calls `fetch_similar_candidates()` (`candidate_retrieval.py`) for vector-similarity candidates before ever attempting an LLM classification. `fetch_similar_candidates()` requires both `CRYSTALLIZER_EMBED_HOST_URL` and `CHROMA_HOST` non-empty, and requires the `chromadb` Python package importable — both were broken independently.

## Architecture touched

Single service, `orion-memory-consolidation` — Dockerfile and requirements.txt only. No schema, bus, or API contract changes. No change to `concept_relation.py`'s logic, thresholds, or LLM prompt.

## Files changed

- `services/orion-memory-consolidation/requirements.txt`: added `chromadb==0.4.24`, `numpy==1.26.4` (pinned to match the three sibling services that already depend on the same package — `numpy==1.26.4` specifically because `chromadb==0.4.24`'s transitive code path uses `np.float_`, removed in numpy 2.0).
- `services/orion-memory-consolidation/Dockerfile`: added `apt-get install gcc g++ libpq-dev` before `pip install`, matching `orion-dream`'s Dockerfile — `chroma-hnswlib` (chromadb's transitive dependency) builds a native C extension and has no prebuilt wheel for this base image.
- `docs/superpowers/specs/2026-07-13-recall-epistemic-honesty-and-observability-spec.md`: addendum documenting the corrected finding (this spec originally concluded item 2 was "not confirmed broken" — that was wrong, corrected here with the real root cause and live verification).

## Schema / bus / API changes

None.

## Env/config changes

- Added keys: none (no `.env_example` shape change — `CRYSTALLIZER_EMBED_HOST_URL`/`CHROMA_HOST`/`CONCEPT_RELATION_RESOLUTION_ENABLED` already existed).
- This host's live `.env` values (`CRYSTALLIZER_EMBED_HOST_URL=http://orion-athena-vector-host:8320/embedding`, `CHROMA_HOST=orion-athena-vector-db`) were restored as part of diagnosing this — gitignored, not part of this commit, already applied live and confirmed working in the verification below.
- `.env_example` intentionally still ships these two keys empty (existing comment: "even if `CONCEPT_RELATION_RESOLUTION_ENABLED` is flipped true without also configuring these, the feature degrades to a no-op") — that's the correct safe default for fresh deployments and is unchanged by this patch. Any deployment that flips `CONCEPT_RELATION_RESOLUTION_ENABLED=true` now also needs a working `chromadb` install (this patch) *and* real embed/chroma host values (operator's own `.env`, unchanged contract).

## Tests run

```text
$ source venv/bin/activate && python -m pytest services/orion-memory-consolidation/tests -q
71 passed, 14 warnings in 4.31s
```
No regression. No new unit test added for this fix — it's a dependency/build-toolchain fix, not a logic change; the meaningful verification is the live end-to-end run below, not a mock.

## Evals run

No eval harness exists for `orion-memory-consolidation`'s concept-relation resolution specifically. The live verification below is the closest equivalent and is the standard this fix is held to, matching how the duplicate-detection Jaccard bug was verified earlier this session (empirically, not by inspection).

## Docker/build/smoke checks

```text
$ docker compose --env-file .env --env-file services/orion-memory-consolidation/.env \
    -f services/orion-memory-consolidation/docker-compose.yml up -d --build
Successfully installed ... chroma-hnswlib-0.7.3 chromadb-0.4.24 numpy-2.5.1 ...
# (first build: numpy 2.5.1 pulled in transitively, chromadb import failed on np.float_ removal)

$ docker exec orion-athena-memory-consolidation python -c "import chromadb"
AttributeError: `np.float_` was removed in the NumPy 2.0 release.
# fixed by pinning numpy==1.26.4 explicitly, rebuilt:

$ docker exec orion-athena-memory-consolidation python -c "import chromadb; print(chromadb.__version__)"
chromadb ok 0.4.24

# Live end-to-end verification (real production function, real infra, not mocked):
# 1. Proposed+approved seed belief via Hub: "deploy orion services at night, never during the day"
# 2. Directly invoked process_consolidation_crystallization() inside the running container with a
#    second crystallization asserting the opposite claim on the same subject.
$ docker exec orion-athena-memory-consolidation python /tmp/test_contradiction_live.py
RESULT: (..., MemoryCrystallizationV1(... links=[CrystallizationLinkV1(
    target_crystallization_id='b65bc9ca-ca05-41fb-bab5-f4c1c2541267',
    relation='contradicts', confidence=0.95, note='concept_relation_llm')], ...), 'proposed')

# 3. Confirmed persisted (not just returned) via direct Postgres query:
$ psql -c "select from_crystallization_id, to_crystallization_id, relation, confidence, note
           from memory_crystallization_links where relation='contradicts';"
 429b4c0e-... | b65bc9ca-... | contradicts | 0.9499999999999999... | concept_relation_llm

# 4. Test crystallizations cleaned up (deprecated/rejected) after verification, not left as
#    permanent pollution:
$ curl .../crystallizations/429b4c0e.../reject -> 200
$ curl .../crystallizations/b65bc9ca.../deprecate -> 200
```

## Review findings fixed

Self-caught, not from a separate review pass: my own first two live-test attempts each surfaced a genuine problem (the numpy incompatibility, and a same-window Jaccard collision with a leftover row from an earlier broken test-harness attempt where a shell-quoting bug had passed an empty subject) — both root-caused and fixed before concluding the underlying feature itself works. No material findings against the actual Dockerfile/requirements.txt diff, which is a two-line, low-risk, purely additive change mirroring an already-established pattern in three sibling services.

## Restart required

Already executed live during this session:

```bash
docker compose --env-file .env --env-file services/orion-memory-consolidation/.env \
  -f services/orion-memory-consolidation/docker-compose.yml up -d --build
```

If merged and redeployed elsewhere: same command. `CONCEPT_RELATION_RESOLUTION_ENABLED` stays operator-controlled per `.env_example`'s existing default (`false`) — this patch only ensures the feature actually works on hosts that choose to enable it, it does not change the default.

## Risks / concerns

- Severity: Low — `chromadb==0.4.24`/`numpy==1.26.4` are the same versions already running in three other services on this host; no new version-compatibility surface introduced beyond what's already proven elsewhere.
- Severity: Low — this session's earlier env-sync-script bug (now fixed, PR #996) is what caused bug A in the first place. No further action needed here; that fix is already merged.