### PR TITLE
Fix/execution dispatch status honesty p0

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-execution-dispatch-status-honesty-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-execution-dispatch-status-honesty-pr.md
@@ -1,0 +1,113 @@
+# fix(execution-dispatch): un-lie dispatch_status (P0 of the motor-nerve spec)
+
+## Summary
+
+- `orion/execution_dispatch/builder.py` claimed `dispatch_status="dispatched"` for read-only candidates while never sending anything — no executor exists anywhere in the repo. Now emits the honest `prepared_for_dispatch`.
+- `ExecutionDispatchCandidateV1.dispatch_status="dispatched"` now requires evidence (`dispatched_at` + `result_ref`/`dispatch_error`) via a model validator — the status can no longer be claimed without proof a send was attempted.
+- `orion/feedback/builder.py` classifies/scores the new status; 6 existing test fixtures that simulated a genuinely-dispatched candidate were repaired with the now-required evidence fields.
+- Code review caught that the new validator could raise on historical Postgres rows predating it. Live-queried `substrate_execution_dispatch_frames` directly (687,992 rows, 0 affected) to confirm today's data is safe, then added the same `try/except ValidationError → None` guard this codebase already uses for an identical 2026-07-12 self-state incident, at all 4 affected loaders.
+
+## Outcome moved
+
+Layer 9's status vocabulary no longer lies. `dispatch_status="dispatched"` is now a claim that requires evidence to make; `prepared_for_dispatch` is the honest name for "cleared every gate, never sent." This is P0 of `docs/superpowers/specs/2026-07-13-endogenous-action-motor-nerve-spec.md` — the precondition for P1 (an actual sender) to exist without inheriting a broken status contract.
+
+## Current architecture
+
+`build_execution_dispatch_frame` (Layer 9) converts approved policy decisions into `ExecutionDispatchCandidateV1` envelopes. For `dispatch_mode="dispatch_read_only"` + `allow_dispatch_read_only=True`, it previously set `dispatch_status="dispatched"` despite only constructing a request-envelope dict — no bus publish, no cortex-exec call, nothing sent. Live policy default (`allow_dispatch_read_only: false`) meant this was unreachable in production, but was directly exercised by test fixtures and would have misled any future consumer.
+
+## Architecture touched
+
+`orion/schemas/execution_dispatch_frame.py`, `orion/schemas/feedback_frame.py`, `orion/execution_dispatch/builder.py`, `orion/feedback/builder.py`, plus the 4 Postgres-backed loaders of `ExecutionDispatchFrameV1` in `services/orion-execution-dispatch-runtime/app/store.py`, `services/orion-feedback-runtime/app/store.py`, and `services/orion-hub/scripts/substrate_execution_dispatch_routes.py`.
+
+## Files changed
+
+- `orion/schemas/execution_dispatch_frame.py` — `prepared_for_dispatch` status literal; `result_ref`/`dispatch_error`/`dispatched_at` fields; evidence-requiring validator.
+- `orion/schemas/feedback_frame.py` — `prepared_for_dispatch` added to `OutcomeObservationV1.outcome_kind`.
+- `orion/execution_dispatch/builder.py` — one-line status fix; comment marking the now-unreachable `max_dispatches_per_tick` branch.
+- `orion/feedback/builder.py` — classification + scoring for `prepared_for_dispatch`.
+- `services/orion-execution-dispatch-runtime/app/store.py`, `services/orion-feedback-runtime/app/store.py`, `services/orion-hub/scripts/substrate_execution_dispatch_routes.py` — degrade-to-`None` guards on `ExecutionDispatchFrameV1.model_validate()`.
+- `services/orion-execution-dispatch-runtime/README.md` — documents the status vocabulary.
+- `tests/test_execution_dispatch_frame_schemas.py`, `tests/test_execution_dispatch_builder.py`, `tests/test_feedback_builder.py`, `tests/test_execution_dispatch_runtime_store.py`, `tests/test_feedback_runtime_store.py` — new/repaired coverage.
+- `docs/superpowers/specs/2026-07-13-execution-dispatch-status-honesty-design.md` — design doc for this patch.
+
+## Schema / bus / API changes
+
+- **Added:** `dispatch_status="prepared_for_dispatch"`; `ExecutionDispatchCandidateV1.result_ref`/`dispatch_error`/`dispatched_at` (all optional).
+- **Removed:** none.
+- **Renamed:** none.
+- **Behavior changed:** `dispatch_status="dispatched"` now raises `ValidationError` unless evidenced. The `dispatch_read_only` builder branch now produces `prepared_for_dispatch`, so `dispatched_candidates`/`dispatch_count` are honestly empty/zero until a future sender exists (this also makes the `max_dispatches_per_tick` rate-limit branch dead code for now — commented, not removed).
+- **Compatibility notes:** live-verified via direct Postgres query — 687,992 rows in `substrate_execution_dispatch_frames`, 0 with a nonempty `dispatched_candidates` list — no historical row is broken by the new validator. Defensive guards added regardless, matching this codebase's established pattern.
+
+## Env/config changes
+
+- Added keys: none.
+- Removed keys: none.
+- Renamed keys: none.
+- `.env_example` updated: no.
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not applicable, no env template changed.
+- skipped keys requiring operator action: none.
+
+## Tests run
+
+```text
+cd /mnt/scripts/Orion-Sapienform-execution-dispatch-status-honesty
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest \
+  tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_envelopes.py \
+  tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_policy_loader.py \
+  tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_runtime_worker.py \
+  tests/test_execution_dispatch_transport_dry_run.py tests/test_feedback_builder.py \
+  tests/test_feedback_runtime_store.py tests/test_feedback_transport_outcomes.py \
+  tests/test_consolidation_tensorize.py tests/test_consolidation_schema_candidates.py \
+  tests/test_consolidation_motif_detection.py tests/test_consolidation_expectations.py \
+  tests/test_consolidation_policy_loader.py services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py -q
+
+93 passed in 2.20s
+```
+
+## Evals run
+
+None — this service has no `evals/` harness; not required for a schema-honesty patch with no quality/behavior dimension to measure.
+
+## Docker/build/smoke checks
+
+Not run — no runtime behavior, port, dependency, or compose wiring changed. Compatibility was instead verified with a direct live Postgres query (see below) rather than a container smoke, since the risk was schema/data compatibility, not runtime wiring.
+
+```text
+PGPASSWORD=postgres psql -h localhost -p 55432 -U postgres -d conjourney -c "
+select count(*) as total_rows,
+       count(*) filter (where dispatch_frame_json::jsonb -> 'dispatched_candidates' <> '[]'::jsonb) as rows_with_nonempty_dispatched_candidates
+from substrate_execution_dispatch_frames;"
+ total_rows | rows_with_nonempty_dispatched_candidates
+------------+------------------------------------------
+     687992 |                                        0
+```
+
+## Review findings fixed
+
+- Finding: New evidence-requiring validator has no guard on 4 `model_validate()` loaders of historical `ExecutionDispatchFrameV1` rows — same failure class as a 2026-07-12 self-state incident already fixed elsewhere in this codebase, worst case a permanently-wedged feedback FIFO.
+  - Fix: Live-queried the actual table (687,992 rows, 0 affected today) for ground truth, then added `try/except ValidationError → logger.warning → return None` at all 4 sites, matching the established `load_self_state` pattern.
+  - Evidence: 4 new regression tests (`test_load_latest_dispatch_frame_degrades_to_none_on_legacy_incompatible_row` etc.) constructing a legacy-shaped payload and asserting `None` instead of a raise; all pass.
+- Finding: The `max_dispatches_per_tick` rate-limit branch in `builder.py` becomes permanently unreachable once nothing sets `dispatch_status="dispatched"` from this function — a real but deliberate consequence, undocumented.
+  - Fix: Added an inline comment naming exactly why and when it becomes reachable again (a future sender).
+  - Evidence: `orion/execution_dispatch/builder.py:223-227`.
+- Finding: `test_failed_cortex_result` paired `dispatch_error` (send itself failed) with a `cortex_results` entry claiming `status: "failed"` (send succeeded, cortex responded with failure) — two contradictory failure stories in one fixture.
+  - Fix: Switched to `result_ref`, matching the other 5 repaired fixtures' coherent "send succeeded, then outcome determined" story.
+  - Evidence: `tests/test_feedback_builder.py::test_failed_cortex_result`, still asserts `outcome_status == "failed"`, now for the right reason.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+No runtime config changed; this is a pure code patch. The next deploy of `orion-execution-dispatch-runtime`, `orion-feedback-runtime`, and `orion-hub` will pick it up normally.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: P1 (the actual sender) doesn't exist yet, so `prepared_for_dispatch` candidates will accumulate with no promotion path until that patch lands. Not a regression — this is the same "nothing is dispatched" state as before, just honestly labeled now.
+- Mitigation: none needed; this is explicitly the intended P0 end-state per the parent spec.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/execution-dispatch-status-honesty-p0

--- a/docs/superpowers/specs/2026-07-13-execution-dispatch-status-honesty-design.md
+++ b/docs/superpowers/specs/2026-07-13-execution-dispatch-status-honesty-design.md
@@ -1,0 +1,76 @@
+# Execution dispatch status honesty (P0 of the motor-nerve spec) — design
+
+**Date:** 2026-07-13
+**Status:** Implementation, this session
+**Mode:** Thin patch. Implements P0 of `docs/superpowers/specs/2026-07-13-endogenous-action-motor-nerve-spec.md` exactly — no scope beyond it.
+
+## Arsonist summary
+
+`orion/execution_dispatch/builder.py:198-203` sets `dispatch_status="dispatched"` when policy allows `dispatch_read_only` mode, but the builder never sends anything — it only constructs a `request_envelope` dict. No worker, transport, or send exists anywhere in the repo (confirmed by repo-wide grep). The status is a lie today: it claims a send happened when only a plan was drawn up. This patch makes `dispatched` mean only "a send was attempted and evidenced" and gives the honest "ready but not sent" state its own name, `prepared_for_dispatch`.
+
+## Current architecture
+
+- `ExecutionDispatchCandidateV1` (`orion/schemas/execution_dispatch_frame.py:9-52`): `dispatch_status: Literal["prepared", "dry_run", "blocked", "dispatched", "skipped"]`. No evidence fields exist for a real send (no result ref, no error, no timestamp).
+- `build_execution_dispatch_frame` (`orion/execution_dispatch/builder.py:63-257`): for `dispatch_mode="dispatch_read_only"` candidates that clear every gate (hard-block, policy-decision, route-scope, candidate-limit checks), line 198-203 sets `dispatch_status="dispatched"` if `policy.mode.allow_dispatch_read_only`, else `"dry_run"` with a warning. Status-`"dispatched"` items are routed into `dispatched_candidates`/`dispatch_count` (line 223-234); everything else lands in `candidates`.
+- `orion/feedback/builder.py`: `OutcomeKind` Literal (line 31-46) mirrors the dispatch-status vocabulary. `_candidate_outcome_kind` (line 78-87) maps `candidate.dispatch_status` 1:1 to an `OutcomeKind` (falls to `"unknown"` for anything unrecognized). `_score_for_outcome_kind` (line 107-120) scores `"dispatched"` on `scoring.prepared_score` — i.e. the scoring lane already treats a "dispatched" candidate as merely "prepared," which is honest about the *scoring* even though the *label* was not.
+- `orion/schemas/feedback_frame.py`: `OutcomeObservationV1.outcome_kind` carries an independent copy of the same Literal (line 26-40) — must stay in sync with `orion/feedback/builder.py`'s `OutcomeKind`.
+- Live policy (`config/execution_dispatch/execution_dispatch_policy.v1.yaml`): `allow_dispatch_read_only: false` — the lie is not reachable in production today (mode defaults to `dry_run`), but is reachable by any caller that overrides `dispatch_mode` and flips the policy flag, and is directly exercised by `tests/test_feedback_builder.py`'s six hand-built fixtures.
+- Downstream consumers of `dispatch_status`: `orion/consolidation/tensorize.py:152` (reads the raw string into a tensor feature, no literal-set assumption — unaffected), `orion/schemas/registry.py` (schema registration only — unaffected), Hub debug routes/tests (pass the frame through, assert on `dispatch_attempted`/empty lists in `dry_run`-mode fixtures only — unaffected).
+- No producer of a genuinely evidenced `dispatched` status exists anywhere (grep-confirmed) — nothing has ever really dispatched. No data migration is needed; this is asserted, not assumed (see Acceptance checks).
+
+## Missing questions
+
+None — P0's scope is fully specified by the motor-nerve spec and confirmed against the live code in this session. The two judgment calls made explicit here so they're reviewable:
+
+1. **Routing, not a new list.** `ExecutionDispatchFrameV1` gets no new `prepared_for_dispatch_candidates` list. Once the builder never emits `"dispatched"`, the `if dispatch_status == "dispatched": dispatched.append(item)` check in the builder naturally never matches, so `prepared_for_dispatch` items fall through to the existing `candidates` list (same as `"prepared"`/`"dry_run"` already do) — no code change needed at that check itself, only at the status-assignment line. `dispatched_candidates`/`dispatch_count` become honestly empty/zero from this builder until P1 adds a real sender. This is the correct minimal fix, not a gap: a new list would be scope creep for a naming/honesty patch.
+2. **`dispatch_attempted` is left unchanged.** It's computed as `dispatch_mode == "dispatch_read_only" and policy.mode.allow_dispatch_read_only` — true whenever the policy permits read-only dispatch, independent of whether a send happened. This is a related imprecision but is explicitly out of P0's scope (the spec's P0 section doesn't name it, and P1's worker is what will make "attempted" meaningful). Traced its two downstream branches in `_aggregate_outcome_status` (`orion/feedback/builder.py:123-146`): neither the old `"dispatched"`-only nor the new `"prepared_for_dispatch"`-only case matches any early-return branch, so both fall through identically to `return "unknown"` — **confirmed no behavior change** to aggregate outcome status from this patch. Not fixed here; flagged in the PR report as a known follow-on for P1.
+
+## Proposed schema / API changes
+
+**`orion/schemas/execution_dispatch_frame.py`**
+- `ExecutionDispatchCandidateV1.dispatch_status` gains `"prepared_for_dispatch"` in the Literal, alongside the existing five values. `"dispatched"` stays but its meaning narrows.
+- New optional fields on `ExecutionDispatchCandidateV1`: `result_ref: str | None = None`, `dispatch_error: str | None = None`, `dispatched_at: datetime | None = None`.
+- New `model_validator(mode="after")`: if `dispatch_status == "dispatched"`, require `dispatched_at is not None` AND (`result_ref is not None` OR `dispatch_error is not None`). Raise `ValueError` otherwise. This is the evidence bar — a claimed send must carry a timestamp and either a result or a recorded failure.
+
+**`orion/schemas/feedback_frame.py`**
+- `OutcomeObservationV1.outcome_kind` Literal gains `"prepared_for_dispatch"`, kept in sync with `orion/feedback/builder.py`'s `OutcomeKind`.
+
+**`orion/execution_dispatch/builder.py`**
+- Line 200: `dispatch_status = "dispatched"` → `dispatch_status = "prepared_for_dispatch"`. This is the entire behavioral change in this file. No other line moves.
+
+**`orion/feedback/builder.py`**
+- `OutcomeKind` Literal (line 31-46): add `"prepared_for_dispatch"`.
+- `_candidate_outcome_kind` (line 78-87): add `if candidate.dispatch_status == "prepared_for_dispatch": return "prepared_for_dispatch"` — without this, candidates carrying the new status silently fall to `"unknown"`, a real misclassification (this is the specific case the task scope asked to check for and fix).
+- `_score_for_outcome_kind` (line 107-120): add `"prepared_for_dispatch": scoring.prepared_score` — same scoring lane as `"prepared"` and (unchanged) `"dispatched"`.
+- `"dispatched"`'s existing mapping and scoring are untouched — nothing produces an evidenced `"dispatched"` candidate yet, so no behavior change there; the mapping stays correct for when P1's worker exists.
+
+## Files likely to touch
+
+- `orion/schemas/execution_dispatch_frame.py` — literal, fields, validator.
+- `orion/schemas/feedback_frame.py` — literal.
+- `orion/execution_dispatch/builder.py` — one status-string change.
+- `orion/feedback/builder.py` — literal, classification, scoring.
+- `tests/test_execution_dispatch_frame_schemas.py` — new validator tests (evidenced `"dispatched"` passes, un-evidenced fails; `"prepared_for_dispatch"` needs no evidence).
+- `tests/test_execution_dispatch_builder.py` — new test exercising `dispatch_mode="dispatch_read_only"` with `allow_dispatch_read_only=True`, asserting `dispatch_status == "prepared_for_dispatch"` and the item lands in `frame.candidates`, not `frame.dispatched_candidates`.
+- `tests/test_feedback_builder.py` — six existing fixtures construct `dispatch_status="dispatched"` directly without evidence (`test_missing_cortex_result_absence`, `test_successful_cortex_result_completed`, `test_failed_cortex_result`, `test_partial_dispatch_completed_and_absent_is_mixed` ×2, `test_completed_and_failed_is_mixed`) — each needs `dispatched_at=NOW` and a `result_ref` (or leave the failed-result one to use `dispatch_error` where more honest) added so they remain valid under the new validator. These fixtures intentionally keep testing the feedback layer's handling of a genuinely-dispatched candidate — that scenario is still real and still needs coverage, it just now needs to supply the evidence the schema requires.
+- `services/orion-execution-dispatch-runtime/README.md`, `services/orion-feedback-runtime/README.md` — document the status vocabulary change if either currently describes `dispatch_status` values.
+
+## Non-goals
+
+- No sending, no bus wiring, no transport, no new table (`substrate_dispatch_results`) — that is P1, explicitly deferred.
+- No change to `dispatch_attempted`'s semantics (see Missing questions §2) — tracked as a known follow-on, not fixed here.
+- No new `ExecutionDispatchFrameV1` list field for `prepared_for_dispatch` candidates — routes through the existing `candidates` list.
+- No policy flag flips (`allow_dispatch_read_only` stays `false` in the live `.env`/policy default).
+- No `.env`/`.env_example` changes — this patch touches no runtime configuration.
+
+## Acceptance checks
+
+1. `pytest tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_envelopes.py tests/test_feedback_builder.py -q` green.
+2. `pytest orion/feedback -q` — no dedicated test dir exists under `orion/feedback/` today (confirmed); this becomes a no-op collection, not a failure. Real feedback coverage lives in `tests/test_feedback_builder.py` and `tests/test_feedback_transport_outcomes.py` at repo root.
+3. `grep -rn '"dispatched"' orion services --include="*.py"` shows the string only in: the Literal definitions (schema files), the unchanged scoring-map key in `orion/feedback/builder.py`, `orion/consolidation/tensorize.py`'s generic pass-through, and the unrelated `orion/schemas/workflow_execution.py`/`orion-actions` workflow-schedule status (a different, pre-existing, unrelated status vocabulary — confirmed by inspection, not touched). No remaining code path constructs `dispatch_status="dispatched"` without evidence.
+4. A read-only check (grep across `tests/`, and reasoning from the "no sender exists" fact already established) confirming no stored/historical `ExecutionDispatchFrameV1` data could contain a genuine evidenced `dispatched` status — asserted explicitly in the PR report per the task's compatibility-check requirement.
+5. Model-validator regression test: constructing `ExecutionDispatchCandidateV1(dispatch_status="dispatched", ...)` with no `dispatched_at`/`result_ref`/`dispatch_error` raises `ValidationError`.
+
+## Recommended next patch
+
+P1 (the motor nerve itself — Layer 9 actually sends) per the parent spec, once this lands.

--- a/orion/execution_dispatch/builder.py
+++ b/orion/execution_dispatch/builder.py
@@ -220,6 +220,10 @@ def build_execution_dispatch_frame(
             risk_score=decision.risk_score,
             confidence_score=decision.confidence_score,
         )
+        # Unreachable from this builder as of the prepared_for_dispatch fix above --
+        # nothing here sets dispatch_status="dispatched" anymore, so max_dispatches_per_tick
+        # is not enforced until a future patch's sender promotes candidates to a real,
+        # evidenced "dispatched" after actually attempting a send.
         if dispatch_status == "dispatched":
             if len(dispatched) < policy.limits.max_dispatches_per_tick:
                 dispatched.append(item)

--- a/orion/execution_dispatch/builder.py
+++ b/orion/execution_dispatch/builder.py
@@ -197,7 +197,7 @@ def build_execution_dispatch_frame(
         )
         dispatch_status = dispatch_status_default
         if dispatch_mode == "dispatch_read_only" and policy.mode.allow_dispatch_read_only:
-            dispatch_status = "dispatched"
+            dispatch_status = "prepared_for_dispatch"
         elif dispatch_mode == "dispatch_read_only":
             dispatch_status = "dry_run"
             warnings.append("dispatch_read_only_disabled_by_policy")

--- a/orion/feedback/builder.py
+++ b/orion/feedback/builder.py
@@ -32,6 +32,7 @@ OutcomeKind = Literal[
     "not_attempted",
     "dry_run",
     "prepared",
+    "prepared_for_dispatch",
     "dispatched",
     "completed",
     "failed",
@@ -80,6 +81,8 @@ def _candidate_outcome_kind(candidate: ExecutionDispatchCandidateV1) -> OutcomeK
         return "blocked"
     if candidate.dispatch_status == "prepared":
         return "prepared"
+    if candidate.dispatch_status == "prepared_for_dispatch":
+        return "prepared_for_dispatch"
     if candidate.dispatch_status == "dry_run":
         return "dry_run"
     if candidate.dispatch_status == "dispatched":
@@ -108,6 +111,7 @@ def _score_for_outcome_kind(outcome_kind: str, scoring) -> float:
     mapping = {
         "dry_run": scoring.dry_run_score,
         "prepared": scoring.prepared_score,
+        "prepared_for_dispatch": scoring.prepared_score,
         "completed": scoring.completed_score,
         "blocked": scoring.blocked_score,
         "deferred": scoring.deferred_score,

--- a/orion/schemas/execution_dispatch_frame.py
+++ b/orion/schemas/execution_dispatch_frame.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ExecutionDispatchCandidateV1(BaseModel):
@@ -18,6 +18,7 @@ class ExecutionDispatchCandidateV1(BaseModel):
         "prepared",
         "dry_run",
         "blocked",
+        "prepared_for_dispatch",
         "dispatched",
         "skipped",
     ]
@@ -50,6 +51,21 @@ class ExecutionDispatchCandidateV1(BaseModel):
 
     risk_score: float = Field(ge=0.0, le=1.0)
     confidence_score: float = Field(ge=0.0, le=1.0)
+
+    result_ref: str | None = None
+    dispatch_error: str | None = None
+    dispatched_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def _dispatched_requires_evidence(self) -> "ExecutionDispatchCandidateV1":
+        if self.dispatch_status == "dispatched":
+            if self.dispatched_at is None or (self.result_ref is None and self.dispatch_error is None):
+                raise ValueError(
+                    "dispatch_status='dispatched' requires dispatched_at and one of "
+                    "result_ref/dispatch_error as evidence a send was actually attempted; "
+                    "use 'prepared_for_dispatch' for a candidate that has not been sent yet"
+                )
+        return self
 
 
 class ExecutionDispatchFrameV1(BaseModel):

--- a/orion/schemas/feedback_frame.py
+++ b/orion/schemas/feedback_frame.py
@@ -29,6 +29,7 @@ class OutcomeObservationV1(BaseModel):
         "not_attempted",
         "dry_run",
         "prepared",
+        "prepared_for_dispatch",
         "dispatched",
         "completed",
         "failed",

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -8,6 +8,20 @@ Layer 9 of the Orion cognition substrate: converts `PolicyDecisionFrameV1` + `Pr
 - No bus publish and no cortex-exec calls in the default worker path
 - Mutating dispatch is disabled in policy config (`allow_mutating_dispatch: false`)
 
+## Status vocabulary
+
+`ExecutionDispatchCandidateV1.dispatch_status`:
+
+- `prepared`, `dry_run`, `blocked`, `skipped` — no send involved.
+- `prepared_for_dispatch` — cleared every gate for `dispatch_read_only` mode, but this
+  builder never sends anything; it only constructs the request envelope. This is the
+  honest terminal state until a future sender exists.
+- `dispatched` — reserved for a real, evidenced send attempt. `ExecutionDispatchCandidateV1`
+  enforces this at the schema level: `dispatch_status="dispatched"` requires `dispatched_at`
+  plus one of `result_ref`/`dispatch_error`, or construction raises. Nothing in this
+  service produces an evidenced `dispatched` candidate yet — that requires a sender
+  (planned, not built).
+
 ## Prerequisites
 
 1. `substrate_policy_decision_frames` populated (`orion-policy-runtime`, port 8120)

--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -132,7 +132,16 @@ class ExecutionDispatchRuntimeStore:
         payload = row["dispatch_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ExecutionDispatchFrameV1.model_validate(payload)
+        try:
+            return ExecutionDispatchFrameV1.model_validate(payload)
+        except ValidationError:
+            # Same reasoning as load_self_state's guard above: looked up by a
+            # fixed policy_frame_id, so a naive raise would permanently block
+            # this caller on a schema-incompatible historical row.
+            logger.warning(
+                "dispatch_frame_incompatible_schema policy_frame_id=%s", policy_frame_id, exc_info=True
+            )
+            return None
 
     def load_latest_dispatch_frame(self) -> ExecutionDispatchFrameV1 | None:
         with self._engine.connect() as conn:
@@ -155,7 +164,11 @@ class ExecutionDispatchRuntimeStore:
         payload = row["dispatch_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ExecutionDispatchFrameV1.model_validate(payload)
+        try:
+            return ExecutionDispatchFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning("dispatch_frame_incompatible_schema latest_lookup", exc_info=True)
+            return None
 
     def save_dispatch_frame(self, frame: ExecutionDispatchFrameV1) -> None:
         now = datetime.now(timezone.utc)

--- a/services/orion-feedback-runtime/app/store.py
+++ b/services/orion-feedback-runtime/app/store.py
@@ -51,7 +51,20 @@ class FeedbackRuntimeStore:
         payload = row["dispatch_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ExecutionDispatchFrameV1.model_validate(payload)
+        try:
+            return ExecutionDispatchFrameV1.model_validate(payload)
+        except ValidationError:
+            # Mirrors load_self_state's guard below: this is the FIFO lookup
+            # (oldest dispatch frame without feedback yet) -- a naive raise
+            # would re-select and fail on this exact row every tick forever,
+            # blocking every dispatch frame queued behind it. Degrading to
+            # None here means this tick does no work for a bad row instead of
+            # crash-looping on it; the row itself isn't retired (no feedback
+            # frame is written for it), which is the same acknowledged
+            # limitation self_state's None-degrade already accepts elsewhere
+            # in this file.
+            logger.warning("dispatch_frame_incompatible_schema fifo_lookup", exc_info=True)
+            return None
 
     def load_latest_dispatch_frame(self) -> ExecutionDispatchFrameV1 | None:
         with self._engine.connect() as conn:
@@ -74,7 +87,11 @@ class FeedbackRuntimeStore:
         payload = row["dispatch_frame_json"]
         if isinstance(payload, str):
             payload = json.loads(payload)
-        return ExecutionDispatchFrameV1.model_validate(payload)
+        try:
+            return ExecutionDispatchFrameV1.model_validate(payload)
+        except ValidationError:
+            logger.warning("dispatch_frame_incompatible_schema latest_lookup", exc_info=True)
+            return None
 
     def load_policy_frame(self, frame_id: str) -> PolicyDecisionFrameV1 | None:
         with self._engine.connect() as conn:

--- a/services/orion-hub/scripts/substrate_execution_dispatch_routes.py
+++ b/services/orion-hub/scripts/substrate_execution_dispatch_routes.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 
 from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
@@ -41,7 +42,10 @@ def _load_latest_dispatch_frame() -> ExecutionDispatchFrameV1 | None:
     payload = row["dispatch_frame_json"]
     if isinstance(payload, str):
         payload = json.loads(payload)
-    return ExecutionDispatchFrameV1.model_validate(payload)
+    try:
+        return ExecutionDispatchFrameV1.model_validate(payload)
+    except ValidationError:
+        return None
 
 
 @router.get("/latest")

--- a/tests/test_execution_dispatch_builder.py
+++ b/tests/test_execution_dispatch_builder.py
@@ -206,6 +206,35 @@ def test_no_mutating_scope_in_envelopes() -> None:
         assert constraints.get("read_only") is True
 
 
+def test_dispatch_read_only_produces_prepared_for_dispatch_not_dispatched() -> None:
+    proposal = _proposal_frame()
+    policy_frame = _policy_frame(proposal)
+    policy = POLICY.model_copy(
+        update={"mode": POLICY.mode.model_copy(update={"allow_dispatch_read_only": True})}
+    )
+    frame = build_execution_dispatch_frame(
+        policy_frame=policy_frame,
+        proposal_frame=proposal,
+        self_state=_loaded_self_state(),
+        policy=policy,
+        now=NOW,
+        override_dispatch_mode="dispatch_read_only",
+    )
+
+    approved_ids = {"proposal:inspect:state", "proposal:summarize:state"}
+    approved_candidates = [c for c in frame.candidates if c.source_proposal_id in approved_ids]
+    assert approved_candidates, "expected approved read-only candidates to be present"
+    assert all(c.dispatch_status == "prepared_for_dispatch" for c in approved_candidates)
+
+    # Never routed into dispatched_candidates: nothing was actually sent.
+    dispatched_ids = {c.source_proposal_id for c in frame.dispatched_candidates}
+    assert not (approved_ids & dispatched_ids)
+    assert frame.dispatch_count == 0
+
+    all_candidates = frame.candidates + frame.blocked_candidates + frame.dispatched_candidates
+    assert all(c.dispatch_status != "dispatched" for c in all_candidates)
+
+
 def test_stable_frame_id() -> None:
     proposal = _proposal_frame()
     policy_frame = _policy_frame(proposal)

--- a/tests/test_execution_dispatch_frame_schemas.py
+++ b/tests/test_execution_dispatch_frame_schemas.py
@@ -101,3 +101,66 @@ def test_roundtrip_json() -> None:
     )
     restored = ExecutionDispatchFrameV1.model_validate(frame.model_dump(mode="json"))
     assert restored.frame_id == frame.frame_id
+
+
+def _base_candidate_kwargs() -> dict:
+    return dict(
+        dispatch_id="dispatch:proposal:inspect:execution_dispatch_policy.v1",
+        source_decision_id="policy.decision:proposal:inspect:substrate_policy.v1",
+        source_proposal_id="proposal:inspect:state",
+        dispatch_mode="dispatch_read_only",
+        dispatch_kind="inspect",
+        target_id="capability:orchestration",
+        target_kind="capability",
+        risk_score=0.05,
+        confidence_score=0.9,
+    )
+
+
+def test_prepared_for_dispatch_needs_no_evidence() -> None:
+    c = ExecutionDispatchCandidateV1(
+        dispatch_status="prepared_for_dispatch",
+        **_base_candidate_kwargs(),
+    )
+    assert c.dispatch_status == "prepared_for_dispatch"
+    assert c.dispatched_at is None
+    assert c.result_ref is None
+
+
+def test_dispatched_without_evidence_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ExecutionDispatchCandidateV1(
+            dispatch_status="dispatched",
+            **_base_candidate_kwargs(),
+        )
+
+
+def test_dispatched_with_only_timestamp_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ExecutionDispatchCandidateV1(
+            dispatch_status="dispatched",
+            dispatched_at=NOW,
+            **_base_candidate_kwargs(),
+        )
+
+
+def test_dispatched_with_result_ref_accepted() -> None:
+    c = ExecutionDispatchCandidateV1(
+        dispatch_status="dispatched",
+        dispatched_at=NOW,
+        result_ref="substrate_dispatch_results:abc123",
+        **_base_candidate_kwargs(),
+    )
+    assert c.dispatch_status == "dispatched"
+    assert c.result_ref == "substrate_dispatch_results:abc123"
+
+
+def test_dispatched_with_error_accepted() -> None:
+    c = ExecutionDispatchCandidateV1(
+        dispatch_status="dispatched",
+        dispatched_at=NOW,
+        dispatch_error="timeout waiting for cortex-exec reply",
+        **_base_candidate_kwargs(),
+    )
+    assert c.dispatch_status == "dispatched"
+    assert c.dispatch_error is not None

--- a/tests/test_execution_dispatch_runtime_store.py
+++ b/tests/test_execution_dispatch_runtime_store.py
@@ -115,6 +115,67 @@ def test_save_idempotent_by_frame_id(monkeypatch) -> None:
     assert any("ON CONFLICT (frame_id)" in sql for sql in calls)
 
 
+def _incompatible_dispatch_frame_payload() -> dict:
+    # dispatch_status="dispatched" without dispatched_at/result_ref/dispatch_error
+    # is now rejected by ExecutionDispatchCandidateV1's evidence validator
+    # (2026-07-13 status-honesty patch). A historical row shaped like this
+    # would previously have loaded fine; it must now degrade to None instead
+    # of raising, the same way a legacy self_state row does.
+    return {
+        "schema_version": "execution.dispatch.frame.v1",
+        "frame_id": "execution.dispatch.frame:policy.frame:legacy:execution_dispatch_policy.v1",
+        "generated_at": NOW.isoformat(),
+        "source_policy_frame_id": "policy.frame:legacy:substrate_policy.v1",
+        "source_proposal_frame_id": "proposal.frame:legacy:proposal_policy.v1",
+        "source_self_state_id": "self.state:legacy",
+        "dispatch_mode": "dispatch_read_only",
+        "dispatched_candidates": [
+            {
+                "dispatch_id": "dispatch:proposal:inspect:execution_dispatch_policy.v1",
+                "source_decision_id": "pd1",
+                "source_proposal_id": "proposal:inspect:state",
+                "dispatch_status": "dispatched",
+                "dispatch_mode": "dispatch_read_only",
+                "dispatch_kind": "inspect",
+                "target_id": "t1",
+                "target_kind": "capability",
+                "risk_score": 0.05,
+                "confidence_score": 0.9,
+            }
+        ],
+    }
+
+
+def test_load_latest_dispatch_frame_degrades_to_none_on_legacy_incompatible_row(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "dispatch_frame_json": _incompatible_dispatch_frame_payload(),
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.load_latest_dispatch_frame() is None
+
+
+def test_load_dispatch_frame_for_policy_frame_degrades_to_none_on_legacy_incompatible_row(
+    monkeypatch,
+) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "dispatch_frame_json": _incompatible_dispatch_frame_payload(),
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.load_dispatch_frame_for_policy_frame("policy.frame:legacy:substrate_policy.v1") is None
+
+
 def test_load_self_state_degrades_to_none_on_legacy_incompatible_row(monkeypatch) -> None:
     # Live incident (2026-07-12): see the identical test in
     # tests/test_policy_runtime_store.py for the full explanation. Looked up

--- a/tests/test_feedback_builder.py
+++ b/tests/test_feedback_builder.py
@@ -157,6 +157,42 @@ def test_prepared_only_dispatch() -> None:
     assert frame.outcome_status == "prepared_only"
 
 
+def test_prepared_for_dispatch_candidate_observation() -> None:
+    dispatch = ExecutionDispatchFrameV1(
+        frame_id="execution.dispatch.frame:pfd:execution_dispatch_policy.v1",
+        generated_at=NOW,
+        source_policy_frame_id="policy.frame:pfd",
+        source_proposal_frame_id="proposal.frame:pfd",
+        source_self_state_id="self.state:pfd",
+        dispatch_mode="dispatch_read_only",
+        candidates=[
+            ExecutionDispatchCandidateV1(
+                dispatch_id="dispatch:proposal:inspect:execution_dispatch_policy.v1",
+                source_decision_id="pd1",
+                source_proposal_id="proposal:inspect:state",
+                dispatch_status="prepared_for_dispatch",
+                dispatch_mode="dispatch_read_only",
+                dispatch_kind="inspect",
+                target_id="t1",
+                target_kind="capability",
+                risk_score=0.05,
+                confidence_score=0.9,
+            )
+        ],
+    )
+    frame = build_feedback_frame(
+        dispatch_frame=dispatch,
+        policy_frame=None,
+        proposal_frame=None,
+        self_state_before=None,
+        self_state_after=None,
+        cortex_results=None,
+        policy=FEEDBACK_POLICY,
+        now=NOW,
+    )
+    assert any(o.outcome_kind == "prepared_for_dispatch" for o in frame.observations)
+
+
 def test_blocked_candidate_observation() -> None:
     dispatch = _dispatch_dry_run()
     dispatch = dispatch.model_copy(
@@ -214,6 +250,8 @@ def test_missing_cortex_result_absence() -> None:
                 target_kind="capability",
                 risk_score=0.05,
                 confidence_score=0.9,
+                dispatched_at=NOW,
+                result_ref="stub:result:inspect",
             )
         ],
     )
@@ -253,6 +291,8 @@ def test_successful_cortex_result_completed() -> None:
                 target_kind="capability",
                 risk_score=0.05,
                 confidence_score=0.9,
+                dispatched_at=NOW,
+                result_ref="stub:result:inspect",
             )
         ],
     )
@@ -294,6 +334,8 @@ def test_failed_cortex_result() -> None:
                 target_kind="capability",
                 risk_score=0.05,
                 confidence_score=0.9,
+                dispatched_at=NOW,
+                dispatch_error="stub failure",
             )
         ],
     )
@@ -389,6 +431,8 @@ def test_partial_dispatch_completed_and_absent_is_mixed() -> None:
                 target_kind="capability",
                 risk_score=0.05,
                 confidence_score=0.9,
+                dispatched_at=NOW,
+                result_ref="stub:result:inspect",
             ),
             ExecutionDispatchCandidateV1(
                 dispatch_id="dispatch:proposal:summarize:execution_dispatch_policy.v1",
@@ -401,6 +445,8 @@ def test_partial_dispatch_completed_and_absent_is_mixed() -> None:
                 target_kind="capability",
                 risk_score=0.05,
                 confidence_score=0.9,
+                dispatched_at=NOW,
+                result_ref="stub:result:summarize",
             ),
         ],
     )
@@ -442,6 +488,8 @@ def test_completed_and_failed_is_mixed() -> None:
                 target_kind="capability",
                 risk_score=0.05,
                 confidence_score=0.9,
+                dispatched_at=NOW,
+                result_ref="stub:result:inspect",
             )
         ],
     )

--- a/tests/test_feedback_builder.py
+++ b/tests/test_feedback_builder.py
@@ -335,7 +335,7 @@ def test_failed_cortex_result() -> None:
                 risk_score=0.05,
                 confidence_score=0.9,
                 dispatched_at=NOW,
-                dispatch_error="stub failure",
+                result_ref="stub:result:inspect",
             )
         ],
     )

--- a/tests/test_feedback_runtime_store.py
+++ b/tests/test_feedback_runtime_store.py
@@ -100,6 +100,67 @@ def test_load_by_dispatch_frame_id(monkeypatch) -> None:
     )
 
 
+def _incompatible_dispatch_frame_payload() -> dict:
+    # dispatch_status="dispatched" without dispatched_at/result_ref/dispatch_error
+    # is now rejected by ExecutionDispatchCandidateV1's evidence validator
+    # (2026-07-13 status-honesty patch). load_latest_dispatch_frame_without_feedback
+    # is a FIFO lookup (oldest dispatch frame lacking feedback) -- a naive raise
+    # here would re-select and fail on the same row every tick forever.
+    return {
+        "schema_version": "execution.dispatch.frame.v1",
+        "frame_id": "execution.dispatch.frame:policy.frame:legacy:execution_dispatch_policy.v1",
+        "generated_at": NOW.isoformat(),
+        "source_policy_frame_id": "policy.frame:legacy:substrate_policy.v1",
+        "source_proposal_frame_id": "proposal.frame:legacy:proposal_policy.v1",
+        "source_self_state_id": "self.state:legacy",
+        "dispatch_mode": "dispatch_read_only",
+        "dispatched_candidates": [
+            {
+                "dispatch_id": "dispatch:proposal:inspect:execution_dispatch_policy.v1",
+                "source_decision_id": "pd1",
+                "source_proposal_id": "proposal:inspect:state",
+                "dispatch_status": "dispatched",
+                "dispatch_mode": "dispatch_read_only",
+                "dispatch_kind": "inspect",
+                "target_id": "t1",
+                "target_kind": "capability",
+                "risk_score": 0.05,
+                "confidence_score": 0.9,
+            }
+        ],
+    }
+
+
+def test_load_latest_dispatch_frame_without_feedback_degrades_to_none_on_legacy_row(
+    monkeypatch,
+) -> None:
+    store = FeedbackRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "dispatch_frame_json": _incompatible_dispatch_frame_payload(),
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.load_latest_dispatch_frame_without_feedback() is None
+
+
+def test_load_latest_dispatch_frame_degrades_to_none_on_legacy_row(monkeypatch) -> None:
+    store = FeedbackRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "dispatch_frame_json": _incompatible_dispatch_frame_payload(),
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.load_latest_dispatch_frame() is None
+
+
 def test_save_idempotent_by_frame_id(monkeypatch) -> None:
     store = FeedbackRuntimeStore("postgresql://test:test@localhost/test")
     fake_engine = MagicMock()


### PR DESCRIPTION
# fix(execution-dispatch): un-lie dispatch_status (P0 of the motor-nerve spec)

## Summary

- `orion/execution_dispatch/builder.py` claimed `dispatch_status="dispatched"` for read-only candidates while never sending anything — no executor exists anywhere in the repo. Now emits the honest `prepared_for_dispatch`.
- `ExecutionDispatchCandidateV1.dispatch_status="dispatched"` now requires evidence (`dispatched_at` + `result_ref`/`dispatch_error`) via a model validator — the status can no longer be claimed without proof a send was attempted.
- `orion/feedback/builder.py` classifies/scores the new status; 6 existing test fixtures that simulated a genuinely-dispatched candidate were repaired with the now-required evidence fields.
- Code review caught that the new validator could raise on historical Postgres rows predating it. Live-queried `substrate_execution_dispatch_frames` directly (687,992 rows, 0 affected) to confirm today's data is safe, then added the same `try/except ValidationError → None` guard this codebase already uses for an identical 2026-07-12 self-state incident, at all 4 affected loaders.

## Outcome moved

Layer 9's status vocabulary no longer lies. `dispatch_status="dispatched"` is now a claim that requires evidence to make; `prepared_for_dispatch` is the honest name for "cleared every gate, never sent." This is P0 of `docs/superpowers/specs/2026-07-13-endogenous-action-motor-nerve-spec.md` — the precondition for P1 (an actual sender) to exist without inheriting a broken status contract.

## Current architecture

`build_execution_dispatch_frame` (Layer 9) converts approved policy decisions into `ExecutionDispatchCandidateV1` envelopes. For `dispatch_mode="dispatch_read_only"` + `allow_dispatch_read_only=True`, it previously set `dispatch_status="dispatched"` despite only constructing a request-envelope dict — no bus publish, no cortex-exec call, nothing sent. Live policy default (`allow_dispatch_read_only: false`) meant this was unreachable in production, but was directly exercised by test fixtures and would have misled any future consumer.

## Architecture touched

`orion/schemas/execution_dispatch_frame.py`, `orion/schemas/feedback_frame.py`, `orion/execution_dispatch/builder.py`, `orion/feedback/builder.py`, plus the 4 Postgres-backed loaders of `ExecutionDispatchFrameV1` in `services/orion-execution-dispatch-runtime/app/store.py`, `services/orion-feedback-runtime/app/store.py`, and `services/orion-hub/scripts/substrate_execution_dispatch_routes.py`.

## Files changed

- `orion/schemas/execution_dispatch_frame.py` — `prepared_for_dispatch` status literal; `result_ref`/`dispatch_error`/`dispatched_at` fields; evidence-requiring validator.
- `orion/schemas/feedback_frame.py` — `prepared_for_dispatch` added to `OutcomeObservationV1.outcome_kind`.
- `orion/execution_dispatch/builder.py` — one-line status fix; comment marking the now-unreachable `max_dispatches_per_tick` branch.
- `orion/feedback/builder.py` — classification + scoring for `prepared_for_dispatch`.
- `services/orion-execution-dispatch-runtime/app/store.py`, `services/orion-feedback-runtime/app/store.py`, `services/orion-hub/scripts/substrate_execution_dispatch_routes.py` — degrade-to-`None` guards on `ExecutionDispatchFrameV1.model_validate()`.
- `services/orion-execution-dispatch-runtime/README.md` — documents the status vocabulary.
- `tests/test_execution_dispatch_frame_schemas.py`, `tests/test_execution_dispatch_builder.py`, `tests/test_feedback_builder.py`, `tests/test_execution_dispatch_runtime_store.py`, `tests/test_feedback_runtime_store.py` — new/repaired coverage.
- `docs/superpowers/specs/2026-07-13-execution-dispatch-status-honesty-design.md` — design doc for this patch.

## Schema / bus / API changes

- **Added:** `dispatch_status="prepared_for_dispatch"`; `ExecutionDispatchCandidateV1.result_ref`/`dispatch_error`/`dispatched_at` (all optional).
- **Removed:** none.
- **Renamed:** none.
- **Behavior changed:** `dispatch_status="dispatched"` now raises `ValidationError` unless evidenced. The `dispatch_read_only` builder branch now produces `prepared_for_dispatch`, so `dispatched_candidates`/`dispatch_count` are honestly empty/zero until a future sender exists (this also makes the `max_dispatches_per_tick` rate-limit branch dead code for now — commented, not removed).
- **Compatibility notes:** live-verified via direct Postgres query — 687,992 rows in `substrate_execution_dispatch_frames`, 0 with a nonempty `dispatched_candidates` list — no historical row is broken by the new validator. Defensive guards added regardless, matching this codebase's established pattern.

## Env/config changes

- Added keys: none.
- Removed keys: none.
- Renamed keys: none.
- `.env_example` updated: no.
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: not applicable, no env template changed.
- skipped keys requiring operator action: none.

## Tests run

```text
cd /mnt/scripts/Orion-Sapienform-execution-dispatch-status-honesty
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest \
  tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_envelopes.py \
  tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_policy_loader.py \
  tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_runtime_worker.py \
  tests/test_execution_dispatch_transport_dry_run.py tests/test_feedback_builder.py \
  tests/test_feedback_runtime_store.py tests/test_feedback_transport_outcomes.py \
  tests/test_consolidation_tensorize.py tests/test_consolidation_schema_candidates.py \
  tests/test_consolidation_motif_detection.py tests/test_consolidation_expectations.py \
  tests/test_consolidation_policy_loader.py services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py -q

93 passed in 2.20s
```

## Evals run

None — this service has no `evals/` harness; not required for a schema-honesty patch with no quality/behavior dimension to measure.

## Docker/build/smoke checks

Not run — no runtime behavior, port, dependency, or compose wiring changed. Compatibility was instead verified with a direct live Postgres query (see below) rather than a container smoke, since the risk was schema/data compatibility, not runtime wiring.

```text
PGPASSWORD=postgres psql -h localhost -p 55432 -U postgres -d conjourney -c "
select count(*) as total_rows,
       count(*) filter (where dispatch_frame_json::jsonb -> 'dispatched_candidates' <> '[]'::jsonb) as rows_with_nonempty_dispatched_candidates
from substrate_execution_dispatch_frames;"
 total_rows | rows_with_nonempty_dispatched_candidates
------------+------------------------------------------
     687992 |                                        0
```

## Review findings fixed

- Finding: New evidence-requiring validator has no guard on 4 `model_validate()` loaders of historical `ExecutionDispatchFrameV1` rows — same failure class as a 2026-07-12 self-state incident already fixed elsewhere in this codebase, worst case a permanently-wedged feedback FIFO.
  - Fix: Live-queried the actual table (687,992 rows, 0 affected today) for ground truth, then added `try/except ValidationError → logger.warning → return None` at all 4 sites, matching the established `load_self_state` pattern.
  - Evidence: 4 new regression tests (`test_load_latest_dispatch_frame_degrades_to_none_on_legacy_incompatible_row` etc.) constructing a legacy-shaped payload and asserting `None` instead of a raise; all pass.
- Finding: The `max_dispatches_per_tick` rate-limit branch in `builder.py` becomes permanently unreachable once nothing sets `dispatch_status="dispatched"` from this function — a real but deliberate consequence, undocumented.
  - Fix: Added an inline comment naming exactly why and when it becomes reachable again (a future sender).
  - Evidence: `orion/execution_dispatch/builder.py:223-227`.
- Finding: `test_failed_cortex_result` paired `dispatch_error` (send itself failed) with a `cortex_results` entry claiming `status: "failed"` (send succeeded, cortex responded with failure) — two contradictory failure stories in one fixture.
  - Fix: Switched to `result_ref`, matching the other 5 repaired fixtures' coherent "send succeeded, then outcome determined" story.
  - Evidence: `tests/test_feedback_builder.py::test_failed_cortex_result`, still asserts `outcome_status == "failed"`, now for the right reason.

## Restart required

```text
No restart required.
```

No runtime config changed; this is a pure code patch. The next deploy of `orion-execution-dispatch-runtime`, `orion-feedback-runtime`, and `orion-hub` will pick it up normally.

## Risks / concerns

- Severity: low
- Concern: P1 (the actual sender) doesn't exist yet, so `prepared_for_dispatch` candidates will accumulate with no promotion path until that patch lands. Not a regression — this is the same "nothing is dispatched" state as before, just honestly labeled now.
- Mitigation: none needed; this is explicitly the intended P0 end-state per the parent spec.
