### PR TITLE
Feat/concept relation decision loop

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-concept-relation-decision-loop-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-concept-relation-decision-loop-pr.md
@@ -1,0 +1,122 @@
+# PR report: concept-relation decision log + belief-revision digest
+
+Implements item 1 of `docs/superpowers/specs/2026-07-13-recall-followups-loop-retirement-saturation-gate-spec.md`.
+
+## Summary
+
+- `maybe_resolve_concept_relation()`'s LLM decisions were only observable via a log line that fired *after* the confidence-floor/relation filter — every `unrelated` decision and every sub-floor `contradicts`/`refines` decision vanished silently. Now every real LLM decision writes a row to a new `memory_concept_relation_decisions` table, regardless of outcome.
+- New `scripts/concept_relation_digest.py` reads undigested rows and produces two things in one pass: a threshold-tuning report (call volume, relation distribution, near-miss counts below `CONCEPT_RELATION_CONFIDENCE_FLOOR`), and — for real belief-revision decisions (`same`/`refines`/`contradicts` that cleared the floor) — a new `reflection`-kind crystallization: a deterministic, non-LLM trace of Orion revising its own beliefs over time.
+- `reflection` is a new `CrystallizationKind` with a real `salience.py::KIND_BASE` entry (0.4) so it participates in real ranking, not an inert schema-valid label — satisfies this repo's "no keyword cathedral" requirement (producer + consumer in the same patch).
+- Self-caught review finding, already fixed: the decision-log write was initially unguarded — wrapped in try/except so a transient DB error on this purely observational write can no longer take down an entire consolidation window.
+- Live-verified end to end, twice (once by the implementing agent, once independently by the orchestrator): seed a real decision, run the digest, confirm a real reflection crystallization lands in Postgres with real salience/confidence, confirm a second run produces zero duplicates.
+
+## Outcome moved
+
+The concept-relation resolver (proven working in PR #1000) goes from "we can only see its decisive outputs" to "every decision is inspectable, including the near-misses that would tell us if the 0.6 floor needs retuning" — and its real belief revisions now leave a structured trace instead of disappearing into a link table nobody reads back.
+
+## Current architecture (before this patch)
+
+`maybe_resolve_concept_relation()` called a real LLM, computed a relation + confidence, and either attached a link/reinforced a match (decisive outcomes) or returned `None` silently (everything else). No table, no digest, no `reflection` kind existed.
+
+## Architecture touched
+
+`orion/memory/crystallization/` (schema, salience, concept_relation, repository), one new top-level script, one new SQL table (via the existing idempotent-DDL-file mechanism, not a new migration-file system — this repo has none).
+
+## Files changed
+
+- `orion/core/storage/sql/memory_crystallizations.sql`: new `memory_concept_relation_decisions` table (`CREATE TABLE IF NOT EXISTS`, matching how `memory_crystallization_retrieval_events` already lives in the same file) + index on `(digested, decided_at)`.
+- `orion/memory/crystallization/repository.py`: `insert_concept_relation_decision()`, mirroring `insert_retrieval_event()`'s exact shape.
+- `orion/memory/crystallization/concept_relation.py`: `maybe_resolve_concept_relation()` now inserts a decision row (try/except-guarded) after `resolve_concept_relation()` returns, before the existing floor/relation filter — so nothing vanishes silently anymore.
+- `orion/memory/crystallization/schemas.py`: `reflection` added to `CrystallizationKind`; `concept_relation_decision` added to `CrystallizationSourceKind` (required for the reflection crystallization's evidence ref — schema is `extra="forbid"`).
+- `orion/memory/crystallization/salience.py`: `reflection` added to `KIND_BASE` at 0.4 (below `episode`'s 0.45 — the lowest tier, since these are meta-observations about the decision loop itself, not first-hand evidence).
+- `scripts/concept_relation_digest.py` (new): standalone script matching `check_activation_saturation.py`'s exact conventions (argparse, `POSTGRES_URI`/`--postgres-uri`, `--json`, sys.path guard). Runs the whole read/create-reflections/mark-digested sequence inside one real Postgres transaction via a `_SingleConnPool` shim, so a mid-run crash rolls back cleanly instead of double-creating reflections on retry.
+- Tests: `tests/test_memory_crystallization_concept_relation.py` (decision-log round-trip, unrelated/sub-floor decisions now logged, write-failure-doesn't-break-formation regression), `tests/test_concept_relation_digest.py` (report counts, reflection creation gated correctly on `floor_cleared`, second-run-no-duplicates, clean-empty-run), `tests/test_memory_crystallization.py` (`reflection` kind scores real nonzero salience).
+
+## Design decisions worth flagging
+
+**Status `"active"`, not `"proposed"`.** Reflection crystallizations are system-derived observations about the decision loop's own history, not claims requiring governor review — same trust tier as other automated provenance already in this codebase. `governance.approved_by`/`approval_mode` set to `"system:concept_relation_digest"`/`"auto_policy"` to make that origin explicit and auditable, not hidden behind a human-looking approval.
+
+**One transaction, not a naive read-then-write.** The `_SingleConnPool` shim lets `insert_crystallization()` (which expects a real `asyncpg.Pool`) run on the same already-open connection/transaction as the digest's own reads and digested-flag update. This is the correct fix for the obvious failure mode (crash mid-digest leaving some rows digested with no reflection, or vice versa) rather than leaving it as a known gap.
+
+**No new migration-file system invented.** This repo's schema for `orion/memory/crystallization/` lives in one idempotent `CREATE TABLE IF NOT EXISTS`-per-table SQL file, re-applied wholesale via `apply_memory_crystallizations_schema()`. The new table was added there, not as a new standalone migration mechanism.
+
+## Schema / bus / API changes
+
+- Added: `memory_concept_relation_decisions` table (new, additive). `reflection` `CrystallizationKind` value (new, additive — existing kind-based logic elsewhere either explicitly lists kinds it cares about, unaffected by an unlisted new one, or falls back safely, per the implementing agent's review pass confirming `KIND_TO_BUCKET.get()` has a safe default and `formation_policy.GATED_KINDS` doesn't need this kind since the digest bypasses the governor path entirely).
+- Removed: none.
+- Behavior changed: `maybe_resolve_concept_relation()` now performs one additional DB write per real LLM decision (previously zero for non-decisive outcomes). Guarded to never raise.
+- Compatibility notes: no existing caller's contract changes; the new write is purely additive and independently guarded.
+
+## Env/config changes
+
+None. No new env keys — `CONCEPT_RELATION_CONFIDENCE_FLOOR` (pre-existing) is read, not changed.
+
+## Tests run
+
+```text
+$ source venv/bin/activate && python -m pytest tests/test_memory_crystallization_concept_relation.py \
+    tests/test_memory_crystallization.py tests/test_concept_relation_digest.py \
+    tests/test_encode_reinforce_not_duplicate.py -v
+78 passed, 1 failed
+```
+The 1 failure (`TestMemoryCardBackwardCompat::test_memory_card_v1_unchanged_in_registry_gap`) is the same pre-existing, unrelated failure confirmed multiple times earlier this session (registry-gap issue, zero relation to this patch's files). Independently re-run by the orchestrator, not taken from the implementing agent's report alone.
+
+## Evals run
+
+No eval harness applies — this is deterministic aggregation logic, fully covered by the unit tests above. The live verification below is the standard this session holds "does it actually work" claims to.
+
+## Docker/build/smoke checks
+
+```text
+# Schema applied live, confirmed via \d:
+$ psql -c '\d memory_concept_relation_decisions'
+(all 8 columns present as designed, including the digested/decided_at index)
+
+# Orchestrator's own independent live end-to-end run (separate from the implementing
+# agent's own verification, seeded fresh, not reusing their test data):
+$ python verify_concept_relation_digest.py
+seeded target: e4dde759-dbad-4508-a3fd-c01e9b2850dd
+seeded decision: 0cf96e0d-24d5-4e21-8000-91f457e7f9ca
+
+$ POSTGRES_URI=postgresql://postgres:postgres@127.0.0.1:55432/conjourney python scripts/concept_relation_digest.py
+concept_relation_digest: 1 decision(s) since last run
+  relation distribution: contradicts: 1 (rest 0)
+  near-misses: contradicts: 0, refines: 0
+  reflection crystallizations created: 1
+    040407e5-4f06-4638-883f-6e84c2133901
+
+$ (second run) -> "0 decision(s) since last run ... nothing new to report." (no duplicate)
+
+# Confirmed the reflection crystallization actually landed correctly, by direct query:
+$ psql -c "select crystallization_id, kind, status, subject, salience, confidence
+           from memory_crystallizations where crystallization_id='040407e5-...'"
+040407e5-... | reflection | active | Concept relation decision: contradicts | 0.491 | possible
+```
+Real, non-zero, non-default salience (0.491) and a real computed confidence (`possible`, via the already-merged `infer_confidence()` from PR #1002) — not an empty-shell stub. Test rows deprecated/deleted after verification, no permanent pollution.
+
+## Review findings fixed
+
+- Finding: `insert_concept_relation_decision()`'s call site in `maybe_resolve_concept_relation()` was unguarded — unlike `resolve_concept_relation()` (documented to never raise), a transient DB error on this purely observational write would propagate up through `intake_pipeline.py` and fail an entire consolidation window over the loss of one diagnostic row.
+  - Fix: wrapped in `try/except Exception` with a `logger.warning`, matching the file's existing never-raise convention.
+  - Evidence: commit `4429bf74`; new regression test `test_decision_log_write_failure_does_not_break_formation` asserts `maybe_resolve_concept_relation()` still returns the correct outcome even when the decision-log insert raises.
+
+Orchestrator independently re-read every diff in full, re-ran the full targeted test suite, and ran an independent live end-to-end verification (fresh seed data, not reused from the implementing agent's own run) rather than trusting the report alone.
+
+## Restart required
+
+```text
+No restart required for the code itself (no env/schema-deploy-time changes beyond the
+idempotent SQL file, which orion-memory-consolidation and orion-hub already re-apply on
+their normal startup path via apply_memory_crystallizations_schema()).
+```
+
+## Risks / concerns
+
+- Severity: Low — `scripts/concept_relation_digest.py` is on-demand/cron-category, not a live service loop (matches the spec's explicit non-goal). Nothing runs it automatically yet; someone needs to invoke it (manually or via a future scheduled job) for the loop to actually close in production. This mirrors `check_activation_saturation.py`'s exact same status.
+- Severity: Low — `reflection` crystallizations are created with `requires_manual_review=False` and never surface in the governor review queue by design (system-derived, not requiring human approval). If this trust level is ever reconsidered, the change is isolated to `_build_reflection_crystallization()`'s governance fields.
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/concept-relation-decision-loop?expand=1`

--- a/orion/core/storage/sql/memory_crystallizations.sql
+++ b/orion/core/storage/sql/memory_crystallizations.sql
@@ -104,6 +104,26 @@ CREATE TABLE IF NOT EXISTS memory_crystallization_retrieval_events (
     created_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- Decision log for maybe_resolve_concept_relation() (orion/memory/crystallization/
+-- concept_relation.py). One row per real LLM classification call, regardless of which
+-- way the confidence-floor / relation branch below it goes -- previously only the
+-- decisive outcome reached a log line, so every "unrelated" decision and every
+-- sub-floor "contradicts"/"refines" decision vanished silently. `digested` is a simple
+-- watermark for scripts/concept_relation_digest.py so repeated runs don't reprocess
+-- rows (no separate cursor-state table).
+CREATE TABLE IF NOT EXISTS memory_concept_relation_decisions (
+    decision_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    candidate_crystallization_id text NOT NULL,
+    target_crystallization_id text,
+    relation text NOT NULL,
+    confidence numeric NOT NULL,
+    floor_cleared boolean NOT NULL,
+    decided_at timestamptz NOT NULL DEFAULT now(),
+    digested boolean NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcrd_digested ON memory_concept_relation_decisions (digested, decided_at);
+
 CREATE INDEX IF NOT EXISTS idx_mcr_status ON memory_crystallizations (status);
 CREATE INDEX IF NOT EXISTS idx_mcr_kind ON memory_crystallizations (kind);
 CREATE INDEX IF NOT EXISTS idx_mcr_salience ON memory_crystallizations (salience DESC);

--- a/orion/memory/crystallization/concept_relation.py
+++ b/orion/memory/crystallization/concept_relation.py
@@ -234,14 +234,25 @@ async def maybe_resolve_concept_relation(
     # vanished silently. scripts/concept_relation_digest.py reads this table to surface
     # those near-misses (threshold-tuning report) and to produce belief-revision
     # "reflection" crystallizations for the ones that did clear the floor.
-    await insert_concept_relation_decision(
-        pool,
-        candidate_crystallization_id=candidate.crystallization_id,
-        target_crystallization_id=decision.target_crystallization_id,
-        relation=decision.relation,
-        confidence=decision.confidence,
-        floor_cleared=floor_cleared,
-    )
+    #
+    # This write is purely observational -- unlike resolve_concept_relation() above
+    # (which is documented to NEVER raise), a DB error here must not propagate and take
+    # down the whole formation flow. Before this patch nothing between here and the
+    # caller's insert_crystallization() could fail this early; a swallowed exception on
+    # a diagnostic log write is a strictly better failure mode than losing an entire
+    # consolidation window over it (see services/orion-memory-consolidation's
+    # mark_failed(window_id) on any uncaught exception).
+    try:
+        await insert_concept_relation_decision(
+            pool,
+            candidate_crystallization_id=candidate.crystallization_id,
+            target_crystallization_id=decision.target_crystallization_id,
+            relation=decision.relation,
+            confidence=decision.confidence,
+            floor_cleared=floor_cleared,
+        )
+    except Exception as exc:
+        logger.warning("concept_relation_decision_log_failed error=%s", exc)
 
     if decision.relation == "unrelated" or not floor_cleared:
         return None

--- a/orion/memory/crystallization/concept_relation.py
+++ b/orion/memory/crystallization/concept_relation.py
@@ -12,7 +12,7 @@ from orion.core.llm_json import parse_json_object
 from orion.memory.crystallization.bus_emit import emit_crystallization_lifecycle
 from orion.memory.crystallization.candidate_retrieval import fetch_similar_candidates
 from orion.memory.crystallization.dynamics import reinforce
-from orion.memory.crystallization.repository import update_crystallization
+from orion.memory.crystallization.repository import insert_concept_relation_decision, update_crystallization
 from orion.memory.crystallization.schemas import (
     CrystallizationLinkV1,
     MemoryCrystallizationV1,
@@ -226,7 +226,24 @@ async def maybe_resolve_concept_relation(
     # Plain getattr default (no `or` fallback): CONCEPT_RELATION_CONFIDENCE_FLOOR=0.0
     # is a legitimate "accept every LLM decision" operator setting.
     confidence_floor = float(getattr(settings, "CONCEPT_RELATION_CONFIDENCE_FLOOR", 0.6))
-    if decision.relation == "unrelated" or decision.confidence < confidence_floor:
+    floor_cleared = decision.confidence >= confidence_floor
+
+    # Record every real decision here, before the filter below discards anything --
+    # previously only the decisive outcome reached a log line (see logger.info below),
+    # so every "unrelated" decision and every sub-floor "contradicts"/"refines" decision
+    # vanished silently. scripts/concept_relation_digest.py reads this table to surface
+    # those near-misses (threshold-tuning report) and to produce belief-revision
+    # "reflection" crystallizations for the ones that did clear the floor.
+    await insert_concept_relation_decision(
+        pool,
+        candidate_crystallization_id=candidate.crystallization_id,
+        target_crystallization_id=decision.target_crystallization_id,
+        relation=decision.relation,
+        confidence=decision.confidence,
+        floor_cleared=floor_cleared,
+    )
+
+    if decision.relation == "unrelated" or not floor_cleared:
         return None
 
     target = next((c for c in candidates if c.crystallization_id == decision.target_crystallization_id), None)

--- a/orion/memory/crystallization/repository.py
+++ b/orion/memory/crystallization/repository.py
@@ -473,3 +473,34 @@ async def insert_retrieval_event(
             _jsonb(trace),
         )
     return str(row["retrieval_event_id"])
+
+
+async def insert_concept_relation_decision(
+    pool: asyncpg.Pool,
+    *,
+    candidate_crystallization_id: str,
+    target_crystallization_id: str | None,
+    relation: str,
+    confidence: float,
+    floor_cleared: bool,
+) -> str:
+    """Records every real `maybe_resolve_concept_relation()` LLM decision, not just the
+    decisive ones -- see memory_concept_relation_decisions in memory_crystallizations.sql.
+    Callers should insert regardless of which way the confidence-floor / relation branch
+    goes so `scripts/concept_relation_digest.py` can see near-misses that would otherwise
+    vanish silently."""
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO memory_concept_relation_decisions
+                (candidate_crystallization_id, target_crystallization_id, relation, confidence, floor_cleared)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING decision_id
+            """,
+            candidate_crystallization_id,
+            target_crystallization_id,
+            relation,
+            confidence,
+            floor_cleared,
+        )
+    return str(row["decision_id"])

--- a/orion/memory/crystallization/salience.py
+++ b/orion/memory/crystallization/salience.py
@@ -12,6 +12,11 @@ KIND_BASE = {
     "failure_mode": 0.55,
     "semantic": 0.5,
     "episode": 0.45,
+    # System-generated observations about the concept-relation decision loop itself
+    # (scripts/concept_relation_digest.py), not a first-hand stance/decision/fact --
+    # lowest of the scale, below "episode", since these are meta-observations about
+    # prior reasoning rather than any direct evidence about the world.
+    "reflection": 0.4,
 }
 
 CONFIDENCE_BOOST = {

--- a/orion/memory/crystallization/schemas.py
+++ b/orion/memory/crystallization/schemas.py
@@ -17,6 +17,7 @@ CrystallizationKind = Literal[
     "attractor",
     "decision",
     "failure_mode",
+    "reflection",
 ]
 
 CrystallizationStatus = Literal[
@@ -49,6 +50,9 @@ CrystallizationSourceKind = Literal[
     "graphiti_episode",
     "operator_note",
     "autonomy_episode",
+    # scripts/concept_relation_digest.py's evidence ref back onto the
+    # memory_concept_relation_decisions row a "reflection" crystallization summarizes.
+    "concept_relation_decision",
 ]
 
 CrystallizationRelation = Literal[

--- a/scripts/concept_relation_digest.py
+++ b/scripts/concept_relation_digest.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Threshold-tuning report + belief-revision digest for
+`maybe_resolve_concept_relation()` (orion/memory/crystallization/concept_relation.py).
+
+Context: that function classifies every new crystallization against similar existing
+ones via a real LLM call (same/refines/contradicts/unrelated, with a confidence float
+gated by CONCEPT_RELATION_CONFIDENCE_FLOOR, default 0.6). Until this patch, only the
+*decisive* outcome reached a log line -- every "unrelated" decision and every sub-floor
+"contradicts"/"refines" decision vanished silently. Those decisions are now written to
+`memory_concept_relation_decisions` (see orion/core/storage/sql/memory_crystallizations.sql)
+by `insert_concept_relation_decision()` regardless of outcome. This script is the reader
+that makes that table worth having -- a write-only log is the same "theater" pattern this
+repo has already killed twice (see docs/superpowers/specs/2026-07-13-recall-followups-
+loop-retirement-saturation-gate-spec.md, section 1).
+
+Two things happen per run, over every row with digested = false:
+
+1. Threshold-tuning report (printed, and available via --json): call volume, the
+   same/refines/contradicts/unrelated distribution, and specifically how many
+   contradicts/refines decisions had floor_cleared = false -- i.e. the LLM judged a real
+   relation but confidence landed under the floor. Those are near-misses invisible
+   until now; this report exists so a human can decide whether CONCEPT_RELATION_
+   CONFIDENCE_FLOOR needs retuning. Nothing here is auto-applied.
+
+2. Belief-revision digest: for every row where relation is contradicts/refines/same AND
+   floor_cleared = true (i.e. the ones concept_relation.py actually acted on -- attached
+   a link or reinforced a match), write one new `reflection`-kind crystallization with a
+   deterministic (no LLM) summary of the row's own fields. This is Orion's own trace of
+   revising its beliefs over time -- AGENTS.md's "error correction... coherent action
+   over time" sentence prerequisite, given a real producer.
+
+No LLM call happens anywhere in this script -- it is pure aggregation over decisions
+`concept_relation.py` already classified. It never auto-supersedes or mutates any
+existing crystallization's status; it only reports and creates new, purely observational
+`reflection` records.
+
+Not a service loop -- a standalone script you run on demand or via cron, same category
+as scripts/check_activation_saturation.py.
+
+Usage:
+    POSTGRES_URI=postgresql://user:pass@host:port/db python scripts/concept_relation_digest.py
+    python scripts/concept_relation_digest.py --postgres-uri postgresql://...
+    python scripts/concept_relation_digest.py --json
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/concept_relation_digest.py` puts scripts/ on sys.path[0],
+# which shadows stdlib modules (same issue documented in
+# scripts/check_inner_state_registry.py / scripts/check_activation_saturation.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+_REPO_ROOT = str(Path(__file__).resolve().parents[1])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+_RELATIONS = ("same", "refines", "contradicts", "unrelated")
+_ACTIONABLE_RELATIONS = ("same", "refines", "contradicts")
+
+_SELECT_PENDING_SQL = """
+    SELECT decision_id, candidate_crystallization_id, target_crystallization_id,
+           relation, confidence, floor_cleared, decided_at
+    FROM memory_concept_relation_decisions
+    WHERE digested = false
+    ORDER BY decided_at
+"""
+
+_MARK_DIGESTED_SQL = """
+    UPDATE memory_concept_relation_decisions
+    SET digested = true
+    WHERE decision_id = ANY($1::uuid[])
+"""
+
+
+class _SingleConnPool:
+    """Thin shim so repository.py::insert_crystallization() (which expects an
+    asyncpg.Pool and calls pool.acquire()) can run on the SAME already-open connection
+    and transaction as this script's own read + digested-flag update. That keeps the
+    whole run (reads, reflection-crystallization inserts, digested-flag writes) inside
+    one real transaction, so a crash mid-run rolls everything back and the next run
+    reprocesses cleanly instead of double-creating reflections."""
+
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    def acquire(self) -> "_SingleConnPool":
+        return self
+
+    async def __aenter__(self) -> Any:
+        return self._conn
+
+    async def __aexit__(self, *exc_info: Any) -> bool:
+        return False
+
+
+@dataclass
+class DigestReport:
+    decisions_seen: int
+    relation_counts: dict[str, int]
+    near_miss_counts: dict[str, int]  # contradicts/refines with floor_cleared=false
+    reflections_created: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decisions_seen": self.decisions_seen,
+            "relation_counts": self.relation_counts,
+            "near_miss_counts": self.near_miss_counts,
+            "reflections_created": self.reflections_created,
+        }
+
+
+def _build_reflection_summary(row: dict[str, Any]) -> str:
+    relation = row["relation"]
+    confidence = float(row["confidence"])
+    candidate_id = row["candidate_crystallization_id"]
+    target_id = row["target_crystallization_id"] or "(no target)"
+    return f"Belief revision: {relation} between {candidate_id} and {target_id} (confidence {confidence:.2f})"
+
+
+def _build_reflection_crystallization(row: dict[str, Any]):
+    # Imports deferred until inside an async context that has already put the repo
+    # root on sys.path (see module-level sys.path handling above).
+    from orion.memory.crystallization.salience import apply_salience
+    from orion.memory.crystallization.schemas import (
+        CrystallizationEvidenceRefV1,
+        CrystallizationGovernanceV1,
+        MemoryCrystallizationV1,
+        _utc_now,
+        new_crystallization_id,
+    )
+
+    now = _utc_now()
+    confidence = float(row["confidence"])
+    subject = f"Concept relation decision: {row['relation']}"
+    summary = _build_reflection_summary(row)
+
+    crystallization = MemoryCrystallizationV1(
+        crystallization_id=new_crystallization_id(),
+        kind="reflection",
+        subject=subject,
+        summary=summary,
+        status="active",
+        scope=["project:orion"],
+        evidence=[
+            CrystallizationEvidenceRefV1(
+                source_kind="concept_relation_decision",
+                source_id=str(row["decision_id"]),
+                strength=max(0.0, min(1.0, confidence)),
+                note=summary,
+            )
+        ],
+        governance=CrystallizationGovernanceV1(
+            proposed_by="system:concept_relation_digest",
+            approved_by="system:concept_relation_digest",
+            approval_mode="auto_policy",
+            validation_status="valid",
+            requires_manual_review=False,
+            sensitivity="private",
+            created_from_policy="concept_relation_digest",
+        ),
+        created_at=now,
+        updated_at=now,
+    )
+    return apply_salience(crystallization)
+
+
+async def _run_digest(postgres_uri: str) -> DigestReport:
+    import asyncpg
+
+    from orion.memory.crystallization.repository import insert_crystallization
+
+    conn = await asyncpg.connect(postgres_uri)
+    try:
+        async with conn.transaction():
+            rows = [dict(r) for r in await conn.fetch(_SELECT_PENDING_SQL)]
+
+            relation_counts = {r: 0 for r in _RELATIONS}
+            near_miss_counts = {"contradicts": 0, "refines": 0}
+            reflections_created: list[str] = []
+
+            single_conn_pool = _SingleConnPool(conn)
+
+            for row in rows:
+                relation = row["relation"]
+                relation_counts[relation] = relation_counts.get(relation, 0) + 1
+
+                if relation in near_miss_counts and not row["floor_cleared"]:
+                    near_miss_counts[relation] += 1
+
+                if relation in _ACTIONABLE_RELATIONS and row["floor_cleared"]:
+                    reflection = _build_reflection_crystallization(row)
+                    cid = await insert_crystallization(single_conn_pool, reflection)
+                    reflections_created.append(cid)
+
+            if rows:
+                decision_ids = [r["decision_id"] for r in rows]
+                await conn.execute(_MARK_DIGESTED_SQL, decision_ids)
+
+            return DigestReport(
+                decisions_seen=len(rows),
+                relation_counts=relation_counts,
+                near_miss_counts=near_miss_counts,
+                reflections_created=reflections_created,
+            )
+    finally:
+        await conn.close()
+
+
+def _print_report(report: DigestReport) -> None:
+    print(
+        f"concept_relation_digest: {report.decisions_seen} decision(s) since last run "
+        f"(digested = false -> true)"
+    )
+    if report.decisions_seen == 0:
+        print("  nothing new to report.")
+        return
+
+    print("  relation distribution:")
+    for relation in _RELATIONS:
+        print(f"    {relation}: {report.relation_counts.get(relation, 0)}")
+
+    print("  near-misses (relation judged, confidence below CONCEPT_RELATION_CONFIDENCE_FLOOR):")
+    for relation, count in report.near_miss_counts.items():
+        print(f"    {relation}: {count}")
+
+    print(f"  reflection crystallizations created: {len(report.reflections_created)}")
+    for cid in report.reflections_created:
+        print(f"    {cid}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--postgres-uri",
+        default=os.getenv("POSTGRES_URI", ""),
+        help="Postgres DSN. Defaults to $POSTGRES_URI (e.g. services/orion-hub/.env).",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of prose.")
+    args = parser.parse_args(argv)
+
+    if not args.postgres_uri.strip():
+        print(
+            "concept_relation_digest: no --postgres-uri given and $POSTGRES_URI is unset. "
+            "Check services/orion-hub/.env for POSTGRES_URI.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        report = asyncio.run(_run_digest(args.postgres_uri))
+    except Exception as exc:
+        print(f"concept_relation_digest: run failed -- {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report.to_dict()))
+    else:
+        _print_report(report)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-memory-consolidation/README.md
+++ b/services/orion-memory-consolidation/README.md
@@ -22,6 +22,8 @@ Same-window duplicate detection (`orion.memory.crystallization.detection.detect_
 
 Dispatch is deliberately conservative: `same` reinforces the existing target (identical mechanism to the same-window path). `refines` and `contradicts` only attach a typed link to the *new* candidate's own `links` (persisted to `memory_crystallization_links` on insert, same as any other crystallization) — they never mutate or supersede the existing target's status. That stays a human decision via the existing `/api/memory/crystallizations/{id}/links` and supersede endpoints. Every decisive branch (`same`/`refines`/`contradicts`) stamps `provenance.concept_relation` (relation, target id, confidence) on the affected row for audit, independent of which branch acted.
 
+**Decision log + belief-revision digest.** Every real LLM decision — including `unrelated` and sub-floor `contradicts`/`refines` that the dispatch above discards — is written to `memory_concept_relation_decisions` (`orion.memory.crystallization.repository.insert_concept_relation_decision`, guarded to never raise). `scripts/concept_relation_digest.py` (repo root, run on demand or via cron — not a live service loop) reads undigested rows and reports call volume / relation distribution / near-miss counts under `CONCEPT_RELATION_CONFIDENCE_FLOOR`, then creates one `reflection`-kind crystallization per real belief-revision decision (`same`/`refines`/`contradicts` that cleared the floor) — a structured, deterministic trace of Orion revising its own beliefs, not just a link nobody reads back.
+
 Ships flag-gated off; flipping the flag alone does not activate anything without also configuring the embed/chroma hosts (both default to empty string):
 
 | Env | Default | Purpose |

--- a/tests/test_concept_relation_digest.py
+++ b/tests/test_concept_relation_digest.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import concept_relation_digest as digest  # noqa: E402
+
+
+class _NullAsyncCtx:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class FakeConn:
+    """Minimal in-process double for the handful of asyncpg.Connection calls this
+    script + repository.py::insert_crystallization() make. Dispatches on substrings
+    in the SQL text rather than emulating a real query engine -- enough to prove the
+    digest script's read/report/write/mark-digested behavior without a live Postgres,
+    matching this repo's existing convention of mocking at the pool/connection
+    boundary (see tests/test_encode_reinforce_not_duplicate.py)."""
+
+    def __init__(self, decisions: list[dict]) -> None:
+        self.decisions = decisions
+        self.crystallizations: dict[str, dict] = {}
+        self.sources: list[dict] = []
+        self.closed = False
+
+    def transaction(self):
+        return _NullAsyncCtx()
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def fetch(self, sql: str, *args):
+        if "memory_concept_relation_decisions" in sql and "digested = false" in sql:
+            pending = [dict(r) for r in self.decisions if not r["digested"]]
+            pending.sort(key=lambda r: r["decided_at"])
+            return pending
+        raise AssertionError(f"FakeConn.fetch: unexpected query: {sql}")
+
+    async def fetchrow(self, sql: str, *args):
+        if "INSERT INTO memory_crystallizations" in sql:
+            crystallization_id = args[0] if args and args[0] else str(uuid4())
+            self.crystallizations[crystallization_id] = {"args": args}
+            return {"crystallization_id": crystallization_id}
+        raise AssertionError(f"FakeConn.fetchrow: unexpected query: {sql}")
+
+    async def execute(self, sql: str, *args):
+        if "INSERT INTO memory_crystallization_sources" in sql:
+            self.sources.append({"args": args})
+            return "INSERT 0 1"
+        if "UPDATE memory_concept_relation_decisions" in sql and "SET digested = true" in sql:
+            ids = set(args[0])
+            for row in self.decisions:
+                if row["decision_id"] in ids:
+                    row["digested"] = True
+            return f"UPDATE {len(ids)}"
+        raise AssertionError(f"FakeConn.execute: unexpected query: {sql}")
+
+
+def _row(*, relation: str, floor_cleared: bool, confidence: float, offset_sec: int, target: str | None = "crys_target") -> dict:
+    return {
+        "decision_id": str(uuid4()),
+        "candidate_crystallization_id": "crys_candidate",
+        "target_crystallization_id": target,
+        "relation": relation,
+        "confidence": confidence,
+        "floor_cleared": floor_cleared,
+        "decided_at": datetime(2026, 7, 13, tzinfo=timezone.utc) + timedelta(seconds=offset_sec),
+        "digested": False,
+    }
+
+
+def _seeded_rows() -> list[dict]:
+    return [
+        _row(relation="same", floor_cleared=True, confidence=0.9, offset_sec=1),
+        _row(relation="refines", floor_cleared=True, confidence=0.8, offset_sec=2),
+        _row(relation="contradicts", floor_cleared=True, confidence=0.75, offset_sec=3),
+        # Near-misses: relation judged, confidence landed under the floor.
+        _row(relation="contradicts", floor_cleared=False, confidence=0.4, offset_sec=4),
+        _row(relation="refines", floor_cleared=False, confidence=0.5, offset_sec=5),
+        # unrelated is never floor_cleared (resolve_concept_relation degrades confidence to 0.0).
+        _row(relation="unrelated", floor_cleared=False, confidence=0.0, offset_sec=6, target=None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_digest_report_counts_and_reflection_creation():
+    conn = FakeConn(_seeded_rows())
+
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+        report = await digest._run_digest("postgresql://fake/db")
+
+    assert report.decisions_seen == 6
+    assert report.relation_counts == {"same": 1, "refines": 2, "contradicts": 2, "unrelated": 1}
+    assert report.near_miss_counts == {"contradicts": 1, "refines": 1}
+
+    # Only the floor_cleared=True same/refines/contradicts rows (3 of them) produce a
+    # reflection crystallization -- near-misses and "unrelated" do not.
+    assert len(report.reflections_created) == 3
+    assert len(conn.crystallizations) == 3
+    assert len(conn.sources) == 3
+
+    # Every row seen this run is now marked digested, including the non-actionable ones.
+    assert all(row["digested"] for row in conn.decisions)
+
+
+@pytest.mark.asyncio
+async def test_digest_reflection_crystallization_shape():
+    conn = FakeConn([_row(relation="contradicts", floor_cleared=True, confidence=0.82, offset_sec=1)])
+
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+        report = await digest._run_digest("postgresql://fake/db")
+
+    assert len(report.reflections_created) == 1
+    stored = next(iter(conn.crystallizations.values()))
+    # args order from repository.py::insert_crystallization's INSERT INTO
+    # memory_crystallizations statement: (crystallization_id, kind, subject, summary, ...)
+    args = stored["args"]
+    assert args[1] == "reflection"
+    assert "contradicts" in args[3]  # summary mentions the relation
+    assert "0.82" in args[3]  # summary embeds the confidence
+
+    assert len(conn.sources) == 1
+    source_args = conn.sources[0]["args"]
+    # (crystallization_id, source_kind, source_id, excerpt, strength, note)
+    assert source_args[1] == "concept_relation_decision"
+
+
+@pytest.mark.asyncio
+async def test_digest_second_run_with_no_new_rows_is_empty_not_duplicated():
+    conn = FakeConn(_seeded_rows())
+
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+        first = await digest._run_digest("postgresql://fake/db")
+        second = await digest._run_digest("postgresql://fake/db")
+
+    assert first.decisions_seen == 6
+    assert len(first.reflections_created) == 3
+
+    assert second.decisions_seen == 0
+    assert second.relation_counts == {r: 0 for r in digest._RELATIONS}
+    assert second.reflections_created == []
+
+    # No duplicate reflections were created on the second, empty run.
+    assert len(conn.crystallizations) == 3
+
+
+@pytest.mark.asyncio
+async def test_digest_no_pending_rows_reports_cleanly():
+    conn = FakeConn([])
+
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+        report = await digest._run_digest("postgresql://fake/db")
+
+    assert report.decisions_seen == 0
+    assert report.reflections_created == []
+
+
+def test_main_reports_missing_postgres_uri(capsys):
+    exit_code = digest.main(["--postgres-uri", ""])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "POSTGRES_URI" in captured.err

--- a/tests/test_memory_crystallization.py
+++ b/tests/test_memory_crystallization.py
@@ -236,6 +236,30 @@ class TestSalienceAndBus:
         assert three_sources.confidence == "certain"
         assert score_salience(one_source) != score_salience(three_sources)
 
+    def test_reflection_kind_scores_real_nonzero_salience(self):
+        # "reflection" (scripts/concept_relation_digest.py's belief-revision output) must
+        # participate in the same salience/ranking machinery as every other kind, not be
+        # a schema-valid-but-inert stub ("no empty-shell cognition") -- confirm it scores
+        # a real, non-error value, sits below "episode" (the previous floor of the scale,
+        # 0.45) since these are system meta-observations rather than direct evidence, and
+        # still moves with evidence/confidence like every other kind.
+        req = _base_request(kind="reflection")
+        crys = apply_salience(propose(req))
+        assert 0.0 < score_salience(crys) <= 0.45
+        assert score_salience(crys) != 0.5  # not silently falling back to the KIND_BASE.get() default
+
+        # Real signal, not a stub: more/stronger evidence still moves the score, same as
+        # every other kind.
+        stronger_req = _base_request(
+            kind="reflection",
+            evidence=[
+                CrystallizationEvidenceRefV1(source_kind="memory_card", source_id="c1", strength=0.9),
+                CrystallizationEvidenceRefV1(source_kind="memory_card", source_id="c2", strength=0.9),
+            ],
+        )
+        stronger_crys = apply_salience(propose(stronger_req))
+        assert score_salience(stronger_crys) > score_salience(crys)
+
 
 def _bare_crystallization(
     *,

--- a/tests/test_memory_crystallization_concept_relation.py
+++ b/tests/test_memory_crystallization_concept_relation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,6 +15,7 @@ from orion.memory.crystallization.concept_relation import (
 )
 from orion.memory.crystallization.governor import approve
 from orion.memory.crystallization.proposer import propose
+from orion.memory.crystallization.repository import insert_concept_relation_decision
 from orion.memory.crystallization.schemas import (
     CrystallizationEvidenceRefV1,
     MemoryCrystallizationProposeRequestV1,
@@ -245,6 +248,8 @@ class TestMaybeResolveConceptRelation:
         update_mock = AsyncMock()
         emit_mock = AsyncMock(return_value=True)
 
+        decision_log_mock = AsyncMock(return_value="decision-1")
+
         with patch(
             "orion.memory.crystallization.concept_relation.fetch_similar_candidates",
             new=AsyncMock(return_value=[target]),
@@ -257,6 +262,9 @@ class TestMaybeResolveConceptRelation:
         ), patch(
             "orion.memory.crystallization.concept_relation.emit_crystallization_lifecycle",
             new=emit_mock,
+        ), patch(
+            "orion.memory.crystallization.concept_relation.insert_concept_relation_decision",
+            new=decision_log_mock,
         ):
             result = await maybe_resolve_concept_relation(
                 pool, bus, candidate=candidate, settings=_Settings(), emit_kw={"service_name": "x"}
@@ -268,6 +276,9 @@ class TestMaybeResolveConceptRelation:
         assert outcome == "reinforced_by_relation"
         update_mock.assert_called_once()
         emit_mock.assert_called_once()
+        decision_log_mock.assert_called_once()
+        assert decision_log_mock.call_args.kwargs["relation"] == "same"
+        assert decision_log_mock.call_args.kwargs["floor_cleared"] is True
 
     @pytest.mark.asyncio
     async def test_refines_attaches_link_without_returning(self):
@@ -288,6 +299,9 @@ class TestMaybeResolveConceptRelation:
         ), patch(
             "orion.memory.crystallization.concept_relation.resolve_concept_relation",
             new=AsyncMock(return_value=decision),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.insert_concept_relation_decision",
+            new=AsyncMock(return_value="decision-1"),
         ):
             result = await maybe_resolve_concept_relation(
                 pool, bus, candidate=candidate, settings=_Settings(), emit_kw={}
@@ -318,6 +332,9 @@ class TestMaybeResolveConceptRelation:
         ), patch(
             "orion.memory.crystallization.concept_relation.resolve_concept_relation",
             new=AsyncMock(return_value=decision),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.insert_concept_relation_decision",
+            new=AsyncMock(return_value="decision-1"),
         ):
             result = await maybe_resolve_concept_relation(
                 pool, bus, candidate=candidate, settings=_Settings(), emit_kw={}
@@ -340,12 +357,17 @@ class TestMaybeResolveConceptRelation:
             relation="same", target_crystallization_id="crys_target", confidence=0.3
         )
 
+        decision_log_mock = AsyncMock(return_value="decision-1")
+
         with patch(
             "orion.memory.crystallization.concept_relation.fetch_similar_candidates",
             new=AsyncMock(return_value=[target]),
         ), patch(
             "orion.memory.crystallization.concept_relation.resolve_concept_relation",
             new=AsyncMock(return_value=decision),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.insert_concept_relation_decision",
+            new=decision_log_mock,
         ):
             result = await maybe_resolve_concept_relation(
                 pool, bus, candidate=candidate, settings=_Settings(), emit_kw={}
@@ -353,6 +375,90 @@ class TestMaybeResolveConceptRelation:
 
         assert result is None
         assert candidate.links == []
+
+        # Regression: previously this sub-floor "same" decision vanished silently --
+        # only the decisive outcome (past the floor filter below) ever reached a log
+        # line. It must still be recorded so scripts/concept_relation_digest.py's
+        # threshold-tuning report can surface it as a near-miss.
+        decision_log_mock.assert_called_once()
+        assert decision_log_mock.call_args.kwargs["relation"] == "same"
+        assert decision_log_mock.call_args.kwargs["confidence"] == 0.3
+        assert decision_log_mock.call_args.kwargs["floor_cleared"] is False
+
+    @pytest.mark.asyncio
+    async def test_unrelated_decision_is_logged_even_though_it_returns_none(self):
+        # Regression: an "unrelated" decision (the common case -- resolve_concept_relation
+        # degrades to this on any LLM failure, and it's the model's own explicit choice
+        # otherwise) previously never reached the logger.info line at all, since that line
+        # sits after this exact filter. Every one of these vanished silently.
+        candidate = _active_crystallization()
+        target = _active_crystallization()
+        target.crystallization_id = "crys_target"
+
+        pool = MagicMock()
+        bus = MagicMock()
+
+        decision = ConceptRelationDecision(relation="unrelated", confidence=0.0)
+
+        decision_log_mock = AsyncMock(return_value="decision-1")
+
+        with patch(
+            "orion.memory.crystallization.concept_relation.fetch_similar_candidates",
+            new=AsyncMock(return_value=[target]),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.resolve_concept_relation",
+            new=AsyncMock(return_value=decision),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.insert_concept_relation_decision",
+            new=decision_log_mock,
+        ):
+            result = await maybe_resolve_concept_relation(
+                pool, bus, candidate=candidate, settings=_Settings(), emit_kw={}
+            )
+
+        assert result is None
+        decision_log_mock.assert_called_once()
+        assert decision_log_mock.call_args.kwargs["relation"] == "unrelated"
+        assert decision_log_mock.call_args.kwargs["target_crystallization_id"] is None
+        assert decision_log_mock.call_args.kwargs["floor_cleared"] is False
+
+    @pytest.mark.asyncio
+    async def test_subfloor_contradicts_is_logged_even_though_it_returns_none(self):
+        # Regression: a "contradicts" decision below the confidence floor previously
+        # vanished silently too (same filter, same missing log line) -- not just "same".
+        candidate = _active_crystallization()
+        target = _active_crystallization()
+        target.crystallization_id = "crys_target"
+
+        pool = MagicMock()
+        bus = MagicMock()
+
+        decision = ConceptRelationDecision(
+            relation="contradicts", target_crystallization_id="crys_target", confidence=0.45
+        )
+
+        decision_log_mock = AsyncMock(return_value="decision-1")
+
+        with patch(
+            "orion.memory.crystallization.concept_relation.fetch_similar_candidates",
+            new=AsyncMock(return_value=[target]),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.resolve_concept_relation",
+            new=AsyncMock(return_value=decision),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.insert_concept_relation_decision",
+            new=decision_log_mock,
+        ):
+            result = await maybe_resolve_concept_relation(
+                pool, bus, candidate=candidate, settings=_Settings(), emit_kw={}
+            )
+
+        assert result is None
+        assert candidate.links == []
+        decision_log_mock.assert_called_once()
+        assert decision_log_mock.call_args.kwargs["relation"] == "contradicts"
+        assert decision_log_mock.call_args.kwargs["target_crystallization_id"] == "crys_target"
+        assert decision_log_mock.call_args.kwargs["floor_cleared"] is False
 
     @pytest.mark.asyncio
     async def test_confidence_floor_zero_is_respected_not_clobbered(self):
@@ -388,6 +494,9 @@ class TestMaybeResolveConceptRelation:
         ), patch(
             "orion.memory.crystallization.concept_relation.emit_crystallization_lifecycle",
             new=emit_mock,
+        ), patch(
+            "orion.memory.crystallization.concept_relation.insert_concept_relation_decision",
+            new=AsyncMock(return_value="decision-1"),
         ):
             result = await maybe_resolve_concept_relation(
                 pool, bus, candidate=candidate, settings=settings, emit_kw={}
@@ -416,6 +525,9 @@ class TestMaybeResolveConceptRelation:
         ), patch(
             "orion.memory.crystallization.concept_relation.resolve_concept_relation",
             new=AsyncMock(return_value=decision),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.insert_concept_relation_decision",
+            new=AsyncMock(return_value="decision-1"),
         ):
             result = await maybe_resolve_concept_relation(
                 pool, bus, candidate=candidate, settings=_Settings(), emit_kw={}
@@ -493,6 +605,76 @@ class TestMaybeResolveConceptRelation:
 
         assert result is None
         mock_resolve.assert_not_called()
+
+
+class _FakeDecisionConn:
+    """Minimal double for the single INSERT ... RETURNING decision_id query that
+    insert_concept_relation_decision() issues -- proves the write round-trips (the
+    params passed in come back out as the row read from the "database") without a
+    live Postgres, matching this repo's existing convention of mocking at the
+    pool/connection boundary."""
+
+    def __init__(self) -> None:
+        self.captured_sql: str | None = None
+        self.captured_args: tuple | None = None
+
+    async def fetchrow(self, sql, *args):
+        self.captured_sql = sql
+        self.captured_args = args
+        return {"decision_id": str(uuid4())}
+
+
+class _FakePool:
+    def __init__(self, conn: _FakeDecisionConn) -> None:
+        self._conn = conn
+
+    def acquire(self) -> "_FakePool":
+        return self
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class TestInsertConceptRelationDecision:
+    @pytest.mark.asyncio
+    async def test_round_trips_all_fields(self):
+        conn = _FakeDecisionConn()
+        pool = _FakePool(conn)
+
+        decision_id = await insert_concept_relation_decision(
+            pool,
+            candidate_crystallization_id="crys_candidate",
+            target_crystallization_id="crys_target",
+            relation="refines",
+            confidence=0.73,
+            floor_cleared=True,
+        )
+
+        assert decision_id  # a real id came back from the "INSERT ... RETURNING"
+        assert conn.captured_args == ("crys_candidate", "crys_target", "refines", 0.73, True)
+        assert "INSERT INTO memory_concept_relation_decisions" in conn.captured_sql
+        assert "RETURNING decision_id" in conn.captured_sql
+
+    @pytest.mark.asyncio
+    async def test_round_trips_unrelated_with_null_target(self):
+        # "unrelated" decisions never have a target_crystallization_id -- confirm the
+        # write path tolerates None and it comes back through unchanged.
+        conn = _FakeDecisionConn()
+        pool = _FakePool(conn)
+
+        await insert_concept_relation_decision(
+            pool,
+            candidate_crystallization_id="crys_candidate",
+            target_crystallization_id=None,
+            relation="unrelated",
+            confidence=0.0,
+            floor_cleared=False,
+        )
+
+        assert conn.captured_args == ("crys_candidate", None, "unrelated", 0.0, False)
 
 
 class TestMergeNewEvidence:

--- a/tests/test_memory_crystallization_concept_relation.py
+++ b/tests/test_memory_crystallization_concept_relation.py
@@ -345,6 +345,54 @@ class TestMaybeResolveConceptRelation:
         assert candidate.links[0].relation == "contradicts"
 
     @pytest.mark.asyncio
+    async def test_decision_log_write_failure_does_not_break_formation(self):
+        # Regression (code review finding): insert_concept_relation_decision() is a
+        # purely observational write. Before this guard, a DB error there (pool down,
+        # connection reset, etc.) would propagate all the way up through
+        # intake_pipeline.py and fail the entire consolidation window -- a strictly
+        # worse failure mode than losing one diagnostic log row. resolve_concept_relation()
+        # is documented to never raise; this write must be equally forgiving.
+        candidate = _active_crystallization()
+        target = _active_crystallization()
+        target.crystallization_id = "crys_target"
+
+        pool = MagicMock()
+        bus = MagicMock()
+
+        decision = ConceptRelationDecision(
+            relation="same", target_crystallization_id="crys_target", confidence=0.9
+        )
+
+        update_mock = AsyncMock()
+        emit_mock = AsyncMock(return_value=True)
+
+        with patch(
+            "orion.memory.crystallization.concept_relation.fetch_similar_candidates",
+            new=AsyncMock(return_value=[target]),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.resolve_concept_relation",
+            new=AsyncMock(return_value=decision),
+        ), patch(
+            "orion.memory.crystallization.concept_relation.update_crystallization",
+            new=update_mock,
+        ), patch(
+            "orion.memory.crystallization.concept_relation.emit_crystallization_lifecycle",
+            new=emit_mock,
+        ), patch(
+            "orion.memory.crystallization.concept_relation.insert_concept_relation_decision",
+            new=AsyncMock(side_effect=RuntimeError("connection reset")),
+        ):
+            result = await maybe_resolve_concept_relation(
+                pool, bus, candidate=candidate, settings=_Settings(), emit_kw={}
+            )
+
+        # The decision-log write failed, but the real formation outcome still happened.
+        assert result is not None
+        cid, row, outcome = result
+        assert cid == "crys_target"
+        assert outcome == "reinforced_by_relation"
+
+    @pytest.mark.asyncio
     async def test_confidence_below_floor_returns_none(self):
         candidate = _active_crystallization()
         target = _active_crystallization()


### PR DESCRIPTION
# PR report: concept-relation decision log + belief-revision digest

Implements item 1 of `docs/superpowers/specs/2026-07-13-recall-followups-loop-retirement-saturation-gate-spec.md`.

## Summary

- `maybe_resolve_concept_relation()`'s LLM decisions were only observable via a log line that fired *after* the confidence-floor/relation filter — every `unrelated` decision and every sub-floor `contradicts`/`refines` decision vanished silently. Now every real LLM decision writes a row to a new `memory_concept_relation_decisions` table, regardless of outcome.
- New `scripts/concept_relation_digest.py` reads undigested rows and produces two things in one pass: a threshold-tuning report (call volume, relation distribution, near-miss counts below `CONCEPT_RELATION_CONFIDENCE_FLOOR`), and — for real belief-revision decisions (`same`/`refines`/`contradicts` that cleared the floor) — a new `reflection`-kind crystallization: a deterministic, non-LLM trace of Orion revising its own beliefs over time.
- `reflection` is a new `CrystallizationKind` with a real `salience.py::KIND_BASE` entry (0.4) so it participates in real ranking, not an inert schema-valid label — satisfies this repo's "no keyword cathedral" requirement (producer + consumer in the same patch).
- Self-caught review finding, already fixed: the decision-log write was initially unguarded — wrapped in try/except so a transient DB error on this purely observational write can no longer take down an entire consolidation window.
- Live-verified end to end, twice (once by the implementing agent, once independently by the orchestrator): seed a real decision, run the digest, confirm a real reflection crystallization lands in Postgres with real salience/confidence, confirm a second run produces zero duplicates.

## Outcome moved

The concept-relation resolver (proven working in PR #1000) goes from "we can only see its decisive outputs" to "every decision is inspectable, including the near-misses that would tell us if the 0.6 floor needs retuning" — and its real belief revisions now leave a structured trace instead of disappearing into a link table nobody reads back.

## Current architecture (before this patch)

`maybe_resolve_concept_relation()` called a real LLM, computed a relation + confidence, and either attached a link/reinforced a match (decisive outcomes) or returned `None` silently (everything else). No table, no digest, no `reflection` kind existed.

## Architecture touched

`orion/memory/crystallization/` (schema, salience, concept_relation, repository), one new top-level script, one new SQL table (via the existing idempotent-DDL-file mechanism, not a new migration-file system — this repo has none).

## Files changed

- `orion/core/storage/sql/memory_crystallizations.sql`: new `memory_concept_relation_decisions` table (`CREATE TABLE IF NOT EXISTS`, matching how `memory_crystallization_retrieval_events` already lives in the same file) + index on `(digested, decided_at)`.
- `orion/memory/crystallization/repository.py`: `insert_concept_relation_decision()`, mirroring `insert_retrieval_event()`'s exact shape.
- `orion/memory/crystallization/concept_relation.py`: `maybe_resolve_concept_relation()` now inserts a decision row (try/except-guarded) after `resolve_concept_relation()` returns, before the existing floor/relation filter — so nothing vanishes silently anymore.
- `orion/memory/crystallization/schemas.py`: `reflection` added to `CrystallizationKind`; `concept_relation_decision` added to `CrystallizationSourceKind` (required for the reflection crystallization's evidence ref — schema is `extra="forbid"`).
- `orion/memory/crystallization/salience.py`: `reflection` added to `KIND_BASE` at 0.4 (below `episode`'s 0.45 — the lowest tier, since these are meta-observations about the decision loop itself, not first-hand evidence).
- `scripts/concept_relation_digest.py` (new): standalone script matching `check_activation_saturation.py`'s exact conventions (argparse, `POSTGRES_URI`/`--postgres-uri`, `--json`, sys.path guard). Runs the whole read/create-reflections/mark-digested sequence inside one real Postgres transaction via a `_SingleConnPool` shim, so a mid-run crash rolls back cleanly instead of double-creating reflections on retry.
- Tests: `tests/test_memory_crystallization_concept_relation.py` (decision-log round-trip, unrelated/sub-floor decisions now logged, write-failure-doesn't-break-formation regression), `tests/test_concept_relation_digest.py` (report counts, reflection creation gated correctly on `floor_cleared`, second-run-no-duplicates, clean-empty-run), `tests/test_memory_crystallization.py` (`reflection` kind scores real nonzero salience).

## Design decisions worth flagging

**Status `"active"`, not `"proposed"`.** Reflection crystallizations are system-derived observations about the decision loop's own history, not claims requiring governor review — same trust tier as other automated provenance already in this codebase. `governance.approved_by`/`approval_mode` set to `"system:concept_relation_digest"`/`"auto_policy"` to make that origin explicit and auditable, not hidden behind a human-looking approval.

**One transaction, not a naive read-then-write.** The `_SingleConnPool` shim lets `insert_crystallization()` (which expects a real `asyncpg.Pool`) run on the same already-open connection/transaction as the digest's own reads and digested-flag update. This is the correct fix for the obvious failure mode (crash mid-digest leaving some rows digested with no reflection, or vice versa) rather than leaving it as a known gap.

**No new migration-file system invented.** This repo's schema for `orion/memory/crystallization/` lives in one idempotent `CREATE TABLE IF NOT EXISTS`-per-table SQL file, re-applied wholesale via `apply_memory_crystallizations_schema()`. The new table was added there, not as a new standalone migration mechanism.

## Schema / bus / API changes

- Added: `memory_concept_relation_decisions` table (new, additive). `reflection` `CrystallizationKind` value (new, additive — existing kind-based logic elsewhere either explicitly lists kinds it cares about, unaffected by an unlisted new one, or falls back safely, per the implementing agent's review pass confirming `KIND_TO_BUCKET.get()` has a safe default and `formation_policy.GATED_KINDS` doesn't need this kind since the digest bypasses the governor path entirely).
- Removed: none.
- Behavior changed: `maybe_resolve_concept_relation()` now performs one additional DB write per real LLM decision (previously zero for non-decisive outcomes). Guarded to never raise.
- Compatibility notes: no existing caller's contract changes; the new write is purely additive and independently guarded.

## Env/config changes

None. No new env keys — `CONCEPT_RELATION_CONFIDENCE_FLOOR` (pre-existing) is read, not changed.

## Tests run

```text
$ source venv/bin/activate && python -m pytest tests/test_memory_crystallization_concept_relation.py \
    tests/test_memory_crystallization.py tests/test_concept_relation_digest.py \
    tests/test_encode_reinforce_not_duplicate.py -v
78 passed, 1 failed
```
The 1 failure (`TestMemoryCardBackwardCompat::test_memory_card_v1_unchanged_in_registry_gap`) is the same pre-existing, unrelated failure confirmed multiple times earlier this session (registry-gap issue, zero relation to this patch's files). Independently re-run by the orchestrator, not taken from the implementing agent's report alone.

## Evals run

No eval harness applies — this is deterministic aggregation logic, fully covered by the unit tests above. The live verification below is the standard this session holds "does it actually work" claims to.

## Docker/build/smoke checks

```text
# Schema applied live, confirmed via \d:
$ psql -c '\d memory_concept_relation_decisions'
(all 8 columns present as designed, including the digested/decided_at index)

# Orchestrator's own independent live end-to-end run (separate from the implementing
# agent's own verification, seeded fresh, not reusing their test data):
$ python verify_concept_relation_digest.py
seeded target: e4dde759-dbad-4508-a3fd-c01e9b2850dd
seeded decision: 0cf96e0d-24d5-4e21-8000-91f457e7f9ca

$ POSTGRES_URI=postgresql://postgres:postgres@127.0.0.1:55432/conjourney python scripts/concept_relation_digest.py
concept_relation_digest: 1 decision(s) since last run
  relation distribution: contradicts: 1 (rest 0)
  near-misses: contradicts: 0, refines: 0
  reflection crystallizations created: 1
    040407e5-4f06-4638-883f-6e84c2133901

$ (second run) -> "0 decision(s) since last run ... nothing new to report." (no duplicate)

# Confirmed the reflection crystallization actually landed correctly, by direct query:
$ psql -c "select crystallization_id, kind, status, subject, salience, confidence
           from memory_crystallizations where crystallization_id='040407e5-...'"
040407e5-... | reflection | active | Concept relation decision: contradicts | 0.491 | possible
```
Real, non-zero, non-default salience (0.491) and a real computed confidence (`possible`, via the already-merged `infer_confidence()` from PR #1002) — not an empty-shell stub. Test rows deprecated/deleted after verification, no permanent pollution.

## Review findings fixed

- Finding: `insert_concept_relation_decision()`'s call site in `maybe_resolve_concept_relation()` was unguarded — unlike `resolve_concept_relation()` (documented to never raise), a transient DB error on this purely observational write would propagate up through `intake_pipeline.py` and fail an entire consolidation window over the loss of one diagnostic row.
  - Fix: wrapped in `try/except Exception` with a `logger.warning`, matching the file's existing never-raise convention.
  - Evidence: commit `4429bf74`; new regression test `test_decision_log_write_failure_does_not_break_formation` asserts `maybe_resolve_concept_relation()` still returns the correct outcome even when the decision-log insert raises.

Orchestrator independently re-read every diff in full, re-ran the full targeted test suite, and ran an independent live end-to-end verification (fresh seed data, not reused from the implementing agent's own run) rather than trusting the report alone.

## Restart required

```text
No restart required for the code itself (no env/schema-deploy-time changes beyond the
idempotent SQL file, which orion-memory-consolidation and orion-hub already re-apply on
their normal startup path via apply_memory_crystallizations_schema()).
```

## Risks / concerns

- Severity: Low — `scripts/concept_relation_digest.py` is on-demand/cron-category, not a live service loop (matches the spec's explicit non-goal). Nothing runs it automatically yet; someone needs to invoke it (manually or via a future scheduled job) for the loop to actually close in production. This mirrors `check_activation_saturation.py`'s exact same status.
- Severity: Low — `reflection` crystallizations are created with `requires_manual_review=False` and never surface in the governor review queue by design (system-derived, not requiring human approval). If this trust level is ever reconsidered, the change is isolated to `_build_reflection_crystallization()`'s governance fields.
