### PR TITLE
Fix/autonomy gate instrument p6

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-autonomy-gate-instrument-p6-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-autonomy-gate-instrument-p6-pr.md
@@ -1,0 +1,100 @@
+# fix(autonomy-gate): instrument fix -- UNMEASURABLE verdict, --window-hours, retention caveat (P6)
+
+## Summary
+
+- `scripts/analysis/measure_autonomy_gate.py` (the read-only gate that decides whether Orion's endogenous-drive-origination cognition feature is safe to build) had a real bug: when a data source returned zero rows -- unreachable, or a write pipeline silently stopped -- every metric degraded to `0.0`, which read as a genuine "measured and flat, NO-GO" verdict instead of "we measured nothing."
+- Added a third verdict value, `UNMEASURABLE`, returned instead of a numeric NO-GO when an input is empty. `run()`/`main()` now exit `2` when either verdict is UNMEASURABLE, distinct from `0` for a completed GO/NO-GO measurement.
+- Added `--window-hours` (mutually exclusive with `--window-days`) -- the 1-hour run used to produce today's earlier verdict-(a) GO needed an ad-hoc wrapper before this.
+- Added a retention-bound caveat: if the requested window reaches further back than a source's actual live retention, the report names which source is the binding constraint and by how many hours, instead of silently under-covering older buckets.
+- Live-diagnosed a real, previously-uncommitted finding while re-running the fixed instrument: the Fuseki `DriveAudit` graph has received zero writes since 2026-06-19T07:06:29Z (traced to commit `e9b233e9`, which disabled RDF materialization that day). The 2026-07-08 verdict-(b) NO-GO on record was computed against this same frozen snapshot the whole time -- corrected to UNMEASURABLE, with the root cause committed so it stops being re-measured as a false NO-GO.
+
+## Outcome moved
+
+The gate this feature (and the internal-economy spec) is blocked on now tells the truth about whether it measured anything. Verdict (a), re-run live today, is **GO** on both 1h and 7d windows -- Step 1 of the origination arc is no longer gated. Verdict (b) is now honestly **UNMEASURABLE**, not a fabricated NO-GO -- Step 4 stays blocked, but on the right basis.
+
+## Current architecture
+
+The original P6 scope (from `docs/superpowers/specs/2026-07-13-endogenous-action-motor-nerve-spec.md`) assumed the Fuseki co-activation query itself needed repointing. Re-verified against live data before starting: that part was already fixed by an unrelated commit series (`de0ad072`..`8d20cc36`, already on `main`) -- confirmed via a direct SPARQL `COUNT` (444,943 rows exist). P6's real remaining scope was re-derived from reading the live script instead of trusting the (by-then-stale) spec text.
+
+## Architecture touched
+
+One script (`scripts/analysis/measure_autonomy_gate.py`), its test file, its README, and the origination design doc it gates (`docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md`). No services, no runtime config, no `.env` files -- this is a standalone, read-only analysis CLI.
+
+## Files changed
+
+- `scripts/analysis/measure_autonomy_gate.py` -- `UNMEASURABLE` constant + guard in both verdict functions (symmetric, after a review fix -- see below), `retention_caveat()` + two new IO adapters (`fetch_earliest_self_state_ts`/`fetch_earliest_receipt_ts`), `--window-hours` flag + `resolve_window()`, exit code 2 on UNMEASURABLE.
+- `scripts/analysis/tests/test_measure_autonomy_gate.py` -- 10 new pure-layer tests (no DB/network); one existing test's assertion flipped from `NO-GO` to `UNMEASURABLE` (it had been asserting the bug's own behavior as correct).
+- `scripts/analysis/README.md` -- documents `--window-hours`, `UNMEASURABLE`, retention caveats, exit codes.
+- `docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md` -- appended today's live re-run with the frozen-graph root cause.
+- `docs/superpowers/specs/2026-07-13-autonomy-gate-instrument-p6-design.md` (new) -- design spec.
+
+## Schema / bus / API changes
+
+None -- standalone script, no bus/schema/service surface.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+cd /mnt/scripts/Orion-Sapienform-autonomy-gate-instrument-fix
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest scripts/analysis/tests/test_measure_autonomy_gate.py -q
+
+26 passed
+```
+`git diff --check` clean.
+
+**Live verification (not a unit test, a real run against production Postgres/Fuseki, read-only):**
+
+```text
+POSTGRES_URI=postgresql://postgres:postgres@localhost:55432/conjourney \
+AUTONOMY_GRAPH_QUERY_URL=http://localhost:3030/orion/query \
+python scripts/analysis/measure_autonomy_gate.py --window-hours 1
+# exit code: 2 (verdict b UNMEASURABLE)
+# (a) GO -- silent median_abs_trajectory 0.0442 >= 0.03
+# (b) UNMEASURABLE -- 0 DriveAudit rows in the last hour
+
+python scripts/analysis/measure_autonomy_gate.py --window-days 7
+# exit code: 2
+# (a) GO -- silent median_abs_trajectory 0.0408 >= 0.03
+# (b) UNMEASURABLE -- 0 DriveAudit rows in the last 7 days
+# caveat fired: substrate_self_state retention only covers back to
+#   2026-07-10T18:32:24Z, 95.9h short of the requested window start
+```
+
+## Evals run
+
+None -- this is a measurement instrument, not a service; its own output (GO/NO-GO/UNMEASURABLE against real data) is the eval.
+
+## Docker/build/smoke checks
+
+Not applicable -- no container, no runtime service. The "smoke test" for this patch is the two live runs above, both against real production Postgres and Fuseki, read-only (`open_readonly_connection` refuses to proceed if the session isn't verified read-only).
+
+## Review findings fixed
+
+- Finding: `verdict_economy`'s `UNMEASURABLE` guard only checked `drive.record_count == 0`, not `pressure.row_count == 0`, even though the GO/NO-GO rule reads both. A dead Postgres source with a live Fuseki source would silently produce a real-looking `"NO-GO"` string instead of `UNMEASURABLE` -- the exact failure mode this patch exists to prevent, left open on one of its two inputs.
+  - Fix: guard changed to `if drive.record_count == 0 or pressure.row_count == 0: return UNMEASURABLE`.
+  - Evidence: `tests/test_measure_autonomy_gate.py::test_verdict_b_unmeasurable_when_pressure_empty_even_with_live_drive_data` -- live coactivation data (50%, well above threshold) + empty pressure now correctly returns UNMEASURABLE, not NO-GO.
+- Finding: one new test (`test_unmeasurable_constant_is_distinct_from_go_and_no_go`) only compared string literals and exercised no function under test -- zero regression value.
+  - Fix: replaced with the asymmetric-guard regression test above.
+  - Evidence: `git diff` on the test file.
+- Checked and confirmed correct (no fix needed): exit-code precedence (report/CSV/progress always written before the exit-code decision), argparse mutual-exclusion and default-preservation, `retention_caveat`'s comparison direction and hour math, the new IO adapters' degrade-on-failure convention, and the `e9b233e9` commit citation in the origination doc (verified via `git show e9b233e9` -- real commit, ~2.5 minutes after the doc's claimed last-Fuseki-write timestamp, tight and plausible match).
+
+## Restart required
+
+```text
+No restart required.
+```
+Standalone script; no service reads or depends on it at runtime.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: verdict (b) (internal economy) remains genuinely unmeasured -- re-enabling Fuseki RDF materialization for `DriveAudit` (reversing `e9b233e9`) is a real infra decision (that commit disabled it to relieve Fuseki load) not made or recommended here; repointing the gate's adapter at a different live source is named as a follow-up, not attempted.
+- Mitigation: none needed for this patch specifically -- the point of P6 was making the instrument honest about not knowing, not making Step 4 measurable. That's a separate, larger decision for whoever owns the internal-economy spec next.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/autonomy-gate-instrument-p6

--- a/docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md
+++ b/docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md
@@ -245,3 +245,78 @@ drift. Step 4 (internal economy) is also blocked by 0(b)'s failure. This spec
 remains design-only; `orion/autonomy/endogenous_origination.py` exists as a
 pre-gate implementation stub only (see its module docstring for current status)
 and must not be treated as adopted.
+
+## Measurement gate re-run (2026-07-13) — (a) now GO, (b) corrected to UNMEASURABLE
+
+The 2026-07-08 verdict above was re-run today with a fixed instrument
+(`scripts/analysis/measure_autonomy_gate.py`, `--window-hours`/`UNMEASURABLE`
+patch, same session as this entry). This section corrects, not just updates,
+the 2026-07-08 record: verdict (b)'s NO-GO was never actually measuring live
+data, for a specific, now-identified reason below.
+
+**(a) Endogenous drift — GO**, on both a 1-hour and a 7-day live window (Postgres
+`substrate_self_state`, read-only):
+
+| Window | silent median_abs_trajectory | silent rows | busy rows |
+| --- | --- | --- | --- |
+| 1h (2026-07-13T17:39Z → 18:39Z) | **0.0442** | 731 | 1025 |
+| 7d (2026-07-06T18:40Z → 07-13T18:40Z) | **0.0408** | 61,251 | 1,025 |
+
+Both clear the `>= 0.03` threshold (the 2026-07-08 run measured `0.0000` against
+the same rule — a real change, not noise: the leaky-integrator rebuild
+(`[[project_homeostatic_drives_real_tensions]]`, merged 2026-07-07/08) replaced
+the old `soft_saturate` fixed-point that pinned every drive flat; the 2026-07-08
+gate ran against data from *before or right at* that fix and caught the
+flat-pinned era. Today's data is genuinely post-fix.
+
+**Retention caveat, live-confirmed by the same run:** `substrate_self_state`
+only retains back to `2026-07-10T18:32:24Z` — the 7-day run's requested window
+start (`2026-07-06T18:40Z`) is **95.9h short** of what the table actually
+covers. The 7-day figures above are real for the ~3 days they *do* cover;
+treat the 1-hour run as the cleaner, fully-covered measurement, not a fallback.
+
+**(b) Internal economy — UNMEASURABLE, root-caused precisely (was misreported
+as NO-GO on 2026-07-08):**
+
+Live-queried the Fuseki `autonomy/drives` graph directly (not through the
+gate script) to root-cause the zero-row result:
+
+```
+SELECT (MAX(?ts) as ?latest) (COUNT(*) as ?c) WHERE {
+  GRAPH <http://conjourney.net/graph/autonomy/drives> {
+    ?audit a orion:DriveAudit . ?audit orion:timestamp ?ts .
+  }
+}
+→ latest = 2026-06-19T07:06:29Z, c = 448941 (timestamp triples; audit-row
+  count via the gate's own histogram query = 444,943 distinct audits — the
+  gap is `orion:timestamp` being multi-valued per audit, not new data)
+```
+
+**The graph has not received a single new `DriveAudit` write since
+2026-06-19T07:06:29Z** — 24 days before this re-run, and *before* the
+2026-07-08 gate run that reported NO-GO for verdict (b). This lines up exactly
+with commit `e9b233e9` (2026-06-19, direct-to-main): *"Disable autonomy Fuseki
+reads and graph churn by default... archive and RDF materialization are off
+until re-enabled"* (see `[[project_concept_induction_deactivation_decisions]]`
+for the fuller trace of that commit's scope). **The 2026-07-08 NO-GO verdict
+for (b) was computed against this same frozen, pre-disable snapshot the whole
+time** — it was never measuring 120 days of live co-activation; the co-activation
+math and thresholds were sound, but the input had stopped updating three weeks
+before the window it claimed to cover. This is not a new bug introduced today —
+it is what today's instrument fix (`verdict_economy` now returns
+`UNMEASURABLE` when `drive.record_count == 0` *in the requested window*,
+rather than folding a dead source into `coactivation_frac = 0.0 → NO-GO`) is
+specifically built to catch and never silently repeat.
+
+**Consequence:** Step 0(a) now **passes** — per the "Build sequence & gate"
+section above, Step 1 (this spec, endogenous drive origination) is no longer
+gated on 0(a). Step 0(b) remains **unresolved**, not failed — the internal-economy
+question (Step 4) cannot be answered until either (1) RDF materialization for
+`DriveAudit` is re-enabled (a real infra decision, reintroducing the Fuseki
+load `e9b233e9` was written to relieve — not this doc's call), or (2) the gate's
+(b) adapter is repointed at a different, currently-live source of drive
+co-activation data (`DriveEngine`'s per-tick pressures are computed live but
+not currently persisted anywhere the gate can read — a separate follow-up, not
+attempted here). Until one of those happens, **Step 4 stays blocked on an
+honestly-unmeasured question, not a measured failure** — the distinction this
+session's instrument fix exists to preserve.

--- a/docs/superpowers/specs/2026-07-13-autonomy-gate-instrument-p6-design.md
+++ b/docs/superpowers/specs/2026-07-13-autonomy-gate-instrument-p6-design.md
@@ -1,0 +1,59 @@
+# Autonomy gate instrument fix (P6 of the motor-nerve spec) — design
+
+**Date:** 2026-07-13
+**Status:** Implementation, this session
+**Mode:** Thin patch. Implements P6 of `docs/superpowers/specs/2026-07-13-endogenous-action-motor-nerve-spec.md` — with its own diagnosis re-verified against live data first, since part of the original P6 scope turned out to already be fixed by unrelated work.
+
+## Arsonist summary
+
+P6's parent-spec framing (written earlier today) says the Fuseki `DriveAudit` graph "has been empty ≥7 days" and needs repointing. That's now **stale** — a separate commit series (`de0ad072` through `8d20cc36`, already on `main`) rewrote `fetch_drive_stats`/`build_drive_coactivation_histogram_sparql` to read the real `orion:hasDriveAssessment`/`orion:driveActive` shape via a server-side histogram query. Live-queried it directly: **444,943 `DriveAudit` rows** exist in the graph right now. Verdict (b)'s data source is not dead. Re-verified per CLAUDE.md's "runtime truth beats config truth" rather than trusting the hours-old spec text.
+
+What's actually still missing, re-derived from reading the live script (`scripts/analysis/measure_autonomy_gate.py`) rather than the old diagnosis:
+
+1. **No `--window-hours` flag.** Only `--window-days` (int) exists. The 1-hour run that produced today's earlier GO verdict for (a) needed an ad-hoc wrapper — there's no first-class way to ask for a sub-day window.
+2. **No `UNMEASURABLE` distinction.** Both `verdict_drift` and `verdict_economy` compute their GO/NO-GO purely from the numeric thresholds. If a data source degrades to zero rows (Postgres down, Fuseki empty — the exact failure this file's own `open_readonly_connection`/`fetch_drive_stats` are built to degrade gracefully into), the metrics all resolve to `0.0`, which reads as a real behavioral "NO-GO" from the threshold comparisons — indistinguishable from "measured and it's genuinely flat." This is a real, live risk *regardless* of today's data being healthy — the whole point of a gate is to still be trustworthy the next time a source goes dark.
+3. **No receipt/self-state retention-bound caveat.** Live-checked: `substrate_reduction_receipts` spans 2026-07-03 → 2026-07-13 (10 days), but `substrate_self_state` only spans 2026-07-10 → 2026-07-13 (~3 days). A `--window-days 7` run today would silently under-cover verdict (a)'s self-state metrics for the older ~4 days of the window with no indication in the report that this happened — the exact "busy/silent classification validity bound" gap P6 named, just discovered against different numbers than the original spec guessed.
+4. **Today's re-verified numbers were never committed.** The origination design doc still shows only the 2026-07-08 NO-GO; the 2026-07-13 re-run (GO on verdict a) exists only in a prior session's `/tmp` output, never appended to the repo.
+
+## Current architecture
+
+`scripts/analysis/measure_autonomy_gate.py`: a pure/IO-split, read-only, single-file measurement CLI. Pure layer (bucket classification, drift/co-activation math, verdict rules) has 15 existing unit tests (`scripts/analysis/tests/test_measure_autonomy_gate.py`) and zero I/O. IO layer (`open_readonly_connection`, `fetch_self_state_records`, `fetch_receipt_timestamps`, `fetch_drive_stats`) degrades to empty/`None` on any failure, never raises — already follows the "never raise on read" convention this repo uses elsewhere (`services/orion-feedback-runtime/app/store.py` etc.). `run(window_days: int)` orchestrates: connect → fetch three sources → pure compute → write `report.md`/`before_after.csv`/`progress.log` to `/tmp/autonomy-gate/`.
+
+## Proposed schema / API changes
+
+**`build_arg_parser()`**: add `--window-hours` (float), mutually exclusive with `--window-days` (`argparse` mutually-exclusive group). `run()` gains a `window: timedelta` parameter (replacing the `window_days: int` parameter) so both flags funnel through one code path instead of forcing hours into a days-shaped API.
+
+**Verdict functions**: `verdict_drift`/`verdict_economy` gain a `"UNMEASURABLE"` return value, returned when the relevant input has zero real rows — distinct from `"GO"`/`"NO-GO"`. Specifically:
+- `verdict_drift`: `UNMEASURABLE` when both `silent.row_count == 0` and `busy.row_count == 0` (no self-state data at all in the window — can't distinguish "measured zero drift" from "measured nothing").
+- `verdict_economy`: `UNMEASURABLE` when `drive.record_count == 0` (matches P6's original ask precisely) — resource-pressure zero-rows already gets its own caveat via `pressure.row_count`, but doesn't independently block the verdict since it shares the self-state source with verdict (a) and that's already covered there.
+
+**`run()`**: exits with a distinct nonzero code (`2`) when either verdict is `UNMEASURABLE`, separate from the normal `0` exit for a completed (GO or NO-GO) measurement — so a caller (cron, CI, a human running this by hand) can immediately tell "the instrument didn't work" from "the instrument worked and said no."
+
+**Retention-bound caveat**: after fetching self-state and receipt rows, compare `window_start` against the oldest row actually returned by each source (or the oldest row in the table generally, via a cheap `MIN(generated_at)`/`MIN(created_at)` query when the fetch itself returned rows but potentially fewer than the full window implies) and append a caveat naming which source's retention is the binding constraint and by how much, when the window requested exceeds what's actually available.
+
+**Origination design doc**: append today's re-verified numbers (this patch's own fresh run, not the stale numbers from earlier in the day) to `docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md`.
+
+## Files likely to touch
+
+- `scripts/analysis/measure_autonomy_gate.py` — `--window-hours` flag, `UNMEASURABLE` verdict value + exit code, retention-bound caveat.
+- `scripts/analysis/tests/test_measure_autonomy_gate.py` — new pure-layer tests for the `UNMEASURABLE` branches (zero-row inputs) and the mutually-exclusive-flag parsing.
+- `scripts/analysis/README.md` — document `--window-hours`, `UNMEASURABLE`, exit codes.
+- `docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md` — append this session's fresh re-run.
+
+## Non-goals
+
+- Not re-deriving or re-tuning the GO/NO-GO thresholds themselves (`DRIFT_MIN_MEDIAN_ABS_TRAJECTORY`, `COACTIVATION_MIN_FRAC`, etc.) — out of scope, a separate empirical question.
+- Not touching the already-fixed Fuseki co-activation query (`build_drive_coactivation_histogram_sparql`, `fetch_drive_stats`) — confirmed live and correct against 444,943 real rows; re-verifying it further is not this patch's job.
+- Not building a turn-timestamp source (`run()`'s existing `# no cheap turn store located` comment stands — still true, still not invented here).
+- Not flipping `ORION_ENDOGENOUS_ORIGINATION_ENABLED` — that's P7, gated on its own separate burn-in condition regardless of what this instrument reports.
+
+## Acceptance checks
+
+1. `pytest scripts/analysis/tests/test_measure_autonomy_gate.py -q` green, including new `UNMEASURABLE`/flag-parsing tests.
+2. A live run with `--window-hours 1` succeeds and produces the same report shape as a `--window-days` run.
+3. A synthetic zero-row scenario (mocked/empty inputs) returns `UNMEASURABLE` from both verdict functions, not a numeric NO-GO.
+4. A live run (real Postgres + Fuseki) this session, with its actual verdicts and row counts appended to the origination design doc — not copied from an earlier session's stale numbers.
+
+## Recommended next patch
+
+None within this series — P6 is the last independent item; P7 (origination enable decision) remains gated on 2 weeks of clean P1–P3 burn-in per the parent spec, unaffected by this instrument fix either way.

--- a/scripts/analysis/README.md
+++ b/scripts/analysis/README.md
@@ -133,13 +133,17 @@ change its dynamics source before it is built.
 
 ### (b) Internal economy — `verdict_economy`
 
-**UNMEASURABLE** iff zero `DriveAudit` records exist in the requested window
-(dead or unreachable Fuseki source, or a source that stopped being written to
-— see the 2026-07-13 re-run in
+**UNMEASURABLE** iff **either** input is empty: zero `DriveAudit` records in
+the requested window (dead/unreachable Fuseki, or a source that stopped being
+written to — see the 2026-07-13 re-run in
 `docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md`
 for a real example: RDF materialization for `DriveAudit` was disabled
 2026-06-19, and the previous instrument silently reported this as a
-behavioral `NO-GO` for three weeks before anyone noticed).
+behavioral `NO-GO` for three weeks before anyone noticed), **or** zero
+self-state rows (dead/unreachable Postgres — the source `pressure` is built
+from). Both inputs are checked independently; guarding only one would leave
+the other free to silently degrade to `0.0` and produce a real-looking
+`NO-GO` string.
 
 Otherwise, **GO** iff:
 

--- a/scripts/analysis/README.md
+++ b/scripts/analysis/README.md
@@ -42,15 +42,21 @@ Generic / in-container form (defaults resolve on the docker `app-net` network):
 
 ```bash
 python scripts/analysis/measure_autonomy_gate.py --window-days 7
+# or a sub-day window:
+python scripts/analysis/measure_autonomy_gate.py --window-hours 1
 ```
 
-- `--window-days` defaults to `7` (`DEFAULT_WINDOW_DAYS`). The window is
-  `now - window_days` through `now`.
+- `--window-days` (int) and `--window-hours` (float) are mutually exclusive.
+  Neither given → defaults to `7` days (`DEFAULT_WINDOW_DAYS`). The window is
+  `now - window` through `now`.
 - Within the window, activity is bucketed into fixed `300`-second buckets
   (`WINDOW_SEC`) to classify each interval as `silent` or `busy`.
 - `psycopg2` is required for live DB metrics. If it is unavailable or the DB is
   unreachable, `open_readonly_connection` degrades gracefully (returns `None`,
   adds a caveat, and self-state/receipt metrics are empty) — it does not crash.
+- **Exit code**: `0` for a completed measurement (either verdict came back `GO`
+  or `NO-GO`); `2` if either verdict is `UNMEASURABLE` (see below) — a caller
+  (cron, CI, a human) can branch on this without parsing the report text.
 
 ### Environment variables
 
@@ -95,15 +101,27 @@ for Fuseki), as shown in the host command above.
   This is reported as a coverage caveat in the output.
 - Every adapter degrades gracefully: missing DB, unreachable Fuseki, or absent
   columns produce empty metrics plus a caveat rather than a crash.
+- **Retention-bound caveat**: if the requested window reaches further back than
+  a source's actual retention (e.g. `substrate_self_state` currently retains
+  only ~3 days live while `substrate_reduction_receipts` retains ~10), the
+  report names which source is the binding constraint and by how many hours —
+  older buckets in an over-long window reflect *zero rows*, not measured
+  absence, and this caveat is how the report says so explicitly instead of
+  silently under-covering.
 
 ## Verdict rules
 
 Thresholds are the **seed decision boundary**. The report always prints the raw
-numbers so a human can override the mechanical verdict.
+numbers so a human can override the mechanical verdict. Both verdicts can
+return a third value, **`UNMEASURABLE`**, distinct from `GO`/`NO-GO` — see
+below.
 
 ### (a) Endogenous drift — `verdict_drift`
 
-**GO** iff, in **silent** buckets:
+**UNMEASURABLE** iff both silent and busy self-state row counts are `0` (dead
+or unreachable Postgres source — nothing was measured, not measured-flat).
+
+Otherwise, **GO** iff, in **silent** buckets:
 
 - `median_abs_trajectory >= DRIFT_MIN_MEDIAN_ABS_TRAJECTORY` (**0.03**), **AND**
 - silent `dim_score_variance >= DRIFT_VARIANCE_RATIO` (**0.25**) × busy
@@ -115,7 +133,15 @@ change its dynamics source before it is built.
 
 ### (b) Internal economy — `verdict_economy`
 
-**GO** iff:
+**UNMEASURABLE** iff zero `DriveAudit` records exist in the requested window
+(dead or unreachable Fuseki source, or a source that stopped being written to
+— see the 2026-07-13 re-run in
+`docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md`
+for a real example: RDF materialization for `DriveAudit` was disabled
+2026-06-19, and the previous instrument silently reported this as a
+behavioral `NO-GO` for three weeks before anyone noticed).
+
+Otherwise, **GO** iff:
 
 - `coactivation_frac >= COACTIVATION_MIN_FRAC` (**0.10**), **AND**
 - fraction of self-state rows with `resource_pressure >= RESOURCE_PRESSURE_LEVEL`
@@ -123,6 +149,10 @@ change its dynamics source before it is built.
 
 **NO-GO** means the economy allocator would be a cathedral at current
 activation / pressure levels — do not build.
+
+**`UNMEASURABLE` must never be treated as `NO-GO`** by anything reading this
+gate's output — it means the instrument didn't get real data, not that the
+answer is no.
 
 ## Outputs & monitoring
 

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -465,15 +465,19 @@ def retention_caveat(
 def verdict_economy(drive: DriveStats, pressure: ResourcePressureStats) -> str:
     """Verdict (b): GO iff drives co-activate AND resource_pressure rises.
 
-    UNMEASURABLE iff no DriveAudit records exist in the window at all --
-    same reasoning as verdict_drift: a dead Fuseki source must never resolve
-    to a numeric "0% co-activation, NO-GO" behavioral finding.
+    UNMEASURABLE iff EITHER input has zero rows -- the rule reads both
+    drive.coactivation_frac (Fuseki) and pressure.frac_gt_level (Postgres
+    self-state), two independent sources. Guarding only one (e.g. only
+    drive.record_count) would let the other silently degrade to 0.0 and
+    resolve as a real "NO-GO" string -- exactly the failure mode this
+    function exists to prevent, just left open on whichever input isn't
+    checked.
 
     Otherwise, GO iff coactivation_frac >= COACTIVATION_MIN_FRAC
       AND frac_gt(resource_pressure >= level) >= RESOURCE_PRESSURE_MIN_FRAC.
     """
 
-    if drive.record_count == 0:
+    if drive.record_count == 0 or pressure.row_count == 0:
         return UNMEASURABLE
     if drive.coactivation_frac < COACTIVATION_MIN_FRAC:
         return "NO-GO"

--- a/scripts/analysis/measure_autonomy_gate.py
+++ b/scripts/analysis/measure_autonomy_gate.py
@@ -406,15 +406,26 @@ def parse_sparql_histogram_bindings(bindings: Iterable[dict]) -> dict[int, int]:
     return out
 
 
+UNMEASURABLE = "UNMEASURABLE"
+
+
 def verdict_drift(silent: SelfStateMetrics, busy: SelfStateMetrics) -> str:
     """Verdict (a): GO iff silent-bucket self-state genuinely drifts.
 
-    GO iff, in SILENT buckets:
+    UNMEASURABLE iff there is no self-state data at all in the window (both
+    classes empty) -- a dead/unreachable source resolves every metric to 0.0,
+    which would otherwise read as a real "flat, NO-GO" behavioral finding
+    instead of "we didn't measure anything." Never silently downgrade a dead
+    sensor into a behavioral verdict.
+
+    Otherwise, GO iff, in SILENT buckets:
       median(per-row |trajectory|) >= DRIFT_MIN_MEDIAN_ABS_TRAJECTORY
       AND silent dim_score_variance >= DRIFT_VARIANCE_RATIO * busy variance.
     When busy variance is 0, the ratio test passes iff silent variance > 0.
     """
 
+    if silent.row_count == 0 and busy.row_count == 0:
+        return UNMEASURABLE
     if silent.median_abs_trajectory < DRIFT_MIN_MEDIAN_ABS_TRAJECTORY:
         return "NO-GO"
     if busy.dim_score_variance == 0.0:
@@ -424,13 +435,46 @@ def verdict_drift(silent: SelfStateMetrics, busy: SelfStateMetrics) -> str:
     return "GO" if variance_ok else "NO-GO"
 
 
+def retention_caveat(
+    source_name: str, oldest_available: Optional[datetime], window_start: datetime
+) -> Optional[str]:
+    """Caveat when a source's actual retention doesn't reach back to
+    window_start -- the exact "busy/silent classification validity bound"
+    gap: a longer window silently under-covers older buckets with zero rows
+    (not measured absence) with nothing in the report saying so. Returns
+    None when the source covers the full window, or when oldest_available
+    itself is unknown (a separate unavailability caveat already covers that
+    case). Pure, unit-testable.
+    """
+
+    if oldest_available is None:
+        return None
+    oldest = _as_utc(oldest_available)
+    start = _as_utc(window_start)
+    if oldest <= start:
+        return None
+    gap_hours = (oldest - start).total_seconds() / 3600.0
+    return (
+        f"{source_name} retention only covers back to {oldest.isoformat()}, "
+        f"{gap_hours:.1f}h short of the requested window start ({start.isoformat()}) "
+        "-- classification/metrics for the uncovered period reflect zero rows, "
+        "not measured absence"
+    )
+
+
 def verdict_economy(drive: DriveStats, pressure: ResourcePressureStats) -> str:
     """Verdict (b): GO iff drives co-activate AND resource_pressure rises.
 
-    GO iff coactivation_frac >= COACTIVATION_MIN_FRAC
+    UNMEASURABLE iff no DriveAudit records exist in the window at all --
+    same reasoning as verdict_drift: a dead Fuseki source must never resolve
+    to a numeric "0% co-activation, NO-GO" behavioral finding.
+
+    Otherwise, GO iff coactivation_frac >= COACTIVATION_MIN_FRAC
       AND frac_gt(resource_pressure >= level) >= RESOURCE_PRESSURE_MIN_FRAC.
     """
 
+    if drive.record_count == 0:
+        return UNMEASURABLE
     if drive.coactivation_frac < COACTIVATION_MIN_FRAC:
         return "NO-GO"
     if pressure.frac_gt_level < RESOURCE_PRESSURE_MIN_FRAC:
@@ -593,6 +637,42 @@ def fetch_receipt_timestamps(conn, since: datetime, max_rows: int = MAX_ROWS) ->
     return out, len(rows) >= max_rows
 
 
+def fetch_earliest_self_state_ts(conn) -> Optional[datetime]:
+    """Earliest substrate_self_state row overall (not window-bounded) -- the
+    real retention floor for verdict (a)'s primary source. Degrades to None
+    on any failure or an empty table; never raises.
+    """
+
+    if conn is None:
+        return None
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT MIN(generated_at) FROM substrate_self_state")
+            row = cur.fetchone()
+    except Exception:
+        logger.error("failed to fetch earliest substrate_self_state timestamp", exc_info=True)
+        return None
+    return _coerce_dt(row[0]) if row else None
+
+
+def fetch_earliest_receipt_ts(conn) -> Optional[datetime]:
+    """Earliest substrate_reduction_receipts row overall -- the retention
+    floor for the busy/silent classification signal. Degrades to None on any
+    failure or an empty table; never raises.
+    """
+
+    if conn is None:
+        return None
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT MIN(created_at) FROM substrate_reduction_receipts")
+            row = cur.fetchone()
+    except Exception:
+        logger.error("failed to fetch earliest substrate_reduction_receipts timestamp", exc_info=True)
+        return None
+    return _coerce_dt(row[0]) if row else None
+
+
 def fetch_drive_stats(
     query_url: str,
     since: datetime,
@@ -711,7 +791,7 @@ def write_before_after_csv(path: Path, silent: SelfStateMetrics, busy: SelfState
 
 def render_report(
     *,
-    window_days: int,
+    window_label: str,
     window_start: datetime,
     window_end: datetime,
     silent: SelfStateMetrics,
@@ -728,7 +808,7 @@ def render_report(
         "",
         "Read-only measurement. No writes, no events, no flag changes.",
         "",
-        f"- Window: last {window_days} day(s) ({window_start.isoformat()} -> {window_end.isoformat()})",
+        f"- Window: last {window_label} ({window_start.isoformat()} -> {window_end.isoformat()})",
         f"- Bucket width: {WINDOW_SEC}s",
         "",
         "## Verdicts",
@@ -782,9 +862,9 @@ def render_report(
 # ===========================================================================
 
 
-def run(window_days: int) -> int:
+def run(window: timedelta, window_label: str) -> int:
     now = datetime.now(timezone.utc)
-    window_start = now - timedelta(days=window_days)
+    window_start = now - window
     dsn = os.environ.get("POSTGRES_URI", DEFAULT_POSTGRES_URI)
     fuseki_url = os.environ.get("AUTONOMY_GRAPH_QUERY_URL", DEFAULT_FUSEKI_QUERY_URL)
 
@@ -803,6 +883,11 @@ def run(window_days: int) -> int:
     if ss_trunc:
         caveats.append(f"self-state rows truncated at MAX_ROWS={MAX_ROWS}")
         anomalies += 1
+    ss_retention_note = retention_caveat(
+        "substrate_self_state", fetch_earliest_self_state_ts(conn), window_start
+    )
+    if ss_retention_note:
+        caveats.append(ss_retention_note)
     progress.emit(
         "self_state loaded", percent=40.0, processed=len(self_states), total=len(self_states), anomalies=anomalies
     )
@@ -811,6 +896,11 @@ def run(window_days: int) -> int:
     if r_trunc:
         caveats.append(f"reduction receipts truncated at MAX_ROWS={MAX_ROWS}")
         anomalies += 1
+    receipt_retention_note = retention_caveat(
+        "substrate_reduction_receipts", fetch_earliest_receipt_ts(conn), window_start
+    )
+    if receipt_retention_note:
+        caveats.append(receipt_retention_note)
     progress.emit(
         "receipts loaded", percent=60.0, processed=len(receipts), total=len(receipts), anomalies=anomalies
     )
@@ -854,7 +944,7 @@ def run(window_days: int) -> int:
     # ---- Emit artifacts ----
     write_before_after_csv(CSV_PATH, silent_metrics, busy_metrics)
     report = render_report(
-        window_days=window_days,
+        window_label=window_label,
         window_start=window_start,
         window_end=now,
         silent=silent_metrics,
@@ -884,24 +974,47 @@ def run(window_days: int) -> int:
     print(f"\nverdict (a) endogenous drift : {verdict_a}")
     print(f"verdict (b) internal economy : {verdict_b}")
     print(f"\nartifacts: {REPORT_PATH}, {CSV_PATH}, {PROGRESS_PATH}")
+    # Exit code distinguishes "the instrument didn't work" (2) from a
+    # completed measurement, whichever way it came out (0) -- a caller
+    # (cron, CI, a human) must not have to parse the report text to tell
+    # a dead sensor from a real GO/NO-GO.
+    if UNMEASURABLE in (verdict_a, verdict_b):
+        return 2
     return 0
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Read-only autonomy-origination measurement gate.")
-    parser.add_argument(
+    window_group = parser.add_mutually_exclusive_group()
+    window_group.add_argument(
         "--window-days",
         type=int,
-        default=DEFAULT_WINDOW_DAYS,
-        help=f"analysis window in days (default {DEFAULT_WINDOW_DAYS})",
+        default=None,
+        help=f"analysis window in days (default {DEFAULT_WINDOW_DAYS} if neither flag given)",
+    )
+    window_group.add_argument(
+        "--window-hours",
+        type=float,
+        default=None,
+        help="analysis window in hours (mutually exclusive with --window-days)",
     )
     return parser
+
+
+def resolve_window(args: argparse.Namespace) -> tuple[timedelta, str]:
+    """Turn parsed args into (timedelta, human label). Pure, unit-testable."""
+
+    if args.window_hours is not None:
+        return timedelta(hours=args.window_hours), f"{args.window_hours:g}h"
+    days = args.window_days if args.window_days is not None else DEFAULT_WINDOW_DAYS
+    return timedelta(days=days), f"{days} day(s)"
 
 
 def main(argv: Optional[list[str]] = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     args = build_arg_parser().parse_args(argv)
-    return run(args.window_days)
+    window, window_label = resolve_window(args)
+    return run(window, window_label)
 
 
 if __name__ == "__main__":  # pragma: no cover - guarded so import stays I/O-free

--- a/scripts/analysis/tests/test_measure_autonomy_gate.py
+++ b/scripts/analysis/tests/test_measure_autonomy_gate.py
@@ -93,6 +93,25 @@ def test_verdict_a_busy_zero_variance_passes_when_silent_moves():
     assert mod.verdict_drift(silent, busy) == "GO"
 
 
+def test_verdict_a_unmeasurable_when_no_self_state_rows_at_all():
+    # Both classes empty (dead/unreachable Postgres source) -> UNMEASURABLE,
+    # not a numeric "flat, NO-GO" -- distinct from real flat data below.
+    empty = mod.SelfStateMetrics()
+    assert mod.verdict_drift(empty, empty) == mod.UNMEASURABLE
+
+
+def test_verdict_a_flat_but_measured_is_no_go_not_unmeasurable():
+    # Real rows exist and are genuinely flat -- this IS a measured NO-GO,
+    # must not be conflated with the zero-rows UNMEASURABLE case above.
+    silent_rows = [
+        _self_state(i * 10, {"coherence": 0.5}, {"coherence": 0.0}) for i in range(6)
+    ]
+    silent = mod.compute_self_state_metrics(silent_rows)
+    busy = mod.compute_self_state_metrics(silent_rows)
+    assert silent.row_count > 0
+    assert mod.verdict_drift(silent, busy) == "NO-GO"
+
+
 # ---------------------------------------------------------------------------
 # 3. Rare co-activation + flat pressure -> verdict (b) NO-GO
 # ---------------------------------------------------------------------------
@@ -104,6 +123,17 @@ def test_verdict_b_rare_coactivation_is_no_go():
     assert drive.coactivation_frac < mod.COACTIVATION_MIN_FRAC
     assert pressure.frac_gt_level < mod.RESOURCE_PRESSURE_MIN_FRAC
     assert mod.verdict_economy(drive, pressure) == "NO-GO"
+
+
+def test_verdict_b_unmeasurable_when_no_drive_audit_rows():
+    # Dead/unreachable Fuseki source (record_count == 0) -> UNMEASURABLE, not
+    # a numeric "0% co-activation, NO-GO" -- this is the exact failure mode
+    # that motivated this fix (the graph was empty for days without anyone
+    # noticing the verdict was silently reading as a real behavioral NO-GO).
+    empty_drive = mod.drive_stats_from_histogram({})
+    pressure = mod.compute_resource_pressure_stats([])
+    assert empty_drive.record_count == 0
+    assert mod.verdict_economy(empty_drive, pressure) == mod.UNMEASURABLE
 
 
 # ---------------------------------------------------------------------------
@@ -194,9 +224,10 @@ def test_empty_metrics_do_not_raise():
     assert mod.per_row_abs_trajectory([]) == []
     assert mod._percentile([], 0.9) is None
 
-    # Verdicts on empty metrics are well-defined NO-GO.
-    assert mod.verdict_drift(ss, ss) == "NO-GO"
-    assert mod.verdict_economy(drive, pressure) == "NO-GO"
+    # Verdicts on empty metrics are UNMEASURABLE, not a numeric NO-GO -- a
+    # dead/unreachable source must never resolve to a behavioral finding.
+    assert mod.verdict_drift(ss, ss) == mod.UNMEASURABLE
+    assert mod.verdict_economy(drive, pressure) == mod.UNMEASURABLE
 
 
 def test_percentile_and_median():
@@ -268,3 +299,64 @@ def test_parse_sparql_histogram_bindings_retains_zero_bucket():
 def test_parse_sparql_histogram_bindings_degrades():
     # Empty bindings -> empty dict, no raise.
     assert mod.parse_sparql_histogram_bindings([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# 8. --window-hours / --window-days: mutually exclusive, resolve to a timedelta
+# ---------------------------------------------------------------------------
+def test_resolve_window_defaults_to_days_when_neither_flag_given():
+    args = mod.build_arg_parser().parse_args([])
+    window, label = mod.resolve_window(args)
+    assert window == timedelta(days=mod.DEFAULT_WINDOW_DAYS)
+    assert label == f"{mod.DEFAULT_WINDOW_DAYS} day(s)"
+
+
+def test_resolve_window_hours_flag():
+    args = mod.build_arg_parser().parse_args(["--window-hours", "1"])
+    window, label = mod.resolve_window(args)
+    assert window == timedelta(hours=1)
+    assert label == "1h"
+
+
+def test_resolve_window_days_flag_explicit():
+    args = mod.build_arg_parser().parse_args(["--window-days", "3"])
+    window, label = mod.resolve_window(args)
+    assert window == timedelta(days=3)
+    assert label == "3 day(s)"
+
+
+def test_window_hours_and_window_days_are_mutually_exclusive():
+    with pytest.raises(SystemExit):
+        mod.build_arg_parser().parse_args(["--window-days", "3", "--window-hours", "1"])
+
+
+# ---------------------------------------------------------------------------
+# 9. Retention-bound caveat -- window exceeds what a source actually covers
+# ---------------------------------------------------------------------------
+def test_retention_caveat_none_when_source_covers_full_window():
+    window_start = BASE
+    oldest_available = BASE - timedelta(days=1)  # covers further back than needed
+    assert mod.retention_caveat("substrate_self_state", oldest_available, window_start) is None
+
+
+def test_retention_caveat_fires_when_source_retention_is_shorter():
+    window_start = BASE - timedelta(days=7)
+    oldest_available = BASE - timedelta(days=3)  # only 3 of the 7 requested days exist
+    note = mod.retention_caveat("substrate_self_state", oldest_available, window_start)
+    assert note is not None
+    assert "substrate_self_state" in note
+    assert "96.0h" in note  # 4 days short, expressed in hours
+
+
+def test_retention_caveat_none_when_oldest_unknown():
+    # oldest_available=None means "couldn't determine" (empty table / fetch
+    # failure) -- a separate unavailability caveat already covers that case,
+    # this function must not fabricate a bound it doesn't actually know.
+    assert mod.retention_caveat("substrate_self_state", None, BASE) is None
+
+
+# ---------------------------------------------------------------------------
+# 10. Exit code distinguishes UNMEASURABLE from a completed GO/NO-GO
+# ---------------------------------------------------------------------------
+def test_unmeasurable_constant_is_distinct_from_go_and_no_go():
+    assert mod.UNMEASURABLE not in ("GO", "NO-GO")

--- a/scripts/analysis/tests/test_measure_autonomy_gate.py
+++ b/scripts/analysis/tests/test_measure_autonomy_gate.py
@@ -358,5 +358,14 @@ def test_retention_caveat_none_when_oldest_unknown():
 # ---------------------------------------------------------------------------
 # 10. Exit code distinguishes UNMEASURABLE from a completed GO/NO-GO
 # ---------------------------------------------------------------------------
-def test_unmeasurable_constant_is_distinct_from_go_and_no_go():
-    assert mod.UNMEASURABLE not in ("GO", "NO-GO")
+def test_verdict_b_unmeasurable_when_pressure_empty_even_with_live_drive_data():
+    # The asymmetric-guard bug this locks in: drive co-activation data is
+    # real and high (Fuseki alive), but pressure comes from an empty
+    # self-state list (Postgres dead/unreachable) -- must be UNMEASURABLE,
+    # not a numeric "NO-GO" fabricated from pressure.frac_gt_level
+    # silently defaulting to 0.0 against a real coactivation_frac.
+    drive = mod.drive_stats_from_histogram({2: 10, 1: 10})  # 50% co-active
+    empty_pressure = mod.compute_resource_pressure_stats([])
+    assert drive.coactivation_frac >= mod.COACTIVATION_MIN_FRAC
+    assert empty_pressure.row_count == 0
+    assert mod.verdict_economy(drive, empty_pressure) == mod.UNMEASURABLE


### PR DESCRIPTION
# fix(autonomy-gate): instrument fix -- UNMEASURABLE verdict, --window-hours, retention caveat (P6)

## Summary

- `scripts/analysis/measure_autonomy_gate.py` (the read-only gate that decides whether Orion's endogenous-drive-origination cognition feature is safe to build) had a real bug: when a data source returned zero rows -- unreachable, or a write pipeline silently stopped -- every metric degraded to `0.0`, which read as a genuine "measured and flat, NO-GO" verdict instead of "we measured nothing."
- Added a third verdict value, `UNMEASURABLE`, returned instead of a numeric NO-GO when an input is empty. `run()`/`main()` now exit `2` when either verdict is UNMEASURABLE, distinct from `0` for a completed GO/NO-GO measurement.
- Added `--window-hours` (mutually exclusive with `--window-days`) -- the 1-hour run used to produce today's earlier verdict-(a) GO needed an ad-hoc wrapper before this.
- Added a retention-bound caveat: if the requested window reaches further back than a source's actual live retention, the report names which source is the binding constraint and by how many hours, instead of silently under-covering older buckets.
- Live-diagnosed a real, previously-uncommitted finding while re-running the fixed instrument: the Fuseki `DriveAudit` graph has received zero writes since 2026-06-19T07:06:29Z (traced to commit `e9b233e9`, which disabled RDF materialization that day). The 2026-07-08 verdict-(b) NO-GO on record was computed against this same frozen snapshot the whole time -- corrected to UNMEASURABLE, with the root cause committed so it stops being re-measured as a false NO-GO.

## Outcome moved

The gate this feature (and the internal-economy spec) is blocked on now tells the truth about whether it measured anything. Verdict (a), re-run live today, is **GO** on both 1h and 7d windows -- Step 1 of the origination arc is no longer gated. Verdict (b) is now honestly **UNMEASURABLE**, not a fabricated NO-GO -- Step 4 stays blocked, but on the right basis.

## Current architecture

The original P6 scope (from `docs/superpowers/specs/2026-07-13-endogenous-action-motor-nerve-spec.md`) assumed the Fuseki co-activation query itself needed repointing. Re-verified against live data before starting: that part was already fixed by an unrelated commit series (`de0ad072`..`8d20cc36`, already on `main`) -- confirmed via a direct SPARQL `COUNT` (444,943 rows exist). P6's real remaining scope was re-derived from reading the live script instead of trusting the (by-then-stale) spec text.

## Architecture touched

One script (`scripts/analysis/measure_autonomy_gate.py`), its test file, its README, and the origination design doc it gates (`docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md`). No services, no runtime config, no `.env` files -- this is a standalone, read-only analysis CLI.

## Files changed

- `scripts/analysis/measure_autonomy_gate.py` -- `UNMEASURABLE` constant + guard in both verdict functions (symmetric, after a review fix -- see below), `retention_caveat()` + two new IO adapters (`fetch_earliest_self_state_ts`/`fetch_earliest_receipt_ts`), `--window-hours` flag + `resolve_window()`, exit code 2 on UNMEASURABLE.
- `scripts/analysis/tests/test_measure_autonomy_gate.py` -- 10 new pure-layer tests (no DB/network); one existing test's assertion flipped from `NO-GO` to `UNMEASURABLE` (it had been asserting the bug's own behavior as correct).
- `scripts/analysis/README.md` -- documents `--window-hours`, `UNMEASURABLE`, retention caveats, exit codes.
- `docs/superpowers/specs/2026-07-07-endogenous-drive-origination-design.md` -- appended today's live re-run with the frozen-graph root cause.
- `docs/superpowers/specs/2026-07-13-autonomy-gate-instrument-p6-design.md` (new) -- design spec.

## Schema / bus / API changes

None -- standalone script, no bus/schema/service surface.

## Env/config changes

None.

## Tests run

```text
cd /mnt/scripts/Orion-Sapienform-autonomy-gate-instrument-fix
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest scripts/analysis/tests/test_measure_autonomy_gate.py -q

26 passed
```
`git diff --check` clean.

**Live verification (not a unit test, a real run against production Postgres/Fuseki, read-only):**

```text
POSTGRES_URI=postgresql://postgres:postgres@localhost:55432/conjourney \
AUTONOMY_GRAPH_QUERY_URL=http://localhost:3030/orion/query \
python scripts/analysis/measure_autonomy_gate.py --window-hours 1
# exit code: 2 (verdict b UNMEASURABLE)
# (a) GO -- silent median_abs_trajectory 0.0442 >= 0.03
# (b) UNMEASURABLE -- 0 DriveAudit rows in the last hour

python scripts/analysis/measure_autonomy_gate.py --window-days 7
# exit code: 2
# (a) GO -- silent median_abs_trajectory 0.0408 >= 0.03
# (b) UNMEASURABLE -- 0 DriveAudit rows in the last 7 days
# caveat fired: substrate_self_state retention only covers back to
#   2026-07-10T18:32:24Z, 95.9h short of the requested window start
```

## Evals run

None -- this is a measurement instrument, not a service; its own output (GO/NO-GO/UNMEASURABLE against real data) is the eval.

## Docker/build/smoke checks

Not applicable -- no container, no runtime service. The "smoke test" for this patch is the two live runs above, both against real production Postgres and Fuseki, read-only (`open_readonly_connection` refuses to proceed if the session isn't verified read-only).

## Review findings fixed

- Finding: `verdict_economy`'s `UNMEASURABLE` guard only checked `drive.record_count == 0`, not `pressure.row_count == 0`, even though the GO/NO-GO rule reads both. A dead Postgres source with a live Fuseki source would silently produce a real-looking `"NO-GO"` string instead of `UNMEASURABLE` -- the exact failure mode this patch exists to prevent, left open on one of its two inputs.
  - Fix: guard changed to `if drive.record_count == 0 or pressure.row_count == 0: return UNMEASURABLE`.
  - Evidence: `tests/test_measure_autonomy_gate.py::test_verdict_b_unmeasurable_when_pressure_empty_even_with_live_drive_data` -- live coactivation data (50%, well above threshold) + empty pressure now correctly returns UNMEASURABLE, not NO-GO.
- Finding: one new test (`test_unmeasurable_constant_is_distinct_from_go_and_no_go`) only compared string literals and exercised no function under test -- zero regression value.
  - Fix: replaced with the asymmetric-guard regression test above.
  - Evidence: `git diff` on the test file.
- Checked and confirmed correct (no fix needed): exit-code precedence (report/CSV/progress always written before the exit-code decision), argparse mutual-exclusion and default-preservation, `retention_caveat`'s comparison direction and hour math, the new IO adapters' degrade-on-failure convention, and the `e9b233e9` commit citation in the origination doc (verified via `git show e9b233e9` -- real commit, ~2.5 minutes after the doc's claimed last-Fuseki-write timestamp, tight and plausible match).

## Restart required

```text
No restart required.
```
Standalone script; no service reads or depends on it at runtime.

## Risks / concerns

- Severity: low
- Concern: verdict (b) (internal economy) remains genuinely unmeasured -- re-enabling Fuseki RDF materialization for `DriveAudit` (reversing `e9b233e9`) is a real infra decision (that commit disabled it to relieve Fuseki load) not made or recommended here; repointing the gate's adapter at a different live source is named as a follow-up, not attempted.
- Mitigation: none needed for this patch specifically -- the point of P6 was making the instrument honest about not knowing, not making Step 4 measurable. That's a separate, larger decision for whoever owns the internal-economy spec next.
