### PR TITLE
Feat/mood arc encoder manifest schema

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-mood-arc-encoder-manifest-schema-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-mood-arc-encoder-manifest-schema-pr.md
@@ -1,0 +1,91 @@
+## Summary
+
+- Adds `MoodArcEncoderManifestV1` to `orion/schemas/telemetry/mood_arc.py` — the manifest schema for Item 2 (windowed felt-state-trajectory autoencoder) of `docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md`. Sibling to `PhiEncoderManifestV1` (reuses `CorpusStatsV1`/`TrainingStatsV1` as-is from `orion.schemas.telemetry.phi_encoder`, not a subclass — different input/window semantics per spec).
+- Fixes a pre-existing gap: `MoodArcCorpusRowV1` (shipped in PR #989) was never registered in `orion/schemas/registry.py`'s `_REGISTRY` or `SCHEMA_REGISTRY`, unlike its phi-encoder siblings. Both `MoodArcCorpusRowV1` and `MoodArcEncoderManifestV1` are now registered.
+- Adds `tests/test_mood_arc_encoder_schema.py` covering registry resolution, `kind` string assertions, a `model_dump_json()`/`model_validate_json()` round-trip, and `extra="forbid"` rejection.
+- No producer, no consumer, no runtime behavior change — schema-only slice, disk-only artifact, dark by design.
+
+## Outcome moved
+
+Establishes the schema contract Item 2's actual training CLI (`scripts/fit_mood_arc_encoder.py`, follow-up branch `feat/mood-arc-encoder-cli`) is built against, and closes a real, pre-existing registry gap for `MoodArcCorpusRowV1` from PR #989.
+
+## Current architecture
+
+Before this patch, `orion/schemas/telemetry/mood_arc.py` had only `MoodArcCorpusRowV1` (Item 1's per-tick corpus row schema), and neither it nor any mood-arc schema was registered in `orion/schemas/registry.py`.
+
+## Architecture touched
+
+`orion/schemas/telemetry/mood_arc.py`, `orion/schemas/registry.py`, new test file. No service, config, or runtime files.
+
+## Files changed
+
+- `orion/schemas/telemetry/mood_arc.py`: added `MoodArcEncoderManifestV1` class + import of `CorpusStatsV1`/`TrainingStatsV1`
+- `orion/schemas/registry.py`: added import line, `_REGISTRY` entries, and `SCHEMA_REGISTRY` entries (with `kind`) for both `MoodArcCorpusRowV1` and `MoodArcEncoderManifestV1`
+- `tests/test_mood_arc_encoder_schema.py`: new test file
+
+## Schema / bus / API changes
+
+- Added: `MoodArcEncoderManifestV1` (file-only schema, no bus channel)
+- Registered (gap fix, not newly introduced): `MoodArcCorpusRowV1` in `_REGISTRY` / `SCHEMA_REGISTRY` with kind `self.mood_arc_corpus.v1`
+- Registered (new): `MoodArcEncoderManifestV1` in `_REGISTRY` / `SCHEMA_REGISTRY` with kind `self.mood_arc_encoder.manifest.v1`
+- Compatibility notes: purely additive, no existing schema shape changed
+
+## Env/config changes
+
+None — schema-only patch, no `.env`/`.env_example`/compose/requirements touched.
+
+## Tests run
+
+```text
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest \
+  tests/test_mood_arc_encoder_schema.py \
+  tests/test_phi_encoder_schema.py \
+  services/orion-spark-introspector/tests/test_mood_arc_corpus.py -q
+=> 10 passed, 16 warnings (warnings are pre-existing, unrelated protected-namespace deprecation notices)
+```
+
+## Evals run
+
+Not applicable — schema-only patch, no model/training component in this item.
+
+## Docker/build/smoke checks
+
+Not applicable — schema-only patch, no runtime/config/Docker changes.
+
+## Known acceptance-check conflict (flagged, not silently swallowed — resolved by a follow-up branch)
+
+```text
+/mnt/scripts/Orion-Sapienform/.venv/bin/python scripts/check_inner_state_registry.py
+=> inner_state_registry gate FAILED:
+   - orion/schemas/registry.py declares 'MoodArcEncoderManifestV1', which matches an
+     inner-state keyword ("mood") and has no orion/self_state/inner_state_registry.py entry
+```
+
+Root cause: `scripts/check_inner_state_registry.py`'s keyword heuristic (`INNER_STATE_KEYWORDS` includes `"mood"`) flags any name added to `orion/schemas/registry.py`'s flat `_REGISTRY` that matches the keyword list and isn't covered by an entry in `orion/self_state/inner_state_registry.py`'s `REGISTRY` or the script's own `_EXTRA_COVERED_SCHEMA_NAMES` allowlist. `MoodArcCorpusRowV1` is already covered (it's the schema behind `signal_id="mood_arc_corpus.v1"`); `MoodArcEncoderManifestV1` was not, since it had no producer or inner-state-registry entry yet by design at the time of this patch.
+
+This task was explicitly scoped to three files (`mood_arc.py`, `registry.py`, the new test file) and forbade touching `orion/self_state/inner_state_registry.py` — fixing this gate required a real producer to exist first. **Resolved in the follow-up branch `feat/mood-arc-encoder-cli`**, which adds `scripts/fit_mood_arc_encoder.py` (the producer) and the corresponding `mood_arc_encoder.v1` registry entry. `check_inner_state_registry.py` passes on that branch.
+
+## Review findings fixed
+
+Code-review skill not run in a subagent for this patch (scope was schema/registry/test-only, explicitly bounded to 3 files). No material issues found by manual inspection; patterns mirror existing `PhiEncoderManifestV1`/`PhiIntrinsicRewardV1` registrations exactly.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `scripts/check_inner_state_registry.py` gate fails on this branch in isolation, until the follow-up producer branch merges.
+- Mitigation: resolved by `feat/mood-arc-encoder-cli` (already pushed, depends on this branch merging first). Documented here rather than silently deferred.
+
+## Merge order
+
+This branch has no dependencies and can merge first. `feat/mood-arc-encoder-cli` branches from this branch's tip (not `main`) and should be rebased onto `main` once this merges.
+
+## PR link
+
+`gh` is unauthenticated in this environment — open manually at:
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/mood-arc-encoder-manifest-schema

--- a/orion/schemas/registry.py
+++ b/orion/schemas/registry.py
@@ -439,6 +439,7 @@ from orion.schemas.self_study import (
     SelfWritebackStatusV1,
 )
 from orion.schemas.telemetry.inner_state import InnerFeatureV1, InnerStateFeaturesV1
+from orion.schemas.telemetry.mood_arc import MoodArcCorpusRowV1, MoodArcEncoderManifestV1
 from orion.schemas.telemetry.phi_encoder import PhiEncoderManifestV1, PhiIntrinsicRewardV1
 from orion.schemas.telemetry.reasoning import ReasoningActivityV1, ReasoningCallV1
 from orion.schemas.telemetry.spark import SparkStateSnapshotV1, SparkTelemetryPayload
@@ -712,6 +713,8 @@ _REGISTRY: Dict[str, Type[BaseModel]] = {
     "MetacogEnrichScorePatchV1": MetacogEnrichScorePatchV1,
     "InnerStateFeaturesV1": InnerStateFeaturesV1,
     "InnerFeatureV1": InnerFeatureV1,
+    "MoodArcCorpusRowV1": MoodArcCorpusRowV1,
+    "MoodArcEncoderManifestV1": MoodArcEncoderManifestV1,
     "PhiEncoderManifestV1": PhiEncoderManifestV1,
     "PhiIntrinsicRewardV1": PhiIntrinsicRewardV1,
     "ReasoningCallV1": ReasoningCallV1,
@@ -1243,6 +1246,14 @@ SCHEMA_REGISTRY: Dict[str, SchemaRegistration] = {
     "InnerStateFeaturesV1": SchemaRegistration(
         model=InnerStateFeaturesV1,
         kind="self.inner_features.v1",
+    ),
+    "MoodArcCorpusRowV1": SchemaRegistration(
+        model=MoodArcCorpusRowV1,
+        kind="self.mood_arc_corpus.v1",
+    ),
+    "MoodArcEncoderManifestV1": SchemaRegistration(
+        model=MoodArcEncoderManifestV1,
+        kind="self.mood_arc_encoder.manifest.v1",
     ),
     "PhiEncoderManifestV1": SchemaRegistration(
         model=PhiEncoderManifestV1,

--- a/orion/schemas/telemetry/mood_arc.py
+++ b/orion/schemas/telemetry/mood_arc.py
@@ -6,6 +6,8 @@ from typing import Optional, Literal
 
 from pydantic import BaseModel, ConfigDict
 
+from orion.schemas.telemetry.phi_encoder import CorpusStatsV1, TrainingStatsV1
+
 
 class MoodArcCorpusRowV1(BaseModel):
     """One per-tick training-data row for the not-yet-built windowed felt-
@@ -44,3 +46,29 @@ class MoodArcCorpusRowV1(BaseModel):
     valence: float
     valence_source: Literal["proxy", "heuristic"]
     dominant_node: Optional[str] = None
+
+
+class MoodArcEncoderManifestV1(BaseModel):
+    """Item 2's windowed felt-state-trajectory encoder manifest -- dark
+    artifact, disk-only, no cognition consumer yet (see roadmap item 2,
+    docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    encoder_id: str
+    encoder_version: str
+    parent_version: Optional[str] = None
+    status: Literal["candidate", "active", "retired"]
+    architecture: str  # "mlp_shallow_v1", same as phi encoder
+    window_size: int
+    stride: int
+    max_gap_sec: float
+    hidden_dim: int
+    latent_dim: int
+    corpus: CorpusStatsV1        # reused as-is from orion.schemas.telemetry.phi_encoder
+    training: TrainingStatsV1    # reused as-is
+    shuffle_baseline_loss: float # held_out_loss with rows shuffled within-window (see gate)
+    git_sha: str
+    trained_at: datetime
+    promoted_at: Optional[datetime] = None

--- a/tests/test_mood_arc_encoder_schema.py
+++ b/tests/test_mood_arc_encoder_schema.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from orion.schemas.registry import SCHEMA_REGISTRY, resolve
+from orion.schemas.telemetry.mood_arc import MoodArcCorpusRowV1, MoodArcEncoderManifestV1
+from orion.schemas.telemetry.phi_encoder import CorpusStatsV1, TrainingStatsV1
+
+
+def test_registry_resolves_mood_arc_schemas() -> None:
+    assert resolve("MoodArcCorpusRowV1") is MoodArcCorpusRowV1
+    assert resolve("MoodArcEncoderManifestV1") is MoodArcEncoderManifestV1
+    assert SCHEMA_REGISTRY["MoodArcCorpusRowV1"].model is MoodArcCorpusRowV1
+    assert SCHEMA_REGISTRY["MoodArcEncoderManifestV1"].model is MoodArcEncoderManifestV1
+    assert SCHEMA_REGISTRY["MoodArcCorpusRowV1"].kind == "self.mood_arc_corpus.v1"
+    assert SCHEMA_REGISTRY["MoodArcEncoderManifestV1"].kind == "self.mood_arc_encoder.manifest.v1"
+
+
+def _manifest_kwargs() -> dict:
+    return dict(
+        encoder_id="mood-arc-test",
+        encoder_version="v0-test",
+        parent_version=None,
+        status="candidate",
+        architecture="mlp_shallow_v1",
+        window_size=16,
+        stride=4,
+        max_gap_sec=30.0,
+        hidden_dim=8,
+        latent_dim=2,
+        corpus=CorpusStatsV1(
+            corpus_path="/tmp/mood_arc.jsonl",
+            row_count=100,
+            excluded_degenerate=0,
+            time_range_start=datetime(2026, 7, 1, tzinfo=timezone.utc),
+            time_range_end=datetime(2026, 7, 13, tzinfo=timezone.utc),
+        ),
+        training=TrainingStatsV1(
+            epochs=10,
+            final_loss=0.05,
+            held_out_loss=0.06,
+            recon_error_p50=0.04,
+            recon_error_p95=0.09,
+        ),
+        shuffle_baseline_loss=0.5,
+        git_sha="deadbeef",
+        trained_at=datetime(2026, 7, 13, tzinfo=timezone.utc),
+        promoted_at=None,
+    )
+
+
+def test_mood_arc_encoder_manifest_round_trips() -> None:
+    manifest = MoodArcEncoderManifestV1(**_manifest_kwargs())
+    restored = MoodArcEncoderManifestV1.model_validate_json(manifest.model_dump_json())
+    assert restored == manifest
+
+
+def test_mood_arc_encoder_manifest_forbids_unexpected_kwarg() -> None:
+    kwargs = _manifest_kwargs()
+    kwargs["not_a_real_field"] = "nope"
+    with pytest.raises(ValidationError):
+        MoodArcEncoderManifestV1(**kwargs)


### PR DESCRIPTION
## Summary

- Adds `MoodArcEncoderManifestV1` to `orion/schemas/telemetry/mood_arc.py` — the manifest schema for Item 2 (windowed felt-state-trajectory autoencoder) of `docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md`. Sibling to `PhiEncoderManifestV1` (reuses `CorpusStatsV1`/`TrainingStatsV1` as-is from `orion.schemas.telemetry.phi_encoder`, not a subclass — different input/window semantics per spec).
- Fixes a pre-existing gap: `MoodArcCorpusRowV1` (shipped in PR #989) was never registered in `orion/schemas/registry.py`'s `_REGISTRY` or `SCHEMA_REGISTRY`, unlike its phi-encoder siblings. Both `MoodArcCorpusRowV1` and `MoodArcEncoderManifestV1` are now registered.
- Adds `tests/test_mood_arc_encoder_schema.py` covering registry resolution, `kind` string assertions, a `model_dump_json()`/`model_validate_json()` round-trip, and `extra="forbid"` rejection.
- No producer, no consumer, no runtime behavior change — schema-only slice, disk-only artifact, dark by design.

## Outcome moved

Establishes the schema contract Item 2's actual training CLI (`scripts/fit_mood_arc_encoder.py`, follow-up branch `feat/mood-arc-encoder-cli`) is built against, and closes a real, pre-existing registry gap for `MoodArcCorpusRowV1` from PR #989.

## Current architecture

Before this patch, `orion/schemas/telemetry/mood_arc.py` had only `MoodArcCorpusRowV1` (Item 1's per-tick corpus row schema), and neither it nor any mood-arc schema was registered in `orion/schemas/registry.py`.

## Architecture touched

`orion/schemas/telemetry/mood_arc.py`, `orion/schemas/registry.py`, new test file. No service, config, or runtime files.

## Files changed

- `orion/schemas/telemetry/mood_arc.py`: added `MoodArcEncoderManifestV1` class + import of `CorpusStatsV1`/`TrainingStatsV1`
- `orion/schemas/registry.py`: added import line, `_REGISTRY` entries, and `SCHEMA_REGISTRY` entries (with `kind`) for both `MoodArcCorpusRowV1` and `MoodArcEncoderManifestV1`
- `tests/test_mood_arc_encoder_schema.py`: new test file

## Schema / bus / API changes

- Added: `MoodArcEncoderManifestV1` (file-only schema, no bus channel)
- Registered (gap fix, not newly introduced): `MoodArcCorpusRowV1` in `_REGISTRY` / `SCHEMA_REGISTRY` with kind `self.mood_arc_corpus.v1`
- Registered (new): `MoodArcEncoderManifestV1` in `_REGISTRY` / `SCHEMA_REGISTRY` with kind `self.mood_arc_encoder.manifest.v1`
- Compatibility notes: purely additive, no existing schema shape changed

## Env/config changes

None — schema-only patch, no `.env`/`.env_example`/compose/requirements touched.

## Tests run

```text
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest \
  tests/test_mood_arc_encoder_schema.py \
  tests/test_phi_encoder_schema.py \
  services/orion-spark-introspector/tests/test_mood_arc_corpus.py -q
=> 10 passed, 16 warnings (warnings are pre-existing, unrelated protected-namespace deprecation notices)
```

## Evals run

Not applicable — schema-only patch, no model/training component in this item.

## Docker/build/smoke checks

Not applicable — schema-only patch, no runtime/config/Docker changes.

## Known acceptance-check conflict (flagged, not silently swallowed — resolved by a follow-up branch)

```text
/mnt/scripts/Orion-Sapienform/.venv/bin/python scripts/check_inner_state_registry.py
=> inner_state_registry gate FAILED:
   - orion/schemas/registry.py declares 'MoodArcEncoderManifestV1', which matches an
     inner-state keyword ("mood") and has no orion/self_state/inner_state_registry.py entry
```

Root cause: `scripts/check_inner_state_registry.py`'s keyword heuristic (`INNER_STATE_KEYWORDS` includes `"mood"`) flags any name added to `orion/schemas/registry.py`'s flat `_REGISTRY` that matches the keyword list and isn't covered by an entry in `orion/self_state/inner_state_registry.py`'s `REGISTRY` or the script's own `_EXTRA_COVERED_SCHEMA_NAMES` allowlist. `MoodArcCorpusRowV1` is already covered (it's the schema behind `signal_id="mood_arc_corpus.v1"`); `MoodArcEncoderManifestV1` was not, since it had no producer or inner-state-registry entry yet by design at the time of this patch.

This task was explicitly scoped to three files (`mood_arc.py`, `registry.py`, the new test file) and forbade touching `orion/self_state/inner_state_registry.py` — fixing this gate required a real producer to exist first. **Resolved in the follow-up branch `feat/mood-arc-encoder-cli`**, which adds `scripts/fit_mood_arc_encoder.py` (the producer) and the corresponding `mood_arc_encoder.v1` registry entry. `check_inner_state_registry.py` passes on that branch.

## Review findings fixed

Code-review skill not run in a subagent for this patch (scope was schema/registry/test-only, explicitly bounded to 3 files). No material issues found by manual inspection; patterns mirror existing `PhiEncoderManifestV1`/`PhiIntrinsicRewardV1` registrations exactly.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: low
- Concern: `scripts/check_inner_state_registry.py` gate fails on this branch in isolation, until the follow-up producer branch merges.
- Mitigation: resolved by `feat/mood-arc-encoder-cli` (already pushed, depends on this branch merging first). Documented here rather than silently deferred.

## Merge order

This branch has no dependencies and can merge first. `feat/mood-arc-encoder-cli` branches from this branch's tip (not `main`) and should be rebased onto `main` once this merges.
