### PR TITLE
Commit the knowledge graph for the first time

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,0 +1,4904 @@
+# Graph Report - .  (2026-07-14)
+
+## Corpus Check
+- 40 files · ~1,769,059 words
+- Verdict: corpus is large enough that graph structure adds value.
+
+## Summary
+- 31386 nodes · 93510 edges · 1419 communities (1095 shown, 324 thin omitted)
+- Extraction: 87% EXTRACTED · 13% INFERRED · 0% AMBIGUOUS · INFERRED: 12559 edges (avg confidence: 0.62)
+- Token cost: 0 input · 0 output
+
+## Community Hubs (Navigation)
+- Core Bus Schemas (Envelope/ServiceRef family)
+- Async Bus Service Client
+- Frontier Curiosity Target Zone Schemas
+- Consolidation Windows
+- Attention Schema & Self-State
+- Memory Turn-Change Signal
+- Endogenous Goal Origination
+- Concept Profile Backend
+- Bus Chat Result Payload Schemas
+- Bus Chat/Input Payload Schemas
+- Social Artifact Schemas
+- Cognition Plan Loader
+- Harness Cortex Client
+- Substrate Mutation Trial Schemas
+- Bus Queue Service Chassis
+- PAD Affect Schemas
+- Context-Exec Request Schemas
+- Autonomy Subject Fanout
+- Chat Role Schemas
+- Graph SPARQL Client
+- Language/Grammar Schemas
+- Autonomy Capability Policy
+- Biometrics Publisher/Loader
+- Autonomy Goal-Action Errors
+- Daily Metacog Prompt Tests
+- Notify Client
+- Grounding/Investigation Findings
+- Journaler Write Schemas
+- Autonomy Origination Eval
+- Cognition Projection Concept Tests
+- Reverie Broadcast Reader
+- Cognition Reflect/Recall Integration Tests
+- Autonomy Deviation Gate
+- Vision Frame Pointer Schemas
+- Agent Council Bound-Capability Schemas
+- Attention Frame Schemas
+- Substrate Experiment Gradient Observer
+- Cognition Verb Activation
+- Telemetry Field-Channel Corpus
+- Hub Static JS Frontend App
+- Story/Narrative Weave
+- Bus Schema Rationale Notes
+- Cognition Recall Query
+- Consolidation Builder
+- Field Coherence
+- Context-Exec V2 Readiness Hardening Tests
+- Bus Schema Rationale Notes (2)
+- LLM/OpenAI Message Content
+- Repair Evidence Schemas
+- Bus Base Envelope
+- Grammar Ledger (Atom/Event Storage)
+- Proposal Ledger
+- Concept Induction Core Schemas
+- Image Assets
+- Social Autonomy Schemas
+- Telemetry Spark Signal
+- Autonomy Repository
+- Cognition Hub-Gateway Bus Harness
+- Bus Span Exporter (Tracing)
+- LLM Gateway Backend
+- Community 60
+- Community 61
+- Community 62
+- Community 63
+- Community 64
+- Community 65
+- Community 66
+- Community 67
+- Community 68
+- Community 69
+- Community 70
+- Community 71
+- Community 72
+- Community 73
+- Community 74
+- Community 75
+- Community 76
+- Community 77
+- Bus Channels: Chat/GPT Ingest Family
+- Community 79
+- Community 80
+- Community 81
+- Community 82
+- Community 83
+- Community 84
+- Community 85
+- Community 86
+- Community 87
+- Community 88
+- Community 89
+- Community 90
+- Community 91
+- Community 92
+- Community 93
+- Community 94
+- Community 95
+- Community 96
+- Community 97
+- Community 98
+- Community 99
+- Community 100
+- Community 101
+- Community 102
+- Community 103
+- Community 104
+- Community 105
+- Community 106
+- Community 107
+- Community 108
+- Community 109
+- Community 110
+- Community 111
+- Community 112
+- Community 113
+- Community 114
+- Community 115
+- Community 116
+- Bus Channels: Agent Council & Chat History
+- Community 118
+- Community 119
+- Community 120
+- Community 121
+- Community 122
+- Community 123
+- Community 124
+- Community 125
+- Community 126
+- Community 127
+- Community 128
+- Community 129
+- Community 130
+- Community 131
+- Community 132
+- Community 133
+- Community 134
+- Community 135
+- Community 136
+- Community 137
+- Community 138
+- Community 139
+- Community 140
+- Community 141
+- Community 142
+- Bus Channels: Actions Trigger/Audit Family
+- Community 144
+- Community 145
+- Community 146
+- Bus Channels: Social Room Bridge
+- Community 148
+- Community 149
+- Community 150
+- Community 151
+- Community 152
+- Community 153
+- Community 154
+- Community 155
+- Community 156
+- Bus Channels: Collapse Mirror & Autonomy Goal
+- Community 158
+- Community 159
+- Community 160
+- Community 161
+- Community 162
+- Community 163
+- Community 164
+- Community 165
+- Community 166
+- Community 167
+- Community 168
+- Community 169
+- Community 170
+- Community 171
+- Community 172
+- Community 173
+- Community 174
+- Community 175
+- Community 176
+- Community 177
+- Community 178
+- Community 179
+- Community 180
+- Community 181
+- Community 182
+- Community 183
+- Community 184
+- Community 185
+- Community 186
+- Community 187
+- Community 188
+- Community 189
+- Community 190
+- Community 191
+- Bus Channels: Vision Exec Request/Result
+- Community 193
+- Community 194
+- Community 195
+- Community 196
+- Community 197
+- Community 198
+- Community 199
+- Community 200
+- Community 201
+- Community 202
+- Community 203
+- Community 204
+- Community 205
+- Community 206
+- Community 207
+- Community 208
+- Community 209
+- Community 210
+- Community 211
+- Community 212
+- Community 213
+- Community 214
+- Community 215
+- Community 216
+- Community 217
+- Community 218
+- Community 219
+- Community 220
+- Community 221
+- Community 222
+- Community 223
+- Community 224
+- Community 225
+- Community 226
+- Community 227
+- Community 228
+- Bus Channels: Biometrics & Cognition Trace
+- Community 230
+- Community 231
+- Community 232
+- Community 233
+- Community 234
+- Community 235
+- Community 236
+- Bus Channels: Embodiment & Harness/Grammar
+- Community 238
+- Community 239
+- Community 240
+- Community 241
+- Community 242
+- Community 243
+- Community 244
+- Community 245
+- Community 246
+- Community 247
+- Community 248
+- Community 249
+- Community 250
+- Community 251
+- Community 252
+- Community 253
+- Community 254
+- Community 255
+- Community 256
+- Community 257
+- Community 258
+- Community 259
+- Community 260
+- Community 261
+- Community 262
+- Community 263
+- Community 264
+- Community 265
+- Community 266
+- Community 267
+- Community 268
+- Community 269
+- Community 270
+- Community 271
+- Community 272
+- Community 273
+- Community 274
+- Community 275
+- Community 276
+- Community 277
+- Community 278
+- Community 279
+- Community 280
+- Community 281
+- Community 282
+- Community 283
+- Community 284
+- Community 285
+- Community 286
+- Community 287
+- Community 288
+- Community 289
+- Community 290
+- Community 291
+- Community 292
+- Community 293
+- Community 294
+- Community 295
+- Community 296
+- Community 297
+- Community 298
+- Community 299
+- Community 300
+- Community 301
+- Community 302
+- Community 303
+- Community 304
+- Community 305
+- Community 306
+- Community 307
+- Community 308
+- Community 309
+- Community 310
+- Community 311
+- Community 312
+- Community 313
+- Community 314
+- Community 315
+- Community 317
+- Community 318
+- Community 319
+- Community 320
+- Community 321
+- Community 322
+- Community 323
+- Community 324
+- Community 325
+- Community 326
+- Community 327
+- Community 328
+- Community 329
+- Community 330
+- Community 331
+- Community 332
+- Community 333
+- Community 334
+- Community 335
+- Community 336
+- Community 337
+- Community 338
+- Community 339
+- Community 340
+- Community 341
+- Community 343
+- Community 344
+- Community 345
+- Community 346
+- Community 347
+- Community 348
+- Community 349
+- Community 350
+- Community 351
+- Community 352
+- Community 353
+- Community 354
+- Community 355
+- Community 356
+- Community 357
+- Community 358
+- Community 359
+- Community 360
+- Community 361
+- Community 362
+- Community 363
+- Community 364
+- Community 365
+- Community 366
+- Community 367
+- Community 368
+- Community 369
+- Community 370
+- Community 371
+- Community 372
+- Community 373
+- Community 374
+- Community 375
+- Community 376
+- Community 377
+- Community 378
+- Community 379
+- Bus Channels: Meta-Tags & KG Edge Ingest
+- Community 381
+- Community 382
+- Community 383
+- Community 384
+- Community 385
+- Community 386
+- Community 387
+- Community 388
+- Community 389
+- Community 390
+- Community 391
+- Community 392
+- Community 393
+- Community 394
+- Community 395
+- Community 396
+- Community 397
+- Community 398
+- Community 399
+- Community 400
+- Community 401
+- Community 402
+- Community 403
+- Community 404
+- Community 405
+- Community 406
+- Community 407
+- Community 408
+- Community 409
+- Community 410
+- Community 411
+- Community 412
+- Community 413
+- Community 414
+- Community 415
+- Community 416
+- Community 417
+- Community 418
+- Community 419
+- Community 420
+- Community 421
+- Community 422
+- Community 423
+- Community 424
+- Community 425
+- Community 426
+- Community 427
+- Community 428
+- Community 429
+- Community 430
+- Community 431
+- Community 432
+- Community 433
+- Community 434
+- Community 435
+- Community 436
+- Community 437
+- Community 438
+- Community 439
+- Community 440
+- Community 441
+- Community 442
+- Community 443
+- Community 444
+- Community 445
+- Community 446
+- Community 447
+- Community 448
+- Community 449
+- Community 450
+- Community 451
+- Community 452
+- Community 453
+- Community 454
+- Community 455
+- Community 456
+- Community 457
+- Community 458
+- Community 459
+- Community 460
+- Community 461
+- Community 462
+- Community 463
+- Community 464
+- Community 465
+- Community 466
+- Community 467
+- Community 469
+- Community 470
+- Community 471
+- Community 472
+- Community 473
+- Community 474
+- Community 475
+- Community 476
+- Community 477
+- Community 478
+- Community 479
+- Community 480
+- Community 481
+- Community 482
+- Community 484
+- Community 485
+- Community 486
+- Community 487
+- Community 488
+- Community 489
+- Community 490
+- Community 491
+- Community 492
+- Community 493
+- Community 494
+- Community 495
+- Community 496
+- Community 497
+- Community 498
+- Community 499
+- Community 500
+- Community 501
+- Community 502
+- Community 503
+- Community 504
+- Community 505
+- Community 506
+- Community 507
+- Community 508
+- Community 509
+- Community 510
+- Community 511
+- Community 512
+- Community 513
+- Community 514
+- Community 515
+- Community 516
+- Community 517
+- Community 518
+- Community 519
+- Community 520
+- Community 521
+- Community 522
+- Community 523
+- Community 524
+- Community 525
+- Community 526
+- Community 527
+- Community 528
+- Community 529
+- Community 530
+- Community 531
+- Community 532
+- Community 533
+- Community 534
+- Community 535
+- Community 536
+- Community 537
+- Community 538
+- Community 539
+- Community 540
+- Community 541
+- Community 542
+- Community 543
+- Community 544
+- Community 545
+- Community 546
+- Community 547
+- Community 548
+- Community 549
+- Community 550
+- Community 551
+- Community 552
+- Community 553
+- Community 554
+- Community 555
+- Community 556
+- Community 557
+- Community 558
+- Community 559
+- Community 560
+- Community 561
+- Community 562
+- Community 563
+- Community 564
+- Community 565
+- Community 566
+- Community 567
+- Community 568
+- Community 569
+- Community 570
+- Community 571
+- Community 572
+- Community 574
+- Community 575
+- Community 576
+- Community 577
+- Community 578
+- Community 579
+- Community 580
+- Community 581
+- Community 582
+- Community 583
+- Community 584
+- Community 585
+- Community 586
+- Community 587
+- Community 588
+- Community 589
+- Community 590
+- Community 591
+- Community 592
+- Community 593
+- Community 594
+- Community 595
+- Community 596
+- Community 597
+- Community 598
+- Community 599
+- Community 600
+- Community 601
+- Community 602
+- Community 603
+- Community 604
+- Community 605
+- Community 606
+- Community 607
+- Community 608
+- Community 609
+- Community 610
+- Community 611
+- Community 612
+- Community 613
+- Community 614
+- Community 615
+- Bus Channels: Graph Compression & RDF
+- Community 617
+- Community 618
+- Community 619
+- Community 620
+- Community 621
+- Community 622
+- Community 623
+- Community 624
+- Community 625
+- Community 626
+- Community 627
+- Community 628
+- Community 629
+- Community 630
+- Community 631
+- Community 632
+- Community 633
+- Community 634
+- Community 635
+- Community 636
+- Community 637
+- Community 638
+- Community 639
+- Community 640
+- Community 641
+- Community 642
+- Community 643
+- Community 644
+- Community 645
+- Community 646
+- Community 647
+- Community 648
+- Community 649
+- Community 650
+- Community 651
+- Community 652
+- Community 653
+- Community 654
+- Community 655
+- Community 656
+- Community 657
+- Community 658
+- Community 659
+- Community 660
+- Community 661
+- Community 662
+- Community 663
+- Community 664
+- Community 666
+- Community 667
+- Community 668
+- Community 669
+- Community 670
+- Community 671
+- Community 672
+- Community 673
+- Community 674
+- Community 675
+- Community 676
+- Community 677
+- Community 678
+- Community 679
+- Community 680
+- Community 681
+- Community 682
+- Community 683
+- Community 684
+- Community 685
+- Community 686
+- Community 687
+- Community 688
+- Community 689
+- Community 690
+- Community 691
+- Community 692
+- Community 693
+- Community 694
+- Community 695
+- Community 696
+- Community 697
+- Community 698
+- Community 699
+- Community 700
+- Community 701
+- Community 702
+- Community 703
+- Community 704
+- Community 705
+- Bus Channels: Substrate Tier Telemetry
+- Community 707
+- Community 708
+- Community 709
+- Community 710
+- Community 711
+- Community 712
+- Community 713
+- Community 714
+- Community 715
+- Community 716
+- Community 717
+- Community 718
+- Community 719
+- Community 720
+- Community 721
+- Community 722
+- Community 723
+- Community 724
+- Community 725
+- Community 726
+- Community 727
+- Community 728
+- Community 730
+- Community 731
+- Community 732
+- Community 733
+- Community 734
+- Community 735
+- Community 736
+- Community 737
+- Community 738
+- Community 739
+- Community 740
+- Community 741
+- Community 742
+- Community 743
+- Community 744
+- Community 745
+- Community 746
+- Community 747
+- Community 749
+- Community 750
+- Community 751
+- Community 752
+- Community 754
+- Community 755
+- Community 756
+- Community 757
+- Community 758
+- Community 759
+- Community 760
+- Community 761
+- Community 762
+- Community 763
+- Community 764
+- Community 765
+- Community 766
+- Community 767
+- Community 768
+- Community 769
+- Community 770
+- Community 771
+- Community 772
+- Community 773
+- Community 774
+- Community 775
+- Community 776
+- Community 777
+- Community 778
+- Community 779
+- Community 781
+- Community 783
+- Community 784
+- Community 786
+- Community 787
+- Community 788
+- Community 789
+- Community 790
+- Community 791
+- Community 792
+- Community 793
+- Community 794
+- Community 795
+- Community 796
+- Community 797
+- Community 798
+- Community 799
+- Community 800
+- Community 801
+- Community 802
+- Community 803
+- Community 804
+- Community 805
+- Community 806
+- Community 807
+- Community 808
+- Community 809
+- Community 810
+- Community 811
+- Community 812
+- Community 813
+- Community 814
+- Community 815
+- Community 816
+- Community 817
+- Community 818
+- Community 819
+- Community 820
+- Community 821
+- Community 822
+- Community 823
+- Community 824
+- Community 825
+- Community 826
+- Community 827
+- Community 828
+- Community 829
+- Community 832
+- Community 833
+- Community 834
+- Community 835
+- Community 836
+- Community 837
+- Community 838
+- Community 839
+- Community 840
+- Community 841
+- Community 842
+- Community 843
+- Community 844
+- Community 845
+- Community 846
+- Community 847
+- Community 848
+- Community 849
+- Community 850
+- Community 851
+- Community 852
+- Community 853
+- Community 854
+- Community 855
+- Community 856
+- Community 857
+- Community 858
+- Community 859
+- Community 860
+- Community 861
+- Community 862
+- Community 863
+- Community 864
+- Community 865
+- Community 866
+- Community 867
+- Community 868
+- Community 869
+- Community 870
+- Community 871
+- Community 872
+- Community 873
+- Community 874
+- Community 875
+- Community 876
+- Community 877
+- Community 878
+- Community 879
+- Community 882
+- Community 883
+- Community 884
+- Community 885
+- Community 886
+- Community 887
+- Community 888
+- Community 889
+- Community 890
+- Community 891
+- Community 892
+- Community 897
+- Community 898
+- Community 899
+- Community 900
+- Community 901
+- Community 902
+- Community 905
+- Community 908
+- Community 909
+- Community 910
+- Community 911
+- Community 912
+- Community 913
+- Community 914
+- Community 915
+- Community 916
+- Community 917
+- Community 918
+- Community 919
+- Community 920
+- Community 921
+- Community 922
+- Community 923
+- Community 925
+- Community 926
+- Community 927
+- Community 928
+- Community 929
+- Community 930
+- Community 931
+- Community 932
+- Community 933
+- Community 934
+- Community 936
+- Community 937
+- Community 938
+- Community 939
+- Community 940
+- Community 941
+- Community 942
+- Community 943
+- Community 944
+- Community 945
+- Community 946
+- Community 947
+- Community 948
+- Community 949
+- Community 950
+- Community 951
+- Community 952
+- Community 953
+- Community 954
+- Community 955
+- Community 956
+- Community 957
+- Community 958
+- Community 959
+- Community 960
+- Community 961
+- Community 962
+- Community 964
+- Community 965
+- Community 966
+- Community 967
+- Community 968
+- Community 969
+- Community 970
+- Community 971
+- Community 972
+- Community 973
+- Community 974
+- Community 975
+- Community 976
+- Community 977
+- Community 978
+- Community 979
+- Community 980
+- Community 981
+- Community 982
+- Community 984
+- Community 987
+- Community 989
+- Community 990
+- Community 991
+- Community 992
+- Community 994
+- Community 995
+- Community 1000
+- Community 1001
+- Community 1002
+- Community 1003
+- Community 1004
+- Community 1005
+- Community 1006
+- Community 1007
+- Community 1008
+- Community 1009
+- Community 1010
+- Community 1011
+- Community 1012
+- Community 1013
+- Community 1014
+- Community 1016
+- Community 1017
+- Community 1019
+- Community 1021
+- Community 1022
+- Community 1023
+- Community 1026
+- Community 1027
+- Community 1028
+- Community 1029
+- Community 1030
+- Community 1031
+- Community 1032
+- Community 1033
+- Community 1034
+- Community 1035
+- Community 1036
+- Community 1037
+- Community 1038
+- Community 1039
+- Community 1040
+- Community 1041
+- Community 1042
+- Community 1043
+- Community 1045
+- Community 1046
+- Community 1047
+- Community 1048
+- Community 1049
+- Community 1050
+- Community 1051
+- Community 1052
+- Community 1053
+- Community 1054
+- Community 1055
+- Community 1056
+- Community 1057
+- Community 1058
+- Community 1059
+- Community 1060
+- Community 1061
+- Community 1062
+- Community 1063
+- Community 1065
+- Community 1066
+- Community 1067
+- Community 1068
+- Community 1069
+- Community 1070
+- Community 1071
+- Community 1072
+- Community 1073
+- Community 1074
+- Community 1075
+- Community 1076
+- Community 1077
+- Community 1078
+- Community 1079
+- Community 1080
+- Community 1081
+- Community 1082
+- Community 1083
+- Community 1084
+- Community 1085
+- Community 1086
+- Community 1087
+- Community 1088
+- Community 1089
+- Community 1090
+- Community 1091
+- Community 1092
+- Community 1093
+- Community 1094
+- Community 1095
+- Community 1096
+- Community 1097
+- Community 1098
+- Community 1099
+- Community 1100
+- Community 1101
+- Community 1102
+- Community 1103
+- Community 1104
+- Community 1105
+- Community 1106
+- Community 1107
+- Community 1108
+- Community 1109
+- Community 1110
+- Community 1111
+- Community 1112
+- Community 1113
+- Community 1114
+- Community 1115
+- Community 1116
+- Community 1117
+- Community 1118
+- Community 1119
+- Community 1120
+- Community 1121
+- Community 1122
+- Community 1123
+- Community 1124
+- Community 1125
+- Community 1127
+- Community 1128
+- Community 1129
+- Community 1132
+- Community 1133
+- Community 1134
+- Community 1135
+- Community 1136
+- Community 1138
+- Community 1141
+- Community 1149
+- Community 1150
+- Community 1153
+- Community 1154
+- Community 1155
+- Community 1156
+- Community 1157
+- Community 1158
+- Community 1159
+- Community 1161
+- Community 1162
+- Community 1163
+- Community 1164
+- Community 1165
+- Community 1168
+- Community 1172
+- Community 1173
+- Community 1174
+- Community 1175
+- Community 1176
+- Community 1177
+- Community 1178
+- Community 1179
+- Community 1180
+- Community 1181
+- Community 1182
+- Community 1183
+- Community 1184
+- Community 1185
+- Community 1187
+- Community 1189
+- Community 1190
+- Community 1195
+- Community 1196
+- Community 1197
+- Community 1198
+- Community 1199
+- Community 1200
+- Community 1201
+- Community 1202
+- Community 1203
+- Community 1204
+- Community 1205
+- Community 1206
+- Community 1207
+- Community 1209
+- Community 1220
+- Community 1221
+- Community 1222
+- Community 1223
+- Community 1224
+- Community 1225
+- Community 1226
+- Community 1227
+- Community 1228
+- Community 1229
+- Community 1230
+- Community 1232
+- Community 1233
+- Community 1234
+- Community 1235
+- Community 1236
+- Community 1237
+- Community 1238
+- Community 1239
+- Community 1240
+- Community 1241
+- Community 1242
+- Community 1243
+- Community 1244
+- Community 1245
+- Community 1246
+- Community 1247
+- Community 1248
+- Community 1249
+- Community 1250
+- Community 1251
+- Community 1252
+- Community 1253
+- Community 1254
+- Community 1255
+- Community 1256
+- Community 1257
+- Community 1267
+- Community 1269
+- Community 1270
+- Community 1271
+- Community 1272
+- Community 1273
+- Community 1274
+- Community 1275
+- Community 1276
+- Community 1277
+- Community 1281
+- Community 1286
+- Community 1287
+- Community 1297
+- Community 1298
+- Community 1299
+- Community 1300
+- Community 1301
+- Community 1302
+- Community 1303
+- Community 1304
+- Community 1305
+- Community 1308
+- Community 1309
+- Community 1364
+- Community 1367
+- Community 1379
+- Community 1380
+- Community 1395
+
+## God Nodes (most connected - your core abstractions)
+1. `ServiceRef` - 1128 edges
+2. `BaseEnvelope` - 1115 edges
+3. `OrionBusAsync` - 670 edges
+4. `SchemaRegistration` - 555 edges
+5. `Orion Bus Channels Registry (channels.yaml)` - 262 edges
+6. `ContextExecRequestV1` - 218 edges
+7. `SelfStateV1` - 194 edges
+8. `GrammarEventV1` - 184 edges
+9. `settings()` - 184 edges
+10. `SubstrateMutationStore` - 181 edges
+
+## Surprising Connections (you probably didn't know these)
+- `Agent Trace inspection modal (Hub UI, fail case screenshot)` --semantically_similar_to--> `Idea 4: Click-through payload cards`  [INFERRED] [semantically similar]
+  .verify-run/hub_agent_trace_timeline.png → 2026-07-11-turn-visibility-design-spec.md
+- `Agent Trace inspection modal (Hub UI, fail case screenshot)` --conceptually_related_to--> `agent-trace.js (plain-text step consumer)`  [AMBIGUOUS]
+  .verify-run/hub_agent_trace_timeline.png → 2026-07-11-turn-visibility-design-spec.md
+- `Turn Visibility Design Spec (2026-07-11)` --semantically_similar_to--> `/brainstorming command (sentience-development ideation)`  [INFERRED] [semantically similar]
+  2026-07-11-turn-visibility-design-spec.md → .claude/commands/superpowers/brainstorming.md
+- `Ethics & non-instrumental stance` --semantically_similar_to--> `Privacy and blocked material stay blocked: raw private traces, journals, mirrors, and internal memory artifacts must not leak through convenience surfaces; summaries/projections preserve privacy boundaries`  [INFERRED] [semantically similar]
+  README.md → AGENTS.md
+- `Autonomy Origination Measurement Gate (scripts/analysis/README.md)` --semantically_similar_to--> `Phase 3B: Parity Evidence and Cutover-Readiness Model`  [INFERRED] [semantically similar]
+  scripts/analysis/README.md → orion/spark/concept_induction/PHASE3B_PARITY_EVIDENCE_READINESS.md
+
+## Import Cycles
+- 3-file cycle: `services/orion-cortex-exec/app/executor.py -> services/orion-cortex-exec/app/verb_adapters.py -> services/orion-cortex-exec/app/router.py -> services/orion-cortex-exec/app/executor.py`
+- 4-file cycle: `services/orion-cortex-exec/app/executor.py -> services/orion-cortex-exec/app/verb_adapters.py -> services/orion-cortex-exec/app/router.py -> services/orion-cortex-exec/app/pcr_chat_memory.py -> services/orion-cortex-exec/app/executor.py`
+- 4-file cycle: `services/orion-cortex-exec/app/executor.py -> services/orion-cortex-exec/app/verb_adapters.py -> services/orion-cortex-exec/app/router.py -> services/orion-cortex-exec/app/supervisor.py -> services/orion-cortex-exec/app/executor.py`
+- 5-file cycle: `services/orion-cortex-exec/app/executor.py -> services/orion-cortex-exec/app/verb_adapters.py -> services/orion-cortex-exec/app/router.py -> services/orion-cortex-exec/app/grounding_capsule.py -> services/orion-cortex-exec/app/pcr_chat_memory.py -> services/orion-cortex-exec/app/executor.py`
+- 5-file cycle: `services/orion-cortex-exec/app/executor.py -> services/orion-cortex-exec/app/verb_adapters.py -> services/orion-cortex-exec/app/router.py -> services/orion-cortex-exec/app/supervisor.py -> services/orion-cortex-exec/app/pcr_chat_memory.py -> services/orion-cortex-exec/app/executor.py`
+
+## Hyperedges (group relationships)
+- **Social memory event family (sole producer orion-social-memory)** — orion_bus_channels_orion_social_participant_continuity, orion_bus_channels_orion_social_room_continuity, orion_bus_channels_orion_social_stance_snapshot, orion_bus_channels_orion_social_relational_update, orion_bus_channels_orion_social_open_thread, orion_bus_channels_orion_social_peer_style, orion_bus_channels_orion_social_room_ritual, orion_bus_channels_orion_social_commitment, orion_bus_channels_orion_social_commitment_resolution, orion_bus_channels_orion_social_claim, orion_bus_channels_orion_social_claim_revision, orion_bus_channels_orion_social_claim_stance, orion_bus_channels_orion_social_claim_attribution, orion_bus_channels_orion_social_claim_consensus, orion_bus_channels_orion_social_claim_divergence, orion_bus_channels_orion_social_bridge_summary, orion_bus_channels_orion_social_clarifying_question, orion_bus_channels_orion_social_deliberation_decision, orion_bus_channels_orion_social_turn_handoff, orion_bus_channels_orion_social_closure_signal, orion_bus_channels_orion_social_floor_decision, orion_bus_channels_svc_orion_social_memory [INFERRED 0.95]
+- **World Pulse event family (sole producer orion-world-pulse)** — orion_bus_channels_orion_world_pulse_run_result, orion_bus_channels_orion_stream_world_pulse_run_result, orion_bus_channels_orion_world_pulse_digest_created, orion_bus_channels_orion_world_pulse_digest_item, orion_bus_channels_orion_world_pulse_article_emit, orion_bus_channels_orion_world_pulse_cluster_emit, orion_bus_channels_orion_world_pulse_digest_published, orion_bus_channels_orion_world_pulse_learning_emit, orion_bus_channels_orion_world_pulse_worth_reading, orion_bus_channels_orion_world_pulse_worth_watching, orion_bus_channels_orion_world_pulse_claim_emit, orion_bus_channels_orion_world_pulse_event_emit, orion_bus_channels_orion_world_pulse_entity_emit, orion_bus_channels_orion_world_pulse_situation_brief_upsert, orion_bus_channels_orion_world_pulse_situation_change_emit, orion_bus_channels_orion_world_pulse_graph_upsert, orion_bus_channels_orion_world_context_daily_capsule, orion_bus_channels_orion_world_pulse_publish_status, orion_bus_channels_orion_hub_messages_create, orion_bus_channels_svc_orion_world_pulse [INFERRED 0.95]
+- **Hub-originated channel family (sole producer orion-hub)** — orion_bus_channels_orion_conversation_request, orion_bus_channels_orion_cortex_gateway_request, orion_bus_channels_orion_cortex_pre_turn_appraisal_request, orion_bus_channels_orion_exec_request_councilservice, orion_bus_channels_orion_spark_introspect_candidate_log, orion_bus_channels_orion_chat_history_log, orion_bus_channels_orion_chat_history_turn, orion_bus_channels_orion_chat_social_turn, orion_bus_channels_orion_chat_gpt_log, orion_bus_channels_orion_chat_gpt_turn, orion_bus_channels_orion_chat_gpt_message_log, orion_bus_channels_orion_memory_cards_active, orion_bus_channels_orion_tts_intake, orion_bus_channels_orion_stt_intake, orion_bus_channels_orion_thought_request, orion_bus_channels_orion_attention_loop_outcome, orion_bus_channels_orion_harness_run_request, orion_bus_channels_orion_harness_run_cancel, orion_bus_channels_svc_orion_hub [INFERRED 0.95]
+- **Cortex-exec-originated channel family (sole producer orion-cortex-exec)** — orion_bus_channels_orion_verb_result, orion_bus_channels_orion_verb_result_wild, orion_bus_channels_orion_effect_wild, orion_bus_channels_orion_dream_log, orion_bus_channels_orion_cortex_pre_turn_appraisal_result_wild, orion_bus_channels_orion_collapse_enrich, orion_bus_channels_orion_collapse_scored, orion_bus_channels_orion_spark_introspect_candidate, orion_bus_channels_orion_cognition_reasoning_call, orion_bus_channels_orion_rdf_worker, orion_bus_channels_orion_exec_request_metatagsservice, orion_bus_channels_orion_exec_request_collapsemirrorservice, orion_bus_channels_orion_cognition_trace, orion_bus_channels_orion_autonomy_goal_planned, orion_bus_channels_orion_endogenous_runtime_record, orion_bus_channels_orion_endogenous_runtime_audit, orion_bus_channels_orion_calibration_profile_audit, orion_bus_channels_orion_substrate_tier_outcomes, orion_bus_channels_svc_orion_cortex_exec [INFERRED 0.95]
+- **Social room bridge event family (sole producer orion-social-room-bridge)** — orion_bus_channels_orion_bridge_social_participant, orion_bus_channels_orion_bridge_social_room_intake, orion_bus_channels_orion_bridge_social_room_delivery, orion_bus_channels_orion_bridge_social_room_skipped, orion_bus_channels_orion_social_repair_signal, orion_bus_channels_orion_social_repair_decision, orion_bus_channels_orion_social_epistemic_signal, orion_bus_channels_orion_social_epistemic_decision, orion_bus_channels_orion_social_turn_policy, orion_bus_channels_svc_orion_social_room_bridge [INFERRED 0.95]
+- **Spark concept-induction event family (sole producer orion-spark-concept-induction)** — orion_bus_channels_orion_spark_concepts_profile, orion_bus_channels_orion_spark_concepts_delta, orion_bus_channels_orion_memory_drives_state, orion_bus_channels_orion_memory_tension_event, orion_bus_channels_orion_memory_drives_audit, orion_bus_channels_orion_memory_identity_snapshot, orion_bus_channels_orion_memory_goals_proposed, orion_bus_channels_orion_debug_turn_dossier, orion_bus_channels_orion_stream_world_pulse_run_result_dlq, orion_bus_channels_svc_orion_spark_concept_induction [INFERRED 0.95]
+- **Harness governor event/result family (sole producer orion-harness-governor)** — orion_bus_channels_orion_harness_run_result_wild, orion_bus_channels_orion_harness_run_artifact, orion_bus_channels_orion_harness_run_step, orion_bus_channels_orion_substrate_finalize_appraisal_request, orion_bus_channels_orion_harness_verdict_artifact, orion_bus_channels_orion_substrate_turn_outcome, orion_bus_channels_orion_substrate_post_turn_closure, orion_bus_channels_svc_orion_harness_governor [INFERRED 0.95]
+- **Orion-thought event/result family (sole producer orion-thought)** — orion_bus_channels_orion_thought_result_wild, orion_bus_channels_orion_thought_artifact, orion_bus_channels_orion_reverie_thought, orion_bus_channels_orion_reverie_chain, orion_bus_channels_orion_dream_compaction_request, orion_bus_channels_orion_reverie_resonance_alert, orion_bus_channels_orion_attention_salience_trace, orion_bus_channels_svc_orion_thought [INFERRED 0.95]
+- **Notification service event family (sole producer orion-notify)** — orion_bus_channels_orion_notify_in_app, orion_bus_channels_orion_notify_persistence_request, orion_bus_channels_orion_notify_config_recipient, orion_bus_channels_orion_notify_config_preference, orion_bus_channels_orion_notify_persistence_receipt, orion_bus_channels_svc_orion_notify [INFERRED 0.95]
+- **ChatGPT import pipeline event family (sole producer chatgpt-import)** — orion_bus_channels_orion_chat_gpt_import_run, orion_bus_channels_orion_chat_gpt_conversation, orion_bus_channels_orion_chat_gpt_example, orion_bus_channels_svc_chatgpt_import [INFERRED 0.95]
+- **Channels sharing the generic catch-all payload schema (GenericPayloadV1)** — orion_bus_channels_orion_context_exec_event, orion_bus_channels_orion_exec_request_councilservice, orion_bus_channels_orion_llm_reply_wild, orion_bus_channels_orion_agent_council_intake, orion_bus_channels_orion_agent_council_reply_wild, orion_bus_channels_orion_actions_trigger_daily_pulse_v1, orion_bus_channels_orion_actions_trigger_daily_metacog_v1, orion_bus_channels_orion_actions_audit, orion_bus_channels_orion_pad_signal, orion_bus_channels_orion_pad_stats, orion_bus_channels_orion_exec_request_collapsemirrorservice, orion_bus_channels_orion_spark_introspector_reply_wild, orion_bus_channels_orion_world_pulse_publish_status, orion_bus_channels_schema_genericpayloadv1 [INFERRED 0.85]
+- **Memory crystallization lifecycle events sharing schema MemoryCrystallizationV1** — orion_bus_channels_orion_memory_crystallization_proposed, orion_bus_channels_orion_memory_crystallization_validated, orion_bus_channels_orion_memory_crystallization_approved, orion_bus_channels_orion_memory_crystallization_rejected, orion_bus_channels_orion_memory_crystallization_quarantined, orion_bus_channels_orion_memory_crystallization_project, orion_bus_channels_orion_memory_crystallization_reinforced, orion_bus_channels_orion_memory_crystallization_auto_activated, orion_bus_channels_schema_memorycrystallizationv1 [INFERRED 0.85]
+- **Collapse mirror pipeline events sharing schema CollapseMirrorEntryV2** — orion_bus_channels_orion_collapse_intake, orion_bus_channels_orion_collapse_triage, orion_bus_channels_orion_collapse_sql_write, orion_bus_channels_orion_collapse_events, orion_bus_channels_orion_collapse_enrich, orion_bus_channels_orion_collapse_scored, orion_bus_channels_schema_collapsemirrorentryv2 [INFERRED 0.85]
+- **Layer 7-9 autonomy action loop: proposal frame, execution dispatch frame, and drive-tension relief closing the loop from possible action to executed action to homeostatic effect** — services_orion_proposal_runtime_readme_proposalframev1, services_orion_execution_dispatch_runtime_readme_executiondispatchframev1, services_orion_spark_concept_induction_readme_satisfaction_tensions_relief [EXTRACTED 1.00]
+- **Shared-checkout Docker safety mechanism: the incident, the wrapper script it produced, and the spec formalizing the same guard as an installable git-level mechanism** — incident_shared_checkout_docker_revert, scripts_safe_docker_build_sh, reviews_pending_2026_07_14_agent_worktree_discipline_and_graphify_sync_spec_safe_docker_build_wrapper [EXTRACTED 1.00]
+- **Readonly capability gating: the policy config's readonly capability rules and their live consumer implementation in orion-spark-concept-induction's readonly recall/fetch dispatch** — config_autonomy_capability_policy_v1_recall_query_readonly, config_autonomy_capability_policy_v1_web_fetch_readonly, services_orion_spark_concept_induction_readme_recall_readonly_capabilities [EXTRACTED 1.00]
+- **Mesh Node Topology Consistency (atlas/athena/circe/prometheus across configs)** — config_biometrics_node_catalog_athena, config_biometrics_node_catalog_atlas, config_field_orion_field_topology_v1_node_athena, config_field_orion_field_topology_v1_node_atlas, config_consolidation_consolidation_policy_v1_policy [INFERRED 0.80]
+- **Transport Lane Pressure Sensing Pipeline** — config_substrate_lattice_grammar_producer_registry_v1_orion_bus, config_substrate_lattice_transport_lattice_policy_v1_policy, config_field_orion_field_topology_v1_capability_transport, config_attention_field_attention_policy_v1_policy [INFERRED 0.80]
+- **Layered Dry-Run/Read-Only Safety Ceiling** — config_execution_dispatch_execution_dispatch_policy_v1_policy, config_substrate_lattice_action_ceiling_policy_v1_policy, config_substrate_lattice_gate_policy_v1_policy, config_policy_substrate_policy_v1_policy [INFERRED 0.80]
+- **Proposed turn-hop event spine (schema + channel + relay + swimlane UI)** — 2026_07_11_turn_visibility_design_spec_turn_hop_v1, 2026_07_11_turn_visibility_design_spec_orion_turn_hop_channel, 2026_07_11_turn_visibility_design_spec_turn_hop_relay, 2026_07_11_turn_visibility_design_spec_swimlane_pipeline_view [INFERRED 0.85]
+- **Core cognitive-loop organs (Cortex, Recall, Spark, Metacog, Stance)** — readme_cortex_orch, readme_recall, readme_spark, readme_metacognition, readme_stance_assembly_chatstancebrief [INFERRED 0.85]
+- **Channel triage audit lineage across audit_001 (pre/postfix) and audit_002** — codex_reviews_audit_001_reports_channel_triage, codex_reviews_audit_001_reports_postfix_channel_triage, codex_reviews_audit_002_reports_channel_triage [INFERRED 0.85]
+- **Knowledge Forge v1 Ingest-to-Compile Pipeline** — orion_knowledge_agents_agent_contract, orion_knowledge_readme_authority_layers, orion_knowledge_raw_sources_2026_05_20_knowledge_forge_v1_merge_doc, orion_knowledge_claims_accepted_claim_knowledge_forge_v1_api_claim_0001 [INFERRED 0.80]
+- **Substrate Tier Telemetry Verification Flow** — orion_knowledge_claims_accepted_claim_substrate_telemetry_0001_claim_0001, orion_knowledge_claims_accepted_claim_substrate_telemetry_0002_claim_0002, orion_knowledge_context_packs_cursor_substrate_tier_telemetry_v1_doc, orion_knowledge_raw_sources_2026_05_14_substrate_tier_telemetry_design_ref_doc [INFERRED 0.85]
+- **Knowledge Forge Ideation Review Workflow** — orion_knowledge_reviews_pending_source_delta_20260521t001031z_smoke_003_review, orion_knowledge_specs_execution_ready_knowledge_forge_ideation_review_v1_doc, orion_knowledge_specs_execution_ready_knowledge_forge_ideation_review_v1_yaml [EXTRACTED 0.90]
+- **Substrate Tier Telemetry Pipeline** — orion_knowledge_specs_execution_ready_substrate_tier_telemetry_v1_yaml, orion_knowledge_wiki_concepts_substrate_tier_telemetry_doc, orion_bus_channels_substrate_tier_outcomes [EXTRACTED 0.90]
+- **Cognition Pack + Verb System** — orion_cognition_readme_cognition_packs, orion_cognition_packs_executive_pack, orion_cognition_verbs_analyze_text [EXTRACTED 0.90]
+- **Context-Exec Investigative Verb Family** — orion_cognition_verbs_context_exec_belief_provenance_context_exec_belief_provenance, orion_cognition_verbs_context_exec_grammar_collision_audit_context_exec_grammar_collision_audit, orion_cognition_verbs_context_exec_memory_contradiction_review_context_exec_memory_contradiction_review, orion_cognition_verbs_context_exec_repo_impact_analysis_context_exec_repo_impact_analysis, orion_cognition_verbs_context_exec_trace_autopsy_context_exec_trace_autopsy [INFERRED 0.85]
+- **Capability-Selector-Backed Assessment Verbs** — orion_cognition_verbs_assess_mesh_presence_assess_mesh_presence, orion_cognition_verbs_assess_runtime_state_assess_runtime_state, orion_cognition_verbs_assess_storage_health_assess_storage_health [INFERRED 0.85]
+- **Chat Lane Verb Family** — orion_cognition_verbs_chat_general_chat_general, orion_cognition_verbs_chat_quick_chat_quick, orion_cognition_verbs_chat_kids_story_chat_kids_story, orion_cognition_verbs_chat_deep_graph_chat_deep_graph, orion_cognition_verbs_chat_social_room_chat_social_room [INFERRED 0.75]
+- **Dream Cycle Consolidation Family** — orion_cognition_verbs_dream_cycle_dream_cycle, orion_cognition_verbs_dream_preprocess_dream_preprocess, orion_cognition_verbs_dream_simple_dream_simple [EXTRACTED 1.00]
+- **Recall-then-Draft Journaling Family** — orion_cognition_verbs_daily_metacog_v1_daily_metacog_v1, orion_cognition_verbs_daily_pulse_v1_daily_pulse_v1, orion_cognition_verbs_journal_compose_journal_compose [INFERRED 0.85]
+- **Capability-Backed Runtime Inspection Family** — orion_cognition_verbs_housekeep_runtime_housekeep_runtime, orion_cognition_verbs_inspect_docker_container_status_inspect_docker_container_status, orion_cognition_verbs_inspect_gpu_status_inspect_gpu_status, orion_cognition_verbs_list_biometrics_recent_readings_list_biometrics_recent_readings [INFERRED 0.80]
+- **Vision Perception Pipeline (Host retina_fast composing Embed/Detect/Caption, chaining into Window/Council/Scribe)** — orion_cognition_verbs_perceive_caption_frame_perceive_caption_frame, orion_cognition_verbs_perceive_detect_open_vocab_perceive_detect_open_vocab, orion_cognition_verbs_perceive_embed_image_perceive_embed_image, orion_cognition_verbs_perceive_retina_fast_perceive_retina_fast, orion_cognition_verbs_perceive_vision_events_perceive_vision_events, orion_cognition_verbs_perceive_vision_memory_perceive_vision_memory [EXTRACTED 1.00]
+- **Self-Study Trust Lanes (authoritative -> induced -> reflective -> lane-aware retrieval)** — orion_cognition_verbs_self_repo_inspect_self_repo_inspect, orion_cognition_verbs_self_concept_induce_self_concept_induce, orion_cognition_verbs_self_concept_reflect_self_concept_reflect, orion_cognition_verbs_self_retrieve_self_retrieve [EXTRACTED 1.00]
+- **Capability-Backed Selector Verbs (notification/snapshot-metric read verbs sharing identical execution_mode + schema shape)** — orion_cognition_verbs_send_operator_notification_send_operator_notification, orion_cognition_verbs_show_biometrics_snapshot_show_biometrics_snapshot, orion_cognition_verbs_show_landing_pad_metrics_show_landing_pad_metrics [EXTRACTED 1.00]
+- **Mesh Operations Skill Family (skills.mesh.*)** — orion_cognition_verbs_skills_mesh_mesh_ops_round_v1_skills_mesh_mesh_ops_round_v1, orion_cognition_verbs_skills_mesh_refresh_service_envs_v1_skills_mesh_refresh_service_envs_v1, orion_cognition_verbs_skills_mesh_tailscale_mesh_status_v1_skills_mesh_tailscale_mesh_status_v1, orion_cognition_verbs_skills_mesh_up_all_services_v1_skills_mesh_up_all_services_v1 [EXTRACTED 1.00]
+- **Read-Only Diagnostic Snapshot Skill Family (skills.*)** — orion_cognition_verbs_skills_docker_ps_status_v1_skills_docker_ps_status_v1, orion_cognition_verbs_skills_gpu_nvidia_smi_snapshot_v1_skills_gpu_nvidia_smi_snapshot_v1, orion_cognition_verbs_skills_storage_disk_health_snapshot_v1_skills_storage_disk_health_snapshot_v1, orion_cognition_verbs_skills_biometrics_raw_recent_v1_skills_biometrics_raw_recent_v1, orion_cognition_verbs_skills_biometrics_snapshot_v1_skills_biometrics_snapshot_v1, orion_cognition_verbs_skills_landing_pad_last_events_v1_skills_landing_pad_last_events_v1, orion_cognition_verbs_skills_landing_pad_metrics_snapshot_v1_skills_landing_pad_metrics_snapshot_v1, orion_cognition_verbs_skills_system_time_now_v1_skills_system_time_now_v1 [EXTRACTED 1.00]
+- **Substrate Probe Verb Family (substrate.inspect/observe/summarize)** — orion_cognition_verbs_substrate_inspect_substrate_inspect, orion_cognition_verbs_substrate_observe_substrate_observe, orion_cognition_verbs_substrate_summarize_substrate_summarize [EXTRACTED 1.00]
+- **Chat Belief Profile Family (Contradiction, Open Loop, Procedural, Relational, Semantic)** — orion_recall_profiles_chat_belief_contradiction_v1_profile, orion_recall_profiles_chat_belief_open_loop_v1_profile, orion_recall_profiles_chat_belief_procedural_v1_profile, orion_recall_profiles_chat_belief_relational_v1_profile, orion_recall_profiles_chat_belief_semantic_v1_profile [INFERRED 0.95]
+- **Generative Writing Verbs Family (Guide, Recommendation, Runbook, Tutorial)** — orion_cognition_verbs_write_guide_write_guide, orion_cognition_verbs_write_recommendation_write_recommendation, orion_cognition_verbs_write_runbook_write_runbook, orion_cognition_verbs_write_tutorial_write_tutorial [INFERRED 0.95]
+- **Lightweight Non-Vector Chat Recall Profiles** — orion_recall_profiles_chat_general_v1_profile, orion_recall_profiles_chat_continuity_v1_profile, orion_recall_profiles_chat_story_kids_v1_profile, orion_recall_profiles_assist_light_v1_profile [INFERRED 0.75]
+- **Journal *.grounded.v1 recall profile family** — orion_recall_profiles_journal_daily_grounded_v1_profile, orion_recall_profiles_journal_daily_metacog_grounded_v1_profile, orion_recall_profiles_journal_notify_grounded_v1_profile, orion_recall_profiles_journal_world_pulse_grounded_v1_profile [EXTRACTED 1.00]
+- **reflect.* recall profile family** — orion_recall_profiles_reflect_v1_profile, orion_recall_profiles_reflect_alerts_v1_profile, orion_recall_profiles_reflect_anchor_v1_profile, orion_recall_profiles_reflect_sql_only_v1_profile [INFERRED 0.85]
+- **graph.compressions.* recall profile family (global/local/unified)** — orion_recall_profiles_graph_compressions_global_v1_profile, orion_recall_profiles_graph_compressions_local_v1_profile, orion_recall_profiles_graph_compressions_v1_profile [INFERRED 0.85]
+- **Spark ConceptProfile Graph-Backend Rollout (Phase 0-4)** — orion_spark_concept_induction_profile_repository_seam, orion_spark_concept_induction_phase2_concept_profile_graph_read_model, orion_spark_concept_induction_phase3a_shadow_rollout_note, orion_spark_concept_induction_phase3b_parity_evidence_readiness, orion_spark_concept_induction_phase4_concept_profile_cutover_note [EXTRACTED 1.00]
+- **Brainstorming Session #1 Appendix Ideas 3-10 (self-state/autonomy substrate proposals)** — reviews_pending_2026_06_20_brainstorming_session_1_appendix_idea3_action_outcome_feedback_loop, reviews_pending_2026_06_20_brainstorming_session_1_appendix_idea4_drive_pressures_bridge_self_state, reviews_pending_2026_06_20_brainstorming_session_1_appendix_idea5_substrate_surprise_signal, reviews_pending_2026_06_20_brainstorming_session_1_appendix_idea6_rolling_self_state_archive, reviews_pending_2026_06_20_brainstorming_session_1_appendix_idea7_drive_audit_loop, reviews_pending_2026_06_20_brainstorming_session_1_appendix_idea8_identity_snapshot, reviews_pending_2026_06_20_brainstorming_session_1_appendix_idea9_cross_reducer_coherence_checker, reviews_pending_2026_06_20_brainstorming_session_1_appendix_idea10_predictive_substrate [EXTRACTED 1.00]
+- **Evidence-gated cutover/build readiness pattern (measure before cathedral)** — scripts_analysis_readme, orion_spark_concept_induction_phase3b_parity_evidence_readiness, orion_spark_concept_induction_phase4_concept_profile_cutover_note [INFERRED 0.75]
+- **Bus observability/wiretap tooling group (bus, mirror, tap)** — services_orion_bus_readme_orion_bus, services_orion_bus_mirror_readme_orion_bus_mirror, services_orion_bus_tap_readme_orion_bus_tap [INFERRED 0.85]
+- **orion-bus core Redis stack (bus-core, bus-exporter, bus-observer)** — services_orion_bus_docker_compose_bus_core, services_orion_bus_docker_compose_bus_exporter, services_orion_bus_docker_compose_bus_observer [EXTRACTED 1.00]
+- **Field attention production pipeline (digester -> field state -> attention frames)** — services_orion_attention_runtime_readme_orion_attention_runtime, services_orion_attention_runtime_readme_fieldstatev1, services_orion_attention_runtime_readme_fieldattentionframev1, services_orion_attention_runtime_readme_orion_field_digester [EXTRACTED 1.00]
+- **Cortex Request Routing Chain (Gateway to Context-Exec)** — services_orion_cortex_gateway_readme_service, services_orion_cortex_orch_readme_service, services_orion_cortex_exec_readme_service, services_orion_context_exec_readme_service [EXTRACTED 1.00]
+- **Concept Profile Repository Seam Family** — services_orion_cortex_orch_concept_profile_config_adapter_note_rationale, orion_concept_profile_repository_concept, services_orion_cortex_orch_docker_compose_service, services_orion_cortex_exec_docker_compose_service [INFERRED 0.85]
+- **Substrate Layer Aggregation Family (Consolidation, Exec, Orch)** — services_orion_consolidation_runtime_readme_service, services_orion_cortex_exec_readme_service, services_orion_cortex_orch_readme_service [INFERRED 0.65]
+- **Substrate Execution, Feedback, and Field-State Pipeline** — services_orion_execution_dispatch_runtime_readme_orion_execution_dispatch_runtime_service, services_orion_feedback_runtime_readme_orion_feedback_runtime_service, services_orion_field_digester_readme_orion_field_digester_service [INFERRED 0.75]
+- **Bridge/Façade Services Connecting Cognition to External Mediums** — services_orion_dream_readme_orion_dream_service, services_orion_embodiment_readme_orion_embodiment_service, services_orion_fcc_readme_orion_fcc_service [INFERRED 0.65]
+- **Health and System-State Monitoring Services** — services_orion_equilibrium_service_readme_orion_equilibrium_service, services_orion_field_digester_readme_orion_field_digester_service, services_orion_feedback_runtime_readme_orion_feedback_runtime_service [INFERRED 0.65]
+- **Hub debug/observability UI panel family** — services_orion_hub_templates_index_dashboard, services_orion_hub_static_pressure_analytics_panel, services_orion_hub_static_substrate_lattice_panel, services_orion_hub_static_self_brain_panel [INFERRED 0.85]
+- **Graph/knowledge projection service family (compression + temporal graph)** — services_orion_graph_compression_readme_service, services_orion_graphiti_adapter_readme_service, services_orion_graphiti_adapter_docker_compose_falkordb [INFERRED 0.75]
+- **Harness governor semantic self-indexing stack (GitNexus + Context Mode)** — services_orion_harness_governor_readme_service, services_orion_harness_governor_readme_gitnexus, services_orion_harness_governor_readme_context_mode [EXTRACTED 1.00]
+- **GPU LLM hosting service family (llama-cola, llamacpp, llamacpp-neural)** — services_orion_llama_cola_host_docker_compose_service, services_orion_llamacpp_host_docker_compose_service, services_orion_llamacpp_neural_host_docker_compose_service [INFERRED 0.85]
+- **Orion debug/inspector UI surfaces (substrate, substrate atlas, landing pad explorer)** — services_orion_hub_templates_substrate_ui, services_orion_hub_templates_substrate_atlas_ui, services_orion_landing_pad_app_static_landing_pad_index_ui [INFERRED 0.75]
+- **Atlas LLM serving pipeline (llamacpp Atlas workers -> gateway route table -> profile registry)** — services_orion_llamacpp_host_docker_compose_atlas_workers_service, services_orion_llm_gateway_readme_service, config_llm_profiles_yaml_registry [EXTRACTED 1.00]
+- **Services wired to the shared LLMGatewayService intake channel** — services_orion_llm_gateway_tests_llm_gateway_smoketests, services_orion_memory_consolidation_docker_compose, services_orion_mind_docker_compose [EXTRACTED 1.00]
+- **Notify-centered attention/escalation ecosystem** — services_orion_notify_readme, services_orion_notify_digest_readme, services_orion_mesh_guardian_readme [EXTRACTED 1.00]
+- **Governed memory crystallization pipeline (consolidation gate -> crystallizer worker -> MemoryCrystallizationV1)** — services_orion_memory_consolidation_readme, services_orion_memory_crystallizer_readme, schema_memory_crystallization_v1 [EXTRACTED 1.00]
+- **Substrate Proposal -> Policy Decision Pipeline (Layer 7 -> Layer 8)** — services_orion_proposal_runtime_readme_service, services_orion_policy_runtime_readme_service, services_orion_proposal_runtime_readme_substrate_proposal_frames [EXTRACTED 1.00]
+- **RDF Triple Write and Storage Subsystem (Writer + Fuseki Store)** — services_orion_rdf_writer_readme_service, services_orion_rdf_store_readme_service, services_orion_rdf_store_docker_compose_service_config [EXTRACTED 1.00]
+- **Notification Policy and Digest Family** — services_orion_notify_app_policy_rules_orion_notify_service, services_orion_notify_app_policy_rules_notification_rules, services_orion_notify_digest_requirements_dependencies [INFERRED 0.75]
+- **orion-signal-gateway OTel observability stack (collector + Tempo + Grafana)** — services_orion_signal_gateway_otel_collector_config_config, services_orion_signal_gateway_otel_grafana_datasources_config, services_orion_signal_gateway_otel_tempo_config [EXTRACTED 1.00]
+- **Spark / Self-State Cognition Pipeline** — services_orion_spark_concept_induction_service, services_orion_spark_introspector_service, services_orion_state_service_service, services_orion_state_journaler_service [INFERRED 0.85]
+- **Social Room Continuity Substrate** — services_orion_social_memory_service, services_orion_social_room_bridge_service, services_orion_social_memory_readme_chat_social_stored_channel [EXTRACTED 1.00]
+- **Orion SQL Persistence Family** — services_orion_sql_db_service, services_orion_sql_writer_service, services_orion_state_journaler_service [INFERRED 0.85]
+- **Substrate service family (organs contract layer, runtime reducer worker, telemetry)** — services_orion_substrate_organs_readme_service, services_orion_substrate_runtime_readme_service, services_orion_substrate_telemetry_docker_compose_service [INFERRED 0.65]
+- **Vector pipeline family (vector-host embeds, vector-writer persists, vector-db stores)** — services_orion_vector_host_readme_service, services_orion_vector_writer_readme_service, services_orion_vector_db_readme_service [INFERRED 0.85]
+- **Host Vision Pipeline (Retina -> Router -> Host -> Window -> Council -> Scribe)** — services_orion_vision_retina_readme_service, services_orion_vision_frame_router_readme_service, services_orion_vision_host_readme_service, services_orion_vision_window_readme_service, services_orion_vision_council_readme_service, services_orion_vision_scribe_readme_service [EXTRACTED 1.00]
+- **orion-vision-edge Service Bundle (README, compose, deps, debug UI)** — services_orion_vision_edge_readme_service, services_orion_vision_edge_docker_compose_service, services_orion_vision_edge_requirements_deps, services_orion_vision_edge_app_static_index_ui [INFERRED 0.75]
+- **Vision Event Persistence Pipeline (Council -> Scribe -> Vector Writer)** — services_orion_vision_council_readme_service, services_orion_vision_scribe_readme_service, services_orion_vector_writer_requirements_service [EXTRACTED 1.00]
+- **Knowledge Forge claim-source-spec provenance chain** — tests_fixtures_knowledge_forge_claims_accepted_claim_test_0001_claim, tests_fixtures_knowledge_forge_raw_sources_source_test_fixture_source, tests_fixtures_knowledge_forge_specs_execution_ready_spec_test_compile_spec [EXTRACTED 1.00]
+- **Knowledge Forge dangling-reference test family** — tests_fixtures_knowledge_forge_claims_disputed_claim_test_bad_ref_claim, tests_fixtures_knowledge_forge_claims_disputed_claim_test_bad_ref_missing_claim, tests_fixtures_knowledge_forge_claims_disputed_claim_test_bad_ref_missing_source [INFERRED 0.65]
+- **orion-whisper-tts service definition family (README + compose + requirements)** — services_orion_whisper_tts_readme_doc, services_orion_whisper_tts_docker_compose_whisper_tts, services_orion_whisper_tts_requirements_dependencies [EXTRACTED 1.00]
+
+## Communities (1419 total, 324 thin omitted)
+
+### Community 0 - "Core Bus Schemas (Envelope/ServiceRef family)"
+Cohesion: 0.02
+Nodes (251): build_projection_unification_registry(), Construct the shared producer registry for cognitive projection reads., test_projection_registry_matches_expected_chat_stance_producers(), test_unified_beliefs_for_chat_stance_uses_shared_context_path(), _concept(), ConceptNodeV1, ContradictionNodeV1, DriveNodeV1 (+243 more)
+
+### Community 1 - "Async Bus Service Client"
+Cohesion: 0.04
+Nodes (229): MutationTrialStatusV1, GoalActionError, GoalActionResult, Exception, CognitiveDraftRecommendationV1, CognitiveProposalDraftV1, CognitiveProposalReviewV1, CognitiveStanceNoteV1 (+221 more)
+
+### Community 2 - "Frontier Curiosity Target Zone Schemas"
+Cohesion: 0.02
+Nodes (318): ChatRole, ge, GoalActionKind, le, build_goal_graph_query_client(), complete_goal(), dismiss_goal(), execute_goal_action() (+310 more)
+
+### Community 3 - "Consolidation Windows"
+Cohesion: 0.01
+Nodes (205): HttpClient, ScenarioRunResult, OrionBusAsync, Any, Redis, Async Redis bus client., Unified async message iterator. Yields dicts with fields similar to redis-py's l, Publish `envelope` to request_channel and await first message on reply_channel. (+197 more)
+
+### Community 4 - "Attention Schema & Self-State"
+Cohesion: 0.02
+Nodes (252): log_mind_projection_prebuild_ctx_summary(), Recall bundle prefetch for Mind preflight (Orch, before Exec)., Structured pre-build ctx summary (after recall prefetch, before projection)., _BusStub, test_process_recall_includes_sql(), test_recall_handler_returns_bundle(), CollapseMirrorPayload, datetime (+244 more)
+
+### Community 5 - "Memory Turn-Change Signal"
+Cohesion: 0.01
+Nodes (210): BBox, BaseModel, VisionArtifactOutputs, VisionArtifactPayload, VisionCaption, VisionCouncilRequestPayload, VisionCouncilResultPayload, VisionEdgeActivityPayload (+202 more)
+
+### Community 6 - "Endogenous Goal Origination"
+Cohesion: 0.02
+Nodes (229): bootstrap_answer_contract_on_request(), enrich_answer_contract_after_routing(), merge_draft(), _norm_user_text(), output_modes_for_answer_contract_style(), Normalize hub `answer_contract_draft` + heuristics into a bus-safe AnswerContrac, Phase 1: attach normalized AnswerContract from heuristic + hub draft (pre-router, Weaken classifier: fold output_mode_decision into contract hints without removin (+221 more)
+
+### Community 7 - "Concept Profile Backend"
+Cohesion: 0.02
+Nodes (175): DecodeResult, OrionCodec, Any, BaseModel, Bulletproof encode/decode layer.      Goals:     - Never leak raw JSON dicts int, _attempt_from_envelope(), _consumer_suffix(), _expires_at() (+167 more)
+
+### Community 8 - "Bus Chat Result Payload Schemas"
+Cohesion: 0.03
+Nodes (195): InputT, ChatRequestPayload, ChatResultPayload, LLMMessage, BaseModel, Request payload for LLM chat., Standard response from LLM Gateway.     Strictly normalizes 'text' (Gateway) vs, RecallQueryV1 (+187 more)
+
+### Community 9 - "Bus Chat/Input Payload Schemas"
+Cohesion: 0.03
+Nodes (112): BaseSubstrateNodeV1, SubstrateEdgeV1, Any, Session, Minimal SPARQL Protocol HTTP clients (Fuseki + generic SPARQL endpoints)., Host + path + query + fragment only (strips userinfo from URL)., Resolve Basic Auth for substrate SPARQL HTTP (query + update).      Precedence (, SPARQL 1.1 Protocol over HTTP: separate query and update endpoints, optional Bas (+104 more)
+
+### Community 10 - "Social Artifact Schemas"
+Cohesion: 0.03
+Nodes (203): ContextExecCreatableReviewState, assert_context_exec_proposal_safe(), build_memory_correction_proposal_envelope(), build_patch_proposal_envelope(), MemoryCorrectionProposalV1, PatchProposalV1, ProposalEnvelopeV1, Shared review wrapper for context-exec proposal artifacts. (+195 more)
+
+### Community 11 - "Cognition Plan Loader"
+Cohesion: 0.02
+Nodes (137): dispatch_autonomy_episode_journal(), _new_reply_channel(), Any, Compose autonomy episode journal via cortex RPC and publish journal write., test_dispatch_autonomy_episode_journal_publishes_write(), BaseEnvelope, Titanium, universal, versioned envelope.      - Strict (extra fields forbidden), OrionRouter (+129 more)
+
+### Community 12 - "Harness Cortex Client"
+Cohesion: 0.04
+Nodes (113): AutonomyAdapter, _extract_state(), _extract_summary_dict(), _pressure_dimensions(), Any, Autonomy summary/state → autonomy_state OrionSignalV1 (Milestone B4)., OrionSignalAdapter, ABC (+105 more)
+
+### Community 13 - "Substrate Mutation Trial Schemas"
+Cohesion: 0.06
+Nodes (165): BaseModel, SocialArtifactConfirmationV1, SocialArtifactProposalV1, SocialArtifactRevisionV1, BaseModel, SocialCalibrationSignalV1, SocialPeerCalibrationV1, SocialTrustBoundaryV1 (+157 more)
+
+### Community 14 - "Bus Queue Service Chassis"
+Cohesion: 0.02
+Nodes (124): FileResponse, ErrorInfo, BaseChassis, ChassisConfig, Clock, BaseException, Handler, Restart subscriber loops if they exit without an explicit stop signal. (+116 more)
+
+### Community 15 - "PAD Affect Schemas"
+Cohesion: 0.03
+Nodes (113): BeliefProvenanceReportV1, ContextExecBudgetV1, ContextExecRequestV1, BaseModel, Bounded RLM context-exec investigation schemas., RepoImpactAnalysisReportV1, TraceAutopsyReportV1, Schema validation for context-exec llm_profile. (+105 more)
+
+### Community 16 - "Context-Exec Request Schemas"
+Cohesion: 0.05
+Nodes (147): CortexClientFn, Layer attribution evals (spec §11.2) — structural replay with mocked inputs., High surprise appraisal blocks quick lane; low surprise allows deterministic 5b., Misaligned reflection must change voice finalize output vs aligned., test_5a_affects_5b_verdict(), test_5b_affects_5c_text(), A 'How are you?' unified turn carries Orion self-context into both passes., test_how_are_you_turn_is_grounded_end_to_end() (+139 more)
+
+### Community 17 - "Autonomy Subject Fanout"
+Cohesion: 0.03
+Nodes (143): BroadcastReader, Dependency-free stable identifiers (hashlib only).  Use from thin services (orio, Return ``{prefix}_{sha256(preimage)[:24]}`` from ordered semantic parts., stable_hash_id(), Eval: reverie semantic lift quality bar — referent, voice, grounding., test_bad_meta_fixture_fails_infra_vocab(), test_good_fixture_passes_semantic_gates(), _database_url() (+135 more)
+
+### Community 18 - "Chat Role Schemas"
+Cohesion: 0.04
+Nodes (117): build_consolidation_frame(), datetime, _attention_target_pressure(), _detect_attention_saturated_execution(), _detect_blocked_review_loop(), _detect_dry_run_feedback_loop(), _detect_loaded_but_reliable(), _detect_read_only_policy_loop() (+109 more)
+
+### Community 19 - "Graph SPARQL Client"
+Cohesion: 0.03
+Nodes (127): new_goal_task_id(), build_verb_list(), _discover_verbs(), is_active(), list_all_verbs(), _load_manifest(), Any, AutonomyGoalPlannedV1 (+119 more)
+
+### Community 20 - "Language/Grammar Schemas"
+Cohesion: 0.04
+Nodes (123): AcceptedPublisher, AvailabilityStatus, EmissionSaver, NodeBioLoader, NodeBioSaver, NodeCatalog, NodeProfile, Any (+115 more)
+
+### Community 21 - "Autonomy Capability Policy"
+Cohesion: 0.03
+Nodes (51): publish_with_reconnect(), Any, Publish once; on transport failure reconnect the command client and retry., _FlakyBus, MonkeyPatch, orion.core.bus.resilience must not crash-on-import when loguru is missing., test_publish_with_reconnect_retries_after_transport_error(), test_resilience_importable_without_loguru() (+43 more)
+
+### Community 22 - "Biometrics Publisher/Loader"
+Cohesion: 0.06
+Nodes (100): FrontierInvocationDecisionV1, FrontierInvocationPlanV1, FrontierInvocationRunResultV1, FrontierInvocationSignalV1, BaseModel, Curiosity/gap-driven frontier invocation contracts (Phase 8)., GraphConsolidationRequestV1, build_metacog_perception_brief() (+92 more)
+
+### Community 23 - "Autonomy Goal-Action Errors"
+Cohesion: 0.04
+Nodes (86): VisionFramePointerPayload, VisionTaskRequestPayload, VisionTaskResultPayload, test_llm_chat_route_forwards_messages_and_stop(), FrameDispatcher, Settings, extract_host_trigger_labels(), stream_id_from_host_result() (+78 more)
+
+### Community 24 - "Daily Metacog Prompt Tests"
+Cohesion: 0.03
+Nodes (129): AttentionTargetSummaryV1, BaseModel, Structured per-target attention data (2026-07-12, inner-state     unification Ph, SelfStateDimensionV1, BaseModel, Spark telemetry row that maps to spark_telemetry table.      Note: The durable t, SparkTelemetryPayload, ndarray (+121 more)
+
+### Community 25 - "Notify Client"
+Cohesion: 0.05
+Nodes (132): BaseModel, SelfConceptEvidenceRefV1, SelfConceptInduceResultV1, SelfConceptReflectResultV1, SelfConceptRefV1, SelfInducedConceptV1, SelfKnowledgeItemV1, SelfKnowledgeSectionCountsV1 (+124 more)
+
+### Community 26 - "Grounding/Investigation Findings"
+Cohesion: 0.06
+Nodes (77): GraphConsolidationDecisionV1, GraphConsolidationResultV1, GraphReviewCycleRecordV1, GraphStateDeltaDigestV1, BaseModel, Bounded reflective graph consolidation contracts (Phase 9)., GraphReviewCycleBudgetV1, GraphReviewCyclePolicyV1 (+69 more)
+
+### Community 27 - "Journaler Write Schemas"
+Cohesion: 0.04
+Nodes (88): JournalMode, JournalDispatchPolicy, Declarative journal notification dispatch policy, keyed off `trigger_kind`.  Con, Fail-closed lookup: an unregistered trigger_kind sends nothing., resolve_policy(), _as_optional_str(), build_journal_entry_index_payload(), _list_of_str() (+80 more)
+
+### Community 28 - "Autonomy Origination Eval"
+Cohesion: 0.02
+Nodes (92): API_BASE_URL, appendExecutionStepsPanel(), appendSocialInspectionStateList(), applyMindPrefsToControls(), applyPreferenceRows(), audioContext, audioQueue, autonomyAvailabilityRowsForDisplay() (+84 more)
+
+### Community 29 - "Cognition Projection Concept Tests"
+Cohesion: 0.04
+Nodes (103): __getattr__(), HubAssociationBundleV1, BaseModel, StanceHarnessSliceV1, StanceReactRequestV1, align_evidence_refs_to_coalition(), coalition_ids_from_association(), attended_node_ids + open_loop ids + always the current Hub turn anchor. (+95 more)
+
+### Community 30 - "Reverie Broadcast Reader"
+Cohesion: 0.03
+Nodes (69): execution_prediction_error(), _mean(), 0-1 surprise score: how much did execution pressure hints change this batch?, 0-1 surprise score: how much did transport bus health change this batch?, transport_prediction_error(), ReducerHealthClass, clear_health_for_tests(), _get() (+61 more)
+
+### Community 31 - "Cognition Reflect/Recall Integration Tests"
+Cohesion: 0.04
+Nodes (95): deque, emit_contradiction(), emit_pressure(), Any, Thin substrate-emit helpers for the autonomy/pressure organ.  These do not modif, A pressure molecule is a constraint+gradient pair.      ``magnitude`` is folded, Emit a contradiction molecule that points at two other molecule ids., MonkeyPatch (+87 more)
+
+### Community 32 - "Autonomy Deviation Gate"
+Cohesion: 0.03
+Nodes (84): _rpc_request(), _service_ref(), build_turn_change_appraisal(), MemoryTurnPersistedV1, should_close_window(), _build_window_transcript(), _classify_scores(), classify_turn() (+76 more)
+
+### Community 33 - "Vision Frame Pointer Schemas"
+Cohesion: 0.03
+Nodes (97): build_compact_skill_catalog(), _default_verbs_dir(), _family_for_skill(), load_skill_manifest(), BaseModel, Path, _risk_for_skill(), SkillManifestEntry (+89 more)
+
+### Community 34 - "Agent Council Bound-Capability Schemas"
+Cohesion: 0.04
+Nodes (93): Contract smoke tests for dream modernization schemas., test_dream_internal_trigger_v1(), test_dream_result_v1_defaults_and_audit(), test_dream_trigger_payload_minimal(), Canonical recall boundary. The only acceptable request field for text is `query_, Normalized recall response. Exec exposes debug counts, not raw fragments, by def, RecallRequestPayload, RecallResultPayload (+85 more)
+
+### Community 35 - "Attention Frame Schemas"
+Cohesion: 0.04
+Nodes (95): GraphStoreClient, SparqlUpdateClient, approve_memory_graph_draft(), ApproveOutcome, preview_validate_only(), Any, Pool, Session (+87 more)
+
+### Community 36 - "Substrate Experiment Gradient Observer"
+Cohesion: 0.04
+Nodes (78): GradientObserver, compute_daily_rollup(), _contradiction_clusters(), _gradient_stats(), _health_score(), date, Path, Per-day rollup computation + JSON persistence. (+70 more)
+
+### Community 37 - "Cognition Verb Activation"
+Cohesion: 0.05
+Nodes (87): _LLMCaller, build_orion_turn_request(), Any, Thin Orion-mode turn dict — not the Brain chat request builder., PreTurnAppraisalRequestV1, BaseModel, TurnAppraisalBundleV1, TurnAppraisalParadigmSliceV1 (+79 more)
+
+### Community 38 - "Telemetry Field-Channel Corpus"
+Cohesion: 0.05
+Nodes (76): AnchorScope, ArtifactType, apply_operator_goal_reasoning_promotion(), _goal_to_reasoning_claim(), ClaimV1, datetime, ConceptProfileDelta, Delta between two concept profile revisions. (+68 more)
+
+### Community 39 - "Hub Static JS Frontend App"
+Cohesion: 0.04
+Nodes (67): AutonomyLookupV1, AutonomyRepository, AutonomyRepositoryStatus, _bounded_reason(), _classify_query_error(), _dominant_drive_from_evidence(), _drives_facet_ok(), _drives_facet_status() (+59 more)
+
+### Community 40 - "Story/Narrative Weave"
+Cohesion: 0.05
+Nodes (81): callable, build_answer_contract_draft_for_hub(), Light hub-side draft (metadata only)., ExternalRoomMessageV1, ExternalRoomParticipantV1, ExternalRoomPostRequestV1, ExternalRoomPostResultV1, ExternalRoomTurnSkippedV1 (+73 more)
+
+### Community 41 - "Bus Schema Rationale Notes"
+Cohesion: 0.04
+Nodes (99): ContextRisk, auto_approve_from_env(), claude_permission_argv(), extend_mcp_argv(), mcp_allowed_tool_patterns(), mcp_disallowed_tool_patterns(), Any, Path (+91 more)
+
+### Community 42 - "Cognition Recall Query"
+Cohesion: 0.05
+Nodes (68): _build_ollama_payload(), _common_http_client(), _debug_len(), _debug_snippet(), _debug_think_capture(), _execute_llamacpp_native_completion(), _execute_ollama_chat(), _execute_openai_chat() (+60 more)
+
+### Community 43 - "Consolidation Builder"
+Cohesion: 0.05
+Nodes (83): AutonomyStanceMode, AutonomyStateQuality, AttentionItemV1, AutonomyActiveGoalV1, AutonomyGoalHeadlineV1, AutonomyStateV1, AutonomyStateV2, AutonomySummaryV1 (+75 more)
+
+### Community 44 - "Field Coherence"
+Cohesion: 0.04
+Nodes (87): _embed_bus(), ChatHistoryMessageEnvelope, ChatHistoryMessageV1, ChatHistoryTurnEnvelope, ChatHistoryTurnV1, Any, BaseModel, UUID (+79 more)
+
+### Community 45 - "Context-Exec V2 Readiness Hardening Tests"
+Cohesion: 0.06
+Nodes (33): BaseSettings, Language, ConceptEvidenceRef, make_concept_id(), Deterministic-ish concept id helper.      Uses a simple stable hash of the norma, Lineage reference for evidence used in concept formation., ClusterResult, ConceptClusterer (+25 more)
+
+### Community 46 - "Bus Schema Rationale Notes (2)"
+Cohesion: 0.05
+Nodes (74): build_active_packet(), _entry(), Any, datetime, _task_boost(), attach_grammar_to_crystallization(), envelope_from_grammar_event(), Any (+66 more)
+
+### Community 47 - "LLM/OpenAI Message Content"
+Cohesion: 0.05
+Nodes (78): _tool_stats(), ContextExecOperatorSummaryV1, ContextExecRunV1, ContextExecSafetySummaryV1, Operator-facing summary for Hub Agent mode responses., AgentTraceStepV1, AgentTraceToolStatV1, AgentSynthesisResult (+70 more)
+
+### Community 48 - "Repair Evidence Schemas"
+Cohesion: 0.06
+Nodes (95): InvestigationV2AnswerStatus, BusConsumerReadinessResult, BaseModel, EvidenceBundle, InvestigationReportV2, InvestigationSectionV2, Enum, str (+87 more)
+
+### Community 49 - "Bus Base Envelope"
+Cohesion: 0.03
+Nodes (40): _count(), main(), ExecutionDispatchRuntimeStore, FieldDigesterStore, CompressionStore, Any, datetime, _make_store() (+32 more)
+
+### Community 50 - "Grammar Ledger (Atom/Event Storage)"
+Cohesion: 0.05
+Nodes (78): AttentionTargetSummaryV1, FieldAttentionFrameV1, FieldStateV1, _build_candidate(), build_proposal_frame(), _policy_required(), datetime, SelfStateV1 (+70 more)
+
+### Community 51 - "Proposal Ledger"
+Cohesion: 0.05
+Nodes (76): assert_chat_compactor_digest_within_budget(), build_quiet_day_chat_digest(), parse_chat_history_compactor_digest_json(), Any, stable_chat_compactor_journal_entry_id(), trim_chat_history_compactor_input(), test_assert_chat_compactor_digest_within_budget(), test_build_quiet_day_chat_digest() (+68 more)
+
+### Community 52 - "Concept Induction Core Schemas"
+Cohesion: 0.04
+Nodes (71): CausalityLink, Envelope, Any, Create a child envelope that extends the causality chain with this message as a, Typed envelope: payload is a Pydantic model.      This is the preferred new path, Vacuum Validator:         1. Ensures 'content' is populated from 'text'., A single step in a causality chain. Used for Conjourney lineage., Rabbit (+63 more)
+
+### Community 53 - "Image Assets"
+Cohesion: 0.04
+Nodes (89): Call, heuristic_answer_contract(), investigation_state_for_contract(), Any, test_heuristic_runtime_debug(), context_exec_permissions_for_llm_profile(), Map Hub compute lane / LLM profile to a context-exec permission envelope., _call_name() (+81 more)
+
+### Community 54 - "Social Autonomy Schemas"
+Cohesion: 0.06
+Nodes (66): derive_workflow_execution_policy(), _has_explicit_schedule_intent(), _hour_from_token(), next_run_for_recurring_schedule(), _next_weekday_run(), _normalize_prompt(), _one_shot_tonight(), _parse_notify_on() (+58 more)
+
+### Community 55 - "Telemetry Spark Signal"
+Cohesion: 0.06
+Nodes (49): FrontierTargetZoneV1, BaseModel, Operator-controlled substrate policy profile adoption contracts (Phase 17)., SubstratePolicyAdoptionRequestV1, SubstratePolicyAdoptionResultV1, SubstratePolicyAuditEventV1, SubstratePolicyComparisonV1, SubstratePolicyInspectionV1 (+41 more)
+
+### Community 56 - "Autonomy Repository"
+Cohesion: 0.05
+Nodes (79): apply_grammar_event(), apply_grammar_trace_batch(), _atom_row(), _bulk_insert_derived(), _bulk_insert_events(), _compaction_row(), _created_at(), _edge_row() (+71 more)
+
+### Community 57 - "Cognition Hub-Gateway Bus Harness"
+Cohesion: 0.05
+Nodes (70): build_turn_change_signal(), ConceptAtomV1, BaseModel, Atoms — reusable semantic invariants.  An atom is *not* a domain noun (memory, d, A reusable semantic invariant.      `key` is the unique handle (e.g. "signal.val, CompositeV1, BaseModel, Composite — a small bundle of atoms + relations.  This is the *kernel-level* com (+62 more)
+
+### Community 58 - "Bus Span Exporter (Tracing)"
+Cohesion: 0.06
+Nodes (90): format_recent_turn_effect_alerts(), _alert_tags_from_recent_alerts(), _append_memory_digest(), _apply_draft_patch(), _apply_enrich_patch(), _apply_metacog_system_fields(), _build_hop_messages(), call_step_services() (+82 more)
+
+### Community 59 - "LLM Gateway Backend"
+Cohesion: 0.07
+Nodes (77): ExecutionProjectionLoader, ExecutionProjectionSaver, ExecutionRunStateV1, ExecutionTrajectoryProjectionV1, BaseModel, GrammarProvenanceV1, _boolish(), compute_pressure_hints() (+69 more)
+
+### Community 60 - "Community 60"
+Cohesion: 0.04
+Nodes (90): Channel "orion:chat:gpt:conversation" (kind=event, schema=ChatGptConversationV1) producers=[chatgpt-import] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:example" (kind=event, schema=ChatGptDerivedExampleV1) producers=[chatgpt-import] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:import:run" (kind=event, schema=ChatGptImportRunV1) producers=[chatgpt-import] consumers=[orion-sql-writer], Channel "orion:chat:gpt:log" (kind=event, schema=ChatGptMessageV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:message:log" (kind=event, schema=ChatGptMessageV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:turn" (kind=event, schema=ChatGptLogTurnV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:history:log" (kind=event, schema=ChatHistoryMessageV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-writer, orion-vector-host, orion-spark-concept-induction], Channel "orion:chat:history:turn" (kind=event, schema=ChatHistoryTurnV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-writer, orion-vector-host, orion-spark-concept-induction] (+82 more)
+
+### Community 61 - "Community 61"
+Cohesion: 0.05
+Nodes (85): _forward_llm_uncertainty_metadata(), prepare_chat_quick_reply_context(), Copy gateway meta.llm_uncertainty into execution ctx metadata for Hub spark_meta, Hub quick lane: identity YAML only — no stance/autonomy graph (must stay fast; G, short_error_kind(), extract_reasoning_features(), Any, has_inline_recall() (+77 more)
+
+### Community 62 - "Community 62"
+Cohesion: 0.06
+Nodes (75): InsertOutcome, BaseModel, Typed self-experiment registry schemas., Accept legacy skill_id payloads or typed experiment fields., SelfExperimentCreateRequestV1, SelfExperimentCreateResponseV1, SelfExperimentDispatchRequestV1, SelfExperimentDispatchResponseV1 (+67 more)
+
+### Community 63 - "Community 63"
+Cohesion: 0.07
+Nodes (73): DecisionLiteral, CortexRouteTemplateV1, build_policy_decision_frame(), build_unevaluable_policy_decision_frame(), datetime, A proposal whose source self-state could not be loaded (missing, or a     row sa, stable_policy_frame_id(), evaluate_proposal_candidate() (+65 more)
+
+### Community 64 - "Community 64"
+Cohesion: 0.04
+Nodes (52): InMemorySpanExporter, normalize_adapter_result(), AdapterResult, test_normalize_list(), test_normalize_single_signal(), OrganClass, Enum, str (+44 more)
+
+### Community 65 - "Community 65"
+Cohesion: 0.06
+Nodes (50): fetch_similar_candidates(), Pool, Vector-similarity candidate retrieval across ALL active crystallizations, not sc, approve(), can_activate(), GovernorError, datetime, ValueError (+42 more)
+
+### Community 66 - "Community 66"
+Cohesion: 0.07
+Nodes (74): _perception_in_convo(), Observability seam: a healthy loop (all other logs exception-only) must still, The 'void' regression, corrected: the worker must NOT send `finishSendingMessage, test_empty_reply_is_not_injected(), test_heartbeat_logs_once_then_throttles(), test_injectable_reply_is_injected(), test_no_speech_until_participating(), test_no_speech_when_orion_spoke_last() (+66 more)
+
+### Community 67 - "Community 67"
+Cohesion: 0.06
+Nodes (76): GrammarWorkItem, list_attention(), list_chat_messages(), mark_attention_escalated(), get_session(), remove_session(), cancel_active_grammar_persist(), Cancel the in-flight Postgres query for the active grammar persist on a shard. (+68 more)
+
+### Community 68 - "Community 68"
+Cohesion: 0.06
+Nodes (73): _aggregate_outcome_status(), build_feedback_frame(), _candidate_outcome_kind(), _cortex_status_to_outcome(), _observation(), _policy_decision_outcome(), datetime, _score_for_outcome_kind() (+65 more)
+
+### Community 69 - "Community 69"
+Cohesion: 0.06
+Nodes (75): BaseModel, datetime, Repair pressure evidence schema (bus/registry layer).  Lives under orion.schemas, RepairEvidenceV1, _utcnow(), apply_repair_pressure_contract(), assemble_repair_contract_delta(), _evidence_kinds_from_dimensions() (+67 more)
+
+### Community 70 - "Community 70"
+Cohesion: 0.04
+Nodes (71): Depends, require_operator_token, require_quarantine_operator_token, clear_tail_seeds_for_tests(), has_cold_start_tail_seed(), has_recent_tail_seed(), Track substrate cursor tail-seeds that skip unreduced history., tail_seed_snapshot() (+63 more)
+
+### Community 71 - "Community 71"
+Cohesion: 0.05
+Nodes (73): _broadcast_enabled(), _broadcast_is_stale(), build_hub_association_bundle(), _default_reader(), _parse_broadcast(), Any, Ensure the current Hub turn is always a coalition member for fail-closed evidenc, Orion capability: felt-state context for the stance turn.      Supplies Thought (+65 more)
+
+### Community 72 - "Community 72"
+Cohesion: 0.07
+Nodes (27): BaseModel, SocialOpenThreadV1, SocialTurnPolicyDecisionV1, CallSyneRoomMessageV1, Thin transport contract for inbound CallSyne-style room traffic., BaseModel, SocialEpistemicDecisionV1, SocialEpistemicSignalV1 (+19 more)
+
+### Community 73 - "Community 73"
+Cohesion: 0.07
+Nodes (43): JournalRepository, chat_episodes_query(), chat_episodes_status(), journals_query(), journals_status(), rebuild_chat_episodes(), rebuild_journals(), BuildResponse (+35 more)
+
+### Community 74 - "Community 74"
+Cohesion: 0.07
+Nodes (78): FetchedArticleRefV1, SubstrateActResultV1, SubstrateEpisodeIntentV1, build_episode_narrative_seed(), build_readonly_fetch_query(), curiosity_strength_from_signals(), _execute_readonly_recall(), _gap_section_label() (+70 more)
+
+### Community 75 - "Community 75"
+Cohesion: 0.07
+Nodes (51): test_atom_roundtrip(), test_grammar_event_requires_provenance(), test_invalid_atom_type_rejected(), build_harness_grammar_events(), build_harness_grammar_finalize_events(), compute_harness_reasoning_present(), compute_harness_thinking_source(), _event() (+43 more)
+
+### Community 76 - "Community 76"
+Cohesion: 0.05
+Nodes (64): CompactionMetricsV1, ConsolidateEntryV1, DownscaleEntryV1, MemoryCompactionDeltaV1, PruneEntryV1, BaseModel, datetime, Memory-compaction delta — the dream's *proposed* housekeeping (Phase F).  A `Mem (+56 more)
+
+### Community 77 - "Community 77"
+Cohesion: 0.06
+Nodes (75): MoodArcCorpusRowV1, MoodArcEncoderManifestV1, BaseModel, Mood-arc corpus row schema -- Item 1 of docs/superpowers/specs/2026-07-13-felt-s, One per-tick training-data row for the not-yet-built windowed felt-     state au, Item 2's windowed felt-state-trajectory encoder manifest -- dark     artifact, d, Adam, block_bootstrap_ratio_ci() (+67 more)
+
+### Community 78 - "Bus Channels: Chat/GPT Ingest Family"
+Cohesion: 0.06
+Nodes (62): HTMLParser, Any, SourceRegistryV1, SourceTrustAssessmentV1, WorldPulseAllowedUsesV1, WorldPulseSourceV1, fetch_rss_articles(), _parse_date() (+54 more)
+
+### Community 79 - "Community 79"
+Cohesion: 0.06
+Nodes (71): Telemetry for recall decisions., RecallDecisionV1, RetrievalIntentV1, main(), intent_telemetry_payload(), Build recall.intent.v1 telemetry. ``query_hash16`` is SHA-256 of UTF-8 query tex, fetch_memory_graph_sparql_candidates(), Any (+63 more)
+
+### Community 80 - "Community 80"
+Cohesion: 0.08
+Nodes (72): ConceptProfileBackendKind, CutoverFallbackPolicyKind, coerce_journal_title(), stable_journal_entry_id_for_workflow_compose(), Any, Shared rules for workflow-owned journal persistence (orch vs exec)., When True, journal.entry.write.v1 is emitted from cortex-exec after journal.comp, workflow_journal_write_delegated_to_exec() (+64 more)
+
+### Community 81 - "Community 81"
+Cohesion: 0.09
+Nodes (65): main(), _parse_args(), Namespace, build_sft_dataset(), _chat_template(), _iter_jsonl(), _load_from_jsonl(), _load_from_postgres() (+57 more)
+
+### Community 82 - "Community 82"
+Cohesion: 0.06
+Nodes (73): AutonomyGraphReadPlan, log_autonomy_graph_backend_decision(), build_autonomy_repository(), RepositoryBackendKind, strip_graph_credentials(), main(), run_probe(), build_chat_stance_debug_payload() (+65 more)
+
+### Community 83 - "Community 83"
+Cohesion: 0.05
+Nodes (73): _abs_trajectory_for_row(), _as_utc(), bucket_class_for(), bucket_index(), BucketActivity, build_arg_parser(), build_bucket_activity(), build_drive_coactivation_histogram_sparql() (+65 more)
+
+### Community 84 - "Community 84"
+Cohesion: 0.07
+Nodes (62): _clean(), extract_anchors(), _clean_block(), extract_blocks(), _extract_code_or_command(), _extract_logs(), _reasoning_summary(), _candidate_claims() (+54 more)
+
+### Community 85 - "Community 85"
+Cohesion: 0.05
+Nodes (39): Image, Lock, is_caption_prompt_echo(), _normalize(), True when caption text is the VLM prompt echoed back, not scene description., test_is_caption_prompt_echo_matches_current_prompt(), test_is_caption_prompt_echo_matches_legacy_phrase(), test_is_caption_prompt_echo_rejects_blip_suffix_noise() (+31 more)
+
+### Community 86 - "Community 86"
+Cohesion: 0.06
+Nodes (61): api_service_logs_services(), build_compose_logs_command(), collect_service_inventory(), discover_loggable_services(), _docker_diagnostics(), Any, Path, Queue (+53 more)
+
+### Community 87 - "Community 87"
+Cohesion: 0.14
+Nodes (55): SocialRoomBridgeService, _FailingCallSyneClient, _FailingHubClient, _FakeBus, _FakeCallSyneClient, _FakeHubClient, _FakeSocialMemoryClient, _payload() (+47 more)
+
+### Community 88 - "Community 88"
+Cohesion: 0.08
+Nodes (62): InnerStateFeaturesV1, AttributionV1, CorpusStatsV1, PhiEncoderManifestV1, BaseModel, Phi encoder manifest + intrinsic reward schemas (Plan 2)., TrainingStatsV1, _apply_grads() (+54 more)
+
+### Community 89 - "Community 89"
+Cohesion: 0.09
+Nodes (69): execute_chat_workflow(), DummyBus, _load_sql_writer_worker(), Load orion-sql-writer's worker under its own ``app`` package.      The worker im, Production path: digest arrives only as final_text JSON, no metadata dict., A transient DB error on card persist must not discard the digest., When orch skips bus publish, mirror exec-side journal write so tests still see o, _req() (+61 more)
+
+### Community 90 - "Community 90"
+Cohesion: 0.06
+Nodes (66): CapabilitiesResponse, DatasetCreateRequest, DatasetCreateResponse, DatasetListResponse, DatasetPreviewDoc, DriftListResponse, DriftRecord, DriftRunRequest (+58 more)
+
+### Community 91 - "Community 91"
+Cohesion: 0.07
+Nodes (54): EvidenceUnitSQL, EvidenceAdapter, Any, Protocol, _as_dt(), CollapseMirrorEvidenceAdapter, Any, datetime (+46 more)
+
+### Community 92 - "Community 92"
+Cohesion: 0.06
+Nodes (65): build_plan_for_verb(), load_prompt_template(), load_verb_yaml(), Any, ExecutionPlan, Honor explicit `services: []` on a plan step; do not treat it as 'inherit defaul, _resolve_step_services(), test_grounding_capsule_round_trip() (+57 more)
+
+### Community 93 - "Community 93"
+Cohesion: 0.07
+Nodes (55): FieldEdgeV1, FieldStateV1, BaseModel, apply_decay(), apply_diffusion(), _clamp01(), Recompute every diffused capability channel fresh from this tick's node/     cap, apply_suppression() (+47 more)
+
+### Community 94 - "Community 94"
+Cohesion: 0.07
+Nodes (65): build_cognitive_projection_for_context(), build_cognitive_projection_for_mind_with_diagnostics(), _env_float(), get_projection_unification_layer(), _publish_tier_outcomes_if_needed(), Any, Shared CognitiveUnificationLayer → CognitiveProjection builder.  Phase-3 seam: m, Return the process-level CognitiveUnificationLayer used by projection builders. (+57 more)
+
+### Community 95 - "Community 95"
+Cohesion: 0.08
+Nodes (64): Shared contracts for bus message payloads., MemoryCardEdgeCreateV1, MemoryCardEdgeV1, MemoryCardHistoryEntryV1, MemoryCardPatchV1, MemoryCardV1, BaseModel, visibility_allows_card() (+56 more)
+
+### Community 96 - "Community 96"
+Cohesion: 0.07
+Nodes (68): Path, Unit tests for the pure helpers in scripts/context_mode_hooks_smoke.py.  These n, _stream_lines(), test_check_result_json_line_round_trips(), test_dir_diff_detects_added_file(), test_dir_diff_detects_modified_file(), test_exit_code_zero_only_without_fail(), test_extract_final_text_falls_back_to_assistant_text() (+60 more)
+
+### Community 97 - "Community 97"
+Cohesion: 0.05
+Nodes (72): applyCapabilityDefaults(), applySegmentsClientFilters(), bindTopicStudioPersistence(), clearPreview(), copyText(), executePreview(), exportEventsCsv(), exportKgCsv() (+64 more)
+
+### Community 98 - "Community 98"
+Cohesion: 0.07
+Nodes (30): ConceptProfile, ConceptProfileDelta, GraphReadyArtifact, ConceptWorker, BaseEnvelope, ServiceRef, TensionEventV1, Manages windowed intake and triggers induction. (+22 more)
+
+### Community 99 - "Community 99"
+Cohesion: 0.04
+Nodes (71): Channel "orion:bridge:social:participant" (kind=event, schema=ExternalRoomParticipantV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:bridge:social:room:delivery" (kind=event, schema=ExternalRoomPostResultV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:bridge:social:room:intake" (kind=event, schema=ExternalRoomMessageV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:bridge:social:room:skipped" (kind=event, schema=ExternalRoomTurnSkippedV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:core:events" (kind=event, schema=CoreEventV1) producers=[*] consumers=[*], Channel "orion:rdf:error" (kind=event, schema=SystemErrorV1) producers=[orion-rdf-writer] consumers=[*], Channel "orion:social:bridge-summary" (kind=event, schema=SocialBridgeSummaryV1) producers=[orion-social-memory] consumers=[*, orion-social-room-bridge, orion-hub], Channel "orion:social:claim" (kind=event, schema=SocialClaimV1) producers=[orion-social-memory] consumers=[*, orion-social-room-bridge, orion-hub] (+63 more)
+
+### Community 100 - "Community 100"
+Cohesion: 0.09
+Nodes (44): CalibrationRolloutScopeV1, apply_calibration_adoption(), compare_endogenous_runtime_profile_outcomes(), EndogenousRuntimeAdoptionService, inspect_calibration_profile_audit(), inspect_calibration_profile_audit_with_source(), inspect_calibration_profile_state_with_source(), inspect_calibration_profiles() (+36 more)
+
+### Community 101 - "Community 101"
+Cohesion: 0.10
+Nodes (47): FrontierContextRefsV1, FrontierDeltaItemV1, FrontierExpansionRequestV1, FrontierExpansionResponseV1, FrontierGraphDeltaBundleV1, FrontierGraphRegionRefV1, FrontierSourceProvenanceV1, BaseModel (+39 more)
+
+### Community 102 - "Community 102"
+Cohesion: 0.07
+Nodes (56): PhiIntrinsicRewardV1, ExecutionTrajectorySnapshot, GrammarTruthSnapshot, ReasoningActivitySnapshot, _mock_healthy_substrate_reads(), The main-path trace EKG frame (handle_trace, non-heartbeat) must show the     ho, # NOTE: handle_self_state does `SelfStateV1.model_validate(payload)` inside a, A healthy row (phi_health='ok', grammar not degraded, cognitive features     bac (+48 more)
+
+### Community 103 - "Community 103"
+Cohesion: 0.07
+Nodes (38): build_latest_profile_query(), build_profile_details_query(), _escape_sparql(), GraphQueryConfig, GraphQueryError, RuntimeError, _sparql_values_str(), _sparql_values_uri() (+30 more)
+
+### Community 104 - "Community 104"
+Cohesion: 0.07
+Nodes (42): ClaimSummaryV1, ContextPackCompileRequestV1, ContextPackCompileResultV1, ContextPackSummaryV1, ContextPackTargetApiV1, DecisionSummaryV1, IdeationMode, KnowledgeForgeStatusV1 (+34 more)
+
+### Community 105 - "Community 105"
+Cohesion: 0.06
+Nodes (58): InnerFeatureV1, BaseModel, InnerStateFeaturesV1 — Orion's honest, decontaminated inner-state vector.  Felt+, is_corpus_row_healthy(), Pure gate predicate for the phi (InnerStateFeaturesV1) training corpus.  Garbage, Pure predicate: should this InnerStateFeaturesV1 row enter the phi corpus?, main(), _parse_args() (+50 more)
+
+### Community 106 - "Community 106"
+Cohesion: 0.09
+Nodes (59): MemoryCardStatus, EvidenceItemV1, MemoryCardCreateV1, Payload for creating a card (Hub POST)., TimeHorizonV1, CardProjectionDefaultsV1, DispositionDraft, EdgeDraft (+51 more)
+
+### Community 107 - "Community 107"
+Cohesion: 0.07
+Nodes (54): build_expectations_from_motifs(), detect_motifs(), PolicyDecisionFrameV1, PolicyDecisionV1, BaseModel, _engine(), _load_latest_policy_frame(), policy_latest() (+46 more)
+
+### Community 108 - "Community 108"
+Cohesion: 0.08
+Nodes (63): _FakeBus, _payload(), _service_and_session(), test_accepted_artifact_confirmation_expands_active_continuity(), test_accepted_confirmation_without_clear_scope_stays_non_active(), test_active_commitment_is_selected_over_old_ritual_hint(), test_addressed_peer_context_is_preferred_over_generic_room_context(), test_ambiguous_divergence_prefers_one_clarifying_question() (+55 more)
+
+### Community 109 - "Community 109"
+Cohesion: 0.08
+Nodes (62): ActiveFrontierDiagnosticsV1, AppraisalFeatureVectorV1, DeferredFrontierMatterV1, MindEvidenceItemV1, MindEvidencePackV1, BaseModel, Mind semantic synthesis, appraisal, and stance handoff contracts., SemanticClaimV1 (+54 more)
+
+### Community 110 - "Community 110"
+Cohesion: 0.04
+Nodes (56): Cross-cutting ouroboros invariants for the reverie/dream/compaction weave.  The, A producer of a weave channel must never also be listed as a consumer of     tha, The memory-touching / dispatch-adjacent channels stay dead-ended: no     service, test_channel_schema_ids_match_the_weave_contract(), test_dangerous_channels_have_no_live_consumer(), test_every_weave_kind_is_registered_and_resolvable(), test_no_process_reads_its_own_output_kind(), _weave_channel_entries() (+48 more)
+
+### Community 111 - "Community 111"
+Cohesion: 0.06
+Nodes (59): HarnessDraftMoleculeV1, CompactionRequestV1, BaseModel, Readout of one train of thought — successive climbs of the ladder.      Continui, A typed *ask* from the awake reverie (reasoning) to the offline dream     (stora, ReverieChainTriggerV1, ReverieChainV1, CoalitionSnapshotV1 (+51 more)
+
+### Community 112 - "Community 112"
+Cohesion: 0.07
+Nodes (63): configured_storage_paths(), ensure_storage_dirs(), _path_status(), persist_context_exec_run(), Any, Path, Best-effort conversion to a JSON-serializable structure.      Never raises; un-s, Persist an immutable forensic bundle for a completed context-exec run.      Retu (+55 more)
+
+### Community 113 - "Community 113"
+Cohesion: 0.04
+Nodes (57): _make_engine_sequence(), Returns a fake engine where each successive execute() call returns the next resu, Simulate endpoint must not access the DB engine beyond loading the proof chain., Endpoint must not modify the policy YAML file., Returns 503 when the policy YAML file doesn't exist., M3 status is 'fresh' when projection updated_at is recent., M3 status is 'stale' when projection updated_at is old., L11 status is 'missing' when consolidation frames table has no rows. (+49 more)
+
+### Community 114 - "Community 114"
+Cohesion: 0.06
+Nodes (56): ClosureHandler, _envelope_correlation_id(), _handle_bus_message(), handle_finalize_appraisal_request(), Any, Settings, Task, UUID (+48 more)
+
+### Community 115 - "Community 115"
+Cohesion: 0.05
+Nodes (17): record_tail_seed(), TailSeedRecord, BiometricsSubstrateStore, _cursor_lag_seconds(), Any, datetime, Pending backlog and stream lag for a grammar reducer cursor., Operator recovery: reset reducer cursor. Caller must validate auth/mode/name. (+9 more)
+
+### Community 116 - "Community 116"
+Cohesion: 0.07
+Nodes (53): MemoryBundleStatsV1, MemoryBundleV1, MemoryItemV1, BaseModel, Per-fetch-path vector gating outcome (see ``source_policy.recall_vector_allowed`, A single retrieved memory item., Path-keyed vector policy diagnostics attached under ``recall_debug.vector_policy, Coarse source enablement labels under ``recall_debug.source_gating``. (+45 more)
+
+### Community 117 - "Bus Channels: Agent Council & Chat History"
+Cohesion: 0.10
+Nodes (35): EndogenousTriggerDebugV1, EndogenousTriggerDecisionV1, EndogenousTriggerRequestV1, EndogenousTriggerSignalV1, EndogenousWorkflowActionV1, EndogenousWorkflowExecutionResultV1, EndogenousWorkflowPlanV1, BaseModel (+27 more)
+
+### Community 118 - "Community 118"
+Cohesion: 0.05
+Nodes (53): ChatStanceBrief, BaseModel, Bounded internal stance brief used by chat_general speech pass., _brief_response_hazards(), enforce_chat_stance_quality(), _extract_json_object(), fallback_chat_stance_brief(), _is_identity_sensitive_turn() (+45 more)
+
+### Community 119 - "Community 119"
+Cohesion: 0.05
+Nodes (57): Narrator, RequestLoader, MonkeyPatch, test_legacy_rabbit_enables_concurrent_handlers_by_default(), test_legacy_rabbit_respects_concurrent_handlers_setting(), _enable_pcr(), _enable_pcr_and_grounding(), build_compaction_delta() (+49 more)
+
+### Community 120 - "Community 120"
+Cohesion: 0.10
+Nodes (53): ReductionReceiptV1, emission_touches_node(), _normalize_node_id(), Any, Node-scoped filtering for substrate receipts and organ emissions., receipt_touches_node(), state_deltas_for_node(), classify_receipt() (+45 more)
+
+### Community 121 - "Community 121"
+Cohesion: 0.06
+Nodes (44): BaseModel, StateDeltaV1, apply_perturbations(), delta_to_perturbations(), _node_key(), Perturbation, empty_field_state(), new_tick_id() (+36 more)
+
+### Community 122 - "Community 122"
+Cohesion: 0.05
+Nodes (49): test_notify_verb_fills_body_from_context_when_skill_args_empty(), OperationalSemanticHarnessTests, LogCaptureFixture, MonkeyPatch, Settings, Regression: direct lane RPC must reuse the same plan as the verb path (router +, Regression: lane/mind/output_mode arbitration facts must reach the caller on, _settings_routing_off() (+41 more)
+
+### Community 123 - "Community 123"
+Cohesion: 0.05
+Nodes (64): Channel "orion:attention:loop_outcome" (kind=event, schema=AttentionLoopOutcomeV1) producers=[orion-hub] consumers=[none], Channel "orion:attention:salience:trace" (kind=telemetry, schema=AttentionSalienceTraceV1) producers=[orion-thought] consumers=[none], Channel "orion:chat:history:spark_meta:patch" (kind=event, schema=ChatHistorySparkMetaPatchV1) producers=[orion-memory-consolidation] consumers=[orion-sql-writer], Channel "orion:chat:response:feedback" (kind=event, schema=ChatResponseFeedbackV1) producers=[orion-hub, *] consumers=[orion-sql-writer], Channel "orion:conversation:request" (kind=request, schema=ChatRequestPayload) producers=[orion-hub] consumers=[orion-cortex-orch], Channel "orion:conversation:result" (kind=result, schema=ChatResultPayload) producers=[orion-cortex-orch] consumers=[orion-hub], Channel "orion:council:reply*" (kind=result, schema=ChatResultPayload) producers=[orion-llm-gateway] consumers=[orion-vision-council], Channel "orion:dream:compaction-request" (kind=event, schema=CompactionRequestV1) producers=[orion-thought] consumers=[none] (+56 more)
+
+### Community 124 - "Community 124"
+Cohesion: 0.06
+Nodes (50): _clamp01(), Phase B — spontaneous thought → governed proposal candidate.  Maps a non-hollow, Convert a thought into a review-gated proposal candidate, or None.      Returns, spontaneous_thought_to_candidate(), _coalition(), Phase B — spontaneous thought → governed proposal candidate.  The security-criti, test_absent_coalition_targets_self_state_without_raising(), test_autoaction_posture_recorded_but_gate_unchanged() (+42 more)
+
+### Community 125 - "Community 125"
+Cohesion: 0.07
+Nodes (57): apply_fast_chat_recall_profile_clamp(), apply_hub_chat_lane_recall_clamp(), _clean_profile(), delivery_safe_recall_decision(), _is_concrete_ops_query(), _normalize_bool(), plan_ctx_latest_user_text(), Any (+49 more)
+
+### Community 126 - "Community 126"
+Cohesion: 0.09
+Nodes (51): BaseModel, RouteArbitrationProjectionV1, RouteArbitrationRunStateV1, _boolish(), extract_route_state_from_events(), _parse_summary_kv(), datetime, _utc_now() (+43 more)
+
+### Community 127 - "Community 127"
+Cohesion: 0.10
+Nodes (54): build_self_state(), _emit_summary_labels(), evidence_for_dimension(), _provenance_label(), datetime, Friendlier evidence label: strip the "node:" prefix (e.g. "node:atlas"     -> "a, Phase 3 (2026-07-12): fold node/capability provenance into the     free-text `re, _reason_for_evidence() (+46 more)
+
+### Community 128 - "Community 128"
+Cohesion: 0.07
+Nodes (54): AbstractEventLoop, Model, PermissionError, _diff_path_from_header(), _is_allowed(), _is_denied(), _normalize_rel_path(), patch_validate() (+46 more)
+
+### Community 129 - "Community 129"
+Cohesion: 0.15
+Nodes (56): HTTPException, resolve_graphiti_adapter_url(), count_eligible_active(), get_crystallization(), insert_history(), insert_retrieval_event(), list_crystallizations(), Pool (+48 more)
+
+### Community 130 - "Community 130"
+Cohesion: 0.09
+Nodes (39): decay_activation(), Half-life activation decay — stdlib only (safe for lightweight service imports)., _aware(), _clamp(), decay(), decayed_activation(), datetime, Dynamic memory weight for crystallizations: encode weakly, strengthen on reinfor (+31 more)
+
+### Community 131 - "Community 131"
+Cohesion: 0.06
+Nodes (54): _cast_embedding_to_vecf32(), _embed_query(), ensure_graphiti_indices(), _ensure_target_entity_stub(), _extract_crystallization_ids(), _falkor_driver(), _filter_intimate_crystallization_ids(), get_neighborhood() (+46 more)
+
+### Community 132 - "Community 132"
+Cohesion: 0.09
+Nodes (25): _build_relation_prompt(), ConceptRelationDecision, maybe_resolve_concept_relation(), merge_new_evidence(), Any, BaseModel, Bounded structured-output LLM call. NEVER raises -- degrades to     ConceptRelat, Returns a (crystallization_id, row, outcome) tuple ONLY when it took a decisive (+17 more)
+
+### Community 133 - "Community 133"
+Cohesion: 0.07
+Nodes (51): FccRunner, _extract_tool_name(), short_error_kind(), publish_harness_step_grammar(), Any, PublishFn, harness_motor_instruction(), is_relational_motor_stance() (+43 more)
+
+### Community 134 - "Community 134"
+Cohesion: 0.08
+Nodes (49): BrainEdgeSampleV1, BrainNodeSampleV1, BrainRegionV1, BrainSpotlightV1, BaseModel, The spine of the contract: a continuous, trackable per-region signal., Best-effort decoration. NO continuity guarantee across frames., SubstrateBrainFrameV1 (+41 more)
+
+### Community 135 - "Community 135"
+Cohesion: 0.07
+Nodes (41): _coerce_features(), _coerce_matter_item(), _coerce_matter_kind(), _coerce_recommended_effect(), _coerce_string_list(), _extract_selected_raw(), _float_field(), _is_bare_frontier_matter_root() (+33 more)
+
+### Community 136 - "Community 136"
+Cohesion: 0.08
+Nodes (49): ChatProjectionLoader, ChatProjectionSaver, ChatTurnStateV1, BaseModel, compute_chat_pressure_hints(), extract_chat_turn_state(), _parse_trace_id(), datetime (+41 more)
+
+### Community 137 - "Community 137"
+Cohesion: 0.09
+Nodes (53): EmitObservationFn, execute_unified_turn(), _finalize_phase_error(), _harness_error_frame(), _partial_draft_from_run(), _publish_unified_turn_chat_grammar(), _publish_unified_turn_chat_history(), Any (+45 more)
+
+### Community 138 - "Community 138"
+Cohesion: 0.08
+Nodes (53): GrammarAtomSQL, GrammarCompactionSQL, GrammarEdgeSQL, GrammarEventSQL, GrammarProjectionSQL, GrammarTemporalHopSQL, GrammarTraceSQL, Canonical layer and dimension enums for Substrate Atlas (spec §5.4–5.5). (+45 more)
+
+### Community 139 - "Community 139"
+Cohesion: 0.06
+Nodes (49): build_answer_grounding_context(), _compose_grounding_context(), delivery_grounding_mode(), extract_trace_preferred_output(), Any, Answer/runtime grounding strings split from delivery-oriented helpers., Structured grounding for answer/render verbs (repo + runtime; Discord only when, build_delivery_grounding_context() (+41 more)
+
+### Community 140 - "Community 140"
+Cohesion: 0.09
+Nodes (35): ArtifactEventRef, ArtifactEvidence, DriveStateV1, GraphReadyArtifact, BaseModel, datetime, Lightweight join stub for turn-level debugability (not a service)., TurnDossierV1 (+27 more)
+
+### Community 141 - "Community 141"
+Cohesion: 0.06
+Nodes (47): collect_fragments(), Fragment, Fan-out collector.      This is the only place that knows which storage backends, RecallResult, End-to-end recall pipeline:      1. Collect candidate fragments from SQL and RDF, run_recall_pipeline(), _dedupe(), _mix_kinds() (+39 more)
+
+### Community 142 - "Community 142"
+Cohesion: 0.10
+Nodes (44): ObservationMode, datetime, stable_frame_id(), AttentionLimitsV1, AttentionThresholdsV1, AttentionWeightsV1, FieldAttentionPolicyV1, load_attention_policy() (+36 more)
+
+### Community 143 - "Bus Channels: Actions Trigger/Audit Family"
+Cohesion: 0.12
+Nodes (24): CalibrationAdoptionRequestV1, CalibrationAdoptionResultV1, CalibrationProfileAuditV1, CalibrationProfileResolutionV1, CalibrationProfileV1, CalibrationRollbackRequestV1, CalibrationRollbackResultV1, BaseModel (+16 more)
+
+### Community 144 - "Community 144"
+Cohesion: 0.08
+Nodes (47): ProjectionUpdateV1, BaseModel, BaseModel, TransportBusProjectionV1, TransportBusStateV1, _biometrics_projection(), _execution_projection(), test_biometrics_adapter_accepts_dict_json_absent_and_garbage() (+39 more)
+
+### Community 145 - "Community 145"
+Cohesion: 0.09
+Nodes (48): CollapseMirrorEntry, Direct request to write raw triples or triggers to the RDF writer.     Used for, RdfWriteRequest, MetaTagsPayload, MetaTagsRequestV1, MetaTagsResultV1, BaseModel, Standard schema for enrichment tags emitted by analysis services.     Conforms t (+40 more)
+
+### Community 146 - "Community 146"
+Cohesion: 0.07
+Nodes (47): build_identity_context(), load_identity_file(), Any, Path, resolve_identity_path(), enrich_projection_context(), identity_kernel_with_fallbacks(), inject_identity_context_for_projection() (+39 more)
+
+### Community 147 - "Bus Channels: Social Room Bridge"
+Cohesion: 0.08
+Nodes (49): test_fuse_dedupe_and_limit(), test_self_factual_filters_exclude_induced_and_reflective_candidates(), Pattern, _backend_weights(), _belief_source_rank(), _candidate_allowed(), _cards_rail_enabled(), _denial_patterns() (+41 more)
+
+### Community 148 - "Community 148"
+Cohesion: 0.08
+Nodes (46): build_speech_prompt(), _interlocutor_name(), is_injectable(), latest_partner_line(), _participants(), Any, Pure helpers for the cortex-generated town speech bridge.  No I/O. The worker ow, Anti empty-shell guard: only non-empty, non-whitespace replies are injectable. (+38 more)
+
+### Community 149 - "Community 149"
+Cohesion: 0.07
+Nodes (49): PcrChatMemoryV1, Purpose-conditioned recall (PCR) schema types., Cortex ctx shape for PCR chat memory surfaces., assemble_stance_grounding(), build_grounding_capsule(), _clean(), Any, Settings (+41 more)
+
+### Community 150 - "Community 150"
+Cohesion: 0.10
+Nodes (50): config/autonomy/signal_drive_map.yaml, _cold(), main(), AutonomyEvidenceRefV1, AutonomyStateDeltaV1, CandidateImpulseV1, AutonomyStateV2 evidence pipeline (chat, env-gated), Orion Autonomy README (+42 more)
+
+### Community 151 - "Community 151"
+Cohesion: 0.08
+Nodes (50): RouteName, _apply_llm_route(), _call_cortex(), _extract_attempt_diagnostics(), _normalize_route(), Any, BaseException, Try grounded Quick, then Brain on hard failures; RDF-validate without persisting (+42 more)
+
+### Community 152 - "Community 152"
+Cohesion: 0.07
+Nodes (51): inject_session_presence(), load_session_presence(), _payload_has_presence_context(), Any, Merge stored presence into a chat payload when the client did not send one., Return session-scoped audience presence, or None when unavailable., cancel_agent_claude_turn(), cancel_in_flight_turn() (+43 more)
+
+### Community 153 - "Community 153"
+Cohesion: 0.11
+Nodes (48): BaseModel, SocialConceptEvidenceV1, SocialGroundingStateV1, SocialRedactionScoreV1, BaseModel, SocialSkillRequestV1, SocialSkillResultV1, SocialSkillSelectionV1 (+40 more)
+
+### Community 154 - "Community 154"
+Cohesion: 0.10
+Nodes (52): asList(), asObject(), attach(), buildExecutionStepsPanel(), cleanText(), collectBase(), compactProjectionItems(), comparisonColumn() (+44 more)
+
+### Community 155 - "Community 155"
+Cohesion: 0.10
+Nodes (43): CoverageStatus, _gpu_gap_result(), test_metabolism_skips_covered_sections(), test_metabolism_sparse_gpu_section_raises_predictive(), DailyWorldPulseItemV1, DailyWorldPulseSectionsV1, DailyWorldPulseV1, HubWorldPulseMessageV1 (+35 more)
+
+### Community 156 - "Community 156"
+Cohesion: 0.08
+Nodes (44): FeedbackFrameV1, ActionOutcomeEmitV1, Bus payload carrying an action outcome for durable persistence via sql-writer., _artifact_id(), _canonical_pressures_for_spread(), clamp01(), _delta_from_turn_effect(), derive_pressure_competition_tensions() (+36 more)
+
+### Community 157 - "Bus Channels: Collapse Mirror & Autonomy Goal"
+Cohesion: 0.07
+Nodes (43): expand_env_path(), load_fcc_env(), Path, build_orion_town_persona(), Project the self-model into a public-safe town persona.      Empty-shell guard:, _truncate(), test_blurb_is_truncated(), test_empty_projection_falls_back() (+35 more)
+
+### Community 158 - "Community 158"
+Cohesion: 0.12
+Nodes (41): _autonomy_goal_execution_enabled(), plan_promoted_goal(), update_goal_planned_task_id(), _FakeGraphClient, _goal_row(), test_plan_promoted_goal_persists_task_id_with_planned_status(), test_plan_promoted_goal_requires_planned_status(), test_promote_goal_chains_planner_task_id() (+33 more)
+
+### Community 159 - "Community 159"
+Cohesion: 0.08
+Nodes (42): bus_consumer_readiness_v1(), check_bus_consumer_readiness(), check_heartbeat_fresh(), _decode_redis_val(), _heartbeat_matches_service(), _parse_last_seen_ts(), Any, datetime (+34 more)
+
+### Community 160 - "Community 160"
+Cohesion: 0.09
+Nodes (41): ConceptCluster, ConceptItem, ConceptProfile, BaseModel, datetime, Canonical schemas for Concept Induction artifacts., Versioned snapshot of induced concepts., A single induced concept or motif. (+33 more)
+
+### Community 161 - "Community 161"
+Cohesion: 0.15
+Nodes (44): ArticleClusterV1, ClaimRecordV1, EntityRecordV1, EventRecordV1, BaseModel, SituationChangeV1, SituationEvidenceV1, SituationObservationV1 (+36 more)
+
+### Community 162 - "Community 162"
+Cohesion: 0.06
+Nodes (33): control_surface_store(), get_chat_reflective_lane_threshold(), inspect_chat_reflective_lane_threshold(), Any, datetime, _resolve_postgres_url(), _resolve_sqlite_path(), RuntimeControlSurfaceStore (+25 more)
+
+### Community 163 - "Community 163"
+Cohesion: 0.09
+Nodes (50): _available_route_keys(), _backend_supports_anthropic_messages(), build_models_list_payload(), _extract_correlation_id(), _forwardable_request_headers(), _forwardable_response_headers(), handle_messages_get(), handle_messages_head() (+42 more)
+
+### Community 164 - "Community 164"
+Cohesion: 0.10
+Nodes (41): emit_active_packet_retrieved(), emit_crystallization_lifecycle(), _source(), auto_activate(), GovernorPathRequired, datetime, ValueError, _utc_now() (+33 more)
+
+### Community 165 - "Community 165"
+Cohesion: 0.10
+Nodes (40): SocialGifUsageStateV1, _artifact_boundary_active(), _boolish(), _caution_context_present(), _chaotic_room(), _contested_claims(), evaluate_social_gif_policy(), _freshness_state() (+32 more)
+
+### Community 166 - "Community 166"
+Cohesion: 0.08
+Nodes (40): ConceptInductionTrigger, WorkerLivenessState, drive_state_from_values(), DriveEngine, DriveMathConfig, datetime, DriveStateV1, TensionEventV1 (+32 more)
+
+### Community 167 - "Community 167"
+Cohesion: 0.07
+Nodes (41): Popen, asterisk_cmd(), bootstrap_asterisk_and_cisco(), CompletedProcess, Path, Settings, Ensure Asterisk dirs exist, write core configs and SEP<MAC>.cnf.xml (only if mis, Start in.tftpd (tftpd-hpa) serving /tftpboot. (+33 more)
+
+### Community 168 - "Community 168"
+Cohesion: 0.10
+Nodes (42): _check(), check_resonance_worsening(), HealthCheck, _is_worsening(), Severity, Phase H+ — resonance health monitor.  The resonance tripwire (`orion.reverie.res, Edge-triggered per-theme resonance monitor.      Tracks every theme currently be, Reconstruct tracked themes (and their known-unhealthy state) from         orion- (+34 more)
+
+### Community 169 - "Community 169"
+Cohesion: 0.10
+Nodes (40): IntentKind, IntentSource, ArbiterDecision, ArbiterState, decide(), datetime, Pure arbitration. Mutates only ``state.deliberate_hold_until`` on accept., DriveMapThresholds (+32 more)
+
+### Community 170 - "Community 170"
+Cohesion: 0.07
+Nodes (37): check_field_coherence(), Return 0-1 incoherence score for one node vector., Return per-node incoherence scores (0-1). Empty if no suspicion found., _rule_suspicion(), FieldChannelCorpusRowV1, BaseModel, Field-channel corpus row schema -- Item 1 v2 of docs/superpowers/specs/ 2026-07-, One per-tick training-data row of raw `FieldStateV1` channel     pressures, stra (+29 more)
+
+### Community 171 - "Community 171"
+Cohesion: 0.10
+Nodes (43): Evidence-derived feature vector scored by the salience combiner.      Replaces t, SalienceFeaturesV1, bounded(), compute_features(), compute_salience(), default_combiner(), _habituation(), LinearSalienceCombiner (+35 more)
+
+### Community 172 - "Community 172"
+Cohesion: 0.10
+Nodes (30): _canonical_phi_hint(), _coerce_change_type_payload(), CollapseMirrorConstraints, CollapseMirrorEntryV2, CollapseMirrorNumericSisters, CollapseMirrorStateSnapshot, CollapseMirrorWhatChanged, _extract_first_json_object() (+22 more)
+
+### Community 173 - "Community 173"
+Cohesion: 0.07
+Nodes (23): EmbodimentWorker, datetime, Fail-open, cached walkable set from the AI Town map. Fetched once., Re-read AI Town ids from the mounted FCC env each perception tick., Serialized actuate+publish. The lock keeps the cooldown check and the         ``, Gated, deduped, fail-open journal emit for salient town episodes.          Off u, Best-effort human name of Orion's conversation partner.          Prefers an expl, Derive salient episodes from a perception tick and journal them.          Two si (+15 more)
+
+### Community 174 - "Community 174"
+Cohesion: 0.07
+Nodes (44): orion/bus/channels.yaml (referenced), Orion Knowledge Forge Agent Contract, Knowledge Forge Compile Prompt, Knowledge Forge Ingest Prompt, Typed Claim Relations Vocabulary (supports/contradicts/supersedes/depends_on/implements/tested_by/blocked_by/motivated_by), claim:orion:substrate-telemetry:0001 — orion-substrate-telemetry persists tier outcomes, claim:orion:substrate-telemetry:0002 — orion-cortex-orch optionally merges telemetry facet, Context Pack: orion-substrate-telemetry (Cursor, markdown) (+36 more)
+
+### Community 175 - "Community 175"
+Cohesion: 0.07
+Nodes (32): is_stub_signal(), Shared stub-signal detection for Hub inspect cache and adapter tests (spec §5.9), True when the signal is a placeholder stub emission, not real organ truth., test_is_stub_signal_detects_placeholder_dimensions(), test_is_stub_signal_false_for_real_equilibrium(), api_observability_grafana_tempo_trace(), api_signals_trace(), Rolling trace cache by ``otel_trace_id`` (bounded by ``TRACE_CACHE_*`` settings) (+24 more)
+
+### Community 176 - "Community 176"
+Cohesion: 0.07
+Nodes (37): PromptContext, PromptFactory, Any, Turns (AgentConfig + PromptContext) into a messages[] list.      This is where φ, PromptContext, PromptFactory, Any, Shared context for building prompts for any agent.     Keeps council logic DRY, (+29 more)
+
+### Community 177 - "Community 177"
+Cohesion: 0.08
+Nodes (41): build_llama_server_cmd_and_env(), _ensure_draft_file(), _ensure_hf_gguf_file(), _ensure_mmproj_file(), _ensure_model_file(), _get_llama_server_build(), _get_supported_llama_server_flags(), main() (+33 more)
+
+### Community 178 - "Community 178"
+Cohesion: 0.09
+Nodes (43): IterableDataset, iter_batches(), load_fineweb_edu_tokens(), load_gpt2_tokenizer(), _load_streaming_text_tokens(), load_text_file_tokens(), load_tinystories_tokens(), device (+35 more)
+
+### Community 179 - "Community 179"
+Cohesion: 0.05
+Nodes (48): Channel "orion:biometrics:cluster" (kind=telemetry, schema=BiometricsClusterV1) producers=[orion-biometrics-hub] consumers=[orion-state-service, orion-sql-writer], Channel "orion:biometrics:induction" (kind=telemetry, schema=BiometricsInductionV1) producers=[orion-biometrics, orion-biometrics-hub] consumers=[orion-state-service, orion-sql-writer], Channel "orion:biometrics:sample" (kind=telemetry, schema=BiometricsSampleV1) producers=[orion-biometrics] consumers=[orion-sql-writer, orion-landing-pad], Channel "orion:biometrics:summary" (kind=telemetry, schema=BiometricsSummaryV1) producers=[orion-biometrics, orion-biometrics-hub] consumers=[orion-state-service, orion-sql-writer, orion-landing-pad], Channel "orion:cognition:trace" (kind=event, schema=CognitionTracePayload) producers=[orion-cortex-exec] consumers=[orion-spark-introspector, orion-landing-pad, orion-bus-tap], Channel "orion:exec:result:PadRpc:*" (kind=result, schema=PadRpcResponseV1) producers=[orion-landing-pad] consumers=[orion-cortex-exec, *], Channel "orion:exec:result:StateService:*" (kind=result, schema=StateLatestReply) producers=[orion-state-service] consumers=[orion-cortex-exec, *], Channel "orion:pad:event" (kind=event, schema=PadEventV1) producers=[orion-landing-pad] consumers=[*] (+40 more)
+
+### Community 180 - "Community 180"
+Cohesion: 0.06
+Nodes (48): Channel "orion:exec:request:VisionCouncilService" (kind=request, schema=VisionCouncilRequestPayload) producers=[orion-vision-window] consumers=[orion-vision-council], Channel "orion:exec:request:VisionHostService" (kind=request, schema=VisionTaskRequestPayload) producers=[orion-cortex-exec, orion-hub, orion-vision-host, orion-vision-frame-router] consumers=[orion-vision-host], Channel "orion:exec:request:VisionScribeService" (kind=request, schema=VisionScribeRequestPayload) producers=[orion-vision-council] consumers=[orion-vision-scribe], Channel "orion:exec:request:VisionWindowService" (kind=request, schema=VisionWindowRequestPayload) producers=[orion-vision-window] consumers=[orion-vision-council], Channel "orion:exec:result:VisionCouncilService" (kind=result, schema=VisionCouncilResultPayload) producers=[orion-vision-council] consumers=[orion-vision-window], Channel "orion:exec:result:VisionScribeService" (kind=result, schema=VisionScribeResultPayload) producers=[orion-vision-scribe] consumers=[orion-vision-council], Channel "orion:exec:result:VisionWindowService" (kind=result, schema=VisionWindowResultPayload) producers=[orion-vision-window] consumers=[orion-vision-council], Channel "orion:grammar:event" (kind=event, schema=GrammarEventV1) producers=[orion-vision-retina, orion-hub, orion-vision-edge, orion-vision-window, orion-biometrics, orion-cortex-exec, orion-bus, orion-harness-governor, orion-cortex-orch] consumers=[orion-sql-writer] (+40 more)
+
+### Community 181 - "Community 181"
+Cohesion: 0.13
+Nodes (45): AgendaContextV1, EnvironmentContextV1, LabContextV1, PresenceCompanionV1, BaseModel, RequestorContextV1, SituationAffordanceV1, SituationDiagnosticsV1 (+37 more)
+
+### Community 182 - "Community 182"
+Cohesion: 0.08
+Nodes (30): BaseModel, Payload for Speech-to-Text (ASR) request.     Kind: stt.transcribe.request, Payload for TTS synthesis request.     Kind: tts.synthesize.request, STTRequestPayload, STTResultPayload, TTSRequestPayload, TTSResultPayload, Sends a TTSRequestPayload to the TTS Service and waits for a TTSResultPayload. (+22 more)
+
+### Community 183 - "Community 183"
+Cohesion: 0.13
+Nodes (42): main(), extract_from_python(), extract_from_yaml(), _extract_str(), main(), merge_inv(), Any, AST (+34 more)
+
+### Community 184 - "Community 184"
+Cohesion: 0.08
+Nodes (28): build_rollup_from_redis_snapshot(), _fetch_redis_snapshot(), load_channel_catalog_names(), ObserverRollup, Any, datetime, Path, Settings (+20 more)
+
+### Community 185 - "Community 185"
+Cohesion: 0.08
+Nodes (38): apply_grammar_events_retention(), build_grammar_truth_snapshot(), _fallback_counts(), _grammar_index_valid(), GrammarRetentionState, _latest_events_by_source(), Any, Runtime snapshot and bounded retention for grammar production observe mode. (+30 more)
+
+### Community 186 - "Community 186"
+Cohesion: 0.13
+Nodes (31): MentorConstraintsV1, MentorContextSliceV1, MentorGatewayResultV1, MentorProposalItemV1, MentorRequestV1, MentorResponseV1, BaseModel, datetime (+23 more)
+
+### Community 187 - "Community 187"
+Cohesion: 0.11
+Nodes (40): build_execution_dispatch_frame(), build_unevaluable_execution_dispatch_frame(), _candidate_status_for_mode(), _is_hard_blocked(), _proposal_by_id(), datetime, A policy frame whose proposal or self-state could not be loaded still     needs, _resolve_dispatch_mode() (+32 more)
+
+### Community 188 - "Community 188"
+Cohesion: 0.11
+Nodes (41): build_conversation_envelope(), build_envelopes_for_turn(), build_example_envelope(), build_import_run_envelope(), build_import_run_id(), build_message_envelope(), ChatMessage, ChatTurn (+33 more)
+
+### Community 189 - "Community 189"
+Cohesion: 0.08
+Nodes (41): compact_schema_for_llamacpp(), compact_suggest_draft_json_schema(), Any, JSON Schema contracts for memory-graph suggest (llama.cpp-friendly compact form), Full Pydantic JSON schema (may include $defs / $ref)., Strip Pydantic noise; keep inline object shapes only., Stage-1 schema: top-level keys + array item shapes without $ref/oneOf., suggest_draft_json_schema() (+33 more)
+
+### Community 190 - "Community 190"
+Cohesion: 0.10
+Nodes (45): collect_topical_spine_warnings(), _draft_utterance_corpus(), _entity_surface_forms_lower(), _entity_tokens(), extract_selected_role_evidence(), _has_assistant_role_entity(), _has_role_entity(), _has_topical_entity() (+37 more)
+
+### Community 191 - "Community 191"
+Cohesion: 0.05
+Nodes (46): Field Attention Policy v1, Signal Kind: biometrics_state, Signal Kind: chat_reasoning_quality, Signal Kind: chat_social_hazard, Signal Kind: failure_event, Signal Kind: mesh_health, Signal to Drive Map v1, Signal Kind: spark_signal (+38 more)
+
+### Community 192 - "Bus Channels: Vision Exec Request/Result"
+Cohesion: 0.09
+Nodes (41): binary_score_from_top_logprobs(), build_classify_prompt(), parse_classify_lines(), Any, appraisal_confidence(), binary_margin(), build_change_only_prompt(), build_turn_change_prompt() (+33 more)
+
+### Community 193 - "Community 193"
+Cohesion: 0.08
+Nodes (39): AgentChainRequest, AgentChainResult, Primary entry point for the Agent Chain service., Response from Agent Chain., agent_chain_request_to_context_exec(), context_exec_run_to_agent_chain_result(), _parse_answer_contract(), Any (+31 more)
+
+### Community 194 - "Community 194"
+Cohesion: 0.14
+Nodes (36): OpenLoopV1, BaseModel, Recorded when top-down goal bias makes a lower-bottom-up loop win — an     inspe, VoluntaryOverrideV1, _candidates(), _override_rate(), Eval: voluntary attention override dynamics (spec Step 2).  Replays synthetic ca, run() (+28 more)
+
+### Community 195 - "Community 195"
+Cohesion: 0.10
+Nodes (35): _attention_broadcast_section(), _compaction_delta_section(), _compaction_queue_section(), _curiosity_section(), _engine(), _hub_presence_section(), _iso(), _latest_row() (+27 more)
+
+### Community 196 - "Community 196"
+Cohesion: 0.08
+Nodes (23): create_frame_source(), FolderFrameSource, FrameReadResult, FrameSource, MockFrameSource, BaseModel, Protocol, Test/dev: random sample from folder like legacy mock. (+15 more)
+
+### Community 197 - "Community 197"
+Cohesion: 0.11
+Nodes (32): NotificationReceiptDB, Path, UUID, AgentTraceSummaryV1, ChatAttentionState, ChatMessageNotification, ChatMessageState, DeliveryAttempt (+24 more)
+
+### Community 198 - "Community 198"
+Cohesion: 0.11
+Nodes (35): MetabolismResultV1, Immutable typed lookup of dimension rules per signal_kind., SignalDriveMap, _build_tension(), chat_evidence_to_tension(), _clamp01(), equilibrium_to_tension(), failure_to_tension() (+27 more)
+
+### Community 199 - "Community 199"
+Cohesion: 0.06
+Nodes (45): Channel "orion:autonomy:goal:planned" (kind=event, schema=AutonomyGoalPlannedV1) producers=[orion-cortex-exec] consumers=[orion-cortex-exec, *], Channel "orion:calibration:profile:audit" (kind=event, schema=CalibrationProfileAuditV1) producers=[orion-cortex-exec] consumers=[orion-sql-writer], Channel "orion:cognition:reasoning_call" (kind=telemetry, schema=ReasoningCallV1) producers=[orion-cortex-exec] consumers=[orion-thought], Channel "orion:collapse:enrich" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-cortex-exec] consumers=[orion-collapse-mirror], Channel "orion:collapse:events" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-collapse-mirror, orion-cortex-exec] consumers=[orion-timeline, orion-athena-spark-introspector], Channel "orion:collapse:intake" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-cortex-exec, orion-collapse-mirror] consumers=[orion-collapse-mirror], Channel "orion:collapse:scored" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-cortex-exec] consumers=[orion-collapse-mirror], Channel "orion:collapse:sql-write" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-collapse-mirror] consumers=[orion-sql-writer] (+37 more)
+
+### Community 200 - "Community 200"
+Cohesion: 0.08
+Nodes (28): FeedbackFrameV1, OutcomeObservationV1, BaseModel, FeedbackRuntimeStore, datetime, _engine(), feedback_latest(), _load_latest_feedback_frame() (+20 more)
+
+### Community 201 - "Community 201"
+Cohesion: 0.08
+Nodes (28): Shared contract for JSONL corpus-sink rotation naming and file resolution.  Sing, InnerStateCorpusSink, BaseModel, Generic append-only JSONL corpus sink, any pydantic BaseModel payload.  Original, BaseModel, Unit tests for InnerStateCorpusSink's size-based rotation + retention pruning., _read_jsonl(), test_append_continues_working_after_rotation() (+20 more)
+
+### Community 202 - "Community 202"
+Cohesion: 0.07
+Nodes (35): DbRefractoryStore, InMemoryRefractoryStore, _maybe_emit_resonance_alert(), _now(), Any, datetime, Protocol, Phase C — reverie chain (a train of thought).  Successive reverie steps that cli (+27 more)
+
+### Community 203 - "Community 203"
+Cohesion: 0.14
+Nodes (43): pg_conn(), connection, count_segments(), create_conversation_override(), create_dataset(), create_event(), create_model(), create_model_event() (+35 more)
+
+### Community 204 - "Community 204"
+Cohesion: 0.11
+Nodes (39): outcome_from_followup(), Return the followup whose section matches the first gap-section label the     re, Rebuild an ActionOutcomeRefV1 from a world-pulse curiosity followup so the     r, select_reusable_followup(), iter_gap_section_labels(), Yield normalized section labels from `section:` focal refs across     world_cove, _followup(), _gap_signal() (+31 more)
+
+### Community 205 - "Community 205"
+Cohesion: 0.09
+Nodes (33): call_with_fuseki_retry(), fuseki_http_error_body(), fuseki_http_retry_attempts(), fuseki_http_retry_base_delay_sec(), is_fuseki_lock_exhaustion(), is_fuseki_retryable_http_error(), Response, T (+25 more)
+
+### Community 206 - "Community 206"
+Cohesion: 0.08
+Nodes (43): _coerce(), _make_prov(), map_curiosity_ctx_to_substrate(), Any, Map ``ctx['curiosity_signals']`` → one ``curiosity:unresolved_gaps`` node., Coerce raw input to list of FrontierInvocationSignalV1.      Accepts:     - list, _make_signal(), Tests for curiosity_ctx adapter. (+35 more)
+
+### Community 207 - "Community 207"
+Cohesion: 0.09
+Nodes (38): _admin_key(), AitownClientError, _base_url(), convex_mutation(), convex_query(), convex_request(), _default_player_id(), fetch_version() (+30 more)
+
+### Community 208 - "Community 208"
+Cohesion: 0.08
+Nodes (30): AuditFn, DispatchJournalFn, WorldPulseRunResultV1, _trigger_world_pulse_run(), Config, get_settings(), BaseSettings, Settings (+22 more)
+
+### Community 209 - "Community 209"
+Cohesion: 0.14
+Nodes (26): EndogenousWorkflowTypeV1, EndogenousHistoryEntryV1, InMemoryTriggerHistoryStore, datetime, Deterministic cooldown/debounce history for endogenous workflow triggers., EndogenousTriggerEvaluator, Deterministic pressure evaluator that selects bounded workflow triggers., EndogenousWorkflowOrchestrator (+18 more)
+
+### Community 210 - "Community 210"
+Cohesion: 0.10
+Nodes (38): Finding, attach_findings_to_debug(), merge_findings_bundle_dicts(), Any, Synthesize a serializable FindingsBundle from planner trace + contract (Phase 2, Merge two FindingsBundle-shaped dicts (exec supervisor aggregation)., synthesize_findings_bundle(), _trace_has_repo_evidence() (+30 more)
+
+### Community 211 - "Community 211"
+Cohesion: 0.09
+Nodes (35): _Baseline, DeviationGate, Deviation gate: turn a stream of per-dimension observations into impulses that f, Adaptive per-dimension deviation detector.      Args:         alpha: EWMA weight, Return the deviation impulse (>=0) for this observation, then fold it         in, _gate(), Task 2: deviation gate fires on change, not presence., A steady stream (the scene_state flood) mints ~0 after warm-up. (+27 more)
+
+### Community 212 - "Community 212"
+Cohesion: 0.12
+Nodes (36): _gap_strength(), _gaps_from_rollups(), _load_recommended_sections(), metabolize_substrate_signals(), _signal_from_gap(), _tension_from_gap(), _attention_loop_candidates(), _clamp01() (+28 more)
+
+### Community 213 - "Community 213"
+Cohesion: 0.06
+Nodes (43): Channel "orion:autonomy:action:outcome" (kind=event, schema=ActionOutcomeEmitV1) producers=[orion-spark-concept-induction, orion-execution-dispatch-runtime] consumers=[orion-sql-writer, *], Channel "orion:cortex:exec:request" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch, orion-thought] consumers=[orion-cortex-exec], Channel "orion:cortex:exec:request:background" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch, orion-actions, orion-harness-governor, orion-execution-dispatch-runtime] consumers=[orion-cortex-exec], Channel "orion:cortex:exec:request:chat" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch] consumers=[orion-cortex-exec], Channel "orion:cortex:exec:request:spark" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch] consumers=[orion-cortex-exec], Channel "orion:cortex:gateway:request" (kind=request, schema=CortexChatRequest) producers=[orion-hub] consumers=[orion-cortex-gateway], Channel "orion:cortex:gateway:result:*" (kind=result, schema=CortexChatResult) producers=[orion-cortex-gateway] consumers=[orion-hub], Channel "orion:cortex:request" (kind=request, schema=CortexClientRequest) producers=[orion-hub, orion-cortex-gateway, orion-actions, orion-memory-consolidation] consumers=[orion-cortex-orch] (+35 more)
+
+### Community 214 - "Community 214"
+Cohesion: 0.11
+Nodes (37): _coerce_float(), compute_deltas_from_turn_effect(), _delta_block(), evaluate_turn_effect_alert(), _evidence_block(), Any, should_emit_turn_effect_alert(), summarize_turn_effect() (+29 more)
+
+### Community 215 - "Community 215"
+Cohesion: 0.10
+Nodes (34): VisionEventBundleItem, build_intake_envelope(), build_rdf_write_request(), build_smoke_bundle_item(), build_vision_event_payload(), coerce_sql_row(), _collect_envelopes(), expected_sql_row_fields() (+26 more)
+
+### Community 216 - "Community 216"
+Cohesion: 0.08
+Nodes (27): check_token(), create_app(), create_service(), get_service(), get_settings(), heartbeat_loop(), psu_cycle(), psu_off() (+19 more)
+
+### Community 217 - "Community 217"
+Cohesion: 0.07
+Nodes (30): mock_pool(), test_ingest_episode_returns_ids(), _edge_data_calls(), _entity_data_calls(), _FakeEntityEdge, _FakeEntityNode, _patch_graphiti_node_edge_modules(), Stands in for graphiti_core.nodes.EntityNode in this dev venv (graphiti-core isn (+22 more)
+
+### Community 218 - "Community 218"
+Cohesion: 0.08
+Nodes (29): IdeationRunRequestV1, IdeationRunResultV1, build_user_prompt(), _collect_snippets(), detect_monorepo_root(), _is_under_allowed_roots(), Path, _read_snippet() (+21 more)
+
+### Community 219 - "Community 219"
+Cohesion: 0.12
+Nodes (40): maybe_send_email(), should_send_email(), attention_ack(), attention_request(), _attention_request_to_notification(), _attention_request_to_state(), chat_message(), chat_message_receipt() (+32 more)
+
+### Community 220 - "Community 220"
+Cohesion: 0.13
+Nodes (37): NotificationAttemptDB, NotificationRequestDB, Base, build_digest_content(), DigestSummary, DriftItem, _extract_drift_score(), _extract_topic_items() (+29 more)
+
+### Community 221 - "Community 221"
+Cohesion: 0.09
+Nodes (30): AlertPayload, Detection, BaseModel, Detection coming from the vision edge service.      - kind: "face", "motion", "y, Raw event from vision edge, as seen on orion:vision:edge:raw., Simple persistent security state., Summary of a logical 'visit' (a contiguous episode of humans present).     v1 is, What we publish as an alert + optionally email. (+22 more)
+
+### Community 222 - "Community 222"
+Cohesion: 0.12
+Nodes (38): HDBSCAN, DatasetSpec, EnrichmentSpec, ModelSpec, RunRecord, RunSpecSnapshot, RunTrainRequest, train_run_endpoint() (+30 more)
+
+### Community 223 - "Community 223"
+Cohesion: 0.11
+Nodes (29): _clamp01(), OriginationConfig, OriginationEngine, datetime, Deterministic endogenous "spontaneous want" generator.  STATUS (2026-07-08): NO-, Push a bounded summary of this self-state into the ring (cap cfg.window)., Compute D,W,A -> P over the current window and fire iff:          exogenous_tens, {'drift','dwell','agency','P','fired'} from the last maybe_originate call. (+21 more)
+
+### Community 224 - "Community 224"
+Cohesion: 0.08
+Nodes (23): CognitionPack, PackManager, Path, Represents a pack as defined in packs/*.yaml., Given one or more pack names, return consolidated list of unique verbs., Manages cognitive packs.      Responsibilities:     - Load packs from packs/*.ya, Validate that all verbs in the pack exist in verbs/*.yaml.         Returns a dic, ensure_delivery_pack_in_packs() (+15 more)
+
+### Community 225 - "Community 225"
+Cohesion: 0.11
+Nodes (39): accept_invite(), _admin_key(), AitownClientError, _base_url(), convex_mutation(), convex_query(), convex_request(), _game_descriptions() (+31 more)
+
+### Community 226 - "Community 226"
+Cohesion: 0.11
+Nodes (37): MetacogCausalDensityV1, MetacogConstraintsV1, MetacogDraftTextPatchV1, MetacogDraftWhatChangedV1, MetacogEnrichScorePatchV1, MetacogNumericSistersV1, BaseModel, _draft_ctx() (+29 more)
+
+### Community 227 - "Community 227"
+Cohesion: 0.06
+Nodes (21): find_orphaned_registry_entries(), find_unregistered_trigger_kinds(), _load(), main(), trigger_kinds the journaler actually understands but the dispatch registry     d, Registry rows for trigger_kinds no longer recognized by the journaler at all, Regression/live check: the actual orion.journaler.worker._TRIGGER_TO_MODE and, test_main_fails_when_a_trigger_kind_is_unregistered() (+13 more)
+
+### Community 228 - "Community 228"
+Cohesion: 0.08
+Nodes (33): cognitive_lane_dark(), fetch_execution_trajectory(), fetch_grammar_truth(), fetch_reasoning_activity(), _grammar_http_error(), Any, BaseException, Fail-closed HTTP reads from orion-substrate-runtime (grammar truth + trajectory) (+25 more)
+
+### Community 229 - "Bus Channels: Biometrics & Cognition Trace"
+Cohesion: 0.10
+Nodes (26): LivenessCheckFn, HarnessRunCancelV1, Fire-and-forget cancel for an in-flight FCC motor turn (Hub disconnect / abort)., _get_message_within(), HarnessGovernorClient, pubsub.get_message() performs exactly one read per call: if that single read, Fire-and-forget cancel for an in-flight FCC motor (no reply expected)., _FakeBus (+18 more)
+
+### Community 230 - "Community 230"
+Cohesion: 0.13
+Nodes (39): MindLLMSynthesisOutcome, MindShadowSynthesisV1, Non-authoritative Mind stance candidate for comparison/debug.      Shadow synthe, canonical_json_bytes(), hash_snapshot_inputs(), Any, Pure validators for Mind contracts (no HTTP / service imports beyond schemas)., validate_merged_stance_brief() (+31 more)
+
+### Community 231 - "Community 231"
+Cohesion: 0.13
+Nodes (15): BaseModel, SocialScenarioEvaluationResultV1, SocialScenarioExpectationV1, SocialScenarioFixtureV1, SocialScenarioSeedStateV1, SocialScenarioTurnFixtureV1, _clear_app_modules(), _FakeBus (+7 more)
+
+### Community 232 - "Community 232"
+Cohesion: 0.09
+Nodes (35): BaseSettings, Settings, client(), corpus_root(), MonkeyPatch, Path, TestClient, MonkeyPatch (+27 more)
+
+### Community 233 - "Community 233"
+Cohesion: 0.09
+Nodes (26): ExecutionDispatchCortexClient, Thin RPC client sending prepared_for_dispatch envelopes to cortex-exec.      Mir, extract_final_text(), parse_structured_observation(), Any, Parse a substrate.* verb's structured JSON output.      Expected shape: {"observ, Pull the plan's final_text out of a decoded CortexExecResultPayload.      Mirror, get_settings() (+18 more)
+
+### Community 234 - "Community 234"
+Cohesion: 0.10
+Nodes (33): _BlockingAfterLinesStream, _fake_fcc_env(), _FakeProc, _FakeStream, Any, MonkeyPatch, Path, Near the whole-turn deadline, fcc_timeout fires, not fcc_stream_stalled. (+25 more)
+
+### Community 235 - "Community 235"
+Cohesion: 0.12
+Nodes (25): _accepted_claims_for_spec(), compile_context_pack_markdown(), ClaimV1, lint_corpus(), _lint_relations(), LintIssue, LintReport, DocModel (+17 more)
+
+### Community 236 - "Community 236"
+Cohesion: 0.16
+Nodes (39): VisionWindowPayload, _attach_raw_model_output(), build_interpretation_prompt(), _clamp_float(), _coerce_event_candidate_item(), _coerce_legacy_events_field(), _coerce_llm_text(), _coerce_salient_observation_item() (+31 more)
+
+### Community 237 - "Bus Channels: Embodiment & Harness/Grammar"
+Cohesion: 0.11
+Nodes (33): ArticleRecordV1, TopicRecordV1, main(), classify_article(), build_article_clusters(), _ClusterState, _jaccard(), _score_match() (+25 more)
+
+### Community 238 - "Community 238"
+Cohesion: 0.08
+Nodes (32): enrich_from_graphdb_ids(), _avg(), fetch_recent_sql_fragments(), Fragment, Returns fragments from:       - collapse_mirror (timestamp is string → cast to t, Input columns:       - gpu (JSON): {"latest_file":"...", "gpus":[             {", _summarize_biometrics(), _to_float() (+24 more)
+
+### Community 239 - "Community 239"
+Cohesion: 0.13
+Nodes (33): append_action_outcome(), _db_url(), _get_engine(), load_action_outcomes(), _load_from_sql(), _load_raw(), Path, Read the most recent outcomes for a subject from the shared SQL store.      Retu (+25 more)
+
+### Community 240 - "Community 240"
+Cohesion: 0.11
+Nodes (31): CapabilityEvaluationContext, _decision(), _env_bool(), _env_float(), evaluate_capability(), _find_rule(), _goal_status_level(), _layer_a_episode_journal_enabled() (+23 more)
+
+### Community 241 - "Community 241"
+Cohesion: 0.10
+Nodes (35): _compile_repair_speech_overlay(), compile_speech_contract(), _inject_prior_stance_to_inputs(), Deterministic regime-specific contract injected near TASK in chat_general.j2., Copy prior brief summary into stance inputs and expose it as a TOP-LEVEL ctx, Drop trailing customer-support closers when stance contract forbids them., _sentence_is_transactional_closer(), _split_reply_sentences() (+27 more)
+
+### Community 242 - "Community 242"
+Cohesion: 0.09
+Nodes (33): _cards_enabled(), _close(), CloseRequest, dismiss_loop(), list_loops(), publish_loop_outcome(), BaseModel, Operator Pending Attention API — cognitive-loop rows + Resolve/Dismiss.  Flag-ga (+25 more)
+
+### Community 243 - "Community 243"
+Cohesion: 0.14
+Nodes (35): WindowingSpec, _build_prompt(), _cache_key(), _call_llm(), _hash_text(), judge_boundaries(), Any, _write_artifact() (+27 more)
+
+### Community 244 - "Community 244"
+Cohesion: 0.10
+Nodes (33): Autonomy graph IRIs (no heavy imports — safe for orion-actions / hub)., archive_subject_goals(), archive_subjects(), archive_subjects_drain(), _binding_value(), build_archive_candidates(), build_archive_status_update(), _build_client() (+25 more)
+
+### Community 245 - "Community 245"
+Cohesion: 0.06
+Nodes (38): Channel "orion:actions:trigger:journal.v1" (kind=event, schema=JournalTriggerV1) producers=[orion-actions, orion-embodiment, *] consumers=[orion-actions], Channel "orion:embodiment:intent" (kind=event, schema=EmbodimentIntentV1) producers=[orion-substrate-runtime, orion-harness-governor, orion-cortex-exec] consumers=[orion-embodiment], Channel "orion:embodiment:outcome" (kind=event, schema=EmbodimentOutcomeV1) producers=[orion-embodiment] consumers=[orion-hub], Channel "orion:embodiment:perception" (kind=event, schema=WorldPerceptionV1) producers=[orion-embodiment] consumers=[orion-substrate-runtime, orion-self-state-runtime, orion-cortex-exec], Channel "orion:exec:result:*" (kind=result, schema=CortexExecResultPayload) producers=[orion-cortex-exec, *] consumers=[orion-cortex-orch, orion-harness-governor, orion-thought, orion-hub, *], Channel "orion:grammar:accepted-pressure" (kind=event, schema=GrammarEventV1) producers=[orion-substrate-runtime] consumers=[none], Channel "orion:harness:run:artifact" (kind=event, schema=HarnessRunV1) producers=[orion-harness-governor] consumers=[*], Channel "orion:harness:run:cancel" (kind=event, schema=HarnessRunCancelV1) producers=[orion-hub] consumers=[orion-harness-governor] (+30 more)
+
+### Community 246 - "Community 246"
+Cohesion: 0.08
+Nodes (25): Hub legacy label ``recall.v1`` must resolve to structured brain recall, not chat, test_dream_v1_profile_loads(), test_profiles_load_default(), test_recall_v1_hub_alias_maps_to_brain_recall(), _canonical_profile_name(), _find_profiles_dir(), get_profile(), load_profiles() (+17 more)
+
+### Community 247 - "Community 247"
+Cohesion: 0.11
+Nodes (32): _normalize(), _parse_time(), BaseModel, resolve_workflow_schedule_management(), WorkflowScheduleManagementIntent, get_workflow_definition(), _journal_discussion_window_command_intent(), list_workflows() (+24 more)
+
+### Community 248 - "Community 248"
+Cohesion: 0.16
+Nodes (26): EndogenousCalibrationProfileV1, EndogenousCalibrationRecommendationV1, EndogenousEvaluationRequestV1, EndogenousEvaluationResultV1, EndogenousMetricSummaryV1, PromotionCalibrationSummaryV1, BaseModel, datetime (+18 more)
+
+### Community 249 - "Community 249"
+Cohesion: 0.12
+Nodes (33): BaseModel, Recall V2 / recall-strategy promotion readiness (advisory only; no live apply)., RecallStrategyReadinessV1, _cognitive_template_for_surface(), _default_patch_for_class(), _default_rollback_for_class(), _proposal_expected_effect(), _proposal_rationale() (+25 more)
+
+### Community 250 - "Community 250"
+Cohesion: 0.15
+Nodes (20): AttentionSignalV1, datetime, _utc_now(), compact(), Any, stable_id(), unique(), AutonomySignalDetector (+12 more)
+
+### Community 251 - "Community 251"
+Cohesion: 0.10
+Nodes (31): RenderedAnswer, _contract_dict(), _fallback_text(), FinalizePassResult, _findings_bundle_dict(), _jinja_env(), Any, Mandatory finalize pass: FindingsBundle + AnswerContract → user-visible Rendered (+23 more)
+
+### Community 252 - "Community 252"
+Cohesion: 0.13
+Nodes (28): EvidenceSnapshot, EvidenceTransitionDecision, EvidenceTransitionTracker, _hard_labels_from_evidence(), _labels_for_gate(), _labels_summary(), Deterministic pre-LLM gate: interpret only on host evidence transitions., snapshot_from_window() (+20 more)
+
+### Community 253 - "Community 253"
+Cohesion: 0.13
+Nodes (31): _clip(), fetch_turn_text_by_correlation(), format_turn_utterance_text(), hydrate_consolidation_draft_dict(), hydrate_draft_utterance_text(), Any, Pool, Hydrate consolidation suggest drafts with turn text from chat_history_log. (+23 more)
+
+### Community 254 - "Community 254"
+Cohesion: 0.11
+Nodes (20): BiometricsContext, BaseModel, RPC request payload for the state read-model service., RPC reply payload from the state read-model service., StateGetLatestRequest, StateLatestReply, BiometricsClusterV1, _age_ms() (+12 more)
+
+### Community 255 - "Community 255"
+Cohesion: 0.13
+Nodes (32): One LLM call's reasoning metadata. No trace text — privacy-preserving., ReasoningCallV1, build_reasoning_call(), _coerce_correlation_uuid(), _coerce_str(), _coerce_token(), publish_reasoning_call(), Any (+24 more)
+
+### Community 256 - "Community 256"
+Cohesion: 0.09
+Nodes (23): BiometricsAdapter, EquilibriumAdapter, adapter(), make_induction_payload(), norm_ctx(), Biometrics adapter contract (spec §7.A) — lives under ``orion/signals/adapters/t, test_adapt_leaves_otel_for_gateway(), TestAdapt (+15 more)
+
+### Community 257 - "Community 257"
+Cohesion: 0.08
+Nodes (21): Deterministic unit tests for the pure layer of measure_autonomy_gate.  No DB, no, _self_state(), test_bucket_boundary_timestamp(), test_percentile_and_median(), test_resolve_window_days_flag_explicit(), test_resolve_window_defaults_to_days_when_neither_flag_given(), test_resolve_window_hours_flag(), test_retention_caveat_fires_when_source_retention_is_shorter() (+13 more)
+
+### Community 258 - "Community 258"
+Cohesion: 0.10
+Nodes (16): OrionTissue, Any, ndarray, Path, Baseline-relative novelty using a rolling z-score of cosine distance.          n, Hybrid coherence:           - If an embedding is provided (spark_vector or featu, Main update cycle:           1. Update expectation (learning)           2. Evolv, Advance the tissue by one or more local-update steps.          v0 local rule: (+8 more)
+
+### Community 259 - "Community 259"
+Cohesion: 0.10
+Nodes (20): _artanh_clamped(), expmap0(), mobius_add(), poincare_distance(), poincare_distance_pairs(), project_to_ball(), Tensor, Exponential map at origin: tangent vector -> point on ball. (+12 more)
+
+### Community 260 - "Community 260"
+Cohesion: 0.13
+Nodes (28): _check(), HealthCheck, HealthMonitor, Settings, Severity, Edge-triggered health monitor: fires an orion-notify attention request only, run_checks(), health() (+20 more)
+
+### Community 261 - "Community 261"
+Cohesion: 0.09
+Nodes (37): agentAnswerHeadline(), applyAgentClaudePayloadFields(), applyHubModeSelection(), applyOrionUnifiedPayloadFields(), audienceChipLabel(), beginWsReadyWait(), confirmDownRouteOrProceed(), drawVisualizer() (+29 more)
+
+### Community 262 - "Community 262"
+Cohesion: 0.08
+Nodes (17): PadStore, Redis, _bucketize(), build_router(), _event_value(), _extract_dimension(), _frame_value(), _percentile() (+9 more)
+
+### Community 263 - "Community 263"
+Cohesion: 0.10
+Nodes (21): Auth, build_rdf_store_client(), FusekiRdfStoreClient, GenericSparqlRdfStoreClient, GraphDbRdfStoreClient, _httpx_auth(), _httpx_limits(), httpx_limits_for_settings() (+13 more)
+
+### Community 264 - "Community 264"
+Cohesion: 0.10
+Nodes (32): ChatResponsePayload, ExecutionStep, _resolve_llm_chat_max_tokens(), _resolve_llm_max_tokens(), _should_prepare_brain_reply_context(), _base_ctx(), dream_cycle + dream_synthesis must not fall through to default chat completion c, test_chat_general_final_step_uses_chat_route() (+24 more)
+
+### Community 265 - "Community 265"
+Cohesion: 0.10
+Nodes (27): Any, query_chroma_collection(), Query Chroma HTTP API for semantic hits (Postgres remains canonical)., _apply_recall_boost(), _embed_query(), _persist_recall_boost(), Any, datetime (+19 more)
+
+### Community 266 - "Community 266"
+Cohesion: 0.11
+Nodes (15): BiometricsInductionV1, EwmaBand, InductionMetricState, InductionTracker, Return the InductionTracker for (organ_id, metric_key)., BiometricsPipeline, NormalizationConfig, normalize_rate() (+7 more)
+
+### Community 267 - "Community 267"
+Cohesion: 0.12
+Nodes (15): HyperbolicGPTConfig, Any, Path, main(), parse_args(), Namespace, Block, HyperbolicCausalSelfAttention (+7 more)
+
+### Community 268 - "Community 268"
+Cohesion: 0.06
+Nodes (6): MonkeyPatch, test_build_chat_request_social_room_metadata_includes_redaction_posture(), test_hub_social_redaction_posture_defaults_to_strict(), test_hub_social_redaction_posture_payload_override_wins_over_env(), test_hub_social_redaction_posture_reads_env_override(), test_hub_social_redaction_posture_rejects_invalid_value()
+
+### Community 269 - "Community 269"
+Cohesion: 0.12
+Nodes (20): _binding(), FakeConn, FakeSparqlClient, _grounded_llm_content(), _make_bus(), Exception, fetch_drive_history_events is list-only (no detail join) -- see its     docstrin, Minimal in-process double for the asyncpg.Connection calls     repository.py::in (+12 more)
+
+### Community 270 - "Community 270"
+Cohesion: 0.13
+Nodes (33): build_attention_frame(), _attention_target_summary(), Structured summary of one FieldAttentionTargetV1 (2026-07-12, inner-state     un, End-to-end regression guard (2026-07-12, found by code review): the     tests ab, test_hardware_bypass_survives_real_build_self_state_pipeline(), _synthetic_field(), test_builder_selects_athena_and_orchestration(), test_dominant_channels_present() (+25 more)
+
+### Community 271 - "Community 271"
+Cohesion: 0.17
+Nodes (17): __getattr__(), AutonomyVerificationHarness, CheckResult, GraphDBClient, load_scenarios(), Any, Graph, Path (+9 more)
+
+### Community 272 - "Community 272"
+Cohesion: 0.11
+Nodes (32): extract_tool_metrics(), _iter_message_blocks(), load_fixture(), Any, Path, Deterministic scoring for the unified-turn introspection eval.  Experiment artif, Return (passed, failed) assertion id lists for one answer., Fold fcc_motor step frames (raw stream-json events) into navigation metrics. (+24 more)
+
+### Community 273 - "Community 273"
+Cohesion: 0.09
+Nodes (31): Turn N closure with surprise_unresolved exposes reducer-facing strain signal., test_turn_n_error_shifts_turn_n_plus_one_strain(), HarnessPostTurnClosureV1, _coalition_ref(), persist_turn_referent(), Any, datetime, Best-effort writer for substrate_turn_referent (reverie semantic lift v1). (+23 more)
+
+### Community 274 - "Community 274"
+Cohesion: 0.14
+Nodes (24): main(), SourceV1, Path, resolve_corpus_root(), apply_pending_patch(), list_pending_patches(), _parse_patch_file(), PendingPatch (+16 more)
+
+### Community 275 - "Community 275"
+Cohesion: 0.14
+Nodes (29): CuriositySuppressionV1, AttentionSignalDetector, Any, Protocol, attention_frame_enabled(), build_attention_frame(), _detect_signals(), _env_float() (+21 more)
+
+### Community 276 - "Community 276"
+Cohesion: 0.13
+Nodes (32): ContextExecVerbStepV1, _artifact_evidence_count(), artifact_repo_evidence_count(), _blocked_summary(), count_evidence(), evaluate_investigation_outcome(), explicit_fake_run_requested(), grounding_required() (+24 more)
+
+### Community 277 - "Community 277"
+Cohesion: 0.13
+Nodes (34): build_drive_audit_detail_sparql(), build_drive_audit_event_list_sparql(), build_fact_sheet(), _build_narrative_prompt(), _build_reflection_crystallization(), _call_llm_narrative(), DriveAuditEvent, DriveHistoryAggregationV1 (+26 more)
+
+### Community 278 - "Community 278"
+Cohesion: 0.08
+Nodes (35): appendMessage(), backfillLatestUserTurnIdForGraph(), buildAgentTraceOverviewNode(), buildAgentTraceRawPayloadsNode(), buildAgentTraceTimelineNode(), buildAgentTraceToolGroupsNode(), buildCodePre(), buildWorkflowMetaBadges() (+27 more)
+
+### Community 279 - "Community 279"
+Cohesion: 0.12
+Nodes (26): Config, BaseSettings, Settings, CoquiBackend, _ensure_torch_load_compat(), _is_xtts_model(), Path, Settings (+18 more)
+
+### Community 280 - "Community 280"
+Cohesion: 0.10
+Nodes (26): BaseTransport, Shared Mind contract constants (no runtime / IO)., MindRunArtifactV1, BaseModel, Bus + Postgres artifact for a completed Mind run (producer: orch, consumer: sql-, _clip(), _clip_str_or_none(), _envelope_correlation_id() (+18 more)
+
+### Community 281 - "Community 281"
+Cohesion: 0.12
+Nodes (23): build_context_pack_output_path(), _claim_included(), compile_context_pack_api_v1(), _dedupe_preserve_order(), ClaimV1, datetime, _relevant_decisions(), _slugify() (+15 more)
+
+### Community 282 - "Community 282"
+Cohesion: 0.11
+Nodes (27): BaseModel, Reasoning telemetry — per-call cognition metadata + windowed activity.  `Reasoni, Rolling-window aggregate of ReasoningCallV1, read by φ (spark-introspector)., ReasoningActivityV1, _decode_reasoning_call(), Any, Decode a bus message into a `ReasoningCallV1`, or None if unusable.      Defensi, Capped rolling window of `ReasoningCallV1`, materialized on demand.      The buf (+19 more)
+
+### Community 283 - "Community 283"
+Cohesion: 0.14
+Nodes (31): build_operator_summary(), _build_synthesis_prompt(), _default_title(), _deterministic_summary(), _extract_memory_id_tokens(), _extract_path_tokens(), _flatten_strings(), _ground_corpus() (+23 more)
+
+### Community 284 - "Community 284"
+Cohesion: 0.18
+Nodes (30): _attention_event(), Enum, str, _reset_hour_window(), ServicePhase, ServiceState, transition(), TransitionInput (+22 more)
+
+### Community 285 - "Community 285"
+Cohesion: 0.11
+Nodes (30): fetch_card_fragments(), fetch_card_fragments_guarded(), _neighbor_confidence_ok(), Any, Pool, Score memory cards for fusion via embedding cosine similarity (source=cards)., card_recall_text(), cosine_similarity() (+22 more)
+
+### Community 286 - "Community 286"
+Cohesion: 0.19
+Nodes (30): MemoryCardStatusChangeV1, _bus(), _clamp_limit(), _clamp_offset(), _http_if_missing_memory_schema(), _maybe_emit_card_for_crystallizer(), memory_add_edge(), memory_change_status() (+22 more)
+
+### Community 287 - "Community 287"
+Cohesion: 0.18
+Nodes (31): MindHandoffBriefV1, MindRunResultV1, build_synthetic_mind_http_failure_result(), merge_mind_brief_into_plan_metadata(), _mind_result_is_deterministic_contract_only(), _mind_result_quality(), _client_request(), _orch_prep() (+23 more)
+
+### Community 288 - "Community 288"
+Cohesion: 0.13
+Nodes (32): Path, All files backing one corpus path, oldest first: any rotated     siblings (match, resolve_rotated_corpus_files(), input_features_for_version(), _variance_gate(), _feature(), _inner_row(), CompletedProcess (+24 more)
+
+### Community 289 - "Community 289"
+Cohesion: 0.15
+Nodes (30): activateAtlasPanel(), apiFetch(), applyGraphFilters(), destroyCy(), escapeHtml(), fetchTraces(), fitAtlasGraph(), formatTs() (+22 more)
+
+### Community 290 - "Community 290"
+Cohesion: 0.07
+Nodes (21): anim(), btn, cam, clk, elConnStatus, elExplanation, elGearBtn, elInfoToggle (+13 more)
+
+### Community 291 - "Community 291"
+Cohesion: 0.12
+Nodes (27): append_github_mcp_harness_brief(), default_harness_workspace(), github_mcp_brief_lines(), github_mcp_repo_brief_line(), parse_github_remote_url(), Path, Resolve GitHub owner/repo for FCC MCP operator briefs., Append GitHub MCP operator lines when harness MCP is enabled. (+19 more)
+
+### Community 292 - "Community 292"
+Cohesion: 0.14
+Nodes (27): extract_suggest_draft_dict_from_cortex_payload(), extract_suggest_text_from_cortex_payload(), _openai_choice_message_text(), Any, Extract memory_graph_suggest draft JSON from CortexClientResult-shaped payloads., Parse a SuggestDraftV1 dict from a CortexClientResult-shaped payload., Return best-effort model text containing a suggest draft from a cortex payload., _service_block_text_candidates() (+19 more)
+
+### Community 293 - "Community 293"
+Cohesion: 0.15
+Nodes (28): Deterministic Phase 0 gate: skip recall on low-info social turns., recall_skip_gate(), RecallSkipGateResult, _coerce_novelty(), derive_retrieval_intent(), _has_contradiction_seed(), _has_entity_query(), _has_planning_like_priority() (+20 more)
+
+### Community 294 - "Community 294"
+Cohesion: 0.13
+Nodes (26): get_settings(), BaseSettings, Configuration for the Orion Hub service, loaded from environment variables., Settings, atom_neighborhood_api(), atom_provenance_api(), atom_temporal_path_api(), _ensure_sql_writer_on_path() (+18 more)
+
+### Community 295 - "Community 295"
+Cohesion: 0.15
+Nodes (23): _assert_get_path(), _assert_post_path(), _base_url(), fetch_health(), get_eligibility(), _get_json(), get_proposal(), list_proposals() (+15 more)
+
+### Community 296 - "Community 296"
+Cohesion: 0.12
+Nodes (30): build_response_format_for_method(), _chat_payload(), _default_base_url(), _default_model(), _evaluate_content(), extract_message_content(), has_forbidden_content(), main() (+22 more)
+
+### Community 297 - "Community 297"
+Cohesion: 0.14
+Nodes (24): _check(), HealthCheck, HealthMonitor, Settings, Severity, Edge-triggered health monitor: fires an orion-notify attention request only, run_checks(), health() (+16 more)
+
+### Community 298 - "Community 298"
+Cohesion: 0.10
+Nodes (15): datetime, Cache the latest town perception as a best-effort observability input., Return the age-gated embodied-perception grounding signal, or ``None``., Measurement-only (Phase 2, 2026-07-12): log each dimension's         deviation-f, SelfStateRuntimeWorker, _make_worker(), _perception(), Unit tests for the Orion embodiment perception grounding input.  Verifies the se (+7 more)
+
+### Community 299 - "Community 299"
+Cohesion: 0.18
+Nodes (31): project_interpretation_to_events(), _parse(), Council V2 scene interpretation parsing and projection tests (no live LLM/Redis/, Live failure mode: LLM put event_candidates fields under salient_observations., test_build_interpretation_prompt_caps_artifact_bloat(), test_debug_parse_mode_available_from_outcome(), test_empty_event_candidates_projection_returns_empty_payload(), test_event_candidates_populated_from_misplaced_salient_observations() (+23 more)
+
+### Community 300 - "Community 300"
+Cohesion: 0.12
+Nodes (21): get_db(), init_models(), generate_biometrics_model(), Returns a SQLAlchemy model with the table name defined in .env → TABLE_NAME, DigestRunDB, _check_topic_drift(), _digest_already_sent(), _drift_alert_loop() (+13 more)
+
+### Community 301 - "Community 301"
+Cohesion: 0.21
+Nodes (27): test_mind_run_request_roundtrip(), MindRunPolicyV1, MindRunRequestV1, run_mind(), FakeMindLLMClient, Deterministic JSON responses for unit tests., set_llm_client_override(), mind_run() (+19 more)
+
+### Community 302 - "Community 302"
+Cohesion: 0.14
+Nodes (26): _inner_proposal_artifact(), main(), _quality_pass(), _run(), assert_claim_clean(), assert_engine_runtime_debug(), assert_safety_posture(), blob_text() (+18 more)
+
+### Community 303 - "Community 303"
+Cohesion: 0.14
+Nodes (24): ActionSkillManifestEntry, ActionsSkillRegistry, _family_for_skill(), BaseModel, Path, Normalized orion-actions skill manifest derived from skills.* verb YAMLs., _risk_for_skill(), _bound_capability_service_payload() (+16 more)
+
+### Community 304 - "Community 304"
+Cohesion: 0.12
+Nodes (31): closeAgentTraceModal(), closeAutonomyConstitutionModal(), closeAutonomyDebugModal(), closeChatInputExpandModal(), closeChatStanceDebugModal(), closeCognitiveReviewModal(), closeMemoryDebugModal(), closeRecallCanaryModal() (+23 more)
+
+### Community 305 - "Community 305"
+Cohesion: 0.16
+Nodes (27): activateSubview(), apiFetch(), escapeHtml(), formatHistoryWhen(), formatMemoryApiError(), graphSetOut(), loadAll(), loadConsolidationDrafts() (+19 more)
+
+### Community 306 - "Community 306"
+Cohesion: 0.11
+Nodes (23): _epoch(), _extract_turn_effect_delta(), fetch_exact_fragments(), fetch_recent_fragments(), fetch_related_by_entities(), _filter_excluded_rows(), _is_current_turn_echo(), _memory_filter_clause() (+15 more)
+
+### Community 307 - "Community 307"
+Cohesion: 0.13
+Nodes (28): _build_chatturn_keyword_filter(), _build_graphtri_anchor_kind_sparql(), _build_graphtri_anchor_sparql(), _build_sparql_query(), _escape_sparql(), _extract_keywords(), _extract_labels(), fetch_graphtri_anchors() (+20 more)
+
+### Community 308 - "Community 308"
+Cohesion: 0.22
+Nodes (28): _candidate(), _FakeClient, _frame_with_candidates(), _make_worker(), _patch_bus_and_client(), _policy_frame(), _proposal(), Stand-in for ExecutionDispatchCortexClient -- returns canned results     or rais (+20 more)
+
+### Community 309 - "Community 309"
+Cohesion: 0.13
+Nodes (27): End-to-end eval for homeostatic drives (spec/plan Task 8).  Replays a synthetic, run(), _sig(), compute_tick_attribution(), dominant_drive_from_attribution(), primary_drive_for_tension_kind(), Sum magnitude × drive_impact weight per drive for THIS tick only., Structural map for tie-break; not digest keyword matching. (+19 more)
+
+### Community 310 - "Community 310"
+Cohesion: 0.12
+Nodes (20): load_channel_catalog(), Any, Path, ChannelCatalogEnforcer, Any, _assert_channel_wiring(), main(), Path (+12 more)
+
+### Community 311 - "Community 311"
+Cohesion: 0.18
+Nodes (26): cleanup_mcp_config(), _deep_replace(), McpPreflightError, _probe_convex_auth(), _probe_convex_version(), Any, Exception, Path (+18 more)
+
+### Community 312 - "Community 312"
+Cohesion: 0.19
+Nodes (27): _derive_fuseki_urls(), _fuseki_base(), _fuseki_dataset(), GraphBackendConfig, is_legacy_graphdb_enabled(), Central graph backend resolution (Fuseki / SPARQL vs explicit GraphDB legacy)., SPARQL query URL for autonomy reads (AUTONOMY_GRAPH_QUERY_URL wins, then RDF_STO, SPARQL update URL for autonomy writes (AUTONOMY_GRAPH_UPDATE_URL wins, then RDF_ (+19 more)
+
+### Community 313 - "Community 313"
+Cohesion: 0.16
+Nodes (27): build_turn_trace(), classify_log_line(), cmd_dump(), cmd_latest(), cmd_live(), _docker_logs(), extract_correlation_id(), _fetch_grammar_summaries() (+19 more)
+
+### Community 314 - "Community 314"
+Cohesion: 0.12
+Nodes (18): In-memory LRU cache of per-turn substrate effect snapshots., SubstrateEffectCache, SubstrateEffectSnapshot, Any, Run the appraiser end-to-end. Stash a snapshot in `cache`. Return summary., run_substrate_effect_pipeline(), _summary_dict(), _make_snapshot() (+10 more)
+
+### Community 315 - "Community 315"
+Cohesion: 0.22
+Nodes (29): asBool(), asList(), asObject(), calloutSeverityClass(), chip(), escapeHtml(), findPhaseTelemetry(), hasSourceTagLeakage() (+21 more)
+
+### Community 317 - "Community 317"
+Cohesion: 0.17
+Nodes (29): app_client(), _load_app(), MonkeyPatch, Path, Tests for proposal review API on orion-context-exec., _seed_store(), store_path(), test_context_exec_app_mounts_proposal_review_routes_when_enabled() (+21 more)
+
+### Community 318 - "Community 318"
+Cohesion: 0.22
+Nodes (14): BaseModelOutputWithPast, Cache, CausalLMOutputWithPast, FloatTensor, LongTensor, multinomial_num_samples_1(), _prepare_4d_causal_attention_mask_with_cache_position(), device (+6 more)
+
+### Community 319 - "Community 319"
+Cohesion: 0.12
+Nodes (25): DimensionRule, load_signal_drive_map(), Path, ValueError, Load + validate the structural signal->drive map (spec 2026-07-07 §3).  The map, Dimension rules for a signal_kind; empty list if unmapped., Resolve a concrete (signal_kind, dimension) to its rule, if any.          Exact, Parse and validate the YAML map. Raises SignalDriveMapError on any     structura (+17 more)
+
+### Community 320 - "Community 320"
+Cohesion: 0.11
+Nodes (19): main(), create_default_planner(), Path, Convenience helper to construct a SemanticPlanner using the standard     verbs/, ExecutionPlan, ExecutionStep, Any, Path (+11 more)
+
+### Community 321 - "Community 321"
+Cohesion: 0.11
+Nodes (20): build_identity_snapshot(), datetime, IdentitySnapshotV1, _snapshot_id(), IdentitySnapshotV1, BaseModel, BaseModel, SelfStatePredictionV1 (+12 more)
+
+### Community 322 - "Community 322"
+Cohesion: 0.15
+Nodes (24): _appraisal(), consolidation_memory_gate(), Any, _significance(), _atom_semantic_role(), fetch_grammar_evidence_for_window(), _parse_event_json(), Any (+16 more)
+
+### Community 323 - "Community 323"
+Cohesion: 0.16
+Nodes (26): _healthy(), Phase H eval harness — efficacy + resonance over synthetic corpora.  This is the, _runaway(), test_detector_fires_on_synthetic_runaway_loop(), test_detector_isolates_runaway_amid_healthy_noise(), test_detector_silent_on_healthy_loop(), detect_resonance(), datetime (+18 more)
+
+### Community 324 - "Community 324"
+Cohesion: 0.10
+Nodes (13): prediction_error_mutation_signals(), Map sustained self-model prediction error to governed mutation signals.      Ret, _self_state(), test_calm_self_model_emits_nothing(), test_single_weak_signal_is_below_threshold_but_sustained_error_drafts_a_proposal(), test_sustained_self_model_error_emits_only_supported_cognitive_signals(), scheduler_fixture(), _self_revision_self_state() (+5 more)
+
+### Community 325 - "Community 325"
+Cohesion: 0.09
+Nodes (29): orion-gpu-cluster-power service (compose), orion-gpu-cluster-power requirements.txt, compression_policy.v1.yaml (scopes, clustering, summarization policy), orion-graph-compression service (compose), GraphCompressionRegionMaterializedV1 (bus event schema), MutationPressureEvidenceV1 (bus event schema), orion-graph-compression service (README), orion-graph-compression requirements.txt (networkx/leidenalg/igraph) (+21 more)
+
+### Community 326 - "Community 326"
+Cohesion: 0.12
+Nodes (24): _convex_base_from_settings(), fetch_aitown_status(), Any, AI Town status probe for Hub API., aitown_status(), api_fcc_model_labels(), _maybe_render_mcp_config(), Path (+16 more)
+
+### Community 327 - "Community 327"
+Cohesion: 0.10
+Nodes (29): createRecallCanaryReviewArtifact(), hydrateRecallCanaryProfileSelect(), recordRecallCanaryJudgment(), refreshAutonomyConstitutionModal(), refreshAutonomyReadinessPanel(), refreshCognitiveReviewModal(), refreshCognitiveReviewPanelInto(), refreshRecallCanaryModal() (+21 more)
+
+### Community 328 - "Community 328"
+Cohesion: 0.15
+Nodes (27): AppState, ChatCompletionRequest, ChatMessage, create_chat_completion(), create_embeddings(), EmbeddingRequest, _ensure_model_path(), _format_messages() (+19 more)
+
+### Community 329 - "Community 329"
+Cohesion: 0.11
+Nodes (12): AttentionPublisher, Settings, lifespan(), FastAPI, MeshGuardianService, Settings, Connect to mesh Redis; retry through transient bring-up races (batched compose u, Config (+4 more)
+
+### Community 330 - "Community 330"
+Cohesion: 0.14
+Nodes (23): BaseModel, HTTP API request model (backwards compatibility)., RecallCompareRequestBody, RecallCompareResponseBody, RecallRequestBody, RecallResponseBody, _check_rdf_endpoint(), lifespan() (+15 more)
+
+### Community 331 - "Community 331"
+Cohesion: 0.12
+Nodes (25): _dim(), Regression for the live incident: resource_pressure.score pinned at 1.0     by t, Honest no-signal fallback: when resource_pressure carries no hardware     channe, dominant_evidence is an unvalidated list[str] crossing a service     boundary. A, A malformed >1.0 hardware value must be clamped, not passed through     raw -- a, Regression: dimension_trajectory["resource_pressure"] tracks the delta     of th, When there's no hardware evidence (fallback to the raw score), the     trajector, Regression: handle_semantic_upsert's tissue.update broadcast used to     compute (+17 more)
+
+### Community 332 - "Community 332"
+Cohesion: 0.09
+Nodes (17): BiometricsInput, BaseModel, ChatHistoryInput, BaseModel, DreamFragmentMeta, DreamInput, DreamMetrics, BaseModel (+9 more)
+
+### Community 333 - "Community 333"
+Cohesion: 0.21
+Nodes (21): BaseModel, datetime, Compiled reasoning-summary contracts for turn-time stance consumption (Phase 4)., ReasoningAutonomySummaryV1, ReasoningClaimDigestV1, ReasoningConceptDigestV1, ReasoningSparkSummaryV1, ReasoningSummaryDebugV1 (+13 more)
+
+### Community 334 - "Community 334"
+Cohesion: 0.15
+Nodes (25): evaluate_salience(), datetime, Pure salience gate for town embodiment episodes.  Decides whether a world event, Cross-event memory for the salience gate.      ``seen_players`` dedupes first-en, Decide whether ``event`` is worth journaling.      Salient cases:       - ``conv, SalienceEvaluation, SalienceState, _utcnow() (+17 more)
+
+### Community 335 - "Community 335"
+Cohesion: 0.19
+Nodes (22): _append_unique(), build_hub_direct_inspection_sections(), build_social_inspection_snapshot(), _candidate_bucket(), _compact_text(), _make_section(), Any, Materialize hub-local inspection sections when bridge turn-policy surfaces are a (+14 more)
+
+### Community 336 - "Community 336"
+Cohesion: 0.19
+Nodes (19): KgEdgeIngestItemV1, KgEdgeIngestV1, BaseModel, TopicFoundryDriftAlertV1, TopicFoundryEnrichCompleteV1, TopicFoundryRunCompleteV1, get_bus_publisher(), Any (+11 more)
+
+### Community 337 - "Community 337"
+Cohesion: 0.20
+Nodes (25): VisionEventCandidateV1, VisionSceneInterpretationV1, _activity_claim_has_caption_slop(), build_person_presence_fallback(), enforce_evidence_grounding(), ensure_grounded_person_presence(), _events_mention_person(), _filter_person_entity_names() (+17 more)
+
+### Community 338 - "Community 338"
+Cohesion: 0.15
+Nodes (8): LocalProfileStore, Any, datetime, Minimal JSON-backed store for latest profiles., True if an autonomy episode has already been composed for this world-pulse run., test_episode_run_processed_ignores_empty_run_id(), test_episode_run_processed_persists_across_instances(), test_episode_run_processed_roundtrip()
+
+### Community 339 - "Community 339"
+Cohesion: 0.10
+Nodes (15): health(), latest(), lifespan(), Any, FastAPI, get_settings(), BaseSettings, Settings (+7 more)
+
+### Community 340 - "Community 340"
+Cohesion: 0.16
+Nodes (9): main(), EquilibriumService, Any, datetime, Shared logic to calculate current distress/zen and build state list., Evaluate distress/zen and publish a baseline metacog trigger when due., _utcnow(), Bytes hash keys from redis must not duplicate str keys from heartbeats. (+1 more)
+
+### Community 341 - "Community 341"
+Cohesion: 0.10
+Nodes (17): HarnessStepRelay, Queue, Drop liveness bookkeeping for a finished correlation_id., True if a harness step for this correlation_id was observed within `within_sec`., Opportunistically evict liveness entries older than the TTL. Cheap: only scans, HarnessStepRelay fans harness.run.step events to per-correlation queues., Regression test: a burst of unique correlation_ids within a single sweep interva, A step should mark liveness for its correlation_id even with no registered UI qu (+9 more)
+
+### Community 343 - "Community 343"
+Cohesion: 0.28
+Nodes (27): _add_common_artifact(), _add_drive_dimension(), _add_evidence(), _add_lineage(), _add_literal(), _add_source_event_ref(), _add_tensions(), _artifact_type() (+19 more)
+
+### Community 344 - "Community 344"
+Cohesion: 0.12
+Nodes (26): apply_sql_file(), assert_grammar_event_indexes_valid(), bus_transport_trace_batch(), _clear_app_namespace(), delete_trace(), ensure_grammar_schema(), grammar_session_factory(), _is_executable_sql() (+18 more)
+
+### Community 345 - "Community 345"
+Cohesion: 0.19
+Nodes (14): CrystallizationConfidence, infer_confidence(), Deterministic confidence tier from evidence + recurrence. No LLM, no I/O.      R, CrystallizationEvidenceRefV1, Pool, Best-effort: grammar events may live in substrate tables or bus-only., resolve_crystallization_sources(), resolve_evidence_ref() (+6 more)
+
+### Community 346 - "Community 346"
+Cohesion: 0.20
+Nodes (26): EffectKind, _agent_chain_delegate_status(), _agent_chain_delegate_summary(), _agent_chain_failure_detail(), _agent_chain_failure_signals(), _agent_delegate_payload(), _agent_delegate_service_key(), _bound_capability_payload() (+18 more)
+
+### Community 347 - "Community 347"
+Cohesion: 0.09
+Nodes (25): HTMLResponse, Any, Server-side AI Town tab HTML fragments for Hub index render., render_aitown_tab_blocks(), Normalize HUB_AUTONOMY_SUBJECT_DISPLAY for Hub template injection (two|three)., Serves the main Hub UI (index.html)., resolve_hub_autonomy_subject_display(), root() (+17 more)
+
+### Community 348 - "Community 348"
+Cohesion: 0.10
+Nodes (22): Collapse Mirror split invariant (Strict/Juniper vs Metacog/Orion; rationale: metacog mirrors must never hit Juniper's triage/enrichment pipeline by default), Metacog/Spark Surgical Patch Tracker, Oríon identity + response-policy profile, actions.respond_to_juniper_collapse_mirror.v1 verb, CollapseMirrorEntryV1, should_route_to_triage(), main(), build_services() (+14 more)
+
+### Community 349 - "Community 349"
+Cohesion: 0.19
+Nodes (20): CollapseMirrorStore, create_entry_from_v2(), enrich_entry(), _get_store(), Any, Unchanged public entry point: no self_state, no behavior change for any     exis, score_causal_density(), score_causal_density_with_self_state() (+12 more)
+
+### Community 350 - "Community 350"
+Cohesion: 0.18
+Nodes (18): build_artifact_cap_select(), build_artifact_child_delete(), build_subject_age_delete(), cutoff_literal(), GraphRetentionPolicy, parse_retention_policies(), PruneGraphResult, Any (+10 more)
+
+### Community 351 - "Community 351"
+Cohesion: 0.19
+Nodes (21): BiometricsInductionMetricV1, BiometricsPayload, BiometricsSampleV1, BiometricsSummaryV1, BaseModel, _availability_summary(), build_biometrics_node_grammar_events(), _dt() (+13 more)
+
+### Community 352 - "Community 352"
+Cohesion: 0.12
+Nodes (24): detect_drive_tensions(), DriveTensionV1, One detected tension between two drives at a single tick.      `drive_a` is the, Detect pairwise inverse-coactivation tensions between drives.      Definition: a, _pairs(), Spec for cross-drive tension detection (`drive_tension.py`).  Tension definition, pressures[drive_b] == deactivate_threshold exactly -> NOT suppressed,     no ten, A hair below the threshold -> suppressed, tension fires. (+16 more)
+
+### Community 353 - "Community 353"
+Cohesion: 0.15
+Nodes (24): attention_broadcast_enabled(), broadcast_projection_from_frame(), build_substrate_attention_frame(), _current_history(), _node_salience(), Any, datetime, Continuous global broadcast — rung 3 of the self-modeling loop.  The workspace c (+16 more)
+
+### Community 354 - "Community 354"
+Cohesion: 0.19
+Nodes (26): _draft_ctx(), _load_executor_module(), _load_template(), Replay spec §2 section sizes (minus removed biometrics_json blob)., test_draft_ctx_overflow_after_cue_and_spark_trim(), test_draft_trims_biometrics_cue_before_ctx_overflow_fallback(), test_enrich_ctx_overflow_after_biometrics_trim(), test_enrich_prompt_uses_enrich_biometrics_cue() (+18 more)
+
+### Community 355 - "Community 355"
+Cohesion: 0.17
+Nodes (21): ProbeResult, run_probe(), load_roster(), ProbeConfig, ProbeMode, BaseModel, Enum, str (+13 more)
+
+### Community 356 - "Community 356"
+Cohesion: 0.20
+Nodes (25): CompletedProcess, Path, Tests for operator proposal CLI., _run_cli(), _seed_and_approve(), store_path(), test_dry_run_execute_creates_receipt_without_mutation(), test_dry_run_execute_does_not_change_memory() (+17 more)
+
+### Community 357 - "Community 357"
+Cohesion: 0.13
+Nodes (22): Environment, test_chat_general_prompt_contains_identity_and_behavior_rails(), test_chat_general_prompt_menu_topic_selection_disallows_fabricated_tools_and_links(), test_chat_quick_prompt_contains_recall_and_forbidden_rails(), test_social_room_prompt_includes_agreement_and_disagreement_grounding(), test_social_room_prompt_includes_compact_relational_memory_sections(), test_social_room_prompt_includes_social_skill_support_when_selected(), test_social_room_prompt_includes_style_and_ritual_grounding() (+14 more)
+
+### Community 358 - "Community 358"
+Cohesion: 0.09
+Nodes (26): datasets (PyPI dependency), fastapi (PyPI dependency), httpx (PyPI dependency), loguru (PyPI dependency), numpy (PyPI dependency), orjson (PyPI dependency), pydantic (PyPI dependency), PyYAML (PyPI dependency) (+18 more)
+
+### Community 359 - "Community 359"
+Cohesion: 0.17
+Nodes (23): autonomy_graph_backend_raw(), autonomy_graph_reads_explicitly_enabled(), _env_float(), is_quick_autonomy_graph_lane(), _parse_subjects_csv(), _parse_subqueries_csv(), Any, Autonomy graph read gate: Fuseki/SPARQL by default; explicit GraphDB legacy only (+15 more)
+
+### Community 360 - "Community 360"
+Cohesion: 0.16
+Nodes (24): SelectedFrontierMatterV1, Project the mode-agnostic self/attention subset of a Mind run.      Returns None, select_mind_coloring(), _frontier(), Eval: Mind coloring is mode-agnostic and never leaks task-control into the unifi, _request(), _result(), test_context_injection_does_not_touch_stance_authoring() (+16 more)
+
+### Community 361 - "Community 361"
+Cohesion: 0.18
+Nodes (18): BaseModel, SocialShakedownFixV1, SocialShakedownIssueV1, load_scenarios(), load_shakedown_pack(), Path, SocialRoomShakedownWorkflow, test_social_room_replay_failures_are_inspectable() (+10 more)
+
+### Community 362 - "Community 362"
+Cohesion: 0.19
+Nodes (20): _check(), HealthCheck, HealthMonitor, Settings, Severity, Edge-triggered health monitor: fires an orion-notify attention request only, run_checks(), _client_mock() (+12 more)
+
+### Community 363 - "Community 363"
+Cohesion: 0.18
+Nodes (24): _base_stance_for_shadow(), _build_exec_late_shadow_synthesis(), _env_float(), _inject_projection_debug(), _inline_projection_from_metadata(), install_chat_stance_shared_spine(), _label_for_projection_item(), _projection_debug_bundle() (+16 more)
+
+### Community 364 - "Community 364"
+Cohesion: 0.11
+Nodes (13): attachFormEditor(), dateInput(), debounce(), defaultCardProjectionDefaults(), el(), entityMultiSelect(), entityOptionLabel(), entitySelect() (+5 more)
+
+### Community 365 - "Community 365"
+Cohesion: 0.10
+Nodes (15): _MemoryGraphNoRetryClient, _MemoryGraphRetryClient, _ReasoningBrainClient, _ReasoningQuickClient, test_handle_chat_request_does_not_retry_memory_graph_with_explicit_llm_route(), test_handle_chat_request_exports_turn_effect_into_result_payload(), test_handle_chat_request_ingests_nested_executor_recall_pressure_events(), test_handle_chat_request_ingests_recall_debug_pressure_events() (+7 more)
+
+### Community 366 - "Community 366"
+Cohesion: 0.17
+Nodes (24): _count_unstable_spans(), _entropy_proxy(), extract_llm_uncertainty_from_native_completion(), extract_llm_uncertainty_from_openai_response(), native_completion_probs_to_logprob_content(), Any, Summary-only language-surface stability metrics from OpenAI logprobs., Normalize llama.cpp /completion prob shapes into OpenAI logprobs.content entries (+16 more)
+
+### Community 367 - "Community 367"
+Cohesion: 0.16
+Nodes (25): build_report(), collapse_reasons(), discover_encoder_dirs(), evaluate_run(), filter_eval_rows(), format_text_report(), headline_fit_stats(), HeadlineFitStats (+17 more)
+
+### Community 368 - "Community 368"
+Cohesion: 0.13
+Nodes (14): BeliefObserveResult, Any, Per-stream scene label habituation (observed → believed tier)., Enter votes: empty ring slots inherit last non-empty labels (flicker fix)., Exit votes: count only labels present in each raw observation., SceneBeliefRegistry, SceneBeliefTracker, test_belief_ignores_single_empty_observation() (+6 more)
+
+### Community 369 - "Community 369"
+Cohesion: 0.11
+Nodes (12): dict, LlamaForCausalLM, IntentionForCausalLM, _FakeBatch, _FakeTokenizer, LlamaConfig, test_bc_mode_is_deterministic_across_repeated_calls(), test_bc_mode_returns_three_tensors_with_valid_distribution() (+4 more)
+
+### Community 370 - "Community 370"
+Cohesion: 0.14
+Nodes (12): EmailTransport, _split_mime(), enrich_with_policy(), datetime, _build_email_transport(), _load_policy(), _parse_time(), Policy (+4 more)
+
+### Community 371 - "Community 371"
+Cohesion: 0.14
+Nodes (22): normalize_collapse_entry(), _load_executor_module(), main(), _load_executor_module(), test_change_type_dict_coercion(), test_fail_fast_skips_enrich_when_draft_fails(), test_metacog_entry_id_differs_from_trigger_corr(), test_metacog_source_service_is_stamped() (+14 more)
+
+### Community 372 - "Community 372"
+Cohesion: 0.15
+Nodes (19): BaseModel, datetime, Normalized signal contract for Spark., SparkSignalV1, _build_snapshot_payload(), chassis_cfg(), _cluster_trend(), _constraint_from_snapshot() (+11 more)
+
+### Community 373 - "Community 373"
+Cohesion: 0.20
+Nodes (23): main(), _parse_args(), Namespace, Pure: load + gate-check a corpus, return the full report dict. Never raises., run_diag(), features_version(), input_features(), _feature() (+15 more)
+
+### Community 374 - "Community 374"
+Cohesion: 0.17
+Nodes (23): _arousal_band(), _as_float(), _center_valence(), _clarity_band(), _format_value(), _overload_band(), Any, Compact, structured bins suitable for embedding in mirror telemetry hints.     ( (+15 more)
+
+### Community 375 - "Community 375"
+Cohesion: 0.08
+Nodes (3): test_execute_once_endpoint_is_single_cycle_operator_only_and_followup_default_off(), test_execute_once_followup_endpoint_keeps_followup_explicit(), test_self_experiments_trigger_daily_publishes_bus_event()
+
+### Community 376 - "Community 376"
+Cohesion: 0.12
+Nodes (13): _DreamWorkflowClient, _FakeCortexClient, _FakeWebSocket, The WS turn-completion path must mirror the HTTP path's best-effort     hub_pres, record_turn() is best-effort: if it raises, the WS chat turn must still     comp, test_handle_chat_request_marks_dream_workflow_as_metadata_only(), test_http_chat_path_exports_autonomy_payload_for_brain_lane(), test_http_chat_path_preserves_scheduled_workflow_policy() (+5 more)
+
+### Community 377 - "Community 377"
+Cohesion: 0.09
+Nodes (25): chromadb dependency (vector store backend), orion-vector-writer service, orion-vision-council docker-compose config, evidence_grounding.py choke point, evidence_transition.py choke point, orion-vision-council service, orion-vision-council dependencies (fastapi, redis, pydantic), orion-vision-edge live MJPEG/SSE debug UI (+17 more)
+
+### Community 378 - "Community 378"
+Cohesion: 0.14
+Nodes (20): _autonomy_state(), _mock_store(), Build a mock LocalProfileStore class whose instances' load_drive_state     retur, test_compare_drives_both_present_real_divergence(), test_compare_drives_corrupted_pressure_value_does_not_crash(), test_compare_drives_drive_state_missing(), test_load_autonomy_state_present(), test_load_drive_state_v1_missing_store_returns_none_no_error() (+12 more)
+
+### Community 379 - "Community 379"
+Cohesion: 0.14
+Nodes (12): CountVectorizer, capabilities(), VectorHostEmbeddingProvider, build_topic_engine(), _build_vectorizer(), _parse_topic_list(), _parse_zeroshot_list(), Any (+4 more)
+
+### Community 380 - "Bus Channels: Meta-Tags & KG Edge Ingest"
+Cohesion: 0.10
+Nodes (24): Channel "orion:actions:audit" (kind=event, schema=GenericPayloadV1) producers=[orion-actions] consumers=[none], Channel "orion:actions:manage:result:*" (kind=result, schema=WorkflowScheduleManageResponseV1) producers=[orion-actions] consumers=[orion-cortex-orch], Channel "orion:actions:manage:workflow.v1" (kind=request, schema=WorkflowScheduleManageRequestV1) producers=[orion-cortex-orch] consumers=[orion-actions], Channel "orion:actions:trigger:daily_metacog.v1" (kind=event, schema=GenericPayloadV1) producers=[orion-actions] consumers=[orion-actions], Channel "orion:actions:trigger:daily_pulse.v1" (kind=event, schema=GenericPayloadV1) producers=[orion-actions, orion-cortex-exec] consumers=[orion-actions], Channel "orion:actions:trigger:workflow.v1" (kind=event, schema=WorkflowDispatchRequestV1) producers=[orion-cortex-orch, orion-actions] consumers=[orion-actions], Channel "orion:agent-council:intake" (kind=request, schema=GenericPayloadV1) producers=[orion-hub, orion-cortex-exec] consumers=[orion-agent-council], Channel "orion:agent-council:reply*" (kind=result, schema=GenericPayloadV1) producers=[orion-agent-council] consumers=[orion-hub, orion-cortex-exec] (+16 more)
+
+### Community 381 - "Community 381"
+Cohesion: 0.11
+Nodes (24): concept_induction_pass Workflow, Concept Profile Repository Seam, orion-chat-memory Docker Compose Service, orion-chat-memory Python Dependencies, orion-collapse-mirror Docker Compose Service, Orion Collapse Mirror Service, orion-collapse-mirror Python Dependencies, orion-consolidation-runtime Docker Compose Service (+16 more)
+
+### Community 382 - "Community 382"
+Cohesion: 0.17
+Nodes (18): EpisodeSummaryV1, BaseModel, Episodic continuity contracts (self-modeling loop, rung 4).  An episode is a pro, derive_episode_id(), EpisodicConsolidationEvaluator, datetime, Episodic continuity — rung 4 of the self-modeling loop.  `GraphConsolidationEval, Windowed rollup alongside the region-based GraphConsolidationEvaluator. (+10 more)
+
+### Community 383 - "Community 383"
+Cohesion: 0.17
+Nodes (9): filter_temps(), BiometricsCollector, collect_biometrics(), _CpuTimes, _DiskStats, _NetStats, Any, collect_gpu_stats() (+1 more)
+
+### Community 384 - "Community 384"
+Cohesion: 0.16
+Nodes (15): ContextExecEventEmitter, Any, ContextExecMode, Publishes lifecycle events to orion:context_exec:event., TraceHit, _corr_in_payload(), _make_handle(), _matches_query() (+7 more)
+
+### Community 385 - "Community 385"
+Cohesion: 0.12
+Nodes (23): build_route_arbitration_grammar_events(), _dt(), _event(), _hash_id(), Any, datetime, Orch route-arbitration grammar event emitter.  Pure builder -- no I/O, no Redis,, Build the two-event shadow trace for one turn's route arbitration.      Pure fun (+15 more)
+
+### Community 386 - "Community 386"
+Cohesion: 0.12
+Nodes (24): forgeBadgeClass(), forgeHideSourceIngestError(), forgeRenderBadge(), forgeRenderClaimsList(), forgeRenderCompileResult(), forgeRenderCompileSpecCheckboxes(), forgeRenderReviewsList(), forgeRenderSearchResults() (+16 more)
+
+### Community 387 - "Community 387"
+Cohesion: 0.14
+Nodes (11): apply_rotary_pos_emb(), LlamaMergeMLP, LlamaRMSNorm, LlamaRotaryEmbedding, LlamaConfig, LlamaRMSNorm is equivalent to T5LayerNorm, dynamic RoPE layers should recompute `inv_freq` in the following situations:, Rotates half the hidden dims of the input. (+3 more)
+
+### Community 388 - "Community 388"
+Cohesion: 0.14
+Nodes (13): _fetch_rollups(), get_rollups(), lifespan(), FastAPI, Record, Any, datetime, StateJournaler (+5 more)
+
+### Community 389 - "Community 389"
+Cohesion: 0.13
+Nodes (21): _cfg(), _handle_biometrics(), _handle_get_latest(), _handle_snapshot(), health(), http_debug(), http_get_latest(), _hydrate_from_postgres() (+13 more)
+
+### Community 390 - "Community 390"
+Cohesion: 0.19
+Nodes (22): AttentionSchemaType, derive_attention_schema(), Derive (attention_schema_type, attention_dwell_ticks, attention_node_count)., _build_state(), _open_loop(), _projection(), Tests for attention schema derivation in the self-state build path., All attention schema type values are valid on SelfStateV1. (+14 more)
+
+### Community 391 - "Community 391"
+Cohesion: 0.18
+Nodes (20): cortex_exec_failure_detail(), extract_cortex_payload_text(), _openai_choice_message_text(), Any, Extract model text / JSON-bearing strings from Cortex PlanExecutionResult-shaped, Summarize why a cortex exec payload has no usable model text., Return best-effort model text from a cortex exec payload (may be JSON-ish prose), _service_block_text_candidates() (+12 more)
+
+### Community 392 - "Community 392"
+Cohesion: 0.14
+Nodes (19): cancel_fcc_turn(), SIGKILL a live FCC claude subprocess for this correlation_id, if any.      If th, apply_harness_run_cancel(), handle_cancel_bus_message(), Any, Validate cancel payload and kill the matching FCC subprocess if live., Subscribe to harness run cancel events and kill matching FCC motors., run_cancel_worker() (+11 more)
+
+### Community 393 - "Community 393"
+Cohesion: 0.20
+Nodes (21): _assert_write_targets_allowed(), build_source_delta_review(), _bullet_line_number(), find_possibly_affected_specs(), _infer_title(), ingest_source(), IngestSourceResult, parse_source_markdown() (+13 more)
+
+### Community 394 - "Community 394"
+Cohesion: 0.16
+Nodes (21): example_value_is_host_placeholder(), main(), parse_kv(), Path, Skip syncing template placeholders that must stay host-specific in local .env., Result of syncing one service's .env from its .env_example.      updated: keys a, should_sync_key(), sync_file() (+13 more)
+
+### Community 395 - "Community 395"
+Cohesion: 0.13
+Nodes (23): addNotification(), focusChatInput(), formatHubLocalTime(), handleAttentionAck(), handleChatMessageReceipt(), isAttentionNotification(), isChatMessageNotification(), isNotificationTrayItem() (+15 more)
+
+### Community 396 - "Community 396"
+Cohesion: 0.14
+Nodes (20): _extract_keywords(), fetch_graph_compression_fragments(), _fetch_summary_from_fuseki(), _get_engine(), Any, Query Postgres artifact index, rank by salience + keyword relevance,     fetch s, Simple salience + keyword hit scoring., _score_artifact() (+12 more)
+
+### Community 397 - "Community 397"
+Cohesion: 0.13
+Nodes (21): _database_url(), _get_engine(), load_recent_chain_theme_events(), load_recent_resonance_alerts(), persist_compaction_request(), persist_resonance_alert(), persist_reverie_chain(), persist_reverie_thought() (+13 more)
+
+### Community 398 - "Community 398"
+Cohesion: 0.21
+Nodes (11): stream_key_from_window(), InterpretationParseOutcome, CouncilService, lifespan(), FastAPI, test_finalize_drops_youtube_activity_without_hard_person(), test_finalize_host_fallback_on_parse_failure(), test_finalize_injects_person_when_llm_omits_despite_hard_labels() (+3 more)
+
+### Community 399 - "Community 399"
+Cohesion: 0.17
+Nodes (19): gap_terms_from_signals(), Deterministic term-overlap salience scorer for readonly-fetch articles.  Narrow, Public term tokenizer (lowercase alphanumeric). Reused by producers that     nee, Union of tokens from `section:` focal refs across world_coverage_gap signals., Fraction of gap terms present in the article text, clamped to [0, 1]., score_article_salience(), _tokenize(), tokenize_terms() (+11 more)
+
+### Community 400 - "Community 400"
+Cohesion: 0.23
+Nodes (20): _engine_for(), load_expectations_for_motif(), _load_latest_consolidation_frame(), load_latest_tensor_slices(), load_recent_motifs(), load_schema_candidates(), _parse_json(), Engine (+12 more)
+
+### Community 401 - "Community 401"
+Cohesion: 0.25
+Nodes (20): _match(), _nearest(), _others(), _pos(), Any, resolve_destination(), _resolve_target(), ResolveResult (+12 more)
+
+### Community 402 - "Community 402"
+Cohesion: 0.21
+Nodes (21): RdfWriteResult, _strip_credentials(), _append_deadletter(), _evict_dedupe_cache(), _execute_write_job(), handle_envelope(), _handle_write_final_failure(), _inflight_slot() (+13 more)
+
+### Community 403 - "Community 403"
+Cohesion: 0.13
+Nodes (22): enableMindModalFocusTrap(), escapeHtml(), fetchMindRunDetail(), formatMindRunsApiError(), formatMindTs(), getMindModalTabbables(), mindJsonPrettyObject(), mindRequestOverviewHtml() (+14 more)
+
+### Community 404 - "Community 404"
+Cohesion: 0.26
+Nodes (21): _cleanup_hub_path_pollution(), hub_client(), MonkeyPatch, TestClient, Hub proposal review client, routes, and review actions., Prevent hub reload from shadowing orion-context-exec `app` in later tests., _reload_hub_modules(), test_hub_pending_decisions_shows_denver_memory_correction() (+13 more)
+
+### Community 405 - "Community 405"
+Cohesion: 0.13
+Nodes (6): configured_routes(), MonkeyPatch, TestClient, test_resolve_anthropic_route_falls_back_when_model_missing(), test_resolve_anthropic_route_missing_returns_error(), TestAnthropicPassthroughHTTP
+
+### Community 406 - "Community 406"
+Cohesion: 0.13
+Nodes (14): MindRunBudget, Wall-clock budget for Cortex-governed Mind LLM phases., Tracks remaining wall time for a single MindRun and caps per-phase timeouts., _mind_prep(), MonkeyPatch, Wall-clock budget enforcement (loop_budget_exceeded)., Simulate snapshot phase taking longer than policy allows., Regression for fix/mind-enrichment-wall-budget: a 12s wall cannot fit even a (+6 more)
+
+### Community 407 - "Community 407"
+Cohesion: 0.11
+Nodes (14): configure_tracing(), _DropSpanExporter, OpenTelemetry tracer setup for the signal gateway (spec §5 gateway instrumentati, Swallows finished spans (no backend); span context IDs are still real., Install a TracerProvider. If ``otlp_endpoint`` is set, export spans there; else, health(), lifespan(), Any (+6 more)
+
+### Community 408 - "Community 408"
+Cohesion: 0.22
+Nodes (20): _elapsed_secs(), enqueue_enrichment(), _enrich_segment(), _extract_evidence(), _finalize_enrichment(), _generate_edges(), _heuristic_enrich(), _llm_enrich() (+12 more)
+
+### Community 409 - "Community 409"
+Cohesion: 0.14
+Nodes (19): _make_service(), Path, Real syntax from services/orion-hub/docker-compose.yml -- the plain string-list, A sidecar service's own environment: keys must never leak into the checked     s, Regression test: the actual orion-recall docker-compose.yml, checked against the, docker-compose also supports `environment:` as a mapping (KEY: value) instead, test_compose_env_file_directive_detected_extended_mapping_form(), test_compose_env_file_directive_detected_inline() (+11 more)
+
+### Community 410 - "Community 410"
+Cohesion: 0.10
+Nodes (21): Turn Visibility Design Spec (2026-07-11), scripts/trace_unified_turn.py (regex hop detector), TurnHopV1 schema (proposed), Clean git and worktree rules (§2): start with git status/branch check, classify dirt before mixing, prefer a separate worktree for parallel subagent work — stated as prose policy, not an enforced mechanism, /brainstorming command (sentience-development ideation), Completion status (§19): every task ends in exactly one of DONE, DONE_WITH_CONCERNS, BLOCKED, or NEEDS_CONTEXT — never 'partially done', Env/config/settings contract (§7): env parity is non-negotiable — any add/remove/rename of an env key must update .env_example, local .env, settings.py, docker-compose.yml, requirements.txt, and README in the same changeset, via scripts/sync_local_env_from_example.py, Event substrate first: grow from events -> schema -> trace -> reducer -> projection -> eval -> UI, not from a hand-authored mind-palace ontology with no runtime proof (+13 more)
+
+### Community 411 - "Community 411"
+Cohesion: 0.14
+Nodes (11): Client, PowerStatus, BaseModel, Parsed snapshot of UPS state from SNMP., NISUPSClient, Reads APC UPS status from a local or remote apcupsd NIS server (TCP 3551)., Connects to apcupsd and requests the 'status' dump., Async wrapper to fetch and parse status.          (We keep it async to match the (+3 more)
+
+### Community 412 - "Community 412"
+Cohesion: 0.14
+Nodes (8): DetectorSpec, FaceDetector, build_detectors(), MotionDetector, PresenceDetector, ndarray, Run detection on BGR frame.         Returns list of (x, y, w, h, label, score)., YoloDetector
+
+### Community 413 - "Community 413"
+Cohesion: 0.12
+Nodes (6): LlamaPreTrainedModel, IntentionModel, IntentionModel_v1, IntentionModel_v1a, IntentionModel_v1p, Transformer decoder consisting of *config.num_hidden_layers* layers. Each layer
+
+### Community 414 - "Community 414"
+Cohesion: 0.22
+Nodes (18): _db_url(), _get_engine(), load_autonomy_state_v2(), Postgres-backed persistence for the latest AutonomyStateV2 per subject.  Closes, Load the most recently persisted AutonomyStateV2 for a subject.      Returns Non, Upsert the latest AutonomyStateV2 for a subject.      No-ops when no DSN is conf, save_autonomy_state_v2(), _make_db() (+10 more)
+
+### Community 415 - "Community 415"
+Cohesion: 0.17
+Nodes (16): TensionEventV1, Bound the tension stream: per-source cap, dedup, storm safety (spec §5).  Even w, Source identity: kind + the set of drives it pushes. Two tensions with the     s, Return the subset of ``candidates`` allowed through, updating windows., _signature(), TensionRateLimiter, TensionEventV1, Task 5: rate-limit / dedup / bounded state. (+8 more)
+
+### Community 416 - "Community 416"
+Cohesion: 0.29
+Nodes (14): configure_parity_evidence_store(), ConsumerParityEvidence, get_parity_evidence_snapshot(), ParityEvidenceStore, ParityReadinessThresholds, Any, record_parity_evidence(), reset_parity_evidence_store() (+6 more)
+
+### Community 417 - "Community 417"
+Cohesion: 0.19
+Nodes (16): BaseSettings, Settings, MonkeyPatch, test_factory_default_graphdb_requires_url(), test_factory_fuseki_does_not_require_graphdb_url(), test_factory_generic_builds_generic_client(), test_factory_graphdb_builds_graphdb_when_url_present(), test_factory_rdf4j_aliases_generic() (+8 more)
+
+### Community 418 - "Community 418"
+Cohesion: 0.22
+Nodes (15): generate(), main(), parse_args(), Namespace, entropy_floor_loss(), fisher_trace_proxy(), ManifoldBatchMetrics, margin_gap_loss() (+7 more)
+
+### Community 419 - "Community 419"
+Cohesion: 0.15
+Nodes (15): ProxyGet, ProxyPost, attention_escalation_loop(), _build_escalation_request(), _hub_link(), _parse_ts(), Any, datetime (+7 more)
+
+### Community 420 - "Community 420"
+Cohesion: 0.24
+Nodes (20): buildDimRail(), DIMENSIONS, drawBrain(), drawEkg(), drawSpotlight(), _get(), goLive(), init() (+12 more)
+
+### Community 421 - "Community 421"
+Cohesion: 0.21
+Nodes (20): _asList(), _clearError(), _esc(), _fmt(), _gateColor(), _get(), _loadAll(), _post() (+12 more)
+
+### Community 422 - "Community 422"
+Cohesion: 0.16
+Nodes (11): apply_structured_output_to_payload(), build_response_format(), Any, Build llama.cpp / OpenAI-compatible response_format payloads from a named method, Mutate opts in place for structured output + thinking policy.     Returns (opts,, Pick method: options.structured_output_method → env → none., Return response_format dict for the given method, or None for none/unknown., resolve_structured_output_method() (+3 more)
+
+### Community 423 - "Community 423"
+Cohesion: 0.28
+Nodes (20): _claims_list_empty(), _coerce_array_claim_item(), _coerce_evidence_refs(), _coerce_semantic_claim_item(), coerce_semantic_llm_root(), _float_field(), _has_current_claim_shape(), _is_bare_semantic_claim_root() (+12 more)
+
+### Community 424 - "Community 424"
+Cohesion: 0.15
+Nodes (17): duplicate_orion_reply_assistant(), extract_orion_assistant_from_snippet(), materially_same_text(), normalize_compare_text(), OrionDigestDeduper, Collapse repeated Orion assistant lines in recall snippets (vector → same catchp, Second line of defense: render skips duplicate assistant bodies even if fusion l, If snippet matches transcript-shaped vector rows, return a compact user-only lin (+9 more)
+
+### Community 425 - "Community 425"
+Cohesion: 0.10
+Nodes (21): biometrics_pressure organ contract (organ.contract.v1), orion-substrate-organs service (event-native organ contracts), orion-substrate-runtime compose config, brain-frame live stimulus-response smoke test (acceptance section 6), orion-substrate-runtime service (biometrics closed loop, grammar reducers, Layers 1-5), orion-substrate-runtime dependencies (fastapi/sqlalchemy/psycopg2/redis), orion-substrate-telemetry compose config, orion-substrate-telemetry dependencies (fastapi/asyncpg/redis) (+13 more)
+
+### Community 426 - "Community 426"
+Cohesion: 0.19
+Nodes (18): DatasetPreviewRequest, DatasetPreviewResponse, preview_dataset_endpoint(), apply_overrides(), build_conversations(), Conversation, OverrideRecord, _parse_ts() (+10 more)
+
+### Community 427 - "Community 427"
+Cohesion: 0.12
+Nodes (20): cortex-exec remediation entry, cortex-gateway remediation entry, cortex-orch remediation entry, equilibrium-service remediation entry (auto_remediate: false), landing-pad remediation entry, config/mesh_remediation_roster.yaml (auto-remediation roster), notify remediation entry (auto_remediate: false), recall remediation entry (+12 more)
+
+### Community 428 - "Community 428"
+Cohesion: 0.24
+Nodes (12): Normalization utilities for Orion payloads., _as_mapping(), _coerce_datetime(), _coerce_telemetry_timestamp(), normalize_spark(), normalize_spark_state_snapshot(), normalize_spark_telemetry(), Any (+4 more)
+
+### Community 429 - "Community 429"
+Cohesion: 0.15
+Nodes (18): action_usefulness_rate(), pressure_discharge_rate(), Phase H — efficacy metrics for the reverie/dream weave.  Pure, deterministic red, Fraction of chains where post-chain pressure fell below pre-chain pressure., Fraction of reverie-originated action outcomes judged useful (FeedbackFrameV1)., Before/after recall metrics around a compaction., Deterministic before/after recall reduction. Negative deltas are wins:     lower, recall_delta() (+10 more)
+
+### Community 430 - "Community 430"
+Cohesion: 0.14
+Nodes (20): Orion (AI Town persona card), orion-biometrics service, fork_rpc_client (orion.core.bus.rpc_fork), GrammarEventV1 (bus substrate trace schema), bus-core (Redis broker container), bus-exporter (Prometheus redis_exporter), bus-observer (grammar trace sidecar), bus_transport_reducer (deferred Layer 3 reducer) (+12 more)
+
+### Community 431 - "Community 431"
+Cohesion: 0.14
+Nodes (8): _Conn, _Engine, _Result, test_latest_salience_for_theme_dict_features(), test_latest_salience_for_theme_no_row(), test_latest_salience_for_theme_string_features(), test_load_pending_loops_falls_back_to_theme_key(), test_load_pending_loops_filters_and_builds()
+
+### Community 432 - "Community 432"
+Cohesion: 0.24
+Nodes (6): BiometricsCache, _clamp01(), _isoformat(), Any, datetime, _utcnow()
+
+### Community 433 - "Community 433"
+Cohesion: 0.17
+Nodes (14): attach(), coalesceChatSuggestDraft(), coalesceMemoryGraphSuggestEnvelope(), contentLooksLikeGatewayFailureBlurb(), debounce(), draftToCyElements(), emptySuggestDraft(), emptyValidSuggestDraft() (+6 more)
+
+### Community 434 - "Community 434"
+Cohesion: 0.14
+Nodes (15): _Dim, _FakeSelfState, A malformed/negative thinking_tokens_sum must degrade to a truthful     zero, no, bool is a subclass of int in Python; a JSON `true` for     thinking_tokens_sum m, Regression: the _recall_gate_fired/_active_trajectory_runs factoring     must no, scripts/fit_phi_encoder.py dynamically loads this same inner_state.py     module, _sample_self_state(), test_fit_phi_encoder_resolves_seed_v4_names() (+7 more)
+
+### Community 435 - "Community 435"
+Cohesion: 0.22
+Nodes (18): _attention_frame(), _dim(), _dispatch_frame(), _feedback_frame(), _motif(), _policy_frame(), _proposal_frame(), _self_state() (+10 more)
+
+### Community 436 - "Community 436"
+Cohesion: 0.11
+Nodes (19): Clean git and worktree rules (§2): start with git status/branch check, classify dirt before mixing, prefer a separate worktree for parallel subagent work — stated as prose policy, not an enforced mechanism, Completion status (§19): every task ends in exactly one of DONE, DONE_WITH_CONCERNS, BLOCKED, or NEEDS_CONTEXT — never 'partially done', Deterministic gates over repeated yelling: if Juniper has to repeat a rule twice, turn it into a script/test/check/hook/make target instead of a louder prompt, Env/config/settings contract (§7): env parity is non-negotiable — any add/remove/rename of an env key must update .env_example, local .env, settings.py, docker-compose.yml, requirements.txt, and README in the same changeset, via scripts/sync_local_env_from_example.py, Event substrate first: grow from events -> schema -> trace -> reducer -> projection -> eval -> UI, not from a hand-authored mind-palace ontology with no runtime proof, Follow-through is part of the feature: a patch isn't done until the branch is clean, tests/evals pass, review is fixed, env is synced, Docker checks run, restart commands are listed, the branch is pushed, and the PR report exists, No empty-shell cognition: do not ship cognition-shaped output with no substance — empty semantic projections, placeholder memory cards, fallback text as generated cognition, raw_len=0 treated as success, stale reducer cursors are all invalid success states requiring inspectable evidence, No keyword cathedrals: labels/enums/taxonomies/ontology nodes without a schema contract, producer, consumer, reducer, UI surface, metric, test, eval, or live smoke attached in the same patch are banned as junk that names the world without changing runtime behavior (+11 more)
+
+### Community 437 - "Community 437"
+Cohesion: 0.15
+Nodes (15): CandidateCard, extract_candidates(), fingerprint(), fingerprint_from_candidate(), Lightweight Stage-1 extraction candidate (not yet persisted)., Same normalization as fingerprint(MemoryCardV1) for summary + anchor_class., _coerce_turn(), _get_memory_pool() (+7 more)
+
+### Community 438 - "Community 438"
+Cohesion: 0.20
+Nodes (16): Deterministic discussion-window helpers over persisted chat turns., _ensure_utc(), fetch_discussion_window(), _format_transcript(), Any, datetime, Read bounded discussion windows from chat_history_log (Postgres via SQLAlchemy)., Rows must be sorted ascending by created_at.     Keep the most recent contiguous (+8 more)
+
+### Community 439 - "Community 439"
+Cohesion: 0.20
+Nodes (17): _active_conversation(), build_perception(), _facing_partner(), Any, True iff Orion's facing vector aligns with the direction to the partner.      Co, Shape the conversation Orion is a member of (invited/walkingOver/participating)., test_build_perception_computes_distances_and_nearby(), test_build_perception_exposes_own_facing_and_pathfinding() (+9 more)
+
+### Community 440 - "Community 440"
+Cohesion: 0.32
+Nodes (16): Orion Mind shared contracts (types only; runtime lives in services/orion-mind)., ActiveCognitiveFrontierV1, MindStanceHandoffV1, test_hash_snapshot_inputs_stable(), test_mind_run_result_roundtrip(), test_universe_snapshot_facets(), test_validate_merged_stance_brief_accepts_minimal(), MindControlDecisionV1 (+8 more)
+
+### Community 441 - "Community 441"
+Cohesion: 0.21
+Nodes (17): CuriosityCandidateActionV1, _apply_voluntary_attention(), Layer top-down goal bias onto the bottom-up frame (spec Step 2).      Default-of, Default OFF (proposal mode): voluntary attention is inert until enabled., top_down_enabled(), _frame(), _goal(), _loop() (+9 more)
+
+### Community 442 - "Community 442"
+Cohesion: 0.20
+Nodes (14): EquilibriumServiceState, EquilibriumSnapshotV1, datetime, Current service state used by the Equilibrium snapshot publisher., Aggregate view of system equilibrium and distress., _enqueue_snapshot(), equilibrium_status_for_service(), Queue (+6 more)
+
+### Community 443 - "Community 443"
+Cohesion: 0.15
+Nodes (11): EmailWorldPulseRenderV1, publish_email(), publish_email_preview(), BaseSettings, Settings, notify_client(), test_curiosity_defaults_off(), test_curiosity_env_override() (+3 more)
+
+### Community 444 - "Community 444"
+Cohesion: 0.20
+Nodes (16): anchor_strategy_for_subject(), _artifact_id(), build_identity_snapshot(), entity_id_for_subject(), infer_external_subject(), _payload_dict(), Any, IdentitySnapshotV1 (+8 more)
+
+### Community 445 - "Community 445"
+Cohesion: 0.22
+Nodes (17): apply_moc(), _diag(), _head_values(), _moc_forward(), model_geometry_diagnostics(), Tensor, Turn an existing HyperbolicGPT into a per-head MoC variant in-place., _raw() (+9 more)
+
+### Community 446 - "Community 446"
+Cohesion: 0.20
+Nodes (18): _project_reverie_glimpse(), Projection helper: surface the latest fresh, non-hollow reverie thought.      Re, _fresh_payload(), Guard the call-site contract: chat_reverie_glimpse, when set, is exactly     the, is_hollow() rejects absent_coalition even if the stored `hollow` bool     says F, is_hollow() rejects evidence outside the coalition's grounding ids, even     if, A payload that no longer validates as SpontaneousThoughtV1 at all     (e.g. sche, test_ctx_key_wiring_only_sets_no_other_fields() (+10 more)
+
+### Community 447 - "Community 447"
+Cohesion: 0.17
+Nodes (7): EndogenousRuntimeSqlReader, datetime, SqlReadResult, _Conn, _Engine, test_calibration_reader_profile_history_query(), test_runtime_reader_filters_and_limit_are_bounded()
+
+### Community 448 - "Community 448"
+Cohesion: 0.16
+Nodes (17): _build_memory_digest_from_fragments(), build_personality_summary(), ChatTurnPayload, ChatTurnResult, conversation_front_worker(), handle_chat_turn(), Any, BaseModel (+9 more)
+
+### Community 449 - "Community 449"
+Cohesion: 0.20
+Nodes (16): wake_today(), fetch_dream_row_from_sql(), Any, date, Load latest dream row from Postgres for wake readout (canonical path)., build_readout(), _default_readout(), _dream_path_for_date() (+8 more)
+
+### Community 450 - "Community 450"
+Cohesion: 0.20
+Nodes (16): _fake_engine_with_joined_rows(), _fake_engine_with_state(), _legacy_self_state_payload_with_policy_pressure(), A fake engine that dispatches on which table the query text targets,     so both, Regression test for the same bug class as the 2026-07-12 schema-drift     incide, Self-state exists but its source field-state row is gone (e.g. pruned) --     th, _sample_field_state(), _sample_self_state() (+8 more)
+
+### Community 451 - "Community 451"
+Cohesion: 0.19
+Nodes (17): _first_route_key(), LlmLaneRouteDecision, _match_served_by(), _norm_lane(), Any, Side-effect free: picks a route-table key for the LLM gateway HTTP hop.      Cha, resolve_llm_lane_route(), _resolve() (+9 more)
+
+### Community 452 - "Community 452"
+Cohesion: 0.15
+Nodes (5): SparkContractMetrics, _legacy_action(), FakeLogger, TestSparkContractMetrics, TestSqlWriterLegacyMode
+
+### Community 453 - "Community 453"
+Cohesion: 0.25
+Nodes (15): disk_usage_pct(), get_cached_pressure_state(), log_receipt_pressure(), maybe_run_emergency_prune(), measure_pressure_state(), Engine, Settings, refresh_pressure_cache() (+7 more)
+
+### Community 454 - "Community 454"
+Cohesion: 0.16
+Nodes (9): FakeConn, _NullAsyncCtx, Minimal in-process double for the handful of asyncpg.Connection calls this     s, _row(), _seeded_rows(), test_digest_no_pending_rows_reports_cleanly(), test_digest_reflection_crystallization_shape(), test_digest_report_counts_and_reflection_creation() (+1 more)
+
+### Community 455 - "Community 455"
+Cohesion: 0.11
+Nodes (18): agent-trace.js (plain-text step consumer), api_routes.py (GET /api/cognition/trace/{correlation_id}), Idea 4: Click-through payload cards, cognition_trace_cache.py, CognitionTracePayload schema, HarnessRunStepV1 schema, HarnessStepRelay (harness_step_relay.py), orion:cognition:trace bus channel (+10 more)
+
+### Community 456 - "Community 456"
+Cohesion: 0.18
+Nodes (16): consecutive_tool_count(), plan_action_saturated(), Pure guard logic for agent-chain runtime (Pass 2 testability)., Second or later plan_action in the same chain should become a delivery verb., Count consecutive calls of `candidate` from the tail of tools_called., True when a new plan_action would exceed max_consecutive repeated plan_action ca, Triage is disallowed once any prior delegated step exists., repeated_plan_action_needs_delivery() (+8 more)
+
+### Community 457 - "Community 457"
+Cohesion: 0.21
+Nodes (14): apply_causal_density_to_entry(), _coerce_self_state(), _condition_severity_rank(), _label_for_score(), _phi_evidence_score(), Computed phi evidence score in [0, 1], or None if no self_state available., Apply causal density scoring in-memory (no collapse store required)., _score_from_values() (+6 more)
+
+### Community 458 - "Community 458"
+Cohesion: 0.27
+Nodes (16): ConsolidationGateResult, _appraisal_from_turn(), build_crystallization_from_window(), _evidence_note_for_turn(), _kind_for_gate(), _planning_and_retrieval_for_kind(), Any, Derive content-grounded planning_effects/retrieval_affordances for a kind. (+8 more)
+
+### Community 459 - "Community 459"
+Cohesion: 0.14
+Nodes (10): main(), datetime, _query_backlog(), FakeConn, datetime, test_fresh_backlog_within_threshold_is_healthy(), test_main_exits_one_when_backlog_stale(), test_main_exits_zero_when_backlog_fresh() (+2 more)
+
+### Community 460 - "Community 460"
+Cohesion: 0.24
+Nodes (16): _bounded_unique_tensions(), build_autonomy_slice(), _pressure_trend(), Any, Cheap before/after pressure comparison from ctx['chat_autonomy_movement_debug']., Assemble the compact slice from the V2 reducer output already in ctx.      Retur, _delta(), _state_v2() (+8 more)
+
+### Community 461 - "Community 461"
+Cohesion: 0.24
+Nodes (16): _coerce_allow_chat_fallback(), Any, Return True/False if caller set allow_chat_fallback on options or ctx; else None, Decide LLM lane metadata for gateway Phase 3 routing (orthogonal to route keys l, resolve_llm_lane_for_step(), Mirror the finalize_reflect context (top-level llm_lane) as cortex-exec merges i, _settings(), test_chat_general_chat_lane() (+8 more)
+
+### Community 462 - "Community 462"
+Cohesion: 0.26
+Nodes (13): ApiClient, BattleSummary, build_parser(), _fmt_row(), load_battle_fixture(), _load_operator_token(), main(), print_case_table() (+5 more)
+
+### Community 463 - "Community 463"
+Cohesion: 0.14
+Nodes (18): applyHashToTab(), buildMemoryGraphSuggestUserContent(), closeMemoryGraphBridgeModal(), collectConversationTurnsUpTo(), ensureMemoryGraphBridgeDraftViz(), ensureOrganSignalsGraph(), flushMemoryGraphBridgeDraftForm(), formatMemoryGraphBridgeDiagnosticsBlock() (+10 more)
+
+### Community 464 - "Community 464"
+Cohesion: 0.19
+Nodes (13): cadenceSummary(), healthChipClass(), normalizeAnalytics(), normalizeEventItem(), normalizeHistoryItem(), normalizeRecentOutcomes(), normalizeSchedule(), oneOf() (+5 more)
+
+### Community 465 - "Community 465"
+Cohesion: 0.21
+Nodes (16): buildConceptInductionSections(), buildWorkflowDetailRows(), canRunAgain(), extractWorkflow(), getWorkflowBadgeLabel(), getWorkflowStatusLabel(), normalizeConceptInductionDetails(), normalizeStatus() (+8 more)
+
+### Community 466 - "Community 466"
+Cohesion: 0.17
+Nodes (11): _FakeProc, _FakeStream, MonkeyPatch, test_build_subprocess_env_enables_tool_search(), test_build_subprocess_env_omits_autocompact_when_zero(), test_build_subprocess_env_preserves_tool_search_override(), test_build_subprocess_env_sets_claude_context_limits(), test_cancel_turn_sigterms_active() (+3 more)
+
+### Community 467 - "Community 467"
+Cohesion: 0.24
+Nodes (13): _assert_valid_suggest_draft_shape(), _node_coalesce(), _parse_draft_text(), Any, Regression: coalescer must not assign data.text directly to draftText without va, test_coalesce_accepts_valid_empty_suggest_draft(), test_coalesce_accepts_valid_nonempty_suggest_draft(), test_coalesce_failed_api_returns_empty_draft() (+5 more)
+
+### Community 469 - "Community 469"
+Cohesion: 0.15
+Nodes (14): build_vector_policy(), _profile_vector_top_k(), Any, Shared recall source policy — vector removal diagnostics (vector no longer fetch, Vector retrieval was removed from orion-recall; always disabled (diagnostics onl, Build path-keyed vector policy diagnostics for recall_debug., recall_vector_allowed(), Regression: orion-recall must not import or call vector_adapter. (+6 more)
+
+### Community 470 - "Community 470"
+Cohesion: 0.18
+Nodes (14): health(), _load_eval_mod(), Path, Gate tests for train/evals/eval_phi_encoder_health.py., Write a tiny valid MLP matching PhiEncoderRuntime shape checks., Low residual_std alone must not flag collapse when slope≠1., test_build_report_fails_when_active_collapsed(), test_constant_phi_is_not_identity_collapse() (+6 more)
+
+### Community 471 - "Community 471"
+Cohesion: 0.12
+Nodes (17): Proposal mode required before invasive cognition changes: memory, identity, self-modeling, autonomy, private recall, social continuity, or cognition-loop changes need a proposal naming capability change, data touched, privacy boundary, proof trace, dangerous failure mode, and rollback before implementation, baseline dispatch policy (retina_fast, every_n_frames 10, no caption/embeddings), porch_eye camera config (open-vocab detect: person/package/vehicle/animal), triggered dispatch policy (person trigger, TTL 8s, caption+embeddings on), config/vision_frame_router.yaml (baseline vs triggered dispatch), Autonomy readiness / mutation pipeline, Dreams / Dream Weaver (symbolic residue processing), Journal layer (autobiographical compression) (+9 more)
+
+### Community 472 - "Community 472"
+Cohesion: 0.12
+Nodes (17): description, type, properties, description, minimum, type, applies_when_state, order (+9 more)
+
+### Community 473 - "Community 473"
+Cohesion: 0.15
+Nodes (17): required, required, can_interrupt_others, category, description, interruptible, max_recursion_depth, name (+9 more)
+
+### Community 474 - "Community 474"
+Cohesion: 0.23
+Nodes (15): _json_to_dict(), parse_json_object(), repair_json(), _strip_outer_quotes(), _try_candidate(), coerce_json(), Uses the json_repair library to fix common JSON errors from LLMs.     1. Strips, RFC 8259 has no \\'; models often emit it for possessives inside JSON strings. (+7 more)
+
+### Community 475 - "Community 475"
+Cohesion: 0.20
+Nodes (14): emit_vector_upsert(), Any, _embed_http(), publish_crystallization_to_chroma(), Build upsert, optionally embed, publish to vector bus. Returns updated crystalli, build_chroma_upsert(), can_project_to_chroma(), chroma_bus_envelope_kind() (+6 more)
+
+### Community 476 - "Community 476"
+Cohesion: 0.23
+Nodes (15): build_agent_trace_summary(), _counts_with_order(), Counter, _bound_capability_step(), Regression: ``next(iter(result.keys()))`` picked ``metadata`` first and skipped, test_agent_trace_delegate_row_fail_on_domain_negative_structured(), test_agent_trace_delegate_row_fail_when_non_service_keys_precede_context_exec_payload(), test_agent_trace_summary_surfaces_bound_failure_details() (+7 more)
+
+### Community 477 - "Community 477"
+Cohesion: 0.21
+Nodes (15): _classify_degraded_reason(), format_degraded_reason_groups(), format_mode_summary(), format_reducer_health_summary(), _missing_fields(), Any, Validate /grammar/truth payloads for the production smoke gate., validate_truth_payload() (+7 more)
+
+### Community 478 - "Community 478"
+Cohesion: 0.28
+Nodes (16): _project_recent_dispatch_actions(), Projection helper: surface the most recent autonomous dispatch-action     outcom, _outcome(), _patched(), A schema-drifted item (e.g. a future writer that doesn't set kind/summary)     m, success=None (ActionOutcomeRefV1's documented "genuinely unknown" state)     mus, test_caps_at_three_newest_first_and_exact_keys(), test_empty_ctx_still_queries_and_returns_empty() (+8 more)
+
+### Community 479 - "Community 479"
+Cohesion: 0.18
+Nodes (13): health(), lifespan(), FastAPI, get_settings(), BaseSettings, Settings, test_emit_perception_once_fail_open_on_list_players_error(), test_emit_perception_once_fail_open_on_malformed_row() (+5 more)
+
+### Community 480 - "Community 480"
+Cohesion: 0.15
+Nodes (12): EpisodicFederator, Triple, Autonomy data is written under graph/autonomy/*, not graph/orion/autonomy/*., Literal objects are not graph nodes and must be filtered out., SPARQL query must reference all 9 episodic named graphs., Fuseki failure → empty list, no exception., Parse SPARQL JSON bindings into (subject, predicate, object) tuples., test_episodic_federator_builds_sparql_for_all_graphs() (+4 more)
+
+### Community 481 - "Community 481"
+Cohesion: 0.19
+Nodes (17): buildWorkflowModalSummaryCard(), fetchScheduleInventory(), filteredSchedules(), formatOverdue(), loadScheduleInventory(), normalizeSchedule(), openScheduleDetails(), openScheduleEdit() (+9 more)
+
+### Community 482 - "Community 482"
+Cohesion: 0.24
+Nodes (15): buildOperatorSummary(), buildSurfaceModel(), cleanList(), countStateItems(), formatCountLabel(), getSection(), normalizeSection(), normalizeSnapshot() (+7 more)
+
+### Community 484 - "Community 484"
+Cohesion: 0.17
+Nodes (10): get_settings(), BaseSettings, Settings, PolicyRuntimeWorker, _existing_policy_frame(), _proposal(), _self_state(), test_worker_records_unevaluable_frame_when_self_state_missing() (+2 more)
+
+### Community 485 - "Community 485"
+Cohesion: 0.22
+Nodes (13): _fake_packet(), _query(), test_does_not_log_when_no_crystallization_refs(), test_logs_retrieval_event_when_refs_present(), test_retrieval_event_log_failure_does_not_break_fragments(), _chat_profile(), test_chat_general_instruction_tail_does_not_shift_query_anchor(), test_chat_general_social_turn_keeps_lightweight_behavior() (+5 more)
+
+### Community 486 - "Community 486"
+Cohesion: 0.24
+Nodes (16): _projection_payload(), Exception, _store_raising(), _store_with_row(), test_attention_broadcast_bad_payload_returns_none(), test_attention_broadcast_fresh_row_parses(), test_attention_broadcast_missing_table_returns_none(), test_attention_broadcast_naive_timestamp_treated_as_utc() (+8 more)
+
+### Community 487 - "Community 487"
+Cohesion: 0.17
+Nodes (5): _FakeQuery, _FakeRow, _FakeSession, test_chat_history_thought_for_merge_preserves_existing_non_empty_thought(), test_chat_history_thought_for_merge_writes_insert_and_update_when_empty_existing()
+
+### Community 488 - "Community 488"
+Cohesion: 0.24
+Nodes (9): _annotate_reason(), _check(), _format_local(), HealthCheck, HealthMonitor, Settings, Severity, Edge-triggered health monitor: fires an orion-notify attention request only (+1 more)
+
+### Community 489 - "Community 489"
+Cohesion: 0.26
+Nodes (16): _compute_current_distribution(), drift_daemon_loop(), fetch_drift_records(), _is_drift_alert(), _js_divergence(), _load_baseline_distribution(), _load_clusterer(), _normalize_counts() (+8 more)
+
+### Community 490 - "Community 490"
+Cohesion: 0.27
+Nodes (14): _load_stt_module(), _mock_canonicalize(), MonkeyPatch, Path, stt_engine(), test_canonicalize_wav_produces_16k_mono_s16(), test_measure_wav_levels_silent_vs_tone(), test_peak_threshold_invalid_env_falls_back() (+6 more)
+
+### Community 491 - "Community 491"
+Cohesion: 0.20
+Nodes (13): generate_turtle_for_all(), _load_verbs(), Any, Path, Render a Python value as a Turtle-safe literal.      We only use this for *strin, Yield all verb definitions as dicts from verbs/*.yaml., Return Turtle triples for a single verb and its steps., Generate Turtle for all verbs in base_dir/verbs.      base_dir is typically the (+5 more)
+
+### Community 492 - "Community 492"
+Cohesion: 0.12
+Nodes (16): description, type, type, description, type, description, type, properties (+8 more)
+
+### Community 493 - "Community 493"
+Cohesion: 0.20
+Nodes (6): ChatHistorySparkMetaPatchV1, _ExistingRow, _FakeQuery, _FakeSession, test_spark_meta_patch_merges_existing_row(), test_spark_meta_patch_missing_row()
+
+### Community 494 - "Community 494"
+Cohesion: 0.24
+Nodes (14): assert_context_exec_engine_identity(), assert_context_exec_safety_posture(), assert_hub_context_exec_routing(), _blob(), _has_context_exec_signal(), Any, Assertions for Hub golden probes — context-exec routing must be proven, not assu, Assert context-exec runtime_debug identifies the RLM engine. (+6 more)
+
+### Community 495 - "Community 495"
+Cohesion: 0.22
+Nodes (13): banner(), classify_failure(), FAIL_LOGS, FAIL_NAMES, record_fail(), record_pass(), record_skip(), require_repo_root() (+5 more)
+
+### Community 496 - "Community 496"
+Cohesion: 0.24
+Nodes (15): _project_self_state_from_beliefs(), Projection helper: fold Orion's self-model condition into stance hazards.      R, _beliefs_with_self_nodes(), _node(), MonkeyPatch, SimpleNamespace, Build a real UnifiedRelationalBeliefSetV1 (not a SimpleNamespace) for the     in, _real_beliefs_with_self_nodes() (+7 more)
+
+### Community 497 - "Community 497"
+Cohesion: 0.18
+Nodes (6): CompressionWorker, Any, Construct a RegionSummarizer when LLM summarization is viable, else None., LLM summaries require the feature flag, a bus, a running loop, and budget., Return (summary_text, summary_kind). Uses the LLM gateway when budget         al, Bridge the async post-write bus emit from the sync tick thread to the         ev
+
+### Community 498 - "Community 498"
+Cohesion: 0.29
+Nodes (15): apiFetch(), escapeHtml(), evidenceSummary(), init(), loadPendingDecisions(), loadProposalDetail(), renderDetail(), renderListRow() (+7 more)
+
+### Community 499 - "Community 499"
+Cohesion: 0.27
+Nodes (14): appendLog(), bindTerminalScroll(), connectSocket(), createTerminalState(), diagnosticsHint(), ensureServiceTerminal(), flushTerminal(), loadInventory() (+6 more)
+
+### Community 500 - "Community 500"
+Cohesion: 0.33
+Nodes (15): el(), initSubstrateEffectTab(), loadRecentEffects(), openSubstrateEffectModal(), renderBehaviorDelta(), renderCausalChain(), renderEvidenceCards(), renderMoleculeSummaries() (+7 more)
+
+### Community 501 - "Community 501"
+Cohesion: 0.22
+Nodes (13): Live Memory graph from chat cases for Playwright e2e., _artifact_dir(), _entity_labels(), hub_available(), _hub_reachable(), _is_evidence_only(), _is_strict_suggest_draft(), _looks_like_prose_outside_json() (+5 more)
+
+### Community 502 - "Community 502"
+Cohesion: 0.18
+Nodes (11): _find_flag_value(), config/llm_profiles qwen3-8b-q4km-v100-16gb-balanced: non-thinking template kwar, Atlas metacog: Q5_K_M, n_parallel=1 -> full 16k ctx per slot, reasoning off., Synthetic profile: only chat_template_kwargs={'enable_thinking': False} → policy, test_draft_fields_emit_speculative_decoding_flags(), test_gemma4_31b_multimodal_profile_forwards_mmproj_and_image_flags(), test_qwen3_64k_profile_forwards_validated_flags(), test_qwen3_64k_profile_skips_unsupported_reasoning_flag() (+3 more)
+
+### Community 503 - "Community 503"
+Cohesion: 0.30
+Nodes (13): build_compose_build_command(), build_compose_command(), build_compose_up_command(), execute_remediation(), RemediationResult, _run_command(), RosterEntry, _entry() (+5 more)
+
+### Community 504 - "Community 504"
+Cohesion: 0.17
+Nodes (7): _FakeQuery, _FakeSession, test_chat_history_log_scalar_columns_from_meta_llm_uncertainty(), test_chat_history_spark_meta_merges_llm_uncertainty_from_meta(), test_chat_history_spark_meta_merges_llm_uncertainty_from_spark_meta(), _write_chat_history(), _write_chat_history_row()
+
+### Community 505 - "Community 505"
+Cohesion: 0.17
+Nodes (9): Path, True positive against the actual repo config: Daily Journal reuses Daily     Pul, test_load_cadences_includes_synthetic_daily_journal_entry(), test_main_fail_on_collision_exits_one(), test_main_fail_on_collision_exits_zero_when_below_threshold(), test_main_json_output_contains_collisions(), test_main_report_only_exits_zero_even_with_collision(), test_real_env_example_has_known_daily_pulse_journal_collision() (+1 more)
+
+### Community 506 - "Community 506"
+Cohesion: 0.24
+Nodes (13): AutonomyEvidenceCompileResult, compile_autonomy_evidence(), Any, datetime, Compile turn-local AutonomyStateV2 evidence with proven-non-empty gates.  Must b, Emit evidence only when upstream is proven non-empty. Never raises., _unique_hazards(), test_compiler_never_raises() (+5 more)
+
+### Community 507 - "Community 507"
+Cohesion: 0.13
+Nodes (15): collapse_mirror.v1 recall profile, deep.graph.v1 recall profile, dream.v1 recall profile, graphtri.v1 recall profile, journal.daily.grounded.v1 recall profile, journal.daily.metacog.grounded.v1 recall profile, journal.notify.grounded.v1 recall profile, journal.world_pulse.grounded.v1 recall profile (+7 more)
+
+### Community 508 - "Community 508"
+Cohesion: 0.26
+Nodes (14): ddp_print(), ddp_setup(), eval_loss_and_geometry(), main(), parse_args(), device, Module, Namespace (+6 more)
+
+### Community 509 - "Community 509"
+Cohesion: 0.22
+Nodes (7): AttentionRuntimeStore, _frame(), _mock_engine_for_frames(), test_load_attention_frame_for_field_tick(), test_load_latest_attention_frame(), test_load_latest_field(), test_save_attention_frame_idempotent()
+
+### Community 510 - "Community 510"
+Cohesion: 0.18
+Nodes (13): Remove identity-kernel prose from llm_chat_general prompt context on ordinary tu, suppress_chat_general_speech_identity_priming(), _apply_chat_general_identity_boundary_guard(), _step(), test_chat_general_identity_boundary_repairs_user_role_inversion(), test_extract_final_text_does_not_rewrite_availability_phrases(), test_identity_boundary_leaves_correct_assistant_user_roles(), test_identity_boundary_repairs_variants() (+5 more)
+
+### Community 511 - "Community 511"
+Cohesion: 0.29
+Nodes (10): _FakeBundle, _FakeItem, _FakeRecallReply, Any, _run_with_items(), test_logs_report_impl_and_service_status(), test_service_backed_path_is_primary(), test_service_error_falls_back_to_native() (+2 more)
+
+### Community 512 - "Community 512"
+Cohesion: 0.20
+Nodes (9): build_orch_concept_profile_settings(), Config, get_orch_concept_profile_settings(), OrchConceptProfileSettings, Any, BaseSettings, Concept-profile repository settings used by Orch runtime.      This adapter inte, Return concept-profile repository config for Orch runtime.      Environment is t (+1 more)
+
+### Community 513 - "Community 513"
+Cohesion: 0.32
+Nodes (14): activate(), apiFetch(), chatTurnCount(), escapeHtml(), loadInbox(), loadRetirementCandidates(), renderDetail(), renderEvidence() (+6 more)
+
+### Community 514 - "Community 514"
+Cohesion: 0.32
+Nodes (14): _atlas_test_app(), client(), _ensure_hub_scripts_import_path(), _mock_with_session(), FastAPI, MonkeyPatch, TestClient, Hub Grammar Atlas read API (substrate trace/graph introspection). (+6 more)
+
+### Community 515 - "Community 515"
+Cohesion: 0.24
+Nodes (10): _all_rows(), _fake_engine(), datetime, HTTP tests for the self-observability summary route (self-observability v2)., Engine whose execute() keys responses off the table name in the SQL., test_summary_curiosity_signals_capped_and_ranked(), test_summary_each_section_degrades_to_null(), test_summary_full_contract_shape() (+2 more)
+
+### Community 516 - "Community 516"
+Cohesion: 0.24
+Nodes (12): main(), _main_async(), monitor_ups(), _publish_event(), _run_shutdown(), setup_logging(), _source(), PowerEvent (+4 more)
+
+### Community 517 - "Community 517"
+Cohesion: 0.17
+Nodes (5): Embedder, Settings, Config, BaseSettings, Settings
+
+### Community 518 - "Community 518"
+Cohesion: 0.24
+Nodes (5): _decode_envelope(), Any, Bounded Redis recovery index for vision-window (design §4.2, §4.3). Stores JSON, Return (latest_cursor, earliest_cursor) from last_n list if parseable., RecoveryStore
+
+### Community 519 - "Community 519"
+Cohesion: 0.26
+Nodes (14): Docker readiness (§8): run docker compose builds/deploys through scripts/safe_docker_build.sh instead of calling docker compose directly; it refuses to run from the shared/primary checkout and applies the --env-file/-f pattern automatically; raw docker compose examples retained only as reference for one-off logs/ps commands, Docker readiness (§8): run docker compose builds/deploys through scripts/safe_docker_build.sh instead of calling docker compose directly; it refuses to run from the shared/primary checkout and applies the --env-file/-f pattern automatically; raw docker compose examples retained only as reference for one-off logs/ps commands, docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md — PR report documenting the full shared-checkout-docker-revert incident story, cited from CLAUDE.md §8, Incident: a concurrent agent session ran docker compose build+up straight from the shared/primary checkout and silently reverted another session's already-verified fix — the concrete motivation for both the safe_docker_build.sh wrapper and the pre-commit shared-checkout guard, Acceptance checks: 10 checks covering pre-commit guard refusal/success/escape-hatch, safe_docker_build.sh refusal/success, graphify hook status and rebuild-log evidence, tracked vs ignored graphify-out files, zero-conflict merge-driver test, gap-tolerant graphify . --update diff, /loop or /schedule cadence confirmation, and (already done) live-verified branch protection, Arsonist summary: parallel Claude Code agent sessions treat the shared main checkout as fair game instead of using worktrees; the existing mitigation (a sentence in CLAUDE.md saying worktrees only) was in place the whole time and did not stop the incident, motivating an actual git-level gate instead of more prose, Branch protection on main: confirmed off (404 Branch not protected) at session start, then enabled and verified live via gh api — PR required to merge, 1 required approving review, enforce_admins true (no owner exceptions), force-push blocked, branch deletion blocked; required no paid plan since the repo is public, graphify merge-driver registration: graphify merge-driver <base> <current> <other> is a real working CLI subcommand (nx.compose union merge, fails loudly above a 50MB/100k-node cap) but is not auto-registered by any graphify command — requires a new .gitattributes entry (graphify-out/graph.json merge=graphify, committable) plus a per-clone local git config merge.graphify.driver entry (not committable, a git design constraint) via a new scripts/setup_graphify_merge_driver.sh (+6 more)
+
+### Community 520 - "Community 520"
+Cohesion: 0.19
+Nodes (14): config/llm_profiles.yaml (LLM profile/model registry, source of truth), orion-llama-cola-host Docker Compose, Orion Llama-CoLA Host service (dual-path text + latent action indices), orion-llama-cola-host Python dependencies (torch, transformers, deepspeed), orion-llamacpp-host Atlas multi-worker Docker Compose (chat/metacog/fast/agent lanes), orion-llamacpp-host single-worker Docker Compose, orion-llamacpp-host service (profile-driven llama.cpp GGUF wrapper, Atlas topology), orion-llamacpp-host Python dependencies (thin wrapper, no ML libs) (+6 more)
+
+### Community 521 - "Community 521"
+Cohesion: 0.14
+Nodes (14): config/proposals/proposal_policy.v1.yaml — Layer 7 proposal policy: limits, priority/risk thresholds, dimension weights, and named proposal_templates that turn substrate state into ProposalFrameV1 candidates, template defer_due_to_low_readiness — no policy gate, defer on self:current to preserve_stability, base_priority 0.25, base_risk 0.0, dimensions uncertainty 0.50 / reliability_pressure 0.50, template inspect_attended_target (P5) — target_binding self_state.dominant_attention_targets[0] with a fallback literal to capability:orchestration if the binding fails to resolve; shipped live at base_priority 0.34 per explicit user go-ahead, not dark-shipped at 0.0, since it's a read-only inspect under the same policy gate/risk class as the other already-live inspect templates; carries a falsifiable 7-day kill criterion (distinct target_id count must be >= 3 or the binding isn't doing anything the literal templates don't already do), checked by run_attention_bound_proposal_eval.py, template inspect_bus_channel_catalog — read_only inspect of orion/bus/channels.yaml as a system target, base_priority 0.38, dimension contract_pressure 0.60, template inspect_execution_pressure — read_only inspect of capability:orchestration, base_priority 0.40, base_risk 0.05, dimension execution_pressure 0.60, template inspect_field_topology_catalog — read_only inspect of config/field/orion_field_topology.v1.yaml, base_priority 0.33, dimension field_intensity 0.45, template inspect_node_resource_pressure — read_only inspect of node:atlas, base_priority 0.34, dimension resource_pressure 0.50, template inspect_transport_status — read_only inspect of capability:transport, base_priority 0.42, dimensions contract_pressure 0.55 / reliability_pressure 0.40 (+6 more)
+
+### Community 522 - "Community 522"
+Cohesion: 0.24
+Nodes (7): Path, Loads and caches VerbConfig objects from verbs/*.yaml, Return all registered verbs. Use reload=True to refresh the cache., Lightweight filtering helper used by supervisors/planners., VerbRegistry, BaseModel, VerbConfig
+
+### Community 523 - "Community 523"
+Cohesion: 0.25
+Nodes (11): CompressionRegionV1, CompressionStalenessMarkV1, GraphCompressionRegionMaterializedV1, BaseModel, A cached semantic compression of a graph region, written to orion:compressions., Bus payload marking a graph region stale when source triples are written., Bus event emitted after each compression artifact is written to Fuseki., test_compression_region_v1_requires_exemplar_ids() (+3 more)
+
+### Community 524 - "Community 524"
+Cohesion: 0.23
+Nodes (13): normalize_hub_presence(), Any, Pass a non-empty presence dict through as-is; anything else becomes None., _build_state(), Tests for hub presence passthrough in the self-state build path., _synthetic_field(), test_build_self_state_absent_hub_presence_is_none(), test_build_self_state_empty_hub_presence_is_none() (+5 more)
+
+### Community 525 - "Community 525"
+Cohesion: 0.26
+Nodes (13): _probe_records(), Unit tests for the Phase 4 drive-pressure measurement probe (2026-07-12).  Measu, Call site 1 (~line 717, _handle_signal_drive_tick via handle_envelope)., Call site 2 (~line 847, handle_envelope's non-homeostatic drive-update rail)., A probe logging failure at call site 2 must not break save_drive_state or     pr, _signal_env(), test_handle_envelope_call_site_logs_probe(), test_handle_envelope_call_site_survives_probe_failure() (+5 more)
+
+### Community 526 - "Community 526"
+Cohesion: 0.26
+Nodes (11): evaluate_trust_rupture_fixture(), _load_fixtures(), Any, Return failure messages for a single fixture; empty when expectations pass., Run all trust rupture fixtures; return aggregated failure messages., run_trust_rupture_eval_corpus(), _stance_slice(), _thought_from_fixture() (+3 more)
+
+### Community 527 - "Community 527"
+Cohesion: 0.24
+Nodes (3): _clean_raw_llm_content(), Strips common LLM preambles and code fences to expose raw JSON., TestExecutorCleaning
+
+### Community 528 - "Community 528"
+Cohesion: 0.22
+Nodes (8): _bindings(), _FakeResponse, _graphdb_post(), test_graphdb_conceptual_retrieval_returns_persisted_concept_profiles(), test_graphdb_factual_retrieval_returns_authoritative_only(), test_graphdb_reflective_retrieval_preserves_all_tiers_and_links(), test_graphdb_retrieval_is_stable_across_repeated_reads(), test_graphdb_retrieval_never_upcasts_in_factual_mode()
+
+### Community 529 - "Community 529"
+Cohesion: 0.34
+Nodes (13): get_mind_run(), list_mind_runs(), list_recent_mind_runs(), _mind_run_row_dict(), _need_session(), _pool(), Any, BaseException (+5 more)
+
+### Community 530 - "Community 530"
+Cohesion: 0.24
+Nodes (11): attach_repair_pressure_contract(), _contract_changed(), Wire substrate repair contract into Hub → Cortex chat metadata., Mutate req.metadata in place when repair pressure changed behavior., WS builds chat_req before pipeline; attach must run after pipeline., _snapshot(), test_attach_skips_when_disabled(), test_attach_skips_when_mode_unchanged() (+3 more)
+
+### Community 531 - "Community 531"
+Cohesion: 0.26
+Nodes (13): _build(), Tests for hub chat turn grammar event emitter (TDD — written before implementati, test_atom_types_are_valid(), test_build_returns_grammar_event_v1_instances(), test_relation_types_are_valid(), test_repair_signal_absent_when_flag_false(), test_repair_signal_present_when_flag_true(), test_stable_event_ids_same_inputs_same_ids() (+5 more)
+
+### Community 532 - "Community 532"
+Cohesion: 0.25
+Nodes (13): _mock_pool(), SimpleNamespace, Hub Mind run read APIs (session-gated; mock PG pool)., test_get_mind_run_allows_context_session_id(), test_get_mind_run_not_found_when_other_session(), test_get_mind_run_returns_row(), test_list_mind_runs_allows_context_session_without_current_match(), test_list_mind_runs_excludes_other_non_null_session_without_context() (+5 more)
+
+### Community 533 - "Community 533"
+Cohesion: 0.27
+Nodes (8): _FakeClient, _load_module(), Path, _status_payload(), test_battle_runner_never_calls_judgment_or_review_or_execute_once(), test_battle_runner_rejects_invalid_profile_before_posting(), test_battle_runner_uses_default_profile_when_omitted(), test_operator_token_loader_prefers_explicit_then_env()
+
+### Community 534 - "Community 534"
+Cohesion: 0.25
+Nodes (9): GPUConfig, LlamaCppConfig, LLMProfile, LLMProfileRegistry, BaseModel, BaseSettings, LLMProfile, LLMProfileRegistry (+1 more)
+
+### Community 535 - "Community 535"
+Cohesion: 0.27
+Nodes (8): GPUConfig, LLMProfile, LLMProfileRegistry, BaseModel, Config, BaseSettings, LLMProfileRegistry, Settings
+
+### Community 536 - "Community 536"
+Cohesion: 0.23
+Nodes (5): configured_routes(), MonkeyPatch, TestClient, test_resolve_openai_route_missing_returns_error(), TestOpenAIPassthroughHTTP
+
+### Community 537 - "Community 537"
+Cohesion: 0.23
+Nodes (8): AlertSnapshot, A single snapshot image captured around the time of an alert., Notifier, Send an email with alert details and optional snapshot attachments.          IMP, Handles:     - Capturing snapshots from the vision edge service     - Sending al, Pull frames from the vision edge /snapshot.jpg endpoint and save to disk., Remove `user:pass@` credentials from URLs for safe logging / email.      Example, redact_url()
+
+### Community 538 - "Community 538"
+Cohesion: 0.14
+Nodes (14): orion-biometrics (tier1, organ: biometrics), orion-bus (core, required), orion-collapse-mirror (tier1, organ: collapse_mirror), orion-cortex-exec (tier1, organs: cortex_exec, autonomy, chat_stance), orion-cortex-gateway (routing), orion-cortex-orch (routing), orion-equilibrium-service (tier1, organ: equilibrium), orion-llm-gateway (routing) (+6 more)
+
+### Community 539 - "Community 539"
+Cohesion: 0.25
+Nodes (12): _done_key(), get_redis_client(), _inflight_key(), is_done(), mark_done(), Redis, Shared async Redis client for idempotency keys.     Returns None if idempotency, Return whether a done marker exists for ``trace_id``.      On Redis read errors, (+4 more)
+
+### Community 540 - "Community 540"
+Cohesion: 0.23
+Nodes (7): _Bus, _Codec, _Decoded, _Env, test_gateway_disabled_recall_forwards_supervised_request_and_replies_to_hub(), test_gateway_replies_when_orch_rpc_raises(), test_gateway_replies_when_result_validation_fails()
+
+### Community 541 - "Community 541"
+Cohesion: 0.23
+Nodes (3): _ev(), TestBuildFactSheet, TestReduceDriveHistory
+
+### Community 542 - "Community 542"
+Cohesion: 0.24
+Nodes (11): AutonomySubjectFanout, autonomy_subject_fanout_from_runtime_ctx(), Any, Runtime policy for Graph autonomy multi-subject SPARQL fan-out (bounded vs full), Return ``bounded`` only for the default Hub quick lane; deep lanes use ``full``., test_fanout_bounded_chat_kids_story(), test_fanout_bounded_plain_chat_quick(), test_fanout_full_agent_mode_even_if_verb_chat_quick() (+3 more)
+
+### Community 543 - "Community 543"
+Cohesion: 0.17
+Nodes (13): Deterministic gates over repeated yelling: if Juniper has to repeat a rule twice, turn it into a script/test/check/hook/make target instead of a louder prompt, scripts/concept_relation_digest.py — standalone script (not a live service loop) run every 30 minutes via Athena cron, turning memory_concept_relation_decisions rows into reflection crystallizations; make check-concept-relation-digest-liveness is the fail-safe, querying the real undigested backlog age (not a heartbeat file) and exiting non-zero past MAX_AGE_HOURS (default 3h) — a deterministic gate against the cron entry silently dying or not persisting across a host migration, Cross-window concept-relation resolution (off by default): vector-similarity candidate retrieval plus one bounded structured-output LLM call judging same/refines/contradicts/unrelated against nearest existing active crystallizations of the same kind; refines/contradicts only attach a typed link to the new candidate, never mutate the existing target — that stays a human decision via the links/supersede API; gated by CONCEPT_RELATION_RESOLUTION_ENABLED plus embed/chroma host config, both required or the feature does nothing, MEMORY_CONSOLIDATION_OUTPUT modes: crystallization_propose (default, runs consolidation_memory_gate and skips low-signal windows or proposes MemoryCrystallizationV1), graph_draft (legacy LLM graph-suggest path), skip_only (gate runs for traceability, always marks skipped); gate thresholds require the window not be all low-info-social, since a bare novelty/significance float alone previously let a noisy classifier score crystallize a short greeting-only turn, scripts/drive_history_reflection_synthesis.py (manual/on-demand only, NOT cron'd) — reads real persisted DriveAuditV1 ticks from the Fuseki drives graph and synthesizes one reflection-kind MemoryCrystallizationV1 via a deterministic reducer stage (reduce_drive_history, a pure unit-tested function, same bar as orion/spark/concept_induction/drive_tension.py) followed by a narrow LLM-phrasing stage that only ever sees a pre-computed fact sheet; parse_and_validate_narrative enforces that every cited fact's literal tokens appear verbatim in the output, and the script refuses to synthesize below MIN_EVENTS=5 or MIN_DISTINCT_DAYS=2, Known recurring footgun: 'flag on, dependency not wired' — CONCEPT_RELATION_RESOLUTION_ENABLED=true alone does not imply the digest is scheduled, and this exact pattern has already caused silent no-ops twice in this repo (CONCEPT_RELATION_RESOLUTION_ENABLED itself missing its embed/chroma hosts on first activation, and RECALL_GRAPHITI_IN_CHAT missing its adapter URL) — checking both halves explicitly every time is cheaper than re-discovering this, services/orion-memory-consolidation/README.md — subscribes to orion:memory:turn:persisted, classifies each chat turn via LLM gateway quick-lane logprobs, patches chat_history_log.spark_meta, tracks consolidation windows, and on boundary closure runs a deterministic consolidation gate (default) or legacy graph suggest, Turn change appraisal: each persisted turn after the first in a window gets a logprob-calibrated turn_change_appraisal patch (novelty score, shift kind, confidence, baseline mode); high-confidence novel turns emit OrionSignalV1 on orion:signals:memory_consolidation (+5 more)
+
+### Community 544 - "Community 544"
+Cohesion: 0.17
+Nodes (13): No empty-shell cognition: do not ship cognition-shaped output with no substance — empty semantic projections, placeholder memory cards, fallback text as generated cognition, raw_len=0 treated as success, stale reducer cursors are all invalid success states requiring inspectable evidence, Experience loop (P2): every real send (success, empty observation, or RPC failure) publishes an ActionOutcomeEmitV1 event onto orion:autonomy:action:outcome (BUS_ACTION_OUTCOME_OUT) — the same always-on route orion-spark-concept-induction already produces onto for curiosity-fetch outcomes, consumed by orion-sql-writer into the durable action_outcomes table; subject always 'orion' (self-directed, never relationship-scoped); replay-safe since sql-writer upserts by dispatch_id via merge(), EXECUTION_DISPATCH_MODE gate — default dry_run (build, no send); real sends require both this env set to dispatch_read_only AND config/execution_dispatch/execution_dispatch_policy.v1.yaml's mode.allow_dispatch_read_only true, plus per-tick and daily send budgets enforced before any send happens, ExecutionDispatchFrameV1 / ExecutionDispatchCandidateV1 — the schema this service builds; dispatch_status vocabulary (prepared, dry_run, blocked, skipped, prepared_for_dispatch, dispatched) enforced at the schema level, with dispatched requiring dispatched_at plus a result_ref or dispatch_error, Idempotency: dispatch_id is deterministic per proposal+policy, so if the process dies between a successful send and frame persistence, the next tick replays the stored substrate_dispatch_results row instead of resending — a real cortex-exec call never fires twice for the same candidate, Prerequisites: substrate_policy_decision_frames populated by orion-policy-runtime (port 8120); substrate_proposal_frames and substrate_self_state from Layers 7-6; two manual SQL migrations applied for ExecutionDispatchFrameV1 and substrate_dispatch_results_v1, Rollback: set EXECUTION_DISPATCH_MODE=dry_run and restart this one container — single kill switch for all real sending, services/orion-execution-dispatch-runtime/README.md — Layer 9 of the Orion cognition substrate: converts PolicyDecisionFrameV1 + ProposalFrameV1 + SelfStateV1 into ExecutionDispatchFrameV1 envelopes, the motor-nerve service that can actually send real actions (+5 more)
+
+### Community 545 - "Community 545"
+Cohesion: 0.18
+Nodes (13): Gemma 4 31B/E4B multimodal (text+image[+audio]) profiles, llama3-1-cola CoLA intention host profile, config/llm_profiles.yaml (LLM profile registry), qwen36-35b-a3b-udq5km-2xv100-32gb-deep-cognition profile (monster FCC), qwen3-30b-a3b-instruct-2507-q5km-atlas-metacog-16k profile, qwen3-8b-q5km-v100-16gb-atlas-metacog-16k profile, qwen3-coder-next agent breadth/depth profiles, llm-gateway remediation entry (+5 more)
+
+### Community 546 - "Community 546"
+Cohesion: 0.23
+Nodes (10): FrameSender, _envelope_correlation_id(), publish_harness_run_step(), Any, UUID, Any, Forward harness governor FCC steps to Hub WS as claude_step frames., relay_harness_run_steps() (+2 more)
+
+### Community 547 - "Community 547"
+Cohesion: 0.27
+Nodes (12): Load opt-in render/prompt flags from recall profile YAML., recall_profile_prompt_flags(), _load_profile(), _load_verb(), _long_candidates(), test_daily_metacog_verb_uses_metacog_profile(), test_daily_pulse_verb_uses_scheduler_journal_profile(), test_journal_daily_grounded_not_capped_at_1280_without_explicit_config() (+4 more)
+
+### Community 548 - "Community 548"
+Cohesion: 0.23
+Nodes (12): _bounded_memory_digest(), _load_daily_metacog_template(), test_daily_metacog_prompt_rejects_oversize_without_truncation(), test_daily_metacog_rendered_prompt_stays_bounded(), test_prompt_render_ctx_preserves_journal_lane_bundle_by_default(), test_prompt_render_ctx_strips_debug_recall_bundle_only_when_opted_in(), _enforce_daily_metacog_prompt_budget(), _estimate_prompt_tokens() (+4 more)
+
+### Community 549 - "Community 549"
+Cohesion: 0.21
+Nodes (6): _FakeProc, _FakeStream, MonkeyPatch, test_cancel_before_register_kills_on_spawn(), test_cancel_fcc_turn_kills_registered_process(), test_run_fcc_turn_registers_and_unregisters_process()
+
+### Community 550 - "Community 550"
+Cohesion: 0.21
+Nodes (11): compact_vision_scene_interpretation_json_schema(), Any, Compact JSON Schema for VisionSceneInterpretationV1 (llama.cpp json_object+schem, Inline schema without $ref — suitable for Atlas metacog json_object+schema., build_interpretation_llm_options(), Gateway options for deterministic VisionSceneInterpretationV1 JSON., test_build_interpretation_llm_options_wires_structured_schema(), Tests for VisionSceneInterpretationV1 compact JSON schema contract. (+3 more)
+
+### Community 551 - "Community 551"
+Cohesion: 0.18
+Nodes (13): orion-self-state-runtime (Layer 6 substrate: synthesizes SelfStateV1), orion-signal-gateway (normalizes organ-bus events into OrionSignalV1), orion-signals (organ signal mesh launcher, not a runtime service), orion-self-state-runtime docker-compose.yml, orion-self-state-runtime README.md, orion-self-state-runtime requirements.txt, orion-signal-gateway docker-compose.yml, orion-signal-gateway otel/collector-config.yaml (OTLP collector) (+5 more)
+
+### Community 552 - "Community 552"
+Cohesion: 0.29
+Nodes (12): ProposalListFilter, _disabled_payload(), proposal_review_action(), proposal_review_detail(), proposal_review_eligibility(), proposal_review_health(), proposal_review_pending(), ProposalReviewActionRequest (+4 more)
+
+### Community 553 - "Community 553"
+Cohesion: 0.32
+Nodes (12): _collapse(), compose_identity(), compose_presence_blurb(), main(), patch_juniper(), Splice Juniper (human player) into constants.ts (DEFAULT_NAME) and     world.ts, Rich, third-person identity injected into the agent's prompts., Rich blurb for players seeded outside `Descriptions` (Juniper human join,     Or (+4 more)
+
+### Community 554 - "Community 554"
+Cohesion: 0.28
+Nodes (10): _FakeDetector, _inputs(), test_already_known_fact_suppresses_redundant_question(), test_autonomy_detector_emits_attention_item_signal(), test_concept_and_autonomy_pressure_influence_ranking(), test_detector_registry_accepts_fake_detector_without_regex(), test_generic_reciprocity_is_suppressed(), test_high_value_open_loop_selects_single_ask() (+2 more)
+
+### Community 555 - "Community 555"
+Cohesion: 0.32
+Nodes (12): _build_capability_field_projection(), _build_node_field_projection(), _capability_key(), _engine(), field_capability(), field_latest(), field_node(), _load_latest_field() (+4 more)
+
+### Community 556 - "Community 556"
+Cohesion: 0.27
+Nodes (11): build_audio_debug(), empty_transcript_error_message(), Any, sanitize_client_audio_meta(), test_build_audio_debug(), test_empty_transcript_browser_no_chunks(), test_empty_transcript_low_peak_warn_when_stt_passed(), test_empty_transcript_no_speech_default() (+3 more)
+
+### Community 557 - "Community 557"
+Cohesion: 0.36
+Nodes (12): activate(), clearReadyTimer(), deactivate(), el(), finishLoading(), loadIframe(), readFrameState(), refreshStatus() (+4 more)
+
+### Community 558 - "Community 558"
+Cohesion: 0.36
+Nodes (12): mcp_config(), _mock_mcp_toolchain(), Any, MonkeyPatch, Path, test_render_defaults_github_toolsets_lean_and_read_only(), test_render_fails_when_aitown_unreachable(), test_render_fails_without_docker() (+4 more)
+
+### Community 559 - "Community 559"
+Cohesion: 0.21
+Nodes (4): MonkeyPatch, _render_hub_index(), test_render_hub_index_html_injects_proposal_review_when_enabled(), test_render_hub_index_html_omits_proposal_review_when_disabled()
+
+### Community 560 - "Community 560"
+Cohesion: 0.26
+Nodes (11): client(), Any, TestClient, _sample_row(), test_consolidation_draft_routes_memory_schema_missing(), test_get_consolidation_draft(), test_list_consolidation_drafts(), test_list_consolidation_drafts_memory_schema_missing() (+3 more)
+
+### Community 561 - "Community 561"
+Cohesion: 0.27
+Nodes (8): GPUConfig, LLMProfile, LLMProfileRegistry, BaseModel, BaseSettings, LLMProfile, LLMProfileRegistry, Settings
+
+### Community 562 - "Community 562"
+Cohesion: 0.19
+Nodes (9): main(), pull_model(), Wait for Ollama server to be ready., Pull the specified model using Ollama API., wait_for_ollama(), Config, Any, BaseSettings (+1 more)
+
+### Community 563 - "Community 563"
+Cohesion: 0.23
+Nodes (11): _cfg(), health(), lifespan(), FastAPI, Any, Background retention scheduler for orion-rdf-writer., retention_health_snapshot(), _retention_loop() (+3 more)
+
+### Community 564 - "Community 564"
+Cohesion: 0.15
+Nodes (13): orion-spark-introspector (tier1, organ: spark_introspector), Orion Cognitive Dashboard UI (index.html + tissue_viz.js), orion-spark-introspector docker-compose.yml, orion-spark-introspector README (Spark Engine v2), CoLA-derived novelty signal (orion-llama-cola-host /v1/understand, per-session distribution novelty), Mood-arc corpus collector (roadmap item 1: MoodArcCorpusRowV1 JSONL sink), scripts/fit_mood_arc_encoder.py (roadmap item 2: windowed sequence-autoencoder over mood-arc corpus), OrionState (compact self-state representation: mood, focus_themes, latent_state) (+5 more)
+
+### Community 565 - "Community 565"
+Cohesion: 0.18
+Nodes (6): _compose_service_names(), _load_roster(), Path, Gate tests for orion-signals roster contract., roster(), test_every_compose_service_in_compose_file()
+
+### Community 566 - "Community 566"
+Cohesion: 0.19
+Nodes (4): FakeWorker, test_debug_endpoint_returns_structured_json_when_worker_present(), test_lifespan_attaches_worker_and_starts_task(), test_shutdown_stops_worker_once()
+
+### Community 567 - "Community 567"
+Cohesion: 0.19
+Nodes (9): build_vllm_command_and_env(), main(), Build the vLLM OpenAI server command + environment based on Settings + profiles., Config, Any, BaseSettings, Resolve (model_id, gpu_cfg) using:           1) Explicit env: VLLM_MODEL_ID (opt, Load raw profile dicts from YAML (same file used by llm-gateway). (+1 more)
+
+### Community 568 - "Community 568"
+Cohesion: 0.24
+Nodes (12): Capability: vision (declared, unwired), Pipeline: Retina Dense, Pipeline: Retina Fast, Profile: Image Embedding, Profile: Identity/Face Embedding, Profile: Pose Estimation, Profile: Open-Vocab Detector, Profile: Segmentation (SAM2-class) (+4 more)
+
+### Community 569 - "Community 569"
+Cohesion: 0.17
+Nodes (12): Source: BBC World RSS, Source: CISA KEV Catalog (Manual URL), Source: Hugging Face Blog RSS, Source: Utah Government News (disabled, 404), Source: NASA News RSS, Source: NOAA Newsroom, Source: NPR Politics RSS, World Pulse Sources Policy v1 (+4 more)
+
+### Community 570 - "Community 570"
+Cohesion: 0.27
+Nodes (7): collect_up_failures(), is_excluded(), print_failed_logs(), up_all_services_batched.sh script, up_one(), up_one_bg(), wait_for_bus_ready()
+
+### Community 571 - "Community 571"
+Cohesion: 0.21
+Nodes (6): clear_active_goal(), get_active_goal(), GoalContextStore, Goal → attention wire (spec 2026-07-07 Step 2, the scope-doubler).  The substrat, Adopt this goal as the current active context (latest active wins).          A t, set_active_goal()
+
+### Community 572 - "Community 572"
+Cohesion: 0.17
+Nodes (12): description, type, description, items, minItems, type, plan, services (+4 more)
+
+### Community 574 - "Community 574"
+Cohesion: 0.30
+Nodes (11): harness_mcp_enabled(), append_self_index_harness_brief(), context_mode_brief_lines(), context_mode_enabled(), context_mode_hooks_enabled(), _env_truthy(), gitnexus_brief_lines(), gitnexus_enabled() (+3 more)
+
+### Community 575 - "Community 575"
+Cohesion: 0.24
+Nodes (9): MonkeyPatch, Path, test_claude_permission_argv_non_root_uses_skip(), test_claude_permission_argv_root_uses_dont_ask(), test_extend_mcp_argv_appends_extra_allowed_tools_after_server_patterns(), test_extend_mcp_argv_extra_none_or_empty_keeps_argv_identical(), test_extend_mcp_argv_extra_with_zero_servers_still_emits_allowed_tools(), test_extend_mcp_argv_uses_per_server_patterns() (+1 more)
+
+### Community 576 - "Community 576"
+Cohesion: 0.29
+Nodes (11): Task 6 live: homeostatic signal channels ride a drive-only rail.  Asserts the wo, A bad prior state / store fault in the drive-update section must degrade to, _signal_env(), test_disabled_flag_falls_through_to_concept_path(), test_failure_channel_mints_tension(), test_homeostatic_source_classification(), test_never_raises_when_drive_update_breaks(), test_pubsub_patterns_include_specific_channels_not_wildcard() (+3 more)
+
+### Community 577 - "Community 577"
+Cohesion: 0.23
+Nodes (8): main(), parse_args(), Namespace, HyperbolicGPTMoC, HyperbolicGPT v3: MoC architecture plus v2 manifold diagnostics., main(), _pick_device(), device
+
+### Community 578 - "Community 578"
+Cohesion: 0.17
+Nodes (7): ingest_file(), Reads a text file, splits it into chunks, and ingests them into the vector store, A client that connects to the standalone Orion Vector DB service.     This write, Loads the embedding model and initializes the ChromaDB HTTP client         to co, Embeds a list of document texts and adds them to the collection., # NOTE: This is a simple incremental ID. For production, you'd, VectorStore
+
+### Community 579 - "Community 579"
+Cohesion: 0.24
+Nodes (11): main(), Any, Path, ValueError, Returns (keys exposed via `environment:`, has env_file directive) for the     se, Raised when the target service can't be unambiguously identified inside a     mu, Pick the compose `services:` entry that corresponds to `service_dirname`     (e., _read_compose_env_keys() (+3 more)
+
+### Community 580 - "Community 580"
+Cohesion: 0.35
+Nodes (8): _extract_cortex_result(), main(), MatrixRow, _one_row(), ProbeCollector, Any, _service_ref(), _summarize()
+
+### Community 581 - "Community 581"
+Cohesion: 0.29
+Nodes (11): _ensure_sys_path_stdlib_safe(), _http_to_ws_url(), main(), phase0_offline(), phase1_http(), phase2_ws(), Any, Path (+3 more)
+
+### Community 582 - "Community 582"
+Cohesion: 0.24
+Nodes (9): _cards(), Backtick / ${...} / backslash must be escaped for a TS backtick literal., Drift guard: the composed Juniper blurb must be spliced into world.ts., test_cards_have_all_expected_ids(), test_compose_identity_is_rich_and_collapsed(), test_compose_presence_blurb_orion_uses_they(), test_juniper_blurb_present_in_world_ts(), test_render_descriptions_emits_eight_valid_sprites() (+1 more)
+
+### Community 583 - "Community 583"
+Cohesion: 0.26
+Nodes (10): _disable_gateway_probe(), Any, MonkeyPatch, Runner integration tests for llm_profile → route binding., _RouteProbeEngine, test_engine_subcall_records_route_for_profile(), test_llm_chat_route_accepts_ctxcorr_correlation_id(), test_llm_chat_route_uses_route_key() (+2 more)
+
+### Community 584 - "Community 584"
+Cohesion: 0.41
+Nodes (11): _perc(), test_engage_accepts_invite(), test_engage_does_not_stop_when_not_pathfinding(), test_engage_initiates_with_nearby_player(), test_engage_stops_once_to_face_partner_when_pathfinding(), test_engage_walks_to_partner_when_walking_over(), test_initiate_off_when_distance_zero(), test_initiate_respects_cooldown() (+3 more)
+
+### Community 585 - "Community 585"
+Cohesion: 0.24
+Nodes (9): build_graph_from_triples(), leiden_cluster(), Graph, Triple, Three connected triples form at least one community., test_build_graph_from_triples(), test_leiden_cluster_empty_graph_returns_empty(), test_leiden_cluster_single_node() (+1 more)
+
+### Community 586 - "Community 586"
+Cohesion: 0.23
+Nodes (5): CompressionWriter, Emit a passive materialization event for any region kind., Emit substrate mutation pressure for contradiction regions only., Emit all post-write bus events: materialization + grammar hook., Write region to Fuseki. Returns True on success.
+
+### Community 587 - "Community 587"
+Cohesion: 0.29
+Nodes (9): extract_autonomy_payload(), log_autonomy_payload_extraction(), Any, Diagnostic logging after autonomy extraction on Hub chat ingress paths., test_log_autonomy_payload_extraction_empty(), test_log_autonomy_payload_extraction_present(), test_extract_autonomy_payload_forwards_v2_keys(), test_extract_autonomy_payload_includes_execution_mode_and_goal_lineage() (+1 more)
+
+### Community 588 - "Community 588"
+Cohesion: 0.38
+Nodes (11): appendLiveClaudeStep(), basename(), clip(), contextRiskSuffix(), ensurePanel(), finalizeLiveClaudeTrace(), formatHarnessHeading(), formatToolInput() (+3 more)
+
+### Community 589 - "Community 589"
+Cohesion: 0.21
+Nodes (6): _FakeProc, _FakeStream, MonkeyPatch, test_run_turn_adds_mcp_config_when_enabled(), test_run_turn_omits_mcp_config_when_disabled(), test_run_turn_surfaces_mcp_preflight_error_code()
+
+### Community 591 - "Community 591"
+Cohesion: 0.30
+Nodes (11): Historical runs may omit mind.llm_synthesis_attempted on the success path., _run_node(), test_fail_open_fixture_normalizer(), test_fail_open_fixture_phase_rows_expose_semantic_filter_counts(), test_fail_open_fixture_still_renders_provenance_sections(), test_filtered_empty_semantic_only_warns_not_failed_callout(), test_orch_http_failed_fixture_normalizer(), test_shadow_fixture_renders_shadow_fields() (+3 more)
+
+### Community 592 - "Community 592"
+Cohesion: 0.24
+Nodes (10): MonkeyPatch, General 'stop chat' command: a per-connection active-turn registry in websocket_, A connection is registered at setup even before any turn starts (correlation_id, The registry stores the active_turn dict by reference: mutating it directly, test_api_chat_turn_cancel_503_when_bus_unavailable(), test_api_chat_turn_cancel_returns_cancelled_correlation_id(), test_cancel_active_turn_for_connection(), test_cancel_active_turn_for_connection_with_no_turn_in_flight_is_noop() (+2 more)
+
+### Community 593 - "Community 593"
+Cohesion: 0.29
+Nodes (11): _mind_prep(), _prep(), Any, MonkeyPatch, Tests for LLM surface instability metacog advisory trigger., test_maybe_publish_runs_when_metacog_enabled(), test_maybe_publish_skips_when_metacog_disabled(), test_maybe_publish_skips_when_status_not_ok() (+3 more)
+
+### Community 594 - "Community 594"
+Cohesion: 0.44
+Nodes (11): build_autonomy_triples(), _parse(), _provenance(), Graph, test_drive_audit_materialization_preserves_lineage_and_tensions(), test_goal_materialization_preserves_proposal_only_semantics(), test_goal_materialization_writes_planned_task_and_completed_at(), test_goal_materialization_writes_proposal_status_and_base() (+3 more)
+
+### Community 595 - "Community 595"
+Cohesion: 0.23
+Nodes (10): Any, Session, Idempotent spark_telemetry persistence keyed by correlation_id., upsert_spark_telemetry(), Tests for idempotent spark_telemetry persistence., Regression: ON CONFLICT SET must target DB column 'metadata', not Python attr 'm, test_on_conflict_update_uses_metadata_column_not_python_attr(), test_upsert_filters_unknown_keys() (+2 more)
+
+### Community 596 - "Community 596"
+Cohesion: 0.35
+Nodes (11): _graph_node(), _make_worker(), SimpleNamespace, Unit tests for the continuous attention broadcast tick (rung 3).  Verifies the w, Each broadcast tick appends a dwell row alongside the projection., test_broadcast_disabled_is_noop(), test_broadcast_fails_open_on_snapshot_error(), test_broadcast_fails_open_on_store_init_error() (+3 more)
+
+### Community 597 - "Community 597"
+Cohesion: 0.27
+Nodes (9): lifespan(), FastAPI, ready(), get_llm_client(), check_embedding(), check_model_dir(), check_postgres(), Any (+1 more)
+
+### Community 598 - "Community 598"
+Cohesion: 0.25
+Nodes (11): Orion Memory Ontology (GraphDB), orionmem-v2026-05.ttl, shapes-orionmem-v2026-05.ttl, claim:orion:knowledge-forge:0001 — Forge v1 FastAPI endpoints on port 8630, claim:orion:knowledge-forge:0003 — git-tracked orion-knowledge/ remains source of truth, claim:orion:knowledge-forge:0004 — compile excludes disputed/stale/superseded claims by default, claim:orion:knowledge-forge:0002 — Hub Forge tab proxies /api/knowledge/*, claim:orion:knowledge-forge:0005 — v1 excludes GraphDB/vector search/autonomous rewriting/silent mutation (+3 more)
+
+### Community 599 - "Community 599"
+Cohesion: 0.29
+Nodes (8): _goal(), GoalProposalV1, test_capability_policy_allows_episode_journal_at_proposed(), test_capability_policy_allows_readonly_when_goal_proposed(), test_capability_policy_allows_recall_when_goal_proposed(), test_capability_policy_denies_episode_journal_when_disabled(), test_capability_policy_denies_recall_when_auto_readonly_disabled(), test_capability_policy_denies_when_auto_readonly_disabled()
+
+### Community 600 - "Community 600"
+Cohesion: 0.18
+Nodes (11): Channel "orion:notify:config:preference" (kind=event, schema=NotificationPreferencesUpdate) producers=[orion-notify] consumers=[orion-sql-writer], Channel "orion:notify:config:recipient" (kind=event, schema=RecipientProfileUpdate) producers=[orion-notify] consumers=[orion-sql-writer], Channel "orion:notify:in_app" (kind=event, schema=HubNotificationEvent) producers=[orion-notify] consumers=[orion-hub], Channel "orion:notify:persistence:receipt" (kind=event, schema=NotificationReceiptEvent) producers=[orion-notify] consumers=[orion-sql-writer], Channel "orion:notify:persistence:request" (kind=event, schema=NotificationRecord) producers=[orion-notify] consumers=[orion-sql-writer], Schema: HubNotificationEvent, Schema: NotificationPreferencesUpdate, Schema: NotificationReceiptEvent (+3 more)
+
+### Community 601 - "Community 601"
+Cohesion: 0.20
+Nodes (11): delivery_pack: user-facing artifact verbs, emergent_pack: introspection/reflection/dream/counterfactual verbs, executive_pack: classify/plan/prioritize/evaluate verbs, memory_pack: memory retrieval/contextualization/narrative verbs, Cognition Packs (Memory, Executive, Emergent), Orion Cognition Layer README, Semantic Planner (verb -> ExecutionPlan), Verb exec_step bus contract (orion-exec:request/result:<Service>) (+3 more)
+
+### Community 602 - "Community 602"
+Cohesion: 0.27
+Nodes (9): _map(), objectTiles indexed [layer][x][y]; -1 = empty. `blocked` is a set of (x,y)., test_walkable_empty_on_malformed(), test_walkable_excludes_blocked_tiles(), test_walkable_multiple_layers_any_block(), Any, Walkability derived from an AI Town ``worldMap``.  AI Town stores object/collisi, Return the set of walkable integer tiles ``(x, y)`` for a worldMap.      Fail-op (+1 more)
+
+### Community 603 - "Community 603"
+Cohesion: 0.27
+Nodes (10): mcp_tool_result_max_chars(), _forward_input(), _forward_output(), main(), _maybe_truncate_line(), Any, stdio MCP proxy: truncate oversized tool results before they reach Claude Code., Walk MCP JSON-RPC result and truncate text tool payloads. (+2 more)
+
+### Community 604 - "Community 604"
+Cohesion: 0.40
+Nodes (10): summarize_harness_step(), Regression: harness step summaries must carry tool_use names and tool_result bod, Replay the failing turn's stream: tool evidence must survive into summaries., _step(), test_pr_title_stream_receipts_carry_tool_evidence(), test_summarize_assistant_text_preserved(), test_summarize_system_subtype(), test_summarize_tool_result_carries_body() (+2 more)
+
+### Community 605 - "Community 605"
+Cohesion: 0.42
+Nodes (7): ChatAttentionRequest, DummyBus, DummyPolicy, DummyTransport, _noop_create_task(), test_attention_request_sends_email_for_critical(), test_attention_request_skips_immediate_email_for_error()
+
+### Community 606 - "Community 606"
+Cohesion: 0.40
+Nodes (8): Any, recommend_actions_from_alerts(), summarize_recommended_actions(), main(), test_policy_coherence_drop_error_actions(), test_policy_dedup_and_ordering(), test_policy_novelty_spike_warn_actions(), test_policy_summary()
+
+### Community 607 - "Community 607"
+Cohesion: 0.29
+Nodes (9): test_refit_consumes_label_rows_and_returns_weights(), test_refit_handles_empty_labels(), candidate_weights_from_labels(), load_labels(), main(), Any, Salience weight refit — DOCUMENTED STUB. Not run in production this round.  The, Read outcome label rows. Best-effort; [] if no DB configured. (+1 more)
+
+### Community 608 - "Community 608"
+Cohesion: 0.25
+Nodes (10): evaluate_counts(), fetch_live_counts(), load_single_consumer_channels(), main(), parse_numsub_output(), Path, Pure decision core: (violations, warnings, status_by_channel).      count > 1  -, Query live subscriber counts via redis-cli. Raises RuntimeError on infra failure (+2 more)
+
+### Community 609 - "Community 609"
+Cohesion: 0.24
+Nodes (6): main(), _print_report(), Any, Thin shim so repository.py::insert_crystallization() (which expects an     async, RunResult, _SingleConnPool
+
+### Community 610 - "Community 610"
+Cohesion: 0.29
+Nodes (10): _coerce_float(), compare_drives(), load_autonomy_state(), load_drive_state_v1(), main(), Any, Load the current autonomy_state_v2 for `subject`.      `load_autonomy_state_v2`, Best-effort numeric coercion for values read from the unvalidated     LocalProfi (+2 more)
+
+### Community 611 - "Community 611"
+Cohesion: 0.22
+Nodes (11): _load_prior_stance_into_ctx(), _prior_stance_cache_get(), _prior_stance_cache_set(), Store compact brief summary keyed by session_id for next-turn carryforward., Return stored brief summary if present and not expired; evict on expiry., Load prior-turn stance summary from the session cache into ctx as a TOP-LEVEL, test_load_prior_stance_into_ctx_noop_without_session_id(), test_load_prior_stance_into_ctx_sets_top_level_from_cache() (+3 more)
+
+### Community 612 - "Community 612"
+Cohesion: 0.29
+Nodes (9): _plan_request_from_step_ctx(), Rebuild PlanExecutionRequest args/context from exec ctx (merged from payload.arg, _skill_args(), test_plan_request_merges_capability_bridge_skill_args_from_metadata(), Exec rebuilds PlanExecutionRequest from ctx; docker prune must see outer user te, _skill_args_from_plan(), test_plan_request_does_not_override_explicit_skill_args(), test_plan_request_injects_from_messages_when_raw_absent() (+1 more)
+
+### Community 613 - "Community 613"
+Cohesion: 0.29
+Nodes (10): Unit tests for the Phase 4 drive-pressure measurement probe (2026-07-12).  Measu, Direct unit test of the helper itself: a raising logger.info must be     caught, The logged pressures must be the SAME dict the reducer actually folded     into, A probe logging failure must never break the hot chat-turn path. The     call si, test_log_autonomy_pressure_probe_never_raises_on_logging_failure(), test_pressure_probe_failure_is_swallowed_and_reducer_still_completes(), test_run_autonomy_reducer_logs_pressure_probe(), test_run_autonomy_reducer_pressure_probe_matches_folded_state() (+2 more)
+
+### Community 614 - "Community 614"
+Cohesion: 0.40
+Nodes (10): _build_evidence_trail(), _engine(), _load_field_state_for_tick(), _load_latest_self_state(), _load_self_state_by_id(), Any, Read-only debug API for substrate self-state snapshots., self_state_evidence_trail() (+2 more)
+
+### Community 615 - "Community 615"
+Cohesion: 0.35
+Nodes (9): appendLiveAgentStep(), buildTimelineRows(), ensureLiveTracePanel(), extractAgentTrace(), formatDuration(), normalizeSummary(), resolveLiveTraceAnchor(), shouldShowAgentTrace() (+1 more)
+
+### Community 616 - "Bus Channels: Graph Compression & RDF"
+Cohesion: 0.33
+Nodes (9): attach(), buildCorrelationGraphElements(), buildGraphElements(), destroyCy(), filterSignalsByLayer(), isPlaceholderDimensions(), isStubSignal(), organClassColor() (+1 more)
+
+### Community 617 - "Community 617"
+Cohesion: 0.29
+Nodes (6): _Store, test_presence_invalid_payload_is_422(), test_presence_roundtrip(), test_situation_brief_reflects_manual_presence(), test_situation_status_and_brief(), test_situation_status_and_brief_disabled()
+
+### Community 618 - "Community 618"
+Cohesion: 0.38
+Nodes (9): build_routes_response(), _entry_to_dict(), get_routes_payload(), _probe_one(), Any, Route catalog and upstream health cache for GET /routes., refresh_route_health_cache(), RouteHealthEntry (+1 more)
+
+### Community 619 - "Community 619"
+Cohesion: 0.31
+Nodes (9): Regression for fix/mind-enrichment-wall-budget: the shipped default wall must, _reload_settings(), test_config_warnings_silent_when_disabled(), test_config_warns_on_http_timeout_not_above_wall(), test_config_warns_on_sub_viable_wall(), test_default_wall_is_viable_for_three_phase_synthesis(), test_mind_enrichment_defaults_off(), test_mind_enrichment_reads_env() (+1 more)
+
+### Community 620 - "Community 620"
+Cohesion: 0.20
+Nodes (7): CollapseTriageEvent, Config, Any, BaseModel, RAGDocumentEvent, Defines the schema for explicitly adding a document to the RAG store,     coming, Converts the RAG document event into the standard format.
+
+### Community 621 - "Community 621"
+Cohesion: 0.45
+Nodes (10): _coverage(), _fake_backend(), test_backend_error_degrades_to_no_followup(), test_capability_denied_returns_empty(), test_disabled_returns_empty(), test_dry_run_skips_fetch(), test_fetches_under_covered_section(), test_gate_evaluation_error_degrades_to_empty() (+2 more)
+
+### Community 623 - "Community 623"
+Cohesion: 0.36
+Nodes (6): _iter_python_files(), _parse_ast(), Module, Path, _relative(), TestSparkContractGate
+
+### Community 624 - "Community 624"
+Cohesion: 0.44
+Nodes (10): MonkeyPatch, Docker compose passes empty RETINA_WIDTH/HEIGHT; must not crash Settings()., _reload_settings(), test_blank_retina_dimensions_coerced_to_none(), test_blank_retina_width_and_height_together(), test_jpeg_quality_clamped(), test_retina_dimensions_explicit_integers(), test_retina_source_explicit_overrides_path_alias() (+2 more)
+
+### Community 625 - "Community 625"
+Cohesion: 0.22
+Nodes (10): Self-State Continuity and Live Dimensions v1 (spec, ideas 1-2 implemented), Brainstorming Session #1 - Appendix Ideas 3-10, Idea 10: Predictive substrate (forward model), Idea 3: Close the action outcome feedback loop, Idea 4: Bridge autonomy drive pressures to self-state, Idea 5: Substrate-level surprise signal (prediction error), Idea 6: Rolling self-state archive, Idea 7: Drive audit loop (+2 more)
+
+### Community 626 - "Community 626"
+Cohesion: 0.38
+Nodes (8): GoalGenerationMode, _base_template(), _evidence_rules_text(), generate_goal_statement(), _llm_goal_text(), test_evidence_rules_adds_tension_clause(), test_llm_mode_falls_back_to_evidence_rules(), test_template_mode_returns_base_template()
+
+### Community 627 - "Community 627"
+Cohesion: 0.27
+Nodes (6): LogRecord, _install_stdlib_logging_bridge(), _InterceptHandler, lifespan(), FastAPI, Route stdlib logging records into loguru.      The worker (`orion.spark.concept_
+
+### Community 628 - "Community 628"
+Cohesion: 0.20
+Nodes (10): Channel "orion:kg:edge:ingest.v1" (kind=event, schema=KgEdgeIngestV1) producers=[orion-topic-foundry] consumers=[orion-rdf-writer, orion-graphdb], Channel "orion:topic:foundry:drift:alert.v1" (kind=event, schema=TopicFoundryDriftAlertV1) producers=[orion-topic-foundry] consumers=[*], Channel "orion:topic:foundry:enrich:complete.v1" (kind=event, schema=TopicFoundryEnrichCompleteV1) producers=[orion-topic-foundry] consumers=[*], Channel "orion:topic:foundry:run:complete.v1" (kind=event, schema=TopicFoundryRunCompleteV1) producers=[orion-topic-foundry] consumers=[*], Schema: KgEdgeIngestV1, Schema: TopicFoundryDriftAlertV1, Schema: TopicFoundryEnrichCompleteV1, Schema: TopicFoundryRunCompleteV1 (+2 more)
+
+### Community 629 - "Community 629"
+Cohesion: 0.36
+Nodes (6): BaseModel, datetime, SparkStateSnapshotAckV1, _coerce_iso(), datetime, TestSparkStateSnapshotAckV1
+
+### Community 630 - "Community 630"
+Cohesion: 0.44
+Nodes (7): explain_alerts(), Any, summarize_explanations(), main(), test_explain_alerts_coherence_drop(), test_explain_alerts_novelty_spike(), test_summarize_explanations()
+
+### Community 631 - "Community 631"
+Cohesion: 0.33
+Nodes (9): _find_collisions(), _format_time_of_day(), _load_cadences(), main(), Path, Minimal distance in minutes between two minute-of-day values, generic over     s, Returns {cadence_name: minute_of_day} for all four named cadences (including the, _read_env_example_values() (+1 more)
+
+### Community 632 - "Community 632"
+Cohesion: 0.33
+Nodes (9): Derive periodic-scheduler finding strings from skills.docker.ps_status.v1 result, scheduler_docker_findings(), test_empty_not_dict(), test_exited_with_unhealthy_text_skipped(), test_healthy_running_no_findings(), test_missing_state_requires_up_prefix(), test_running_unhealthy_finding(), test_unavailable_no_findings() (+1 more)
+
+### Community 633 - "Community 633"
+Cohesion: 0.36
+Nodes (5): CoreEventCache, get_core_event_cache(), _is_turn_effect_alert(), _normalize_turn_effect_alert(), Any
+
+### Community 634 - "Community 634"
+Cohesion: 0.44
+Nodes (9): _attempt_mind_handoff_chat_stance_shortcut(), If Orch supplied a validated Mind handoff, skip the LLM stance synthesis step., _exec_prep(), ExecutionStep, _step(), test_shortcut_returns_none_when_orch_did_not_authorize_skip(), test_shortcut_returns_none_when_payload_invalid(), test_shortcut_returns_none_when_skip_flag_without_authorization() (+1 more)
+
+### Community 635 - "Community 635"
+Cohesion: 0.22
+Nodes (8): _format_message_history_for_chat_prompt(), Compact transcript for chat_general / chat_quick Jinja (message_history).     Sk, Regression guardrails for brain-lane chat prompts + recall gating.  Rationale (2, Brittle but cheap: if someone reverts router recall wiring, CI fails., Empty message_history must never be the only dialogue anchor when turns exist., test_chat_quick_render_surfaces_transcript_not_only_user_line(), test_format_message_history_includes_latest_user_and_assistant(), test_router_still_wires_plan_ctx_latest_user_text_for_recall_decision()
+
+### Community 636 - "Community 636"
+Cohesion: 0.29
+Nodes (9): Non-amnesiac acceptance check for `_run_autonomy_reducer`.  Verifies the reducer, Store returning None (unreachable / no DSN) must not change today's     fallback, save_autonomy_state_v2 raising must not propagate out of the reducer --     belt, Regression: chat_autonomy_movement_debug['pressures_before'] must reflect     th, test_run_autonomy_reducer_falls_back_to_v1_baseline_when_store_unreachable(), test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_state(), test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_call(), test_run_autonomy_reducer_write_failure_is_swallowed() (+1 more)
+
+### Community 637 - "Community 637"
+Cohesion: 0.24
+Nodes (8): health(), latest(), lifespan(), Any, FastAPI, get_settings(), BaseSettings, Settings
+
+### Community 638 - "Community 638"
+Cohesion: 0.29
+Nodes (9): _make_worker(), When ENABLE_COMPRESSION_RUNTIME=false the tick does nothing., All federators returning [] must not raise — just skip region., If LLM token budget is 0, no summarization occurs but regions are still processe, Substrate clusters must default to 'hotspot' so we don't spuriously flood     su, test_substrate_scope_labels_clusters_hotspot_not_contradiction(), test_worker_budget_gate_halts_mid_batch(), test_worker_disabled_skips_tick() (+1 more)
+
+### Community 639 - "Community 639"
+Cohesion: 0.27
+Nodes (8): correlation_chain_from_cognition_trace(), _map_step_organ(), Any, Synthesize Organ Signals correlation chains from cached cognition traces., Build a correlation graph chain when signal inspect cache missed the turn., _step_services(), Correlation API fallback from cognition trace cache., test_correlation_chain_from_cognition_trace_builds_step_chain()
+
+### Community 640 - "Community 640"
+Cohesion: 0.31
+Nodes (9): _first_json_object(), hub_memory_graph_suggest_text(), _openai_choice_message_text(), Any, Extract memory_graph_suggest model text from CortexChatResult (final_text + step, Recover visible assistant text from gateway ``raw`` OpenAI completion shape., Prefer final_text; fall back to llm_memory_graph_suggest step LLMGatewayService, _step_text_candidates() (+1 more)
+
+### Community 641 - "Community 641"
+Cohesion: 0.27
+Nodes (9): presence_snapshot(), Any, Hub presence — Orion's chat liveness as a self-state observable.  Records chat-t, Test helper: clear in-process presence state., Presence from in-process turn history; None before the first turn., Record one chat turn; best-effort, never raises, never blocks chat.      The Pos, record_turn(), reset() (+1 more)
+
+### Community 642 - "Community 642"
+Cohesion: 0.31
+Nodes (10): applyDebugTextLayout(), buildMemoryDebugRecallEntryNode(), clearMemoryDebugPanel(), collectRecallEntries(), normalizeMemoryDebugModel(), renderMemoryDebugModal(), summarizeInlineText(), toPrettyText() (+2 more)
+
+### Community 643 - "Community 643"
+Cohesion: 0.29
+Nodes (5): fetchSection(), metaForSection(), refresh(), renderError(), renderSection()
+
+### Community 644 - "Community 644"
+Cohesion: 0.31
+Nodes (6): _build(), test_context_metadata_mind_enabled_true_passes_through(), test_grounded_small_payload_sets_metadata_mind_enabled_true(), test_missing_mind_enabled_reports_not_requested(), test_string_true_in_context_metadata_is_normalized(), test_top_level_mind_enabled_true_is_normalized()
+
+### Community 645 - "Community 645"
+Cohesion: 0.31
+Nodes (8): frames(), health(), latest_frame(), latest_tensor(), lifespan(), Any, FastAPI, salient_events()
+
+### Community 646 - "Community 646"
+Cohesion: 0.44
+Nodes (9): _collect_dimensions(), _env_kind_from_event(), _format_ts(), main(), _metric_name_from_event(), Any, Counter, _redact_payload() (+1 more)
+
+### Community 647 - "Community 647"
+Cohesion: 0.31
+Nodes (9): client(), _empty_projection_with_diagnostics(), _mind_prep(), TestClient, Regression: populated projection must not downgrade to starved fallback silently, Regression for fix/mind-enrichment-wall-budget: a light Mind run that sends NO, test_light_path_without_projection_does_not_claim_orch_starvation(), test_mind_run_emits_projection_starvation_diagnostics() (+1 more)
+
+### Community 648 - "Community 648"
+Cohesion: 0.42
+Nodes (9): _legacy_self_state_payload_with_policy_pressure(), Regression tests for a real live incident (2026-07-12): after Phase 0 removed `p, _store_with_row(), _store_with_rows(), test_load_latest_self_state_degrades_to_none_on_legacy_incompatible_row(), test_load_latest_self_state_still_parses_a_valid_row(), test_load_recent_self_states_skips_legacy_row_keeps_valid_ones(), test_load_self_state_for_attention_frame_degrades_to_none_on_legacy_row() (+1 more)
+
+### Community 649 - "Community 649"
+Cohesion: 0.27
+Nodes (8): health(), inspection(), lifespan(), Any, FastAPI, summary(), BaseSettings, Settings
+
+### Community 650 - "Community 650"
+Cohesion: 0.31
+Nodes (6): _Dim, _FakeSelfState, _sample_self_state(), test_seed_v3_headline_still_reads_reliability_from_dimensions(), test_seed_v3_moves_reliability_to_infra_only(), test_seed_v3_still_emits_saturated_felt_for_audit()
+
+### Community 651 - "Community 651"
+Cohesion: 0.24
+Nodes (5): _dim(), Confirms the actual bug mechanism directly, with the exact dimension     reading, Reproduces the live incident's exact dimension readings.      The `uncertainty`, _self_state_payload(), test_phi_from_self_state_novelty_is_zero_with_live_incident_dimensions()
+
+### Community 652 - "Community 652"
+Cohesion: 0.42
+Nodes (9): _drive(), _make_worker(), Unit tests for the Orion embodiment C producer hook.  Verifies the substrate wor, test_cache_drive_state_fails_open_on_bad_decode(), test_emit_fails_open_when_publish_raises(), test_flag_off_publishes_nothing(), test_flag_on_publishes_one_involuntary_intent(), test_no_drive_state_publishes_nothing() (+1 more)
+
+### Community 653 - "Community 653"
+Cohesion: 0.47
+Nodes (9): _make_worker(), Unit tests for the Orion embodiment perception->substrate ingest consumer.  Veri, _set_decode(), test_flag_off_writes_nothing(), test_flag_on_writes_real_proximity_node(), test_invalid_payload_fails_open(), test_no_store_fails_open(), test_store_write_exception_fails_open() (+1 more)
+
+### Community 654 - "Community 654"
+Cohesion: 0.38
+Nodes (9): _make_worker(), datetime, Unit tests for the episodic consolidation tick (self-modeling loop rung 4).  Ver, _receipt(), test_episodic_tick_disabled_is_noop(), test_episodic_tick_fails_open_on_store_error(), test_episodic_tick_is_idempotent_within_a_window(), test_episodic_tick_saves_proposal_marked_episode() (+1 more)
+
+### Community 655 - "Community 655"
+Cohesion: 0.31
+Nodes (3): _peak_threshold(), STTEngine, get_stt_engine()
+
+### Community 656 - "Community 656"
+Cohesion: 0.33
+Nodes (8): ExecutionDispatchFrameV1, _dispatch_status_summary(), _engine(), execution_dispatch_latest(), _load_latest_dispatch_frame(), Any, Read-only debug API for substrate execution dispatch frames., Operator-visible breakdown of what actually happened in this frame --     P3's "
+
+### Community 657 - "Community 657"
+Cohesion: 0.22
+Nodes (9): Reverie Narrate (Spontaneous Felt-Layer Narration), SpontaneousThoughtV1 (schema), Simulation, Skills — Mesh Presence (Tailscale), Stance React, Story Weave, Substrate Inspect, Substrate Observe (+1 more)
+
+### Community 658 - "Community 658"
+Cohesion: 0.42
+Nodes (7): CognitionTraceAdapter, adapter(), _payload_with_correlation(), test_cognition_trace_adapter_chat_general(), test_cognition_trace_adapter_cognition_trace_kind(), test_cognition_trace_adapter_envelope_correlation_only(), test_cognition_trace_adapter_no_pii_in_signal()
+
+### Community 659 - "Community 659"
+Cohesion: 0.28
+Nodes (8): _get_engine(), load_pending_requests(), persist_compaction_delta(), Phase F store — read the compaction-request queue, persist staged deltas.  Two s, Recent un-consumed compaction requests (Phase-E queue). [] on any miss.      Rea, Insert one staged delta. Never raises; idempotent on delta_id.      Writes ONLY, Regression: the default loader must match the positional RequestLoader     alias, test_default_request_loader_accepts_positional_limit()
+
+### Community 660 - "Community 660"
+Cohesion: 0.28
+Nodes (5): _parse_list(), BaseSettings, Settings, Docker compose may pass empty strings when .env keys are missing., test_settings_ignore_empty_substrate_env()
+
+### Community 661 - "Community 661"
+Cohesion: 0.28
+Nodes (7): get_cognition_library(), Returns the scanned list of Packs and Verbs available in the system.     Used by, find_repo_root(), Any, Path, Scans the orion/cognition folder for packs and verbs.     Returns:         {, scan_cognition_library()
+
+### Community 662 - "Community 662"
+Cohesion: 0.31
+Nodes (8): apply_curiosity_hint(), _fetch_fresh_candidates(), format_curiosity_hint(), Any, Curiosity focus hint for the Hub agent lane (self-observability v2).  When the a, Latest curiosity candidate set newer than _MAX_AGE_SEC, else []., One bounded hint line from the strongest candidate summaries, or None., Prepend the focus hint to ``prompt`` when available; never raises.
+
+### Community 663 - "Community 663"
+Cohesion: 0.31
+Nodes (8): get(), get_latest(), Any, In-memory store for the latest social-room routing_debug per room.  Hub writes a, Record the latest routing_debug for a completed social-room turn., Return the latest snapshot for a specific room, or None., Return the most recently stored snapshot across all rooms., store()
+
+### Community 664 - "Community 664"
+Cohesion: 0.31
+Nodes (6): build_spark_introspect_candidate_envelope(), publish_spark_introspect_candidate(), Any, Build a spark.candidate envelope for the introspector EKG / turn-effect UI., Publish spark.candidate so spark-introspector refreshes tissue/phi on chat turns, test_build_spark_introspect_candidate_envelope_carries_turn_effect()
+
+### Community 666 - "Community 666"
+Cohesion: 0.31
+Nodes (7): _client_result(), _ensure_hub_scripts_import_path(), hub_settings(), _msg_payload(), Any, Hub memory_graph_suggest structured-output request wiring., test_suggest_request_includes_structured_options()
+
+### Community 667 - "Community 667"
+Cohesion: 0.31
+Nodes (5): _atlas_emission(), _atlas_pressure_receipt(), Newest global receipt for another node must not appear on atlas latest., test_latest_chain_shape(), test_latest_chain_skips_non_matching_global_receipt()
+
+### Community 668 - "Community 668"
+Cohesion: 0.33
+Nodes (5): _candidate(), _sample_dispatch_frame(), test_latest_includes_status_summary_counts(), test_latest_returns_frame(), test_latest_status_summary_all_zero_on_empty_frame()
+
+### Community 669 - "Community 669"
+Cohesion: 0.42
+Nodes (6): _atlas_field_state(), _fake_engine_with_field(), test_field_capability_llm_inference(), test_field_latest_not_found(), test_field_latest_returns_parsed_state(), test_field_node_atlas_returns_vector_and_capabilities()
+
+### Community 670 - "Community 670"
+Cohesion: 0.33
+Nodes (4): _DummyBus, _DummyStore, test_get_stats_returns_tracker_snapshot(), test_handler_mapping_includes_get_stats()
+
+### Community 671 - "Community 671"
+Cohesion: 0.39
+Nodes (8): client(), _mind_prep(), _projection_with_item(), TestClient, test_health_ok(), test_mind_run_deterministic_ok(), test_mind_run_emits_shadow_synthesis_from_projection_items_without_authority(), test_mind_run_surfaces_cognitive_projection_seen_without_shadow_when_no_items()
+
+### Community 672 - "Community 672"
+Cohesion: 0.22
+Nodes (9): orion-ollama-host docker-compose (GPU runtime, port 11434, healthcheck, model volume), orion-ollama-host: wrapper around official Ollama container, auto-pulls model on startup, exposes port 11434, orion-ollama-host dependencies (pydantic, pydantic-settings, PyYAML, requests), orion-pageindex docker-compose (port 8360, PageIndex build args, journal_entry_index table wiring), orion-pageindex: standalone journals PageIndex service (corpora rebuild/status/query API for journals and chat_episodes), orion-pageindex dependencies (fastapi, uvicorn, pydantic, psycopg2-binary, SQLAlchemy, pytest), orion-rag docker-compose (bus request/reply channels, VECTOR_DB_URL, EMBEDDING_MODEL), orion-rag: retrieval-augmented generation orchestrator, enriches queries with vector-db context before delegating to LLM host (+1 more)
+
+### Community 673 - "Community 673"
+Cohesion: 0.33
+Nodes (8): callsyne_room_message(), health(), lifespan(), _normalize_signature(), Any, FastAPI, Request, _verify_webhook_hmac_signature()
+
+### Community 674 - "Community 674"
+Cohesion: 0.25
+Nodes (9): orion-sql-db docker-compose.yml (Postgres 15 + pgAdmin), mem_limit/autovacuum tuning to prevent TOAST-vacuum OOM host freeze (16g cap, bounded vacuum memory), orion-sql-db: PostgreSQL database + pgAdmin client, orion-state-journaler docker-compose.yml, orion-state-journaler requirements.txt, orion-state-journaler: Spark/equilibrium snapshot rollup journaler to Postgres, orion-state-service docker-compose.yml, orion-state-service README (+1 more)
+
+### Community 675 - "Community 675"
+Cohesion: 0.31
+Nodes (8): build_journal_entry_index_select(), Any, datetime, Select, Session, query_journal_entry_index(), _tokens(), test_simple_filtered_retrieval_sql_shape()
+
+### Community 676 - "Community 676"
+Cohesion: 0.31
+Nodes (5): _drain_grammar_tasks(), _grammar_payload(), _metacog_payload(), Regression tests for sql-writer bus consumer stall (grammar INSERT hang blocking, test_grammar_persist_is_non_blocking_and_allows_next_envelope()
+
+### Community 677 - "Community 677"
+Cohesion: 0.53
+Nodes (8): _ok_result_json(), _req(), _settings(), test_empty_base_url_fails_open(), test_http_500_fails_open(), test_ok_returns_result(), test_oversized_body_fails_open(), test_timeout_fails_open()
+
+### Community 678 - "Community 678"
+Cohesion: 0.64
+Nodes (8): _allowed_schemas(), _get_cached(), list_columns(), list_schemas(), list_tables(), Any, _set_cached(), table_fingerprint()
+
+### Community 679 - "Community 679"
+Cohesion: 0.36
+Nodes (7): BaseSettings, Settings, _clear_transition_env(), MonkeyPatch, test_settings_reads_legacy_skip_enabled_alias(), test_settings_reads_legacy_skip_max_sec_alias(), test_settings_refresh_ttl_default_zero()
+
+### Community 680 - "Community 680"
+Cohesion: 0.42
+Nodes (8): _built_state(), _live_shaped_field(), test_context_channels_not_unresolved(), test_dimension_evidence_is_dimension_specific(), test_pressure_channels_in_unresolved_pressures(), test_stabilized_but_loaded_label(), test_stabilizers_in_stabilizing_factors(), test_stabilizers_not_in_unresolved_pressures()
+
+### Community 681 - "Community 681"
+Cohesion: 0.25
+Nodes (8): Endogenous Drive Origination Design (Step 1 spec), Internal Economy Scarcity Allocation Design (Step 4 spec), Phase 2: Spark ConceptProfile Graph Read Model, Phase 3A: Shadow Rollout for Spark ConceptProfile Repository, Phase 3B: Parity Evidence and Cutover-Readiness Model, Phase 4: ConceptProfile Runtime Cutover (concept_induction_pass), Phase 0: Spark Concept Profile Repository Seam, Autonomy Origination Measurement Gate (scripts/analysis/README.md)
+
+### Community 682 - "Community 682"
+Cohesion: 0.25
+Nodes (8): Tailscale auth key placeholder file (empty), Admin SSH authorized_keys policy, Script: orion-bootstrap.sh, Orion Node Bootstrap README (Ubuntu 24.04), Requirement: docker-compose.repo SSH URL, Requirement: Tailscale auth key (env or file), Script: verify-agent.sh, Script: verify-gpu.sh
+
+### Community 683 - "Community 683"
+Cohesion: 0.36
+Nodes (7): fetch_attended_target_ids(), open_readonly_connection(), datetime, Kill-criterion eval: attention-bound proposal target diversity (P5).  `inspect_a, Open a psycopg2 connection and force a read-only session.      Returns None on a, Return the target_id of every inspect_attended_target candidate whose     parent, run()
+
+### Community 684 - "Community 684"
+Cohesion: 0.25
+Nodes (8): enum, ExecutiveControl, Generative, MemoryAccess, MetaCognition, Perception, SelfModification, Transform
+
+### Community 685 - "Community 685"
+Cohesion: 0.36
+Nodes (6): join_openai_message_content(), Any, Normalize OpenAI-compatible message.content (str or part list) to plain text., Tests for join_openai_message_content helper., test_join_list_content_skips_reasoning_parts(), test_join_string_content()
+
+### Community 686 - "Community 686"
+Cohesion: 0.57
+Nodes (7): detect_contradictions(), detect_duplicates(), DetectionResult, _jaccard(), merge_detection(), _normalize_text(), _token_set()
+
+### Community 687 - "Community 687"
+Cohesion: 0.50
+Nodes (7): insert_link(), list_links(), neighborhood(), _normalize_uuid(), Any, Pool, Return crystallization link neighborhood (not Graphiti).
+
+### Community 688 - "Community 688"
+Cohesion: 0.32
+Nodes (7): ChatResultPayload, EnrichedChat, BaseModel, Standardized payload for LLM generation results., Enriched metadata for a chat message (tags, summary, embeddings pointer)., Minimal payload capturing a raw chat exchange., RawChat
+
+### Community 689 - "Community 689"
+Cohesion: 0.25
+Nodes (8): Composition status taxonomy: COMPOSED/SHADOW/DUPLICATE/REHEARSAL, inner_state_registry.py: registry of all self-state signals, Rationale: registry built after signal duplication/dead-end rediscovered 5x by grep-archaeology, SelfStateV1 (Layer 6: the mood), Canonical phi: _phi_from_self_state() / _get_phi_stats(), orion-equilibrium-service heartbeat trigger, OrionTissue: fallback-only tensor (cold-start/outage path), Rationale: spark_engine.py/integration.py/strategies.py deleted (zero production consumers, third φ implementation)
+
+### Community 691 - "Community 691"
+Cohesion: 0.39
+Nodes (7): eval_row_to_v1_v2_compare(), infer_pressure_category_for_eval_row(), pressure_evidence_from_eval_suite_rows(), Any, Helpers to map recall_eval suite rows into mutation pressure metadata (proposal-, Compact V1 vs V2 summary for MutationPressureEvidenceV1.metadata["v1_v2_compare", Build first-class pressure evidence rows from recall_eval-style dicts (manual in
+
+### Community 692 - "Community 692"
+Cohesion: 0.39
+Nodes (6): add_test(), smoke_all_notifications.sh script, SKIP_COMPOSE, start_stack(), usage(), wait_for_health()
+
+### Community 693 - "Community 693"
+Cohesion: 0.57
+Nodes (7): _load_app(), MonkeyPatch, Path, test_health(), test_health_proposal_review_block_parent_writable_before_first_write(), test_health_proposal_review_block_store_configured(), test_health_proposal_review_block_store_missing()
+
+### Community 694 - "Community 694"
+Cohesion: 0.32
+Nodes (7): _ensure_cortex_exec_paths(), _purge_app_modules_if_wrong_service(), pytest_sessionstart(), Make the top-level ``app`` package resolve to orion-cortex-exec.      In a multi, Avoid importing full spaCy when tests only need app.router (pulls autonomy -> co, Service .env often sets large LLM_CHAT_* dev budgets; unit tests expect canonica, _stub_spacy_for_router_imports()
+
+### Community 695 - "Community 695"
+Cohesion: 0.36
+Nodes (7): build_region(), Deterministic region ID from scope + kind + sorted node URIs., stable_region_id(), test_region_builder_different_nodes_different_id(), test_region_builder_produces_valid_region(), test_region_builder_stable_id_idempotent(), test_region_builder_trust_tier_inherits_lowest()
+
+### Community 696 - "Community 696"
+Cohesion: 0.32
+Nodes (7): api_llm_routes(), _base_url(), fetch_routes(), Any, ClientTimeout, Hub client for LLM gateway GET /routes catalog., _timeout()
+
+### Community 697 - "Community 697"
+Cohesion: 0.29
+Nodes (7): _chat_turn_trace_linkage(), Canonical correlation linkage for chat turn metadata (Runtime Trace Nexus §5.8)., Correlation ID propagation tests (Runtime Trace Nexus §5.8 gate).  Manual stagin, Hub must expose the same corr id used for cortex + trace APIs (spec §5.8)., HTTP chat must expose trace_linkage canonical id, not cortex-only id (§5.8)., test_chat_response_metadata_includes_canonical_correlation_id(), test_trace_linkage_canonical_preferred_over_cortex_result_id()
+
+### Community 698 - "Community 698"
+Cohesion: 0.43
+Nodes (7): build_mutation_store_from_env(), build_parser(), _default_profile_payload(), main(), ArgumentParser, _resolve_control_plane_postgres_url(), seed_recall_canary_profile()
+
+### Community 699 - "Community 699"
+Cohesion: 0.54
+Nodes (7): _coerce(), _engine(), frames_range(), frames_tail(), Any, Read-only Self-brain API: realtime tail + playback range + window bounds.  Reads, window()
+
+### Community 700 - "Community 700"
+Cohesion: 0.29
+Nodes (5): _ensure_hub_scripts_import_path(), hub_client(), test_complete_goal_success_when_enabled(), test_dismiss_goal_success_when_enabled(), test_promote_goal_success_when_enabled()
+
+### Community 701 - "Community 701"
+Cohesion: 0.36
+Nodes (7): client(), MonkeyPatch, Path, TestClient, FCC model labels API for agent-claude mode., test_fcc_model_labels_disabled_by_default(), test_fcc_model_labels_reads_fixture_env()
+
+### Community 702 - "Community 702"
+Cohesion: 0.43
+Nodes (7): _denver_env(), _extract_format_hub_local_time_source(), Behavioral regression test for `formatHubLocalTime` in app.js.  Bug: orion-notif, Pull the real `formatHubLocalTime` (and its helpers) straight out of app.js., _run_node_denver(), test_naive_utc_created_at_renders_correct_denver_day_and_time(), test_offset_suffixed_value_is_not_double_converted()
+
+### Community 703 - "Community 703"
+Cohesion: 0.32
+Nodes (4): _bridge_suggest_block(), _memory_suggest_block(), test_app_js_wires_memory_graph_bridge_handlers(), test_memory_js_listens_for_bridge_import_event()
+
+### Community 704 - "Community 704"
+Cohesion: 0.25
+Nodes (4): mindRunsModal must not live under #scheduleModal.hidden or it never paints., Bare `global` is undefined in browsers and aborts DOMContentLoaded before tab wi, test_app_js_lane_api_uses_global_this_not_node_global(), test_mind_runs_modal_is_sibling_of_schedule_modal_not_nested()
+
+### Community 705 - "Community 705"
+Cohesion: 0.36
+Nodes (3): _FakeCortexClient, _Store, test_handle_chat_request_injects_session_presence()
+
+### Community 706 - "Bus Channels: Substrate Tier Telemetry"
+Cohesion: 0.36
+Nodes (4): _FakeBus, test_api_chat_response_feedback_publishes_valid_payload(), test_api_chat_response_feedback_rejects_invalid_payload(), test_feedback_downvote_emits_pressure_event_telemetry()
+
+### Community 707 - "Community 707"
+Cohesion: 0.32
+Nodes (3): _fake_engine(), _frame(), test_tail_returns_ascending_and_200()
+
+### Community 708 - "Community 708"
+Cohesion: 0.25
+Nodes (4): Regression guard: the cancel request must key off the per-connection id     capt, The Stop button must be shown for every WS send path that starts a     server-ca, test_app_js_shows_stop_button_on_every_turn_kind_send(), test_app_js_stop_request_uses_connection_id_not_session_id()
+
+### Community 709 - "Community 709"
+Cohesion: 0.29
+Nodes (8): orion-mesh-guardian docker compose deployment (port 7161, mounts /repo ro + docker.sock, NOTIFY_BASE_URL, equilibrium snapshot), orion-mesh-guardian: detects half-dead bus consumers on chat critical path, publishes Hub Pending Attention cards via notify, optional auto-remediation via docker compose, orion-mesh-guardian Python dependencies (fastapi, pydantic, httpx, pyyaml, redis, loguru, requests), orion-notify-digest docker compose deployment (port 7150, shared postgres with notify, drift alert env), orion-notify-digest: builds daily summary of notification activity, sends via orion-notify, integrates Topic Foundry topics/drift alerts, orion-notify docker compose deployment (port 7140, SMTP env, in-app channel, escalation poll), orion-notify: minimal notification host centralizing email delivery, attention requests, chat messages, recipient preferences, escalation, orion-notify Python dependencies (fastapi, requests, pyyaml, loguru, redis, httpx)
+
+### Community 710 - "Community 710"
+Cohesion: 0.43
+Nodes (6): classify_intent_v1(), IntentClassification, BaseModel, resolve_profile_for_intent(), test_biographical_intent(), test_fallback_profile()
+
+### Community 711 - "Community 711"
+Cohesion: 0.32
+Nodes (4): RDF chat-turn recall must honor the profile time window.  The graph stores no us, _run_window(), test_windowing_drops_out_of_window_and_stamps_kept(), test_windowing_noop_when_since_minutes_non_positive()
+
+### Community 712 - "Community 712"
+Cohesion: 0.46
+Nodes (6): _mock_post(), MonkeyPatch, RDF-backed recall fragments must score by real recency, not a frozen UUID sort., test_rdf_chatturn_fragments_score_by_recency(), test_rdf_fragment_ordering_uses_timestamp_not_uri(), test_rdf_graphtri_fragments_score_by_recency()
+
+### Community 713 - "Community 713"
+Cohesion: 0.25
+Nodes (8): orion-social-memory docker-compose.yml, orion-social-memory README, orion:chat:social:stored (social-memory input channel), orion-social-memory requirements.txt, orion-social-memory: relational continuity synthesizer for social-room turns, orion-social-room-bridge docker-compose.yml, orion-social-room-bridge requirements.txt, orion-social-room-bridge: social platform bridge (Callsyne/Hub)
+
+### Community 714 - "Community 714"
+Cohesion: 0.32
+Nodes (3): ConnectionManager, Any, WebSocket
+
+### Community 715 - "Community 715"
+Cohesion: 0.43
+Nodes (6): _load_settings_module(), test_evidence_index_wiring_exists_in_settings_env_compose_bus_and_registry(), test_feedback_wiring_exists_in_settings_env_and_compose(), test_journal_index_wiring_exists_in_settings_env_compose_bus_and_registry(), test_markdown_adapter_channel_wiring_exists_in_settings_env_compose_bus_and_registry(), test_parsed_document_channel_wiring_exists_in_settings_env_compose_bus_and_registry()
+
+### Community 716 - "Community 716"
+Cohesion: 0.68
+Nodes (7): _candidate(), _decision(), _self_state(), test_envelope_includes_refs(), test_envelope_includes_verb_mode_source_dry_run(), test_envelope_no_field_state_or_prompts(), test_envelope_read_only_constraints()
+
+### Community 717 - "Community 717"
+Cohesion: 0.52
+Nodes (6): BackgroundTasks, compare_runs(), enrich_run_endpoint(), get_run_endpoint(), UUID, fetch_run()
+
+### Community 718 - "Community 718"
+Cohesion: 0.38
+Nodes (7): Bus channel orion-exec:request:LLMGatewayService (LLM gateway intake), OrionBusAsync class (orion.core.bus.async_service.OrionBusAsync) used to publish/subscribe on Redis bus, orion-llm-gateway manual smoke tests: bus chat/exec_step envelopes, ollama vs vllm backend selection, orion-memory-consolidation docker compose deployment (port 8635, consolidation/crystallizer/concept-relation env), orion-mind router profiles: default (route_kind brain, chat_general, advisory) and conservative (route_kind no_chat, mandatory), orion-mind docker compose deployment: semantic/appraisal/stance LLM synthesis routes, evidence limits, LLM gateway intake channel, orion-mind Python dependencies (fastapi, pydantic, pyyaml, redis)
+
+### Community 719 - "Community 719"
+Cohesion: 0.33
+Nodes (7): config/autonomy/capability_policy.v1.yaml — policy config gating which autonomy capabilities may auto-execute per cycle, by side-effect class, required goal status, required drive origins/signal kinds, and per-cycle budget, capability journal.compose.episode — write side-effect, auto_execute true, requires goal status 'proposed', predictive drive origin, no required signal kinds, budget 1/cycle, capability recall.query.readonly — readonly side-effect, auto_execute true, requires goal status 'proposed', predictive drive origin, world_coverage_gap signal, budget 2/cycle (P4 addition, mirrors web.fetch.readonly's gate), capability web.fetch.readonly — readonly side-effect, auto_execute true, requires goal status 'proposed', predictive drive origin, world_coverage_gap signal, budget 2/cycle, capability web.fetch.write — external side-effect, auto_execute false, requires goal status 'planned', budget 0/cycle (blocked from autonomous execution), capability world_pulse.run — readonly side-effect, auto_execute true, requires no goal status, no drive origin gating, budget 1/cycle, Readonly capabilities (recall.query.readonly, P4): ConceptWorker is the sole production call site for maybe_execute_substrate_act_after_metabolism, which gates a Firecrawl fetch and a new inline RecallService RPC under config/autonomy/capability_policy.v1.yaml per cycle, trying recall first so a successful recall leaves that cycle's fetch budget unconsumed; degrades to a no-op if recall_bus/recall_source kwargs aren't wired
+
+### Community 720 - "Community 720"
+Cohesion: 0.43
+Nodes (4): is_excluded(), print_failed_logs(), up_all_services.sh script, up_one()
+
+### Community 721 - "Community 721"
+Cohesion: 0.29
+Nodes (7): Channel "orion:dream:compaction-delta" (kind=event, schema=MemoryCompactionDeltaV1) producers=[orion-dream] consumers=[none], Channel "orion:dream:log" (kind=event, schema=DreamResultV1) producers=[orion-cortex-exec] consumers=[orion-sql-writer, orion-dream], Channel "orion:dream:trigger" (kind=event, schema=DreamTriggerPayload) producers=[orion-dream] consumers=[orion-cortex-orch], Schema: DreamResultV1, Schema: DreamTriggerPayload, Schema: MemoryCompactionDeltaV1, Service: orion-dream
+
+### Community 722 - "Community 722"
+Cohesion: 0.29
+Nodes (7): Channel "orion:evidence:index:upsert" (kind=event, schema=EvidenceUnitV1) producers=[orion-sql-writer, *] consumers=[orion-evidence-index, orion-sql-writer, *], Channel "orion:evidence:markdown:ingest" (kind=event, schema=MarkdownSpecIngestV1) producers=[*] consumers=[orion-sql-writer, orion-evidence-index], Channel "orion:evidence:parsed:ingest" (kind=event, schema=ParsedDocumentIngestV1) producers=[*] consumers=[orion-sql-writer, orion-evidence-index], Schema: EvidenceUnitV1, Schema: MarkdownSpecIngestV1, Schema: ParsedDocumentIngestV1, Service: orion-evidence-index
+
+### Community 723 - "Community 723"
+Cohesion: 0.29
+Nodes (7): Channel "orion:graph:compression:events" (kind=event, schema=GraphCompressionRegionMaterializedV1) producers=[orion-graph-compression] consumers=[*], Channel "orion:graph:compression:stale" (kind=event, schema=CompressionStalenessMarkV1) producers=[orion-rdf-writer, orion-graph-compression] consumers=[orion-graph-compression], Channel "orion:substrate:mutation:pressure" (kind=event, schema=MutationPressureEvidenceV1) producers=[orion-graph-compression] consumers=[none], Schema: CompressionStalenessMarkV1, Schema: GraphCompressionRegionMaterializedV1, Schema: MutationPressureEvidenceV1, Service: orion-graph-compression
+
+### Community 724 - "Community 724"
+Cohesion: 0.29
+Nodes (7): orion-rdf-writer (bus → triples → RDF store service), orion-recall (memory retrieval / MemoryBundleV1 fusion service), orion-rdf-writer docker-compose.yml, orion-rdf-writer requirements.txt, orion-recall docker-compose.yml, orion-recall README.md, orion-recall requirements.txt
+
+### Community 725 - "Community 725"
+Cohesion: 0.43
+Nodes (5): GraphDeltaPlanV1, main(), _status(), build_graph_delta(), _escape_rdf_literal()
+
+### Community 726 - "Community 726"
+Cohesion: 0.38
+Nodes (4): _Node, End-to-end: a repeatedly-selected stuck loop must lose the coalition on     the, test_broadcast_history_tracks_selection(), test_rumination_lock_breaks_on_produced_path()
+
+### Community 727 - "Community 727"
+Cohesion: 0.43
+Nodes (5): fail(), _health_curl(), PYTHONPATH, run_pytest(), smoke_memory_cognition_loop_e2e.sh script
+
+### Community 728 - "Community 728"
+Cohesion: 0.33
+Nodes (7): Generated Juniper Feld join description, town_cards.yaml (cast source of truth), Juniper Feld (AI Town human player character card), Orion (AI Town character card), orion-ai-town docker-compose.yml, orion-ai-town README, orion-ai-town service (AI Town mesh wrapper)
+
+### Community 730 - "Community 730"
+Cohesion: 0.43
+Nodes (6): Skip journal PageIndex for compose paths that would self-loop on journal_entry_i, _skip_journal_pageindex_for_automated_trigger(), test_manual_collapse_not_skipped(), test_skips_metacog_digest(), test_skips_notify_summary(), test_skips_scheduler_daily()
+
+### Community 732 - "Community 732"
+Cohesion: 0.52
+Nodes (6): _clear_graphdb_env(), test_autonomy_graph_probe_configured_success(), test_autonomy_graph_probe_deep_optional_repo_ready_check(), test_autonomy_graph_probe_failure_logs_without_secret(), test_autonomy_graph_probe_non_200_logs_bounded_snippet(), test_autonomy_graph_probe_unconfigured_graceful()
+
+### Community 733 - "Community 733"
+Cohesion: 0.29
+Nodes (7): orion-cortex-orch Python Dependencies, orion-dream Docker Compose Service, orion-dream Service, orion-dream Python Dependencies, orion-embodiment Docker Compose Service, orion-embodiment Service, orion-embodiment Python Dependencies
+
+### Community 734 - "Community 734"
+Cohesion: 0.38
+Nodes (4): label_to_claude_model_id(), Map FCC env key labels to stable Claude tier model ids for claude CLI --model., test_label_to_tier_model_ids(), test_unknown_label_raises()
+
+### Community 735 - "Community 735"
+Cohesion: 0.29
+Nodes (4): Hub Skill Runner: exact catalogue prompt -> concrete skill verb (direct exec, no, Guards Hub Skill Runner catalogue against drift from templates/index.html., 23 operator catalogue skills (excludes placeholder, workflows, and free-text row, test_skill_runner_catalogue_entry_count_matches_non_workflow_options()
+
+### Community 737 - "Community 737"
+Cohesion: 0.43
+Nodes (4): _Store, test_inject_session_presence_fills_empty_client_dict_from_store(), test_inject_session_presence_preserves_client_payload(), test_inject_session_presence_uses_store_when_payload_missing()
+
+### Community 738 - "Community 738"
+Cohesion: 0.43
+Nodes (4): _fake_engine_with_frame(), _sample_attention_frame(), test_attention_latest_not_found(), test_attention_latest_returns_frame()
+
+### Community 739 - "Community 739"
+Cohesion: 0.43
+Nodes (4): _fake_engine_with_frame(), _sample_policy_frame(), test_policy_latest_not_found(), test_policy_latest_returns_frame()
+
+### Community 740 - "Community 740"
+Cohesion: 0.43
+Nodes (4): _fake_engine_with_frame(), _sample_proposal_frame(), test_proposals_latest_not_found(), test_proposals_latest_returns_frame()
+
+### Community 741 - "Community 741"
+Cohesion: 0.43
+Nodes (6): MonkeyPatch, Mid-turn send raising WebSocketDisconnect must still cancel (not only poller)., test_cancel_in_flight_turn_agent_claude(), test_cancel_in_flight_turn_orion_publishes(), test_run_awaitable_cancel_on_websocket_disconnect_exception(), test_run_awaitable_cancel_on_ws_disconnect()
+
+### Community 742 - "Community 742"
+Cohesion: 0.33
+Nodes (6): _load_env_key(), RDF_STORE_PASS, RDF_STORE_QUERY_URL, RDF_STORE_UPDATE_URL, RDF_STORE_USER, fuseki_prune_retention.sh script
+
+### Community 743 - "Community 743"
+Cohesion: 0.38
+Nodes (3): _ensure_jena(), _run_tdbcompact(), fuseki_tdb_compact.sh script
+
+### Community 745 - "Community 745"
+Cohesion: 0.57
+Nodes (6): build_state_response(), get_security_state(), get_security_state_root(), Any, set_security_state(), set_security_state_root()
+
+### Community 746 - "Community 746"
+Cohesion: 0.29
+Nodes (3): ``ORGAN_REGISTRY`` integrity (phase-2 causal DAG contract)., DFS from each organ must not revisit nodes on the stack (no cycles)., test_registry_acyclic()
+
+### Community 747 - "Community 747"
+Cohesion: 0.33
+Nodes (4): client(), _make_row(), Regression test: the ack must actually set attention_acked_at/ack_type/     ack_, test_attention_ack_persists_fields_on_notify_requests_row()
+
+### Community 749 - "Community 749"
+Cohesion: 0.33
+Nodes (3): _load_sql_writer_channel_kinds(), Ensure every subscribed bus kind has a sql-writer persistence path (prevents sil, test_subscribed_catalog_kinds_are_routable_or_explicitly_special()
+
+### Community 750 - "Community 750"
+Cohesion: 0.33
+Nodes (7): vllm-host (docker-compose service, GPU-backed vLLM runtime), orion-vllm-host Python dependencies (pydantic, pydantic-settings, pyyaml), voip-endpoint (docker-compose service, Asterisk/SIP host-networked), orion-voip-endpoint Python dependencies (fastapi, redis, pydantic), whisper-tts (docker-compose service, GPU TTS/STT), Orion Whisper TTS README (TTS/STT bus contracts, Coqui XTTS-v2, Whisper), orion-whisper-tts Python dependencies (TTS, openai-whisper, transformers pin)
+
+### Community 751 - "Community 751"
+Cohesion: 0.38
+Nodes (3): _load_settings_module(), test_tts_settings_xtts_defaults(), test_whisper_tts_timeout_settings_defaults()
+
+### Community 752 - "Community 752"
+Cohesion: 0.43
+Nodes (6): _channel_entry(), Bus catalog coverage for orion-execution-dispatch-runtime as a cortex-exec produ, recall.query.readonly (P4): the autonomy tick issues an inline recall RPC     fr, test_concept_induction_is_recall_service_request_producer(), test_execution_dispatch_runtime_is_action_outcome_producer(), test_execution_dispatch_runtime_is_background_exec_request_producer()
+
+### Community 754 - "Community 754"
+Cohesion: 0.57
+Nodes (6): _import_app_module(), _purge_module(), Path, test_deep_graph_verb_profile_binding(), test_rdf_adapter_builds_neighbor_query(), test_rdf_enabled_for_deep_graph_profile()
+
+### Community 755 - "Community 755"
+Cohesion: 0.33
+Nodes (5): description, $id, $schema, title, type
+
+### Community 756 - "Community 756"
+Cohesion: 0.33
+Nodes (6): enum, type, priority, high, low, medium
+
+### Community 757 - "Community 757"
+Cohesion: 0.40
+Nodes (6): Pattern Detection, Build RDF Triples, Recall Memory, Recall Profile: reflect.v1, Reflect, Web Search (Simulated)
+
+### Community 758 - "Community 758"
+Cohesion: 0.40
+Nodes (6): Perceive: Caption Frame, Perceive: Detect Open-Vocabulary Objects, Perceive: Embed Image, Perceive: Retina Fast Pipeline (Embed, Detect, Caption), Perceive Vision Events (Host -> Window -> Council), Perceive Vision Memory (Host -> Window -> Council -> Scribe)
+
+### Community 759 - "Community 759"
+Cohesion: 0.40
+Nodes (5): BaseModel, Standardized memory fragment returned by Recall service., Request to recall memory from various sources (Vector, SQL, RDF)., RecallRequest, RecallResult
+
+### Community 760 - "Community 760"
+Cohesion: 0.47
+Nodes (4): build_introspection_context(), Any, test_introspection_parity_for_primary_workflow_metadata(), test_introspection_context_preserves_workflow_identity_and_personality_metadata()
+
+### Community 761 - "Community 761"
+Cohesion: 0.33
+Nodes (6): orion-meta-tags service, orion-notify-digest service, Spark organ (salience, change, concept formation), orion-spark-concept-induction service, orion-spark-introspector service, orion-topic-foundry service
+
+### Community 762 - "Community 762"
+Cohesion: 0.47
+Nodes (4): check_beta_key(), print_env_file(), PYTHONPATH, context_exec_beta_gate.sh script
+
+### Community 764 - "Community 764"
+Cohesion: 0.73
+Nodes (5): _count_triples(), _export_batch(), _import_batch(), main(), _request()
+
+### Community 765 - "Community 765"
+Cohesion: 0.33
+Nodes (5): ACTIONS_DAILY_RUN_ONCE_DATE, NOTIFY_API_TOKEN, NOTIFY_BASE_URL, ORION_BUS_URL, smoke_actions_daily.sh script
+
+### Community 766 - "Community 766"
+Cohesion: 0.53
+Nodes (4): main(), run_fake_mode(), run_real_mode(), smoke_vision_caption_provenance.sh script
+
+### Community 767 - "Community 767"
+Cohesion: 0.53
+Nodes (5): _load_compose(), _parse_env_example(), Guards the fix for the ephemeral-/tmp cursor durability gap.  `services/orion-ac, test_compose_mounts_volume_covering_state_paths(), test_env_example_store_paths_not_under_tmp()
+
+### Community 770 - "Community 770"
+Cohesion: 0.33
+Nodes (6): FieldAttentionFrameV1 (substrate_attention_frames), FieldStateV1 (substrate_field_state), orion-attention-runtime service, orion-field-digester service (referenced upstream writer), orion-notify service (referenced alert sink), orion-athena-sql-db / orion-sql-db (referenced Postgres)
+
+### Community 771 - "Community 771"
+Cohesion: 0.40
+Nodes (5): health(), latest(), lifespan(), Any, FastAPI
+
+### Community 772 - "Community 772"
+Cohesion: 0.47
+Nodes (4): filter_world_context_capsule(), Any, test_filter_world_context_capsule_fail_open_missing(), test_filter_world_context_capsule_filters_expired_and_low_confidence()
+
+### Community 773 - "Community 773"
+Cohesion: 0.33
+Nodes (5): ORION_ACTIONS_TAILSCALE_PATH, ORION_CONTAINER_TAILSCALE_BIN, ORION_HOST_TAILSCALE_BIN, ORION_HOST_TAILSCALE_RUN, up-with-tailscale.sh script
+
+### Community 774 - "Community 774"
+Cohesion: 0.33
+Nodes (6): orion-equilibrium-service Docker Compose Service, orion-equilibrium-service Service, orion-equilibrium-service Python Dependencies, orion-field-digester Docker Compose Service, orion-field-digester Service, orion-field-digester Python Dependencies
+
+### Community 776 - "Community 776"
+Cohesion: 0.40
+Nodes (5): health(), latest(), lifespan(), Any, FastAPI
+
+### Community 777 - "Community 777"
+Cohesion: 0.33
+Nodes (3): Triple, Fetches triples from the substrate graph using bounded SPARQL.     Uses simple n, SubstrateFederator
+
+### Community 778 - "Community 778"
+Cohesion: 0.47
+Nodes (5): attention_latest(), _engine(), _load_latest_attention_frame(), Any, Read-only debug API for substrate field attention frames.
+
+### Community 779 - "Community 779"
+Cohesion: 0.53
+Nodes (4): MonkeyPatch, _request(), test_aitown_proxy_disabled_returns_404(), test_aitown_proxy_forwards_path()
+
+### Community 781 - "Community 781"
+Cohesion: 0.67
+Nodes (5): MonkeyPatch, _request(), test_knowledge_forge_alias_routes_forward_expected_paths(), test_knowledge_forge_proxy_requires_base_url(), test_knowledge_forge_proxy_returns_controlled_http_error()
+
+### Community 786 - "Community 786"
+Cohesion: 0.53
+Nodes (4): MonkeyPatch, _request(), test_world_pulse_alias_routes_forward_expected_paths(), test_world_pulse_proxy_returns_controlled_http_error()
+
+### Community 787 - "Community 787"
+Cohesion: 0.73
+Nodes (5): check_url(), fail(), pass(), verify_mind_llm_e2e.sh script, warn()
+
+### Community 788 - "Community 788"
+Cohesion: 0.40
+Nodes (5): _mind_prep(), _prep(), Any, Mind llm_uncertainty telemetry for semantic synthesis., _semantic_payload()
+
+### Community 789 - "Community 789"
+Cohesion: 0.40
+Nodes (5): health(), latest(), lifespan(), Any, FastAPI
+
+### Community 790 - "Community 790"
+Cohesion: 0.40
+Nodes (5): health(), latest(), lifespan(), Any, FastAPI
+
+### Community 793 - "Community 793"
+Cohesion: 0.33
+Nodes (4): Config, BaseSettings, Helper to parse the subscription channels from env var., Settings
+
+### Community 794 - "Community 794"
+Cohesion: 0.40
+Nodes (3): _active_doc_text(), Assert context-exec proposal ledger smoke scripts use durable storage defaults., test_proposal_review_doc_active_examples_use_durable_storage()
+
+### Community 795 - "Community 795"
+Cohesion: 0.33
+Nodes (3): seed-v2 keeps encoder input dims stable when HTTP traj is dark., test_execution_trajectory_stale_runs_excluded(), test_seed_v2_emits_cognitive_slots_when_trajectory_absent()
+
+### Community 796 - "Community 796"
+Cohesion: 0.47
+Nodes (5): _profiles_dir(), Path, Every shipped recall profile must declare cards_top_k for the memory-cards rail., test_all_recall_profiles_define_cards_backend_weight(), test_all_recall_profiles_define_cards_top_k()
+
+### Community 797 - "Community 797"
+Cohesion: 0.53
+Nodes (5): _load_core_event_cache(), _load_executor_module(), test_core_event_cache_filters_turn_effect_alerts(), test_format_recent_turn_effect_alerts_summary(), test_system_alert_tags_merge()
+
+### Community 798 - "Community 798"
+Cohesion: 0.40
+Nodes (5): Bus channel orion:memory:crystallization:proposed (memory.crystallization.proposed.v1), MemoryCrystallizationV1 artifact schema: governed cognitive memory, proposal/approval workflow, orion-memory-crystallizer docker compose deployment (port 8634, crystallization channel + Graphiti/FalkorDB env), orion-memory-crystallizer: governed cognitive memory crystallization worker; proposes/validates MemoryCrystallizationV1, projects to Chroma/Graphiti/FalkorDB, never canonical without governor, orion-memory-crystallizer Python dependencies (fastapi 0.111, asyncpg, psycopg2-binary)
+
+### Community 799 - "Community 799"
+Cohesion: 0.70
+Nodes (4): add_generic_repo_list(), add_hardcoded_repo_list(), install_from_ubuntu_repo(), install-nvidia.sh script
+
+### Community 800 - "Community 800"
+Cohesion: 0.50
+Nodes (3): cortex_exec_fleet_helpers.sh script, up_cortex_exec_fleet(), verify_cortex_exec_fleet()
+
+### Community 801 - "Community 801"
+Cohesion: 0.70
+Nodes (4): _imports_autonomy_v2(), Path, _python_files(), test_autonomy_state_v2_not_wired_into_phi_or_self_state()
+
+### Community 803 - "Community 803"
+Cohesion: 0.40
+Nodes (5): Chat (Generalist), Chat (Kids Story), Chat (Quick), Chat (Social Room), Orion Voice Finalize
+
+### Community 804 - "Community 804"
+Cohesion: 0.50
+Nodes (5): Daily Metacog v1, Daily Pulse v1, Journal Compose, Log (Collapse Mirror), Log Orion Metacognition
+
+### Community 805 - "Community 805"
+Cohesion: 0.70
+Nodes (5): Self Concept Induce, Self Concept Reflect, Recall Profile: self.factual.v1, Self Repo Inspect, Self Retrieve (Trust-Mode Lane Retrieval)
+
+### Community 806 - "Community 806"
+Cohesion: 0.50
+Nodes (5): Chat Discussion Window Journaling Workflow, Journal Dispatch Registry (trigger_kind -> policy, fail-closed), Orion Journaler Service Boundaries and Semantics, JournalEntryWriteV1.trigger_kind Propagation, chat.continuity.v1 Recall Profile (Recent sql_chat Only)
+
+### Community 807 - "Community 807"
+Cohesion: 0.40
+Nodes (5): orion-security-watcher (Guard: vision presence/alert debounce service), orion-security-watcher index.html template, orion-security-watcher docker-compose.yml, orion-security-watcher README.md, orion-security-watcher requirements.txt
+
+### Community 808 - "Community 808"
+Cohesion: 0.40
+Nodes (5): Rationale: concept_induction_pass stayed a bounded reader; missing runtime behavior was autonomous triggering, ConceptInductionTrigger contract (source_kind, subjects, trigger_reason, ...), Bounded trigger loop in ConceptWorker.handle_envelope(), Graph mapping shape (SparkConceptProfile/Subject/Concept/Cluster/StateEstimate RDF nodes), Rationale: graph write additive/isolated, LocalProfileStore stays source of truth
+
+### Community 809 - "Community 809"
+Cohesion: 0.70
+Nodes (4): _ensure_sys_path_stdlib_safe(), main(), Path, _repo_root()
+
+### Community 811 - "Community 811"
+Cohesion: 0.60
+Nodes (3): fail(), pass(), smoke_active_verbs.sh script
+
+### Community 812 - "Community 812"
+Cohesion: 0.60
+Nodes (4): _headers(), main(), _print_step(), Any
+
+### Community 813 - "Community 813"
+Cohesion: 0.70
+Nodes (3): fail(), need_cmd(), verify-bound-capability-live.sh script
+
+### Community 814 - "Community 814"
+Cohesion: 0.40
+Nodes (3): Config, BaseSettings, Settings
+
+### Community 815 - "Community 815"
+Cohesion: 0.60
+Nodes (4): ensure_orion_cortex_exec_app(), _purge_app_tree(), Side-effect: put ``services/orion-cortex-exec`` first and drop a foreign ``app``, _strip_other_service_paths()
+
+### Community 816 - "Community 816"
+Cohesion: 0.70
+Nodes (4): _load_executor_module(), test_metacog_trigger_lineage_chat_turn_overrides_trigger_kind(), test_metacog_trigger_lineage_passes_baseline_from_trigger_payload(), test_metacog_trigger_lineage_passes_dense_from_trigger_payload()
+
+### Community 818 - "Community 818"
+Cohesion: 0.80
+Nodes (4): _base_ctx(), _render(), test_prompts_render_with_situation_fragment_scenarios(), test_prompts_render_without_situation_fragment()
+
+### Community 819 - "Community 819"
+Cohesion: 0.60
+Nodes (4): client(), TestClient, test_ready_200_when_consumer_ready(), test_ready_503_when_intake_bus_not_connected()
+
+### Community 820 - "Community 820"
+Cohesion: 0.60
+Nodes (4): ensure_orion_cortex_orch_app(), _purge_app_tree(), Side-effect: put ``services/orion-cortex-orch`` first and drop a foreign ``app``, _strip_other_service_paths()
+
+### Community 823 - "Community 823"
+Cohesion: 0.50
+Nodes (4): _make_contradiction_region(), Writing a contradiction region must publish MutationPressureEvidenceV1 on the pr, test_contradiction_region_emits_mutation_pressure(), test_non_contradiction_region_does_not_emit_pressure()
+
+### Community 824 - "Community 824"
+Cohesion: 0.60
+Nodes (4): get_neighborhood(), ingest_episode(), Any, Pool
+
+### Community 825 - "Community 825"
+Cohesion: 0.60
+Nodes (4): _ensure_hub_paths(), _hub_service_isolation(), pytest_configure(), Ensure Hub ``scripts`` package resolves to ``services/orion-hub/scripts`` (not r
+
+### Community 828 - "Community 828"
+Cohesion: 0.60
+Nodes (4): _ensure_hub_scripts_import_path(), Repo-root ``scripts/`` shadows Hub when pytest mixes repo tests with Hub tests (, test_memory_graph_approve_requires_graph_or_named_graph(), test_memory_graph_validate_fixture_roundtrip()
+
+### Community 832 - "Community 832"
+Cohesion: 0.60
+Nodes (4): MonkeyPatch, _social_memory_base_url(), test_api_social_memory_inspection_proxies_existing_endpoint(), test_api_social_memory_inspection_surfaces_upstream_errors()
+
+### Community 834 - "Community 834"
+Cohesion: 0.60
+Nodes (4): _clear_route_cache(), MonkeyPatch, test_build_routes_response_defaults_to_chat(), test_get_routes_payload_marks_probe_up()
+
+### Community 835 - "Community 835"
+Cohesion: 0.40
+Nodes (4): orion-memory-consolidation ships only asyncpg; the crystallization     repositor, The sync DDL helper is allowed to require psycopg2, but only when called., test_apply_schema_still_uses_psycopg2_lazily(), test_repository_imports_without_psycopg2()
+
+### Community 836 - "Community 836"
+Cohesion: 0.60
+Nodes (4): ensure_orion_mind_app(), _purge_app_tree(), Side-effect: put ``services/orion-mind`` first and drop a foreign ``app`` packag, _strip_other_service_paths()
+
+### Community 838 - "Community 838"
+Cohesion: 0.60
+Nodes (4): Post-fetch SQL chat windowing drops stale sql_timeline/sql_chat rows., _run_window(), test_sql_windowing_drops_out_of_window_uuid_rows(), test_sql_windowing_keeps_recent_rows_with_real_ts_when_id_not_uuid()
+
+### Community 839 - "Community 839"
+Cohesion: 0.70
+Nodes (4): _fake_process(), _sign(), test_webhook_accepts_valid_hmac_when_secret_configured(), test_webhook_rejects_invalid_hmac_when_secret_configured()
+
+### Community 840 - "Community 840"
+Cohesion: 0.60
+Nodes (4): _drive_state_ready(), Regression: world-pulse curiosity-followup reuse wiring in bus_worker.  Covers t, test_curiosity_followup_reused_skips_live_fetch(), _world_pulse_envelope_with_followup()
+
+### Community 842 - "Community 842"
+Cohesion: 0.40
+Nodes (5): orion-sql-writer docker-compose.yml, orion-sql-writer README, action.outcome.emit.v1 persistence (action_outcomes table, idempotent upsert on action_id), orion-sql-writer requirements.txt, orion-sql-writer: durable bus-to-Postgres persistence consumer
+
+### Community 844 - "Community 844"
+Cohesion: 0.50
+Nodes (4): _emitted_at(), datetime, Return an aware UTC emitted_at so naive/aware comparisons never crash., Materialize the window ending at ``now``. Never raises.
+
+### Community 845 - "Community 845"
+Cohesion: 0.60
+Nodes (4): _ensure_thought_paths(), pytest_configure(), Ensure orion-thought ``app`` resolves to this service during tests., _thought_service_isolation()
+
+### Community 846 - "Community 846"
+Cohesion: 0.70
+Nodes (4): _render(), test_block_absent_without_coloring(), test_block_does_not_introduce_output_keys(), test_block_present_with_coloring()
+
+### Community 847 - "Community 847"
+Cohesion: 0.50
+Nodes (4): _heuristic_gate_score(), Bounded lightweight score used by tests and fallback heuristics., test_heuristic_gate_score_bounds(), test_heuristic_gate_score_prefers_longer_text()
+
+### Community 848 - "Community 848"
+Cohesion: 0.60
+Nodes (4): _load_real_registry(), Thin regression guard, not a topic classifier.      Asserts that none of the sou, test_nasa_news_is_not_tagged_hardware_compute_gpu(), test_no_known_off_topic_source_tagged_hardware_compute_gpu()
+
+### Community 849 - "Community 849"
+Cohesion: 0.70
+Nodes (4): _run_node(), test_agent_trace_helpers_gate_group_and_timeline(), test_agent_trace_helpers_gate_message_level_debug_sections(), test_live_agent_step_anchors_to_conversation_not_body()
+
+### Community 851 - "Community 851"
+Cohesion: 0.60
+Nodes (4): _import_top_levels(), Memory-graph core stays deterministic: no LLM vendor SDKs or bus client imports., test_json_extract_has_no_nonstdlib_imports(), test_memory_graph_core_modules_have_no_llm_vendor_or_bus_imports()
+
+### Community 853 - "Community 853"
+Cohesion: 0.60
+Nodes (3): AST, test_retina_has_no_detector_imports(), _walk_imports()
+
+### Community 854 - "Community 854"
+Cohesion: 0.60
+Nodes (4): main(), Quick (fast) only: send probe1, wait for reply, immediately send probe2, wait ag, _run_fast_two_turns(), _run_one()
+
+### Community 855 - "Community 855"
+Cohesion: 0.50
+Nodes (4): description, minimum, type, max_recursion_depth
+
+### Community 856 - "Community 856"
+Cohesion: 0.50
+Nodes (4): safety_rules, description, items, type
+
+### Community 857 - "Community 857"
+Cohesion: 0.67
+Nodes (4): Evaluate, Fact Extraction, Goal Formulation, Memory graph suggest (brain draft JSON)
+
+### Community 858 - "Community 858"
+Cohesion: 0.67
+Nodes (4): Source Delta Review: smoke-003, POST /v1/ideation/run API (proposal-only Claude-backed review), Knowledge Forge Ideation Review v1 spec (markdown), spec:knowledge-forge-ideation-review-v1 (YAML contract)
+
+### Community 859 - "Community 859"
+Cohesion: 0.83
+Nodes (3): attach_llm_uncertainty_to_collapse_payload(), test_attach_llm_uncertainty_noop_when_missing(), test_attach_llm_uncertainty_preserves_existing_telemetry()
+
+### Community 860 - "Community 860"
+Cohesion: 0.50
+Nodes (3): BaseModel, Standard request to write data to the SQL database., SqlWriteRequest
+
+### Community 861 - "Community 861"
+Cohesion: 0.50
+Nodes (4): orion-self-experiments (typed self-experiment registry + context-exec dispatcher), orion-self-experiments docker-compose.yml, orion-self-experiments README.md, orion-self-experiments requirements.txt
+
+### Community 862 - "Community 862"
+Cohesion: 0.67
+Nodes (3): main(), parse_args(), Namespace
+
+### Community 863 - "Community 863"
+Cohesion: 0.50
+Nodes (3): puppeteer, dependencies, puppeteer
+
+### Community 864 - "Community 864"
+Cohesion: 0.83
+Nodes (3): main(), _max_profile_ctx_size(), _read_env_int()
+
+### Community 866 - "Community 866"
+Cohesion: 0.83
+Nodes (3): check_truth(), grammar_production_truth.sh script, validate_truth_json()
+
+### Community 867 - "Community 867"
+Cohesion: 0.50
+Nodes (3): ORION_KNOWLEDGE_ROOT, PYTHONPATH, orion-knowledge-forge.sh script
+
+### Community 868 - "Community 868"
+Cohesion: 0.83
+Nodes (3): _ensure_test_runtime_deps(), _has_import(), main()
+
+### Community 869 - "Community 869"
+Cohesion: 0.83
+Nodes (3): fail(), pass(), smoke_council_debug.sh script
+
+### Community 873 - "Community 873"
+Cohesion: 0.83
+Nodes (3): _ensure_platform_system(), _load_executor_module(), main()
+
+### Community 874 - "Community 874"
+Cohesion: 0.83
+Nodes (3): psql_run(), smoke_orion_bus_transport_full_stack.sh script, usage()
+
+### Community 875 - "Community 875"
+Cohesion: 0.83
+Nodes (3): _ensure_platform_system(), _load_module(), main()
+
+### Community 876 - "Community 876"
+Cohesion: 0.83
+Nodes (3): require_jq(), run_train(), smoke_topic_foundry_bertopic.sh script
+
+### Community 877 - "Community 877"
+Cohesion: 0.83
+Nodes (3): curl_api(), require_cmd(), smoke_topic_foundry_remote.sh script
+
+### Community 882 - "Community 882"
+Cohesion: 0.67
+Nodes (3): _dream_service_isolation(), _ensure_dream_paths(), Ensure orion-dream ``app`` resolves to this service during evals.
+
+### Community 883 - "Community 883"
+Cohesion: 0.67
+Nodes (3): _dream_service_isolation(), _ensure_dream_paths(), Ensure orion-dream ``app`` resolves to this service during tests.
+
+### Community 884 - "Community 884"
+Cohesion: 0.67
+Nodes (3): _load_embodiment_settings(), Regression: town speech must not default to legacy cortex intake., test_speech_defaults_use_chat_lane_and_skip_unified()
+
+### Community 885 - "Community 885"
+Cohesion: 0.50
+Nodes (3): FCC_OPEN_BROWSER, LOG_FILE, entrypoint.sh script
+
+### Community 886 - "Community 886"
+Cohesion: 0.67
+Nodes (3): get_settings(), BaseSettings, Settings
+
+### Community 887 - "Community 887"
+Cohesion: 0.83
+Nodes (3): _make_region(), test_writer_builds_sparql_update_targeting_compressions_graph(), test_writer_includes_summary_literal()
+
+### Community 888 - "Community 888"
+Cohesion: 0.50
+Nodes (3): Config, BaseSettings, Settings
+
+### Community 889 - "Community 889"
+Cohesion: 0.67
+Nodes (3): _ensure_governor_paths(), _governor_service_isolation(), Ensure orion-harness-governor ``app`` resolves to this service during tests.
+
+### Community 890 - "Community 890"
+Cohesion: 0.67
+Nodes (3): main(), Live smoke: Hub agent-claude WS streams claude_step + final llm_response.  Usage, run()
+
+### Community 891 - "Community 891"
+Cohesion: 0.67
+Nodes (3): main(), Gate 2 live proof: drive the Hub chat WS in agent mode and assert live step fram, run()
+
+### Community 892 - "Community 892"
+Cohesion: 0.83
+Nodes (3): activatePanel(), deactivatePanel(), styleTabButton()
+
+### Community 898 - "Community 898"
+Cohesion: 0.83
+Nodes (3): run_infer(), run_server_boot(), validate_llamacpp_upgrade.sh script
+
+### Community 899 - "Community 899"
+Cohesion: 0.50
+Nodes (3): Config, BaseSettings, Settings
+
+### Community 900 - "Community 900"
+Cohesion: 0.50
+Nodes (4): orion-policy-runtime docker-compose (port 8120, SUBSTRATE_POLICY_PATH, POLICY_POLL_INTERVAL_SEC), orion-policy-runtime: Layer 8 substrate service evaluating ProposalFrameV1 against SubstratePolicyV1, persists PolicyDecisionFrameV1 (policy is not execution), substrate_policy_decision_frames table (PolicyDecisionFrameV1 records), orion-policy-runtime dependencies (fastapi, sqlalchemy, psycopg2-binary, PyYAML)
+
+### Community 901 - "Community 901"
+Cohesion: 0.83
+Nodes (3): fail(), pass(), smoke.sh script
+
+### Community 902 - "Community 902"
+Cohesion: 0.67
+Nodes (3): main(), Eval: honest inner-state headline is responsive and never floored.  Run: python, _raw()
+
+### Community 905 - "Community 905"
+Cohesion: 0.67
+Nodes (3): _ensure_substrate_paths(), Ensure substrate-runtime ``app`` resolves to this service during tests., _substrate_service_isolation()
+
+### Community 908 - "Community 908"
+Cohesion: 0.83
+Nodes (3): MonkeyPatch, _reload_settings(), test_settings_defaults()
+
+### Community 909 - "Community 909"
+Cohesion: 0.50
+Nodes (4): claim:test:0001 (accepted claim fixture), source:test:fixture (design_doc source fixture, primary trust), test-source.md (raw source content fixture: alpha/beta requirements), spec:test:compile (execution_ready spec fixture, component orion-test)
+
+### Community 910 - "Community 910"
+Cohesion: 0.83
+Nodes (3): _is_allowed_channel(), test_channel_catalog_prefixes(), test_literal_publish_subscribe_prefixes()
+
+### Community 913 - "Community 913"
+Cohesion: 0.83
+Nodes (3): _load_executor_module(), test_format_pad_frame_summary_prefers_signal_lists(), test_format_pad_stats_summary_highlights_counters_and_last_frame()
+
+### Community 914 - "Community 914"
+Cohesion: 0.83
+Nodes (3): _load_fusion_module(), test_tag_prefix_boost_ranks_alert_tag(), test_turn_effect_boost_ranks_high_delta()
+
+### Community 915 - "Community 915"
+Cohesion: 0.83
+Nodes (3): _load_worker_module(), test_append_turn_effect_metadata_includes_effect(), test_publishable_channel_guard_blocks_wildcards()
+
+### Community 916 - "Community 916"
+Cohesion: 0.83
+Nodes (3): _run_node(), test_workflow_ui_normalizes_metadata_and_chip_label(), test_workflow_ui_run_again_visibility_rules_and_non_workflow_passthrough()
+
+### Community 917 - "Community 917"
+Cohesion: 0.67
+Nodes (3): Substrate Atlas (grammar-atom Cytoscape.js graph), substrate-atlas.js, substrate-lattice.js (sibling viz, uninspected)
+
+### Community 918 - "Community 918"
+Cohesion: 0.67
+Nodes (3): Channel triage heuristic report (audit_001/reports), Channel triage heuristic report (audit_001/reports_postfix, remediated), Channel triage heuristic report (audit_002/reports)
+
+### Community 919 - "Community 919"
+Cohesion: 0.67
+Nodes (3): Mesh Node: prometheus (observability), Capability: memory, Topology Node: prometheus
+
+### Community 920 - "Community 920"
+Cohesion: 0.67
+Nodes (3): orion-sql-writer-tests CI workflow, Memory-graph / SHACL validation dependency (rdflib+pyshacl), requirements-dev.txt (repo-wide dev/test deps)
+
+### Community 923 - "Community 923"
+Cohesion: 0.67
+Nodes (3): Channel "orion:feedback:frame" (kind=event, schema=FeedbackFrameV1) producers=[orion-feedback-runtime] consumers=[orion-spark-concept-induction], Schema: FeedbackFrameV1, Service: orion-feedback-runtime
+
+### Community 925 - "Community 925"
+Cohesion: 0.67
+Nodes (3): description, type, description
+
+### Community 926 - "Community 926"
+Cohesion: 0.67
+Nodes (3): description, type, name
+
+### Community 927 - "Community 927"
+Cohesion: 0.67
+Nodes (3): description, type, prompt_template
+
+### Community 928 - "Community 928"
+Cohesion: 0.67
+Nodes (3): Assess Mesh Presence, Assess Runtime State, Assess Storage Health
+
+### Community 929 - "Community 929"
+Cohesion: 0.67
+Nodes (3): Dream Cycle, Dream Preprocess, Dream Simple
+
+### Community 930 - "Community 930"
+Cohesion: 1.00
+Nodes (3): Finalize Response, Generate Code Scaffold, GitHub Compactor Digest
+
+### Community 932 - "Community 932"
+Cohesion: 0.67
+Nodes (3): spec:substrate-tier-telemetry-v1, Substrate Tier Telemetry (wiki concept page), Forge Log
+
+### Community 933 - "Community 933"
+Cohesion: 0.67
+Nodes (3): assist.light.v1 Recall Profile (Latency Lane, No Vector), chat.general.v1 Recall Profile (UX Continuity / Lightweight), Orion Recall Profiles Overview (Multi-Backend Ensemble Policy)
+
+### Community 934 - "Community 934"
+Cohesion: 0.67
+Nodes (3): graph.compressions.global.v1 recall profile, graph.compressions.local.v1 recall profile, graph.compressions.v1 recall profile (unified)
+
+### Community 936 - "Community 936"
+Cohesion: 1.00
+Nodes (3): Autonomous Event-Driven Concept Induction Trigger Loop note, Phase 1: Spark ConceptProfile Graph Materialization note, orion/spark README
+
+### Community 953 - "Community 953"
+Cohesion: 0.67
+Nodes (3): NarrativeUngrounded, Exception, Raised when the LLM's reply is malformed, cites nothing real, or cites     a fac
+
+### Community 989 - "Community 989"
+Cohesion: 0.67
+Nodes (3): orion-fcc Docker Compose Service, orion-fcc Service (Anthropic-compatible FCC proxy), orion-fcc Python Dependencies (free-claude-code)
+
+### Community 990 - "Community 990"
+Cohesion: 0.67
+Nodes (3): orion-feedback-runtime Docker Compose Service, orion-feedback-runtime Service (Layer 10), orion-feedback-runtime Python Dependencies
+
+### Community 1000 - "Community 1000"
+Cohesion: 0.67
+Nodes (3): Orion Knowledge Forge service contract (CLAUDE.md), orion-knowledge-forge Docker Compose, orion-knowledge-forge Python dependencies
+
+### Community 1001 - "Community 1001"
+Cohesion: 0.67
+Nodes (3): orion-meta-tags docker compose deployment (bus enabled, triage/tagged channels, health check, startup delay), orion-meta-tags: LLM-based enrichment of collapse events (entities, sentiment, tags) via orion:collapse:triage -> orion:tags:enriched, orion-meta-tags Python dependencies (fastapi, spacy, sentence-transformers, pydantic, redis)
+
+### Community 1003 - "Community 1003"
+Cohesion: 0.67
+Nodes (3): orion-notify policy rules (quiet hours, recipient groups, event-kind/severity routing, throttling), orion-notify service (notification policy owner), orion-notify-digest dependencies (fastapi, uvicorn, pydantic, SQLAlchemy, requests, redis, loguru)
+
+### Community 1004 - "Community 1004"
+Cohesion: 0.67
+Nodes (3): orion-rdf-store docker-compose (orion-athena-fuseki container, port 3030, JVM_ARGS, FUSEKI_DATA_DIR bind mount), orion-rdf-store: operator/deployment stack for Orion's primary RDF datastore (Apache Jena Fuseki); not a Python service, no app/settings.py/requirements.txt, orion-rdf-writer: constructs the Knowledge Graph by converting incoming bus events into RDF triples via RdfStoreClient (graphdb/fuseki/generic/rdf4j backends)
+
+### Community 1014 - "Community 1014"
+Cohesion: 0.67
+Nodes (3): Golden phi + node attribution (trained encoder overrides phi_now coherence/energy/novelty), Spark train/evals README (offline phi-encoder health reports), eval_phi_encoder_health.py (recon/residual-after-headline-fit collapse gate)
+
+### Community 1021 - "Community 1021"
+Cohesion: 0.67
+Nodes (3): orion-world-pulse (docker-compose service, Firecrawl-backed curiosity fetch), orion-world-pulse Python dependencies (fastapi, requests, redis, pytest), sample_section.html test fixture (HTML link extraction, internal vs external hrefs)
+
+### Community 1022 - "Community 1022"
+Cohesion: 0.67
+Nodes (3): claim:test:bad-ref (disputed claim fixture with dangling references), claim:does:not:exist (dangling depends_on reference, no fixture defines it), source:missing:0001 (dangling source_refs reference, no fixture defines it)
+
+## Ambiguous Edges - Review These
+- `agent-trace.js (plain-text step consumer)` → `Agent Trace inspection modal (Hub UI, fail case screenshot)`  [AMBIGUOUS]
+  .verify-run/hub_agent_trace_timeline.png · relation: conceptually_related_to
+- `orion-cortex-gateway Docker Compose Service` → `orion-cortex-orch Docker Compose Service`  [AMBIGUOUS]
+  services/orion-cortex-gateway/docker-compose.yml · relation: references
+- `Orion Cortex Orchestrator Service` → `orion-cortex-orch Docker Compose Service`  [AMBIGUOUS]
+  services/orion-cortex-orch/README.md · relation: references
+- `orion-gpu-cluster-power service (compose)` → `orion-hub service (README) — browser gateway into the mesh`  [AMBIGUOUS]
+  services/orion-gpu-cluster-power/docker-compose.yml · relation: conceptually_related_to
+- `Self Brain UI panel — brain map + region EKG canvas visualizer` → `Hub main dashboard template (index.html) — tab nav + chat/EKG/debug panels`  [AMBIGUOUS]
+  services/orion-hub/templates/index.html · relation: references
+- `Substrate Inspector UI (orion-hub)` → `Substrate Atlas UI (orion-hub)`  [AMBIGUOUS]
+  services/orion-hub/templates/substrate.html · relation: conceptually_related_to
+- `orion-substrate-runtime compose config` → `orion-substrate-telemetry compose config`  [AMBIGUOUS]
+  services/orion-substrate-telemetry/docker-compose.yml · relation: conceptually_related_to
+- `orion-vision-edge perception node service` → `orion-vision-window rolling window aggregator service`  [AMBIGUOUS]
+  services/orion-vision-window/README.md · relation: shares_data_with
+- `claim:test:bad-ref (disputed claim fixture with dangling references)` → `claim:does:not:exist (dangling depends_on reference, no fixture defines it)`  [AMBIGUOUS]
+  tests/fixtures/knowledge_forge/claims/disputed/claim-test-bad-ref.yaml · relation: references
+- `claim:test:bad-ref (disputed claim fixture with dangling references)` → `source:missing:0001 (dangling source_refs reference, no fixture defines it)`  [AMBIGUOUS]
+  tests/fixtures/knowledge_forge/claims/disputed/claim-test-bad-ref.yaml · relation: references
+- `source:test:fixture (design_doc source fixture, primary trust)` → `test-source.md (raw source content fixture: alpha/beta requirements)`  [AMBIGUOUS]
+  tests/fixtures/knowledge_forge/raw/sources/source-test-fixture.yaml · relation: references
+
+## Knowledge Gaps
+- **967 isolated node(s):** `install-docker.sh script`, `install-utils.sh script`, `orion-bootstrap.sh script`, `GIT_SSH_COMMAND`, `setup-node.sh script` (+962 more)
+  These have ≤1 connection - possible missing edges or undocumented components.
+- **324 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+
+## Suggested Questions
+_Questions this graph is uniquely positioned to answer:_
+
+- **What is the exact relationship between `agent-trace.js (plain-text step consumer)` and `Agent Trace inspection modal (Hub UI, fail case screenshot)`?**
+  _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
+- **What is the exact relationship between `orion-cortex-gateway Docker Compose Service` and `orion-cortex-orch Docker Compose Service`?**
+  _Edge tagged AMBIGUOUS (relation: references) - confidence is low._
+- **What is the exact relationship between `Orion Cortex Orchestrator Service` and `orion-cortex-orch Docker Compose Service`?**
+  _Edge tagged AMBIGUOUS (relation: references) - confidence is low._
+- **What is the exact relationship between `orion-gpu-cluster-power service (compose)` and `orion-hub service (README) — browser gateway into the mesh`?**
+  _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
+- **What is the exact relationship between `Self Brain UI panel — brain map + region EKG canvas visualizer` and `Hub main dashboard template (index.html) — tab nav + chat/EKG/debug panels`?**
+  _Edge tagged AMBIGUOUS (relation: references) - confidence is low._
+- **What is the exact relationship between `Substrate Inspector UI (orion-hub)` and `Substrate Atlas UI (orion-hub)`?**
+  _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
+- **What is the exact relationship between `orion-substrate-runtime compose config` and `orion-substrate-telemetry compose config`?**
+  _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,0 +1,19487 @@
+{
+  ".claude/settings.json": {
+    "mtime": 1779677230.9917977,
+    "ast_hash": "612bd60d0903ad81b4bd319a074d580e",
+    "semantic_hash": "612bd60d0903ad81b4bd319a074d580e"
+  },
+  ".claude/settings.local.json": {
+    "mtime": 1781757826.5226443,
+    "ast_hash": "711eaddfadf9c93a51750d7d33bbb155",
+    "semantic_hash": "711eaddfadf9c93a51750d7d33bbb155"
+  },
+  ".verify-run/disk.json": {
+    "mtime": 1775948546.048512,
+    "ast_hash": "c0cfbb1db29836ae4a3767bc29a4c39e",
+    "semantic_hash": "c0cfbb1db29836ae4a3767bc29a4c39e"
+  },
+  ".verify-run/docker.json": {
+    "mtime": 1775948546.048512,
+    "ast_hash": "6f8193c5f597c527050fcfb9954d23b7",
+    "semantic_hash": "6f8193c5f597c527050fcfb9954d23b7"
+  },
+  ".verify-run/hub_agent_trace_ui_smoke.py": {
+    "mtime": 1775948546.049512,
+    "ast_hash": "f6a5b03a8c09166fa8781bf9ea5d82e7",
+    "semantic_hash": "f6a5b03a8c09166fa8781bf9ea5d82e7"
+  },
+  ".verify-run/hub_quick_playwright_live.py": {
+    "mtime": 1778901838.362395,
+    "ast_hash": "0aa78327e0c3ff1d84600a89beb0bf4b",
+    "semantic_hash": "0aa78327e0c3ff1d84600a89beb0bf4b"
+  },
+  ".verify-run/nodes.json": {
+    "mtime": 1775948546.049512,
+    "ast_hash": "db7756be4177611bab32874adcfb5759",
+    "semantic_hash": "db7756be4177611bab32874adcfb5759"
+  },
+  "__init__.py": {
+    "mtime": 1768597909.84523,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "codex_reviews/audit_001/reports/antipatterns.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "9a54e0ea574c105eb5a81e1700bbef6a",
+    "semantic_hash": "9a54e0ea574c105eb5a81e1700bbef6a"
+  },
+  "codex_reviews/audit_001/reports/channel_drift.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "aa6dd94b11fe6869ec1d07ead718d526",
+    "semantic_hash": "aa6dd94b11fe6869ec1d07ead718d526"
+  },
+  "codex_reviews/audit_001/reports/channel_inventory.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "7eeb3f1ea27d369b7ecff9bbdd2cf4a4",
+    "semantic_hash": "7eeb3f1ea27d369b7ecff9bbdd2cf4a4"
+  },
+  "codex_reviews/audit_001/reports/config_lineage.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "566205819a0cb8f096a567ce244b3ab5",
+    "semantic_hash": "566205819a0cb8f096a567ce244b3ab5"
+  },
+  "codex_reviews/audit_001/reports/schema_drift.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "defd030ea87913ea10a2ee68e2273908",
+    "semantic_hash": "defd030ea87913ea10a2ee68e2273908"
+  },
+  "codex_reviews/audit_001/reports/schema_inventory.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "06fd27efa5edddc16528dac47d71f5b9",
+    "semantic_hash": "06fd27efa5edddc16528dac47d71f5b9"
+  },
+  "codex_reviews/audit_001/reports/spine_audit.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "b6b00e0d95a6b5e1dc575d3b19ce766a",
+    "semantic_hash": "b6b00e0d95a6b5e1dc575d3b19ce766a"
+  },
+  "codex_reviews/audit_001/reports_postfix/antipatterns.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "bc568beddee29a3948aa7a9f053f6afd",
+    "semantic_hash": "bc568beddee29a3948aa7a9f053f6afd"
+  },
+  "codex_reviews/audit_001/reports_postfix/channel_drift.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "0f35c7013a5e2481176142fa7648dd31",
+    "semantic_hash": "0f35c7013a5e2481176142fa7648dd31"
+  },
+  "codex_reviews/audit_001/reports_postfix/channel_inventory.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "85478bc1b3a88352ba9f7c7ef1074c9d",
+    "semantic_hash": "85478bc1b3a88352ba9f7c7ef1074c9d"
+  },
+  "codex_reviews/audit_001/reports_postfix/config_lineage.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "6a20bef28a5b520e8e0fa3a13bbe5ea8",
+    "semantic_hash": "6a20bef28a5b520e8e0fa3a13bbe5ea8"
+  },
+  "codex_reviews/audit_001/reports_postfix/schema_drift.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "691888da18b8851c35d3042583f242cd",
+    "semantic_hash": "691888da18b8851c35d3042583f242cd"
+  },
+  "codex_reviews/audit_001/reports_postfix/schema_inventory.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "06fd27efa5edddc16528dac47d71f5b9",
+    "semantic_hash": "06fd27efa5edddc16528dac47d71f5b9"
+  },
+  "codex_reviews/audit_001/reports_postfix/spine_audit.json": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "aeaf05b85939a2c2d145c7440192c519",
+    "semantic_hash": "aeaf05b85939a2c2d145c7440192c519"
+  },
+  "codex_reviews/audit_002/reports/antipatterns.json": {
+    "mtime": 1783573136.0176039,
+    "ast_hash": "07e5fb8dcd125939b3b02cbd0e9294eb",
+    "semantic_hash": "07e5fb8dcd125939b3b02cbd0e9294eb"
+  },
+  "codex_reviews/audit_002/reports/channel_drift.json": {
+    "mtime": 1783573136.0176039,
+    "ast_hash": "a65c952c0b795dc6a5a1bcb63d57c9c8",
+    "semantic_hash": "a65c952c0b795dc6a5a1bcb63d57c9c8"
+  },
+  "codex_reviews/audit_002/reports/channel_inventory.json": {
+    "mtime": 1783573136.0176039,
+    "ast_hash": "2223e1e86b3d2b72aa1aaaad1243d6e3",
+    "semantic_hash": "2223e1e86b3d2b72aa1aaaad1243d6e3"
+  },
+  "codex_reviews/audit_002/reports/config_lineage.json": {
+    "mtime": 1783573136.0176039,
+    "ast_hash": "4fc03463ae33476ab33aa1a730690fce",
+    "semantic_hash": "4fc03463ae33476ab33aa1a730690fce"
+  },
+  "codex_reviews/audit_002/reports/schema_drift.json": {
+    "mtime": 1783573136.0176039,
+    "ast_hash": "e1332c989e9bcb698ccd9a7ba6b9e1cf",
+    "semantic_hash": "e1332c989e9bcb698ccd9a7ba6b9e1cf"
+  },
+  "codex_reviews/audit_002/reports/schema_inventory.json": {
+    "mtime": 1783573136.0176039,
+    "ast_hash": "06fd27efa5edddc16528dac47d71f5b9",
+    "semantic_hash": "06fd27efa5edddc16528dac47d71f5b9"
+  },
+  "codex_reviews/audit_002/reports/spine_audit.json": {
+    "mtime": 1783573136.0176039,
+    "ast_hash": "aeaf05b85939a2c2d145c7440192c519",
+    "semantic_hash": "aeaf05b85939a2c2d145c7440192c519"
+  },
+  "mesh-utilities/bootstrap/scripts/install-docker.sh": {
+    "mtime": 1763232123.3958905,
+    "ast_hash": "53e57dc0311a9c77a8e0160e7b84326f",
+    "semantic_hash": "53e57dc0311a9c77a8e0160e7b84326f"
+  },
+  "mesh-utilities/bootstrap/scripts/install-nvidia.sh": {
+    "mtime": 1763232123.3958905,
+    "ast_hash": "02604bc547457256f0ad6304b82ccfa2",
+    "semantic_hash": "02604bc547457256f0ad6304b82ccfa2"
+  },
+  "mesh-utilities/bootstrap/scripts/install-utils.sh": {
+    "mtime": 1763232123.3958905,
+    "ast_hash": "6155b3922080928b567c30be0900a42b",
+    "semantic_hash": "6155b3922080928b567c30be0900a42b"
+  },
+  "mesh-utilities/bootstrap/scripts/orion-bootstrap.sh": {
+    "mtime": 1763232123.3958905,
+    "ast_hash": "0c2441183ff22924629004be3f6d4179",
+    "semantic_hash": "0c2441183ff22924629004be3f6d4179"
+  },
+  "mesh-utilities/bootstrap/scripts/setup-node.sh": {
+    "mtime": 1763232123.3958905,
+    "ast_hash": "fd3761ce9a2f3ae7c1c242af2f54029e",
+    "semantic_hash": "fd3761ce9a2f3ae7c1c242af2f54029e"
+  },
+  "mesh-utilities/bootstrap/scripts/setup-rsfp-10g.sh": {
+    "mtime": 1763232123.3958905,
+    "ast_hash": "fc8f978cb0698ecc897b0d82e4487313",
+    "semantic_hash": "fc8f978cb0698ecc897b0d82e4487313"
+  },
+  "mesh-utilities/bootstrap/scripts/setup-ssh.sh": {
+    "mtime": 1763232123.3958905,
+    "ast_hash": "de05766d8f6a42689f46928e742873a3",
+    "semantic_hash": "de05766d8f6a42689f46928e742873a3"
+  },
+  "mesh-utilities/bootstrap/scripts/verify-agent.sh": {
+    "mtime": 1763232123.3958905,
+    "ast_hash": "f1ec9027a923bce86da23cdedef11834",
+    "semantic_hash": "f1ec9027a923bce86da23cdedef11834"
+  },
+  "mesh-utilities/bootstrap/scripts/verify-gpu.sh": {
+    "mtime": 1763232123.3968906,
+    "ast_hash": "e7210180c2aeb8a2a46eadc810164c6f",
+    "semantic_hash": "e7210180c2aeb8a2a46eadc810164c6f"
+  },
+  "mesh-utilities/bootstrap/voice-node/voice-bootstrap.sh": {
+    "mtime": 1763232123.3968906,
+    "ast_hash": "b1761261adaf4b3a10fc4a33640b6a4e",
+    "semantic_hash": "b1761261adaf4b3a10fc4a33640b6a4e"
+  },
+  "mesh-utilities/common/cortex_exec_fleet_helpers.sh": {
+    "mtime": 1783136738.0538802,
+    "ast_hash": "2c8fc6685497b42cc25f86eb114a4dca",
+    "semantic_hash": "2c8fc6685497b42cc25f86eb114a4dca"
+  },
+  "mesh-utilities/common/refresh_service_envs.sh": {
+    "mtime": 1768597909.8472302,
+    "ast_hash": "229a695cb9dbc3167f45ea3ec3ccf864",
+    "semantic_hash": "229a695cb9dbc3167f45ea3ec3ccf864"
+  },
+  "mesh-utilities/common/up_all_services.sh": {
+    "mtime": 1783136738.0538802,
+    "ast_hash": "ab9126b5c5c4f8004dae4e24923090bf",
+    "semantic_hash": "ab9126b5c5c4f8004dae4e24923090bf"
+  },
+  "mesh-utilities/common/up_all_services_batched.sh": {
+    "mtime": 1783136738.0538802,
+    "ast_hash": "c3f2e140008d82ae517f5c0a58c519ed",
+    "semantic_hash": "c3f2e140008d82ae517f5c0a58c519ed"
+  },
+  "mesh-utilities/disk-onboarding/disk-onboarding.sh": {
+    "mtime": 1763232123.3968906,
+    "ast_hash": "4b8710c1b9e9d914f85cbfbb9ebaf58a",
+    "semantic_hash": "4b8710c1b9e9d914f85cbfbb9ebaf58a"
+  },
+  "orion/__init__.py": {
+    "mtime": 1763232123.3968906,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/attention/__init__.py": {
+    "mtime": 1779681646.0184531,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/attention/field_attention/__init__.py": {
+    "mtime": 1779681646.0184531,
+    "ast_hash": "30eac16985b9edcb2c6ec43f56e32ce7",
+    "semantic_hash": "30eac16985b9edcb2c6ec43f56e32ce7"
+  },
+  "orion/attention/field_attention/builder.py": {
+    "mtime": 1779681646.0184531,
+    "ast_hash": "1080f95c647b48626b25c83c35de24e3",
+    "semantic_hash": "1080f95c647b48626b25c83c35de24e3"
+  },
+  "orion/attention/field_attention/policy.py": {
+    "mtime": 1779681646.0184531,
+    "ast_hash": "b5e59d4b2ce2351f75816f71fbd46ba2",
+    "semantic_hash": "b5e59d4b2ce2351f75816f71fbd46ba2"
+  },
+  "orion/attention/field_attention/scoring.py": {
+    "mtime": 1779681646.0184531,
+    "ast_hash": "4b1b688f723de1fd8df75bd6cb4beccb",
+    "semantic_hash": "4b1b688f723de1fd8df75bd6cb4beccb"
+  },
+  "orion/attention/field_attention/selectors.py": {
+    "mtime": 1779681646.0184531,
+    "ast_hash": "fa68bc5ac9fdde8a8f1bfb464140c7e6",
+    "semantic_hash": "fa68bc5ac9fdde8a8f1bfb464140c7e6"
+  },
+  "orion/autonomy/__init__.py": {
+    "mtime": 1774836321.9541385,
+    "ast_hash": "e25b3f9d9ed934fea7a05e61d9cc3f0b",
+    "semantic_hash": "e25b3f9d9ed934fea7a05e61d9cc3f0b"
+  },
+  "orion/autonomy/action_outcomes.py": {
+    "mtime": 1783406173.2689035,
+    "ast_hash": "232f5e95a16f60a8d8591c59f22ad15c",
+    "semantic_hash": "232f5e95a16f60a8d8591c59f22ad15c"
+  },
+  "orion/autonomy/capability_policy.py": {
+    "mtime": 1783807364.4288404,
+    "ast_hash": "bf3e5df5dc03d12c56a8375fd969d322",
+    "semantic_hash": "bf3e5df5dc03d12c56a8375fd969d322"
+  },
+  "orion/autonomy/constants.py": {
+    "mtime": 1779334690.4211192,
+    "ast_hash": "e61427e46126973b46067e5e19a242ed",
+    "semantic_hash": "e61427e46126973b46067e5e19a242ed"
+  },
+  "orion/autonomy/curiosity_reuse.py": {
+    "mtime": 1783461977.1283035,
+    "ast_hash": "fb2bf0920a8f6ebc4e12c0b02aa09945",
+    "semantic_hash": "fb2bf0920a8f6ebc4e12c0b02aa09945"
+  },
+  "orion/autonomy/deviation_gate.py": {
+    "mtime": 1783478774.6147194,
+    "ast_hash": "8ea547372cb2636d2dfe1db446256ea7",
+    "semantic_hash": "8ea547372cb2636d2dfe1db446256ea7"
+  },
+  "orion/autonomy/endogenous_origination.py": {
+    "mtime": 1783834645.3778684,
+    "ast_hash": "bf6ac7a814dcc62fb57e102fd82f7edb",
+    "semantic_hash": "bf6ac7a814dcc62fb57e102fd82f7edb"
+  },
+  "orion/autonomy/episode_fetch.py": {
+    "mtime": 1783447063.25037,
+    "ast_hash": "941787c4aa6414ab2c79d6d387f43bb0",
+    "semantic_hash": "941787c4aa6414ab2c79d6d387f43bb0"
+  },
+  "orion/autonomy/episode_journal.py": {
+    "mtime": 1783388479.8224325,
+    "ast_hash": "2dce11a14e047be1a8539435bd38158a",
+    "semantic_hash": "2dce11a14e047be1a8539435bd38158a"
+  },
+  "orion/autonomy/evals/__init__.py": {
+    "mtime": 1783478774.6147194,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/autonomy/evals/run_autonomy_v2_movement_eval.py": {
+    "mtime": 1783720227.345996,
+    "ast_hash": "e569e9540cc57705cb21b09c93e69be4",
+    "semantic_hash": "e569e9540cc57705cb21b09c93e69be4"
+  },
+  "orion/autonomy/evals/run_homeostatic_drives_eval.py": {
+    "mtime": 1783478774.6147194,
+    "ast_hash": "d53928bac13b11642659669e86f40950",
+    "semantic_hash": "d53928bac13b11642659669e86f40950"
+  },
+  "orion/autonomy/evals/run_origination_eval.py": {
+    "mtime": 1783490446.2993593,
+    "ast_hash": "52d67bcf81eb13f9f1567f473b03b856",
+    "semantic_hash": "52d67bcf81eb13f9f1567f473b03b856"
+  },
+  "orion/autonomy/evidence_compiler.py": {
+    "mtime": 1783720227.345996,
+    "ast_hash": "9077153e454073d8644c6405315aa741",
+    "semantic_hash": "9077153e454073d8644c6405315aa741"
+  },
+  "orion/autonomy/fanout_policy.py": {
+    "mtime": 1778901838.3653948,
+    "ast_hash": "c28599f4b0f8457d720b849213a23570",
+    "semantic_hash": "c28599f4b0f8457d720b849213a23570"
+  },
+  "orion/autonomy/fcc_env.py": {
+    "mtime": 1783388479.8234327,
+    "ast_hash": "b185b561b524eceebf3a026807e40380",
+    "semantic_hash": "b185b561b524eceebf3a026807e40380"
+  },
+  "orion/autonomy/fetch_backend_resolve.py": {
+    "mtime": 1783388479.8234327,
+    "ast_hash": "149a70eaa3819629820925a1578c8d80",
+    "semantic_hash": "149a70eaa3819629820925a1578c8d80"
+  },
+  "orion/autonomy/fetch_backends.py": {
+    "mtime": 1783447063.25037,
+    "ast_hash": "2eab27bd23d9f031c420408aa8b86f14",
+    "semantic_hash": "2eab27bd23d9f031c420408aa8b86f14"
+  },
+  "orion/autonomy/goal_actions.py": {
+    "mtime": 1779328788.9547868,
+    "ast_hash": "83666ed1ed694b578c21285f90e6a206",
+    "semantic_hash": "83666ed1ed694b578c21285f90e6a206"
+  },
+  "orion/autonomy/goal_archive.py": {
+    "mtime": 1781845427.7726762,
+    "ast_hash": "5baa8e914e7f3c6b695e7fd88abcbf05",
+    "semantic_hash": "5baa8e914e7f3c6b695e7fd88abcbf05"
+  },
+  "orion/autonomy/graph_gate.py": {
+    "mtime": 1778901838.3653948,
+    "ast_hash": "069d3577c4c6eb14a07ada44bb848bf0",
+    "semantic_hash": "069d3577c4c6eb14a07ada44bb848bf0"
+  },
+  "orion/autonomy/models.py": {
+    "mtime": 1784008374.2405007,
+    "ast_hash": "ff8bc07735d3c6c0a8d4cebd3f602741",
+    "semantic_hash": "ff8bc07735d3c6c0a8d4cebd3f602741"
+  },
+  "orion/autonomy/policy_act.py": {
+    "mtime": 1784008374.2415006,
+    "ast_hash": "2d0b48586e6fb470aef9a92f7a3cbd22",
+    "semantic_hash": "2d0b48586e6fb470aef9a92f7a3cbd22"
+  },
+  "orion/autonomy/reducer.py": {
+    "mtime": 1783720227.3469958,
+    "ast_hash": "0e351f5b4cf861f73ab8a75136528e20",
+    "semantic_hash": "0e351f5b4cf861f73ab8a75136528e20"
+  },
+  "orion/autonomy/repository.py": {
+    "mtime": 1779753471.2762897,
+    "ast_hash": "1fd352e556ff8a6e854fd2a9468f7c9d",
+    "semantic_hash": "1fd352e556ff8a6e854fd2a9468f7c9d"
+  },
+  "orion/autonomy/salience.py": {
+    "mtime": 1783461977.1283035,
+    "ast_hash": "7131cdbfe0255f351a22c93ae3691e6c",
+    "semantic_hash": "7131cdbfe0255f351a22c93ae3691e6c"
+  },
+  "orion/autonomy/signal_drive_map.py": {
+    "mtime": 1783478774.6147194,
+    "ast_hash": "4c71c4e6fb4577a31f845fe5bcf29136",
+    "semantic_hash": "4c71c4e6fb4577a31f845fe5bcf29136"
+  },
+  "orion/autonomy/signal_tension.py": {
+    "mtime": 1783720227.3469958,
+    "ast_hash": "1616838a552f225590be90a8c2786eae",
+    "semantic_hash": "1616838a552f225590be90a8c2786eae"
+  },
+  "orion/autonomy/state_store.py": {
+    "mtime": 1783740584.5904982,
+    "ast_hash": "9d96e3fbac8ed2b83c82f240a45bcad5",
+    "semantic_hash": "9d96e3fbac8ed2b83c82f240a45bcad5"
+  },
+  "orion/autonomy/substrate_emit.py": {
+    "mtime": 1779649387.7952988,
+    "ast_hash": "d5f6171d9360b1db3f3465c9dcc65bcd",
+    "semantic_hash": "d5f6171d9360b1db3f3465c9dcc65bcd"
+  },
+  "orion/autonomy/substrate_metabolism.py": {
+    "mtime": 1783365495.728666,
+    "ast_hash": "fa17f101964b7b9fd2d97c857c8cc67f",
+    "semantic_hash": "fa17f101964b7b9fd2d97c857c8cc67f"
+  },
+  "orion/autonomy/summary.py": {
+    "mtime": 1783807362.662784,
+    "ast_hash": "3683fe0bde9dfac8b9018581a4ae1bcb",
+    "semantic_hash": "3683fe0bde9dfac8b9018581a4ae1bcb"
+  },
+  "orion/autonomy/tension_ratelimit.py": {
+    "mtime": 1784008374.2415006,
+    "ast_hash": "a53f4968a06baee89eaae418d34206bd",
+    "semantic_hash": "a53f4968a06baee89eaae418d34206bd"
+  },
+  "orion/autonomy/tests/test_action_outcomes.py": {
+    "mtime": 1783365495.728666,
+    "ast_hash": "d8d884b5e97337e2e4c9bf4981bbe63f",
+    "semantic_hash": "d8d884b5e97337e2e4c9bf4981bbe63f"
+  },
+  "orion/autonomy/tests/test_action_outcomes_sql.py": {
+    "mtime": 1783405468.2187881,
+    "ast_hash": "4191a2c71d34a81ed85e2f77c0fbb823",
+    "semantic_hash": "4191a2c71d34a81ed85e2f77c0fbb823"
+  },
+  "orion/autonomy/tests/test_active_goal_lifecycle_qualifiers.py": {
+    "mtime": 1779328788.9557867,
+    "ast_hash": "2ed9743c57427ff26c2a7fc0058e854b",
+    "semantic_hash": "2ed9743c57427ff26c2a7fc0058e854b"
+  },
+  "orion/autonomy/tests/test_autonomy_isolation.py": {
+    "mtime": 1783720227.3469958,
+    "ast_hash": "f7a2206a2309d91850b9554715db4e90",
+    "semantic_hash": "f7a2206a2309d91850b9554715db4e90"
+  },
+  "orion/autonomy/tests/test_autonomy_reducer.py": {
+    "mtime": 1783720227.3469958,
+    "ast_hash": "8578a6f1e05fecdcb3900908737c3f20",
+    "semantic_hash": "8578a6f1e05fecdcb3900908737c3f20"
+  },
+  "orion/autonomy/tests/test_autonomy_state_v2_upgrade.py": {
+    "mtime": 1777761366.3693066,
+    "ast_hash": "a0880c2f6db9e4a76ac53e24a4b9d311",
+    "semantic_hash": "a0880c2f6db9e4a76ac53e24a4b9d311"
+  },
+  "orion/autonomy/tests/test_autonomy_summary_v2.py": {
+    "mtime": 1777761366.3693066,
+    "ast_hash": "5bfdef36ab98494eedee88a3b602653e",
+    "semantic_hash": "5bfdef36ab98494eedee88a3b602653e"
+  },
+  "orion/autonomy/tests/test_capability_policy.py": {
+    "mtime": 1784008374.2415006,
+    "ast_hash": "ee7c31033a6168f88f0df29d14ee2655",
+    "semantic_hash": "ee7c31033a6168f88f0df29d14ee2655"
+  },
+  "orion/autonomy/tests/test_capability_policy_models.py": {
+    "mtime": 1784008374.2415006,
+    "ast_hash": "5de4e34a437ba72e06cc05fd3ede152f",
+    "semantic_hash": "5de4e34a437ba72e06cc05fd3ede152f"
+  },
+  "orion/autonomy/tests/test_curiosity_reuse.py": {
+    "mtime": 1783461977.1283035,
+    "ast_hash": "0b2cb40b58ac1fb32630d3354f6f8ba8",
+    "semantic_hash": "0b2cb40b58ac1fb32630d3354f6f8ba8"
+  },
+  "orion/autonomy/tests/test_deviation_gate.py": {
+    "mtime": 1783478774.6147194,
+    "ast_hash": "d899b8bffc2c86fe4ab34f0e08140cde",
+    "semantic_hash": "d899b8bffc2c86fe4ab34f0e08140cde"
+  },
+  "orion/autonomy/tests/test_endogenous_origination.py": {
+    "mtime": 1783490446.2993593,
+    "ast_hash": "3c923e0d62fd42100f767b31532169c1",
+    "semantic_hash": "3c923e0d62fd42100f767b31532169c1"
+  },
+  "orion/autonomy/tests/test_episode_fetch.py": {
+    "mtime": 1783447063.2513702,
+    "ast_hash": "3936aef2a72e373a5fd723c9d5519593",
+    "semantic_hash": "3936aef2a72e373a5fd723c9d5519593"
+  },
+  "orion/autonomy/tests/test_episode_journal.py": {
+    "mtime": 1783413759.4756405,
+    "ast_hash": "667258992d408f7d7ba638d9d3318603",
+    "semantic_hash": "667258992d408f7d7ba638d9d3318603"
+  },
+  "orion/autonomy/tests/test_evidence_compiler.py": {
+    "mtime": 1783720227.3469958,
+    "ast_hash": "a888ff19221ab00ca479cf43ae712cd4",
+    "semantic_hash": "a888ff19221ab00ca479cf43ae712cd4"
+  },
+  "orion/autonomy/tests/test_evidence_ref_schema.py": {
+    "mtime": 1783720227.3469958,
+    "ast_hash": "20c2a9179ab5dc76fd8f3d246cf32c3c",
+    "semantic_hash": "20c2a9179ab5dc76fd8f3d246cf32c3c"
+  },
+  "orion/autonomy/tests/test_fanout_policy.py": {
+    "mtime": 1778901838.366395,
+    "ast_hash": "33eab50a9091812573a9c7c8bc3433f7",
+    "semantic_hash": "33eab50a9091812573a9c7c8bc3433f7"
+  },
+  "orion/autonomy/tests/test_fetch_backend_resolve.py": {
+    "mtime": 1783388479.8234327,
+    "ast_hash": "2b9b75d85b598cc3ff59d4c924b95618",
+    "semantic_hash": "2b9b75d85b598cc3ff59d4c924b95618"
+  },
+  "orion/autonomy/tests/test_fetch_backends.py": {
+    "mtime": 1783447063.2513702,
+    "ast_hash": "611ae2654da23f2ce875b1a2aac5f08b",
+    "semantic_hash": "611ae2654da23f2ce875b1a2aac5f08b"
+  },
+  "orion/autonomy/tests/test_goal_actions_promote.py": {
+    "mtime": 1779328788.9557867,
+    "ast_hash": "c169cc6a6bcba760b0aacf4d3798abf0",
+    "semantic_hash": "c169cc6a6bcba760b0aacf4d3798abf0"
+  },
+  "orion/autonomy/tests/test_goal_archive.py": {
+    "mtime": 1781845427.7726762,
+    "ast_hash": "32c3e584f2df2942b017fc5421810edc",
+    "semantic_hash": "32c3e584f2df2942b017fc5421810edc"
+  },
+  "orion/autonomy/tests/test_goal_headline_dedupe.py": {
+    "mtime": 1779331489.37435,
+    "ast_hash": "d26ace03238f9602c8ab24dcabde4382",
+    "semantic_hash": "d26ace03238f9602c8ab24dcabde4382"
+  },
+  "orion/autonomy/tests/test_graph_gate.py": {
+    "mtime": 1778901838.366395,
+    "ast_hash": "36d1e0528db4369d24ecee6123736d5d",
+    "semantic_hash": "36d1e0528db4369d24ecee6123736d5d"
+  },
+  "orion/autonomy/tests/test_metabolism_models.py": {
+    "mtime": 1783365495.729666,
+    "ast_hash": "695af4fdaa6e630ac611ef580f1a727f",
+    "semantic_hash": "695af4fdaa6e630ac611ef580f1a727f"
+  },
+  "orion/autonomy/tests/test_policy_act.py": {
+    "mtime": 1784008374.2415006,
+    "ast_hash": "5b3feb4c1e9fbafdbbbfc241b77deec6",
+    "semantic_hash": "5b3feb4c1e9fbafdbbbfc241b77deec6"
+  },
+  "orion/autonomy/tests/test_policy_act_prefetched.py": {
+    "mtime": 1783461977.1283035,
+    "ast_hash": "4fa7371eb2a8831fae07dc89ece02df5",
+    "semantic_hash": "4fa7371eb2a8831fae07dc89ece02df5"
+  },
+  "orion/autonomy/tests/test_repository_active_goals.py": {
+    "mtime": 1779333968.8916838,
+    "ast_hash": "53a543e14a2db60ed6a89d0b760aad83",
+    "semantic_hash": "53a543e14a2db60ed6a89d0b760aad83"
+  },
+  "orion/autonomy/tests/test_repository_active_subqueries.py": {
+    "mtime": 1778901838.366395,
+    "ast_hash": "b644a0e489a80c34aeecb18d140dcf0e",
+    "semantic_hash": "b644a0e489a80c34aeecb18d140dcf0e"
+  },
+  "orion/autonomy/tests/test_repository_defer_orion_drives.py": {
+    "mtime": 1779753471.2772896,
+    "ast_hash": "f71c1d272109f428f2726b0d3f438208",
+    "semantic_hash": "f71c1d272109f428f2726b0d3f438208"
+  },
+  "orion/autonomy/tests/test_repository_selection_and_query.py": {
+    "mtime": 1779753471.2772896,
+    "ast_hash": "4cb0e06d214fa3bb3b4fff06b31686b4",
+    "semantic_hash": "4cb0e06d214fa3bb3b4fff06b31686b4"
+  },
+  "orion/autonomy/tests/test_salience.py": {
+    "mtime": 1783447063.2513702,
+    "ast_hash": "0c2f480d38940a0ba145d7e99a9b59e5",
+    "semantic_hash": "0c2f480d38940a0ba145d7e99a9b59e5"
+  },
+  "orion/autonomy/tests/test_salience_tokenize.py": {
+    "mtime": 1783461977.1283035,
+    "ast_hash": "9a10595e390de3cc58645d6ca564a8c3",
+    "semantic_hash": "9a10595e390de3cc58645d6ca564a8c3"
+  },
+  "orion/autonomy/tests/test_signal_drive_map.py": {
+    "mtime": 1783720227.3479958,
+    "ast_hash": "ecdec66537d42672f5e7f8b257bd17ab",
+    "semantic_hash": "ecdec66537d42672f5e7f8b257bd17ab"
+  },
+  "orion/autonomy/tests/test_signal_tension.py": {
+    "mtime": 1783720227.348996,
+    "ast_hash": "966375332662877f79e617f8f802d51b",
+    "semantic_hash": "966375332662877f79e617f8f802d51b"
+  },
+  "orion/autonomy/tests/test_state_store.py": {
+    "mtime": 1783740584.5904982,
+    "ast_hash": "093a9d7a374cc93a0e4ab59c9bdaee8e",
+    "semantic_hash": "093a9d7a374cc93a0e4ab59c9bdaee8e"
+  },
+  "orion/autonomy/tests/test_substrate_act_models.py": {
+    "mtime": 1783447063.2513702,
+    "ast_hash": "bb83cbde3ec2be73d80e0abbdbfd5745",
+    "semantic_hash": "bb83cbde3ec2be73d80e0abbdbfd5745"
+  },
+  "orion/autonomy/tests/test_substrate_metabolism.py": {
+    "mtime": 1783365495.729666,
+    "ast_hash": "a1322ab2c909c5a55f4dc1228ff10702",
+    "semantic_hash": "a1322ab2c909c5a55f4dc1228ff10702"
+  },
+  "orion/autonomy/tests/test_tension_ratelimit.py": {
+    "mtime": 1784008374.2415006,
+    "ast_hash": "6fbf2bef47b2c7bcaa3811fbe510949a",
+    "semantic_hash": "6fbf2bef47b2c7bcaa3811fbe510949a"
+  },
+  "orion/autonomy/verification.py": {
+    "mtime": 1779328788.9557867,
+    "ast_hash": "05ae41eb3a0becf395e1de1b42c50763",
+    "semantic_hash": "05ae41eb3a0becf395e1de1b42c50763"
+  },
+  "orion/biometrics/__init__.py": {
+    "mtime": 1779668252.1370118,
+    "ast_hash": "6512f546d85d9a32549ca0e9afacb792",
+    "semantic_hash": "6512f546d85d9a32549ca0e9afacb792"
+  },
+  "orion/biometrics/node_catalog.py": {
+    "mtime": 1779668252.1370118,
+    "ast_hash": "a98e9a87de0fd8fc55a01737789b420a",
+    "semantic_hash": "a98e9a87de0fd8fc55a01737789b420a"
+  },
+  "orion/bus/__init__.py": {
+    "mtime": 1781559772.6074517,
+    "ast_hash": "5de1980dee48c44fc3e850f3a8b673f6",
+    "semantic_hash": "5de1980dee48c44fc3e850f3a8b673f6"
+  },
+  "orion/bus/consumer_readiness.py": {
+    "mtime": 1781584864.5155818,
+    "ast_hash": "0bf581652fecee9adbe0d7a308b78f65",
+    "semantic_hash": "0bf581652fecee9adbe0d7a308b78f65"
+  },
+  "orion/bus/tests/__init__.py": {
+    "mtime": 1781559772.6074517,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/bus/tests/test_consumer_readiness.py": {
+    "mtime": 1781584864.5155818,
+    "ast_hash": "8a02a40a49307565a018fd242d82c28f",
+    "semantic_hash": "8a02a40a49307565a018fd242d82c28f"
+  },
+  "orion/cognition/__init__.py": {
+    "mtime": 1763597328.715061,
+    "ast_hash": "0902359a23b4f1f8be20f58a77c4b5fd",
+    "semantic_hash": "0902359a23b4f1f8be20f58a77c4b5fd"
+  },
+  "orion/cognition/agent_chain_guards.py": {
+    "mtime": 1774673418.66604,
+    "ast_hash": "f579db4407aceecd71d02b8a7e13e066",
+    "semantic_hash": "f579db4407aceecd71d02b8a7e13e066"
+  },
+  "orion/cognition/answer_contract_normalize.py": {
+    "mtime": 1783296219.0031555,
+    "ast_hash": "a498d6065091370131220b934676abd2",
+    "semantic_hash": "a498d6065091370131220b934676abd2"
+  },
+  "orion/cognition/answer_grounding.py": {
+    "mtime": 1775968823.1912751,
+    "ast_hash": "870bab98bcb83c74962bd69987b286cd",
+    "semantic_hash": "870bab98bcb83c74962bd69987b286cd"
+  },
+  "orion/cognition/chat_history_compactor/__init__.py": {
+    "mtime": 1783958824.2766836,
+    "ast_hash": "e208e510a381657f52003dae03716cd0",
+    "semantic_hash": "e208e510a381657f52003dae03716cd0"
+  },
+  "orion/cognition/chat_history_compactor/constants.py": {
+    "mtime": 1783960753.1668303,
+    "ast_hash": "bb7f401db6e02db88052f002fea05ef4",
+    "semantic_hash": "bb7f401db6e02db88052f002fea05ef4"
+  },
+  "orion/cognition/chat_history_compactor/digest.py": {
+    "mtime": 1783958824.2766836,
+    "ast_hash": "38b013436103760b04a504aebc55b652",
+    "semantic_hash": "38b013436103760b04a504aebc55b652"
+  },
+  "orion/cognition/chat_history_compactor/tests/__init__.py": {
+    "mtime": 1783958824.2766836,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/cognition/chat_history_compactor/tests/test_digest.py": {
+    "mtime": 1783958824.2776837,
+    "ast_hash": "746b22952a2299101a118c31250d7a5a",
+    "semantic_hash": "746b22952a2299101a118c31250d7a5a"
+  },
+  "orion/cognition/chat_history_compactor/tests/test_window.py": {
+    "mtime": 1783965599.1503572,
+    "ast_hash": "88ba21ef45f1aa7f7dc707629bf145b5",
+    "semantic_hash": "88ba21ef45f1aa7f7dc707629bf145b5"
+  },
+  "orion/cognition/chat_history_compactor/window.py": {
+    "mtime": 1783965599.1503572,
+    "ast_hash": "3142b57e5ca92d7cf7d5ea97960d9960",
+    "semantic_hash": "3142b57e5ca92d7cf7d5ea97960d9960"
+  },
+  "orion/cognition/cli.py": {
+    "mtime": 1763509312.227362,
+    "ast_hash": "c7b3760bb453ded9b9d566b949577b4e",
+    "semantic_hash": "c7b3760bb453ded9b9d566b949577b4e"
+  },
+  "orion/cognition/compactor/__init__.py": {
+    "mtime": 1783958824.2776837,
+    "ast_hash": "68309a26ef98e6389aedbbec21abc755",
+    "semantic_hash": "68309a26ef98e6389aedbbec21abc755"
+  },
+  "orion/cognition/compactor/budget.py": {
+    "mtime": 1783958824.2776837,
+    "ast_hash": "5d0b467b5a86e999f6964584617d2529",
+    "semantic_hash": "5d0b467b5a86e999f6964584617d2529"
+  },
+  "orion/cognition/compactor/digest.py": {
+    "mtime": 1783958824.2776837,
+    "ast_hash": "35c1921c6d32ce077a8373dbbf80be9d",
+    "semantic_hash": "35c1921c6d32ce077a8373dbbf80be9d"
+  },
+  "orion/cognition/compactor/index.py": {
+    "mtime": 1783958824.2776837,
+    "ast_hash": "a333768e76103413615b3d7eb05b9f6e",
+    "semantic_hash": "a333768e76103413615b3d7eb05b9f6e"
+  },
+  "orion/cognition/compactor/tests/__init__.py": {
+    "mtime": 1783958824.2776837,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/cognition/compactor/tests/test_budget.py": {
+    "mtime": 1783958824.2776837,
+    "ast_hash": "116af9fb42eff55ac8b816420f6a65d0",
+    "semantic_hash": "116af9fb42eff55ac8b816420f6a65d0"
+  },
+  "orion/cognition/compactor/tests/test_index.py": {
+    "mtime": 1783958824.2776837,
+    "ast_hash": "4071800572c27670c802a2e4aeb6ab24",
+    "semantic_hash": "4071800572c27670c802a2e4aeb6ab24"
+  },
+  "orion/cognition/cortex_payload_extract.py": {
+    "mtime": 1783312413.5082457,
+    "ast_hash": "d0b780fdedf8bd160184831e11bb6e32",
+    "semantic_hash": "d0b780fdedf8bd160184831e11bb6e32"
+  },
+  "orion/cognition/delivery_grounding.py": {
+    "mtime": 1775968826.5942304,
+    "ast_hash": "622eeb08eb8c2ced7255a4bb6e8a901b",
+    "semantic_hash": "622eeb08eb8c2ced7255a4bb6e8a901b"
+  },
+  "orion/cognition/fast_chat_verbs.py": {
+    "mtime": 1778901838.366395,
+    "ast_hash": "6fa55a1649b2be770946a19b6f1c898f",
+    "semantic_hash": "6fa55a1649b2be770946a19b6f1c898f"
+  },
+  "orion/cognition/finalize_payload.py": {
+    "mtime": 1776044955.6142368,
+    "ast_hash": "f48b21febbf76b08eacbefd9f1fd5aa4",
+    "semantic_hash": "f48b21febbf76b08eacbefd9f1fd5aa4"
+  },
+  "orion/cognition/findings_bundle_synth.py": {
+    "mtime": 1775968874.887597,
+    "ast_hash": "f95bac57299ac8d53070b456fe23b1a9",
+    "semantic_hash": "f95bac57299ac8d53070b456fe23b1a9"
+  },
+  "orion/cognition/github_compactor/__init__.py": {
+    "mtime": 1783555541.5276737,
+    "ast_hash": "90eb7c8c452309e26671b171fca05b10",
+    "semantic_hash": "90eb7c8c452309e26671b171fca05b10"
+  },
+  "orion/cognition/github_compactor/constants.py": {
+    "mtime": 1783614403.5912728,
+    "ast_hash": "7fc4cec4a643529f862218f4136afa90",
+    "semantic_hash": "7fc4cec4a643529f862218f4136afa90"
+  },
+  "orion/cognition/github_compactor/digest.py": {
+    "mtime": 1783958824.2786837,
+    "ast_hash": "5f0718c9d9a963d386d9c74fe05ec16f",
+    "semantic_hash": "5f0718c9d9a963d386d9c74fe05ec16f"
+  },
+  "orion/cognition/github_compactor/tests/test_digest.py": {
+    "mtime": 1783614403.4802694,
+    "ast_hash": "aa59902ad0f61c1f09ccc70eba03f07d",
+    "semantic_hash": "aa59902ad0f61c1f09ccc70eba03f07d"
+  },
+  "orion/cognition/hub_gateway/__init__.py": {
+    "mtime": 1767676515.6251066,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/cognition/hub_gateway/bus_harness.py": {
+    "mtime": 1768597909.8742297,
+    "ast_hash": "577e0be484d7c22d8bbaed8fdaddbc1b",
+    "semantic_hash": "577e0be484d7c22d8bbaed8fdaddbc1b"
+  },
+  "orion/cognition/ontology/__init__.py": {
+    "mtime": 1763509312.227362,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/cognition/output_mode_classifier.py": {
+    "mtime": 1775968844.399997,
+    "ast_hash": "fed2607af327cf56e8aee1136f6eac17",
+    "semantic_hash": "fed2607af327cf56e8aee1136f6eac17"
+  },
+  "orion/cognition/packs_loader.py": {
+    "mtime": 1763509312.227362,
+    "ast_hash": "7eb36af92378a3c27d17f261fb72d62d",
+    "semantic_hash": "7eb36af92378a3c27d17f261fb72d62d"
+  },
+  "orion/cognition/personality/__init__.py": {
+    "mtime": 1774417080.6487088,
+    "ast_hash": "390fcc87c9dd56caddf493733434047f",
+    "semantic_hash": "390fcc87c9dd56caddf493733434047f"
+  },
+  "orion/cognition/personality/identity_context.py": {
+    "mtime": 1774417080.6487088,
+    "ast_hash": "19b96b3f071a238eac3cf01e8b729401",
+    "semantic_hash": "19b96b3f071a238eac3cf01e8b729401"
+  },
+  "orion/cognition/plan_loader.py": {
+    "mtime": 1781405728.4940891,
+    "ast_hash": "bd6d7429f2e9bb511de61d847cf61543",
+    "semantic_hash": "bd6d7429f2e9bb511de61d847cf61543"
+  },
+  "orion/cognition/planner/__init__.py": {
+    "mtime": 1763598158.4362404,
+    "ast_hash": "2405be7adf048c18ad678217048b4f76",
+    "semantic_hash": "2405be7adf048c18ad678217048b4f76"
+  },
+  "orion/cognition/planner/loader.py": {
+    "mtime": 1773975149.9457865,
+    "ast_hash": "3f5e56ddd1c98c395c189d7ad37af61d",
+    "semantic_hash": "3f5e56ddd1c98c395c189d7ad37af61d"
+  },
+  "orion/cognition/planner/models.py": {
+    "mtime": 1774564470.047171,
+    "ast_hash": "f633dac8b758cbd731f62f8d9c20daf8",
+    "semantic_hash": "f633dac8b758cbd731f62f8d9c20daf8"
+  },
+  "orion/cognition/planner/planner.py": {
+    "mtime": 1763598137.4550724,
+    "ast_hash": "ee8913a7cc8b139a2f8661064011ed2a",
+    "semantic_hash": "ee8913a7cc8b139a2f8661064011ed2a"
+  },
+  "orion/cognition/planner/prompt_renderer.py": {
+    "mtime": 1763509312.228362,
+    "ast_hash": "138597338fdbe3270877eed32bf89782",
+    "semantic_hash": "138597338fdbe3270877eed32bf89782"
+  },
+  "orion/cognition/planner/rdf_sync.py": {
+    "mtime": 1763850080.799916,
+    "ast_hash": "1756479169682bb3d6dff2e896e8dffd",
+    "semantic_hash": "1756479169682bb3d6dff2e896e8dffd"
+  },
+  "orion/cognition/projection.py": {
+    "mtime": 1778910799.8653874,
+    "ast_hash": "ed9cbd43ae4ea3ef01af72a546897059",
+    "semantic_hash": "ed9cbd43ae4ea3ef01af72a546897059"
+  },
+  "orion/cognition/projection_builder.py": {
+    "mtime": 1783027452.0076115,
+    "ast_hash": "02c94e40ea5d5daf2be2101b17388adb",
+    "semantic_hash": "02c94e40ea5d5daf2be2101b17388adb"
+  },
+  "orion/cognition/projection_context.py": {
+    "mtime": 1779070080.2392051,
+    "ast_hash": "24f974d9f4bf876f09f490d27ff7de73",
+    "semantic_hash": "24f974d9f4bf876f09f490d27ff7de73"
+  },
+  "orion/cognition/prompts/__init__.py": {
+    "mtime": 1763509312.228362,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/cognition/prompts/tests/test_imperative_first_prompts.py": {
+    "mtime": 1783298706.1984499,
+    "ast_hash": "ded472f9ba9e956099515d63d267e35b",
+    "semantic_hash": "ded472f9ba9e956099515d63d267e35b"
+  },
+  "orion/cognition/pyproject.toml": {
+    "mtime": 1763597344.4651635,
+    "ast_hash": "0531905fb36cbb68218985360fe07a2b",
+    "semantic_hash": "0531905fb36cbb68218985360fe07a2b"
+  },
+  "orion/cognition/quality_evaluator.py": {
+    "mtime": 1775969154.988905,
+    "ast_hash": "6150ad8ff8c6f9fc4bb9145dc4d561f2",
+    "semantic_hash": "6150ad8ff8c6f9fc4bb9145dc4d561f2"
+  },
+  "orion/cognition/recall_prefetch.py": {
+    "mtime": 1779070080.2412052,
+    "ast_hash": "9db8cd00bb388b0da9696196fcb9f38d",
+    "semantic_hash": "9db8cd00bb388b0da9696196fcb9f38d"
+  },
+  "orion/cognition/recall_query.py": {
+    "mtime": 1781405728.4940891,
+    "ast_hash": "d1c8040efb35e9c0702531eab41d3279",
+    "semantic_hash": "d1c8040efb35e9c0702531eab41d3279"
+  },
+  "orion/cognition/runtime_pack_merge.py": {
+    "mtime": 1773984591.7450988,
+    "ast_hash": "d7ba2e459e61ea01d30bf3e187178b2b",
+    "semantic_hash": "d7ba2e459e61ea01d30bf3e187178b2b"
+  },
+  "orion/cognition/schemas/__init__.py": {
+    "mtime": 1763509312.229362,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/cognition/schemas/verb.schema.json": {
+    "mtime": 1764872202.212803,
+    "ast_hash": "89e7186c79c806bf359762a5334e7c66",
+    "semantic_hash": "89e7186c79c806bf359762a5334e7c66"
+  },
+  "orion/cognition/skills_manifest.py": {
+    "mtime": 1778901838.366395,
+    "ast_hash": "17963a90e36b245e2b345a7793bf44ab",
+    "semantic_hash": "17963a90e36b245e2b345a7793bf44ab"
+  },
+  "orion/cognition/tests/rdf_sync.py": {
+    "mtime": 1763509312.229362,
+    "ast_hash": "748393d3aa960af1b4a74d24162a0528",
+    "semantic_hash": "748393d3aa960af1b4a74d24162a0528"
+  },
+  "orion/cognition/tests/test_agent_chain_guards.py": {
+    "mtime": 1774673418.66604,
+    "ast_hash": "3795a7db8053dcbfffdab2ba03d0ae8b",
+    "semantic_hash": "3795a7db8053dcbfffdab2ba03d0ae8b"
+  },
+  "orion/cognition/tests/test_answer_contract_normalize.py": {
+    "mtime": 1775969188.023468,
+    "ast_hash": "29dba5e4e47a34d62d3587797084efa5",
+    "semantic_hash": "29dba5e4e47a34d62d3587797084efa5"
+  },
+  "orion/cognition/tests/test_answer_grounding_discord.py": {
+    "mtime": 1775969169.8777082,
+    "ast_hash": "383e1b470e619a4de730df22a37ca496",
+    "semantic_hash": "383e1b470e619a4de730df22a37ca496"
+  },
+  "orion/cognition/tests/test_daily_metacog_prompt.py": {
+    "mtime": 1781405728.4940891,
+    "ast_hash": "b812ecab9c55708f09d3a9a656a87031",
+    "semantic_hash": "b812ecab9c55708f09d3a9a656a87031"
+  },
+  "orion/cognition/tests/test_delivery_grounding.py": {
+    "mtime": 1775969155.904893,
+    "ast_hash": "77e6abcaf52c6f3373b985c091f8503c",
+    "semantic_hash": "77e6abcaf52c6f3373b985c091f8503c"
+  },
+  "orion/cognition/tests/test_dream_contracts.py": {
+    "mtime": 1774236180.4423857,
+    "ast_hash": "49d0c13a62d9083eb2be42a8ba10b3ab",
+    "semantic_hash": "49d0c13a62d9083eb2be42a8ba10b3ab"
+  },
+  "orion/cognition/tests/test_finalize_payload.py": {
+    "mtime": 1776044955.0592444,
+    "ast_hash": "2297442b16b847b70d26e1ee38dc299b",
+    "semantic_hash": "2297442b16b847b70d26e1ee38dc299b"
+  },
+  "orion/cognition/tests/test_findings_bundle_synth.py": {
+    "mtime": 1775969201.7332866,
+    "ast_hash": "fdc9ee0f319a724d6d9e4be23543d468",
+    "semantic_hash": "fdc9ee0f319a724d6d9e4be23543d468"
+  },
+  "orion/cognition/tests/test_live_tool_resolution_pass2.py": {
+    "mtime": 1773984591.7450988,
+    "ast_hash": "4a250078067ff5216d47dc8b3d1cf92c",
+    "semantic_hash": "4a250078067ff5216d47dc8b3d1cf92c"
+  },
+  "orion/cognition/tests/test_packs.py": {
+    "mtime": 1763509312.229362,
+    "ast_hash": "401f83fe55e1e04eb6d92d02d94bf84c",
+    "semantic_hash": "401f83fe55e1e04eb6d92d02d94bf84c"
+  },
+  "orion/cognition/tests/test_planner.py": {
+    "mtime": 1763509312.229362,
+    "ast_hash": "d996ccc8de66d00aa614349474b0e2a8",
+    "semantic_hash": "d996ccc8de66d00aa614349474b0e2a8"
+  },
+  "orion/cognition/tests/test_projection.py": {
+    "mtime": 1778910799.8653874,
+    "ast_hash": "ba813703bc10deabc315ee714de5f896",
+    "semantic_hash": "ba813703bc10deabc315ee714de5f896"
+  },
+  "orion/cognition/tests/test_projection_builder.py": {
+    "mtime": 1782871399.0077329,
+    "ast_hash": "e34580d349fbc90fa1d38bbcde3efe82",
+    "semantic_hash": "e34580d349fbc90fa1d38bbcde3efe82"
+  },
+  "orion/cognition/tests/test_projection_context.py": {
+    "mtime": 1779070080.2412052,
+    "ast_hash": "1b6a740548b34aab2fb4271536a3eeb3",
+    "semantic_hash": "1b6a740548b34aab2fb4271536a3eeb3"
+  },
+  "orion/cognition/tests/test_projection_starvation_diagnostics.py": {
+    "mtime": 1779070080.2412052,
+    "ast_hash": "e6343d3e8ffa5d5c59686234472a0c0c",
+    "semantic_hash": "e6343d3e8ffa5d5c59686234472a0c0c"
+  },
+  "orion/cognition/tests/test_quality_evaluator.py": {
+    "mtime": 1773984591.7450988,
+    "ast_hash": "6ec2f1d568bb65a732b0fa977ffdf0c9",
+    "semantic_hash": "6ec2f1d568bb65a732b0fa977ffdf0c9"
+  },
+  "orion/cognition/tests/test_quality_evaluator_claims.py": {
+    "mtime": 1775969168.8837214,
+    "ast_hash": "a3c95694817d1caa6672a05c95b0a3b6",
+    "semantic_hash": "a3c95694817d1caa6672a05c95b0a3b6"
+  },
+  "orion/cognition/tests/test_recall_fusion.py": {
+    "mtime": 1774236180.4423857,
+    "ast_hash": "e8238fac530bba4447449e682cbc0da7",
+    "semantic_hash": "e8238fac530bba4447449e682cbc0da7"
+  },
+  "orion/cognition/tests/test_recall_prefetch.py": {
+    "mtime": 1781405728.495089,
+    "ast_hash": "5996c99b76810d62cbbedd9c40938b81",
+    "semantic_hash": "5996c99b76810d62cbbedd9c40938b81"
+  },
+  "orion/cognition/tests/test_recall_profiles.py": {
+    "mtime": 1781405728.495089,
+    "ast_hash": "95d8f2281c9f1e9106df5a3076ce2ea1",
+    "semantic_hash": "95d8f2281c9f1e9106df5a3076ce2ea1"
+  },
+  "orion/cognition/tests/test_recall_render_lane_separation.py": {
+    "mtime": 1781405728.495089,
+    "ast_hash": "073245695ce7e8d7f836d861a2386e7b",
+    "semantic_hash": "073245695ce7e8d7f836d861a2386e7b"
+  },
+  "orion/cognition/tests/test_recall_sql_timeline_projection.py": {
+    "mtime": 1779070080.2422051,
+    "ast_hash": "06c7f929fe71d3b9d72437d2a83c8563",
+    "semantic_hash": "06c7f929fe71d3b9d72437d2a83c8563"
+  },
+  "orion/cognition/tests/test_reflect_recall_integration.py": {
+    "mtime": 1768597909.8752296,
+    "ast_hash": "6f95f04cd3f655ee4ad8e198486df4d2",
+    "semantic_hash": "6f95f04cd3f655ee4ad8e198486df4d2"
+  },
+  "orion/cognition/tests/test_runtime_pack_merge.py": {
+    "mtime": 1773984591.7450988,
+    "ast_hash": "43c72b00a3a24dbcd4ac015fb0e46469",
+    "semantic_hash": "43c72b00a3a24dbcd4ac015fb0e46469"
+  },
+  "orion/cognition/tests/verb_configs.py": {
+    "mtime": 1763509312.229362,
+    "ast_hash": "52b8d6eb1d999e9c53093cc876537972",
+    "semantic_hash": "52b8d6eb1d999e9c53093cc876537972"
+  },
+  "orion/cognition/tools/generate_rdf.py": {
+    "mtime": 1763509312.229362,
+    "ast_hash": "e43728060971a50051a9703f0b315fba",
+    "semantic_hash": "e43728060971a50051a9703f0b315fba"
+  },
+  "orion/cognition/tools/list_packs.py": {
+    "mtime": 1763509312.229362,
+    "ast_hash": "acb74703698b1556f1a54387eea414fc",
+    "semantic_hash": "acb74703698b1556f1a54387eea414fc"
+  },
+  "orion/cognition/tools/show_packs.py": {
+    "mtime": 1763509312.229362,
+    "ast_hash": "3bc4344c0add946ecfc6e6b40c50cca1",
+    "semantic_hash": "3bc4344c0add946ecfc6e6b40c50cca1"
+  },
+  "orion/cognition/verb_activation.py": {
+    "mtime": 1773975149.9477863,
+    "ast_hash": "5249555abe1a41e697dcc0aed20d08de",
+    "semantic_hash": "5249555abe1a41e697dcc0aed20d08de"
+  },
+  "orion/cognition/verb_catalog.py": {
+    "mtime": 1773984591.7450988,
+    "ast_hash": "9467370c411cab5bc07f929ecf3269c0",
+    "semantic_hash": "9467370c411cab5bc07f929ecf3269c0"
+  },
+  "orion/cognition/verbs/__init__.py": {
+    "mtime": 1763509312.229362,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/cognition/workflows/__init__.py": {
+    "mtime": 1774478925.1972294,
+    "ast_hash": "83322982b80a84472214252bbcc90730",
+    "semantic_hash": "83322982b80a84472214252bbcc90730"
+  },
+  "orion/cognition/workflows/execution_policy.py": {
+    "mtime": 1774564470.047171,
+    "ast_hash": "e147fbf652fccbcc1ee1cdbeb593bd8e",
+    "semantic_hash": "e147fbf652fccbcc1ee1cdbeb593bd8e"
+  },
+  "orion/cognition/workflows/management.py": {
+    "mtime": 1774478925.1972294,
+    "ast_hash": "74d50c067d33b6fe71f26acbab8ac69e",
+    "semantic_hash": "74d50c067d33b6fe71f26acbab8ac69e"
+  },
+  "orion/cognition/workflows/registry.py": {
+    "mtime": 1783958824.2786837,
+    "ast_hash": "ed9399a4793d778ba3b82dd72e379500",
+    "semantic_hash": "ed9399a4793d778ba3b82dd72e379500"
+  },
+  "orion/collapse/__init__.py": {
+    "mtime": 1782938951.7367241,
+    "ast_hash": "3e33adf5c2abd652d8d87ec731d37918",
+    "semantic_hash": "3e33adf5c2abd652d8d87ec731d37918"
+  },
+  "orion/collapse/service.py": {
+    "mtime": 1783107031.9689016,
+    "ast_hash": "680ed2564845a701dfbe7ce473035e5e",
+    "semantic_hash": "680ed2564845a701dfbe7ce473035e5e"
+  },
+  "orion/collapse/tests/test_apply_causal_density_to_entry.py": {
+    "mtime": 1783107031.9689016,
+    "ast_hash": "50cbc4e89fb7ee2fe29cd7348b3c987b",
+    "semantic_hash": "50cbc4e89fb7ee2fe29cd7348b3c987b"
+  },
+  "orion/consolidation/__init__.py": {
+    "mtime": 1779749949.3184676,
+    "ast_hash": "27673bc1adb758ac7ec18d6feba4af8d",
+    "semantic_hash": "27673bc1adb758ac7ec18d6feba4af8d"
+  },
+  "orion/consolidation/builder.py": {
+    "mtime": 1779749949.3194675,
+    "ast_hash": "51777533b8a59f1dca048421f0388437",
+    "semantic_hash": "51777533b8a59f1dca048421f0388437"
+  },
+  "orion/consolidation/expectation.py": {
+    "mtime": 1780622613.5927644,
+    "ast_hash": "f428d2ff29a2222db666a9d7631433a0",
+    "semantic_hash": "f428d2ff29a2222db666a9d7631433a0"
+  },
+  "orion/consolidation/motif.py": {
+    "mtime": 1780622613.5927644,
+    "ast_hash": "04e74a026d1d5fc9d801a7771bb72059",
+    "semantic_hash": "04e74a026d1d5fc9d801a7771bb72059"
+  },
+  "orion/consolidation/policy.py": {
+    "mtime": 1779749949.3194675,
+    "ast_hash": "ea762ceeada44ff33dbb6822eff4ac19",
+    "semantic_hash": "ea762ceeada44ff33dbb6822eff4ac19"
+  },
+  "orion/consolidation/repository.py": {
+    "mtime": 1779749949.3194675,
+    "ast_hash": "3152445576a0b12333f277f52668a8c6",
+    "semantic_hash": "3152445576a0b12333f277f52668a8c6"
+  },
+  "orion/consolidation/schema_candidates.py": {
+    "mtime": 1779749949.3194675,
+    "ast_hash": "36cbbd8270525786de3d0121de63bd20",
+    "semantic_hash": "36cbbd8270525786de3d0121de63bd20"
+  },
+  "orion/consolidation/tensorize.py": {
+    "mtime": 1779749949.3194675,
+    "ast_hash": "74911b898ff98e66b7efc9ad303f54a6",
+    "semantic_hash": "74911b898ff98e66b7efc9ad303f54a6"
+  },
+  "orion/consolidation/windows.py": {
+    "mtime": 1779749949.3194675,
+    "ast_hash": "426a92fafa893bb192c7b4d1ec2f647e",
+    "semantic_hash": "426a92fafa893bb192c7b4d1ec2f647e"
+  },
+  "orion/core/activation_decay.py": {
+    "mtime": 1783614403.7462773,
+    "ast_hash": "e452342836745a1835e974a69128c339",
+    "semantic_hash": "e452342836745a1835e974a69128c339"
+  },
+  "orion/core/bus/__init__.py": {
+    "mtime": 1768597909.8752296,
+    "ast_hash": "ebfaed111809a56aee865b9db9c68e5e",
+    "semantic_hash": "ebfaed111809a56aee865b9db9c68e5e"
+  },
+  "orion/core/bus/async_service.py": {
+    "mtime": 1783753435.471319,
+    "ast_hash": "eb0a7cd4e89576ea9ed07ad78f1ab539",
+    "semantic_hash": "eb0a7cd4e89576ea9ed07ad78f1ab539"
+  },
+  "orion/core/bus/bus_schemas.py": {
+    "mtime": 1775636422.2494783,
+    "ast_hash": "d31c494baa07fe298fbe8450f28a8009",
+    "semantic_hash": "d31c494baa07fe298fbe8450f28a8009"
+  },
+  "orion/core/bus/bus_service_chassis.py": {
+    "mtime": 1781846476.4911659,
+    "ast_hash": "3a2cbbf34dd04be01bf0671f72200a36",
+    "semantic_hash": "3a2cbbf34dd04be01bf0671f72200a36"
+  },
+  "orion/core/bus/catalog_loader.py": {
+    "mtime": 1768597909.8752296,
+    "ast_hash": "39bc1f253236e3a1f27b519c9539157c",
+    "semantic_hash": "39bc1f253236e3a1f27b519c9539157c"
+  },
+  "orion/core/bus/codec.py": {
+    "mtime": 1767676515.6321065,
+    "ast_hash": "51a948d0fe66687b9d13fa55b725ce77",
+    "semantic_hash": "51a948d0fe66687b9d13fa55b725ce77"
+  },
+  "orion/core/bus/enforce.py": {
+    "mtime": 1768597909.8752296,
+    "ast_hash": "6a7d766b95c12059e6aef57eb68d0e6f",
+    "semantic_hash": "6a7d766b95c12059e6aef57eb68d0e6f"
+  },
+  "orion/core/bus/orion-router.py": {
+    "mtime": 1767676515.6321065,
+    "ast_hash": "9293e5f141b7a9db280d635a7c03b67f",
+    "semantic_hash": "9293e5f141b7a9db280d635a7c03b67f"
+  },
+  "orion/core/bus/queue_service_chassis.py": {
+    "mtime": 1778901838.367395,
+    "ast_hash": "23c435c037089c935908bfe330a1235d",
+    "semantic_hash": "23c435c037089c935908bfe330a1235d"
+  },
+  "orion/core/bus/resilience.py": {
+    "mtime": 1783912914.8307593,
+    "ast_hash": "74aee0df0eaaf3150b93a4f4951815b3",
+    "semantic_hash": "74aee0df0eaaf3150b93a4f4951815b3"
+  },
+  "orion/core/bus/rpc_fork.py": {
+    "mtime": 1781730419.486787,
+    "ast_hash": "3b44b723cd6f91f65b58172c1d9b2956",
+    "semantic_hash": "3b44b723cd6f91f65b58172c1d9b2956"
+  },
+  "orion/core/bus/telemetry.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "c9c7ac6faf68a40fc244d369df65f6d7",
+    "semantic_hash": "c9c7ac6faf68a40fc244d369df65f6d7"
+  },
+  "orion/core/bus/tests/test_resilience.py": {
+    "mtime": 1783912914.8317595,
+    "ast_hash": "702cdf4a9a7f257111e70d62c1c912a2",
+    "semantic_hash": "702cdf4a9a7f257111e70d62c1c912a2"
+  },
+  "orion/core/bus/work_queue.py": {
+    "mtime": 1778901838.367395,
+    "ast_hash": "c0a14fdffc06af5ed644ec9192c33c83",
+    "semantic_hash": "c0a14fdffc06af5ed644ec9192c33c83"
+  },
+  "orion/core/contracts/__init__.py": {
+    "mtime": 1779070080.2422051,
+    "ast_hash": "28315f8a0224b7e813f982f9e0ff661d",
+    "semantic_hash": "28315f8a0224b7e813f982f9e0ff661d"
+  },
+  "orion/core/contracts/memory_cards.py": {
+    "mtime": 1783958824.2786837,
+    "ast_hash": "4c0367efb96d421ae6a034e3e194ff3c",
+    "semantic_hash": "4c0367efb96d421ae6a034e3e194ff3c"
+  },
+  "orion/core/contracts/recall.py": {
+    "mtime": 1783398623.0061564,
+    "ast_hash": "ddf9ad072eebbeeb45ca517879885ed5",
+    "semantic_hash": "ddf9ad072eebbeeb45ca517879885ed5"
+  },
+  "orion/core/ids.py": {
+    "mtime": 1783402731.2983196,
+    "ast_hash": "512f220c706d70d51c6337e1a71effed",
+    "semantic_hash": "512f220c706d70d51c6337e1a71effed"
+  },
+  "orion/core/llm_json.py": {
+    "mtime": 1776044955.0482445,
+    "ast_hash": "0bec47f423aae4df65d5bb088618d8c3",
+    "semantic_hash": "0bec47f423aae4df65d5bb088618d8c3"
+  },
+  "orion/core/schemas/__init__.py": {
+    "mtime": 1777142854.8072352,
+    "ast_hash": "63fc99a84b7455e78f185386cd5fd421",
+    "semantic_hash": "63fc99a84b7455e78f185386cd5fd421"
+  },
+  "orion/core/schemas/calibration_adoption.py": {
+    "mtime": 1775601136.3168964,
+    "ast_hash": "92d3083b3f26b6799decd817ad013a74",
+    "semantic_hash": "92d3083b3f26b6799decd817ad013a74"
+  },
+  "orion/core/schemas/cognitive_substrate.py": {
+    "mtime": 1778901838.367395,
+    "ast_hash": "2f13a31f8fcd9d2a9863ea971a51c853",
+    "semantic_hash": "2f13a31f8fcd9d2a9863ea971a51c853"
+  },
+  "orion/core/schemas/concept_induction.py": {
+    "mtime": 1773980667.707536,
+    "ast_hash": "ee6fa96e6f3d53527ee2d73737a8976f",
+    "semantic_hash": "ee6fa96e6f3d53527ee2d73737a8976f"
+  },
+  "orion/core/schemas/drives.py": {
+    "mtime": 1783490446.2993593,
+    "ast_hash": "a0e1fda5dfc966a36f4d089c93b4548a",
+    "semantic_hash": "a0e1fda5dfc966a36f4d089c93b4548a"
+  },
+  "orion/core/schemas/endogenous.py": {
+    "mtime": 1775601136.3168964,
+    "ast_hash": "cc60c1fb05747e18edea1411902d9e8b",
+    "semantic_hash": "cc60c1fb05747e18edea1411902d9e8b"
+  },
+  "orion/core/schemas/endogenous_eval.py": {
+    "mtime": 1775601136.3168964,
+    "ast_hash": "be2de6981676fa74908a09d577750f31",
+    "semantic_hash": "be2de6981676fa74908a09d577750f31"
+  },
+  "orion/core/schemas/endogenous_runtime.py": {
+    "mtime": 1775601136.3168964,
+    "ast_hash": "963a5bb28e24213a4c3255b4e7441ddd",
+    "semantic_hash": "963a5bb28e24213a4c3255b4e7441ddd"
+  },
+  "orion/core/schemas/frontier_curiosity.py": {
+    "mtime": 1783365495.729666,
+    "ast_hash": "7dd5e56b42b3ec5c56349f9ea5712f34",
+    "semantic_hash": "7dd5e56b42b3ec5c56349f9ea5712f34"
+  },
+  "orion/core/schemas/frontier_expansion.py": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "9e2df6c70022f540dee66711a8f67585",
+    "semantic_hash": "9e2df6c70022f540dee66711a8f67585"
+  },
+  "orion/core/schemas/frontier_landing.py": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "093cba4fd0723e6d021771aa139bb096",
+    "semantic_hash": "093cba4fd0723e6d021771aa139bb096"
+  },
+  "orion/core/schemas/mentor.py": {
+    "mtime": 1775601136.3168964,
+    "ast_hash": "ac698047c5cfa0911714829ba74723f8",
+    "semantic_hash": "ac698047c5cfa0911714829ba74723f8"
+  },
+  "orion/core/schemas/reasoning.py": {
+    "mtime": 1775601136.3168964,
+    "ast_hash": "25d2c48531305e88083841cb3e5fcfd4",
+    "semantic_hash": "25d2c48531305e88083841cb3e5fcfd4"
+  },
+  "orion/core/schemas/reasoning_io.py": {
+    "mtime": 1775601136.3168964,
+    "ast_hash": "5192a027e42035ad93dcdefc1e12422f",
+    "semantic_hash": "5192a027e42035ad93dcdefc1e12422f"
+  },
+  "orion/core/schemas/reasoning_policy.py": {
+    "mtime": 1775601136.3168964,
+    "ast_hash": "f34950bd58be5c6f8f004185138c7f93",
+    "semantic_hash": "f34950bd58be5c6f8f004185138c7f93"
+  },
+  "orion/core/schemas/reasoning_summary.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "52ad292fa7ce24ff780e39c13d76635e",
+    "semantic_hash": "52ad292fa7ce24ff780e39c13d76635e"
+  },
+  "orion/core/schemas/recall_strategy_readiness.py": {
+    "mtime": 1777158084.603312,
+    "ast_hash": "1aa502bad1bbae91a1011c374a66f214",
+    "semantic_hash": "1aa502bad1bbae91a1011c374a66f214"
+  },
+  "orion/core/schemas/spark_canonical.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "14f08ff1bc280c9f2f9047188fb0ff22",
+    "semantic_hash": "14f08ff1bc280c9f2f9047188fb0ff22"
+  },
+  "orion/core/schemas/substrate_consolidation.py": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "59f0b5a3d033d3312ac0bcd5c9673e7e",
+    "semantic_hash": "59f0b5a3d033d3312ac0bcd5c9673e7e"
+  },
+  "orion/core/schemas/substrate_episodes.py": {
+    "mtime": 1782955647.2154183,
+    "ast_hash": "3eceee77c1b4add40d9a2dd17f54abde",
+    "semantic_hash": "3eceee77c1b4add40d9a2dd17f54abde"
+  },
+  "orion/core/schemas/substrate_mutation.py": {
+    "mtime": 1777748523.3175988,
+    "ast_hash": "1cd1f3099cca0df785deeddfe2badf05",
+    "semantic_hash": "1cd1f3099cca0df785deeddfe2badf05"
+  },
+  "orion/core/schemas/substrate_policy_adoption.py": {
+    "mtime": 1775634425.3982525,
+    "ast_hash": "b0234324ed1071fc4b7a9e77ab317d8a",
+    "semantic_hash": "b0234324ed1071fc4b7a9e77ab317d8a"
+  },
+  "orion/core/schemas/substrate_policy_comparison.py": {
+    "mtime": 1775634425.3992527,
+    "ast_hash": "8c6875bb205aec850b827eece1f45efc",
+    "semantic_hash": "8c6875bb205aec850b827eece1f45efc"
+  },
+  "orion/core/schemas/substrate_review_queue.py": {
+    "mtime": 1775613610.4134464,
+    "ast_hash": "310ac50fc1c2f2f8d0093c86d635829d",
+    "semantic_hash": "310ac50fc1c2f2f8d0093c86d635829d"
+  },
+  "orion/core/schemas/substrate_review_runtime.py": {
+    "mtime": 1775613610.4134464,
+    "ast_hash": "5738fd54224a1cb715a7625be3a7ee02",
+    "semantic_hash": "5738fd54224a1cb715a7625be3a7ee02"
+  },
+  "orion/core/schemas/substrate_review_telemetry.py": {
+    "mtime": 1777148947.9764428,
+    "ast_hash": "13e04fc6af8e4182db5a337c93140a0a",
+    "semantic_hash": "13e04fc6af8e4182db5a337c93140a0a"
+  },
+  "orion/core/sql_router/__init__.py": {
+    "mtime": 1763232123.3978906,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/core/sql_router/db.py": {
+    "mtime": 1763232123.3978906,
+    "ast_hash": "3c0a4285f956ab5b9e79264d5334cba6",
+    "semantic_hash": "3c0a4285f956ab5b9e79264d5334cba6"
+  },
+  "orion/core/sql_router/router.py": {
+    "mtime": 1763232123.3978906,
+    "ast_hash": "8dfb9dfff8a6ace633c8cf1926b571a1",
+    "semantic_hash": "8dfb9dfff8a6ace633c8cf1926b571a1"
+  },
+  "orion/core/sql_router/worker.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "af98f392a2b3941ccc0430786c2a4dbe",
+    "semantic_hash": "af98f392a2b3941ccc0430786c2a4dbe"
+  },
+  "orion/core/storage/__init__.py": {
+    "mtime": 1783958824.2786837,
+    "ast_hash": "78129ab4373e72ddc6d9804ea966241d",
+    "semantic_hash": "78129ab4373e72ddc6d9804ea966241d"
+  },
+  "orion/core/storage/memory_cards.py": {
+    "mtime": 1783958824.2796838,
+    "ast_hash": "371a0cf50bee94eee6a4749540c79173",
+    "semantic_hash": "371a0cf50bee94eee6a4749540c79173"
+  },
+  "orion/core/storage/memory_extraction.py": {
+    "mtime": 1777753742.938735,
+    "ast_hash": "910819153f1dbbcc0fc06df82669f2c6",
+    "semantic_hash": "910819153f1dbbcc0fc06df82669f2c6"
+  },
+  "orion/core/storage/sql/graphiti_projection.sql": {
+    "mtime": 1781129793.9222505,
+    "ast_hash": "83b7ee036415c24fbcac9c1a766f4d8f",
+    "semantic_hash": "83b7ee036415c24fbcac9c1a766f4d8f"
+  },
+  "orion/core/storage/sql/memory_cards.sql": {
+    "mtime": 1783958824.2796838,
+    "ast_hash": "7b2b21250125495ee9e00b308a4e2217",
+    "semantic_hash": "7b2b21250125495ee9e00b308a4e2217"
+  },
+  "orion/core/storage/sql/memory_crystallizations.sql": {
+    "mtime": 1783965578.731708,
+    "ast_hash": "ddca5546467ebceac4d74b49400018d4",
+    "semantic_hash": "ddca5546467ebceac4d74b49400018d4"
+  },
+  "orion/core/verbs/__init__.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "45d6e8b094edf63caaf5a18549642214",
+    "semantic_hash": "45d6e8b094edf63caaf5a18549642214"
+  },
+  "orion/core/verbs/base.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "45c2313653978e1b1698822c8ee4bd5c",
+    "semantic_hash": "45c2313653978e1b1698822c8ee4bd5c"
+  },
+  "orion/core/verbs/models.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "8cb24929335a78ec12152915beefe036",
+    "semantic_hash": "8cb24929335a78ec12152915beefe036"
+  },
+  "orion/core/verbs/registry.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "7f14540379196fbbbf9d58a4026dfb40",
+    "semantic_hash": "7f14540379196fbbbf9d58a4026dfb40"
+  },
+  "orion/core/verbs/runtime.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "3e90585a3404b3339545279128bcd62f",
+    "semantic_hash": "3e90585a3404b3339545279128bcd62f"
+  },
+  "orion/discussion_window/__init__.py": {
+    "mtime": 1776049199.5245712,
+    "ast_hash": "725797a5f80b9c2f6583ee2082a46064",
+    "semantic_hash": "725797a5f80b9c2f6583ee2082a46064"
+  },
+  "orion/discussion_window/sql_fetch.py": {
+    "mtime": 1783967737.3747127,
+    "ast_hash": "a3ca1a26332fe2d79bc2c3baca89220b",
+    "semantic_hash": "a3ca1a26332fe2d79bc2c3baca89220b"
+  },
+  "orion/discussion_window/tests/test_sql_fetch.py": {
+    "mtime": 1783967737.3747127,
+    "ast_hash": "880801d9a5e7d64be7aff843531f2a6d",
+    "semantic_hash": "880801d9a5e7d64be7aff843531f2a6d"
+  },
+  "orion/discussion_window/tests/test_timeframe.py": {
+    "mtime": 1776049528.1767964,
+    "ast_hash": "7a8876b3940c5350dd9f157b4de00b6f",
+    "semantic_hash": "7a8876b3940c5350dd9f157b4de00b6f"
+  },
+  "orion/discussion_window/timeframe.py": {
+    "mtime": 1776049206.215499,
+    "ast_hash": "805eb83525009fd59f76a14fb2548773",
+    "semantic_hash": "805eb83525009fd59f76a14fb2548773"
+  },
+  "orion/embodiment/__init__.py": {
+    "mtime": 1783450708.6387277,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/embodiment/aitown_client.py": {
+    "mtime": 1783461977.1293035,
+    "ast_hash": "97e7336ccfb706cb72812db3e4d0f411",
+    "semantic_hash": "97e7336ccfb706cb72812db3e4d0f411"
+  },
+  "orion/embodiment/arbiter.py": {
+    "mtime": 1783450708.6397278,
+    "ast_hash": "866b14d6b9717029f1dccb9167aebcc0",
+    "semantic_hash": "866b14d6b9717029f1dccb9167aebcc0"
+  },
+  "orion/embodiment/drive_map.py": {
+    "mtime": 1783450708.6397278,
+    "ast_hash": "e033b23d223558d57ead7e60be7c8c41",
+    "semantic_hash": "e033b23d223558d57ead7e60be7c8c41"
+  },
+  "orion/embodiment/intents.py": {
+    "mtime": 1783450708.6397278,
+    "ast_hash": "3ca2f424bd315ef384098a62775e87b7",
+    "semantic_hash": "3ca2f424bd315ef384098a62775e87b7"
+  },
+  "orion/embodiment/perception.py": {
+    "mtime": 1783473102.6416757,
+    "ast_hash": "43fed0d954774c222b5b446fb55d09df",
+    "semantic_hash": "43fed0d954774c222b5b446fb55d09df"
+  },
+  "orion/embodiment/persona.py": {
+    "mtime": 1783450708.6397278,
+    "ast_hash": "a42b491b401ecdc7632ecf39ed6f2d98",
+    "semantic_hash": "a42b491b401ecdc7632ecf39ed6f2d98"
+  },
+  "orion/embodiment/resolver.py": {
+    "mtime": 1783461977.1293035,
+    "ast_hash": "c659e3c2ca4ba938549debf14595a7f9",
+    "semantic_hash": "c659e3c2ca4ba938549debf14595a7f9"
+  },
+  "orion/embodiment/salience.py": {
+    "mtime": 1783450708.6397278,
+    "ast_hash": "afb7ac45f0da4bb52fed8b18e511eadf",
+    "semantic_hash": "afb7ac45f0da4bb52fed8b18e511eadf"
+  },
+  "orion/embodiment/speech.py": {
+    "mtime": 1783615607.9849458,
+    "ast_hash": "59d91c6c4c72cabc7f9ce9eff1689cd9",
+    "semantic_hash": "59d91c6c4c72cabc7f9ce9eff1689cd9"
+  },
+  "orion/embodiment/tests/__init__.py": {
+    "mtime": 1783450708.6397278,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/embodiment/tests/test_aitown_client.py": {
+    "mtime": 1783461977.1293035,
+    "ast_hash": "2942743cb47c7a30400d7c201c955b9f",
+    "semantic_hash": "2942743cb47c7a30400d7c201c955b9f"
+  },
+  "orion/embodiment/tests/test_arbiter.py": {
+    "mtime": 1783450708.6397278,
+    "ast_hash": "318290ffb8721f73b54ece9f4e6b1ed8",
+    "semantic_hash": "318290ffb8721f73b54ece9f4e6b1ed8"
+  },
+  "orion/embodiment/tests/test_drive_map.py": {
+    "mtime": 1783450708.6407278,
+    "ast_hash": "9fcaaa918145e983bcdfb4f6e2514e84",
+    "semantic_hash": "9fcaaa918145e983bcdfb4f6e2514e84"
+  },
+  "orion/embodiment/tests/test_intents.py": {
+    "mtime": 1783450708.6407278,
+    "ast_hash": "67f6023e3882b7adef753b165835e1b6",
+    "semantic_hash": "67f6023e3882b7adef753b165835e1b6"
+  },
+  "orion/embodiment/tests/test_perception.py": {
+    "mtime": 1783473102.6416757,
+    "ast_hash": "4168e96e0ad817d2b416ff2e6c2c810e",
+    "semantic_hash": "4168e96e0ad817d2b416ff2e6c2c810e"
+  },
+  "orion/embodiment/tests/test_persona.py": {
+    "mtime": 1783450708.6407278,
+    "ast_hash": "1021ab6b93184929c094fe146f682d10",
+    "semantic_hash": "1021ab6b93184929c094fe146f682d10"
+  },
+  "orion/embodiment/tests/test_resolver.py": {
+    "mtime": 1783461977.1293035,
+    "ast_hash": "59b096cf14593ae6596d40e13dcdb8d0",
+    "semantic_hash": "59b096cf14593ae6596d40e13dcdb8d0"
+  },
+  "orion/embodiment/tests/test_salience.py": {
+    "mtime": 1783450708.6407278,
+    "ast_hash": "25270d1f60fb3f834279be0a45f9db5d",
+    "semantic_hash": "25270d1f60fb3f834279be0a45f9db5d"
+  },
+  "orion/embodiment/tests/test_schemas.py": {
+    "mtime": 1783450708.6407278,
+    "ast_hash": "a0b604cfdf38eff11b13b695790b18f8",
+    "semantic_hash": "a0b604cfdf38eff11b13b695790b18f8"
+  },
+  "orion/embodiment/tests/test_speech.py": {
+    "mtime": 1783615607.985946,
+    "ast_hash": "88a985c983fddcc7e5b53be5dde5fe49",
+    "semantic_hash": "88a985c983fddcc7e5b53be5dde5fe49"
+  },
+  "orion/embodiment/tests/test_town_perception_ctx.py": {
+    "mtime": 1783450708.6407278,
+    "ast_hash": "ec16e5f623616f4b9d7c3c26e8837811",
+    "semantic_hash": "ec16e5f623616f4b9d7c3c26e8837811"
+  },
+  "orion/embodiment/tests/test_worldmap.py": {
+    "mtime": 1783461977.1293035,
+    "ast_hash": "6c7c9bb05e8d63a85e65b270d2ac5666",
+    "semantic_hash": "6c7c9bb05e8d63a85e65b270d2ac5666"
+  },
+  "orion/embodiment/worldmap.py": {
+    "mtime": 1783461977.1293035,
+    "ast_hash": "f1a62d1bcef54ea4db070d48ced2286a",
+    "semantic_hash": "f1a62d1bcef54ea4db070d48ced2286a"
+  },
+  "orion/evidence_index/__init__.py": {
+    "mtime": 1776566446.4178953,
+    "ast_hash": "b7b92021cdff3b59179e160889f7cf87",
+    "semantic_hash": "b7b92021cdff3b59179e160889f7cf87"
+  },
+  "orion/evidence_index/adapters/__init__.py": {
+    "mtime": 1776566446.4178953,
+    "ast_hash": "38980eb55da90e0e9ac4a505901d636c",
+    "semantic_hash": "38980eb55da90e0e9ac4a505901d636c"
+  },
+  "orion/evidence_index/adapters/base.py": {
+    "mtime": 1776566446.4178953,
+    "ast_hash": "c20531a262672d8d7b5c1e9417ccd5b0",
+    "semantic_hash": "c20531a262672d8d7b5c1e9417ccd5b0"
+  },
+  "orion/evidence_index/adapters/collapse_mirror.py": {
+    "mtime": 1776566446.4178953,
+    "ast_hash": "f30c0fbe40b803b7ea8dd26f64a2e0a4",
+    "semantic_hash": "f30c0fbe40b803b7ea8dd26f64a2e0a4"
+  },
+  "orion/evidence_index/adapters/journal.py": {
+    "mtime": 1776566446.4188952,
+    "ast_hash": "e82bc9a4e25daec0603b2f009071d7ff",
+    "semantic_hash": "e82bc9a4e25daec0603b2f009071d7ff"
+  },
+  "orion/evidence_index/adapters/markdown_spec.py": {
+    "mtime": 1776566446.4188952,
+    "ast_hash": "4ba3be98b4664decbedb538e0bcfc411",
+    "semantic_hash": "4ba3be98b4664decbedb538e0bcfc411"
+  },
+  "orion/evidence_index/adapters/notify_output.py": {
+    "mtime": 1776566446.4188952,
+    "ast_hash": "53dbbd1843305adcb5c254fca3549f0c",
+    "semantic_hash": "53dbbd1843305adcb5c254fca3549f0c"
+  },
+  "orion/evidence_index/adapters/parsed_document.py": {
+    "mtime": 1776566446.4188952,
+    "ast_hash": "27b30577bf341119b9280ca35c52390b",
+    "semantic_hash": "27b30577bf341119b9280ca35c52390b"
+  },
+  "orion/evidence_index/ingest.py": {
+    "mtime": 1776566446.4188952,
+    "ast_hash": "e4e8f7233fe9f847310c27392342ab08",
+    "semantic_hash": "e4e8f7233fe9f847310c27392342ab08"
+  },
+  "orion/execution_dispatch/__init__.py": {
+    "mtime": 1779722671.521158,
+    "ast_hash": "63d55e4e53b0d1614e4ddb22ce76f438",
+    "semantic_hash": "63d55e4e53b0d1614e4ddb22ce76f438"
+  },
+  "orion/execution_dispatch/builder.py": {
+    "mtime": 1783961966.7714355,
+    "ast_hash": "5399ef45c488bc467d639e9d31eea230",
+    "semantic_hash": "5399ef45c488bc467d639e9d31eea230"
+  },
+  "orion/execution_dispatch/cortex_client.py": {
+    "mtime": 1783967452.500406,
+    "ast_hash": "d46627e0f155f2f97a31cd7b5dea36d6",
+    "semantic_hash": "d46627e0f155f2f97a31cd7b5dea36d6"
+  },
+  "orion/execution_dispatch/policy.py": {
+    "mtime": 1779722671.522158,
+    "ast_hash": "bdb73a57b0c45e9307013eb16afea885",
+    "semantic_hash": "bdb73a57b0c45e9307013eb16afea885"
+  },
+  "orion/execution_dispatch/result_extraction.py": {
+    "mtime": 1783967452.500406,
+    "ast_hash": "b0a8cb2db35122c3839546c926550177",
+    "semantic_hash": "b0a8cb2db35122c3839546c926550177"
+  },
+  "orion/fcc/__init__.py": {
+    "mtime": 1783615212.476912,
+    "ast_hash": "fca2c87619c85fda4d9569b74380f469",
+    "semantic_hash": "fca2c87619c85fda4d9569b74380f469"
+  },
+  "orion/fcc/claude_spawn.py": {
+    "mtime": 1783807841.1681182,
+    "ast_hash": "697042728d10ad87f48d74c2cb44c6e8",
+    "semantic_hash": "697042728d10ad87f48d74c2cb44c6e8"
+  },
+  "orion/fcc/context_budget.py": {
+    "mtime": 1783652292.7794662,
+    "ast_hash": "1228fe77d05435e95468fc0bf754a740",
+    "semantic_hash": "1228fe77d05435e95468fc0bf754a740"
+  },
+  "orion/fcc/fcc_claude_mcp.template.json": {
+    "mtime": 1783615212.476912,
+    "ast_hash": "a8c4df31448a5706589b3a851e9d0ea6",
+    "semantic_hash": "a8c4df31448a5706589b3a851e9d0ea6"
+  },
+  "orion/fcc/github_repo_context.py": {
+    "mtime": 1783615212.476912,
+    "ast_hash": "dc6627a6578df89c9049acc11535a52a",
+    "semantic_hash": "dc6627a6578df89c9049acc11535a52a"
+  },
+  "orion/fcc/mcp_config.py": {
+    "mtime": 1783805454.2203035,
+    "ast_hash": "0fbcf60b4429967c3e05261115a1568b",
+    "semantic_hash": "0fbcf60b4429967c3e05261115a1568b"
+  },
+  "orion/fcc/mcp_stdio_proxy.py": {
+    "mtime": 1783615212.476912,
+    "ast_hash": "b2beef7a076b9edbf3aa663766ea42e8",
+    "semantic_hash": "b2beef7a076b9edbf3aa663766ea42e8"
+  },
+  "orion/fcc/self_index_brief.py": {
+    "mtime": 1783820991.6701157,
+    "ast_hash": "022741a6060b5ffed658f190742be603",
+    "semantic_hash": "022741a6060b5ffed658f190742be603"
+  },
+  "orion/fcc/tests/test_claude_spawn.py": {
+    "mtime": 1783807841.1681182,
+    "ast_hash": "dc088175c49e19e36fa12f82e5aa2272",
+    "semantic_hash": "dc088175c49e19e36fa12f82e5aa2272"
+  },
+  "orion/fcc/tests/test_context_budget.py": {
+    "mtime": 1783652292.7794662,
+    "ast_hash": "156d46eb7720318a99c3c629720d8687",
+    "semantic_hash": "156d46eb7720318a99c3c629720d8687"
+  },
+  "orion/fcc/tests/test_context_mode_hooks_smoke.py": {
+    "mtime": 1783807841.1681182,
+    "ast_hash": "9d9d07e436066f0a23e0a6771d3e5c6e",
+    "semantic_hash": "9d9d07e436066f0a23e0a6771d3e5c6e"
+  },
+  "orion/fcc/tests/test_github_repo_context.py": {
+    "mtime": 1783615212.476912,
+    "ast_hash": "ef432a8065b86f8ebf58e502e4ee37a5",
+    "semantic_hash": "ef432a8065b86f8ebf58e502e4ee37a5"
+  },
+  "orion/fcc/tests/test_mcp_config.py": {
+    "mtime": 1783805454.2213035,
+    "ast_hash": "33130406745b0611e4007fa357e89140",
+    "semantic_hash": "33130406745b0611e4007fa357e89140"
+  },
+  "orion/feedback/__init__.py": {
+    "mtime": 1779722671.522158,
+    "ast_hash": "beaf6ebf19f327488b813b228441f8aa",
+    "semantic_hash": "beaf6ebf19f327488b813b228441f8aa"
+  },
+  "orion/feedback/builder.py": {
+    "mtime": 1783967452.500406,
+    "ast_hash": "1a294c2eb8a90e879110914f0500c3ae",
+    "semantic_hash": "1a294c2eb8a90e879110914f0500c3ae"
+  },
+  "orion/feedback/extractors.py": {
+    "mtime": 1779722671.523158,
+    "ast_hash": "ea597cfaa7f0e77ecb1f9d4688e87755",
+    "semantic_hash": "ea597cfaa7f0e77ecb1f9d4688e87755"
+  },
+  "orion/feedback/policy.py": {
+    "mtime": 1779722671.523158,
+    "ast_hash": "d89dc1ae0fd00814469707b104b17f2f",
+    "semantic_hash": "d89dc1ae0fd00814469707b104b17f2f"
+  },
+  "orion/feedback/scoring.py": {
+    "mtime": 1779722671.523158,
+    "ast_hash": "496a0c98f73db64bcaf15cd4f56bd7c3",
+    "semantic_hash": "496a0c98f73db64bcaf15cd4f56bd7c3"
+  },
+  "orion/field_coherence.py": {
+    "mtime": 1782438858.701639,
+    "ast_hash": "80b66745d0c00fdb5c38fa9f87e4b46f",
+    "semantic_hash": "80b66745d0c00fdb5c38fa9f87e4b46f"
+  },
+  "orion/grammar/__init__.py": {
+    "mtime": 1779649387.7952988,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/grammar/constants.py": {
+    "mtime": 1779649387.7952988,
+    "ast_hash": "b2922668e0171687f7a3ad887b3d8029",
+    "semantic_hash": "b2922668e0171687f7a3ad887b3d8029"
+  },
+  "orion/grammar/graph_view.py": {
+    "mtime": 1779649387.7952988,
+    "ast_hash": "fbcc1b7a45d703b2d8de62a60d08365b",
+    "semantic_hash": "fbcc1b7a45d703b2d8de62a60d08365b"
+  },
+  "orion/grammar/ledger.py": {
+    "mtime": 1781395651.2095692,
+    "ast_hash": "cb5939a95918dc91490968481b9d3fe1",
+    "semantic_hash": "cb5939a95918dc91490968481b9d3fe1"
+  },
+  "orion/grammar/publish.py": {
+    "mtime": 1779675743.8857543,
+    "ast_hash": "97029132390daac5e30a9de2fb451414",
+    "semantic_hash": "97029132390daac5e30a9de2fb451414"
+  },
+  "orion/grammar/query.py": {
+    "mtime": 1779649387.796299,
+    "ast_hash": "0fc2944ce8d6364a0b845284860b3ec5",
+    "semantic_hash": "0fc2944ce8d6364a0b845284860b3ec5"
+  },
+  "orion/grammar/seed_demo.py": {
+    "mtime": 1779649387.796299,
+    "ast_hash": "1df2361a9b5d2c42f3034fd0c3ae23ad",
+    "semantic_hash": "1df2361a9b5d2c42f3034fd0c3ae23ad"
+  },
+  "orion/grammar/tests/__init__.py": {
+    "mtime": 1779649387.796299,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/grammar/tests/conftest.py": {
+    "mtime": 1779649387.796299,
+    "ast_hash": "69ec34dd40a909ec8156a8ab1f872ce6",
+    "semantic_hash": "69ec34dd40a909ec8156a8ab1f872ce6"
+  },
+  "orion/grammar/tests/test_biometrics_substrate_schemas.py": {
+    "mtime": 1779668252.1390116,
+    "ast_hash": "f0d51e9864bb80a3ebf39d7471d60360",
+    "semantic_hash": "f0d51e9864bb80a3ebf39d7471d60360"
+  },
+  "orion/grammar/tests/test_ledger.py": {
+    "mtime": 1781395651.2105694,
+    "ast_hash": "3026eb2698b92b70f539ed3f792d63aa",
+    "semantic_hash": "3026eb2698b92b70f539ed3f792d63aa"
+  },
+  "orion/grammar/tests/test_query.py": {
+    "mtime": 1779649387.796299,
+    "ast_hash": "9e29619ea78acbce65fbf208f40cea52",
+    "semantic_hash": "9e29619ea78acbce65fbf208f40cea52"
+  },
+  "orion/grammar/tests/test_schemas.py": {
+    "mtime": 1779649387.796299,
+    "ast_hash": "1676c8aafd04c0726a46e0c0719032dc",
+    "semantic_hash": "1676c8aafd04c0726a46e0c0719032dc"
+  },
+  "orion/grammar/tests/test_seed_demo.py": {
+    "mtime": 1779649387.796299,
+    "ast_hash": "de1ec4cf8c8df89460c5088b6fd6e03a",
+    "semantic_hash": "de1ec4cf8c8df89460c5088b6fd6e03a"
+  },
+  "orion/graph/__init__.py": {
+    "mtime": 1778901838.367395,
+    "ast_hash": "0dc62e86c1c0abb53e2dd4880ad0febf",
+    "semantic_hash": "0dc62e86c1c0abb53e2dd4880ad0febf"
+  },
+  "orion/graph/backend_config.py": {
+    "mtime": 1781845427.7726762,
+    "ast_hash": "02683e9b7a6cb2abfaca1140f2cd5b5e",
+    "semantic_hash": "02683e9b7a6cb2abfaca1140f2cd5b5e"
+  },
+  "orion/graph/fuseki_http.py": {
+    "mtime": 1780617278.2906375,
+    "ast_hash": "a4a2159b881bb6301b407221e0f280fd",
+    "semantic_hash": "a4a2159b881bb6301b407221e0f280fd"
+  },
+  "orion/graph/rdf_retention.py": {
+    "mtime": 1781152352.2147326,
+    "ast_hash": "c344cb1d8c69a673c8ca0b17ab3b85db",
+    "semantic_hash": "c344cb1d8c69a673c8ca0b17ab3b85db"
+  },
+  "orion/graph/sparql_client.py": {
+    "mtime": 1780617289.8786232,
+    "ast_hash": "db0c8152b1b8dafbf639591859debcc1",
+    "semantic_hash": "db0c8152b1b8dafbf639591859debcc1"
+  },
+  "orion/graph/tests/__init__.py": {
+    "mtime": 1778901838.367395,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/graph/tests/test_backend_config.py": {
+    "mtime": 1781845427.7726762,
+    "ast_hash": "af9a389126b3c6ba7783273ce7062cc9",
+    "semantic_hash": "af9a389126b3c6ba7783273ce7062cc9"
+  },
+  "orion/graph/tests/test_fuseki_http.py": {
+    "mtime": 1780617280.5926347,
+    "ast_hash": "7050f8a8556e462cb1656a3170325ccd",
+    "semantic_hash": "7050f8a8556e462cb1656a3170325ccd"
+  },
+  "orion/graph/tests/test_rdf_retention.py": {
+    "mtime": 1781152354.4427254,
+    "ast_hash": "17ebe4869be49cc441ea5149a57987ae",
+    "semantic_hash": "17ebe4869be49cc441ea5149a57987ae"
+  },
+  "orion/graph_cognition/__init__.py": {
+    "mtime": 1775634425.3992527,
+    "ast_hash": "de164815bcc378a4b55cf6b3d56f9b6e",
+    "semantic_hash": "de164815bcc378a4b55cf6b3d56f9b6e"
+  },
+  "orion/graph_cognition/brief.py": {
+    "mtime": 1775613610.4134464,
+    "ast_hash": "2c98402f427c7eff2c67c199c465baec",
+    "semantic_hash": "2c98402f427c7eff2c67c199c465baec"
+  },
+  "orion/graph_cognition/evidence.py": {
+    "mtime": 1775613610.4134464,
+    "ast_hash": "d7f16b7a5f0e3c5d0783653bea6e971f",
+    "semantic_hash": "d7f16b7a5f0e3c5d0783653bea6e971f"
+  },
+  "orion/graph_cognition/features.py": {
+    "mtime": 1775613610.4134464,
+    "ast_hash": "a61baab4f68205fa4b5f0d804e969cb6",
+    "semantic_hash": "a61baab4f68205fa4b5f0d804e969cb6"
+  },
+  "orion/graph_cognition/interpreters.py": {
+    "mtime": 1775613610.4134464,
+    "ast_hash": "3d77b40a78939a4f6c6db343a313e336",
+    "semantic_hash": "3d77b40a78939a4f6c6db343a313e336"
+  },
+  "orion/graph_cognition/views.py": {
+    "mtime": 1775634425.3992527,
+    "ast_hash": "9a0ce22171bbb7c5cfb2d595e36f543a",
+    "semantic_hash": "9a0ce22171bbb7c5cfb2d595e36f543a"
+  },
+  "orion/harness/__init__.py": {
+    "mtime": 1783291410.0187016,
+    "ast_hash": "86ae8a84fd2bc375572c3e289cfe2e4d",
+    "semantic_hash": "86ae8a84fd2bc375572c3e289cfe2e4d"
+  },
+  "orion/harness/cortex_client.py": {
+    "mtime": 1783817872.1376846,
+    "ast_hash": "0dec50ddfea6844f701a89cd99f6c43d",
+    "semantic_hash": "0dec50ddfea6844f701a89cd99f6c43d"
+  },
+  "orion/harness/evals/fixtures/unified_turn_introspection.json": {
+    "mtime": 1783805454.2213035,
+    "ast_hash": "f7f3a22dd54b7f1fcf5407959ea136bb",
+    "semantic_hash": "f7f3a22dd54b7f1fcf5407959ea136bb"
+  },
+  "orion/harness/evals/introspection_scoring.py": {
+    "mtime": 1783805454.2213035,
+    "ast_hash": "e420d45200d70dc9e0a5874eb0408533",
+    "semantic_hash": "e420d45200d70dc9e0a5874eb0408533"
+  },
+  "orion/harness/evals/test_introspection_fixture.py": {
+    "mtime": 1783805454.2213035,
+    "ast_hash": "bf8302b46d43dda7eb1e2e38e326fa7d",
+    "semantic_hash": "bf8302b46d43dda7eb1e2e38e326fa7d"
+  },
+  "orion/harness/evals/test_layer_attribution.py": {
+    "mtime": 1783291410.0187016,
+    "ast_hash": "70ddc5e867874643c7cc0c1e387dea5d",
+    "semantic_hash": "70ddc5e867874643c7cc0c1e387dea5d"
+  },
+  "orion/harness/evals/test_unified_turn_grounding_eval.py": {
+    "mtime": 1783458889.5679457,
+    "ast_hash": "3738b70da2b9613467571ed594b6a4e6",
+    "semantic_hash": "3738b70da2b9613467571ed594b6a4e6"
+  },
+  "orion/harness/fcc_motor.py": {
+    "mtime": 1783820991.6711159,
+    "ast_hash": "06fb66fb956439d50e24cb69e5fc6ff6",
+    "semantic_hash": "06fb66fb956439d50e24cb69e5fc6ff6"
+  },
+  "orion/harness/finalize.py": {
+    "mtime": 1783807362.502779,
+    "ast_hash": "1a33b3164cc4ea7757e0bd2c20c76b84",
+    "semantic_hash": "1a33b3164cc4ea7757e0bd2c20c76b84"
+  },
+  "orion/harness/grammar_emit.py": {
+    "mtime": 1783566259.2629366,
+    "ast_hash": "cd4a77113916c1b00050f2b9678eb95f",
+    "semantic_hash": "cd4a77113916c1b00050f2b9678eb95f"
+  },
+  "orion/harness/grammar_publish.py": {
+    "mtime": 1783300876.6799147,
+    "ast_hash": "03345f8db02192bd4770caddfdc77b2e",
+    "semantic_hash": "03345f8db02192bd4770caddfdc77b2e"
+  },
+  "orion/harness/operator_brief.py": {
+    "mtime": 1783615212.4779122,
+    "ast_hash": "908fa697ab57d7e52b63858c9c7c8084",
+    "semantic_hash": "908fa697ab57d7e52b63858c9c7c8084"
+  },
+  "orion/harness/prefix.py": {
+    "mtime": 1783805454.2213035,
+    "ast_hash": "7c514eb44524d4d1afa96cd0ec94821c",
+    "semantic_hash": "7c514eb44524d4d1afa96cd0ec94821c"
+  },
+  "orion/harness/repair.py": {
+    "mtime": 1783291410.0197017,
+    "ast_hash": "4cde7d3f31e445df7f7f946159024b4b",
+    "semantic_hash": "4cde7d3f31e445df7f7f946159024b4b"
+  },
+  "orion/harness/runner.py": {
+    "mtime": 1783817872.1376846,
+    "ast_hash": "19ab615446ef86a641888925648027f7",
+    "semantic_hash": "19ab615446ef86a641888925648027f7"
+  },
+  "orion/harness/step_stream.py": {
+    "mtime": 1783298706.19945,
+    "ast_hash": "7e40669e0f0f73a3eccab80e612d8987",
+    "semantic_hash": "7e40669e0f0f73a3eccab80e612d8987"
+  },
+  "orion/harness/substrate_client.py": {
+    "mtime": 1783291410.0197017,
+    "ast_hash": "3ef01a42e2813907dc94dfc4845fd317",
+    "semantic_hash": "3ef01a42e2813907dc94dfc4845fd317"
+  },
+  "orion/harness/tests/fixtures.py": {
+    "mtime": 1783458889.5679457,
+    "ast_hash": "9adae87d889895bb0cb6d4b93e36e6b0",
+    "semantic_hash": "9adae87d889895bb0cb6d4b93e36e6b0"
+  },
+  "orion/harness/tests/test_cortex_client_finalize_timeouts.py": {
+    "mtime": 1783817872.1376846,
+    "ast_hash": "ec18a105b00a7f20757997ec578d0b09",
+    "semantic_hash": "ec18a105b00a7f20757997ec578d0b09"
+  },
+  "orion/harness/tests/test_fcc_motor_cancel.py": {
+    "mtime": 1783655498.742199,
+    "ast_hash": "a5ab4e3cea94d0ccaa092fbbea43fbbd",
+    "semantic_hash": "a5ab4e3cea94d0ccaa092fbbea43fbbd"
+  },
+  "orion/harness/tests/test_fcc_motor_mcp.py": {
+    "mtime": 1783820991.6711159,
+    "ast_hash": "bc9b5c56e02a3ca029ead71ddd6ccf81",
+    "semantic_hash": "bc9b5c56e02a3ca029ead71ddd6ccf81"
+  },
+  "orion/harness/tests/test_fcc_motor_summarize.py": {
+    "mtime": 1783408664.9990335,
+    "ast_hash": "48ff45b71318350631de6a414d55d665",
+    "semantic_hash": "48ff45b71318350631de6a414d55d665"
+  },
+  "orion/harness/tests/test_finalize_cortex_payload_extract.py": {
+    "mtime": 1783312413.5102458,
+    "ast_hash": "61b563149508228e50979ca07745194b",
+    "semantic_hash": "61b563149508228e50979ca07745194b"
+  },
+  "orion/harness/tests/test_finalize_embodiment_emit.py": {
+    "mtime": 1783450708.641728,
+    "ast_hash": "53ff19b686ce670b101e9c7fc37d18e2",
+    "semantic_hash": "53ff19b686ce670b101e9c7fc37d18e2"
+  },
+  "orion/harness/tests/test_finalize_failure_closure.py": {
+    "mtime": 1783551182.7575676,
+    "ast_hash": "baf3d93bdc25a596f62360230c45d047",
+    "semantic_hash": "baf3d93bdc25a596f62360230c45d047"
+  },
+  "orion/harness/tests/test_finalize_grammar_receipts_context.py": {
+    "mtime": 1783298706.20045,
+    "ast_hash": "a45fcd17332ff04d03314908ed615842",
+    "semantic_hash": "a45fcd17332ff04d03314908ed615842"
+  },
+  "orion/harness/tests/test_finalize_reflect_lane.py": {
+    "mtime": 1783451739.0375216,
+    "ast_hash": "70b5df29f1e757c6f1c2c032125a8660",
+    "semantic_hash": "70b5df29f1e757c6f1c2c032125a8660"
+  },
+  "orion/harness/tests/test_finalize_reflect_llm_fallback.py": {
+    "mtime": 1783555541.5296738,
+    "ast_hash": "6fb299a8f47e9da31a7266597abe4525",
+    "semantic_hash": "6fb299a8f47e9da31a7266597abe4525"
+  },
+  "orion/harness/tests/test_finalize_reflection_json_parse.py": {
+    "mtime": 1783312413.5102458,
+    "ast_hash": "be7dbaa637ef49c2dae5563daa676526",
+    "semantic_hash": "be7dbaa637ef49c2dae5563daa676526"
+  },
+  "orion/harness/tests/test_finalize_tool_execution.py": {
+    "mtime": 1783408665.0000334,
+    "ast_hash": "fcc9f00faa8c0e1479204749abdc6a7f",
+    "semantic_hash": "fcc9f00faa8c0e1479204749abdc6a7f"
+  },
+  "orion/harness/tests/test_grounding_capsule_consumers.py": {
+    "mtime": 1783458889.5689456,
+    "ast_hash": "2911a22511cfc1be98b38ebf24cd7a9b",
+    "semantic_hash": "2911a22511cfc1be98b38ebf24cd7a9b"
+  },
+  "orion/harness/tests/test_harness_finalize_chain.py": {
+    "mtime": 1783298706.20045,
+    "ast_hash": "49cc8b299fbf18eb24e8272be5d8a92c",
+    "semantic_hash": "49cc8b299fbf18eb24e8272be5d8a92c"
+  },
+  "orion/harness/tests/test_harness_grammar_emit.py": {
+    "mtime": 1783564192.735144,
+    "ast_hash": "039251bd6f50ee40b7bbdc5791e81964",
+    "semantic_hash": "039251bd6f50ee40b7bbdc5791e81964"
+  },
+  "orion/harness/tests/test_harness_grammar_publish_per_step.py": {
+    "mtime": 1783291410.0197017,
+    "ast_hash": "71f5bc7b397d5dfad9c4a19baccebbe1",
+    "semantic_hash": "71f5bc7b397d5dfad9c4a19baccebbe1"
+  },
+  "orion/harness/tests/test_harness_prefix.py": {
+    "mtime": 1783820991.6711159,
+    "ast_hash": "677b6ecd1bb14ee39cf1a0899e11e0a8",
+    "semantic_hash": "677b6ecd1bb14ee39cf1a0899e11e0a8"
+  },
+  "orion/harness/tests/test_harness_runner.py": {
+    "mtime": 1783817872.1386845,
+    "ast_hash": "eba56ff461da31b7c00bae331630285c",
+    "semantic_hash": "eba56ff461da31b7c00bae331630285c"
+  },
+  "orion/harness/tests/test_harness_step_stream.py": {
+    "mtime": 1783298706.20045,
+    "ast_hash": "51bfa6f08c673f683d23a04bde104f95",
+    "semantic_hash": "51bfa6f08c673f683d23a04bde104f95"
+  },
+  "orion/harness/tests/test_outcome_molecule_before_hub_publish.py": {
+    "mtime": 1783291410.0197017,
+    "ast_hash": "53b06dc8ea19dcaef4809d840d6f6807",
+    "semantic_hash": "53b06dc8ea19dcaef4809d840d6f6807"
+  },
+  "orion/harness/tests/test_post_turn_closure_emits.py": {
+    "mtime": 1783396080.013995,
+    "ast_hash": "c61dac327eaa79c56a747078d8edd739",
+    "semantic_hash": "c61dac327eaa79c56a747078d8edd739"
+  },
+  "orion/harness/tests/test_quick_lane_blocked_on_hard_cases.py": {
+    "mtime": 1783291410.0197017,
+    "ast_hash": "c24f0f0a2ea529277f44218fcfb6a3c9",
+    "semantic_hash": "c24f0f0a2ea529277f44218fcfb6a3c9"
+  },
+  "orion/harness/tests/test_reflect_consumes_substrate_appraisal.py": {
+    "mtime": 1783291410.0197017,
+    "ast_hash": "8f1d66350ca96070e939c12f774c3d4c",
+    "semantic_hash": "8f1d66350ca96070e939c12f774c3d4c"
+  },
+  "orion/harness/tests/test_repair_overlay_changes_harness_prefix.py": {
+    "mtime": 1783291410.0207016,
+    "ast_hash": "b74e73107da64f28e70ee272c6779002",
+    "semantic_hash": "b74e73107da64f28e70ee272c6779002"
+  },
+  "orion/harness/tests/test_voice_changes_on_misaligned_verdict.py": {
+    "mtime": 1783291410.0207016,
+    "ast_hash": "0e0fabf5182e2d2313c76be22cbbeb49",
+    "semantic_hash": "0e0fabf5182e2d2313c76be22cbbeb49"
+  },
+  "orion/hub/__init__.py": {
+    "mtime": 1783291410.0207016,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/hub/association.py": {
+    "mtime": 1783805454.2223036,
+    "ast_hash": "5d4dd39750aadd01b6cc0546044ced8b",
+    "semantic_hash": "5d4dd39750aadd01b6cc0546044ced8b"
+  },
+  "orion/hub/harness_step_stream.py": {
+    "mtime": 1783614403.4892697,
+    "ast_hash": "d19b15f62c8c905bc743916512682ba4",
+    "semantic_hash": "d19b15f62c8c905bc743916512682ba4"
+  },
+  "orion/hub/tests/test_association_read_fail_closed.py": {
+    "mtime": 1783298706.20045,
+    "ast_hash": "3ba2a53ab575b2cf26ff9fdb279c55c2",
+    "semantic_hash": "3ba2a53ab575b2cf26ff9fdb279c55c2"
+  },
+  "orion/hub/tests/test_harness_step_relay.py": {
+    "mtime": 1783614403.4712691,
+    "ast_hash": "639a35e6d71d8d04b0cd94ce7c61c564",
+    "semantic_hash": "639a35e6d71d8d04b0cd94ce7c61c564"
+  },
+  "orion/hub/tests/test_phase0_ingress_smoke.py": {
+    "mtime": 1783291410.0207016,
+    "ast_hash": "727c0b21306954acd2723a8a72ddb051",
+    "semantic_hash": "727c0b21306954acd2723a8a72ddb051"
+  },
+  "orion/hub/turn_orchestrator.py": {
+    "mtime": 1783908076.952645,
+    "ast_hash": "2d8979232a923e7676ce16e41c55ac63",
+    "semantic_hash": "2d8979232a923e7676ce16e41c55ac63"
+  },
+  "orion/hub/turn_request.py": {
+    "mtime": 1783291410.0207016,
+    "ast_hash": "f82bff2912bfbbbe56e6367b63c5275b",
+    "semantic_hash": "f82bff2912bfbbbe56e6367b63c5275b"
+  },
+  "orion/identity/__init__.py": {
+    "mtime": 1782438858.701639,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/identity/snapshot.py": {
+    "mtime": 1782438858.701639,
+    "ast_hash": "22e78ba51e9794fa66823a9953c72755",
+    "semantic_hash": "22e78ba51e9794fa66823a9953c72755"
+  },
+  "orion/importers/__init__.py": {
+    "mtime": 1769550252.5820262,
+    "ast_hash": "24dc6031c70e880fd80b45d095a10a90",
+    "semantic_hash": "24dc6031c70e880fd80b45d095a10a90"
+  },
+  "orion/importers/chatgpt_export.py": {
+    "mtime": 1776925210.0161622,
+    "ast_hash": "c96fde30f0c644ecf6f755d4eb3937f0",
+    "semantic_hash": "c96fde30f0c644ecf6f755d4eb3937f0"
+  },
+  "orion/inspection/__init__.py": {
+    "mtime": 1774236180.4433856,
+    "ast_hash": "540f886481edcf611904a57aaadcb402",
+    "semantic_hash": "540f886481edcf611904a57aaadcb402"
+  },
+  "orion/inspection/social.py": {
+    "mtime": 1783107031.9689016,
+    "ast_hash": "b1ca9fc282e7b9ab23c422a00a7b5ff5",
+    "semantic_hash": "b1ca9fc282e7b9ab23c422a00a7b5ff5"
+  },
+  "orion/journaler/__init__.py": {
+    "mtime": 1783986358.0996563,
+    "ast_hash": "49d65c77babccab76aefd353c108970c",
+    "semantic_hash": "49d65c77babccab76aefd353c108970c"
+  },
+  "orion/journaler/dispatch_registry.py": {
+    "mtime": 1783986358.0996563,
+    "ast_hash": "315f17589de3028115ed6757d878b15a",
+    "semantic_hash": "315f17589de3028115ed6757d878b15a"
+  },
+  "orion/journaler/indexing.py": {
+    "mtime": 1783986358.0996563,
+    "ast_hash": "31411e0100bd292c7f4c00141a0a3a59",
+    "semantic_hash": "31411e0100bd292c7f4c00141a0a3a59"
+  },
+  "orion/journaler/schemas.py": {
+    "mtime": 1783986358.1006565,
+    "ast_hash": "5b5f749af2299f571b24f3f6e4c7af08",
+    "semantic_hash": "5b5f749af2299f571b24f3f6e4c7af08"
+  },
+  "orion/journaler/tests/test_autonomy_episode_journal.py": {
+    "mtime": 1783365495.730666,
+    "ast_hash": "5baae9e176c528107c808cf9b58fad80",
+    "semantic_hash": "5baae9e176c528107c808cf9b58fad80"
+  },
+  "orion/journaler/tests/test_trigger_kind_roundtrip.py": {
+    "mtime": 1783986358.1006565,
+    "ast_hash": "be1e75b32c2cec61313a07266b2095fc",
+    "semantic_hash": "be1e75b32c2cec61313a07266b2095fc"
+  },
+  "orion/journaler/worker.py": {
+    "mtime": 1783986358.1006565,
+    "ast_hash": "1b302be73c3cf9f938f47e661b0a838f",
+    "semantic_hash": "1b302be73c3cf9f938f47e661b0a838f"
+  },
+  "orion/journaler/workflow_journal_delegate.py": {
+    "mtime": 1776053297.272055,
+    "ast_hash": "ebd7fea0939cf5e119a9dae93d1bbf94",
+    "semantic_hash": "ebd7fea0939cf5e119a9dae93d1bbf94"
+  },
+  "orion/knowledge_forge/__init__.py": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "e4012ec243ce7e779bf4198e101f8bda",
+    "semantic_hash": "e4012ec243ce7e779bf4198e101f8bda"
+  },
+  "orion/knowledge_forge/__main__.py": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "490b46adbbd4e2d2552c6471a067d07f",
+    "semantic_hash": "490b46adbbd4e2d2552c6471a067d07f"
+  },
+  "orion/knowledge_forge/api_compile.py": {
+    "mtime": 1779306072.504066,
+    "ast_hash": "b312e6017e19e0bd8c156635d57269bb",
+    "semantic_hash": "b312e6017e19e0bd8c156635d57269bb"
+  },
+  "orion/knowledge_forge/cli.py": {
+    "mtime": 1779317383.6875997,
+    "ast_hash": "f08bcc41b911ce8d1fa4158a43e25a89",
+    "semantic_hash": "f08bcc41b911ce8d1fa4158a43e25a89"
+  },
+  "orion/knowledge_forge/compile.py": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "737e055226b5e6674dd72e38a05cb312",
+    "semantic_hash": "737e055226b5e6674dd72e38a05cb312"
+  },
+  "orion/knowledge_forge/lint.py": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "4c68b3b21db441ee09114ad2228679b4",
+    "semantic_hash": "4c68b3b21db441ee09114ad2228679b4"
+  },
+  "orion/knowledge_forge/models.py": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "83e5550461724c9f1178fac92a29c723",
+    "semantic_hash": "83e5550461724c9f1178fac92a29c723"
+  },
+  "orion/knowledge_forge/paths.py": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "836f67e27fc5edab6d349ac2db5cf16d",
+    "semantic_hash": "836f67e27fc5edab6d349ac2db5cf16d"
+  },
+  "orion/knowledge_forge/probes.py": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "d6067ec0a1ea67fbecfbbe3b9aa61b70",
+    "semantic_hash": "d6067ec0a1ea67fbecfbbe3b9aa61b70"
+  },
+  "orion/knowledge_forge/review.py": {
+    "mtime": 1779305390.1057496,
+    "ast_hash": "5b37a1b7840a68fdf7fd278a662a7be8",
+    "semantic_hash": "5b37a1b7840a68fdf7fd278a662a7be8"
+  },
+  "orion/knowledge_forge/sources.py": {
+    "mtime": 1779317383.6875997,
+    "ast_hash": "841d13fc6a6940878ad6bb39a3acae83",
+    "semantic_hash": "841d13fc6a6940878ad6bb39a3acae83"
+  },
+  "orion/knowledge_forge/store.py": {
+    "mtime": 1779305390.1057496,
+    "ast_hash": "c0dc6a08dd3f6b3418a22d5bb1fe6dc7",
+    "semantic_hash": "c0dc6a08dd3f6b3418a22d5bb1fe6dc7"
+  },
+  "orion/knowledge_forge/yaml_doc.py": {
+    "mtime": 1779305390.1057496,
+    "ast_hash": "5e2cf2b1aa713ad2f23b707a198bbcfb",
+    "semantic_hash": "5e2cf2b1aa713ad2f23b707a198bbcfb"
+  },
+  "orion/llm/__init__.py": {
+    "mtime": 1783107031.9689016,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/llm/openai_message_content.py": {
+    "mtime": 1783107031.9689016,
+    "ast_hash": "421f595c710cc94ec4c5446c27001f8d",
+    "semantic_hash": "421f595c710cc94ec4c5446c27001f8d"
+  },
+  "orion/memory/__init__.py": {
+    "mtime": 1781129793.9222505,
+    "ast_hash": "d44a0efb44e032e0fdc519524709c6e3",
+    "semantic_hash": "d44a0efb44e032e0fdc519524709c6e3"
+  },
+  "orion/memory/consolidation_classify.py": {
+    "mtime": 1782190803.0993247,
+    "ast_hash": "ec39026d7ca32d469b8a138a5b09075f",
+    "semantic_hash": "ec39026d7ca32d469b8a138a5b09075f"
+  },
+  "orion/memory/consolidation_gate.py": {
+    "mtime": 1783900735.4915981,
+    "ast_hash": "cac235d08767efa81cc62f4bfd6f531f",
+    "semantic_hash": "cac235d08767efa81cc62f4bfd6f531f"
+  },
+  "orion/memory/consolidation_grammar.py": {
+    "mtime": 1783402731.2983196,
+    "ast_hash": "98a087952a0531c3161201d8895948e1",
+    "semantic_hash": "98a087952a0531c3161201d8895948e1"
+  },
+  "orion/memory/crystallization/__init__.py": {
+    "mtime": 1781129793.9222505,
+    "ast_hash": "8e7f11a9155120e7f09273d4410dc990",
+    "semantic_hash": "8e7f11a9155120e7f09273d4410dc990"
+  },
+  "orion/memory/crystallization/active_packet.py": {
+    "mtime": 1783960753.1678302,
+    "ast_hash": "18f53a92f14ff44dcc419d9c2eebc232",
+    "semantic_hash": "18f53a92f14ff44dcc419d9c2eebc232"
+  },
+  "orion/memory/crystallization/bus_emit.py": {
+    "mtime": 1783555541.5296738,
+    "ast_hash": "16384c9b4f4e9ee03603100d2f6c417c",
+    "semantic_hash": "16384c9b4f4e9ee03603100d2f6c417c"
+  },
+  "orion/memory/crystallization/bus_emit_memory_card.py": {
+    "mtime": 1783388479.8244326,
+    "ast_hash": "4d55a6f2c9cc280015391802451f4757",
+    "semantic_hash": "4d55a6f2c9cc280015391802451f4757"
+  },
+  "orion/memory/crystallization/candidate_retrieval.py": {
+    "mtime": 1783900735.4915981,
+    "ast_hash": "16183de89073710db3023754ab9e570b",
+    "semantic_hash": "16183de89073710db3023754ab9e570b"
+  },
+  "orion/memory/crystallization/chroma_publish.py": {
+    "mtime": 1781129793.9232504,
+    "ast_hash": "8cfe39abd3bbc41ed55d1bbd13c2ff51",
+    "semantic_hash": "8cfe39abd3bbc41ed55d1bbd13c2ff51"
+  },
+  "orion/memory/crystallization/chroma_query.py": {
+    "mtime": 1781129793.9232504,
+    "ast_hash": "271888ff7e3c6b97ca11b5cf9a9e009e",
+    "semantic_hash": "271888ff7e3c6b97ca11b5cf9a9e009e"
+  },
+  "orion/memory/crystallization/concept_relation.py": {
+    "mtime": 1783965578.732708,
+    "ast_hash": "3a9f1bc675fac9bc622f5c148b45f6a7",
+    "semantic_hash": "3a9f1bc675fac9bc622f5c148b45f6a7"
+  },
+  "orion/memory/crystallization/detection.py": {
+    "mtime": 1781129793.9232504,
+    "ast_hash": "cbbc2755e7f5e44df4967c66d4f3fb4e",
+    "semantic_hash": "cbbc2755e7f5e44df4967c66d4f3fb4e"
+  },
+  "orion/memory/crystallization/dynamics.py": {
+    "mtime": 1783959647.9241297,
+    "ast_hash": "7f5ce3071b4a3273455d051a984d0123",
+    "semantic_hash": "7f5ce3071b4a3273455d051a984d0123"
+  },
+  "orion/memory/crystallization/formation_executor.py": {
+    "mtime": 1783555541.5306737,
+    "ast_hash": "979c3cba7c50db62d62d98eb7aba89bf",
+    "semantic_hash": "979c3cba7c50db62d62d98eb7aba89bf"
+  },
+  "orion/memory/crystallization/formation_policy.py": {
+    "mtime": 1783555541.5306737,
+    "ast_hash": "5d9da73d39c6f5cbb7a0c023d2d01c67",
+    "semantic_hash": "5d9da73d39c6f5cbb7a0c023d2d01c67"
+  },
+  "orion/memory/crystallization/governor.py": {
+    "mtime": 1783555541.5306737,
+    "ast_hash": "e39083c6e8566b8a199f3867fae33455",
+    "semantic_hash": "e39083c6e8566b8a199f3867fae33455"
+  },
+  "orion/memory/crystallization/grammar_adapter.py": {
+    "mtime": 1781129793.9232504,
+    "ast_hash": "db62751e2d534c3f166b9fcdff35d38e",
+    "semantic_hash": "db62751e2d534c3f166b9fcdff35d38e"
+  },
+  "orion/memory/crystallization/graphiti_config.py": {
+    "mtime": 1783356609.5620096,
+    "ast_hash": "a1b19a2865543482df21fd79b6571816",
+    "semantic_hash": "a1b19a2865543482df21fd79b6571816"
+  },
+  "orion/memory/crystallization/intake_autonomy_episode.py": {
+    "mtime": 1783365495.730666,
+    "ast_hash": "905dad43f54bce5b6fad32f2aeaaec6b",
+    "semantic_hash": "905dad43f54bce5b6fad32f2aeaaec6b"
+  },
+  "orion/memory/crystallization/intake_consolidation_window.py": {
+    "mtime": 1783614403.5452714,
+    "ast_hash": "019a4faa4187e01c3ffe162d5e7a905e",
+    "semantic_hash": "019a4faa4187e01c3ffe162d5e7a905e"
+  },
+  "orion/memory/crystallization/intake_pipeline.py": {
+    "mtime": 1783900735.4915981,
+    "ast_hash": "2d771823eda337577ab322804ff3e121",
+    "semantic_hash": "2d771823eda337577ab322804ff3e121"
+  },
+  "orion/memory/crystallization/links.py": {
+    "mtime": 1781129793.9232504,
+    "ast_hash": "7dc0c80ad98a6ae43ea2752df4e51b40",
+    "semantic_hash": "7dc0c80ad98a6ae43ea2752df4e51b40"
+  },
+  "orion/memory/crystallization/projection_cards.py": {
+    "mtime": 1781129793.9232504,
+    "ast_hash": "7479c94af49c6a269bb4f2fa9564a3c9",
+    "semantic_hash": "7479c94af49c6a269bb4f2fa9564a3c9"
+  },
+  "orion/memory/crystallization/projection_chroma.py": {
+    "mtime": 1781129793.9232504,
+    "ast_hash": "83ab6a084b1b8f2a322e24c1e39d0276",
+    "semantic_hash": "83ab6a084b1b8f2a322e24c1e39d0276"
+  },
+  "orion/memory/crystallization/projection_graphiti.py": {
+    "mtime": 1783356609.5620096,
+    "ast_hash": "38aaf880d6dc36bd540cc4039fdda648",
+    "semantic_hash": "38aaf880d6dc36bd540cc4039fdda648"
+  },
+  "orion/memory/crystallization/projection_rdf.py": {
+    "mtime": 1781129793.9232504,
+    "ast_hash": "0d49e500959603e0c966647d1754fc40",
+    "semantic_hash": "0d49e500959603e0c966647d1754fc40"
+  },
+  "orion/memory/crystallization/projector.py": {
+    "mtime": 1783356609.5630095,
+    "ast_hash": "94958fcd864299e4f7c38100910e57c2",
+    "semantic_hash": "94958fcd864299e4f7c38100910e57c2"
+  },
+  "orion/memory/crystallization/proposer.py": {
+    "mtime": 1781129793.9242506,
+    "ast_hash": "7a9a57321bd6fa5adcd3ea036b7ec526",
+    "semantic_hash": "7a9a57321bd6fa5adcd3ea036b7ec526"
+  },
+  "orion/memory/crystallization/recall_eligibility.py": {
+    "mtime": 1783555541.5306737,
+    "ast_hash": "526087dc9cf61a4bfca23a2977bc7f68",
+    "semantic_hash": "526087dc9cf61a4bfca23a2977bc7f68"
+  },
+  "orion/memory/crystallization/repository.py": {
+    "mtime": 1783965578.732708,
+    "ast_hash": "f6c602aabbf2bd8348c3a8e8c2357f21",
+    "semantic_hash": "f6c602aabbf2bd8348c3a8e8c2357f21"
+  },
+  "orion/memory/crystallization/retriever.py": {
+    "mtime": 1783960753.1678302,
+    "ast_hash": "48495c0e036fa5091e42cedfd4a1785c",
+    "semantic_hash": "48495c0e036fa5091e42cedfd4a1785c"
+  },
+  "orion/memory/crystallization/salience.py": {
+    "mtime": 1783965578.732708,
+    "ast_hash": "ac8f460d14c82b06284e413a3cc544cf",
+    "semantic_hash": "ac8f460d14c82b06284e413a3cc544cf"
+  },
+  "orion/memory/crystallization/schemas.py": {
+    "mtime": 1783965578.732708,
+    "ast_hash": "f7843e498041ae377eb29864e60d9feb",
+    "semantic_hash": "f7843e498041ae377eb29864e60d9feb"
+  },
+  "orion/memory/crystallization/sources.py": {
+    "mtime": 1783365495.730666,
+    "ast_hash": "c5ec4e26267b8c414d883e33c30abdde",
+    "semantic_hash": "c5ec4e26267b8c414d883e33c30abdde"
+  },
+  "orion/memory/crystallization/tests/test_bus_emit_memory_card.py": {
+    "mtime": 1783388479.8244326,
+    "ast_hash": "893d28167fea47ee300802cb9e925a37",
+    "semantic_hash": "893d28167fea47ee300802cb9e925a37"
+  },
+  "orion/memory/crystallization/validator.py": {
+    "mtime": 1781129793.9242506,
+    "ast_hash": "24cf0c22b1ee2ef211fdbecaa0ab050c",
+    "semantic_hash": "24cf0c22b1ee2ef211fdbecaa0ab050c"
+  },
+  "orion/memory/low_info_social.py": {
+    "mtime": 1783402731.2983196,
+    "ast_hash": "82200814aaaa65475c0cb737f4aeaa32",
+    "semantic_hash": "82200814aaaa65475c0cb737f4aeaa32"
+  },
+  "orion/memory/recall_skip_gate.py": {
+    "mtime": 1783398623.0061564,
+    "ast_hash": "f4f79eabef5f5eb933eb2f136e0e6033",
+    "semantic_hash": "f4f79eabef5f5eb933eb2f136e0e6033"
+  },
+  "orion/memory/retrieval_intent.py": {
+    "mtime": 1783555541.5306737,
+    "ast_hash": "87440151f9c93015416581300a7a950e",
+    "semantic_hash": "87440151f9c93015416581300a7a950e"
+  },
+  "orion/memory/turn_change_classify.py": {
+    "mtime": 1782438858.7276397,
+    "ast_hash": "9bc4ed097b904972a6720589bb846686",
+    "semantic_hash": "9bc4ed097b904972a6720589bb846686"
+  },
+  "orion/memory/turn_change_signal.py": {
+    "mtime": 1782190803.0993247,
+    "ast_hash": "0b9d1b25c29adc6d453411b9546b5c4c",
+    "semantic_hash": "0b9d1b25c29adc6d453411b9546b5c4c"
+  },
+  "orion/memory_graph/__init__.py": {
+    "mtime": 1780988982.7723832,
+    "ast_hash": "540392daca09d8328606be513e15e1e3",
+    "semantic_hash": "540392daca09d8328606be513e15e1e3"
+  },
+  "orion/memory_graph/approve.py": {
+    "mtime": 1781138878.5948527,
+    "ast_hash": "344593bc99d9b95023955c9d7839faeb",
+    "semantic_hash": "344593bc99d9b95023955c9d7839faeb"
+  },
+  "orion/memory_graph/consolidation_draft_hydrate.py": {
+    "mtime": 1782190803.0993247,
+    "ast_hash": "2a26b489d70a30fb8fd95b61bb89f055",
+    "semantic_hash": "2a26b489d70a30fb8fd95b61bb89f055"
+  },
+  "orion/memory_graph/cortex_suggest_extract.py": {
+    "mtime": 1781765088.068288,
+    "ast_hash": "a185c18317c9c040e7583a3b90562c0b",
+    "semantic_hash": "a185c18317c9c040e7583a3b90562c0b"
+  },
+  "orion/memory_graph/draft_repository.py": {
+    "mtime": 1781893873.1149724,
+    "ast_hash": "9d3fbe7bacc7bc33757f73af68851e83",
+    "semantic_hash": "9d3fbe7bacc7bc33757f73af68851e83"
+  },
+  "orion/memory_graph/draft_sanitize.py": {
+    "mtime": 1782955647.2164185,
+    "ast_hash": "0caaa511c459be9c4e717a930532972f",
+    "semantic_hash": "0caaa511c459be9c4e717a930532972f"
+  },
+  "orion/memory_graph/dto.py": {
+    "mtime": 1781138870.1638918,
+    "ast_hash": "42d02ec0fb1cb01f2eaf7e30f39d5e65",
+    "semantic_hash": "42d02ec0fb1cb01f2eaf7e30f39d5e65"
+  },
+  "orion/memory_graph/graphdb.py": {
+    "mtime": 1777758592.2192445,
+    "ast_hash": "8f924c5c8ce77d97c231f6f25e68196f",
+    "semantic_hash": "8f924c5c8ce77d97c231f6f25e68196f"
+  },
+  "orion/memory_graph/json_extract.py": {
+    "mtime": 1783807361.8307576,
+    "ast_hash": "1d46128978bfdd82895a7c530d4a14da",
+    "semantic_hash": "1d46128978bfdd82895a7c530d4a14da"
+  },
+  "orion/memory_graph/json_to_rdf.py": {
+    "mtime": 1780622613.5937643,
+    "ast_hash": "2d8576d3a5f7afdfb3094b1789aa5390",
+    "semantic_hash": "2d8576d3a5f7afdfb3094b1789aa5390"
+  },
+  "orion/memory_graph/project.py": {
+    "mtime": 1781138875.253868,
+    "ast_hash": "13d478b82642935de15877dd8d33831d",
+    "semantic_hash": "13d478b82642935de15877dd8d33831d"
+  },
+  "orion/memory_graph/rdf_target.py": {
+    "mtime": 1778901838.367395,
+    "ast_hash": "248989ba10798369c85988fe5aca9499",
+    "semantic_hash": "248989ba10798369c85988fe5aca9499"
+  },
+  "orion/memory_graph/schema_contract.py": {
+    "mtime": 1779166416.993654,
+    "ast_hash": "0861964a21dca2eba546648a8e1e5a3a",
+    "semantic_hash": "0861964a21dca2eba546648a8e1e5a3a"
+  },
+  "orion/memory_graph/suggest_runner.py": {
+    "mtime": 1783807362.0287638,
+    "ast_hash": "73fb2dac74b95d60a14cd872d37e58e0",
+    "semantic_hash": "73fb2dac74b95d60a14cd872d37e58e0"
+  },
+  "orion/memory_graph/suggest_token_budget.py": {
+    "mtime": 1782445600.7210422,
+    "ast_hash": "e4fc4572c1754400df80024eedc09ee9",
+    "semantic_hash": "e4fc4572c1754400df80024eedc09ee9"
+  },
+  "orion/memory_graph/suggest_validate.py": {
+    "mtime": 1783807362.5097792,
+    "ast_hash": "97192ee52fe8c4ee2ce8d503dd8cf5af",
+    "semantic_hash": "97192ee52fe8c4ee2ce8d503dd8cf5af"
+  },
+  "orion/memory_graph/utterance_text.py": {
+    "mtime": 1780100357.2025113,
+    "ast_hash": "226a223f1d2150bd2fff2f1f7d8ee62a",
+    "semantic_hash": "226a223f1d2150bd2fff2f1f7d8ee62a"
+  },
+  "orion/memory_graph/validate.py": {
+    "mtime": 1779080192.53448,
+    "ast_hash": "a86dec61bc1a046401353647244f65f4",
+    "semantic_hash": "a86dec61bc1a046401353647244f65f4"
+  },
+  "orion/mind/__init__.py": {
+    "mtime": 1777790653.2150316,
+    "ast_hash": "2786028af0778840fa096c02e652ac38",
+    "semantic_hash": "2786028af0778840fa096c02e652ac38"
+  },
+  "orion/mind/constants.py": {
+    "mtime": 1777790653.2150316,
+    "ast_hash": "d16844ee081d99096418b5a86f178975",
+    "semantic_hash": "d16844ee081d99096418b5a86f178975"
+  },
+  "orion/mind/substrate_emit.py": {
+    "mtime": 1779649387.797299,
+    "ast_hash": "99781a32124a1762cfcdb2839033b93a",
+    "semantic_hash": "99781a32124a1762cfcdb2839033b93a"
+  },
+  "orion/mind/synthesis_v1.py": {
+    "mtime": 1779070080.243205,
+    "ast_hash": "0ee918640b2a6078fef8e4a8a7271307",
+    "semantic_hash": "0ee918640b2a6078fef8e4a8a7271307"
+  },
+  "orion/mind/tests/test_v1_roundtrip.py": {
+    "mtime": 1777790653.2150316,
+    "ast_hash": "97b1ad563a416a8344ee49c049bb23c7",
+    "semantic_hash": "97b1ad563a416a8344ee49c049bb23c7"
+  },
+  "orion/mind/v1.py": {
+    "mtime": 1779070080.243205,
+    "ast_hash": "34629605802757225f78f9c9d4bfa2e6",
+    "semantic_hash": "34629605802757225f78f9c9d4bfa2e6"
+  },
+  "orion/mind/validation.py": {
+    "mtime": 1777790653.2160316,
+    "ast_hash": "1e7dcb3dd3f37a907e2dc907af2eea82",
+    "semantic_hash": "1e7dcb3dd3f37a907e2dc907af2eea82"
+  },
+  "orion/normalizers/__init__.py": {
+    "mtime": 1774236180.4433856,
+    "ast_hash": "74828e60a88cb9e70703448ffe90a064",
+    "semantic_hash": "74828e60a88cb9e70703448ffe90a064"
+  },
+  "orion/normalizers/agent_trace.py": {
+    "mtime": 1783499830.1925209,
+    "ast_hash": "8f2c908be7cfff1e8668525df4d4010d",
+    "semantic_hash": "8f2c908be7cfff1e8668525df4d4010d"
+  },
+  "orion/normalizers/spark.py": {
+    "mtime": 1769663878.093563,
+    "ast_hash": "8110db3e3539498140e2c0879341fe57",
+    "semantic_hash": "8110db3e3539498140e2c0879341fe57"
+  },
+  "orion/notify/__init__.py": {
+    "mtime": 1773975149.9487863,
+    "ast_hash": "2162f9d917a367a7db43c6fe485082c4",
+    "semantic_hash": "2162f9d917a367a7db43c6fe485082c4"
+  },
+  "orion/notify/client.py": {
+    "mtime": 1777095728.5794997,
+    "ast_hash": "7edf84aa9df89c117a20dd4f501b7390",
+    "semantic_hash": "7edf84aa9df89c117a20dd4f501b7390"
+  },
+  "orion/notify/models.py": {
+    "mtime": 1773975149.9487863,
+    "ast_hash": "865ee19cefd841edd00afa5518cbaed4",
+    "semantic_hash": "865ee19cefd841edd00afa5518cbaed4"
+  },
+  "orion/notify/transport.py": {
+    "mtime": 1773975149.9487863,
+    "ast_hash": "96e9a1be83646c5b8290dad8ec060abc",
+    "semantic_hash": "96e9a1be83646c5b8290dad8ec060abc"
+  },
+  "orion/policy/__init__.py": {
+    "mtime": 1779689417.3402014,
+    "ast_hash": "72b5263192ce7229e590c374491eb445",
+    "semantic_hash": "72b5263192ce7229e590c374491eb445"
+  },
+  "orion/policy/builder.py": {
+    "mtime": 1783845232.208588,
+    "ast_hash": "d1e72f6faae28796fc8f66fb01cff3f5",
+    "semantic_hash": "d1e72f6faae28796fc8f66fb01cff3f5"
+  },
+  "orion/policy/evaluator.py": {
+    "mtime": 1779689417.3412013,
+    "ast_hash": "dc32bd683a5bf60b9ca4b92e4d5963ec",
+    "semantic_hash": "dc32bd683a5bf60b9ca4b92e4d5963ec"
+  },
+  "orion/policy/policy.py": {
+    "mtime": 1779689417.3412013,
+    "ast_hash": "922d4b4f752e254c0d44281955abe1c5",
+    "semantic_hash": "922d4b4f752e254c0d44281955abe1c5"
+  },
+  "orion/policy/rules.py": {
+    "mtime": 1779689417.3412013,
+    "ast_hash": "08c75c8d24b46a09322552d9f31782fa",
+    "semantic_hash": "08c75c8d24b46a09322552d9f31782fa"
+  },
+  "orion/proposals/__init__.py": {
+    "mtime": 1779687966.455823,
+    "ast_hash": "bb5db834fa6f4165eb795280757ff727",
+    "semantic_hash": "bb5db834fa6f4165eb795280757ff727"
+  },
+  "orion/proposals/builder.py": {
+    "mtime": 1784008374.2425008,
+    "ast_hash": "ced59b4a0c70ba68c4559e64a7016855",
+    "semantic_hash": "ced59b4a0c70ba68c4559e64a7016855"
+  },
+  "orion/proposals/policy.py": {
+    "mtime": 1784008374.2425008,
+    "ast_hash": "7f9e5d5219b0f50ec859d6f50efa5d42",
+    "semantic_hash": "7f9e5d5219b0f50ec859d6f50efa5d42"
+  },
+  "orion/proposals/scoring.py": {
+    "mtime": 1783834617.5039666,
+    "ast_hash": "7969688fbeabc58d55e77eadbfec17df",
+    "semantic_hash": "7969688fbeabc58d55e77eadbfec17df"
+  },
+  "orion/proposals/templates.py": {
+    "mtime": 1780622613.5937643,
+    "ast_hash": "543c562cd1d518b96e46b821cbe0106f",
+    "semantic_hash": "543c562cd1d518b96e46b821cbe0106f"
+  },
+  "orion/reasoning/__init__.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "cc13375682232b1c6b514b1b31c2002a",
+    "semantic_hash": "cc13375682232b1c6b514b1b31c2002a"
+  },
+  "orion/reasoning/adapters/__init__.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "4d758153a271e2aaf2694dcb1349d8ae",
+    "semantic_hash": "4d758153a271e2aaf2694dcb1349d8ae"
+  },
+  "orion/reasoning/adapters/autonomy.py": {
+    "mtime": 1779328788.9567866,
+    "ast_hash": "490bb4dd474bff4e66d2a7e55596f53c",
+    "semantic_hash": "490bb4dd474bff4e66d2a7e55596f53c"
+  },
+  "orion/reasoning/adapters/concept_induction.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "e7cb5802426871e588196198baae10ac",
+    "semantic_hash": "e7cb5802426871e588196198baae10ac"
+  },
+  "orion/reasoning/adapters/spark_state.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "ef6d9fab0bf38dd1ff3256e0f0c8bd5e",
+    "semantic_hash": "ef6d9fab0bf38dd1ff3256e0f0c8bd5e"
+  },
+  "orion/reasoning/calibration.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "51e9aa87573d6d1a7f3daa1a6c1b7684",
+    "semantic_hash": "51e9aa87573d6d1a7f3daa1a6c1b7684"
+  },
+  "orion/reasoning/calibration_profiles.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "84f8f65c73b6365fbc41a91255ef97e2",
+    "semantic_hash": "84f8f65c73b6365fbc41a91255ef97e2"
+  },
+  "orion/reasoning/evaluation.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "c1c3b629522dcb05a04293aade3b5462",
+    "semantic_hash": "c1c3b629522dcb05a04293aade3b5462"
+  },
+  "orion/reasoning/lifecycle.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "12149168d9e9ca7a778946789db15546",
+    "semantic_hash": "12149168d9e9ca7a778946789db15546"
+  },
+  "orion/reasoning/materializer.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "ed73f3dc0a171659f46fcc21b38b7a06",
+    "semantic_hash": "ed73f3dc0a171659f46fcc21b38b7a06"
+  },
+  "orion/reasoning/mentor_context.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "92b0d6a09593cd3192bc484b7af7b574",
+    "semantic_hash": "92b0d6a09593cd3192bc484b7af7b574"
+  },
+  "orion/reasoning/mentor_gateway.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "917f76225e3640b2c9a82d1c7ff9d900",
+    "semantic_hash": "917f76225e3640b2c9a82d1c7ff9d900"
+  },
+  "orion/reasoning/mentor_mapper.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "a2d0a15e1c87b0579403d012ff9710e0",
+    "semantic_hash": "a2d0a15e1c87b0579403d012ff9710e0"
+  },
+  "orion/reasoning/promotion.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "6355e8480ea5c8f9f0842bf882bb6719",
+    "semantic_hash": "6355e8480ea5c8f9f0842bf882bb6719"
+  },
+  "orion/reasoning/repository.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "130519ca85a6c636582b870d2d566818",
+    "semantic_hash": "130519ca85a6c636582b870d2d566818"
+  },
+  "orion/reasoning/summary.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "69651afa66ad70c8c99f9fafc334abbb",
+    "semantic_hash": "69651afa66ad70c8c99f9fafc334abbb"
+  },
+  "orion/reasoning/trigger_history.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "40cb99b20c52eea4d1677b5d530520a1",
+    "semantic_hash": "40cb99b20c52eea4d1677b5d530520a1"
+  },
+  "orion/reasoning/triggers.py": {
+    "mtime": 1775601136.3178966,
+    "ast_hash": "554c243a9462693a36831779823ca996",
+    "semantic_hash": "554c243a9462693a36831779823ca996"
+  },
+  "orion/reasoning/workflows.py": {
+    "mtime": 1775601136.3188965,
+    "ast_hash": "41607e107e3ec57c197e339d62b439b5",
+    "semantic_hash": "41607e107e3ec57c197e339d62b439b5"
+  },
+  "orion/reverie/__init__.py": {
+    "mtime": 1783355701.7901406,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/reverie/efficacy.py": {
+    "mtime": 1783355701.7901406,
+    "ast_hash": "a7f7e37a5520582ac038ef9e82212f37",
+    "semantic_hash": "a7f7e37a5520582ac038ef9e82212f37"
+  },
+  "orion/reverie/evals/test_reverie_efficacy_resonance_eval.py": {
+    "mtime": 1783355701.7911408,
+    "ast_hash": "e44fedd18b14c0dfbd57e7f9aae592ba",
+    "semantic_hash": "e44fedd18b14c0dfbd57e7f9aae592ba"
+  },
+  "orion/reverie/evals/test_reverie_semantic_quality_eval.py": {
+    "mtime": 1783396080.013995,
+    "ast_hash": "525a5665b89496d6eb2c868fb26fd1c8",
+    "semantic_hash": "525a5665b89496d6eb2c868fb26fd1c8"
+  },
+  "orion/reverie/proposal.py": {
+    "mtime": 1783405468.2207882,
+    "ast_hash": "f25be955129618700bb4a919517a2e17",
+    "semantic_hash": "f25be955129618700bb4a919517a2e17"
+  },
+  "orion/reverie/referent_loader.py": {
+    "mtime": 1783396080.013995,
+    "ast_hash": "60367162e41976733e2de70cb5347acf",
+    "semantic_hash": "60367162e41976733e2de70cb5347acf"
+  },
+  "orion/reverie/resonance.py": {
+    "mtime": 1783355701.7911408,
+    "ast_hash": "2ddd63a4d19ea716c697a820d29d8d28",
+    "semantic_hash": "2ddd63a4d19ea716c697a820d29d8d28"
+  },
+  "orion/reverie/semantic_lift.py": {
+    "mtime": 1783807364.3198369,
+    "ast_hash": "56801441935e81f29038f0e290fcc367",
+    "semantic_hash": "56801441935e81f29038f0e290fcc367"
+  },
+  "orion/reverie/tests/test_efficacy.py": {
+    "mtime": 1783355701.7911408,
+    "ast_hash": "6eaec1ded6b79c392b4e40b31bcec104",
+    "semantic_hash": "6eaec1ded6b79c392b4e40b31bcec104"
+  },
+  "orion/reverie/tests/test_ouroboros_invariants.py": {
+    "mtime": 1783355701.7911408,
+    "ast_hash": "6bf74fccbfafaada040d91efd878a810",
+    "semantic_hash": "6bf74fccbfafaada040d91efd878a810"
+  },
+  "orion/reverie/tests/test_proposal.py": {
+    "mtime": 1783405468.2207882,
+    "ast_hash": "a8bc4612b339814e4728a1147f16e8a2",
+    "semantic_hash": "a8bc4612b339814e4728a1147f16e8a2"
+  },
+  "orion/reverie/tests/test_resonance.py": {
+    "mtime": 1783355701.7911408,
+    "ast_hash": "c35bc58a4923bdaba70c6bb52741560e",
+    "semantic_hash": "c35bc58a4923bdaba70c6bb52741560e"
+  },
+  "orion/reverie/tests/test_semantic_lift.py": {
+    "mtime": 1783807362.1367674,
+    "ast_hash": "2bd9c05eff97edc79ed97e201a539e70",
+    "semantic_hash": "2bd9c05eff97edc79ed97e201a539e70"
+  },
+  "orion/schema_kernel/__init__.py": {
+    "mtime": 1779649387.797299,
+    "ast_hash": "12c5521ee6f29abadcbb2d8c2609c2e9",
+    "semantic_hash": "12c5521ee6f29abadcbb2d8c2609c2e9"
+  },
+  "orion/schema_kernel/atom.py": {
+    "mtime": 1779649387.797299,
+    "ast_hash": "65d5709d7758856c3d502efbd8643858",
+    "semantic_hash": "65d5709d7758856c3d502efbd8643858"
+  },
+  "orion/schema_kernel/composite.py": {
+    "mtime": 1779649387.797299,
+    "ast_hash": "34534b271ffc7adb3478556832515ebc",
+    "semantic_hash": "34534b271ffc7adb3478556832515ebc"
+  },
+  "orion/schema_kernel/gradient.py": {
+    "mtime": 1779649387.797299,
+    "ast_hash": "d35340958630a12d145c8bf863213d0e",
+    "semantic_hash": "d35340958630a12d145c8bf863213d0e"
+  },
+  "orion/schema_kernel/registry.py": {
+    "mtime": 1781854374.4536924,
+    "ast_hash": "701811dcf160e0caf8d05e24087dcf22",
+    "semantic_hash": "701811dcf160e0caf8d05e24087dcf22"
+  },
+  "orion/schema_kernel/relation.py": {
+    "mtime": 1779649387.797299,
+    "ast_hash": "9a10a1373f92e9ebe1f6b6f5208820fc",
+    "semantic_hash": "9a10a1373f92e9ebe1f6b6f5208820fc"
+  },
+  "orion/schema_kernel/validator.py": {
+    "mtime": 1779649387.797299,
+    "ast_hash": "7e02dfff6401efafe907bf7702a1f545",
+    "semantic_hash": "7e02dfff6401efafe907bf7702a1f545"
+  },
+  "orion/schemas/__init__.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "e1c06d85ae7b8b032bef47e42e4c08f9",
+    "semantic_hash": "e1c06d85ae7b8b032bef47e42e4c08f9"
+  },
+  "orion/schemas/actions/__init__.py": {
+    "mtime": 1775613610.4134464,
+    "ast_hash": "f8aafc9d8c9e00f582f9f1d930c82423",
+    "semantic_hash": "f8aafc9d8c9e00f582f9f1d930c82423"
+  },
+  "orion/schemas/actions/chat_history_compactor.py": {
+    "mtime": 1783958824.2796838,
+    "ast_hash": "14c9098b3f41e3535b9ab56e993eca0d",
+    "semantic_hash": "14c9098b3f41e3535b9ab56e993eca0d"
+  },
+  "orion/schemas/actions/daily.py": {
+    "mtime": 1777748523.3185987,
+    "ast_hash": "36f1b28bc1bf0247b6c24dd65630a0e5",
+    "semantic_hash": "36f1b28bc1bf0247b6c24dd65630a0e5"
+  },
+  "orion/schemas/actions/github_compactor.py": {
+    "mtime": 1783555541.5306737,
+    "ast_hash": "5d10e5e1a06c5e5c0ff919276c8db785",
+    "semantic_hash": "5d10e5e1a06c5e5c0ff919276c8db785"
+  },
+  "orion/schemas/actions/mesh_ops.py": {
+    "mtime": 1783555541.5306737,
+    "ast_hash": "9f912750685f620d724d336c21429744",
+    "semantic_hash": "9f912750685f620d724d336c21429744"
+  },
+  "orion/schemas/agents/__init__.py": {
+    "mtime": 1767676515.6331065,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/schemas/agents/bound_capability.py": {
+    "mtime": 1775631837.3821614,
+    "ast_hash": "1172bbd05034824197d2b7c5647321fa",
+    "semantic_hash": "1172bbd05034824197d2b7c5647321fa"
+  },
+  "orion/schemas/agents/schemas.py": {
+    "mtime": 1775968959.4514854,
+    "ast_hash": "9d603652211c16b22fc8fc1eb9cbbad1",
+    "semantic_hash": "9d603652211c16b22fc8fc1eb9cbbad1"
+  },
+  "orion/schemas/attention_frame.py": {
+    "mtime": 1783499830.1925209,
+    "ast_hash": "9e4a3ae719a796e575629512d11766a1",
+    "semantic_hash": "9e4a3ae719a796e575629512d11766a1"
+  },
+  "orion/schemas/attention_salience.py": {
+    "mtime": 1783447063.25237,
+    "ast_hash": "85fa196ecaa86f81e5eb1b559791c72a",
+    "semantic_hash": "85fa196ecaa86f81e5eb1b559791c72a"
+  },
+  "orion/schemas/biometrics_projection.py": {
+    "mtime": 1779668252.1390116,
+    "ast_hash": "ac137a59d0afd4bedafd9286616b8e0d",
+    "semantic_hash": "ac137a59d0afd4bedafd9286616b8e0d"
+  },
+  "orion/schemas/brain_frame.py": {
+    "mtime": 1783468068.6318662,
+    "ast_hash": "03a3a6e46f9f886a7afe3eb96498a86f",
+    "semantic_hash": "03a3a6e46f9f886a7afe3eb96498a86f"
+  },
+  "orion/schemas/chat.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "47cd2a025df91a96b4d2774685698291",
+    "semantic_hash": "47cd2a025df91a96b4d2774685698291"
+  },
+  "orion/schemas/chat_gpt_log.py": {
+    "mtime": 1776925210.017162,
+    "ast_hash": "798811ab8675927620c50fd6623f4ea4",
+    "semantic_hash": "798811ab8675927620c50fd6623f4ea4"
+  },
+  "orion/schemas/chat_history.py": {
+    "mtime": 1775636422.2504785,
+    "ast_hash": "2dcbc51e5f302a974cd0d75d8c172b21",
+    "semantic_hash": "2dcbc51e5f302a974cd0d75d8c172b21"
+  },
+  "orion/schemas/chat_projection.py": {
+    "mtime": 1783908076.952645,
+    "ast_hash": "e3b1ff14dfb0c66f57eec541129dfe6e",
+    "semantic_hash": "e3b1ff14dfb0c66f57eec541129dfe6e"
+  },
+  "orion/schemas/chat_response_feedback.py": {
+    "mtime": 1775634425.3992527,
+    "ast_hash": "0dc4b379062619a6cbef85747817c22e",
+    "semantic_hash": "0dc4b379062619a6cbef85747817c22e"
+  },
+  "orion/schemas/chat_stance.py": {
+    "mtime": 1782874038.2529726,
+    "ast_hash": "1bd892d07bdfdd684998cddbe9123864",
+    "semantic_hash": "1bd892d07bdfdd684998cddbe9123864"
+  },
+  "orion/schemas/cognition/__init__.py": {
+    "mtime": 1775968824.8512533,
+    "ast_hash": "4edc169c076080435eb8d1d362575a76",
+    "semantic_hash": "4edc169c076080435eb8d1d362575a76"
+  },
+  "orion/schemas/cognition/answer_contract.py": {
+    "mtime": 1775968823.8702662,
+    "ast_hash": "ff9b31b951a35d7cafeb2151136f8a8c",
+    "semantic_hash": "ff9b31b951a35d7cafeb2151136f8a8c"
+  },
+  "orion/schemas/cognition/tests/test_answer_contract_roundtrip.py": {
+    "mtime": 1775969163.0227988,
+    "ast_hash": "ba02a09a18dc219c488509c728c2abaa",
+    "semantic_hash": "ba02a09a18dc219c488509c728c2abaa"
+  },
+  "orion/schemas/collapse_mirror.py": {
+    "mtime": 1779649387.797299,
+    "ast_hash": "d4cc6bdf81bf7b4a35195431c5aefe57",
+    "semantic_hash": "d4cc6bdf81bf7b4a35195431c5aefe57"
+  },
+  "orion/schemas/compaction.py": {
+    "mtime": 1783355701.7911408,
+    "ast_hash": "ff2acd6500de1bbf9d5976df5a53e726",
+    "semantic_hash": "ff2acd6500de1bbf9d5976df5a53e726"
+  },
+  "orion/schemas/consolidation_frame.py": {
+    "mtime": 1780622613.5947645,
+    "ast_hash": "5f0361afb35e5634df2618e7303e9c70",
+    "semantic_hash": "5f0361afb35e5634df2618e7303e9c70"
+  },
+  "orion/schemas/context_exec.py": {
+    "mtime": 1783027450.975579,
+    "ast_hash": "81d10ae121fe2c2b39327f94760d71a1",
+    "semantic_hash": "81d10ae121fe2c2b39327f94760d71a1"
+  },
+  "orion/schemas/cortex/contracts.py": {
+    "mtime": 1777748844.4987803,
+    "ast_hash": "13db327e8741f419ee4526a004af7ca7",
+    "semantic_hash": "13db327e8741f419ee4526a004af7ca7"
+  },
+  "orion/schemas/cortex/exec.py": {
+    "mtime": 1773975149.9497864,
+    "ast_hash": "b47c1e07e93d32a0363e411a29d15edc",
+    "semantic_hash": "b47c1e07e93d32a0363e411a29d15edc"
+  },
+  "orion/schemas/cortex/gateway.py": {
+    "mtime": 1767676515.6331065,
+    "ast_hash": "d35735f0c5e9997d4a9f1aa584478b91",
+    "semantic_hash": "d35735f0c5e9997d4a9f1aa584478b91"
+  },
+  "orion/schemas/cortex/schemas.py": {
+    "mtime": 1775636422.2504785,
+    "ast_hash": "e59b314c5969e13be82d3fcb59667f5d",
+    "semantic_hash": "e59b314c5969e13be82d3fcb59667f5d"
+  },
+  "orion/schemas/cortex/types.py": {
+    "mtime": 1773975149.9497864,
+    "ast_hash": "a15f8a5f5f8b1f1beb0b06fb330996b8",
+    "semantic_hash": "a15f8a5f5f8b1f1beb0b06fb330996b8"
+  },
+  "orion/schemas/discussion_window.py": {
+    "mtime": 1783967737.3747127,
+    "ast_hash": "149fb7050ca1b1f36762d35584148273",
+    "semantic_hash": "149fb7050ca1b1f36762d35584148273"
+  },
+  "orion/schemas/embodiment.py": {
+    "mtime": 1783490446.3003592,
+    "ast_hash": "50e767dc5e1421f666ac3d2a94e4851d",
+    "semantic_hash": "50e767dc5e1421f666ac3d2a94e4851d"
+  },
+  "orion/schemas/evidence_index.py": {
+    "mtime": 1776566446.4188952,
+    "ast_hash": "1678247fcbeaebd6d2047d0e14cc3117",
+    "semantic_hash": "1678247fcbeaebd6d2047d0e14cc3117"
+  },
+  "orion/schemas/execution_dispatch_frame.py": {
+    "mtime": 1783961966.7724354,
+    "ast_hash": "3d200707a5af690818ea15d0bdd6cd87",
+    "semantic_hash": "3d200707a5af690818ea15d0bdd6cd87"
+  },
+  "orion/schemas/execution_projection.py": {
+    "mtime": 1779677734.9984543,
+    "ast_hash": "4bb97c65781a834aac9cbe964e6dfcf6",
+    "semantic_hash": "4bb97c65781a834aac9cbe964e6dfcf6"
+  },
+  "orion/schemas/feedback_frame.py": {
+    "mtime": 1783961966.7724354,
+    "ast_hash": "53794837170bcf1cb767584ae5def69e",
+    "semantic_hash": "53794837170bcf1cb767584ae5def69e"
+  },
+  "orion/schemas/field_attention_frame.py": {
+    "mtime": 1779681646.019453,
+    "ast_hash": "17c90148a7fb0ecda5e7e1fa4b5fd326",
+    "semantic_hash": "17c90148a7fb0ecda5e7e1fa4b5fd326"
+  },
+  "orion/schemas/field_state.py": {
+    "mtime": 1783843021.919588,
+    "ast_hash": "629e0d30d01a11f9bb03f87d531d2659",
+    "semantic_hash": "629e0d30d01a11f9bb03f87d531d2659"
+  },
+  "orion/schemas/grammar.py": {
+    "mtime": 1779649387.7982988,
+    "ast_hash": "42deefacafaf97b7950ed32fe0663e35",
+    "semantic_hash": "42deefacafaf97b7950ed32fe0663e35"
+  },
+  "orion/schemas/graph_compression.py": {
+    "mtime": 1780972924.4322648,
+    "ast_hash": "313d08d77523818528eeddcff608f406",
+    "semantic_hash": "313d08d77523818528eeddcff608f406"
+  },
+  "orion/schemas/harness_finalize.py": {
+    "mtime": 1783655498.742199,
+    "ast_hash": "94e5ad054c04a06acf57172886063b55",
+    "semantic_hash": "94e5ad054c04a06acf57172886063b55"
+  },
+  "orion/schemas/identity_snapshot.py": {
+    "mtime": 1782438858.701639,
+    "ast_hash": "88e42a8d6a11ae9a15969fa5c8afb48e",
+    "semantic_hash": "88e42a8d6a11ae9a15969fa5c8afb48e"
+  },
+  "orion/schemas/memory_consolidation.py": {
+    "mtime": 1783402731.2983196,
+    "ast_hash": "7d43094c2e3fad3e8c3151d3ff183b0c",
+    "semantic_hash": "7d43094c2e3fad3e8c3151d3ff183b0c"
+  },
+  "orion/schemas/memory_crystallization.py": {
+    "mtime": 1781129793.9242506,
+    "ast_hash": "0b260a6e44535ab0a094bbc6b6287605",
+    "semantic_hash": "0b260a6e44535ab0a094bbc6b6287605"
+  },
+  "orion/schemas/metacog_patches.py": {
+    "mtime": 1773975149.9497864,
+    "ast_hash": "2fbf273ad70c38ad8f01d7f7dbe83cf3",
+    "semantic_hash": "2fbf273ad70c38ad8f01d7f7dbe83cf3"
+  },
+  "orion/schemas/metacognitive_trace.py": {
+    "mtime": 1774759059.157305,
+    "ast_hash": "40d36a5628111e0d9731376ac95a8887",
+    "semantic_hash": "40d36a5628111e0d9731376ac95a8887"
+  },
+  "orion/schemas/mind/__init__.py": {
+    "mtime": 1777790653.2160316,
+    "ast_hash": "e2c9d8adf627fe3a8272575a8cd5bda7",
+    "semantic_hash": "e2c9d8adf627fe3a8272575a8cd5bda7"
+  },
+  "orion/schemas/mind/artifact.py": {
+    "mtime": 1777790653.2160316,
+    "ast_hash": "0ebad215b5586e34916fc656f6978e65",
+    "semantic_hash": "0ebad215b5586e34916fc656f6978e65"
+  },
+  "orion/schemas/notify.py": {
+    "mtime": 1774417080.6507087,
+    "ast_hash": "fc3ccbecfce93ee6d182487d092d2aae",
+    "semantic_hash": "fc3ccbecfce93ee6d182487d092d2aae"
+  },
+  "orion/schemas/organ_emission.py": {
+    "mtime": 1779668252.1390116,
+    "ast_hash": "07517f463d0e92ddeb7062af3c5c53b2",
+    "semantic_hash": "07517f463d0e92ddeb7062af3c5c53b2"
+  },
+  "orion/schemas/pad/__init__.py": {
+    "mtime": 1768597909.8762298,
+    "ast_hash": "0f3a2c05ae09e2c6326262b2a7a2f8e3",
+    "semantic_hash": "0f3a2c05ae09e2c6326262b2a7a2f8e3"
+  },
+  "orion/schemas/pad/v1.py": {
+    "mtime": 1773980667.707536,
+    "ast_hash": "d7167b7a42520f20e3f3026b5db70cc9",
+    "semantic_hash": "d7167b7a42520f20e3f3026b5db70cc9"
+  },
+  "orion/schemas/platform.py": {
+    "mtime": 1768597909.8772297,
+    "ast_hash": "50e0468a906b8059c35d01a0d235778d",
+    "semantic_hash": "50e0468a906b8059c35d01a0d235778d"
+  },
+  "orion/schemas/policy_decision_frame.py": {
+    "mtime": 1779689417.3412013,
+    "ast_hash": "4cda80183e6ddb5bc902e84b24000bba",
+    "semantic_hash": "4cda80183e6ddb5bc902e84b24000bba"
+  },
+  "orion/schemas/pre_turn_appraisal.py": {
+    "mtime": 1783130278.2334743,
+    "ast_hash": "8ad2da96ebeaf14f29808dae7fca1da1",
+    "semantic_hash": "8ad2da96ebeaf14f29808dae7fca1da1"
+  },
+  "orion/schemas/proposal_frame.py": {
+    "mtime": 1784008374.2425008,
+    "ast_hash": "27e10f323d42888314d50daf8ba249f6",
+    "semantic_hash": "27e10f323d42888314d50daf8ba249f6"
+  },
+  "orion/schemas/proposal_ledger.py": {
+    "mtime": 1781479799.2097633,
+    "ast_hash": "71d7f2bf230a6c3fea6e3a737e2dc4d6",
+    "semantic_hash": "71d7f2bf230a6c3fea6e3a737e2dc4d6"
+  },
+  "orion/schemas/proposal_lifecycle.py": {
+    "mtime": 1781479799.2097633,
+    "ast_hash": "cf9dfea6f53ea4cff98bee2e235dac98",
+    "semantic_hash": "cf9dfea6f53ea4cff98bee2e235dac98"
+  },
+  "orion/schemas/rdf.py": {
+    "mtime": 1767676515.6341066,
+    "ast_hash": "66236fc752f146fc5cc9e089a78d18a8",
+    "semantic_hash": "66236fc752f146fc5cc9e089a78d18a8"
+  },
+  "orion/schemas/recall.py": {
+    "mtime": 1767676515.6341066,
+    "ast_hash": "6f93422735115fd7136b851691f0efd8",
+    "semantic_hash": "6f93422735115fd7136b851691f0efd8"
+  },
+  "orion/schemas/recall_pcr.py": {
+    "mtime": 1783398623.0071564,
+    "ast_hash": "4c7f0b5e6eb2c5e7bee147e64e567270",
+    "semantic_hash": "4c7f0b5e6eb2c5e7bee147e64e567270"
+  },
+  "orion/schemas/reduction_receipt.py": {
+    "mtime": 1779668252.1390116,
+    "ast_hash": "10d510fb244f45809c15e3c372164ef8",
+    "semantic_hash": "10d510fb244f45809c15e3c372164ef8"
+  },
+  "orion/schemas/registry.py": {
+    "mtime": 1783967452.500406,
+    "ast_hash": "1a34c15ee4f560547e2bd6281c1508ab",
+    "semantic_hash": "1a34c15ee4f560547e2bd6281c1508ab"
+  },
+  "orion/schemas/repair_evidence.py": {
+    "mtime": 1783125791.0180876,
+    "ast_hash": "2ccd73969bbd982aceb6a8d2bcec1b01",
+    "semantic_hash": "2ccd73969bbd982aceb6a8d2bcec1b01"
+  },
+  "orion/schemas/reverie.py": {
+    "mtime": 1783807362.8677907,
+    "ast_hash": "ea27e1a8d14f3930b03ce214dcfd234e",
+    "semantic_hash": "ea27e1a8d14f3930b03ce214dcfd234e"
+  },
+  "orion/schemas/route_projection.py": {
+    "mtime": 1783903398.6404438,
+    "ast_hash": "70fbfdb9a49919e6568bd8fbc9aaf8ac",
+    "semantic_hash": "70fbfdb9a49919e6568bd8fbc9aaf8ac"
+  },
+  "orion/schemas/self_experiments.py": {
+    "mtime": 1781739116.1586347,
+    "ast_hash": "9ed90eefda63df6d112ac0d128b0445e",
+    "semantic_hash": "9ed90eefda63df6d112ac0d128b0445e"
+  },
+  "orion/schemas/self_state.py": {
+    "mtime": 1783897997.641214,
+    "ast_hash": "650681cf051572095c079b9e8e20ac48",
+    "semantic_hash": "650681cf051572095c079b9e8e20ac48"
+  },
+  "orion/schemas/self_state_prediction.py": {
+    "mtime": 1782438858.702639,
+    "ast_hash": "c1ca694bf918cbc5b94395785ec1d46e",
+    "semantic_hash": "c1ca694bf918cbc5b94395785ec1d46e"
+  },
+  "orion/schemas/self_study.py": {
+    "mtime": 1774242565.110185,
+    "ast_hash": "1f0a3ff27fc07fd4963386fa4415d76e",
+    "semantic_hash": "1f0a3ff27fc07fd4963386fa4415d76e"
+  },
+  "orion/schemas/situation.py": {
+    "mtime": 1777748523.3185987,
+    "ast_hash": "efc451ee1a0ce60a216ce4d85d297ec5",
+    "semantic_hash": "efc451ee1a0ce60a216ce4d85d297ec5"
+  },
+  "orion/schemas/social_artifact.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "83b6f2fd99aef00d42b4ddd3fcee44c6",
+    "semantic_hash": "83b6f2fd99aef00d42b4ddd3fcee44c6"
+  },
+  "orion/schemas/social_autonomy.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "e8277df9bdd99a80ee4a4804a17d435e",
+    "semantic_hash": "e8277df9bdd99a80ee4a4804a17d435e"
+  },
+  "orion/schemas/social_bridge.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "75fd15960e3b9f1208ce8bfd97e2b2cb",
+    "semantic_hash": "75fd15960e3b9f1208ce8bfd97e2b2cb"
+  },
+  "orion/schemas/social_calibration.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "5c56c145fb2a681195d8dfd341a4a2ee",
+    "semantic_hash": "5c56c145fb2a681195d8dfd341a4a2ee"
+  },
+  "orion/schemas/social_chat.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "f57806b69cbbd0284033f4ca80d579f4",
+    "semantic_hash": "f57806b69cbbd0284033f4ca80d579f4"
+  },
+  "orion/schemas/social_claim.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "cc4661fe36eab4b66f6da6ddde19b674",
+    "semantic_hash": "cc4661fe36eab4b66f6da6ddde19b674"
+  },
+  "orion/schemas/social_commitment.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "f94b45e28b1e7a4b12288822d912506f",
+    "semantic_hash": "f94b45e28b1e7a4b12288822d912506f"
+  },
+  "orion/schemas/social_context.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "5235cd70cd5ef9768d96e9fde646c0f6",
+    "semantic_hash": "5235cd70cd5ef9768d96e9fde646c0f6"
+  },
+  "orion/schemas/social_deliberation.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "55418a402e8204ee812e486b984172b7",
+    "semantic_hash": "55418a402e8204ee812e486b984172b7"
+  },
+  "orion/schemas/social_epistemic.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "40b626574c095d1282a683a00f22586d",
+    "semantic_hash": "40b626574c095d1282a683a00f22586d"
+  },
+  "orion/schemas/social_floor.py": {
+    "mtime": 1774236180.4443855,
+    "ast_hash": "d4feeb41cfd6bfa95819d64509755ebc",
+    "semantic_hash": "d4feeb41cfd6bfa95819d64509755ebc"
+  },
+  "orion/schemas/social_freshness.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "7d4aa8594e5438846dda1949c6013264",
+    "semantic_hash": "7d4aa8594e5438846dda1949c6013264"
+  },
+  "orion/schemas/social_gif.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "3d50d163552107f08aa4e8b371009c1e",
+    "semantic_hash": "3d50d163552107f08aa4e8b371009c1e"
+  },
+  "orion/schemas/social_inspection.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "12ea839e9eb93c245e3022713f8bbc7b",
+    "semantic_hash": "12ea839e9eb93c245e3022713f8bbc7b"
+  },
+  "orion/schemas/social_memory.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "533cb5e86039e161e3cc4e5d4d235605",
+    "semantic_hash": "533cb5e86039e161e3cc4e5d4d235605"
+  },
+  "orion/schemas/social_repair.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "6dbef1dbb68a36f8c4c1134fcd6e0d83",
+    "semantic_hash": "6dbef1dbb68a36f8c4c1134fcd6e0d83"
+  },
+  "orion/schemas/social_scenario.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "d64b12616c14646d6d75596e3b1f7d0e",
+    "semantic_hash": "d64b12616c14646d6d75596e3b1f7d0e"
+  },
+  "orion/schemas/social_shakedown.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "f9a6d69bb45a6ff5886d301a48a34367",
+    "semantic_hash": "f9a6d69bb45a6ff5886d301a48a34367"
+  },
+  "orion/schemas/social_skills.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "9a4f22a08df2fa2f764b7348ae58d1b2",
+    "semantic_hash": "9a4f22a08df2fa2f764b7348ae58d1b2"
+  },
+  "orion/schemas/social_style.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "05537c796ee2adb7a5d7a1cd6d6a60c2",
+    "semantic_hash": "05537c796ee2adb7a5d7a1cd6d6a60c2"
+  },
+  "orion/schemas/social_thread.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "1fdc6c29f084db0fa3eed7a657bd4d68",
+    "semantic_hash": "1fdc6c29f084db0fa3eed7a657bd4d68"
+  },
+  "orion/schemas/spark_concept_graph.py": {
+    "mtime": 1774680717.525936,
+    "ast_hash": "9dd79bfcd82c9f4535f4af56a1a62a00",
+    "semantic_hash": "9dd79bfcd82c9f4535f4af56a1a62a00"
+  },
+  "orion/schemas/sql/schemas.py": {
+    "mtime": 1767676515.6341066,
+    "ast_hash": "1fe9e457f87a28738cd54f1830975f5f",
+    "semantic_hash": "1fe9e457f87a28738cd54f1830975f5f"
+  },
+  "orion/schemas/state/__init__.py": {
+    "mtime": 1768971372.3560236,
+    "ast_hash": "52fb3a7cae17c3f439e28d0c7cc8f788",
+    "semantic_hash": "52fb3a7cae17c3f439e28d0c7cc8f788"
+  },
+  "orion/schemas/state/contracts.py": {
+    "mtime": 1768971372.3570237,
+    "ast_hash": "9a4379936652105e2a61179b688aae17",
+    "semantic_hash": "9a4379936652105e2a61179b688aae17"
+  },
+  "orion/schemas/state_delta.py": {
+    "mtime": 1779668252.1390116,
+    "ast_hash": "72b411b6a0c537d9e8741aefb68ad3ba",
+    "semantic_hash": "72b411b6a0c537d9e8741aefb68ad3ba"
+  },
+  "orion/schemas/substrate_telemetry.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "57261aad2f348d1a48fc72418458c3e7",
+    "semantic_hash": "57261aad2f348d1a48fc72418458c3e7"
+  },
+  "orion/schemas/telemetry/__init__.py": {
+    "mtime": 1781559772.6084518,
+    "ast_hash": "d34d0959092609d163f8257df3a1f4c8",
+    "semantic_hash": "d34d0959092609d163f8257df3a1f4c8"
+  },
+  "orion/schemas/telemetry/biometrics.py": {
+    "mtime": 1768971372.3570237,
+    "ast_hash": "39191eed7d5f1fdd165036e7da9ae426",
+    "semantic_hash": "39191eed7d5f1fdd165036e7da9ae426"
+  },
+  "orion/schemas/telemetry/cognition_trace.py": {
+    "mtime": 1773975149.9507864,
+    "ast_hash": "78f63d23075571835d3b2a08c6106cd2",
+    "semantic_hash": "78f63d23075571835d3b2a08c6106cd2"
+  },
+  "orion/schemas/telemetry/dream.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "f8428343fab2d67242ca51ad2f381988",
+    "semantic_hash": "f8428343fab2d67242ca51ad2f381988"
+  },
+  "orion/schemas/telemetry/field_channel_corpus.py": {
+    "mtime": 1783984456.987051,
+    "ast_hash": "b9ace282b2b5e6ff383dc4d66e266ebc",
+    "semantic_hash": "b9ace282b2b5e6ff383dc4d66e266ebc"
+  },
+  "orion/schemas/telemetry/inner_state.py": {
+    "mtime": 1783490446.3003592,
+    "ast_hash": "1d88cf60d334693b3a6d94ef931e52dd",
+    "semantic_hash": "1d88cf60d334693b3a6d94ef931e52dd"
+  },
+  "orion/schemas/telemetry/meta_tags.py": {
+    "mtime": 1768597909.8782296,
+    "ast_hash": "fb738f7594ae66f3524e0929c0b85220",
+    "semantic_hash": "fb738f7594ae66f3524e0929c0b85220"
+  },
+  "orion/schemas/telemetry/metacog_trigger.py": {
+    "mtime": 1779649387.7982988,
+    "ast_hash": "6e0beb0dcee4c3298555662b1294973e",
+    "semantic_hash": "6e0beb0dcee4c3298555662b1294973e"
+  },
+  "orion/schemas/telemetry/metacognition.py": {
+    "mtime": 1768597909.8782296,
+    "ast_hash": "cb20582c2b5df3f32259dffb672f1f03",
+    "semantic_hash": "cb20582c2b5df3f32259dffb672f1f03"
+  },
+  "orion/schemas/telemetry/mood_arc.py": {
+    "mtime": 1783984456.987051,
+    "ast_hash": "e76722fa3a6859daa8b65e461440b53e",
+    "semantic_hash": "e76722fa3a6859daa8b65e461440b53e"
+  },
+  "orion/schemas/telemetry/phi_encoder.py": {
+    "mtime": 1783898916.2576118,
+    "ast_hash": "2b299f26fa5dd09ad5f5a34ef573e05b",
+    "semantic_hash": "2b299f26fa5dd09ad5f5a34ef573e05b"
+  },
+  "orion/schemas/telemetry/reasoning.py": {
+    "mtime": 1783622541.3515248,
+    "ast_hash": "7301f6c946b51c7c31392c7bd37a70d9",
+    "semantic_hash": "7301f6c946b51c7c31392c7bd37a70d9"
+  },
+  "orion/schemas/telemetry/spark.py": {
+    "mtime": 1783903398.6404438,
+    "ast_hash": "0997c71412abf208f6c4b6a12671d731",
+    "semantic_hash": "0997c71412abf208f6c4b6a12671d731"
+  },
+  "orion/schemas/telemetry/spark_ack.py": {
+    "mtime": 1773975149.9507864,
+    "ast_hash": "3a58dd753cf53164bad1cd824f81f413",
+    "semantic_hash": "3a58dd753cf53164bad1cd824f81f413"
+  },
+  "orion/schemas/telemetry/spark_candidate.py": {
+    "mtime": 1768597909.8782296,
+    "ast_hash": "fe3593c37b0805b05e247136b255168d",
+    "semantic_hash": "fe3593c37b0805b05e247136b255168d"
+  },
+  "orion/schemas/telemetry/spark_signal.py": {
+    "mtime": 1783136738.0538802,
+    "ast_hash": "f6924eaea244c90f5f38803d9485fd4c",
+    "semantic_hash": "f6924eaea244c90f5f38803d9485fd4c"
+  },
+  "orion/schemas/telemetry/system_health.py": {
+    "mtime": 1781559772.6084518,
+    "ast_hash": "e7fefb86cd5d6051dca0bcfb1dd29a05",
+    "semantic_hash": "e7fefb86cd5d6051dca0bcfb1dd29a05"
+  },
+  "orion/schemas/telemetry/turn_effect.py": {
+    "mtime": 1782190803.0993247,
+    "ast_hash": "f212d29d7795995329f1f111d3009431",
+    "semantic_hash": "f212d29d7795995329f1f111d3009431"
+  },
+  "orion/schemas/telemetry/turn_effect_explanations.py": {
+    "mtime": 1773975149.9507864,
+    "ast_hash": "272036e31ac24ce43a918fdceed4de70",
+    "semantic_hash": "272036e31ac24ce43a918fdceed4de70"
+  },
+  "orion/schemas/telemetry/turn_effect_policy.py": {
+    "mtime": 1773975149.9507864,
+    "ast_hash": "41ef667156261094e40c9ac6c9e66761",
+    "semantic_hash": "41ef667156261094e40c9ac6c9e66761"
+  },
+  "orion/schemas/tests/test_context_exec_investigation_v2.py": {
+    "mtime": 1781559772.6084518,
+    "ast_hash": "36975fac9bfbfdbd9513e7d3317bff51",
+    "semantic_hash": "36975fac9bfbfdbd9513e7d3317bff51"
+  },
+  "orion/schemas/tests/test_context_exec_llm_profile.py": {
+    "mtime": 1781494684.917417,
+    "ast_hash": "0a099a062395eae461b8eda171496ae0",
+    "semantic_hash": "0a099a062395eae461b8eda171496ae0"
+  },
+  "orion/schemas/tests/test_grounding_capsule_registry.py": {
+    "mtime": 1783458889.5689456,
+    "ast_hash": "f928bcf5d9ff14d265bfabbd7f74aff9",
+    "semantic_hash": "f928bcf5d9ff14d265bfabbd7f74aff9"
+  },
+  "orion/schemas/tests/test_proposal_dry_run_lifecycle.py": {
+    "mtime": 1781479799.2107632,
+    "ast_hash": "93986d4a960a5d461deaa1380dbe678d",
+    "semantic_hash": "93986d4a960a5d461deaa1380dbe678d"
+  },
+  "orion/schemas/tests/test_proposal_ledger_registry.py": {
+    "mtime": 1781479799.2107632,
+    "ast_hash": "0d332bbebb68c0bd4d7435c9f12bb345",
+    "semantic_hash": "0d332bbebb68c0bd4d7435c9f12bb345"
+  },
+  "orion/schemas/tests/test_self_experiments.py": {
+    "mtime": 1781739116.1586347,
+    "ast_hash": "9ac56c28837131ba78159a882c54028b",
+    "semantic_hash": "9ac56c28837131ba78159a882c54028b"
+  },
+  "orion/schemas/tests/test_thought.py": {
+    "mtime": 1783740584.5904982,
+    "ast_hash": "917465b947666f940bfc97566aea82e2",
+    "semantic_hash": "917465b947666f940bfc97566aea82e2"
+  },
+  "orion/schemas/thought.py": {
+    "mtime": 1783892565.0034528,
+    "ast_hash": "da2b6d78823cb2228f55abe000e299e9",
+    "semantic_hash": "da2b6d78823cb2228f55abe000e299e9"
+  },
+  "orion/schemas/topic_foundry.py": {
+    "mtime": 1773975149.9507864,
+    "ast_hash": "e33a6a9bcea383c1d3113070f2901680",
+    "semantic_hash": "e33a6a9bcea383c1d3113070f2901680"
+  },
+  "orion/schemas/transport_projection.py": {
+    "mtime": 1780622613.5947645,
+    "ast_hash": "e972384027e41ae231c9cab91f0e43fe",
+    "semantic_hash": "e972384027e41ae231c9cab91f0e43fe"
+  },
+  "orion/schemas/tts.py": {
+    "mtime": 1767676515.6351066,
+    "ast_hash": "8d90c7ac765d8d4eae42a1ace8c13d96",
+    "semantic_hash": "8d90c7ac765d8d4eae42a1ace8c13d96"
+  },
+  "orion/schemas/vector/schemas.py": {
+    "mtime": 1773975149.9507864,
+    "ast_hash": "ecd00a671b46821c1df1fd7c8406b97e",
+    "semantic_hash": "ecd00a671b46821c1df1fd7c8406b97e"
+  },
+  "orion/schemas/vision.py": {
+    "mtime": 1783028252.549353,
+    "ast_hash": "4ce1ee42a64c214bddd6a3f111f1c126",
+    "semantic_hash": "4ce1ee42a64c214bddd6a3f111f1c126"
+  },
+  "orion/schemas/vision_interpretation_contract.py": {
+    "mtime": 1783107031.9699016,
+    "ast_hash": "8b87a7d044f050c7c9f5b0d65b61f66e",
+    "semantic_hash": "8b87a7d044f050c7c9f5b0d65b61f66e"
+  },
+  "orion/schemas/workflow_execution.py": {
+    "mtime": 1774478925.1982296,
+    "ast_hash": "a6c55d999c5d26049854d5cc4ea4bb26",
+    "semantic_hash": "a6c55d999c5d26049854d5cc4ea4bb26"
+  },
+  "orion/schemas/world_pulse.py": {
+    "mtime": 1783479691.3184597,
+    "ast_hash": "b5ed038fdf7be8c6eae1aad66a213193",
+    "semantic_hash": "b5ed038fdf7be8c6eae1aad66a213193"
+  },
+  "orion/self_state/__init__.py": {
+    "mtime": 1779683294.759711,
+    "ast_hash": "3835429b952a13700b59c179f5de4a0c",
+    "semantic_hash": "3835429b952a13700b59c179f5de4a0c"
+  },
+  "orion/self_state/builder.py": {
+    "mtime": 1783897997.641214,
+    "ast_hash": "e6395dff6e08ecd93e6660239c7f8239",
+    "semantic_hash": "e6395dff6e08ecd93e6660239c7f8239"
+  },
+  "orion/self_state/deviation.py": {
+    "mtime": 1783841798.4905632,
+    "ast_hash": "59138ca6177ac9e31a377161a00fd35a",
+    "semantic_hash": "59138ca6177ac9e31a377161a00fd35a"
+  },
+  "orion/self_state/inner_state_registry.py": {
+    "mtime": 1783984456.988051,
+    "ast_hash": "75892305a47743e4cc2079d56a5aa78c",
+    "semantic_hash": "75892305a47743e4cc2079d56a5aa78c"
+  },
+  "orion/self_state/policy.py": {
+    "mtime": 1783841798.4905632,
+    "ast_hash": "ce3aee70624c1f2d202bb66c7212a9dc",
+    "semantic_hash": "ce3aee70624c1f2d202bb66c7212a9dc"
+  },
+  "orion/self_state/prediction.py": {
+    "mtime": 1782874038.2529726,
+    "ast_hash": "9d1bd30308d082d7e1c0f16b10098534",
+    "semantic_hash": "9d1bd30308d082d7e1c0f16b10098534"
+  },
+  "orion/self_state/scoring.py": {
+    "mtime": 1783843021.920588,
+    "ast_hash": "e9ff050ab548f601736a33ad864d0ebb",
+    "semantic_hash": "e9ff050ab548f601736a33ad864d0ebb"
+  },
+  "orion/self_state/transport.py": {
+    "mtime": 1780622613.5957644,
+    "ast_hash": "8e9d0dbf9c26e925b4e36960521404c0",
+    "semantic_hash": "8e9d0dbf9c26e925b4e36960521404c0"
+  },
+  "orion/sensors/gpu_host_stats.sh": {
+    "mtime": 1763232123.3988905,
+    "ast_hash": "4a9db5d30d9bef0728aa6cc99bc7749d",
+    "semantic_hash": "4a9db5d30d9bef0728aa6cc99bc7749d"
+  },
+  "orion/signals/__init__.py": {
+    "mtime": 1777696739.8195698,
+    "ast_hash": "c820ea37a802580cb80ca8a530b07b38",
+    "semantic_hash": "c820ea37a802580cb80ca8a530b07b38"
+  },
+  "orion/signals/adapters/__init__.py": {
+    "mtime": 1783499830.193521,
+    "ast_hash": "f7127068bef686224f6f86761ae1279e",
+    "semantic_hash": "f7127068bef686224f6f86761ae1279e"
+  },
+  "orion/signals/adapters/autonomy.py": {
+    "mtime": 1779332554.3238986,
+    "ast_hash": "a2c0c4f02e4cdc0646f0c4e245f1a409",
+    "semantic_hash": "a2c0c4f02e4cdc0646f0c4e245f1a409"
+  },
+  "orion/signals/adapters/base.py": {
+    "mtime": 1779332554.3238986,
+    "ast_hash": "546a766fcc43901f59b3ad90a6cba996",
+    "semantic_hash": "546a766fcc43901f59b3ad90a6cba996"
+  },
+  "orion/signals/adapters/biometrics.py": {
+    "mtime": 1777696817.3302784,
+    "ast_hash": "1173baff3c238fecce647b9eb6e2fcff",
+    "semantic_hash": "1173baff3c238fecce647b9eb6e2fcff"
+  },
+  "orion/signals/adapters/chat_stance.py": {
+    "mtime": 1779332554.3238986,
+    "ast_hash": "3c84c1629997a8d3903cb8fe540533cd",
+    "semantic_hash": "3c84c1629997a8d3903cb8fe540533cd"
+  },
+  "orion/signals/adapters/cognition_trace.py": {
+    "mtime": 1783499830.193521,
+    "ast_hash": "e4a843923df24af18c08122454967728",
+    "semantic_hash": "e4a843923df24af18c08122454967728"
+  },
+  "orion/signals/adapters/collapse_mirror.py": {
+    "mtime": 1779332554.3238986,
+    "ast_hash": "28d1ec9274c06823bbb48a0adc5a9b5c",
+    "semantic_hash": "28d1ec9274c06823bbb48a0adc5a9b5c"
+  },
+  "orion/signals/adapters/concept_induction.py": {
+    "mtime": 1777696812.6531754,
+    "ast_hash": "1af148ccda165f33c14ca4d2b7077be0",
+    "semantic_hash": "1af148ccda165f33c14ca4d2b7077be0"
+  },
+  "orion/signals/adapters/cortex_gateway.py": {
+    "mtime": 1779332554.3238986,
+    "ast_hash": "35c145dd5205d5fc7209448d57c8f4ed",
+    "semantic_hash": "35c145dd5205d5fc7209448d57c8f4ed"
+  },
+  "orion/signals/adapters/cortex_orch.py": {
+    "mtime": 1779332554.3238986,
+    "ast_hash": "85c5d55dc9fbdb60017d76e7659f1834",
+    "semantic_hash": "85c5d55dc9fbdb60017d76e7659f1834"
+  },
+  "orion/signals/adapters/dream.py": {
+    "mtime": 1777696812.6531754,
+    "ast_hash": "62013fa141f5df9856d5f25b654217b4",
+    "semantic_hash": "62013fa141f5df9856d5f25b654217b4"
+  },
+  "orion/signals/adapters/equilibrium.py": {
+    "mtime": 1779332554.3238986,
+    "ast_hash": "841ee97cb9ab3b763c2c5b5023e931f6",
+    "semantic_hash": "841ee97cb9ab3b763c2c5b5023e931f6"
+  },
+  "orion/signals/adapters/graph_cognition.py": {
+    "mtime": 1777696812.6531754,
+    "ast_hash": "1122dfc1298ec1ed8ccc310791819726",
+    "semantic_hash": "1122dfc1298ec1ed8ccc310791819726"
+  },
+  "orion/signals/adapters/hub.py": {
+    "mtime": 1779332554.3238986,
+    "ast_hash": "273543f55b0aed356920be8952972814",
+    "semantic_hash": "273543f55b0aed356920be8952972814"
+  },
+  "orion/signals/adapters/journaler.py": {
+    "mtime": 1779332554.3248985,
+    "ast_hash": "1c5e007b44384725de1b87597b4b8003",
+    "semantic_hash": "1c5e007b44384725de1b87597b4b8003"
+  },
+  "orion/signals/adapters/persistence_writers.py": {
+    "mtime": 1779332554.3248985,
+    "ast_hash": "430eb026cb98e82706d87c59f72c51b2",
+    "semantic_hash": "430eb026cb98e82706d87c59f72c51b2"
+  },
+  "orion/signals/adapters/power_guard.py": {
+    "mtime": 1777696812.6531754,
+    "ast_hash": "c0b48b3862368ec06aab417bf6774508",
+    "semantic_hash": "c0b48b3862368ec06aab417bf6774508"
+  },
+  "orion/signals/adapters/recall.py": {
+    "mtime": 1779332554.3248985,
+    "ast_hash": "eea9a50706478daeec902c92e5143cc2",
+    "semantic_hash": "eea9a50706478daeec902c92e5143cc2"
+  },
+  "orion/signals/adapters/result.py": {
+    "mtime": 1779332554.3248985,
+    "ast_hash": "23aa154d4120ef2f06530593614ca376",
+    "semantic_hash": "23aa154d4120ef2f06530593614ca376"
+  },
+  "orion/signals/adapters/security_watcher.py": {
+    "mtime": 1777696812.6541753,
+    "ast_hash": "9692988cd4fd8793f5a3656e4214a62d",
+    "semantic_hash": "9692988cd4fd8793f5a3656e4214a62d"
+  },
+  "orion/signals/adapters/social_memory.py": {
+    "mtime": 1779332554.3248985,
+    "ast_hash": "f83c399355124a2b870e9b3699d0ae22",
+    "semantic_hash": "f83c399355124a2b870e9b3699d0ae22"
+  },
+  "orion/signals/adapters/social_room_bridge.py": {
+    "mtime": 1777696812.6541753,
+    "ast_hash": "4eae5c173e2de7397572ec589c1bd20b",
+    "semantic_hash": "4eae5c173e2de7397572ec589c1bd20b"
+  },
+  "orion/signals/adapters/spark.py": {
+    "mtime": 1779332554.3248985,
+    "ast_hash": "b3a39894ace7d0b648236d918efe2dc9",
+    "semantic_hash": "b3a39894ace7d0b648236d918efe2dc9"
+  },
+  "orion/signals/adapters/state_journaler.py": {
+    "mtime": 1777696812.6541753,
+    "ast_hash": "390101ef806948188d0f778a2e955c26",
+    "semantic_hash": "390101ef806948188d0f778a2e955c26"
+  },
+  "orion/signals/adapters/tests/__init__.py": {
+    "mtime": 1777696739.8205698,
+    "ast_hash": "cb67385850d6b1d7f43d24583bf5a0b7",
+    "semantic_hash": "cb67385850d6b1d7f43d24583bf5a0b7"
+  },
+  "orion/signals/adapters/tests/conftest.py": {
+    "mtime": 1777696739.8205698,
+    "ast_hash": "609c0baffa7e3f1447af4f925aead561",
+    "semantic_hash": "609c0baffa7e3f1447af4f925aead561"
+  },
+  "orion/signals/adapters/tests/fixtures/cognition_trace_chat_general.json": {
+    "mtime": 1779332554.3248985,
+    "ast_hash": "bb93a514affe6f640816ef02e64ce705",
+    "semantic_hash": "bb93a514affe6f640816ef02e64ce705"
+  },
+  "orion/signals/adapters/tests/fixtures/recall_exec_result.json": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "0030505e22e6368b824332b6f4afe1c2",
+    "semantic_hash": "0030505e22e6368b824332b6f4afe1c2"
+  },
+  "orion/signals/adapters/tests/test_adapter_result.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "53b2b02106cc5d6a22bab04340c32031",
+    "semantic_hash": "53b2b02106cc5d6a22bab04340c32031"
+  },
+  "orion/signals/adapters/tests/test_autonomy_adapter.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "1a26c84f66add5c5b7a3c99963c645a3",
+    "semantic_hash": "1a26c84f66add5c5b7a3c99963c645a3"
+  },
+  "orion/signals/adapters/tests/test_b6_priority_adapters.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "8d59b717058877637f4ec403a98b343f",
+    "semantic_hash": "8d59b717058877637f4ec403a98b343f"
+  },
+  "orion/signals/adapters/tests/test_biometrics_adapter.py": {
+    "mtime": 1777696901.7071395,
+    "ast_hash": "605250112ffcde944121d9ec9a282fec",
+    "semantic_hash": "605250112ffcde944121d9ec9a282fec"
+  },
+  "orion/signals/adapters/tests/test_causal_helpers.py": {
+    "mtime": 1777696739.8205698,
+    "ast_hash": "352746af4f75ba21a4d7cfe39b672ffb",
+    "semantic_hash": "352746af4f75ba21a4d7cfe39b672ffb"
+  },
+  "orion/signals/adapters/tests/test_chat_stance_adapter.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "456ae805527b70ffd6fd5f6a2c29de57",
+    "semantic_hash": "456ae805527b70ffd6fd5f6a2c29de57"
+  },
+  "orion/signals/adapters/tests/test_cognition_trace_adapter.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "87a44d143e29e86076f9c6fed8378511",
+    "semantic_hash": "87a44d143e29e86076f9c6fed8378511"
+  },
+  "orion/signals/adapters/tests/test_equilibrium_adapter.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "b540862837947f1dd9e8406aac4f46ed",
+    "semantic_hash": "b540862837947f1dd9e8406aac4f46ed"
+  },
+  "orion/signals/adapters/tests/test_recall_adapter.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "ba826b65156aca7cfde2114a5e5be6e5",
+    "semantic_hash": "ba826b65156aca7cfde2114a5e5be6e5"
+  },
+  "orion/signals/adapters/tests/test_runtime_adapters.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "5be58eec15fb9a50736468fd9e0f9d9a",
+    "semantic_hash": "5be58eec15fb9a50736468fd9e0f9d9a"
+  },
+  "orion/signals/adapters/tests/test_runtime_registry_entries.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "35276767090325a8297270c47419d3f3",
+    "semantic_hash": "35276767090325a8297270c47419d3f3"
+  },
+  "orion/signals/adapters/tests/test_spark_adapter.py": {
+    "mtime": 1779332554.3258986,
+    "ast_hash": "55065b9f80afca8cadfab2b32a39724e",
+    "semantic_hash": "55065b9f80afca8cadfab2b32a39724e"
+  },
+  "orion/signals/adapters/tests/test_world_pulse_adapter.py": {
+    "mtime": 1779330729.108181,
+    "ast_hash": "0e3cd21e1024ee65f05fc7077f7fd427",
+    "semantic_hash": "0e3cd21e1024ee65f05fc7077f7fd427"
+  },
+  "orion/signals/adapters/topic_foundry.py": {
+    "mtime": 1777696812.6541753,
+    "ast_hash": "3f0ef4a7c9c8bedfa49ca487f85117c9",
+    "semantic_hash": "3f0ef4a7c9c8bedfa49ca487f85117c9"
+  },
+  "orion/signals/adapters/vision.py": {
+    "mtime": 1777696812.6541753,
+    "ast_hash": "65d70033f036e2d8b6fe5574d2e3f876",
+    "semantic_hash": "65d70033f036e2d8b6fe5574d2e3f876"
+  },
+  "orion/signals/adapters/world_pulse.py": {
+    "mtime": 1779330729.108181,
+    "ast_hash": "2757528a77e5c0895c33e7fe5f4c4e93",
+    "semantic_hash": "2757528a77e5c0895c33e7fe5f4c4e93"
+  },
+  "orion/signals/causal_helpers.py": {
+    "mtime": 1777696739.82157,
+    "ast_hash": "8f91c351600f87d6440657c7553c0253",
+    "semantic_hash": "8f91c351600f87d6440657c7553c0253"
+  },
+  "orion/signals/layers.py": {
+    "mtime": 1783499830.193521,
+    "ast_hash": "e9e2cd5af667836063a11a3cec34bff4",
+    "semantic_hash": "e9e2cd5af667836063a11a3cec34bff4"
+  },
+  "orion/signals/models.py": {
+    "mtime": 1777696989.1130688,
+    "ast_hash": "0f14b5a8c47f4ad2e3637ca6daed586b",
+    "semantic_hash": "0f14b5a8c47f4ad2e3637ca6daed586b"
+  },
+  "orion/signals/normalization.py": {
+    "mtime": 1777696739.82157,
+    "ast_hash": "76a03f1a53fcfcef4fcfcb764701d6d6",
+    "semantic_hash": "76a03f1a53fcfcef4fcfcb764701d6d6"
+  },
+  "orion/signals/registry.py": {
+    "mtime": 1783499830.193521,
+    "ast_hash": "ba70f08b6ae483fffac72b2ba9d43124",
+    "semantic_hash": "ba70f08b6ae483fffac72b2ba9d43124"
+  },
+  "orion/signals/signal_ids.py": {
+    "mtime": 1777696797.808848,
+    "ast_hash": "194280dae73ca59e21a85c822d3c7929",
+    "semantic_hash": "194280dae73ca59e21a85c822d3c7929"
+  },
+  "orion/signals/stub_detection.py": {
+    "mtime": 1779332554.3268986,
+    "ast_hash": "3f6dc5db0ff3dc38ea4b95e862202da2",
+    "semantic_hash": "3f6dc5db0ff3dc38ea4b95e862202da2"
+  },
+  "orion/signals/tests/__init__.py": {
+    "mtime": 1779332554.3268986,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/signals/tests/test_layers.py": {
+    "mtime": 1779332554.3268986,
+    "ast_hash": "c3003f39f90caae45f611d88738146b6",
+    "semantic_hash": "c3003f39f90caae45f611d88738146b6"
+  },
+  "orion/signals/tests/test_stub_detection.py": {
+    "mtime": 1779332554.3268986,
+    "ast_hash": "211e53b36f66e612bd649c65239f8051",
+    "semantic_hash": "211e53b36f66e612bd649c65239f8051"
+  },
+  "orion/social/__init__.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "d569c9c9e6609b43c238a872dc4be763",
+    "semantic_hash": "d569c9c9e6609b43c238a872dc4be763"
+  },
+  "orion/social/scenario_replay.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "72d7cf857c3b531985fada41e4eb3031",
+    "semantic_hash": "72d7cf857c3b531985fada41e4eb3031"
+  },
+  "orion/social/shakedown.py": {
+    "mtime": 1774236180.4453855,
+    "ast_hash": "ddef3c17debd7ae001070b56670bf997",
+    "semantic_hash": "ddef3c17debd7ae001070b56670bf997"
+  },
+  "orion/spark/__init__.py": {
+    "mtime": 1763941089.167007,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/spark/concept_induction/__init__.py": {
+    "mtime": 1768597909.8792295,
+    "ast_hash": "d9d28167cf458f60ae7ed3c4b5bcc848",
+    "semantic_hash": "d9d28167cf458f60ae7ed3c4b5bcc848"
+  },
+  "orion/spark/concept_induction/audit.py": {
+    "mtime": 1783396080.0149949,
+    "ast_hash": "09078c78d6b93a3c20f1ff45ab1c2970",
+    "semantic_hash": "09078c78d6b93a3c20f1ff45ab1c2970"
+  },
+  "orion/spark/concept_induction/bus_worker.py": {
+    "mtime": 1784008374.2435007,
+    "ast_hash": "1792af9709bc20993e3c0468963f0b5c",
+    "semantic_hash": "1792af9709bc20993e3c0468963f0b5c"
+  },
+  "orion/spark/concept_induction/clusterer.py": {
+    "mtime": 1768597909.8792295,
+    "ast_hash": "cdea86eefcf4310aa8e1718983e5c7a1",
+    "semantic_hash": "cdea86eefcf4310aa8e1718983e5c7a1"
+  },
+  "orion/spark/concept_induction/dossier.py": {
+    "mtime": 1773980667.707536,
+    "ast_hash": "d18a1d965893f91c64a0ba4bff272f33",
+    "semantic_hash": "d18a1d965893f91c64a0ba4bff272f33"
+  },
+  "orion/spark/concept_induction/drive_attribution.py": {
+    "mtime": 1783396080.015995,
+    "ast_hash": "015ffcefedd52b59b44a3d48c1524470",
+    "semantic_hash": "015ffcefedd52b59b44a3d48c1524470"
+  },
+  "orion/spark/concept_induction/drive_tension.py": {
+    "mtime": 1783986358.1006565,
+    "ast_hash": "13865a438ec0ac7f9eab8d5d62c8ff59",
+    "semantic_hash": "13865a438ec0ac7f9eab8d5d62c8ff59"
+  },
+  "orion/spark/concept_induction/drives.py": {
+    "mtime": 1784008374.2435007,
+    "ast_hash": "a6cabbeca9ae973b92287abf0e509db3",
+    "semantic_hash": "a6cabbeca9ae973b92287abf0e509db3"
+  },
+  "orion/spark/concept_induction/embedder.py": {
+    "mtime": 1773980667.7085361,
+    "ast_hash": "a8c980aa041d7cbb6b050e17bd211716",
+    "semantic_hash": "a8c980aa041d7cbb6b050e17bd211716"
+  },
+  "orion/spark/concept_induction/extractor.py": {
+    "mtime": 1782445600.7220423,
+    "ast_hash": "ea81a8e1c1412284e871973b11c19672",
+    "semantic_hash": "ea81a8e1c1412284e871973b11c19672"
+  },
+  "orion/spark/concept_induction/goal_generator.py": {
+    "mtime": 1779328788.9577868,
+    "ast_hash": "e3c2ba709e9d615bb526876cb5ee9998",
+    "semantic_hash": "e3c2ba709e9d615bb526876cb5ee9998"
+  },
+  "orion/spark/concept_induction/goals.py": {
+    "mtime": 1783490446.3013592,
+    "ast_hash": "87e7a8117d35d79a5c52eef22e70f361",
+    "semantic_hash": "87e7a8117d35d79a5c52eef22e70f361"
+  },
+  "orion/spark/concept_induction/graph_mapper.py": {
+    "mtime": 1774680717.5269358,
+    "ast_hash": "065db193fca698c2a9c539cd2d44708b",
+    "semantic_hash": "065db193fca698c2a9c539cd2d44708b"
+  },
+  "orion/spark/concept_induction/graph_query.py": {
+    "mtime": 1779328788.9577868,
+    "ast_hash": "ef5b8d12b5f30a50bd9fe58566f2306d",
+    "semantic_hash": "ef5b8d12b5f30a50bd9fe58566f2306d"
+  },
+  "orion/spark/concept_induction/identity.py": {
+    "mtime": 1777093481.8371313,
+    "ast_hash": "eaabe2ab7cbee63d45d6051e147c6bc2",
+    "semantic_hash": "eaabe2ab7cbee63d45d6051e147c6bc2"
+  },
+  "orion/spark/concept_induction/inducer.py": {
+    "mtime": 1782445600.7220423,
+    "ast_hash": "d0559de53aed4474f5d8b4b72f6b957d",
+    "semantic_hash": "d0559de53aed4474f5d8b4b72f6b957d"
+  },
+  "orion/spark/concept_induction/parity_evidence.py": {
+    "mtime": 1774680717.5269358,
+    "ast_hash": "6f86088598eb9a994125688406e4d8c7",
+    "semantic_hash": "6f86088598eb9a994125688406e4d8c7"
+  },
+  "orion/spark/concept_induction/profile_repository.py": {
+    "mtime": 1774680717.5269358,
+    "ast_hash": "5ad0bbae2640c1ecd87bdcb05a11a7b7",
+    "semantic_hash": "5ad0bbae2640c1ecd87bdcb05a11a7b7"
+  },
+  "orion/spark/concept_induction/rdf_materialization.py": {
+    "mtime": 1774680717.5269358,
+    "ast_hash": "c156b55cb9628896c33edfb3d17dd616",
+    "semantic_hash": "c156b55cb9628896c33edfb3d17dd616"
+  },
+  "orion/spark/concept_induction/settings.py": {
+    "mtime": 1784008374.2435007,
+    "ast_hash": "ec0442ab7257147adfb6e0040543aa55",
+    "semantic_hash": "ec0442ab7257147adfb6e0040543aa55"
+  },
+  "orion/spark/concept_induction/store.py": {
+    "mtime": 1783453525.6769116,
+    "ast_hash": "a9af31c5b981ced6b56f7b65295fa0b2",
+    "semantic_hash": "a9af31c5b981ced6b56f7b65295fa0b2"
+  },
+  "orion/spark/concept_induction/summarizer.py": {
+    "mtime": 1768597909.8792295,
+    "ast_hash": "b58c61f34c5cc09619e9e12cd9f717c0",
+    "semantic_hash": "b58c61f34c5cc09619e9e12cd9f717c0"
+  },
+  "orion/spark/concept_induction/tensions.py": {
+    "mtime": 1784008374.2435007,
+    "ast_hash": "bb1109089ad4462721c157ba29a7ba3d",
+    "semantic_hash": "bb1109089ad4462721c157ba29a7ba3d"
+  },
+  "orion/spark/concept_induction/tests/__init__.py": {
+    "mtime": 1768597909.8792295,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "orion/spark/concept_induction/tests/test_concept_induction.py": {
+    "mtime": 1774814683.1648676,
+    "ast_hash": "949c7c5bb83e12f0755384f61b94de7e",
+    "semantic_hash": "949c7c5bb83e12f0755384f61b94de7e"
+  },
+  "orion/spark/concept_induction/tests/test_drive_attribution.py": {
+    "mtime": 1783396080.015995,
+    "ast_hash": "28d1edbb8edd1b617883b21035a69eba",
+    "semantic_hash": "28d1edbb8edd1b617883b21035a69eba"
+  },
+  "orion/spark/concept_induction/tests/test_drive_pressure_probe.py": {
+    "mtime": 1783847515.5398455,
+    "ast_hash": "41c41f0fc4c1e3f6523db5d48a8e6f42",
+    "semantic_hash": "41c41f0fc4c1e3f6523db5d48a8e6f42"
+  },
+  "orion/spark/concept_induction/tests/test_drive_tension.py": {
+    "mtime": 1783986358.1006565,
+    "ast_hash": "5dc85272068dbe5ae423519ea99136b4",
+    "semantic_hash": "5dc85272068dbe5ae423519ea99136b4"
+  },
+  "orion/spark/concept_induction/tests/test_drives_leaky.py": {
+    "mtime": 1784008374.2445009,
+    "ast_hash": "60261cbc4ca9742f312872fee3b51c25",
+    "semantic_hash": "60261cbc4ca9742f312872fee3b51c25"
+  },
+  "orion/spark/concept_induction/tests/test_endogenous_origination_wiring.py": {
+    "mtime": 1783490446.3013592,
+    "ast_hash": "7462466aa8254e9574e96d4bfe41675a",
+    "semantic_hash": "7462466aa8254e9574e96d4bfe41675a"
+  },
+  "orion/spark/concept_induction/tests/test_goal_generator.py": {
+    "mtime": 1779328788.9587867,
+    "ast_hash": "0e14d6c7bb809be04b4f4ec3608d27a0",
+    "semantic_hash": "0e14d6c7bb809be04b4f4ec3608d27a0"
+  },
+  "orion/spark/concept_induction/tests/test_goal_spawned_correlation.py": {
+    "mtime": 1783365495.731666,
+    "ast_hash": "2e978dae4c2f03455967839edbe99ba1",
+    "semantic_hash": "2e978dae4c2f03455967839edbe99ba1"
+  },
+  "orion/spark/concept_induction/tests/test_goals.py": {
+    "mtime": 1783396080.015995,
+    "ast_hash": "e0384b2c38e839a9ac83975918d4baa2",
+    "semantic_hash": "e0384b2c38e839a9ac83975918d4baa2"
+  },
+  "orion/spark/concept_induction/tests/test_graph_profile_repository.py": {
+    "mtime": 1774680717.527936,
+    "ast_hash": "e35688a68c2ad70d0543c2b5484eda84",
+    "semantic_hash": "e35688a68c2ad70d0543c2b5484eda84"
+  },
+  "orion/spark/concept_induction/tests/test_metabolism_hook.py": {
+    "mtime": 1783807362.662784,
+    "ast_hash": "2e0b3df23e8df3920663d5008fa7244e",
+    "semantic_hash": "2e0b3df23e8df3920663d5008fa7244e"
+  },
+  "orion/spark/concept_induction/tests/test_parity_evidence.py": {
+    "mtime": 1774680717.527936,
+    "ast_hash": "a1d4d0c823a4a3c17698c9d57c02f201",
+    "semantic_hash": "a1d4d0c823a4a3c17698c9d57c02f201"
+  },
+  "orion/spark/concept_induction/tests/test_pressure_tensions.py": {
+    "mtime": 1777093481.8371313,
+    "ast_hash": "ffe72522b0bce2e677ae4ab681da8e60",
+    "semantic_hash": "ffe72522b0bce2e677ae4ab681da8e60"
+  },
+  "orion/spark/concept_induction/tests/test_profile_repository.py": {
+    "mtime": 1774654210.0928352,
+    "ast_hash": "80edad316541b88170026b6fbf2018d2",
+    "semantic_hash": "80edad316541b88170026b6fbf2018d2"
+  },
+  "orion/spark/concept_induction/tests/test_rdf_materialization.py": {
+    "mtime": 1774680717.527936,
+    "ast_hash": "9566770d847dafeaa42af272e18e7180",
+    "semantic_hash": "9566770d847dafeaa42af272e18e7180"
+  },
+  "orion/spark/concept_induction/tests/test_resolve_subject_identity.py": {
+    "mtime": 1777093481.8421311,
+    "ast_hash": "7fc39e1e56d47b95854156cda39e2640",
+    "semantic_hash": "7fc39e1e56d47b95854156cda39e2640"
+  },
+  "orion/spark/concept_induction/tests/test_signal_drive_consumer.py": {
+    "mtime": 1783480961.3277907,
+    "ast_hash": "a4b1c1d7d794291d327a21565bc3bf7e",
+    "semantic_hash": "a4b1c1d7d794291d327a21565bc3bf7e"
+  },
+  "orion/spark/concept_induction/tests/test_store_episode_idempotency.py": {
+    "mtime": 1783453525.6769116,
+    "ast_hash": "9df26cd50a866817c4b0b1c0ddf8c5db",
+    "semantic_hash": "9df26cd50a866817c4b0b1c0ddf8c5db"
+  },
+  "orion/spark/concept_induction/tests/test_tension_extract_turn_effect.py": {
+    "mtime": 1777093481.8371313,
+    "ast_hash": "a7fe90593ada5b0e0a51fbca95a12400",
+    "semantic_hash": "a7fe90593ada5b0e0a51fbca95a12400"
+  },
+  "orion/spark/concept_induction/tests/test_wp_stream_consumer.py": {
+    "mtime": 1783453525.6769116,
+    "ast_hash": "6c2b62fad695a6ccddd96d2170ac4ea0",
+    "semantic_hash": "6c2b62fad695a6ccddd96d2170ac4ea0"
+  },
+  "orion/spark/concept_induction/wp_stream_consumer.py": {
+    "mtime": 1783453525.6769116,
+    "ast_hash": "5998f0c817d0ae20aa22eb7132827ea9",
+    "semantic_hash": "5998f0c817d0ae20aa22eb7132827ea9"
+  },
+  "orion/spark/introspection_metadata.py": {
+    "mtime": 1774566954.6982691,
+    "ast_hash": "60a65e2f34e8357f918a5e8e9ca247ea",
+    "semantic_hash": "60a65e2f34e8357f918a5e8e9ca247ea"
+  },
+  "orion/spark/orion_tissue.py": {
+    "mtime": 1781142159.4001744,
+    "ast_hash": "3d28dbdc885e28d571c9bf061d48c2e1",
+    "semantic_hash": "3d28dbdc885e28d571c9bf061d48c2e1"
+  },
+  "orion/spark/signal_mapper.py": {
+    "mtime": 1767676515.6361067,
+    "ast_hash": "1c0351d5869383b666a856f6d90ff908",
+    "semantic_hash": "1c0351d5869383b666a856f6d90ff908"
+  },
+  "orion/spark/surface_encoding.py": {
+    "mtime": 1767676515.6361067,
+    "ast_hash": "32614a06d405ca68899c33010337dec6",
+    "semantic_hash": "32614a06d405ca68899c33010337dec6"
+  },
+  "orion/spark/telemetry/__init__.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/spark/telemetry/spark.py": {
+    "mtime": 1769663878.093563,
+    "ast_hash": "e75972f3b423d02129e0c0876350ab0a",
+    "semantic_hash": "e75972f3b423d02129e0c0876350ab0a"
+  },
+  "orion/substrate/__init__.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "ba932a21a999e38c45685316c4644352",
+    "semantic_hash": "ba932a21a999e38c45685316c4644352"
+  },
+  "orion/substrate/activation.py": {
+    "mtime": 1783614403.6902757,
+    "ast_hash": "f4130e7ec22218b8eed87f41bab18f53",
+    "semantic_hash": "f4130e7ec22218b8eed87f41bab18f53"
+  },
+  "orion/substrate/adapters/__init__.py": {
+    "mtime": 1775601136.3188965,
+    "ast_hash": "56323bc3ea730e74319040d8e221d617",
+    "semantic_hash": "56323bc3ea730e74319040d8e221d617"
+  },
+  "orion/substrate/adapters/_common.py": {
+    "mtime": 1775601136.3188965,
+    "ast_hash": "c878075334493d34259a7c7973e254aa",
+    "semantic_hash": "c878075334493d34259a7c7973e254aa"
+  },
+  "orion/substrate/adapters/autonomy.py": {
+    "mtime": 1783986358.1006565,
+    "ast_hash": "3e23fce92935f5fc0dc800774fb0d24e",
+    "semantic_hash": "3e23fce92935f5fc0dc800774fb0d24e"
+  },
+  "orion/substrate/adapters/concept_induction.py": {
+    "mtime": 1775601136.3188965,
+    "ast_hash": "ca68f552f347e37c4c1ffb16aa66ad6e",
+    "semantic_hash": "ca68f552f347e37c4c1ffb16aa66ad6e"
+  },
+  "orion/substrate/adapters/spark.py": {
+    "mtime": 1775601136.3188965,
+    "ast_hash": "cc9d720fc0193ad7e3a0dfd2abf0facc",
+    "semantic_hash": "cc9d720fc0193ad7e3a0dfd2abf0facc"
+  },
+  "orion/substrate/appraisal/__init__.py": {
+    "mtime": 1783125791.0180876,
+    "ast_hash": "b16992e983e35c3fbed84e2b183eab60",
+    "semantic_hash": "b16992e983e35c3fbed84e2b183eab60"
+  },
+  "orion/substrate/appraisal/contract.py": {
+    "mtime": 1783125791.0190876,
+    "ast_hash": "0568e7a1daaf4b383ac9f89c82e9bd55",
+    "semantic_hash": "0568e7a1daaf4b383ac9f89c82e9bd55"
+  },
+  "orion/substrate/appraisal/evidence.py": {
+    "mtime": 1779649387.7992988,
+    "ast_hash": "989f958b32c76acab334ffe944686294",
+    "semantic_hash": "989f958b32c76acab334ffe944686294"
+  },
+  "orion/substrate/appraisal/finalize_draft_v1.py": {
+    "mtime": 1783291410.0217016,
+    "ast_hash": "766f1d1539fd2377f5aa0124369330cf",
+    "semantic_hash": "766f1d1539fd2377f5aa0124369330cf"
+  },
+  "orion/substrate/appraisal/models.py": {
+    "mtime": 1783125791.0190876,
+    "ast_hash": "2a777dc81b1b9480ed107df93744e742",
+    "semantic_hash": "2a777dc81b1b9480ed107df93744e742"
+  },
+  "orion/substrate/appraisal/paradigms/__init__.py": {
+    "mtime": 1783125791.0190876,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/substrate/appraisal/paradigms/base.py": {
+    "mtime": 1783125791.0190876,
+    "ast_hash": "97f07593c023f94957afe218c847080f",
+    "semantic_hash": "97f07593c023f94957afe218c847080f"
+  },
+  "orion/substrate/appraisal/paradigms/registry.py": {
+    "mtime": 1783125791.0190876,
+    "ast_hash": "683ed572b0fd7294ec384a40cc8728b8",
+    "semantic_hash": "683ed572b0fd7294ec384a40cc8728b8"
+  },
+  "orion/substrate/appraisal/paradigms/repair_pressure_v2.py": {
+    "mtime": 1783136738.0538802,
+    "ast_hash": "854c1ffa3db628d2e47039828dec6d92",
+    "semantic_hash": "854c1ffa3db628d2e47039828dec6d92"
+  },
+  "orion/substrate/appraisal/probe/__init__.py": {
+    "mtime": 1783125791.0190876,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/substrate/appraisal/probe/logprob_runner.py": {
+    "mtime": 1783136738.0538802,
+    "ast_hash": "0c45aa3697dfb3b76d6ed8d66587e4da",
+    "semantic_hash": "0c45aa3697dfb3b76d6ed8d66587e4da"
+  },
+  "orion/substrate/appraisal/repair_pressure.py": {
+    "mtime": 1779649387.7992988,
+    "ast_hash": "75a0c6a34e856573eedadd7970de6e81",
+    "semantic_hash": "75a0c6a34e856573eedadd7970de6e81"
+  },
+  "orion/substrate/appraisal/signal_bridge.py": {
+    "mtime": 1779649387.7992988,
+    "ast_hash": "0ec9461171c2a53cc1dfe3d1474dc86b",
+    "semantic_hash": "0ec9461171c2a53cc1dfe3d1474dc86b"
+  },
+  "orion/substrate/appraisal/tests/test_finalize_draft_v1.py": {
+    "mtime": 1783291410.0217016,
+    "ast_hash": "2d34ca24c9c4db55974605e08810f019",
+    "semantic_hash": "2d34ca24c9c4db55974605e08810f019"
+  },
+  "orion/substrate/appraisal/turn_window.py": {
+    "mtime": 1783125791.0190876,
+    "ast_hash": "2809894a93442260e15bd9d7b448fc41",
+    "semantic_hash": "2809894a93442260e15bd9d7b448fc41"
+  },
+  "orion/substrate/appraisal/view_model.py": {
+    "mtime": 1779649387.7992988,
+    "ast_hash": "aebaf6514ef5d6760b91a7e54e5eca69",
+    "semantic_hash": "aebaf6514ef5d6760b91a7e54e5eca69"
+  },
+  "orion/substrate/appraisal/windowing.py": {
+    "mtime": 1779649387.7992988,
+    "ast_hash": "d1f1e7f467ad14792ebf137e3c3632d6",
+    "semantic_hash": "d1f1e7f467ad14792ebf137e3c3632d6"
+  },
+  "orion/substrate/attention/__init__.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "9405b6ec447a4d09aacf823e94bcf3e5",
+    "semantic_hash": "9405b6ec447a4d09aacf823e94bcf3e5"
+  },
+  "orion/substrate/attention/common.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "3fedfbe6ce3760a873119c80b40fedf0",
+    "semantic_hash": "3fedfbe6ce3760a873119c80b40fedf0"
+  },
+  "orion/substrate/attention/detectors/__init__.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "b6b9f69551e949af6f9b8cb275faa86b",
+    "semantic_hash": "b6b9f69551e949af6f9b8cb275faa86b"
+  },
+  "orion/substrate/attention/detectors/autonomy.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "d5dc5b294772f162490d0cb740192574",
+    "semantic_hash": "d5dc5b294772f162490d0cb740192574"
+  },
+  "orion/substrate/attention/detectors/base.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "0265936f3fe290d91803586b3a4b8025",
+    "semantic_hash": "0265936f3fe290d91803586b3a4b8025"
+  },
+  "orion/substrate/attention/detectors/concept_induction.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "f9afad12d45b2afd23123d927b46af9b",
+    "semantic_hash": "f9afad12d45b2afd23123d927b46af9b"
+  },
+  "orion/substrate/attention/detectors/current_turn.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "7f2fcc0ce06c2b95141ae2b488e84571",
+    "semantic_hash": "7f2fcc0ce06c2b95141ae2b488e84571"
+  },
+  "orion/substrate/attention/detectors/legacy_regex.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "83829cd432ffd73fcbf45b3d339578a0",
+    "semantic_hash": "83829cd432ffd73fcbf45b3d339578a0"
+  },
+  "orion/substrate/attention/detectors/situation.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "17c30a4d8929eafe0cf164d4050a4fe9",
+    "semantic_hash": "17c30a4d8929eafe0cf164d4050a4fe9"
+  },
+  "orion/substrate/attention/evals/__init__.py": {
+    "mtime": 1783499830.193521,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/substrate/attention/evals/run_topdown_eval.py": {
+    "mtime": 1783499830.193521,
+    "ast_hash": "6ddb3e1a44c66abba14ef0baa95cef94",
+    "semantic_hash": "6ddb3e1a44c66abba14ef0baa95cef94"
+  },
+  "orion/substrate/attention/goal_context.py": {
+    "mtime": 1783499830.193521,
+    "ast_hash": "c00d936ee092297bb60255d51fd5aa6c",
+    "semantic_hash": "c00d936ee092297bb60255d51fd5aa6c"
+  },
+  "orion/substrate/attention/policy.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "0a6b85f9b56bffdf945d4e9081af2345",
+    "semantic_hash": "0a6b85f9b56bffdf945d4e9081af2345"
+  },
+  "orion/substrate/attention/questions.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "c2a71c2565dfc8c7f11f223966454389",
+    "semantic_hash": "c2a71c2565dfc8c7f11f223966454389"
+  },
+  "orion/substrate/attention/salience.py": {
+    "mtime": 1783447063.25237,
+    "ast_hash": "5b8f756326082a60a51c99997f800714",
+    "semantic_hash": "5b8f756326082a60a51c99997f800714"
+  },
+  "orion/substrate/attention/scoring.py": {
+    "mtime": 1783447063.25237,
+    "ast_hash": "331082805f5cf8eaf39737f114d4d72f",
+    "semantic_hash": "331082805f5cf8eaf39737f114d4d72f"
+  },
+  "orion/substrate/attention/top_down.py": {
+    "mtime": 1783499830.193521,
+    "ast_hash": "bd2ff3f6499683465a661349660fc629",
+    "semantic_hash": "bd2ff3f6499683465a661349660fc629"
+  },
+  "orion/substrate/attention_broadcast.py": {
+    "mtime": 1783499830.194521,
+    "ast_hash": "89a2440662bdd226aad602c870575527",
+    "semantic_hash": "89a2440662bdd226aad602c870575527"
+  },
+  "orion/substrate/attention_frame.py": {
+    "mtime": 1778901838.3683949,
+    "ast_hash": "a13ed0402cbef87124a067a4501315da",
+    "semantic_hash": "a13ed0402cbef87124a067a4501315da"
+  },
+  "orion/substrate/biometrics_loop/__init__.py": {
+    "mtime": 1779668252.1390116,
+    "ast_hash": "104f73dc7d2d636ba18b2e9d9c790c35",
+    "semantic_hash": "104f73dc7d2d636ba18b2e9d9c790c35"
+  },
+  "orion/substrate/biometrics_loop/candidate_events.py": {
+    "mtime": 1779668252.1390116,
+    "ast_hash": "95b04b47fa5436c3ba3a4b43097534f0",
+    "semantic_hash": "95b04b47fa5436c3ba3a4b43097534f0"
+  },
+  "orion/substrate/biometrics_loop/constants.py": {
+    "mtime": 1779668252.1390116,
+    "ast_hash": "8e604019d2815b035ad84b580b5d4e9e",
+    "semantic_hash": "8e604019d2815b035ad84b580b5d4e9e"
+  },
+  "orion/substrate/biometrics_loop/emission_validator.py": {
+    "mtime": 1779668252.1400118,
+    "ast_hash": "de2ea01d924bde07e4e6941952d6e3fd",
+    "semantic_hash": "de2ea01d924bde07e4e6941952d6e3fd"
+  },
+  "orion/substrate/biometrics_loop/grammar_extract.py": {
+    "mtime": 1779668252.1400118,
+    "ast_hash": "80deccd98699561e9069509da43219d6",
+    "semantic_hash": "80deccd98699561e9069509da43219d6"
+  },
+  "orion/substrate/biometrics_loop/ids.py": {
+    "mtime": 1779668252.1400118,
+    "ast_hash": "9f599b1ecbc2140f9ad48d4c9ee51a45",
+    "semantic_hash": "9f599b1ecbc2140f9ad48d4c9ee51a45"
+  },
+  "orion/substrate/biometrics_loop/lineage.py": {
+    "mtime": 1779668837.6843047,
+    "ast_hash": "d49d75496c572e9f534dcce867a258ee",
+    "semantic_hash": "d49d75496c572e9f534dcce867a258ee"
+  },
+  "orion/substrate/biometrics_loop/node_reducer.py": {
+    "mtime": 1781772134.802745,
+    "ast_hash": "cd1d888029c53f58e43686ac504683d9",
+    "semantic_hash": "cd1d888029c53f58e43686ac504683d9"
+  },
+  "orion/substrate/biometrics_loop/pipeline.py": {
+    "mtime": 1782185238.9397068,
+    "ast_hash": "6287dc7687daedd28c58418cfd5c1b2f",
+    "semantic_hash": "6287dc7687daedd28c58418cfd5c1b2f"
+  },
+  "orion/substrate/biometrics_loop/pressure_organ.py": {
+    "mtime": 1779668252.1400118,
+    "ast_hash": "da836ce1862330a9b94f95152ad4fdca",
+    "semantic_hash": "da836ce1862330a9b94f95152ad4fdca"
+  },
+  "orion/substrate/biometrics_loop/pressure_reducer.py": {
+    "mtime": 1781845427.7736762,
+    "ast_hash": "73ad46e3f2aa81ef0d2e38cabb7858bc",
+    "semantic_hash": "73ad46e3f2aa81ef0d2e38cabb7858bc"
+  },
+  "orion/substrate/chat_loop/__init__.py": {
+    "mtime": 1781897477.5810869,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/substrate/chat_loop/constants.py": {
+    "mtime": 1781897477.5810869,
+    "ast_hash": "570901379c9ed857c1d4451d44338f8f",
+    "semantic_hash": "570901379c9ed857c1d4451d44338f8f"
+  },
+  "orion/substrate/chat_loop/grammar_extract.py": {
+    "mtime": 1783908076.952645,
+    "ast_hash": "a0f71a258392ea9caf64d8d9d71187bb",
+    "semantic_hash": "a0f71a258392ea9caf64d8d9d71187bb"
+  },
+  "orion/substrate/chat_loop/pipeline.py": {
+    "mtime": 1781897477.5810869,
+    "ast_hash": "dfc46e2a1b09f62bab62f4adceda1e3d",
+    "semantic_hash": "dfc46e2a1b09f62bab62f4adceda1e3d"
+  },
+  "orion/substrate/chat_loop/reducer.py": {
+    "mtime": 1781897477.5810869,
+    "ast_hash": "219710230fb5183d34e7d23a3b8b654b",
+    "semantic_hash": "219710230fb5183d34e7d23a3b8b654b"
+  },
+  "orion/substrate/consolidation.py": {
+    "mtime": 1775634425.3992527,
+    "ast_hash": "95ad42979d13c27a3f52a03fd3751009",
+    "semantic_hash": "95ad42979d13c27a3f52a03fd3751009"
+  },
+  "orion/substrate/dynamics.py": {
+    "mtime": 1782528981.5940208,
+    "ast_hash": "94a6657c561c7d525197d79f494ca788",
+    "semantic_hash": "94a6657c561c7d525197d79f494ca788"
+  },
+  "orion/substrate/endogenous_curiosity.py": {
+    "mtime": 1783807362.259771,
+    "ast_hash": "d74607683c17c8e8786b259511486e7b",
+    "semantic_hash": "d74607683c17c8e8786b259511486e7b"
+  },
+  "orion/substrate/episodic_consolidation.py": {
+    "mtime": 1782955647.2164185,
+    "ast_hash": "359e88f851db3f9e6b4c32ac13679e5c",
+    "semantic_hash": "359e88f851db3f9e6b4c32ac13679e5c"
+  },
+  "orion/substrate/evals/fixtures/repair_pressure/grounding_negative.json": {
+    "mtime": 1783125791.0190876,
+    "ast_hash": "c3817ed039d6125746e246e94e4f5a4f",
+    "semantic_hash": "c3817ed039d6125746e246e94e4f5a4f"
+  },
+  "orion/substrate/evals/fixtures/repair_pressure/neutral.json": {
+    "mtime": 1783125791.0200877,
+    "ast_hash": "ad298b800606ee7164e96d39ef335d0b",
+    "semantic_hash": "ad298b800606ee7164e96d39ef335d0b"
+  },
+  "orion/substrate/evals/fixtures/repair_pressure/ops_frustration_positive.json": {
+    "mtime": 1783125791.0200877,
+    "ast_hash": "fdf502c536be03e0309ac23907c75a7c",
+    "semantic_hash": "fdf502c536be03e0309ac23907c75a7c"
+  },
+  "orion/substrate/evals/repair_pressure_v2_eval.py": {
+    "mtime": 1783125791.0200877,
+    "ast_hash": "e7c41ab78d9b8223fe84d89d991025d6",
+    "semantic_hash": "e7c41ab78d9b8223fe84d89d991025d6"
+  },
+  "orion/substrate/execution_loop/__init__.py": {
+    "mtime": 1779677734.9994545,
+    "ast_hash": "9cd93822acf6e091f4301bc6a8da1823",
+    "semantic_hash": "9cd93822acf6e091f4301bc6a8da1823"
+  },
+  "orion/substrate/execution_loop/constants.py": {
+    "mtime": 1783622541.3515248,
+    "ast_hash": "26b18fd748c5941d2fccdfc03591dc29",
+    "semantic_hash": "26b18fd748c5941d2fccdfc03591dc29"
+  },
+  "orion/substrate/execution_loop/grammar_extract.py": {
+    "mtime": 1783564192.735144,
+    "ast_hash": "b388eed3107b7565dfd3e147aaa66602",
+    "semantic_hash": "b388eed3107b7565dfd3e147aaa66602"
+  },
+  "orion/substrate/execution_loop/ids.py": {
+    "mtime": 1783566259.2639368,
+    "ast_hash": "ba403991c9e09227a9b7a848b6a26583",
+    "semantic_hash": "ba403991c9e09227a9b7a848b6a26583"
+  },
+  "orion/substrate/execution_loop/merge.py": {
+    "mtime": 1781852203.1065342,
+    "ast_hash": "bcca3956d2845148fe1cd490ff5d91bd",
+    "semantic_hash": "bcca3956d2845148fe1cd490ff5d91bd"
+  },
+  "orion/substrate/execution_loop/pipeline.py": {
+    "mtime": 1783622541.3515248,
+    "ast_hash": "5f170dce249f82e4893a69494d3444f1",
+    "semantic_hash": "5f170dce249f82e4893a69494d3444f1"
+  },
+  "orion/substrate/execution_loop/projection.py": {
+    "mtime": 1779677734.9994545,
+    "ast_hash": "bcf8130058fe53e2ed515f75b328df3e",
+    "semantic_hash": "bcf8130058fe53e2ed515f75b328df3e"
+  },
+  "orion/substrate/execution_loop/reducer.py": {
+    "mtime": 1783622541.3515248,
+    "ast_hash": "752dfb7e68b2a71586401b56fbdc0ab9",
+    "semantic_hash": "752dfb7e68b2a71586401b56fbdc0ab9"
+  },
+  "orion/substrate/experiment/__init__.py": {
+    "mtime": 1779649387.7992988,
+    "ast_hash": "5e349dabdf067177ffe66eb9ad8cebab",
+    "semantic_hash": "5e349dabdf067177ffe66eb9ad8cebab"
+  },
+  "orion/substrate/experiment/daily_rollup.py": {
+    "mtime": 1779649387.7992988,
+    "ast_hash": "2b21d121aa2d39af3564cdefb1f2a4a5",
+    "semantic_hash": "2b21d121aa2d39af3564cdefb1f2a4a5"
+  },
+  "orion/substrate/experiment/harness.py": {
+    "mtime": 1779649387.7992988,
+    "ast_hash": "741c7939d772ff94deffb127961a587b",
+    "semantic_hash": "741c7939d772ff94deffb127961a587b"
+  },
+  "orion/substrate/experiment/metrics.py": {
+    "mtime": 1779649387.7992988,
+    "ast_hash": "ed7b8cdb33ff7d4498d5527ec56c19e9",
+    "semantic_hash": "ed7b8cdb33ff7d4498d5527ec56c19e9"
+  },
+  "orion/substrate/experiment/report.py": {
+    "mtime": 1779649387.800299,
+    "ast_hash": "0ac45e5a9fb72e8a413119d078fd9d08",
+    "semantic_hash": "0ac45e5a9fb72e8a413119d078fd9d08"
+  },
+  "orion/substrate/experiments/__init__.py": {
+    "mtime": 1780122273.490206,
+    "ast_hash": "3d3de7f8f1f7d2262a868e3795b11862",
+    "semantic_hash": "3d3de7f8f1f7d2262a868e3795b11862"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/__init__.py": {
+    "mtime": 1780122273.4912062,
+    "ast_hash": "c565a8108cbbd5fd13458beda98fe3df",
+    "semantic_hash": "c565a8108cbbd5fd13458beda98fe3df"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/cache_fineweb_edu.py": {
+    "mtime": 1780594546.644881,
+    "ast_hash": "157138c7a779fd200386af81b17e064c",
+    "semantic_hash": "157138c7a779fd200386af81b17e064c"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/config.py": {
+    "mtime": 1780595246.331919,
+    "ast_hash": "8e45e3c889363a58bae000beb880c684",
+    "semantic_hash": "8e45e3c889363a58bae000beb880c684"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/data.py": {
+    "mtime": 1780594546.644881,
+    "ast_hash": "9b82ea5b111e9b1db033d3be680595f5",
+    "semantic_hash": "9b82ea5b111e9b1db033d3be680595f5"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/generate.py": {
+    "mtime": 1780122273.4912062,
+    "ast_hash": "b29e9f6d63ac466cf3008a4074455ded",
+    "semantic_hash": "b29e9f6d63ac466cf3008a4074455ded"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/generate_moc.py": {
+    "mtime": 1780595246.331919,
+    "ast_hash": "0a65e330923351cbdfdceba219d8d2d7",
+    "semantic_hash": "0a65e330923351cbdfdceba219d8d2d7"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/generate_v2.py": {
+    "mtime": 1780595246.3169188,
+    "ast_hash": "126718f321e695f3f8e3213dbd6c172a",
+    "semantic_hash": "126718f321e695f3f8e3213dbd6c172a"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/hyperbolic.py": {
+    "mtime": 1780595246.3169188,
+    "ast_hash": "9077e234d648212c59a9ba7a0835e2a2",
+    "semantic_hash": "9077e234d648212c59a9ba7a0835e2a2"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/manifold_metrics.py": {
+    "mtime": 1780595246.3169188,
+    "ast_hash": "e4b4cd1354f4c6e63fff06c3604dd492",
+    "semantic_hash": "e4b4cd1354f4c6e63fff06c3604dd492"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/moc_patch.py": {
+    "mtime": 1780594546.6458812,
+    "ast_hash": "093d6b6dda1e1b335fd704bd1bddc7a8",
+    "semantic_hash": "093d6b6dda1e1b335fd704bd1bddc7a8"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/model.py": {
+    "mtime": 1780179103.9457953,
+    "ast_hash": "b889d7b8031f34e06885f0443c4c709a",
+    "semantic_hash": "b889d7b8031f34e06885f0443c4c709a"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/model_moc.py": {
+    "mtime": 1780180394.5422373,
+    "ast_hash": "abff5921a34b9e3266acf1c7583c4d88",
+    "semantic_hash": "abff5921a34b9e3266acf1c7583c4d88"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/model_v2.py": {
+    "mtime": 1780595246.3169188,
+    "ast_hash": "4282c7a09b29e34eec844db23de02770",
+    "semantic_hash": "4282c7a09b29e34eec844db23de02770"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/cache_fineweb_edu_sample.sh": {
+    "mtime": 1780594546.6458812,
+    "ast_hash": "cb7e1d8bf31c92f4e4f33f099ec3917a",
+    "semantic_hash": "cb7e1d8bf31c92f4e4f33f099ec3917a"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/generate_moc_sample.sh": {
+    "mtime": 1780180394.5422373,
+    "ast_hash": "2b083307a3d2aace96fe5b382ad2f3cd",
+    "semantic_hash": "2b083307a3d2aace96fe5b382ad2f3cd"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/generate_sample.sh": {
+    "mtime": 1780122273.492206,
+    "ast_hash": "b92d7f36512ab24587401a0db8b3542c",
+    "semantic_hash": "b92d7f36512ab24587401a0db8b3542c"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/smoke_test.sh": {
+    "mtime": 1780122273.492206,
+    "ast_hash": "8c3e6fe1413abd2c87a27eb4df8e09d4",
+    "semantic_hash": "8c3e6fe1413abd2c87a27eb4df8e09d4"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/smoke_test_moc.sh": {
+    "mtime": 1780180394.5422373,
+    "ast_hash": "6a2a095dab56850d477550c2c079dffa",
+    "semantic_hash": "6a2a095dab56850d477550c2c079dffa"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/smoke_test_v2.sh": {
+    "mtime": 1780179107.838783,
+    "ast_hash": "e98f5bbd30c30ed799209d04354d1254",
+    "semantic_hash": "e98f5bbd30c30ed799209d04354d1254"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/train_fineweb_edu_text_12l_768d.sh": {
+    "mtime": 1780594546.6458812,
+    "ast_hash": "f4648610cb9fce6231d12b3ef5dba1e4",
+    "semantic_hash": "f4648610cb9fce6231d12b3ef5dba1e4"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/train_moc_fineweb_edu_12l_768d.sh": {
+    "mtime": 1780594546.6458812,
+    "ast_hash": "a796b9b7bc4eedc6ef945e3c595f3bd2",
+    "semantic_hash": "a796b9b7bc4eedc6ef945e3c595f3bd2"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/train_moc_tinystories_12l_768d.sh": {
+    "mtime": 1780180394.5422373,
+    "ast_hash": "b239259286c74a26cc11371fe1894c21",
+    "semantic_hash": "b239259286c74a26cc11371fe1894c21"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/train_tinystories.sh": {
+    "mtime": 1780122273.492206,
+    "ast_hash": "55b0f6eb85b134f8ea6143cfea89070e",
+    "semantic_hash": "55b0f6eb85b134f8ea6143cfea89070e"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/train_v2_fineweb_edu_12l_768d.sh": {
+    "mtime": 1780594546.6458812,
+    "ast_hash": "e172380b1ad7612ef5d8f44e30996f3c",
+    "semantic_hash": "e172380b1ad7612ef5d8f44e30996f3c"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/scripts/train_v2_tinystories.sh": {
+    "mtime": 1780595246.3169188,
+    "ast_hash": "3ed48501aba47ef1d15ff499792471f6",
+    "semantic_hash": "3ed48501aba47ef1d15ff499792471f6"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/smoke_test.py": {
+    "mtime": 1780122273.492206,
+    "ast_hash": "ee5ff63aa24871dd6c0b15f8d87bb194",
+    "semantic_hash": "ee5ff63aa24871dd6c0b15f8d87bb194"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/smoke_test_moc.py": {
+    "mtime": 1780180394.5422373,
+    "ast_hash": "4aff0545113e52f757f1e39339c3a9d0",
+    "semantic_hash": "4aff0545113e52f757f1e39339c3a9d0"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/smoke_test_v2.py": {
+    "mtime": 1780595246.3169188,
+    "ast_hash": "c4cbfb7a508b252ca237da9c300377f1",
+    "semantic_hash": "c4cbfb7a508b252ca237da9c300377f1"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/train.py": {
+    "mtime": 1780179103.9457953,
+    "ast_hash": "99b38cab2be86c65ae5ce4fe5340fb6a",
+    "semantic_hash": "99b38cab2be86c65ae5ce4fe5340fb6a"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/train_moc.py": {
+    "mtime": 1780595246.332919,
+    "ast_hash": "c8a0f19282965fcbcdeae5030e3e6970",
+    "semantic_hash": "c8a0f19282965fcbcdeae5030e3e6970"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/train_v2.py": {
+    "mtime": 1780595246.317919,
+    "ast_hash": "94ba52cda7bc7a308fb8f9df0ce4cdca",
+    "semantic_hash": "94ba52cda7bc7a308fb8f9df0ce4cdca"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/train_v3_moc.py": {
+    "mtime": 1780594546.646881,
+    "ast_hash": "d7e0aaca278554a2f6685959af379563",
+    "semantic_hash": "d7e0aaca278554a2f6685959af379563"
+  },
+  "orion/substrate/felt_state_reader.py": {
+    "mtime": 1783903398.6404438,
+    "ast_hash": "35dee24009e1e21927453cc8170a965b",
+    "semantic_hash": "35dee24009e1e21927453cc8170a965b"
+  },
+  "orion/substrate/frontier_context.py": {
+    "mtime": 1775613610.4144464,
+    "ast_hash": "3e14814122566737a3ba532b9f4cf226",
+    "semantic_hash": "3e14814122566737a3ba532b9f4cf226"
+  },
+  "orion/substrate/frontier_curiosity.py": {
+    "mtime": 1782955647.2174184,
+    "ast_hash": "033e70b3395e5b7cd7228d5e39c29eeb",
+    "semantic_hash": "033e70b3395e5b7cd7228d5e39c29eeb"
+  },
+  "orion/substrate/frontier_expansion.py": {
+    "mtime": 1775613610.4154463,
+    "ast_hash": "54e13ae85ec3a8844597db581d4c26b4",
+    "semantic_hash": "54e13ae85ec3a8844597db581d4c26b4"
+  },
+  "orion/substrate/frontier_landing.py": {
+    "mtime": 1775613610.4154463,
+    "ast_hash": "3b456b66a33af1df58ffec978493abbf",
+    "semantic_hash": "3b456b66a33af1df58ffec978493abbf"
+  },
+  "orion/substrate/frontier_mapper.py": {
+    "mtime": 1775613610.4154463,
+    "ast_hash": "fc61d79918f2b0037e2a4cb93924986a",
+    "semantic_hash": "fc61d79918f2b0037e2a4cb93924986a"
+  },
+  "orion/substrate/graphdb_store.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "d803a88581459fa7b46c609923a90760",
+    "semantic_hash": "d803a88581459fa7b46c609923a90760"
+  },
+  "orion/substrate/ids.py": {
+    "mtime": 1783402731.2993197,
+    "ast_hash": "a37f66125cad5b9a8456c0d9a3c4027a",
+    "semantic_hash": "a37f66125cad5b9a8456c0d9a3c4027a"
+  },
+  "orion/substrate/materializer.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "839a5f65315aa713358b16a73273148c",
+    "semantic_hash": "839a5f65315aa713358b16a73273148c"
+  },
+  "orion/substrate/metacog_trigger_signals.py": {
+    "mtime": 1783107031.9699016,
+    "ast_hash": "df25ee091845a9b6a22556da1cb577fa",
+    "semantic_hash": "df25ee091845a9b6a22556da1cb577fa"
+  },
+  "orion/substrate/molecule_store.py": {
+    "mtime": 1779649387.800299,
+    "ast_hash": "65bfc329b337e4195247ceec05d73f34",
+    "semantic_hash": "65bfc329b337e4195247ceec05d73f34"
+  },
+  "orion/substrate/molecules.py": {
+    "mtime": 1779649387.800299,
+    "ast_hash": "3d76be29b69c1e961c35bbe8906f0295",
+    "semantic_hash": "3d76be29b69c1e961c35bbe8906f0295"
+  },
+  "orion/substrate/mutation_apply.py": {
+    "mtime": 1777157048.1319087,
+    "ast_hash": "4b231a10f5b4f72677d85178fb12f4e3",
+    "semantic_hash": "4b231a10f5b4f72677d85178fb12f4e3"
+  },
+  "orion/substrate/mutation_contracts.py": {
+    "mtime": 1777158162.3682656,
+    "ast_hash": "5b788d85d9feaa47a9509f1fd1a67749",
+    "semantic_hash": "5b788d85d9feaa47a9509f1fd1a67749"
+  },
+  "orion/substrate/mutation_control_surface.py": {
+    "mtime": 1777145224.9362612,
+    "ast_hash": "ff2f0cf9bd169f2135f19b9e50127ade",
+    "semantic_hash": "ff2f0cf9bd169f2135f19b9e50127ade"
+  },
+  "orion/substrate/mutation_decision.py": {
+    "mtime": 1779328788.9587867,
+    "ast_hash": "af5788976a0053ae9a1cb33c61158a67",
+    "semantic_hash": "af5788976a0053ae9a1cb33c61158a67"
+  },
+  "orion/substrate/mutation_detectors.py": {
+    "mtime": 1777157502.1337283,
+    "ast_hash": "351ea9a333a6305959c6ba5487a931aa",
+    "semantic_hash": "351ea9a333a6305959c6ba5487a931aa"
+  },
+  "orion/substrate/mutation_monitor.py": {
+    "mtime": 1777096641.4101894,
+    "ast_hash": "fca8c4cf91bf3a0609d8efca3731d2f3",
+    "semantic_hash": "fca8c4cf91bf3a0609d8efca3731d2f3"
+  },
+  "orion/substrate/mutation_pressure.py": {
+    "mtime": 1777157485.429743,
+    "ast_hash": "5de9f8aa98331dbd627f28c8c76a36e7",
+    "semantic_hash": "5de9f8aa98331dbd627f28c8c76a36e7"
+  },
+  "orion/substrate/mutation_proposals.py": {
+    "mtime": 1777158147.7612743,
+    "ast_hash": "e003d705a74ba8d56ffb56d2df2085df",
+    "semantic_hash": "e003d705a74ba8d56ffb56d2df2085df"
+  },
+  "orion/substrate/mutation_queue.py": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "7da30932796777bbc3a9d5765307e6d5",
+    "semantic_hash": "7da30932796777bbc3a9d5765307e6d5"
+  },
+  "orion/substrate/mutation_scoring.py": {
+    "mtime": 1777096607.8302643,
+    "ast_hash": "a53ac2164481b49fa06f98e29b412062",
+    "semantic_hash": "a53ac2164481b49fa06f98e29b412062"
+  },
+  "orion/substrate/mutation_self_revision.py": {
+    "mtime": 1782868429.846242,
+    "ast_hash": "15a272ded1ac99cffcaa4d5838f66d75",
+    "semantic_hash": "15a272ded1ac99cffcaa4d5838f66d75"
+  },
+  "orion/substrate/mutation_trials.py": {
+    "mtime": 1777146763.8002646,
+    "ast_hash": "3822eccb1863d2fdf8a75f83d602628b",
+    "semantic_hash": "3822eccb1863d2fdf8a75f83d602628b"
+  },
+  "orion/substrate/mutation_worker.py": {
+    "mtime": 1783125791.0200877,
+    "ast_hash": "d110972d10bde28260f7fce27043fbda",
+    "semantic_hash": "d110972d10bde28260f7fce27043fbda"
+  },
+  "orion/substrate/operators.py": {
+    "mtime": 1779649387.800299,
+    "ast_hash": "9fa4699f9507d6bb594fa6c15fdd84f2",
+    "semantic_hash": "9fa4699f9507d6bb594fa6c15fdd84f2"
+  },
+  "orion/substrate/policy_comparison.py": {
+    "mtime": 1775634425.4002526,
+    "ast_hash": "7ab6780dba31054d979a7b59bcf2bb07",
+    "semantic_hash": "7ab6780dba31054d979a7b59bcf2bb07"
+  },
+  "orion/substrate/policy_profiles.py": {
+    "mtime": 1775953911.198072,
+    "ast_hash": "d7bb9dbd86d93b5b6ce3c39bf5320268",
+    "semantic_hash": "d7bb9dbd86d93b5b6ce3c39bf5320268"
+  },
+  "orion/substrate/prediction_error.py": {
+    "mtime": 1782438858.702639,
+    "ast_hash": "129ef0271c57416e061e52d88d64dbcf",
+    "semantic_hash": "129ef0271c57416e061e52d88d64dbcf"
+  },
+  "orion/substrate/pressure.py": {
+    "mtime": 1782528981.5940208,
+    "ast_hash": "14b21817fdd475b24854e3f997ac7cb8",
+    "semantic_hash": "14b21817fdd475b24854e3f997ac7cb8"
+  },
+  "orion/substrate/query_planning.py": {
+    "mtime": 1775634425.4002526,
+    "ast_hash": "b3aca019e880609c3a8576d59162804b",
+    "semantic_hash": "b3aca019e880609c3a8576d59162804b"
+  },
+  "orion/substrate/recall_eval_bridge.py": {
+    "mtime": 1777158143.105277,
+    "ast_hash": "673e1d8e9f01dc7dcee0c69642cf08bb",
+    "semantic_hash": "673e1d8e9f01dc7dcee0c69642cf08bb"
+  },
+  "orion/substrate/recall_strategy_readiness.py": {
+    "mtime": 1777158249.7502148,
+    "ast_hash": "fa10e352699da787e3be5feca8fb4c42",
+    "semantic_hash": "fa10e352699da787e3be5feca8fb4c42"
+  },
+  "orion/substrate/receipts/__init__.py": {
+    "mtime": 1780106291.7457774,
+    "ast_hash": "dc53630c9eb7ed69ffd4ffc1eb41d855",
+    "semantic_hash": "dc53630c9eb7ed69ffd4ffc1eb41d855"
+  },
+  "orion/substrate/receipts/retention.py": {
+    "mtime": 1780613748.712424,
+    "ast_hash": "5b8fdbae1aabf6f1d9bebc9709dc11af",
+    "semantic_hash": "5b8fdbae1aabf6f1d9bebc9709dc11af"
+  },
+  "orion/substrate/reconcile.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "bbbbec3408cc320f65c1cfcda4b7cb47",
+    "semantic_hash": "bbbbec3408cc320f65c1cfcda4b7cb47"
+  },
+  "orion/substrate/relational/__init__.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "2720380e5f6081b319a50367fff226be",
+    "semantic_hash": "2720380e5f6081b319a50367fff226be"
+  },
+  "orion/substrate/relational/adapters/__init__.py": {
+    "mtime": 1783450708.6427279,
+    "ast_hash": "3c96a4921eb2fdc4039a9a11a7c3a37c",
+    "semantic_hash": "3c96a4921eb2fdc4039a9a11a7c3a37c"
+  },
+  "orion/substrate/relational/adapters/attention_ctx.py": {
+    "mtime": 1782964832.6336591,
+    "ast_hash": "4980300f0963c91259a09d2c7a1bdc2c",
+    "semantic_hash": "4980300f0963c91259a09d2c7a1bdc2c"
+  },
+  "orion/substrate/relational/adapters/autonomy_ctx.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "aced12b1b67600248aa5764775ad897c",
+    "semantic_hash": "aced12b1b67600248aa5764775ad897c"
+  },
+  "orion/substrate/relational/adapters/biometrics_ctx.py": {
+    "mtime": 1782871399.0077329,
+    "ast_hash": "1ba155788afbf1cccc063eb094af4f99",
+    "semantic_hash": "1ba155788afbf1cccc063eb094af4f99"
+  },
+  "orion/substrate/relational/adapters/concept_induction_ctx.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "073c3d029cb8db2ef77e4b8adeb27e38",
+    "semantic_hash": "073c3d029cb8db2ef77e4b8adeb27e38"
+  },
+  "orion/substrate/relational/adapters/curiosity_ctx.py": {
+    "mtime": 1783027452.0086117,
+    "ast_hash": "6100ed5c7666da9c84a8759d6359e128",
+    "semantic_hash": "6100ed5c7666da9c84a8759d6359e128"
+  },
+  "orion/substrate/relational/adapters/episodes_ctx.py": {
+    "mtime": 1782964832.634659,
+    "ast_hash": "8fcd8f575ded75427437e3d7092a3b9e",
+    "semantic_hash": "8fcd8f575ded75427437e3d7092a3b9e"
+  },
+  "orion/substrate/relational/adapters/execution_ctx.py": {
+    "mtime": 1782871399.0077329,
+    "ast_hash": "8091161f22278476df24d0810c85a69e",
+    "semantic_hash": "8091161f22278476df24d0810c85a69e"
+  },
+  "orion/substrate/relational/adapters/identity_yaml.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "1ed9f71762f970a0cd1eaab7d965164b",
+    "semantic_hash": "1ed9f71762f970a0cd1eaab7d965164b"
+  },
+  "orion/substrate/relational/adapters/orionmem.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "9ac423d8eaa13baa14f0de7454839fd9",
+    "semantic_hash": "9ac423d8eaa13baa14f0de7454839fd9"
+  },
+  "orion/substrate/relational/adapters/recall.py": {
+    "mtime": 1779070080.2452052,
+    "ast_hash": "fd868e6b007acc22c93bd184dc872d52",
+    "semantic_hash": "fd868e6b007acc22c93bd184dc872d52"
+  },
+  "orion/substrate/relational/adapters/self_state_ctx.py": {
+    "mtime": 1783027450.9765792,
+    "ast_hash": "d1af41a1c182073185d2ad42cced98d7",
+    "semantic_hash": "d1af41a1c182073185d2ad42cced98d7"
+  },
+  "orion/substrate/relational/adapters/self_study.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "fdf0d3aec018d73487632713698baece",
+    "semantic_hash": "fdf0d3aec018d73487632713698baece"
+  },
+  "orion/substrate/relational/adapters/social.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "ff8e644aed43cba819f0a904ff4216d3",
+    "semantic_hash": "ff8e644aed43cba819f0a904ff4216d3"
+  },
+  "orion/substrate/relational/adapters/spark_ctx.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "dd54346cdd56e4d1415faf3b7ba92bed",
+    "semantic_hash": "dd54346cdd56e4d1415faf3b7ba92bed"
+  },
+  "orion/substrate/relational/adapters/town_perception_ctx.py": {
+    "mtime": 1783450708.6427279,
+    "ast_hash": "cf8b52cfeaac72769a0987f2a0468702",
+    "semantic_hash": "cf8b52cfeaac72769a0987f2a0468702"
+  },
+  "orion/substrate/relational/adapters/transport_ctx.py": {
+    "mtime": 1782871399.0077329,
+    "ast_hash": "5770b898eb50fc65fe4e529fe90f8126",
+    "semantic_hash": "5770b898eb50fc65fe4e529fe90f8126"
+  },
+  "orion/substrate/relational/beliefs.py": {
+    "mtime": 1778901838.369395,
+    "ast_hash": "7eea75be65606d7b9c29bd98dfb6c896",
+    "semantic_hash": "7eea75be65606d7b9c29bd98dfb6c896"
+  },
+  "orion/substrate/relational/layer.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "a8f073e49f7475eacaf7401ffcb2891f",
+    "semantic_hash": "a8f073e49f7475eacaf7401ffcb2891f"
+  },
+  "orion/substrate/relational/registry.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "c76115b478f903d021a3c2ac74ad5ba0",
+    "semantic_hash": "c76115b478f903d021a3c2ac74ad5ba0"
+  },
+  "orion/substrate/relational/tests/__init__.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/substrate/relational/tests/test_adapters.py": {
+    "mtime": 1779070080.2452052,
+    "ast_hash": "9477c6f135a39736acbaec82af8d6126",
+    "semantic_hash": "9477c6f135a39736acbaec82af8d6126"
+  },
+  "orion/substrate/relational/tests/test_attention_ctx_adapter.py": {
+    "mtime": 1782964832.634659,
+    "ast_hash": "101b9c5a7e601e644145b6fc3a06913a",
+    "semantic_hash": "101b9c5a7e601e644145b6fc3a06913a"
+  },
+  "orion/substrate/relational/tests/test_curiosity_ctx_adapter.py": {
+    "mtime": 1783105164.3470721,
+    "ast_hash": "fa2d8dd7dc752e4407e53a6b9cb8011d",
+    "semantic_hash": "fa2d8dd7dc752e4407e53a6b9cb8011d"
+  },
+  "orion/substrate/relational/tests/test_episodes_ctx_adapter.py": {
+    "mtime": 1782964832.634659,
+    "ast_hash": "a7504d521a38709b2c0a540483db36b0",
+    "semantic_hash": "a7504d521a38709b2c0a540483db36b0"
+  },
+  "orion/substrate/relational/tests/test_golden_path.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "f70624094599a2e551e84cd89214e626",
+    "semantic_hash": "f70624094599a2e551e84cd89214e626"
+  },
+  "orion/substrate/relational/tests/test_layer.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "71871d02e3b805bd701c51d5f91371b6",
+    "semantic_hash": "71871d02e3b805bd701c51d5f91371b6"
+  },
+  "orion/substrate/relational/tests/test_reducer_lane_adapters.py": {
+    "mtime": 1783027452.0086117,
+    "ast_hash": "9719fce809221ef0d453000901a2ac9f",
+    "semantic_hash": "9719fce809221ef0d453000901a2ac9f"
+  },
+  "orion/substrate/relational/tests/test_self_state_adapter.py": {
+    "mtime": 1782874038.2529726,
+    "ast_hash": "f80a1c9d3977c0865e19969d8f4444cc",
+    "semantic_hash": "f80a1c9d3977c0865e19969d8f4444cc"
+  },
+  "orion/substrate/relational/tests/test_self_state_attention_schema.py": {
+    "mtime": 1783105164.3470721,
+    "ast_hash": "eb54cb9d130e8817c446087145813e1a",
+    "semantic_hash": "eb54cb9d130e8817c446087145813e1a"
+  },
+  "orion/substrate/relational/tests/test_self_state_hub_presence.py": {
+    "mtime": 1783105164.3470721,
+    "ast_hash": "5065405cd92fe7995ec21004a3ef765c",
+    "semantic_hash": "5065405cd92fe7995ec21004a3ef765c"
+  },
+  "orion/substrate/review_bootstrap.py": {
+    "mtime": 1775790852.1692114,
+    "ast_hash": "b70a324cf29f7524c7d362220326430b",
+    "semantic_hash": "b70a324cf29f7524c7d362220326430b"
+  },
+  "orion/substrate/review_queue.py": {
+    "mtime": 1775790852.1692114,
+    "ast_hash": "1748806562de640353ce47025a541632",
+    "semantic_hash": "1748806562de640353ce47025a541632"
+  },
+  "orion/substrate/review_runtime.py": {
+    "mtime": 1775634425.4002526,
+    "ast_hash": "416e834035b001cb118a8e63bab9ab4f",
+    "semantic_hash": "416e834035b001cb118a8e63bab9ab4f"
+  },
+  "orion/substrate/review_schedule.py": {
+    "mtime": 1775634425.4002526,
+    "ast_hash": "cc4c8e02c9683cd6732196304a4e970c",
+    "semantic_hash": "cc4c8e02c9683cd6732196304a4e970c"
+  },
+  "orion/substrate/review_telemetry.py": {
+    "mtime": 1777093481.8421311,
+    "ast_hash": "51e19a5aa6a8e9062fc5e2e9b0c5afff",
+    "semantic_hash": "51e19a5aa6a8e9062fc5e2e9b0c5afff"
+  },
+  "orion/substrate/route_loop/__init__.py": {
+    "mtime": 1783903398.6414437,
+    "ast_hash": "32ddf20ed1d1518bc19d9dad0c6d16ce",
+    "semantic_hash": "32ddf20ed1d1518bc19d9dad0c6d16ce"
+  },
+  "orion/substrate/route_loop/constants.py": {
+    "mtime": 1783903398.6414437,
+    "ast_hash": "046545ca633914feb9a8538be04d82a4",
+    "semantic_hash": "046545ca633914feb9a8538be04d82a4"
+  },
+  "orion/substrate/route_loop/grammar_extract.py": {
+    "mtime": 1783903398.6414437,
+    "ast_hash": "cce964eb4fa87fd4159f3df615be7b00",
+    "semantic_hash": "cce964eb4fa87fd4159f3df615be7b00"
+  },
+  "orion/substrate/route_loop/ids.py": {
+    "mtime": 1783903398.6414437,
+    "ast_hash": "6f93f634ac048d2279542e6f439a6707",
+    "semantic_hash": "6f93f634ac048d2279542e6f439a6707"
+  },
+  "orion/substrate/route_loop/merge.py": {
+    "mtime": 1783903398.6414437,
+    "ast_hash": "707f37ff4d10d72b8e0d105b58dd0eed",
+    "semantic_hash": "707f37ff4d10d72b8e0d105b58dd0eed"
+  },
+  "orion/substrate/route_loop/pipeline.py": {
+    "mtime": 1783903398.6414437,
+    "ast_hash": "26899785ebb77cb1a30874549f60dcc5",
+    "semantic_hash": "26899785ebb77cb1a30874549f60dcc5"
+  },
+  "orion/substrate/route_loop/projection.py": {
+    "mtime": 1783903398.6414437,
+    "ast_hash": "a5e45b6f5da9eeb87aea8e6d0d908d7b",
+    "semantic_hash": "a5e45b6f5da9eeb87aea8e6d0d908d7b"
+  },
+  "orion/substrate/route_loop/reducer.py": {
+    "mtime": 1783903398.6414437,
+    "ast_hash": "7471da765f08957a23097a6fc7144622",
+    "semantic_hash": "7471da765f08957a23097a6fc7144622"
+  },
+  "orion/substrate/scripts/smoke_mutation_v21.py": {
+    "mtime": 1777142854.8072352,
+    "ast_hash": "1c79dade81eb4de6f9b8280957d35921",
+    "semantic_hash": "1c79dade81eb4de6f9b8280957d35921"
+  },
+  "orion/substrate/signal_bridge.py": {
+    "mtime": 1782190803.1003246,
+    "ast_hash": "c073301c2cd04a0823fe7d9317b8b6b0",
+    "semantic_hash": "c073301c2cd04a0823fe7d9317b8b6b0"
+  },
+  "orion/substrate/signal_bus_worker.py": {
+    "mtime": 1781854374.4556923,
+    "ast_hash": "17e67cfe392dad5b0336c053f5823495",
+    "semantic_hash": "17e67cfe392dad5b0336c053f5823495"
+  },
+  "orion/substrate/store.py": {
+    "mtime": 1775634425.4012525,
+    "ast_hash": "dc13b55202eb999cd207f2f0721cd36d",
+    "semantic_hash": "dc13b55202eb999cd207f2f0721cd36d"
+  },
+  "orion/substrate/tests/fixtures/recall_readiness/canary_golden_cases.json": {
+    "mtime": 1777165691.9340978,
+    "ast_hash": "b026e18a00c9b071735b1c559cb7b06a",
+    "semantic_hash": "b026e18a00c9b071735b1c559cb7b06a"
+  },
+  "orion/substrate/tests/test_attention_broadcast.py": {
+    "mtime": 1782955647.2174184,
+    "ast_hash": "83735b8cf0b3ecf4bea88604f1d619dd",
+    "semantic_hash": "83735b8cf0b3ecf4bea88604f1d619dd"
+  },
+  "orion/substrate/tests/test_attention_broadcast_dwell.py": {
+    "mtime": 1783105164.3470721,
+    "ast_hash": "2e5f6c331c1286871fec4fd5b1f1c172",
+    "semantic_hash": "2e5f6c331c1286871fec4fd5b1f1c172"
+  },
+  "orion/substrate/tests/test_attention_salience_contracts.py": {
+    "mtime": 1783447063.2533703,
+    "ast_hash": "7b0cf9ca64bb6c487995728868cd5cc4",
+    "semantic_hash": "7b0cf9ca64bb6c487995728868cd5cc4"
+  },
+  "orion/substrate/tests/test_broadcast_habituation.py": {
+    "mtime": 1783447063.2533703,
+    "ast_hash": "851d67d1c269b989eef0f796881f3578",
+    "semantic_hash": "851d67d1c269b989eef0f796881f3578"
+  },
+  "orion/substrate/tests/test_endogenous_curiosity.py": {
+    "mtime": 1783807363.6198146,
+    "ast_hash": "8236af1060c1042a5a9228b2ddee8c15",
+    "semantic_hash": "8236af1060c1042a5a9228b2ddee8c15"
+  },
+  "orion/substrate/tests/test_episodic_consolidation.py": {
+    "mtime": 1782955647.2174184,
+    "ast_hash": "a5fde034407c89356b93ec56a625a4bc",
+    "semantic_hash": "a5fde034407c89356b93ec56a625a4bc"
+  },
+  "orion/substrate/tests/test_graphdb_store.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "c70ab9a2ef6493888a8beb5549577524",
+    "semantic_hash": "c70ab9a2ef6493888a8beb5549577524"
+  },
+  "orion/substrate/tests/test_metacog_trigger_signals.py": {
+    "mtime": 1783107031.9699016,
+    "ast_hash": "d9251ee25b7b86f0acf020acf6503e64",
+    "semantic_hash": "d9251ee25b7b86f0acf020acf6503e64"
+  },
+  "orion/substrate/tests/test_mutation_self_revision.py": {
+    "mtime": 1782868429.846242,
+    "ast_hash": "8add1d391bf83d0534500d0ae56754a7",
+    "semantic_hash": "8add1d391bf83d0534500d0ae56754a7"
+  },
+  "orion/substrate/tests/test_mutation_unpromoted_goal_regression.py": {
+    "mtime": 1779328788.9587867,
+    "ast_hash": "7ac53b2b0e0e01b7ff56983d5ba23ff8",
+    "semantic_hash": "7ac53b2b0e0e01b7ff56983d5ba23ff8"
+  },
+  "orion/substrate/tests/test_mutation_v21.py": {
+    "mtime": 1777161083.3471003,
+    "ast_hash": "8c22e7adce910036a728710a3c3663ab",
+    "semantic_hash": "8c22e7adce910036a728710a3c3663ab"
+  },
+  "orion/substrate/tests/test_mutation_worker_extra_signals.py": {
+    "mtime": 1783125791.0200877,
+    "ast_hash": "497d3bdb9617b51b97546c5ee88d589b",
+    "semantic_hash": "497d3bdb9617b51b97546c5ee88d589b"
+  },
+  "orion/substrate/tests/test_phase15_reanchoring.py": {
+    "mtime": 1775634425.4012525,
+    "ast_hash": "76ae27e1a4320f8d5be043892fa8cb85",
+    "semantic_hash": "76ae27e1a4320f8d5be043892fa8cb85"
+  },
+  "orion/substrate/tests/test_phase16_query_planning.py": {
+    "mtime": 1775634425.4012525,
+    "ast_hash": "3f9d704839784d97cb3dfa7813f90e38",
+    "semantic_hash": "3f9d704839784d97cb3dfa7813f90e38"
+  },
+  "orion/substrate/tests/test_phase17_policy_adoption.py": {
+    "mtime": 1775953912.5410523,
+    "ast_hash": "bb778006c913e0d2f5b45e800f68b290",
+    "semantic_hash": "bb778006c913e0d2f5b45e800f68b290"
+  },
+  "orion/substrate/tests/test_phase18_durable_policy_store.py": {
+    "mtime": 1775634425.4012525,
+    "ast_hash": "e1c86d7aa3c08e56ea4ae958d1b3c358",
+    "semantic_hash": "e1c86d7aa3c08e56ea4ae958d1b3c358"
+  },
+  "orion/substrate/tests/test_phase19_sql_policy_store.py": {
+    "mtime": 1775634425.4012525,
+    "ast_hash": "dffc449e9b4264b4bddd4fd96c7f6c6d",
+    "semantic_hash": "dffc449e9b4264b4bddd4fd96c7f6c6d"
+  },
+  "orion/substrate/tests/test_phase20_policy_comparison.py": {
+    "mtime": 1775634425.4012525,
+    "ast_hash": "8da09dbc6f8162b9b028ecc4e1f4ba2b",
+    "semantic_hash": "8da09dbc6f8162b9b028ecc4e1f4ba2b"
+  },
+  "orion/substrate/tests/test_phase21_control_plane_parity.py": {
+    "mtime": 1775634425.4012525,
+    "ast_hash": "16a6b7b420c0190a3797401b2008609b",
+    "semantic_hash": "16a6b7b420c0190a3797401b2008609b"
+  },
+  "orion/substrate/tests/test_recall_strategy_readiness.py": {
+    "mtime": 1777158604.7640204,
+    "ast_hash": "3f2eabbe2e66d8635125b4e8ca3aa31e",
+    "semantic_hash": "3f2eabbe2e66d8635125b4e8ca3aa31e"
+  },
+  "orion/substrate/tests/test_refit_salience_stub.py": {
+    "mtime": 1783447063.2533703,
+    "ast_hash": "eac6f17c380fb641ee249318874d70cb",
+    "semantic_hash": "eac6f17c380fb641ee249318874d70cb"
+  },
+  "orion/substrate/tests/test_rumination_replay.py": {
+    "mtime": 1783447063.2533703,
+    "ast_hash": "4a68fab946d2e43cad0ce25e1f7b824b",
+    "semantic_hash": "4a68fab946d2e43cad0ce25e1f7b824b"
+  },
+  "orion/substrate/tests/test_salience_combiner.py": {
+    "mtime": 1783447063.2533703,
+    "ast_hash": "c89f5b8ad8bfc524ad6873d28152d473",
+    "semantic_hash": "c89f5b8ad8bfc524ad6873d28152d473"
+  },
+  "orion/substrate/tests/test_salience_discrimination_eval.py": {
+    "mtime": 1783447063.2533703,
+    "ast_hash": "d5bfb49536e69d2c4377099b0773c6b5",
+    "semantic_hash": "d5bfb49536e69d2c4377099b0773c6b5"
+  },
+  "orion/substrate/tests/test_salience_schema.py": {
+    "mtime": 1783447063.2533703,
+    "ast_hash": "1537d27678cfdd3b2af3de653315922a",
+    "semantic_hash": "1537d27678cfdd3b2af3de653315922a"
+  },
+  "orion/substrate/tests/test_scoring_salience_wiring.py": {
+    "mtime": 1783447063.2533703,
+    "ast_hash": "e0ec3cc8da6c0687979018ce367de4cb",
+    "semantic_hash": "e0ec3cc8da6c0687979018ce367de4cb"
+  },
+  "orion/substrate/tier_outcomes_bus.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "7e2f5a9a18b71218c73b69cdac77e086",
+    "semantic_hash": "7e2f5a9a18b71218c73b69cdac77e086"
+  },
+  "orion/substrate/transport_loop/__init__.py": {
+    "mtime": 1780622613.5957644,
+    "ast_hash": "f262255dc17cd5816a29660147be06f3",
+    "semantic_hash": "f262255dc17cd5816a29660147be06f3"
+  },
+  "orion/substrate/transport_loop/constants.py": {
+    "mtime": 1780622613.5957644,
+    "ast_hash": "a8380184641bb57e102941d4bc8d00ee",
+    "semantic_hash": "a8380184641bb57e102941d4bc8d00ee"
+  },
+  "orion/substrate/transport_loop/extract.py": {
+    "mtime": 1780622613.5957644,
+    "ast_hash": "8cf499a2dc1fdcbe9f526346dab8cae9",
+    "semantic_hash": "8cf499a2dc1fdcbe9f526346dab8cae9"
+  },
+  "orion/substrate/transport_loop/pipeline.py": {
+    "mtime": 1780622613.5957644,
+    "ast_hash": "1f78327ebb2ea6956ce2a01687c93395",
+    "semantic_hash": "1f78327ebb2ea6956ce2a01687c93395"
+  },
+  "orion/substrate/transport_loop/reducer.py": {
+    "mtime": 1780622613.5957644,
+    "ast_hash": "a270cd1463d42587d752601874b482af",
+    "semantic_hash": "a270cd1463d42587d752601874b482af"
+  },
+  "orion/substrate/trial_runner.py": {
+    "mtime": 1777096676.4251156,
+    "ast_hash": "bb7c2135533293b0b85e3e0ed1e7dae7",
+    "semantic_hash": "bb7c2135533293b0b85e3e0ed1e7dae7"
+  },
+  "orion/telemetry/__init__.py": {
+    "mtime": 1768971372.3570237,
+    "ast_hash": "8a6547d460f49abd38abd8b48b12ec47",
+    "semantic_hash": "8a6547d460f49abd38abd8b48b12ec47"
+  },
+  "orion/telemetry/biometrics_pipeline.py": {
+    "mtime": 1777747487.258672,
+    "ast_hash": "951286ba9f59b106c28992b5e74d9e25",
+    "semantic_hash": "951286ba9f59b106c28992b5e74d9e25"
+  },
+  "orion/telemetry/corpus_gate.py": {
+    "mtime": 1783622541.3515248,
+    "ast_hash": "b94a3d70338200cbe7f783125937ac5b",
+    "semantic_hash": "b94a3d70338200cbe7f783125937ac5b"
+  },
+  "orion/telemetry/corpus_rotation.py": {
+    "mtime": 1783984456.988051,
+    "ast_hash": "6ca4a1481211c9437cb7c1cfd716c9b6",
+    "semantic_hash": "6ca4a1481211c9437cb7c1cfd716c9b6"
+  },
+  "orion/telemetry/corpus_sink.py": {
+    "mtime": 1783984456.988051,
+    "ast_hash": "8c5f2b7e95b975d7e6cc88b30faf927d",
+    "semantic_hash": "8c5f2b7e95b975d7e6cc88b30faf927d"
+  },
+  "orion/thought/__init__.py": {
+    "mtime": 1783291410.0217016,
+    "ast_hash": "c7a02aee5c370d84353c384a3194e283",
+    "semantic_hash": "c7a02aee5c370d84353c384a3194e283"
+  },
+  "orion/thought/coalition.py": {
+    "mtime": 1783298706.20145,
+    "ast_hash": "1d0cc9d4a7622ec83eba16910663a322",
+    "semantic_hash": "1d0cc9d4a7622ec83eba16910663a322"
+  },
+  "orion/thought/evals/fixtures/trust_rupture/defer_missing_evidence_not_trust.json": {
+    "mtime": 1783291410.0227017,
+    "ast_hash": "d54c906ff33ac963e381a03f381356b9",
+    "semantic_hash": "d54c906ff33ac963e381a03f381356b9"
+  },
+  "orion/thought/evals/fixtures/trust_rupture/proceed_below_threshold.json": {
+    "mtime": 1783291410.0227017,
+    "ast_hash": "584115cae91d44b2ac74f44dd619b3b1",
+    "semantic_hash": "584115cae91d44b2ac74f44dd619b3b1"
+  },
+  "orion/thought/evals/fixtures/trust_rupture/refuse_above_threshold.json": {
+    "mtime": 1783291410.0227017,
+    "ast_hash": "fb73a636498a3060f564664e0e584bcc",
+    "semantic_hash": "fb73a636498a3060f564664e0e584bcc"
+  },
+  "orion/thought/evals/fixtures/trust_rupture/refuse_at_threshold.json": {
+    "mtime": 1783291410.0227017,
+    "ast_hash": "1368feec88041c6c5b9892fb431f7e8a",
+    "semantic_hash": "1368feec88041c6c5b9892fb431f7e8a"
+  },
+  "orion/thought/evals/trust_rupture_eval.py": {
+    "mtime": 1783291410.0227017,
+    "ast_hash": "5951cee19e697b0afea985bb9f6fb140",
+    "semantic_hash": "5951cee19e697b0afea985bb9f6fb140"
+  },
+  "orion/thought/json_extract.py": {
+    "mtime": 1783298706.20145,
+    "ast_hash": "7216b191ea97eb708743f402e1841fce",
+    "semantic_hash": "7216b191ea97eb708743f402e1841fce"
+  },
+  "orion/thought/policy_refusal.py": {
+    "mtime": 1783291410.0227017,
+    "ast_hash": "421a776606a18e1b58a379f6e665fc00",
+    "semantic_hash": "421a776606a18e1b58a379f6e665fc00"
+  },
+  "orion/thought/stance_quality.py": {
+    "mtime": 1783291410.0227017,
+    "ast_hash": "46d54e9a0f4e20973062725bcb055112",
+    "semantic_hash": "46d54e9a0f4e20973062725bcb055112"
+  },
+  "orion/thought/stance_react.py": {
+    "mtime": 1783892565.0034528,
+    "ast_hash": "c3625dc86dfb338cff0ee9b3c86eae02",
+    "semantic_hash": "c3625dc86dfb338cff0ee9b3c86eae02"
+  },
+  "orion/thought/tests/test_stance_react_evidence_refs_fail_closed.py": {
+    "mtime": 1783291410.0227017,
+    "ast_hash": "d3e369421b1766303c4fb83351f2885d",
+    "semantic_hash": "d3e369421b1766303c4fb83351f2885d"
+  },
+  "orion/thought/tests/test_stance_react_pipeline.py": {
+    "mtime": 1783892565.004453,
+    "ast_hash": "aafb8aa8b8561ed303e3af261a354c7a",
+    "semantic_hash": "aafb8aa8b8561ed303e3af261a354c7a"
+  },
+  "orion/thought/tests/test_stance_react_prompt_imperative_discipline.py": {
+    "mtime": 1783298706.20245,
+    "ast_hash": "aea932c738bd6f732e1eece94bade3ed",
+    "semantic_hash": "aea932c738bd6f732e1eece94bade3ed"
+  },
+  "orion/thought/tests/test_stance_react_relational_survives_compressor.py": {
+    "mtime": 1783291410.0227017,
+    "ast_hash": "5f01b899ce049d24d369eb6532ead092",
+    "semantic_hash": "5f01b899ce049d24d369eb6532ead092"
+  },
+  "orion/thought/tests/test_trust_rupture_threshold_frozen.py": {
+    "mtime": 1783291410.0237017,
+    "ast_hash": "464a891aedbe8619b8fe943bd791d443",
+    "semantic_hash": "464a891aedbe8619b8fe943bd791d443"
+  },
+  "orion/tier_semantic/__init__.py": {
+    "mtime": 1763232123.3988905,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion/tier_semantic/ingest.py": {
+    "mtime": 1763232123.3988905,
+    "ast_hash": "03cba384688249e3d2fbaf8a89d19734",
+    "semantic_hash": "03cba384688249e3d2fbaf8a89d19734"
+  },
+  "orion/tier_semantic/vector_store.py": {
+    "mtime": 1763232123.3988905,
+    "ast_hash": "a2b923cabd610ccb953d91d4ea1f0e71",
+    "semantic_hash": "a2b923cabd610ccb953d91d4ea1f0e71"
+  },
+  "orion/training/chatgpt_qlora/__init__.py": {
+    "mtime": 1776925210.017162,
+    "ast_hash": "92d296f93c723c847869d08a362dbc0e",
+    "semantic_hash": "92d296f93c723c847869d08a362dbc0e"
+  },
+  "orion/training/chatgpt_qlora/cli.py": {
+    "mtime": 1776925210.017162,
+    "ast_hash": "4a3b247c9265c42b3ec44fbc2a6b5775",
+    "semantic_hash": "4a3b247c9265c42b3ec44fbc2a6b5775"
+  },
+  "orion/training/chatgpt_qlora/dataset.py": {
+    "mtime": 1776925210.017162,
+    "ast_hash": "9f11cea6afd66fb07e5f0d77b3e26b40",
+    "semantic_hash": "9f11cea6afd66fb07e5f0d77b3e26b40"
+  },
+  "orion/training/chatgpt_qlora/eval.py": {
+    "mtime": 1776925210.017162,
+    "ast_hash": "1af53d327dcfd8517b6d3b851b0dea78",
+    "semantic_hash": "1af53d327dcfd8517b6d3b851b0dea78"
+  },
+  "orion/training/chatgpt_qlora/examples/pipeline_config.example.json": {
+    "mtime": 1776925210.018162,
+    "ast_hash": "dce08ac3fd6d27af110437d5909aac5d",
+    "semantic_hash": "dce08ac3fd6d27af110437d5909aac5d"
+  },
+  "orion/training/chatgpt_qlora/foundry.py": {
+    "mtime": 1776925210.018162,
+    "ast_hash": "0e5ca7829135f304c9fb4a778e1e145f",
+    "semantic_hash": "0e5ca7829135f304c9fb4a778e1e145f"
+  },
+  "orion/training/chatgpt_qlora/ontology_seed.py": {
+    "mtime": 1783499830.194521,
+    "ast_hash": "c2324f1d17be954e1fdc56e88814c953",
+    "semantic_hash": "c2324f1d17be954e1fdc56e88814c953"
+  },
+  "orion/training/chatgpt_qlora/runtime.py": {
+    "mtime": 1776925210.018162,
+    "ast_hash": "18cedcad3d7712b788f16de5904d46d9",
+    "semantic_hash": "18cedcad3d7712b788f16de5904d46d9"
+  },
+  "orion/training/chatgpt_qlora/schemas.py": {
+    "mtime": 1776925210.018162,
+    "ast_hash": "803a549977bd01362485b943198278b0",
+    "semantic_hash": "803a549977bd01362485b943198278b0"
+  },
+  "orion/training/chatgpt_qlora/trainer.py": {
+    "mtime": 1776925210.018162,
+    "ast_hash": "1bbd5e2086a9b382f0ac6d2685c98f31",
+    "semantic_hash": "1bbd5e2086a9b382f0ac6d2685c98f31"
+  },
+  "orion/vision/__init__.py": {
+    "mtime": 1783110541.1419032,
+    "ast_hash": "4c9b17c1f53fc23451f14e328e74fb54",
+    "semantic_hash": "4c9b17c1f53fc23451f14e328e74fb54"
+  },
+  "orion/vision/caption_echo.py": {
+    "mtime": 1783110541.1419032,
+    "ast_hash": "967435963b931b5bc263a815447ccc77",
+    "semantic_hash": "967435963b931b5bc263a815447ccc77"
+  },
+  "orion/vision/tests/test_caption_echo.py": {
+    "mtime": 1783110541.1419032,
+    "ast_hash": "e50c6a0222a80200fe46b666ed07ee06",
+    "semantic_hash": "e50c6a0222a80200fe46b666ed07ee06"
+  },
+  "pyproject.toml": {
+    "mtime": 1783499830.194521,
+    "ast_hash": "92cb279daedde64dfed769120ff330fd",
+    "semantic_hash": "92cb279daedde64dfed769120ff330fd"
+  },
+  "scripts/__init__.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "scripts/analysis/measure_autonomy_gate.py": {
+    "mtime": 1783979364.1171374,
+    "ast_hash": "15909d95d8e4cb12238a5dac0cb08b3d",
+    "semantic_hash": "15909d95d8e4cb12238a5dac0cb08b3d"
+  },
+  "scripts/analysis/tests/test_measure_autonomy_gate.py": {
+    "mtime": 1783979364.1171374,
+    "ast_hash": "49a7545698aeec155a445b032bdd633e",
+    "semantic_hash": "49a7545698aeec155a445b032bdd633e"
+  },
+  "scripts/autonomy/archive_stale_goal_proposals.py": {
+    "mtime": 1780100357.2035112,
+    "ast_hash": "b80cfbb51ae2ec7ee272a6bbdf04c44c",
+    "semantic_hash": "b80cfbb51ae2ec7ee272a6bbdf04c44c"
+  },
+  "scripts/autonomy/tests/test_archive_stale_goal_proposals.py": {
+    "mtime": 1779333968.8916838,
+    "ast_hash": "953855b5f644bd141aebd132551be37d",
+    "semantic_hash": "953855b5f644bd141aebd132551be37d"
+  },
+  "scripts/backfill_phi_corpus.py": {
+    "mtime": 1783622541.3515248,
+    "ast_hash": "51bd3088888c8d3c227772730ce5ed6e",
+    "semantic_hash": "51bd3088888c8d3c227772730ce5ed6e"
+  },
+  "scripts/bootstrap_test_envs.sh": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "3d23e8ad9725cc70e00588b2c61f586c",
+    "semantic_hash": "3d23e8ad9725cc70e00588b2c61f586c"
+  },
+  "scripts/bus_harness.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "7eb97d3dc83f0ac6c56a152919798aff",
+    "semantic_hash": "7eb97d3dc83f0ac6c56a152919798aff"
+  },
+  "scripts/bus_probe.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "fc06e7ffdf57e6a970fc99eea4c0bd7b",
+    "semantic_hash": "fc06e7ffdf57e6a970fc99eea4c0bd7b"
+  },
+  "scripts/check_activation_saturation.py": {
+    "mtime": 1783960753.1678302,
+    "ast_hash": "0804dfcd2c5577b5815e473d6143edb8",
+    "semantic_hash": "0804dfcd2c5577b5815e473d6143edb8"
+  },
+  "scripts/check_concept_relation_digest_liveness.py": {
+    "mtime": 1783983558.4702075,
+    "ast_hash": "39e222b0202ed8e18376f4164c8faa4d",
+    "semantic_hash": "39e222b0202ed8e18376f4164c8faa4d"
+  },
+  "scripts/check_daily_schedule_collisions.py": {
+    "mtime": 1783986358.1016564,
+    "ast_hash": "f4300007184d69e0d60c98aa40f4efda",
+    "semantic_hash": "f4300007184d69e0d60c98aa40f4efda"
+  },
+  "scripts/check_fcc_context_parity.py": {
+    "mtime": 1783615212.478912,
+    "ast_hash": "4c920983b429a14603be12debcc13b9c",
+    "semantic_hash": "4c920983b429a14603be12debcc13b9c"
+  },
+  "scripts/check_inner_state_registry.py": {
+    "mtime": 1783897997.642214,
+    "ast_hash": "dc26a7c9a33f2727aad2547eb43145b5",
+    "semantic_hash": "dc26a7c9a33f2727aad2547eb43145b5"
+  },
+  "scripts/check_journal_dispatch_registry.py": {
+    "mtime": 1783986358.1016564,
+    "ast_hash": "975e47283753c6e4b420f7b6bfb4850b",
+    "semantic_hash": "975e47283753c6e4b420f7b6bfb4850b"
+  },
+  "scripts/check_service_env_compose_parity.py": {
+    "mtime": 1783983558.4702075,
+    "ast_hash": "465b1e8fd087b917a4ed3d692c03c516",
+    "semantic_hash": "465b1e8fd087b917a4ed3d692c03c516"
+  },
+  "scripts/check_single_consumer_channels.py": {
+    "mtime": 1783957069.416255,
+    "ast_hash": "3bdc7fcfb642d37248fbc43f4a2c900a",
+    "semantic_hash": "3bdc7fcfb642d37248fbc43f4a2c900a"
+  },
+  "scripts/collapse_mirror_live_path_truth.sh": {
+    "mtime": 1781730419.486787,
+    "ast_hash": "d79cc8117635d5931d66a2d1ce520656",
+    "semantic_hash": "d79cc8117635d5931d66a2d1ce520656"
+  },
+  "scripts/complete_fuseki_graphdb_migration.sh": {
+    "mtime": 1781145187.8072572,
+    "ast_hash": "6dfb6204b7b6e553aad128aad40f7155",
+    "semantic_hash": "6dfb6204b7b6e553aad128aad40f7155"
+  },
+  "scripts/concept_relation_digest.py": {
+    "mtime": 1783965578.732708,
+    "ast_hash": "299143a89314f3afa2c7cb2af35f56ae",
+    "semantic_hash": "299143a89314f3afa2c7cb2af35f56ae"
+  },
+  "scripts/context_exec_agent_route_probe.sh": {
+    "mtime": 1781495566.025971,
+    "ast_hash": "fc38d2c32458a7fe3fd0576c7d2129f7",
+    "semantic_hash": "fc38d2c32458a7fe3fd0576c7d2129f7"
+  },
+  "scripts/context_exec_beta_gate.sh": {
+    "mtime": 1781484475.966773,
+    "ast_hash": "eadb4fb47aa1aef6cee347362f228808",
+    "semantic_hash": "eadb4fb47aa1aef6cee347362f228808"
+  },
+  "scripts/context_exec_golden_probes.sh": {
+    "mtime": 1781133520.6373346,
+    "ast_hash": "f0273f69be8b2cc3ccc7f53267276b12",
+    "semantic_hash": "f0273f69be8b2cc3ccc7f53267276b12"
+  },
+  "scripts/context_exec_live_smoke.sh": {
+    "mtime": 1781131289.7020948,
+    "ast_hash": "50be94904f246909849be3414283c59b",
+    "semantic_hash": "50be94904f246909849be3414283c59b"
+  },
+  "scripts/context_exec_probe_lib.py": {
+    "mtime": 1781484475.967773,
+    "ast_hash": "7d246411e42dff157461d392c3761348",
+    "semantic_hash": "7d246411e42dff157461d392c3761348"
+  },
+  "scripts/context_exec_rlm_eval.py": {
+    "mtime": 1781457339.7654073,
+    "ast_hash": "28993a6797a108b100fa4f9d2698fc79",
+    "semantic_hash": "28993a6797a108b100fa4f9d2698fc79"
+  },
+  "scripts/context_mode_hooks_smoke.py": {
+    "mtime": 1783807841.1691182,
+    "ast_hash": "e6a5fa38abeb462463c1e5dad636ead9",
+    "semantic_hash": "e6a5fa38abeb462463c1e5dad636ead9"
+  },
+  "scripts/debug_recall_pipeline.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "35a50eadeb2f85d76c9206cd891c1578",
+    "semantic_hash": "35a50eadeb2f85d76c9206cd891c1578"
+  },
+  "scripts/denver_memory_correction_vertical_smoke.sh": {
+    "mtime": 1781479799.2107632,
+    "ast_hash": "4ecd5852dd55c08e6d4ea9b670214e16",
+    "semantic_hash": "4ecd5852dd55c08e6d4ea9b670214e16"
+  },
+  "scripts/diag.py": {
+    "mtime": 1783644551.7176976,
+    "ast_hash": "ee7add758abb63583b419be5aa904f0d",
+    "semantic_hash": "ee7add758abb63583b419be5aa904f0d"
+  },
+  "scripts/diagnose_cortex_bus_stack.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "7448876a82f1b83d464e2ce983900ec1",
+    "semantic_hash": "7448876a82f1b83d464e2ce983900ec1"
+  },
+  "scripts/dream_spine_smoke.py": {
+    "mtime": 1774236180.4463856,
+    "ast_hash": "f4fd9581283997268360c872cb085046",
+    "semantic_hash": "f4fd9581283997268360c872cb085046"
+  },
+  "scripts/drive_state_divergence_audit.py": {
+    "mtime": 1784008374.2445009,
+    "ast_hash": "1046e4d494c5a21b7a1280d8ec42684b",
+    "semantic_hash": "1046e4d494c5a21b7a1280d8ec42684b"
+  },
+  "scripts/eval_spark_introspection_contract.sh": {
+    "mtime": 1783110541.1419032,
+    "ast_hash": "a8b408201ae1f8745cbfa37f940865c5",
+    "semantic_hash": "a8b408201ae1f8745cbfa37f940865c5"
+  },
+  "scripts/export_graphdb_collapse_offline.sh": {
+    "mtime": 1781143128.399986,
+    "ast_hash": "1e64bab434ccf33813f1abf1cff2e56f",
+    "semantic_hash": "1e64bab434ccf33813f1abf1cff2e56f"
+  },
+  "scripts/fit_mood_arc_encoder.py": {
+    "mtime": 1783967452.501406,
+    "ast_hash": "0cbc78f70ad059fc381a3a1e906b4eb6",
+    "semantic_hash": "0cbc78f70ad059fc381a3a1e906b4eb6"
+  },
+  "scripts/fit_phi_encoder.py": {
+    "mtime": 1783918473.8063107,
+    "ast_hash": "43e899fa0969ff2933c3de3cc0180814",
+    "semantic_hash": "43e899fa0969ff2933c3de3cc0180814"
+  },
+  "scripts/force_replay_world_pulse_goal.py": {
+    "mtime": 1783388479.8254328,
+    "ast_hash": "826a5eb680d1d88a8f5af70ee861a648",
+    "semantic_hash": "826a5eb680d1d88a8f5af70ee861a648"
+  },
+  "scripts/git-stash-table.sh": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "e49166c99043b8164faa54cfae77fbb1",
+    "semantic_hash": "e49166c99043b8164faa54cfae77fbb1"
+  },
+  "scripts/grammar_production_truth.sh": {
+    "mtime": 1781584864.5155818,
+    "ast_hash": "83a513471e3cae9c427add4988b40f27",
+    "semantic_hash": "83a513471e3cae9c427add4988b40f27"
+  },
+  "scripts/grammar_truth_gate.py": {
+    "mtime": 1781585632.7489526,
+    "ast_hash": "8146782cfc9fb0fe4676ee324cbe35c5",
+    "semantic_hash": "8146782cfc9fb0fe4676ee324cbe35c5"
+  },
+  "scripts/import_chatgpt_export.py": {
+    "mtime": 1776925210.0191622,
+    "ast_hash": "d6b6e82b9fa7686b078c94d4470f0160",
+    "semantic_hash": "d6b6e82b9fa7686b078c94d4470f0160"
+  },
+  "scripts/import_graphdb_export_to_fuseki.sh": {
+    "mtime": 1781143119.0439985,
+    "ast_hash": "a2d8e910e3489a6c976a14657aa7fd97",
+    "semantic_hash": "a2d8e910e3489a6c976a14657aa7fd97"
+  },
+  "scripts/locate-bound-capability-live-path.sh": {
+    "mtime": 1783499830.194521,
+    "ast_hash": "b621fa2d2d6db2b5052f3b727a569426",
+    "semantic_hash": "b621fa2d2d6db2b5052f3b727a569426"
+  },
+  "scripts/migrate_fuseki_data_to_graphdb.sh": {
+    "mtime": 1781142255.4598167,
+    "ast_hash": "69258ec485206fa5e0b05043bf671706",
+    "semantic_hash": "69258ec485206fa5e0b05043bf671706"
+  },
+  "scripts/migrate_graphdb_to_fuseki.py": {
+    "mtime": 1781145188.143256,
+    "ast_hash": "25934ac5b50fd6759e14f669f59d71c0",
+    "semantic_hash": "25934ac5b50fd6759e14f669f59d71c0"
+  },
+  "scripts/orion-knowledge-forge.sh": {
+    "mtime": 1779305390.1057496,
+    "ast_hash": "7defd0c8e6f09a213412cb365224255d",
+    "semantic_hash": "7defd0c8e6f09a213412cb365224255d"
+  },
+  "scripts/orion_proposal_cli.py": {
+    "mtime": 1781479799.2107632,
+    "ast_hash": "719b24f23a4c967957d2f29d875b6861",
+    "semantic_hash": "719b24f23a4c967957d2f29d875b6861"
+  },
+  "scripts/platform/__init__.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "scripts/platform/_common.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "0ed31ada7610f98774461b6b5858f877",
+    "semantic_hash": "0ed31ada7610f98774461b6b5858f877"
+  },
+  "scripts/platform/audit_antipatterns.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "985967fae88e9c6a04f693ada68d89b0",
+    "semantic_hash": "985967fae88e9c6a04f693ada68d89b0"
+  },
+  "scripts/platform/audit_channels.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "2490ae452ffd23fb907a3f9918ad40bc",
+    "semantic_hash": "2490ae452ffd23fb907a3f9918ad40bc"
+  },
+  "scripts/platform/audit_config_lineage.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "d3613fe42298107bedb7078aebb33426",
+    "semantic_hash": "d3613fe42298107bedb7078aebb33426"
+  },
+  "scripts/platform/audit_schemas.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "0add673a2e82cf6cde723fd6e85695cf",
+    "semantic_hash": "0add673a2e82cf6cde723fd6e85695cf"
+  },
+  "scripts/platform/audit_spine.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "c4c3e72f182ff7f4bfcd0dd055fe95a7",
+    "semantic_hash": "c4c3e72f182ff7f4bfcd0dd055fe95a7"
+  },
+  "scripts/platform/run_all_audits.sh": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "c5e8f7a0fc7c9e43eacf26c723fba4d4",
+    "semantic_hash": "c5e8f7a0fc7c9e43eacf26c723fba4d4"
+  },
+  "scripts/print_recent_turn_effects.py": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "739183b6d7541fa58d357cff18524cc3",
+    "semantic_hash": "739183b6d7541fa58d357cff18524cc3"
+  },
+  "scripts/proposal_review_api_smoke.sh": {
+    "mtime": 1781739116.1586347,
+    "ast_hash": "91e49f875906d20c0e8e8faea36fb940",
+    "semantic_hash": "91e49f875906d20c0e8e8faea36fb940"
+  },
+  "scripts/recall_smoke_deep_graph.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "bc60ee90396ec04f633bee07aba18612",
+    "semantic_hash": "bc60ee90396ec04f633bee07aba18612"
+  },
+  "scripts/refit_salience_weights.py": {
+    "mtime": 1783447063.2533703,
+    "ast_hash": "9fa6daec8ffa1eceb1fe245c05018add",
+    "semantic_hash": "9fa6daec8ffa1eceb1fe245c05018add"
+  },
+  "scripts/repl/orion_fresh_main_smoke.sh": {
+    "mtime": 1781739116.1596346,
+    "ast_hash": "343842099ce859333b7f2181e4fe0d73",
+    "semantic_hash": "343842099ce859333b7f2181e4fe0d73"
+  },
+  "scripts/replay_autonomy_artifacts.py": {
+    "mtime": 1773980667.709536,
+    "ast_hash": "9f7638a505e61ec1954b156f3f7e0aab",
+    "semantic_hash": "9f7638a505e61ec1954b156f3f7e0aab"
+  },
+  "scripts/replay_world_pulse_run_to_bus.py": {
+    "mtime": 1783388479.8254328,
+    "ast_hash": "c6eef0c1b004ed9dd35b5018beb8d526",
+    "semantic_hash": "c6eef0c1b004ed9dd35b5018beb8d526"
+  },
+  "scripts/run_agent_flow_live_matrix.py": {
+    "mtime": 1775955424.7523599,
+    "ast_hash": "19100be020d388f850c5b6546fd126c8",
+    "semantic_hash": "19100be020d388f850c5b6546fd126c8"
+  },
+  "scripts/run_answer_depth_live_proof.py": {
+    "mtime": 1783499830.194521,
+    "ast_hash": "e3cc211e503a8cccacd7c9df9fd5feea",
+    "semantic_hash": "e3cc211e503a8cccacd7c9df9fd5feea"
+  },
+  "scripts/run_answer_depth_proof_suite.py": {
+    "mtime": 1783499830.194521,
+    "ast_hash": "19d51e50b80225947be336b11096719d",
+    "semantic_hash": "19d51e50b80225947be336b11096719d"
+  },
+  "scripts/run_autonomy_scenario.py": {
+    "mtime": 1773980667.709536,
+    "ast_hash": "a7f9032102b66e36fdacd3138f4682f9",
+    "semantic_hash": "a7f9032102b66e36fdacd3138f4682f9"
+  },
+  "scripts/run_chatgpt_qlora_sft.py": {
+    "mtime": 1776925210.0191622,
+    "ast_hash": "1c8cacfb0b2814bce48477d8c06486f4",
+    "semantic_hash": "1c8cacfb0b2814bce48477d8c06486f4"
+  },
+  "scripts/run_fuseki_retention.py": {
+    "mtime": 1781151983.0209444,
+    "ast_hash": "0fb363bb40068497952144eba7cb5ee6",
+    "semantic_hash": "0fb363bb40068497952144eba7cb5ee6"
+  },
+  "scripts/run_unified_turn_introspection_eval.py": {
+    "mtime": 1783805454.2223036,
+    "ast_hash": "b5592a181f93aa7f7477f0d427b82ebd",
+    "semantic_hash": "b5592a181f93aa7f7477f0d427b82ebd"
+  },
+  "scripts/seed_substrate_atlas_demo.py": {
+    "mtime": 1779651270.7470577,
+    "ast_hash": "012bfbc41474c3c387569f6109ba30e6",
+    "semantic_hash": "012bfbc41474c3c387569f6109ba30e6"
+  },
+  "scripts/self_experiment_context_exec_smoke.sh": {
+    "mtime": 1781739116.1596346,
+    "ast_hash": "b74622348c122b8ecd8529113201dc5a",
+    "semantic_hash": "b74622348c122b8ecd8529113201dc5a"
+  },
+  "scripts/self_study_harness.py": {
+    "mtime": 1774242565.111185,
+    "ast_hash": "8b7f9b668b3e6fc7c2ad62e2716a1a40",
+    "semantic_hash": "8b7f9b668b3e6fc7c2ad62e2716a1a40"
+  },
+  "scripts/smoke_actions_async_message.sh": {
+    "mtime": 1777095728.5794997,
+    "ast_hash": "2c5682717ddaedf7ad32a58af17ffede",
+    "semantic_hash": "2c5682717ddaedf7ad32a58af17ffede"
+  },
+  "scripts/smoke_actions_daily.sh": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "2e2300ea3353dd00fe6ca112fd59a829",
+    "semantic_hash": "2e2300ea3353dd00fe6ca112fd59a829"
+  },
+  "scripts/smoke_actions_daily_email_message.sh": {
+    "mtime": 1777148295.1980968,
+    "ast_hash": "526eeed5c2305bcfe52a9f6c2ded4dc6",
+    "semantic_hash": "526eeed5c2305bcfe52a9f6c2ded4dc6"
+  },
+  "scripts/smoke_actions_pending_attention.sh": {
+    "mtime": 1777095728.5794997,
+    "ast_hash": "361c190d79d2233fe9c3a5426c03b4ac",
+    "semantic_hash": "361c190d79d2233fe9c3a5426c03b4ac"
+  },
+  "scripts/smoke_actions_scheduler_daily_journal_message.sh": {
+    "mtime": 1777148295.1980968,
+    "ast_hash": "7561fc7424f0a39de359fb366bd94965",
+    "semantic_hash": "7561fc7424f0a39de359fb366bd94965"
+  },
+  "scripts/smoke_active_verbs.sh": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "4d03524ab3d05b633d99c2837328ae3f",
+    "semantic_hash": "4d03524ab3d05b633d99c2837328ae3f"
+  },
+  "scripts/smoke_all_notifications.sh": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "d5a92cd2fb9625129722449b2f9b6668",
+    "semantic_hash": "d5a92cd2fb9625129722449b2f9b6668"
+  },
+  "scripts/smoke_attention.sh": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "19b84c40861b152a35f79cade5b767b0",
+    "semantic_hash": "19b84c40861b152a35f79cade5b767b0"
+  },
+  "scripts/smoke_attention_frame_v1.sh": {
+    "mtime": 1779681646.020453,
+    "ast_hash": "9f0b1abe999fad8e846a8af3e65fbc4c",
+    "semantic_hash": "9f0b1abe999fad8e846a8af3e65fbc4c"
+  },
+  "scripts/smoke_biometrics.sh": {
+    "mtime": 1768971372.3570237,
+    "ast_hash": "b062cd30f15eb297e0dada393326a686",
+    "semantic_hash": "b062cd30f15eb297e0dada393326a686"
+  },
+  "scripts/smoke_biometrics_closed_loop.sh": {
+    "mtime": 1779668252.1400118,
+    "ast_hash": "60b769bacec8bd613d6b075acb61c17f",
+    "semantic_hash": "60b769bacec8bd613d6b075acb61c17f"
+  },
+  "scripts/smoke_biometrics_grammar.sh": {
+    "mtime": 1779668252.1400118,
+    "ast_hash": "206be9c8fc96ad7d92cc38a13d38b06b",
+    "semantic_hash": "206be9c8fc96ad7d92cc38a13d38b06b"
+  },
+  "scripts/smoke_bus_publish_pad.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "9c45a6318bcf685643291d8e4c58b6ab",
+    "semantic_hash": "9c45a6318bcf685643291d8e4c58b6ab"
+  },
+  "scripts/smoke_change_type_dict.py": {
+    "mtime": 1769550252.5840263,
+    "ast_hash": "a090a37e52aac96534f91477ccce70de",
+    "semantic_hash": "a090a37e52aac96534f91477ccce70de"
+  },
+  "scripts/smoke_chat_message.sh": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "64090e940abdb982332a1e21a9022000",
+    "semantic_hash": "64090e940abdb982332a1e21a9022000"
+  },
+  "scripts/smoke_chat_message_notify.sh": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "a0f737a9b1883bec7d154b6965e2f496",
+    "semantic_hash": "a0f737a9b1883bec7d154b6965e2f496"
+  },
+  "scripts/smoke_chat_to_rdf.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "9c95654e90262103c0ec226817eba948",
+    "semantic_hash": "9c95654e90262103c0ec226817eba948"
+  },
+  "scripts/smoke_chat_to_rdf_store.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "969ba21cc0a8c2525bfbf0aed09c09d6",
+    "semantic_hash": "969ba21cc0a8c2525bfbf0aed09c09d6"
+  },
+  "scripts/smoke_chatgpt_import_channel_wiring.py": {
+    "mtime": 1776925210.0191622,
+    "ast_hash": "ad91305af2d54f3ff08c9e84b06875a3",
+    "semantic_hash": "ad91305af2d54f3ff08c9e84b06875a3"
+  },
+  "scripts/smoke_consolidation_v1.sh": {
+    "mtime": 1779749949.3204675,
+    "ast_hash": "f1d55bbd299bde61d4fd4d6b3a9b6dc0",
+    "semantic_hash": "f1d55bbd299bde61d4fd4d6b3a9b6dc0"
+  },
+  "scripts/smoke_cortex_exec_grammar.sh": {
+    "mtime": 1779675743.8857543,
+    "ast_hash": "b033ed747ef058a3dbecd1dff151fd42",
+    "semantic_hash": "b033ed747ef058a3dbecd1dff151fd42"
+  },
+  "scripts/smoke_council_debug.sh": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "6c86adf3335212a1577a0d93f8cbaf8f",
+    "semantic_hash": "6c86adf3335212a1577a0d93f8cbaf8f"
+  },
+  "scripts/smoke_daily_actions.py": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "adaf6ff520f2178c8ed404496d7d51ed",
+    "semantic_hash": "adaf6ff520f2178c8ed404496d7d51ed"
+  },
+  "scripts/smoke_daily_self_experiments.py": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "8301421f4e27a3c5a2dc86bd37cd888e",
+    "semantic_hash": "8301421f4e27a3c5a2dc86bd37cd888e"
+  },
+  "scripts/smoke_digest.sh": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "626155f9ad30613f555c82f8dce48529",
+    "semantic_hash": "626155f9ad30613f555c82f8dce48529"
+  },
+  "scripts/smoke_equilibrium.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "50f58229fe5379af9da24b563493d615",
+    "semantic_hash": "50f58229fe5379af9da24b563493d615"
+  },
+  "scripts/smoke_execution_dispatch_v1.sh": {
+    "mtime": 1779722671.524158,
+    "ast_hash": "4de986a698bda9632d0e7b4e362b35f4",
+    "semantic_hash": "4de986a698bda9632d0e7b4e362b35f4"
+  },
+  "scripts/smoke_execution_field_digestion.sh": {
+    "mtime": 1779681646.020453,
+    "ast_hash": "3bb2612d3f974fe64a2165478d75b2dc",
+    "semantic_hash": "3bb2612d3f974fe64a2165478d75b2dc"
+  },
+  "scripts/smoke_feedback_frame_v1.sh": {
+    "mtime": 1779722671.525158,
+    "ast_hash": "93112d40074b0da96ae779047adbcfda",
+    "semantic_hash": "93112d40074b0da96ae779047adbcfda"
+  },
+  "scripts/smoke_field_digester_biometrics.sh": {
+    "mtime": 1779671370.5160108,
+    "ast_hash": "17d668e5807c1216cd4dd7bb2c0d5adb",
+    "semantic_hash": "17d668e5807c1216cd4dd7bb2c0d5adb"
+  },
+  "scripts/smoke_graphiti_active_packet_search_e2e.sh": {
+    "mtime": 1783957069.416255,
+    "ast_hash": "c8f75a7f67deeba32de0b739ae8c04dc",
+    "semantic_hash": "c8f75a7f67deeba32de0b739ae8c04dc"
+  },
+  "scripts/smoke_graphiti_links_e2e.sh": {
+    "mtime": 1783920873.661785,
+    "ast_hash": "468f8ee1efac6db32624826ff28667cf",
+    "semantic_hash": "468f8ee1efac6db32624826ff28667cf"
+  },
+  "scripts/smoke_graphiti_search_e2e.sh": {
+    "mtime": 1783923933.4916658,
+    "ast_hash": "bb1be0bb23238384db4e82719a759829",
+    "semantic_hash": "bb1be0bb23238384db4e82719a759829"
+  },
+  "scripts/smoke_harness_finalize_lane.py": {
+    "mtime": 1783807364.4288404,
+    "ast_hash": "211535deaefccbd9f2bb74b596d6aadc",
+    "semantic_hash": "211535deaefccbd9f2bb74b596d6aadc"
+  },
+  "scripts/smoke_heartbeat_trace.py": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "dbd6b7e82bec5e368641dc31310e0a00",
+    "semantic_hash": "dbd6b7e82bec5e368641dc31310e0a00"
+  },
+  "scripts/smoke_hub_serve_origin.sh": {
+    "mtime": 1773975149.9517863,
+    "ast_hash": "9538d83a6b894d5065a4f3ba908856c1",
+    "semantic_hash": "9538d83a6b894d5065a4f3ba908856c1"
+  },
+  "scripts/smoke_hub_topic_studio_dom.sh": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "57d23be346d06f0ff65da39c828b2629",
+    "semantic_hash": "57d23be346d06f0ff65da39c828b2629"
+  },
+  "scripts/smoke_hub_topic_studio_panel.sh": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "1033533489969638eead79eb0604d70c",
+    "semantic_hash": "1033533489969638eead79eb0604d70c"
+  },
+  "scripts/smoke_hub_topic_studio_preview_options.sh": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "9b4234dc65a4f41bc9db03f0af31af99",
+    "semantic_hash": "9b4234dc65a4f41bc9db03f0af31af99"
+  },
+  "scripts/smoke_hub_topic_studio_render.sh": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "bbf3271bc56eee482bf90feddd2a1af2",
+    "semantic_hash": "bbf3271bc56eee482bf90feddd2a1af2"
+  },
+  "scripts/smoke_hub_topic_studio_segments_full_text.sh": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "d5b23fa8a724cd0a21a864cde80bc9d6",
+    "semantic_hash": "d5b23fa8a724cd0a21a864cde80bc9d6"
+  },
+  "scripts/smoke_in_app_notify.sh": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "bf9651b09e613ace0022daf80ef18a4d",
+    "semantic_hash": "bf9651b09e613ace0022daf80ef18a4d"
+  },
+  "scripts/smoke_juniper_collapse_fanout.py": {
+    "mtime": 1768784663.7497582,
+    "ast_hash": "790d18b81aa8bfce9226094a6c10fe6e",
+    "semantic_hash": "790d18b81aa8bfce9226094a6c10fe6e"
+  },
+  "scripts/smoke_llm_gateway_routes.py": {
+    "mtime": 1781494684.9184172,
+    "ast_hash": "0740bffeaeb59b433916a52e112084ec",
+    "semantic_hash": "0740bffeaeb59b433916a52e112084ec"
+  },
+  "scripts/smoke_memory_cards_e2e.sh": {
+    "mtime": 1777753742.936735,
+    "ast_hash": "55a4572be0c417580b2152de2d22a11e",
+    "semantic_hash": "55a4572be0c417580b2152de2d22a11e"
+  },
+  "scripts/smoke_memory_cognition_loop_e2e.sh": {
+    "mtime": 1783555541.531674,
+    "ast_hash": "8122ad1ff0ea8234376b4fecb99b6cde",
+    "semantic_hash": "8122ad1ff0ea8234376b4fecb99b6cde"
+  },
+  "scripts/smoke_memory_consolidation_gate.sh": {
+    "mtime": 1783402731.2993197,
+    "ast_hash": "307af8d3963e867e2a146f554c5032f1",
+    "semantic_hash": "307af8d3963e867e2a146f554c5032f1"
+  },
+  "scripts/smoke_memory_consolidation_pipeline.py": {
+    "mtime": 1781653616.6583447,
+    "ast_hash": "616d9173ec13b7123f3d2c16bdfa55b2",
+    "semantic_hash": "616d9173ec13b7123f3d2c16bdfa55b2"
+  },
+  "scripts/smoke_memory_crystallization_e2e.sh": {
+    "mtime": 1783356609.5630095,
+    "ast_hash": "4507d340709881819a6cc91c0a7a2970",
+    "semantic_hash": "4507d340709881819a6cc91c0a7a2970"
+  },
+  "scripts/smoke_mesh_guardian.sh": {
+    "mtime": 1781852203.1065342,
+    "ast_hash": "f75636020f49666955981f17c6a15d0a",
+    "semantic_hash": "f75636020f49666955981f17c6a15d0a"
+  },
+  "scripts/smoke_metacog.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "e77c1639c759c9c3589e20a965e287e2",
+    "semantic_hash": "e77c1639c759c9c3589e20a965e287e2"
+  },
+  "scripts/smoke_metacog_lineage.py": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "fa711c10fd8f9b1fd3e38811ad74cfe4",
+    "semantic_hash": "fa711c10fd8f9b1fd3e38811ad74cfe4"
+  },
+  "scripts/smoke_metacog_phase_contract.py": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "ac89ad50822ce9cf2d7ffe6dccbfe310",
+    "semantic_hash": "ac89ad50822ce9cf2d7ffe6dccbfe310"
+  },
+  "scripts/smoke_metacog_source_service.py": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "27f5e49cb5cd86938b671070db75e84b",
+    "semantic_hash": "27f5e49cb5cd86938b671070db75e84b"
+  },
+  "scripts/smoke_metacog_turn_effect_render.py": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "2476965c038c7dca327e05add7fe3d21",
+    "semantic_hash": "2476965c038c7dca327e05add7fe3d21"
+  },
+  "scripts/smoke_mirror_split.py": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "f4f230e5a1145bb3a22bf6ca522f6342",
+    "semantic_hash": "f4f230e5a1145bb3a22bf6ca522f6342"
+  },
+  "scripts/smoke_no_topic_rail.sh": {
+    "mtime": 1779681646.020453,
+    "ast_hash": "051678b628e1960f11f1773d2b8a7213",
+    "semantic_hash": "051678b628e1960f11f1773d2b8a7213"
+  },
+  "scripts/smoke_notify.sh": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "b9e3d5f93032ee7254672fd421909f7e",
+    "semantic_hash": "b9e3d5f93032ee7254672fd421909f7e"
+  },
+  "scripts/smoke_notify_attention.sh": {
+    "mtime": 1777095728.5794997,
+    "ast_hash": "4d63fc286078f0b2c2a7c85025380592",
+    "semantic_hash": "4d63fc286078f0b2c2a7c85025380592"
+  },
+  "scripts/smoke_notify_chat_message.sh": {
+    "mtime": 1777095728.5794997,
+    "ast_hash": "6cc792db40dbbfec8fbcba4605e93517",
+    "semantic_hash": "6cc792db40dbbfec8fbcba4605e93517"
+  },
+  "scripts/smoke_notify_prefs.sh": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "63a726cfd4ad5da9f0fdb16f06c48124",
+    "semantic_hash": "63a726cfd4ad5da9f0fdb16f06c48124"
+  },
+  "scripts/smoke_orion_bus_substrate_trace.sh": {
+    "mtime": 1779749949.3204675,
+    "ast_hash": "77259f9c6a2d2b0bfa58d957c7f524e0",
+    "semantic_hash": "77259f9c6a2d2b0bfa58d957c7f524e0"
+  },
+  "scripts/smoke_orion_bus_transport_full_stack.sh": {
+    "mtime": 1780628225.3411634,
+    "ast_hash": "a9101f71249d0718074d627605b3c864",
+    "semantic_hash": "a9101f71249d0718074d627605b3c864"
+  },
+  "scripts/smoke_pcr_chat_memory_e2e.sh": {
+    "mtime": 1783398623.0071564,
+    "ast_hash": "04be3b45670d1a4000f56b98534e8c42",
+    "semantic_hash": "04be3b45670d1a4000f56b98534e8c42"
+  },
+  "scripts/smoke_policy_decision_frame_v1.sh": {
+    "mtime": 1779689417.3422012,
+    "ast_hash": "99fb01550a40dc83e6093f42bf243fa2",
+    "semantic_hash": "99fb01550a40dc83e6093f42bf243fa2"
+  },
+  "scripts/smoke_presence_grounding.py": {
+    "mtime": 1779070080.2452052,
+    "ast_hash": "38dfca602b3cd05a2f0169578de31f4f",
+    "semantic_hash": "38dfca602b3cd05a2f0169578de31f4f"
+  },
+  "scripts/smoke_proposal_frame_v1.sh": {
+    "mtime": 1779687966.456823,
+    "ast_hash": "a7342c068ae840d463a63dc2360d30e9",
+    "semantic_hash": "a7342c068ae840d463a63dc2360d30e9"
+  },
+  "scripts/smoke_rdf.py": {
+    "mtime": 1767676515.6371067,
+    "ast_hash": "64f9e28e29198af459d0a8cd070871c2",
+    "semantic_hash": "64f9e28e29198af459d0a8cd070871c2"
+  },
+  "scripts/smoke_self_state_v1.sh": {
+    "mtime": 1779683294.760711,
+    "ast_hash": "b14a26bc1dc85728ed129bff19f890e1",
+    "semantic_hash": "b14a26bc1dc85728ed129bff19f890e1"
+  },
+  "scripts/smoke_situation_grounding.py": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "eccd5753fac1240db5c6d91f59b9462c",
+    "semantic_hash": "eccd5753fac1240db5c6d91f59b9462c"
+  },
+  "scripts/smoke_substrate_motivation_golden_path.py": {
+    "mtime": 1783365495.731666,
+    "ast_hash": "b6b738c5f9673898fd85dca2c711197f",
+    "semantic_hash": "b6b738c5f9673898fd85dca2c711197f"
+  },
+  "scripts/smoke_supervisor.py": {
+    "mtime": 1767676515.6381066,
+    "ast_hash": "229d5d1e9501168f8bddc6d571c59452",
+    "semantic_hash": "229d5d1e9501168f8bddc6d571c59452"
+  },
+  "scripts/smoke_tags_to_rdf.py": {
+    "mtime": 1768784663.7507582,
+    "ast_hash": "74223134da60f7ed611efb15ef870c05",
+    "semantic_hash": "74223134da60f7ed611efb15ef870c05"
+  },
+  "scripts/smoke_telemetry_normalization.py": {
+    "mtime": 1773975149.9527862,
+    "ast_hash": "0aca2b05aadbfcca1ced119872bdb0b4",
+    "semantic_hash": "0aca2b05aadbfcca1ced119872bdb0b4"
+  },
+  "scripts/smoke_topic_digest.sh": {
+    "mtime": 1779681646.020453,
+    "ast_hash": "98a6c5213262a7f5f946d4553ca8c9c0",
+    "semantic_hash": "98a6c5213262a7f5f946d4553ca8c9c0"
+  },
+  "scripts/smoke_topic_drift_alert.sh": {
+    "mtime": 1779681646.020453,
+    "ast_hash": "8902341dc40d7a4cc7c8c97c23eb42d7",
+    "semantic_hash": "8902341dc40d7a4cc7c8c97c23eb42d7"
+  },
+  "scripts/smoke_topic_foundry_all.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "a3b3cf7cf22abb9b64c099d3509f717f",
+    "semantic_hash": "a3b3cf7cf22abb9b64c099d3509f717f"
+  },
+  "scripts/smoke_topic_foundry_bertopic.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "5f59f31fd401fa0aa404546cde658ed8",
+    "semantic_hash": "5f59f31fd401fa0aa404546cde658ed8"
+  },
+  "scripts/smoke_topic_foundry_contract.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "067beb4ba4e40cd2c1829464f4f74f6b",
+    "semantic_hash": "067beb4ba4e40cd2c1829464f4f74f6b"
+  },
+  "scripts/smoke_topic_foundry_dataset_create.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "a3e36d7092909cd258590961e3ccd920",
+    "semantic_hash": "a3e36d7092909cd258590961e3ccd920"
+  },
+  "scripts/smoke_topic_foundry_dataset_update.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "66eb40ac6354390fe50b2f115296fb10",
+    "semantic_hash": "66eb40ac6354390fe50b2f115296fb10"
+  },
+  "scripts/smoke_topic_foundry_enrich.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "13dc8735312411ccf33e32ed3f1b8b8b",
+    "semantic_hash": "13dc8735312411ccf33e32ed3f1b8b8b"
+  },
+  "scripts/smoke_topic_foundry_facets.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "6f1bd8983fd3115689d5ab47dd9f0f7b",
+    "semantic_hash": "6f1bd8983fd3115689d5ab47dd9f0f7b"
+  },
+  "scripts/smoke_topic_foundry_introspect.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "d85ff657aa556c1374c6b5580cd69438",
+    "semantic_hash": "d85ff657aa556c1374c6b5580cd69438"
+  },
+  "scripts/smoke_topic_foundry_preview.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "6bda270bb1fbe4debb5148d7d1ed1296",
+    "semantic_hash": "6bda270bb1fbe4debb5148d7d1ed1296"
+  },
+  "scripts/smoke_topic_foundry_preview_conversation_bound.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "64737dffe2a83a149ed8c7f77b758460",
+    "semantic_hash": "64737dffe2a83a149ed8c7f77b758460"
+  },
+  "scripts/smoke_topic_foundry_preview_detail.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "488835e4b249108a4a7d0357834619f1",
+    "semantic_hash": "488835e4b249108a4a7d0357834619f1"
+  },
+  "scripts/smoke_topic_foundry_preview_doc_counts.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "ab912d517bbf9ed4e8f43df6e2a05464",
+    "semantic_hash": "ab912d517bbf9ed4e8f43df6e2a05464"
+  },
+  "scripts/smoke_topic_foundry_preview_minimal.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "f00f8a8f549c98facca4bd53f61775c2",
+    "semantic_hash": "f00f8a8f549c98facca4bd53f61775c2"
+  },
+  "scripts/smoke_topic_foundry_remote.sh": {
+    "mtime": 1773975149.9537861,
+    "ast_hash": "6b44b609f2b6f3e5cf139d2547279059",
+    "semantic_hash": "6b44b609f2b6f3e5cf139d2547279059"
+  },
+  "scripts/smoke_topic_foundry_run_results_inspector.sh": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "a30addcc82ca89c07db5b898f2fe1efa",
+    "semantic_hash": "a30addcc82ca89c07db5b898f2fe1efa"
+  },
+  "scripts/smoke_topic_foundry_segment_detail.sh": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "2565b9a03a9da2f53fe707f141e21a58",
+    "semantic_hash": "2565b9a03a9da2f53fe707f141e21a58"
+  },
+  "scripts/smoke_topic_foundry_segments_facets.sh": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "5c3aa7f06372ce1039268759ac0bb034",
+    "semantic_hash": "5c3aa7f06372ce1039268759ac0bb034"
+  },
+  "scripts/smoke_topic_foundry_train.sh": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "cc9c7e20974f6f1ac21aea24e77930e6",
+    "semantic_hash": "cc9c7e20974f6f1ac21aea24e77930e6"
+  },
+  "scripts/smoke_topic_foundry_train_cosine.sh": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "359281480c5c50d24b23c8f7bcbfce39",
+    "semantic_hash": "359281480c5c50d24b23c8f7bcbfce39"
+  },
+  "scripts/smoke_topic_foundry_windowing.sh": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "ea8a1f162171f52b5576950103c2f353",
+    "semantic_hash": "ea8a1f162171f52b5576950103c2f353"
+  },
+  "scripts/smoke_topic_studio_e2e.sh": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "5f106b5592c24486e5d8992044b16f78",
+    "semantic_hash": "5f106b5592c24486e5d8992044b16f78"
+  },
+  "scripts/smoke_topic_studio_ui.sh": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "d3814ada65f14b67084b2b7a0c974144",
+    "semantic_hash": "d3814ada65f14b67084b2b7a0c974144"
+  },
+  "scripts/smoke_turn_effect_alerts.py": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "9f32389f1e9443c7a31238c23a269abe",
+    "semantic_hash": "9f32389f1e9443c7a31238c23a269abe"
+  },
+  "scripts/smoke_turn_effect_evidence.py": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "3d8cfa36a76322fa8f1cffc11689124f",
+    "semantic_hash": "3d8cfa36a76322fa8f1cffc11689124f"
+  },
+  "scripts/smoke_turn_effect_explanations.py": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "d7e772e344f90cacea103b9d347775dc",
+    "semantic_hash": "d7e772e344f90cacea103b9d347775dc"
+  },
+  "scripts/smoke_turn_effect_policy.py": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "17bfe8d51100d42fa347e5824a66e598",
+    "semantic_hash": "17bfe8d51100d42fa347e5824a66e598"
+  },
+  "scripts/smoke_turn_effect_signal.py": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "54014bf5570128ee8b28028f0551cdc2",
+    "semantic_hash": "54014bf5570128ee8b28028f0551cdc2"
+  },
+  "scripts/smoke_ui_frame_contract.sh": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "f8683354300c1a7138e4660dda2c0ecf",
+    "semantic_hash": "f8683354300c1a7138e4660dda2c0ecf"
+  },
+  "scripts/smoke_vector_upsert.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "3744002aa412d68972617d70906c7cd1",
+    "semantic_hash": "3744002aa412d68972617d70906c7cd1"
+  },
+  "scripts/smoke_vision_caption_provenance.sh": {
+    "mtime": 1782871399.0087328,
+    "ast_hash": "7419b71b6b1713f15fd5e52711a7ea7f",
+    "semantic_hash": "7419b71b6b1713f15fd5e52711a7ea7f"
+  },
+  "scripts/smoke_vision_persistence_live.sh": {
+    "mtime": 1782964832.634659,
+    "ast_hash": "682c6416d052d644ddbb0d8fd2170b43",
+    "semantic_hash": "682c6416d052d644ddbb0d8fd2170b43"
+  },
+  "scripts/sql/turn_effect_timeseries_postgres.sql": {
+    "mtime": 1773975149.9547863,
+    "ast_hash": "55265cd7672651c8fb9ea5b0a55bd2a6",
+    "semantic_hash": "55265cd7672651c8fb9ea5b0a55bd2a6"
+  },
+  "scripts/sync_local_env_from_example.py": {
+    "mtime": 1783984456.988051,
+    "ast_hash": "cc98be7458c8c5f53bd8e6602e15917d",
+    "semantic_hash": "cc98be7458c8c5f53bd8e6602e15917d"
+  },
+  "scripts/test_concept_induction_publish.py": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "df61c7e74a93ebdb77353f7dd21980e7",
+    "semantic_hash": "df61c7e74a93ebdb77353f7dd21980e7"
+  },
+  "scripts/test_hub.sh": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "94374ac71bb1ce6b2357b3c9eb5b46fd",
+    "semantic_hash": "94374ac71bb1ce6b2357b3c9eb5b46fd"
+  },
+  "scripts/test_orion_actions.sh": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "690fe58e65504fbf8c81d44561735f44",
+    "semantic_hash": "690fe58e65504fbf8c81d44561735f44"
+  },
+  "scripts/test_recall_harness.py": {
+    "mtime": 1768597909.8812296,
+    "ast_hash": "d13af172595c2363d1f3350d4aa1a680",
+    "semantic_hash": "d13af172595c2363d1f3350d4aa1a680"
+  },
+  "scripts/test_service.sh": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "2ded2b9bba0bdb3c40b1ae6913123ebc",
+    "semantic_hash": "2ded2b9bba0bdb3c40b1ae6913123ebc"
+  },
+  "scripts/trace_hub_skill_runner_e2e.py": {
+    "mtime": 1778901838.370395,
+    "ast_hash": "b55d7a1d08ffce93d293354815b398fb",
+    "semantic_hash": "b55d7a1d08ffce93d293354815b398fb"
+  },
+  "scripts/trace_metacog.py": {
+    "mtime": 1768597909.8812296,
+    "ast_hash": "08922fd113ed2e32a671f74859d597f2",
+    "semantic_hash": "08922fd113ed2e32a671f74859d597f2"
+  },
+  "scripts/trace_unified_turn.py": {
+    "mtime": 1783551182.7575676,
+    "ast_hash": "aab171c553457e2f6f9ffb07fb28aede",
+    "semantic_hash": "aab171c553457e2f6f9ffb07fb28aede"
+  },
+  "scripts/vector_smoke_test.py": {
+    "mtime": 1769550252.5840263,
+    "ast_hash": "4b4e388d367fa282de9c60ad1ca30320",
+    "semantic_hash": "4b4e388d367fa282de9c60ad1ca30320"
+  },
+  "scripts/verify-bound-capability-live.sh": {
+    "mtime": 1783499830.194521,
+    "ast_hash": "2c973ffbea47a75166731b884f9ec68b",
+    "semantic_hash": "2c973ffbea47a75166731b884f9ec68b"
+  },
+  "scripts/verify_autonomy_graph.py": {
+    "mtime": 1773980667.709536,
+    "ast_hash": "6e8c28d36d2c43bccb9c4f0d54c758c2",
+    "semantic_hash": "6e8c28d36d2c43bccb9c4f0d54c758c2"
+  },
+  "scripts/vision_persistence_smoke.py": {
+    "mtime": 1782964832.634659,
+    "ast_hash": "c1255431e967e60a0795ecf7e2832480",
+    "semantic_hash": "c1255431e967e60a0795ecf7e2832480"
+  },
+  "scripts/world_pulse_integration_smoke.py": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "7b16b3d3690b1827650bb0854fdf3ca4",
+    "semantic_hash": "7b16b3d3690b1827650bb0854fdf3ca4"
+  },
+  "scripts/world_pulse_reflective_journal_smoke.py": {
+    "mtime": 1779330729.109181,
+    "ast_hash": "2f78515f650f9e91e32aebc97430d8ef",
+    "semantic_hash": "2f78515f650f9e91e32aebc97430d8ef"
+  },
+  "scripts/world_pulse_smoke.py": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "271186549f32919cb00f0be7d45b2e47",
+    "semantic_hash": "271186549f32919cb00f0be7d45b2e47"
+  },
+  "scripts/world_pulse_verify_persistence.py": {
+    "mtime": 1777748523.319599,
+    "ast_hash": "fbb047d6dd9a0b2a359b664c763bf5da",
+    "semantic_hash": "fbb047d6dd9a0b2a359b664c763bf5da"
+  },
+  "services/orion-actions/app/__init__.py": {
+    "mtime": 1773975149.9557862,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-actions/app/logic.py": {
+    "mtime": 1778901838.3713949,
+    "ast_hash": "1af22f2ff7ccdc451f0b2734188fd06c",
+    "semantic_hash": "1af22f2ff7ccdc451f0b2734188fd06c"
+  },
+  "services/orion-actions/app/main.py": {
+    "mtime": 1783986358.1026566,
+    "ast_hash": "29319209fabb048298148de449196094",
+    "semantic_hash": "29319209fabb048298148de449196094"
+  },
+  "services/orion-actions/app/scheduler_cursor_store.py": {
+    "mtime": 1777754021.5523632,
+    "ast_hash": "ee23ca8f89a10041c513fba3fcc7771b",
+    "semantic_hash": "ee23ca8f89a10041c513fba3fcc7771b"
+  },
+  "services/orion-actions/app/settings.py": {
+    "mtime": 1783986358.1026566,
+    "ast_hash": "812244d6c34e314f5795e08fa2816772",
+    "semantic_hash": "812244d6c34e314f5795e08fa2816772"
+  },
+  "services/orion-actions/app/workflow_schedule_bootstrap.py": {
+    "mtime": 1783958824.2806838,
+    "ast_hash": "8817f1680d44cde10edff5ec0745c323",
+    "semantic_hash": "8817f1680d44cde10edff5ec0745c323"
+  },
+  "services/orion-actions/app/workflow_schedule_metrics.py": {
+    "mtime": 1774564470.048171,
+    "ast_hash": "b6922c926d480516c27ba8606b3f6838",
+    "semantic_hash": "b6922c926d480516c27ba8606b3f6838"
+  },
+  "services/orion-actions/app/workflow_schedule_store.py": {
+    "mtime": 1783958824.2806838,
+    "ast_hash": "de957f8e02a3c59216b72bef13961e78",
+    "semantic_hash": "de957f8e02a3c59216b72bef13961e78"
+  },
+  "services/orion-actions/app/workflow_scheduler.py": {
+    "mtime": 1774417080.6507087,
+    "ast_hash": "21332952f6b5020a3b789df6ab90b0c9",
+    "semantic_hash": "21332952f6b5020a3b789df6ab90b0c9"
+  },
+  "services/orion-actions/app/world_pulse_journal.py": {
+    "mtime": 1783548475.1942117,
+    "ast_hash": "d8172e4cb0d2a1590e0d4505753d2571",
+    "semantic_hash": "d8172e4cb0d2a1590e0d4505753d2571"
+  },
+  "services/orion-actions/tests/conftest.py": {
+    "mtime": 1773975149.9557862,
+    "ast_hash": "77b228d26b01a86764a8fd0f0d216a52",
+    "semantic_hash": "77b228d26b01a86764a8fd0f0d216a52"
+  },
+  "services/orion-actions/tests/test_actions_v1.py": {
+    "mtime": 1776554226.8368285,
+    "ast_hash": "0c5db57eb7f4dfc72439fe95997374c7",
+    "semantic_hash": "0c5db57eb7f4dfc72439fe95997374c7"
+  },
+  "services/orion-actions/tests/test_async_notify_producers.py": {
+    "mtime": 1783986358.1036565,
+    "ast_hash": "80b6a5597d5ab8beb3c9fd56bc44aefa",
+    "semantic_hash": "80b6a5597d5ab8beb3c9fd56bc44aefa"
+  },
+  "services/orion-actions/tests/test_chat_history_compactor_schedule_bootstrap.py": {
+    "mtime": 1783958824.2806838,
+    "ast_hash": "cff3a269b714935864d9ba6652930a5b",
+    "semantic_hash": "cff3a269b714935864d9ba6652930a5b"
+  },
+  "services/orion-actions/tests/test_daily_actions.py": {
+    "mtime": 1781739116.1606345,
+    "ast_hash": "136035c35077bd7ddf07f34902fb1cfe",
+    "semantic_hash": "136035c35077bd7ddf07f34902fb1cfe"
+  },
+  "services/orion-actions/tests/test_daily_goal_archive_scheduler.py": {
+    "mtime": 1780100357.2055113,
+    "ast_hash": "e59435500253c33d2a2cbad6713f5461",
+    "semantic_hash": "e59435500253c33d2a2cbad6713f5461"
+  },
+  "services/orion-actions/tests/test_handle_envelope_world_pulse_journal.py": {
+    "mtime": 1783958824.2806838,
+    "ast_hash": "b6c3b6d74025973465fa88d6fb2b2c2a",
+    "semantic_hash": "b6c3b6d74025973465fa88d6fb2b2c2a"
+  },
+  "services/orion-actions/tests/test_hunter_concurrent_handlers.py": {
+    "mtime": 1783907558.042593,
+    "ast_hash": "65a11aa99826ba0bc0fa3088d2a5772a",
+    "semantic_hash": "65a11aa99826ba0bc0fa3088d2a5772a"
+  },
+  "services/orion-actions/tests/test_journal_actions.py": {
+    "mtime": 1783986358.1036565,
+    "ast_hash": "b7028af403cc487b7410440939a8a848",
+    "semantic_hash": "b7028af403cc487b7410440939a8a848"
+  },
+  "services/orion-actions/tests/test_rpc_bus_fork.py": {
+    "mtime": 1781730419.4877872,
+    "ast_hash": "b82e149a37fdc7a92826d98e272a13e1",
+    "semantic_hash": "b82e149a37fdc7a92826d98e272a13e1"
+  },
+  "services/orion-actions/tests/test_scheduler_cursor_state_path.py": {
+    "mtime": 1783986358.1036565,
+    "ast_hash": "4103d675b20ca48fbca0e03c8aeb049c",
+    "semantic_hash": "4103d675b20ca48fbca0e03c8aeb049c"
+  },
+  "services/orion-actions/tests/test_scheduler_cursor_store.py": {
+    "mtime": 1777754049.540023,
+    "ast_hash": "0a353da873c94fbff470c8c06f6705db",
+    "semantic_hash": "0a353da873c94fbff470c8c06f6705db"
+  },
+  "services/orion-actions/tests/test_scheduler_docker_findings.py": {
+    "mtime": 1778901838.3713949,
+    "ast_hash": "3e90f6daf98042d280795f26b7d58f3b",
+    "semantic_hash": "3e90f6daf98042d280795f26b7d58f3b"
+  },
+  "services/orion-actions/tests/test_settings_blank_workflow_ints.py": {
+    "mtime": 1774479623.415085,
+    "ast_hash": "58ffd33010eadded0d41179969a026bb",
+    "semantic_hash": "58ffd33010eadded0d41179969a026bb"
+  },
+  "services/orion-actions/tests/test_skill_scheduler.py": {
+    "mtime": 1773980667.710536,
+    "ast_hash": "bb3450f4e38ced1b18caf86800672b9c",
+    "semantic_hash": "bb3450f4e38ced1b18caf86800672b9c"
+  },
+  "services/orion-actions/tests/test_workflow_schedule_store.py": {
+    "mtime": 1783958824.2816837,
+    "ast_hash": "4b8a67224629473150338e18679cd76d",
+    "semantic_hash": "4b8a67224629473150338e18679cd76d"
+  },
+  "services/orion-actions/tests/test_workflow_scheduler_bridge.py": {
+    "mtime": 1777095728.5804996,
+    "ast_hash": "a6ddc6c4db104ff215486a8d7ce0aee7",
+    "semantic_hash": "a6ddc6c4db104ff215486a8d7ce0aee7"
+  },
+  "services/orion-actions/tests/test_world_pulse_reflective_journal_handler.py": {
+    "mtime": 1779330729.1111808,
+    "ast_hash": "0f791824d8d8f9b86f34c66bfc518973",
+    "semantic_hash": "0f791824d8d8f9b86f34c66bfc518973"
+  },
+  "services/orion-actions/tests/test_world_pulse_run_dry_run_setting.py": {
+    "mtime": 1779330729.1111808,
+    "ast_hash": "e808e4fd217d79a5a62d93c437ad8289",
+    "semantic_hash": "e808e4fd217d79a5a62d93c437ad8289"
+  },
+  "services/orion-actions/tests/test_world_pulse_scheduler_guard.py": {
+    "mtime": 1777748523.321599,
+    "ast_hash": "ea26c2f0e15f6a2de5d97638e10a7f7d",
+    "semantic_hash": "ea26c2f0e15f6a2de5d97638e10a7f7d"
+  },
+  "services/orion-agent-council/app/__init__.py": {
+    "mtime": 1764356739.8056984,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-agent-council/app/api_routes.py": {
+    "mtime": 1767676515.6411066,
+    "ast_hash": "27e16c50ef643044c8c877dc4cb18b4b",
+    "semantic_hash": "27e16c50ef643044c8c877dc4cb18b4b"
+  },
+  "services/orion-agent-council/app/core/prompt_factory.py": {
+    "mtime": 1764458296.0505009,
+    "ast_hash": "f817b4db4d2e5029df5919eeb6178afd",
+    "semantic_hash": "f817b4db4d2e5029df5919eeb6178afd"
+  },
+  "services/orion-agent-council/app/core/prompting.py": {
+    "mtime": 1767067951.8711193,
+    "ast_hash": "b7b00ecd9512ca56316f9c5e5f5e6621",
+    "semantic_hash": "b7b00ecd9512ca56316f9c5e5f5e6621"
+  },
+  "services/orion-agent-council/app/core/registry.py": {
+    "mtime": 1764357691.9586864,
+    "ast_hash": "c34d7e8ec05e06b64290a018046951a0",
+    "semantic_hash": "c34d7e8ec05e06b64290a018046951a0"
+  },
+  "services/orion-agent-council/app/council.py": {
+    "mtime": 1767676515.6411066,
+    "ast_hash": "a5b199cc30672380c5516edab367cd84",
+    "semantic_hash": "a5b199cc30672380c5516edab367cd84"
+  },
+  "services/orion-agent-council/app/council_policy.py": {
+    "mtime": 1767676515.6411066,
+    "ast_hash": "b96850f4599802b925f9aa9b9a002418",
+    "semantic_hash": "b96850f4599802b925f9aa9b9a002418"
+  },
+  "services/orion-agent-council/app/council_prompts.py": {
+    "mtime": 1767676515.6411066,
+    "ast_hash": "f53a386e59ea5ef44796e3b126ccc0b9",
+    "semantic_hash": "f53a386e59ea5ef44796e3b126ccc0b9"
+  },
+  "services/orion-agent-council/app/deliberation.py": {
+    "mtime": 1768597909.8812296,
+    "ast_hash": "f0b552494861cc81ebbdd90be6f516b1",
+    "semantic_hash": "f0b552494861cc81ebbdd90be6f516b1"
+  },
+  "services/orion-agent-council/app/llm_client.py": {
+    "mtime": 1768597909.8812296,
+    "ast_hash": "ba1bbd646e358214d4e0a932611f410f",
+    "semantic_hash": "ba1bbd646e358214d4e0a932611f410f"
+  },
+  "services/orion-agent-council/app/main.py": {
+    "mtime": 1767676515.6421068,
+    "ast_hash": "3f41f179feedcd5e72c9ea954088892b",
+    "semantic_hash": "3f41f179feedcd5e72c9ea954088892b"
+  },
+  "services/orion-agent-council/app/models.py": {
+    "mtime": 1767676515.6421068,
+    "ast_hash": "abb6ea8e099f5ef689e22de32d693480",
+    "semantic_hash": "abb6ea8e099f5ef689e22de32d693480"
+  },
+  "services/orion-agent-council/app/persona_factory.py": {
+    "mtime": 1765060504.6347587,
+    "ast_hash": "b00e49defa7025700e22c565a5b33f50",
+    "semantic_hash": "b00e49defa7025700e22c565a5b33f50"
+  },
+  "services/orion-agent-council/app/personas.py": {
+    "mtime": 1767676515.6431067,
+    "ast_hash": "cd50d2e13d2318cdfac3f0eaff9cb869",
+    "semantic_hash": "cd50d2e13d2318cdfac3f0eaff9cb869"
+  },
+  "services/orion-agent-council/app/pipeline.py": {
+    "mtime": 1767676515.6431067,
+    "ast_hash": "52140a4284076b5043292f8f954e684f",
+    "semantic_hash": "52140a4284076b5043292f8f954e684f"
+  },
+  "services/orion-agent-council/app/prompt_factory.py": {
+    "mtime": 1764458199.4691458,
+    "ast_hash": "f982c3656396c8042ba20d06137c2ee0",
+    "semantic_hash": "f982c3656396c8042ba20d06137c2ee0"
+  },
+  "services/orion-agent-council/app/publisher.py": {
+    "mtime": 1767676515.6431067,
+    "ast_hash": "ddfefb4fffc7a97cd0d9093513a43beb",
+    "semantic_hash": "ddfefb4fffc7a97cd0d9093513a43beb"
+  },
+  "services/orion-agent-council/app/settings.py": {
+    "mtime": 1768597909.8812296,
+    "ast_hash": "3fc80e019de7c3a013fd82e8c75aa090",
+    "semantic_hash": "3fc80e019de7c3a013fd82e8c75aa090"
+  },
+  "services/orion-agent-council/app/stages.py": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "3af5a29110e375fa258c241c1f307975",
+    "semantic_hash": "3af5a29110e375fa258c241c1f307975"
+  },
+  "services/orion-ai-town/mcp/orion_aitown_mcp/__init__.py": {
+    "mtime": 1783356609.5630095,
+    "ast_hash": "f6c827257f62051595fdb61faf8c7feb",
+    "semantic_hash": "f6c827257f62051595fdb61faf8c7feb"
+  },
+  "services/orion-ai-town/mcp/orion_aitown_mcp/client.py": {
+    "mtime": 1783356609.5640097,
+    "ast_hash": "146f072f16679aee62c633f7751a44c2",
+    "semantic_hash": "146f072f16679aee62c633f7751a44c2"
+  },
+  "services/orion-ai-town/mcp/orion_aitown_mcp/server.py": {
+    "mtime": 1783356609.5640097,
+    "ast_hash": "cfef3bc71bb42dc57607a5f740bcbd99",
+    "semantic_hash": "cfef3bc71bb42dc57607a5f740bcbd99"
+  },
+  "services/orion-ai-town/mcp/pyproject.toml": {
+    "mtime": 1783356609.5640097,
+    "ast_hash": "04ffffc068c0ca13f6bc09264a8dfd47",
+    "semantic_hash": "04ffffc068c0ca13f6bc09264a8dfd47"
+  },
+  "services/orion-ai-town/mcp/tests/test_aitown_tools.py": {
+    "mtime": 1783356609.5640097,
+    "ast_hash": "ae7eed304ef80ccfe489101e7a0445a0",
+    "semantic_hash": "ae7eed304ef80ccfe489101e7a0445a0"
+  },
+  "services/orion-ai-town/scripts/apply_upstream_patches.sh": {
+    "mtime": 1783709409.4403973,
+    "ast_hash": "5cf8c93522386bad10b4cd09a9ff9de0",
+    "semantic_hash": "5cf8c93522386bad10b4cd09a9ff9de0"
+  },
+  "services/orion-ai-town/scripts/generate_descriptions.py": {
+    "mtime": 1783490446.3023593,
+    "ast_hash": "2dd8bb07d5c0ba4a035935246110fe5a",
+    "semantic_hash": "2dd8bb07d5c0ba4a035935246110fe5a"
+  },
+  "services/orion-ai-town/scripts/smoke_llm_rail.sh": {
+    "mtime": 1783364899.121467,
+    "ast_hash": "ee9189122d00a7b8e4bcdcfd91a3f0be",
+    "semantic_hash": "ee9189122d00a7b8e4bcdcfd91a3f0be"
+  },
+  "services/orion-ai-town/scripts/wire_llm_gateway.sh": {
+    "mtime": 1783649405.4941766,
+    "ast_hash": "2530638e08c2088b64fb102af5873827",
+    "semantic_hash": "2530638e08c2088b64fb102af5873827"
+  },
+  "services/orion-ai-town/tests/test_conversation_proximity_patch.py": {
+    "mtime": 1783548475.1952116,
+    "ast_hash": "d672365986fa9a700a374a214ff43ab6",
+    "semantic_hash": "d672365986fa9a700a374a214ff43ab6"
+  },
+  "services/orion-ai-town/tests/test_generate_descriptions.py": {
+    "mtime": 1783490446.3033593,
+    "ast_hash": "57525c345d83442db07a9faa5b4d4c7a",
+    "semantic_hash": "57525c345d83442db07a9faa5b4d4c7a"
+  },
+  "services/orion-ai-town/tests/test_town_chat_turns_patch.py": {
+    "mtime": 1783548475.1952116,
+    "ast_hash": "76ad381232384daf9f2b2b96fb3c271e",
+    "semantic_hash": "76ad381232384daf9f2b2b96fb3c271e"
+  },
+  "services/orion-attention-runtime/app/__init__.py": {
+    "mtime": 1779681646.020453,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-attention-runtime/app/health_monitor.py": {
+    "mtime": 1783898916.258612,
+    "ast_hash": "0e5bc806fcfa76d08bcb747faf0a6bd3",
+    "semantic_hash": "0e5bc806fcfa76d08bcb747faf0a6bd3"
+  },
+  "services/orion-attention-runtime/app/main.py": {
+    "mtime": 1779681646.020453,
+    "ast_hash": "42d0befce887bc8a30993508164e864b",
+    "semantic_hash": "42d0befce887bc8a30993508164e864b"
+  },
+  "services/orion-attention-runtime/app/settings.py": {
+    "mtime": 1783898916.258612,
+    "ast_hash": "ba2cb239947a8bb84323225d893fff67",
+    "semantic_hash": "ba2cb239947a8bb84323225d893fff67"
+  },
+  "services/orion-attention-runtime/app/store.py": {
+    "mtime": 1783898916.258612,
+    "ast_hash": "2eb2bbfcc148263ea3b07b0a99f81711",
+    "semantic_hash": "2eb2bbfcc148263ea3b07b0a99f81711"
+  },
+  "services/orion-attention-runtime/app/worker.py": {
+    "mtime": 1783898916.258612,
+    "ast_hash": "cb42729051783fc9c71157b77b360b04",
+    "semantic_hash": "cb42729051783fc9c71157b77b360b04"
+  },
+  "services/orion-attention-runtime/tests/conftest.py": {
+    "mtime": 1782964832.635659,
+    "ast_hash": "2c1af5f900de7e8ec55ad9afd2ac4fc2",
+    "semantic_hash": "2c1af5f900de7e8ec55ad9afd2ac4fc2"
+  },
+  "services/orion-attention-runtime/tests/test_health_monitor.py": {
+    "mtime": 1783898916.258612,
+    "ast_hash": "bd6a0ae33494577a9401838f58681956",
+    "semantic_hash": "bd6a0ae33494577a9401838f58681956"
+  },
+  "services/orion-attention-runtime/tests/test_worker_prune.py": {
+    "mtime": 1782964832.635659,
+    "ast_hash": "e5cb7675e5b550fce6f9fd94b218b560",
+    "semantic_hash": "e5cb7675e5b550fce6f9fd94b218b560"
+  },
+  "services/orion-biometrics/app/grammar_emit.py": {
+    "mtime": 1779668252.1410117,
+    "ast_hash": "05c024fcbec0ef4dcb487aa8d9b9833a",
+    "semantic_hash": "05c024fcbec0ef4dcb487aa8d9b9833a"
+  },
+  "services/orion-biometrics/app/main.py": {
+    "mtime": 1779668252.1410117,
+    "ast_hash": "a4b74c03b2112484768dd43dc3c745c5",
+    "semantic_hash": "a4b74c03b2112484768dd43dc3c745c5"
+  },
+  "services/orion-biometrics/app/metrics.py": {
+    "mtime": 1768971372.3580236,
+    "ast_hash": "baf284ab1c74484290b081fdce944471",
+    "semantic_hash": "baf284ab1c74484290b081fdce944471"
+  },
+  "services/orion-biometrics/app/models.py": {
+    "mtime": 1763232123.4078906,
+    "ast_hash": "28e460615308bdd60189b4b7b375af97",
+    "semantic_hash": "28e460615308bdd60189b4b7b375af97"
+  },
+  "services/orion-biometrics/app/node_catalog.py": {
+    "mtime": 1779668252.1410117,
+    "ast_hash": "6512f546d85d9a32549ca0e9afacb792",
+    "semantic_hash": "6512f546d85d9a32549ca0e9afacb792"
+  },
+  "services/orion-biometrics/app/settings.py": {
+    "mtime": 1779668252.1410117,
+    "ast_hash": "297342ec783b4bb5c88692344f1e5fe9",
+    "semantic_hash": "297342ec783b4bb5c88692344f1e5fe9"
+  },
+  "services/orion-biometrics/app/utils.py": {
+    "mtime": 1763232123.4078906,
+    "ast_hash": "ef76ec5eb462031fdac1497b3375ea63",
+    "semantic_hash": "ef76ec5eb462031fdac1497b3375ea63"
+  },
+  "services/orion-biometrics/tests/test_biometrics_grammar_emit.py": {
+    "mtime": 1779668252.1410117,
+    "ast_hash": "202e0ed718cb1b6dec8c85635c46af45",
+    "semantic_hash": "202e0ed718cb1b6dec8c85635c46af45"
+  },
+  "services/orion-biometrics/tests/test_node_catalog.py": {
+    "mtime": 1779668252.1410117,
+    "ast_hash": "5047968ee0a57f98506ac554cca3a53a",
+    "semantic_hash": "5047968ee0a57f98506ac554cca3a53a"
+  },
+  "services/orion-bus-mirror/app/main.py": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "1f2e55da4f54e3693a9c9cdf3327b127",
+    "semantic_hash": "1f2e55da4f54e3693a9c9cdf3327b127"
+  },
+  "services/orion-bus-mirror/app/settings.py": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "f1139f8fadd8c6f4293920497d5a0d71",
+    "semantic_hash": "f1139f8fadd8c6f4293920497d5a0d71"
+  },
+  "services/orion-bus-tap/app/main.py": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "448ef0aac96ad5aaafb5c6f19302d05f",
+    "semantic_hash": "448ef0aac96ad5aaafb5c6f19302d05f"
+  },
+  "services/orion-bus-tap/app/settings.py": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "2fcb5e141cb09e3d1180b424ba2bfbc4",
+    "semantic_hash": "2fcb5e141cb09e3d1180b424ba2bfbc4"
+  },
+  "services/orion-bus/app/__init__.py": {
+    "mtime": 1779749949.3214674,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-bus/app/bus_observer.py": {
+    "mtime": 1779749949.3214674,
+    "ast_hash": "c1c557076fb2907d53d3bc768906ba44",
+    "semantic_hash": "c1c557076fb2907d53d3bc768906ba44"
+  },
+  "services/orion-bus/app/grammar_emit.py": {
+    "mtime": 1779749949.3214674,
+    "ast_hash": "edff072a2a2800f547bbe0d3c1ec432e",
+    "semantic_hash": "edff072a2a2800f547bbe0d3c1ec432e"
+  },
+  "services/orion-bus/app/grammar_publish.py": {
+    "mtime": 1779749949.3214674,
+    "ast_hash": "772652538bac3078e5bc1a4cd1fcd7af",
+    "semantic_hash": "772652538bac3078e5bc1a4cd1fcd7af"
+  },
+  "services/orion-bus/app/main.py": {
+    "mtime": 1779749949.3214674,
+    "ast_hash": "b85f0d39e34634a6232c404a560df1a2",
+    "semantic_hash": "b85f0d39e34634a6232c404a560df1a2"
+  },
+  "services/orion-bus/app/settings.py": {
+    "mtime": 1779749949.3214674,
+    "ast_hash": "065f02c3cb638c82af5fc053d02a757e",
+    "semantic_hash": "065f02c3cb638c82af5fc053d02a757e"
+  },
+  "services/orion-bus/tests/__init__.py": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-bus/tests/test_orion_bus_grammar_emit.py": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "35a4d1ece7107999f1c6c3af36fee8d1",
+    "semantic_hash": "35a4d1ece7107999f1c6c3af36fee8d1"
+  },
+  "services/orion-bus/tests/test_orion_bus_grammar_publish_fail_open.py": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "ff0aebf2ba120b7f5286411c8403f156",
+    "semantic_hash": "ff0aebf2ba120b7f5286411c8403f156"
+  },
+  "services/orion-bus/tests/test_orion_bus_observer_rollup.py": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "2ae93e063a860d1de1339ff795191644",
+    "semantic_hash": "2ae93e063a860d1de1339ff795191644"
+  },
+  "services/orion-bus/tests/test_redis_pubsub_buffer_config.py": {
+    "mtime": 1783614403.4402683,
+    "ast_hash": "9a776b704099bba7d5273b7a5b39ca4e",
+    "semantic_hash": "9a776b704099bba7d5273b7a5b39ca4e"
+  },
+  "services/orion-chat-memory/app/__init__.py": {
+    "mtime": 1768597909.8832295,
+    "ast_hash": "897ca4cc0ae07fda3fcec9820a57b2d7",
+    "semantic_hash": "897ca4cc0ae07fda3fcec9820a57b2d7"
+  },
+  "services/orion-chat-memory/app/main.py": {
+    "mtime": 1781730419.489787,
+    "ast_hash": "67e99ed787336d383a95965e29594fe0",
+    "semantic_hash": "67e99ed787336d383a95965e29594fe0"
+  },
+  "services/orion-chat-memory/app/models.py": {
+    "mtime": 1768597909.8832295,
+    "ast_hash": "a625b326408f85e59fdf1ab5c411f14b",
+    "semantic_hash": "a625b326408f85e59fdf1ab5c411f14b"
+  },
+  "services/orion-chat-memory/app/settings.py": {
+    "mtime": 1768597909.8832295,
+    "ast_hash": "15a6b54859f9b99e8297cb9762be9aaa",
+    "semantic_hash": "15a6b54859f9b99e8297cb9762be9aaa"
+  },
+  "services/orion-collapse-mirror/app/__init__.py": {
+    "mtime": 1763232123.4088907,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-collapse-mirror/app/bus_runtime.py": {
+    "mtime": 1781730419.490787,
+    "ast_hash": "d08578bc2be714736f41eb126decbf20",
+    "semantic_hash": "d08578bc2be714736f41eb126decbf20"
+  },
+  "services/orion-collapse-mirror/app/main.py": {
+    "mtime": 1781730419.490787,
+    "ast_hash": "fd8d90c4d6892e2e94ff16ad7f04b5cc",
+    "semantic_hash": "fd8d90c4d6892e2e94ff16ad7f04b5cc"
+  },
+  "services/orion-collapse-mirror/app/models.py": {
+    "mtime": 1763232123.4088907,
+    "ast_hash": "e81ba4ef20134ca87b21050f911078f7",
+    "semantic_hash": "e81ba4ef20134ca87b21050f911078f7"
+  },
+  "services/orion-collapse-mirror/app/routes.py": {
+    "mtime": 1768597909.8832295,
+    "ast_hash": "cda6725350c61c6a019b0756867e525e",
+    "semantic_hash": "cda6725350c61c6a019b0756867e525e"
+  },
+  "services/orion-collapse-mirror/app/schemas.py": {
+    "mtime": 1768597909.8832295,
+    "ast_hash": "a99d19a3f36c77d6f1fb7e5f13005b65",
+    "semantic_hash": "a99d19a3f36c77d6f1fb7e5f13005b65"
+  },
+  "services/orion-collapse-mirror/app/settings.py": {
+    "mtime": 1781730419.490787,
+    "ast_hash": "5baea4bc857a293eaac6f61cd9dd6d65",
+    "semantic_hash": "5baea4bc857a293eaac6f61cd9dd6d65"
+  },
+  "services/orion-collapse-mirror/app/utils/helpers.py": {
+    "mtime": 1763232123.4088907,
+    "ast_hash": "c4d6dae57f47d01c545a1e53abb06f55",
+    "semantic_hash": "c4d6dae57f47d01c545a1e53abb06f55"
+  },
+  "services/orion-collapse-mirror/app/utils_json.py": {
+    "mtime": 1768597909.8832295,
+    "ast_hash": "bc6962d8cf3daf33aef76b71e40c2975",
+    "semantic_hash": "bc6962d8cf3daf33aef76b71e40c2975"
+  },
+  "services/orion-collapse-mirror/tests/collapse.json": {
+    "mtime": 1763232123.4088907,
+    "ast_hash": "eae18c76e3dd1242444da51752b19f7e",
+    "semantic_hash": "eae18c76e3dd1242444da51752b19f7e"
+  },
+  "services/orion-collapse-mirror/tests/conftest.py": {
+    "mtime": 1781730419.490787,
+    "ast_hash": "8ea016f4c0d59b5ffec04d889726472a",
+    "semantic_hash": "8ea016f4c0d59b5ffec04d889726472a"
+  },
+  "services/orion-collapse-mirror/tests/test_ready.py": {
+    "mtime": 1781730419.490787,
+    "ast_hash": "9c3f13c0df25abd32e2f321c04034918",
+    "semantic_hash": "9c3f13c0df25abd32e2f321c04034918"
+  },
+  "services/orion-consolidation-runtime/app/__init__.py": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-consolidation-runtime/app/main.py": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "40c1c66f0b6cb7900628b23d8cafee1e",
+    "semantic_hash": "40c1c66f0b6cb7900628b23d8cafee1e"
+  },
+  "services/orion-consolidation-runtime/app/settings.py": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "6e39040cb96903a168e101f3ead32099",
+    "semantic_hash": "6e39040cb96903a168e101f3ead32099"
+  },
+  "services/orion-consolidation-runtime/app/store.py": {
+    "mtime": 1783845232.2095878,
+    "ast_hash": "f6606b507349493d6031e2ad9859fe9d",
+    "semantic_hash": "f6606b507349493d6031e2ad9859fe9d"
+  },
+  "services/orion-consolidation-runtime/app/worker.py": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "027b3e29d1ca46eaab5f35d829ec61de",
+    "semantic_hash": "027b3e29d1ca46eaab5f35d829ec61de"
+  },
+  "services/orion-context-exec/app/__init__.py": {
+    "mtime": 1781131289.7020948,
+    "ast_hash": "e612c73d143fc2e638d5244420894055",
+    "semantic_hash": "e612c73d143fc2e638d5244420894055"
+  },
+  "services/orion-context-exec/app/agent_compat.py": {
+    "mtime": 1781584864.5165818,
+    "ast_hash": "8a4a9895cfb512441b1a930316f31c65",
+    "semantic_hash": "8a4a9895cfb512441b1a930316f31c65"
+  },
+  "services/orion-context-exec/app/agent_lane_health.py": {
+    "mtime": 1781511934.2787468,
+    "ast_hash": "19f5c376a62506b1e7965f4b3a1a60fd",
+    "semantic_hash": "19f5c376a62506b1e7965f4b3a1a60fd"
+  },
+  "services/orion-context-exec/app/agent_repl_telemetry.py": {
+    "mtime": 1783113795.7059557,
+    "ast_hash": "5c628b7fbe0e4688d1ee4a87f43ab2d4",
+    "semantic_hash": "5c628b7fbe0e4688d1ee4a87f43ab2d4"
+  },
+  "services/orion-context-exec/app/agent_synthesis.py": {
+    "mtime": 1781559772.6094518,
+    "ast_hash": "eb58cc16c3f4444e41912e5a3f648fcc",
+    "semantic_hash": "eb58cc16c3f4444e41912e5a3f648fcc"
+  },
+  "services/orion-context-exec/app/alexzhang_rlm_engine.py": {
+    "mtime": 1781511934.2787468,
+    "ast_hash": "7c20edd72f9ecb4b168e4db31facb6e8",
+    "semantic_hash": "7c20edd72f9ecb4b168e4db31facb6e8"
+  },
+  "services/orion-context-exec/app/api.py": {
+    "mtime": 1783107031.9709017,
+    "ast_hash": "b63791430c3029669215eaa92e0232d1",
+    "semantic_hash": "b63791430c3029669215eaa92e0232d1"
+  },
+  "services/orion-context-exec/app/artifact_builder.py": {
+    "mtime": 1781559772.6094518,
+    "ast_hash": "a1fcdbb6da931c1cb71bec311c29011d",
+    "semantic_hash": "a1fcdbb6da931c1cb71bec311c29011d"
+  },
+  "services/orion-context-exec/app/bus_dependency_preflight.py": {
+    "mtime": 1781584864.5165818,
+    "ast_hash": "ed0d07ce05834be0e732dc6ecc120138",
+    "semantic_hash": "ed0d07ce05834be0e732dc6ecc120138"
+  },
+  "services/orion-context-exec/app/bus_listener.py": {
+    "mtime": 1781730419.490787,
+    "ast_hash": "ee18ddaf4a40cb380bb6cf6dbc2e9bec",
+    "semantic_hash": "ee18ddaf4a40cb380bb6cf6dbc2e9bec"
+  },
+  "services/orion-context-exec/app/callable_namespace.py": {
+    "mtime": 1781132422.6994808,
+    "ast_hash": "1a75b9c77b1b799c68f23c3c5398dea6",
+    "semantic_hash": "1a75b9c77b1b799c68f23c3c5398dea6"
+  },
+  "services/orion-context-exec/app/events.py": {
+    "mtime": 1782955656.273706,
+    "ast_hash": "e44d2ad2e28572788407c8f1b44a9f69",
+    "semantic_hash": "e44d2ad2e28572788407c8f1b44a9f69"
+  },
+  "services/orion-context-exec/app/finalize_pass.py": {
+    "mtime": 1781739261.7851834,
+    "ast_hash": "56d2c5a46c76165d93101aaecfe7ebed",
+    "semantic_hash": "56d2c5a46c76165d93101aaecfe7ebed"
+  },
+  "services/orion-context-exec/app/grounding_eval.py": {
+    "mtime": 1781511934.2797468,
+    "ast_hash": "7f246b0b569da63a73b5e9d59c46721a",
+    "semantic_hash": "7f246b0b569da63a73b5e9d59c46721a"
+  },
+  "services/orion-context-exec/app/investigation_probe_plan.py": {
+    "mtime": 1781739116.1606345,
+    "ast_hash": "b28e7dbc97b3c6a0032c2b3e27723547",
+    "semantic_hash": "b28e7dbc97b3c6a0032c2b3e27723547"
+  },
+  "services/orion-context-exec/app/investigation_v2.py": {
+    "mtime": 1781739116.1606345,
+    "ast_hash": "66a8fda2fe684b7f514d37dcb27b2928",
+    "semantic_hash": "66a8fda2fe684b7f514d37dcb27b2928"
+  },
+  "services/orion-context-exec/app/investigation_v2_reducers.py": {
+    "mtime": 1781739116.1616344,
+    "ast_hash": "0e7a9fb60b05e465f69ec5813c6df2a9",
+    "semantic_hash": "0e7a9fb60b05e465f69ec5813c6df2a9"
+  },
+  "services/orion-context-exec/app/llm_profile_resolver.py": {
+    "mtime": 1781494684.9194171,
+    "ast_hash": "19366b2df8335aa36c34783151b8afe7",
+    "semantic_hash": "19366b2df8335aa36c34783151b8afe7"
+  },
+  "services/orion-context-exec/app/llm_tools.py": {
+    "mtime": 1782955656.273706,
+    "ast_hash": "75b34ef33b663ec7ea9c53f033f07e4b",
+    "semantic_hash": "75b34ef33b663ec7ea9c53f033f07e4b"
+  },
+  "services/orion-context-exec/app/main.py": {
+    "mtime": 1781730419.4917872,
+    "ast_hash": "57173cb42a396136ed0894d335a53b53",
+    "semantic_hash": "57173cb42a396136ed0894d335a53b53"
+  },
+  "services/orion-context-exec/app/organ_runtime.py": {
+    "mtime": 1783107031.9709017,
+    "ast_hash": "b1641f016f729782deca17cd88dd0051",
+    "semantic_hash": "b1641f016f729782deca17cd88dd0051"
+  },
+  "services/orion-context-exec/app/organ_status.py": {
+    "mtime": 1781511934.2797468,
+    "ast_hash": "3acf655ad3f804a73b123db7feafca0b",
+    "semantic_hash": "3acf655ad3f804a73b123db7feafca0b"
+  },
+  "services/orion-context-exec/app/proposal_ledger_intake.py": {
+    "mtime": 1781470352.0752296,
+    "ast_hash": "e2e3a9658ca4b59d30f5d6e968ae3b05",
+    "semantic_hash": "e2e3a9658ca4b59d30f5d6e968ae3b05"
+  },
+  "services/orion-context-exec/app/proposal_review_api.py": {
+    "mtime": 1781739116.1616344,
+    "ast_hash": "4d208cd5b13139b3d96b6978e7674ef0",
+    "semantic_hash": "4d208cd5b13139b3d96b6978e7674ef0"
+  },
+  "services/orion-context-exec/app/recall_tools.py": {
+    "mtime": 1781132422.6994808,
+    "ast_hash": "c60dcba53c86bcba2ca26f8c0cd40bce",
+    "semantic_hash": "c60dcba53c86bcba2ca26f8c0cd40bce"
+  },
+  "services/orion-context-exec/app/repo_tools.py": {
+    "mtime": 1783107031.9709017,
+    "ast_hash": "b68ce1f27cdd217727a97c48c788ed14",
+    "semantic_hash": "b68ce1f27cdd217727a97c48c788ed14"
+  },
+  "services/orion-context-exec/app/rlm_engine.py": {
+    "mtime": 1781757063.3629289,
+    "ast_hash": "620e56a3d1b86ed2dd6f3004547a8c66",
+    "semantic_hash": "620e56a3d1b86ed2dd6f3004547a8c66"
+  },
+  "services/orion-context-exec/app/rlm_eval_harness.py": {
+    "mtime": 1781484475.9687731,
+    "ast_hash": "75b2db1720f908cf687c2eb26953fe2f",
+    "semantic_hash": "75b2db1720f908cf687c2eb26953fe2f"
+  },
+  "services/orion-context-exec/app/runner.py": {
+    "mtime": 1783113795.7059557,
+    "ast_hash": "3974ff89952a5861e81426323969597a",
+    "semantic_hash": "3974ff89952a5861e81426323969597a"
+  },
+  "services/orion-context-exec/app/schemas.py": {
+    "mtime": 1781132422.7004807,
+    "ast_hash": "d0124d438454560fa191f74e87f1ba30",
+    "semantic_hash": "d0124d438454560fa191f74e87f1ba30"
+  },
+  "services/orion-context-exec/app/security.py": {
+    "mtime": 1781131289.703095,
+    "ast_hash": "49ff04eb89dd2a6287feaff77c9535e3",
+    "semantic_hash": "49ff04eb89dd2a6287feaff77c9535e3"
+  },
+  "services/orion-context-exec/app/settings.py": {
+    "mtime": 1783107031.9709017,
+    "ast_hash": "b0056d6686f604767ced51e8e57ec7df",
+    "semantic_hash": "b0056d6686f604767ced51e8e57ec7df"
+  },
+  "services/orion-context-exec/app/smolcode_engine.py": {
+    "mtime": 1783107031.9719017,
+    "ast_hash": "b6a20271e319274cc0ae823337e7300b",
+    "semantic_hash": "b6a20271e319274cc0ae823337e7300b"
+  },
+  "services/orion-context-exec/app/storage.py": {
+    "mtime": 1781739116.1616344,
+    "ast_hash": "776a016f822846ab283a63304e7bf5a8",
+    "semantic_hash": "776a016f822846ab283a63304e7bf5a8"
+  },
+  "services/orion-context-exec/app/trace_tools.py": {
+    "mtime": 1781132422.7004807,
+    "ast_hash": "44d7e2fe5419997d029b5b4c5c1775ae",
+    "semantic_hash": "44d7e2fe5419997d029b5b4c5c1775ae"
+  },
+  "services/orion-context-exec/app/workspace.py": {
+    "mtime": 1781739116.1616344,
+    "ast_hash": "16a3fd7515ec905c83ca4619f649d16b",
+    "semantic_hash": "16a3fd7515ec905c83ca4619f649d16b"
+  },
+  "services/orion-context-exec/app/workspace_tools.py": {
+    "mtime": 1783107031.9719017,
+    "ast_hash": "92cce9f32cbe0bbccdaf59e102f85c71",
+    "semantic_hash": "92cce9f32cbe0bbccdaf59e102f85c71"
+  },
+  "services/orion-context-exec/scripts/verify_agent_repl_live.py": {
+    "mtime": 1782955656.2747061,
+    "ast_hash": "5669678398a5b14c09dc66c557de98f4",
+    "semantic_hash": "5669678398a5b14c09dc66c557de98f4"
+  },
+  "services/orion-context-exec/tests/conftest.py": {
+    "mtime": 1781739116.1626346,
+    "ast_hash": "2849be43f5f451145e9f92e7030f0033",
+    "semantic_hash": "2849be43f5f451145e9f92e7030f0033"
+  },
+  "services/orion-context-exec/tests/test_agent_chain_compat.py": {
+    "mtime": 1781131289.704095,
+    "ast_hash": "9549f4e62af508fc9dbeb5ef2cbf9bcb",
+    "semantic_hash": "9549f4e62af508fc9dbeb5ef2cbf9bcb"
+  },
+  "services/orion-context-exec/tests/test_agent_lane_health.py": {
+    "mtime": 1781511934.2807467,
+    "ast_hash": "f2d0b8f8e018aea20d0239317f0e816d",
+    "semantic_hash": "f2d0b8f8e018aea20d0239317f0e816d"
+  },
+  "services/orion-context-exec/tests/test_agent_repl_runner.py": {
+    "mtime": 1783113795.7059557,
+    "ast_hash": "44d23ec6f2b7a09d9889eeb940d4bc8f",
+    "semantic_hash": "44d23ec6f2b7a09d9889eeb940d4bc8f"
+  },
+  "services/orion-context-exec/tests/test_agent_repl_semantic_telemetry.py": {
+    "mtime": 1783113795.7059557,
+    "ast_hash": "be586d90081b21bbc0f51c25f56993eb",
+    "semantic_hash": "be586d90081b21bbc0f51c25f56993eb"
+  },
+  "services/orion-context-exec/tests/test_agent_repl_tools.py": {
+    "mtime": 1783107031.9719017,
+    "ast_hash": "ec25b3c2ceaf7b05213af1850dcb15e7",
+    "semantic_hash": "ec25b3c2ceaf7b05213af1850dcb15e7"
+  },
+  "services/orion-context-exec/tests/test_agent_synthesis.py": {
+    "mtime": 1781511934.2807467,
+    "ast_hash": "fedcc2d274ffda20818157c78cd8c90c",
+    "semantic_hash": "fedcc2d274ffda20818157c78cd8c90c"
+  },
+  "services/orion-context-exec/tests/test_alexzhang_rlm_engine.py": {
+    "mtime": 1781511934.2807467,
+    "ast_hash": "cdf0fb57730a86ffc5f5c9adf3543d8c",
+    "semantic_hash": "cdf0fb57730a86ffc5f5c9adf3543d8c"
+  },
+  "services/orion-context-exec/tests/test_belief_provenance_contract.py": {
+    "mtime": 1781131289.704095,
+    "ast_hash": "7a4b5be5dc571f954185b49f9024d19b",
+    "semantic_hash": "7a4b5be5dc571f954185b49f9024d19b"
+  },
+  "services/orion-context-exec/tests/test_bus_listener_causality.py": {
+    "mtime": 1781153487.9885786,
+    "ast_hash": "8b879837128fa983eed96fa9d8d32569",
+    "semantic_hash": "8b879837128fa983eed96fa9d8d32569"
+  },
+  "services/orion-context-exec/tests/test_context_exec_events.py": {
+    "mtime": 1781132422.7004807,
+    "ast_hash": "cc42587226189e3b3bf589233bfeee98",
+    "semantic_hash": "cc42587226189e3b3bf589233bfeee98"
+  },
+  "services/orion-context-exec/tests/test_context_exec_timeout.py": {
+    "mtime": 1781131289.704095,
+    "ast_hash": "f371d836dfd993dfdb476970a4e2b19d",
+    "semantic_hash": "f371d836dfd993dfdb476970a4e2b19d"
+  },
+  "services/orion-context-exec/tests/test_context_exec_v2_readiness_hardening.py": {
+    "mtime": 1781584864.517582,
+    "ast_hash": "f298635180b025a32184d9c429b7d3be",
+    "semantic_hash": "f298635180b025a32184d9c429b7d3be"
+  },
+  "services/orion-context-exec/tests/test_event_emitter_isolation.py": {
+    "mtime": 1781132422.7014809,
+    "ast_hash": "ad703533dc50c626c1858c4e99acc33a",
+    "semantic_hash": "ad703533dc50c626c1858c4e99acc33a"
+  },
+  "services/orion-context-exec/tests/test_fake_organs_policy.py": {
+    "mtime": 1781132422.7014809,
+    "ast_hash": "7a1477e4f754f3a6d27ea6e8da9158a0",
+    "semantic_hash": "7a1477e4f754f3a6d27ea6e8da9158a0"
+  },
+  "services/orion-context-exec/tests/test_grounding_eval.py": {
+    "mtime": 1781511934.2807467,
+    "ast_hash": "3c031ae0f16b6049eb93402813dd6f84",
+    "semantic_hash": "3c031ae0f16b6049eb93402813dd6f84"
+  },
+  "services/orion-context-exec/tests/test_health.py": {
+    "mtime": 1783107031.9719017,
+    "ast_hash": "9ebec6ec191ce3b14d19d80a9095deae",
+    "semantic_hash": "9ebec6ec191ce3b14d19d80a9095deae"
+  },
+  "services/orion-context-exec/tests/test_investigation_probe_plan.py": {
+    "mtime": 1781739116.1626346,
+    "ast_hash": "d21da783964bda72a2997f2cbf8006c7",
+    "semantic_hash": "d21da783964bda72a2997f2cbf8006c7"
+  },
+  "services/orion-context-exec/tests/test_investigation_v2.py": {
+    "mtime": 1781739116.1626346,
+    "ast_hash": "5f84538453737eb7725d713167b272c1",
+    "semantic_hash": "5f84538453737eb7725d713167b272c1"
+  },
+  "services/orion-context-exec/tests/test_investigation_v2_epistemic.py": {
+    "mtime": 1781739116.1626346,
+    "ast_hash": "14d3039d9941e2e71d637e5986b17765",
+    "semantic_hash": "14d3039d9941e2e71d637e5986b17765"
+  },
+  "services/orion-context-exec/tests/test_investigation_v2_readiness.py": {
+    "mtime": 1781559772.6104517,
+    "ast_hash": "32717d34b191e4e82c746bcd6057bac6",
+    "semantic_hash": "32717d34b191e4e82c746bcd6057bac6"
+  },
+  "services/orion-context-exec/tests/test_investigation_v2_reducers.py": {
+    "mtime": 1781739116.1626346,
+    "ast_hash": "399c1f0392df68334e5a937a44c38fff",
+    "semantic_hash": "399c1f0392df68334e5a937a44c38fff"
+  },
+  "services/orion-context-exec/tests/test_llm_profile_binding.py": {
+    "mtime": 1781495413.7773755,
+    "ast_hash": "13451740684216611bd34a77e32972ba",
+    "semantic_hash": "13451740684216611bd34a77e32972ba"
+  },
+  "services/orion-context-exec/tests/test_llm_profile_resolver.py": {
+    "mtime": 1781494684.920417,
+    "ast_hash": "7a5863d4c2a0b1b31755bdce0265c1fe",
+    "semantic_hash": "7a5863d4c2a0b1b31755bdce0265c1fe"
+  },
+  "services/orion-context-exec/tests/test_memory_correction_proposal.py": {
+    "mtime": 1781477213.6547468,
+    "ast_hash": "a6376fe36dfe0bddbf64d6e60c45c602",
+    "semantic_hash": "a6376fe36dfe0bddbf64d6e60c45c602"
+  },
+  "services/orion-context-exec/tests/test_no_write_policy.py": {
+    "mtime": 1781131289.704095,
+    "ast_hash": "36266d151798dfaab4bff048772bebab",
+    "semantic_hash": "36266d151798dfaab4bff048772bebab"
+  },
+  "services/orion-context-exec/tests/test_organ_runtime_trace_search.py": {
+    "mtime": 1781132422.7014809,
+    "ast_hash": "005bcef78a178fa92bfc8af0a5c111bb",
+    "semantic_hash": "005bcef78a178fa92bfc8af0a5c111bb"
+  },
+  "services/orion-context-exec/tests/test_organ_status.py": {
+    "mtime": 1781511934.2807467,
+    "ast_hash": "a2a9e4d313e8498184dd9c2fe4c84c5d",
+    "semantic_hash": "a2a9e4d313e8498184dd9c2fe4c84c5d"
+  },
+  "services/orion-context-exec/tests/test_patch_proposal.py": {
+    "mtime": 1781405728.498089,
+    "ast_hash": "c32d96e75b31b5fddd7eecd10f36ab9d",
+    "semantic_hash": "c32d96e75b31b5fddd7eecd10f36ab9d"
+  },
+  "services/orion-context-exec/tests/test_proposal_envelope.py": {
+    "mtime": 1781457339.7694073,
+    "ast_hash": "d9e8c4946ac674eb138b116c0401efb5",
+    "semantic_hash": "d9e8c4946ac674eb138b116c0401efb5"
+  },
+  "services/orion-context-exec/tests/test_proposal_ledger.py": {
+    "mtime": 1781457339.7694073,
+    "ast_hash": "6e64b93c654d39de1986333407325f3e",
+    "semantic_hash": "6e64b93c654d39de1986333407325f3e"
+  },
+  "services/orion-context-exec/tests/test_proposal_ledger_intake.py": {
+    "mtime": 1781484475.969773,
+    "ast_hash": "114e9893aa6ab4352424f674fce2a229",
+    "semantic_hash": "114e9893aa6ab4352424f674fce2a229"
+  },
+  "services/orion-context-exec/tests/test_real_organs_disabled_writes.py": {
+    "mtime": 1781132422.7014809,
+    "ast_hash": "bddb0250c34060d4a1c1b92f5f517289",
+    "semantic_hash": "bddb0250c34060d4a1c1b92f5f517289"
+  },
+  "services/orion-context-exec/tests/test_recall_tools.py": {
+    "mtime": 1781132422.7014809,
+    "ast_hash": "417918863955e5dda548c69c072fbd5f",
+    "semantic_hash": "417918863955e5dda548c69c072fbd5f"
+  },
+  "services/orion-context-exec/tests/test_repo_tools.py": {
+    "mtime": 1781756361.843556,
+    "ast_hash": "0f214a779907ff8174edffaf774c834f",
+    "semantic_hash": "0f214a779907ff8174edffaf774c834f"
+  },
+  "services/orion-context-exec/tests/test_rlm_eval_fixtures.py": {
+    "mtime": 1781484475.969773,
+    "ast_hash": "69d47852e10e7e8a6625b0c42ea3a0c3",
+    "semantic_hash": "69d47852e10e7e8a6625b0c42ea3a0c3"
+  },
+  "services/orion-context-exec/tests/test_run_ledger.py": {
+    "mtime": 1781739116.1626346,
+    "ast_hash": "1e4277cfdd095d7e351bb4e17a4d7420",
+    "semantic_hash": "1e4277cfdd095d7e351bb4e17a4d7420"
+  },
+  "services/orion-context-exec/tests/test_runner_grounding_preflight.py": {
+    "mtime": 1781511934.2807467,
+    "ast_hash": "214719944d05a2e2b8cf82c59361d82d",
+    "semantic_hash": "214719944d05a2e2b8cf82c59361d82d"
+  },
+  "services/orion-context-exec/tests/test_smolcode_engine.py": {
+    "mtime": 1782955656.2747061,
+    "ast_hash": "b1ba3c0d4acb73d2de3206af14c42cac",
+    "semantic_hash": "b1ba3c0d4acb73d2de3206af14c42cac"
+  },
+  "services/orion-context-exec/tests/test_trace_tools.py": {
+    "mtime": 1781132422.7014809,
+    "ast_hash": "f894cfd53fc75bdb81ca63bd40ef8448",
+    "semantic_hash": "f894cfd53fc75bdb81ca63bd40ef8448"
+  },
+  "services/orion-context-exec/tests/test_workspace.py": {
+    "mtime": 1781739263.4071784,
+    "ast_hash": "a88905fdd0f1fe44aaa0d5fc8705e287",
+    "semantic_hash": "a88905fdd0f1fe44aaa0d5fc8705e287"
+  },
+  "services/orion-cortex-exec/app/__init__.py": {
+    "mtime": 1778910799.8663874,
+    "ast_hash": "6a4d5043583974e6fe055220504f12ef",
+    "semantic_hash": "6a4d5043583974e6fe055220504f12ef"
+  },
+  "services/orion-cortex-exec/app/actions_skill_registry.py": {
+    "mtime": 1783499830.1955209,
+    "ast_hash": "c58a25a1c6153526c8eedd3ed80fb33a",
+    "semantic_hash": "c58a25a1c6153526c8eedd3ed80fb33a"
+  },
+  "services/orion-cortex-exec/app/attention_frame.py": {
+    "mtime": 1778901838.372395,
+    "ast_hash": "e6a33ba9c2472fe0cd2aeaf1f4a94fc2",
+    "semantic_hash": "e6a33ba9c2472fe0cd2aeaf1f4a94fc2"
+  },
+  "services/orion-cortex-exec/app/autonomy_goal_execute.py": {
+    "mtime": 1783499830.1955209,
+    "ast_hash": "08dd20a518170007e75fd0fb960cfaf1",
+    "semantic_hash": "08dd20a518170007e75fd0fb960cfaf1"
+  },
+  "services/orion-cortex-exec/app/autonomy_graph_probe.py": {
+    "mtime": 1778901838.372395,
+    "ast_hash": "9facf114abbaaa8996a96515c1f635b1",
+    "semantic_hash": "9facf114abbaaa8996a96515c1f635b1"
+  },
+  "services/orion-cortex-exec/app/autonomy_slice.py": {
+    "mtime": 1783740584.5914984,
+    "ast_hash": "1e827539a92cd32876ac752dade47b1e",
+    "semantic_hash": "1e827539a92cd32876ac752dade47b1e"
+  },
+  "services/orion-cortex-exec/app/bound_capability_exec.py": {
+    "mtime": 1783499830.1955209,
+    "ast_hash": "4c8cffab2ea982ca9e8256211ccac13f",
+    "semantic_hash": "4c8cffab2ea982ca9e8256211ccac13f"
+  },
+  "services/orion-cortex-exec/app/capability_bridge.py": {
+    "mtime": 1783499830.1955209,
+    "ast_hash": "bb9aa192a0dd4806258c55897655fb8a",
+    "semantic_hash": "bb9aa192a0dd4806258c55897655fb8a"
+  },
+  "services/orion-cortex-exec/app/chat_stance.py": {
+    "mtime": 1783986358.1046565,
+    "ast_hash": "54fdc618c5a12405e0b75e671d2dcb0e",
+    "semantic_hash": "54fdc618c5a12405e0b75e671d2dcb0e"
+  },
+  "services/orion-cortex-exec/app/chat_stance_shared_spine.py": {
+    "mtime": 1779070080.246205,
+    "ast_hash": "35442e5c2ac6e86e5e2a6a1d73a4790a",
+    "semantic_hash": "35442e5c2ac6e86e5e2a6a1d73a4790a"
+  },
+  "services/orion-cortex-exec/app/clients.py": {
+    "mtime": 1783499830.1955209,
+    "ast_hash": "1b488c56e1894950e295caf69176903c",
+    "semantic_hash": "1b488c56e1894950e295caf69176903c"
+  },
+  "services/orion-cortex-exec/app/collapse_verbs.py": {
+    "mtime": 1782938951.7367241,
+    "ast_hash": "12e583e54ee02361fdcdabe45253316c",
+    "semantic_hash": "12e583e54ee02361fdcdabe45253316c"
+  },
+  "services/orion-cortex-exec/app/core_event_cache.py": {
+    "mtime": 1773975149.957786,
+    "ast_hash": "770399fa87420b672c622655d8972c7b",
+    "semantic_hash": "770399fa87420b672c622655d8972c7b"
+  },
+  "services/orion-cortex-exec/app/dream_publish.py": {
+    "mtime": 1774236180.4473855,
+    "ast_hash": "7c2538e557c12c9c2184ff71f990ded2",
+    "semantic_hash": "7c2538e557c12c9c2184ff71f990ded2"
+  },
+  "services/orion-cortex-exec/app/embodiment_background.py": {
+    "mtime": 1783450708.643728,
+    "ast_hash": "6ecf324af0185be7bd02ac9ed62c34d3",
+    "semantic_hash": "6ecf324af0185be7bd02ac9ed62c34d3"
+  },
+  "services/orion-cortex-exec/app/endogenous_runtime.py": {
+    "mtime": 1783834650.9980502,
+    "ast_hash": "5a5adbd17fa666dd034615d594bb2cff",
+    "semantic_hash": "5a5adbd17fa666dd034615d594bb2cff"
+  },
+  "services/orion-cortex-exec/app/endogenous_runtime_sql_reader.py": {
+    "mtime": 1775601136.3198965,
+    "ast_hash": "592e6a41c42cc957a0823ab781259423",
+    "semantic_hash": "592e6a41c42cc957a0823ab781259423"
+  },
+  "services/orion-cortex-exec/app/endogenous_runtime_store.py": {
+    "mtime": 1775601136.3198965,
+    "ast_hash": "2fbb1a68966679cf73d941a17659dbc0",
+    "semantic_hash": "2fbb1a68966679cf73d941a17659dbc0"
+  },
+  "services/orion-cortex-exec/app/executor.py": {
+    "mtime": 1783958824.2826838,
+    "ast_hash": "c6a4d46b53835324516a1c495cd7137a",
+    "semantic_hash": "c6a4d46b53835324516a1c495cd7137a"
+  },
+  "services/orion-cortex-exec/app/grammar_emit.py": {
+    "mtime": 1783614403.6182735,
+    "ast_hash": "bd0b4114a80b96e4eca44180ba33572a",
+    "semantic_hash": "bd0b4114a80b96e4eca44180ba33572a"
+  },
+  "services/orion-cortex-exec/app/grammar_publish.py": {
+    "mtime": 1779675743.8867543,
+    "ast_hash": "9a751ce310afb37cdf8df7c99afee12b",
+    "semantic_hash": "9a751ce310afb37cdf8df7c99afee12b"
+  },
+  "services/orion-cortex-exec/app/grounding_capsule.py": {
+    "mtime": 1783555541.5326738,
+    "ast_hash": "e92646aa614259a0149738b1208f9850",
+    "semantic_hash": "e92646aa614259a0149738b1208f9850"
+  },
+  "services/orion-cortex-exec/app/health_http.py": {
+    "mtime": 1781846476.492166,
+    "ast_hash": "0d45b90c632e52b96163783c0cfe3800",
+    "semantic_hash": "0d45b90c632e52b96163783c0cfe3800"
+  },
+  "services/orion-cortex-exec/app/llm_lane.py": {
+    "mtime": 1783396080.016995,
+    "ast_hash": "9c3e47548db88ac2f4dd4f40d9a8274c",
+    "semantic_hash": "9c3e47548db88ac2f4dd4f40d9a8274c"
+  },
+  "services/orion-cortex-exec/app/main.py": {
+    "mtime": 1783922614.1634874,
+    "ast_hash": "59ef63cb0a74b58c70bc92fc7bc0c7e0",
+    "semantic_hash": "59ef63cb0a74b58c70bc92fc7bc0c7e0"
+  },
+  "services/orion-cortex-exec/app/metacog_enrichment.py": {
+    "mtime": 1774759059.158305,
+    "ast_hash": "9297716ebbf475fb5ced94225b39b158",
+    "semantic_hash": "9297716ebbf475fb5ced94225b39b158"
+  },
+  "services/orion-cortex-exec/app/pageindex_client.py": {
+    "mtime": 1776570604.7987216,
+    "ast_hash": "8b2d9248f6af2ef7247463ee7e76be4d",
+    "semantic_hash": "8b2d9248f6af2ef7247463ee7e76be4d"
+  },
+  "services/orion-cortex-exec/app/pcr_chat_memory.py": {
+    "mtime": 1783555541.533674,
+    "ast_hash": "12efd070e76c77725461296dea350406",
+    "semantic_hash": "12efd070e76c77725461296dea350406"
+  },
+  "services/orion-cortex-exec/app/pre_turn_appraisal.py": {
+    "mtime": 1783136738.0548804,
+    "ast_hash": "07750771b6d1ebdc13f6881eec2f8e18",
+    "semantic_hash": "07750771b6d1ebdc13f6881eec2f8e18"
+  },
+  "services/orion-cortex-exec/app/reasoning_emit.py": {
+    "mtime": 1783615607.9869459,
+    "ast_hash": "33af66a48abe8f86c7f2d763c25237e7",
+    "semantic_hash": "33af66a48abe8f86c7f2d763c25237e7"
+  },
+  "services/orion-cortex-exec/app/recall_utils.py": {
+    "mtime": 1780122138.1665592,
+    "ast_hash": "82693675c2d977c34133effd170c3e6e",
+    "semantic_hash": "82693675c2d977c34133effd170c3e6e"
+  },
+  "services/orion-cortex-exec/app/router.py": {
+    "mtime": 1783967452.502406,
+    "ast_hash": "4e2b5d7e4ed5e459629a4e7b397881bb",
+    "semantic_hash": "4e2b5d7e4ed5e459629a4e7b397881bb"
+  },
+  "services/orion-cortex-exec/app/self_study.py": {
+    "mtime": 1774242565.111185,
+    "ast_hash": "62ed5d03d7173c8baf758e9ca33b6f39",
+    "semantic_hash": "62ed5d03d7173c8baf758e9ca33b6f39"
+  },
+  "services/orion-cortex-exec/app/self_study_harness.py": {
+    "mtime": 1774242565.111185,
+    "ast_hash": "632eac124db6f64e21ae367a65ad6436",
+    "semantic_hash": "632eac124db6f64e21ae367a65ad6436"
+  },
+  "services/orion-cortex-exec/app/self_study_policy.py": {
+    "mtime": 1774236180.4473855,
+    "ast_hash": "63565c98ee5bae876977b31b588e59c8",
+    "semantic_hash": "63565c98ee5bae876977b31b588e59c8"
+  },
+  "services/orion-cortex-exec/app/service_registry.py": {
+    "mtime": 1783499830.197521,
+    "ast_hash": "3cd5f94abcd3c22d0f59d093cc36ecb8",
+    "semantic_hash": "3cd5f94abcd3c22d0f59d093cc36ecb8"
+  },
+  "services/orion-cortex-exec/app/settings.py": {
+    "mtime": 1783615607.9869459,
+    "ast_hash": "c03b809b7c66969bec3bca1e3c4c00bb",
+    "semantic_hash": "c03b809b7c66969bec3bca1e3c4c00bb"
+  },
+  "services/orion-cortex-exec/app/situation.py": {
+    "mtime": 1779070080.249205,
+    "ast_hash": "4170e6ccc59f1292b6af141897811354",
+    "semantic_hash": "4170e6ccc59f1292b6af141897811354"
+  },
+  "services/orion-cortex-exec/app/spark_narrative.py": {
+    "mtime": 1783903398.6434438,
+    "ast_hash": "e2973c1f9efa3b23ae906636ca6261c6",
+    "semantic_hash": "e2973c1f9efa3b23ae906636ca6261c6"
+  },
+  "services/orion-cortex-exec/app/substrate_felt_state_reader.py": {
+    "mtime": 1783107031.9739017,
+    "ast_hash": "2d1d6e5b17da60191bd6379f316ba0a3",
+    "semantic_hash": "2d1d6e5b17da60191bd6379f316ba0a3"
+  },
+  "services/orion-cortex-exec/app/supervisor.py": {
+    "mtime": 1783499830.1985211,
+    "ast_hash": "7bbed4f3602d400be6b1bf5e333393a4",
+    "semantic_hash": "7bbed4f3602d400be6b1bf5e333393a4"
+  },
+  "services/orion-cortex-exec/app/trace_cache.py": {
+    "mtime": 1768597909.8852296,
+    "ast_hash": "48a41d988a62c5339c8c309f405d7e58",
+    "semantic_hash": "48a41d988a62c5339c8c309f405d7e58"
+  },
+  "services/orion-cortex-exec/app/verb_adapters.py": {
+    "mtime": 1783555541.534674,
+    "ast_hash": "0589545400b0d9200c5bd86862071462",
+    "semantic_hash": "0589545400b0d9200c5bd86862071462"
+  },
+  "services/orion-cortex-exec/app/workflow_journal_exec.py": {
+    "mtime": 1776053446.5125825,
+    "ast_hash": "f7d4e1221ac540e1c5c95a90b3a2ce1c",
+    "semantic_hash": "f7d4e1221ac540e1c5c95a90b3a2ce1c"
+  },
+  "services/orion-cortex-exec/app/world_context.py": {
+    "mtime": 1777748523.3235989,
+    "ast_hash": "44d255403756645dd59998274bded3be",
+    "semantic_hash": "44d255403756645dd59998274bded3be"
+  },
+  "services/orion-cortex-exec/scripts/up-with-tailscale.sh": {
+    "mtime": 1775948546.0555117,
+    "ast_hash": "8afe5ab1968a84210cea1f251457a8ba",
+    "semantic_hash": "8afe5ab1968a84210cea1f251457a8ba"
+  },
+  "services/orion-cortex-exec/tests/_exec_import_guard.py": {
+    "mtime": 1777790653.2170317,
+    "ast_hash": "06616f993db6a013b7427d6073befc1e",
+    "semantic_hash": "06616f993db6a013b7427d6073befc1e"
+  },
+  "services/orion-cortex-exec/tests/conftest.py": {
+    "mtime": 1783807362.662784,
+    "ast_hash": "822a1f290ea37197440178dc8526a831",
+    "semantic_hash": "822a1f290ea37197440178dc8526a831"
+  },
+  "services/orion-cortex-exec/tests/test_actions_verb.py": {
+    "mtime": 1776554728.1446984,
+    "ast_hash": "bffebe3274748e53c80692e2d0501de4",
+    "semantic_hash": "bffebe3274748e53c80692e2d0501de4"
+  },
+  "services/orion-cortex-exec/tests/test_attention_frame.py": {
+    "mtime": 1778901838.3753948,
+    "ast_hash": "a7a15c572b3dbde27cc1c04250360e65",
+    "semantic_hash": "a7a15c572b3dbde27cc1c04250360e65"
+  },
+  "services/orion-cortex-exec/tests/test_attention_frame_integration.py": {
+    "mtime": 1783740584.5934982,
+    "ast_hash": "d41187b4be4862d9eaae4920554a9cce",
+    "semantic_hash": "d41187b4be4862d9eaae4920554a9cce"
+  },
+  "services/orion-cortex-exec/tests/test_autonomy_goal_execute.py": {
+    "mtime": 1783499830.1985211,
+    "ast_hash": "393d88c2f7b850cecdf69e80d4d5febb",
+    "semantic_hash": "393d88c2f7b850cecdf69e80d4d5febb"
+  },
+  "services/orion-cortex-exec/tests/test_autonomy_goal_execution_mode.py": {
+    "mtime": 1783499830.1985211,
+    "ast_hash": "2f392a4b12c43e73b4be224e55805645",
+    "semantic_hash": "2f392a4b12c43e73b4be224e55805645"
+  },
+  "services/orion-cortex-exec/tests/test_autonomy_repository_graph_diagnostics.py": {
+    "mtime": 1779320543.2493434,
+    "ast_hash": "6c27d1cfd474f8356f777ddaf30e2137",
+    "semantic_hash": "6c27d1cfd474f8356f777ddaf30e2137"
+  },
+  "services/orion-cortex-exec/tests/test_autonomy_repository_list_latest_short_circuit.py": {
+    "mtime": 1779320543.2493434,
+    "ast_hash": "6d5c3428fb12df26b68670ed5c0ac396",
+    "semantic_hash": "6d5c3428fb12df26b68670ed5c0ac396"
+  },
+  "services/orion-cortex-exec/tests/test_autonomy_slice.py": {
+    "mtime": 1783740584.5944984,
+    "ast_hash": "cb69c3b1ee1880c1ee91487042d2cc34",
+    "semantic_hash": "cb69c3b1ee1880c1ee91487042d2cc34"
+  },
+  "services/orion-cortex-exec/tests/test_bound_capability_full_path.py": {
+    "mtime": 1783499830.199521,
+    "ast_hash": "6ceb95d45ac1fca7c64478acd4ebac68",
+    "semantic_hash": "6ceb95d45ac1fca7c64478acd4ebac68"
+  },
+  "services/orion-cortex-exec/tests/test_canonical_capability_routing.py": {
+    "mtime": 1775948546.0555117,
+    "ast_hash": "1a5278b1904e7dbacf5bb08cb135416c",
+    "semantic_hash": "1a5278b1904e7dbacf5bb08cb135416c"
+  },
+  "services/orion-cortex-exec/tests/test_chat_general_route_mapping.py": {
+    "mtime": 1778901838.3753948,
+    "ast_hash": "2a14403c1933ef7e1c9016022fa961d5",
+    "semantic_hash": "2a14403c1933ef7e1c9016022fa961d5"
+  },
+  "services/orion-cortex-exec/tests/test_chat_general_stance_plumbing.py": {
+    "mtime": 1782874038.2549727,
+    "ast_hash": "b53be744f1cf4427e06b24447472a9e8",
+    "semantic_hash": "b53be744f1cf4427e06b24447472a9e8"
+  },
+  "services/orion-cortex-exec/tests/test_chat_kids_story_plumbing.py": {
+    "mtime": 1778901838.3753948,
+    "ast_hash": "f069979e30430d33c69a22d768e78b93",
+    "semantic_hash": "f069979e30430d33c69a22d768e78b93"
+  },
+  "services/orion-cortex-exec/tests/test_chat_prompt_context_guardrails.py": {
+    "mtime": 1777875214.3356206,
+    "ast_hash": "d5d979e2a4537eb6712761a33a7b0895",
+    "semantic_hash": "d5d979e2a4537eb6712761a33a7b0895"
+  },
+  "services/orion-cortex-exec/tests/test_chat_quick_plumbing.py": {
+    "mtime": 1777875218.2626045,
+    "ast_hash": "90e7ef67d349901e05175c88b32df80e",
+    "semantic_hash": "90e7ef67d349901e05175c88b32df80e"
+  },
+  "services/orion-cortex-exec/tests/test_chat_relational_stance.py": {
+    "mtime": 1783114357.2179706,
+    "ast_hash": "a23327f328379ad8dc8bcfc191bfd58b",
+    "semantic_hash": "a23327f328379ad8dc8bcfc191bfd58b"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_autonomy_plumbing.py": {
+    "mtime": 1783740584.5944984,
+    "ast_hash": "ba6518446919d7b4434998847afc6034",
+    "semantic_hash": "ba6518446919d7b4434998847afc6034"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py": {
+    "mtime": 1783740584.5944984,
+    "ast_hash": "5d3e510d53fc375f761d3dda00a12da5",
+    "semantic_hash": "5d3e510d53fc375f761d3dda00a12da5"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_persistence.py": {
+    "mtime": 1783740584.5944984,
+    "ast_hash": "ed92c0f67c99285512e3e8cd52e71c10",
+    "semantic_hash": "ed92c0f67c99285512e3e8cd52e71c10"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2_pressure_probe.py": {
+    "mtime": 1783847515.5408454,
+    "ast_hash": "0a634ec461f8433a9fc83f27875c19e0",
+    "semantic_hash": "0a634ec461f8433a9fc83f27875c19e0"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_brief.py": {
+    "mtime": 1783740584.5944984,
+    "ast_hash": "2a5eac9f87d57bee4ced0448a0587650",
+    "semantic_hash": "2a5eac9f87d57bee4ced0448a0587650"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_drive_state_projection.py": {
+    "mtime": 1783986358.1046565,
+    "ast_hash": "7d06a4f63e1c1ca8f557420feeb34122",
+    "semantic_hash": "7d06a4f63e1c1ca8f557420feeb34122"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_reasoning_summary_phase4.py": {
+    "mtime": 1783740584.5944984,
+    "ast_hash": "5a392479653c35f9e005ecdce272dc04",
+    "semantic_hash": "5a392479653c35f9e005ecdce272dc04"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py": {
+    "mtime": 1783986358.1046565,
+    "ast_hash": "f91ed847d139a076c4b20b493882ff15",
+    "semantic_hash": "f91ed847d139a076c4b20b493882ff15"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_reverie_glimpse_projection.py": {
+    "mtime": 1783903398.6434438,
+    "ast_hash": "fbeebbf2c2b9ec07b75912809d971e88",
+    "semantic_hash": "fbeebbf2c2b9ec07b75912809d971e88"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_self_state_projection.py": {
+    "mtime": 1783740584.5944984,
+    "ast_hash": "4353e44f1e8b41d5746f96958b23a03b",
+    "semantic_hash": "4353e44f1e8b41d5746f96958b23a03b"
+  },
+  "services/orion-cortex-exec/tests/test_chat_stance_shared_spine.py": {
+    "mtime": 1778910799.8663874,
+    "ast_hash": "f5e955cf887698be35d8f4782fc46505",
+    "semantic_hash": "f5e955cf887698be35d8f4782fc46505"
+  },
+  "services/orion-cortex-exec/tests/test_cognition_trace_metadata.py": {
+    "mtime": 1783136738.0558803,
+    "ast_hash": "242e490c471470c07657256610311fd0",
+    "semantic_hash": "242e490c471470c07657256610311fd0"
+  },
+  "services/orion-cortex-exec/tests/test_cognition_trace_verb_runtime.py": {
+    "mtime": 1779335651.2567878,
+    "ast_hash": "299c54e7501e4724c4a90ad832fdddb4",
+    "semantic_hash": "299c54e7501e4724c4a90ad832fdddb4"
+  },
+  "services/orion-cortex-exec/tests/test_collapse_llm_uncertainty_telemetry.py": {
+    "mtime": 1779649387.8022988,
+    "ast_hash": "a74859aebee2dc64e960b0f125ff8e7a",
+    "semantic_hash": "a74859aebee2dc64e960b0f125ff8e7a"
+  },
+  "services/orion-cortex-exec/tests/test_conftest_cross_service_isolation.py": {
+    "mtime": 1783458889.5709457,
+    "ast_hash": "4b4a43daa153f32c8dc9180998ad4b50",
+    "semantic_hash": "4b4a43daa153f32c8dc9180998ad4b50"
+  },
+  "services/orion-cortex-exec/tests/test_context_exec_client.py": {
+    "mtime": 1781131289.706095,
+    "ast_hash": "c5dce42bf9a5becf7adb2b0207cab4fe",
+    "semantic_hash": "c5dce42bf9a5becf7adb2b0207cab4fe"
+  },
+  "services/orion-cortex-exec/tests/test_context_exec_depth2_routing.py": {
+    "mtime": 1783499830.199521,
+    "ast_hash": "d2923d3ca681bc049f1bc00eb3a8bbbc",
+    "semantic_hash": "d2923d3ca681bc049f1bc00eb3a8bbbc"
+  },
+  "services/orion-cortex-exec/tests/test_depth_routing.py": {
+    "mtime": 1774069579.2316463,
+    "ast_hash": "84d0a8fe71132b3cdb3dafc95c9e44e6",
+    "semantic_hash": "84d0a8fe71132b3cdb3dafc95c9e44e6"
+  },
+  "services/orion-cortex-exec/tests/test_dream_publish.py": {
+    "mtime": 1777748523.3235989,
+    "ast_hash": "66f3b89b3521fe6567ec13877f771a8c",
+    "semantic_hash": "66f3b89b3521fe6567ec13877f771a8c"
+  },
+  "services/orion-cortex-exec/tests/test_embodiment_background_emit.py": {
+    "mtime": 1783450708.644728,
+    "ast_hash": "4e598f2320c6aeb83a32360550e7802a",
+    "semantic_hash": "4e598f2320c6aeb83a32360550e7802a"
+  },
+  "services/orion-cortex-exec/tests/test_endogenous_runtime_phase8.py": {
+    "mtime": 1775601136.3198965,
+    "ast_hash": "cb96bc900b5602319db2d701dbb1ac90",
+    "semantic_hash": "cb96bc900b5602319db2d701dbb1ac90"
+  },
+  "services/orion-cortex-exec/tests/test_endogenous_runtime_sql_read_phase14.py": {
+    "mtime": 1775601136.3198965,
+    "ast_hash": "cb879b021b233b2a3be3623628d004a5",
+    "semantic_hash": "cb879b021b233b2a3be3623628d004a5"
+  },
+  "services/orion-cortex-exec/tests/test_exec_concurrent_handlers.py": {
+    "mtime": 1783807364.5538445,
+    "ast_hash": "11d41f1097217b90e4bbe39e0f6634bf",
+    "semantic_hash": "11d41f1097217b90e4bbe39e0f6634bf"
+  },
+  "services/orion-cortex-exec/tests/test_exec_grammar_emit.py": {
+    "mtime": 1783614403.4892697,
+    "ast_hash": "1a112c0a8acaec509285215b2c94c566",
+    "semantic_hash": "1a112c0a8acaec509285215b2c94c566"
+  },
+  "services/orion-cortex-exec/tests/test_exec_grammar_publish_fail_open.py": {
+    "mtime": 1779675743.8887544,
+    "ast_hash": "7ff4e37a4a8753724ee70bc12873afb7",
+    "semantic_hash": "7ff4e37a4a8753724ee70bc12873afb7"
+  },
+  "services/orion-cortex-exec/tests/test_executor_capability_bridge_skill_args.py": {
+    "mtime": 1775948546.0555117,
+    "ast_hash": "6bbd4a41fba354165d3fef9e341867c6",
+    "semantic_hash": "6bbd4a41fba354165d3fef9e341867c6"
+  },
+  "services/orion-cortex-exec/tests/test_executor_cleaning.py": {
+    "mtime": 1781404088.5861397,
+    "ast_hash": "9160f8b0a397cdc8411cb6cc2a54a74f",
+    "semantic_hash": "9160f8b0a397cdc8411cb6cc2a54a74f"
+  },
+  "services/orion-cortex-exec/tests/test_executor_docker_prune_skill_args.py": {
+    "mtime": 1775948546.0555117,
+    "ast_hash": "7a54fadfe8d5984622ec84da0088ad6a",
+    "semantic_hash": "7a54fadfe8d5984622ec84da0088ad6a"
+  },
+  "services/orion-cortex-exec/tests/test_executor_journal_pageindex_skip.py": {
+    "mtime": 1777748523.3235989,
+    "ast_hash": "4eb62e5fc9552c6eb6b1d3a5532aeac9",
+    "semantic_hash": "4eb62e5fc9552c6eb6b1d3a5532aeac9"
+  },
+  "services/orion-cortex-exec/tests/test_executor_runtime_context_skip.py": {
+    "mtime": 1781839414.7087297,
+    "ast_hash": "b8f76ed17f163ef320738936aaa23bd6",
+    "semantic_hash": "b8f76ed17f163ef320738936aaa23bd6"
+  },
+  "services/orion-cortex-exec/tests/test_felt_state_reader_curiosity_lane.py": {
+    "mtime": 1783105164.3500724,
+    "ast_hash": "3e8a3e0ece6a0774173dc0959f1ab6c6",
+    "semantic_hash": "3e8a3e0ece6a0774173dc0959f1ab6c6"
+  },
+  "services/orion-cortex-exec/tests/test_felt_state_reader_new_lanes.py": {
+    "mtime": 1782964832.635659,
+    "ast_hash": "04511750d388b9e852be41c56ae7e8ac",
+    "semantic_hash": "04511750d388b9e852be41c56ae7e8ac"
+  },
+  "services/orion-cortex-exec/tests/test_felt_state_reader_reverie_lane.py": {
+    "mtime": 1783903398.6434438,
+    "ast_hash": "43e6e54e79d0ead100865b8029350151",
+    "semantic_hash": "43e6e54e79d0ead100865b8029350151"
+  },
+  "services/orion-cortex-exec/tests/test_firebreak.py": {
+    "mtime": 1781405728.5000892,
+    "ast_hash": "2ecab7fbc3ef90e44f3b2b64ba8eb1c7",
+    "semantic_hash": "2ecab7fbc3ef90e44f3b2b64ba8eb1c7"
+  },
+  "services/orion-cortex-exec/tests/test_grounding_capsule_assembly.py": {
+    "mtime": 1783458889.5709457,
+    "ast_hash": "8a7b128d1d67ad9c6c98dd9739a03b02",
+    "semantic_hash": "8a7b128d1d67ad9c6c98dd9739a03b02"
+  },
+  "services/orion-cortex-exec/tests/test_harness_finalize_max_tokens.py": {
+    "mtime": 1783312413.512246,
+    "ast_hash": "c1eb0d3bbccf8046bba3ced918c794d5",
+    "semantic_hash": "c1eb0d3bbccf8046bba3ced918c794d5"
+  },
+  "services/orion-cortex-exec/tests/test_harness_finalize_route.py": {
+    "mtime": 1783817872.1396847,
+    "ast_hash": "fae5ffa11d51425f37885c2a814b67f8",
+    "semantic_hash": "fae5ffa11d51425f37885c2a814b67f8"
+  },
+  "services/orion-cortex-exec/tests/test_hub_chat_lane_recall_clamp.py": {
+    "mtime": 1780122153.412518,
+    "ast_hash": "28aacce1fe41af8ec18ab356367287f0",
+    "semantic_hash": "28aacce1fe41af8ec18ab356367287f0"
+  },
+  "services/orion-cortex-exec/tests/test_identity_injection.py": {
+    "mtime": 1774483364.9666045,
+    "ast_hash": "339163e470803c472ccc265e73ac13fd",
+    "semantic_hash": "339163e470803c472ccc265e73ac13fd"
+  },
+  "services/orion-cortex-exec/tests/test_journal_pageindex_mvp.py": {
+    "mtime": 1777164889.0888295,
+    "ast_hash": "19aa10012850ffdf18ee3468b1644906",
+    "semantic_hash": "19aa10012850ffdf18ee3468b1644906"
+  },
+  "services/orion-cortex-exec/tests/test_legacy_plan_personality_plumbing.py": {
+    "mtime": 1774483364.9666045,
+    "ast_hash": "154fd34eed6449df3b22d7abf47300d7",
+    "semantic_hash": "154fd34eed6449df3b22d7abf47300d7"
+  },
+  "services/orion-cortex-exec/tests/test_llm_lane_propagation.py": {
+    "mtime": 1783451739.0385215,
+    "ast_hash": "40820e61cdb2b0c4d90040ff2024c5a0",
+    "semantic_hash": "40820e61cdb2b0c4d90040ff2024c5a0"
+  },
+  "services/orion-cortex-exec/tests/test_llm_uncertainty_metadata.py": {
+    "mtime": 1783740584.5944984,
+    "ast_hash": "380b269d0dff1207114202ea26f4c568",
+    "semantic_hash": "380b269d0dff1207114202ea26f4c568"
+  },
+  "services/orion-cortex-exec/tests/test_main_autonomy_graph_probe.py": {
+    "mtime": 1775613610.4174464,
+    "ast_hash": "86f7cf7b755af43d270807d0f81e23fd",
+    "semantic_hash": "86f7cf7b755af43d270807d0f81e23fd"
+  },
+  "services/orion-cortex-exec/tests/test_memory_graph_suggest_final_text.py": {
+    "mtime": 1779079994.8332214,
+    "ast_hash": "6550bbfbdbbb17e07de1a3c74e9ffa9e",
+    "semantic_hash": "6550bbfbdbbb17e07de1a3c74e9ffa9e"
+  },
+  "services/orion-cortex-exec/tests/test_menu_topic_selection_output_guard.py": {
+    "mtime": 1774840917.2972112,
+    "ast_hash": "ecf9dbfd2367b57665ac7e573b447a97",
+    "semantic_hash": "ecf9dbfd2367b57665ac7e573b447a97"
+  },
+  "services/orion-cortex-exec/tests/test_metacog_publish_lane.py": {
+    "mtime": 1783107031.9739017,
+    "ast_hash": "ffb370577e2562607a7fa38a5f969773",
+    "semantic_hash": "ffb370577e2562607a7fa38a5f969773"
+  },
+  "services/orion-cortex-exec/tests/test_metacog_route_profile.py": {
+    "mtime": 1776554226.8218286,
+    "ast_hash": "9ad77b42c9b6130a7ddde8298b1ad4ec",
+    "semantic_hash": "9ad77b42c9b6130a7ddde8298b1ad4ec"
+  },
+  "services/orion-cortex-exec/tests/test_metacog_trigger_lineage.py": {
+    "mtime": 1783107031.974902,
+    "ast_hash": "6ed65183399b0f4262bead2aa8d01365",
+    "semantic_hash": "6ed65183399b0f4262bead2aa8d01365"
+  },
+  "services/orion-cortex-exec/tests/test_metacog_two_pass_draft.py": {
+    "mtime": 1783107031.974902,
+    "ast_hash": "33267d103f9fe9385ba33c913c46b7f6",
+    "semantic_hash": "33267d103f9fe9385ba33c913c46b7f6"
+  },
+  "services/orion-cortex-exec/tests/test_mind_handoff_shortcut.py": {
+    "mtime": 1779070080.250205,
+    "ast_hash": "19cba53f5798a3fadfdfe3f86299bb24",
+    "semantic_hash": "19cba53f5798a3fadfdfe3f86299bb24"
+  },
+  "services/orion-cortex-exec/tests/test_notify_chat_message_body_fallback.py": {
+    "mtime": 1775948546.0565119,
+    "ast_hash": "d4fdcdfc67f1786483b2b844ce24b25d",
+    "semantic_hash": "d4fdcdfc67f1786483b2b844ce24b25d"
+  },
+  "services/orion-cortex-exec/tests/test_operational_semantic_harness.py": {
+    "mtime": 1783499830.199521,
+    "ast_hash": "ef6fac1e4b54be0f91e6c90da699d638",
+    "semantic_hash": "ef6fac1e4b54be0f91e6c90da699d638"
+  },
+  "services/orion-cortex-exec/tests/test_pcr_chat_memory.py": {
+    "mtime": 1783398623.0111566,
+    "ast_hash": "92f909e7249a366d9f019715e5fad43f",
+    "semantic_hash": "92f909e7249a366d9f019715e5fad43f"
+  },
+  "services/orion-cortex-exec/tests/test_plan_ctx_latest_user_text.py": {
+    "mtime": 1777874942.6348488,
+    "ast_hash": "19b7ff00ab7be4007bc374733c554d7c",
+    "semantic_hash": "19b7ff00ab7be4007bc374733c554d7c"
+  },
+  "services/orion-cortex-exec/tests/test_pre_turn_appraisal_rpc.py": {
+    "mtime": 1783136738.0558803,
+    "ast_hash": "e4cd67ba885f356b36a2d4560147f639",
+    "semantic_hash": "e4cd67ba885f356b36a2d4560147f639"
+  },
+  "services/orion-cortex-exec/tests/test_pre_turn_handler_gate.py": {
+    "mtime": 1783136738.0558803,
+    "ast_hash": "501f7631abe2300659bb227c3ccccab7",
+    "semantic_hash": "501f7631abe2300659bb227c3ccccab7"
+  },
+  "services/orion-cortex-exec/tests/test_ready.py": {
+    "mtime": 1781846476.493166,
+    "ast_hash": "64c8745f754b20263a4b21cf8fb9098c",
+    "semantic_hash": "64c8745f754b20263a4b21cf8fb9098c"
+  },
+  "services/orion-cortex-exec/tests/test_reasoning_emit.py": {
+    "mtime": 1783615607.9869459,
+    "ast_hash": "30da827f24e26a66e16ee08a211716c0",
+    "semantic_hash": "30da827f24e26a66e16ee08a211716c0"
+  },
+  "services/orion-cortex-exec/tests/test_recall_active_turn_exclusion_payload.py": {
+    "mtime": 1774748231.6561255,
+    "ast_hash": "a3b2106d0da37d112385c0b298e3f5b0",
+    "semantic_hash": "a3b2106d0da37d112385c0b298e3f5b0"
+  },
+  "services/orion-cortex-exec/tests/test_recall_bus_rpc_timeout.py": {
+    "mtime": 1778901838.3753948,
+    "ast_hash": "6746399ec920be36935c9b5c59367bf5",
+    "semantic_hash": "6746399ec920be36935c9b5c59367bf5"
+  },
+  "services/orion-cortex-exec/tests/test_recall_delivery_gating.py": {
+    "mtime": 1778901838.376395,
+    "ast_hash": "931c706ef6bff6452341dcfcbfdaafcd",
+    "semantic_hash": "931c706ef6bff6452341dcfcbfdaafcd"
+  },
+  "services/orion-cortex-exec/tests/test_recall_profile_precedence.py": {
+    "mtime": 1774753212.3465319,
+    "ast_hash": "a957d8f49aa11df3309581ae1cf6ef87",
+    "semantic_hash": "a957d8f49aa11df3309581ae1cf6ef87"
+  },
+  "services/orion-cortex-exec/tests/test_repair_pressure_speech_wiring.py": {
+    "mtime": 1783114357.2179706,
+    "ast_hash": "8f3df7de0eb7e3afa1a6c59ad37f4b66",
+    "semantic_hash": "8f3df7de0eb7e3afa1a6c59ad37f4b66"
+  },
+  "services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py": {
+    "mtime": 1783740584.5954983,
+    "ast_hash": "4d2bf65fe393d1b588957661c3b9256f",
+    "semantic_hash": "4d2bf65fe393d1b588957661c3b9256f"
+  },
+  "services/orion-cortex-exec/tests/test_router_chat_general_recall_profile_default.py": {
+    "mtime": 1774753212.3465319,
+    "ast_hash": "38789895ce49f4d7b82970b2755c8010",
+    "semantic_hash": "38789895ce49f4d7b82970b2755c8010"
+  },
+  "services/orion-cortex-exec/tests/test_router_chat_quick_recall_rpc_cap.py": {
+    "mtime": 1783740584.5954983,
+    "ast_hash": "1a7aa9cbe34335841bd27b89d11d61c0",
+    "semantic_hash": "1a7aa9cbe34335841bd27b89d11d61c0"
+  },
+  "services/orion-cortex-exec/tests/test_router_final_text_assembly.py": {
+    "mtime": 1783967452.502406,
+    "ast_hash": "a84945984f8fcb834aa38423d77413c1",
+    "semantic_hash": "a84945984f8fcb834aa38423d77413c1"
+  },
+  "services/orion-cortex-exec/tests/test_router_grounding_capsule_metadata.py": {
+    "mtime": 1783740584.5954983,
+    "ast_hash": "27dd505d54ab4fc25de7b5ec1e79876f",
+    "semantic_hash": "27dd505d54ab4fc25de7b5ec1e79876f"
+  },
+  "services/orion-cortex-exec/tests/test_router_identity_boundary.py": {
+    "mtime": 1782531013.7273662,
+    "ast_hash": "008d7c15c156e625e98553359b732772",
+    "semantic_hash": "008d7c15c156e625e98553359b732772"
+  },
+  "services/orion-cortex-exec/tests/test_rpc_bus_fork.py": {
+    "mtime": 1781730419.4917872,
+    "ast_hash": "4d64eb615651cf93172526f680082c27",
+    "semantic_hash": "4d64eb615651cf93172526f680082c27"
+  },
+  "services/orion-cortex-exec/tests/test_self_study_consumer_wiring.py": {
+    "mtime": 1774236180.4483855,
+    "ast_hash": "5f40b92c4d91608548641115fce95e26",
+    "semantic_hash": "5f40b92c4d91608548641115fce95e26"
+  },
+  "services/orion-cortex-exec/tests/test_self_study_graphdb.py": {
+    "mtime": 1774242565.1121852,
+    "ast_hash": "c63eefb3043e537871208ccc47240c56",
+    "semantic_hash": "c63eefb3043e537871208ccc47240c56"
+  },
+  "services/orion-cortex-exec/tests/test_self_study_harness.py": {
+    "mtime": 1774242565.1121852,
+    "ast_hash": "3d96e2662f0d409732d2b5ff37d41cda",
+    "semantic_hash": "3d96e2662f0d409732d2b5ff37d41cda"
+  },
+  "services/orion-cortex-exec/tests/test_self_study_pass1.py": {
+    "mtime": 1774236180.4483855,
+    "ast_hash": "8537856570c415720e8bf66775cc111e",
+    "semantic_hash": "8537856570c415720e8bf66775cc111e"
+  },
+  "services/orion-cortex-exec/tests/test_self_study_policy.py": {
+    "mtime": 1774236180.4483855,
+    "ast_hash": "3e230e576fb2ae63a69c5a594dbacbf5",
+    "semantic_hash": "3e230e576fb2ae63a69c5a594dbacbf5"
+  },
+  "services/orion-cortex-exec/tests/test_situation_prompt_integration.py": {
+    "mtime": 1777748523.324599,
+    "ast_hash": "fc6f2b50b036155501782b9a47874901",
+    "semantic_hash": "fc6f2b50b036155501782b9a47874901"
+  },
+  "services/orion-cortex-exec/tests/test_situation_provider.py": {
+    "mtime": 1779070080.2512052,
+    "ast_hash": "b1a0926c91a256977bf1395d6b49ad09",
+    "semantic_hash": "b1a0926c91a256977bf1395d6b49ad09"
+  },
+  "services/orion-cortex-exec/tests/test_situation_settings_env.py": {
+    "mtime": 1777753742.9557354,
+    "ast_hash": "8a9bc33fc042b7cda5e96f33c5a5a9ab",
+    "semantic_hash": "8a9bc33fc042b7cda5e96f33c5a5a9ab"
+  },
+  "services/orion-cortex-exec/tests/test_skill_verbs.py": {
+    "mtime": 1783555541.534674,
+    "ast_hash": "abaeab7c7b62a992e79eb589f52e6419",
+    "semantic_hash": "abaeab7c7b62a992e79eb589f52e6419"
+  },
+  "services/orion-cortex-exec/tests/test_spark_narrative_embodiment.py": {
+    "mtime": 1783903398.6434438,
+    "ast_hash": "4bf84a5d4ddda1b0d07a427ccc2908e0",
+    "semantic_hash": "4bf84a5d4ddda1b0d07a427ccc2908e0"
+  },
+  "services/orion-cortex-exec/tests/test_story_weave_smoke.py": {
+    "mtime": 1773975149.9587862,
+    "ast_hash": "aba6825b9cfd7190a7c15459c3a463f5",
+    "semantic_hash": "aba6825b9cfd7190a7c15459c3a463f5"
+  },
+  "services/orion-cortex-exec/tests/test_substrate_felt_state_reader.py": {
+    "mtime": 1782871399.009733,
+    "ast_hash": "ea692f6385c488cd3f3b705c5894a48b",
+    "semantic_hash": "ea692f6385c488cd3f3b705c5894a48b"
+  },
+  "services/orion-cortex-exec/tests/test_tailscale_binary_resolve.py": {
+    "mtime": 1775948546.0565119,
+    "ast_hash": "c2d2346187f0779f8766e1b156be7876",
+    "semantic_hash": "c2d2346187f0779f8766e1b156be7876"
+  },
+  "services/orion-cortex-exec/tests/test_unified_pcr_phase01.py": {
+    "mtime": 1783740584.5954983,
+    "ast_hash": "da106040a247cb9d73589c128f1ccf21",
+    "semantic_hash": "da106040a247cb9d73589c128f1ccf21"
+  },
+  "services/orion-cortex-exec/tests/test_verb_listener_lane_wiring.py": {
+    "mtime": 1783922614.1634874,
+    "ast_hash": "890d5695b7678b33fd89fb74280323c1",
+    "semantic_hash": "890d5695b7678b33fd89fb74280323c1"
+  },
+  "services/orion-cortex-exec/tests/test_verb_runtime_reply_channel.py": {
+    "mtime": 1774069579.2316463,
+    "ast_hash": "053c5321652c6807c3ca9a814228ae59",
+    "semantic_hash": "053c5321652c6807c3ca9a814228ae59"
+  },
+  "services/orion-cortex-exec/tests/test_world_context_capsule_filter.py": {
+    "mtime": 1777748523.324599,
+    "ast_hash": "78f457b2f90aa25cc0dc785e703386ea",
+    "semantic_hash": "78f457b2f90aa25cc0dc785e703386ea"
+  },
+  "services/orion-cortex-gateway/app/__init__.py": {
+    "mtime": 1767676515.6501067,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-cortex-gateway/app/bus_client.py": {
+    "mtime": 1781839415.0907283,
+    "ast_hash": "14324f3199efdc61922defafe8c859db",
+    "semantic_hash": "14324f3199efdc61922defafe8c859db"
+  },
+  "services/orion-cortex-gateway/app/main.py": {
+    "mtime": 1781846476.493166,
+    "ast_hash": "8301c63c99959e8d06788ffae424fc3c",
+    "semantic_hash": "8301c63c99959e8d06788ffae424fc3c"
+  },
+  "services/orion-cortex-gateway/app/settings.py": {
+    "mtime": 1778901838.376395,
+    "ast_hash": "c1c761f41e3db999d2833b5f775458f8",
+    "semantic_hash": "c1c761f41e3db999d2833b5f775458f8"
+  },
+  "services/orion-cortex-gateway/tests/test_context_messages.py": {
+    "mtime": 1774761145.164644,
+    "ast_hash": "40a9334aae2217f282c71d61d73c130f",
+    "semantic_hash": "40a9334aae2217f282c71d61d73c130f"
+  },
+  "services/orion-cortex-gateway/tests/test_gateway_consumer_resilience.py": {
+    "mtime": 1781839415.7547262,
+    "ast_hash": "08a062bdf62dfe609af382e02879152e",
+    "semantic_hash": "08a062bdf62dfe609af382e02879152e"
+  },
+  "services/orion-cortex-gateway/tests/test_ready.py": {
+    "mtime": 1781846476.493166,
+    "ast_hash": "eeb71159038b285892bafb87041ec95b",
+    "semantic_hash": "eeb71159038b285892bafb87041ec95b"
+  },
+  "services/orion-cortex-orch/app/__init__.py": {
+    "mtime": 1767676515.6511068,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-cortex-orch/app/chat_history_compactor_memory.py": {
+    "mtime": 1783958824.2836838,
+    "ast_hash": "7e866569df300464072a9c8486d15bfc",
+    "semantic_hash": "7e866569df300464072a9c8486d15bfc"
+  },
+  "services/orion-cortex-orch/app/clients.py": {
+    "mtime": 1774823126.5286682,
+    "ast_hash": "37a5e38ad8275f5a615c66acec100079",
+    "semantic_hash": "37a5e38ad8275f5a615c66acec100079"
+  },
+  "services/orion-cortex-orch/app/concept_profile_config.py": {
+    "mtime": 1774754647.368414,
+    "ast_hash": "a60e23c5ab05008149e6f313cec79bb6",
+    "semantic_hash": "a60e23c5ab05008149e6f313cec79bb6"
+  },
+  "services/orion-cortex-orch/app/conversation_front.py": {
+    "mtime": 1777748523.324599,
+    "ast_hash": "313ff1c4e1833fe1c64e6acd757b861a",
+    "semantic_hash": "313ff1c4e1833fe1c64e6acd757b861a"
+  },
+  "services/orion-cortex-orch/app/decision_router.py": {
+    "mtime": 1781131289.707095,
+    "ast_hash": "788c057eaab6d46c4ddf3c0d7d469dd4",
+    "semantic_hash": "788c057eaab6d46c4ddf3c0d7d469dd4"
+  },
+  "services/orion-cortex-orch/app/execution_lanes.py": {
+    "mtime": 1778901838.376395,
+    "ast_hash": "a28019cf3d2a8eae875d2a442cef5f1d",
+    "semantic_hash": "a28019cf3d2a8eae875d2a442cef5f1d"
+  },
+  "services/orion-cortex-orch/app/github_compactor_memory.py": {
+    "mtime": 1783555541.5356739,
+    "ast_hash": "02c519dc0c6394d39bd75b430c556aa6",
+    "semantic_hash": "02c519dc0c6394d39bd75b430c556aa6"
+  },
+  "services/orion-cortex-orch/app/grammar_emit.py": {
+    "mtime": 1783903398.644444,
+    "ast_hash": "d76244f4b4dc275c970f110ffb2e627e",
+    "semantic_hash": "d76244f4b4dc275c970f110ffb2e627e"
+  },
+  "services/orion-cortex-orch/app/grammar_publish.py": {
+    "mtime": 1783903398.644444,
+    "ast_hash": "2d42d9489806fb871489c3b0ec2fd6c7",
+    "semantic_hash": "2d42d9489806fb871489c3b0ec2fd6c7"
+  },
+  "services/orion-cortex-orch/app/health_http.py": {
+    "mtime": 1781846476.493166,
+    "ast_hash": "0d45b90c632e52b96163783c0cfe3800",
+    "semantic_hash": "0d45b90c632e52b96163783c0cfe3800"
+  },
+  "services/orion-cortex-orch/app/main.py": {
+    "mtime": 1783903398.644444,
+    "ast_hash": "0ce62e287716d5d17edf2016381751a1",
+    "semantic_hash": "0ce62e287716d5d17edf2016381751a1"
+  },
+  "services/orion-cortex-orch/app/memory_extractor.py": {
+    "mtime": 1777753742.9557354,
+    "ast_hash": "09bfddedc2392e955ef851c69679ff49",
+    "semantic_hash": "09bfddedc2392e955ef851c69679ff49"
+  },
+  "services/orion-cortex-orch/app/memory_inject.py": {
+    "mtime": 1777758592.2212446,
+    "ast_hash": "4f21fa0994194a73c2aee4c28899c2b1",
+    "semantic_hash": "4f21fa0994194a73c2aee4c28899c2b1"
+  },
+  "services/orion-cortex-orch/app/mind_runtime.py": {
+    "mtime": 1779078270.5526717,
+    "ast_hash": "2dbc2fad43a1ce56e1ac1155ca1c7523",
+    "semantic_hash": "2dbc2fad43a1ce56e1ac1155ca1c7523"
+  },
+  "services/orion-cortex-orch/app/orchestrator.py": {
+    "mtime": 1783903398.644444,
+    "ast_hash": "314ecfecb50895ad6df5dafc202ea999",
+    "semantic_hash": "314ecfecb50895ad6df5dafc202ea999"
+  },
+  "services/orion-cortex-orch/app/output_mode_classifier.py": {
+    "mtime": 1775969148.8259866,
+    "ast_hash": "ecb093911898fc9af71872e0f9648737",
+    "semantic_hash": "ecb093911898fc9af71872e0f9648737"
+  },
+  "services/orion-cortex-orch/app/settings.py": {
+    "mtime": 1783915348.4277909,
+    "ast_hash": "a5b9ee4fc505eec824620b4c2bbccfbf",
+    "semantic_hash": "a5b9ee4fc505eec824620b4c2bbccfbf"
+  },
+  "services/orion-cortex-orch/app/tests/smoke_bus_worker.py": {
+    "mtime": 1768597909.8862295,
+    "ast_hash": "9dcfb7243c625cbe647f2273799f087f",
+    "semantic_hash": "9dcfb7243c625cbe647f2273799f087f"
+  },
+  "services/orion-cortex-orch/app/workflow_runtime.py": {
+    "mtime": 1783967737.3757126,
+    "ast_hash": "acb6810e2f558d57521dbb8ae0f0d31a",
+    "semantic_hash": "acb6810e2f558d57521dbb8ae0f0d31a"
+  },
+  "services/orion-cortex-orch/evals/conftest.py": {
+    "mtime": 1783958824.284684,
+    "ast_hash": "8911ddb7dec71ea142decdc479bf2dad",
+    "semantic_hash": "8911ddb7dec71ea142decdc479bf2dad"
+  },
+  "services/orion-cortex-orch/evals/test_chat_history_compactor_digest_eval.py": {
+    "mtime": 1783958824.284684,
+    "ast_hash": "94d63bb1801d15aa50707c889dbae71b",
+    "semantic_hash": "94d63bb1801d15aa50707c889dbae71b"
+  },
+  "services/orion-cortex-orch/tests/_orch_import_guard.py": {
+    "mtime": 1777790653.2180316,
+    "ast_hash": "aa7089c4f9a32ad6b6ca1449c29122f5",
+    "semantic_hash": "aa7089c4f9a32ad6b6ca1449c29122f5"
+  },
+  "services/orion-cortex-orch/tests/conftest.py": {
+    "mtime": 1778901838.377395,
+    "ast_hash": "f28b9ac457168920d292e27784990a9a",
+    "semantic_hash": "f28b9ac457168920d292e27784990a9a"
+  },
+  "services/orion-cortex-orch/tests/test_agent_trace_bound_failure_summary.py": {
+    "mtime": 1783499830.199521,
+    "ast_hash": "f4f238036bbb3f46ca146990eae53a29",
+    "semantic_hash": "f4f238036bbb3f46ca146990eae53a29"
+  },
+  "services/orion-cortex-orch/tests/test_auto_router.py": {
+    "mtime": 1783499830.2005212,
+    "ast_hash": "dd65d1e5ad318f3b7bb37d71a03abdbc",
+    "semantic_hash": "dd65d1e5ad318f3b7bb37d71a03abdbc"
+  },
+  "services/orion-cortex-orch/tests/test_concept_profile_config_adapter.py": {
+    "mtime": 1774754647.368414,
+    "ast_hash": "0d267223dc4806891be6335d677af0ca",
+    "semantic_hash": "0d267223dc4806891be6335d677af0ca"
+  },
+  "services/orion-cortex-orch/tests/test_context_exec_router.py": {
+    "mtime": 1781131289.707095,
+    "ast_hash": "537787405b6f5d4b48c79aa09c8dcfc7",
+    "semantic_hash": "537787405b6f5d4b48c79aa09c8dcfc7"
+  },
+  "services/orion-cortex-orch/tests/test_context_exec_router_heuristics.py": {
+    "mtime": 1781131289.707095,
+    "ast_hash": "765396bfcd3b4fe68491c7a8aaf16e40",
+    "semantic_hash": "765396bfcd3b4fe68491c7a8aaf16e40"
+  },
+  "services/orion-cortex-orch/tests/test_execution_lanes.py": {
+    "mtime": 1778901838.377395,
+    "ast_hash": "50c69f3b9bbbb2f4b200f940f232338d",
+    "semantic_hash": "50c69f3b9bbbb2f4b200f940f232338d"
+  },
+  "services/orion-cortex-orch/tests/test_lane_routing.py": {
+    "mtime": 1783903398.644444,
+    "ast_hash": "0cb43a075d2cc2e37cac684abd7ad10f",
+    "semantic_hash": "0cb43a075d2cc2e37cac684abd7ad10f"
+  },
+  "services/orion-cortex-orch/tests/test_memory_extractor.py": {
+    "mtime": 1777753742.9597354,
+    "ast_hash": "b9c5de7fd92d61bac51e4c150df2391e",
+    "semantic_hash": "b9c5de7fd92d61bac51e4c150df2391e"
+  },
+  "services/orion-cortex-orch/tests/test_mind_evidence_facets.py": {
+    "mtime": 1779070080.254205,
+    "ast_hash": "aa1843bb69479a0c5cec3d4bf025ee11",
+    "semantic_hash": "aa1843bb69479a0c5cec3d4bf025ee11"
+  },
+  "services/orion-cortex-orch/tests/test_mind_orch.py": {
+    "mtime": 1783615212.4799123,
+    "ast_hash": "cad4ca245d032b770668b83e3d4a977e",
+    "semantic_hash": "cad4ca245d032b770668b83e3d4a977e"
+  },
+  "services/orion-cortex-orch/tests/test_mind_projection_context_enrichment.py": {
+    "mtime": 1779070080.254205,
+    "ast_hash": "f2e73037aa0653c3c280d37ec9b2fd66",
+    "semantic_hash": "f2e73037aa0653c3c280d37ec9b2fd66"
+  },
+  "services/orion-cortex-orch/tests/test_mind_projection_resolver.py": {
+    "mtime": 1779070080.2552052,
+    "ast_hash": "9af9cff07b246f222909f3cf67c6c35e",
+    "semantic_hash": "9af9cff07b246f222909f3cf67c6c35e"
+  },
+  "services/orion-cortex-orch/tests/test_mind_skip_logging.py": {
+    "mtime": 1779070080.2552052,
+    "ast_hash": "63e4f736fe792f1d0137c5f343fc3d02",
+    "semantic_hash": "63e4f736fe792f1d0137c5f343fc3d02"
+  },
+  "services/orion-cortex-orch/tests/test_orch_routing_gate.py": {
+    "mtime": 1775704127.9229608,
+    "ast_hash": "ec6aa6b59fca51182512e8937d1e2e5e",
+    "semantic_hash": "ec6aa6b59fca51182512e8937d1e2e5e"
+  },
+  "services/orion-cortex-orch/tests/test_output_mode_routing.py": {
+    "mtime": 1773984591.7500987,
+    "ast_hash": "d3715eed0f6e9bcee20206acf171d154",
+    "semantic_hash": "d3715eed0f6e9bcee20206acf171d154"
+  },
+  "services/orion-cortex-orch/tests/test_ready.py": {
+    "mtime": 1781846476.494166,
+    "ast_hash": "30614a51ef4aef5d3526697c065a809f",
+    "semantic_hash": "30614a51ef4aef5d3526697c065a809f"
+  },
+  "services/orion-cortex-orch/tests/test_route_grammar_emit.py": {
+    "mtime": 1783903398.645444,
+    "ast_hash": "e4f5cc277eec5b2d2e68a0903aaabcc9",
+    "semantic_hash": "e4f5cc277eec5b2d2e68a0903aaabcc9"
+  },
+  "services/orion-cortex-orch/tests/test_rpc_bus_fork.py": {
+    "mtime": 1781730419.4927871,
+    "ast_hash": "01b65a85fa70d89e7d64a9eedd918c78",
+    "semantic_hash": "01b65a85fa70d89e7d64a9eedd918c78"
+  },
+  "services/orion-cortex-orch/tests/test_verb_runtime_rpc.py": {
+    "mtime": 1783903398.645444,
+    "ast_hash": "665fc9a9d97ccfff32c7556ecb8b0ded",
+    "semantic_hash": "665fc9a9d97ccfff32c7556ecb8b0ded"
+  },
+  "services/orion-cortex-orch/tests/test_workflow_lane.py": {
+    "mtime": 1783967737.3767128,
+    "ast_hash": "8206c5df7d933a0d0c091b6aaf46bb89",
+    "semantic_hash": "8206c5df7d933a0d0c091b6aaf46bb89"
+  },
+  "services/orion-dream/app/__init__.py": {
+    "mtime": 1763232123.4098907,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-dream/app/aggregators_rdf.py": {
+    "mtime": 1783807362.662784,
+    "ast_hash": "44d8499434ea96b427908fba1cd48fb1",
+    "semantic_hash": "44d8499434ea96b427908fba1cd48fb1"
+  },
+  "services/orion-dream/app/aggregators_sql.py": {
+    "mtime": 1763232123.4098907,
+    "ast_hash": "cab7769a12f473a6b853f23e23567747",
+    "semantic_hash": "cab7769a12f473a6b853f23e23567747"
+  },
+  "services/orion-dream/app/aggregators_vector.py": {
+    "mtime": 1763232123.4098907,
+    "ast_hash": "90185d7b7d6e87be3a149017c1617e33",
+    "semantic_hash": "90185d7b7d6e87be3a149017c1617e33"
+  },
+  "services/orion-dream/app/compaction_applier.py": {
+    "mtime": 1783355701.7921407,
+    "ast_hash": "1189c5a56c3c785398a20e973aed341f",
+    "semantic_hash": "1189c5a56c3c785398a20e973aed341f"
+  },
+  "services/orion-dream/app/context.py": {
+    "mtime": 1768597909.8862295,
+    "ast_hash": "a5711c6dfb7f86bf275cb940a5d03bc0",
+    "semantic_hash": "a5711c6dfb7f86bf275cb940a5d03bc0"
+  },
+  "services/orion-dream/app/dream_api.py": {
+    "mtime": 1774240323.6594942,
+    "ast_hash": "b676539b64e121cbfb14edbc4669880d",
+    "semantic_hash": "b676539b64e121cbfb14edbc4669880d"
+  },
+  "services/orion-dream/app/dream_cycle.py": {
+    "mtime": 1776044955.0482445,
+    "ast_hash": "ed35db3e06de0dbc984b00e2209fb8a9",
+    "semantic_hash": "ed35db3e06de0dbc984b00e2209fb8a9"
+  },
+  "services/orion-dream/app/main.py": {
+    "mtime": 1783355701.793141,
+    "ast_hash": "e5f62ec6165d6d77745586de5973c578",
+    "semantic_hash": "e5f62ec6165d6d77745586de5973c578"
+  },
+  "services/orion-dream/app/memory_listener.py": {
+    "mtime": 1768597909.8862295,
+    "ast_hash": "7030d601f1b519aec9fe866bfe89eea0",
+    "semantic_hash": "7030d601f1b519aec9fe866bfe89eea0"
+  },
+  "services/orion-dream/app/rem_compaction.py": {
+    "mtime": 1783355701.793141,
+    "ast_hash": "db0477e9343b95460dd0197a663b81d1",
+    "semantic_hash": "db0477e9343b95460dd0197a663b81d1"
+  },
+  "services/orion-dream/app/rem_store.py": {
+    "mtime": 1783355701.793141,
+    "ast_hash": "74cbf794e0987cee03678c7f0642acc7",
+    "semantic_hash": "74cbf794e0987cee03678c7f0642acc7"
+  },
+  "services/orion-dream/app/settings.py": {
+    "mtime": 1783807364.4288404,
+    "ast_hash": "e7fe276140d862c8a5fcfb7a4a39de38",
+    "semantic_hash": "e7fe276140d862c8a5fcfb7a4a39de38"
+  },
+  "services/orion-dream/app/sql_readout.py": {
+    "mtime": 1774236180.4493854,
+    "ast_hash": "d5d09bdde0de3a20f36b4c6fb8295b0e",
+    "semantic_hash": "d5d09bdde0de3a20f36b4c6fb8295b0e"
+  },
+  "services/orion-dream/app/utils.py": {
+    "mtime": 1763232123.4098907,
+    "ast_hash": "2ee25019e3885687299465c8ac101cbd",
+    "semantic_hash": "2ee25019e3885687299465c8ac101cbd"
+  },
+  "services/orion-dream/app/wake_readout.py": {
+    "mtime": 1774236180.4493854,
+    "ast_hash": "b21cc9585b92b53dbb4095046a638e8e",
+    "semantic_hash": "b21cc9585b92b53dbb4095046a638e8e"
+  },
+  "services/orion-dream/evals/conftest.py": {
+    "mtime": 1783355701.793141,
+    "ast_hash": "42d72bfbecc84366d8273532a52650de",
+    "semantic_hash": "42d72bfbecc84366d8273532a52650de"
+  },
+  "services/orion-dream/evals/test_rem_compaction_eval.py": {
+    "mtime": 1783355701.793141,
+    "ast_hash": "53c383d26f734f26b861bea38ab3d8a2",
+    "semantic_hash": "53c383d26f734f26b861bea38ab3d8a2"
+  },
+  "services/orion-dream/sql/ddl.sql": {
+    "mtime": 1763232123.4098907,
+    "ast_hash": "82d53112465dab18fdd1a0423d26a6b9",
+    "semantic_hash": "82d53112465dab18fdd1a0423d26a6b9"
+  },
+  "services/orion-dream/tests/conftest.py": {
+    "mtime": 1783355701.793141,
+    "ast_hash": "cc1c8765dccd6bf9c13df15a1a112ede",
+    "semantic_hash": "cc1c8765dccd6bf9c13df15a1a112ede"
+  },
+  "services/orion-dream/tests/test_compaction_applier.py": {
+    "mtime": 1783355701.793141,
+    "ast_hash": "513162aaac6e5670002b427607ee7858",
+    "semantic_hash": "513162aaac6e5670002b427607ee7858"
+  },
+  "services/orion-dream/tests/test_rem_compaction.py": {
+    "mtime": 1783355701.7941408,
+    "ast_hash": "b339b04de44f27ebd3a6e5a7792394df",
+    "semantic_hash": "b339b04de44f27ebd3a6e5a7792394df"
+  },
+  "services/orion-embodiment/app/__init__.py": {
+    "mtime": 1783450708.644728,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-embodiment/app/main.py": {
+    "mtime": 1783466316.5386345,
+    "ast_hash": "18eb12bc6e68c5187d18f154649fb829",
+    "semantic_hash": "18eb12bc6e68c5187d18f154649fb829"
+  },
+  "services/orion-embodiment/app/settings.py": {
+    "mtime": 1783554331.4044738,
+    "ast_hash": "99a1419f7d4d2af23130b9ce1fca06ea",
+    "semantic_hash": "99a1419f7d4d2af23130b9ce1fca06ea"
+  },
+  "services/orion-embodiment/app/worker.py": {
+    "mtime": 1783807362.502779,
+    "ast_hash": "81cc854cf80abfec98f1c661b2685f21",
+    "semantic_hash": "81cc854cf80abfec98f1c661b2685f21"
+  },
+  "services/orion-embodiment/evals/conftest.py": {
+    "mtime": 1783450708.645728,
+    "ast_hash": "d50b5724d9d826d05a3a82bb5d1ab57d",
+    "semantic_hash": "d50b5724d9d826d05a3a82bb5d1ab57d"
+  },
+  "services/orion-embodiment/evals/test_embodiment_arbitration_eval.py": {
+    "mtime": 1783615607.987946,
+    "ast_hash": "202f0b080502c951cfc1b02ce883d29e",
+    "semantic_hash": "202f0b080502c951cfc1b02ce883d29e"
+  },
+  "services/orion-embodiment/scripts/__init__.py": {
+    "mtime": 1783450708.645728,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-embodiment/scripts/bootstrap_orion_agent.py": {
+    "mtime": 1783490446.3033593,
+    "ast_hash": "14db7270cc4df9f54885d16336810487",
+    "semantic_hash": "14db7270cc4df9f54885d16336810487"
+  },
+  "services/orion-embodiment/tests/conftest.py": {
+    "mtime": 1783450708.645728,
+    "ast_hash": "d50b5724d9d826d05a3a82bb5d1ab57d",
+    "semantic_hash": "d50b5724d9d826d05a3a82bb5d1ab57d"
+  },
+  "services/orion-embodiment/tests/test_bootstrap.py": {
+    "mtime": 1783490446.3043594,
+    "ast_hash": "6513580b52333d807ac5a029588c1f8b",
+    "semantic_hash": "6513580b52333d807ac5a029588c1f8b"
+  },
+  "services/orion-embodiment/tests/test_speech_settings_defaults.py": {
+    "mtime": 1783807363.3898072,
+    "ast_hash": "1d2a3a7a682d38a4d757862f878c248c",
+    "semantic_hash": "1d2a3a7a682d38a4d757862f878c248c"
+  },
+  "services/orion-embodiment/tests/test_worker_actuate.py": {
+    "mtime": 1783461977.1323037,
+    "ast_hash": "1dd1105842d44c854244c81828347d29",
+    "semantic_hash": "1dd1105842d44c854244c81828347d29"
+  },
+  "services/orion-embodiment/tests/test_worker_aitown_world_id_regression.py": {
+    "mtime": 1783548475.1972117,
+    "ast_hash": "b69805091c9dadf60ee5afbaaaadc1bd",
+    "semantic_hash": "b69805091c9dadf60ee5afbaaaadc1bd"
+  },
+  "services/orion-embodiment/tests/test_worker_idle.py": {
+    "mtime": 1783461977.1323037,
+    "ast_hash": "aae6d6a486f16d684b9708c599ca25c3",
+    "semantic_hash": "aae6d6a486f16d684b9708c599ca25c3"
+  },
+  "services/orion-embodiment/tests/test_worker_memory.py": {
+    "mtime": 1783450708.645728,
+    "ast_hash": "09c74157c1b17c824549eeaeda5ac9b6",
+    "semantic_hash": "09c74157c1b17c824549eeaeda5ac9b6"
+  },
+  "services/orion-embodiment/tests/test_worker_perception.py": {
+    "mtime": 1783548475.1972117,
+    "ast_hash": "636989730eac053a683ed0d8a2bf86d3",
+    "semantic_hash": "636989730eac053a683ed0d8a2bf86d3"
+  },
+  "services/orion-embodiment/tests/test_worker_social.py": {
+    "mtime": 1783473102.6436758,
+    "ast_hash": "a33f5057af9620c96a904867ff625538",
+    "semantic_hash": "a33f5057af9620c96a904867ff625538"
+  },
+  "services/orion-embodiment/tests/test_worker_speech.py": {
+    "mtime": 1783615607.987946,
+    "ast_hash": "02306e0270a76f598b0d67d86f91878f",
+    "semantic_hash": "02306e0270a76f598b0d67d86f91878f"
+  },
+  "services/orion-embodiment/tests/test_worker_speech_unified.py": {
+    "mtime": 1783807364.1738322,
+    "ast_hash": "70530080e7e6621ff20cf9af9926427c",
+    "semantic_hash": "70530080e7e6621ff20cf9af9926427c"
+  },
+  "services/orion-embodiment/tests/test_worker_start_conversation.py": {
+    "mtime": 1783461977.1333036,
+    "ast_hash": "8de04f4591b934f53d33f33392b469b7",
+    "semantic_hash": "8de04f4591b934f53d33f33392b469b7"
+  },
+  "services/orion-equilibrium-service/app/__init__.py": {
+    "mtime": 1768597909.8862295,
+    "ast_hash": "926f4e5204c6798c74d87aa7327b2ccb",
+    "semantic_hash": "926f4e5204c6798c74d87aa7327b2ccb"
+  },
+  "services/orion-equilibrium-service/app/main.py": {
+    "mtime": 1768597909.8862295,
+    "ast_hash": "508796cf019b280972480ddde2f21feb",
+    "semantic_hash": "508796cf019b280972480ddde2f21feb"
+  },
+  "services/orion-equilibrium-service/app/service.py": {
+    "mtime": 1783114357.2179706,
+    "ast_hash": "f75f8de22d08a8ed27357ed007145c70",
+    "semantic_hash": "f75f8de22d08a8ed27357ed007145c70"
+  },
+  "services/orion-equilibrium-service/app/settings.py": {
+    "mtime": 1783957069.416255,
+    "ast_hash": "ac10dec52d6f48700573c0cf9ad04c12",
+    "semantic_hash": "ac10dec52d6f48700573c0cf9ad04c12"
+  },
+  "services/orion-equilibrium-service/app/substrate_metacog_gate.py": {
+    "mtime": 1783107031.974902,
+    "ast_hash": "a264b682ffa23e4906c634b6710f1e0d",
+    "semantic_hash": "a264b682ffa23e4906c634b6710f1e0d"
+  },
+  "services/orion-equilibrium-service/tests/test_baseline_hygiene.py": {
+    "mtime": 1781735866.8337395,
+    "ast_hash": "1e288c6e4782a60db735dc2679e39d5a",
+    "semantic_hash": "1e288c6e4782a60db735dc2679e39d5a"
+  },
+  "services/orion-equilibrium-service/tests/test_baseline_startup_emit.py": {
+    "mtime": 1781735866.8337395,
+    "ast_hash": "b24bae045abc2178bca986e55f5e87bc",
+    "semantic_hash": "b24bae045abc2178bca986e55f5e87bc"
+  },
+  "services/orion-equilibrium-service/tests/test_load_state_key_decode.py": {
+    "mtime": 1783114357.2189705,
+    "ast_hash": "f00c10649406879e09eae2ac79102099",
+    "semantic_hash": "f00c10649406879e09eae2ac79102099"
+  },
+  "services/orion-equilibrium-service/tests/test_settings_empty_env.py": {
+    "mtime": 1783107031.9759018,
+    "ast_hash": "8b9977b21ac95fc4e7c388bcb02b4b0b",
+    "semantic_hash": "8b9977b21ac95fc4e7c388bcb02b4b0b"
+  },
+  "services/orion-equilibrium-service/tests/test_substrate_metacog_gate.py": {
+    "mtime": 1783107031.9759018,
+    "ast_hash": "ace24708fd431fc10129128ce55755a8",
+    "semantic_hash": "ace24708fd431fc10129128ce55755a8"
+  },
+  "services/orion-execution-dispatch-runtime/app/__init__.py": {
+    "mtime": 1779722671.525158,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-execution-dispatch-runtime/app/main.py": {
+    "mtime": 1783967452.503406,
+    "ast_hash": "627c971e086e71f8f25339981987f081",
+    "semantic_hash": "627c971e086e71f8f25339981987f081"
+  },
+  "services/orion-execution-dispatch-runtime/app/settings.py": {
+    "mtime": 1783986358.1056566,
+    "ast_hash": "679d8b6f795de3530d61d511899117c4",
+    "semantic_hash": "679d8b6f795de3530d61d511899117c4"
+  },
+  "services/orion-execution-dispatch-runtime/app/store.py": {
+    "mtime": 1783967452.503406,
+    "ast_hash": "722183d58acfc4982efcc1bce31d5e4c",
+    "semantic_hash": "722183d58acfc4982efcc1bce31d5e4c"
+  },
+  "services/orion-execution-dispatch-runtime/app/worker.py": {
+    "mtime": 1783986358.1056566,
+    "ast_hash": "04b92803eb84f109d38a013d53e2d432",
+    "semantic_hash": "04b92803eb84f109d38a013d53e2d432"
+  },
+  "services/orion-fcc/entrypoint.sh": {
+    "mtime": 1783389507.7144868,
+    "ast_hash": "bfeed32d81e745bf0d0dfc27cd7780ac",
+    "semantic_hash": "bfeed32d81e745bf0d0dfc27cd7780ac"
+  },
+  "services/orion-feedback-runtime/app/__init__.py": {
+    "mtime": 1779722671.527158,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-feedback-runtime/app/main.py": {
+    "mtime": 1779722671.528158,
+    "ast_hash": "90373be77452a1770490a6af8f1ab937",
+    "semantic_hash": "90373be77452a1770490a6af8f1ab937"
+  },
+  "services/orion-feedback-runtime/app/settings.py": {
+    "mtime": 1782445799.9373975,
+    "ast_hash": "cf964349411713fbef313da7c6cb1ca8",
+    "semantic_hash": "cf964349411713fbef313da7c6cb1ca8"
+  },
+  "services/orion-feedback-runtime/app/store.py": {
+    "mtime": 1783967452.503406,
+    "ast_hash": "060785458617969be49c92da2a2fc519",
+    "semantic_hash": "060785458617969be49c92da2a2fc519"
+  },
+  "services/orion-feedback-runtime/app/worker.py": {
+    "mtime": 1782445600.7230422,
+    "ast_hash": "08857d6dcff8b89cc5333829c3000396",
+    "semantic_hash": "08857d6dcff8b89cc5333829c3000396"
+  },
+  "services/orion-field-digester/app/__init__.py": {
+    "mtime": 1779671370.5160108,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-field-digester/app/digestion/__init__.py": {
+    "mtime": 1779671370.5160108,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-field-digester/app/digestion/decay.py": {
+    "mtime": 1783848986.607421,
+    "ast_hash": "cf5f47a3c49cc4c277bffaad9eda2446",
+    "semantic_hash": "cf5f47a3c49cc4c277bffaad9eda2446"
+  },
+  "services/orion-field-digester/app/digestion/diffusion.py": {
+    "mtime": 1783890426.4927747,
+    "ast_hash": "9ebc1caeba66c181298e65fc30670963",
+    "semantic_hash": "9ebc1caeba66c181298e65fc30670963"
+  },
+  "services/orion-field-digester/app/digestion/perturbation.py": {
+    "mtime": 1781765088.0702882,
+    "ast_hash": "6e23eb5ab9d2fba31c0bfa82455767ff",
+    "semantic_hash": "6e23eb5ab9d2fba31c0bfa82455767ff"
+  },
+  "services/orion-field-digester/app/digestion/suppression.py": {
+    "mtime": 1779671370.5160108,
+    "ast_hash": "037392d016d86315f4d91168588aad57",
+    "semantic_hash": "037392d016d86315f4d91168588aad57"
+  },
+  "services/orion-field-digester/app/emit/__init__.py": {
+    "mtime": 1779671370.5160108,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-field-digester/app/emit/field_events.py": {
+    "mtime": 1779671370.5160108,
+    "ast_hash": "e4853c2d7c6f2de308573881c8d8bdf1",
+    "semantic_hash": "e4853c2d7c6f2de308573881c8d8bdf1"
+  },
+  "services/orion-field-digester/app/graph/__init__.py": {
+    "mtime": 1779671370.5160108,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-field-digester/app/graph/edge_registry.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "5c14ccb7a7b945771be17dae320edc64",
+    "semantic_hash": "5c14ccb7a7b945771be17dae320edc64"
+  },
+  "services/orion-field-digester/app/graph/lattice.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "cdf228f323d06863e8a6f9e1b1bf5003",
+    "semantic_hash": "cdf228f323d06863e8a6f9e1b1bf5003"
+  },
+  "services/orion-field-digester/app/graph/node_registry.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "05ee513c82b7471cd6eb6abba30b5dd7",
+    "semantic_hash": "05ee513c82b7471cd6eb6abba30b5dd7"
+  },
+  "services/orion-field-digester/app/health_monitor.py": {
+    "mtime": 1783897997.642214,
+    "ast_hash": "4f309cd5e44d2f99cff6419b72389444",
+    "semantic_hash": "4f309cd5e44d2f99cff6419b72389444"
+  },
+  "services/orion-field-digester/app/ingest/__init__.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-field-digester/app/ingest/receipts.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "0260f83660487fba52bef7f3c62cccba",
+    "semantic_hash": "0260f83660487fba52bef7f3c62cccba"
+  },
+  "services/orion-field-digester/app/ingest/state_deltas.py": {
+    "mtime": 1782438858.702639,
+    "ast_hash": "5ff2bfbb19a0c4854abc019b3d2751bc",
+    "semantic_hash": "5ff2bfbb19a0c4854abc019b3d2751bc"
+  },
+  "services/orion-field-digester/app/main.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "2ba9fac70f8c5b19c4233b7474764e6f",
+    "semantic_hash": "2ba9fac70f8c5b19c4233b7474764e6f"
+  },
+  "services/orion-field-digester/app/projections/__init__.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-field-digester/app/projections/capability_field_projection.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "ab49c3300969a83bd4dfdf8ba1f854cb",
+    "semantic_hash": "ab49c3300969a83bd4dfdf8ba1f854cb"
+  },
+  "services/orion-field-digester/app/projections/node_field_projection.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "b2d59c24300ef49149ba47ff17e8e46f",
+    "semantic_hash": "b2d59c24300ef49149ba47ff17e8e46f"
+  },
+  "services/orion-field-digester/app/projections/substrate_field_projection.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "5dff7166844b583f21891a78e6bff119",
+    "semantic_hash": "5dff7166844b583f21891a78e6bff119"
+  },
+  "services/orion-field-digester/app/settings.py": {
+    "mtime": 1783984456.988051,
+    "ast_hash": "2f23cbcadf350b000657e2415490e521",
+    "semantic_hash": "2f23cbcadf350b000657e2415490e521"
+  },
+  "services/orion-field-digester/app/store.py": {
+    "mtime": 1783897997.642214,
+    "ast_hash": "898fd34a01253735ac3cec5bc244a320",
+    "semantic_hash": "898fd34a01253735ac3cec5bc244a320"
+  },
+  "services/orion-field-digester/app/tensor/__init__.py": {
+    "mtime": 1779671370.5170107,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-field-digester/app/tensor/channels.py": {
+    "mtime": 1782438858.702639,
+    "ast_hash": "539e05d8dc1beba754ba1b3800206845",
+    "semantic_hash": "539e05d8dc1beba754ba1b3800206845"
+  },
+  "services/orion-field-digester/app/tensor/field_state.py": {
+    "mtime": 1779671370.5180106,
+    "ast_hash": "7816f9006d2054b59b53fe77f53e69ac",
+    "semantic_hash": "7816f9006d2054b59b53fe77f53e69ac"
+  },
+  "services/orion-field-digester/app/tensor/reconcile.py": {
+    "mtime": 1779681646.0214531,
+    "ast_hash": "f58f5728eae1e8beeb0d51ef51b6c688",
+    "semantic_hash": "f58f5728eae1e8beeb0d51ef51b6c688"
+  },
+  "services/orion-field-digester/app/tensor/update_rules.py": {
+    "mtime": 1779671370.5180106,
+    "ast_hash": "af13838733fc7afe80b0fa2ae8693ddc",
+    "semantic_hash": "af13838733fc7afe80b0fa2ae8693ddc"
+  },
+  "services/orion-field-digester/app/worker.py": {
+    "mtime": 1783984456.988051,
+    "ast_hash": "7d502edfe9f597474b1b8d9a45e5b613",
+    "semantic_hash": "7d502edfe9f597474b1b8d9a45e5b613"
+  },
+  "services/orion-field-digester/tests/conftest.py": {
+    "mtime": 1781897477.5820868,
+    "ast_hash": "90f8ab24d1384f1c6cf877032573fb1a",
+    "semantic_hash": "90f8ab24d1384f1c6cf877032573fb1a"
+  },
+  "services/orion-field-digester/tests/test_diffusion_provenance.py": {
+    "mtime": 1783890426.4927747,
+    "ast_hash": "cb13afc13f92add01901011e9e12b529",
+    "semantic_hash": "cb13afc13f92add01901011e9e12b529"
+  },
+  "services/orion-field-digester/tests/test_field_channel_corpus.py": {
+    "mtime": 1783984456.989051,
+    "ast_hash": "84c77f81e05f9eef2457977910c4d7bf",
+    "semantic_hash": "84c77f81e05f9eef2457977910c4d7bf"
+  },
+  "services/orion-field-digester/tests/test_field_chat_perturbations.py": {
+    "mtime": 1781897477.5820868,
+    "ast_hash": "fce5aa922942de1a745053989cf6c4d1",
+    "semantic_hash": "fce5aa922942de1a745053989cf6c4d1"
+  },
+  "services/orion-field-digester/tests/test_health_monitor.py": {
+    "mtime": 1783897997.643214,
+    "ast_hash": "21d75549b60a8b3f9fe3e1a2c0ee4253",
+    "semantic_hash": "21d75549b60a8b3f9fe3e1a2c0ee4253"
+  },
+  "services/orion-field-digester/tests/test_worker.py": {
+    "mtime": 1782874038.2559726,
+    "ast_hash": "ab19bcef28a5c8f5486d5fcd2c69be34",
+    "semantic_hash": "ab19bcef28a5c8f5486d5fcd2c69be34"
+  },
+  "services/orion-field-digester/tests/test_worker_prune.py": {
+    "mtime": 1783897997.643214,
+    "ast_hash": "c2d79bb961c1d10e5c0f30a35d208120",
+    "semantic_hash": "c2d79bb961c1d10e5c0f30a35d208120"
+  },
+  "services/orion-gpu-cluster-power/app/api.py": {
+    "mtime": 1768597909.8872294,
+    "ast_hash": "4a1a1359ee6167d182a9ae00fbad76f9",
+    "semantic_hash": "4a1a1359ee6167d182a9ae00fbad76f9"
+  },
+  "services/orion-gpu-cluster-power/app/bus.py": {
+    "mtime": 1768597909.8872294,
+    "ast_hash": "bc967b1b7e6fd1150da629084eb39bff",
+    "semantic_hash": "bc967b1b7e6fd1150da629084eb39bff"
+  },
+  "services/orion-gpu-cluster-power/app/main.py": {
+    "mtime": 1764608861.798301,
+    "ast_hash": "04db77c61c9af5e96c08deea27f39f02",
+    "semantic_hash": "04db77c61c9af5e96c08deea27f39f02"
+  },
+  "services/orion-gpu-cluster-power/app/service.py": {
+    "mtime": 1768597909.8872294,
+    "ast_hash": "a2de5e0414ea6629f2e46f258a2226d5",
+    "semantic_hash": "a2de5e0414ea6629f2e46f258a2226d5"
+  },
+  "services/orion-gpu-cluster-power/app/settings.py": {
+    "mtime": 1781142159.4051743,
+    "ast_hash": "c67b5898e8c56f14ebd8753913cde5a1",
+    "semantic_hash": "c67b5898e8c56f14ebd8753913cde5a1"
+  },
+  "services/orion-graph-compression/app/__init__.py": {
+    "mtime": 1780972924.4322648,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-graph-compression/app/clustering/__init__.py": {
+    "mtime": 1780972924.4322648,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-graph-compression/app/clustering/leiden.py": {
+    "mtime": 1780972924.4322648,
+    "ast_hash": "40a605e6c48ce30b5f071934e4813ab2",
+    "semantic_hash": "40a605e6c48ce30b5f071934e4813ab2"
+  },
+  "services/orion-graph-compression/app/clustering/region_builder.py": {
+    "mtime": 1780972924.4322648,
+    "ast_hash": "0fd977064d9fe99741477fa46b3a3814",
+    "semantic_hash": "0fd977064d9fe99741477fa46b3a3814"
+  },
+  "services/orion-graph-compression/app/federators/__init__.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-graph-compression/app/federators/episodic.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "e493f08be7d50b319d2f3800e7b5b8e9",
+    "semantic_hash": "e493f08be7d50b319d2f3800e7b5b8e9"
+  },
+  "services/orion-graph-compression/app/federators/self_study.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "5ef921dcbb0dee6dee166d83eca50d53",
+    "semantic_hash": "5ef921dcbb0dee6dee166d83eca50d53"
+  },
+  "services/orion-graph-compression/app/federators/substrate.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "3e7c820c0681eb86220340e9e9c415c9",
+    "semantic_hash": "3e7c820c0681eb86220340e9e9c415c9"
+  },
+  "services/orion-graph-compression/app/main.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "1421673fccd1ba53cdf9208190d8ca1b",
+    "semantic_hash": "1421673fccd1ba53cdf9208190d8ca1b"
+  },
+  "services/orion-graph-compression/app/settings.py": {
+    "mtime": 1780989395.0870895,
+    "ast_hash": "a2a73f3353e11a18d03408379ca63c8d",
+    "semantic_hash": "a2a73f3353e11a18d03408379ca63c8d"
+  },
+  "services/orion-graph-compression/app/stale_listener.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "b388c8e2503e15f6e4159881ca6adc0a",
+    "semantic_hash": "b388c8e2503e15f6e4159881ca6adc0a"
+  },
+  "services/orion-graph-compression/app/store.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "90e17d99c449f9b65554349d38537b8b",
+    "semantic_hash": "90e17d99c449f9b65554349d38537b8b"
+  },
+  "services/orion-graph-compression/app/summarizer.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "9454150e7719bfde5f29b72169dee1ce",
+    "semantic_hash": "9454150e7719bfde5f29b72169dee1ce"
+  },
+  "services/orion-graph-compression/app/worker.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "b99eb3c163daeeb53575d40b4b340056",
+    "semantic_hash": "b99eb3c163daeeb53575d40b4b340056"
+  },
+  "services/orion-graph-compression/app/writer.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "4579aa7953f946b3fc30b7ae092f710d",
+    "semantic_hash": "4579aa7953f946b3fc30b7ae092f710d"
+  },
+  "services/orion-graph-compression/tests/__init__.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-graph-compression/tests/conftest.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "248e27cd755d00e23f050491b0d3260a",
+    "semantic_hash": "248e27cd755d00e23f050491b0d3260a"
+  },
+  "services/orion-graph-compression/tests/test_compression_schema.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "f5ceaf936167a1ce9fe0457af8a3d852",
+    "semantic_hash": "f5ceaf936167a1ce9fe0457af8a3d852"
+  },
+  "services/orion-graph-compression/tests/test_federator_episodic.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "5d26e19ff8e08f4cda118b4cc6e6b101",
+    "semantic_hash": "5d26e19ff8e08f4cda118b4cc6e6b101"
+  },
+  "services/orion-graph-compression/tests/test_grammar_hook.py": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "0aedec7897feeb5abbd43821dfca2329",
+    "semantic_hash": "0aedec7897feeb5abbd43821dfca2329"
+  },
+  "services/orion-graph-compression/tests/test_leiden_clustering.py": {
+    "mtime": 1780972924.434265,
+    "ast_hash": "149e3451b26b92b92814e2f811804489",
+    "semantic_hash": "149e3451b26b92b92814e2f811804489"
+  },
+  "services/orion-graph-compression/tests/test_region_builder.py": {
+    "mtime": 1780972924.434265,
+    "ast_hash": "a6903a8b0458538fc735cccaa1cf9bf2",
+    "semantic_hash": "a6903a8b0458538fc735cccaa1cf9bf2"
+  },
+  "services/orion-graph-compression/tests/test_store_staleness.py": {
+    "mtime": 1780972924.434265,
+    "ast_hash": "693efc0aa71d7ed1581716a0b3393e49",
+    "semantic_hash": "693efc0aa71d7ed1581716a0b3393e49"
+  },
+  "services/orion-graph-compression/tests/test_worker_degraded.py": {
+    "mtime": 1780972924.434265,
+    "ast_hash": "f197bff1e9e63df0cc5ad05d57ebadc6",
+    "semantic_hash": "f197bff1e9e63df0cc5ad05d57ebadc6"
+  },
+  "services/orion-graph-compression/tests/test_writer_sparql.py": {
+    "mtime": 1780972924.434265,
+    "ast_hash": "3a9a5cbd08d1a41d571566154e761f51",
+    "semantic_hash": "3a9a5cbd08d1a41d571566154e761f51"
+  },
+  "services/orion-graphiti-adapter/app/backends/__init__.py": {
+    "mtime": 1783356609.5640097,
+    "ast_hash": "b38b6804a3f631232a0b74cc06c15113",
+    "semantic_hash": "b38b6804a3f631232a0b74cc06c15113"
+  },
+  "services/orion-graphiti-adapter/app/backends/graphiti_core.py": {
+    "mtime": 1783925507.4340801,
+    "ast_hash": "932ca234b0771e042a218b8cac0d13a9",
+    "semantic_hash": "932ca234b0771e042a218b8cac0d13a9"
+  },
+  "services/orion-graphiti-adapter/app/backends/orion_postgres.py": {
+    "mtime": 1783356609.5640097,
+    "ast_hash": "2ad21149d654adce240bcc47ed7b9407",
+    "semantic_hash": "2ad21149d654adce240bcc47ed7b9407"
+  },
+  "services/orion-graphiti-adapter/app/crystallization_ids.py": {
+    "mtime": 1783920873.662785,
+    "ast_hash": "129a08afc70ed1d26123865c63da6ad5",
+    "semantic_hash": "129a08afc70ed1d26123865c63da6ad5"
+  },
+  "services/orion-graphiti-adapter/app/falkordb.py": {
+    "mtime": 1783356609.5650096,
+    "ast_hash": "3e9942f66c42a3043a998ff2cf9091e1",
+    "semantic_hash": "3e9942f66c42a3043a998ff2cf9091e1"
+  },
+  "services/orion-graphiti-adapter/app/main.py": {
+    "mtime": 1783923933.4926658,
+    "ast_hash": "59cb980590fb3d353f490543ccb4e3f4",
+    "semantic_hash": "59cb980590fb3d353f490543ccb4e3f4"
+  },
+  "services/orion-graphiti-adapter/app/settings.py": {
+    "mtime": 1783925507.4340801,
+    "ast_hash": "b4282f47204481e6333cf06b228637df",
+    "semantic_hash": "b4282f47204481e6333cf06b228637df"
+  },
+  "services/orion-graphiti-adapter/app/store.py": {
+    "mtime": 1783356609.5650096,
+    "ast_hash": "162269d87dd7746cb94e39f5cf30d957",
+    "semantic_hash": "162269d87dd7746cb94e39f5cf30d957"
+  },
+  "services/orion-graphiti-adapter/tests/conftest.py": {
+    "mtime": 1783925507.4340801,
+    "ast_hash": "6471373e31203c6c57823aa852d67b16",
+    "semantic_hash": "6471373e31203c6c57823aa852d67b16"
+  },
+  "services/orion-graphiti-adapter/tests/test_crystallization_ids.py": {
+    "mtime": 1783920873.663785,
+    "ast_hash": "9b354f9bc83b0b00f397a52ea3189e8a",
+    "semantic_hash": "9b354f9bc83b0b00f397a52ea3189e8a"
+  },
+  "services/orion-graphiti-adapter/tests/test_episodes.py": {
+    "mtime": 1783925507.4340801,
+    "ast_hash": "cb30ef4708cdef946d2df7f603b6cf68",
+    "semantic_hash": "cb30ef4708cdef946d2df7f603b6cf68"
+  },
+  "services/orion-graphiti-adapter/tests/test_graphiti_core_backend.py": {
+    "mtime": 1783925507.4340801,
+    "ast_hash": "d42a894c65d86e28ebd3c695d963ffe3",
+    "semantic_hash": "d42a894c65d86e28ebd3c695d963ffe3"
+  },
+  "services/orion-graphiti-adapter/tests/test_health.py": {
+    "mtime": 1783925507.4340801,
+    "ast_hash": "4da3115a668029b5953ef8bc40b94807",
+    "semantic_hash": "4da3115a668029b5953ef8bc40b94807"
+  },
+  "services/orion-graphiti-adapter/tests/test_links.py": {
+    "mtime": 1783925507.4340801,
+    "ast_hash": "9b2b36e3e6e47777fc8fe08e8d04e894",
+    "semantic_hash": "9b2b36e3e6e47777fc8fe08e8d04e894"
+  },
+  "services/orion-graphiti-adapter/tests/test_rebuild.py": {
+    "mtime": 1783925507.4350803,
+    "ast_hash": "8c99b289e8adfe1252fd0d5f51830931",
+    "semantic_hash": "8c99b289e8adfe1252fd0d5f51830931"
+  },
+  "services/orion-graphiti-adapter/tests/test_search.py": {
+    "mtime": 1783356609.5660098,
+    "ast_hash": "a1fe23e2be00768946e592a5a475f7d5",
+    "semantic_hash": "a1fe23e2be00768946e592a5a475f7d5"
+  },
+  "services/orion-harness-governor/app/__init__.py": {
+    "mtime": 1783291410.0237017,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-harness-governor/app/bus_listener.py": {
+    "mtime": 1783805454.2233036,
+    "ast_hash": "44cb3aa2870114e3e98ca7096077798f",
+    "semantic_hash": "44cb3aa2870114e3e98ca7096077798f"
+  },
+  "services/orion-harness-governor/app/cancel_listener.py": {
+    "mtime": 1783655498.7431989,
+    "ast_hash": "81b82b3c14d9e1ac2fe532f0e96ce6a6",
+    "semantic_hash": "81b82b3c14d9e1ac2fe532f0e96ce6a6"
+  },
+  "services/orion-harness-governor/app/main.py": {
+    "mtime": 1783655498.7431989,
+    "ast_hash": "dd934857543615ec70eae241061f7168",
+    "semantic_hash": "dd934857543615ec70eae241061f7168"
+  },
+  "services/orion-harness-governor/app/settings.py": {
+    "mtime": 1783820991.6721158,
+    "ast_hash": "b7b046df133000e03e56d5b183df862c",
+    "semantic_hash": "b7b046df133000e03e56d5b183df862c"
+  },
+  "services/orion-harness-governor/tests/conftest.py": {
+    "mtime": 1783655498.744199,
+    "ast_hash": "fa5def8a05f85d16b6a071b3c3e31b9a",
+    "semantic_hash": "fa5def8a05f85d16b6a071b3c3e31b9a"
+  },
+  "services/orion-harness-governor/tests/test_finalize_exec_channel.py": {
+    "mtime": 1783807362.3657746,
+    "ast_hash": "cda464d5dd667a55ddcacd260e37bf63",
+    "semantic_hash": "cda464d5dd667a55ddcacd260e37bf63"
+  },
+  "services/orion-harness-governor/tests/test_harness_governor_rpc.py": {
+    "mtime": 1783564192.7361438,
+    "ast_hash": "0aeecd6e3353480033152cd1d9c563ab",
+    "semantic_hash": "0aeecd6e3353480033152cd1d9c563ab"
+  },
+  "services/orion-harness-governor/tests/test_harness_run_cancel.py": {
+    "mtime": 1783655498.744199,
+    "ast_hash": "16f5832ac64659388c22c6bdd3d52b39",
+    "semantic_hash": "16f5832ac64659388c22c6bdd3d52b39"
+  },
+  "services/orion-hub/app/settings.py": {
+    "mtime": 1783745566.6153476,
+    "ast_hash": "b544704997eb8bbaed3f1b1e1f6362d8",
+    "semantic_hash": "b544704997eb8bbaed3f1b1e1f6362d8"
+  },
+  "services/orion-hub/entrypoint.sh": {
+    "mtime": 1783389151.3530161,
+    "ast_hash": "979139d3317ebab8901511c33b923d26",
+    "semantic_hash": "979139d3317ebab8901511c33b923d26"
+  },
+  "services/orion-hub/package.json": {
+    "mtime": 1783360821.8300579,
+    "ast_hash": "6d8991e5c679e84d180062dfb85554f9",
+    "semantic_hash": "6d8991e5c679e84d180062dfb85554f9"
+  },
+  "services/orion-hub/scripts/__init__.py": {
+    "mtime": 1763232123.4108906,
+    "ast_hash": "e1c06d85ae7b8b032bef47e42e4c08f9",
+    "semantic_hash": "e1c06d85ae7b8b032bef47e42e4c08f9"
+  },
+  "services/orion-hub/scripts/agent_claude_input.py": {
+    "mtime": 1783402854.8333287,
+    "ast_hash": "bb794db0bf2f5477bef864a81cba024d",
+    "semantic_hash": "bb794db0bf2f5477bef864a81cba024d"
+  },
+  "services/orion-hub/scripts/agent_step_relay.py": {
+    "mtime": 1782955656.275706,
+    "ast_hash": "449306ba82d07a3ab0a7473bbc5dc091",
+    "semantic_hash": "449306ba82d07a3ab0a7473bbc5dc091"
+  },
+  "services/orion-hub/scripts/aitown_status.py": {
+    "mtime": 1783364899.121467,
+    "ast_hash": "ce385eb52eeb608b54d584272317f335",
+    "semantic_hash": "ce385eb52eeb608b54d584272317f335"
+  },
+  "services/orion-hub/scripts/aitown_ui.py": {
+    "mtime": 1783364899.121467,
+    "ast_hash": "74659d388f35fb95a1ab2336f85a0229",
+    "semantic_hash": "74659d388f35fb95a1ab2336f85a0229"
+  },
+  "services/orion-hub/scripts/api_routes.py": {
+    "mtime": 1783753435.472319,
+    "ast_hash": "c0aadcecf0637ec44a0315890e20f450",
+    "semantic_hash": "c0aadcecf0637ec44a0315890e20f450"
+  },
+  "services/orion-hub/scripts/attention_loops_routes.py": {
+    "mtime": 1783447063.2563703,
+    "ast_hash": "52de2ba8edb9294df53a694973a7413f",
+    "semantic_hash": "52de2ba8edb9294df53a694973a7413f"
+  },
+  "services/orion-hub/scripts/attention_loops_store.py": {
+    "mtime": 1783447063.2563703,
+    "ast_hash": "3e3651a4e587d3d03e831fec5bdd286f",
+    "semantic_hash": "3e3651a4e587d3d03e831fec5bdd286f"
+  },
+  "services/orion-hub/scripts/autonomy_constitution.py": {
+    "mtime": 1777748523.328599,
+    "ast_hash": "ed729f7bcda44d1c8a014dcbe8ae789f",
+    "semantic_hash": "ed729f7bcda44d1c8a014dcbe8ae789f"
+  },
+  "services/orion-hub/scripts/autonomy_payloads.py": {
+    "mtime": 1780119700.2799513,
+    "ast_hash": "4d0f65449a7c60238733dff5823eb8da",
+    "semantic_hash": "4d0f65449a7c60238733dff5823eb8da"
+  },
+  "services/orion-hub/scripts/biometrics_cache.py": {
+    "mtime": 1769550252.5870264,
+    "ast_hash": "e688ff8ddfc86c277effa2236783af0d",
+    "semantic_hash": "e688ff8ddfc86c277effa2236783af0d"
+  },
+  "services/orion-hub/scripts/bus_clients/__init__.py": {
+    "mtime": 1767676515.6541069,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-hub/scripts/bus_clients/cortex_client.py": {
+    "mtime": 1779079185.1792552,
+    "ast_hash": "b5870131242b3634c48119246b7a33da",
+    "semantic_hash": "b5870131242b3634c48119246b7a33da"
+  },
+  "services/orion-hub/scripts/bus_clients/tts_client.py": {
+    "mtime": 1783807362.0687652,
+    "ast_hash": "c6a98153c1f088e58546c37d28e56fc4",
+    "semantic_hash": "c6a98153c1f088e58546c37d28e56fc4"
+  },
+  "services/orion-hub/scripts/bus_publish.py": {
+    "mtime": 1783447063.2563703,
+    "ast_hash": "1a62f21a2360f1bc7569f411e9474b30",
+    "semantic_hash": "1a62f21a2360f1bc7569f411e9474b30"
+  },
+  "services/orion-hub/scripts/chat_history.py": {
+    "mtime": 1778304594.4916453,
+    "ast_hash": "834b6dfe7382b6c32ca1c2b16fbcdbb3",
+    "semantic_hash": "834b6dfe7382b6c32ca1c2b16fbcdbb3"
+  },
+  "services/orion-hub/scripts/chat_request_builder.py": {
+    "mtime": 1774654210.095835,
+    "ast_hash": "76fff3f14376ced42dff48bdfed18ef6",
+    "semantic_hash": "76fff3f14376ced42dff48bdfed18ef6"
+  },
+  "services/orion-hub/scripts/cognition_trace_cache.py": {
+    "mtime": 1779332554.3288987,
+    "ast_hash": "60a1f33ad7fa0858ce27f80b6d6d8671",
+    "semantic_hash": "60a1f33ad7fa0858ce27f80b6d6d8671"
+  },
+  "services/orion-hub/scripts/context_exec_agent_bridge.py": {
+    "mtime": 1783107031.976902,
+    "ast_hash": "3d3979555aeb9bc518161a7185d470c5",
+    "semantic_hash": "3d3979555aeb9bc518161a7185d470c5"
+  },
+  "services/orion-hub/scripts/context_exec_client.py": {
+    "mtime": 1781494684.923417,
+    "ast_hash": "0a4f4c6f4441aecc1814cf0e9bcbf3f2",
+    "semantic_hash": "0a4f4c6f4441aecc1814cf0e9bcbf3f2"
+  },
+  "services/orion-hub/scripts/correlation_chain_fallback.py": {
+    "mtime": 1783499830.2015212,
+    "ast_hash": "6bf5e35f3fdc850b2e2ff1c8d3ada640",
+    "semantic_hash": "6bf5e35f3fdc850b2e2ff1c8d3ada640"
+  },
+  "services/orion-hub/scripts/cortex_bus_stack_diagnostic.py": {
+    "mtime": 1778901838.379395,
+    "ast_hash": "1f60a8800038aa304159c76d9776aa25",
+    "semantic_hash": "1f60a8800038aa304159c76d9776aa25"
+  },
+  "services/orion-hub/scripts/cortex_chat_display.py": {
+    "mtime": 1775948546.0575118,
+    "ast_hash": "beda9a14fd7f56d6dbfa5c5555abf0bd",
+    "semantic_hash": "beda9a14fd7f56d6dbfa5c5555abf0bd"
+  },
+  "services/orion-hub/scripts/cortex_memory_graph_text.py": {
+    "mtime": 1779753471.2792897,
+    "ast_hash": "5d53eea2605e785304b2d0fd8aef4089",
+    "semantic_hash": "5d53eea2605e785304b2d0fd8aef4089"
+  },
+  "services/orion-hub/scripts/cortex_request_builder.py": {
+    "mtime": 1783555541.536674,
+    "ast_hash": "8a3bf5bdab7d04dc62daee313c3a3452",
+    "semantic_hash": "8a3bf5bdab7d04dc62daee313c3a3452"
+  },
+  "services/orion-hub/scripts/crystallization_routes.py": {
+    "mtime": 1783965578.7337081,
+    "ast_hash": "20164d4e6db75a7e04db115ca80cde46",
+    "semantic_hash": "20164d4e6db75a7e04db115ca80cde46"
+  },
+  "services/orion-hub/scripts/curiosity_hint.py": {
+    "mtime": 1783105164.3540723,
+    "ast_hash": "deca770c9f4d263df27e58a85d3851bf",
+    "semantic_hash": "deca770c9f4d263df27e58a85d3851bf"
+  },
+  "services/orion-hub/scripts/embodiment_outcome_cache.py": {
+    "mtime": 1783450708.647728,
+    "ast_hash": "d5d127f68edcd3568568f73407f99d13",
+    "semantic_hash": "d5d127f68edcd3568568f73407f99d13"
+  },
+  "services/orion-hub/scripts/fcc_claude_bridge.py": {
+    "mtime": 1783615212.4809122,
+    "ast_hash": "ebb0411c5d607b62b80f0d24d81eb05b",
+    "semantic_hash": "ebb0411c5d607b62b80f0d24d81eb05b"
+  },
+  "services/orion-hub/scripts/fcc_env_catalog.py": {
+    "mtime": 1783219371.2220643,
+    "ast_hash": "28b55ba1907e81c198c442d1e5b8f9bf",
+    "semantic_hash": "28b55ba1907e81c198c442d1e5b8f9bf"
+  },
+  "services/orion-hub/scripts/fcc_mcp_config.py": {
+    "mtime": 1783365495.7336662,
+    "ast_hash": "58804860acd2cf46d178efcfe8371a22",
+    "semantic_hash": "58804860acd2cf46d178efcfe8371a22"
+  },
+  "services/orion-hub/scripts/fcc_model_mapping.py": {
+    "mtime": 1783219371.2220643,
+    "ast_hash": "eb2b4cdefed8d5ee48217bf3c9dbe35d",
+    "semantic_hash": "eb2b4cdefed8d5ee48217bf3c9dbe35d"
+  },
+  "services/orion-hub/scripts/grafana_tempo_link.py": {
+    "mtime": 1777790653.2200315,
+    "ast_hash": "41318a8e75ca91a5a2deb66a00966c39",
+    "semantic_hash": "41318a8e75ca91a5a2deb66a00966c39"
+  },
+  "services/orion-hub/scripts/grammar_atlas_routes.py": {
+    "mtime": 1779665098.5715795,
+    "ast_hash": "a3561209764e62db0bc4efec8f5fcd71",
+    "semantic_hash": "a3561209764e62db0bc4efec8f5fcd71"
+  },
+  "services/orion-hub/scripts/grammar_emit.py": {
+    "mtime": 1783908076.953645,
+    "ast_hash": "1d800c9ebe1eeee3a945d52f3a119d87",
+    "semantic_hash": "1d800c9ebe1eeee3a945d52f3a119d87"
+  },
+  "services/orion-hub/scripts/grammar_publish.py": {
+    "mtime": 1781897477.5820868,
+    "ast_hash": "3cb3dfff4307ff4e3b6b790871773d8e",
+    "semantic_hash": "3cb3dfff4307ff4e3b6b790871773d8e"
+  },
+  "services/orion-hub/scripts/harness_governor_client.py": {
+    "mtime": 1783753435.473319,
+    "ast_hash": "8ef9d9b467db2dc67e4aadacc789aebb",
+    "semantic_hash": "8ef9d9b467db2dc67e4aadacc789aebb"
+  },
+  "services/orion-hub/scripts/harness_step_relay.py": {
+    "mtime": 1783745566.6173477,
+    "ast_hash": "fdaabc245085343c15bb0ea107eaf1e2",
+    "semantic_hash": "fdaabc245085343c15bb0ea107eaf1e2"
+  },
+  "services/orion-hub/scripts/hub_presence.py": {
+    "mtime": 1783105164.3540723,
+    "ast_hash": "b6fdfc1025d077602422bbfebdb28dfd",
+    "semantic_hash": "b6fdfc1025d077602422bbfebdb28dfd"
+  },
+  "services/orion-hub/scripts/library/__init__.py": {
+    "mtime": 1767676515.6541069,
+    "ast_hash": "bafbb806a2c5ab88691b1c76565ac632",
+    "semantic_hash": "bafbb806a2c5ab88691b1c76565ac632"
+  },
+  "services/orion-hub/scripts/library/scanner.py": {
+    "mtime": 1773975149.961786,
+    "ast_hash": "e6c634f8d7512f7ec3a4a0c5e4806b3c",
+    "semantic_hash": "e6c634f8d7512f7ec3a4a0c5e4806b3c"
+  },
+  "services/orion-hub/scripts/llm_gateway_client.py": {
+    "mtime": 1781494684.924417,
+    "ast_hash": "52f1eaffb00dfb999a4695892a764146",
+    "semantic_hash": "52f1eaffb00dfb999a4695892a764146"
+  },
+  "services/orion-hub/scripts/main.py": {
+    "mtime": 1783745566.6173477,
+    "ast_hash": "a92c3c55a413e8b753e7fbd7023d90e9",
+    "semantic_hash": "a92c3c55a413e8b753e7fbd7023d90e9"
+  },
+  "services/orion-hub/scripts/memory_consolidation_draft_routes.py": {
+    "mtime": 1782190803.1003246,
+    "ast_hash": "32d6010ceed0f9825d40c9ce744f9307",
+    "semantic_hash": "32d6010ceed0f9825d40c9ce744f9307"
+  },
+  "services/orion-hub/scripts/memory_graph_routes.py": {
+    "mtime": 1783388479.8264327,
+    "ast_hash": "2e93c71584a99c49a1736253d57fee42",
+    "semantic_hash": "2e93c71584a99c49a1736253d57fee42"
+  },
+  "services/orion-hub/scripts/memory_graph_structured_output.py": {
+    "mtime": 1783807362.0687652,
+    "ast_hash": "7722a3ea22d26e8573ff7a934209fcfb",
+    "semantic_hash": "7722a3ea22d26e8573ff7a934209fcfb"
+  },
+  "services/orion-hub/scripts/memory_graph_suggest.py": {
+    "mtime": 1783807362.1497676,
+    "ast_hash": "f5c6e3e0dfdd78f7c931985bc0ea5527",
+    "semantic_hash": "f5c6e3e0dfdd78f7c931985bc0ea5527"
+  },
+  "services/orion-hub/scripts/memory_graph_suggest_timeout.py": {
+    "mtime": 1781730419.493787,
+    "ast_hash": "431851679c41216476723fa3da385177",
+    "semantic_hash": "431851679c41216476723fa3da385177"
+  },
+  "services/orion-hub/scripts/memory_routes.py": {
+    "mtime": 1783807363.1157985,
+    "ast_hash": "7f5fd594bdc57ccd06d1e15ef956f9b3",
+    "semantic_hash": "7f5fd594bdc57ccd06d1e15ef956f9b3"
+  },
+  "services/orion-hub/scripts/mind_routes.py": {
+    "mtime": 1780613748.8994234,
+    "ast_hash": "fc1de0eba89212407555ae814b4ce2ae",
+    "semantic_hash": "fc1de0eba89212407555ae814b4ce2ae"
+  },
+  "services/orion-hub/scripts/mutation_cognition_context.py": {
+    "mtime": 1777748523.328599,
+    "ast_hash": "0ddb169b2bf3a37d6c93610d824c7728",
+    "semantic_hash": "0ddb169b2bf3a37d6c93610d824c7728"
+  },
+  "services/orion-hub/scripts/notification_cache.py": {
+    "mtime": 1773975149.961786,
+    "ast_hash": "09f2be97d38a0ef4988c5376cf92b0cc",
+    "semantic_hash": "09f2be97d38a0ef4988c5376cf92b0cc"
+  },
+  "services/orion-hub/scripts/otel_trace_id.py": {
+    "mtime": 1777790653.2200315,
+    "ast_hash": "c4933ba743d3522c1844befa5b789945",
+    "semantic_hash": "c4933ba743d3522c1844befa5b789945"
+  },
+  "services/orion-hub/scripts/pre_turn_appraisal_client.py": {
+    "mtime": 1783125791.024088,
+    "ast_hash": "89b73e2b6362017ffb9e3bc6ea954cb3",
+    "semantic_hash": "89b73e2b6362017ffb9e3bc6ea954cb3"
+  },
+  "services/orion-hub/scripts/pre_turn_appraisal_wiring.py": {
+    "mtime": 1783136738.0558803,
+    "ast_hash": "5f12f7c7385e2d102dca0b02a4ac14fe",
+    "semantic_hash": "5f12f7c7385e2d102dca0b02a4ac14fe"
+  },
+  "services/orion-hub/scripts/presence_session.py": {
+    "mtime": 1779070080.261205,
+    "ast_hash": "89bdb4f6f2aa77ef312e019a848a23d0",
+    "semantic_hash": "89bdb4f6f2aa77ef312e019a848a23d0"
+  },
+  "services/orion-hub/scripts/proposal_review_client.py": {
+    "mtime": 1781479799.2117631,
+    "ast_hash": "d7b78ff10f01c56bffd51db8a028d9e0",
+    "semantic_hash": "d7b78ff10f01c56bffd51db8a028d9e0"
+  },
+  "services/orion-hub/scripts/proposal_review_routes.py": {
+    "mtime": 1781479799.2117631,
+    "ast_hash": "e924c951959ef62a6f6f14e7170a43ff",
+    "semantic_hash": "e924c951959ef62a6f6f14e7170a43ff"
+  },
+  "services/orion-hub/scripts/repair_pressure_wiring.py": {
+    "mtime": 1783114357.2209706,
+    "ast_hash": "1dd574fc321de233b481f3611e1fa6d5",
+    "semantic_hash": "1dd574fc321de233b481f3611e1fa6d5"
+  },
+  "services/orion-hub/scripts/run_recall_canary_battle.py": {
+    "mtime": 1777748523.328599,
+    "ast_hash": "357a05bb853ae73dbee6f28f678c02d7",
+    "semantic_hash": "357a05bb853ae73dbee6f28f678c02d7"
+  },
+  "services/orion-hub/scripts/seed_recall_canary_profile.py": {
+    "mtime": 1777748523.328599,
+    "ast_hash": "c98a6133baee4e4119882a90b2c128dd",
+    "semantic_hash": "c98a6133baee4e4119882a90b2c128dd"
+  },
+  "services/orion-hub/scripts/seed_substrate_graphdb.py": {
+    "mtime": 1775951237.9657023,
+    "ast_hash": "e569128cb4a2d41212662f54250936d0",
+    "semantic_hash": "e569128cb4a2d41212662f54250936d0"
+  },
+  "services/orion-hub/scripts/self_brain_routes.py": {
+    "mtime": 1783468068.6348665,
+    "ast_hash": "2a9be3c06dcda48eebc57adc7018e6a9",
+    "semantic_hash": "2a9be3c06dcda48eebc57adc7018e6a9"
+  },
+  "services/orion-hub/scripts/service_logs.py": {
+    "mtime": 1775410382.9575405,
+    "ast_hash": "657ed7d7a2f670fc80cb330ecb45e56e",
+    "semantic_hash": "657ed7d7a2f670fc80cb330ecb45e56e"
+  },
+  "services/orion-hub/scripts/service_logs_ws.py": {
+    "mtime": 1775410382.9575405,
+    "ast_hash": "8773ffc826f58587f57f72d549cd533b",
+    "semantic_hash": "8773ffc826f58587f57f72d549cd533b"
+  },
+  "services/orion-hub/scripts/session.py": {
+    "mtime": 1767089828.7633495,
+    "ast_hash": "154d1aa8a665bcbff313d264f02c2f20",
+    "semantic_hash": "154d1aa8a665bcbff313d264f02c2f20"
+  },
+  "services/orion-hub/scripts/settings.py": {
+    "mtime": 1783291410.026702,
+    "ast_hash": "ce6cb1985a85668e95e569bd92d35bfc",
+    "semantic_hash": "ce6cb1985a85668e95e569bd92d35bfc"
+  },
+  "services/orion-hub/scripts/signals_inspect_cache.py": {
+    "mtime": 1779336650.7887821,
+    "ast_hash": "6edc983944f60d3dd49114f5c031b564",
+    "semantic_hash": "6edc983944f60d3dd49114f5c031b564"
+  },
+  "services/orion-hub/scripts/skill_runner_catalogue.py": {
+    "mtime": 1783807364.326837,
+    "ast_hash": "98a1bd19b2a908099e7fb04646fbfa85",
+    "semantic_hash": "98a1bd19b2a908099e7fb04646fbfa85"
+  },
+  "services/orion-hub/scripts/social_room.py": {
+    "mtime": 1783107031.976902,
+    "ast_hash": "2a4be0bdf3a27bb8051722ceca66cb2a",
+    "semantic_hash": "2a4be0bdf3a27bb8051722ceca66cb2a"
+  },
+  "services/orion-hub/scripts/social_room_inspection_cache.py": {
+    "mtime": 1783807361.8307576,
+    "ast_hash": "8c5f88cd3e4865eb2f243968c493ff65",
+    "semantic_hash": "8c5f88cd3e4865eb2f243968c493ff65"
+  },
+  "services/orion-hub/scripts/spark_candidate.py": {
+    "mtime": 1781845457.8065681,
+    "ast_hash": "51b239ca838505e2d8c3b7cda1bd412f",
+    "semantic_hash": "51b239ca838505e2d8c3b7cda1bd412f"
+  },
+  "services/orion-hub/scripts/substrate_attention_routes.py": {
+    "mtime": 1779681646.023453,
+    "ast_hash": "77f947f6baee1e9f5f1105bc6da254db",
+    "semantic_hash": "77f947f6baee1e9f5f1105bc6da254db"
+  },
+  "services/orion-hub/scripts/substrate_biometrics_routes.py": {
+    "mtime": 1779668837.6853046,
+    "ast_hash": "7a359ac62bf43c1912eea5e93b9fb61e",
+    "semantic_hash": "7a359ac62bf43c1912eea5e93b9fb61e"
+  },
+  "services/orion-hub/scripts/substrate_consolidation_routes.py": {
+    "mtime": 1779749949.3244674,
+    "ast_hash": "f21ddb647f17a56226e147f412cec2fc",
+    "semantic_hash": "f21ddb647f17a56226e147f412cec2fc"
+  },
+  "services/orion-hub/scripts/substrate_effect_cache.py": {
+    "mtime": 1779649387.8052988,
+    "ast_hash": "3835ec0f337ecec924ab07ec1374ea4a",
+    "semantic_hash": "3835ec0f337ecec924ab07ec1374ea4a"
+  },
+  "services/orion-hub/scripts/substrate_effect_pipeline.py": {
+    "mtime": 1783125791.024088,
+    "ast_hash": "ec9bbcbf78824946af49b02e10eebcb1",
+    "semantic_hash": "ec9bbcbf78824946af49b02e10eebcb1"
+  },
+  "services/orion-hub/scripts/substrate_execution_dispatch_routes.py": {
+    "mtime": 1784008374.2455008,
+    "ast_hash": "a6272d48c9bd037e119cd55dce69967c",
+    "semantic_hash": "a6272d48c9bd037e119cd55dce69967c"
+  },
+  "services/orion-hub/scripts/substrate_feedback_routes.py": {
+    "mtime": 1779722671.532158,
+    "ast_hash": "1510fc7639dba0f06c3c8356770de377",
+    "semantic_hash": "1510fc7639dba0f06c3c8356770de377"
+  },
+  "services/orion-hub/scripts/substrate_field_routes.py": {
+    "mtime": 1779671370.5200107,
+    "ast_hash": "38a17e813bcf8e743ef78911d999cd69",
+    "semantic_hash": "38a17e813bcf8e743ef78911d999cd69"
+  },
+  "services/orion-hub/scripts/substrate_lattice_routes.py": {
+    "mtime": 1783499830.2025213,
+    "ast_hash": "685f443ce37dff19980eb9f3e6037af6",
+    "semantic_hash": "685f443ce37dff19980eb9f3e6037af6"
+  },
+  "services/orion-hub/scripts/substrate_observability_routes.py": {
+    "mtime": 1783355701.7941408,
+    "ast_hash": "ffc5bcfc7bfa331061a50003aae12617",
+    "semantic_hash": "ffc5bcfc7bfa331061a50003aae12617"
+  },
+  "services/orion-hub/scripts/substrate_policy_routes.py": {
+    "mtime": 1779689417.3442013,
+    "ast_hash": "4b2f0eceab65eb94adfa3e95173cf54c",
+    "semantic_hash": "4b2f0eceab65eb94adfa3e95173cf54c"
+  },
+  "services/orion-hub/scripts/substrate_proposal_routes.py": {
+    "mtime": 1779687966.458823,
+    "ast_hash": "fd467ca2672b24c4baad116022b100e1",
+    "semantic_hash": "fd467ca2672b24c4baad116022b100e1"
+  },
+  "services/orion-hub/scripts/substrate_self_state_routes.py": {
+    "mtime": 1783847515.5408454,
+    "ast_hash": "879cc9890a8f266ac263c1c262150156",
+    "semantic_hash": "879cc9890a8f266ac263c1c262150156"
+  },
+  "services/orion-hub/scripts/thought_client.py": {
+    "mtime": 1783614403.4952698,
+    "ast_hash": "c5514a1086237d9cc851b0c002d4c41e",
+    "semantic_hash": "c5514a1086237d9cc851b0c002d4c41e"
+  },
+  "services/orion-hub/scripts/trace_payloads.py": {
+    "mtime": 1774236180.4503853,
+    "ast_hash": "00717e0ff9e4f9ca78a375347f0fdaa1",
+    "semantic_hash": "00717e0ff9e4f9ca78a375347f0fdaa1"
+  },
+  "services/orion-hub/scripts/turn_cancel.py": {
+    "mtime": 1783655498.745199,
+    "ast_hash": "131d81003033bdce1fbe4bdacb39fbe3",
+    "semantic_hash": "131d81003033bdce1fbe4bdacb39fbe3"
+  },
+  "services/orion-hub/scripts/unified_turn_stub.py": {
+    "mtime": 1783614403.6182735,
+    "ast_hash": "58159874e1ac3415c9aca48c868e9e0c",
+    "semantic_hash": "58159874e1ac3415c9aca48c868e9e0c"
+  },
+  "services/orion-hub/scripts/utils.py": {
+    "mtime": 1763232123.4118907,
+    "ast_hash": "c8b74dda902e63d8f0d7cb8f0dd145a4",
+    "semantic_hash": "c8b74dda902e63d8f0d7cb8f0dd145a4"
+  },
+  "services/orion-hub/scripts/verify_agent_claude_stream_live.py": {
+    "mtime": 1783219371.2230642,
+    "ast_hash": "0695073da5c602af69e7a77a763b6036",
+    "semantic_hash": "0695073da5c602af69e7a77a763b6036"
+  },
+  "services/orion-hub/scripts/verify_agent_repl_stream_live.py": {
+    "mtime": 1782955656.275706,
+    "ast_hash": "c99fa6443c9889fab7d6dd1a2629088b",
+    "semantic_hash": "c99fa6443c9889fab7d6dd1a2629088b"
+  },
+  "services/orion-hub/scripts/voice_stt_errors.py": {
+    "mtime": 1780115804.9091446,
+    "ast_hash": "91d715214162f5694eed624965d3af48",
+    "semantic_hash": "91d715214162f5694eed624965d3af48"
+  },
+  "services/orion-hub/scripts/warm_start.py": {
+    "mtime": 1767676515.6551068,
+    "ast_hash": "af05c03cdbe79f2b5bab2ad54c11ed0d",
+    "semantic_hash": "af05c03cdbe79f2b5bab2ad54c11ed0d"
+  },
+  "services/orion-hub/scripts/websocket_handler.py": {
+    "mtime": 1783807361.8307576,
+    "ast_hash": "54a2eba0f4e1683f469180b99491d6b9",
+    "semantic_hash": "54a2eba0f4e1683f469180b99491d6b9"
+  },
+  "services/orion-hub/scripts/workflow_payloads.py": {
+    "mtime": 1774417080.6527085,
+    "ast_hash": "0ab31598c9b4e555d5d38024ed9f51d8",
+    "semantic_hash": "0ab31598c9b4e555d5d38024ed9f51d8"
+  },
+  "services/orion-hub/static/js/agent-claude-trace.js": {
+    "mtime": 1783615212.4819124,
+    "ast_hash": "2af0d9f8758aaf5a79f67a5500af5526",
+    "semantic_hash": "2af0d9f8758aaf5a79f67a5500af5526"
+  },
+  "services/orion-hub/static/js/agent-trace.js": {
+    "mtime": 1782964828.613541,
+    "ast_hash": "3ccea5aab93a63f49788ef1c23ad6485",
+    "semantic_hash": "3ccea5aab93a63f49788ef1c23ad6485"
+  },
+  "services/orion-hub/static/js/aitown-panel.js": {
+    "mtime": 1783364899.1244671,
+    "ast_hash": "1f6f92f6ddbed55157aa77199287be8f",
+    "semantic_hash": "1f6f92f6ddbed55157aa77199287be8f"
+  },
+  "services/orion-hub/static/js/app.js": {
+    "mtime": 1783960753.1718304,
+    "ast_hash": "abfa7f55241230a84a01eb7485b228d3",
+    "semantic_hash": "abfa7f55241230a84a01eb7485b228d3"
+  },
+  "services/orion-hub/static/js/collapse-mirror.js": {
+    "mtime": 1780972924.4402647,
+    "ast_hash": "8fceb6f4fb06c881a4fa9e26e281a7ea",
+    "semantic_hash": "8fceb6f4fb06c881a4fa9e26e281a7ea"
+  },
+  "services/orion-hub/static/js/memory-crystallization-ui.js": {
+    "mtime": 1783965578.7337081,
+    "ast_hash": "91615ef015366e0808c7cbef101c3ec5",
+    "semantic_hash": "91615ef015366e0808c7cbef101c3ec5"
+  },
+  "services/orion-hub/static/js/memory-graph-draft-form.js": {
+    "mtime": 1783555541.5416741,
+    "ast_hash": "fec9f2b72f11af1168a80cc1a997aeb0",
+    "semantic_hash": "fec9f2b72f11af1168a80cc1a997aeb0"
+  },
+  "services/orion-hub/static/js/memory-graph-draft-ui.js": {
+    "mtime": 1783807362.1367674,
+    "ast_hash": "230adc3d461d0e8b85ce50dfa0a9363f",
+    "semantic_hash": "230adc3d461d0e8b85ce50dfa0a9363f"
+  },
+  "services/orion-hub/static/js/memory.js": {
+    "mtime": 1783807362.84879,
+    "ast_hash": "ecf33092d1c95b7f085637433117dec8",
+    "semantic_hash": "ecf33092d1c95b7f085637433117dec8"
+  },
+  "services/orion-hub/static/js/mind_provenance.js": {
+    "mtime": 1779318302.5461986,
+    "ast_hash": "9aef5f19d4b667635bcb4359c542eafe",
+    "semantic_hash": "9aef5f19d4b667635bcb4359c542eafe"
+  },
+  "services/orion-hub/static/js/organ-signals-graph-ui.js": {
+    "mtime": 1779336686.0855548,
+    "ast_hash": "7fe18320e7633966266e64a3c695ac95",
+    "semantic_hash": "7fe18320e7633966266e64a3c695ac95"
+  },
+  "services/orion-hub/static/js/proposal-review-ui.js": {
+    "mtime": 1783499830.2055213,
+    "ast_hash": "e70befaf7ccb70b8c5ae683c6d94db33",
+    "semantic_hash": "e70befaf7ccb70b8c5ae683c6d94db33"
+  },
+  "services/orion-hub/static/js/self-brain.js": {
+    "mtime": 1783473102.644676,
+    "ast_hash": "22f1f6feed9ee9679d134e7c734b6d11",
+    "semantic_hash": "22f1f6feed9ee9679d134e7c734b6d11"
+  },
+  "services/orion-hub/static/js/self_observability.js": {
+    "mtime": 1783473102.644676,
+    "ast_hash": "619415ba81f294a64c7047770ea9d16f",
+    "semantic_hash": "619415ba81f294a64c7047770ea9d16f"
+  },
+  "services/orion-hub/static/js/service-logs-ui.js": {
+    "mtime": 1783499830.2055213,
+    "ast_hash": "58b5531d681d667b9bdaf01b87f5e986",
+    "semantic_hash": "58b5531d681d667b9bdaf01b87f5e986"
+  },
+  "services/orion-hub/static/js/social-inspection.js": {
+    "mtime": 1774240323.6624937,
+    "ast_hash": "77fe549f2a86af5cbc8e7a557257a457",
+    "semantic_hash": "77fe549f2a86af5cbc8e7a557257a457"
+  },
+  "services/orion-hub/static/js/social-inspection.test.js": {
+    "mtime": 1774240323.6624937,
+    "ast_hash": "2053c1a74c44aec85160fa269440d6bc",
+    "semantic_hash": "2053c1a74c44aec85160fa269440d6bc"
+  },
+  "services/orion-hub/static/js/substrate-atlas.js": {
+    "mtime": 1779652349.0312264,
+    "ast_hash": "23da31aaeb29b7f9bf78a5669ba5ec2c",
+    "semantic_hash": "23da31aaeb29b7f9bf78a5669ba5ec2c"
+  },
+  "services/orion-hub/static/js/substrate-atlas.test.js": {
+    "mtime": 1779651270.2090595,
+    "ast_hash": "7bedb727d8876cbf2d919623cd24b939",
+    "semantic_hash": "7bedb727d8876cbf2d919623cd24b939"
+  },
+  "services/orion-hub/static/js/substrate-effect-ui.js": {
+    "mtime": 1783807362.662784,
+    "ast_hash": "3905ccb9264a684522ef0ff4734da87f",
+    "semantic_hash": "3905ccb9264a684522ef0ff4734da87f"
+  },
+  "services/orion-hub/static/js/substrate-lattice.js": {
+    "mtime": 1783499830.2055213,
+    "ast_hash": "8bd3622df7f6a983eeb33e6cc58d6d29",
+    "semantic_hash": "8bd3622df7f6a983eeb33e6cc58d6d29"
+  },
+  "services/orion-hub/static/js/substrate.js": {
+    "mtime": 1775953393.2778995,
+    "ast_hash": "b9e983b3ab30f21d10e746b48d3fe59b",
+    "semantic_hash": "b9e983b3ab30f21d10e746b48d3fe59b"
+  },
+  "services/orion-hub/static/js/thought-process.js": {
+    "mtime": 1783292185.7363167,
+    "ast_hash": "4cba2b125238a28c5055d28c7c4028b4",
+    "semantic_hash": "4cba2b125238a28c5055d28c7c4028b4"
+  },
+  "services/orion-hub/static/js/thought-process.test.js": {
+    "mtime": 1783292185.7373168,
+    "ast_hash": "875a77a23c05bbfb13f976d0711b3843",
+    "semantic_hash": "875a77a23c05bbfb13f976d0711b3843"
+  },
+  "services/orion-hub/static/js/workflow-schedule-ui.js": {
+    "mtime": 1783499830.2055213,
+    "ast_hash": "b7aefdb66b478a19c4574c8b5f9f4def",
+    "semantic_hash": "b7aefdb66b478a19c4574c8b5f9f4def"
+  },
+  "services/orion-hub/static/js/workflow-schedule-ui.test.js": {
+    "mtime": 1774478925.2032306,
+    "ast_hash": "7011cf863ddfb177eb218f3b46efddf0",
+    "semantic_hash": "7011cf863ddfb177eb218f3b46efddf0"
+  },
+  "services/orion-hub/static/js/workflow-ui.js": {
+    "mtime": 1783958824.2886841,
+    "ast_hash": "ab2ae022c0fe5191d2c107d5ec711433",
+    "semantic_hash": "ab2ae022c0fe5191d2c107d5ec711433"
+  },
+  "services/orion-hub/static/js/workflow-ui.test.js": {
+    "mtime": 1774832776.3347197,
+    "ast_hash": "1b13425363914adcb33b7a67b4269a6a",
+    "semantic_hash": "1b13425363914adcb33b7a67b4269a6a"
+  },
+  "services/orion-hub/tests/conftest.py": {
+    "mtime": 1783291410.0277019,
+    "ast_hash": "b80b5e56219692e3d11d60d4b2719712",
+    "semantic_hash": "b80b5e56219692e3d11d60d4b2719712"
+  },
+  "services/orion-hub/tests/e2e/conftest.py": {
+    "mtime": 1779083923.0911815,
+    "ast_hash": "f0473e755ce566f74d935fff98b1962e",
+    "semantic_hash": "f0473e755ce566f74d935fff98b1962e"
+  },
+  "services/orion-hub/tests/e2e/memory_graph_from_chat_cases.py": {
+    "mtime": 1779083923.0911815,
+    "ast_hash": "d0c6914ddb886af15b3c33bc3f794542",
+    "semantic_hash": "d0c6914ddb886af15b3c33bc3f794542"
+  },
+  "services/orion-hub/tests/e2e/test_memory_graph_from_chat_live.py": {
+    "mtime": 1779083923.0911815,
+    "ast_hash": "e31790d348b59708bc625fce4ea91ce2",
+    "semantic_hash": "e31790d348b59708bc625fce4ea91ce2"
+  },
+  "services/orion-hub/tests/fixtures/cognitive_proposals/golden_cases.json": {
+    "mtime": 1777748523.3325992,
+    "ast_hash": "e4e0ed728cf6e116545eb6a02d45ea9d",
+    "semantic_hash": "e4e0ed728cf6e116545eb6a02d45ea9d"
+  },
+  "services/orion-hub/tests/fixtures/recall_canary/golden_cases.json": {
+    "mtime": 1777165684.9530957,
+    "ast_hash": "58703702766bd7da8e7bff4905505ff3",
+    "semantic_hash": "58703702766bd7da8e7bff4905505ff3"
+  },
+  "services/orion-hub/tests/fixtures/recall_canary/orion_memory_battle_cases.json": {
+    "mtime": 1777748523.3325992,
+    "ast_hash": "fefd1270ed7ff2ed83cba1b931839987",
+    "semantic_hash": "fefd1270ed7ff2ed83cba1b931839987"
+  },
+  "services/orion-hub/tests/test_agent_claude_chat_history.py": {
+    "mtime": 1783225697.9823585,
+    "ast_hash": "212eaf9b981348fa6ab4dccd176c6bd1",
+    "semantic_hash": "212eaf9b981348fa6ab4dccd176c6bd1"
+  },
+  "services/orion-hub/tests/test_agent_claude_input.py": {
+    "mtime": 1783402854.8333287,
+    "ast_hash": "8984aa97b30e85a78f8c83c492984f87",
+    "semantic_hash": "8984aa97b30e85a78f8c83c492984f87"
+  },
+  "services/orion-hub/tests/test_agent_claude_trace_js.py": {
+    "mtime": 1783614403.4762692,
+    "ast_hash": "02f188271077f1eb6704212226c0f7f3",
+    "semantic_hash": "02f188271077f1eb6704212226c0f7f3"
+  },
+  "services/orion-hub/tests/test_agent_repl_bridge.py": {
+    "mtime": 1783105164.3560724,
+    "ast_hash": "33b6fd3083cb51b4293f17d7a401e16d",
+    "semantic_hash": "33b6fd3083cb51b4293f17d7a401e16d"
+  },
+  "services/orion-hub/tests/test_agent_step_relay.py": {
+    "mtime": 1782955656.2797062,
+    "ast_hash": "7f2bc18f59b438f00ec664c47da5aadd",
+    "semantic_hash": "7f2bc18f59b438f00ec664c47da5aadd"
+  },
+  "services/orion-hub/tests/test_agent_trace_debug_panel.py": {
+    "mtime": 1775631837.3881614,
+    "ast_hash": "75451ac613fc06b9ba9e2553e3808e77",
+    "semantic_hash": "75451ac613fc06b9ba9e2553e3808e77"
+  },
+  "services/orion-hub/tests/test_agent_trace_payload.py": {
+    "mtime": 1774236180.4523852,
+    "ast_hash": "c003de0e97bad8e9ce6680f1965a579b",
+    "semantic_hash": "c003de0e97bad8e9ce6680f1965a579b"
+  },
+  "services/orion-hub/tests/test_aitown_proxy.py": {
+    "mtime": 1783364899.1274674,
+    "ast_hash": "82e9e8756087a7e7eeabffc5ef592223",
+    "semantic_hash": "82e9e8756087a7e7eeabffc5ef592223"
+  },
+  "services/orion-hub/tests/test_aitown_status_api.py": {
+    "mtime": 1783356609.57501,
+    "ast_hash": "41fd955f986ee6c9cf6738a6372cd23f",
+    "semantic_hash": "41fd955f986ee6c9cf6738a6372cd23f"
+  },
+  "services/orion-hub/tests/test_attention_card_legibility.py": {
+    "mtime": 1783447063.2613704,
+    "ast_hash": "aa004ea48a31f8b84487db7344fc60bd",
+    "semantic_hash": "aa004ea48a31f8b84487db7344fc60bd"
+  },
+  "services/orion-hub/tests/test_attention_closure_e2e.py": {
+    "mtime": 1783447063.2613704,
+    "ast_hash": "cc2bbed47fa254e1fded0422093f85c0",
+    "semantic_hash": "cc2bbed47fa254e1fded0422093f85c0"
+  },
+  "services/orion-hub/tests/test_attention_frame_debug_panel.py": {
+    "mtime": 1778901838.384395,
+    "ast_hash": "245e8d3b7912cdf015bb9122feb08aa2",
+    "semantic_hash": "245e8d3b7912cdf015bb9122feb08aa2"
+  },
+  "services/orion-hub/tests/test_attention_loop_closure.py": {
+    "mtime": 1783447063.2613704,
+    "ast_hash": "ebbeda3d84a240ddb181141cc06a8277",
+    "semantic_hash": "ebbeda3d84a240ddb181141cc06a8277"
+  },
+  "services/orion-hub/tests/test_attention_loops_api.py": {
+    "mtime": 1783447063.2613704,
+    "ast_hash": "3900bf5829157819ef9d53f88bc2f080",
+    "semantic_hash": "3900bf5829157819ef9d53f88bc2f080"
+  },
+  "services/orion-hub/tests/test_attention_loops_reader.py": {
+    "mtime": 1783447063.2613704,
+    "ast_hash": "9a0d5d006a903bf304d60d6b9f532d1b",
+    "semantic_hash": "9a0d5d006a903bf304d60d6b9f532d1b"
+  },
+  "services/orion-hub/tests/test_attention_loops_ui_smoke.py": {
+    "mtime": 1783447063.2613704,
+    "ast_hash": "2808bc5bcaec3004886719df0f5d8452",
+    "semantic_hash": "2808bc5bcaec3004886719df0f5d8452"
+  },
+  "services/orion-hub/tests/test_attention_outcome_publish.py": {
+    "mtime": 1783447063.2613704,
+    "ast_hash": "bd4d4f912b8abf1005013e7a06ec2749",
+    "semantic_hash": "bd4d4f912b8abf1005013e7a06ec2749"
+  },
+  "services/orion-hub/tests/test_autonomy_goal_actions.py": {
+    "mtime": 1779328788.9697866,
+    "ast_hash": "260f4c2d15eeb2de3b5f5aca0d0155af",
+    "semantic_hash": "260f4c2d15eeb2de3b5f5aca0d0155af"
+  },
+  "services/orion-hub/tests/test_autonomy_goal_archive_api.py": {
+    "mtime": 1779333968.8986838,
+    "ast_hash": "618e843da901d0436d4118f8269b53b6",
+    "semantic_hash": "618e843da901d0436d4118f8269b53b6"
+  },
+  "services/orion-hub/tests/test_autonomy_payload_extraction_logging.py": {
+    "mtime": 1780119700.2979512,
+    "ast_hash": "339a62a52ce0bef833d9bce54295a223",
+    "semantic_hash": "339a62a52ce0bef833d9bce54295a223"
+  },
+  "services/orion-hub/tests/test_autonomy_payloads_turn_effect.py": {
+    "mtime": 1777761366.3713067,
+    "ast_hash": "bd0509fbe57743680db81581f6c44e06",
+    "semantic_hash": "bd0509fbe57743680db81581f6c44e06"
+  },
+  "services/orion-hub/tests/test_autonomy_runtime_ui_panel.py": {
+    "mtime": 1783499830.2075214,
+    "ast_hash": "cfd1c19c90c8e066c558389194a55a37",
+    "semantic_hash": "cfd1c19c90c8e066c558389194a55a37"
+  },
+  "services/orion-hub/tests/test_build_orion_turn_request.py": {
+    "mtime": 1783291410.0277019,
+    "ast_hash": "f66a0f88395af8c13b2e7e37129433a3",
+    "semantic_hash": "f66a0f88395af8c13b2e7e37129433a3"
+  },
+  "services/orion-hub/tests/test_chat_stance_debug_panel.py": {
+    "mtime": 1781505763.9879193,
+    "ast_hash": "be56baca08c55844100b87ca3e015176",
+    "semantic_hash": "be56baca08c55844100b87ca3e015176"
+  },
+  "services/orion-hub/tests/test_chat_turn_spark_meta_turn_effect.py": {
+    "mtime": 1777149194.4185002,
+    "ast_hash": "6d4a121d6db1534254d7e1d5198810d0",
+    "semantic_hash": "6d4a121d6db1534254d7e1d5198810d0"
+  },
+  "services/orion-hub/tests/test_cognition_trace_api.py": {
+    "mtime": 1783136738.0558803,
+    "ast_hash": "7968c4d065244c632afcd9dc6f98d6df",
+    "semantic_hash": "7968c4d065244c632afcd9dc6f98d6df"
+  },
+  "services/orion-hub/tests/test_context_exec_agent_grounding.py": {
+    "mtime": 1783113795.7059557,
+    "ast_hash": "d94756a9111dd9f38a7309c901ef44bb",
+    "semantic_hash": "d94756a9111dd9f38a7309c901ef44bb"
+  },
+  "services/orion-hub/tests/test_correlation_chain_fallback.py": {
+    "mtime": 1779336664.5916924,
+    "ast_hash": "f83156646a8edbfdd954cded1e549c6b",
+    "semantic_hash": "f83156646a8edbfdd954cded1e549c6b"
+  },
+  "services/orion-hub/tests/test_correlation_id_propagation.py": {
+    "mtime": 1779332554.3348985,
+    "ast_hash": "def023375cae5118304ea2c197ab3fbf",
+    "semantic_hash": "def023375cae5118304ea2c197ab3fbf"
+  },
+  "services/orion-hub/tests/test_cortex_chat_display.py": {
+    "mtime": 1775948546.0595117,
+    "ast_hash": "a67d8f21f55f66ac5344e8792152fbd2",
+    "semantic_hash": "a67d8f21f55f66ac5344e8792152fbd2"
+  },
+  "services/orion-hub/tests/test_cortex_memory_graph_text.py": {
+    "mtime": 1779753471.2832897,
+    "ast_hash": "fde6c72280c09ad6265ea8be8035c3e7",
+    "semantic_hash": "fde6c72280c09ad6265ea8be8035c3e7"
+  },
+  "services/orion-hub/tests/test_cortex_request_builder.py": {
+    "mtime": 1783555541.5436742,
+    "ast_hash": "74daeb6dcc27cf76f7f4bf3b354a02c0",
+    "semantic_hash": "74daeb6dcc27cf76f7f4bf3b354a02c0"
+  },
+  "services/orion-hub/tests/test_crystallization_routes_contract.py": {
+    "mtime": 1783965578.7337081,
+    "ast_hash": "72dd190abae4055cf108390fc44fa3d2",
+    "semantic_hash": "72dd190abae4055cf108390fc44fa3d2"
+  },
+  "services/orion-hub/tests/test_epistemic_pipeline_bridge.py": {
+    "mtime": 1783105289.1780746,
+    "ast_hash": "2fae0b79cc6aa3451813b27e682288ac",
+    "semantic_hash": "2fae0b79cc6aa3451813b27e682288ac"
+  },
+  "services/orion-hub/tests/test_fcc_claude_bridge_mcp.py": {
+    "mtime": 1783399673.9747026,
+    "ast_hash": "77c73901ce0ca31ce19d3621e225d3d3",
+    "semantic_hash": "77c73901ce0ca31ce19d3621e225d3d3"
+  },
+  "services/orion-hub/tests/test_fcc_claude_bridge_parse.py": {
+    "mtime": 1783219371.2270644,
+    "ast_hash": "8f398376e80544773d7cb8231e5c3374",
+    "semantic_hash": "8f398376e80544773d7cb8231e5c3374"
+  },
+  "services/orion-hub/tests/test_fcc_claude_bridge_run.py": {
+    "mtime": 1783652292.780466,
+    "ast_hash": "af42f1adc481f1858f2d2fc6f4dad5a7",
+    "semantic_hash": "af42f1adc481f1858f2d2fc6f4dad5a7"
+  },
+  "services/orion-hub/tests/test_fcc_env_catalog.py": {
+    "mtime": 1783219371.2280643,
+    "ast_hash": "40c4c2ae05efc385baa33ece9a22caf5",
+    "semantic_hash": "40c4c2ae05efc385baa33ece9a22caf5"
+  },
+  "services/orion-hub/tests/test_fcc_mcp_config.py": {
+    "mtime": 1783405468.2227883,
+    "ast_hash": "2c21b3bfd3a6830fbfcbe0e70e9f7de1",
+    "semantic_hash": "2c21b3bfd3a6830fbfcbe0e70e9f7de1"
+  },
+  "services/orion-hub/tests/test_fcc_model_label_mapping.py": {
+    "mtime": 1783219371.2280643,
+    "ast_hash": "2acb3f7365e4f717cc6896e65b5a196b",
+    "semantic_hash": "2acb3f7365e4f717cc6896e65b5a196b"
+  },
+  "services/orion-hub/tests/test_fcc_model_labels_api.py": {
+    "mtime": 1783219371.2280643,
+    "ast_hash": "dcfd2674c184e3b313896e4798ba17ec",
+    "semantic_hash": "dcfd2674c184e3b313896e4798ba17ec"
+  },
+  "services/orion-hub/tests/test_forge_hub_tab.py": {
+    "mtime": 1779320543.2543433,
+    "ast_hash": "af7402e2bca76270f4ef93f253ea8b8a",
+    "semantic_hash": "af7402e2bca76270f4ef93f253ea8b8a"
+  },
+  "services/orion-hub/tests/test_grafana_tempo_link.py": {
+    "mtime": 1777790653.2240317,
+    "ast_hash": "ca7f1399018e795f1421869a21a48934",
+    "semantic_hash": "ca7f1399018e795f1421869a21a48934"
+  },
+  "services/orion-hub/tests/test_grammar_atlas_api.py": {
+    "mtime": 1779651270.5890582,
+    "ast_hash": "7e3af22d0a72f2efca0603144bee95e5",
+    "semantic_hash": "7e3af22d0a72f2efca0603144bee95e5"
+  },
+  "services/orion-hub/tests/test_graphiti_config_parity.py": {
+    "mtime": 1783356609.57501,
+    "ast_hash": "4098d00b20a546618678ae5533001777",
+    "semantic_hash": "4098d00b20a546618678ae5533001777"
+  },
+  "services/orion-hub/tests/test_graphiti_sync_payload.py": {
+    "mtime": 1783356609.57501,
+    "ast_hash": "2baaa33e05309b57f37cb37ec8ffa0f6",
+    "semantic_hash": "2baaa33e05309b57f37cb37ec8ffa0f6"
+  },
+  "services/orion-hub/tests/test_handle_chat_request_substrate_effect.py": {
+    "mtime": 1783125791.0250878,
+    "ast_hash": "29f8c54cb01d5e6900304fd8bf86a226",
+    "semantic_hash": "29f8c54cb01d5e6900304fd8bf86a226"
+  },
+  "services/orion-hub/tests/test_handle_chat_request_turn_effect.py": {
+    "mtime": 1778901838.3853948,
+    "ast_hash": "ce87847df6dd7c7b7628a7a977584088",
+    "semantic_hash": "ce87847df6dd7c7b7628a7a977584088"
+  },
+  "services/orion-hub/tests/test_harness_governor_client_liveness.py": {
+    "mtime": 1783753435.4783192,
+    "ast_hash": "ef39b630432bc6cc03ebd179aca67ef3",
+    "semantic_hash": "ef39b630432bc6cc03ebd179aca67ef3"
+  },
+  "services/orion-hub/tests/test_http_agent_claude.py": {
+    "mtime": 1783225697.9833586,
+    "ast_hash": "1618b1a9984ba27fd115e2ddbbcc4034",
+    "semantic_hash": "1618b1a9984ba27fd115e2ddbbcc4034"
+  },
+  "services/orion-hub/tests/test_http_chat_spark_candidate.py": {
+    "mtime": 1781845457.8065681,
+    "ast_hash": "a3654983124d871c0a70f5fe5ff3c5ab",
+    "semantic_hash": "a3654983124d871c0a70f5fe5ff3c5ab"
+  },
+  "services/orion-hub/tests/test_http_chat_spark_meta.py": {
+    "mtime": 1777093481.8371313,
+    "ast_hash": "6fdd1017d6e1c4145c9e46eac2b2f7bc",
+    "semantic_hash": "6fdd1017d6e1c4145c9e46eac2b2f7bc"
+  },
+  "services/orion-hub/tests/test_hub_aitown_tab.py": {
+    "mtime": 1783364899.1274674,
+    "ast_hash": "899376a44e7806e8cd63ae12a42338f8",
+    "semantic_hash": "899376a44e7806e8cd63ae12a42338f8"
+  },
+  "services/orion-hub/tests/test_hub_direct_inspection_cache.py": {
+    "mtime": 1783107031.9789019,
+    "ast_hash": "70d5c3ad349d764cc8f7df0984e55e37",
+    "semantic_hash": "70d5c3ad349d764cc8f7df0984e55e37"
+  },
+  "services/orion-hub/tests/test_hub_direct_social_room_isolation.py": {
+    "mtime": 1782879116.7631662,
+    "ast_hash": "c3c70cc402687b7d2dac98a50736e90e",
+    "semantic_hash": "c3c70cc402687b7d2dac98a50736e90e"
+  },
+  "services/orion-hub/tests/test_hub_grammar_emit.py": {
+    "mtime": 1783908076.953645,
+    "ast_hash": "25150684c27695bf1fc39787aed29e30",
+    "semantic_hash": "25150684c27695bf1fc39787aed29e30"
+  },
+  "services/orion-hub/tests/test_hub_grammar_publish_fail_open.py": {
+    "mtime": 1781897477.5830867,
+    "ast_hash": "f6e22719f95b30b660b7d036f424f9f9",
+    "semantic_hash": "f6e22719f95b30b660b7d036f424f9f9"
+  },
+  "services/orion-hub/tests/test_hub_harness_step_relay.py": {
+    "mtime": 1783745566.6173477,
+    "ast_hash": "391c6a56bcfb13e26c971c9955238972",
+    "semantic_hash": "391c6a56bcfb13e26c971c9955238972"
+  },
+  "services/orion-hub/tests/test_hub_local_time_naive_utc.py": {
+    "mtime": 1783960753.1718304,
+    "ast_hash": "25d257ca46e48f264966813d76a36d5d",
+    "semantic_hash": "25d257ca46e48f264966813d76a36d5d"
+  },
+  "services/orion-hub/tests/test_hub_presence.py": {
+    "mtime": 1783105164.3560724,
+    "ast_hash": "d7059b0b4f540dc23b134d77eab9d617",
+    "semantic_hash": "d7059b0b4f540dc23b134d77eab9d617"
+  },
+  "services/orion-hub/tests/test_hub_ui_polish.py": {
+    "mtime": 1783499830.2075214,
+    "ast_hash": "7c75273d9cba05d139086e94c1f2cc4d",
+    "semantic_hash": "7c75273d9cba05d139086e94c1f2cc4d"
+  },
+  "services/orion-hub/tests/test_investigation_v2_request.py": {
+    "mtime": 1782955656.2807064,
+    "ast_hash": "c6be9a53530be4c2c42a4929db5924f4",
+    "semantic_hash": "c6be9a53530be4c2c42a4929db5924f4"
+  },
+  "services/orion-hub/tests/test_knowledge_forge_proxy_routes.py": {
+    "mtime": 1779317383.6905997,
+    "ast_hash": "6683c0b09f42fcf381664a108413e5c4",
+    "semantic_hash": "6683c0b09f42fcf381664a108413e5c4"
+  },
+  "services/orion-hub/tests/test_llm_route_selector.py": {
+    "mtime": 1783298706.2104504,
+    "ast_hash": "088428b692ea96e68b6a7a966300a35c",
+    "semantic_hash": "088428b692ea96e68b6a7a966300a35c"
+  },
+  "services/orion-hub/tests/test_memory_api.py": {
+    "mtime": 1783807361.8437579,
+    "ast_hash": "7552383fe3b459b2a856e8958b508d75",
+    "semantic_hash": "7552383fe3b459b2a856e8958b508d75"
+  },
+  "services/orion-hub/tests/test_memory_consolidation_draft_routes.py": {
+    "mtime": 1782190803.1013248,
+    "ast_hash": "493c6130bd92062dcf80564cbc2b6a9f",
+    "semantic_hash": "493c6130bd92062dcf80564cbc2b6a9f"
+  },
+  "services/orion-hub/tests/test_memory_crystallization_ui.py": {
+    "mtime": 1783965578.7337081,
+    "ast_hash": "07f078ef9743a1710db647233a03f6b7",
+    "semantic_hash": "07f078ef9743a1710db647233a03f6b7"
+  },
+  "services/orion-hub/tests/test_memory_graph_bridge_ui.py": {
+    "mtime": 1779083923.0911815,
+    "ast_hash": "6ecaa6083ddf996f1985604db2c31684",
+    "semantic_hash": "6ecaa6083ddf996f1985604db2c31684"
+  },
+  "services/orion-hub/tests/test_memory_graph_consolidation_draft_approve.py": {
+    "mtime": 1782190803.1013248,
+    "ast_hash": "5495b718d6451228a4ff19a4a02e48b8",
+    "semantic_hash": "5495b718d6451228a4ff19a4a02e48b8"
+  },
+  "services/orion-hub/tests/test_memory_graph_draft_form_ui.py": {
+    "mtime": 1781138973.2524207,
+    "ast_hash": "d7b612a650472270d7b34f1aa997b7de",
+    "semantic_hash": "d7b612a650472270d7b34f1aa997b7de"
+  },
+  "services/orion-hub/tests/test_memory_graph_routes.py": {
+    "mtime": 1778901838.3853948,
+    "ast_hash": "815376172690f01b6b38d75b574fdf5a",
+    "semantic_hash": "815376172690f01b6b38d75b574fdf5a"
+  },
+  "services/orion-hub/tests/test_memory_graph_structured_output.py": {
+    "mtime": 1783807362.029764,
+    "ast_hash": "22b227964bc28bfa82ca05642d395335",
+    "semantic_hash": "22b227964bc28bfa82ca05642d395335"
+  },
+  "services/orion-hub/tests/test_memory_graph_structured_output_resolve.py": {
+    "mtime": 1779753471.2832897,
+    "ast_hash": "00ab1b25e7f776aa1bfc4667239e7119",
+    "semantic_hash": "00ab1b25e7f776aa1bfc4667239e7119"
+  },
+  "services/orion-hub/tests/test_memory_graph_suggest_coalesce_ui.py": {
+    "mtime": 1779073959.9812613,
+    "ast_hash": "11f27ac5b2b4454e22b86ea07b756ad3",
+    "semantic_hash": "11f27ac5b2b4454e22b86ea07b756ad3"
+  },
+  "services/orion-hub/tests/test_memory_graph_suggest_escalation.py": {
+    "mtime": 1783807362.029764,
+    "ast_hash": "1786db039c89e93328450e489cb8bab2",
+    "semantic_hash": "1786db039c89e93328450e489cb8bab2"
+  },
+  "services/orion-hub/tests/test_memory_graph_suggest_timeout.py": {
+    "mtime": 1781730419.4947872,
+    "ast_hash": "780d4ae2bee3054269ee2de4f47037c1",
+    "semantic_hash": "780d4ae2bee3054269ee2de4f47037c1"
+  },
+  "services/orion-hub/tests/test_memory_review_ui.py": {
+    "mtime": 1781893873.1209724,
+    "ast_hash": "8b53d7e27b2965b8c876c7e2f5f6a7d4",
+    "semantic_hash": "8b53d7e27b2965b8c876c7e2f5f6a7d4"
+  },
+  "services/orion-hub/tests/test_mind_enabled_contract.py": {
+    "mtime": 1781848714.9817007,
+    "ast_hash": "52e1b7a7cf022f55a86c8d61c6ed6868",
+    "semantic_hash": "52e1b7a7cf022f55a86c8d61c6ed6868"
+  },
+  "services/orion-hub/tests/test_mind_hub_tab.py": {
+    "mtime": 1780615691.185713,
+    "ast_hash": "6bd6b3e8fe12d566ade99f84f458477d",
+    "semantic_hash": "6bd6b3e8fe12d566ade99f84f458477d"
+  },
+  "services/orion-hub/tests/test_mind_provenance_normalizer.py": {
+    "mtime": 1779318302.5471985,
+    "ast_hash": "46329def29f22d92d7550f93734b66c7",
+    "semantic_hash": "46329def29f22d92d7550f93734b66c7"
+  },
+  "services/orion-hub/tests/test_mind_routes.py": {
+    "mtime": 1780613748.712424,
+    "ast_hash": "884760e97608d59adcfd972b5692d352",
+    "semantic_hash": "884760e97608d59adcfd972b5692d352"
+  },
+  "services/orion-hub/tests/test_observability_api.py": {
+    "mtime": 1777790653.2240317,
+    "ast_hash": "28f5ef43f485dd1efc4606226b641d7b",
+    "semantic_hash": "28f5ef43f485dd1efc4606226b641d7b"
+  },
+  "services/orion-hub/tests/test_organ_signals_correlation_mode.py": {
+    "mtime": 1779332554.3348985,
+    "ast_hash": "20da1a95c95ddb2598b3d889e983f4ad",
+    "semantic_hash": "20da1a95c95ddb2598b3d889e983f4ad"
+  },
+  "services/orion-hub/tests/test_organ_signals_graph_hub_tab.py": {
+    "mtime": 1779332554.3348985,
+    "ast_hash": "01f46c3944204e23865703b238c2fad5",
+    "semantic_hash": "01f46c3944204e23865703b238c2fad5"
+  },
+  "services/orion-hub/tests/test_postgres_env_resolution.py": {
+    "mtime": 1775785276.3348587,
+    "ast_hash": "95f037c7b7b52b80af0a43bed04454aa",
+    "semantic_hash": "95f037c7b7b52b80af0a43bed04454aa"
+  },
+  "services/orion-hub/tests/test_pre_turn_appraisal_wiring.py": {
+    "mtime": 1783136738.0558803,
+    "ast_hash": "ec2e53d508ca0b224c31966c2a272d24",
+    "semantic_hash": "ec2e53d508ca0b224c31966c2a272d24"
+  },
+  "services/orion-hub/tests/test_presence_api.py": {
+    "mtime": 1779070080.271205,
+    "ast_hash": "e2cf40591b958f9babb6a137292537f0",
+    "semantic_hash": "e2cf40591b958f9babb6a137292537f0"
+  },
+  "services/orion-hub/tests/test_presence_chat_injection.py": {
+    "mtime": 1779070080.271205,
+    "ast_hash": "c127a5ad857fda93b1ca58ac12adfe9e",
+    "semantic_hash": "c127a5ad857fda93b1ca58ac12adfe9e"
+  },
+  "services/orion-hub/tests/test_presence_session.py": {
+    "mtime": 1779070080.271205,
+    "ast_hash": "0a393387c3c9bcafffc70db407020e82",
+    "semantic_hash": "0a393387c3c9bcafffc70db407020e82"
+  },
+  "services/orion-hub/tests/test_pressure_analytics_hub_tab.py": {
+    "mtime": 1777748523.333599,
+    "ast_hash": "63aa8530cc66adac5a2902a694c7d295",
+    "semantic_hash": "63aa8530cc66adac5a2902a694c7d295"
+  },
+  "services/orion-hub/tests/test_proposal_review_hub.py": {
+    "mtime": 1783499830.2075214,
+    "ast_hash": "a97ab13323ddc63552530797df1dde11",
+    "semantic_hash": "a97ab13323ddc63552530797df1dde11"
+  },
+  "services/orion-hub/tests/test_proposal_review_ui.py": {
+    "mtime": 1783499830.2075214,
+    "ast_hash": "6d881265f6006127bbb95073255d167b",
+    "semantic_hash": "6d881265f6006127bbb95073255d167b"
+  },
+  "services/orion-hub/tests/test_reasoning_trace_selection.py": {
+    "mtime": 1774810918.8258383,
+    "ast_hash": "4476d1eed478d345c7fec0285c271ba1",
+    "semantic_hash": "4476d1eed478d345c7fec0285c271ba1"
+  },
+  "services/orion-hub/tests/test_recall_canary_battle_harness.py": {
+    "mtime": 1777748523.333599,
+    "ast_hash": "01845a8a9c0096519ebe9e0a1b306974",
+    "semantic_hash": "01845a8a9c0096519ebe9e0a1b306974"
+  },
+  "services/orion-hub/tests/test_recall_canary_profile_dropdown.py": {
+    "mtime": 1777748523.333599,
+    "ast_hash": "d7467a322026454e5290b56b7cfa7a17",
+    "semantic_hash": "d7467a322026454e5290b56b7cfa7a17"
+  },
+  "services/orion-hub/tests/test_recall_canary_profile_seed.py": {
+    "mtime": 1777748523.333599,
+    "ast_hash": "4094f1362a8c38637211378c1d9fd2a5",
+    "semantic_hash": "4094f1362a8c38637211378c1d9fd2a5"
+  },
+  "services/orion-hub/tests/test_recall_strategy_profiles_runtime.py": {
+    "mtime": 1777748523.333599,
+    "ast_hash": "5ecca428bbfaeccdb55ecd8a69fe7be9",
+    "semantic_hash": "5ecca428bbfaeccdb55ecd8a69fe7be9"
+  },
+  "services/orion-hub/tests/test_recall_strategy_readiness_route.py": {
+    "mtime": 1777158591.0640275,
+    "ast_hash": "8f7a25e6e9a6a5238859dfee4f6f106d",
+    "semantic_hash": "8f7a25e6e9a6a5238859dfee4f6f106d"
+  },
+  "services/orion-hub/tests/test_repair_pressure_wiring.py": {
+    "mtime": 1783114357.2219706,
+    "ast_hash": "2b3d76d79594380c8782a24a4b3aed0c",
+    "semantic_hash": "2b3d76d79594380c8782a24a4b3aed0c"
+  },
+  "services/orion-hub/tests/test_response_feedback_api.py": {
+    "mtime": 1777149054.6984704,
+    "ast_hash": "21031054b0f9265b80ebc9ed47ef6d18",
+    "semantic_hash": "21031054b0f9265b80ebc9ed47ef6d18"
+  },
+  "services/orion-hub/tests/test_response_feedback_ui.py": {
+    "mtime": 1775629219.3249528,
+    "ast_hash": "9692225e8bb11ff8599e920e1cf6c648",
+    "semantic_hash": "9692225e8bb11ff8599e920e1cf6c648"
+  },
+  "services/orion-hub/tests/test_reverie_observability_section.py": {
+    "mtime": 1783355701.7941408,
+    "ast_hash": "9b52f8cc4737cb0a27bcba65e1116e35",
+    "semantic_hash": "9b52f8cc4737cb0a27bcba65e1116e35"
+  },
+  "services/orion-hub/tests/test_schedule_panel_browser_smoke.py": {
+    "mtime": 1774564470.051171,
+    "ast_hash": "e995e6c128fe12c7878c137b34950303",
+    "semantic_hash": "e995e6c128fe12c7878c137b34950303"
+  },
+  "services/orion-hub/tests/test_self_brain_routes.py": {
+    "mtime": 1783468068.6368666,
+    "ast_hash": "41cd3f72a19aae2df6f1da84c959dd72",
+    "semantic_hash": "41cd3f72a19aae2df6f1da84c959dd72"
+  },
+  "services/orion-hub/tests/test_self_observability_ui_panel.py": {
+    "mtime": 1783473102.646676,
+    "ast_hash": "569642e8ddacc7fffeba22b2ea67291e",
+    "semantic_hash": "569642e8ddacc7fffeba22b2ea67291e"
+  },
+  "services/orion-hub/tests/test_service_logs.py": {
+    "mtime": 1775410382.9585407,
+    "ast_hash": "8b4ebb99e49360c42697ffe65dc260ef",
+    "semantic_hash": "8b4ebb99e49360c42697ffe65dc260ef"
+  },
+  "services/orion-hub/tests/test_signals_inspect_api.py": {
+    "mtime": 1779336656.0737476,
+    "ast_hash": "60ebef5a042410ec65c88213db52e01f",
+    "semantic_hash": "60ebef5a042410ec65c88213db52e01f"
+  },
+  "services/orion-hub/tests/test_situation_request_builder.py": {
+    "mtime": 1779070080.271205,
+    "ast_hash": "f85c73968585d1c17d6fdb21f3b0f1bb",
+    "semantic_hash": "f85c73968585d1c17d6fdb21f3b0f1bb"
+  },
+  "services/orion-hub/tests/test_situation_settings_env.py": {
+    "mtime": 1777748523.333599,
+    "ast_hash": "b257b24885f2b2d8541ed274682fdfe1",
+    "semantic_hash": "b257b24885f2b2d8541ed274682fdfe1"
+  },
+  "services/orion-hub/tests/test_skill_runner_catalogue.py": {
+    "mtime": 1778901838.3853948,
+    "ast_hash": "7dae068260dedbeebaa18f93fba2baf8",
+    "semantic_hash": "7dae068260dedbeebaa18f93fba2baf8"
+  },
+  "services/orion-hub/tests/test_social_inspection_api.py": {
+    "mtime": 1774240323.6634936,
+    "ast_hash": "f2e7353aae20d5830fd1ab0e4761f4fb",
+    "semantic_hash": "f2e7353aae20d5830fd1ab0e4761f4fb"
+  },
+  "services/orion-hub/tests/test_social_room.py": {
+    "mtime": 1783107031.9789019,
+    "ast_hash": "578c0d046503352dc0205acbce006f34",
+    "semantic_hash": "578c0d046503352dc0205acbce006f34"
+  },
+  "services/orion-hub/tests/test_social_room_turn_publish.py": {
+    "mtime": 1778304582.151687,
+    "ast_hash": "c7d2f4afb149418550e13d5dba3ddf18",
+    "semantic_hash": "c7d2f4afb149418550e13d5dba3ddf18"
+  },
+  "services/orion-hub/tests/test_stop_chat_ui_smoke.py": {
+    "mtime": 1783753435.4783192,
+    "ast_hash": "72dea7e4cbf52ec7ccb7ffb4483c47aa",
+    "semantic_hash": "72dea7e4cbf52ec7ccb7ffb4483c47aa"
+  },
+  "services/orion-hub/tests/test_substrate_attention_debug_api.py": {
+    "mtime": 1779681646.026453,
+    "ast_hash": "6fec6d442d7c1e15b1354163c368240a",
+    "semantic_hash": "6fec6d442d7c1e15b1354163c368240a"
+  },
+  "services/orion-hub/tests/test_substrate_biometrics_debug_api.py": {
+    "mtime": 1779668837.6853046,
+    "ast_hash": "ba762d36a27cad3a53a3e778bbbea4a4",
+    "semantic_hash": "ba762d36a27cad3a53a3e778bbbea4a4"
+  },
+  "services/orion-hub/tests/test_substrate_consolidation_debug_api.py": {
+    "mtime": 1779749949.3244674,
+    "ast_hash": "6820083fd2c25c87d11463a1d7aa34a0",
+    "semantic_hash": "6820083fd2c25c87d11463a1d7aa34a0"
+  },
+  "services/orion-hub/tests/test_substrate_effect_cache.py": {
+    "mtime": 1779649387.8112988,
+    "ast_hash": "eeda78a1195c9553f3fb03f0ab68192e",
+    "semantic_hash": "eeda78a1195c9553f3fb03f0ab68192e"
+  },
+  "services/orion-hub/tests/test_substrate_effect_endpoint.py": {
+    "mtime": 1779649387.8112988,
+    "ast_hash": "81e19f0fe28a61c0035f73f35cf5d918",
+    "semantic_hash": "81e19f0fe28a61c0035f73f35cf5d918"
+  },
+  "services/orion-hub/tests/test_substrate_effect_pipeline.py": {
+    "mtime": 1779649387.8112988,
+    "ast_hash": "0ea3a488691484f111ff244442a46784",
+    "semantic_hash": "0ea3a488691484f111ff244442a46784"
+  },
+  "services/orion-hub/tests/test_substrate_execution_dispatch_debug_api.py": {
+    "mtime": 1784008374.2455008,
+    "ast_hash": "fcdc6c1cd20e2f533c78b65753a99e38",
+    "semantic_hash": "fcdc6c1cd20e2f533c78b65753a99e38"
+  },
+  "services/orion-hub/tests/test_substrate_feedback_debug_api.py": {
+    "mtime": 1779722671.532158,
+    "ast_hash": "4d143cdbfb588808f830e56d85e52e32",
+    "semantic_hash": "4d143cdbfb588808f830e56d85e52e32"
+  },
+  "services/orion-hub/tests/test_substrate_field_debug_api.py": {
+    "mtime": 1779671370.5200107,
+    "ast_hash": "98dac5beea2e2af5fdf43223ac71c497",
+    "semantic_hash": "98dac5beea2e2af5fdf43223ac71c497"
+  },
+  "services/orion-hub/tests/test_substrate_lattice_hub_tab.py": {
+    "mtime": 1780972924.4412649,
+    "ast_hash": "2f2fdda2cddd723ccf8f053d4489d5a8",
+    "semantic_hash": "2f2fdda2cddd723ccf8f053d4489d5a8"
+  },
+  "services/orion-hub/tests/test_substrate_lattice_routes.py": {
+    "mtime": 1783499830.2075214,
+    "ast_hash": "c97196a16f48bdfeded0d32167bb2b30",
+    "semantic_hash": "c97196a16f48bdfeded0d32167bb2b30"
+  },
+  "services/orion-hub/tests/test_substrate_mutation_manual_route_routing.py": {
+    "mtime": 1777145867.812196,
+    "ast_hash": "1c5ff50052f233a06241418172f4adba",
+    "semantic_hash": "1c5ff50052f233a06241418172f4adba"
+  },
+  "services/orion-hub/tests/test_substrate_mutation_scheduler_runtime.py": {
+    "mtime": 1783125791.0250878,
+    "ast_hash": "28da11ade6d8e7432b663a8e8730ed48",
+    "semantic_hash": "28da11ade6d8e7432b663a8e8730ed48"
+  },
+  "services/orion-hub/tests/test_substrate_observability_api.py": {
+    "mtime": 1783107031.9789019,
+    "ast_hash": "371ea293cdfefb3f13aa7d5944a58ddf",
+    "semantic_hash": "371ea293cdfefb3f13aa7d5944a58ddf"
+  },
+  "services/orion-hub/tests/test_substrate_policy_debug_api.py": {
+    "mtime": 1779689417.3442013,
+    "ast_hash": "deb00465f14eed7f3c6515cc87433f91",
+    "semantic_hash": "deb00465f14eed7f3c6515cc87433f91"
+  },
+  "services/orion-hub/tests/test_substrate_proposal_debug_api.py": {
+    "mtime": 1779687966.458823,
+    "ast_hash": "a11861462040e72fb322634a9f4194b1",
+    "semantic_hash": "a11861462040e72fb322634a9f4194b1"
+  },
+  "services/orion-hub/tests/test_substrate_review_runtime_hub_debug.py": {
+    "mtime": 1777748523.333599,
+    "ast_hash": "d4135650ef6cf77fa071bd675d393cad",
+    "semantic_hash": "d4135650ef6cf77fa071bd675d393cad"
+  },
+  "services/orion-hub/tests/test_substrate_self_state_debug_api.py": {
+    "mtime": 1783847515.5408454,
+    "ast_hash": "37698f36f634c4fd4ba61f34814907a0",
+    "semantic_hash": "37698f36f634c4fd4ba61f34814907a0"
+  },
+  "services/orion-hub/tests/test_substrate_standalone_page.py": {
+    "mtime": 1775954038.242208,
+    "ast_hash": "b03687934e9e4cf895cff523d77c6593",
+    "semantic_hash": "b03687934e9e4cf895cff523d77c6593"
+  },
+  "services/orion-hub/tests/test_thought_client.py": {
+    "mtime": 1783614403.50027,
+    "ast_hash": "78f0b087a13dca6e16766c6dd05d8d4c",
+    "semantic_hash": "78f0b087a13dca6e16766c6dd05d8d4c"
+  },
+  "services/orion-hub/tests/test_tts_client_errors.py": {
+    "mtime": 1780115804.9131448,
+    "ast_hash": "b8385476e646da5ac25a50ae2304001f",
+    "semantic_hash": "b8385476e646da5ac25a50ae2304001f"
+  },
+  "services/orion-hub/tests/test_turn_cancel.py": {
+    "mtime": 1783655498.7461991,
+    "ast_hash": "57846e1838481ba2b7bbc1d4a3d0ebc1",
+    "semantic_hash": "57846e1838481ba2b7bbc1d4a3d0ebc1"
+  },
+  "services/orion-hub/tests/test_turn_orchestrator_ws_frames.py": {
+    "mtime": 1783915348.428791,
+    "ast_hash": "60a68126a6d0f63af15b6666ee9defb0",
+    "semantic_hash": "60a68126a6d0f63af15b6666ee9defb0"
+  },
+  "services/orion-hub/tests/test_turn_stop_command.py": {
+    "mtime": 1783753435.4783192,
+    "ast_hash": "17a59ab3da7d71fd01e1d9984a27cf6f",
+    "semantic_hash": "17a59ab3da7d71fd01e1d9984a27cf6f"
+  },
+  "services/orion-hub/tests/test_unified_orion_turn_pollution_firewall.py": {
+    "mtime": 1783291410.0277019,
+    "ast_hash": "5d2a117692023ff7d292f043de07d03d",
+    "semantic_hash": "5d2a117692023ff7d292f043de07d03d"
+  },
+  "services/orion-hub/tests/test_voice_stt_errors.py": {
+    "mtime": 1780115804.9131448,
+    "ast_hash": "0a6d6805370603ffef464552df0f6ff3",
+    "semantic_hash": "0a6d6805370603ffef464552df0f6ff3"
+  },
+  "services/orion-hub/tests/test_voice_tts_hang_guards.py": {
+    "mtime": 1780115804.9131448,
+    "ast_hash": "d3b461d85e499aff486c10c804da6e0f",
+    "semantic_hash": "d3b461d85e499aff486c10c804da6e0f"
+  },
+  "services/orion-hub/tests/test_websocket_agent_claude_routing.py": {
+    "mtime": 1783219371.2280643,
+    "ast_hash": "9744d2ff3b5a110d5429cd34a819fabd",
+    "semantic_hash": "9744d2ff3b5a110d5429cd34a819fabd"
+  },
+  "services/orion-hub/tests/test_workflow_payloads.py": {
+    "mtime": 1774566954.7002692,
+    "ast_hash": "9139a2c3ff5b798e1f573bc1e4a9754a",
+    "semantic_hash": "9139a2c3ff5b798e1f573bc1e4a9754a"
+  },
+  "services/orion-hub/tests/test_workflow_request_builder.py": {
+    "mtime": 1783958824.289684,
+    "ast_hash": "1ccf8f70213aba0acfaaae81dc24470a",
+    "semantic_hash": "1ccf8f70213aba0acfaaae81dc24470a"
+  },
+  "services/orion-hub/tests/test_workflow_schedule_runtime_paths.py": {
+    "mtime": 1783110541.1429033,
+    "ast_hash": "caeb492aa672477a480c4533050a3c28",
+    "semantic_hash": "caeb492aa672477a480c4533050a3c28"
+  },
+  "services/orion-hub/tests/test_world_pulse_proxy_routes.py": {
+    "mtime": 1777748523.3345993,
+    "ast_hash": "6b7b39fca2fca53005d0102376b41fc7",
+    "semantic_hash": "6b7b39fca2fca53005d0102376b41fc7"
+  },
+  "services/orion-knowledge-forge/app/__init__.py": {
+    "mtime": 1779306072.511066,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-knowledge-forge/app/api_schemas.py": {
+    "mtime": 1779317383.6905997,
+    "ast_hash": "783700dc3d73f423330a11032eb4041a",
+    "semantic_hash": "783700dc3d73f423330a11032eb4041a"
+  },
+  "services/orion-knowledge-forge/app/ideation/__init__.py": {
+    "mtime": 1779310786.0190036,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-knowledge-forge/app/ideation/prompts.py": {
+    "mtime": 1779310786.0190036,
+    "ast_hash": "0e5ace91f369beddacd319875b29d62d",
+    "semantic_hash": "0e5ace91f369beddacd319875b29d62d"
+  },
+  "services/orion-knowledge-forge/app/ideation/runner.py": {
+    "mtime": 1779310786.0190036,
+    "ast_hash": "0dd7ee3b46eee544c367ac0493601c46",
+    "semantic_hash": "0dd7ee3b46eee544c367ac0493601c46"
+  },
+  "services/orion-knowledge-forge/app/ideation/writer.py": {
+    "mtime": 1779310786.0200036,
+    "ast_hash": "1a9e2aa6596385599454c0b810ecd37e",
+    "semantic_hash": "1a9e2aa6596385599454c0b810ecd37e"
+  },
+  "services/orion-knowledge-forge/app/main.py": {
+    "mtime": 1779310786.0200036,
+    "ast_hash": "fe678e3cc2c7e4854f5fcb37a7197ed3",
+    "semantic_hash": "fe678e3cc2c7e4854f5fcb37a7197ed3"
+  },
+  "services/orion-knowledge-forge/app/providers/__init__.py": {
+    "mtime": 1779310786.0200036,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-knowledge-forge/app/providers/anthropic_provider.py": {
+    "mtime": 1779310786.0200036,
+    "ast_hash": "5fc08c2b82f45e9cbab882e7103b3e8c",
+    "semantic_hash": "5fc08c2b82f45e9cbab882e7103b3e8c"
+  },
+  "services/orion-knowledge-forge/app/providers/base.py": {
+    "mtime": 1779310786.0200036,
+    "ast_hash": "6b1820aa9a21152fcee8512ad74e7129",
+    "semantic_hash": "6b1820aa9a21152fcee8512ad74e7129"
+  },
+  "services/orion-knowledge-forge/app/providers/local_provider.py": {
+    "mtime": 1779310786.0200036,
+    "ast_hash": "8795d2bde35f48f9efa4a93a5a46cb28",
+    "semantic_hash": "8795d2bde35f48f9efa4a93a5a46cb28"
+  },
+  "services/orion-knowledge-forge/app/routers/__init__.py": {
+    "mtime": 1779306072.511066,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-knowledge-forge/app/routers/ideation.py": {
+    "mtime": 1779310786.0200036,
+    "ast_hash": "42de0b3ea5769c29b4f0c44faeac7c0f",
+    "semantic_hash": "42de0b3ea5769c29b4f0c44faeac7c0f"
+  },
+  "services/orion-knowledge-forge/app/routers/v1.py": {
+    "mtime": 1779317383.6905997,
+    "ast_hash": "90423486fb6b6986dcb20309cce08c17",
+    "semantic_hash": "90423486fb6b6986dcb20309cce08c17"
+  },
+  "services/orion-knowledge-forge/app/service.py": {
+    "mtime": 1779317383.6905997,
+    "ast_hash": "59ea420b86494921aff4f976d11c31ee",
+    "semantic_hash": "59ea420b86494921aff4f976d11c31ee"
+  },
+  "services/orion-knowledge-forge/app/settings.py": {
+    "mtime": 1779310786.0200036,
+    "ast_hash": "35e6793768530f03f587445609557067",
+    "semantic_hash": "35e6793768530f03f587445609557067"
+  },
+  "services/orion-knowledge-forge/tests/conftest.py": {
+    "mtime": 1779310786.0210037,
+    "ast_hash": "9838527048c9890a39fb02a89c34384b",
+    "semantic_hash": "9838527048c9890a39fb02a89c34384b"
+  },
+  "services/orion-knowledge-forge/tests/test_ideation_api.py": {
+    "mtime": 1779310786.0210037,
+    "ast_hash": "fcfb06ca96a3e28d579c0e681dee9fbf",
+    "semantic_hash": "fcfb06ca96a3e28d579c0e681dee9fbf"
+  },
+  "services/orion-knowledge-forge/tests/test_knowledge_forge_api.py": {
+    "mtime": 1779306072.511066,
+    "ast_hash": "050328ba48310ca218e686520f114297",
+    "semantic_hash": "050328ba48310ca218e686520f114297"
+  },
+  "services/orion-knowledge-forge/tests/test_source_ingest_api.py": {
+    "mtime": 1779317383.6905997,
+    "ast_hash": "3fd080cd4af9118f7240744a1bfa4e90",
+    "semantic_hash": "3fd080cd4af9118f7240744a1bfa4e90"
+  },
+  "services/orion-landing-pad/app/__init__.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "0ad8a52b9bda84fbee3ce934e61c0597",
+    "semantic_hash": "0ad8a52b9bda84fbee3ce934e61c0597"
+  },
+  "services/orion-landing-pad/app/bus_resilience.py": {
+    "mtime": 1781846476.494166,
+    "ast_hash": "724c99176d9746ebd6c11ebd687ebc65",
+    "semantic_hash": "724c99176d9746ebd6c11ebd687ebc65"
+  },
+  "services/orion-landing-pad/app/main.py": {
+    "mtime": 1781853619.249282,
+    "ast_hash": "cd6650312e3eebf758b9021b7eb0bd9a",
+    "semantic_hash": "cd6650312e3eebf758b9021b7eb0bd9a"
+  },
+  "services/orion-landing-pad/app/observability/__init__.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-landing-pad/app/observability/stats.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "f71e3c2f0156fa28ddff38163abe21c4",
+    "semantic_hash": "f71e3c2f0156fa28ddff38163abe21c4"
+  },
+  "services/orion-landing-pad/app/pipeline/__init__.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-landing-pad/app/pipeline/aggregate.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "7296786dbe0b583cb82676f3e6d57758",
+    "semantic_hash": "7296786dbe0b583cb82676f3e6d57758"
+  },
+  "services/orion-landing-pad/app/pipeline/ingest.py": {
+    "mtime": 1781845427.774676,
+    "ast_hash": "6503b61388103d57f63f0e1058252b75",
+    "semantic_hash": "6503b61388103d57f63f0e1058252b75"
+  },
+  "services/orion-landing-pad/app/pipeline/normalize.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "3ab2db4ca18c721bb36f13579f446119",
+    "semantic_hash": "3ab2db4ca18c721bb36f13579f446119"
+  },
+  "services/orion-landing-pad/app/reducers/__init__.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-landing-pad/app/reducers/fallback.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "3ed7f7b8ab7cf44f4977e95c61aa4c0f",
+    "semantic_hash": "3ed7f7b8ab7cf44f4977e95c61aa4c0f"
+  },
+  "services/orion-landing-pad/app/reducers/registry.py": {
+    "mtime": 1768971372.3590236,
+    "ast_hash": "26aec5a10e7147bcbdd14e3c6c9747f3",
+    "semantic_hash": "26aec5a10e7147bcbdd14e3c6c9747f3"
+  },
+  "services/orion-landing-pad/app/reducers/stubs.py": {
+    "mtime": 1773975149.9637861,
+    "ast_hash": "4ac8d474c72b29cf576c17509f60e98f",
+    "semantic_hash": "4ac8d474c72b29cf576c17509f60e98f"
+  },
+  "services/orion-landing-pad/app/rpc/__init__.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-landing-pad/app/rpc/server.py": {
+    "mtime": 1781845427.774676,
+    "ast_hash": "22d5ab512536181ba0887e889f871c66",
+    "semantic_hash": "22d5ab512536181ba0887e889f871c66"
+  },
+  "services/orion-landing-pad/app/scoring/__init__.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-landing-pad/app/scoring/default.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "27f9750b15c259c340c40a2639cef62b",
+    "semantic_hash": "27f9750b15c259c340c40a2639cef62b"
+  },
+  "services/orion-landing-pad/app/scoring/interface.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "4c90ae83fe7b19c4258789006caad79f",
+    "semantic_hash": "4c90ae83fe7b19c4258789006caad79f"
+  },
+  "services/orion-landing-pad/app/service.py": {
+    "mtime": 1781845427.774676,
+    "ast_hash": "869169092e0142bf08d2157ef132779d",
+    "semantic_hash": "869169092e0142bf08d2157ef132779d"
+  },
+  "services/orion-landing-pad/app/settings.py": {
+    "mtime": 1773975149.9637861,
+    "ast_hash": "95869b941c5789a89ec246275b07383a",
+    "semantic_hash": "95869b941c5789a89ec246275b07383a"
+  },
+  "services/orion-landing-pad/app/store/__init__.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-landing-pad/app/store/redis_store.py": {
+    "mtime": 1769550252.5900264,
+    "ast_hash": "c5ccd927197398dea0cd6f9632edb40e",
+    "semantic_hash": "c5ccd927197398dea0cd6f9632edb40e"
+  },
+  "services/orion-landing-pad/app/tensor/__init__.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-landing-pad/app/tensor/hash_projection.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "095dbe9b8f30707d7c438f85547286a0",
+    "semantic_hash": "095dbe9b8f30707d7c438f85547286a0"
+  },
+  "services/orion-landing-pad/app/tensor/interface.py": {
+    "mtime": 1768597909.8892295,
+    "ast_hash": "b647761cf613e45c9982dd6b37192fb2",
+    "semantic_hash": "b647761cf613e45c9982dd6b37192fb2"
+  },
+  "services/orion-landing-pad/app/web/api.py": {
+    "mtime": 1779681646.026453,
+    "ast_hash": "754369f5984e4a85402c45be087e2dec",
+    "semantic_hash": "754369f5984e4a85402c45be087e2dec"
+  },
+  "services/orion-landing-pad/app/web/main.py": {
+    "mtime": 1769550252.5900264,
+    "ast_hash": "fe406ace98356c339050a1d26c23846b",
+    "semantic_hash": "fe406ace98356c339050a1d26c23846b"
+  },
+  "services/orion-landing-pad/scripts/pad_inventory_report.py": {
+    "mtime": 1769550252.5910263,
+    "ast_hash": "f284f1a878b760c0c65a60aef899f963",
+    "semantic_hash": "f284f1a878b760c0c65a60aef899f963"
+  },
+  "services/orion-landing-pad/scripts/publish_sample_envelopes.py": {
+    "mtime": 1768597909.8902295,
+    "ast_hash": "a4b400dbc3d46e2fe1f01fb360da05ef",
+    "semantic_hash": "a4b400dbc3d46e2fe1f01fb360da05ef"
+  },
+  "services/orion-landing-pad/scripts/rpc_smoke_test.py": {
+    "mtime": 1768597909.8902295,
+    "ast_hash": "a29d076b318d34e44595b9f5efc22b96",
+    "semantic_hash": "a29d076b318d34e44595b9f5efc22b96"
+  },
+  "services/orion-landing-pad/tests/test_bus_resilience.py": {
+    "mtime": 1781846476.494166,
+    "ast_hash": "6772e12b7b80028caf9e849ce3455b13",
+    "semantic_hash": "6772e12b7b80028caf9e849ce3455b13"
+  },
+  "services/orion-landing-pad/tests/test_ready.py": {
+    "mtime": 1781852203.1105344,
+    "ast_hash": "37ed171fa3bd2ea2ae8a6c1aad6f20f3",
+    "semantic_hash": "37ed171fa3bd2ea2ae8a6c1aad6f20f3"
+  },
+  "services/orion-landing-pad/tests/test_rpc_server.py": {
+    "mtime": 1773980667.713536,
+    "ast_hash": "07d60a65b2d10172c48455940ed97c0e",
+    "semantic_hash": "07d60a65b2d10172c48455940ed97c0e"
+  },
+  "services/orion-llama-cola-host/app/__init__.py": {
+    "mtime": 1768597909.8912294,
+    "ast_hash": "edcb911e199b0e0ce97c854aa2781415",
+    "semantic_hash": "edcb911e199b0e0ce97c854aa2781415"
+  },
+  "services/orion-llama-cola-host/app/main.py": {
+    "mtime": 1783136738.0568805,
+    "ast_hash": "9bbbae6463441a61b6d69926f23de3a5",
+    "semantic_hash": "9bbbae6463441a61b6d69926f23de3a5"
+  },
+  "services/orion-llama-cola-host/app/profiles.py": {
+    "mtime": 1768597909.8922296,
+    "ast_hash": "db4857453783e850530f80c37a81332b",
+    "semantic_hash": "db4857453783e850530f80c37a81332b"
+  },
+  "services/orion-llama-cola-host/app/settings.py": {
+    "mtime": 1768597909.8922296,
+    "ast_hash": "76afda84650c73a727afec081be1e53c",
+    "semantic_hash": "76afda84650c73a727afec081be1e53c"
+  },
+  "services/orion-llama-cola-host/intention.py": {
+    "mtime": 1783136738.0568805,
+    "ast_hash": "7692c9e8e5a24b6d6e3bff7b58e96ac9",
+    "semantic_hash": "7692c9e8e5a24b6d6e3bff7b58e96ac9"
+  },
+  "services/orion-llama-cola-host/tests/conftest.py": {
+    "mtime": 1783136738.0568805,
+    "ast_hash": "821874207bfd206c87833166968116d4",
+    "semantic_hash": "821874207bfd206c87833166968116d4"
+  },
+  "services/orion-llama-cola-host/tests/test_bc_mode_understand.py": {
+    "mtime": 1783136738.0578804,
+    "ast_hash": "55b77d3cbb622e28e28a42da8142a453",
+    "semantic_hash": "55b77d3cbb622e28e28a42da8142a453"
+  },
+  "services/orion-llamacpp-host/app/__init__.py": {
+    "mtime": 1767676515.656107,
+    "ast_hash": "2502d7d135252ba541d24cd4b410fa92",
+    "semantic_hash": "2502d7d135252ba541d24cd4b410fa92"
+  },
+  "services/orion-llamacpp-host/app/main.py": {
+    "mtime": 1783711326.8448281,
+    "ast_hash": "4acc0463d81e7da96870c17b557aa4f3",
+    "semantic_hash": "4acc0463d81e7da96870c17b557aa4f3"
+  },
+  "services/orion-llamacpp-host/app/profiles.py": {
+    "mtime": 1783711326.8448281,
+    "ast_hash": "91b3f1fd354dab4b12cb96095c4a1c48",
+    "semantic_hash": "91b3f1fd354dab4b12cb96095c4a1c48"
+  },
+  "services/orion-llamacpp-host/app/settings.py": {
+    "mtime": 1768940476.2267253,
+    "ast_hash": "d76bbbc019320150075479ba93db13bc",
+    "semantic_hash": "d76bbbc019320150075479ba93db13bc"
+  },
+  "services/orion-llamacpp-host/app/thinking_policy.py": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "3dc25c6bdff2a5da144cd5896cd32d70",
+    "semantic_hash": "3dc25c6bdff2a5da144cd5896cd32d70"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/json_object_only_primary.json": {
+    "mtime": 1783107031.979902,
+    "ast_hash": "86c45f5fb9ff02c5537ad5db04bbdd22",
+    "semantic_hash": "86c45f5fb9ff02c5537ad5db04bbdd22"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/json_object_schema_adversarial.json": {
+    "mtime": 1783107031.979902,
+    "ast_hash": "25f1105f07fce0eeac173d2e9f474f97",
+    "semantic_hash": "25f1105f07fce0eeac173d2e9f474f97"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/json_object_schema_primary.json": {
+    "mtime": 1783107031.979902,
+    "ast_hash": "12586ef1d559e7673e548ac1ddd6d4b2",
+    "semantic_hash": "12586ef1d559e7673e548ac1ddd6d4b2"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/json_schema_nested_schema_adversarial.json": {
+    "mtime": 1783107031.979902,
+    "ast_hash": "b4cbf41681013e77c6b240dd13349a9c",
+    "semantic_hash": "b4cbf41681013e77c6b240dd13349a9c"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/json_schema_nested_schema_primary.json": {
+    "mtime": 1783107031.979902,
+    "ast_hash": "6fec67ebf4532f3de31f29fa68a3bb29",
+    "semantic_hash": "6fec67ebf4532f3de31f29fa68a3bb29"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/json_schema_schema_adversarial.json": {
+    "mtime": 1783107031.979902,
+    "ast_hash": "512a8f8d4b1d3e5b250fefc95a751556",
+    "semantic_hash": "512a8f8d4b1d3e5b250fefc95a751556"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/json_schema_schema_primary.json": {
+    "mtime": 1783107031.979902,
+    "ast_hash": "c2862f359c41fe0f8aa9d0f5bc4307d1",
+    "semantic_hash": "c2862f359c41fe0f8aa9d0f5bc4307d1"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/no_response_format_control_primary.json": {
+    "mtime": 1783107031.979902,
+    "ast_hash": "051e32f09fa5038662333d3ffba27775",
+    "semantic_hash": "051e32f09fa5038662333d3ffba27775"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/openai_json_schema_wrapper_adversarial.json": {
+    "mtime": 1783107031.980902,
+    "ast_hash": "1d05a30a6a3bdc492c47402b70eb7b68",
+    "semantic_hash": "1d05a30a6a3bdc492c47402b70eb7b68"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/openai_json_schema_wrapper_primary.json": {
+    "mtime": 1783107031.980902,
+    "ast_hash": "033859eeee58ddc6fa7eb945435eba1c",
+    "semantic_hash": "033859eeee58ddc6fa7eb945435eba1c"
+  },
+  "services/orion-llamacpp-host/artifacts/structured-output-probe/latest/summary.json": {
+    "mtime": 1783107031.980902,
+    "ast_hash": "096e6e382bf62535f046decdff65b63a",
+    "semantic_hash": "096e6e382bf62535f046decdff65b63a"
+  },
+  "services/orion-llamacpp-host/scripts/probe_structured_output.py": {
+    "mtime": 1779166416.995654,
+    "ast_hash": "6e6cee7ff0343939d3ee90d034f651b9",
+    "semantic_hash": "6e6cee7ff0343939d3ee90d034f651b9"
+  },
+  "services/orion-llamacpp-host/scripts/validate_llamacpp_upgrade.sh": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "0686d0d9b15b46a98496ee6a11b58c11",
+    "semantic_hash": "0686d0d9b15b46a98496ee6a11b58c11"
+  },
+  "services/orion-llamacpp-host/scripts/verify_atlas_quick_llamacpp_thinking_off.sh": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "c02e1167285d5f9a29e452d22c879fb0",
+    "semantic_hash": "c02e1167285d5f9a29e452d22c879fb0"
+  },
+  "services/orion-llamacpp-host/scripts/verify_qwen3_thinking_off_live.sh": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "95b98c503b4e75768353b306b0f6ce96",
+    "semantic_hash": "95b98c503b4e75768353b306b0f6ce96"
+  },
+  "services/orion-llamacpp-host/tests/conftest.py": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "343a077b286247380ac3782deca09858",
+    "semantic_hash": "343a077b286247380ac3782deca09858"
+  },
+  "services/orion-llamacpp-host/tests/test_probe_structured_output.py": {
+    "mtime": 1779166416.996654,
+    "ast_hash": "19ef0928e9902d9a7ad03417cd0fb1cd",
+    "semantic_hash": "19ef0928e9902d9a7ad03417cd0fb1cd"
+  },
+  "services/orion-llamacpp-host/tests/test_profile_forwarding.py": {
+    "mtime": 1783711326.8448281,
+    "ast_hash": "1feec2e42a621237e004cd292171ccdf",
+    "semantic_hash": "1feec2e42a621237e004cd292171ccdf"
+  },
+  "services/orion-llamacpp-host/tests/test_thinking_policy.py": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "e48dcff02b408a4b22ad4479e22c8f0d",
+    "semantic_hash": "e48dcff02b408a4b22ad4479e22c8f0d"
+  },
+  "services/orion-llamacpp-neural-host/app/__init__.py": {
+    "mtime": 1767676515.6581068,
+    "ast_hash": "85aa91f9cbeeef4ab1ea6790bc8ef2c5",
+    "semantic_hash": "85aa91f9cbeeef4ab1ea6790bc8ef2c5"
+  },
+  "services/orion-llamacpp-neural-host/app/main.py": {
+    "mtime": 1768597909.8952293,
+    "ast_hash": "f82a77f57774a633714b2077ca442b14",
+    "semantic_hash": "f82a77f57774a633714b2077ca442b14"
+  },
+  "services/orion-llamacpp-neural-host/app/profiles.py": {
+    "mtime": 1768597909.8952293,
+    "ast_hash": "f3369309c356e247cbf113fb7a273199",
+    "semantic_hash": "f3369309c356e247cbf113fb7a273199"
+  },
+  "services/orion-llamacpp-neural-host/app/settings.py": {
+    "mtime": 1768597909.8952293,
+    "ast_hash": "a3567a826b9fb014d1aa8d276197c155",
+    "semantic_hash": "a3567a826b9fb014d1aa8d276197c155"
+  },
+  "services/orion-llm-gateway/app/__init__.py": {
+    "mtime": 1764355970.1689374,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-llm-gateway/app/anthropic_passthrough.py": {
+    "mtime": 1783196287.3208847,
+    "ast_hash": "a37e4fc64bb1e7d4a237b8b52f0adf1b",
+    "semantic_hash": "a37e4fc64bb1e7d4a237b8b52f0adf1b"
+  },
+  "services/orion-llm-gateway/app/embed_publish.py": {
+    "mtime": 1768940476.2267253,
+    "ast_hash": "ee55da5465b9d0c9fc15b9c397cdd4ec",
+    "semantic_hash": "ee55da5465b9d0c9fc15b9c397cdd4ec"
+  },
+  "services/orion-llm-gateway/app/lane_routes.py": {
+    "mtime": 1778901838.387395,
+    "ast_hash": "36a40ed6aeac93c1cf38ecbe26134c37",
+    "semantic_hash": "36a40ed6aeac93c1cf38ecbe26134c37"
+  },
+  "services/orion-llm-gateway/app/llm_backend.py": {
+    "mtime": 1783183459.1416054,
+    "ast_hash": "196715136d9c361cfcd89d07b62d2b9b",
+    "semantic_hash": "196715136d9c361cfcd89d07b62d2b9b"
+  },
+  "services/orion-llm-gateway/app/llm_uncertainty.py": {
+    "mtime": 1779649387.8122988,
+    "ast_hash": "07dca582b8dbce09191ac3678642f498",
+    "semantic_hash": "07dca582b8dbce09191ac3678642f498"
+  },
+  "services/orion-llm-gateway/app/main.py": {
+    "mtime": 1783548475.2022119,
+    "ast_hash": "fdb04ff1c2bbc00c86bf41e16ae6bb8c",
+    "semantic_hash": "fdb04ff1c2bbc00c86bf41e16ae6bb8c"
+  },
+  "services/orion-llm-gateway/app/models.py": {
+    "mtime": 1768971372.3600237,
+    "ast_hash": "6a05f900d5cbd14e35459cf342e3ede9",
+    "semantic_hash": "6a05f900d5cbd14e35459cf342e3ede9"
+  },
+  "services/orion-llm-gateway/app/openai_passthrough.py": {
+    "mtime": 1783364899.1284673,
+    "ast_hash": "7e82b8b5c5cc5e9db65232d599e5929e",
+    "semantic_hash": "7e82b8b5c5cc5e9db65232d599e5929e"
+  },
+  "services/orion-llm-gateway/app/profiles.py": {
+    "mtime": 1768597909.8982294,
+    "ast_hash": "b35cbde9e39e12e79961dc977b791307",
+    "semantic_hash": "b35cbde9e39e12e79961dc977b791307"
+  },
+  "services/orion-llm-gateway/app/route_catalog.py": {
+    "mtime": 1781494684.931417,
+    "ast_hash": "e476c71897898b633ad8ebf4dd466311",
+    "semantic_hash": "e476c71897898b633ad8ebf4dd466311"
+  },
+  "services/orion-llm-gateway/app/settings.py": {
+    "mtime": 1783548475.2022119,
+    "ast_hash": "f04044a6268c83033007e61cc059fa03",
+    "semantic_hash": "f04044a6268c83033007e61cc059fa03"
+  },
+  "services/orion-llm-gateway/app/structured_output.py": {
+    "mtime": 1779166416.996654,
+    "ast_hash": "8b8bb46ccd2fb6c86cce8532d8cd11da",
+    "semantic_hash": "8b8bb46ccd2fb6c86cce8532d8cd11da"
+  },
+  "services/orion-llm-gateway/tests/conftest.py": {
+    "mtime": 1778901838.387395,
+    "ast_hash": "b1812aa779da93ac1b5d6dabe82cea54",
+    "semantic_hash": "b1812aa779da93ac1b5d6dabe82cea54"
+  },
+  "services/orion-llm-gateway/tests/test_anthropic_passthrough.py": {
+    "mtime": 1783196287.3218846,
+    "ast_hash": "aaa8428872cfceb10ded61d1b7a32d09",
+    "semantic_hash": "aaa8428872cfceb10ded61d1b7a32d09"
+  },
+  "services/orion-llm-gateway/tests/test_concurrent_handlers.py": {
+    "mtime": 1783548475.2022119,
+    "ast_hash": "7000e7bc11faa862c4533ac0311b68bf",
+    "semantic_hash": "7000e7bc11faa862c4533ac0311b68bf"
+  },
+  "services/orion-llm-gateway/tests/test_handle_chat_meta.py": {
+    "mtime": 1779649387.8122988,
+    "ast_hash": "398a283a2f8980919645df7d6ae0c8b4",
+    "semantic_hash": "398a283a2f8980919645df7d6ae0c8b4"
+  },
+  "services/orion-llm-gateway/tests/test_lane_routes.py": {
+    "mtime": 1778901838.387395,
+    "ast_hash": "af8d28d6d67d2ea5050a5f5278c2fa69",
+    "semantic_hash": "af8d28d6d67d2ea5050a5f5278c2fa69"
+  },
+  "services/orion-llm-gateway/tests/test_llm_backend.py": {
+    "mtime": 1783107031.9819021,
+    "ast_hash": "dd693b4792b56363de535b07a637d47a",
+    "semantic_hash": "dd693b4792b56363de535b07a637d47a"
+  },
+  "services/orion-llm-gateway/tests/test_llm_chat.py": {
+    "mtime": 1768597909.8992293,
+    "ast_hash": "b2523a5c6043a65e80df8a52e9e2e983",
+    "semantic_hash": "b2523a5c6043a65e80df8a52e9e2e983"
+  },
+  "services/orion-llm-gateway/tests/test_llm_lane_run_llm_chat.py": {
+    "mtime": 1778901838.387395,
+    "ast_hash": "0d3f47a312ff98197b88d2b91bac7935",
+    "semantic_hash": "0d3f47a312ff98197b88d2b91bac7935"
+  },
+  "services/orion-llm-gateway/tests/test_llm_uncertainty.py": {
+    "mtime": 1779649387.8122988,
+    "ast_hash": "2e79026a77a6d5c6c99fdd1fd2d5ac99",
+    "semantic_hash": "2e79026a77a6d5c6c99fdd1fd2d5ac99"
+  },
+  "services/orion-llm-gateway/tests/test_openai_passthrough.py": {
+    "mtime": 1783364899.1284673,
+    "ast_hash": "b392a19920fca3375c5dcfc2e585d5ec",
+    "semantic_hash": "b392a19920fca3375c5dcfc2e585d5ec"
+  },
+  "services/orion-llm-gateway/tests/test_route_catalog.py": {
+    "mtime": 1781494684.931417,
+    "ast_hash": "ebe46f16bc9f7e51d7c74cde9dc933f8",
+    "semantic_hash": "ebe46f16bc9f7e51d7c74cde9dc933f8"
+  },
+  "services/orion-llm-gateway/tests/test_spark_candidate_publish_policy.py": {
+    "mtime": 1783110541.1429033,
+    "ast_hash": "83c147e27f47a1f54f65e2a4f9b31fae",
+    "semantic_hash": "83c147e27f47a1f54f65e2a4f9b31fae"
+  },
+  "services/orion-llm-gateway/tests/test_structured_output.py": {
+    "mtime": 1779166416.997654,
+    "ast_hash": "666e322057b8fc29ae7d028618a0800c",
+    "semantic_hash": "666e322057b8fc29ae7d028618a0800c"
+  },
+  "services/orion-memory-consolidation/app/__init__.py": {
+    "mtime": 1781653616.6593447,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-memory-consolidation/app/boundary.py": {
+    "mtime": 1782193638.8683894,
+    "ast_hash": "83ee4f756954a2c8d47bd3c2afa4d825",
+    "semantic_hash": "83ee4f756954a2c8d47bd3c2afa4d825"
+  },
+  "services/orion-memory-consolidation/app/classify.py": {
+    "mtime": 1783807362.5097792,
+    "ast_hash": "55eaf265aa9dc258024f190b6c41d164",
+    "semantic_hash": "55eaf265aa9dc258024f190b6c41d164"
+  },
+  "services/orion-memory-consolidation/app/main.py": {
+    "mtime": 1783807362.8677907,
+    "ast_hash": "f9992c3dd86f503507f56ce4d1a965f6",
+    "semantic_hash": "f9992c3dd86f503507f56ce4d1a965f6"
+  },
+  "services/orion-memory-consolidation/app/retry_degraded_classifies.py": {
+    "mtime": 1782526649.4723125,
+    "ast_hash": "0934c7aa207bd857b9b78b7f9a791141",
+    "semantic_hash": "0934c7aa207bd857b9b78b7f9a791141"
+  },
+  "services/orion-memory-consolidation/app/retry_failed_windows.py": {
+    "mtime": 1783807364.326837,
+    "ast_hash": "e63791075752097654ca3895c94b4506",
+    "semantic_hash": "e63791075752097654ca3895c94b4506"
+  },
+  "services/orion-memory-consolidation/app/settings.py": {
+    "mtime": 1783900735.492598,
+    "ast_hash": "f6ce956defe37251154417e72c86f6f6",
+    "semantic_hash": "f6ce956defe37251154417e72c86f6f6"
+  },
+  "services/orion-memory-consolidation/app/window_fetch.py": {
+    "mtime": 1781653616.6593447,
+    "ast_hash": "3f031f442fdff77a30c0a26eadc5d561",
+    "semantic_hash": "3f031f442fdff77a30c0a26eadc5d561"
+  },
+  "services/orion-memory-consolidation/app/window_state.py": {
+    "mtime": 1783614403.4762692,
+    "ast_hash": "e02ec30a96488df556993b65706ee38a",
+    "semantic_hash": "e02ec30a96488df556993b65706ee38a"
+  },
+  "services/orion-memory-consolidation/app/worker.py": {
+    "mtime": 1783807364.326837,
+    "ast_hash": "33461f835eb747858af3f217e19b252c",
+    "semantic_hash": "33461f835eb747858af3f217e19b252c"
+  },
+  "services/orion-memory-consolidation/tests/conftest.py": {
+    "mtime": 1781653616.6603448,
+    "ast_hash": "592f701246c04bcc9767ab96a8ee4015",
+    "semantic_hash": "592f701246c04bcc9767ab96a8ee4015"
+  },
+  "services/orion-memory-consolidation/tests/test_boundary.py": {
+    "mtime": 1782193645.5426018,
+    "ast_hash": "ab675859755de440b8f8f88a9020ae7b",
+    "semantic_hash": "ab675859755de440b8f8f88a9020ae7b"
+  },
+  "services/orion-memory-consolidation/tests/test_classify_route_fallback.py": {
+    "mtime": 1782526649.4723125,
+    "ast_hash": "ee1dba9b9c80a41cfad927f0a2ad188d",
+    "semantic_hash": "ee1dba9b9c80a41cfad927f0a2ad188d"
+  },
+  "services/orion-memory-consolidation/tests/test_classify_turn_change.py": {
+    "mtime": 1783807362.029764,
+    "ast_hash": "333f6ff7c34f9071a33bb3f25ed30daf",
+    "semantic_hash": "333f6ff7c34f9071a33bb3f25ed30daf"
+  },
+  "services/orion-memory-consolidation/tests/test_consolidation_gate.py": {
+    "mtime": 1783900735.492598,
+    "ast_hash": "9f8260b62617ab7fea5928da1172ee2c",
+    "semantic_hash": "9f8260b62617ab7fea5928da1172ee2c"
+  },
+  "services/orion-memory-consolidation/tests/test_crystallization_repository_import.py": {
+    "mtime": 1783405468.2237885,
+    "ast_hash": "ec60d64d18c82f26711ed82f3e88ca54",
+    "semantic_hash": "ec60d64d18c82f26711ed82f3e88ca54"
+  },
+  "services/orion-memory-consolidation/tests/test_intake_consolidation_window.py": {
+    "mtime": 1783614403.7232766,
+    "ast_hash": "4a234507575219659436774f3e48d64e",
+    "semantic_hash": "4a234507575219659436774f3e48d64e"
+  },
+  "services/orion-memory-consolidation/tests/test_retry_failed_windows.py": {
+    "mtime": 1783807362.84879,
+    "ast_hash": "bacc43cce12d78949ce02743c7b9b7aa",
+    "semantic_hash": "bacc43cce12d78949ce02743c7b9b7aa"
+  },
+  "services/orion-memory-consolidation/tests/test_window_close_turns.py": {
+    "mtime": 1783614403.7172766,
+    "ast_hash": "e6680d47d6ade3e8ae18158200415a3b",
+    "semantic_hash": "e6680d47d6ade3e8ae18158200415a3b"
+  },
+  "services/orion-memory-consolidation/tests/test_worker_classify_patch.py": {
+    "mtime": 1783402731.3003197,
+    "ast_hash": "5bde4a30be7b7bfd56918aabc865abd9",
+    "semantic_hash": "5bde4a30be7b7bfd56918aabc865abd9"
+  },
+  "services/orion-memory-consolidation/tests/test_worker_consolidation_gate.py": {
+    "mtime": 1783555541.5446742,
+    "ast_hash": "c7e50db0c62957500cd0c5b14cec41fd",
+    "semantic_hash": "c7e50db0c62957500cd0c5b14cec41fd"
+  },
+  "services/orion-memory-crystallizer/app/main.py": {
+    "mtime": 1781129793.9302504,
+    "ast_hash": "c612d4164e988ed43f4fe003d4b672a0",
+    "semantic_hash": "c612d4164e988ed43f4fe003d4b672a0"
+  },
+  "services/orion-memory-crystallizer/app/settings.py": {
+    "mtime": 1781129793.9302504,
+    "ast_hash": "cc73a4effb19ffafc0165cf36c7b927c",
+    "semantic_hash": "cc73a4effb19ffafc0165cf36c7b927c"
+  },
+  "services/orion-memory-crystallizer/app/worker.py": {
+    "mtime": 1781129793.9302504,
+    "ast_hash": "4c065bb245dc7a593232669eda7f6a65",
+    "semantic_hash": "4c065bb245dc7a593232669eda7f6a65"
+  },
+  "services/orion-mesh-guardian/app/__init__.py": {
+    "mtime": 1781846476.4951658,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-mesh-guardian/app/attention.py": {
+    "mtime": 1781893873.1209724,
+    "ast_hash": "9bbb6e17b2fb467ffccea334e3fd5227",
+    "semantic_hash": "9bbb6e17b2fb467ffccea334e3fd5227"
+  },
+  "services/orion-mesh-guardian/app/equilibrium_watch.py": {
+    "mtime": 1781846476.4951658,
+    "ast_hash": "00bc780dea20411867f1cf0f7ad5ce5d",
+    "semantic_hash": "00bc780dea20411867f1cf0f7ad5ce5d"
+  },
+  "services/orion-mesh-guardian/app/main.py": {
+    "mtime": 1781846476.4951658,
+    "ast_hash": "3b37e5ff3f47e54110382e9c7f3370a1",
+    "semantic_hash": "3b37e5ff3f47e54110382e9c7f3370a1"
+  },
+  "services/orion-mesh-guardian/app/probe.py": {
+    "mtime": 1781846476.4951658,
+    "ast_hash": "722a96997dc7b451082737511e7b23be",
+    "semantic_hash": "722a96997dc7b451082737511e7b23be"
+  },
+  "services/orion-mesh-guardian/app/remediator.py": {
+    "mtime": 1781846476.4951658,
+    "ast_hash": "3f4c72e5d4e3edd7cbda60882a51c15f",
+    "semantic_hash": "3f4c72e5d4e3edd7cbda60882a51c15f"
+  },
+  "services/orion-mesh-guardian/app/roster.py": {
+    "mtime": 1781846476.496166,
+    "ast_hash": "4dda94dfa2d67d7bcfedfc7ce548a86a",
+    "semantic_hash": "4dda94dfa2d67d7bcfedfc7ce548a86a"
+  },
+  "services/orion-mesh-guardian/app/service.py": {
+    "mtime": 1781852203.1115344,
+    "ast_hash": "620841d7f633272740e10682349c5ecd",
+    "semantic_hash": "620841d7f633272740e10682349c5ecd"
+  },
+  "services/orion-mesh-guardian/app/settings.py": {
+    "mtime": 1781852203.1115344,
+    "ast_hash": "e31543cf9b1355c44b5218e091a0a489",
+    "semantic_hash": "e31543cf9b1355c44b5218e091a0a489"
+  },
+  "services/orion-mesh-guardian/app/state_machine.py": {
+    "mtime": 1783960753.1728303,
+    "ast_hash": "8fcd58671bec365e90928a7d32098a37",
+    "semantic_hash": "8fcd58671bec365e90928a7d32098a37"
+  },
+  "services/orion-mesh-guardian/app/state_store.py": {
+    "mtime": 1781846476.496166,
+    "ast_hash": "9cbfc0775d251faca7b452159dbf9d21",
+    "semantic_hash": "9cbfc0775d251faca7b452159dbf9d21"
+  },
+  "services/orion-mesh-guardian/tests/test_attention.py": {
+    "mtime": 1781893873.1219723,
+    "ast_hash": "c7c3b96978d187ece8bc8b184befb828",
+    "semantic_hash": "c7c3b96978d187ece8bc8b184befb828"
+  },
+  "services/orion-mesh-guardian/tests/test_bus_connect_retry.py": {
+    "mtime": 1781852203.1115344,
+    "ast_hash": "c584c288fce296be0ef7ab095a0d0001",
+    "semantic_hash": "c584c288fce296be0ef7ab095a0d0001"
+  },
+  "services/orion-mesh-guardian/tests/test_compose_command.py": {
+    "mtime": 1781846476.496166,
+    "ast_hash": "08c159dd1dd43a524a60854d92b7431b",
+    "semantic_hash": "08c159dd1dd43a524a60854d92b7431b"
+  },
+  "services/orion-mesh-guardian/tests/test_equilibrium_watch.py": {
+    "mtime": 1781846476.496166,
+    "ast_hash": "23c554bf343091e96f018f359a2b834d",
+    "semantic_hash": "23c554bf343091e96f018f359a2b834d"
+  },
+  "services/orion-mesh-guardian/tests/test_health.py": {
+    "mtime": 1781846476.497166,
+    "ast_hash": "3bcd663ab75a71a89563c43229819af6",
+    "semantic_hash": "3bcd663ab75a71a89563c43229819af6"
+  },
+  "services/orion-mesh-guardian/tests/test_probe_logic.py": {
+    "mtime": 1781846476.497166,
+    "ast_hash": "ef7cdc9c24fdffa86dd8798c806f77f7",
+    "semantic_hash": "ef7cdc9c24fdffa86dd8798c806f77f7"
+  },
+  "services/orion-mesh-guardian/tests/test_remediator_exec.py": {
+    "mtime": 1781846476.497166,
+    "ast_hash": "c080208c1854d3666fc11b8c8b7eebae",
+    "semantic_hash": "c080208c1854d3666fc11b8c8b7eebae"
+  },
+  "services/orion-mesh-guardian/tests/test_roster_load.py": {
+    "mtime": 1781846476.497166,
+    "ast_hash": "f25aacf71df30b76495a9bf7e835469a",
+    "semantic_hash": "f25aacf71df30b76495a9bf7e835469a"
+  },
+  "services/orion-mesh-guardian/tests/test_service_integration.py": {
+    "mtime": 1781846476.497166,
+    "ast_hash": "9a94d5197bd0b4643880c13c47ff5eea",
+    "semantic_hash": "9a94d5197bd0b4643880c13c47ff5eea"
+  },
+  "services/orion-mesh-guardian/tests/test_state_machine.py": {
+    "mtime": 1783960753.1738305,
+    "ast_hash": "af2519a067d06fb34e8c296d90fea5d9",
+    "semantic_hash": "af2519a067d06fb34e8c296d90fea5d9"
+  },
+  "services/orion-meta-tags/app/__init__.py": {
+    "mtime": 1763232123.4118907,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-meta-tags/app/main.py": {
+    "mtime": 1774236180.453385,
+    "ast_hash": "7b8553f2e1bfcca6a6d59c46ad5ec908",
+    "semantic_hash": "7b8553f2e1bfcca6a6d59c46ad5ec908"
+  },
+  "services/orion-meta-tags/app/models.py": {
+    "mtime": 1767676515.662107,
+    "ast_hash": "1f9c1ca27a37613276806bb97c641058",
+    "semantic_hash": "1f9c1ca27a37613276806bb97c641058"
+  },
+  "services/orion-meta-tags/app/settings.py": {
+    "mtime": 1768784663.751758,
+    "ast_hash": "be33cf3138e962fea0d542a3ec5b4b2b",
+    "semantic_hash": "be33cf3138e962fea0d542a3ec5b4b2b"
+  },
+  "services/orion-mind/app/appraisal.py": {
+    "mtime": 1783614403.6792753,
+    "ast_hash": "996223a4167775729971f2ba8fe664ff",
+    "semantic_hash": "996223a4167775729971f2ba8fe664ff"
+  },
+  "services/orion-mind/app/budget.py": {
+    "mtime": 1779070080.272205,
+    "ast_hash": "df98e87156c9abd884728efb8a14b442",
+    "semantic_hash": "df98e87156c9abd884728efb8a14b442"
+  },
+  "services/orion-mind/app/engine.py": {
+    "mtime": 1783497833.3897908,
+    "ast_hash": "d8af6ec5c134f62824fa07e5fc185dfb",
+    "semantic_hash": "d8af6ec5c134f62824fa07e5fc185dfb"
+  },
+  "services/orion-mind/app/evidence.py": {
+    "mtime": 1779306072.512066,
+    "ast_hash": "0ae4a131cad1e8dd9a459d6e96f32916",
+    "semantic_hash": "0ae4a131cad1e8dd9a459d6e96f32916"
+  },
+  "services/orion-mind/app/guardrails.py": {
+    "mtime": 1779306072.512066,
+    "ast_hash": "ea0601c69784dbac2e02dd276f17e240",
+    "semantic_hash": "ea0601c69784dbac2e02dd276f17e240"
+  },
+  "services/orion-mind/app/llm_client.py": {
+    "mtime": 1779649387.8132987,
+    "ast_hash": "b64575749141ff66716b33a3201a0a79",
+    "semantic_hash": "b64575749141ff66716b33a3201a0a79"
+  },
+  "services/orion-mind/app/llm_context.py": {
+    "mtime": 1779070080.274205,
+    "ast_hash": "4b1f6c6b59ab8ebafe7fa627e5e0a541",
+    "semantic_hash": "4b1f6c6b59ab8ebafe7fa627e5e0a541"
+  },
+  "services/orion-mind/app/llm_fail_open.py": {
+    "mtime": 1779073959.9822612,
+    "ast_hash": "7f80b44bc7f072b2d931e449e44b11a4",
+    "semantic_hash": "7f80b44bc7f072b2d931e449e44b11a4"
+  },
+  "services/orion-mind/app/main.py": {
+    "mtime": 1783615212.4819124,
+    "ast_hash": "3763da7ab3e43053dda36c739ac7ee67",
+    "semantic_hash": "3763da7ab3e43053dda36c739ac7ee67"
+  },
+  "services/orion-mind/app/phase_telemetry.py": {
+    "mtime": 1779649387.8132987,
+    "ast_hash": "072822a560333bf6cb78b8f561dad4d2",
+    "semantic_hash": "072822a560333bf6cb78b8f561dad4d2"
+  },
+  "services/orion-mind/app/settings.py": {
+    "mtime": 1783615212.4819124,
+    "ast_hash": "8ade29a7f07328dd8873315db5196427",
+    "semantic_hash": "8ade29a7f07328dd8873315db5196427"
+  },
+  "services/orion-mind/app/stance_handoff.py": {
+    "mtime": 1779316847.6205964,
+    "ast_hash": "5c83fe79daa237cac2ae2abb9dfa3648",
+    "semantic_hash": "5c83fe79daa237cac2ae2abb9dfa3648"
+  },
+  "services/orion-mind/app/synthesis.py": {
+    "mtime": 1783614403.5562716,
+    "ast_hash": "3ccd2e2e07666dc97223e51107809931",
+    "semantic_hash": "3ccd2e2e07666dc97223e51107809931"
+  },
+  "services/orion-mind/app/uncertainty_metacog.py": {
+    "mtime": 1779649387.8132987,
+    "ast_hash": "74f1010047292f849337bcefef083296",
+    "semantic_hash": "74f1010047292f849337bcefef083296"
+  },
+  "services/orion-mind/scripts/verify_mind_llm_e2e.sh": {
+    "mtime": 1779316847.6205964,
+    "ast_hash": "f002174e9d3150dcbc1cb47ca8afcaee",
+    "semantic_hash": "f002174e9d3150dcbc1cb47ca8afcaee"
+  },
+  "services/orion-mind/tests/_mind_import_guard.py": {
+    "mtime": 1777790653.2250316,
+    "ast_hash": "48bfd190c561f099caf847780838310d",
+    "semantic_hash": "48bfd190c561f099caf847780838310d"
+  },
+  "services/orion-mind/tests/conftest.py": {
+    "mtime": 1777790653.2250316,
+    "ast_hash": "6f6060cf019ed93ca33bec3a56579cba",
+    "semantic_hash": "6f6060cf019ed93ca33bec3a56579cba"
+  },
+  "services/orion-mind/tests/test_engine_budget.py": {
+    "mtime": 1783615212.4829123,
+    "ast_hash": "c38befad6cf990b988c7606c99b88622",
+    "semantic_hash": "c38befad6cf990b988c7606c99b88622"
+  },
+  "services/orion-mind/tests/test_http_contract.py": {
+    "mtime": 1779070080.275205,
+    "ast_hash": "87ab0619a7a5fb9003e8bbbb66729e5a",
+    "semantic_hash": "87ab0619a7a5fb9003e8bbbb66729e5a"
+  },
+  "services/orion-mind/tests/test_llm_uncertainty_telemetry.py": {
+    "mtime": 1779649387.8132987,
+    "ast_hash": "9736ea807e93166609931c5149c5047e",
+    "semantic_hash": "9736ea807e93166609931c5149c5047e"
+  },
+  "services/orion-mind/tests/test_mind_governance.py": {
+    "mtime": 1779070080.275205,
+    "ast_hash": "d08fd66d117fdf54d2f3cc7e424e03a9",
+    "semantic_hash": "d08fd66d117fdf54d2f3cc7e424e03a9"
+  },
+  "services/orion-mind/tests/test_mind_llm_pipeline.py": {
+    "mtime": 1783614403.4802694,
+    "ast_hash": "8b136c3f6a8df07204792250f130718f",
+    "semantic_hash": "8b136c3f6a8df07204792250f130718f"
+  },
+  "services/orion-mind/tests/test_projection_starvation.py": {
+    "mtime": 1783476056.7662747,
+    "ast_hash": "c38463ae1be08c76ce5b48963eb518f9",
+    "semantic_hash": "c38463ae1be08c76ce5b48963eb518f9"
+  },
+  "services/orion-mind/tests/test_uncertainty_metacog.py": {
+    "mtime": 1779649387.8142989,
+    "ast_hash": "a0c22790559ceac60deceeb7240b4551",
+    "semantic_hash": "a0c22790559ceac60deceeb7240b4551"
+  },
+  "services/orion-notify-digest/app/__init__.py": {
+    "mtime": 1773975149.964786,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-notify-digest/app/db_models.py": {
+    "mtime": 1773975149.964786,
+    "ast_hash": "d827cbcc70eb1cbe606a2ed831abb0fc",
+    "semantic_hash": "d827cbcc70eb1cbe606a2ed831abb0fc"
+  },
+  "services/orion-notify-digest/app/digest.py": {
+    "mtime": 1779681646.027453,
+    "ast_hash": "fbaa3a955165698ecb39b7d6ee131244",
+    "semantic_hash": "fbaa3a955165698ecb39b7d6ee131244"
+  },
+  "services/orion-notify-digest/app/main.py": {
+    "mtime": 1779681646.027453,
+    "ast_hash": "0d9302d409e6b98f3d4800686d85f383",
+    "semantic_hash": "0d9302d409e6b98f3d4800686d85f383"
+  },
+  "services/orion-notify-digest/app/run_digest.py": {
+    "mtime": 1773975149.965786,
+    "ast_hash": "8a3cc4306fc36d77538c0e11bf56e77c",
+    "semantic_hash": "8a3cc4306fc36d77538c0e11bf56e77c"
+  },
+  "services/orion-notify-digest/app/settings.py": {
+    "mtime": 1779681646.027453,
+    "ast_hash": "4db19b57cec49da375ca3f226f4214e1",
+    "semantic_hash": "4db19b57cec49da375ca3f226f4214e1"
+  },
+  "services/orion-notify-digest/tests/conftest.py": {
+    "mtime": 1779681646.028453,
+    "ast_hash": "6323b6f04a11898ef77d96cefe57b295",
+    "semantic_hash": "6323b6f04a11898ef77d96cefe57b295"
+  },
+  "services/orion-notify-digest/tests/test_digest_topics.py": {
+    "mtime": 1779681646.028453,
+    "ast_hash": "48f6c8c6cf9fac170d20bc4769b7da98",
+    "semantic_hash": "48f6c8c6cf9fac170d20bc4769b7da98"
+  },
+  "services/orion-notify/app/__init__.py": {
+    "mtime": 1773975149.965786,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-notify/app/attention_escalation.py": {
+    "mtime": 1781893873.1229722,
+    "ast_hash": "42664db6650c768bba0f29067e5036ea",
+    "semantic_hash": "42664db6650c768bba0f29067e5036ea"
+  },
+  "services/orion-notify/app/email_delivery.py": {
+    "mtime": 1781893873.1229722,
+    "ast_hash": "e76c1a84b2658aeef5648a819d6007ae",
+    "semantic_hash": "e76c1a84b2658aeef5648a819d6007ae"
+  },
+  "services/orion-notify/app/main.py": {
+    "mtime": 1783960753.1748304,
+    "ast_hash": "d58473c58d8452586eac8c0d2754b752",
+    "semantic_hash": "d58473c58d8452586eac8c0d2754b752"
+  },
+  "services/orion-notify/app/policy.py": {
+    "mtime": 1773975149.965786,
+    "ast_hash": "c8a3f3d6ae108f955c1aada8181fbd7f",
+    "semantic_hash": "c8a3f3d6ae108f955c1aada8181fbd7f"
+  },
+  "services/orion-notify/app/settings.py": {
+    "mtime": 1773975149.966786,
+    "ast_hash": "807552cde89cf184eb69c9c3e5bf3995",
+    "semantic_hash": "807552cde89cf184eb69c9c3e5bf3995"
+  },
+  "services/orion-notify/tests/test_attention_ack.py": {
+    "mtime": 1783960753.1748304,
+    "ast_hash": "41f0c09f6ec437f1b33a99b2af737a25",
+    "semantic_hash": "41f0c09f6ec437f1b33a99b2af737a25"
+  },
+  "services/orion-notify/tests/test_attention_email_delivery.py": {
+    "mtime": 1781893873.1239724,
+    "ast_hash": "e77fbc30e862515d0b6ac3194e71c71e",
+    "semantic_hash": "e77fbc30e862515d0b6ac3194e71c71e"
+  },
+  "services/orion-notify/tests/test_attention_escalation_loop.py": {
+    "mtime": 1781893873.1249723,
+    "ast_hash": "2c13e2a30cb762e3c6c6b9b8b67545ff",
+    "semantic_hash": "2c13e2a30cb762e3c6c6b9b8b67545ff"
+  },
+  "services/orion-notify/tests/test_notify_email_delivery.py": {
+    "mtime": 1781893873.1249723,
+    "ast_hash": "edd1e2345ecf6052d747223c91f39727",
+    "semantic_hash": "edd1e2345ecf6052d747223c91f39727"
+  },
+  "services/orion-ollama-host/app/__init__.py": {
+    "mtime": 1767676515.663107,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-ollama-host/app/main.py": {
+    "mtime": 1767676515.663107,
+    "ast_hash": "945f7e7a027a5e08f6e79de870d42334",
+    "semantic_hash": "945f7e7a027a5e08f6e79de870d42334"
+  },
+  "services/orion-ollama-host/app/settings.py": {
+    "mtime": 1767676515.663107,
+    "ast_hash": "468e54879de0ba93446d0da615ddd0c2",
+    "semantic_hash": "468e54879de0ba93446d0da615ddd0c2"
+  },
+  "services/orion-pageindex/app/__init__.py": {
+    "mtime": 1776570604.7997217,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-pageindex/app/journal_repository.py": {
+    "mtime": 1777748523.3345993,
+    "ast_hash": "d5e437b9d1cc2943db16b1244bfbddb5",
+    "semantic_hash": "d5e437b9d1cc2943db16b1244bfbddb5"
+  },
+  "services/orion-pageindex/app/main.py": {
+    "mtime": 1777748523.3345993,
+    "ast_hash": "4f81f0f4b2211ce08509ba5e4af9b21d",
+    "semantic_hash": "4f81f0f4b2211ce08509ba5e4af9b21d"
+  },
+  "services/orion-pageindex/app/models.py": {
+    "mtime": 1777748523.3345993,
+    "ast_hash": "2ce5c9e06ddda3fd5e1765fd50afabd3",
+    "semantic_hash": "2ce5c9e06ddda3fd5e1765fd50afabd3"
+  },
+  "services/orion-pageindex/app/pageindex_cli.py": {
+    "mtime": 1777748523.3345993,
+    "ast_hash": "6e314e7fabb47d5bf705172ae8ae07a9",
+    "semantic_hash": "6e314e7fabb47d5bf705172ae8ae07a9"
+  },
+  "services/orion-pageindex/app/service.py": {
+    "mtime": 1777748523.3355992,
+    "ast_hash": "ab3afa90003329e2e60c6dcb2aea0f39",
+    "semantic_hash": "ab3afa90003329e2e60c6dcb2aea0f39"
+  },
+  "services/orion-pageindex/app/settings.py": {
+    "mtime": 1777748523.3355992,
+    "ast_hash": "21c4955f2e44f4bff53bc10afca2c539",
+    "semantic_hash": "21c4955f2e44f4bff53bc10afca2c539"
+  },
+  "services/orion-pageindex/tests/test_service.py": {
+    "mtime": 1777748523.3355992,
+    "ast_hash": "a16c5323545764ce3ca3ea1b3f9d841b",
+    "semantic_hash": "a16c5323545764ce3ca3ea1b3f9d841b"
+  },
+  "services/orion-policy-runtime/app/__init__.py": {
+    "mtime": 1779689417.3452013,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-policy-runtime/app/main.py": {
+    "mtime": 1779689417.3452013,
+    "ast_hash": "7da4dab3bd12e37237b0ca2d5895768f",
+    "semantic_hash": "7da4dab3bd12e37237b0ca2d5895768f"
+  },
+  "services/orion-policy-runtime/app/settings.py": {
+    "mtime": 1779689417.3452013,
+    "ast_hash": "224dbf17073da19d2302fe648574743a",
+    "semantic_hash": "224dbf17073da19d2302fe648574743a"
+  },
+  "services/orion-policy-runtime/app/store.py": {
+    "mtime": 1783845232.2095878,
+    "ast_hash": "e0e36f8ee55cc5ebdaf6a30fba117bfb",
+    "semantic_hash": "e0e36f8ee55cc5ebdaf6a30fba117bfb"
+  },
+  "services/orion-policy-runtime/app/worker.py": {
+    "mtime": 1783845232.2095878,
+    "ast_hash": "83a7a1add3dbed00f8d35cf777516fdc",
+    "semantic_hash": "83a7a1add3dbed00f8d35cf777516fdc"
+  },
+  "services/orion-power-guard/app/__init__.py": {
+    "mtime": 1765658977.019579,
+    "ast_hash": "23e7f2e67851c2c0a26ee7e2f5113c4a",
+    "semantic_hash": "23e7f2e67851c2c0a26ee7e2f5113c4a"
+  },
+  "services/orion-power-guard/app/main.py": {
+    "mtime": 1768597909.9012294,
+    "ast_hash": "0525a0ae319d704e00c48b5f8d35481b",
+    "semantic_hash": "0525a0ae319d704e00c48b5f8d35481b"
+  },
+  "services/orion-power-guard/app/models.py": {
+    "mtime": 1765659013.125836,
+    "ast_hash": "79104d2f3a58d406aa668b5f08e94646",
+    "semantic_hash": "79104d2f3a58d406aa668b5f08e94646"
+  },
+  "services/orion-power-guard/app/settings.py": {
+    "mtime": 1768597909.9012294,
+    "ast_hash": "be3f45f1d8be091a49689a2289f4d6be",
+    "semantic_hash": "be3f45f1d8be091a49689a2289f4d6be"
+  },
+  "services/orion-power-guard/app/ups_nis_client.py": {
+    "mtime": 1765708144.4618504,
+    "ast_hash": "04dbbbabf22c4fa262900bc9bb893398",
+    "semantic_hash": "04dbbbabf22c4fa262900bc9bb893398"
+  },
+  "services/orion-power-guard/app/ups_snmp_client.py": {
+    "mtime": 1765702593.9551573,
+    "ast_hash": "014b4a5eb84a41420548e224d3a4b574",
+    "semantic_hash": "014b4a5eb84a41420548e224d3a4b574"
+  },
+  "services/orion-proposal-runtime/app/__init__.py": {
+    "mtime": 1779687966.458823,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-proposal-runtime/app/main.py": {
+    "mtime": 1779687966.458823,
+    "ast_hash": "8b4eb32dd7977b27029250ff2090ca41",
+    "semantic_hash": "8b4eb32dd7977b27029250ff2090ca41"
+  },
+  "services/orion-proposal-runtime/app/settings.py": {
+    "mtime": 1783355701.7951407,
+    "ast_hash": "d64d56ef5e95b8176b032dc59fbd4c96",
+    "semantic_hash": "d64d56ef5e95b8176b032dc59fbd4c96"
+  },
+  "services/orion-proposal-runtime/app/store.py": {
+    "mtime": 1783845232.2095878,
+    "ast_hash": "9fddb0abb57fc8f8f2226509378fefff",
+    "semantic_hash": "9fddb0abb57fc8f8f2226509378fefff"
+  },
+  "services/orion-proposal-runtime/app/worker.py": {
+    "mtime": 1783355701.796141,
+    "ast_hash": "a88ef79001c67f915288d8cdb9ea97b8",
+    "semantic_hash": "a88ef79001c67f915288d8cdb9ea97b8"
+  },
+  "services/orion-rag/app/__init__.py": {
+    "mtime": 1763232123.4128907,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-rag/app/listener.py": {
+    "mtime": 1768597909.9012294,
+    "ast_hash": "f0f6c9c6c0c8190c706f52bc99bc8933",
+    "semantic_hash": "f0f6c9c6c0c8190c706f52bc99bc8933"
+  },
+  "services/orion-rag/app/main.py": {
+    "mtime": 1768597909.9012294,
+    "ast_hash": "deba6fadcad379c2c31f925d7922ac19",
+    "semantic_hash": "deba6fadcad379c2c31f925d7922ac19"
+  },
+  "services/orion-rag/app/processor.py": {
+    "mtime": 1768597909.9012294,
+    "ast_hash": "f15b6cff792b7778180c685cd775e455",
+    "semantic_hash": "f15b6cff792b7778180c685cd775e455"
+  },
+  "services/orion-rag/app/settings.py": {
+    "mtime": 1768597909.9022293,
+    "ast_hash": "daf21736b0de601f1c94230d3e03cee0",
+    "semantic_hash": "daf21736b0de601f1c94230d3e03cee0"
+  },
+  "services/orion-rag/app/vector_store.py": {
+    "mtime": 1763272288.9202633,
+    "ast_hash": "2a07e5b2eed494c5d4090ae303d4b0fe",
+    "semantic_hash": "2a07e5b2eed494c5d4090ae303d4b0fe"
+  },
+  "services/orion-rag/scripts/run_server.sh": {
+    "mtime": 1763232123.4128907,
+    "ast_hash": "2473ecc32db7021474f8c29decb5f84e",
+    "semantic_hash": "2473ecc32db7021474f8c29decb5f84e"
+  },
+  "services/orion-rdf-store/scripts/fuseki_delete_stale_copy.sh": {
+    "mtime": 1781151669.697976,
+    "ast_hash": "eb29628c8eecab1796621cf21e8528c8",
+    "semantic_hash": "eb29628c8eecab1796621cf21e8528c8"
+  },
+  "services/orion-rdf-store/scripts/fuseki_disk_guard.sh": {
+    "mtime": 1781151568.1643114,
+    "ast_hash": "cf0f0d67ebcb584b5217fc59f750b6b0",
+    "semantic_hash": "cf0f0d67ebcb584b5217fc59f750b6b0"
+  },
+  "services/orion-rdf-store/scripts/fuseki_health_probe.sh": {
+    "mtime": 1781845427.775676,
+    "ast_hash": "10ea1a176ef508b7862fe80c65b54741",
+    "semantic_hash": "10ea1a176ef508b7862fe80c65b54741"
+  },
+  "services/orion-rdf-store/scripts/fuseki_prune_retention.sh": {
+    "mtime": 1781152122.2004871,
+    "ast_hash": "30a0995aa88780c4618d44ab3b2948cc",
+    "semantic_hash": "30a0995aa88780c4618d44ab3b2948cc"
+  },
+  "services/orion-rdf-store/scripts/fuseki_recover.sh": {
+    "mtime": 1781748329.8800387,
+    "ast_hash": "d73c1a35e259029059026725d87561ea",
+    "semantic_hash": "d73c1a35e259029059026725d87561ea"
+  },
+  "services/orion-rdf-store/scripts/fuseki_restore_active_mount.sh": {
+    "mtime": 1781151672.9339652,
+    "ast_hash": "89be25e06b3921aad6c619d437166e20",
+    "semantic_hash": "89be25e06b3921aad6c619d437166e20"
+  },
+  "services/orion-rdf-store/scripts/fuseki_storage_status.sh": {
+    "mtime": 1781151667.7639823,
+    "ast_hash": "954c6feb6e1e85766acc27c234e37f27",
+    "semantic_hash": "954c6feb6e1e85766acc27c234e37f27"
+  },
+  "services/orion-rdf-store/scripts/fuseki_tdb_compact.sh": {
+    "mtime": 1781845427.775676,
+    "ast_hash": "c4431007c6601bb6b4fbdfea6ae11bc1",
+    "semantic_hash": "c4431007c6601bb6b4fbdfea6ae11bc1"
+  },
+  "services/orion-rdf-writer/app/__init__.py": {
+    "mtime": 1774236180.453385,
+    "ast_hash": "cde92094b03be24377600423ba3c822b",
+    "semantic_hash": "cde92094b03be24377600423ba3c822b"
+  },
+  "services/orion-rdf-writer/app/autonomy.py": {
+    "mtime": 1779328788.9707866,
+    "ast_hash": "4ad5466a081f665b765387f2c3f5de09",
+    "semantic_hash": "4ad5466a081f665b765387f2c3f5de09"
+  },
+  "services/orion-rdf-writer/app/main.py": {
+    "mtime": 1781151985.219937,
+    "ast_hash": "117304320fddf4caa6e95a0ae1e41cce",
+    "semantic_hash": "117304320fddf4caa6e95a0ae1e41cce"
+  },
+  "services/orion-rdf-writer/app/provenance.py": {
+    "mtime": 1763232123.4128907,
+    "ast_hash": "cf7cb17c1d44eb1b6933eef8ae85d344",
+    "semantic_hash": "cf7cb17c1d44eb1b6933eef8ae85d344"
+  },
+  "services/orion-rdf-writer/app/rdf_builder.py": {
+    "mtime": 1782185238.9407067,
+    "ast_hash": "21530151f0c1a4f7810ffa568178d4e4",
+    "semantic_hash": "21530151f0c1a4f7810ffa568178d4e4"
+  },
+  "services/orion-rdf-writer/app/rdf_retention.py": {
+    "mtime": 1781151977.9849608,
+    "ast_hash": "6a36221db373f3b1aedbab713f45e029",
+    "semantic_hash": "6a36221db373f3b1aedbab713f45e029"
+  },
+  "services/orion-rdf-writer/app/rdf_store.py": {
+    "mtime": 1780972924.4422648,
+    "ast_hash": "a05bce689809c29674608eafd828ce9c",
+    "semantic_hash": "a05bce689809c29674608eafd828ce9c"
+  },
+  "services/orion-rdf-writer/app/router.py": {
+    "mtime": 1778901838.3883948,
+    "ast_hash": "85e190a852a198eeb8042e4ab0cb9cd5",
+    "semantic_hash": "85e190a852a198eeb8042e4ab0cb9cd5"
+  },
+  "services/orion-rdf-writer/app/service.py": {
+    "mtime": 1778901838.3883948,
+    "ast_hash": "cd0a46a91d8f411dea5df7946b7571f5",
+    "semantic_hash": "cd0a46a91d8f411dea5df7946b7571f5"
+  },
+  "services/orion-rdf-writer/app/settings.py": {
+    "mtime": 1781152352.4667318,
+    "ast_hash": "696a97948ce91a89327ded88634b7ad1",
+    "semantic_hash": "696a97948ce91a89327ded88634b7ad1"
+  },
+  "services/orion-rdf-writer/app/utils.py": {
+    "mtime": 1763232123.4138906,
+    "ast_hash": "8cf69de890b4fa11d71f0b9bf9e48b8c",
+    "semantic_hash": "8cf69de890b4fa11d71f0b9bf9e48b8c"
+  },
+  "services/orion-rdf-writer/tests/test_autonomy_materialization.py": {
+    "mtime": 1779328788.9707866,
+    "ast_hash": "c02b054066d63cf77b0e9791b710d891",
+    "semantic_hash": "c02b054066d63cf77b0e9791b710d891"
+  },
+  "services/orion-rdf-writer/tests/test_rdf_store.py": {
+    "mtime": 1778901838.3883948,
+    "ast_hash": "e59c965c8976429acfdc92498b7d06ad",
+    "semantic_hash": "e59c965c8976429acfdc92498b7d06ad"
+  },
+  "services/orion-rdf-writer/tests/test_rdf_write_queue.py": {
+    "mtime": 1778901838.3883948,
+    "ast_hash": "e6ee600100a3a44e7e18a9954a75fca3",
+    "semantic_hash": "e6ee600100a3a44e7e18a9954a75fca3"
+  },
+  "services/orion-rdf-writer/tests/test_service_rdf_store_integration.py": {
+    "mtime": 1778901838.3883948,
+    "ast_hash": "b81d6ec9cec4894d7df65ddc5b0965d1",
+    "semantic_hash": "b81d6ec9cec4894d7df65ddc5b0965d1"
+  },
+  "services/orion-rdf-writer/tests/test_world_pulse_graph_gates.py": {
+    "mtime": 1777748523.3355992,
+    "ast_hash": "f2284250ab6491cd73065ac162b58848",
+    "semantic_hash": "f2284250ab6491cd73065ac162b58848"
+  },
+  "services/orion-recall/app/__init__.py": {
+    "mtime": 1764369444.635212,
+    "ast_hash": "2c3cee016b7abd2fcff3ffdde0647246",
+    "semantic_hash": "2c3cee016b7abd2fcff3ffdde0647246"
+  },
+  "services/orion-recall/app/cards_adapter.py": {
+    "mtime": 1780779151.183656,
+    "ast_hash": "00144f46769bb3eb114bcbe4ffd6e324",
+    "semantic_hash": "00144f46769bb3eb114bcbe4ffd6e324"
+  },
+  "services/orion-recall/app/cards_embedding.py": {
+    "mtime": 1780779151.183656,
+    "ast_hash": "c3e51e37775451cfbd9e09c676ad1f5c",
+    "semantic_hash": "c3e51e37775451cfbd9e09c676ad1f5c"
+  },
+  "services/orion-recall/app/collectors.py": {
+    "mtime": 1780115804.9141448,
+    "ast_hash": "010b6a02586f92c71cb6411e3ab35508",
+    "semantic_hash": "010b6a02586f92c71cb6411e3ab35508"
+  },
+  "services/orion-recall/app/collectors/__init__.py": {
+    "mtime": 1783398623.0121567,
+    "ast_hash": "bc2e7e3e972d9385738c79ef0e04b57f",
+    "semantic_hash": "bc2e7e3e972d9385738c79ef0e04b57f"
+  },
+  "services/orion-recall/app/collectors/active_packet.py": {
+    "mtime": 1783960753.1748304,
+    "ast_hash": "f1dcca97ff96ca33e4c5d321a126f04e",
+    "semantic_hash": "f1dcca97ff96ca33e4c5d321a126f04e"
+  },
+  "services/orion-recall/app/fusion.py": {
+    "mtime": 1783398623.0121567,
+    "ast_hash": "29303d174e0f048cbc08be0c8ff64803",
+    "semantic_hash": "29303d174e0f048cbc08be0c8ff64803"
+  },
+  "services/orion-recall/app/http_models.py": {
+    "mtime": 1777155570.9854944,
+    "ast_hash": "6b6006ad96834c1bc7ab3105c60d25c7",
+    "semantic_hash": "6b6006ad96834c1bc7ab3105c60d25c7"
+  },
+  "services/orion-recall/app/intent.py": {
+    "mtime": 1777748523.3365993,
+    "ast_hash": "4630aab7c456be9388e6aa7272837b3b",
+    "semantic_hash": "4630aab7c456be9388e6aa7272837b3b"
+  },
+  "services/orion-recall/app/main.py": {
+    "mtime": 1781584864.5185819,
+    "ast_hash": "417d63930256ee01a1c08f4b76a532ee",
+    "semantic_hash": "417d63930256ee01a1c08f4b76a532ee"
+  },
+  "services/orion-recall/app/memory_graph_sparql.py": {
+    "mtime": 1777758592.2242446,
+    "ast_hash": "e2d4d8f9b62ad1488a7f13b68e3c400e",
+    "semantic_hash": "e2d4d8f9b62ad1488a7f13b68e3c400e"
+  },
+  "services/orion-recall/app/pcr_collectors.py": {
+    "mtime": 1783398623.0131567,
+    "ast_hash": "e6d0a73244e8c3b37221a48ff380703d",
+    "semantic_hash": "e6d0a73244e8c3b37221a48ff380703d"
+  },
+  "services/orion-recall/app/pipeline.py": {
+    "mtime": 1780115804.9141448,
+    "ast_hash": "639dabf8512d916865aad9e53b90dbe1",
+    "semantic_hash": "639dabf8512d916865aad9e53b90dbe1"
+  },
+  "services/orion-recall/app/postprocessing.py": {
+    "mtime": 1764571295.1738224,
+    "ast_hash": "d85d3bbace1dee3b83a9e8df468cb8c8",
+    "semantic_hash": "d85d3bbace1dee3b83a9e8df468cb8c8"
+  },
+  "services/orion-recall/app/profiles.py": {
+    "mtime": 1780119290.9092214,
+    "ast_hash": "66b339ce6a8bcd10c4003976f026b3c9",
+    "semantic_hash": "66b339ce6a8bcd10c4003976f026b3c9"
+  },
+  "services/orion-recall/app/recall_eval.py": {
+    "mtime": 1777157129.3808827,
+    "ast_hash": "cc20555c756433e5211cd314befb9a27",
+    "semantic_hash": "cc20555c756433e5211cd314befb9a27"
+  },
+  "services/orion-recall/app/recall_eval_corpus.json": {
+    "mtime": 1777155539.3674371,
+    "ast_hash": "3c4d2b285866a3a56ab03ea43569e03b",
+    "semantic_hash": "3c4d2b285866a3a56ab03ea43569e03b"
+  },
+  "services/orion-recall/app/recall_v2.py": {
+    "mtime": 1783497833.9348083,
+    "ast_hash": "b5ba3a68c7ad2cbd6459cafad31ce781",
+    "semantic_hash": "b5ba3a68c7ad2cbd6459cafad31ce781"
+  },
+  "services/orion-recall/app/render.py": {
+    "mtime": 1781405728.501089,
+    "ast_hash": "f2a7c9d2f5864b31953657879fcf2209",
+    "semantic_hash": "f2a7c9d2f5864b31953657879fcf2209"
+  },
+  "services/orion-recall/app/scoring.py": {
+    "mtime": 1780115804.9141448,
+    "ast_hash": "145a7239641bec35d3956094a1066704",
+    "semantic_hash": "145a7239641bec35d3956094a1066704"
+  },
+  "services/orion-recall/app/service.py": {
+    "mtime": 1769550252.5940263,
+    "ast_hash": "227dfe728ee62db4b3f6b20b1b48f2b7",
+    "semantic_hash": "227dfe728ee62db4b3f6b20b1b48f2b7"
+  },
+  "services/orion-recall/app/settings.py": {
+    "mtime": 1783398623.0131567,
+    "ast_hash": "cba90b994a11778eb6730fdacd5d0a56",
+    "semantic_hash": "cba90b994a11778eb6730fdacd5d0a56"
+  },
+  "services/orion-recall/app/snippet_dedupe.py": {
+    "mtime": 1778901838.389395,
+    "ast_hash": "9571be29cffaa5f31efbc517da31cab0",
+    "semantic_hash": "9571be29cffaa5f31efbc517da31cab0"
+  },
+  "services/orion-recall/app/source_policy.py": {
+    "mtime": 1780115804.9141448,
+    "ast_hash": "a43131bed7f151a0112f541817d37b9b",
+    "semantic_hash": "a43131bed7f151a0112f541817d37b9b"
+  },
+  "services/orion-recall/app/sql_chat.py": {
+    "mtime": 1783225697.9833586,
+    "ast_hash": "7d958b739a2de9aeb9b8c0eaf75d28a7",
+    "semantic_hash": "7d958b739a2de9aeb9b8c0eaf75d28a7"
+  },
+  "services/orion-recall/app/sql_timeline.py": {
+    "mtime": 1783497833.4827936,
+    "ast_hash": "3cfc81f25f9e33200e71a3825e3a26ff",
+    "semantic_hash": "3cfc81f25f9e33200e71a3825e3a26ff"
+  },
+  "services/orion-recall/app/storage/__init__.py": {
+    "mtime": 1764560734.4727876,
+    "ast_hash": "335bcc8a97758fe978b6c4edb14da82a",
+    "semantic_hash": "335bcc8a97758fe978b6c4edb14da82a"
+  },
+  "services/orion-recall/app/storage/graph_compression_adapter.py": {
+    "mtime": 1780972924.4422648,
+    "ast_hash": "74c4e558cd2a3e06bba1e787b34c2bef",
+    "semantic_hash": "74c4e558cd2a3e06bba1e787b34c2bef"
+  },
+  "services/orion-recall/app/storage/pg.py": {
+    "mtime": 1764560700.035267,
+    "ast_hash": "2c88ec6c776d5464ee6c4cba91999954",
+    "semantic_hash": "2c88ec6c776d5464ee6c4cba91999954"
+  },
+  "services/orion-recall/app/storage/rdf_adapter.py": {
+    "mtime": 1783986358.1066566,
+    "ast_hash": "9c463479971187c626c87d88bf785c47",
+    "semantic_hash": "9c463479971187c626c87d88bf785c47"
+  },
+  "services/orion-recall/app/storage/sql_adapter.py": {
+    "mtime": 1768597909.9022293,
+    "ast_hash": "ab0fa60d8f68aa17fd5b88bf50f2fc5a",
+    "semantic_hash": "ab0fa60d8f68aa17fd5b88bf50f2fc5a"
+  },
+  "services/orion-recall/app/storage/types.py": {
+    "mtime": 1764560717.3990254,
+    "ast_hash": "822303f9e949d62369f0b7d3ccd67c0c",
+    "semantic_hash": "822303f9e949d62369f0b7d3ccd67c0c"
+  },
+  "services/orion-recall/app/types.py": {
+    "mtime": 1767676515.668107,
+    "ast_hash": "ace1cd20390b9d9606344e792bca8d04",
+    "semantic_hash": "ace1cd20390b9d9606344e792bca8d04"
+  },
+  "services/orion-recall/app/worker.py": {
+    "mtime": 1783555541.5456743,
+    "ast_hash": "730475f740b142af10924130f46c3cc4",
+    "semantic_hash": "730475f740b142af10924130f46c3cc4"
+  },
+  "services/orion-recall/scripts/distill_memory_cards.py": {
+    "mtime": 1777748523.3375993,
+    "ast_hash": "24f4bd18a2096bd9adcd25eca79d7c24",
+    "semantic_hash": "24f4bd18a2096bd9adcd25eca79d7c24"
+  },
+  "services/orion-recall/sql/memory_cards.sql": {
+    "mtime": 1777753742.9597354,
+    "ast_hash": "63f8a19ec58ed42e34676ccb1299db54",
+    "semantic_hash": "63f8a19ec58ed42e34676ccb1299db54"
+  },
+  "services/orion-recall/sql/recall_telemetry.sql": {
+    "mtime": 1768597909.9032292,
+    "ast_hash": "02c3cc7781c23d36739963eed4b0850d",
+    "semantic_hash": "02c3cc7781c23d36739963eed4b0850d"
+  },
+  "services/orion-recall/tests/conftest.py": {
+    "mtime": 1774748231.6571257,
+    "ast_hash": "266e85a837a6e0b1bb65c2192bc381af",
+    "semantic_hash": "266e85a837a6e0b1bb65c2192bc381af"
+  },
+  "services/orion-recall/tests/test_active_packet_activation_floor.py": {
+    "mtime": 1783555541.5456743,
+    "ast_hash": "467b531061c0722e39e7e4a315d793d4",
+    "semantic_hash": "467b531061c0722e39e7e4a315d793d4"
+  },
+  "services/orion-recall/tests/test_active_packet_retrieval_event_logging.py": {
+    "mtime": 1783960753.1748304,
+    "ast_hash": "a652f598bacfc8f7f62d8a936f2b6d9d",
+    "semantic_hash": "a652f598bacfc8f7f62d8a936f2b6d9d"
+  },
+  "services/orion-recall/tests/test_brain_recall_profile.py": {
+    "mtime": 1780120684.8107352,
+    "ast_hash": "4dac33ca64e08ad18077b485a4f5beb2",
+    "semantic_hash": "4dac33ca64e08ad18077b485a4f5beb2"
+  },
+  "services/orion-recall/tests/test_cards_adapter_active_only.py": {
+    "mtime": 1780779151.183656,
+    "ast_hash": "43259f901a9cc1c7b8ae313e20a613a7",
+    "semantic_hash": "43259f901a9cc1c7b8ae313e20a613a7"
+  },
+  "services/orion-recall/tests/test_cards_embedding.py": {
+    "mtime": 1780779151.183656,
+    "ast_hash": "4a4ac1766e05e45d3e93872a91acb78f",
+    "semantic_hash": "4a4ac1766e05e45d3e93872a91acb78f"
+  },
+  "services/orion-recall/tests/test_chat_general_recall_salience.py": {
+    "mtime": 1783398623.0131567,
+    "ast_hash": "54a7d46cd56859906140c6c7a0227779",
+    "semantic_hash": "54a7d46cd56859906140c6c7a0227779"
+  },
+  "services/orion-recall/tests/test_fusion_profile_filters.py": {
+    "mtime": 1777748523.3375993,
+    "ast_hash": "e9867e8dc6c5a6a559a3093af12a3210",
+    "semantic_hash": "e9867e8dc6c5a6a559a3093af12a3210"
+  },
+  "services/orion-recall/tests/test_fusion_transcript_dedupe.py": {
+    "mtime": 1777872517.2270768,
+    "ast_hash": "fbde346aff34b5c2bab19e3e66120fa1",
+    "semantic_hash": "fbde346aff34b5c2bab19e3e66120fa1"
+  },
+  "services/orion-recall/tests/test_graph_compression_adapter.py": {
+    "mtime": 1780972924.4432647,
+    "ast_hash": "4d7f2e78d63ecb9182cbf30703800451",
+    "semantic_hash": "4d7f2e78d63ecb9182cbf30703800451"
+  },
+  "services/orion-recall/tests/test_intent_routing.py": {
+    "mtime": 1777748523.3375993,
+    "ast_hash": "a30d027e59ef54744a3418a66f90b626",
+    "semantic_hash": "a30d027e59ef54744a3418a66f90b626"
+  },
+  "services/orion-recall/tests/test_pcr_belief.py": {
+    "mtime": 1783398623.0141568,
+    "ast_hash": "ac2ab76bc76bd953ab38f93c253b198b",
+    "semantic_hash": "ac2ab76bc76bd953ab38f93c253b198b"
+  },
+  "services/orion-recall/tests/test_pcr_continuity.py": {
+    "mtime": 1783555541.5456743,
+    "ast_hash": "e18d07015096550e5ea9e11de9c9da3a",
+    "semantic_hash": "e18d07015096550e5ea9e11de9c9da3a"
+  },
+  "services/orion-recall/tests/test_process_recall_active_turn_exclusion.py": {
+    "mtime": 1774748231.6581259,
+    "ast_hash": "90a182ac2958189e0ab66754461fcf98",
+    "semantic_hash": "90a182ac2958189e0ab66754461fcf98"
+  },
+  "services/orion-recall/tests/test_profile_runtime_knobs.py": {
+    "mtime": 1780115804.915145,
+    "ast_hash": "50c42de1f846a6ddb03c225a2aec265a",
+    "semantic_hash": "50c42de1f846a6ddb03c225a2aec265a"
+  },
+  "services/orion-recall/tests/test_query_backends_compression.py": {
+    "mtime": 1780972924.4432647,
+    "ast_hash": "9c112194b61886c7f2e3c37e31a1859b",
+    "semantic_hash": "9c112194b61886c7f2e3c37e31a1859b"
+  },
+  "services/orion-recall/tests/test_rdf_adapter_graph_iri.py": {
+    "mtime": 1780991890.178284,
+    "ast_hash": "89ed19219f43a16e0fe749d9e854e9d0",
+    "semantic_hash": "89ed19219f43a16e0fe749d9e854e9d0"
+  },
+  "services/orion-recall/tests/test_rdf_chatturn_windowing.py": {
+    "mtime": 1783225697.9843585,
+    "ast_hash": "ed04916ae298ae96a8da3696635379f8",
+    "semantic_hash": "ed04916ae298ae96a8da3696635379f8"
+  },
+  "services/orion-recall/tests/test_rdf_recency_scoring.py": {
+    "mtime": 1783986358.1066566,
+    "ast_hash": "f43a2622d530db01c3f58fd28f85ca43",
+    "semantic_hash": "f43a2622d530db01c3f58fd28f85ca43"
+  },
+  "services/orion-recall/tests/test_recall_policy_harness.py": {
+    "mtime": 1775626160.9069614,
+    "ast_hash": "9a9d17ca28c55fd81019df32bd6b754b",
+    "semantic_hash": "9a9d17ca28c55fd81019df32bd6b754b"
+  },
+  "services/orion-recall/tests/test_recall_profiles_compression.py": {
+    "mtime": 1780972924.4432647,
+    "ast_hash": "467a0d6f9813d4ffdefc2f511f902469",
+    "semantic_hash": "467a0d6f9813d4ffdefc2f511f902469"
+  },
+  "services/orion-recall/tests/test_recall_v2_shadow.py": {
+    "mtime": 1780115804.9161448,
+    "ast_hash": "f2385bc78dc97b5f04da0b972e36de5b",
+    "semantic_hash": "f2385bc78dc97b5f04da0b972e36de5b"
+  },
+  "services/orion-recall/tests/test_recall_vector_amputation.py": {
+    "mtime": 1780115804.9161448,
+    "ast_hash": "49b42c310dfbb16eea5f0af4c884d369",
+    "semantic_hash": "49b42c310dfbb16eea5f0af4c884d369"
+  },
+  "services/orion-recall/tests/test_render_budget_metacog.py": {
+    "mtime": 1781405728.501089,
+    "ast_hash": "e8b3b2398b49cfd3ae52409adcf27efd",
+    "semantic_hash": "e8b3b2398b49cfd3ae52409adcf27efd"
+  },
+  "services/orion-recall/tests/test_render_orion_dedupe.py": {
+    "mtime": 1778901838.389395,
+    "ast_hash": "217fcb9d8b5aa04316099e413fe2eca8",
+    "semantic_hash": "217fcb9d8b5aa04316099e413fe2eca8"
+  },
+  "services/orion-recall/tests/test_snippet_dedupe.py": {
+    "mtime": 1778901838.389395,
+    "ast_hash": "007fb0be1cfd82a3a76bc7def2f99d17",
+    "semantic_hash": "007fb0be1cfd82a3a76bc7def2f99d17"
+  },
+  "services/orion-recall/tests/test_source_policy_vector.py": {
+    "mtime": 1780115804.9161448,
+    "ast_hash": "f20754ddafd82b4332aa5fc436735ea0",
+    "semantic_hash": "f20754ddafd82b4332aa5fc436735ea0"
+  },
+  "services/orion-recall/tests/test_sql_anchor_since_minutes.py": {
+    "mtime": 1783365495.734666,
+    "ast_hash": "901605d7416a2795254c85879edb4528",
+    "semantic_hash": "901605d7416a2795254c85879edb4528"
+  },
+  "services/orion-recall/tests/test_sql_chat_self_hit_suppression.py": {
+    "mtime": 1774748231.6581259,
+    "ast_hash": "317bf842a7e56385e9b439d89f69d290",
+    "semantic_hash": "317bf842a7e56385e9b439d89f69d290"
+  },
+  "services/orion-recall/tests/test_sql_chat_windowing.py": {
+    "mtime": 1783365495.734666,
+    "ast_hash": "8c1ac861c17ce86a49ab8577057c28b3",
+    "semantic_hash": "8c1ac861c17ce86a49ab8577057c28b3"
+  },
+  "services/orion-recall/tests/test_sql_exact_windowing.py": {
+    "mtime": 1783365495.7356663,
+    "ast_hash": "5449fcb25a5ae7e7fb940c1ce057abd5",
+    "semantic_hash": "5449fcb25a5ae7e7fb940c1ce057abd5"
+  },
+  "services/orion-recall/tests/test_sql_timeline_self_hit_suppression.py": {
+    "mtime": 1774748231.6581259,
+    "ast_hash": "010a07bf3dfe35ce36d01874cd753729",
+    "semantic_hash": "010a07bf3dfe35ce36d01874cd753729"
+  },
+  "services/orion-security-watcher/app/bus_worker.py": {
+    "mtime": 1768597909.9032292,
+    "ast_hash": "0a2eaf6ff3e9c030f148bd90010642c5",
+    "semantic_hash": "0a2eaf6ff3e9c030f148bd90010642c5"
+  },
+  "services/orion-security-watcher/app/context.py": {
+    "mtime": 1767676515.6701071,
+    "ast_hash": "396ba5b859fce6beb491b607355c578e",
+    "semantic_hash": "396ba5b859fce6beb491b607355c578e"
+  },
+  "services/orion-security-watcher/app/guard.py": {
+    "mtime": 1767676515.6701071,
+    "ast_hash": "327a94c56d6962168853a78b53dc1f6f",
+    "semantic_hash": "327a94c56d6962168853a78b53dc1f6f"
+  },
+  "services/orion-security-watcher/app/main.py": {
+    "mtime": 1767676515.6701071,
+    "ast_hash": "6f0cd4388a432e088c6c86490c014152",
+    "semantic_hash": "6f0cd4388a432e088c6c86490c014152"
+  },
+  "services/orion-security-watcher/app/models.py": {
+    "mtime": 1766257761.7428114,
+    "ast_hash": "219bbf68625f34447650eb4258bfccb8",
+    "semantic_hash": "219bbf68625f34447650eb4258bfccb8"
+  },
+  "services/orion-security-watcher/app/notifications.py": {
+    "mtime": 1773975149.967786,
+    "ast_hash": "59f3b7e649816e2751d5b3a82cb7a1b2",
+    "semantic_hash": "59f3b7e649816e2751d5b3a82cb7a1b2"
+  },
+  "services/orion-security-watcher/app/routers/__init__.py": {
+    "mtime": 1766258339.447156,
+    "ast_hash": "0a9db90bcbc0b470c1c11eb117642944",
+    "semantic_hash": "0a9db90bcbc0b470c1c11eb117642944"
+  },
+  "services/orion-security-watcher/app/routers/debug.py": {
+    "mtime": 1766260180.0789647,
+    "ast_hash": "eae8376622534d2d7a5a388575706d5f",
+    "semantic_hash": "eae8376622534d2d7a5a388575706d5f"
+  },
+  "services/orion-security-watcher/app/routers/state.py": {
+    "mtime": 1767676515.6701071,
+    "ast_hash": "304dc70d604b0e3e76966b284535a97e",
+    "semantic_hash": "304dc70d604b0e3e76966b284535a97e"
+  },
+  "services/orion-security-watcher/app/routers/test.py": {
+    "mtime": 1766258305.01167,
+    "ast_hash": "367c76cfae5f4a7352bf2294ca8d2d70",
+    "semantic_hash": "367c76cfae5f4a7352bf2294ca8d2d70"
+  },
+  "services/orion-security-watcher/app/routers/ui.py": {
+    "mtime": 1766258280.5800347,
+    "ast_hash": "8ab4b56bbe3ac6fd91e937650680021f",
+    "semantic_hash": "8ab4b56bbe3ac6fd91e937650680021f"
+  },
+  "services/orion-security-watcher/app/settings.py": {
+    "mtime": 1773975149.967786,
+    "ast_hash": "76ab372400e9e3fcd5523d71cae3895a",
+    "semantic_hash": "76ab372400e9e3fcd5523d71cae3895a"
+  },
+  "services/orion-security-watcher/app/state_store.py": {
+    "mtime": 1766257936.1761887,
+    "ast_hash": "d1c649994fadc86fde5015822b32cfe3",
+    "semantic_hash": "d1c649994fadc86fde5015822b32cfe3"
+  },
+  "services/orion-security-watcher/app/utils.py": {
+    "mtime": 1766259341.8222346,
+    "ast_hash": "97928488e66f211bf9196c77d27a7ef3",
+    "semantic_hash": "97928488e66f211bf9196c77d27a7ef3"
+  },
+  "services/orion-security-watcher/app/visits.py": {
+    "mtime": 1766256483.625784,
+    "ast_hash": "62e14884305e351429b78bfa44add140",
+    "semantic_hash": "62e14884305e351429b78bfa44add140"
+  },
+  "services/orion-self-experiments/app/context_exec_client.py": {
+    "mtime": 1781739116.1676345,
+    "ast_hash": "5c591289d9aa5281d6407f9dc4cee638",
+    "semantic_hash": "5c591289d9aa5281d6407f9dc4cee638"
+  },
+  "services/orion-self-experiments/app/experiment_registry.py": {
+    "mtime": 1781739116.1676345,
+    "ast_hash": "677a8b9fc82bf0a1efc141309e58031e",
+    "semantic_hash": "677a8b9fc82bf0a1efc141309e58031e"
+  },
+  "services/orion-self-experiments/app/main.py": {
+    "mtime": 1781739116.1676345,
+    "ast_hash": "b40426bb20cf774f083c854747013c88",
+    "semantic_hash": "b40426bb20cf774f083c854747013c88"
+  },
+  "services/orion-self-experiments/app/settings.py": {
+    "mtime": 1781739116.1686344,
+    "ast_hash": "1b575186c4b824126ebdc3d4acf6f035",
+    "semantic_hash": "1b575186c4b824126ebdc3d4acf6f035"
+  },
+  "services/orion-self-experiments/app/store.py": {
+    "mtime": 1781739116.1686344,
+    "ast_hash": "46aa6637b2eaa54d3b0bc2724a3fbdac",
+    "semantic_hash": "46aa6637b2eaa54d3b0bc2724a3fbdac"
+  },
+  "services/orion-self-experiments/tests/conftest.py": {
+    "mtime": 1781739116.1686344,
+    "ast_hash": "14bb20076081b30c83675288ea8309af",
+    "semantic_hash": "14bb20076081b30c83675288ea8309af"
+  },
+  "services/orion-self-experiments/tests/test_experiment_registry.py": {
+    "mtime": 1781739116.1686344,
+    "ast_hash": "3be8b267e17a0c10e6963daca003e2a4",
+    "semantic_hash": "3be8b267e17a0c10e6963daca003e2a4"
+  },
+  "services/orion-self-state-runtime/app/__init__.py": {
+    "mtime": 1779683294.7627108,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-self-state-runtime/app/health_monitor.py": {
+    "mtime": 1783898916.2596118,
+    "ast_hash": "2ec7fcc23784286e4fb4098ff8f3145d",
+    "semantic_hash": "2ec7fcc23784286e4fb4098ff8f3145d"
+  },
+  "services/orion-self-state-runtime/app/main.py": {
+    "mtime": 1782185238.9407067,
+    "ast_hash": "fc3191cffe40f9d382a52f5c72ea64b9",
+    "semantic_hash": "fc3191cffe40f9d382a52f5c72ea64b9"
+  },
+  "services/orion-self-state-runtime/app/settings.py": {
+    "mtime": 1783898916.2596118,
+    "ast_hash": "e21a8a763dad6dc603435008e84693a3",
+    "semantic_hash": "e21a8a763dad6dc603435008e84693a3"
+  },
+  "services/orion-self-state-runtime/app/store.py": {
+    "mtime": 1783898916.2596118,
+    "ast_hash": "f2ccb8561bcfcd01f47dd94148bbf1dd",
+    "semantic_hash": "f2ccb8561bcfcd01f47dd94148bbf1dd"
+  },
+  "services/orion-self-state-runtime/app/worker.py": {
+    "mtime": 1783898916.2596118,
+    "ast_hash": "d483249a926fe4895fcf52ace662bc9d",
+    "semantic_hash": "d483249a926fe4895fcf52ace662bc9d"
+  },
+  "services/orion-self-state-runtime/tests/conftest.py": {
+    "mtime": 1782964832.6366591,
+    "ast_hash": "52e5c2311141b14b701b174eab99a0ed",
+    "semantic_hash": "52e5c2311141b14b701b174eab99a0ed"
+  },
+  "services/orion-self-state-runtime/tests/test_embodiment_perception_input.py": {
+    "mtime": 1783450708.6487281,
+    "ast_hash": "9f30215188af1f5d036d696da60c331d",
+    "semantic_hash": "9f30215188af1f5d036d696da60c331d"
+  },
+  "services/orion-self-state-runtime/tests/test_health_monitor.py": {
+    "mtime": 1783898916.2596118,
+    "ast_hash": "e818de73f953f9470a80f705728d6d9d",
+    "semantic_hash": "e818de73f953f9470a80f705728d6d9d"
+  },
+  "services/orion-self-state-runtime/tests/test_store_observability_loaders.py": {
+    "mtime": 1783105164.3580725,
+    "ast_hash": "f782c18cd88712aa012f815d6729b774",
+    "semantic_hash": "f782c18cd88712aa012f815d6729b774"
+  },
+  "services/orion-self-state-runtime/tests/test_store_schema_drift_tolerance.py": {
+    "mtime": 1783845232.210588,
+    "ast_hash": "e0c241b8b5b51803076f9717f4a73576",
+    "semantic_hash": "e0c241b8b5b51803076f9717f4a73576"
+  },
+  "services/orion-self-state-runtime/tests/test_worker_deviation_probe.py": {
+    "mtime": 1783841798.491563,
+    "ast_hash": "18376af999e332d4c9e942ab083f8116",
+    "semantic_hash": "18376af999e332d4c9e942ab083f8116"
+  },
+  "services/orion-self-state-runtime/tests/test_worker_prune.py": {
+    "mtime": 1782964832.6366591,
+    "ast_hash": "03f939852dc80164783bcf6f5f43c136",
+    "semantic_hash": "03f939852dc80164783bcf6f5f43c136"
+  },
+  "services/orion-signal-gateway/app/__init__.py": {
+    "mtime": 1777696739.8845713,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-signal-gateway/app/instrumentation.py": {
+    "mtime": 1777696739.8845713,
+    "ast_hash": "a308525cbd492213c37bcfe54a84b929",
+    "semantic_hash": "a308525cbd492213c37bcfe54a84b929"
+  },
+  "services/orion-signal-gateway/app/main.py": {
+    "mtime": 1777696739.8845713,
+    "ast_hash": "c6eff8574e8f0e794ecfa09069c56692",
+    "semantic_hash": "c6eff8574e8f0e794ecfa09069c56692"
+  },
+  "services/orion-signal-gateway/app/normalization_state.py": {
+    "mtime": 1777696739.8845713,
+    "ast_hash": "edc87b449106eeec779196fd756ff1de",
+    "semantic_hash": "edc87b449106eeec779196fd756ff1de"
+  },
+  "services/orion-signal-gateway/app/passthrough.py": {
+    "mtime": 1777696739.8845713,
+    "ast_hash": "c6afc2a447c4c89ccb132acbd8c64f70",
+    "semantic_hash": "c6afc2a447c4c89ccb132acbd8c64f70"
+  },
+  "services/orion-signal-gateway/app/processor.py": {
+    "mtime": 1783807364.3198369,
+    "ast_hash": "d329a15e9d25b419e071b5c83e254074",
+    "semantic_hash": "d329a15e9d25b419e071b5c83e254074"
+  },
+  "services/orion-signal-gateway/app/service.py": {
+    "mtime": 1777696739.8855712,
+    "ast_hash": "4611f3e5cfc7a3ec48a06a03b70a61c7",
+    "semantic_hash": "4611f3e5cfc7a3ec48a06a03b70a61c7"
+  },
+  "services/orion-signal-gateway/app/settings.py": {
+    "mtime": 1783807363.847822,
+    "ast_hash": "054ef93ada452f06053935fa105f57e1",
+    "semantic_hash": "054ef93ada452f06053935fa105f57e1"
+  },
+  "services/orion-signal-gateway/app/signal_window.py": {
+    "mtime": 1777696739.8855712,
+    "ast_hash": "560c1f9e06f77005e92867781d6174a9",
+    "semantic_hash": "560c1f9e06f77005e92867781d6174a9"
+  },
+  "services/orion-signal-gateway/app/tests/__init__.py": {
+    "mtime": 1777696739.8855712,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-signal-gateway/app/tests/conftest.py": {
+    "mtime": 1777696739.8855712,
+    "ast_hash": "60be680681a1e302fa9ea5b98687ca52",
+    "semantic_hash": "60be680681a1e302fa9ea5b98687ca52"
+  },
+  "services/orion-signal-gateway/app/tests/test_causal_parent_resolution.py": {
+    "mtime": 1777696739.8855712,
+    "ast_hash": "e361a82770080b9ba5ca1e7ccca55b67",
+    "semantic_hash": "e361a82770080b9ba5ca1e7ccca55b67"
+  },
+  "services/orion-signal-gateway/app/tests/test_cognition_channel_subscription.py": {
+    "mtime": 1779332554.3358986,
+    "ast_hash": "bdc73ae9869bd2fce671218bf1b5024d",
+    "semantic_hash": "bdc73ae9869bd2fce671218bf1b5024d"
+  },
+  "services/orion-signal-gateway/app/tests/test_normalization.py": {
+    "mtime": 1777696739.8855712,
+    "ast_hash": "3e5ceb04f358e029ba6c0a83c818c3a4",
+    "semantic_hash": "3e5ceb04f358e029ba6c0a83c818c3a4"
+  },
+  "services/orion-signal-gateway/app/tests/test_otel_propagation.py": {
+    "mtime": 1777696940.7840018,
+    "ast_hash": "8301ddc707ad3f7d6fca3916f62c432b",
+    "semantic_hash": "8301ddc707ad3f7d6fca3916f62c432b"
+  },
+  "services/orion-signal-gateway/app/tests/test_passthrough_validation.py": {
+    "mtime": 1777696739.8855712,
+    "ast_hash": "417bc493689bf641e99084fb60008435",
+    "semantic_hash": "417bc493689bf641e99084fb60008435"
+  },
+  "services/orion-signal-gateway/app/tests/test_processor_multi_emission.py": {
+    "mtime": 1779332554.3358986,
+    "ast_hash": "d9ba508a85e6ff7d039841499f4bb13d",
+    "semantic_hash": "d9ba508a85e6ff7d039841499f4bb13d"
+  },
+  "services/orion-signal-gateway/app/tests/test_registry_dag.py": {
+    "mtime": 1777696879.424648,
+    "ast_hash": "cb535db052d937516f658a72ad7de03d",
+    "semantic_hash": "cb535db052d937516f658a72ad7de03d"
+  },
+  "services/orion-signal-gateway/app/tests/test_suppress_adapted.py": {
+    "mtime": 1777748844.5067804,
+    "ast_hash": "cf018d00f2c82fceb8dd7bf0b4ecd8fe",
+    "semantic_hash": "cf018d00f2c82fceb8dd7bf0b4ecd8fe"
+  },
+  "services/orion-signal-gateway/scripts/e2e_otel_phase1.py": {
+    "mtime": 1777790653.2260315,
+    "ast_hash": "56a06096d94e840c9b40fa72a0370e5b",
+    "semantic_hash": "56a06096d94e840c9b40fa72a0370e5b"
+  },
+  "services/orion-signal-gateway/scripts/smoke_otel_phase1.sh": {
+    "mtime": 1777790653.2260315,
+    "ast_hash": "c0a8de05f0d77fccc3f1158a74c338e4",
+    "semantic_hash": "c0a8de05f0d77fccc3f1158a74c338e4"
+  },
+  "services/orion-signals/scripts/down.sh": {
+    "mtime": 1783551182.7595675,
+    "ast_hash": "651d8476715bb718f4002938fb9aa21d",
+    "semantic_hash": "651d8476715bb718f4002938fb9aa21d"
+  },
+  "services/orion-signals/scripts/smoke.sh": {
+    "mtime": 1783551182.7595675,
+    "ast_hash": "6f7d4d0e818afb6ba4374aa3259085e5",
+    "semantic_hash": "6f7d4d0e818afb6ba4374aa3259085e5"
+  },
+  "services/orion-signals/scripts/up.sh": {
+    "mtime": 1783551182.7595675,
+    "ast_hash": "1db0ffa8e7a86242d71a7159a641dd22",
+    "semantic_hash": "1db0ffa8e7a86242d71a7159a641dd22"
+  },
+  "services/orion-signals/tests/test_roster.py": {
+    "mtime": 1783551182.7605677,
+    "ast_hash": "2b5c693525102ca4bf0d4c10597759d2",
+    "semantic_hash": "2b5c693525102ca4bf0d4c10597759d2"
+  },
+  "services/orion-signals/tests/test_scripts.py": {
+    "mtime": 1783551182.7605677,
+    "ast_hash": "95d8a0a82947f08deb75b3a370790e33",
+    "semantic_hash": "95d8a0a82947f08deb75b3a370790e33"
+  },
+  "services/orion-social-memory/app/__init__.py": {
+    "mtime": 1774236180.454385,
+    "ast_hash": "c53117d08002232993517fc02730def7",
+    "semantic_hash": "c53117d08002232993517fc02730def7"
+  },
+  "services/orion-social-memory/app/db.py": {
+    "mtime": 1774236180.454385,
+    "ast_hash": "0557578d5b0076084cc6da9451ef23d9",
+    "semantic_hash": "0557578d5b0076084cc6da9451ef23d9"
+  },
+  "services/orion-social-memory/app/main.py": {
+    "mtime": 1774236180.454385,
+    "ast_hash": "4f5be28b3f30949b4002567ef2ec5b43",
+    "semantic_hash": "4f5be28b3f30949b4002567ef2ec5b43"
+  },
+  "services/orion-social-memory/app/models.py": {
+    "mtime": 1774236180.454385,
+    "ast_hash": "b7a1fc9699cd73ae4cb8efb39efb8ebe",
+    "semantic_hash": "b7a1fc9699cd73ae4cb8efb39efb8ebe"
+  },
+  "services/orion-social-memory/app/service.py": {
+    "mtime": 1783807364.5568445,
+    "ast_hash": "72275c6105ec5c700938270dc32d1443",
+    "semantic_hash": "72275c6105ec5c700938270dc32d1443"
+  },
+  "services/orion-social-memory/app/settings.py": {
+    "mtime": 1774236180.454385,
+    "ast_hash": "f0f12176b416c5cf9887295efb6164f3",
+    "semantic_hash": "f0f12176b416c5cf9887295efb6164f3"
+  },
+  "services/orion-social-memory/app/synthesizer.py": {
+    "mtime": 1783807361.90676,
+    "ast_hash": "966d34470016e71fe018326fa08337c7",
+    "semantic_hash": "966d34470016e71fe018326fa08337c7"
+  },
+  "services/orion-social-memory/tests/test_artifact_dialogue_records.py": {
+    "mtime": 1783111410.299544,
+    "ast_hash": "53befe29606132c0ec52f8213da4b513",
+    "semantic_hash": "53befe29606132c0ec52f8213da4b513"
+  },
+  "services/orion-social-memory/tests/test_social_gif_usage.py": {
+    "mtime": 1774236180.4553852,
+    "ast_hash": "388a02f18a26b6446247c44bee0c421b",
+    "semantic_hash": "388a02f18a26b6446247c44bee0c421b"
+  },
+  "services/orion-social-memory/tests/test_social_memory_service.py": {
+    "mtime": 1774236180.4563851,
+    "ast_hash": "71271bfd2330b4e65e10c4e3de1ab9e5",
+    "semantic_hash": "71271bfd2330b4e65e10c4e3de1ab9e5"
+  },
+  "services/orion-social-room-bridge/app/__init__.py": {
+    "mtime": 1774236180.4563851,
+    "ast_hash": "10300c3e9a75fc9be97e58fc253b3f32",
+    "semantic_hash": "10300c3e9a75fc9be97e58fc253b3f32"
+  },
+  "services/orion-social-room-bridge/app/clients.py": {
+    "mtime": 1778306629.1226344,
+    "ast_hash": "17307e30ba396f114472cb40a0636934",
+    "semantic_hash": "17307e30ba396f114472cb40a0636934"
+  },
+  "services/orion-social-room-bridge/app/gif_policy.py": {
+    "mtime": 1774236180.4563851,
+    "ast_hash": "f223b867e51d0355db4305926f6bd5fb",
+    "semantic_hash": "f223b867e51d0355db4305926f6bd5fb"
+  },
+  "services/orion-social-room-bridge/app/gif_proxy.py": {
+    "mtime": 1774236180.4563851,
+    "ast_hash": "b5d156773ac31a007bdd38eaa23fd96e",
+    "semantic_hash": "b5d156773ac31a007bdd38eaa23fd96e"
+  },
+  "services/orion-social-room-bridge/app/main.py": {
+    "mtime": 1778303664.9180677,
+    "ast_hash": "4567a566af040c1c8b3e23c29064f289",
+    "semantic_hash": "4567a566af040c1c8b3e23c29064f289"
+  },
+  "services/orion-social-room-bridge/app/policy.py": {
+    "mtime": 1774236180.4563851,
+    "ast_hash": "01e0eb810ef021ce5a2f4260d1ef4208",
+    "semantic_hash": "01e0eb810ef021ce5a2f4260d1ef4208"
+  },
+  "services/orion-social-room-bridge/app/service.py": {
+    "mtime": 1778901838.390395,
+    "ast_hash": "22b13dbc4a55ddf6ad528b72b11adf20",
+    "semantic_hash": "22b13dbc4a55ddf6ad528b72b11adf20"
+  },
+  "services/orion-social-room-bridge/app/settings.py": {
+    "mtime": 1778303659.3041089,
+    "ast_hash": "66e3c8fc9bd756796595543bd098cc73",
+    "semantic_hash": "66e3c8fc9bd756796595543bd098cc73"
+  },
+  "services/orion-social-room-bridge/tests/test_bridge_service.py": {
+    "mtime": 1778901838.390395,
+    "ast_hash": "6249b4fece3678089927e990ad6cab41",
+    "semantic_hash": "6249b4fece3678089927e990ad6cab41"
+  },
+  "services/orion-social-room-bridge/tests/test_gif_policy.py": {
+    "mtime": 1774236180.457385,
+    "ast_hash": "2b78756f48c625944ae725e9a4857a61",
+    "semantic_hash": "2b78756f48c625944ae725e9a4857a61"
+  },
+  "services/orion-social-room-bridge/tests/test_gif_proxy.py": {
+    "mtime": 1774236180.457385,
+    "ast_hash": "26891f14075d53082ba9e289fc7ef084",
+    "semantic_hash": "26891f14075d53082ba9e289fc7ef084"
+  },
+  "services/orion-social-room-bridge/tests/test_webhook_auth.py": {
+    "mtime": 1778303731.9815996,
+    "ast_hash": "4a0ef87f14a55e2af4584499930d90dc",
+    "semantic_hash": "4a0ef87f14a55e2af4584499930d90dc"
+  },
+  "services/orion-spark-concept-induction/app/__init__.py": {
+    "mtime": 1768597909.9032292,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-spark-concept-induction/app/main.py": {
+    "mtime": 1783413759.4766405,
+    "ast_hash": "23307b0699a5cd0bc0718ce248ca7265",
+    "semantic_hash": "23307b0699a5cd0bc0718ce248ca7265"
+  },
+  "services/orion-spark-concept-induction/app/settings.py": {
+    "mtime": 1768597909.9032292,
+    "ast_hash": "bb23ba9248cd474d2a21689c9d0d0ff0",
+    "semantic_hash": "bb23ba9248cd474d2a21689c9d0d0ff0"
+  },
+  "services/orion-spark-concept-induction/tests/test_curiosity_reuse_wiring.py": {
+    "mtime": 1783461977.1333036,
+    "ast_hash": "2de064fc0fe1e40267ad3f8c38d9d701",
+    "semantic_hash": "2de064fc0fe1e40267ad3f8c38d9d701"
+  },
+  "services/orion-spark-concept-induction/tests/test_main_lifecycle.py": {
+    "mtime": 1774810093.0461361,
+    "ast_hash": "9c58410756dda9f23d30d9d8e45ce99f",
+    "semantic_hash": "9c58410756dda9f23d30d9d8e45ce99f"
+  },
+  "services/orion-spark-introspector/app/__init__.py": {
+    "mtime": 1764302528.9928074,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-spark-introspector/app/conn_manager.py": {
+    "mtime": 1767676515.6701071,
+    "ast_hash": "eb89eddef8d93f5f5362ef84eb654305",
+    "semantic_hash": "eb89eddef8d93f5f5362ef84eb654305"
+  },
+  "services/orion-spark-introspector/app/inner_state.py": {
+    "mtime": 1783627091.5850115,
+    "ast_hash": "3c5bb561429adc74679041eb6dac30d7",
+    "semantic_hash": "3c5bb561429adc74679041eb6dac30d7"
+  },
+  "services/orion-spark-introspector/app/introspection_guard.py": {
+    "mtime": 1778901838.390395,
+    "ast_hash": "0a655822adc077f2c4c4abe118097c36",
+    "semantic_hash": "0a655822adc077f2c4c4abe118097c36"
+  },
+  "services/orion-spark-introspector/app/introspector.py": {
+    "mtime": 1767676515.671107,
+    "ast_hash": "55a22b8e689d76e5c02e4bdd5d2eeee8",
+    "semantic_hash": "55a22b8e689d76e5c02e4bdd5d2eeee8"
+  },
+  "services/orion-spark-introspector/app/main.py": {
+    "mtime": 1782528981.5950208,
+    "ast_hash": "c3cc7f203741aeedb1dd6e1d1472dad5",
+    "semantic_hash": "c3cc7f203741aeedb1dd6e1d1472dad5"
+  },
+  "services/orion-spark-introspector/app/phi_encoder.py": {
+    "mtime": 1783537420.3163679,
+    "ast_hash": "7836f40a1de737558981a621dd55681e",
+    "semantic_hash": "7836f40a1de737558981a621dd55681e"
+  },
+  "services/orion-spark-introspector/app/queue_jobs.py": {
+    "mtime": 1778901838.390395,
+    "ast_hash": "9c01005cb2448286bf1c519af801db5f",
+    "semantic_hash": "9c01005cb2448286bf1c519af801db5f"
+  },
+  "services/orion-spark-introspector/app/queue_worker.py": {
+    "mtime": 1778901838.390395,
+    "ast_hash": "691a6b2c5967eacdecaf53ca93fed3c6",
+    "semantic_hash": "691a6b2c5967eacdecaf53ca93fed3c6"
+  },
+  "services/orion-spark-introspector/app/settings.py": {
+    "mtime": 1783918473.8083107,
+    "ast_hash": "8ba4ecc9d92fd88a2a9090e5e0da5c84",
+    "semantic_hash": "8ba4ecc9d92fd88a2a9090e5e0da5c84"
+  },
+  "services/orion-spark-introspector/app/static/tissue_viz.js": {
+    "mtime": 1783490446.3053594,
+    "ast_hash": "532d389712e1f2909e7eea6088d2cb63",
+    "semantic_hash": "532d389712e1f2909e7eea6088d2cb63"
+  },
+  "services/orion-spark-introspector/app/substrate_reads.py": {
+    "mtime": 1783630338.4893365,
+    "ast_hash": "a0d8afdff3caaba7285c3ce640cf0823",
+    "semantic_hash": "a0d8afdff3caaba7285c3ce640cf0823"
+  },
+  "services/orion-spark-introspector/app/worker.py": {
+    "mtime": 1783984456.990051,
+    "ast_hash": "64414b115330335746d37c4709a2f5c9",
+    "semantic_hash": "64414b115330335746d37c4709a2f5c9"
+  },
+  "services/orion-spark-introspector/evals/eval_inner_state_readout.py": {
+    "mtime": 1783490446.3063595,
+    "ast_hash": "3f901f12f98b6e8381c971b24dad93e3",
+    "semantic_hash": "3f901f12f98b6e8381c971b24dad93e3"
+  },
+  "services/orion-spark-introspector/evals/eval_phi_encoder_fit.py": {
+    "mtime": 1783537420.318368,
+    "ast_hash": "923ffce3336082bdb17c0f4f15a5a36a",
+    "semantic_hash": "923ffce3336082bdb17c0f4f15a5a36a"
+  },
+  "services/orion-spark-introspector/evals/eval_phi_reward_bounded.py": {
+    "mtime": 1783537420.318368,
+    "ast_hash": "93ad7b745cac548f5acbb95dc99a570f",
+    "semantic_hash": "93ad7b745cac548f5acbb95dc99a570f"
+  },
+  "services/orion-spark-introspector/scripts/smoke_spark_vector_text.py": {
+    "mtime": 1773975149.968786,
+    "ast_hash": "87438d1ca4c2a0a2a0f449bb9f00d366",
+    "semantic_hash": "87438d1ca4c2a0a2a0f449bb9f00d366"
+  },
+  "services/orion-spark-introspector/tests/conftest.py": {
+    "mtime": 1783716548.5476468,
+    "ast_hash": "e2c55aef7afaccec6236cec957af5761",
+    "semantic_hash": "e2c55aef7afaccec6236cec957af5761"
+  },
+  "services/orion-spark-introspector/tests/test_candidate_turn_effect_quality.py": {
+    "mtime": 1781845457.807568,
+    "ast_hash": "e713c453e6cba2e188480630c5451a69",
+    "semantic_hash": "e713c453e6cba2e188480630c5451a69"
+  },
+  "services/orion-spark-introspector/tests/test_cola_novelty_signal.py": {
+    "mtime": 1783136738.0588806,
+    "ast_hash": "4752f0133509a0cad6d6b5e08fd609c9",
+    "semantic_hash": "4752f0133509a0cad6d6b5e08fd609c9"
+  },
+  "services/orion-spark-introspector/tests/test_compose_seed_v2_telemetry_mount.py": {
+    "mtime": 1783627771.3667467,
+    "ast_hash": "c71f06dc2aec9dae76d57ec776e1caf2",
+    "semantic_hash": "c71f06dc2aec9dae76d57ec776e1caf2"
+  },
+  "services/orion-spark-introspector/tests/test_handle_candidate_enqueue_policy.py": {
+    "mtime": 1783107031.9839022,
+    "ast_hash": "619e29487c38e84f2ed9a5d3f6fd8520",
+    "semantic_hash": "619e29487c38e84f2ed9a5d3f6fd8520"
+  },
+  "services/orion-spark-introspector/tests/test_handle_candidate_queue_enqueue.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "54a2ad1ee6ea39a20aa3b92c2bde56f9",
+    "semantic_hash": "54a2ad1ee6ea39a20aa3b92c2bde56f9"
+  },
+  "services/orion-spark-introspector/tests/test_inner_state_emit.py": {
+    "mtime": 1783834625.366221,
+    "ast_hash": "21b36ecac6dc163a31ca4ae8198136f6",
+    "semantic_hash": "21b36ecac6dc163a31ca4ae8198136f6"
+  },
+  "services/orion-spark-introspector/tests/test_inner_state_seed_v3.py": {
+    "mtime": 1783564192.737144,
+    "ast_hash": "3dbd583cf3a4a70143ac972a8859d497",
+    "semantic_hash": "3dbd583cf3a4a70143ac972a8859d497"
+  },
+  "services/orion-spark-introspector/tests/test_inner_state_seed_v4.py": {
+    "mtime": 1783627091.5860116,
+    "ast_hash": "e79a4dd99012c0a0d03e32775a416801",
+    "semantic_hash": "e79a4dd99012c0a0d03e32775a416801"
+  },
+  "services/orion-spark-introspector/tests/test_inner_state_sink_rotation.py": {
+    "mtime": 1783984456.990051,
+    "ast_hash": "8b5776e3c46d711260587219b76193c4",
+    "semantic_hash": "8b5776e3c46d711260587219b76193c4"
+  },
+  "services/orion-spark-introspector/tests/test_introspection_guard.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "d6c0557186684ff7103f23f1fd93f87c",
+    "semantic_hash": "d6c0557186684ff7103f23f1fd93f87c"
+  },
+  "services/orion-spark-introspector/tests/test_main_debug_queue.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "ce1ab8601d76c9f75afd6f09b3594369",
+    "semantic_hash": "ce1ab8601d76c9f75afd6f09b3594369"
+  },
+  "services/orion-spark-introspector/tests/test_mood_arc_corpus.py": {
+    "mtime": 1783916134.44194,
+    "ast_hash": "0dbe401ccb9f04e4557789e3743835cf",
+    "semantic_hash": "0dbe401ccb9f04e4557789e3743835cf"
+  },
+  "services/orion-spark-introspector/tests/test_phi_encoder_health_eval.py": {
+    "mtime": 1783918473.8103108,
+    "ast_hash": "87acb6daad350ed58f4fa0609b47165a",
+    "semantic_hash": "87acb6daad350ed58f4fa0609b47165a"
+  },
+  "services/orion-spark-introspector/tests/test_phi_reward_emit.py": {
+    "mtime": 1783911030.0524845,
+    "ast_hash": "8fdd68e3e6af67bdd9937c37489f89f4",
+    "semantic_hash": "8fdd68e3e6af67bdd9937c37489f89f4"
+  },
+  "services/orion-spark-introspector/tests/test_run_heavy_redis_unavailable.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "cabf8187d960621659648eb781d72fb5",
+    "semantic_hash": "cabf8187d960621659648eb781d72fb5"
+  },
+  "services/orion-spark-introspector/tests/test_spark_introspection_queue_jobs.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "30d1d94e612ac7bdd14feae06cf58ba6",
+    "semantic_hash": "30d1d94e612ac7bdd14feae06cf58ba6"
+  },
+  "services/orion-spark-introspector/tests/test_spark_introspection_queue_worker.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "e95b607c282dc17340f269077967e3d8",
+    "semantic_hash": "e95b607c282dc17340f269077967e3d8"
+  },
+  "services/orion-spark-introspector/tests/test_spark_llm_lane_metadata.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "52ed711dfd1a216350ca499010a42b85",
+    "semantic_hash": "52ed711dfd1a216350ca499010a42b85"
+  },
+  "services/orion-spark-introspector/tests/test_spark_meta_patch_heavy_enqueue.py": {
+    "mtime": 1783110541.1439033,
+    "ast_hash": "223db3528fb7352a6a8e15fe5870948e",
+    "semantic_hash": "223db3528fb7352a6a8e15fe5870948e"
+  },
+  "services/orion-spark-introspector/tests/test_spark_meta_patch_tissue_refresh.py": {
+    "mtime": 1782531013.7283664,
+    "ast_hash": "05e7cad23dda205d416b5c2ed9896e6e",
+    "semantic_hash": "05e7cad23dda205d416b5c2ed9896e6e"
+  },
+  "services/orion-spark-introspector/tests/test_spark_queue_redis_integration.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "d99a12f43390e51c1bf12139f98d4045",
+    "semantic_hash": "d99a12f43390e51c1bf12139f98d4045"
+  },
+  "services/orion-spark-introspector/tests/test_substrate_reads.py": {
+    "mtime": 1783630338.4913366,
+    "ast_hash": "19382f4b087e26fecb724daa1f25f2f2",
+    "semantic_hash": "19382f4b087e26fecb724daa1f25f2f2"
+  },
+  "services/orion-spark-introspector/tests/test_tissue_viz_arousal.py": {
+    "mtime": 1783838962.0010893,
+    "ast_hash": "02059832e988e262725e977556fa7f28",
+    "semantic_hash": "02059832e988e262725e977556fa7f28"
+  },
+  "services/orion-spark-introspector/tests/test_tissue_viz_novelty.py": {
+    "mtime": 1783834622.984144,
+    "ast_hash": "8ee7bf165480eb82840529ee465186d1",
+    "semantic_hash": "8ee7bf165480eb82840529ee465186d1"
+  },
+  "services/orion-spark-introspector/tests/test_worker_correlation_resolve.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "e421730f23536221e866539c06140bf2",
+    "semantic_hash": "e421730f23536221e866539c06140bf2"
+  },
+  "services/orion-spark-introspector/train/evals/eval_phi_encoder_health.py": {
+    "mtime": 1783918473.8113108,
+    "ast_hash": "c72aef48452014bd66908a57965aa621",
+    "semantic_hash": "c72aef48452014bd66908a57965aa621"
+  },
+  "services/orion-sql-db/collapse_dump.sql": {
+    "mtime": 1768597909.9042292,
+    "ast_hash": "42c4bfeac7f632b2973a4b87e8b03b65",
+    "semantic_hash": "42c4bfeac7f632b2973a4b87e8b03b65"
+  },
+  "services/orion-sql-db/collapse_dump_pg.sql": {
+    "mtime": 1768597909.9042292,
+    "ast_hash": "b1befdcb6f89d6d298a051ba018e1e5b",
+    "semantic_hash": "b1befdcb6f89d6d298a051ba018e1e5b"
+  },
+  "services/orion-sql-db/manual_migration_action_outcomes_v1.sql": {
+    "mtime": 1783406173.2689035,
+    "ast_hash": "c494d458e1b62c73aeefc4e03c8617bd",
+    "semantic_hash": "c494d458e1b62c73aeefc4e03c8617bd"
+  },
+  "services/orion-sql-db/manual_migration_attention_broadcast_v1.sql": {
+    "mtime": 1782955647.2234187,
+    "ast_hash": "e7690a8c720081f8374159850dfd53f0",
+    "semantic_hash": "e7690a8c720081f8374159850dfd53f0"
+  },
+  "services/orion-sql-db/manual_migration_attention_frame_v1.sql": {
+    "mtime": 1779681646.028453,
+    "ast_hash": "af354e1298258bfc15e1621f86b3dc53",
+    "semantic_hash": "af354e1298258bfc15e1621f86b3dc53"
+  },
+  "services/orion-sql-db/manual_migration_attention_loop_outcome.sql": {
+    "mtime": 1783447063.2613704,
+    "ast_hash": "64f9f2ff2953db02c1d3f5f56fb83c2c",
+    "semantic_hash": "64f9f2ff2953db02c1d3f5f56fb83c2c"
+  },
+  "services/orion-sql-db/manual_migration_attention_salience_trace.sql": {
+    "mtime": 1783447063.2613704,
+    "ast_hash": "4566889454452027efbd32e058e6e6cb",
+    "semantic_hash": "4566889454452027efbd32e058e6e6cb"
+  },
+  "services/orion-sql-db/manual_migration_autonomy_state_v2.sql": {
+    "mtime": 1783740584.5954983,
+    "ast_hash": "41f84edf420dc76d79151655093cd7b1",
+    "semantic_hash": "41f84edf420dc76d79151655093cd7b1"
+  },
+  "services/orion-sql-db/manual_migration_biometrics_substrate_loop.sql": {
+    "mtime": 1779668252.1430116,
+    "ast_hash": "6ddbc862c257c890956132eed64ef31b",
+    "semantic_hash": "6ddbc862c257c890956132eed64ef31b"
+  },
+  "services/orion-sql-db/manual_migration_bus_fallback_ts_spark_idempotency.sql": {
+    "mtime": 1781395651.2125692,
+    "ast_hash": "edcdd7344cd856222baca0bbee936371",
+    "semantic_hash": "edcdd7344cd856222baca0bbee936371"
+  },
+  "services/orion-sql-db/manual_migration_chat_substrate_loop.sql": {
+    "mtime": 1781897477.5830867,
+    "ast_hash": "aa4efdfc3f89f72a593671bfd88220b0",
+    "semantic_hash": "aa4efdfc3f89f72a593671bfd88220b0"
+  },
+  "services/orion-sql-db/manual_migration_chat_topic.sql": {
+    "mtime": 1779681646.028453,
+    "ast_hash": "de22f2b8299f8f2bf3038f9b6277f572",
+    "semantic_hash": "de22f2b8299f8f2bf3038f9b6277f572"
+  },
+  "services/orion-sql-db/manual_migration_chat_topic_analytics.sql": {
+    "mtime": 1773975149.968786,
+    "ast_hash": "653e2f42760b9465f998aa386cadd0ff",
+    "semantic_hash": "653e2f42760b9465f998aa386cadd0ff"
+  },
+  "services/orion-sql-db/manual_migration_coalition_dwell_v1.sql": {
+    "mtime": 1783027452.0086117,
+    "ast_hash": "051687b88e07cb146701ce5e8065ea92",
+    "semantic_hash": "051687b88e07cb146701ce5e8065ea92"
+  },
+  "services/orion-sql-db/manual_migration_collapse_correlation.sql": {
+    "mtime": 1768597909.9042292,
+    "ast_hash": "391e39a85290e504f0f5980903fcdfa6",
+    "semantic_hash": "391e39a85290e504f0f5980903fcdfa6"
+  },
+  "services/orion-sql-db/manual_migration_consolidation_expectations_v1.sql": {
+    "mtime": 1779749949.3244674,
+    "ast_hash": "4b148112122d15b75b32b5b72f3ce000",
+    "semantic_hash": "4b148112122d15b75b32b5b72f3ce000"
+  },
+  "services/orion-sql-db/manual_migration_consolidation_schema_candidates_v1.sql": {
+    "mtime": 1779749949.3244674,
+    "ast_hash": "4f085a8ca07c62a5d893e8caf56647ad",
+    "semantic_hash": "4f085a8ca07c62a5d893e8caf56647ad"
+  },
+  "services/orion-sql-db/manual_migration_consolidation_tensor_slices_v1.sql": {
+    "mtime": 1779749949.3244674,
+    "ast_hash": "85be676cd80d23cf998c45575695c09d",
+    "semantic_hash": "85be676cd80d23cf998c45575695c09d"
+  },
+  "services/orion-sql-db/manual_migration_consolidation_v1.sql": {
+    "mtime": 1779749949.3244674,
+    "ast_hash": "472cee16c5556a539d4954263f8bab02",
+    "semantic_hash": "472cee16c5556a539d4954263f8bab02"
+  },
+  "services/orion-sql-db/manual_migration_dream_compaction_delta.sql": {
+    "mtime": 1783355701.796141,
+    "ast_hash": "4eddb809318c90f82640c137cfaec698",
+    "semantic_hash": "4eddb809318c90f82640c137cfaec698"
+  },
+  "services/orion-sql-db/manual_migration_dream_compaction_request_queue.sql": {
+    "mtime": 1783355701.796141,
+    "ast_hash": "ec301a960ba6988a9c454ca214932733",
+    "semantic_hash": "ec301a960ba6988a9c454ca214932733"
+  },
+  "services/orion-sql-db/manual_migration_dreams_drop_unique_dream_date.sql": {
+    "mtime": 1777748523.3385992,
+    "ast_hash": "41a673e1a974d3703efb759299dc11fc",
+    "semantic_hash": "41a673e1a974d3703efb759299dc11fc"
+  },
+  "services/orion-sql-db/manual_migration_endogenous_curiosity_candidates_v1.sql": {
+    "mtime": 1783105164.3580725,
+    "ast_hash": "b065be485734a52f75e2073c1465f2ce",
+    "semantic_hash": "b065be485734a52f75e2073c1465f2ce"
+  },
+  "services/orion-sql-db/manual_migration_execution_dispatch_frame_v1.sql": {
+    "mtime": 1779722671.533158,
+    "ast_hash": "00ef33e2503119018023b3c6384e275d",
+    "semantic_hash": "00ef33e2503119018023b3c6384e275d"
+  },
+  "services/orion-sql-db/manual_migration_execution_substrate_loop.sql": {
+    "mtime": 1779677735.0004544,
+    "ast_hash": "f60ec5559bcf08ca4f2ca6be50c1cb91",
+    "semantic_hash": "f60ec5559bcf08ca4f2ca6be50c1cb91"
+  },
+  "services/orion-sql-db/manual_migration_feedback_frame_v1.sql": {
+    "mtime": 1779722671.534158,
+    "ast_hash": "63dc004768993b8ff4d9f346ff1e1dfc",
+    "semantic_hash": "63dc004768993b8ff4d9f346ff1e1dfc"
+  },
+  "services/orion-sql-db/manual_migration_field_digester_v1.sql": {
+    "mtime": 1783897997.643214,
+    "ast_hash": "65b01bebb91ecb382b86f82dd5e8c1f2",
+    "semantic_hash": "65b01bebb91ecb382b86f82dd5e8c1f2"
+  },
+  "services/orion-sql-db/manual_migration_grammar_atlas.sql": {
+    "mtime": 1781395651.2125692,
+    "ast_hash": "516caa1c9464093ba3bd581a8bc71cb0",
+    "semantic_hash": "516caa1c9464093ba3bd581a8bc71cb0"
+  },
+  "services/orion-sql-db/manual_migration_hub_presence_v1.sql": {
+    "mtime": 1783105164.3580725,
+    "ast_hash": "75eed0f2bcffe0606be1a330f08a7df5",
+    "semantic_hash": "75eed0f2bcffe0606be1a330f08a7df5"
+  },
+  "services/orion-sql-db/manual_migration_identity_snapshot_v1.sql": {
+    "mtime": 1782438858.7046392,
+    "ast_hash": "25f9a8365c09da67421d30965dbb296c",
+    "semantic_hash": "25f9a8365c09da67421d30965dbb296c"
+  },
+  "services/orion-sql-db/manual_migration_memory_consolidation_v1.sql": {
+    "mtime": 1781653616.6603448,
+    "ast_hash": "de07ea5a50f88888deb79ea38f67666a",
+    "semantic_hash": "de07ea5a50f88888deb79ea38f67666a"
+  },
+  "services/orion-sql-db/manual_migration_metacognitive_trace.sql": {
+    "mtime": 1774759059.1623049,
+    "ast_hash": "520ad37862d59794d9c2b6276206d2f9",
+    "semantic_hash": "520ad37862d59794d9c2b6276206d2f9"
+  },
+  "services/orion-sql-db/manual_migration_policy_decision_frame_v1.sql": {
+    "mtime": 1779689417.3452013,
+    "ast_hash": "1995238878fc87faa6e777690a6fabb2",
+    "semantic_hash": "1995238878fc87faa6e777690a6fabb2"
+  },
+  "services/orion-sql-db/manual_migration_proposal_frame_v1.sql": {
+    "mtime": 1779687966.459823,
+    "ast_hash": "86574ccd2e02537a8382621254f743c4",
+    "semantic_hash": "86574ccd2e02537a8382621254f743c4"
+  },
+  "services/orion-sql-db/manual_migration_receipt_retention_v1.sql": {
+    "mtime": 1780106291.7487774,
+    "ast_hash": "776461dbe2c262f8eeb0125d4b88ca86",
+    "semantic_hash": "776461dbe2c262f8eeb0125d4b88ca86"
+  },
+  "services/orion-sql-db/manual_migration_receipt_retention_v2_aggressive.sql": {
+    "mtime": 1780613748.3914251,
+    "ast_hash": "350eb4453808fefe7646ed4b305948dc",
+    "semantic_hash": "350eb4453808fefe7646ed4b305948dc"
+  },
+  "services/orion-sql-db/manual_migration_route_substrate_loop.sql": {
+    "mtime": 1783903398.646444,
+    "ast_hash": "0c49eabad0b2c4b1c7f1bc6ebc05036d",
+    "semantic_hash": "0c49eabad0b2c4b1c7f1bc6ebc05036d"
+  },
+  "services/orion-sql-db/manual_migration_self_state_prediction_v1.sql": {
+    "mtime": 1782438858.7056391,
+    "ast_hash": "8ced1510ab40185b016204c8b246cda3",
+    "semantic_hash": "8ced1510ab40185b016204c8b246cda3"
+  },
+  "services/orion-sql-db/manual_migration_self_state_v1.sql": {
+    "mtime": 1779683294.7627108,
+    "ast_hash": "795fd42d1f5fbc2c32b1d821a7f608fb",
+    "semantic_hash": "795fd42d1f5fbc2c32b1d821a7f608fb"
+  },
+  "services/orion-sql-db/manual_migration_social_memory_calibration_v1.sql": {
+    "mtime": 1783107031.9839022,
+    "ast_hash": "0630914bc529748e2a32b50a9eb7dc1e",
+    "semantic_hash": "0630914bc529748e2a32b50a9eb7dc1e"
+  },
+  "services/orion-sql-db/manual_migration_substrate_brain_frame_v1.sql": {
+    "mtime": 1783468068.6368666,
+    "ast_hash": "bcf3d8e869aec1f7ac3ac66ac9389dd6",
+    "semantic_hash": "bcf3d8e869aec1f7ac3ac66ac9389dd6"
+  },
+  "services/orion-sql-db/manual_migration_substrate_dispatch_results_v1.sql": {
+    "mtime": 1783967452.504406,
+    "ast_hash": "3fcb5f6cb9786a03ade7c002950a0a91",
+    "semantic_hash": "3fcb5f6cb9786a03ade7c002950a0a91"
+  },
+  "services/orion-sql-db/manual_migration_substrate_episodes_v1.sql": {
+    "mtime": 1782955647.2234187,
+    "ast_hash": "acb66f5001651407447475acacf4c48c",
+    "semantic_hash": "acb66f5001651407447475acacf4c48c"
+  },
+  "services/orion-sql-db/manual_migration_substrate_receipts_autovacuum_guard.sql": {
+    "mtime": 1782181889.4753525,
+    "ast_hash": "b6cbf3de546d6b7e7ca50ea046e61c53",
+    "semantic_hash": "b6cbf3de546d6b7e7ca50ea046e61c53"
+  },
+  "services/orion-sql-db/manual_migration_substrate_reducer_quarantine_v1.sql": {
+    "mtime": 1781585632.7489526,
+    "ast_hash": "2ecd1ef52b9d5232fe584fa7587f0572",
+    "semantic_hash": "2ecd1ef52b9d5232fe584fa7587f0572"
+  },
+  "services/orion-sql-db/manual_migration_substrate_reverie_chain.sql": {
+    "mtime": 1783355701.796141,
+    "ast_hash": "e8a6b4b30d96cfdbb3fb3931bb9886c2",
+    "semantic_hash": "e8a6b4b30d96cfdbb3fb3931bb9886c2"
+  },
+  "services/orion-sql-db/manual_migration_substrate_reverie_refractory.sql": {
+    "mtime": 1783355701.796141,
+    "ast_hash": "72c1433c16206e09b4db55691cfa6ec7",
+    "semantic_hash": "72c1433c16206e09b4db55691cfa6ec7"
+  },
+  "services/orion-sql-db/manual_migration_substrate_reverie_resonance_alert.sql": {
+    "mtime": 1783355701.796141,
+    "ast_hash": "664899956774a95957ccaa190aef0113",
+    "semantic_hash": "664899956774a95957ccaa190aef0113"
+  },
+  "services/orion-sql-db/manual_migration_substrate_reverie_thought.sql": {
+    "mtime": 1783312413.5132458,
+    "ast_hash": "81b79318160dc2a860894ae252366eaa",
+    "semantic_hash": "81b79318160dc2a860894ae252366eaa"
+  },
+  "services/orion-sql-db/manual_migration_substrate_turn_referent_v1.sql": {
+    "mtime": 1783396080.016995,
+    "ast_hash": "5960e98900e40ce1a765e66c26106ffe",
+    "semantic_hash": "5960e98900e40ce1a765e66c26106ffe"
+  },
+  "services/orion-sql-db/manual_migration_transport_substrate_loop.sql": {
+    "mtime": 1780622613.6047645,
+    "ast_hash": "55decd0a464a5b5aab19993d03b42997",
+    "semantic_hash": "55decd0a464a5b5aab19993d03b42997"
+  },
+  "services/orion-sql-writer/app/__init__.py": {
+    "mtime": 1769663878.094563,
+    "ast_hash": "d15821d977e3c1280032e65752083a35",
+    "semantic_hash": "d15821d977e3c1280032e65752083a35"
+  },
+  "services/orion-sql-writer/app/api_notify.py": {
+    "mtime": 1783960753.1748304,
+    "ast_hash": "2642d19e71a7d18a4d616689505b3022",
+    "semantic_hash": "2642d19e71a7d18a4d616689505b3022"
+  },
+  "services/orion-sql-writer/app/db.py": {
+    "mtime": 1781395651.2135694,
+    "ast_hash": "e51b673535d36a39bcb92d1a9f885295",
+    "semantic_hash": "e51b673535d36a39bcb92d1a9f885295"
+  },
+  "services/orion-sql-writer/app/db_utils.py": {
+    "mtime": 1763232123.4138906,
+    "ast_hash": "d115e203da2299ec75a937ee0210ea2e",
+    "semantic_hash": "d115e203da2299ec75a937ee0210ea2e"
+  },
+  "services/orion-sql-writer/app/evidence_index_repository.py": {
+    "mtime": 1776566446.4208953,
+    "ast_hash": "c99ab64b8a4108b26ba5a1c118f625d9",
+    "semantic_hash": "c99ab64b8a4108b26ba5a1c118f625d9"
+  },
+  "services/orion-sql-writer/app/grammar_ledger_handler.py": {
+    "mtime": 1781395651.2135694,
+    "ast_hash": "d6e8b488eada95c4efb9ac1ab19695fa",
+    "semantic_hash": "d6e8b488eada95c4efb9ac1ab19695fa"
+  },
+  "services/orion-sql-writer/app/grammar_truth.py": {
+    "mtime": 1781395651.2135694,
+    "ast_hash": "8be9f47258924124fe1aac2b754e75e6",
+    "semantic_hash": "8be9f47258924124fe1aac2b754e75e6"
+  },
+  "services/orion-sql-writer/app/journal_index_repository.py": {
+    "mtime": 1776566446.4208953,
+    "ast_hash": "d296838713f5645c45dec9ea71495931",
+    "semantic_hash": "d296838713f5645c45dec9ea71495931"
+  },
+  "services/orion-sql-writer/app/main.py": {
+    "mtime": 1783406173.2689035,
+    "ast_hash": "e5659382e83de46c68cd45a5a984dea1",
+    "semantic_hash": "e5659382e83de46c68cd45a5a984dea1"
+  },
+  "services/orion-sql-writer/app/schemas/__init__.py": {
+    "mtime": 1764305250.0924265,
+    "ast_hash": "aed834fdc3460da2cee742fce26980c3",
+    "semantic_hash": "aed834fdc3460da2cee742fce26980c3"
+  },
+  "services/orion-sql-writer/app/schemas/biometrics.py": {
+    "mtime": 1763232123.4148908,
+    "ast_hash": "ba9cebb58078ebc3143f656c58449ecd",
+    "semantic_hash": "ba9cebb58078ebc3143f656c58449ecd"
+  },
+  "services/orion-sql-writer/app/schemas/chat_history.py": {
+    "mtime": 1764289624.0710883,
+    "ast_hash": "d80716e66875581bddaaea5cc2085b25",
+    "semantic_hash": "d80716e66875581bddaaea5cc2085b25"
+  },
+  "services/orion-sql-writer/app/schemas/dream.py": {
+    "mtime": 1774236180.458385,
+    "ast_hash": "7efa0efb1efb430a16282fc5c06742c6",
+    "semantic_hash": "7efa0efb1efb430a16282fc5c06742c6"
+  },
+  "services/orion-sql-writer/app/schemas/enrichment.py": {
+    "mtime": 1763232123.4148908,
+    "ast_hash": "426490fa94187581e7bbe08d6cd20db3",
+    "semantic_hash": "426490fa94187581e7bbe08d6cd20db3"
+  },
+  "services/orion-sql-writer/app/schemas/mirror.py": {
+    "mtime": 1763232123.4148908,
+    "ast_hash": "3712601d4dd2bf2c542a00622409b1d9",
+    "semantic_hash": "3712601d4dd2bf2c542a00622409b1d9"
+  },
+  "services/orion-sql-writer/app/schemas/spark_introspection_log.py": {
+    "mtime": 1764302528.9948075,
+    "ast_hash": "429a054c99a374fd7dad432bb70bbf04",
+    "semantic_hash": "429a054c99a374fd7dad432bb70bbf04"
+  },
+  "services/orion-sql-writer/app/settings.py": {
+    "mtime": 1783537420.3193681,
+    "ast_hash": "be1db6a9a4f0839ffea957f1c71f494e",
+    "semantic_hash": "be1db6a9a4f0839ffea957f1c71f494e"
+  },
+  "services/orion-sql-writer/app/spark_contract_metrics.py": {
+    "mtime": 1769663878.094563,
+    "ast_hash": "a4a94c4b8d7bc79c20724fadc509f181",
+    "semantic_hash": "a4a94c4b8d7bc79c20724fadc509f181"
+  },
+  "services/orion-sql-writer/app/spark_telemetry_persist.py": {
+    "mtime": 1781893873.1259723,
+    "ast_hash": "0136086339413650e9e7e30cabd19755",
+    "semantic_hash": "0136086339413650e9e7e30cabd19755"
+  },
+  "services/orion-sql-writer/app/worker.py": {
+    "mtime": 1783807361.8537583,
+    "ast_hash": "0f72f97fcaafcc3c08c693e8417e1498",
+    "semantic_hash": "0f72f97fcaafcc3c08c693e8417e1498"
+  },
+  "services/orion-sql-writer/scripts/smoke_chatgpt_turn_sql.py": {
+    "mtime": 1773975149.969786,
+    "ast_hash": "3f73c2c5819e36632456b5e3969491d6",
+    "semantic_hash": "3f73c2c5819e36632456b5e3969491d6"
+  },
+  "services/orion-sql-writer/tests/grammar_integration_helpers.py": {
+    "mtime": 1781395651.2155693,
+    "ast_hash": "ea4f70c2b491b48d24200cfcfd465652",
+    "semantic_hash": "ea4f70c2b491b48d24200cfcfd465652"
+  },
+  "services/orion-sql-writer/tests/test_action_outcome_sql_shape.py": {
+    "mtime": 1783406173.2699037,
+    "ast_hash": "274956009bb75dec262c122925d81c1b",
+    "semantic_hash": "274956009bb75dec262c122925d81c1b"
+  },
+  "services/orion-sql-writer/tests/test_chat_history_turn_coalesce.py": {
+    "mtime": 1782526649.4733126,
+    "ast_hash": "73f9f886d540e52ddfd5fbcfe8830bb3",
+    "semantic_hash": "73f9f886d540e52ddfd5fbcfe8830bb3"
+  },
+  "services/orion-sql-writer/tests/test_chat_response_feedback_routing.py": {
+    "mtime": 1775634425.4042528,
+    "ast_hash": "c5f8aa91d44ccc4b75c6078e6775c7ea",
+    "semantic_hash": "c5f8aa91d44ccc4b75c6078e6775c7ea"
+  },
+  "services/orion-sql-writer/tests/test_chatgpt_export_ingestion.py": {
+    "mtime": 1776925210.020162,
+    "ast_hash": "f825335a97eabfbc7a2e7dec0444c5a5",
+    "semantic_hash": "f825335a97eabfbc7a2e7dec0444c5a5"
+  },
+  "services/orion-sql-writer/tests/test_chatgpt_import_layers.py": {
+    "mtime": 1776925210.020162,
+    "ast_hash": "5a0e8116c3c9f572042ab8cfd68eb66e",
+    "semantic_hash": "5a0e8116c3c9f572042ab8cfd68eb66e"
+  },
+  "services/orion-sql-writer/tests/test_consumer_resilience.py": {
+    "mtime": 1781395651.2155693,
+    "ast_hash": "fa00399ef4e448906dda87c95deff8c6",
+    "semantic_hash": "fa00399ef4e448906dda87c95deff8c6"
+  },
+  "services/orion-sql-writer/tests/test_dream_model_constraints.py": {
+    "mtime": 1777748523.3395994,
+    "ast_hash": "2573326220285b978078b38028c20d30",
+    "semantic_hash": "2573326220285b978078b38028c20d30"
+  },
+  "services/orion-sql-writer/tests/test_endogenous_runtime_sql_routing_phase13b.py": {
+    "mtime": 1775601136.3208966,
+    "ast_hash": "138250357a8736eba5661b54d43f5573",
+    "semantic_hash": "138250357a8736eba5661b54d43f5573"
+  },
+  "services/orion-sql-writer/tests/test_evidence_index_substrate.py": {
+    "mtime": 1776566446.4228952,
+    "ast_hash": "b5a10807c6032ff35bd187f7788497e8",
+    "semantic_hash": "b5a10807c6032ff35bd187f7788497e8"
+  },
+  "services/orion-sql-writer/tests/test_fallback_log_timestamp.py": {
+    "mtime": 1781395651.2155693,
+    "ast_hash": "5b7c776c9259f42a2cda0201e176a712",
+    "semantic_hash": "5b7c776c9259f42a2cda0201e176a712"
+  },
+  "services/orion-sql-writer/tests/test_grammar_event_routing.py": {
+    "mtime": 1781395651.2155693,
+    "ast_hash": "b0fa887d7f2d142dbedb50ff6121aa75",
+    "semantic_hash": "b0fa887d7f2d142dbedb50ff6121aa75"
+  },
+  "services/orion-sql-writer/tests/test_grammar_ledger_integration.py": {
+    "mtime": 1781395651.2165692,
+    "ast_hash": "32dcbdd889f17e8406de2e4da8a157ae",
+    "semantic_hash": "32dcbdd889f17e8406de2e4da8a157ae"
+  },
+  "services/orion-sql-writer/tests/test_grammar_ledger_sql_shape.py": {
+    "mtime": 1781395651.2165692,
+    "ast_hash": "124c9c8e26be5d5b0658f852806ad90f",
+    "semantic_hash": "124c9c8e26be5d5b0658f852806ad90f"
+  },
+  "services/orion-sql-writer/tests/test_grammar_truth.py": {
+    "mtime": 1781395651.2165692,
+    "ast_hash": "fa85409184592a3e23d290d99b1465b3",
+    "semantic_hash": "fa85409184592a3e23d290d99b1465b3"
+  },
+  "services/orion-sql-writer/tests/test_journal_entry_indexing.py": {
+    "mtime": 1779649387.8162987,
+    "ast_hash": "d214d6c422a17262252646702f6a7e0d",
+    "semantic_hash": "d214d6c422a17262252646702f6a7e0d"
+  },
+  "services/orion-sql-writer/tests/test_journal_entry_payload_boundary.py": {
+    "mtime": 1774839547.8280632,
+    "ast_hash": "e7b848f6e6d5c169f20b31caac000188",
+    "semantic_hash": "e7b848f6e6d5c169f20b31caac000188"
+  },
+  "services/orion-sql-writer/tests/test_journal_entry_trigger_kind_filtering.py": {
+    "mtime": 1783986358.1076567,
+    "ast_hash": "ed47770209a4852193833e988c71747f",
+    "semantic_hash": "ed47770209a4852193833e988c71747f"
+  },
+  "services/orion-sql-writer/tests/test_llm_uncertainty_spark_meta.py": {
+    "mtime": 1779649387.8162987,
+    "ast_hash": "6d6672a74ae300de46c692bc1537d4f8",
+    "semantic_hash": "6d6672a74ae300de46c692bc1537d4f8"
+  },
+  "services/orion-sql-writer/tests/test_memory_turn_persisted_outbox.py": {
+    "mtime": 1781653616.6613448,
+    "ast_hash": "4f6646381d1b4704b8af4d044577e2d7",
+    "semantic_hash": "4f6646381d1b4704b8af4d044577e2d7"
+  },
+  "services/orion-sql-writer/tests/test_notify_attention_ack.py": {
+    "mtime": 1783960753.1758304,
+    "ast_hash": "a7ad0339350ce79cf1aba08092353590",
+    "semantic_hash": "a7ad0339350ce79cf1aba08092353590"
+  },
+  "services/orion-sql-writer/tests/test_notify_attention_escalate.py": {
+    "mtime": 1781893873.1269724,
+    "ast_hash": "922bcce3ca8215a2e7920db7c171e2d4",
+    "semantic_hash": "922bcce3ca8215a2e7920db7c171e2d4"
+  },
+  "services/orion-sql-writer/tests/test_notify_request_normalization.py": {
+    "mtime": 1777095728.5814998,
+    "ast_hash": "748d90fbc6b2c46334816b55f171c1f9",
+    "semantic_hash": "748d90fbc6b2c46334816b55f171c1f9"
+  },
+  "services/orion-sql-writer/tests/test_phase21_wiring_verification.py": {
+    "mtime": 1776566446.4228952,
+    "ast_hash": "a95db0902d75a6b5727772e5ec5e7dda",
+    "semantic_hash": "a95db0902d75a6b5727772e5ec5e7dda"
+  },
+  "services/orion-sql-writer/tests/test_phi_reward_sql_shape.py": {
+    "mtime": 1783537420.320368,
+    "ast_hash": "d6801c916bf92781ede8d41b6c58cf9f",
+    "semantic_hash": "d6801c916bf92781ede8d41b6c58cf9f"
+  },
+  "services/orion-sql-writer/tests/test_route_map_completeness.py": {
+    "mtime": 1781653616.6613448,
+    "ast_hash": "ea0b4c19118cfe17fa43f57f120472a6",
+    "semantic_hash": "ea0b4c19118cfe17fa43f57f120472a6"
+  },
+  "services/orion-sql-writer/tests/test_social_turn_stored_emit.py": {
+    "mtime": 1783110134.1412156,
+    "ast_hash": "1c7cac0751a4d4f5a12a2ab02fe3a2fd",
+    "semantic_hash": "1c7cac0751a4d4f5a12a2ab02fe3a2fd"
+  },
+  "services/orion-sql-writer/tests/test_spark_meta_patch.py": {
+    "mtime": 1781653616.6613448,
+    "ast_hash": "991d88967e336827d6cd95c4544ac11d",
+    "semantic_hash": "991d88967e336827d6cd95c4544ac11d"
+  },
+  "services/orion-sql-writer/tests/test_spark_telemetry_idempotency.py": {
+    "mtime": 1781893873.1269724,
+    "ast_hash": "cc4c1c318e2fd1b350fd3a7e480e183d",
+    "semantic_hash": "cc4c1c318e2fd1b350fd3a7e480e183d"
+  },
+  "services/orion-sql-writer/tests/test_thought_candidate.py": {
+    "mtime": 1775704127.9229608,
+    "ast_hash": "16c5ea766959e79bc75f22d72f674009",
+    "semantic_hash": "16c5ea766959e79bc75f22d72f674009"
+  },
+  "services/orion-sql-writer/tests/test_vision_event_sql_shape.py": {
+    "mtime": 1782944093.6512637,
+    "ast_hash": "a314063324dba561d4dcf2d18c2478b6",
+    "semantic_hash": "a314063324dba561d4dcf2d18c2478b6"
+  },
+  "services/orion-sql-writer/tests/test_vision_persistence_lane.py": {
+    "mtime": 1782964832.6366591,
+    "ast_hash": "c74f079cc408d99fc281d7d2c8cf7da4",
+    "semantic_hash": "c74f079cc408d99fc281d7d2c8cf7da4"
+  },
+  "services/orion-sql-writer/tests/test_world_pulse_routing.py": {
+    "mtime": 1781140097.1178908,
+    "ast_hash": "20a8c076ffdba97450af7468c62e6ad8",
+    "semantic_hash": "20a8c076ffdba97450af7468c62e6ad8"
+  },
+  "services/orion-state-journaler/app/__init__.py": {
+    "mtime": 1768597909.9052293,
+    "ast_hash": "08dc4eba5618a5b3ab5f4864eecdf89d",
+    "semantic_hash": "08dc4eba5618a5b3ab5f4864eecdf89d"
+  },
+  "services/orion-state-journaler/app/main.py": {
+    "mtime": 1768597909.9052293,
+    "ast_hash": "cde81ee3ba1dc948237b037219103ef0",
+    "semantic_hash": "cde81ee3ba1dc948237b037219103ef0"
+  },
+  "services/orion-state-journaler/app/service.py": {
+    "mtime": 1773975149.9707859,
+    "ast_hash": "d68266b09f4601226361b746d20d2c52",
+    "semantic_hash": "d68266b09f4601226361b746d20d2c52"
+  },
+  "services/orion-state-journaler/app/settings.py": {
+    "mtime": 1768597909.9052293,
+    "ast_hash": "c85f4712c922ebdec2fa27bd5b571c2e",
+    "semantic_hash": "c85f4712c922ebdec2fa27bd5b571c2e"
+  },
+  "services/orion-state-service/app/__init__.py": {
+    "mtime": 1768597909.9052293,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-state-service/app/main.py": {
+    "mtime": 1783890426.4927747,
+    "ast_hash": "a9285a8e65312d2220560b0e46fffd01",
+    "semantic_hash": "a9285a8e65312d2220560b0e46fffd01"
+  },
+  "services/orion-state-service/app/pg.py": {
+    "mtime": 1768597909.9052293,
+    "ast_hash": "8aeefafa8c9fd5a8645a10db86985faf",
+    "semantic_hash": "8aeefafa8c9fd5a8645a10db86985faf"
+  },
+  "services/orion-state-service/app/settings.py": {
+    "mtime": 1773975149.9707859,
+    "ast_hash": "4f2614ff912009a8f292c005784d7782",
+    "semantic_hash": "4f2614ff912009a8f292c005784d7782"
+  },
+  "services/orion-state-service/app/store.py": {
+    "mtime": 1768971372.3620236,
+    "ast_hash": "b7284b0fc31455477e7043edd035c4b7",
+    "semantic_hash": "b7284b0fc31455477e7043edd035c4b7"
+  },
+  "services/orion-substrate-organs/app/organs/biometrics_pressure.py": {
+    "mtime": 1779668252.1440117,
+    "ast_hash": "b2a214573e64390c158a5dfc7cbc9e44",
+    "semantic_hash": "b2a214573e64390c158a5dfc7cbc9e44"
+  },
+  "services/orion-substrate-organs/app/runtime/emission_validator.py": {
+    "mtime": 1779668252.1440117,
+    "ast_hash": "671f05526f34d8ca6077e05a2dbf922e",
+    "semantic_hash": "671f05526f34d8ca6077e05a2dbf922e"
+  },
+  "services/orion-substrate-organs/app/runtime/event_native_organ.py": {
+    "mtime": 1779668252.1440117,
+    "ast_hash": "78397bee831031828e00ae1ca33998a2",
+    "semantic_hash": "78397bee831031828e00ae1ca33998a2"
+  },
+  "services/orion-substrate-runtime/app/__init__.py": {
+    "mtime": 1779668252.1440117,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-substrate-runtime/app/brain_frame_producer.py": {
+    "mtime": 1783473102.646676,
+    "ast_hash": "ccc260221d7a35fdbc61448bc1a9289f",
+    "semantic_hash": "ccc260221d7a35fdbc61448bc1a9289f"
+  },
+  "services/orion-substrate-runtime/app/cursor_gaps.py": {
+    "mtime": 1781395651.2165692,
+    "ast_hash": "fd22bb0d33a7727178f07e1ad923d843",
+    "semantic_hash": "fd22bb0d33a7727178f07e1ad923d843"
+  },
+  "services/orion-substrate-runtime/app/cursor_reset.py": {
+    "mtime": 1781395651.2165692,
+    "ast_hash": "8b1a737993196e6642ac0da7efe46aa3",
+    "semantic_hash": "8b1a737993196e6642ac0da7efe46aa3"
+  },
+  "services/orion-substrate-runtime/app/finalize_appraisal_listener.py": {
+    "mtime": 1783291410.028702,
+    "ast_hash": "4bb57d62d135844ae4c769b6f971053c",
+    "semantic_hash": "4bb57d62d135844ae4c769b6f971053c"
+  },
+  "services/orion-substrate-runtime/app/goal_context_listener.py": {
+    "mtime": 1783655498.7461991,
+    "ast_hash": "b02b5bb9032407fb47a0db433028d48d",
+    "semantic_hash": "b02b5bb9032407fb47a0db433028d48d"
+  },
+  "services/orion-substrate-runtime/app/grammar_truth.py": {
+    "mtime": 1783960753.1758304,
+    "ast_hash": "dd32298366770f2ced661edb32674edc",
+    "semantic_hash": "dd32298366770f2ced661edb32674edc"
+  },
+  "services/orion-substrate-runtime/app/health_monitor.py": {
+    "mtime": 1783965578.734708,
+    "ast_hash": "5cd7aa9c19e2df3e297d387a6d5e4879",
+    "semantic_hash": "5cd7aa9c19e2df3e297d387a6d5e4879"
+  },
+  "services/orion-substrate-runtime/app/main.py": {
+    "mtime": 1783918729.2293985,
+    "ast_hash": "2ea7d3074fe4117d638b90de6ccf4666",
+    "semantic_hash": "2ea7d3074fe4117d638b90de6ccf4666"
+  },
+  "services/orion-substrate-runtime/app/post_turn_closure_listener.py": {
+    "mtime": 1783300876.6819148,
+    "ast_hash": "c4ab4f416f8a5f05aad53e2423fae660",
+    "semantic_hash": "c4ab4f416f8a5f05aad53e2423fae660"
+  },
+  "services/orion-substrate-runtime/app/publish.py": {
+    "mtime": 1781395651.2175694,
+    "ast_hash": "80926a3d42f9d1196b69673b0cc388b4",
+    "semantic_hash": "80926a3d42f9d1196b69673b0cc388b4"
+  },
+  "services/orion-substrate-runtime/app/quarantine_ack.py": {
+    "mtime": 1781585632.7499526,
+    "ast_hash": "f9a2f4f43984ed0df553fcbf6047e46b",
+    "semantic_hash": "f9a2f4f43984ed0df553fcbf6047e46b"
+  },
+  "services/orion-substrate-runtime/app/receipt_pruner.py": {
+    "mtime": 1782526649.4733126,
+    "ast_hash": "57eeb450795de4fbaa8049497b2a9e50",
+    "semantic_hash": "57eeb450795de4fbaa8049497b2a9e50"
+  },
+  "services/orion-substrate-runtime/app/reducer_health.py": {
+    "mtime": 1781585632.7499526,
+    "ast_hash": "b82d2826e09ddf845db03011fddbef8b",
+    "semantic_hash": "b82d2826e09ddf845db03011fddbef8b"
+  },
+  "services/orion-substrate-runtime/app/settings.py": {
+    "mtime": 1783965578.734708,
+    "ast_hash": "063a1e6eb94d3cac08a92b8f67cd693c",
+    "semantic_hash": "063a1e6eb94d3cac08a92b8f67cd693c"
+  },
+  "services/orion-substrate-runtime/app/store.py": {
+    "mtime": 1783903398.647444,
+    "ast_hash": "7a304496cb2e9705aa6433d1e4e7c1b1",
+    "semantic_hash": "7a304496cb2e9705aa6433d1e4e7c1b1"
+  },
+  "services/orion-substrate-runtime/app/turn_referent_store.py": {
+    "mtime": 1783396080.017995,
+    "ast_hash": "6e9860f7adeb4a179d50d1b5cac2f8f6",
+    "semantic_hash": "6e9860f7adeb4a179d50d1b5cac2f8f6"
+  },
+  "services/orion-substrate-runtime/app/worker.py": {
+    "mtime": 1783912914.8337595,
+    "ast_hash": "feea422fc25ddd00e65416d2376c38fa",
+    "semantic_hash": "feea422fc25ddd00e65416d2376c38fa"
+  },
+  "services/orion-substrate-runtime/evals/test_brain_frame_substance_eval.py": {
+    "mtime": 1783473102.646676,
+    "ast_hash": "6a03a88f610066828c39064bc1e61814",
+    "semantic_hash": "6a03a88f610066828c39064bc1e61814"
+  },
+  "services/orion-substrate-runtime/tests/conftest.py": {
+    "mtime": 1783291410.028702,
+    "ast_hash": "f8ef4b4354ebc0afc7b4bcc77f88ef20",
+    "semantic_hash": "f8ef4b4354ebc0afc7b4bcc77f88ef20"
+  },
+  "services/orion-substrate-runtime/tests/test_brain_frame_producer.py": {
+    "mtime": 1783473102.646676,
+    "ast_hash": "246b9b41bf88bd5055aada991d03ca50",
+    "semantic_hash": "246b9b41bf88bd5055aada991d03ca50"
+  },
+  "services/orion-substrate-runtime/tests/test_brain_frame_settings.py": {
+    "mtime": 1783468068.6378665,
+    "ast_hash": "b65340a7a8c1ceb53d6be91fa3c18bd0",
+    "semantic_hash": "b65340a7a8c1ceb53d6be91fa3c18bd0"
+  },
+  "services/orion-substrate-runtime/tests/test_brain_frame_store.py": {
+    "mtime": 1783468068.6378665,
+    "ast_hash": "a12a523eaedcb809fc93a3fc2adcbbc9",
+    "semantic_hash": "a12a523eaedcb809fc93a3fc2adcbbc9"
+  },
+  "services/orion-substrate-runtime/tests/test_brain_frame_worker.py": {
+    "mtime": 1783903398.647444,
+    "ast_hash": "d472c7968c191822777d3b9758361d2c",
+    "semantic_hash": "d472c7968c191822777d3b9758361d2c"
+  },
+  "services/orion-substrate-runtime/tests/test_chat_session_route_arbitration_endpoints.py": {
+    "mtime": 1783918729.2293985,
+    "ast_hash": "c6624accce8be2a4e1fa9d019583db5a",
+    "semantic_hash": "c6624accce8be2a4e1fa9d019583db5a"
+  },
+  "services/orion-substrate-runtime/tests/test_cursor_reset_auth.py": {
+    "mtime": 1781395651.2175694,
+    "ast_hash": "6aa0b9dac97142ba7a1ac5ad4106189f",
+    "semantic_hash": "6aa0b9dac97142ba7a1ac5ad4106189f"
+  },
+  "services/orion-substrate-runtime/tests/test_cursor_tail_seed.py": {
+    "mtime": 1781395651.2185693,
+    "ast_hash": "da193831761b2f42c7b57ca57796e472",
+    "semantic_hash": "da193831761b2f42c7b57ca57796e472"
+  },
+  "services/orion-substrate-runtime/tests/test_embodiment_c_hook.py": {
+    "mtime": 1783450708.649728,
+    "ast_hash": "cf94e31ed56fc74869e4c9003dc87a0b",
+    "semantic_hash": "cf94e31ed56fc74869e4c9003dc87a0b"
+  },
+  "services/orion-substrate-runtime/tests/test_embodiment_perception_ingest.py": {
+    "mtime": 1783450708.649728,
+    "ast_hash": "f2fdab3116a1c27e6c685a1b9932e7da",
+    "semantic_hash": "f2fdab3116a1c27e6c685a1b9932e7da"
+  },
+  "services/orion-substrate-runtime/tests/test_execution_grammar_fetch.py": {
+    "mtime": 1783571153.8761108,
+    "ast_hash": "5c60ce97a140827a6887b8de66e0a02f",
+    "semantic_hash": "5c60ce97a140827a6887b8de66e0a02f"
+  },
+  "services/orion-substrate-runtime/tests/test_execution_trajectory_endpoint.py": {
+    "mtime": 1783622541.3545249,
+    "ast_hash": "7a38f9df69f6a443fbcc5348d676c990",
+    "semantic_hash": "7a38f9df69f6a443fbcc5348d676c990"
+  },
+  "services/orion-substrate-runtime/tests/test_finalize_appraisal_rpc.py": {
+    "mtime": 1783291410.028702,
+    "ast_hash": "ffeafb7232a8cf2b1f8336a30dc109d5",
+    "semantic_hash": "ffeafb7232a8cf2b1f8336a30dc109d5"
+  },
+  "services/orion-substrate-runtime/tests/test_goal_context_listener.py": {
+    "mtime": 1783655498.7461991,
+    "ast_hash": "889f8038c939319ef525d7f59b4de650",
+    "semantic_hash": "889f8038c939319ef525d7f59b4de650"
+  },
+  "services/orion-substrate-runtime/tests/test_grammar_consumer_integration.py": {
+    "mtime": 1781395651.2185693,
+    "ast_hash": "da434af0cea55212cdc47ad8867f549f",
+    "semantic_hash": "da434af0cea55212cdc47ad8867f549f"
+  },
+  "services/orion-substrate-runtime/tests/test_grammar_truth_reducer_health.py": {
+    "mtime": 1783960753.1758304,
+    "ast_hash": "57a2548c91b0f775e6cba1cc1723ba88",
+    "semantic_hash": "57a2548c91b0f775e6cba1cc1723ba88"
+  },
+  "services/orion-substrate-runtime/tests/test_health_monitor.py": {
+    "mtime": 1783965578.734708,
+    "ast_hash": "949a16c6355195890df3d27bf9a9ee68",
+    "semantic_hash": "949a16c6355195890df3d27bf9a9ee68"
+  },
+  "services/orion-substrate-runtime/tests/test_post_turn_closure_listener.py": {
+    "mtime": 1783300876.6829147,
+    "ast_hash": "85f78c63b162d7c32671b3de391fbd67",
+    "semantic_hash": "85f78c63b162d7c32671b3de391fbd67"
+  },
+  "services/orion-substrate-runtime/tests/test_quarantine_truth.py": {
+    "mtime": 1781585632.7509527,
+    "ast_hash": "4f9d4659fa4f197823102d07958b4931",
+    "semantic_hash": "4f9d4659fa4f197823102d07958b4931"
+  },
+  "services/orion-substrate-runtime/tests/test_reducer_health.py": {
+    "mtime": 1781584864.5205817,
+    "ast_hash": "ffe3d9d427484c3b70700cb88821fdcd",
+    "semantic_hash": "ffe3d9d427484c3b70700cb88821fdcd"
+  },
+  "services/orion-substrate-runtime/tests/test_store_observability_writers.py": {
+    "mtime": 1783807363.1157985,
+    "ast_hash": "7ef04ead9381317b3a90967d7cbd3c65",
+    "semantic_hash": "7ef04ead9381317b3a90967d7cbd3c65"
+  },
+  "services/orion-substrate-runtime/tests/test_turn_referent_store.py": {
+    "mtime": 1783396080.017995,
+    "ast_hash": "b108f264798369b3cda78bc33bcee784",
+    "semantic_hash": "b108f264798369b3cda78bc33bcee784"
+  },
+  "services/orion-substrate-runtime/tests/test_worker_attention_broadcast_tick.py": {
+    "mtime": 1783105164.3590727,
+    "ast_hash": "ad16c05ebc42e96cd1090ed675ccbbc6",
+    "semantic_hash": "ad16c05ebc42e96cd1090ed675ccbbc6"
+  },
+  "services/orion-substrate-runtime/tests/test_worker_dynamics_tick.py": {
+    "mtime": 1782874038.2569726,
+    "ast_hash": "0330bfd6beb50e347ac0ba060a785906",
+    "semantic_hash": "0330bfd6beb50e347ac0ba060a785906"
+  },
+  "services/orion-substrate-runtime/tests/test_worker_endogenous_curiosity_tick.py": {
+    "mtime": 1783807362.662784,
+    "ast_hash": "db93f57c5822e98a708469a48c4df8e5",
+    "semantic_hash": "db93f57c5822e98a708469a48c4df8e5"
+  },
+  "services/orion-substrate-runtime/tests/test_worker_episodic_tick.py": {
+    "mtime": 1782955647.2244186,
+    "ast_hash": "12089afe2556999a381f99fc6a1a614d",
+    "semantic_hash": "12089afe2556999a381f99fc6a1a614d"
+  },
+  "services/orion-substrate-runtime/tests/test_worker_independent_reducers.py": {
+    "mtime": 1781585632.7509527,
+    "ast_hash": "8d1c8f5b49059c9852d22ce7e56b24b2",
+    "semantic_hash": "8d1c8f5b49059c9852d22ce7e56b24b2"
+  },
+  "services/orion-substrate-runtime/tests/test_worker_prediction_error_node.py": {
+    "mtime": 1783110541.1449034,
+    "ast_hash": "1aa4f0fb6f5ac103e4f8f3929e54952b",
+    "semantic_hash": "1aa4f0fb6f5ac103e4f8f3929e54952b"
+  },
+  "services/orion-substrate-runtime/tests/test_worker_reducer.py": {
+    "mtime": 1781585632.7509527,
+    "ast_hash": "8ece54f439808ecafd7b07d2f90b5681",
+    "semantic_hash": "8ece54f439808ecafd7b07d2f90b5681"
+  },
+  "services/orion-substrate-telemetry/app/__init__.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-substrate-telemetry/app/db.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "a20ecbf5a3192119ba57f2780f66c1a0",
+    "semantic_hash": "a20ecbf5a3192119ba57f2780f66c1a0"
+  },
+  "services/orion-substrate-telemetry/app/main.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "55a5fb4ab0d94300a07cde9369b87d22",
+    "semantic_hash": "55a5fb4ab0d94300a07cde9369b87d22"
+  },
+  "services/orion-substrate-telemetry/app/pg_pool.py": {
+    "mtime": 1778901838.3913949,
+    "ast_hash": "b632e817f33d45ed60324bc583b76593",
+    "semantic_hash": "b632e817f33d45ed60324bc583b76593"
+  },
+  "services/orion-substrate-telemetry/app/service.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "3f2dcf024e1e0e46b8e11bffddd11c1e",
+    "semantic_hash": "3f2dcf024e1e0e46b8e11bffddd11c1e"
+  },
+  "services/orion-substrate-telemetry/app/settings.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "727d1337571330ff69d945f2a2a7a517",
+    "semantic_hash": "727d1337571330ff69d945f2a2a7a517"
+  },
+  "services/orion-substrate-telemetry/tests/test_db_queries.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "452475063d645d1223ee80d1f22afa7a",
+    "semantic_hash": "452475063d645d1223ee80d1f22afa7a"
+  },
+  "services/orion-substrate-telemetry/tests/test_decode_persist_map.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "062031cb93a26e297e19bcc23689bf81",
+    "semantic_hash": "062031cb93a26e297e19bcc23689bf81"
+  },
+  "services/orion-substrate-telemetry/tests/test_integration_postgres.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "c77c95ac1a202691dec3c55cbc510beb",
+    "semantic_hash": "c77c95ac1a202691dec3c55cbc510beb"
+  },
+  "services/orion-thought/app/__init__.py": {
+    "mtime": 1783291410.029702,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-thought/app/broadcast_reader.py": {
+    "mtime": 1783388479.8264327,
+    "ast_hash": "05e0c6589629a9df547458d7e16e4f96",
+    "semantic_hash": "05e0c6589629a9df547458d7e16e4f96"
+  },
+  "services/orion-thought/app/bus_listener.py": {
+    "mtime": 1783805454.2243037,
+    "ast_hash": "2088a3840e437880964b0be11efe5e05",
+    "semantic_hash": "2088a3840e437880964b0be11efe5e05"
+  },
+  "services/orion-thought/app/chain.py": {
+    "mtime": 1783903398.6484442,
+    "ast_hash": "d6c2aa44d2b9454d1007ef9d6eb201d3",
+    "semantic_hash": "d6c2aa44d2b9454d1007ef9d6eb201d3"
+  },
+  "services/orion-thought/app/cortex_client.py": {
+    "mtime": 1783291410.029702,
+    "ast_hash": "cee045b8b7d440dd5358776996e5b161",
+    "semantic_hash": "cee045b8b7d440dd5358776996e5b161"
+  },
+  "services/orion-thought/app/grounding.py": {
+    "mtime": 1783355701.796141,
+    "ast_hash": "0f0710ab40b6d771f5264359723fd7f0",
+    "semantic_hash": "0f0710ab40b6d771f5264359723fd7f0"
+  },
+  "services/orion-thought/app/main.py": {
+    "mtime": 1783615607.988946,
+    "ast_hash": "d7469a319bf40e5d0ccfc1e725249ea7",
+    "semantic_hash": "d7469a319bf40e5d0ccfc1e725249ea7"
+  },
+  "services/orion-thought/app/mind_enrichment.py": {
+    "mtime": 1783473099.1425624,
+    "ast_hash": "9cb65fce7374e709d94a91f63c20ec1e",
+    "semantic_hash": "9cb65fce7374e709d94a91f63c20ec1e"
+  },
+  "services/orion-thought/app/reasoning_activity.py": {
+    "mtime": 1783615607.988946,
+    "ast_hash": "5e21ed48c7eb811ac399740df056debe",
+    "semantic_hash": "5e21ed48c7eb811ac399740df056debe"
+  },
+  "services/orion-thought/app/resonance_monitor.py": {
+    "mtime": 1783903398.6484442,
+    "ast_hash": "ee60e85314452a04878991287c7f756d",
+    "semantic_hash": "ee60e85314452a04878991287c7f756d"
+  },
+  "services/orion-thought/app/reverie.py": {
+    "mtime": 1783807362.259771,
+    "ast_hash": "ed68b7545836bfb9d6a9e2c45da76d6d",
+    "semantic_hash": "ed68b7545836bfb9d6a9e2c45da76d6d"
+  },
+  "services/orion-thought/app/settings.py": {
+    "mtime": 1783903398.6484442,
+    "ast_hash": "61e2eca8df6f5031878a21b879d67e0a",
+    "semantic_hash": "61e2eca8df6f5031878a21b879d67e0a"
+  },
+  "services/orion-thought/app/store.py": {
+    "mtime": 1783903398.6484442,
+    "ast_hash": "a03fc241bc0cc0afd2062fb75043c7f4",
+    "semantic_hash": "a03fc241bc0cc0afd2062fb75043c7f4"
+  },
+  "services/orion-thought/evals/test_mind_enrichment_eval.py": {
+    "mtime": 1783473099.1435623,
+    "ast_hash": "2944c10b38ceca9b06a8072c6d82d897",
+    "semantic_hash": "2944c10b38ceca9b06a8072c6d82d897"
+  },
+  "services/orion-thought/evals/test_reverie_hollow_guard_eval.py": {
+    "mtime": 1783396080.018995,
+    "ast_hash": "f3b564f9c08f4eadddddf5a3a2512a70",
+    "semantic_hash": "f3b564f9c08f4eadddddf5a3a2512a70"
+  },
+  "services/orion-thought/tests/conftest.py": {
+    "mtime": 1783458889.5729458,
+    "ast_hash": "93e57ae828e8855d93f682c64637047c",
+    "semantic_hash": "93e57ae828e8855d93f682c64637047c"
+  },
+  "services/orion-thought/tests/test_bus_listener_errors.py": {
+    "mtime": 1783298706.2114503,
+    "ast_hash": "96eb4b30dc2978b98370c90eb4264e1a",
+    "semantic_hash": "96eb4b30dc2978b98370c90eb4264e1a"
+  },
+  "services/orion-thought/tests/test_bus_listener_nonblocking_dispatch.py": {
+    "mtime": 1783614403.6182735,
+    "ast_hash": "d49c74972f53de3612f8c86aca5dde98",
+    "semantic_hash": "d49c74972f53de3612f8c86aca5dde98"
+  },
+  "services/orion-thought/tests/test_bus_listener_pubsub_health.py": {
+    "mtime": 1783555541.5456743,
+    "ast_hash": "e85edc2e2d29d153be5d137cbc1067b0",
+    "semantic_hash": "e85edc2e2d29d153be5d137cbc1067b0"
+  },
+  "services/orion-thought/tests/test_mind_artifact_mode_tag.py": {
+    "mtime": 1783473099.1445625,
+    "ast_hash": "b27548b5059b5990d128b9dc740189f4",
+    "semantic_hash": "b27548b5059b5990d128b9dc740189f4"
+  },
+  "services/orion-thought/tests/test_mind_coloring_selector.py": {
+    "mtime": 1783473099.1445625,
+    "ast_hash": "23d4128fd034ad100e33bf66aba81fec",
+    "semantic_hash": "23d4128fd034ad100e33bf66aba81fec"
+  },
+  "services/orion-thought/tests/test_mind_enrichment_fail_open.py": {
+    "mtime": 1783473099.1445625,
+    "ast_hash": "e99e071111df3faa924069516aabc509",
+    "semantic_hash": "e99e071111df3faa924069516aabc509"
+  },
+  "services/orion-thought/tests/test_mind_http_client.py": {
+    "mtime": 1783473099.1445625,
+    "ast_hash": "9a343ecc5f0d06978e2220fc3b5fba21",
+    "semantic_hash": "9a343ecc5f0d06978e2220fc3b5fba21"
+  },
+  "services/orion-thought/tests/test_mind_light_snapshot.py": {
+    "mtime": 1783473099.1455624,
+    "ast_hash": "5dae769df66e1aa9054dcf500e6c1e8d",
+    "semantic_hash": "5dae769df66e1aa9054dcf500e6c1e8d"
+  },
+  "services/orion-thought/tests/test_reasoning_activity.py": {
+    "mtime": 1783615607.988946,
+    "ast_hash": "583dab2274dcfc2abc3246008783a0f1",
+    "semantic_hash": "583dab2274dcfc2abc3246008783a0f1"
+  },
+  "services/orion-thought/tests/test_resonance_monitor.py": {
+    "mtime": 1783903398.6484442,
+    "ast_hash": "ddf158828cb166ea2ff367a5540db6fc",
+    "semantic_hash": "ddf158828cb166ea2ff367a5540db6fc"
+  },
+  "services/orion-thought/tests/test_reverie_chain.py": {
+    "mtime": 1783355701.7971408,
+    "ast_hash": "73d9db71574faf9d199929372cb07196",
+    "semantic_hash": "73d9db71574faf9d199929372cb07196"
+  },
+  "services/orion-thought/tests/test_reverie_compaction_request.py": {
+    "mtime": 1783355701.7971408,
+    "ast_hash": "50560ed8f4653fc92b4316ecc1dcd276",
+    "semantic_hash": "50560ed8f4653fc92b4316ecc1dcd276"
+  },
+  "services/orion-thought/tests/test_reverie_grounding.py": {
+    "mtime": 1783355701.7971408,
+    "ast_hash": "01cbbd6edc9315f749fb7fbf8d272d92",
+    "semantic_hash": "01cbbd6edc9315f749fb7fbf8d272d92"
+  },
+  "services/orion-thought/tests/test_reverie_salience_trace.py": {
+    "mtime": 1783447063.2623706,
+    "ast_hash": "4d1c03a72535edf41c96dc606903e526",
+    "semantic_hash": "4d1c03a72535edf41c96dc606903e526"
+  },
+  "services/orion-thought/tests/test_reverie_salience_v2.py": {
+    "mtime": 1783447063.2623706,
+    "ast_hash": "ff15b08edacfd05d6c1ba179a953c51f",
+    "semantic_hash": "ff15b08edacfd05d6c1ba179a953c51f"
+  },
+  "services/orion-thought/tests/test_reverie_semantic_lift.py": {
+    "mtime": 1783396080.018995,
+    "ast_hash": "cf6e561a297a268f3fd8f0069d5b66ae",
+    "semantic_hash": "cf6e561a297a268f3fd8f0069d5b66ae"
+  },
+  "services/orion-thought/tests/test_reverie_semantic_lift_failopen.py": {
+    "mtime": 1783402731.3013198,
+    "ast_hash": "a1c760e9d2206043320a2a62a48ab2fd",
+    "semantic_hash": "a1c760e9d2206043320a2a62a48ab2fd"
+  },
+  "services/orion-thought/tests/test_reverie_spontaneous_thought.py": {
+    "mtime": 1783388479.8274329,
+    "ast_hash": "16856e2bb55ae548f5584d4b16092c46",
+    "semantic_hash": "16856e2bb55ae548f5584d4b16092c46"
+  },
+  "services/orion-thought/tests/test_reverie_thin_import_boundary.py": {
+    "mtime": 1783450708.649728,
+    "ast_hash": "c2c3e7478d7f4d82532d7ff9bb7e9a07",
+    "semantic_hash": "c2c3e7478d7f4d82532d7ff9bb7e9a07"
+  },
+  "services/orion-thought/tests/test_settings_mind_enrichment.py": {
+    "mtime": 1783615212.4829123,
+    "ast_hash": "db413b0534257f09048756dc495f422a",
+    "semantic_hash": "db413b0534257f09048756dc495f422a"
+  },
+  "services/orion-thought/tests/test_settings_salience_flags.py": {
+    "mtime": 1783447063.2623706,
+    "ast_hash": "a84190b2e299d5f668f46b3fd84185a8",
+    "semantic_hash": "a84190b2e299d5f668f46b3fd84185a8"
+  },
+  "services/orion-thought/tests/test_stance_context_mind_coloring.py": {
+    "mtime": 1783473099.1455624,
+    "ast_hash": "fa4ae147671899d2950a48cfa53665e7",
+    "semantic_hash": "fa4ae147671899d2950a48cfa53665e7"
+  },
+  "services/orion-thought/tests/test_stance_prompt_renders_coloring.py": {
+    "mtime": 1783473099.1455624,
+    "ast_hash": "bdd8693e3ed79f1fe8e7261a2153dbb3",
+    "semantic_hash": "bdd8693e3ed79f1fe8e7261a2153dbb3"
+  },
+  "services/orion-thought/tests/test_stance_react_grounding_capsule.py": {
+    "mtime": 1783740584.5954983,
+    "ast_hash": "c42677d22f5046847bdcfa50a7a80e7b",
+    "semantic_hash": "c42677d22f5046847bdcfa50a7a80e7b"
+  },
+  "services/orion-thought/tests/test_thought_artifact_published.py": {
+    "mtime": 1783291410.0307019,
+    "ast_hash": "98bbb5a38d79fa5c68185f2a2f3f6761",
+    "semantic_hash": "98bbb5a38d79fa5c68185f2a2f3f6761"
+  },
+  "services/orion-topic-foundry/app/__init__.py": {
+    "mtime": 1773975149.9707859,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-topic-foundry/app/main.py": {
+    "mtime": 1777179232.1029155,
+    "ast_hash": "bd73d233b52fafdf47999ed535f855fb",
+    "semantic_hash": "bd73d233b52fafdf47999ed535f855fb"
+  },
+  "services/orion-topic-foundry/app/models.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "e8816428fd15615e0aea0f02c8848eb7",
+    "semantic_hash": "e8816428fd15615e0aea0f02c8848eb7"
+  },
+  "services/orion-topic-foundry/app/pipelines/__init__.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/__init__.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "57b041296951f01876d1cf08aabf8dfc",
+    "semantic_hash": "57b041296951f01876d1cf08aabf8dfc"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/anchors.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "e906cb619afff4af247dea887f28f203",
+    "semantic_hash": "e906cb619afff4af247dea887f28f203"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/blocks.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "03d91f36a7564872e77cdc7aba08de6a",
+    "semantic_hash": "03d91f36a7564872e77cdc7aba08de6a"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/claims.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "364a311f3f88f8715f4872e04550c40d",
+    "semantic_hash": "364a311f3f88f8715f4872e04550c40d"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/cli.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "4e9f6963d5f7427dc3063abe875f5c56",
+    "semantic_hash": "4e9f6963d5f7427dc3063abe875f5c56"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/episodes.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "1cb8a644f43ad370809852f66f908b08",
+    "semantic_hash": "1cb8a644f43ad370809852f66f908b08"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/graph.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "23cec93150d2b4c9439071cbaed4b5e1",
+    "semantic_hash": "23cec93150d2b4c9439071cbaed4b5e1"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/indexer.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "15c705f764e43305beb108fa78ecf985",
+    "semantic_hash": "15c705f764e43305beb108fa78ecf985"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/io_utils.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "97b2237196f50d234ac5de7fe53b565f",
+    "semantic_hash": "97b2237196f50d234ac5de7fe53b565f"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/orchestrator.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "0ece3dd42e0c8c2281372674320fd7a8",
+    "semantic_hash": "0ece3dd42e0c8c2281372674320fd7a8"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/renderer.py": {
+    "mtime": 1777748523.3405993,
+    "ast_hash": "8ddb829d22a752ec791217c8aac60a6a",
+    "semantic_hash": "8ddb829d22a752ec791217c8aac60a6a"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/repository.py": {
+    "mtime": 1777748523.3415995,
+    "ast_hash": "89fe336fd553b32d61792f0499881189",
+    "semantic_hash": "89fe336fd553b32d61792f0499881189"
+  },
+  "services/orion-topic-foundry/app/pipelines/chat_corpus_builder/types.py": {
+    "mtime": 1777748523.3415995,
+    "ast_hash": "611f291264a7eee3c266e3b1df2b5e44",
+    "semantic_hash": "611f291264a7eee3c266e3b1df2b5e44"
+  },
+  "services/orion-topic-foundry/app/routers/__init__.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-topic-foundry/app/routers/capabilities.py": {
+    "mtime": 1777748523.3415995,
+    "ast_hash": "dd0fee4c0a613281cd34b91f67f7a6a0",
+    "semantic_hash": "dd0fee4c0a613281cd34b91f67f7a6a0"
+  },
+  "services/orion-topic-foundry/app/routers/datasets.py": {
+    "mtime": 1777179232.1029155,
+    "ast_hash": "20c5e24964d52b5ff3e04538e477f7b2",
+    "semantic_hash": "20c5e24964d52b5ff3e04538e477f7b2"
+  },
+  "services/orion-topic-foundry/app/routers/drift.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "3228c3da876ae4ab46a35e4a65d7e7cf",
+    "semantic_hash": "3228c3da876ae4ab46a35e4a65d7e7cf"
+  },
+  "services/orion-topic-foundry/app/routers/edges.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "bc84489b4159169ef035f59a83b5b757",
+    "semantic_hash": "bc84489b4159169ef035f59a83b5b757"
+  },
+  "services/orion-topic-foundry/app/routers/events.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "52297ddb2c107aa4bd992b4d8179973b",
+    "semantic_hash": "52297ddb2c107aa4bd992b4d8179973b"
+  },
+  "services/orion-topic-foundry/app/routers/introspect.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "1d5f9e558db28499320008598983a47e",
+    "semantic_hash": "1d5f9e558db28499320008598983a47e"
+  },
+  "services/orion-topic-foundry/app/routers/models.py": {
+    "mtime": 1777179232.1029155,
+    "ast_hash": "03e0c6bd66882e487bcd03e424b169d5",
+    "semantic_hash": "03e0c6bd66882e487bcd03e424b169d5"
+  },
+  "services/orion-topic-foundry/app/routers/runs.py": {
+    "mtime": 1777179232.1029155,
+    "ast_hash": "68ec0c635ffb695f9fdd43f03896794e",
+    "semantic_hash": "68ec0c635ffb695f9fdd43f03896794e"
+  },
+  "services/orion-topic-foundry/app/routers/segments.py": {
+    "mtime": 1774480147.7563217,
+    "ast_hash": "9ffdd6a9b873456ee4bf0a5691d33762",
+    "semantic_hash": "9ffdd6a9b873456ee4bf0a5691d33762"
+  },
+  "services/orion-topic-foundry/app/routers/topics.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "c9b2233de8002a103caff539d88db99b",
+    "semantic_hash": "c9b2233de8002a103caff539d88db99b"
+  },
+  "services/orion-topic-foundry/app/services/__init__.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-topic-foundry/app/services/boundary_judge.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "f7aca46cadf836de936f85894fa30259",
+    "semantic_hash": "f7aca46cadf836de936f85894fa30259"
+  },
+  "services/orion-topic-foundry/app/services/bus_events.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "44fd2403e021e17024de34904773d7a9",
+    "semantic_hash": "44fd2403e021e17024de34904773d7a9"
+  },
+  "services/orion-topic-foundry/app/services/conversation_overrides.py": {
+    "mtime": 1773975149.971786,
+    "ast_hash": "989fb751bec1a655b2e2d79ec292ec27",
+    "semantic_hash": "989fb751bec1a655b2e2d79ec292ec27"
+  },
+  "services/orion-topic-foundry/app/services/data_access.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "cd9bb432b2e75ed90d97469fcaff8eab",
+    "semantic_hash": "cd9bb432b2e75ed90d97469fcaff8eab"
+  },
+  "services/orion-topic-foundry/app/services/drift.py": {
+    "mtime": 1777748523.3415995,
+    "ast_hash": "c042e672a16397cc65884fb65a32a2f3",
+    "semantic_hash": "c042e672a16397cc65884fb65a32a2f3"
+  },
+  "services/orion-topic-foundry/app/services/embedding_client.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "f3f0b94c4bb649127636d21397ea6c47",
+    "semantic_hash": "f3f0b94c4bb649127636d21397ea6c47"
+  },
+  "services/orion-topic-foundry/app/services/enrichment.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "56d7588e7fcd4ec8203c4f08bd99ca17",
+    "semantic_hash": "56d7588e7fcd4ec8203c4f08bd99ca17"
+  },
+  "services/orion-topic-foundry/app/services/kg_edges.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "c54d0ab772e8c6e856ecc80aa3784537",
+    "semantic_hash": "c54d0ab772e8c6e856ecc80aa3784537"
+  },
+  "services/orion-topic-foundry/app/services/llm_client.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "2d8951c89682fca7a870daaa3d0da2fe",
+    "semantic_hash": "2d8951c89682fca7a870daaa3d0da2fe"
+  },
+  "services/orion-topic-foundry/app/services/metrics.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "f435e17eb6fa9be003428ed27c520886",
+    "semantic_hash": "f435e17eb6fa9be003428ed27c520886"
+  },
+  "services/orion-topic-foundry/app/services/preview.py": {
+    "mtime": 1777179232.1029155,
+    "ast_hash": "58609e756afe25f13b498958608d5bd9",
+    "semantic_hash": "58609e756afe25f13b498958608d5bd9"
+  },
+  "services/orion-topic-foundry/app/services/readiness.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "4d97df3df49f5d7e4964919b3898cae3",
+    "semantic_hash": "4d97df3df49f5d7e4964919b3898cae3"
+  },
+  "services/orion-topic-foundry/app/services/semantic_segmentation.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "e62f5b62abd016e9ff2bd58f46015673",
+    "semantic_hash": "e62f5b62abd016e9ff2bd58f46015673"
+  },
+  "services/orion-topic-foundry/app/services/spec_hash.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "c4afea5a211785c220779618919b2dd7",
+    "semantic_hash": "c4afea5a211785c220779618919b2dd7"
+  },
+  "services/orion-topic-foundry/app/services/taxonomy.py": {
+    "mtime": 1773975149.972786,
+    "ast_hash": "2d51f9208cad0542263eac95cb63e9a2",
+    "semantic_hash": "2d51f9208cad0542263eac95cb63e9a2"
+  },
+  "services/orion-topic-foundry/app/services/training.py": {
+    "mtime": 1777748523.3415995,
+    "ast_hash": "15315280dbc221b8e301c2945b33115f",
+    "semantic_hash": "15315280dbc221b8e301c2945b33115f"
+  },
+  "services/orion-topic-foundry/app/services/types.py": {
+    "mtime": 1773975149.9737859,
+    "ast_hash": "cf96281ae94c55c780588f0c0308ffeb",
+    "semantic_hash": "cf96281ae94c55c780588f0c0308ffeb"
+  },
+  "services/orion-topic-foundry/app/services/windowing.py": {
+    "mtime": 1777748523.3415995,
+    "ast_hash": "99abcc8ef54a3bd51521eec5e3812f3a",
+    "semantic_hash": "99abcc8ef54a3bd51521eec5e3812f3a"
+  },
+  "services/orion-topic-foundry/app/settings.py": {
+    "mtime": 1777748523.3415995,
+    "ast_hash": "9b4ca529b05a8a4081160c917abda9c5",
+    "semantic_hash": "9b4ca529b05a8a4081160c917abda9c5"
+  },
+  "services/orion-topic-foundry/app/storage/__init__.py": {
+    "mtime": 1773975149.9737859,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-topic-foundry/app/storage/ddl.py": {
+    "mtime": 1777179232.1039155,
+    "ast_hash": "906d4d8be478ae3f5a894fa7a5bff616",
+    "semantic_hash": "906d4d8be478ae3f5a894fa7a5bff616"
+  },
+  "services/orion-topic-foundry/app/storage/migrations/20260207_add_boundary_column.sql": {
+    "mtime": 1773975149.9737859,
+    "ast_hash": "5b23d28688ec5487054649e87200ccda",
+    "semantic_hash": "5b23d28688ec5487054649e87200ccda"
+  },
+  "services/orion-topic-foundry/app/storage/pg.py": {
+    "mtime": 1773975149.9737859,
+    "ast_hash": "57a973da3e8ce658a69e7ec5072a70ee",
+    "semantic_hash": "57a973da3e8ce658a69e7ec5072a70ee"
+  },
+  "services/orion-topic-foundry/app/storage/repository.py": {
+    "mtime": 1777179232.1039155,
+    "ast_hash": "1a4cc8b00bd5d4b24b1fe6b805092d65",
+    "semantic_hash": "1a4cc8b00bd5d4b24b1fe6b805092d65"
+  },
+  "services/orion-topic-foundry/app/topic_engine.py": {
+    "mtime": 1777748523.3415995,
+    "ast_hash": "a20c51399fcb57aa16f5b3327491cbca",
+    "semantic_hash": "a20c51399fcb57aa16f5b3327491cbca"
+  },
+  "services/orion-topic-foundry/scripts/run_chat_corpus_builder.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "062c898efd01c324e90fb36a9b8dce66",
+    "semantic_hash": "062c898efd01c324e90fb36a9b8dce66"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_capabilities_and_snippets.sh": {
+    "mtime": 1773975149.9737859,
+    "ast_hash": "034e5d96c8571c4c28b4ea8a78e40307",
+    "semantic_hash": "034e5d96c8571c4c28b4ea8a78e40307"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_drift.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "8924da10d498d63bac4290b7ff5eec90",
+    "semantic_hash": "8924da10d498d63bac4290b7ff5eec90"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_drift_list.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "ea0dcbe48b06d4ca83960e5114cfc8d9",
+    "semantic_hash": "ea0dcbe48b06d4ca83960e5114cfc8d9"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_enrich.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "0a2326b013518c07bbeec3a2c8c1a116",
+    "semantic_hash": "0a2326b013518c07bbeec3a2c8c1a116"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_events.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "d237e57f77651d639e1036827923ea0f",
+    "semantic_hash": "d237e57f77651d639e1036827923ea0f"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_facets_and_search.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "7225cf70c8388bdbfef2e4a46c5581fa",
+    "semantic_hash": "7225cf70c8388bdbfef2e4a46c5581fa"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_health.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "edd5a54f982d00ebc9d7d58045b607fe",
+    "semantic_hash": "edd5a54f982d00ebc9d7d58045b607fe"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_kg_edges.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "ab2800e20126cdd1adc0272bfa8e1c9d",
+    "semantic_hash": "ab2800e20126cdd1adc0272bfa8e1c9d"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_kg_edges_list.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "92bb7329bd239e27745b719b5da36a1b",
+    "semantic_hash": "92bb7329bd239e27745b719b5da36a1b"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_llm_segmentation.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "058b0b0992d83ed2df9474b6c3dc7ee9",
+    "semantic_hash": "058b0b0992d83ed2df9474b6c3dc7ee9"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_preview.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "5836b43f7d3fe148898bd1bdaaa6540d",
+    "semantic_hash": "5836b43f7d3fe148898bd1bdaaa6540d"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_runs_and_segments_paging.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "44971e35223baf2e77e21cdf4bdd5a0e",
+    "semantic_hash": "44971e35223baf2e77e21cdf4bdd5a0e"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_topics.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "3de320e2a2d0aebff5ded7076361cbb6",
+    "semantic_hash": "3de320e2a2d0aebff5ded7076361cbb6"
+  },
+  "services/orion-topic-foundry/scripts/smoke_topic_foundry_train_and_poll.sh": {
+    "mtime": 1773975149.9747858,
+    "ast_hash": "effc32f81f182e93c2a2c74ab77bf0f7",
+    "semantic_hash": "effc32f81f182e93c2a2c74ab77bf0f7"
+  },
+  "services/orion-topic-foundry/tests/test_chat_corpus_builder_renderer.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "c73e6f9cecac67acf829420ee5c05914",
+    "semantic_hash": "c73e6f9cecac67acf829420ee5c05914"
+  },
+  "services/orion-topic-foundry/tests/test_chat_corpus_builder_stages.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "8d13dd25bc13580a95772f22e9dcd6ae",
+    "semantic_hash": "8d13dd25bc13580a95772f22e9dcd6ae"
+  },
+  "services/orion-vector-db/scripts/chroma_preflight.py": {
+    "mtime": 1776554226.8358285,
+    "ast_hash": "b8c2a4edc51b5eefe41701a9b220a02b",
+    "semantic_hash": "b8c2a4edc51b5eefe41701a9b220a02b"
+  },
+  "services/orion-vector-host/app/embedder.py": {
+    "mtime": 1768940476.2287254,
+    "ast_hash": "25220526940a75ee294fb987b56ab09e",
+    "semantic_hash": "25220526940a75ee294fb987b56ab09e"
+  },
+  "services/orion-vector-host/app/main.py": {
+    "mtime": 1774236180.458385,
+    "ast_hash": "9012cb04784e1787ae1217a9a3c0ed87",
+    "semantic_hash": "9012cb04784e1787ae1217a9a3c0ed87"
+  },
+  "services/orion-vector-host/app/settings.py": {
+    "mtime": 1773975149.9777858,
+    "ast_hash": "706c1d1aa08f86da88dbe2987398621c",
+    "semantic_hash": "706c1d1aa08f86da88dbe2987398621c"
+  },
+  "services/orion-vector-host/scripts/smoke_chatgpt_ingest.py": {
+    "mtime": 1773975149.9777858,
+    "ast_hash": "72b99f811dbc3ec76f63809aa7ec0c68",
+    "semantic_hash": "72b99f811dbc3ec76f63809aa7ec0c68"
+  },
+  "services/orion-vector-host/scripts/smoke_gateway_style_embedding_flow.py": {
+    "mtime": 1768940476.2297254,
+    "ast_hash": "74eb054b0a1bfdd910b5c4212e7c3643",
+    "semantic_hash": "74eb054b0a1bfdd910b5c4212e7c3643"
+  },
+  "services/orion-vector-host/scripts/smoke_no_latent_leak.py": {
+    "mtime": 1768940476.2297254,
+    "ast_hash": "d9e9cae9d8d6776286b6fe8a8609840c",
+    "semantic_hash": "d9e9cae9d8d6776286b6fe8a8609840c"
+  },
+  "services/orion-vector-writer/app/chat_history.py": {
+    "mtime": 1769651229.377528,
+    "ast_hash": "772e14c3dabb25096fe31e024f01ceda",
+    "semantic_hash": "772e14c3dabb25096fe31e024f01ceda"
+  },
+  "services/orion-vector-writer/app/collection_browse.py": {
+    "mtime": 1763232123.4158907,
+    "ast_hash": "625582abf64b8c44ee01b7a57c51fce9",
+    "semantic_hash": "625582abf64b8c44ee01b7a57c51fce9"
+  },
+  "services/orion-vector-writer/app/main.py": {
+    "mtime": 1774759059.1633048,
+    "ast_hash": "b6341a4a0468310d23aa878d0125a313",
+    "semantic_hash": "b6341a4a0468310d23aa878d0125a313"
+  },
+  "services/orion-vector-writer/app/models.py": {
+    "mtime": 1768597909.9092293,
+    "ast_hash": "46661e975d0596bb0125f2eb5b1a82b2",
+    "semantic_hash": "46661e975d0596bb0125f2eb5b1a82b2"
+  },
+  "services/orion-vector-writer/app/query_similarity.py": {
+    "mtime": 1763232123.4158907,
+    "ast_hash": "77043a375d5687748a6eecb19a90e280",
+    "semantic_hash": "77043a375d5687748a6eecb19a90e280"
+  },
+  "services/orion-vector-writer/app/settings.py": {
+    "mtime": 1774759059.1633048,
+    "ast_hash": "f1953102220ca5f771441888359decc0",
+    "semantic_hash": "f1953102220ca5f771441888359decc0"
+  },
+  "services/orion-vector-writer/tests/test_chat_history_ingestion.py": {
+    "mtime": 1768597909.9092293,
+    "ast_hash": "a2a8f9b35d44141a47ad440928e6be35",
+    "semantic_hash": "a2a8f9b35d44141a47ad440928e6be35"
+  },
+  "services/orion-vision-council/app/__init__.py": {
+    "mtime": 1767676515.675107,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-vision-council/app/evidence_grounding.py": {
+    "mtime": 1783807364.4288404,
+    "ast_hash": "820b2c76e2b02829a97a0201efa81c39",
+    "semantic_hash": "820b2c76e2b02829a97a0201efa81c39"
+  },
+  "services/orion-vision-council/app/evidence_transition.py": {
+    "mtime": 1783218343.7024755,
+    "ast_hash": "2db05738e46b40123c9cae8de72b7319",
+    "semantic_hash": "2db05738e46b40123c9cae8de72b7319"
+  },
+  "services/orion-vision-council/app/interpretation.py": {
+    "mtime": 1783110541.1449034,
+    "ast_hash": "946c9452d34080fe8b95e13789315585",
+    "semantic_hash": "946c9452d34080fe8b95e13789315585"
+  },
+  "services/orion-vision-council/app/main.py": {
+    "mtime": 1783807361.8307576,
+    "ast_hash": "92b08ac14ebc95453d9cdbf4432f7c1c",
+    "semantic_hash": "92b08ac14ebc95453d9cdbf4432f7c1c"
+  },
+  "services/orion-vision-council/app/settings.py": {
+    "mtime": 1783218343.7034755,
+    "ast_hash": "d7bfb450ecf374fff1be609df93d9ae6",
+    "semantic_hash": "d7bfb450ecf374fff1be609df93d9ae6"
+  },
+  "services/orion-vision-council/tests/test_evidence_grounding.py": {
+    "mtime": 1783807364.3198369,
+    "ast_hash": "cc3278188abaf55c09771e3e4a9c3e43",
+    "semantic_hash": "cc3278188abaf55c09771e3e4a9c3e43"
+  },
+  "services/orion-vision-council/tests/test_evidence_transition.py": {
+    "mtime": 1783218343.7034755,
+    "ast_hash": "4c9b2abb4928e36857b78e80ebf3c73e",
+    "semantic_hash": "4c9b2abb4928e36857b78e80ebf3c73e"
+  },
+  "services/orion-vision-council/tests/test_interpretation_v2.py": {
+    "mtime": 1783107031.9859023,
+    "ast_hash": "a47e4bf8ca8e371748213d4c52e00dab",
+    "semantic_hash": "a47e4bf8ca8e371748213d4c52e00dab"
+  },
+  "services/orion-vision-council/tests/test_main_grounding_wiring.py": {
+    "mtime": 1783807364.326837,
+    "ast_hash": "8db1d83aae14d7e0c18052c836239a23",
+    "semantic_hash": "8db1d83aae14d7e0c18052c836239a23"
+  },
+  "services/orion-vision-council/tests/test_scene_belief.py": {
+    "mtime": 1783218343.7034755,
+    "ast_hash": "39bd553243453f0ba5c0c88623c038e1",
+    "semantic_hash": "39bd553243453f0ba5c0c88623c038e1"
+  },
+  "services/orion-vision-council/tests/test_transition_settings.py": {
+    "mtime": 1783218343.7034755,
+    "ast_hash": "49990eafa25f94baa8dc200160fbc10e",
+    "semantic_hash": "49990eafa25f94baa8dc200160fbc10e"
+  },
+  "services/orion-vision-edge/app/__init__.py": {
+    "mtime": 1765408123.8095906,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-vision-edge/app/activity.py": {
+    "mtime": 1783107031.9859023,
+    "ast_hash": "b33af6f0b750ca1b10dbfa76170d3a44",
+    "semantic_hash": "b33af6f0b750ca1b10dbfa76170d3a44"
+  },
+  "services/orion-vision-edge/app/capture.py": {
+    "mtime": 1767676515.6761072,
+    "ast_hash": "bd019fff914a9b8fed23eb39df249003",
+    "semantic_hash": "bd019fff914a9b8fed23eb39df249003"
+  },
+  "services/orion-vision-edge/app/capture_worker.py": {
+    "mtime": 1768597909.9092293,
+    "ast_hash": "fbce56fce78b27c28a2f65cf54faa5c8",
+    "semantic_hash": "fbce56fce78b27c28a2f65cf54faa5c8"
+  },
+  "services/orion-vision-edge/app/context.py": {
+    "mtime": 1767676515.677107,
+    "ast_hash": "e58ba76310aeee50e4e762fc8df91fbb",
+    "semantic_hash": "e58ba76310aeee50e4e762fc8df91fbb"
+  },
+  "services/orion-vision-edge/app/detector_worker.py": {
+    "mtime": 1783028252.5503528,
+    "ast_hash": "9343042b9c56b9ab14caa866815ddbc8",
+    "semantic_hash": "9343042b9c56b9ab14caa866815ddbc8"
+  },
+  "services/orion-vision-edge/app/detectors/__init__.py": {
+    "mtime": 1766255075.0216417,
+    "ast_hash": "03d4c4201af51251f5db3e285b05bbe7",
+    "semantic_hash": "03d4c4201af51251f5db3e285b05bbe7"
+  },
+  "services/orion-vision-edge/app/detectors/face.py": {
+    "mtime": 1763232123.4158907,
+    "ast_hash": "0fdd8b72cc707b4c3a63ba7da0981c49",
+    "semantic_hash": "0fdd8b72cc707b4c3a63ba7da0981c49"
+  },
+  "services/orion-vision-edge/app/detectors/motion.py": {
+    "mtime": 1763232123.4158907,
+    "ast_hash": "846736ed42ec986c09e4589db96efb7f",
+    "semantic_hash": "846736ed42ec986c09e4589db96efb7f"
+  },
+  "services/orion-vision-edge/app/detectors/presence.py": {
+    "mtime": 1763232123.4158907,
+    "ast_hash": "b2ae2c9e1c46f4cb7a9d5cf53a861d52",
+    "semantic_hash": "b2ae2c9e1c46f4cb7a9d5cf53a861d52"
+  },
+  "services/orion-vision-edge/app/detectors/yolo.py": {
+    "mtime": 1767676515.677107,
+    "ast_hash": "c6312d7473d0e2de5ff0d28aa81c5f93",
+    "semantic_hash": "c6312d7473d0e2de5ff0d28aa81c5f93"
+  },
+  "services/orion-vision-edge/app/main.py": {
+    "mtime": 1768597909.9102292,
+    "ast_hash": "d644e036b46c0ca088b0e489b3a6d5cf",
+    "semantic_hash": "d644e036b46c0ca088b0e489b3a6d5cf"
+  },
+  "services/orion-vision-edge/app/routes.py": {
+    "mtime": 1767676515.678107,
+    "ast_hash": "8eb18f737aee5ffb5e57308ef4d7ce42",
+    "semantic_hash": "8eb18f737aee5ffb5e57308ef4d7ce42"
+  },
+  "services/orion-vision-edge/app/schemas.py": {
+    "mtime": 1765408087.6843786,
+    "ast_hash": "eb80dc7bdbcfc77e77e65afaf2b65b4c",
+    "semantic_hash": "eb80dc7bdbcfc77e77e65afaf2b65b4c"
+  },
+  "services/orion-vision-edge/app/settings.py": {
+    "mtime": 1783028252.5503528,
+    "ast_hash": "378fa259d11d1a7237a3ac1d2311013c",
+    "semantic_hash": "378fa259d11d1a7237a3ac1d2311013c"
+  },
+  "services/orion-vision-edge/app/state.py": {
+    "mtime": 1765411254.0149755,
+    "ast_hash": "4b75a55a31e33d6cb37d3c4db33497be",
+    "semantic_hash": "4b75a55a31e33d6cb37d3c4db33497be"
+  },
+  "services/orion-vision-edge/app/utils.py": {
+    "mtime": 1765408791.1224658,
+    "ast_hash": "4c608df00000f64d5684f6fb3b889c63",
+    "semantic_hash": "4c608df00000f64d5684f6fb3b889c63"
+  },
+  "services/orion-vision-edge/tests/test_activity.py": {
+    "mtime": 1783028252.5503528,
+    "ast_hash": "96270f5a482a5eb6845eb268dc34996c",
+    "semantic_hash": "96270f5a482a5eb6845eb268dc34996c"
+  },
+  "services/orion-vision-frame-router/app/__init__.py": {
+    "mtime": 1779649387.8162987,
+    "ast_hash": "b19268d8719097968aa249967d6c94e8",
+    "semantic_hash": "b19268d8719097968aa249967d6c94e8"
+  },
+  "services/orion-vision-frame-router/app/dispatcher.py": {
+    "mtime": 1783110541.1459033,
+    "ast_hash": "c6ad7e016ff48532a96b293b14550a85",
+    "semantic_hash": "c6ad7e016ff48532a96b293b14550a85"
+  },
+  "services/orion-vision-frame-router/app/host_trigger.py": {
+    "mtime": 1783110541.1459033,
+    "ast_hash": "88843cfd445fff6f9b67c1c5ba3e2c93",
+    "semantic_hash": "88843cfd445fff6f9b67c1c5ba3e2c93"
+  },
+  "services/orion-vision-frame-router/app/main.py": {
+    "mtime": 1783110541.1459033,
+    "ast_hash": "2c2232d2fb414b0c7400cfca8e2b1280",
+    "semantic_hash": "2c2232d2fb414b0c7400cfca8e2b1280"
+  },
+  "services/orion-vision-frame-router/app/metrics.py": {
+    "mtime": 1783110541.1459033,
+    "ast_hash": "f453257e69015eb9d7a0076703d467c7",
+    "semantic_hash": "f453257e69015eb9d7a0076703d467c7"
+  },
+  "services/orion-vision-frame-router/app/policy.py": {
+    "mtime": 1783110541.1459033,
+    "ast_hash": "61b37e570f5bb6c2ffd46137d10e0b8f",
+    "semantic_hash": "61b37e570f5bb6c2ffd46137d10e0b8f"
+  },
+  "services/orion-vision-frame-router/app/settings.py": {
+    "mtime": 1783110541.1469033,
+    "ast_hash": "e5729d99e96c58dfc2d1009067de3f51",
+    "semantic_hash": "e5729d99e96c58dfc2d1009067de3f51"
+  },
+  "services/orion-vision-frame-router/app/state.py": {
+    "mtime": 1783110541.1469033,
+    "ast_hash": "0d905774d3447ac103d3239e108e0f33",
+    "semantic_hash": "0d905774d3447ac103d3239e108e0f33"
+  },
+  "services/orion-vision-frame-router/tests/test_default_request_config.py": {
+    "mtime": 1783028252.551353,
+    "ast_hash": "99a0cca615ce23cee4b4edd77815966b",
+    "semantic_hash": "99a0cca615ce23cee4b4edd77815966b"
+  },
+  "services/orion-vision-frame-router/tests/test_dispatcher.py": {
+    "mtime": 1783110541.1469033,
+    "ast_hash": "d64e381693a4dd89899657ab179a3d96",
+    "semantic_hash": "d64e381693a4dd89899657ab179a3d96"
+  },
+  "services/orion-vision-frame-router/tests/test_envelopes.py": {
+    "mtime": 1779649387.817299,
+    "ast_hash": "92eeeb23b8ee7359285ae8524fc2bee9",
+    "semantic_hash": "92eeeb23b8ee7359285ae8524fc2bee9"
+  },
+  "services/orion-vision-frame-router/tests/test_host_trigger.py": {
+    "mtime": 1783110541.1469033,
+    "ast_hash": "81fafda403a0a56a9e4323fbefacabd4",
+    "semantic_hash": "81fafda403a0a56a9e4323fbefacabd4"
+  },
+  "services/orion-vision-frame-router/tests/test_no_contamination.py": {
+    "mtime": 1779649387.817299,
+    "ast_hash": "897804d4ee55f0d18d9a42d7eee6913e",
+    "semantic_hash": "897804d4ee55f0d18d9a42d7eee6913e"
+  },
+  "services/orion-vision-frame-router/tests/test_policy.py": {
+    "mtime": 1779649387.817299,
+    "ast_hash": "57e9fba51432ad8007bdf1c796954d7a",
+    "semantic_hash": "57e9fba51432ad8007bdf1c796954d7a"
+  },
+  "services/orion-vision-frame-router/tests/test_policy_triggers.py": {
+    "mtime": 1783028252.551353,
+    "ast_hash": "47967b645f8ab13cba7e54ece715befc",
+    "semantic_hash": "47967b645f8ab13cba7e54ece715befc"
+  },
+  "services/orion-vision-frame-router/tests/test_settings.py": {
+    "mtime": 1779649387.817299,
+    "ast_hash": "888e90af6954b78a0fe76f490bde0e37",
+    "semantic_hash": "888e90af6954b78a0fe76f490bde0e37"
+  },
+  "services/orion-vision-frame-router/tests/test_state.py": {
+    "mtime": 1783110541.1469033,
+    "ast_hash": "cee3764fd997b236e456975df8882b5d",
+    "semantic_hash": "cee3764fd997b236e456975df8882b5d"
+  },
+  "services/orion-vision-host/app/artifacts.py": {
+    "mtime": 1782871399.009733,
+    "ast_hash": "7f322ac8c311e1763e6df2e373ca6ec4",
+    "semantic_hash": "7f322ac8c311e1763e6df2e373ca6ec4"
+  },
+  "services/orion-vision-host/app/caption_sanitize.py": {
+    "mtime": 1783807364.3748386,
+    "ast_hash": "169ebf816c7b93f5a5a9a9bec9954cd5",
+    "semantic_hash": "169ebf816c7b93f5a5a9a9bec9954cd5"
+  },
+  "services/orion-vision-host/app/gpu.py": {
+    "mtime": 1766464542.2481222,
+    "ast_hash": "98ff11d8f73dbc0cfb567cc2bac6cacb",
+    "semantic_hash": "98ff11d8f73dbc0cfb567cc2bac6cacb"
+  },
+  "services/orion-vision-host/app/main.py": {
+    "mtime": 1782874038.2579727,
+    "ast_hash": "8e82ecbadb6a8f02fa2203c5f1e872c8",
+    "semantic_hash": "8e82ecbadb6a8f02fa2203c5f1e872c8"
+  },
+  "services/orion-vision-host/app/model_manager.py": {
+    "mtime": 1783107031.9869022,
+    "ast_hash": "e9418e591c7c615a4c702feffb557e15",
+    "semantic_hash": "e9418e591c7c615a4c702feffb557e15"
+  },
+  "services/orion-vision-host/app/models.py": {
+    "mtime": 1782871399.010733,
+    "ast_hash": "65c6a9f3ed5b553f9292229c995f78c0",
+    "semantic_hash": "65c6a9f3ed5b553f9292229c995f78c0"
+  },
+  "services/orion-vision-host/app/profiles.py": {
+    "mtime": 1766464650.6876836,
+    "ast_hash": "45fb0978e17b6a6fd3fc165c8bde374e",
+    "semantic_hash": "45fb0978e17b6a6fd3fc165c8bde374e"
+  },
+  "services/orion-vision-host/app/runner.py": {
+    "mtime": 1783028252.552353,
+    "ast_hash": "1ce8afd1d254e7655e70d950a071776d",
+    "semantic_hash": "1ce8afd1d254e7655e70d950a071776d"
+  },
+  "services/orion-vision-host/app/scheduler.py": {
+    "mtime": 1777790653.2270315,
+    "ast_hash": "c9098f815a3bf385a4c69d8ef87f1a9c",
+    "semantic_hash": "c9098f815a3bf385a4c69d8ef87f1a9c"
+  },
+  "services/orion-vision-host/app/settings.py": {
+    "mtime": 1777790653.2280316,
+    "ast_hash": "a77e1a918ef773b4087d0aace6cdc4a0",
+    "semantic_hash": "a77e1a918ef773b4087d0aace6cdc4a0"
+  },
+  "services/orion-vision-host/scripts/publish_test_task.py": {
+    "mtime": 1769663878.094563,
+    "ast_hash": "10711d34e1a4a927f230f1b2494d4c63",
+    "semantic_hash": "10711d34e1a4a927f230f1b2494d4c63"
+  },
+  "services/orion-vision-host/scripts/tap_artifacts.py": {
+    "mtime": 1767676515.7191076,
+    "ast_hash": "5ee1853cb4598fc14648bc8ae3ba34c7",
+    "semantic_hash": "5ee1853cb4598fc14648bc8ae3ba34c7"
+  },
+  "services/orion-vision-host/scripts/verify_cortex_vision.py": {
+    "mtime": 1768597909.9102292,
+    "ast_hash": "cb1c62b16faa676673e6b94e65aa4f3f",
+    "semantic_hash": "cb1c62b16faa676673e6b94e65aa4f3f"
+  },
+  "services/orion-vision-host/tests/test_artifact_provenance.py": {
+    "mtime": 1782871399.010733,
+    "ast_hash": "e4a6df2f69a4fe56f0387c9f008e508c",
+    "semantic_hash": "e4a6df2f69a4fe56f0387c9f008e508c"
+  },
+  "services/orion-vision-host/tests/test_caption_profile_routing.py": {
+    "mtime": 1782871399.010733,
+    "ast_hash": "23824d9fc1155d5ce04276160b7ef200",
+    "semantic_hash": "23824d9fc1155d5ce04276160b7ef200"
+  },
+  "services/orion-vision-host/tests/test_caption_sanitize.py": {
+    "mtime": 1783807362.3677747,
+    "ast_hash": "b6d75c651bd5c8ea573071b299112b88",
+    "semantic_hash": "b6d75c651bd5c8ea573071b299112b88"
+  },
+  "services/orion-vision-host/tests/test_scheduler.py": {
+    "mtime": 1777790653.2280316,
+    "ast_hash": "71f7c5aa41884fb555786a18f58e9ca0",
+    "semantic_hash": "71f7c5aa41884fb555786a18f58e9ca0"
+  },
+  "services/orion-vision-retina/app/__init__.py": {
+    "mtime": 1767676515.7201076,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-vision-retina/app/frame_store.py": {
+    "mtime": 1779649387.8182988,
+    "ast_hash": "73ddf4c84ccf61e8c8e760dd91bc4ed9",
+    "semantic_hash": "73ddf4c84ccf61e8c8e760dd91bc4ed9"
+  },
+  "services/orion-vision-retina/app/health.py": {
+    "mtime": 1779649387.8182988,
+    "ast_hash": "617bb985ef35638cc97d5c1f18f29e8b",
+    "semantic_hash": "617bb985ef35638cc97d5c1f18f29e8b"
+  },
+  "services/orion-vision-retina/app/main.py": {
+    "mtime": 1779649387.8182988,
+    "ast_hash": "9e6360951b179e7959c8f96fc379e14a",
+    "semantic_hash": "9e6360951b179e7959c8f96fc379e14a"
+  },
+  "services/orion-vision-retina/app/settings.py": {
+    "mtime": 1782879116.7631662,
+    "ast_hash": "c945b06bc9678c7d77e265b991b78ab3",
+    "semantic_hash": "c945b06bc9678c7d77e265b991b78ab3"
+  },
+  "services/orion-vision-retina/app/sources.py": {
+    "mtime": 1779649387.8182988,
+    "ast_hash": "8668b18978547bf33c40b71a3a8528bc",
+    "semantic_hash": "8668b18978547bf33c40b71a3a8528bc"
+  },
+  "services/orion-vision-scribe/app/__init__.py": {
+    "mtime": 1767676515.7201076,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-vision-scribe/app/main.py": {
+    "mtime": 1782964832.637659,
+    "ast_hash": "186824f425d40393b84221a9f9f82c29",
+    "semantic_hash": "186824f425d40393b84221a9f9f82c29"
+  },
+  "services/orion-vision-scribe/app/settings.py": {
+    "mtime": 1782944093.6522636,
+    "ast_hash": "7f6c7d57dbd62a00e089f8e2de0db185",
+    "semantic_hash": "7f6c7d57dbd62a00e089f8e2de0db185"
+  },
+  "services/orion-vision-scribe/tests/__init__.py": {
+    "mtime": 1782944093.6532638,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-vision-scribe/tests/test_vision_persistence_smoke_helpers.py": {
+    "mtime": 1782964832.637659,
+    "ast_hash": "ca1526f94e722eaf96e553fbbf32a79f",
+    "semantic_hash": "ca1526f94e722eaf96e553fbbf32a79f"
+  },
+  "services/orion-vision-scribe/tests/test_write_to_sinks.py": {
+    "mtime": 1782944093.6532638,
+    "ast_hash": "bb75a69f50aebe43e98cbc4c9b407fae",
+    "semantic_hash": "bb75a69f50aebe43e98cbc4c9b407fae"
+  },
+  "services/orion-vision-window/app/__init__.py": {
+    "mtime": 1767676515.7201076,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "services/orion-vision-window/app/main.py": {
+    "mtime": 1783218343.7034755,
+    "ast_hash": "75e9effe9ae1b5086911b7512b194e33",
+    "semantic_hash": "75e9effe9ae1b5086911b7512b194e33"
+  },
+  "services/orion-vision-window/app/projection.py": {
+    "mtime": 1783807362.7147858,
+    "ast_hash": "d676c6fbcb45656703fdb3865cfbeda2",
+    "semantic_hash": "d676c6fbcb45656703fdb3865cfbeda2"
+  },
+  "services/orion-vision-window/app/recovery_store.py": {
+    "mtime": 1777790653.2280316,
+    "ast_hash": "1fc75844ed8a50655f68a705b4f240c6",
+    "semantic_hash": "1fc75844ed8a50655f68a705b4f240c6"
+  },
+  "services/orion-vision-window/app/scene_belief.py": {
+    "mtime": 1783219371.2280643,
+    "ast_hash": "8e4ac5d0cb66b3e87517fef82c9cd4e6",
+    "semantic_hash": "8e4ac5d0cb66b3e87517fef82c9cd4e6"
+  },
+  "services/orion-vision-window/app/settings.py": {
+    "mtime": 1783219371.2280643,
+    "ast_hash": "dff5a5cffcf2ab28692dd114b605fb2a",
+    "semantic_hash": "dff5a5cffcf2ab28692dd114b605fb2a"
+  },
+  "services/orion-vision-window/tests/test_belief_flush_wiring.py": {
+    "mtime": 1783219371.2290645,
+    "ast_hash": "37407b25083ab73c009d5eff2892b681",
+    "semantic_hash": "37407b25083ab73c009d5eff2892b681"
+  },
+  "services/orion-vision-window/tests/test_projection.py": {
+    "mtime": 1777790653.2290316,
+    "ast_hash": "76469f23631743fd7242d17e3b503deb",
+    "semantic_hash": "76469f23631743fd7242d17e3b503deb"
+  },
+  "services/orion-vision-window/tests/test_projection_evidence.py": {
+    "mtime": 1783807362.7137856,
+    "ast_hash": "e8af3615f5b3637b24be8ce92412fcc9",
+    "semantic_hash": "e8af3615f5b3637b24be8ce92412fcc9"
+  },
+  "services/orion-vision-window/tests/test_projection_provenance.py": {
+    "mtime": 1782871399.010733,
+    "ast_hash": "1a5476b11028733232d9565b42afe7e3",
+    "semantic_hash": "1a5476b11028733232d9565b42afe7e3"
+  },
+  "services/orion-vision-window/tests/test_scene_belief.py": {
+    "mtime": 1783219371.2290645,
+    "ast_hash": "6fd8d2fb52e3d6c1a74993a0ea750a8a",
+    "semantic_hash": "6fd8d2fb52e3d6c1a74993a0ea750a8a"
+  },
+  "services/orion-vllm-host/app/main.py": {
+    "mtime": 1767676515.7211077,
+    "ast_hash": "10b9328ec63f1986f7b20b9becd5c864",
+    "semantic_hash": "10b9328ec63f1986f7b20b9becd5c864"
+  },
+  "services/orion-vllm-host/app/settings.py": {
+    "mtime": 1767676515.7211077,
+    "ast_hash": "339b4461d8fa4affbd4a913e9106e2b0",
+    "semantic_hash": "339b4461d8fa4affbd4a913e9106e2b0"
+  },
+  "services/orion-voip-endpoint/app/asterisk_control.py": {
+    "mtime": 1764136051.686789,
+    "ast_hash": "158c2b9e48812ac10a6e11df510b871b",
+    "semantic_hash": "158c2b9e48812ac10a6e11df510b871b"
+  },
+  "services/orion-voip-endpoint/app/bus_integration.py": {
+    "mtime": 1768597909.9112291,
+    "ast_hash": "9516bf2d64b06eb4d04b574d36553eec",
+    "semantic_hash": "9516bf2d64b06eb4d04b574d36553eec"
+  },
+  "services/orion-voip-endpoint/app/http_api.py": {
+    "mtime": 1764133980.376752,
+    "ast_hash": "8e03d620a0d35b53060df1f6d48066e1",
+    "semantic_hash": "8e03d620a0d35b53060df1f6d48066e1"
+  },
+  "services/orion-voip-endpoint/app/main.py": {
+    "mtime": 1764134017.5030885,
+    "ast_hash": "1091a7c211c8d78247a789b944f5be09",
+    "semantic_hash": "1091a7c211c8d78247a789b944f5be09"
+  },
+  "services/orion-voip-endpoint/app/settings.py": {
+    "mtime": 1764133579.143149,
+    "ast_hash": "3d14defe279ab3bf366f2da7cbdae461",
+    "semantic_hash": "3d14defe279ab3bf366f2da7cbdae461"
+  },
+  "services/orion-whisper-tts/app/main.py": {
+    "mtime": 1780106291.7507772,
+    "ast_hash": "0190ca72543d7992b163fe17937d7bd2",
+    "semantic_hash": "0190ca72543d7992b163fe17937d7bd2"
+  },
+  "services/orion-whisper-tts/app/settings.py": {
+    "mtime": 1780115804.917145,
+    "ast_hash": "922609a1dc17f87416cb57fde441051f",
+    "semantic_hash": "922609a1dc17f87416cb57fde441051f"
+  },
+  "services/orion-whisper-tts/app/stt.py": {
+    "mtime": 1783807362.1497676,
+    "ast_hash": "4d9fac3073c657b3cb5c2d9589646e6b",
+    "semantic_hash": "4d9fac3073c657b3cb5c2d9589646e6b"
+  },
+  "services/orion-whisper-tts/app/stt_worker.py": {
+    "mtime": 1783807362.1367674,
+    "ast_hash": "aa1aee4d674f618f616bb0b19957aa9c",
+    "semantic_hash": "aa1aee4d674f618f616bb0b19957aa9c"
+  },
+  "services/orion-whisper-tts/app/tts.py": {
+    "mtime": 1780115804.917145,
+    "ast_hash": "3a87579f5ea647c19c3e03e08ef49f28",
+    "semantic_hash": "3a87579f5ea647c19c3e03e08ef49f28"
+  },
+  "services/orion-whisper-tts/app/tts_worker.py": {
+    "mtime": 1780115804.917145,
+    "ast_hash": "6e555fbad3bc06357bf5ae4ed12cf2b7",
+    "semantic_hash": "6e555fbad3bc06357bf5ae4ed12cf2b7"
+  },
+  "services/orion-whisper-tts/scripts/download_xtts_model.py": {
+    "mtime": 1780106291.7517774,
+    "ast_hash": "4b977d0704634632d029b2895421131c",
+    "semantic_hash": "4b977d0704634632d029b2895421131c"
+  },
+  "services/orion-whisper-tts/scripts/smoke_xtts.py": {
+    "mtime": 1780106291.7517774,
+    "ast_hash": "21eda3c63dbaa4f02f92d21b7a60cfd1",
+    "semantic_hash": "21eda3c63dbaa4f02f92d21b7a60cfd1"
+  },
+  "services/orion-whisper-tts/tests/test_stt_engine.py": {
+    "mtime": 1780115804.917145,
+    "ast_hash": "a7f5ba115c50af77d5e044d7c04835fd",
+    "semantic_hash": "a7f5ba115c50af77d5e044d7c04835fd"
+  },
+  "services/orion-whisper-tts/tests/test_tts_engine_settings.py": {
+    "mtime": 1783807361.8537583,
+    "ast_hash": "87f43e4775b102426e150ba6a5d2013a",
+    "semantic_hash": "87f43e4775b102426e150ba6a5d2013a"
+  },
+  "services/orion-whisper-tts/tests/test_tts_voice_resolution.py": {
+    "mtime": 1780106291.7527773,
+    "ast_hash": "29860c8a59fa464565e130b412533a45",
+    "semantic_hash": "29860c8a59fa464565e130b412533a45"
+  },
+  "services/orion-whisper-tts/tests/test_tts_worker_replies.py": {
+    "mtime": 1780106291.7527773,
+    "ast_hash": "0e8b69a6921b965cb6a00985f85dc50c",
+    "semantic_hash": "0e8b69a6921b965cb6a00985f85dc50c"
+  },
+  "services/orion-world-pulse/app/__init__.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-world-pulse/app/main.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "51d5aae6707858bceb45c763ec532c5b",
+    "semantic_hash": "51d5aae6707858bceb45c763ec532c5b"
+  },
+  "services/orion-world-pulse/app/models.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "8a013ec8d07e1a42909e2cb467a1737d",
+    "semantic_hash": "8a013ec8d07e1a42909e2cb467a1737d"
+  },
+  "services/orion-world-pulse/app/routers/__init__.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-world-pulse/app/routers/publish.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "84e7f09dce0b585749987d562d90c9aa",
+    "semantic_hash": "84e7f09dce0b585749987d562d90c9aa"
+  },
+  "services/orion-world-pulse/app/routers/runs.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "3dbf9e58b7810f52d61485c32a9cfb11",
+    "semantic_hash": "3dbf9e58b7810f52d61485c32a9cfb11"
+  },
+  "services/orion-world-pulse/app/services/__init__.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-world-pulse/app/services/analysis.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "9a6ad6f25fcbd5f56aeb744eac63afa4",
+    "semantic_hash": "9a6ad6f25fcbd5f56aeb744eac63afa4"
+  },
+  "services/orion-world-pulse/app/services/capsule.py": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "033d7eab31e11527547b8f4d7cb81698",
+    "semantic_hash": "033d7eab31e11527547b8f4d7cb81698"
+  },
+  "services/orion-world-pulse/app/services/classify.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "4678bfb1be8573633d708c29a07798d5",
+    "semantic_hash": "4678bfb1be8573633d708c29a07798d5"
+  },
+  "services/orion-world-pulse/app/services/cluster.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "24518714f89412741b4066196823bffb",
+    "semantic_hash": "24518714f89412741b4066196823bffb"
+  },
+  "services/orion-world-pulse/app/services/corroboration.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "20430120dfed2b150e91e4f86f83d7b2",
+    "semantic_hash": "20430120dfed2b150e91e4f86f83d7b2"
+  },
+  "services/orion-world-pulse/app/services/curiosity.py": {
+    "mtime": 1783461977.1333036,
+    "ast_hash": "16f6bdf6db5528f52e6e26dd69f3c51e",
+    "semantic_hash": "16f6bdf6db5528f52e6e26dd69f3c51e"
+  },
+  "services/orion-world-pulse/app/services/dedupe.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "72285d23dcaf7061e80c8c262a0257fd",
+    "semantic_hash": "72285d23dcaf7061e80c8c262a0257fd"
+  },
+  "services/orion-world-pulse/app/services/digest.py": {
+    "mtime": 1783461977.1333036,
+    "ast_hash": "84c0b23dfa80236ce16df0b4f57e59b6",
+    "semantic_hash": "84c0b23dfa80236ce16df0b4f57e59b6"
+  },
+  "services/orion-world-pulse/app/services/emit_graph.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "fd88e2bf7cc7a7ae07001498f1c8bc32",
+    "semantic_hash": "fd88e2bf7cc7a7ae07001498f1c8bc32"
+  },
+  "services/orion-world-pulse/app/services/emit_runtime.py": {
+    "mtime": 1783453525.6779118,
+    "ast_hash": "b8e92df4d9572a562bbfc0b4b41d029b",
+    "semantic_hash": "b8e92df4d9572a562bbfc0b4b41d029b"
+  },
+  "services/orion-world-pulse/app/services/emit_sql.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "cd9b711c0255815597a7d476cc0fb720",
+    "semantic_hash": "cd9b711c0255815597a7d476cc0fb720"
+  },
+  "services/orion-world-pulse/app/services/extract.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "e5151d35dbf6ce8b959f8ce4fd124a2b",
+    "semantic_hash": "e5151d35dbf6ce8b959f8ce4fd124a2b"
+  },
+  "services/orion-world-pulse/app/services/fetchers/__init__.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "68b329da9893e34099c7d8ad5cb9c940",
+    "semantic_hash": "68b329da9893e34099c7d8ad5cb9c940"
+  },
+  "services/orion-world-pulse/app/services/fetchers/rss_fetcher.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "51b507bee3f05c9e4ddca102460e1a2f",
+    "semantic_hash": "51b507bee3f05c9e4ddca102460e1a2f"
+  },
+  "services/orion-world-pulse/app/services/ingest/__init__.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "fbe9fc778bc6459e124746c7d961be4f",
+    "semantic_hash": "fbe9fc778bc6459e124746c7d961be4f"
+  },
+  "services/orion-world-pulse/app/services/ingest/base.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "b4611390ad70352f2bfa57bcfa8e31cb",
+    "semantic_hash": "b4611390ad70352f2bfa57bcfa8e31cb"
+  },
+  "services/orion-world-pulse/app/services/ingest/html_section_adapter.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "e26b142d5f6cc459d4ff5be2ebc80bb3",
+    "semantic_hash": "e26b142d5f6cc459d4ff5be2ebc80bb3"
+  },
+  "services/orion-world-pulse/app/services/ingest/manual_urls_adapter.py": {
+    "mtime": 1777748523.3435993,
+    "ast_hash": "b9aba22449123319ee02e4d33a643907",
+    "semantic_hash": "b9aba22449123319ee02e4d33a643907"
+  },
+  "services/orion-world-pulse/app/services/ingest/models.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "4ab8abc9a44f46664113defc1a687e78",
+    "semantic_hash": "4ab8abc9a44f46664113defc1a687e78"
+  },
+  "services/orion-world-pulse/app/services/ingest/registry.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "72b5d3806f285e6604f61047819d5444",
+    "semantic_hash": "72b5d3806f285e6604f61047819d5444"
+  },
+  "services/orion-world-pulse/app/services/ingest/rss_adapter.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "e847abfdfca0e0416989faadfd6ee8c3",
+    "semantic_hash": "e847abfdfca0e0416989faadfd6ee8c3"
+  },
+  "services/orion-world-pulse/app/services/ingest/sitemap_adapter.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "8d53434c39778537dbecc307e6c3b226",
+    "semantic_hash": "8d53434c39778537dbecc307e6c3b226"
+  },
+  "services/orion-world-pulse/app/services/normalize_article.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "c7e640d60f6b61569353c7d4bde508ab",
+    "semantic_hash": "c7e640d60f6b61569353c7d4bde508ab"
+  },
+  "services/orion-world-pulse/app/services/pipeline.py": {
+    "mtime": 1783461977.1343038,
+    "ast_hash": "36f30327d8fe0410f30318289fc3cbf4",
+    "semantic_hash": "36f30327d8fe0410f30318289fc3cbf4"
+  },
+  "services/orion-world-pulse/app/services/publish_email.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "05c7e4c296fe388ad6e136df2f1343e3",
+    "semantic_hash": "05c7e4c296fe388ad6e136df2f1343e3"
+  },
+  "services/orion-world-pulse/app/services/publish_hub.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "fba37b9ca29189840e22c917a2a96ae3",
+    "semantic_hash": "fba37b9ca29189840e22c917a2a96ae3"
+  },
+  "services/orion-world-pulse/app/services/renderers.py": {
+    "mtime": 1783479691.3224597,
+    "ast_hash": "b2d562d8811a1df8ae7249b74d2a8e3b",
+    "semantic_hash": "b2d562d8811a1df8ae7249b74d2a8e3b"
+  },
+  "services/orion-world-pulse/app/services/source_registry.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "5e137cea266ef52c1c47b7e4a2ea4b11",
+    "semantic_hash": "5e137cea266ef52c1c47b7e4a2ea4b11"
+  },
+  "services/orion-world-pulse/app/services/topic_normalization.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "cb916c823c9a440da3bbe4b80ef9f64a",
+    "semantic_hash": "cb916c823c9a440da3bbe4b80ef9f64a"
+  },
+  "services/orion-world-pulse/app/services/trust.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "3a803e8d964ef1991cf4c400384a4ad7",
+    "semantic_hash": "3a803e8d964ef1991cf4c400384a4ad7"
+  },
+  "services/orion-world-pulse/app/settings.py": {
+    "mtime": 1783461977.1343038,
+    "ast_hash": "e02fbbc90675f877b41656dc80b086a1",
+    "semantic_hash": "e02fbbc90675f877b41656dc80b086a1"
+  },
+  "services/orion-world-pulse/app/state.py": {
+    "mtime": 1777748523.3445995,
+    "ast_hash": "fc7d7475f0a3b8ea54cba9227e1ba8fc",
+    "semantic_hash": "fc7d7475f0a3b8ea54cba9227e1ba8fc"
+  },
+  "services/orion-world-pulse/app/wiring.py": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "ff73f4c13e03428a0794e960c8a1ac25",
+    "semantic_hash": "ff73f4c13e03428a0794e960c8a1ac25"
+  },
+  "services/orion-world-pulse/tests/conftest.py": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "e6d17858f5488fb31e0d08d118bf8ec1",
+    "semantic_hash": "e6d17858f5488fb31e0d08d118bf8ec1"
+  },
+  "services/orion-world-pulse/tests/fixtures/rss_items.json": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "82ebe0067d9071a79bcb11f1631a9ddf",
+    "semantic_hash": "82ebe0067d9071a79bcb11f1631a9ddf"
+  },
+  "services/orion-world-pulse/tests/test_analysis_branches.py": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "dc05082db888699bb1e936babf61549a",
+    "semantic_hash": "dc05082db888699bb1e936babf61549a"
+  },
+  "services/orion-world-pulse/tests/test_curiosity.py": {
+    "mtime": 1783461977.1343038,
+    "ast_hash": "bf2057ae87dc627b951a3cfb2106ce41",
+    "semantic_hash": "bf2057ae87dc627b951a3cfb2106ce41"
+  },
+  "services/orion-world-pulse/tests/test_curiosity_followups_schema.py": {
+    "mtime": 1783461977.1343038,
+    "ast_hash": "efb399751e65247307f762fdb6272eb4",
+    "semantic_hash": "efb399751e65247307f762fdb6272eb4"
+  },
+  "services/orion-world-pulse/tests/test_curiosity_settings.py": {
+    "mtime": 1783461977.1343038,
+    "ast_hash": "ade841948c98a2cbbfbb5cc0d5b86c1f",
+    "semantic_hash": "ade841948c98a2cbbfbb5cc0d5b86c1f"
+  },
+  "services/orion-world-pulse/tests/test_emit_sql_envelopes.py": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "0fb9c88dd6fc8633a48425f84f95657b",
+    "semantic_hash": "0fb9c88dd6fc8633a48425f84f95657b"
+  },
+  "services/orion-world-pulse/tests/test_ingest_adapters.py": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "81024b20f24c23d4ccb146eb400ad465",
+    "semantic_hash": "81024b20f24c23d4ccb146eb400ad465"
+  },
+  "services/orion-world-pulse/tests/test_publish_paths.py": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "fed02a12ce48aeb6cd9b3edcb8c53513",
+    "semantic_hash": "fed02a12ce48aeb6cd9b3edcb8c53513"
+  },
+  "services/orion-world-pulse/tests/test_renderers_curiosity.py": {
+    "mtime": 1783479691.3224597,
+    "ast_hash": "6c6385a5e83ead733f248d40b170dd37",
+    "semantic_hash": "6c6385a5e83ead733f248d40b170dd37"
+  },
+  "services/orion-world-pulse/tests/test_run_result_stream_enqueue.py": {
+    "mtime": 1783453525.6779118,
+    "ast_hash": "eea34952fa527d46febeedfd79a1888b",
+    "semantic_hash": "eea34952fa527d46febeedfd79a1888b"
+  },
+  "services/orion-world-pulse/tests/test_safety_defaults.py": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "b39b481340f600019e9f829b339ccc33",
+    "semantic_hash": "b39b481340f600019e9f829b339ccc33"
+  },
+  "services/orion-world-pulse/tests/test_source_registry_config.py": {
+    "mtime": 1783915348.429791,
+    "ast_hash": "3c4dfa329104075f36437ea6149bf894",
+    "semantic_hash": "3c4dfa329104075f36437ea6149bf894"
+  },
+  "services/orion-world-pulse/tests/test_world_pulse_pipeline.py": {
+    "mtime": 1783461977.1343038,
+    "ast_hash": "80efa3ac997f9019270a0cadac772e66",
+    "semantic_hash": "80efa3ac997f9019270a0cadac772e66"
+  },
+  "services/orion-world-pulse/tests/test_world_pulse_unit.py": {
+    "mtime": 1777748523.3465996,
+    "ast_hash": "34ac3221ed3f208cfc57d4abce99d172",
+    "semantic_hash": "34ac3221ed3f208cfc57d4abce99d172"
+  },
+  "tests/__init__.py": {
+    "mtime": 1769663878.094563,
+    "ast_hash": "9f5f67d7d2fd715e663ea4effd0775e1",
+    "semantic_hash": "9f5f67d7d2fd715e663ea4effd0775e1"
+  },
+  "tests/fixtures/autonomy_graph/scenario_pack.json": {
+    "mtime": 1773980667.714536,
+    "ast_hash": "cf303d7a75edfc4c1a7e67d47f7a2b4c",
+    "semantic_hash": "cf303d7a75edfc4c1a7e67d47f7a2b4c"
+  },
+  "tests/fixtures/denver_vertical_slice.py": {
+    "mtime": 1781484475.969773,
+    "ast_hash": "878cf5de7a59725a2748f5df95b05783",
+    "semantic_hash": "878cf5de7a59725a2748f5df95b05783"
+  },
+  "tests/fixtures/memory_graph/joey_cats_draft.json": {
+    "mtime": 1779070080.280205,
+    "ast_hash": "cf3c994c3dfb5e2f83ad6f5dd12ad7b0",
+    "semantic_hash": "cf3c994c3dfb5e2f83ad6f5dd12ad7b0"
+  },
+  "tests/fixtures/memory_graph/joey_cats_subschema_snapshot.json": {
+    "mtime": 1777758592.2242446,
+    "ast_hash": "e9e5acfdef8ae3d16ad7c92caee4ed9b",
+    "semantic_hash": "e9e5acfdef8ae3d16ad7c92caee4ed9b"
+  },
+  "tests/fixtures/memory_graph/pragmatic_take_draft.json": {
+    "mtime": 1780622613.6057644,
+    "ast_hash": "a61ad79941c3b46608ff711f6f03a72a",
+    "semantic_hash": "a61ad79941c3b46608ff711f6f03a72a"
+  },
+  "tests/fixtures/memory_graph/shower_role_grounded_draft.json": {
+    "mtime": 1779073959.9822612,
+    "ast_hash": "a6a2e127b0d410733f91c272916599fa",
+    "semantic_hash": "a6a2e127b0d410733f91c272916599fa"
+  },
+  "tests/fixtures/social_room/scenario_replay.json": {
+    "mtime": 1774236180.459385,
+    "ast_hash": "20f527d10dda5bf3613fa6a7c2fde5e6",
+    "semantic_hash": "20f527d10dda5bf3613fa6a7c2fde5e6"
+  },
+  "tests/fixtures/social_room/shakedown_issues.json": {
+    "mtime": 1774236180.459385,
+    "ast_hash": "fe3c0e2873e0eca585182792d4f06454",
+    "semantic_hash": "fe3c0e2873e0eca585182792d4f06454"
+  },
+  "tests/integration/conftest.py": {
+    "mtime": 1783107031.9869022,
+    "ast_hash": "eeb8e866e13a49d8cf16a5c475703b08",
+    "semantic_hash": "eeb8e866e13a49d8cf16a5c475703b08"
+  },
+  "tests/integration/test_spark_introspection_feedback_loop.py": {
+    "mtime": 1783107031.9869022,
+    "ast_hash": "508a8921c18d22043fed01912e036dd0",
+    "semantic_hash": "508a8921c18d22043fed01912e036dd0"
+  },
+  "tests/scripts/test_context_exec_proposal_storage_defaults.py": {
+    "mtime": 1781739116.1686344,
+    "ast_hash": "68dffb2338797e3c1f7ddda22ba1a18a",
+    "semantic_hash": "68dffb2338797e3c1f7ddda22ba1a18a"
+  },
+  "tests/scripts/test_orion_proposal_cli.py": {
+    "mtime": 1781479799.2127633,
+    "ast_hash": "a9fe5fa436a3e3e4c72973a92f8b99c8",
+    "semantic_hash": "a9fe5fa436a3e3e4c72973a92f8b99c8"
+  },
+  "tests/scripts/test_sync_local_env_from_example.py": {
+    "mtime": 1783966883.3226395,
+    "ast_hash": "de7a6da5a93f4513df32baeaf7175494",
+    "semantic_hash": "de7a6da5a93f4513df32baeaf7175494"
+  },
+  "tests/services/test_proposal_review_api.py": {
+    "mtime": 1781477213.658747,
+    "ast_hash": "8ccfa9942cff099f51c3c97af81d3ca1",
+    "semantic_hash": "8ccfa9942cff099f51c3c97af81d3ca1"
+  },
+  "tests/test_agent_no_recall_live_proof.py": {
+    "mtime": 1783499830.2085214,
+    "ast_hash": "2a5d0c5afdbe351af07441d14837f1e2",
+    "semantic_hash": "2a5d0c5afdbe351af07441d14837f1e2"
+  },
+  "tests/test_agent_trace_js.py": {
+    "mtime": 1782964828.615541,
+    "ast_hash": "58b65a881e2d765379ad8c203cc963b4",
+    "semantic_hash": "58b65a881e2d765379ad8c203cc963b4"
+  },
+  "tests/test_agent_trace_schema_registry.py": {
+    "mtime": 1774236180.459385,
+    "ast_hash": "9cbdc8d41f7a5662ea396e7bed7b2800",
+    "semantic_hash": "9cbdc8d41f7a5662ea396e7bed7b2800"
+  },
+  "tests/test_agent_trace_summary.py": {
+    "mtime": 1774236180.459385,
+    "ast_hash": "4ba84753ba1b2d2df95d7427f3d5b880",
+    "semantic_hash": "4ba84753ba1b2d2df95d7427f3d5b880"
+  },
+  "tests/test_analyze_text_prompt_contract.py": {
+    "mtime": 1774840917.2992113,
+    "ast_hash": "8e2cb42ff4875c0b63a9eb791ff0932b",
+    "semantic_hash": "8e2cb42ff4875c0b63a9eb791ff0932b"
+  },
+  "tests/test_answer_depth_pass2_wiring.py": {
+    "mtime": 1773984591.7500987,
+    "ast_hash": "506b4e1dd371aa7ce22c57d50af7c11b",
+    "semantic_hash": "506b4e1dd371aa7ce22c57d50af7c11b"
+  },
+  "tests/test_answer_depth_pass3_golden_path_discord.py": {
+    "mtime": 1783499830.2085214,
+    "ast_hash": "37f371fa019b512a5db941ea51ca4fb6",
+    "semantic_hash": "37f371fa019b512a5db941ea51ca4fb6"
+  },
+  "tests/test_answer_depth_pass3_supervisor_meta_plan_proof.py": {
+    "mtime": 1773984591.7500987,
+    "ast_hash": "3e939ddc32cc95f8a29f4c9134dfd392",
+    "semantic_hash": "3e939ddc32cc95f8a29f4c9134dfd392"
+  },
+  "tests/test_answer_depth_pass5_live_evidence.py": {
+    "mtime": 1773984591.7500987,
+    "ast_hash": "6a8702c6f8351d38d794aedca65d6c51",
+    "semantic_hash": "6a8702c6f8351d38d794aedca65d6c51"
+  },
+  "tests/test_attention_field_scoring.py": {
+    "mtime": 1779681646.028453,
+    "ast_hash": "208e8a036f03913a362dc8b1e62a6a03",
+    "semantic_hash": "208e8a036f03913a362dc8b1e62a6a03"
+  },
+  "tests/test_attention_frame_builder.py": {
+    "mtime": 1779681646.028453,
+    "ast_hash": "285aa3a585e121e137f6ffb39be242d8",
+    "semantic_hash": "285aa3a585e121e137f6ffb39be242d8"
+  },
+  "tests/test_attention_frame_schemas.py": {
+    "mtime": 1779681646.028453,
+    "ast_hash": "81b7a4a4eae331659f550a00295f1e1f",
+    "semantic_hash": "81b7a4a4eae331659f550a00295f1e1f"
+  },
+  "tests/test_attention_policy_loader.py": {
+    "mtime": 1779681646.028453,
+    "ast_hash": "91f3a20cf84223acc72533ee6d6840e2",
+    "semantic_hash": "91f3a20cf84223acc72533ee6d6840e2"
+  },
+  "tests/test_attention_runtime_store.py": {
+    "mtime": 1779681646.028453,
+    "ast_hash": "d2f17527cb70b4926813a98412e33465",
+    "semantic_hash": "d2f17527cb70b4926813a98412e33465"
+  },
+  "tests/test_attention_runtime_worker.py": {
+    "mtime": 1779681646.029453,
+    "ast_hash": "266fdd6a5530a2d7fc91c254b8dac25d",
+    "semantic_hash": "266fdd6a5530a2d7fc91c254b8dac25d"
+  },
+  "tests/test_attention_transport_visibility.py": {
+    "mtime": 1780622613.6057644,
+    "ast_hash": "34e42616cd1719b9d6a1978dcf88bc19",
+    "semantic_hash": "34e42616cd1719b9d6a1978dcf88bc19"
+  },
+  "tests/test_autonomy_episode_crystallization.py": {
+    "mtime": 1783365495.7356663,
+    "ast_hash": "296db21b489be3ebabbc497e5e9c0c4d",
+    "semantic_hash": "296db21b489be3ebabbc497e5e9c0c4d"
+  },
+  "tests/test_autonomy_goals_bus_catalog.py": {
+    "mtime": 1783499830.2085214,
+    "ast_hash": "65be00e3ace96b56d5dbe3121f8dd06c",
+    "semantic_hash": "65be00e3ace96b56d5dbe3121f8dd06c"
+  },
+  "tests/test_autonomy_repository.py": {
+    "mtime": 1774836321.9571385,
+    "ast_hash": "0e0f20f4e71fdede91c6d3dc246edbdc",
+    "semantic_hash": "0e0f20f4e71fdede91c6d3dc246edbdc"
+  },
+  "tests/test_autonomy_summary.py": {
+    "mtime": 1777093481.8421311,
+    "ast_hash": "e2ed05a09f3d4a61e7704c77a25751d7",
+    "semantic_hash": "e2ed05a09f3d4a61e7704c77a25751d7"
+  },
+  "tests/test_autonomy_summary_degraded.py": {
+    "mtime": 1779663510.7039404,
+    "ast_hash": "7e5e43ee15f952b20328bc946cc215b8",
+    "semantic_hash": "7e5e43ee15f952b20328bc946cc215b8"
+  },
+  "tests/test_autonomy_verification_harness.py": {
+    "mtime": 1773980667.714536,
+    "ast_hash": "d1c85685a3eb8cb03e6a166b90137fd3",
+    "semantic_hash": "d1c85685a3eb8cb03e6a166b90137fd3"
+  },
+  "tests/test_biometrics_grammar_extract.py": {
+    "mtime": 1779668252.1450117,
+    "ast_hash": "bf4c4370cfb96946a0b3328b38a430be",
+    "semantic_hash": "bf4c4370cfb96946a0b3328b38a430be"
+  },
+  "tests/test_biometrics_pipeline.py": {
+    "mtime": 1779668252.1450117,
+    "ast_hash": "02a791751a1278bbe0d0e94fd3baf318",
+    "semantic_hash": "02a791751a1278bbe0d0e94fd3baf318"
+  },
+  "tests/test_biometrics_pressure_organ.py": {
+    "mtime": 1779668252.1450117,
+    "ast_hash": "25bcde6d84d05684988fb9f643d0b003",
+    "semantic_hash": "25bcde6d84d05684988fb9f643d0b003"
+  },
+  "tests/test_bus_async_rpc_worker.py": {
+    "mtime": 1783753435.4783192,
+    "ast_hash": "2b6e07e21cffb01e548ca2160026591f",
+    "semantic_hash": "2b6e07e21cffb01e548ca2160026591f"
+  },
+  "tests/test_bus_pubsub_timeout.py": {
+    "mtime": 1781584864.5205817,
+    "ast_hash": "b9edba03a5672ff868ceed4713c32109",
+    "semantic_hash": "b9edba03a5672ff868ceed4713c32109"
+  },
+  "tests/test_bus_rpc_fork_client.py": {
+    "mtime": 1781730419.4957871,
+    "ast_hash": "170f04fb8a00ca7342d1b539b593825b",
+    "semantic_hash": "170f04fb8a00ca7342d1b539b593825b"
+  },
+  "tests/test_calibration_profile_adoption_phase12.py": {
+    "mtime": 1775601136.3208966,
+    "ast_hash": "e371f965d3b146edfe107ecf8f49e1ee",
+    "semantic_hash": "e371f965d3b146edfe107ecf8f49e1ee"
+  },
+  "tests/test_channel_prefix_guardrail.py": {
+    "mtime": 1768597909.912229,
+    "ast_hash": "0add6a4353383e69c6039a698e7e16e2",
+    "semantic_hash": "0add6a4353383e69c6039a698e7e16e2"
+  },
+  "tests/test_chassis_heartbeat_reconnect.py": {
+    "mtime": 1781846476.497166,
+    "ast_hash": "84eb1873c8be9d02b396ce80cd8ae8bc",
+    "semantic_hash": "84eb1873c8be9d02b396ce80cd8ae8bc"
+  },
+  "tests/test_chat_general_prompt.py": {
+    "mtime": 1783398623.0141568,
+    "ast_hash": "1955874fca870789d51d9f6856ad2d4a",
+    "semantic_hash": "1955874fca870789d51d9f6856ad2d4a"
+  },
+  "tests/test_chat_quick_prompt.py": {
+    "mtime": 1777873274.741052,
+    "ast_hash": "371b10a759823050afbe898a331738c7",
+    "semantic_hash": "371b10a759823050afbe898a331738c7"
+  },
+  "tests/test_chat_response_feedback_schema.py": {
+    "mtime": 1775629219.3249528,
+    "ast_hash": "54a2e97f04f9c5d5031d2a00f6a77d10",
+    "semantic_hash": "54a2e97f04f9c5d5031d2a00f6a77d10"
+  },
+  "tests/test_chat_substrate_pipeline.py": {
+    "mtime": 1781897477.584087,
+    "ast_hash": "c1104d08f3c453a30c5332816bb1f973",
+    "semantic_hash": "c1104d08f3c453a30c5332816bb1f973"
+  },
+  "tests/test_chat_substrate_reducer.py": {
+    "mtime": 1783908076.953645,
+    "ast_hash": "084056dd52d8fd57a17e064050865a0c",
+    "semantic_hash": "084056dd52d8fd57a17e064050865a0c"
+  },
+  "tests/test_chat_workflow_registry.py": {
+    "mtime": 1776049553.7894866,
+    "ast_hash": "35855bdd7f61a974dbbabf2044e06592",
+    "semantic_hash": "35855bdd7f61a974dbbabf2044e06592"
+  },
+  "tests/test_check_concept_relation_digest_liveness.py": {
+    "mtime": 1783983558.4712076,
+    "ast_hash": "3cfab8c442f63ff3aa4b720e523f28b8",
+    "semantic_hash": "3cfab8c442f63ff3aa4b720e523f28b8"
+  },
+  "tests/test_check_daily_schedule_collisions.py": {
+    "mtime": 1783986358.1076567,
+    "ast_hash": "3db3f97f7beae4a4da9dd35a7a6bd04d",
+    "semantic_hash": "3db3f97f7beae4a4da9dd35a7a6bd04d"
+  },
+  "tests/test_check_journal_dispatch_registry.py": {
+    "mtime": 1783986358.1076567,
+    "ast_hash": "4d6f53cd3af3bc8e13eadf1e0bde7b3e",
+    "semantic_hash": "4d6f53cd3af3bc8e13eadf1e0bde7b3e"
+  },
+  "tests/test_check_service_env_compose_parity.py": {
+    "mtime": 1783983558.4712076,
+    "ast_hash": "89122af2ec08818b8eea586c5e2a5cab",
+    "semantic_hash": "89122af2ec08818b8eea586c5e2a5cab"
+  },
+  "tests/test_cognitive_substrate_phase1.py": {
+    "mtime": 1775601136.3208966,
+    "ast_hash": "8f65e8c1f4dbe7f2cd974e06cbee2852",
+    "semantic_hash": "8f65e8c1f4dbe7f2cd974e06cbee2852"
+  },
+  "tests/test_cognitive_substrate_phase10_review_scheduling.py": {
+    "mtime": 1775613610.4184463,
+    "ast_hash": "26488f56f3dbdbb2a668bf8b03c69aec",
+    "semantic_hash": "26488f56f3dbdbb2a668bf8b03c69aec"
+  },
+  "tests/test_cognitive_substrate_phase11_review_runtime.py": {
+    "mtime": 1775613610.4184463,
+    "ast_hash": "6210cb0c9c917f2780e5b3c5d28c86d1",
+    "semantic_hash": "6210cb0c9c917f2780e5b3c5d28c86d1"
+  },
+  "tests/test_cognitive_substrate_phase12_review_bootstrap.py": {
+    "mtime": 1775790852.1702113,
+    "ast_hash": "07b84e0715eea1f86e39950f964b3ff7",
+    "semantic_hash": "07b84e0715eea1f86e39950f964b3ff7"
+  },
+  "tests/test_cognitive_substrate_phase12_review_telemetry.py": {
+    "mtime": 1775613610.4184463,
+    "ast_hash": "250ceba501a087c69869f840ed57611c",
+    "semantic_hash": "250ceba501a087c69869f840ed57611c"
+  },
+  "tests/test_cognitive_substrate_phase2_domain_mappings.py": {
+    "mtime": 1783986358.1076567,
+    "ast_hash": "630b7b60175e25bc7ed6f6b422654bad",
+    "semantic_hash": "630b7b60175e25bc7ed6f6b422654bad"
+  },
+  "tests/test_cognitive_substrate_phase3_materialization.py": {
+    "mtime": 1775601136.3208966,
+    "ast_hash": "9f5f5b55106738ec5ca3f5dc91022c69",
+    "semantic_hash": "9f5f5b55106738ec5ca3f5dc91022c69"
+  },
+  "tests/test_cognitive_substrate_phase4_dynamics.py": {
+    "mtime": 1782528981.596021,
+    "ast_hash": "e980c27fd4939ddc7d6d66750a5557c4",
+    "semantic_hash": "e980c27fd4939ddc7d6d66750a5557c4"
+  },
+  "tests/test_cognitive_substrate_phase5_graph_cognition.py": {
+    "mtime": 1775613610.4184463,
+    "ast_hash": "fb9d15256589f7a88659eda3d65679ca",
+    "semantic_hash": "fb9d15256589f7a88659eda3d65679ca"
+  },
+  "tests/test_cognitive_substrate_phase6_frontier_expansion.py": {
+    "mtime": 1775613610.4184463,
+    "ast_hash": "6bb4b57a319e68d37da204c100a65244",
+    "semantic_hash": "6bb4b57a319e68d37da204c100a65244"
+  },
+  "tests/test_cognitive_substrate_phase7_frontier_landing.py": {
+    "mtime": 1775613610.4184463,
+    "ast_hash": "665352d83f2b3942e9640bdb155da351",
+    "semantic_hash": "665352d83f2b3942e9640bdb155da351"
+  },
+  "tests/test_cognitive_substrate_phase8_frontier_invocation.py": {
+    "mtime": 1775613610.4184463,
+    "ast_hash": "26daf920cb29802bfba0e393c436e6a7",
+    "semantic_hash": "26daf920cb29802bfba0e393c436e6a7"
+  },
+  "tests/test_cognitive_substrate_phase9_consolidation.py": {
+    "mtime": 1775613610.4184463,
+    "ast_hash": "d9962be109333ae7ab7535e132dcff88",
+    "semantic_hash": "d9962be109333ae7ab7535e132dcff88"
+  },
+  "tests/test_collapse_service_causal_density.py": {
+    "mtime": 1782938951.7367241,
+    "ast_hash": "36c1c3ed16ba7de838d1be0dc32be53c",
+    "semantic_hash": "36c1c3ed16ba7de838d1be0dc32be53c"
+  },
+  "tests/test_concept_relation_digest.py": {
+    "mtime": 1783965578.734708,
+    "ast_hash": "5ac2575e702fb46e82e05339712b2f9b",
+    "semantic_hash": "5ac2575e702fb46e82e05339712b2f9b"
+  },
+  "tests/test_consolidation_builder.py": {
+    "mtime": 1779749949.3244674,
+    "ast_hash": "db79e81226991e3ae801565294286465",
+    "semantic_hash": "db79e81226991e3ae801565294286465"
+  },
+  "tests/test_consolidation_classify.py": {
+    "mtime": 1782190803.1033247,
+    "ast_hash": "cc2b810cac2a71621fbacae61ef07af1",
+    "semantic_hash": "cc2b810cac2a71621fbacae61ef07af1"
+  },
+  "tests/test_consolidation_expectations.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "efd5d3f38115b6479d6a5ac64a0b6134",
+    "semantic_hash": "efd5d3f38115b6479d6a5ac64a0b6134"
+  },
+  "tests/test_consolidation_frame_schemas.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "654ac5ad40d05cbca6a629c372745d01",
+    "semantic_hash": "654ac5ad40d05cbca6a629c372745d01"
+  },
+  "tests/test_consolidation_motif_detection.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "1d3b838e122adc00537a8a68f8606d40",
+    "semantic_hash": "1d3b838e122adc00537a8a68f8606d40"
+  },
+  "tests/test_consolidation_policy_loader.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "c67664aaba56ff8c2631f35d0a7c2459",
+    "semantic_hash": "c67664aaba56ff8c2631f35d0a7c2459"
+  },
+  "tests/test_consolidation_repository.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "a24d44d87a173028a38c1828807375d0",
+    "semantic_hash": "a24d44d87a173028a38c1828807375d0"
+  },
+  "tests/test_consolidation_runtime_store.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "69024532f3f4adb867e2aec85d3f90fd",
+    "semantic_hash": "69024532f3f4adb867e2aec85d3f90fd"
+  },
+  "tests/test_consolidation_runtime_worker.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "f684b9b73c99450ddb9062b61b0ee915",
+    "semantic_hash": "f684b9b73c99450ddb9062b61b0ee915"
+  },
+  "tests/test_consolidation_schema_candidates.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "51b68bbc9608b95dceb95f2f86990059",
+    "semantic_hash": "51b68bbc9608b95dceb95f2f86990059"
+  },
+  "tests/test_consolidation_tensorize.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "64b90334b81de711e04954ce8566d297",
+    "semantic_hash": "64b90334b81de711e04954ce8566d297"
+  },
+  "tests/test_consolidation_transport_motifs.py": {
+    "mtime": 1780622613.6067643,
+    "ast_hash": "79153c9aad68a3bfcf198d8115296162",
+    "semantic_hash": "79153c9aad68a3bfcf198d8115296162"
+  },
+  "tests/test_consolidation_windows.py": {
+    "mtime": 1779749949.3254676,
+    "ast_hash": "2818c332b548debc60d214c5f4e09ee9",
+    "semantic_hash": "2818c332b548debc60d214c5f4e09ee9"
+  },
+  "tests/test_context_exec_golden_probe_lib.py": {
+    "mtime": 1781133520.6373346,
+    "ast_hash": "b05cc8a0af54928458a156aca83de174",
+    "semantic_hash": "b05cc8a0af54928458a156aca83de174"
+  },
+  "tests/test_corpus_gate.py": {
+    "mtime": 1783622541.3545249,
+    "ast_hash": "9f6048743cf123fe3052cd43174c8a14",
+    "semantic_hash": "9f6048743cf123fe3052cd43174c8a14"
+  },
+  "tests/test_cortex_gateway_error_reply.py": {
+    "mtime": 1774069579.2346463,
+    "ast_hash": "98087abb2cfbad29689b06453d9d18b4",
+    "semantic_hash": "98087abb2cfbad29689b06453d9d18b4"
+  },
+  "tests/test_crystallization_hub_provenance_ui.py": {
+    "mtime": 1783614403.7102764,
+    "ast_hash": "a22b4009a59219a7094bdc905030ec02",
+    "semantic_hash": "a22b4009a59219a7094bdc905030ec02"
+  },
+  "tests/test_dream_trigger_contract.py": {
+    "mtime": 1774244600.829933,
+    "ast_hash": "855c903b4cb310d88afeaacafc3c59eb",
+    "semantic_hash": "855c903b4cb310d88afeaacafc3c59eb"
+  },
+  "tests/test_drive_state_divergence_audit.py": {
+    "mtime": 1784008374.246501,
+    "ast_hash": "41bb541b115b1acf2e671c1adb572453",
+    "semantic_hash": "41bb541b115b1acf2e671c1adb572453"
+  },
+  "tests/test_embodiment_bus_catalog.py": {
+    "mtime": 1783450708.649728,
+    "ast_hash": "6d03f0a76671ce814c23babfc45b7ee8",
+    "semantic_hash": "6d03f0a76671ce814c23babfc45b7ee8"
+  },
+  "tests/test_embodiment_journal_contract.py": {
+    "mtime": 1783450708.649728,
+    "ast_hash": "97d78abb7d8ec4d75753f9c7b67bbaa0",
+    "semantic_hash": "97d78abb7d8ec4d75753f9c7b67bbaa0"
+  },
+  "tests/test_encode_reinforce_not_duplicate.py": {
+    "mtime": 1783900735.492598,
+    "ast_hash": "9b5ccd1f5464d1f8d488c725efbae771",
+    "semantic_hash": "9b5ccd1f5464d1f8d488c725efbae771"
+  },
+  "tests/test_endogenous_offline_evaluation_phase11.py": {
+    "mtime": 1775601136.3208966,
+    "ast_hash": "9d86d3bb7ddfec8816cb270fc21efd26",
+    "semantic_hash": "9d86d3bb7ddfec8816cb270fc21efd26"
+  },
+  "tests/test_endogenous_sql_bus_channels_phase13b.py": {
+    "mtime": 1775601136.3208966,
+    "ast_hash": "ae56fd6a8480d73300b80eaeecd0f946",
+    "semantic_hash": "ae56fd6a8480d73300b80eaeecd0f946"
+  },
+  "tests/test_endogenous_triggers_phase7.py": {
+    "mtime": 1775601136.3208966,
+    "ast_hash": "6a48745617ba86abd41995d5e5467c56",
+    "semantic_hash": "6a48745617ba86abd41995d5e5467c56"
+  },
+  "tests/test_exec_result_channel_catalog_specificity.py": {
+    "mtime": 1783499830.2085214,
+    "ast_hash": "a564eadc0ae94aa7515f6f7614a32db9",
+    "semantic_hash": "a564eadc0ae94aa7515f6f7614a32db9"
+  },
+  "tests/test_execution_dispatch_builder.py": {
+    "mtime": 1783961966.7734356,
+    "ast_hash": "346ec3323fa19764b228939468d3fafa",
+    "semantic_hash": "346ec3323fa19764b228939468d3fafa"
+  },
+  "tests/test_execution_dispatch_bus_catalog.py": {
+    "mtime": 1784008374.246501,
+    "ast_hash": "88f564569e7c646323949da087893e48",
+    "semantic_hash": "88f564569e7c646323949da087893e48"
+  },
+  "tests/test_execution_dispatch_cortex_client.py": {
+    "mtime": 1783967452.504406,
+    "ast_hash": "f481f34cf741e94b82954ad0713d32f1",
+    "semantic_hash": "f481f34cf741e94b82954ad0713d32f1"
+  },
+  "tests/test_execution_dispatch_envelopes.py": {
+    "mtime": 1779722671.534158,
+    "ast_hash": "91989bebe73a78220fdf96ee00085552",
+    "semantic_hash": "91989bebe73a78220fdf96ee00085552"
+  },
+  "tests/test_execution_dispatch_frame_schemas.py": {
+    "mtime": 1783961966.7734356,
+    "ast_hash": "fad26318cf3e4053b88330ccbae08e5d",
+    "semantic_hash": "fad26318cf3e4053b88330ccbae08e5d"
+  },
+  "tests/test_execution_dispatch_policy_loader.py": {
+    "mtime": 1783967452.504406,
+    "ast_hash": "4d4c01a8dcf6320e87110424720b06d7",
+    "semantic_hash": "4d4c01a8dcf6320e87110424720b06d7"
+  },
+  "tests/test_execution_dispatch_result_extraction.py": {
+    "mtime": 1783967452.504406,
+    "ast_hash": "8ebf2bb0de9a4f82231544eb8c4b2cdc",
+    "semantic_hash": "8ebf2bb0de9a4f82231544eb8c4b2cdc"
+  },
+  "tests/test_execution_dispatch_runtime_store.py": {
+    "mtime": 1783967452.504406,
+    "ast_hash": "79c4f8587f6b936eb9e6ca96c3fee58f",
+    "semantic_hash": "79c4f8587f6b936eb9e6ca96c3fee58f"
+  },
+  "tests/test_execution_dispatch_runtime_worker.py": {
+    "mtime": 1783986358.1076567,
+    "ast_hash": "7426f19973dbd756542a824e4c1cb17e",
+    "semantic_hash": "7426f19973dbd756542a824e4c1cb17e"
+  },
+  "tests/test_execution_dispatch_transport_dry_run.py": {
+    "mtime": 1780622613.6067643,
+    "ast_hash": "29cd99450e7b83fdd50224e39c4e88f8",
+    "semantic_hash": "29cd99450e7b83fdd50224e39c4e88f8"
+  },
+  "tests/test_execution_loop_ids.py": {
+    "mtime": 1783566259.2639368,
+    "ast_hash": "e653bcc362c91d79c5aca26086b758b0",
+    "semantic_hash": "e653bcc362c91d79c5aca26086b758b0"
+  },
+  "tests/test_execution_projection_schemas.py": {
+    "mtime": 1779677735.0004544,
+    "ast_hash": "c013b0e8aa884899f99fb04954688e17",
+    "semantic_hash": "c013b0e8aa884899f99fb04954688e17"
+  },
+  "tests/test_execution_substrate_pipeline.py": {
+    "mtime": 1779677735.0004544,
+    "ast_hash": "5ebb13be210b58c4a7ee0d87744a9ce7",
+    "semantic_hash": "5ebb13be210b58c4a7ee0d87744a9ce7"
+  },
+  "tests/test_execution_substrate_reducer.py": {
+    "mtime": 1783622541.355525,
+    "ast_hash": "02b2485924f5e5cf17c4572be532daae",
+    "semantic_hash": "02b2485924f5e5cf17c4572be532daae"
+  },
+  "tests/test_feedback_builder.py": {
+    "mtime": 1783967452.5054061,
+    "ast_hash": "608682a15b2f958365a109252d323a7f",
+    "semantic_hash": "608682a15b2f958365a109252d323a7f"
+  },
+  "tests/test_feedback_extractors.py": {
+    "mtime": 1779722671.535158,
+    "ast_hash": "8f34a223ac95617ad6731f6b3f8cdf0c",
+    "semantic_hash": "8f34a223ac95617ad6731f6b3f8cdf0c"
+  },
+  "tests/test_feedback_frame_schemas.py": {
+    "mtime": 1779722671.536158,
+    "ast_hash": "be24a1017a6d30e37e53e680017e2821",
+    "semantic_hash": "be24a1017a6d30e37e53e680017e2821"
+  },
+  "tests/test_feedback_policy_loader.py": {
+    "mtime": 1779722671.536158,
+    "ast_hash": "10801d5d813c365dcac242790069f91f",
+    "semantic_hash": "10801d5d813c365dcac242790069f91f"
+  },
+  "tests/test_feedback_runtime_store.py": {
+    "mtime": 1783967452.5054061,
+    "ast_hash": "94a645dbe44e4a15bcf097ab7dd707ed",
+    "semantic_hash": "94a645dbe44e4a15bcf097ab7dd707ed"
+  },
+  "tests/test_feedback_scoring.py": {
+    "mtime": 1779722671.536158,
+    "ast_hash": "e09a6f9a7d4e311cdc3ad0967703f931",
+    "semantic_hash": "e09a6f9a7d4e311cdc3ad0967703f931"
+  },
+  "tests/test_feedback_transport_outcomes.py": {
+    "mtime": 1780622613.6067643,
+    "ast_hash": "58ab6731501d452184a4bde877647d58",
+    "semantic_hash": "58ab6731501d452184a4bde877647d58"
+  },
+  "tests/test_field_channel_corpus_schema.py": {
+    "mtime": 1783984456.990051,
+    "ast_hash": "04cfc786f9cec424abee7fb8b146e653",
+    "semantic_hash": "04cfc786f9cec424abee7fb8b146e653"
+  },
+  "tests/test_field_delta_ingest.py": {
+    "mtime": 1779671370.5200107,
+    "ast_hash": "d93eea57ebd89a6afb6145b60e6f688c",
+    "semantic_hash": "d93eea57ebd89a6afb6145b60e6f688c"
+  },
+  "tests/test_field_deterministic_replay.py": {
+    "mtime": 1779671370.5200107,
+    "ast_hash": "7a9cf487904272b2161514c7f182d6d9",
+    "semantic_hash": "7a9cf487904272b2161514c7f182d6d9"
+  },
+  "tests/test_field_digestion_rules.py": {
+    "mtime": 1781772134.803745,
+    "ast_hash": "f7e47f3607c0c29f6387657a7c726f82",
+    "semantic_hash": "f7e47f3607c0c29f6387657a7c726f82"
+  },
+  "tests/test_field_execution_perturbations.py": {
+    "mtime": 1781765088.071288,
+    "ast_hash": "6a40e31f69f9964e49ab1cf2c90df259",
+    "semantic_hash": "6a40e31f69f9964e49ab1cf2c90df259"
+  },
+  "tests/test_field_state_schemas.py": {
+    "mtime": 1779681646.029453,
+    "ast_hash": "027b4b028b214d129e0586a703512ca0",
+    "semantic_hash": "027b4b028b214d129e0586a703512ca0"
+  },
+  "tests/test_field_topology_config.py": {
+    "mtime": 1779681646.029453,
+    "ast_hash": "5a87518a03da3de6551626e40f0c2848",
+    "semantic_hash": "5a87518a03da3de6551626e40f0c2848"
+  },
+  "tests/test_field_topology_reconciliation.py": {
+    "mtime": 1779681646.029453,
+    "ast_hash": "22bfc42badbfcf72937fb446445cb87d",
+    "semantic_hash": "22bfc42badbfcf72937fb446445cb87d"
+  },
+  "tests/test_field_transport_perturbations.py": {
+    "mtime": 1780622613.6067643,
+    "ast_hash": "e966ec8cf750e5ca9d991c53fc88112e",
+    "semantic_hash": "e966ec8cf750e5ca9d991c53fc88112e"
+  },
+  "tests/test_formation_executor_auto_activate.py": {
+    "mtime": 1783555541.5466743,
+    "ast_hash": "88cc7af721e68b61eab126c0c96ef2f9",
+    "semantic_hash": "88cc7af721e68b61eab126c0c96ef2f9"
+  },
+  "tests/test_formation_policy_auto_vs_gated.py": {
+    "mtime": 1783555541.5466743,
+    "ast_hash": "1614ec80b4a856515f181f5fa6d539b9",
+    "semantic_hash": "1614ec80b4a856515f181f5fa6d539b9"
+  },
+  "tests/test_github_compactor_memory_cards.py": {
+    "mtime": 1783555541.5466743,
+    "ast_hash": "b928b3b8b3269c8dbb9bf4406f284cbf",
+    "semantic_hash": "b928b3b8b3269c8dbb9bf4406f284cbf"
+  },
+  "tests/test_grammar_lane_defaults.py": {
+    "mtime": 1783915348.429791,
+    "ast_hash": "65b979362caae60452e9544fdd8f5f44",
+    "semantic_hash": "65b979362caae60452e9544fdd8f5f44"
+  },
+  "tests/test_grammar_truth_gate.py": {
+    "mtime": 1781585632.7509527,
+    "ast_hash": "06692cd9c94f61e9cb8c7e40f589ac34",
+    "semantic_hash": "06692cd9c94f61e9cb8c7e40f589ac34"
+  },
+  "tests/test_graphiti_config.py": {
+    "mtime": 1783356609.57601,
+    "ast_hash": "fa90a7dbffd364837573f7e97f759549",
+    "semantic_hash": "fa90a7dbffd364837573f7e97f759549"
+  },
+  "tests/test_heartbeat_trace.py": {
+    "mtime": 1773975149.9777858,
+    "ast_hash": "a7a3991ea53a324a167448f0449f9e43",
+    "semantic_hash": "a7a3991ea53a324a167448f0449f9e43"
+  },
+  "tests/test_hub_js_syntax.py": {
+    "mtime": 1773975149.9777858,
+    "ast_hash": "20f9c08389c7664bc9c046218a475e6e",
+    "semantic_hash": "20f9c08389c7664bc9c046218a475e6e"
+  },
+  "tests/test_hunter_reconnect.py": {
+    "mtime": 1781584864.521582,
+    "ast_hash": "1f8a96ef551864c5f542df0396ed63ef",
+    "semantic_hash": "1f8a96ef551864c5f542df0396ed63ef"
+  },
+  "tests/test_identity_context.py": {
+    "mtime": 1774417080.6557083,
+    "ast_hash": "04a35a657ee6f3ef9dc6da481f25107e",
+    "semantic_hash": "04a35a657ee6f3ef9dc6da481f25107e"
+  },
+  "tests/test_indexed_compactor_memory_cards.py": {
+    "mtime": 1783958824.290684,
+    "ast_hash": "563bd3eb53ccd792371315e501b4c995",
+    "semantic_hash": "563bd3eb53ccd792371315e501b4c995"
+  },
+  "tests/test_inner_state_features.py": {
+    "mtime": 1783984456.990051,
+    "ast_hash": "5c21d5ca35657ca9349d09fc522821dc",
+    "semantic_hash": "5c21d5ca35657ca9349d09fc522821dc"
+  },
+  "tests/test_inner_state_registry_gate.py": {
+    "mtime": 1783897997.643214,
+    "ast_hash": "182befaf81e0bb5f1dfaefe6a0dcb398",
+    "semantic_hash": "182befaf81e0bb5f1dfaefe6a0dcb398"
+  },
+  "tests/test_inner_state_schema.py": {
+    "mtime": 1783490446.3073595,
+    "ast_hash": "eb0ec34918006e2030185d912665f919",
+    "semantic_hash": "eb0ec34918006e2030185d912665f919"
+  },
+  "tests/test_inner_state_trajectory_features.py": {
+    "mtime": 1783537420.320368,
+    "ast_hash": "e2ae58b33f9448a57708d24e542102fc",
+    "semantic_hash": "e2ae58b33f9448a57708d24e542102fc"
+  },
+  "tests/test_introspection_metadata_continuity.py": {
+    "mtime": 1774566954.7012691,
+    "ast_hash": "13ee2b2f7dcc12ff04c0921ca144f59d",
+    "semantic_hash": "13ee2b2f7dcc12ff04c0921ca144f59d"
+  },
+  "tests/test_journal_compose_prompt.py": {
+    "mtime": 1777748523.3465996,
+    "ast_hash": "8952e751967b55e36430d90d2d6a6763",
+    "semantic_hash": "8952e751967b55e36430d90d2d6a6763"
+  },
+  "tests/test_journal_e2e.py": {
+    "mtime": 1774236180.459385,
+    "ast_hash": "0c3d864171d97f5cfbac53f36c9f5b82",
+    "semantic_hash": "0c3d864171d97f5cfbac53f36c9f5b82"
+  },
+  "tests/test_journaler_worker.py": {
+    "mtime": 1777748523.3465996,
+    "ast_hash": "fc5e9600fd17d1cc1ef888dbec3072c4",
+    "semantic_hash": "fc5e9600fd17d1cc1ef888dbec3072c4"
+  },
+  "tests/test_knowledge_forge_compile.py": {
+    "mtime": 1779305390.1067498,
+    "ast_hash": "eaadeedb41ceb0b8ad523139bcf460ed",
+    "semantic_hash": "eaadeedb41ceb0b8ad523139bcf460ed"
+  },
+  "tests/test_knowledge_forge_golden_path.py": {
+    "mtime": 1779305390.1067498,
+    "ast_hash": "a4cfa3aa28820fe8047e7a36ed29e25f",
+    "semantic_hash": "a4cfa3aa28820fe8047e7a36ed29e25f"
+  },
+  "tests/test_knowledge_forge_lint.py": {
+    "mtime": 1779305390.1067498,
+    "ast_hash": "12b6d83924b74ce45031479986c83036",
+    "semantic_hash": "12b6d83924b74ce45031479986c83036"
+  },
+  "tests/test_knowledge_forge_models.py": {
+    "mtime": 1779305390.1067498,
+    "ast_hash": "f19e624f948818c46668cacf7d53a251",
+    "semantic_hash": "f19e624f948818c46668cacf7d53a251"
+  },
+  "tests/test_knowledge_forge_probes.py": {
+    "mtime": 1779305390.1067498,
+    "ast_hash": "60bf698128c6fe4928e0d07b34580040",
+    "semantic_hash": "60bf698128c6fe4928e0d07b34580040"
+  },
+  "tests/test_knowledge_forge_review.py": {
+    "mtime": 1779305390.1067498,
+    "ast_hash": "28c364b5f6203fbab579e745f7017bd6",
+    "semantic_hash": "28c364b5f6203fbab579e745f7017bd6"
+  },
+  "tests/test_knowledge_forge_source_ingest.py": {
+    "mtime": 1779317383.6915996,
+    "ast_hash": "5e155e723d22e7589bb2d753a61ea2d6",
+    "semantic_hash": "5e155e723d22e7589bb2d753a61ea2d6"
+  },
+  "tests/test_knowledge_forge_store.py": {
+    "mtime": 1779305390.1067498,
+    "ast_hash": "13f8f1c38552e0f66a32802d39ddb9d3",
+    "semantic_hash": "13f8f1c38552e0f66a32802d39ddb9d3"
+  },
+  "tests/test_landing_pad_spark_snapshot_reducer.py": {
+    "mtime": 1773975149.9777858,
+    "ast_hash": "3073a008ea9efe2125a6960522cf8fb0",
+    "semantic_hash": "3073a008ea9efe2125a6960522cf8fb0"
+  },
+  "tests/test_llm_json_parser.py": {
+    "mtime": 1776044955.6142368,
+    "ast_hash": "29ea133d56bcdd2b3ce500639e9f7499",
+    "semantic_hash": "29ea133d56bcdd2b3ce500639e9f7499"
+  },
+  "tests/test_logprob_probe_runner.py": {
+    "mtime": 1783136738.0588806,
+    "ast_hash": "6d248d4114308433cd81790abfc0b79c",
+    "semantic_hash": "6d248d4114308433cd81790abfc0b79c"
+  },
+  "tests/test_low_info_social.py": {
+    "mtime": 1783402731.3013198,
+    "ast_hash": "ade53f54a87da21210915e775b23745c",
+    "semantic_hash": "ade53f54a87da21210915e775b23745c"
+  },
+  "tests/test_memory_cards_contracts.py": {
+    "mtime": 1780779151.183656,
+    "ast_hash": "f6af694ee77b441f4f0db2fc381b2975",
+    "semantic_hash": "f6af694ee77b441f4f0db2fc381b2975"
+  },
+  "tests/test_memory_cards_reverse_history.py": {
+    "mtime": 1780987589.831224,
+    "ast_hash": "973e20351ecca046e6500ede6fe0c2ff",
+    "semantic_hash": "973e20351ecca046e6500ede6fe0c2ff"
+  },
+  "tests/test_memory_consolidation_bus_catalog.py": {
+    "mtime": 1781735866.8357394,
+    "ast_hash": "56e566f5b42fb9a86bb06bc7eaa3c1a9",
+    "semantic_hash": "56e566f5b42fb9a86bb06bc7eaa3c1a9"
+  },
+  "tests/test_memory_consolidation_schema_skipped.py": {
+    "mtime": 1783402731.3013198,
+    "ast_hash": "f8fdc8bd4f720ac2b934f5fb79f47061",
+    "semantic_hash": "f8fdc8bd4f720ac2b934f5fb79f47061"
+  },
+  "tests/test_memory_crystallization.py": {
+    "mtime": 1783965578.734708,
+    "ast_hash": "361e9960c3d1c8a26afdb570c0655232",
+    "semantic_hash": "361e9960c3d1c8a26afdb570c0655232"
+  },
+  "tests/test_memory_crystallization_concept_relation.py": {
+    "mtime": 1783965578.7357082,
+    "ast_hash": "6047ad78c16ee38b45462aaec15b6806",
+    "semantic_hash": "6047ad78c16ee38b45462aaec15b6806"
+  },
+  "tests/test_memory_crystallization_dynamics.py": {
+    "mtime": 1783960753.1758304,
+    "ast_hash": "95403b25818e3dcb4e6ed56c0f6d4913",
+    "semantic_hash": "95403b25818e3dcb4e6ed56c0f6d4913"
+  },
+  "tests/test_memory_graph_approve.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "c9a4d11c4c813c24c97394738263b060",
+    "semantic_hash": "c9a4d11c4c813c24c97394738263b060"
+  },
+  "tests/test_memory_graph_consolidation_draft_hydrate.py": {
+    "mtime": 1782190803.1033247,
+    "ast_hash": "d9beef966b65879ff9869db247eeebb6",
+    "semantic_hash": "d9beef966b65879ff9869db247eeebb6"
+  },
+  "tests/test_memory_graph_core_pure.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "e842e21f103ff3d6f2bf49f2218db368",
+    "semantic_hash": "e842e21f103ff3d6f2bf49f2218db368"
+  },
+  "tests/test_memory_graph_cortex_suggest_extract.py": {
+    "mtime": 1781765088.071288,
+    "ast_hash": "bf41d6ac006684dfd6efe1897668fd40",
+    "semantic_hash": "bf41d6ac006684dfd6efe1897668fd40"
+  },
+  "tests/test_memory_graph_draft_repository.py": {
+    "mtime": 1781893873.1269724,
+    "ast_hash": "6446e6c1e73ebc3e820732ab55419b2e",
+    "semantic_hash": "6446e6c1e73ebc3e820732ab55419b2e"
+  },
+  "tests/test_memory_graph_draft_sanitize.py": {
+    "mtime": 1782955647.2244186,
+    "ast_hash": "edbb6835ef9f6e2f31040f706d5ccbcf",
+    "semantic_hash": "edbb6835ef9f6e2f31040f706d5ccbcf"
+  },
+  "tests/test_memory_graph_dto.py": {
+    "mtime": 1777758592.2252445,
+    "ast_hash": "fde5116a65e1dba73b83cca231300fa9",
+    "semantic_hash": "fde5116a65e1dba73b83cca231300fa9"
+  },
+  "tests/test_memory_graph_graphdb_mocked.py": {
+    "mtime": 1777758592.2252445,
+    "ast_hash": "0a7b86c935ad464bf1b8c64934194311",
+    "semantic_hash": "0a7b86c935ad464bf1b8c64934194311"
+  },
+  "tests/test_memory_graph_json_extract.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "e2f20dcbc1993ba9580aada2ac2e38f4",
+    "semantic_hash": "e2f20dcbc1993ba9580aada2ac2e38f4"
+  },
+  "tests/test_memory_graph_json_salvage.py": {
+    "mtime": 1783807362.6757846,
+    "ast_hash": "70f4f5e20f880fa78cea52ce8e999d32",
+    "semantic_hash": "70f4f5e20f880fa78cea52ce8e999d32"
+  },
+  "tests/test_memory_graph_json_to_rdf.py": {
+    "mtime": 1780119290.9102213,
+    "ast_hash": "d121c16ab742a0c26c3013e81808c0a2",
+    "semantic_hash": "d121c16ab742a0c26c3013e81808c0a2"
+  },
+  "tests/test_memory_graph_project.py": {
+    "mtime": 1781138955.9704986,
+    "ast_hash": "c59c0dc85a6d0c48b4c7303d0e0bc748",
+    "semantic_hash": "c59c0dc85a6d0c48b4c7303d0e0bc748"
+  },
+  "tests/test_memory_graph_schema_contract.py": {
+    "mtime": 1779166416.997654,
+    "ast_hash": "eb31836bc1ef4abb7c2341adb17eb331",
+    "semantic_hash": "eb31836bc1ef4abb7c2341adb17eb331"
+  },
+  "tests/test_memory_graph_suggest_runner.py": {
+    "mtime": 1783807364.326837,
+    "ast_hash": "f2256ae01cf728c0762841f40754ad1a",
+    "semantic_hash": "f2256ae01cf728c0762841f40754ad1a"
+  },
+  "tests/test_memory_graph_suggest_validate.py": {
+    "mtime": 1780622613.6067643,
+    "ast_hash": "947ea34b625f073864447d689aafaa15",
+    "semantic_hash": "947ea34b625f073864447d689aafaa15"
+  },
+  "tests/test_memory_graph_utterance_text.py": {
+    "mtime": 1780100357.2205112,
+    "ast_hash": "1ae5dfba2934318b03ff920f32350586",
+    "semantic_hash": "1ae5dfba2934318b03ff920f32350586"
+  },
+  "tests/test_memory_graph_validate.py": {
+    "mtime": 1777758592.2252445,
+    "ast_hash": "edd86ac088a59801d21e3f964a6df014",
+    "semantic_hash": "edd86ac088a59801d21e3f964a6df014"
+  },
+  "tests/test_mentor_gateway_phase6.py": {
+    "mtime": 1775601136.3208966,
+    "ast_hash": "a4bbfeabe34fdb3bf745ad4338078f28",
+    "semantic_hash": "a4bbfeabe34fdb3bf745ad4338078f28"
+  },
+  "tests/test_metacog.py": {
+    "mtime": 1781405728.502089,
+    "ast_hash": "facd3ec72f32b5c976608935f1f53a46",
+    "semantic_hash": "facd3ec72f32b5c976608935f1f53a46"
+  },
+  "tests/test_metacog_context_summary.py": {
+    "mtime": 1783123491.839622,
+    "ast_hash": "613aed4c4855f7680493c01268e60350",
+    "semantic_hash": "613aed4c4855f7680493c01268e60350"
+  },
+  "tests/test_metacog_phase_contract.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "74c2c5aff6703801e24a92cdc5a4c6f8",
+    "semantic_hash": "74c2c5aff6703801e24a92cdc5a4c6f8"
+  },
+  "tests/test_metacog_prompt_phase_contract.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "33f3410fbf617b2a1a21a14ef122a9cc",
+    "semantic_hash": "33f3410fbf617b2a1a21a14ef122a9cc"
+  },
+  "tests/test_mind_llm_bus_catalog.py": {
+    "mtime": 1779078270.5556717,
+    "ast_hash": "52b58c77f0084b091173a470c392b44f",
+    "semantic_hash": "52b58c77f0084b091173a470c392b44f"
+  },
+  "tests/test_mind_run_artifact_registry.py": {
+    "mtime": 1779078270.5556717,
+    "ast_hash": "c1fc539651415b42363561a8fec62d6b",
+    "semantic_hash": "c1fc539651415b42363561a8fec62d6b"
+  },
+  "tests/test_mood_arc_encoder_fit_script.py": {
+    "mtime": 1783967452.5054061,
+    "ast_hash": "a838afb7d747db91da06dc5e465be8c4",
+    "semantic_hash": "a838afb7d747db91da06dc5e465be8c4"
+  },
+  "tests/test_mood_arc_encoder_schema.py": {
+    "mtime": 1783967452.5054061,
+    "ast_hash": "a14fe9d785f0bf6e53d86fc822632960",
+    "semantic_hash": "a14fe9d785f0bf6e53d86fc822632960"
+  },
+  "tests/test_node_biometrics_reducer.py": {
+    "mtime": 1781772134.803745,
+    "ast_hash": "2552139dea6b520142c8302d5f767f92",
+    "semantic_hash": "2552139dea6b520142c8302d5f767f92"
+  },
+  "tests/test_node_pressure_reducer.py": {
+    "mtime": 1779668837.6863048,
+    "ast_hash": "e8df5b0f9bb8fb4d395ff56a5642ad29",
+    "semantic_hash": "e8df5b0f9bb8fb4d395ff56a5642ad29"
+  },
+  "tests/test_notify_agent_trace_contract.py": {
+    "mtime": 1774417080.6557083,
+    "ast_hash": "470ea1b685cf64a5207189977eae506e",
+    "semantic_hash": "470ea1b685cf64a5207189977eae506e"
+  },
+  "tests/test_openai_message_content.py": {
+    "mtime": 1783107031.9869022,
+    "ast_hash": "299e71af47189f27f7b99e2b51c57ebd",
+    "semantic_hash": "299e71af47189f27f7b99e2b51c57ebd"
+  },
+  "tests/test_paradigm_registry.py": {
+    "mtime": 1783125791.0250878,
+    "ast_hash": "d077c99ccbd553ade501cb36207c386b",
+    "semantic_hash": "d077c99ccbd553ade501cb36207c386b"
+  },
+  "tests/test_phi_corpus_diag_script.py": {
+    "mtime": 1783644551.7176976,
+    "ast_hash": "9f837a3e0e30998cd929c757fd0c19a0",
+    "semantic_hash": "9f837a3e0e30998cd929c757fd0c19a0"
+  },
+  "tests/test_phi_encoder_fit_script.py": {
+    "mtime": 1783918473.8113108,
+    "ast_hash": "6b1f66712dcb000a2d213ccd1dc7b1ef",
+    "semantic_hash": "6b1f66712dcb000a2d213ccd1dc7b1ef"
+  },
+  "tests/test_phi_encoder_mlp.py": {
+    "mtime": 1783537420.320368,
+    "ast_hash": "e90b3a90e3a4e6f81a091fc0ef49671d",
+    "semantic_hash": "e90b3a90e3a4e6f81a091fc0ef49671d"
+  },
+  "tests/test_phi_encoder_schema.py": {
+    "mtime": 1783537420.320368,
+    "ast_hash": "5cbdc66bca7de741ffc56ebae0c171ed",
+    "semantic_hash": "5cbdc66bca7de741ffc56ebae0c171ed"
+  },
+  "tests/test_plan_loader.py": {
+    "mtime": 1783967452.5054061,
+    "ast_hash": "e3a9d7fc2f245966459a9f7dcc82eb00",
+    "semantic_hash": "e3a9d7fc2f245966459a9f7dcc82eb00"
+  },
+  "tests/test_policy_decision_builder.py": {
+    "mtime": 1779689417.3452013,
+    "ast_hash": "2a04257a51e8b026d0492a88dfe85e04",
+    "semantic_hash": "2a04257a51e8b026d0492a88dfe85e04"
+  },
+  "tests/test_policy_decision_frame_schemas.py": {
+    "mtime": 1779689417.3462012,
+    "ast_hash": "a7211babfa2474060baa594e9d3f6d2e",
+    "semantic_hash": "a7211babfa2474060baa594e9d3f6d2e"
+  },
+  "tests/test_policy_evaluator.py": {
+    "mtime": 1779689417.3462012,
+    "ast_hash": "c2f37e29edda02fb4b74718f5a8026ad",
+    "semantic_hash": "c2f37e29edda02fb4b74718f5a8026ad"
+  },
+  "tests/test_policy_loader.py": {
+    "mtime": 1779689417.3462012,
+    "ast_hash": "5f9fe6e9ba4cb5ecc65aac773a348588",
+    "semantic_hash": "5f9fe6e9ba4cb5ecc65aac773a348588"
+  },
+  "tests/test_policy_runtime_store.py": {
+    "mtime": 1783845232.210588,
+    "ast_hash": "7fdcfc42ce5bedccd3702b71dd302ed8",
+    "semantic_hash": "7fdcfc42ce5bedccd3702b71dd302ed8"
+  },
+  "tests/test_policy_runtime_worker.py": {
+    "mtime": 1783845232.210588,
+    "ast_hash": "06827b45d6cc58bb390183f66a6d350b",
+    "semantic_hash": "06827b45d6cc58bb390183f66a6d350b"
+  },
+  "tests/test_policy_transport_gates.py": {
+    "mtime": 1780622613.6077642,
+    "ast_hash": "5e75463bfdf0285356e957d1959eca48",
+    "semantic_hash": "5e75463bfdf0285356e957d1959eca48"
+  },
+  "tests/test_pre_turn_appraisal_schemas.py": {
+    "mtime": 1783125791.0260878,
+    "ast_hash": "02db78e5c957ea0a0e65a895e75df560",
+    "semantic_hash": "02db78e5c957ea0a0e65a895e75df560"
+  },
+  "tests/test_print_recent_turn_effects.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "3b105419c4cc1fc80d74f7f9f4182000",
+    "semantic_hash": "3b105419c4cc1fc80d74f7f9f4182000"
+  },
+  "tests/test_proposal_frame_builder.py": {
+    "mtime": 1784008374.246501,
+    "ast_hash": "dd0d31f8dd2301c109c0154ca5092cf3",
+    "semantic_hash": "dd0d31f8dd2301c109c0154ca5092cf3"
+  },
+  "tests/test_proposal_frame_schemas.py": {
+    "mtime": 1779687966.459823,
+    "ast_hash": "c653658851b7520965f776c64244d5f6",
+    "semantic_hash": "c653658851b7520965f776c64244d5f6"
+  },
+  "tests/test_proposal_policy_loader.py": {
+    "mtime": 1784008374.246501,
+    "ast_hash": "b0aedfce7ff07ed560cc34c260f0d378",
+    "semantic_hash": "b0aedfce7ff07ed560cc34c260f0d378"
+  },
+  "tests/test_proposal_runtime_store.py": {
+    "mtime": 1779687966.459823,
+    "ast_hash": "3e9b9478df645030cdc8bc952db00523",
+    "semantic_hash": "3e9b9478df645030cdc8bc952db00523"
+  },
+  "tests/test_proposal_runtime_worker.py": {
+    "mtime": 1779687966.459823,
+    "ast_hash": "df4d3ed8093db314f2aed96a69823736",
+    "semantic_hash": "df4d3ed8093db314f2aed96a69823736"
+  },
+  "tests/test_proposal_scoring.py": {
+    "mtime": 1779687966.459823,
+    "ast_hash": "986daef0ac0189fbe34fcc1f9ae5ecd0",
+    "semantic_hash": "986daef0ac0189fbe34fcc1f9ae5ecd0"
+  },
+  "tests/test_proposal_transport_readonly_candidates.py": {
+    "mtime": 1783834618.450997,
+    "ast_hash": "500e154ec5d759ee888de61302f9a065",
+    "semantic_hash": "500e154ec5d759ee888de61302f9a065"
+  },
+  "tests/test_queue_service_chassis.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "d2b5c95fc4f4baa4a18b7cd4eff6a45b",
+    "semantic_hash": "d2b5c95fc4f4baa4a18b7cd4eff6a45b"
+  },
+  "tests/test_reasoning_canonicalization_phase5.py": {
+    "mtime": 1775601136.3218966,
+    "ast_hash": "d23fd3ae79fadec6a3ba4855d78eed09",
+    "semantic_hash": "d23fd3ae79fadec6a3ba4855d78eed09"
+  },
+  "tests/test_reasoning_materialization_phase2.py": {
+    "mtime": 1775601136.3218966,
+    "ast_hash": "165ec79143a078bfb524da199703c33c",
+    "semantic_hash": "165ec79143a078bfb524da199703c33c"
+  },
+  "tests/test_reasoning_promotion_phase3.py": {
+    "mtime": 1775601136.3218966,
+    "ast_hash": "3572882ee4f60bffbbae95bdb0ced4ff",
+    "semantic_hash": "3572882ee4f60bffbbae95bdb0ced4ff"
+  },
+  "tests/test_reasoning_schemas_phase1.py": {
+    "mtime": 1775601136.3218966,
+    "ast_hash": "b8d17393c39e8368693a44a74947dc1d",
+    "semantic_hash": "b8d17393c39e8368693a44a74947dc1d"
+  },
+  "tests/test_reasoning_spark_adapter_phase2.py": {
+    "mtime": 1775601136.3218966,
+    "ast_hash": "8597f864e3a5c8b1a3ef1d565aad8811",
+    "semantic_hash": "8597f864e3a5c8b1a3ef1d565aad8811"
+  },
+  "tests/test_reasoning_summary_phase4.py": {
+    "mtime": 1775601136.3218966,
+    "ast_hash": "59afd6c489f64af555a5a06cd4680b89",
+    "semantic_hash": "59afd6c489f64af555a5a06cd4680b89"
+  },
+  "tests/test_recall_alert_profile.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "a28851ac0ec41cd499443916f60814cf",
+    "semantic_hash": "a28851ac0ec41cd499443916f60814cf"
+  },
+  "tests/test_recall_deep_graph.py": {
+    "mtime": 1768597909.912229,
+    "ast_hash": "84e74278d57becf35d9288a5a6d7adee",
+    "semantic_hash": "84e74278d57becf35d9288a5a6d7adee"
+  },
+  "tests/test_recall_diagnostic_schema_registry.py": {
+    "mtime": 1779070080.280205,
+    "ast_hash": "18346bd80ddfb37911eb0e73b4a21c3f",
+    "semantic_hash": "18346bd80ddfb37911eb0e73b4a21c3f"
+  },
+  "tests/test_recall_eligibility.py": {
+    "mtime": 1783555541.5466743,
+    "ast_hash": "b7c493ac6a12254be5a43a3eab711b03",
+    "semantic_hash": "b7c493ac6a12254be5a43a3eab711b03"
+  },
+  "tests/test_recall_pcr_contract.py": {
+    "mtime": 1783398623.0141568,
+    "ast_hash": "387eb4a5171c1f520b97bf3d0dcdfb47",
+    "semantic_hash": "387eb4a5171c1f520b97bf3d0dcdfb47"
+  },
+  "tests/test_recall_profiles_cards_knobs.py": {
+    "mtime": 1780779151.183656,
+    "ast_hash": "cbb6c4dabbbbdfd5d95d1593db8728a9",
+    "semantic_hash": "cbb6c4dabbbbdfd5d95d1593db8728a9"
+  },
+  "tests/test_recall_skip_gate.py": {
+    "mtime": 1783398623.0141568,
+    "ast_hash": "2ba8aede7ad0f2ee82af32f99424a35e",
+    "semantic_hash": "2ba8aede7ad0f2ee82af32f99424a35e"
+  },
+  "tests/test_receipt_pruner.py": {
+    "mtime": 1780613748.3904252,
+    "ast_hash": "d622806fc3e59cd2f71443e61e0d29a7",
+    "semantic_hash": "d622806fc3e59cd2f71443e61e0d29a7"
+  },
+  "tests/test_receipt_retention.py": {
+    "mtime": 1780613748.8364234,
+    "ast_hash": "de7adf34b0e6e4a91f8290ce0eb7c8c6",
+    "semantic_hash": "de7adf34b0e6e4a91f8290ce0eb7c8c6"
+  },
+  "tests/test_recent_turn_effect_alerts.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "bfc8d246a4b6247bbff2d658e784b66e",
+    "semantic_hash": "bfc8d246a4b6247bbff2d658e784b66e"
+  },
+  "tests/test_repair_pressure_appraisal.py": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "a633f8913a6ec967a598c94963c8084f",
+    "semantic_hash": "a633f8913a6ec967a598c94963c8084f"
+  },
+  "tests/test_repair_pressure_behavior_contract.py": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "f83cc50d005a6584dbd74f365fdc7b88",
+    "semantic_hash": "f83cc50d005a6584dbd74f365fdc7b88"
+  },
+  "tests/test_repair_pressure_contract_v2.py": {
+    "mtime": 1783125791.0260878,
+    "ast_hash": "1cf01790f03493bf5c9cbdacc6d3c054",
+    "semantic_hash": "1cf01790f03493bf5c9cbdacc6d3c054"
+  },
+  "tests/test_repair_pressure_e2e.py": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "f28015d76c1f83536aa37bf3d14e8b95",
+    "semantic_hash": "f28015d76c1f83536aa37bf3d14e8b95"
+  },
+  "tests/test_repair_pressure_evidence.py": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "a6cb559aca7c1b13948df2c605ec884e",
+    "semantic_hash": "a6cb559aca7c1b13948df2c605ec884e"
+  },
+  "tests/test_repair_pressure_models.py": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "f10c37dca46a3f4595edfd2698f17729",
+    "semantic_hash": "f10c37dca46a3f4595edfd2698f17729"
+  },
+  "tests/test_repair_pressure_signal_bridge.py": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "4276abef69d67884ecda9c9af339cc66",
+    "semantic_hash": "4276abef69d67884ecda9c9af339cc66"
+  },
+  "tests/test_repair_pressure_v2_paradigm.py": {
+    "mtime": 1783136738.0588806,
+    "ast_hash": "158432a9f77e1de665314d57c553fcca",
+    "semantic_hash": "158432a9f77e1de665314d57c553fcca"
+  },
+  "tests/test_repair_pressure_windowing.py": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "2a87a1f04682d2e9c48ce40c54c1016b",
+    "semantic_hash": "2a87a1f04682d2e9c48ce40c54c1016b"
+  },
+  "tests/test_retrieval_intent.py": {
+    "mtime": 1783555541.5466743,
+    "ast_hash": "6bb0981bfc076ae77b3a85a20bf3f9df",
+    "semantic_hash": "6bb0981bfc076ae77b3a85a20bf3f9df"
+  },
+  "tests/test_route_substrate_reducer.py": {
+    "mtime": 1783903398.649444,
+    "ast_hash": "ffbaf3e7b26e3d4c1f00b85ed5c9d3ad",
+    "semantic_hash": "ffbaf3e7b26e3d4c1f00b85ed5c9d3ad"
+  },
+  "tests/test_schema_registry_import_light.py": {
+    "mtime": 1783125791.0260878,
+    "ast_hash": "f6d2413f692c67987f1a2a11865df3ea",
+    "semantic_hash": "f6d2413f692c67987f1a2a11865df3ea"
+  },
+  "tests/test_self_state_builder.py": {
+    "mtime": 1783897997.643214,
+    "ast_hash": "1df02b124323ea74b5c13cb1e6689258",
+    "semantic_hash": "1df02b124323ea74b5c13cb1e6689258"
+  },
+  "tests/test_self_state_builder_hardening.py": {
+    "mtime": 1783836411.4424524,
+    "ast_hash": "dd9162d1ed70b402547c84f1cd9475bb",
+    "semantic_hash": "dd9162d1ed70b402547c84f1cd9475bb"
+  },
+  "tests/test_self_state_deviation.py": {
+    "mtime": 1783841798.491563,
+    "ast_hash": "6359232d54b5275565678adb4a6498f6",
+    "semantic_hash": "6359232d54b5275565678adb4a6498f6"
+  },
+  "tests/test_self_state_policy_loader.py": {
+    "mtime": 1783836422.8648114,
+    "ast_hash": "915db2e7c59c05ef9a1842a2a0bd512e",
+    "semantic_hash": "915db2e7c59c05ef9a1842a2a0bd512e"
+  },
+  "tests/test_self_state_prediction.py": {
+    "mtime": 1782874038.2589726,
+    "ast_hash": "6221e254a93d702e176475ead606214e",
+    "semantic_hash": "6221e254a93d702e176475ead606214e"
+  },
+  "tests/test_self_state_reliability_decontamination.py": {
+    "mtime": 1783836429.3520155,
+    "ast_hash": "a3b9828c36e2095808a266658ade138e",
+    "semantic_hash": "a3b9828c36e2095808a266658ade138e"
+  },
+  "tests/test_self_state_runtime_store.py": {
+    "mtime": 1779683294.7627108,
+    "ast_hash": "ff5f5eafc526e37e4d9aacac12728511",
+    "semantic_hash": "ff5f5eafc526e37e4d9aacac12728511"
+  },
+  "tests/test_self_state_schemas.py": {
+    "mtime": 1779683294.7627108,
+    "ast_hash": "9323850e5027bd76959f76076547ec79",
+    "semantic_hash": "9323850e5027bd76959f76076547ec79"
+  },
+  "tests/test_self_state_scoring.py": {
+    "mtime": 1783843021.920588,
+    "ast_hash": "8a6bd54c0a964b8adec250b11d4fdf22",
+    "semantic_hash": "8a6bd54c0a964b8adec250b11d4fdf22"
+  },
+  "tests/test_self_state_transport_dimension.py": {
+    "mtime": 1783836497.883172,
+    "ast_hash": "53a7de17e292a7e88160180e1b2145eb",
+    "semantic_hash": "53a7de17e292a7e88160180e1b2145eb"
+  },
+  "tests/test_single_consumer_channels_gate.py": {
+    "mtime": 1783957069.416255,
+    "ast_hash": "fb23d596c432bfc5d56c2065a13b9859",
+    "semantic_hash": "fb23d596c432bfc5d56c2065a13b9859"
+  },
+  "tests/test_social_inspection.py": {
+    "mtime": 1783107031.9869022,
+    "ast_hash": "24903a3746daa9196544cf758d20c4af",
+    "semantic_hash": "24903a3746daa9196544cf758d20c4af"
+  },
+  "tests/test_social_room_prompt.py": {
+    "mtime": 1777748523.3465996,
+    "ast_hash": "3abb78fb5d8dbab1b073e1e8f6710b1c",
+    "semantic_hash": "3abb78fb5d8dbab1b073e1e8f6710b1c"
+  },
+  "tests/test_social_room_scenario_replay.py": {
+    "mtime": 1774236180.459385,
+    "ast_hash": "ec15b609bf8a5317d73505fc98c61c91",
+    "semantic_hash": "ec15b609bf8a5317d73505fc98c61c91"
+  },
+  "tests/test_social_room_shakedown.py": {
+    "mtime": 1774236180.459385,
+    "ast_hash": "94002a0917c82f0c87b071b35c119a0e",
+    "semantic_hash": "94002a0917c82f0c87b071b35c119a0e"
+  },
+  "tests/test_spark_concept_profile_graph_schema_registry.py": {
+    "mtime": 1774680717.5299358,
+    "ast_hash": "2e3e919ebb84764f66ec8a8aa03b47cf",
+    "semantic_hash": "2e3e919ebb84764f66ec8a8aa03b47cf"
+  },
+  "tests/test_spark_contract_gate.py": {
+    "mtime": 1769663878.094563,
+    "ast_hash": "2d75907ff95cc849186b8eb691ad5c2c",
+    "semantic_hash": "2d75907ff95cc849186b8eb691ad5c2c"
+  },
+  "tests/test_spark_contract_metrics.py": {
+    "mtime": 1769663878.094563,
+    "ast_hash": "8656e0f42203f86aaf49a3a346c0b8df",
+    "semantic_hash": "8656e0f42203f86aaf49a3a346c0b8df"
+  },
+  "tests/test_spark_introspector_no_legacy.py": {
+    "mtime": 1769663878.094563,
+    "ast_hash": "582ad8fd142d2484a7d460987faa2d57",
+    "semantic_hash": "582ad8fd142d2484a7d460987faa2d57"
+  },
+  "tests/test_spark_introspector_publish_guard.py": {
+    "mtime": 1781048876.1341224,
+    "ast_hash": "33ef881fc0c48b9289438833edef121d",
+    "semantic_hash": "33ef881fc0c48b9289438833edef121d"
+  },
+  "tests/test_spark_metrics_v2.py": {
+    "mtime": 1783716548.5476468,
+    "ast_hash": "9cb5610f1f552a1ecd91b30f681b12dc",
+    "semantic_hash": "9cb5610f1f552a1ecd91b30f681b12dc"
+  },
+  "tests/test_spark_normalizer.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "c0e50fe899f85a58d2b2dce25d509b84",
+    "semantic_hash": "c0e50fe899f85a58d2b2dce25d509b84"
+  },
+  "tests/test_sql_writer_chat_feedback.py": {
+    "mtime": 1775629219.325953,
+    "ast_hash": "fe65ea138ca4ea847ba6c4f79f0e0982",
+    "semantic_hash": "fe65ea138ca4ea847ba6c4f79f0e0982"
+  },
+  "tests/test_sql_writer_journal.py": {
+    "mtime": 1774236180.459385,
+    "ast_hash": "b2281410e29f96c6eb4893041c81097b",
+    "semantic_hash": "b2281410e29f96c6eb4893041c81097b"
+  },
+  "tests/test_sql_writer_legacy_mode.py": {
+    "mtime": 1769663878.0955632,
+    "ast_hash": "7f7c6722a1edcef87099756840d74660",
+    "semantic_hash": "7f7c6722a1edcef87099756840d74660"
+  },
+  "tests/test_sql_writer_spark_mapping.py": {
+    "mtime": 1769663878.0955632,
+    "ast_hash": "06edab075522bf956bd63d858bc91b10",
+    "semantic_hash": "06edab075522bf956bd63d858bc91b10"
+  },
+  "tests/test_state_journaler_semantics.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "a129ec816b238f459bc0d8a64e9bf50c",
+    "semantic_hash": "a129ec816b238f459bc0d8a64e9bf50c"
+  },
+  "tests/test_state_service_http_latest.py": {
+    "mtime": 1783890426.4927747,
+    "ast_hash": "3dab5a17122cb8e3d41c0fed8b46992b",
+    "semantic_hash": "3dab5a17122cb8e3d41c0fed8b46992b"
+  },
+  "tests/test_state_service_snapshot_ack.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "eeecc0f31669719aaca3001961cbc557",
+    "semantic_hash": "eeecc0f31669719aaca3001961cbc557"
+  },
+  "tests/test_substrate_brain_frame_bus_catalog.py": {
+    "mtime": 1783468068.6378665,
+    "ast_hash": "0b212b5eb9e322d11bd9d42aa250ad3a",
+    "semantic_hash": "0b212b5eb9e322d11bd9d42aa250ad3a"
+  },
+  "tests/test_substrate_deterministic_ids.py": {
+    "mtime": 1779668837.6863048,
+    "ast_hash": "55eb8a1018c589183db36466aa39f0c3",
+    "semantic_hash": "55eb8a1018c589183db36466aa39f0c3"
+  },
+  "tests/test_substrate_effect_view_model.py": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "ae66689919fb15f287b3830c7ad28f03",
+    "semantic_hash": "ae66689919fb15f287b3830c7ad28f03"
+  },
+  "tests/test_substrate_experiment_harness.py": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "307258c31d2d2af590d2add07a77cfc9",
+    "semantic_hash": "307258c31d2d2af590d2add07a77cfc9"
+  },
+  "tests/test_substrate_kernel_atoms.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "fa9512c6f15ec8d691f97fcb78a8eda6",
+    "semantic_hash": "fa9512c6f15ec8d691f97fcb78a8eda6"
+  },
+  "tests/test_substrate_kernel_molecules.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "3045b393426b3bbf5ff13991113df2b3",
+    "semantic_hash": "3045b393426b3bbf5ff13991113df2b3"
+  },
+  "tests/test_substrate_kernel_operators.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "bb98405e7a0f500f263b158f09f7790d",
+    "semantic_hash": "bb98405e7a0f500f263b158f09f7790d"
+  },
+  "tests/test_substrate_lineage.py": {
+    "mtime": 1779668837.6863048,
+    "ast_hash": "b76d65ae0bc3f28430aa6b06fb1bff41",
+    "semantic_hash": "b76d65ae0bc3f28430aa6b06fb1bff41"
+  },
+  "tests/test_substrate_organ_emit.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "f400920eeadd230f5550267c60e935da",
+    "semantic_hash": "f400920eeadd230f5550267c60e935da"
+  },
+  "tests/test_substrate_signal_bridge.py": {
+    "mtime": 1782190803.1043248,
+    "ast_hash": "c826e0bbecec132dd8fdd0083778510e",
+    "semantic_hash": "c826e0bbecec132dd8fdd0083778510e"
+  },
+  "tests/test_substrate_signal_bridge_e2e.py": {
+    "mtime": 1781854374.4566925,
+    "ast_hash": "d42d19b79072d14f0c655cf4c4bd6a59",
+    "semantic_hash": "d42d19b79072d14f0c655cf4c4bd6a59"
+  },
+  "tests/test_telemetry_normalization.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "ade53b91c8413e1ca59d1781b19ad661",
+    "semantic_hash": "ade53b91c8413e1ca59d1781b19ad661"
+  },
+  "tests/test_top_down.py": {
+    "mtime": 1783499830.2085214,
+    "ast_hash": "a8e59ff703356aacf367260615d6ea82",
+    "semantic_hash": "a8e59ff703356aacf367260615d6ea82"
+  },
+  "tests/test_topic_foundry_capabilities_defaults.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "4e533987711824dc3b63d820c97ab6c6",
+    "semantic_hash": "4e533987711824dc3b63d820c97ab6c6"
+  },
+  "tests/test_topic_foundry_model_meta_merge.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "0c9f61b2ffd89b45a2c1e7469572ed35",
+    "semantic_hash": "0c9f61b2ffd89b45a2c1e7469572ed35"
+  },
+  "tests/test_topic_foundry_training_json_safe.py": {
+    "mtime": 1773975149.9787858,
+    "ast_hash": "af3c2ef87081a51d150d04d7e2abeb70",
+    "semantic_hash": "af3c2ef87081a51d150d04d7e2abeb70"
+  },
+  "tests/test_topic_foundry_vectorizer_stop_words.py": {
+    "mtime": 1773975149.9797857,
+    "ast_hash": "e1e62e29e71b8b9e8b4da9ea115de463",
+    "semantic_hash": "e1e62e29e71b8b9e8b4da9ea115de463"
+  },
+  "tests/test_topic_foundry_windowing_heuristic.py": {
+    "mtime": 1773975149.9797857,
+    "ast_hash": "dd1850e638feffeaa3dfe317109dbd10",
+    "semantic_hash": "dd1850e638feffeaa3dfe317109dbd10"
+  },
+  "tests/test_trace_unified_turn.py": {
+    "mtime": 1783316816.2532282,
+    "ast_hash": "cdf3c02a1eb4d90cab92269d47064105",
+    "semantic_hash": "cdf3c02a1eb4d90cab92269d47064105"
+  },
+  "tests/test_transport_projection_schemas.py": {
+    "mtime": 1780622613.6077642,
+    "ast_hash": "5939f95413d613cb8b86d81bd502440b",
+    "semantic_hash": "5939f95413d613cb8b86d81bd502440b"
+  },
+  "tests/test_transport_substrate_pipeline.py": {
+    "mtime": 1780622613.6077642,
+    "ast_hash": "b47996afb93c9ba3f643b2707a78faff",
+    "semantic_hash": "b47996afb93c9ba3f643b2707a78faff"
+  },
+  "tests/test_transport_substrate_reducer.py": {
+    "mtime": 1780622613.6077642,
+    "ast_hash": "e6dac7314f57ea7151dcfd2ebb721786",
+    "semantic_hash": "e6dac7314f57ea7151dcfd2ebb721786"
+  },
+  "tests/test_turn_change_classify.py": {
+    "mtime": 1782438858.7286398,
+    "ast_hash": "c4c96ba7f4323bca119d7c06aac6a496",
+    "semantic_hash": "c4c96ba7f4323bca119d7c06aac6a496"
+  },
+  "tests/test_turn_effect.py": {
+    "mtime": 1782190803.1043248,
+    "ast_hash": "d0c328b1fd5520c5839c75201c4667c7",
+    "semantic_hash": "d0c328b1fd5520c5839c75201c4667c7"
+  },
+  "tests/test_turn_effect_alert_logging.py": {
+    "mtime": 1773975149.9797857,
+    "ast_hash": "49baf7866ee2b29e1e2082f3b91791d1",
+    "semantic_hash": "49baf7866ee2b29e1e2082f3b91791d1"
+  },
+  "tests/test_turn_effect_explanations.py": {
+    "mtime": 1773975149.9797857,
+    "ast_hash": "06bd742c397b5db3ef8132228e457901",
+    "semantic_hash": "06bd742c397b5db3ef8132228e457901"
+  },
+  "tests/test_turn_effect_policy.py": {
+    "mtime": 1773975149.9797857,
+    "ast_hash": "2f7b1e88598de8b7e3d9a7433e1efb5d",
+    "semantic_hash": "2f7b1e88598de8b7e3d9a7433e1efb5d"
+  },
+  "tests/test_turn_window.py": {
+    "mtime": 1783125791.0260878,
+    "ast_hash": "01562759d6b4f742cc9d22272603ce0e",
+    "semantic_hash": "01562759d6b4f742cc9d22272603ce0e"
+  },
+  "tests/test_unified_turn_bus_catalog.py": {
+    "mtime": 1783554331.4044738,
+    "ast_hash": "4fc116418a56380ff1d61655fb51b410",
+    "semantic_hash": "4fc116418a56380ff1d61655fb51b410"
+  },
+  "tests/test_unified_turn_schemas.py": {
+    "mtime": 1783551182.7605677,
+    "ast_hash": "65f8afe677ee1f41dc7c781ae93aaa13",
+    "semantic_hash": "65f8afe677ee1f41dc7c781ae93aaa13"
+  },
+  "tests/test_vision_edge_activity_bus_catalog.py": {
+    "mtime": 1783110541.1479034,
+    "ast_hash": "72352ee2dbacd3f0f23525b8ab0b689a",
+    "semantic_hash": "72352ee2dbacd3f0f23525b8ab0b689a"
+  },
+  "tests/test_vision_edge_activity_schema.py": {
+    "mtime": 1783028252.5533528,
+    "ast_hash": "179f2ed9826feaf262cf6e5e17e93928",
+    "semantic_hash": "179f2ed9826feaf262cf6e5e17e93928"
+  },
+  "tests/test_vision_interpretation_contract.py": {
+    "mtime": 1783107031.9869022,
+    "ast_hash": "848eb19bace0e3ed91bbfef2908b1714",
+    "semantic_hash": "848eb19bace0e3ed91bbfef2908b1714"
+  },
+  "tests/test_vision_retina_capture_once.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "0bd1522cc0ed2a6d8819397e9a2c8978",
+    "semantic_hash": "0bd1522cc0ed2a6d8819397e9a2c8978"
+  },
+  "tests/test_vision_retina_envelopes.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "13b65e8a55f99f455465d5ba147cb737",
+    "semantic_hash": "13b65e8a55f99f455465d5ba147cb737"
+  },
+  "tests/test_vision_retina_frame_store.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "f2ca0bcaa9342fe909e31fe6d342a8b4",
+    "semantic_hash": "f2ca0bcaa9342fe909e31fe6d342a8b4"
+  },
+  "tests/test_vision_retina_health.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "346e58a3dc767732907d6cdf7f373116",
+    "semantic_hash": "346e58a3dc767732907d6cdf7f373116"
+  },
+  "tests/test_vision_retina_no_detector.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "80102a6dbb15d3d7db73c2887a40fcea",
+    "semantic_hash": "80102a6dbb15d3d7db73c2887a40fcea"
+  },
+  "tests/test_vision_retina_settings.py": {
+    "mtime": 1782879116.764166,
+    "ast_hash": "38e67e337f9cc549fa28712d58cbc15b",
+    "semantic_hash": "38e67e337f9cc549fa28712d58cbc15b"
+  },
+  "tests/test_vision_retina_sources.py": {
+    "mtime": 1779649387.8202987,
+    "ast_hash": "352ec90f82265f25d37ffcecee9e310f",
+    "semantic_hash": "352ec90f82265f25d37ffcecee9e310f"
+  },
+  "tests/test_voluntary_attention_wiring.py": {
+    "mtime": 1783499830.2085214,
+    "ast_hash": "a355a3418673ea46583ac6fc587b7a38",
+    "semantic_hash": "a355a3418673ea46583ac6fc587b7a38"
+  },
+  "tests/test_work_queue.py": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "175db31e6ab8bed8c3b6e20d3378fcd5",
+    "semantic_hash": "175db31e6ab8bed8c3b6e20d3378fcd5"
+  },
+  "tests/test_workflow_execution_policy.py": {
+    "mtime": 1774417080.6557083,
+    "ast_hash": "f91e49889d7083cd84d483b99f115a7e",
+    "semantic_hash": "f91e49889d7083cd84d483b99f115a7e"
+  },
+  "tests/test_workflow_ui_js.py": {
+    "mtime": 1774417080.6557083,
+    "ast_hash": "8af6808e83b6650ef1752f096ff7207e",
+    "semantic_hash": "8af6808e83b6650ef1752f096ff7207e"
+  },
+  "tests/test_world_pulse_reflective_journal.py": {
+    "mtime": 1783548475.2032118,
+    "ast_hash": "3df9ca5ce90e351edf16cd4d76f3a16b",
+    "semantic_hash": "3df9ca5ce90e351edf16cd4d76f3a16b"
+  },
+  "tests/test_world_pulse_reflective_journal_bus_catalog.py": {
+    "mtime": 1779330729.1111808,
+    "ast_hash": "8a0772731179654c97b6204c4dd3f453",
+    "semantic_hash": "8a0772731179654c97b6204c4dd3f453"
+  },
+  "tests/training/test_chatgpt_qlora_pipeline.py": {
+    "mtime": 1776925210.021162,
+    "ast_hash": "7fee6d25b228d4cefdd258ec0170e834",
+    "semantic_hash": "7fee6d25b228d4cefdd258ec0170e834"
+  },
+  ".claude/commands/forge-arsonist.md": {
+    "mtime": 1779310786.0180037,
+    "ast_hash": "a85eba675e27f9200c811f704414bf45",
+    "semantic_hash": "a85eba675e27f9200c811f704414bf45"
+  },
+  ".claude/commands/forge-context-pack.md": {
+    "mtime": 1779310786.0180037,
+    "ast_hash": "6d07465a9ef4c5802893890780e7df51",
+    "semantic_hash": "6d07465a9ef4c5802893890780e7df51"
+  },
+  ".claude/commands/forge-critique.md": {
+    "mtime": 1779310786.0180037,
+    "ast_hash": "0c9e599a4ec954789c0f7a2870dd7aba",
+    "semantic_hash": "0c9e599a4ec954789c0f7a2870dd7aba"
+  },
+  ".claude/commands/forge-spec.md": {
+    "mtime": 1779310786.0180037,
+    "ast_hash": "afa4581747b1530b59d85940513c6f21",
+    "semantic_hash": "afa4581747b1530b59d85940513c6f21"
+  },
+  ".claude/commands/superpowers/brainstorming.md": {
+    "mtime": 1782182699.1160815,
+    "ast_hash": "1743aeea92250e34ad741b6f730267c7",
+    "semantic_hash": "1743aeea92250e34ad741b6f730267c7"
+  },
+  ".claude/commands/superpowers/subagent-driven-development.md": {
+    "mtime": 1782869034.1047947,
+    "ast_hash": "0b2bedb25fcd846ab9e5fb6d8a92a919",
+    "semantic_hash": "0b2bedb25fcd846ab9e5fb6d8a92a919"
+  },
+  ".github/workflows/orion-signal-gateway-tests.yml": {
+    "mtime": 1777790653.2130318,
+    "ast_hash": "04ee8fa9d8dd740aa4a2b329728c4c70",
+    "semantic_hash": "04ee8fa9d8dd740aa4a2b329728c4c70"
+  },
+  ".github/workflows/orion-sql-writer-tests.yml": {
+    "mtime": 1781395651.2085693,
+    "ast_hash": "1db1ae37e48ecfc9358d2d95d01aba31",
+    "semantic_hash": "1db1ae37e48ecfc9358d2d95d01aba31"
+  },
+  ".github/workflows/schedule-browser-smoke.yml": {
+    "mtime": 1774564470.0461712,
+    "ast_hash": "fad61f2ffa179bda3ddc197b38eeacf9",
+    "semantic_hash": "fad61f2ffa179bda3ddc197b38eeacf9"
+  },
+  "2026-07-11-turn-visibility-design-spec.md": {
+    "mtime": 1783805454.210303,
+    "ast_hash": "bf1242b8f0e4e4bc5833e223cfcbb601",
+    "semantic_hash": "bf1242b8f0e4e4bc5833e223cfcbb601"
+  },
+  "AGENTS.md": {
+    "mtime": 1784011930.1179996,
+    "ast_hash": "3e3caf6301f03f45b9515f98fe8b80ec",
+    "semantic_hash": "3e3caf6301f03f45b9515f98fe8b80ec"
+  },
+  "CLAUDE.md": {
+    "mtime": 1784011930.1179996,
+    "ast_hash": "3e3caf6301f03f45b9515f98fe8b80ec",
+    "semantic_hash": "3e3caf6301f03f45b9515f98fe8b80ec"
+  },
+  "README.md": {
+    "mtime": 1783551182.7565675,
+    "ast_hash": "7c74ab62de78fa1815e9ec6dc4daec22",
+    "semantic_hash": "7c74ab62de78fa1815e9ec6dc4daec22"
+  },
+  "codex_reviews/audit_001/reports/channel_triage.md": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "b007c12a7685f376ac22598845760d46",
+    "semantic_hash": "b007c12a7685f376ac22598845760d46"
+  },
+  "codex_reviews/audit_001/reports_postfix/channel_triage.md": {
+    "mtime": 1783573136.016604,
+    "ast_hash": "a3465aec2555cb1d92a53a896e096316",
+    "semantic_hash": "a3465aec2555cb1d92a53a896e096316"
+  },
+  "codex_reviews/audit_002/reports/channel_triage.md": {
+    "mtime": 1783573136.0176039,
+    "ast_hash": "a3465aec2555cb1d92a53a896e096316",
+    "semantic_hash": "a3465aec2555cb1d92a53a896e096316"
+  },
+  "config/attention/field_attention_policy.v1.yaml": {
+    "mtime": 1780622613.5887644,
+    "ast_hash": "eb6cc866e20197f27f3be0fb58922ed6",
+    "semantic_hash": "eb6cc866e20197f27f3be0fb58922ed6"
+  },
+  "config/autonomy/capability_policy.v1.yaml": {
+    "mtime": 1784008374.2395005,
+    "ast_hash": "749adc82c3c5f3e673f67e01fbc91780",
+    "semantic_hash": "749adc82c3c5f3e673f67e01fbc91780"
+  },
+  "config/autonomy/signal_drive_map.yaml": {
+    "mtime": 1783720227.3439958,
+    "ast_hash": "159035bc9dd88830ddf82e98400dd050",
+    "semantic_hash": "159035bc9dd88830ddf82e98400dd050"
+  },
+  "config/biometrics/node_catalog.yaml": {
+    "mtime": 1779668252.1370118,
+    "ast_hash": "c05d81bcd8d19481bb49bc2f018113ca",
+    "semantic_hash": "c05d81bcd8d19481bb49bc2f018113ca"
+  },
+  "config/consolidation/consolidation_policy.v1.yaml": {
+    "mtime": 1780622613.5897644,
+    "ast_hash": "a6c5676454708c815d6fa06a20f81cf0",
+    "semantic_hash": "a6c5676454708c815d6fa06a20f81cf0"
+  },
+  "config/execution_dispatch/execution_dispatch_policy.v1.yaml": {
+    "mtime": 1783967452.498406,
+    "ast_hash": "bfe8a54a289722a258e0cac7ca7a1998",
+    "semantic_hash": "bfe8a54a289722a258e0cac7ca7a1998"
+  },
+  "config/feedback/feedback_policy.v1.yaml": {
+    "mtime": 1779722671.518158,
+    "ast_hash": "1248b52401860e35a89fa3f9e9d9967c",
+    "semantic_hash": "1248b52401860e35a89fa3f9e9d9967c"
+  },
+  "config/field/biometrics_lattice.yaml": {
+    "mtime": 1781897477.580087,
+    "ast_hash": "7e803dcac9b4d2fff382dc82eab28921",
+    "semantic_hash": "7e803dcac9b4d2fff382dc82eab28921"
+  },
+  "config/field/orion_field_topology.v1.yaml": {
+    "mtime": 1783490446.2983592,
+    "ast_hash": "1af375456339557af7dbdd7b65b8508a",
+    "semantic_hash": "1af375456339557af7dbdd7b65b8508a"
+  },
+  "config/llm_profiles.yaml": {
+    "mtime": 1783807361.8437579,
+    "ast_hash": "424c55934aead93380cf272598459ef0",
+    "semantic_hash": "424c55934aead93380cf272598459ef0"
+  },
+  "config/memory_graph/projector_mapping.yaml": {
+    "mtime": 1780988938.1546035,
+    "ast_hash": "35bdd9bf848c1274907fafb3e4ae71d4",
+    "semantic_hash": "35bdd9bf848c1274907fafb3e4ae71d4"
+  },
+  "config/mesh_remediation_roster.yaml": {
+    "mtime": 1781846476.490166,
+    "ast_hash": "d7ba0e28205cfb9fbb1fbeb53a4840f3",
+    "semantic_hash": "d7ba0e28205cfb9fbb1fbeb53a4840f3"
+  },
+  "config/policy/substrate_policy.v1.yaml": {
+    "mtime": 1780622613.5907643,
+    "ast_hash": "e95fed0400e68b5554092052c102af2c",
+    "semantic_hash": "e95fed0400e68b5554092052c102af2c"
+  },
+  "config/proposals/proposal_policy.v1.yaml": {
+    "mtime": 1784008374.2395005,
+    "ast_hash": "232afe1cebac3f41042bcfddb10a9bff",
+    "semantic_hash": "232afe1cebac3f41042bcfddb10a9bff"
+  },
+  "config/self_state/self_state_policy.v1.yaml": {
+    "mtime": 1783841798.4905632,
+    "ast_hash": "0042b4dd652cc36cb0e0de6e84877ed1",
+    "semantic_hash": "0042b4dd652cc36cb0e0de6e84877ed1"
+  },
+  "config/substrate-lattice/action_ceiling_policy.v1.yaml": {
+    "mtime": 1780972924.4312649,
+    "ast_hash": "75bf654d2867ba009e62ef6c9892d5a4",
+    "semantic_hash": "75bf654d2867ba009e62ef6c9892d5a4"
+  },
+  "config/substrate-lattice/gate_policy.v1.yaml": {
+    "mtime": 1780972924.4312649,
+    "ast_hash": "c299f3b890675bfa377b90d9223c0b13",
+    "semantic_hash": "c299f3b890675bfa377b90d9223c0b13"
+  },
+  "config/substrate-lattice/grammar_producer_registry.v1.yaml": {
+    "mtime": 1783903398.6384437,
+    "ast_hash": "22515f3e74b40465e59d2ab901ad1cb5",
+    "semantic_hash": "22515f3e74b40465e59d2ab901ad1cb5"
+  },
+  "config/substrate-lattice/transport_lattice_policy.v1.yaml": {
+    "mtime": 1780972924.4312649,
+    "ast_hash": "4b708feb23b15378faf3d31e544d6e3b",
+    "semantic_hash": "4b708feb23b15378faf3d31e544d6e3b"
+  },
+  "config/substrate/repair_pressure_weights.v2.yaml": {
+    "mtime": 1783125791.0170875,
+    "ast_hash": "09d6c6c1c320f87a84d4c89a15708ae0",
+    "semantic_hash": "09d6c6c1c320f87a84d4c89a15708ae0"
+  },
+  "config/vision_frame_router.yaml": {
+    "mtime": 1783110541.1409032,
+    "ast_hash": "1e493f7af70b6825dd5b906028b43720",
+    "semantic_hash": "1e493f7af70b6825dd5b906028b43720"
+  },
+  "config/vision_profiles.yaml": {
+    "mtime": 1783107031.9669015,
+    "ast_hash": "39ab7339b12d86f0498ba38bea3c1a24",
+    "semantic_hash": "39ab7339b12d86f0498ba38bea3c1a24"
+  },
+  "config/world_pulse/sources.yaml": {
+    "mtime": 1783915348.4277909,
+    "ast_hash": "7cbfbfc1f7ed3e20b08942ef6526bf42",
+    "semantic_hash": "7cbfbfc1f7ed3e20b08942ef6526bf42"
+  },
+  "mesh-utilities/bootstrap/README.md": {
+    "mtime": 1763232123.3948905,
+    "ast_hash": "9f1cc4c379ad0f31621b4e6a890faf25",
+    "semantic_hash": "9f1cc4c379ad0f31621b4e6a890faf25"
+  },
+  "mesh-utilities/bootstrap/config/tailscale-auth-key.txt": {
+    "mtime": 1763232123.3948905,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "mesh-utilities/common/exclude_services.txt": {
+    "mtime": 1783821153.3444276,
+    "ast_hash": "b4c3093f00e18fba2d1f2f1cf83e9b0a",
+    "semantic_hash": "b4c3093f00e18fba2d1f2f1cf83e9b0a"
+  },
+  "mesh-utilities/common/exclude_services_env_refresh.txt": {
+    "mtime": 1775530899.8889406,
+    "ast_hash": "2efac61a1dcb9abf34dd7986ac06d453",
+    "semantic_hash": "2efac61a1dcb9abf34dd7986ac06d453"
+  },
+  "mesh-utilities/disk-onboarding/README.md": {
+    "mtime": 1763232123.3968906,
+    "ast_hash": "d207863034fc3d55bcd931e916272b70",
+    "semantic_hash": "d207863034fc3d55bcd931e916272b70"
+  },
+  "ontology/memory/README.md": {
+    "mtime": 1777758592.2182443,
+    "ast_hash": "8c79384cd22c5f8152409fd277acda33",
+    "semantic_hash": "8c79384cd22c5f8152409fd277acda33"
+  },
+  "orion-knowledge/AGENTS.md": {
+    "mtime": 1779305390.1027498,
+    "ast_hash": "6980a7099899f29305713d3b1eb09ccc",
+    "semantic_hash": "6980a7099899f29305713d3b1eb09ccc"
+  },
+  "orion-knowledge/README.md": {
+    "mtime": 1779305390.1027498,
+    "ast_hash": "6386114462f83df8ed6eb8617fe5478a",
+    "semantic_hash": "6386114462f83df8ed6eb8617fe5478a"
+  },
+  "orion-knowledge/claims/accepted/claim-knowledge-forge-v1-api.yaml": {
+    "mtime": 1779315897.134747,
+    "ast_hash": "2cd1631285809eb190ac274629f8221f",
+    "semantic_hash": "2cd1631285809eb190ac274629f8221f"
+  },
+  "orion-knowledge/claims/accepted/claim-knowledge-forge-v1-corpus.yaml": {
+    "mtime": 1779315897.134747,
+    "ast_hash": "1d8b572e2fdc1e0bd7e0f03e6b39c26f",
+    "semantic_hash": "1d8b572e2fdc1e0bd7e0f03e6b39c26f"
+  },
+  "orion-knowledge/claims/accepted/claim-knowledge-forge-v1-filter.yaml": {
+    "mtime": 1779315897.134747,
+    "ast_hash": "9a03869ceb81182e4bc584d1ee8f6004",
+    "semantic_hash": "9a03869ceb81182e4bc584d1ee8f6004"
+  },
+  "orion-knowledge/claims/accepted/claim-knowledge-forge-v1-hub.yaml": {
+    "mtime": 1779315897.135747,
+    "ast_hash": "ca37f100a67d14d952597ec0af5c2619",
+    "semantic_hash": "ca37f100a67d14d952597ec0af5c2619"
+  },
+  "orion-knowledge/claims/accepted/claim-knowledge-forge-v1-non-goals.yaml": {
+    "mtime": 1779315897.135747,
+    "ast_hash": "417224e9a84255520a27e14d06d0d3e1",
+    "semantic_hash": "417224e9a84255520a27e14d06d0d3e1"
+  },
+  "orion-knowledge/claims/accepted/claim-substrate-telemetry-0001.yaml": {
+    "mtime": 1779305390.1027498,
+    "ast_hash": "a017e8f061f213d6558225b3a5710985",
+    "semantic_hash": "a017e8f061f213d6558225b3a5710985"
+  },
+  "orion-knowledge/claims/accepted/claim-substrate-telemetry-0002.yaml": {
+    "mtime": 1779305390.1027498,
+    "ast_hash": "c270639d6b79aa5caf7d54423d4300b8",
+    "semantic_hash": "c270639d6b79aa5caf7d54423d4300b8"
+  },
+  "orion-knowledge/context_packs/cursor/substrate-tier-telemetry-v1.md": {
+    "mtime": 1779305390.1037498,
+    "ast_hash": "ec3fc5d2c52527619bf9f4034e0dbb92",
+    "semantic_hash": "ec3fc5d2c52527619bf9f4034e0dbb92"
+  },
+  "orion-knowledge/context_packs/cursor/substrate-tier-telemetry-v1.yaml": {
+    "mtime": 1779305390.1037498,
+    "ast_hash": "0fc399516cf60329438218c14858a691",
+    "semantic_hash": "0fc399516cf60329438218c14858a691"
+  },
+  "orion-knowledge/evals/lint_reports/2026-05-20.txt": {
+    "mtime": 1779305390.1037498,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "orion-knowledge/raw/sources/2026-05-14-substrate-tier-telemetry-design-ref.md": {
+    "mtime": 1779305390.1037498,
+    "ast_hash": "8de63569be8340580402171b4f4eb7fe",
+    "semantic_hash": "8de63569be8340580402171b4f4eb7fe"
+  },
+  "orion-knowledge/raw/sources/2026-05-20-knowledge-forge-v1-merge.md": {
+    "mtime": 1779315897.135747,
+    "ast_hash": "416823fc3be219522025ad2d579bb555",
+    "semantic_hash": "416823fc3be219522025ad2d579bb555"
+  },
+  "orion-knowledge/raw/sources/smoke-003.md": {
+    "mtime": 1779322225.6244369,
+    "ast_hash": "96a815837a624c693cd01515246717ee",
+    "semantic_hash": "96a815837a624c693cd01515246717ee"
+  },
+  "orion-knowledge/raw/sources/source-2026-05-14-substrate-tier-telemetry-design-ref.yaml": {
+    "mtime": 1779305390.1037498,
+    "ast_hash": "2dba2618b64cf92fd25bfa86fb492fd6",
+    "semantic_hash": "2dba2618b64cf92fd25bfa86fb492fd6"
+  },
+  "orion-knowledge/raw/sources/source-2026-05-20-knowledge-forge-v1-merge.yaml": {
+    "mtime": 1779315897.135747,
+    "ast_hash": "e049806df007e7d4240bb392a795069b",
+    "semantic_hash": "e049806df007e7d4240bb392a795069b"
+  },
+  "orion-knowledge/raw/sources/source-smoke-003.yaml": {
+    "mtime": 1779322231.1834064,
+    "ast_hash": "fdf9e7d6bfebb49c5488143234ba6cbc",
+    "semantic_hash": "fdf9e7d6bfebb49c5488143234ba6cbc"
+  },
+  "orion-knowledge/reviews/pending/source-delta-20260521T001031Z-smoke-003.md": {
+    "mtime": 1779322231.1834064,
+    "ast_hash": "146d1f466c24bf68a0ce49884d43d286",
+    "semantic_hash": "146d1f466c24bf68a0ce49884d43d286"
+  },
+  "orion-knowledge/specs/execution_ready/knowledge-forge-ideation-review-v1.md": {
+    "mtime": 1779315897.135747,
+    "ast_hash": "dd484698baa9c7731132d9e49780f344",
+    "semantic_hash": "dd484698baa9c7731132d9e49780f344"
+  },
+  "orion-knowledge/specs/execution_ready/knowledge-forge-ideation-review-v1.yaml": {
+    "mtime": 1779315897.136747,
+    "ast_hash": "3baaa6d5068db5304ff205e7f093882d",
+    "semantic_hash": "3baaa6d5068db5304ff205e7f093882d"
+  },
+  "orion-knowledge/specs/execution_ready/substrate-tier-telemetry-v1.yaml": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "f8571d7fd223f0df04093bae72735371",
+    "semantic_hash": "f8571d7fd223f0df04093bae72735371"
+  },
+  "orion-knowledge/wiki/concepts/substrate-tier-telemetry.md": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "5c1716610810bc180f6e655b78f15202",
+    "semantic_hash": "5c1716610810bc180f6e655b78f15202"
+  },
+  "orion-knowledge/wiki/index.md": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "6fd2e69c6a446d0f4c57432d662c687e",
+    "semantic_hash": "6fd2e69c6a446d0f4c57432d662c687e"
+  },
+  "orion-knowledge/wiki/log.md": {
+    "mtime": 1779305390.1047497,
+    "ast_hash": "ddabf32431fdbcf5abb5f5b032573177",
+    "semantic_hash": "ddabf32431fdbcf5abb5f5b032573177"
+  },
+  "orion/autonomy/README.md": {
+    "mtime": 1783732746.9261913,
+    "ast_hash": "0d34d95181d56cbddbd66298b09aa248",
+    "semantic_hash": "0d34d95181d56cbddbd66298b09aa248"
+  },
+  "orion/bus/channels.yaml": {
+    "mtime": 1784008374.2425008,
+    "ast_hash": "066975262ba77fc4a8b05e93904cfc87",
+    "semantic_hash": "066975262ba77fc4a8b05e93904cfc87"
+  },
+  "orion/cognition/README.md": {
+    "mtime": 1777767971.3303168,
+    "ast_hash": "4199c427fadd6c8014e84fb2a9bc21e1",
+    "semantic_hash": "4199c427fadd6c8014e84fb2a9bc21e1"
+  },
+  "orion/cognition/change_logs/metacog_v2.md": {
+    "mtime": 1773975149.9457865,
+    "ast_hash": "2c22fb96fa8b5ec913e0e9fa5db42a0e",
+    "semantic_hash": "2c22fb96fa8b5ec913e0e9fa5db42a0e"
+  },
+  "orion/cognition/compactor/README.md": {
+    "mtime": 1783958824.2776837,
+    "ast_hash": "74c79e2397df46f69047b4ac3df2009c",
+    "semantic_hash": "74c79e2397df46f69047b4ac3df2009c"
+  },
+  "orion/cognition/hub-gateway/README.md": {
+    "mtime": 1767676515.6251066,
+    "ast_hash": "335374d5f044cd88b9e2a732e7f76df9",
+    "semantic_hash": "335374d5f044cd88b9e2a732e7f76df9"
+  },
+  "orion/cognition/packs/delivery_pack.yaml": {
+    "mtime": 1773984591.7430987,
+    "ast_hash": "4ccbbc24bec3a78837519c441d32878c",
+    "semantic_hash": "4ccbbc24bec3a78837519c441d32878c"
+  },
+  "orion/cognition/packs/emergent_pack.yaml": {
+    "mtime": 1774236180.4423857,
+    "ast_hash": "173eba5125620cbb688072c4c7966338",
+    "semantic_hash": "173eba5125620cbb688072c4c7966338"
+  },
+  "orion/cognition/packs/executive_pack.yaml": {
+    "mtime": 1775948546.0505118,
+    "ast_hash": "2b47cd490579e8866d09f4530205d5dd",
+    "semantic_hash": "2b47cd490579e8866d09f4530205d5dd"
+  },
+  "orion/cognition/packs/memory_pack.yaml": {
+    "mtime": 1763509312.227362,
+    "ast_hash": "ff5bd5c44ba258ec2114e4eaf1e23723",
+    "semantic_hash": "ff5bd5c44ba258ec2114e4eaf1e23723"
+  },
+  "orion/cognition/personality/orion_identity.yaml": {
+    "mtime": 1782531013.7263663,
+    "ast_hash": "de7cb369d9b2ccf73e48a471a5ae8c7b",
+    "semantic_hash": "de7cb369d9b2ccf73e48a471a5ae8c7b"
+  },
+  "orion/cognition/verbs/actions.respond_to_juniper_collapse_mirror.v1.yaml": {
+    "mtime": 1776554226.8368285,
+    "ast_hash": "724a57a4c127a429b6d0a0b482fee0b0",
+    "semantic_hash": "724a57a4c127a429b6d0a0b482fee0b0"
+  },
+  "orion/cognition/verbs/active.yaml": {
+    "mtime": 1774236180.4423857,
+    "ast_hash": "7368debbc5ddce5704c54ed96cbe296b",
+    "semantic_hash": "7368debbc5ddce5704c54ed96cbe296b"
+  },
+  "orion/cognition/verbs/analyze_text.yaml": {
+    "mtime": 1767676515.6281066,
+    "ast_hash": "788c2b2b56b4623bb55b58a6b07cc79b",
+    "semantic_hash": "788c2b2b56b4623bb55b58a6b07cc79b"
+  },
+  "orion/cognition/verbs/answer_current_datetime.yaml": {
+    "mtime": 1775948546.0505118,
+    "ast_hash": "3fc3ab007eb70baf871c072652045178",
+    "semantic_hash": "3fc3ab007eb70baf871c072652045178"
+  },
+  "orion/cognition/verbs/answer_direct.yaml": {
+    "mtime": 1773984591.7450988,
+    "ast_hash": "7024e152f5e5f29726a47153dc0f1074",
+    "semantic_hash": "7024e152f5e5f29726a47153dc0f1074"
+  },
+  "orion/cognition/verbs/assess_mesh_presence.yaml": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "c74f8aed25c0424537ef2df49e2bc41b",
+    "semantic_hash": "c74f8aed25c0424537ef2df49e2bc41b"
+  },
+  "orion/cognition/verbs/assess_risk.yaml": {
+    "mtime": 1767676515.6281066,
+    "ast_hash": "9d7b6804544c72ba64e9653cb9693f45",
+    "semantic_hash": "9d7b6804544c72ba64e9653cb9693f45"
+  },
+  "orion/cognition/verbs/assess_runtime_state.yaml": {
+    "mtime": 1774564470.047171,
+    "ast_hash": "33fabdd2ac5ae8f1000477324847dcde",
+    "semantic_hash": "33fabdd2ac5ae8f1000477324847dcde"
+  },
+  "orion/cognition/verbs/assess_storage_health.yaml": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "bc440a9faed85c8f174836170969b1e9",
+    "semantic_hash": "bc440a9faed85c8f174836170969b1e9"
+  },
+  "orion/cognition/verbs/auto_depth_select.yaml": {
+    "mtime": 1773975149.9477863,
+    "ast_hash": "4d60126410f16caedf164d7e30537fb1",
+    "semantic_hash": "4d60126410f16caedf164d7e30537fb1"
+  },
+  "orion/cognition/verbs/auto_route.yaml": {
+    "mtime": 1773975149.9477863,
+    "ast_hash": "74e105e0d477de5b192a58db68fb4b37",
+    "semantic_hash": "74e105e0d477de5b192a58db68fb4b37"
+  },
+  "orion/cognition/verbs/chat_deep_graph.yaml": {
+    "mtime": 1768597909.8752296,
+    "ast_hash": "783f256fa917da21b1ca21cd03881a49",
+    "semantic_hash": "783f256fa917da21b1ca21cd03881a49"
+  },
+  "orion/cognition/verbs/chat_general.yaml": {
+    "mtime": 1777093481.8421311,
+    "ast_hash": "b16e7249d97c0df1f0b38cbd68d2dd67",
+    "semantic_hash": "b16e7249d97c0df1f0b38cbd68d2dd67"
+  },
+  "orion/cognition/verbs/chat_history_compactor_digest_v1.yaml": {
+    "mtime": 1783958824.2786837,
+    "ast_hash": "e1b299f7f99c12b5da8d39dd6718d922",
+    "semantic_hash": "e1b299f7f99c12b5da8d39dd6718d922"
+  },
+  "orion/cognition/verbs/chat_kids_story.yaml": {
+    "mtime": 1778901838.366395,
+    "ast_hash": "795c3d80c1430add9af2f05c7765d7c9",
+    "semantic_hash": "795c3d80c1430add9af2f05c7765d7c9"
+  },
+  "orion/cognition/verbs/chat_quick.yaml": {
+    "mtime": 1777093481.8421311,
+    "ast_hash": "dce50a28772fe19e0901a474bc549973",
+    "semantic_hash": "dce50a28772fe19e0901a474bc549973"
+  },
+  "orion/cognition/verbs/chat_social_room.yaml": {
+    "mtime": 1774236180.4433856,
+    "ast_hash": "e8fcb23ba509b5ed609e3de250e7b824",
+    "semantic_hash": "e8fcb23ba509b5ed609e3de250e7b824"
+  },
+  "orion/cognition/verbs/compare_options.yaml": {
+    "mtime": 1773984591.7460988,
+    "ast_hash": "38739697926cac45b432714ad5b128fd",
+    "semantic_hash": "38739697926cac45b432714ad5b128fd"
+  },
+  "orion/cognition/verbs/concept_induction.yaml": {
+    "mtime": 1768597909.8752296,
+    "ast_hash": "bd55b938e8b892d48262631133861dcc",
+    "semantic_hash": "bd55b938e8b892d48262631133861dcc"
+  },
+  "orion/cognition/verbs/concept_induction_journal_synthesize.yaml": {
+    "mtime": 1774840917.2962112,
+    "ast_hash": "7c066d6c2f1d7379a5c77832a76dfd94",
+    "semantic_hash": "7c066d6c2f1d7379a5c77832a76dfd94"
+  },
+  "orion/cognition/verbs/context_exec_belief_provenance.yaml": {
+    "mtime": 1781131289.7010949,
+    "ast_hash": "08d9661d6b8a54f907973b27cffee0d8",
+    "semantic_hash": "08d9661d6b8a54f907973b27cffee0d8"
+  },
+  "orion/cognition/verbs/context_exec_grammar_collision_audit.yaml": {
+    "mtime": 1781131289.7010949,
+    "ast_hash": "b17a75a9b11a32c737d0033abba0b640",
+    "semantic_hash": "b17a75a9b11a32c737d0033abba0b640"
+  },
+  "orion/cognition/verbs/context_exec_memory_contradiction_review.yaml": {
+    "mtime": 1781131289.7010949,
+    "ast_hash": "80b9d79d241b79613a188dea46188cbb",
+    "semantic_hash": "80b9d79d241b79613a188dea46188cbb"
+  },
+  "orion/cognition/verbs/context_exec_repo_impact_analysis.yaml": {
+    "mtime": 1781131289.7010949,
+    "ast_hash": "73d7f858aeacc2f2418d779c6281939e",
+    "semantic_hash": "73d7f858aeacc2f2418d779c6281939e"
+  },
+  "orion/cognition/verbs/context_exec_trace_autopsy.yaml": {
+    "mtime": 1781131289.7010949,
+    "ast_hash": "c3a96e9dc7aa8826b2cde7302842157a",
+    "semantic_hash": "c3a96e9dc7aa8826b2cde7302842157a"
+  },
+  "orion/cognition/verbs/counterfactual.yaml": {
+    "mtime": 1764872202.212803,
+    "ast_hash": "e3b27da4962158cd09c75e5302387f5e",
+    "semantic_hash": "e3b27da4962158cd09c75e5302387f5e"
+  },
+  "orion/cognition/verbs/daily_metacog_v1.yaml": {
+    "mtime": 1781405728.495089,
+    "ast_hash": "0dc331e5139c614714eb14a3e6e30901",
+    "semantic_hash": "0dc331e5139c614714eb14a3e6e30901"
+  },
+  "orion/cognition/verbs/daily_pulse_v1.yaml": {
+    "mtime": 1777748523.316599,
+    "ast_hash": "eda81ff4cc4beb9a3928d9fe567c771b",
+    "semantic_hash": "eda81ff4cc4beb9a3928d9fe567c771b"
+  },
+  "orion/cognition/verbs/dream_cycle.yaml": {
+    "mtime": 1776044955.0592444,
+    "ast_hash": "1554f76d55d3a6c5da88ea9f48978b82",
+    "semantic_hash": "1554f76d55d3a6c5da88ea9f48978b82"
+  },
+  "orion/cognition/verbs/dream_preprocess.yaml": {
+    "mtime": 1774236180.4433856,
+    "ast_hash": "06a7560fcdccfa3c086f2c60768e5819",
+    "semantic_hash": "06a7560fcdccfa3c086f2c60768e5819"
+  },
+  "orion/cognition/verbs/dream_simple.yaml": {
+    "mtime": 1774236180.4433856,
+    "ast_hash": "3bac40d4dc76edd101a2df37a78dac6f",
+    "semantic_hash": "3bac40d4dc76edd101a2df37a78dac6f"
+  },
+  "orion/cognition/verbs/evaluate.yaml": {
+    "mtime": 1767676515.6281066,
+    "ast_hash": "f38381d9b4060c5f341e4fb8f4035cc3",
+    "semantic_hash": "f38381d9b4060c5f341e4fb8f4035cc3"
+  },
+  "orion/cognition/verbs/extract_facts.yaml": {
+    "mtime": 1767676515.6291065,
+    "ast_hash": "313f3e491df9f84e941780408c9f4ae7",
+    "semantic_hash": "313f3e491df9f84e941780408c9f4ae7"
+  },
+  "orion/cognition/verbs/finalize_response.yaml": {
+    "mtime": 1773984591.7460988,
+    "ast_hash": "1271ddc375c086db62e8e77d590e15c0",
+    "semantic_hash": "1271ddc375c086db62e8e77d590e15c0"
+  },
+  "orion/cognition/verbs/generate_code_scaffold.yaml": {
+    "mtime": 1773984591.7460988,
+    "ast_hash": "78e7fdde09da1e84889fb855af824d86",
+    "semantic_hash": "78e7fdde09da1e84889fb855af824d86"
+  },
+  "orion/cognition/verbs/github_compactor_digest_v1.yaml": {
+    "mtime": 1783555541.5276737,
+    "ast_hash": "ef0ea40b2a8c01e2c8414ea8a3d13bd8",
+    "semantic_hash": "ef0ea40b2a8c01e2c8414ea8a3d13bd8"
+  },
+  "orion/cognition/verbs/goal_formulate.yaml": {
+    "mtime": 1767676515.6291065,
+    "ast_hash": "0b0b146a8f2c801f472781b9c093234b",
+    "semantic_hash": "0b0b146a8f2c801f472781b9c093234b"
+  },
+  "orion/cognition/verbs/harness_finalize_reflect.yaml": {
+    "mtime": 1783548475.1912115,
+    "ast_hash": "dd5f4e566b5e792299ce82eb56bfc106",
+    "semantic_hash": "dd5f4e566b5e792299ce82eb56bfc106"
+  },
+  "orion/cognition/verbs/housekeep_runtime.yaml": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "86b03796cf50050e5bdd815443ee31f7",
+    "semantic_hash": "86b03796cf50050e5bdd815443ee31f7"
+  },
+  "orion/cognition/verbs/inspect_docker_container_status.yaml": {
+    "mtime": 1775948546.0505118,
+    "ast_hash": "0c3f6ba59fd4d12056e4c555b3fc69c0",
+    "semantic_hash": "0c3f6ba59fd4d12056e4c555b3fc69c0"
+  },
+  "orion/cognition/verbs/inspect_gpu_status.yaml": {
+    "mtime": 1775948546.0505118,
+    "ast_hash": "85476dcb3bf57d92d20681bcac1f5d93",
+    "semantic_hash": "85476dcb3bf57d92d20681bcac1f5d93"
+  },
+  "orion/cognition/verbs/introspect.yaml": {
+    "mtime": 1764872202.212803,
+    "ast_hash": "7950a2cdaac2d8458200279ffefd3834",
+    "semantic_hash": "7950a2cdaac2d8458200279ffefd3834"
+  },
+  "orion/cognition/verbs/introspect_spark.yaml": {
+    "mtime": 1774566954.6982691,
+    "ast_hash": "bfc865e425ad221d27051c869318b758",
+    "semantic_hash": "bfc865e425ad221d27051c869318b758"
+  },
+  "orion/cognition/verbs/journal.compose.yaml": {
+    "mtime": 1774570011.5397575,
+    "ast_hash": "a32b5594c9c0ffa8485f79c47329a8cc",
+    "semantic_hash": "a32b5594c9c0ffa8485f79c47329a8cc"
+  },
+  "orion/cognition/verbs/list_biometrics_recent_readings.yaml": {
+    "mtime": 1775948546.0515118,
+    "ast_hash": "9419f7e6999c31156a0cab43e6279774",
+    "semantic_hash": "9419f7e6999c31156a0cab43e6279774"
+  },
+  "orion/cognition/verbs/log_collapse_mirror.yaml": {
+    "mtime": 1768597909.8752296,
+    "ast_hash": "527ea420b0af4c2487eba98f4daf1435",
+    "semantic_hash": "527ea420b0af4c2487eba98f4daf1435"
+  },
+  "orion/cognition/verbs/log_orion_metacognition.yaml": {
+    "mtime": 1781405728.495089,
+    "ast_hash": "4b490099a07961f0b73902c7fec76f75",
+    "semantic_hash": "4b490099a07961f0b73902c7fec76f75"
+  },
+  "orion/cognition/verbs/memory_graph_suggest.yaml": {
+    "mtime": 1779070080.2422051,
+    "ast_hash": "b4548a80f50b10001543f8075bdc3c3b",
+    "semantic_hash": "b4548a80f50b10001543f8075bdc3c3b"
+  },
+  "orion/cognition/verbs/orion_voice_finalize.yaml": {
+    "mtime": 1783548475.1912115,
+    "ast_hash": "c4392da1e4b975caa6d3e9f304a83e9f",
+    "semantic_hash": "c4392da1e4b975caa6d3e9f304a83e9f"
+  },
+  "orion/cognition/verbs/pattern_detect.yaml": {
+    "mtime": 1767676515.6291065,
+    "ast_hash": "ce76116a3023d599f3fd4a016542f208",
+    "semantic_hash": "ce76116a3023d599f3fd4a016542f208"
+  },
+  "orion/cognition/verbs/perceive_caption_frame.yaml": {
+    "mtime": 1767676515.6301064,
+    "ast_hash": "f668eeb347a478152b4c138dd22baf8f",
+    "semantic_hash": "f668eeb347a478152b4c138dd22baf8f"
+  },
+  "orion/cognition/verbs/perceive_detect_open_vocab.yaml": {
+    "mtime": 1767676515.6301064,
+    "ast_hash": "9dd4fb8aa96884e2754cb61db7ef0ff3",
+    "semantic_hash": "9dd4fb8aa96884e2754cb61db7ef0ff3"
+  },
+  "orion/cognition/verbs/perceive_embed_image.yaml": {
+    "mtime": 1767676515.6301064,
+    "ast_hash": "e8a3bbff20c56396442ea9960d9afcbb",
+    "semantic_hash": "e8a3bbff20c56396442ea9960d9afcbb"
+  },
+  "orion/cognition/verbs/perceive_retina_fast.yaml": {
+    "mtime": 1767676515.6301064,
+    "ast_hash": "7a946427a909df082391ddda2ff7da24",
+    "semantic_hash": "7a946427a909df082391ddda2ff7da24"
+  },
+  "orion/cognition/verbs/perceive_vision_events.yaml": {
+    "mtime": 1767676515.6301064,
+    "ast_hash": "7821e95fda4819433dd40da9f8258329",
+    "semantic_hash": "7821e95fda4819433dd40da9f8258329"
+  },
+  "orion/cognition/verbs/perceive_vision_memory.yaml": {
+    "mtime": 1767676515.6301064,
+    "ast_hash": "1151a1a295e2339c1889ebdddea58d33",
+    "semantic_hash": "1151a1a295e2339c1889ebdddea58d33"
+  },
+  "orion/cognition/verbs/plan_action.yaml": {
+    "mtime": 1767676515.6301064,
+    "ast_hash": "419a45575e9975599ccdd95c4d10a499",
+    "semantic_hash": "419a45575e9975599ccdd95c4d10a499"
+  },
+  "orion/cognition/verbs/rdf_build.yaml": {
+    "mtime": 1767676515.6311066,
+    "ast_hash": "9fac2f655a05796df2d50f85fb3fbec3",
+    "semantic_hash": "9fac2f655a05796df2d50f85fb3fbec3"
+  },
+  "orion/cognition/verbs/recall.yaml": {
+    "mtime": 1763509312.230362,
+    "ast_hash": "5c88a468e52e371a8763447fcdd1cc12",
+    "semantic_hash": "5c88a468e52e371a8763447fcdd1cc12"
+  },
+  "orion/cognition/verbs/reflect.yaml": {
+    "mtime": 1768597909.8752296,
+    "ast_hash": "5549204e6064e47d98274115c09e0357",
+    "semantic_hash": "5549204e6064e47d98274115c09e0357"
+  },
+  "orion/cognition/verbs/reverie_narrate.yaml": {
+    "mtime": 1783312413.5092456,
+    "ast_hash": "72cca42a83d01534c100ebbb1623c0cb",
+    "semantic_hash": "72cca42a83d01534c100ebbb1623c0cb"
+  },
+  "orion/cognition/verbs/search_web.yaml": {
+    "mtime": 1764872202.212803,
+    "ast_hash": "86bf2ed7387f27dc4dc19bab713c973e",
+    "semantic_hash": "86bf2ed7387f27dc4dc19bab713c973e"
+  },
+  "orion/cognition/verbs/self_concept_induce.yaml": {
+    "mtime": 1774236180.4433856,
+    "ast_hash": "d9f3e82072a88923a1ee240e9248acc0",
+    "semantic_hash": "d9f3e82072a88923a1ee240e9248acc0"
+  },
+  "orion/cognition/verbs/self_concept_reflect.yaml": {
+    "mtime": 1774570011.5397575,
+    "ast_hash": "5d84bdfa707f9b9f74d23b174f06992d",
+    "semantic_hash": "5d84bdfa707f9b9f74d23b174f06992d"
+  },
+  "orion/cognition/verbs/self_critique.yaml": {
+    "mtime": 1765358476.4329603,
+    "ast_hash": "c2a880c536563a8b548f79e28124d839",
+    "semantic_hash": "c2a880c536563a8b548f79e28124d839"
+  },
+  "orion/cognition/verbs/self_repo_inspect.yaml": {
+    "mtime": 1774236180.4433856,
+    "ast_hash": "86b866405da89dc8dd6a140289c08fe4",
+    "semantic_hash": "86b866405da89dc8dd6a140289c08fe4"
+  },
+  "orion/cognition/verbs/self_retrieve.yaml": {
+    "mtime": 1774236180.4433856,
+    "ast_hash": "41b10bcad1a760b37a3a347e1bcf6d48",
+    "semantic_hash": "41b10bcad1a760b37a3a347e1bcf6d48"
+  },
+  "orion/cognition/verbs/send_operator_notification.yaml": {
+    "mtime": 1775948546.0515118,
+    "ast_hash": "b128d87c98c163ca54928c42367b95e4",
+    "semantic_hash": "b128d87c98c163ca54928c42367b95e4"
+  },
+  "orion/cognition/verbs/show_biometrics_snapshot.yaml": {
+    "mtime": 1775948546.0515118,
+    "ast_hash": "302e97666dd1c70f216aa9e66ad5b3ad",
+    "semantic_hash": "302e97666dd1c70f216aa9e66ad5b3ad"
+  },
+  "orion/cognition/verbs/show_landing_pad_metrics.yaml": {
+    "mtime": 1775948546.0515118,
+    "ast_hash": "070ed7bd61c4ad3884c6c399c0138161",
+    "semantic_hash": "070ed7bd61c4ad3884c6c399c0138161"
+  },
+  "orion/cognition/verbs/simulate.yaml": {
+    "mtime": 1767676515.6311066,
+    "ast_hash": "ef68bc3899b51f1dcb76e5051a5a71ed",
+    "semantic_hash": "ef68bc3899b51f1dcb76e5051a5a71ed"
+  },
+  "orion/cognition/verbs/skills.biometrics.raw_recent.v1.yaml": {
+    "mtime": 1773980667.706536,
+    "ast_hash": "90363bc9f531880e4e0136eafa077661",
+    "semantic_hash": "90363bc9f531880e4e0136eafa077661"
+  },
+  "orion/cognition/verbs/skills.biometrics.snapshot.v1.yaml": {
+    "mtime": 1773980667.706536,
+    "ast_hash": "06fc0aca1b77ed473e54bf109048c76a",
+    "semantic_hash": "06fc0aca1b77ed473e54bf109048c76a"
+  },
+  "orion/cognition/verbs/skills.chat.discussion_window.v1.yaml": {
+    "mtime": 1776049266.909834,
+    "ast_hash": "08a302ca6169292b1195a9902592d7e5",
+    "semantic_hash": "08a302ca6169292b1195a9902592d7e5"
+  },
+  "orion/cognition/verbs/skills.docker.ps_status.v1.yaml": {
+    "mtime": 1773980667.706536,
+    "ast_hash": "6ed2615863fe75cf9765e3f73bc49ead",
+    "semantic_hash": "6ed2615863fe75cf9765e3f73bc49ead"
+  },
+  "orion/cognition/verbs/skills.gpu.nvidia_smi_snapshot.v1.yaml": {
+    "mtime": 1773980667.706536,
+    "ast_hash": "14bd7f2c5ff0980fa434706e27a96684",
+    "semantic_hash": "14bd7f2c5ff0980fa434706e27a96684"
+  },
+  "orion/cognition/verbs/skills.landing_pad.last_events.v1.yaml": {
+    "mtime": 1773980667.706536,
+    "ast_hash": "788838e813e7a391eaac9f55318178af",
+    "semantic_hash": "788838e813e7a391eaac9f55318178af"
+  },
+  "orion/cognition/verbs/skills.landing_pad.metrics_snapshot.v1.yaml": {
+    "mtime": 1773980667.706536,
+    "ast_hash": "172b8de9bf7cffa562ce6c720b1a6fbd",
+    "semantic_hash": "172b8de9bf7cffa562ce6c720b1a6fbd"
+  },
+  "orion/cognition/verbs/skills.mesh.mesh_ops_round.v1.yaml": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "01eaf2550d84079c794f54490ea1abba",
+    "semantic_hash": "01eaf2550d84079c794f54490ea1abba"
+  },
+  "orion/cognition/verbs/skills.mesh.refresh_service_envs.v1.yaml": {
+    "mtime": 1778901838.366395,
+    "ast_hash": "be5135b20e19ae6c0f9488c3ec3ceb1f",
+    "semantic_hash": "be5135b20e19ae6c0f9488c3ec3ceb1f"
+  },
+  "orion/cognition/verbs/skills.mesh.tailscale_mesh_status.v1.yaml": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "1dc16fe71e7f0c7e5cef3f01160809d0",
+    "semantic_hash": "1dc16fe71e7f0c7e5cef3f01160809d0"
+  },
+  "orion/cognition/verbs/skills.mesh.up_all_services.v1.yaml": {
+    "mtime": 1778901838.367395,
+    "ast_hash": "bf18859a06986eb8a73077352cbf560c",
+    "semantic_hash": "bf18859a06986eb8a73077352cbf560c"
+  },
+  "orion/cognition/verbs/skills.repo.github_recent_prs.v1.yaml": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "e7ba58b640b3017744ea3bcbba896757",
+    "semantic_hash": "e7ba58b640b3017744ea3bcbba896757"
+  },
+  "orion/cognition/verbs/skills.runtime.docker_prune_stopped_containers.v1.yaml": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "ab7705fee8634d2b99b2cc24238ebacd",
+    "semantic_hash": "ab7705fee8634d2b99b2cc24238ebacd"
+  },
+  "orion/cognition/verbs/skills.storage.disk_health_snapshot.v1.yaml": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "bef30833fa3b5664a85c55f4451df57e",
+    "semantic_hash": "bef30833fa3b5664a85c55f4451df57e"
+  },
+  "orion/cognition/verbs/skills.system.notify_chat_message.v1.yaml": {
+    "mtime": 1773980667.706536,
+    "ast_hash": "a76c744a05a083c5b3ff28514b7aa99c",
+    "semantic_hash": "a76c744a05a083c5b3ff28514b7aa99c"
+  },
+  "orion/cognition/verbs/skills.system.time_now.v1.yaml": {
+    "mtime": 1773980667.706536,
+    "ast_hash": "d0ce14a9aa866b3091df64b061becbe4",
+    "semantic_hash": "d0ce14a9aa866b3091df64b061becbe4"
+  },
+  "orion/cognition/verbs/stance_react.yaml": {
+    "mtime": 1783458889.5679457,
+    "ast_hash": "22464e0262b09909e153007600dd053c",
+    "semantic_hash": "22464e0262b09909e153007600dd053c"
+  },
+  "orion/cognition/verbs/story_weave.yaml": {
+    "mtime": 1773975149.9487863,
+    "ast_hash": "e2e3e12efadc37be1cabffe7f703e76a",
+    "semantic_hash": "e2e3e12efadc37be1cabffe7f703e76a"
+  },
+  "orion/cognition/verbs/substrate.inspect.yaml": {
+    "mtime": 1783967452.4994059,
+    "ast_hash": "e08e7dba9c3927851f96603c74e00bbe",
+    "semantic_hash": "e08e7dba9c3927851f96603c74e00bbe"
+  },
+  "orion/cognition/verbs/substrate.observe.yaml": {
+    "mtime": 1783967452.500406,
+    "ast_hash": "f32dc091d7f9d39cc74c6b08c225c2ec",
+    "semantic_hash": "f32dc091d7f9d39cc74c6b08c225c2ec"
+  },
+  "orion/cognition/verbs/substrate.summarize.yaml": {
+    "mtime": 1783967452.500406,
+    "ast_hash": "a664bbd8fd23a5f8e19fc676e286710a",
+    "semantic_hash": "a664bbd8fd23a5f8e19fc676e286710a"
+  },
+  "orion/cognition/verbs/summarize_context.yaml": {
+    "mtime": 1765360946.1666746,
+    "ast_hash": "50296d4adee48a708cc7b9813efd31d4",
+    "semantic_hash": "50296d4adee48a708cc7b9813efd31d4"
+  },
+  "orion/cognition/verbs/summarize_recent_changes.yaml": {
+    "mtime": 1775613610.4124463,
+    "ast_hash": "0254a8c0c20d8ca8b09b100a0ba7215a",
+    "semantic_hash": "0254a8c0c20d8ca8b09b100a0ba7215a"
+  },
+  "orion/cognition/verbs/synthesize_patterns.yaml": {
+    "mtime": 1773984591.7460988,
+    "ast_hash": "47c3c264fa71766fbcbe2b191157a2cc",
+    "semantic_hash": "47c3c264fa71766fbcbe2b191157a2cc"
+  },
+  "orion/cognition/verbs/tag_enrich.yaml": {
+    "mtime": 1763509312.230362,
+    "ast_hash": "9ea7d22f023d3ea3c256f247b3f83c41",
+    "semantic_hash": "9ea7d22f023d3ea3c256f247b3f83c41"
+  },
+  "orion/cognition/verbs/triage.yaml": {
+    "mtime": 1767676515.6311066,
+    "ast_hash": "44b095bf819ccbb634ea4c818a69faa7",
+    "semantic_hash": "44b095bf819ccbb634ea4c818a69faa7"
+  },
+  "orion/cognition/verbs/write_guide.yaml": {
+    "mtime": 1773984591.7460988,
+    "ast_hash": "dae21e7cc47369f1d1dc3275c615151b",
+    "semantic_hash": "dae21e7cc47369f1d1dc3275c615151b"
+  },
+  "orion/cognition/verbs/write_recommendation.yaml": {
+    "mtime": 1773984591.7460988,
+    "ast_hash": "cc998e73cd9194f10599a667a9bc12d1",
+    "semantic_hash": "cc998e73cd9194f10599a667a9bc12d1"
+  },
+  "orion/cognition/verbs/write_runbook.yaml": {
+    "mtime": 1773984591.7460988,
+    "ast_hash": "0ef78fcfd24b3c0a9bf89bdb2e97cee0",
+    "semantic_hash": "0ef78fcfd24b3c0a9bf89bdb2e97cee0"
+  },
+  "orion/cognition/verbs/write_tutorial.yaml": {
+    "mtime": 1773984591.7460988,
+    "ast_hash": "a0770989fd5a18670b969e2785ddcf57",
+    "semantic_hash": "a0770989fd5a18670b969e2785ddcf57"
+  },
+  "orion/journaler/README.md": {
+    "mtime": 1783986358.0996563,
+    "ast_hash": "69b7a668e0654efa36693cb4a49d6106",
+    "semantic_hash": "69b7a668e0654efa36693cb4a49d6106"
+  },
+  "orion/recall/profiles/README.md": {
+    "mtime": 1780779151.1776562,
+    "ast_hash": "9b92b5f667cef68ea12666b1766b639a",
+    "semantic_hash": "9b92b5f667cef68ea12666b1766b639a"
+  },
+  "orion/recall/profiles/assist.light.v1.yaml": {
+    "mtime": 1780779151.1776562,
+    "ast_hash": "428baa8c94605530c745538b1dae9590",
+    "semantic_hash": "428baa8c94605530c745538b1dae9590"
+  },
+  "orion/recall/profiles/biographical.v1.yaml": {
+    "mtime": 1780115804.9071445,
+    "ast_hash": "9cfde181fd00ff1389aae5185b4fed61",
+    "semantic_hash": "9cfde181fd00ff1389aae5185b4fed61"
+  },
+  "orion/recall/profiles/brain.recall.v1.yaml": {
+    "mtime": 1780779151.178656,
+    "ast_hash": "0e6144790e65314f4f13cc2ddfcc2042",
+    "semantic_hash": "0e6144790e65314f4f13cc2ddfcc2042"
+  },
+  "orion/recall/profiles/chat.belief.contradiction.v1.yaml": {
+    "mtime": 1783398623.0071564,
+    "ast_hash": "2ae2c0505134a44a63f5be6f6627ea89",
+    "semantic_hash": "2ae2c0505134a44a63f5be6f6627ea89"
+  },
+  "orion/recall/profiles/chat.belief.open_loop.v1.yaml": {
+    "mtime": 1783398623.0071564,
+    "ast_hash": "361333af7917523d8fcd09cfef8fb057",
+    "semantic_hash": "361333af7917523d8fcd09cfef8fb057"
+  },
+  "orion/recall/profiles/chat.belief.procedural.v1.yaml": {
+    "mtime": 1783398623.0071564,
+    "ast_hash": "b61032a62d683b57af4dfd8f001e8183",
+    "semantic_hash": "b61032a62d683b57af4dfd8f001e8183"
+  },
+  "orion/recall/profiles/chat.belief.relational.v1.yaml": {
+    "mtime": 1783398623.0071564,
+    "ast_hash": "44143b774e6d5e927d5ebf1f2d312778",
+    "semantic_hash": "44143b774e6d5e927d5ebf1f2d312778"
+  },
+  "orion/recall/profiles/chat.belief.semantic.v1.yaml": {
+    "mtime": 1783398623.0071564,
+    "ast_hash": "7eb1be694a4329658beca3912bef6a1c",
+    "semantic_hash": "7eb1be694a4329658beca3912bef6a1c"
+  },
+  "orion/recall/profiles/chat.continuity.v1.yaml": {
+    "mtime": 1783398623.0071564,
+    "ast_hash": "99c7d98046f1e4a6f608211c5dd9bf73",
+    "semantic_hash": "99c7d98046f1e4a6f608211c5dd9bf73"
+  },
+  "orion/recall/profiles/chat.general.v1.yaml": {
+    "mtime": 1780779151.178656,
+    "ast_hash": "d00079a5d404cba7c7f5b73c77473f4e",
+    "semantic_hash": "d00079a5d404cba7c7f5b73c77473f4e"
+  },
+  "orion/recall/profiles/chat.story.kids.v1.yaml": {
+    "mtime": 1780115804.9071445,
+    "ast_hash": "5411816e09eb1cb7b90924d02e1951be",
+    "semantic_hash": "5411816e09eb1cb7b90924d02e1951be"
+  },
+  "orion/recall/profiles/collapse_mirror.v1.yaml": {
+    "mtime": 1780779151.178656,
+    "ast_hash": "dd48c05b07887948b84e25fb6957122e",
+    "semantic_hash": "dd48c05b07887948b84e25fb6957122e"
+  },
+  "orion/recall/profiles/deep.graph.v1.yaml": {
+    "mtime": 1780779151.178656,
+    "ast_hash": "019f03a083cbf4864291ad5562273bda",
+    "semantic_hash": "019f03a083cbf4864291ad5562273bda"
+  },
+  "orion/recall/profiles/dream.v1.yaml": {
+    "mtime": 1780779151.179656,
+    "ast_hash": "204f09bfbb2420af760efdb0db12f06b",
+    "semantic_hash": "204f09bfbb2420af760efdb0db12f06b"
+  },
+  "orion/recall/profiles/graph.compressions.global.v1.yaml": {
+    "mtime": 1780972924.4322648,
+    "ast_hash": "77d76d9f643b29a35b6c6178bd529735",
+    "semantic_hash": "77d76d9f643b29a35b6c6178bd529735"
+  },
+  "orion/recall/profiles/graph.compressions.local.v1.yaml": {
+    "mtime": 1780972924.4322648,
+    "ast_hash": "9500bdbbdc9a0b92724c3cad5096dd82",
+    "semantic_hash": "9500bdbbdc9a0b92724c3cad5096dd82"
+  },
+  "orion/recall/profiles/graph.compressions.v1.yaml": {
+    "mtime": 1780972924.4322648,
+    "ast_hash": "aee6eb088ba267c5fc1062730447ccfe",
+    "semantic_hash": "aee6eb088ba267c5fc1062730447ccfe"
+  },
+  "orion/recall/profiles/graphtri.v1.yaml": {
+    "mtime": 1780779151.179656,
+    "ast_hash": "9335f708eb3b1ac04bdd9cbcadc1a3e6",
+    "semantic_hash": "9335f708eb3b1ac04bdd9cbcadc1a3e6"
+  },
+  "orion/recall/profiles/journal.daily.grounded.v1.yaml": {
+    "mtime": 1781735866.8317394,
+    "ast_hash": "21062ea76e3d03f791dbfcc871c33c8e",
+    "semantic_hash": "21062ea76e3d03f791dbfcc871c33c8e"
+  },
+  "orion/recall/profiles/journal.daily.metacog.grounded.v1.yaml": {
+    "mtime": 1781735866.8317394,
+    "ast_hash": "9e5d8a32dc5ee780c36e4b6ae84591e5",
+    "semantic_hash": "9e5d8a32dc5ee780c36e4b6ae84591e5"
+  },
+  "orion/recall/profiles/journal.notify.grounded.v1.yaml": {
+    "mtime": 1781735866.8317394,
+    "ast_hash": "980a8d99c38951269cb3f71db05cfee0",
+    "semantic_hash": "980a8d99c38951269cb3f71db05cfee0"
+  },
+  "orion/recall/profiles/journal.world_pulse.grounded.v1.yaml": {
+    "mtime": 1781735866.8317394,
+    "ast_hash": "f06167cc4951e7434d9370303be4f4b3",
+    "semantic_hash": "f06167cc4951e7434d9370303be4f4b3"
+  },
+  "orion/recall/profiles/reflect.alerts.v1.yaml": {
+    "mtime": 1780779151.179656,
+    "ast_hash": "84252ae4dddb459d55188c07b72b8b6b",
+    "semantic_hash": "84252ae4dddb459d55188c07b72b8b6b"
+  },
+  "orion/recall/profiles/reflect.anchor.v1.yaml": {
+    "mtime": 1780779151.179656,
+    "ast_hash": "a3a2e5241c9e546372710ba22cc718ed",
+    "semantic_hash": "a3a2e5241c9e546372710ba22cc718ed"
+  },
+  "orion/recall/profiles/reflect.sql_only.v1.yaml": {
+    "mtime": 1780779151.179656,
+    "ast_hash": "17346b9a98027e0eb73fe6ab6cde74f7",
+    "semantic_hash": "17346b9a98027e0eb73fe6ab6cde74f7"
+  },
+  "orion/recall/profiles/reflect.v1.yaml": {
+    "mtime": 1780779151.1806562,
+    "ast_hash": "3a3cceebec49f30efb7f135aed6f0055",
+    "semantic_hash": "3a3cceebec49f30efb7f135aed6f0055"
+  },
+  "orion/recall/profiles/self.factual.v1.yaml": {
+    "mtime": 1780779151.1806562,
+    "ast_hash": "5081c9375a3e3d81c40e1efd934d4733",
+    "semantic_hash": "5081c9375a3e3d81c40e1efd934d4733"
+  },
+  "orion/recall/profiles/social.room.v1.yaml": {
+    "mtime": 1780779151.1806562,
+    "ast_hash": "dd9b4244fae568f90238e6fdab477b8c",
+    "semantic_hash": "dd9b4244fae568f90238e6fdab477b8c"
+  },
+  "orion/recall/profiles/story_weave.yaml": {
+    "mtime": 1780779151.1806562,
+    "ast_hash": "079cc69eec83ab02490ca239d7ef8c3b",
+    "semantic_hash": "079cc69eec83ab02490ca239d7ef8c3b"
+  },
+  "orion/self_state/README.md": {
+    "mtime": 1783984456.988051,
+    "ast_hash": "3dda68bc8ecd4b9d24f3062acad7e404",
+    "semantic_hash": "3dda68bc8ecd4b9d24f3062acad7e404"
+  },
+  "orion/spark/README.md": {
+    "mtime": 1783716548.5466468,
+    "ast_hash": "fcf18bdfc0065651b5446bf2d2950a3f",
+    "semantic_hash": "fcf18bdfc0065651b5446bf2d2950a3f"
+  },
+  "orion/spark/concept_induction/AUTONOMOUS_TRIGGER_LOOP_NOTE.md": {
+    "mtime": 1774757769.2409265,
+    "ast_hash": "5014f69e69644695d9ebdba48bc279b0",
+    "semantic_hash": "5014f69e69644695d9ebdba48bc279b0"
+  },
+  "orion/spark/concept_induction/PHASE1_CONCEPT_PROFILE_GRAPH_MATERIALIZATION.md": {
+    "mtime": 1774680717.525936,
+    "ast_hash": "0547d6be2d2d7f5da93ed08f9b5c9fad",
+    "semantic_hash": "0547d6be2d2d7f5da93ed08f9b5c9fad"
+  },
+  "orion/spark/concept_induction/PHASE2_CONCEPT_PROFILE_GRAPH_READ_MODEL.md": {
+    "mtime": 1774680717.525936,
+    "ast_hash": "20a8b0b0ee4a69182ab9aae2095e8d6a",
+    "semantic_hash": "20a8b0b0ee4a69182ab9aae2095e8d6a"
+  },
+  "orion/spark/concept_induction/PHASE3A_SHADOW_ROLLOUT_NOTE.md": {
+    "mtime": 1774680717.525936,
+    "ast_hash": "ca3e45e5f3f8789b2b88465f6513fa91",
+    "semantic_hash": "ca3e45e5f3f8789b2b88465f6513fa91"
+  },
+  "orion/spark/concept_induction/PHASE3B_PARITY_EVIDENCE_READINESS.md": {
+    "mtime": 1774680717.525936,
+    "ast_hash": "07393457023d59190b67bf7bf54f8e07",
+    "semantic_hash": "07393457023d59190b67bf7bf54f8e07"
+  },
+  "orion/spark/concept_induction/PHASE4_CONCEPT_PROFILE_CUTOVER_NOTE.md": {
+    "mtime": 1774680717.525936,
+    "ast_hash": "910fe853813e78d1e651620e6d4289d7",
+    "semantic_hash": "910fe853813e78d1e651620e6d4289d7"
+  },
+  "orion/spark/concept_induction/PROFILE_REPOSITORY_SEAM.md": {
+    "mtime": 1774654210.0928352,
+    "ast_hash": "edc973a389ae31e8a4d425ab20b49ff4",
+    "semantic_hash": "edc973a389ae31e8a4d425ab20b49ff4"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/README.md": {
+    "mtime": 1780180394.5412374,
+    "ast_hash": "346c93ddc8b5b19db43705bbe2f4d5fc",
+    "semantic_hash": "346c93ddc8b5b19db43705bbe2f4d5fc"
+  },
+  "orion/substrate/experiments/hyperbolic_gpt/requirements.txt": {
+    "mtime": 1780179103.9457953,
+    "ast_hash": "f164dcdcb173f2ecec1a2d0970d2c3dc",
+    "semantic_hash": "f164dcdcb173f2ecec1a2d0970d2c3dc"
+  },
+  "requirements-dev.txt": {
+    "mtime": 1783745566.6143477,
+    "ast_hash": "7735e274ab83f308915a6c66287c14bd",
+    "semantic_hash": "7735e274ab83f308915a6c66287c14bd"
+  },
+  "reviews/pending/2026-06-20-brainstorming-session-1-appendix.md": {
+    "mtime": 1783573136.0176039,
+    "ast_hash": "5d5a47356d9c683ca63c6ca43e1891ac",
+    "semantic_hash": "5d5a47356d9c683ca63c6ca43e1891ac"
+  },
+  "scripts/README.md": {
+    "mtime": 1783986358.1016564,
+    "ast_hash": "4132a97ad8226154c35aa9502cd27ee6",
+    "semantic_hash": "4132a97ad8226154c35aa9502cd27ee6"
+  },
+  "scripts/analysis/README.md": {
+    "mtime": 1783979364.1161375,
+    "ast_hash": "3851289a2389932349cfdeea73b966a2",
+    "semantic_hash": "3851289a2389932349cfdeea73b966a2"
+  },
+  "scripts/platform/README.md": {
+    "mtime": 1768597909.8802297,
+    "ast_hash": "95c48190f5a3936800c7553d4b54c7c7",
+    "semantic_hash": "95c48190f5a3936800c7553d4b54c7c7"
+  },
+  "services/orion-actions/README.md": {
+    "mtime": 1783986358.1016564,
+    "ast_hash": "2bc690f7789b7b9d79fabb0773195037",
+    "semantic_hash": "2bc690f7789b7b9d79fabb0773195037"
+  },
+  "services/orion-actions/docker-compose.yml": {
+    "mtime": 1783986358.1026566,
+    "ast_hash": "b7572d6a330b55e04db240ffdd438448",
+    "semantic_hash": "b7572d6a330b55e04db240ffdd438448"
+  },
+  "services/orion-actions/orion_actions_verb_bridge_design_philosophy(1).md": {
+    "mtime": 1774328502.803118,
+    "ast_hash": "f5f2f7fbd8fb12042f236a4ef3650bcb",
+    "semantic_hash": "f5f2f7fbd8fb12042f236a4ef3650bcb"
+  },
+  "services/orion-actions/requirements.txt": {
+    "mtime": 1777748523.3205988,
+    "ast_hash": "c597370a97ec1ca03bb791cdd31e8fd0",
+    "semantic_hash": "c597370a97ec1ca03bb791cdd31e8fd0"
+  },
+  "services/orion-agent-council/README.md": {
+    "mtime": 1767676515.6411066,
+    "ast_hash": "ffd3a5483aa84cc247bdf24205a8c616",
+    "semantic_hash": "ffd3a5483aa84cc247bdf24205a8c616"
+  },
+  "services/orion-agent-council/docker-compose.yml": {
+    "mtime": 1773975149.957786,
+    "ast_hash": "9354786a7273853b2793ebe0709fc295",
+    "semantic_hash": "9354786a7273853b2793ebe0709fc295"
+  },
+  "services/orion-agent-council/requirements.txt": {
+    "mtime": 1767676515.6441066,
+    "ast_hash": "6eddf3155261d2a4bfcf41d98a99f2ee",
+    "semantic_hash": "6eddf3155261d2a4bfcf41d98a99f2ee"
+  },
+  "services/orion-ai-town/README.md": {
+    "mtime": 1783709409.5434005,
+    "ast_hash": "2a6eccfbc98a3b1f3210bd882027df76",
+    "semantic_hash": "2a6eccfbc98a3b1f3210bd882027df76"
+  },
+  "services/orion-ai-town/cards/generated/juniper_description.txt": {
+    "mtime": 1783490446.3023593,
+    "ast_hash": "764e2a708285d918398995be54cec50d",
+    "semantic_hash": "764e2a708285d918398995be54cec50d"
+  },
+  "services/orion-ai-town/cards/generated/orion_town_card.txt": {
+    "mtime": 1783490446.3023593,
+    "ast_hash": "86ebe6c66ad3742ed9c6c004e6d26b87",
+    "semantic_hash": "86ebe6c66ad3742ed9c6c004e6d26b87"
+  },
+  "services/orion-ai-town/cards/town_cards.yaml": {
+    "mtime": 1783490446.3023593,
+    "ast_hash": "96cbf5fbbd750e66232db3825f85ab9a",
+    "semantic_hash": "96cbf5fbbd750e66232db3825f85ab9a"
+  },
+  "services/orion-ai-town/docker-compose.yml": {
+    "mtime": 1783364899.121467,
+    "ast_hash": "bf6ff8d1728cd6ceb9aecc6819c1ecb6",
+    "semantic_hash": "bf6ff8d1728cd6ceb9aecc6819c1ecb6"
+  },
+  "services/orion-attention-runtime/README.md": {
+    "mtime": 1783898916.2576118,
+    "ast_hash": "d99e5601acc146d498081ed1960d21e5",
+    "semantic_hash": "d99e5601acc146d498081ed1960d21e5"
+  },
+  "services/orion-attention-runtime/docker-compose.yml": {
+    "mtime": 1783898916.258612,
+    "ast_hash": "b09649a97a636dc26ce9777855cc6683",
+    "semantic_hash": "b09649a97a636dc26ce9777855cc6683"
+  },
+  "services/orion-attention-runtime/requirements.txt": {
+    "mtime": 1783898916.258612,
+    "ast_hash": "9f1b8eea4d6a6ffbad4a721cda78563f",
+    "semantic_hash": "9f1b8eea4d6a6ffbad4a721cda78563f"
+  },
+  "services/orion-biometrics/README.md": {
+    "mtime": 1779668252.1410117,
+    "ast_hash": "08a5d39c8303a22449227929cba9c98d",
+    "semantic_hash": "08a5d39c8303a22449227929cba9c98d"
+  },
+  "services/orion-biometrics/docker-compose.yml": {
+    "mtime": 1781142159.222175,
+    "ast_hash": "67d55909ebf452d2283e3b860bdb8626",
+    "semantic_hash": "67d55909ebf452d2283e3b860bdb8626"
+  },
+  "services/orion-biometrics/requirements.txt": {
+    "mtime": 1779668252.1410117,
+    "ast_hash": "230bdfbd0a6bf152b02aa95f8685d7d8",
+    "semantic_hash": "230bdfbd0a6bf152b02aa95f8685d7d8"
+  },
+  "services/orion-bus-mirror/README.md": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "41e83818653e38b7e96e67f352345941",
+    "semantic_hash": "41e83818653e38b7e96e67f352345941"
+  },
+  "services/orion-bus-mirror/docker-compose.yml": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "85ed07d25ec22852a9007a8f89c4cb06",
+    "semantic_hash": "85ed07d25ec22852a9007a8f89c4cb06"
+  },
+  "services/orion-bus-mirror/requirements.txt": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "08c260ea520a86b5398a9ab3b333adfc",
+    "semantic_hash": "08c260ea520a86b5398a9ab3b333adfc"
+  },
+  "services/orion-bus-tap/README.md": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "98f9fe50bb0fa65fc626dad654549426",
+    "semantic_hash": "98f9fe50bb0fa65fc626dad654549426"
+  },
+  "services/orion-bus-tap/docker-compose.yml": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "7a5d30d03050dbfbfe4e9005c9f7cff7",
+    "semantic_hash": "7a5d30d03050dbfbfe4e9005c9f7cff7"
+  },
+  "services/orion-bus-tap/requirements.txt": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "cbde882fd5d2d5911e7a0068b48b0238",
+    "semantic_hash": "cbde882fd5d2d5911e7a0068b48b0238"
+  },
+  "services/orion-bus-tap/static/index.html": {
+    "mtime": 1768597909.8822296,
+    "ast_hash": "d1b40333548d1e8ac2ad378f88e42ee3",
+    "semantic_hash": "d1b40333548d1e8ac2ad378f88e42ee3"
+  },
+  "services/orion-bus/AGENT_CONTEXT.md": {
+    "mtime": 1781730419.489787,
+    "ast_hash": "7ea33f195f2ba6029e26bbad564ddfaa",
+    "semantic_hash": "7ea33f195f2ba6029e26bbad564ddfaa"
+  },
+  "services/orion-bus/LAYER_PIPELINE_PLAN.md": {
+    "mtime": 1779749949.3204675,
+    "ast_hash": "b35032ad555230715e89e23f4890d14e",
+    "semantic_hash": "b35032ad555230715e89e23f4890d14e"
+  },
+  "services/orion-bus/README.md": {
+    "mtime": 1783614403.696276,
+    "ast_hash": "1f4b3aca9bf0d839134e30f4e5b2d55b",
+    "semantic_hash": "1f4b3aca9bf0d839134e30f4e5b2d55b"
+  },
+  "services/orion-bus/SERVICE_PORTS.yaml": {
+    "mtime": 1779749949.3214674,
+    "ast_hash": "6b01620ac89de208558edf61648910d5",
+    "semantic_hash": "6b01620ac89de208558edf61648910d5"
+  },
+  "services/orion-bus/SUBSTRATE_TRACE_MAP.md": {
+    "mtime": 1779749949.3214674,
+    "ast_hash": "42560a9f2f8a2de78d30c9b9525b67c8",
+    "semantic_hash": "42560a9f2f8a2de78d30c9b9525b67c8"
+  },
+  "services/orion-bus/docker-compose.yml": {
+    "mtime": 1783614403.4762692,
+    "ast_hash": "c89d402301169f50c1c7d189b64ccba6",
+    "semantic_hash": "c89d402301169f50c1c7d189b64ccba6"
+  },
+  "services/orion-bus/requirements.txt": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "7adef3cc39d59ac87b9e4b636df87a49",
+    "semantic_hash": "7adef3cc39d59ac87b9e4b636df87a49"
+  },
+  "services/orion-chat-memory/README.md": {
+    "mtime": 1768597909.8832295,
+    "ast_hash": "5092cc1efd6aa66eb73cba3543fd135a",
+    "semantic_hash": "5092cc1efd6aa66eb73cba3543fd135a"
+  },
+  "services/orion-chat-memory/docker-compose.yml": {
+    "mtime": 1768597909.8832295,
+    "ast_hash": "a3375df259edbffc59703923ca1976a4",
+    "semantic_hash": "a3375df259edbffc59703923ca1976a4"
+  },
+  "services/orion-chat-memory/requirements.txt": {
+    "mtime": 1768597909.8832295,
+    "ast_hash": "d9d0ce07610424302f62b37e61ab8c34",
+    "semantic_hash": "d9d0ce07610424302f62b37e61ab8c34"
+  },
+  "services/orion-collapse-mirror/README.md": {
+    "mtime": 1782938951.8057263,
+    "ast_hash": "d708dc9ba2a42d9fa43e38574384d5a7",
+    "semantic_hash": "d708dc9ba2a42d9fa43e38574384d5a7"
+  },
+  "services/orion-collapse-mirror/docker-compose.yml": {
+    "mtime": 1781730419.490787,
+    "ast_hash": "4ff0eb0f2220d3394283e6bc5d73ac1f",
+    "semantic_hash": "4ff0eb0f2220d3394283e6bc5d73ac1f"
+  },
+  "services/orion-collapse-mirror/requirements.txt": {
+    "mtime": 1767676515.6471066,
+    "ast_hash": "178ddadc1804518d4385bfe4bb82b03f",
+    "semantic_hash": "178ddadc1804518d4385bfe4bb82b03f"
+  },
+  "services/orion-consolidation-runtime/README.md": {
+    "mtime": 1779749949.3224676,
+    "ast_hash": "d6ea4a33d678271f371dbc0d2488dcfe",
+    "semantic_hash": "d6ea4a33d678271f371dbc0d2488dcfe"
+  },
+  "services/orion-consolidation-runtime/docker-compose.yml": {
+    "mtime": 1779749949.3234675,
+    "ast_hash": "a97a689076e5187bcbccd78c8364bf1b",
+    "semantic_hash": "a97a689076e5187bcbccd78c8364bf1b"
+  },
+  "services/orion-consolidation-runtime/requirements.txt": {
+    "mtime": 1779749949.3234675,
+    "ast_hash": "f45613f6c78f7694bd933d7f52006f19",
+    "semantic_hash": "f45613f6c78f7694bd933d7f52006f19"
+  },
+  "services/orion-context-exec/README.md": {
+    "mtime": 1783113795.7049558,
+    "ast_hash": "eca40766bdd1ac391fd20b69d85a4cab",
+    "semantic_hash": "eca40766bdd1ac391fd20b69d85a4cab"
+  },
+  "services/orion-context-exec/docker-compose.yml": {
+    "mtime": 1783107031.9719017,
+    "ast_hash": "87e30742d35abb88125783897d5d4952",
+    "semantic_hash": "87e30742d35abb88125783897d5d4952"
+  },
+  "services/orion-context-exec/requirements.txt": {
+    "mtime": 1781756701.4674652,
+    "ast_hash": "7ec1dcf636e609726c3f74827f8129f5",
+    "semantic_hash": "7ec1dcf636e609726c3f74827f8129f5"
+  },
+  "services/orion-cortex-exec/README.md": {
+    "mtime": 1783986358.1036565,
+    "ast_hash": "f2d88a6d624087d715de6422a72ff242",
+    "semantic_hash": "f2d88a6d624087d715de6422a72ff242"
+  },
+  "services/orion-cortex-exec/docker-compose.tailscale-live.yml": {
+    "mtime": 1775948546.0555117,
+    "ast_hash": "f0a1f45c7148618ad4903a8c19c5510b",
+    "semantic_hash": "f0a1f45c7148618ad4903a8c19c5510b"
+  },
+  "services/orion-cortex-exec/docker-compose.yml": {
+    "mtime": 1783554331.4034736,
+    "ast_hash": "50ed08ec8cef6b58709ce23c9ec55f11",
+    "semantic_hash": "50ed08ec8cef6b58709ce23c9ec55f11"
+  },
+  "services/orion-cortex-exec/requirements.txt": {
+    "mtime": 1775609170.0457675,
+    "ast_hash": "e049f99fe81d4931d23dfba306f0d57c",
+    "semantic_hash": "e049f99fe81d4931d23dfba306f0d57c"
+  },
+  "services/orion-cortex-gateway/README.md": {
+    "mtime": 1767676515.6501067,
+    "ast_hash": "44c98d547d3a68dbcdffac9d7415a5d0",
+    "semantic_hash": "44c98d547d3a68dbcdffac9d7415a5d0"
+  },
+  "services/orion-cortex-gateway/docker-compose.yml": {
+    "mtime": 1778901838.376395,
+    "ast_hash": "0c59635b474e3a63d9f03fa2e34c6367",
+    "semantic_hash": "0c59635b474e3a63d9f03fa2e34c6367"
+  },
+  "services/orion-cortex-gateway/requirements.txt": {
+    "mtime": 1767676515.6511068,
+    "ast_hash": "34754b32ab4bb21d7204e10301af75dd",
+    "semantic_hash": "34754b32ab4bb21d7204e10301af75dd"
+  },
+  "services/orion-cortex-orch/CONCEPT_INDUCTION_DETAILS_MODAL_NOTE.md": {
+    "mtime": 1774840917.2972112,
+    "ast_hash": "736755f664b2971ba56ab510c6e13c65",
+    "semantic_hash": "736755f664b2971ba56ab510c6e13c65"
+  },
+  "services/orion-cortex-orch/CONCEPT_PROFILE_CONFIG_ADAPTER_NOTE.md": {
+    "mtime": 1774754647.368414,
+    "ast_hash": "06905f72b78a8448e0ac46673cd52b17",
+    "semantic_hash": "06905f72b78a8448e0ac46673cd52b17"
+  },
+  "services/orion-cortex-orch/README.md": {
+    "mtime": 1783958824.2836838,
+    "ast_hash": "385ca5c7dc108fd2f723bc408e8668d8",
+    "semantic_hash": "385ca5c7dc108fd2f723bc408e8668d8"
+  },
+  "services/orion-cortex-orch/docker-compose.yml": {
+    "mtime": 1783915348.428791,
+    "ast_hash": "e9f7b8e4c6bda93f8ad5a7b8ff01638a",
+    "semantic_hash": "e9f7b8e4c6bda93f8ad5a7b8ff01638a"
+  },
+  "services/orion-cortex-orch/requirements.txt": {
+    "mtime": 1777790653.2180316,
+    "ast_hash": "eae3d7e99c351b37fad0f82cd0970bb0",
+    "semantic_hash": "eae3d7e99c351b37fad0f82cd0970bb0"
+  },
+  "services/orion-dream/README.md": {
+    "mtime": 1774236180.4493854,
+    "ast_hash": "0626936c1128e2140016413222636b92",
+    "semantic_hash": "0626936c1128e2140016413222636b92"
+  },
+  "services/orion-dream/docker-compose.yml": {
+    "mtime": 1781142159.222175,
+    "ast_hash": "5e6daac1294bb9bb15cc5d2baa8944bb",
+    "semantic_hash": "5e6daac1294bb9bb15cc5d2baa8944bb"
+  },
+  "services/orion-dream/requirements.txt": {
+    "mtime": 1763232123.4098907,
+    "ast_hash": "a8d606e01331eecca52a571b010841d2",
+    "semantic_hash": "a8d606e01331eecca52a571b010841d2"
+  },
+  "services/orion-embodiment/README.md": {
+    "mtime": 1783554331.4044738,
+    "ast_hash": "a8b5bec784842672d7e3708d91979f8d",
+    "semantic_hash": "a8b5bec784842672d7e3708d91979f8d"
+  },
+  "services/orion-embodiment/docker-compose.yml": {
+    "mtime": 1783554331.4044738,
+    "ast_hash": "6e38fffc06a7b5424734a8b0f3a158ab",
+    "semantic_hash": "6e38fffc06a7b5424734a8b0f3a158ab"
+  },
+  "services/orion-embodiment/requirements.txt": {
+    "mtime": 1783461977.1323037,
+    "ast_hash": "20ddf8b0aff409864f25cf1157772088",
+    "semantic_hash": "20ddf8b0aff409864f25cf1157772088"
+  },
+  "services/orion-equilibrium-service/README.md": {
+    "mtime": 1783107031.974902,
+    "ast_hash": "596fe0f6f62e224d09ccb45bf48c92ca",
+    "semantic_hash": "596fe0f6f62e224d09ccb45bf48c92ca"
+  },
+  "services/orion-equilibrium-service/docker-compose.yml": {
+    "mtime": 1783107031.9759018,
+    "ast_hash": "4f835d0cb4b2bff5263cd4514abba8b4",
+    "semantic_hash": "4f835d0cb4b2bff5263cd4514abba8b4"
+  },
+  "services/orion-equilibrium-service/requirements.txt": {
+    "mtime": 1783107031.9759018,
+    "ast_hash": "62a320b82ca458839fb478ff542a619d",
+    "semantic_hash": "62a320b82ca458839fb478ff542a619d"
+  },
+  "services/orion-execution-dispatch-runtime/README.md": {
+    "mtime": 1784008374.2445009,
+    "ast_hash": "eece1838dc67511ea90c535307877167",
+    "semantic_hash": "eece1838dc67511ea90c535307877167"
+  },
+  "services/orion-execution-dispatch-runtime/docker-compose.yml": {
+    "mtime": 1779722671.526158,
+    "ast_hash": "bc6e803c21f0c374fb3c1f85f8327ca3",
+    "semantic_hash": "bc6e803c21f0c374fb3c1f85f8327ca3"
+  },
+  "services/orion-execution-dispatch-runtime/requirements.txt": {
+    "mtime": 1783967452.503406,
+    "ast_hash": "9d27f83d3b9339beec52a521f9f89249",
+    "semantic_hash": "9d27f83d3b9339beec52a521f9f89249"
+  },
+  "services/orion-fcc/README.md": {
+    "mtime": 1783389507.7134867,
+    "ast_hash": "b205a3ace233393a3e36e3be8a669bc8",
+    "semantic_hash": "b205a3ace233393a3e36e3be8a669bc8"
+  },
+  "services/orion-fcc/docker-compose.yml": {
+    "mtime": 1783389507.7134867,
+    "ast_hash": "4bddcc349d3e62ad92e310fa0c703a3d",
+    "semantic_hash": "4bddcc349d3e62ad92e310fa0c703a3d"
+  },
+  "services/orion-fcc/requirements.txt": {
+    "mtime": 1783389507.7144868,
+    "ast_hash": "6921e6d29514fc85257694ed0d66e017",
+    "semantic_hash": "6921e6d29514fc85257694ed0d66e017"
+  },
+  "services/orion-feedback-runtime/README.md": {
+    "mtime": 1783967452.503406,
+    "ast_hash": "2fbbae090828aaf8c0ed7bd23013f0f4",
+    "semantic_hash": "2fbbae090828aaf8c0ed7bd23013f0f4"
+  },
+  "services/orion-feedback-runtime/docker-compose.yml": {
+    "mtime": 1782445797.5973227,
+    "ast_hash": "ed638f7b850cdb13ea9edfad9a49a084",
+    "semantic_hash": "ed638f7b850cdb13ea9edfad9a49a084"
+  },
+  "services/orion-feedback-runtime/requirements.txt": {
+    "mtime": 1782446434.8998,
+    "ast_hash": "fc950486831785ce2722c2ed07678708",
+    "semantic_hash": "fc950486831785ce2722c2ed07678708"
+  },
+  "services/orion-field-digester/README.md": {
+    "mtime": 1783984456.988051,
+    "ast_hash": "4b6d092b393f03fec22381a9b500a7b0",
+    "semantic_hash": "4b6d092b393f03fec22381a9b500a7b0"
+  },
+  "services/orion-field-digester/docker-compose.yml": {
+    "mtime": 1783986358.1056566,
+    "ast_hash": "a878b960de187141b763413037b86333",
+    "semantic_hash": "a878b960de187141b763413037b86333"
+  },
+  "services/orion-field-digester/requirements.txt": {
+    "mtime": 1783897997.642214,
+    "ast_hash": "9f1b8eea4d6a6ffbad4a721cda78563f",
+    "semantic_hash": "9f1b8eea4d6a6ffbad4a721cda78563f"
+  },
+  "services/orion-gpu-cluster-power/docker-compose.yml": {
+    "mtime": 1768597909.8872294,
+    "ast_hash": "8519d45d07485f33669275f39ff9632a",
+    "semantic_hash": "8519d45d07485f33669275f39ff9632a"
+  },
+  "services/orion-gpu-cluster-power/requirements.txt": {
+    "mtime": 1764610357.5958822,
+    "ast_hash": "db4ce20a7ad3c8f9b8ba0ca975f9a039",
+    "semantic_hash": "db4ce20a7ad3c8f9b8ba0ca975f9a039"
+  },
+  "services/orion-graph-compression/README.md": {
+    "mtime": 1780989397.5300848,
+    "ast_hash": "e18a2a9a7a3dff53d887c33ca0952de0",
+    "semantic_hash": "e18a2a9a7a3dff53d887c33ca0952de0"
+  },
+  "services/orion-graph-compression/config/compression_policy.v1.yaml": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "291521a7e02d4a7a5cff1db34713589e",
+    "semantic_hash": "291521a7e02d4a7a5cff1db34713589e"
+  },
+  "services/orion-graph-compression/docker-compose.yml": {
+    "mtime": 1780989393.0490935,
+    "ast_hash": "6cc3f77db106c31dc81e9ce575eeecb7",
+    "semantic_hash": "6cc3f77db106c31dc81e9ce575eeecb7"
+  },
+  "services/orion-graph-compression/requirements.txt": {
+    "mtime": 1780972924.4332647,
+    "ast_hash": "69d4830500f94f1a4368b2b585b684b8",
+    "semantic_hash": "69d4830500f94f1a4368b2b585b684b8"
+  },
+  "services/orion-graphiti-adapter/README.md": {
+    "mtime": 1783925507.4330802,
+    "ast_hash": "2ed8080ef8bf4367ffaa5d5873bb31f9",
+    "semantic_hash": "2ed8080ef8bf4367ffaa5d5873bb31f9"
+  },
+  "services/orion-graphiti-adapter/docker-compose.yml": {
+    "mtime": 1783923933.4926658,
+    "ast_hash": "d2fd1c0b3671b3f0b1a0bf3b77eb4ee8",
+    "semantic_hash": "d2fd1c0b3671b3f0b1a0bf3b77eb4ee8"
+  },
+  "services/orion-graphiti-adapter/requirements.txt": {
+    "mtime": 1783356911.6329517,
+    "ast_hash": "a70aa466d01c0b29eca1409876302989",
+    "semantic_hash": "a70aa466d01c0b29eca1409876302989"
+  },
+  "services/orion-harness-governor/README.md": {
+    "mtime": 1783820991.6711159,
+    "ast_hash": "13c9a1d611aa78b0cbe0424cf1bee754",
+    "semantic_hash": "13c9a1d611aa78b0cbe0424cf1bee754"
+  },
+  "services/orion-harness-governor/docker-compose.yml": {
+    "mtime": 1783820991.6721158,
+    "ast_hash": "959e158612a5366cdf9ab5cf803a481e",
+    "semantic_hash": "959e158612a5366cdf9ab5cf803a481e"
+  },
+  "services/orion-harness-governor/requirements.txt": {
+    "mtime": 1783292020.1160612,
+    "ast_hash": "3c81f25612eba8499b157e5c3e3f3ae2",
+    "semantic_hash": "3c81f25612eba8499b157e5c3e3f3ae2"
+  },
+  "services/orion-hub/README.md": {
+    "mtime": 1783917986.1039932,
+    "ast_hash": "700459861d3f981cb3317d75ab6c0133",
+    "semantic_hash": "700459861d3f981cb3317d75ab6c0133"
+  },
+  "services/orion-hub/docker-compose.yml": {
+    "mtime": 1783615212.4809122,
+    "ast_hash": "279d7758f2fa7987674fd5fb6f393f75",
+    "semantic_hash": "279d7758f2fa7987674fd5fb6f393f75"
+  },
+  "services/orion-hub/requirements.txt": {
+    "mtime": 1783497696.2973437,
+    "ast_hash": "42eca504ab7ba3ae913d7ee8eff3dede",
+    "semantic_hash": "42eca504ab7ba3ae913d7ee8eff3dede"
+  },
+  "services/orion-hub/scripts/memory/identity.yaml": {
+    "mtime": 1763509312.232362,
+    "ast_hash": "0a7ab99f5e745593bb1971ba4c509d1e",
+    "semantic_hash": "0a7ab99f5e745593bb1971ba4c509d1e"
+  },
+  "services/orion-hub/scripts/memory/narrative.yaml": {
+    "mtime": 1763509312.232362,
+    "ast_hash": "20698594eebbb2a3799b77b855f15b6a",
+    "semantic_hash": "20698594eebbb2a3799b77b855f15b6a"
+  },
+  "services/orion-hub/scripts/smoke_biometrics_ws.md": {
+    "mtime": 1769550252.5870264,
+    "ast_hash": "acb916bfca833cb4a4c2cbd0e5b98812",
+    "semantic_hash": "acb916bfca833cb4a4c2cbd0e5b98812"
+  },
+  "services/orion-hub/static/pressure-analytics.html": {
+    "mtime": 1777748523.3315992,
+    "ast_hash": "56ca593fe72d0e7e3eb36309b46c2771",
+    "semantic_hash": "56ca593fe72d0e7e3eb36309b46c2771"
+  },
+  "services/orion-hub/static/self-brain.html": {
+    "mtime": 1783473102.644676,
+    "ast_hash": "1c8908a4ba811ba64a82b54d70843b91",
+    "semantic_hash": "1c8908a4ba811ba64a82b54d70843b91"
+  },
+  "services/orion-hub/static/substrate-lattice.html": {
+    "mtime": 1780991890.177284,
+    "ast_hash": "96ed196482e31c67f160d9c4d9165c74",
+    "semantic_hash": "96ed196482e31c67f160d9c4d9165c74"
+  },
+  "services/orion-hub/templates/index.html": {
+    "mtime": 1783958824.289684,
+    "ast_hash": "5687c571719c91f54ca652b1f7ea012c",
+    "semantic_hash": "5687c571719c91f54ca652b1f7ea012c"
+  },
+  "services/orion-hub/templates/substrate.html": {
+    "mtime": 1775953716.799958,
+    "ast_hash": "07bc0ebc117a384c73d8326d51baffde",
+    "semantic_hash": "07bc0ebc117a384c73d8326d51baffde"
+  },
+  "services/orion-hub/templates/substrate_atlas.html": {
+    "mtime": 1779649387.810299,
+    "ast_hash": "0c7e412c88421d33cff86c2ad83bde90",
+    "semantic_hash": "0c7e412c88421d33cff86c2ad83bde90"
+  },
+  "services/orion-knowledge-forge/CLAUDE.md": {
+    "mtime": 1779310786.0190036,
+    "ast_hash": "ee0357e8065a72ccb56fab14fec26d8c",
+    "semantic_hash": "ee0357e8065a72ccb56fab14fec26d8c"
+  },
+  "services/orion-knowledge-forge/docker-compose.yml": {
+    "mtime": 1779322188.0016465,
+    "ast_hash": "0dec3e6b3e24a53b489868eb1fcb6e0f",
+    "semantic_hash": "0dec3e6b3e24a53b489868eb1fcb6e0f"
+  },
+  "services/orion-knowledge-forge/requirements.txt": {
+    "mtime": 1779310786.0200036,
+    "ast_hash": "edde3ffaa36b153d0fb7df4db104dc82",
+    "semantic_hash": "edde3ffaa36b153d0fb7df4db104dc82"
+  },
+  "services/orion-landing-pad/README.md": {
+    "mtime": 1768597909.8882296,
+    "ast_hash": "5dd49e6e78f92920f670fd7f2e776fe4",
+    "semantic_hash": "5dd49e6e78f92920f670fd7f2e776fe4"
+  },
+  "services/orion-landing-pad/app/static/landing_pad/index.html": {
+    "mtime": 1769550252.5890265,
+    "ast_hash": "c51538359f4b8306dc087cb2bc4bb1a9",
+    "semantic_hash": "c51538359f4b8306dc087cb2bc4bb1a9"
+  },
+  "services/orion-landing-pad/docker-compose.yml": {
+    "mtime": 1781722043.3403635,
+    "ast_hash": "1029dba7521862f7e507048d6fb23161",
+    "semantic_hash": "1029dba7521862f7e507048d6fb23161"
+  },
+  "services/orion-landing-pad/requirements.txt": {
+    "mtime": 1773975149.9637861,
+    "ast_hash": "adca7ee64a697a55fc0a7be940c72edd",
+    "semantic_hash": "adca7ee64a697a55fc0a7be940c72edd"
+  },
+  "services/orion-llama-cola-host/README.md": {
+    "mtime": 1783136738.0558803,
+    "ast_hash": "22559545b41e618c3a21f9b0aa927f0d",
+    "semantic_hash": "22559545b41e618c3a21f9b0aa927f0d"
+  },
+  "services/orion-llama-cola-host/docker-compose.yml": {
+    "mtime": 1768597909.8922296,
+    "ast_hash": "b4656240f7ebced15e684932bc34865f",
+    "semantic_hash": "b4656240f7ebced15e684932bc34865f"
+  },
+  "services/orion-llama-cola-host/requirements.txt": {
+    "mtime": 1768597909.8932295,
+    "ast_hash": "8339aa0dc67b8036a41222050e499a5c",
+    "semantic_hash": "8339aa0dc67b8036a41222050e499a5c"
+  },
+  "services/orion-llamacpp-host/README.md": {
+    "mtime": 1783711326.843828,
+    "ast_hash": "196071b026441ead70cd1241802d4b89",
+    "semantic_hash": "196071b026441ead70cd1241802d4b89"
+  },
+  "services/orion-llamacpp-host/docker-compose.atlas-workers.yml": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "8b416fa89992c1e2ddd1b1fa5bd6d92f",
+    "semantic_hash": "8b416fa89992c1e2ddd1b1fa5bd6d92f"
+  },
+  "services/orion-llamacpp-host/docker-compose.yml": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "e06a700023000ec95445c94f5719482e",
+    "semantic_hash": "e06a700023000ec95445c94f5719482e"
+  },
+  "services/orion-llamacpp-host/requirements.txt": {
+    "mtime": 1768597909.8952293,
+    "ast_hash": "6ab032161cbfe1a7d13154aa1e691b57",
+    "semantic_hash": "6ab032161cbfe1a7d13154aa1e691b57"
+  },
+  "services/orion-llamacpp-host/scripts/goldens/README.md": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "c49d84c12668a5f011bcafcd4e15d997",
+    "semantic_hash": "c49d84c12668a5f011bcafcd4e15d997"
+  },
+  "services/orion-llamacpp-host/scripts/goldens/forbidden_thinking_markers.txt": {
+    "mtime": 1778901838.386395,
+    "ast_hash": "07cda3eca477d61681e135b13c84bbd1",
+    "semantic_hash": "07cda3eca477d61681e135b13c84bbd1"
+  },
+  "services/orion-llamacpp-neural-host/docker-compose.yml": {
+    "mtime": 1768597909.8952293,
+    "ast_hash": "de3408ac90acf5bbe22cf09eb0cdff34",
+    "semantic_hash": "de3408ac90acf5bbe22cf09eb0cdff34"
+  },
+  "services/orion-llamacpp-neural-host/requirements.txt": {
+    "mtime": 1768597909.8952293,
+    "ast_hash": "22f0e75b064c1f4eb2140713ea9a36c2",
+    "semantic_hash": "22f0e75b064c1f4eb2140713ea9a36c2"
+  },
+  "services/orion-llm-gateway/README.md": {
+    "mtime": 1783364899.1284673,
+    "ast_hash": "0c98290870c91e60dcf0d09c1323a2d8",
+    "semantic_hash": "0c98290870c91e60dcf0d09c1323a2d8"
+  },
+  "services/orion-llm-gateway/docker-compose.yml": {
+    "mtime": 1783649405.4951768,
+    "ast_hash": "59a630420ee2b7f2b1c9ea9f85dcf5e9",
+    "semantic_hash": "59a630420ee2b7f2b1c9ea9f85dcf5e9"
+  },
+  "services/orion-llm-gateway/requirements.txt": {
+    "mtime": 1783497833.5767968,
+    "ast_hash": "6e1240164572c586bda16c7b4fe29c10",
+    "semantic_hash": "6e1240164572c586bda16c7b4fe29c10"
+  },
+  "services/orion-llm-gateway/tests/llm_gateway_smoketests.md": {
+    "mtime": 1768597909.8992293,
+    "ast_hash": "2d0ab06a8bae872b592ee27f166a22ed",
+    "semantic_hash": "2d0ab06a8bae872b592ee27f166a22ed"
+  },
+  "services/orion-memory-consolidation/README.md": {
+    "mtime": 1784008374.2455008,
+    "ast_hash": "6e1127fe5bc32ee21de5d7bc2f40e0cb",
+    "semantic_hash": "6e1127fe5bc32ee21de5d7bc2f40e0cb"
+  },
+  "services/orion-memory-consolidation/docker-compose.yml": {
+    "mtime": 1783900735.492598,
+    "ast_hash": "3f301c882416f0e0f1fd1cc858e5b832",
+    "semantic_hash": "3f301c882416f0e0f1fd1cc858e5b832"
+  },
+  "services/orion-memory-consolidation/requirements.txt": {
+    "mtime": 1783957069.416255,
+    "ast_hash": "330d5ee2245d369bd14205aa033276c6",
+    "semantic_hash": "330d5ee2245d369bd14205aa033276c6"
+  },
+  "services/orion-memory-crystallizer/README.md": {
+    "mtime": 1781129793.9302504,
+    "ast_hash": "ce6d868ea67a19a0e00b4375f252f79a",
+    "semantic_hash": "ce6d868ea67a19a0e00b4375f252f79a"
+  },
+  "services/orion-memory-crystallizer/docker-compose.yml": {
+    "mtime": 1781129793.9302504,
+    "ast_hash": "85067531b8cea027f43c5a95988952ef",
+    "semantic_hash": "85067531b8cea027f43c5a95988952ef"
+  },
+  "services/orion-memory-crystallizer/requirements.txt": {
+    "mtime": 1781129793.9302504,
+    "ast_hash": "84eefc4b347073956492dd9ab057a062",
+    "semantic_hash": "84eefc4b347073956492dd9ab057a062"
+  },
+  "services/orion-mesh-guardian/README.md": {
+    "mtime": 1781846476.4951658,
+    "ast_hash": "e23ed7848db7112d8882ff661f1282b2",
+    "semantic_hash": "e23ed7848db7112d8882ff661f1282b2"
+  },
+  "services/orion-mesh-guardian/docker-compose.yml": {
+    "mtime": 1781852203.1115344,
+    "ast_hash": "8e8c23d7d318e281999ca25d428c1397",
+    "semantic_hash": "8e8c23d7d318e281999ca25d428c1397"
+  },
+  "services/orion-mesh-guardian/requirements.txt": {
+    "mtime": 1781846476.496166,
+    "ast_hash": "afba5a76f69201111fa280f2485743c6",
+    "semantic_hash": "afba5a76f69201111fa280f2485743c6"
+  },
+  "services/orion-meta-tags/README.md": {
+    "mtime": 1768784663.751758,
+    "ast_hash": "2b9b178349edd9dfc12197d88061fd68",
+    "semantic_hash": "2b9b178349edd9dfc12197d88061fd68"
+  },
+  "services/orion-meta-tags/docker-compose.yml": {
+    "mtime": 1768597909.9002292,
+    "ast_hash": "572d0a0f5cfc97487a2b4b00fe2afc54",
+    "semantic_hash": "572d0a0f5cfc97487a2b4b00fe2afc54"
+  },
+  "services/orion-meta-tags/requirements.txt": {
+    "mtime": 1767676515.662107,
+    "ast_hash": "87dcb05a67073c8c86385b792e9a349d",
+    "semantic_hash": "87dcb05a67073c8c86385b792e9a349d"
+  },
+  "services/orion-mind/app/config/router_profiles.yaml": {
+    "mtime": 1777790653.2240317,
+    "ast_hash": "b79b29d4e3b4dfb939aa5754b18914cc",
+    "semantic_hash": "b79b29d4e3b4dfb939aa5754b18914cc"
+  },
+  "services/orion-mind/docker-compose.yml": {
+    "mtime": 1783615212.4819124,
+    "ast_hash": "2e2adc506a777a429260cb9ea1263d6f",
+    "semantic_hash": "2e2adc506a777a429260cb9ea1263d6f"
+  },
+  "services/orion-mind/requirements.txt": {
+    "mtime": 1779070080.275205,
+    "ast_hash": "fb0aa8ba038a4f2b8db75d0631302427",
+    "semantic_hash": "fb0aa8ba038a4f2b8db75d0631302427"
+  },
+  "services/orion-notify-digest/README.md": {
+    "mtime": 1779681646.027453,
+    "ast_hash": "63abbeae97233246af35a2d605d07288",
+    "semantic_hash": "63abbeae97233246af35a2d605d07288"
+  },
+  "services/orion-notify-digest/docker-compose.yml": {
+    "mtime": 1779681646.027453,
+    "ast_hash": "9e54e0d581151712742f4d1fb0225768",
+    "semantic_hash": "9e54e0d581151712742f4d1fb0225768"
+  },
+  "services/orion-notify-digest/requirements.txt": {
+    "mtime": 1773975149.965786,
+    "ast_hash": "e0cffafae8eadfc35e79e23a7e571352",
+    "semantic_hash": "e0cffafae8eadfc35e79e23a7e571352"
+  },
+  "services/orion-notify/README.md": {
+    "mtime": 1781893873.1229722,
+    "ast_hash": "8b48a6a39d4bf1aa5c26fc2659785c90",
+    "semantic_hash": "8b48a6a39d4bf1aa5c26fc2659785c90"
+  },
+  "services/orion-notify/app/policy/rules.yaml": {
+    "mtime": 1773975149.966786,
+    "ast_hash": "aee82c9fc9a48080c70bbda10774dff7",
+    "semantic_hash": "aee82c9fc9a48080c70bbda10774dff7"
+  },
+  "services/orion-notify/docker-compose.yml": {
+    "mtime": 1773975149.966786,
+    "ast_hash": "a2a753d5cbbac936fcef352129ace25f",
+    "semantic_hash": "a2a753d5cbbac936fcef352129ace25f"
+  },
+  "services/orion-notify/requirements.txt": {
+    "mtime": 1773975149.966786,
+    "ast_hash": "f30fe66d214269f6a359cca38f88e8bd",
+    "semantic_hash": "f30fe66d214269f6a359cca38f88e8bd"
+  },
+  "services/orion-ollama-host/README.md": {
+    "mtime": 1767676515.663107,
+    "ast_hash": "b109013a98b23e233c243639b1c004b7",
+    "semantic_hash": "b109013a98b23e233c243639b1c004b7"
+  },
+  "services/orion-ollama-host/docker-compose.yml": {
+    "mtime": 1767676515.663107,
+    "ast_hash": "6bf5f56153d767df30d434e58c475372",
+    "semantic_hash": "6bf5f56153d767df30d434e58c475372"
+  },
+  "services/orion-ollama-host/requirements.txt": {
+    "mtime": 1767676515.663107,
+    "ast_hash": "a5d602e500c28463b23a55469d4f044a",
+    "semantic_hash": "a5d602e500c28463b23a55469d4f044a"
+  },
+  "services/orion-pageindex/README.md": {
+    "mtime": 1777165921.4101253,
+    "ast_hash": "43b8626ebfcc89d2e8b17300ab42721d",
+    "semantic_hash": "43b8626ebfcc89d2e8b17300ab42721d"
+  },
+  "services/orion-pageindex/docker-compose.yml": {
+    "mtime": 1777748523.3355992,
+    "ast_hash": "2346faeb1564017c6d1cb9c0045c8eaf",
+    "semantic_hash": "2346faeb1564017c6d1cb9c0045c8eaf"
+  },
+  "services/orion-pageindex/requirements.txt": {
+    "mtime": 1777748523.3355992,
+    "ast_hash": "e022da0429f3926de37e198f10f3874c",
+    "semantic_hash": "e022da0429f3926de37e198f10f3874c"
+  },
+  "services/orion-policy-runtime/README.md": {
+    "mtime": 1779689417.3452013,
+    "ast_hash": "554b9acdf82e194f66dcaa27a5639cf9",
+    "semantic_hash": "554b9acdf82e194f66dcaa27a5639cf9"
+  },
+  "services/orion-policy-runtime/docker-compose.yml": {
+    "mtime": 1779689417.3452013,
+    "ast_hash": "00bbf7867479bd607f31a67bd569010b",
+    "semantic_hash": "00bbf7867479bd607f31a67bd569010b"
+  },
+  "services/orion-policy-runtime/requirements.txt": {
+    "mtime": 1779689417.3452013,
+    "ast_hash": "f45613f6c78f7694bd933d7f52006f19",
+    "semantic_hash": "f45613f6c78f7694bd933d7f52006f19"
+  },
+  "services/orion-power-guard/docker-compose.yml": {
+    "mtime": 1768597909.9012294,
+    "ast_hash": "9ba713000582b1e20c0dde26e2c727bc",
+    "semantic_hash": "9ba713000582b1e20c0dde26e2c727bc"
+  },
+  "services/orion-power-guard/requirements.txt": {
+    "mtime": 1768597909.9012294,
+    "ast_hash": "50c3d5a1de72999287fa7745a4c1c952",
+    "semantic_hash": "50c3d5a1de72999287fa7745a4c1c952"
+  },
+  "services/orion-proposal-runtime/README.md": {
+    "mtime": 1784008374.2455008,
+    "ast_hash": "9032bfaee44c2207784030c726ec527b",
+    "semantic_hash": "9032bfaee44c2207784030c726ec527b"
+  },
+  "services/orion-proposal-runtime/docker-compose.yml": {
+    "mtime": 1783499830.2075214,
+    "ast_hash": "bcc8e0910fb19c29527a8b60d49845c8",
+    "semantic_hash": "bcc8e0910fb19c29527a8b60d49845c8"
+  },
+  "services/orion-proposal-runtime/requirements.txt": {
+    "mtime": 1779687966.459823,
+    "ast_hash": "f45613f6c78f7694bd933d7f52006f19",
+    "semantic_hash": "f45613f6c78f7694bd933d7f52006f19"
+  },
+  "services/orion-rag/README.md": {
+    "mtime": 1767676515.665107,
+    "ast_hash": "7c170a23c405bb2986e70c00742ebe72",
+    "semantic_hash": "7c170a23c405bb2986e70c00742ebe72"
+  },
+  "services/orion-rag/docker-compose.yml": {
+    "mtime": 1768597909.9022293,
+    "ast_hash": "6560b76c61447dceb65fbe279f2f1df3",
+    "semantic_hash": "6560b76c61447dceb65fbe279f2f1df3"
+  },
+  "services/orion-rag/requirements.txt": {
+    "mtime": 1763232123.4128907,
+    "ast_hash": "a64864eadb95adb91d2e93c881f7e0b9",
+    "semantic_hash": "a64864eadb95adb91d2e93c881f7e0b9"
+  },
+  "services/orion-rdf-store/README.md": {
+    "mtime": 1781748329.8800387,
+    "ast_hash": "86abe7e022139b338fca10ca2d8c4028",
+    "semantic_hash": "86abe7e022139b338fca10ca2d8c4028"
+  },
+  "services/orion-rdf-store/docker-compose.yml": {
+    "mtime": 1782182452.3592443,
+    "ast_hash": "f3d21a285a9274a8c1e2a9f9f3a9ae10",
+    "semantic_hash": "f3d21a285a9274a8c1e2a9f9f3a9ae10"
+  },
+  "services/orion-rdf-writer/README.md": {
+    "mtime": 1778901838.3883948,
+    "ast_hash": "6d4bc23d700b31502274bf50537ad22f",
+    "semantic_hash": "6d4bc23d700b31502274bf50537ad22f"
+  },
+  "services/orion-rdf-writer/docker-compose.yml": {
+    "mtime": 1781152354.0547266,
+    "ast_hash": "3e47d332c51f9de6e404db65dced3881",
+    "semantic_hash": "3e47d332c51f9de6e404db65dced3881"
+  },
+  "services/orion-rdf-writer/requirements.txt": {
+    "mtime": 1781370700.0588322,
+    "ast_hash": "3d9a90720ff3b74994c330edfe645a2b",
+    "semantic_hash": "3d9a90720ff3b74994c330edfe645a2b"
+  },
+  "services/orion-recall/README.md": {
+    "mtime": 1783986358.1056566,
+    "ast_hash": "64cf786c8811897d4739660acce59994",
+    "semantic_hash": "64cf786c8811897d4739660acce59994"
+  },
+  "services/orion-recall/docker-compose.yml": {
+    "mtime": 1783983558.4712076,
+    "ast_hash": "236e23eb57117e1c3a364853accc8a8b",
+    "semantic_hash": "236e23eb57117e1c3a364853accc8a8b"
+  },
+  "services/orion-recall/requirements.txt": {
+    "mtime": 1780115804.915145,
+    "ast_hash": "07c99b9c3fd993af78428f5573d08820",
+    "semantic_hash": "07c99b9c3fd993af78428f5573d08820"
+  },
+  "services/orion-security-watcher/README.md": {
+    "mtime": 1767676515.669107,
+    "ast_hash": "6d28bacfe2590f87395621a8045a375d",
+    "semantic_hash": "6d28bacfe2590f87395621a8045a375d"
+  },
+  "services/orion-security-watcher/app/templates/index.html": {
+    "mtime": 1765417470.9642785,
+    "ast_hash": "18bf0f00c24de48faf3ed1767113895a",
+    "semantic_hash": "18bf0f00c24de48faf3ed1767113895a"
+  },
+  "services/orion-security-watcher/docker-compose.yml": {
+    "mtime": 1773975149.967786,
+    "ast_hash": "cd279c9e6f20ac2d1090fdffda12aa7d",
+    "semantic_hash": "cd279c9e6f20ac2d1090fdffda12aa7d"
+  },
+  "services/orion-security-watcher/requirements.txt": {
+    "mtime": 1765420584.0829775,
+    "ast_hash": "b8b43dec230e8704b46522fb4cdc178e",
+    "semantic_hash": "b8b43dec230e8704b46522fb4cdc178e"
+  },
+  "services/orion-self-experiments/README.md": {
+    "mtime": 1781739116.1676345,
+    "ast_hash": "b0b28ccecbc3ee3632013e8109024b32",
+    "semantic_hash": "b0b28ccecbc3ee3632013e8109024b32"
+  },
+  "services/orion-self-experiments/docker-compose.yml": {
+    "mtime": 1781739116.1686344,
+    "ast_hash": "9e9ff46b70b5cb1644d8567cacb90b7e",
+    "semantic_hash": "9e9ff46b70b5cb1644d8567cacb90b7e"
+  },
+  "services/orion-self-experiments/requirements.txt": {
+    "mtime": 1781739116.1686344,
+    "ast_hash": "dc77ea785f6c9d669596a64ae4c80cb2",
+    "semantic_hash": "dc77ea785f6c9d669596a64ae4c80cb2"
+  },
+  "services/orion-self-state-runtime/README.md": {
+    "mtime": 1783898916.2596118,
+    "ast_hash": "8117b3d5ca18842dfa502301178366c6",
+    "semantic_hash": "8117b3d5ca18842dfa502301178366c6"
+  },
+  "services/orion-self-state-runtime/docker-compose.yml": {
+    "mtime": 1783898916.2596118,
+    "ast_hash": "1afa371aeedb6ba059e3bd0f86491dd9",
+    "semantic_hash": "1afa371aeedb6ba059e3bd0f86491dd9"
+  },
+  "services/orion-self-state-runtime/requirements.txt": {
+    "mtime": 1783898916.2596118,
+    "ast_hash": "d757d44cb69e788bbf4f60285a86f786",
+    "semantic_hash": "d757d44cb69e788bbf4f60285a86f786"
+  },
+  "services/orion-signal-gateway/README.md": {
+    "mtime": 1779332554.3348985,
+    "ast_hash": "724f02bb77e832079187b8dd53a707bc",
+    "semantic_hash": "724f02bb77e832079187b8dd53a707bc"
+  },
+  "services/orion-signal-gateway/docker-compose.yml": {
+    "mtime": 1777790653.2250316,
+    "ast_hash": "c996ba6855217b0fbb0824b24e5c673d",
+    "semantic_hash": "c996ba6855217b0fbb0824b24e5c673d"
+  },
+  "services/orion-signal-gateway/otel/collector-config.yaml": {
+    "mtime": 1777790653.2250316,
+    "ast_hash": "442dab0e73d95554433016d32e120ef2",
+    "semantic_hash": "442dab0e73d95554433016d32e120ef2"
+  },
+  "services/orion-signal-gateway/otel/grafana-datasources.yaml": {
+    "mtime": 1777790653.2250316,
+    "ast_hash": "d3ebecbf64263e3fbaf3d3d90b56d82e",
+    "semantic_hash": "d3ebecbf64263e3fbaf3d3d90b56d82e"
+  },
+  "services/orion-signal-gateway/otel/tempo.yaml": {
+    "mtime": 1777790653.2250316,
+    "ast_hash": "797351dba6c8528e15cbd13ead80a6e5",
+    "semantic_hash": "797351dba6c8528e15cbd13ead80a6e5"
+  },
+  "services/orion-signal-gateway/requirements.txt": {
+    "mtime": 1782190704.8260353,
+    "ast_hash": "c11932fdc0e79ea07abde319d2098843",
+    "semantic_hash": "c11932fdc0e79ea07abde319d2098843"
+  },
+  "services/orion-signals/README.md": {
+    "mtime": 1783551182.7595675,
+    "ast_hash": "d331b480a976a8032a9ac36788545577",
+    "semantic_hash": "d331b480a976a8032a9ac36788545577"
+  },
+  "services/orion-signals/roster.v1.yaml": {
+    "mtime": 1783551182.7595675,
+    "ast_hash": "42c8a66a80ec0c89b760c64ae36cc378",
+    "semantic_hash": "42c8a66a80ec0c89b760c64ae36cc378"
+  },
+  "services/orion-social-memory/README.md": {
+    "mtime": 1783107031.9819021,
+    "ast_hash": "ef0e996b94d2b73bce5b0f44a375903a",
+    "semantic_hash": "ef0e996b94d2b73bce5b0f44a375903a"
+  },
+  "services/orion-social-memory/docker-compose.yml": {
+    "mtime": 1774236180.4553852,
+    "ast_hash": "254b2249187564aa1087a786a449c483",
+    "semantic_hash": "254b2249187564aa1087a786a449c483"
+  },
+  "services/orion-social-memory/requirements.txt": {
+    "mtime": 1774236180.4553852,
+    "ast_hash": "6d3859f0b0f7744f90e32becc10ff279",
+    "semantic_hash": "6d3859f0b0f7744f90e32becc10ff279"
+  },
+  "services/orion-social-room-bridge/docker-compose.yml": {
+    "mtime": 1778303911.968509,
+    "ast_hash": "625963b6d3809e9a2b665f52ebb69a7f",
+    "semantic_hash": "625963b6d3809e9a2b665f52ebb69a7f"
+  },
+  "services/orion-social-room-bridge/requirements.txt": {
+    "mtime": 1774236180.457385,
+    "ast_hash": "a46417e4184f9e8d48273a3645647f97",
+    "semantic_hash": "a46417e4184f9e8d48273a3645647f97"
+  },
+  "services/orion-spark-concept-induction/README.md": {
+    "mtime": 1784008374.2455008,
+    "ast_hash": "3311ac9746845a0de8405473be55a048",
+    "semantic_hash": "3311ac9746845a0de8405473be55a048"
+  },
+  "services/orion-spark-concept-induction/docker-compose.yml": {
+    "mtime": 1783807362.0687652,
+    "ast_hash": "0154e7cd3b321a6e3f03dc6ac060de48",
+    "semantic_hash": "0154e7cd3b321a6e3f03dc6ac060de48"
+  },
+  "services/orion-spark-concept-induction/requirements.txt": {
+    "mtime": 1768597909.9032292,
+    "ast_hash": "ee24c17fbb174fa4667f4e1904c7c1b4",
+    "semantic_hash": "ee24c17fbb174fa4667f4e1904c7c1b4"
+  },
+  "services/orion-spark-introspector/README.md": {
+    "mtime": 1783984456.989051,
+    "ast_hash": "c41043e68cd5c850f77e129970ce3778",
+    "semantic_hash": "c41043e68cd5c850f77e129970ce3778"
+  },
+  "services/orion-spark-introspector/app/static/index.html": {
+    "mtime": 1783490446.3053594,
+    "ast_hash": "7728ad5d8c059f4a07114b59eb5f3a7d",
+    "semantic_hash": "7728ad5d8c059f4a07114b59eb5f3a7d"
+  },
+  "services/orion-spark-introspector/docker-compose.yml": {
+    "mtime": 1783918473.8103108,
+    "ast_hash": "ce9f2b598ed73230ff9ce6843f5aaef6",
+    "semantic_hash": "ce9f2b598ed73230ff9ce6843f5aaef6"
+  },
+  "services/orion-spark-introspector/requirements.txt": {
+    "mtime": 1768597909.9042292,
+    "ast_hash": "c859dffd3b4cd3eaa28e7ed1c86eac66",
+    "semantic_hash": "c859dffd3b4cd3eaa28e7ed1c86eac66"
+  },
+  "services/orion-spark-introspector/train/evals/README.md": {
+    "mtime": 1783918473.8103108,
+    "ast_hash": "2758042aa57b7b468402f7340a481166",
+    "semantic_hash": "2758042aa57b7b468402f7340a481166"
+  },
+  "services/orion-sql-db/docker-compose.yml": {
+    "mtime": 1782183480.7389724,
+    "ast_hash": "70f4ef7ebf40ee320699dee8e29db3c0",
+    "semantic_hash": "70f4ef7ebf40ee320699dee8e29db3c0"
+  },
+  "services/orion-sql-writer/README.md": {
+    "mtime": 1783405468.2247884,
+    "ast_hash": "1fdb3aeac05fa055b5275fb2b6906152",
+    "semantic_hash": "1fdb3aeac05fa055b5275fb2b6906152"
+  },
+  "services/orion-sql-writer/docker-compose.yml": {
+    "mtime": 1781722042.947365,
+    "ast_hash": "530060d27694b60786f9e0d162048409",
+    "semantic_hash": "530060d27694b60786f9e0d162048409"
+  },
+  "services/orion-sql-writer/requirements.txt": {
+    "mtime": 1767676515.674107,
+    "ast_hash": "bf91094b9e3695ab69bad64f1354bb0b",
+    "semantic_hash": "bf91094b9e3695ab69bad64f1354bb0b"
+  },
+  "services/orion-state-journaler/docker-compose.yml": {
+    "mtime": 1768597909.9052293,
+    "ast_hash": "fdd9d540cc1d4147a72e67055084737f",
+    "semantic_hash": "fdd9d540cc1d4147a72e67055084737f"
+  },
+  "services/orion-state-journaler/requirements.txt": {
+    "mtime": 1768597909.9052293,
+    "ast_hash": "51a48069931ff43c2bba0db8a667e86d",
+    "semantic_hash": "51a48069931ff43c2bba0db8a667e86d"
+  },
+  "services/orion-state-service/README.md": {
+    "mtime": 1773975149.9707859,
+    "ast_hash": "8347be321a20b080961e9df9ee098489",
+    "semantic_hash": "8347be321a20b080961e9df9ee098489"
+  },
+  "services/orion-state-service/docker-compose.yml": {
+    "mtime": 1781722043.0323648,
+    "ast_hash": "dabf31d4a6dd747abdf8ca65b560b749",
+    "semantic_hash": "dabf31d4a6dd747abdf8ca65b560b749"
+  },
+  "services/orion-state-service/requirements.txt": {
+    "mtime": 1768597909.9052293,
+    "ast_hash": "37c3a633327671d666ebeca2efe31b36",
+    "semantic_hash": "37c3a633327671d666ebeca2efe31b36"
+  },
+  "services/orion-substrate-organs/README.md": {
+    "mtime": 1779668252.1430116,
+    "ast_hash": "fb69bb616a9e9bcb8ef45939544b7337",
+    "semantic_hash": "fb69bb616a9e9bcb8ef45939544b7337"
+  },
+  "services/orion-substrate-organs/app/contracts/biometrics_pressure.yaml": {
+    "mtime": 1779668252.1440117,
+    "ast_hash": "1e20c2466b1857d57e889f52f46cd976",
+    "semantic_hash": "1e20c2466b1857d57e889f52f46cd976"
+  },
+  "services/orion-substrate-runtime/README.md": {
+    "mtime": 1783965578.734708,
+    "ast_hash": "8358cbc5b8f44ee835209842b98aed31",
+    "semantic_hash": "8358cbc5b8f44ee835209842b98aed31"
+  },
+  "services/orion-substrate-runtime/docker-compose.yml": {
+    "mtime": 1783965578.734708,
+    "ast_hash": "89ce42743526b8ad44c802b06e8b5fad",
+    "semantic_hash": "89ce42743526b8ad44c802b06e8b5fad"
+  },
+  "services/orion-substrate-runtime/evals/README_brain_frame_smoke.md": {
+    "mtime": 1783468068.6378665,
+    "ast_hash": "2cea81b09f21b3b81ff2c46824fe2b07",
+    "semantic_hash": "2cea81b09f21b3b81ff2c46824fe2b07"
+  },
+  "services/orion-substrate-runtime/requirements.txt": {
+    "mtime": 1783912914.8337595,
+    "ast_hash": "825c5f59ba6d5f525ea8c0455a841a01",
+    "semantic_hash": "825c5f59ba6d5f525ea8c0455a841a01"
+  },
+  "services/orion-substrate-telemetry/docker-compose.yml": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "14966ec336c2732c0e9cf8c3fef30bda",
+    "semantic_hash": "14966ec336c2732c0e9cf8c3fef30bda"
+  },
+  "services/orion-substrate-telemetry/requirements.txt": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "59d4e9ef651398a4ac4bbca81e1e3e7f",
+    "semantic_hash": "59d4e9ef651398a4ac4bbca81e1e3e7f"
+  },
+  "services/orion-thought/README.md": {
+    "mtime": 1783903398.6484442,
+    "ast_hash": "0b82060e754f609a5723175c1193ee72",
+    "semantic_hash": "0b82060e754f609a5723175c1193ee72"
+  },
+  "services/orion-thought/docker-compose.yml": {
+    "mtime": 1783903398.6484442,
+    "ast_hash": "0c125e16427c855e59967636da774f78",
+    "semantic_hash": "0c125e16427c855e59967636da774f78"
+  },
+  "services/orion-thought/requirements.txt": {
+    "mtime": 1783903398.6484442,
+    "ast_hash": "7b2433e9d38de33ec84ea20824bf7949",
+    "semantic_hash": "7b2433e9d38de33ec84ea20824bf7949"
+  },
+  "services/orion-topic-foundry/README.md": {
+    "mtime": 1773975149.9707859,
+    "ast_hash": "92b8e84ecee5baf5cf2c42ab420be7b9",
+    "semantic_hash": "92b8e84ecee5baf5cf2c42ab420be7b9"
+  },
+  "services/orion-topic-foundry/docker-compose.yml": {
+    "mtime": 1777748523.3415995,
+    "ast_hash": "3e41d7b443e2af0c37314044fd511cd2",
+    "semantic_hash": "3e41d7b443e2af0c37314044fd511cd2"
+  },
+  "services/orion-topic-foundry/requirements.txt": {
+    "mtime": 1777748523.3425994,
+    "ast_hash": "7185e956b428b1bd84d3f5c5fd612bf2",
+    "semantic_hash": "7185e956b428b1bd84d3f5c5fd612bf2"
+  },
+  "services/orion-vector-db/README.MD": {
+    "mtime": 1768940476.2287254,
+    "ast_hash": "d8b4375a382a0fdeade576ea58d0a3fd",
+    "semantic_hash": "d8b4375a382a0fdeade576ea58d0a3fd"
+  },
+  "services/orion-vector-db/docker-compose.yml": {
+    "mtime": 1776554227.0318274,
+    "ast_hash": "8549616c54b800b4760586657e280a96",
+    "semantic_hash": "8549616c54b800b4760586657e280a96"
+  },
+  "services/orion-vector-host/README.md": {
+    "mtime": 1773975149.976786,
+    "ast_hash": "859ffb872915f160eb44ecce7ee5812f",
+    "semantic_hash": "859ffb872915f160eb44ecce7ee5812f"
+  },
+  "services/orion-vector-host/docker-compose.yml": {
+    "mtime": 1773975149.9777858,
+    "ast_hash": "963fa0e9cc5153637c18b756055b5769",
+    "semantic_hash": "963fa0e9cc5153637c18b756055b5769"
+  },
+  "services/orion-vector-host/requirements.txt": {
+    "mtime": 1768940476.2297254,
+    "ast_hash": "72221436f71871bb7d248915a62a7050",
+    "semantic_hash": "72221436f71871bb7d248915a62a7050"
+  },
+  "services/orion-vector-writer/README.md": {
+    "mtime": 1768597909.908229,
+    "ast_hash": "62e84c53ce7c80b6494d2ef9691c0dd1",
+    "semantic_hash": "62e84c53ce7c80b6494d2ef9691c0dd1"
+  },
+  "services/orion-vector-writer/docker-compose.yml": {
+    "mtime": 1781142159.222175,
+    "ast_hash": "06e2b056f131a426bff2363278943d25",
+    "semantic_hash": "06e2b056f131a426bff2363278943d25"
+  },
+  "services/orion-vector-writer/requirements.txt": {
+    "mtime": 1768597909.9092293,
+    "ast_hash": "e5a0cc3d3355225c00d0995efd964923",
+    "semantic_hash": "e5a0cc3d3355225c00d0995efd964923"
+  },
+  "services/orion-vision-council/README.md": {
+    "mtime": 1783218343.7024755,
+    "ast_hash": "753a2ea48a07c4bffc43a3b116a99a5f",
+    "semantic_hash": "753a2ea48a07c4bffc43a3b116a99a5f"
+  },
+  "services/orion-vision-council/docker-compose.yml": {
+    "mtime": 1783218343.7034755,
+    "ast_hash": "b5cf74f912d0465deaed22495a9cd363",
+    "semantic_hash": "b5cf74f912d0465deaed22495a9cd363"
+  },
+  "services/orion-vision-council/requirements.txt": {
+    "mtime": 1767676515.6761072,
+    "ast_hash": "2bb0e48c399f6f81e55460308a7ed4d0",
+    "semantic_hash": "2bb0e48c399f6f81e55460308a7ed4d0"
+  },
+  "services/orion-vision-edge/README.md": {
+    "mtime": 1783110541.1459033,
+    "ast_hash": "1a6673b81f52360b35d2ae466ac3a093",
+    "semantic_hash": "1a6673b81f52360b35d2ae466ac3a093"
+  },
+  "services/orion-vision-edge/app/static/index.html": {
+    "mtime": 1766306403.7553797,
+    "ast_hash": "ad2fa3666210344c39fc7ce9b1f43db3",
+    "semantic_hash": "ad2fa3666210344c39fc7ce9b1f43db3"
+  },
+  "services/orion-vision-edge/docker-compose.yml": {
+    "mtime": 1783107031.9859023,
+    "ast_hash": "84f4949ecfc192e80af63550127f80f1",
+    "semantic_hash": "84f4949ecfc192e80af63550127f80f1"
+  },
+  "services/orion-vision-edge/requirements.txt": {
+    "mtime": 1763232123.4188907,
+    "ast_hash": "46844ee8f29ecde31cae0f7dbff8bef6",
+    "semantic_hash": "46844ee8f29ecde31cae0f7dbff8bef6"
+  },
+  "services/orion-vision-frame-router/README.md": {
+    "mtime": 1783110541.1459033,
+    "ast_hash": "435ec2b28d6995bc03d9d155430a07b2",
+    "semantic_hash": "435ec2b28d6995bc03d9d155430a07b2"
+  },
+  "services/orion-vision-frame-router/docker-compose.yml": {
+    "mtime": 1782872425.8586848,
+    "ast_hash": "a915e35c64e90bfe0b829a60d7324f5d",
+    "semantic_hash": "a915e35c64e90bfe0b829a60d7324f5d"
+  },
+  "services/orion-vision-frame-router/requirements.txt": {
+    "mtime": 1779649387.817299,
+    "ast_hash": "b24f61733e20843e330043242533e188",
+    "semantic_hash": "b24f61733e20843e330043242533e188"
+  },
+  "services/orion-vision-host/README.md": {
+    "mtime": 1783028252.552353,
+    "ast_hash": "d566b5f366211e3852352ce48575649c",
+    "semantic_hash": "d566b5f366211e3852352ce48575649c"
+  },
+  "services/orion-vision-host/app/config/vision_profiles.yaml": {
+    "mtime": 1777790653.2270315,
+    "ast_hash": "3b0e6fc37e90fdc71da03a5b4a8624bf",
+    "semantic_hash": "3b0e6fc37e90fdc71da03a5b4a8624bf"
+  },
+  "services/orion-vision-host/docker-compose.yml": {
+    "mtime": 1782874038.2589726,
+    "ast_hash": "4852dbe8181397d73834b6d615a31fc3",
+    "semantic_hash": "4852dbe8181397d73834b6d615a31fc3"
+  },
+  "services/orion-vision-host/requirements.txt": {
+    "mtime": 1782874038.2589726,
+    "ast_hash": "a68d0e9b5ebe2342168c0389c3d52085",
+    "semantic_hash": "a68d0e9b5ebe2342168c0389c3d52085"
+  },
+  "services/orion-vision-retina/README.md": {
+    "mtime": 1782879116.7631662,
+    "ast_hash": "d8657e01aff1c071c0e65ffb6ecf3bc8",
+    "semantic_hash": "d8657e01aff1c071c0e65ffb6ecf3bc8"
+  },
+  "services/orion-vision-retina/docker-compose.yml": {
+    "mtime": 1782879116.7631662,
+    "ast_hash": "cbe4d280f09bc953476a060a26701ccf",
+    "semantic_hash": "cbe4d280f09bc953476a060a26701ccf"
+  },
+  "services/orion-vision-retina/requirements.txt": {
+    "mtime": 1779649387.8192987,
+    "ast_hash": "6d071a0cac4e4532c02d1158d6385e5d",
+    "semantic_hash": "6d071a0cac4e4532c02d1158d6385e5d"
+  },
+  "services/orion-vision-scribe/README.md": {
+    "mtime": 1782944093.6522636,
+    "ast_hash": "e997ce00b331a445aef5e083d56b6d2e",
+    "semantic_hash": "e997ce00b331a445aef5e083d56b6d2e"
+  },
+  "services/orion-vision-scribe/docker-compose.yml": {
+    "mtime": 1782944093.6522636,
+    "ast_hash": "4416683a22fd178e85e9a141c5637973",
+    "semantic_hash": "4416683a22fd178e85e9a141c5637973"
+  },
+  "services/orion-vision-scribe/requirements.txt": {
+    "mtime": 1782944093.6532638,
+    "ast_hash": "8a6489e57222ac57f5ef6f11591460ed",
+    "semantic_hash": "8a6489e57222ac57f5ef6f11591460ed"
+  },
+  "services/orion-vision-window/README.md": {
+    "mtime": 1783219371.2280643,
+    "ast_hash": "a5938a6653b52f8e70a90c463bcd0fc2",
+    "semantic_hash": "a5938a6653b52f8e70a90c463bcd0fc2"
+  },
+  "services/orion-vision-window/docker-compose.yml": {
+    "mtime": 1783219371.2280643,
+    "ast_hash": "af871f7ae83330b20f329baad7e70690",
+    "semantic_hash": "af871f7ae83330b20f329baad7e70690"
+  },
+  "services/orion-vision-window/requirements.txt": {
+    "mtime": 1778901838.392395,
+    "ast_hash": "e8c8efaddc6d88a3f683b9e271ef7673",
+    "semantic_hash": "e8c8efaddc6d88a3f683b9e271ef7673"
+  },
+  "services/orion-vllm-host/docker-compose.yml": {
+    "mtime": 1767676515.7211077,
+    "ast_hash": "acd7eee8beab0c3804c4684a1787c42a",
+    "semantic_hash": "acd7eee8beab0c3804c4684a1787c42a"
+  },
+  "services/orion-vllm-host/requirements.txt": {
+    "mtime": 1767676515.7211077,
+    "ast_hash": "607fad2b403a5ed6e7e2373ba88fb6b6",
+    "semantic_hash": "607fad2b403a5ed6e7e2373ba88fb6b6"
+  },
+  "services/orion-voip-endpoint/docker-compose.yml": {
+    "mtime": 1768597909.9112291,
+    "ast_hash": "a9da623bf83a28bd0280946ac8f3a05c",
+    "semantic_hash": "a9da623bf83a28bd0280946ac8f3a05c"
+  },
+  "services/orion-voip-endpoint/requirements.txt": {
+    "mtime": 1764134382.320415,
+    "ast_hash": "0e19a32042562da84a8eee02e5bcd400",
+    "semantic_hash": "0e19a32042562da84a8eee02e5bcd400"
+  },
+  "services/orion-whisper-tts/README.md": {
+    "mtime": 1780115804.917145,
+    "ast_hash": "9b07d0ef10fd4a32556924c640103bc2",
+    "semantic_hash": "9b07d0ef10fd4a32556924c640103bc2"
+  },
+  "services/orion-whisper-tts/docker-compose.yml": {
+    "mtime": 1780115804.917145,
+    "ast_hash": "f564383b73909410ff9c1ad0afe21d59",
+    "semantic_hash": "f564383b73909410ff9c1ad0afe21d59"
+  },
+  "services/orion-whisper-tts/requirements.txt": {
+    "mtime": 1780106291.7517774,
+    "ast_hash": "f7d47d15d29db8a6a503365d7459fb68",
+    "semantic_hash": "f7d47d15d29db8a6a503365d7459fb68"
+  },
+  "services/orion-world-pulse/docker-compose.yml": {
+    "mtime": 1783476056.7672749,
+    "ast_hash": "4400da7623ae1149e12a2eb4c775dd9b",
+    "semantic_hash": "4400da7623ae1149e12a2eb4c775dd9b"
+  },
+  "services/orion-world-pulse/requirements.txt": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "37e2a32d95af3af9bccf753d1cfd10c3",
+    "semantic_hash": "37e2a32d95af3af9bccf753d1cfd10c3"
+  },
+  "services/orion-world-pulse/tests/fixtures/sample_section.html": {
+    "mtime": 1777748523.3455994,
+    "ast_hash": "1eebf678ad7a160887a2f294003c3fa0",
+    "semantic_hash": "1eebf678ad7a160887a2f294003c3fa0"
+  },
+  "tests/fixtures/knowledge_forge/claims/accepted/claim-test-0001.yaml": {
+    "mtime": 1779305390.1057496,
+    "ast_hash": "cc6ef5c2535ad0980b332a47a3645ce8",
+    "semantic_hash": "cc6ef5c2535ad0980b332a47a3645ce8"
+  },
+  "tests/fixtures/knowledge_forge/claims/disputed/claim-test-bad-ref.yaml": {
+    "mtime": 1779305390.1057496,
+    "ast_hash": "704b3ac63b5926e484bd0d60cc34aa41",
+    "semantic_hash": "704b3ac63b5926e484bd0d60cc34aa41"
+  },
+  "tests/fixtures/knowledge_forge/raw/sources/source-test-fixture.yaml": {
+    "mtime": 1779305390.1067498,
+    "ast_hash": "d7a8be6165fa88eeb88256de37f4def3",
+    "semantic_hash": "d7a8be6165fa88eeb88256de37f4def3"
+  },
+  "tests/fixtures/knowledge_forge/raw/sources/test-source.md": {
+    "mtime": 1779575629.633062,
+    "ast_hash": "31e551ff9201b563d82333da5504157d",
+    "semantic_hash": "31e551ff9201b563d82333da5504157d"
+  },
+  "tests/fixtures/knowledge_forge/specs/execution_ready/spec-test-compile.yaml": {
+    "mtime": 1779305390.1067498,
+    "ast_hash": "058ea2b2fae07a3b0171f50439424358",
+    "semantic_hash": "058ea2b2fae07a3b0171f50439424358"
+  },
+  ".verify-run/hub_agent_trace_timeline.png": {
+    "mtime": 1775948546.049512,
+    "ast_hash": "fa8c143ac509d68a79cf3c37b00f4ed9",
+    "semantic_hash": "fa8c143ac509d68a79cf3c37b00f4ed9"
+  },
+  "orion-hub.png": {
+    "mtime": 1768597909.8742297,
+    "ast_hash": "2ec9cf2748f64bea753fd2ec5248fb6c",
+    "semantic_hash": "2ec9cf2748f64bea753fd2ec5248fb6c"
+  },
+  "orion/autonomy/evals/run_attention_bound_proposal_eval.py": {
+    "mtime": 1784008374.2405007,
+    "ast_hash": "c5ac46d52400b35739bcdc4cd70b2f43",
+    "semantic_hash": "c5ac46d52400b35739bcdc4cd70b2f43"
+  },
+  "orion/spark/concept_induction/tests/test_action_outcome_tensions.py": {
+    "mtime": 1784008374.2435007,
+    "ast_hash": "8a5c3d238d805b3d586328dadbc8a06a",
+    "semantic_hash": "8a5c3d238d805b3d586328dadbc8a06a"
+  },
+  "scripts/drive_history_reflection_synthesis.py": {
+    "mtime": 1784008374.2445009,
+    "ast_hash": "6515396d7ce8427861161157864c0f62",
+    "semantic_hash": "6515396d7ce8427861161157864c0f62"
+  },
+  "scripts/git_hooks/pre-commit": {
+    "mtime": 1784011930.1179996,
+    "ast_hash": "5e9c3568b371065d6c977874e1eacd66",
+    "semantic_hash": "5e9c3568b371065d6c977874e1eacd66"
+  },
+  "scripts/install_git_safety_hooks.sh": {
+    "mtime": 1784011930.1179996,
+    "ast_hash": "a855fefcc4a37972c9216690108c9929",
+    "semantic_hash": "a855fefcc4a37972c9216690108c9929"
+  },
+  "scripts/safe_docker_build.sh": {
+    "mtime": 1784011930.1189995,
+    "ast_hash": "159266e4d5d7e9d2039cd19c81cbc512",
+    "semantic_hash": "159266e4d5d7e9d2039cd19c81cbc512"
+  },
+  "scripts/setup_graphify_merge_driver.sh": {
+    "mtime": 1784011930.1189995,
+    "ast_hash": "d7a3dcc3d67dfc26e58239ae47c894ec",
+    "semantic_hash": "d7a3dcc3d67dfc26e58239ae47c894ec"
+  },
+  "tests/test_drive_history_reflection_synthesis.py": {
+    "mtime": 1784008374.246501,
+    "ast_hash": "0c2e463317dce3ea4bc31c3550841ff1",
+    "semantic_hash": "0c2e463317dce3ea4bc31c3550841ff1"
+  },
+  "reviews/pending/2026-07-14-agent-worktree-discipline-and-graphify-sync-spec.md": {
+    "mtime": 1784008006.0574543,
+    "ast_hash": "fad87289461d90a247ce68fb178e4b1e",
+    "semantic_hash": "fad87289461d90a247ce68fb178e4b1e"
+  }
+}


### PR DESCRIPTION
## Summary

- Commits `graphify-out/{graph.json, GRAPH_REPORT.md, manifest.json}` for the first time -- previously untracked local state.
- Per graphify's own documented team-setup workflow and `reviews/pending/2026-07-14-agent-worktree-discipline-and-graphify-sync-spec.md`.
- Refreshed via `graphify . --update` immediately before committing to catch up on everything merged since the original build (40 changed files: 30 code, 10 docs; 0 deletions).

## Why now

Nothing auto-triggers this yet -- confirmed earlier today that graphify's own `post-commit`/`post-checkout` hooks don't cover `git merge`/`git pull` at all, so a batch of merged PRs (including #1032, which this branch itself builds on) never gets picked up automatically. This is the manual/scheduled catch-up step; a `/loop` or `/schedule` cadence for future runs is still an open decision.

## Notable: channels.yaml full re-enumeration

`orion/bus/channels.yaml` changed by exactly one field since the last full build (a producer service added to one existing channel). A shallow re-extract of just that delta would have replaced its ~260 previously-extracted channel nodes with a fraction of that, since `build_merge` fully replaces a re-extracted source file's prior contribution rather than patching it. Ran a dedicated full-enumeration pass instead -- verified all 261 channel nodes survived the update, plus the new producer edge.

## Not committed

- `graphify-out/cost.json` -- graphify's own docs mark this local-only.
- `graphify-out/cache/` -- optional either way per graphify's docs, skipped for repo size.

## Test plan

- [x] Graph health check clean: no dangling/missing endpoints, no self-loops
- [x] Node/edge diff reviewed: 656 new nodes, 1830 new edges (includes churn from the more accurate channels.yaml re-count), 354 removed, 1665 edges removed
- [x] `graph.html` regenerated (aggregated community view, 31,386 nodes exceeds the 5,000-node single-graph threshold)
- [x] Committed via a proper worktree, not the shared checkout -- the new pre-commit guard from #1032 is live and would have blocked a direct commit there; it correctly let this through since it originated in a linked worktree

Final graph: 31,386 nodes, 93,510 edges, 1,419 communities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)