### PR TITLE
Feat/recall reinforcement decay wiring

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-recall-reinforcement-decay-wiring-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-recall-reinforcement-decay-wiring-pr.md
@@ -1,0 +1,120 @@
+# PR report: wire recall_boost() and decay-at-read into live recall
+
+Implements `docs/superpowers/specs/2026-07-13-memory-recall-reinforcement-decay-wiring-spec.md` in full — both items ship together per the spec's non-negotiable requirement (reinforcement without decay would only grow the ceiling-pinned fraction this codebase has already been burned by once).
+
+## Summary
+
+- `dynamics.py::recall_boost()` and `decayed_activation()` existed, fully unit-tested, with **zero live call sites**. Live data showed 55/100 active crystallizations already at the activation ceiling with no recall-time reinforcement ever having fired — a live precursor to the exact saturation bug already shipped once in this codebase (homeostatic drives pinned flat).
+- `active_packet.py`'s ranking key now reads `decayed_activation(c, now=...)` instead of the raw stored value — decay is live everywhere ranking happens, no cron job, no new service.
+- `retriever.py::retrieve_active_packet()` gains an optional `pool` param. After a packet is finalized, every crystallization that actually appears in `crystallization_refs` (not every candidate considered) gets `recall_boost()` applied and persisted.
+- Hard invariant enforced by a dedicated test: `confidence`/`salience` are provably unchanged across any ordering of `recall_boost()`/`decay()` calls.
+- New standing gate script, `scripts/check_activation_saturation.py` — the acceptance-check-1 ship/no-ship criterion from the spec, runnable by anyone, anytime.
+- Live-verified end to end against real Postgres: a real row's activation moved by exactly the `recall_boost()` formula, confidence/salience genuinely unchanged.
+
+## Outcome moved
+
+The one dynamics signal with real variance (`activation`) now actually responds to real usage instead of being a write-once value from formation. Decay is live in ranking. The saturation gate that would have caught this codebase's last flat-pin bug earlier now exists as a standing, re-runnable check.
+
+## Current architecture (before this patch)
+
+`dynamics.py` had `recall_boost()` (boost=0.08) and `decay()`/`decayed_activation()` fully written and unit-tested in isolation — reachable from nowhere in the live path. `active_packet.py:55` read `c.dynamics.activation` directly.
+
+## Architecture touched
+
+`orion/memory/crystallization/{active_packet.py,retriever.py}`, two one-line pass-through additions in `orion-hub`/`orion-recall`'s existing `retrieve_active_packet()` callers, one new top-level script. No schema, bus, or `.env` changes — every field and function this patch wires already existed.
+
+## Files changed
+
+- `orion/memory/crystallization/active_packet.py`: ranking key uses `decayed_activation(c, now=ranking_time)`; `build_active_packet()` gained an optional `now` param (defaults to wall-clock).
+- `orion/memory/crystallization/retriever.py`: `retrieve_active_packet()` gained an optional `pool` param; new `_apply_recall_boost()`/`_persist_recall_boost()` helpers, called after packet finalization.
+- `services/orion-hub/scripts/crystallization_routes.py`, `services/orion-recall/app/collectors/active_packet.py`: pass their already-in-scope `pool` through to `retrieve_active_packet()` — one line each.
+- `scripts/check_activation_saturation.py` (new): standing gate, `POSTGRES_URI`-driven, `--fail-above` for CI-style regression checks.
+- `tests/test_memory_crystallization_dynamics.py`: +260 lines — `TestRecallBoostWiring` (5 tests), `TestDecayAtRankingReadSite` (3 tests), `TestRecallBoostDecayInvariant` (1 test), covering all 4 spec acceptance checks.
+
+## Design decisions worth flagging
+
+**Refetch-before-persist.** `_persist_recall_boost()` refetches the freshest row via `get_crystallization()` immediately before boosting and persisting, rather than reusing the snapshot collected at the start of retrieval. `update_crystallization()` does a full-row UPDATE (the existing pattern, matching `reinforce()`'s call sites) — persisting a stale snapshot risks clobbering a concurrent governance write. Refetching narrows the staleness window from "however long the whole retrieval took" (embed/chroma/graphiti round trips included) down to "between refetch and write." It does not eliminate the race (no transaction/row-lock) — that would need changing `repository.py`'s persistence contract, explicitly out of scope for this call-site-only patch per the spec. Documented as a known, accepted limitation, not silently left unaddressed.
+
+**Concurrent persistence.** Multiple refs in one packet are boosted+persisted via `asyncio.gather` — each row's update is independent, no reason to serialize.
+
+**Graceful degradation.** `pool=None` (offline/test callers) is a no-op, not an error. A persistence failure for one crystallization logs a warning and does not raise or affect the returned packet.
+
+## Schema / bus / API changes
+
+None. `retrieve_active_packet()`'s new `pool` param is optional and backward-compatible — every existing caller not updated in this patch continues to work unchanged (degrades to no persistence).
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+$ source venv/bin/activate && python -m pytest tests/test_memory_crystallization_dynamics.py -v
+22 passed in 0.47s
+```
+All 4 spec acceptance checks covered: head-to-head recall competition (`test_recall_boost_wins_contested_bucket_slot`), decay reduces rank for disused items (`test_disused_item_loses_contested_slot_to_recently_recalled_competitor`), the confidence/salience invariant (`test_confidence_and_salience_unchanged_across_all_orderings`), no regression to `reinforce()`'s Phase 2 call sites (`TestReinforce` unchanged, still passing).
+
+```text
+$ python -m pytest tests/test_memory_crystallization_dynamics.py tests/test_memory_crystallization.py \
+    tests/test_memory_crystallization_concept_relation.py tests/test_encode_reinforce_not_duplicate.py \
+    services/orion-recall/tests/ services/orion-hub/tests/test_crystallization_routes_contract.py \
+    orion/memory/crystallization/tests/ -q
+4 failed, 173 passed, 7 warnings in 8.30s
+```
+All 4 failures independently confirmed pre-existing on clean `origin/main` earlier this same session (same test names, same failures, unrelated to this patch — `TestMemoryCardBackwardCompat` registry-gap issue and 3 `orion-recall` vector/gating tests).
+
+All output above independently re-run by the orchestrator, not taken from the implementing agent's report alone.
+
+## Evals run
+
+No eval harness applies. The live end-to-end verification below is the standard this session holds every recall-quality claim to.
+
+## Docker/build/smoke checks
+
+```text
+# Standing saturation gate, independently re-run by orchestrator:
+$ POSTGRES_URI=postgresql://postgres:postgres@127.0.0.1:55432/conjourney python scripts/check_activation_saturation.py
+activation_saturation: 55/102 active crystallizations at or above activation=0.99 (53.9% ceiling-pinned)
+```
+Ceiling count held flat at 55 (matches spec's original 55/100 baseline); fraction actually decreased slightly (53.9% vs 55.0%) as total active count grew — no regression.
+
+```text
+# Live end-to-end smoke against real Postgres, independently written and run by the orchestrator
+# (not the implementing agent's script):
+BEFORE id=32c50000-... activation=0.3612 reinforcement_count=0 confidence=likely salience=0.764
+crystallization_refs=['32c50000-...']
+AFTER  id=32c50000-... activation=0.4123 reinforcement_count=0 confidence=likely salience=0.764
+expected_activation=0.4123 actual=0.4123 match=True
+confidence_unchanged=True salience_unchanged=True
+```
+`0.3612 + (1 - 0.3612) * 0.08 = 0.4123` — exact match to `recall_boost()`'s formula. A real row moved, confirmed by independent direct query, not by trusting the function's return value.
+
+## Review findings fixed
+
+Implementing agent ran its own code-review subagent pass (2 parallel finder angles) before returning:
+- **Fixed**: `update_crystallization`'s full-row UPDATE now fires on every recall (not just rare dedup) against a snapshot that could be stale after embed/chroma/graphiti round trips — added the refetch-before-persist mitigation described above, with a dedicated regression test.
+- **Fixed**: sequential per-item persistence changed to `asyncio.gather`.
+- **Fixed**: `check_activation_saturation.py` initially had no way to fail a CI-style check — added `--fail-above`.
+- **Not fixed, by design**: decay is read-time-only and never persists a decrease — this is exactly the spec's stated scope (retirement/persisted-decay is an explicitly deferred, heavier follow-on needing governor review), not an oversight. See Risks below.
+
+**Orchestrator-caught concurrency incident (not a code defect):** mid-implementation, `git stash`/`pop` (run to isolate a pre-existing test failure) raced with a concurrent agent's stash operation in a *different* worktree — `refs/stash` is shared across all worktrees in a repository by git design, not scoped per-worktree. The agent's own work briefly vanished from its working tree; root-caused via `git fsck --unreachable` (both agents' stash entries were preserved as dangling commits, not yet garbage-collected) and fully recovered — verified byte-identical to the pre-incident diff. Orchestrator independently confirmed the sibling agent's dangling stash (`96aa0ad5...`) was a fully-redundant duplicate of already-verified, already-pushed work on `feat/crystallization-confidence-assignment` — no data was lost on either side. Flagging as a real, reproducible operational hazard for future concurrent multi-worktree sessions on this host, not something this PR's diff needed to change.
+
+## Restart required
+
+```text
+No restart required for the code change itself (pure Python, no schema/env/config changes).
+```
+`orion-hub` and `orion-recall` pick this up on their normal next deploy/restart cycle.
+
+## Risks / concerns
+
+- Severity: Medium — stored `dynamics.activation` is now monotonically non-decreasing per row (`recall_boost`/`reinforce` only push up; decay is read-time-only, never persists a decrease). The saturation gate's *stored* metric can therefore only stay flat or grow under this patch alone — it does not by itself prove ranking correctness. Ranking correctness is separately proven by the decay-at-read tests (a stale item's *effective* rank at query time is correctly demoted even though its *stored* value hasn't moved). Retirement — the mechanism that would let stored activation actually come back down — is explicitly deferred pending governor review, matching the spec's own phasing.
+- Severity: Low — the refetch-before-persist mitigation narrows but does not eliminate the read-modify-write race on `update_crystallization`'s full-row UPDATE. A full fix needs either a partial-column UPDATE or optimistic concurrency in `repository.py` — explicitly out of scope for this call-site-only patch.
+- Severity: Low — this PR and the already-pushed `feat/orion-recall-retrieval-event-logging` PR both touch `services/orion-recall/app/collectors/active_packet.py`, on adjacent lines within the same function (this PR adds `pool=pool,` inside the `retrieve_active_packet(...)` call; the other PR adds a new block immediately after it). Both are independently valid and mergeable against current `main` on their own — whichever merges second will likely need a small rebase to resolve proximity, not a real logical conflict (the two changes don't touch the same lines).
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/recall-reinforcement-decay-wiring?expand=1`

--- a/orion/memory/crystallization/active_packet.py
+++ b/orion/memory/crystallization/active_packet.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
+from orion.memory.crystallization.dynamics import decayed_activation
 from orion.memory.crystallization.recall_eligibility import eligible_for_recall
 from orion.memory.crystallization.schemas import ActiveMemoryPacketV1, MemoryCrystallizationV1
 
@@ -47,12 +49,16 @@ def build_active_packet(
     task_type: str | None = None,
     project_id: str | None = None,
     session_id: str | None = None,
+    now: datetime | None = None,
 ) -> ActiveMemoryPacketV1:
+    ranking_time = now if now is not None else datetime.now(timezone.utc)
     active = [c for c in crystallizations if eligible_for_recall(c)]
     if project_id:
         active = [c for c in active if project_id in c.scope or c.scope == []]
     active.sort(
-        key=lambda c: (c.dynamics.activation or 0.0) * (c.salience or 0.5) + _task_boost(c.kind, task_type),
+        key=lambda c: (
+            decayed_activation(c, now=ranking_time) * (c.salience or 0.5) + _task_boost(c.kind, task_type)
+        ),
         reverse=True,
     )
 

--- a/orion/memory/crystallization/retriever.py
+++ b/orion/memory/crystallization/retriever.py
@@ -1,14 +1,67 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+from datetime import datetime, timezone
 from typing import Any, Optional
+
+import asyncpg
 
 from orion.memory.crystallization.active_packet import build_active_packet
 from orion.memory.crystallization.chroma_query import query_chroma_collection
+from orion.memory.crystallization.dynamics import recall_boost
 from orion.memory.crystallization.projection_graphiti import GraphitiAdapter
+from orion.memory.crystallization.repository import get_crystallization, update_crystallization
 from orion.memory.crystallization.schemas import ActiveMemoryPacketV1, MemoryCrystallizationV1
 
 logger = logging.getLogger(__name__)
+
+
+async def _persist_recall_boost(
+    pool: "asyncpg.Pool",
+    crystallization_id: str,
+    *,
+    now: datetime,
+) -> None:
+    try:
+        current = await get_crystallization(pool, crystallization_id)
+        if current is None:
+            return
+        updated = recall_boost(current, now=now)
+        await update_crystallization(pool, updated)
+    except Exception as exc:
+        logger.warning(
+            "retriever_recall_boost_failed crystallization_id=%s error=%s", crystallization_id, exc
+        )
+
+
+async def _apply_recall_boost(
+    *,
+    pool: "asyncpg.Pool | None",
+    crystallization_refs: list[str],
+    now: datetime,
+) -> None:
+    """Reinforce every crystallization that actually made it into the render budget.
+
+    Recall is a weaker signal than recurrence (see `dynamics.recall_boost`'s docstring):
+    only what appears in `crystallization_refs` -- not every candidate considered --
+    counts as "this got recalled". Refetches each row immediately before mutating,
+    rather than reusing the in-memory snapshot collected at the start of retrieval --
+    `update_crystallization()` does a full-row UPDATE (existing pattern, matches
+    `reinforce()`'s call sites), so persisting from a stale snapshot risks clobbering a
+    concurrent governance write. Refetching narrows that staleness window from "however
+    long this whole retrieval took" (embed/chroma/graphiti round trips included) down to
+    "between this refetch and this write" -- it does not eliminate the race (no
+    transaction/row-lock), just shrinks it to the cheapest fix available without
+    changing `repository.py`'s persistence contract. Persists concurrently since each
+    row's update is independent. Degrades gracefully to a no-op when `pool` is absent
+    (e.g. offline/test callers), never raises.
+    """
+    if pool is None or not crystallization_refs:
+        return
+    await asyncio.gather(
+        *(_persist_recall_boost(pool, cid, now=now) for cid in crystallization_refs)
+    )
 
 
 async def _embed_query(
@@ -50,6 +103,7 @@ async def retrieve_active_packet(
     embed_host_url: str = "",
     graphiti_adapter: GraphitiAdapter | None = None,
     seed_crystallization_id: str | None = None,
+    pool: "asyncpg.Pool | None" = None,
 ) -> ActiveMemoryPacketV1:
     """Multi-rail retrieval: Postgres crystallizations + cards + Chroma + Graphiti."""
     chroma_hits: list[dict[str, Any]] = []
@@ -124,4 +178,11 @@ async def retrieve_active_packet(
     trace["graphiti_refs"] = len(graphiti_refs)
     trace["extra_crystallization_ids_from_chroma"] = sorted(extra_crystallization_ids)
     packet.retrieval_trace = trace
+
+    await _apply_recall_boost(
+        pool=pool,
+        crystallization_refs=packet.crystallization_refs,
+        now=datetime.now(timezone.utc),
+    )
+
     return packet

--- a/scripts/check_activation_saturation.py
+++ b/scripts/check_activation_saturation.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Standing saturation gate for `memory_crystallizations.dynamics.activation`.
+
+Context: live-data check on 2026-07-13 found 55% of active crystallizations already
+sitting at the activation ceiling (1.00) with zero recall-time reinforcement having
+ever fired -- see docs/superpowers/specs/2026-07-13-memory-recall-reinforcement-decay-
+wiring-spec.md. Wiring `recall_boost()` (orion/memory/crystallization/dynamics.py)
+without `decay()` in the same patch would only grow that ceiling-pinned fraction over
+time. This codebase has already shipped exactly this saturation bug once before
+(homeostatic drives pinned flat because a leaky integrator's soft-saturate went stale).
+
+This script is the acceptance-check-1 gate from that spec: it is meant to be re-run by
+anyone, anytime, before and after a real usage window (not a synthetic smoke burst) --
+it is not a one-time manual query. If the ceiling-saturated fraction *increases* across
+two runs, that is a fail; revert the patch, don't ship as-is.
+
+Usage:
+    POSTGRES_URI=postgresql://user:pass@host:port/db python scripts/check_activation_saturation.py
+    python scripts/check_activation_saturation.py --postgres-uri postgresql://...
+    python scripts/check_activation_saturation.py --ceiling 0.99 --json
+    python scripts/check_activation_saturation.py --fail-above 0.55   # exit 1 if fraction exceeds this
+
+Note on --fail-above: this repo has no persisted baseline to auto-diff two runs against
+(and no cross-run state store this script should invent -- see the spec's own framing:
+compare "before" vs. "after a real usage window" by hand, or pass the "before" run's
+fraction here for a one-shot regression check). Without --fail-above this script only
+reports; it always exits 0 on a successful query, matching "standing check you re-run
+and read", not "stateful CI gate".
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/check_activation_saturation.py` puts scripts/ on
+# sys.path[0], which shadows stdlib modules (same issue documented in
+# scripts/check_inner_state_registry.py / scripts/check_single_consumer_channels.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+_QUERY = """
+select
+    count(*) filter (where (dynamics->>'activation')::float >= $1) as ceiling,
+    count(*) as total
+from memory_crystallizations
+where status = 'active'
+"""
+
+
+async def _query_saturation(postgres_uri: str, *, ceiling_threshold: float) -> tuple[int, int]:
+    import asyncpg
+
+    conn = await asyncpg.connect(postgres_uri)
+    try:
+        row = await conn.fetchrow(_QUERY, ceiling_threshold)
+    finally:
+        await conn.close()
+    return int(row["ceiling"]), int(row["total"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--postgres-uri",
+        default=os.getenv("POSTGRES_URI", ""),
+        help="Postgres DSN. Defaults to $POSTGRES_URI (e.g. services/orion-hub/.env).",
+    )
+    parser.add_argument(
+        "--ceiling",
+        type=float,
+        default=0.99,
+        help="activation value counted as 'ceiling-pinned' (default: 0.99).",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of prose.")
+    parser.add_argument(
+        "--fail-above",
+        type=float,
+        default=None,
+        metavar="FRACTION",
+        help=(
+            "exit 1 if the ceiling-pinned fraction exceeds this value (e.g. the fraction "
+            "from a prior 'before' run). Omit to run in report-only mode (always exit 0 "
+            "on a successful query)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if not args.postgres_uri.strip():
+        print(
+            "check_activation_saturation: no --postgres-uri given and $POSTGRES_URI is unset. "
+            "Check services/orion-hub/.env for POSTGRES_URI.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        ceiling_count, total_count = asyncio.run(
+            _query_saturation(args.postgres_uri, ceiling_threshold=args.ceiling)
+        )
+    except Exception as exc:
+        print(f"check_activation_saturation: query failed -- {exc}", file=sys.stderr)
+        return 2
+
+    fraction = (ceiling_count / total_count) if total_count else 0.0
+
+    if args.json:
+        print(json.dumps({
+            "ceiling_threshold": args.ceiling,
+            "ceiling_count": ceiling_count,
+            "total_active": total_count,
+            "ceiling_fraction": fraction,
+        }))
+    else:
+        print(
+            f"activation_saturation: {ceiling_count}/{total_count} active crystallizations "
+            f"at or above activation={args.ceiling} ({fraction:.1%} ceiling-pinned)"
+        )
+        if args.fail_above is None:
+            print(
+                "Compare this fraction against a prior run from before real usage of "
+                "recall_boost()+decay() -- an INCREASE is a fail, revert the patch. "
+                "(Pass --fail-above <prior-fraction> to make this check exit 1 automatically.)"
+            )
+
+    if args.fail_above is not None and fraction > args.fail_above:
+        print(
+            f"check_activation_saturation FAILED: {fraction:.1%} exceeds --fail-above "
+            f"{args.fail_above:.1%}",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-hub/scripts/crystallization_routes.py
+++ b/services/orion-hub/scripts/crystallization_routes.py
@@ -512,6 +512,7 @@ async def memory_active_packet(
         embed_host_url=getattr(s, "CRYSTALLIZER_EMBED_HOST_URL", "") or "",
         graphiti_adapter=_graphiti(request) if seed_id else None,
         seed_crystallization_id=seed_id or None,
+        pool=pool,
     )
 
     event_id = await insert_retrieval_event(

--- a/services/orion-recall/app/collectors/active_packet.py
+++ b/services/orion-recall/app/collectors/active_packet.py
@@ -160,6 +160,7 @@ async def fetch_active_packet_fragments(
         embed_host_url=str(getattr(settings, "RECALL_CARDS_EMBEDDING_URL", "") or ""),
         graphiti_adapter=graphiti,
         seed_crystallization_id=seed_id or None,
+        pool=pool,
     )
 
     fragments: list[dict[str, Any]] = []

--- a/tests/test_memory_crystallization_dynamics.py
+++ b/tests/test_memory_crystallization_dynamics.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import itertools
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
 
+import pytest
+
+from orion.memory.crystallization.active_packet import build_active_packet
 from orion.memory.crystallization.dynamics import (
     decay,
     decayed_activation,
@@ -12,9 +17,11 @@ from orion.memory.crystallization.dynamics import (
     should_retire,
 )
 from orion.memory.crystallization.proposer import propose
+from orion.memory.crystallization.retriever import retrieve_active_packet
 from orion.memory.crystallization.schemas import (
     CrystallizationDynamicsV1,
     CrystallizationEvidenceRefV1,
+    CrystallizationGovernanceV1,
     MemoryCrystallizationProposeRequestV1,
     MemoryCrystallizationV1,
 )
@@ -34,6 +41,39 @@ def _crys() -> MemoryCrystallizationV1:
         proposed_by="test",
     )
     return propose(req)
+
+
+def _active_crys(
+    *,
+    activation: float,
+    salience: float = 0.5,
+    crystallization_id: str,
+    summary: str = "test memory",
+    formed_at: datetime | None = None,
+    decay_half_life_days: float = 30.0,
+) -> MemoryCrystallizationV1:
+    """Build an `active`-status crystallization with real dynamics, bypassing the full
+    propose/governor pipeline -- mirrors the helper pattern used in
+    services/orion-recall/tests/test_active_packet_activation_floor.py.
+    """
+    now = formed_at if formed_at is not None else _now()
+    return MemoryCrystallizationV1(
+        crystallization_id=crystallization_id,
+        kind="semantic",
+        subject="s",
+        summary=summary,
+        status="active",
+        confidence="likely",
+        salience=salience,
+        dynamics=CrystallizationDynamicsV1(
+            activation=activation,
+            formed_at=now,
+            decay_half_life_days=decay_half_life_days,
+        ),
+        governance=CrystallizationGovernanceV1(proposed_by="t"),
+        created_at=now,
+        updated_at=now,
+    )
 
 
 class TestDynamicsSchema:
@@ -145,3 +185,223 @@ class TestRetirement:
         crys = reinforce(crys, now=_now(), boost=0.5)
         crys = reinforce(crys, now=_now(), boost=0.5)
         assert should_retire(crys, now=_now(), floor=0.05) is False
+
+
+# --- Phase 4+5 wiring: recall_boost + decay at the real call sites ------------------
+#
+# Acceptance checks from docs/superpowers/specs/2026-07-13-memory-recall-reinforcement-
+# decay-wiring-spec.md. `retrieve_active_packet` persists via `update_crystallization`,
+# which is patched here rather than hitting real Postgres -- the persistence *pattern*
+# (mirroring `reinforce()`'s existing call sites) is exercised in orion/memory/crystallization/
+# retriever.py itself; these tests exercise the ranking behavior it's supposed to produce.
+
+
+class TestRecallBoostWiring:
+    @pytest.mark.asyncio
+    async def test_recall_boost_wins_contested_bucket_slot(self, monkeypatch):
+        """Acceptance check 1: head-to-head recall competition.
+
+        Two crystallizations seeded with equal activation/salience. One is recalled via
+        repeated `retrieve_active_packet()` calls with distinct queries; the other is never
+        touched. The reinforced one must win a subsequent contested ranking.
+        """
+        store: dict[str, MemoryCrystallizationV1] = {
+            "crys_recalled": _active_crys(activation=0.3, salience=0.5, crystallization_id="crys_recalled"),
+            "crys_untouched": _active_crys(activation=0.3, salience=0.5, crystallization_id="crys_untouched"),
+        }
+
+        async def _fetch(pool, cid):
+            return store.get(cid)
+
+        async def _persist(pool, crystallization):
+            store[crystallization.crystallization_id] = crystallization
+
+        monkeypatch.setattr(
+            "orion.memory.crystallization.retriever.get_crystallization",
+            AsyncMock(side_effect=_fetch),
+        )
+        monkeypatch.setattr(
+            "orion.memory.crystallization.retriever.update_crystallization",
+            AsyncMock(side_effect=_persist),
+        )
+
+        pool = object()  # non-None sentinel; the real call is mocked, so no live DB needed
+        for query in ("first distinct query", "second distinct query", "third distinct query"):
+            await retrieve_active_packet(
+                query=query,
+                crystallizations=[store["crys_recalled"]],
+                pool=pool,
+            )
+
+        assert store["crys_recalled"].dynamics.activation > 0.3
+        assert store["crys_untouched"].dynamics.activation == 0.3
+        # Untouched item's other dynamics fields never moved.
+        assert store["crys_untouched"].dynamics.last_recalled_at is None
+
+        packet = await retrieve_active_packet(
+            query="ambiguous query naming both",
+            crystallizations=[store["crys_recalled"], store["crys_untouched"]],
+            pool=pool,
+        )
+        assert packet.crystallization_refs[0] == "crys_recalled"
+
+    @pytest.mark.asyncio
+    async def test_recall_boost_only_applies_to_items_actually_in_refs(self, monkeypatch):
+        """Only what made it into `packet.crystallization_refs` gets boosted -- not every
+        candidate considered. An ineligible (below-floor) candidate must not be touched."""
+        eligible = _active_crys(activation=0.3, salience=0.5, crystallization_id="crys_eligible")
+        ineligible = _active_crys(activation=0.01, salience=0.5, crystallization_id="crys_ineligible")
+
+        fetch_mock = AsyncMock(return_value=eligible)
+        update_mock = AsyncMock()
+        monkeypatch.setattr(
+            "orion.memory.crystallization.retriever.get_crystallization",
+            fetch_mock,
+        )
+        monkeypatch.setattr(
+            "orion.memory.crystallization.retriever.update_crystallization",
+            update_mock,
+        )
+
+        packet = await retrieve_active_packet(
+            query="test",
+            crystallizations=[eligible, ineligible],
+            pool=object(),
+        )
+
+        assert packet.crystallization_refs == ["crys_eligible"]
+        update_mock.assert_called_once()
+        (_, persisted), _kwargs = update_mock.call_args
+        assert persisted.crystallization_id == "crys_eligible"
+
+    @pytest.mark.asyncio
+    async def test_recall_boost_skips_persistence_when_pool_absent(self):
+        """Pool defaults to None (offline/test callers) -- must degrade gracefully, never raise."""
+        crys = _active_crys(activation=0.3, salience=0.5, crystallization_id="crys_no_pool")
+        packet = await retrieve_active_packet(query="test", crystallizations=[crys])
+        assert packet.crystallization_refs == ["crys_no_pool"]
+
+    @pytest.mark.asyncio
+    async def test_recall_boost_persistence_failure_does_not_raise(self, monkeypatch):
+        """A DB error during persistence must not break the retrieval path."""
+        crys = _active_crys(activation=0.3, salience=0.5, crystallization_id="crys_persist_fail")
+        monkeypatch.setattr(
+            "orion.memory.crystallization.retriever.get_crystallization",
+            AsyncMock(return_value=crys),
+        )
+        monkeypatch.setattr(
+            "orion.memory.crystallization.retriever.update_crystallization",
+            AsyncMock(side_effect=RuntimeError("db down")),
+        )
+        packet = await retrieve_active_packet(query="test", crystallizations=[crys], pool=object())
+        assert packet.crystallization_refs == ["crys_persist_fail"]
+
+    @pytest.mark.asyncio
+    async def test_recall_boost_refetches_fresh_row_before_persisting(self, monkeypatch):
+        """The in-memory snapshot passed via `crystallizations=` can be stale by the time
+        persistence runs (embed/chroma/graphiti round trips happen first). Persisting a
+        stale snapshot through `update_crystallization`'s full-row UPDATE would clobber a
+        concurrent governance write -- `_apply_recall_boost` must refetch the freshest row
+        via `get_crystallization()` immediately before boosting+persisting instead."""
+        stale_snapshot = _active_crys(activation=0.3, salience=0.5, crystallization_id="crys_race")
+        fresh_row = stale_snapshot.model_copy(deep=True)
+        fresh_row.confidence = "certain"  # simulates a concurrent governance write
+        fresh_row.dynamics.activation = 0.7  # simulates a concurrent reinforcement
+
+        monkeypatch.setattr(
+            "orion.memory.crystallization.retriever.get_crystallization",
+            AsyncMock(return_value=fresh_row),
+        )
+        update_mock = AsyncMock()
+        monkeypatch.setattr(
+            "orion.memory.crystallization.retriever.update_crystallization",
+            update_mock,
+        )
+
+        await retrieve_active_packet(query="test", crystallizations=[stale_snapshot], pool=object())
+
+        update_mock.assert_called_once()
+        (_, persisted), _kwargs = update_mock.call_args
+        # Persisted row is boosted from the FRESH activation (0.7), not the stale
+        # snapshot's (0.3), and preserves the concurrent confidence change.
+        assert persisted.dynamics.activation > 0.7
+        assert persisted.confidence == "certain"
+
+
+class TestDecayAtRankingReadSite:
+    def test_decayed_activation_measurably_lower_than_stored_value(self):
+        formed = _now()
+        stale = _active_crys(
+            activation=0.6, salience=0.5, crystallization_id="crys_stale",
+            formed_at=formed, decay_half_life_days=1.0,
+        )
+        later = formed + timedelta(days=5)  # 5 half-lives
+        stored_value = stale.dynamics.activation
+        decayed_value = decayed_activation(stale, now=later)
+        assert decayed_value < stored_value - 0.3  # measurably lower, not a rounding wobble
+
+    def test_disused_item_loses_contested_slot_to_recently_recalled_competitor(self):
+        """Acceptance check 2: decay actually reduces rank at the ranking read site
+        (active_packet.py), not just in isolation."""
+        formed = _now()
+        stale = _active_crys(
+            activation=0.6, salience=0.5, crystallization_id="crys_stale",
+            formed_at=formed, decay_half_life_days=1.0,
+        )
+        fresh = _active_crys(
+            activation=0.6, salience=0.5, crystallization_id="crys_fresh",
+            formed_at=formed, decay_half_life_days=1.0,
+        )
+        later = formed + timedelta(days=5)
+        # Simulate `fresh` having been recalled moments before ranking time -- resets its
+        # decay reference clock (same mechanic `test_reinforcement_resets_the_decay_clock`
+        # already proves for reinforce()).
+        fresh.dynamics.last_recalled_at = later - timedelta(minutes=1)
+
+        packet = build_active_packet(
+            query="test", crystallizations=[stale, fresh], now=later,
+        )
+        assert packet.crystallization_refs[0] == "crys_fresh"
+        assert packet.crystallization_refs[1] == "crys_stale"
+
+    def test_build_active_packet_without_now_still_ranks_correctly(self):
+        """No-regression check: `now` is optional, defaults to current time, and freshly
+        formed/equal-salience items with unequal activation still rank as before."""
+        low = _active_crys(activation=0.2, salience=0.5, crystallization_id="crys_low")
+        high = _active_crys(activation=0.9, salience=0.5, crystallization_id="crys_high")
+        packet = build_active_packet(query="test", crystallizations=[low, high])
+        assert packet.crystallization_refs[0] == "crys_high"
+
+
+class TestRecallBoostDecayInvariant:
+    """Acceptance check 3 (hard invariant): recall_boost()/decay() move `activation`
+    (and recall bookkeeping fields) only. `confidence`, `salience`, and every other
+    non-dynamics field must be provably unchanged, in any call order."""
+
+    def test_confidence_and_salience_unchanged_across_all_orderings(self):
+        base = _active_crys(activation=0.3, salience=0.37, crystallization_id="crys_invariant")
+        base.confidence = "likely"
+        base.dynamics.decay_half_life_days = 10.0
+
+        now = _now()
+        op_specs = [
+            ("recall", now + timedelta(hours=1)),
+            ("decay", now + timedelta(hours=2)),
+            ("recall", now + timedelta(hours=3)),
+            ("decay", now + timedelta(hours=4)),
+        ]
+
+        checked_any = False
+        for order in itertools.permutations(range(len(op_specs))):
+            state = base.model_copy(deep=True)
+            for idx in order:
+                kind, ts = op_specs[idx]
+                state = recall_boost(state, now=ts) if kind == "recall" else decay(state, now=ts)
+                assert state.confidence == base.confidence
+                assert state.salience == base.salience
+                assert state.summary == base.summary
+                assert state.subject == base.subject
+                assert state.status == base.status
+                assert state.kind == base.kind
+                checked_any = True
+        assert checked_any


### PR DESCRIPTION
# PR report: wire recall_boost() and decay-at-read into live recall

Implements `docs/superpowers/specs/2026-07-13-memory-recall-reinforcement-decay-wiring-spec.md` in full — both items ship together per the spec's non-negotiable requirement (reinforcement without decay would only grow the ceiling-pinned fraction this codebase has already been burned by once).

## Summary

- `dynamics.py::recall_boost()` and `decayed_activation()` existed, fully unit-tested, with **zero live call sites**. Live data showed 55/100 active crystallizations already at the activation ceiling with no recall-time reinforcement ever having fired — a live precursor to the exact saturation bug already shipped once in this codebase (homeostatic drives pinned flat).
- `active_packet.py`'s ranking key now reads `decayed_activation(c, now=...)` instead of the raw stored value — decay is live everywhere ranking happens, no cron job, no new service.
- `retriever.py::retrieve_active_packet()` gains an optional `pool` param. After a packet is finalized, every crystallization that actually appears in `crystallization_refs` (not every candidate considered) gets `recall_boost()` applied and persisted.
- Hard invariant enforced by a dedicated test: `confidence`/`salience` are provably unchanged across any ordering of `recall_boost()`/`decay()` calls.
- New standing gate script, `scripts/check_activation_saturation.py` — the acceptance-check-1 ship/no-ship criterion from the spec, runnable by anyone, anytime.
- Live-verified end to end against real Postgres: a real row's activation moved by exactly the `recall_boost()` formula, confidence/salience genuinely unchanged.

## Outcome moved

The one dynamics signal with real variance (`activation`) now actually responds to real usage instead of being a write-once value from formation. Decay is live in ranking. The saturation gate that would have caught this codebase's last flat-pin bug earlier now exists as a standing, re-runnable check.

## Current architecture (before this patch)

`dynamics.py` had `recall_boost()` (boost=0.08) and `decay()`/`decayed_activation()` fully written and unit-tested in isolation — reachable from nowhere in the live path. `active_packet.py:55` read `c.dynamics.activation` directly.

## Architecture touched

`orion/memory/crystallization/{active_packet.py,retriever.py}`, two one-line pass-through additions in `orion-hub`/`orion-recall`'s existing `retrieve_active_packet()` callers, one new top-level script. No schema, bus, or `.env` changes — every field and function this patch wires already existed.

## Files changed

- `orion/memory/crystallization/active_packet.py`: ranking key uses `decayed_activation(c, now=ranking_time)`; `build_active_packet()` gained an optional `now` param (defaults to wall-clock).
- `orion/memory/crystallization/retriever.py`: `retrieve_active_packet()` gained an optional `pool` param; new `_apply_recall_boost()`/`_persist_recall_boost()` helpers, called after packet finalization.
- `services/orion-hub/scripts/crystallization_routes.py`, `services/orion-recall/app/collectors/active_packet.py`: pass their already-in-scope `pool` through to `retrieve_active_packet()` — one line each.
- `scripts/check_activation_saturation.py` (new): standing gate, `POSTGRES_URI`-driven, `--fail-above` for CI-style regression checks.
- `tests/test_memory_crystallization_dynamics.py`: +260 lines — `TestRecallBoostWiring` (5 tests), `TestDecayAtRankingReadSite` (3 tests), `TestRecallBoostDecayInvariant` (1 test), covering all 4 spec acceptance checks.

## Design decisions worth flagging

**Refetch-before-persist.** `_persist_recall_boost()` refetches the freshest row via `get_crystallization()` immediately before boosting and persisting, rather than reusing the snapshot collected at the start of retrieval. `update_crystallization()` does a full-row UPDATE (the existing pattern, matching `reinforce()`'s call sites) — persisting a stale snapshot risks clobbering a concurrent governance write. Refetching narrows the staleness window from "however long the whole retrieval took" (embed/chroma/graphiti round trips included) down to "between refetch and write." It does not eliminate the race (no transaction/row-lock) — that would need changing `repository.py`'s persistence contract, explicitly out of scope for this call-site-only patch per the spec. Documented as a known, accepted limitation, not silently left unaddressed.

**Concurrent persistence.** Multiple refs in one packet are boosted+persisted via `asyncio.gather` — each row's update is independent, no reason to serialize.

**Graceful degradation.** `pool=None` (offline/test callers) is a no-op, not an error. A persistence failure for one crystallization logs a warning and does not raise or affect the returned packet.

## Schema / bus / API changes

None. `retrieve_active_packet()`'s new `pool` param is optional and backward-compatible — every existing caller not updated in this patch continues to work unchanged (degrades to no persistence).

## Env/config changes

None.

## Tests run

```text
$ source venv/bin/activate && python -m pytest tests/test_memory_crystallization_dynamics.py -v
22 passed in 0.47s
```
All 4 spec acceptance checks covered: head-to-head recall competition (`test_recall_boost_wins_contested_bucket_slot`), decay reduces rank for disused items (`test_disused_item_loses_contested_slot_to_recently_recalled_competitor`), the confidence/salience invariant (`test_confidence_and_salience_unchanged_across_all_orderings`), no regression to `reinforce()`'s Phase 2 call sites (`TestReinforce` unchanged, still passing).

```text
$ python -m pytest tests/test_memory_crystallization_dynamics.py tests/test_memory_crystallization.py \
    tests/test_memory_crystallization_concept_relation.py tests/test_encode_reinforce_not_duplicate.py \
    services/orion-recall/tests/ services/orion-hub/tests/test_crystallization_routes_contract.py \
    orion/memory/crystallization/tests/ -q
4 failed, 173 passed, 7 warnings in 8.30s
```
All 4 failures independently confirmed pre-existing on clean `origin/main` earlier this same session (same test names, same failures, unrelated to this patch — `TestMemoryCardBackwardCompat` registry-gap issue and 3 `orion-recall` vector/gating tests).

All output above independently re-run by the orchestrator, not taken from the implementing agent's report alone.

## Evals run

No eval harness applies. The live end-to-end verification below is the standard this session holds every recall-quality claim to.

## Docker/build/smoke checks

```text
# Standing saturation gate, independently re-run by orchestrator:
$ POSTGRES_URI=postgresql://postgres:postgres@127.0.0.1:55432/conjourney python scripts/check_activation_saturation.py
activation_saturation: 55/102 active crystallizations at or above activation=0.99 (53.9% ceiling-pinned)
```
Ceiling count held flat at 55 (matches spec's original 55/100 baseline); fraction actually decreased slightly (53.9% vs 55.0%) as total active count grew — no regression.

```text
# Live end-to-end smoke against real Postgres, independently written and run by the orchestrator
# (not the implementing agent's script):
BEFORE id=32c50000-... activation=0.3612 reinforcement_count=0 confidence=likely salience=0.764
crystallization_refs=['32c50000-...']
AFTER  id=32c50000-... activation=0.4123 reinforcement_count=0 confidence=likely salience=0.764
expected_activation=0.4123 actual=0.4123 match=True
confidence_unchanged=True salience_unchanged=True
```
`0.3612 + (1 - 0.3612) * 0.08 = 0.4123` — exact match to `recall_boost()`'s formula. A real row moved, confirmed by independent direct query, not by trusting the function's return value.

## Review findings fixed

Implementing agent ran its own code-review subagent pass (2 parallel finder angles) before returning:
- **Fixed**: `update_crystallization`'s full-row UPDATE now fires on every recall (not just rare dedup) against a snapshot that could be stale after embed/chroma/graphiti round trips — added the refetch-before-persist mitigation described above, with a dedicated regression test.
- **Fixed**: sequential per-item persistence changed to `asyncio.gather`.
- **Fixed**: `check_activation_saturation.py` initially had no way to fail a CI-style check — added `--fail-above`.
- **Not fixed, by design**: decay is read-time-only and never persists a decrease — this is exactly the spec's stated scope (retirement/persisted-decay is an explicitly deferred, heavier follow-on needing governor review), not an oversight. See Risks below.

**Orchestrator-caught concurrency incident (not a code defect):** mid-implementation, `git stash`/`pop` (run to isolate a pre-existing test failure) raced with a concurrent agent's stash operation in a *different* worktree — `refs/stash` is shared across all worktrees in a repository by git design, not scoped per-worktree. The agent's own work briefly vanished from its working tree; root-caused via `git fsck --unreachable` (both agents' stash entries were preserved as dangling commits, not yet garbage-collected) and fully recovered — verified byte-identical to the pre-incident diff. Orchestrator independently confirmed the sibling agent's dangling stash (`96aa0ad5...`) was a fully-redundant duplicate of already-verified, already-pushed work on `feat/crystallization-confidence-assignment` — no data was lost on either side. Flagging as a real, reproducible operational hazard for future concurrent multi-worktree sessions on this host, not something this PR's diff needed to change.

## Restart required

```text
No restart required for the code change itself (pure Python, no schema/env/config changes).
```
`orion-hub` and `orion-recall` pick this up on their normal next deploy/restart cycle.

## Risks / concerns

- Severity: Medium — stored `dynamics.activation` is now monotonically non-decreasing per row (`recall_boost`/`reinforce` only push up; decay is read-time-only, never persists a decrease). The saturation gate's *stored* metric can therefore only stay flat or grow under this patch alone — it does not by itself prove ranking correctness. Ranking correctness is separately proven by the decay-at-read tests (a stale item's *effective* rank at query time is correctly demoted even though its *stored* value hasn't moved). Retirement — the mechanism that would let stored activation actually come back down — is explicitly deferred pending governor review, matching the spec's own phasing.
- Severity: Low — the refetch-before-persist mitigation narrows but does not eliminate the read-modify-write race on `update_crystallization`'s full-row UPDATE. A full fix needs either a partial-column UPDATE or optimistic concurrency in `repository.py` — explicitly out of scope for this call-site-only patch.
- Severity: Low — this PR and the already-pushed `feat/orion-recall-retrieval-event-logging` PR both touch `services/orion-recall/app/collectors/active_packet.py`, on adjacent lines within the same function (this PR adds `pool=pool,` inside the `retrieve_active_packet(...)` call; the other PR adds a new block immediately after it). Both are independently valid and mergeable against current `main` on their own — whichever merges second will likely need a small rebase to resolve proximity, not a real logical conflict (the two changes don't touch the same lines).