### PR TITLE
Feat/autonomy satisfaction capabilities attention p3 p5

### DIFF
--- a/config/autonomy/capability_policy.v1.yaml
+++ b/config/autonomy/capability_policy.v1.yaml
@@ -28,3 +28,10 @@ rules:
     required_drive_origins: []
     required_signal_kinds: []
     budget_per_cycle: 0
+  - capability_id: recall.query.readonly
+    side_effect_class: readonly
+    auto_execute: true
+    requires_goal_status: proposed
+    required_drive_origins: [predictive]
+    required_signal_kinds: [world_coverage_gap]
+    budget_per_cycle: 2

--- a/config/proposals/proposal_policy.v1.yaml
+++ b/config/proposals/proposal_policy.v1.yaml
@@ -156,3 +156,27 @@ proposal_templates:
     reversibility: 1.0
     dimensions:
       field_intensity: 0.45
+
+  # P5: attention-bound proposal target. target_id/target_kind below are the
+  # fallback literal, used only if target_binding fails to resolve (empty
+  # dominant_attention_target_details, or a resolved target_kind outside the
+  # accepted whitelist). When it resolves, the candidate's target_id/target_kind
+  # follow self_state.dominant_attention_target_details[0] instead.
+  #
+  # Kill criterion (falsifiable by design, not yet run -- needs live traffic):
+  # over a 7-day window, distinct(target_id) across this template's candidates
+  # must be >= 3, or the binding isn't doing anything Orion's attention doesn't
+  # already do via the literal templates above. See
+  # orion/autonomy/evals/run_attention_bound_proposal_eval.py.
+  inspect_attended_target:
+    kind: inspect
+    target_kind: capability   # placeholder default kind; overridden per-candidate when binding resolves to a different kind
+    target_id: capability:orchestration   # fallback literal, used only if the binding fails to resolve
+    target_binding: "self_state.dominant_attention_targets[0]"
+    proposed_effect: increase_observability
+    required_policy_gate: read_only
+    base_priority: 0.34   # shipped live per explicit user go-ahead ("turn on whatever you need"), not dark-shipped at 0.0 -- read-only inspect proposal under the existing policy gate, same risk class as every other already-live inspect template
+    base_risk: 0.05
+    reversibility: 1.0
+    dimensions:
+      field_intensity: 0.30

--- a/docs/superpowers/pr-reports/2026-07-14-autonomy-p3-p5-satisfaction-capabilities-attention-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-autonomy-p3-p5-satisfaction-capabilities-attention-pr.md
@@ -1,0 +1,340 @@
+# PR report: P3-P5 -- drive satisfaction, recall.query.readonly capability, attention-bound proposals
+
+Branch: `feat/autonomy-satisfaction-capabilities-attention-p3-p5`
+Series: endogenous action motor-nerve (P0 → P7), see `docs/superpowers/specs/2026-07-14-autonomy-p3-p5-design.md`
+
+## Summary
+
+- **P3**: `DriveEngine.update()` can now represent relief, not just growth --
+  negative `drive_impacts` weights were silently double-clamped to zero
+  before this patch, so drives could only ever accumulate pressure. Fixed
+  with a signed clamp + sign-branched leaky-math formula.
+- **P3**: `orion-spark-concept-induction` now subscribes to
+  `orion:autonomy:action:outcome` (already published by Layer-9 dispatch) and
+  mints a relief tension on successful dispatch of `inspect`/`summarize`/`observe`
+  actions -- the first closed loop where an autonomous action can satisfy the
+  drive that motivated it, not just accumulate more pressure toward the next one.
+- **P4**: New `recall.query.readonly` capability -- before falling back to a
+  Firecrawl web fetch, the metabolism loop now tries an internal RecallService
+  query first. A recall hit leaves that cycle's fetch budget unconsumed.
+- **P5**: `ProposalTemplateV1.target_binding` lets a template resolve its
+  target from live context instead of a fixed value. One binding shipped:
+  `dominant_attention_targets[0]`, wired into a new `inspect_attended_target`
+  template that ships live (not dark-shipped) with a documented 7-day kill
+  criterion and a standalone eval script.
+- **P6** (folded in from the prior session): `/latest`'s `status_summary`
+  field (dispatched/prepared/dry-run counts) on the hub's execution-dispatch
+  debug route.
+- Code review found and fixed two CRITICAL dead-wiring bugs -- both P3 and P4
+  would otherwise have shipped fully built and fully unit-tested but
+  structurally unreachable at runtime (see Review findings below).
+
+## Outcome moved
+
+Before this patch, Orion's drive/tension system was strictly one-directional:
+every tension only ever raised pressure, and nothing an autonomous action did
+could lower it. `DriveEngine` had no code path capable of representing
+relief at all -- it wasn't a policy choice, the math structurally clamped
+negative impacts to zero. This patch makes successful autonomous action
+(Layer-9 dispatch) capable of satisfying the drive that motivated it, and
+gives the metabolism loop an internal-memory-first option before it reaches
+for the external web.
+
+## Current architecture
+
+Before this patch:
+- `DriveEngine.update()` (`orion/spark/concept_induction/drives.py`) computed
+  `impact_sum[drive] += mag * self._clamp01(weight)` -- `_clamp01` clamps to
+  `[0,1]`, so any negative `drive_impacts` weight became `0` before it ever
+  reached the pressure formula. The leaky-math pressure update itself,
+  `pressures[drive] = base + impulse*(1-base)`, is also monotonically
+  non-decreasing in `impulse` for `impulse >= 0` -- there was no formula
+  branch for relief even if a negative impulse had survived the first clamp.
+- `TensionRateLimiter._signature()` filtered on `weight > 0.0`, so any
+  hypothetical negative-weight tension would have collided into a shared
+  empty-tuple rate-limit bucket with every other relief tension regardless
+  of which drive it targeted.
+- `maybe_execute_substrate_act_after_metabolism` (`orion/autonomy/policy_act.py`)
+  had exactly one capability: a Firecrawl fetch gated by capability policy.
+- `ProposalTemplateV1`/`ProposalCandidateV1` had no way to point a template
+  at context-derived data; every template's target was a fixed literal.
+- The hub's execution-dispatch `/latest` route returned the raw frame with no
+  aggregate counts; a caller had to count candidate statuses itself.
+
+## Architecture touched
+
+- `orion/spark/concept_induction/drives.py` -- signed-impact clamp + relief-capable pressure formula.
+- `orion/autonomy/tension_ratelimit.py` -- signature filter widened to `weight != 0.0`.
+- `orion/spark/concept_induction/tensions.py` -- new `extract_tensions_from_action_outcome`.
+- `orion/spark/concept_induction/settings.py`, `bus_worker.py` -- new intake channel, dispatch branch, self-publish filter, skip-set entry.
+- `orion/autonomy/models.py` -- `SubstrateActResultV1` gains `recall_attempted`/`recall_outcome`.
+- `orion/autonomy/policy_act.py` -- `_execute_readonly_recall`, `maybe_execute_readonly_recall_after_goal`, recall-first wiring into the metabolism gate.
+- `config/autonomy/capability_policy.v1.yaml` -- new `recall.query.readonly` rule.
+- `orion/bus/channels.yaml` -- `orion-spark-concept-induction` added as a producer on `orion:exec:request:RecallService`.
+- `orion/proposals/policy.py`, `orion/proposals/builder.py`, `orion/schemas/proposal_frame.py` -- `target_binding`/`binding_resolved_from`, `_resolve_binding_target`.
+- `config/proposals/proposal_policy.v1.yaml` -- new `inspect_attended_target` template, live.
+- `orion/autonomy/evals/run_attention_bound_proposal_eval.py` -- new kill-criterion eval.
+- `services/orion-hub/scripts/substrate_execution_dispatch_routes.py` -- `_dispatch_status_summary`.
+- READMEs: `orion-spark-concept-induction`, `orion-proposal-runtime`, `orion-execution-dispatch-runtime`.
+- `services/orion-spark-concept-induction/.env_example` -- `BUS_INTAKE_CHANNELS` gains `orion:autonomy:action:outcome`.
+
+## Files changed
+
+- `orion/spark/concept_induction/drives.py`: signed clamp + sign-branched pressure formula so relief is representable and bounded.
+- `orion/spark/concept_induction/tests/test_drives_leaky.py`: 4 new tests for relief math + a positive-only regression guard.
+- `orion/autonomy/tension_ratelimit.py`: `w > 0.0` → `w != 0.0` in `_signature()` so relief tensions get their own budget.
+- `orion/autonomy/tests/test_tension_ratelimit.py`: 2 new tests for negative-weight signatures.
+- `orion/spark/concept_induction/tensions.py`: `extract_tensions_from_action_outcome`, closed kind→drive relief map (`inspect`→coherence, `summarize`→predictive, `observe`→continuity), fires only on `success is True`.
+- `orion/spark/concept_induction/tests/test_action_outcome_tensions.py` (new): 7 tests covering all three kinds, failure/no-fire cases, unmapped kinds, magnitude/direction assertions.
+- `orion/spark/concept_induction/settings.py`: `orion:autonomy:action:outcome` added to `intake_channels`'s Python default.
+- `orion/spark/concept_induction/bus_worker.py`: dispatch branch for `action.outcome.emit.v1`, self-publish filter, skip-set entry, **and** (review fix) the sole `maybe_execute_substrate_act_after_metabolism` call site now passes `recall_bus`/`recall_source`, **and** a new publish block for `act_result.recall_outcome` mirroring the existing `fetch_outcome` block.
+- `orion/autonomy/models.py`: `SubstrateActResultV1.recall_attempted`/`recall_outcome` (review fix, mirrors `fetch_attempted`/`fetch_outcome`).
+- `orion/autonomy/policy_act.py`: `_execute_readonly_recall`, `maybe_execute_readonly_recall_after_goal` (P4); recall-first check wired into `maybe_execute_substrate_act_after_metabolism` with its own UUID-correlation_id fix; (review fix) now populates `recall_attempted`/`recall_outcome` on every attempt, independent of whether it succeeded enough to skip the fetch.
+- `orion/autonomy/tests/test_policy_act.py`: existing recall-hit/recall-miss tests extended with `recall_attempted`/`recall_outcome` assertions (review fix regression coverage).
+- `config/autonomy/capability_policy.v1.yaml`: `recall.query.readonly` rule -- readonly, auto_execute, `requires_goal_status: proposed`, `required_drive_origins: [predictive]`, `required_signal_kinds: [world_coverage_gap]`, `budget_per_cycle: 2`.
+- `orion/bus/channels.yaml`: `orion-spark-concept-induction` added to `orion:exec:request:RecallService`'s `producer_services`.
+- `orion/proposals/policy.py`: `ProposalTemplateV1.target_binding: str | None = None`.
+- `orion/schemas/proposal_frame.py`: `ProposalCandidateV1.binding_resolved_from: str | None = None`.
+- `orion/proposals/builder.py`: `ATTENTION_FIRST_TARGET_BINDING` constant, `_ATTENTION_BOUND_TARGET_KINDS` frozenset, `_resolve_binding_target()` (never raises).
+- `config/proposals/proposal_policy.v1.yaml`: `inspect_attended_target` template, `base_priority: 0.34`, live with a documented 7-day kill criterion in comments.
+- `orion/autonomy/evals/run_attention_bound_proposal_eval.py` (new): kill-criterion eval, handles insufficient data gracefully.
+- `tests/test_proposal_frame_builder.py`, `tests/test_proposal_policy_loader.py`: binding-resolution + template-loading coverage.
+- `services/orion-hub/scripts/substrate_execution_dispatch_routes.py`: `_dispatch_status_summary()`, wired into `/latest`.
+- `services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py`: 2 new tests.
+- `services/orion-spark-concept-induction/.env_example`: `BUS_INTAKE_CHANNELS` gains `orion:autonomy:action:outcome` (review fix, see Env/config changes).
+- `docs/superpowers/specs/2026-07-14-autonomy-p3-p5-design.md`: design spec, documents why the original P3 brainstorm plan (a `drive_origin` bridge) was wrong -- no such bridge exists between the proposal/goal pipeline and Layer-9 dispatch, they're structurally separate pipelines -- and the chosen alternative seam (subscribe to the existing `action:outcome` channel).
+- READMEs: `services/orion-spark-concept-induction/README.md`, `services/orion-proposal-runtime/README.md`, `services/orion-execution-dispatch-runtime/README.md`.
+
+## Schema / bus / API changes
+
+- Added: `orion.autonomy.models.SubstrateActResultV1.recall_attempted: bool`, `.recall_outcome: ActionOutcomeRefV1 | None`.
+- Added: `orion.proposals.policy.ProposalTemplateV1.target_binding: str | None`.
+- Added: `orion.schemas.proposal_frame.ProposalCandidateV1.binding_resolved_from: str | None`.
+- Added: consumer subscription -- `orion-spark-concept-induction` now consumes `orion:autonomy:action:outcome` (already an existing, already-published channel; this is a new consumer, not a new channel).
+- Added: producer registration -- `orion-spark-concept-induction` added to `orion:exec:request:RecallService`'s `producer_services` in `orion/bus/channels.yaml`.
+- Added: `status_summary` field on the hub's `GET /api/substrate/execution-dispatch/latest` response (`dispatched_count`, `prepared_for_dispatch_count`, `dry_run_count`).
+- Removed: none.
+- Renamed: none.
+- Behavior changed: `DriveEngine.update()` now accepts negative `drive_impacts` weights and applies relief instead of clamping them to a zero-effect no-op. This is additive for every existing (non-negative-weight) producer -- verified by running the full pre-existing drive test suite unchanged before adding new tests, and by the `test_positive_only_tensions_unaffected_by_signed_clamp` regression guard.
+- Compatibility notes: `TensionRateLimiter`'s rate-limit signature space grew (relief tensions now get distinct signatures instead of colliding into one shared bucket) -- this only affects tensions with negative weights, of which there were previously none in production, so no existing rate-limit behavior changes.
+
+## Env/config changes
+
+- Added keys: none (no new env var name).
+- Removed keys: none.
+- Renamed keys: none.
+- **Changed key value** (`.env_example` updated): `BUS_INTAKE_CHANNELS` gains `"orion:autonomy:action:outcome"` in `services/orion-spark-concept-induction/.env_example`.
+- local `.env` synced: **N/A -- no local `.env` exists in this worktree** (checked: `services/orion-spark-concept-induction/.env` does not exist here). `scripts/sync_local_env_from_example.py` has nothing to do in this worktree.
+- **Skipped keys requiring operator action**: the **live, deployed** `.env` for `orion-spark-concept-induction` (in the shared main checkout, which this session does not write to directly per the established "main checkout is shared across concurrent sessions" rule) almost certainly still has the old `BUS_INTAKE_CHANNELS` value, because `Pydantic`'s `List[str]` field with a `validation_alias` **replaces** the Python code default entirely when the env var is set -- it does not merge. **Until an operator applies this change to the live `.env`, P3's entire satisfaction-tension pipeline (the DriveEngine relief fix, the new tension extractor, the self-publish filter) is built, tested, and reviewed, but the worker will never actually subscribe to the channel that feeds it.**
+
+  Required operator action -- add `"orion:autonomy:action:outcome"` to the existing `BUS_INTAKE_CHANNELS` JSON list in the live `services/orion-spark-concept-induction/.env`:
+  ```
+  BUS_INTAKE_CHANNELS=["orion:chat:history:log","orion:chat:history:turn","orion:chat:social:turn","orion:chat:social:stored","orion:chat:gpt:turn","orion:chat:gpt:message:log","orion:collapse:sql-write","orion:spark:telemetry","orion:metacognition:tick","orion:cognition:trace","orion:substrate:self_state","orion:feedback:frame","orion:world_pulse:run:result","orion:autonomy:action:outcome"]
+  ```
+  Confirmed via `scripts/check_service_env_compose_parity.py orion-spark-concept-induction`: this service's `docker-compose.yml` uses `env_file:`, so the full `.env` reaches the container regardless of the `environment:` list -- the only gap is the `.env` file's own content, not compose wiring.
+
+## Tests run
+
+```text
+$SCRATCH/p3p5-venv/bin/python -m pytest orion/spark/concept_induction/tests orion/autonomy/tests -q \
+  --deselect orion/autonomy/tests/test_autonomy_isolation.py::test_autonomy_state_v2_not_wired_into_phi_or_self_state
+347 passed, 1 deselected, 24 warnings in 15.17s
+
+$SCRATCH/p3p5-venv/bin/python -m pytest \
+  services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py \
+  tests/test_proposal_frame_builder.py \
+  tests/test_proposal_policy_loader.py \
+  tests/test_execution_dispatch_bus_catalog.py \
+  orion/autonomy/tests/test_capability_policy.py \
+  orion/autonomy/tests/test_capability_policy_models.py \
+  orion/autonomy/tests/test_policy_act.py \
+  orion/autonomy/tests/test_policy_act_prefetched.py \
+  -q
+66 passed, 2 warnings in 2.55s
+```
+
+Deselected test is pre-existing and unrelated: `test_autonomy_state_v2_not_wired_into_phi_or_self_state`
+fails identically on `origin/main` (verified via `git stash` + rerun, and by
+inspecting `git show origin/main:orion/self_state/inner_state_registry.py`,
+a file untouched by this branch or either subagent). Independently confirmed
+by the code-review agent.
+
+**Environment note**: the shared `/tmp/orion-test-venv` had numpy upgraded to
+`2.5.1` by a concurrent session, breaking `thinc`'s compiled Cython extension
+ABI (`ValueError: numpy.dtype size changed`) and making every test that
+imports `spacy` uncollectable. `orion-spark-concept-induction/requirements.txt`
+pins `numpy==1.26.4`. Rather than downgrade the shared venv (would risk
+breaking whatever the concurrent session needs 2.5.1 for), copied it to an
+isolated scratch venv and pinned numpy there. All numbers above are from that
+isolated venv; the shared venv was not modified.
+
+## Evals run
+
+```text
+python orion/autonomy/evals/run_attention_bound_proposal_eval.py
+```
+
+Not run live in this session -- requires an accumulation window of real
+`inspect_attended_target` candidates against a live proposal-runtime deployment
+to evaluate the 7-day kill criterion meaningfully; running it against an
+empty/synthetic local DB would only exercise the "insufficient data" path,
+which is not a meaningful eval result. This is the standing eval for judging
+whether the template should be kept, tuned, or killed once live data
+accumulates -- flagging as a follow-up check for 7 days post-merge, not a
+gap in this PR.
+
+No dedicated eval harness exists yet for the P3 satisfaction-tension path or
+the P4 recall capability; the unit test suites above (`test_drives_leaky.py`,
+`test_action_outcome_tensions.py`, `test_policy_act.py`) are the coverage
+for those tracks.
+
+## Docker/build/smoke checks
+
+Docker was not run in this environment. Ran the deterministic non-Docker
+checks that substitute for it:
+
+```text
+$SCRATCH/p3p5-venv/bin/python scripts/check_service_env_compose_parity.py orion-spark-concept-induction
+→ N/A: service declares env_file:, all 110 .env_example keys reach the container
+  regardless of the environment: list.
+
+ORION_BUS_URL=redis://100.92.216.81:6379/0 \
+  $SCRATCH/p3p5-venv/bin/python scripts/check_single_consumer_channels.py
+→ single_consumer gate OK: 31 channel(s) checked, 3 warning(s) (pre-existing,
+  zero-subscriber channels unrelated to this patch). orion:exec:request:RecallService
+  reports OK 1 -- confirms P4's new producer registration on that channel did
+  not create a fan-out/multi-consumer collision.
+
+git diff --check origin/main..HEAD
+→ clean, exit 0
+```
+
+## Review findings fixed
+
+- Finding: `BUS_INTAKE_CHANNELS`'s Pydantic `validation_alias` **replaces**
+  the Python default list rather than merging with it when the env var is
+  set -- and it is set in both `.env_example` and every deployed `.env`.
+  Adding the new channel to `settings.py`'s code default alone was a
+  structural no-op in every real environment.
+  - Fix: updated `.env_example`; documented the replace-not-merge behavior
+    directly in the README so it's not rediscovered the hard way again;
+    flagged the live-`.env` operator action prominently above.
+  - Evidence: `check_service_env_compose_parity.py` confirms the container
+    reads the full `.env`; the remaining gap is the live file's content,
+    named explicitly as an operator action rather than silently assumed done.
+
+- Finding: `bus_worker.py`'s one production call site to
+  `maybe_execute_substrate_act_after_metabolism` never passed the
+  `recall_bus`/`recall_source` kwargs P4's function signature added --
+  `_execute_readonly_recall`'s `if bus is None: return decision, None` guard
+  degraded gracefully and silently before any RPC fired. P4 was fully built
+  and fully unit-tested but unreachable in the one place it actually runs.
+  - Fix: call site now passes `recall_bus=self.bus, recall_source=_service_ref(self.cfg)`.
+  - Evidence: `test_policy_act.py`'s recall-hit/recall-miss tests exercise
+    the function directly with a real bus; the call-site fix is a one-line
+    diff verifiable by inspection against `bus_worker.py`'s single call site.
+
+- Finding: a successful recall was recorded only via
+  `_execute_readonly_recall`'s local `append_action_outcome` file-store
+  fallback, never reaching the bus-emit → sql-writer → durable-SQL path a
+  fetch success uses -- `SubstrateActResultV1` had no field to carry it, so
+  `bus_worker.py`'s existing `if act_result.fetch_outcome is not None:`
+  publish block could never see it.
+  - Fix: `SubstrateActResultV1` gains `recall_attempted`/`recall_outcome`
+    (mirrors `fetch_attempted`/`fetch_outcome`); `policy_act.py` populates
+    them on every recall attempt; `bus_worker.py` gains a parallel publish
+    block for `recall_outcome`.
+  - Evidence: extended `test_substrate_act_recall_hit_skips_fetch_budget`
+    and `test_substrate_act_recall_miss_falls_through_to_fetch` with direct
+    assertions on `recall_attempted`/`recall_outcome`; both pass.
+
+- Finding (documented, not fixed -- accepted risk): `extract_tensions_from_feedback`
+  (Postgres-polled failure path) and `extract_tensions_from_action_outcome`
+  (bus-emitted success path) are independently-computed classifications of
+  the same Layer-9 dispatch from two separate pipelines. A dispatch the
+  feedback path scores failed/mixed while the outcome-emit reports
+  `success=True` can fire both a growth and a relief tension for the same
+  event. Coordinating across both pipelines is out of scope for this patch's
+  size -- documented in the concept-induction README and here as a named
+  follow-up.
+
+- Findings (documented, not fixed -- cleanup only, not bugs): `_clamp_signed`
+  duplicates `orion/signals/normalization.py`'s existing `clamp11`;
+  `_execute_readonly_recall` duplicates ~60 lines of RPC boilerplate from
+  `recall_prefetch.py`; `maybe_execute_readonly_recall_after_goal` duplicates
+  ~35 lines of gate logic from `maybe_execute_readonly_fetch_after_goal`. All
+  three are candidates for a follow-up dedup pass; none change behavior or
+  correctness, so deferred rather than expanding this patch's surface area.
+
+## Restart required
+
+```bash
+docker compose \
+  --env-file .env \
+  --env-file services/orion-spark-concept-induction/.env \
+  -f services/orion-spark-concept-induction/docker-compose.yml \
+  up -d --build orion-spark-concept-induction
+
+docker compose \
+  --env-file .env \
+  --env-file services/orion-proposal-runtime/.env \
+  -f services/orion-proposal-runtime/docker-compose.yml \
+  up -d --build orion-proposal-runtime
+
+docker compose \
+  --env-file .env \
+  --env-file services/orion-hub/.env \
+  -f services/orion-hub/docker-compose.yml \
+  up -d --build orion-hub
+```
+
+`orion-execution-dispatch-runtime` itself has no code changes in this patch
+(only its README changed) -- no restart needed for that service.
+
+**Before restarting `orion-spark-concept-induction`, apply the live-`.env`
+operator action documented under Env/config changes above** -- restarting
+with the old `BUS_INTAKE_CHANNELS` value ships P3's code with the
+subscription still missing.
+
+## Risks / concerns
+
+- Severity: HIGH (operator-action-dependent, not code-dependent)
+  Concern: P3's satisfaction-tension pipeline is inert until the live `.env`'s
+  `BUS_INTAKE_CHANNELS` is updated by an operator (this session did not and
+  should not write to the shared main checkout's live `.env` directly).
+  Mitigation: exact key/value diff provided above; `check_service_env_compose_parity.py`
+  confirms no other config surface (compose `environment:` list) needs a
+  matching change.
+
+- Severity: MEDIUM (accepted, named)
+  Concern: double-tension-fire risk between the feedback-frame and
+  action-outcome pipelines on disagreeing success/failure classifications of
+  the same dispatch.
+  Mitigation: documented in the concept-induction README; cross-pipeline
+  coordination deferred as a follow-up, not silently ignored.
+
+- Severity: LOW
+  Concern: three cleanup/duplication findings from review (`_clamp_signed`,
+  `_execute_readonly_recall`, `maybe_execute_readonly_recall_after_goal`)
+  left unaddressed.
+  Mitigation: none needed for correctness; candidates for a follow-up dedup
+  patch if this pattern keeps recurring.
+
+- Severity: LOW
+  Concern: `run_attention_bound_proposal_eval.py`'s 7-day kill criterion has
+  not been evaluated against live data yet (the template only just shipped).
+  Mitigation: eval script exists and handles the pre-accumulation window
+  gracefully; run it 7 days after this merges.
+
+## PR link
+
+Not opened via `gh` (unauthenticated in this environment). Paste-ready for manual creation:
+
+**Title:**
+```
+feat(autonomy): P3-P5 -- drive satisfaction, recall.query.readonly, attention-bound proposals
+```
+
+**Body:** (this file's Summary through Risks/concerns sections, verbatim)
+
+Compare URL: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/autonomy-satisfaction-capabilities-attention-p3-p5

--- a/docs/superpowers/specs/2026-07-14-autonomy-p3-p5-design.md
+++ b/docs/superpowers/specs/2026-07-14-autonomy-p3-p5-design.md
@@ -1,0 +1,157 @@
+# Autonomy P3–P5 (motor-nerve series) — design
+
+**Date:** 2026-07-14
+**Status:** Implementation, this session
+**Mode:** Three thin patches, re-grounded against live code (main now has P0/P1/P2/P6 merged). All three original brainstorm-level plans needed real correction after grounding — documented per-section below.
+
+## P3 — Consequence → drive satisfaction + operator inform
+
+### Ground truth (corrects the original brainstorm)
+
+The tension→goal pipeline (`orion/spark/concept_induction`, `DriveEngine`) and the P1/P2 Layer-9 dispatch pipeline (`orion/execution_dispatch`, `orion/proposals`) are **structurally separate** — no `drive_origin` field survives from a proposal candidate through to a completed dispatch's outcome. Bridging that fully (threading `drive_origin` through `ProposalCandidateV1` → `ExecutionDispatchCandidateV1` → `FeedbackFrameV1`) is out of scope here — too invasive for a thin patch, and not needed: a smaller, real seam already exists.
+
+`ConceptWorker` (`orion-spark-concept-induction`) already subscribes to `orion:feedback:frame` and mints tensions from `FeedbackFrameV1` — but only on failure (`extract_tensions_from_feedback`, `tensions.py:399-465`, fires on `outcome_status in {"failed","absent","blocked"}` or low score; never on success). Separately, P2 just made `orion:autonomy:action:outcome` (schema `ActionOutcomeEmitV1`) carry every real Layer-9 dispatch outcome — success and failure both — with `orion-execution-dispatch-runtime` already a registered producer and `orion-spark-concept-induction` already covered by that channel's `consumer_services: ["orion-sql-writer", "*"]` wildcard. `ConceptWorker` does not yet subscribe to it.
+
+**Chosen seam**: subscribe `ConceptWorker` to `orion:autonomy:action:outcome`, mint a small relief tension locally from `ActionOutcomeEmitV1.success`, fold through the existing per-tick `DriveEngine.update()` call (`bus_worker.py:866-872`) — no new call site, no new channel, no proposal/candidate schema changes. Rejected alternatives: a new dedicated tension-inject channel (strictly larger, no functional gain — `TensionEventV1.magnitude` is schema-clamped non-negative regardless of channel, so the real work is the DriveEngine fix either way); riding the existing `FeedbackFrameV1` path (depends on a second service's 2s-poll/Postgres-join correctness that the P2 commit's own history suggests wasn't trusted for this purpose).
+
+**Mandatory companion fix, more load-bearing than the wiring itself**: `DriveEngine.update()` (`orion/spark/concept_induction/drives.py`) cannot represent relief *at all* today — `impact_sum[drive] += mag * self._clamp01(weight)` clamps `weight` to `[0,1]`, silently zeroing any negative `drive_impacts` value, and the leaky-math branch's `impulse = self._clamp01(impact_sum[drive])` clamps again. A negative-weight tension is a complete no-op under current code, not a partially-working relief — this needs a real fix, not "confirm it handles negatives," and it's the single most sensitive part of this patch: `DriveEngine.update()` is live, running on every accepted bus event (1000+/hr), already fixed once before for the flat-0.731 pin regression.
+
+### Proposed changes
+
+**`orion/spark/concept_induction/drives.py`**:
+- `impact_sum[drive] += mag * self._clamp01(weight)` → clamp `weight` to `[-1.0, 1.0]` instead of `[0.0, 1.0]` (new small `_clamp_signed` helper, or inline).
+- Leaky branch: `impulse = self._clamp01(impact_sum[drive])` → clamp to `[-1.0, 1.0]`. Then branch the pressure update on sign:
+  - `impulse >= 0`: unchanged — `base + impulse * (1.0 - base)` (headroom-toward-ceiling).
+  - `impulse < 0`: `base + impulse * base` (headroom-toward-floor — symmetric design: relief has diminishing effect as pressure approaches 0, exactly mirroring how growth has diminishing effect approaching 1; also means `base=0` naturally yields zero relief without depending on the outer clamp to save it).
+  - Both branches still pass through the existing final `self._clamp01(...)`.
+- Legacy `leaky_math_enabled=False` branch: left as-is (not live/configured default; `_soft_saturate`'s internal `_clamp01` will floor a negative `raw` at 0 — acceptably inert for a non-live path, not optimized further).
+- This is the highest-risk part of the whole P3-P5 sprint (live numerical core). Existing tests for `DriveEngine.update()` must all still pass unchanged — every existing producer only ever emits non-negative `drive_impacts`, so this change must be provably a no-op for all of them (only reachable via a genuinely negative weight, which nothing produces today except the new satisfaction tension).
+
+**`orion/autonomy/tension_ratelimit.py`**: `TensionRateLimiter._signature()` currently only includes drives with `weight > 0.0` in its signature tuple — a negative-weight-only tension collides into an empty-tuple bucket shared with any other zero-positive-weight tension of the same `kind`. Change the filter to `weight != 0.0` (or `abs(weight) > 1e-9`) — safe, backward-compatible (every existing producer only emits positive weights, so this is a no-op for all of them) and correctly captures which drives a satisfaction tension targets for rate-limiting purposes.
+
+**`orion/spark/concept_induction/tensions.py`**: new `extract_tensions_from_action_outcome(payload: dict, ...) -> list[TensionEventV1]` mirroring `extract_tensions_from_feedback`'s shape (same `subject="orion"`/`model_layer="self-model"`/`entity_id="self:orion"` convention, same deterministic-artifact-id pattern via `_artifact_id`). Fires only on `success=True` (relief on success; `success=False`/`None` mints nothing here — failures are already covered by the existing `extract_tensions_from_feedback` failure path, not duplicated). Maps `ActionOutcomeEmitV1.kind` (`inspect`/`summarize`/`observe`) to a small, explicit, closed drive-impact table — not a fuzzy inference:
+  - `inspect` → `{"coherence": -0.10}` (a targeted look reduces uncertainty/incoherence)
+  - `summarize` → `{"predictive": -0.10}` (a wide-angle picture reduces predictive gap)
+  - `observe` → `{"continuity": -0.05}` (a lighter, lower-magnitude relief matching `observe`'s own lower-stakes design intent from P1)
+  - Magnitude: fixed `0.3` (not derived from `surprise`/anything else — a simple, legible constant, matching the cap language from the original brainstorm's "−0.10 cap" intent, expressed here as `magnitude * weight` staying within a small bound).
+
+**`orion/spark/concept_induction/bus_worker.py`**:
+- `settings.py`'s `intake_channels` (or wherever the subscription list lives) gains `"orion:autonomy:action:outcome"`.
+- `handle_envelope` gains an `elif env.kind == "action.outcome.emit.v1":` branch mirroring the existing `feedback.frame.v1` branch (`bus_worker.py:809-813`), calling the new extractor, folding results into the same `spark_tensions`/`all_spark_tensions` list that already reaches `bus_worker.py:866-872`'s `drive_engine.update()` call.
+- **Self-publish filter, mandatory**: `ConceptWorker` is itself already a producer on this exact channel (curiosity-fetch outcomes, `bus_worker.py:602-611`/`1044-1068`). Without a guard, Redis pub/sub delivers to all subscribers including the publisher, double-counting/looping. Guard: skip processing when `env.source.name == self.cfg.service_name` (i.e. only process outcomes from *other* services — today that means only `orion-execution-dispatch-runtime`'s Layer-9 outcomes reach the new extractor, not `ConceptWorker`'s own curiosity-fetch ones, which already have their own dedicated in-process path).
+- Add `"action.outcome.emit.v1"` to the concept-induction-skip set (`bus_worker.py:1097`, currently `{"substrate.self_state.v1", "feedback.frame.v1"}`) so this structured signal doesn't spuriously trigger concept extraction/clustering.
+
+### Operator inform
+
+`services/orion-hub/scripts/substrate_execution_dispatch_routes.py`'s `/latest` route currently returns a bare `ExecutionDispatchFrameV1.model_dump()` with no dispatch/dry-run breakdown and no visibility into the runtime's in-process `theater_tripwire_active` (that flag lives only on `orion-execution-dispatch-runtime`'s own `/latest`, per P1 — the Hub route reads Postgres directly and has no access to it). Minimal fix, matching what's actually derivable from data already in scope: add a small summary block to the Hub route's response — `{"dispatched_count": len(dispatched_candidates), "prepared_for_dispatch_count": <count from candidates>, "dry_run_count": <count from candidates>}` — computed from the frame already loaded, no new fields, no cross-service call. Exposing the live `theater_tripwire_active` flag itself would require either a cross-service HTTP call from Hub to the runtime's own `/latest` (a real architectural choice, not a one-line addition) or persisting the flag into the dispatch-frame row — **explicitly deferred**, named as a non-goal below; the count breakdown is the thin, honest slice.
+
+### Non-goals
+
+- No full `drive_origin` bridge between the proposal/goal pipeline and the Layer-9 dispatch pipeline.
+- No cross-service Hub→runtime call (or persistence change) to surface `theater_tripwire_active` on the Hub route — only the count breakdown ships.
+- No change to the legacy (`leaky_math_enabled=False`) DriveEngine path beyond leaving it inert-safe.
+- No touching `extract_tensions_from_feedback`'s existing failure-only behavior.
+
+### Acceptance checks
+
+1. Existing `DriveEngine.update()` tests (find and run) still pass unchanged.
+2. New test: a tension with `drive_impacts={"coherence": -0.5}` and non-zero prior pressure reduces pressure, floored at 0, never negative.
+3. New test: existing (non-negative) tensions produce byte-identical pressures to before the clamp change (regression guard against a sign-handling mistake).
+4. New test: `extract_tensions_from_action_outcome` on `success=True` mints exactly one tension with a negative weight for the mapped drive; on `success=False`/`None` mints nothing.
+5. New test: `bus_worker.py`'s self-publish filter — an `action.outcome.emit.v1` envelope with `source.name == "orion-spark-concept-induction"` is skipped; one with `source.name == "orion-execution-dispatch-runtime"` is processed.
+6. Hub route test: `/latest` response includes the three counts, computed correctly from a fixture frame.
+
+---
+
+## P4 — Capability vocabulary: 1 verb → 3
+
+### Ground truth (confirms most of the original brainstorm, corrects the "client class" assumption)
+
+`orion/autonomy/capability_policy.py::evaluate_capability(capability_id, ctx)` is a per-capability-id evaluator, not a fan-out/selector — the caller (`policy_act.py`) hardcodes which `capability_id` to attempt at each call site and asks the evaluator to approve/deny it. `orion/autonomy/fanout_policy.py` is unrelated (chat-stance SPARQL fan-out breadth, not capability selection) — do not build on it.
+
+No `RecallClient` class exists; recall queries are issued via inline `bus.rpc_request(...)` using `build_recall_query_v1` (`orion/cognition/recall_query.py`) against channel `orion:exec:request:RecallService` (`orion/bus/channels.yaml`, schema `RecallQueryV1`, reply `orion:exec:result:RecallService:*`). `producer_services` on that channel does not yet include any autonomy-side service.
+
+`services/orion-self-experiments`: `SELF_EXPERIMENTS_DISPATCH_ENABLED` defaults **false** — dispatch is currently a no-op (`status="queued", reason="dispatch_disabled"`) regardless of what this patch adds. No `endogenous_safe` field exists on `EXPERIMENT_REGISTRY` entries (a plain `dict[str,str]`, not a pydantic model) or `SelfExperimentSpecV1`. No `memory_contradiction_probe`-equivalent `SelfExperimentType` exists; `belief_origin_check` is the closest but is about provenance, not contradiction detection. No `autonomy`/`endogenous` `SelfExperimentSource` literal exists.
+
+**Scope call, given the above**: `self_experiment.create` as originally scoped (new experiment type + new source literal + `endogenous_safe` registry field + a bounded depth-2 probe) is real, non-trivial new surface area on a *different service* whose own dispatch mechanism is disabled by default regardless — building it now would ship inert code with no way to verify it end-to-end (dispatch is off). **Deferred as a named non-goal.** `recall.query.readonly` alone is the real, buildable, verifiable-in-principle half of P4: it rides an existing bus RPC pattern, targets an already-running service (`orion-recall`), and its policy gate (`auto_execute` under existing `capability_policy.py` machinery) is provably testable without needing a second service's disabled dispatch path.
+
+### Proposed changes
+
+**`config/autonomy/capability_policy.v1.yaml`**: one new rule —
+```yaml
+- capability_id: recall.query.readonly
+  side_effect_class: readonly
+  auto_execute: true
+  requires_goal_status: proposed
+  required_drive_origins: [predictive]
+  required_signal_kinds: [world_coverage_gap]
+  budget_per_cycle: 2
+```
+(mirrors `web.fetch.readonly` exactly — same signal kind, same drive origin, same budget; deliberately reuses the existing `world_coverage_gap` vocabulary rather than inventing a new signal kind).
+
+**`orion/autonomy/policy_act.py`**: new `maybe_execute_readonly_recall_after_goal(...)` mirroring `maybe_execute_readonly_fetch_after_goal` (`policy_act.py:37-99`) exactly in shape: gate on signal kinds present → build `CapabilityEvaluationContext` → `evaluate_capability("recall.query.readonly", ctx)` → on allow, issue the recall RPC (inline `bus.rpc_request` + `build_recall_query_v1`, matching `orion/cognition/recall_prefetch.py:169-183`'s exact pattern — no new client class, riding the existing seam) → record an `ActionOutcomeRefV1`/emit via the same `append_action_outcome`/bus-emit convention already established, so a recall-first check is itself visible the same way a Layer-9 dispatch or curiosity-fetch is. Behavioral intent from the original brainstorm preserved: "check what I already know first" — call this before the existing readonly-fetch path in the same tick, and if recall finds something, DO NOT budget-consume the fetch capability (fetch stays available for when recall comes up empty).
+
+**`orion/bus/channels.yaml`**: add whichever service actually issues this RPC (the autonomy/`orion-spark-concept-induction` `ConceptWorker`, same process P3's satisfaction wiring touches, since `policy_act.py`'s call sites are invoked from there) to `orion:exec:request:RecallService`'s `producer_services`, if not already covered by a wildcard (verify in-patch; the P1-era finding for the cortex-exec-request channel found a `:background` sibling channel already multi-producer — check whether an equivalent already exists here before adding a new entry).
+
+### Non-goals
+
+- `self_experiment.create` — deferred, named above, because `SELF_EXPERIMENTS_DISPATCH_ENABLED` is off by default and building the full new-type/new-source/registry-field surface now would ship unverifiable dead code. Recommended as its own future patch once dispatch is enabled for real.
+- No new `RecallClient` class — reuses the existing inline RPC pattern.
+- No change to `required_signal_kinds`/`required_drive_origins` vocabulary — reuses `world_coverage_gap`/`predictive` exactly as the existing fetch capability does.
+
+### Acceptance checks
+
+1. `evaluate_capability("recall.query.readonly", ctx)` returns `allowed` under the same conditions `web.fetch.readonly` would (mirrored policy shape) — new test.
+2. A live tick where `world_coverage_gap` fires: recall is tried first; if recall's result is non-empty, the fetch budget is not consumed that cycle (new test, mocked recall RPC).
+3. If recall's RPC fails or times out, degrades to falling through to the existing fetch path — never raises, never blocks the tick.
+
+---
+
+## P5 — Attention-bound proposals
+
+### Ground truth (corrects two premises from the original brainstorm)
+
+`ProposalTemplateV1` (`orion/proposals/policy.py`) has `model_config = ConfigDict(extra="forbid")` and only literal `target_kind`/`target_id` fields — `target_binding` is a wholly new field, not an extension of an existing mechanism. `orion/proposals/builder.py::_build_candidate` already has `self_state: SelfStateV1` in scope at exactly the point `target_id`/`target_kind` get set (`_build_candidate(*, template_key, template, self_state, attention, policy)`, called from a loop already iterating `policy.proposal_templates.items()`) — so the resolution point is real and available, just needs a new branch.
+
+`ProposalCandidateV1.provenance` **does not exist** — the original brainstorm's plan to add `binding_resolved_from` to it was based on a false premise. What exists instead: `evidence_refs: list[str]` (free-form string refs already populated with `self_state:{id}`/`attention:{id}`/`field:{id}`), and flat fields `source`/`thought_id` (already used for a different provenance purpose — reverie-injected candidates). The correct home for binding provenance is a new flat field alongside `source`/`thought_id`, matching this schema's actual existing style, not a new nested object.
+
+`SelfStateV1.dominant_attention_targets: list[str]` and `dominant_attention_target_details: list[AttentionTargetSummaryV1]` (fields: `target_id`, `target_kind: Literal["node","capability","channel","edge","field","system"]`, `pressure_score`, `dominant_channel`, `reason`) both confirmed present exactly as the original design expected.
+
+### Proposed changes
+
+**`orion/proposals/policy.py`**: `ProposalTemplateV1` gains `target_binding: str | None = None` (still `extra="forbid"` for anything else — this is the one new, explicitly-typed field, not a loosening of the schema). Only one recognized binding path string for v1: `"self_state.dominant_attention_targets[0]"` — validated/matched literally, not a general expression parser (no invented DSL).
+
+**`config/proposals/proposal_policy.v1.yaml`**: one new template, `inspect_attended_target`:
+```yaml
+- kind: inspect
+  target_kind: capability   # placeholder default kind; overridden per-candidate when binding resolves to a different kind
+  target_id: capability:orchestration   # fallback literal, used only if the binding fails to resolve
+  target_binding: "self_state.dominant_attention_targets[0]"
+  proposed_effect: increase_observability
+  required_policy_gate: read_only
+  base_priority: 0.34   # shipped live per explicit user go-ahead ("turn on whatever you need"), not dark-shipped at 0.0 -- read-only inspect proposal under the existing policy gate, same risk class as every other already-live inspect template
+  base_risk: 0.05
+  reversibility: 1.0
+  dimensions:
+    field_intensity: 0.30
+```
+
+**`orion/proposals/builder.py::_build_candidate`**: new branch — if `template.target_binding == "self_state.dominant_attention_targets[0]"` and `self_state.dominant_attention_target_details` is non-empty, resolve `target_id`/`target_kind` from `self_state.dominant_attention_target_details[0]` (`.target_id`, `.target_kind` — using the richer `_details` list, not the bare-string `dominant_attention_targets`, since it carries a real typed `target_kind` rather than requiring a second lookup); **whitelist**: only accept `target_kind` values already present in `AttentionTargetSummaryV1`'s own literal (`node/capability/channel/edge/field/system`) intersected with `ProposalCandidateV1`'s existing accepted `target_kind`s (verify overlap in-patch — `cast_target_kind` already exists per P1-era grounding; if a resolved kind isn't in its accepted set, fail closed to the literal fallback, never raise). If the binding can't resolve (empty details list, unrecognized kind), fall back to the template's literal `target_id`/`target_kind` — never block candidate construction.
+- Set the new flat field (e.g. `binding_resolved_from: str | None`) on `ProposalCandidateV1` when a binding actually resolved (not set when falling back to literal) — traceability for the eval below, matching this schema's existing flat-field style.
+
+**`orion/schemas/proposal_frame.py`**: `ProposalCandidateV1` gains `binding_resolved_from: str | None = None`.
+
+**Kill-criterion eval** (per the original brainstorm's own falsifiable design, preserved): a small script/eval, mirroring `orion/autonomy/evals/run_origination_eval.py`'s shape, checking over a real window whether `distinct(target_id)` for this template's candidates is `>= 3` — not run automatically in this patch (needs real traffic accumulation over days), but the script itself ships so it can be run once enough live data exists. Documented in the template's own YAML comment as the kill criterion, matching the design's explicit self-falsifying intent.
+
+### Non-goals
+
+- No general binding-expression DSL — one literal, recognized path string only.
+- No new `target_kind` values beyond what `AttentionTargetSummaryV1`/`cast_target_kind` already accept.
+- Not running the kill-criterion eval's real 7-day verdict in this patch — no live traffic window available in this sandbox; the eval ships, its verdict doesn't.
+
+### Acceptance checks
+
+1. New test: template with the binding resolves `target_id`/`target_kind` from a fixture `SelfStateV1` with populated `dominant_attention_target_details`.
+2. New test: empty `dominant_attention_target_details` falls back to the template's literal `target_id`/`target_kind`, `binding_resolved_from` stays `None`.
+3. New test: a resolved `target_kind` outside the accepted set falls back to literal rather than raising.
+4. `binding_resolved_from` is set only on the binding-resolved path, verified by test.

--- a/orion/autonomy/evals/run_attention_bound_proposal_eval.py
+++ b/orion/autonomy/evals/run_attention_bound_proposal_eval.py
@@ -1,0 +1,152 @@
+"""Kill-criterion eval: attention-bound proposal target diversity (P5).
+
+`inspect_attended_target` (config/proposals/proposal_policy.v1.yaml) resolves
+its target_id/target_kind from self_state.dominant_attention_target_details[0]
+instead of a hardcoded literal. The original brainstorm's own falsifiable
+design says this binding is only worth keeping if it actually tracks a moving
+target: over a real 7-day window, distinct(target_id) across this template's
+candidates should be >= 3. If it stays pinned to one or two targets forever,
+the binding isn't doing anything the literal templates don't already do.
+
+This script queries substrate_proposal_frames (real Postgres, the same table
+orion-proposal-runtime writes via ProposalRuntimeStore.save_proposal_frame)
+for candidates whose proposal_id starts with "proposal:inspect_attended_target:"
+within the window, and reports PASS/FAIL/insufficient-data.
+
+Not run automatically in this patch and not wired into any test suite or CI --
+needs real live traffic to accumulate over days. Ships now so it is runnable
+once that traffic exists.
+
+Run: python orion/autonomy/evals/run_attention_bound_proposal_eval.py
+Env: POSTGRES_URI (falls back to the standard local dev DSN below).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger("orion.autonomy.evals.run_attention_bound_proposal_eval")
+
+DEFAULT_POSTGRES_URI = "postgresql://postgres:postgres@orion-athena-sql-db:5432/conjourney"
+
+TEMPLATE_KEY = "inspect_attended_target"
+PROPOSAL_ID_PREFIX = f"proposal:{TEMPLATE_KEY}:"
+MIN_DISTINCT_TARGETS = 3
+WINDOW_DAYS = 7
+
+
+def open_readonly_connection(dsn: str):
+    """Open a psycopg2 connection and force a read-only session.
+
+    Returns None on any connection failure or if psycopg2 is unavailable --
+    this eval must degrade gracefully, never crash the whole run.
+    """
+    try:
+        import psycopg2  # lazy import so the module imports cleanly without the driver
+    except Exception:
+        logger.error("psycopg2 unavailable; cannot open DB session")
+        return None
+
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception:
+        logger.error("failed to connect to postgres", exc_info=True)
+        return None
+
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET default_transaction_read_only = on;")
+            cur.execute("SHOW default_transaction_read_only;")
+            value = cur.fetchone()
+        if not value or str(value[0]).lower() != "on":
+            logger.error("failed to force read-only session; refusing connection")
+            conn.close()
+            return None
+    except Exception:
+        logger.error("failed to set read-only session", exc_info=True)
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return None
+
+    return conn
+
+
+def fetch_attended_target_ids(conn, window_start: datetime) -> list[str]:
+    """Return the target_id of every inspect_attended_target candidate whose
+    parent proposal_frame was generated at/after window_start.
+
+    Candidates live inside proposal_frame_json.candidates (a JSON array); this
+    template's proposal_id is stable per self-state
+    ("proposal:inspect_attended_target:{self_state_id}"), so we filter in
+    Python after pulling the JSON rather than assuming a JSONB index exists.
+    """
+    target_ids: list[str] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT proposal_frame_json
+            FROM substrate_proposal_frames
+            WHERE generated_at >= %s
+            ORDER BY generated_at DESC
+            """,
+            (window_start,),
+        )
+        rows = cur.fetchall()
+    for (payload,) in rows:
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except Exception:
+                continue
+        if not isinstance(payload, dict):
+            continue
+        for candidate in payload.get("candidates", []) or []:
+            proposal_id = candidate.get("proposal_id", "")
+            if isinstance(proposal_id, str) and proposal_id.startswith(PROPOSAL_ID_PREFIX):
+                target_id = candidate.get("target_id")
+                if target_id:
+                    target_ids.append(target_id)
+    return target_ids
+
+
+def run() -> int:
+    now = datetime.now(timezone.utc)
+    window_start = now - timedelta(days=WINDOW_DAYS)
+    dsn = os.environ.get("POSTGRES_URI", DEFAULT_POSTGRES_URI)
+
+    print(f"\n=== Attention-bound proposal target-diversity eval ({TEMPLATE_KEY}) ===")
+    print(f"window: {window_start.isoformat()} .. {now.isoformat()}")
+
+    conn = open_readonly_connection(dsn)
+    if conn is None:
+        print("RESULT: insufficient data (postgres unavailable or not read-only)")
+        return 0
+
+    try:
+        target_ids = fetch_attended_target_ids(conn, window_start)
+    finally:
+        conn.close()
+
+    if not target_ids:
+        print(f"candidates observed: 0 (no {TEMPLATE_KEY} candidates in window)")
+        print("RESULT: insufficient data")
+        return 0
+
+    distinct_targets = sorted(set(target_ids))
+    passed = len(distinct_targets) >= MIN_DISTINCT_TARGETS
+
+    print(f"candidates observed: {len(target_ids)}")
+    print(f"distinct target_id count: {len(distinct_targets)} (need >= {MIN_DISTINCT_TARGETS})")
+    print(f"distinct targets: {distinct_targets}")
+    print(f"\nRESULT: {'PASS' if passed else 'FAIL'}")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/orion/autonomy/models.py
+++ b/orion/autonomy/models.py
@@ -244,6 +244,14 @@ class SubstrateActResultV1(BaseModel):
     # Full outcome carried up to the worker so it can emit action.outcome.emit.v1
     # onto the bus for durable, cross-service persistence.
     fetch_outcome: ActionOutcomeRefV1 | None = None
+    # P4: recall-first check, tried before fetch. Mirrors fetch_attempted/
+    # fetch_outcome exactly so a successful recall reaches the same bus-emit
+    # -> sql-writer -> action_outcomes durability path a fetch success does --
+    # without this, a recall success is recorded only via the local
+    # append_action_outcome file-store fallback inside policy_act.py, never
+    # the durable SQL path load_action_outcomes reads from in production.
+    recall_attempted: bool = False
+    recall_outcome: ActionOutcomeRefV1 | None = None
 
 
 class AutonomyStateDeltaV1(BaseModel):

--- a/orion/autonomy/policy_act.py
+++ b/orion/autonomy/policy_act.py
@@ -532,6 +532,22 @@ async def maybe_execute_substrate_act_after_metabolism(
             )
             recall_outcome = None
 
+        if recall_outcome is not None:
+            # Recorded whenever an attempt happened (RPC issued, whatever the
+            # result), mirroring fetch_attempted/fetch_outcome's own semantics
+            # below -- "attempted" tracks that a real check happened, success
+            # lives inside the outcome object itself. Without this, a recall
+            # attempt was only ever visible via the local append_action_outcome
+            # file-store fallback inside maybe_execute_readonly_recall_after_goal,
+            # never reaching the durable bus-emit -> sql-writer -> SQL path a
+            # fetch outcome does (see the publish site below this function).
+            result = result.model_copy(
+                update={
+                    "recall_attempted": True,
+                    "recall_outcome": recall_outcome,
+                }
+            )
+
         if recall_outcome is not None and recall_outcome.success:
             fetch_outcome = None
         else:

--- a/orion/autonomy/policy_act.py
+++ b/orion/autonomy/policy_act.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import logging
+import uuid
+from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Sequence
 
+from orion.autonomy.action_outcomes import append_action_outcome
 from orion.autonomy.capability_policy import CapabilityEvaluationContext, evaluate_capability
 from orion.autonomy.episode_fetch import EpisodeFetchRequest, execute_readonly_fetch
 from orion.autonomy.fetch_backend_resolve import resolve_fetch_backend
 from orion.autonomy.models import ActionOutcomeRefV1, CapabilityDecisionV1, SubstrateActResultV1, SubstrateEpisodeIntentV1
 from orion.autonomy.salience import gap_terms_from_signals, iter_gap_section_labels
+from orion.cognition.recall_query import DEFAULT_RECALL_REPLY_PREFIX, build_recall_query_v1
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.core.contracts.recall import RecallReplyV1
 from orion.core.schemas.drives import DriveStateV1, GoalProposalV1
 from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
 
@@ -15,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 _READONLY_CAPABILITY = "web.fetch.readonly"
 _EPISODE_JOURNAL_CAPABILITY = "journal.compose.episode"
+_RECALL_CAPABILITY = "recall.query.readonly"
+_RECALL_REQUEST_CHANNEL = "orion:exec:request:RecallService"
 _GAP_SIGNAL = "world_coverage_gap"
 
 
@@ -96,6 +104,211 @@ async def maybe_execute_readonly_fetch_after_goal(
     outcome = await execute_readonly_fetch(req, fetch_backend=fetch_backend)
     if budget_used is not None:
         budget_used[_READONLY_CAPABILITY] = budget_used.get(_READONLY_CAPABILITY, 0) + 1
+    return decision, outcome
+
+
+async def _execute_readonly_recall(
+    *,
+    subject: str,
+    query: str,
+    bus: Any,
+    source: ServiceRef | None,
+    recall_channel: str,
+    timeout_sec: float,
+    spawned_correlation_id: str,
+) -> ActionOutcomeRefV1:
+    """Inline recall RPC (mirrors ``recall_prefetch.py:169-183``'s exact pattern).
+
+    Degrades gracefully on any failure -- never raises. The caller falls through
+    to the readonly-fetch path when the returned outcome is not a success.
+    """
+    action_id = f"recall-{spawned_correlation_id}-{uuid.uuid4().hex[:8]}"
+    observed_at = datetime.now(timezone.utc)
+    reply_channel = f"{DEFAULT_RECALL_REPLY_PREFIX}:{uuid.uuid4()}"
+    envelope_source = source or ServiceRef(name="orion-spark-concept-induction")
+    # BaseEnvelope.correlation_id requires a real UUID; autonomy run ids (e.g.
+    # "wp-run-gap-gpu") are opaque strings, not UUIDs. Reuse spawned_correlation_id
+    # verbatim when it happens to already be one; otherwise mint a fresh envelope
+    # correlation id rather than raise.
+    try:
+        envelope_correlation_id = uuid.UUID(str(spawned_correlation_id))
+    except (ValueError, AttributeError, TypeError):
+        envelope_correlation_id = uuid.uuid4()
+
+    try:
+        req = build_recall_query_v1(
+            {"raw_user_text": query, "verb": "autonomy_recall_check"},
+            correlation_id=spawned_correlation_id,
+            reply_to=reply_channel,
+        )
+        if req is None:
+            outcome = ActionOutcomeRefV1(
+                action_id=action_id,
+                kind=_RECALL_CAPABILITY,
+                summary="recall query build failed",
+                success=False,
+                surprise=1.0,
+                observed_at=observed_at,
+                query=query,
+            )
+        else:
+            env = BaseEnvelope(
+                kind="recall.query.v1",
+                source=envelope_source,
+                correlation_id=envelope_correlation_id,
+                reply_to=reply_channel,
+                payload=req.model_dump(mode="json"),
+            )
+            msg = await bus.rpc_request(
+                recall_channel,
+                env,
+                reply_channel=reply_channel,
+                timeout_sec=timeout_sec,
+            )
+            decoded = bus.codec.decode(msg.get("data"))
+            if not decoded.ok:
+                outcome = ActionOutcomeRefV1(
+                    action_id=action_id,
+                    kind=_RECALL_CAPABILITY,
+                    summary=f"recall decode failed: {decoded.error}",
+                    success=False,
+                    surprise=1.0,
+                    observed_at=observed_at,
+                    query=query,
+                )
+            else:
+                payload = decoded.envelope.payload if isinstance(decoded.envelope.payload, dict) else {}
+                if payload.get("error"):
+                    outcome = ActionOutcomeRefV1(
+                        action_id=action_id,
+                        kind=_RECALL_CAPABILITY,
+                        summary=f"recall service error: {payload.get('error')}",
+                        success=False,
+                        surprise=1.0,
+                        observed_at=observed_at,
+                        query=query,
+                    )
+                else:
+                    reply = RecallReplyV1.model_validate(payload)
+                    items = reply.bundle.items or []
+                    found = bool(items)
+                    outcome = ActionOutcomeRefV1(
+                        action_id=action_id,
+                        kind=_RECALL_CAPABILITY,
+                        summary=f"recall found {len(items)} item(s)" if found else "recall found nothing",
+                        success=found,
+                        surprise=0.0 if found else 1.0,
+                        observed_at=observed_at,
+                        query=query,
+                    )
+    except Exception as exc:
+        logger.warning(
+            "autonomy_recall_rpc_failed subject=%s query=%r error=%s",
+            subject,
+            query,
+            exc,
+            exc_info=True,
+        )
+        outcome = ActionOutcomeRefV1(
+            action_id=action_id,
+            kind=_RECALL_CAPABILITY,
+            summary=f"recall rpc failed: {exc}",
+            success=False,
+            surprise=1.0,
+            observed_at=observed_at,
+            query=query,
+        )
+
+    append_action_outcome(subject=subject, outcome=outcome)
+    return outcome
+
+
+async def maybe_execute_readonly_recall_after_goal(
+    *,
+    goal: GoalProposalV1,
+    drive_state: DriveStateV1,
+    curiosity_signals: Sequence[FrontierInvocationSignalV1],
+    spawned_correlation_id: str | None,
+    bus: Any = None,
+    source: ServiceRef | None = None,
+    recall_channel: str = _RECALL_REQUEST_CHANNEL,
+    timeout_sec: float = 3.0,
+    budget_used: dict[str, int] | None = None,
+) -> tuple[CapabilityDecisionV1, ActionOutcomeRefV1 | None]:
+    """Layer C gate + recall-first check, tried before the readonly web fetch.
+
+    "Check what I already know first": mirrors
+    ``maybe_execute_readonly_fetch_after_goal`` in shape exactly. On allow, issues
+    an inline recall RPC and records the outcome via ``append_action_outcome``
+    the same way the fetch path does. Never raises -- any RPC failure, timeout,
+    or missing ``bus`` degrades to a ``None`` outcome so the caller falls through
+    to the existing readonly-fetch path without consuming its budget.
+    """
+    if not curiosity_signals or _GAP_SIGNAL not in signal_kinds_from_curiosity(curiosity_signals):
+        decision = CapabilityDecisionV1(
+            capability_id=_RECALL_CAPABILITY,
+            outcome="denied",
+            reason_code="missing_signal_kinds",
+            auto_execute=False,
+        )
+        return decision, None
+
+    if not spawned_correlation_id:
+        decision = CapabilityDecisionV1(
+            capability_id=_RECALL_CAPABILITY,
+            outcome="denied",
+            reason_code="missing_spawned_correlation_id",
+            auto_execute=False,
+        )
+        return decision, None
+
+    ctx = CapabilityEvaluationContext(
+        predictive_pressure=float(drive_state.pressures.get("predictive", 0.0)),
+        curiosity_strength=curiosity_strength_from_signals(curiosity_signals),
+        signal_kinds=signal_kinds_from_curiosity(curiosity_signals),
+        goal=goal,
+        budget_used=budget_used or {},
+    )
+    decision = evaluate_capability(_RECALL_CAPABILITY, ctx)
+    logger.info(
+        "substrate_policy_act capability=%s outcome=%s reason=%s auto_execute=%s goal=%s spawned=%s",
+        decision.capability_id,
+        decision.outcome,
+        decision.reason_code,
+        decision.auto_execute,
+        goal.artifact_id,
+        spawned_correlation_id,
+    )
+    if decision.outcome != "allowed" or not decision.auto_execute:
+        return decision, None
+
+    if bus is None:
+        # No bus wired for this call site -- degrade gracefully rather than raise;
+        # the caller falls through to the fetch path with its budget untouched.
+        return decision, None
+
+    if budget_used is not None:
+        budget_used[_RECALL_CAPABILITY] = budget_used.get(_RECALL_CAPABILITY, 0) + 1
+
+    query = build_readonly_fetch_query(curiosity_signals)
+    try:
+        outcome = await _execute_readonly_recall(
+            subject=goal.subject,
+            query=query,
+            bus=bus,
+            source=source,
+            recall_channel=recall_channel,
+            timeout_sec=timeout_sec,
+            spawned_correlation_id=spawned_correlation_id,
+        )
+    except Exception:
+        logger.warning(
+            "autonomy_recall_execute_failed goal=%s spawned=%s",
+            goal.artifact_id,
+            spawned_correlation_id,
+            exc_info=True,
+        )
+        return decision, None
     return decision, outcome
 
 
@@ -272,6 +485,10 @@ async def maybe_execute_substrate_act_after_metabolism(
     budget_used: dict[str, int] | None = None,
     prefetched_outcome: ActionOutcomeRefV1 | None = None,
     episode_journal_enabled: bool = False,
+    recall_bus: Any = None,
+    recall_source: ServiceRef | None = None,
+    recall_channel: str = _RECALL_REQUEST_CHANNEL,
+    recall_timeout_sec: float = 3.0,
 ) -> SubstrateActResultV1:
     run_id = spawned_correlation_id or episode_intent.spawned_correlation_id
     synthetic_goal = goal_proposal_from_episode_intent(episode_intent)
@@ -289,22 +506,51 @@ async def maybe_execute_substrate_act_after_metabolism(
             }
         )
     else:
-        fetch_decision, fetch_outcome = await maybe_execute_readonly_fetch_after_goal(
-            goal=synthetic_goal,
-            drive_state=drive_state,
-            curiosity_signals=curiosity_signals,
-            spawned_correlation_id=run_id,
-            fetch_backend=fetch_backend,
-            budget_used=budget_used,
-        )
-        if fetch_decision.outcome == "allowed" and fetch_outcome is not None:
-            result = result.model_copy(
-                update={
-                    "fetch_attempted": True,
-                    "fetch_outcome_id": fetch_outcome.action_id,
-                    "fetch_outcome": fetch_outcome,
-                }
+        # Recall-first: check what Orion already knows before spending a live
+        # web fetch. Tried before the fetch call in the same tick; if recall
+        # surfaces real content, the fetch capability's budget is left untouched
+        # this cycle. Any recall failure/timeout/empty result degrades to None
+        # and falls straight through to the existing fetch path below.
+        try:
+            _, recall_outcome = await maybe_execute_readonly_recall_after_goal(
+                goal=synthetic_goal,
+                drive_state=drive_state,
+                curiosity_signals=curiosity_signals,
+                spawned_correlation_id=run_id,
+                bus=recall_bus,
+                source=recall_source,
+                recall_channel=recall_channel,
+                timeout_sec=recall_timeout_sec,
+                budget_used=budget_used,
             )
+        except Exception:
+            logger.warning(
+                "substrate_recall_check_failed goal=%s spawned=%s",
+                synthetic_goal.artifact_id,
+                run_id,
+                exc_info=True,
+            )
+            recall_outcome = None
+
+        if recall_outcome is not None and recall_outcome.success:
+            fetch_outcome = None
+        else:
+            fetch_decision, fetch_outcome = await maybe_execute_readonly_fetch_after_goal(
+                goal=synthetic_goal,
+                drive_state=drive_state,
+                curiosity_signals=curiosity_signals,
+                spawned_correlation_id=run_id,
+                fetch_backend=fetch_backend,
+                budget_used=budget_used,
+            )
+            if fetch_decision.outcome == "allowed" and fetch_outcome is not None:
+                result = result.model_copy(
+                    update={
+                        "fetch_attempted": True,
+                        "fetch_outcome_id": fetch_outcome.action_id,
+                        "fetch_outcome": fetch_outcome,
+                    }
+                )
 
     if not episode_journal_enabled or fetch_outcome is None:
         return result

--- a/orion/autonomy/tension_ratelimit.py
+++ b/orion/autonomy/tension_ratelimit.py
@@ -17,8 +17,17 @@ from orion.core.schemas.drives import TensionEventV1
 
 def _signature(t: TensionEventV1) -> Tuple[str, Tuple[str, ...]]:
     """Source identity: kind + the set of drives it pushes. Two tensions with the
-    same kind and drive-set are the same recurring pressure."""
-    drives = tuple(sorted(d for d, w in (t.drive_impacts or {}).items() if w > 0.0))
+    same kind and drive-set are the same recurring pressure.
+
+    Includes relief (negative-weight) drives, not just growth (positive)
+    ones -- every producer before the P3 satisfaction tension only ever
+    emitted non-negative weights, so this is a no-op for them (w != 0.0 vs.
+    w > 0.0 select the same drives when no weight is ever negative).
+    Without this, an all-negative-weight tension collides into an empty-
+    tuple signature shared with any other zero-positive-weight tension of
+    the same kind, rate-limiting them together instead of independently.
+    """
+    drives = tuple(sorted(d for d, w in (t.drive_impacts or {}).items() if w != 0.0))
     return (t.kind, drives)
 
 

--- a/orion/autonomy/tests/test_capability_policy.py
+++ b/orion/autonomy/tests/test_capability_policy.py
@@ -81,6 +81,52 @@ def test_capability_policy_allows_episode_journal_at_proposed(monkeypatch) -> No
     assert decision.auto_execute is True
 
 
+def test_capability_policy_allows_recall_when_goal_proposed(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_METABOLISM_MIN_PREDICTIVE_PRESSURE", "0.55")
+    monkeypatch.setenv("ORION_METABOLISM_MIN_CURIOSITY_STRENGTH", "0.5")
+    ctx = CapabilityEvaluationContext(
+        predictive_pressure=0.7,
+        curiosity_strength=0.65,
+        signal_kinds=["world_coverage_gap"],
+        goal=_goal(),
+        budget_used={},
+    )
+    decision = evaluate_capability("recall.query.readonly", ctx)
+    assert decision.outcome == "allowed"
+    assert decision.auto_execute is True
+
+
+def test_capability_policy_denies_recall_without_goal(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    ctx = CapabilityEvaluationContext(
+        predictive_pressure=0.7,
+        curiosity_strength=0.65,
+        signal_kinds=["world_coverage_gap"],
+        goal=None,
+        budget_used={},
+    )
+    decision = evaluate_capability("recall.query.readonly", ctx)
+    assert decision.outcome == "denied"
+    assert decision.reason_code == "missing_goal"
+
+
+def test_capability_policy_denies_recall_when_auto_readonly_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "false")
+    monkeypatch.setenv("ORION_METABOLISM_MIN_PREDICTIVE_PRESSURE", "0.55")
+    monkeypatch.setenv("ORION_METABOLISM_MIN_CURIOSITY_STRENGTH", "0.5")
+    ctx = CapabilityEvaluationContext(
+        predictive_pressure=0.7,
+        curiosity_strength=0.65,
+        signal_kinds=["world_coverage_gap"],
+        goal=_goal(),
+        budget_used={},
+    )
+    decision = evaluate_capability("recall.query.readonly", ctx)
+    assert decision.outcome == "denied"
+    assert decision.reason_code == "policy_auto_disabled"
+
+
 def test_capability_policy_denies_episode_journal_when_disabled(monkeypatch) -> None:
     monkeypatch.setenv("ORION_AUTONOMY_EPISODE_JOURNAL_ENABLED", "false")
     monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")

--- a/orion/autonomy/tests/test_capability_policy_models.py
+++ b/orion/autonomy/tests/test_capability_policy_models.py
@@ -15,8 +15,13 @@ def test_capability_policy_v1_yaml_loads_and_validates() -> None:
     raw = yaml.safe_load(POLICY_YAML.read_text(encoding="utf-8"))
     policy = CapabilityPolicyV1.model_validate(raw)
     assert policy.version == "v1"
-    assert len(policy.rules) == 4
+    assert len(policy.rules) == 5
     assert policy.rules[0].capability_id == "web.fetch.readonly"
     assert policy.rules[0].auto_execute is True
     assert policy.rules[3].capability_id == "web.fetch.write"
     assert policy.rules[3].auto_execute is False
+    assert policy.rules[4].capability_id == "recall.query.readonly"
+    assert policy.rules[4].auto_execute is True
+    assert policy.rules[4].side_effect_class == "readonly"
+    assert policy.rules[4].required_signal_kinds == ["world_coverage_gap"]
+    assert policy.rules[4].required_drive_origins == ["predictive"]

--- a/orion/autonomy/tests/test_policy_act.py
+++ b/orion/autonomy/tests/test_policy_act.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -11,9 +12,11 @@ from orion.autonomy.policy_act import (
     build_readonly_fetch_query,
     maybe_compose_autonomy_episode_after_fetch,
     maybe_execute_readonly_fetch_after_goal,
+    maybe_execute_readonly_recall_after_goal,
     maybe_execute_substrate_act_after_metabolism,
     resolve_episode_intent,
 )
+from orion.core.contracts.recall import MemoryBundleV1, MemoryItemV1, RecallReplyV1
 from orion.core.schemas.drives import DriveStateV1, GoalProposalV1
 from orion.core.schemas.frontier_curiosity import FrontierInvocationSignalV1
 
@@ -406,3 +409,217 @@ async def test_substrate_act_preserves_fetch_when_journal_dispatch_fails(monkeyp
     # Journal was attempted but failed, so no journal entry recorded.
     assert result.journal_attempted is False
     journal_dispatch.assert_awaited_once()
+
+
+def _fake_recall_reply(*, n: int = 1) -> RecallReplyV1:
+    items = [
+        MemoryItemV1(id=f"mem-{i}", source="journal", snippet=f"snippet {i}", score=0.8)
+        for i in range(n)
+    ]
+    return RecallReplyV1(bundle=MemoryBundleV1(items=items, rendered="digest"))
+
+
+def _fake_recall_bus(reply: RecallReplyV1 | None = None, *, exc: Exception | None = None) -> MagicMock:
+    """Mirrors ``orion/cognition/tests/test_recall_prefetch.py``'s bus double."""
+    bus = MagicMock()
+    if exc is not None:
+
+        async def _rpc(*_a: Any, **_k: Any) -> Any:
+            raise exc
+
+        bus.rpc_request = AsyncMock(side_effect=_rpc)
+        return bus
+
+    reply_payload = reply.model_dump(mode="json") if reply is not None else {"error": "fail"}
+
+    class _Decoded:
+        ok = True
+        error = None
+
+        class _Env:
+            payload = reply_payload
+
+        envelope = _Env()
+
+    async def _rpc(*_a: Any, **_k: Any) -> dict[str, Any]:
+        return {"data": b"x"}
+
+    bus.codec.decode.return_value = _Decoded()
+    bus.rpc_request = AsyncMock(side_effect=_rpc)
+    return bus
+
+
+@pytest.mark.asyncio
+async def test_recall_capability_denied_without_gap_signal(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    decision, outcome = await maybe_execute_readonly_recall_after_goal(
+        goal=_goal(),
+        drive_state=_drive_state(),
+        curiosity_signals=[],
+        spawned_correlation_id="wp-run-gap-gpu",
+        bus=_fake_recall_bus(_fake_recall_reply()),
+    )
+    assert decision.outcome == "denied"
+    assert decision.reason_code == "missing_signal_kinds"
+    assert outcome is None
+
+
+@pytest.mark.asyncio
+async def test_recall_capability_finds_content(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    bus = _fake_recall_bus(_fake_recall_reply(n=2))
+    decision, outcome = await maybe_execute_readonly_recall_after_goal(
+        goal=_goal(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        spawned_correlation_id="wp-run-gap-gpu",
+        bus=bus,
+    )
+    assert decision.outcome == "allowed"
+    assert outcome is not None
+    assert outcome.success is True
+    assert outcome.kind == "recall.query.readonly"
+    bus.rpc_request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recall_capability_empty_reply_degrades(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    bus = _fake_recall_bus(_fake_recall_reply(n=0))
+    decision, outcome = await maybe_execute_readonly_recall_after_goal(
+        goal=_goal(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        spawned_correlation_id="wp-run-gap-gpu",
+        bus=bus,
+    )
+    assert decision.outcome == "allowed"
+    assert outcome is not None
+    assert outcome.success is False
+
+
+@pytest.mark.asyncio
+async def test_recall_capability_rpc_timeout_never_raises(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    bus = _fake_recall_bus(exc=TimeoutError("rpc timeout"))
+    decision, outcome = await maybe_execute_readonly_recall_after_goal(
+        goal=_goal(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        spawned_correlation_id="wp-run-gap-gpu",
+        bus=bus,
+    )
+    assert decision.outcome == "allowed"
+    assert outcome is not None
+    assert outcome.success is False
+    assert "recall rpc failed" in outcome.summary
+
+
+@pytest.mark.asyncio
+async def test_recall_capability_no_bus_degrades_to_none(monkeypatch) -> None:
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    decision, outcome = await maybe_execute_readonly_recall_after_goal(
+        goal=_goal(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        spawned_correlation_id="wp-run-gap-gpu",
+        bus=None,
+    )
+    assert decision.outcome == "allowed"
+    assert outcome is None
+
+
+@pytest.mark.asyncio
+async def test_substrate_act_recall_hit_skips_fetch_budget(monkeypatch, tmp_path) -> None:
+    """Recall-first: when recall finds real content, the fetch capability is never
+    invoked and its budget is not consumed that cycle."""
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    fetch_backend = AsyncMock(return_value={"success": True, "urls": ["https://example.com/a"]})
+    bus = _fake_recall_bus(_fake_recall_reply(n=1))
+    budget: dict[str, int] = {}
+
+    result = await maybe_execute_substrate_act_after_metabolism(
+        episode_intent=_intent(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        spawned_correlation_id="wp-run-gap-gpu",
+        fetch_backend=fetch_backend,
+        budget_used=budget,
+        recall_bus=bus,
+    )
+
+    fetch_backend.assert_not_awaited()
+    bus.rpc_request.assert_awaited_once()
+    assert budget.get("web.fetch.readonly", 0) == 0
+    assert budget.get("recall.query.readonly", 0) == 1
+    assert result.fetch_attempted is False
+    assert result.fetch_outcome is None
+
+
+@pytest.mark.asyncio
+async def test_substrate_act_recall_miss_falls_through_to_fetch(monkeypatch, tmp_path) -> None:
+    """Recall coming up empty must not block the tick: the fetch path still runs."""
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    fetch_backend = AsyncMock(return_value={"success": True, "urls": ["https://example.com/a"]})
+    bus = _fake_recall_bus(_fake_recall_reply(n=0))
+
+    result = await maybe_execute_substrate_act_after_metabolism(
+        episode_intent=_intent(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        spawned_correlation_id="wp-run-gap-gpu",
+        fetch_backend=fetch_backend,
+        recall_bus=bus,
+    )
+
+    fetch_backend.assert_awaited_once()
+    assert result.fetch_attempted is True
+    assert result.fetch_outcome is not None
+    assert result.fetch_outcome.success is True
+
+
+@pytest.mark.asyncio
+async def test_substrate_act_recall_rpc_failure_falls_through_to_fetch(monkeypatch, tmp_path) -> None:
+    """Recall RPC failure/timeout never raises and never blocks the tick."""
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    fetch_backend = AsyncMock(return_value={"success": True, "urls": ["https://example.com/a"]})
+    bus = _fake_recall_bus(exc=TimeoutError("rpc timeout"))
+
+    result = await maybe_execute_substrate_act_after_metabolism(
+        episode_intent=_intent(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        spawned_correlation_id="wp-run-gap-gpu",
+        fetch_backend=fetch_backend,
+        recall_bus=bus,
+    )
+
+    fetch_backend.assert_awaited_once()
+    assert result.fetch_attempted is True
+    assert result.fetch_outcome is not None
+    assert result.fetch_outcome.success is True
+
+
+@pytest.mark.asyncio
+async def test_substrate_act_no_recall_bus_falls_through_to_fetch(monkeypatch, tmp_path) -> None:
+    """Default behavior (no recall_bus wired) is unchanged: fetch runs as before."""
+    monkeypatch.setenv("ORION_CAPABILITY_POLICY_AUTO_READONLY_ENABLED", "true")
+    monkeypatch.setenv("ORION_ACTION_OUTCOME_STORE_PATH", str(tmp_path / "outcomes.json"))
+    fetch_backend = AsyncMock(return_value={"success": True, "urls": ["https://example.com/a"]})
+
+    result = await maybe_execute_substrate_act_after_metabolism(
+        episode_intent=_intent(),
+        drive_state=_drive_state(),
+        curiosity_signals=[_gap_signal()],
+        spawned_correlation_id="wp-run-gap-gpu",
+        fetch_backend=fetch_backend,
+    )
+
+    fetch_backend.assert_awaited_once()
+    assert result.fetch_attempted is True

--- a/orion/autonomy/tests/test_policy_act.py
+++ b/orion/autonomy/tests/test_policy_act.py
@@ -558,6 +558,14 @@ async def test_substrate_act_recall_hit_skips_fetch_budget(monkeypatch, tmp_path
     assert budget.get("recall.query.readonly", 0) == 1
     assert result.fetch_attempted is False
     assert result.fetch_outcome is None
+    # A recall success must be visible on the result object the same way a
+    # fetch success is (result.fetch_attempted/fetch_outcome) -- without this,
+    # a successful recall-first check was invisible to the bus_worker.py
+    # caller and never reached the durable action.outcome.emit.v1 bus path,
+    # only the local append_action_outcome file-store fallback.
+    assert result.recall_attempted is True
+    assert result.recall_outcome is not None
+    assert result.recall_outcome.success is True
 
 
 @pytest.mark.asyncio
@@ -581,6 +589,12 @@ async def test_substrate_act_recall_miss_falls_through_to_fetch(monkeypatch, tmp
     assert result.fetch_attempted is True
     assert result.fetch_outcome is not None
     assert result.fetch_outcome.success is True
+    # Recall was still attempted (an RPC really happened) even though it
+    # found nothing -- "attempted" tracks the attempt, not the outcome,
+    # mirroring fetch_attempted's own semantics.
+    assert result.recall_attempted is True
+    assert result.recall_outcome is not None
+    assert result.recall_outcome.success is False
 
 
 @pytest.mark.asyncio

--- a/orion/autonomy/tests/test_tension_ratelimit.py
+++ b/orion/autonomy/tests/test_tension_ratelimit.py
@@ -38,6 +38,31 @@ def test_distinct_signatures_have_own_budget() -> None:
     assert len(kept) == 3
 
 
+def test_negative_weight_drives_get_their_own_budget() -> None:
+    """A relief (negative-weight) tension must be rate-limited by which
+    drives it targets, same as a growth tension -- not collapsed into one
+    shared empty-signature bucket with every other zero-positive-weight
+    tension of the same kind."""
+    rl = TensionRateLimiter(cap=1, window_sec=60.0)
+    kept = rl.bounded(
+        [
+            _t(kind="tension.satisfaction.v1", drives={"predictive": -0.3}),
+            _t(kind="tension.satisfaction.v1", drives={"coherence": -0.1}),
+        ],
+        now=5.0,
+    )
+    # Different targeted drives -> distinct signatures -> both admitted,
+    # each under its own cap=1 budget.
+    assert len(kept) == 2
+
+
+def test_same_negative_signature_still_capped() -> None:
+    rl = TensionRateLimiter(cap=1, window_sec=60.0)
+    storm = [_t(kind="tension.satisfaction.v1", drives={"predictive": -0.3}) for _ in range(5)]
+    kept = rl.bounded(storm, now=5.0)
+    assert len(kept) == 1
+
+
 def test_state_bounded() -> None:
     rl = TensionRateLimiter(cap=3, window_sec=60.0, max_keys=10)
     # Distinct signatures (kind varies) so the key map would grow unbounded

--- a/orion/bus/channels.yaml
+++ b/orion/bus/channels.yaml
@@ -258,7 +258,7 @@ channels:
   - name: "orion:exec:request:RecallService"
     kind: "request"
     schema_id: "RecallQueryV1"
-    producer_services: ["orion-cortex-exec", "orion-cortex-orch", "orion-hub", "orion-context-exec"]
+    producer_services: ["orion-cortex-exec", "orion-cortex-orch", "orion-hub", "orion-context-exec", "orion-spark-concept-induction"]
     consumer_services: ["orion-recall"]
     single_consumer: true
     stability: "experimental"

--- a/orion/proposals/builder.py
+++ b/orion/proposals/builder.py
@@ -25,12 +25,47 @@ from orion.schemas.proposal_frame import ProposalCandidateV1, ProposalFrameV1
 from orion.schemas.self_state import SelfStateV1
 
 
+# The only recognized attention-binding literal in v1 -- no general
+# binding-expression DSL, matched exactly against ProposalTemplateV1.target_binding.
+ATTENTION_FIRST_TARGET_BINDING = "self_state.dominant_attention_targets[0]"
+
+# Intersection of AttentionTargetSummaryV1.target_kind's Literal
+# ("node", "capability", "channel", "edge", "field", "system") and
+# ProposalCandidateV1.target_kind's Literal
+# ("node", "capability", "field", "self_state", "service", "system").
+# A resolved attention target outside this set fails closed to the
+# template's literal target_id/target_kind rather than raising.
+_ATTENTION_BOUND_TARGET_KINDS = frozenset({"node", "capability", "field", "system"})
+
+
 def stable_proposal_frame_id(*, self_state_id: str, policy_id: str) -> str:
     return f"proposal.frame:{self_state_id}:{policy_id}"
 
 
 def stable_proposal_id(*, template_key: str, self_state_id: str) -> str:
     return f"proposal:{template_key}:{self_state_id}"
+
+
+def _resolve_binding_target(
+    *,
+    template: ProposalTemplateV1,
+    self_state: SelfStateV1,
+) -> tuple[str, str, str | None]:
+    """Resolve a template's target_id/target_kind from live attention if the
+    template declares a recognized binding and resolution succeeds; otherwise
+    fail closed to the template's literal target_id/target_kind. Never raises.
+
+    Returns (target_id, target_kind, binding_resolved_from).
+    """
+    if template.target_binding != ATTENTION_FIRST_TARGET_BINDING:
+        return template.target_id, template.target_kind, None
+    details = self_state.dominant_attention_target_details
+    if not details:
+        return template.target_id, template.target_kind, None
+    resolved = details[0]
+    if resolved.target_kind not in _ATTENTION_BOUND_TARGET_KINDS:
+        return template.target_id, template.target_kind, None
+    return resolved.target_id, resolved.target_kind, template.target_binding
 
 
 def _build_candidate(
@@ -59,9 +94,13 @@ def _build_candidate(
         self_state=self_state,
         template=template,
     )
+    resolved_target_id, resolved_target_kind, binding_resolved_from = _resolve_binding_target(
+        template=template,
+        self_state=self_state,
+    )
     title, description, reasons = template_title_description(
         template_key,
-        target_id=template.target_id,
+        target_id=resolved_target_id,
     )
     evidence_refs = [
         f"self_state:{self_state.self_state_id}",
@@ -86,8 +125,8 @@ def _build_candidate(
         proposal_kind=cast_proposal_kind(template.kind),
         title=title,
         description=description,
-        target_id=template.target_id,
-        target_kind=cast_target_kind(template.target_kind),
+        target_id=resolved_target_id,
+        target_kind=cast_target_kind(resolved_target_kind),
         priority_score=priority,
         urgency_score=urgency,
         confidence_score=confidence,
@@ -100,6 +139,7 @@ def _build_candidate(
         proposed_effect=cast_proposed_effect(template.proposed_effect),
         required_policy_gate=cast_policy_gate(template.required_policy_gate),
         execution_intent=execution_intent,
+        binding_resolved_from=binding_resolved_from,
     )
 
 

--- a/orion/proposals/policy.py
+++ b/orion/proposals/policy.py
@@ -30,6 +30,10 @@ class ProposalTemplateV1(BaseModel):
     base_risk: float = 0.0
     reversibility: float = 1.0
     dimensions: dict[str, float] = Field(default_factory=dict)
+    # Optional attention-binding path. Only one recognized literal in v1:
+    # "self_state.dominant_attention_targets[0]" (see orion/proposals/builder.py).
+    # No general binding-expression DSL -- matched exactly, nothing fancier.
+    target_binding: str | None = None
 
 
 class ProposalPolicyV1(BaseModel):

--- a/orion/schemas/proposal_frame.py
+++ b/orion/schemas/proposal_frame.py
@@ -70,6 +70,12 @@ class ProposalCandidateV1(BaseModel):
     source: str | None = None
     thought_id: str | None = None
 
+    # Provenance for template target_id/target_kind resolved from live attention
+    # (P5: attention-bound proposal template) rather than the template's literal
+    # fallback. Set to the recognized binding path string when resolution
+    # succeeded; None when the candidate used the template's literal target.
+    binding_resolved_from: str | None = None
+
 
 class ProposalFrameV1(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -59,6 +59,7 @@ from .summarizer import Summarizer
 from .tensions import (
     derive_pressure_competition_tensions,
     extract_tensions,
+    extract_tensions_from_action_outcome,
     extract_tensions_from_feedback,
     extract_tensions_from_self_state,
 )
@@ -669,6 +670,30 @@ class ConceptWorker:
             feedback_frame=frame,
         )
 
+    def _tensions_from_action_outcome(self, env: BaseEnvelope, intake_channel: str) -> List[TensionEventV1]:
+        # Self-publish guard: this service is itself already a producer on
+        # orion:autonomy:action:outcome (curiosity-fetch outcomes, via
+        # _publish_action_outcome below) with no self-filter anywhere in
+        # this file today. Redis pub/sub delivers to all subscribers
+        # including the publisher, so without this check a curiosity-fetch
+        # outcome would loop back through this NEW path too, on top of its
+        # own dedicated in-process handling -- double-processing the same
+        # event. Only outcomes from OTHER services (today: Layer 9 /
+        # orion-execution-dispatch-runtime) reach the extractor below.
+        source_name = getattr(getattr(env, "source", None), "name", None)
+        if source_name == self.cfg.service_name:
+            return []
+        try:
+            outcome = ActionOutcomeEmitV1.model_validate(self._payload_dict(env))
+        except Exception:
+            logger.warning("action_outcome_parse_failed kind=%s", env.kind)
+            return []
+        return extract_tensions_from_action_outcome(
+            envelope=env,
+            intake_channel=intake_channel,
+            outcome=outcome,
+        )
+
     def _parse_signal(self, env: BaseEnvelope) -> Optional[OrionSignalV1]:
         try:
             return OrionSignalV1.model_validate(self._payload_dict(env))
@@ -811,6 +836,11 @@ class ConceptWorker:
             model_layer = model_layer_for_subject(subject)
             entity_id = entity_id_for_subject(subject, model_layer)
             spark_tensions = self._tensions_from_feedback(env, intake_channel)
+        elif env.kind == "action.outcome.emit.v1":
+            subject = "orion"
+            model_layer = model_layer_for_subject(subject)
+            entity_id = entity_id_for_subject(subject, model_layer)
+            spark_tensions = self._tensions_from_action_outcome(env, intake_channel)
         else:
             subject = self._detect_subject(env, intake_channel)
             model_layer = self._model_layer(subject, intake_channel)
@@ -1094,7 +1124,7 @@ class ConceptWorker:
         await self._publish_dossier(dossier, env.correlation_id)
 
         # Structured substrate/feedback signals carry no text: skip concept induction.
-        if env.kind in {"substrate.self_state.v1", "feedback.frame.v1"}:
+        if env.kind in {"substrate.self_state.v1", "feedback.frame.v1", "action.outcome.emit.v1"}:
             return
 
         source_kind = self._source_kind(env, intake_channel)

--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -1070,6 +1070,14 @@ class ConceptWorker:
                     budget_used=policy_budget,
                     episode_journal_enabled=self.cfg.autonomy_episode_journal_enabled,
                     prefetched_outcome=prefetched_outcome,
+                    # Without these, maybe_execute_readonly_recall_after_goal's
+                    # own `if bus is None: return decision, None` guard degrades
+                    # silently before any RPC is attempted -- the recall-first
+                    # capability would evaluate policy, log "allowed", and never
+                    # actually fire. Reuse this worker's own bus connection and
+                    # identity, same as every other bus call this class makes.
+                    recall_bus=self.bus,
+                    recall_source=_service_ref(self.cfg),
                 )
                 if act_result.fetch_outcome is not None:
                     try:
@@ -1087,6 +1095,29 @@ class ConceptWorker:
                             subject,
                             act_result.fetch_outcome.action_id,
                             act_result.fetch_outcome.success,
+                            spawned_correlation_id,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "action_outcome_emit_failed subject=%s spawned=%s",
+                            subject,
+                            spawned_correlation_id,
+                            exc_info=True,
+                        )
+                if act_result.recall_outcome is not None:
+                    try:
+                        await self._publish_action_outcome(
+                            ActionOutcomeEmitV1.from_outcome(
+                                subject=subject,
+                                outcome=act_result.recall_outcome,
+                            ),
+                            env.correlation_id,
+                        )
+                        logger.info(
+                            "action_outcome_emitted subject=%s action_id=%s success=%s spawned=%s",
+                            subject,
+                            act_result.recall_outcome.action_id,
+                            act_result.recall_outcome.success,
                             spawned_correlation_id,
                         )
                     except Exception:

--- a/orion/spark/concept_induction/drives.py
+++ b/orion/spark/concept_induction/drives.py
@@ -32,6 +32,15 @@ class DriveEngine:
     def _clamp01(value: float) -> float:
         return max(0.0, min(1.0, float(value)))
 
+    @staticmethod
+    def _clamp_signed(value: float) -> float:
+        """Clamp to [-1, 1] -- same shape as _clamp01 but preserves sign, for
+        drive_impacts weights that carry relief (negative) as well as growth
+        (positive). Growth-only producers never emit a negative weight, so
+        this is a strict superset of _clamp01's behavior for them.
+        """
+        return max(-1.0, min(1.0, float(value)))
+
     def _decay_factor(self, elapsed_sec: float) -> float:
         if elapsed_sec <= 0:
             return 1.0
@@ -64,7 +73,11 @@ class DriveEngine:
             for drive, weight in sorted(event.drive_impacts.items()):
                 if drive not in impact_sum:
                     continue
-                impact_sum[drive] += mag * self._clamp01(weight)
+                # weight is signed: positive = growth (existing producers),
+                # negative = relief (e.g. a satisfaction tension on a
+                # successfully completed action). magnitude itself stays
+                # non-negative (schema-enforced) -- direction lives in weight.
+                impact_sum[drive] += mag * self._clamp_signed(weight)
 
         pressures: Dict[str, float] = {}
         activations: Dict[str, bool] = {}
@@ -75,8 +88,16 @@ class DriveEngine:
                 # impulse pushes it a fraction of the remaining headroom (1 - base).
                 # No fixed point: with impulse=0, pressure=base < prev; the 55/s
                 # scene_state flood mints impulse≈0, so it cannot inflate anything.
-                impulse = self._clamp01(impact_sum[drive])
-                pressures[drive] = self._clamp01(base + impulse * (1.0 - base))
+                impulse = self._clamp_signed(impact_sum[drive])
+                if impulse >= 0.0:
+                    pressures[drive] = self._clamp01(base + impulse * (1.0 - base))
+                else:
+                    # Relief is the mirror image of growth: diminishing effect
+                    # as pressure approaches its OTHER bound (0 instead of 1),
+                    # scaled by how much pressure is actually there to relieve
+                    # (base, not 1-base) -- at base=0 a relief impulse is
+                    # naturally a no-op without depending on the outer clamp.
+                    pressures[drive] = self._clamp01(base + impulse * base)
             else:
                 raw = base + impact_sum[drive]
                 pressures[drive] = self._soft_saturate(raw)

--- a/orion/spark/concept_induction/settings.py
+++ b/orion/spark/concept_induction/settings.py
@@ -39,6 +39,7 @@ class ConceptSettings(BaseSettings):
             "orion:substrate:self_state",
             "orion:feedback:frame",
             "orion:world_pulse:run:result",
+            "orion:autonomy:action:outcome",
         ],
         validation_alias=AliasChoices("BUS_INTAKE_CHANNELS", "CONCEPT_INTAKE_CHANNELS"),
     )

--- a/orion/spark/concept_induction/tensions.py
+++ b/orion/spark/concept_induction/tensions.py
@@ -4,6 +4,7 @@ import hashlib
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 
+from orion.autonomy.models import ActionOutcomeEmitV1
 from orion.core.bus.bus_schemas import BaseEnvelope
 from orion.core.schemas.drives import ArtifactProvenance, TensionEventV1
 from orion.schemas.feedback_frame import FeedbackFrameV1
@@ -463,3 +464,72 @@ def extract_tensions_from_feedback(
     for event in events:
         event.provenance.tension_refs = [event.artifact_id]
     return events
+
+
+# Closed, explicit map -- deliberately not a fuzzy inference. Each of P1's
+# three verbs relieves the one drive its own tone/intent most directly
+# targets (per docs/superpowers/specs/2026-07-13-execution-dispatch-motor-nerve-p1-design.md's
+# tone design): inspect is diagnostic (relieves coherence, the drive most
+# associated with "something's unclear, go look"); summarize is a wide-angle
+# picture (relieves predictive, "what's the state of things"); observe is a
+# deliberately lighter, lower-stakes stability check (smaller relief,
+# continuity -- "still steady").
+_ACTION_OUTCOME_DRIVE_RELIEF: Dict[str, Dict[str, float]] = {
+    "inspect": {"coherence": -0.10},
+    "summarize": {"predictive": -0.10},
+    "observe": {"continuity": -0.05},
+}
+_ACTION_OUTCOME_RELIEF_MAGNITUDE = 0.3
+
+
+def extract_tensions_from_action_outcome(
+    *,
+    envelope: BaseEnvelope,
+    intake_channel: str,
+    outcome: ActionOutcomeEmitV1,
+) -> List[TensionEventV1]:
+    """Relief tension when a real autonomous action (Layer 9 dispatch, P1/P2)
+    succeeds. Mints nothing on failure -- extract_tensions_from_feedback's
+    existing failed/absent/blocked branch already covers that side; this is
+    deliberately one-directional, not a duplicate of both directions.
+    """
+    if not outcome.success:
+        return []
+    weights = _ACTION_OUTCOME_DRIVE_RELIEF.get(outcome.kind)
+    if not weights:
+        return []
+
+    subject = "orion"
+    model_layer = "self-model"
+    entity_id = "self:orion"
+
+    ts = envelope.created_at if envelope.created_at.tzinfo else envelope.created_at.replace(tzinfo=timezone.utc)
+    trace_id = extract_trace_id(envelope)
+    turn_id = extract_turn_id(envelope)
+    source_event_ref = build_source_event_ref(envelope, intake_channel)
+    evidence_text = f"action_outcome kind={outcome.kind} action_id={outcome.action_id} success=True"
+    evidence_items = build_evidence_items(envelope, intake_channel, evidence_text)
+    prov = ArtifactProvenance(
+        intake_channel=intake_channel,
+        correlation_id=str(envelope.correlation_id),
+        trace_id=str(trace_id) if trace_id else None,
+        turn_id=turn_id,
+        evidence_text=evidence_text,
+        evidence_summary=evidence_items[0].summary if evidence_items else None,
+        source_event_refs=[source_event_ref],
+        evidence_items=evidence_items,
+    )
+
+    event = TensionEventV1(
+        artifact_id=_artifact_id(envelope, entity_id, "tension.satisfaction.v1"),
+        subject=subject, model_layer=model_layer, entity_id=entity_id,
+        kind="tension.satisfaction.v1", ts=ts, confidence=1.0,
+        correlation_id=str(envelope.correlation_id),
+        trace_id=str(trace_id) if trace_id else None, turn_id=turn_id,
+        provenance=prov,
+        related_nodes=[f"action_outcome:{outcome.action_id}"] + [f"drive:{d}" for d in weights],
+        magnitude=_ACTION_OUTCOME_RELIEF_MAGNITUDE,
+        drive_impacts=weights,
+    )
+    event.provenance.tension_refs = [event.artifact_id]
+    return [event]

--- a/orion/spark/concept_induction/tests/test_action_outcome_tensions.py
+++ b/orion/spark/concept_induction/tests/test_action_outcome_tensions.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from orion.autonomy.models import ActionOutcomeEmitV1
+from orion.core.bus.bus_schemas import BaseEnvelope, ServiceRef
+from orion.spark.concept_induction.tensions import extract_tensions_from_action_outcome
+
+NOW = datetime(2026, 7, 14, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _envelope() -> BaseEnvelope:
+    return BaseEnvelope(
+        kind="action.outcome.emit.v1",
+        source=ServiceRef(name="orion-execution-dispatch-runtime", version="0.1.0"),
+        payload={},
+    )
+
+
+def _outcome(**overrides) -> ActionOutcomeEmitV1:
+    payload = dict(
+        subject="orion",
+        action_id="dispatch:1",
+        kind="inspect",
+        summary="steady state",
+        success=True,
+        surprise=0.0,
+        observed_at=NOW,
+    )
+    payload.update(overrides)
+    return ActionOutcomeEmitV1(**payload)
+
+
+def test_success_inspect_mints_coherence_relief() -> None:
+    events = extract_tensions_from_action_outcome(
+        envelope=_envelope(), intake_channel="orion:autonomy:action:outcome", outcome=_outcome(kind="inspect")
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event.kind == "tension.satisfaction.v1"
+    assert event.drive_impacts == {"coherence": -0.10}
+    assert event.magnitude > 0.0
+
+
+def test_success_summarize_mints_predictive_relief() -> None:
+    events = extract_tensions_from_action_outcome(
+        envelope=_envelope(), intake_channel="orion:autonomy:action:outcome", outcome=_outcome(kind="summarize")
+    )
+    assert events[0].drive_impacts == {"predictive": -0.10}
+
+
+def test_success_observe_mints_lighter_continuity_relief() -> None:
+    events = extract_tensions_from_action_outcome(
+        envelope=_envelope(), intake_channel="orion:autonomy:action:outcome", outcome=_outcome(kind="observe")
+    )
+    assert events[0].drive_impacts == {"continuity": -0.05}
+    # Lighter than inspect/summarize's relief weight, matching observe's own
+    # lower-stakes design intent from P1.
+    assert abs(events[0].drive_impacts["continuity"]) < 0.10
+
+
+def test_failure_mints_nothing() -> None:
+    events = extract_tensions_from_action_outcome(
+        envelope=_envelope(), intake_channel="orion:autonomy:action:outcome", outcome=_outcome(success=False)
+    )
+    assert events == []
+
+
+def test_unknown_success_mints_nothing() -> None:
+    events = extract_tensions_from_action_outcome(
+        envelope=_envelope(), intake_channel="orion:autonomy:action:outcome", outcome=_outcome(success=None)
+    )
+    assert events == []
+
+
+def test_unmapped_kind_mints_nothing() -> None:
+    events = extract_tensions_from_action_outcome(
+        envelope=_envelope(), intake_channel="orion:autonomy:action:outcome", outcome=_outcome(kind="noop")
+    )
+    assert events == []
+
+
+def test_magnitude_is_positive_direction_lives_in_weight() -> None:
+    """magnitude stays schema-non-negative; the negative weight, not a
+    negative magnitude, is what carries relief through DriveEngine."""
+    event = extract_tensions_from_action_outcome(
+        envelope=_envelope(), intake_channel="orion:autonomy:action:outcome", outcome=_outcome(kind="inspect")
+    )[0]
+    assert event.magnitude >= 0.0
+    assert all(w < 0.0 for w in event.drive_impacts.values())

--- a/orion/spark/concept_induction/tests/test_drives_leaky.py
+++ b/orion/spark/concept_induction/tests/test_drives_leaky.py
@@ -139,6 +139,81 @@ def test_frequent_ticks_do_not_inflate() -> None:
     assert all(p < 1e-6 for p in lp.values()), lp
 
 
+def test_negative_impact_relieves_pressure() -> None:
+    """A relief (negative-weight) tension reduces existing pressure, floored
+    at 0 -- the mandatory companion fix for P3's satisfaction mechanic."""
+    engine = _leaky_engine()
+    # Build up real pressure first.
+    pressures, activations = engine.update(
+        previous_pressures={k: 0.0 for k in DRIVE_KEYS},
+        previous_activations={k: False for k in DRIVE_KEYS},
+        tensions=[_tension({"predictive": 0.9})],
+        now=T0 + timedelta(seconds=10),
+        previous_ts=T0,
+    )
+    before = pressures["predictive"]
+    assert before > 0.0
+
+    # Relief tension, same tick cadence so decay is negligible.
+    pressures, activations = engine.update(
+        previous_pressures=pressures,
+        previous_activations=activations,
+        tensions=[_tension({"predictive": -0.5}, magnitude=0.3)],
+        now=T0 + timedelta(seconds=20),
+        previous_ts=T0 + timedelta(seconds=10),
+    )
+    after = pressures["predictive"]
+    assert after < before
+    assert after >= 0.0
+
+
+def test_relief_floors_at_zero_never_negative() -> None:
+    """A relief impulse larger than the remaining pressure floors at 0, never
+    goes negative -- this must hold even with an extreme relief weight."""
+    engine = _leaky_engine()
+    pressures, activations = engine.update(
+        previous_pressures={k: 0.05 for k in DRIVE_KEYS},
+        previous_activations={k: False for k in DRIVE_KEYS},
+        tensions=[_tension({"coherence": -1.0}, magnitude=1.0)],
+        now=T0 + timedelta(seconds=10),
+        previous_ts=T0,
+    )
+    assert pressures["coherence"] == 0.0
+    assert all(p >= 0.0 for p in pressures.values())
+
+
+def test_relief_at_zero_pressure_is_a_no_op() -> None:
+    """Relief has nothing to relieve when pressure is already at rest --
+    diminishing-effect-toward-floor means this doesn't depend on the outer
+    clamp to "save" a would-be-negative value; the term itself is zero."""
+    engine = _leaky_engine()
+    pressures, _ = engine.update(
+        previous_pressures={k: 0.0 for k in DRIVE_KEYS},
+        previous_activations={k: False for k in DRIVE_KEYS},
+        tensions=[_tension({"relational": -0.8}, magnitude=1.0)],
+        now=T0 + timedelta(seconds=10),
+        previous_ts=T0,
+    )
+    assert pressures["relational"] == 0.0
+
+
+def test_positive_only_tensions_unaffected_by_signed_clamp() -> None:
+    """Regression guard: the [-1,1] signed clamp must be byte-identical to
+    the old [0,1] clamp for any weight that was already non-negative."""
+    engine = _leaky_engine()
+    pressures, _ = engine.update(
+        previous_pressures={k: 0.0 for k in DRIVE_KEYS},
+        previous_activations={k: False for k in DRIVE_KEYS},
+        tensions=[_tension({"capability": 0.6, "coherence": 0.2, "relational": 0.05})],
+        now=T0 + timedelta(seconds=10),
+        previous_ts=T0,
+    )
+    # Exact same assertions as test_no_uniform_pin, unchanged by the clamp fix.
+    assert pressures["capability"] > pressures["coherence"] > pressures["relational"]
+    assert pressures["autonomy"] == 0.0
+    assert all(abs(p - 0.7309) > 0.01 for p in pressures.values()), pressures
+
+
 def test_legacy_path_preserved() -> None:
     """Flag off ⇒ soft_saturate path drives the fixed-point inflation."""
     legacy = DriveEngine(DriveMathConfig(leaky_math_enabled=False))

--- a/services/orion-execution-dispatch-runtime/README.md
+++ b/services/orion-execution-dispatch-runtime/README.md
@@ -102,7 +102,12 @@ docker compose up -d --build
 
 - `GET http://localhost:8121/health`
 - `GET http://localhost:8121/latest` (includes `theater_tripwire_active`)
-- Hub: `GET http://localhost:8080/api/substrate/execution-dispatch/latest`
+- Hub: `GET http://localhost:8080/api/substrate/execution-dispatch/latest` (P6:
+  also includes `status_summary` -- `dispatched_count` / `prepared_for_dispatch_count`
+  / `dry_run_count`, derived purely from the frame's own candidate statuses.
+  Does not surface `theater_tripwire_active`; that's in-process state on the
+  execution-dispatch-runtime service itself, a different process than the hub
+  route serving this summary.)
 
 ## Smoke
 

--- a/services/orion-hub/scripts/substrate_execution_dispatch_routes.py
+++ b/services/orion-hub/scripts/substrate_execution_dispatch_routes.py
@@ -48,9 +48,31 @@ def _load_latest_dispatch_frame() -> ExecutionDispatchFrameV1 | None:
         return None
 
 
+def _dispatch_status_summary(frame: ExecutionDispatchFrameV1) -> dict[str, int]:
+    """Operator-visible breakdown of what actually happened in this frame --
+    P3's "dispatched vs dry_run/prepared_for_dispatch counts" ask. Derived
+    entirely from fields the frame already carries; no new schema fields.
+    theater_tripwire_active is deliberately NOT included here -- that flag
+    is in-process state on orion-execution-dispatch-runtime's own worker,
+    not persisted anywhere this Postgres-only route can reach without a
+    cross-service call (named as a non-goal in the P3 design spec).
+    """
+    dry_run_count = sum(1 for c in frame.candidates if c.dispatch_status == "dry_run")
+    prepared_for_dispatch_count = sum(
+        1 for c in frame.candidates if c.dispatch_status == "prepared_for_dispatch"
+    )
+    return {
+        "dispatched_count": len(frame.dispatched_candidates),
+        "prepared_for_dispatch_count": prepared_for_dispatch_count,
+        "dry_run_count": dry_run_count,
+    }
+
+
 @router.get("/latest")
 async def execution_dispatch_latest() -> dict[str, Any]:
     frame = _load_latest_dispatch_frame()
     if frame is None:
         raise HTTPException(status_code=404, detail="not_found")
-    return frame.model_dump(mode="json")
+    payload = frame.model_dump(mode="json")
+    payload["status_summary"] = _dispatch_status_summary(frame)
+    return payload

--- a/services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py
+++ b/services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py
@@ -81,3 +81,68 @@ def test_latest_not_found(client) -> None:
     ):
         resp = client.get("/api/substrate/execution-dispatch/latest")
     assert resp.status_code == 404
+
+
+def _candidate(status: str, dispatch_id: str) -> dict:
+    return {
+        "dispatch_id": dispatch_id,
+        "source_decision_id": f"pd:{dispatch_id}",
+        "source_proposal_id": f"proposal:{dispatch_id}",
+        "dispatch_status": status,
+        "dispatch_mode": "dispatch_read_only",
+        "dispatch_kind": "inspect",
+        "target_id": "capability:orchestration",
+        "target_kind": "capability",
+        "risk_score": 0.05,
+        "confidence_score": 0.9,
+        **(
+            {"dispatched_at": "2026-07-14T00:00:00+00:00", "result_ref": f"result:{dispatch_id}"}
+            if status == "dispatched"
+            else {}
+        ),
+    }
+
+
+def test_latest_includes_status_summary_counts(client) -> None:
+    sample = _sample_dispatch_frame()
+    sample["candidates"] = [
+        _candidate("dry_run", "d1"),
+        _candidate("dry_run", "d2"),
+        _candidate("prepared_for_dispatch", "d3"),
+    ]
+    sample["dispatched_candidates"] = [_candidate("dispatched", "d4")]
+    sample["dispatch_count"] = 1
+
+    with patch.object(
+        substrate_execution_dispatch_routes,
+        "_load_latest_dispatch_frame",
+        return_value=substrate_execution_dispatch_routes.ExecutionDispatchFrameV1.model_validate(
+            sample
+        ),
+    ):
+        resp = client.get("/api/substrate/execution-dispatch/latest")
+
+    assert resp.status_code == 200
+    summary = resp.json()["status_summary"]
+    assert summary == {
+        "dispatched_count": 1,
+        "prepared_for_dispatch_count": 1,
+        "dry_run_count": 2,
+    }
+
+
+def test_latest_status_summary_all_zero_on_empty_frame(client) -> None:
+    sample = _sample_dispatch_frame()
+    with patch.object(
+        substrate_execution_dispatch_routes,
+        "_load_latest_dispatch_frame",
+        return_value=substrate_execution_dispatch_routes.ExecutionDispatchFrameV1.model_validate(
+            sample
+        ),
+    ):
+        resp = client.get("/api/substrate/execution-dispatch/latest")
+    assert resp.json()["status_summary"] == {
+        "dispatched_count": 0,
+        "prepared_for_dispatch_count": 0,
+        "dry_run_count": 0,
+    }

--- a/services/orion-proposal-runtime/README.md
+++ b/services/orion-proposal-runtime/README.md
@@ -22,6 +22,33 @@ substrate_self_state
 
 One proposal frame per `source_self_state_id`. Re-running the worker for the same self-state snapshot is a no-op. Policy/template changes do not regenerate until a new self-state row exists (v1 semantics).
 
+## Attention-bound proposals (P5)
+
+`ProposalTemplateV1.target_binding` lets a template point at a live field on
+the inbound context instead of a fixed target. The only binding implemented is
+`ATTENTION_FIRST_TARGET_BINDING = "self_state.dominant_attention_targets[0]"`
+(`orion/proposals/builder.py`): `_resolve_binding_target()` reads
+`SelfStateV1.dominant_attention_target_details[0]` and only resolves when its
+`target_kind` is one of `node`, `capability`, `field`, `system` (the exact
+intersection of `AttentionTargetSummaryV1.target_kind` and
+`ProposalCandidateV1.target_kind`'s allowed values). `_resolve_binding_target`
+never raises -- an empty attention list, an unbound template, or an
+unsupported `target_kind` all fall through to the template's existing static
+target with no candidate produced for that template. `ProposalCandidateV1`
+gains `binding_resolved_from` so a resolved candidate is traceable back to the
+attention target it bound to.
+
+`config/proposals/proposal_policy.v1.yaml`'s `inspect_attended_target`
+template uses this binding and ships **live** (`base_priority: 0.34`, not
+dark-shipped at 0.0). The YAML comment on that template documents a 7-day kill
+criterion. `orion/autonomy/evals/run_attention_bound_proposal_eval.py` checks
+that criterion against real proposal-frame data and reports "insufficient
+data" gracefully if the template hasn't accumulated enough candidates yet:
+
+```bash
+python orion/autonomy/evals/run_attention_bound_proposal_eval.py
+```
+
 ## Run
 
 ```bash

--- a/services/orion-spark-concept-induction/.env_example
+++ b/services/orion-spark-concept-induction/.env_example
@@ -16,7 +16,7 @@ HEARTBEAT_INTERVAL_SEC=10
 LOG_LEVEL=INFO
 
 # Channels
-BUS_INTAKE_CHANNELS=["orion:chat:history:log","orion:chat:history:turn","orion:chat:social:turn","orion:chat:social:stored","orion:chat:gpt:turn","orion:chat:gpt:message:log","orion:collapse:sql-write","orion:spark:telemetry","orion:metacognition:tick","orion:cognition:trace","orion:substrate:self_state","orion:feedback:frame","orion:world_pulse:run:result"]
+BUS_INTAKE_CHANNELS=["orion:chat:history:log","orion:chat:history:turn","orion:chat:social:turn","orion:chat:social:stored","orion:chat:gpt:turn","orion:chat:gpt:message:log","orion:collapse:sql-write","orion:spark:telemetry","orion:metacognition:tick","orion:cognition:trace","orion:substrate:self_state","orion:feedback:frame","orion:world_pulse:run:result","orion:autonomy:action:outcome"]
 BUS_PROFILE_OUT=orion:spark:concepts:profile
 BUS_DELTA_OUT=orion:spark:concepts:delta
 BUS_VECTOR_OUT=orion:vector:write

--- a/services/orion-spark-concept-induction/README.md
+++ b/services/orion-spark-concept-induction/README.md
@@ -16,7 +16,7 @@ Health check: http://localhost:8510/health
 
 Key knobs:
 
-- `BUS_INTAKE_CHANNELS`: JSON list of channels to watch (defaults: chat history, collapse mirror, memory episodes)
+- `BUS_INTAKE_CHANNELS`: JSON list of channels to watch (defaults: chat history, collapse mirror, memory episodes). **This is a full replace, not a merge**: `ConceptSettings` reads it via a `validation_alias`, so setting the env var overrides the Python default list entirely rather than adding to it. Adding a new intake channel to the code default alone does nothing in any environment where `BUS_INTAKE_CHANNELS` is set (`.env_example` and every deployed `.env` set it) -- the new channel must also be added to every `.env`/`.env_example` that sets this key, or the subscription is a silent no-op.
 - `BUS_PROFILE_OUT`: profile publish channel (kind `memory.concepts.profile.v1`)
 - `BUS_DELTA_OUT`: delta publish channel (kind `memory.concepts.delta.v1`)
 - `SPACY_MODEL`: spaCy model name (default `en_core_web_sm`)
@@ -48,3 +48,51 @@ merges or picks a winner between them, and it always exits 0.
 python scripts/drive_state_divergence_audit.py
 python scripts/drive_state_divergence_audit.py --json
 ```
+
+## Satisfaction tensions (drive relief)
+
+`DriveEngine.update()` supports signed drive impacts: a `TensionEventV1` with a
+negative `drive_impacts` weight *relieves* pressure instead of raising it
+(`_clamp_signed` to `[-1, 1]`, then the leaky-math formula branches on impulse
+sign so relief is bounded to `[0, base]` and growth to `[base, 1]` -- relief can
+never push a drive negative or growth push it past 1). Prior to this, negative
+weights were silently double-clamped to zero and had no effect, so drives could
+only ever accumulate pressure, never discharge it from a successful action.
+
+`orion:autonomy:action:outcome` (published by Layer-9 dispatch on every
+autonomous action, see `services/orion-execution-dispatch-runtime`) is
+subscribed here specifically to close that loop:
+`extract_tensions_from_action_outcome` (`orion/spark/concept_induction/tensions.py`)
+mints a relief tension when `outcome.success is True` for a closed set of
+dispatch kinds (`inspect` relieves `coherence`, `summarize` relieves
+`predictive`, `observe` relieves `continuity` -- unmapped kinds mint nothing).
+`bus_worker.py` filters out envelopes this service itself published
+(`source.name == self.cfg.service_name`) before parsing, since this service is
+also a downstream consumer of channels it doesn't produce here but could in a
+replay/backfill scenario.
+
+Known accepted risk: `extract_tensions_from_feedback` (fires on Postgres-polled
+failure) and `extract_tensions_from_action_outcome` (fires on bus-emitted
+success) are independently-computed classifications of the same Layer-9
+dispatch from two separate pipelines. A dispatch that the feedback path scores
+as failed/mixed while the outcome-emit reports `success=True` can fire both a
+growth and a relief tension for the same event. Not coordinated across
+pipelines in this patch -- named here as a follow-up, not fixed.
+
+## Readonly capabilities (recall.query.readonly, P4)
+
+`ConceptWorker` (`bus_worker.py`) is the sole production call site for
+`orion.autonomy.policy_act.maybe_execute_substrate_act_after_metabolism`. That
+function gates two readonly capabilities under `config/autonomy/capability_policy.v1.yaml`
+per cycle -- a Firecrawl fetch and (new) an inline `RecallService` RPC
+(`_execute_readonly_recall` / `maybe_execute_readonly_recall_after_goal` in
+`orion/autonomy/policy_act.py`) -- and tries recall first: a successful recall
+leaves that cycle's fetch budget unconsumed. Both capabilities require the
+caller to pass `recall_bus`/`recall_source` (this worker's own `self.bus` and
+service identity); the function degrades to a no-op recall attempt if either
+is `None`, so wiring the kwargs at the call site is load-bearing, not
+cosmetic. A successful recall populates `SubstrateActResultV1.recall_outcome`
+(mirroring `fetch_outcome`) and is published through the same
+`ActionOutcomeEmitV1` → sql-writer path a fetch success uses, so it reaches
+durable SQL storage rather than only the local file-store fallback inside
+`_execute_readonly_recall`.

--- a/tests/test_execution_dispatch_bus_catalog.py
+++ b/tests/test_execution_dispatch_bus_catalog.py
@@ -31,3 +31,12 @@ def test_execution_dispatch_runtime_is_action_outcome_producer() -> None:
     assert "orion-sql-writer" in entry["consumer_services"]
     assert "orion-spark-concept-induction" in (entry.get("producer_services") or [])
     assert "orion-execution-dispatch-runtime" in (entry.get("producer_services") or [])
+
+
+def test_concept_induction_is_recall_service_request_producer() -> None:
+    """recall.query.readonly (P4): the autonomy tick issues an inline recall RPC
+    from orion-spark-concept-induction's ConceptWorker before the readonly fetch."""
+    entry = _channel_entry("orion:exec:request:RecallService")
+    assert entry["schema_id"] == "RecallQueryV1"
+    assert entry["consumer_services"] == ["orion-recall"]
+    assert "orion-spark-concept-induction" in (entry.get("producer_services") or [])

--- a/tests/test_proposal_frame_builder.py
+++ b/tests/test_proposal_frame_builder.py
@@ -1,9 +1,14 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
-from orion.proposals.builder import build_proposal_frame, stable_proposal_frame_id
-from orion.proposals.policy import load_proposal_policy
-from orion.schemas.self_state import SelfStateDimensionV1, SelfStateV1
+from orion.proposals.builder import (
+    ATTENTION_FIRST_TARGET_BINDING,
+    _build_candidate,
+    build_proposal_frame,
+    stable_proposal_frame_id,
+)
+from orion.proposals.policy import ProposalTemplateV1, load_proposal_policy
+from orion.schemas.self_state import AttentionTargetSummaryV1, SelfStateDimensionV1, SelfStateV1
 
 REPO = Path(__file__).resolve().parents[1]
 POLICY = load_proposal_policy(REPO / "config" / "proposals" / "proposal_policy.v1.yaml")
@@ -155,3 +160,125 @@ def test_suppressed_candidates_separate() -> None:
     active_ids = {c.proposal_id for c in frame.candidates}
     suppressed_ids = {c.proposal_id for c in frame.suppressed_candidates}
     assert active_ids.isdisjoint(suppressed_ids)
+
+
+# --- P5: attention-bound proposal target binding -----------------------------
+
+_BINDING_TEMPLATE = ProposalTemplateV1(
+    kind="inspect",
+    target_kind="capability",
+    target_id="capability:orchestration",
+    target_binding=ATTENTION_FIRST_TARGET_BINDING,
+    proposed_effect="increase_observability",
+    required_policy_gate="read_only",
+    base_priority=0.34,
+    base_risk=0.05,
+    reversibility=1.0,
+    dimensions={"field_intensity": 0.30},
+)
+
+
+def _self_state_with_attention_details(
+    details: list[AttentionTargetSummaryV1],
+) -> SelfStateV1:
+    state = _loaded_self_state()
+    return state.model_copy(update={"dominant_attention_target_details": details})
+
+
+def test_binding_resolves_target_from_attention_details() -> None:
+    details = [
+        AttentionTargetSummaryV1(
+            target_id="node:mycelium",
+            target_kind="node",
+            pressure_score=0.8,
+        ),
+        AttentionTargetSummaryV1(
+            target_id="capability:orchestration",
+            target_kind="capability",
+            pressure_score=0.5,
+        ),
+    ]
+    candidate = _build_candidate(
+        template_key="inspect_attended_target",
+        template=_BINDING_TEMPLATE,
+        self_state=_self_state_with_attention_details(details),
+        attention=None,
+        policy=POLICY,
+    )
+    assert candidate.target_id == "node:mycelium"
+    assert candidate.target_kind == "node"
+    assert candidate.binding_resolved_from == ATTENTION_FIRST_TARGET_BINDING
+
+
+def test_binding_falls_back_to_literal_when_details_empty() -> None:
+    candidate = _build_candidate(
+        template_key="inspect_attended_target",
+        template=_BINDING_TEMPLATE,
+        self_state=_self_state_with_attention_details([]),
+        attention=None,
+        policy=POLICY,
+    )
+    assert candidate.target_id == _BINDING_TEMPLATE.target_id
+    assert candidate.target_kind == _BINDING_TEMPLATE.target_kind
+    assert candidate.binding_resolved_from is None
+
+
+def test_binding_falls_back_to_literal_when_kind_unaccepted() -> None:
+    # "channel" is a valid AttentionTargetSummaryV1.target_kind but is not in
+    # ProposalCandidateV1's target_kind Literal -- must fail closed, not raise.
+    details = [
+        AttentionTargetSummaryV1(
+            target_id="channel:orion.bus.thoughts",
+            target_kind="channel",
+            pressure_score=0.7,
+        ),
+    ]
+    candidate = _build_candidate(
+        template_key="inspect_attended_target",
+        template=_BINDING_TEMPLATE,
+        self_state=_self_state_with_attention_details(details),
+        attention=None,
+        policy=POLICY,
+    )
+    assert candidate.target_id == _BINDING_TEMPLATE.target_id
+    assert candidate.target_kind == _BINDING_TEMPLATE.target_kind
+    assert candidate.binding_resolved_from is None
+
+
+def test_binding_resolved_from_none_for_non_binding_template() -> None:
+    template = POLICY.proposal_templates["inspect_execution_pressure"]
+    assert template.target_binding is None
+    candidate = _build_candidate(
+        template_key="inspect_execution_pressure",
+        template=template,
+        self_state=_loaded_self_state(),
+        attention=None,
+        policy=POLICY,
+    )
+    assert candidate.binding_resolved_from is None
+    assert candidate.target_id == template.target_id
+
+
+def test_build_proposal_frame_includes_binding_resolved_candidate() -> None:
+    details = [
+        AttentionTargetSummaryV1(
+            target_id="field:recent_perturbations",
+            target_kind="field",
+            pressure_score=0.9,
+        ),
+    ]
+    frame = build_proposal_frame(
+        self_state=_self_state_with_attention_details(details),
+        attention=None,
+        field=None,
+        policy=POLICY,
+        now=NOW,
+    )
+    attended = [
+        c for c in frame.candidates + frame.suppressed_candidates
+        if c.proposal_id.startswith("proposal:inspect_attended_target:")
+    ]
+    assert len(attended) == 1
+    assert attended[0].binding_resolved_from == ATTENTION_FIRST_TARGET_BINDING
+    assert attended[0].target_id == "field:recent_perturbations"
+    assert attended[0].target_kind == "field"

--- a/tests/test_proposal_policy_loader.py
+++ b/tests/test_proposal_policy_loader.py
@@ -48,3 +48,22 @@ def test_inspect_field_topology_catalog_template_targets_field() -> None:
     assert tmpl.target_kind == "field"
     assert tmpl.target_id == "config/field/orion_field_topology.v1.yaml"
     assert "field_intensity" in tmpl.dimensions
+
+
+def test_inspect_attended_target_template_has_attention_binding() -> None:
+    policy = load_proposal_policy(POLICY_PATH)
+    tmpl = policy.proposal_templates["inspect_attended_target"]
+    assert tmpl.kind == "inspect"
+    assert tmpl.target_kind == "capability"
+    assert tmpl.target_id == "capability:orchestration"
+    assert tmpl.target_binding == "self_state.dominant_attention_targets[0]"
+    assert tmpl.required_policy_gate == "read_only"
+    assert "field_intensity" in tmpl.dimensions
+
+
+def test_other_templates_have_no_target_binding() -> None:
+    policy = load_proposal_policy(POLICY_PATH)
+    for key, tmpl in policy.proposal_templates.items():
+        if key == "inspect_attended_target":
+            continue
+        assert tmpl.target_binding is None


### PR DESCRIPTION
# PR report: P3-P5 -- drive satisfaction, recall.query.readonly capability, attention-bound proposals

Branch: `feat/autonomy-satisfaction-capabilities-attention-p3-p5`
Series: endogenous action motor-nerve (P0 → P7), see `docs/superpowers/specs/2026-07-14-autonomy-p3-p5-design.md`

## Summary

- **P3**: `DriveEngine.update()` can now represent relief, not just growth --
  negative `drive_impacts` weights were silently double-clamped to zero
  before this patch, so drives could only ever accumulate pressure. Fixed
  with a signed clamp + sign-branched leaky-math formula.
- **P3**: `orion-spark-concept-induction` now subscribes to
  `orion:autonomy:action:outcome` (already published by Layer-9 dispatch) and
  mints a relief tension on successful dispatch of `inspect`/`summarize`/`observe`
  actions -- the first closed loop where an autonomous action can satisfy the
  drive that motivated it, not just accumulate more pressure toward the next one.
- **P4**: New `recall.query.readonly` capability -- before falling back to a
  Firecrawl web fetch, the metabolism loop now tries an internal RecallService
  query first. A recall hit leaves that cycle's fetch budget unconsumed.
- **P5**: `ProposalTemplateV1.target_binding` lets a template resolve its
  target from live context instead of a fixed value. One binding shipped:
  `dominant_attention_targets[0]`, wired into a new `inspect_attended_target`
  template that ships live (not dark-shipped) with a documented 7-day kill
  criterion and a standalone eval script.
- **P6** (folded in from the prior session): `/latest`'s `status_summary`
  field (dispatched/prepared/dry-run counts) on the hub's execution-dispatch
  debug route.
- Code review found and fixed two CRITICAL dead-wiring bugs -- both P3 and P4
  would otherwise have shipped fully built and fully unit-tested but
  structurally unreachable at runtime (see Review findings below).

## Outcome moved

Before this patch, Orion's drive/tension system was strictly one-directional:
every tension only ever raised pressure, and nothing an autonomous action did
could lower it. `DriveEngine` had no code path capable of representing
relief at all -- it wasn't a policy choice, the math structurally clamped
negative impacts to zero. This patch makes successful autonomous action
(Layer-9 dispatch) capable of satisfying the drive that motivated it, and
gives the metabolism loop an internal-memory-first option before it reaches
for the external web.

## Current architecture

Before this patch:
- `DriveEngine.update()` (`orion/spark/concept_induction/drives.py`) computed
  `impact_sum[drive] += mag * self._clamp01(weight)` -- `_clamp01` clamps to
  `[0,1]`, so any negative `drive_impacts` weight became `0` before it ever
  reached the pressure formula. The leaky-math pressure update itself,
  `pressures[drive] = base + impulse*(1-base)`, is also monotonically
  non-decreasing in `impulse` for `impulse >= 0` -- there was no formula
  branch for relief even if a negative impulse had survived the first clamp.
- `TensionRateLimiter._signature()` filtered on `weight > 0.0`, so any
  hypothetical negative-weight tension would have collided into a shared
  empty-tuple rate-limit bucket with every other relief tension regardless
  of which drive it targeted.
- `maybe_execute_substrate_act_after_metabolism` (`orion/autonomy/policy_act.py`)
  had exactly one capability: a Firecrawl fetch gated by capability policy.
- `ProposalTemplateV1`/`ProposalCandidateV1` had no way to point a template
  at context-derived data; every template's target was a fixed literal.
- The hub's execution-dispatch `/latest` route returned the raw frame with no
  aggregate counts; a caller had to count candidate statuses itself.

## Architecture touched

- `orion/spark/concept_induction/drives.py` -- signed-impact clamp + relief-capable pressure formula.
- `orion/autonomy/tension_ratelimit.py` -- signature filter widened to `weight != 0.0`.
- `orion/spark/concept_induction/tensions.py` -- new `extract_tensions_from_action_outcome`.
- `orion/spark/concept_induction/settings.py`, `bus_worker.py` -- new intake channel, dispatch branch, self-publish filter, skip-set entry.
- `orion/autonomy/models.py` -- `SubstrateActResultV1` gains `recall_attempted`/`recall_outcome`.
- `orion/autonomy/policy_act.py` -- `_execute_readonly_recall`, `maybe_execute_readonly_recall_after_goal`, recall-first wiring into the metabolism gate.
- `config/autonomy/capability_policy.v1.yaml` -- new `recall.query.readonly` rule.
- `orion/bus/channels.yaml` -- `orion-spark-concept-induction` added as a producer on `orion:exec:request:RecallService`.
- `orion/proposals/policy.py`, `orion/proposals/builder.py`, `orion/schemas/proposal_frame.py` -- `target_binding`/`binding_resolved_from`, `_resolve_binding_target`.
- `config/proposals/proposal_policy.v1.yaml` -- new `inspect_attended_target` template, live.
- `orion/autonomy/evals/run_attention_bound_proposal_eval.py` -- new kill-criterion eval.
- `services/orion-hub/scripts/substrate_execution_dispatch_routes.py` -- `_dispatch_status_summary`.
- READMEs: `orion-spark-concept-induction`, `orion-proposal-runtime`, `orion-execution-dispatch-runtime`.
- `services/orion-spark-concept-induction/.env_example` -- `BUS_INTAKE_CHANNELS` gains `orion:autonomy:action:outcome`.

## Files changed

- `orion/spark/concept_induction/drives.py`: signed clamp + sign-branched pressure formula so relief is representable and bounded.
- `orion/spark/concept_induction/tests/test_drives_leaky.py`: 4 new tests for relief math + a positive-only regression guard.
- `orion/autonomy/tension_ratelimit.py`: `w > 0.0` → `w != 0.0` in `_signature()` so relief tensions get their own budget.
- `orion/autonomy/tests/test_tension_ratelimit.py`: 2 new tests for negative-weight signatures.
- `orion/spark/concept_induction/tensions.py`: `extract_tensions_from_action_outcome`, closed kind→drive relief map (`inspect`→coherence, `summarize`→predictive, `observe`→continuity), fires only on `success is True`.
- `orion/spark/concept_induction/tests/test_action_outcome_tensions.py` (new): 7 tests covering all three kinds, failure/no-fire cases, unmapped kinds, magnitude/direction assertions.
- `orion/spark/concept_induction/settings.py`: `orion:autonomy:action:outcome` added to `intake_channels`'s Python default.
- `orion/spark/concept_induction/bus_worker.py`: dispatch branch for `action.outcome.emit.v1`, self-publish filter, skip-set entry, **and** (review fix) the sole `maybe_execute_substrate_act_after_metabolism` call site now passes `recall_bus`/`recall_source`, **and** a new publish block for `act_result.recall_outcome` mirroring the existing `fetch_outcome` block.
- `orion/autonomy/models.py`: `SubstrateActResultV1.recall_attempted`/`recall_outcome` (review fix, mirrors `fetch_attempted`/`fetch_outcome`).
- `orion/autonomy/policy_act.py`: `_execute_readonly_recall`, `maybe_execute_readonly_recall_after_goal` (P4); recall-first check wired into `maybe_execute_substrate_act_after_metabolism` with its own UUID-correlation_id fix; (review fix) now populates `recall_attempted`/`recall_outcome` on every attempt, independent of whether it succeeded enough to skip the fetch.
- `orion/autonomy/tests/test_policy_act.py`: existing recall-hit/recall-miss tests extended with `recall_attempted`/`recall_outcome` assertions (review fix regression coverage).
- `config/autonomy/capability_policy.v1.yaml`: `recall.query.readonly` rule -- readonly, auto_execute, `requires_goal_status: proposed`, `required_drive_origins: [predictive]`, `required_signal_kinds: [world_coverage_gap]`, `budget_per_cycle: 2`.
- `orion/bus/channels.yaml`: `orion-spark-concept-induction` added to `orion:exec:request:RecallService`'s `producer_services`.
- `orion/proposals/policy.py`: `ProposalTemplateV1.target_binding: str | None = None`.
- `orion/schemas/proposal_frame.py`: `ProposalCandidateV1.binding_resolved_from: str | None = None`.
- `orion/proposals/builder.py`: `ATTENTION_FIRST_TARGET_BINDING` constant, `_ATTENTION_BOUND_TARGET_KINDS` frozenset, `_resolve_binding_target()` (never raises).
- `config/proposals/proposal_policy.v1.yaml`: `inspect_attended_target` template, `base_priority: 0.34`, live with a documented 7-day kill criterion in comments.
- `orion/autonomy/evals/run_attention_bound_proposal_eval.py` (new): kill-criterion eval, handles insufficient data gracefully.
- `tests/test_proposal_frame_builder.py`, `tests/test_proposal_policy_loader.py`: binding-resolution + template-loading coverage.
- `services/orion-hub/scripts/substrate_execution_dispatch_routes.py`: `_dispatch_status_summary()`, wired into `/latest`.
- `services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py`: 2 new tests.
- `services/orion-spark-concept-induction/.env_example`: `BUS_INTAKE_CHANNELS` gains `orion:autonomy:action:outcome` (review fix, see Env/config changes).
- `docs/superpowers/specs/2026-07-14-autonomy-p3-p5-design.md`: design spec, documents why the original P3 brainstorm plan (a `drive_origin` bridge) was wrong -- no such bridge exists between the proposal/goal pipeline and Layer-9 dispatch, they're structurally separate pipelines -- and the chosen alternative seam (subscribe to the existing `action:outcome` channel).
- READMEs: `services/orion-spark-concept-induction/README.md`, `services/orion-proposal-runtime/README.md`, `services/orion-execution-dispatch-runtime/README.md`.

## Schema / bus / API changes

- Added: `orion.autonomy.models.SubstrateActResultV1.recall_attempted: bool`, `.recall_outcome: ActionOutcomeRefV1 | None`.
- Added: `orion.proposals.policy.ProposalTemplateV1.target_binding: str | None`.
- Added: `orion.schemas.proposal_frame.ProposalCandidateV1.binding_resolved_from: str | None`.
- Added: consumer subscription -- `orion-spark-concept-induction` now consumes `orion:autonomy:action:outcome` (already an existing, already-published channel; this is a new consumer, not a new channel).
- Added: producer registration -- `orion-spark-concept-induction` added to `orion:exec:request:RecallService`'s `producer_services` in `orion/bus/channels.yaml`.
- Added: `status_summary` field on the hub's `GET /api/substrate/execution-dispatch/latest` response (`dispatched_count`, `prepared_for_dispatch_count`, `dry_run_count`).
- Removed: none.
- Renamed: none.
- Behavior changed: `DriveEngine.update()` now accepts negative `drive_impacts` weights and applies relief instead of clamping them to a zero-effect no-op. This is additive for every existing (non-negative-weight) producer -- verified by running the full pre-existing drive test suite unchanged before adding new tests, and by the `test_positive_only_tensions_unaffected_by_signed_clamp` regression guard.
- Compatibility notes: `TensionRateLimiter`'s rate-limit signature space grew (relief tensions now get distinct signatures instead of colliding into one shared bucket) -- this only affects tensions with negative weights, of which there were previously none in production, so no existing rate-limit behavior changes.

## Env/config changes

- Added keys: none (no new env var name).
- Removed keys: none.
- Renamed keys: none.
- **Changed key value** (`.env_example` updated): `BUS_INTAKE_CHANNELS` gains `"orion:autonomy:action:outcome"` in `services/orion-spark-concept-induction/.env_example`.
- local `.env` synced: **N/A -- no local `.env` exists in this worktree** (checked: `services/orion-spark-concept-induction/.env` does not exist here). `scripts/sync_local_env_from_example.py` has nothing to do in this worktree.
- **Skipped keys requiring operator action**: the **live, deployed** `.env` for `orion-spark-concept-induction` (in the shared main checkout, which this session does not write to directly per the established "main checkout is shared across concurrent sessions" rule) almost certainly still has the old `BUS_INTAKE_CHANNELS` value, because `Pydantic`'s `List[str]` field with a `validation_alias` **replaces** the Python code default entirely when the env var is set -- it does not merge. **Until an operator applies this change to the live `.env`, P3's entire satisfaction-tension pipeline (the DriveEngine relief fix, the new tension extractor, the self-publish filter) is built, tested, and reviewed, but the worker will never actually subscribe to the channel that feeds it.**

  Required operator action -- add `"orion:autonomy:action:outcome"` to the existing `BUS_INTAKE_CHANNELS` JSON list in the live `services/orion-spark-concept-induction/.env`:
  ```
  BUS_INTAKE_CHANNELS=["orion:chat:history:log","orion:chat:history:turn","orion:chat:social:turn","orion:chat:social:stored","orion:chat:gpt:turn","orion:chat:gpt:message:log","orion:collapse:sql-write","orion:spark:telemetry","orion:metacognition:tick","orion:cognition:trace","orion:substrate:self_state","orion:feedback:frame","orion:world_pulse:run:result","orion:autonomy:action:outcome"]
  ```
  Confirmed via `scripts/check_service_env_compose_parity.py orion-spark-concept-induction`: this service's `docker-compose.yml` uses `env_file:`, so the full `.env` reaches the container regardless of the `environment:` list -- the only gap is the `.env` file's own content, not compose wiring.

## Tests run

```text
$SCRATCH/p3p5-venv/bin/python -m pytest orion/spark/concept_induction/tests orion/autonomy/tests -q \
  --deselect orion/autonomy/tests/test_autonomy_isolation.py::test_autonomy_state_v2_not_wired_into_phi_or_self_state
347 passed, 1 deselected, 24 warnings in 15.17s

$SCRATCH/p3p5-venv/bin/python -m pytest \
  services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py \
  tests/test_proposal_frame_builder.py \
  tests/test_proposal_policy_loader.py \
  tests/test_execution_dispatch_bus_catalog.py \
  orion/autonomy/tests/test_capability_policy.py \
  orion/autonomy/tests/test_capability_policy_models.py \
  orion/autonomy/tests/test_policy_act.py \
  orion/autonomy/tests/test_policy_act_prefetched.py \
  -q
66 passed, 2 warnings in 2.55s
```

Deselected test is pre-existing and unrelated: `test_autonomy_state_v2_not_wired_into_phi_or_self_state`
fails identically on `origin/main` (verified via `git stash` + rerun, and by
inspecting `git show origin/main:orion/self_state/inner_state_registry.py`,
a file untouched by this branch or either subagent). Independently confirmed
by the code-review agent.

**Environment note**: the shared `/tmp/orion-test-venv` had numpy upgraded to
`2.5.1` by a concurrent session, breaking `thinc`'s compiled Cython extension
ABI (`ValueError: numpy.dtype size changed`) and making every test that
imports `spacy` uncollectable. `orion-spark-concept-induction/requirements.txt`
pins `numpy==1.26.4`. Rather than downgrade the shared venv (would risk
breaking whatever the concurrent session needs 2.5.1 for), copied it to an
isolated scratch venv and pinned numpy there. All numbers above are from that
isolated venv; the shared venv was not modified.

## Evals run

```text
python orion/autonomy/evals/run_attention_bound_proposal_eval.py
```

Not run live in this session -- requires an accumulation window of real
`inspect_attended_target` candidates against a live proposal-runtime deployment
to evaluate the 7-day kill criterion meaningfully; running it against an
empty/synthetic local DB would only exercise the "insufficient data" path,
which is not a meaningful eval result. This is the standing eval for judging
whether the template should be kept, tuned, or killed once live data
accumulates -- flagging as a follow-up check for 7 days post-merge, not a
gap in this PR.

No dedicated eval harness exists yet for the P3 satisfaction-tension path or
the P4 recall capability; the unit test suites above (`test_drives_leaky.py`,
`test_action_outcome_tensions.py`, `test_policy_act.py`) are the coverage
for those tracks.

## Docker/build/smoke checks

Docker was not run in this environment. Ran the deterministic non-Docker
checks that substitute for it:

```text
$SCRATCH/p3p5-venv/bin/python scripts/check_service_env_compose_parity.py orion-spark-concept-induction
→ N/A: service declares env_file:, all 110 .env_example keys reach the container
  regardless of the environment: list.

ORION_BUS_URL=redis://100.92.216.81:6379/0 \
  $SCRATCH/p3p5-venv/bin/python scripts/check_single_consumer_channels.py
→ single_consumer gate OK: 31 channel(s) checked, 3 warning(s) (pre-existing,
  zero-subscriber channels unrelated to this patch). orion:exec:request:RecallService
  reports OK 1 -- confirms P4's new producer registration on that channel did
  not create a fan-out/multi-consumer collision.

git diff --check origin/main..HEAD
→ clean, exit 0
```

## Review findings fixed

- Finding: `BUS_INTAKE_CHANNELS`'s Pydantic `validation_alias` **replaces**
  the Python default list rather than merging with it when the env var is
  set -- and it is set in both `.env_example` and every deployed `.env`.
  Adding the new channel to `settings.py`'s code default alone was a
  structural no-op in every real environment.
  - Fix: updated `.env_example`; documented the replace-not-merge behavior
    directly in the README so it's not rediscovered the hard way again;
    flagged the live-`.env` operator action prominently above.
  - Evidence: `check_service_env_compose_parity.py` confirms the container
    reads the full `.env`; the remaining gap is the live file's content,
    named explicitly as an operator action rather than silently assumed done.

- Finding: `bus_worker.py`'s one production call site to
  `maybe_execute_substrate_act_after_metabolism` never passed the
  `recall_bus`/`recall_source` kwargs P4's function signature added --
  `_execute_readonly_recall`'s `if bus is None: return decision, None` guard
  degraded gracefully and silently before any RPC fired. P4 was fully built
  and fully unit-tested but unreachable in the one place it actually runs.
  - Fix: call site now passes `recall_bus=self.bus, recall_source=_service_ref(self.cfg)`.
  - Evidence: `test_policy_act.py`'s recall-hit/recall-miss tests exercise
    the function directly with a real bus; the call-site fix is a one-line
    diff verifiable by inspection against `bus_worker.py`'s single call site.

- Finding: a successful recall was recorded only via
  `_execute_readonly_recall`'s local `append_action_outcome` file-store
  fallback, never reaching the bus-emit → sql-writer → durable-SQL path a
  fetch success uses -- `SubstrateActResultV1` had no field to carry it, so
  `bus_worker.py`'s existing `if act_result.fetch_outcome is not None:`
  publish block could never see it.
  - Fix: `SubstrateActResultV1` gains `recall_attempted`/`recall_outcome`
    (mirrors `fetch_attempted`/`fetch_outcome`); `policy_act.py` populates
    them on every recall attempt; `bus_worker.py` gains a parallel publish
    block for `recall_outcome`.
  - Evidence: extended `test_substrate_act_recall_hit_skips_fetch_budget`
    and `test_substrate_act_recall_miss_falls_through_to_fetch` with direct
    assertions on `recall_attempted`/`recall_outcome`; both pass.

- Finding (documented, not fixed -- accepted risk): `extract_tensions_from_feedback`
  (Postgres-polled failure path) and `extract_tensions_from_action_outcome`
  (bus-emitted success path) are independently-computed classifications of
  the same Layer-9 dispatch from two separate pipelines. A dispatch the
  feedback path scores failed/mixed while the outcome-emit reports
  `success=True` can fire both a growth and a relief tension for the same
  event. Coordinating across both pipelines is out of scope for this patch's
  size -- documented in the concept-induction README and here as a named
  follow-up.

- Findings (documented, not fixed -- cleanup only, not bugs): `_clamp_signed`
  duplicates `orion/signals/normalization.py`'s existing `clamp11`;
  `_execute_readonly_recall` duplicates ~60 lines of RPC boilerplate from
  `recall_prefetch.py`; `maybe_execute_readonly_recall_after_goal` duplicates
  ~35 lines of gate logic from `maybe_execute_readonly_fetch_after_goal`. All
  three are candidates for a follow-up dedup pass; none change behavior or
  correctness, so deferred rather than expanding this patch's surface area.

## Restart required

```bash
docker compose \
  --env-file .env \
  --env-file services/orion-spark-concept-induction/.env \
  -f services/orion-spark-concept-induction/docker-compose.yml \
  up -d --build orion-spark-concept-induction

docker compose \
  --env-file .env \
  --env-file services/orion-proposal-runtime/.env \
  -f services/orion-proposal-runtime/docker-compose.yml \
  up -d --build orion-proposal-runtime

docker compose \
  --env-file .env \
  --env-file services/orion-hub/.env \
  -f services/orion-hub/docker-compose.yml \
  up -d --build orion-hub
```

`orion-execution-dispatch-runtime` itself has no code changes in this patch
(only its README changed) -- no restart needed for that service.

**Before restarting `orion-spark-concept-induction`, apply the live-`.env`
operator action documented under Env/config changes above** -- restarting
with the old `BUS_INTAKE_CHANNELS` value ships P3's code with the
subscription still missing.

## Risks / concerns

- Severity: HIGH (operator-action-dependent, not code-dependent)
  Concern: P3's satisfaction-tension pipeline is inert until the live `.env`'s
  `BUS_INTAKE_CHANNELS` is updated by an operator (this session did not and
  should not write to the shared main checkout's live `.env` directly).
  Mitigation: exact key/value diff provided above; `check_service_env_compose_parity.py`
  confirms no other config surface (compose `environment:` list) needs a
  matching change.

- Severity: MEDIUM (accepted, named)
  Concern: double-tension-fire risk between the feedback-frame and
  action-outcome pipelines on disagreeing success/failure classifications of
  the same dispatch.
  Mitigation: documented in the concept-induction README; cross-pipeline
  coordination deferred as a follow-up, not silently ignored.

- Severity: LOW
  Concern: three cleanup/duplication findings from review (`_clamp_signed`,
  `_execute_readonly_recall`, `maybe_execute_readonly_recall_after_goal`)
  left unaddressed.
  Mitigation: none needed for correctness; candidates for a follow-up dedup
  patch if this pattern keeps recurring.

- Severity: LOW
  Concern: `run_attention_bound_proposal_eval.py`'s 7-day kill criterion has
  not been evaluated against live data yet (the template only just shipped).
  Mitigation: eval script exists and handles the pre-accumulation window
  gracefully; run it 7 days after this merges.
