### PR TITLE
Feat/autonomy experience loop p2

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-autonomy-experience-loop-p2-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-autonomy-experience-loop-p2-pr.md
@@ -1,0 +1,105 @@
+# feat(autonomy): experience loop -- Layer 9 actions become memory + chat evidence (P2)
+
+## Summary
+
+- Layer 9 (`orion-execution-dispatch-runtime`, P0+P1, merged) reached nothing outside its own table until now — zero references to episode journaling or action outcomes existed anywhere in that service. Every real dispatch result (success, empty observation, or RPC failure) now publishes an `ActionOutcomeEmitV1` event onto the existing `orion:autonomy:action:outcome` bus channel — the same always-on route `orion-spark-concept-induction` already produces onto for curiosity-fetch outcomes. No new pipe.
+- `services/orion-cortex-exec/app/chat_stance.py` gained `_project_recent_dispatch_actions`, querying `load_action_outcomes(subject="orion")` directly and projecting to a bounded, privacy-safe `{kind, summary, success, observed_at}` shape (never `action_id`/`query`/`articles`/`salience`), rendered into `chat_general.j2`'s existing EVIDENCE-GATED CLAIMS section.
+- Re-grounded against live code before writing anything: the original brainstorm-level P2 plan assumed a new `felt_state_reader.py` lane and flipping `ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED`. Both were wrong — the data already reaches chat-turn state via a different, already-wired path, and that flag gates a *retired* duplicate-email feature, not anything Layer-9-related. Neither is touched by this patch.
+
+## Outcome moved
+
+A real autonomous action, once it happens (still gated behind `EXECUTION_DISPATCH_MODE=dispatch_read_only`, still not the default anywhere), now becomes something Orion can truthfully reference in conversation — "I looked into X" backed by a real evidence row, not invented. Before this patch, a completed Layer 9 dispatch produced a database row nothing else in the system ever read.
+
+## Current architecture
+
+Two real, already-durable mechanisms existed and were both orphaned from Layer 9: the `ActionOutcomeEmitV1` → sql-writer → `action_outcomes` bus route (fired only from one curiosity-fetch call site), and `AutonomyStateV2.last_action_outcomes` (already wired into `chat_stance.py` at the reducer level, but never rendered into any template). This patch connects Layer 9 to the producer side of the first, and connects the second's already-flowing data to a template — two thin patches, not the three-part design the pre-grounding brainstorm assumed.
+
+## Architecture touched
+
+`orion-execution-dispatch-runtime` (worker, settings, `.env_example`), `orion/bus/channels.yaml` (producer registration), `orion-cortex-exec` (`chat_stance.py`, `chat_general.j2`). No new schemas, no new tables, no new services.
+
+## Files changed
+
+- `services/orion-execution-dispatch-runtime/app/worker.py` — `_emit_action_outcome`, wired into all three `_send_one` outcome paths including idempotent replay.
+- `services/orion-execution-dispatch-runtime/app/settings.py`, `.env_example` — `BUS_ACTION_OUTCOME_OUT` / `action_outcome_channel`.
+- `orion/bus/channels.yaml` — `orion-execution-dispatch-runtime` added as a second producer on `orion:autonomy:action:outcome`.
+- `services/orion-cortex-exec/app/chat_stance.py` — `_project_recent_dispatch_actions`.
+- `orion/cognition/prompts/chat_general.j2` — renders `chat_recent_dispatch_actions` in the evidence-gated section.
+- `tests/test_execution_dispatch_runtime_worker.py`, `tests/test_execution_dispatch_bus_catalog.py` — new/extended.
+- `services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py` (new).
+- `services/orion-execution-dispatch-runtime/README.md`, `services/orion-cortex-exec/README.md` — documented.
+- `docs/superpowers/specs/2026-07-13-autonomy-experience-loop-p2-design.md` — design spec.
+
+## Schema / bus / API changes
+
+- **Added:** none — reuses `ActionOutcomeEmitV1` and the `orion:autonomy:action:outcome` channel exactly as they already exist.
+- **Removed:** none.
+- **Renamed:** none.
+- **Behavior changed:** `orion:autonomy:action:outcome` now has two producers instead of one. `chat_general.j2` renders an additional evidence block when `chat_recent_dispatch_actions` is non-empty (harmless/absent otherwise).
+- **Compatibility notes:** `sql-writer`'s route for this channel upserts by `action_id` (SQL primary key) via `merge()` — confirmed during review, this is why re-emitting on replay is safe rather than a duplication risk.
+
+## Env/config changes
+
+- Added keys: `BUS_ACTION_OUTCOME_OUT` (`services/orion-execution-dispatch-runtime/.env_example`, default `orion:autonomy:action:outcome`).
+- Removed/renamed keys: none.
+- `.env_example` updated: yes.
+- local `.env` synced: no local `.env` exists for this service in this sandbox (never run locally here) — confirmed via `git status --short`, nothing created.
+
+## Tests run
+
+```text
+cd /mnt/scripts/Orion-Sapienform-autonomy-experience-loop-p2
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest tests/test_execution_dispatch_runtime_worker.py tests/test_execution_dispatch_bus_catalog.py -q
+22 passed
+
+/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py -q
+10 passed
+```
+(Run as two invocations — combining `orion-execution-dispatch-runtime` and `orion-cortex-exec` test files in one pytest process hits a pre-existing cross-service `app.*` module-name collision, same as encountered in P1; not introduced by this patch.)
+
+`git diff --check` clean. Broader execution-dispatch/feedback suite (100 tests) also re-run and green after the review-fix commit.
+
+## Evals run
+
+None — no eval harness exists for either touched service; this patch doesn't add a new quality dimension an eval would measure (it wires existing, already-tested mechanisms together).
+
+## Docker/build/smoke checks
+
+Not run — no container build available in this sandbox. The data-flow chain (emit → sql-writer route → SQL table → `load_action_outcomes` → chat_stance projection → template) was traced file-by-file and confirmed intact during code review, but not live-exercised end-to-end (would require a running bus + sql-writer + real dispatch, none available here).
+
+## Review findings fixed
+
+- Finding (HIGH): the idempotent-replay path in `worker.py` skipped the `ActionOutcomeEmitV1` emit entirely, justified by a "would duplicate the record" comment that was factually wrong — `action_outcomes.action_id` is the SQL primary key and sql-writer's route upserts via `merge()`, so a repeat emit for the same `dispatch_id` overwrites rather than duplicates. Skipping it meant a crash between `save_dispatch_result` and the emit (or a transient bus failure inside the emit's own swallowed try/except) permanently lost that outcome, since every later tick also hits the replay branch.
+  - Fix: replay path now re-emits, reconstructing summary/success from the stored result.
+  - Evidence: `tests/test_execution_dispatch_runtime_worker.py::test_send_one_re_emits_action_outcome_on_idempotent_replay`.
+- Finding (MEDIUM): `_project_recent_dispatch_actions` read `ctx["chat_autonomy_state_v2"]["last_action_outcomes"]`, which silently returns `[]` whenever `_run_autonomy_reducer` resolved a different subject for that turn (e.g. `"relationship"` during autonomy contextual fallback, a real production path) even though real Layer 9 outcomes exist under `subject="orion"`.
+  - Fix: queries `load_action_outcomes(subject="orion")` directly, decoupling the feature from the ambient reducer's per-turn subject.
+  - Evidence: `services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py::test_queries_the_orion_subject_directly_not_ctx`.
+- Checked and confirmed correct (no fix needed): the full data-flow chain from emit to template render (traced line-by-line by the reviewer); the `chat_autonomy_state_v2` vs `chat_autonomy_state` key choice (the design doc's originally-specified key doesn't have the needed field at all — caught by the implementing agent mid-build via runtime verification, not the reviewer); sort/newest-first ordering; a claimed test-pollution issue was independently reproduced against unmodified `origin/main` and confirmed pre-existing, unrelated to this patch.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-execution-dispatch-runtime/.env \
+  -f services/orion-execution-dispatch-runtime/docker-compose.yml \
+  up -d --build
+
+docker compose \
+  --env-file .env \
+  --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml \
+  up -d --build
+```
+No migration needed — reuses the existing `action_outcomes` table and channel. No config flip required for this patch's own code to be inert-safe; it only produces visible behavior once real dispatches occur, which itself still requires `EXECUTION_DISPATCH_MODE=dispatch_read_only` to be set (not the default).
+
+## Risks / concerns
+
+- Severity: low
+- Concern: the full chain (bus emit → sql-writer → SQL → chat projection → template) is unit-tested at each link but not live-exercised end-to-end in this sandbox.
+- Mitigation: recommend confirming this during the same P1 burn-in window already planned (watch for `action_outcomes` rows appearing with `subject='orion'` when a real dispatch fires, then confirm a subsequent chat turn's stance context contains `chat_recent_dispatch_actions`).
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/autonomy-experience-loop-p2

--- a/docs/superpowers/specs/2026-07-13-autonomy-experience-loop-p2-design.md
+++ b/docs/superpowers/specs/2026-07-13-autonomy-experience-loop-p2-design.md
@@ -1,0 +1,81 @@
+# Autonomy experience loop (P2 of the motor-nerve spec) — design
+
+**Date:** 2026-07-13
+**Status:** Implementation, this session
+**Mode:** Thin patch. Implements P2 of the motor-nerve series (P0/P1/P6 merged) — re-grounded against live code, not the original brainstorm-level P2 section, which assumed a `felt_state_reader` lane and a flag-flip that turn out to be wrong.
+
+## Arsonist summary
+
+P1 gave Layer 9 a real send path: `orion-execution-dispatch-runtime` now dispatches real cortex-exec calls and records results in `substrate_dispatch_results`. Nothing downstream of that knows it happened. Zero references to `episode_journal`, `action_outcome`, or any journaling/memory call exist anywhere in `services/orion-execution-dispatch-runtime/`. An autonomous action today produces a database row nothing reads and nothing narrates.
+
+Two real mechanisms already exist to fix this, both currently orphaned from Layer 9:
+1. **`ActionOutcomeEmitV1` bus-emit → sql-writer → `action_outcomes` table** — an always-on, no-feature-toggle route (`orion:autonomy:action:outcome` channel). Currently fired from exactly one call site: `orion/spark/concept_induction/bus_worker.py:1048`, on world-pulse curiosity-fetch completion. Layer 9 never calls it.
+2. **`load_action_outcomes(subject)` → `AutonomyReducerInputV1.action_outcomes` → `AutonomyStateV2.last_action_outcomes`** — already wired at `services/orion-cortex-exec/app/chat_stance.py:2284`. This data already reaches chat-turn state. It is never rendered into any prompt template (`grep` confirms zero `.j2` references to `last_action_outcomes` or any autonomy-state action field).
+
+So the real gap isn't "build a new pipe" — it's "connect Layer 9 to pipe #1's producer side, and connect pipe #2's already-flowing data to a template." Two thin patches, not the three-part felt-state-lane design the original brainstorm assumed before this session re-verified the code.
+
+**Explicitly not in scope, corrected from the brainstorm:** flipping `ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED`. That flag is documented (`.env_example:127-135`, `orion/journaler/worker.py:219-223`) as retired — it gates a duplicate-email path that was deliberately folded into the world-pulse journal to stop sending two emails a day. Flipping it back on would resurrect that regression, not enable anything Layer-9-related. If Layer 9 dispatch results should also produce an episode-journal entry (narrating "I looked into X"), that needs its own, distinctly-named flag and its own call site — scoped as a explicit non-goal for this patch (see below) since it's a second, separable piece of surface area with its own privacy/tone considerations (mirroring `dispatch_autonomy_episode_journal`'s existing machinery, per `orion/autonomy/episode_journal.py`), better done as its own reviewed slice than bundled in.
+
+## Current architecture
+
+- **`services/orion-execution-dispatch-runtime/app/worker.py`** (P1): `_send_one` calls `client.dispatch(...)`, persists a result via `self._store.save_dispatch_result(...)`, and returns a promoted candidate. No bus publish beyond the cortex RPC itself. No `orion.autonomy` imports at all.
+- **`orion/autonomy/action_outcomes.py`**: `append_action_outcome(subject, outcome)` writes only to a local file store (`/tmp/orion-action-outcomes.json` by default) — this is a dev/fallback path, not the durable one. The durable path is the bus-emit (`ActionOutcomeEmitV1` → `orion:autonomy:action:outcome` → sql-writer → `action_outcomes` SQL table), fired only from `bus_worker.py:1048`. `load_action_outcomes(subject)` reads SQL first (if `ORION_ACTION_OUTCOME_DB_URL` set) else falls back to the file store — so Layer 9's new outcomes must reach SQL via the bus-emit route to be visible to `load_action_outcomes` in the live (non-dev) config.
+- **`orion/autonomy/models.py`**: `ActionOutcomeEmitV1` (flat: `subject, action_id, kind, summary, success, surprise, observed_at`) is what travels the bus; `ActionOutcomeRefV1` (richer: adds `query, articles, salience`) is what `load_action_outcomes` returns after `.to_outcome()` converts back. Layer 9 has no `query`/`articles` to report — the flat `ActionOutcomeEmitV1` shape is a complete fit, no schema change needed.
+- **Bus channel**: `orion:autonomy:action:outcome` (`orion/bus/channels.yaml:1738-1744`), `kind: event`, `producer_services: ["orion-spark-concept-induction"]`, `consumer_services: ["orion-sql-writer", "*"]`. Needs `orion-execution-dispatch-runtime` added as a second producer.
+- **`BaseEnvelope.correlation_id` must be a real UUID** (confirmed the hard way during P1) — the existing call site passes `env.correlation_id` (already a UUID from the triggering envelope). Layer 9 has no triggering envelope with a UUID correlation_id readily available per-candidate; generate a fresh `uuid4()` per emit, same pattern as P1's `cortex_client.py`.
+- **`services/orion-cortex-exec/app/chat_stance.py`**: `_project_reverie_glimpse` (lines 1336-1382) is the established pattern for "typed, bounded, privacy-safe projection from raw ctx into a template-visible field" — reads a raw lane, validates it, extracts only the narration-safe field, documents explicitly what it does NOT pass through. `ctx["chat_autonomy_state"]` already carries `last_action_outcomes: list[ActionOutcomeRefV1]` by the time stance-building reaches template rendering (populated at line 2284, attached to ctx around line 2474-2475).
+- **Templates**: `orion/cognition/prompts/chat_general.j2` has an explicit "EVIDENCE-GATED CLAIMS" section (lines 105-114): *"Evidence sources are current-turn inputs only... If evidence is absent, do not claim they occurred."* — the correct, already-designed landing spot for a bounded "recent autonomous actions" reference, so Orion can truthfully say "I looked into X" only when real evidence is present.
+
+## Proposed schema / API changes
+
+**No new schemas.** `ActionOutcomeEmitV1` and `ActionOutcomeRefV1` already exist and already fit Layer 9's shape.
+
+**`services/orion-execution-dispatch-runtime/app/worker.py`**: after `_send_one` computes a result (success, empty, or failed), publish an `ActionOutcomeEmitV1` onto `orion:autonomy:action:outcome`:
+- `subject="orion"` (the established self-subject convention — confirmed via `orion/autonomy/reducer.py:237`, `substrate_metabolism.py:41`, `signal_tension.py:64`, all default/use `subject="orion"`).
+- `action_id=candidate.dispatch_id`.
+- `kind=candidate.dispatch_kind` (already one of `inspect`/`summarize`/`observe`/`noop`).
+- `summary=` the `observation` field from `parse_structured_observation`'s result, truncated to a bounded length (mirror `episode_fetch.py`'s discipline — never pass raw multi-KB text through; a short truncation constant, e.g. 280 chars, matches the "typed ref not raw content" rule).
+- `success=(status == "success")`, `None` for `status == "failed"` (unknown, not false — an RPC failure isn't evidence the action itself didn't happen) — actually: `success=True` iff `status=="success"`, `success=False` iff `status in ("empty", "failed")` (both are real, evidenced non-successes; `None` is reserved for genuinely unknown, which doesn't occur here since every candidate reaching this point has a determined status).
+- `surprise=0.0` (no computed surprise signal exists for this action type yet; explicit `0.0` rather than inventing one).
+- `observed_at=dispatched_at` (the same timestamp already stamped on the candidate).
+
+Failure to publish this event must never fail the tick — wrap in the same `try/except: logger.warning(...)` discipline already used for `_notify_tripwire`.
+
+**`orion/bus/channels.yaml`**: add `orion-execution-dispatch-runtime` to `orion:autonomy:action:outcome`'s `producer_services`.
+
+**`services/orion-cortex-exec/app/chat_stance.py`**: new `_project_recent_dispatch_actions(ctx)` function, mirroring `_project_reverie_glimpse`'s shape exactly:
+- Reads `ctx["chat_autonomy_state"]` (already populated), extracts `.last_action_outcomes` if present.
+- Filters to a small bounded window (reuse the existing `_MAX_OUTCOMES = 12` convention from `action_outcomes.py`, but only surface the most recent 1-3 in the prompt — a wall of 12 actions is not what "truthfully reference what I did" needs; cap at 3, newest-first).
+- Projects each to `{kind, summary, success, observed_at}` only — never `query`/`articles`/`salience`/`action_id` (internal correlation data, matches `_project_reverie_glimpse`'s "never `evidence_refs`/`coalition`/`chain_id`" precedent).
+- Result → `ctx["chat_recent_dispatch_actions"]`, a list (possibly empty).
+
+**`orion/cognition/prompts/chat_general.j2`**: render `chat_recent_dispatch_actions` inside the existing "EVIDENCE-GATED CLAIMS" section, following that section's existing tone/format — only present if non-empty, formatted as bounded evidence lines, not prose Orion is meant to copy verbatim.
+
+## Files likely to touch
+
+- `services/orion-execution-dispatch-runtime/app/worker.py` — emit `ActionOutcomeEmitV1` after each real send.
+- `orion/bus/channels.yaml` — producer registration.
+- `services/orion-cortex-exec/app/chat_stance.py` — `_project_recent_dispatch_actions`.
+- `orion/cognition/prompts/chat_general.j2` — render the new ctx key in the evidence-gated section.
+- New bus-catalog test for the producer registration (mirrors P1's pattern).
+- New/extended tests: `services/orion-execution-dispatch-runtime`'s worker test file (emit happens on success/empty/failed, never raises the tick); `services/orion-cortex-exec/tests`' chat_stance test file (projection bounds/truncates/never leaks raw fields, empty-safe).
+
+## Non-goals
+
+- **Episode journal integration for Layer 9 dispatch results** — a real, separate piece of surface area (new flag, new call site reusing `dispatch_autonomy_episode_journal`, its own narrative-seed privacy discipline). Explicitly deferred to its own patch, not bundled here — see Arsonist summary. `ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED` stays untouched.
+- **No `felt_state_reader.py` lane.** The original brainstorm's plan assumed one was needed; re-grounding found the data already reaches chat-turn state via a different, already-wired path (`AutonomyStateV2.last_action_outcomes`). Adding a redundant lane would be exactly the kind of duplicate-pipe cathedral this project's mandate bans.
+- **No new `success`/`surprise` scoring model.** `success` is a direct boolean from dispatch status; `surprise=0.0` is an honest placeholder, not a computed signal — computing real surprise for this action type is future work if it turns out to matter, not invented here.
+- **No mutating dispatch, no flag flips on `EXECUTION_DISPATCH_MODE`.** This patch only wires what happens *after* a real dispatch already occurred (which today only happens with `EXECUTION_DISPATCH_MODE=dispatch_read_only`, still not the default anywhere).
+
+## Acceptance checks
+
+1. `_send_one`'s three outcome paths (success, empty, failed) each produce exactly one `ActionOutcomeEmitV1` publish attempt, verified via a mocked bus in the worker test suite.
+2. A publish failure (bus down) logs a warning and does not raise out of `_send_one`/`_send_prepared_candidates` — the tick completes and the frame still gets persisted.
+3. `_project_recent_dispatch_actions` on an empty/missing `last_action_outcomes` returns `[]`, never raises.
+4. `_project_recent_dispatch_actions` never includes `query`/`articles`/`salience`/`action_id` in its output — a test constructs an `ActionOutcomeRefV1` with all fields populated and asserts the projected dict's keys are exactly `{kind, summary, success, observed_at}`.
+5. `chat_general.j2` renders without error whether `chat_recent_dispatch_actions` is present, empty, or absent from ctx.
+6. Bus-catalog test confirms `orion-execution-dispatch-runtime` is a registered producer on `orion:autonomy:action:outcome`.
+
+## Recommended next patch
+
+The deferred episode-journal-for-Layer-9-dispatch piece named in Non-goals, once this lands and (per P1's own burn-in note) real dispatch data exists to journal. P3 (drive satisfaction + operator inform) is otherwise the next item in the parent series' dependency order.

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -1739,7 +1739,7 @@ channels:
     kind: "event"
     schema_id: "ActionOutcomeEmitV1"
     message_kind: "action.outcome.emit.v1"
-    producer_services: ["orion-spark-concept-induction"]
+    producer_services: ["orion-spark-concept-induction", "orion-execution-dispatch-runtime"]
     consumer_services: ["orion-sql-writer", "*"]
     stability: "experimental"
     since: "2026-07-06"

--- a/orion/cognition/prompts/chat_general.j2
+++ b/orion/cognition/prompts/chat_general.j2
@@ -112,6 +112,12 @@ EVIDENCE-GATED CLAIMS (operational side effects and automation only — not reca
   - avoid: "I logged it in the thread and I'll surface it immediately."
   - prefer (no evidence): "I don't have an automatic tracker here, but I can keep this as an explicit next check-in in this conversation."
   - prefer (with evidence): "I can see an open room-local commitment for this thread; I'll treat it as a local follow-up cue, not a global notification."
+{% if chat_recent_dispatch_actions | default([]) %}
+- Recent autonomous actions (evidence you may truthfully reference, not prose to copy verbatim):
+{% for action in chat_recent_dispatch_actions %}
+  - {{ action.kind }}: {{ action.summary }} ({{ "succeeded" if action.success == true else ("did not succeed" if action.success == false else "outcome unknown") }}, {{ action.observed_at }})
+{% endfor %}
+{% endif %}
 
 {% if speech_contract %}
 TURN CONTRACT

--- a/services/orion-cortex-exec/README.md
+++ b/services/orion-cortex-exec/README.md
@@ -116,6 +116,21 @@ PYTHONPATH=. python orion/autonomy/evals/run_autonomy_v2_movement_eval.py
 
 Operator notes: [docs/autonomy_state_v2_reducer.md](../../docs/autonomy_state_v2_reducer.md). Package README: [orion/autonomy/README.md](../../orion/autonomy/README.md).
 
+### Recent dispatch actions in chat evidence (P2, always on)
+
+`_project_recent_dispatch_actions` (`app/chat_stance.py`) queries
+`load_action_outcomes(subject="orion")` directly — **not** gated by
+`AUTONOMY_STATE_V2_REDUCER_ENABLED` and not read from `ctx`, on purpose:
+reading `ctx["chat_autonomy_state_v2"]["last_action_outcomes"]` instead would
+silently go blank whenever the reducer resolved a different subject for that
+turn (e.g. `"relationship"` during autonomy contextual fallback), even though
+real Layer 9 (`orion-execution-dispatch-runtime`) dispatch outcomes exist
+under `subject="orion"`. Result lands in `ctx["chat_recent_dispatch_actions"]`
+(at most 3, newest-first, projected to exactly `{kind, summary, success,
+observed_at}` — never `action_id`/`query`/`articles`/`salience`) and renders
+in `orion/cognition/prompts/chat_general.j2`'s EVIDENCE-GATED CLAIMS section.
+Fail-open: `[]` on any DB/parse failure, never raises.
+
 ```bash
 pytest services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py -q
 ```

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1387,23 +1387,31 @@ _MAX_RECENT_DISPATCH_ACTIONS = 3
 # `summary` per the P2 design doc. This is a generous defensive ceiling only,
 # not the primary truncation point -- do not rely on it as the main guard.
 _DISPATCH_ACTION_SUMMARY_MAX_CHARS = 300
+# Layer 9 (execution-dispatch-runtime) always emits under this subject --
+# it's self-directed autonomous action, never relationship-scoped. Reading
+# ctx["chat_autonomy_state_v2"]["last_action_outcomes"] instead would silently
+# return [] whenever _run_autonomy_reducer resolved a different subject for
+# THIS turn (e.g. "relationship" during contextual fallback when Orion's own
+# drive/autonomy graph is unavailable -- see select_preferred_autonomy_lookup)
+# even though real dispatch actions exist under "orion". Querying directly
+# decouples this feature from whichever subject the ambient reducer used.
+_DISPATCH_ACTION_SUBJECT = "orion"
 
 
 def _project_recent_dispatch_actions(ctx: Dict[str, Any]) -> list[dict]:
     """Projection helper: surface the most recent autonomous dispatch-action
     outcomes as bounded, privacy-safe evidence for chat narration.
 
-    Reads ``ctx['chat_autonomy_state_v2']`` -- the ``AutonomyStateV2`` dict
-    (``model_dump(mode="json")``) set by ``_run_autonomy_reducer`` once
-    ``AUTONOMY_STATE_V2_REDUCER_ENABLED`` is on -- and extracts
-    ``.last_action_outcomes`` (a list of ``ActionOutcomeRefV1``-shaped dicts
-    or objects). Deliberately NOT ``ctx['chat_autonomy_state']``: that key
-    holds the plain ``AutonomyStateV1`` graph-lookup state, which has no
-    ``last_action_outcomes`` field at all (``AutonomyLookupV1.state`` is typed
-    ``AutonomyStateV1 | None`` in ``orion/autonomy/repository.py``;
-    ``last_action_outcomes`` only exists on the ``AutonomyStateV2`` subclass
-    in ``orion/autonomy/models.py``, and is only populated by
-    ``reduce_autonomy_state`` in ``orion/autonomy/reducer.py``).
+    Queries ``load_action_outcomes(subject=_DISPATCH_ACTION_SUBJECT)``
+    directly, independent of ``ctx`` (the ``ctx`` parameter is accepted only
+    to match this file's other ``_project_*`` helpers' call-site shape).
+    Deliberately NOT ``ctx['chat_autonomy_state_v2']['last_action_outcomes']``
+    -- see ``_DISPATCH_ACTION_SUBJECT``'s comment above for why that would
+    silently go blank during autonomy contextual-fallback turns. Also NOT
+    ``ctx['chat_autonomy_state']`` (the plain ``AutonomyStateV1`` graph-lookup
+    state): it has no ``last_action_outcomes`` field at all (that field only
+    exists on the ``AutonomyStateV2`` subclass in ``orion/autonomy/models.py``,
+    populated by ``reduce_autonomy_state`` in ``orion/autonomy/reducer.py``).
 
     Takes at most ``_MAX_RECENT_DISPATCH_ACTIONS`` entries, newest-first by
     ``observed_at``. Entries with a missing/unparsable ``observed_at`` sort
@@ -1416,17 +1424,13 @@ def _project_recent_dispatch_actions(ctx: Dict[str, Any]) -> list[dict]:
     (``evidence_refs``/``coalition``/``chain_id``).
 
     Fail-open: returns ``[]`` on anything missing, malformed, or unparsable.
-    Never raises.
+    Never raises (``load_action_outcomes`` already degrades gracefully on its
+    own SQL/file-store failures; this wraps the projection logic too).
     """
+    del ctx  # accepted only for call-site consistency with sibling _project_* helpers
     try:
-        state = ctx.get("chat_autonomy_state_v2")
-        if state is None:
-            return []
-        if isinstance(state, dict):
-            outcomes = state.get("last_action_outcomes")
-        else:
-            outcomes = getattr(state, "last_action_outcomes", None)
-        if not outcomes or not isinstance(outcomes, (list, tuple)):
+        outcomes = load_action_outcomes(subject=_DISPATCH_ACTION_SUBJECT)
+        if not outcomes:
             return []
 
         def _field(item: Any, name: str) -> Any:
@@ -2539,12 +2543,11 @@ async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
         except Exception as exc:
             logger.warning("autonomy_reducer_v2_failed error=%s", exc)
 
-    # Placed here, not alongside chat_reverie_glimpse above, because the
-    # source data (chat_autonomy_state_v2.last_action_outcomes) only exists
-    # once the V2 reducer block above has run -- see
-    # _project_recent_dispatch_actions' docstring for why chat_autonomy_state
-    # (set later, at the bottom of this function) is NOT the right source.
-    # Fail-open: [] when the reducer is disabled or produced nothing.
+    # Queries load_action_outcomes(subject="orion") directly (see
+    # _project_recent_dispatch_actions' docstring) rather than reading ctx,
+    # so placement here isn't order-dependent on the V2 reducer block above --
+    # kept in this general area only for proximity to the other stance
+    # context-building calls. Fail-open: [] on any failure.
     ctx["chat_recent_dispatch_actions"] = _project_recent_dispatch_actions(ctx)
 
     if attention_frame_enabled():

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1382,6 +1382,105 @@ def _project_reverie_glimpse(ctx: Dict[str, Any]) -> str | None:
         return None
 
 
+_MAX_RECENT_DISPATCH_ACTIONS = 3
+# The producer (execution-dispatch-runtime) is expected to already bound
+# `summary` per the P2 design doc. This is a generous defensive ceiling only,
+# not the primary truncation point -- do not rely on it as the main guard.
+_DISPATCH_ACTION_SUMMARY_MAX_CHARS = 300
+
+
+def _project_recent_dispatch_actions(ctx: Dict[str, Any]) -> list[dict]:
+    """Projection helper: surface the most recent autonomous dispatch-action
+    outcomes as bounded, privacy-safe evidence for chat narration.
+
+    Reads ``ctx['chat_autonomy_state_v2']`` -- the ``AutonomyStateV2`` dict
+    (``model_dump(mode="json")``) set by ``_run_autonomy_reducer`` once
+    ``AUTONOMY_STATE_V2_REDUCER_ENABLED`` is on -- and extracts
+    ``.last_action_outcomes`` (a list of ``ActionOutcomeRefV1``-shaped dicts
+    or objects). Deliberately NOT ``ctx['chat_autonomy_state']``: that key
+    holds the plain ``AutonomyStateV1`` graph-lookup state, which has no
+    ``last_action_outcomes`` field at all (``AutonomyLookupV1.state`` is typed
+    ``AutonomyStateV1 | None`` in ``orion/autonomy/repository.py``;
+    ``last_action_outcomes`` only exists on the ``AutonomyStateV2`` subclass
+    in ``orion/autonomy/models.py``, and is only populated by
+    ``reduce_autonomy_state`` in ``orion/autonomy/reducer.py``).
+
+    Takes at most ``_MAX_RECENT_DISPATCH_ACTIONS`` entries, newest-first by
+    ``observed_at``. Entries with a missing/unparsable ``observed_at`` sort
+    last (oldest) rather than crashing the sort.
+
+    Projects each entry to EXACTLY ``{kind, summary, success, observed_at}``
+    -- never ``action_id``, ``query``, ``articles``, or ``salience``, since
+    those are internal correlation/audit fields, the same reasoning
+    ``_project_reverie_glimpse`` documents for its own field
+    (``evidence_refs``/``coalition``/``chain_id``).
+
+    Fail-open: returns ``[]`` on anything missing, malformed, or unparsable.
+    Never raises.
+    """
+    try:
+        state = ctx.get("chat_autonomy_state_v2")
+        if state is None:
+            return []
+        if isinstance(state, dict):
+            outcomes = state.get("last_action_outcomes")
+        else:
+            outcomes = getattr(state, "last_action_outcomes", None)
+        if not outcomes or not isinstance(outcomes, (list, tuple)):
+            return []
+
+        def _field(item: Any, name: str) -> Any:
+            if isinstance(item, dict):
+                return item.get(name)
+            return getattr(item, name, None)
+
+        def _sort_epoch(item: Any) -> float:
+            observed_at = _field(item, "observed_at")
+            dt = observed_at if isinstance(observed_at, datetime) else None
+            if dt is None and isinstance(observed_at, str) and observed_at.strip():
+                try:
+                    dt = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+                except Exception:
+                    dt = None
+            if dt is None:
+                return float("-inf")
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+
+        ordered = sorted(outcomes, key=_sort_epoch, reverse=True)[:_MAX_RECENT_DISPATCH_ACTIONS]
+
+        projected: list[dict] = []
+        for item in ordered:
+            observed_at = _field(item, "observed_at")
+            if isinstance(observed_at, datetime):
+                observed_at = observed_at.isoformat()
+            kind = _field(item, "kind")
+            summary = _field(item, "summary")
+            # Skip items that don't validate as a real outcome (non-string
+            # kind/summary) rather than surfacing a hollow {kind: None,
+            # summary: None, ...} row -- an empty-shell entry here would be
+            # exactly the kind of meaningless "evidence" this section exists
+            # to prevent. Only reachable via schema drift in a future writer;
+            # today's sole producer (reduce_autonomy_state) always sets both.
+            if not isinstance(kind, str) or not kind or not isinstance(summary, str) or not summary:
+                continue
+            if len(summary) > _DISPATCH_ACTION_SUMMARY_MAX_CHARS:
+                summary = summary[:_DISPATCH_ACTION_SUMMARY_MAX_CHARS]
+            projected.append(
+                {
+                    "kind": kind,
+                    "summary": summary,
+                    "success": _field(item, "success"),
+                    "observed_at": observed_at,
+                }
+            )
+        return projected
+    except Exception:
+        logger.debug("recent_dispatch_actions_projection_failed", exc_info=True)
+        return []
+
+
 def _concept_summary_from_store(ctx: Dict[str, Any] | None = None) -> dict[str, list[str]]:
     ctx = ctx if isinstance(ctx, dict) else {}
     try:
@@ -2439,6 +2538,14 @@ async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
                 ctx["autonomy_slice"] = autonomy_slice.model_dump(mode="json")
         except Exception as exc:
             logger.warning("autonomy_reducer_v2_failed error=%s", exc)
+
+    # Placed here, not alongside chat_reverie_glimpse above, because the
+    # source data (chat_autonomy_state_v2.last_action_outcomes) only exists
+    # once the V2 reducer block above has run -- see
+    # _project_recent_dispatch_actions' docstring for why chat_autonomy_state
+    # (set later, at the bottom of this function) is NOT the right source.
+    # Fail-open: [] when the reducer is disabled or produced nothing.
+    ctx["chat_recent_dispatch_actions"] = _project_recent_dispatch_actions(ctx)
 
     if attention_frame_enabled():
         try:

--- a/services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
-from app.chat_stance import _project_recent_dispatch_actions
+from app.chat_stance import _DISPATCH_ACTION_SUBJECT, _project_recent_dispatch_actions
 from orion.autonomy.models import ActionOutcomeRefV1
 
 _EXPECTED_KEYS = {"kind", "summary", "success", "observed_at"}
@@ -25,26 +26,32 @@ def _outcome(**overrides) -> ActionOutcomeRefV1:
     return ActionOutcomeRefV1(**payload)
 
 
-def test_empty_when_chat_autonomy_state_v2_absent():
-    assert _project_recent_dispatch_actions({}) == []
+def _patched(outcomes):
+    return patch("app.chat_stance.load_action_outcomes", return_value=outcomes)
 
 
-def test_empty_when_last_action_outcomes_missing():
-    ctx = {"chat_autonomy_state_v2": {"subject": "orion"}}
-    assert _project_recent_dispatch_actions(ctx) == []
+def test_queries_the_orion_subject_directly_not_ctx() -> None:
+    # The whole point of this fix: it must not depend on whatever subject
+    # ctx["chat_autonomy_state_v2"] happened to be reduced for this turn
+    # (e.g. "relationship" during contextual fallback) -- Layer 9 dispatch
+    # actions always live under subject="orion".
+    with _patched([]) as mock_load:
+        _project_recent_dispatch_actions({"chat_autonomy_state_v2": {"subject": "relationship"}})
+    mock_load.assert_called_once_with(subject=_DISPATCH_ACTION_SUBJECT)
+    assert _DISPATCH_ACTION_SUBJECT == "orion"
 
 
-def test_empty_when_last_action_outcomes_empty_list():
-    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": []}}
-    assert _project_recent_dispatch_actions(ctx) == []
+def test_empty_ctx_still_queries_and_returns_empty() -> None:
+    with _patched([]):
+        assert _project_recent_dispatch_actions({}) == []
 
 
-def test_empty_when_last_action_outcomes_none():
-    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": None}}
-    assert _project_recent_dispatch_actions(ctx) == []
+def test_empty_when_load_action_outcomes_returns_empty_list() -> None:
+    with _patched([]):
+        assert _project_recent_dispatch_actions({}) == []
 
 
-def test_caps_at_three_newest_first_and_exact_keys():
+def test_caps_at_three_newest_first_and_exact_keys() -> None:
     outcomes = [
         _outcome(action_id="a1", kind="inspect", observed_at=_NOW - timedelta(hours=4)),
         _outcome(action_id="a2", kind="summarize", observed_at=_NOW - timedelta(hours=3)),
@@ -52,8 +59,8 @@ def test_caps_at_three_newest_first_and_exact_keys():
         _outcome(action_id="a4", kind="inspect", observed_at=_NOW - timedelta(hours=1)),
         _outcome(action_id="a5", kind="noop", observed_at=_NOW),
     ]
-    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": outcomes}}
-    result = _project_recent_dispatch_actions(ctx)
+    with _patched(outcomes):
+        result = _project_recent_dispatch_actions({})
 
     assert len(result) == 3
     # Newest-first: a5 (NOW), a4 (NOW-1h), a3 (NOW-2h).
@@ -66,10 +73,10 @@ def test_caps_at_three_newest_first_and_exact_keys():
         assert "salience" not in r
 
 
-def test_projected_dict_field_values():
+def test_projected_dict_field_values() -> None:
     outcome = _outcome(kind="inspect", summary="checked the mesh", success=True, observed_at=_NOW)
-    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": [outcome]}}
-    result = _project_recent_dispatch_actions(ctx)
+    with _patched([outcome]):
+        result = _project_recent_dispatch_actions({})
 
     assert len(result) == 1
     entry = result[0]
@@ -79,52 +86,31 @@ def test_projected_dict_field_values():
     assert entry["observed_at"] == _NOW.isoformat()
 
 
-def test_handles_json_dumped_dict_shaped_outcomes():
-    """Production shape: ctx['chat_autonomy_state_v2'] is a
-    model_dump(mode='json') dict, so last_action_outcomes items are plain
-    dicts with an ISO string observed_at, not ActionOutcomeRefV1 objects."""
-    outcomes = [
-        {
-            "action_id": "a1",
-            "kind": "inspect",
-            "summary": "checked the mesh",
-            "success": True,
-            "surprise": 0.0,
-            "observed_at": "2026-07-13T00:00:00+00:00",
-            "query": "mesh",
-            "articles": [],
-            "salience": 0.5,
-        }
-    ]
-    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": outcomes}}
-    result = _project_recent_dispatch_actions(ctx)
-
-    assert len(result) == 1
-    assert set(result[0].keys()) == _EXPECTED_KEYS
-    assert result[0]["observed_at"] == "2026-07-13T00:00:00+00:00"
-    assert "action_id" not in result[0]
-
-
-def test_entry_with_none_observed_at_does_not_crash_sort():
+def test_entry_with_none_observed_at_does_not_crash_sort() -> None:
     outcomes = [
         _outcome(action_id="a1", kind="inspect", observed_at=None),
         _outcome(action_id="a2", kind="observe", observed_at=_NOW - timedelta(hours=1)),
         _outcome(action_id="a3", kind="summarize", observed_at=_NOW),
     ]
-    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": outcomes}}
-    result = _project_recent_dispatch_actions(ctx)
+    with _patched(outcomes):
+        result = _project_recent_dispatch_actions({})
 
     # Newest-first, None-timestamped entry sorts last.
     assert [r["kind"] for r in result] == ["summarize", "observe", "inspect"]
     assert result[-1]["observed_at"] is None
 
 
-def test_never_raises_on_malformed_state():
-    assert _project_recent_dispatch_actions({"chat_autonomy_state_v2": "not-a-dict"}) == []
-    assert _project_recent_dispatch_actions({"chat_autonomy_state_v2": {"last_action_outcomes": "not-a-list"}}) == []
+def test_never_raises_when_load_action_outcomes_raises() -> None:
+    with patch("app.chat_stance.load_action_outcomes", side_effect=RuntimeError("db down")):
+        assert _project_recent_dispatch_actions({}) == []
 
 
-def test_skips_items_with_missing_kind_or_summary_rather_than_emitting_hollow_row():
+def test_never_raises_on_malformed_returned_value() -> None:
+    with _patched("not-a-list"):
+        assert _project_recent_dispatch_actions({}) == []
+
+
+def test_skips_items_with_missing_kind_or_summary_rather_than_emitting_hollow_row() -> None:
     """A schema-drifted item (e.g. a future writer that doesn't set kind/summary)
     must be dropped, not surfaced as a {kind: None, summary: None, ...} row --
     that would be exactly the empty-shell "evidence" this projection exists to
@@ -134,19 +120,19 @@ def test_skips_items_with_missing_kind_or_summary_rather_than_emitting_hollow_ro
         {"kind": "inspect", "summary": "", "success": True, "observed_at": _NOW.isoformat()},
         {"kind": "inspect", "summary": "valid entry", "success": True, "observed_at": _NOW.isoformat()},
     ]
-    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": outcomes}}
-    result = _project_recent_dispatch_actions(ctx)
+    with _patched(outcomes):
+        result = _project_recent_dispatch_actions({})
 
     assert len(result) == 1
     assert result[0]["summary"] == "valid entry"
 
 
-def test_success_none_is_preserved_not_coerced_to_false():
+def test_success_none_is_preserved_not_coerced_to_false() -> None:
     """success=None (ActionOutcomeRefV1's documented "genuinely unknown" state)
     must pass through as None, not be silently coerced -- the template layer
     decides how to word an unknown outcome, this projection must not lie about
     it by turning "unknown" into "failed"."""
     outcome = _outcome(success=None)
-    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": [outcome]}}
-    result = _project_recent_dispatch_actions(ctx)
+    with _patched([outcome]):
+        result = _project_recent_dispatch_actions({})
     assert result[0]["success"] is None

--- a/services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.chat_stance import _project_recent_dispatch_actions
+from orion.autonomy.models import ActionOutcomeRefV1
+
+_EXPECTED_KEYS = {"kind", "summary", "success", "observed_at"}
+_NOW = datetime(2026, 7, 13, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _outcome(**overrides) -> ActionOutcomeRefV1:
+    payload = dict(
+        action_id="dispatch-1",
+        kind="inspect",
+        summary="checked the mesh for anomalies",
+        success=True,
+        surprise=0.0,
+        observed_at=_NOW,
+        query="mesh anomalies",
+        articles=[],
+        salience=0.5,
+    )
+    payload.update(overrides)
+    return ActionOutcomeRefV1(**payload)
+
+
+def test_empty_when_chat_autonomy_state_v2_absent():
+    assert _project_recent_dispatch_actions({}) == []
+
+
+def test_empty_when_last_action_outcomes_missing():
+    ctx = {"chat_autonomy_state_v2": {"subject": "orion"}}
+    assert _project_recent_dispatch_actions(ctx) == []
+
+
+def test_empty_when_last_action_outcomes_empty_list():
+    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": []}}
+    assert _project_recent_dispatch_actions(ctx) == []
+
+
+def test_empty_when_last_action_outcomes_none():
+    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": None}}
+    assert _project_recent_dispatch_actions(ctx) == []
+
+
+def test_caps_at_three_newest_first_and_exact_keys():
+    outcomes = [
+        _outcome(action_id="a1", kind="inspect", observed_at=_NOW - timedelta(hours=4)),
+        _outcome(action_id="a2", kind="summarize", observed_at=_NOW - timedelta(hours=3)),
+        _outcome(action_id="a3", kind="observe", observed_at=_NOW - timedelta(hours=2)),
+        _outcome(action_id="a4", kind="inspect", observed_at=_NOW - timedelta(hours=1)),
+        _outcome(action_id="a5", kind="noop", observed_at=_NOW),
+    ]
+    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": outcomes}}
+    result = _project_recent_dispatch_actions(ctx)
+
+    assert len(result) == 3
+    # Newest-first: a5 (NOW), a4 (NOW-1h), a3 (NOW-2h).
+    assert [r["kind"] for r in result] == ["noop", "inspect", "observe"]
+    for r in result:
+        assert set(r.keys()) == _EXPECTED_KEYS
+        assert "action_id" not in r
+        assert "query" not in r
+        assert "articles" not in r
+        assert "salience" not in r
+
+
+def test_projected_dict_field_values():
+    outcome = _outcome(kind="inspect", summary="checked the mesh", success=True, observed_at=_NOW)
+    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": [outcome]}}
+    result = _project_recent_dispatch_actions(ctx)
+
+    assert len(result) == 1
+    entry = result[0]
+    assert entry["kind"] == "inspect"
+    assert entry["summary"] == "checked the mesh"
+    assert entry["success"] is True
+    assert entry["observed_at"] == _NOW.isoformat()
+
+
+def test_handles_json_dumped_dict_shaped_outcomes():
+    """Production shape: ctx['chat_autonomy_state_v2'] is a
+    model_dump(mode='json') dict, so last_action_outcomes items are plain
+    dicts with an ISO string observed_at, not ActionOutcomeRefV1 objects."""
+    outcomes = [
+        {
+            "action_id": "a1",
+            "kind": "inspect",
+            "summary": "checked the mesh",
+            "success": True,
+            "surprise": 0.0,
+            "observed_at": "2026-07-13T00:00:00+00:00",
+            "query": "mesh",
+            "articles": [],
+            "salience": 0.5,
+        }
+    ]
+    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": outcomes}}
+    result = _project_recent_dispatch_actions(ctx)
+
+    assert len(result) == 1
+    assert set(result[0].keys()) == _EXPECTED_KEYS
+    assert result[0]["observed_at"] == "2026-07-13T00:00:00+00:00"
+    assert "action_id" not in result[0]
+
+
+def test_entry_with_none_observed_at_does_not_crash_sort():
+    outcomes = [
+        _outcome(action_id="a1", kind="inspect", observed_at=None),
+        _outcome(action_id="a2", kind="observe", observed_at=_NOW - timedelta(hours=1)),
+        _outcome(action_id="a3", kind="summarize", observed_at=_NOW),
+    ]
+    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": outcomes}}
+    result = _project_recent_dispatch_actions(ctx)
+
+    # Newest-first, None-timestamped entry sorts last.
+    assert [r["kind"] for r in result] == ["summarize", "observe", "inspect"]
+    assert result[-1]["observed_at"] is None
+
+
+def test_never_raises_on_malformed_state():
+    assert _project_recent_dispatch_actions({"chat_autonomy_state_v2": "not-a-dict"}) == []
+    assert _project_recent_dispatch_actions({"chat_autonomy_state_v2": {"last_action_outcomes": "not-a-list"}}) == []
+
+
+def test_skips_items_with_missing_kind_or_summary_rather_than_emitting_hollow_row():
+    """A schema-drifted item (e.g. a future writer that doesn't set kind/summary)
+    must be dropped, not surfaced as a {kind: None, summary: None, ...} row --
+    that would be exactly the empty-shell "evidence" this projection exists to
+    prevent from reaching the evidence-gated prompt section."""
+    outcomes = [
+        {"kind": None, "summary": "has no kind", "success": True, "observed_at": _NOW.isoformat()},
+        {"kind": "inspect", "summary": "", "success": True, "observed_at": _NOW.isoformat()},
+        {"kind": "inspect", "summary": "valid entry", "success": True, "observed_at": _NOW.isoformat()},
+    ]
+    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": outcomes}}
+    result = _project_recent_dispatch_actions(ctx)
+
+    assert len(result) == 1
+    assert result[0]["summary"] == "valid entry"
+
+
+def test_success_none_is_preserved_not_coerced_to_false():
+    """success=None (ActionOutcomeRefV1's documented "genuinely unknown" state)
+    must pass through as None, not be silently coerced -- the template layer
+    decides how to word an unknown outcome, this projection must not lie about
+    it by turning "unknown" into "failed"."""
+    outcome = _outcome(success=None)
+    ctx = {"chat_autonomy_state_v2": {"last_action_outcomes": [outcome]}}
+    result = _project_recent_dispatch_actions(ctx)
+    assert result[0]["success"] is None

--- a/services/orion-execution-dispatch-runtime/.env_example
+++ b/services/orion-execution-dispatch-runtime/.env_example
@@ -21,6 +21,10 @@ ORION_BUS_URL=redis://<tailscale-node-ip>:6379/0
 ORION_BUS_ENABLED=true
 EXECUTION_DISPATCH_RPC_TIMEOUT_SEC=120
 ORION_DISPATCH_MAX_PER_DAY=24
+# Real-send outcomes publish here so load_action_outcomes() (chat-stance,
+# reducer) sees them the same way it already sees curiosity-fetch outcomes --
+# same channel orion-spark-concept-induction already produces onto.
+BUS_ACTION_OUTCOME_OUT=orion:autonomy:action:outcome
 NOTIFY_URL=http://orion-notify:7140
 NOTIFY_API_TOKEN=
 LOG_LEVEL=INFO

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -42,6 +42,29 @@ cortex-exec call never fires twice for the same candidate.
 **Rollback**: set `EXECUTION_DISPATCH_MODE=dry_run` and restart this one container. Single kill
 switch for all real sending.
 
+## Experience loop (P2)
+
+Every real send (success, empty observation, or RPC failure) also publishes an
+`ActionOutcomeEmitV1` event onto `orion:autonomy:action:outcome`
+(`BUS_ACTION_OUTCOME_OUT`, default `orion:autonomy:action:outcome`) — the same
+always-on route `orion-spark-concept-induction` already produces onto for
+curiosity-fetch outcomes, consumed by `orion-sql-writer` into the durable
+`action_outcomes` table. `subject="orion"` (self-directed action, never
+relationship-scoped). This is how a real Layer 9 dispatch becomes something
+`load_action_outcomes()` — and therefore chat-turn stance context — can see;
+see `services/orion-cortex-exec/README.md` for the read side.
+
+The idempotent-replay path (see Idempotency above) re-emits on every replay,
+not just the first attempt: `action_outcomes.action_id` is the SQL primary
+key and sql-writer's route upserts by `merge()`, so a repeat emit for the
+same `dispatch_id` overwrites the same row rather than duplicating it — this
+is what makes replay-safe re-emission correct instead of risky.
+
+A publish failure here is caught and logged, never raises out of the tick —
+`substrate_dispatch_results` already durably recorded the result before the
+emit is attempted, so an unreachable bus loses only chat-visible narration,
+never the underlying record.
+
 ## Status vocabulary
 
 `ExecutionDispatchCandidateV1.dispatch_status`:

--- a/services/orion-execution-dispatch-runtime/app/settings.py
+++ b/services/orion-execution-dispatch-runtime/app/settings.py
@@ -40,6 +40,9 @@ class Settings(BaseSettings):
         120.0, alias="EXECUTION_DISPATCH_RPC_TIMEOUT_SEC"
     )
     orion_dispatch_max_per_day: int = Field(24, alias="ORION_DISPATCH_MAX_PER_DAY")
+    action_outcome_channel: str = Field(
+        "orion:autonomy:action:outcome", alias="BUS_ACTION_OUTCOME_OUT"
+    )
     notify_url: str = Field("http://orion-notify:7140", alias="NOTIFY_URL")
     notify_api_token: str | None = Field(None, alias="NOTIFY_API_TOKEN")
     log_level: str = Field("INFO", alias="LOG_LEVEL")

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -4,8 +4,11 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 
+from orion.autonomy.models import ActionOutcomeEmitV1
 from orion.core.bus.async_service import OrionBusAsync
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
 from orion.execution_dispatch.builder import (
     build_execution_dispatch_frame,
     build_unevaluable_execution_dispatch_frame,
@@ -27,6 +30,13 @@ logger = logging.getLogger("orion.execution_dispatch.runtime")
 
 THEATER_TRIPWIRE_WINDOW = 10
 THEATER_TRIPWIRE_EMPTY_THRESHOLD = 0.5
+# ActionOutcomeEmitV1.summary lands in chat-visible evidence via
+# chat_stance.py's _project_recent_dispatch_actions -- bounded here at the
+# producer so nothing downstream needs to re-truncate raw model output.
+ACTION_OUTCOME_SUMMARY_MAX_CHARS = 280
+# Established self-subject convention across orion/autonomy/* (reducer.py,
+# substrate_metabolism.py, signal_tension.py all default/use this).
+ACTION_OUTCOME_SUBJECT = "orion"
 
 
 class ExecutionDispatchRuntimeWorker:
@@ -192,7 +202,7 @@ class ExecutionDispatchRuntimeWorker:
         newly_dispatched: list[ExecutionDispatchCandidateV1] = []
         try:
             for candidate in to_send:
-                newly_dispatched.append(await self._send_one(client, frame, candidate))
+                newly_dispatched.append(await self._send_one(client, bus, frame, candidate))
         finally:
             await bus.close()
 
@@ -234,6 +244,7 @@ class ExecutionDispatchRuntimeWorker:
     async def _send_one(
         self,
         client: ExecutionDispatchCortexClient,
+        bus: OrionBusAsync,
         frame: ExecutionDispatchFrameV1,
         candidate: ExecutionDispatchCandidateV1,
     ) -> ExecutionDispatchCandidateV1:
@@ -292,6 +303,13 @@ class ExecutionDispatchRuntimeWorker:
                 result_json={"error": str(exc)[:2000], "evidence_refs": [result_id]},
                 raw_len=0,
             )
+            await self._emit_action_outcome(
+                bus,
+                candidate=candidate,
+                summary=f"attempted {candidate.dispatch_kind} on {candidate.target_id}, send failed",
+                success=False,
+                observed_at=now,
+            )
             return candidate.model_copy(
                 update={
                     "dispatch_status": "dispatched",
@@ -318,6 +336,17 @@ class ExecutionDispatchRuntimeWorker:
             status,
             raw_len,
         )
+        await self._emit_action_outcome(
+            bus,
+            candidate=candidate,
+            summary=(
+                observation_data["observation"]
+                if raw_len > 0
+                else f"{candidate.dispatch_kind} on {candidate.target_id} returned no observation"
+            ),
+            success=raw_len > 0,
+            observed_at=now,
+        )
         return candidate.model_copy(
             update={
                 "dispatch_status": "dispatched",
@@ -325,6 +354,48 @@ class ExecutionDispatchRuntimeWorker:
                 "result_ref": result_id,
             }
         )
+
+    async def _emit_action_outcome(
+        self,
+        bus: OrionBusAsync,
+        *,
+        candidate: ExecutionDispatchCandidateV1,
+        summary: str,
+        success: bool,
+        observed_at: datetime,
+    ) -> None:
+        """Publish onto the same always-on ActionOutcomeEmitV1 route
+        orion-spark-concept-induction already uses for curiosity-fetch
+        outcomes -- no new pipe, reusing an existing durable sink
+        (sql-writer -> action_outcomes) so load_action_outcomes() sees
+        Layer 9's real dispatch results the same way it already sees
+        curiosity-fetch ones. Never lets a publish failure raise out of
+        the tick -- an unreachable bus must not lose a result that's
+        already durably recorded via save_dispatch_result above.
+        """
+        try:
+            emit = ActionOutcomeEmitV1(
+                subject=ACTION_OUTCOME_SUBJECT,
+                action_id=candidate.dispatch_id,
+                kind=candidate.dispatch_kind,
+                summary=summary[:ACTION_OUTCOME_SUMMARY_MAX_CHARS],
+                success=success,
+                surprise=0.0,
+                observed_at=observed_at,
+            )
+            env = BaseEnvelope(
+                kind="action.outcome.emit.v1",
+                source=ServiceRef(name=self._settings.service_name),
+                correlation_id=str(uuid4()),
+                payload=emit.model_dump(mode="json"),
+            )
+            await bus.publish(self._settings.action_outcome_channel, env)
+        except Exception:
+            logger.warning(
+                "execution_dispatch_action_outcome_emit_failed dispatch_id=%s",
+                candidate.dispatch_id,
+                exc_info=True,
+            )
 
     def _notify_tripwire(self, empty_count: int, window: int) -> None:
         try:

--- a/services/orion-execution-dispatch-runtime/app/worker.py
+++ b/services/orion-execution-dispatch-runtime/app/worker.py
@@ -265,8 +265,24 @@ class ExecutionDispatchRuntimeWorker:
                 candidate.dispatch_id,
                 existing["status"],
             )
+            # Re-emit on replay too: action_outcomes.action_id is the SQL
+            # primary key and sql-writer's route upserts by merge(), so a
+            # repeat emit for the same dispatch_id idempotently overwrites
+            # the same row -- it does not duplicate. Skipping the emit here
+            # would risk permanently losing it instead: if the process died
+            # between save_dispatch_result (above, on a prior attempt) and
+            # the emit, or the emit itself failed transiently, no later tick
+            # would ever retry it, since every later tick also hits this
+            # replay branch.
             if existing["status"] == "failed":
                 error = existing["result_json"].get("error", "previous attempt failed")
+                await self._emit_action_outcome(
+                    bus,
+                    candidate=candidate,
+                    summary=f"attempted {candidate.dispatch_kind} on {candidate.target_id}, send failed",
+                    success=False,
+                    observed_at=now,
+                )
                 return candidate.model_copy(
                     update={
                         "dispatch_status": "dispatched",
@@ -274,6 +290,18 @@ class ExecutionDispatchRuntimeWorker:
                         "dispatch_error": str(error)[:500],
                     }
                 )
+            existing_observation = existing["result_json"].get("observation") or ""
+            await self._emit_action_outcome(
+                bus,
+                candidate=candidate,
+                summary=(
+                    existing_observation
+                    if existing_observation
+                    else f"{candidate.dispatch_kind} on {candidate.target_id} returned no observation"
+                ),
+                success=bool(existing_observation),
+                observed_at=now,
+            )
             return candidate.model_copy(
                 update={
                     "dispatch_status": "dispatched",

--- a/tests/test_execution_dispatch_bus_catalog.py
+++ b/tests/test_execution_dispatch_bus_catalog.py
@@ -23,3 +23,11 @@ def test_execution_dispatch_runtime_is_background_exec_request_producer() -> Non
     assert entry["schema_id"] == "CortexExecRequestPayload"
     assert entry["consumer_services"] == ["orion-cortex-exec"]
     assert "orion-execution-dispatch-runtime" in (entry.get("producer_services") or [])
+
+
+def test_execution_dispatch_runtime_is_action_outcome_producer() -> None:
+    entry = _channel_entry("orion:autonomy:action:outcome")
+    assert entry["schema_id"] == "ActionOutcomeEmitV1"
+    assert "orion-sql-writer" in entry["consumer_services"]
+    assert "orion-spark-concept-induction" in (entry.get("producer_services") or [])
+    assert "orion-execution-dispatch-runtime" in (entry.get("producer_services") or [])

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -200,13 +200,15 @@ class _FakeClient:
 _FAKE_CLIENT_OUTCOMES: dict[str, object] = {}
 
 
-def _patch_bus_and_client(monkeypatch, outcomes: dict[str, object]) -> None:
+def _patch_bus_and_client(monkeypatch, outcomes: dict[str, object]) -> MagicMock:
     _FAKE_CLIENT_OUTCOMES.clear()
     _FAKE_CLIENT_OUTCOMES.update(outcomes)
     fake_bus = MagicMock()
     fake_bus.close = AsyncMock()
+    fake_bus.publish = AsyncMock()
     monkeypatch.setattr(worker_mod, "OrionBusAsync", MagicMock(return_value=fake_bus))
     monkeypatch.setattr(worker_mod, "ExecutionDispatchCortexClient", _FakeClient)
+    return fake_bus
 
 
 @pytest.mark.asyncio
@@ -236,6 +238,129 @@ async def test_send_prepared_candidates_promotes_on_success(monkeypatch) -> None
     worker._store.save_dispatch_result.assert_called_once()
     assert worker._store.save_dispatch_result.call_args.kwargs["status"] == "success"
     assert worker._store.save_dispatch_result.call_args.kwargs["raw_len"] == 6
+
+
+@pytest.mark.asyncio
+async def test_send_one_emits_action_outcome_on_success(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    fake_bus = _patch_bus_and_client(
+        monkeypatch,
+        {"dispatch:1": {"result": {"final_text": '{"observation": "steady state observed"}'}}},
+    )
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    await worker._send_prepared_candidates(frame)
+
+    fake_bus.publish.assert_awaited_once()
+    channel, env = fake_bus.publish.await_args.args
+    assert channel == worker._settings.action_outcome_channel
+    assert env.kind == "action.outcome.emit.v1"
+    assert env.payload["subject"] == "orion"
+    assert env.payload["action_id"] == "dispatch:1"
+    assert env.payload["kind"] == "inspect"
+    assert env.payload["summary"] == "steady state observed"
+    assert env.payload["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_one_emits_action_outcome_on_empty_observation(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    fake_bus = _patch_bus_and_client(monkeypatch, {"dispatch:1": {"result": {"final_text": ""}}})
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    await worker._send_prepared_candidates(frame)
+
+    fake_bus.publish.assert_awaited_once()
+    _, env = fake_bus.publish.await_args.args
+    assert env.payload["success"] is False
+    assert "no observation" in env.payload["summary"]
+
+
+@pytest.mark.asyncio
+async def test_send_one_emits_action_outcome_on_rpc_failure(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    fake_bus = _patch_bus_and_client(monkeypatch, {"dispatch:1": RuntimeError("rpc timed out")})
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    await worker._send_prepared_candidates(frame)
+
+    fake_bus.publish.assert_awaited_once()
+    _, env = fake_bus.publish.await_args.args
+    assert env.payload["success"] is False
+    assert "send failed" in env.payload["summary"]
+
+
+@pytest.mark.asyncio
+async def test_send_one_does_not_emit_action_outcome_on_idempotent_replay(monkeypatch) -> None:
+    # A replayed result was already emitted (or attempted) the tick it first
+    # happened -- re-emitting on every subsequent replay would duplicate the
+    # outcome record for the same real action.
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
+        return_value={"result_id": "result:dispatch:1", "status": "success", "result_json": {}, "raw_len": 6}
+    )
+    fake_bus = _patch_bus_and_client(monkeypatch, {})
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    await worker._send_prepared_candidates(frame)
+
+    fake_bus.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_one_action_outcome_publish_failure_does_not_raise(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    fake_bus = _patch_bus_and_client(
+        monkeypatch,
+        {"dispatch:1": {"result": {"final_text": '{"observation": "steady"}'}}},
+    )
+    fake_bus.publish = AsyncMock(side_effect=RuntimeError("bus unreachable"))
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    # Must not raise -- save_dispatch_result already durably recorded the
+    # result; an unreachable bus must not lose that or crash the tick.
+    updated = await worker._send_prepared_candidates(frame)
+
+    assert updated.dispatched_candidates[0].result_ref == "result:dispatch:1"
+
+
+@pytest.mark.asyncio
+async def test_send_one_action_outcome_summary_is_truncated(monkeypatch) -> None:
+    worker = _make_worker(monkeypatch)
+    worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
+    worker._store.count_dispatches_today = MagicMock(return_value=0)
+    worker._store.save_dispatch_result = MagicMock()
+    worker._store.load_dispatch_result_by_dispatch_id = MagicMock(return_value=None)
+    long_observation = "x" * 5000
+    fake_bus = _patch_bus_and_client(
+        monkeypatch,
+        {"dispatch:1": {"result": {"final_text": f'{{"observation": "{long_observation}"}}'}}},
+    )
+    frame = _frame_with_candidates(_candidate("dispatch:1"))
+
+    await worker._send_prepared_candidates(frame)
+
+    _, env = fake_bus.publish.await_args.args
+    assert len(env.payload["summary"]) == worker_mod.ACTION_OUTCOME_SUMMARY_MAX_CHARS
 
 
 @pytest.mark.asyncio

--- a/tests/test_execution_dispatch_runtime_worker.py
+++ b/tests/test_execution_dispatch_runtime_worker.py
@@ -303,23 +303,37 @@ async def test_send_one_emits_action_outcome_on_rpc_failure(monkeypatch) -> None
 
 
 @pytest.mark.asyncio
-async def test_send_one_does_not_emit_action_outcome_on_idempotent_replay(monkeypatch) -> None:
-    # A replayed result was already emitted (or attempted) the tick it first
-    # happened -- re-emitting on every subsequent replay would duplicate the
-    # outcome record for the same real action.
+async def test_send_one_re_emits_action_outcome_on_idempotent_replay(monkeypatch) -> None:
+    # Re-emitting on replay is safe (action_outcomes.action_id is the SQL
+    # primary key, sql-writer's route upserts by merge() -- a repeat emit
+    # idempotently overwrites the same row, it does not duplicate). NOT
+    # re-emitting would risk permanently losing the outcome if the process
+    # died between the original save_dispatch_result and its emit, or if
+    # that emit itself failed transiently -- every later tick also hits
+    # this same replay branch, so there'd be no other chance to retry it.
     worker = _make_worker(monkeypatch)
     worker._store.recent_dispatch_result_statuses = MagicMock(return_value=[])
     worker._store.count_dispatches_today = MagicMock(return_value=0)
     worker._store.save_dispatch_result = MagicMock()
     worker._store.load_dispatch_result_by_dispatch_id = MagicMock(
-        return_value={"result_id": "result:dispatch:1", "status": "success", "result_json": {}, "raw_len": 6}
+        return_value={
+            "result_id": "result:dispatch:1",
+            "status": "success",
+            "result_json": {"observation": "steady state"},
+            "raw_len": 6,
+        }
     )
     fake_bus = _patch_bus_and_client(monkeypatch, {})
     frame = _frame_with_candidates(_candidate("dispatch:1"))
 
     await worker._send_prepared_candidates(frame)
 
-    fake_bus.publish.assert_not_awaited()
+    fake_bus.publish.assert_awaited_once()
+    _, env = fake_bus.publish.await_args.args
+    assert env.payload["summary"] == "steady state"
+    assert env.payload["success"] is True
+    # The dispatch result itself is NOT re-saved -- only the bus emit repeats.
+    worker._store.save_dispatch_result.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# feat(autonomy): experience loop -- Layer 9 actions become memory + chat evidence (P2)

## Summary

- Layer 9 (`orion-execution-dispatch-runtime`, P0+P1, merged) reached nothing outside its own table until now — zero references to episode journaling or action outcomes existed anywhere in that service. Every real dispatch result (success, empty observation, or RPC failure) now publishes an `ActionOutcomeEmitV1` event onto the existing `orion:autonomy:action:outcome` bus channel — the same always-on route `orion-spark-concept-induction` already produces onto for curiosity-fetch outcomes. No new pipe.
- `services/orion-cortex-exec/app/chat_stance.py` gained `_project_recent_dispatch_actions`, querying `load_action_outcomes(subject="orion")` directly and projecting to a bounded, privacy-safe `{kind, summary, success, observed_at}` shape (never `action_id`/`query`/`articles`/`salience`), rendered into `chat_general.j2`'s existing EVIDENCE-GATED CLAIMS section.
- Re-grounded against live code before writing anything: the original brainstorm-level P2 plan assumed a new `felt_state_reader.py` lane and flipping `ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED`. Both were wrong — the data already reaches chat-turn state via a different, already-wired path, and that flag gates a *retired* duplicate-email feature, not anything Layer-9-related. Neither is touched by this patch.

## Outcome moved

A real autonomous action, once it happens (still gated behind `EXECUTION_DISPATCH_MODE=dispatch_read_only`, still not the default anywhere), now becomes something Orion can truthfully reference in conversation — "I looked into X" backed by a real evidence row, not invented. Before this patch, a completed Layer 9 dispatch produced a database row nothing else in the system ever read.

## Current architecture

Two real, already-durable mechanisms existed and were both orphaned from Layer 9: the `ActionOutcomeEmitV1` → sql-writer → `action_outcomes` bus route (fired only from one curiosity-fetch call site), and `AutonomyStateV2.last_action_outcomes` (already wired into `chat_stance.py` at the reducer level, but never rendered into any template). This patch connects Layer 9 to the producer side of the first, and connects the second's already-flowing data to a template — two thin patches, not the three-part design the pre-grounding brainstorm assumed.

## Architecture touched

`orion-execution-dispatch-runtime` (worker, settings, `.env_example`), `orion/bus/channels.yaml` (producer registration), `orion-cortex-exec` (`chat_stance.py`, `chat_general.j2`). No new schemas, no new tables, no new services.

## Files changed

- `services/orion-execution-dispatch-runtime/app/worker.py` — `_emit_action_outcome`, wired into all three `_send_one` outcome paths including idempotent replay.
- `services/orion-execution-dispatch-runtime/app/settings.py`, `.env_example` — `BUS_ACTION_OUTCOME_OUT` / `action_outcome_channel`.
- `orion/bus/channels.yaml` — `orion-execution-dispatch-runtime` added as a second producer on `orion:autonomy:action:outcome`.
- `services/orion-cortex-exec/app/chat_stance.py` — `_project_recent_dispatch_actions`.
- `orion/cognition/prompts/chat_general.j2` — renders `chat_recent_dispatch_actions` in the evidence-gated section.
- `tests/test_execution_dispatch_runtime_worker.py`, `tests/test_execution_dispatch_bus_catalog.py` — new/extended.
- `services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py` (new).
- `services/orion-execution-dispatch-runtime/README.md`, `services/orion-cortex-exec/README.md` — documented.
- `docs/superpowers/specs/2026-07-13-autonomy-experience-loop-p2-design.md` — design spec.

## Schema / bus / API changes

- **Added:** none — reuses `ActionOutcomeEmitV1` and the `orion:autonomy:action:outcome` channel exactly as they already exist.
- **Removed:** none.
- **Renamed:** none.
- **Behavior changed:** `orion:autonomy:action:outcome` now has two producers instead of one. `chat_general.j2` renders an additional evidence block when `chat_recent_dispatch_actions` is non-empty (harmless/absent otherwise).
- **Compatibility notes:** `sql-writer`'s route for this channel upserts by `action_id` (SQL primary key) via `merge()` — confirmed during review, this is why re-emitting on replay is safe rather than a duplication risk.

## Env/config changes

- Added keys: `BUS_ACTION_OUTCOME_OUT` (`services/orion-execution-dispatch-runtime/.env_example`, default `orion:autonomy:action:outcome`).
- Removed/renamed keys: none.
- `.env_example` updated: yes.
- local `.env` synced: no local `.env` exists for this service in this sandbox (never run locally here) — confirmed via `git status --short`, nothing created.

## Tests run

```text
cd /mnt/scripts/Orion-Sapienform-autonomy-experience-loop-p2
/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest tests/test_execution_dispatch_runtime_worker.py tests/test_execution_dispatch_bus_catalog.py -q
22 passed

/mnt/scripts/Orion-Sapienform/.venv/bin/python -m pytest services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py -q
10 passed
```
(Run as two invocations — combining `orion-execution-dispatch-runtime` and `orion-cortex-exec` test files in one pytest process hits a pre-existing cross-service `app.*` module-name collision, same as encountered in P1; not introduced by this patch.)

`git diff --check` clean. Broader execution-dispatch/feedback suite (100 tests) also re-run and green after the review-fix commit.

## Evals run

None — no eval harness exists for either touched service; this patch doesn't add a new quality dimension an eval would measure (it wires existing, already-tested mechanisms together).

## Docker/build/smoke checks

Not run — no container build available in this sandbox. The data-flow chain (emit → sql-writer route → SQL table → `load_action_outcomes` → chat_stance projection → template) was traced file-by-file and confirmed intact during code review, but not live-exercised end-to-end (would require a running bus + sql-writer + real dispatch, none available here).

## Review findings fixed

- Finding (HIGH): the idempotent-replay path in `worker.py` skipped the `ActionOutcomeEmitV1` emit entirely, justified by a "would duplicate the record" comment that was factually wrong — `action_outcomes.action_id` is the SQL primary key and sql-writer's route upserts via `merge()`, so a repeat emit for the same `dispatch_id` overwrites rather than duplicates. Skipping it meant a crash between `save_dispatch_result` and the emit (or a transient bus failure inside the emit's own swallowed try/except) permanently lost that outcome, since every later tick also hits the replay branch.
  - Fix: replay path now re-emits, reconstructing summary/success from the stored result.
  - Evidence: `tests/test_execution_dispatch_runtime_worker.py::test_send_one_re_emits_action_outcome_on_idempotent_replay`.
- Finding (MEDIUM): `_project_recent_dispatch_actions` read `ctx["chat_autonomy_state_v2"]["last_action_outcomes"]`, which silently returns `[]` whenever `_run_autonomy_reducer` resolved a different subject for that turn (e.g. `"relationship"` during autonomy contextual fallback, a real production path) even though real Layer 9 outcomes exist under `subject="orion"`.
  - Fix: queries `load_action_outcomes(subject="orion")` directly, decoupling the feature from the ambient reducer's per-turn subject.
  - Evidence: `services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py::test_queries_the_orion_subject_directly_not_ctx`.
- Checked and confirmed correct (no fix needed): the full data-flow chain from emit to template render (traced line-by-line by the reviewer); the `chat_autonomy_state_v2` vs `chat_autonomy_state` key choice (the design doc's originally-specified key doesn't have the needed field at all — caught by the implementing agent mid-build via runtime verification, not the reviewer); sort/newest-first ordering; a claimed test-pollution issue was independently reproduced against unmodified `origin/main` and confirmed pre-existing, unrelated to this patch.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-execution-dispatch-runtime/.env \
  -f services/orion-execution-dispatch-runtime/docker-compose.yml \
  up -d --build

docker compose \
  --env-file .env \
  --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml \
  up -d --build
```
No migration needed — reuses the existing `action_outcomes` table and channel. No config flip required for this patch's own code to be inert-safe; it only produces visible behavior once real dispatches occur, which itself still requires `EXECUTION_DISPATCH_MODE=dispatch_read_only` to be set (not the default).

## Risks / concerns

- Severity: low
- Concern: the full chain (bus emit → sql-writer → SQL → chat projection → template) is unit-tested at each link but not live-exercised end-to-end in this sandbox.
- Mitigation: recommend confirming this during the same P1 burn-in window already planned (watch for `action_outcomes` rows appearing with `subject='orion'` when a real dispatch fires, then confirm a subsequent chat turn's stance context contains `chat_recent_dispatch_actions`).