### PR TITLE
fix(workflow-notify): stop truncating completion emails to 280 chars

### DIFF
--- a/services/orion-cortex-orch/app/workflow_runtime.py
+++ b/services/orion-cortex-orch/app/workflow_runtime.py
@@ -365,13 +365,14 @@ async def _emit_workflow_notify(
     status = "completed" if ok else "failed"
     event_kind = "orion.workflow.completed" if ok else "orion.workflow.failed"
     title = f"Workflow {workflow_name} {status}"
-    preview = f"{workflow_name} {status}. {final_text}".strip()[:280]
+    body = f"{workflow_name} {status}.\n\n{final_text}".strip()
+    preview = body[:280]
     notification = NotificationRequest(
         source_service=source.name or "orion-cortex-orch",
         event_kind=event_kind,
         severity="info" if ok else "warning",
         title=title,
-        body_text=preview,
+        body_text=body,
         body_md=final_text,
         recipient_group=recipient_group or "juniper_primary",
         session_id=req.context.session_id or "workflow",
@@ -2465,8 +2466,10 @@ async def _execute_chat_history_compactor_pass(
         main_result = (
             f"Compacted {window.turn_count} chat turn(s) for {window_spec.compactor_index}."
         )
+        if digest.card_summary:
+            main_result = f"{main_result}\n\n{digest.card_summary}"
         if journal_entry:
-            main_result = f"{main_result} Journal entry {journal_entry.get('entry_id')}."
+            main_result = f"{main_result}\n\nJournal entry {journal_entry.get('entry_id')}."
         if card_id:
             main_result = f"{main_result} Memory card {card_id}."
 

--- a/services/orion-cortex-orch/tests/test_workflow_lane.py
+++ b/services/orion-cortex-orch/tests/test_workflow_lane.py
@@ -2582,6 +2582,95 @@ def test_chat_history_compactor_pass_upserts_card_and_writes_journal(monkeypatch
     assert card_calls.get("digest") is not None
     assert any(ch == "orion:journal:write" for ch, _ in bus.published)
     assert digest_routes[0] == "chat"
+    assert "Discussed indexed memory card upserts." in (result.final_text or "")
+
+
+def test_chat_history_compactor_pass_completion_notify_carries_full_digest_not_truncated_preview(monkeypatch) -> None:
+    bus = DummyBus()
+
+    async def _fake_call_verb_runtime(*args, **kwargs):
+        req = kwargs["client_request"]
+        if req.verb == "skills.chat.discussion_window.v1":
+            skill = {
+                "window_start_utc": "2026-07-09T04:00:00+00:00",
+                "window_end_utc": "2026-07-09T10:00:00+00:00",
+                "turn_count": 1,
+                "turns": [
+                    {
+                        "created_at": "2026-07-09T05:00:00+00:00",
+                        "correlation_id": "corr-a",
+                        "prompt": "hi",
+                        "response": "hello",
+                    }
+                ],
+                "transcript_text": "user: hi\norion: hello",
+                "selection_strategy": "time_bound_then_contiguous_suffix",
+            }
+            return DummyVerbResult(
+                payload={
+                    "result": {
+                        "status": "success",
+                        "final_text": json.dumps(skill),
+                        "metadata": {"skill_result": skill},
+                    }
+                }
+            )
+        if req.verb == "chat_history_compactor_digest_v1":
+            # Long enough that a naive 280-char preview would truncate it away entirely.
+            digest = {
+                "card_summary": "Notable theme discussed at length. " * 12,
+                "journal_title": "Chat digest — daily",
+                "journal_body": "Narrative body.",
+                "turn_refs": ["corr-a"],
+            }
+            return DummyVerbResult(
+                payload={
+                    "result": {
+                        "status": "success",
+                        "final_text": json.dumps(digest),
+                        "metadata": {"chat_history_compactor_digest": digest},
+                    }
+                }
+            )
+        raise AssertionError(f"unexpected verb {req.verb}")
+
+    async def _fake_persist_card(**kwargs):
+        return uuid4()
+
+    monkeypatch.setattr(
+        "app.workflow_runtime.persist_chat_history_compactor_memory_card",
+        _fake_persist_card,
+    )
+
+    req = _req_with_policy(
+        "chat_history_compactor_pass",
+        {
+            "workflow_id": "chat_history_compactor_pass",
+            "invocation_mode": "immediate",
+            "notify_on": "completion",
+            "recipient_group": "juniper_primary",
+        },
+    )
+
+    asyncio.run(
+        execute_chat_workflow(
+            bus=bus,
+            source=ServiceRef(name="cortex-orch"),
+            req=req,
+            correlation_id="00000000-0000-0000-0000-000000000302",
+            causality_chain=[],
+            trace={},
+            call_verb_runtime=_fake_call_verb_runtime,
+        )
+    )
+
+    notify_envelopes = [
+        env for ch, env in bus.published if ch == "orion:notify:persistence:request"
+    ]
+    assert len(notify_envelopes) == 1
+    payload = notify_envelopes[0].payload
+    assert "Notable theme discussed at length." in payload["body_text"]
+    assert len(payload["body_text"]) > 280
 
 
 def test_chat_history_compactor_pass_quiet_day_skips_card(monkeypatch) -> None:


### PR DESCRIPTION
Juniper reported the chat history compactor's completion email said only "ran the job" with no actual digest content. Root-caused two compounding bugs:

1. chat_history_compactor_pass's main_result never included the digest's card_summary — only turn counts and persisted IDs.
2. _emit_workflow_notify put a hard 280-char preview in body_text, and EmailTransport.send() picks body_text over body_md whenever body_text is non-empty (matching every other notification producer in the repo, which all put full content in body_text). The 280-char cap silently ate the digest before it ever reached an inbox.

Fixes both: card_summary now flows into main_result/final_text, and body_text carries the full text (matching the rest of the codebase's convention) with the short preview kept in context.preview_text for UI list views. Hub's notification list already truncates+expands long body_text client-side, so this only improves that surface.