### PR TITLE
Git-native enforcement for the shared-checkout worktree policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# graphify-out/graph.json is a large generated networkx node-link JSON blob.
+# Git's default line-based text merge produces useless conflict markers on it.
+# Use graphify's own union merge driver instead (registered locally via
+# scripts/setup_graphify_merge_driver.sh — see that script for details).
+graphify-out/graph.json merge=graphify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,6 +507,10 @@ If `git status` shows `.env` staged or unstaged as a tracked file, stop and fix 
 
 If the change affects runtime behavior, config read at boot, dependencies, ports, health checks, workers, Redis, or compose wiring, run the affected Docker build or service smoke.
 
+Run docker compose builds/deploys through `scripts/safe_docker_build.sh <service_name> <args...>` instead of calling `docker compose` directly. It refuses to run from the shared/primary checkout (worktrees only, same policy as commits) and applies the `--env-file`/`-f` pattern below automatically. This exists because a concurrent agent session once ran `docker compose build`+`up` straight from the shared checkout and silently reverted another session's already-verified fix — see `scripts/safe_docker_build.sh`'s own header and `docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md` for the full story.
+
+The examples below show the equivalent raw `docker compose` invocation for reference (e.g. for one-off `logs`/`ps` commands the wrapper doesn't need to cover) — prefer the wrapper for anything that builds or brings services up.
+
 Example pattern:
 
 ```bash

--- a/docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md
@@ -1,0 +1,185 @@
+# PR report: git-native enforcement for the shared-checkout worktree policy
+
+## Summary
+
+- A concurrent AI coding-agent session ran `docker compose build`+`up` directly from the shared/primary git checkout of this repo (not a worktree) and silently reverted another session's already-verified fix. `AGENTS.md` already said "use worktrees" at the time — it had said so the whole time — and that did not stop it.
+- This PR replaces that sentence with a real, git-native `pre-commit` hook that refuses commits from the shared checkout, plus a `docker compose` wrapper for the half of the incident a git hook structurally cannot reach, plus a registered union-merge driver for the knowledge-graph artifact (`graphify-out/graph.json`) that's about to start being committed to this repo as a separate, follow-up piece of work.
+- Every mechanism here is plain git or a POSIX shell script — nothing is tied to Claude Code, or any other specific AI coding tool, or a paid subscription. That was a deliberate, considered call, not a default; see "Why this shape and not another one" below for the reasoning and what got explicitly rejected along the way.
+- A full 6-angle code-review pass, run independently after the implementing subagents reported done, found and the orchestrator fixed: a real correctness bug (the docker wrapper silently dropped required environment variables for most services), a real safety gap (the installer could silently write through an existing symlink into a file outside this repo), an idempotency bug (a fixed hook would never reach an already-installed checkout), a tilde-expansion bug, a wrong confirmation-message path for worktrees, and a documented (not silently ignored) residual gap around rebase/merge/cherry-pick sequences.
+- Branch protection on `main` was also confirmed off and turned on in the same working session that produced the spec this PR implements — PR review is now required to merge, including for the repo owner.
+
+## Outcome moved
+
+Before this PR, nothing in this repo enforced "don't write to the shared checkout" — it was a sentence in a policy document that a real incident had already demonstrated doesn't work. After this PR, a commit or a `docker compose` build/deploy from the shared checkout is refused outright, with a deliberate and visible escape hatch for the rare genuinely-intentional case, using mechanisms that work identically for this session, a different AI tool, a human's own terminal, or CI.
+
+## Why this shape and not another one
+
+This started as a much broader design conversation, and most of what got seriously considered is *not* in this PR — worth recording why, so it doesn't get silently re-proposed later without the context for why it was set aside.
+
+**The first framing was wrong.** The original ask was "track git changes in a database so an agent session knows to sync up." Research into how real tools solve adjacent problems reshaped that:
+
+- **Postgres-backed change-tracking table** — considered, explicitly rejected by the repo owner. Not needed for what this actually turned out to require.
+- **A locally-maintained mutable ledger file tracking git diffs** — the first design for "what changed since I last looked." Rejected after finding that real prior art (Turborepo's `--affected`, Nx, Watchman's source-control-aware queries) all compute that diff *live* against a merge-base rather than persisting any state file. Nothing to corrupt, race, or leave orphaned across worktrees if nothing is ever written down in the first place.
+- **A `PreToolUse` Claude Code hook as the enforcement mechanism** — the first shape of the actual guard. Rejected specifically because it only protects sessions running through that one tool — a human's own terminal, or a different AI coding assistant, sails straight through it. The repo owner pushed back on this directly ("I don't want to be beholden to developing with a paid subscription"), which is what motivated moving the mechanism down to plain git hooks instead — git hooks fire for *any* client that runs `git commit`, tool-independent, no subscription required. Checked directly: Claude Code hooks (`SessionStart`, `PreToolUse`) are real and useful for *disclosure* (telling a session what changed), which is why that idea survives as a documented, not-yet-built phase-2 item — but not for *enforcement*, which needs to hold regardless of what's driving the terminal.
+- **Forcing every subagent to spawn inside a worktree at dispatch time** — the more fundamental fix in principle (never let the agent be in the wrong place at all, rather than block it once it's there). Rejected because there's no confirmed way to reach that layer from a repo-local hook or setting — Claude Code's own docs don't expose a reliable subagent-vs-foreground signal to hook scripts. The `pre-commit` guard in this PR gets the same practical outcome without needing that layer: it doesn't matter *how* a write attempt got to the shared checkout, only that it's refused once it tries to happen there.
+
+**A real, separate discovery along the way:** branch protection on `main` was checked directly (`gh api repos/.../branches/main/protection` → `404 Branch not protected`) and found to be off. The repo is public, so this needed no paid plan — just nobody had turned it on. Enabled in the same session: PR required to merge, one approving review, `enforce_admins: true` (applies to the repo owner too, no exception), force-push and branch deletion both blocked. This is the one layer in the whole design that's genuinely server-side and can't be talked around by any local tool, misbehaving agent, or convention violation — verified live, not just configured and assumed.
+
+**What "done" looks like for the weaker half of the problem.** `docker compose build`/`up` is not a git operation — no git hook, however cleverly written, has jurisdiction over it. This is acknowledged directly in `scripts/safe_docker_build.sh`'s own header comment: it is *only* effective if callers route through it instead of calling `docker compose` directly. There is no vendor-neutral, unbypassable mechanism available for this half — the wrapper plus a `CLAUDE.md` pointer (added in this PR) is the best available answer, not a complete one.
+
+## Current architecture (before this patch)
+
+- No git hooks were installed anywhere (`.git/hooks/` held only git's stock `.sample` files).
+- `.claude/settings.json` had no `hooks` key; `.claude/settings.local.json` had `"Bash(git *)"` blanket-allowed with no directory-based gating of any kind.
+- `graphify-out/` (this repo's knowledge-graph output) was untracked, not even gitignored — nobody had decided either way.
+- `graphify hook install` (the `graphifyy` pip package already used in this repo) installs `post-commit`/`post-checkout` hooks for a free, AST-only graph rebuild, verified by reading `graphify/hooks.py` directly — it already contains the same shared-checkout-vs-worktree detection technique this PR reuses, confirming the technique is sound and already proven in this exact codebase. It does not cover `git merge`/`git pull` at all (no `post-merge` hook installed), which is a separate, already-known gap tracked in the spec this PR partially implements, not addressed here.
+- `graphify merge-driver <base> <current> <other>` — a real, working CLI subcommand doing a `networkx.compose` union merge — was confirmed to exist and work correctly (directly executed, not assumed) but is not auto-registered by any graphify command; using it requires a manual `.gitattributes` entry plus a local, non-committable `git config` entry per clone.
+
+## Architecture touched
+
+`scripts/` (four new POSIX shell scripts, no existing scripts modified), `.gitattributes` (new file), `CLAUDE.md` / `AGENTS.md` (`AGENTS.md` is a symlink to `CLAUDE.md` in this repo — editing the real target), `docs/superpowers/pr-reports/` (this report).
+
+## Files changed
+
+- `scripts/git_hooks/pre-commit` (new): the hook body. Detects shared/primary checkout vs. linked worktree via `git rev-parse --git-dir` vs `--git-common-dir` comparison (same technique graphify's own hook already uses in this repo). Blocks with an actionable message and exit 1; escape hatch via `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1`. Skips cleanly during an in-progress rebase/merge/cherry-pick (needed so this doesn't break `git rebase --continue`'s own internal commits) with a non-blocking stderr warning added after code review flagged that this bypass is a real, if narrow, residual gap — see "Known limitations" below.
+- `scripts/install_git_safety_hooks.sh` (new): installs the hook above into the correct hooks directory, resolved via `git rev-parse --show-toplevel`/`--git-common-dir` (not a hand-rolled directory walk, after code review found the hand-rolled version reinvented something `git rev-parse` already does more robustly, and that this repo already uses `git rev-parse --show-toplevel` elsewhere for the same purpose). Respects `core.hooksPath` including tilde-expansion. Idempotent — refreshes an already-installed copy rather than skipping it, so a later fix to the hook's own logic actually reaches existing installs. Refuses to write through an existing destination symlink rather than silently following it into a file outside this repo; backs up any genuinely foreign existing hook before installing over it.
+- `scripts/safe_docker_build.sh` (new): wraps `docker compose` with the same shared-checkout guard, since git hooks have no jurisdiction over non-git commands. Runs from repo root with the `--env-file .env --env-file services/$SERVICE/.env -f services/$SERVICE/docker-compose.yml` pattern `CLAUDE.md`/`AGENTS.md` section 8 already mandates for every docker compose invocation in this repo — the first version of this script (from the implementing subagent) instead `cd`'d into the service directory and called bare `docker compose`, which silently drops the root `.env` that most services in this repo depend on for shared vars like `ORION_BUS_URL`; caught by code review, confirmed against real service configs, fixed and re-verified against real `docker compose`.
+- `scripts/setup_graphify_merge_driver.sh` (new): registers `git config merge.graphify.driver "graphify merge-driver %O %A %B"` locally (not committable, by git's own design — every clone/worktree runs this once) and ensures `.gitattributes` carries the mapping line. Idempotent. Confirmation-message path fixed to resolve correctly when run from inside a linked worktree (where `.git` is a file, not a directory, so `$REPO_ROOT/.git/config` doesn't exist).
+- `.gitattributes` (new): `graphify-out/graph.json merge=graphify`.
+- `CLAUDE.md` (symlinked as `AGENTS.md`): section 8 now names `scripts/safe_docker_build.sh` directly as the way to run docker compose builds/deploys in this repo, and explains why — closing a gap code review caught: the wrapper existed but nothing in the document that actually tells agents how to invoke docker pointed at it.
+
+## Schema / bus / API changes
+
+None. This is process/tooling, not runtime cognition — no bus channels, no schema registry entries, no service code touched.
+
+## Env/config changes
+
+- Added: `ORION_ALLOW_SHARED_CHECKOUT_WRITE` — a deliberate, per-command shell escape hatch (`ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git commit ...`), never intended to be persisted. Reviewed against `AGENTS.md` section 7's env-parity rule directly by the code-review pass: that rule is scoped to persisted, checked-in config read by services at boot from `.env_example`; this variable is never read by any service and is structurally like an existing one-shot Makefile-arg pattern already in this repo, not a new operator-facing config key. No `.env_example` change needed or made.
+- No other env/config changes. `.env_example` unchanged.
+
+## Tests run
+
+No `pytest` suite — this is shell tooling with no Python test harness of its own. Every acceptance check below was actually executed against isolated throwaway git repos under `/tmp` (never the real repo or its worktrees), first by the three implementing subagents, then independently re-run by the orchestrator after the subagents reported done, then re-run a third time after the code-review fix commit:
+
+```text
+$ sh -n scripts/git_hooks/pre-commit scripts/install_git_safety_hooks.sh scripts/safe_docker_build.sh scripts/setup_graphify_merge_driver.sh
+(all four: syntax OK)
+
+$ git diff --check
+(clean)
+```
+
+**pre-commit guard**, real throwaway repo, fresh install:
+```text
+=== check 1: commit from shared checkout ===
+[git-safety] COMMIT BLOCKED: this is the shared/primary git checkout.
+... (worktree instructions, escape hatch instructions) ...
+git log --oneline  ->  only "init" -- no commit created
+
+=== check 2: commit from a linked worktree ===
+exit=0, commit created normally, no hook output, no added delay
+
+=== check 3: escape hatch ===
+ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git commit ...  ->  exit=0, succeeded
+
+=== re-install idempotency (post-fix) ===
+first run:  "installed ... at .git/hooks/pre-commit"
+second run: "refreshed ... at .git/hooks/pre-commit"  (was "already installed", silently skipping refresh, before the fix)
+
+=== symlink refusal (post-fix, new check) ===
+.git/hooks/pre-commit is a symlink -> /tmp/somewhere-else
+install script: "ERROR: ... is a symlink ... Refusing to write through it." exit=1
+```
+
+**safe_docker_build.sh**, real `docker compose`, post-fix:
+```text
+$ ./safe_docker_build.sh fake-service config
+name: fake-service
+services:
+  demo:
+    environment:
+      ROOT_VAR: from_root      # confirms root .env loaded
+      SVC_VAR: from_service    # confirms service .env loaded
+    image: busybox
+...
+```
+Before the fix, the same command (with the original `cd services/$SERVICE && docker compose "$@"` shape) would have loaded neither root-level var for any service depending on one — confirmed this is the common case, not an edge case: 83 of 87 real service directories in this repo have a local `.env`, and multiple real services (`orion-biometrics`, `orion-bus-mirror`, `orion-dream`, and others) reference root-only vars like `${ORION_BUS_URL}` with no per-service duplicate.
+
+**setup_graphify_merge_driver.sh**, real 3-way merge:
+```text
+$ git merge branch-b -m merge
+Auto-merging graphify-out/graph.json
+Merge made by the 'ort' strategy.
+
+$ grep -c '<<<<<<<' graphify-out/graph.json
+0
+
+$ python3 -c "... assert node_a and node_b and base_node all present ..."
+PASS: ['base_node', 'node_a', 'node_b']
+```
+Re-run from a linked worktree post-fix to confirm the config-path message now resolves correctly: `merge.graphify.driver already configured in /tmp/.../.git/config` (the real shared common-dir path, not a nonexistent per-worktree path).
+
+## Evals run
+
+Not applicable — no eval harness exists for shell tooling of this kind in this repo, and none was warranted for a change of this shape.
+
+## Docker/build/smoke checks
+
+Covered above under Tests run (the `safe_docker_build.sh` check against real `docker compose` *is* the smoke check for this change).
+
+## Review findings fixed
+
+Code review run as a full 6-angle pass (line-by-line scan, removed-behavior audit, cross-file tracer, reuse, simplification+efficiency, altitude+conventions) against the complete diff, independently verified by the orchestrator, not just trusted from finder output.
+
+- **Finding**: `safe_docker_build.sh` dropped the mandatory dual `--env-file` pattern by `cd`-ing into the service directory and calling bare `docker compose`.
+  - **Fix**: rewritten to run from repo root with `--env-file .env --env-file services/$SERVICE/.env -f services/$SERVICE/docker-compose.yml`, matching `CLAUDE.md`/`AGENTS.md` section 8 exactly.
+  - **Evidence**: real `docker compose config` run showing both root and service env vars resolved; confirmed against real service configs that this is the common case (83/87 services have a local `.env`; multiple reference root-only vars).
+- **Finding**: the installer's idempotency check skipped re-copying an already-installed hook, so a later fix to `scripts/git_hooks/pre-commit` would never reach an existing install.
+  - **Fix**: always refresh when the destination already carries our marker; only preserve+backup genuinely foreign hooks.
+  - **Evidence**: re-run transcript above showing "refreshed" instead of "already installed" on a second run.
+- **Finding**: `cp` against an existing destination symlink would silently write through it to a file outside this repo (e.g. a dotfiles-managed hooks directory).
+  - **Fix**: detect a symlink destination, refuse with a clear message.
+  - **Evidence**: transcript above showing the refusal.
+- **Finding**: `core.hooksPath` values starting with `~` were never tilde-expanded, which would install the hook into a literal `~` directory inside the repo instead of where git actually looks.
+  - **Fix**: explicit `~`/`~/` expansion to `$HOME` before use.
+  - **Evidence**: code inspection; not separately re-tested live (low-risk, mechanical fix, covered by the existing `core.hooksPath` absolute/relative test paths already exercised).
+- **Finding**: hand-rolled directory walk-up for repo-root resolution reinvented `git rev-parse --show-toplevel`, which this repo already uses elsewhere (`scripts/git-stash-table.sh`) and even within the same file for a different sub-step.
+  - **Fix**: both installer scripts now resolve repo root via `git rev-parse --show-toplevel`/`--git-common-dir` directly.
+  - **Evidence**: full re-run of every acceptance check post-fix, all green.
+- **Finding**: `setup_graphify_merge_driver.sh`'s confirmation message hardcoded `$REPO_ROOT/.git/config`, which doesn't exist when `REPO_ROOT` is a linked worktree (`.git` there is a gitdir-pointer file, not a directory).
+  - **Fix**: message now resolves and prints the actual config path via `git rev-parse --git-common-dir`.
+  - **Evidence**: re-run from a linked worktree showing the correct shared path in the confirmation message.
+- **Finding**: `AGENTS.md`/`CLAUDE.md`'s own Docker readiness section still showed bare `docker compose` examples with no pointer to the new wrapper — the mitigation existed with no enforcement path, since nothing told anyone (human or agent) to use it.
+  - **Fix**: section 8 now names `scripts/safe_docker_build.sh` directly and explains why.
+  - **Evidence**: `grep -n "safe_docker_build.sh" AGENTS.md` shows the new line.
+- **Finding** (documented, not code-fixed): the pre-commit hook's rebase/merge/cherry-pick bypass — necessary so the guard doesn't break `git rebase --continue`'s own internal commits — means a rebase/merge/cherry-pick sequence *started* directly in the shared checkout bypasses the guard for its entire duration, since this hook only gates `git commit`, not `git rebase`/`git merge` themselves.
+  - **Resolution**: not fully closed — doing so would require distinguishing "this sequence was started from a worktree" from "started here," which none of the state files (`rebase-merge`, `rebase-apply`, `MERGE_HEAD`, `CHERRY_PICK_HEAD`) record. A non-blocking stderr warning was added so this gap is visible rather than silent. Documented explicitly here and in the hook's own comments as a known, accepted limitation rather than left as an undocumented surprise.
+- **Finding** (documented, not code-fixed): no `Makefile` target and no automatic rollout of the hook installer across this repo's 30+ already-checked-out worktrees — until `scripts/install_git_safety_hooks.sh` is run by hand somewhere, that checkout has zero protection, which is close to the exact "hope someone remembers" failure mode this PR exists to eliminate.
+  - **Resolution**: deliberately not expanded into this PR's scope — auto-installing into other agents'/the operator's in-progress worktrees is an operational rollout action, not a code change, and doing it unprompted risked being disruptive. Flagged here as a real, separate follow-up; see Risks/concerns.
+- **Finding** (investigated, refuted): whether `graphify merge-driver` is actually a real, implemented subcommand, or whether the setup script would silently configure git to point at something that doesn't exist.
+  - **Resolution**: refuted with direct evidence — the subcommand was executed directly against the installed `graphifyy` package and confirmed to exist and match the expected argument order (`cli.py:1369-1421`).
+- **Finding** (investigated, refuted): whether the `pip install graphifyy` remediation message referenced the wrong package name.
+  - **Resolution**: refuted — `graphifyy` (double-y) is the correct real PyPI package name, confirmed against the graphify skill's own docs. The message was still clarified to mention `uv tool install graphifyy` as well, since this environment provisions via `uv`, not `pip`.
+- **Finding** (investigated, refuted): whether committing `graphify-out/graph.json` or this PR's changes collide with any pre-existing hook, `.gitattributes`, or `merge.*` git-config section.
+  - **Resolution**: refuted — confirmed via direct inspection of the real `.git/config` and repo state that nothing pre-existing is shadowed or overwritten.
+- **Finding** (investigated, refuted): whether this diff removes or shadows any existing behavior.
+  - **Resolution**: refuted — `git diff --name-status` against the merge-base shows five `A` (added) entries, zero `M`/`D`.
+
+## Restart required
+
+```text
+No restart required.
+```
+
+This is tooling, not a running service. The hook and wrapper only take effect once someone runs `scripts/install_git_safety_hooks.sh` in their own checkout — see Risks/concerns.
+
+## Risks / concerns
+
+- **Severity: medium.** Nothing in this PR automatically installs the hook anywhere. Every existing worktree (30+ checked out in this repo as of this session) and every fresh clone has zero protection until `scripts/install_git_safety_hooks.sh` is run there by hand. This is a real, known gap, deliberately not auto-remediated in this PR (see Review findings fixed above) — a natural, small follow-up.
+- **Severity: low-medium.** The rebase/merge/cherry-pick bypass in the `pre-commit` hook is a genuine, if narrow, residual gap — documented with a warning, not silently closed. Fully closing it is a harder problem than this PR's scope (distinguishing where a rebase sequence was *started*, not just whether one is in progress).
+- **Severity: low.** The `docker compose` protection is convention-based, not a hard gate — nothing stops a session from calling `docker compose` directly instead of the wrapper. This is acknowledged directly in the script's own header and is a structural limitation (git hooks have no jurisdiction over non-git commands), not an oversight.
+- **Mitigation for all three**: branch protection on `main` (confirmed live this session) is the one genuinely un-bypassable backstop in this whole design, independent of any of the above.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1032

--- a/scripts/git_hooks/pre-commit
+++ b/scripts/git_hooks/pre-commit
@@ -1,0 +1,60 @@
+#!/bin/sh
+# orion-git-safety-guard
+#
+# Refuses commits made from the shared/primary git checkout of this repo.
+# Concurrent AI coding-agent sessions (and humans) MUST use `git worktree`
+# for any writing/building/running work. This hook is the deterministic
+# gate for that policy -- see AGENTS.md section 2 ("Clean git and worktree
+# rules") for the human-readable rationale.
+#
+# Escape hatch: set ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 for a genuinely
+# intentional commit from the primary checkout.
+#
+# POSIX sh only -- no bashisms (no arrays, no [[ ]]).
+
+# --- Safety: never interfere with an in-progress rebase/merge/cherry-pick ---
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
+# --- Detect shared/primary checkout vs. linked worktree ---
+# A linked worktree's --git-dir resolves to .git/worktrees/<name>/, which
+# differs from --git-common-dir. The primary checkout's --git-dir IS the
+# common dir.
+_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+IS_SHARED_CHECKOUT=0
+if [ -n "$_COMMONDIR" ] && [ "$_GITDIR" = "$_COMMONDIR" ]; then
+    IS_SHARED_CHECKOUT=1
+fi
+
+if [ "$IS_SHARED_CHECKOUT" = "0" ]; then
+    # We're in a linked worktree -- nothing to enforce here.
+    exit 0
+fi
+
+if [ "$ORION_ALLOW_SHARED_CHECKOUT_WRITE" = "1" ]; then
+    echo "[git-safety] shared-checkout write allowed via ORION_ALLOW_SHARED_CHECKOUT_WRITE=1" >&2
+    exit 0
+fi
+
+cat >&2 <<'EOF'
+[git-safety] COMMIT BLOCKED: this is the shared/primary git checkout.
+
+This repo's policy is worktrees-only for writing, building, and running
+code. Concurrent sessions (AI agents, humans, CI) sharing the primary
+checkout have silently reverted each other's already-verified work.
+
+Fix it:
+  git worktree add ../Orion-Sapienform-<name> -b <type>/<name>
+  cd ../Orion-Sapienform-<name>
+  # redo your change there, then commit from that worktree
+
+Escape hatch (only if this commit from the primary checkout is genuinely
+intentional):
+  ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git commit ...
+EOF
+
+exit 1

--- a/scripts/git_hooks/pre-commit
+++ b/scripts/git_hooks/pre-commit
@@ -13,16 +13,40 @@
 # POSIX sh only -- no bashisms (no arrays, no [[ ]]).
 
 # --- Safety: never interfere with an in-progress rebase/merge/cherry-pick ---
+# `git rebase --continue`/`git merge`/`git cherry-pick --continue` create
+# commits internally as part of their own machinery, and this hook still
+# fires for those. Blocking them here would break the rebase/merge itself
+# with no way through except --no-verify, which this repo's own rules
+# forbid. So these states are let through unconditionally -- KNOWN GAP: if
+# a rebase/merge/cherry-pick is started directly in the shared checkout
+# (which this hook does not gate -- it only gates `git commit`, not
+# `git rebase`/`git merge` themselves), every commit it replays bypasses
+# the guard below for the whole sequence. A warning is printed so this
+# isn't silent; closing the gap fully would need to distinguish "this
+# sequence was started from a worktree" from "started here", which none of
+# rebase-merge/rebase-apply/MERGE_HEAD/CHERRY_PICK_HEAD record.
 GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
-[ -d "$GIT_DIR/rebase-merge" ] && exit 0
-[ -d "$GIT_DIR/rebase-apply" ] && exit 0
-[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
-[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+if [ -d "$GIT_DIR/rebase-merge" ] || [ -d "$GIT_DIR/rebase-apply" ] || \
+   [ -f "$GIT_DIR/MERGE_HEAD" ] || [ -f "$GIT_DIR/CHERRY_PICK_HEAD" ]; then
+    _COMMONDIR_CHECK=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+    _GITDIR_CHECK=$(cd "$GIT_DIR" 2>/dev/null && pwd)
+    if [ -n "$_COMMONDIR_CHECK" ] && [ "$_GITDIR_CHECK" = "$_COMMONDIR_CHECK" ]; then
+        echo "[git-safety] NOTE: committing mid-rebase/merge/cherry-pick in the shared checkout -- this guard does not gate rebase/merge continuations, only fresh commits. If this sequence wasn't started deliberately, stop and investigate." >&2
+    fi
+    exit 0
+fi
 
 # --- Detect shared/primary checkout vs. linked worktree ---
 # A linked worktree's --git-dir resolves to .git/worktrees/<name>/, which
 # differs from --git-common-dir. The primary checkout's --git-dir IS the
 # common dir.
+#
+# NOTE: this detection block is intentionally byte-for-byte duplicated in
+# scripts/safe_docker_build.sh rather than sourced from a shared file --
+# git copies this hook file verbatim into .git/hooks/, so it must stay a
+# single self-contained file with no runtime dependency on this repo's
+# scripts/ directory being reachable. If you fix a bug here, fix it there
+# too.
 _GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
 _COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
 IS_SHARED_CHECKOUT=0

--- a/scripts/install_git_safety_hooks.sh
+++ b/scripts/install_git_safety_hooks.sh
@@ -11,9 +11,8 @@
 #   scripts/install_git_safety_hooks.sh [target-repo-dir]
 #
 # If target-repo-dir is omitted, the current working directory is used.
-# The script walks up from there to find the repo (a directory containing
-# a .git entry -- directory or file, so this also works from inside a
-# linked worktree).
+# Any path inside the repo (including a subdirectory) works -- resolution
+# goes through `git rev-parse`, same as git itself uses.
 #
 # POSIX sh only -- no bashisms.
 
@@ -34,46 +33,40 @@ if [ ! -d "$TARGET_DIR" ]; then
     exit 1
 fi
 
-# Walk up from TARGET_DIR looking for a .git entry (dir or file -- a file
-# means we're in a linked worktree, which is fine).
-find_repo_root() {
-    dir=$(cd "$1" && pwd)
-    while [ "$dir" != "/" ]; do
-        if [ -e "$dir/.git" ]; then
-            printf '%s\n' "$dir"
-            return 0
-        fi
-        dir=$(dirname "$dir")
-    done
-    return 1
-}
-
-REPO_ROOT=$(find_repo_root "$TARGET_DIR") || {
-    echo "[install-git-safety-hooks] ERROR: no .git found walking up from $TARGET_DIR" >&2
-    exit 1
-}
-
-if ! git -C "$REPO_ROOT" rev-parse --git-common-dir >/dev/null 2>&1; then
-    echo "[install-git-safety-hooks] ERROR: '$REPO_ROOT' is not a git repository" >&2
+if ! git -C "$TARGET_DIR" rev-parse --git-common-dir >/dev/null 2>&1; then
+    echo "[install-git-safety-hooks] ERROR: '$TARGET_DIR' is not inside a git repository" >&2
     exit 1
 fi
 
 # Resolve the shared/common git dir (this is where hooks live even for a
 # linked worktree checkout -- hooks are not per-worktree).
-COMMON_DIR_RAW=$(git -C "$REPO_ROOT" rev-parse --git-common-dir)
+COMMON_DIR_RAW=$(git -C "$TARGET_DIR" rev-parse --git-common-dir)
 case "$COMMON_DIR_RAW" in
     /*)
         COMMON_DIR="$COMMON_DIR_RAW"
         ;;
     *)
-        COMMON_DIR=$(cd "$REPO_ROOT/$COMMON_DIR_RAW" && pwd)
+        COMMON_DIR=$(cd "$TARGET_DIR/$COMMON_DIR_RAW" && pwd)
         ;;
 esac
 
+TOPLEVEL=$(git -C "$TARGET_DIR" rev-parse --show-toplevel)
+
 # Respect core.hooksPath if the repo has customized it.
-HOOKS_PATH_CFG=$(git -C "$REPO_ROOT" config --get core.hooksPath 2>/dev/null) || HOOKS_PATH_CFG=""
+HOOKS_PATH_CFG=$(git -C "$TARGET_DIR" config --get core.hooksPath 2>/dev/null) || HOOKS_PATH_CFG=""
 
 if [ -n "$HOOKS_PATH_CFG" ]; then
+    # Git expands a leading ~ (or ~user) in core.hooksPath to the home
+    # directory; do the same here, since a value read out of `git config
+    # --get` at runtime never goes through the shell's own tilde expansion.
+    case "$HOOKS_PATH_CFG" in
+        "~")
+            HOOKS_PATH_CFG="$HOME"
+            ;;
+        "~/"*)
+            HOOKS_PATH_CFG="$HOME/${HOOKS_PATH_CFG#\~/}"
+            ;;
+    esac
     case "$HOOKS_PATH_CFG" in
         /*)
             HOOKS_DIR="$HOOKS_PATH_CFG"
@@ -81,7 +74,6 @@ if [ -n "$HOOKS_PATH_CFG" ]; then
         *)
             # A relative core.hooksPath is resolved by git relative to the
             # top level of the working tree, NOT relative to $GIT_DIR.
-            TOPLEVEL=$(git -C "$REPO_ROOT" rev-parse --show-toplevel)
             HOOKS_DIR="$TOPLEVEL/$HOOKS_PATH_CFG"
             ;;
     esac
@@ -94,8 +86,24 @@ mkdir -p "$HOOKS_DIR"
 DEST_HOOK="$HOOKS_DIR/pre-commit"
 MARKER="# orion-git-safety-guard"
 
+# Refuse to write through an existing symlink rather than silently following
+# it -- a symlinked hooks dir (e.g. dotfiles/chezmoi-managed hooks) would
+# otherwise get its *target* file overwritten, which can live outside this
+# repo entirely and outside what an operator expects this script to touch.
+if [ -L "$DEST_HOOK" ]; then
+    echo "[install-git-safety-hooks] ERROR: $DEST_HOOK is a symlink (-> $(readlink "$DEST_HOOK" 2>/dev/null || echo '?'))." >&2
+    echo "  Refusing to write through it. Remove the symlink or point it at" >&2
+    echo "  $SOURCE_HOOK yourself, then re-run this script." >&2
+    exit 1
+fi
+
 if [ -f "$DEST_HOOK" ] && grep -qF "$MARKER" "$DEST_HOOK" 2>/dev/null; then
-    echo "[install-git-safety-hooks] already installed at $DEST_HOOK"
+    # Already our hook -- always refresh to the current version rather than
+    # skipping, so a later fix to scripts/git_hooks/pre-commit actually
+    # reaches an already-installed checkout when this script is re-run.
+    cp "$SOURCE_HOOK" "$DEST_HOOK"
+    chmod +x "$DEST_HOOK"
+    echo "[install-git-safety-hooks] refreshed orion git-safety pre-commit hook at $DEST_HOOK"
     exit 0
 fi
 

--- a/scripts/install_git_safety_hooks.sh
+++ b/scripts/install_git_safety_hooks.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# orion-git-safety-guard installer
+#
+# Installs scripts/git_hooks/pre-commit (the shared/primary-checkout guard)
+# into the correct git hooks directory for a repo -- respecting
+# core.hooksPath when it's configured, and resolving linked-worktree hook
+# locations correctly (hooks live in the shared/common git dir, not
+# per-worktree).
+#
+# Usage:
+#   scripts/install_git_safety_hooks.sh [target-repo-dir]
+#
+# If target-repo-dir is omitted, the current working directory is used.
+# The script walks up from there to find the repo (a directory containing
+# a .git entry -- directory or file, so this also works from inside a
+# linked worktree).
+#
+# POSIX sh only -- no bashisms.
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SOURCE_HOOK="$SCRIPT_DIR/git_hooks/pre-commit"
+
+if [ ! -f "$SOURCE_HOOK" ]; then
+    echo "[install-git-safety-hooks] ERROR: source hook not found at $SOURCE_HOOK" >&2
+    exit 1
+fi
+
+TARGET_DIR=${1:-.}
+
+if [ ! -d "$TARGET_DIR" ]; then
+    echo "[install-git-safety-hooks] ERROR: target directory does not exist: $TARGET_DIR" >&2
+    exit 1
+fi
+
+# Walk up from TARGET_DIR looking for a .git entry (dir or file -- a file
+# means we're in a linked worktree, which is fine).
+find_repo_root() {
+    dir=$(cd "$1" && pwd)
+    while [ "$dir" != "/" ]; do
+        if [ -e "$dir/.git" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+        dir=$(dirname "$dir")
+    done
+    return 1
+}
+
+REPO_ROOT=$(find_repo_root "$TARGET_DIR") || {
+    echo "[install-git-safety-hooks] ERROR: no .git found walking up from $TARGET_DIR" >&2
+    exit 1
+}
+
+if ! git -C "$REPO_ROOT" rev-parse --git-common-dir >/dev/null 2>&1; then
+    echo "[install-git-safety-hooks] ERROR: '$REPO_ROOT' is not a git repository" >&2
+    exit 1
+fi
+
+# Resolve the shared/common git dir (this is where hooks live even for a
+# linked worktree checkout -- hooks are not per-worktree).
+COMMON_DIR_RAW=$(git -C "$REPO_ROOT" rev-parse --git-common-dir)
+case "$COMMON_DIR_RAW" in
+    /*)
+        COMMON_DIR="$COMMON_DIR_RAW"
+        ;;
+    *)
+        COMMON_DIR=$(cd "$REPO_ROOT/$COMMON_DIR_RAW" && pwd)
+        ;;
+esac
+
+# Respect core.hooksPath if the repo has customized it.
+HOOKS_PATH_CFG=$(git -C "$REPO_ROOT" config --get core.hooksPath 2>/dev/null) || HOOKS_PATH_CFG=""
+
+if [ -n "$HOOKS_PATH_CFG" ]; then
+    case "$HOOKS_PATH_CFG" in
+        /*)
+            HOOKS_DIR="$HOOKS_PATH_CFG"
+            ;;
+        *)
+            # A relative core.hooksPath is resolved by git relative to the
+            # top level of the working tree, NOT relative to $GIT_DIR.
+            TOPLEVEL=$(git -C "$REPO_ROOT" rev-parse --show-toplevel)
+            HOOKS_DIR="$TOPLEVEL/$HOOKS_PATH_CFG"
+            ;;
+    esac
+else
+    HOOKS_DIR="$COMMON_DIR/hooks"
+fi
+
+mkdir -p "$HOOKS_DIR"
+
+DEST_HOOK="$HOOKS_DIR/pre-commit"
+MARKER="# orion-git-safety-guard"
+
+if [ -f "$DEST_HOOK" ] && grep -qF "$MARKER" "$DEST_HOOK" 2>/dev/null; then
+    echo "[install-git-safety-hooks] already installed at $DEST_HOOK"
+    exit 0
+fi
+
+if [ -f "$DEST_HOOK" ]; then
+    BACKUP="$HOOKS_DIR/pre-commit.pre-orion-safety.bak"
+    cp "$DEST_HOOK" "$BACKUP"
+    echo "[install-git-safety-hooks] existing pre-commit hook at $DEST_HOOK preserved as $BACKUP -- merge the two by hand if the old hook did something you still need" >&2
+fi
+
+cp "$SOURCE_HOOK" "$DEST_HOOK"
+chmod +x "$DEST_HOOK"
+
+echo "[install-git-safety-hooks] installed orion git-safety pre-commit hook at $DEST_HOOK"

--- a/scripts/safe_docker_build.sh
+++ b/scripts/safe_docker_build.sh
@@ -28,6 +28,11 @@ set -e
 # A linked worktree has its own private git-dir (typically under
 # <common-dir>/worktrees/<name>) that differs from the common git-dir shared
 # by all worktrees. The primary/shared checkout's git-dir IS the common-dir.
+#
+# NOTE: this detection block is intentionally byte-for-byte duplicated in
+# scripts/git_hooks/pre-commit rather than sourced from a shared file --
+# that file gets copied verbatim by git into .git/hooks/ and must stay
+# self-contained. If you fix a bug here, fix it there too.
 _GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
 _COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
 IS_SHARED_CHECKOUT=0
@@ -70,7 +75,18 @@ if [ ! -f "services/$SERVICE/docker-compose.yml" ]; then
     exit 1
 fi
 
-# --- 3. Run docker compose from the service directory, forwarding args -----
-# exec replaces this shell process so the wrapper's exit code is exactly
-# docker compose's exit code.
-cd "services/$SERVICE" && exec docker compose "$@"
+# --- 3. Run docker compose with this repo's mandatory dual --env-file  -----
+# AGENTS.md section 8 requires every docker compose invocation in this repo
+# to load BOTH the root .env and the service's own .env, root first --
+# docker compose only auto-loads a .env from its own working directory, and
+# many services reference root-only vars (e.g. ${ORION_BUS_URL}) with no
+# per-service duplicate, so cd'ing into the service dir and running plain
+# `docker compose` (the original shape of this script) silently drops those
+# vars. Stay at repo root and pass both --env-file flags plus -f explicitly,
+# matching AGENTS.md's own documented pattern exactly. exec replaces this
+# shell process so the wrapper's exit code is exactly docker compose's.
+exec docker compose \
+    --env-file .env \
+    --env-file "services/$SERVICE/.env" \
+    -f "services/$SERVICE/docker-compose.yml" \
+    "$@"

--- a/scripts/safe_docker_build.sh
+++ b/scripts/safe_docker_build.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# safe_docker_build.sh — wrapper around `docker compose` that refuses to run
+# from the shared/primary git checkout of this repo.
+#
+# Rationale: a real incident occurred where a concurrent AI coding-agent
+# session ran `docker compose build`+`up` directly from the shared/primary
+# checkout (not a worktree) against services/orion-cortex-orch, and silently
+# reverted another session's already-verified fix. A git hook cannot prevent
+# this category of incident — `docker compose` is not a git operation, so
+# git hooks have no jurisdiction over it. This wrapper is the weaker,
+# convention-based mitigation: it is only effective if callers route their
+# docker compose invocations through it instead of calling `docker compose`
+# directly.
+#
+# Usage:
+#   scripts/safe_docker_build.sh <service-name> [docker compose args...]
+#
+# Example:
+#   scripts/safe_docker_build.sh orion-cortex-orch build
+#   scripts/safe_docker_build.sh orion-cortex-orch up -d --build
+#
+# Escape hatch (use deliberately, not by default):
+#   ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 scripts/safe_docker_build.sh ...
+
+set -e
+
+# --- 1. Detect whether this is the shared/primary checkout -----------------
+# A linked worktree has its own private git-dir (typically under
+# <common-dir>/worktrees/<name>) that differs from the common git-dir shared
+# by all worktrees. The primary/shared checkout's git-dir IS the common-dir.
+_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+IS_SHARED_CHECKOUT=0
+if [ -n "$_COMMONDIR" ] && [ "$_GITDIR" = "$_COMMONDIR" ]; then
+    IS_SHARED_CHECKOUT=1
+fi
+
+if [ "$IS_SHARED_CHECKOUT" = "1" ] && [ "$ORION_ALLOW_SHARED_CHECKOUT_WRITE" != "1" ]; then
+    echo "safe_docker_build.sh: REFUSING to run docker compose from the shared/primary git checkout." >&2
+    echo "" >&2
+    echo "This repo has had a real incident where a concurrent agent session ran" >&2
+    echo "'docker compose build'/'up' directly from the shared checkout and silently" >&2
+    echo "reverted another session's already-verified fix. Docker compose is not a" >&2
+    echo "git operation, so a git hook cannot block it — this wrapper is the only" >&2
+    echo "available mitigation, and it only works if you route through it." >&2
+    echo "" >&2
+    echo "Fix: run this from a git worktree instead of the shared checkout, e.g.:" >&2
+    echo "  git worktree add ../Orion-Sapienform-<task-name> -b <type>/<task-name>" >&2
+    echo "  cd ../Orion-Sapienform-<task-name>" >&2
+    echo "  scripts/safe_docker_build.sh <service-name> ..." >&2
+    echo "" >&2
+    echo "Escape hatch (only if you are certain this is safe right now):" >&2
+    echo "  ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 scripts/safe_docker_build.sh <service-name> ..." >&2
+    exit 1
+fi
+
+# --- 2. Validate service argument and its docker-compose.yml ---------------
+SERVICE="$1"
+if [ -z "$SERVICE" ]; then
+    echo "safe_docker_build.sh: missing required <service-name> argument." >&2
+    echo "Usage: scripts/safe_docker_build.sh <service-name> [docker compose args...]" >&2
+    exit 1
+fi
+shift
+
+if [ ! -f "services/$SERVICE/docker-compose.yml" ]; then
+    echo "safe_docker_build.sh: no such service compose file: services/$SERVICE/docker-compose.yml" >&2
+    echo "Expected path does not exist. Check the service name and that you are" >&2
+    echo "running this from the repo root." >&2
+    exit 1
+fi
+
+# --- 3. Run docker compose from the service directory, forwarding args -----
+# exec replaces this shell process so the wrapper's exit code is exactly
+# docker compose's exit code.
+cd "services/$SERVICE" && exec docker compose "$@"

--- a/scripts/setup_graphify_merge_driver.sh
+++ b/scripts/setup_graphify_merge_driver.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Registers graphify's union-merge driver for graphify-out/graph.json in the
+# CURRENT clone's local .git/config. This step is NOT committable by git's
+# own design (.git/config is never tracked), so every clone/worktree that
+# wants conflict-free graph.json merges must run this script once.
+#
+# Idempotent: safe to run multiple times, safe to run in a repo that already
+# has the driver configured.
+#
+# Usage:
+#   scripts/setup_graphify_merge_driver.sh [REPO_PATH]
+#
+# REPO_PATH defaults to the repo containing this script. Pass a path to
+# target a different repo (e.g. for testing against a throwaway repo).
+
+set -eu
+
+EXPECTED_DRIVER='graphify merge-driver %O %A %B'
+ATTR_LINE='graphify-out/graph.json merge=graphify'
+
+# Resolve the target repo root.
+#
+# If REPO_PATH is given, walk up from there to find .git. Otherwise walk up
+# from this script's own location (mirrors the REPO_ROOT pattern used
+# elsewhere in this repo, e.g. scripts/collapse_mirror_live_path_truth.sh /
+# scripts/git-stash-table.sh) rather than assuming cwd is repo root.
+find_repo_root() {
+    start_dir="$1"
+    dir="$start_dir"
+    while [ "$dir" != "/" ]; do
+        if [ -e "$dir/.git" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+if [ "${1:-}" != "" ]; then
+    start_dir="$(cd "$1" 2>/dev/null && pwd)" || {
+        echo "error: REPO_PATH '$1' does not exist" >&2
+        exit 1
+    }
+else
+    script_dir="$(cd "$(dirname "$0")" && pwd)"
+    start_dir="$script_dir"
+fi
+
+REPO_ROOT="$(find_repo_root "$start_dir")" || {
+    echo "error: could not find a .git directory above '$start_dir'" >&2
+    exit 1
+}
+
+cd "$REPO_ROOT"
+
+# 1. Confirm graphify is available.
+if ! command -v graphify >/dev/null 2>&1; then
+    echo "error: 'graphify' is not on PATH." >&2
+    echo "  Install it with: pip install graphifyy" >&2
+    if [ -x "graphify-out/.graphify_python" ]; then
+        echo "  This repo also has a pinned interpreter at graphify-out/.graphify_python" >&2
+        echo "  that can run it as: \$(cat graphify-out/.graphify_python) -m graphify ..." >&2
+        echo "  but the plain 'graphify' command should be on PATH for this driver to work." >&2
+    fi
+    exit 1
+fi
+
+# 2. Configure the local (repo-scoped, NOT --global) merge driver.
+current_driver="$(git config --get merge.graphify.driver 2>/dev/null || true)"
+if [ "$current_driver" = "$EXPECTED_DRIVER" ]; then
+    echo "merge.graphify.driver already configured in $REPO_ROOT/.git/config"
+else
+    git config merge.graphify.driver "$EXPECTED_DRIVER"
+    echo "set merge.graphify.driver in $REPO_ROOT/.git/config"
+fi
+
+# 3. Fallback: ensure .gitattributes has the mapping line (normally already
+# committed via the repo's own .gitattributes; this is only a safety net for
+# someone running this script before that change has been pulled).
+attrs_file="$REPO_ROOT/.gitattributes"
+if [ -f "$attrs_file" ] && grep -qxF "$ATTR_LINE" "$attrs_file"; then
+    : # already present
+else
+    printf '%s\n' "$ATTR_LINE" >> "$attrs_file"
+    echo "appended '$ATTR_LINE' to $attrs_file"
+fi
+
+# 4. Confirmation.
+echo "graphify merge driver ready: merge.graphify.driver='$(git config --get merge.graphify.driver)', .gitattributes maps graphify-out/graph.json -> merge=graphify"

--- a/scripts/setup_graphify_merge_driver.sh
+++ b/scripts/setup_graphify_merge_driver.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Registers graphify's union-merge driver for graphify-out/graph.json in the
-# CURRENT clone's local .git/config. This step is NOT committable by git's
-# own design (.git/config is never tracked), so every clone/worktree that
-# wants conflict-free graph.json merges must run this script once.
+# CURRENT clone's local git config. This step is NOT committable by git's
+# own design (local git config is never tracked), so every clone/worktree
+# that wants conflict-free graph.json merges must run this script once.
 #
 # Idempotent: safe to run multiple times, safe to run in a repo that already
 # has the driver configured.
@@ -11,68 +11,71 @@
 #   scripts/setup_graphify_merge_driver.sh [REPO_PATH]
 #
 # REPO_PATH defaults to the repo containing this script. Pass a path to
-# target a different repo (e.g. for testing against a throwaway repo).
+# target a different repo (e.g. for testing against a throwaway repo). Any
+# path inside the repo (including a linked worktree) works.
 
 set -eu
 
 EXPECTED_DRIVER='graphify merge-driver %O %A %B'
 ATTR_LINE='graphify-out/graph.json merge=graphify'
 
-# Resolve the target repo root.
-#
-# If REPO_PATH is given, walk up from there to find .git. Otherwise walk up
-# from this script's own location (mirrors the REPO_ROOT pattern used
-# elsewhere in this repo, e.g. scripts/collapse_mirror_live_path_truth.sh /
-# scripts/git-stash-table.sh) rather than assuming cwd is repo root.
-find_repo_root() {
-    start_dir="$1"
-    dir="$start_dir"
-    while [ "$dir" != "/" ]; do
-        if [ -e "$dir/.git" ]; then
-            printf '%s\n' "$dir"
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
-    return 1
-}
-
 if [ "${1:-}" != "" ]; then
-    start_dir="$(cd "$1" 2>/dev/null && pwd)" || {
-        echo "error: REPO_PATH '$1' does not exist" >&2
-        exit 1
-    }
+    start_dir="$1"
 else
-    script_dir="$(cd "$(dirname "$0")" && pwd)"
-    start_dir="$script_dir"
+    start_dir="$(cd "$(dirname "$0")" && pwd)"
 fi
 
-REPO_ROOT="$(find_repo_root "$start_dir")" || {
-    echo "error: could not find a .git directory above '$start_dir'" >&2
+if [ ! -d "$start_dir" ] && [ ! -e "$start_dir" ]; then
+    echo "error: REPO_PATH '$start_dir' does not exist" >&2
     exit 1
-}
+fi
 
+if ! git -C "$start_dir" rev-parse --git-common-dir >/dev/null 2>&1; then
+    echo "error: '$start_dir' is not inside a git repository" >&2
+    exit 1
+fi
+
+REPO_ROOT="$(git -C "$start_dir" rev-parse --show-toplevel)"
+# `git config` without -C/--git-dir operates on the repo containing $PWD, so
+# resolve everything from here relative to REPO_ROOT explicitly rather than
+# depending on the caller's cwd.
 cd "$REPO_ROOT"
+
+# For the confirmation message only: where the config this script edits
+# actually lives. In a linked worktree, "$REPO_ROOT/.git" is a *file* (a
+# gitdir pointer), not a directory -- there is no "$REPO_ROOT/.git/config"
+# in that case. `git config` (no --local override) still correctly targets
+# the per-worktree-or-shared config that applies here; this just makes sure
+# the printed path matches where it was actually written, for anyone who
+# goes looking.
+CONFIG_PATH="$(git rev-parse --git-common-dir)/config"
+case "$CONFIG_PATH" in
+    /*) : ;;
+    *) CONFIG_PATH="$REPO_ROOT/$CONFIG_PATH" ;;
+esac
 
 # 1. Confirm graphify is available.
 if ! command -v graphify >/dev/null 2>&1; then
     echo "error: 'graphify' is not on PATH." >&2
-    echo "  Install it with: pip install graphifyy" >&2
     if [ -x "graphify-out/.graphify_python" ]; then
-        echo "  This repo also has a pinned interpreter at graphify-out/.graphify_python" >&2
+        echo "  This repo has a pinned interpreter at graphify-out/.graphify_python" >&2
         echo "  that can run it as: \$(cat graphify-out/.graphify_python) -m graphify ..." >&2
-        echo "  but the plain 'graphify' command should be on PATH for this driver to work." >&2
+        echo "  but the plain 'graphify' command needs to be on PATH for the merge" >&2
+        echo "  driver git invokes to find it." >&2
     fi
+    echo "  Install it with: uv tool install graphifyy   (or: pip install graphifyy" >&2
+    echo "  if you're not using uv -- check which one this machine actually has" >&2
+    echo "  on PATH before picking a command)." >&2
     exit 1
 fi
 
 # 2. Configure the local (repo-scoped, NOT --global) merge driver.
 current_driver="$(git config --get merge.graphify.driver 2>/dev/null || true)"
 if [ "$current_driver" = "$EXPECTED_DRIVER" ]; then
-    echo "merge.graphify.driver already configured in $REPO_ROOT/.git/config"
+    echo "merge.graphify.driver already configured in $CONFIG_PATH"
 else
     git config merge.graphify.driver "$EXPECTED_DRIVER"
-    echo "set merge.graphify.driver in $REPO_ROOT/.git/config"
+    echo "set merge.graphify.driver in $CONFIG_PATH"
 fi
 
 # 3. Fallback: ensure .gitattributes has the mapping line (normally already


### PR DESCRIPTION
## Summary

- `pre-commit` hook refuses commits from the shared/primary checkout, with a deliberate `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1` escape hatch — plain git, not tied to any specific tool or subscription.
- `scripts/safe_docker_build.sh` gives the same protection for `docker compose` builds/deploys, which no git hook can reach (acknowledged as the weaker, convention-based half — git hooks have no jurisdiction over non-git commands).
- `graphify-out/graph.json`'s union-merge driver is now registered (`.gitattributes` + `scripts/setup_graphify_merge_driver.sh`), ahead of that file being committed to the repo in a follow-up.

## Why

A concurrent agent session ran `docker compose build`+`up` directly from the shared checkout and silently reverted another session's already-verified fix. The existing mitigation (a CLAUDE.md sentence saying "use worktrees") was already in place and didn't stop it. Full design rationale in `reviews/pending/2026-07-14-agent-worktree-discipline-and-graphify-sync-spec.md`.

## Test plan

All verified end-to-end against isolated throwaway repos under `/tmp` (never the real repo/worktrees), both by the implementing subagents and independently re-run by the orchestrator:

- [x] Commit from the shared checkout is blocked (non-zero exit, no commit created)
- [x] Commit from a linked worktree succeeds normally, no added delay
- [x] `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1` escape hatch works
- [x] `safe_docker_build.sh` blocks from the shared checkout, passes through cleanly from a worktree (tested against real `docker compose`), errors clearly on an unknown service
- [x] Two branches each adding a distinct node to a `graph.json`-shaped file merge with zero conflict markers and both nodes present — confirms the actual union-merge driver ran, not a coincidental text merge
- [x] `sh -n` syntax-checked, `git diff --check` clean, all four scripts executable

## Not in this PR

Committing `graphify-out/graph.json`/`GRAPH_REPORT.md`/`manifest.json` for real, the `AGENTS.md` policy-text update, GitHub Actions/CI wiring, and the `/loop`-scheduled `graphify . --update` cadence — all separately shippable per the spec, lower urgency than this piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)