### PR TITLE
Feat/drive audit substrate chat visibility

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-drive-audit-substrate-chat-visibility-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-drive-audit-substrate-chat-visibility-pr.md
@@ -1,0 +1,95 @@
+# PR report: surface drive_state.v1's already-computed provenance to substrate + chat stance
+
+## Summary
+
+- `DriveAuditV1` (`dominant_drive`, `tension_refs`, `tension_kinds`, a human-readable `summary`) is already built and already published on every drive-engine tick (`build_drive_audit()` in `orion/spark/concept_induction/audit.py`, called live twice in `bus_worker.py`). It was being silently dropped two hops downstream — the exact "real engineering thrown away one hop downstream" pattern this repo already found once with `field_attention_frame.v1`.
+- Gap 1: `orion/substrate/adapters/autonomy.py`'s substrate projection accepted a `DriveAuditV1` param but never wrote its `dominant_drive`/`summary` into the `drive_state` `StateSnapshotNodeV1`'s metadata.
+- Gap 2: `services/orion-cortex-exec/app/chat_stance.py::_project_autonomy_from_beliefs()` only collected substrate snapshots tagged `snapshot_source == "autonomy"`. Investigated whether that filter had ever matched anything real (it was suspected dead) — **it hadn't been dead**: `orion/substrate/relational/adapters/autonomy_ctx.py` is a real, still-wired legacy GraphDB/SPARQL path, gated off by default (`AUTONOMY_GRAPH_BACKEND=disabled`). Kept it, added `"drive_state"` alongside it rather than replacing it.
+- Also found and fixed: `sl.drives` nodes (already read by this function) carry each drive's live pressure in `.signals.salience`, previously extracted only as a bare `drive_kind` label with the value discarded.
+- New `inputs["drive_state"]` in the chat-turn prompt payload — a **sibling** of the existing `inputs["autonomy"]`, never merged, per `orion/self_state/inner_state_registry.py`'s explicit `DUPLICATE` note on `drive_state.v1` vs `autonomy_state_v2`. Ships behind `CHAT_STANCE_DRIVE_STATE_VISIBLE`, default off.
+
+## Outcome moved
+
+Real drive-audit data (which drive dominates, why, in plain language) that has existed and published on every tick now has a path to reach the LLM's own reasoning context — previously it was computed, published to the bus, written to RDF, and then invisible everywhere else. This is visibility only; no behavior changes live (flag off by default).
+
+## Current architecture (before this patch)
+
+`DriveAuditV1` had zero real cognition consumers per `orion/self_state/inner_state_registry.py`'s own accounting. The substrate ladder already carried `drive_state` pressures in `StateSnapshotNodeV1.dimensions`, but `chat_stance.py`'s belief-projection function filtered for a snapshot_source value (`"autonomy"`) that a *different*, legacy adapter produces — `drive_state`'s snapshots were present in the belief graph but never collected by this function.
+
+## Architecture touched
+
+`orion/substrate/adapters/autonomy.py` (substrate projection), `services/orion-cortex-exec/app/chat_stance.py` (belief projection + prompt input assembly), test files for both, `.env_example`/`README.md`.
+
+## Files changed
+
+- `orion/substrate/adapters/autonomy.py`: `map_autonomy_artifacts_to_substrate()` now stamps `metadata["dominant_drive"]`/`metadata["summary"]` onto the `drive_state` snapshot node when a `DriveAuditV1` is passed. Purely additive — `dimensions`, `snapshot_source`, and every other field untouched.
+- `services/orion-cortex-exec/app/chat_stance.py`: `_project_autonomy_from_beliefs()` now collects `snapshot_source in ("autonomy", "drive_state")` (was `== "autonomy"` only); builds a `pressures: dict[str, float]` from `sl.drives[*].signals.salience` (previously discarded); returns a structurally separate `"drive_state"` key alongside its existing `summary`/`debug` (autonomy_state_v2-lineage) fields. At the `build_chat_stance_inputs` call site, behind `CHAT_STANCE_DRIVE_STATE_VISIBLE` (default off, documented in `.env_example`), sets `inputs["drive_state"]` as a sibling of `inputs["autonomy"]`.
+- `services/orion-cortex-exec/tests/test_chat_stance_drive_state_projection.py` (new): snapshot-source collection, the "autonomy" filter still working alongside the new "drive_state" one, and — critically — explicit assertions that `inputs["autonomy"]` never gains `pressures`/`activations`/`drive_state` keys (the non-merge requirement, independently re-verified by the orchestrator).
+- `tests/test_cognitive_substrate_phase2_domain_mappings.py`: two new tests for the substrate adapter metadata change (with and without a `DriveAuditV1` present).
+- `.env_example` / `README.md`: new flag documented with the `DUPLICATE`-note citation.
+
+## Schema / bus / API changes
+
+- Added: `CHAT_STANCE_DRIVE_STATE_VISIBLE` env flag (default `false`/off).
+- No schema changes — `StateSnapshotNodeV1.metadata` is already a free-form dict; no new Pydantic fields anywhere.
+- Behavior changed: `_project_autonomy_from_beliefs()`'s return dict gains a new `"drive_state"` key (additive, existing keys unchanged).
+- Compatibility notes: flag defaults off, so no live behavior change until explicitly flipped.
+
+## Env/config changes
+
+- Added keys: `CHAT_STANCE_DRIVE_STATE_VISIBLE` (services/orion-cortex-exec).
+- `.env_example` updated: yes.
+- Local `.env` synced: no local `.env` exists in this worktree (confirmed via `git check-ignore` — nothing to sync); run `python scripts/sync_local_env_from_example.py` on a host with a real `.env` before this flag is usable there.
+- Skipped keys requiring operator action: none — this key is safe to sync normally (not a `NEVER_SYNC_KEYS` case), defaults to off.
+
+## Tests run
+
+```text
+# Substrate adapter tests
+$ python -m pytest tests/test_cognitive_substrate_phase2_domain_mappings.py -q
+7 passed
+
+# Full chat_stance suite
+$ python -m pytest services/orion-cortex-exec/tests/test_chat_stance_drive_state_projection.py \
+    services/orion-cortex-exec/tests/test_chat_stance_autonomy_plumbing.py \
+    services/orion-cortex-exec/tests/test_chat_stance_self_state_projection.py \
+    services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py \
+    services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py -q
+46 passed
+```
+Both runs independently re-executed by the orchestrator (not just the implementing agent), using `/tmp/orion-test-venv` for the cortex-exec suite.
+
+## Evals run
+
+Not applicable — pure plumbing/visibility patch, no behavior to eval yet (nothing downstream consumes `inputs["drive_state"]` in a prompt template in this patch; that's explicitly the next step, not this one).
+
+## Docker/build/smoke checks
+
+Not run — no runtime config, ports, or Docker-relevant surface touched. Pure Python + env flag.
+
+## Review findings fixed
+
+- Investigated and resolved an open question from the task brief: whether `snapshot_source == "autonomy"` had ever matched anything. Confirmed real (legacy GraphDB path, off by default) rather than dead — kept the filter rather than removing it, avoiding a regression the original task brief would have caused if blindly followed.
+- Implementing agent ran its own code-review pass; one soft note (no downstream prompt-template consumer yet) — expected and correct for this patch's scope (surface, don't yet consume).
+- Orchestrator independently re-read the full diff and re-ran all tests rather than trusting the agent's self-report — no discrepancies found between agent intent and agent output.
+
+## Restart required
+
+```text
+No restart required for this patch alone (flag defaults off, no behavior change).
+```
+If/when `CHAT_STANCE_DRIVE_STATE_VISIBLE=true` is set later:
+```bash
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: Low — `inputs["drive_state"]` has no prompt-template consumer yet, so flipping the flag today would add data to the `inputs` payload with no visible effect until a follow-up patch actually renders it into the prompt. Intentional scoping (this patch is the visibility seam per the accepted spec, not the full feature) — flagging so it isn't mistaken for a bug if someone flips the flag and sees no change.
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/drive-audit-substrate-chat-visibility?expand=1`

--- a/orion/substrate/adapters/autonomy.py
+++ b/orion/substrate/adapters/autonomy.py
@@ -36,6 +36,10 @@ def map_autonomy_artifacts_to_substrate(
 
     if drive_state:
         snapshot_id = f"sub-state-autonomy-{drive_state.artifact_id}"
+        drive_state_metadata: dict = {"activations": dict(drive_state.activations), "artifact_id": drive_state.artifact_id}
+        if drive_audit is not None:
+            drive_state_metadata["dominant_drive"] = drive_audit.dominant_drive
+            drive_state_metadata["summary"] = drive_audit.summary
         nodes.append(
             StateSnapshotNodeV1(
                 node_id=snapshot_id,
@@ -52,7 +56,7 @@ def map_autonomy_artifacts_to_substrate(
                 dimensions={k: float(v) for k, v in drive_state.pressures.items()},
                 snapshot_source="drive_state",
                 signals={"confidence": drive_state.confidence, "salience": max(drive_state.pressures.values(), default=0.0)},
-                metadata={"activations": dict(drive_state.activations), "artifact_id": drive_state.artifact_id},
+                metadata=drive_state_metadata,
             )
         )
 

--- a/services/orion-cortex-exec/.env_example
+++ b/services/orion-cortex-exec/.env_example
@@ -282,6 +282,11 @@ AUTONOMY_GOAL_EXECUTION_ENABLED=true
 GOAL_HINT_PRIORITY_THRESHOLD=0.4
 # AutonomyStateV2 deterministic reducer sidecar in chat stance (export ctx + router preview; default off).
 AUTONOMY_STATE_V2_REDUCER_ENABLED=
+# Surface drive_state.v1 (DriveAuditV1/DriveStateV1 pressures+activations+dominant_drive+summary)
+# as a sibling inputs["drive_state"] key in chat stance inputs. Kept structurally separate from
+# inputs["autonomy"]/autonomy_state_v2 — see orion/self_state/inner_state_registry.py DUPLICATE
+# note (drive_state and autonomy_state_v2 are independently-computed, never crosswalked). Default off.
+CHAT_STANCE_DRIVE_STATE_VISIBLE=
 # DSN for the autonomy_state_v2 table (see services/orion-sql-db/manual_migration_autonomy_state_v2.sql).
 # Closes the reducer's own fold loop: _run_autonomy_reducer() reads/writes the latest
 # AutonomyStateV2 per subject here instead of discarding it every turn. Same shared

--- a/services/orion-cortex-exec/README.md
+++ b/services/orion-cortex-exec/README.md
@@ -120,6 +120,18 @@ Operator notes: [docs/autonomy_state_v2_reducer.md](../../docs/autonomy_state_v2
 pytest services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py -q
 ```
 
+### drive_state.v1 visibility on chat stance (default off)
+
+| Variable | Default (`.env_example`) | Description |
+| :--- | :--- | :--- |
+| `CHAT_STANCE_DRIVE_STATE_VISIBLE` | empty / not `true` | When `true`, `build_chat_stance_inputs` surfaces `DriveAuditV1`/`DriveStateV1` provenance (drive pressures, activations, dominant drive, summary) as a **sibling** `inputs["drive_state"]` key, built from the same unified-beliefs `drive_state`-sourced substrate nodes that `_project_autonomy_from_beliefs` already reads. |
+
+`drive_state.v1` and `autonomy_state_v2` are registered as `DUPLICATE` of each other in `orion/self_state/inner_state_registry.py` — they are independently-computed signals over the same 6-drive taxonomy, with no agreed merge-or-keep-separate resolution yet. This patch keeps them structurally separate everywhere: `inputs["drive_state"]` is never merged, blended, or nested into `inputs["autonomy"]`.
+
+```bash
+pytest services/orion-cortex-exec/tests/test_chat_stance_drive_state_projection.py -q
+```
+
 ### Turn effect and drive tensions (bus)
 
 When the executor computes `turn_effect` / `turn_effect_evidence`, they are included in `PlanExecutionResult.metadata`. Hub merges that metadata into each chat turn `spark_meta`, so `orion-spark-concept-induction` can derive `extract_tensions` from `spark_meta.turn_effect`. For graph-backed tension kinds on `DriveAudit`, `orion-rdf-writer` must still consume `memory.drives.audit.v1` after concept-induction publishes it.

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -1210,7 +1210,9 @@ def _project_autonomy_from_beliefs(
         drives.extend([n for n in sl.drives if n.node_kind == "drive"])
         goals.extend([n for n in sl.goals if n.node_kind == "goal"])
         tensions.extend([n for n in sl.tensions if n.node_kind == "tension"])
-        snapshots.extend([s for s in sl.snapshots if getattr(s, "snapshot_source", "") == "autonomy"])
+        snapshots.extend(
+            [s for s in sl.snapshots if getattr(s, "snapshot_source", "") in ("autonomy", "drive_state")]
+        )
 
     if not any([drives, goals, tensions, snapshots]):
         return None
@@ -1262,6 +1264,47 @@ def _project_autonomy_from_beliefs(
             }
         )
 
+    # drive_state.v1 projection — kept structurally separate from the `summary`/
+    # `debug` fields above (those are the autonomy_state_v2-lineage signal; see
+    # orion/self_state/inner_state_registry.py's DUPLICATE note: drive_state and
+    # autonomy_state_v2 are independently-computed and must never be crosswalked).
+    pressures: Dict[str, float] = {}
+    for d in drives:
+        dk = str(getattr(d, "drive_kind", "") or "")
+        if not dk or dk in pressures:
+            continue
+        salience = getattr(getattr(d, "signals", None), "salience", None)
+        if salience is not None:
+            pressures[dk] = float(salience)
+
+    drive_state_snapshots = [s for s in snapshots if getattr(s, "snapshot_source", "") == "drive_state"]
+    activations: Dict[str, bool] = {}
+    drive_state_dominant_drive: str | None = None
+    drive_state_summary: str | None = None
+    for snap in drive_state_snapshots:
+        meta = snap.metadata or {}
+        if not activations:
+            raw_activations = meta.get("activations")
+            if isinstance(raw_activations, dict):
+                activations = dict(raw_activations)
+        if drive_state_dominant_drive is None:
+            dd = str(meta.get("dominant_drive") or "").strip()
+            if dd:
+                drive_state_dominant_drive = dd
+        if drive_state_summary is None:
+            sm = str(meta.get("summary") or "").strip()
+            if sm:
+                drive_state_summary = sm
+
+    drive_state_projection: Dict[str, Any] | None = None
+    if pressures or activations or drive_state_dominant_drive or drive_state_summary:
+        drive_state_projection = {
+            "pressures": pressures,
+            "activations": activations,
+            "dominant_drive": drive_state_dominant_drive,
+            "summary": drive_state_summary,
+        }
+
     return {
         "state": None,
         "summary": summary,
@@ -1277,6 +1320,7 @@ def _project_autonomy_from_beliefs(
         "selected_subject": "orion",
         "repository_status": {"source_available": True, "source_path": "substrate"},
         "partial_used": False,
+        "drive_state": drive_state_projection,
     }
 
 
@@ -2411,6 +2455,15 @@ async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
     mg_hints = _project_memory_graph_hints_from_beliefs(beliefs) or fetch_chat_stance_memory_graph_hints()
     if mg_hints:
         inputs["memory_graph"] = {"disposition_hints": mg_hints}
+
+    # drive_state.v1 visibility — a sibling of `inputs["autonomy"]`, never merged
+    # into it. drive_state and autonomy_state_v2 are independently-computed
+    # signals per orion/self_state/inner_state_registry.py's DUPLICATE note.
+    # Off by default; flip CHAT_STANCE_DRIVE_STATE_VISIBLE=true to surface it.
+    if os.getenv("CHAT_STANCE_DRIVE_STATE_VISIBLE", "").strip().lower() == "true":
+        drive_state_projection = autonomy.get("drive_state") if isinstance(autonomy, dict) else None
+        if drive_state_projection:
+            inputs["drive_state"] = drive_state_projection
 
     if os.getenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "").strip().lower() == "true":
         try:

--- a/services/orion-cortex-exec/tests/test_chat_stance_drive_state_projection.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_drive_state_projection.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app import chat_stance
+from app.chat_stance import _project_autonomy_from_beliefs
+from orion.substrate.relational.beliefs import AnchorBeliefSliceV1, UnifiedRelationalBeliefSetV1
+
+
+def _drive_node(drive_kind: str, salience: float) -> SimpleNamespace:
+    return SimpleNamespace(
+        node_kind="drive",
+        drive_kind=drive_kind,
+        signals=SimpleNamespace(salience=salience),
+        metadata={},
+    )
+
+
+def _snapshot_node(snapshot_source: str, metadata: dict) -> SimpleNamespace:
+    return SimpleNamespace(node_kind="state_snapshot", snapshot_source=snapshot_source, metadata=metadata)
+
+
+def _anchor_slice(*, drives=None, snapshots=None, goals=None, tensions=None, degraded=False) -> SimpleNamespace:
+    return SimpleNamespace(
+        drives=drives or [],
+        goals=goals or [],
+        tensions=tensions or [],
+        snapshots=snapshots or [],
+        degraded=degraded,
+        tier_outcomes=[],
+    )
+
+
+# --- unit tests on _project_autonomy_from_beliefs directly (SimpleNamespace fixtures,
+# matching the pattern in test_chat_stance_self_state_projection.py) ---
+
+
+def test_drive_state_snapshot_source_is_now_collected_and_populates_drive_state_key():
+    """Gap 2 fix: snapshot_source == 'drive_state' must be picked up, not silently dropped."""
+    beliefs = SimpleNamespace(
+        anchors={
+            "orion": _anchor_slice(
+                drives=[_drive_node("coherence", 0.8), _drive_node("continuity", 0.6)],
+                snapshots=[
+                    _snapshot_node(
+                        "drive_state",
+                        {
+                            "activations": {"coherence": True, "continuity": False},
+                            "artifact_id": "drive-state-1",
+                            "dominant_drive": "coherence",
+                            "summary": "orion pressure concentrates on coherence",
+                        },
+                    )
+                ],
+            )
+        }
+    )
+    result = _project_autonomy_from_beliefs(beliefs, {})
+    assert result is not None
+    ds = result["drive_state"]
+    assert ds is not None
+    assert ds["pressures"] == {"coherence": 0.8, "continuity": 0.6}
+    assert ds["activations"] == {"coherence": True, "continuity": False}
+    assert ds["dominant_drive"] == "coherence"
+    assert ds["summary"] == "orion pressure concentrates on coherence"
+
+
+def test_autonomy_snapshot_source_still_works_alongside_drive_state():
+    """The legacy 'autonomy' snapshot_source producer (autonomy_ctx.py, gated behind
+    AUTONOMY_GRAPH_BACKEND=graphdb/sparql) must keep working -- it is a real,
+    registered producer, not dead code, so the filter clause is kept."""
+    beliefs = SimpleNamespace(
+        anchors={
+            "orion": _anchor_slice(
+                drives=[_drive_node("relational", 0.5)],
+                snapshots=[
+                    _snapshot_node(
+                        "autonomy",
+                        {"dominant_drive": "relational", "identity_summary": "steady"},
+                    )
+                ],
+            )
+        }
+    )
+    result = _project_autonomy_from_beliefs(beliefs, {})
+    assert result is not None
+    assert result["summary"].dominant_drive == "relational"
+    # No drive_state-sourced snapshot present -> no activations/summary/dominant_drive
+    # from the drive_state.v1 lineage, even though pressures still reflect the shared
+    # drive nodes (drive nodes aren't source-scoped).
+    ds = result["drive_state"]
+    assert ds is not None
+    assert ds["pressures"] == {"relational": 0.5}
+    assert ds["activations"] == {}
+    assert ds["dominant_drive"] is None
+    assert ds["summary"] is None
+
+
+def test_no_drive_or_snapshot_nodes_returns_none():
+    beliefs = SimpleNamespace(anchors={"orion": _anchor_slice()})
+    assert _project_autonomy_from_beliefs(beliefs, {}) is None
+
+
+def test_none_beliefs_returns_none():
+    assert _project_autonomy_from_beliefs(None, {}) is None
+
+
+# --- integration tests through build_chat_stance_inputs: verify inputs["drive_state"]
+# is a sibling of inputs["autonomy"], gated behind CHAT_STANCE_DRIVE_STATE_VISIBLE,
+# and never merged into inputs["autonomy"]. ---
+
+
+def _real_beliefs_with_drive_state() -> UnifiedRelationalBeliefSetV1:
+    anchor_slice = AnchorBeliefSliceV1(
+        anchor="orion",
+        drives=[_drive_node("coherence", 0.8)],
+        snapshots=[
+            _snapshot_node(
+                "drive_state",
+                {
+                    "activations": {"coherence": True},
+                    "artifact_id": "drive-state-1",
+                    "dominant_drive": "coherence",
+                    "summary": "orion pressure concentrates on coherence",
+                },
+            )
+        ],
+    )
+    return UnifiedRelationalBeliefSetV1(anchors={"orion": anchor_slice})
+
+
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_exposes_drive_state_as_sibling_when_flag_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(chat_stance, "_unified_beliefs_for_stance", lambda ctx: _real_beliefs_with_drive_state())
+    monkeypatch.setenv("CHAT_STANCE_DRIVE_STATE_VISIBLE", "true")
+
+    ctx = {"user_message": "hello"}
+    built = await chat_stance.build_chat_stance_inputs(ctx)
+
+    assert "drive_state" in built
+    assert built["drive_state"]["pressures"] == {"coherence": 0.8}
+    assert built["drive_state"]["dominant_drive"] == "coherence"
+    assert built["drive_state"]["summary"] == "orion pressure concentrates on coherence"
+
+    # `autonomy` and `drive_state` are structurally independent siblings -- `drive_state`
+    # is a top-level `inputs` key, never nested inside or blended into `autonomy`'s dict.
+    assert "autonomy" in built
+    assert built["autonomy"].keys() >= {"state", "summary", "debug"}
+    assert "pressures" not in built["autonomy"]
+    assert "activations" not in built["autonomy"]
+    assert "drive_state" not in built["autonomy"]
+    # autonomy's own `summary` is the AutonomySummaryV1 dump, not drive_state's summary string.
+    assert built["autonomy"]["summary"] != built["drive_state"]["summary"]
+
+
+@pytest.mark.asyncio
+async def test_build_chat_stance_inputs_omits_drive_state_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(chat_stance, "_unified_beliefs_for_stance", lambda ctx: _real_beliefs_with_drive_state())
+    monkeypatch.delenv("CHAT_STANCE_DRIVE_STATE_VISIBLE", raising=False)
+
+    ctx = {"user_message": "hello"}
+    built = await chat_stance.build_chat_stance_inputs(ctx)
+
+    assert "drive_state" not in built
+    assert "autonomy" in built

--- a/tests/test_cognitive_substrate_phase2_domain_mappings.py
+++ b/tests/test_cognitive_substrate_phase2_domain_mappings.py
@@ -135,6 +135,61 @@ def test_autonomy_adapter_maps_drive_goal_tension_state_without_overpromoting() 
     assert all(n.node_kind != "ontology_branch" for n in out.nodes)
 
 
+def test_autonomy_adapter_drive_state_snapshot_carries_drive_audit_dominant_drive_and_summary() -> None:
+    """DriveAuditV1's dominant_drive/summary must reach the drive_state StateSnapshotNodeV1.metadata."""
+    drive_audit = DriveAuditV1(
+        subject="orion",
+        model_layer="autonomy",
+        entity_id="entity:orion",
+        kind="drive.audit",
+        provenance=_provenance(),
+        drive_pressures={"coherence": 0.8, "continuity": 0.6},
+        active_drives=["coherence", "continuity"],
+        dominant_drive="continuity",
+        summary="orion pressure concentrates on continuity",
+    )
+    drive_state = DriveStateV1(
+        subject="orion",
+        model_layer="autonomy",
+        entity_id="entity:orion",
+        kind="drive.state",
+        provenance=_provenance(),
+        pressures={"coherence": 0.9, "continuity": 0.6},
+        activations={"coherence": True},
+    )
+    out = map_autonomy_artifacts_to_substrate(drive_audit=drive_audit, drive_state=drive_state, anchor_scope="orion")
+    snapshot_nodes = [n for n in out.nodes if n.node_kind == "state_snapshot" and n.snapshot_source == "drive_state"]
+    assert len(snapshot_nodes) == 1
+    meta = snapshot_nodes[0].metadata
+    assert meta["dominant_drive"] == "continuity"
+    assert meta["summary"] == "orion pressure concentrates on continuity"
+    # Purely additive: pre-existing metadata keys are untouched.
+    assert meta["artifact_id"] == drive_state.artifact_id
+    assert meta["activations"] == {"coherence": True}
+    # dimensions/snapshot_source untouched by this patch.
+    assert snapshot_nodes[0].dimensions == {"coherence": 0.9, "continuity": 0.6}
+    assert snapshot_nodes[0].snapshot_source == "drive_state"
+
+
+def test_autonomy_adapter_drive_state_snapshot_without_drive_audit_omits_dominant_drive_and_summary() -> None:
+    """When no DriveAuditV1 is passed, the metadata dict must not gain the new keys."""
+    drive_state = DriveStateV1(
+        subject="orion",
+        model_layer="autonomy",
+        entity_id="entity:orion",
+        kind="drive.state",
+        provenance=_provenance(),
+        pressures={"coherence": 0.9},
+        activations={"coherence": True},
+    )
+    out = map_autonomy_artifacts_to_substrate(drive_state=drive_state, anchor_scope="orion")
+    snapshot_nodes = [n for n in out.nodes if n.node_kind == "state_snapshot" and n.snapshot_source == "drive_state"]
+    assert len(snapshot_nodes) == 1
+    meta = snapshot_nodes[0].metadata
+    assert "dominant_drive" not in meta
+    assert "summary" not in meta
+
+
 def test_spark_adapter_maps_snapshots_conservatively() -> None:
     now = datetime.now(timezone.utc)
     source_snapshot = SparkSourceSnapshotV1(


### PR DESCRIPTION
# PR report: surface drive_state.v1's already-computed provenance to substrate + chat stance

## Summary

- `DriveAuditV1` (`dominant_drive`, `tension_refs`, `tension_kinds`, a human-readable `summary`) is already built and already published on every drive-engine tick (`build_drive_audit()` in `orion/spark/concept_induction/audit.py`, called live twice in `bus_worker.py`). It was being silently dropped two hops downstream — the exact "real engineering thrown away one hop downstream" pattern this repo already found once with `field_attention_frame.v1`.
- Gap 1: `orion/substrate/adapters/autonomy.py`'s substrate projection accepted a `DriveAuditV1` param but never wrote its `dominant_drive`/`summary` into the `drive_state` `StateSnapshotNodeV1`'s metadata.
- Gap 2: `services/orion-cortex-exec/app/chat_stance.py::_project_autonomy_from_beliefs()` only collected substrate snapshots tagged `snapshot_source == "autonomy"`. Investigated whether that filter had ever matched anything real (it was suspected dead) — **it hadn't been dead**: `orion/substrate/relational/adapters/autonomy_ctx.py` is a real, still-wired legacy GraphDB/SPARQL path, gated off by default (`AUTONOMY_GRAPH_BACKEND=disabled`). Kept it, added `"drive_state"` alongside it rather than replacing it.
- Also found and fixed: `sl.drives` nodes (already read by this function) carry each drive's live pressure in `.signals.salience`, previously extracted only as a bare `drive_kind` label with the value discarded.
- New `inputs["drive_state"]` in the chat-turn prompt payload — a **sibling** of the existing `inputs["autonomy"]`, never merged, per `orion/self_state/inner_state_registry.py`'s explicit `DUPLICATE` note on `drive_state.v1` vs `autonomy_state_v2`. Ships behind `CHAT_STANCE_DRIVE_STATE_VISIBLE`, default off.

## Outcome moved

Real drive-audit data (which drive dominates, why, in plain language) that has existed and published on every tick now has a path to reach the LLM's own reasoning context — previously it was computed, published to the bus, written to RDF, and then invisible everywhere else. This is visibility only; no behavior changes live (flag off by default).

## Current architecture (before this patch)

`DriveAuditV1` had zero real cognition consumers per `orion/self_state/inner_state_registry.py`'s own accounting. The substrate ladder already carried `drive_state` pressures in `StateSnapshotNodeV1.dimensions`, but `chat_stance.py`'s belief-projection function filtered for a snapshot_source value (`"autonomy"`) that a *different*, legacy adapter produces — `drive_state`'s snapshots were present in the belief graph but never collected by this function.

## Architecture touched

`orion/substrate/adapters/autonomy.py` (substrate projection), `services/orion-cortex-exec/app/chat_stance.py` (belief projection + prompt input assembly), test files for both, `.env_example`/`README.md`.

## Files changed

- `orion/substrate/adapters/autonomy.py`: `map_autonomy_artifacts_to_substrate()` now stamps `metadata["dominant_drive"]`/`metadata["summary"]` onto the `drive_state` snapshot node when a `DriveAuditV1` is passed. Purely additive — `dimensions`, `snapshot_source`, and every other field untouched.
- `services/orion-cortex-exec/app/chat_stance.py`: `_project_autonomy_from_beliefs()` now collects `snapshot_source in ("autonomy", "drive_state")` (was `== "autonomy"` only); builds a `pressures: dict[str, float]` from `sl.drives[*].signals.salience` (previously discarded); returns a structurally separate `"drive_state"` key alongside its existing `summary`/`debug` (autonomy_state_v2-lineage) fields. At the `build_chat_stance_inputs` call site, behind `CHAT_STANCE_DRIVE_STATE_VISIBLE` (default off, documented in `.env_example`), sets `inputs["drive_state"]` as a sibling of `inputs["autonomy"]`.
- `services/orion-cortex-exec/tests/test_chat_stance_drive_state_projection.py` (new): snapshot-source collection, the "autonomy" filter still working alongside the new "drive_state" one, and — critically — explicit assertions that `inputs["autonomy"]` never gains `pressures`/`activations`/`drive_state` keys (the non-merge requirement, independently re-verified by the orchestrator).
- `tests/test_cognitive_substrate_phase2_domain_mappings.py`: two new tests for the substrate adapter metadata change (with and without a `DriveAuditV1` present).
- `.env_example` / `README.md`: new flag documented with the `DUPLICATE`-note citation.

## Schema / bus / API changes

- Added: `CHAT_STANCE_DRIVE_STATE_VISIBLE` env flag (default `false`/off).
- No schema changes — `StateSnapshotNodeV1.metadata` is already a free-form dict; no new Pydantic fields anywhere.
- Behavior changed: `_project_autonomy_from_beliefs()`'s return dict gains a new `"drive_state"` key (additive, existing keys unchanged).
- Compatibility notes: flag defaults off, so no live behavior change until explicitly flipped.

## Env/config changes

- Added keys: `CHAT_STANCE_DRIVE_STATE_VISIBLE` (services/orion-cortex-exec).
- `.env_example` updated: yes.
- Local `.env` synced: no local `.env` exists in this worktree (confirmed via `git check-ignore` — nothing to sync); run `python scripts/sync_local_env_from_example.py` on a host with a real `.env` before this flag is usable there.
- Skipped keys requiring operator action: none — this key is safe to sync normally (not a `NEVER_SYNC_KEYS` case), defaults to off.

## Tests run

```text
# Substrate adapter tests
$ python -m pytest tests/test_cognitive_substrate_phase2_domain_mappings.py -q
7 passed

# Full chat_stance suite
$ python -m pytest services/orion-cortex-exec/tests/test_chat_stance_drive_state_projection.py \
    services/orion-cortex-exec/tests/test_chat_stance_autonomy_plumbing.py \
    services/orion-cortex-exec/tests/test_chat_stance_self_state_projection.py \
    services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py \
    services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py -q
46 passed
```
Both runs independently re-executed by the orchestrator (not just the implementing agent), using `/tmp/orion-test-venv` for the cortex-exec suite.

## Evals run

Not applicable — pure plumbing/visibility patch, no behavior to eval yet (nothing downstream consumes `inputs["drive_state"]` in a prompt template in this patch; that's explicitly the next step, not this one).

## Docker/build/smoke checks

Not run — no runtime config, ports, or Docker-relevant surface touched. Pure Python + env flag.

## Review findings fixed

- Investigated and resolved an open question from the task brief: whether `snapshot_source == "autonomy"` had ever matched anything. Confirmed real (legacy GraphDB path, off by default) rather than dead — kept the filter rather than removing it, avoiding a regression the original task brief would have caused if blindly followed.
- Implementing agent ran its own code-review pass; one soft note (no downstream prompt-template consumer yet) — expected and correct for this patch's scope (surface, don't yet consume).
- Orchestrator independently re-read the full diff and re-ran all tests rather than trusting the agent's self-report — no discrepancies found between agent intent and agent output.

## Restart required

```text
No restart required for this patch alone (flag defaults off, no behavior change).
```
If/when `CHAT_STANCE_DRIVE_STATE_VISIBLE=true` is set later:
```bash
docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml up -d --build
```

## Risks / concerns

- Severity: Low — `inputs["drive_state"]` has no prompt-template consumer yet, so flipping the flag today would add data to the `inputs` payload with no visible effect until a follow-up patch actually renders it into the prompt. Intentional scoping (this patch is the visibility seam per the accepted spec, not the full feature) — flagging so it isn't mistaken for a bug if someone flips the flag and sees no change.
