### PR TITLE
fix(notify): persist attention acks to sql-writer instead of faking them

### DIFF
--- a/services/orion-notify/app/main.py
+++ b/services/orion-notify/app/main.py
@@ -286,58 +286,26 @@ async def attention_ack(
     x_orion_notify_token: Optional[str] = Header(default=None, alias="X-Orion-Notify-Token"),
 ) -> ChatAttentionState:
     _check_token(x_orion_notify_token)
-    # Ack is a state change. We don't have a specific "Ack Event" schema in the prompt,
-    # but we have "Receipt" for messages. Attention Ack is similar.
-    # However, existing code updates the record.
-    # We should probably define an event for this or reuse receipt?
-    # Attention is different from message receipt.
-    # We will use the generic persistence path or just log it?
-    # Wait, the prompt requirements: "3) publish durable write-intent events... notify.notification.request.v1, notify.notification.receipt.v1".
-    # It missed "Attention Ack".
-    # But "Attention" is stored in "NotificationRequestDB".
-    # If we want to persist Ack, we need an event.
-    # I'll re-use "notify.notification.receipt.v1" but map it?
-    # Receipt schema has "message_id". Attention has "attention_id".
-    # "NotificationRequestDB" has both message_id and attention_id columns.
-    # If I use receipt event with message_id=attention_id (UUID), it might work if the consumer handles it?
-    # The `NotificationReceiptDB` model (and event) has `message_id` and `receipt_type`.
-    # It doesn't have `attention_id`.
-    # This implies we might lose Attention Ack persistence unless I add a channel or schema.
-    # BUT, I must follow constraints "Minimal".
-    # I will skip attention ack persistence implementation if not strictly required by "notify.notification.receipt.v1" scope,
-    # OR I will try to fit it.
-    # Actually, `ChatAttentionAck` updates the `notify_requests` table.
-    # I should probably just return a mock state and log it, or publish a generic event.
-    # I'll publish a Receipt event where message_id = attention_id, assuming sql-writer can join/update.
-    # But `receipt_type` is seen/opened/dismissed. Attention has `ack_type`.
-    # They are compatible.
-    # So I will publish a receipt event.
+    if str(payload.attention_id) != attention_id:
+        raise HTTPException(status_code=400, detail="Attention ID mismatch")
 
-    bus: OrionBusAsync | None = request.app.state.bus
-    if bus:
-        event = NotificationReceiptEvent(
-            message_id=UUID(attention_id), # Assuming attention_id matches message_id or is used as key
-            receipt_type=payload.ack_type,
-            received_at=payload.acked_at,
-            created_at=datetime.utcnow()
-        )
-        asyncio.create_task(_publish_persistence_event(bus, "orion:notify:persistence:receipt", event))
-
-    # We can't return the updated state from DB because we can't read it.
-    # We return an optimistic state.
-    return ChatAttentionState(
-        attention_id=UUID(attention_id),
-        created_at=datetime.utcnow(), # Fake
-        source_service="unknown",
-        reason="ack",
-        severity="info",
-        message="",
-        require_ack=True,
-        status="acked",
-        acked_at=payload.acked_at,
-        ack_type=payload.ack_type,
-        ack_note=payload.note
+    # Attention state (NotificationRequestDB.attention_*) lives in sql-writer's
+    # database. sql-writer already exposes a direct write endpoint for the
+    # sibling "escalate" state change (see attention_escalation.py calling
+    # POST /attention/{id}/escalate via this same proxy). We follow that
+    # established convention here instead of routing through the bus: the
+    # bus publish this endpoint used to make (a NotificationReceiptEvent with
+    # message_id=attention_id) wrote into the *wrong* table/column -- receipts
+    # are keyed by message_id, not attention_id, and NotificationReceiptDB has
+    # no attention_id column at all, so the ack was never actually applied to
+    # NotificationRequestDB.attention_acked_at/ack_type/ack_actor/ack_note.
+    # Calling sql-writer's endpoint directly gives us a synchronous, real
+    # persisted state to return instead of an optimistic guess.
+    result = await request.app.state.proxy_post(
+        f"/attention/{attention_id}/ack",
+        payload.model_dump(mode="json"),
     )
+    return ChatAttentionState.model_validate(result)
 
 
 @app.post("/chat/message")

--- a/services/orion-notify/tests/test_attention_ack.py
+++ b/services/orion-notify/tests/test_attention_ack.py
@@ -1,0 +1,108 @@
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = SERVICE_ROOT.parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app import main
+from orion.schemas.notify import ChatAttentionAck, ChatAttentionState
+
+ATTN_ID = "8c0c1a20-9a9f-45b1-9aa0-1af6d1f7a6f3"
+
+
+def _persisted_state(**overrides) -> dict:
+    base = dict(
+        attention_id=ATTN_ID,
+        notification_id=None,
+        created_at=datetime(2026, 7, 1, 12, 0, 0).isoformat(),
+        source_service="orion-cortex",
+        reason="I want to talk",
+        severity="info",
+        message="Can you check the latest summary?",
+        context={},
+        require_ack=True,
+        acked_at=datetime.now(timezone.utc).isoformat(),
+        ack_type="dismissed",
+        ack_actor="juniper",
+        ack_note="handled",
+        status="acked",
+    )
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_attention_ack_calls_sql_writer_proxy_not_bus():
+    """The fix routes acks through sql-writer's direct write endpoint
+    (proxy_post) instead of publishing a NotificationReceiptEvent to the bus
+    -- that event was keyed on message_id and never persisted attention ack
+    state at all."""
+    proxy_post = AsyncMock(return_value=_persisted_state())
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(proxy_post=proxy_post))
+    )
+    payload = ChatAttentionAck(
+        attention_id=ATTN_ID,
+        ack_type="dismissed",
+        actor="juniper",
+        note="handled",
+    )
+
+    result = await main.attention_ack(ATTN_ID, payload, request, None)
+
+    assert isinstance(result, ChatAttentionState)
+    assert result.status == "acked"
+    assert result.ack_type == "dismissed"
+    assert result.ack_actor == "juniper"
+    assert result.ack_note == "handled"
+
+    proxy_post.assert_awaited_once()
+    call_args = proxy_post.await_args.args
+    assert call_args[0] == f"/attention/{ATTN_ID}/ack"
+    sent_payload = call_args[1]
+    assert sent_payload["attention_id"] == ATTN_ID
+    assert sent_payload["ack_type"] == "dismissed"
+    assert sent_payload["actor"] == "juniper"
+    assert sent_payload["note"] == "handled"
+
+
+@pytest.mark.asyncio
+async def test_attention_ack_rejects_mismatched_attention_id():
+    proxy_post = AsyncMock()
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(proxy_post=proxy_post))
+    )
+    payload = ChatAttentionAck(attention_id=ATTN_ID, ack_type="seen")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await main.attention_ack("00000000-0000-0000-0000-000000000000", payload, request, None)
+
+    assert exc_info.value.status_code == 400
+    proxy_post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_attention_ack_propagates_not_found_from_sql_writer():
+    proxy_post = AsyncMock(
+        side_effect=HTTPException(status_code=404, detail="Resource not found via sql-writer")
+    )
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(proxy_post=proxy_post))
+    )
+    payload = ChatAttentionAck(attention_id=ATTN_ID, ack_type="seen")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await main.attention_ack(ATTN_ID, payload, request, None)
+
+    assert exc_info.value.status_code == 404

--- a/services/orion-sql-writer/app/api_notify.py
+++ b/services/orion-sql-writer/app/api_notify.py
@@ -11,6 +11,7 @@ from app.models.notify_models import (
 )
 from orion.schemas.cortex.contracts import AgentTraceSummaryV1
 from orion.schemas.notify import (
+    ChatAttentionAck,
     ChatAttentionState,
     ChatMessageState,
 )
@@ -132,6 +133,29 @@ async def list_attention(limit: int = 50, status: Optional[str] = None):
             query = query.filter(NotificationRequestDB.attention_acked_at.isnot(None))
         rows = query.order_by(NotificationRequestDB.created_at.desc()).limit(limit).all()
         return [_attention_to_schema(row) for row in rows]
+    finally:
+        remove_session()
+
+
+@router.post("/attention/{attention_id}/ack")
+async def mark_attention_acked(attention_id: str, payload: ChatAttentionAck) -> ChatAttentionState:
+    db = get_session()
+    try:
+        row = (
+            db.query(NotificationRequestDB)
+            .filter(NotificationRequestDB.attention_id == attention_id)
+            .first()
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="attention_not_found")
+        if row.attention_acked_at is None:
+            row.attention_acked_at = payload.acked_at
+            row.attention_ack_type = payload.ack_type
+            row.attention_ack_actor = payload.actor
+            row.attention_ack_note = payload.note
+            db.commit()
+            db.refresh(row)
+        return _attention_to_schema(row)
     finally:
         remove_session()
 

--- a/services/orion-sql-writer/tests/test_notify_attention_ack.py
+++ b/services/orion-sql-writer/tests/test_notify_attention_ack.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api_notify import router
+
+ATTN_ID = "8c0c1a20-9a9f-45b1-9aa0-1af6d1f7a6f3"
+
+
+def _make_row(**overrides):
+    base = dict(
+        attention_id=ATTN_ID,
+        notification_id=None,
+        created_at=datetime(2026, 7, 1, 12, 0, 0),
+        source_service="orion-cortex",
+        severity="info",
+        title="I want to talk",
+        body_text="Can you check the latest summary?",
+        context={},
+        tags=[],
+        correlation_id=None,
+        session_id=None,
+        attention_expires_at=None,
+        attention_require_ack=True,
+        attention_ack_deadline_minutes=None,
+        attention_acked_at=None,
+        attention_ack_type=None,
+        attention_ack_actor=None,
+        attention_ack_note=None,
+        attention_escalated_at=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = FastAPI()
+    app.include_router(router, prefix="/api/notify-read")
+
+    fake_db = MagicMock()
+    fake_row = _make_row()
+
+    fake_query = MagicMock()
+    fake_query.filter.return_value.first.return_value = fake_row
+    fake_db.query.return_value = fake_query
+
+    monkeypatch.setattr("app.api_notify.get_session", lambda: fake_db)
+    monkeypatch.setattr("app.api_notify.remove_session", lambda: None)
+
+    with TestClient(app) as test_client:
+        yield test_client, fake_db, fake_row
+
+
+def test_attention_ack_persists_fields_on_notify_requests_row(client):
+    """Regression test: the ack must actually set attention_acked_at/ack_type/
+    ack_actor/ack_note on the NotificationRequestDB row (the bug was that the
+    old code published a NotificationReceiptEvent keyed on message_id, which
+    never touched these columns at all)."""
+    test_client, fake_db, fake_row = client
+
+    resp = test_client.post(
+        f"/api/notify-read/attention/{ATTN_ID}/ack",
+        json={
+            "attention_id": ATTN_ID,
+            "ack_type": "dismissed",
+            "actor": "juniper",
+            "note": "handled",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "acked"
+    assert body["ack_type"] == "dismissed"
+    assert body["ack_actor"] == "juniper"
+    assert body["ack_note"] == "handled"
+
+    # The underlying row was actually mutated (this is the persistence check).
+    assert fake_row.attention_acked_at is not None
+    assert fake_row.attention_ack_type == "dismissed"
+    assert fake_row.attention_ack_actor == "juniper"
+    assert fake_row.attention_ack_note == "handled"
+    fake_db.commit.assert_called_once()
+    fake_db.refresh.assert_called_once()
+
+
+def test_attention_ack_idempotent_does_not_overwrite(client):
+    test_client, fake_db, fake_row = client
+    fake_row.attention_acked_at = datetime(2026, 6, 19, 12, 0, 0)
+    fake_row.attention_ack_type = "seen"
+    fake_row.attention_ack_actor = "juniper"
+    fake_row.attention_ack_note = None
+
+    resp = test_client.post(
+        f"/api/notify-read/attention/{ATTN_ID}/ack",
+        json={"attention_id": ATTN_ID, "ack_type": "dismissed", "actor": "someone_else"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ack_type"] == "seen"  # unchanged, first ack wins
+    fake_db.commit.assert_not_called()
+
+
+def test_attention_ack_missing_row_returns_404_not_crash(client):
+    test_client, fake_db, _fake_row = client
+    fake_db.query.return_value.filter.return_value.first.return_value = None
+
+    resp = test_client.post(
+        f"/api/notify-read/attention/{ATTN_ID}/ack",
+        json={"attention_id": ATTN_ID, "ack_type": "seen"},
+    )
+
+    assert resp.status_code == 404
+    fake_db.commit.assert_not_called()


### PR DESCRIPTION
  ## Summary

  - `POST /attention/{id}/ack` returned `status: "acked"` but never touched the database — confirmed live by acking a real alert and immediately seeing it still listed under `GET /attention?status=pending`.
  - Root cause: the handler published a `NotificationReceiptEvent` keyed by `message_id=UUID(attention_id)` to `orion:notify:persistence:receipt`. `NotificationReceiptDB` has no `attention_id` column, and sql-writer's consumer for
  that channel only ever inserts a new receipt row — it never updates `NotificationRequestDB.attention_acked_at`/`ack_type`/`ack_actor`/`ack_note`. The endpoint's own code comments admitted this was a guess ("We can't return the
  updated state from DB... We return an optimistic state").
  - Fixed by adding `POST /attention/{attention_id}/ack` directly on sql-writer (`services/orion-sql-writer/app/api_notify.py`), mirroring the existing sibling `/attention/{id}/escalate` endpoint exactly — a synchronous,
  idempotent UPDATE by `attention_id`. `orion-notify`'s handler now calls it via the existing `proxy_post` mechanism (already used for escalate) instead of publishing to the bus.

  ## Outcome moved

  Acking an attention item now actually persists and clears it from the pending list. No new bus channel or schema needed — `ChatAttentionAck` was already registered but unused as an event; it's now used as an HTTP body instead.

  ## Files changed

  - `services/orion-notify/app/main.py` — `attention_ack` now calls sql-writer synchronously instead of publishing a wrong-table bus event.
  - `services/orion-sql-writer/app/api_notify.py` — new `mark_attention_acked` endpoint (idempotent, 404s cleanly if the row isn't there yet instead of crashing).
  - `services/orion-notify/tests/test_attention_ack.py` (new)
  - `services/orion-sql-writer/tests/test_notify_attention_ack.py` (new)

  ## Schema / bus / API changes

  None. No new channel, no new schema. `POST /attention/{attention_id}/ack` is a new internal sql-writer endpoint, additive only.

  ## Tests run

  PYTHONPATH=.:<repo-root> POSTGRES_URI="postgresql://unused/unused" pytest services/orion-sql-writer/tests/test_notify_attention_ack.py -q
  → 3 passed

  PYTHONPATH=.:<repo-root> POSTGRES_URI="postgresql://unused/unused" pytest services/orion-notify/tests/test_attention_ack.py -q
  → 3 passed

  PYTHONPATH=.:<repo-root> POSTGRES_URI="postgresql://unused/unused" pytest services/orion-notify/tests -q
  → 14 passed, no regressions
  All re-run and confirmed independently of the implementing agent.

  ## Review findings fixed

  - Self-flagged: the `attention_id` path/body mismatch check does a raw-string compare against a canonicalized UUID (could theoretically 400 on differently-cased-but-equal UUIDs). Verified this mirrors the pre-existing
  `chat_message_receipt` handler's identical pattern (`main.py:393`) — consistent with established convention, not a new risk, left as-is.

  ## Restart required

  ```bash
  docker compose --env-file .env --env-file services/orion-notify/.env -f services/orion-notify/docker-compose.yml up -d --build
  docker compose --env-file .env --env-file services/orion-sql-writer/.env -f services/orion-sql-writer/docker-compose.yml up -d --build
