### PR TITLE
Feat/drive history identity reflection

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-14-drive-history-reflection-synthesis-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-drive-history-reflection-synthesis-pr.md
@@ -1,0 +1,108 @@
+# PR report: drive-history reflection synthesis (weekly-cadence self-modeling batch job)
+
+## Summary
+
+- New `scripts/drive_history_reflection_synthesis.py`: reads Orion's real, persisted drive-activation history from the Fuseki `drives` graph (append-only per-tick `DriveAuditV1` artifacts — the only genuine historical time-series of this signal in the repo; the two "latest value only" stores investigated in earlier rounds today have no history) and synthesizes ONE narrative observation about a long-horizon drive pattern into a `reflection`-kind crystallization.
+- Built with an explicit two-stage architecture per AGENTS.md's event-substrate-first mandate: a **pure, unit-tested deterministic reducer** (`reduce_drive_history()`, mirroring `orion/spark/concept_induction/drive_tension.py`'s bar exactly) computes the actual aggregation; the LLM only ever sees an already-computed fact sheet and is asked to phrase one sentence, never to extract a pattern from raw data itself. This was a mid-build course-correction — the original design let the LLM read raw SPARQL rows directly, which is exactly the "reducer shortcut" AGENTS.md's `event -> schema -> trace -> reducer -> projection` mandate forbids.
+- A strict anti-hallucination guardrail (`parse_and_validate_narrative()`) requires every cited fact's literal tokens (drive name, date, percentage, count) to appear verbatim in the narrative, and requires at least one citation to be a real per-tick artifact, not just an aggregate claim.
+- Refuses to synthesize on thin data (`MIN_EVENTS=5`, `MIN_DISTINCT_DAYS=2`) — reports insufficiency plainly instead of forcing a confident-sounding narrative from noise.
+- **Not scheduled or cron'd in this patch** — explicitly manual/on-demand, documented as needing human review before anyone trusts it as a recurring process.
+- Orchestrator independently reproduced a real live run, found the guardrail correctly rejecting an otherwise fully-accurate narrative over one paraphrase ("100%" written as "all"), and applied a surgical prompt fix for that exact failure mode.
+
+## Outcome moved
+
+Orion's drive-activation history — which existed and was durably persisted but had zero cognition consumers — now has a real, working pipeline that can turn it into an inspectable self-observation, with a genuine (not decorative) anti-hallucination check proven against a real LLM reply, not just synthetic test strings.
+
+## Current architecture (before this patch)
+
+`DriveAuditV1` was already being written append-only to Fuseki's `drives` graph (confirmed earlier today: 437,756 real `orion`-subject artifacts). Nothing read that history. The two "current value" stores (`LocalProfileStore`, `autonomy_state_v2`'s Postgres UPSERT) explicitly cannot serve this purpose — investigated and ruled out in this same session, before this build started.
+
+## Architecture touched
+
+`scripts/` (new standalone script, matches this repo's `check_activation_saturation.py`/`concept_relation_digest.py` conventions), `services/orion-memory-consolidation/README.md` (new section, sibling to the existing `concept_relation_digest.py` docs), `tests/`.
+
+## Files changed
+
+- `scripts/drive_history_reflection_synthesis.py` (new, ~1290 lines): `reduce_drive_history()` (pure reducer), `build_fact_sheet()` (pure projection to fact strings), `_build_narrative_prompt()` (LLM prompt, receives only the fact sheet), `parse_and_validate_narrative()` (grounding guardrail, raises `NarrativeUngrounded` rather than silently degrading), SPARQL fetch layer (`orion/graph/sparql_client.py`-adjacent, with a documented, deliberate choice not to import `orion.autonomy.repository`'s SPARQL helpers due to a measured ~2.6s import-time cost disproportionate to this script's occasional-batch-job purpose), bus-RPC LLM call mirroring `orion/memory/crystallization/concept_relation.py::resolve_concept_relation()`'s exact pattern, crystallization creation mirroring `concept_relation_digest.py`'s conventions (governance, evidence refs, `_SingleConnPool`-style transactional safety).
+- `tests/test_drive_history_reflection_synthesis.py` (new, 45 tests): `TestReduceDriveHistory` (8 tests, synthetic-input/known-output, zero I/O — insufficient-history cases, tie-break determinism, cited-event-id selection, active-drive frequency/mean-pressure correctness), `TestParseAndValidateNarrative` (8 tests — the guardrail's own unit coverage), plus SPARQL-query-builder, fetch-layer, and end-to-end pipeline tests with all I/O boundaries mocked (`FakeSparqlClient`, mocked bus, `FakeConn` at the asyncpg boundary mirroring `test_concept_relation_digest.py`'s convention).
+- `services/orion-memory-consolidation/README.md`: new section explaining the architecture, the guardrail, the insufficiency threshold, usage, and explicitly stating this is not cron'd yet and needs human review first.
+
+## Schema / bus / API changes
+
+None. No new `CrystallizationKind` (`"reflection"` already exists from an earlier round today), no new bus channel, no schema-registry entry. Reuses existing `MemoryCrystallizationV1`/`CrystallizationEvidenceRefV1`/`CrystallizationGovernanceV1`.
+
+## Env/config changes
+
+None new. Reads existing `POSTGRES_URI`, `ORION_BUS_URL`, and resolves a Fuseki query URL from existing `AUTONOMY_GRAPH_QUERY_URL`/`RDF_STORE_QUERY_URL`/`RDF_STORE_BASE_URL` (same resolution chain other RDF-reading code in this repo already uses).
+
+## Tests run
+
+```text
+$ python -m pytest tests/test_drive_history_reflection_synthesis.py -q
+45 passed
+```
+Run independently by the orchestrator three times across this patch's lifecycle (after the implementing agent's build, after the orchestrator's own prompt fix, and again after a rebase onto a moved `main` that included an unrelated `DriveEngine.update()` change) — all three green, no regressions.
+
+## Evals run
+
+Not a formal eval harness, but the closest real equivalent: the orchestrator independently reproduced a genuine live run against real Fuseki data (500 real `DriveAuditV1` ticks, 2 distinct days, subject=orion) and a real LLM call, to directly observe the guardrail's behavior against real model output rather than trusting synthetic test strings alone. See "Docker/build/smoke checks" below for the full transcript of what that found.
+
+## Docker/build/smoke checks
+
+**Orchestrator-reproduced live run (before the prompt fix), full transcript of the real rejection:**
+
+```text
+$ POSTGRES_URI=postgresql://postgres:postgres@localhost:55432/conjourney \
+  ORION_BUS_URL=redis://localhost:6379/0 \
+  RDF_STORE_QUERY_URL=http://localhost:3030/orion/query \
+  python scripts/drive_history_reflection_synthesis.py --since-days 30 --subject orion
+
+drive_history_reflection_synthesis: event-detail enrichment failed: HTTPConnectionPool(host='localhost', port=3030): Read timed out. (read timeout=10.0)
+  [known, already-disclosed limitation -- the per-drive detail-enrichment SPARQL join
+   is slow/broken against this Fuseki instance; the 10s timeout + graceful degradation
+   the implementing agent built worked exactly as designed here]
+
+RAW_LLM_CONTENT_DEBUG (temporary instrumentation, reverted before commit):
+{"narrative": "Over the period from 2026-06-14 to 2026-06-19, autonomy was the
+dominant drive in all 500 audited ticks, demonstrating a consistent focus on
+autonomy. On 2026-06-18, autonomy was the dominant drive in 81 ticks, and on
+2026-06-19, it was dominant in 419 ticks, with multiple audits confirming this
+pattern, such as Audit drive-audit-6a131c91c8bd3edf at 2026-06-19 06:54 UTC.",
+"cited_fact_numbers": [1, 2, 3, 6, 11]}
+
+status=llm_output_ungrounded
+  LLM output rejected as ungrounded: cited fact 1 but not all of its real tokens
+  ('autonomy', '100%', '500') appear verbatim in the narrative
+```
+
+This is a genuinely well-grounded narrative — every date, count, drive name, and the specific per-tick artifact ID + exact timestamp were reproduced verbatim and correctly. The only miss: fact 1 required the literal token `100%`, and the model wrote "all 500 audited ticks" instead. **The guardrail rejected this correctly** — "all" is a real paraphrase, not the literal fact — but it meant a fully accurate narrative was discarded over one word choice, which is a real usability gap worth closing without weakening the guardrail itself.
+
+**Orchestrator's fix:** added an explicit instruction + concrete example to `_build_narrative_prompt()` (mirroring the date-format example already present) telling the model to reproduce percentages as literal digits+percent-sign, not "all"/"every"/"always"/"entirely". Text-only change; no test asserts exact prompt wording, 45/45 still pass.
+
+**Honest disclosure: could not re-confirm end-to-end success after the fix.** Two follow-up live attempts both timed out (2+ minutes) rather than completing. All dependent containers reported healthy (`fuseki` 20h up/healthy, `bus-core` 4 days up/healthy, `llm-gateway` 59min up) at the time. The timeout pattern is consistent with the already-disclosed slow Fuseki detail-enrichment join (confirmed independently flaky earlier in the same session) combined with repeated back-to-back heavy queries against the same graph in a short window, not something a pure prompt-string edit could cause — the code path up to narrative generation is byte-identical except for the prompt text itself. Documented plainly rather than claiming a re-confirmation that didn't happen.
+
+## Review findings fixed
+
+- Finding (orchestrator-discovered via a live run, not a static review pass): the LLM's one real reply was correctly rejected by the grounding guardrail, but for a usability reason (percentage paraphrase) rather than a real grounding failure — the narrative was otherwise fully accurate and specific.
+  - Fix: explicit percentage-verbatim instruction + example added to the narrative prompt.
+  - Evidence: full before/after transcript above. Fix is unverified end-to-end live (see disclosure above) but is a minimal, low-risk, well-reasoned change addressing the exact observed failure mode; all existing tests remain green.
+- The implementing agent's own mid-build course-correction (reducer/LLM separation) was requested by the orchestrator before any code was written, based on AGENTS.md's `event -> schema -> trace -> reducer -> projection` mandate — not a post-hoc review finding, a pre-build architecture correction. Verified real and correctly implemented by the orchestrator via direct code read (`reduce_drive_history()`, `build_fact_sheet()`, `parse_and_validate_narrative()` — all pure, all independently tested, LLM never sees raw SPARQL rows).
+
+## Restart required
+
+```text
+No restart required.
+```
+Standalone, on-demand script — nothing running to restart. Not cron'd (deliberately, per the README).
+
+## Risks / concerns
+
+- Severity: Medium — the prompt fix for the percentage-paraphrase failure mode is well-reasoned and evidence-based but **not re-confirmed against a real live run** due to apparent Fuseki/infra flakiness encountered independently. Recommend: run this by hand once live infra is convenient, inspect whether the fix resolves the exact failure mode observed, and iterate on the prompt further if the guardrail is still over-rejecting on other token types (case, whitespace, or count-formatting variants haven't been observed failing yet, only the percentage-vs-"all" pattern).
+- Severity: Low — the per-drive detail-enrichment SPARQL join's slowness against live Fuseki (first flagged by the implementing agent, independently reproduced by the orchestrator) remains undiagnosed at the query-planner level. Mitigated via a short, separate timeout with graceful degradation (confirmed working in both the agent's and the orchestrator's live runs) — not blocking, but worth a follow-up if per-tick pressure detail in evidence notes turns out to matter.
+- Severity: Low (inherited, documented, not new) — this script is explicitly not cron'd; someone has to remember to run it. Intentional per the accepted design (output needs human review before automation), not an oversight.
+
+## PR link
+
+Not opened via `gh` (no token, SSH-only remote, consistent with every PR this session). Branch pushed; use this to open it:
+
+`https://github.com/junebug-junie/Orion-Sapienform/compare/main...feat/drive-history-identity-reflection?expand=1`

--- a/scripts/drive_history_reflection_synthesis.py
+++ b/scripts/drive_history_reflection_synthesis.py
@@ -422,8 +422,12 @@ def _build_narrative_prompt(agg: DriveHistoryAggregationV1, facts: list[Grounded
         "date(s)/timestamp(s), percentage(s), count(s), and drive name(s) MUST appear verbatim in your "
         "narrative text -- partially reproducing a fact (e.g. only its drive name, without its exact "
         "percentage or count) does not count as citing it. Reproduce dates/timestamps in EXACTLY the "
-        "same format shown in the fact (e.g. 2026-06-14, not 'June 14'), and reproduce drive names, "
-        "percentages, and counts exactly as written, not paraphrased or rounded differently.\n\n"
+        "same format shown in the fact (e.g. write '2026-06-14', not 'June 14'). Reproduce every "
+        "percentage EXACTLY as the digits+percent-sign shown in the fact -- e.g. if a fact says '100%', "
+        "your sentence must contain the literal text '100%'; do NOT substitute words like 'all', "
+        "'every', 'always', or 'entirely' in place of the percentage, even when they are accurate in "
+        "meaning. The same applies to counts and drive names: write them exactly as shown, never "
+        "paraphrased, summarized, or rounded differently.\n\n"
         "Respond with ONLY a single JSON object, no prose, no markdown fences, shaped exactly like:\n"
         '{"narrative": "<your 2-4 sentence observation>", "cited_fact_numbers": [<int>, ...]}\n'
     )

--- a/scripts/drive_history_reflection_synthesis.py
+++ b/scripts/drive_history_reflection_synthesis.py
@@ -1,0 +1,1287 @@
+#!/usr/bin/env python3
+"""Weekly-cadence batch job: turn Orion's own real, persisted drive-activation
+history into ONE narrative `reflection`-kind crystallization.
+
+Context: `DriveAuditV1` (`orion/core/schemas/drives.py`) is computed live on every
+DriveEngine tick and written, append-only, by `services/orion-rdf-writer/app/
+autonomy.py::_handle_drive_audit()` to the Fuseki `drives` graph
+(`http://conjourney.net/graph/autonomy/drives`) as a timestamped `orion:DriveAudit` --
+a genuine historical time-series, unlike the "latest value only" stores this repo
+already has for the same drive signal (see `orion/spark/concept_induction/store.py`'s
+`LocalProfileStore` and `orion.autonomy.state_store`'s single-row-per-subject UPSERT).
+
+This script is the first real reader of that history for self-modeling purposes.
+
+Architecture (event -> schema -> trace -> reducer -> projection -> eval/LLM phrasing
+-> crystallization -- per AGENTS.md's mandated path, NOT "vague theory -> LLM invents
+a pattern"):
+
+    1. FETCH   -- read real DriveAuditV1-derived triples from Fuseki via
+                  orion.graph.sparql_client.SparqlQueryClient (`fetch_drive_history_events`).
+    2. REDUCE  -- `reduce_drive_history()`: a PURE, deterministic, unit-tested Python
+                  function (no I/O, no LLM) that aggregates the raw per-tick events
+                  into `DriveHistoryAggregationV1` -- dominant-drive counts/shares,
+                  per-day breakdown, active-drive frequency, mean pressures, and a
+                  sufficiency verdict. This is the same bar as
+                  `orion/spark/concept_induction/drive_tension.py`: synthetic-input,
+                  known-output tests, zero LLM involvement.
+    3. GUARDRAIL -- lives INSIDE the reducer (`agg.sufficient` /
+                  `agg.insufficiency_reason`), not bolted on after: it is a
+                  reduction-time decision ("not enough real data to claim a
+                  pattern"), not a separate pre-check. See MIN_EVENTS /
+                  MIN_DISTINCT_DAYS below.
+    4. PHRASE  -- `build_fact_sheet()` renders the aggregation into a small, numbered
+                  list of already-computed, already-verified fact strings. The LLM
+                  (`_call_llm_narrative`, bus RPC per
+                  `orion/memory/crystallization/concept_relation.py`'s established
+                  pattern) receives ONLY this fact sheet -- never raw per-tick SPARQL
+                  rows. Its job shrinks to "phrase these facts as one narrative
+                  sentence and cite which facts you used" -- it cannot invent a
+                  pattern that was not already established deterministically, because
+                  the pattern (or lack of one) was computed before the LLM ever saw
+                  anything.
+    5. VALIDATE -- `parse_and_validate_narrative()`: every cited fact number must be
+                  real, and the fact's own literal tokens (real dates/percentages/
+                  drive names/timestamps) must appear verbatim in the LLM's narrative
+                  text. A citation that does not literally quote real data is
+                  rejected -- this is the mandatory grounding defense the task brief
+                  calls out as the single biggest risk in this build.
+    6. WRITE   -- one `reflection`-kind `MemoryCrystallizationV1` via
+                  `apply_salience()` + `insert_crystallization()`, mirroring
+                  `scripts/concept_relation_digest.py`'s governance/evidence shape
+                  exactly. Evidence refs cite BOTH the reducer's aggregation object
+                  AND the individual raw DriveAuditV1 artifacts the LLM actually
+                  cited, so a human reviewer can verify the narrative against what
+                  was really computed, not just that some event IDs exist.
+
+Not a service loop -- a standalone script, run on demand (see
+services/orion-memory-consolidation/README.md for why this one is NOT cron'd, unlike
+concept_relation_digest.py).
+
+Usage:
+    POSTGRES_URI=postgresql://user:pass@host:port/db python scripts/drive_history_reflection_synthesis.py
+    python scripts/drive_history_reflection_synthesis.py --postgres-uri postgresql://... --since-days 14
+    python scripts/drive_history_reflection_synthesis.py --json
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+# Running as `python scripts/drive_history_reflection_synthesis.py` puts scripts/ on
+# sys.path[0], which shadows stdlib `platform` via scripts/platform/ (imported
+# transitively by `uuid`, `asyncio`, etc.) -- same issue documented in
+# scripts/check_inner_state_registry.py / scripts/concept_relation_digest.py. This
+# fix MUST run before any stdlib import that might transitively pull in `platform`,
+# so it comes immediately after the only two imports (`sys`, `pathlib.Path`) needed
+# to perform it.
+if sys.path and sys.path[0] == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+_REPO_ROOT = str(Path(__file__).resolve().parents[1])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Mapping, Sequence
+from uuid import uuid4
+
+logger = logging.getLogger("orion.scripts.drive_history_reflection_synthesis")
+
+ORION_NS = "http://conjourney.net/orion#"
+RDFS_NS = "http://www.w3.org/2000/01/rdf-schema#"
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+AUTONOMY_DRIVES_GRAPH = "http://conjourney.net/graph/autonomy/drives"
+
+DEFAULT_SINCE_DAYS = 30
+DEFAULT_SUBJECT = "orion"
+# Hard cap on raw events fetched from Fuseki -- DriveEngine ticks can run several
+# times a minute (live volume observed: tens of thousands of audits in a 30-day
+# window), so an uncapped fetch would transfer an unbounded result set. This caps
+# the *fetch*, not the reduction: reduce_drive_history() aggregates over exactly
+# whatever was fetched and reports that honestly (see DriveHistoryAggregationV1.
+# total_events). ORDER BY DESC(created_at) means a capped fetch is the most recent
+# `max_events` real ticks in the window, not a fabricated or estimated sample.
+DEFAULT_MAX_EVENTS = 500
+
+# Guardrail thresholds (module-level constants, visible + testable, mirrors
+# scripts/analysis/measure_autonomy_gate.py's threshold posture). Both must clear
+# for reduce_drive_history() to consider the window "sufficient":
+#   MIN_EVENTS: below this, a handful of ticks cannot distinguish a real
+#     recurring tendency from a momentary blip -- 5 is the smallest count where
+#     "most often" (a majority/plurality claim) is even a meaningful statement.
+#   MIN_DISTINCT_DAYS: DriveEngine ticks frequently within a single session
+#     (observed: multiple ticks per minute), so event COUNT alone can be
+#     satisfied entirely within one sitting. Requiring >=2 distinct calendar
+#     days is what actually distinguishes a "long-horizon pattern" (the whole
+#     point of this script) from an artifact of one continuous session.
+MIN_EVENTS = 5
+MIN_DISTINCT_DAYS = 2
+# Minimum number of real facts the LLM must cite (by number) for its narrative to
+# be considered grounded rather than generic filler.
+MIN_CITED_FACTS = 2
+
+
+# ===========================================================================
+# Fetch-layer types (I/O boundary representation of a real DriveAuditV1 tick)
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class DriveAuditEvent:
+    """One real, already-persisted DriveAuditV1 tick, as read back from Fuseki.
+
+    `artifact_uri` is the RDF subject IRI (used only to join the detail query);
+    it is optional so synthetic events built directly in tests do not need one.
+    """
+
+    artifact_id: str
+    created_at: datetime
+    dominant_drive: str | None = None
+    summary: str | None = None
+    active_drives: tuple[str, ...] = ()
+    drive_pressures: Mapping[str, float] = field(default_factory=dict)
+    artifact_uri: str | None = None
+
+
+# ===========================================================================
+# REDUCER -- pure, deterministic, no I/O, no LLM. Mirrors
+# orion/spark/concept_induction/drive_tension.py's contract exactly: typed
+# dataclass output, synthetic-input/known-output unit tests.
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class DriveHistoryAggregationV1:
+    """Deterministic aggregation over a real, already-fetched set of
+    DriveAuditEvent ticks. Nothing in this object is inferred or guessed --
+    every field is computed directly from `events` by reduce_drive_history()."""
+
+    subject: str
+    since: datetime
+    until: datetime | None
+    total_events: int
+    distinct_days: int
+    dominant_drive_counts: Mapping[str, int]
+    dominant_drive_share: Mapping[str, float]
+    top_dominant_drive: str | None
+    top_dominant_drive_count: int
+    top_dominant_drive_share: float
+    day_counts: Mapping[str, int]
+    day_dominant_drive: Mapping[str, str]
+    active_drive_frequency: Mapping[str, int]
+    mean_pressure_by_drive: Mapping[str, float]
+    cited_event_ids: tuple[str, ...]
+    sufficient: bool
+    insufficiency_reason: str | None
+
+
+def reduce_drive_history(
+    events: Sequence[DriveAuditEvent],
+    *,
+    subject: str,
+    since: datetime,
+    min_events: int = MIN_EVENTS,
+    min_distinct_days: int = MIN_DISTINCT_DAYS,
+    max_cited_events: int = 8,
+) -> DriveHistoryAggregationV1:
+    """Pure reduction over a real, already-fetched event list. Never raises on
+    empty input (degrades to a `sufficient=False` aggregation with zeroed
+    counts) -- callers must check `.sufficient` before doing anything with the
+    rest of the fields. This is the ONLY place the "insufficient history"
+    guardrail decision is made; nothing downstream re-derives it.
+    """
+    ordered = sorted(events, key=lambda e: e.created_at)
+    total_events = len(ordered)
+
+    day_counts: dict[str, int] = {}
+    dominant_drive_counts: dict[str, int] = {}
+    day_dominant_raw: dict[str, dict[str, int]] = {}
+    active_drive_frequency: dict[str, int] = {}
+    pressure_sums: dict[str, float] = {}
+    pressure_counts: dict[str, int] = {}
+
+    for ev in ordered:
+        day = ev.created_at.astimezone(timezone.utc).date().isoformat()
+        day_counts[day] = day_counts.get(day, 0) + 1
+        if ev.dominant_drive:
+            dominant_drive_counts[ev.dominant_drive] = dominant_drive_counts.get(ev.dominant_drive, 0) + 1
+            day_dominant_raw.setdefault(day, {})
+            day_dominant_raw[day][ev.dominant_drive] = day_dominant_raw[day].get(ev.dominant_drive, 0) + 1
+        for drive in ev.active_drives:
+            active_drive_frequency[drive] = active_drive_frequency.get(drive, 0) + 1
+        for drive, pressure in ev.drive_pressures.items():
+            try:
+                p = float(pressure)
+            except (TypeError, ValueError):
+                continue
+            pressure_sums[drive] = pressure_sums.get(drive, 0.0) + p
+            pressure_counts[drive] = pressure_counts.get(drive, 0) + 1
+
+    distinct_days = len(day_counts)
+
+    dominant_drive_share = (
+        {drive: count / total_events for drive, count in dominant_drive_counts.items()} if total_events else {}
+    )
+
+    top_dominant_drive: str | None = None
+    top_dominant_drive_count = 0
+    if dominant_drive_counts:
+        # Deterministic tie-break: highest count first, then alphabetically first
+        # name -- two runs over the same data must always agree.
+        top_dominant_drive = sorted(dominant_drive_counts.items(), key=lambda kv: (-kv[1], kv[0]))[0][0]
+        top_dominant_drive_count = dominant_drive_counts[top_dominant_drive]
+    top_dominant_drive_share = (
+        top_dominant_drive_count / total_events if total_events and top_dominant_drive else 0.0
+    )
+
+    day_dominant_drive = {
+        day: sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[0][0] for day, counts in day_dominant_raw.items()
+    }
+
+    mean_pressure_by_drive = {drive: pressure_sums[drive] / pressure_counts[drive] for drive in pressure_sums}
+
+    # Deterministic, evenly-spaced sample across the time-ordered event list --
+    # always includes the earliest and latest event (so the fact sheet can
+    # ground a real time span, not just a cluster) -- used both for LLM
+    # citation and as crystallization evidence refs.
+    cited_event_ids: tuple[str, ...] = ()
+    if ordered:
+        k = min(max_cited_events, total_events)
+        if k <= 1:
+            indices = [0]
+        else:
+            indices = sorted({round(i * (total_events - 1) / (k - 1)) for i in range(k)})
+        cited_event_ids = tuple(ordered[i].artifact_id for i in indices)
+
+    sufficient = total_events >= min_events and distinct_days >= min_distinct_days
+    insufficiency_reason: str | None = None
+    if not sufficient:
+        reasons = []
+        if total_events < min_events:
+            reasons.append(f"only {total_events} event(s) found (need >= {min_events})")
+        if distinct_days < min_distinct_days:
+            reasons.append(f"events span only {distinct_days} distinct day(s) (need >= {min_distinct_days})")
+        insufficiency_reason = "; ".join(reasons)
+
+    until = ordered[-1].created_at if ordered else None
+
+    return DriveHistoryAggregationV1(
+        subject=subject,
+        since=since,
+        until=until,
+        total_events=total_events,
+        distinct_days=distinct_days,
+        dominant_drive_counts=dominant_drive_counts,
+        dominant_drive_share=dominant_drive_share,
+        top_dominant_drive=top_dominant_drive,
+        top_dominant_drive_count=top_dominant_drive_count,
+        top_dominant_drive_share=top_dominant_drive_share,
+        day_counts=day_counts,
+        day_dominant_drive=day_dominant_drive,
+        active_drive_frequency=active_drive_frequency,
+        mean_pressure_by_drive=mean_pressure_by_drive,
+        cited_event_ids=cited_event_ids,
+        sufficient=sufficient,
+        insufficiency_reason=insufficiency_reason,
+    )
+
+
+# ===========================================================================
+# Fact sheet -- deterministic rendering of the aggregation into short,
+# citable, already-verified fact strings. This is the ONLY thing the LLM
+# sees; it never sees raw per-tick SPARQL rows.
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class GroundedFact:
+    index: int
+    text: str
+    # Literal substrings that must ALL appear verbatim (case-insensitively) in
+    # the narrative for a citation of this fact to count as grounded (real
+    # dates/percentages/drive names/naturalized timestamps -- never
+    # LLM-generated). Requiring every token, not just one, matters: a fact's
+    # low-entropy count token (e.g. "5") or a single correct drive name is not
+    # enough on its own to prove the LLM reproduced the fact's actual claim
+    # rather than coincidentally overlapping one substring.
+    tokens: tuple[str, ...]
+    # Set only for individual-event facts; lets evidence-building look up the
+    # real DriveAuditEvent a citation refers back to, and lets
+    # parse_and_validate_narrative require at least one real per-tick
+    # citation (not just aggregate-level facts).
+    artifact_id: str | None = None
+
+
+# Per-tick `summary` text (currently always a deterministic template from
+# orion/spark/concept_induction/audit.py::build_drive_audit -- never
+# freeform/model-generated) rides along in individual-event facts as
+# descriptive context, NOT as a grounding token requiring narrative
+# reproduction. Truncated defensively so a future non-deterministic summary
+# producer cannot blow up prompt size or smuggle unbounded content through.
+_SUMMARY_TRUNC_CHARS = 200
+
+# Bounds how many per-day facts the fact sheet can contain, independent of
+# `--since-days` -- unlike every other stage of this pipeline (fetch is
+# capped by --max-events, citation is capped by max_cited_events), a wide
+# --since-days window with daily activity would otherwise inflate the
+# prompt/cost without limit. Keeps the most recent days (most relevant to a
+# "recent tendency" narrative).
+MAX_DAY_FACTS = 14
+
+
+def _naturalized_ts(dt: datetime) -> str:
+    """Human-reproducible timestamp token (no seconds/timezone-offset
+    punctuation) -- a full tz-aware ISO-8601 string with seconds and a UTC
+    offset (e.g. `2026-06-14T09:00:00+00:00`) is not something a short
+    reflective-voice sentence naturally reproduces verbatim, which made the
+    individual-event citation path practically unreachable in practice."""
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M")
+
+
+def build_fact_sheet(
+    agg: DriveHistoryAggregationV1, events_by_id: Mapping[str, DriveAuditEvent]
+) -> list[GroundedFact]:
+    """Pure function: renders an already-computed DriveHistoryAggregationV1 into
+    a small numbered list of fact strings. No randomness, no LLM, fully
+    deterministic given the same aggregation."""
+    facts: list[GroundedFact] = []
+    idx = 1
+
+    if agg.top_dominant_drive:
+        pct = f"{agg.top_dominant_drive_share * 100:.0f}%"
+        since_day = agg.since.astimezone(timezone.utc).date().isoformat()
+        until_day = (agg.until or agg.since).astimezone(timezone.utc).date().isoformat()
+        facts.append(
+            GroundedFact(
+                index=idx,
+                text=(
+                    f"'{agg.top_dominant_drive}' was the dominant drive in {agg.top_dominant_drive_count} of "
+                    f"{agg.total_events} audited ticks ({pct}) across {agg.distinct_days} distinct day(s) "
+                    f"between {since_day} and {until_day}."
+                ),
+                tokens=(agg.top_dominant_drive, pct, str(agg.top_dominant_drive_count)),
+            )
+        )
+        idx += 1
+
+    # Most recent MAX_DAY_FACTS days only -- see MAX_DAY_FACTS docstring.
+    for day in sorted(agg.day_dominant_drive)[-MAX_DAY_FACTS:]:
+        drive = agg.day_dominant_drive[day]
+        count = agg.day_counts.get(day, 0)
+        facts.append(
+            GroundedFact(
+                index=idx,
+                text=f"On {day}, the dominant drive was '{drive}' ({count} tick(s) that day).",
+                tokens=(day, drive),
+            )
+        )
+        idx += 1
+
+    for eid in agg.cited_event_ids:
+        ev = events_by_id.get(eid)
+        if ev is None:
+            continue
+        ts = _naturalized_ts(ev.created_at)
+        summary = (ev.summary or "(no summary)").strip()
+        if len(summary) > _SUMMARY_TRUNC_CHARS:
+            summary = summary[: _SUMMARY_TRUNC_CHARS - 3] + "..."
+        dominant = ev.dominant_drive or "none"
+        facts.append(
+            GroundedFact(
+                index=idx,
+                text=(f"Audit {ev.artifact_id} at {ts} UTC: dominant_drive={dominant}, summary={summary}."),
+                tokens=(ts, dominant),
+                artifact_id=ev.artifact_id,
+            )
+        )
+        idx += 1
+
+    return facts
+
+
+def _build_narrative_prompt(agg: DriveHistoryAggregationV1, facts: list[GroundedFact]) -> str:
+    facts_block = "\n".join(f"Fact {f.index}: {f.text}" for f in facts)
+    event_fact_numbers = [f.index for f in facts if f.artifact_id]
+    instructions = (
+        "You are given a set of ALREADY-COMPUTED, verified facts about Orion's own drive-activation "
+        "history over a real time window (queried directly from Orion's persisted drive-audit graph; "
+        "every fact below was computed deterministically, not inferred or estimated by you). Do not "
+        "invent any fact, number, date, or drive name that is not explicitly listed below.\n\n"
+        "Write ONE short narrative observation (2-4 sentences) in Orion's own reflective voice, about "
+        "the long-horizon pattern these facts reveal about Orion's own drive activity.\n\n"
+        "You MUST cite at least 2 of the facts above by number, including AT LEAST ONE of these specific "
+        f"individual-audit facts: {event_fact_numbers}. For every fact you cite, ALL of its literal "
+        "date(s)/timestamp(s), percentage(s), count(s), and drive name(s) MUST appear verbatim in your "
+        "narrative text -- partially reproducing a fact (e.g. only its drive name, without its exact "
+        "percentage or count) does not count as citing it. Reproduce dates/timestamps in EXACTLY the "
+        "same format shown in the fact (e.g. 2026-06-14, not 'June 14'), and reproduce drive names, "
+        "percentages, and counts exactly as written, not paraphrased or rounded differently.\n\n"
+        "Respond with ONLY a single JSON object, no prose, no markdown fences, shaped exactly like:\n"
+        '{"narrative": "<your 2-4 sentence observation>", "cited_fact_numbers": [<int>, ...]}\n'
+    )
+    return f"FACTS:\n{facts_block}\n\n{instructions}"
+
+
+# ===========================================================================
+# Narrative validation -- the mandatory anti-hallucination guardrail. Pure,
+# no I/O; fully unit-testable with synthetic LLM output strings.
+# ===========================================================================
+
+
+class NarrativeUngrounded(Exception):
+    """Raised when the LLM's reply is malformed, cites nothing real, or cites
+    a fact without literally quoting any of that fact's real tokens. Callers
+    must treat this the same as an LLM call failure: no crystallization is
+    written."""
+
+
+@dataclass(frozen=True)
+class GroundedNarrative:
+    narrative: str
+    cited_fact_numbers: tuple[int, ...]
+
+
+def parse_and_validate_narrative(
+    raw_content: str, facts: list[GroundedFact], *, min_cited: int = MIN_CITED_FACTS
+) -> GroundedNarrative:
+    from orion.core.llm_json import parse_json_object
+
+    try:
+        obj = parse_json_object(raw_content)
+    except Exception as exc:
+        raise NarrativeUngrounded(f"LLM reply was not valid JSON: {exc}") from exc
+
+    narrative = str(obj.get("narrative") or "").strip()
+    cited_raw = obj.get("cited_fact_numbers")
+    if not narrative:
+        raise NarrativeUngrounded("LLM reply had an empty narrative")
+    if not isinstance(cited_raw, list) or not cited_raw:
+        raise NarrativeUngrounded("LLM reply did not cite any fact numbers")
+
+    facts_by_index = {f.index: f for f in facts}
+    cited_numbers: list[int] = []
+    for raw in cited_raw:
+        try:
+            n = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if n in facts_by_index and n not in cited_numbers:
+            cited_numbers.append(n)
+
+    if len(cited_numbers) < min_cited:
+        raise NarrativeUngrounded(f"LLM cited only {len(cited_numbers)} valid fact(s), need >= {min_cited}")
+
+    narrative_lower = narrative.lower()
+    for n in cited_numbers:
+        fact = facts_by_index[n]
+        # ALL of a fact's tokens must match, not just one: a fact carries
+        # several independent claims (e.g. drive name + percentage + count),
+        # and matching only the drive name (or, worse, only a low-entropy
+        # digit like a small count) would let a narrative "cite" a fact
+        # without actually reproducing its specific numbers -- defeating the
+        # point of a verbatim-token guardrail. Case-insensitive: an LLM
+        # naturally capitalizing a drive name at a sentence start (e.g.
+        # "Continuity has...") is still a genuine, faithful citation and
+        # must not be rejected over case alone -- dates/percentages/counts
+        # are digit strings unaffected by lowercasing, so this does not
+        # weaken the numeric half of the guarantee.
+        if not all(token and token.lower() in narrative_lower for token in fact.tokens):
+            raise NarrativeUngrounded(
+                f"cited fact {n} but not all of its real tokens {fact.tokens!r} appear verbatim in the narrative"
+            )
+
+    # At least one citation must be a real, individual DriveAuditV1 artifact
+    # (not just an aggregate-level fact) -- this is what lets
+    # _build_reflection_crystallization() attach genuine per-tick evidence
+    # refs, not just a description of the aggregation. Aggregate-only
+    # citations are still real and grounded, but the task's evidence
+    # contract requires the queried event set itself to be traceable, not
+    # only a summary of it.
+    if not any(facts_by_index[n].artifact_id for n in cited_numbers):
+        raise NarrativeUngrounded(
+            "no cited fact referenced an individual audited tick (all citations were aggregate-level); "
+            "at least one citation must be a real per-tick DriveAuditV1 artifact"
+        )
+
+    return GroundedNarrative(narrative=narrative, cited_fact_numbers=tuple(cited_numbers))
+
+
+# ===========================================================================
+# SPARQL fetch layer -- query builders are pure (unit-testable without a
+# live endpoint); `fetch_drive_history_events` is the only I/O function here.
+# ===========================================================================
+
+
+# _escape_sparql / _literal below are intentionally NOT imported from
+# orion.autonomy.repository (which has the same two tiny helpers) --
+# importing that module was measured at ~2.6s just to load its transitive
+# dependency chain, which is a real, disproportionate cost for a script whose
+# whole point is a light, occasional batch job. This repeats a pattern
+# already independently duplicated 4+ times elsewhere in the repo (no single
+# canonical orion.graph-level home exists to import from without the same
+# cost); a shared low-weight `orion.graph.sparql_bindings` module would be
+# the real fix, but is out of scope for this patch.
+def _escape_sparql(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _is_safe_sparql_iri(uri: str) -> bool:
+    """Defensive validation before interpolating a URI raw into a SPARQL
+    `VALUES ?x { <uri> ... }` clause (unlike string literals, IRIREFs cannot
+    be escaped -- illegal characters must be rejected instead). These URIs
+    are always ones this same process just read back from our own list
+    query's `?artifact` bindings (never user input), so this is defense in
+    depth against a malformed/legacy artifact URI breaking the query, not a
+    response to any known live issue."""
+    if not uri or "<" in uri or ">" in uri or '"' in uri or "{" in uri or "}" in uri:
+        return False
+    return not any(ch.isspace() or ord(ch) < 0x20 for ch in uri)
+
+
+def build_drive_audit_event_list_sparql(
+    *, since: datetime, subject: str, graph_uri: str = AUTONOMY_DRIVES_GRAPH, limit: int
+) -> str:
+    """Single-valued fields only (artifact_id/created_at/dominant_drive/summary) --
+    no multi-valued predicate (`orion:hasDriveAssessment`, `orion:highlightsActiveDrive`)
+    is joined here, so this query cannot fan out and LIMIT means what it says.
+    `orion:timestamp` is multi-valued per audit (up to several per artifact per
+    scripts/analysis/measure_autonomy_gate.py's documented live finding); the inner
+    subquery aggregates with MIN(?ts) per artifact so each artifact contributes
+    exactly one row to the outer query, using only the timestamp(s) that actually
+    fall in-window.
+    """
+    since_iso = since.astimezone(timezone.utc).isoformat()
+    return f"""PREFIX orion: <{ORION_NS}>
+PREFIX xsd: <{XSD_NS}>
+SELECT ?artifact ?artifact_id ?created_at ?dominant_drive ?summary WHERE {{
+  GRAPH <{graph_uri}> {{
+    {{
+      SELECT ?artifact ?artifact_id (MIN(?ts) AS ?created_at) WHERE {{
+        ?artifact a orion:DriveAudit ;
+          orion:subjectKey "{_escape_sparql(subject)}" ;
+          orion:artifactId ?artifact_id ;
+          orion:timestamp ?ts .
+        FILTER(?ts >= "{since_iso}"^^xsd:dateTime)
+      }}
+      GROUP BY ?artifact ?artifact_id
+    }}
+    OPTIONAL {{ ?artifact orion:dominantDriveName ?dominant_drive . }}
+    OPTIONAL {{ ?artifact orion:auditSummary ?summary . }}
+  }}
+}}
+ORDER BY DESC(?created_at)
+LIMIT {int(limit)}
+""".strip()
+
+
+def build_drive_audit_detail_sparql(*, artifact_uris: Sequence[str], graph_uri: str = AUTONOMY_DRIVES_GRAPH) -> str:
+    """Per-drive pressure + active-drive detail for a bounded, explicit set of
+    artifact URIs (the events the list query already selected) -- fan-out from
+    the multi-valued `hasDriveAssessment` / `highlightsActiveDrive` predicates
+    is safe here because it is scoped to exactly this small VALUES set, not the
+    whole window. Malformed URIs (see _is_safe_sparql_iri) are silently
+    dropped rather than raising -- a single bad artifact URI should not abort
+    detail enrichment for every other artifact in the set."""
+    safe_uris = [uri for uri in artifact_uris if _is_safe_sparql_iri(uri)]
+    values = " ".join(f"<{uri}>" for uri in safe_uris)
+    return f"""PREFIX orion: <{ORION_NS}>
+PREFIX rdfs: <{RDFS_NS}>
+SELECT ?artifact ?drive_name ?drive_pressure ?active_drive WHERE {{
+  VALUES ?artifact {{ {values} }}
+  GRAPH <{graph_uri}> {{
+    OPTIONAL {{
+      ?artifact orion:hasDriveAssessment ?assessment .
+      ?assessment orion:driveDimension ?drive_ref ;
+        orion:drivePressure ?drive_pressure .
+      OPTIONAL {{ FILTER(isIRI(?drive_ref)) ?drive_ref rdfs:label ?drive_name_label . }}
+      BIND(COALESCE(?drive_name_label, STR(?drive_ref)) AS ?drive_name)
+    }}
+    OPTIONAL {{
+      ?artifact orion:highlightsActiveDrive ?active_drive_ref .
+      OPTIONAL {{ FILTER(isIRI(?active_drive_ref)) ?active_drive_ref rdfs:label ?active_drive_label . }}
+      BIND(COALESCE(?active_drive_label, STR(?active_drive_ref)) AS ?active_drive)
+    }}
+  }}
+}}
+""".strip()
+
+
+def _literal(binding: Mapping[str, Mapping[str, str]], key: str) -> str | None:
+    val = binding.get(key, {}).get("value")
+    if isinstance(val, str) and val.strip():
+        return val.strip()
+    return None
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def parse_event_list_bindings(bindings: Iterable[dict]) -> list[DriveAuditEvent]:
+    events: list[DriveAuditEvent] = []
+    for row in bindings:
+        if not isinstance(row, dict):
+            continue
+        artifact_uri = _literal(row, "artifact")
+        artifact_id = _literal(row, "artifact_id")
+        created_at = _parse_dt(_literal(row, "created_at"))
+        if not artifact_id or created_at is None:
+            continue
+        events.append(
+            DriveAuditEvent(
+                artifact_id=artifact_id,
+                created_at=created_at,
+                dominant_drive=_literal(row, "dominant_drive"),
+                summary=_literal(row, "summary"),
+                artifact_uri=artifact_uri,
+            )
+        )
+    return events
+
+
+def merge_event_details(events: list[DriveAuditEvent], detail_bindings: Iterable[dict]) -> list[DriveAuditEvent]:
+    pressures: dict[str, dict[str, float]] = {}
+    actives: dict[str, set[str]] = {}
+    for row in detail_bindings:
+        if not isinstance(row, dict):
+            continue
+        artifact_uri = _literal(row, "artifact")
+        if not artifact_uri:
+            continue
+        drive_name = _literal(row, "drive_name")
+        drive_pressure = _literal(row, "drive_pressure")
+        if drive_name and drive_pressure is not None:
+            try:
+                pressures.setdefault(artifact_uri, {})[drive_name] = float(drive_pressure)
+            except ValueError:
+                pass
+        active_drive = _literal(row, "active_drive")
+        if active_drive:
+            actives.setdefault(artifact_uri, set()).add(active_drive)
+
+    merged: list[DriveAuditEvent] = []
+    for ev in events:
+        key = ev.artifact_uri
+        merged.append(
+            replace(
+                ev,
+                drive_pressures=pressures.get(key, {}) if key else {},
+                active_drives=tuple(sorted(actives.get(key, set()))) if key else (),
+            )
+        )
+    return merged
+
+
+def fetch_drive_history_events(
+    client: Any,
+    *,
+    since: datetime,
+    subject: str,
+    graph_uri: str = AUTONOMY_DRIVES_GRAPH,
+    max_events: int = DEFAULT_MAX_EVENTS,
+) -> list[DriveAuditEvent]:
+    """I/O function: `client` needs only a `.select(sparql: str) -> list[dict]`
+    method (the shape of `orion.graph.sparql_client.SparqlQueryClient`, and
+    trivially fakeable in tests). Any exception from `client.select()`
+    propagates to the caller -- this function does not swallow SPARQL errors,
+    unlike the LLM call below (which is documented to degrade); a failed graph
+    read must abort the run cleanly, not silently report "no history".
+
+    Returns list-level fields only (artifact_id/created_at/dominant_drive/
+    summary) -- `drive_pressures`/`active_drives` are left at their empty
+    defaults here. Measured live against real Fuseki: a detail join
+    (`orion:hasDriveAssessment`/`orion:highlightsActiveDrive`, both
+    multi-valued) scoped to `max_events` (up to `DEFAULT_MAX_EVENTS=500`)
+    artifacts did not return within several minutes -- the VALUES+double-
+    OPTIONAL combinatorics do not scale to hundreds of artifacts. Per-drive
+    detail is fetched separately, ONLY for the bounded citable sample
+    (`DriveHistoryAggregationV1.cited_event_ids`, capped at 8) via
+    `fetch_event_details()` below, which is fast at that scale. This is a
+    deliberate, disclosed scope reduction: `mean_pressure_by_drive` /
+    `active_drive_frequency` on the resulting aggregation therefore reflect
+    only whichever events actually got enriched, not the full window --
+    callers must not read them as full-window statistics.
+    """
+    list_sparql = build_drive_audit_event_list_sparql(since=since, subject=subject, graph_uri=graph_uri, limit=max_events)
+    bindings = client.select(list_sparql)
+    return parse_event_list_bindings(bindings)
+
+
+def fetch_event_details(
+    client: Any,
+    events: Sequence[DriveAuditEvent],
+    *,
+    graph_uri: str = AUTONOMY_DRIVES_GRAPH,
+) -> list[DriveAuditEvent]:
+    """Enrich a SMALL, already-selected set of events (real live measurement:
+    safe at citable-sample scale, i.e. <=8-20 artifacts -- see
+    fetch_drive_history_events's docstring for why this is not run over the
+    full fetched window). Any exception from `client.select()` propagates;
+    callers that consider detail enrichment non-critical (current caller,
+    `_run_once`, does -- pressures/active-drives are not referenced by the
+    narrative prompt today, only carried for evidence completeness) should
+    catch it themselves rather than relying on this function to degrade."""
+    uris = [ev.artifact_uri for ev in events if ev.artifact_uri and _is_safe_sparql_iri(ev.artifact_uri)]
+    if not uris:
+        return list(events)
+
+    detail_sparql = build_drive_audit_detail_sparql(artifact_uris=uris, graph_uri=graph_uri)
+    detail_bindings = client.select(detail_sparql)
+    return merge_event_details(list(events), detail_bindings)
+
+
+# ===========================================================================
+# LLM call -- bus RPC, mirrors orion/memory/crystallization/concept_relation.py
+# ::resolve_concept_relation() exactly (same envelope/channel/decode shape).
+# Unlike that function, this one does NOT degrade silently on failure -- a
+# failed or ungrounded LLM call must abort the run, not write a fabricated
+# crystallization.
+# ===========================================================================
+
+
+async def _call_llm_narrative(
+    bus: Any,
+    *,
+    prompt: str,
+    route: str,
+    request_channel: str,
+    timeout_sec: float,
+    service_name: str,
+) -> str:
+    from orion.core.bus.bus_schemas import BaseEnvelope, ChatRequestPayload, LLMMessage, ServiceRef
+
+    corr_id = str(uuid4())
+    reply_channel = f"orion:exec:result:LLMGatewayService:{corr_id}"
+    payload = ChatRequestPayload(
+        messages=[LLMMessage(role="user", content=prompt)],
+        route=route,
+        options={
+            "return_logprobs": False,
+            "max_tokens": 400,
+            "llm_route": route,
+            "purpose": "reflect",
+            "skip_spark_candidate_publish": True,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+    )
+    env = BaseEnvelope(
+        kind="llm.chat.request",
+        source=ServiceRef(name=service_name, version="0.1.0", node=os.getenv("NODE_NAME", "athena")),
+        correlation_id=corr_id,
+        reply_to=reply_channel,
+        payload=payload.model_dump(mode="json"),
+    )
+    msg = await bus.rpc_request(request_channel, env, reply_channel=reply_channel, timeout_sec=timeout_sec)
+    decoded = bus.codec.decode(msg.get("data"))
+    if not decoded.ok:
+        raise RuntimeError(f"LLM gateway RPC failed: {decoded.error}")
+    payload_out = decoded.envelope.payload if isinstance(decoded.envelope.payload, dict) else {}
+    content = str(payload_out.get("content") or payload_out.get("text") or "")
+    return content
+
+
+# ===========================================================================
+# Crystallization builder -- mirrors
+# scripts/concept_relation_digest.py::_build_reflection_crystallization()
+# exactly (same governance shape, same apply_salience()+insert_crystallization()
+# pipeline).
+# ===========================================================================
+
+
+def _build_reflection_crystallization(
+    agg: DriveHistoryAggregationV1,
+    narrative: GroundedNarrative,
+    facts: list[GroundedFact],
+    events_by_id: Mapping[str, DriveAuditEvent],
+):
+    from orion.memory.crystallization.salience import apply_salience
+    from orion.memory.crystallization.schemas import (
+        CrystallizationEvidenceRefV1,
+        CrystallizationGovernanceV1,
+        MemoryCrystallizationV1,
+        _utc_now,
+        new_crystallization_id,
+    )
+
+    now = _utc_now()
+    subject_line = f"Drive-activation history reflection: {agg.subject}"
+
+    facts_by_index = {f.index: f for f in facts}
+    cited_facts = [facts_by_index[n] for n in narrative.cited_fact_numbers if n in facts_by_index]
+
+    evidence: list[CrystallizationEvidenceRefV1] = [
+        # Evidence ref #1: the reducer's own aggregation, so a human reviewer
+        # can verify the narrative actually matches what was computed -- not
+        # just that some raw event IDs exist.
+        CrystallizationEvidenceRefV1(
+            source_kind="rdf_memory_graph",
+            source_id=f"drive_history_aggregation:{agg.subject}:{agg.since.date().isoformat()}",
+            strength=1.0,
+            note=(
+                f"aggregation: top_dominant_drive={agg.top_dominant_drive} "
+                f"count={agg.top_dominant_drive_count}/{agg.total_events} "
+                f"distinct_days={agg.distinct_days} cited_fact_numbers={list(narrative.cited_fact_numbers)}"
+            ),
+        )
+    ]
+
+    # Evidence refs #2..N: the real underlying DriveAuditV1 artifacts the LLM
+    # actually cited, each traceable back to the Fuseki drives graph by
+    # artifact_id.
+    for fact in cited_facts:
+        if not fact.artifact_id:
+            continue
+        ev = events_by_id.get(fact.artifact_id)
+        if ev is None:
+            continue
+        note = f"raw_event: ts={ev.created_at.isoformat()} dominant_drive={ev.dominant_drive}"
+        # Pressures/active-drives are only present when detail enrichment
+        # succeeded (best-effort, see fetch_event_details) -- included when
+        # available so this evidence note is actually useful for the "per-drive
+        # detail" a human reviewer would want, not just timestamp+dominant.
+        if ev.drive_pressures:
+            note += f" pressures={dict(sorted(ev.drive_pressures.items()))}"
+        if ev.active_drives:
+            note += f" active_drives={list(ev.active_drives)}"
+        evidence.append(
+            CrystallizationEvidenceRefV1(
+                source_kind="rdf_memory_graph",
+                source_id=ev.artifact_id,
+                strength=0.8,
+                note=note,
+            )
+        )
+
+    crystallization = MemoryCrystallizationV1(
+        crystallization_id=new_crystallization_id(),
+        kind="reflection",
+        subject=subject_line,
+        summary=narrative.narrative,
+        status="active",
+        scope=["project:orion", f"subject:{agg.subject}"],
+        evidence=evidence,
+        governance=CrystallizationGovernanceV1(
+            proposed_by="system:drive_history_reflection_synthesis",
+            approved_by="system:drive_history_reflection_synthesis",
+            approval_mode="auto_policy",
+            validation_status="valid",
+            requires_manual_review=False,
+            sensitivity="private",
+            created_from_policy="drive_history_reflection_synthesis",
+        ),
+        created_at=now,
+        updated_at=now,
+    )
+    return apply_salience(crystallization)
+
+
+class _SingleConnPool:
+    """Thin shim so repository.py::insert_crystallization() (which expects an
+    asyncpg.Pool and calls pool.acquire()) can run on a single already-open
+    connection. Mirrors scripts/concept_relation_digest.py's identical shim."""
+
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    def acquire(self) -> "_SingleConnPool":
+        return self
+
+    async def __aenter__(self) -> Any:
+        return self._conn
+
+    async def __aexit__(self, *exc_info: Any) -> bool:
+        return False
+
+
+# ===========================================================================
+# Orchestration
+# ===========================================================================
+
+
+@dataclass
+class RunResult:
+    status: str
+    subject: str
+    since: datetime
+    max_events: int
+    aggregation: DriveHistoryAggregationV1 | None = None
+    narrative: str | None = None
+    cited_fact_numbers: tuple[int, ...] = ()
+    crystallization_id: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        agg = self.aggregation
+        return {
+            "status": self.status,
+            "subject": self.subject,
+            "since": self.since.isoformat(),
+            "max_events": self.max_events,
+            "aggregation": (
+                {
+                    "total_events": agg.total_events,
+                    "distinct_days": agg.distinct_days,
+                    "top_dominant_drive": agg.top_dominant_drive,
+                    "top_dominant_drive_count": agg.top_dominant_drive_count,
+                    "top_dominant_drive_share": agg.top_dominant_drive_share,
+                    "dominant_drive_counts": dict(agg.dominant_drive_counts),
+                    "day_counts": dict(agg.day_counts),
+                    "sufficient": agg.sufficient,
+                    "insufficiency_reason": agg.insufficiency_reason,
+                }
+                if agg is not None
+                else None
+            ),
+            "narrative": self.narrative,
+            "cited_fact_numbers": list(self.cited_fact_numbers),
+            "crystallization_id": self.crystallization_id,
+            "error": self.error,
+        }
+
+
+async def _run_once(
+    *,
+    sparql_client: Any,
+    bus: Any,
+    postgres_uri: str,
+    subject: str,
+    since: datetime,
+    max_events: int = DEFAULT_MAX_EVENTS,
+    llm_route: str = "metacog",
+    llm_request_channel: str = "orion:exec:request:LLMGatewayService",
+    llm_timeout_sec: float = 30.0,
+    graph_uri: str = AUTONOMY_DRIVES_GRAPH,
+    detail_sparql_client: Any | None = None,
+) -> RunResult:
+    """Core orchestration, fully injectable (sparql_client / bus / postgres_uri)
+    for testing without a live Fuseki/Redis/Postgres. `sparql_client` needs only
+    `.select()`; `bus` needs only `.rpc_request()` + `.codec.decode()`."""
+    result = RunResult(status="unknown", subject=subject, since=since, max_events=max_events)
+
+    try:
+        # fetch_drive_history_events is a blocking `requests`-based call (real
+        # windows have been observed to take 20+ seconds against Fuseki) --
+        # run it off the event loop so it cannot stall bus/asyncio machinery.
+        events = await asyncio.to_thread(
+            fetch_drive_history_events,
+            sparql_client,
+            since=since,
+            subject=subject,
+            graph_uri=graph_uri,
+            max_events=max_events,
+        )
+    except Exception as exc:
+        result.status = "sparql_query_failed"
+        result.error = str(exc)
+        return result
+
+    agg = reduce_drive_history(events, subject=subject, since=since)
+    result.aggregation = agg
+
+    if not agg.sufficient:
+        result.status = "insufficient_history"
+        result.error = agg.insufficiency_reason
+        return result
+
+    # Same-day dedup guard: skip cleanly (no LLM call, no write) if a
+    # reflection for this exact (subject, calendar day of `since`) was
+    # already synthesized -- the most common accidental-duplicate case for a
+    # manual/on-demand tool is simply re-running it the same day. This does
+    # NOT solve cross-window redundancy in general (a rolling --since-days
+    # window run on two different days will still both pass this check and
+    # can each produce a real, independently-grounded reflection covering
+    # overlapping history) -- that broader problem is intentionally left to
+    # human review, per this script's manual/on-demand design (see README).
+    dedup_source_id = f"drive_history_aggregation:{subject}:{since.date().isoformat()}"
+    try:
+        import asyncpg
+
+        dedup_conn = await asyncpg.connect(postgres_uri)
+        try:
+            existing_id = await dedup_conn.fetchval(
+                "SELECT crystallization_id FROM memory_crystallization_sources "
+                "WHERE source_kind = $1 AND source_id = $2 LIMIT 1",
+                "rdf_memory_graph",
+                dedup_source_id,
+            )
+        finally:
+            await dedup_conn.close()
+    except Exception as exc:
+        # Dedup is a best-effort convenience, not a correctness guarantee --
+        # a failed check must not block an otherwise-valid synthesis run.
+        logger.warning("drive_history_reflection_synthesis: dedup check failed (continuing): %s", exc)
+        existing_id = None
+
+    if existing_id:
+        result.status = "already_synthesized_today"
+        result.crystallization_id = str(existing_id)
+        result.error = (
+            f"a reflection for subject={subject!r} since={since.date().isoformat()} already exists "
+            f"(crystallization_id={existing_id}); skipping duplicate synthesis"
+        )
+        return result
+
+    events_by_id = {ev.artifact_id: ev for ev in events}
+
+    # Per-drive pressure/active-drive detail is fetched ONLY for the bounded
+    # citable sample (see fetch_drive_history_events's docstring for the real
+    # live-measured performance reason this is not done for the full fetched
+    # window). Not fatal on failure -- the narrative prompt does not reference
+    # raw pressures/active-drives today, only timestamp/dominant_drive/summary,
+    # so a detail-enrichment failure degrades to plainer evidence notes rather
+    # than aborting an otherwise-valid, already-reduced run.
+    #
+    # Live measurement finding: the detail join (VALUES + double OPTIONAL
+    # through orion:hasDriveAssessment / orion:highlightsActiveDrive) did not
+    # return within 60s against a live Fuseki instance with ~437k persisted
+    # DriveAudit artifacts (~2.6M assessment triples) EVEN at citable-sample
+    # scale (8 artifacts) -- the slowness is not proportional to the VALUES
+    # set size, so it is very likely Jena/Fuseki failing to push the VALUES
+    # restriction down before scanning DriveAssessment triples. A dedicated,
+    # short `detail_sparql_client` (default well under `sparql_client`'s
+    # timeout) is used here so this best-effort enrichment fails fast and
+    # degrades rather than stalling an otherwise-successful run -- especially
+    # important because `orion.graph.fuseki_http.call_with_fuseki_retry`
+    # retries transient failures up to 4x with backoff, which would otherwise
+    # multiply a single slow query into several minutes of blocking.
+    cited_events = [events_by_id[eid] for eid in agg.cited_event_ids if eid in events_by_id]
+    if cited_events:
+        try:
+            enriched = await asyncio.to_thread(
+                fetch_event_details, detail_sparql_client or sparql_client, cited_events, graph_uri=graph_uri
+            )
+            for ev in enriched:
+                events_by_id[ev.artifact_id] = ev
+            # Re-reduce over the now-enriched events so mean_pressure_by_drive /
+            # active_drive_frequency on the reported aggregation reflect real
+            # data instead of staying unconditionally empty (reduce_drive_history
+            # is pure and deterministic over cited_event_ids/day/dominant-drive
+            # counts, so re-running it here changes nothing except the two
+            # pressure/active fields, which now see the enriched subset).
+            agg = reduce_drive_history(list(events_by_id.values()), subject=subject, since=since)
+            result.aggregation = agg
+        except Exception as exc:
+            logger.warning("drive_history_reflection_synthesis: event-detail enrichment failed: %s", exc)
+
+    facts = build_fact_sheet(agg, events_by_id)
+    prompt = _build_narrative_prompt(agg, facts)
+
+    try:
+        raw_content = await _call_llm_narrative(
+            bus,
+            prompt=prompt,
+            route=llm_route,
+            request_channel=llm_request_channel,
+            timeout_sec=llm_timeout_sec,
+            service_name="drive-history-reflection-synthesis",
+        )
+    except Exception as exc:
+        result.status = "llm_call_failed"
+        result.error = str(exc)
+        return result
+
+    try:
+        narrative = parse_and_validate_narrative(raw_content, facts)
+    except NarrativeUngrounded as exc:
+        result.status = "llm_output_ungrounded"
+        result.error = str(exc)
+        return result
+
+    result.narrative = narrative.narrative
+    result.cited_fact_numbers = narrative.cited_fact_numbers
+
+    crystallization = _build_reflection_crystallization(agg, narrative, facts, events_by_id)
+
+    import asyncpg
+
+    from orion.memory.crystallization.repository import insert_crystallization
+
+    conn = await asyncpg.connect(postgres_uri)
+    try:
+        cid = await insert_crystallization(_SingleConnPool(conn), crystallization)
+    except Exception as exc:
+        result.status = "insert_failed"
+        result.error = str(exc)
+        return result
+    finally:
+        await conn.close()
+
+    result.status = "created"
+    result.crystallization_id = cid
+    return result
+
+
+def _print_report(result: RunResult) -> None:
+    print(
+        f"drive_history_reflection_synthesis: subject={result.subject!r} "
+        f"since={result.since.isoformat()} status={result.status}"
+    )
+    agg = result.aggregation
+    if agg is not None:
+        print(
+            f"  history: {agg.total_events} event(s) fetched, {agg.distinct_days} distinct day(s) "
+            f"(min required: {MIN_EVENTS} events / {MIN_DISTINCT_DAYS} days)"
+        )
+        if agg.top_dominant_drive:
+            print(
+                f"  top dominant drive: {agg.top_dominant_drive} "
+                f"({agg.top_dominant_drive_count}/{agg.total_events}, "
+                f"{agg.top_dominant_drive_share * 100:.0f}%)"
+            )
+
+    if result.status == "insufficient_history":
+        print(f"  refusing to synthesize: {result.error}")
+    elif result.status == "already_synthesized_today":
+        print(f"  skipping duplicate: {result.error}")
+    elif result.status == "sparql_query_failed":
+        print(f"  SPARQL query failed: {result.error}")
+    elif result.status == "llm_call_failed":
+        print(f"  LLM call failed: {result.error}")
+    elif result.status == "llm_output_ungrounded":
+        print(f"  LLM output rejected as ungrounded: {result.error}")
+    elif result.status == "insert_failed":
+        print(f"  crystallization insert failed: {result.error}")
+    elif result.status == "created":
+        print(f"  cited facts: {list(result.cited_fact_numbers)}")
+        print(f"  crystallization created: {result.crystallization_id}")
+        print("  summary:")
+        print(f"    {result.narrative}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--postgres-uri",
+        default=os.getenv("POSTGRES_URI", ""),
+        help="Postgres DSN. Defaults to $POSTGRES_URI (e.g. services/orion-hub/.env).",
+    )
+    parser.add_argument("--subject", default=DEFAULT_SUBJECT, help="DriveAuditV1 subjectKey to read (default: orion).")
+    parser.add_argument(
+        "--since-days",
+        type=int,
+        default=DEFAULT_SINCE_DAYS,
+        help=f"How many days of drive-audit history to consider (default: {DEFAULT_SINCE_DAYS}). "
+        "The system may not have this much retained history yet -- real coverage found is always "
+        "reported explicitly, never assumed.",
+    )
+    parser.add_argument(
+        "--max-events",
+        type=int,
+        default=DEFAULT_MAX_EVENTS,
+        help=f"Cap on raw ticks fetched from Fuseki (default: {DEFAULT_MAX_EVENTS}, most recent first).",
+    )
+    parser.add_argument(
+        "--query-url",
+        default="",
+        help="Explicit Fuseki SPARQL query URL. Defaults to autonomy-graph resolution "
+        "(AUTONOMY_GRAPH_QUERY_URL / RDF_STORE_QUERY_URL / RDF_STORE_BASE_URL derivation).",
+    )
+    parser.add_argument(
+        "--sparql-timeout-sec",
+        type=float,
+        default=60.0,
+        help="Live measurement: a 30-day/500-event list query took ~24s against real "
+        "Fuseki -- default gives headroom over that.",
+    )
+    parser.add_argument(
+        "--detail-timeout-sec",
+        type=float,
+        default=10.0,
+        help="Timeout for the small, best-effort per-drive detail enrichment query "
+        "(see fetch_event_details). Deliberately short and separate from "
+        "--sparql-timeout-sec: live measurement found this specific join did not "
+        "return within 60s even at citable-sample scale (~8 artifacts), and "
+        "orion.graph.fuseki_http.call_with_fuseki_retry retries transient failures "
+        "up to 4x -- a short timeout here keeps a slow/stuck detail join from "
+        "blocking an otherwise-successful run for minutes.",
+    )
+    parser.add_argument("--redis", default=os.getenv("ORION_BUS_URL", "redis://localhost:6379/0"), help="Orion bus URL.")
+    parser.add_argument(
+        "--llm-request-channel",
+        default=os.getenv("CHANNEL_LLM_INTAKE", "orion:exec:request:LLMGatewayService"),
+    )
+    parser.add_argument("--llm-route", default=os.getenv("TURN_CHANGE_CLASSIFY_ROUTE", "metacog"))
+    parser.add_argument("--llm-timeout-sec", type=float, default=30.0)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of prose.")
+    args = parser.parse_args(argv)
+
+    if not args.postgres_uri.strip():
+        print(
+            "drive_history_reflection_synthesis: no --postgres-uri given and $POSTGRES_URI is unset. "
+            "Check services/orion-hub/.env for POSTGRES_URI.",
+            file=sys.stderr,
+        )
+        return 2
+
+    from orion.graph.backend_config import resolve_autonomy_read_query_url, resolve_rdf_store_auth
+    from orion.graph.sparql_client import SparqlQueryClient
+    from orion.core.bus.async_service import OrionBusAsync
+
+    query_url = args.query_url.strip() or resolve_autonomy_read_query_url()[0]
+    if not query_url:
+        print(
+            "drive_history_reflection_synthesis: no SPARQL query endpoint resolved. "
+            "Set --query-url, AUTONOMY_GRAPH_QUERY_URL, RDF_STORE_QUERY_URL, or RDF_STORE_BASE_URL.",
+            file=sys.stderr,
+        )
+        return 2
+
+    user, password = resolve_rdf_store_auth()
+    sparql_client = SparqlQueryClient(query_url, timeout_sec=args.sparql_timeout_sec, user=user, password=password)
+    detail_sparql_client = SparqlQueryClient(
+        query_url, timeout_sec=args.detail_timeout_sec, user=user, password=password
+    )
+
+    since = datetime.now(timezone.utc) - timedelta(days=args.since_days)
+
+    async def _main_async() -> RunResult:
+        bus = OrionBusAsync(args.redis)
+        await bus.connect()
+        try:
+            return await _run_once(
+                sparql_client=sparql_client,
+                detail_sparql_client=detail_sparql_client,
+                bus=bus,
+                postgres_uri=args.postgres_uri,
+                subject=args.subject,
+                since=since,
+                max_events=args.max_events,
+                llm_route=args.llm_route,
+                llm_request_channel=args.llm_request_channel,
+                llm_timeout_sec=args.llm_timeout_sec,
+            )
+        finally:
+            await bus.close()
+
+    try:
+        result = asyncio.run(_main_async())
+    except Exception as exc:
+        print(f"drive_history_reflection_synthesis: run failed -- {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result.to_dict(), default=str))
+    else:
+        _print_report(result)
+
+    return 0 if result.status in ("created", "insufficient_history", "already_synthesized_today") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/orion-memory-consolidation/README.md
+++ b/services/orion-memory-consolidation/README.md
@@ -68,6 +68,77 @@ Use this checklist any time this service (or its cron dependency) is missing aft
 3. **Run the liveness check once by hand** (`make check-concept-relation-digest-liveness`) to confirm the new cron entry is actually firing, rather than waiting up to 3 hours to find out.
 4. **Do not assume `CONCEPT_RELATION_RESOLUTION_ENABLED=true` implies the digest is scheduled** -- they are two independent things that must both be true for the loop documented above to actually close. This exact "flag on, dependency not wired" pattern has already caused silent no-ops twice in this repo (`CONCEPT_RELATION_RESOLUTION_ENABLED` itself missing its embed/chroma hosts on first activation, and `RECALL_GRAPHITI_IN_CHAT` missing its adapter URL) -- checking both halves explicitly, every time, is cheaper than re-discovering this.
 
+## Drive-history reflection synthesis (manual/on-demand only -- NOT cron'd)
+
+`scripts/drive_history_reflection_synthesis.py` (repo root) reads Orion's own real,
+persisted drive-activation history and synthesizes ONE `reflection`-kind
+`MemoryCrystallizationV1` observing a long-horizon pattern -- e.g. "continuity has
+been the dominant drive in most audited ticks this week." Source data: `DriveAuditV1`
+(`orion/core/schemas/drives.py`) is computed on every DriveEngine tick and persisted,
+append-only, by `services/orion-rdf-writer` to the Fuseki `drives` graph
+(`http://conjourney.net/graph/autonomy/drives`) -- unlike the "latest value only"
+stores this repo already has for the same signal (`LocalProfileStore` /
+`autonomy_state_v2`'s single-row UPSERT), this graph is a genuine historical
+time-series, one triple-set per tick.
+
+**Architecture is deliberately split into a deterministic reducer stage and a
+narrow LLM-phrasing stage** (event -> schema -> trace -> reducer -> projection ->
+LLM phrasing -> crystallization, per this repo's event-substrate-first mandate) --
+the LLM is never shown raw per-tick SPARQL rows:
+
+1. Fetch real `DriveAuditV1` ticks from Fuseki (bounded by `--max-events`, most
+   recent first).
+2. `reduce_drive_history()` -- a **pure, unit-tested Python function** (same bar as
+   `orion/spark/concept_induction/drive_tension.py`: synthetic-input/known-output
+   tests, zero LLM involvement) -- aggregates them into dominant-drive counts/shares,
+   a per-day breakdown, active-drive frequency, and mean pressures.
+3. `build_fact_sheet()` renders that aggregation into a small numbered list of
+   already-computed, already-verified fact strings (real dates, real counts, real
+   percentages, real timestamps).
+4. The LLM (bus RPC, same pattern as `concept_relation.py::resolve_concept_relation()`)
+   receives ONLY the fact sheet and is asked to phrase ONE narrative sentence,
+   citing specific facts by number.
+5. `parse_and_validate_narrative()` enforces the grounding guardrail: every cited
+   fact's real literal tokens (drive name, date, percentage, or timestamp) must
+   appear verbatim in the narrative text, or the run is rejected -- an LLM cannot
+   pass validation by inventing plausible-sounding but fake specifics.
+6. Only then is a `reflection` crystallization written, with evidence refs citing
+   both the aggregation object and the real cited `DriveAuditV1` artifacts, so a
+   human reviewer can verify the narrative against what was actually computed.
+
+**Guardrail: refuses to synthesize on thin data.** Below `MIN_EVENTS=5` real ticks
+or `MIN_DISTINCT_DAYS=2` distinct calendar days in the queried window, the reducer
+marks the aggregation insufficient and the script exits cleanly reporting exactly
+why -- no LLM call is made, nothing is written. `MIN_DISTINCT_DAYS` exists because
+DriveEngine ticks several times a minute in a single session, so event *count*
+alone can be satisfied entirely within one sitting; requiring real day-spread is
+what distinguishes an actual long-horizon pattern from a burst.
+
+Run:
+
+```bash
+POSTGRES_URI=postgresql://user:pass@host:port/db python scripts/drive_history_reflection_synthesis.py
+python scripts/drive_history_reflection_synthesis.py --postgres-uri postgresql://... --since-days 14
+python scripts/drive_history_reflection_synthesis.py --json
+```
+
+| Env / flag | Default | Purpose |
+|---|---|---|
+| `--postgres-uri` / `$POSTGRES_URI` | *(required)* | Same convention as `concept_relation_digest.py` |
+| `--subject` | `orion` | `DriveAuditV1.subjectKey` to read |
+| `--since-days` | `30` | Window size; real coverage found is always reported, never assumed |
+| `--max-events` | `500` | Cap on raw ticks fetched from Fuseki (most recent first) |
+| `--query-url` | *(resolved)* | Explicit Fuseki SPARQL query URL; else `AUTONOMY_GRAPH_QUERY_URL` / `RDF_STORE_QUERY_URL` / Fuseki derivation |
+| `--redis` / `$ORION_BUS_URL` | `redis://localhost:6379/0` | Bus URL for the LLM gateway RPC |
+| `--llm-route` | `metacog` | Gateway route for the narrative-phrasing call |
+
+**This is NOT scheduled or cron'd in this patch, unlike `concept_relation_digest.py`
+above.** It is explicitly a manual/on-demand tool: its output (a narrative claim
+about Orion's own long-horizon tendencies) needs human review before anyone should
+trust it as a recurring automated process. Run it by hand, read the generated
+`summary` text critically, and decide separately whether a cron entry is warranted
+once the grounding guardrail and prompt have been proven out on real data.
+
 ## Channels
 
 | Direction | Channel |

--- a/tests/test_drive_history_reflection_synthesis.py
+++ b/tests/test_drive_history_reflection_synthesis.py
@@ -1,0 +1,881 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import drive_history_reflection_synthesis as dhrs  # noqa: E402
+
+
+# ===========================================================================
+# Reducer -- pure, synthetic-input/known-output (mirrors
+# orion/spark/concept_induction/tests/test_drive_tension.py's bar).
+# ===========================================================================
+
+
+def _ev(day: str, hour: int, *, dominant: str | None, artifact_id: str | None = None, active=(), pressures=None) -> dhrs.DriveAuditEvent:
+    return dhrs.DriveAuditEvent(
+        artifact_id=artifact_id or f"drive-audit-{day}-{hour}",
+        created_at=datetime.fromisoformat(f"{day}T{hour:02d}:00:00+00:00"),
+        dominant_drive=dominant,
+        summary=f"summary for {day} {hour}h",
+        active_drives=tuple(active),
+        drive_pressures=pressures or {},
+    )
+
+
+class TestReduceDriveHistory:
+    def test_empty_events_is_insufficient(self):
+        agg = dhrs.reduce_drive_history([], subject="orion", since=datetime.now(timezone.utc))
+
+        assert agg.total_events == 0
+        assert agg.distinct_days == 0
+        assert agg.sufficient is False
+        assert "0 event" in agg.insufficiency_reason
+        assert agg.top_dominant_drive is None
+        assert agg.cited_event_ids == ()
+
+    def test_below_min_events_is_insufficient(self):
+        events = [_ev("2026-06-14", h, dominant="continuity") for h in range(3)]
+
+        agg = dhrs.reduce_drive_history(events, subject="orion", since=datetime.now(timezone.utc))
+
+        assert agg.total_events == 3
+        assert agg.sufficient is False
+        assert "need >= 5" in agg.insufficiency_reason
+
+    def test_below_min_distinct_days_is_insufficient_even_with_many_events(self):
+        # 10 ticks, all in one session/day -- event COUNT alone is satisfied,
+        # but this must still refuse: a burst within one sitting is not a
+        # "long-horizon pattern".
+        events = [_ev("2026-06-14", h, dominant="continuity") for h in range(10)]
+
+        agg = dhrs.reduce_drive_history(events, subject="orion", since=datetime.now(timezone.utc))
+
+        assert agg.total_events == 10
+        assert agg.distinct_days == 1
+        assert agg.sufficient is False
+        assert "distinct day" in agg.insufficiency_reason
+
+    def test_sufficient_history_known_counts_and_shares(self):
+        events = [
+            _ev("2026-06-14", 9, dominant="continuity"),
+            _ev("2026-06-14", 10, dominant="continuity"),
+            _ev("2026-06-14", 11, dominant="autonomy"),
+            _ev("2026-06-15", 9, dominant="continuity"),
+            _ev("2026-06-15", 10, dominant="continuity"),
+            _ev("2026-06-15", 11, dominant="continuity"),
+        ]
+        since = datetime(2026, 6, 14, tzinfo=timezone.utc)
+
+        agg = dhrs.reduce_drive_history(events, subject="orion", since=since)
+
+        assert agg.total_events == 6
+        assert agg.distinct_days == 2
+        assert agg.sufficient is True
+        assert agg.insufficiency_reason is None
+        assert agg.dominant_drive_counts == {"continuity": 5, "autonomy": 1}
+        assert agg.top_dominant_drive == "continuity"
+        assert agg.top_dominant_drive_count == 5
+        assert abs(agg.top_dominant_drive_share - (5 / 6)) < 1e-9
+        assert agg.day_counts == {"2026-06-14": 3, "2026-06-15": 3}
+        assert agg.day_dominant_drive == {"2026-06-14": "continuity", "2026-06-15": "continuity"}
+        assert agg.until == events[-1].created_at
+
+    def test_tie_break_is_deterministic_alphabetical(self):
+        events = [
+            _ev("2026-06-14", 9, dominant="continuity"),
+            _ev("2026-06-15", 9, dominant="autonomy"),
+        ]
+        events = events * 3  # can't dup artifact_id, build distinct instead below
+        events = [
+            _ev("2026-06-14", 9, dominant="continuity", artifact_id="a1"),
+            _ev("2026-06-15", 9, dominant="autonomy", artifact_id="a2"),
+        ]
+
+        agg = dhrs.reduce_drive_history(
+            events, subject="orion", since=datetime.now(timezone.utc), min_events=2, min_distinct_days=2
+        )
+
+        # Tied 1-1 -- alphabetically first ("autonomy" < "continuity") wins deterministically.
+        assert agg.top_dominant_drive == "autonomy"
+
+    def test_cited_event_ids_include_first_and_last(self):
+        events = [
+            _ev("2026-06-14", h, dominant="continuity", artifact_id=f"a{h}") for h in range(8)
+        ] + [_ev("2026-06-15", 0, dominant="continuity", artifact_id="a_last")]
+
+        agg = dhrs.reduce_drive_history(events, subject="orion", since=datetime.now(timezone.utc), max_cited_events=4)
+
+        assert agg.cited_event_ids[0] == "a0"
+        assert agg.cited_event_ids[-1] == "a_last"
+        assert len(agg.cited_event_ids) <= 4
+
+    def test_active_drive_frequency_and_mean_pressure(self):
+        events = [
+            _ev("2026-06-14", 9, dominant="continuity", active=("continuity", "autonomy"), pressures={"continuity": 0.8, "autonomy": 0.4}),
+            _ev("2026-06-15", 9, dominant="continuity", active=("continuity",), pressures={"continuity": 0.6}),
+        ]
+
+        agg = dhrs.reduce_drive_history(events, subject="orion", since=datetime.now(timezone.utc), min_events=2, min_distinct_days=2)
+
+        assert agg.active_drive_frequency == {"continuity": 2, "autonomy": 1}
+        assert abs(agg.mean_pressure_by_drive["continuity"] - 0.7) < 1e-9
+        assert abs(agg.mean_pressure_by_drive["autonomy"] - 0.4) < 1e-9
+
+    def test_events_with_no_dominant_drive_are_not_fabricated(self):
+        events = [
+            _ev("2026-06-14", 9, dominant=None, artifact_id="a1"),
+            _ev("2026-06-15", 9, dominant=None, artifact_id="a2"),
+        ]
+
+        agg = dhrs.reduce_drive_history(events, subject="orion", since=datetime.now(timezone.utc), min_events=2, min_distinct_days=2)
+
+        assert agg.dominant_drive_counts == {}
+        assert agg.top_dominant_drive is None
+        assert agg.top_dominant_drive_share == 0.0
+
+
+# ===========================================================================
+# Fact sheet -- deterministic rendering of an aggregation.
+# ===========================================================================
+
+
+class TestBuildFactSheet:
+    def test_fact_sheet_contains_real_tokens_only(self):
+        events = [
+            _ev("2026-06-14", 9, dominant="continuity", artifact_id="a1"),
+            _ev("2026-06-14", 10, dominant="continuity", artifact_id="a2"),
+            _ev("2026-06-15", 9, dominant="continuity", artifact_id="a3"),
+        ]
+        since = datetime(2026, 6, 14, tzinfo=timezone.utc)
+        agg = dhrs.reduce_drive_history(events, subject="orion", since=since, min_events=3, min_distinct_days=2)
+        events_by_id = {e.artifact_id: e for e in events}
+
+        facts = dhrs.build_fact_sheet(agg, events_by_id)
+
+        assert facts[0].index == 1
+        assert "continuity" in facts[0].text
+        assert "3" in facts[0].tokens  # top_dominant_drive_count
+        # day facts follow, sorted ascending
+        day_facts = [f for f in facts if f.text.startswith("On ")]
+        assert [f.tokens[0] for f in day_facts] == ["2026-06-14", "2026-06-15"]
+        # event facts carry a real artifact_id back-reference
+        event_facts = [f for f in facts if f.artifact_id]
+        assert {f.artifact_id for f in event_facts} <= {"a1", "a2", "a3"}
+
+    def test_event_fact_tokens_are_naturally_reproducible(self):
+        # Individual-event fact tokens must be a naturalized (no seconds/tz-
+        # offset) timestamp + dominant drive -- not a full ISO-8601 string or
+        # the opaque hashed artifact_id, which a short reflective-voice
+        # sentence is very unlikely to ever reproduce verbatim.
+        events = [
+            _ev("2026-06-14", 9, dominant="continuity", artifact_id="a1"),
+            _ev("2026-06-15", 9, dominant="continuity", artifact_id="a2"),
+        ]
+        since = datetime(2026, 6, 14, tzinfo=timezone.utc)
+        agg = dhrs.reduce_drive_history(events, subject="orion", since=since, min_events=2, min_distinct_days=2)
+        events_by_id = {e.artifact_id: e for e in events}
+
+        facts = dhrs.build_fact_sheet(agg, events_by_id)
+        event_facts = [f for f in facts if f.artifact_id]
+
+        assert event_facts
+        for f in event_facts:
+            assert len(f.tokens) == 2
+            ts_token, drive_token = f.tokens
+            assert "T" not in ts_token  # not a raw ISO-8601 timestamp
+            assert "+00:00" not in ts_token
+            assert f.artifact_id not in f.tokens  # opaque hash is not a grounding token
+            assert drive_token == "continuity"
+
+    def test_day_facts_are_capped_independent_of_window_size(self):
+        # A wide --since-days window with daily activity must not inflate the
+        # fact sheet/prompt without bound -- day-facts are capped at
+        # MAX_DAY_FACTS regardless of how many distinct days are present.
+        events = [
+            _ev(f"2026-0{1 + (d // 28)}-{1 + (d % 28):02d}", 9, dominant="continuity", artifact_id=f"a{d}")
+            for d in range(20)
+        ]
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        agg = dhrs.reduce_drive_history(events, subject="orion", since=since, min_events=5, min_distinct_days=2)
+        assert agg.distinct_days == 20
+        events_by_id = {e.artifact_id: e for e in events}
+
+        facts = dhrs.build_fact_sheet(agg, events_by_id)
+
+        day_facts = [f for f in facts if f.text.startswith("On ")]
+        assert len(day_facts) == dhrs.MAX_DAY_FACTS
+        # keeps the MOST RECENT days, not the earliest
+        assert day_facts[-1].tokens[0] == sorted(agg.day_dominant_drive)[-1]
+
+
+class TestIsSafeSparqlIri:
+    def test_normal_uri_is_safe(self):
+        assert dhrs._is_safe_sparql_iri("http://conjourney.net/orion/autonomy/driveAudit/abc123") is True
+
+    def test_uri_with_angle_bracket_is_unsafe(self):
+        assert dhrs._is_safe_sparql_iri("http://x/a>bogus<http://evil/") is False
+
+    def test_uri_with_whitespace_is_unsafe(self):
+        assert dhrs._is_safe_sparql_iri("http://x/a b") is False
+
+    def test_empty_uri_is_unsafe(self):
+        assert dhrs._is_safe_sparql_iri("") is False
+
+
+class TestDetailSparqlSkipsUnsafeUris:
+    def test_unsafe_uri_is_dropped_not_interpolated(self):
+        sparql = dhrs.build_drive_audit_detail_sparql(
+            artifact_uris=["http://x/good", "http://x/bad>injected"]
+        )
+        assert "<http://x/good>" in sparql
+        assert "bad>injected" not in sparql
+
+
+# ===========================================================================
+# Narrative validation -- the mandatory anti-hallucination guardrail.
+# ===========================================================================
+
+
+def _facts_fixture() -> list[dhrs.GroundedFact]:
+    return [
+        dhrs.GroundedFact(index=1, text="'continuity' dominant 5/6 (83%)", tokens=("continuity", "83%", "5")),
+        dhrs.GroundedFact(index=2, text="On 2026-06-14 continuity", tokens=("2026-06-14", "continuity")),
+        dhrs.GroundedFact(
+            index=3,
+            text="Audit a1 at 2026-06-14 09:00 UTC: dominant_drive=continuity",
+            tokens=("2026-06-14 09:00", "continuity"),
+            artifact_id="a1",
+        ),
+    ]
+
+
+class TestParseAndValidateNarrative:
+    def test_valid_grounded_narrative_is_accepted(self):
+        facts = _facts_fixture()
+        content = json.dumps(
+            {
+                # ALL tokens of fact 1 (continuity, 83%, 5) and fact 3
+                # (2026-06-14 09:00, continuity) appear verbatim.
+                "narrative": (
+                    "Since 2026-06-14 09:00, continuity has stood out, appearing in 5 of this "
+                    "window's audited ticks (83%)."
+                ),
+                "cited_fact_numbers": [1, 3],
+            }
+        )
+
+        result = dhrs.parse_and_validate_narrative(content, facts)
+
+        assert result.cited_fact_numbers == (1, 3)
+        assert "continuity" in result.narrative
+
+    def test_case_insensitive_token_match_is_accepted(self):
+        # An LLM naturally capitalizing a drive name at a sentence start must
+        # not be falsely rejected over case alone.
+        facts = _facts_fixture()
+        content = json.dumps(
+            {
+                "narrative": (
+                    "Continuity dominated since 2026-06-14 09:00, present in 5 of this window's ticks (83%)."
+                ),
+                "cited_fact_numbers": [1, 3],
+            }
+        )
+
+        result = dhrs.parse_and_validate_narrative(content, facts)
+
+        assert result.cited_fact_numbers == (1, 3)
+
+    def test_partial_token_match_is_rejected(self):
+        # Reproducing only the drive name from fact 1 (not its percentage or
+        # count) must NOT count as a grounded citation -- this is the core
+        # hallucination defense: matching one low-entropy token is not proof
+        # the LLM actually reproduced the fact's specific numbers.
+        facts = _facts_fixture()
+        content = json.dumps(
+            {
+                "narrative": (
+                    "continuity dominated recently, at 2026-06-14 09:00 in particular, roughly most of the time."
+                ),
+                "cited_fact_numbers": [1, 3],
+            }
+        )
+        with pytest.raises(dhrs.NarrativeUngrounded):
+            dhrs.parse_and_validate_narrative(content, facts)
+
+    def test_aggregate_only_citations_without_individual_event_are_rejected(self):
+        # Citing only fact 1 (top-dominant, aggregate) and fact 2 (a day-level
+        # aggregate) -- neither carries an artifact_id -- must be rejected:
+        # at least one citation must be a real per-tick DriveAuditV1 artifact.
+        facts = _facts_fixture()
+        content = json.dumps(
+            {
+                "narrative": "continuity dominated 5 of these ticks (83%) on 2026-06-14 in particular.",
+                "cited_fact_numbers": [1, 2],
+            }
+        )
+        with pytest.raises(dhrs.NarrativeUngrounded):
+            dhrs.parse_and_validate_narrative(content, facts)
+
+    def test_malformed_json_is_rejected(self):
+        with pytest.raises(dhrs.NarrativeUngrounded):
+            dhrs.parse_and_validate_narrative("not json at all", _facts_fixture())
+
+    def test_empty_narrative_is_rejected(self):
+        content = json.dumps({"narrative": "  ", "cited_fact_numbers": [1, 3]})
+        with pytest.raises(dhrs.NarrativeUngrounded):
+            dhrs.parse_and_validate_narrative(content, _facts_fixture())
+
+    def test_missing_citations_is_rejected(self):
+        content = json.dumps({"narrative": "Something vague happened.", "cited_fact_numbers": []})
+        with pytest.raises(dhrs.NarrativeUngrounded):
+            dhrs.parse_and_validate_narrative(content, _facts_fixture())
+
+    def test_too_few_valid_citations_is_rejected(self):
+        # Only fact 1 is a real index; fact 99 does not exist and is dropped,
+        # leaving 1 valid citation -- below MIN_CITED_FACTS=2.
+        content = json.dumps(
+            {"narrative": "continuity dominant recently.", "cited_fact_numbers": [1, 99]}
+        )
+        with pytest.raises(dhrs.NarrativeUngrounded):
+            dhrs.parse_and_validate_narrative(content, _facts_fixture())
+
+    def test_citation_without_real_token_in_text_is_rejected(self):
+        # Cites facts 1 and 3 but never actually quotes any of their real
+        # tokens in the narrative -- this is the core hallucination defense.
+        content = json.dumps(
+            {
+                "narrative": "Orion seems to enjoy exploring new ideas lately, generally speaking.",
+                "cited_fact_numbers": [1, 3],
+            }
+        )
+        with pytest.raises(dhrs.NarrativeUngrounded):
+            dhrs.parse_and_validate_narrative(content, _facts_fixture())
+
+
+# ===========================================================================
+# SPARQL query builders -- pure.
+# ===========================================================================
+
+
+class TestSparqlBuilders:
+    def test_event_list_sparql_embeds_subject_and_since(self):
+        since = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        sparql = dhrs.build_drive_audit_event_list_sparql(since=since, subject="orion", limit=100)
+
+        assert 'orion:subjectKey "orion"' in sparql
+        assert "2026-06-01T00:00:00" in sparql
+        assert "LIMIT 100" in sparql
+        assert "orion:DriveAudit" in sparql
+
+    def test_event_list_sparql_escapes_subject(self):
+        since = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        sparql = dhrs.build_drive_audit_event_list_sparql(since=since, subject='ori"on', limit=10)
+
+        assert '\\"' in sparql
+
+    def test_detail_sparql_uses_values_clause(self):
+        sparql = dhrs.build_drive_audit_detail_sparql(artifact_uris=["http://x/a", "http://x/b"])
+
+        assert "VALUES ?artifact" in sparql
+        assert "<http://x/a>" in sparql
+        assert "<http://x/b>" in sparql
+
+
+class TestParseBindings:
+    def test_parse_event_list_bindings_skips_incomplete_rows(self):
+        bindings = [
+            {
+                "artifact": {"type": "uri", "value": "http://x/a"},
+                "artifact_id": {"type": "literal", "value": "a1"},
+                "created_at": {"type": "literal", "value": "2026-06-14T09:00:00+00:00"},
+                "dominant_drive": {"type": "literal", "value": "continuity"},
+            },
+            {"artifact_id": {"type": "literal", "value": "a2"}},  # missing created_at -- skipped
+        ]
+
+        events = dhrs.parse_event_list_bindings(bindings)
+
+        assert len(events) == 1
+        assert events[0].artifact_id == "a1"
+        assert events[0].dominant_drive == "continuity"
+
+    def test_merge_event_details_attaches_pressures_and_active_drives(self):
+        events = [
+            dhrs.DriveAuditEvent(
+                artifact_id="a1",
+                created_at=datetime(2026, 6, 14, 9, tzinfo=timezone.utc),
+                artifact_uri="http://x/a",
+            )
+        ]
+        detail_bindings = [
+            {
+                "artifact": {"value": "http://x/a"},
+                "drive_name": {"value": "continuity"},
+                "drive_pressure": {"value": "0.7"},
+            },
+            {"artifact": {"value": "http://x/a"}, "active_drive": {"value": "continuity"}},
+        ]
+
+        merged = dhrs.merge_event_details(events, detail_bindings)
+
+        assert merged[0].drive_pressures == {"continuity": 0.7}
+        assert merged[0].active_drives == ("continuity",)
+
+
+# ===========================================================================
+# Fetch layer -- fake SPARQL client (boundary mock, no live Fuseki).
+# ===========================================================================
+
+
+class FakeSparqlClient:
+    def __init__(self, list_bindings, detail_bindings=None, list_error: Exception | None = None):
+        self.list_bindings = list_bindings
+        self.detail_bindings = detail_bindings or []
+        self.list_error = list_error
+        self.calls: list[str] = []
+
+    def select(self, sparql: str):
+        self.calls.append(sparql)
+        if "VALUES ?artifact" in sparql:
+            return self.detail_bindings
+        if self.list_error is not None:
+            raise self.list_error
+        return self.list_bindings
+
+
+def _binding(artifact_id: str, day: str, hour: int, dominant: str, uri: str | None = None) -> dict:
+    row = {
+        "artifact": {"type": "uri", "value": uri or f"http://conjourney.net/orion/autonomy/driveAudit/{artifact_id}"},
+        "artifact_id": {"type": "literal", "value": artifact_id},
+        "created_at": {"type": "literal", "value": f"{day}T{hour:02d}:00:00+00:00"},
+        "dominant_drive": {"type": "literal", "value": dominant},
+        "summary": {"type": "literal", "value": f"{dominant} pressure concentrates"},
+    }
+    return row
+
+
+class TestFetchDriveHistoryEvents:
+    """fetch_drive_history_events is list-only (no detail join) -- see its
+    docstring: a detail join at the full fetched-window scale (up to
+    DEFAULT_MAX_EVENTS=500 artifacts) was measured live against real Fuseki
+    and did not return within minutes, so per-drive detail is fetched
+    separately, only for the bounded citable sample, via fetch_event_details."""
+
+    def test_only_list_query_runs(self):
+        client = FakeSparqlClient(list_bindings=[])
+
+        events = dhrs.fetch_drive_history_events(client, since=datetime.now(timezone.utc), subject="orion")
+
+        assert events == []
+        assert len(client.calls) == 1
+        assert "VALUES ?artifact" not in client.calls[0]
+
+    def test_events_are_returned_without_detail_fetch(self):
+        bindings = [_binding("a1", "2026-06-14", 9, "continuity")]
+        client = FakeSparqlClient(list_bindings=bindings, detail_bindings=[])
+
+        events = dhrs.fetch_drive_history_events(client, since=datetime.now(timezone.utc), subject="orion")
+
+        assert len(events) == 1
+        assert len(client.calls) == 1  # list query only -- no detail join here
+        assert events[0].drive_pressures == {}
+        assert events[0].active_drives == ()
+
+    def test_sparql_error_propagates(self):
+        client = FakeSparqlClient(list_bindings=[], list_error=RuntimeError("fuseki down"))
+
+        with pytest.raises(RuntimeError):
+            dhrs.fetch_drive_history_events(client, since=datetime.now(timezone.utc), subject="orion")
+
+
+class TestFetchEventDetails:
+    def test_enriches_given_small_event_set(self):
+        events = [
+            dhrs.DriveAuditEvent(
+                artifact_id="a1",
+                created_at=datetime(2026, 6, 14, 9, tzinfo=timezone.utc),
+                artifact_uri="http://x/a",
+            )
+        ]
+        client = FakeSparqlClient(
+            list_bindings=[],
+            detail_bindings=[
+                {"artifact": {"value": "http://x/a"}, "drive_name": {"value": "continuity"}, "drive_pressure": {"value": "0.6"}},
+            ],
+        )
+
+        enriched = dhrs.fetch_event_details(client, events)
+
+        assert enriched[0].drive_pressures == {"continuity": 0.6}
+        assert any("VALUES ?artifact" in c for c in client.calls)
+
+    def test_no_artifact_uris_short_circuits(self):
+        events = [dhrs.DriveAuditEvent(artifact_id="a1", created_at=datetime.now(timezone.utc))]
+        client = FakeSparqlClient(list_bindings=[], detail_bindings=[])
+
+        enriched = dhrs.fetch_event_details(client, events)
+
+        assert enriched == events
+        assert client.calls == []
+
+    def test_detail_error_propagates(self):
+        events = [
+            dhrs.DriveAuditEvent(
+                artifact_id="a1", created_at=datetime.now(timezone.utc), artifact_uri="http://x/a"
+            )
+        ]
+        client = FakeSparqlClient(list_bindings=[], list_error=RuntimeError("fuseki down"))
+        # Force the VALUES-clause branch to also raise:
+        client.list_error = RuntimeError("fuseki down")
+
+        def _select(sparql):
+            raise RuntimeError("fuseki down")
+
+        client.select = _select
+
+        with pytest.raises(RuntimeError):
+            dhrs.fetch_event_details(client, events)
+
+
+# ===========================================================================
+# End-to-end orchestration (_run_once) -- SPARQL client + bus mocked at their
+# boundaries; Postgres mocked with a FakeConn double, same style as
+# tests/test_concept_relation_digest.py.
+# ===========================================================================
+
+
+class _NullAsyncCtx:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class FakeConn:
+    """Minimal in-process double for the asyncpg.Connection calls
+    repository.py::insert_crystallization() makes -- mirrors
+    tests/test_concept_relation_digest.py's FakeConn exactly."""
+
+    def __init__(self, existing_sources: list[dict] | None = None) -> None:
+        self.crystallizations: dict[str, dict] = {}
+        self.sources: list[dict] = list(existing_sources or [])
+        self.closed = False
+
+    def transaction(self):
+        return _NullAsyncCtx()
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def fetchrow(self, sql: str, *args):
+        if "INSERT INTO memory_crystallizations" in sql:
+            crystallization_id = args[0] if args and args[0] else str(uuid4())
+            self.crystallizations[crystallization_id] = {"args": args}
+            return {"crystallization_id": crystallization_id}
+        raise AssertionError(f"FakeConn.fetchrow: unexpected query: {sql}")
+
+    async def fetchval(self, sql: str, *args):
+        if "SELECT crystallization_id" in sql and "memory_crystallization_sources" in sql:
+            source_kind, source_id = args
+            for row in self.sources:
+                row_args = row["args"]
+                if row_args[1] == source_kind and row_args[2] == source_id:
+                    return row_args[0]
+            return None
+        raise AssertionError(f"FakeConn.fetchval: unexpected query: {sql}")
+
+    async def execute(self, sql: str, *args):
+        if "INSERT INTO memory_crystallization_sources" in sql:
+            self.sources.append({"args": args})
+            return "INSERT 0 1"
+        raise AssertionError(f"FakeConn.execute: unexpected query: {sql}")
+
+
+def _sufficient_history_bindings() -> list[dict]:
+    return [
+        _binding("a1", "2026-06-14", 9, "continuity"),
+        _binding("a2", "2026-06-14", 10, "continuity"),
+        _binding("a3", "2026-06-14", 11, "autonomy"),
+        _binding("a4", "2026-06-15", 9, "continuity"),
+        _binding("a5", "2026-06-15", 10, "continuity"),
+        _binding("a6", "2026-06-15", 11, "continuity"),
+    ]
+
+
+def _grounded_llm_content() -> str:
+    # Fact 1 is the top-dominant-drive fact: continuity dominant in 5/6 ticks
+    # (83%). With 2 distinct days, facts 2-3 are the per-day facts and facts
+    # 4+ are individual cited events (starting with the earliest, at
+    # 2026-06-14 09:00, artifact_id "a1"). ALL tokens of both cited facts
+    # must appear verbatim, and at least one cited fact (4) carries a real
+    # artifact_id so evidence-building covers both the aggregation and a real
+    # per-tick artifact.
+    return json.dumps(
+        {
+            "narrative": (
+                "Since 2026-06-14 09:00, continuity has stood out as Orion's dominant drive, "
+                "appearing in 5 of this window's audited ticks (83%)."
+            ),
+            "cited_fact_numbers": [1, 4],
+        }
+    )
+
+
+def _make_bus(reply_content: str | None = None, *, raise_exc: Exception | None = None) -> MagicMock:
+    bus = MagicMock()
+    if raise_exc is not None:
+        bus.rpc_request = AsyncMock(side_effect=raise_exc)
+    else:
+        bus.rpc_request = AsyncMock(return_value={"data": b"whatever"})
+        decoded = MagicMock()
+        decoded.ok = True
+        decoded.envelope.payload = {"content": reply_content or ""}
+        bus.codec.decode = MagicMock(return_value=decoded)
+    return bus
+
+
+@pytest.mark.asyncio
+async def test_sufficient_history_creates_grounded_crystallization():
+    client = FakeSparqlClient(list_bindings=_sufficient_history_bindings(), detail_bindings=[])
+    bus = _make_bus(_grounded_llm_content())
+    conn = FakeConn()
+
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+        result = await dhrs._run_once(
+            sparql_client=client,
+            bus=bus,
+            postgres_uri="postgresql://fake/db",
+            subject="orion",
+            since=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        )
+
+    assert result.status == "created"
+    assert result.crystallization_id is not None
+    assert result.narrative is not None
+    assert "continuity" in result.narrative
+    assert len(conn.crystallizations) == 1
+    stored_args = next(iter(conn.crystallizations.values()))["args"]
+    assert stored_args[1] == "reflection"
+    assert stored_args[3] == result.narrative  # summary column
+    # Evidence includes the aggregation ref plus real cited raw events.
+    assert len(conn.sources) >= 2
+    source_kinds = {row["args"][1] for row in conn.sources}
+    assert source_kinds == {"rdf_memory_graph"}
+    bus.rpc_request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_successful_enrichment_repopulates_pressure_aggregation_and_evidence_note():
+    # reduce_drive_history runs once before enrichment (drive_pressures/
+    # active_drives are empty defaults at that point) and _run_once must
+    # re-reduce afterward so mean_pressure_by_drive/active_drive_frequency on
+    # the reported aggregation reflect the real enriched data, and the
+    # per-event evidence note includes it too -- otherwise those fields (and
+    # the enrichment RPC itself) are dead weight on every real run.
+    detail_bindings = [
+        {
+            "artifact": {"value": "http://conjourney.net/orion/autonomy/driveAudit/a1"},
+            "drive_name": {"value": "continuity"},
+            "drive_pressure": {"value": "0.71"},
+        },
+        {
+            "artifact": {"value": "http://conjourney.net/orion/autonomy/driveAudit/a1"},
+            "active_drive": {"value": "continuity"},
+        },
+    ]
+    client = FakeSparqlClient(list_bindings=_sufficient_history_bindings(), detail_bindings=detail_bindings)
+    bus = _make_bus(_grounded_llm_content())
+    conn = FakeConn()
+
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+        result = await dhrs._run_once(
+            sparql_client=client,
+            bus=bus,
+            postgres_uri="postgresql://fake/db",
+            subject="orion",
+            since=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        )
+
+    assert result.status == "created"
+    assert result.aggregation.mean_pressure_by_drive == {"continuity": 0.71}
+    assert result.aggregation.active_drive_frequency == {"continuity": 1}
+    # sufficiency-relevant fields must be unchanged by the re-reduce
+    assert result.aggregation.total_events == 6
+    assert result.aggregation.distinct_days == 2
+
+    raw_event_source = next(row for row in conn.sources if row["args"][2] == "a1")
+    note = raw_event_source["args"][5]
+    assert "pressures=" in note
+    assert "0.71" in note
+    assert "active_drives=" in note
+
+
+@pytest.mark.asyncio
+async def test_insufficient_history_refuses_cleanly_no_llm_no_write():
+    # Only 2 events, both the same day -- fails both thresholds.
+    bindings = [
+        _binding("a1", "2026-06-14", 9, "continuity"),
+        _binding("a2", "2026-06-14", 10, "continuity"),
+    ]
+    client = FakeSparqlClient(list_bindings=bindings, detail_bindings=[])
+    bus = _make_bus("")
+
+    with patch("asyncpg.connect", new=AsyncMock()) as connect_mock:
+        result = await dhrs._run_once(
+            sparql_client=client,
+            bus=bus,
+            postgres_uri="postgresql://fake/db",
+            subject="orion",
+            since=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        )
+
+    assert result.status == "insufficient_history"
+    assert result.error is not None
+    assert result.crystallization_id is None
+    bus.rpc_request.assert_not_called()
+    connect_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sparql_query_failure_is_clean_not_a_crash():
+    client = FakeSparqlClient(list_bindings=[], list_error=RuntimeError("fuseki unreachable"))
+    bus = _make_bus("")
+
+    with patch("asyncpg.connect", new=AsyncMock()) as connect_mock:
+        result = await dhrs._run_once(
+            sparql_client=client,
+            bus=bus,
+            postgres_uri="postgresql://fake/db",
+            subject="orion",
+            since=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        )
+
+    assert result.status == "sparql_query_failed"
+    assert "fuseki unreachable" in result.error
+    bus.rpc_request.assert_not_called()
+    connect_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_llm_call_failure_writes_nothing():
+    # A real (empty) FakeConn -- the dedup guard now runs a fetchval SELECT
+    # before the LLM call even for a sufficient/non-duplicate window, so
+    # asyncpg.connect IS called once for that check; the assertion that
+    # matters is that no crystallization/source row is ever written.
+    client = FakeSparqlClient(list_bindings=_sufficient_history_bindings(), detail_bindings=[])
+    bus = _make_bus(raise_exc=RuntimeError("gateway timeout"))
+    conn = FakeConn()
+
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+        result = await dhrs._run_once(
+            sparql_client=client,
+            bus=bus,
+            postgres_uri="postgresql://fake/db",
+            subject="orion",
+            since=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        )
+
+    assert result.status == "llm_call_failed"
+    assert "gateway timeout" in result.error
+    assert result.crystallization_id is None
+    assert conn.crystallizations == {}
+    assert conn.sources == []
+
+
+@pytest.mark.asyncio
+async def test_llm_output_ungrounded_writes_nothing():
+    client = FakeSparqlClient(list_bindings=_sufficient_history_bindings(), detail_bindings=[])
+    # Cites nothing real -- generic filler, no verbatim tokens.
+    ungrounded_content = json.dumps(
+        {"narrative": "Orion has been exploring many interesting things lately.", "cited_fact_numbers": [1, 2]}
+    )
+    bus = _make_bus(ungrounded_content)
+    conn = FakeConn()
+
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+        result = await dhrs._run_once(
+            sparql_client=client,
+            bus=bus,
+            postgres_uri="postgresql://fake/db",
+            subject="orion",
+            since=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        )
+
+    assert result.status == "llm_output_ungrounded"
+    assert result.crystallization_id is None
+    assert conn.crystallizations == {}
+    assert conn.sources == []
+
+
+@pytest.mark.asyncio
+async def test_dedup_guard_skips_when_already_synthesized_same_window():
+    since = datetime(2026, 6, 14, tzinfo=timezone.utc)
+    dedup_source_id = f"drive_history_aggregation:orion:{since.date().isoformat()}"
+    existing = [{"args": ("existing-crys-id", "rdf_memory_graph", dedup_source_id, None, 1.0, "note")}]
+    conn = FakeConn(existing_sources=existing)
+    client = FakeSparqlClient(list_bindings=_sufficient_history_bindings(), detail_bindings=[])
+    bus = _make_bus("")  # must never be called
+
+    with patch("asyncpg.connect", new=AsyncMock(return_value=conn)):
+        result = await dhrs._run_once(
+            sparql_client=client,
+            bus=bus,
+            postgres_uri="postgresql://fake/db",
+            subject="orion",
+            since=since,
+        )
+
+    assert result.status == "already_synthesized_today"
+    assert result.crystallization_id == "existing-crys-id"
+    bus.rpc_request.assert_not_called()
+    assert conn.crystallizations == {}  # no new row inserted
+
+
+@pytest.mark.asyncio
+async def test_dedup_guard_failure_does_not_block_synthesis():
+    # A dedup-check failure (e.g. transient DB error) must degrade to
+    # "proceed" rather than blocking an otherwise-valid, already-reduced run.
+    client = FakeSparqlClient(list_bindings=_sufficient_history_bindings(), detail_bindings=[])
+    bus = _make_bus(_grounded_llm_content())
+
+    call_count = {"n": 0}
+    real_conn = FakeConn()
+
+    async def _flaky_connect(uri):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("transient connect failure")
+        return real_conn
+
+    with patch("asyncpg.connect", new=_flaky_connect):
+        result = await dhrs._run_once(
+            sparql_client=client,
+            bus=bus,
+            postgres_uri="postgresql://fake/db",
+            subject="orion",
+            since=datetime(2026, 6, 14, tzinfo=timezone.utc),
+        )
+
+    assert result.status == "created"
+    assert result.crystallization_id is not None
+
+
+def test_main_reports_missing_postgres_uri(capsys):
+    exit_code = dhrs.main(["--postgres-uri", ""])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "POSTGRES_URI" in captured.err


### PR DESCRIPTION
# PR report: drive-history reflection synthesis (weekly-cadence self-modeling batch job)

## Summary

- New `scripts/drive_history_reflection_synthesis.py`: reads Orion's real, persisted drive-activation history from the Fuseki `drives` graph (append-only per-tick `DriveAuditV1` artifacts — the only genuine historical time-series of this signal in the repo; the two "latest value only" stores investigated in earlier rounds today have no history) and synthesizes ONE narrative observation about a long-horizon drive pattern into a `reflection`-kind crystallization.
- Built with an explicit two-stage architecture per AGENTS.md's event-substrate-first mandate: a **pure, unit-tested deterministic reducer** (`reduce_drive_history()`, mirroring `orion/spark/concept_induction/drive_tension.py`'s bar exactly) computes the actual aggregation; the LLM only ever sees an already-computed fact sheet and is asked to phrase one sentence, never to extract a pattern from raw data itself. This was a mid-build course-correction — the original design let the LLM read raw SPARQL rows directly, which is exactly the "reducer shortcut" AGENTS.md's `event -> schema -> trace -> reducer -> projection` mandate forbids.
- A strict anti-hallucination guardrail (`parse_and_validate_narrative()`) requires every cited fact's literal tokens (drive name, date, percentage, count) to appear verbatim in the narrative, and requires at least one citation to be a real per-tick artifact, not just an aggregate claim.
- Refuses to synthesize on thin data (`MIN_EVENTS=5`, `MIN_DISTINCT_DAYS=2`) — reports insufficiency plainly instead of forcing a confident-sounding narrative from noise.
- **Not scheduled or cron'd in this patch** — explicitly manual/on-demand, documented as needing human review before anyone trusts it as a recurring process.
- Orchestrator independently reproduced a real live run, found the guardrail correctly rejecting an otherwise fully-accurate narrative over one paraphrase ("100%" written as "all"), and applied a surgical prompt fix for that exact failure mode.

## Outcome moved

Orion's drive-activation history — which existed and was durably persisted but had zero cognition consumers — now has a real, working pipeline that can turn it into an inspectable self-observation, with a genuine (not decorative) anti-hallucination check proven against a real LLM reply, not just synthetic test strings.

## Current architecture (before this patch)

`DriveAuditV1` was already being written append-only to Fuseki's `drives` graph (confirmed earlier today: 437,756 real `orion`-subject artifacts). Nothing read that history. The two "current value" stores (`LocalProfileStore`, `autonomy_state_v2`'s Postgres UPSERT) explicitly cannot serve this purpose — investigated and ruled out in this same session, before this build started.

## Architecture touched

`scripts/` (new standalone script, matches this repo's `check_activation_saturation.py`/`concept_relation_digest.py` conventions), `services/orion-memory-consolidation/README.md` (new section, sibling to the existing `concept_relation_digest.py` docs), `tests/`.

## Files changed

- `scripts/drive_history_reflection_synthesis.py` (new, ~1290 lines): `reduce_drive_history()` (pure reducer), `build_fact_sheet()` (pure projection to fact strings), `_build_narrative_prompt()` (LLM prompt, receives only the fact sheet), `parse_and_validate_narrative()` (grounding guardrail, raises `NarrativeUngrounded` rather than silently degrading), SPARQL fetch layer (`orion/graph/sparql_client.py`-adjacent, with a documented, deliberate choice not to import `orion.autonomy.repository`'s SPARQL helpers due to a measured ~2.6s import-time cost disproportionate to this script's occasional-batch-job purpose), bus-RPC LLM call mirroring `orion/memory/crystallization/concept_relation.py::resolve_concept_relation()`'s exact pattern, crystallization creation mirroring `concept_relation_digest.py`'s conventions (governance, evidence refs, `_SingleConnPool`-style transactional safety).
- `tests/test_drive_history_reflection_synthesis.py` (new, 45 tests): `TestReduceDriveHistory` (8 tests, synthetic-input/known-output, zero I/O — insufficient-history cases, tie-break determinism, cited-event-id selection, active-drive frequency/mean-pressure correctness), `TestParseAndValidateNarrative` (8 tests — the guardrail's own unit coverage), plus SPARQL-query-builder, fetch-layer, and end-to-end pipeline tests with all I/O boundaries mocked (`FakeSparqlClient`, mocked bus, `FakeConn` at the asyncpg boundary mirroring `test_concept_relation_digest.py`'s convention).
- `services/orion-memory-consolidation/README.md`: new section explaining the architecture, the guardrail, the insufficiency threshold, usage, and explicitly stating this is not cron'd yet and needs human review first.

## Schema / bus / API changes

None. No new `CrystallizationKind` (`"reflection"` already exists from an earlier round today), no new bus channel, no schema-registry entry. Reuses existing `MemoryCrystallizationV1`/`CrystallizationEvidenceRefV1`/`CrystallizationGovernanceV1`.

## Env/config changes

None new. Reads existing `POSTGRES_URI`, `ORION_BUS_URL`, and resolves a Fuseki query URL from existing `AUTONOMY_GRAPH_QUERY_URL`/`RDF_STORE_QUERY_URL`/`RDF_STORE_BASE_URL` (same resolution chain other RDF-reading code in this repo already uses).

## Tests run

```text
$ python -m pytest tests/test_drive_history_reflection_synthesis.py -q
45 passed
```
Run independently by the orchestrator three times across this patch's lifecycle (after the implementing agent's build, after the orchestrator's own prompt fix, and again after a rebase onto a moved `main` that included an unrelated `DriveEngine.update()` change) — all three green, no regressions.

## Evals run

Not a formal eval harness, but the closest real equivalent: the orchestrator independently reproduced a genuine live run against real Fuseki data (500 real `DriveAuditV1` ticks, 2 distinct days, subject=orion) and a real LLM call, to directly observe the guardrail's behavior against real model output rather than trusting synthetic test strings alone. See "Docker/build/smoke checks" below for the full transcript of what that found.

## Docker/build/smoke checks

**Orchestrator-reproduced live run (before the prompt fix), full transcript of the real rejection:**

```text
$ POSTGRES_URI=postgresql://postgres:postgres@localhost:55432/conjourney \
  ORION_BUS_URL=redis://localhost:6379/0 \
  RDF_STORE_QUERY_URL=http://localhost:3030/orion/query \
  python scripts/drive_history_reflection_synthesis.py --since-days 30 --subject orion

drive_history_reflection_synthesis: event-detail enrichment failed: HTTPConnectionPool(host='localhost', port=3030): Read timed out. (read timeout=10.0)
  [known, already-disclosed limitation -- the per-drive detail-enrichment SPARQL join
   is slow/broken against this Fuseki instance; the 10s timeout + graceful degradation
   the implementing agent built worked exactly as designed here]

RAW_LLM_CONTENT_DEBUG (temporary instrumentation, reverted before commit):
{"narrative": "Over the period from 2026-06-14 to 2026-06-19, autonomy was the
dominant drive in all 500 audited ticks, demonstrating a consistent focus on
autonomy. On 2026-06-18, autonomy was the dominant drive in 81 ticks, and on
2026-06-19, it was dominant in 419 ticks, with multiple audits confirming this
pattern, such as Audit drive-audit-6a131c91c8bd3edf at 2026-06-19 06:54 UTC.",
"cited_fact_numbers": [1, 2, 3, 6, 11]}

status=llm_output_ungrounded
  LLM output rejected as ungrounded: cited fact 1 but not all of its real tokens
  ('autonomy', '100%', '500') appear verbatim in the narrative
```

This is a genuinely well-grounded narrative — every date, count, drive name, and the specific per-tick artifact ID + exact timestamp were reproduced verbatim and correctly. The only miss: fact 1 required the literal token `100%`, and the model wrote "all 500 audited ticks" instead. **The guardrail rejected this correctly** — "all" is a real paraphrase, not the literal fact — but it meant a fully accurate narrative was discarded over one word choice, which is a real usability gap worth closing without weakening the guardrail itself.

**Orchestrator's fix:** added an explicit instruction + concrete example to `_build_narrative_prompt()` (mirroring the date-format example already present) telling the model to reproduce percentages as literal digits+percent-sign, not "all"/"every"/"always"/"entirely". Text-only change; no test asserts exact prompt wording, 45/45 still pass.

**Honest disclosure: could not re-confirm end-to-end success after the fix.** Two follow-up live attempts both timed out (2+ minutes) rather than completing. All dependent containers reported healthy (`fuseki` 20h up/healthy, `bus-core` 4 days up/healthy, `llm-gateway` 59min up) at the time. The timeout pattern is consistent with the already-disclosed slow Fuseki detail-enrichment join (confirmed independently flaky earlier in the same session) combined with repeated back-to-back heavy queries against the same graph in a short window, not something a pure prompt-string edit could cause — the code path up to narrative generation is byte-identical except for the prompt text itself. Documented plainly rather than claiming a re-confirmation that didn't happen.

## Review findings fixed

- Finding (orchestrator-discovered via a live run, not a static review pass): the LLM's one real reply was correctly rejected by the grounding guardrail, but for a usability reason (percentage paraphrase) rather than a real grounding failure — the narrative was otherwise fully accurate and specific.
  - Fix: explicit percentage-verbatim instruction + example added to the narrative prompt.
  - Evidence: full before/after transcript above. Fix is unverified end-to-end live (see disclosure above) but is a minimal, low-risk, well-reasoned change addressing the exact observed failure mode; all existing tests remain green.
- The implementing agent's own mid-build course-correction (reducer/LLM separation) was requested by the orchestrator before any code was written, based on AGENTS.md's `event -> schema -> trace -> reducer -> projection` mandate — not a post-hoc review finding, a pre-build architecture correction. Verified real and correctly implemented by the orchestrator via direct code read (`reduce_drive_history()`, `build_fact_sheet()`, `parse_and_validate_narrative()` — all pure, all independently tested, LLM never sees raw SPARQL rows).

## Restart required

```text
No restart required.
```
Standalone, on-demand script — nothing running to restart. Not cron'd (deliberately, per the README).

## Risks / concerns

- Severity: Medium — the prompt fix for the percentage-paraphrase failure mode is well-reasoned and evidence-based but **not re-confirmed against a real live run** due to apparent Fuseki/infra flakiness encountered independently. Recommend: run this by hand once live infra is convenient, inspect whether the fix resolves the exact failure mode observed, and iterate on the prompt further if the guardrail is still over-rejecting on other token types (case, whitespace, or count-formatting variants haven't been observed failing yet, only the percentage-vs-"all" pattern).
- Severity: Low — the per-drive detail-enrichment SPARQL join's slowness against live Fuseki (first flagged by the implementing agent, independently reproduced by the orchestrator) remains undiagnosed at the query-planner level. Mitigated via a short, separate timeout with graceful degradation (confirmed working in both the agent's and the orchestrator's live runs) — not blocking, but worth a follow-up if per-tick pressure detail in evidence notes turns out to matter.
- Severity: Low (inherited, documented, not new) — this script is explicitly not cron'd; someone has to remember to run it. Intentional per the accepted design (output needs human review before automation), not an oversight.
