### PR TITLE
Feat/mood arc encoder cli

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-mood-arc-encoder-cli-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-mood-arc-encoder-cli-pr.md
@@ -1,0 +1,114 @@
+## Summary
+
+- Adds `scripts/fit_mood_arc_encoder.py` (new): trains a shallow MLP autoencoder over windows of the mood-arc corpus (Item 1, PR #989) — `train` subcommand only, offline/manual, no bus wiring, no service.
+- Fixes this session's spike findings baked into the design: Adam optimizer + mean-initialized decoder bias (the spec's vanilla-SGD/zero-init never converged, scored worse than a trivial mean-repeat baseline) and `hidden_dim=32`/`latent_dim=16` defaults (the spec's `hidden_dim=8`/`latent_dim=4` lacked capacity).
+- Adds a two-tier gate: shuffle-baseline floor (hard-gated, unchanged `<0.5` threshold from the spec) plus an AR(1)-surrogate ceiling (diagnostic only, not yet calibrated) — because raw-signal ACF analysis traced most of the corpus's autocorrelation to a known, deliberate decay mechanism (`BIOMETRICS_FIELD_DECAY_RATE=0.92`) that a single shuffle gate could pass without learning anything Orion-specific.
+- Adds a purged/embargoed temporal train/held-out split (`purged_temporal_split`) instead of a naive random window split, plus a block-bootstrap 95% CI on the floor ratio.
+- Extends `MoodArcEncoderManifestV1` with 5 new `Optional[...] = None` fields for this methodology (kept optional so the sibling schema PR's existing `test_mood_arc_encoder_schema.py` still passes unmodified).
+- Registers `mood_arc_encoder.v1` in `orion/self_state/inner_state_registry.py`, closing the exact gap the sibling schema PR (`feat/mood-arc-encoder-manifest-schema`) flagged and correctly declined to fill (no producer existed until this patch).
+- Updates both `services/orion-spark-introspector/README.md` and `orion/self_state/README.md` to describe what was actually built (including deviations from the original spec's defaults/gate design).
+
+## Outcome moved
+
+`scripts/check_inner_state_registry.py` now passes (was failing before this patch — `MoodArcEncoderManifestV1` matched the "mood" keyword heuristic with no registry entry). A real, working `train` CLI now exists for roadmap item 2, verified against the live 20,996-row corpus.
+
+## Current architecture
+
+Before this patch, Item 2 of `docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md` was design-only: a schema (`MoodArcEncoderManifestV1`, sibling branch) with no producer, and `check_inner_state_registry.py` failing as a result. No windowing, training, or gating code existed.
+
+## Architecture touched
+
+`scripts/` (new training CLI), `orion/schemas/telemetry/mood_arc.py` (schema extension), `orion/self_state/inner_state_registry.py` (new entry), two service/self-state READMEs, one new test file. No bus channels, no service runtime, no config/env.
+
+## Real training run (live corpus, not synthetic)
+
+```bash
+python scripts/fit_mood_arc_encoder.py train \
+  --corpus /mnt/telemetry/mood_arc/corpus/mood_arc.jsonl \
+  --hidden-dim 32 --latent-dim 16 --epochs 500 --lr 0.003 \
+  --purge-gap-windows 6 --out /tmp/mood-arc-encoders/v1-candidate-real2
+```
+
+- `rows`: 20,996 (spanning `2026-07-13T06:26:29Z` onward)
+- `windows_total`: 1387 (`windows_train`: 1173, `windows_held_out`: 208)
+- **`floor_ratio`: 0.439** (need `< 0.5`) → **`floor_pass`: True**
+- **`floor_ratio_ci_low`/`ci_high`: 0.394 / 0.485** (95% block-bootstrap CI, entirely under the 0.5 threshold — a robust pass, not a borderline one)
+- `ceiling_ratio`: 0.785 (diagnostic only, not gated — real loss beats the AR(1)-surrogate null by ~22%)
+- Channel variance reported (not gated): `coherence=0.00094`, `energy=0.00237`, `novelty=0.1196`, `valence=0.098` — coherence/energy are real but low-variance; no threshold invented for this.
+- Runtime: ~44s on the full live corpus.
+
+## Files changed
+
+- `scripts/fit_mood_arc_encoder.py` (new, 793 lines): `train` CLI, windowing, purged split, Adam-trained autoencoder, two-tier gate, AR(1) surrogate, block bootstrap, `compute_window_probes`.
+- `tests/test_mood_arc_encoder_fit_script.py` (new): end-to-end train run on synthetic periodic-pattern corpus (floor gate passes), negative control (untrained weights on the *same structured* corpus fail the floor gate), `purged_temporal_split` boundary/exclusion/error tests, `build_windows` gap-break test (real recorded 8.09s gap vs. default `max_gap_sec=6.0`), `generate_ar1_surrogate_windows` sanity test.
+- `orion/schemas/telemetry/mood_arc.py`: `MoodArcEncoderManifestV1` gains `purge_gap_windows`, `ar1_surrogate_loss`, `ceiling_ratio`, `floor_ratio_ci_low`, `floor_ratio_ci_high` (all `Optional[...] = None`, additive, `extra="forbid"` unchanged).
+- `orion/self_state/inner_state_registry.py`: new `mood_arc_encoder.v1` entry + import.
+- `services/orion-spark-introspector/README.md`, `orion/self_state/README.md`: document what was actually built, including deviations from the original spec doc.
+
+## Schema / bus / API changes
+
+- Added: 5 optional fields on `MoodArcEncoderManifestV1` (see above).
+- Removed: none.
+- Renamed: none.
+- Behavior changed: none for existing consumers — additive only.
+- Compatibility notes: existing `test_mood_arc_encoder_schema.py`'s manifest fixtures still construct valid manifests since new fields default to `None`.
+
+## Env/config changes
+
+None. This is a disk-only offline script; no `.env`/`.env_example`/compose/requirements touched.
+
+## Tests run
+
+```text
+.venv/bin/python -m pytest tests/test_mood_arc_encoder_fit_script.py tests/test_mood_arc_encoder_schema.py services/orion-spark-introspector/tests/test_mood_arc_corpus.py -q
+=> 17 passed
+.venv/bin/python scripts/check_inner_state_registry.py
+=> inner_state_registry gate OK (12 entries checked)
+.venv/bin/python -c "import yaml"
+=> OK
+```
+
+## Evals run
+
+The real live-corpus training run above (`floor_ratio=0.439`, `floor_pass=True`, CI `[0.394, 0.485]`) is this patch's eval — there's no separate `evals/` harness for this offline script (mirrors `fit_phi_encoder.py`, which also has no dedicated eval harness beyond its own promote gate).
+
+## Docker/build/smoke checks
+
+Not applicable — no runtime/deployment files touched.
+
+## Review findings fixed
+
+- Finding: `test_negative_control_untrained_weights_fail_floor_gate` used pure i.i.d.-noise windows with no temporal structure, so shuffling destroyed nothing and the test couldn't actually distinguish an untrained from a trained encoder (any model scored `floor_ratio≈1.0` on it).
+  - Fix: rewrote the test to use the same structured (real periodic-pattern) synthetic corpus as the end-to-end pass test, so there is real structure an untrained model fails to exploit.
+  - Evidence: `tests/test_mood_arc_encoder_fit_script.py::test_negative_control_untrained_weights_fail_floor_gate` now passes against structured data.
+- Finding: the AR(1) null-model's training-only cutoff (`cutoff_ts`) was derived from the last training window's *end* timestamp, which — for 50%-overlapping windows — could still overlap the first held-out window's raw ticks if `--purge-gap-windows` were overridden to a small value (e.g. `0`), leaking held-out data into `fit_ar1_per_channel`'s fit regardless of the configured purge size.
+  - Fix: window construction now tracks each window's start timestamp too; `cmd_train` derives the AR(1) cutoff strictly from the first held-out window's own start timestamp, correct for any `--purge-gap-windows` value including `0`.
+  - Evidence: `cutoff_ts = start_ts[held_start]` in `cmd_train`; full test suite + live run re-verified after the fix.
+- Finding: `_per_window_losses` (called every epoch for held-loss tracking, plus several more times per training run) always computed a full backward pass even though gradients were never used there, roughly doubling held-set evaluation cost.
+  - Fix: added a forward-only `recon_loss()`; all loss-only call sites switched to it, `recon_loss_and_grads` reserved for the actual training step.
+  - Evidence: real live-corpus run time dropped from ~53s to ~44s after the fix; all tests still pass.
+- Noted, not fixed (out of scope per this task's hard constraints): `_git_sha()` and `_load_jsonl()` in the new script are near-duplicates of the same helpers in `scripts/fit_phi_encoder.py`. Extracting a shared helper would require touching `fit_phi_encoder.py`, explicitly forbidden as a read-only reference file for this task. Flagged for a future cross-cutting cleanup.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+## Risks / concerns
+
+- Severity: Low
+- Concern: `_git_sha()`/`_load_jsonl()` duplication with `scripts/fit_phi_encoder.py`.
+- Mitigation: flagged above; a future patch touching both scripts could extract these into `orion/telemetry/corpus_rotation.py` or a new shared module.
+- Severity: Low
+- Concern: `ceiling_ratio` has no calibrated pass/fail threshold yet — by design, not an oversight, but means it can't yet catch a regression toward "merely re-learning the known decay filter" on its own.
+- Mitigation: recorded in every manifest going forward; calibrate once multiple training runs exist (noted in schema docstring and both READMEs).
+
+## Merge order
+
+This branch is built on top of the not-yet-merged `feat/mood-arc-encoder-manifest-schema` (branches from its tip commit, not `main`). **Merge that PR first**, then this one — rebase onto `main` if needed once the schema PR lands.
+
+## PR link
+
+`gh` is unauthenticated in this environment — open manually at:
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/mood-arc-encoder-cli

--- a/orion/schemas/telemetry/mood_arc.py
+++ b/orion/schemas/telemetry/mood_arc.py
@@ -52,6 +52,23 @@ class MoodArcEncoderManifestV1(BaseModel):
     """Item 2's windowed felt-state-trajectory encoder manifest -- dark
     artifact, disk-only, no cognition consumer yet (see roadmap item 2,
     docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md).
+
+    2026-07-13 methodology addition (scripts/fit_mood_arc_encoder.py, same
+    session as this manifest's initial fields): the spec's original single
+    shuffle-gate design was found to be too weak on its own -- the corpus's
+    real autocorrelation is largely explained by a known, deliberate
+    leaky-integrator decay mechanism (BIOMETRICS_FIELD_DECAY_RATE=0.92 in
+    services/orion-field-digester/app/digestion/decay.py), so an encoder can
+    pass the shuffle floor purely by learning that already-known mechanism
+    without capturing anything specific to Orion's actual trajectories. The
+    fields below extend the manifest with a second, non-gating "ceiling"
+    comparison against a matched-autocorrelation AR(1) surrogate, plus a
+    purged/embargoed temporal train/held-out split (naive random window
+    sampling leaks given ~10-15 tick autocorrelation from 50%-overlapping
+    windows) and a block-bootstrap confidence interval on the floor ratio.
+    None of this is in the original written spec doc -- it is stricter than
+    what item 2 originally asked for, added after empirical spike work found
+    the original single-gate design passed for the wrong reason.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -69,6 +86,38 @@ class MoodArcEncoderManifestV1(BaseModel):
     corpus: CorpusStatsV1        # reused as-is from orion.schemas.telemetry.phi_encoder
     training: TrainingStatsV1    # reused as-is
     shuffle_baseline_loss: float # held_out_loss with rows shuffled within-window (see gate)
+    # purge_gap_windows: number of windows dropped as an embargo zone between
+    # the train/held-out temporal boundary (see purged_temporal_split()) --
+    # not in the original spec, added because a held-out window merely
+    # adjacent to a training window is still autocorrelation-leaked even
+    # with zero literal tick overlap (measured ACF stays nonzero out to lag
+    # ~10-15 ticks, ~20-30s). Optional/None only for manifests written before
+    # this methodology addition -- scripts/fit_mood_arc_encoder.py always
+    # populates a real value; None is never fabricated as 0 (0 would falsely
+    # claim "no purge zone was used", a real and different config choice).
+    purge_gap_windows: Optional[int] = None
+    # ar1_surrogate_loss: held-out reconstruction loss against synthetic
+    # windows generated from a per-channel AR(1) null model fit on the
+    # training portion only (see generate_ar1_surrogate_windows()) -- the
+    # "this is already explained by the known decay filter" null. None means
+    # not computed for this manifest, never a fabricated 0.0.
+    ar1_surrogate_loss: Optional[float] = None
+    # ceiling_ratio: real_held_loss / ar1_surrogate_loss. Diagnostic and
+    # exploratory ONLY, not a hard gate -- there is no calibrated pass/fail
+    # threshold for this yet across multiple training runs. Recorded here so
+    # future runs can be compared once enough runs exist to calibrate one.
+    # Do not read a low/high ceiling_ratio as pass/fail; only floor_ratio's
+    # derived floor_pass (see two_tier_gate()) is a hard gate today. None
+    # means not computed for this manifest, never a fabricated 0.0.
+    ceiling_ratio: Optional[float] = None
+    # floor_ratio_ci_low / floor_ratio_ci_high: 95% block-bootstrap
+    # confidence interval on real_held_loss / shuffle_baseline_loss
+    # (block_bootstrap_ratio_ci()), resampling contiguous blocks of
+    # held-out windows rather than individual windows (they're
+    # autocorrelated, so naive i.i.d. bootstrap would overstate confidence).
+    # None means not computed for this manifest, never a fabricated 0.0.
+    floor_ratio_ci_low: Optional[float] = None
+    floor_ratio_ci_high: Optional[float] = None
     git_sha: str
     trained_at: datetime
     promoted_at: Optional[datetime] = None

--- a/orion/self_state/README.md
+++ b/orion/self_state/README.md
@@ -71,17 +71,38 @@ of four composition statuses:
   record separately — this registry makes the fact visible, it doesn't
   force the answer).
 - `REHEARSAL` — computed, verified to reach no cognition consumer at all.
-  Three current entries: the L7–L11 ladder; `mood_arc_corpus.v1`
+  Four current entries: the L7–L11 ladder; `mood_arc_corpus.v1`
   (2026-07-13) — an append-only training-data sink for a not-yet-built
   windowed felt-state autoencoder
   (`docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md`),
-  deliberately dark until real hours of data accumulate; and
-  `chat_stance_disposition` (2026-07-13) — the Thought proceed/defer/refuse
-  decision per unified-turn chat turn, real and correctly computed but
-  dead-ends at the raw `active_chat_session` ledger row today. A composition
-  route into `SelfStateV1.social_pressure` was considered and rejected
-  (that dimension is already excluded from φ's live trainable feature set —
-  see `docs/superpowers/specs/2026-07-13-stance-disposition-inner-state-path.md`
+  deliberately dark until real hours of data accumulate; `mood_arc_encoder.v1`
+  (2026-07-13, same day, roadmap item 2 now built) —
+  `scripts/fit_mood_arc_encoder.py` trains a windowed autoencoder over
+  `mood_arc_corpus.v1` rows and writes a dark, disk-only
+  `MoodArcEncoderManifestV1` artifact triad (`manifest.json`/`weights.npz`/
+  `probes.json`); no bus publish, no cognition consumer, same REHEARSAL
+  reasoning as its corpus sibling. That same session found the spec's
+  original single shuffle-baseline gate too weak on its own — this corpus's
+  real autocorrelation is largely explained by a known, deliberate
+  leaky-integrator decay mechanism (`BIOMETRICS_FIELD_DECAY_RATE=0.92`,
+  `services/orion-field-digester/app/digestion/decay.py`), so an encoder
+  could pass the original gate purely by learning that already-known filter.
+  Addressed with a two-tier gate (a shuffle floor, hard-gated, unchanged
+  threshold from the spec; an AR(1)-surrogate ceiling, diagnostic-only, not
+  yet calibrated) plus a purged/embargoed temporal train/held-out split
+  (naive random window sampling leaks given measured autocorrelation out to
+  lag ~10-15 ticks across 50%-overlapping windows) and a block-bootstrap
+  confidence interval on the floor ratio — none of this is in the original
+  written spec doc, it is stricter than what item 2 originally asked for;
+  see `MoodArcEncoderManifestV1`'s docstring
+  (`orion/schemas/telemetry/mood_arc.py`) for the field-level rationale so a
+  future reader doesn't have to re-derive it; and `chat_stance_disposition`
+  (2026-07-13) — the Thought proceed/defer/refuse decision per unified-turn
+  chat turn, real and correctly computed but dead-ends at the raw
+  `active_chat_session` ledger row today. A composition route into
+  `SelfStateV1.social_pressure` was considered and rejected (that dimension
+  is already excluded from φ's live trainable feature set — see
+  `docs/superpowers/specs/2026-07-13-stance-disposition-inner-state-path.md`
   for the full trace and the candidate paths forward, none chosen yet).
 
 This was built because the same failure mode — a real signal silently

--- a/orion/self_state/inner_state_registry.py
+++ b/orion/self_state/inner_state_registry.py
@@ -34,7 +34,7 @@ from orion.schemas.field_attention_frame import FieldAttentionFrameV1
 from orion.schemas.field_state import FieldStateV1
 from orion.schemas.self_state import SelfStateV1
 from orion.schemas.telemetry.biometrics import BiometricsClusterV1
-from orion.schemas.telemetry.mood_arc import MoodArcCorpusRowV1
+from orion.schemas.telemetry.mood_arc import MoodArcCorpusRowV1, MoodArcEncoderManifestV1
 from orion.schemas.telemetry.phi_encoder import PhiIntrinsicRewardV1
 
 
@@ -315,6 +315,52 @@ REGISTRY: tuple[InnerStateSignal, ...] = (
             "roadmap spec's own estimate). Revisit if/when this corpus is "
             "actually used for training and the shared thresholds turn out "
             "wrong for its cadence (found by code review, 2026-07-13)."
+        ),
+    ),
+    InnerStateSignal(
+        signal_id="mood_arc_encoder.v1",
+        schema=MoodArcEncoderManifestV1,
+        producer_service="orion-spark-introspector",
+        cadence=Cadence.OFFLINE_TRAINED,
+        composition_status=CompositionStatus.REHEARSAL,
+        cognition_consumers=(),
+        notes=(
+            "Item 2 of docs/superpowers/specs/2026-07-13-felt-state-arc-"
+            "roadmap-spec.md -- the windowed felt-state-trajectory "
+            "autoencoder trained by scripts/fit_mood_arc_encoder.py over "
+            "mood_arc_corpus.v1 rows. A dark, disk-only training artifact "
+            "(manifest.json/weights.npz/probes.json under --out): no bus "
+            "publish, no service wiring, no cognition consumer by design -- "
+            "same REHEARSAL precedent as mood_arc_corpus.v1 and "
+            "l7_l11_ladder, not a gap to close. This entry is the exact "
+            "follow-up the sibling schema PR "
+            "(feat/mood-arc-encoder-manifest-schema, MoodArcEncoderManifestV1 "
+            "registered in orion/schemas/registry.py) flagged and correctly "
+            "declined to add itself, since it had no producer yet -- this "
+            "patch is the producer, so the registry gap is now closed. "
+            "Methodology note (2026-07-13, same session): the spec's "
+            "original single shuffle-baseline gate and its "
+            "hidden_dim=8/latent_dim=4 defaults both failed empirically -- "
+            "vanilla-SGD/zero-init training never converged and scored "
+            "worse than a trivial mean-repeat baseline. Fixed via "
+            "mean-initialized decoder bias + Adam (converges in ~80-120 "
+            "epochs) and hidden_dim=32/latent_dim=16 (latent_dim=4 lacked "
+            "capacity). Separately, raw-signal ACF analysis traced the "
+            "corpus's real autocorrelation to a known, deliberate "
+            "leaky-integrator decay mechanism "
+            "(BIOMETRICS_FIELD_DECAY_RATE=0.92, "
+            "services/orion-field-digester/app/digestion/decay.py) -- so "
+            "the original single shuffle gate could pass purely by learning "
+            "that already-known filter, not anything Orion-specific. "
+            "Addressed with a two-tier gate (shuffle floor, hard-gated per "
+            "spec; AR(1)-surrogate ceiling, diagnostic-only, not yet "
+            "calibrated) and a purged/embargoed temporal train/held-out "
+            "split (naive random window sampling leaks given ~10-15 tick "
+            "autocorrelation from 50%-overlapping windows) -- see "
+            "MoodArcEncoderManifestV1's docstring for the full field-level "
+            "rationale. None of this two-tier/purged-split methodology is "
+            "in the original written spec doc; it is stricter than what "
+            "was originally asked for."
         ),
     ),
     InnerStateSignal(

--- a/scripts/fit_mood_arc_encoder.py
+++ b/scripts/fit_mood_arc_encoder.py
@@ -1,0 +1,824 @@
+#!/usr/bin/env python3
+"""Offline mood-arc windowed felt-state-trajectory autoencoder: train subcommand.
+
+Item 2 of docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md.
+Trains a shallow MLP autoencoder over flattened windows of item 1's
+mood_arc_corpus.v1 JSONL corpus (coherence/energy/novelty/valence per tick).
+Artifacts: manifest.json, weights.npz, probes.json under --out. Dark
+deployment -- disk-only, no bus publish, no cognition consumer.
+
+This file mirrors scripts/fit_phi_encoder.py's harness shape (corpus gates,
+Adam-free-but-analogous training loop, write_artifacts triad,
+_percentile/_pearson reuse) but is NOT a copy: the phi script's
+_init_weights/_forward/_losses/_apply_grads carry a vestigial phi-prediction
+head with no meaning here, and use plain-SGD/zero-init, which a same-session
+spike found to fail to converge on this problem (scored worse than a
+trivial "repeat the window's own mean" baseline). This script's
+init_weights/forward/recon_loss_and_grads are a dedicated, phi-head-free
+rewrite using Adam and a mean-initialized decoder bias -- the fix.
+
+A same-session spike also found the original spec's single shuffle-baseline
+gate is too weak on its own: this corpus's real autocorrelation is largely
+explained by a known, deliberate leaky-integrator decay mechanism
+(BIOMETRICS_FIELD_DECAY_RATE=0.92,
+services/orion-field-digester/app/digestion/decay.py), so an encoder can
+pass the shuffle floor purely by learning that already-known filter. This
+script adds a second, non-gating "ceiling" comparison against a
+matched-autocorrelation AR(1) surrogate, plus a purged/embargoed temporal
+train/held-out split (naive random window sampling leaks given ~10-15 tick
+autocorrelation from 50%-overlapping windows) and a block-bootstrap
+confidence interval on the floor ratio. None of this is in the original
+written spec doc -- see MoodArcEncoderManifestV1's docstring for the
+field-level rationale.
+
+Only `train` is implemented here. `promote`/`infer` are later roadmap items
+(3+), not built by this patch.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/fit_mood_arc_encoder.py` puts scripts/ on
+# sys.path[0], which shadows stdlib `platform` via scripts/platform/ and
+# breaks pydantic (same issue documented in scripts/fit_phi_encoder.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import numpy as np
+
+from orion.schemas.telemetry.mood_arc import MoodArcCorpusRowV1, MoodArcEncoderManifestV1
+from orion.schemas.telemetry.phi_encoder import CorpusStatsV1, TrainingStatsV1
+from orion.telemetry.corpus_rotation import resolve_rotated_corpus_files
+
+# Reused as-is from fit_phi_encoder.py -- these operate on plain np.ndarrays
+# and are genuinely shape-agnostic (percentile-of-a-list, Pearson-of-two-
+# vectors). Everything else in that file (_init_weights/_forward/_losses/
+# _apply_grads) carries phi-specific baggage (a vestigial phi-prediction
+# head, plain-SGD/zero-init) and is deliberately NOT reused -- see module
+# docstring.
+from scripts.fit_phi_encoder import _pearson, _percentile  # noqa: E402
+
+ARCHITECTURE = "mlp_shallow_v1"  # same architecture family as the phi encoder
+FIELDS: tuple[str, ...] = ("coherence", "energy", "novelty", "valence")
+
+# Evidence-based defaults from this session's spike (NOT the original spec's
+# hidden_dim=8/latent_dim=4, which failed to beat even a mean-repeat
+# baseline -- see module docstring).
+DEFAULT_WINDOW_SIZE = 30
+DEFAULT_STRIDE = 15
+DEFAULT_MAX_GAP_SEC = 6.0
+DEFAULT_HIDDEN_DIM = 32
+DEFAULT_LATENT_DIM = 16
+DEFAULT_EPOCHS = 500
+DEFAULT_LR = 0.003
+DEFAULT_HELD_OUT_FRAC = 0.15
+DEFAULT_PURGE_GAP_WINDOWS = 6
+DEFAULT_BOOTSTRAP_BLOCK_SIZE = 10
+DEFAULT_BOOTSTRAP_N = 200
+DEFAULT_MIN_HOURS = 6.0
+DEFAULT_MIN_ROWS = 500
+DEFAULT_BATCH_SIZE = 32
+
+# Hard gate threshold, unchanged from the original spec: real held-out recon
+# loss must beat the shuffle baseline by at least 2x.
+FLOOR_MAX_RATIO = 0.5
+
+
+def _git_sha() -> str:
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode == 0:
+            return proc.stdout.strip()
+    except OSError:
+        pass
+    return "unknown"
+
+
+def _load_jsonl(path: Path) -> list[MoodArcCorpusRowV1]:
+    """Rotation-aware corpus load, mirroring fit_phi_encoder.py's own
+    pattern -- InnerStateCorpusSink (the class backing this corpus too)
+    rotates at CORPUS_SINK_MAX_BYTES, so reading only `path` would silently
+    see just the post-rotation slice once the active file first rotates."""
+    rows: list[MoodArcCorpusRowV1] = []
+    for file in resolve_rotated_corpus_files(path):
+        for line_no, line in enumerate(file.read_text(encoding="utf-8").splitlines(), start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                rows.append(MoodArcCorpusRowV1.model_validate_json(text))
+            except Exception as exc:  # noqa: BLE001 -- corpus loader should skip bad lines with context
+                raise ValueError(f"invalid JSONL at {file}:{line_no}: {exc}") from exc
+    rows.sort(key=lambda r: r.generated_at)
+    return rows
+
+
+def _hours_span(rows: list[MoodArcCorpusRowV1]) -> float:
+    if not rows:
+        return 0.0
+    start = min(r.generated_at for r in rows)
+    end = max(r.generated_at for r in rows)
+    return (end - start).total_seconds() / 3600.0
+
+
+def check_corpus_gates(rows: list[MoodArcCorpusRowV1], *, min_rows: int, min_hours: float) -> None:
+    """min_rows/min_hours are HARD gates (raise SystemExit), matching
+    fit_phi_encoder.py's check_corpus_gates. Per-channel variance is
+    reported separately (see report_channel_variance) but NOT hard-gated --
+    unlike phi's SEEDV4_* variance constants (empirically tuned over time),
+    there is no calibrated "too flat" threshold yet for this 4-channel
+    signal. coherence/energy are known (this session) to have real but low
+    variance in the current corpus; inventing a threshold here would be
+    exactly the kind of ungrounded number CLAUDE.md's rules warn against."""
+    if len(rows) < min_rows:
+        raise SystemExit(f"corpus gate failed: min_rows={min_rows} got={len(rows)}")
+    hours = _hours_span(rows)
+    if hours < min_hours:
+        raise SystemExit(f"corpus gate failed: min_hours={min_hours} got={hours:.3f}")
+
+
+def report_channel_variance(rows: list[MoodArcCorpusRowV1]) -> dict[str, float]:
+    """Reported, not gated -- see check_corpus_gates docstring."""
+    if not rows:
+        return {f: 0.0 for f in FIELDS}
+    matrix = np.asarray([[getattr(r, f) for f in FIELDS] for r in rows], dtype=np.float64)
+    variances = {f: float(np.var(matrix[:, i])) for i, f in enumerate(FIELDS)}
+    for f, v in variances.items():
+        print(f"channel variance: {f}={v:.6f}")
+    return variances
+
+
+def _build_windows_with_span(
+    rows: list[MoodArcCorpusRowV1],
+    *,
+    window_size: int,
+    stride: int,
+    max_gap_sec: float,
+) -> list[tuple[np.ndarray, datetime, datetime]]:
+    """Internal: build_windows() plus each window's (start_ts, end_ts) --
+    the generated_at of its first and last row. Neither timestamp is part
+    of build_windows()'s public (spec-mandated) return shape, but cmd_train
+    needs both: end_ts to report corpus stats, and start_ts to derive a
+    leakage-safe cutoff for fit_ar1_per_channel's training-only rows that
+    holds regardless of --purge-gap-windows (see cmd_train) rather than
+    re-deriving the same run/stride math twice."""
+    triples: list[tuple[np.ndarray, datetime, datetime]] = []
+    if not rows:
+        return triples
+
+    runs: list[list[MoodArcCorpusRowV1]] = []
+    current_run: list[MoodArcCorpusRowV1] = [rows[0]]
+    for prev, row in zip(rows, rows[1:]):
+        gap = (row.generated_at - prev.generated_at).total_seconds()
+        if gap > max_gap_sec:
+            runs.append(current_run)
+            current_run = [row]
+        else:
+            current_run.append(row)
+    runs.append(current_run)
+
+    n_fields = len(FIELDS)
+    for run in runs:
+        if len(run) < window_size:
+            continue
+        for start in range(0, len(run) - window_size + 1, stride):
+            chunk = run[start : start + window_size]
+            vec = np.empty(window_size * n_fields, dtype=np.float64)
+            for i, r in enumerate(chunk):
+                base = i * n_fields
+                vec[base + 0] = r.coherence
+                vec[base + 1] = r.energy
+                vec[base + 2] = r.novelty
+                vec[base + 3] = r.valence
+            triples.append((vec, chunk[0].generated_at, chunk[-1].generated_at))
+    return triples
+
+
+def build_windows(
+    rows: list[MoodArcCorpusRowV1],
+    *,
+    window_size: int,
+    stride: int,
+    max_gap_sec: float,
+) -> list[np.ndarray]:
+    """Flatten contiguous runs of `rows` (strict timestamp order) into
+    `(window_size*4,)` float vectors:
+    `[c_0,e_0,n_0,v_0, c_1,e_1,n_1,v_1, ..., c_{W-1},e_{W-1},n_{W-1},v_{W-1}]`.
+    A gap between consecutive rows' timestamps exceeding `max_gap_sec` breaks
+    the run -- no window is built across it. Returns windows in timestamp
+    order."""
+    return [
+        w
+        for w, _, _ in _build_windows_with_span(
+            rows, window_size=window_size, stride=stride, max_gap_sec=max_gap_sec
+        )
+    ]
+
+
+def _purge_split_indices(n: int, held_out_frac: float, purge_gap_windows: int) -> tuple[int, int]:
+    held_n = max(1, int(round(n * held_out_frac)))
+    held_start = n - held_n
+    purge_start = held_start - purge_gap_windows
+    return purge_start, held_start
+
+
+def purged_temporal_split(
+    windows: list[np.ndarray],
+    *,
+    held_out_frac: float = DEFAULT_HELD_OUT_FRAC,
+    purge_gap_windows: int = DEFAULT_PURGE_GAP_WINDOWS,
+) -> tuple[np.ndarray, np.ndarray]:
+    """windows must already be in strict temporal order (build_windows
+    guarantees this). Held-out = the LAST held_out_frac windows by time --
+    NOT a random sample, since random sampling over 50%-overlapping windows
+    leaks (found this session). purge_gap_windows windows immediately before
+    the held-out boundary are DROPPED entirely (neither train nor held-out)
+    -- an embargo zone. Default purge_gap_windows=6 is a conservative ~180s
+    buffer (stride=15 ticks=~30s per window-step * 6), well beyond the
+    measured ~30-60s decorrelation horizon (ACF stays nonzero out to lag
+    ~10-15 ticks this session) -- so even a held-out window immediately
+    after the embargo zone is not meaningfully autocorrelated with the last
+    training window.
+
+    Returns (train_windows, held_out_windows) as stacked np.ndarray
+    matrices. Raises ValueError (not a silent empty array) if there aren't
+    enough windows to produce a nonempty train set and held-out set after
+    purging."""
+    n = len(windows)
+    if n == 0:
+        raise ValueError("purged_temporal_split: no windows to split")
+
+    purge_start, held_start = _purge_split_indices(n, held_out_frac, purge_gap_windows)
+    train_windows = windows[: max(0, purge_start)]
+    held_windows = windows[held_start:]
+
+    if not train_windows:
+        raise ValueError(
+            f"purged_temporal_split: no training windows remain after purge "
+            f"(n={n}, held_out_frac={held_out_frac}, purge_gap_windows={purge_gap_windows}); "
+            "reduce purge_gap_windows/held_out_frac or gather more corpus"
+        )
+    if not held_windows:
+        raise ValueError(
+            f"purged_temporal_split: no held-out windows (n={n}, held_out_frac={held_out_frac})"
+        )
+    return np.stack(train_windows, axis=0), np.stack(held_windows, axis=0)
+
+
+def init_weights(d_in: int, hidden_dim: int, latent_dim: int, seed: int, data_mean: np.ndarray) -> dict[str, np.ndarray]:
+    """W1,b1 (d_in->hidden, ReLU), W2,b2 (hidden->latent), W3,b3 (latent->d_in).
+
+    b3 is initialized to data_mean (NOT zero) so training starts at the
+    mean-baseline instead of having to learn it from scratch -- this was the
+    root cause of this session's initial training failure (vanilla-SGD,
+    zero-init scored worse than a trivial mean-repeat baseline because it
+    never got anywhere close to it). W3 is scaled down (0.1x W1/W2's init
+    scale) so its near-zero random component doesn't immediately fight the
+    mean-start."""
+    rng = np.random.default_rng(seed)
+    scale = 0.05
+    return {
+        "W1": (rng.standard_normal((d_in, hidden_dim)) * scale).astype(np.float64),
+        "b1": np.zeros(hidden_dim, dtype=np.float64),
+        "W2": (rng.standard_normal((hidden_dim, latent_dim)) * scale).astype(np.float64),
+        "b2": np.zeros(latent_dim, dtype=np.float64),
+        "W3": (rng.standard_normal((latent_dim, d_in)) * scale * 0.1).astype(np.float64),
+        "b3": np.asarray(data_mean, dtype=np.float64).copy(),
+    }
+
+
+def forward(x: np.ndarray, weights: dict[str, np.ndarray]) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Linear -> ReLU -> linear bottleneck -> linear decoder. No phi head."""
+    h_pre = x @ weights["W1"] + weights["b1"]
+    h = np.maximum(0.0, h_pre)
+    z = h @ weights["W2"] + weights["b2"]
+    xhat = z @ weights["W3"] + weights["b3"]
+    return h_pre, h, z, xhat
+
+
+def recon_loss(x: np.ndarray, weights: dict[str, np.ndarray]) -> float:
+    """Forward-only MSE reconstruction loss, no backward pass. Used
+    everywhere a caller only wants the loss number (held-set eval, gate
+    comparisons, probes) -- found by code review (2026-07-13) that
+    reusing recon_loss_and_grads() for those call sites was computing a
+    full, unused backward pass (6 outer-product gradient tensors) on every
+    held-set evaluation, roughly doubling their cost for no reason."""
+    _, _, _, xhat = forward(x, weights)
+    recon = xhat - x
+    return float(np.mean(recon**2))
+
+
+def recon_loss_and_grads(x: np.ndarray, weights: dict[str, np.ndarray]) -> tuple[float, dict[str, np.ndarray]]:
+    """Pure MSE reconstruction loss + backprop, no phi term. Only used where
+    gradients are actually consumed (the training step) -- see recon_loss()
+    for the forward-only variant used everywhere else."""
+    h_pre, h, z, xhat = forward(x, weights)
+    recon = xhat - x
+    loss = float(np.mean(recon**2))
+
+    d_xhat = (2.0 / x.size) * recon
+    d_W3 = np.outer(z, d_xhat)
+    d_b3 = d_xhat
+
+    d_z = d_xhat @ weights["W3"].T
+    d_W2 = np.outer(h, d_z)
+    d_b2 = d_z
+
+    d_h = d_z @ weights["W2"].T
+    relu_mask = (h_pre > 0.0).astype(np.float64)
+    d_h_pre = d_h * relu_mask
+    d_W1 = np.outer(x, d_h_pre)
+    d_b1 = d_h_pre
+
+    grads = {"W1": d_W1, "b1": d_b1, "W2": d_W2, "b2": d_b2, "W3": d_W3, "b3": d_b3}
+    return loss, grads
+
+
+class Adam:
+    """Numpy-only Adam optimizer, no phi-specific baggage. Fixes the
+    vanilla-SGD training failure this session's spike found -- SGD+zero-init
+    never converged on this problem; Adam+mean-init converges in ~80-120
+    epochs."""
+
+    def __init__(
+        self,
+        weights: dict[str, np.ndarray],
+        lr: float = DEFAULT_LR,
+        beta1: float = 0.9,
+        beta2: float = 0.999,
+        eps: float = 1e-8,
+    ) -> None:
+        self.lr = lr
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.eps = eps
+        self.t = 0
+        self.m = {k: np.zeros_like(v) for k, v in weights.items()}
+        self.v = {k: np.zeros_like(v) for k, v in weights.items()}
+
+    def step(self, weights: dict[str, np.ndarray], grads: dict[str, np.ndarray]) -> None:
+        self.t += 1
+        bias1 = 1.0 - self.beta1**self.t
+        bias2 = 1.0 - self.beta2**self.t
+        for key in weights:
+            g = grads[key]
+            self.m[key] = self.beta1 * self.m[key] + (1.0 - self.beta1) * g
+            self.v[key] = self.beta2 * self.v[key] + (1.0 - self.beta2) * (g * g)
+            m_hat = self.m[key] / bias1
+            v_hat = self.v[key] / bias2
+            weights[key] = weights[key] - self.lr * m_hat / (np.sqrt(v_hat) + self.eps)
+
+
+def _per_window_losses(matrix: np.ndarray, weights: dict[str, np.ndarray]) -> np.ndarray:
+    if matrix.shape[0] == 0:
+        return np.zeros(0, dtype=np.float64)
+    return np.asarray([recon_loss(row, weights) for row in matrix], dtype=np.float64)
+
+
+def train_autoencoder(
+    train_matrix: np.ndarray,
+    held_matrix: np.ndarray,
+    *,
+    hidden_dim: int,
+    latent_dim: int,
+    epochs: int,
+    lr: float,
+    seed: int,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+) -> tuple[dict[str, np.ndarray], TrainingStatsV1]:
+    if train_matrix.shape[0] == 0:
+        raise SystemExit("train: no training windows after purged temporal split")
+
+    d_in = train_matrix.shape[1]
+    data_mean = np.mean(train_matrix, axis=0)
+    weights = init_weights(d_in, hidden_dim, latent_dim, seed, data_mean)
+    optimizer = Adam(weights, lr=lr)
+    rng = np.random.default_rng(seed)
+
+    n_train = train_matrix.shape[0]
+    best_held = float("inf")
+    best_weights = {k: v.copy() for k, v in weights.items()}
+    final_epoch = 0
+
+    for epoch in range(1, epochs + 1):
+        final_epoch = epoch
+        perm = rng.permutation(n_train)
+        for start in range(0, n_train, batch_size):
+            idx = perm[start : start + batch_size]
+            batch = train_matrix[idx]
+            accum = {k: np.zeros_like(v) for k, v in weights.items()}
+            for row in batch:
+                _, grads = recon_loss_and_grads(row, weights)
+                for k in accum:
+                    accum[k] += grads[k]
+            scale = 1.0 / max(1, len(batch))
+            for k in accum:
+                accum[k] *= scale
+            optimizer.step(weights, accum)
+
+        if held_matrix.shape[0] > 0:
+            held_loss = float(np.mean(_per_window_losses(held_matrix, weights)))
+        else:
+            held_loss = float(np.mean(_per_window_losses(train_matrix, weights)))
+
+        if held_loss < best_held:
+            best_held = held_loss
+            best_weights = {k: v.copy() for k, v in weights.items()}
+
+    train_losses = _per_window_losses(train_matrix, best_weights)
+    recon_errors = []
+    for row in train_matrix:
+        _, _, _, xhat = forward(row, best_weights)
+        recon_errors.append(float(np.mean((row - xhat) ** 2)))
+
+    stats = TrainingStatsV1(
+        epochs=final_epoch,
+        final_loss=float(np.mean(train_losses)) if train_losses.size else 0.0,
+        held_out_loss=best_held,
+        recon_error_p50=_percentile(recon_errors, 50),
+        recon_error_p95=_percentile(recon_errors, 95),
+    )
+    return best_weights, stats
+
+
+def shuffle_within_windows(X: np.ndarray, window_size: int, n_fields: int, rng: np.random.Generator) -> np.ndarray:
+    """Shuffle tick order within each window independently, destroying
+    temporal order but preserving the window's own marginal 4-dim
+    distribution."""
+    shuffled = X.copy()
+    for i in range(shuffled.shape[0]):
+        w = shuffled[i].reshape(window_size, n_fields)
+        perm = rng.permutation(window_size)
+        shuffled[i] = w[perm].reshape(-1)
+    return shuffled
+
+
+def fit_ar1_per_channel(
+    train_rows: list[MoodArcCorpusRowV1],
+    *,
+    max_gap_sec: float | None = None,
+) -> dict[str, tuple[float, float, float]]:
+    """Per raw field, fit x_t = a*x_{t-1} + b + noise via least squares on
+    the TRAINING portion of the corpus only (not held-out -- this is a
+    null-model fit, must not see held-out data any more than the real model
+    does). Returns {field: (a, b, innovation_std)}.
+
+    If max_gap_sec is given, lag-1 pairs whose timestamp gap exceeds it are
+    dropped -- the same run-boundary discipline build_windows() uses, so an
+    outage/restart boundary doesn't get treated as a real one-tick
+    transition."""
+    result: dict[str, tuple[float, float, float]] = {}
+    for field in FIELDS:
+        values: list[float] = []
+        prev_row: MoodArcCorpusRowV1 | None = None
+        pairs_prev: list[float] = []
+        pairs_next: list[float] = []
+        for row in train_rows:
+            if prev_row is not None:
+                gap = (row.generated_at - prev_row.generated_at).total_seconds()
+                if max_gap_sec is None or gap <= max_gap_sec:
+                    pairs_prev.append(getattr(prev_row, field))
+                    pairs_next.append(getattr(row, field))
+            prev_row = row
+            values.append(getattr(row, field))
+
+        if len(pairs_prev) < 3:
+            mean_val = float(np.mean(values)) if values else 0.0
+            result[field] = (0.0, mean_val, 1e-6)
+            continue
+
+        x_prev = np.asarray(pairs_prev, dtype=np.float64)
+        x_next = np.asarray(pairs_next, dtype=np.float64)
+        design = np.vstack([x_prev, np.ones_like(x_prev)]).T
+        coeffs, *_ = np.linalg.lstsq(design, x_next, rcond=None)
+        a, b = float(coeffs[0]), float(coeffs[1])
+        resid = x_next - (a * x_prev + b)
+        innovation_std = float(np.std(resid)) if resid.size > 1 else 1e-6
+        result[field] = (a, b, max(innovation_std, 1e-6))
+    return result
+
+
+def generate_ar1_surrogate_windows(
+    held_windows: np.ndarray,
+    ar1_params: dict[str, tuple[float, float, float]],
+    *,
+    window_size: int,
+    fields: tuple[str, ...] = FIELDS,
+    seed: int,
+) -> np.ndarray:
+    """For each held-out window, simulate a synthetic replacement of the
+    same shape: start from that window's own real first tick per field (so
+    the starting point/marginal level matches), then roll forward
+    window_size-1 steps using each field's fitted AR(1) coefficient/
+    intercept plus i.i.d. Gaussian noise at the fitted innovation_std. This
+    produces windows with the SAME autocorrelation structure as the known
+    decay mechanism, but nothing beyond a single-lag linear process -- the
+    "this is already explained by the known filter" null."""
+    rng = np.random.default_rng(seed)
+    n_fields = len(fields)
+    surrogates = np.empty_like(held_windows)
+    for i in range(held_windows.shape[0]):
+        w = held_windows[i].reshape(window_size, n_fields)
+        surro = np.empty_like(w)
+        surro[0] = w[0]
+        for f_idx, field in enumerate(fields):
+            a, b, innovation_std = ar1_params[field]
+            prev = float(w[0, f_idx])
+            for t in range(1, window_size):
+                noise = float(rng.normal(0.0, innovation_std))
+                prev = a * prev + b + noise
+                surro[t, f_idx] = prev
+        surrogates[i] = surro.reshape(-1)
+    return surrogates
+
+
+def two_tier_gate(real_held_loss: float, shuffle_loss: float, ar1_surrogate_loss: float) -> dict:
+    """floor_pass is the ONLY hard pass/fail (matches the original spec's
+    gate, unchanged threshold: real held-out loss must beat the shuffle
+    baseline by at least 2x). ceiling_ratio is reported but NOT hard-gated
+    on an invented threshold -- we don't have a calibrated cutoff for it yet
+    across multiple runs; it's recorded in the manifest for future
+    calibration. This is intentional, not an oversight: inventing a ceiling
+    threshold now, with a single training run's worth of evidence, would be
+    exactly the kind of ungrounded number this project's own rules
+    (CLAUDE.md) warn against -- the SEEDV4_* variance constants in
+    fit_phi_encoder.py earned their thresholds from real tuning history;
+    this hasn't yet."""
+    floor_ratio = real_held_loss / max(shuffle_loss, 1e-12)
+    ceiling_ratio = real_held_loss / max(ar1_surrogate_loss, 1e-12)
+    return {
+        "floor_ratio": floor_ratio,
+        "floor_pass": floor_ratio < FLOOR_MAX_RATIO,
+        "ceiling_ratio": ceiling_ratio,
+    }
+
+
+def block_bootstrap_ratio_ci(
+    per_window_real_losses: np.ndarray,
+    per_window_shuffle_losses: np.ndarray,
+    *,
+    block_size: int = DEFAULT_BOOTSTRAP_BLOCK_SIZE,
+    n_boot: int = DEFAULT_BOOTSTRAP_N,
+    seed: int,
+) -> tuple[float, float]:
+    """Resample CONTIGUOUS BLOCKS of held-out windows (size=block_size) with
+    replacement -- not individual windows, since held-out windows are
+    autocorrelated by construction (50% stride overlap plus the corpus's
+    own real autocorrelation), so a naive i.i.d. bootstrap would overstate
+    confidence. Returns the (2.5th, 97.5th) percentile of the resampled
+    mean(real)/mean(shuffle) ratio distribution."""
+    real = np.asarray(per_window_real_losses, dtype=np.float64)
+    shuf = np.asarray(per_window_shuffle_losses, dtype=np.float64)
+    n = real.size
+    if n == 0:
+        raise ValueError("block_bootstrap_ratio_ci: no held-out losses to bootstrap")
+
+    rng = np.random.default_rng(seed)
+    block_size = max(1, min(block_size, n))
+    n_blocks_needed = int(np.ceil(n / block_size))
+    ratios: list[float] = []
+    for _ in range(n_boot):
+        idx: list[int] = []
+        for _ in range(n_blocks_needed):
+            max_start = n - block_size
+            start = int(rng.integers(0, max_start + 1)) if max_start > 0 else 0
+            idx.extend(range(start, start + block_size))
+        sample_idx = np.asarray(idx[:n])
+        r_mean = float(np.mean(real[sample_idx]))
+        s_mean = float(np.mean(shuf[sample_idx]))
+        ratios.append(r_mean / max(s_mean, 1e-12))
+
+    lo = float(np.percentile(ratios, 2.5))
+    hi = float(np.percentile(ratios, 97.5))
+    return lo, hi
+
+
+def compute_window_probes(windows: np.ndarray, weights: dict[str, np.ndarray]) -> dict[str, dict[str, float]]:
+    """Per latent dim z_i, Pearson r against window summary stats:
+    mean_valence, valence_range (max-min within window), sign_change_count
+    (how many times valence crosses 0 within the window)."""
+    if windows.shape[0] == 0:
+        return {}
+    latent_dim = int(weights["W2"].shape[1])
+    n_fields = len(FIELDS)
+    window_size = windows.shape[1] // n_fields
+    valence_idx = FIELDS.index("valence")
+
+    z_cols: list[list[float]] = [[] for _ in range(latent_dim)]
+    mean_valence: list[float] = []
+    valence_range: list[float] = []
+    sign_change_count: list[float] = []
+
+    for i in range(windows.shape[0]):
+        x = windows[i]
+        _, _, z, _ = forward(x, weights)
+        for d in range(latent_dim):
+            z_cols[d].append(float(z[d]))
+        w = x.reshape(window_size, n_fields)
+        series = w[:, valence_idx]
+        mean_valence.append(float(np.mean(series)))
+        valence_range.append(float(np.max(series) - np.min(series)))
+        signs = np.sign(series)
+        sign_change_count.append(float(np.sum(signs[1:] != signs[:-1])))
+
+    summary_cols = {
+        "mean_valence": np.asarray(mean_valence, dtype=np.float64),
+        "valence_range": np.asarray(valence_range, dtype=np.float64),
+        "sign_change_count": np.asarray(sign_change_count, dtype=np.float64),
+    }
+    probes: dict[str, dict[str, float]] = {}
+    for d in range(latent_dim):
+        z_arr = np.asarray(z_cols[d], dtype=np.float64)
+        probes[f"z{d}"] = {
+            name: round(_pearson(z_arr, vals), 4) for name, vals in summary_cols.items()
+        }
+    return probes
+
+
+def write_artifacts(
+    out_dir: Path,
+    *,
+    manifest: MoodArcEncoderManifestV1,
+    weights: dict[str, np.ndarray],
+    probes: dict[str, dict[str, float]],
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "manifest.json").write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+    np.savez(out_dir / "weights.npz", **weights)
+    (out_dir / "probes.json").write_text(json.dumps(probes, indent=2), encoding="utf-8")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Offline mood-arc windowed autoencoder fit")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    train_p = sub.add_parser("train", help="Train a candidate mood-arc encoder")
+    train_p.add_argument("--corpus", type=Path, required=True, help="MoodArcCorpusRowV1 JSONL corpus")
+    train_p.add_argument("--out", type=Path, required=True, help="Output directory for trained artifacts")
+    train_p.add_argument("--window-size", type=int, default=DEFAULT_WINDOW_SIZE)
+    train_p.add_argument("--stride", type=int, default=DEFAULT_STRIDE)
+    train_p.add_argument("--max-gap-sec", type=float, default=DEFAULT_MAX_GAP_SEC)
+    train_p.add_argument("--hidden-dim", type=int, default=DEFAULT_HIDDEN_DIM)
+    train_p.add_argument("--latent-dim", type=int, default=DEFAULT_LATENT_DIM)
+    train_p.add_argument("--epochs", type=int, default=DEFAULT_EPOCHS)
+    train_p.add_argument("--lr", type=float, default=DEFAULT_LR)
+    train_p.add_argument("--held-out-frac", type=float, default=DEFAULT_HELD_OUT_FRAC)
+    train_p.add_argument("--purge-gap-windows", type=int, default=DEFAULT_PURGE_GAP_WINDOWS)
+    train_p.add_argument("--bootstrap-block-size", type=int, default=DEFAULT_BOOTSTRAP_BLOCK_SIZE)
+    train_p.add_argument("--bootstrap-n", type=int, default=DEFAULT_BOOTSTRAP_N)
+    train_p.add_argument("--min-hours", type=float, default=DEFAULT_MIN_HOURS)
+    train_p.add_argument("--min-rows", type=int, default=DEFAULT_MIN_ROWS)
+    train_p.add_argument("--seed", type=int, default=42)
+    train_p.add_argument(
+        "--encoder-version", type=str, default=None, help="manifest encoder_version (default: out dir name)"
+    )
+    return parser.parse_args(argv)
+
+
+def cmd_train(args: argparse.Namespace) -> int:
+    rows = _load_jsonl(args.corpus)
+    check_corpus_gates(rows, min_rows=args.min_rows, min_hours=args.min_hours)
+    variances = report_channel_variance(rows)
+
+    triples = _build_windows_with_span(
+        rows, window_size=args.window_size, stride=args.stride, max_gap_sec=args.max_gap_sec
+    )
+    if not triples:
+        raise SystemExit(
+            "train: no windows built from corpus (check window-size/stride/max-gap-sec "
+            "against row count/gaps)"
+        )
+    windows = [w for w, _, _ in triples]
+    start_ts = [s for _, s, _ in triples]
+    end_ts = [e for _, _, e in triples]
+    n_windows = len(windows)
+
+    _purge_start, held_start = _purge_split_indices(n_windows, args.held_out_frac, args.purge_gap_windows)
+    train_matrix, held_matrix = purged_temporal_split(
+        windows, held_out_frac=args.held_out_frac, purge_gap_windows=args.purge_gap_windows
+    )
+    # AR(1) leakage-safe cutoff: rows strictly before the FIRST held-out
+    # window's own start timestamp. Deliberately not derived from
+    # purge_gap_windows/end_ts of the last training window -- found by code
+    # review (2026-07-13) that with 50%-overlapping windows (window_size=30,
+    # stride=15), a small --purge-gap-windows override (e.g. 0) could still
+    # leave the last "training" window's end timestamp *after* the first
+    # held-out window's start (they physically overlap in raw ticks), which
+    # would leak held-out rows into fit_ar1_per_channel's training-only fit
+    # regardless of how large purge_gap_windows claims to be. Using the
+    # held-out boundary's own start_ts directly is correct for any
+    # purge_gap_windows value, including 0.
+    cutoff_ts = start_ts[held_start]
+    train_rows_for_ar1 = [r for r in rows if r.generated_at < cutoff_ts]
+
+    best_weights, training_stats = train_autoencoder(
+        train_matrix,
+        held_matrix,
+        hidden_dim=args.hidden_dim,
+        latent_dim=args.latent_dim,
+        epochs=args.epochs,
+        lr=args.lr,
+        seed=args.seed,
+    )
+
+    real_held_losses = _per_window_losses(held_matrix, best_weights)
+    real_held_loss = float(np.mean(real_held_losses))
+
+    shuffle_rng = np.random.default_rng(args.seed + 1)
+    shuffled_held = shuffle_within_windows(held_matrix, args.window_size, len(FIELDS), shuffle_rng)
+    shuffle_losses = _per_window_losses(shuffled_held, best_weights)
+    shuffle_baseline_loss = float(np.mean(shuffle_losses))
+
+    ar1_params = fit_ar1_per_channel(train_rows_for_ar1, max_gap_sec=args.max_gap_sec)
+    surrogate_held = generate_ar1_surrogate_windows(
+        held_matrix, ar1_params, window_size=args.window_size, fields=FIELDS, seed=args.seed + 2
+    )
+    ar1_losses = _per_window_losses(surrogate_held, best_weights)
+    ar1_surrogate_loss = float(np.mean(ar1_losses))
+
+    gate = two_tier_gate(real_held_loss, shuffle_baseline_loss, ar1_surrogate_loss)
+    ci_low, ci_high = block_bootstrap_ratio_ci(
+        real_held_losses,
+        shuffle_losses,
+        block_size=args.bootstrap_block_size,
+        n_boot=args.bootstrap_n,
+        seed=args.seed + 3,
+    )
+
+    probes = compute_window_probes(held_matrix, best_weights)
+
+    times = [r.generated_at for r in rows]
+    encoder_version = args.encoder_version or args.out.name
+    manifest = MoodArcEncoderManifestV1(
+        encoder_id=f"mood-arc-encoder:{encoder_version}",
+        encoder_version=encoder_version,
+        status="candidate",
+        architecture=ARCHITECTURE,
+        window_size=args.window_size,
+        stride=args.stride,
+        max_gap_sec=args.max_gap_sec,
+        hidden_dim=args.hidden_dim,
+        latent_dim=args.latent_dim,
+        corpus=CorpusStatsV1(
+            corpus_path=str(args.corpus),
+            row_count=len(rows),
+            excluded_degenerate=0,  # no per-row degenerate filter for this corpus (no phi_health field)
+            time_range_start=min(times) if times else None,
+            time_range_end=max(times) if times else None,
+        ),
+        training=training_stats,
+        shuffle_baseline_loss=shuffle_baseline_loss,
+        purge_gap_windows=args.purge_gap_windows,
+        ar1_surrogate_loss=ar1_surrogate_loss,
+        ceiling_ratio=gate["ceiling_ratio"],
+        floor_ratio_ci_low=ci_low,
+        floor_ratio_ci_high=ci_high,
+        git_sha=_git_sha(),
+        trained_at=datetime.now(timezone.utc),
+    )
+    write_artifacts(args.out, manifest=manifest, weights=best_weights, probes=probes)
+
+    result = {
+        "trained": str(args.out),
+        "rows": len(rows),
+        "windows_total": n_windows,
+        "windows_train": int(train_matrix.shape[0]),
+        "windows_held_out": int(held_matrix.shape[0]),
+        "channel_variance": variances,
+        "gate": {
+            "floor_ratio": gate["floor_ratio"],
+            "floor_pass": gate["floor_pass"],
+            "ceiling_ratio": gate["ceiling_ratio"],
+            "floor_ratio_ci_low": ci_low,
+            "floor_ratio_ci_high": ci_high,
+        },
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.command == "train":
+        return cmd_train(args)
+    raise SystemExit(f"unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-spark-introspector/README.md
+++ b/services/orion-spark-introspector/README.md
@@ -418,6 +418,81 @@ on disk. See `services/orion-spark-introspector/app/inner_state_sink.py`.
 | Rotation | `CORPUS_SINK_MAX_BYTES` (default `200000000`), `CORPUS_SINK_ROTATED_KEEP` (default `5`) — shared with `INNER_FEATURES_CORPUS_PATH`, one policy for both sinks. |
 | Consumer | None yet — see the roadmap spec for the gated next steps (train a windowed autoencoder once enough hours accumulate). |
 
+#### Mood-arc windowed encoder (2026-07-13, roadmap item 2)
+
+`scripts/fit_mood_arc_encoder.py` (repo root, `train` subcommand) trains
+item 2 of the roadmap spec: an MLP-shallow autoencoder over *windows* of
+the mood-arc corpus above, not single ticks — the latent space is a
+compressed representation of a felt-state **trajectory**, not a felt-state
+point. It is an **offline, manual script**, run by hand — not a service
+process, no bus wiring, no container. Producer service is credited as
+`orion-spark-introspector` in `orion/self_state/inner_state_registry.py`'s
+`mood_arc_encoder.v1` entry because it trains on that service's corpus
+sink, not because it runs inside that service.
+
+```bash
+python scripts/fit_mood_arc_encoder.py train \
+  --corpus /mnt/telemetry/mood_arc/corpus/mood_arc.jsonl \
+  --window-size 30 --stride 15 --max-gap-sec 6.0 \
+  --hidden-dim 32 --latent-dim 16 \
+  --epochs 500 --lr 0.003 \
+  --held-out-frac 0.15 --purge-gap-windows 6 \
+  --min-hours 6.0 --min-rows 500 \
+  --out /tmp/mood-arc-encoders/v1-candidate
+```
+
+**Defaults deviate from the original spec doc, on evidence.** The spec's
+original `hidden_dim=8, latent_dim=4` plus a vanilla-SGD/zero-init training
+loop were found (same session) to never converge — they scored *worse*
+than a trivial "repeat the window's own mean" baseline. Root cause: zero-
+init decoder bias plus SGD, not a lack of real structure. Fixed by
+mean-initializing the decoder's output bias to the training set's mean
+(instead of zero) and using Adam instead of vanilla SGD — converges in
+~80-120 epochs. `latent_dim=4` also turned out to lack capacity for this
+problem; `latent_dim=16` (with `hidden_dim=32`) is this script's actual
+default.
+
+**Two-tier gate**, also beyond the original spec (which only had a single
+shuffle gate):
+
+- **Floor** (hard gate, unchanged threshold from the spec): held-out
+  reconstruction loss must beat a within-window-shuffle baseline by at
+  least 2x (`floor_ratio < 0.5`). This is the falsifiable claim that the
+  model learned *sequence structure*, not just per-tick statistics.
+- **Ceiling** (diagnostic only, reported but NOT hard-gated): held-out
+  reconstruction loss compared against a synthetic AR(1) surrogate —
+  windows generated from a simple per-channel lag-1 linear model fit on
+  the training data. This exists because raw-signal analysis (this
+  session) traced most of the corpus's real autocorrelation to a known,
+  deliberate leaky-integrator decay mechanism
+  (`BIOMETRICS_FIELD_DECAY_RATE=0.92`,
+  `services/orion-field-digester/app/digestion/decay.py`) — an encoder
+  could pass the shuffle floor purely by learning that already-known
+  filter, without capturing anything Orion-specific. `ceiling_ratio` has
+  no calibrated pass/fail threshold yet (needs multiple training runs to
+  calibrate); it is recorded in the manifest for future comparison, not
+  invented as a number today.
+
+The train/held-out split is also **purged/embargoed**, not a naive random
+window sample: held-out windows are the temporally-last slice, with
+`purge_gap_windows` (default 6) windows dropped entirely between train and
+held-out as a buffer — 50%-overlapping windows plus real measured
+autocorrelation out to lag ~10-15 ticks mean a naive random split would
+leak. A block-bootstrap 95% confidence interval on the floor ratio is also
+computed and stored in the manifest.
+
+Writes the same artifact triad as `fit_phi_encoder.py`:
+`manifest.json`/`weights.npz`/`probes.json` under `--out`. The manifest is
+`MoodArcEncoderManifestV1` (`orion/schemas/telemetry/mood_arc.py`) —
+`purge_gap_windows`, `ar1_surrogate_loss`, `ceiling_ratio`,
+`floor_ratio_ci_low`/`floor_ratio_ci_high` are new fields added for this
+methodology, documented field-by-field in that schema's docstring.
+
+**Dark by design**: no bus publish, no cognition consumer, same as the
+corpus sink above — see `mood_arc_encoder.v1` in
+`orion/self_state/inner_state_registry.py`. Only `train` is implemented;
+`promote`/`infer` are later roadmap items (3+), not built yet.
+
 #### Golden phi + node attribution (2026-07-12)
 
 `handle_self_state()` overrides `phi_now`'s coherence/energy/novelty with the

--- a/tests/test_mood_arc_encoder_fit_script.py
+++ b/tests/test_mood_arc_encoder_fit_script.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from orion.schemas.telemetry.mood_arc import MoodArcCorpusRowV1, MoodArcEncoderManifestV1
+
+REPO = Path(__file__).resolve().parents[1]
+FIT_SCRIPT = REPO / "scripts" / "fit_mood_arc_encoder.py"
+
+
+def _run_fit(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(FIT_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+
+
+def _make_row(
+    *,
+    t: datetime,
+    coherence: float,
+    energy: float,
+    novelty: float,
+    valence: float,
+    idx: int,
+) -> MoodArcCorpusRowV1:
+    return MoodArcCorpusRowV1(
+        generated_at=t,
+        self_state_id=f"tick_{idx}",
+        coherence=coherence,
+        energy=energy,
+        novelty=novelty,
+        valence=valence,
+        valence_source="proxy",
+        dominant_node="node:athena",
+    )
+
+
+def _synthetic_corpus_with_real_pattern(n_rows: int = 1500, seed: int = 0) -> list[MoodArcCorpusRowV1]:
+    """A deliberately-injected real periodic/trend pattern per field, plus
+    noise -- distinct from pure noise so the floor gate (real beats a
+    within-window shuffle) is expected to genuinely pass."""
+    rng = np.random.default_rng(seed)
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    rows: list[MoodArcCorpusRowV1] = []
+    for i in range(n_rows):
+        t = start + timedelta(seconds=2 * i)
+        phase = i * 0.05
+        coherence = 0.6 + 0.05 * np.sin(phase) + rng.normal(0, 0.01)
+        energy = 0.3 + 0.1 * np.sin(phase * 0.7) + rng.normal(0, 0.02)
+        novelty = 0.5 + 0.3 * np.sin(phase * 1.3) + rng.normal(0, 0.03)
+        valence = 0.2 * np.sin(phase * 0.9) + rng.normal(0, 0.02)
+        rows.append(
+            _make_row(
+                t=t,
+                coherence=float(coherence),
+                energy=float(energy),
+                novelty=float(novelty),
+                valence=float(valence),
+                idx=i,
+            )
+        )
+    return rows
+
+
+def _write_corpus(path: Path, rows: list[MoodArcCorpusRowV1]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(row.model_dump_json() + "\n")
+
+
+def test_fit_refuses_small_corpus(tmp_path: Path) -> None:
+    corpus = tmp_path / "tiny.jsonl"
+    corpus.write_text("")  # empty
+    proc = _run_fit("train", "--corpus", str(corpus), "--out", str(tmp_path / "out"))
+    assert proc.returncode != 0
+    assert "min_rows" in proc.stdout.lower() or "min_rows" in proc.stderr.lower()
+
+
+def test_train_end_to_end_passes_floor_gate_on_synthetic_corpus(tmp_path: Path) -> None:
+    corpus = tmp_path / "mood_arc.jsonl"
+    out_dir = tmp_path / "v1-candidate"
+    _write_corpus(corpus, _synthetic_corpus_with_real_pattern())
+
+    proc = _run_fit(
+        "train",
+        "--corpus", str(corpus),
+        "--out", str(out_dir),
+        "--hidden-dim", "32",
+        "--latent-dim", "16",
+        "--epochs", "150",
+        "--lr", "0.003",
+        "--min-hours", "0.5",
+        "--min-rows", "100",
+        "--purge-gap-windows", "6",
+        "--bootstrap-n", "50",
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+
+    assert (out_dir / "manifest.json").is_file()
+    assert (out_dir / "weights.npz").is_file()
+    assert (out_dir / "probes.json").is_file()
+
+    manifest = MoodArcEncoderManifestV1.model_validate_json((out_dir / "manifest.json").read_text())
+    assert manifest.architecture == "mlp_shallow_v1"
+    assert manifest.hidden_dim == 32
+    assert manifest.latent_dim == 16
+    assert manifest.window_size == 30
+    assert manifest.stride == 15
+    assert manifest.purge_gap_windows == 6
+
+    # cmd_train prints per-channel variance lines before the final JSON
+    # result blob -- slice from the first "{" to isolate it.
+    result = json.loads(proc.stdout[proc.stdout.index("{") :])
+    gate = result["gate"]
+    assert gate["floor_pass"] is True, f"expected floor gate to pass on real periodic pattern, got {gate}"
+    assert gate["floor_ratio"] < 0.5
+
+    # New methodology fields populated and sane.
+    assert manifest.ar1_surrogate_loss is not None
+    assert manifest.ceiling_ratio is not None
+    assert manifest.floor_ratio_ci_low is not None
+    assert manifest.floor_ratio_ci_high is not None
+    assert manifest.floor_ratio_ci_low <= manifest.floor_ratio_ci_high
+
+    weights = np.load(out_dir / "weights.npz")
+    for key in ("W1", "b1", "W2", "b2", "W3", "b3"):
+        assert key in weights
+
+    probes = json.loads((out_dir / "probes.json").read_text())
+    assert len(probes) == 16  # one entry per latent dim
+    # At least one latent dim must show |r| > 0.4 against at least one
+    # summary stat (per the original spec's own acceptance check).
+    max_abs_r = max(abs(v) for dim_probes in probes.values() for v in dim_probes.values())
+    assert max_abs_r > 0.4, f"expected at least one strong probe correlation, got max |r|={max_abs_r}"
+
+
+def test_negative_control_untrained_weights_fail_floor_gate() -> None:
+    """Required per the original spec's own acceptance-check list: a
+    trivially-bad encoder (random, untrained weights) must FAIL the floor
+    gate -- confirms the gate isn't a tautology that always passes.
+
+    Uses the SAME structured (real periodic pattern) corpus as
+    test_train_end_to_end_passes_floor_gate_on_synthetic_corpus, which
+    passes the floor gate once trained -- if this test instead used pure
+    i.i.d. noise windows, within-window shuffling would destroy nothing
+    (there is no temporal structure to lose), and *any* model -- trained or
+    not -- would score floor_ratio ~= 1.0 on it. That would only prove "the
+    gate fails on structureless noise", not the actually-required claim
+    that the gate distinguishes an untrained encoder from a real one on
+    data that does have structure to learn (found by code review,
+    2026-07-13)."""
+    from scripts.fit_mood_arc_encoder import (
+        build_windows,
+        init_weights,
+        _per_window_losses,
+        purged_temporal_split,
+        shuffle_within_windows,
+        two_tier_gate,
+    )
+
+    rows = _synthetic_corpus_with_real_pattern()
+    windows = build_windows(rows, window_size=30, stride=15, max_gap_sec=6.0)
+    train_matrix, held_matrix = purged_temporal_split(windows, held_out_frac=0.15, purge_gap_windows=6)
+
+    data_mean = np.mean(train_matrix, axis=0)
+    # No training loop at all -- init_weights() output used as-is, the
+    # trivially-bad encoder the spec's acceptance check requires.
+    untrained_weights = init_weights(train_matrix.shape[1], hidden_dim=32, latent_dim=16, seed=99, data_mean=data_mean)
+
+    real_losses = _per_window_losses(held_matrix, untrained_weights)
+    shuffle_rng = np.random.default_rng(2)
+    shuffled_held = shuffle_within_windows(held_matrix, window_size=30, n_fields=4, rng=shuffle_rng)
+    shuffle_losses = _per_window_losses(shuffled_held, untrained_weights)
+
+    gate = two_tier_gate(float(np.mean(real_losses)), float(np.mean(shuffle_losses)), 1.0)
+    assert gate["floor_pass"] is False, f"untrained weights should fail the floor gate, got {gate}"
+
+
+def test_purged_temporal_split_boundary_and_exclusion_count() -> None:
+    from scripts.fit_mood_arc_encoder import purged_temporal_split
+
+    n = 100
+    # Distinct windows so we can identify exactly which ones survive.
+    windows = [np.full(4, float(i)) for i in range(n)]
+
+    train, held = purged_temporal_split(windows, held_out_frac=0.15, purge_gap_windows=6)
+
+    held_n = max(1, int(round(n * 0.15)))
+    held_start = n - held_n
+    purge_start = held_start - 6
+
+    assert held.shape[0] == held_n
+    assert train.shape[0] == purge_start
+    # Held-out set is the temporally-last slice.
+    assert list(held[:, 0]) == list(range(held_start, n))
+    # Train set is the temporally-first slice, stopping before the purge zone.
+    assert list(train[:, 0]) == list(range(0, purge_start))
+    # Exactly purge_gap_windows windows excluded from both sets.
+    excluded_count = n - train.shape[0] - held.shape[0]
+    assert excluded_count == 6
+
+
+def test_purged_temporal_split_raises_clear_error_when_too_few_windows() -> None:
+    from scripts.fit_mood_arc_encoder import purged_temporal_split
+
+    windows = [np.full(4, float(i)) for i in range(5)]  # far too few for held_out_frac + purge
+    with pytest.raises(ValueError, match="purged_temporal_split"):
+        purged_temporal_split(windows, held_out_frac=0.15, purge_gap_windows=6)
+
+
+def test_purged_temporal_split_raises_on_empty_windows() -> None:
+    from scripts.fit_mood_arc_encoder import purged_temporal_split
+
+    with pytest.raises(ValueError, match="no windows to split"):
+        purged_temporal_split([], held_out_frac=0.15, purge_gap_windows=6)
+
+
+def test_build_windows_breaks_on_real_recorded_gap() -> None:
+    """Uses this session's own recorded max gap (8.09s) against the default
+    max_gap_sec=6.0 to confirm a run correctly breaks there."""
+    from scripts.fit_mood_arc_encoder import build_windows
+
+    start = datetime(2026, 7, 13, 6, 0, 0, tzinfo=timezone.utc)
+    rows: list[MoodArcCorpusRowV1] = []
+    idx = 0
+    # Run 1: 10 rows, 2s apart, coherence pinned to a distinguishable value.
+    for i in range(10):
+        rows.append(
+            _make_row(
+                t=start + timedelta(seconds=2 * i),
+                coherence=0.1,
+                energy=0.1,
+                novelty=0.1,
+                valence=0.1,
+                idx=idx,
+            )
+        )
+        idx += 1
+    gap_start = rows[-1].generated_at + timedelta(seconds=8.09)  # recorded real gap value
+    # Run 2: 10 more rows, 2s apart, distinguishable coherence value.
+    for i in range(10):
+        rows.append(
+            _make_row(
+                t=gap_start + timedelta(seconds=2 * i),
+                coherence=0.9,
+                energy=0.9,
+                novelty=0.9,
+                valence=0.9,
+                idx=idx,
+            )
+        )
+        idx += 1
+
+    windows = build_windows(rows, window_size=5, stride=1, max_gap_sec=6.0)
+
+    # 6 windows per 10-row run of window_size=5, stride=1 (10-5+1=6), two runs -> 12.
+    assert len(windows) == 12
+    for w in windows:
+        coherence_values = w.reshape(5, 4)[:, 0]
+        # No window may mix run-1 and run-2 values -- the gap must have
+        # broken the run, so every window is entirely 0.1s or entirely 0.9s.
+        assert np.allclose(coherence_values, 0.1) or np.allclose(coherence_values, 0.9), (
+            f"window spans the 8.09s gap: {coherence_values}"
+        )
+
+
+def test_generate_ar1_surrogate_windows_matches_variance_but_not_identical() -> None:
+    from scripts.fit_mood_arc_encoder import (
+        FIELDS,
+        fit_ar1_per_channel,
+        generate_ar1_surrogate_windows,
+    )
+
+    rng = np.random.default_rng(3)
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    n = 400
+    rows: list[MoodArcCorpusRowV1] = []
+    val = {f: 0.5 for f in FIELDS}
+    for i in range(n):
+        t = start + timedelta(seconds=2 * i)
+        new_vals = {}
+        for f in FIELDS:
+            val[f] = 0.9 * val[f] + rng.normal(0, 0.05)
+            new_vals[f] = val[f]
+        rows.append(
+            _make_row(
+                t=t,
+                coherence=new_vals["coherence"],
+                energy=new_vals["energy"],
+                novelty=new_vals["novelty"],
+                valence=new_vals["valence"],
+                idx=i,
+            )
+        )
+
+    ar1_params = fit_ar1_per_channel(rows, max_gap_sec=6.0)
+
+    window_size = 30
+    n_fields = len(FIELDS)
+    held_windows = np.stack(
+        [
+            np.asarray(
+                [getattr(r, f) for r in rows[i : i + window_size] for f in FIELDS],
+                dtype=np.float64,
+            )
+            for i in range(0, n - window_size, window_size)
+        ]
+    )
+
+    surrogates = generate_ar1_surrogate_windows(
+        held_windows, ar1_params, window_size=window_size, fields=FIELDS, seed=7
+    )
+
+    assert surrogates.shape == held_windows.shape
+    # Surrogates must not reproduce the exact real sequence.
+    assert not np.array_equal(surrogates, held_windows)
+
+    real_var = np.var(held_windows)
+    surrogate_var = np.var(surrogates)
+    # Similar order of magnitude variance (matched autocorrelation
+    # structure), not wildly different -- loose bound, this is a sanity
+    # check not a precise statistical equivalence test.
+    assert surrogate_var > 0
+    assert 0.1 < (surrogate_var / real_var) < 10.0


### PR DESCRIPTION
## Summary

- Adds `scripts/fit_mood_arc_encoder.py` (new): trains a shallow MLP autoencoder over windows of the mood-arc corpus (Item 1, PR #989) — `train` subcommand only, offline/manual, no bus wiring, no service.
- Fixes this session's spike findings baked into the design: Adam optimizer + mean-initialized decoder bias (the spec's vanilla-SGD/zero-init never converged, scored worse than a trivial mean-repeat baseline) and `hidden_dim=32`/`latent_dim=16` defaults (the spec's `hidden_dim=8`/`latent_dim=4` lacked capacity).
- Adds a two-tier gate: shuffle-baseline floor (hard-gated, unchanged `<0.5` threshold from the spec) plus an AR(1)-surrogate ceiling (diagnostic only, not yet calibrated) — because raw-signal ACF analysis traced most of the corpus's autocorrelation to a known, deliberate decay mechanism (`BIOMETRICS_FIELD_DECAY_RATE=0.92`) that a single shuffle gate could pass without learning anything Orion-specific.
- Adds a purged/embargoed temporal train/held-out split (`purged_temporal_split`) instead of a naive random window split, plus a block-bootstrap 95% CI on the floor ratio.
- Extends `MoodArcEncoderManifestV1` with 5 new `Optional[...] = None` fields for this methodology (kept optional so the sibling schema PR's existing `test_mood_arc_encoder_schema.py` still passes unmodified).
- Registers `mood_arc_encoder.v1` in `orion/self_state/inner_state_registry.py`, closing the exact gap the sibling schema PR (`feat/mood-arc-encoder-manifest-schema`) flagged and correctly declined to fill (no producer existed until this patch).
- Updates both `services/orion-spark-introspector/README.md` and `orion/self_state/README.md` to describe what was actually built (including deviations from the original spec's defaults/gate design).

## Outcome moved

`scripts/check_inner_state_registry.py` now passes (was failing before this patch — `MoodArcEncoderManifestV1` matched the "mood" keyword heuristic with no registry entry). A real, working `train` CLI now exists for roadmap item 2, verified against the live 20,996-row corpus.

## Current architecture

Before this patch, Item 2 of `docs/superpowers/specs/2026-07-13-felt-state-arc-roadmap-spec.md` was design-only: a schema (`MoodArcEncoderManifestV1`, sibling branch) with no producer, and `check_inner_state_registry.py` failing as a result. No windowing, training, or gating code existed.

## Architecture touched

`scripts/` (new training CLI), `orion/schemas/telemetry/mood_arc.py` (schema extension), `orion/self_state/inner_state_registry.py` (new entry), two service/self-state READMEs, one new test file. No bus channels, no service runtime, no config/env.

## Real training run (live corpus, not synthetic)

```bash
python scripts/fit_mood_arc_encoder.py train \
  --corpus /mnt/telemetry/mood_arc/corpus/mood_arc.jsonl \
  --hidden-dim 32 --latent-dim 16 --epochs 500 --lr 0.003 \
  --purge-gap-windows 6 --out /tmp/mood-arc-encoders/v1-candidate-real2
```

- `rows`: 20,996 (spanning `2026-07-13T06:26:29Z` onward)
- `windows_total`: 1387 (`windows_train`: 1173, `windows_held_out`: 208)
- **`floor_ratio`: 0.439** (need `< 0.5`) → **`floor_pass`: True**
- **`floor_ratio_ci_low`/`ci_high`: 0.394 / 0.485** (95% block-bootstrap CI, entirely under the 0.5 threshold — a robust pass, not a borderline one)
- `ceiling_ratio`: 0.785 (diagnostic only, not gated — real loss beats the AR(1)-surrogate null by ~22%)
- Channel variance reported (not gated): `coherence=0.00094`, `energy=0.00237`, `novelty=0.1196`, `valence=0.098` — coherence/energy are real but low-variance; no threshold invented for this.
- Runtime: ~44s on the full live corpus.

## Files changed

- `scripts/fit_mood_arc_encoder.py` (new, 793 lines): `train` CLI, windowing, purged split, Adam-trained autoencoder, two-tier gate, AR(1) surrogate, block bootstrap, `compute_window_probes`.
- `tests/test_mood_arc_encoder_fit_script.py` (new): end-to-end train run on synthetic periodic-pattern corpus (floor gate passes), negative control (untrained weights on the *same structured* corpus fail the floor gate), `purged_temporal_split` boundary/exclusion/error tests, `build_windows` gap-break test (real recorded 8.09s gap vs. default `max_gap_sec=6.0`), `generate_ar1_surrogate_windows` sanity test.
- `orion/schemas/telemetry/mood_arc.py`: `MoodArcEncoderManifestV1` gains `purge_gap_windows`, `ar1_surrogate_loss`, `ceiling_ratio`, `floor_ratio_ci_low`, `floor_ratio_ci_high` (all `Optional[...] = None`, additive, `extra="forbid"` unchanged).
- `orion/self_state/inner_state_registry.py`: new `mood_arc_encoder.v1` entry + import.
- `services/orion-spark-introspector/README.md`, `orion/self_state/README.md`: document what was actually built, including deviations from the original spec doc.

## Schema / bus / API changes

- Added: 5 optional fields on `MoodArcEncoderManifestV1` (see above).
- Removed: none.
- Renamed: none.
- Behavior changed: none for existing consumers — additive only.
- Compatibility notes: existing `test_mood_arc_encoder_schema.py`'s manifest fixtures still construct valid manifests since new fields default to `None`.

## Env/config changes

None. This is a disk-only offline script; no `.env`/`.env_example`/compose/requirements touched.

## Tests run

```text
.venv/bin/python -m pytest tests/test_mood_arc_encoder_fit_script.py tests/test_mood_arc_encoder_schema.py services/orion-spark-introspector/tests/test_mood_arc_corpus.py -q
=> 17 passed
.venv/bin/python scripts/check_inner_state_registry.py
=> inner_state_registry gate OK (12 entries checked)
.venv/bin/python -c "import yaml"
=> OK
```

## Evals run

The real live-corpus training run above (`floor_ratio=0.439`, `floor_pass=True`, CI `[0.394, 0.485]`) is this patch's eval — there's no separate `evals/` harness for this offline script (mirrors `fit_phi_encoder.py`, which also has no dedicated eval harness beyond its own promote gate).

## Docker/build/smoke checks

Not applicable — no runtime/deployment files touched.

## Review findings fixed

- Finding: `test_negative_control_untrained_weights_fail_floor_gate` used pure i.i.d.-noise windows with no temporal structure, so shuffling destroyed nothing and the test couldn't actually distinguish an untrained from a trained encoder (any model scored `floor_ratio≈1.0` on it).
  - Fix: rewrote the test to use the same structured (real periodic-pattern) synthetic corpus as the end-to-end pass test, so there is real structure an untrained model fails to exploit.
  - Evidence: `tests/test_mood_arc_encoder_fit_script.py::test_negative_control_untrained_weights_fail_floor_gate` now passes against structured data.
- Finding: the AR(1) null-model's training-only cutoff (`cutoff_ts`) was derived from the last training window's *end* timestamp, which — for 50%-overlapping windows — could still overlap the first held-out window's raw ticks if `--purge-gap-windows` were overridden to a small value (e.g. `0`), leaking held-out data into `fit_ar1_per_channel`'s fit regardless of the configured purge size.
  - Fix: window construction now tracks each window's start timestamp too; `cmd_train` derives the AR(1) cutoff strictly from the first held-out window's own start timestamp, correct for any `--purge-gap-windows` value including `0`.
  - Evidence: `cutoff_ts = start_ts[held_start]` in `cmd_train`; full test suite + live run re-verified after the fix.
- Finding: `_per_window_losses` (called every epoch for held-loss tracking, plus several more times per training run) always computed a full backward pass even though gradients were never used there, roughly doubling held-set evaluation cost.
  - Fix: added a forward-only `recon_loss()`; all loss-only call sites switched to it, `recon_loss_and_grads` reserved for the actual training step.
  - Evidence: real live-corpus run time dropped from ~53s to ~44s after the fix; all tests still pass.
- Noted, not fixed (out of scope per this task's hard constraints): `_git_sha()` and `_load_jsonl()` in the new script are near-duplicates of the same helpers in `scripts/fit_phi_encoder.py`. Extracting a shared helper would require touching `fit_phi_encoder.py`, explicitly forbidden as a read-only reference file for this task. Flagged for a future cross-cutting cleanup.

## Restart required

```text
No restart required.
```

## Risks / concerns

- Severity: Low
- Concern: `_git_sha()`/`_load_jsonl()` duplication with `scripts/fit_phi_encoder.py`.
- Mitigation: flagged above; a future patch touching both scripts could extract these into `orion/telemetry/corpus_rotation.py` or a new shared module.
- Severity: Low
- Concern: `ceiling_ratio` has no calibrated pass/fail threshold yet — by design, not an oversight, but means it can't yet catch a regression toward "merely re-learning the known decay filter" on its own.
- Mitigation: recorded in every manifest going forward; calibrate once multiple training runs exist (noted in schema docstring and both READMEs).

## Merge order

This branch is built on top of the not-yet-merged `feat/mood-arc-encoder-manifest-schema` (branches from its tip commit, not `main`). **Merge that PR first**, then this one — rebase onto `main` if needed once the schema PR lands.
