### PR TITLE
Feat/crystallization confidence assignment

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-crystallization-confidence-assignment-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-crystallization-confidence-assignment-pr.md
@@ -1,0 +1,97 @@
+# PR report: deterministic confidence assignment (formation + reinforcement)
+
+Implements Item 1 of `docs/superpowers/specs/2026-07-13-recall-epistemic-honesty-and-observability-spec.md`.
+
+## Summary
+
+- `CrystallizationConfidence` (`certain | likely | possible | uncertain`) has been a dead field since inception — every one of 164 historical rows in `memory_crystallizations` sits on the schema's `"likely"` default; nothing anywhere ever set it explicitly. `salience.py::CONFIDENCE_BOOST`, a real downstream consumer, has therefore never varied.
+- Adds `infer_confidence()` (deterministic, no LLM, no I/O) to `orion/memory/crystallization/salience.py`, reading evidence count/strength and `dynamics.reinforcement_count`.
+- `apply_salience()` now calls `infer_confidence()` as its first step — both real formation call sites (`proposer.py::propose`, `intake_pipeline.py::process_consolidation_crystallization`) get it for free, no call-site duplication.
+- `dynamics.py::reinforce()` recomputes confidence after `reinforcement_count` increments — recurrence (the same fact independently re-derived) is real evidentiary support.
+- **Hard invariant enforced by a dedicated test:** `recall_boost()` never touches confidence — being retrieved is not evidence something is true, only that it's relevant. This guards against the exact conformity-bias failure mode the companion reinforcement/decay spec named.
+
+## Outcome moved
+
+`score_salience()`'s confidence term goes from a silent flat constant (always `+0.05`, since `confidence` was always `"likely"`) to a real, evidence-driven signal. Two otherwise-identical crystallizations with different evidence support now get different salience.
+
+## Current architecture (before this patch)
+
+`apply_salience()` computed salience by reading `crystallization.confidence` — but nothing ever set that field to anything but the Pydantic model default. One whole dimension of the salience formula was inert.
+
+## Architecture touched
+
+`orion/memory/crystallization/salience.py`, `orion/memory/crystallization/dynamics.py`. No schema, bus, or API contract changes — `CrystallizationConfidence`/`dynamics.reinforcement_count` already existed; this patch makes them causally connected for the first time.
+
+## Files changed
+
+- `orion/memory/crystallization/salience.py`: new `infer_confidence()`; `apply_salience()` calls it first.
+- `orion/memory/crystallization/dynamics.py`: `reinforce()` recomputes confidence after incrementing `reinforcement_count`; one new import (`salience.py::infer_confidence`).
+- `tests/test_memory_crystallization.py`: `TestInferConfidence` (12 cases covering the full tiering table) + 2 formation/salience-movement acceptance tests (spec's acceptance checks 1 and 2).
+- `tests/test_memory_crystallization_dynamics.py`: `TestReinforceConfidence` (confidence climbs tiers across repeated reinforcement, monotonic — never regresses on a stale recompute) + `test_recall_boost_never_touches_confidence` (the hard invariant).
+
+## Design decisions worth flagging
+
+**Where `infer_confidence()` lives:** in `salience.py`, next to `CONFIDENCE_BOOST`/`score_salience()` (they're conceptually paired). Checked for an import cycle first — `dynamics.py` importing from `salience.py` is safe (`salience.py` has no `dynamics.py` import), confirmed by direct import.
+
+**Call-site consolidation:** the spec suggested calling `infer_confidence()` "wherever `apply_salience()` is currently called." Instead, it's called once, inside `apply_salience()` itself, so every real caller gets it automatically with no duplication. Verified the full list of real `apply_salience()` callers: `proposer.py::propose()` (used by Hub's manual propose route and `orion-memory-crystallizer`'s worker) and `intake_pipeline.py::process_consolidation_crystallization()` (used by `orion-memory-consolidation`'s worker, including the window-intake path). Also checked `intake_autonomy_episode.py::build_crystallization_from_episode()` — it does **not** call `apply_salience()` and has no live service consumer today (only referenced from a smoke script) — nothing to wire there, consistent with the spec's own arsonist summary.
+
+**Tiering resolution:** the spec's table lists conditions in presentational (ascending-confidence) order, but the row conditions overlap — e.g. a single moderate-strength source with zero reinforcement literally matches both the "possible" and "likely" rows as written. Implemented as strength-ordered evaluation (floor → certain → possible → likely → fallback) so each case lands on the tier the spec's intent actually describes. Documented inline in the function's docstring.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+$ source venv/bin/activate && python -m pytest tests/test_memory_crystallization.py tests/test_memory_crystallization_dynamics.py -q
+1 failed, 58 passed, 6 warnings in 3.03s
+```
+
+The 1 failure (`TestMemoryCardBackwardCompat::test_memory_card_v1_unchanged_in_registry_gap`) is pre-existing and unrelated — independently confirmed by running the identical test against clean `origin/main`:
+
+```text
+$ python -m pytest tests/test_memory_crystallization.py::TestMemoryCardBackwardCompat::test_memory_card_v1_unchanged_in_registry_gap -q
+1 failed, 6 warnings in 3.09s
+```
+
+Both runs independently re-executed by the orchestrator, not taken from the implementing agent's report alone. The 16-test `test_memory_crystallization_dynamics.py` suite specifically, including the two new confidence tests and the hard-invariant test, passes 16/16:
+
+```text
+$ python -m pytest tests/test_memory_crystallization_dynamics.py -v
+... 16 passed
+```
+
+## Evals run
+
+No eval harness applies to this deterministic formula. Acceptance checks 1 and 2 from the spec (real variance appears post-deploy; salience actually moves between differently-evidenced crystallizations) are implemented as unit tests above rather than a live-deploy check, since the logic is deterministic and fully covered by construction — unlike the companion reinforcement/decay spec's saturation gate, there's no live-traffic-dependent behavior to separately verify here.
+
+## Docker/build/smoke checks
+
+Not applicable — this is a pure Python library change (`orion/memory/crystallization/`), consumed by `orion-hub`, `orion-memory-crystallizer`, and `orion-memory-consolidation` without any of their own code changing. No new dependency, no Docker rebuild required for those services to pick this up (they already `COPY orion /app/orion` from the shared package).
+
+## Review findings fixed
+
+**Worktree-isolation anomaly caught and corrected by the orchestrator, not the implementing agent.** During implementation, the agent reported observing a "concurrent sibling agent's" uncommitted edits (from the parallel `feat/recall-reinforcement-decay-wiring` patch) appearing in this worktree's working tree — despite the two worktrees being confirmed-distinct physical directories (different inodes, verified via `stat`). The agent's own commit (`f39ec431`) was already correctly scoped to only its intended 4 files at the time it reported this, but left 5 stray uncommitted files (byte-identical to the sibling patch's changes) sitting in the working tree afterward. Orchestrator independently verified via `git show f39ec431 --stat` that the commit itself was clean, then discarded the stray uncommitted files with `git restore` (safe — they were uncommitted duplicates of work the sibling patch owns and commits separately in its own branch). Final pushed state contains only this patch's intended 4 files, confirmed via `git diff origin/main --stat` post-rebase.
+
+## Restart required
+
+```text
+No restart required.
+```
+Pure library change; consuming services (`orion-hub`, `orion-memory-crystallizer`, `orion-memory-consolidation`) pick it up on their next normal rebuild/restart, no special action.
+
+## Risks / concerns
+
+- Severity: Low — the tiering thresholds are a first-cut heuristic (explicitly named as such in the spec). Real-world calibration against post-deploy data (spec acceptance check 1: query the confidence distribution on new rows after deployment) is a natural follow-up, not blocking for this patch.
+- Severity: Low — no retroactive backfill of the 164 existing `"likely"` rows, matching the spec's explicit non-goal. They'll pick up real confidence only when/if they're independently reinforced going forward.
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/crystallization-confidence-assignment?expand=1`

--- a/orion/memory/crystallization/dynamics.py
+++ b/orion/memory/crystallization/dynamics.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from orion.core.activation_decay import decay_activation
+from orion.memory.crystallization.salience import infer_confidence
 from orion.memory.crystallization.schemas import MemoryCrystallizationV1
 
 _SECONDS_PER_DAY = 86400.0
@@ -67,12 +68,19 @@ def reinforce(
 
     Multiplicative-toward-ceiling so repeated reinforcement has diminishing returns
     (never overshoots 1.0), matching how rehearsal consolidates but saturates.
+
+    Also recomputes `confidence` via `infer_confidence()` now that
+    `reinforcement_count` has moved -- recurrence (the same fact independently
+    re-derived) is real evidentiary support. This is the one and only place
+    outside formation that confidence changes; `recall_boost()` deliberately does
+    not touch it (being looked up is not evidence something is true).
     """
     updated = crystallization.model_copy(deep=True)
     current = _clamp(updated.dynamics.activation)
     updated.dynamics.activation = _clamp(current + (1.0 - current) * _clamp(boost))
     updated.dynamics.reinforcement_count += 1
     updated.dynamics.last_reinforced_at = _aware(now)
+    updated.confidence = infer_confidence(updated)
     updated.updated_at = _aware(now)
     return updated
 

--- a/orion/memory/crystallization/salience.py
+++ b/orion/memory/crystallization/salience.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from orion.memory.crystallization.schemas import MemoryCrystallizationV1
+from orion.memory.crystallization.schemas import CrystallizationConfidence, MemoryCrystallizationV1
 
 KIND_BASE = {
     "stance": 0.85,
@@ -21,6 +21,61 @@ CONFIDENCE_BOOST = {
     "uncertain": -0.05,
 }
 
+# Threshold separating "weak/no real signal" evidence from "moderate" evidence in
+# infer_confidence(). Mirrors the floor implied by the spec table's "avg < 0.3" cutoff.
+_MODERATE_STRENGTH_FLOOR = 0.3
+
+
+def infer_confidence(crystallization: MemoryCrystallizationV1) -> CrystallizationConfidence:
+    """Deterministic confidence tier from evidence + recurrence. No LLM, no I/O.
+
+    Reads `crystallization.evidence` (independent evidence sources at formation time)
+    and `crystallization.dynamics.reinforcement_count` (recurrence — the same fact
+    independently re-derived). Both are real evidentiary signals.
+
+    Deliberately does NOT read `dynamics.last_recalled_at` or anything recall-related:
+    being looked up is not evidence something is true, only that it's relevant. Callers
+    must never invoke this from `recall_boost()` or any retrieval-time path — see
+    `dynamics.py`'s module docstring / the reinforcement-decay wiring spec's hard
+    invariant against conflating recall with reinforcement.
+
+    Tiering (highest-support tier wins; evaluated strongest-to-weakest, not in the
+    spec table's presentational uncertain->certain order, because the table's row
+    conditions overlap and only a strength-ordered evaluation resolves that):
+
+      1. Floor: no evidence, or evidence exists but is all weak on average
+         (avg strength < 0.3), and nothing has independently recurred yet -> uncertain.
+      2. Strong support: 3+ evidence sources, OR reinforcement_count >= 3, OR
+         (2+ evidence sources AND reinforcement_count >= 1) -> certain.
+      3. A single moderate-strength source with no recurrence yet is a first-cut
+         guess, not yet corroborated -> possible.
+      4. Everything else with real (if modest) support -- 1-2 evidence sources, or
+         reinforcement_count 1-2 -> likely.
+      5. Fallback (should be unreachable given 1-4, kept for safety) -> uncertain.
+    """
+    evidence = crystallization.evidence
+    evidence_count = len(evidence)
+    reinforcement_count = crystallization.dynamics.reinforcement_count
+    avg_strength = (sum(ev.strength for ev in evidence) / evidence_count) if evidence_count else 0.0
+
+    if (evidence_count == 0 or avg_strength < _MODERATE_STRENGTH_FLOOR) and reinforcement_count == 0:
+        return "uncertain"
+
+    if (
+        evidence_count >= 3
+        or reinforcement_count >= 3
+        or (evidence_count >= 2 and reinforcement_count >= 1)
+    ):
+        return "certain"
+
+    if evidence_count == 1 and reinforcement_count == 0 and avg_strength >= _MODERATE_STRENGTH_FLOOR:
+        return "possible"
+
+    if (1 <= evidence_count <= 2) or (1 <= reinforcement_count <= 2):
+        return "likely"
+
+    return "uncertain"
+
 
 def score_salience(crystallization: MemoryCrystallizationV1) -> float:
     """Compute salience from kind, evidence strength, and confidence."""
@@ -36,6 +91,15 @@ def score_salience(crystallization: MemoryCrystallizationV1) -> float:
 
 
 def apply_salience(crystallization: MemoryCrystallizationV1) -> MemoryCrystallizationV1:
+    """Compute confidence (from evidence/recurrence) and salience (which reads it).
+
+    `infer_confidence()` runs first so `score_salience()`'s CONFIDENCE_BOOST lookup
+    reads a real computed value on this same pass, not the schema's stale "likely"
+    default. Both real formation call sites (proposer.py, intake_pipeline.py) go
+    through this one function, so this is the single seam rather than duplicating
+    the infer_confidence() call at each call site.
+    """
     updated = crystallization.model_copy(deep=True)
+    updated.confidence = infer_confidence(updated)
     updated.salience = score_salience(updated)
     return updated

--- a/tests/test_memory_crystallization.py
+++ b/tests/test_memory_crystallization.py
@@ -12,10 +12,11 @@ from orion.memory.crystallization.projection_chroma import build_chroma_upsert, 
 from orion.memory.crystallization.projection_graphiti import GraphitiAdapter
 from orion.memory.crystallization.projection_rdf import build_rdf_projection_hint
 from orion.memory.crystallization.proposer import propose
-from orion.memory.crystallization.salience import score_salience, apply_salience
+from orion.memory.crystallization.salience import infer_confidence, score_salience, apply_salience
 from orion.memory.crystallization.bus_emit import LIFECYCLE_KINDS, CHANNEL_DEFAULTS
 from orion.memory.crystallization.detection import detect_contradictions, detect_duplicates, merge_detection
 from orion.memory.crystallization.schemas import (
+    CrystallizationDynamicsV1,
     CrystallizationEvidenceRefV1,
     CrystallizationGovernanceV1,
     CrystallizationLinkV1,
@@ -192,6 +193,167 @@ class TestSalienceAndBus:
     def test_bus_lifecycle_kinds_registered(self):
         assert "approved" in LIFECYCLE_KINDS
         assert CHANNEL_DEFAULTS["project"] == "orion:memory:crystallization:project"
+
+    def test_apply_salience_sets_real_confidence_not_stale_default(self):
+        # Spec acceptance check: formation call site produces a non-default confidence
+        # when evidence supports it, computed on the same pass apply_salience() runs.
+        req = _base_request(
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="memory_card", source_id="c1", strength=0.6),
+                CrystallizationEvidenceRefV1(source_kind="memory_card", source_id="c2", strength=0.6),
+            ]
+        )
+        crys = apply_salience(propose(req))
+        assert crys.confidence == "likely"
+
+    def test_salience_moves_with_evidence_count(self):
+        # Spec acceptance check 2: two otherwise-identical crystallizations that differ
+        # only in evidence count get different confidence and therefore different
+        # salience post-formation. Before this patch this was impossible by
+        # construction (confidence was always the stale "likely" default).
+        one_source = apply_salience(
+            propose(
+                _base_request(
+                    evidence=[
+                        CrystallizationEvidenceRefV1(source_kind="memory_card", source_id="c1", strength=0.5)
+                    ]
+                )
+            )
+        )
+        three_sources = apply_salience(
+            propose(
+                _base_request(
+                    evidence=[
+                        CrystallizationEvidenceRefV1(source_kind="memory_card", source_id="c1", strength=0.5),
+                        CrystallizationEvidenceRefV1(source_kind="memory_card", source_id="c2", strength=0.5),
+                        CrystallizationEvidenceRefV1(source_kind="memory_card", source_id="c3", strength=0.5),
+                    ]
+                )
+            )
+        )
+        assert one_source.confidence != three_sources.confidence
+        assert one_source.confidence == "possible"
+        assert three_sources.confidence == "certain"
+        assert score_salience(one_source) != score_salience(three_sources)
+
+
+def _bare_crystallization(
+    *,
+    evidence: list[CrystallizationEvidenceRefV1] | None = None,
+    reinforcement_count: int = 0,
+) -> MemoryCrystallizationV1:
+    """Construct a raw MemoryCrystallizationV1 with no formation-pipeline side effects,
+    for exercising infer_confidence() directly against arbitrary evidence/reinforcement
+    combinations that don't need real duplicate-detection/governor machinery."""
+    now = _now()
+    return MemoryCrystallizationV1(
+        crystallization_id="crys_test",
+        kind="semantic",
+        subject="subject",
+        summary="summary",
+        evidence=list(evidence or []),
+        dynamics=CrystallizationDynamicsV1(reinforcement_count=reinforcement_count),
+        governance=CrystallizationGovernanceV1(proposed_by="test"),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestInferConfidence:
+    def test_no_evidence_no_reinforcement_is_uncertain(self):
+        crys = _bare_crystallization(evidence=[], reinforcement_count=0)
+        assert infer_confidence(crys) == "uncertain"
+
+    def test_weak_evidence_no_reinforcement_is_uncertain(self):
+        crys = _bare_crystallization(
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c1", strength=0.1)
+            ],
+            reinforcement_count=0,
+        )
+        assert infer_confidence(crys) == "uncertain"
+
+    def test_multiple_weak_evidence_avg_below_floor_no_reinforcement_is_uncertain(self):
+        crys = _bare_crystallization(
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c1", strength=0.1),
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c2", strength=0.2),
+            ],
+            reinforcement_count=0,
+        )
+        assert infer_confidence(crys) == "uncertain"
+
+    def test_single_moderate_evidence_no_reinforcement_is_possible(self):
+        crys = _bare_crystallization(
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c1", strength=0.5)
+            ],
+            reinforcement_count=0,
+        )
+        assert infer_confidence(crys) == "possible"
+
+    def test_two_moderate_evidence_no_reinforcement_is_likely(self):
+        crys = _bare_crystallization(
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c1", strength=0.5),
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c2", strength=0.5),
+            ],
+            reinforcement_count=0,
+        )
+        assert infer_confidence(crys) == "likely"
+
+    def test_no_evidence_reinforcement_one_is_likely(self):
+        crys = _bare_crystallization(evidence=[], reinforcement_count=1)
+        assert infer_confidence(crys) == "likely"
+
+    def test_no_evidence_reinforcement_two_is_likely(self):
+        crys = _bare_crystallization(evidence=[], reinforcement_count=2)
+        assert infer_confidence(crys) == "likely"
+
+    def test_single_evidence_reinforcement_one_is_likely(self):
+        crys = _bare_crystallization(
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c1", strength=0.1)
+            ],
+            reinforcement_count=1,
+        )
+        assert infer_confidence(crys) == "likely"
+
+    def test_three_evidence_sources_is_certain_regardless_of_reinforcement(self):
+        crys = _bare_crystallization(
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c1", strength=0.3),
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c2", strength=0.3),
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c3", strength=0.3),
+            ],
+            reinforcement_count=0,
+        )
+        assert infer_confidence(crys) == "certain"
+
+    def test_reinforcement_three_is_certain_regardless_of_evidence(self):
+        crys = _bare_crystallization(evidence=[], reinforcement_count=3)
+        assert infer_confidence(crys) == "certain"
+
+    def test_two_evidence_and_one_reinforcement_is_certain(self):
+        crys = _bare_crystallization(
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c1", strength=0.5),
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c2", strength=0.5),
+            ],
+            reinforcement_count=1,
+        )
+        assert infer_confidence(crys) == "certain"
+
+    def test_high_reinforcement_overrides_weak_evidence(self):
+        # Recurrence is real evidentiary support even when the original evidence
+        # excerpt was weak -- this is the "floor" only applying when reinforcement==0.
+        crys = _bare_crystallization(
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="chat_turn", source_id="c1", strength=0.05)
+            ],
+            reinforcement_count=3,
+        )
+        assert infer_confidence(crys) == "certain"
 
 
 class TestRdfProjection:

--- a/tests/test_memory_crystallization_dynamics.py
+++ b/tests/test_memory_crystallization_dynamics.py
@@ -98,6 +98,36 @@ class TestReinforce:
         assert crys.dynamics.activation > 0.99
 
 
+class TestReinforceConfidence:
+    def test_reinforce_climbs_confidence_tiers_as_reinforcement_count_grows(self):
+        # _crys() proposes with 1 moderate-strength evidence source (default strength
+        # 0.5) and reinforcement_count starts at 0 -> apply_salience's infer_confidence
+        # call lands on "possible" at formation.
+        crys = _crys()
+        assert crys.confidence == "possible"
+
+        r1 = reinforce(crys, now=_now())
+        assert r1.dynamics.reinforcement_count == 1
+        assert r1.confidence == "likely"
+
+        r2 = reinforce(r1, now=_now())
+        assert r2.dynamics.reinforcement_count == 2
+        assert r2.confidence == "likely"
+
+        r3 = reinforce(r2, now=_now())
+        assert r3.dynamics.reinforcement_count == 3
+        assert r3.confidence == "certain"
+
+    def test_reinforce_never_lowers_confidence_via_stale_recompute(self):
+        crys = _crys()
+        r1 = reinforce(crys, now=_now())
+        r2 = reinforce(r1, now=_now())
+        r3 = reinforce(r2, now=_now())
+        tiers = ["uncertain", "possible", "likely", "certain"]
+        ranks = [tiers.index(c.confidence) for c in (crys, r1, r2, r3)]
+        assert ranks == sorted(ranks)
+
+
 class TestRecallBoost:
     def test_recall_is_weaker_than_reinforce_and_marks_recall(self):
         crys = _crys()
@@ -105,6 +135,14 @@ class TestRecallBoost:
         assert abs(recalled.dynamics.activation - 0.08) < 1e-9
         assert recalled.dynamics.last_recalled_at == _now()
         assert recalled.dynamics.reinforcement_count == 0
+
+    def test_recall_boost_never_touches_confidence(self):
+        # Hard invariant: being recalled is not evidence something is true, only
+        # that it's relevant. recall_boost() must never move confidence.
+        crys = _crys()
+        before = crys.confidence
+        recalled = recall_boost(crys, now=_now(), boost=0.08)
+        assert recalled.confidence == before
 
 
 class TestDecay:


### PR DESCRIPTION
# PR report: deterministic confidence assignment (formation + reinforcement)

Implements Item 1 of `docs/superpowers/specs/2026-07-13-recall-epistemic-honesty-and-observability-spec.md`.

## Summary

- `CrystallizationConfidence` (`certain | likely | possible | uncertain`) has been a dead field since inception — every one of 164 historical rows in `memory_crystallizations` sits on the schema's `"likely"` default; nothing anywhere ever set it explicitly. `salience.py::CONFIDENCE_BOOST`, a real downstream consumer, has therefore never varied.
- Adds `infer_confidence()` (deterministic, no LLM, no I/O) to `orion/memory/crystallization/salience.py`, reading evidence count/strength and `dynamics.reinforcement_count`.
- `apply_salience()` now calls `infer_confidence()` as its first step — both real formation call sites (`proposer.py::propose`, `intake_pipeline.py::process_consolidation_crystallization`) get it for free, no call-site duplication.
- `dynamics.py::reinforce()` recomputes confidence after `reinforcement_count` increments — recurrence (the same fact independently re-derived) is real evidentiary support.
- **Hard invariant enforced by a dedicated test:** `recall_boost()` never touches confidence — being retrieved is not evidence something is true, only that it's relevant. This guards against the exact conformity-bias failure mode the companion reinforcement/decay spec named.

## Outcome moved

`score_salience()`'s confidence term goes from a silent flat constant (always `+0.05`, since `confidence` was always `"likely"`) to a real, evidence-driven signal. Two otherwise-identical crystallizations with different evidence support now get different salience.

## Current architecture (before this patch)

`apply_salience()` computed salience by reading `crystallization.confidence` — but nothing ever set that field to anything but the Pydantic model default. One whole dimension of the salience formula was inert.

## Architecture touched

`orion/memory/crystallization/salience.py`, `orion/memory/crystallization/dynamics.py`. No schema, bus, or API contract changes — `CrystallizationConfidence`/`dynamics.reinforcement_count` already existed; this patch makes them causally connected for the first time.

## Files changed

- `orion/memory/crystallization/salience.py`: new `infer_confidence()`; `apply_salience()` calls it first.
- `orion/memory/crystallization/dynamics.py`: `reinforce()` recomputes confidence after incrementing `reinforcement_count`; one new import (`salience.py::infer_confidence`).
- `tests/test_memory_crystallization.py`: `TestInferConfidence` (12 cases covering the full tiering table) + 2 formation/salience-movement acceptance tests (spec's acceptance checks 1 and 2).
- `tests/test_memory_crystallization_dynamics.py`: `TestReinforceConfidence` (confidence climbs tiers across repeated reinforcement, monotonic — never regresses on a stale recompute) + `test_recall_boost_never_touches_confidence` (the hard invariant).

## Design decisions worth flagging

**Where `infer_confidence()` lives:** in `salience.py`, next to `CONFIDENCE_BOOST`/`score_salience()` (they're conceptually paired). Checked for an import cycle first — `dynamics.py` importing from `salience.py` is safe (`salience.py` has no `dynamics.py` import), confirmed by direct import.

**Call-site consolidation:** the spec suggested calling `infer_confidence()` "wherever `apply_salience()` is currently called." Instead, it's called once, inside `apply_salience()` itself, so every real caller gets it automatically with no duplication. Verified the full list of real `apply_salience()` callers: `proposer.py::propose()` (used by Hub's manual propose route and `orion-memory-crystallizer`'s worker) and `intake_pipeline.py::process_consolidation_crystallization()` (used by `orion-memory-consolidation`'s worker, including the window-intake path). Also checked `intake_autonomy_episode.py::build_crystallization_from_episode()` — it does **not** call `apply_salience()` and has no live service consumer today (only referenced from a smoke script) — nothing to wire there, consistent with the spec's own arsonist summary.

**Tiering resolution:** the spec's table lists conditions in presentational (ascending-confidence) order, but the row conditions overlap — e.g. a single moderate-strength source with zero reinforcement literally matches both the "possible" and "likely" rows as written. Implemented as strength-ordered evaluation (floor → certain → possible → likely → fallback) so each case lands on the tier the spec's intent actually describes. Documented inline in the function's docstring.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```text
$ source venv/bin/activate && python -m pytest tests/test_memory_crystallization.py tests/test_memory_crystallization_dynamics.py -q
1 failed, 58 passed, 6 warnings in 3.03s
```

The 1 failure (`TestMemoryCardBackwardCompat::test_memory_card_v1_unchanged_in_registry_gap`) is pre-existing and unrelated — independently confirmed by running the identical test against clean `origin/main`:

```text
$ python -m pytest tests/test_memory_crystallization.py::TestMemoryCardBackwardCompat::test_memory_card_v1_unchanged_in_registry_gap -q
1 failed, 6 warnings in 3.09s
```

Both runs independently re-executed by the orchestrator, not taken from the implementing agent's report alone. The 16-test `test_memory_crystallization_dynamics.py` suite specifically, including the two new confidence tests and the hard-invariant test, passes 16/16:

```text
$ python -m pytest tests/test_memory_crystallization_dynamics.py -v
... 16 passed
```

## Evals run

No eval harness applies to this deterministic formula. Acceptance checks 1 and 2 from the spec (real variance appears post-deploy; salience actually moves between differently-evidenced crystallizations) are implemented as unit tests above rather than a live-deploy check, since the logic is deterministic and fully covered by construction — unlike the companion reinforcement/decay spec's saturation gate, there's no live-traffic-dependent behavior to separately verify here.

## Docker/build/smoke checks

Not applicable — this is a pure Python library change (`orion/memory/crystallization/`), consumed by `orion-hub`, `orion-memory-crystallizer`, and `orion-memory-consolidation` without any of their own code changing. No new dependency, no Docker rebuild required for those services to pick this up (they already `COPY orion /app/orion` from the shared package).

## Review findings fixed

**Worktree-isolation anomaly caught and corrected by the orchestrator, not the implementing agent.** During implementation, the agent reported observing a "concurrent sibling agent's" uncommitted edits (from the parallel `feat/recall-reinforcement-decay-wiring` patch) appearing in this worktree's working tree — despite the two worktrees being confirmed-distinct physical directories (different inodes, verified via `stat`). The agent's own commit (`f39ec431`) was already correctly scoped to only its intended 4 files at the time it reported this, but left 5 stray uncommitted files (byte-identical to the sibling patch's changes) sitting in the working tree afterward. Orchestrator independently verified via `git show f39ec431 --stat` that the commit itself was clean, then discarded the stray uncommitted files with `git restore` (safe — they were uncommitted duplicates of work the sibling patch owns and commits separately in its own branch). Final pushed state contains only this patch's intended 4 files, confirmed via `git diff origin/main --stat` post-rebase.

## Restart required

```text
No restart required.
```
Pure library change; consuming services (`orion-hub`, `orion-memory-crystallizer`, `orion-memory-consolidation`) pick it up on their next normal rebuild/restart, no special action.

## Risks / concerns

- Severity: Low — the tiering thresholds are a first-cut heuristic (explicitly named as such in the spec). Real-world calibration against post-deploy data (spec acceptance check 1: query the confidence distribution on new rows after deployment) is a natural follow-up, not blocking for this patch.
- Severity: Low — no retroactive backfill of the 164 existing `"likely"` rows, matching the spec's explicit non-goal. They'll pick up real confidence only when/if they're independently reinforced going forward.