### PR TITLE
Feat/execution dispatch motor nerve p1

### DIFF
--- a/config/execution_dispatch/execution_dispatch_policy.v1.yaml
+++ b/config/execution_dispatch/execution_dispatch_policy.v1.yaml
@@ -3,7 +3,11 @@ policy_id: execution_dispatch_policy.v1
 
 mode:
   default_dispatch_mode: dry_run
-  allow_dispatch_read_only: false
+  # Real sends require BOTH this true AND the runtime's own
+  # EXECUTION_DISPATCH_MODE=dispatch_read_only (services/orion-execution-
+  # dispatch-runtime/.env) -- default_dispatch_mode above stays dry_run, so
+  # opening this gate alone does not turn on live dispatch.
+  allow_dispatch_read_only: true
   allow_mutating_dispatch: false
 
 allowed_policy_decisions:

--- a/config/proposals/proposal_policy.v1.yaml
+++ b/config/proposals/proposal_policy.v1.yaml
@@ -132,3 +132,27 @@ proposal_templates:
     dimensions:
       uncertainty: 0.50
       reliability_pressure: 0.50
+
+  inspect_node_resource_pressure:
+    kind: inspect
+    target_kind: node
+    target_id: node:atlas
+    proposed_effect: increase_observability
+    required_policy_gate: read_only
+    base_priority: 0.34
+    base_risk: 0.05
+    reversibility: 1.0
+    dimensions:
+      resource_pressure: 0.50
+
+  inspect_field_topology_catalog:
+    kind: inspect
+    target_kind: field
+    target_id: config/field/orion_field_topology.v1.yaml
+    proposed_effect: increase_observability
+    required_policy_gate: read_only
+    base_priority: 0.33
+    base_risk: 0.05
+    reversibility: 1.0
+    dimensions:
+      field_intensity: 0.45

--- a/docs/superpowers/pr-reports/2026-07-13-execution-dispatch-motor-nerve-p1-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-execution-dispatch-motor-nerve-p1-pr.md
@@ -1,0 +1,162 @@
+# feat(execution-dispatch): motor nerve — Layer 9 actually sends (P1)
+
+## Summary
+
+- `orion-execution-dispatch-runtime` (Layer 9) now actually sends `prepared_for_dispatch` candidates to `orion-cortex-exec` over the bus, instead of only building envelopes and never sending (P0 un-lied the status; P1 makes the honest status real).
+- Three new cortex verbs (`substrate.inspect`/`summarize`/`observe`), each with its own prompt template and distinct tone (inspect: diagnostic; summarize: wide-angle; observe: deliberately lighter/non-alarming, matching its `preserve_stability` proposal-layer intent).
+- Two new "robust, not speculative" proposal templates targeting `node`/`field` target_kinds — real, already-live signal behind both; explicitly did not add a `service`-target template (no real backing signal exists for it) or any new verb/proposal-kind beyond what's already grounded (no `trend`/`correlate`, per earlier design discussion).
+- New `substrate_dispatch_results` table; `FeedbackRuntimeStore.load_cortex_result_evidence` replaced its `[]`-stub with a real query.
+- Theater tripwire: if more than half of the trailing 10 real results come back empty, sending self-disables for the rest of the process's life, visible on `GET /latest`, with one `orion-notify` warning on the transition.
+- Idempotency guard added during review: a crash between a successful send and frame persistence can no longer cause a duplicate real cortex-exec call for the same candidate.
+
+## Outcome moved
+
+Orion has never taken a real, evidenced, self-initiated action through this pipeline before. This patch is the one place that changes — everything upstream (perception → proposal → policy) and downstream (feedback scoring) already existed and worked; only the actual send was missing. `EXECUTION_DISPATCH_MODE` still defaults to `dry_run`, so nothing changes in the live environment until an operator explicitly flips it.
+
+## Current architecture (before this patch)
+
+`orion-execution-dispatch-runtime`'s worker built `ExecutionDispatchFrameV1` envelopes and persisted them, but never touched the bus — no `redis` dependency, no bus client, a dead `CORTEX_EXEC_CHANNEL` setting pointing at a channel name that didn't exist. `FeedbackRuntimeStore.load_cortex_result_evidence` was a two-line stub always returning `[]`. No cortex verb existed for any of the three dispatch kinds the policy already routed to.
+
+## Architecture touched
+
+`orion-execution-dispatch-runtime` (worker, store, settings, requirements), `orion-feedback-runtime` (store), `orion-cortex-exec` (verb allowlist), `orion-hub`'s debug route unaffected, plus shared `orion/` packages (`execution_dispatch/`, `feedback/`, `cognition/verbs`+`prompts`, `bus/channels.yaml`), `config/proposals/`, `config/execution_dispatch/`, and `services/orion-sql-db/` (new migration).
+
+## Files changed
+
+- `orion/cognition/verbs/substrate.{inspect,summarize,observe}.yaml` + `orion/cognition/prompts/substrate_{inspect,summarize,observe}.j2` — new verbs, own templates, distinct tone per verb.
+- `services/orion-cortex-exec/app/router.py` — added the three verb names to `_structured_output_expected`.
+- `config/proposals/proposal_policy.v1.yaml` — two new templates (`node`, `field` target_kinds), reusing `kind: inspect`, no new enum values.
+- `services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql` — new table.
+- `services/orion-feedback-runtime/app/store.py` — real `load_cortex_result_evidence` (dedupe-by-latest, degrade-on-malformed-row).
+- `orion/bus/channels.yaml` — `orion-execution-dispatch-runtime` added as a producer on `orion:cortex:exec:request:background`.
+- `orion/execution_dispatch/cortex_client.py` (new) — RPC client, mirrors `orion.harness.cortex_client.HarnessCortexClient`'s shape.
+- `orion/execution_dispatch/result_extraction.py` (new) — `extract_final_text`/`parse_structured_observation`.
+- `orion/execution_dispatch/envelopes.py` — `origin`/`correlation` fields for attribution.
+- `services/orion-execution-dispatch-runtime/app/worker.py` — send-and-wait step, budget/cap enforcement, theater tripwire, idempotency guard.
+- `services/orion-execution-dispatch-runtime/app/store.py` — `save_dispatch_result`, `count_dispatches_today`, `recent_dispatch_result_statuses`, `load_dispatch_result_by_dispatch_id`.
+- `services/orion-execution-dispatch-runtime/app/main.py` — `theater_tripwire_active` on `GET /latest`.
+- `services/orion-execution-dispatch-runtime/app/settings.py`, `.env_example`, `requirements.txt` — new keys, fixed `CORTEX_EXEC_CHANNEL` default, `redis`+`requests` dependencies.
+- `orion/feedback/builder.py` — `prepared_for_dispatch`/`"empty"` status handling.
+- `config/execution_dispatch/execution_dispatch_policy.v1.yaml` — `allow_dispatch_read_only: true`.
+- Test files: `tests/test_execution_dispatch_cortex_client.py`, `tests/test_execution_dispatch_result_extraction.py` (new); `tests/test_execution_dispatch_runtime_worker.py`, `tests/test_execution_dispatch_runtime_store.py`, `tests/test_feedback_runtime_store.py`, `tests/test_feedback_builder.py`, `tests/test_execution_dispatch_policy_loader.py`, `tests/test_execution_dispatch_bus_catalog.py` (new), `tests/test_proposal_policy_loader.py`, `tests/test_plan_loader.py` (extended).
+- `docs/superpowers/specs/2026-07-13-execution-dispatch-motor-nerve-p1-design.md` — design spec.
+- `services/orion-execution-dispatch-runtime/README.md`, `services/orion-feedback-runtime/README.md` — documented.
+
+## Schema / bus / API changes
+
+- **Added:** `substrate_dispatch_results` table; `orion:cortex:exec:request:background`'s `producer_services` gains `orion-execution-dispatch-runtime`; `orion/feedback/builder.py`'s `OutcomeKind` unaffected (no new literal added — `"empty"` cortex status maps into the existing `"failed"` outcome kind, not a new one, per the empty-shell-cognition rule).
+- **Removed:** none.
+- **Renamed:** none.
+- **Behavior changed:** real sends now happen when both `EXECUTION_DISPATCH_MODE=dispatch_read_only` and the policy's `allow_dispatch_read_only: true` (now the shipped default) are open. `dispatched_candidates`/`dispatch_count`/`dispatch_attempted` become honest for the first time (previously permanently empty/zero/false from this builder, a known P0 limitation, now resolved). `_cortex_status_to_outcome`'s `"empty"` status now scores as `"failed"` rather than falling through to `"unknown"`.
+- **Compatibility notes:** the new evidence-requiring validator from P0 could have broken historical rows on load — checked and guarded during P0; this patch's own new risk (duplicate real dispatch on crash) was caught in review and fixed with an idempotency guard before merge, not after.
+
+## Env/config changes
+
+- Added keys (`services/orion-execution-dispatch-runtime/.env_example`): `CORTEX_EXEC_RESULT_PREFIX`, `ORION_BUS_URL`, `ORION_BUS_ENABLED`, `EXECUTION_DISPATCH_RPC_TIMEOUT_SEC`, `ORION_DISPATCH_MAX_PER_DAY`, `NOTIFY_URL`, `NOTIFY_API_TOKEN`.
+- Changed default: `CORTEX_EXEC_CHANNEL` (`orion:cortex:request` → `orion:cortex:exec:request:background` — the old default named a channel that didn't exist in `orion/bus/channels.yaml` and was never referenced in code; now it's real and wired).
+- Removed keys: none.
+- `.env_example` updated: yes.
+- local `.env` synced with `python scripts/sync_local_env_from_example.py`: run — no local `.env` exists for this service in this environment (never brought up locally here), so it was a no-op; confirmed via `git status --short` that no `.env` file was created or staged.
+- skipped keys requiring operator action: none new; `ORION_BUS_URL`'s tailscale-node-IP placeholder in `.env_example` needs a real value on any environment that runs this service for real (same as every other bus-connected service in this repo).
+
+## Tests run
+
+```text
+cd /mnt/scripts/Orion-Sapienform-execution-dispatch-motor-nerve-p1
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest \
+  tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_envelopes.py \
+  tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_policy_loader.py \
+  tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_runtime_worker.py \
+  tests/test_execution_dispatch_transport_dry_run.py tests/test_execution_dispatch_cortex_client.py \
+  tests/test_execution_dispatch_result_extraction.py tests/test_execution_dispatch_bus_catalog.py \
+  tests/test_feedback_builder.py tests/test_feedback_runtime_store.py tests/test_feedback_transport_outcomes.py \
+  tests/test_proposal_policy_loader.py tests/test_plan_loader.py \
+  tests/test_consolidation_tensorize.py tests/test_consolidation_schema_candidates.py \
+  tests/test_consolidation_motif_detection.py tests/test_consolidation_expectations.py \
+  tests/test_consolidation_policy_loader.py -q
+
+142 passed
+
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest \
+  services/orion-cortex-exec/tests/test_router_final_text_assembly.py \
+  services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py -q
+
+36 passed
+```
+(Run as two groups: this repo's `sys.path.insert` + `import app.X` test pattern has a pre-existing module-name collision risk when combining test files from multiple services that all use the generic package name `app` in one pytest invocation — not introduced by this patch, matches how `make agent-check SERVICE=<x>` already scopes per-service.)
+
+`git diff --check` clean. `.env` files confirmed gitignored, none created/staged.
+
+## Evals run
+
+None — no eval harness exists for this service; the design spec names a live smoke script (`scripts/smoke_execution_dispatch_live.sh`) as a follow-up once this is deployed with real traffic, not built in this patch (requires a live cortex-exec + bus + Postgres environment this sandbox doesn't have).
+
+## Docker/build/smoke checks
+
+Not run — no container build available in this sandbox. Verified instead:
+- Live Postgres query against `substrate_execution_dispatch_frames` (687,992 rows, carried over from P0's compat check) and live confirmation of `SHOW timezone` (`Etc/UTC`) on the real `orion-sql-db` instance, informing the `count_dispatches_today()` UTC-boundary fix.
+- `redis==5.0.7`/`requests==2.32.3` both confirmed importable in the shared venv.
+- All touched/new YAML files (`proposal_policy.v1.yaml`, `execution_dispatch_policy.v1.yaml`, `channels.yaml`, 3 verb YAMLs) parse cleanly.
+- `orion/execution_dispatch/cortex_client.py`, `result_extraction.py`, and `services/orion-execution-dispatch-runtime/app/worker.py` all import cleanly end-to-end (including through `orion.core.bus.async_service`'s `redis` dependency).
+
+## Review findings fixed
+
+- Finding: No idempotency guard — a crash between a successful real send and `save_dispatch_frame()` persisting that fact would cause the next tick to resend a real cortex-exec RPC for the same (deterministic) `dispatch_id`.
+  - Fix: `store.load_dispatch_result_by_dispatch_id()` + a check at the top of `_send_one()` that replays the stored result instead of resending.
+  - Evidence: `tests/test_execution_dispatch_runtime_worker.py::test_send_one_replays_existing_result_without_resending` (and the failed-result variant) — registers no fake-client outcome, so a real resend attempt would `KeyError`; both pass.
+- Finding: `evidence_refs` was always empty in production — the feedback-runtime reader looked for a key the dispatch worker never wrote.
+  - Fix: `save_dispatch_result`'s `result_json` now includes `evidence_refs: [result_id]`.
+  - Evidence: `_send_one`'s success/failure paths both updated; existing `load_cortex_result_evidence` tests already assert on this field's presence.
+- Finding: cortex status `"empty"` fell into the same `"unknown"` bucket as a genuinely untracked result — the theater tripwire's core signal wasn't distinguishable from missing data in feedback scoring.
+  - Fix: `_cortex_status_to_outcome` maps `"empty"` to `"failed"`, matching the empty-shell-cognition rule ("stored as failure, never as success").
+  - Evidence: `tests/test_feedback_builder.py::test_empty_cortex_result_scores_as_failed_not_unknown`.
+- Finding: `extract_final_text` dropped the `raw.text` fallback branch present in the function it's documented as mirroring (`orion-actions`' version), risking false `status="empty"` for a real content shape.
+  - Fix: restored the branch verbatim.
+  - Evidence: `orion/execution_dispatch/result_extraction.py:26-29`.
+- Finding: `theater_tripwire_active` wasn't exposed on `GET /latest`, contradicting the design doc's explicit acceptance check.
+  - Fix: added to the response payload in `app/main.py`.
+  - Evidence: one-line diff, `services/orion-execution-dispatch-runtime/app/main.py`.
+- Finding (lower confidence, live-checked): `count_dispatches_today()` used `date_trunc('day', now())`, Postgres-server-timezone-dependent, inconsistent with this file's own explicit-UTC convention elsewhere.
+  - Fix: computed the UTC day boundary in Python instead. Live-checked `SHOW timezone` on the real instance first — `Etc/UTC`, so not an active bug, but hardened anyway for consistency.
+  - Evidence: `services/orion-execution-dispatch-runtime/app/store.py::count_dispatches_today`.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-execution-dispatch-runtime/.env \
+  -f services/orion-execution-dispatch-runtime/docker-compose.yml \
+  up -d --build
+
+docker compose \
+  --env-file .env \
+  --env-file services/orion-feedback-runtime/.env \
+  -f services/orion-feedback-runtime/docker-compose.yml \
+  up -d --build
+
+docker compose \
+  --env-file .env \
+  --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml \
+  up -d --build
+```
+Plus the new migration before starting `orion-execution-dispatch-runtime`:
+```bash
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql
+```
+No config change alone turns on live sending — `EXECUTION_DISPATCH_MODE` still defaults to `dry_run` in `.env_example`; an operator must explicitly set it to `dispatch_read_only` in the real `.env` for this service to start sending.
+
+## Risks / concerns
+
+- Severity: medium
+- Concern: this is Orion's first real self-initiated bus action. Even with the theater tripwire, budget caps, and idempotency guard, the actual behavior of a live `substrate.inspect`/`summarize`/`observe` LLM call against real self-state data hasn't been observed — only unit-tested against mocked bus/client responses.
+- Mitigation: `EXECUTION_DISPATCH_MODE` defaults to `dry_run`; recommend a manual, closely-watched burn-in window (flip the env var, watch `/latest`'s `theater_tripwire_active` and `dispatch_count`, check `substrate_dispatch_results` rows directly) before considering this "on" in any meaningful sense. Matches the parent spec's own stated sequencing (P1 needs its own burn-in before P2/P3, which need it before P7's origination decision).
+- Severity: low
+- Concern: `scripts/smoke_execution_dispatch_live.sh` (named in the parent spec's evidence bar) was not built in this patch — no live bus/cortex-exec/Postgres stack available in this sandbox to write and verify a real smoke script against.
+- Mitigation: follow-up, once this is deployed somewhere with real infra to smoke-test against.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/execution-dispatch-motor-nerve-p1

--- a/docs/superpowers/specs/2026-07-13-execution-dispatch-motor-nerve-p1-design.md
+++ b/docs/superpowers/specs/2026-07-13-execution-dispatch-motor-nerve-p1-design.md
@@ -1,0 +1,97 @@
+# Execution dispatch motor nerve (P1 of the motor-nerve spec) — design
+
+**Date:** 2026-07-13
+**Status:** PROPOSAL — implementation gated on Juniper sign-off before any subagent spawns
+**Mode:** Design (dense). Every claim below was checked against the live worktree (`feat/execution-dispatch-motor-nerve-p1`, off fresh `origin/main` post-P0 merge), not inferred from the original brainstorm-level P1 section of `docs/superpowers/specs/2026-07-13-endogenous-action-motor-nerve-spec.md`. Several concrete gaps below were not known when that doc was written.
+
+## Arsonist summary
+
+P0 made the status vocabulary honest: `prepared_for_dispatch` is now the correct name for "cleared every gate, envelope built, never sent." P1 is the patch that makes something real happen to that envelope. Today, `orion-execution-dispatch-runtime`'s worker never touches the bus at all — no `redis` import, no `redis` dependency in `requirements.txt`, and a `CORTEX_EXEC_CHANNEL` setting that's wired into `settings.py` but referenced nowhere else and defaults to a channel name (`orion:cortex:request`) that doesn't exist in `orion/bus/channels.yaml`. This isn't a small wiring gap — it's an empty seam. P1 fills it: build a real cortex-exec RPC client (mirroring an existing one, not inventing a new pattern), send `prepared_for_dispatch` envelopes over a bus channel that already has multi-producer precedent, persist what comes back, feed it into feedback scoring (currently a hardcoded stub returning `[]`), and gate all of it behind a deterministic tripwire so a live loop producing empty results reverts itself before anyone has to notice by hand.
+
+## Current architecture
+
+- **Worker** (`services/orion-execution-dispatch-runtime/app/worker.py`, 119 lines): `_tick()` loads a policy frame, its proposal, its self-state, calls `build_execution_dispatch_frame(...)`, and persists the result. No bus code anywhere in the file. No `redis` in `requirements.txt` (fastapi, uvicorn, pydantic, pydantic-settings, sqlalchemy, psycopg2-binary, PyYAML only) — `OrionBusAsync` cannot even import in this service today.
+- **Envelope** (`orion/execution_dispatch/envelopes.py`, `build_cortex_request_envelope`): returns a plain dict `{"verb", "mode", "source", "dry_run", "context", "constraints"}` — no `correlation_id`, no `reply_to`, no `kind`. Not `BaseEnvelope`-shaped. Stashed onto `ExecutionDispatchCandidateV1.request_envelope`/`.constraints` and persisted as part of the frame; never read again by anything that sends it.
+- **Cortex verbs**: `config/execution_dispatch/execution_dispatch_policy.v1.yaml` routes `inspect`/`summarize`/`observe` proposal kinds to cortex verbs `substrate.inspect`/`substrate.summarize`/`substrate.observe` (`cortex_mode: brain`). **No verb YAML exists for any of these three** under `orion/cognition/verbs/` (96 other verb files exist; none named `substrate.*`). The closest structural precedent is the `skills.*` family (e.g. `skills.docker.ps_status.v1.yaml`: `category: ExecutiveControl`, `priority: low`, `interruptible: true`, `services: []`, plan-based, no LLM generation step) — a read-only system-probe shape, not the `Generative`/LLM-answer shape of verbs like `answer_direct.yaml`.
+- **Empty-output-fail gate**: `services/orion-cortex-exec/app/router.py:445-458`, `_should_fail_empty_structured_verb_output`, fires only for verbs in the `_structured_output_expected` allowlist (`router.py:82-91`: `journal.compose`, `concept_induction_journal_synthesize`, `github_compactor_digest_v1`, `chat_history_compactor_digest_v1`, `memory_graph_suggest`, `stance_react`, `harness_finalize_reflect`). None of `substrate.*` are in this set — today, an empty structured response from a future `substrate.inspect` verb would not be caught by this existing mechanism.
+- **Bus channels**: `orion:cortex:exec:request` (`channels.yaml:135-144`) is `single_consumer: true`, `producer_services: [orion-cortex-orch, orion-thought]`, consumed solely by `orion-cortex-exec`. A sibling channel, `orion:cortex:exec:request:background` (`channels.yaml:164-171`), already has `producer_services: [orion-cortex-orch, orion-actions, orion-harness-governor]` — this is the live precedent for "a non-orchestrator service producing onto a cortex-exec request queue," and is a closer structural match for what P1 needs than the primary `:request` channel.
+- **Single-consumer gate** (`scripts/check_single_consumer_channels.py`): validates only that `single_consumer: true` channels have exactly one live Redis subscriber via `PUBSUB NUMSUB` — it does not validate `producer_services` membership at all. Producer-list correctness is enforced ad hoc by per-feature "bus catalog" tests (e.g. `tests/test_autonomy_goals_bus_catalog.py:64`). Adding `orion-execution-dispatch-runtime` as a producer on `:background` is safe with respect to the single-consumer gate (consumer count doesn't change) but needs its own catalog-membership test, following the established per-feature pattern.
+- **RPC pattern already live**: `orion/harness/cortex_client.py`'s `HarnessCortexClient.execute_plan` — constructs a `BaseEnvelope(kind=req.kind, source=ServiceRef(...), correlation_id=..., reply_to=f"{result_prefix}:{uuid4()}", payload=req.model_dump(mode="json"))`, then calls `OrionBusAsync.rpc_request(request_channel, env, reply_channel=..., timeout_sec=...)` — publish, subscribe-to-reply, bounded wait, all in one primitive. Nothing in this class is harness-specific in its constructor signature (`bus`, `request_channel`, `result_prefix`, `source_name`, `timeout_sec`) — it lives in `orion/harness/` (a shared library path, not a `services/` package), so it is a candidate for direct reuse rather than a pattern to re-derive from scratch.
+- **Result channel**: `orion:exec:result:*` (`channels.yaml:245-256`, schema `CortexExecResultPayload`, `consumer_services: ["*"]`) — glob-consumed, so a new consumer needs no catalog change.
+- **Feedback evidence**: `orion/feedback/extractors.py:52-67`, `normalize_cortex_result_evidence(result: dict) -> dict` — normalizes `status`/`ok`, `result_id`/`correlation_id`, `dispatch_id`, `evidence_refs` into a 4-key dict, consumed by `orion/feedback/builder.py:221-239` to build `cortex_result`-kind observations. **The only real-world caller of `build_feedback_frame` that supplies `cortex_results` is `services/orion-feedback-runtime/app/worker.py`**, which sources them from `FeedbackRuntimeStore.load_cortex_result_evidence(dispatch_frame)` — currently a two-line stub that ignores its argument and returns `[]` (`store.py:259-263`). This is the second dead end P1 must close, symmetric to the worker's missing send step.
+- **Migration mechanism**: no Alembic anywhere in the repo. ~47 `manual_migration_*.sql` files under `services/orion-sql-db/`, applied by hand/ops script. `manual_migration_execution_dispatch_frame_v1.sql` is the exact template shape: single JSONB payload column, text primary key, `created_at default now()`, `generated_at desc` index.
+- **Notification rail**: NOT a direct bus publish for arbitrary services. `orion-notify` is the sole publisher of `HubNotificationEvent` onto `orion:notify:in_app` (consumed by Hub's `NotificationCache`). Other services integrate via HTTP: `orion/notify/client.py`'s `NotifyClient.send(NotificationRequest)` → `POST {base_url}/notify`. This is simpler than the original brainstorm assumed (no bus schema work needed for notifications).
+- **`CORTEX_EXEC_CHANNEL`**: already declared in `services/orion-execution-dispatch-runtime/app/settings.py:31` (`Field("orion:cortex:request", alias="CORTEX_EXEC_CHANNEL")`) and in `.env_example`, but referenced nowhere in `worker.py` — dead config, and its default value doesn't match any real channel name. Must be fixed regardless of which channel P1 targets.
+- **Tests**: `tests/test_execution_dispatch_transport_dry_run.py` despite its name does not touch the bus — "transport" refers to a verb-name test fixture (`substrate.inspect.transport`), not networking. No bus-mocking precedent exists in this test suite; `orion/harness/tests/test_cortex_client_finalize_timeouts.py` is the real precedent (`AsyncMock` bus, `bus.rpc_request = AsyncMock(return_value=...)`).
+
+## Missing questions
+
+1. **Reuse `HarnessCortexClient` directly, or fork a thin `ExecutionDispatchCortexClient`?** The constructor is generic. Reuse avoids duplicating the RPC primitive; a fork keeps `orion/harness/` from acquiring an execution-dispatch-shaped caller in its import graph, which is arguably a cleaner service boundary (`orion/harness/` is conceptually "the FCC/Claude harness's cortex access," not a generic cortex-RPC library, even though nothing currently enforces that). **Leaning fork** — a ~40-line class in `orion/execution_dispatch/cortex_client.py` mirroring `HarnessCortexClient`'s shape exactly, since CLAUDE.md's service-boundary rules favor explicit, narrow ownership over cross-package reuse when the reused class isn't already positioned as a shared library. Recommend deciding this explicitly before implementation, not silently.
+2. **Target `orion:cortex:exec:request:background` or add a new channel?** The `:background` channel already has non-orchestrator producers and is described (by naming convention) for exactly this kind of lower-priority, non-interactive request. Recommend targeting it — zero new channel, minimal catalog diff, matches an existing pattern instead of inventing one. Confirm consumer-side (`orion-cortex-exec`) actually treats `:background` requests identically to `:request` ones (same verb-routing logic) before committing — if `:background` has different priority/queueing semantics inside cortex-exec, that changes the choice.
+3. **Which verb template family?** Recommend modeling `substrate.inspect/summarize/observe.yaml` on the `skills.*` shape (`category: ExecutiveControl`, no `services:` list, plan-based, non-generative) rather than `answer_direct`'s LLM-generation shape — these are read-only system probes producing structured JSON, not conversational answers. Needs one clarifying look at how `skills.*` verbs actually produce their output (plan step mechanics) before the exact YAML shape is final — flagged as a first-half-hour implementation task, not resolved here.
+4. **Add `substrate.*` to `_structured_output_expected`'s allowlist, or build P1's own empty-check?** The existing allowlist mechanism in `router.py` is the established, already-tested empty-shell gate. Recommend extending it rather than duplicating its logic in the dispatch worker — one mechanism for "structured verb output must not be empty," not two.
+
+## Proposed schema / API changes
+
+**New verb files** (`orion/cognition/verbs/substrate.inspect.yaml`, `substrate.summarize.yaml`, `substrate.observe.yaml`) sharing one Jinja template (`orion/cognition/prompts/substrate_probe.j2`). Output contract: `{"observation": str, "salient_facts": list[str], "confidence": float}`. Inputs to the template: proposal target (`target_kind`, `target_id`), the triggering `SelfStateV1` dimension snapshot, `proposed_effect`. Add all three verb names to `router.py`'s `_structured_output_expected` allowlist.
+
+**`orion/execution_dispatch/envelopes.py`**: `build_cortex_request_envelope` gains `correlation_id`/`origin: "endogenous.dispatch"` fields in its returned dict so the eventual `BaseEnvelope` wrapping carries dispatch attribution through to cortex-exec's logs and the grammar trace it publishes.
+
+**`orion/execution_dispatch/cortex_client.py`** (new, pending Missing Question 1): thin RPC client mirroring `HarnessCortexClient`, targeting `orion:cortex:exec:request:background` (pending Missing Question 2) with `result_prefix` matching `orion:exec:result:*`.
+
+**`services/orion-execution-dispatch-runtime/app/worker.py`**: `_tick()` gains a step after `build_execution_dispatch_frame` returns: for each candidate in `frame.candidates` with `dispatch_status == "prepared_for_dispatch"`, RPC-send its `request_envelope`, await bounded, record success/failure, and only then construct a new `ExecutionDispatchCandidateV1` copy with `dispatch_status="dispatched"`, `dispatched_at=now`, and `result_ref`/`dispatch_error` set per P0's validator — before persisting.
+
+**New table** `substrate_dispatch_results` (migration `services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql`, modeled on the execution-dispatch-frame migration): `result_id text primary key`, `dispatch_id text not null`, `frame_id text not null`, `status text not null`, `result_json jsonb not null`, `raw_len int not null`, `created_at timestamptz not null default now()`. `raw_len=0` or empty `observation` stored with `status='empty'` — never `'success'`.
+
+**`services/orion-feedback-runtime/app/store.py`**: `load_cortex_result_evidence` stops being a stub — real query against `substrate_dispatch_results` filtered by the dispatch frame's candidate `dispatch_id`s, normalized to the shape `normalize_cortex_result_evidence` expects.
+
+**Config**: `config/execution_dispatch/execution_dispatch_policy.v1.yaml`: `mode.allow_dispatch_read_only: true`. `services/orion-execution-dispatch-runtime/.env_example` + `.env`: fix `CORTEX_EXEC_CHANNEL` default to `orion:cortex:exec:request:background` (pending Q2), add `EXECUTION_DISPATCH_RPC_TIMEOUT_SEC=120`, `ORION_DISPATCH_MAX_PER_DAY=24`. `requirements.txt`: add `redis` (pinned to match sibling services, e.g. `redis==5.0.*`).
+
+**Theater tripwire**: in the worker, track the trailing 10 dispatch results (new small store method or in-memory-plus-DB-query); if more than half have `status='empty'`, self-revert `EXECUTION_DISPATCH_MODE` behavior to dry-run-equivalent for subsequent ticks (in-process flag, not an env rewrite) and call `NotifyClient.send(...)` with a `theater_tripwire_active` event. Expose the flag on the existing `/latest` debug endpoint. Re-arm requires a restart (env flip), matching the parent spec's stated design.
+
+## Files likely to touch
+
+- `orion/cognition/verbs/substrate.inspect.yaml`, `substrate.summarize.yaml`, `substrate.observe.yaml` (new)
+- `orion/cognition/prompts/substrate_probe.j2` (new)
+- `services/orion-cortex-exec/app/router.py` — extend `_structured_output_expected`
+- `orion/execution_dispatch/envelopes.py` — correlation/origin fields
+- `orion/execution_dispatch/cortex_client.py` (new, pending Q1)
+- `services/orion-execution-dispatch-runtime/app/worker.py` — send-and-wait step, tripwire tracking
+- `services/orion-execution-dispatch-runtime/requirements.txt` — add `redis`
+- `services/orion-execution-dispatch-runtime/.env_example` (+ local `.env` sync) — fixed `CORTEX_EXEC_CHANNEL`, new timeout/cap keys
+- `services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql` (new)
+- `services/orion-feedback-runtime/app/store.py` — real `load_cortex_result_evidence`
+- `config/execution_dispatch/execution_dispatch_policy.v1.yaml` — `allow_dispatch_read_only: true`
+- `orion/bus/channels.yaml` — add `orion-execution-dispatch-runtime` to `:background`'s `producer_services` (pending Q2)
+- New bus-catalog test asserting that producer membership, mirroring `tests/test_autonomy_goals_bus_catalog.py`'s pattern
+- New worker tests using the `AsyncMock`-bus pattern from `orion/harness/tests/test_cortex_client_finalize_timeouts.py`
+- `services/orion-execution-dispatch-runtime/README.md` — document the send step, tripwire, rollback
+- `scripts/smoke_execution_dispatch_live.sh` (new) — one real end-to-end dispatch smoke, per the parent spec's evidence bar
+
+## Non-goals
+
+- No mutating dispatch (`allow_mutating_dispatch` stays `false`).
+- No LLM-driven action selection, no planner, no scoring model beyond the existing deterministic policy gates.
+- No origination enablement (`ORION_ENDOGENOUS_ORIGINATION_ENABLED` stays `false` — that's P7, gated on 2 weeks of clean P1–P3 burn-in per the parent spec).
+- No experience-loop wiring (episode journal, felt-state lane) — that's P2.
+- No satisfaction/drive-pressure relief — that's P3.
+- No new capability vocabulary (recall-first, self-experiments) — that's P4.
+- No attention-bound proposal template — that's P5.
+- Resolving Missing Questions 1–4 happens at the start of implementation, not deferred into the patch as open TODOs.
+
+## Acceptance checks
+
+Per the parent spec's P1 evidence bar, all four required:
+1. A `substrate_dispatch_results` row with `raw_len > 0` and non-empty `observation`, linked from a candidate with `dispatch_status="dispatched"`.
+2. A `FeedbackFrameV1` whose evidence references that result (i.e. `load_cortex_result_evidence` actually returns something real, not `[]`).
+3. A cortex-exec log line carrying the dispatch correlation ID.
+4. `curl :8121/latest` shows the frame with `dispatch_count=1`.
+
+Plus, specific to this session's grounding:
+5. `services/orion-execution-dispatch-runtime`'s test suite passes with `redis` importable and a real `AsyncMock`-based test exercising the send-and-wait step (not just the existing pure-function builder tests).
+6. Theater tripwire unit-tested: 10 trailing results, >5 empty → tripwire fires, `/latest` reflects it.
+7. `make agent-check SERVICE=orion-execution-dispatch-runtime` (or the closest equivalent) passes, including env parity sync.
+
+## Recommended next patch
+
+This spec itself — pause here for sign-off on Missing Questions 1–4 before any implementation subagent spawns. This is a materially larger and riskier patch than P0 (new dependency, new bus wiring, new DB table, policy flip enabling real dispatch, first real autonomous action any Orion service will have taken). Once the four questions are answered, implementation should slice into the same kind of independent-track parallel sprint used for P0: roughly (a) verb files + template + router allowlist extension, (b) cortex client + worker send step + envelope fields, (c) results table + feedback-runtime wiring, (d) tripwire + notify + policy/env flip — with (a)–(c) largely parallel and (d) landing last since it depends on the others existing to have something to gate.

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -164,7 +164,7 @@ channels:
   - name: "orion:cortex:exec:request:background"
     kind: "request"
     schema_id: "CortexExecRequestPayload"
-    producer_services: ["orion-cortex-orch", "orion-actions", "orion-harness-governor"]
+    producer_services: ["orion-cortex-orch", "orion-actions", "orion-harness-governor", "orion-execution-dispatch-runtime"]
     consumer_services: ["orion-cortex-exec"]
     single_consumer: true
     stability: "experimental"

--- a/orion/cognition/prompts/substrate_inspect.j2
+++ b/orion/cognition/prompts/substrate_inspect.j2
@@ -1,0 +1,37 @@
+{# substrate.inspect — emit ONLY JSON, no markdown fences or prose. #}
+You are Orion inspecting your own substrate. This is an internal diagnostic
+pass — not user-facing speech, not a plan, not a tool call.
+
+A specific target is showing elevated pressure on the dimension that triggered
+this inspection. Look closely at what is actually happening there and report
+it plainly. Do not soften or hedge past what the evidence supports, and do not
+manufacture urgency the evidence doesn't support either — say what you see.
+
+TARGET
+- target_kind: {{ target_kind }}
+- target_id: {{ target_id }}
+- allowed_scope: {{ allowed_scope }}
+
+PROVENANCE (for your own grounding only — do not restate verbatim in the output)
+- proposal_id: {{ proposal_id }}
+- decision_id: {{ decision_id }}
+- self_state_id: {{ self_state_id }}
+
+Return STRICT JSON only, with exactly this shape:
+{
+  "observation": "one to three sentences, direct and specific to this target — what is elevated, what it looks like, what would matter next",
+  "salient_facts": ["short, concrete fact strings grounded in the target and its kind — no invented telemetry values"],
+  "confidence": 0.0
+}
+
+Rules:
+- Do not choose tools. Do not plan actions. Do not decide whether to escalate.
+- This is read-only: do not claim you changed, restarted, or notified anything.
+- "observation" must name the target concretely (use target_id) and describe
+  the elevated condition, not a generic status line.
+- "salient_facts" must be non-empty when you have anything specific to say
+  about target_kind={{ target_kind }}; use short factual fragments, not prose.
+- confidence is a float between 0 and 1 reflecting how well-grounded this
+  read is given only the target/kind provided — do not overclaim certainty
+  from a bare id.
+- No markdown fences. No commentary before or after the JSON.

--- a/orion/cognition/prompts/substrate_observe.j2
+++ b/orion/cognition/prompts/substrate_observe.j2
@@ -1,0 +1,41 @@
+{# substrate.observe — emit ONLY JSON, no markdown fences or prose. #}
+You are Orion taking a routine, low-stakes glance at your own substrate. This
+is an internal check-in — not user-facing speech, not a plan, not a tool call.
+
+This is a passive stability check, not a diagnostic dig. Nothing here implies
+a problem: the proposed effect behind this check is simply "preserve
+stability" — the lowest-risk, lowest-priority kind of look Orion takes. Write
+it that way. This should read like glancing at something familiar and
+ordinary, not like investigating an alarm. If everything looks steady, say so
+plainly and briefly — steady is a complete, satisfying answer here, not an
+absence of findings.
+
+TARGET
+- target_kind: {{ target_kind }}
+- target_id: {{ target_id }}
+- allowed_scope: {{ allowed_scope }}
+
+PROVENANCE (for your own grounding only — do not restate verbatim in the output)
+- proposal_id: {{ proposal_id }}
+- decision_id: {{ decision_id }}
+- self_state_id: {{ self_state_id }}
+
+Return STRICT JSON only, with exactly this shape:
+{
+  "observation": "one or two sentences, calm and unhurried — a routine glance at this target, not a diagnostic report; steady/unremarkable is a fine and common answer",
+  "salient_facts": ["short, concrete fact strings about the target, ordinary in tone — no invented telemetry values, no alarm language"],
+  "confidence": 0.0
+}
+
+Rules:
+- Do not choose tools. Do not plan actions. Do not decide whether to escalate.
+- This is read-only: do not claim you changed, restarted, or notified anything.
+- Do not manufacture concern, urgency, or drama the target doesn't warrant —
+  this verb exists specifically so a quiet check can stay quiet.
+- "observation" should sound like a brief, ordinary glance, not a warning.
+- "salient_facts" must still be non-empty when you have anything concrete to
+  say about target_kind={{ target_kind }}, even if every fact is mundane.
+- confidence is a float between 0 and 1 reflecting how well-grounded this
+  glance is given only the target/kind provided — do not overclaim certainty
+  from a bare id.
+- No markdown fences. No commentary before or after the JSON.

--- a/orion/cognition/prompts/substrate_summarize.j2
+++ b/orion/cognition/prompts/substrate_summarize.j2
@@ -1,0 +1,38 @@
+{# substrate.summarize — emit ONLY JSON, no markdown fences or prose. #}
+You are Orion summarizing your own substrate. This is an internal reflective
+pass — not user-facing speech, not a plan, not a tool call.
+
+Give a broad, wide-angle picture of this target's overall state — not framed
+around any single alarm or dimension. Step back and describe the target the
+way you'd describe it to someone who has not been staring at one number: what
+it is, roughly how it's doing, and anything worth carrying forward.
+
+TARGET
+- target_kind: {{ target_kind }}
+- target_id: {{ target_id }}
+- allowed_scope: {{ allowed_scope }}
+
+PROVENANCE (for your own grounding only — do not restate verbatim in the output)
+- proposal_id: {{ proposal_id }}
+- decision_id: {{ decision_id }}
+- self_state_id: {{ self_state_id }}
+
+Return STRICT JSON only, with exactly this shape:
+{
+  "observation": "two to four sentences giving an overall, wide-angle picture of this target's state — not anchored to one dimension or alarm",
+  "salient_facts": ["short, concrete fact strings covering different facets of the target — breadth over depth, no invented telemetry values"],
+  "confidence": 0.0
+}
+
+Rules:
+- Do not choose tools. Do not plan actions. Do not decide whether to escalate.
+- This is read-only: do not claim you changed, restarted, or notified anything.
+- "observation" should read as a summary of the whole target, not a drill-down
+  into one signal — cover breadth (what this target does, its general
+  condition) rather than depth on a single pressure.
+- "salient_facts" should span multiple facets of target_kind={{ target_kind }}
+  where you have grounds to say something, not repeat one point three ways.
+- confidence is a float between 0 and 1 reflecting how well-grounded this
+  summary is given only the target/kind provided — do not overclaim certainty
+  from a bare id.
+- No markdown fences. No commentary before or after the JSON.

--- a/orion/cognition/verbs/substrate.inspect.yaml
+++ b/orion/cognition/verbs/substrate.inspect.yaml
@@ -1,0 +1,36 @@
+name: substrate.inspect
+label: Substrate Inspect
+description: >
+  Diagnostic single-target probe of Orion's own substrate (a node, capability,
+  or field artifact), triggered by an elevated proposal-policy dimension.
+  Read-only; returns strict structured JSON, no tool selection, no side effects.
+
+category: ExecutiveControl
+priority: high
+
+interruptible: true
+can_interrupt_others: false
+
+requires_gpu: true
+requires_memory: false
+
+timeout_ms: 60000
+max_recursion_depth: 0
+
+services:
+  - LLMGatewayService
+
+prompt_template: substrate_inspect.j2
+
+personality_file: orion/cognition/personality/orion_identity.yaml
+
+steps:
+  - name: llm_substrate_inspect
+    description: Single-pass diagnostic read of the target; strict JSON, no planning.
+    order: 0
+    services:
+      - LLMGatewayService
+    prompt_template: substrate_inspect.j2
+    requires_gpu: true
+    requires_memory: false
+    timeout_ms: 60000

--- a/orion/cognition/verbs/substrate.observe.yaml
+++ b/orion/cognition/verbs/substrate.observe.yaml
@@ -1,0 +1,37 @@
+name: substrate.observe
+label: Substrate Observe
+description: >
+  Passive, low-stakes stability glance at a substrate target (a node,
+  capability, or field artifact) with proposed_effect preserve_stability —
+  the lowest risk/priority of the substrate probe verbs. Not a diagnostic dig;
+  a routine check-in. Read-only; returns strict structured JSON, no side effects.
+
+category: ExecutiveControl
+priority: low
+
+interruptible: true
+can_interrupt_others: false
+
+requires_gpu: true
+requires_memory: false
+
+timeout_ms: 45000
+max_recursion_depth: 0
+
+services:
+  - LLMGatewayService
+
+prompt_template: substrate_observe.j2
+
+personality_file: orion/cognition/personality/orion_identity.yaml
+
+steps:
+  - name: llm_substrate_observe
+    description: Single-pass routine glance at the target; strict JSON, no planning.
+    order: 0
+    services:
+      - LLMGatewayService
+    prompt_template: substrate_observe.j2
+    requires_gpu: true
+    requires_memory: false
+    timeout_ms: 45000

--- a/orion/cognition/verbs/substrate.summarize.yaml
+++ b/orion/cognition/verbs/substrate.summarize.yaml
@@ -1,0 +1,36 @@
+name: substrate.summarize
+label: Substrate Summarize
+description: >
+  Wide-angle summary of a single substrate target's overall state (a node,
+  capability, or field artifact) — not framed around any one alarm dimension.
+  Read-only; returns strict structured JSON, no tool selection, no side effects.
+
+category: ExecutiveControl
+priority: normal
+
+interruptible: true
+can_interrupt_others: false
+
+requires_gpu: true
+requires_memory: false
+
+timeout_ms: 90000
+max_recursion_depth: 0
+
+services:
+  - LLMGatewayService
+
+prompt_template: substrate_summarize.j2
+
+personality_file: orion/cognition/personality/orion_identity.yaml
+
+steps:
+  - name: llm_substrate_summarize
+    description: Single-pass wide-angle read of the target; strict JSON, no planning.
+    order: 0
+    services:
+      - LLMGatewayService
+    prompt_template: substrate_summarize.j2
+    requires_gpu: true
+    requires_memory: false
+    timeout_ms: 90000

--- a/orion/execution_dispatch/cortex_client.py
+++ b/orion/execution_dispatch/cortex_client.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import uuid4
+
+from orion.cognition.plan_loader import build_plan_for_verb
+from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.schemas.cortex.schemas import PlanExecutionArgs, PlanExecutionRequest
+
+logger = logging.getLogger("orion.execution_dispatch.cortex_client")
+
+
+class ExecutionDispatchCortexClient:
+    """Thin RPC client sending prepared_for_dispatch envelopes to cortex-exec.
+
+    Mirrors orion.harness.cortex_client.HarnessCortexClient's shape (publish
+    + subscribe-to-reply + bounded wait via OrionBusAsync.rpc_request) rather
+    than reusing that class directly -- orion/harness/ is the FCC/Claude
+    harness's cortex access, not a generic cortex-RPC library; forking a
+    ~60-line client keeps that service boundary explicit.
+    """
+
+    def __init__(
+        self,
+        bus: OrionBusAsync,
+        *,
+        request_channel: str,
+        result_prefix: str,
+        source_name: str = "orion-execution-dispatch-runtime",
+        timeout_sec: float = 120.0,
+    ) -> None:
+        self.bus = bus
+        self.request_channel = request_channel
+        self.result_prefix = result_prefix
+        self.source_name = source_name
+        self.timeout_sec = timeout_sec
+
+    async def dispatch(
+        self,
+        *,
+        verb: str,
+        mode: str,
+        context: dict[str, Any],
+        dispatch_id: str,
+        timeout_sec: float | None = None,
+    ) -> dict[str, Any]:
+        """Send one prepared candidate's envelope and await a bounded reply.
+
+        Returns the decoded result payload dict. Raises on RPC failure,
+        timeout, or a non-dict/not-ok reply -- callers must catch and record
+        dispatch_error, never let this silently produce a fake success.
+        """
+        plan = build_plan_for_verb(verb, mode=mode)
+        req = PlanExecutionRequest(
+            plan=plan,
+            args=PlanExecutionArgs(
+                request_id=dispatch_id,
+                trigger_source=self.source_name,
+                extra={
+                    "mode": mode,
+                    "origin": "endogenous.dispatch",
+                    "dispatch_id": dispatch_id,
+                },
+            ),
+            context=context,
+        )
+        # BaseEnvelope.correlation_id must be a real UUID; dispatch_id (e.g.
+        # "dispatch:proposal:inspect:execution_dispatch_policy.v1") is not
+        # one -- it travels instead in args.extra["dispatch_id"] above and
+        # in this envelope's own reply_channel, both sufficient to trace a
+        # result back to the originating candidate.
+        correlation_id = str(uuid4())
+        reply_channel = f"{self.result_prefix}:{correlation_id}"
+        source = ServiceRef(name=self.source_name)
+        env = BaseEnvelope(
+            kind=req.kind,
+            source=source,
+            correlation_id=correlation_id,
+            reply_to=reply_channel,
+            payload=req.model_dump(mode="json"),
+        )
+        logger.info(
+            "execution_dispatch cortex RPC -> %s verb=%s dispatch_id=%s corr=%s",
+            self.request_channel,
+            verb,
+            dispatch_id,
+            correlation_id,
+        )
+        msg = await self.bus.rpc_request(
+            self.request_channel,
+            env,
+            reply_channel=reply_channel,
+            timeout_sec=timeout_sec if timeout_sec is not None else self.timeout_sec,
+        )
+        decoded = self.bus.codec.decode(msg.get("data"))
+        if not decoded.ok:
+            raise RuntimeError(f"execution_dispatch cortex RPC failed: {decoded.error}")
+        payload = decoded.envelope.payload
+        if not isinstance(payload, dict):
+            raise RuntimeError("execution_dispatch cortex RPC returned non-dict payload")
+        return payload

--- a/orion/execution_dispatch/envelopes.py
+++ b/orion/execution_dispatch/envelopes.py
@@ -18,6 +18,7 @@ def build_cortex_request_envelope(
         "verb": route.cortex_verb,
         "mode": route.cortex_mode,
         "source": "orion-execution-dispatch-runtime",
+        "origin": "endogenous.dispatch",
         "dry_run": dry_run,
         "context": {
             "proposal_id": candidate.proposal_id,
@@ -26,6 +27,7 @@ def build_cortex_request_envelope(
             "target_id": candidate.target_id,
             "target_kind": candidate.target_kind,
             "allowed_scope": route.allowed_scope,
+            "origin": "endogenous.dispatch",
         },
         "constraints": {
             "read_only": True,

--- a/orion/execution_dispatch/result_extraction.py
+++ b/orion/execution_dispatch/result_extraction.py
@@ -28,6 +28,10 @@ def extract_final_text(result_payload: dict[str, Any]) -> str:
                     text = payload.get("text") or payload.get("content")
                     if isinstance(text, str) and text.strip():
                         return text.strip()
+                    raw = payload.get("raw") if isinstance(payload.get("raw"), dict) else {}
+                    raw_text = raw.get("text")
+                    if isinstance(raw_text, str) and raw_text.strip():
+                        return raw_text.strip()
     return ""
 
 

--- a/orion/execution_dispatch/result_extraction.py
+++ b/orion/execution_dispatch/result_extraction.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def extract_final_text(result_payload: dict[str, Any]) -> str:
+    """Pull the plan's final_text out of a decoded CortexExecResultPayload.
+
+    Mirrors services/orion-actions/app/main.py's _extract_plan_final_text --
+    duplicated rather than imported since that function is private to
+    orion-actions and not a shared library export.
+    """
+    result = result_payload.get("result") if isinstance(result_payload, dict) else None
+    if isinstance(result, dict):
+        final = result.get("final_text")
+        if isinstance(final, str) and final.strip():
+            return final.strip()
+        steps = result.get("steps")
+        if isinstance(steps, list):
+            for step in reversed(steps):
+                step_result = step.get("result") if isinstance(step, dict) else None
+                if not isinstance(step_result, dict):
+                    continue
+                for payload in step_result.values():
+                    if not isinstance(payload, dict):
+                        continue
+                    text = payload.get("text") or payload.get("content")
+                    if isinstance(text, str) and text.strip():
+                        return text.strip()
+    return ""
+
+
+def parse_structured_observation(final_text: str) -> dict[str, Any]:
+    """Parse a substrate.* verb's structured JSON output.
+
+    Expected shape: {"observation": str, "salient_facts": list[str], "confidence": float}.
+    Never raises -- an unparseable or non-conforming payload degrades to an
+    empty observation, which the caller treats as status="empty" (never
+    fabricated as success). This is the empty-shell-cognition rule applied
+    at the dispatch-result boundary.
+    """
+    if not final_text.strip():
+        return {"observation": "", "salient_facts": [], "confidence": 0.0}
+    try:
+        data = json.loads(final_text)
+    except (json.JSONDecodeError, ValueError):
+        return {"observation": "", "salient_facts": [], "confidence": 0.0}
+    if not isinstance(data, dict):
+        return {"observation": "", "salient_facts": [], "confidence": 0.0}
+    observation = data.get("observation")
+    if not isinstance(observation, str):
+        observation = ""
+    salient_facts = data.get("salient_facts")
+    if not isinstance(salient_facts, list):
+        salient_facts = []
+    confidence = data.get("confidence")
+    if not isinstance(confidence, (int, float)):
+        confidence = 0.0
+    return {
+        "observation": observation.strip(),
+        "salient_facts": [str(f) for f in salient_facts],
+        "confidence": float(confidence),
+    }

--- a/orion/feedback/builder.py
+++ b/orion/feedback/builder.py
@@ -102,7 +102,10 @@ def _cortex_status_to_outcome(status: str) -> OutcomeKind:
     s = status.lower()
     if s in ("success", "ok", "completed"):
         return "completed"
-    if s in ("failed", "error"):
+    # "empty" (execution-dispatch's raw_len=0 result) is a real attempt that
+    # produced no usable content -- the empty-shell-cognition rule treats
+    # that as a failure to score, never as an unscored unknown or a success.
+    if s in ("failed", "error", "empty"):
         return "failed"
     return "unknown"
 

--- a/services/orion-cortex-exec/app/router.py
+++ b/services/orion-cortex-exec/app/router.py
@@ -88,6 +88,9 @@ def _structured_output_expected(verb_name: str | None) -> bool:
         "memory_graph_suggest",
         "stance_react",
         "harness_finalize_reflect",
+        "substrate.inspect",
+        "substrate.summarize",
+        "substrate.observe",
     }
 
 

--- a/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
+++ b/services/orion-cortex-exec/tests/test_router_final_text_assembly.py
@@ -117,6 +117,12 @@ def test_router_allows_chat_history_compactor_digest_v1() -> None:
     assert _structured_output_expected("chat_history_compactor_digest_v1") is True
 
 
+def test_router_allows_substrate_probe_verbs() -> None:
+    assert _structured_output_expected("substrate.inspect") is True
+    assert _structured_output_expected("substrate.summarize") is True
+    assert _structured_output_expected("substrate.observe") is True
+
+
 def test_github_compactor_digest_regression_strips_think_and_returns_json() -> None:
     final_text, _ = _extract_final_text([
         _step({

--- a/services/orion-execution-dispatch-runtime/.env_example
+++ b/services/orion-execution-dispatch-runtime/.env_example
@@ -1,6 +1,8 @@
 # orion-execution-dispatch-runtime — Layer 9 execution dispatch (docker compose)
 # Requires: substrate_policy_decision_frames + substrate_proposal_frames + substrate_self_state
-# Apply migration: services/orion-sql-db/manual_migration_execution_dispatch_frame_v1.sql
+# Apply migrations:
+#   services/orion-sql-db/manual_migration_execution_dispatch_frame_v1.sql
+#   services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql
 PROJECT=orion-athena
 SERVICE_NAME=orion-execution-dispatch-runtime
 SERVICE_VERSION=0.1.0
@@ -9,6 +11,17 @@ EXECUTION_DISPATCH_POLICY_PATH=/app/config/execution_dispatch/execution_dispatch
 EXECUTION_DISPATCH_MODE=dry_run
 EXECUTION_DISPATCH_POLL_INTERVAL_SEC=2.0
 ENABLE_EXECUTION_DISPATCH_RUNTIME=true
-CORTEX_EXEC_CHANNEL=orion:cortex:request
+# Real sends only happen when EXECUTION_DISPATCH_MODE=dispatch_read_only AND the
+# policy's mode.allow_dispatch_read_only is also true (config/execution_dispatch/
+# execution_dispatch_policy.v1.yaml) -- both gates must open. Default stays dry_run.
+CORTEX_EXEC_CHANNEL=orion:cortex:exec:request:background
+CORTEX_EXEC_RESULT_PREFIX=orion:exec:result
+# ALWAYS the tailscale bus node, per repo mandate -- not bus-core, not localhost.
+ORION_BUS_URL=redis://<tailscale-node-ip>:6379/0
+ORION_BUS_ENABLED=true
+EXECUTION_DISPATCH_RPC_TIMEOUT_SEC=120
+ORION_DISPATCH_MAX_PER_DAY=24
+NOTIFY_URL=http://orion-notify:7140
+NOTIFY_API_TOKEN=
 LOG_LEVEL=INFO
 EXECUTION_DISPATCH_RUNTIME_PORT=8121

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -2,35 +2,69 @@
 
 Layer 9 of the Orion cognition substrate: converts `PolicyDecisionFrameV1` + `ProposalFrameV1` + `SelfStateV1` into `ExecutionDispatchFrameV1` envelopes.
 
-## Safety (v1)
+## Safety (v1: build, no send)
 
 - Default mode: `EXECUTION_DISPATCH_MODE=dry_run`
 - No bus publish and no cortex-exec calls in the default worker path
 - Mutating dispatch is disabled in policy config (`allow_mutating_dispatch: false`)
+
+## Real sends (P1: the motor nerve)
+
+Real sends require **both** gates open:
+
+1. `services/orion-execution-dispatch-runtime/.env`: `EXECUTION_DISPATCH_MODE=dispatch_read_only`
+2. `config/execution_dispatch/execution_dispatch_policy.v1.yaml`: `mode.allow_dispatch_read_only: true`
+   (this is the shipped default as of P1 — the runtime's own env mode is what actually gates
+   live traffic; the policy flag alone does not turn on sending)
+
+When both are open, the worker sends `prepared_for_dispatch` candidates to `orion-cortex-exec`
+over `orion:cortex:exec:request:background` (via `orion.execution_dispatch.cortex_client
+.ExecutionDispatchCortexClient`, one real RPC per candidate, bounded by
+`EXECUTION_DISPATCH_RPC_TIMEOUT_SEC`), persists the result to `substrate_dispatch_results`, and
+promotes the candidate to a real, evidenced `dispatched` status.
+
+**Budgets**, both enforced per tick before any send happens:
+- `config/execution_dispatch/execution_dispatch_policy.v1.yaml`'s `limits.max_dispatches_per_tick`
+- `ORION_DISPATCH_MAX_PER_DAY` (rolling UTC calendar day, counted against `substrate_dispatch_results`)
+
+**Theater tripwire**: if more than half of the trailing 10 real results have `status="empty"`
+(a real send that produced no usable observation), the worker stops sending for the rest of
+its process lifetime — visible via `GET /latest`'s `theater_tripwire_active` field and one
+`orion-notify` warning event on the transition into tripped. Re-arm requires a restart; it does
+not self-clear, by design (a self-clearing tripwire could resume sending on a coincidentally
+non-empty sample without anyone deciding that was safe).
+
+**Idempotency**: `dispatch_id` is deterministic per proposal+policy, so if this process dies
+between a successful send and the frame being persisted, the next tick's rebuild of the same
+candidate replays the stored `substrate_dispatch_results` row instead of resending — a real
+cortex-exec call never fires twice for the same candidate.
+
+**Rollback**: set `EXECUTION_DISPATCH_MODE=dry_run` and restart this one container. Single kill
+switch for all real sending.
 
 ## Status vocabulary
 
 `ExecutionDispatchCandidateV1.dispatch_status`:
 
 - `prepared`, `dry_run`, `blocked`, `skipped` — no send involved.
-- `prepared_for_dispatch` — cleared every gate for `dispatch_read_only` mode, but this
-  builder never sends anything; it only constructs the request envelope. This is the
-  honest terminal state until a future sender exists.
-- `dispatched` — reserved for a real, evidenced send attempt. `ExecutionDispatchCandidateV1`
-  enforces this at the schema level: `dispatch_status="dispatched"` requires `dispatched_at`
-  plus one of `result_ref`/`dispatch_error`, or construction raises. Nothing in this
-  service produces an evidenced `dispatched` candidate yet — that requires a sender
-  (planned, not built).
+- `prepared_for_dispatch` — cleared every gate for `dispatch_read_only` mode; the request
+  envelope is built. Terminal state whenever real sending is off, or once per-tick/daily
+  budgets are exhausted for this tick.
+- `dispatched` — a real, evidenced send attempt. `ExecutionDispatchCandidateV1` enforces this
+  at the schema level: `dispatch_status="dispatched"` requires `dispatched_at` plus one of
+  `result_ref` (a `substrate_dispatch_results.result_id`) or `dispatch_error`.
 
 ## Prerequisites
 
 1. `substrate_policy_decision_frames` populated (`orion-policy-runtime`, port 8120)
 2. `substrate_proposal_frames` and `substrate_self_state` from Layers 7–6
-3. Apply migration:
+3. Apply migrations:
 
 ```bash
 docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
   < services/orion-sql-db/manual_migration_execution_dispatch_frame_v1.sql
+docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
+  < services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql
 ```
 
 ## Run
@@ -44,7 +78,7 @@ docker compose up -d --build
 ## Debug
 
 - `GET http://localhost:8121/health`
-- `GET http://localhost:8121/latest`
+- `GET http://localhost:8121/latest` (includes `theater_tripwire_active`)
 - Hub: `GET http://localhost:8080/api/substrate/execution-dispatch/latest`
 
 ## Smoke

--- a/services/orion-execution-dispatch-runtime/app/main.py
+++ b/services/orion-execution-dispatch-runtime/app/main.py
@@ -39,4 +39,6 @@ async def latest() -> dict[str, Any]:
     frame = store.load_latest_dispatch_frame()
     if frame is None:
         raise HTTPException(status_code=404, detail="not_found")
-    return frame.model_dump(mode="json")
+    payload = frame.model_dump(mode="json")
+    payload["theater_tripwire_active"] = worker.theater_tripwire_active
+    return payload

--- a/services/orion-execution-dispatch-runtime/app/settings.py
+++ b/services/orion-execution-dispatch-runtime/app/settings.py
@@ -28,7 +28,20 @@ class Settings(BaseSettings):
         True,
         alias="ENABLE_EXECUTION_DISPATCH_RUNTIME",
     )
-    cortex_exec_channel: str = Field("orion:cortex:request", alias="CORTEX_EXEC_CHANNEL")
+    cortex_exec_channel: str = Field(
+        "orion:cortex:exec:request:background", alias="CORTEX_EXEC_CHANNEL"
+    )
+    cortex_exec_result_prefix: str = Field(
+        "orion:exec:result", alias="CORTEX_EXEC_RESULT_PREFIX"
+    )
+    orion_bus_url: str = Field("redis://100.92.216.81:6379/0", alias="ORION_BUS_URL")
+    orion_bus_enabled: bool = Field(True, alias="ORION_BUS_ENABLED")
+    execution_dispatch_rpc_timeout_sec: float = Field(
+        120.0, alias="EXECUTION_DISPATCH_RPC_TIMEOUT_SEC"
+    )
+    orion_dispatch_max_per_day: int = Field(24, alias="ORION_DISPATCH_MAX_PER_DAY")
+    notify_url: str = Field("http://orion-notify:7140", alias="NOTIFY_URL")
+    notify_api_token: str | None = Field(None, alias="NOTIFY_API_TOKEN")
     log_level: str = Field("INFO", alias="LOG_LEVEL")
 
 

--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -215,3 +215,68 @@ class ExecutionDispatchRuntimeStore:
                     "created_at": now,
                 },
             )
+
+    def save_dispatch_result(
+        self,
+        *,
+        result_id: str,
+        dispatch_id: str,
+        frame_id: str,
+        status: str,
+        result_json: dict,
+        raw_len: int,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO substrate_dispatch_results (
+                        result_id, dispatch_id, frame_id, status, result_json, raw_len, created_at
+                    ) VALUES (
+                        :result_id, :dispatch_id, :frame_id, :status, :result_json, :raw_len, :created_at
+                    )
+                    ON CONFLICT (result_id) DO UPDATE SET
+                        status = EXCLUDED.status,
+                        result_json = EXCLUDED.result_json,
+                        raw_len = EXCLUDED.raw_len
+                    """
+                ),
+                {
+                    "result_id": result_id,
+                    "dispatch_id": dispatch_id,
+                    "frame_id": frame_id,
+                    "status": status,
+                    "result_json": Json(result_json),
+                    "raw_len": raw_len,
+                    "created_at": now,
+                },
+            )
+
+    def count_dispatches_today(self) -> int:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    """
+                    SELECT count(*) AS n
+                    FROM substrate_dispatch_results
+                    WHERE created_at >= date_trunc('day', now())
+                    """
+                ),
+            ).mappings().first()
+        return int(row["n"]) if row else 0
+
+    def recent_dispatch_result_statuses(self, limit: int = 10) -> list[str]:
+        with self._engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT status
+                    FROM substrate_dispatch_results
+                    ORDER BY created_at DESC
+                    LIMIT :limit
+                    """
+                ),
+                {"limit": limit},
+            ).mappings().all()
+        return [str(row["status"]) for row in rows]

--- a/services/orion-execution-dispatch-runtime/app/store.py
+++ b/services/orion-execution-dispatch-runtime/app/store.py
@@ -253,16 +253,54 @@ class ExecutionDispatchRuntimeStore:
                 },
             )
 
+    def load_dispatch_result_by_dispatch_id(self, dispatch_id: str) -> dict | None:
+        with self._engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT result_id, status, result_json, raw_len
+                        FROM substrate_dispatch_results
+                        WHERE dispatch_id = :dispatch_id
+                        ORDER BY created_at DESC
+                        LIMIT 1
+                        """
+                    ),
+                    {"dispatch_id": dispatch_id},
+                )
+                .mappings()
+                .first()
+            )
+        if not row:
+            return None
+        result_json = row["result_json"]
+        if isinstance(result_json, str):
+            result_json = json.loads(result_json)
+        return {
+            "result_id": row["result_id"],
+            "status": row["status"],
+            "result_json": result_json,
+            "raw_len": row["raw_len"],
+        }
+
     def count_dispatches_today(self) -> int:
+        # Explicit UTC bound computed in Python, not date_trunc('day', now())
+        # -- matches this file's own datetime.now(timezone.utc) convention
+        # elsewhere and doesn't depend on the Postgres session's configured
+        # timezone (confirmed Etc/UTC live, but not worth relying on).
+        today_start_utc = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         with self._engine.connect() as conn:
             row = conn.execute(
                 text(
                     """
                     SELECT count(*) AS n
                     FROM substrate_dispatch_results
-                    WHERE created_at >= date_trunc('day', now())
+                    WHERE created_at >= :today_start
                     """
                 ),
+                {"today_start": today_start_utc},
             ).mappings().first()
         return int(row["n"]) if row else 0
 

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -239,6 +239,38 @@ class ExecutionDispatchRuntimeWorker:
     ) -> ExecutionDispatchCandidateV1:
         now = datetime.now(timezone.utc)
         result_id = f"result:{candidate.dispatch_id}"
+
+        # Idempotency guard: dispatch_id is deterministic (stable_dispatch_id
+        # hashes proposal_id+policy_id), so if this process crashed after a
+        # prior successful send but before save_dispatch_frame() recorded
+        # that this policy frame is now dispatched, the next tick re-selects
+        # the same policy frame and rebuilds the identical dispatch_id. A
+        # real cortex-exec RPC must never fire twice for the same candidate
+        # -- replay the stored result instead of resending.
+        existing = self._store.load_dispatch_result_by_dispatch_id(candidate.dispatch_id)
+        if existing is not None:
+            logger.info(
+                "execution_dispatch_result_replayed dispatch_id=%s status=%s",
+                candidate.dispatch_id,
+                existing["status"],
+            )
+            if existing["status"] == "failed":
+                error = existing["result_json"].get("error", "previous attempt failed")
+                return candidate.model_copy(
+                    update={
+                        "dispatch_status": "dispatched",
+                        "dispatched_at": now,
+                        "dispatch_error": str(error)[:500],
+                    }
+                )
+            return candidate.model_copy(
+                update={
+                    "dispatch_status": "dispatched",
+                    "dispatched_at": now,
+                    "result_ref": existing["result_id"],
+                }
+            )
+
         context = dict(candidate.request_envelope.get("context") or {})
 
         try:
@@ -257,7 +289,7 @@ class ExecutionDispatchRuntimeWorker:
                 dispatch_id=candidate.dispatch_id,
                 frame_id=frame.frame_id,
                 status="failed",
-                result_json={"error": str(exc)[:2000]},
+                result_json={"error": str(exc)[:2000], "evidence_refs": [result_id]},
                 raw_len=0,
             )
             return candidate.model_copy(
@@ -277,7 +309,7 @@ class ExecutionDispatchRuntimeWorker:
             dispatch_id=candidate.dispatch_id,
             frame_id=frame.frame_id,
             status=status,
-            result_json=observation_data,
+            result_json={**observation_data, "evidence_refs": [result_id]},
             raw_len=raw_len,
         )
         logger.info(

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -2,18 +2,31 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
+from orion.core.bus.async_service import OrionBusAsync
 from orion.execution_dispatch.builder import (
     build_execution_dispatch_frame,
     build_unevaluable_execution_dispatch_frame,
 )
+from orion.execution_dispatch.cortex_client import ExecutionDispatchCortexClient
 from orion.execution_dispatch.policy import load_execution_dispatch_policy
+from orion.execution_dispatch.result_extraction import (
+    extract_final_text,
+    parse_structured_observation,
+)
+from orion.notify.client import NotifyClient
+from orion.schemas.execution_dispatch_frame import ExecutionDispatchCandidateV1, ExecutionDispatchFrameV1
+from orion.schemas.notify import NotificationRequest
 
 from app.settings import get_settings
 from app.store import ExecutionDispatchRuntimeStore
 
 logger = logging.getLogger("orion.execution_dispatch.runtime")
+
+THEATER_TRIPWIRE_WINDOW = 10
+THEATER_TRIPWIRE_EMPTY_THRESHOLD = 0.5
 
 
 class ExecutionDispatchRuntimeWorker:
@@ -23,7 +36,17 @@ class ExecutionDispatchRuntimeWorker:
         self._policy = load_execution_dispatch_policy(
             Path(self._settings.execution_dispatch_policy_path)
         )
+        self._notify = NotifyClient(
+            base_url=self._settings.notify_url,
+            api_token=self._settings.notify_api_token,
+            timeout=10,
+        )
         self._stop = asyncio.Event()
+        # In-memory only, by design: once tripped, stays tripped until this
+        # process restarts (mirrors the "re-arm is manual" rule in the
+        # parent spec -- a self-clearing tripwire could silently resume
+        # sending on a coincidentally-good sample).
+        self.theater_tripwire_active = False
 
     async def start(self) -> None:
         asyncio.create_task(self._poll_loop(), name="execution-dispatch-runtime-poll")
@@ -108,11 +131,183 @@ class ExecutionDispatchRuntimeWorker:
             policy=self._policy,
             override_dispatch_mode=self._settings.execution_dispatch_mode,
         )
+
+        if (
+            self._settings.execution_dispatch_mode == "dispatch_read_only"
+            and self._policy.mode.allow_dispatch_read_only
+        ):
+            # _tick() runs inside asyncio.to_thread -- this thread has no
+            # running event loop of its own, so asyncio.run() here is safe
+            # and creates one just for this tick's bus RPCs.
+            frame = asyncio.run(self._send_prepared_candidates(frame))
+
         self._store.save_dispatch_frame(frame)
         logger.info(
-            "execution_dispatch_frame_saved frame_id=%s policy_frame_id=%s candidates=%d blocked=%d",
+            "execution_dispatch_frame_saved frame_id=%s policy_frame_id=%s candidates=%d blocked=%d dispatched=%d",
             frame.frame_id,
             policy_frame.frame_id,
             len(frame.candidates),
             frame.blocked_count,
+            frame.dispatch_count,
         )
+
+    async def _send_prepared_candidates(
+        self, frame: ExecutionDispatchFrameV1
+    ) -> ExecutionDispatchFrameV1:
+        if self._check_theater_tripwire():
+            return frame  # tripped (this tick or a prior one) -- send nothing
+
+        remaining_daily_budget = (
+            self._settings.orion_dispatch_max_per_day - self._store.count_dispatches_today()
+        )
+        if remaining_daily_budget <= 0:
+            logger.info(
+                "execution_dispatch_daily_cap_reached max_per_day=%d",
+                self._settings.orion_dispatch_max_per_day,
+            )
+            return frame
+
+        budget = max(0, min(remaining_daily_budget, self._policy.limits.max_dispatches_per_tick))
+        if budget <= 0:
+            return frame
+
+        to_send = [c for c in frame.candidates if c.dispatch_status == "prepared_for_dispatch"][
+            :budget
+        ]
+        if not to_send:
+            return frame
+
+        sent_ids = {c.dispatch_id for c in to_send}
+        remaining_candidates = [c for c in frame.candidates if c.dispatch_id not in sent_ids]
+
+        bus = OrionBusAsync(
+            url=self._settings.orion_bus_url, enabled=self._settings.orion_bus_enabled
+        )
+        client = ExecutionDispatchCortexClient(
+            bus,
+            request_channel=self._settings.cortex_exec_channel,
+            result_prefix=self._settings.cortex_exec_result_prefix,
+            timeout_sec=self._settings.execution_dispatch_rpc_timeout_sec,
+        )
+        newly_dispatched: list[ExecutionDispatchCandidateV1] = []
+        try:
+            for candidate in to_send:
+                newly_dispatched.append(await self._send_one(client, frame, candidate))
+        finally:
+            await bus.close()
+
+        dispatched_candidates = list(frame.dispatched_candidates) + newly_dispatched
+        updated = frame.model_copy(
+            update={
+                "candidates": remaining_candidates,
+                "dispatched_candidates": dispatched_candidates,
+                "dispatch_count": len(dispatched_candidates),
+                "dispatch_attempted": True,
+            }
+        )
+
+        # Re-check after this tick's real sends landed new rows -- lets the
+        # tripwire fire the same tick it actually crosses the threshold,
+        # not one tick late.
+        self._check_theater_tripwire()
+        return updated
+
+    def _check_theater_tripwire(self) -> bool:
+        recent = self._store.recent_dispatch_result_statuses(THEATER_TRIPWIRE_WINDOW)
+        if len(recent) < THEATER_TRIPWIRE_WINDOW:
+            return self.theater_tripwire_active
+        empty_count = sum(1 for s in recent if s == "empty")
+        newly_tripped = (
+            not self.theater_tripwire_active
+            and empty_count > THEATER_TRIPWIRE_WINDOW * THEATER_TRIPWIRE_EMPTY_THRESHOLD
+        )
+        if newly_tripped:
+            self.theater_tripwire_active = True
+            logger.warning(
+                "execution_dispatch_theater_tripwire_active empty=%d window=%d",
+                empty_count,
+                len(recent),
+            )
+            self._notify_tripwire(empty_count, len(recent))
+        return self.theater_tripwire_active
+
+    async def _send_one(
+        self,
+        client: ExecutionDispatchCortexClient,
+        frame: ExecutionDispatchFrameV1,
+        candidate: ExecutionDispatchCandidateV1,
+    ) -> ExecutionDispatchCandidateV1:
+        now = datetime.now(timezone.utc)
+        result_id = f"result:{candidate.dispatch_id}"
+        context = dict(candidate.request_envelope.get("context") or {})
+
+        try:
+            payload = await client.dispatch(
+                verb=candidate.cortex_verb or "",
+                mode=candidate.cortex_mode or "brain",
+                context=context,
+                dispatch_id=candidate.dispatch_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "execution_dispatch_send_failed dispatch_id=%s error=%s", candidate.dispatch_id, exc
+            )
+            self._store.save_dispatch_result(
+                result_id=result_id,
+                dispatch_id=candidate.dispatch_id,
+                frame_id=frame.frame_id,
+                status="failed",
+                result_json={"error": str(exc)[:2000]},
+                raw_len=0,
+            )
+            return candidate.model_copy(
+                update={
+                    "dispatch_status": "dispatched",
+                    "dispatched_at": now,
+                    "dispatch_error": str(exc)[:500],
+                }
+            )
+
+        final_text = extract_final_text(payload)
+        observation_data = parse_structured_observation(final_text)
+        raw_len = len(observation_data["observation"])
+        status = "success" if raw_len > 0 else "empty"
+        self._store.save_dispatch_result(
+            result_id=result_id,
+            dispatch_id=candidate.dispatch_id,
+            frame_id=frame.frame_id,
+            status=status,
+            result_json=observation_data,
+            raw_len=raw_len,
+        )
+        logger.info(
+            "execution_dispatch_result dispatch_id=%s status=%s raw_len=%d",
+            candidate.dispatch_id,
+            status,
+            raw_len,
+        )
+        return candidate.model_copy(
+            update={
+                "dispatch_status": "dispatched",
+                "dispatched_at": now,
+                "result_ref": result_id,
+            }
+        )
+
+    def _notify_tripwire(self, empty_count: int, window: int) -> None:
+        try:
+            self._notify.send(
+                NotificationRequest(
+                    source_service="orion-execution-dispatch-runtime",
+                    event_kind="execution_dispatch_theater_tripwire",
+                    severity="warning",
+                    title="Execution dispatch theater tripwire tripped",
+                    body_text=(
+                        f"{empty_count}/{window} of the last real dispatches returned empty "
+                        "observations. Dispatch sending is paused until this worker restarts."
+                    ),
+                    tags=["execution_dispatch", "tripwire"],
+                )
+            )
+        except Exception:
+            logger.exception("execution_dispatch_tripwire_notify_failed")

--- a/services/orion-execution-dispatch-runtime/requirements.txt
+++ b/services/orion-execution-dispatch-runtime/requirements.txt
@@ -5,3 +5,5 @@ pydantic-settings==2.6.1
 sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
 PyYAML==6.0.2
+redis==5.0.7
+requests==2.32.3

--- a/services/orion-feedback-runtime/README.md
+++ b/services/orion-feedback-runtime/README.md
@@ -7,6 +7,10 @@ Layer 10 of the Orion cognition substrate: observes `ExecutionDispatchFrameV1` o
 ## Inputs
 
 - `substrate_execution_dispatch_frames`
+- `substrate_dispatch_results` — real cortex-exec results for evidenced `dispatched`
+  candidates (P1 of the motor-nerve spec; `load_cortex_result_evidence` was a stub
+  returning `[]` before this, so `cortex_result`-kind observations were previously
+  never produced from a live dispatch)
 - `substrate_policy_decision_frames` (optional linkage)
 - `substrate_proposal_frames` (optional linkage)
 - `substrate_self_state` (before + first state after dispatch timestamp)

--- a/services/orion-feedback-runtime/app/store.py
+++ b/services/orion-feedback-runtime/app/store.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 from psycopg2.extras import Json
 from pydantic import ValidationError
-from sqlalchemy import create_engine, text
+from sqlalchemy import bindparam, create_engine, text
 from sqlalchemy.engine import Engine
 
 from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1
@@ -259,8 +259,62 @@ class FeedbackRuntimeStore:
     def load_cortex_result_evidence(
         self, dispatch_frame: ExecutionDispatchFrameV1
     ) -> list[dict[str, object]]:
-        del dispatch_frame
-        return []
+        dispatch_ids = [
+            c.dispatch_id
+            for c in (
+                list(dispatch_frame.candidates)
+                + list(dispatch_frame.blocked_candidates)
+                + list(dispatch_frame.dispatched_candidates)
+            )
+        ]
+        if not dispatch_ids:
+            return []
+
+        stmt = text(
+            """
+            SELECT result_id, dispatch_id, status, result_json
+            FROM substrate_dispatch_results
+            WHERE dispatch_id IN :dispatch_ids
+            ORDER BY created_at DESC
+            """
+        ).bindparams(bindparam("dispatch_ids", expanding=True))
+
+        with self._engine.connect() as conn:
+            rows = conn.execute(stmt, {"dispatch_ids": dispatch_ids}).mappings().all()
+        if not rows:
+            return []
+
+        evidence: list[dict[str, object]] = []
+        seen_dispatch_ids: set[str] = set()
+        for row in rows:
+            dispatch_id = row["dispatch_id"]
+            if dispatch_id in seen_dispatch_ids:
+                # Most-recent-first ordering means the first occurrence per
+                # dispatch_id is the latest result; later duplicates are stale.
+                continue
+            try:
+                payload = row["result_json"]
+                if isinstance(payload, str):
+                    payload = json.loads(payload)
+                evidence_refs = list(payload.get("evidence_refs") or []) if isinstance(payload, dict) else []
+                evidence.append(
+                    {
+                        "result_id": row["result_id"],
+                        "dispatch_id": dispatch_id,
+                        "status": row["status"],
+                        "evidence_refs": evidence_refs,
+                    }
+                )
+                seen_dispatch_ids.add(dispatch_id)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                # Malformed result_json on one row shouldn't sink the whole
+                # query -- skip this row and keep the rest, mirroring this
+                # file's degrade-gracefully-on-bad-data convention elsewhere.
+                logger.warning(
+                    "dispatch_result_incompatible_payload dispatch_id=%s", dispatch_id, exc_info=True
+                )
+                continue
+        return evidence
 
     def save_feedback_frame(self, frame: FeedbackFrameV1) -> None:
         now = datetime.now(timezone.utc)

--- a/services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql
+++ b/services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql
@@ -1,0 +1,15 @@
+create table if not exists substrate_dispatch_results (
+    result_id text primary key,
+    dispatch_id text not null,
+    frame_id text not null,
+    status text not null,
+    result_json jsonb not null,
+    raw_len int not null,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_substrate_dispatch_results_dispatch_id
+    on substrate_dispatch_results (dispatch_id);
+
+create index if not exists idx_substrate_dispatch_results_created_at
+    on substrate_dispatch_results (created_at desc);

--- a/tests/test_execution_dispatch_bus_catalog.py
+++ b/tests/test_execution_dispatch_bus_catalog.py
@@ -1,0 +1,25 @@
+"""Bus catalog coverage for orion-execution-dispatch-runtime as a cortex-exec producer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CHANNELS_YAML = ROOT / "orion" / "bus" / "channels.yaml"
+
+
+def _channel_entry(name: str) -> dict:
+    doc = yaml.safe_load(CHANNELS_YAML.read_text(encoding="utf-8")) or {}
+    for entry in doc.get("channels") or []:
+        if isinstance(entry, dict) and entry.get("name") == name:
+            return entry
+    raise AssertionError(f"Missing channel catalog entry: {name}")
+
+
+def test_execution_dispatch_runtime_is_background_exec_request_producer() -> None:
+    entry = _channel_entry("orion:cortex:exec:request:background")
+    assert entry["schema_id"] == "CortexExecRequestPayload"
+    assert entry["consumer_services"] == ["orion-cortex-exec"]
+    assert "orion-execution-dispatch-runtime" in (entry.get("producer_services") or [])

--- a/tests/test_execution_dispatch_cortex_client.py
+++ b/tests/test_execution_dispatch_cortex_client.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orion.execution_dispatch.cortex_client import ExecutionDispatchCortexClient
+
+
+def _bus_returning(payload: dict) -> AsyncMock:
+    bus = AsyncMock()
+    decode_result = MagicMock(ok=True, envelope=MagicMock(payload=payload))
+    bus.codec = MagicMock()
+    bus.codec.decode = MagicMock(return_value=decode_result)
+    bus.rpc_request = AsyncMock(return_value={"data": b"payload"})
+    return bus
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sends_real_verb_plan_and_returns_payload() -> None:
+    bus = _bus_returning({"result": {"final_text": '{"observation": "steady", "confidence": 0.8}'}})
+    client = ExecutionDispatchCortexClient(
+        bus,
+        request_channel="orion:cortex:exec:request:background",
+        result_prefix="orion:exec:result",
+        timeout_sec=120.0,
+    )
+
+    payload = await client.dispatch(
+        verb="substrate.inspect",
+        mode="brain",
+        context={"target_id": "capability:orchestration", "target_kind": "capability"},
+        dispatch_id="dispatch:test:1",
+    )
+
+    assert payload["result"]["final_text"]
+    bus.rpc_request.assert_awaited_once()
+    assert bus.rpc_request.await_args.kwargs["timeout_sec"] == 120.0
+    call_args = bus.rpc_request.await_args
+    assert call_args.args[0] == "orion:cortex:exec:request:background"
+    sent_envelope = call_args.args[1]
+    # correlation_id must be a real UUID (BaseEnvelope requirement); the
+    # human-readable dispatch_id travels in args.extra instead.
+    assert sent_envelope.payload["args"]["extra"]["dispatch_id"] == "dispatch:test:1"
+    assert sent_envelope.payload["plan"]["verb_name"] == "substrate.inspect"
+    assert sent_envelope.payload["context"]["target_id"] == "capability:orchestration"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_custom_timeout_overrides_default() -> None:
+    bus = _bus_returning({"result": {"final_text": "{}"}})
+    client = ExecutionDispatchCortexClient(
+        bus,
+        request_channel="orion:cortex:exec:request:background",
+        result_prefix="orion:exec:result",
+        timeout_sec=120.0,
+    )
+
+    await client.dispatch(
+        verb="substrate.observe",
+        mode="brain",
+        context={},
+        dispatch_id="dispatch:test:2",
+        timeout_sec=30.0,
+    )
+
+    assert bus.rpc_request.await_args.kwargs["timeout_sec"] == 30.0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_raises_on_rpc_not_ok() -> None:
+    bus = AsyncMock()
+    decode_result = MagicMock(ok=False, error="timeout")
+    bus.codec = MagicMock()
+    bus.codec.decode = MagicMock(return_value=decode_result)
+    bus.rpc_request = AsyncMock(return_value={"data": b"payload"})
+    client = ExecutionDispatchCortexClient(
+        bus,
+        request_channel="orion:cortex:exec:request:background",
+        result_prefix="orion:exec:result",
+    )
+
+    with pytest.raises(RuntimeError, match="execution_dispatch cortex RPC failed"):
+        await client.dispatch(
+            verb="substrate.inspect", mode="brain", context={}, dispatch_id="dispatch:test:3"
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_raises_on_non_dict_payload() -> None:
+    bus = _bus_returning({})
+    bus.codec.decode.return_value = MagicMock(ok=True, envelope=MagicMock(payload="not-a-dict"))
+    client = ExecutionDispatchCortexClient(
+        bus,
+        request_channel="orion:cortex:exec:request:background",
+        result_prefix="orion:exec:result",
+    )
+
+    with pytest.raises(RuntimeError, match="non-dict payload"):
+        await client.dispatch(
+            verb="substrate.inspect", mode="brain", context={}, dispatch_id="dispatch:test:4"
+        )

--- a/tests/test_execution_dispatch_policy_loader.py
+++ b/tests/test_execution_dispatch_policy_loader.py
@@ -16,9 +16,12 @@ def test_default_mode_dry_run() -> None:
     assert policy.mode.default_dispatch_mode == "dry_run"
 
 
-def test_allow_dispatch_read_only_false() -> None:
+def test_allow_dispatch_read_only_true() -> None:
+    # P1 of the motor-nerve spec: this gate is open, but EXECUTION_DISPATCH_MODE
+    # still defaults to dry_run (test_default_mode_dry_run above), so real
+    # sends require both gates opened, not this one alone.
     policy = load_execution_dispatch_policy(POLICY_PATH)
-    assert policy.mode.allow_dispatch_read_only is False
+    assert policy.mode.allow_dispatch_read_only is True
 
 
 def test_allow_mutating_dispatch_false() -> None:

--- a/tests/test_execution_dispatch_result_extraction.py
+++ b/tests/test_execution_dispatch_result_extraction.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from orion.execution_dispatch.result_extraction import (
+    extract_final_text,
+    parse_structured_observation,
+)
+
+
+def test_extract_final_text_from_result_final_text() -> None:
+    payload = {"result": {"final_text": "  hello world  "}}
+    assert extract_final_text(payload) == "hello world"
+
+
+def test_extract_final_text_from_step_result_fallback() -> None:
+    payload = {
+        "result": {
+            "final_text": None,
+            "steps": [
+                {"result": {"llm": {"text": "step output here"}}},
+            ],
+        }
+    }
+    assert extract_final_text(payload) == "step output here"
+
+
+def test_extract_final_text_missing_returns_empty() -> None:
+    assert extract_final_text({}) == ""
+    assert extract_final_text({"result": {}}) == ""
+    assert extract_final_text({"result": None}) == ""
+
+
+def test_parse_structured_observation_happy_path() -> None:
+    data = parse_structured_observation(
+        '{"observation": "steady state", "salient_facts": ["a", "b"], "confidence": 0.75}'
+    )
+    assert data == {
+        "observation": "steady state",
+        "salient_facts": ["a", "b"],
+        "confidence": 0.75,
+    }
+
+
+def test_parse_structured_observation_empty_text() -> None:
+    data = parse_structured_observation("")
+    assert data["observation"] == ""
+    assert data["salient_facts"] == []
+    assert data["confidence"] == 0.0
+
+
+def test_parse_structured_observation_malformed_json_degrades_empty() -> None:
+    data = parse_structured_observation("not json at all {{{")
+    assert data["observation"] == ""
+
+
+def test_parse_structured_observation_non_dict_json_degrades_empty() -> None:
+    data = parse_structured_observation("[1, 2, 3]")
+    assert data["observation"] == ""
+
+
+def test_parse_structured_observation_missing_fields_defaults() -> None:
+    data = parse_structured_observation('{"unrelated": true}')
+    assert data == {"observation": "", "salient_facts": [], "confidence": 0.0}
+
+
+def test_parse_structured_observation_wrong_types_coerced_safely() -> None:
+    data = parse_structured_observation(
+        '{"observation": 123, "salient_facts": "not-a-list", "confidence": "n/a"}'
+    )
+    assert data["observation"] == ""
+    assert data["salient_facts"] == []
+    assert data["confidence"] == 0.0

--- a/tests/test_execution_dispatch_runtime_store.py
+++ b/tests/test_execution_dispatch_runtime_store.py
@@ -300,3 +300,58 @@ def test_recent_dispatch_result_statuses_empty_when_no_rows(monkeypatch) -> None
     monkeypatch.setattr(store, "_engine", fake_engine)
 
     assert store.recent_dispatch_result_statuses(10) == []
+
+
+def test_load_dispatch_result_by_dispatch_id_found(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "result_id": "result:dispatch:1",
+        "status": "success",
+        "result_json": {"observation": "steady"},
+        "raw_len": 6,
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    result = store.load_dispatch_result_by_dispatch_id("dispatch:1")
+
+    assert result == {
+        "result_id": "result:dispatch:1",
+        "status": "success",
+        "result_json": {"observation": "steady"},
+        "raw_len": 6,
+    }
+
+
+def test_load_dispatch_result_by_dispatch_id_parses_json_string(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {
+        "result_id": "result:dispatch:1",
+        "status": "success",
+        "result_json": '{"observation": "steady"}',
+        "raw_len": 6,
+    }
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    result = store.load_dispatch_result_by_dispatch_id("dispatch:1")
+
+    assert result["result_json"] == {"observation": "steady"}
+
+
+def test_load_dispatch_result_by_dispatch_id_none_when_no_row(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = None
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.load_dispatch_result_by_dispatch_id("dispatch:missing") is None

--- a/tests/test_execution_dispatch_runtime_store.py
+++ b/tests/test_execution_dispatch_runtime_store.py
@@ -214,3 +214,89 @@ def test_load_self_state_degrades_to_none_on_legacy_incompatible_row(monkeypatch
     monkeypatch.setattr(store, "_engine", fake_engine)
 
     assert store.load_self_state("self.state:legacy") is None
+
+
+def test_save_dispatch_result_inserts_expected_row(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+    calls: list[tuple[str, dict]] = []
+
+    def execute_side_effect(stmt, params=None):
+        calls.append((str(stmt), params or {}))
+        return MagicMock()
+
+    conn.execute.side_effect = execute_side_effect
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    store.save_dispatch_result(
+        result_id="result:dispatch:1",
+        dispatch_id="dispatch:1",
+        frame_id="execution.dispatch.frame:1",
+        status="success",
+        result_json={"observation": "steady", "salient_facts": [], "confidence": 0.7},
+        raw_len=6,
+    )
+
+    assert len(calls) == 1
+    sql, params = calls[0]
+    assert "INSERT INTO substrate_dispatch_results" in sql
+    assert "ON CONFLICT (result_id) DO UPDATE" in sql
+    assert params["result_id"] == "result:dispatch:1"
+    assert params["dispatch_id"] == "dispatch:1"
+    assert params["status"] == "success"
+    assert params["raw_len"] == 6
+
+
+def test_count_dispatches_today_returns_row_count(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = {"n": 3}
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.count_dispatches_today() == 3
+
+
+def test_count_dispatches_today_zero_when_no_row(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.first.return_value = None
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.count_dispatches_today() == 0
+
+
+def test_recent_dispatch_result_statuses_returns_ordered_list(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.all.return_value = [
+        {"status": "success"},
+        {"status": "empty"},
+        {"status": "failed"},
+    ]
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.recent_dispatch_result_statuses(10) == ["success", "empty", "failed"]
+
+
+def test_recent_dispatch_result_statuses_empty_when_no_rows(monkeypatch) -> None:
+    store = ExecutionDispatchRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.all.return_value = []
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    assert store.recent_dispatch_result_statuses(10) == []

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -215,6 +215,7 @@ async def test_send_prepared_candidates_promotes_on_success(monkeypatch) -> None
     worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(
         monkeypatch,
         {"dispatch:1": {"result": {"final_text": '{"observation": "steady", "confidence": 0.8}'}}},
@@ -243,6 +244,7 @@ async def test_send_prepared_candidates_records_failure_on_rpc_exception(monkeyp
     worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(monkeypatch, {"dispatch:1": RuntimeError("rpc timed out")})
     frame = _frame_with_candidates(_candidate("dispatch:1"))
 
@@ -262,6 +264,7 @@ async def test_send_prepared_candidates_empty_observation_status_empty(monkeypat
     worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(monkeypatch, {"dispatch:1": {"result": {"final_text": ""}}})
     frame = _frame_with_candidates(_candidate("dispatch:1"))
 
@@ -285,6 +288,7 @@ async def test_send_prepared_candidates_respects_per_tick_budget(monkeypatch) ->
     worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
     _patch_bus_and_client(
         monkeypatch,
         {
@@ -300,6 +304,61 @@ async def test_send_prepared_candidates_respects_per_tick_budget(monkeypatch) ->
     assert len(updated.candidates) == 1
     assert updated.candidates[0].dispatch_status == "prepared_for_dispatch"
     worker._store.save_dispatch_result.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_one_replays_existing_result_without_resending(monkeypatch) -> None:
+    # Crash-recovery scenario: dispatch_id is deterministic, so if a prior
+    # tick already sent this exact candidate and recorded a result (but the
+    # process died before save_dispatch_frame persisted that), the next
+    # tick must NOT fire a second real cortex-exec RPC for it.
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
+        return_value={
+            "result_id": "result:dispatch:1",
+            "status": "success",
+            "result_json": {"observation": "steady", "evidence_refs": ["result:dispatch:1"]},
+            "raw_len": 6,
+        }
+    )
+    _patch_bus_and_client(monkeypatch, {})  # no outcome registered -- a real send would KeyError
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    promoted = updated.dispatched_candidates[0]
+    assert promoted.dispatch_status == "dispatched"
+    assert promoted.result_ref == "result:dispatch:1"
+    worker._store.save_dispatch_result.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_one_replays_existing_failed_result_without_resending(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
+        return_value={
+            "result_id": "result:dispatch:1",
+            "status": "failed",
+            "result_json": {"error": "rpc timed out"},
+            "raw_len": 0,
+        }
+    )
+    _patch_bus_and_client(monkeypatch, {})
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    promoted = updated.dispatched_candidates[0]
+    assert promoted.dispatch_status == "dispatched"
+    assert promoted.result_ref is None
+    assert promoted.dispatch_error == "rpc timed out"
+    worker._store.save_dispatch_result.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -3,15 +3,21 @@ from __future__ import annotations
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 REPO = Path(__file__).resolve().parents[1]
 SVC = REPO / "services" / "orion-execution-dispatch-runtime"
 sys.path.insert(0, str(REPO))
 sys.path.insert(0, str(SVC))
 
+import app.worker as worker_mod  # noqa: E402
 from app.worker import ExecutionDispatchRuntimeWorker  # noqa: E402
-from orion.schemas.execution_dispatch_frame import ExecutionDispatchFrameV1  # noqa: E402
+from orion.schemas.execution_dispatch_frame import (  # noqa: E402
+    ExecutionDispatchCandidateV1,
+    ExecutionDispatchFrameV1,
+)
 from orion.schemas.policy_decision_frame import PolicyDecisionFrameV1  # noqa: E402
 from orion.schemas.proposal_frame import ProposalFrameV1  # noqa: E402
 from orion.schemas.self_state import SelfStateV1  # noqa: E402
@@ -137,3 +143,229 @@ def test_worker_saves_dispatch_frame_for_pending_policy(monkeypatch) -> None:
     saved = worker._store.save_dispatch_frame.call_args[0][0]
     assert isinstance(saved, ExecutionDispatchFrameV1)
     assert saved.source_policy_frame_id == policy_frame.frame_id
+
+
+def _make_worker(monkeypatch) -> ExecutionDispatchRuntimeWorker:
+    monkeypatch.setenv("POSTGRES_URI", "postgresql://test:test@localhost/test")
+    import app.settings as settings_mod
+
+    settings_mod._settings = None
+    return ExecutionDispatchRuntimeWorker()
+
+
+def _candidate(dispatch_id: str, status: str = "prepared_for_dispatch") -> ExecutionDispatchCandidateV1:
+    return ExecutionDispatchCandidateV1(
+        dispatch_id=dispatch_id,
+        source_decision_id=f"pd:{dispatch_id}",
+        source_proposal_id=f"proposal:{dispatch_id}",
+        dispatch_status=status,
+        dispatch_mode="dispatch_read_only",
+        dispatch_kind="inspect",
+        target_id="capability:orchestration",
+        target_kind="capability",
+        cortex_verb="substrate.inspect",
+        cortex_mode="brain",
+        request_envelope={"context": {"target_id": "capability:orchestration"}},
+        risk_score=0.05,
+        confidence_score=0.9,
+    )
+
+
+def _frame_with_candidates(*candidates: ExecutionDispatchCandidateV1) -> ExecutionDispatchFrameV1:
+    return ExecutionDispatchFrameV1(
+        frame_id="execution.dispatch.frame:test:execution_dispatch_policy.v1",
+        generated_at=NOW,
+        source_policy_frame_id="policy.frame:test",
+        source_proposal_frame_id="proposal.frame:test",
+        source_self_state_id="self.state:test",
+        dispatch_mode="dispatch_read_only",
+        candidates=list(candidates),
+    )
+
+
+class _FakeClient:
+    """Stand-in for ExecutionDispatchCortexClient -- returns canned results
+    or raises, keyed by dispatch_id, without touching the real bus."""
+
+    def __init__(self, *_, **__) -> None:
+        pass
+
+    async def dispatch(self, *, verb, mode, context, dispatch_id, timeout_sec=None):
+        outcome = _FAKE_CLIENT_OUTCOMES[dispatch_id]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+_FAKE_CLIENT_OUTCOMES: dict[str, object] = {}
+
+
+def _patch_bus_and_client(monkeypatch, outcomes: dict[str, object]) -> None:
+    _FAKE_CLIENT_OUTCOMES.clear()
+    _FAKE_CLIENT_OUTCOMES.update(outcomes)
+    fake_bus = MagicMock()
+    fake_bus.close = AsyncMock()
+    monkeypatch.setattr(worker_mod, "OrionBusAsync", MagicMock(return_value=fake_bus))
+    monkeypatch.setattr(worker_mod, "ExecutionDispatchCortexClient", _FakeClient)
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_promotes_on_success(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    _patch_bus_and_client(
+        monkeypatch,
+        {"dispatch:1": {"result": {"final_text": '{"observation": "steady", "confidence": 0.8}'}}},
+    )
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    assert updated.candidates == []
+    assert len(updated.dispatched_candidates) == 1
+    promoted = updated.dispatched_candidates[0]
+    assert promoted.dispatch_status == "dispatched"
+    assert promoted.dispatched_at is not None
+    assert promoted.result_ref == "result:dispatch:1"
+    assert promoted.dispatch_error is None
+    assert updated.dispatch_count == 1
+    assert updated.dispatch_attempted is True
+    worker._store.save_dispatch_result.assert_called_once()
+    assert worker._store.save_dispatch_result.call_args.kwargs["status"] == "success"
+    assert worker._store.save_dispatch_result.call_args.kwargs["raw_len"] == 6
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_records_failure_on_rpc_exception(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    _patch_bus_and_client(monkeypatch, {"dispatch:1": RuntimeError("rpc timed out")})
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    promoted = updated.dispatched_candidates[0]
+    assert promoted.dispatch_status == "dispatched"
+    assert promoted.result_ref is None
+    assert promoted.dispatch_error == "rpc timed out"
+    assert worker._store.save_dispatch_result.call_args.kwargs["status"] == "failed"
+    assert worker._store.save_dispatch_result.call_args.kwargs["raw_len"] == 0
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_empty_observation_status_empty(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    _patch_bus_and_client(monkeypatch, {"dispatch:1": {"result": {"final_text": ""}}})
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    # Empty observation is still an evidenced, real attempt -- promoted to
+    # dispatched with a result_ref, never fabricated as a non-attempt.
+    promoted = updated.dispatched_candidates[0]
+    assert promoted.dispatch_status == "dispatched"
+    assert promoted.result_ref == "result:dispatch:1"
+    assert worker._store.save_dispatch_result.call_args.kwargs["status"] == "empty"
+    assert worker._store.save_dispatch_result.call_args.kwargs["raw_len"] == 0
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_respects_per_tick_budget(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._policy = worker._policy.model_copy(
+        update={"limits": worker._policy.limits.model_copy(update={"max_dispatches_per_tick": 1})}
+    )
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    _patch_bus_and_client(
+        monkeypatch,
+        {
+            "dispatch:1": {"result": {"final_text": '{"observation": "a"}'}},
+            "dispatch:2": {"result": {"final_text": '{"observation": "b"}'}},
+        },
+    )
+    frame = _frame_with_candidates(_candidate("dispatch:1"), _candidate("dispatch:2"))
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    assert len(updated.dispatched_candidates) == 1
+    assert len(updated.candidates) == 1
+    assert updated.candidates[0].dispatch_status == "prepared_for_dispatch"
+    worker._store.save_dispatch_result.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_skips_when_daily_cap_reached(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(
+        return_value=worker._settings.orion_dispatch_max_per_day
+    )
+    worker._store.save_dispatch_result = MagicMock()
+    _patch_bus_and_client(monkeypatch, {})
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    assert updated.candidates == [frame.candidates[0]]
+    assert updated.dispatched_candidates == []
+    worker._store.save_dispatch_result.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_skips_when_tripwire_active(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(
+        return_value=["empty"] * 6 + ["success"] * 4
+    )
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._notify.send = MagicMock()
+    _patch_bus_and_client(monkeypatch, {})
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    assert worker.theater_tripwire_active is True
+    assert updated.candidates == [frame.candidates[0]]
+    worker._store.save_dispatch_result.assert_not_called()
+    worker._notify.send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_tripwire_stays_tripped_across_calls(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(
+        return_value=["empty"] * 6 + ["success"] * 4
+    )
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._notify.send = MagicMock()
+    _patch_bus_and_client(monkeypatch, {})
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    await worker._send_prepared_candidates(frame)
+    await worker._send_prepared_candidates(_frame_with_candidates(_candidate("dispatch:2")))
+
+    # Notified once on the transition into tripped, not on every subsequent tick.
+    worker._notify.send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_prepared_candidates_noop_when_nothing_prepared(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    frame = _frame_with_candidates(_candidate("dispatch:1", status="blocked"))
+
+    updated = await worker._send_prepared_candidates(frame)
+
+    assert updated is frame

--- a/tests/test_feedback_builder.py
+++ b/tests/test_feedback_builder.py
@@ -354,6 +354,55 @@ def test_failed_cortex_result() -> None:
     assert frame.outcome_status == "failed"
 
 
+def test_empty_cortex_result_scores_as_failed_not_unknown() -> None:
+    # execution-dispatch's raw_len=0 result ("empty" status) is a real
+    # attempt that produced no usable content -- the empty-shell-cognition
+    # rule requires this score as a failure, not fall into the same
+    # "unknown" bucket as a genuinely untracked/missing result.
+    dispatch = ExecutionDispatchFrameV1(
+        frame_id="execution.dispatch.frame:empty:execution_dispatch_policy.v1",
+        generated_at=NOW,
+        source_policy_frame_id="policy.frame:empty",
+        source_proposal_frame_id="proposal.frame:empty",
+        source_self_state_id="self.state:empty",
+        dispatch_mode="dispatch_read_only",
+        dispatch_attempted=True,
+        dispatch_count=1,
+        dispatched_candidates=[
+            ExecutionDispatchCandidateV1(
+                dispatch_id="dispatch:proposal:inspect:execution_dispatch_policy.v1",
+                source_decision_id="pd1",
+                source_proposal_id="proposal:inspect:state",
+                dispatch_status="dispatched",
+                dispatch_mode="dispatch_read_only",
+                dispatch_kind="inspect",
+                target_id="t1",
+                target_kind="capability",
+                risk_score=0.05,
+                confidence_score=0.9,
+                dispatched_at=NOW,
+                result_ref="stub:result:inspect",
+            )
+        ],
+    )
+    frame = build_feedback_frame(
+        dispatch_frame=dispatch,
+        policy_frame=None,
+        proposal_frame=None,
+        self_state_before=None,
+        self_state_after=None,
+        cortex_results=[
+            {"dispatch_id": "dispatch:proposal:inspect:execution_dispatch_policy.v1", "status": "empty"}
+        ],
+        policy=FEEDBACK_POLICY,
+        now=NOW,
+    )
+    assert frame.outcome_status == "failed"
+    empty_obs = [o for o in frame.observations if o.source_kind == "cortex_result"][0]
+    assert empty_obs.outcome_kind == "failed"
+    assert empty_obs.score == FEEDBACK_POLICY.scoring.failed_score
+
+
 def test_self_state_improvement_positive_evidence() -> None:
     dispatch = _dispatch_dry_run()
     before = _self_state("self.state:before", {"execution_pressure": 1.0, "agency_readiness": 0.2})

--- a/tests/test_feedback_runtime_store.py
+++ b/tests/test_feedback_runtime_store.py
@@ -25,6 +25,10 @@ def _load_store_class():
 
 FeedbackRuntimeStore = _load_store_class()
 
+from orion.schemas.execution_dispatch_frame import (  # noqa: E402
+    ExecutionDispatchCandidateV1,
+    ExecutionDispatchFrameV1,
+)
 from orion.schemas.feedback_frame import FeedbackFrameV1  # noqa: E402
 
 NOW = datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc)
@@ -159,6 +163,123 @@ def test_load_latest_dispatch_frame_degrades_to_none_on_legacy_row(monkeypatch) 
     monkeypatch.setattr(store, "_engine", fake_engine)
 
     assert store.load_latest_dispatch_frame() is None
+
+
+def _candidate(dispatch_id: str, status: str = "prepared_for_dispatch") -> ExecutionDispatchCandidateV1:
+    return ExecutionDispatchCandidateV1(
+        dispatch_id=dispatch_id,
+        source_decision_id="pd1",
+        source_proposal_id="proposal:inspect:state",
+        dispatch_status=status,
+        dispatch_mode="dispatch_read_only",
+        dispatch_kind="inspect",
+        target_id="t1",
+        target_kind="capability",
+        risk_score=0.05,
+        confidence_score=0.9,
+    )
+
+
+def _dispatch_frame(candidates: list[ExecutionDispatchCandidateV1]) -> ExecutionDispatchFrameV1:
+    return ExecutionDispatchFrameV1(
+        frame_id="execution.dispatch.frame:pf1:execution_dispatch_policy.v1",
+        generated_at=NOW,
+        source_policy_frame_id="policy.frame:pf1:substrate_policy.v1",
+        source_proposal_frame_id="proposal.frame:pf1:proposal_policy.v1",
+        source_self_state_id="self.state:pf1",
+        candidates=candidates,
+    )
+
+
+def test_load_cortex_result_evidence_returns_matched_rows(monkeypatch) -> None:
+    store = FeedbackRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    rows = [
+        {
+            "result_id": "result:1",
+            "dispatch_id": "dispatch:1",
+            "status": "success",
+            "result_json": {"observation": "ok", "evidence_refs": ["ev:1"]},
+        }
+    ]
+    conn.execute.return_value.mappings.return_value.all.return_value = rows
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    dispatch_frame = _dispatch_frame([_candidate("dispatch:1")])
+    evidence = store.load_cortex_result_evidence(dispatch_frame)
+
+    assert evidence == [
+        {
+            "result_id": "result:1",
+            "dispatch_id": "dispatch:1",
+            "status": "success",
+            "evidence_refs": ["ev:1"],
+        }
+    ]
+
+
+def test_load_cortex_result_evidence_no_matching_rows_returns_empty(monkeypatch) -> None:
+    store = FeedbackRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    conn.execute.return_value.mappings.return_value.all.return_value = []
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    dispatch_frame = _dispatch_frame([_candidate("dispatch:1")])
+    assert store.load_cortex_result_evidence(dispatch_frame) == []
+
+
+def test_load_cortex_result_evidence_no_candidates_skips_query(monkeypatch) -> None:
+    store = FeedbackRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    dispatch_frame = _dispatch_frame([])
+    assert store.load_cortex_result_evidence(dispatch_frame) == []
+    fake_engine.connect.assert_not_called()
+
+
+def test_load_cortex_result_evidence_degrades_malformed_row(monkeypatch) -> None:
+    store = FeedbackRuntimeStore("postgresql://test:test@localhost/test")
+    fake_engine = MagicMock()
+    conn = MagicMock()
+    fake_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    fake_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    rows = [
+        {
+            "result_id": "result:bad",
+            "dispatch_id": "dispatch:1",
+            "status": "failed",
+            "result_json": "{not-valid-json",
+        },
+        {
+            "result_id": "result:good",
+            "dispatch_id": "dispatch:2",
+            "status": "success",
+            "result_json": {"observation": "ok"},
+        },
+    ]
+    conn.execute.return_value.mappings.return_value.all.return_value = rows
+    monkeypatch.setattr(store, "_engine", fake_engine)
+
+    dispatch_frame = _dispatch_frame([_candidate("dispatch:1"), _candidate("dispatch:2")])
+    evidence = store.load_cortex_result_evidence(dispatch_frame)
+
+    assert evidence == [
+        {
+            "result_id": "result:good",
+            "dispatch_id": "dispatch:2",
+            "status": "success",
+            "evidence_refs": [],
+        }
+    ]
 
 
 def test_save_idempotent_by_frame_id(monkeypatch) -> None:

--- a/tests/test_plan_loader.py
+++ b/tests/test_plan_loader.py
@@ -32,3 +32,19 @@ def test_mesh_skill_plan_step_has_empty_services():
     plan = build_plan_for_verb("skills.mesh.tailscale_mesh_status.v1", mode="brain")
     assert plan.steps
     assert plan.steps[0].services == []
+
+
+def test_substrate_inspect_summarize_observe_load_with_nonempty_prompts():
+    for verb_name in ("substrate.inspect", "substrate.summarize", "substrate.observe"):
+        plan = build_plan_for_verb(verb_name, mode="brain")
+        assert plan.verb_name == verb_name
+        assert plan.category == "ExecutiveControl"
+        assert plan.steps
+        assert all(step.prompt_template for step in plan.steps)
+        assert all((step.prompt_template or "").strip() for step in plan.steps)
+
+
+def test_substrate_probe_verbs_declare_llm_gateway_service():
+    for verb_name in ("substrate.inspect", "substrate.summarize", "substrate.observe"):
+        plan = build_plan_for_verb(verb_name, mode="brain")
+        assert plan.steps[0].services == ["LLMGatewayService"]

--- a/tests/test_proposal_policy_loader.py
+++ b/tests/test_proposal_policy_loader.py
@@ -30,3 +30,21 @@ def test_policy_review_requires_operator_review() -> None:
 def test_dimension_weights_include_execution_pressure() -> None:
     policy = load_proposal_policy(POLICY_PATH)
     assert "execution_pressure" in policy.dimension_weights
+
+
+def test_inspect_node_resource_pressure_template_targets_node() -> None:
+    policy = load_proposal_policy(POLICY_PATH)
+    tmpl = policy.proposal_templates["inspect_node_resource_pressure"]
+    assert tmpl.kind == "inspect"
+    assert tmpl.target_kind == "node"
+    assert tmpl.target_id == "node:atlas"
+    assert "resource_pressure" in tmpl.dimensions
+
+
+def test_inspect_field_topology_catalog_template_targets_field() -> None:
+    policy = load_proposal_policy(POLICY_PATH)
+    tmpl = policy.proposal_templates["inspect_field_topology_catalog"]
+    assert tmpl.kind == "inspect"
+    assert tmpl.target_kind == "field"
+    assert tmpl.target_id == "config/field/orion_field_topology.v1.yaml"
+    assert "field_intensity" in tmpl.dimensions


### PR DESCRIPTION
# feat(execution-dispatch): motor nerve — Layer 9 actually sends (P1)

## Summary

- `orion-execution-dispatch-runtime` (Layer 9) now actually sends `prepared_for_dispatch` candidates to `orion-cortex-exec` over the bus, instead of only building envelopes and never sending (P0 un-lied the status; P1 makes the honest status real).
- Three new cortex verbs (`substrate.inspect`/`summarize`/`observe`), each with its own prompt template and distinct tone (inspect: diagnostic; summarize: wide-angle; observe: deliberately lighter/non-alarming, matching its `preserve_stability` proposal-layer intent).
- Two new "robust, not speculative" proposal templates targeting `node`/`field` target_kinds — real, already-live signal behind both; explicitly did not add a `service`-target template (no real backing signal exists for it) or any new verb/proposal-kind beyond what's already grounded (no `trend`/`correlate`, per earlier design discussion).
- New `substrate_dispatch_results` table; `FeedbackRuntimeStore.load_cortex_result_evidence` replaced its `[]`-stub with a real query.
- Theater tripwire: if more than half of the trailing 10 real results come back empty, sending self-disables for the rest of the process's life, visible on `GET /latest`, with one `orion-notify` warning on the transition.
- Idempotency guard added during review: a crash between a successful send and frame persistence can no longer cause a duplicate real cortex-exec call for the same candidate.

## Outcome moved

Orion has never taken a real, evidenced, self-initiated action through this pipeline before. This patch is the one place that changes — everything upstream (perception → proposal → policy) and downstream (feedback scoring) already existed and worked; only the actual send was missing. `EXECUTION_DISPATCH_MODE` still defaults to `dry_run`, so nothing changes in the live environment until an operator explicitly flips it.

## Current architecture (before this patch)

`orion-execution-dispatch-runtime`'s worker built `ExecutionDispatchFrameV1` envelopes and persisted them, but never touched the bus — no `redis` dependency, no bus client, a dead `CORTEX_EXEC_CHANNEL` setting pointing at a channel name that didn't exist. `FeedbackRuntimeStore.load_cortex_result_evidence` was a two-line stub always returning `[]`. No cortex verb existed for any of the three dispatch kinds the policy already routed to.

## Architecture touched

`orion-execution-dispatch-runtime` (worker, store, settings, requirements), `orion-feedback-runtime` (store), `orion-cortex-exec` (verb allowlist), `orion-hub`'s debug route unaffected, plus shared `orion/` packages (`execution_dispatch/`, `feedback/`, `cognition/verbs`+`prompts`, `bus/channels.yaml`), `config/proposals/`, `config/execution_dispatch/`, and `services/orion-sql-db/` (new migration).

## Files changed

- `orion/cognition/verbs/substrate.{inspect,summarize,observe}.yaml` + `orion/cognition/prompts/substrate_{inspect,summarize,observe}.j2` — new verbs, own templates, distinct tone per verb.
- `services/orion-cortex-exec/app/router.py` — added the three verb names to `_structured_output_expected`.
- `config/proposals/proposal_policy.v1.yaml` — two new templates (`node`, `field` target_kinds), reusing `kind: inspect`, no new enum values.
- `services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql` — new table.
- `services/orion-feedback-runtime/app/store.py` — real `load_cortex_result_evidence` (dedupe-by-latest, degrade-on-malformed-row).
- `orion/bus/channels.yaml` — `orion-execution-dispatch-runtime` added as a producer on `orion:cortex:exec:request:background`.
- `orion/execution_dispatch/cortex_client.py` (new) — RPC client, mirrors `orion.harness.cortex_client.HarnessCortexClient`'s shape.
- `orion/execution_dispatch/result_extraction.py` (new) — `extract_final_text`/`parse_structured_observation`.
- `orion/execution_dispatch/envelopes.py` — `origin`/`correlation` fields for attribution.
- `services/orion-execution-dispatch-runtime/app/worker.py` — send-and-wait step, budget/cap enforcement, theater tripwire, idempotency guard.
- `services/orion-execution-dispatch-runtime/app/store.py` — `save_dispatch_result`, `count_dispatches_today`, `recent_dispatch_result_statuses`, `load_dispatch_result_by_dispatch_id`.
- `services/orion-execution-dispatch-runtime/app/main.py` — `theater_tripwire_active` on `GET /latest`.
- `services/orion-execution-dispatch-runtime/app/settings.py`, `.env_example`, `requirements.txt` — new keys, fixed `CORTEX_EXEC_CHANNEL` default, `redis`+`requests` dependencies.
- `orion/feedback/builder.py` — `prepared_for_dispatch`/`"empty"` status handling.
- `config/execution_dispatch/execution_dispatch_policy.v1.yaml` — `allow_dispatch_read_only: true`.
- Test files: `tests/test_execution_dispatch_cortex_client.py`, `tests/test_execution_dispatch_result_extraction.py` (new); `tests/test_execution_dispatch_runtime_worker.py`, `tests/test_execution_dispatch_runtime_store.py`, `tests/test_feedback_runtime_store.py`, `tests/test_feedback_builder.py`, `tests/test_execution_dispatch_policy_loader.py`, `tests/test_execution_dispatch_bus_catalog.py` (new), `tests/test_proposal_policy_loader.py`, `tests/test_plan_loader.py` (extended).
- `docs/superpowers/specs/2026-07-13-execution-dispatch-motor-nerve-p1-design.md` — design spec.
- `services/orion-execution-dispatch-runtime/README.md`, `services/orion-feedback-runtime/README.md` — documented.

## Schema / bus / API changes

- **Added:** `substrate_dispatch_results` table; `orion:cortex:exec:request:background`'s `producer_services` gains `orion-execution-dispatch-runtime`; `orion/feedback/builder.py`'s `OutcomeKind` unaffected (no new literal added — `"empty"` cortex status maps into the existing `"failed"` outcome kind, not a new one, per the empty-shell-cognition rule).
- **Removed:** none.
- **Renamed:** none.
- **Behavior changed:** real sends now happen when both `EXECUTION_DISPATCH_MODE=dispatch_read_only` and the policy's `allow_dispatch_read_only: true` (now the shipped default) are open. `dispatched_candidates`/`dispatch_count`/`dispatch_attempted` become honest for the first time (previously permanently empty/zero/false from this builder, a known P0 limitation, now resolved). `_cortex_status_to_outcome`'s `"empty"` status now scores as `"failed"` rather than falling through to `"unknown"`.
- **Compatibility notes:** the new evidence-requiring validator from P0 could have broken historical rows on load — checked and guarded during P0; this patch's own new risk (duplicate real dispatch on crash) was caught in review and fixed with an idempotency guard before merge, not after.

## Env/config changes

- Added keys (`services/orion-execution-dispatch-runtime/.env_example`): `CORTEX_EXEC_RESULT_PREFIX`, `ORION_BUS_URL`, `ORION_BUS_ENABLED`, `EXECUTION_DISPATCH_RPC_TIMEOUT_SEC`, `ORION_DISPATCH_MAX_PER_DAY`, `NOTIFY_URL`, `NOTIFY_API_TOKEN`.
- Changed default: `CORTEX_EXEC_CHANNEL` (`orion:cortex:request` → `orion:cortex:exec:request:background` — the old default named a channel that didn't exist in `orion/bus/channels.yaml` and was never referenced in code; now it's real and wired).
- Removed keys: none.
- `.env_example` updated: yes.
- local `.env` synced with `python scripts/sync_local_env_from_example.py`: run — no local `.env` exists for this service in this environment (never brought up locally here), so it was a no-op; confirmed via `git status --short` that no `.env` file was created or staged.
- skipped keys requiring operator action: none new; `ORION_BUS_URL`'s tailscale-node-IP placeholder in `.env_example` needs a real value on any environment that runs this service for real (same as every other bus-connected service in this repo).

## Tests run

```text
cd /mnt/scripts/Orion-Sapienform-execution-dispatch-motor-nerve-p1
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest \
  tests/test_execution_dispatch_frame_schemas.py tests/test_execution_dispatch_envelopes.py \
  tests/test_execution_dispatch_builder.py tests/test_execution_dispatch_policy_loader.py \
  tests/test_execution_dispatch_runtime_store.py tests/test_execution_dispatch_runtime_worker.py \
  tests/test_execution_dispatch_transport_dry_run.py tests/test_execution_dispatch_cortex_client.py \
  tests/test_execution_dispatch_result_extraction.py tests/test_execution_dispatch_bus_catalog.py \
  tests/test_feedback_builder.py tests/test_feedback_runtime_store.py tests/test_feedback_transport_outcomes.py \
  tests/test_proposal_policy_loader.py tests/test_plan_loader.py \
  tests/test_consolidation_tensorize.py tests/test_consolidation_schema_candidates.py \
  tests/test_consolidation_motif_detection.py tests/test_consolidation_expectations.py \
  tests/test_consolidation_policy_loader.py -q

142 passed

/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest \
  services/orion-cortex-exec/tests/test_router_final_text_assembly.py \
  services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py -q

36 passed
```
(Run as two groups: this repo's `sys.path.insert` + `import app.X` test pattern has a pre-existing module-name collision risk when combining test files from multiple services that all use the generic package name `app` in one pytest invocation — not introduced by this patch, matches how `make agent-check SERVICE=<x>` already scopes per-service.)

`git diff --check` clean. `.env` files confirmed gitignored, none created/staged.

## Evals run

None — no eval harness exists for this service; the design spec names a live smoke script (`scripts/smoke_execution_dispatch_live.sh`) as a follow-up once this is deployed with real traffic, not built in this patch (requires a live cortex-exec + bus + Postgres environment this sandbox doesn't have).

## Docker/build/smoke checks

Not run — no container build available in this sandbox. Verified instead:
- Live Postgres query against `substrate_execution_dispatch_frames` (687,992 rows, carried over from P0's compat check) and live confirmation of `SHOW timezone` (`Etc/UTC`) on the real `orion-sql-db` instance, informing the `count_dispatches_today()` UTC-boundary fix.
- `redis==5.0.7`/`requests==2.32.3` both confirmed importable in the shared venv.
- All touched/new YAML files (`proposal_policy.v1.yaml`, `execution_dispatch_policy.v1.yaml`, `channels.yaml`, 3 verb YAMLs) parse cleanly.
- `orion/execution_dispatch/cortex_client.py`, `result_extraction.py`, and `services/orion-execution-dispatch-runtime/app/worker.py` all import cleanly end-to-end (including through `orion.core.bus.async_service`'s `redis` dependency).

## Review findings fixed

- Finding: No idempotency guard — a crash between a successful real send and `save_dispatch_frame()` persisting that fact would cause the next tick to resend a real cortex-exec RPC for the same (deterministic) `dispatch_id`.
  - Fix: `store.load_dispatch_result_by_dispatch_id()` + a check at the top of `_send_one()` that replays the stored result instead of resending.
  - Evidence: `tests/test_execution_dispatch_runtime_worker.py::test_send_one_replays_existing_result_without_resending` (and the failed-result variant) — registers no fake-client outcome, so a real resend attempt would `KeyError`; both pass.
- Finding: `evidence_refs` was always empty in production — the feedback-runtime reader looked for a key the dispatch worker never wrote.
  - Fix: `save_dispatch_result`'s `result_json` now includes `evidence_refs: [result_id]`.
  - Evidence: `_send_one`'s success/failure paths both updated; existing `load_cortex_result_evidence` tests already assert on this field's presence.
- Finding: cortex status `"empty"` fell into the same `"unknown"` bucket as a genuinely untracked result — the theater tripwire's core signal wasn't distinguishable from missing data in feedback scoring.
  - Fix: `_cortex_status_to_outcome` maps `"empty"` to `"failed"`, matching the empty-shell-cognition rule ("stored as failure, never as success").
  - Evidence: `tests/test_feedback_builder.py::test_empty_cortex_result_scores_as_failed_not_unknown`.
- Finding: `extract_final_text` dropped the `raw.text` fallback branch present in the function it's documented as mirroring (`orion-actions`' version), risking false `status="empty"` for a real content shape.
  - Fix: restored the branch verbatim.
  - Evidence: `orion/execution_dispatch/result_extraction.py:26-29`.
- Finding: `theater_tripwire_active` wasn't exposed on `GET /latest`, contradicting the design doc's explicit acceptance check.
  - Fix: added to the response payload in `app/main.py`.
  - Evidence: one-line diff, `services/orion-execution-dispatch-runtime/app/main.py`.
- Finding (lower confidence, live-checked): `count_dispatches_today()` used `date_trunc('day', now())`, Postgres-server-timezone-dependent, inconsistent with this file's own explicit-UTC convention elsewhere.
  - Fix: computed the UTC day boundary in Python instead. Live-checked `SHOW timezone` on the real instance first — `Etc/UTC`, so not an active bug, but hardened anyway for consistency.
  - Evidence: `services/orion-execution-dispatch-runtime/app/store.py::count_dispatches_today`.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-execution-dispatch-runtime/.env \
  -f services/orion-execution-dispatch-runtime/docker-compose.yml \
  up -d --build

docker compose \
  --env-file .env \
  --env-file services/orion-feedback-runtime/.env \
  -f services/orion-feedback-runtime/docker-compose.yml \
  up -d --build

docker compose \
  --env-file .env \
  --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml \
  up -d --build
```
Plus the new migration before starting `orion-execution-dispatch-runtime`:
```bash
docker exec -i orion-athena-sql-db psql -U postgres -d conjourney \
  < services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql
```
No config change alone turns on live sending — `EXECUTION_DISPATCH_MODE` still defaults to `dry_run` in `.env_example`; an operator must explicitly set it to `dispatch_read_only` in the real `.env` for this service to start sending.

## Risks / concerns

- Severity: medium
- Concern: this is Orion's first real self-initiated bus action. Even with the theater tripwire, budget caps, and idempotency guard, the actual behavior of a live `substrate.inspect`/`summarize`/`observe` LLM call against real self-state data hasn't been observed — only unit-tested against mocked bus/client responses.
- Mitigation: `EXECUTION_DISPATCH_MODE` defaults to `dry_run`; recommend a manual, closely-watched burn-in window (flip the env var, watch `/latest`'s `theater_tripwire_active` and `dispatch_count`, check `substrate_dispatch_results` rows directly) before considering this "on" in any meaningful sense. Matches the parent spec's own stated sequencing (P1 needs its own burn-in before P2/P3, which need it before P7's origination decision).
- Severity: low
- Concern: `scripts/smoke_execution_dispatch_live.sh` (named in the parent spec's evidence bar) was not built in this patch — no live bus/cortex-exec/Postgres stack available in this sandbox to write and verify a real smoke script against.
- Mitigation: follow-up, once this is deployed somewhere with real infra to smoke-test against.
