### PR TITLE
Chore/drive state divergence audit

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-drive-state-divergence-audit-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-drive-state-divergence-audit-pr.md
@@ -1,0 +1,75 @@
+# PR report: drive_state.v1 vs autonomy_state_v2 divergence audit
+
+## Summary
+
+- `drive_state.v1` (`DriveEngine`, `orion/spark/concept_induction/drives.py`) and `autonomy_state_v2` (`orion.autonomy.reducer`) independently compute the same 6-drive taxonomy (`coherence, continuity, capability, relational, predictive, autonomy`) and are explicitly marked `DUPLICATE` of each other in `orion/self_state/inner_state_registry.py`, with the merge-or-keep-separate decision deferred to a later phase, not resolved.
+- New `scripts/drive_state_divergence_audit.py` — a report-only, point-in-time snapshot comparison of the two signals' *current* values (neither is historically persisted — `drive_state.v1` lives in a local JSON file that gets overwritten, `autonomy_state_v2` in a single-row-per-subject Postgres UPSERT). Measures, never merges or picks a winner.
+- Does not touch either signal's producer, consumer, or the deferred merge decision — pure diagnostic.
+
+## Outcome moved
+
+There was no way to answer "how far apart are these two signals right now" without manually querying two different backends by hand. Now there's a standing, runnable script — the actual evidence input the deferred Phase-4-style merge decision needs, whenever someone picks it back up.
+
+## Current architecture (before this patch)
+
+Two signals, two backends, zero comparison tooling. `drive_state.v1`'s current value: `orion/spark/concept_induction/store.py::LocalProfileStore.load_drive_state(subject)`, a raw unvalidated dict from a local JSON file (`CONCEPT_STORE_PATH`). `autonomy_state_v2`'s current value: `orion/autonomy/state_store.py::load_autonomy_state_v2(subject)`, a pydantic-validated `AutonomyStateV2` from Postgres (`ORION_AUTONOMY_STATE_DB_URL`), fails open (returns `None`) on any error.
+
+## Architecture touched
+
+`scripts/` (new standalone script, matches `check_activation_saturation.py`'s conventions), `services/orion-spark-concept-induction/README.md` (new short section), `tests/`.
+
+## Files changed
+
+- `scripts/drive_state_divergence_audit.py` (new): loads both current signals, computes per-drive-key `abs(pressure_a - pressure_b)` and activation-flag agreement (`DriveStateV1.activations[key]` bool vs. `AutonomyStateV2.active_drives` list membership — the two schemas don't share the same activation representation, handled explicitly). Reports prose or `--json`. Always exits 0 (report-only, no known-good baseline to gate against, matching `check_activation_saturation.py`'s posture before it grew a `--fail-above` flag).
+- `tests/test_drive_state_divergence_audit.py` (new, 15 tests): both signals present, one/both missing, activation agreement/disagreement, and a regression test for a corrupted-JSON-value crash the implementing agent found and fixed in its own review pass (`_coerce_float()` guards against the local store's lack of type validation, unlike the Postgres side which fails closed via pydantic).
+- `services/orion-spark-concept-induction/README.md`: short section documenting what/why/how to run.
+
+## Schema / bus / API changes
+
+None. Read-only consumer of two already-existing, already-typed signals.
+
+## Env/config changes
+
+None new. Reads existing `ORION_AUTONOMY_STATE_DB_URL` / `CONCEPT_STORE_PATH`.
+
+## Tests run
+
+```text
+$ python -m pytest tests/test_drive_state_divergence_audit.py -q
+15 passed
+
+$ python -m pytest tests/test_drive_state_divergence_audit.py tests/test_inner_state_registry_gate.py tests/test_check_concept_relation_digest_liveness.py -q
+31 passed
+```
+Independently re-run by the orchestrator (not just the implementing agent) — confirmed.
+
+## Evals run
+
+Not applicable — deterministic diagnostic script, no eval surface. Its own live-data run against a real local store file (see Docker/build/smoke checks) is the closest equivalent to an eval here.
+
+## Docker/build/smoke checks
+
+Live-ran against a real local `CONCEPT_STORE_PATH` file on this host (found real `drive_state.v1` data, `updated_at=2026-07-12T08:50:17`), and confirmed both the DSN-unset and DB-connection-refused paths for `autonomy_state_v2` degrade to a clear "UNAVAILABLE" report with exit 0, no crash — proof beyond the mocked unit tests that the script's degrade-gracefully claims hold against real infrastructure, not just mocks.
+
+## Review findings fixed
+
+- Finding: the implementing agent's own first draft called `float(pressure_value)` unconditionally on the JSON-store side. `LocalProfileStore.load_drive_state()` returns a raw, unvalidated dict (unlike the Postgres side, which fails closed via pydantic validation) — a hand-edited or corrupted store value would crash the script instead of degrading.
+  - Fix: `_coerce_float()` helper, non-numeric values reported as unavailable rather than raising.
+  - Evidence: `test_compare_drives_corrupted_pressure_value_does_not_crash` (new regression test).
+
+## Restart required
+
+```text
+No restart required.
+```
+Standalone, on-demand script — nothing running to restart.
+
+## Risks / concerns
+
+- Severity: Low — this is a point-in-time snapshot tool, not a trend/history report (neither backing store retains history). If a future need arises for trend analysis, that's a different, larger patch (would require adding persistence to one or both stores) — explicitly out of scope here and not attempted.
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...chore/drive-state-divergence-audit?expand=1`

--- a/scripts/drive_state_divergence_audit.py
+++ b/scripts/drive_state_divergence_audit.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Point-in-time divergence snapshot between the two independently-computed
+drive-pressure signals that share the 6-key `DRIVE_KEYS` taxonomy
+(coherence, continuity, capability, relational, predictive, autonomy):
+
+1. `drive_state.v1` -- computed by `DriveEngine`
+   (orion/spark/concept_induction/drives.py), run inside
+   orion/spark/concept_induction/bus_worker.py. Only the *current* value is
+   persisted: a local JSON file via
+   `LocalProfileStore.load_drive_state("orion")`
+   (orion/spark/concept_induction/store.py), path from
+   `ConceptSettings.store_path` (env `CONCEPT_STORE_PATH`, default
+   `DEFAULT_CONCEPT_STORE_PATH` in orion/spark/concept_induction/settings.py).
+2. `autonomy_state_v2` -- computed by `orion.autonomy.reducer`, consumed in
+   services/orion-cortex-exec/app/chat_stance.py::_run_autonomy_reducer. Only
+   the *current* value is persisted: a single-row-per-subject UPSERT in
+   Postgres via `load_autonomy_state_v2("orion")`
+   (orion/autonomy/state_store.py), DSN from env `ORION_AUTONOMY_STATE_DB_URL`.
+   That loader fails open -- it never raises, and returns None on any error,
+   missing DSN, or missing row.
+
+`orion/self_state/inner_state_registry.py` marks both signals `DUPLICATE` of
+each other and explicitly defers the merge-or-keep-separate decision to a
+later phase -- that decision is NOT made here. This script only measures and
+reports how far apart the two CURRENT values are; it never merges, blends,
+or picks a winner between them.
+
+Neither backing store keeps history -- the JSON file is overwritten in place
+and the Postgres row is UPSERTed -- so this is not a time-window trend
+report. It is a snapshot comparison, safe to re-run any time.
+
+Usage:
+    python scripts/drive_state_divergence_audit.py
+    python scripts/drive_state_divergence_audit.py --subject orion --json
+    CONCEPT_STORE_PATH=/tmp/concept-induction-state.json \\
+    ORION_AUTONOMY_STATE_DB_URL=postgresql://user:pass@host:port/db \\
+        python scripts/drive_state_divergence_audit.py
+
+This is a report-only diagnostic, not a pass/fail gate (mirrors
+scripts/check_activation_saturation.py's report-only-by-default posture --
+there is no known-good baseline for divergence between these two signals).
+It always exits 0.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/drive_state_divergence_audit.py` puts scripts/ on
+# sys.path[0], which shadows stdlib modules (same issue documented in
+# scripts/check_inner_state_registry.py / scripts/check_single_consumer_channels.py).
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+_REPO_ROOT = str(Path(__file__).resolve().parents[1])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from orion.autonomy.models import AutonomyStateV2  # noqa: E402
+from orion.autonomy.state_store import load_autonomy_state_v2  # noqa: E402
+from orion.spark.concept_induction.drives import DRIVE_KEYS  # noqa: E402
+from orion.spark.concept_induction.settings import DEFAULT_CONCEPT_STORE_PATH  # noqa: E402
+from orion.spark.concept_induction.store import LocalProfileStore  # noqa: E402
+
+
+def load_drive_state_v1(store_path: str, subject: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Load the current drive_state.v1 raw dict for `subject`.
+
+    Returns (state_or_None, error_or_None). `LocalProfileStore.load_drive_state`
+    already never raises and returns `{}` for a cold/missing store or unknown
+    subject (see store.py) -- this wraps it defensively anyway (e.g. an
+    unwritable parent dir in `LocalProfileStore.__init__`'s mkdir) so a bad
+    store path is reported, not a crash. A `None` return means "no data
+    available", not "zero divergence" -- callers must not treat it as pressures
+    of 0.0.
+    """
+    try:
+        store = LocalProfileStore(store_path)
+        raw = store.load_drive_state(subject)
+    except Exception as exc:  # pragma: no cover - defensive, store.py itself never raises
+        return None, f"LocalProfileStore.load_drive_state raised: {exc}"
+    if not isinstance(raw, dict) or "pressures" not in raw:
+        return None, None
+    return raw, None
+
+
+def load_autonomy_state(subject: str) -> Tuple[Optional[AutonomyStateV2], Optional[str]]:
+    """Load the current autonomy_state_v2 for `subject`.
+
+    `load_autonomy_state_v2` is documented to fail open (never raises, returns
+    None on any error/missing DSN/missing row) -- this wraps it anyway per the
+    same defensive posture as `load_drive_state_v1`.
+    """
+    try:
+        state = load_autonomy_state_v2(subject)
+    except Exception as exc:  # pragma: no cover - defensive, state_store.py itself never raises
+        return None, f"load_autonomy_state_v2 raised: {exc}"
+    return state, None
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    """Best-effort numeric coercion for values read from the unvalidated
+    LocalProfileStore JSON file (no pydantic model backs it, unlike
+    AutonomyStateV2.drive_pressures). A hand-edited or corrupted store could
+    hold a non-numeric pressure value -- treat that as "not available" for
+    this key rather than raising and crashing the whole report."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def compare_drives(
+    drive_raw: Optional[Dict[str, Any]],
+    autonomy_state: Optional[AutonomyStateV2],
+) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any]]:
+    """Per-drive pressure divergence + activation-flag agreement.
+
+    `drive_state.v1` carries `activations: Dict[str, bool]` (one flag per
+    drive). `AutonomyStateV2` (via its `AutonomyStateV1` base) has no such
+    per-drive bool map -- it has `active_drives: list[str]`, so the
+    activation-equivalent comparison here is membership in that list, not a
+    dict lookup. Never fabricates a value for a side with no data: any field
+    that can't be computed is `None`, not 0.0/False.
+    """
+    pressures_a = (drive_raw or {}).get("pressures") or {}
+    activations_a = (drive_raw or {}).get("activations") or {}
+    pressures_b = autonomy_state.drive_pressures if autonomy_state is not None else {}
+    active_b = set(autonomy_state.active_drives) if autonomy_state is not None else set()
+
+    per_drive: Dict[str, Dict[str, Any]] = {}
+    diffs: Dict[str, float] = {}
+    activation_agreements = 0
+    activation_disagreements = 0
+
+    for key in DRIVE_KEYS:
+        # pb is safe to treat as already-numeric: AutonomyStateV2.drive_pressures
+        # is pydantic-typed dict[str, float], so a malformed row would have
+        # failed validation upstream in load_autonomy_state_v2 (which fails
+        # open to None) rather than reaching us. pa has no such guarantee.
+        pa = _coerce_float(pressures_a.get(key)) if drive_raw is not None else None
+        pb = pressures_b.get(key) if autonomy_state is not None else None
+        abs_diff = abs(pa - pb) if (pa is not None and pb is not None) else None
+
+        aa = activations_a.get(key) if drive_raw is not None else None
+        ab = (key in active_b) if autonomy_state is not None else None
+        agree = (bool(aa) == bool(ab)) if (aa is not None and ab is not None) else None
+        if agree is True:
+            activation_agreements += 1
+        elif agree is False:
+            activation_disagreements += 1
+
+        per_drive[key] = {
+            "pressure_drive_state_v1": pa,
+            "pressure_autonomy_state_v2": pb,
+            "abs_diff": abs_diff,
+            "activation_drive_state_v1": aa,
+            "active_autonomy_state_v2": ab,
+            "activation_agree": agree,
+        }
+        if abs_diff is not None:
+            diffs[key] = abs_diff
+
+    max_diff_drive = max(diffs, key=diffs.get) if diffs else None
+    summary = {
+        "drives_compared_pressure": len(diffs),
+        "drives_total": len(DRIVE_KEYS),
+        "mean_abs_diff": (sum(diffs.values()) / len(diffs)) if diffs else None,
+        "max_abs_diff": diffs[max_diff_drive] if max_diff_drive else None,
+        "max_abs_diff_drive": max_diff_drive,
+        "activation_drives_compared": activation_agreements + activation_disagreements,
+        "activation_agreements": activation_agreements,
+        "activation_disagreements": activation_disagreements,
+    }
+    return per_drive, summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--subject",
+        default="orion",
+        help="subject key both signals are keyed on (default: orion, the repo-wide convention).",
+    )
+    parser.add_argument(
+        "--store-path",
+        default=os.getenv("CONCEPT_STORE_PATH", DEFAULT_CONCEPT_STORE_PATH),
+        help=(
+            "path to the concept-induction LocalProfileStore JSON file. "
+            "Defaults to $CONCEPT_STORE_PATH, falling back to "
+            f"{DEFAULT_CONCEPT_STORE_PATH!r}."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of prose.")
+    args = parser.parse_args(argv)
+
+    drive_raw, drive_error = load_drive_state_v1(args.store_path, args.subject)
+    autonomy_state, autonomy_error = load_autonomy_state(args.subject)
+
+    drive_available = drive_raw is not None
+    autonomy_available = autonomy_state is not None
+
+    per_drive, summary = compare_drives(drive_raw, autonomy_state)
+
+    if args.json:
+        payload = {
+            "subject": args.subject,
+            "drive_state_v1": {
+                "available": drive_available,
+                "store_path": args.store_path,
+                "error": drive_error,
+                "pressures": (drive_raw or {}).get("pressures") if drive_available else None,
+                "activations": (drive_raw or {}).get("activations") if drive_available else None,
+                "updated_at": (drive_raw or {}).get("updated_at") if drive_available else None,
+            },
+            "autonomy_state_v2": {
+                "available": autonomy_available,
+                "dsn_configured": bool(os.getenv("ORION_AUTONOMY_STATE_DB_URL", "").strip()),
+                "error": autonomy_error,
+                "drive_pressures": autonomy_state.drive_pressures if autonomy_available else None,
+                "active_drives": autonomy_state.active_drives if autonomy_available else None,
+                "generated_at": (
+                    autonomy_state.generated_at.isoformat()
+                    if autonomy_available and autonomy_state.generated_at
+                    else None
+                ),
+            },
+            "per_drive": per_drive,
+            "summary": summary,
+        }
+        print(json.dumps(payload, indent=2, default=str))
+        return 0
+
+    print(f"drive_state_divergence_audit: subject={args.subject!r}")
+    print()
+    if drive_available:
+        updated_at = (drive_raw or {}).get("updated_at")
+        print(f"drive_state.v1: available (store_path={args.store_path}, updated_at={updated_at})")
+    elif drive_error:
+        print(f"drive_state.v1: UNAVAILABLE -- {drive_error}")
+    else:
+        print(
+            f"drive_state.v1: UNAVAILABLE -- no data at store_path={args.store_path} "
+            f"(cold store, wrong path, or subject {args.subject!r} never ticked)"
+        )
+
+    if autonomy_available:
+        print(f"autonomy_state_v2: available (generated_at={autonomy_state.generated_at})")
+    elif autonomy_error:
+        print(f"autonomy_state_v2: UNAVAILABLE -- {autonomy_error}")
+    elif not os.getenv("ORION_AUTONOMY_STATE_DB_URL", "").strip():
+        print("autonomy_state_v2: UNAVAILABLE -- $ORION_AUTONOMY_STATE_DB_URL is unset")
+    else:
+        print(
+            "autonomy_state_v2: UNAVAILABLE -- load_autonomy_state_v2 returned None "
+            f"(no persisted row yet for subject={args.subject!r}, or a DB error was logged and swallowed)"
+        )
+    print()
+
+    if not drive_available and not autonomy_available:
+        print("Cannot compute divergence: both signals are unavailable.")
+        return 0
+    if not drive_available or not autonomy_available:
+        missing = "drive_state.v1" if not drive_available else "autonomy_state_v2"
+        print(f"Cannot compute divergence: {missing} has no data. Per-drive comparison below is all n/a.")
+        print()
+
+    header = f"{'drive':<12} {'drive_state.v1':>16} {'autonomy_v2':>14} {'abs_diff':>10} {'active_a':>9} {'active_b':>9} {'agree':>7}"
+    print(header)
+    print("-" * len(header))
+    for key in DRIVE_KEYS:
+        entry = per_drive[key]
+
+        def _fmt(v: Any, precision: int = 3) -> str:
+            if v is None:
+                return "n/a"
+            if isinstance(v, float):
+                return f"{v:.{precision}f}"
+            return str(v)
+
+        print(
+            f"{key:<12} {_fmt(entry['pressure_drive_state_v1']):>16} "
+            f"{_fmt(entry['pressure_autonomy_state_v2']):>14} {_fmt(entry['abs_diff']):>10} "
+            f"{_fmt(entry['activation_drive_state_v1']):>9} {_fmt(entry['active_autonomy_state_v2']):>9} "
+            f"{_fmt(entry['activation_agree']):>7}"
+        )
+
+    print()
+    if summary["drives_compared_pressure"]:
+        print(
+            f"summary: {summary['drives_compared_pressure']}/{summary['drives_total']} drives compared, "
+            f"mean_abs_diff={summary['mean_abs_diff']:.3f}, "
+            f"max_abs_diff={summary['max_abs_diff']:.3f} (drive={summary['max_abs_diff_drive']})"
+        )
+    else:
+        print("summary: no drive had pressures available on both sides -- 0 drives compared.")
+    if summary["activation_drives_compared"]:
+        print(
+            f"activation flags: {summary['activation_agreements']}/{summary['activation_drives_compared']} agree, "
+            f"{summary['activation_disagreements']}/{summary['activation_drives_compared']} disagree"
+        )
+    else:
+        print("activation flags: no drive had an activation flag available on both sides -- 0 compared.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-spark-concept-induction/README.md
+++ b/services/orion-spark-concept-induction/README.md
@@ -30,3 +30,21 @@ python -m scripts.test_concept_induction_publish
 ```
 
 This publishes a fake chat event and waits for a profile on `BUS_PROFILE_OUT`.
+
+## Drive-state divergence audit
+
+`drive_state.v1` (this service's `DriveEngine`, persisted to the local
+`LocalProfileStore` JSON file at `CONCEPT_STORE_PATH`) and `autonomy_state_v2`
+(`orion.autonomy.reducer`, persisted to Postgres via
+`ORION_AUTONOMY_STATE_DB_URL`) independently compute pressures over the same
+6-key drive taxonomy. `orion/self_state/inner_state_registry.py` marks both
+`DUPLICATE` of each other and defers the merge-or-keep-separate decision to a
+later phase. `scripts/drive_state_divergence_audit.py` (repo root) is a
+report-only diagnostic that loads the current value of each and prints
+per-drive pressure divergence and activation-flag agreement -- it never
+merges or picks a winner between them, and it always exits 0.
+
+```bash
+python scripts/drive_state_divergence_audit.py
+python scripts/drive_state_divergence_audit.py --json
+```

--- a/tests/test_drive_state_divergence_audit.py
+++ b/tests/test_drive_state_divergence_audit.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import drive_state_divergence_audit as dsa  # noqa: E402
+from orion.autonomy.models import AutonomyStateV2  # noqa: E402
+
+
+def _autonomy_state(*, drive_pressures: dict, active_drives: list[str]) -> AutonomyStateV2:
+    return AutonomyStateV2(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        source="reducer",
+        drive_pressures=drive_pressures,
+        active_drives=active_drives,
+    )
+
+
+def _mock_store(load_drive_state_return):
+    """Build a mock LocalProfileStore class whose instances' load_drive_state
+    returns `load_drive_state_return` (or raises, if it's an exception instance)."""
+    instance = Mock()
+    if isinstance(load_drive_state_return, Exception):
+        instance.load_drive_state.side_effect = load_drive_state_return
+    else:
+        instance.load_drive_state.return_value = load_drive_state_return
+    cls = Mock(return_value=instance)
+    return cls
+
+
+# --------------------------------------------------------------------------
+# load_drive_state_v1 / load_autonomy_state loader wrappers
+# --------------------------------------------------------------------------
+
+def test_load_drive_state_v1_missing_store_returns_none_no_error():
+    with patch.object(dsa, "LocalProfileStore", _mock_store({})):
+        state, error = dsa.load_drive_state_v1("/tmp/does-not-matter.json", "orion")
+    assert state is None
+    assert error is None
+
+
+def test_load_drive_state_v1_present():
+    raw = {"pressures": {"coherence": 0.5}, "activations": {"coherence": True}, "updated_at": "2026-07-13T00:00:00+00:00"}
+    with patch.object(dsa, "LocalProfileStore", _mock_store(raw)):
+        state, error = dsa.load_drive_state_v1("/tmp/does-not-matter.json", "orion")
+    assert state == raw
+    assert error is None
+
+
+def test_load_drive_state_v1_raises_is_caught():
+    with patch.object(dsa, "LocalProfileStore", _mock_store(RuntimeError("disk full"))):
+        state, error = dsa.load_drive_state_v1("/tmp/does-not-matter.json", "orion")
+    assert state is None
+    assert error is not None
+    assert "disk full" in error
+
+
+def test_load_autonomy_state_none():
+    with patch.object(dsa, "load_autonomy_state_v2", return_value=None):
+        state, error = dsa.load_autonomy_state("orion")
+    assert state is None
+    assert error is None
+
+
+def test_load_autonomy_state_present():
+    expected = _autonomy_state(drive_pressures={"coherence": 0.4}, active_drives=["coherence"])
+    with patch.object(dsa, "load_autonomy_state_v2", return_value=expected):
+        state, error = dsa.load_autonomy_state("orion")
+    assert state is expected
+    assert error is None
+
+
+def test_load_autonomy_state_raises_is_caught():
+    with patch.object(dsa, "load_autonomy_state_v2", side_effect=RuntimeError("db down")):
+        state, error = dsa.load_autonomy_state("orion")
+    assert state is None
+    assert error is not None
+    assert "db down" in error
+
+
+# --------------------------------------------------------------------------
+# compare_drives
+# --------------------------------------------------------------------------
+
+def test_compare_drives_both_present_real_divergence():
+    drive_raw = {
+        "pressures": {
+            "coherence": 0.80,
+            "continuity": 0.10,
+            "capability": 0.50,
+            "relational": 0.20,
+            "predictive": 0.30,
+            "autonomy": 0.60,
+        },
+        "activations": {
+            "coherence": True,
+            "continuity": False,
+            "capability": True,
+            "relational": False,
+            "predictive": False,
+            "autonomy": True,
+        },
+    }
+    autonomy_state = _autonomy_state(
+        drive_pressures={
+            "coherence": 0.20,
+            "continuity": 0.15,
+            "capability": 0.50,
+            "relational": 0.90,
+            "predictive": 0.30,
+            "autonomy": 0.05,
+        },
+        # active_drives disagrees with drive_state.v1 on coherence and autonomy,
+        # agrees on continuity/capability/relational/predictive.
+        active_drives=["capability"],
+    )
+
+    per_drive, summary = dsa.compare_drives(drive_raw, autonomy_state)
+
+    assert per_drive["coherence"]["abs_diff"] == pytest.approx(0.60)
+    assert per_drive["continuity"]["abs_diff"] == pytest.approx(0.05)
+    assert per_drive["capability"]["abs_diff"] == pytest.approx(0.0)
+    assert per_drive["relational"]["abs_diff"] == pytest.approx(0.70)
+    assert per_drive["predictive"]["abs_diff"] == pytest.approx(0.0)
+    assert per_drive["autonomy"]["abs_diff"] == pytest.approx(0.55)
+
+    assert summary["drives_compared_pressure"] == 6
+    assert summary["max_abs_diff_drive"] == "relational"
+    assert summary["max_abs_diff"] == pytest.approx(0.70)
+    assert summary["mean_abs_diff"] == pytest.approx((0.60 + 0.05 + 0.0 + 0.70 + 0.0 + 0.55) / 6)
+
+    # activation agreement: coherence True vs not-in-active_drives(False) -> disagree
+    assert per_drive["coherence"]["activation_agree"] is False
+    # continuity False vs not-in-active_drives(False) -> agree
+    assert per_drive["continuity"]["activation_agree"] is True
+    # capability True vs in active_drives(True) -> agree
+    assert per_drive["capability"]["activation_agree"] is True
+    # relational False vs not-in-active_drives(False) -> agree
+    assert per_drive["relational"]["activation_agree"] is True
+    # predictive False vs not-in-active_drives(False) -> agree
+    assert per_drive["predictive"]["activation_agree"] is True
+    # autonomy True vs not-in-active_drives(False) -> disagree
+    assert per_drive["autonomy"]["activation_agree"] is False
+
+    assert summary["activation_drives_compared"] == 6
+    assert summary["activation_agreements"] == 4
+    assert summary["activation_disagreements"] == 2
+
+
+def test_compare_drives_autonomy_missing():
+    drive_raw = {
+        "pressures": {k: 0.5 for k in dsa.DRIVE_KEYS},
+        "activations": {k: True for k in dsa.DRIVE_KEYS},
+    }
+    per_drive, summary = dsa.compare_drives(drive_raw, None)
+    for key in dsa.DRIVE_KEYS:
+        assert per_drive[key]["pressure_autonomy_state_v2"] is None
+        assert per_drive[key]["abs_diff"] is None
+        assert per_drive[key]["active_autonomy_state_v2"] is None
+        assert per_drive[key]["activation_agree"] is None
+        assert per_drive[key]["pressure_drive_state_v1"] == 0.5
+    assert summary["drives_compared_pressure"] == 0
+    assert summary["mean_abs_diff"] is None
+    assert summary["max_abs_diff_drive"] is None
+    assert summary["activation_drives_compared"] == 0
+
+
+def test_compare_drives_drive_state_missing():
+    autonomy_state = _autonomy_state(
+        drive_pressures={k: 0.3 for k in dsa.DRIVE_KEYS},
+        active_drives=list(dsa.DRIVE_KEYS),
+    )
+    per_drive, summary = dsa.compare_drives(None, autonomy_state)
+    for key in dsa.DRIVE_KEYS:
+        assert per_drive[key]["pressure_drive_state_v1"] is None
+        assert per_drive[key]["abs_diff"] is None
+        assert per_drive[key]["activation_drive_state_v1"] is None
+        assert per_drive[key]["activation_agree"] is None
+        assert per_drive[key]["pressure_autonomy_state_v2"] == 0.3
+    assert summary["drives_compared_pressure"] == 0
+    assert summary["activation_drives_compared"] == 0
+
+
+def test_compare_drives_corrupted_pressure_value_does_not_crash():
+    # LocalProfileStore's JSON file is unvalidated (no pydantic model) -- a
+    # hand-edited or corrupted store could hold a non-numeric pressure value.
+    # This must degrade that single key to "unavailable", not raise.
+    drive_raw = {
+        "pressures": {"coherence": "not-a-number", "continuity": 0.4},
+        "activations": {"coherence": True, "continuity": False},
+    }
+    autonomy_state = _autonomy_state(
+        drive_pressures={"coherence": 0.5, "continuity": 0.5},
+        active_drives=[],
+    )
+    per_drive, summary = dsa.compare_drives(drive_raw, autonomy_state)
+    assert per_drive["coherence"]["pressure_drive_state_v1"] is None
+    assert per_drive["coherence"]["abs_diff"] is None
+    assert per_drive["continuity"]["abs_diff"] == pytest.approx(0.1)
+    assert summary["drives_compared_pressure"] == 1
+
+
+def test_compare_drives_both_missing():
+    per_drive, summary = dsa.compare_drives(None, None)
+    for key in dsa.DRIVE_KEYS:
+        assert per_drive[key]["pressure_drive_state_v1"] is None
+        assert per_drive[key]["pressure_autonomy_state_v2"] is None
+        assert per_drive[key]["abs_diff"] is None
+    assert summary["drives_compared_pressure"] == 0
+    assert summary["mean_abs_diff"] is None
+    assert summary["activation_drives_compared"] == 0
+
+
+# --------------------------------------------------------------------------
+# main() end-to-end (loaders mocked)
+# --------------------------------------------------------------------------
+
+def test_main_json_both_present_exits_zero(capsys):
+    drive_raw = {
+        "pressures": {k: 0.4 for k in dsa.DRIVE_KEYS},
+        "activations": {k: False for k in dsa.DRIVE_KEYS},
+        "updated_at": "2026-07-13T00:00:00+00:00",
+    }
+    autonomy_state = _autonomy_state(
+        drive_pressures={k: 0.6 for k in dsa.DRIVE_KEYS},
+        active_drives=[],
+    )
+    with patch.object(dsa, "LocalProfileStore", _mock_store(drive_raw)), patch.object(
+        dsa, "load_autonomy_state_v2", return_value=autonomy_state
+    ):
+        exit_code = dsa.main(["--json"])
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["drive_state_v1"]["available"] is True
+    assert out["autonomy_state_v2"]["available"] is True
+    assert out["summary"]["drives_compared_pressure"] == 6
+    for key in dsa.DRIVE_KEYS:
+        assert out["per_drive"][key]["abs_diff"] == pytest.approx(0.2)
+
+
+def test_main_prose_both_missing_exits_zero(capsys):
+    with patch.object(dsa, "LocalProfileStore", _mock_store({})), patch.object(
+        dsa, "load_autonomy_state_v2", return_value=None
+    ):
+        exit_code = dsa.main([])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "drive_state.v1: UNAVAILABLE" in out
+    assert "autonomy_state_v2: UNAVAILABLE" in out
+    assert "Cannot compute divergence: both signals are unavailable." in out
+
+
+def test_main_prose_one_missing_exits_zero_reports_na(capsys):
+    autonomy_state = _autonomy_state(
+        drive_pressures={k: 0.6 for k in dsa.DRIVE_KEYS},
+        active_drives=["capability"],
+    )
+    with patch.object(dsa, "LocalProfileStore", _mock_store({})), patch.object(
+        dsa, "load_autonomy_state_v2", return_value=autonomy_state
+    ):
+        exit_code = dsa.main([])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "drive_state.v1: UNAVAILABLE" in out
+    assert "autonomy_state_v2: available" in out
+    assert "n/a" in out
+
+
+def test_main_never_crashes_on_loader_exceptions(capsys):
+    with patch.object(dsa, "LocalProfileStore", _mock_store(RuntimeError("boom"))), patch.object(
+        dsa, "load_autonomy_state_v2", side_effect=RuntimeError("boom2")
+    ):
+        exit_code = dsa.main([])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "boom" in out
+    assert "boom2" in out


### PR DESCRIPTION
# PR report: drive_state.v1 vs autonomy_state_v2 divergence audit

## Summary

- `drive_state.v1` (`DriveEngine`, `orion/spark/concept_induction/drives.py`) and `autonomy_state_v2` (`orion.autonomy.reducer`) independently compute the same 6-drive taxonomy (`coherence, continuity, capability, relational, predictive, autonomy`) and are explicitly marked `DUPLICATE` of each other in `orion/self_state/inner_state_registry.py`, with the merge-or-keep-separate decision deferred to a later phase, not resolved.
- New `scripts/drive_state_divergence_audit.py` — a report-only, point-in-time snapshot comparison of the two signals' *current* values (neither is historically persisted — `drive_state.v1` lives in a local JSON file that gets overwritten, `autonomy_state_v2` in a single-row-per-subject Postgres UPSERT). Measures, never merges or picks a winner.
- Does not touch either signal's producer, consumer, or the deferred merge decision — pure diagnostic.

## Outcome moved

There was no way to answer "how far apart are these two signals right now" without manually querying two different backends by hand. Now there's a standing, runnable script — the actual evidence input the deferred Phase-4-style merge decision needs, whenever someone picks it back up.

## Current architecture (before this patch)

Two signals, two backends, zero comparison tooling. `drive_state.v1`'s current value: `orion/spark/concept_induction/store.py::LocalProfileStore.load_drive_state(subject)`, a raw unvalidated dict from a local JSON file (`CONCEPT_STORE_PATH`). `autonomy_state_v2`'s current value: `orion/autonomy/state_store.py::load_autonomy_state_v2(subject)`, a pydantic-validated `AutonomyStateV2` from Postgres (`ORION_AUTONOMY_STATE_DB_URL`), fails open (returns `None`) on any error.

## Architecture touched

`scripts/` (new standalone script, matches `check_activation_saturation.py`'s conventions), `services/orion-spark-concept-induction/README.md` (new short section), `tests/`.

## Files changed

- `scripts/drive_state_divergence_audit.py` (new): loads both current signals, computes per-drive-key `abs(pressure_a - pressure_b)` and activation-flag agreement (`DriveStateV1.activations[key]` bool vs. `AutonomyStateV2.active_drives` list membership — the two schemas don't share the same activation representation, handled explicitly). Reports prose or `--json`. Always exits 0 (report-only, no known-good baseline to gate against, matching `check_activation_saturation.py`'s posture before it grew a `--fail-above` flag).
- `tests/test_drive_state_divergence_audit.py` (new, 15 tests): both signals present, one/both missing, activation agreement/disagreement, and a regression test for a corrupted-JSON-value crash the implementing agent found and fixed in its own review pass (`_coerce_float()` guards against the local store's lack of type validation, unlike the Postgres side which fails closed via pydantic).
- `services/orion-spark-concept-induction/README.md`: short section documenting what/why/how to run.

## Schema / bus / API changes

None. Read-only consumer of two already-existing, already-typed signals.

## Env/config changes

None new. Reads existing `ORION_AUTONOMY_STATE_DB_URL` / `CONCEPT_STORE_PATH`.

## Tests run

```text
$ python -m pytest tests/test_drive_state_divergence_audit.py -q
15 passed

$ python -m pytest tests/test_drive_state_divergence_audit.py tests/test_inner_state_registry_gate.py tests/test_check_concept_relation_digest_liveness.py -q
31 passed
```
Independently re-run by the orchestrator (not just the implementing agent) — confirmed.

## Evals run

Not applicable — deterministic diagnostic script, no eval surface. Its own live-data run against a real local store file (see Docker/build/smoke checks) is the closest equivalent to an eval here.

## Docker/build/smoke checks

Live-ran against a real local `CONCEPT_STORE_PATH` file on this host (found real `drive_state.v1` data, `updated_at=2026-07-12T08:50:17`), and confirmed both the DSN-unset and DB-connection-refused paths for `autonomy_state_v2` degrade to a clear "UNAVAILABLE" report with exit 0, no crash — proof beyond the mocked unit tests that the script's degrade-gracefully claims hold against real infrastructure, not just mocks.

## Review findings fixed

- Finding: the implementing agent's own first draft called `float(pressure_value)` unconditionally on the JSON-store side. `LocalProfileStore.load_drive_state()` returns a raw, unvalidated dict (unlike the Postgres side, which fails closed via pydantic validation) — a hand-edited or corrupted store value would crash the script instead of degrading.
  - Fix: `_coerce_float()` helper, non-numeric values reported as unavailable rather than raising.
  - Evidence: `test_compare_drives_corrupted_pressure_value_does_not_crash` (new regression test).

## Restart required

```text
No restart required.
```
Standalone, on-demand script — nothing running to restart.

## Risks / concerns

- Severity: Low — this is a point-in-time snapshot tool, not a trend/history report (neither backing store retains history). If a future need arises for trend analysis, that's a different, larger patch (would require adding persistence to one or both stores) — explicitly out of scope here and not attempted.