### PR TITLE
fix(substrate-runtime): stop false-positive cursor_lag alerts on idle…

### DIFF
--- a/services/orion-substrate-runtime/app/grammar_truth.py
+++ b/services/orion-substrate-runtime/app/grammar_truth.py
@@ -26,6 +26,16 @@ ENABLED_BY_REDUCER_KEY: dict[str, Any] = {
     "route_grammar": lambda s: s.enable_route_grammar_reducer,
 }
 
+# Cursors that only advance on real, externally-triggered traffic rather than a
+# continuous internal tick, and can therefore legitimately sit idle past
+# substrate_cursor_lag_resync_hours with nothing wrong. Verified by direct
+# investigation (2026-07-13 substrate-runtime-health-alerting PR): chat_grammar
+# only advances when a real hub-websocket chat session produces events, not on
+# any background/automated traffic. Other cursors are not known to be
+# traffic-gated in the same way, so they keep the original wall-clock-only
+# cursor_lag check -- prolonged silence there is itself a real signal.
+_TRAFFIC_GATED_CURSORS = frozenset({"chat_grammar_consumer"})
+
 
 def build_substrate_grammar_truth(store: BiometricsSubstrateStore) -> dict[str, Any]:
     settings = get_settings()
@@ -61,14 +71,19 @@ def build_substrate_grammar_truth(store: BiometricsSubstrateStore) -> dict[str, 
         cursor = cursor_by_name.get(cursor_name, {})
         lag = cursor.get("lag_sec")
         lag_by_reducer[cursor_name] = lag
-        if lag is not None and lag > max_lag_sec:
-            degraded_reasons.append(f"cursor_lag:{cursor_name}")
 
         metrics = store.grammar_cursor_metrics(cursor_name)
         stream_lag = metrics.get("stream_lag_sec")
         pending = int(metrics.get("pending_backlog") or 0)
         stream_lag_by_reducer[cursor_name] = stream_lag
         backlog_by_reducer[cursor_name] = pending
+
+        if lag is not None and lag > max_lag_sec:
+            # For traffic-gated cursors, wall-clock idleness alone is not
+            # degradation -- only flag it if there's also an actual
+            # unprocessed backlog (events arrived and the reducer fell behind).
+            if cursor_name not in _TRAFFIC_GATED_CURSORS or pending > 0:
+                degraded_reasons.append(f"cursor_lag:{cursor_name}")
 
         reducer_key = REDUCER_KEY_BY_CURSOR.get(cursor_name, cursor_name)
         enabled_fn = ENABLED_BY_REDUCER_KEY.get(reducer_key, lambda _s: True)

--- a/services/orion-substrate-runtime/app/health_monitor.py
+++ b/services/orion-substrate-runtime/app/health_monitor.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Literal
 from uuid import uuid4
+from zoneinfo import ZoneInfo
 
 import requests
 
@@ -17,6 +19,34 @@ logger = logging.getLogger("orion.substrate.runtime.health")
 
 _SOURCE_SERVICE = "orion-substrate-runtime"
 Severity = Literal["info", "error", "critical"]
+
+# Juniper's operating timezone. Storage and the /grammar/truth API stay UTC
+# (the source of truth); only this human-facing alert message is localized,
+# so an operator reading it doesn't have to mentally convert from UTC.
+_REPORT_TZ = ZoneInfo("America/Denver")
+
+
+def _format_local(iso_timestamp: str | None) -> str | None:
+    if not iso_timestamp:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso_timestamp)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(_REPORT_TZ).strftime("%Y-%m-%d %H:%M %Z")
+
+
+def _annotate_reason(reason: str, cursor_by_name: dict[str, dict]) -> str:
+    if not reason.startswith("cursor_lag:"):
+        return reason
+    cursor_name = reason.split(":", 1)[1]
+    last_at = cursor_by_name.get(cursor_name, {}).get("last_event_created_at")
+    local = _format_local(last_at)
+    if not local:
+        return reason
+    return f"{reason} (last event {local})"
 
 
 @dataclass(frozen=True)
@@ -44,7 +74,11 @@ def run_checks(store: BiometricsSubstrateStore, settings: Settings) -> list[Heal
     reasons = truth.get("degraded_reasons") or []
     message = ""
     if degraded:
-        message = f"substrate-runtime grammar production degraded: {', '.join(reasons)}"
+        cursor_by_name = {
+            row["cursor_name"]: row for row in (truth.get("cursor_positions") or [])
+        }
+        annotated = [_annotate_reason(reason, cursor_by_name) for reason in reasons]
+        message = f"substrate-runtime grammar production degraded: {', '.join(annotated)}"
     checks.append(
         _check(
             "substrate_grammar_degraded",

--- a/services/orion-substrate-runtime/tests/test_grammar_truth_reducer_health.py
+++ b/services/orion-substrate-runtime/tests/test_grammar_truth_reducer_health.py
@@ -14,7 +14,7 @@ if str(SUBSTRATE_ROOT) not in sys.path:
     sys.path.insert(0, str(SUBSTRATE_ROOT))
 
 from app.grammar_truth import build_substrate_grammar_truth
-from app.reducer_health import clear_health_for_tests
+from app.reducer_health import clear_health_for_tests, record_tick
 
 
 def setup_function() -> None:
@@ -93,3 +93,89 @@ def test_truth_includes_reducer_health_and_backlog(monkeypatch) -> None:
     assert "cursor_lag:transport_grammar_reducer" in payload["degraded_reasons"]
     assert payload["pending_backlog_by_reducer"]["transport_grammar_reducer"] == 500
     assert "transport_bus" in payload["reducer_health_by_name"]
+
+
+def test_idle_traffic_gated_lane_with_stale_lag_and_no_backlog_is_not_cursor_lag_degraded(
+    monkeypatch,
+) -> None:
+    """chat_grammar only advances on real chat traffic; a long-idle cursor with
+    zero pending backlog is healthy, not degraded -- regression test for a false
+    positive that fired in production (cursor_lag:chat_grammar_consumer with
+    pending_backlog=0 after ~8h of no chat activity)."""
+    store = MagicMock()
+    store.cursor_positions.return_value = [
+        {
+            "cursor_name": "chat_grammar_consumer",
+            "lag_sec": 28308.0,  # ~7.9h, well past the 6h resync threshold
+            "last_event_created_at": "2026-07-13T07:52:47+00:00",
+            "last_event_id": "gev_old",
+            "updated_at": "2026-07-13T07:52:48+00:00",
+        }
+    ]
+    store.grammar_cursor_metrics.side_effect = lambda name: {
+        "cursor_name": name,
+        "pending_backlog": 0,
+        "stream_lag_sec": 0.0,
+        "cursor_wall_lag_sec": 28308.0 if name == "chat_grammar_consumer" else 0.0,
+        "head_event_created_at": "2026-07-13T07:52:47+00:00",
+        "head_event_id": "gev_old",
+    }
+    store.quarantine_summary.return_value = {
+        "unacknowledged_quarantine_count_by_reducer": {},
+        "unacknowledged_quarantine_count_by_cursor": {},
+        "quarantine_by_reducer": {},
+    }
+
+    # Simulate the reducer loop ticking normally (worker.py polls every reducer
+    # on every cycle regardless of whether it finds new events) so the
+    # heartbeat-based classification stays "healthy" and only the cursor_lag
+    # gating under test is exercised.
+    for reducer_key, cursor_name in [
+        ("biometrics", "biometrics_grammar_consumer"),
+        ("chat_grammar", "chat_grammar_consumer"),
+        ("execution_trajectory", "execution_grammar_reducer"),
+        ("transport_bus", "transport_grammar_reducer"),
+        ("route_grammar", "route_grammar_consumer"),
+    ]:
+        record_tick(reducer_key, cursor_name=cursor_name, enabled=True)
+
+    monkeypatch.setattr(
+        "app.grammar_truth.get_settings",
+        lambda: MagicMock(
+            orion_bus_enabled=True,
+            enable_execution_trajectory_reducer=True,
+            enable_transport_bus_reducer=True,
+            enable_biometrics_node_reducer=True,
+            enable_biometrics_pressure_organ=True,
+            enable_node_pressure_reducer=True,
+            enable_chat_grammar_reducer=True,
+            enable_route_grammar_reducer=True,
+            substrate_cursor_lag_resync_hours=6.0,
+            reducer_heartbeat_stale_sec=120.0,
+            grammar_poll_interval_sec=5.0,
+            substrate_cursor_tail_seed_on_lag=False,
+            substrate_cursor_reset_operator_token="tok",
+            biometrics_grammar_batch_limit=50,
+            execution_grammar_batch_limit=100,
+            transport_grammar_batch_limit=500,
+            accepted_pressure_grammar_channel="orion:grammar:accepted-pressure",
+            grammar_event_channel="orion:grammar:event",
+            publish_accepted_pressure_grammar=True,
+        ),
+    )
+    monkeypatch.setattr("app.grammar_truth.has_recent_tail_seed", lambda: False)
+    monkeypatch.setattr("app.grammar_truth.has_cold_start_tail_seed", lambda: False)
+    monkeypatch.setattr("app.grammar_truth.last_reset_skipped_history", lambda: False)
+    monkeypatch.setattr(
+        "app.grammar_truth.tail_seed_snapshot",
+        lambda: {"count": 0, "latest": None, "recent": []},
+    )
+    monkeypatch.setattr(
+        "app.grammar_truth.cursor_reset_snapshot",
+        lambda: {"count": 0, "last": None, "recent": []},
+    )
+
+    payload = build_substrate_grammar_truth(store)
+    assert payload["degraded"] is False
+    assert "cursor_lag:chat_grammar_consumer" not in payload["degraded_reasons"]
+    assert payload["pending_backlog_by_reducer"]["chat_grammar_consumer"] == 0

--- a/services/orion-substrate-runtime/tests/test_health_monitor.py
+++ b/services/orion-substrate-runtime/tests/test_health_monitor.py
@@ -41,9 +41,17 @@ def _store() -> MagicMock:
     return MagicMock()
 
 
-def _truth(*, degraded: bool, reasons: list[str] | None = None) -> dict:
+def _truth(
+    *,
+    degraded: bool,
+    reasons: list[str] | None = None,
+    cursor_positions: list[dict] | None = None,
+) -> dict:
     reasons = reasons or []
-    return {"ok": not degraded, "degraded": degraded, "degraded_reasons": reasons}
+    truth: dict = {"ok": not degraded, "degraded": degraded, "degraded_reasons": reasons}
+    if cursor_positions is not None:
+        truth["cursor_positions"] = cursor_positions
+    return truth
 
 
 def _client_mock(client_cls, *, ok: bool = True):
@@ -93,6 +101,42 @@ def test_run_checks_unhealthy_includes_reasons_in_message():
     assert check.severity == "critical"
     for reason in reasons:
         assert reason in check.message
+
+
+def test_run_checks_annotates_cursor_lag_reason_with_local_denver_time():
+    hm = _hm()
+    reasons = ["cursor_lag:chat_grammar_consumer"]
+    cursor_positions = [
+        {
+            "cursor_name": "chat_grammar_consumer",
+            # 2026-07-13T07:52:47+00:00 is 2026-07-13 01:52 in America/Denver (MDT, UTC-6).
+            "last_event_created_at": "2026-07-13T07:52:47+00:00",
+        }
+    ]
+
+    with patch(
+        "app.health_monitor.build_substrate_grammar_truth",
+        return_value=_truth(degraded=True, reasons=reasons, cursor_positions=cursor_positions),
+    ):
+        checks = hm.run_checks(_store(), _settings())
+
+    check = checks[0]
+    assert "cursor_lag:chat_grammar_consumer" in check.message
+    assert "2026-07-13 01:52 MDT" in check.message
+
+
+def test_run_checks_leaves_reason_unannotated_without_cursor_position_data():
+    hm = _hm()
+    reasons = ["cursor_lag:chat_grammar_consumer"]
+
+    with patch(
+        "app.health_monitor.build_substrate_grammar_truth",
+        return_value=_truth(degraded=True, reasons=reasons),
+    ):
+        checks = hm.run_checks(_store(), _settings())
+
+    check = checks[0]
+    assert check.message == "substrate-runtime grammar production degraded: cursor_lag:chat_grammar_consumer"
 
 
 def test_health_monitor_does_not_alert_on_healthy_first_observation():


### PR DESCRIPTION
… chat lane, report in MDT

chat_grammar_consumer only advances on real hub-websocket chat traffic, so it sat idle for ~8h with zero pending backlog and tripped the new health-alerting hook's wall-clock-only cursor_lag check, firing a critical attention item for a reducer that wasn't actually stuck. Gate that check with a pending-backlog requirement for this specific traffic-gated cursor only; every other cursor (biometrics, transport, execution, route) keeps its original wall-clock-only semantics since prolonged silence there is a real signal.

Also annotate cursor_lag reasons in the alert message with a human-readable America/Denver local time instead of leaving an operator to convert from UTC by hand. Storage and the /grammar/truth API stay UTC.