### PR TITLE
feat(orion-recall): activate real chat-time graph search, guard it fr…

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-recall-graphiti-chat-activation-guard-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-recall-graphiti-chat-activation-guard-pr.md
@@ -1,0 +1,111 @@
+# PR report: activate real chat-time graph search + permanently guard it from the sync script
+
+## Summary
+
+- `RECALL_GRAPHITI_IN_CHAT` (default `false`, and previously entirely absent from this host's live `.env`) gates whether real chat/conversation turns — both `chat_general` and unified-turn (`stance_react`, confirmed to share the same PCR/recall machinery) — ever use the graph-search rail proven working earlier today. It was off; every bit of that earlier work was invisible to real conversations.
+- Flipped on, live: `RECALL_GRAPHITI_IN_CHAT=true` + `RECALL_GRAPHITI_ADAPTER_URL=http://orion-athena-graphiti-adapter:8000` (both were missing from the live `.env` entirely — added, not just toggled).
+- `.env_example` updated to match — this is now the shipped default, not just a live-only override, following the same "prove it, then make it the default" pattern already used for the graphiti_core backend default flip earlier today.
+- `RECALL_GRAPHITI_IN_CHAT`/`RECALL_GRAPHITI_ADAPTER_URL` added to `sync_local_env_from_example.py`'s `NEVER_SYNC_KEYS` — an explicit, permanent guarantee (verified even under `--all-keys --force`) that these two keys can never be silently desynced from each other, closing off the exact failure mode that broke two other features earlier this session (`CONCEPT_RELATION_RESOLUTION_ENABLED`, `GRAPHITI_BACKEND`: flag enabled, dependency left empty).
+- Live-verified via the actual running `Settings` object and the real gating function, not `docker exec env` (which doesn't reflect what this service actually reads — see below) — confirmed a real `GraphitiAdapter` is constructed for `retrieval_intent="contradiction"` and correctly `None` for every other intent.
+
+## Outcome moved
+
+The graph-search work from earlier today (activation, the RELATES_TO fix, default-flip, driver caching) now actually affects real conversations, not just the adapter's own API and Hub's manual calls. And the specific footgun that bit this session twice already (flag on, dependency empty, silent no-op) is now structurally prevented for this feature specifically, and self-documented for the next person who touches it.
+
+## Current architecture (before this patch)
+
+`orion-recall/app/collectors/active_packet.py::_graphiti_adapter()` already existed and correctly gated graph search to `retrieval_intent == "contradiction"` only — this logic was never broken. What was missing was the config to actually turn it on: `RECALL_GRAPHITI_IN_CHAT` wasn't even present in the live `.env`, so it silently defaulted to `False` in Python.
+
+## Architecture touched
+
+`services/orion-recall` (env only, no code change — the gating logic was already correct), `scripts/sync_local_env_from_example.py` (tooling).
+
+## A real gotcha found and worked around during verification
+
+`docker exec orion-athena-recall env | grep RECALL_GRAPHITI...` returned nothing even after the container was rebuilt with the new `.env` — this looked like the change hadn't taken effect. Root cause: `orion-recall`'s `Dockerfile` does `COPY services/orion-recall /app` at build time, baking `.env` directly into the image, and `settings.py`'s pydantic-settings `Config` reads `env_file=".env"` directly — so the app never relies on docker-compose's `environment:` list at all (which, separately, doesn't even list these two keys — a pre-existing gap in `docker-compose.yml`, not touched by this patch since it isn't the actual read path). `docker exec ... env` only shows OS-level environment variables, not what pydantic-settings loads from the baked-in file. Verified correctly instead by asking the running app's actual `Settings` object directly (see Docker/build/smoke checks below) — this is the "runtime truth beats config truth" standard this whole session has been held to, applied to distinguish "looks unset" from "the app's actual view."
+
+## Files changed
+
+- `services/orion-recall/.env_example`: `RECALL_GRAPHITI_IN_CHAT` default `false`→`true`; `RECALL_GRAPHITI_ADAPTER_URL` filled in with a real, container-DNS-reachable value (matching the exact precedent already used for `CRYSTALLIZER_EMBED_HOST_URL` when the graphiti_core backend's own default flipped earlier today); comment documents the `NEVER_SYNC_KEYS` protection and the must-change-together requirement.
+- `services/orion-recall/.env` (live, not committed — gitignored): same two keys, added (were entirely absent, not just `false`).
+- `scripts/sync_local_env_from_example.py`: `NEVER_SYNC_KEYS` gains `RECALL_GRAPHITI_IN_CHAT`, `RECALL_GRAPHITI_ADAPTER_URL`. Belt-and-suspenders on top of an existing, weaker protection: neither key matches any `SYNC_PREFIXES` entry (verified directly via `should_sync_key()`), so they were already excluded from the script's default scan — this makes that exclusion an explicit, permanent decision rather than an accident of the prefix list, and extends it to hold even under `--all-keys --force`.
+- `tests/scripts/test_sync_local_env_from_example.py`: two new tests, mirroring the file's existing `test_orion_bus_url_never_synced` style — `should_sync_key()` returns `False` for both keys in both modes; a real `sync_file()` round-trip with `--force`+`--all-keys` (the strongest possible attempt to override) leaves both keys completely untouched.
+- `docs/superpowers/specs/2026-07-13-recall-followups-loop-retirement-saturation-gate-spec.md`: carried over from an earlier uncommitted state this session, included here since it was sitting untracked and this PR is the natural place for it to land (it documents unrelated prior work from the same day, not part of this patch's diff otherwise).
+
+## Schema / bus / API changes
+
+None. No new keys — both `RECALL_GRAPHITI_IN_CHAT` and `RECALL_GRAPHITI_ADAPTER_URL` already existed in `.env_example`; only their default values and sync-protection changed.
+
+## Env/config changes
+
+- Changed defaults: `RECALL_GRAPHITI_IN_CHAT` (`false`→`true`), `RECALL_GRAPHITI_ADAPTER_URL` (empty→`http://orion-athena-graphiti-adapter:8000`) in `.env_example`.
+- Live `.env` updated to match (both keys were entirely absent before this session; added, not committed — gitignored).
+- `python scripts/sync_local_env_from_example.py orion-recall --dry-run` confirmed clean (`No changes needed`) after these edits — no unexpected divergence introduced elsewhere in the file.
+- Both changed keys are now permanently excluded from any future sync-script run, by design.
+
+## Tests run
+
+```text
+$ source venv/bin/activate && python -m pytest tests/scripts/test_sync_local_env_from_example.py -v
+8 passed in 0.10s
+```
+All existing tests plus the 2 new ones. No regression.
+
+## Evals run
+
+Not applicable — this is config + a tooling guard, not application logic with a meaningful eval surface.
+
+## Docker/build/smoke checks
+
+```text
+$ docker compose --env-file .env --env-file services/orion-recall/.env \
+    -f services/orion-recall/docker-compose.yml up -d --build
+Container orion-athena-recall Started
+
+$ docker ps --format '{{.Names}}\t{{.Status}}' | grep recall
+orion-athena-recall   Up About a minute (healthy)
+
+$ curl -sS http://localhost:<port>/health   (via docker exec, internal)
+{"ok":true,"service":"recall","version":"0.1.0","node":"athena-DEBUG-CONTAINER"}
+
+# Real verification -- NOT docker exec env (see gotcha above), the app's own Settings object:
+$ docker exec orion-athena-recall python -c "
+from app.settings import settings
+print(settings.RECALL_GRAPHITI_IN_CHAT, settings.RECALL_GRAPHITI_ADAPTER_URL)
+"
+True http://orion-athena-graphiti-adapter:8000
+
+# The actual gating function, exercised directly, both branches:
+$ docker exec orion-athena-recall python -c "
+from app.settings import settings
+from app.collectors.active_packet import _graphiti_adapter
+a = _graphiti_adapter(settings, intent='contradiction')
+print(a.enabled, a.url)   # -> True http://orion-athena-graphiti-adapter:8000
+b = _graphiti_adapter(settings, intent='semantic')
+print(b)                  # -> None (narrow gate confirmed correct)
+"
+```
+
+## Review findings fixed
+
+None from a separate review pass — this is a config activation + tooling-guard patch, self-reviewed by directly exercising the real code path (the `_graphiti_adapter()` call above) rather than trusting the config values alone, catching the `docker exec env` red herring along the way rather than reporting a false negative.
+
+## Restart required
+
+Already executed live during this session:
+
+```bash
+docker compose --env-file .env --env-file services/orion-recall/.env \
+  -f services/orion-recall/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: Low — `docker-compose.yml`'s `environment:` block still doesn't list `RECALL_GRAPHITI_*`/`RECALL_ACTIVE_PACKET_ENABLED`/`ACTIVATION_RECALL_FLOOR` at all. Harmless today (the baked-in `.env` file is the actual read path, confirmed), but worth knowing: if this service's Dockerfile ever stops baking `.env` into the image (e.g., switches to a bind-mount-only pattern), these keys would silently stop being read unless also added to the compose file. Not fixed here — out of scope for this patch, flagging for visibility.
+- Severity: Low — `RECALL_GRAPHITI_FALKORDB_URI` remains unset/empty; not required for the `contradiction`-intent search path (`GraphitiAdapter` only needs the adapter URL), left as-is.
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...chore/recall-graphiti-chat-activation-guard?expand=1`

--- a/docs/superpowers/specs/2026-07-13-recall-followups-loop-retirement-saturation-gate-spec.md
+++ b/docs/superpowers/specs/2026-07-13-recall-followups-loop-retirement-saturation-gate-spec.md
@@ -1,0 +1,67 @@
+# Recall follow-ups: concept-relation revision loop, retirement surfacing, saturation gate operationalization
+
+**Date:** 2026-07-13
+**Status:** Proposed
+**Scope:** Three follow-ups from the "bullshit RAG" investigation, discussed and refined in conversation. Drive/goal-conditioned recall ranking is explicitly **not** covered here — still at the discussion stage, no spec yet.
+
+---
+
+## 1. Concept-relation decision loop (closes the "wasted space" gap in spec item 2)
+
+**Problem:** logging every `maybe_resolve_concept_relation()` decision (proposed, not built) is only useful if something reads it. A write-only log is the same theater pattern this session already killed twice (the old retrieval-events table, the pre-fix contradiction detection).
+
+**Two loops, not one:**
+
+### 1a. Threshold-tuning report (operational)
+Periodic (or N-decisions-triggered) job reads new decision log entries since last run, reports: call volume, relation-decision distribution, count of `contradicts`/`refines` decisions that landed *below* the `CONCEPT_RELATION_CONFIDENCE_FLOOR` (0.6) — i.e., near-misses currently invisible. Output is a report, not an auto-applied threshold change — matches "no auto-apply of proposals."
+
+### 1b. Belief-revision digest (the loop that matters for the stated goal)
+For every real `contradicts`/`refines`/`same` decision since last run, produce a short structured artifact: subject, prior belief, new belief, relation, confidence. This is a direct instance of AGENTS.md's own named sentience prerequisite ("error correction... coherent action over time") — a genuine trace of Orion revising its own beliefs, not a hand-authored taxonomy. Write as a new `reflection`-kind crystallization (ties to the previously-shelved "self-referential memory kind" brainstorm idea — this gives it a real producer) and/or surface in Hub's Memory tab review queue.
+
+**Files likely to touch:** `orion/memory/crystallization/concept_relation.py` (the missing full-decision log line, spec item 2's original ask), new module for the digest job (mirrors `orion-memory-consolidation`'s existing periodic-loop pattern, e.g. `run_retry_loop` in `services/orion-memory-consolidation/app/main.py`), `orion/memory/crystallization/schemas.py` if `reflection` becomes a new `CrystallizationKind` value (needs a producer/consumer in the same patch — this digest job is that producer).
+
+**Non-goals:** no LLM in the digest job itself (pure aggregation over already-LLM-classified decisions). No auto-supersede — the digest reports revision, doesn't apply it (that already requires human review via the existing link-review pattern).
+
+**Acceptance check:** after a real usage window, the digest produces at least one real belief-revision artifact when a real contradiction/refinement has fired — verified against real data, not synthetic.
+
+---
+
+## 2. Retirement surfacing (elaborates the deferred item from the reinforcement/decay spec)
+
+**Reframing, thinner than originally scoped:** the retirement *action* already exists — `POST /api/memory/crystallizations/{id}/deprecate` (used this session for test cleanup) sets `status=deprecated` and de-projects from recall. What's missing is only *surfacing which crystallizations are candidates* — no new mutation path needed.
+
+**Proposed (passive, no new job):** Hub's crystallization list endpoint/UI computes `decayed_activation(c, now=utcnow())` per row live (same function already used at the ranking read-site) and flags/sorts anything under `should_retire()`'s floor (0.05 default) as a candidate. A human reviewing the Memory tab sees stale items, clicks the existing deprecate endpoint. Zero new schema, zero new scheduled job.
+
+**Deferred further (only if passive isn't enough):** a periodic proactive-notification job, mirroring `orion-memory-consolidation`'s existing retry-loop pattern, if retirement candidates turn out too numerous/important to wait for passive discovery. Hold off building this until the passive version shows real signal — same "prove it before you build more" discipline as the rest of this session.
+
+**Files likely to touch:** `services/orion-hub/scripts/crystallization_routes.py` (list endpoint — add `decayed_activation` computation per row), `services/orion-hub/static/js/` (Memory tab — surface the flag), no `orion/memory/crystallization/` changes needed since `decayed_activation()`/`should_retire()` already exist.
+
+**Non-goal, unchanged from the original spec:** never auto-apply retirement. A human always clicks deprecate.
+
+---
+
+## 3. `scripts/check_activation_saturation.py` operationalization
+
+**Current state:** works, on-demand only (`POSTGRES_URI=... python scripts/check_activation_saturation.py`), has `--fail-above` for one-shot regression checks. Not wired into anything recurring.
+
+**Existing seam to ride, not invent:** `Makefile` already has standalone `make check-inner-state-registry` / `make check-single-consumer-channels` targets — simple wrappers around `python scripts/check_*.py`, explicitly documented as the real, working piece of a promised-but-not-built `agent-check` chain (see `Makefile`'s own comment: `agent-check` itself doesn't exist yet, these standalone targets are what's real). Mirror that pattern exactly:
+
+```makefile
+check-activation-saturation:
+	@python scripts/check_activation_saturation.py
+```
+
+**For the "after a real usage window" comparison the spec's acceptance check 1 actually needs** (not just a single-run gate): the script has no persisted baseline to diff against by design (documented in its own docstring — deliberately not inventing cross-run state). Two options, not a recommendation yet:
+
+- **Manual cadence**: run it by hand periodically (weekly?), eyeball the trend. Zero new infrastructure. Matches this script's stated design intent exactly ("standing check you re-run and read").
+- **Scheduled + persisted baseline**: a cron/schedule (this repo has a `schedule` skill for exactly this) that runs it on an interval and writes each run's `ceiling_fraction` (via `--json`) to a small append-only log or table, so trend-over-time is queryable instead of remembered by a human. More infrastructure, only worth it if manual cadence turns out to be forgotten in practice (matches "if Juniper has to repeat a rule twice, turn it into a script" — but this would be turning a *check* into a *scheduled* check, a step up, not needed until the manual version proves insufficient).
+
+**Recommendation:** start with the `make check-activation-saturation` target (zero new infrastructure, rides an existing pattern exactly) and manual cadence. Revisit scheduling only if the manual habit doesn't stick.
+
+**Files likely to touch:** `Makefile` only.
+
+---
+
+## Recommended sequencing
+
+All three are independent of each other and of the still-undecided drive-conditioning discussion. Suggested order: `Makefile` target (trivial, ships immediately) → retirement surfacing (thin, no new job) → concept-relation loop (the most substantive of the three, needs the missing full-decision log line first per spec item 2, then the digest job on top).

--- a/scripts/sync_local_env_from_example.py
+++ b/scripts/sync_local_env_from_example.py
@@ -38,6 +38,14 @@ NEVER_SYNC_KEYS = frozenset(
         "PUBLISH_CORTEX_EXEC_GRAMMAR",
         # Host-specific Tailscale / mesh address — never overwrite from docker-oriented templates.
         "ORION_BUS_URL",
+        # Real chat-time graph search gate (orion-recall). Both keys must change together by
+        # hand or the feature silently no-ops (enabled flag + empty/stale URL) -- the exact
+        # bug already hit twice this session with CONCEPT_RELATION_RESOLUTION_ENABLED and
+        # GRAPHITI_BACKEND. Belt-and-suspenders on top of these keys already not matching any
+        # SYNC_PREFIXES entry: this makes the protection an explicit decision, not an
+        # accident of the prefix list, and holds even under --all-keys --force.
+        "RECALL_GRAPHITI_IN_CHAT",
+        "RECALL_GRAPHITI_ADAPTER_URL",
     }
 )
 

--- a/services/orion-recall/.env_example
+++ b/services/orion-recall/.env_example
@@ -42,9 +42,15 @@ RECALL_ACTIVE_PACKET_ENABLED=true
 # Minimum dynamics.activation for crystallizations in active_packet (matches recall_eligibility)
 ACTIVATION_RECALL_FLOOR=0.08
 RECALL_BELIEF_RENDER_BUDGET=128
-RECALL_GRAPHITI_IN_CHAT=false
-# Optional Graphiti adapter for contradiction intent (when RECALL_GRAPHITI_IN_CHAT=true)
-RECALL_GRAPHITI_ADAPTER_URL=
+# Live default as of 2026-07-13 (graphiti_core backend proven working -- docs/superpowers/
+# specs/2026-07-13-graphiti-core-backend-activation-spec.md). Only fires when a turn's
+# retrieval_intent classifies as "contradiction" (see _graphiti_adapter() in
+# app/collectors/active_packet.py), not on every turn. RECALL_GRAPHITI_IN_CHAT and
+# RECALL_GRAPHITI_ADAPTER_URL are NEVER_SYNC_KEYS-protected in
+# scripts/sync_local_env_from_example.py -- change them together by hand, never let one
+# lag the other (an enabled flag with an empty/unreachable URL silently no-ops).
+RECALL_GRAPHITI_IN_CHAT=true
+RECALL_GRAPHITI_ADAPTER_URL=http://orion-athena-graphiti-adapter:8000
 RECALL_GRAPHITI_FALKORDB_URI=
 RECALL_GRAPHITI_TIMEOUT_SEC=10.0
 RECALL_CRYSTALLIZATION_VECTOR_COLLECTION=orion_memory_crystallizations

--- a/tests/scripts/test_sync_local_env_from_example.py
+++ b/tests/scripts/test_sync_local_env_from_example.py
@@ -20,6 +20,43 @@ def test_orion_bus_url_never_synced() -> None:
     assert should_sync_key("ORION_BUS_URL", all_keys=True) is False
 
 
+def test_recall_graphiti_chat_keys_never_synced() -> None:
+    """RECALL_GRAPHITI_IN_CHAT and RECALL_GRAPHITI_ADAPTER_URL gate real chat-time graph
+    search (orion-recall). Both must change together by hand or the feature silently
+    no-ops (enabled flag + empty/stale URL) -- the exact bug already hit twice this
+    session with CONCEPT_RELATION_RESOLUTION_ENABLED and GRAPHITI_BACKEND."""
+    for key in ("RECALL_GRAPHITI_IN_CHAT", "RECALL_GRAPHITI_ADAPTER_URL"):
+        assert key in NEVER_SYNC_KEYS
+        assert should_sync_key(key, all_keys=False) is False
+        assert should_sync_key(key, all_keys=True) is False
+
+
+def test_sync_file_force_does_not_touch_recall_graphiti_chat_keys(tmp_path: Path) -> None:
+    """Even --force (which overwrites ordinary diverged keys) must never touch these --
+    NEVER_SYNC_KEYS is a stricter, unconditional exclusion, unlike the diverged/--force
+    behavior that applies to everything else."""
+    svc = tmp_path / "orion-recall"
+    svc.mkdir()
+    (svc / ".env_example").write_text(
+        "RECALL_GRAPHITI_IN_CHAT=true\n"
+        "RECALL_GRAPHITI_ADAPTER_URL=http://orion-athena-graphiti-adapter:8000\n",
+        encoding="utf-8",
+    )
+    (svc / ".env").write_text(
+        "RECALL_GRAPHITI_IN_CHAT=false\nRECALL_GRAPHITI_ADAPTER_URL=\n",
+        encoding="utf-8",
+    )
+
+    result = sync_file(
+        svc / ".env", svc / ".env_example", dry_run=False, all_keys=True, force=True
+    )
+
+    text = (svc / ".env").read_text(encoding="utf-8")
+    assert "RECALL_GRAPHITI_IN_CHAT=false" in text
+    assert "RECALL_GRAPHITI_ADAPTER_URL=\n" in text
+    assert not any("RECALL_GRAPHITI" in c for c in result.updated + result.diverged)
+
+
 def test_placeholder_bus_url_skipped_even_if_all_keys() -> None:
     assert example_value_is_host_placeholder("ORION_BUS_URL", "redis://100.x.x.x:6379/0")
     assert example_value_is_host_placeholder("ORION_BUS_URL", "redis://bus-core:6379/0")


### PR DESCRIPTION
# PR report: activate real chat-time graph search + permanently guard it from the sync script

## Summary

- `RECALL_GRAPHITI_IN_CHAT` (default `false`, and previously entirely absent from this host's live `.env`) gates whether real chat/conversation turns — both `chat_general` and unified-turn (`stance_react`, confirmed to share the same PCR/recall machinery) — ever use the graph-search rail proven working earlier today. It was off; every bit of that earlier work was invisible to real conversations.
- Flipped on, live: `RECALL_GRAPHITI_IN_CHAT=true` + `RECALL_GRAPHITI_ADAPTER_URL=http://orion-athena-graphiti-adapter:8000` (both were missing from the live `.env` entirely — added, not just toggled).
- `.env_example` updated to match — this is now the shipped default, not just a live-only override, following the same "prove it, then make it the default" pattern already used for the graphiti_core backend default flip earlier today.
- `RECALL_GRAPHITI_IN_CHAT`/`RECALL_GRAPHITI_ADAPTER_URL` added to `sync_local_env_from_example.py`'s `NEVER_SYNC_KEYS` — an explicit, permanent guarantee (verified even under `--all-keys --force`) that these two keys can never be silently desynced from each other, closing off the exact failure mode that broke two other features earlier this session (`CONCEPT_RELATION_RESOLUTION_ENABLED`, `GRAPHITI_BACKEND`: flag enabled, dependency left empty).
- Live-verified via the actual running `Settings` object and the real gating function, not `docker exec env` (which doesn't reflect what this service actually reads — see below) — confirmed a real `GraphitiAdapter` is constructed for `retrieval_intent="contradiction"` and correctly `None` for every other intent.

## Outcome moved

The graph-search work from earlier today (activation, the RELATES_TO fix, default-flip, driver caching) now actually affects real conversations, not just the adapter's own API and Hub's manual calls. And the specific footgun that bit this session twice already (flag on, dependency empty, silent no-op) is now structurally prevented for this feature specifically, and self-documented for the next person who touches it.

## Current architecture (before this patch)

`orion-recall/app/collectors/active_packet.py::_graphiti_adapter()` already existed and correctly gated graph search to `retrieval_intent == "contradiction"` only — this logic was never broken. What was missing was the config to actually turn it on: `RECALL_GRAPHITI_IN_CHAT` wasn't even present in the live `.env`, so it silently defaulted to `False` in Python.

## Architecture touched

`services/orion-recall` (env only, no code change — the gating logic was already correct), `scripts/sync_local_env_from_example.py` (tooling).

## A real gotcha found and worked around during verification

`docker exec orion-athena-recall env | grep RECALL_GRAPHITI...` returned nothing even after the container was rebuilt with the new `.env` — this looked like the change hadn't taken effect. Root cause: `orion-recall`'s `Dockerfile` does `COPY services/orion-recall /app` at build time, baking `.env` directly into the image, and `settings.py`'s pydantic-settings `Config` reads `env_file=".env"` directly — so the app never relies on docker-compose's `environment:` list at all (which, separately, doesn't even list these two keys — a pre-existing gap in `docker-compose.yml`, not touched by this patch since it isn't the actual read path). `docker exec ... env` only shows OS-level environment variables, not what pydantic-settings loads from the baked-in file. Verified correctly instead by asking the running app's actual `Settings` object directly (see Docker/build/smoke checks below) — this is the "runtime truth beats config truth" standard this whole session has been held to, applied to distinguish "looks unset" from "the app's actual view."

## Files changed

- `services/orion-recall/.env_example`: `RECALL_GRAPHITI_IN_CHAT` default `false`→`true`; `RECALL_GRAPHITI_ADAPTER_URL` filled in with a real, container-DNS-reachable value (matching the exact precedent already used for `CRYSTALLIZER_EMBED_HOST_URL` when the graphiti_core backend's own default flipped earlier today); comment documents the `NEVER_SYNC_KEYS` protection and the must-change-together requirement.
- `services/orion-recall/.env` (live, not committed — gitignored): same two keys, added (were entirely absent, not just `false`).
- `scripts/sync_local_env_from_example.py`: `NEVER_SYNC_KEYS` gains `RECALL_GRAPHITI_IN_CHAT`, `RECALL_GRAPHITI_ADAPTER_URL`. Belt-and-suspenders on top of an existing, weaker protection: neither key matches any `SYNC_PREFIXES` entry (verified directly via `should_sync_key()`), so they were already excluded from the script's default scan — this makes that exclusion an explicit, permanent decision rather than an accident of the prefix list, and extends it to hold even under `--all-keys --force`.
- `tests/scripts/test_sync_local_env_from_example.py`: two new tests, mirroring the file's existing `test_orion_bus_url_never_synced` style — `should_sync_key()` returns `False` for both keys in both modes; a real `sync_file()` round-trip with `--force`+`--all-keys` (the strongest possible attempt to override) leaves both keys completely untouched.
- `docs/superpowers/specs/2026-07-13-recall-followups-loop-retirement-saturation-gate-spec.md`: carried over from an earlier uncommitted state this session, included here since it was sitting untracked and this PR is the natural place for it to land (it documents unrelated prior work from the same day, not part of this patch's diff otherwise).

## Schema / bus / API changes

None. No new keys — both `RECALL_GRAPHITI_IN_CHAT` and `RECALL_GRAPHITI_ADAPTER_URL` already existed in `.env_example`; only their default values and sync-protection changed.

## Env/config changes

- Changed defaults: `RECALL_GRAPHITI_IN_CHAT` (`false`→`true`), `RECALL_GRAPHITI_ADAPTER_URL` (empty→`http://orion-athena-graphiti-adapter:8000`) in `.env_example`.
- Live `.env` updated to match (both keys were entirely absent before this session; added, not committed — gitignored).
- `python scripts/sync_local_env_from_example.py orion-recall --dry-run` confirmed clean (`No changes needed`) after these edits — no unexpected divergence introduced elsewhere in the file.
- Both changed keys are now permanently excluded from any future sync-script run, by design.

## Tests run

```text
$ source venv/bin/activate && python -m pytest tests/scripts/test_sync_local_env_from_example.py -v
8 passed in 0.10s
```
All existing tests plus the 2 new ones. No regression.

## Evals run

Not applicable — this is config + a tooling guard, not application logic with a meaningful eval surface.

## Docker/build/smoke checks

```text
$ docker compose --env-file .env --env-file services/orion-recall/.env \
    -f services/orion-recall/docker-compose.yml up -d --build
Container orion-athena-recall Started

$ docker ps --format '{{.Names}}\t{{.Status}}' | grep recall
orion-athena-recall   Up About a minute (healthy)

$ curl -sS http://localhost:<port>/health   (via docker exec, internal)
{"ok":true,"service":"recall","version":"0.1.0","node":"athena-DEBUG-CONTAINER"}

# Real verification -- NOT docker exec env (see gotcha above), the app's own Settings object:
$ docker exec orion-athena-recall python -c "
from app.settings import settings
print(settings.RECALL_GRAPHITI_IN_CHAT, settings.RECALL_GRAPHITI_ADAPTER_URL)
"
True http://orion-athena-graphiti-adapter:8000

# The actual gating function, exercised directly, both branches:
$ docker exec orion-athena-recall python -c "
from app.settings import settings
from app.collectors.active_packet import _graphiti_adapter
a = _graphiti_adapter(settings, intent='contradiction')
print(a.enabled, a.url)   # -> True http://orion-athena-graphiti-adapter:8000
b = _graphiti_adapter(settings, intent='semantic')
print(b)                  # -> None (narrow gate confirmed correct)
"
```

## Review findings fixed

None from a separate review pass — this is a config activation + tooling-guard patch, self-reviewed by directly exercising the real code path (the `_graphiti_adapter()` call above) rather than trusting the config values alone, catching the `docker exec env` red herring along the way rather than reporting a false negative.

## Restart required

Already executed live during this session:

```bash
docker compose --env-file .env --env-file services/orion-recall/.env \
  -f services/orion-recall/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: Low — `docker-compose.yml`'s `environment:` block still doesn't list `RECALL_GRAPHITI_*`/`RECALL_ACTIVE_PACKET_ENABLED`/`ACTIVATION_RECALL_FLOOR` at all. Harmless today (the baked-in `.env` file is the actual read path, confirmed), but worth knowing: if this service's Dockerfile ever stops baking `.env` into the image (e.g., switches to a bind-mount-only pattern), these keys would silently stop being read unless also added to the compose file. Not fixed here — out of scope for this patch, flagging for visibility.
- Severity: Low — `RECALL_GRAPHITI_FALKORDB_URI` remains unset/empty; not required for the `contradiction`-intent search path (`GraphitiAdapter` only needs the adapter URL), left as-is.