### PR TITLE
Feat/cross drive tension signal

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-13-cross-drive-tension-signal-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-13-cross-drive-tension-signal-pr.md
@@ -1,0 +1,74 @@
+# PR report: cross-drive tension detector (pure function, unwired)
+
+## Summary
+
+- New `orion/spark/concept_induction/drive_tension.py`: a pure function, `detect_drive_tensions(pressures, activations) -> list[DriveTensionV1]`, over `DriveEngine`'s existing 6-key pressure/activation output shape.
+- Deliberately scoped to prove the *definition* is sound before touching anything real — zero wiring into `DriveEngine`, `bus_worker.py`, any bus channel, or the schema registry. This round is the "smallest buildable slice" named explicitly in the accepted spec: a typed, documented, unit-tested definition on paper, nothing live.
+- Definition (`INVERSE_COACTIVATION`): fires for a pair `(drive_a, drive_b)` when `drive_a` is active and `drive_b`'s pressure is below `DriveMathConfig.deactivate_threshold` (0.42, reused — no new magic number invented). Magnitude = `pressures[drive_a] * (1.0 - pressures[drive_b])`.
+
+## Outcome moved
+
+Nothing live changes. The outcome is a concrete, testable answer to "what would 'two drives are in tension' even mean" — the open question flagged as the riskiest keyword-cathedral candidate in the accepted brainstorm, now closed with a real definition instead of an unspecified concept.
+
+## Current architecture (before this patch)
+
+`DriveEngine` computes each of the 6 drives independently every tick; nothing detects or represents interaction between drives.
+
+## Architecture touched
+
+`orion/spark/concept_induction/` only — one new module, one new test file. No other seam touched.
+
+## Files changed
+
+- `orion/spark/concept_induction/drive_tension.py` (new): `DriveTensionV1` dataclass (`drive_a`, `drive_b`, `tension_kind`, `magnitude`) + `detect_drive_tensions()`. Module docstring states explicitly: correlational co-occurrence, not a causal claim.
+- `orion/spark/concept_induction/tests/test_drive_tension.py` (new, 9 tests): no-tension baseline, single-pair tension, multiple simultaneous tensions, boundary-exactly-at-threshold (excluded) vs. just-below (included), empty input, and missing-key-in-either-dict degrading gracefully rather than raising.
+
+## Schema / bus / API changes
+
+None. No bus channel, no schema-registry entry, no producer, no consumer — by design for this round.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+$ python -m pytest orion/spark/concept_induction/tests/test_drive_tension.py -q
+9 passed
+
+# Sibling suite re-run for regression confidence
+$ python -m pytest orion/spark/concept_induction/tests/test_drives_leaky.py \
+    orion/spark/concept_induction/tests/test_drive_attribution.py -q
+15 passed
+```
+Independently re-run by the orchestrator (not just the implementing agent) — confirmed.
+
+## Evals run
+
+Not applicable — pure, deterministic, fully unit-testable function; the test suite itself is the eval-equivalent (a decidable spec of what "tension" means, per the acceptance bar in the accepted brainstorm).
+
+## Docker/build/smoke checks
+
+Not applicable — no runtime surface, no service, no Docker relevance.
+
+## Review findings fixed
+
+None from a separate review pass — implementing agent's own diff was self-contained (2 new files only, verified via `git status --short` before commit), no touches to `bus_worker.py`, `audit.py`, channels.yaml, or schema registry. Orchestrator independently re-read both files and re-ran tests; no discrepancies found.
+
+## Restart required
+
+```text
+No restart required.
+```
+Nothing running consumes this module yet.
+
+## Risks / concerns
+
+- Severity: Low — a known environment issue was surfaced during this work (not caused by it): the shared `/tmp/orion-test-venv` has `numpy==2.5.1` installed, binary-incompatible with `thinc==8.2.5` (repo's locked `numpy==2.3.0` per `poetry.lock`), which breaks `import spacy` and therefore collection of every test under `orion/spark/concept_induction/tests/` for anyone using that shared venv. The implementing agent built an isolated venv for its own verification rather than touching the shared one (correctly, since other concurrent agents may depend on its current state) — but this is worth fixing separately, since it likely silently blocks other agents' test runs in this same test directory. Flagging for a follow-up, not fixed here (out of scope for this patch, and fixing a shared venv from inside a worktree is exactly the kind of shared-state action that needs its own careful handling, not a drive-by fix).
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/cross-drive-tension-signal?expand=1`

--- a/orion/spark/concept_induction/drive_tension.py
+++ b/orion/spark/concept_induction/drive_tension.py
@@ -1,0 +1,125 @@
+"""Cross-drive tension detection — pure function, no wiring.
+
+`DriveEngine.update()` (see `drives.py`) produces two independent per-tick
+dicts: `pressures` (0.0-1.0 per drive) and `activations` (bool per drive,
+hysteresis-gated between `DriveMathConfig.activate_threshold` and
+`DriveMathConfig.deactivate_threshold`). Each drive is scored on its own —
+there is no notion today of two drives being in *tension* with each other
+(e.g. `capability` dominating while `relational` sits suppressed — a
+"heads-down, disengaged" pattern).
+
+This module adds exactly one thing: a pure function that takes those same
+two dicts and reports pairwise tensions between drives, using the existing
+`DriveMathConfig.deactivate_threshold` as the "suppressed" bar (no new
+magic number is introduced).
+
+IMPORTANT — this is correlational co-occurrence, NOT a causal claim. A
+`DriveTensionV1` says "drive A is active while drive B is currently low, at
+the same tick." It does not claim A caused B's suppression, that the two
+drives are mechanistically linked, or that the pattern will persist across
+ticks. Treat it as a candidate signal for future inspection, not a verified
+mechanism.
+
+This module has zero side effects, is not imported by any live path
+(`bus_worker.py`, `audit.py`, etc.), is not registered on the bus or in the
+schema registry, and is not consumed anywhere yet. It exists to let the
+definition be reviewed and tested on paper before anything wires it up.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from orion.spark.concept_induction.drives import DRIVE_KEYS, DriveMathConfig
+
+# Tension kind name for the one definition this module implements today.
+# "inverse_coactivation": one drive is active while a different drive's
+# pressure is simultaneously low (below the suppressed bar). Named
+# specifically (not just "tension") because future patches may add other
+# tension kinds (e.g. two drives both racing upward, or oscillation) and
+# those must not be conflated with this one.
+INVERSE_COACTIVATION = "inverse_coactivation"
+
+
+@dataclass(frozen=True)
+class DriveTensionV1:
+    """One detected tension between two drives at a single tick.
+
+    `drive_a` is the drive that is currently *active* (per the caller's
+    `activations` dict). `drive_b` is the drive whose *pressure* is
+    currently below the suppressed bar. The pair is directional: swapping
+    the roles is a different (and not necessarily co-occurring) tension —
+    see `detect_drive_tensions` for why both directions cannot hold at
+    once for the same pair under DriveEngine-consistent inputs.
+    """
+
+    drive_a: str
+    drive_b: str
+    tension_kind: str
+    magnitude: float
+
+
+def detect_drive_tensions(
+    pressures: Dict[str, float],
+    activations: Dict[str, bool],
+    *,
+    cfg: DriveMathConfig | None = None,
+) -> List[DriveTensionV1]:
+    """Detect pairwise inverse-coactivation tensions between drives.
+
+    Definition: a tension `(drive_a, drive_b)` is emitted when
+    `activations[drive_a] is True` and `pressures[drive_b] < suppressed_bar`,
+    where `suppressed_bar` is `DriveMathConfig.deactivate_threshold`
+    (reused, not reinvented — this is the same level at which an already-
+    active drive would itself deactivate, so "below this" is a principled
+    reading of "low" for any drive, active or not).
+
+    The boundary is exclusive: `pressures[drive_b] == suppressed_bar`
+    exactly does NOT qualify. The threshold marks the level at which an
+    active drive is still considered (barely) active; treating a drive
+    sitting exactly on that line as "suppressed" would contradict that
+    same semantics.
+
+    `magnitude = pressures[drive_a] * (1.0 - pressures[drive_b])`: it rises
+    with how strongly A is asserting itself (A's own pressure, not just its
+    boolean activation) and with how thoroughly B is suppressed (1 minus
+    B's pressure). Both terms live in [0, 1] so the product does too. This
+    is the simplest formula that satisfies both properties; no other terms
+    are folded in.
+
+    Only pairs that cross the bar are emitted — the function does not
+    enumerate all `len(DRIVE_KEYS) * (len(DRIVE_KEYS) - 1)` ordered pairs
+    on every call, only the ones that actually qualify as tension.
+
+    Drive names are not restricted to `DRIVE_KEYS`: any key present in
+    both an "active" role and a "pressure" role is evaluated, so the
+    function stays useful even if callers pass a subset or superset. Keys
+    missing from one dict simply cannot participate in the role that dict
+    supplies (e.g. a key absent from `activations` can never be `drive_a`).
+    Missing/empty input degrades to an empty result rather than raising.
+    """
+    threshold = (cfg or DriveMathConfig()).deactivate_threshold
+
+    tensions: List[DriveTensionV1] = []
+    for drive_a, is_active in activations.items():
+        if not is_active:
+            continue
+        pressure_a = pressures.get(drive_a)
+        if pressure_a is None:
+            # drive_a has no pressure reading at all; nothing to score with.
+            continue
+        for drive_b, pressure_b in pressures.items():
+            if drive_b == drive_a:
+                continue
+            if pressure_b >= threshold:
+                continue
+            magnitude = max(0.0, min(1.0, pressure_a)) * (1.0 - max(0.0, min(1.0, pressure_b)))
+            tensions.append(
+                DriveTensionV1(
+                    drive_a=drive_a,
+                    drive_b=drive_b,
+                    tension_kind=INVERSE_COACTIVATION,
+                    magnitude=magnitude,
+                )
+            )
+    return tensions

--- a/orion/spark/concept_induction/tests/test_drive_tension.py
+++ b/orion/spark/concept_induction/tests/test_drive_tension.py
@@ -1,0 +1,168 @@
+"""Spec for cross-drive tension detection (`drive_tension.py`).
+
+Tension definition under test — "inverse_coactivation": a tension
+`(drive_a, drive_b)` is reported when `activations[drive_a] is True` (A is
+currently dominant) and `pressures[drive_b] < DriveMathConfig.
+deactivate_threshold` (0.42; B is currently suppressed). The threshold
+comparison is strict (`<`): a pressure exactly equal to the threshold does
+NOT count as suppressed. `magnitude = pressures[drive_a] * (1 -
+pressures[drive_b])`.
+
+This is a pure, standalone module — it is not wired into `DriveEngine`,
+`bus_worker.py`, or any live path. These tests exercise the function in
+isolation with synthetic pressure/activation vectors and known expected
+outcomes; nothing here touches the bus, DB, or schema registry.
+"""
+from __future__ import annotations
+
+from orion.spark.concept_induction.drive_tension import (
+    INVERSE_COACTIVATION,
+    DriveTensionV1,
+    detect_drive_tensions,
+)
+from orion.spark.concept_induction.drives import DRIVE_KEYS, DriveMathConfig
+
+THRESHOLD = DriveMathConfig().deactivate_threshold  # 0.42
+
+
+def _pairs(tensions: list[DriveTensionV1]) -> set[tuple[str, str]]:
+    return {(t.drive_a, t.drive_b) for t in tensions}
+
+
+def test_no_tension_when_nothing_active() -> None:
+    """All pressures moderate, nothing active -> no tensions at all."""
+    pressures = {k: 0.5 for k in DRIVE_KEYS}
+    activations = {k: False for k in DRIVE_KEYS}
+
+    result = detect_drive_tensions(pressures, activations)
+
+    assert result == []
+
+
+def test_no_tension_when_active_but_nothing_low() -> None:
+    """A drive active, but no other drive dips below the suppressed bar ->
+    no tensions, even though something is active."""
+    pressures = {k: 0.5 for k in DRIVE_KEYS}
+    pressures["capability"] = 0.9
+    activations = {k: False for k in DRIVE_KEYS}
+    activations["capability"] = True
+
+    result = detect_drive_tensions(pressures, activations)
+
+    assert result == []
+
+
+def test_single_pair_tension() -> None:
+    """capability active + high, relational genuinely low, everything else
+    moderate -> exactly one tension: (capability, relational)."""
+    pressures = {k: 0.5 for k in DRIVE_KEYS}
+    pressures["capability"] = 0.8
+    pressures["relational"] = 0.1
+    activations = {k: False for k in DRIVE_KEYS}
+    activations["capability"] = True
+
+    result = detect_drive_tensions(pressures, activations)
+
+    assert len(result) == 1
+    tension = result[0]
+    assert tension.drive_a == "capability"
+    assert tension.drive_b == "relational"
+    assert tension.tension_kind == INVERSE_COACTIVATION
+    # magnitude = 0.8 * (1 - 0.1) = 0.72
+    assert abs(tension.magnitude - 0.72) < 1e-9
+    assert 0.0 <= tension.magnitude <= 1.0
+
+
+def test_multiple_simultaneous_tensions() -> None:
+    """Two drives active + high, two drives genuinely low, two moderate and
+    inactive -> all four cross-pairs qualify, nothing else does."""
+    pressures = {
+        "coherence": 0.5,       # moderate, inactive
+        "continuity": 0.5,      # moderate, inactive
+        "capability": 0.8,      # active + high
+        "autonomy": 0.7,        # active + high
+        "relational": 0.1,      # low
+        "predictive": 0.2,      # low
+    }
+    activations = {
+        "coherence": False,
+        "continuity": False,
+        "capability": True,
+        "autonomy": True,
+        "relational": False,
+        "predictive": False,
+    }
+
+    result = detect_drive_tensions(pressures, activations)
+
+    expected_pairs = {
+        ("capability", "relational"),
+        ("capability", "predictive"),
+        ("autonomy", "relational"),
+        ("autonomy", "predictive"),
+    }
+    assert _pairs(result) == expected_pairs
+    # capability and autonomy are both active but neither is "low", so
+    # neither direction of that pair should appear.
+    assert ("capability", "autonomy") not in _pairs(result)
+    assert ("autonomy", "capability") not in _pairs(result)
+    # every emitted tension is correctly typed and in range.
+    for tension in result:
+        assert tension.tension_kind == INVERSE_COACTIVATION
+        assert 0.0 <= tension.magnitude <= 1.0
+
+
+def test_boundary_exactly_at_threshold_is_excluded() -> None:
+    """pressures[drive_b] == deactivate_threshold exactly -> NOT suppressed,
+    no tension. This locks in the exclusive (`<`, not `<=`) boundary."""
+    pressures = {k: 0.5 for k in DRIVE_KEYS}
+    pressures["capability"] = 0.8
+    pressures["relational"] = THRESHOLD  # exactly on the line
+    activations = {k: False for k in DRIVE_KEYS}
+    activations["capability"] = True
+
+    result = detect_drive_tensions(pressures, activations)
+
+    assert result == []
+
+
+def test_boundary_just_below_threshold_is_included() -> None:
+    """A hair below the threshold -> suppressed, tension fires."""
+    pressures = {k: 0.5 for k in DRIVE_KEYS}
+    pressures["capability"] = 0.8
+    pressures["relational"] = THRESHOLD - 1e-6
+    activations = {k: False for k in DRIVE_KEYS}
+    activations["capability"] = True
+
+    result = detect_drive_tensions(pressures, activations)
+
+    assert _pairs(result) == {("capability", "relational")}
+
+
+def test_empty_inputs_return_empty_list() -> None:
+    """Empty dicts must not raise; there is nothing to compare."""
+    assert detect_drive_tensions({}, {}) == []
+
+
+def test_missing_key_in_pressures_is_skipped_not_raised() -> None:
+    """drive_a is active but has no pressure reading at all (key present in
+    activations, absent from pressures) -> that drive cannot participate as
+    drive_a; no crash, no bogus tension."""
+    activations = {"capability": True}
+    pressures = {"relational": 0.1}  # "capability" missing entirely
+
+    result = detect_drive_tensions(pressures, activations)
+
+    assert result == []
+
+
+def test_missing_key_in_activations_is_treated_as_inactive() -> None:
+    """A drive with a pressure reading but no entry in activations can still
+    serve as drive_b (suppressed side) for another active drive, but can
+    never itself be drive_a since it has no True activation on record."""
+    pressures = {"capability": 0.8, "relational": 0.1}
+    activations = {"capability": True}  # "relational" absent
+
+    result = detect_drive_tensions(pressures, activations)
+
+    assert _pairs(result) == {("capability", "relational")}


### PR DESCRIPTION
# PR report: cross-drive tension detector (pure function, unwired)

## Summary

- New `orion/spark/concept_induction/drive_tension.py`: a pure function, `detect_drive_tensions(pressures, activations) -> list[DriveTensionV1]`, over `DriveEngine`'s existing 6-key pressure/activation output shape.
- Deliberately scoped to prove the *definition* is sound before touching anything real — zero wiring into `DriveEngine`, `bus_worker.py`, any bus channel, or the schema registry. This round is the "smallest buildable slice" named explicitly in the accepted spec: a typed, documented, unit-tested definition on paper, nothing live.
- Definition (`INVERSE_COACTIVATION`): fires for a pair `(drive_a, drive_b)` when `drive_a` is active and `drive_b`'s pressure is below `DriveMathConfig.deactivate_threshold` (0.42, reused — no new magic number invented). Magnitude = `pressures[drive_a] * (1.0 - pressures[drive_b])`.

## Outcome moved

Nothing live changes. The outcome is a concrete, testable answer to "what would 'two drives are in tension' even mean" — the open question flagged as the riskiest keyword-cathedral candidate in the accepted brainstorm, now closed with a real definition instead of an unspecified concept.

## Current architecture (before this patch)

`DriveEngine` computes each of the 6 drives independently every tick; nothing detects or represents interaction between drives.

## Architecture touched

`orion/spark/concept_induction/` only — one new module, one new test file. No other seam touched.

## Files changed

- `orion/spark/concept_induction/drive_tension.py` (new): `DriveTensionV1` dataclass (`drive_a`, `drive_b`, `tension_kind`, `magnitude`) + `detect_drive_tensions()`. Module docstring states explicitly: correlational co-occurrence, not a causal claim.
- `orion/spark/concept_induction/tests/test_drive_tension.py` (new, 9 tests): no-tension baseline, single-pair tension, multiple simultaneous tensions, boundary-exactly-at-threshold (excluded) vs. just-below (included), empty input, and missing-key-in-either-dict degrading gracefully rather than raising.

## Schema / bus / API changes

None. No bus channel, no schema-registry entry, no producer, no consumer — by design for this round.

## Env/config changes

None.

## Tests run

```text
$ python -m pytest orion/spark/concept_induction/tests/test_drive_tension.py -q
9 passed

# Sibling suite re-run for regression confidence
$ python -m pytest orion/spark/concept_induction/tests/test_drives_leaky.py \
    orion/spark/concept_induction/tests/test_drive_attribution.py -q
15 passed
```
Independently re-run by the orchestrator (not just the implementing agent) — confirmed.

## Evals run

Not applicable — pure, deterministic, fully unit-testable function; the test suite itself is the eval-equivalent (a decidable spec of what "tension" means, per the acceptance bar in the accepted brainstorm).

## Docker/build/smoke checks

Not applicable — no runtime surface, no service, no Docker relevance.

## Review findings fixed

None from a separate review pass — implementing agent's own diff was self-contained (2 new files only, verified via `git status --short` before commit), no touches to `bus_worker.py`, `audit.py`, channels.yaml, or schema registry. Orchestrator independently re-read both files and re-ran tests; no discrepancies found.

## Restart required

```text
No restart required.
```
Nothing running consumes this module yet.

## Risks / concerns

- Severity: Low — a known environment issue was surfaced during this work (not caused by it): the shared `/tmp/orion-test-venv` has `numpy==2.5.1` installed, binary-incompatible with `thinc==8.2.5` (repo's locked `numpy==2.3.0` per `poetry.lock`), which breaks `import spacy` and therefore collection of every test under `orion/spark/concept_induction/tests/` for anyone using that shared venv. The implementing agent built an isolated venv for its own verification rather than touching the shared one (correctly, since other concurrent agents may depend on its current state) — but this is worth fixing separately, since it likely silently blocks other agents' test runs in this same test directory. Flagging for a follow-up, not fixed here (out of scope for this patch, and fixing a shared venv from inside a worktree is exactly the kind of shared-state action that needs its own careful handling, not a drive-by fix).
