### PR TITLE
Document the pre-commit guard where the worktree rule actually lives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,16 @@ git worktree add ../Orion-Sapienform-<short-task-name> -b <type>/<short-task-nam
 cd ../Orion-Sapienform-<short-task-name>
 ```
 
+This is enforced, not just advised. A `pre-commit` hook refuses commits made from the shared/primary checkout — plain git, not tied to any specific tool or subscription, so it fires the same way for this session, a different agent, or a human's own terminal. If a commit gets blocked here, that is the hook working as intended, not a bug: redo the work in a worktree instead of reaching for a workaround. Escape hatch for a genuinely intentional exception, set consciously per command, never as a habit:
+
+```bash
+ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git commit ...
+```
+
+Already have uncommitted work sitting in the shared checkout when you realize this? `git stash` is shared across every worktree of a repo, not per-worktree — `git stash -u` here, create the worktree, `git stash pop` there.
+
+New clone, or a worktree where the hook doesn't seem to be firing? Run `scripts/install_git_safety_hooks.sh .` once — hooks live in the shared common git dir, so this protects every worktree of the repo, not just the one it's run from. Full rationale and the incident that prompted this: `docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md`.
+
 Branch type examples:
 
 ```text


### PR DESCRIPTION
## Summary

Section 2 ("Clean git and worktree rules") still read as pure advice after #1032 merged the actual enforcement -- "prefer a separate worktree," no mention that this is now a real, enforced mechanism. Only section 8 (Docker readiness) got a pointer to the new tooling, and that was reactive (caught by code review, not planned). This closes the more central gap: an agent session reading this file cold would have had no idea a pre-commit hook exists, why, or what to do the first time it fires.

## What's added

Right where the worktree pattern is introduced in section 2:
- That it's enforced, not advised -- and that a block is the hook working correctly, not a bug to route around
- The `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1` escape hatch
- How to move already-dirty work in the shared checkout into a worktree (`git stash -u` / `git stash pop` -- stash is shared across worktrees)
- Where to run `scripts/install_git_safety_hooks.sh` for a fresh clone or an unprotected worktree

## Test plan

Doc-only change, no code touched. `git diff --check` clean. Read the rendered section back to confirm it reads coherently in place rather than as a bolted-on addendum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)