### PR TITLE
Investigate/drive state staleness

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-14-drive-divergence-audit-store-path-warning-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-drive-divergence-audit-store-path-warning-pr.md
@@ -1,0 +1,85 @@
+# PR report: drive_state_divergence_audit.py — warn on silent dev-default store path fallback
+
+## Summary
+
+- Investigated a real-looking alarm: `scripts/drive_state_divergence_audit.py` reported `drive_state.v1` 24h+ stale, all-zero pressures across every drive.
+- Root cause: **false alarm, not a production issue.** The script silently fell back to `DEFAULT_CONCEPT_STORE_PATH` (a host-local dev-scratch path, `/tmp/concept-induction-state.json`) when neither `--store-path` nor `$CONCEPT_STORE_PATH` was set. An unrelated stale file happened to be sitting at that exact path from an earlier local run and was misread as the live signal.
+- Live container (`orion-athena-spark-concept-induction`) was never stale — confirmed via live logs (`drive_engine_pressure_probe` firing every ~2-4s with real, changing, non-zero pressures) and the real bind-mounted store file (`/mnt/graphdb/orion/concepts/concept-induction-state.json`, 35MB, updated seconds before this check, vs. the 3.2KB decoy file the script had actually read).
+- Fixed the script to track *why* `store_path` has its value and print a loud, actionable warning whenever it silently lands on the dev fallback — this exact confusion should not be possible to hit silently again.
+
+## Outcome moved
+
+The divergence audit tool from yesterday's round (`chore/drive-state-divergence-audit`, merged) had a real footgun: its own default behavior could produce a false "drives are stale/dead" alarm with no indication that the path itself was the problem, not the signal. Closed that gap.
+
+## Current architecture (before this patch)
+
+`scripts/drive_state_divergence_audit.py --store-path` defaulted to `os.getenv("CONCEPT_STORE_PATH", DEFAULT_CONCEPT_STORE_PATH)` with no distinction in the output between "read a real, intentionally-configured path" and "silently landed on the dev fallback because nothing else was set." The module docstring's own usage example set `CONCEPT_STORE_PATH=/tmp/concept-induction-state.json` as if it were a legitimate live path, reinforcing the trap.
+
+## Architecture touched
+
+`scripts/` only (the audit script itself and its tests) — no runtime/production code touched, since the live service was confirmed healthy throughout.
+
+## Files changed
+
+- `scripts/drive_state_divergence_audit.py`: `--store-path` now tracks provenance (`cli:--store-path` / `env:CONCEPT_STORE_PATH` / `default_fallback`). When it lands on `default_fallback`, prints a `WARNING:` block (prose mode) or sets `store_path_source`/`store_path_warning` fields (`--json` mode) explaining the fallback is almost certainly not the live container's real store, with the exact `docker inspect` command to find the real one and where to cross-reference the compose file's bind mount. Fixed the misleading usage example in the docstring.
+- `tests/test_drive_state_divergence_audit.py`: 6 new tests covering all three provenance paths in both prose and JSON output.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None. No new keys — this is argument/output-provenance tracking within the existing script.
+
+## Tests run
+
+```text
+$ python -m pytest tests/test_drive_state_divergence_audit.py -q
+21 passed
+```
+Independently re-run by the orchestrator (21/21, matching the implementing agent's count of 15 pre-existing + 6 new).
+
+## Evals run
+
+Not applicable — deterministic diagnostic tooling fix.
+
+## Docker/build/smoke checks
+
+Live-verified by both the implementing agent and independently by the orchestrator:
+
+```text
+$ docker exec orion-athena-spark-concept-induction env | grep CONCEPT_STORE_PATH
+CONCEPT_STORE_PATH=/data/concept-induction-state.json
+
+$ ls -la /mnt/graphdb/orion/concepts/concept-induction-state.json
+-rw-r--r-- 1 root root 35774321 Jul 14 00:04 ...   # 35MB, seconds old
+
+$ docker logs orion-athena-spark-concept-induction --since 30s | grep drive_engine_pressure_probe
+drive_engine_pressure_probe subject=orion pressures={'coherence': 0.7748, ...}  # firing every few seconds, real changing values
+
+# Script re-run with no CONCEPT_STORE_PATH set: reproduces the original false alarm
+# exactly, now WITH the warning block explaining why.
+# Script re-run with the real path: no warning, updated_at seconds old, matches live logs.
+```
+
+## Review findings fixed
+
+N/A — this patch is itself the fix for a finding (a false-alarm-producing footgun in yesterday's merged script), not a patch that went through a separate review pass. Orchestrator independently re-verified both the diff scope and the live claims before pushing rather than trusting the investigating agent's self-report alone.
+
+## Restart required
+
+```text
+No restart required.
+```
+No runtime service touched — the live container was confirmed healthy and untouched throughout this investigation.
+
+## Risks / concerns
+
+None identified. Diagnostic-tooling-only fix, fully additive (new warning, new provenance tracking), no change to existing default behavior for callers who already set `--store-path`/`$CONCEPT_STORE_PATH` correctly.
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...investigate/drive-state-staleness?expand=1`

--- a/scripts/drive_state_divergence_audit.py
+++ b/scripts/drive_state_divergence_audit.py
@@ -32,7 +32,18 @@ report. It is a snapshot comparison, safe to re-run any time.
 Usage:
     python scripts/drive_state_divergence_audit.py
     python scripts/drive_state_divergence_audit.py --subject orion --json
-    CONCEPT_STORE_PATH=/tmp/concept-induction-state.json \\
+
+If neither --store-path nor $CONCEPT_STORE_PATH is given, this falls back to a
+host-local dev default that is almost never the live Docker container's real
+store, and prints a loud warning saying so (2026-07-13 incident: a stale file
+sitting at that fallback path was misread as a 24h+-stale live drive_state.v1
+-- the live container was fine and ticking every few seconds). Point this at
+the real store instead -- find it with:
+    docker inspect <concept-induction-container> \\
+        --format '{{json .Config.Env}}' | grep CONCEPT_STORE_PATH
+then cross-reference services/orion-spark-concept-induction/docker-compose.yml's
+volumes: section for the host-side bind mount, e.g.:
+    CONCEPT_STORE_PATH=/mnt/graphdb/orion/concepts/concept-induction-state.json \\
     ORION_AUTONOMY_STATE_DB_URL=postgresql://user:pass@host:port/db \\
         python scripts/drive_state_divergence_audit.py
 
@@ -191,15 +202,50 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--store-path",
-        default=os.getenv("CONCEPT_STORE_PATH", DEFAULT_CONCEPT_STORE_PATH),
+        default=None,
         help=(
             "path to the concept-induction LocalProfileStore JSON file. "
             "Defaults to $CONCEPT_STORE_PATH, falling back to "
-            f"{DEFAULT_CONCEPT_STORE_PATH!r}."
+            f"{DEFAULT_CONCEPT_STORE_PATH!r} (a host-local dev default that is "
+            "almost never the live Docker container's real store -- see the "
+            "printed warning when this fallback is used)."
         ),
     )
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of prose.")
     args = parser.parse_args(argv)
+
+    # Track *why* store_path has its value, distinct from the value itself, so
+    # we can warn when nobody actually pointed this at a real store (2026-07-13
+    # incident: an operator ran this with neither --store-path nor
+    # $CONCEPT_STORE_PATH set, silently landed on DEFAULT_CONCEPT_STORE_PATH, and
+    # that path happened to hold an unrelated stale dev-leftover file -- read as
+    # "drive_state.v1 is 24h+ stale" when the live container's actual store,
+    # a bind-mounted host path configured in
+    # services/orion-spark-concept-induction/docker-compose.yml /
+    # .env's CONCEPT_STORE_PATH, was updating every few seconds).
+    env_store_path = os.getenv("CONCEPT_STORE_PATH")
+    store_path_warning: Optional[str] = None
+    if args.store_path is not None:
+        store_path_source = "cli:--store-path"
+    elif env_store_path:
+        store_path_source = "env:CONCEPT_STORE_PATH"
+        args.store_path = env_store_path
+    else:
+        store_path_source = "default_fallback"
+        args.store_path = DEFAULT_CONCEPT_STORE_PATH
+        store_path_warning = (
+            f"neither --store-path nor $CONCEPT_STORE_PATH was set -- falling back to "
+            f"{DEFAULT_CONCEPT_STORE_PATH!r}, a host-local dev default. This is almost "
+            "certainly NOT the path the live Docker container writes to. The live "
+            "container's real CONCEPT_STORE_PATH is set in "
+            "services/orion-spark-concept-induction/docker-compose.yml + .env, typically "
+            "a bind-mounted host path under $ORION_DATA_ROOT (e.g. "
+            "/mnt/graphdb/orion/concepts/concept-induction-state.json). Verify with: "
+            "docker inspect <container> --format '{{json .Config.Env}}' | grep CONCEPT_STORE_PATH "
+            "-- then cross-reference the compose file's volumes: section for the host-side "
+            "mount. A stale file left over from an old local run can sit at the fallback "
+            "path and look like real staleness."
+        )
 
     drive_raw, drive_error = load_drive_state_v1(args.store_path, args.subject)
     autonomy_state, autonomy_error = load_autonomy_state(args.subject)
@@ -215,6 +261,8 @@ def main(argv: list[str] | None = None) -> int:
             "drive_state_v1": {
                 "available": drive_available,
                 "store_path": args.store_path,
+                "store_path_source": store_path_source,
+                "store_path_warning": store_path_warning,
                 "error": drive_error,
                 "pressures": (drive_raw or {}).get("pressures") if drive_available else None,
                 "activations": (drive_raw or {}).get("activations") if drive_available else None,
@@ -240,6 +288,9 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"drive_state_divergence_audit: subject={args.subject!r}")
     print()
+    if store_path_warning:
+        print(f"WARNING: {store_path_warning}")
+        print()
     if drive_available:
         updated_at = (drive_raw or {}).get("updated_at")
         print(f"drive_state.v1: available (store_path={args.store_path}, updated_at={updated_at})")

--- a/tests/test_drive_state_divergence_audit.py
+++ b/tests/test_drive_state_divergence_audit.py
@@ -277,6 +277,87 @@ def test_main_prose_one_missing_exits_zero_reports_na(capsys):
     assert "n/a" in out
 
 
+# --------------------------------------------------------------------------
+# store_path provenance warning (2026-07-13 incident: an operator ran this
+# with neither --store-path nor $CONCEPT_STORE_PATH set, silently landed on
+# DEFAULT_CONCEPT_STORE_PATH, and a stale dev-leftover file sitting at that
+# path was misread as a 24h+-stale live drive_state.v1 signal.)
+# --------------------------------------------------------------------------
+
+def test_main_warns_when_store_path_falls_back_to_default(capsys, monkeypatch):
+    monkeypatch.delenv("CONCEPT_STORE_PATH", raising=False)
+    with patch.object(dsa, "LocalProfileStore", _mock_store({})), patch.object(
+        dsa, "load_autonomy_state_v2", return_value=None
+    ):
+        exit_code = dsa.main([])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "WARNING:" in out
+    assert "almost certainly NOT the path the live Docker container writes to" in out
+    assert dsa.DEFAULT_CONCEPT_STORE_PATH in out
+
+
+def test_main_no_warning_when_store_path_given_explicitly(capsys, monkeypatch):
+    monkeypatch.delenv("CONCEPT_STORE_PATH", raising=False)
+    with patch.object(dsa, "LocalProfileStore", _mock_store({})), patch.object(
+        dsa, "load_autonomy_state_v2", return_value=None
+    ):
+        exit_code = dsa.main(["--store-path", "/data/concept-induction-state.json"])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "WARNING:" not in out
+
+
+def test_main_no_warning_when_env_var_set(capsys, monkeypatch):
+    monkeypatch.setenv("CONCEPT_STORE_PATH", "/mnt/graphdb/orion/concepts/concept-induction-state.json")
+    with patch.object(dsa, "LocalProfileStore", _mock_store({})), patch.object(
+        dsa, "load_autonomy_state_v2", return_value=None
+    ):
+        exit_code = dsa.main([])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "WARNING:" not in out
+
+
+def test_main_json_reports_store_path_source_and_warning(monkeypatch, capsys):
+    monkeypatch.delenv("CONCEPT_STORE_PATH", raising=False)
+    with patch.object(dsa, "LocalProfileStore", _mock_store({})), patch.object(
+        dsa, "load_autonomy_state_v2", return_value=None
+    ):
+        exit_code = dsa.main(["--json"])
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["drive_state_v1"]["store_path_source"] == "default_fallback"
+    assert out["drive_state_v1"]["store_path_warning"] is not None
+    assert out["drive_state_v1"]["store_path"] == dsa.DEFAULT_CONCEPT_STORE_PATH
+
+
+def test_main_json_store_path_source_env(monkeypatch, capsys):
+    monkeypatch.setenv("CONCEPT_STORE_PATH", "/mnt/graphdb/orion/concepts/concept-induction-state.json")
+    with patch.object(dsa, "LocalProfileStore", _mock_store({})), patch.object(
+        dsa, "load_autonomy_state_v2", return_value=None
+    ):
+        exit_code = dsa.main(["--json"])
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["drive_state_v1"]["store_path_source"] == "env:CONCEPT_STORE_PATH"
+    assert out["drive_state_v1"]["store_path_warning"] is None
+    assert out["drive_state_v1"]["store_path"] == "/mnt/graphdb/orion/concepts/concept-induction-state.json"
+
+
+def test_main_json_store_path_source_cli(monkeypatch, capsys):
+    monkeypatch.delenv("CONCEPT_STORE_PATH", raising=False)
+    with patch.object(dsa, "LocalProfileStore", _mock_store({})), patch.object(
+        dsa, "load_autonomy_state_v2", return_value=None
+    ):
+        exit_code = dsa.main(["--json", "--store-path", "/data/concept-induction-state.json"])
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["drive_state_v1"]["store_path_source"] == "cli:--store-path"
+    assert out["drive_state_v1"]["store_path_warning"] is None
+    assert out["drive_state_v1"]["store_path"] == "/data/concept-induction-state.json"
+
+
 def test_main_never_crashes_on_loader_exceptions(capsys):
     with patch.object(dsa, "LocalProfileStore", _mock_store(RuntimeError("boom"))), patch.object(
         dsa, "load_autonomy_state_v2", side_effect=RuntimeError("boom2")


### PR DESCRIPTION
# PR report: drive_state_divergence_audit.py — warn on silent dev-default store path fallback

## Summary

- Investigated a real-looking alarm: `scripts/drive_state_divergence_audit.py` reported `drive_state.v1` 24h+ stale, all-zero pressures across every drive.
- Root cause: **false alarm, not a production issue.** The script silently fell back to `DEFAULT_CONCEPT_STORE_PATH` (a host-local dev-scratch path, `/tmp/concept-induction-state.json`) when neither `--store-path` nor `$CONCEPT_STORE_PATH` was set. An unrelated stale file happened to be sitting at that exact path from an earlier local run and was misread as the live signal.
- Live container (`orion-athena-spark-concept-induction`) was never stale — confirmed via live logs (`drive_engine_pressure_probe` firing every ~2-4s with real, changing, non-zero pressures) and the real bind-mounted store file (`/mnt/graphdb/orion/concepts/concept-induction-state.json`, 35MB, updated seconds before this check, vs. the 3.2KB decoy file the script had actually read).
- Fixed the script to track *why* `store_path` has its value and print a loud, actionable warning whenever it silently lands on the dev fallback — this exact confusion should not be possible to hit silently again.

## Outcome moved

The divergence audit tool from yesterday's round (`chore/drive-state-divergence-audit`, merged) had a real footgun: its own default behavior could produce a false "drives are stale/dead" alarm with no indication that the path itself was the problem, not the signal. Closed that gap.

## Current architecture (before this patch)

`scripts/drive_state_divergence_audit.py --store-path` defaulted to `os.getenv("CONCEPT_STORE_PATH", DEFAULT_CONCEPT_STORE_PATH)` with no distinction in the output between "read a real, intentionally-configured path" and "silently landed on the dev fallback because nothing else was set." The module docstring's own usage example set `CONCEPT_STORE_PATH=/tmp/concept-induction-state.json` as if it were a legitimate live path, reinforcing the trap.

## Architecture touched

`scripts/` only (the audit script itself and its tests) — no runtime/production code touched, since the live service was confirmed healthy throughout.

## Files changed

- `scripts/drive_state_divergence_audit.py`: `--store-path` now tracks provenance (`cli:--store-path` / `env:CONCEPT_STORE_PATH` / `default_fallback`). When it lands on `default_fallback`, prints a `WARNING:` block (prose mode) or sets `store_path_source`/`store_path_warning` fields (`--json` mode) explaining the fallback is almost certainly not the live container's real store, with the exact `docker inspect` command to find the real one and where to cross-reference the compose file's bind mount. Fixed the misleading usage example in the docstring.
- `tests/test_drive_state_divergence_audit.py`: 6 new tests covering all three provenance paths in both prose and JSON output.

## Schema / bus / API changes

None.

## Env/config changes

None. No new keys — this is argument/output-provenance tracking within the existing script.

## Tests run

```text
$ python -m pytest tests/test_drive_state_divergence_audit.py -q
21 passed
```
Independently re-run by the orchestrator (21/21, matching the implementing agent's count of 15 pre-existing + 6 new).

## Evals run

Not applicable — deterministic diagnostic tooling fix.

## Docker/build/smoke checks

Live-verified by both the implementing agent and independently by the orchestrator:

```text
$ docker exec orion-athena-spark-concept-induction env | grep CONCEPT_STORE_PATH
CONCEPT_STORE_PATH=/data/concept-induction-state.json

$ ls -la /mnt/graphdb/orion/concepts/concept-induction-state.json
-rw-r--r-- 1 root root 35774321 Jul 14 00:04 ...   # 35MB, seconds old

$ docker logs orion-athena-spark-concept-induction --since 30s | grep drive_engine_pressure_probe
drive_engine_pressure_probe subject=orion pressures={'coherence': 0.7748, ...}  # firing every few seconds, real changing values

# Script re-run with no CONCEPT_STORE_PATH set: reproduces the original false alarm
# exactly, now WITH the warning block explaining why.
# Script re-run with the real path: no warning, updated_at seconds old, matches live logs.
```

## Review findings fixed

N/A — this patch is itself the fix for a finding (a false-alarm-producing footgun in yesterday's merged script), not a patch that went through a separate review pass. Orchestrator independently re-verified both the diff scope and the live claims before pushing rather than trusting the investigating agent's self-report alone.

## Restart required

```text
No restart required.
```
No runtime service touched — the live container was confirmed healthy and untouched throughout this investigation.

## Risks / concerns

None identified. Diagnostic-tooling-only fix, fully additive (new warning, new provenance tracking), no change to existing default behavior for callers who already set `--store-path`/`$CONCEPT_STORE_PATH` correctly.