### PR TITLE
fix(mesh-guardian): recover attention_only back to healthy on clean p…

### DIFF
--- a/services/orion-mesh-guardian/app/state_machine.py
+++ b/services/orion-mesh-guardian/app/state_machine.py
@@ -82,6 +82,18 @@ def transition(state: ServiceState, inp: TransitionInput, *, service_id: str = "
     corr = new_state.correlation_id
 
     if new_state.phase == ServicePhase.attention_only:
+        if inp.probe_status == "probe_ok" and not inp.equilibrium_bad:
+            new_state.phase = ServicePhase.healthy
+            new_state.consecutive_probe_fails = 0
+            attention_events.append(
+                _attention_event(
+                    severity="info",
+                    message=f"mesh health: {service_id} recovered",
+                    service_id=service_id,
+                    correlation_id=corr,
+                    event="recovery",
+                )
+            )
         return TransitionOutput(new_state=new_state, attention_events=attention_events)
 
     if new_state.phase == ServicePhase.post_check_grace:

--- a/services/orion-mesh-guardian/tests/test_state_machine.py
+++ b/services/orion-mesh-guardian/tests/test_state_machine.py
@@ -129,3 +129,20 @@ def test_max_attempts_moves_to_attention_only() -> None:
     state = ServiceState(phase=ServicePhase.unhealthy_confirmed, attempts_this_hour=3)
     out = transition(state, _inp(probe_status="probe_bad"), service_id="landing-pad")
     assert out.new_state.phase == ServicePhase.attention_only
+
+
+def test_attention_only_recovers_to_healthy_on_clean_probe() -> None:
+    state = ServiceState(phase=ServicePhase.attention_only, consecutive_probe_fails=4)
+    out = transition(state, _inp(probe_status="probe_ok", equilibrium_bad=False), service_id="landing-pad")
+    assert out.new_state.phase == ServicePhase.healthy
+    assert out.new_state.consecutive_probe_fails == 0
+    assert len(out.attention_events) == 1
+    assert out.attention_events[0]["severity"] == "info"
+    assert out.attention_events[0]["context"]["event"] == "recovery"
+
+
+def test_attention_only_stays_put_on_still_bad_probe() -> None:
+    state = ServiceState(phase=ServicePhase.attention_only, consecutive_probe_fails=4)
+    out = transition(state, _inp(probe_status="probe_bad"), service_id="landing-pad")
+    assert out.new_state.phase == ServicePhase.attention_only
+    assert out.attention_events == []


### PR DESCRIPTION
attention_only was a permanent dead end: once tripped (e.g. auto_remediate disabled), the state machine returned unconditionally with no path back to healthy, so alerts never auto-resolved even after the underlying service recovered. Mirror the recovery check already used in post_check_grace and suspect: on probe_ok + not equilibrium_bad, transition to healthy, reset consecutive_probe_fails, and emit an info-severity "recovery" attention_event.