### PR TITLE
Graphify capabilities: prs/reflect docs + live Postgres schema merge

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,5 +4,27 @@
       "Bash(/mnt/scripts/Orion-Sapienform/orion_dev/bin/pytest *)",
       "Bash(node --check *)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/athena/.local/bin/graphify hook-guard search"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/athena/.local/bin/graphify hook-guard read"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1059,3 +1059,16 @@ Do not pad. Do not hand-wave. Do not hide uncertainty. Speak simply.
 When something is broken, say what is broken and where.
 
 End with the next action.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+- Before starting new work or opening a PR, run `graphify prs --worktrees` to see the live worktree → branch → PR mapping, and `graphify prs --conflicts` to check whether an open PR shares graph communities with what you're about to touch (merge-order risk, not just file-level collision). This is read-only reporting, safe to run any time.
+- When a `graphify query`/`path`/`explain` result turns out useful, wrong, or needed correction, record it: `graphify save-result --question "Q" --answer "A" --nodes Foo Bar --outcome useful|dead_end|corrected`. Run `graphify reflect --if-stale` occasionally to aggregate recorded outcomes into `graphify-out/reflections/LESSONS.md` (cheap no-op if nothing changed). This only builds real value if actually used consistently — an unused save-result is just as inert as an unread report.
+- Not installed: MCP server mode. Considered and deliberately skipped — persistent tool-schema context cost for every session outweighed the benefit over the PreToolUse nudge approach already in place.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-07-14)
 
 ## Corpus Check
-- 40 files · ~1,769,059 words
+- 0 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 31386 nodes · 93510 edges · 1419 communities (1095 shown, 324 thin omitted)
+- 31566 nodes · 93689 edges · 1418 communities (1094 shown, 324 thin omitted)
 - Extraction: 87% EXTRACTED · 13% INFERRED · 0% AMBIGUOUS · INFERRED: 12559 edges (avg confidence: 0.62)
 - Token cost: 0 input · 0 output
 
@@ -23,7 +23,7 @@
 - Social Artifact Schemas
 - Cognition Plan Loader
 - Harness Cortex Client
-- Substrate Mutation Trial Schemas
+- Postgres: conjourney Live Schema (179 tables)
 - Bus Queue Service Chassis
 - PAD Affect Schemas
 - Context-Exec Request Schemas
@@ -320,12 +320,12 @@
 - Community 307
 - Community 308
 - Community 309
-- Community 310
 - Community 311
 - Community 312
 - Community 313
 - Community 314
 - Community 315
+- Community 316
 - Community 317
 - Community 318
 - Community 319
@@ -344,13 +344,13 @@
 - Community 332
 - Community 333
 - Community 334
-- Community 335
 - Community 336
 - Community 337
 - Community 338
 - Community 339
 - Community 340
 - Community 341
+- Community 342
 - Community 343
 - Community 344
 - Community 345
@@ -468,7 +468,6 @@
 - Community 457
 - Community 458
 - Community 459
-- Community 460
 - Community 461
 - Community 462
 - Community 463
@@ -476,6 +475,7 @@
 - Community 465
 - Community 466
 - Community 467
+- Community 468
 - Community 469
 - Community 470
 - Community 471
@@ -488,8 +488,8 @@
 - Community 478
 - Community 479
 - Community 480
-- Community 481
 - Community 482
+- Community 483
 - Community 484
 - Community 485
 - Community 486
@@ -579,13 +579,13 @@
 - Community 570
 - Community 571
 - Community 572
+- Community 573
 - Community 574
 - Community 575
 - Community 576
 - Community 577
 - Community 578
 - Community 579
-- Community 580
 - Community 581
 - Community 582
 - Community 583
@@ -670,7 +670,7 @@
 - Community 662
 - Community 663
 - Community 664
-- Community 666
+- Community 665
 - Community 667
 - Community 668
 - Community 669
@@ -733,7 +733,7 @@
 - Community 726
 - Community 727
 - Community 728
-- Community 730
+- Community 729
 - Community 731
 - Community 732
 - Community 733
@@ -750,11 +750,11 @@
 - Community 744
 - Community 745
 - Community 746
-- Community 747
+- Community 748
 - Community 749
 - Community 750
 - Community 751
-- Community 752
+- Community 753
 - Community 754
 - Community 755
 - Community 756
@@ -781,9 +781,10 @@
 - Community 777
 - Community 778
 - Community 779
-- Community 781
+- Community 780
+- Community 782
 - Community 783
-- Community 784
+- Community 785
 - Community 786
 - Community 787
 - Community 788
@@ -876,7 +877,7 @@
 - Community 877
 - Community 878
 - Community 879
-- Community 882
+- Community 880
 - Community 883
 - Community 884
 - Community 885
@@ -887,12 +888,13 @@
 - Community 890
 - Community 891
 - Community 892
-- Community 897
+- Community 893
 - Community 898
 - Community 899
 - Community 900
 - Community 901
 - Community 902
+- Community 903
 - Community 905
 - Community 908
 - Community 909
@@ -909,7 +911,7 @@
 - Community 920
 - Community 921
 - Community 922
-- Community 923
+- Community 924
 - Community 925
 - Community 926
 - Community 927
@@ -919,7 +921,7 @@
 - Community 931
 - Community 932
 - Community 933
-- Community 934
+- Community 935
 - Community 936
 - Community 937
 - Community 938
@@ -946,7 +948,7 @@
 - Community 959
 - Community 960
 - Community 961
-- Community 962
+- Community 963
 - Community 964
 - Community 965
 - Community 966
@@ -965,15 +967,15 @@
 - Community 979
 - Community 980
 - Community 981
-- Community 982
-- Community 984
-- Community 987
+- Community 983
+- Community 986
+- Community 988
 - Community 989
 - Community 990
 - Community 991
-- Community 992
+- Community 993
 - Community 994
-- Community 995
+- Community 999
 - Community 1000
 - Community 1001
 - Community 1002
@@ -988,13 +990,13 @@
 - Community 1011
 - Community 1012
 - Community 1013
-- Community 1014
+- Community 1015
 - Community 1016
-- Community 1017
-- Community 1019
+- Community 1018
+- Community 1020
 - Community 1021
 - Community 1022
-- Community 1023
+- Community 1025
 - Community 1026
 - Community 1027
 - Community 1028
@@ -1012,7 +1014,7 @@
 - Community 1040
 - Community 1041
 - Community 1042
-- Community 1043
+- Community 1044
 - Community 1045
 - Community 1046
 - Community 1047
@@ -1116,8 +1118,8 @@
 - Community 1162
 - Community 1163
 - Community 1164
-- Community 1165
-- Community 1168
+- Community 1167
+- Community 1171
 - Community 1172
 - Community 1173
 - Community 1174
@@ -1131,10 +1133,10 @@
 - Community 1182
 - Community 1183
 - Community 1184
-- Community 1185
-- Community 1187
+- Community 1186
+- Community 1188
 - Community 1189
-- Community 1190
+- Community 1194
 - Community 1195
 - Community 1196
 - Community 1197
@@ -1147,8 +1149,8 @@
 - Community 1204
 - Community 1205
 - Community 1206
-- Community 1207
-- Community 1209
+- Community 1208
+- Community 1219
 - Community 1220
 - Community 1221
 - Community 1222
@@ -1159,7 +1161,7 @@
 - Community 1227
 - Community 1228
 - Community 1229
-- Community 1230
+- Community 1231
 - Community 1232
 - Community 1233
 - Community 1234
@@ -1185,8 +1187,8 @@
 - Community 1254
 - Community 1255
 - Community 1256
-- Community 1257
-- Community 1267
+- Community 1266
+- Community 1268
 - Community 1269
 - Community 1270
 - Community 1271
@@ -1195,10 +1197,10 @@
 - Community 1274
 - Community 1275
 - Community 1276
-- Community 1277
-- Community 1281
+- Community 1280
+- Community 1285
 - Community 1286
-- Community 1287
+- Community 1296
 - Community 1297
 - Community 1298
 - Community 1299
@@ -1207,14 +1209,13 @@
 - Community 1302
 - Community 1303
 - Community 1304
-- Community 1305
+- Community 1307
 - Community 1308
-- Community 1309
-- Community 1364
-- Community 1367
+- Community 1363
+- Community 1366
+- Community 1378
 - Community 1379
-- Community 1380
-- Community 1395
+- Community 1394
 
 ## God Nodes (most connected - your core abstractions)
 1. `ServiceRef` - 1128 edges
@@ -1233,12 +1234,12 @@
   .verify-run/hub_agent_trace_timeline.png → 2026-07-11-turn-visibility-design-spec.md
 - `Agent Trace inspection modal (Hub UI, fail case screenshot)` --conceptually_related_to--> `agent-trace.js (plain-text step consumer)`  [AMBIGUOUS]
   .verify-run/hub_agent_trace_timeline.png → 2026-07-11-turn-visibility-design-spec.md
+- `test_stable_hash_id_is_deterministic()` --calls--> `stable_hash_id()`  [INFERRED]
+  tests/test_substrate_deterministic_ids.py → orion/core/ids.py
+- `test_model_map_registers_action_outcome_sql_with_emit_schema()` --indirect_call--> `ActionOutcomeEmitV1`  [INFERRED]
+  services/orion-sql-writer/tests/test_action_outcome_sql_shape.py → orion/autonomy/models.py
 - `Turn Visibility Design Spec (2026-07-11)` --semantically_similar_to--> `/brainstorming command (sentience-development ideation)`  [INFERRED] [semantically similar]
   2026-07-11-turn-visibility-design-spec.md → .claude/commands/superpowers/brainstorming.md
-- `Ethics & non-instrumental stance` --semantically_similar_to--> `Privacy and blocked material stay blocked: raw private traces, journals, mirrors, and internal memory artifacts must not leak through convenience surfaces; summaries/projections preserve privacy boundaries`  [INFERRED] [semantically similar]
-  README.md → AGENTS.md
-- `Autonomy Origination Measurement Gate (scripts/analysis/README.md)` --semantically_similar_to--> `Phase 3B: Parity Evidence and Cutover-Readiness Model`  [INFERRED] [semantically similar]
-  scripts/analysis/README.md → orion/spark/concept_induction/PHASE3B_PARITY_EVIDENCE_READINESS.md
 
 ## Import Cycles
 - 3-file cycle: `services/orion-cortex-exec/app/executor.py -> services/orion-cortex-exec/app/verb_adapters.py -> services/orion-cortex-exec/app/router.py -> services/orion-cortex-exec/app/executor.py`
@@ -1330,1967 +1331,1963 @@
 - **Knowledge Forge dangling-reference test family** — tests_fixtures_knowledge_forge_claims_disputed_claim_test_bad_ref_claim, tests_fixtures_knowledge_forge_claims_disputed_claim_test_bad_ref_missing_claim, tests_fixtures_knowledge_forge_claims_disputed_claim_test_bad_ref_missing_source [INFERRED 0.65]
 - **orion-whisper-tts service definition family (README + compose + requirements)** — services_orion_whisper_tts_readme_doc, services_orion_whisper_tts_docker_compose_whisper_tts, services_orion_whisper_tts_requirements_dependencies [EXTRACTED 1.00]
 
-## Communities (1419 total, 324 thin omitted)
+## Communities (1418 total, 324 thin omitted)
 
 ### Community 0 - "Core Bus Schemas (Envelope/ServiceRef family)"
-Cohesion: 0.02
-Nodes (251): build_projection_unification_registry(), Construct the shared producer registry for cognitive projection reads., test_projection_registry_matches_expected_chat_stance_producers(), test_unified_beliefs_for_chat_stance_uses_shared_context_path(), _concept(), ConceptNodeV1, ContradictionNodeV1, DriveNodeV1 (+243 more)
+Cohesion: 0.01
+Nodes (300): HttpClient, ScenarioRunResult, OrionBusAsync, Any, Redis, Async Redis bus client., Publish `envelope` to request_channel and await first message on reply_channel., Compatibility RPC helper for legacy dict-style services.          Convention: (+292 more)
 
 ### Community 1 - "Async Bus Service Client"
-Cohesion: 0.04
-Nodes (229): MutationTrialStatusV1, GoalActionError, GoalActionResult, Exception, CognitiveDraftRecommendationV1, CognitiveProposalDraftV1, CognitiveProposalReviewV1, CognitiveStanceNoteV1 (+221 more)
+Cohesion: 0.02
+Nodes (246): bootstrap_answer_contract_on_request(), enrich_answer_contract_after_routing(), investigation_state_for_contract(), merge_draft(), _norm_user_text(), output_modes_for_answer_contract_style(), Any, Normalize hub `answer_contract_draft` + heuristics into a bus-safe AnswerContrac (+238 more)
 
 ### Community 2 - "Frontier Curiosity Target Zone Schemas"
-Cohesion: 0.02
-Nodes (318): ChatRole, ge, GoalActionKind, le, build_goal_graph_query_client(), complete_goal(), dismiss_goal(), execute_goal_action() (+310 more)
+Cohesion: 0.03
+Nodes (198): InputT, _BusStub, test_process_recall_includes_sql(), test_recall_handler_returns_bundle(), ChatRequestPayload, ChatResultPayload, CollapseMirrorPayload, BaseModel (+190 more)
 
 ### Community 3 - "Consolidation Windows"
-Cohesion: 0.01
-Nodes (205): HttpClient, ScenarioRunResult, OrionBusAsync, Any, Redis, Async Redis bus client., Unified async message iterator. Yields dicts with fields similar to redis-py's l, Publish `envelope` to request_channel and await first message on reply_channel. (+197 more)
+Cohesion: 0.02
+Nodes (161): new_goal_task_id(), Identity for the producer/consumer of a message.      Keep this tiny + stable; y, ServiceRef, AutonomyGoalPlannedV1, Supervisor notification when a promoted goal is allocated a planner task., _source(), _env(), test_extract_tensions_uses_spark_meta_nested_metadata_turn_effect() (+153 more)
 
 ### Community 4 - "Attention Schema & Self-State"
 Cohesion: 0.02
-Nodes (252): log_mind_projection_prebuild_ctx_summary(), Recall bundle prefetch for Mind preflight (Orch, before Exec)., Structured pre-build ctx summary (after recall prefetch, before projection)., _BusStub, test_process_recall_includes_sql(), test_recall_handler_returns_bundle(), CollapseMirrorPayload, datetime (+244 more)
+Nodes (203): ge, le, build_feedback_category_options(), Query, _aitown_convex_internal_url(), aitown_convex_ws_proxy(), _aitown_convex_ws_url(), api_autonomy_goal_complete() (+195 more)
 
 ### Community 5 - "Memory Turn-Change Signal"
-Cohesion: 0.01
-Nodes (210): BBox, BaseModel, VisionArtifactOutputs, VisionArtifactPayload, VisionCaption, VisionCouncilRequestPayload, VisionCouncilResultPayload, VisionEdgeActivityPayload (+202 more)
+Cohesion: 0.03
+Nodes (195): ContextExecCreatableReviewState, assert_context_exec_proposal_safe(), build_memory_correction_proposal_envelope(), build_patch_proposal_envelope(), MemoryCorrectionProposalV1, PatchProposalV1, ProposalEnvelopeV1, Shared review wrapper for context-exec proposal artifacts. (+187 more)
 
 ### Community 6 - "Endogenous Goal Origination"
 Cohesion: 0.02
-Nodes (229): bootstrap_answer_contract_on_request(), enrich_answer_contract_after_routing(), merge_draft(), _norm_user_text(), output_modes_for_answer_contract_style(), Normalize hub `answer_contract_draft` + heuristics into a bus-safe AnswerContrac, Phase 1: attach normalized AnswerContract from heuristic + hub draft (pre-router, Weaken classifier: fold output_mode_decision into contract hints without removin (+221 more)
+Nodes (145): ErrorInfo, BaseChassis, ChassisConfig, Clock, Hunter, BaseException, Handler, Rabbit (+137 more)
 
 ### Community 7 - "Concept Profile Backend"
-Cohesion: 0.02
-Nodes (175): DecodeResult, OrionCodec, Any, BaseModel, Bulletproof encode/decode layer.      Goals:     - Never leak raw JSON dicts int, _attempt_from_envelope(), _consumer_suffix(), _expires_at() (+167 more)
+Cohesion: 0.03
+Nodes (159): _concept(), ConceptNodeV1, DriveNodeV1, EdgeRefV1, EntityNodeV1, EventNodeV1, EvidenceNodeV1, EvidenceRefV1 (+151 more)
 
 ### Community 8 - "Bus Chat Result Payload Schemas"
-Cohesion: 0.03
-Nodes (195): InputT, ChatRequestPayload, ChatResultPayload, LLMMessage, BaseModel, Request payload for LLM chat., Standard response from LLM Gateway.     Strictly normalizes 'text' (Gateway) vs, RecallQueryV1 (+187 more)
+Cohesion: 0.02
+Nodes (159): JournalMode, dispatch_autonomy_episode_journal(), _new_reply_channel(), Any, Compose autonomy episode journal via cortex RPC and publish journal write., test_dispatch_autonomy_episode_journal_publishes_write(), JournalDispatchPolicy, Declarative journal notification dispatch policy, keyed off `trigger_kind`.  Con (+151 more)
 
 ### Community 9 - "Bus Chat/Input Payload Schemas"
-Cohesion: 0.03
-Nodes (112): BaseSubstrateNodeV1, SubstrateEdgeV1, Any, Session, Minimal SPARQL Protocol HTTP clients (Fuseki + generic SPARQL endpoints)., Host + path + query + fragment only (strips userinfo from URL)., Resolve Basic Auth for substrate SPARQL HTTP (query + update).      Precedence (, SPARQL 1.1 Protocol over HTTP: separate query and update endpoints, optional Bas (+104 more)
+Cohesion: 0.04
+Nodes (112): AutonomyAdapter, _extract_state(), _extract_summary_dict(), _pressure_dimensions(), Any, Autonomy summary/state → autonomy_state OrionSignalV1 (Milestone B4)., OrionSignalAdapter, ABC (+104 more)
 
 ### Community 10 - "Social Artifact Schemas"
-Cohesion: 0.03
-Nodes (203): ContextExecCreatableReviewState, assert_context_exec_proposal_safe(), build_memory_correction_proposal_envelope(), build_patch_proposal_envelope(), MemoryCorrectionProposalV1, PatchProposalV1, ProposalEnvelopeV1, Shared review wrapper for context-exec proposal artifacts. (+195 more)
+Cohesion: 0.04
+Nodes (148): MutationTrialStatusV1, BaseModel, Recall V2 / recall-strategy promotion readiness (advisory only; no live apply)., RecallStrategyReadinessV1, MutationAdoptionV1, MutationDecisionV1, MutationPatchV1, MutationPressureV1 (+140 more)
 
 ### Community 11 - "Cognition Plan Loader"
-Cohesion: 0.02
-Nodes (137): dispatch_autonomy_episode_journal(), _new_reply_channel(), Any, Compose autonomy episode journal via cortex RPC and publish journal write., test_dispatch_autonomy_episode_journal_publishes_write(), BaseEnvelope, Titanium, universal, versioned envelope.      - Strict (extra fields forbidden), OrionRouter (+129 more)
+Cohesion: 0.06
+Nodes (166): BaseModel, SocialArtifactConfirmationV1, SocialArtifactProposalV1, SocialArtifactRevisionV1, BaseModel, SocialCalibrationSignalV1, SocialPeerCalibrationV1, SocialTrustBoundaryV1 (+158 more)
 
 ### Community 12 - "Harness Cortex Client"
-Cohesion: 0.04
-Nodes (113): AutonomyAdapter, _extract_state(), _extract_summary_dict(), _pressure_dimensions(), Any, Autonomy summary/state → autonomy_state OrionSignalV1 (Milestone B4)., OrionSignalAdapter, ABC (+105 more)
+Cohesion: 0.03
+Nodes (112): Model, TraceAutopsyReportV1, PermissionError, AlexZhangInitError, AlexZhangRLMEngine, _engine_selection_grep_path(), _engine_selection_risk(), _extract_claim_from_text() (+104 more)
 
-### Community 13 - "Substrate Mutation Trial Schemas"
-Cohesion: 0.06
-Nodes (165): BaseModel, SocialArtifactConfirmationV1, SocialArtifactProposalV1, SocialArtifactRevisionV1, BaseModel, SocialCalibrationSignalV1, SocialPeerCalibrationV1, SocialTrustBoundaryV1 (+157 more)
+### Community 13 - "Postgres: conjourney Live Schema (179 tables)"
+Cohesion: 0.01
+Nodes (179): "public"."action_outcomes", "public"."attention_loop_outcome", "public"."attention_salience_trace", "public"."autonomy_state_v2", "public"."bus_fallback_log", "public"."calibration_profile_audit", "public"."calibration_profiles", "public"."chat_gpt_conversation" (+171 more)
 
 ### Community 14 - "Bus Queue Service Chassis"
-Cohesion: 0.02
-Nodes (124): FileResponse, ErrorInfo, BaseChassis, ChassisConfig, Clock, BaseException, Handler, Restart subscriber loops if they exit without an explicit stop signal. (+116 more)
+Cohesion: 0.03
+Nodes (130): Serialized result for a verb execution., VerbResultV1, Any, Send one prepared candidate's envelope and await a bounded reply.          Retur, HarnessCortexClient, Any, Thin RPC client for cortex-exec finalize verbs (5b / 5c)., _make_plan_request() (+122 more)
 
 ### Community 15 - "PAD Affect Schemas"
-Cohesion: 0.03
-Nodes (113): BeliefProvenanceReportV1, ContextExecBudgetV1, ContextExecRequestV1, BaseModel, Bounded RLM context-exec investigation schemas., RepoImpactAnalysisReportV1, TraceAutopsyReportV1, Schema validation for context-exec llm_profile. (+105 more)
+Cohesion: 0.02
+Nodes (134): api_debug_build(), _chat_turn_trace_linkage(), handle_chat_request(), Canonical correlation linkage for chat turn metadata (Runtime Trace Nexus §5.8)., Core chat handler used by both HTTP /api/chat and (optionally) WebSocket.     De, _rec_tape_req(), _runtime_identity(), extract_autonomy_payload() (+126 more)
 
 ### Community 16 - "Context-Exec Request Schemas"
-Cohesion: 0.05
-Nodes (147): CortexClientFn, Layer attribution evals (spec §11.2) — structural replay with mocked inputs., High surprise appraisal blocks quick lane; low surprise allows deterministic 5b., Misaligned reflection must change voice finalize output vs aligned., test_5a_affects_5b_verdict(), test_5b_affects_5c_text(), A 'How are you?' unified turn carries Orion self-context into both passes., test_how_are_you_turn_is_grounded_end_to_end() (+139 more)
+Cohesion: 0.11
+Nodes (126): GoalActionError, GoalActionResult, Exception, CognitiveProposalDraftV1, CognitiveProposalReviewV1, CognitiveStanceNoteV1, MutationPressureEvidenceV1, MutationSignalV1 (+118 more)
 
 ### Community 17 - "Autonomy Subject Fanout"
 Cohesion: 0.03
-Nodes (143): BroadcastReader, Dependency-free stable identifiers (hashlib only).  Use from thin services (orio, Return ``{prefix}_{sha256(preimage)[:24]}`` from ordered semantic parts., stable_hash_id(), Eval: reverie semantic lift quality bar — referent, voice, grounding., test_bad_meta_fixture_fails_infra_vocab(), test_good_fixture_passes_semantic_gates(), _database_url() (+135 more)
+Nodes (57): Any, Session, Minimal SPARQL Protocol HTTP clients (Fuseki + generic SPARQL endpoints)., Host + path + query + fragment only (strips userinfo from URL)., Resolve Basic Auth for substrate SPARQL HTTP (query + update).      Precedence (, SPARQL 1.1 Protocol over HTTP: separate query and update endpoints, optional Bas, redact_http_url_for_log(), resolve_substrate_sparql_http_basic_auth() (+49 more)
 
 ### Community 18 - "Chat Role Schemas"
-Cohesion: 0.04
-Nodes (117): build_consolidation_frame(), datetime, _attention_target_pressure(), _detect_attention_saturated_execution(), _detect_blocked_review_loop(), _detect_dry_run_feedback_loop(), _detect_loaded_but_reliable(), _detect_read_only_policy_loop() (+109 more)
+Cohesion: 0.03
+Nodes (111): Call, heuristic_answer_contract(), test_heuristic_runtime_debug(), context_exec_permissions_for_llm_profile(), ContextExecRequestV1, Map Hub compute lane / LLM profile to a context-exec permission envelope., test_context_exec_permissions_for_llm_profile_agent_read_repo(), test_context_exec_request_accepts_investigation_v2_mode() (+103 more)
 
 ### Community 19 - "Graph SPARQL Client"
-Cohesion: 0.03
-Nodes (127): new_goal_task_id(), build_verb_list(), _discover_verbs(), is_active(), list_all_verbs(), _load_manifest(), Any, AutonomyGoalPlannedV1 (+119 more)
+Cohesion: 0.04
+Nodes (104): NotificationReceiptDB, Path, UUID, EmailTransport, _split_mime(), AgentTraceSummaryV1, ChatAttentionRequest, ChatAttentionState (+96 more)
 
 ### Community 20 - "Language/Grammar Schemas"
 Cohesion: 0.04
-Nodes (123): AcceptedPublisher, AvailabilityStatus, EmissionSaver, NodeBioLoader, NodeBioSaver, NodeCatalog, NodeProfile, Any (+115 more)
+Nodes (123): build_consolidation_frame(), datetime, build_expectations_from_motifs(), _attention_target_pressure(), _detect_attention_saturated_execution(), _detect_blocked_review_loop(), _detect_dry_run_feedback_loop(), _detect_loaded_but_reliable() (+115 more)
 
 ### Community 21 - "Autonomy Capability Policy"
 Cohesion: 0.03
-Nodes (51): publish_with_reconnect(), Any, Publish once; on transport failure reconnect the command client and retry., _FlakyBus, MonkeyPatch, orion.core.bus.resilience must not crash-on-import when loguru is missing., test_publish_with_reconnect_retries_after_transport_error(), test_resilience_importable_without_loguru() (+43 more)
+Nodes (130): AutonomyGraphReadPlan, log_autonomy_graph_backend_decision(), build_autonomy_repository(), RepositoryBackendKind, strip_graph_credentials(), ChatStanceBrief, BaseModel, Bounded internal stance brief used by chat_general speech pass. (+122 more)
 
 ### Community 22 - "Biometrics Publisher/Loader"
-Cohesion: 0.06
-Nodes (100): FrontierInvocationDecisionV1, FrontierInvocationPlanV1, FrontierInvocationRunResultV1, FrontierInvocationSignalV1, BaseModel, Curiosity/gap-driven frontier invocation contracts (Phase 8)., GraphConsolidationRequestV1, build_metacog_perception_brief() (+92 more)
+Cohesion: 0.04
+Nodes (118): AcceptedPublisher, AvailabilityStatus, EmissionSaver, NodeBioLoader, NodeBioSaver, NodeCatalog, NodeProfile, Any (+110 more)
 
 ### Community 23 - "Autonomy Goal-Action Errors"
 Cohesion: 0.04
-Nodes (86): VisionFramePointerPayload, VisionTaskRequestPayload, VisionTaskResultPayload, test_llm_chat_route_forwards_messages_and_stop(), FrameDispatcher, Settings, extract_host_trigger_labels(), stream_id_from_host_result() (+78 more)
+Nodes (101): DecisionLiteral, CortexRouteTemplateV1, build_policy_decision_frame(), build_unevaluable_policy_decision_frame(), datetime, A proposal whose source self-state could not be loaded (missing, or a     row sa, stable_policy_frame_id(), evaluate_proposal_candidate() (+93 more)
 
 ### Community 24 - "Daily Metacog Prompt Tests"
-Cohesion: 0.03
-Nodes (129): AttentionTargetSummaryV1, BaseModel, Structured per-target attention data (2026-07-12, inner-state     unification Ph, SelfStateDimensionV1, BaseModel, Spark telemetry row that maps to spark_telemetry table.      Note: The durable t, SparkTelemetryPayload, ndarray (+121 more)
+Cohesion: 0.04
+Nodes (131): ChatResponsePayload, Load opt-in render/prompt flags from recall profile YAML., recall_profile_prompt_flags(), _bounded_memory_digest(), _load_daily_metacog_template(), test_daily_metacog_prompt_rejects_oversize_without_truncation(), test_daily_metacog_rendered_prompt_stays_bounded(), LLMGatewayClient (+123 more)
 
 ### Community 25 - "Notify Client"
-Cohesion: 0.05
-Nodes (132): BaseModel, SelfConceptEvidenceRefV1, SelfConceptInduceResultV1, SelfConceptReflectResultV1, SelfConceptRefV1, SelfInducedConceptV1, SelfKnowledgeItemV1, SelfKnowledgeSectionCountsV1 (+124 more)
+Cohesion: 0.03
+Nodes (111): Contract smoke tests for dream modernization schemas., test_dream_internal_trigger_v1(), test_dream_result_v1_defaults_and_audit(), test_dream_trigger_payload_minimal(), Normalized recall response. Exec exposes debug counts, not raw fragments, by def, RecallResultPayload, Per-fetch-path vector gating outcome (see ``source_policy.recall_vector_allowed`, Path-keyed vector policy diagnostics attached under ``recall_debug.vector_policy (+103 more)
 
 ### Community 26 - "Grounding/Investigation Findings"
-Cohesion: 0.06
-Nodes (77): GraphConsolidationDecisionV1, GraphConsolidationResultV1, GraphReviewCycleRecordV1, GraphStateDeltaDigestV1, BaseModel, Bounded reflective graph consolidation contracts (Phase 9)., GraphReviewCycleBudgetV1, GraphReviewCyclePolicyV1 (+69 more)
+Cohesion: 0.02
+Nodes (100): Deterministic unit tests for the pure layer of measure_autonomy_gate.  No DB, no, _self_state(), test_bucket_boundary_timestamp(), test_percentile_and_median(), test_resolve_window_days_flag_explicit(), test_resolve_window_defaults_to_days_when_neither_flag_given(), test_resolve_window_hours_flag(), test_retention_caveat_fires_when_source_retention_is_shorter() (+92 more)
 
 ### Community 27 - "Journaler Write Schemas"
 Cohesion: 0.04
-Nodes (88): JournalMode, JournalDispatchPolicy, Declarative journal notification dispatch policy, keyed off `trigger_kind`.  Con, Fail-closed lookup: an unregistered trigger_kind sends nothing., resolve_policy(), _as_optional_str(), build_journal_entry_index_payload(), _list_of_str() (+80 more)
+Nodes (86): VisionFramePointerPayload, VisionObject, VisionTaskRequestPayload, VisionTaskResultPayload, test_rpc_request_with_retry_raises_after_last_timeout(), FrameDispatcher, Settings, extract_host_trigger_labels() (+78 more)
 
 ### Community 28 - "Autonomy Origination Eval"
-Cohesion: 0.02
-Nodes (92): API_BASE_URL, appendExecutionStepsPanel(), appendSocialInspectionStateList(), applyMindPrefsToControls(), applyPreferenceRows(), audioContext, audioQueue, autonomyAvailabilityRowsForDisplay() (+84 more)
+Cohesion: 0.03
+Nodes (45): ExecutionDispatchRuntimeStore, FieldDigesterStore, datetime, Atomically persist field state, applied deltas, and receipt cursor., CompressionStore, Any, datetime, _make_store() (+37 more)
 
 ### Community 29 - "Cognition Projection Concept Tests"
-Cohesion: 0.04
-Nodes (103): __getattr__(), HubAssociationBundleV1, BaseModel, StanceHarnessSliceV1, StanceReactRequestV1, align_evidence_refs_to_coalition(), coalition_ids_from_association(), attended_node_ids + open_loop ids + always the current Hub turn anchor. (+95 more)
+Cohesion: 0.07
+Nodes (96): BaseSubstrateNodeV1, FrontierInvocationDecisionV1, FrontierInvocationPlanV1, FrontierInvocationRunResultV1, BaseModel, Curiosity/gap-driven frontier invocation contracts (Phase 8)., build_metacog_perception_brief(), MetacogPerceptionBriefV1 (+88 more)
 
 ### Community 30 - "Reverie Broadcast Reader"
-Cohesion: 0.03
-Nodes (69): execution_prediction_error(), _mean(), 0-1 surprise score: how much did execution pressure hints change this batch?, 0-1 surprise score: how much did transport bus health change this batch?, transport_prediction_error(), ReducerHealthClass, clear_health_for_tests(), _get() (+61 more)
+Cohesion: 0.04
+Nodes (80): BiometricsContext, BaseModel, RPC request payload for the state read-model service., RPC reply payload from the state read-model service., StateGetLatestRequest, StateLatestReply, BiometricsClusterV1, BiometricsInductionMetricV1 (+72 more)
 
 ### Community 31 - "Cognition Reflect/Recall Integration Tests"
 Cohesion: 0.04
-Nodes (95): deque, emit_contradiction(), emit_pressure(), Any, Thin substrate-emit helpers for the autonomy/pressure organ.  These do not modif, A pressure molecule is a constraint+gradient pair.      ``magnitude`` is folded, Emit a contradiction molecule that points at two other molecule ids., MonkeyPatch (+87 more)
+Nodes (102): EpisodeSummaryV1, BaseModel, Episodic continuity contracts (self-modeling loop, rung 4).  An episode is a pro, test_projection_update_roundtrip(), test_reduction_receipt_requires_schema_version(), test_state_delta_roundtrip(), ProjectionUpdateV1, BaseModel (+94 more)
 
 ### Community 32 - "Autonomy Deviation Gate"
-Cohesion: 0.03
-Nodes (84): _rpc_request(), _service_ref(), build_turn_change_appraisal(), MemoryTurnPersistedV1, should_close_window(), _build_window_transcript(), _classify_scores(), classify_turn() (+76 more)
+Cohesion: 0.05
+Nodes (116): CortexClientFn, Layer attribution evals (spec §11.2) — structural replay with mocked inputs., High surprise appraisal blocks quick lane; low surprise allows deterministic 5b., Misaligned reflection must change voice finalize output vs aligned., Turn N closure with surprise_unresolved exposes reducer-facing strain signal., test_5a_affects_5b_verdict(), test_5b_affects_5c_text(), test_turn_n_error_shifts_turn_n_plus_one_strain() (+108 more)
 
 ### Community 33 - "Vision Frame Pointer Schemas"
-Cohesion: 0.03
-Nodes (97): build_compact_skill_catalog(), _default_verbs_dir(), _family_for_skill(), load_skill_manifest(), BaseModel, Path, _risk_for_skill(), SkillManifestEntry (+89 more)
+Cohesion: 0.05
+Nodes (58): callable, BaseModel, SocialOpenThreadV1, SocialTurnPolicyDecisionV1, CallSyneRoomMessageV1, ExternalRoomMessageV1, ExternalRoomParticipantV1, ExternalRoomPostResultV1 (+50 more)
 
 ### Community 34 - "Agent Council Bound-Capability Schemas"
 Cohesion: 0.04
-Nodes (93): Contract smoke tests for dream modernization schemas., test_dream_internal_trigger_v1(), test_dream_result_v1_defaults_and_audit(), test_dream_trigger_payload_minimal(), Canonical recall boundary. The only acceptable request field for text is `query_, Normalized recall response. Exec exposes debug counts, not raw fragments, by def, RecallRequestPayload, RecallResultPayload (+85 more)
+Nodes (103): Finding, AnswerContractDraft, AnswerGroundingStatus, Finding, FindingsBundle, InvestigationState, BaseModel, User-visible grounding summary (§9.2). (+95 more)
 
 ### Community 35 - "Attention Frame Schemas"
 Cohesion: 0.04
-Nodes (95): GraphStoreClient, SparqlUpdateClient, approve_memory_graph_draft(), ApproveOutcome, preview_validate_only(), Any, Pool, Session (+87 more)
+Nodes (113): build_cognitive_projection_for_context(), build_cognitive_projection_for_mind_with_diagnostics(), build_projection_unification_registry(), _env_float(), get_projection_unification_layer(), _publish_tier_outcomes_if_needed(), Any, Shared CognitiveUnificationLayer → CognitiveProjection builder.  Phase-3 seam: m (+105 more)
 
 ### Community 36 - "Substrate Experiment Gradient Observer"
-Cohesion: 0.04
-Nodes (78): GradientObserver, compute_daily_rollup(), _contradiction_clusters(), _gradient_stats(), _health_score(), date, Path, Per-day rollup computation + JSON persistence. (+70 more)
+Cohesion: 0.02
+Nodes (90): API_BASE_URL, appendSocialInspectionStateList(), applyMindPrefsToControls(), applyPreferenceRows(), audioContext, audioQueue, autonomyAvailabilityRowsForDisplay(), buildChatStanceSection() (+82 more)
 
 ### Community 37 - "Cognition Verb Activation"
-Cohesion: 0.05
-Nodes (87): _LLMCaller, build_orion_turn_request(), Any, Thin Orion-mode turn dict — not the Brain chat request builder., PreTurnAppraisalRequestV1, BaseModel, TurnAppraisalBundleV1, TurnAppraisalParadigmSliceV1 (+79 more)
+Cohesion: 0.07
+Nodes (101): A 'How are you?' unified turn carries Orion self-context into both passes., test_how_are_you_turn_is_grounded_end_to_end(), build_finalize_reflect_context(), harness_motor_instruction(), is_relational_motor_stance(), Deterministic FCC operator briefs for harness motor turns., _stance_slice(), compile_harness_prefix() (+93 more)
 
 ### Community 38 - "Telemetry Field-Channel Corpus"
-Cohesion: 0.05
-Nodes (76): AnchorScope, ArtifactType, apply_operator_goal_reasoning_promotion(), _goal_to_reasoning_claim(), ClaimV1, datetime, ConceptProfileDelta, Delta between two concept profile revisions. (+68 more)
+Cohesion: 0.03
+Nodes (85): _rpc_request(), _service_ref(), build_turn_change_appraisal(), MemoryConsolidationWindowV1, MemoryGraphSuggestDraftRecordV1, MemoryTurnPersistedV1, BaseModel, _build_window_transcript() (+77 more)
 
 ### Community 39 - "Hub Static JS Frontend App"
 Cohesion: 0.04
-Nodes (67): AutonomyLookupV1, AutonomyRepository, AutonomyRepositoryStatus, _bounded_reason(), _classify_query_error(), _dominant_drive_from_evidence(), _drives_facet_ok(), _drives_facet_status() (+59 more)
+Nodes (93): ConceptCluster, ConceptItem, ConceptProfile, ConceptProfileDelta, make_concept_id(), BaseModel, datetime, Canonical schemas for Concept Induction artifacts. (+85 more)
 
 ### Community 40 - "Story/Narrative Weave"
-Cohesion: 0.05
-Nodes (81): callable, build_answer_contract_draft_for_hub(), Light hub-side draft (metadata only)., ExternalRoomMessageV1, ExternalRoomParticipantV1, ExternalRoomPostRequestV1, ExternalRoomPostResultV1, ExternalRoomTurnSkippedV1 (+73 more)
+Cohesion: 0.04
+Nodes (70): AutonomyLookupV1, AutonomyRepository, AutonomyRepositoryStatus, _bounded_reason(), _classify_query_error(), _dominant_drive_from_evidence(), _drives_facet_ok(), _drives_facet_status() (+62 more)
 
 ### Community 41 - "Bus Schema Rationale Notes"
 Cohesion: 0.04
-Nodes (99): ContextRisk, auto_approve_from_env(), claude_permission_argv(), extend_mcp_argv(), mcp_allowed_tool_patterns(), mcp_disallowed_tool_patterns(), Any, Path (+91 more)
+Nodes (79): GradientObserver, compute_daily_rollup(), _contradiction_clusters(), _gradient_stats(), _health_score(), date, Path, Per-day rollup computation + JSON persistence. (+71 more)
 
 ### Community 42 - "Cognition Recall Query"
-Cohesion: 0.05
-Nodes (68): _build_ollama_payload(), _common_http_client(), _debug_len(), _debug_snippet(), _debug_think_capture(), _execute_llamacpp_native_completion(), _execute_ollama_chat(), _execute_openai_chat() (+60 more)
+Cohesion: 0.04
+Nodes (97): _embed_bus(), _embed_http(), ChatHistoryMessageEnvelope, ChatHistoryMessageV1, ChatHistoryTurnEnvelope, ChatHistoryTurnV1, Any, BaseModel (+89 more)
 
 ### Community 43 - "Consolidation Builder"
-Cohesion: 0.05
-Nodes (83): AutonomyStanceMode, AutonomyStateQuality, AttentionItemV1, AutonomyActiveGoalV1, AutonomyGoalHeadlineV1, AutonomyStateV1, AutonomyStateV2, AutonomySummaryV1 (+75 more)
+Cohesion: 0.03
+Nodes (73): _agent_request(), _ctx_app_modules(), _dead_readiness(), _live_readiness(), _load_app(), MonkeyPatch, Hardening tests: /health bus readiness and LLM gateway synthesis preflight., B: dead LLM gateway consumer skips synthesis RPC; deterministic report preserved (+65 more)
 
 ### Community 44 - "Field Coherence"
 Cohesion: 0.04
-Nodes (87): _embed_bus(), ChatHistoryMessageEnvelope, ChatHistoryMessageV1, ChatHistoryTurnEnvelope, ChatHistoryTurnV1, Any, BaseModel, UUID (+79 more)
+Nodes (100): BroadcastReader, default_referent_loader(), coalition_audit_refs(), _collect_coalition_refs(), Coalition ids the LLM may cite in evidence_refs (audit-only, not for narration)., AttentionBroadcastProjectionV1, Current substrate-wide attention (rung 3): the selected coalition of the     lat, CompactionRequestV1 (+92 more)
 
 ### Community 45 - "Context-Exec V2 Readiness Hardening Tests"
-Cohesion: 0.06
-Nodes (33): BaseSettings, Language, ConceptEvidenceRef, make_concept_id(), Deterministic-ish concept id helper.      Uses a simple stable hash of the norma, Lineage reference for evidence used in concept formation., ClusterResult, ConceptClusterer (+25 more)
+Cohesion: 0.03
+Nodes (70): InMemorySpanExporter, EquilibriumAdapter, normalize_adapter_result(), AdapterResult, test_normalize_list(), test_normalize_single_signal(), Causal parent miss notes (spec §7.B)., _sig() (+62 more)
 
 ### Community 46 - "Bus Schema Rationale Notes (2)"
-Cohesion: 0.05
-Nodes (74): build_active_packet(), _entry(), Any, datetime, _task_boost(), attach_grammar_to_crystallization(), envelope_from_grammar_event(), Any (+66 more)
+Cohesion: 0.04
+Nodes (93): CoreEventV1, AttentionTargetSummaryV1, BaseModel, Structured per-target attention data (2026-07-12, inner-state     unification Ph, SelfStateDimensionV1, BaseModel, Spark telemetry row that maps to spark_telemetry table.      Note: The durable t, SparkTelemetryPayload (+85 more)
 
 ### Community 47 - "LLM/OpenAI Message Content"
 Cohesion: 0.05
-Nodes (78): _tool_stats(), ContextExecOperatorSummaryV1, ContextExecRunV1, ContextExecSafetySummaryV1, Operator-facing summary for Hub Agent mode responses., AgentTraceStepV1, AgentTraceToolStatV1, AgentSynthesisResult (+70 more)
+Nodes (96): HubAssociationBundleV1, StanceReactRequestV1, align_evidence_refs_to_coalition(), coalition_ids_from_association(), attended_node_ids + open_loop ids + always the current Hub turn anchor., Snap LLM evidence_refs to coalition-backed ids; default to hub turn anchor., extract_first_json_object_text(), Lightweight JSON object extraction for stance_react (no memory_graph / rdflib de (+88 more)
 
 ### Community 48 - "Repair Evidence Schemas"
 Cohesion: 0.06
-Nodes (95): InvestigationV2AnswerStatus, BusConsumerReadinessResult, BaseModel, EvidenceBundle, InvestigationReportV2, InvestigationSectionV2, Enum, str (+87 more)
+Nodes (86): join_openai_message_content(), Any, Normalize OpenAI-compatible message.content (str or part list) to plain text., VisionEventCandidateV1, VisionSceneInterpretationV1, VisionWindowPayload, _activity_claim_has_caption_slop(), build_person_presence_fallback() (+78 more)
 
 ### Community 49 - "Bus Base Envelope"
-Cohesion: 0.03
-Nodes (40): _count(), main(), ExecutionDispatchRuntimeStore, FieldDigesterStore, CompressionStore, Any, datetime, _make_store() (+32 more)
+Cohesion: 0.04
+Nodes (52): Image, build_artifact_payload(), merge_result_inputs(), Any, Combine task request + meta into the artifact provenance inputs dict.      On ke, Build VisionArtifactPayload from a successful VisionResult, or None if no artifa, GpuInfo, GpuInspector (+44 more)
 
 ### Community 50 - "Grammar Ledger (Atom/Event Storage)"
-Cohesion: 0.05
-Nodes (78): AttentionTargetSummaryV1, FieldAttentionFrameV1, FieldStateV1, _build_candidate(), build_proposal_frame(), _policy_required(), datetime, SelfStateV1 (+70 more)
+Cohesion: 0.04
+Nodes (78): emit_contradiction(), emit_pressure(), Any, Thin substrate-emit helpers for the autonomy/pressure organ.  These do not modif, A pressure molecule is a constraint+gradient pair.      ``magnitude`` is folded, Emit a contradiction molecule that points at two other molecule ids., build_turn_change_signal(), ConceptAtomV1 (+70 more)
 
 ### Community 51 - "Proposal Ledger"
-Cohesion: 0.05
-Nodes (76): assert_chat_compactor_digest_within_budget(), build_quiet_day_chat_digest(), parse_chat_history_compactor_digest_json(), Any, stable_chat_compactor_journal_entry_id(), trim_chat_history_compactor_input(), test_assert_chat_compactor_digest_within_budget(), test_build_quiet_day_chat_digest() (+68 more)
+Cohesion: 0.04
+Nodes (103): summarize_turn_effect(), turn_effect_from_appraisal(), turn_effect_from_spark_meta(), build_introspection_context(), Any, main(), test_introspection_parity_for_primary_workflow_metadata(), Deprecated module.  Spark Introspector v2 moved to `worker.py` + V2 chassis. Thi (+95 more)
 
 ### Community 52 - "Concept Induction Core Schemas"
-Cohesion: 0.04
-Nodes (71): CausalityLink, Envelope, Any, Create a child envelope that extends the causality chain with this message as a, Typed envelope: payload is a Pydantic model.      This is the preferred new path, Vacuum Validator:         1. Ensures 'content' is populated from 'text'., A single step in a causality chain. Used for Conjourney lineage., Rabbit (+63 more)
+Cohesion: 0.06
+Nodes (70): AnchorScope, ArtifactType, MentorConstraintsV1, MentorContextSliceV1, MentorGatewayResultV1, MentorProposalItemV1, MentorRequestV1, MentorResponseV1 (+62 more)
 
 ### Community 53 - "Image Assets"
-Cohesion: 0.04
-Nodes (89): Call, heuristic_answer_contract(), investigation_state_for_contract(), Any, test_heuristic_runtime_debug(), context_exec_permissions_for_llm_profile(), Map Hub compute lane / LLM profile to a context-exec permission envelope., _call_name() (+81 more)
+Cohesion: 0.05
+Nodes (93): ConceptProfileBackendKind, CutoverFallbackPolicyKind, parse_compactor_digest_json(), Parse an LLM digest JSON payload into the given compactor digest model.      Sha, assert_digest_within_budget(), build_quiet_day_digest(), parse_github_compactor_digest_json(), Bound digest LLM input size while preserving total merge count metadata. (+85 more)
 
 ### Community 54 - "Social Autonomy Schemas"
-Cohesion: 0.06
-Nodes (66): derive_workflow_execution_policy(), _has_explicit_schedule_intent(), _hour_from_token(), next_run_for_recurring_schedule(), _next_weekday_run(), _normalize_prompt(), _one_shot_tonight(), _parse_notify_on() (+58 more)
+Cohesion: 0.05
+Nodes (83): _LLMCaller, build_orion_turn_request(), Any, Thin Orion-mode turn dict — not the Brain chat request builder., PreTurnAppraisalOptionsV1, PreTurnAppraisalRequestV1, BaseModel, TurnAppraisalBundleV1 (+75 more)
 
 ### Community 55 - "Telemetry Spark Signal"
-Cohesion: 0.06
-Nodes (49): FrontierTargetZoneV1, BaseModel, Operator-controlled substrate policy profile adoption contracts (Phase 17)., SubstratePolicyAdoptionRequestV1, SubstratePolicyAdoptionResultV1, SubstratePolicyAuditEventV1, SubstratePolicyComparisonV1, SubstratePolicyInspectionV1 (+41 more)
+Cohesion: 0.04
+Nodes (43): CognitiveDraftRecommendationV1, MutationQueueItemV1, MutationRollbackV1, Any, datetime, SubstrateMutationStore, _utc_now(), test_recall_shadow_profile_activation_keeps_single_active_profile() (+35 more)
 
 ### Community 56 - "Autonomy Repository"
 Cohesion: 0.05
-Nodes (79): apply_grammar_event(), apply_grammar_trace_batch(), _atom_row(), _bulk_insert_derived(), _bulk_insert_events(), _compaction_row(), _created_at(), _edge_row() (+71 more)
+Nodes (38): BaseSettings, Language, ConceptEvidenceRef, Lineage reference for evidence used in concept formation., ClusterResult, ConceptClusterer, _cosine(), _jaccard() (+30 more)
 
 ### Community 57 - "Cognition Hub-Gateway Bus Harness"
 Cohesion: 0.05
-Nodes (70): build_turn_change_signal(), ConceptAtomV1, BaseModel, Atoms — reusable semantic invariants.  An atom is *not* a domain noun (memory, d, A reusable semantic invariant.      `key` is the unique handle (e.g. "signal.val, CompositeV1, BaseModel, Composite — a small bundle of atoms + relations.  This is the *kernel-level* com (+62 more)
+Nodes (62): fetch_similar_candidates(), Pool, Vector-similarity candidate retrieval across ALL active crystallizations, not sc, publish_crystallization_to_chroma(), Build upsert, optionally embed, publish to vector bus. Returns updated crystalli, approve(), can_activate(), GovernorError (+54 more)
 
 ### Community 58 - "Bus Span Exporter (Tracing)"
-Cohesion: 0.06
-Nodes (90): format_recent_turn_effect_alerts(), _alert_tags_from_recent_alerts(), _append_memory_digest(), _apply_draft_patch(), _apply_enrich_patch(), _apply_metacog_system_fields(), _build_hop_messages(), call_step_services() (+82 more)
+Cohesion: 0.05
+Nodes (88): InsertOutcome, build_compact_skill_catalog(), _default_verbs_dir(), _family_for_skill(), load_skill_manifest(), BaseModel, Path, _risk_for_skill() (+80 more)
 
 ### Community 59 - "LLM Gateway Backend"
-Cohesion: 0.07
-Nodes (77): ExecutionProjectionLoader, ExecutionProjectionSaver, ExecutionRunStateV1, ExecutionTrajectoryProjectionV1, BaseModel, GrammarProvenanceV1, _boolish(), compute_pressure_hints() (+69 more)
+Cohesion: 0.06
+Nodes (84): ExecutionProjectionLoader, ExecutionProjectionSaver, ExecutionRunStateV1, ExecutionTrajectoryProjectionV1, BaseModel, GrammarProvenanceV1, _boolish(), compute_pressure_hints() (+76 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.04
-Nodes (90): Channel "orion:chat:gpt:conversation" (kind=event, schema=ChatGptConversationV1) producers=[chatgpt-import] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:example" (kind=event, schema=ChatGptDerivedExampleV1) producers=[chatgpt-import] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:import:run" (kind=event, schema=ChatGptImportRunV1) producers=[chatgpt-import] consumers=[orion-sql-writer], Channel "orion:chat:gpt:log" (kind=event, schema=ChatGptMessageV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:message:log" (kind=event, schema=ChatGptMessageV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:turn" (kind=event, schema=ChatGptLogTurnV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:history:log" (kind=event, schema=ChatHistoryMessageV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-writer, orion-vector-host, orion-spark-concept-induction], Channel "orion:chat:history:turn" (kind=event, schema=ChatHistoryTurnV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-writer, orion-vector-host, orion-spark-concept-induction] (+82 more)
+Cohesion: 0.05
+Nodes (85): Shared contracts for bus message payloads., MemoryCardCreateV1, MemoryCardEdgeCreateV1, MemoryCardEdgeV1, MemoryCardHistoryEntryV1, MemoryCardPatchV1, MemoryCardStatusChangeV1, MemoryCardV1 (+77 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.05
-Nodes (85): _forward_llm_uncertainty_metadata(), prepare_chat_quick_reply_context(), Copy gateway meta.llm_uncertainty into execution ctx metadata for Hub spark_meta, Hub quick lane: identity YAML only — no stance/autonomy graph (must stay fast; G, short_error_kind(), extract_reasoning_features(), Any, has_inline_recall() (+77 more)
+Cohesion: 0.04
+Nodes (94): _count(), main(), prepare_brain_reply_context(), prepare_chat_quick_reply_context(), Hub quick lane: identity YAML only — no stance/autonomy graph (must stay fast; G, Canonical preparation hook for brain-lane reply context.     Ensures identity an, record_assembled_grammar(), short_error_kind() (+86 more)
 
 ### Community 62 - "Community 62"
-Cohesion: 0.06
-Nodes (75): InsertOutcome, BaseModel, Typed self-experiment registry schemas., Accept legacy skill_id payloads or typed experiment fields., SelfExperimentCreateRequestV1, SelfExperimentCreateResponseV1, SelfExperimentDispatchRequestV1, SelfExperimentDispatchResponseV1 (+67 more)
+Cohesion: 0.04
+Nodes (86): Narrator, CompactionMetricsV1, ConsolidateEntryV1, DownscaleEntryV1, MemoryCompactionDeltaV1, PruneEntryV1, BaseModel, datetime (+78 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.07
-Nodes (73): DecisionLiteral, CortexRouteTemplateV1, build_policy_decision_frame(), build_unevaluable_policy_decision_frame(), datetime, A proposal whose source self-state could not be loaded (missing, or a     row sa, stable_policy_frame_id(), evaluate_proposal_candidate() (+65 more)
+Cohesion: 0.05
+Nodes (87): GrammarWorkItem, list_attention(), list_chat_messages(), mark_attention_escalated(), build_engine_connect_args(), dispose_grammar_pool(), get_grammar_session(), get_session() (+79 more)
 
 ### Community 64 - "Community 64"
-Cohesion: 0.04
-Nodes (52): InMemorySpanExporter, normalize_adapter_result(), AdapterResult, test_normalize_list(), test_normalize_single_signal(), OrganClass, Enum, str (+44 more)
+Cohesion: 0.06
+Nodes (92): InvestigationV2AnswerStatus, BusConsumerReadinessResult, BaseModel, EvidenceBundle, InvestigationReportV2, InvestigationSectionV2, Enum, str (+84 more)
 
 ### Community 65 - "Community 65"
-Cohesion: 0.06
-Nodes (50): fetch_similar_candidates(), Pool, Vector-similarity candidate retrieval across ALL active crystallizations, not sc, approve(), can_activate(), GovernorError, datetime, ValueError (+42 more)
+Cohesion: 0.05
+Nodes (83): MonkeyPatch, test_ingress_observation_emitted(), emit_claim(), emit_observation(), Any, Thin substrate-emit helpers for the mind/chat organ.  This module deliberately d, Build an ``observation`` molecule from a chat turn.      The molecule binds two, Build a ``claim`` molecule. Supports/contradicts are other molecule ids. (+75 more)
 
 ### Community 66 - "Community 66"
-Cohesion: 0.07
-Nodes (74): _perception_in_convo(), Observability seam: a healthy loop (all other logs exception-only) must still, The 'void' regression, corrected: the worker must NOT send `finishSendingMessage, test_empty_reply_is_not_injected(), test_heartbeat_logs_once_then_throttles(), test_injectable_reply_is_injected(), test_no_speech_until_participating(), test_no_speech_when_orion_spoke_last() (+66 more)
+Cohesion: 0.05
+Nodes (60): IntentKind, IntentSource, ArbiterDecision, ArbiterState, decide(), datetime, Pure arbitration. Mutates only ``state.deliberate_hold_until`` on accept., build_intent() (+52 more)
 
 ### Community 67 - "Community 67"
-Cohesion: 0.06
-Nodes (76): GrammarWorkItem, list_attention(), list_chat_messages(), mark_attention_escalated(), get_session(), remove_session(), cancel_active_grammar_persist(), Cancel the in-flight Postgres query for the active grammar persist on a shard. (+68 more)
+Cohesion: 0.05
+Nodes (78): apply_grammar_event(), _atom_row(), _bulk_insert_derived(), _bulk_insert_events(), _compaction_row(), _created_at(), _edge_row(), _event_row() (+70 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.06
-Nodes (73): _aggregate_outcome_status(), build_feedback_frame(), _candidate_outcome_kind(), _cortex_status_to_outcome(), _observation(), _policy_decision_outcome(), datetime, _score_for_outcome_kind() (+65 more)
+Cohesion: 0.04
+Nodes (69): Versioned heartbeat contract for Titanium bus., SystemHealthV1, get_artifact(), health(), heartbeat_loop(), lifespan(), list_regions(), Any (+61 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.06
-Nodes (75): BaseModel, datetime, Repair pressure evidence schema (bus/registry layer).  Lives under orion.schemas, RepairEvidenceV1, _utcnow(), apply_repair_pressure_contract(), assemble_repair_contract_delta(), _evidence_kinds_from_dimensions() (+67 more)
+Cohesion: 0.04
+Nodes (61): VisionEdgeArtifact, VisionGuardAlert, VisionGuardSignal, bus_worker(), _handle_envelope(), Subscribe to vision artifacts., _source(), AppContext (+53 more)
 
 ### Community 70 - "Community 70"
 Cohesion: 0.04
-Nodes (71): Depends, require_operator_token, require_quarantine_operator_token, clear_tail_seeds_for_tests(), has_cold_start_tail_seed(), has_recent_tail_seed(), Track substrate cursor tail-seeds that skip unreduced history., tail_seed_snapshot() (+63 more)
+Nodes (93): Channel "orion:chat:gpt:conversation" (kind=event, schema=ChatGptConversationV1) producers=[chatgpt-import] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:example" (kind=event, schema=ChatGptDerivedExampleV1) producers=[chatgpt-import] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:import:run" (kind=event, schema=ChatGptImportRunV1) producers=[chatgpt-import] consumers=[orion-sql-writer], Channel "orion:chat:gpt:log" (kind=event, schema=ChatGptMessageV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:message:log" (kind=event, schema=ChatGptMessageV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:gpt:turn" (kind=event, schema=ChatGptLogTurnV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-host], Channel "orion:chat:history:log" (kind=event, schema=ChatHistoryMessageV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-writer, orion-vector-host, orion-spark-concept-induction], Channel "orion:chat:history:turn" (kind=event, schema=ChatHistoryTurnV1) producers=[orion-hub] consumers=[orion-sql-writer, orion-vector-writer, orion-vector-host, orion-spark-concept-induction] (+85 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.05
-Nodes (73): _broadcast_enabled(), _broadcast_is_stale(), build_hub_association_bundle(), _default_reader(), _parse_broadcast(), Any, Ensure the current Hub turn is always a coalition member for fail-closed evidenc, Orion capability: felt-state context for the stance turn.      Supplies Thought (+65 more)
+Cohesion: 0.07
+Nodes (56): ContradictionNodeV1, GraphConsolidationDecisionV1, GraphConsolidationRequestV1, GraphConsolidationResultV1, GraphReviewCycleRecordV1, GraphStateDeltaDigestV1, BaseModel, Bounded reflective graph consolidation contracts (Phase 9). (+48 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.07
-Nodes (27): BaseModel, SocialOpenThreadV1, SocialTurnPolicyDecisionV1, CallSyneRoomMessageV1, Thin transport contract for inbound CallSyne-style room traffic., BaseModel, SocialEpistemicDecisionV1, SocialEpistemicSignalV1 (+19 more)
+Cohesion: 0.08
+Nodes (75): CoverageStatus, ArticleClusterV1, ArticleRecordV1, ClaimRecordV1, DailyWorldPulseItemV1, EntityRecordV1, EventRecordV1, BaseModel (+67 more)
 
 ### Community 73 - "Community 73"
-Cohesion: 0.07
-Nodes (43): JournalRepository, chat_episodes_query(), chat_episodes_status(), journals_query(), journals_status(), rebuild_chat_episodes(), rebuild_journals(), BuildResponse (+35 more)
+Cohesion: 0.05
+Nodes (79): Deterministic Phase 0 gate: skip recall on low-info social turns., recall_skip_gate(), RecallSkipGateResult, _coerce_novelty(), derive_retrieval_intent(), _has_contradiction_seed(), _has_entity_query(), _has_planning_like_priority() (+71 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.07
-Nodes (78): FetchedArticleRefV1, SubstrateActResultV1, SubstrateEpisodeIntentV1, build_episode_narrative_seed(), build_readonly_fetch_query(), curiosity_strength_from_signals(), _execute_readonly_recall(), _gap_section_label() (+70 more)
+Cohesion: 0.05
+Nodes (72): assert_chat_compactor_digest_within_budget(), build_quiet_day_chat_digest(), parse_chat_history_compactor_digest_json(), Any, stable_chat_compactor_journal_entry_id(), trim_chat_history_compactor_input(), test_assert_chat_compactor_digest_within_budget(), test_build_quiet_day_chat_digest() (+64 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.07
-Nodes (51): test_atom_roundtrip(), test_grammar_event_requires_provenance(), test_invalid_atom_type_rejected(), build_harness_grammar_events(), build_harness_grammar_finalize_events(), compute_harness_reasoning_present(), compute_harness_thinking_source(), _event() (+43 more)
+Cohesion: 0.04
+Nodes (70): CausalityLink, Envelope, Any, Create a child envelope that extends the causality chain with this message as a, Typed envelope: payload is a Pydantic model.      This is the preferred new path, Vacuum Validator:         1. Ensures 'content' is populated from 'text'., A single step in a causality chain. Used for Conjourney lineage., CortexExecResultPayload (+62 more)
 
 ### Community 76 - "Community 76"
 Cohesion: 0.05
-Nodes (64): CompactionMetricsV1, ConsolidateEntryV1, DownscaleEntryV1, MemoryCompactionDeltaV1, PruneEntryV1, BaseModel, datetime, Memory-compaction delta — the dream's *proposed* housekeeping (Phase F).  A `Mem (+56 more)
+Nodes (67): BaseModel, VisionCouncilRequestPayload, VisionCouncilResultPayload, VisionEmbedding, VisionEventBundleItem, VisionEventPayload, VisionGrammarProjectionCandidateV1, VisionMemoryDeltaCandidateV1 (+59 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.06
-Nodes (75): MoodArcCorpusRowV1, MoodArcEncoderManifestV1, BaseModel, Mood-arc corpus row schema -- Item 1 of docs/superpowers/specs/2026-07-13-felt-s, One per-tick training-data row for the not-yet-built windowed felt-     state au, Item 2's windowed felt-state-trajectory encoder manifest -- dark     artifact, d, Adam, block_bootstrap_ratio_ci() (+67 more)
+Cohesion: 0.07
+Nodes (61): AttentionSignalV1, CuriosityCandidateActionV1, CuriositySuppressionV1, BaseModel, datetime, _utc_now(), _node_salience(), Any (+53 more)
 
 ### Community 78 - "Bus Channels: Chat/GPT Ingest Family"
-Cohesion: 0.06
-Nodes (62): HTMLParser, Any, SourceRegistryV1, SourceTrustAssessmentV1, WorldPulseAllowedUsesV1, WorldPulseSourceV1, fetch_rss_articles(), _parse_date() (+54 more)
+Cohesion: 0.05
+Nodes (58): decay_activation(), Half-life activation decay — stdlib only (safe for lightweight service imports)., Any, query_chroma_collection(), Query Chroma HTTP API for semantic hits (Postgres remains canonical)., _aware(), _clamp(), decay() (+50 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.06
-Nodes (71): Telemetry for recall decisions., RecallDecisionV1, RetrievalIntentV1, main(), intent_telemetry_payload(), Build recall.intent.v1 telemetry. ``query_hash16`` is SHA-256 of UTF-8 query tex, fetch_memory_graph_sparql_candidates(), Any (+63 more)
+Cohesion: 0.08
+Nodes (51): EndogenousWorkflowTypeV1, EndogenousHistoryEntryV1, EndogenousTriggerDebugV1, EndogenousTriggerDecisionV1, EndogenousTriggerRequestV1, EndogenousTriggerSignalV1, EndogenousWorkflowActionV1, EndogenousWorkflowExecutionResultV1 (+43 more)
 
 ### Community 80 - "Community 80"
 Cohesion: 0.08
-Nodes (72): ConceptProfileBackendKind, CutoverFallbackPolicyKind, coerce_journal_title(), stable_journal_entry_id_for_workflow_compose(), Any, Shared rules for workflow-owned journal persistence (orch vs exec)., When True, journal.entry.write.v1 is emitted from cortex-exec after journal.comp, workflow_journal_write_delegated_to_exec() (+64 more)
+Nodes (80): ActionOutcomeRefV1, CapabilityDecisionV1, FetchedArticleRefV1, SubstrateActResultV1, SubstrateEpisodeIntentV1, build_episode_narrative_seed(), build_readonly_fetch_query(), curiosity_strength_from_signals() (+72 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.09
-Nodes (65): main(), _parse_args(), Namespace, build_sft_dataset(), _chat_template(), _iter_jsonl(), _load_from_jsonl(), _load_from_postgres() (+57 more)
+Cohesion: 0.06
+Nodes (74): AutonomyStanceMode, AutonomyStateQuality, AttentionItemV1, AutonomyActiveGoalV1, AutonomyGoalHeadlineV1, AutonomyStateDeltaV1, AutonomyStateV1, AutonomyStateV2 (+66 more)
 
 ### Community 82 - "Community 82"
 Cohesion: 0.06
-Nodes (73): AutonomyGraphReadPlan, log_autonomy_graph_backend_decision(), build_autonomy_repository(), RepositoryBackendKind, strip_graph_credentials(), main(), run_probe(), build_chat_stance_debug_payload() (+65 more)
+Nodes (73): _aggregate_outcome_status(), build_feedback_frame(), _candidate_outcome_kind(), _cortex_status_to_outcome(), _observation(), _policy_decision_outcome(), datetime, _score_for_outcome_kind() (+65 more)
 
 ### Community 83 - "Community 83"
 Cohesion: 0.05
-Nodes (73): _abs_trajectory_for_row(), _as_utc(), bucket_class_for(), bucket_index(), BucketActivity, build_arg_parser(), build_bucket_activity(), build_drive_coactivation_histogram_sparql() (+65 more)
+Nodes (73): _broadcast_enabled(), _broadcast_is_stale(), build_hub_association_bundle(), _default_reader(), _parse_broadcast(), Any, Ensure the current Hub turn is always a coalition member for fail-closed evidenc, Orion capability: felt-state context for the stance turn.      Supplies Thought (+65 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.07
-Nodes (62): _clean(), extract_anchors(), _clean_block(), extract_blocks(), _extract_code_or_command(), _extract_logs(), _reasoning_summary(), _candidate_claims() (+54 more)
+Cohesion: 0.06
+Nodes (75): BaseModel, datetime, Repair pressure evidence schema (bus/registry layer).  Lives under orion.schemas, RepairEvidenceV1, _utcnow(), apply_repair_pressure_contract(), assemble_repair_contract_delta(), _evidence_kinds_from_dimensions() (+67 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.05
-Nodes (39): Image, Lock, is_caption_prompt_echo(), _normalize(), True when caption text is the VLM prompt echoed back, not scene description., test_is_caption_prompt_echo_matches_current_prompt(), test_is_caption_prompt_echo_matches_legacy_phrase(), test_is_caption_prompt_echo_rejects_blip_suffix_noise() (+31 more)
+Cohesion: 0.06
+Nodes (68): GraphStoreClient, SparqlUpdateClient, approve_memory_graph_draft(), ApproveOutcome, preview_validate_only(), Any, Pool, Session (+60 more)
 
 ### Community 86 - "Community 86"
 Cohesion: 0.06
-Nodes (61): api_service_logs_services(), build_compose_logs_command(), collect_service_inventory(), discover_loggable_services(), _docker_diagnostics(), Any, Path, Queue (+53 more)
+Nodes (78): MoodArcCorpusRowV1, MoodArcEncoderManifestV1, BaseModel, Mood-arc corpus row schema -- Item 1 of docs/superpowers/specs/2026-07-13-felt-s, One per-tick training-data row for the not-yet-built windowed felt-     state au, Item 2's windowed felt-state-trajectory encoder manifest -- dark     artifact, d, CorpusStatsV1, BaseModel (+70 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.14
-Nodes (55): SocialRoomBridgeService, _FailingCallSyneClient, _FailingHubClient, _FakeBus, _FakeCallSyneClient, _FakeHubClient, _FakeSocialMemoryClient, _payload() (+47 more)
+Cohesion: 0.07
+Nodes (43): JournalRepository, chat_episodes_query(), chat_episodes_status(), journals_query(), journals_status(), rebuild_chat_episodes(), rebuild_journals(), BuildResponse (+35 more)
 
 ### Community 88 - "Community 88"
-Cohesion: 0.08
-Nodes (62): InnerStateFeaturesV1, AttributionV1, CorpusStatsV1, PhiEncoderManifestV1, BaseModel, Phi encoder manifest + intrinsic reward schemas (Plan 2)., TrainingStatsV1, _apply_grads() (+54 more)
+Cohesion: 0.06
+Nodes (69): AttentionTargetSummaryV1, FieldAttentionFrameV1, FieldStateV1, _build_candidate(), build_proposal_frame(), _dominant_motivations(), _overall_action_pressure(), _overall_risk() (+61 more)
 
 ### Community 89 - "Community 89"
-Cohesion: 0.09
-Nodes (69): execute_chat_workflow(), DummyBus, _load_sql_writer_worker(), Load orion-sql-writer's worker under its own ``app`` package.      The worker im, Production path: digest arrives only as final_text JSON, no metadata dict., A transient DB error on card persist must not discard the digest., When orch skips bus publish, mirror exec-side journal write so tests still see o, _req() (+61 more)
+Cohesion: 0.06
+Nodes (66): build_answer_contract_draft_for_hub(), Light hub-side draft (metadata only)., BaseModel, SocialGifIntentV1, SocialGifInterpretationV1, SocialGifObservedSignalV1, SocialGifPolicyDecisionV1, SocialGifProxyContextV1 (+58 more)
 
 ### Community 90 - "Community 90"
 Cohesion: 0.06
-Nodes (66): CapabilitiesResponse, DatasetCreateRequest, DatasetCreateResponse, DatasetListResponse, DatasetPreviewDoc, DriftListResponse, DriftRecord, DriftRunRequest (+58 more)
+Nodes (51): test_atom_roundtrip(), test_grammar_event_requires_provenance(), test_invalid_atom_type_rejected(), GrammarAtomV1, cortex_exec_trace_id(), Build a cortex.exec trace id.      ``lane`` isolates auxiliary cortex-exec runs, build_bus_transport_grammar_events(), bus_transport_trace_id() (+43 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.07
-Nodes (54): EvidenceUnitSQL, EvidenceAdapter, Any, Protocol, _as_dt(), CollapseMirrorEvidenceAdapter, Any, datetime (+46 more)
+Nodes (48): build_latest_profile_query(), build_profile_details_query(), _escape_sparql(), GraphQueryConfig, _sparql_values_str(), _sparql_values_uri(), configure_parity_evidence_store(), ConsumerParityEvidence (+40 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.06
-Nodes (65): build_plan_for_verb(), load_prompt_template(), load_verb_yaml(), Any, ExecutionPlan, Honor explicit `services: []` on a plan step; do not treat it as 'inherit defaul, _resolve_step_services(), test_grounding_capsule_round_trip() (+57 more)
+Cohesion: 0.07
+Nodes (42): FrontierTargetZoneV1, BaseModel, Operator-controlled substrate policy profile adoption contracts (Phase 17)., SubstratePolicyAdoptionRequestV1, SubstratePolicyAdoptionResultV1, SubstratePolicyAuditEventV1, SubstratePolicyComparisonV1, SubstratePolicyInspectionV1 (+34 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.07
-Nodes (55): FieldEdgeV1, FieldStateV1, BaseModel, apply_decay(), apply_diffusion(), _clamp01(), Recompute every diffused capability channel fresh from this tick's node/     cap, apply_suppression() (+47 more)
+Cohesion: 0.05
+Nodes (57): _engine_for(), load_expectations_for_motif(), _load_latest_consolidation_frame(), load_latest_tensor_slices(), load_recent_motifs(), load_schema_candidates(), _parse_json(), Engine (+49 more)
 
 ### Community 94 - "Community 94"
-Cohesion: 0.07
-Nodes (65): build_cognitive_projection_for_context(), build_cognitive_projection_for_mind_with_diagnostics(), _env_float(), get_projection_unification_layer(), _publish_tier_outcomes_if_needed(), Any, Shared CognitiveUnificationLayer → CognitiveProjection builder.  Phase-3 seam: m, Return the process-level CognitiveUnificationLayer used by projection builders. (+57 more)
+Cohesion: 0.06
+Nodes (59): ReasoningSparkStateSnapshotV1, BaseModel, datetime, Canonical spark source seam used by reasoning adapters (Phase 5)., SparkSourceSnapshotV1, Normalization utilities for Orion payloads., _as_mapping(), _coerce_datetime() (+51 more)
 
 ### Community 95 - "Community 95"
-Cohesion: 0.08
-Nodes (64): Shared contracts for bus message payloads., MemoryCardEdgeCreateV1, MemoryCardEdgeV1, MemoryCardHistoryEntryV1, MemoryCardPatchV1, MemoryCardV1, BaseModel, visibility_allows_card() (+56 more)
+Cohesion: 0.12
+Nodes (60): ExternalRoomPostRequestV1, _callsyne_bridge_post_body(), Shape for POST /api/bridge/messages using top-level snake_case fields., SocialRoomBridgeService, _FailingCallSyneClient, _FailingHubClient, _FakeBus, _FakeCallSyneClient (+52 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.07
-Nodes (68): Path, Unit tests for the pure helpers in scripts/context_mode_hooks_smoke.py.  These n, _stream_lines(), test_check_result_json_line_round_trips(), test_dir_diff_detects_added_file(), test_dir_diff_detects_modified_file(), test_exit_code_zero_only_without_fail(), test_extract_final_text_falls_back_to_assistant_text() (+60 more)
+Cohesion: 0.05
+Nodes (67): End-to-end eval for homeostatic drives (spec/plan Task 8).  Replays a synthetic, run(), _sig(), detect_drive_tensions(), DriveTensionV1, One detected tension between two drives at a single tick.      `drive_a` is the, Detect pairwise inverse-coactivation tensions between drives.      Definition: a, drive_state_from_values() (+59 more)
 
 ### Community 97 - "Community 97"
-Cohesion: 0.05
-Nodes (72): applyCapabilityDefaults(), applySegmentsClientFilters(), bindTopicStudioPersistence(), clearPreview(), copyText(), executePreview(), exportEventsCsv(), exportKgCsv() (+64 more)
+Cohesion: 0.07
+Nodes (44): SubstrateEdgeV1, ActivationConfig, _clamp(), datetime, recency_score(), seed_activation(), ActivationUpdateV1, DormancyTransitionV1 (+36 more)
 
 ### Community 98 - "Community 98"
-Cohesion: 0.07
-Nodes (30): ConceptProfile, ConceptProfileDelta, GraphReadyArtifact, ConceptWorker, BaseEnvelope, ServiceRef, TensionEventV1, Manages windowed intake and triggers induction. (+22 more)
+Cohesion: 0.06
+Nodes (65): build_active_packet(), _entry(), Any, datetime, _task_boost(), emit_active_packet_retrieved(), emit_vector_upsert(), Any (+57 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.04
-Nodes (71): Channel "orion:bridge:social:participant" (kind=event, schema=ExternalRoomParticipantV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:bridge:social:room:delivery" (kind=event, schema=ExternalRoomPostResultV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:bridge:social:room:intake" (kind=event, schema=ExternalRoomMessageV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:bridge:social:room:skipped" (kind=event, schema=ExternalRoomTurnSkippedV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:core:events" (kind=event, schema=CoreEventV1) producers=[*] consumers=[*], Channel "orion:rdf:error" (kind=event, schema=SystemErrorV1) producers=[orion-rdf-writer] consumers=[*], Channel "orion:social:bridge-summary" (kind=event, schema=SocialBridgeSummaryV1) producers=[orion-social-memory] consumers=[*, orion-social-room-bridge, orion-hub], Channel "orion:social:claim" (kind=event, schema=SocialClaimV1) producers=[orion-social-memory] consumers=[*, orion-social-room-bridge, orion-hub] (+63 more)
+Cohesion: 0.05
+Nodes (31): PadEventV1, PadLinks, PadRpcRequestV1, PadRpcResponseV1, BaseModel, StateBuckets, StateFrameV1, StateSummary (+23 more)
 
 ### Community 100 - "Community 100"
-Cohesion: 0.09
-Nodes (44): CalibrationRolloutScopeV1, apply_calibration_adoption(), compare_endogenous_runtime_profile_outcomes(), EndogenousRuntimeAdoptionService, inspect_calibration_profile_audit(), inspect_calibration_profile_audit_with_source(), inspect_calibration_profile_state_with_source(), inspect_calibration_profiles() (+36 more)
+Cohesion: 0.06
+Nodes (74): ContextRisk, auto_approve_from_env(), claude_permission_argv(), Auto-approve tool permissions for non-interactive FCC turns., Whether to auto-approve when env is unset: root containers yes, host non-root ye, annotate_harness_step(), apply_context_overflow_hint(), build_context_pressure_step() (+66 more)
 
 ### Community 101 - "Community 101"
-Cohesion: 0.10
-Nodes (47): FrontierContextRefsV1, FrontierDeltaItemV1, FrontierExpansionRequestV1, FrontierExpansionResponseV1, FrontierGraphDeltaBundleV1, FrontierGraphRegionRefV1, FrontierSourceProvenanceV1, BaseModel (+39 more)
+Cohesion: 0.07
+Nodes (66): client(), TestClient, test_ready_200_when_consumer_ready(), test_ready_503_when_intake_bus_not_connected(), TestBaselineStartupEmit, _make_worker(), When ENABLE_COMPRESSION_RUNTIME=false the tick does nothing., All federators returning [] must not raise — just skip region. (+58 more)
 
 ### Community 102 - "Community 102"
-Cohesion: 0.07
-Nodes (56): PhiIntrinsicRewardV1, ExecutionTrajectorySnapshot, GrammarTruthSnapshot, ReasoningActivitySnapshot, _mock_healthy_substrate_reads(), The main-path trace EKG frame (handle_trace, non-heartbeat) must show the     ho, # NOTE: handle_self_state does `SelfStateV1.model_validate(payload)` inside a, A healthy row (phi_health='ok', grammar not degraded, cognitive features     bac (+48 more)
+Cohesion: 0.06
+Nodes (61): HTMLParser, Any, SourceRegistryV1, SourceTrustAssessmentV1, WorldPulseAllowedUsesV1, WorldPulseSourceV1, fetch_rss_articles(), _parse_date() (+53 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.07
-Nodes (38): build_latest_profile_query(), build_profile_details_query(), _escape_sparql(), GraphQueryConfig, GraphQueryError, RuntimeError, _sparql_values_str(), _sparql_values_uri() (+30 more)
+Cohesion: 0.06
+Nodes (48): ArtifactEventRef, ArtifactEvidence, DriveStateV1, GoalProposalV1, GraphReadyArtifact, BaseModel, datetime, Lightweight join stub for turn-level debugability (not a service). (+40 more)
 
 ### Community 104 - "Community 104"
 Cohesion: 0.07
-Nodes (42): ClaimSummaryV1, ContextPackCompileRequestV1, ContextPackCompileResultV1, ContextPackSummaryV1, ContextPackTargetApiV1, DecisionSummaryV1, IdeationMode, KnowledgeForgeStatusV1 (+34 more)
+Nodes (63): FieldEdgeV1, FieldStateV1, BaseModel, collect_field_channel_pressures(), map_channels_to_dimensions(), Merge node_vectors + capability_vectors into one channel-name-keyed     pressure, apply_decay(), apply_diffusion() (+55 more)
 
 ### Community 105 - "Community 105"
-Cohesion: 0.06
-Nodes (58): InnerFeatureV1, BaseModel, InnerStateFeaturesV1 — Orion's honest, decontaminated inner-state vector.  Felt+, is_corpus_row_healthy(), Pure gate predicate for the phi (InnerStateFeaturesV1) training corpus.  Garbage, Pure predicate: should this InnerStateFeaturesV1 row enter the phi corpus?, main(), _parse_args() (+50 more)
+Cohesion: 0.05
+Nodes (73): _abs_trajectory_for_row(), _as_utc(), bucket_class_for(), bucket_index(), BucketActivity, build_arg_parser(), build_bucket_activity(), build_drive_coactivation_histogram_sparql() (+65 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.09
-Nodes (59): MemoryCardStatus, EvidenceItemV1, MemoryCardCreateV1, Payload for creating a card (Hub POST)., TimeHorizonV1, CardProjectionDefaultsV1, DispositionDraft, EdgeDraft (+51 more)
+Cohesion: 0.07
+Nodes (62): _clean(), extract_anchors(), _clean_block(), extract_blocks(), _extract_code_or_command(), _extract_logs(), _reasoning_summary(), _candidate_claims() (+54 more)
 
 ### Community 107 - "Community 107"
-Cohesion: 0.07
-Nodes (54): build_expectations_from_motifs(), detect_motifs(), PolicyDecisionFrameV1, PolicyDecisionV1, BaseModel, _engine(), _load_latest_policy_frame(), policy_latest() (+46 more)
+Cohesion: 0.10
+Nodes (48): HypothesisNodeV1, FrontierContextRefsV1, FrontierDeltaItemV1, FrontierExpansionRequestV1, FrontierExpansionResponseV1, FrontierGraphDeltaBundleV1, FrontierGraphRegionRefV1, FrontierSourceProvenanceV1 (+40 more)
 
 ### Community 108 - "Community 108"
-Cohesion: 0.08
-Nodes (63): _FakeBus, _payload(), _service_and_session(), test_accepted_artifact_confirmation_expands_active_continuity(), test_accepted_confirmation_without_clear_scope_stays_non_active(), test_active_commitment_is_selected_over_old_ritual_hint(), test_addressed_peer_context_is_preferred_over_generic_room_context(), test_ambiguous_divergence_prefers_one_clarifying_question() (+55 more)
+Cohesion: 0.06
+Nodes (61): api_service_logs_services(), build_compose_logs_command(), collect_service_inventory(), discover_loggable_services(), _docker_diagnostics(), Any, Path, Queue (+53 more)
 
 ### Community 109 - "Community 109"
-Cohesion: 0.08
-Nodes (62): ActiveFrontierDiagnosticsV1, AppraisalFeatureVectorV1, DeferredFrontierMatterV1, MindEvidenceItemV1, MindEvidencePackV1, BaseModel, Mind semantic synthesis, appraisal, and stance handoff contracts., SemanticClaimV1 (+54 more)
+Cohesion: 0.07
+Nodes (58): get_db(), init_models(), generate_biometrics_model(), Returns a SQLAlchemy model with the table name defined in .env → TABLE_NAME, DigestRunDB, NotificationAttemptDB, NotificationRequestDB, Base (+50 more)
 
 ### Community 110 - "Community 110"
-Cohesion: 0.04
-Nodes (56): Cross-cutting ouroboros invariants for the reverie/dream/compaction weave.  The, A producer of a weave channel must never also be listed as a consumer of     tha, The memory-touching / dispatch-adjacent channels stay dead-ended: no     service, test_channel_schema_ids_match_the_weave_contract(), test_dangerous_channels_have_no_live_consumer(), test_every_weave_kind_is_registered_and_resolvable(), test_no_process_reads_its_own_output_kind(), _weave_channel_entries() (+48 more)
+Cohesion: 0.06
+Nodes (66): CapabilitiesResponse, DatasetCreateRequest, DatasetCreateResponse, DatasetListResponse, DatasetPreviewDoc, DriftListResponse, DriftRecord, DriftRunRequest (+58 more)
 
 ### Community 111 - "Community 111"
-Cohesion: 0.06
-Nodes (59): HarnessDraftMoleculeV1, CompactionRequestV1, BaseModel, Readout of one train of thought — successive climbs of the ladder.      Continui, A typed *ask* from the awake reverie (reasoning) to the offline dream     (stora, ReverieChainTriggerV1, ReverieChainV1, CoalitionSnapshotV1 (+51 more)
+Cohesion: 0.07
+Nodes (31): ConceptProfile, ConceptProfileDelta, GraphReadyArtifact, ConceptInductionTrigger, ConceptWorker, BaseEnvelope, ServiceRef, TensionEventV1 (+23 more)
 
 ### Community 112 - "Community 112"
 Cohesion: 0.07
-Nodes (63): configured_storage_paths(), ensure_storage_dirs(), _path_status(), persist_context_exec_run(), Any, Path, Best-effort conversion to a JSON-serializable structure.      Never raises; un-s, Persist an immutable forensic bundle for a completed context-exec run.      Retu (+55 more)
+Nodes (54): EvidenceUnitSQL, EvidenceAdapter, Any, Protocol, _as_dt(), CollapseMirrorEvidenceAdapter, Any, datetime (+46 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.04
-Nodes (57): _make_engine_sequence(), Returns a fake engine where each successive execute() call returns the next resu, Simulate endpoint must not access the DB engine beyond loading the proof chain., Endpoint must not modify the policy YAML file., Returns 503 when the policy YAML file doesn't exist., M3 status is 'fresh' when projection updated_at is recent., M3 status is 'stale' when projection updated_at is old., L11 status is 'missing' when consolidation frames table has no rows. (+49 more)
+Cohesion: 0.05
+Nodes (45): BBox, VisionEdgeActivityPayload, VisionEdgeError, VisionEdgeHealth, ActivityRateLimiter, build_activity_payload(), labels_from_detections(), publish_activity_if_allowed() (+37 more)
 
 ### Community 114 - "Community 114"
 Cohesion: 0.06
-Nodes (56): ClosureHandler, _envelope_correlation_id(), _handle_bus_message(), handle_finalize_appraisal_request(), Any, Settings, Task, UUID (+48 more)
+Nodes (64): apply_fast_chat_recall_profile_clamp(), apply_hub_chat_lane_recall_clamp(), _clean_profile(), delivery_safe_recall_decision(), _is_concrete_ops_query(), _normalize_bool(), plan_ctx_latest_user_text(), Any (+56 more)
 
 ### Community 115 - "Community 115"
-Cohesion: 0.05
-Nodes (17): record_tail_seed(), TailSeedRecord, BiometricsSubstrateStore, _cursor_lag_seconds(), Any, datetime, Pending backlog and stream lag for a grammar reducer cursor., Operator recovery: reset reducer cursor. Caller must validate auth/mode/name. (+9 more)
+Cohesion: 0.07
+Nodes (55): GoalGenerationMode, _Baseline, DeviationGate, Deviation gate: turn a stream of per-dimension observations into impulses that f, Adaptive per-dimension deviation detector.      Args:         alpha: EWMA weight, Return the deviation impulse (>=0) for this observation, then fold it         in, _fold_tension_into_pressures(), Immutable typed lookup of dimension rules per signal_kind. (+47 more)
 
 ### Community 116 - "Community 116"
-Cohesion: 0.07
-Nodes (53): MemoryBundleStatsV1, MemoryBundleV1, MemoryItemV1, BaseModel, Per-fetch-path vector gating outcome (see ``source_policy.recall_vector_allowed`, A single retrieved memory item., Path-keyed vector policy diagnostics attached under ``recall_debug.vector_policy, Coarse source enablement labels under ``recall_debug.source_gating``. (+45 more)
+Cohesion: 0.04
+Nodes (71): Channel "orion:bridge:social:participant" (kind=event, schema=ExternalRoomParticipantV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:bridge:social:room:delivery" (kind=event, schema=ExternalRoomPostResultV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:bridge:social:room:intake" (kind=event, schema=ExternalRoomMessageV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:bridge:social:room:skipped" (kind=event, schema=ExternalRoomTurnSkippedV1) producers=[orion-social-room-bridge] consumers=[orion-sql-writer, *], Channel "orion:core:events" (kind=event, schema=CoreEventV1) producers=[*] consumers=[*], Channel "orion:rdf:error" (kind=event, schema=SystemErrorV1) producers=[orion-rdf-writer] consumers=[*], Channel "orion:social:bridge-summary" (kind=event, schema=SocialBridgeSummaryV1) producers=[orion-social-memory] consumers=[*, orion-social-room-bridge, orion-hub], Channel "orion:social:claim" (kind=event, schema=SocialClaimV1) producers=[orion-social-memory] consumers=[*, orion-social-room-bridge, orion-hub] (+63 more)
 
 ### Community 117 - "Bus Channels: Agent Council & Chat History"
-Cohesion: 0.10
-Nodes (35): EndogenousTriggerDebugV1, EndogenousTriggerDecisionV1, EndogenousTriggerRequestV1, EndogenousTriggerSignalV1, EndogenousWorkflowActionV1, EndogenousWorkflowExecutionResultV1, EndogenousWorkflowPlanV1, BaseModel (+27 more)
+Cohesion: 0.06
+Nodes (66): Telemetry for recall decisions., RecallDecisionV1, count_eligible_active(), RetrievalIntentV1, intent_telemetry_payload(), Build recall.intent.v1 telemetry. ``query_hash16`` is SHA-256 of UTF-8 query tex, recall_endpoint(), fetch_memory_graph_sparql_candidates() (+58 more)
 
 ### Community 118 - "Community 118"
-Cohesion: 0.05
-Nodes (53): ChatStanceBrief, BaseModel, Bounded internal stance brief used by chat_general speech pass., _brief_response_hazards(), enforce_chat_stance_quality(), _extract_json_object(), fallback_chat_stance_brief(), _is_identity_sensitive_turn() (+45 more)
+Cohesion: 0.08
+Nodes (67): InnerStateFeaturesV1, PhiEncoderManifestV1, main(), _parse_args(), Namespace, Pure: load + gate-check a corpus, return the full report dict. Never raises., run_diag(), _apply_grads() (+59 more)
 
 ### Community 119 - "Community 119"
-Cohesion: 0.05
-Nodes (57): Narrator, RequestLoader, MonkeyPatch, test_legacy_rabbit_enables_concurrent_handlers_by_default(), test_legacy_rabbit_respects_concurrent_handlers_setting(), _enable_pcr(), _enable_pcr_and_grounding(), build_compaction_delta() (+49 more)
+Cohesion: 0.06
+Nodes (51): FccRunner, build_harness_grammar_events(), build_harness_grammar_finalize_events(), compute_harness_reasoning_present(), compute_harness_thinking_source(), _event(), HarnessGrammarCollector, _hash_id() (+43 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.10
-Nodes (53): ReductionReceiptV1, emission_touches_node(), _normalize_node_id(), Any, Node-scoped filtering for substrate receipts and organ emissions., receipt_touches_node(), state_deltas_for_node(), classify_receipt() (+45 more)
+Cohesion: 0.07
+Nodes (42): ClaimSummaryV1, ContextPackCompileRequestV1, ContextPackCompileResultV1, ContextPackSummaryV1, ContextPackTargetApiV1, DecisionSummaryV1, IdeationMode, KnowledgeForgeStatusV1 (+34 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.06
-Nodes (44): BaseModel, StateDeltaV1, apply_perturbations(), delta_to_perturbations(), _node_key(), Perturbation, empty_field_state(), new_tick_id() (+36 more)
+Cohesion: 0.08
+Nodes (60): Definition of a tool available to the planner., ToolDef, _active_autonomy_goals_from_ctx(), _autonomy_goal_action_from_ctx(), _autonomy_goal_execution_allowed(), _autonomy_goal_execution_enabled(), _available_operational_semantic_tools(), _blocked_bound_step_result() (+52 more)
 
 ### Community 122 - "Community 122"
-Cohesion: 0.05
-Nodes (49): test_notify_verb_fills_body_from_context_when_skill_args_empty(), OperationalSemanticHarnessTests, LogCaptureFixture, MonkeyPatch, Settings, Regression: direct lane RPC must reuse the same plan as the verb path (router +, Regression: lane/mind/output_mode arbitration facts must reach the caller on, _settings_routing_off() (+41 more)
+Cohesion: 0.06
+Nodes (68): applyCapabilityDefaults(), applySegmentsClientFilters(), bindTopicStudioPersistence(), copyText(), executePreview(), exportEventsCsv(), exportKgCsv(), exportSegmentsCsv() (+60 more)
 
 ### Community 123 - "Community 123"
+Cohesion: 0.07
+Nodes (59): Autonomy graph IRIs (no heavy imports — safe for orion-actions / hub)., archive_subject_goals(), archive_subjects(), archive_subjects_drain(), _binding_value(), build_archive_candidates(), build_archive_status_update(), _build_client() (+51 more)
+
+### Community 124 - "Community 124"
+Cohesion: 0.10
+Nodes (32): CalibrationAdoptionRequestV1, CalibrationAdoptionResultV1, CalibrationProfileAuditV1, CalibrationProfileResolutionV1, CalibrationProfileV1, CalibrationRollbackRequestV1, CalibrationRollbackResultV1, CalibrationRolloutScopeV1 (+24 more)
+
+### Community 125 - "Community 125"
+Cohesion: 0.08
+Nodes (63): Path, Unit tests for the pure helpers in scripts/context_mode_hooks_smoke.py.  These n, _stream_lines(), test_check_result_json_line_round_trips(), test_dir_diff_detects_added_file(), test_dir_diff_detects_modified_file(), test_exit_code_zero_only_without_fail(), test_extract_final_text_falls_back_to_assistant_text() (+55 more)
+
+### Community 126 - "Community 126"
+Cohesion: 0.05
+Nodes (39): build_identity_snapshot(), datetime, IdentitySnapshotV1, _snapshot_id(), IdentitySnapshotV1, BaseModel, BaseModel, SelfStatePredictionV1 (+31 more)
+
+### Community 127 - "Community 127"
+Cohesion: 0.06
+Nodes (55): InnerFeatureV1, BaseModel, InnerStateFeaturesV1 — Orion's honest, decontaminated inner-state vector.  Felt+, is_corpus_row_healthy(), Pure gate predicate for the phi (InnerStateFeaturesV1) training corpus.  Garbage, Pure predicate: should this InnerStateFeaturesV1 row enter the phi corpus?, main(), _parse_args() (+47 more)
+
+### Community 128 - "Community 128"
+Cohesion: 0.08
+Nodes (45): filter_allowed(), load_verb_catalog(), rank_verbs_for_query(), serialize_shortlist(), _tokenize(), VerbInfo, AutoDepthDecisionV1, DecisionRouter (+37 more)
+
+### Community 129 - "Community 129"
+Cohesion: 0.05
+Nodes (50): test_notify_verb_fills_body_from_context_when_skill_args_empty(), OperationalSemanticHarnessTests, LogCaptureFixture, MonkeyPatch, Settings, Regression: direct lane RPC must reuse the same plan as the verb path (router +, Regression: lane/mind/output_mode arbitration facts must reach the caller on, _settings_routing_off() (+42 more)
+
+### Community 130 - "Community 130"
+Cohesion: 0.06
+Nodes (27): BiometricsSubstrateWorker, _prediction_error_nodes_enabled(), _prediction_error_receipt(), Any, datetime, Fetch reducer lane health for lane regions, remapped to friendly lane keys., Latest self-state row payload (dict) or None. Fail-open., Assemble + persist one brain frame. Returns the frame or None. (+19 more)
+
+### Community 131 - "Community 131"
 Cohesion: 0.05
 Nodes (64): Channel "orion:attention:loop_outcome" (kind=event, schema=AttentionLoopOutcomeV1) producers=[orion-hub] consumers=[none], Channel "orion:attention:salience:trace" (kind=telemetry, schema=AttentionSalienceTraceV1) producers=[orion-thought] consumers=[none], Channel "orion:chat:history:spark_meta:patch" (kind=event, schema=ChatHistorySparkMetaPatchV1) producers=[orion-memory-consolidation] consumers=[orion-sql-writer], Channel "orion:chat:response:feedback" (kind=event, schema=ChatResponseFeedbackV1) producers=[orion-hub, *] consumers=[orion-sql-writer], Channel "orion:conversation:request" (kind=request, schema=ChatRequestPayload) producers=[orion-hub] consumers=[orion-cortex-orch], Channel "orion:conversation:result" (kind=result, schema=ChatResultPayload) producers=[orion-cortex-orch] consumers=[orion-hub], Channel "orion:council:reply*" (kind=result, schema=ChatResultPayload) producers=[orion-llm-gateway] consumers=[orion-vision-council], Channel "orion:dream:compaction-request" (kind=event, schema=CompactionRequestV1) producers=[orion-thought] consumers=[none] (+56 more)
 
-### Community 124 - "Community 124"
-Cohesion: 0.06
-Nodes (50): _clamp01(), Phase B — spontaneous thought → governed proposal candidate.  Maps a non-hollow, Convert a thought into a review-gated proposal candidate, or None.      Returns, spontaneous_thought_to_candidate(), _coalition(), Phase B — spontaneous thought → governed proposal candidate.  The security-criti, test_absent_coalition_targets_self_state_without_raising(), test_autoaction_posture_recorded_but_gate_unchanged() (+42 more)
-
-### Community 125 - "Community 125"
-Cohesion: 0.07
-Nodes (57): apply_fast_chat_recall_profile_clamp(), apply_hub_chat_lane_recall_clamp(), _clean_profile(), delivery_safe_recall_decision(), _is_concrete_ops_query(), _normalize_bool(), plan_ctx_latest_user_text(), Any (+49 more)
-
-### Community 126 - "Community 126"
-Cohesion: 0.09
-Nodes (51): BaseModel, RouteArbitrationProjectionV1, RouteArbitrationRunStateV1, _boolish(), extract_route_state_from_events(), _parse_summary_kv(), datetime, _utc_now() (+43 more)
-
-### Community 127 - "Community 127"
-Cohesion: 0.10
-Nodes (54): build_self_state(), _emit_summary_labels(), evidence_for_dimension(), _provenance_label(), datetime, Friendlier evidence label: strip the "node:" prefix (e.g. "node:atlas"     -> "a, Phase 3 (2026-07-12): fold node/capability provenance into the     free-text `re, _reason_for_evidence() (+46 more)
-
-### Community 128 - "Community 128"
-Cohesion: 0.07
-Nodes (54): AbstractEventLoop, Model, PermissionError, _diff_path_from_header(), _is_allowed(), _is_denied(), _normalize_rel_path(), patch_validate() (+46 more)
-
-### Community 129 - "Community 129"
-Cohesion: 0.15
-Nodes (56): HTTPException, resolve_graphiti_adapter_url(), count_eligible_active(), get_crystallization(), insert_history(), insert_retrieval_event(), list_crystallizations(), Pool (+48 more)
-
-### Community 130 - "Community 130"
-Cohesion: 0.09
-Nodes (39): decay_activation(), Half-life activation decay — stdlib only (safe for lightweight service imports)., _aware(), _clamp(), decay(), decayed_activation(), datetime, Dynamic memory weight for crystallizations: encode weakly, strengthen on reinfor (+31 more)
-
-### Community 131 - "Community 131"
-Cohesion: 0.06
-Nodes (54): _cast_embedding_to_vecf32(), _embed_query(), ensure_graphiti_indices(), _ensure_target_entity_stub(), _extract_crystallization_ids(), _falkor_driver(), _filter_intimate_crystallization_ids(), get_neighborhood() (+46 more)
-
 ### Community 132 - "Community 132"
-Cohesion: 0.09
-Nodes (25): _build_relation_prompt(), ConceptRelationDecision, maybe_resolve_concept_relation(), merge_new_evidence(), Any, BaseModel, Bounded structured-output LLM call. NEVER raises -- degrades to     ConceptRelat, Returns a (crystallization_id, row, outcome) tuple ONLY when it took a decisive (+17 more)
+Cohesion: 0.07
+Nodes (49): Dependency-free stable identifiers (hashlib only).  Use from thin services (orio, Return ``{prefix}_{sha256(preimage)[:24]}`` from ordered semantic parts., stable_hash_id(), Eval: reverie semantic lift quality bar — referent, voice, grounding., test_bad_meta_fixture_fails_infra_vocab(), test_good_fixture_passes_semantic_gates(), _database_url(), parse_harness_closure_ref() (+41 more)
 
 ### Community 133 - "Community 133"
-Cohesion: 0.07
-Nodes (51): FccRunner, _extract_tool_name(), short_error_kind(), publish_harness_step_grammar(), Any, PublishFn, harness_motor_instruction(), is_relational_motor_stance() (+43 more)
+Cohesion: 0.08
+Nodes (59): AgentSynthesisResult, build_operator_summary(), _build_synthesis_prompt(), _default_title(), _deterministic_summary(), _extract_memory_id_tokens(), _extract_path_tokens(), _flatten_strings() (+51 more)
 
 ### Community 134 - "Community 134"
-Cohesion: 0.08
-Nodes (49): BrainEdgeSampleV1, BrainNodeSampleV1, BrainRegionV1, BrainSpotlightV1, BaseModel, The spine of the contract: a continuous, trackable per-region signal., Best-effort decoration. NO continuity guarantee across frames., SubstrateBrainFrameV1 (+41 more)
+Cohesion: 0.05
+Nodes (44): PolicyDecisionFrameV1, PolicyDecisionV1, BaseModel, apply_compaction_delta(), CompactionApplyReceiptV1, CompactionMemoryStore, policy_approves_execution(), Any (+36 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.07
-Nodes (41): _coerce_features(), _coerce_matter_item(), _coerce_matter_kind(), _coerce_recommended_effect(), _coerce_string_list(), _extract_selected_raw(), _float_field(), _is_bare_frontier_matter_root() (+33 more)
+Cohesion: 0.06
+Nodes (52): Popen, asterisk_cmd(), bootstrap_asterisk_and_cisco(), CompletedProcess, Path, Settings, Ensure Asterisk dirs exist, write core configs and SEP<MAC>.cnf.xml (only if mis, Start in.tftpd (tftpd-hpa) serving /tftpboot. (+44 more)
 
 ### Community 136 - "Community 136"
-Cohesion: 0.08
-Nodes (49): ChatProjectionLoader, ChatProjectionSaver, ChatTurnStateV1, BaseModel, compute_chat_pressure_hints(), extract_chat_turn_state(), _parse_trace_id(), datetime (+41 more)
+Cohesion: 0.14
+Nodes (57): HTTPException, emit_crystallization_lifecycle(), resolve_graphiti_adapter_url(), project_crystallization(), Pool, Project active crystallization to derived stores and emit bus project event., get_crystallization(), insert_history() (+49 more)
 
 ### Community 137 - "Community 137"
-Cohesion: 0.09
-Nodes (53): EmitObservationFn, execute_unified_turn(), _finalize_phase_error(), _harness_error_frame(), _partial_draft_from_run(), _publish_unified_turn_chat_grammar(), _publish_unified_turn_chat_history(), Any (+45 more)
+Cohesion: 0.10
+Nodes (57): MindLLMSynthesisOutcome, Orion Mind shared contracts (types only; runtime lives in services/orion-mind)., ActiveCognitiveFrontierV1, MindStanceHandoffV1, test_hash_snapshot_inputs_stable(), test_mind_run_result_roundtrip(), test_universe_snapshot_facets(), test_validate_merged_stance_brief_accepts_minimal() (+49 more)
 
 ### Community 138 - "Community 138"
-Cohesion: 0.08
-Nodes (53): GrammarAtomSQL, GrammarCompactionSQL, GrammarEdgeSQL, GrammarEventSQL, GrammarProjectionSQL, GrammarTemporalHopSQL, GrammarTraceSQL, Canonical layer and dimension enums for Substrate Atlas (spec §5.4–5.5). (+45 more)
+Cohesion: 0.09
+Nodes (56): ActiveFrontierDiagnosticsV1, AppraisalFeatureVectorV1, DeferredFrontierMatterV1, MindEvidenceItemV1, MindEvidencePackV1, BaseModel, Mind semantic synthesis, appraisal, and stance handoff contracts., SemanticClaimV1 (+48 more)
 
 ### Community 139 - "Community 139"
 Cohesion: 0.06
-Nodes (49): build_answer_grounding_context(), _compose_grounding_context(), delivery_grounding_mode(), extract_trace_preferred_output(), Any, Answer/runtime grounding strings split from delivery-oriented helpers., Structured grounding for answer/render verbs (repo + runtime; Discord only when, build_delivery_grounding_context() (+41 more)
+Nodes (55): AttentionFrameV1, attention_broadcast_enabled(), broadcast_projection_from_frame(), build_substrate_attention_frame(), _current_history(), datetime, One workspace competition over the substrate graph; always one winner.      Same, _record_selection() (+47 more)
 
 ### Community 140 - "Community 140"
-Cohesion: 0.09
-Nodes (35): ArtifactEventRef, ArtifactEvidence, DriveStateV1, GraphReadyArtifact, BaseModel, datetime, Lightweight join stub for turn-level debugability (not a service)., TurnDossierV1 (+27 more)
+Cohesion: 0.07
+Nodes (50): test_grounding_capsule_round_trip(), test_thought_event_capsule_optional_and_defaults_none(), _base_thought(), Back-compat: existing constructors that omit autonomy_slice still validate., test_autonomy_slice_v1_defaults(), test_autonomy_slice_v1_round_trips_through_json(), test_thought_event_accepts_autonomy_slice(), test_thought_event_validates_without_autonomy_slice() (+42 more)
 
 ### Community 141 - "Community 141"
 Cohesion: 0.06
-Nodes (47): collect_fragments(), Fragment, Fan-out collector.      This is the only place that knows which storage backends, RecallResult, End-to-end recall pipeline:      1. Collect candidate fragments from SQL and RDF, run_recall_pipeline(), _dedupe(), _mix_kinds() (+39 more)
+Nodes (54): _cast_embedding_to_vecf32(), _embed_query(), ensure_graphiti_indices(), _ensure_target_entity_stub(), _extract_crystallization_ids(), _falkor_driver(), _filter_intimate_crystallization_ids(), get_neighborhood() (+46 more)
 
 ### Community 142 - "Community 142"
-Cohesion: 0.10
-Nodes (44): ObservationMode, datetime, stable_frame_id(), AttentionLimitsV1, AttentionThresholdsV1, AttentionWeightsV1, FieldAttentionPolicyV1, load_attention_policy() (+36 more)
+Cohesion: 0.09
+Nodes (25): _build_relation_prompt(), ConceptRelationDecision, maybe_resolve_concept_relation(), merge_new_evidence(), Any, BaseModel, Bounded structured-output LLM call. NEVER raises -- degrades to     ConceptRelat, Returns a (crystallization_id, row, outcome) tuple ONLY when it took a decisive (+17 more)
 
 ### Community 143 - "Bus Channels: Actions Trigger/Audit Family"
-Cohesion: 0.12
-Nodes (24): CalibrationAdoptionRequestV1, CalibrationAdoptionResultV1, CalibrationProfileAuditV1, CalibrationProfileResolutionV1, CalibrationProfileV1, CalibrationRollbackRequestV1, CalibrationRollbackResultV1, BaseModel (+16 more)
+Cohesion: 0.07
+Nodes (49): _build_summary(), default_fetch_backend(), EpisodeFetchRequest, execute_readonly_fetch(), _parse_articles(), Build scored article refs from a backend result.      Prefers the rich `articles, resolve_fetch_backend(), resolve_firecrawl_api_key() (+41 more)
 
 ### Community 144 - "Community 144"
 Cohesion: 0.08
-Nodes (47): ProjectionUpdateV1, BaseModel, BaseModel, TransportBusProjectionV1, TransportBusStateV1, _biometrics_projection(), _execution_projection(), test_biometrics_adapter_accepts_dict_json_absent_and_garbage() (+39 more)
+Nodes (49): BrainEdgeSampleV1, BrainNodeSampleV1, BrainRegionV1, BrainSpotlightV1, BaseModel, The spine of the contract: a continuous, trackable per-region signal., Best-effort decoration. NO continuity guarantee across frames., SubstrateBrainFrameV1 (+41 more)
 
 ### Community 145 - "Community 145"
-Cohesion: 0.09
-Nodes (48): CollapseMirrorEntry, Direct request to write raw triples or triggers to the RDF writer.     Used for, RdfWriteRequest, MetaTagsPayload, MetaTagsRequestV1, MetaTagsResultV1, BaseModel, Standard schema for enrichment tags emitted by analysis services.     Conforms t (+40 more)
+Cohesion: 0.10
+Nodes (54): _FakeBus, _payload(), _service_and_session(), test_accepted_artifact_confirmation_expands_active_continuity(), test_accepted_confirmation_without_clear_scope_stays_non_active(), test_active_commitment_is_selected_over_old_ritual_hint(), test_addressed_peer_context_is_preferred_over_generic_room_context(), test_ambiguous_divergence_prefers_one_clarifying_question() (+46 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.07
-Nodes (47): build_identity_context(), load_identity_file(), Any, Path, resolve_identity_path(), enrich_projection_context(), identity_kernel_with_fallbacks(), inject_identity_context_for_projection() (+39 more)
+Cohesion: 0.08
+Nodes (53): GrammarAtomSQL, GrammarCompactionSQL, GrammarEdgeSQL, GrammarEventSQL, GrammarProjectionSQL, GrammarTemporalHopSQL, GrammarTraceSQL, Canonical layer and dimension enums for Substrate Atlas (spec §5.4–5.5). (+45 more)
 
 ### Community 147 - "Bus Channels: Social Room Bridge"
-Cohesion: 0.08
-Nodes (49): test_fuse_dedupe_and_limit(), test_self_factual_filters_exclude_induced_and_reflective_candidates(), Pattern, _backend_weights(), _belief_source_rank(), _candidate_allowed(), _cards_rail_enabled(), _denial_patterns() (+41 more)
+Cohesion: 0.09
+Nodes (45): ObservationMode, AttentionLimitsV1, AttentionThresholdsV1, AttentionWeightsV1, FieldAttentionPolicyV1, load_attention_policy(), ObservationModesV1, BaseModel (+37 more)
 
 ### Community 148 - "Community 148"
 Cohesion: 0.08
-Nodes (46): build_speech_prompt(), _interlocutor_name(), is_injectable(), latest_partner_line(), _participants(), Any, Pure helpers for the cortex-generated town speech bridge.  No I/O. The worker ow, Anti empty-shell guard: only non-empty, non-whitespace replies are injectable. (+38 more)
+Nodes (51): test_fuse_dedupe_and_limit(), test_self_factual_filters_exclude_induced_and_reflective_candidates(), Pattern, _backend_weights(), _belief_source_rank(), _candidate_allowed(), _cards_rail_enabled(), _denial_patterns() (+43 more)
 
 ### Community 149 - "Community 149"
 Cohesion: 0.07
-Nodes (49): PcrChatMemoryV1, Purpose-conditioned recall (PCR) schema types., Cortex ctx shape for PCR chat memory surfaces., assemble_stance_grounding(), build_grounding_capsule(), _clean(), Any, Settings (+41 more)
+Nodes (45): call_with_fuseki_retry(), fuseki_http_error_body(), fuseki_http_retry_attempts(), fuseki_http_retry_base_delay_sec(), is_fuseki_lock_exhaustion(), is_fuseki_retryable_http_error(), Response, T (+37 more)
 
 ### Community 150 - "Community 150"
-Cohesion: 0.10
-Nodes (50): config/autonomy/signal_drive_map.yaml, _cold(), main(), AutonomyEvidenceRefV1, AutonomyStateDeltaV1, CandidateImpulseV1, AutonomyStateV2 evidence pipeline (chat, env-gated), Orion Autonomy README (+42 more)
+Cohesion: 0.09
+Nodes (52): EmitObservationFn, execute_unified_turn(), _finalize_phase_error(), _harness_error_frame(), _partial_draft_from_run(), _publish_unified_turn_chat_grammar(), _publish_unified_turn_chat_history(), Any (+44 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.08
-Nodes (50): RouteName, _apply_llm_route(), _call_cortex(), _extract_attempt_diagnostics(), _normalize_route(), Any, BaseException, Try grounded Quick, then Brain on hard failures; RDF-validate without persisting (+42 more)
+Cohesion: 0.05
+Nodes (47): Cross-cutting ouroboros invariants for the reverie/dream/compaction weave.  The, A producer of a weave channel must never also be listed as a consumer of     tha, The memory-touching / dispatch-adjacent channels stay dead-ended: no     service, test_channel_schema_ids_match_the_weave_contract(), test_dangerous_channels_have_no_live_consumer(), test_every_weave_kind_is_registered_and_resolvable(), test_no_process_reads_its_own_output_kind(), _weave_channel_entries() (+39 more)
 
 ### Community 152 - "Community 152"
-Cohesion: 0.07
-Nodes (51): inject_session_presence(), load_session_presence(), _payload_has_presence_context(), Any, Merge stored presence into a chat payload when the client did not send one., Return session-scoped audience presence, or None when unavailable., cancel_agent_claude_turn(), cancel_in_flight_turn() (+43 more)
+Cohesion: 0.08
+Nodes (43): DailyWorldPulseSectionsV1, DailyWorldPulseV1, GraphDeltaPlanV1, HubWorldPulseMessageV1, WorldPulseRunV1, main(), _status(), _envelope() (+35 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.11
-Nodes (48): BaseModel, SocialConceptEvidenceV1, SocialGroundingStateV1, SocialRedactionScoreV1, BaseModel, SocialSkillRequestV1, SocialSkillResultV1, SocialSkillSelectionV1 (+40 more)
+Cohesion: 0.09
+Nodes (49): ChatProjectionLoader, ChatProjectionSaver, ChatSessionProjectionV1, ChatTurnStateV1, BaseModel, compute_chat_pressure_hints(), extract_chat_turn_state(), _parse_trace_id() (+41 more)
 
 ### Community 154 - "Community 154"
 Cohesion: 0.10
-Nodes (52): asList(), asObject(), attach(), buildExecutionStepsPanel(), cleanText(), collectBase(), compactProjectionItems(), comparisonColumn() (+44 more)
+Nodes (35): EndogenousCalibrationProfileV1, EndogenousCalibrationRecommendationV1, EndogenousEvaluationRequestV1, EndogenousEvaluationResultV1, EndogenousMetricSummaryV1, PromotionCalibrationSummaryV1, BaseModel, datetime (+27 more)
 
 ### Community 155 - "Community 155"
-Cohesion: 0.10
-Nodes (43): CoverageStatus, _gpu_gap_result(), test_metabolism_skips_covered_sections(), test_metabolism_sparse_gpu_section_raises_predictive(), DailyWorldPulseItemV1, DailyWorldPulseSectionsV1, DailyWorldPulseV1, HubWorldPulseMessageV1 (+35 more)
+Cohesion: 0.08
+Nodes (46): build_speech_prompt(), _interlocutor_name(), is_injectable(), latest_partner_line(), _participants(), Any, Pure helpers for the cortex-generated town speech bridge.  No I/O. The worker ow, Anti empty-shell guard: only non-empty, non-whitespace replies are injectable. (+38 more)
 
 ### Community 156 - "Community 156"
-Cohesion: 0.08
-Nodes (44): FeedbackFrameV1, ActionOutcomeEmitV1, Bus payload carrying an action outcome for durable persistence via sql-writer., _artifact_id(), _canonical_pressures_for_spread(), clamp01(), _delta_from_turn_effect(), derive_pressure_competition_tensions() (+36 more)
+Cohesion: 0.09
+Nodes (46): BaseModel, RouteArbitrationProjectionV1, RouteArbitrationRunStateV1, _boolish(), extract_route_state_from_events(), _parse_summary_kv(), datetime, _utc_now() (+38 more)
 
 ### Community 157 - "Bus Channels: Collapse Mirror & Autonomy Goal"
-Cohesion: 0.07
-Nodes (43): expand_env_path(), load_fcc_env(), Path, build_orion_town_persona(), Project the self-model into a public-safe town persona.      Empty-shell guard:, _truncate(), test_blurb_is_truncated(), test_empty_projection_falls_back() (+35 more)
+Cohesion: 0.10
+Nodes (50): BaseModel, Append-only social_room turn persistence payload., SocialConceptEvidenceV1, SocialGroundingStateV1, SocialRedactionScoreV1, SocialRoomTurnV1, BaseModel, SocialSkillRequestV1 (+42 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.12
-Nodes (41): _autonomy_goal_execution_enabled(), plan_promoted_goal(), update_goal_planned_task_id(), _FakeGraphClient, _goal_row(), test_plan_promoted_goal_persists_task_id_with_planned_status(), test_plan_promoted_goal_requires_planned_status(), test_promote_goal_chains_planner_task_id() (+33 more)
+Cohesion: 0.07
+Nodes (43): execution_prediction_error(), _mean(), 0-1 surprise score: how much did execution pressure hints change this batch?, 0-1 surprise score: how much did transport bus health change this batch?, transport_prediction_error(), empty_transport_projection(), ReducerHealthClass, clear_health_for_tests() (+35 more)
 
 ### Community 159 - "Community 159"
-Cohesion: 0.08
-Nodes (42): bus_consumer_readiness_v1(), check_bus_consumer_readiness(), check_heartbeat_fresh(), _decode_redis_val(), _heartbeat_matches_service(), _parse_last_seen_ts(), Any, datetime (+34 more)
+Cohesion: 0.07
+Nodes (26): api_catchup(), api_catchup_stream(), api_current(), api_current_stream(), api_metrics(), api_recent(), api_recent_stream(), _corr_uuid() (+18 more)
 
 ### Community 160 - "Community 160"
-Cohesion: 0.09
-Nodes (41): ConceptCluster, ConceptItem, ConceptProfile, BaseModel, datetime, Canonical schemas for Concept Induction artifacts., Versioned snapshot of induced concepts., A single induced concept or motif. (+33 more)
+Cohesion: 0.08
+Nodes (48): binary_score_from_top_logprobs(), build_classify_prompt(), parse_classify_lines(), Any, appraisal_confidence(), binary_margin(), build_change_only_prompt(), build_turn_change_prompt() (+40 more)
 
 ### Community 161 - "Community 161"
-Cohesion: 0.15
-Nodes (44): ArticleClusterV1, ClaimRecordV1, EntityRecordV1, EventRecordV1, BaseModel, SituationChangeV1, SituationEvidenceV1, SituationObservationV1 (+36 more)
+Cohesion: 0.08
+Nodes (50): RouteName, _apply_llm_route(), _call_cortex(), _extract_attempt_diagnostics(), _normalize_route(), Any, BaseException, Try grounded Quick, then Brain on hard failures; RDF-validate without persisting (+42 more)
 
 ### Community 162 - "Community 162"
-Cohesion: 0.06
-Nodes (33): control_surface_store(), get_chat_reflective_lane_threshold(), inspect_chat_reflective_lane_threshold(), Any, datetime, _resolve_postgres_url(), _resolve_sqlite_path(), RuntimeControlSurfaceStore (+25 more)
+Cohesion: 0.05
+Nodes (40): FileResponse, index(), ConnectionManager, Any, WebSocket, _cfg(), _debug_token_equal(), get_ui() (+32 more)
 
 ### Community 163 - "Community 163"
-Cohesion: 0.09
-Nodes (50): _available_route_keys(), _backend_supports_anthropic_messages(), build_models_list_payload(), _extract_correlation_id(), _forwardable_request_headers(), _forwardable_response_headers(), handle_messages_get(), handle_messages_head() (+42 more)
+Cohesion: 0.10
+Nodes (52): asList(), asObject(), attach(), buildExecutionStepsPanel(), cleanText(), collectBase(), compactProjectionItems(), comparisonColumn() (+44 more)
 
 ### Community 164 - "Community 164"
-Cohesion: 0.10
-Nodes (41): emit_active_packet_retrieved(), emit_crystallization_lifecycle(), _source(), auto_activate(), GovernorPathRequired, datetime, ValueError, _utc_now() (+33 more)
+Cohesion: 0.08
+Nodes (42): _build_ollama_payload(), _common_http_client(), _debug_len(), _debug_snippet(), _debug_think_capture(), _execute_llamacpp_native_completion(), _execute_ollama_chat(), _extract_reasoning_from_openai_response() (+34 more)
 
 ### Community 165 - "Community 165"
-Cohesion: 0.10
-Nodes (40): SocialGifUsageStateV1, _artifact_boundary_active(), _boolish(), _caution_context_present(), _chaotic_room(), _contested_claims(), evaluate_social_gif_policy(), _freshness_state() (+32 more)
+Cohesion: 0.09
+Nodes (44): _check(), check_resonance_worsening(), HealthCheck, _is_worsening(), Severity, Phase H+ — resonance health monitor.  The resonance tripwire (`orion.reverie.res, Edge-triggered per-theme resonance monitor.      Tracks every theme currently be, Reconstruct tracked themes (and their known-unhealthy state) from         orion- (+36 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.08
-Nodes (40): ConceptInductionTrigger, WorkerLivenessState, drive_state_from_values(), DriveEngine, DriveMathConfig, datetime, DriveStateV1, TensionEventV1 (+32 more)
+Cohesion: 0.10
+Nodes (47): config/autonomy/signal_drive_map.yaml, _cold(), main(), AutonomyEvidenceRefV1, AutonomyStateV2 evidence pipeline (chat, env-gated), Orion Autonomy README, _as_utc(), AutonomyReducerInputV1 (+39 more)
 
 ### Community 167 - "Community 167"
-Cohesion: 0.07
-Nodes (41): Popen, asterisk_cmd(), bootstrap_asterisk_and_cisco(), CompletedProcess, Path, Settings, Ensure Asterisk dirs exist, write core configs and SEP<MAC>.cnf.xml (only if mis, Start in.tftpd (tftpd-hpa) serving /tftpboot. (+33 more)
+Cohesion: 0.10
+Nodes (44): Shared Mind contract constants (no runtime / IO)., MindHandoffBriefV1, MindRunResultV1, MindRunArtifactV1, BaseModel, Bus + Postgres artifact for a completed Mind run (producer: orch, consumer: sql-, build_synthetic_mind_http_failure_result(), merge_mind_brief_into_plan_metadata() (+36 more)
 
 ### Community 168 - "Community 168"
-Cohesion: 0.10
-Nodes (42): _check(), check_resonance_worsening(), HealthCheck, _is_worsening(), Severity, Phase H+ — resonance health monitor.  The resonance tripwire (`orion.reverie.res, Edge-triggered per-theme resonance monitor.      Tracks every theme currently be, Reconstruct tracked themes (and their known-unhealthy state) from         orion- (+34 more)
+Cohesion: 0.11
+Nodes (48): EffectKind, _agent_chain_delegate_status(), _agent_chain_delegate_summary(), _agent_chain_failure_detail(), _agent_chain_failure_signals(), _agent_delegate_payload(), _agent_delegate_service_key(), _bound_capability_payload() (+40 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.10
-Nodes (40): IntentKind, IntentSource, ArbiterDecision, ArbiterState, decide(), datetime, Pure arbitration. Mutates only ``state.deliberate_hold_until`` on accept., DriveMapThresholds (+32 more)
+Cohesion: 0.08
+Nodes (41): bus_consumer_readiness_v1(), check_bus_consumer_readiness(), check_heartbeat_fresh(), _decode_redis_val(), _heartbeat_matches_service(), _parse_last_seen_ts(), Any, datetime (+33 more)
 
 ### Community 170 - "Community 170"
-Cohesion: 0.07
-Nodes (37): check_field_coherence(), Return 0-1 incoherence score for one node vector., Return per-node incoherence scores (0-1). Empty if no suspicion found., _rule_suspicion(), FieldChannelCorpusRowV1, BaseModel, Field-channel corpus row schema -- Item 1 v2 of docs/superpowers/specs/ 2026-07-, One per-tick training-data row of raw `FieldStateV1` channel     pressures, stra (+29 more)
+Cohesion: 0.08
+Nodes (45): compact_schema_for_llamacpp(), compact_suggest_draft_json_schema(), Any, JSON Schema contracts for memory-graph suggest (llama.cpp-friendly compact form), Full Pydantic JSON schema (may include $defs / $ref)., Strip Pydantic noise; keep inline object shapes only., Stage-1 schema: top-level keys + array item shapes without $ref/oneOf., suggest_draft_json_schema() (+37 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.10
-Nodes (43): Evidence-derived feature vector scored by the salience combiner.      Replaces t, SalienceFeaturesV1, bounded(), compute_features(), compute_salience(), default_combiner(), _habituation(), LinearSalienceCombiner (+35 more)
+Cohesion: 0.12
+Nodes (48): AgendaContextV1, EnvironmentContextV1, LabContextV1, PresenceCompanionV1, BaseModel, RequestorContextV1, SituationAffordanceV1, SituationDiagnosticsV1 (+40 more)
 
 ### Community 172 - "Community 172"
-Cohesion: 0.10
-Nodes (30): _canonical_phi_hint(), _coerce_change_type_payload(), CollapseMirrorConstraints, CollapseMirrorEntryV2, CollapseMirrorNumericSisters, CollapseMirrorStateSnapshot, CollapseMirrorWhatChanged, _extract_first_json_object() (+22 more)
+Cohesion: 0.09
+Nodes (48): collect_topical_spine_warnings(), _draft_utterance_corpus(), _entity_surface_forms_lower(), _entity_tokens(), extract_selected_role_evidence(), _has_assistant_role_entity(), _has_role_entity(), _has_topical_entity() (+40 more)
 
 ### Community 173 - "Community 173"
-Cohesion: 0.07
-Nodes (23): EmbodimentWorker, datetime, Fail-open, cached walkable set from the AI Town map. Fetched once., Re-read AI Town ids from the mounted FCC env each perception tick., Serialized actuate+publish. The lock keeps the cooldown check and the         ``, Gated, deduped, fail-open journal emit for salient town episodes.          Off u, Best-effort human name of Orion's conversation partner.          Prefers an expl, Derive salient episodes from a perception tick and journal them.          Two si (+15 more)
+Cohesion: 0.12
+Nodes (39): OpenLoopV1, Recorded when top-down goal bias makes a lower-bottom-up loop win — an     inspe, VoluntaryOverrideV1, _candidates(), _override_rate(), Eval: voluntary attention override dynamics (spec Step 2).  Replays synthetic ca, run(), get_active_goal() (+31 more)
 
 ### Community 174 - "Community 174"
-Cohesion: 0.07
-Nodes (44): orion/bus/channels.yaml (referenced), Orion Knowledge Forge Agent Contract, Knowledge Forge Compile Prompt, Knowledge Forge Ingest Prompt, Typed Claim Relations Vocabulary (supports/contradicts/supersedes/depends_on/implements/tested_by/blocked_by/motivated_by), claim:orion:substrate-telemetry:0001 — orion-substrate-telemetry persists tier outcomes, claim:orion:substrate-telemetry:0002 — orion-cortex-orch optionally merges telemetry facet, Context Pack: orion-substrate-telemetry (Cursor, markdown) (+36 more)
+Cohesion: 0.10
+Nodes (44): Evidence-derived feature vector scored by the salience combiner.      Replaces t, SalienceFeaturesV1, bounded(), compute_features(), compute_salience(), default_combiner(), _habituation(), habituation_enabled() (+36 more)
 
 ### Community 175 - "Community 175"
 Cohesion: 0.07
-Nodes (32): is_stub_signal(), Shared stub-signal detection for Hub inspect cache and adapter tests (spec §5.9), True when the signal is a placeholder stub emission, not real organ truth., test_is_stub_signal_detects_placeholder_dimensions(), test_is_stub_signal_false_for_real_equilibrium(), api_observability_grafana_tempo_trace(), api_signals_trace(), Rolling trace cache by ``otel_trace_id`` (bounded by ``TRACE_CACHE_*`` settings) (+24 more)
+Nodes (33): is_stub_signal(), Shared stub-signal detection for Hub inspect cache and adapter tests (spec §5.9), True when the signal is a placeholder stub emission, not real organ truth., test_is_stub_signal_detects_placeholder_dimensions(), test_is_stub_signal_false_for_real_equilibrium(), api_observability_grafana_tempo_trace(), api_signals_trace(), Rolling trace cache by ``otel_trace_id`` (bounded by ``TRACE_CACHE_*`` settings) (+25 more)
 
 ### Community 176 - "Community 176"
-Cohesion: 0.07
-Nodes (37): PromptContext, PromptFactory, Any, Turns (AgentConfig + PromptContext) into a messages[] list.      This is where φ, PromptContext, PromptFactory, Any, Shared context for building prompts for any agent.     Keeps council logic DRY, (+29 more)
+Cohesion: 0.10
+Nodes (49): _available_route_keys(), _backend_supports_anthropic_messages(), build_models_list_payload(), _extract_correlation_id(), _forwardable_request_headers(), _forwardable_response_headers(), handle_messages_get(), handle_messages_head() (+41 more)
 
 ### Community 177 - "Community 177"
-Cohesion: 0.08
-Nodes (41): build_llama_server_cmd_and_env(), _ensure_draft_file(), _ensure_hf_gguf_file(), _ensure_mmproj_file(), _ensure_model_file(), _get_llama_server_build(), _get_supported_llama_server_flags(), main() (+33 more)
+Cohesion: 0.10
+Nodes (45): AbstractEventLoop, _diff_path_from_header(), _is_allowed(), _is_denied(), _normalize_rel_path(), patch_validate(), Path, repo_find_files() (+37 more)
 
 ### Community 178 - "Community 178"
+Cohesion: 0.11
+Nodes (33): build_context_pack_output_path(), _claim_included(), compile_context_pack_api_v1(), _dedupe_preserve_order(), ClaimV1, datetime, _relevant_decisions(), _slugify() (+25 more)
+
+### Community 179 - "Community 179"
+Cohesion: 0.09
+Nodes (37): validate_merged_stance_brief_optional(), _coerce_features(), _coerce_matter_item(), _coerce_matter_kind(), _coerce_recommended_effect(), _coerce_string_list(), _extract_selected_raw(), _float_field() (+29 more)
+
+### Community 180 - "Community 180"
+Cohesion: 0.07
+Nodes (23): control_surface_store(), inspect_chat_reflective_lane_threshold(), Any, datetime, _resolve_postgres_url(), _resolve_sqlite_path(), RuntimeControlSurfaceStore, set_chat_reflective_lane_threshold() (+15 more)
+
+### Community 181 - "Community 181"
+Cohesion: 0.09
+Nodes (45): configured_storage_paths(), ensure_storage_dirs(), _path_status(), persist_context_exec_run(), Any, Path, Best-effort conversion to a JSON-serializable structure.      Never raises; un-s, Persist an immutable forensic bundle for a completed context-exec run.      Retu (+37 more)
+
+### Community 182 - "Community 182"
+Cohesion: 0.07
+Nodes (44): orion/bus/channels.yaml (referenced), Orion Knowledge Forge Agent Contract, Knowledge Forge Compile Prompt, Knowledge Forge Ingest Prompt, Typed Claim Relations Vocabulary (supports/contradicts/supersedes/depends_on/implements/tested_by/blocked_by/motivated_by), claim:orion:substrate-telemetry:0001 — orion-substrate-telemetry persists tier outcomes, claim:orion:substrate-telemetry:0002 — orion-cortex-orch optionally merges telemetry facet, Context Pack: orion-substrate-telemetry (Cursor, markdown) (+36 more)
+
+### Community 183 - "Community 183"
+Cohesion: 0.07
+Nodes (45): test_prompt_render_ctx_preserves_journal_lane_bundle_by_default(), test_prompt_render_ctx_strips_debug_recall_bundle_only_when_opted_in(), compile_speech_contract(), _inject_prior_stance_to_inputs(), Deterministic regime-specific contract injected near TASK in chat_general.j2., Copy prior brief summary into stance inputs and expose it as a TOP-LEVEL ctx, _load_prior_stance_into_ctx(), _prior_stance_cache_get() (+37 more)
+
+### Community 184 - "Community 184"
+Cohesion: 0.10
+Nodes (39): auto_activate(), GovernorPathRequired, datetime, ValueError, _utc_now(), FormationPolicy, _has_identity_scope(), Enum (+31 more)
+
+### Community 185 - "Community 185"
+Cohesion: 0.09
+Nodes (44): action_usefulness_rate(), pressure_discharge_rate(), Phase H — efficacy metrics for the reverie/dream weave.  Pure, deterministic red, Fraction of chains where post-chain pressure fell below pre-chain pressure., Fraction of reverie-originated action outcomes judged useful (FeedbackFrameV1)., Before/after recall metrics around a compaction., Deterministic before/after recall reduction. Negative deltas are wins:     lower, recall_delta() (+36 more)
+
+### Community 186 - "Community 186"
+Cohesion: 0.08
+Nodes (25): OrionTissue, Any, ndarray, Path, Baseline-relative novelty using a rolling z-score of cosine distance.          n, Hybrid coherence:           - If an embedding is provided (spark_vector or featu, Main update cycle:           1. Update expectation (learning)           2. Evolv, Advance the tissue by one or more local-update steps.          v0 local rule: (+17 more)
+
+### Community 187 - "Community 187"
+Cohesion: 0.08
+Nodes (41): allocate_workspace(), _build_manifest(), _load_existing_workspace(), _materialize_repo(), Any, Path, Conservative copy from canonical repo into workspace/repo. Fail-open., Allocate a per-run workspace under workspaces/{run_id}/.      Idempotent for the (+33 more)
+
+### Community 188 - "Community 188"
+Cohesion: 0.07
+Nodes (39): collect_fragments(), Fragment, Fan-out collector.      This is the only place that knows which storage backends, RecallResult, End-to-end recall pipeline:      1. Collect candidate fragments from SQL and RDF, run_recall_pipeline(), _dedupe(), _mix_kinds() (+31 more)
+
+### Community 189 - "Community 189"
 Cohesion: 0.09
 Nodes (43): IterableDataset, iter_batches(), load_fineweb_edu_tokens(), load_gpt2_tokenizer(), _load_streaming_text_tokens(), load_text_file_tokens(), load_tinystories_tokens(), device (+35 more)
 
-### Community 179 - "Community 179"
-Cohesion: 0.05
-Nodes (48): Channel "orion:biometrics:cluster" (kind=telemetry, schema=BiometricsClusterV1) producers=[orion-biometrics-hub] consumers=[orion-state-service, orion-sql-writer], Channel "orion:biometrics:induction" (kind=telemetry, schema=BiometricsInductionV1) producers=[orion-biometrics, orion-biometrics-hub] consumers=[orion-state-service, orion-sql-writer], Channel "orion:biometrics:sample" (kind=telemetry, schema=BiometricsSampleV1) producers=[orion-biometrics] consumers=[orion-sql-writer, orion-landing-pad], Channel "orion:biometrics:summary" (kind=telemetry, schema=BiometricsSummaryV1) producers=[orion-biometrics, orion-biometrics-hub] consumers=[orion-state-service, orion-sql-writer, orion-landing-pad], Channel "orion:cognition:trace" (kind=event, schema=CognitionTracePayload) producers=[orion-cortex-exec] consumers=[orion-spark-introspector, orion-landing-pad, orion-bus-tap], Channel "orion:exec:result:PadRpc:*" (kind=result, schema=PadRpcResponseV1) producers=[orion-landing-pad] consumers=[orion-cortex-exec, *], Channel "orion:exec:result:StateService:*" (kind=result, schema=StateLatestReply) producers=[orion-state-service] consumers=[orion-cortex-exec, *], Channel "orion:pad:event" (kind=event, schema=PadEventV1) producers=[orion-landing-pad] consumers=[*] (+40 more)
-
-### Community 180 - "Community 180"
+### Community 190 - "Community 190"
 Cohesion: 0.06
 Nodes (48): Channel "orion:exec:request:VisionCouncilService" (kind=request, schema=VisionCouncilRequestPayload) producers=[orion-vision-window] consumers=[orion-vision-council], Channel "orion:exec:request:VisionHostService" (kind=request, schema=VisionTaskRequestPayload) producers=[orion-cortex-exec, orion-hub, orion-vision-host, orion-vision-frame-router] consumers=[orion-vision-host], Channel "orion:exec:request:VisionScribeService" (kind=request, schema=VisionScribeRequestPayload) producers=[orion-vision-council] consumers=[orion-vision-scribe], Channel "orion:exec:request:VisionWindowService" (kind=request, schema=VisionWindowRequestPayload) producers=[orion-vision-window] consumers=[orion-vision-council], Channel "orion:exec:result:VisionCouncilService" (kind=result, schema=VisionCouncilResultPayload) producers=[orion-vision-council] consumers=[orion-vision-window], Channel "orion:exec:result:VisionScribeService" (kind=result, schema=VisionScribeResultPayload) producers=[orion-vision-scribe] consumers=[orion-vision-council], Channel "orion:exec:result:VisionWindowService" (kind=result, schema=VisionWindowResultPayload) producers=[orion-vision-window] consumers=[orion-vision-council], Channel "orion:grammar:event" (kind=event, schema=GrammarEventV1) producers=[orion-vision-retina, orion-hub, orion-vision-edge, orion-vision-window, orion-biometrics, orion-cortex-exec, orion-bus, orion-harness-governor, orion-cortex-orch] consumers=[orion-sql-writer] (+40 more)
 
-### Community 181 - "Community 181"
-Cohesion: 0.13
-Nodes (45): AgendaContextV1, EnvironmentContextV1, LabContextV1, PresenceCompanionV1, BaseModel, RequestorContextV1, SituationAffordanceV1, SituationDiagnosticsV1 (+37 more)
-
-### Community 182 - "Community 182"
-Cohesion: 0.08
-Nodes (30): BaseModel, Payload for Speech-to-Text (ASR) request.     Kind: stt.transcribe.request, Payload for TTS synthesis request.     Kind: tts.synthesize.request, STTRequestPayload, STTResultPayload, TTSRequestPayload, TTSResultPayload, Sends a TTSRequestPayload to the TTS Service and waits for a TTSResultPayload. (+22 more)
-
-### Community 183 - "Community 183"
-Cohesion: 0.13
-Nodes (42): main(), extract_from_python(), extract_from_yaml(), _extract_str(), main(), merge_inv(), Any, AST (+34 more)
-
-### Community 184 - "Community 184"
-Cohesion: 0.08
-Nodes (28): build_rollup_from_redis_snapshot(), _fetch_redis_snapshot(), load_channel_catalog_names(), ObserverRollup, Any, datetime, Path, Settings (+20 more)
-
-### Community 185 - "Community 185"
-Cohesion: 0.08
-Nodes (38): apply_grammar_events_retention(), build_grammar_truth_snapshot(), _fallback_counts(), _grammar_index_valid(), GrammarRetentionState, _latest_events_by_source(), Any, Runtime snapshot and bounded retention for grammar production observe mode. (+30 more)
-
-### Community 186 - "Community 186"
-Cohesion: 0.13
-Nodes (31): MentorConstraintsV1, MentorContextSliceV1, MentorGatewayResultV1, MentorProposalItemV1, MentorRequestV1, MentorResponseV1, BaseModel, datetime (+23 more)
-
-### Community 187 - "Community 187"
-Cohesion: 0.11
-Nodes (40): build_execution_dispatch_frame(), build_unevaluable_execution_dispatch_frame(), _candidate_status_for_mode(), _is_hard_blocked(), _proposal_by_id(), datetime, A policy frame whose proposal or self-state could not be loaded still     needs, _resolve_dispatch_mode() (+32 more)
-
-### Community 188 - "Community 188"
-Cohesion: 0.11
-Nodes (41): build_conversation_envelope(), build_envelopes_for_turn(), build_example_envelope(), build_import_run_envelope(), build_import_run_id(), build_message_envelope(), ChatMessage, ChatTurn (+33 more)
-
-### Community 189 - "Community 189"
-Cohesion: 0.08
-Nodes (41): compact_schema_for_llamacpp(), compact_suggest_draft_json_schema(), Any, JSON Schema contracts for memory-graph suggest (llama.cpp-friendly compact form), Full Pydantic JSON schema (may include $defs / $ref)., Strip Pydantic noise; keep inline object shapes only., Stage-1 schema: top-level keys + array item shapes without $ref/oneOf., suggest_draft_json_schema() (+33 more)
-
-### Community 190 - "Community 190"
-Cohesion: 0.10
-Nodes (45): collect_topical_spine_warnings(), _draft_utterance_corpus(), _entity_surface_forms_lower(), _entity_tokens(), extract_selected_role_evidence(), _has_assistant_role_entity(), _has_role_entity(), _has_topical_entity() (+37 more)
-
 ### Community 191 - "Community 191"
-Cohesion: 0.05
-Nodes (46): Field Attention Policy v1, Signal Kind: biometrics_state, Signal Kind: chat_reasoning_quality, Signal Kind: chat_social_hazard, Signal Kind: failure_event, Signal Kind: mesh_health, Signal to Drive Map v1, Signal Kind: spark_signal (+38 more)
+Cohesion: 0.08
+Nodes (40): enrich_projection_context(), identity_kernel_with_fallbacks(), inject_identity_context_for_projection(), _orion_state_from_ctx(), Any, Shared projection-context enrichment for Orch Mind preflight and Exec parity., Apply Exec-parity ctx keys needed by substrate producers before projection build, Compact input summary for Orch vs Exec projection parity comparison. (+32 more)
 
 ### Community 192 - "Bus Channels: Vision Exec Request/Result"
 Cohesion: 0.09
-Nodes (41): binary_score_from_top_logprobs(), build_classify_prompt(), parse_classify_lines(), Any, appraisal_confidence(), binary_margin(), build_change_only_prompt(), build_turn_change_prompt() (+33 more)
+Nodes (29): _canonical_phi_hint(), _coerce_change_type_payload(), CollapseMirrorConstraints, CollapseMirrorEntryV1, CollapseMirrorNumericSisters, CollapseMirrorStateSnapshot, CollapseMirrorWhatChanged, _extract_first_json_object() (+21 more)
 
 ### Community 193 - "Community 193"
-Cohesion: 0.08
-Nodes (39): AgentChainRequest, AgentChainResult, Primary entry point for the Agent Chain service., Response from Agent Chain., agent_chain_request_to_context_exec(), context_exec_run_to_agent_chain_result(), _parse_answer_contract(), Any (+31 more)
+Cohesion: 0.10
+Nodes (37): BaseModel, TransportBusProjectionV1, TransportBusStateV1, Deterministic substrate receipt and state-delta identifiers., _sorted_join(), stable_delta_id(), stable_receipt_id(), _boolish() (+29 more)
 
 ### Community 194 - "Community 194"
-Cohesion: 0.14
-Nodes (36): OpenLoopV1, BaseModel, Recorded when top-down goal bias makes a lower-bottom-up loop win — an     inspe, VoluntaryOverrideV1, _candidates(), _override_rate(), Eval: voluntary attention override dynamics (spec Step 2).  Replays synthetic ca, run() (+28 more)
+Cohesion: 0.09
+Nodes (27): CognitiveUnificationLayer, Warm/cold hybrid coordinator for all substrate producer lanes.      Usage::, ProducerEntryV1, ProducerRegistryV1, Descriptor for a single data producer wired into the unification layer., Ordered list of producer entries; constructed once at process startup., Producers that are always-fresh ctx-based (pull_on_cold=False, snapshot_ephemera, autonomy_adapter() (+19 more)
 
 ### Community 195 - "Community 195"
-Cohesion: 0.10
-Nodes (35): _attention_broadcast_section(), _compaction_delta_section(), _compaction_queue_section(), _curiosity_section(), _engine(), _hub_presence_section(), _iso(), _latest_row() (+27 more)
+Cohesion: 0.13
+Nodes (42): main(), extract_from_python(), extract_from_yaml(), _extract_str(), main(), merge_inv(), Any, AST (+34 more)
 
 ### Community 196 - "Community 196"
 Cohesion: 0.08
-Nodes (23): create_frame_source(), FolderFrameSource, FrameReadResult, FrameSource, MockFrameSource, BaseModel, Protocol, Test/dev: random sample from folder like legacy mock. (+15 more)
+Nodes (38): apply_grammar_events_retention(), build_grammar_truth_snapshot(), _fallback_counts(), _grammar_index_valid(), GrammarRetentionState, _latest_events_by_source(), Any, Runtime snapshot and bounded retention for grammar production observe mode. (+30 more)
 
 ### Community 197 - "Community 197"
-Cohesion: 0.11
-Nodes (32): NotificationReceiptDB, Path, UUID, AgentTraceSummaryV1, ChatAttentionState, ChatMessageNotification, ChatMessageState, DeliveryAttempt (+24 more)
+Cohesion: 0.08
+Nodes (36): OrionCodec, Any, BaseModel, Bulletproof encode/decode layer.      Goals:     - Never leak raw JSON dicts int, _parse_ts(), datetime, Exception, Logger (+28 more)
 
 ### Community 198 - "Community 198"
 Cohesion: 0.11
-Nodes (35): MetabolismResultV1, Immutable typed lookup of dimension rules per signal_kind., SignalDriveMap, _build_tension(), chat_evidence_to_tension(), _clamp01(), equilibrium_to_tension(), failure_to_tension() (+27 more)
+Nodes (41): build_conversation_envelope(), build_envelopes_for_turn(), build_example_envelope(), build_import_run_envelope(), build_import_run_id(), build_message_envelope(), ChatMessage, ChatTurn (+33 more)
 
 ### Community 199 - "Community 199"
-Cohesion: 0.06
-Nodes (45): Channel "orion:autonomy:goal:planned" (kind=event, schema=AutonomyGoalPlannedV1) producers=[orion-cortex-exec] consumers=[orion-cortex-exec, *], Channel "orion:calibration:profile:audit" (kind=event, schema=CalibrationProfileAuditV1) producers=[orion-cortex-exec] consumers=[orion-sql-writer], Channel "orion:cognition:reasoning_call" (kind=telemetry, schema=ReasoningCallV1) producers=[orion-cortex-exec] consumers=[orion-thought], Channel "orion:collapse:enrich" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-cortex-exec] consumers=[orion-collapse-mirror], Channel "orion:collapse:events" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-collapse-mirror, orion-cortex-exec] consumers=[orion-timeline, orion-athena-spark-introspector], Channel "orion:collapse:intake" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-cortex-exec, orion-collapse-mirror] consumers=[orion-collapse-mirror], Channel "orion:collapse:scored" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-cortex-exec] consumers=[orion-collapse-mirror], Channel "orion:collapse:sql-write" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-collapse-mirror] consumers=[orion-sql-writer] (+37 more)
+Cohesion: 0.10
+Nodes (32): PhiIntrinsicRewardV1, _Bus, _read_jsonl(), test_mood_arc_corpus_appends_even_when_pub_bus_disabled(), test_mood_arc_corpus_appends_on_heuristic_source(), test_mood_arc_corpus_appends_on_proxy_source(), test_mood_arc_corpus_construction_failure_does_not_abort_tick(), test_mood_arc_corpus_disabled_when_path_empty() (+24 more)
 
 ### Community 200 - "Community 200"
-Cohesion: 0.08
-Nodes (28): FeedbackFrameV1, OutcomeObservationV1, BaseModel, FeedbackRuntimeStore, datetime, _engine(), feedback_latest(), _load_latest_feedback_frame() (+20 more)
+Cohesion: 0.10
+Nodes (40): evidence_for_dimension(), _provenance_label(), Friendlier evidence label: strip the "node:" prefix (e.g. "node:atlas"     -> "a, Phase 3 (2026-07-12): fold node/capability provenance into the     free-text `re, _reason_for_evidence(), load_self_state_policy(), BaseModel, Path (+32 more)
 
 ### Community 201 - "Community 201"
-Cohesion: 0.08
-Nodes (28): Shared contract for JSONL corpus-sink rotation naming and file resolution.  Sing, InnerStateCorpusSink, BaseModel, Generic append-only JSONL corpus sink, any pydantic BaseModel payload.  Original, BaseModel, Unit tests for InnerStateCorpusSink's size-based rotation + retention pruning., _read_jsonl(), test_append_continues_working_after_rotation() (+20 more)
+Cohesion: 0.09
+Nodes (42): ChatRole, ChatResponseFeedbackEnvelope, api_chat(), api_chat_response_feedback(), api_chat_turn_cancel(), api_session(), api_workflow_schedule_action(), api_workflow_schedule_history() (+34 more)
 
 ### Community 202 - "Community 202"
-Cohesion: 0.07
-Nodes (35): DbRefractoryStore, InMemoryRefractoryStore, _maybe_emit_resonance_alert(), _now(), Any, datetime, Protocol, Phase C — reverie chain (a train of thought).  Successive reverie steps that cli (+27 more)
+Cohesion: 0.11
+Nodes (40): CollapseMirrorEntry, Direct request to write raw triples or triggers to the RDF writer.     Used for, RdfWriteRequest, MetaTagsPayload, Standard schema for enrichment tags emitted by analysis services.     Conforms t, main(), test_builder(), test_schemas() (+32 more)
 
 ### Community 203 - "Community 203"
-Cohesion: 0.14
-Nodes (43): pg_conn(), connection, count_segments(), create_conversation_override(), create_dataset(), create_event(), create_model(), create_model_event() (+35 more)
+Cohesion: 0.05
+Nodes (46): Field Attention Policy v1, Signal Kind: biometrics_state, Signal Kind: chat_reasoning_quality, Signal Kind: chat_social_hazard, Signal Kind: failure_event, Signal Kind: mesh_health, Signal to Drive Map v1, Signal Kind: spark_signal (+38 more)
 
 ### Community 204 - "Community 204"
-Cohesion: 0.11
-Nodes (39): outcome_from_followup(), Return the followup whose section matches the first gap-section label the     re, Rebuild an ActionOutcomeRefV1 from a world-pulse curiosity followup so the     r, select_reusable_followup(), iter_gap_section_labels(), Yield normalized section labels from `section:` focal refs across     world_cove, _followup(), _gap_signal() (+31 more)
+Cohesion: 0.12
+Nodes (40): SelfStudyConsumerPolicyDecisionV1, SelfStudyHarnessResultV1, SelfStudyHarnessScenarioResultV1, SelfStudyHarnessSoakResultV1, SelfStudyHarnessSummaryV1, SelfStudyRetrieveResultV1, RetrieveRunner, main() (+32 more)
 
 ### Community 205 - "Community 205"
-Cohesion: 0.09
-Nodes (33): call_with_fuseki_retry(), fuseki_http_error_body(), fuseki_http_retry_attempts(), fuseki_http_retry_base_delay_sec(), is_fuseki_lock_exhaustion(), is_fuseki_retryable_http_error(), Response, T (+25 more)
+Cohesion: 0.13
+Nodes (21): apply_calibration_adoption(), compare_endogenous_runtime_profile_outcomes(), consume_endogenous_runtime_for_reflective_review(), EndogenousRuntimeAdoptionService, inspect_calibration_profile_audit(), inspect_calibration_profile_audit_with_source(), inspect_calibration_profile_state_with_source(), inspect_calibration_profiles() (+13 more)
 
 ### Community 206 - "Community 206"
 Cohesion: 0.08
-Nodes (43): _coerce(), _make_prov(), map_curiosity_ctx_to_substrate(), Any, Map ``ctx['curiosity_signals']`` → one ``curiosity:unresolved_gaps`` node., Coerce raw input to list of FrontierInvocationSignalV1.      Accepts:     - list, _make_signal(), Tests for curiosity_ctx adapter. (+35 more)
+Nodes (23): create_frame_source(), FolderFrameSource, FrameReadResult, FrameSource, MockFrameSource, BaseModel, Protocol, Test/dev: random sample from folder like legacy mock. (+15 more)
 
 ### Community 207 - "Community 207"
-Cohesion: 0.09
-Nodes (38): _admin_key(), AitownClientError, _base_url(), convex_mutation(), convex_query(), convex_request(), _default_player_id(), fetch_version() (+30 more)
+Cohesion: 0.06
+Nodes (45): Channel "orion:autonomy:action:outcome" (kind=event, schema=ActionOutcomeEmitV1) producers=[orion-spark-concept-induction, orion-execution-dispatch-runtime] consumers=[orion-sql-writer, *], Channel "orion:cortex:exec:request" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch, orion-thought] consumers=[orion-cortex-exec], Channel "orion:cortex:exec:request:background" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch, orion-actions, orion-harness-governor, orion-execution-dispatch-runtime] consumers=[orion-cortex-exec], Channel "orion:cortex:exec:request:chat" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch] consumers=[orion-cortex-exec], Channel "orion:cortex:exec:request:spark" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch] consumers=[orion-cortex-exec], Channel "orion:cortex:gateway:request" (kind=request, schema=CortexChatRequest) producers=[orion-hub] consumers=[orion-cortex-gateway], Channel "orion:cortex:gateway:result:*" (kind=result, schema=CortexChatResult) producers=[orion-cortex-gateway] consumers=[orion-hub], Channel "orion:cortex:request" (kind=request, schema=CortexClientRequest) producers=[orion-hub, orion-cortex-gateway, orion-actions, orion-memory-consolidation] consumers=[orion-cortex-orch] (+37 more)
 
 ### Community 208 - "Community 208"
-Cohesion: 0.08
-Nodes (30): AuditFn, DispatchJournalFn, WorldPulseRunResultV1, _trigger_world_pulse_run(), Config, get_settings(), BaseSettings, Settings (+22 more)
+Cohesion: 0.06
+Nodes (45): Channel "orion:autonomy:goal:planned" (kind=event, schema=AutonomyGoalPlannedV1) producers=[orion-cortex-exec] consumers=[orion-cortex-exec, *], Channel "orion:calibration:profile:audit" (kind=event, schema=CalibrationProfileAuditV1) producers=[orion-cortex-exec] consumers=[orion-sql-writer], Channel "orion:cognition:reasoning_call" (kind=telemetry, schema=ReasoningCallV1) producers=[orion-cortex-exec] consumers=[orion-thought], Channel "orion:collapse:enrich" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-cortex-exec] consumers=[orion-collapse-mirror], Channel "orion:collapse:events" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-collapse-mirror, orion-cortex-exec] consumers=[orion-timeline, orion-athena-spark-introspector], Channel "orion:collapse:intake" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-cortex-exec, orion-collapse-mirror] consumers=[orion-collapse-mirror], Channel "orion:collapse:scored" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-cortex-exec] consumers=[orion-collapse-mirror], Channel "orion:collapse:sql-write" (kind=event, schema=CollapseMirrorEntryV2) producers=[orion-collapse-mirror] consumers=[orion-sql-writer] (+37 more)
 
 ### Community 209 - "Community 209"
-Cohesion: 0.14
-Nodes (26): EndogenousWorkflowTypeV1, EndogenousHistoryEntryV1, InMemoryTriggerHistoryStore, datetime, Deterministic cooldown/debounce history for endogenous workflow triggers., EndogenousTriggerEvaluator, Deterministic pressure evaluator that selects bounded workflow triggers., EndogenousWorkflowOrchestrator (+18 more)
+Cohesion: 0.08
+Nodes (35): Return a copy with the hollow flag + reason stamped from the guard.          `ex, Unprompted narration of the current winning coalition.      Grounding is the *sa, The set of coalition ids that legitimately anchor this thought., True if this thought is empty-shell cognition (§0A).          Rejects three fail, SpontaneousThoughtV1, _is_hollow(), _is_meta_mechanism_narration(), Eval: the un-anchored hollow-text guard for spontaneous thoughts.  Phase A's rea (+27 more)
 
 ### Community 210 - "Community 210"
-Cohesion: 0.10
-Nodes (38): Finding, attach_findings_to_debug(), merge_findings_bundle_dicts(), Any, Synthesize a serializable FindingsBundle from planner trace + contract (Phase 2, Merge two FindingsBundle-shaped dicts (exec supervisor aggregation)., synthesize_findings_bundle(), _trace_has_repo_evidence() (+30 more)
+Cohesion: 0.08
+Nodes (34): FieldChannelCorpusRowV1, BaseModel, Field-channel corpus row schema -- Item 1 v2 of docs/superpowers/specs/ 2026-07-, One per-tick training-data row of raw `FieldStateV1` channel     pressures, stra, Cadence, CompositionStatus, duplicates(), get() (+26 more)
 
 ### Community 211 - "Community 211"
-Cohesion: 0.09
-Nodes (35): _Baseline, DeviationGate, Deviation gate: turn a stream of per-dimension observations into impulses that f, Adaptive per-dimension deviation detector.      Args:         alpha: EWMA weight, Return the deviation impulse (>=0) for this observation, then fold it         in, _gate(), Task 2: deviation gate fires on change, not presence., A steady stream (the scene_state flood) mints ~0 after warm-up. (+27 more)
+Cohesion: 0.08
+Nodes (33): _cards_enabled(), _close(), CloseRequest, dismiss_loop(), list_loops(), publish_loop_outcome(), BaseModel, Operator Pending Attention API — cognitive-loop rows + Resolve/Dismiss.  Flag-ga (+25 more)
 
 ### Community 212 - "Community 212"
-Cohesion: 0.12
-Nodes (36): _gap_strength(), _gaps_from_rollups(), _load_recommended_sections(), metabolize_substrate_signals(), _signal_from_gap(), _tension_from_gap(), _attention_loop_candidates(), _clamp01() (+28 more)
+Cohesion: 0.14
+Nodes (43): pg_conn(), connection, count_segments(), create_conversation_override(), create_dataset(), create_event(), create_model(), create_model_event() (+35 more)
 
 ### Community 213 - "Community 213"
-Cohesion: 0.06
-Nodes (43): Channel "orion:autonomy:action:outcome" (kind=event, schema=ActionOutcomeEmitV1) producers=[orion-spark-concept-induction, orion-execution-dispatch-runtime] consumers=[orion-sql-writer, *], Channel "orion:cortex:exec:request" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch, orion-thought] consumers=[orion-cortex-exec], Channel "orion:cortex:exec:request:background" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch, orion-actions, orion-harness-governor, orion-execution-dispatch-runtime] consumers=[orion-cortex-exec], Channel "orion:cortex:exec:request:chat" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch] consumers=[orion-cortex-exec], Channel "orion:cortex:exec:request:spark" (kind=request, schema=CortexExecRequestPayload) producers=[orion-cortex-orch] consumers=[orion-cortex-exec], Channel "orion:cortex:gateway:request" (kind=request, schema=CortexChatRequest) producers=[orion-hub] consumers=[orion-cortex-gateway], Channel "orion:cortex:gateway:result:*" (kind=result, schema=CortexChatResult) producers=[orion-cortex-gateway] consumers=[orion-hub], Channel "orion:cortex:request" (kind=request, schema=CortexClientRequest) producers=[orion-hub, orion-cortex-gateway, orion-actions, orion-memory-consolidation] consumers=[orion-cortex-orch] (+35 more)
+Cohesion: 0.13
+Nodes (42): MemoryCardStatus, EvidenceItemV1, TimeHorizonV1, DispositionDraft, EdgeDraft, EntityDraft, MemoryGraphSubschemaV1, ParticipantDraft (+34 more)
 
 ### Community 214 - "Community 214"
 Cohesion: 0.11
-Nodes (37): _coerce_float(), compute_deltas_from_turn_effect(), _delta_block(), evaluate_turn_effect_alert(), _evidence_block(), Any, should_emit_turn_effect_alert(), summarize_turn_effect() (+29 more)
+Nodes (41): build_attention_frame(), datetime, stable_frame_id(), _attention_target_summary(), build_self_state(), _emit_summary_labels(), datetime, Structured summary of one FieldAttentionTargetV1 (2026-07-12, inner-state     un (+33 more)
 
 ### Community 215 - "Community 215"
-Cohesion: 0.10
-Nodes (34): VisionEventBundleItem, build_intake_envelope(), build_rdf_write_request(), build_smoke_bundle_item(), build_vision_event_payload(), coerce_sql_row(), _collect_envelopes(), expected_sql_row_fields() (+26 more)
+Cohesion: 0.09
+Nodes (38): _admin_key(), AitownClientError, _base_url(), convex_mutation(), convex_query(), convex_request(), _default_player_id(), fetch_version() (+30 more)
 
 ### Community 216 - "Community 216"
-Cohesion: 0.08
-Nodes (27): check_token(), create_app(), create_service(), get_service(), get_settings(), heartbeat_loop(), psu_cycle(), psu_off() (+19 more)
+Cohesion: 0.11
+Nodes (30): _clamp01(), OriginationConfig, OriginationEngine, datetime, Deterministic endogenous "spontaneous want" generator.  STATUS (2026-07-08): NO-, Push a bounded summary of this self-state into the ring (cap cfg.window)., Compute D,W,A -> P over the current window and fire iff:          exogenous_tens, {'drift','dwell','agency','P','fired'} from the last maybe_originate call. (+22 more)
 
 ### Community 217 - "Community 217"
-Cohesion: 0.07
-Nodes (30): mock_pool(), test_ingest_episode_returns_ids(), _edge_data_calls(), _entity_data_calls(), _FakeEntityEdge, _FakeEntityNode, _patch_graphiti_node_edge_modules(), Stands in for graphiti_core.nodes.EntityNode in this dev venv (graphiti-core isn (+22 more)
+Cohesion: 0.12
+Nodes (36): build_execution_dispatch_frame(), build_unevaluable_execution_dispatch_frame(), _candidate_status_for_mode(), _is_hard_blocked(), _proposal_by_id(), datetime, A policy frame whose proposal or self-state could not be loaded still     needs, _resolve_dispatch_mode() (+28 more)
 
 ### Community 218 - "Community 218"
-Cohesion: 0.08
-Nodes (29): IdeationRunRequestV1, IdeationRunResultV1, build_user_prompt(), _collect_snippets(), detect_monorepo_root(), _is_under_allowed_roots(), Path, _read_snippet() (+21 more)
+Cohesion: 0.09
+Nodes (37): append_github_mcp_harness_brief(), default_harness_workspace(), github_mcp_brief_lines(), github_mcp_repo_brief_line(), harness_mcp_enabled(), parse_github_remote_url(), Path, Resolve GitHub owner/repo for FCC MCP operator briefs. (+29 more)
 
 ### Community 219 - "Community 219"
-Cohesion: 0.12
-Nodes (40): maybe_send_email(), should_send_email(), attention_ack(), attention_request(), _attention_request_to_notification(), _attention_request_to_state(), chat_message(), chat_message_receipt() (+32 more)
+Cohesion: 0.09
+Nodes (34): BaseModel, Reasoning telemetry — per-call cognition metadata + windowed activity.  `Reasoni, Rolling-window aggregate of ReasoningCallV1, read by φ (spark-introspector)., ReasoningActivityV1, _decode_reasoning_call(), _emitted_at(), Any, datetime (+26 more)
 
 ### Community 220 - "Community 220"
-Cohesion: 0.13
-Nodes (37): NotificationAttemptDB, NotificationRequestDB, Base, build_digest_content(), DigestSummary, DriftItem, _extract_drift_score(), _extract_topic_items() (+29 more)
+Cohesion: 0.08
+Nodes (42): _coerce(), map_curiosity_ctx_to_substrate(), Any, Map ``ctx['curiosity_signals']`` → one ``curiosity:unresolved_gaps`` node., Coerce raw input to list of FrontierInvocationSignalV1.      Accepts:     - list, _make_signal(), Tests for curiosity_ctx adapter., emitted node has salience exactly 0.4 (verify it, don't relax). (+34 more)
 
 ### Community 221 - "Community 221"
 Cohesion: 0.09
-Nodes (30): AlertPayload, Detection, BaseModel, Detection coming from the vision edge service.      - kind: "face", "motion", "y, Raw event from vision edge, as seen on orion:vision:edge:raw., Simple persistent security state., Summary of a logical 'visit' (a contiguous episode of humans present).     v1 is, What we publish as an alert + optionally email. (+22 more)
+Nodes (27): InnerStateCorpusSink, BaseModel, Generic append-only JSONL corpus sink, any pydantic BaseModel payload.  Original, BaseModel, Unit tests for InnerStateCorpusSink's size-based rotation + retention pruning., _read_jsonl(), test_append_continues_working_after_rotation(), test_disabled_sink_never_rotates() (+19 more)
 
 ### Community 222 - "Community 222"
+Cohesion: 0.09
+Nodes (33): Factory / registry that knows which agents live in which 'universe'.      - Load, UniverseRegistry, build_auditor_prompt(), build_chair_prompt(), AgentConfig, BaseModel, Configuration for an internal Council agent.     This remains local because cons, get_agents_for_universe() (+25 more)
+
+### Community 223 - "Community 223"
+Cohesion: 0.07
+Nodes (30): mock_pool(), test_ingest_episode_returns_ids(), _edge_data_calls(), _entity_data_calls(), _FakeEntityEdge, _FakeEntityNode, _patch_graphiti_node_edge_modules(), Stands in for graphiti_core.nodes.EntityNode in this dev venv (graphiti-core isn (+22 more)
+
+### Community 224 - "Community 224"
 Cohesion: 0.12
 Nodes (38): HDBSCAN, DatasetSpec, EnrichmentSpec, ModelSpec, RunRecord, RunSpecSnapshot, RunTrainRequest, train_run_endpoint() (+30 more)
 
-### Community 223 - "Community 223"
-Cohesion: 0.11
-Nodes (29): _clamp01(), OriginationConfig, OriginationEngine, datetime, Deterministic endogenous "spontaneous want" generator.  STATUS (2026-07-08): NO-, Push a bounded summary of this self-state into the ring (cap cfg.window)., Compute D,W,A -> P over the current window and fire iff:          exogenous_tens, {'drift','dwell','agency','P','fired'} from the last maybe_originate call. (+21 more)
-
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.08
 Nodes (23): CognitionPack, PackManager, Path, Represents a pack as defined in packs/*.yaml., Given one or more pack names, return consolidated list of unique verbs., Manages cognitive packs.      Responsibilities:     - Load packs from packs/*.ya, Validate that all verbs in the pack exist in verbs/*.yaml.         Returns a dic, ensure_delivery_pack_in_packs() (+15 more)
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.11
 Nodes (39): accept_invite(), _admin_key(), AitownClientError, _base_url(), convex_mutation(), convex_query(), convex_request(), _game_descriptions() (+31 more)
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.11
 Nodes (37): MetacogCausalDensityV1, MetacogConstraintsV1, MetacogDraftTextPatchV1, MetacogDraftWhatChangedV1, MetacogEnrichScorePatchV1, MetacogNumericSistersV1, BaseModel, _draft_ctx() (+29 more)
 
-### Community 227 - "Community 227"
-Cohesion: 0.06
-Nodes (21): find_orphaned_registry_entries(), find_unregistered_trigger_kinds(), _load(), main(), trigger_kinds the journaler actually understands but the dispatch registry     d, Registry rows for trigger_kinds no longer recognized by the journaler at all, Regression/live check: the actual orion.journaler.worker._TRIGGER_TO_MODE and, test_main_fails_when_a_trigger_kind_is_unregistered() (+13 more)
-
 ### Community 228 - "Community 228"
-Cohesion: 0.08
-Nodes (33): cognitive_lane_dark(), fetch_execution_trajectory(), fetch_grammar_truth(), fetch_reasoning_activity(), _grammar_http_error(), Any, BaseException, Fail-closed HTTP reads from orion-substrate-runtime (grammar truth + trajectory) (+25 more)
+Cohesion: 0.12
+Nodes (37): FeedbackFrameV1, ActionOutcomeEmitV1, Bus payload carrying an action outcome for durable persistence via sql-writer., WorkerLivenessState, _artifact_id(), _canonical_pressures_for_spread(), clamp01(), _delta_from_turn_effect() (+29 more)
 
 ### Community 229 - "Bus Channels: Biometrics & Cognition Trace"
-Cohesion: 0.10
-Nodes (26): LivenessCheckFn, HarnessRunCancelV1, Fire-and-forget cancel for an in-flight FCC motor turn (Hub disconnect / abort)., _get_message_within(), HarnessGovernorClient, pubsub.get_message() performs exactly one read per call: if that single read, Fire-and-forget cancel for an in-flight FCC motor (no reply expected)., _FakeBus (+18 more)
+Cohesion: 0.09
+Nodes (38): build_step_frame(), _build_subprocess_env(), _env_truthy(), expand_env_path(), extract_final_from_stream_event(), _extract_tool_name(), _fcc_context_env(), _harness_aitown_env() (+30 more)
 
 ### Community 230 - "Community 230"
-Cohesion: 0.13
-Nodes (39): MindLLMSynthesisOutcome, MindShadowSynthesisV1, Non-authoritative Mind stance candidate for comparison/debug.      Shadow synthe, canonical_json_bytes(), hash_snapshot_inputs(), Any, Pure validators for Mind contracts (no HTTP / service imports beyond schemas)., validate_merged_stance_brief() (+31 more)
+Cohesion: 0.14
+Nodes (41): JournalEntryWriteV1, Backward compatibility: a payload built before this patch (no trigger_kind key, test_trigger_kind_absent_when_no_trigger_kind_on_older_producer_payload(), BaseModel, SelfConceptEvidenceRefV1, SelfConceptInduceResultV1, SelfConceptReflectResultV1, SelfConceptRefV1 (+33 more)
 
 ### Community 231 - "Community 231"
 Cohesion: 0.13
 Nodes (15): BaseModel, SocialScenarioEvaluationResultV1, SocialScenarioExpectationV1, SocialScenarioFixtureV1, SocialScenarioSeedStateV1, SocialScenarioTurnFixtureV1, _clear_app_modules(), _FakeBus (+7 more)
 
 ### Community 232 - "Community 232"
-Cohesion: 0.09
-Nodes (35): BaseSettings, Settings, client(), corpus_root(), MonkeyPatch, Path, TestClient, MonkeyPatch (+27 more)
+Cohesion: 0.12
+Nodes (36): VisionArtifactOutputs, VisionArtifactPayload, VisionCaption, artifact_uris_from_artifact(), _build_evidence(), build_window_payload(), camera_id_from_artifact(), _caption_soft_tokens() (+28 more)
 
 ### Community 233 - "Community 233"
-Cohesion: 0.09
-Nodes (26): ExecutionDispatchCortexClient, Thin RPC client sending prepared_for_dispatch envelopes to cortex-exec.      Mir, extract_final_text(), parse_structured_observation(), Any, Parse a substrate.* verb's structured JSON output.      Expected shape: {"observ, Pull the plan's final_text out of a decoded CortexExecResultPayload.      Mirror, get_settings() (+18 more)
+Cohesion: 0.06
+Nodes (20): find_orphaned_registry_entries(), find_unregistered_trigger_kinds(), _load(), main(), trigger_kinds the journaler actually understands but the dispatch registry     d, Registry rows for trigger_kinds no longer recognized by the journaler at all, Regression/live check: the actual orion.journaler.worker._TRIGGER_TO_MODE and, test_main_fails_when_a_trigger_kind_is_unregistered() (+12 more)
 
 ### Community 234 - "Community 234"
-Cohesion: 0.10
-Nodes (33): _BlockingAfterLinesStream, _fake_fcc_env(), _FakeProc, _FakeStream, Any, MonkeyPatch, Path, Near the whole-turn deadline, fcc_timeout fires, not fcc_stream_stalled. (+25 more)
+Cohesion: 0.15
+Nodes (30): ExecutionDispatchRuntimeWorker, _candidate(), _FakeClient, _frame_with_candidates(), _make_worker(), _patch_bus_and_client(), _policy_frame(), _proposal() (+22 more)
 
 ### Community 235 - "Community 235"
-Cohesion: 0.12
-Nodes (25): _accepted_claims_for_spec(), compile_context_pack_markdown(), ClaimV1, lint_corpus(), _lint_relations(), LintIssue, LintReport, DocModel (+17 more)
+Cohesion: 0.09
+Nodes (25): check_token(), create_app(), create_service(), get_service(), heartbeat_loop(), psu_cycle(), psu_off(), psu_on() (+17 more)
 
 ### Community 236 - "Community 236"
-Cohesion: 0.16
-Nodes (39): VisionWindowPayload, _attach_raw_model_output(), build_interpretation_prompt(), _clamp_float(), _coerce_event_candidate_item(), _coerce_legacy_events_field(), _coerce_llm_text(), _coerce_salient_observation_item() (+31 more)
+Cohesion: 0.06
+Nodes (41): appendExecutionStepsPanel(), appendMessage(), backfillLatestUserTurnIdForGraph(), buildAgentTraceOverviewNode(), buildAgentTraceRawPayloadsNode(), buildAgentTraceTimelineNode(), buildAgentTraceToolGroupsNode(), buildCodePre() (+33 more)
 
 ### Community 237 - "Bus Channels: Embodiment & Harness/Grammar"
-Cohesion: 0.11
-Nodes (33): ArticleRecordV1, TopicRecordV1, main(), classify_article(), build_article_clusters(), _ClusterState, _jaccard(), _score_match() (+25 more)
+Cohesion: 0.10
+Nodes (37): BaseTransport, SelectedFrontierMatterV1, _clip(), _clip_str_or_none(), _envelope_correlation_id(), _mind_transport(), Any, UUID (+29 more)
 
 ### Community 238 - "Community 238"
-Cohesion: 0.08
-Nodes (32): enrich_from_graphdb_ids(), _avg(), fetch_recent_sql_fragments(), Fragment, Returns fragments from:       - collapse_mirror (timestamp is string → cast to t, Input columns:       - gpu (JSON): {"latest_file":"...", "gpus":[             {", _summarize_biometrics(), _to_float() (+24 more)
+Cohesion: 0.10
+Nodes (25): LivenessCheckFn, _get_message_within(), HarnessGovernorClient, pubsub.get_message() performs exactly one read per call: if that single read, _FakeBus, _FakePubSub, _FakeWorkerBus, HarnessGovernorClient.run should extend its RPC wait while the governor is still (+17 more)
 
 ### Community 239 - "Community 239"
-Cohesion: 0.13
-Nodes (33): append_action_outcome(), _db_url(), _get_engine(), load_action_outcomes(), _load_from_sql(), _load_raw(), Path, Read the most recent outcomes for a subject from the shared SQL store.      Retu (+25 more)
+Cohesion: 0.06
+Nodes (40): Channel "orion:actions:trigger:journal.v1" (kind=event, schema=JournalTriggerV1) producers=[orion-actions, orion-embodiment, *] consumers=[orion-actions], Channel "orion:embodiment:intent" (kind=event, schema=EmbodimentIntentV1) producers=[orion-substrate-runtime, orion-harness-governor, orion-cortex-exec] consumers=[orion-embodiment], Channel "orion:embodiment:outcome" (kind=event, schema=EmbodimentOutcomeV1) producers=[orion-embodiment] consumers=[orion-hub], Channel "orion:embodiment:perception" (kind=event, schema=WorldPerceptionV1) producers=[orion-embodiment] consumers=[orion-substrate-runtime, orion-self-state-runtime, orion-cortex-exec], Channel "orion:exec:result:*" (kind=result, schema=CortexExecResultPayload) producers=[orion-cortex-exec, *] consumers=[orion-cortex-orch, orion-harness-governor, orion-thought, orion-hub, *], Channel "orion:grammar:accepted-pressure" (kind=event, schema=GrammarEventV1) producers=[orion-substrate-runtime] consumers=[none], Channel "orion:harness:run:artifact" (kind=event, schema=HarnessRunV1) producers=[orion-harness-governor] consumers=[*], Channel "orion:harness:run:cancel" (kind=event, schema=HarnessRunCancelV1) producers=[orion-hub] consumers=[orion-harness-governor] (+32 more)
 
 ### Community 240 - "Community 240"
-Cohesion: 0.11
-Nodes (31): CapabilityEvaluationContext, _decision(), _env_bool(), _env_float(), evaluate_capability(), _find_rule(), _goal_status_level(), _layer_a_episode_journal_enabled() (+23 more)
+Cohesion: 0.10
+Nodes (37): apply_grammar_trace_batch(), Append a trace's events in one transaction. Returns count of new events inserted, apply_sql_file(), assert_grammar_event_indexes_valid(), bus_transport_trace_batch(), _clear_app_namespace(), delete_trace(), ensure_grammar_schema() (+29 more)
 
 ### Community 241 - "Community 241"
 Cohesion: 0.10
-Nodes (35): _compile_repair_speech_overlay(), compile_speech_contract(), _inject_prior_stance_to_inputs(), Deterministic regime-specific contract injected near TASK in chat_general.j2., Copy prior brief summary into stance inputs and expose it as a TOP-LEVEL ctx, Drop trailing customer-support closers when stance contract forbids them., _sentence_is_transactional_closer(), _split_reply_sentences() (+27 more)
+Nodes (33): _BlockingAfterLinesStream, _fake_fcc_env(), _FakeProc, _FakeStream, Any, MonkeyPatch, Path, Near the whole-turn deadline, fcc_timeout fires, not fcc_stream_stalled. (+25 more)
 
 ### Community 242 - "Community 242"
-Cohesion: 0.09
-Nodes (33): _cards_enabled(), _close(), CloseRequest, dismiss_loop(), list_loops(), publish_loop_outcome(), BaseModel, Operator Pending Attention API — cognitive-loop rows + Resolve/Dismiss.  Flag-ga (+25 more)
+Cohesion: 0.18
+Nodes (38): _add_common_artifact(), _add_drive_dimension(), _add_evidence(), _add_lineage(), _add_literal(), _add_source_event_ref(), _add_tensions(), _artifact_type() (+30 more)
 
 ### Community 243 - "Community 243"
 Cohesion: 0.14
-Nodes (35): WindowingSpec, _build_prompt(), _cache_key(), _call_llm(), _hash_text(), judge_boundaries(), Any, _write_artifact() (+27 more)
+Nodes (32): apply_operator_goal_reasoning_promotion(), _autonomy_goal_execution_enabled(), _goal_to_reasoning_claim(), plan_promoted_goal(), ClaimV1, datetime, update_goal_planned_task_id(), _FakeGraphClient (+24 more)
 
 ### Community 244 - "Community 244"
-Cohesion: 0.10
-Nodes (33): Autonomy graph IRIs (no heavy imports — safe for orion-actions / hub)., archive_subject_goals(), archive_subjects(), archive_subjects_drain(), _binding_value(), build_archive_candidates(), build_archive_status_update(), _build_client() (+25 more)
+Cohesion: 0.14
+Nodes (35): WindowingSpec, _build_prompt(), _cache_key(), _call_llm(), _hash_text(), judge_boundaries(), Any, _write_artifact() (+27 more)
 
 ### Community 245 - "Community 245"
-Cohesion: 0.06
-Nodes (38): Channel "orion:actions:trigger:journal.v1" (kind=event, schema=JournalTriggerV1) producers=[orion-actions, orion-embodiment, *] consumers=[orion-actions], Channel "orion:embodiment:intent" (kind=event, schema=EmbodimentIntentV1) producers=[orion-substrate-runtime, orion-harness-governor, orion-cortex-exec] consumers=[orion-embodiment], Channel "orion:embodiment:outcome" (kind=event, schema=EmbodimentOutcomeV1) producers=[orion-embodiment] consumers=[orion-hub], Channel "orion:embodiment:perception" (kind=event, schema=WorldPerceptionV1) producers=[orion-embodiment] consumers=[orion-substrate-runtime, orion-self-state-runtime, orion-cortex-exec], Channel "orion:exec:result:*" (kind=result, schema=CortexExecResultPayload) producers=[orion-cortex-exec, *] consumers=[orion-cortex-orch, orion-harness-governor, orion-thought, orion-hub, *], Channel "orion:grammar:accepted-pressure" (kind=event, schema=GrammarEventV1) producers=[orion-substrate-runtime] consumers=[none], Channel "orion:harness:run:artifact" (kind=event, schema=HarnessRunV1) producers=[orion-harness-governor] consumers=[*], Channel "orion:harness:run:cancel" (kind=event, schema=HarnessRunCancelV1) producers=[orion-hub] consumers=[orion-harness-governor] (+30 more)
+Cohesion: 0.10
+Nodes (32): expand_env_path(), load_fcc_env(), Path, build_orion_town_persona(), Project the self-model into a public-safe town persona.      Empty-shell guard:, _truncate(), test_blurb_is_truncated(), test_empty_projection_falls_back() (+24 more)
 
 ### Community 246 - "Community 246"
 Cohesion: 0.08
 Nodes (25): Hub legacy label ``recall.v1`` must resolve to structured brain recall, not chat, test_dream_v1_profile_loads(), test_profiles_load_default(), test_recall_v1_hub_alias_maps_to_brain_recall(), _canonical_profile_name(), _find_profiles_dir(), get_profile(), load_profiles() (+17 more)
 
 ### Community 247 - "Community 247"
-Cohesion: 0.11
-Nodes (32): _normalize(), _parse_time(), BaseModel, resolve_workflow_schedule_management(), WorkflowScheduleManagementIntent, get_workflow_definition(), _journal_discussion_window_command_intent(), list_workflows() (+24 more)
+Cohesion: 0.13
+Nodes (38): aitown_convex_proxy(), aitown_legacy_assets_proxy(), aitown_proxy(), aitown_proxy_root(), aitown_proxy_vite(), aitown_proxy_vite_root(), _proxy_aitown_request(), proxy_knowledge_forge() (+30 more)
 
 ### Community 248 - "Community 248"
-Cohesion: 0.16
-Nodes (26): EndogenousCalibrationProfileV1, EndogenousCalibrationRecommendationV1, EndogenousEvaluationRequestV1, EndogenousEvaluationResultV1, EndogenousMetricSummaryV1, PromotionCalibrationSummaryV1, BaseModel, datetime (+18 more)
+Cohesion: 0.08
+Nodes (18): PadStore, Redis, _bucketize(), build_router(), _event_value(), _extract_dimension(), _frame_value(), _percentile() (+10 more)
 
 ### Community 249 - "Community 249"
-Cohesion: 0.12
-Nodes (33): BaseModel, Recall V2 / recall-strategy promotion readiness (advisory only; no live apply)., RecallStrategyReadinessV1, _cognitive_template_for_surface(), _default_patch_for_class(), _default_rollback_for_class(), _proposal_expected_effect(), _proposal_rationale() (+25 more)
+Cohesion: 0.08
+Nodes (22): check_field_coherence(), Return 0-1 incoherence score for one node vector., Return per-node incoherence scores (0-1). Empty if no suspicion found., _rule_suspicion(), empty_field_state(), new_tick_id(), datetime, FieldDigesterWorker (+14 more)
 
 ### Community 250 - "Community 250"
-Cohesion: 0.15
-Nodes (20): AttentionSignalV1, datetime, _utc_now(), compact(), Any, stable_id(), unique(), AutonomySignalDetector (+12 more)
-
-### Community 251 - "Community 251"
-Cohesion: 0.10
-Nodes (31): RenderedAnswer, _contract_dict(), _fallback_text(), FinalizePassResult, _findings_bundle_dict(), _jinja_env(), Any, Mandatory finalize pass: FindingsBundle + AnswerContract → user-visible Rendered (+23 more)
-
-### Community 252 - "Community 252"
-Cohesion: 0.13
-Nodes (28): EvidenceSnapshot, EvidenceTransitionDecision, EvidenceTransitionTracker, _hard_labels_from_evidence(), _labels_for_gate(), _labels_summary(), Deterministic pre-LLM gate: interpret only on host evidence transitions., snapshot_from_window() (+20 more)
-
-### Community 253 - "Community 253"
 Cohesion: 0.13
 Nodes (31): _clip(), fetch_turn_text_by_correlation(), format_turn_utterance_text(), hydrate_consolidation_draft_dict(), hydrate_draft_utterance_text(), Any, Pool, Hydrate consolidation suggest drafts with turn text from chat_history_log. (+23 more)
 
-### Community 254 - "Community 254"
-Cohesion: 0.11
-Nodes (20): BiometricsContext, BaseModel, RPC request payload for the state read-model service., RPC reply payload from the state read-model service., StateGetLatestRequest, StateLatestReply, BiometricsClusterV1, _age_ms() (+12 more)
-
-### Community 255 - "Community 255"
+### Community 251 - "Community 251"
 Cohesion: 0.13
 Nodes (32): One LLM call's reasoning metadata. No trace text — privacy-preserving., ReasoningCallV1, build_reasoning_call(), _coerce_correlation_uuid(), _coerce_str(), _coerce_token(), publish_reasoning_call(), Any (+24 more)
 
-### Community 256 - "Community 256"
-Cohesion: 0.09
-Nodes (23): BiometricsAdapter, EquilibriumAdapter, adapter(), make_induction_payload(), norm_ctx(), Biometrics adapter contract (spec §7.A) — lives under ``orion/signals/adapters/t, test_adapt_leaves_otel_for_gateway(), TestAdapt (+15 more)
-
-### Community 257 - "Community 257"
-Cohesion: 0.08
-Nodes (21): Deterministic unit tests for the pure layer of measure_autonomy_gate.  No DB, no, _self_state(), test_bucket_boundary_timestamp(), test_percentile_and_median(), test_resolve_window_days_flag_explicit(), test_resolve_window_defaults_to_days_when_neither_flag_given(), test_resolve_window_hours_flag(), test_retention_caveat_fires_when_source_retention_is_shorter() (+13 more)
-
-### Community 258 - "Community 258"
-Cohesion: 0.10
-Nodes (16): OrionTissue, Any, ndarray, Path, Baseline-relative novelty using a rolling z-score of cosine distance.          n, Hybrid coherence:           - If an embedding is provided (spark_vector or featu, Main update cycle:           1. Update expectation (learning)           2. Evolv, Advance the tissue by one or more local-update steps.          v0 local rule: (+8 more)
-
-### Community 259 - "Community 259"
+### Community 252 - "Community 252"
 Cohesion: 0.10
 Nodes (20): _artanh_clamped(), expmap0(), mobius_add(), poincare_distance(), poincare_distance_pairs(), project_to_ball(), Tensor, Exponential map at origin: tangent vector -> point on ball. (+12 more)
 
-### Community 260 - "Community 260"
+### Community 253 - "Community 253"
+Cohesion: 0.12
+Nodes (30): _amain(), _extract(), LiveScenario, main(), _now_iso(), _ordered_hops(), _parse_args(), ProbeCollector (+22 more)
+
+### Community 254 - "Community 254"
 Cohesion: 0.13
 Nodes (28): _check(), HealthCheck, HealthMonitor, Settings, Severity, Edge-triggered health monitor: fires an orion-notify attention request only, run_checks(), health() (+20 more)
 
-### Community 261 - "Community 261"
+### Community 255 - "Community 255"
 Cohesion: 0.09
 Nodes (37): agentAnswerHeadline(), applyAgentClaudePayloadFields(), applyHubModeSelection(), applyOrionUnifiedPayloadFields(), audienceChipLabel(), beginWsReadyWait(), confirmDownRouteOrProceed(), drawVisualizer() (+29 more)
 
-### Community 262 - "Community 262"
-Cohesion: 0.08
-Nodes (17): PadStore, Redis, _bucketize(), build_router(), _event_value(), _extract_dimension(), _frame_value(), _percentile() (+9 more)
+### Community 256 - "Community 256"
+Cohesion: 0.14
+Nodes (28): EvidenceSnapshot, EvidenceTransitionDecision, EvidenceTransitionTracker, _hard_labels_from_evidence(), _labels_for_gate(), _labels_summary(), Deterministic pre-LLM gate: interpret only on host evidence transitions., snapshot_from_window() (+20 more)
 
-### Community 263 - "Community 263"
+### Community 257 - "Community 257"
 Cohesion: 0.10
-Nodes (21): Auth, build_rdf_store_client(), FusekiRdfStoreClient, GenericSparqlRdfStoreClient, GraphDbRdfStoreClient, _httpx_auth(), _httpx_limits(), httpx_limits_for_settings() (+13 more)
+Nodes (23): Client, main(), _main_async(), monitor_ups(), _publish_event(), _run_shutdown(), setup_logging(), _source() (+15 more)
 
-### Community 264 - "Community 264"
-Cohesion: 0.10
-Nodes (32): ChatResponsePayload, ExecutionStep, _resolve_llm_chat_max_tokens(), _resolve_llm_max_tokens(), _should_prepare_brain_reply_context(), _base_ctx(), dream_cycle + dream_synthesis must not fall through to default chat completion c, test_chat_general_final_step_uses_chat_route() (+24 more)
+### Community 258 - "Community 258"
+Cohesion: 0.16
+Nodes (17): __getattr__(), AutonomyVerificationHarness, CheckResult, GraphDBClient, load_scenarios(), Any, Graph, Path (+9 more)
 
-### Community 265 - "Community 265"
-Cohesion: 0.10
-Nodes (27): Any, query_chroma_collection(), Query Chroma HTTP API for semantic hits (Postgres remains canonical)., _apply_recall_boost(), _embed_query(), _persist_recall_boost(), Any, datetime (+19 more)
+### Community 259 - "Community 259"
+Cohesion: 0.14
+Nodes (34): _apply_ref_remap_to_draft(), _apply_urn_uuid_remap(), _build_malformed_urn_uuid_remap(), _build_short_local_ref_remap(), _collect_refs(), is_blank_ref(), is_malformed_urn_uuid(), is_resolvable_entity_ref() (+26 more)
 
-### Community 266 - "Community 266"
-Cohesion: 0.11
-Nodes (15): BiometricsInductionV1, EwmaBand, InductionMetricState, InductionTracker, Return the InductionTracker for (organ_id, metric_key)., BiometricsPipeline, NormalizationConfig, normalize_rate() (+7 more)
+### Community 260 - "Community 260"
+Cohesion: 0.12
+Nodes (31): _coerce_float(), compute_deltas_from_turn_effect(), _delta_block(), evaluate_turn_effect_alert(), _evidence_block(), Any, should_emit_turn_effect_alert(), _extract_phi_blocks() (+23 more)
 
-### Community 267 - "Community 267"
+### Community 261 - "Community 261"
 Cohesion: 0.12
 Nodes (15): HyperbolicGPTConfig, Any, Path, main(), parse_args(), Namespace, Block, HyperbolicCausalSelfAttention (+7 more)
 
-### Community 268 - "Community 268"
+### Community 262 - "Community 262"
+Cohesion: 0.13
+Nodes (22): CouncilDecision, CouncilPolicy, Encapsulates:       - how we interpret auditor verdict + blink scores       - ho, Adjusts prompt in-place using auditor constraints., Rewrites prompt for a new round of agent thinking., Any, LLMClient, LLMClientTimeout (+14 more)
+
+### Community 263 - "Community 263"
 Cohesion: 0.06
 Nodes (6): MonkeyPatch, test_build_chat_request_social_room_metadata_includes_redaction_posture(), test_hub_social_redaction_posture_defaults_to_strict(), test_hub_social_redaction_posture_payload_override_wins_over_env(), test_hub_social_redaction_posture_reads_env_override(), test_hub_social_redaction_posture_rejects_invalid_value()
 
-### Community 269 - "Community 269"
+### Community 264 - "Community 264"
+Cohesion: 0.09
+Nodes (23): IdeationRunRequestV1, IdeationRunResultV1, build_user_prompt(), _collect_snippets(), detect_monorepo_root(), _is_under_allowed_roots(), Path, _read_snippet() (+15 more)
+
+### Community 265 - "Community 265"
+Cohesion: 0.12
+Nodes (27): Config, BaseSettings, Settings, CoquiBackend, _ensure_torch_load_compat(), _is_xtts_model(), Path, Settings (+19 more)
+
+### Community 266 - "Community 266"
 Cohesion: 0.12
 Nodes (20): _binding(), FakeConn, FakeSparqlClient, _grounded_llm_content(), _make_bus(), Exception, fetch_drive_history_events is list-only (no detail join) -- see its     docstrin, Minimal in-process double for the asyncpg.Connection calls     repository.py::in (+12 more)
 
-### Community 270 - "Community 270"
+### Community 267 - "Community 267"
+Cohesion: 0.09
+Nodes (24): AuditFn, DispatchJournalFn, _trigger_world_pulse_run(), Config, get_settings(), BaseSettings, Settings, build_world_pulse_journal_trigger() (+16 more)
+
+### Community 268 - "Community 268"
+Cohesion: 0.10
+Nodes (20): Auth, build_rdf_store_client(), FusekiRdfStoreClient, GenericSparqlRdfStoreClient, GraphDbRdfStoreClient, _httpx_auth(), _httpx_limits(), httpx_limits_for_settings() (+12 more)
+
+### Community 269 - "Community 269"
 Cohesion: 0.13
-Nodes (33): build_attention_frame(), _attention_target_summary(), Structured summary of one FieldAttentionTargetV1 (2026-07-12, inner-state     un, End-to-end regression guard (2026-07-12, found by code review): the     tests ab, test_hardware_bypass_survives_real_build_self_state_pipeline(), _synthetic_field(), test_builder_selects_athena_and_orchestration(), test_dominant_channels_present() (+25 more)
+Nodes (23): apply_causal_density_to_entry(), _coerce_self_state(), CollapseMirrorStore, _condition_severity_rank(), enrich_entry(), _get_store(), _label_for_score(), _phi_evidence_score() (+15 more)
 
-### Community 271 - "Community 271"
-Cohesion: 0.17
-Nodes (17): __getattr__(), AutonomyVerificationHarness, CheckResult, GraphDBClient, load_scenarios(), Any, Graph, Path (+9 more)
-
-### Community 272 - "Community 272"
+### Community 270 - "Community 270"
 Cohesion: 0.11
 Nodes (32): extract_tool_metrics(), _iter_message_blocks(), load_fixture(), Any, Path, Deterministic scoring for the unified-turn introspection eval.  Experiment artif, Return (passed, failed) assertion id lists for one answer., Fold fcc_motor step frames (raw stream-json events) into navigation metrics. (+24 more)
 
-### Community 273 - "Community 273"
-Cohesion: 0.09
-Nodes (31): Turn N closure with surprise_unresolved exposes reducer-facing strain signal., test_turn_n_error_shifts_turn_n_plus_one_strain(), HarnessPostTurnClosureV1, _coalition_ref(), persist_turn_referent(), Any, datetime, Best-effort writer for substrate_turn_referent (reverie semantic lift v1). (+23 more)
-
-### Community 274 - "Community 274"
+### Community 271 - "Community 271"
 Cohesion: 0.14
 Nodes (24): main(), SourceV1, Path, resolve_corpus_root(), apply_pending_patch(), list_pending_patches(), _parse_patch_file(), PendingPatch (+16 more)
 
-### Community 275 - "Community 275"
-Cohesion: 0.14
-Nodes (29): CuriositySuppressionV1, AttentionSignalDetector, Any, Protocol, attention_frame_enabled(), build_attention_frame(), _detect_signals(), _env_float() (+21 more)
+### Community 272 - "Community 272"
+Cohesion: 0.15
+Nodes (27): main(), _parse_args(), Namespace, evaluate_training_run(), _load_jsonl(), _now(), Any, Path (+19 more)
 
-### Community 276 - "Community 276"
-Cohesion: 0.13
-Nodes (32): ContextExecVerbStepV1, _artifact_evidence_count(), artifact_repo_evidence_count(), _blocked_summary(), count_evidence(), evaluate_investigation_outcome(), explicit_fake_run_requested(), grounding_required() (+24 more)
-
-### Community 277 - "Community 277"
+### Community 273 - "Community 273"
 Cohesion: 0.13
 Nodes (34): build_drive_audit_detail_sparql(), build_drive_audit_event_list_sparql(), build_fact_sheet(), _build_narrative_prompt(), _build_reflection_crystallization(), _call_llm_narrative(), DriveAuditEvent, DriveHistoryAggregationV1 (+26 more)
 
+### Community 274 - "Community 274"
+Cohesion: 0.14
+Nodes (34): Any, Path, Run context-exec fake engine + ledger intake; return run and ledger record., run_denver_vertical_slice(), run_denver_vertical_slice_async(), app_client(), _load_app(), MonkeyPatch (+26 more)
+
+### Community 275 - "Community 275"
+Cohesion: 0.15
+Nodes (19): PendingMessage, Result of XREADGROUP / XAUTOCLAIM: decoded messages plus per-entry decode failur, ReadGroupBatch, _consumer(), _envelope(), FakeQueue, _msg(), In-memory stand-in for RedisStreamWorkQueue exercising the consumer contract. (+11 more)
+
+### Community 276 - "Community 276"
+Cohesion: 0.07
+Nodes (7): GraphReviewRuntimeResultV1, BaseModel, datetime, test_execute_once_endpoint_is_single_cycle_operator_only_and_followup_default_off(), test_execute_once_followup_endpoint_keeps_followup_explicit(), test_mutation_lineage_readonly_endpoints(), test_self_experiments_trigger_daily_publishes_bus_event()
+
+### Community 277 - "Community 277"
+Cohesion: 0.15
+Nodes (27): BoundCapabilityExecutionRequestV1, AgentOpinion, AuditVerdict, BlinkJudgement, BlinkScores, ContextBlock, CouncilResult, DeliberationRequest (+19 more)
+
 ### Community 278 - "Community 278"
-Cohesion: 0.08
-Nodes (35): appendMessage(), backfillLatestUserTurnIdForGraph(), buildAgentTraceOverviewNode(), buildAgentTraceRawPayloadsNode(), buildAgentTraceTimelineNode(), buildAgentTraceToolGroupsNode(), buildCodePre(), buildWorkflowMetaBadges() (+27 more)
+Cohesion: 0.15
+Nodes (9): _execute_openai_chat(), _load_route_targets(), Unified logic for both vLLM and llama.cpp since they share the OpenAI API shape., ChatBody, ChatMessage, TestLLMBackendExecution, minimal_route_table(), test_run_llm_chat_lane_routing_spark_missing_returns_unavailable() (+1 more)
 
 ### Community 279 - "Community 279"
-Cohesion: 0.12
-Nodes (26): Config, BaseSettings, Settings, CoquiBackend, _ensure_torch_load_compat(), _is_xtts_model(), Path, Settings (+18 more)
-
-### Community 280 - "Community 280"
-Cohesion: 0.10
-Nodes (26): BaseTransport, Shared Mind contract constants (no runtime / IO)., MindRunArtifactV1, BaseModel, Bus + Postgres artifact for a completed Mind run (producer: orch, consumer: sql-, _clip(), _clip_str_or_none(), _envelope_correlation_id() (+18 more)
-
-### Community 281 - "Community 281"
-Cohesion: 0.12
-Nodes (23): build_context_pack_output_path(), _claim_included(), compile_context_pack_api_v1(), _dedupe_preserve_order(), ClaimV1, datetime, _relevant_decisions(), _slugify() (+15 more)
-
-### Community 282 - "Community 282"
-Cohesion: 0.11
-Nodes (27): BaseModel, Reasoning telemetry — per-call cognition metadata + windowed activity.  `Reasoni, Rolling-window aggregate of ReasoningCallV1, read by φ (spark-introspector)., ReasoningActivityV1, _decode_reasoning_call(), Any, Decode a bus message into a `ReasoningCallV1`, or None if unusable.      Defensi, Capped rolling window of `ReasoningCallV1`, materialized on demand.      The buf (+19 more)
-
-### Community 283 - "Community 283"
-Cohesion: 0.14
-Nodes (31): build_operator_summary(), _build_synthesis_prompt(), _default_title(), _deterministic_summary(), _extract_memory_id_tokens(), _extract_path_tokens(), _flatten_strings(), _ground_corpus() (+23 more)
-
-### Community 284 - "Community 284"
 Cohesion: 0.18
 Nodes (30): _attention_event(), Enum, str, _reset_hour_window(), ServicePhase, ServiceState, transition(), TransitionInput (+22 more)
 
-### Community 285 - "Community 285"
+### Community 280 - "Community 280"
+Cohesion: 0.11
+Nodes (26): MindLLMFailOpenRecord, Any, Fail-open metadata preserved when LLM synthesis falls back to deterministic Mind, MindPhaseTelemetry, phase_telemetry_machine_keys(), Any, Per-phase LLM telemetry for Mind run inspectability., maybe_publish_llm_surface_instability_trigger() (+18 more)
+
+### Community 281 - "Community 281"
 Cohesion: 0.11
 Nodes (30): fetch_card_fragments(), fetch_card_fragments_guarded(), _neighbor_confidence_ok(), Any, Pool, Score memory cards for fusion via embedding cosine similarity (source=cards)., card_recall_text(), cosine_similarity() (+22 more)
 
-### Community 286 - "Community 286"
-Cohesion: 0.19
-Nodes (30): MemoryCardStatusChangeV1, _bus(), _clamp_limit(), _clamp_offset(), _http_if_missing_memory_schema(), _maybe_emit_card_for_crystallizer(), memory_add_edge(), memory_change_status() (+22 more)
+### Community 282 - "Community 282"
+Cohesion: 0.17
+Nodes (29): FrontierInvocationSignalV1, _attention_loop_candidates(), _clamp01(), _coverage_gap_candidates(), endogenous_curiosity_candidates(), EndogenousCuriosityConfig, _env_flag(), _env_float() (+21 more)
 
-### Community 287 - "Community 287"
-Cohesion: 0.18
-Nodes (31): MindHandoffBriefV1, MindRunResultV1, build_synthetic_mind_http_failure_result(), merge_mind_brief_into_plan_metadata(), _mind_result_is_deterministic_contract_only(), _mind_result_quality(), _client_request(), _orch_prep() (+23 more)
+### Community 283 - "Community 283"
+Cohesion: 0.16
+Nodes (23): SocialGifUsageStateV1, _eligible_summary(), _FakeBus, _FakeCallSyneClient, _FakeHubClient, _FakeSocialMemoryClient, _payload(), _policy_and_message() (+15 more)
 
-### Community 288 - "Community 288"
-Cohesion: 0.13
-Nodes (32): Path, All files backing one corpus path, oldest first: any rotated     siblings (match, resolve_rotated_corpus_files(), input_features_for_version(), _variance_gate(), _feature(), _inner_row(), CompletedProcess (+24 more)
+### Community 284 - "Community 284"
+Cohesion: 0.12
+Nodes (20): In-memory LRU cache of per-turn substrate effect snapshots., SubstrateEffectCache, SubstrateEffectSnapshot, _push_observation(), Any, Orchestrate the repair_pressure appraisal pipeline for one chat turn.  Failure m, Run the appraiser end-to-end. Stash a snapshot in `cache`. Return summary., run_substrate_effect_pipeline() (+12 more)
 
-### Community 289 - "Community 289"
+### Community 285 - "Community 285"
 Cohesion: 0.15
 Nodes (30): activateAtlasPanel(), apiFetch(), applyGraphFilters(), destroyCy(), escapeHtml(), fetchTraces(), fitAtlasGraph(), formatTs() (+22 more)
 
-### Community 290 - "Community 290"
+### Community 286 - "Community 286"
 Cohesion: 0.07
 Nodes (21): anim(), btn, cam, clk, elConnStatus, elExplanation, elGearBtn, elInfoToggle (+13 more)
 
-### Community 291 - "Community 291"
-Cohesion: 0.12
-Nodes (27): append_github_mcp_harness_brief(), default_harness_workspace(), github_mcp_brief_lines(), github_mcp_repo_brief_line(), parse_github_remote_url(), Path, Resolve GitHub owner/repo for FCC MCP operator briefs., Append GitHub MCP operator lines when harness MCP is enabled. (+19 more)
+### Community 287 - "Community 287"
+Cohesion: 0.11
+Nodes (25): ClosureHandler, require_operator_token(), Task, stop_finalize_appraisal_listener(), Task, stop_goal_context_listener(), health(), lifespan() (+17 more)
 
-### Community 292 - "Community 292"
+### Community 288 - "Community 288"
 Cohesion: 0.14
 Nodes (27): extract_suggest_draft_dict_from_cortex_payload(), extract_suggest_text_from_cortex_payload(), _openai_choice_message_text(), Any, Extract memory_graph_suggest draft JSON from CortexClientResult-shaped payloads., Parse a SuggestDraftV1 dict from a CortexClientResult-shaped payload., Return best-effort model text containing a suggest draft from a cortex payload., _service_block_text_candidates() (+19 more)
 
-### Community 293 - "Community 293"
-Cohesion: 0.15
-Nodes (28): Deterministic Phase 0 gate: skip recall on low-info social turns., recall_skip_gate(), RecallSkipGateResult, _coerce_novelty(), derive_retrieval_intent(), _has_contradiction_seed(), _has_entity_query(), _has_planning_like_priority() (+20 more)
-
-### Community 294 - "Community 294"
+### Community 289 - "Community 289"
 Cohesion: 0.13
 Nodes (26): get_settings(), BaseSettings, Configuration for the Orion Hub service, loaded from environment variables., Settings, atom_neighborhood_api(), atom_provenance_api(), atom_temporal_path_api(), _ensure_sql_writer_on_path() (+18 more)
 
-### Community 295 - "Community 295"
+### Community 290 - "Community 290"
 Cohesion: 0.15
 Nodes (23): _assert_get_path(), _assert_post_path(), _base_url(), fetch_health(), get_eligibility(), _get_json(), get_proposal(), list_proposals() (+15 more)
 
-### Community 296 - "Community 296"
+### Community 291 - "Community 291"
 Cohesion: 0.12
 Nodes (30): build_response_format_for_method(), _chat_payload(), _default_base_url(), _default_model(), _evaluate_content(), extract_message_content(), has_forbidden_content(), main() (+22 more)
 
-### Community 297 - "Community 297"
+### Community 292 - "Community 292"
 Cohesion: 0.14
 Nodes (24): _check(), HealthCheck, HealthMonitor, Settings, Severity, Edge-triggered health monitor: fires an orion-notify attention request only, run_checks(), health() (+16 more)
 
-### Community 298 - "Community 298"
-Cohesion: 0.10
-Nodes (15): datetime, Cache the latest town perception as a best-effort observability input., Return the age-gated embodied-perception grounding signal, or ``None``., Measurement-only (Phase 2, 2026-07-12): log each dimension's         deviation-f, SelfStateRuntimeWorker, _make_worker(), _perception(), Unit tests for the Orion embodiment perception grounding input.  Verifies the se (+7 more)
-
-### Community 299 - "Community 299"
+### Community 293 - "Community 293"
 Cohesion: 0.18
 Nodes (31): project_interpretation_to_events(), _parse(), Council V2 scene interpretation parsing and projection tests (no live LLM/Redis/, Live failure mode: LLM put event_candidates fields under salient_observations., test_build_interpretation_prompt_caps_artifact_bloat(), test_debug_parse_mode_available_from_outcome(), test_empty_event_candidates_projection_returns_empty_payload(), test_event_candidates_populated_from_misplaced_salient_observations() (+23 more)
 
-### Community 300 - "Community 300"
-Cohesion: 0.12
-Nodes (21): get_db(), init_models(), generate_biometrics_model(), Returns a SQLAlchemy model with the table name defined in .env → TABLE_NAME, DigestRunDB, _check_topic_drift(), _digest_already_sent(), _drift_alert_loop() (+13 more)
-
-### Community 301 - "Community 301"
-Cohesion: 0.21
-Nodes (27): test_mind_run_request_roundtrip(), MindRunPolicyV1, MindRunRequestV1, run_mind(), FakeMindLLMClient, Deterministic JSON responses for unit tests., set_llm_client_override(), mind_run() (+19 more)
-
-### Community 302 - "Community 302"
-Cohesion: 0.14
-Nodes (26): _inner_proposal_artifact(), main(), _quality_pass(), _run(), assert_claim_clean(), assert_engine_runtime_debug(), assert_safety_posture(), blob_text() (+18 more)
-
-### Community 303 - "Community 303"
-Cohesion: 0.14
-Nodes (24): ActionSkillManifestEntry, ActionsSkillRegistry, _family_for_skill(), BaseModel, Path, Normalized orion-actions skill manifest derived from skills.* verb YAMLs., _risk_for_skill(), _bound_capability_service_payload() (+16 more)
-
-### Community 304 - "Community 304"
-Cohesion: 0.12
-Nodes (31): closeAgentTraceModal(), closeAutonomyConstitutionModal(), closeAutonomyDebugModal(), closeChatInputExpandModal(), closeChatStanceDebugModal(), closeCognitiveReviewModal(), closeMemoryDebugModal(), closeRecallCanaryModal() (+23 more)
-
-### Community 305 - "Community 305"
+### Community 294 - "Community 294"
 Cohesion: 0.16
-Nodes (27): activateSubview(), apiFetch(), escapeHtml(), formatHistoryWhen(), formatMemoryApiError(), graphSetOut(), loadAll(), loadConsolidationDrafts() (+19 more)
+Nodes (26): CapabilityEvaluationContext, _decision(), _env_bool(), _env_float(), evaluate_capability(), _find_rule(), _goal_status_level(), _layer_a_episode_journal_enabled() (+18 more)
 
-### Community 306 - "Community 306"
-Cohesion: 0.11
-Nodes (23): _epoch(), _extract_turn_effect_delta(), fetch_exact_fragments(), fetch_recent_fragments(), fetch_related_by_entities(), _filter_excluded_rows(), _is_current_turn_echo(), _memory_filter_clause() (+15 more)
-
-### Community 307 - "Community 307"
-Cohesion: 0.13
-Nodes (28): _build_chatturn_keyword_filter(), _build_graphtri_anchor_kind_sparql(), _build_graphtri_anchor_sparql(), _build_sparql_query(), _escape_sparql(), _extract_keywords(), _extract_labels(), fetch_graphtri_anchors() (+20 more)
-
-### Community 308 - "Community 308"
-Cohesion: 0.22
-Nodes (28): _candidate(), _FakeClient, _frame_with_candidates(), _make_worker(), _patch_bus_and_client(), _policy_frame(), _proposal(), Stand-in for ExecutionDispatchCortexClient -- returns canned results     or rais (+20 more)
-
-### Community 309 - "Community 309"
-Cohesion: 0.13
-Nodes (27): End-to-end eval for homeostatic drives (spec/plan Task 8).  Replays a synthetic, run(), _sig(), compute_tick_attribution(), dominant_drive_from_attribution(), primary_drive_for_tension_kind(), Sum magnitude × drive_impact weight per drive for THIS tick only., Structural map for tie-break; not digest keyword matching. (+19 more)
-
-### Community 310 - "Community 310"
+### Community 295 - "Community 295"
 Cohesion: 0.12
 Nodes (20): load_channel_catalog(), Any, Path, ChannelCatalogEnforcer, Any, _assert_channel_wiring(), main(), Path (+12 more)
 
-### Community 311 - "Community 311"
+### Community 296 - "Community 296"
+Cohesion: 0.12
+Nodes (26): _as_optional_str(), build_journal_entry_index_payload(), _list_of_str(), Any, Build a denormalized journal retrieval payload.      This stays journal-specific, Mirror executor merge logic under test., _resolve_speech_contract(), test_metadata_absent_keeps_instrumental_contract() (+18 more)
+
+### Community 297 - "Community 297"
+Cohesion: 0.21
+Nodes (27): test_mind_run_request_roundtrip(), MindRunPolicyV1, MindRunRequestV1, run_mind(), FakeMindLLMClient, Deterministic JSON responses for unit tests., set_llm_client_override(), mind_run() (+19 more)
+
+### Community 298 - "Community 298"
+Cohesion: 0.12
+Nodes (13): _anchor_for_fragment(), _anchor_hint(), _fragment_metadata(), map_recall_bundle_to_substrate(), _map_sql_timeline_fragment(), _meta_dict(), Any, Map sql_timeline fragment → conservative substrate node. (+5 more)
+
+### Community 299 - "Community 299"
+Cohesion: 0.13
+Nodes (29): Path, Shared contract for JSONL corpus-sink rotation naming and file resolution.  Sing, All files backing one corpus path, oldest first: any rotated     siblings (match, resolve_rotated_corpus_files(), build_report(), collapse_reasons(), discover_encoder_dirs(), evaluate_run() (+21 more)
+
+### Community 300 - "Community 300"
+Cohesion: 0.12
+Nodes (31): closeAgentTraceModal(), closeAutonomyConstitutionModal(), closeAutonomyDebugModal(), closeChatInputExpandModal(), closeChatStanceDebugModal(), closeCognitiveReviewModal(), closeMemoryDebugModal(), closeRecallCanaryModal() (+23 more)
+
+### Community 301 - "Community 301"
+Cohesion: 0.16
+Nodes (27): activateSubview(), apiFetch(), escapeHtml(), formatHistoryWhen(), formatMemoryApiError(), graphSetOut(), loadAll(), loadConsolidationDrafts() (+19 more)
+
+### Community 302 - "Community 302"
+Cohesion: 0.17
+Nodes (27): outcome_from_followup(), Return the followup whose section matches the first gap-section label the     re, Rebuild an ActionOutcomeRefV1 from a world-pulse curiosity followup so the     r, select_reusable_followup(), iter_gap_section_labels(), Yield normalized section labels from `section:` focal refs across     world_cove, _followup(), _gap_signal() (+19 more)
+
+### Community 303 - "Community 303"
+Cohesion: 0.11
+Nodes (25): DimensionRule, load_signal_drive_map(), Path, ValueError, Load + validate the structural signal->drive map (spec 2026-07-07 §3).  The map, Dimension rules for a signal_kind; empty list if unmapped., Resolve a concrete (signal_kind, dimension) to its rule, if any.          Exact, Parse and validate the YAML map. Raises SignalDriveMapError on any     structura (+17 more)
+
+### Community 304 - "Community 304"
+Cohesion: 0.08
+Nodes (30): Channel "orion:biometrics:cluster" (kind=telemetry, schema=BiometricsClusterV1) producers=[orion-biometrics-hub] consumers=[orion-state-service, orion-sql-writer], Channel "orion:biometrics:induction" (kind=telemetry, schema=BiometricsInductionV1) producers=[orion-biometrics, orion-biometrics-hub] consumers=[orion-state-service, orion-sql-writer], Channel "orion:biometrics:sample" (kind=telemetry, schema=BiometricsSampleV1) producers=[orion-biometrics] consumers=[orion-sql-writer, orion-landing-pad], Channel "orion:biometrics:summary" (kind=telemetry, schema=BiometricsSummaryV1) producers=[orion-biometrics, orion-biometrics-hub] consumers=[orion-state-service, orion-sql-writer, orion-landing-pad], Channel "orion:exec:result:PadRpc:*" (kind=result, schema=PadRpcResponseV1) producers=[orion-landing-pad] consumers=[orion-cortex-exec, *], Channel "orion:exec:result:StateService:*" (kind=result, schema=StateLatestReply) producers=[orion-state-service] consumers=[orion-cortex-exec, *], Channel "orion:pad:event" (kind=event, schema=PadEventV1) producers=[orion-landing-pad] consumers=[*], Channel "orion:pad:frame" (kind=event, schema=StateFrameV1) producers=[orion-landing-pad] consumers=[*] (+22 more)
+
+### Community 305 - "Community 305"
+Cohesion: 0.11
+Nodes (25): build_answer_grounding_context(), _compose_grounding_context(), delivery_grounding_mode(), extract_trace_preferred_output(), Any, Answer/runtime grounding strings split from delivery-oriented helpers., Structured grounding for answer/render verbs (repo + runtime; Discord only when, build_delivery_grounding_context() (+17 more)
+
+### Community 306 - "Community 306"
 Cohesion: 0.18
 Nodes (26): cleanup_mcp_config(), _deep_replace(), McpPreflightError, _probe_convex_auth(), _probe_convex_version(), Any, Exception, Path (+18 more)
 
-### Community 312 - "Community 312"
-Cohesion: 0.19
-Nodes (27): _derive_fuseki_urls(), _fuseki_base(), _fuseki_dataset(), GraphBackendConfig, is_legacy_graphdb_enabled(), Central graph backend resolution (Fuseki / SPARQL vs explicit GraphDB legacy)., SPARQL query URL for autonomy reads (AUTONOMY_GRAPH_QUERY_URL wins, then RDF_STO, SPARQL update URL for autonomy writes (AUTONOMY_GRAPH_UPDATE_URL wins, then RDF_ (+19 more)
+### Community 307 - "Community 307"
+Cohesion: 0.14
+Nodes (29): input_features_for_version(), _variance_gate(), _feature(), _inner_row(), CompletedProcess, datetime, Path, Without feature_names, behavior stays the plain fraction-based gate --     backw (+21 more)
 
-### Community 313 - "Community 313"
+### Community 308 - "Community 308"
 Cohesion: 0.16
 Nodes (27): build_turn_trace(), classify_log_line(), cmd_dump(), cmd_latest(), cmd_live(), _docker_logs(), extract_correlation_id(), _fetch_grammar_summaries() (+19 more)
 
-### Community 314 - "Community 314"
-Cohesion: 0.12
-Nodes (18): In-memory LRU cache of per-turn substrate effect snapshots., SubstrateEffectCache, SubstrateEffectSnapshot, Any, Run the appraiser end-to-end. Stash a snapshot in `cache`. Return summary., run_substrate_effect_pipeline(), _summary_dict(), _make_snapshot() (+10 more)
-
-### Community 315 - "Community 315"
+### Community 309 - "Community 309"
 Cohesion: 0.22
 Nodes (29): asBool(), asList(), asObject(), calloutSeverityClass(), chip(), escapeHtml(), findPhaseTelemetry(), hasSourceTagLeakage() (+21 more)
 
-### Community 317 - "Community 317"
-Cohesion: 0.17
-Nodes (29): app_client(), _load_app(), MonkeyPatch, Path, Tests for proposal review API on orion-context-exec., _seed_store(), store_path(), test_context_exec_app_mounts_proposal_review_routes_when_enabled() (+21 more)
+### Community 311 - "Community 311"
+Cohesion: 0.12
+Nodes (25): BaseSettings, Settings, client(), corpus_root(), MonkeyPatch, Path, TestClient, MonkeyPatch (+17 more)
 
-### Community 318 - "Community 318"
+### Community 312 - "Community 312"
 Cohesion: 0.22
 Nodes (14): BaseModelOutputWithPast, Cache, CausalLMOutputWithPast, FloatTensor, LongTensor, multinomial_num_samples_1(), _prepare_4d_causal_attention_mask_with_cache_position(), device (+6 more)
 
-### Community 319 - "Community 319"
-Cohesion: 0.12
-Nodes (25): DimensionRule, load_signal_drive_map(), Path, ValueError, Load + validate the structural signal->drive map (spec 2026-07-07 §3).  The map, Dimension rules for a signal_kind; empty list if unmapped., Resolve a concrete (signal_kind, dimension) to its rule, if any.          Exact, Parse and validate the YAML map. Raises SignalDriveMapError on any     structura (+17 more)
-
-### Community 320 - "Community 320"
+### Community 313 - "Community 313"
 Cohesion: 0.11
 Nodes (19): main(), create_default_planner(), Path, Convenience helper to construct a SemanticPlanner using the standard     verbs/, ExecutionPlan, ExecutionStep, Any, Path (+11 more)
 
-### Community 321 - "Community 321"
-Cohesion: 0.11
-Nodes (20): build_identity_snapshot(), datetime, IdentitySnapshotV1, _snapshot_id(), IdentitySnapshotV1, BaseModel, BaseModel, SelfStatePredictionV1 (+12 more)
-
-### Community 322 - "Community 322"
+### Community 314 - "Community 314"
 Cohesion: 0.15
 Nodes (24): _appraisal(), consolidation_memory_gate(), Any, _significance(), _atom_semantic_role(), fetch_grammar_evidence_for_window(), _parse_event_json(), Any (+16 more)
 
-### Community 323 - "Community 323"
-Cohesion: 0.16
-Nodes (26): _healthy(), Phase H eval harness — efficacy + resonance over synthetic corpora.  This is the, _runaway(), test_detector_fires_on_synthetic_runaway_loop(), test_detector_isolates_runaway_amid_healthy_noise(), test_detector_silent_on_healthy_loop(), detect_resonance(), datetime (+18 more)
+### Community 315 - "Community 315"
+Cohesion: 0.12
+Nodes (25): normalize_collapse_entry(), should_route_to_triage(), _load_executor_module(), main(), main(), _load_executor_module(), test_change_type_dict_coercion(), test_fail_fast_skips_enrich_when_draft_fails() (+17 more)
 
-### Community 324 - "Community 324"
-Cohesion: 0.10
-Nodes (13): prediction_error_mutation_signals(), Map sustained self-model prediction error to governed mutation signals.      Ret, _self_state(), test_calm_self_model_emits_nothing(), test_single_weak_signal_is_below_threshold_but_sustained_error_drafts_a_proposal(), test_sustained_self_model_error_emits_only_supported_cognitive_signals(), scheduler_fixture(), _self_revision_self_state() (+5 more)
+### Community 316 - "Community 316"
+Cohesion: 0.15
+Nodes (27): _artifact_evidence_count(), artifact_repo_evidence_count(), _blocked_summary(), count_evidence(), evaluate_investigation_outcome(), explicit_fake_run_requested(), grounding_required(), _grounding_sources_attempted() (+19 more)
 
-### Community 325 - "Community 325"
+### Community 317 - "Community 317"
 Cohesion: 0.09
 Nodes (29): orion-gpu-cluster-power service (compose), orion-gpu-cluster-power requirements.txt, compression_policy.v1.yaml (scopes, clustering, summarization policy), orion-graph-compression service (compose), GraphCompressionRegionMaterializedV1 (bus event schema), MutationPressureEvidenceV1 (bus event schema), orion-graph-compression service (README), orion-graph-compression requirements.txt (networkx/leidenalg/igraph) (+21 more)
 
-### Community 326 - "Community 326"
-Cohesion: 0.12
-Nodes (24): _convex_base_from_settings(), fetch_aitown_status(), Any, AI Town status probe for Hub API., aitown_status(), api_fcc_model_labels(), _maybe_render_mcp_config(), Path (+16 more)
-
-### Community 327 - "Community 327"
+### Community 318 - "Community 318"
 Cohesion: 0.10
 Nodes (29): createRecallCanaryReviewArtifact(), hydrateRecallCanaryProfileSelect(), recordRecallCanaryJudgment(), refreshAutonomyConstitutionModal(), refreshAutonomyReadinessPanel(), refreshCognitiveReviewModal(), refreshCognitiveReviewPanelInto(), refreshRecallCanaryModal() (+21 more)
 
-### Community 328 - "Community 328"
+### Community 319 - "Community 319"
 Cohesion: 0.15
 Nodes (27): AppState, ChatCompletionRequest, ChatMessage, create_chat_completion(), create_embeddings(), EmbeddingRequest, _ensure_model_path(), _format_messages() (+19 more)
 
-### Community 329 - "Community 329"
+### Community 320 - "Community 320"
 Cohesion: 0.11
 Nodes (12): AttentionPublisher, Settings, lifespan(), FastAPI, MeshGuardianService, Settings, Connect to mesh Redis; retry through transient bring-up races (batched compose u, Config (+4 more)
 
-### Community 330 - "Community 330"
+### Community 321 - "Community 321"
 Cohesion: 0.14
-Nodes (23): BaseModel, HTTP API request model (backwards compatibility)., RecallCompareRequestBody, RecallCompareResponseBody, RecallRequestBody, RecallResponseBody, _check_rdf_endpoint(), lifespan() (+15 more)
+Nodes (26): _build_chatturn_keyword_filter(), _build_graphtri_anchor_kind_sparql(), _build_graphtri_anchor_sparql(), _build_sparql_query(), _escape_sparql(), _extract_keywords(), _extract_labels(), fetch_graphtri_anchors() (+18 more)
 
-### Community 331 - "Community 331"
+### Community 322 - "Community 322"
 Cohesion: 0.12
 Nodes (25): _dim(), Regression for the live incident: resource_pressure.score pinned at 1.0     by t, Honest no-signal fallback: when resource_pressure carries no hardware     channe, dominant_evidence is an unvalidated list[str] crossing a service     boundary. A, A malformed >1.0 hardware value must be clamped, not passed through     raw -- a, Regression: dimension_trajectory["resource_pressure"] tracks the delta     of th, When there's no hardware evidence (fallback to the raw score), the     trajector, Regression: handle_semantic_upsert's tissue.update broadcast used to     compute (+17 more)
 
-### Community 332 - "Community 332"
+### Community 323 - "Community 323"
 Cohesion: 0.09
 Nodes (17): BiometricsInput, BaseModel, ChatHistoryInput, BaseModel, DreamFragmentMeta, DreamInput, DreamMetrics, BaseModel (+9 more)
 
-### Community 333 - "Community 333"
-Cohesion: 0.21
-Nodes (21): BaseModel, datetime, Compiled reasoning-summary contracts for turn-time stance consumption (Phase 4)., ReasoningAutonomySummaryV1, ReasoningClaimDigestV1, ReasoningConceptDigestV1, ReasoningSparkSummaryV1, ReasoningSummaryDebugV1 (+13 more)
+### Community 324 - "Community 324"
+Cohesion: 0.13
+Nodes (24): detect_generic_delivery_drift(), detect_unverified_install_commands(), looks_like_meta_plan(), Any, Lightweight answer-quality evaluator.  Flags meta-plan or shallow outputs that s, Return (should_rewrite, reason).     For tutorial/implementation output modes, f, Fail-closed when contract disallows unverified specifics and install commands ap, Lowercased tokens from findings the pipeline treated as verified evidence. (+16 more)
 
-### Community 334 - "Community 334"
+### Community 325 - "Community 325"
+Cohesion: 0.14
+Nodes (10): copy_envelope_with_work(), _decode_any(), _field(), _merge_extra_fields(), _normalize_stream_fields(), Any, XREADGROUP for new messages. Each stream entry is decoded independently; malform, DLQ path for decode failures: preserve raw stream fields (esp. envelope bytes). (+2 more)
+
+### Community 326 - "Community 326"
+Cohesion: 0.15
+Nodes (23): MemoryItemV1, A single retrieved memory item., build_recall_v2_plan(), _contains_any(), _extract_entities(), _extract_exact_anchor_tokens(), _extract_project_anchors(), _pageindex_candidates() (+15 more)
+
+### Community 327 - "Community 327"
 Cohesion: 0.15
 Nodes (25): evaluate_salience(), datetime, Pure salience gate for town embodiment episodes.  Decides whether a world event, Cross-event memory for the salience gate.      ``seen_players`` dedupes first-en, Decide whether ``event`` is worth journaling.      Salient cases:       - ``conv, SalienceEvaluation, SalienceState, _utcnow() (+17 more)
 
-### Community 335 - "Community 335"
+### Community 328 - "Community 328"
+Cohesion: 0.12
+Nodes (23): cancel_fcc_turn(), SIGKILL a live FCC claude subprocess for this correlation_id, if any.      If th, HarnessRunCancelV1, Fire-and-forget cancel for an in-flight FCC motor turn (Hub disconnect / abort)., run_bus_worker(), apply_harness_run_cancel(), handle_cancel_bus_message(), Any (+15 more)
+
+### Community 329 - "Community 329"
 Cohesion: 0.19
 Nodes (22): _append_unique(), build_hub_direct_inspection_sections(), build_social_inspection_snapshot(), _candidate_bucket(), _compact_text(), _make_section(), Any, Materialize hub-local inspection sections when bridge turn-policy surfaces are a (+14 more)
 
-### Community 336 - "Community 336"
+### Community 330 - "Community 330"
 Cohesion: 0.19
 Nodes (19): KgEdgeIngestItemV1, KgEdgeIngestV1, BaseModel, TopicFoundryDriftAlertV1, TopicFoundryEnrichCompleteV1, TopicFoundryRunCompleteV1, get_bus_publisher(), Any (+11 more)
 
-### Community 337 - "Community 337"
-Cohesion: 0.20
-Nodes (25): VisionEventCandidateV1, VisionSceneInterpretationV1, _activity_claim_has_caption_slop(), build_person_presence_fallback(), enforce_evidence_grounding(), ensure_grounded_person_presence(), _events_mention_person(), _filter_person_entity_names() (+17 more)
-
-### Community 338 - "Community 338"
+### Community 331 - "Community 331"
 Cohesion: 0.15
 Nodes (8): LocalProfileStore, Any, datetime, Minimal JSON-backed store for latest profiles., True if an autonomy episode has already been composed for this world-pulse run., test_episode_run_processed_ignores_empty_run_id(), test_episode_run_processed_persists_across_instances(), test_episode_run_processed_roundtrip()
 
-### Community 339 - "Community 339"
+### Community 332 - "Community 332"
 Cohesion: 0.10
 Nodes (15): health(), latest(), lifespan(), Any, FastAPI, get_settings(), BaseSettings, Settings (+7 more)
 
-### Community 340 - "Community 340"
-Cohesion: 0.16
-Nodes (9): main(), EquilibriumService, Any, datetime, Shared logic to calculate current distress/zen and build state list., Evaluate distress/zen and publish a baseline metacog trigger when due., _utcnow(), Bytes hash keys from redis must not duplicate str keys from heartbeats. (+1 more)
+### Community 333 - "Community 333"
+Cohesion: 0.12
+Nodes (15): FeedbackRuntimeStore, datetime, _candidate(), _dispatch_frame(), _frame(), _incompatible_dispatch_frame_payload(), test_load_by_dispatch_frame_id(), test_load_cortex_result_evidence_degrades_malformed_row() (+7 more)
 
-### Community 341 - "Community 341"
+### Community 334 - "Community 334"
 Cohesion: 0.10
 Nodes (17): HarnessStepRelay, Queue, Drop liveness bookkeeping for a finished correlation_id., True if a harness step for this correlation_id was observed within `within_sec`., Opportunistically evict liveness entries older than the TTL. Cheap: only scans, HarnessStepRelay fans harness.run.step events to per-correlation queues., Regression test: a burst of unique correlation_ids within a single sweep interva, A step should mark liveness for its correlation_id even with no registered UI qu (+9 more)
 
-### Community 343 - "Community 343"
-Cohesion: 0.28
-Nodes (27): _add_common_artifact(), _add_drive_dimension(), _add_evidence(), _add_lineage(), _add_literal(), _add_source_event_ref(), _add_tensions(), _artifact_type() (+19 more)
+### Community 336 - "Community 336"
+Cohesion: 0.17
+Nodes (25): BaseSettings, Path, Settings, _claims_list_empty(), _coerce_array_claim_item(), _coerce_evidence_refs(), _coerce_semantic_claim_item(), coerce_semantic_llm_root() (+17 more)
 
-### Community 344 - "Community 344"
-Cohesion: 0.12
-Nodes (26): apply_sql_file(), assert_grammar_event_indexes_valid(), bus_transport_trace_batch(), _clear_app_namespace(), delete_trace(), ensure_grammar_schema(), grammar_session_factory(), _is_executable_sql() (+18 more)
-
-### Community 345 - "Community 345"
+### Community 337 - "Community 337"
 Cohesion: 0.19
 Nodes (14): CrystallizationConfidence, infer_confidence(), Deterministic confidence tier from evidence + recurrence. No LLM, no I/O.      R, CrystallizationEvidenceRefV1, Pool, Best-effort: grammar events may live in substrate tables or bus-only., resolve_crystallization_sources(), resolve_evidence_ref() (+6 more)
 
-### Community 346 - "Community 346"
-Cohesion: 0.20
-Nodes (26): EffectKind, _agent_chain_delegate_status(), _agent_chain_delegate_summary(), _agent_chain_failure_detail(), _agent_chain_failure_signals(), _agent_delegate_payload(), _agent_delegate_service_key(), _bound_capability_payload() (+18 more)
+### Community 338 - "Community 338"
+Cohesion: 0.23
+Nodes (11): next_run_for_recurring_schedule(), BaseModel, WorkflowScheduleAnalyticsV1, WorkflowScheduleEventRecordV1, WorkflowScheduleRecordV1, WorkflowScheduleRunRecordV1, ClaimedSchedule, Any (+3 more)
 
-### Community 347 - "Community 347"
-Cohesion: 0.09
-Nodes (25): HTMLResponse, Any, Server-side AI Town tab HTML fragments for Hub index render., render_aitown_tab_blocks(), Normalize HUB_AUTONOMY_SUBJECT_DISPLAY for Hub template injection (two|three)., Serves the main Hub UI (index.html)., resolve_hub_autonomy_subject_display(), root() (+17 more)
+### Community 339 - "Community 339"
+Cohesion: 0.21
+Nodes (20): BaseModel, datetime, Compiled reasoning-summary contracts for turn-time stance consumption (Phase 4)., ReasoningAutonomySummaryV1, ReasoningClaimDigestV1, ReasoningConceptDigestV1, ReasoningSparkSummaryV1, ReasoningSummaryDebugV1 (+12 more)
 
-### Community 348 - "Community 348"
-Cohesion: 0.10
-Nodes (22): Collapse Mirror split invariant (Strict/Juniper vs Metacog/Orion; rationale: metacog mirrors must never hit Juniper's triage/enrichment pipeline by default), Metacog/Spark Surgical Patch Tracker, Oríon identity + response-policy profile, actions.respond_to_juniper_collapse_mirror.v1 verb, CollapseMirrorEntryV1, should_route_to_triage(), main(), build_services() (+14 more)
-
-### Community 349 - "Community 349"
-Cohesion: 0.19
-Nodes (20): CollapseMirrorStore, create_entry_from_v2(), enrich_entry(), _get_store(), Any, Unchanged public entry point: no self_state, no behavior change for any     exis, score_causal_density(), score_causal_density_with_self_state() (+12 more)
-
-### Community 350 - "Community 350"
+### Community 340 - "Community 340"
 Cohesion: 0.18
 Nodes (18): build_artifact_cap_select(), build_artifact_child_delete(), build_subject_age_delete(), cutoff_literal(), GraphRetentionPolicy, parse_retention_policies(), PruneGraphResult, Any (+10 more)
 
-### Community 351 - "Community 351"
-Cohesion: 0.19
-Nodes (21): BiometricsInductionMetricV1, BiometricsPayload, BiometricsSampleV1, BiometricsSummaryV1, BaseModel, _availability_summary(), build_biometrics_node_grammar_events(), _dt() (+13 more)
+### Community 341 - "Community 341"
+Cohesion: 0.11
+Nodes (24): require_operator_token, clear_cursor_resets_for_tests(), cursor_reset_snapshot(), CursorResetRecord, parse_timestamp_at(), Any, datetime, Operator cursor reset auth, validation, and audit trail. (+16 more)
 
-### Community 352 - "Community 352"
+### Community 342 - "Community 342"
 Cohesion: 0.12
-Nodes (24): detect_drive_tensions(), DriveTensionV1, One detected tension between two drives at a single tick.      `drive_a` is the, Detect pairwise inverse-coactivation tensions between drives.      Definition: a, _pairs(), Spec for cross-drive tension detection (`drive_tension.py`).  Tension definition, pressures[drive_b] == deactivate_threshold exactly -> NOT suppressed,     no ten, A hair below the threshold -> suppressed, tension fires. (+16 more)
+Nodes (14): enable_autonomy_graphdb(), _Lookup, MonkeyPatch, Gate + dummy endpoint so ``_load_autonomy_state`` exercises the graph path when, _Repo, test_autonomy_lookup_turn_log_distinguishes(), test_chat_stance_autonomy_debug_contains_unavailable_reason(), test_chat_stance_inputs_include_autonomy_summary_when_available() (+6 more)
 
-### Community 353 - "Community 353"
-Cohesion: 0.15
-Nodes (24): attention_broadcast_enabled(), broadcast_projection_from_frame(), build_substrate_attention_frame(), _current_history(), _node_salience(), Any, datetime, Continuous global broadcast — rung 3 of the self-modeling loop.  The workspace c (+16 more)
-
-### Community 354 - "Community 354"
+### Community 343 - "Community 343"
 Cohesion: 0.19
 Nodes (26): _draft_ctx(), _load_executor_module(), _load_template(), Replay spec §2 section sizes (minus removed biometrics_json blob)., test_draft_ctx_overflow_after_cue_and_spark_trim(), test_draft_trims_biometrics_cue_before_ctx_overflow_fallback(), test_enrich_ctx_overflow_after_biometrics_trim(), test_enrich_prompt_uses_enrich_biometrics_cue() (+18 more)
 
-### Community 355 - "Community 355"
+### Community 344 - "Community 344"
+Cohesion: 0.13
+Nodes (22): _convex_base_from_settings(), fetch_aitown_status(), Any, AI Town status probe for Hub API., aitown_status(), api_fcc_model_labels(), run_turn_from_settings(), catalog_from_settings() (+14 more)
+
+### Community 345 - "Community 345"
 Cohesion: 0.17
 Nodes (21): ProbeResult, run_probe(), load_roster(), ProbeConfig, ProbeMode, BaseModel, Enum, str (+13 more)
 
-### Community 356 - "Community 356"
+### Community 346 - "Community 346"
+Cohesion: 0.15
+Nodes (21): BaseModel, HTTP API request model (backwards compatibility)., RecallCompareRequestBody, RecallCompareResponseBody, RecallRequestBody, RecallResponseBody, _check_rdf_endpoint(), lifespan() (+13 more)
+
+### Community 347 - "Community 347"
+Cohesion: 0.12
+Nodes (14): datetime, Cache the latest town perception as a best-effort observability input., Return the age-gated embodied-perception grounding signal, or ``None``., SelfStateRuntimeWorker, _make_worker(), _perception(), Unit tests for the Orion embodiment perception grounding input.  Verifies the se, test_flag_off_ignores_perception() (+6 more)
+
+### Community 348 - "Community 348"
+Cohesion: 0.12
+Nodes (14): BeliefObserveResult, Any, Per-stream scene label habituation (observed → believed tier)., Enter votes: empty ring slots inherit last non-empty labels (flicker fix)., Exit votes: count only labels present in each raw observation., SceneBeliefRegistry, SceneBeliefTracker, test_belief_ignores_single_empty_observation() (+6 more)
+
+### Community 349 - "Community 349"
 Cohesion: 0.20
 Nodes (25): CompletedProcess, Path, Tests for operator proposal CLI., _run_cli(), _seed_and_approve(), store_path(), test_dry_run_execute_creates_receipt_without_mutation(), test_dry_run_execute_does_not_change_memory() (+17 more)
 
-### Community 357 - "Community 357"
+### Community 350 - "Community 350"
+Cohesion: 0.12
+Nodes (24): Depends, require_quarantine_operator_token, acknowledge_quarantine(), Internal operator endpoint. Acknowledges durable poison quarantine without erasi, clear_quarantine_acks_for_tests(), Any, quarantine_ack_snapshot(), QuarantineAckRecord (+16 more)
+
+### Community 351 - "Community 351"
+Cohesion: 0.12
+Nodes (12): deque, CognitionTracePayload, BaseModel, A canonical trace of a cognition run.      This is the payload published on the, # NOTE: correlation_id belongs to the Titanium/BaseEnvelope. We accept an, _load_worker_module(), main(), handle_trace() (+4 more)
+
+### Community 352 - "Community 352"
 Cohesion: 0.13
 Nodes (22): Environment, test_chat_general_prompt_contains_identity_and_behavior_rails(), test_chat_general_prompt_menu_topic_selection_disallows_fabricated_tools_and_links(), test_chat_quick_prompt_contains_recall_and_forbidden_rails(), test_social_room_prompt_includes_agreement_and_disagreement_grounding(), test_social_room_prompt_includes_compact_relational_memory_sections(), test_social_room_prompt_includes_social_skill_support_when_selected(), test_social_room_prompt_includes_style_and_ritual_grounding() (+14 more)
 
-### Community 358 - "Community 358"
+### Community 353 - "Community 353"
 Cohesion: 0.09
 Nodes (26): datasets (PyPI dependency), fastapi (PyPI dependency), httpx (PyPI dependency), loguru (PyPI dependency), numpy (PyPI dependency), orjson (PyPI dependency), pydantic (PyPI dependency), PyYAML (PyPI dependency) (+18 more)
 
-### Community 359 - "Community 359"
+### Community 354 - "Community 354"
 Cohesion: 0.17
-Nodes (23): autonomy_graph_backend_raw(), autonomy_graph_reads_explicitly_enabled(), _env_float(), is_quick_autonomy_graph_lane(), _parse_subjects_csv(), _parse_subqueries_csv(), Any, Autonomy graph read gate: Fuseki/SPARQL by default; explicit GraphDB legacy only (+15 more)
+Nodes (22): _normalize(), _parse_time(), BaseModel, resolve_workflow_schedule_management(), WorkflowScheduleManagementIntent, get_workflow_definition(), _journal_discussion_window_command_intent(), list_workflows() (+14 more)
 
-### Community 360 - "Community 360"
-Cohesion: 0.16
-Nodes (24): SelectedFrontierMatterV1, Project the mode-agnostic self/attention subset of a Mind run.      Returns None, select_mind_coloring(), _frontier(), Eval: Mind coloring is mode-agnostic and never leaks task-control into the unifi, _request(), _result(), test_context_injection_does_not_touch_stance_authoring() (+16 more)
+### Community 355 - "Community 355"
+Cohesion: 0.14
+Nodes (21): AgentChainRequest, AgentChainResult, Primary entry point for the Agent Chain service., Response from Agent Chain., agent_chain_request_to_context_exec(), context_exec_run_to_agent_chain_result(), _parse_answer_contract(), Any (+13 more)
 
-### Community 361 - "Community 361"
+### Community 356 - "Community 356"
 Cohesion: 0.18
 Nodes (18): BaseModel, SocialShakedownFixV1, SocialShakedownIssueV1, load_scenarios(), load_shakedown_pack(), Path, SocialRoomShakedownWorkflow, test_social_room_replay_failures_are_inspectable() (+10 more)
 
-### Community 362 - "Community 362"
+### Community 357 - "Community 357"
+Cohesion: 0.15
+Nodes (24): compute_tick_attribution(), dominant_drive_from_attribution(), primary_drive_for_tension_kind(), Sum magnitude × drive_impact weight per drive for THIS tick only., Structural map for tie-break; not digest keyword matching., Argmax attribution; tie-break cascade when multiple drives share the max.      1, Highest magnitude this tick; substrate gap preferred on magnitude tie., select_lead_tension() (+16 more)
+
+### Community 358 - "Community 358"
 Cohesion: 0.19
 Nodes (20): _check(), HealthCheck, HealthMonitor, Settings, Severity, Edge-triggered health monitor: fires an orion-notify attention request only, run_checks(), _client_mock() (+12 more)
 
-### Community 363 - "Community 363"
-Cohesion: 0.18
-Nodes (24): _base_stance_for_shadow(), _build_exec_late_shadow_synthesis(), _env_float(), _inject_projection_debug(), _inline_projection_from_metadata(), install_chat_stance_shared_spine(), _label_for_projection_item(), _projection_debug_bundle() (+16 more)
+### Community 359 - "Community 359"
+Cohesion: 0.27
+Nodes (25): _bus(), _clamp_limit(), _clamp_offset(), _http_if_missing_memory_schema(), _maybe_emit_card_for_crystallizer(), memory_add_edge(), memory_change_status(), memory_create_card() (+17 more)
 
-### Community 364 - "Community 364"
+### Community 360 - "Community 360"
 Cohesion: 0.11
 Nodes (13): attachFormEditor(), dateInput(), debounce(), defaultCardProjectionDefaults(), el(), entityMultiSelect(), entityOptionLabel(), entitySelect() (+5 more)
 
-### Community 365 - "Community 365"
-Cohesion: 0.10
-Nodes (15): _MemoryGraphNoRetryClient, _MemoryGraphRetryClient, _ReasoningBrainClient, _ReasoningQuickClient, test_handle_chat_request_does_not_retry_memory_graph_with_explicit_llm_route(), test_handle_chat_request_exports_turn_effect_into_result_payload(), test_handle_chat_request_ingests_nested_executor_recall_pressure_events(), test_handle_chat_request_ingests_recall_debug_pressure_events() (+7 more)
+### Community 361 - "Community 361"
+Cohesion: 0.12
+Nodes (16): _alert_row(), _delta_row(), _FakeConn, _FakeEngine, _FakeResult, _queue_row(), _row(), test_compaction_delta_section_none_when_empty() (+8 more)
 
-### Community 366 - "Community 366"
+### Community 362 - "Community 362"
+Cohesion: 0.14
+Nodes (19): GPUConfig, LlamaCppConfig, LLMProfile, LLMProfileRegistry, BaseModel, BaseSettings, LLMProfile, LLMProfileRegistry (+11 more)
+
+### Community 363 - "Community 363"
 Cohesion: 0.17
 Nodes (24): _count_unstable_spans(), _entropy_proxy(), extract_llm_uncertainty_from_native_completion(), extract_llm_uncertainty_from_openai_response(), native_completion_probs_to_logprob_content(), Any, Summary-only language-surface stability metrics from OpenAI logprobs., Normalize llama.cpp /completion prob shapes into OpenAI logprobs.content entries (+16 more)
 
-### Community 367 - "Community 367"
-Cohesion: 0.16
-Nodes (25): build_report(), collapse_reasons(), discover_encoder_dirs(), evaluate_run(), filter_eval_rows(), format_text_report(), headline_fit_stats(), HeadlineFitStats (+17 more)
+### Community 364 - "Community 364"
+Cohesion: 0.12
+Nodes (16): _FakeConnection, _FakePubSub, _FakeRedis, _make_bus(), Regression coverage for OrionBusAsync._run_rpc_only.  Live incident (2026-07-11,, Once a real caller subscribes a reply channel (as HarnessGovernorClient._run_via, A genuine read failure (network blip) must not kill the worker permanently —, A malformed/unexpected message must degrade like a transport error (reconnect (+8 more)
 
-### Community 368 - "Community 368"
-Cohesion: 0.13
-Nodes (14): BeliefObserveResult, Any, Per-stream scene label habituation (observed → believed tier)., Enter votes: empty ring slots inherit last non-empty labels (flicker fix)., Exit votes: count only labels present in each raw observation., SceneBeliefRegistry, SceneBeliefTracker, test_belief_ignores_single_empty_observation() (+6 more)
-
-### Community 369 - "Community 369"
+### Community 365 - "Community 365"
 Cohesion: 0.11
 Nodes (12): dict, LlamaForCausalLM, IntentionForCausalLM, _FakeBatch, _FakeTokenizer, LlamaConfig, test_bc_mode_is_deterministic_across_repeated_calls(), test_bc_mode_returns_three_tensors_with_valid_distribution() (+4 more)
 
+### Community 366 - "Community 366"
+Cohesion: 0.18
+Nodes (23): autonomy_graph_backend_raw(), autonomy_graph_reads_explicitly_enabled(), _env_float(), is_quick_autonomy_graph_lane(), _parse_subjects_csv(), _parse_subqueries_csv(), Any, Autonomy graph read gate: Fuseki/SPARQL by default; explicit GraphDB legacy only (+15 more)
+
+### Community 367 - "Community 367"
+Cohesion: 0.10
+Nodes (18): Any, Session, Idempotent spark_telemetry persistence keyed by correlation_id., upsert_spark_telemetry(), _make_emit(), Shape checks for the action-outcome SQL write path (no Postgres required).  Asse, Re-delivery of the same action_id must upsert (one row), not duplicate.      Mir, test_emit_data_constructs_action_outcome_sql_without_raising() (+10 more)
+
+### Community 368 - "Community 368"
+Cohesion: 0.23
+Nodes (24): SelfKnowledgeItemV1, SelfKnowledgeSectionCountsV1, SelfRepoInspectResultV1, build_self_snapshot(), build_self_study_summary(), _canonical_snapshot_payload(), _channel_items(), _counts_for_sections() (+16 more)
+
+### Community 369 - "Community 369"
+Cohesion: 0.18
+Nodes (23): agent_repl_enabled(), build_context_exec_request(), _infer_context_exec_mode(), investigation_v2_enabled(), _hub_imports(), Agent lane builds an agent_repl request with no keyword classification., _req(), test_agent_lane_never_builds_investigation_v2() (+15 more)
+
 ### Community 370 - "Community 370"
-Cohesion: 0.14
-Nodes (12): EmailTransport, _split_mime(), enrich_with_policy(), datetime, _build_email_transport(), _load_policy(), _parse_time(), Policy (+4 more)
+Cohesion: 0.13
+Nodes (17): _epoch(), _extract_turn_effect_delta(), _filter_excluded_rows(), _is_current_turn_echo(), _memory_filter_clause(), _normalize_text(), _parse_row(), _parse_spark_meta() (+9 more)
 
 ### Community 371 - "Community 371"
-Cohesion: 0.14
-Nodes (22): normalize_collapse_entry(), _load_executor_module(), main(), _load_executor_module(), test_change_type_dict_coercion(), test_fail_fast_skips_enrich_when_draft_fails(), test_metacog_entry_id_differs_from_trigger_corr(), test_metacog_source_service_is_stamped() (+14 more)
-
-### Community 372 - "Community 372"
-Cohesion: 0.15
-Nodes (19): BaseModel, datetime, Normalized signal contract for Spark., SparkSignalV1, _build_snapshot_payload(), chassis_cfg(), _cluster_trend(), _constraint_from_snapshot() (+11 more)
-
-### Community 373 - "Community 373"
-Cohesion: 0.20
-Nodes (23): main(), _parse_args(), Namespace, Pure: load + gate-check a corpus, return the full report dict. Never raises., run_diag(), features_version(), input_features(), _feature() (+15 more)
-
-### Community 374 - "Community 374"
-Cohesion: 0.17
-Nodes (23): _arousal_band(), _as_float(), _center_valence(), _clarity_band(), _format_value(), _overload_band(), Any, Compact, structured bins suitable for embedding in mirror telemetry hints.     ( (+15 more)
-
-### Community 375 - "Community 375"
-Cohesion: 0.08
-Nodes (3): test_execute_once_endpoint_is_single_cycle_operator_only_and_followup_default_off(), test_execute_once_followup_endpoint_keeps_followup_explicit(), test_self_experiments_trigger_daily_publishes_bus_event()
-
-### Community 376 - "Community 376"
-Cohesion: 0.12
-Nodes (13): _DreamWorkflowClient, _FakeCortexClient, _FakeWebSocket, The WS turn-completion path must mirror the HTTP path's best-effort     hub_pres, record_turn() is best-effort: if it raises, the WS chat turn must still     comp, test_handle_chat_request_marks_dream_workflow_as_metadata_only(), test_http_chat_path_exports_autonomy_payload_for_brain_lane(), test_http_chat_path_preserves_scheduled_workflow_policy() (+5 more)
-
-### Community 377 - "Community 377"
 Cohesion: 0.09
 Nodes (25): chromadb dependency (vector store backend), orion-vector-writer service, orion-vision-council docker-compose config, evidence_grounding.py choke point, evidence_transition.py choke point, orion-vision-council service, orion-vision-council dependencies (fastapi, redis, pydantic), orion-vision-edge live MJPEG/SSE debug UI (+17 more)
 
-### Community 378 - "Community 378"
+### Community 372 - "Community 372"
 Cohesion: 0.14
 Nodes (20): _autonomy_state(), _mock_store(), Build a mock LocalProfileStore class whose instances' load_drive_state     retur, test_compare_drives_both_present_real_divergence(), test_compare_drives_corrupted_pressure_value_does_not_crash(), test_compare_drives_drive_state_missing(), test_load_autonomy_state_present(), test_load_drive_state_v1_missing_store_returns_none_no_error() (+12 more)
 
-### Community 379 - "Community 379"
+### Community 373 - "Community 373"
 Cohesion: 0.14
 Nodes (12): CountVectorizer, capabilities(), VectorHostEmbeddingProvider, build_topic_engine(), _build_vectorizer(), _parse_topic_list(), _parse_zeroshot_list(), Any (+4 more)
 
-### Community 380 - "Bus Channels: Meta-Tags & KG Edge Ingest"
+### Community 374 - "Community 374"
 Cohesion: 0.10
 Nodes (24): Channel "orion:actions:audit" (kind=event, schema=GenericPayloadV1) producers=[orion-actions] consumers=[none], Channel "orion:actions:manage:result:*" (kind=result, schema=WorkflowScheduleManageResponseV1) producers=[orion-actions] consumers=[orion-cortex-orch], Channel "orion:actions:manage:workflow.v1" (kind=request, schema=WorkflowScheduleManageRequestV1) producers=[orion-cortex-orch] consumers=[orion-actions], Channel "orion:actions:trigger:daily_metacog.v1" (kind=event, schema=GenericPayloadV1) producers=[orion-actions] consumers=[orion-actions], Channel "orion:actions:trigger:daily_pulse.v1" (kind=event, schema=GenericPayloadV1) producers=[orion-actions, orion-cortex-exec] consumers=[orion-actions], Channel "orion:actions:trigger:workflow.v1" (kind=event, schema=WorkflowDispatchRequestV1) producers=[orion-cortex-orch, orion-actions] consumers=[orion-actions], Channel "orion:agent-council:intake" (kind=request, schema=GenericPayloadV1) producers=[orion-hub, orion-cortex-exec] consumers=[orion-agent-council], Channel "orion:agent-council:reply*" (kind=result, schema=GenericPayloadV1) producers=[orion-agent-council] consumers=[orion-hub, orion-cortex-exec] (+16 more)
 
-### Community 381 - "Community 381"
+### Community 375 - "Community 375"
 Cohesion: 0.11
 Nodes (24): concept_induction_pass Workflow, Concept Profile Repository Seam, orion-chat-memory Docker Compose Service, orion-chat-memory Python Dependencies, orion-collapse-mirror Docker Compose Service, Orion Collapse Mirror Service, orion-collapse-mirror Python Dependencies, orion-consolidation-runtime Docker Compose Service (+16 more)
 
-### Community 382 - "Community 382"
-Cohesion: 0.17
-Nodes (18): EpisodeSummaryV1, BaseModel, Episodic continuity contracts (self-modeling loop, rung 4).  An episode is a pro, derive_episode_id(), EpisodicConsolidationEvaluator, datetime, Episodic continuity — rung 4 of the self-modeling loop.  `GraphConsolidationEval, Windowed rollup alongside the region-based GraphConsolidationEvaluator. (+10 more)
-
-### Community 383 - "Community 383"
+### Community 376 - "Community 376"
 Cohesion: 0.17
 Nodes (9): filter_temps(), BiometricsCollector, collect_biometrics(), _CpuTimes, _DiskStats, _NetStats, Any, collect_gpu_stats() (+1 more)
 
-### Community 384 - "Community 384"
-Cohesion: 0.16
-Nodes (15): ContextExecEventEmitter, Any, ContextExecMode, Publishes lifecycle events to orion:context_exec:event., TraceHit, _corr_in_payload(), _make_handle(), _matches_query() (+7 more)
-
-### Community 385 - "Community 385"
-Cohesion: 0.12
-Nodes (23): build_route_arbitration_grammar_events(), _dt(), _event(), _hash_id(), Any, datetime, Orch route-arbitration grammar event emitter.  Pure builder -- no I/O, no Redis,, Build the two-event shadow trace for one turn's route arbitration.      Pure fun (+15 more)
-
-### Community 386 - "Community 386"
+### Community 377 - "Community 377"
 Cohesion: 0.12
 Nodes (24): forgeBadgeClass(), forgeHideSourceIngestError(), forgeRenderBadge(), forgeRenderClaimsList(), forgeRenderCompileResult(), forgeRenderCompileSpecCheckboxes(), forgeRenderReviewsList(), forgeRenderSearchResults() (+16 more)
 
-### Community 387 - "Community 387"
+### Community 378 - "Community 378"
 Cohesion: 0.14
 Nodes (11): apply_rotary_pos_emb(), LlamaMergeMLP, LlamaRMSNorm, LlamaRotaryEmbedding, LlamaConfig, LlamaRMSNorm is equivalent to T5LayerNorm, dynamic RoPE layers should recompute `inv_freq` in the following situations:, Rotates half the hidden dims of the input. (+3 more)
 
-### Community 388 - "Community 388"
-Cohesion: 0.14
-Nodes (13): _fetch_rollups(), get_rollups(), lifespan(), FastAPI, Record, Any, datetime, StateJournaler (+5 more)
-
-### Community 389 - "Community 389"
-Cohesion: 0.13
-Nodes (21): _cfg(), _handle_biometrics(), _handle_get_latest(), _handle_snapshot(), health(), http_debug(), http_get_latest(), _hydrate_from_postgres() (+13 more)
-
-### Community 390 - "Community 390"
+### Community 379 - "Community 379"
 Cohesion: 0.19
 Nodes (22): AttentionSchemaType, derive_attention_schema(), Derive (attention_schema_type, attention_dwell_ticks, attention_node_count)., _build_state(), _open_loop(), _projection(), Tests for attention schema derivation in the self-state build path., All attention schema type values are valid on SelfStateV1. (+14 more)
 
-### Community 391 - "Community 391"
+### Community 380 - "Bus Channels: Meta-Tags & KG Edge Ingest"
 Cohesion: 0.18
 Nodes (20): cortex_exec_failure_detail(), extract_cortex_payload_text(), _openai_choice_message_text(), Any, Extract model text / JSON-bearing strings from Cortex PlanExecutionResult-shaped, Summarize why a cortex exec payload has no usable model text., Return best-effort model text from a cortex exec payload (may be JSON-ish prose), _service_block_text_candidates() (+12 more)
 
-### Community 392 - "Community 392"
-Cohesion: 0.14
-Nodes (19): cancel_fcc_turn(), SIGKILL a live FCC claude subprocess for this correlation_id, if any.      If th, apply_harness_run_cancel(), handle_cancel_bus_message(), Any, Validate cancel payload and kill the matching FCC subprocess if live., Subscribe to harness run cancel events and kill matching FCC motors., run_cancel_worker() (+11 more)
-
-### Community 393 - "Community 393"
+### Community 381 - "Community 381"
 Cohesion: 0.20
 Nodes (21): _assert_write_targets_allowed(), build_source_delta_review(), _bullet_line_number(), find_possibly_affected_specs(), _infer_title(), ingest_source(), IngestSourceResult, parse_source_markdown() (+13 more)
 
-### Community 394 - "Community 394"
+### Community 382 - "Community 382"
+Cohesion: 0.19
+Nodes (14): AttributionV1, PhiEncoderRuntime, PhiForwardResult, ndarray, Path, MLP phi encoder runtime — numpy inference + attributions (Plan 2)., _load_phi_encoder(), Path (+6 more)
+
+### Community 383 - "Community 383"
 Cohesion: 0.16
 Nodes (21): example_value_is_host_placeholder(), main(), parse_kv(), Path, Skip syncing template placeholders that must stay host-specific in local .env., Result of syncing one service's .env from its .env_example.      updated: keys a, should_sync_key(), sync_file() (+13 more)
 
-### Community 395 - "Community 395"
+### Community 384 - "Community 384"
+Cohesion: 0.17
+Nodes (18): _daily_notify_request(), _publish_daily_outputs(), _publish_workflow_attention_signal(), _schedule_attention_notify_request(), _send_orion_async_message(), _send_pending_attention(), _dispatch_request(), _FakeNotify (+10 more)
+
+### Community 385 - "Community 385"
+Cohesion: 0.15
+Nodes (17): build_rollup_from_redis_snapshot(), _fetch_redis_snapshot(), load_channel_catalog_names(), ObserverRollup, Any, datetime, Path, Settings (+9 more)
+
+### Community 386 - "Community 386"
 Cohesion: 0.13
 Nodes (23): addNotification(), focusChatInput(), formatHubLocalTime(), handleAttentionAck(), handleChatMessageReceipt(), isAttentionNotification(), isChatMessageNotification(), isNotificationTrayItem() (+15 more)
 
-### Community 396 - "Community 396"
+### Community 387 - "Community 387"
 Cohesion: 0.14
 Nodes (20): _extract_keywords(), fetch_graph_compression_fragments(), _fetch_summary_from_fuseki(), _get_engine(), Any, Query Postgres artifact index, rank by salience + keyword relevance,     fetch s, Simple salience + keyword hit scoring., _score_artifact() (+12 more)
 
-### Community 397 - "Community 397"
-Cohesion: 0.13
-Nodes (21): _database_url(), _get_engine(), load_recent_chain_theme_events(), load_recent_resonance_alerts(), persist_compaction_request(), persist_resonance_alert(), persist_reverie_chain(), persist_reverie_thought() (+13 more)
+### Community 388 - "Community 388"
+Cohesion: 0.14
+Nodes (19): _broadcast(), Phase C — reverie chain. Deterministic control is fully testable with injected f, _step_always(), test_chain_never_raises_on_step_error(), test_chain_none_when_no_coalition(), test_chain_step_none_terminates_without_raise(), test_chain_suppressed_by_refractory(), test_chain_suppresses_theme_after_completion() (+11 more)
 
-### Community 398 - "Community 398"
-Cohesion: 0.21
-Nodes (11): stream_key_from_window(), InterpretationParseOutcome, CouncilService, lifespan(), FastAPI, test_finalize_drops_youtube_activity_without_hard_person(), test_finalize_host_fallback_on_parse_failure(), test_finalize_injects_person_when_llm_omits_despite_hard_labels() (+3 more)
+### Community 389 - "Community 389"
+Cohesion: 0.16
+Nodes (9): Lock, ModelKey, ModelManager, Any, dtype, Loads GroundingDINO open-vocab detector., Loads a VLM for captioning (e.g. IDEFICS, BLIP-2, Git, etc).         Assumes sta, Lazy per-(profile,device) loader for torch/transformers models.      - Avoids du (+1 more)
 
-### Community 399 - "Community 399"
-Cohesion: 0.17
-Nodes (19): gap_terms_from_signals(), Deterministic term-overlap salience scorer for readonly-fetch articles.  Narrow, Public term tokenizer (lowercase alphanumeric). Reused by producers that     nee, Union of tokens from `section:` focal refs across world_coverage_gap signals., Fraction of gap terms present in the article text, clamped to [0, 1]., score_article_salience(), _tokenize(), tokenize_terms() (+11 more)
+### Community 390 - "Community 390"
+Cohesion: 0.20
+Nodes (10): _attempt_from_envelope(), _expires_at(), BaseException, datetime, QueueRabbit, Returns True if message should be acked without handler., Stream consumer chassis: one worker per delivery (Redis consumer group),     rep, extract_work_metadata() (+2 more)
 
-### Community 400 - "Community 400"
-Cohesion: 0.23
-Nodes (20): _engine_for(), load_expectations_for_motif(), _load_latest_consolidation_frame(), load_latest_tensor_slices(), load_recent_motifs(), load_schema_candidates(), _parse_json(), Engine (+12 more)
+### Community 391 - "Community 391"
+Cohesion: 0.10
+Nodes (7): WorkQueueDecodeError, _cfg(), _noop_handler(), _qr(), _sm(), test_decode_failure_dlq_and_ack_when_dlq_configured(), test_decode_failure_no_dlq_leaves_pending()
 
-### Community 401 - "Community 401"
+### Community 392 - "Community 392"
 Cohesion: 0.25
 Nodes (20): _match(), _nearest(), _others(), _pos(), Any, resolve_destination(), _resolve_target(), ResolveResult (+12 more)
 
-### Community 402 - "Community 402"
+### Community 393 - "Community 393"
+Cohesion: 0.18
+Nodes (17): BaseSettings, Settings, MonkeyPatch, test_factory_default_graphdb_requires_url(), test_factory_fuseki_does_not_require_graphdb_url(), test_factory_generic_builds_generic_client(), test_factory_graphdb_builds_graphdb_when_url_present(), test_factory_rdf4j_aliases_generic() (+9 more)
+
+### Community 394 - "Community 394"
 Cohesion: 0.21
 Nodes (21): RdfWriteResult, _strip_credentials(), _append_deadletter(), _evict_dedupe_cache(), _execute_write_job(), handle_envelope(), _handle_write_final_failure(), _inflight_slot() (+13 more)
 
-### Community 403 - "Community 403"
+### Community 395 - "Community 395"
+Cohesion: 0.15
+Nodes (14): Path, Persisted cursor date: forced-window label when ACTIONS_DAILY_RUN_ONCE_DATE is s, Durable last-completed local calendar dates for built-in daily scheduler jobs., resolve_scheduler_cursor_store_path(), scheduler_cursor_completed_local_date(), SchedulerCursorStore, Path, test_resolve_scheduler_cursor_store_path_default_next_to_workflow() (+6 more)
+
+### Community 396 - "Community 396"
 Cohesion: 0.13
 Nodes (22): enableMindModalFocusTrap(), escapeHtml(), fetchMindRunDetail(), formatMindRunsApiError(), formatMindTs(), getMindModalTabbables(), mindJsonPrettyObject(), mindRequestOverviewHtml() (+14 more)
 
-### Community 404 - "Community 404"
+### Community 397 - "Community 397"
 Cohesion: 0.26
 Nodes (21): _cleanup_hub_path_pollution(), hub_client(), MonkeyPatch, TestClient, Hub proposal review client, routes, and review actions., Prevent hub reload from shadowing orion-context-exec `app` in later tests., _reload_hub_modules(), test_hub_pending_decisions_shows_denver_memory_correction() (+13 more)
 
-### Community 405 - "Community 405"
-Cohesion: 0.13
-Nodes (6): configured_routes(), MonkeyPatch, TestClient, test_resolve_anthropic_route_falls_back_when_model_missing(), test_resolve_anthropic_route_missing_returns_error(), TestAnthropicPassthroughHTTP
-
-### Community 406 - "Community 406"
+### Community 398 - "Community 398"
 Cohesion: 0.13
 Nodes (14): MindRunBudget, Wall-clock budget for Cortex-governed Mind LLM phases., Tracks remaining wall time for a single MindRun and caps per-phase timeouts., _mind_prep(), MonkeyPatch, Wall-clock budget enforcement (loop_budget_exceeded)., Simulate snapshot phase taking longer than policy allows., Regression for fix/mind-enrichment-wall-budget: a 12s wall cannot fit even a (+6 more)
 
-### Community 407 - "Community 407"
+### Community 399 - "Community 399"
 Cohesion: 0.11
 Nodes (14): configure_tracing(), _DropSpanExporter, OpenTelemetry tracer setup for the signal gateway (spec §5 gateway instrumentati, Swallows finished spans (no backend); span context IDs are still real., Install a TracerProvider. If ``otlp_endpoint`` is set, export spans there; else, health(), lifespan(), Any (+6 more)
 
-### Community 408 - "Community 408"
+### Community 400 - "Community 400"
 Cohesion: 0.22
 Nodes (20): _elapsed_secs(), enqueue_enrichment(), _enrich_segment(), _extract_evidence(), _finalize_enrichment(), _generate_edges(), _heuristic_enrich(), _llm_enrich() (+12 more)
 
-### Community 409 - "Community 409"
+### Community 401 - "Community 401"
 Cohesion: 0.14
 Nodes (19): _make_service(), Path, Real syntax from services/orion-hub/docker-compose.yml -- the plain string-list, A sidecar service's own environment: keys must never leak into the checked     s, Regression test: the actual orion-recall docker-compose.yml, checked against the, docker-compose also supports `environment:` as a mapping (KEY: value) instead, test_compose_env_file_directive_detected_extended_mapping_form(), test_compose_env_file_directive_detected_inline() (+11 more)
 
-### Community 410 - "Community 410"
+### Community 402 - "Community 402"
 Cohesion: 0.10
 Nodes (21): Turn Visibility Design Spec (2026-07-11), scripts/trace_unified_turn.py (regex hop detector), TurnHopV1 schema (proposed), Clean git and worktree rules (§2): start with git status/branch check, classify dirt before mixing, prefer a separate worktree for parallel subagent work — stated as prose policy, not an enforced mechanism, /brainstorming command (sentience-development ideation), Completion status (§19): every task ends in exactly one of DONE, DONE_WITH_CONCERNS, BLOCKED, or NEEDS_CONTEXT — never 'partially done', Env/config/settings contract (§7): env parity is non-negotiable — any add/remove/rename of an env key must update .env_example, local .env, settings.py, docker-compose.yml, requirements.txt, and README in the same changeset, via scripts/sync_local_env_from_example.py, Event substrate first: grow from events -> schema -> trace -> reducer -> projection -> eval -> UI, not from a hand-authored mind-palace ontology with no runtime proof (+13 more)
 
-### Community 411 - "Community 411"
-Cohesion: 0.14
-Nodes (11): Client, PowerStatus, BaseModel, Parsed snapshot of UPS state from SNMP., NISUPSClient, Reads APC UPS status from a local or remote apcupsd NIS server (TCP 3551)., Connects to apcupsd and requests the 'status' dump., Async wrapper to fetch and parse status.          (We keep it async to match the (+3 more)
-
-### Community 412 - "Community 412"
+### Community 403 - "Community 403"
 Cohesion: 0.14
 Nodes (8): DetectorSpec, FaceDetector, build_detectors(), MotionDetector, PresenceDetector, ndarray, Run detection on BGR frame.         Returns list of (x, y, w, h, label, score)., YoloDetector
 
-### Community 413 - "Community 413"
+### Community 404 - "Community 404"
 Cohesion: 0.12
 Nodes (6): LlamaPreTrainedModel, IntentionModel, IntentionModel_v1, IntentionModel_v1a, IntentionModel_v1p, Transformer decoder consisting of *config.num_hidden_layers* layers. Each layer
 
-### Community 414 - "Community 414"
+### Community 405 - "Community 405"
+Cohesion: 0.20
+Nodes (18): append_action_outcome(), _db_url(), _get_engine(), load_action_outcomes(), _load_from_sql(), _load_raw(), Path, Read the most recent outcomes for a subject from the shared SQL store.      Retu (+10 more)
+
+### Community 406 - "Community 406"
 Cohesion: 0.22
 Nodes (18): _db_url(), _get_engine(), load_autonomy_state_v2(), Postgres-backed persistence for the latest AutonomyStateV2 per subject.  Closes, Load the most recently persisted AutonomyStateV2 for a subject.      Returns Non, Upsert the latest AutonomyStateV2 for a subject.      No-ops when no DSN is conf, save_autonomy_state_v2(), _make_db() (+10 more)
 
-### Community 415 - "Community 415"
+### Community 407 - "Community 407"
 Cohesion: 0.17
 Nodes (16): TensionEventV1, Bound the tension stream: per-source cap, dedup, storm safety (spec §5).  Even w, Source identity: kind + the set of drives it pushes. Two tensions with the     s, Return the subset of ``candidates`` allowed through, updating windows., _signature(), TensionRateLimiter, TensionEventV1, Task 5: rate-limit / dedup / bounded state. (+8 more)
 
-### Community 416 - "Community 416"
-Cohesion: 0.29
-Nodes (14): configure_parity_evidence_store(), ConsumerParityEvidence, get_parity_evidence_snapshot(), ParityEvidenceStore, ParityReadinessThresholds, Any, record_parity_evidence(), reset_parity_evidence_store() (+6 more)
+### Community 408 - "Community 408"
+Cohesion: 0.13
+Nodes (17): extend_mcp_argv(), mcp_allowed_tool_patterns(), mcp_disallowed_tool_patterns(), Any, Path, Shared ``claude -p`` argv helpers for FCC harness bridges., Per-server allow patterns for Claude Code 2.1+ MCP pre-approval.      Use ``mcp_, Block Bash fallbacks that fail in headless Hub (gh not installed). (+9 more)
 
-### Community 417 - "Community 417"
-Cohesion: 0.19
-Nodes (16): BaseSettings, Settings, MonkeyPatch, test_factory_default_graphdb_requires_url(), test_factory_fuseki_does_not_require_graphdb_url(), test_factory_generic_builds_generic_client(), test_factory_graphdb_builds_graphdb_when_url_present(), test_factory_rdf4j_aliases_generic() (+8 more)
-
-### Community 418 - "Community 418"
+### Community 409 - "Community 409"
 Cohesion: 0.22
 Nodes (15): generate(), main(), parse_args(), Namespace, entropy_floor_loss(), fisher_trace_proxy(), ManifoldBatchMetrics, margin_gap_loss() (+7 more)
 
-### Community 419 - "Community 419"
-Cohesion: 0.15
-Nodes (15): ProxyGet, ProxyPost, attention_escalation_loop(), _build_escalation_request(), _hub_link(), _parse_ts(), Any, datetime (+7 more)
+### Community 410 - "Community 410"
+Cohesion: 0.29
+Nodes (20): _attention_broadcast_section(), _compaction_delta_section(), _compaction_queue_section(), _curiosity_section(), _engine(), _hub_presence_section(), _iso(), _latest_row() (+12 more)
 
-### Community 420 - "Community 420"
+### Community 411 - "Community 411"
 Cohesion: 0.24
 Nodes (20): buildDimRail(), DIMENSIONS, drawBrain(), drawEkg(), drawSpotlight(), _get(), goLive(), init() (+12 more)
 
-### Community 421 - "Community 421"
+### Community 412 - "Community 412"
 Cohesion: 0.21
 Nodes (20): _asList(), _clearError(), _esc(), _fmt(), _gateColor(), _get(), _loadAll(), _post() (+12 more)
 
-### Community 422 - "Community 422"
+### Community 413 - "Community 413"
 Cohesion: 0.16
 Nodes (11): apply_structured_output_to_payload(), build_response_format(), Any, Build llama.cpp / OpenAI-compatible response_format payloads from a named method, Mutate opts in place for structured output + thinking policy.     Returns (opts,, Pick method: options.structured_output_method → env → none., Return response_format dict for the given method, or None for none/unknown., resolve_structured_output_method() (+3 more)
 
-### Community 423 - "Community 423"
-Cohesion: 0.28
-Nodes (20): _claims_list_empty(), _coerce_array_claim_item(), _coerce_evidence_refs(), _coerce_semantic_claim_item(), coerce_semantic_llm_root(), _float_field(), _has_current_claim_shape(), _is_bare_semantic_claim_root() (+12 more)
-
-### Community 424 - "Community 424"
+### Community 414 - "Community 414"
 Cohesion: 0.15
 Nodes (17): duplicate_orion_reply_assistant(), extract_orion_assistant_from_snippet(), materially_same_text(), normalize_compare_text(), OrionDigestDeduper, Collapse repeated Orion assistant lines in recall snippets (vector → same catchp, Second line of defense: render skips duplicate assistant bodies even if fusion l, If snippet matches transcript-shaped vector rows, return a compact user-only lin (+9 more)
 
-### Community 425 - "Community 425"
+### Community 415 - "Community 415"
 Cohesion: 0.10
 Nodes (21): biometrics_pressure organ contract (organ.contract.v1), orion-substrate-organs service (event-native organ contracts), orion-substrate-runtime compose config, brain-frame live stimulus-response smoke test (acceptance section 6), orion-substrate-runtime service (biometrics closed loop, grammar reducers, Layers 1-5), orion-substrate-runtime dependencies (fastapi/sqlalchemy/psycopg2/redis), orion-substrate-telemetry compose config, orion-substrate-telemetry dependencies (fastapi/asyncpg/redis) (+13 more)
 
-### Community 426 - "Community 426"
+### Community 416 - "Community 416"
 Cohesion: 0.19
 Nodes (18): DatasetPreviewRequest, DatasetPreviewResponse, preview_dataset_endpoint(), apply_overrides(), build_conversations(), Conversation, OverrideRecord, _parse_ts() (+10 more)
 
-### Community 427 - "Community 427"
+### Community 417 - "Community 417"
 Cohesion: 0.12
 Nodes (20): cortex-exec remediation entry, cortex-gateway remediation entry, cortex-orch remediation entry, equilibrium-service remediation entry (auto_remediate: false), landing-pad remediation entry, config/mesh_remediation_roster.yaml (auto-remediation roster), notify remediation entry (auto_remediate: false), recall remediation entry (+12 more)
 
-### Community 428 - "Community 428"
-Cohesion: 0.24
-Nodes (12): Normalization utilities for Orion payloads., _as_mapping(), _coerce_datetime(), _coerce_telemetry_timestamp(), normalize_spark(), normalize_spark_state_snapshot(), normalize_spark_telemetry(), Any (+4 more)
+### Community 418 - "Community 418"
+Cohesion: 0.19
+Nodes (13): ClaimStatusV1, ContextPackTargetV1, ContextPackV1, DecisionStatusV1, BaseModel, Enum, str, SourceKindV1 (+5 more)
 
-### Community 429 - "Community 429"
-Cohesion: 0.15
-Nodes (18): action_usefulness_rate(), pressure_discharge_rate(), Phase H — efficacy metrics for the reverie/dream weave.  Pure, deterministic red, Fraction of chains where post-chain pressure fell below pre-chain pressure., Fraction of reverie-originated action outcomes judged useful (FeedbackFrameV1)., Before/after recall metrics around a compaction., Deterministic before/after recall reduction. Negative deltas are wins:     lower, recall_delta() (+10 more)
+### Community 419 - "Community 419"
+Cohesion: 0.16
+Nodes (17): BaseModel, SparkCandidateV1, _maybe_publish_spark_introspect(), _publish_spark_introspect(), Future, Chat-turn candidates feed spark-introspector; internal RPCs (introspect_spark,, Option 1 fix: publish SparkCandidate as a Titanium envelope.      Old behavior p, _run_async() (+9 more)
 
-### Community 430 - "Community 430"
+### Community 420 - "Community 420"
+Cohesion: 0.19
+Nodes (15): EquilibriumServiceState, EquilibriumSnapshotV1, BaseModel, datetime, Current service state used by the Equilibrium snapshot publisher., Aggregate view of system equilibrium and distress., _enqueue_snapshot(), equilibrium_status_for_service() (+7 more)
+
+### Community 421 - "Community 421"
 Cohesion: 0.14
 Nodes (20): Orion (AI Town persona card), orion-biometrics service, fork_rpc_client (orion.core.bus.rpc_fork), GrammarEventV1 (bus substrate trace schema), bus-core (Redis broker container), bus-exporter (Prometheus redis_exporter), bus-observer (grammar trace sidecar), bus_transport_reducer (deferred Layer 3 reducer) (+12 more)
 
-### Community 431 - "Community 431"
+### Community 422 - "Community 422"
 Cohesion: 0.14
 Nodes (8): _Conn, _Engine, _Result, test_latest_salience_for_theme_dict_features(), test_latest_salience_for_theme_no_row(), test_latest_salience_for_theme_string_features(), test_load_pending_loops_falls_back_to_theme_key(), test_load_pending_loops_filters_and_builds()
 
-### Community 432 - "Community 432"
-Cohesion: 0.24
-Nodes (6): BiometricsCache, _clamp01(), _isoformat(), Any, datetime, _utcnow()
+### Community 423 - "Community 423"
+Cohesion: 0.14
+Nodes (16): enrich_from_chroma(), _parse_meta_ts(), Any, Fragment, Accepts multiple timestamp styles:     - meta["ts"] as epoch seconds (float/int), For each input fragment (collapse/chat), retrieve vector neighbors from Chroma,, _recent_enough(), clean_text() (+8 more)
 
-### Community 433 - "Community 433"
+### Community 424 - "Community 424"
+Cohesion: 0.19
+Nodes (16): LatticeGraph, load_lattice(), Path, _ensure_capability_vector(), _ensure_node_vector(), reconcile_field_state_with_lattice(), Two consecutive execution_run deltas should not accumulate — second replaces fir, test_execution_perturbations_use_replace_mode() (+8 more)
+
+### Community 425 - "Community 425"
 Cohesion: 0.17
 Nodes (14): attach(), coalesceChatSuggestDraft(), coalesceMemoryGraphSuggestEnvelope(), contentLooksLikeGatewayFailureBlurb(), debounce(), draftToCyElements(), emptySuggestDraft(), emptyValidSuggestDraft() (+6 more)
 
-### Community 434 - "Community 434"
+### Community 426 - "Community 426"
 Cohesion: 0.14
 Nodes (15): _Dim, _FakeSelfState, A malformed/negative thinking_tokens_sum must degrade to a truthful     zero, no, bool is a subclass of int in Python; a JSON `true` for     thinking_tokens_sum m, Regression: the _recall_gate_fired/_active_trajectory_runs factoring     must no, scripts/fit_phi_encoder.py dynamically loads this same inner_state.py     module, _sample_self_state(), test_fit_phi_encoder_resolves_seed_v4_names() (+7 more)
 
-### Community 435 - "Community 435"
+### Community 427 - "Community 427"
 Cohesion: 0.22
 Nodes (18): _attention_frame(), _dim(), _dispatch_frame(), _feedback_frame(), _motif(), _policy_frame(), _proposal_frame(), _self_state() (+10 more)
 
-### Community 436 - "Community 436"
+### Community 428 - "Community 428"
 Cohesion: 0.11
 Nodes (19): Clean git and worktree rules (§2): start with git status/branch check, classify dirt before mixing, prefer a separate worktree for parallel subagent work — stated as prose policy, not an enforced mechanism, Completion status (§19): every task ends in exactly one of DONE, DONE_WITH_CONCERNS, BLOCKED, or NEEDS_CONTEXT — never 'partially done', Deterministic gates over repeated yelling: if Juniper has to repeat a rule twice, turn it into a script/test/check/hook/make target instead of a louder prompt, Env/config/settings contract (§7): env parity is non-negotiable — any add/remove/rename of an env key must update .env_example, local .env, settings.py, docker-compose.yml, requirements.txt, and README in the same changeset, via scripts/sync_local_env_from_example.py, Event substrate first: grow from events -> schema -> trace -> reducer -> projection -> eval -> UI, not from a hand-authored mind-palace ontology with no runtime proof, Follow-through is part of the feature: a patch isn't done until the branch is clean, tests/evals pass, review is fixed, env is synced, Docker checks run, restart commands are listed, the branch is pushed, and the PR report exists, No empty-shell cognition: do not ship cognition-shaped output with no substance — empty semantic projections, placeholder memory cards, fallback text as generated cognition, raw_len=0 treated as success, stale reducer cursors are all invalid success states requiring inspectable evidence, No keyword cathedrals: labels/enums/taxonomies/ontology nodes without a schema contract, producer, consumer, reducer, UI surface, metric, test, eval, or live smoke attached in the same patch are banned as junk that names the world without changing runtime behavior (+11 more)
 
-### Community 437 - "Community 437"
-Cohesion: 0.15
-Nodes (15): CandidateCard, extract_candidates(), fingerprint(), fingerprint_from_candidate(), Lightweight Stage-1 extraction candidate (not yet persisted)., Same normalization as fingerprint(MemoryCardV1) for summary + anchor_class., _coerce_turn(), _get_memory_pool() (+7 more)
+### Community 429 - "Community 429"
+Cohesion: 0.12
+Nodes (19): HTMLResponse, Normalize HUB_AUTONOMY_SUBJECT_DISPLAY for Hub template injection (two|three)., Serves the main Hub UI (index.html)., resolve_hub_autonomy_subject_display(), root(), substrate_atlas_page(), substrate_page(), build_hub_ui_asset_version() (+11 more)
 
-### Community 438 - "Community 438"
-Cohesion: 0.20
-Nodes (16): Deterministic discussion-window helpers over persisted chat turns., _ensure_utc(), fetch_discussion_window(), _format_transcript(), Any, datetime, Read bounded discussion windows from chat_history_log (Postgres via SQLAlchemy)., Rows must be sorted ascending by created_at.     Keep the most recent contiguous (+8 more)
+### Community 430 - "Community 430"
+Cohesion: 0.11
+Nodes (19): description, type, type, description, type, description, type, description (+11 more)
 
-### Community 439 - "Community 439"
+### Community 431 - "Community 431"
 Cohesion: 0.20
 Nodes (17): _active_conversation(), build_perception(), _facing_partner(), Any, True iff Orion's facing vector aligns with the direction to the partner.      Co, Shape the conversation Orion is a member of (invited/walkingOver/participating)., test_build_perception_computes_distances_and_nearby(), test_build_perception_exposes_own_facing_and_pathfinding() (+9 more)
 
-### Community 440 - "Community 440"
-Cohesion: 0.32
-Nodes (16): Orion Mind shared contracts (types only; runtime lives in services/orion-mind)., ActiveCognitiveFrontierV1, MindStanceHandoffV1, test_hash_snapshot_inputs_stable(), test_mind_run_result_roundtrip(), test_universe_snapshot_facets(), test_validate_merged_stance_brief_accepts_minimal(), MindControlDecisionV1 (+8 more)
-
-### Community 441 - "Community 441"
-Cohesion: 0.21
-Nodes (17): CuriosityCandidateActionV1, _apply_voluntary_attention(), Layer top-down goal bias onto the bottom-up frame (spec Step 2).      Default-of, Default OFF (proposal mode): voluntary attention is inert until enabled., top_down_enabled(), _frame(), _goal(), _loop() (+9 more)
-
-### Community 442 - "Community 442"
-Cohesion: 0.20
-Nodes (14): EquilibriumServiceState, EquilibriumSnapshotV1, datetime, Current service state used by the Equilibrium snapshot publisher., Aggregate view of system equilibrium and distress., _enqueue_snapshot(), equilibrium_status_for_service(), Queue (+6 more)
-
-### Community 443 - "Community 443"
-Cohesion: 0.15
-Nodes (11): EmailWorldPulseRenderV1, publish_email(), publish_email_preview(), BaseSettings, Settings, notify_client(), test_curiosity_defaults_off(), test_curiosity_env_override() (+3 more)
-
-### Community 444 - "Community 444"
+### Community 432 - "Community 432"
 Cohesion: 0.20
 Nodes (16): anchor_strategy_for_subject(), _artifact_id(), build_identity_snapshot(), entity_id_for_subject(), infer_external_subject(), _payload_dict(), Any, IdentitySnapshotV1 (+8 more)
 
-### Community 445 - "Community 445"
+### Community 433 - "Community 433"
 Cohesion: 0.22
 Nodes (17): apply_moc(), _diag(), _head_values(), _moc_forward(), model_geometry_diagnostics(), Tensor, Turn an existing HyperbolicGPT into a per-head MoC variant in-place., _raw() (+9 more)
 
-### Community 446 - "Community 446"
+### Community 434 - "Community 434"
+Cohesion: 0.24
+Nodes (17): _load_from_postgres(), _answer_styles(), build_semantic_foundry(), _depth_expectation(), _developmental_fit(), _extract_seed_concepts(), _extract_unknown_concepts(), _failure_modes() (+9 more)
+
+### Community 435 - "Community 435"
 Cohesion: 0.20
 Nodes (18): _project_reverie_glimpse(), Projection helper: surface the latest fresh, non-hollow reverie thought.      Re, _fresh_payload(), Guard the call-site contract: chat_reverie_glimpse, when set, is exactly     the, is_hollow() rejects absent_coalition even if the stored `hollow` bool     says F, is_hollow() rejects evidence outside the coalition's grounding ids, even     if, A payload that no longer validates as SpontaneousThoughtV1 at all     (e.g. sche, test_ctx_key_wiring_only_sets_no_other_fields() (+10 more)
 
-### Community 447 - "Community 447"
+### Community 436 - "Community 436"
 Cohesion: 0.17
 Nodes (7): EndogenousRuntimeSqlReader, datetime, SqlReadResult, _Conn, _Engine, test_calibration_reader_profile_history_query(), test_runtime_reader_filters_and_limit_are_bounded()
 
-### Community 448 - "Community 448"
+### Community 437 - "Community 437"
 Cohesion: 0.16
 Nodes (17): _build_memory_digest_from_fragments(), build_personality_summary(), ChatTurnPayload, ChatTurnResult, conversation_front_worker(), handle_chat_turn(), Any, BaseModel (+9 more)
 
-### Community 449 - "Community 449"
+### Community 438 - "Community 438"
 Cohesion: 0.20
 Nodes (16): wake_today(), fetch_dream_row_from_sql(), Any, date, Load latest dream row from Postgres for wake readout (canonical path)., build_readout(), _default_readout(), _dream_path_for_date() (+8 more)
 
-### Community 450 - "Community 450"
+### Community 439 - "Community 439"
 Cohesion: 0.20
 Nodes (16): _fake_engine_with_joined_rows(), _fake_engine_with_state(), _legacy_self_state_payload_with_policy_pressure(), A fake engine that dispatches on which table the query text targets,     so both, Regression test for the same bug class as the 2026-07-12 schema-drift     incide, Self-state exists but its source field-state row is gone (e.g. pruned) --     th, _sample_field_state(), _sample_self_state() (+8 more)
 
-### Community 451 - "Community 451"
+### Community 440 - "Community 440"
 Cohesion: 0.19
 Nodes (17): _first_route_key(), LlmLaneRouteDecision, _match_served_by(), _norm_lane(), Any, Side-effect free: picks a route-table key for the LLM gateway HTTP hop.      Cha, resolve_llm_lane_route(), _resolve() (+9 more)
 
-### Community 452 - "Community 452"
+### Community 441 - "Community 441"
 Cohesion: 0.15
 Nodes (5): SparkContractMetrics, _legacy_action(), FakeLogger, TestSparkContractMetrics, TestSqlWriterLegacyMode
 
-### Community 453 - "Community 453"
+### Community 442 - "Community 442"
+Cohesion: 0.15
+Nodes (16): clear_tail_seeds_for_tests(), has_cold_start_tail_seed(), has_recent_tail_seed(), Track substrate cursor tail-seeds that skip unreduced history., tail_seed_snapshot(), last_reset_skipped_history(), build_substrate_grammar_truth(), Any (+8 more)
+
+### Community 443 - "Community 443"
 Cohesion: 0.25
 Nodes (15): disk_usage_pct(), get_cached_pressure_state(), log_receipt_pressure(), maybe_run_emergency_prune(), measure_pressure_state(), Engine, Settings, refresh_pressure_cache() (+7 more)
 
-### Community 454 - "Community 454"
+### Community 444 - "Community 444"
 Cohesion: 0.16
 Nodes (9): FakeConn, _NullAsyncCtx, Minimal in-process double for the handful of asyncpg.Connection calls this     s, _row(), _seeded_rows(), test_digest_no_pending_rows_reports_cleanly(), test_digest_reflection_crystallization_shape(), test_digest_report_counts_and_reflection_creation() (+1 more)
 
-### Community 455 - "Community 455"
+### Community 445 - "Community 445"
 Cohesion: 0.11
 Nodes (18): agent-trace.js (plain-text step consumer), api_routes.py (GET /api/cognition/trace/{correlation_id}), Idea 4: Click-through payload cards, cognition_trace_cache.py, CognitionTracePayload schema, HarnessRunStepV1 schema, HarnessStepRelay (harness_step_relay.py), orion:cognition:trace bus channel (+10 more)
 
-### Community 456 - "Community 456"
+### Community 446 - "Community 446"
 Cohesion: 0.18
 Nodes (16): consecutive_tool_count(), plan_action_saturated(), Pure guard logic for agent-chain runtime (Pass 2 testability)., Second or later plan_action in the same chain should become a delivery verb., Count consecutive calls of `candidate` from the tail of tools_called., True when a new plan_action would exceed max_consecutive repeated plan_action ca, Triage is disallowed once any prior delegated step exists., repeated_plan_action_needs_delivery() (+8 more)
 
-### Community 457 - "Community 457"
-Cohesion: 0.21
-Nodes (14): apply_causal_density_to_entry(), _coerce_self_state(), _condition_severity_rank(), _label_for_score(), _phi_evidence_score(), Computed phi evidence score in [0, 1], or None if no self_state available., Apply causal density scoring in-memory (no collapse store required)., _score_from_values() (+6 more)
-
-### Community 458 - "Community 458"
+### Community 447 - "Community 447"
 Cohesion: 0.27
 Nodes (16): ConsolidationGateResult, _appraisal_from_turn(), build_crystallization_from_window(), _evidence_note_for_turn(), _kind_for_gate(), _planning_and_retrieval_for_kind(), Any, Derive content-grounded planning_effects/retrieval_affordances for a kind. (+8 more)
 
-### Community 459 - "Community 459"
-Cohesion: 0.14
-Nodes (10): main(), datetime, _query_backlog(), FakeConn, datetime, test_fresh_backlog_within_threshold_is_healthy(), test_main_exits_one_when_backlog_stale(), test_main_exits_zero_when_backlog_fresh() (+2 more)
+### Community 448 - "Community 448"
+Cohesion: 0.24
+Nodes (15): _clamp01(), Phase B — spontaneous thought → governed proposal candidate.  Maps a non-hollow, Convert a thought into a review-gated proposal candidate, or None.      Returns, spontaneous_thought_to_candidate(), _coalition(), Phase B — spontaneous thought → governed proposal candidate.  The security-criti, test_absent_coalition_targets_self_state_without_raising(), test_autoaction_posture_recorded_but_gate_unchanged() (+7 more)
 
-### Community 460 - "Community 460"
+### Community 449 - "Community 449"
+Cohesion: 0.20
+Nodes (8): BiometricsAdapter, adapter(), make_induction_payload(), norm_ctx(), Biometrics adapter contract (spec §7.A) — lives under ``orion/signals/adapters/t, test_adapt_leaves_otel_for_gateway(), TestAdapt, TestCanHandle
+
+### Community 450 - "Community 450"
+Cohesion: 0.22
+Nodes (16): _apply_voluntary_attention(), Layer top-down goal bias onto the bottom-up frame (spec Step 2).      Default-of, Default OFF (proposal mode): voluntary attention is inert until enabled., top_down_enabled(), _frame(), _goal(), _loop(), Wiring: goal-context store + _apply_voluntary_attention over a real frame. (+8 more)
+
+### Community 451 - "Community 451"
+Cohesion: 0.20
+Nodes (13): is_caption_prompt_echo(), _normalize(), True when caption text is the VLM prompt echoed back, not scene description., test_is_caption_prompt_echo_matches_current_prompt(), test_is_caption_prompt_echo_matches_legacy_phrase(), test_is_caption_prompt_echo_rejects_blip_suffix_noise(), test_is_caption_prompt_echo_rejects_real_caption(), sanitize_caption() (+5 more)
+
+### Community 452 - "Community 452"
 Cohesion: 0.24
 Nodes (16): _bounded_unique_tensions(), build_autonomy_slice(), _pressure_trend(), Any, Cheap before/after pressure comparison from ctx['chat_autonomy_movement_debug']., Assemble the compact slice from the V2 reducer output already in ctx.      Retur, _delta(), _state_v2() (+8 more)
 
-### Community 461 - "Community 461"
+### Community 453 - "Community 453"
 Cohesion: 0.24
 Nodes (16): _coerce_allow_chat_fallback(), Any, Return True/False if caller set allow_chat_fallback on options or ctx; else None, Decide LLM lane metadata for gateway Phase 3 routing (orthogonal to route keys l, resolve_llm_lane_for_step(), Mirror the finalize_reflect context (top-level llm_lane) as cortex-exec merges i, _settings(), test_chat_general_chat_lane() (+8 more)
 
-### Community 462 - "Community 462"
+### Community 454 - "Community 454"
 Cohesion: 0.26
 Nodes (13): ApiClient, BattleSummary, build_parser(), _fmt_row(), load_battle_fixture(), _load_operator_token(), main(), print_case_table() (+5 more)
 
-### Community 463 - "Community 463"
+### Community 455 - "Community 455"
 Cohesion: 0.14
 Nodes (18): applyHashToTab(), buildMemoryGraphSuggestUserContent(), closeMemoryGraphBridgeModal(), collectConversationTurnsUpTo(), ensureMemoryGraphBridgeDraftViz(), ensureOrganSignalsGraph(), flushMemoryGraphBridgeDraftForm(), formatMemoryGraphBridgeDiagnosticsBlock() (+10 more)
 
-### Community 464 - "Community 464"
+### Community 456 - "Community 456"
 Cohesion: 0.19
 Nodes (13): cadenceSummary(), healthChipClass(), normalizeAnalytics(), normalizeEventItem(), normalizeHistoryItem(), normalizeRecentOutcomes(), normalizeSchedule(), oneOf() (+5 more)
 
-### Community 465 - "Community 465"
+### Community 457 - "Community 457"
 Cohesion: 0.21
 Nodes (16): buildConceptInductionSections(), buildWorkflowDetailRows(), canRunAgain(), extractWorkflow(), getWorkflowBadgeLabel(), getWorkflowStatusLabel(), normalizeConceptInductionDetails(), normalizeStatus() (+8 more)
 
-### Community 466 - "Community 466"
+### Community 458 - "Community 458"
 Cohesion: 0.17
 Nodes (11): _FakeProc, _FakeStream, MonkeyPatch, test_build_subprocess_env_enables_tool_search(), test_build_subprocess_env_omits_autocompact_when_zero(), test_build_subprocess_env_preserves_tool_search_override(), test_build_subprocess_env_sets_claude_context_limits(), test_cancel_turn_sigterms_active() (+3 more)
 
-### Community 467 - "Community 467"
+### Community 459 - "Community 459"
 Cohesion: 0.24
 Nodes (13): _assert_valid_suggest_draft_shape(), _node_coalesce(), _parse_draft_text(), Any, Regression: coalescer must not assign data.text directly to draftText without va, test_coalesce_accepts_valid_empty_suggest_draft(), test_coalesce_accepts_valid_nonempty_suggest_draft(), test_coalesce_failed_api_returns_empty_draft() (+5 more)
 
-### Community 469 - "Community 469"
+### Community 461 - "Community 461"
+Cohesion: 0.21
+Nodes (16): assert_safe_artifact_path(), build_artifact_path(), datetime, Path, slugify_task(), write_review_artifact(), MonkeyPatch, TestClient (+8 more)
+
+### Community 462 - "Community 462"
 Cohesion: 0.15
 Nodes (14): build_vector_policy(), _profile_vector_top_k(), Any, Shared recall source policy — vector removal diagnostics (vector no longer fetch, Vector retrieval was removed from orion-recall; always disabled (diagnostics onl, Build path-keyed vector policy diagnostics for recall_debug., recall_vector_allowed(), Regression: orion-recall must not import or call vector_adapter. (+6 more)
 
-### Community 470 - "Community 470"
+### Community 463 - "Community 463"
 Cohesion: 0.18
 Nodes (14): health(), _load_eval_mod(), Path, Gate tests for train/evals/eval_phi_encoder_health.py., Write a tiny valid MLP matching PhiEncoderRuntime shape checks., Low residual_std alone must not flag collapse when slope≠1., test_build_report_fails_when_active_collapsed(), test_constant_phi_is_not_identity_collapse() (+6 more)
 
-### Community 471 - "Community 471"
+### Community 464 - "Community 464"
 Cohesion: 0.12
 Nodes (17): Proposal mode required before invasive cognition changes: memory, identity, self-modeling, autonomy, private recall, social continuity, or cognition-loop changes need a proposal naming capability change, data touched, privacy boundary, proof trace, dangerous failure mode, and rollback before implementation, baseline dispatch policy (retina_fast, every_n_frames 10, no caption/embeddings), porch_eye camera config (open-vocab detect: person/package/vehicle/animal), triggered dispatch policy (person trigger, TTL 8s, caption+embeddings on), config/vision_frame_router.yaml (baseline vs triggered dispatch), Autonomy readiness / mutation pipeline, Dreams / Dream Weaver (symbolic residue processing), Journal layer (autobiographical compression) (+9 more)
 
-### Community 472 - "Community 472"
-Cohesion: 0.12
-Nodes (17): description, type, properties, description, minimum, type, applies_when_state, order (+9 more)
+### Community 465 - "Community 465"
+Cohesion: 0.21
+Nodes (14): build_identity_context(), load_identity_file(), Any, Path, resolve_identity_path(), _inject_identity_context(), test_inject_identity_context_backfills_when_existing_lists_empty(), test_inject_identity_context_does_not_report_fallback_when_yaml_loads() (+6 more)
 
-### Community 473 - "Community 473"
+### Community 466 - "Community 466"
+Cohesion: 0.22
+Nodes (15): build_plan_for_verb(), load_prompt_template(), load_verb_yaml(), Any, ExecutionPlan, Honor explicit `services: []` on a plan step; do not treat it as 'inherit defaul, _resolve_step_services(), Explicit `services: []` must not be replaced by non-empty defaults (truthy `or` (+7 more)
+
+### Community 467 - "Community 467"
 Cohesion: 0.15
 Nodes (17): required, required, can_interrupt_others, category, description, interruptible, max_recursion_depth, name (+9 more)
 
-### Community 474 - "Community 474"
-Cohesion: 0.23
-Nodes (15): _json_to_dict(), parse_json_object(), repair_json(), _strip_outer_quotes(), _try_candidate(), coerce_json(), Uses the json_repair library to fix common JSON errors from LLMs.     1. Strips, RFC 8259 has no \\'; models often emit it for possessives inside JSON strings. (+7 more)
+### Community 468 - "Community 468"
+Cohesion: 0.22
+Nodes (14): build_verb_list(), _discover_verbs(), is_active(), is_runtime_entry_verb(), list_all_verbs(), _load_manifest(), Any, api_verbs() (+6 more)
 
-### Community 475 - "Community 475"
-Cohesion: 0.20
-Nodes (14): emit_vector_upsert(), Any, _embed_http(), publish_crystallization_to_chroma(), Build upsert, optionally embed, publish to vector bus. Returns updated crystalli, build_chroma_upsert(), can_project_to_chroma(), chroma_bus_envelope_kind() (+6 more)
+### Community 469 - "Community 469"
+Cohesion: 0.31
+Nodes (17): SelfStudyRetrieveFiltersV1, _binding_value(), _escape_sparql(), _execute_graphdb_select(), _filter_allows_record_type(), _filter_allows_source_kind(), _filter_allows_trust_tier(), _graphdb_auth() (+9 more)
 
-### Community 476 - "Community 476"
-Cohesion: 0.23
-Nodes (15): build_agent_trace_summary(), _counts_with_order(), Counter, _bound_capability_step(), Regression: ``next(iter(result.keys()))`` picked ``metadata`` first and skipped, test_agent_trace_delegate_row_fail_on_domain_negative_structured(), test_agent_trace_delegate_row_fail_when_non_service_keys_precede_context_exec_payload(), test_agent_trace_summary_surfaces_bound_failure_details() (+7 more)
+### Community 470 - "Community 470"
+Cohesion: 0.29
+Nodes (14): WorkflowScheduleUpdatePatchV1, Path, WorkflowScheduleStore, _dispatch(), test_attention_signals_dedupe_and_recovery(), test_durable_create_load(), test_history_includes_lifecycle_events(), test_list_cancel_update_and_ambiguity() (+6 more)
 
-### Community 477 - "Community 477"
+### Community 471 - "Community 471"
+Cohesion: 0.18
+Nodes (7): Handler, Logger, Idempotent handle + ack for a single stream message., Reclaim messages left pending by a crashed/slow consumer; DLQ the poisonous., Read + handle new (never-delivered) messages. Returns count handled., Consumer-group reader for the world-pulse run-result stream.      Delivery contr, WorldPulseStreamConsumer
+
+### Community 472 - "Community 472"
 Cohesion: 0.21
 Nodes (15): _classify_degraded_reason(), format_degraded_reason_groups(), format_mode_summary(), format_reducer_health_summary(), _missing_fields(), Any, Validate /grammar/truth payloads for the production smoke gate., validate_truth_payload() (+7 more)
 
-### Community 478 - "Community 478"
+### Community 473 - "Community 473"
+Cohesion: 0.26
+Nodes (16): _project_autonomy_from_beliefs(), Projection helper: reconstruct autonomy dict from unified beliefs.      Aggregat, _anchor_slice(), _drive_node(), MonkeyPatch, SimpleNamespace, Gap 2 fix: snapshot_source == 'drive_state' must be picked up, not silently drop, The legacy 'autonomy' snapshot_source producer (autonomy_ctx.py, gated behind (+8 more)
+
+### Community 474 - "Community 474"
 Cohesion: 0.28
 Nodes (16): _project_recent_dispatch_actions(), Projection helper: surface the most recent autonomous dispatch-action     outcom, _outcome(), _patched(), A schema-drifted item (e.g. a future writer that doesn't set kind/summary)     m, success=None (ActionOutcomeRefV1's documented "genuinely unknown" state)     mus, test_caps_at_three_newest_first_and_exact_keys(), test_empty_ctx_still_queries_and_returns_empty() (+8 more)
 
-### Community 479 - "Community 479"
+### Community 475 - "Community 475"
+Cohesion: 0.18
+Nodes (10): build_orch_concept_profile_settings(), Config, get_orch_concept_profile_settings(), OrchConceptProfileSettings, Any, BaseSettings, Concept-profile repository settings used by Orch runtime.      This adapter inte, Return concept-profile repository config for Orch runtime.      Environment is t (+2 more)
+
+### Community 476 - "Community 476"
 Cohesion: 0.18
 Nodes (13): health(), lifespan(), FastAPI, get_settings(), BaseSettings, Settings, test_emit_perception_once_fail_open_on_list_players_error(), test_emit_perception_once_fail_open_on_malformed_row() (+5 more)
 
-### Community 480 - "Community 480"
+### Community 477 - "Community 477"
+Cohesion: 0.29
+Nodes (16): _perception_in_convo(), Observability seam: a healthy loop (all other logs exception-only) must still, The 'void' regression, corrected: the worker must NOT send `finishSendingMessage, test_empty_reply_is_not_injected(), test_heartbeat_logs_once_then_throttles(), test_injectable_reply_is_injected(), test_no_speech_until_participating(), test_no_speech_when_orion_spoke_last() (+8 more)
+
+### Community 478 - "Community 478"
 Cohesion: 0.15
 Nodes (12): EpisodicFederator, Triple, Autonomy data is written under graph/autonomy/*, not graph/orion/autonomy/*., Literal objects are not graph nodes and must be filtered out., SPARQL query must reference all 9 episodic named graphs., Fuseki failure → empty list, no exception., Parse SPARQL JSON bindings into (subject, predicate, object) tuples., test_episodic_federator_builds_sparql_for_all_graphs() (+4 more)
 
-### Community 481 - "Community 481"
+### Community 479 - "Community 479"
 Cohesion: 0.19
 Nodes (17): buildWorkflowModalSummaryCard(), fetchScheduleInventory(), filteredSchedules(), formatOverdue(), loadScheduleInventory(), normalizeSchedule(), openScheduleDetails(), openScheduleEdit() (+9 more)
 
-### Community 482 - "Community 482"
+### Community 480 - "Community 480"
 Cohesion: 0.24
 Nodes (15): buildOperatorSummary(), buildSurfaceModel(), cleanList(), countStateItems(), formatCountLabel(), getSection(), normalizeSection(), normalizeSnapshot() (+7 more)
 
-### Community 484 - "Community 484"
-Cohesion: 0.17
-Nodes (10): get_settings(), BaseSettings, Settings, PolicyRuntimeWorker, _existing_policy_frame(), _proposal(), _self_state(), test_worker_records_unevaluable_frame_when_self_state_missing() (+2 more)
-
-### Community 485 - "Community 485"
+### Community 482 - "Community 482"
 Cohesion: 0.22
 Nodes (13): _fake_packet(), _query(), test_does_not_log_when_no_crystallization_refs(), test_logs_retrieval_event_when_refs_present(), test_retrieval_event_log_failure_does_not_break_fragments(), _chat_profile(), test_chat_general_instruction_tail_does_not_shift_query_anchor(), test_chat_general_social_turn_keeps_lightweight_behavior() (+5 more)
 
-### Community 486 - "Community 486"
+### Community 483 - "Community 483"
 Cohesion: 0.24
 Nodes (16): _projection_payload(), Exception, _store_raising(), _store_with_row(), test_attention_broadcast_bad_payload_returns_none(), test_attention_broadcast_fresh_row_parses(), test_attention_broadcast_missing_table_returns_none(), test_attention_broadcast_naive_timestamp_treated_as_utc() (+8 more)
 
-### Community 487 - "Community 487"
+### Community 484 - "Community 484"
 Cohesion: 0.17
 Nodes (5): _FakeQuery, _FakeRow, _FakeSession, test_chat_history_thought_for_merge_preserves_existing_non_empty_thought(), test_chat_history_thought_for_merge_writes_insert_and_update_when_empty_existing()
 
-### Community 488 - "Community 488"
+### Community 485 - "Community 485"
 Cohesion: 0.24
 Nodes (9): _annotate_reason(), _check(), _format_local(), HealthCheck, HealthMonitor, Settings, Severity, Edge-triggered health monitor: fires an orion-notify attention request only (+1 more)
 
-### Community 489 - "Community 489"
+### Community 486 - "Community 486"
 Cohesion: 0.26
 Nodes (16): _compute_current_distribution(), drift_daemon_loop(), fetch_drift_records(), _is_drift_alert(), _js_divergence(), _load_baseline_distribution(), _load_clusterer(), _normalize_counts() (+8 more)
 
-### Community 490 - "Community 490"
+### Community 487 - "Community 487"
 Cohesion: 0.27
 Nodes (14): _load_stt_module(), _mock_canonicalize(), MonkeyPatch, Path, stt_engine(), test_canonicalize_wav_produces_16k_mono_s16(), test_measure_wav_levels_silent_vs_tone(), test_peak_threshold_invalid_env_falls_back() (+6 more)
 
-### Community 491 - "Community 491"
+### Community 488 - "Community 488"
 Cohesion: 0.20
 Nodes (13): generate_turtle_for_all(), _load_verbs(), Any, Path, Render a Python value as a Turtle-safe literal.      We only use this for *strin, Yield all verb definitions as dicts from verbs/*.yaml., Return Turtle triples for a single verb and its steps., Generate Turtle for all verbs in base_dir/verbs.      base_dir is typically the (+5 more)
 
-### Community 492 - "Community 492"
-Cohesion: 0.12
-Nodes (16): description, type, type, description, type, description, type, properties (+8 more)
+### Community 489 - "Community 489"
+Cohesion: 0.13
+Nodes (16): description, type, properties, type, items, applies_when_state, requires_gpu, requires_memory (+8 more)
 
-### Community 493 - "Community 493"
+### Community 490 - "Community 490"
+Cohesion: 0.23
+Nodes (14): extract_final_text(), parse_structured_observation(), Any, Parse a substrate.* verb's structured JSON output.      Expected shape: {"observ, Pull the plan's final_text out of a decoded CortexExecResultPayload.      Mirror, test_extract_final_text_from_result_final_text(), test_extract_final_text_from_step_result_fallback(), test_extract_final_text_missing_returns_empty() (+6 more)
+
+### Community 491 - "Community 491"
 Cohesion: 0.20
 Nodes (6): ChatHistorySparkMetaPatchV1, _ExistingRow, _FakeQuery, _FakeSession, test_spark_meta_patch_merges_existing_row(), test_spark_meta_patch_missing_row()
+
+### Community 492 - "Community 492"
+Cohesion: 0.15
+Nodes (4): clamp11(), Tests for normalization utilities., TestClamp, TestEwmaBand
 
 ### Community 494 - "Community 494"
 Cohesion: 0.24
@@ -3301,404 +3298,404 @@ Cohesion: 0.22
 Nodes (13): banner(), classify_failure(), FAIL_LOGS, FAIL_NAMES, record_fail(), record_pass(), record_skip(), require_repo_root() (+5 more)
 
 ### Community 496 - "Community 496"
+Cohesion: 0.17
+Nodes (8): Tiny in-process counter surface for schedule hardening signals., WorkflowScheduleMetrics, _dispatch_request(), test_attention_notify_integration_dedupe_payload_and_no_spam(), test_attention_notify_integration_overdue_transition(), test_claim_due_is_restart_safe(), test_recurring_dispatch_failure_requeues_claimed_slot(), test_recurring_schedule_advances_after_dispatch()
+
+### Community 497 - "Community 497"
 Cohesion: 0.24
 Nodes (15): _project_self_state_from_beliefs(), Projection helper: fold Orion's self-model condition into stance hazards.      R, _beliefs_with_self_nodes(), _node(), MonkeyPatch, SimpleNamespace, Build a real UnifiedRelationalBeliefSetV1 (not a SimpleNamespace) for the     in, _real_beliefs_with_self_nodes() (+7 more)
 
-### Community 497 - "Community 497"
+### Community 498 - "Community 498"
 Cohesion: 0.18
 Nodes (6): CompressionWorker, Any, Construct a RegionSummarizer when LLM summarization is viable, else None., LLM summaries require the feature flag, a bus, a running loop, and budget., Return (summary_text, summary_kind). Uses the LLM gateway when budget         al, Bridge the async post-write bus emit from the sync tick thread to the         ev
 
-### Community 498 - "Community 498"
+### Community 499 - "Community 499"
 Cohesion: 0.29
 Nodes (15): apiFetch(), escapeHtml(), evidenceSummary(), init(), loadPendingDecisions(), loadProposalDetail(), renderDetail(), renderListRow() (+7 more)
 
-### Community 499 - "Community 499"
+### Community 500 - "Community 500"
 Cohesion: 0.27
 Nodes (14): appendLog(), bindTerminalScroll(), connectSocket(), createTerminalState(), diagnosticsHint(), ensureServiceTerminal(), flushTerminal(), loadInventory() (+6 more)
 
-### Community 500 - "Community 500"
+### Community 501 - "Community 501"
 Cohesion: 0.33
 Nodes (15): el(), initSubstrateEffectTab(), loadRecentEffects(), openSubstrateEffectModal(), renderBehaviorDelta(), renderCausalChain(), renderEvidenceCards(), renderMoleculeSummaries() (+7 more)
 
-### Community 501 - "Community 501"
+### Community 502 - "Community 502"
 Cohesion: 0.22
 Nodes (13): Live Memory graph from chat cases for Playwright e2e., _artifact_dir(), _entity_labels(), hub_available(), _hub_reachable(), _is_evidence_only(), _is_strict_suggest_draft(), _looks_like_prose_outside_json() (+5 more)
 
-### Community 502 - "Community 502"
+### Community 503 - "Community 503"
 Cohesion: 0.18
 Nodes (11): _find_flag_value(), config/llm_profiles qwen3-8b-q4km-v100-16gb-balanced: non-thinking template kwar, Atlas metacog: Q5_K_M, n_parallel=1 -> full 16k ctx per slot, reasoning off., Synthetic profile: only chat_template_kwargs={'enable_thinking': False} → policy, test_draft_fields_emit_speculative_decoding_flags(), test_gemma4_31b_multimodal_profile_forwards_mmproj_and_image_flags(), test_qwen3_64k_profile_forwards_validated_flags(), test_qwen3_64k_profile_skips_unsupported_reasoning_flag() (+3 more)
 
-### Community 503 - "Community 503"
+### Community 504 - "Community 504"
 Cohesion: 0.30
 Nodes (13): build_compose_build_command(), build_compose_command(), build_compose_up_command(), execute_remediation(), RemediationResult, _run_command(), RosterEntry, _entry() (+5 more)
 
-### Community 504 - "Community 504"
+### Community 505 - "Community 505"
 Cohesion: 0.17
 Nodes (7): _FakeQuery, _FakeSession, test_chat_history_log_scalar_columns_from_meta_llm_uncertainty(), test_chat_history_spark_meta_merges_llm_uncertainty_from_meta(), test_chat_history_spark_meta_merges_llm_uncertainty_from_spark_meta(), _write_chat_history(), _write_chat_history_row()
 
-### Community 505 - "Community 505"
+### Community 506 - "Community 506"
 Cohesion: 0.17
 Nodes (9): Path, True positive against the actual repo config: Daily Journal reuses Daily     Pul, test_load_cadences_includes_synthetic_daily_journal_entry(), test_main_fail_on_collision_exits_one(), test_main_fail_on_collision_exits_zero_when_below_threshold(), test_main_json_output_contains_collisions(), test_main_report_only_exits_zero_even_with_collision(), test_real_env_example_has_known_daily_pulse_journal_collision() (+1 more)
 
-### Community 506 - "Community 506"
+### Community 507 - "Community 507"
 Cohesion: 0.24
 Nodes (13): AutonomyEvidenceCompileResult, compile_autonomy_evidence(), Any, datetime, Compile turn-local AutonomyStateV2 evidence with proven-non-empty gates.  Must b, Emit evidence only when upstream is proven non-empty. Never raises., _unique_hazards(), test_compiler_never_raises() (+5 more)
 
-### Community 507 - "Community 507"
+### Community 508 - "Community 508"
+Cohesion: 0.26
+Nodes (13): derive_workflow_execution_policy(), _has_explicit_schedule_intent(), _hour_from_token(), _next_weekday_run(), _normalize_prompt(), _one_shot_tonight(), _parse_notify_on(), _parse_time_for_schedule() (+5 more)
+
+### Community 509 - "Community 509"
+Cohesion: 0.28
+Nodes (13): _json_to_dict(), parse_json_object(), repair_json(), _strip_outer_quotes(), _try_candidate(), RFC 8259 has no \\'; models often emit it for possessives inside JSON strings., test_parse_json_object_double_encoded_string(), test_parse_json_object_escaped_object_text() (+5 more)
+
+### Community 510 - "Community 510"
 Cohesion: 0.13
 Nodes (15): collapse_mirror.v1 recall profile, deep.graph.v1 recall profile, dream.v1 recall profile, graphtri.v1 recall profile, journal.daily.grounded.v1 recall profile, journal.daily.metacog.grounded.v1 recall profile, journal.notify.grounded.v1 recall profile, journal.world_pulse.grounded.v1 recall profile (+7 more)
 
-### Community 508 - "Community 508"
+### Community 511 - "Community 511"
+Cohesion: 0.26
+Nodes (15): SelfStudyRetrievalBackendStatusV1, SelfStudyRetrievalCountsV1, SelfStudyRetrievedRecordV1, _build_retrieval_result(), _build_self_study_retrieval_records(), _concept_record(), _fact_record(), _graphdb_endpoint() (+7 more)
+
+### Community 512 - "Community 512"
+Cohesion: 0.19
+Nodes (9): EmailWorldPulseRenderV1, publish_email_preview(), BaseSettings, Settings, test_curiosity_defaults_off(), test_curiosity_env_override(), _FakeNotifyClient, test_email_publish_is_blocked_when_disabled() (+1 more)
+
+### Community 513 - "Community 513"
 Cohesion: 0.26
 Nodes (14): ddp_print(), ddp_setup(), eval_loss_and_geometry(), main(), parse_args(), device, Module, Namespace (+6 more)
 
-### Community 509 - "Community 509"
+### Community 514 - "Community 514"
+Cohesion: 0.26
+Nodes (9): _build_reflection_crystallization(), _build_reflection_summary(), DigestReport, main(), _print_report(), Any, Thin shim so repository.py::insert_crystallization() (which expects an     async, _run_digest() (+1 more)
+
+### Community 515 - "Community 515"
 Cohesion: 0.22
 Nodes (7): AttentionRuntimeStore, _frame(), _mock_engine_for_frames(), test_load_attention_frame_for_field_tick(), test_load_latest_attention_frame(), test_load_latest_field(), test_save_attention_frame_idempotent()
 
-### Community 510 - "Community 510"
-Cohesion: 0.18
-Nodes (13): Remove identity-kernel prose from llm_chat_general prompt context on ordinary tu, suppress_chat_general_speech_identity_priming(), _apply_chat_general_identity_boundary_guard(), _step(), test_chat_general_identity_boundary_repairs_user_role_inversion(), test_extract_final_text_does_not_rewrite_availability_phrases(), test_identity_boundary_leaves_correct_assistant_user_roles(), test_identity_boundary_repairs_variants() (+5 more)
-
-### Community 511 - "Community 511"
+### Community 516 - "Community 516"
 Cohesion: 0.29
 Nodes (10): _FakeBundle, _FakeItem, _FakeRecallReply, Any, _run_with_items(), test_logs_report_impl_and_service_status(), test_service_backed_path_is_primary(), test_service_error_falls_back_to_native() (+2 more)
 
-### Community 512 - "Community 512"
-Cohesion: 0.20
-Nodes (9): build_orch_concept_profile_settings(), Config, get_orch_concept_profile_settings(), OrchConceptProfileSettings, Any, BaseSettings, Concept-profile repository settings used by Orch runtime.      This adapter inte, Return concept-profile repository config for Orch runtime.      Environment is t (+1 more)
-
-### Community 513 - "Community 513"
+### Community 517 - "Community 517"
 Cohesion: 0.32
 Nodes (14): activate(), apiFetch(), chatTurnCount(), escapeHtml(), loadInbox(), loadRetirementCandidates(), renderDetail(), renderEvidence() (+6 more)
 
-### Community 514 - "Community 514"
+### Community 518 - "Community 518"
 Cohesion: 0.32
 Nodes (14): _atlas_test_app(), client(), _ensure_hub_scripts_import_path(), _mock_with_session(), FastAPI, MonkeyPatch, TestClient, Hub Grammar Atlas read API (substrate trace/graph introspection). (+6 more)
 
-### Community 515 - "Community 515"
+### Community 519 - "Community 519"
 Cohesion: 0.24
 Nodes (10): _all_rows(), _fake_engine(), datetime, HTTP tests for the self-observability summary route (self-observability v2)., Engine whose execute() keys responses off the table name in the SQL., test_summary_curiosity_signals_capped_and_ranked(), test_summary_each_section_degrades_to_null(), test_summary_full_contract_shape() (+2 more)
 
-### Community 516 - "Community 516"
-Cohesion: 0.24
-Nodes (12): main(), _main_async(), monitor_ups(), _publish_event(), _run_shutdown(), setup_logging(), _source(), PowerEvent (+4 more)
+### Community 520 - "Community 520"
+Cohesion: 0.30
+Nodes (14): _graph_node(), _make_worker(), SimpleNamespace, Unit tests for rung-5 endogenous curiosity tick wiring in substrate-runtime., When no seeds qualify, tick still writes an empty candidate set for observabilit, Evaluator signals are persisted endogenous-first, capped at 8., test_endogenous_curiosity_disabled_is_noop(), test_endogenous_curiosity_fails_open_on_evaluator_error() (+6 more)
 
-### Community 517 - "Community 517"
+### Community 521 - "Community 521"
 Cohesion: 0.17
 Nodes (5): Embedder, Settings, Config, BaseSettings, Settings
 
-### Community 518 - "Community 518"
-Cohesion: 0.24
-Nodes (5): _decode_envelope(), Any, Bounded Redis recovery index for vision-window (design §4.2, §4.3). Stores JSON, Return (latest_cursor, earliest_cursor) from last_n list if parseable., RecoveryStore
-
-### Community 519 - "Community 519"
+### Community 522 - "Community 522"
 Cohesion: 0.26
 Nodes (14): Docker readiness (§8): run docker compose builds/deploys through scripts/safe_docker_build.sh instead of calling docker compose directly; it refuses to run from the shared/primary checkout and applies the --env-file/-f pattern automatically; raw docker compose examples retained only as reference for one-off logs/ps commands, Docker readiness (§8): run docker compose builds/deploys through scripts/safe_docker_build.sh instead of calling docker compose directly; it refuses to run from the shared/primary checkout and applies the --env-file/-f pattern automatically; raw docker compose examples retained only as reference for one-off logs/ps commands, docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md — PR report documenting the full shared-checkout-docker-revert incident story, cited from CLAUDE.md §8, Incident: a concurrent agent session ran docker compose build+up straight from the shared/primary checkout and silently reverted another session's already-verified fix — the concrete motivation for both the safe_docker_build.sh wrapper and the pre-commit shared-checkout guard, Acceptance checks: 10 checks covering pre-commit guard refusal/success/escape-hatch, safe_docker_build.sh refusal/success, graphify hook status and rebuild-log evidence, tracked vs ignored graphify-out files, zero-conflict merge-driver test, gap-tolerant graphify . --update diff, /loop or /schedule cadence confirmation, and (already done) live-verified branch protection, Arsonist summary: parallel Claude Code agent sessions treat the shared main checkout as fair game instead of using worktrees; the existing mitigation (a sentence in CLAUDE.md saying worktrees only) was in place the whole time and did not stop the incident, motivating an actual git-level gate instead of more prose, Branch protection on main: confirmed off (404 Branch not protected) at session start, then enabled and verified live via gh api — PR required to merge, 1 required approving review, enforce_admins true (no owner exceptions), force-push blocked, branch deletion blocked; required no paid plan since the repo is public, graphify merge-driver registration: graphify merge-driver <base> <current> <other> is a real working CLI subcommand (nx.compose union merge, fails loudly above a 50MB/100k-node cap) but is not auto-registered by any graphify command — requires a new .gitattributes entry (graphify-out/graph.json merge=graphify, committable) plus a per-clone local git config merge.graphify.driver entry (not committable, a git design constraint) via a new scripts/setup_graphify_merge_driver.sh (+6 more)
 
-### Community 520 - "Community 520"
+### Community 523 - "Community 523"
+Cohesion: 0.22
+Nodes (11): AutonomySubjectFanout, autonomy_subject_fanout_from_runtime_ctx(), Any, Runtime policy for Graph autonomy multi-subject SPARQL fan-out (bounded vs full), Return ``bounded`` only for the default Hub quick lane; deep lanes use ``full``., test_fanout_bounded_chat_kids_story(), test_fanout_bounded_plain_chat_quick(), test_fanout_full_agent_mode_even_if_verb_chat_quick() (+3 more)
+
+### Community 524 - "Community 524"
 Cohesion: 0.19
 Nodes (14): config/llm_profiles.yaml (LLM profile/model registry, source of truth), orion-llama-cola-host Docker Compose, Orion Llama-CoLA Host service (dual-path text + latent action indices), orion-llama-cola-host Python dependencies (torch, transformers, deepspeed), orion-llamacpp-host Atlas multi-worker Docker Compose (chat/metacog/fast/agent lanes), orion-llamacpp-host single-worker Docker Compose, orion-llamacpp-host service (profile-driven llama.cpp GGUF wrapper, Atlas topology), orion-llamacpp-host Python dependencies (thin wrapper, no ML libs) (+6 more)
 
-### Community 521 - "Community 521"
+### Community 525 - "Community 525"
 Cohesion: 0.14
 Nodes (14): config/proposals/proposal_policy.v1.yaml — Layer 7 proposal policy: limits, priority/risk thresholds, dimension weights, and named proposal_templates that turn substrate state into ProposalFrameV1 candidates, template defer_due_to_low_readiness — no policy gate, defer on self:current to preserve_stability, base_priority 0.25, base_risk 0.0, dimensions uncertainty 0.50 / reliability_pressure 0.50, template inspect_attended_target (P5) — target_binding self_state.dominant_attention_targets[0] with a fallback literal to capability:orchestration if the binding fails to resolve; shipped live at base_priority 0.34 per explicit user go-ahead, not dark-shipped at 0.0, since it's a read-only inspect under the same policy gate/risk class as the other already-live inspect templates; carries a falsifiable 7-day kill criterion (distinct target_id count must be >= 3 or the binding isn't doing anything the literal templates don't already do), checked by run_attention_bound_proposal_eval.py, template inspect_bus_channel_catalog — read_only inspect of orion/bus/channels.yaml as a system target, base_priority 0.38, dimension contract_pressure 0.60, template inspect_execution_pressure — read_only inspect of capability:orchestration, base_priority 0.40, base_risk 0.05, dimension execution_pressure 0.60, template inspect_field_topology_catalog — read_only inspect of config/field/orion_field_topology.v1.yaml, base_priority 0.33, dimension field_intensity 0.45, template inspect_node_resource_pressure — read_only inspect of node:atlas, base_priority 0.34, dimension resource_pressure 0.50, template inspect_transport_status — read_only inspect of capability:transport, base_priority 0.42, dimensions contract_pressure 0.55 / reliability_pressure 0.40 (+6 more)
 
-### Community 522 - "Community 522"
+### Community 526 - "Community 526"
+Cohesion: 0.22
+Nodes (13): _gate(), Task 2: deviation gate fires on change, not presence., A steady stream (the scene_state flood) mints ~0 after warm-up., homeostasis 0.82 steady, then a real drop to 0.55 → sized impulse     (worse='do, A rise when only a fall is 'worse' mints nothing., A perfectly constant series (var→0) then a small step does not explode., test_cold_start_mints_nothing(), test_confidence_scales_impulse() (+5 more)
+
+### Community 527 - "Community 527"
+Cohesion: 0.15
+Nodes (14): Channel "orion:cognition:trace" (kind=event, schema=CognitionTracePayload) producers=[orion-cortex-exec] consumers=[orion-spark-introspector, orion-landing-pad, orion-bus-tap], Channel "orion:self:inner_features" (kind=telemetry, schema=InnerStateFeaturesV1) producers=[orion-spark-introspector] consumers=[orion-hub, orion-sql-writer], Channel "orion:spark:introspect:candidate" (kind=event, schema=SparkCandidateV1) producers=[orion-cortex-exec] consumers=[orion-spark-introspector], Channel "orion:spark:introspect:candidate:log" (kind=event, schema=SparkCandidateV1) producers=[orion-hub] consumers=[orion-spark-introspector], Channel "orion:spark:introspector:reply:*" (kind=result, schema=GenericPayloadV1) producers=[orion-cortex-orch] consumers=[orion-spark-introspector], Channel "orion:spark:signal" (kind=telemetry, schema=SparkSignalV1) producers=[*] consumers=[orion-spark-introspector, orion-state-service], Channel "orion:spark:telemetry" (kind=telemetry, schema=SparkTelemetryPayload) producers=[orion-spark-introspector] consumers=[orion-sql-writer], Schema: CognitionTracePayload (+6 more)
+
+### Community 528 - "Community 528"
 Cohesion: 0.24
 Nodes (7): Path, Loads and caches VerbConfig objects from verbs/*.yaml, Return all registered verbs. Use reload=True to refresh the cache., Lightweight filtering helper used by supervisors/planners., VerbRegistry, BaseModel, VerbConfig
 
-### Community 523 - "Community 523"
+### Community 529 - "Community 529"
+Cohesion: 0.35
+Nodes (13): create_entry_from_v2(), _base_entry_payload(), Path, The real production caller (ScoreCausalDensityVerb.execute) passes a plain     d, Schema drift or garbage payloads must fail open to pure self-report, never raise, _steady_self_state(), _store(), test_metacog_lane_accepts_dict_self_state_like_real_caller() (+5 more)
+
+### Community 530 - "Community 530"
 Cohesion: 0.25
 Nodes (11): CompressionRegionV1, CompressionStalenessMarkV1, GraphCompressionRegionMaterializedV1, BaseModel, A cached semantic compression of a graph region, written to orion:compressions., Bus payload marking a graph region stale when source triples are written., Bus event emitted after each compression artifact is written to Fuseki., test_compression_region_v1_requires_exemplar_ids() (+3 more)
 
-### Community 524 - "Community 524"
+### Community 531 - "Community 531"
 Cohesion: 0.23
 Nodes (13): normalize_hub_presence(), Any, Pass a non-empty presence dict through as-is; anything else becomes None., _build_state(), Tests for hub presence passthrough in the self-state build path., _synthetic_field(), test_build_self_state_absent_hub_presence_is_none(), test_build_self_state_empty_hub_presence_is_none() (+5 more)
 
-### Community 525 - "Community 525"
+### Community 532 - "Community 532"
 Cohesion: 0.26
 Nodes (13): _probe_records(), Unit tests for the Phase 4 drive-pressure measurement probe (2026-07-12).  Measu, Call site 1 (~line 717, _handle_signal_drive_tick via handle_envelope)., Call site 2 (~line 847, handle_envelope's non-homeostatic drive-update rail)., A probe logging failure at call site 2 must not break save_drive_state or     pr, _signal_env(), test_handle_envelope_call_site_logs_probe(), test_handle_envelope_call_site_survives_probe_failure() (+5 more)
 
-### Community 526 - "Community 526"
-Cohesion: 0.26
-Nodes (11): evaluate_trust_rupture_fixture(), _load_fixtures(), Any, Return failure messages for a single fixture; empty when expectations pass., Run all trust rupture fixtures; return aggregated failure messages., run_trust_rupture_eval_corpus(), _stance_slice(), _thought_from_fixture() (+3 more)
+### Community 533 - "Community 533"
+Cohesion: 0.47
+Nodes (12): build_sft_dataset(), DatasetBuildConfig, FoundryConfig, SubstrateSourceConfig, Path, test_dataset_build_is_deterministic_and_preserves_lineage(), test_foundry_frontier_oracle_does_not_enter_direct_sft(), test_foundry_manifest_rollups_and_integration_to_dataset() (+4 more)
 
-### Community 527 - "Community 527"
+### Community 534 - "Community 534"
 Cohesion: 0.24
 Nodes (3): _clean_raw_llm_content(), Strips common LLM preambles and code fences to expose raw JSON., TestExecutorCleaning
 
-### Community 528 - "Community 528"
+### Community 535 - "Community 535"
 Cohesion: 0.22
 Nodes (8): _bindings(), _FakeResponse, _graphdb_post(), test_graphdb_conceptual_retrieval_returns_persisted_concept_profiles(), test_graphdb_factual_retrieval_returns_authoritative_only(), test_graphdb_reflective_retrieval_preserves_all_tiers_and_links(), test_graphdb_retrieval_is_stable_across_repeated_reads(), test_graphdb_retrieval_never_upcasts_in_factual_mode()
 
-### Community 529 - "Community 529"
-Cohesion: 0.34
-Nodes (13): get_mind_run(), list_mind_runs(), list_recent_mind_runs(), _mind_run_row_dict(), _need_session(), _pool(), Any, BaseException (+5 more)
+### Community 536 - "Community 536"
+Cohesion: 0.22
+Nodes (11): enrich_from_graphdb_ids(), _clean_one_chat_fragment(), _counts_by_kind(), AsyncClient, Semaphore, Calls the LLM to clean a single chat fragment.     Uses a semaphore to limit con, Safely parses tags, whether they are a list     or a JSON-encoded string of a li, Safely joins tags, whether they are a list     or a JSON-encoded string of a lis (+3 more)
 
-### Community 530 - "Community 530"
-Cohesion: 0.24
-Nodes (11): attach_repair_pressure_contract(), _contract_changed(), Wire substrate repair contract into Hub → Cortex chat metadata., Mutate req.metadata in place when repair pressure changed behavior., WS builds chat_req before pipeline; attach must run after pipeline., _snapshot(), test_attach_skips_when_disabled(), test_attach_skips_when_mode_unchanged() (+3 more)
+### Community 537 - "Community 537"
+Cohesion: 0.19
+Nodes (6): AgentStepRelay, Any, Queue, AgentStepRelay fans agent_step events to per-correlation queues., test_relay_dispatches_to_registered_queue(), test_relay_ignores_non_step_kinds_and_unknown_corr()
 
-### Community 531 - "Community 531"
+### Community 538 - "Community 538"
+Cohesion: 0.29
+Nodes (4): CognitionTraceCache, Any, Subscribes to ``orion:cognition:trace``, keeps ``CognitionTracePayload`` per ``c, _redacted_step()
+
+### Community 539 - "Community 539"
 Cohesion: 0.26
 Nodes (13): _build(), Tests for hub chat turn grammar event emitter (TDD — written before implementati, test_atom_types_are_valid(), test_build_returns_grammar_event_v1_instances(), test_relation_types_are_valid(), test_repair_signal_absent_when_flag_false(), test_repair_signal_present_when_flag_true(), test_stable_event_ids_same_inputs_same_ids() (+5 more)
 
-### Community 532 - "Community 532"
+### Community 540 - "Community 540"
 Cohesion: 0.25
 Nodes (13): _mock_pool(), SimpleNamespace, Hub Mind run read APIs (session-gated; mock PG pool)., test_get_mind_run_allows_context_session_id(), test_get_mind_run_not_found_when_other_session(), test_get_mind_run_returns_row(), test_list_mind_runs_allows_context_session_without_current_match(), test_list_mind_runs_excludes_other_non_null_session_without_context() (+5 more)
 
-### Community 533 - "Community 533"
+### Community 541 - "Community 541"
 Cohesion: 0.27
 Nodes (8): _FakeClient, _load_module(), Path, _status_payload(), test_battle_runner_never_calls_judgment_or_review_or_execute_once(), test_battle_runner_rejects_invalid_profile_before_posting(), test_battle_runner_uses_default_profile_when_omitted(), test_operator_token_loader_prefers_explicit_then_env()
 
-### Community 534 - "Community 534"
+### Community 542 - "Community 542"
 Cohesion: 0.25
 Nodes (9): GPUConfig, LlamaCppConfig, LLMProfile, LLMProfileRegistry, BaseModel, BaseSettings, LLMProfile, LLMProfileRegistry (+1 more)
 
-### Community 535 - "Community 535"
+### Community 543 - "Community 543"
 Cohesion: 0.27
 Nodes (8): GPUConfig, LLMProfile, LLMProfileRegistry, BaseModel, Config, BaseSettings, LLMProfileRegistry, Settings
 
-### Community 536 - "Community 536"
-Cohesion: 0.23
-Nodes (5): configured_routes(), MonkeyPatch, TestClient, test_resolve_openai_route_missing_returns_error(), TestOpenAIPassthroughHTTP
-
-### Community 537 - "Community 537"
-Cohesion: 0.23
-Nodes (8): AlertSnapshot, A single snapshot image captured around the time of an alert., Notifier, Send an email with alert details and optional snapshot attachments.          IMP, Handles:     - Capturing snapshots from the vision edge service     - Sending al, Pull frames from the vision edge /snapshot.jpg endpoint and save to disk., Remove `user:pass@` credentials from URLs for safe logging / email.      Example, redact_url()
-
-### Community 538 - "Community 538"
+### Community 544 - "Community 544"
 Cohesion: 0.14
 Nodes (14): orion-biometrics (tier1, organ: biometrics), orion-bus (core, required), orion-collapse-mirror (tier1, organ: collapse_mirror), orion-cortex-exec (tier1, organs: cortex_exec, autonomy, chat_stance), orion-cortex-gateway (routing), orion-cortex-orch (routing), orion-equilibrium-service (tier1, organ: equilibrium), orion-llm-gateway (routing) (+6 more)
 
-### Community 539 - "Community 539"
+### Community 545 - "Community 545"
 Cohesion: 0.25
 Nodes (12): _done_key(), get_redis_client(), _inflight_key(), is_done(), mark_done(), Redis, Shared async Redis client for idempotency keys.     Returns None if idempotency, Return whether a done marker exists for ``trace_id``.      On Redis read errors, (+4 more)
 
-### Community 540 - "Community 540"
-Cohesion: 0.23
-Nodes (7): _Bus, _Codec, _Decoded, _Env, test_gateway_disabled_recall_forwards_supervised_request_and_replies_to_hub(), test_gateway_replies_when_orch_rpc_raises(), test_gateway_replies_when_result_validation_fails()
-
-### Community 541 - "Community 541"
-Cohesion: 0.23
-Nodes (3): _ev(), TestBuildFactSheet, TestReduceDriveHistory
-
-### Community 542 - "Community 542"
-Cohesion: 0.24
-Nodes (11): AutonomySubjectFanout, autonomy_subject_fanout_from_runtime_ctx(), Any, Runtime policy for Graph autonomy multi-subject SPARQL fan-out (bounded vs full), Return ``bounded`` only for the default Hub quick lane; deep lanes use ``full``., test_fanout_bounded_chat_kids_story(), test_fanout_bounded_plain_chat_quick(), test_fanout_full_agent_mode_even_if_verb_chat_quick() (+3 more)
-
-### Community 543 - "Community 543"
-Cohesion: 0.17
-Nodes (13): Deterministic gates over repeated yelling: if Juniper has to repeat a rule twice, turn it into a script/test/check/hook/make target instead of a louder prompt, scripts/concept_relation_digest.py — standalone script (not a live service loop) run every 30 minutes via Athena cron, turning memory_concept_relation_decisions rows into reflection crystallizations; make check-concept-relation-digest-liveness is the fail-safe, querying the real undigested backlog age (not a heartbeat file) and exiting non-zero past MAX_AGE_HOURS (default 3h) — a deterministic gate against the cron entry silently dying or not persisting across a host migration, Cross-window concept-relation resolution (off by default): vector-similarity candidate retrieval plus one bounded structured-output LLM call judging same/refines/contradicts/unrelated against nearest existing active crystallizations of the same kind; refines/contradicts only attach a typed link to the new candidate, never mutate the existing target — that stays a human decision via the links/supersede API; gated by CONCEPT_RELATION_RESOLUTION_ENABLED plus embed/chroma host config, both required or the feature does nothing, MEMORY_CONSOLIDATION_OUTPUT modes: crystallization_propose (default, runs consolidation_memory_gate and skips low-signal windows or proposes MemoryCrystallizationV1), graph_draft (legacy LLM graph-suggest path), skip_only (gate runs for traceability, always marks skipped); gate thresholds require the window not be all low-info-social, since a bare novelty/significance float alone previously let a noisy classifier score crystallize a short greeting-only turn, scripts/drive_history_reflection_synthesis.py (manual/on-demand only, NOT cron'd) — reads real persisted DriveAuditV1 ticks from the Fuseki drives graph and synthesizes one reflection-kind MemoryCrystallizationV1 via a deterministic reducer stage (reduce_drive_history, a pure unit-tested function, same bar as orion/spark/concept_induction/drive_tension.py) followed by a narrow LLM-phrasing stage that only ever sees a pre-computed fact sheet; parse_and_validate_narrative enforces that every cited fact's literal tokens appear verbatim in the output, and the script refuses to synthesize below MIN_EVENTS=5 or MIN_DISTINCT_DAYS=2, Known recurring footgun: 'flag on, dependency not wired' — CONCEPT_RELATION_RESOLUTION_ENABLED=true alone does not imply the digest is scheduled, and this exact pattern has already caused silent no-ops twice in this repo (CONCEPT_RELATION_RESOLUTION_ENABLED itself missing its embed/chroma hosts on first activation, and RECALL_GRAPHITI_IN_CHAT missing its adapter URL) — checking both halves explicitly every time is cheaper than re-discovering this, services/orion-memory-consolidation/README.md — subscribes to orion:memory:turn:persisted, classifies each chat turn via LLM gateway quick-lane logprobs, patches chat_history_log.spark_meta, tracks consolidation windows, and on boundary closure runs a deterministic consolidation gate (default) or legacy graph suggest, Turn change appraisal: each persisted turn after the first in a window gets a logprob-calibrated turn_change_appraisal patch (novelty score, shift kind, confidence, baseline mode); high-confidence novel turns emit OrionSignalV1 on orion:signals:memory_consolidation (+5 more)
-
-### Community 544 - "Community 544"
-Cohesion: 0.17
-Nodes (13): No empty-shell cognition: do not ship cognition-shaped output with no substance — empty semantic projections, placeholder memory cards, fallback text as generated cognition, raw_len=0 treated as success, stale reducer cursors are all invalid success states requiring inspectable evidence, Experience loop (P2): every real send (success, empty observation, or RPC failure) publishes an ActionOutcomeEmitV1 event onto orion:autonomy:action:outcome (BUS_ACTION_OUTCOME_OUT) — the same always-on route orion-spark-concept-induction already produces onto for curiosity-fetch outcomes, consumed by orion-sql-writer into the durable action_outcomes table; subject always 'orion' (self-directed, never relationship-scoped); replay-safe since sql-writer upserts by dispatch_id via merge(), EXECUTION_DISPATCH_MODE gate — default dry_run (build, no send); real sends require both this env set to dispatch_read_only AND config/execution_dispatch/execution_dispatch_policy.v1.yaml's mode.allow_dispatch_read_only true, plus per-tick and daily send budgets enforced before any send happens, ExecutionDispatchFrameV1 / ExecutionDispatchCandidateV1 — the schema this service builds; dispatch_status vocabulary (prepared, dry_run, blocked, skipped, prepared_for_dispatch, dispatched) enforced at the schema level, with dispatched requiring dispatched_at plus a result_ref or dispatch_error, Idempotency: dispatch_id is deterministic per proposal+policy, so if the process dies between a successful send and frame persistence, the next tick replays the stored substrate_dispatch_results row instead of resending — a real cortex-exec call never fires twice for the same candidate, Prerequisites: substrate_policy_decision_frames populated by orion-policy-runtime (port 8120); substrate_proposal_frames and substrate_self_state from Layers 7-6; two manual SQL migrations applied for ExecutionDispatchFrameV1 and substrate_dispatch_results_v1, Rollback: set EXECUTION_DISPATCH_MODE=dry_run and restart this one container — single kill switch for all real sending, services/orion-execution-dispatch-runtime/README.md — Layer 9 of the Orion cognition substrate: converts PolicyDecisionFrameV1 + ProposalFrameV1 + SelfStateV1 into ExecutionDispatchFrameV1 envelopes, the motor-nerve service that can actually send real actions (+5 more)
-
-### Community 545 - "Community 545"
-Cohesion: 0.18
-Nodes (13): Gemma 4 31B/E4B multimodal (text+image[+audio]) profiles, llama3-1-cola CoLA intention host profile, config/llm_profiles.yaml (LLM profile registry), qwen36-35b-a3b-udq5km-2xv100-32gb-deep-cognition profile (monster FCC), qwen3-30b-a3b-instruct-2507-q5km-atlas-metacog-16k profile, qwen3-8b-q5km-v100-16gb-atlas-metacog-16k profile, qwen3-coder-next agent breadth/depth profiles, llm-gateway remediation entry (+5 more)
-
 ### Community 546 - "Community 546"
-Cohesion: 0.23
-Nodes (10): FrameSender, _envelope_correlation_id(), publish_harness_run_step(), Any, UUID, Any, Forward harness governor FCC steps to Hub WS as claude_step frames., relay_harness_run_steps() (+2 more)
+Cohesion: 0.30
+Nodes (4): Any, datetime, StateJournaler, _utcnow()
 
 ### Community 547 - "Community 547"
-Cohesion: 0.27
-Nodes (12): Load opt-in render/prompt flags from recall profile YAML., recall_profile_prompt_flags(), _load_profile(), _load_verb(), _long_candidates(), test_daily_metacog_verb_uses_metacog_profile(), test_daily_pulse_verb_uses_scheduler_journal_profile(), test_journal_daily_grounded_not_capped_at_1280_without_explicit_config() (+4 more)
+Cohesion: 0.22
+Nodes (9): _FakeStore, _make_worker(), _RaisingStore, Unit tests for the Rung 1 bridge: worker writes prediction_error onto a durable, Records upsert_node calls without touching a real graph store., test_write_prediction_error_node_fail_open_on_raise(), test_write_prediction_error_node_noop_when_flag_off(), test_write_prediction_error_node_upserts_when_flag_on() (+1 more)
 
 ### Community 548 - "Community 548"
 Cohesion: 0.23
-Nodes (12): _bounded_memory_digest(), _load_daily_metacog_template(), test_daily_metacog_prompt_rejects_oversize_without_truncation(), test_daily_metacog_rendered_prompt_stays_bounded(), test_prompt_render_ctx_preserves_journal_lane_bundle_by_default(), test_prompt_render_ctx_strips_debug_recall_bundle_only_when_opted_in(), _enforce_daily_metacog_prompt_budget(), _estimate_prompt_tokens() (+4 more)
+Nodes (7): _Bus, _Codec, _Decoded, _Env, test_gateway_disabled_recall_forwards_supervised_request_and_replies_to_hub(), test_gateway_replies_when_orch_rpc_raises(), test_gateway_replies_when_result_validation_fails()
 
 ### Community 549 - "Community 549"
+Cohesion: 0.23
+Nodes (3): _ev(), TestBuildFactSheet, TestReduceDriveHistory
+
+### Community 550 - "Community 550"
+Cohesion: 0.17
+Nodes (13): Deterministic gates over repeated yelling: if Juniper has to repeat a rule twice, turn it into a script/test/check/hook/make target instead of a louder prompt, scripts/concept_relation_digest.py — standalone script (not a live service loop) run every 30 minutes via Athena cron, turning memory_concept_relation_decisions rows into reflection crystallizations; make check-concept-relation-digest-liveness is the fail-safe, querying the real undigested backlog age (not a heartbeat file) and exiting non-zero past MAX_AGE_HOURS (default 3h) — a deterministic gate against the cron entry silently dying or not persisting across a host migration, Cross-window concept-relation resolution (off by default): vector-similarity candidate retrieval plus one bounded structured-output LLM call judging same/refines/contradicts/unrelated against nearest existing active crystallizations of the same kind; refines/contradicts only attach a typed link to the new candidate, never mutate the existing target — that stays a human decision via the links/supersede API; gated by CONCEPT_RELATION_RESOLUTION_ENABLED plus embed/chroma host config, both required or the feature does nothing, MEMORY_CONSOLIDATION_OUTPUT modes: crystallization_propose (default, runs consolidation_memory_gate and skips low-signal windows or proposes MemoryCrystallizationV1), graph_draft (legacy LLM graph-suggest path), skip_only (gate runs for traceability, always marks skipped); gate thresholds require the window not be all low-info-social, since a bare novelty/significance float alone previously let a noisy classifier score crystallize a short greeting-only turn, scripts/drive_history_reflection_synthesis.py (manual/on-demand only, NOT cron'd) — reads real persisted DriveAuditV1 ticks from the Fuseki drives graph and synthesizes one reflection-kind MemoryCrystallizationV1 via a deterministic reducer stage (reduce_drive_history, a pure unit-tested function, same bar as orion/spark/concept_induction/drive_tension.py) followed by a narrow LLM-phrasing stage that only ever sees a pre-computed fact sheet; parse_and_validate_narrative enforces that every cited fact's literal tokens appear verbatim in the output, and the script refuses to synthesize below MIN_EVENTS=5 or MIN_DISTINCT_DAYS=2, Known recurring footgun: 'flag on, dependency not wired' — CONCEPT_RELATION_RESOLUTION_ENABLED=true alone does not imply the digest is scheduled, and this exact pattern has already caused silent no-ops twice in this repo (CONCEPT_RELATION_RESOLUTION_ENABLED itself missing its embed/chroma hosts on first activation, and RECALL_GRAPHITI_IN_CHAT missing its adapter URL) — checking both halves explicitly every time is cheaper than re-discovering this, services/orion-memory-consolidation/README.md — subscribes to orion:memory:turn:persisted, classifies each chat turn via LLM gateway quick-lane logprobs, patches chat_history_log.spark_meta, tracks consolidation windows, and on boundary closure runs a deterministic consolidation gate (default) or legacy graph suggest, Turn change appraisal: each persisted turn after the first in a window gets a logprob-calibrated turn_change_appraisal patch (novelty score, shift kind, confidence, baseline mode); high-confidence novel turns emit OrionSignalV1 on orion:signals:memory_consolidation (+5 more)
+
+### Community 551 - "Community 551"
+Cohesion: 0.17
+Nodes (13): No empty-shell cognition: do not ship cognition-shaped output with no substance — empty semantic projections, placeholder memory cards, fallback text as generated cognition, raw_len=0 treated as success, stale reducer cursors are all invalid success states requiring inspectable evidence, Experience loop (P2): every real send (success, empty observation, or RPC failure) publishes an ActionOutcomeEmitV1 event onto orion:autonomy:action:outcome (BUS_ACTION_OUTCOME_OUT) — the same always-on route orion-spark-concept-induction already produces onto for curiosity-fetch outcomes, consumed by orion-sql-writer into the durable action_outcomes table; subject always 'orion' (self-directed, never relationship-scoped); replay-safe since sql-writer upserts by dispatch_id via merge(), EXECUTION_DISPATCH_MODE gate — default dry_run (build, no send); real sends require both this env set to dispatch_read_only AND config/execution_dispatch/execution_dispatch_policy.v1.yaml's mode.allow_dispatch_read_only true, plus per-tick and daily send budgets enforced before any send happens, ExecutionDispatchFrameV1 / ExecutionDispatchCandidateV1 — the schema this service builds; dispatch_status vocabulary (prepared, dry_run, blocked, skipped, prepared_for_dispatch, dispatched) enforced at the schema level, with dispatched requiring dispatched_at plus a result_ref or dispatch_error, Idempotency: dispatch_id is deterministic per proposal+policy, so if the process dies between a successful send and frame persistence, the next tick replays the stored substrate_dispatch_results row instead of resending — a real cortex-exec call never fires twice for the same candidate, Prerequisites: substrate_policy_decision_frames populated by orion-policy-runtime (port 8120); substrate_proposal_frames and substrate_self_state from Layers 7-6; two manual SQL migrations applied for ExecutionDispatchFrameV1 and substrate_dispatch_results_v1, Rollback: set EXECUTION_DISPATCH_MODE=dry_run and restart this one container — single kill switch for all real sending, services/orion-execution-dispatch-runtime/README.md — Layer 9 of the Orion cognition substrate: converts PolicyDecisionFrameV1 + ProposalFrameV1 + SelfStateV1 into ExecutionDispatchFrameV1 envelopes, the motor-nerve service that can actually send real actions (+5 more)
+
+### Community 552 - "Community 552"
+Cohesion: 0.18
+Nodes (13): Gemma 4 31B/E4B multimodal (text+image[+audio]) profiles, llama3-1-cola CoLA intention host profile, config/llm_profiles.yaml (LLM profile registry), qwen36-35b-a3b-udq5km-2xv100-32gb-deep-cognition profile (monster FCC), qwen3-30b-a3b-instruct-2507-q5km-atlas-metacog-16k profile, qwen3-8b-q5km-v100-16gb-atlas-metacog-16k profile, qwen3-coder-next agent breadth/depth profiles, llm-gateway remediation entry (+5 more)
+
+### Community 553 - "Community 553"
+Cohesion: 0.23
+Nodes (10): FrameSender, _envelope_correlation_id(), publish_harness_run_step(), Any, UUID, Any, Forward harness governor FCC steps to Hub WS as claude_step frames., relay_harness_run_steps() (+2 more)
+
+### Community 554 - "Community 554"
+Cohesion: 0.31
+Nodes (11): attach_findings_to_debug(), merge_findings_bundle_dicts(), Any, Synthesize a serializable FindingsBundle from planner trace + contract (Phase 2, Merge two FindingsBundle-shaped dicts (exec supervisor aggregation)., synthesize_findings_bundle(), _trace_has_repo_evidence(), _trace_has_runtime_evidence() (+3 more)
+
+### Community 555 - "Community 555"
+Cohesion: 0.37
+Nodes (12): quick_lane_block_reason(), Return a block reason when quick lane is disallowed; None when eligible., _eligible_inputs(), test_quick_lane_allowed_when_all_criteria_pass(), test_quick_lane_blocked_on_alignment_hints(), test_quick_lane_blocked_on_boundary_register(), test_quick_lane_blocked_on_high_surprise(), test_quick_lane_blocked_on_non_default_repair_overlay() (+4 more)
+
+### Community 556 - "Community 556"
 Cohesion: 0.21
 Nodes (6): _FakeProc, _FakeStream, MonkeyPatch, test_cancel_before_register_kills_on_spawn(), test_cancel_fcc_turn_kills_registered_process(), test_run_fcc_turn_registers_and_unregisters_process()
 
-### Community 550 - "Community 550"
-Cohesion: 0.21
-Nodes (11): compact_vision_scene_interpretation_json_schema(), Any, Compact JSON Schema for VisionSceneInterpretationV1 (llama.cpp json_object+schem, Inline schema without $ref — suitable for Atlas metacog json_object+schema., build_interpretation_llm_options(), Gateway options for deterministic VisionSceneInterpretationV1 JSON., test_build_interpretation_llm_options_wires_structured_schema(), Tests for VisionSceneInterpretationV1 compact JSON schema contract. (+3 more)
-
-### Community 551 - "Community 551"
+### Community 557 - "Community 557"
 Cohesion: 0.18
 Nodes (13): orion-self-state-runtime (Layer 6 substrate: synthesizes SelfStateV1), orion-signal-gateway (normalizes organ-bus events into OrionSignalV1), orion-signals (organ signal mesh launcher, not a runtime service), orion-self-state-runtime docker-compose.yml, orion-self-state-runtime README.md, orion-self-state-runtime requirements.txt, orion-signal-gateway docker-compose.yml, orion-signal-gateway otel/collector-config.yaml (OTLP collector) (+5 more)
 
-### Community 552 - "Community 552"
+### Community 558 - "Community 558"
 Cohesion: 0.29
 Nodes (12): ProposalListFilter, _disabled_payload(), proposal_review_action(), proposal_review_detail(), proposal_review_eligibility(), proposal_review_health(), proposal_review_pending(), ProposalReviewActionRequest (+4 more)
 
-### Community 553 - "Community 553"
+### Community 559 - "Community 559"
 Cohesion: 0.32
 Nodes (12): _collapse(), compose_identity(), compose_presence_blurb(), main(), patch_juniper(), Splice Juniper (human player) into constants.ts (DEFAULT_NAME) and     world.ts, Rich, third-person identity injected into the agent's prompts., Rich blurb for players seeded outside `Descriptions` (Juniper human join,     Or (+4 more)
 
-### Community 554 - "Community 554"
+### Community 560 - "Community 560"
 Cohesion: 0.28
 Nodes (10): _FakeDetector, _inputs(), test_already_known_fact_suppresses_redundant_question(), test_autonomy_detector_emits_attention_item_signal(), test_concept_and_autonomy_pressure_influence_ranking(), test_detector_registry_accepts_fake_detector_without_regex(), test_generic_reciprocity_is_suppressed(), test_high_value_open_loop_selects_single_ask() (+2 more)
 
-### Community 555 - "Community 555"
-Cohesion: 0.32
-Nodes (12): _build_capability_field_projection(), _build_node_field_projection(), _capability_key(), _engine(), field_capability(), field_latest(), field_node(), _load_latest_field() (+4 more)
-
-### Community 556 - "Community 556"
-Cohesion: 0.27
-Nodes (11): build_audio_debug(), empty_transcript_error_message(), Any, sanitize_client_audio_meta(), test_build_audio_debug(), test_empty_transcript_browser_no_chunks(), test_empty_transcript_low_peak_warn_when_stt_passed(), test_empty_transcript_no_speech_default() (+3 more)
-
-### Community 557 - "Community 557"
+### Community 561 - "Community 561"
 Cohesion: 0.36
 Nodes (12): activate(), clearReadyTimer(), deactivate(), el(), finishLoading(), loadIframe(), readFrameState(), refreshStatus() (+4 more)
 
-### Community 558 - "Community 558"
+### Community 562 - "Community 562"
+Cohesion: 0.28
+Nodes (9): client(), _crys(), _FixedDatetime, _now(), datetime, TestClient, No regression: existing consumers reading pre-existing fields still work., test_list_endpoint_flags_stale_crystallization_as_retirement_candidate() (+1 more)
+
+### Community 563 - "Community 563"
 Cohesion: 0.36
 Nodes (12): mcp_config(), _mock_mcp_toolchain(), Any, MonkeyPatch, Path, test_render_defaults_github_toolsets_lean_and_read_only(), test_render_fails_when_aitown_unreachable(), test_render_fails_without_docker() (+4 more)
 
-### Community 559 - "Community 559"
+### Community 564 - "Community 564"
 Cohesion: 0.21
 Nodes (4): MonkeyPatch, _render_hub_index(), test_render_hub_index_html_injects_proposal_review_when_enabled(), test_render_hub_index_html_omits_proposal_review_when_disabled()
 
-### Community 560 - "Community 560"
+### Community 565 - "Community 565"
 Cohesion: 0.26
 Nodes (11): client(), Any, TestClient, _sample_row(), test_consolidation_draft_routes_memory_schema_missing(), test_get_consolidation_draft(), test_list_consolidation_drafts(), test_list_consolidation_drafts_memory_schema_missing() (+3 more)
 
-### Community 561 - "Community 561"
+### Community 566 - "Community 566"
 Cohesion: 0.27
 Nodes (8): GPUConfig, LLMProfile, LLMProfileRegistry, BaseModel, BaseSettings, LLMProfile, LLMProfileRegistry, Settings
 
-### Community 562 - "Community 562"
+### Community 567 - "Community 567"
 Cohesion: 0.19
 Nodes (9): main(), pull_model(), Wait for Ollama server to be ready., Pull the specified model using Ollama API., wait_for_ollama(), Config, Any, BaseSettings (+1 more)
 
-### Community 563 - "Community 563"
+### Community 568 - "Community 568"
 Cohesion: 0.23
 Nodes (11): _cfg(), health(), lifespan(), FastAPI, Any, Background retention scheduler for orion-rdf-writer., retention_health_snapshot(), _retention_loop() (+3 more)
 
-### Community 564 - "Community 564"
+### Community 569 - "Community 569"
 Cohesion: 0.15
 Nodes (13): orion-spark-introspector (tier1, organ: spark_introspector), Orion Cognitive Dashboard UI (index.html + tissue_viz.js), orion-spark-introspector docker-compose.yml, orion-spark-introspector README (Spark Engine v2), CoLA-derived novelty signal (orion-llama-cola-host /v1/understand, per-session distribution novelty), Mood-arc corpus collector (roadmap item 1: MoodArcCorpusRowV1 JSONL sink), scripts/fit_mood_arc_encoder.py (roadmap item 2: windowed sequence-autoencoder over mood-arc corpus), OrionState (compact self-state representation: mood, focus_themes, latent_state) (+5 more)
 
-### Community 565 - "Community 565"
+### Community 570 - "Community 570"
 Cohesion: 0.18
 Nodes (6): _compose_service_names(), _load_roster(), Path, Gate tests for orion-signals roster contract., roster(), test_every_compose_service_in_compose_file()
 
-### Community 566 - "Community 566"
+### Community 571 - "Community 571"
 Cohesion: 0.19
 Nodes (4): FakeWorker, test_debug_endpoint_returns_structured_json_when_worker_present(), test_lifespan_attaches_worker_and_starts_task(), test_shutdown_stops_worker_once()
 
-### Community 567 - "Community 567"
+### Community 572 - "Community 572"
+Cohesion: 0.33
+Nodes (12): _envelope_correlation_id(), _handle_bus_message(), handle_finalize_appraisal_request(), Any, Settings, UUID, Subscribe to finalize_appraisal request channel and reply with substrate apprais, Appraise a draft molecule and publish SubstrateFinalizeAppraisalV1 on reply_to. (+4 more)
+
+### Community 573 - "Community 573"
+Cohesion: 0.22
+Nodes (10): Settings, Subscribe to the goal-proposal channel and keep the attention goal-context store, run_goal_context_listener(), start_goal_context_listener(), test_run_goal_context_listener_returns_when_bus_disabled(), Detection, Event, BaseModel (+2 more)
+
+### Community 574 - "Community 574"
+Cohesion: 0.22
+Nodes (12): _drain_pending_handler_tasks(), Return subscriber count for channel, or -1 when the probe itself fails., run_bus_worker(), _thought_channel_subscribers(), health(), lifespan(), FastAPI, JSONResponse (+4 more)
+
+### Community 575 - "Community 575"
 Cohesion: 0.19
 Nodes (9): build_vllm_command_and_env(), main(), Build the vLLM OpenAI server command + environment based on Settings + profiles., Config, Any, BaseSettings, Resolve (model_id, gpu_cfg) using:           1) Explicit env: VLLM_MODEL_ID (opt, Load raw profile dicts from YAML (same file used by llm-gateway). (+1 more)
 
-### Community 568 - "Community 568"
+### Community 576 - "Community 576"
 Cohesion: 0.24
 Nodes (12): Capability: vision (declared, unwired), Pipeline: Retina Dense, Pipeline: Retina Fast, Profile: Image Embedding, Profile: Identity/Face Embedding, Profile: Pose Estimation, Profile: Open-Vocab Detector, Profile: Segmentation (SAM2-class) (+4 more)
 
-### Community 569 - "Community 569"
+### Community 577 - "Community 577"
 Cohesion: 0.17
 Nodes (12): Source: BBC World RSS, Source: CISA KEV Catalog (Manual URL), Source: Hugging Face Blog RSS, Source: Utah Government News (disabled, 404), Source: NASA News RSS, Source: NOAA Newsroom, Source: NPR Politics RSS, World Pulse Sources Policy v1 (+4 more)
 
-### Community 570 - "Community 570"
+### Community 578 - "Community 578"
 Cohesion: 0.27
 Nodes (7): collect_up_failures(), is_excluded(), print_failed_logs(), up_all_services_batched.sh script, up_one(), up_one_bg(), wait_for_bus_ready()
 
-### Community 571 - "Community 571"
-Cohesion: 0.21
-Nodes (6): clear_active_goal(), get_active_goal(), GoalContextStore, Goal → attention wire (spec 2026-07-07 Step 2, the scope-doubler).  The substrat, Adopt this goal as the current active context (latest active wins).          A t, set_active_goal()
-
-### Community 572 - "Community 572"
-Cohesion: 0.17
-Nodes (12): description, type, description, items, minItems, type, plan, services (+4 more)
-
-### Community 574 - "Community 574"
-Cohesion: 0.30
-Nodes (11): harness_mcp_enabled(), append_self_index_harness_brief(), context_mode_brief_lines(), context_mode_enabled(), context_mode_hooks_enabled(), _env_truthy(), gitnexus_brief_lines(), gitnexus_enabled() (+3 more)
-
-### Community 575 - "Community 575"
-Cohesion: 0.24
-Nodes (9): MonkeyPatch, Path, test_claude_permission_argv_non_root_uses_skip(), test_claude_permission_argv_root_uses_dont_ask(), test_extend_mcp_argv_appends_extra_allowed_tools_after_server_patterns(), test_extend_mcp_argv_extra_none_or_empty_keeps_argv_identical(), test_extend_mcp_argv_extra_with_zero_servers_still_emits_allowed_tools(), test_extend_mcp_argv_uses_per_server_patterns() (+1 more)
-
-### Community 576 - "Community 576"
-Cohesion: 0.29
-Nodes (11): Task 6 live: homeostatic signal channels ride a drive-only rail.  Asserts the wo, A bad prior state / store fault in the drive-update section must degrade to, _signal_env(), test_disabled_flag_falls_through_to_concept_path(), test_failure_channel_mints_tension(), test_homeostatic_source_classification(), test_never_raises_when_drive_update_breaks(), test_pubsub_patterns_include_specific_channels_not_wildcard() (+3 more)
-
-### Community 577 - "Community 577"
-Cohesion: 0.23
-Nodes (8): main(), parse_args(), Namespace, HyperbolicGPTMoC, HyperbolicGPT v3: MoC architecture plus v2 manifold diagnostics., main(), _pick_device(), device
-
-### Community 578 - "Community 578"
-Cohesion: 0.17
-Nodes (7): ingest_file(), Reads a text file, splits it into chunks, and ingests them into the vector store, A client that connects to the standalone Orion Vector DB service.     This write, Loads the embedding model and initializes the ChromaDB HTTP client         to co, Embeds a list of document texts and adds them to the collection., # NOTE: This is a simple incremental ID. For production, you'd, VectorStore
-
 ### Community 579 - "Community 579"
-Cohesion: 0.24
-Nodes (11): main(), Any, Path, ValueError, Returns (keys exposed via `environment:`, has env_file directive) for the     se, Raised when the target service can't be unambiguously identified inside a     mu, Pick the compose `services:` entry that corresponds to `service_dirname`     (e., _read_compose_env_keys() (+3 more)
-
-### Community 580 - "Community 580"
-Cohesion: 0.35
-Nodes (8): _extract_cortex_result(), main(), MatrixRow, _one_row(), ProbeCollector, Any, _service_ref(), _summarize()
+Cohesion: 0.26
+Nodes (10): test_parse_chat_discussion_default_day(), test_parse_day_variants(), test_parse_hours_variants(), test_parse_minutes_variants(), test_parse_non_journal_returns_none(), parse_journal_discussion_lookback_seconds(), Parse relative journal timeframes from natural language (V1: explicit durations, Return lookback in seconds when the prompt is clearly a journal-discussion reque (+2 more)
 
 ### Community 581 - "Community 581"
 Cohesion: 0.29
-Nodes (11): _ensure_sys_path_stdlib_safe(), _http_to_ws_url(), main(), phase0_offline(), phase1_http(), phase2_ws(), Any, Path (+3 more)
+Nodes (11): Task 6 live: homeostatic signal channels ride a drive-only rail.  Asserts the wo, A bad prior state / store fault in the drive-update section must degrade to, _signal_env(), test_disabled_flag_falls_through_to_concept_path(), test_failure_channel_mints_tension(), test_homeostatic_source_classification(), test_never_raises_when_drive_update_breaks(), test_pubsub_patterns_include_specific_channels_not_wildcard() (+3 more)
 
 ### Community 582 - "Community 582"
+Cohesion: 0.23
+Nodes (8): main(), parse_args(), Namespace, HyperbolicGPTMoC, HyperbolicGPT v3: MoC architecture plus v2 manifold diagnostics., main(), _pick_device(), device
+
+### Community 583 - "Community 583"
+Cohesion: 0.17
+Nodes (7): ingest_file(), Reads a text file, splits it into chunks, and ingests them into the vector store, A client that connects to the standalone Orion Vector DB service.     This write, Loads the embedding model and initializes the ChromaDB HTTP client         to co, Embeds a list of document texts and adds them to the collection., # NOTE: This is a simple incremental ID. For production, you'd, VectorStore
+
+### Community 584 - "Community 584"
+Cohesion: 0.24
+Nodes (11): main(), Any, Path, ValueError, Returns (keys exposed via `environment:`, has env_file directive) for the     se, Raised when the target service can't be unambiguously identified inside a     mu, Pick the compose `services:` entry that corresponds to `service_dirname`     (e., _read_compose_env_keys() (+3 more)
+
+### Community 585 - "Community 585"
+Cohesion: 0.29
+Nodes (11): _ensure_sys_path_stdlib_safe(), _http_to_ws_url(), main(), phase0_offline(), phase1_http(), phase2_ws(), Any, Path (+3 more)
+
+### Community 586 - "Community 586"
 Cohesion: 0.24
 Nodes (9): _cards(), Backtick / ${...} / backslash must be escaped for a TS backtick literal., Drift guard: the composed Juniper blurb must be spliced into world.ts., test_cards_have_all_expected_ids(), test_compose_identity_is_rich_and_collapsed(), test_compose_presence_blurb_orion_uses_they(), test_juniper_blurb_present_in_world_ts(), test_render_descriptions_emits_eight_valid_sprites() (+1 more)
 
-### Community 583 - "Community 583"
-Cohesion: 0.26
-Nodes (10): _disable_gateway_probe(), Any, MonkeyPatch, Runner integration tests for llm_profile → route binding., _RouteProbeEngine, test_engine_subcall_records_route_for_profile(), test_llm_chat_route_accepts_ctxcorr_correlation_id(), test_llm_chat_route_uses_route_key() (+2 more)
-
-### Community 584 - "Community 584"
+### Community 587 - "Community 587"
 Cohesion: 0.41
 Nodes (11): _perc(), test_engage_accepts_invite(), test_engage_does_not_stop_when_not_pathfinding(), test_engage_initiates_with_nearby_player(), test_engage_stops_once_to_face_partner_when_pathfinding(), test_engage_walks_to_partner_when_walking_over(), test_initiate_off_when_distance_zero(), test_initiate_respects_cooldown() (+3 more)
 
-### Community 585 - "Community 585"
+### Community 588 - "Community 588"
 Cohesion: 0.24
 Nodes (9): build_graph_from_triples(), leiden_cluster(), Graph, Triple, Three connected triples form at least one community., test_build_graph_from_triples(), test_leiden_cluster_empty_graph_returns_empty(), test_leiden_cluster_single_node() (+1 more)
 
-### Community 586 - "Community 586"
+### Community 589 - "Community 589"
 Cohesion: 0.23
 Nodes (5): CompressionWriter, Emit a passive materialization event for any region kind., Emit substrate mutation pressure for contradiction regions only., Emit all post-write bus events: materialization + grammar hook., Write region to Fuseki. Returns True on success.
 
-### Community 587 - "Community 587"
-Cohesion: 0.29
-Nodes (9): extract_autonomy_payload(), log_autonomy_payload_extraction(), Any, Diagnostic logging after autonomy extraction on Hub chat ingress paths., test_log_autonomy_payload_extraction_empty(), test_log_autonomy_payload_extraction_present(), test_extract_autonomy_payload_forwards_v2_keys(), test_extract_autonomy_payload_includes_execution_mode_and_goal_lineage() (+1 more)
-
-### Community 588 - "Community 588"
+### Community 590 - "Community 590"
 Cohesion: 0.38
 Nodes (11): appendLiveClaudeStep(), basename(), clip(), contextRiskSuffix(), ensurePanel(), finalizeLiveClaudeTrace(), formatHarnessHeading(), formatToolInput() (+3 more)
 
-### Community 589 - "Community 589"
-Cohesion: 0.21
-Nodes (6): _FakeProc, _FakeStream, MonkeyPatch, test_run_turn_adds_mcp_config_when_enabled(), test_run_turn_omits_mcp_config_when_disabled(), test_run_turn_surfaces_mcp_preflight_error_code()
-
-### Community 591 - "Community 591"
+### Community 592 - "Community 592"
 Cohesion: 0.30
 Nodes (11): Historical runs may omit mind.llm_synthesis_attempted on the success path., _run_node(), test_fail_open_fixture_normalizer(), test_fail_open_fixture_phase_rows_expose_semantic_filter_counts(), test_fail_open_fixture_still_renders_provenance_sections(), test_filtered_empty_semantic_only_warns_not_failed_callout(), test_orch_http_failed_fixture_normalizer(), test_shadow_fixture_renders_shadow_fields() (+3 more)
 
-### Community 592 - "Community 592"
+### Community 593 - "Community 593"
 Cohesion: 0.24
 Nodes (10): MonkeyPatch, General 'stop chat' command: a per-connection active-turn registry in websocket_, A connection is registered at setup even before any turn starts (correlation_id, The registry stores the active_turn dict by reference: mutating it directly, test_api_chat_turn_cancel_503_when_bus_unavailable(), test_api_chat_turn_cancel_returns_cancelled_correlation_id(), test_cancel_active_turn_for_connection(), test_cancel_active_turn_for_connection_with_no_turn_in_flight_is_noop() (+2 more)
 
-### Community 593 - "Community 593"
-Cohesion: 0.29
-Nodes (11): _mind_prep(), _prep(), Any, MonkeyPatch, Tests for LLM surface instability metacog advisory trigger., test_maybe_publish_runs_when_metacog_enabled(), test_maybe_publish_skips_when_metacog_disabled(), test_maybe_publish_skips_when_status_not_ok() (+3 more)
-
 ### Community 594 - "Community 594"
-Cohesion: 0.44
-Nodes (11): build_autonomy_triples(), _parse(), _provenance(), Graph, test_drive_audit_materialization_preserves_lineage_and_tensions(), test_goal_materialization_preserves_proposal_only_semantics(), test_goal_materialization_writes_planned_task_and_completed_at(), test_goal_materialization_writes_proposal_status_and_base() (+3 more)
+Cohesion: 0.21
+Nodes (7): _FailingTTSClient, _OkTTSClient, _SlowTTSClient, test_hub_voice_timeout_settings_defaults(), test_run_tts_remote_enqueues_speaking_payload(), test_run_tts_remote_enqueues_tts_error_on_failure(), test_run_tts_remote_enqueues_tts_error_on_timeout()
 
 ### Community 595 - "Community 595"
-Cohesion: 0.23
-Nodes (10): Any, Session, Idempotent spark_telemetry persistence keyed by correlation_id., upsert_spark_telemetry(), Tests for idempotent spark_telemetry persistence., Regression: ON CONFLICT SET must target DB column 'metadata', not Python attr 'm, test_on_conflict_update_uses_metadata_column_not_python_attr(), test_upsert_filters_unknown_keys() (+2 more)
-
-### Community 596 - "Community 596"
 Cohesion: 0.35
 Nodes (11): _graph_node(), _make_worker(), SimpleNamespace, Unit tests for the continuous attention broadcast tick (rung 3).  Verifies the w, Each broadcast tick appends a dwell row alongside the projection., test_broadcast_disabled_is_noop(), test_broadcast_fails_open_on_snapshot_error(), test_broadcast_fails_open_on_store_init_error() (+3 more)
 
-### Community 597 - "Community 597"
+### Community 596 - "Community 596"
 Cohesion: 0.27
 Nodes (9): lifespan(), FastAPI, ready(), get_llm_client(), check_embedding(), check_model_dir(), check_postgres(), Any (+1 more)
+
+### Community 597 - "Community 597"
+Cohesion: 0.55
+Nodes (11): _claim(), _evidence(), _obs(), _previous(), datetime, test_confirmation_branch(), test_contradiction_branch(), test_new_development_branch() (+3 more)
 
 ### Community 598 - "Community 598"
 Cohesion: 0.25
@@ -3717,24 +3714,24 @@ Cohesion: 0.20
 Nodes (11): delivery_pack: user-facing artifact verbs, emergent_pack: introspection/reflection/dream/counterfactual verbs, executive_pack: classify/plan/prioritize/evaluate verbs, memory_pack: memory retrieval/contextualization/narrative verbs, Cognition Packs (Memory, Executive, Emergent), Orion Cognition Layer README, Semantic Planner (verb -> ExecutionPlan), Verb exec_step bus contract (orion-exec:request/result:<Service>) (+3 more)
 
 ### Community 602 - "Community 602"
-Cohesion: 0.27
-Nodes (9): _map(), objectTiles indexed [layer][x][y]; -1 = empty. `blocked` is a set of (x,y)., test_walkable_empty_on_malformed(), test_walkable_excludes_blocked_tiles(), test_walkable_multiple_layers_any_block(), Any, Walkability derived from an AI Town ``worldMap``.  AI Town stores object/collisi, Return the set of walkable integer tiles ``(x, y)`` for a worldMap.      Fail-op (+1 more)
+Cohesion: 0.45
+Nodes (9): DriveMapThresholds, map_drive_state_to_intent(), _drive(), test_all_low_is_idle(), test_dominant_curiosity_wanders(), test_dominant_social_approaches(), test_empty_pressures_is_none(), test_high_social_escalates_to_start_conversation() (+1 more)
 
 ### Community 603 - "Community 603"
 Cohesion: 0.27
-Nodes (10): mcp_tool_result_max_chars(), _forward_input(), _forward_output(), main(), _maybe_truncate_line(), Any, stdio MCP proxy: truncate oversized tool results before they reach Claude Code., Walk MCP JSON-RPC result and truncate text tool payloads. (+2 more)
+Nodes (9): _map(), objectTiles indexed [layer][x][y]; -1 = empty. `blocked` is a set of (x,y)., test_walkable_empty_on_malformed(), test_walkable_excludes_blocked_tiles(), test_walkable_multiple_layers_any_block(), Any, Walkability derived from an AI Town ``worldMap``.  AI Town stores object/collisi, Return the set of walkable integer tiles ``(x, y)`` for a worldMap.      Fail-op (+1 more)
 
 ### Community 604 - "Community 604"
 Cohesion: 0.40
-Nodes (10): summarize_harness_step(), Regression: harness step summaries must carry tool_use names and tool_result bod, Replay the failing turn's stream: tool evidence must survive into summaries., _step(), test_pr_title_stream_receipts_carry_tool_evidence(), test_summarize_assistant_text_preserved(), test_summarize_system_subtype(), test_summarize_tool_result_carries_body() (+2 more)
+Nodes (8): Any, recommend_actions_from_alerts(), summarize_recommended_actions(), main(), test_policy_coherence_drop_error_actions(), test_policy_dedup_and_ordering(), test_policy_novelty_spike_warn_actions(), test_policy_summary()
 
 ### Community 605 - "Community 605"
-Cohesion: 0.42
-Nodes (7): ChatAttentionRequest, DummyBus, DummyPolicy, DummyTransport, _noop_create_task(), test_attention_request_sends_email_for_critical(), test_attention_request_skips_immediate_email_for_error()
+Cohesion: 0.51
+Nodes (10): WorkflowDispatchRequestV1, advance_after_dispatch(), _coerce_utc(), due_schedules(), initial_next_run_utc(), datetime, register_schedule(), schedule_label() (+2 more)
 
 ### Community 606 - "Community 606"
-Cohesion: 0.40
-Nodes (8): Any, recommend_actions_from_alerts(), summarize_recommended_actions(), main(), test_policy_coherence_drop_error_actions(), test_policy_dedup_and_ordering(), test_policy_novelty_spike_warn_actions(), test_policy_summary()
+Cohesion: 0.31
+Nodes (9): WorkflowScheduleSpecV1, _blocks_bootstrap_seed(), ensure_chat_history_compactor_daily_schedule(), True when an existing record means bootstrap must not (re-)seed.      Two cases, Idempotently seed daily 06:00 America/Denver chat history compactor schedule., Path, test_bootstrap_does_not_duplicate_operator_edited_schedule(), test_bootstrap_does_not_resurrect_cancelled_schedule() (+1 more)
 
 ### Community 607 - "Community 607"
 Cohesion: 0.29
@@ -3753,64 +3750,64 @@ Cohesion: 0.29
 Nodes (10): _coerce_float(), compare_drives(), load_autonomy_state(), load_drive_state_v1(), main(), Any, Load the current autonomy_state_v2 for `subject`.      `load_autonomy_state_v2`, Best-effort numeric coercion for values read from the unvalidated     LocalProfi (+2 more)
 
 ### Community 611 - "Community 611"
-Cohesion: 0.22
-Nodes (11): _load_prior_stance_into_ctx(), _prior_stance_cache_get(), _prior_stance_cache_set(), Store compact brief summary keyed by session_id for next-turn carryforward., Return stored brief summary if present and not expired; evict on expiry., Load prior-turn stance summary from the session cache into ctx as a TOP-LEVEL, test_load_prior_stance_into_ctx_noop_without_session_id(), test_load_prior_stance_into_ctx_sets_top_level_from_cache() (+3 more)
+Cohesion: 0.33
+Nodes (6): CoreEventCache, format_recent_turn_effect_alerts(), get_core_event_cache(), _is_turn_effect_alert(), _normalize_turn_effect_alert(), Any
 
 ### Community 612 - "Community 612"
 Cohesion: 0.29
-Nodes (9): _plan_request_from_step_ctx(), Rebuild PlanExecutionRequest args/context from exec ctx (merged from payload.arg, _skill_args(), test_plan_request_merges_capability_bridge_skill_args_from_metadata(), Exec rebuilds PlanExecutionRequest from ctx; docker prune must see outer user te, _skill_args_from_plan(), test_plan_request_does_not_override_explicit_skill_args(), test_plan_request_injects_from_messages_when_raw_absent() (+1 more)
-
-### Community 613 - "Community 613"
-Cohesion: 0.29
 Nodes (10): Unit tests for the Phase 4 drive-pressure measurement probe (2026-07-12).  Measu, Direct unit test of the helper itself: a raising logger.info must be     caught, The logged pressures must be the SAME dict the reducer actually folded     into, A probe logging failure must never break the hot chat-turn path. The     call si, test_log_autonomy_pressure_probe_never_raises_on_logging_failure(), test_pressure_probe_failure_is_swallowed_and_reducer_still_completes(), test_run_autonomy_reducer_logs_pressure_probe(), test_run_autonomy_reducer_pressure_probe_matches_folded_state() (+2 more)
 
-### Community 614 - "Community 614"
+### Community 613 - "Community 613"
 Cohesion: 0.40
 Nodes (10): _build_evidence_trail(), _engine(), _load_field_state_for_tick(), _load_latest_self_state(), _load_self_state_by_id(), Any, Read-only debug API for substrate self-state snapshots., self_state_evidence_trail() (+2 more)
 
-### Community 615 - "Community 615"
+### Community 614 - "Community 614"
 Cohesion: 0.35
 Nodes (9): appendLiveAgentStep(), buildTimelineRows(), ensureLiveTracePanel(), extractAgentTrace(), formatDuration(), normalizeSummary(), resolveLiveTraceAnchor(), shouldShowAgentTrace() (+1 more)
 
-### Community 616 - "Bus Channels: Graph Compression & RDF"
+### Community 615 - "Community 615"
 Cohesion: 0.33
 Nodes (9): attach(), buildCorrelationGraphElements(), buildGraphElements(), destroyCy(), filterSignalsByLayer(), isPlaceholderDimensions(), isStubSignal(), organClassColor() (+1 more)
 
-### Community 617 - "Community 617"
+### Community 616 - "Bus Channels: Graph Compression & RDF"
 Cohesion: 0.29
 Nodes (6): _Store, test_presence_invalid_payload_is_422(), test_presence_roundtrip(), test_situation_brief_reflects_manual_presence(), test_situation_status_and_brief(), test_situation_status_and_brief_disabled()
 
-### Community 618 - "Community 618"
+### Community 617 - "Community 617"
 Cohesion: 0.38
 Nodes (9): build_routes_response(), _entry_to_dict(), get_routes_payload(), _probe_one(), Any, Route catalog and upstream health cache for GET /routes., refresh_route_health_cache(), RouteHealthEntry (+1 more)
 
+### Community 618 - "Community 618"
+Cohesion: 0.24
+Nodes (9): _fetch_rollups(), get_rollups(), lifespan(), FastAPI, Record, Config, get_settings(), BaseSettings (+1 more)
+
 ### Community 619 - "Community 619"
+Cohesion: 0.29
+Nodes (9): _coalition_ref(), persist_turn_referent(), Any, datetime, Best-effort writer for substrate_turn_referent (reverie semantic lift v1)., test_persist_turn_referent_fail_open_on_db_error(), test_persist_turn_referent_skips_when_excerpts_empty(), test_persist_turn_referent_skips_when_surprise_resolved() (+1 more)
+
+### Community 620 - "Community 620"
 Cohesion: 0.31
 Nodes (9): Regression for fix/mind-enrichment-wall-budget: the shipped default wall must, _reload_settings(), test_config_warnings_silent_when_disabled(), test_config_warns_on_http_timeout_not_above_wall(), test_config_warns_on_sub_viable_wall(), test_default_wall_is_viable_for_three_phase_synthesis(), test_mind_enrichment_defaults_off(), test_mind_enrichment_reads_env() (+1 more)
 
-### Community 620 - "Community 620"
+### Community 621 - "Community 621"
+Cohesion: 0.36
+Nodes (4): _extract_json(), Any, _run_blocking(), TopicFoundryLLMClient
+
+### Community 622 - "Community 622"
 Cohesion: 0.20
 Nodes (7): CollapseTriageEvent, Config, Any, BaseModel, RAGDocumentEvent, Defines the schema for explicitly adding a document to the RAG store,     coming, Converts the RAG document event into the standard format.
 
-### Community 621 - "Community 621"
+### Community 623 - "Community 623"
 Cohesion: 0.45
 Nodes (10): _coverage(), _fake_backend(), test_backend_error_degrades_to_no_followup(), test_capability_denied_returns_empty(), test_disabled_returns_empty(), test_dry_run_skips_fetch(), test_fetches_under_covered_section(), test_gate_evaluation_error_degrades_to_empty() (+2 more)
 
-### Community 623 - "Community 623"
-Cohesion: 0.36
-Nodes (6): _iter_python_files(), _parse_ast(), Module, Path, _relative(), TestSparkContractGate
-
-### Community 624 - "Community 624"
+### Community 625 - "Community 625"
 Cohesion: 0.44
 Nodes (10): MonkeyPatch, Docker compose passes empty RETINA_WIDTH/HEIGHT; must not crash Settings()., _reload_settings(), test_blank_retina_dimensions_coerced_to_none(), test_blank_retina_width_and_height_together(), test_jpeg_quality_clamped(), test_retina_dimensions_explicit_integers(), test_retina_source_explicit_overrides_path_alias() (+2 more)
 
-### Community 625 - "Community 625"
+### Community 626 - "Community 626"
 Cohesion: 0.22
 Nodes (10): Self-State Continuity and Live Dimensions v1 (spec, ideas 1-2 implemented), Brainstorming Session #1 - Appendix Ideas 3-10, Idea 10: Predictive substrate (forward model), Idea 3: Close the action outcome feedback loop, Idea 4: Bridge autonomy drive pressures to self-state, Idea 5: Substrate-level surprise signal (prediction error), Idea 6: Rolling self-state archive, Idea 7: Drive audit loop (+2 more)
-
-### Community 626 - "Community 626"
-Cohesion: 0.38
-Nodes (8): GoalGenerationMode, _base_template(), _evidence_rules_text(), generate_goal_statement(), _llm_goal_text(), test_evidence_rules_adds_tension_clause(), test_llm_mode_falls_back_to_evidence_rules(), test_template_mode_returns_base_template()
 
 ### Community 627 - "Community 627"
 Cohesion: 0.27
@@ -3821,44 +3818,44 @@ Cohesion: 0.20
 Nodes (10): Channel "orion:kg:edge:ingest.v1" (kind=event, schema=KgEdgeIngestV1) producers=[orion-topic-foundry] consumers=[orion-rdf-writer, orion-graphdb], Channel "orion:topic:foundry:drift:alert.v1" (kind=event, schema=TopicFoundryDriftAlertV1) producers=[orion-topic-foundry] consumers=[*], Channel "orion:topic:foundry:enrich:complete.v1" (kind=event, schema=TopicFoundryEnrichCompleteV1) producers=[orion-topic-foundry] consumers=[*], Channel "orion:topic:foundry:run:complete.v1" (kind=event, schema=TopicFoundryRunCompleteV1) producers=[orion-topic-foundry] consumers=[*], Schema: KgEdgeIngestV1, Schema: TopicFoundryDriftAlertV1, Schema: TopicFoundryEnrichCompleteV1, Schema: TopicFoundryRunCompleteV1 (+2 more)
 
 ### Community 629 - "Community 629"
-Cohesion: 0.36
-Nodes (6): BaseModel, datetime, SparkStateSnapshotAckV1, _coerce_iso(), datetime, TestSparkStateSnapshotAckV1
+Cohesion: 0.38
+Nodes (9): _load_profile(), _load_verb(), _long_candidates(), test_daily_metacog_verb_uses_metacog_profile(), test_daily_pulse_verb_uses_scheduler_journal_profile(), test_journal_daily_grounded_not_capped_at_1280_without_explicit_config(), test_journal_daily_grounded_profile_is_not_strict_by_default(), test_metacog_profile_has_explicit_strict_opt_in_fields() (+1 more)
 
 ### Community 630 - "Community 630"
 Cohesion: 0.44
 Nodes (7): explain_alerts(), Any, summarize_explanations(), main(), test_explain_alerts_coherence_drop(), test_explain_alerts_novelty_spike(), test_summarize_explanations()
 
 ### Community 631 - "Community 631"
+Cohesion: 0.29
+Nodes (8): compact_vision_scene_interpretation_json_schema(), Any, Compact JSON Schema for VisionSceneInterpretationV1 (llama.cpp json_object+schem, Inline schema without $ref — suitable for Atlas metacog json_object+schema., Tests for VisionSceneInterpretationV1 compact JSON schema contract., test_compact_schema_has_required_top_level_keys(), test_event_candidate_item_requires_event_type_and_narrative(), test_salient_observation_item_requires_observation_field()
+
+### Community 632 - "Community 632"
+Cohesion: 0.31
+Nodes (8): layers_export(), organ_layer(), Organ layer taxonomy for Organ Signals mesh filters (Milestone B0)., Return layer for organ_id; unknown organs default to cognition., JSON-serializable layer map for Hub API., test_layers_export_includes_all_registry_organs(), test_organ_layer_cognition_organs(), test_organ_layer_runtime_organs()
+
+### Community 633 - "Community 633"
+Cohesion: 0.38
+Nodes (9): _coerce(), map_attention_broadcast_ctx_to_substrate(), Any, Map ``ctx['attention_broadcast']`` → one ``attending:current_focus`` node., _payload(), test_accepts_json_string_payload(), test_maps_broadcast_to_single_attending_node(), test_returns_none_on_missing_or_garbage_ctx() (+1 more)
+
+### Community 634 - "Community 634"
+Cohesion: 0.38
+Nodes (9): _coerce(), map_episode_ctx_to_substrate(), Any, Map ``ctx['episode_summary']`` → one proposal-marked ``episode:latest`` node., _episode(), test_accepts_json_string_payload(), test_maps_episode_to_single_proposal_marked_node(), test_returns_none_on_missing_or_garbage_ctx() (+1 more)
+
+### Community 635 - "Community 635"
 Cohesion: 0.33
 Nodes (9): _find_collisions(), _format_time_of_day(), _load_cadences(), main(), Path, Minimal distance in minutes between two minute-of-day values, generic over     s, Returns {cadence_name: minute_of_day} for all four named cadences (including the, _read_env_example_values() (+1 more)
 
-### Community 632 - "Community 632"
-Cohesion: 0.33
-Nodes (9): Derive periodic-scheduler finding strings from skills.docker.ps_status.v1 result, scheduler_docker_findings(), test_empty_not_dict(), test_exited_with_unhealthy_text_skipped(), test_healthy_running_no_findings(), test_missing_state_requires_up_prefix(), test_running_unhealthy_finding(), test_unavailable_no_findings() (+1 more)
-
-### Community 633 - "Community 633"
-Cohesion: 0.36
-Nodes (5): CoreEventCache, get_core_event_cache(), _is_turn_effect_alert(), _normalize_turn_effect_alert(), Any
-
-### Community 634 - "Community 634"
+### Community 636 - "Community 636"
 Cohesion: 0.44
 Nodes (9): _attempt_mind_handoff_chat_stance_shortcut(), If Orch supplied a validated Mind handoff, skip the LLM stance synthesis step., _exec_prep(), ExecutionStep, _step(), test_shortcut_returns_none_when_orch_did_not_authorize_skip(), test_shortcut_returns_none_when_payload_invalid(), test_shortcut_returns_none_when_skip_flag_without_authorization() (+1 more)
 
-### Community 635 - "Community 635"
-Cohesion: 0.22
-Nodes (8): _format_message_history_for_chat_prompt(), Compact transcript for chat_general / chat_quick Jinja (message_history).     Sk, Regression guardrails for brain-lane chat prompts + recall gating.  Rationale (2, Brittle but cheap: if someone reverts router recall wiring, CI fails., Empty message_history must never be the only dialogue anchor when turns exist., test_chat_quick_render_surfaces_transcript_not_only_user_line(), test_format_message_history_includes_latest_user_and_assistant(), test_router_still_wires_plan_ctx_latest_user_text_for_recall_decision()
-
-### Community 636 - "Community 636"
+### Community 637 - "Community 637"
 Cohesion: 0.29
 Nodes (9): Non-amnesiac acceptance check for `_run_autonomy_reducer`.  Verifies the reducer, Store returning None (unreachable / no DSN) must not change today's     fallback, save_autonomy_state_v2 raising must not propagate out of the reducer --     belt, Regression: chat_autonomy_movement_debug['pressures_before'] must reflect     th, test_run_autonomy_reducer_falls_back_to_v1_baseline_when_store_unreachable(), test_run_autonomy_reducer_movement_debug_before_matches_actual_previous_state(), test_run_autonomy_reducer_uses_persisted_state_not_v1_baseline_on_second_call(), test_run_autonomy_reducer_write_failure_is_swallowed() (+1 more)
 
-### Community 637 - "Community 637"
+### Community 638 - "Community 638"
 Cohesion: 0.24
 Nodes (8): health(), latest(), lifespan(), Any, FastAPI, get_settings(), BaseSettings, Settings
-
-### Community 638 - "Community 638"
-Cohesion: 0.29
-Nodes (9): _make_worker(), When ENABLE_COMPRESSION_RUNTIME=false the tick does nothing., All federators returning [] must not raise — just skip region., If LLM token budget is 0, no summarization occurs but regions are still processe, Substrate clusters must default to 'hotspot' so we don't spuriously flood     su, test_substrate_scope_labels_clusters_hotspot_not_contradiction(), test_worker_budget_gate_halts_mid_batch(), test_worker_disabled_skips_tick() (+1 more)
 
 ### Community 639 - "Community 639"
 Cohesion: 0.27
@@ -3897,8 +3894,8 @@ Cohesion: 0.31
 Nodes (9): client(), _empty_projection_with_diagnostics(), _mind_prep(), TestClient, Regression: populated projection must not downgrade to starved fallback silently, Regression for fix/mind-enrichment-wall-budget: a light Mind run that sends NO, test_light_path_without_projection_does_not_claim_orch_starvation(), test_mind_run_emits_projection_starvation_diagnostics() (+1 more)
 
 ### Community 648 - "Community 648"
-Cohesion: 0.42
-Nodes (9): _legacy_self_state_payload_with_policy_pressure(), Regression tests for a real live incident (2026-07-12): after Phase 0 removed `p, _store_with_row(), _store_with_rows(), test_load_latest_self_state_degrades_to_none_on_legacy_incompatible_row(), test_load_latest_self_state_still_parses_a_valid_row(), test_load_recent_self_states_skips_legacy_row_keeps_valid_ones(), test_load_self_state_for_attention_frame_degrades_to_none_on_legacy_row() (+1 more)
+Cohesion: 0.40
+Nodes (9): ChatItem, _contains_active_prompt(), fetch_chat_history_pairs(), fetch_chat_messages(), fetch_chat_turn_timestamps(), _normalize_text(), Any, Resolve created_at (epoch) for chat turns by id, bounded to the last ``since_min (+1 more)
 
 ### Community 649 - "Community 649"
 Cohesion: 0.27
@@ -3909,40 +3906,40 @@ Cohesion: 0.31
 Nodes (6): _Dim, _FakeSelfState, _sample_self_state(), test_seed_v3_headline_still_reads_reliability_from_dimensions(), test_seed_v3_moves_reliability_to_infra_only(), test_seed_v3_still_emits_saturated_felt_for_audit()
 
 ### Community 651 - "Community 651"
-Cohesion: 0.24
-Nodes (5): _dim(), Confirms the actual bug mechanism directly, with the exact dimension     reading, Reproduces the live incident's exact dimension readings.      The `uncertainty`, _self_state_payload(), test_phi_from_self_state_novelty_is_zero_with_live_incident_dimensions()
+Cohesion: 0.31
+Nodes (8): _broadcast(), _chain(), Phase E — compaction request (queue only). A settled chain queues a typed ask; n, test_chain_no_request_when_flag_off(), test_chain_queues_request_when_flag_on(), test_settled_chain_builds_consolidate_request(), test_unknown_theme_yields_no_request(), test_unsettled_chain_yields_no_request()
 
 ### Community 652 - "Community 652"
-Cohesion: 0.42
-Nodes (9): _drive(), _make_worker(), Unit tests for the Orion embodiment C producer hook.  Verifies the substrate wor, test_cache_drive_state_fails_open_on_bad_decode(), test_emit_fails_open_when_publish_raises(), test_flag_off_publishes_nothing(), test_flag_on_publishes_one_involuntary_intent(), test_no_drive_state_publishes_nothing() (+1 more)
-
-### Community 653 - "Community 653"
-Cohesion: 0.47
-Nodes (9): _make_worker(), Unit tests for the Orion embodiment perception->substrate ingest consumer.  Veri, _set_decode(), test_flag_off_writes_nothing(), test_flag_on_writes_real_proximity_node(), test_invalid_payload_fails_open(), test_no_store_fails_open(), test_store_write_exception_fails_open() (+1 more)
-
-### Community 654 - "Community 654"
-Cohesion: 0.38
-Nodes (9): _make_worker(), datetime, Unit tests for the episodic consolidation tick (self-modeling loop rung 4).  Ver, _receipt(), test_episodic_tick_disabled_is_noop(), test_episodic_tick_fails_open_on_store_error(), test_episodic_tick_is_idempotent_within_a_window(), test_episodic_tick_saves_proposal_marked_episode() (+1 more)
-
-### Community 655 - "Community 655"
 Cohesion: 0.31
 Nodes (3): _peak_threshold(), STTEngine, get_stt_engine()
 
-### Community 656 - "Community 656"
+### Community 653 - "Community 653"
+Cohesion: 0.31
+Nodes (5): _env(), FakeQueue, test_enqueue_failure_is_swallowed(), test_enqueue_run_result_stream_selects_run_result_envelope(), test_enqueue_skipped_when_no_run_result_envelope()
+
+### Community 654 - "Community 654"
 Cohesion: 0.33
 Nodes (8): ExecutionDispatchFrameV1, _dispatch_status_summary(), _engine(), execution_dispatch_latest(), _load_latest_dispatch_frame(), Any, Read-only debug API for substrate execution dispatch frames., Operator-visible breakdown of what actually happened in this frame --     P3's "
 
-### Community 657 - "Community 657"
+### Community 655 - "Community 655"
+Cohesion: 0.56
+Nodes (9): GoalActionKind, build_goal_graph_query_client(), complete_goal(), dismiss_goal(), execute_goal_action(), fetch_goal_by_artifact_id(), promote_goal(), update_goal_proposal_status() (+1 more)
+
+### Community 656 - "Community 656"
 Cohesion: 0.22
 Nodes (9): Reverie Narrate (Spontaneous Felt-Layer Narration), SpontaneousThoughtV1 (schema), Simulation, Skills — Mesh Presence (Tailscale), Stance React, Story Weave, Substrate Inspect, Substrate Observe (+1 more)
+
+### Community 657 - "Community 657"
+Cohesion: 0.25
+Nodes (5): _FlakyBus, MonkeyPatch, orion.core.bus.resilience must not crash-on-import when loguru is missing., test_publish_with_reconnect_retries_after_transport_error(), test_resilience_importable_without_loguru()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.42
 Nodes (7): CognitionTraceAdapter, adapter(), _payload_with_correlation(), test_cognition_trace_adapter_chat_general(), test_cognition_trace_adapter_cognition_trace_kind(), test_cognition_trace_adapter_envelope_correlation_only(), test_cognition_trace_adapter_no_pii_in_signal()
 
 ### Community 659 - "Community 659"
-Cohesion: 0.28
-Nodes (8): _get_engine(), load_pending_requests(), persist_compaction_delta(), Phase F store — read the compaction-request queue, persist staged deltas.  Two s, Recent un-consumed compaction requests (Phase-E queue). [] on any miss.      Rea, Insert one staged delta. Never raises; idempotent on delta_id.      Writes ONLY, Regression: the default loader must match the positional RequestLoader     alias, test_default_request_loader_accepts_positional_limit()
+Cohesion: 0.42
+Nodes (8): _chat_template(), _iter_jsonl(), _load_from_jsonl(), _normalize_record(), Any, Path, _stable_bucket(), CanonicalSftExample
 
 ### Community 660 - "Community 660"
 Cohesion: 0.28
@@ -3953,110 +3950,114 @@ Cohesion: 0.28
 Nodes (7): get_cognition_library(), Returns the scanned list of Packs and Verbs available in the system.     Used by, find_repo_root(), Any, Path, Scans the orion/cognition folder for packs and verbs.     Returns:         {, scan_cognition_library()
 
 ### Community 662 - "Community 662"
-Cohesion: 0.31
-Nodes (8): apply_curiosity_hint(), _fetch_fresh_candidates(), format_curiosity_hint(), Any, Curiosity focus hint for the Hub agent lane (self-observability v2).  When the a, Latest curiosity candidate set newer than _MAX_AGE_SEC, else []., One bounded hint line from the strongest candidate summaries, or None., Prepend the focus hint to ``prompt`` when available; never raises.
+Cohesion: 0.28
+Nodes (8): _run_agent_claude_http(), build_harness_reasoning_trace(), Deterministic harness transcript for reasoning_trace.content → thought_process., summarize_harness_steps_for_history(), Agent-claude harness steps must land in chat history thought_process seam., test_build_harness_reasoning_trace_empty_when_no_steps(), test_build_harness_reasoning_trace_shape_for_sql_writer(), test_summarize_harness_steps_for_history_includes_assistant_lines()
 
 ### Community 663 - "Community 663"
 Cohesion: 0.31
-Nodes (8): get(), get_latest(), Any, In-memory store for the latest social-room routing_debug per room.  Hub writes a, Record the latest routing_debug for a completed social-room turn., Return the latest snapshot for a specific room, or None., Return the most recently stored snapshot across all rooms., store()
+Nodes (8): apply_curiosity_hint(), _fetch_fresh_candidates(), format_curiosity_hint(), Any, Curiosity focus hint for the Hub agent lane (self-observability v2).  When the a, Latest curiosity candidate set newer than _MAX_AGE_SEC, else []., One bounded hint line from the strongest candidate summaries, or None., Prepend the focus hint to ``prompt`` when available; never raises.
 
 ### Community 664 - "Community 664"
 Cohesion: 0.31
-Nodes (6): build_spark_introspect_candidate_envelope(), publish_spark_introspect_candidate(), Any, Build a spark.candidate envelope for the introspector EKG / turn-effect UI., Publish spark.candidate so spark-introspector refreshes tissue/phi on chat turns, test_build_spark_introspect_candidate_envelope_carries_turn_effect()
+Nodes (8): get(), get_latest(), Any, In-memory store for the latest social-room routing_debug per room.  Hub writes a, Record the latest routing_debug for a completed social-room turn., Return the latest snapshot for a specific room, or None., Return the most recently stored snapshot across all rooms., store()
 
-### Community 666 - "Community 666"
-Cohesion: 0.31
-Nodes (7): _client_result(), _ensure_hub_scripts_import_path(), hub_settings(), _msg_payload(), Any, Hub memory_graph_suggest structured-output request wiring., test_suggest_request_includes_structured_options()
+### Community 665 - "Community 665"
+Cohesion: 0.56
+Nodes (8): ThoughtClient, _stance_request(), test_thought_client_react_proceeds_when_subscriber_probe_fails(), test_thought_client_react_returns_thought_event(), test_thought_client_react_skips_rpc_when_no_subscriber(), test_thought_client_react_timeout_returns_none(), test_thought_client_react_waits_for_subscriber(), _thought_event()
 
 ### Community 667 - "Community 667"
 Cohesion: 0.31
-Nodes (5): _atlas_emission(), _atlas_pressure_receipt(), Newest global receipt for another node must not appear on atlas latest., test_latest_chain_shape(), test_latest_chain_skips_non_matching_global_receipt()
+Nodes (7): _client_result(), _ensure_hub_scripts_import_path(), hub_settings(), _msg_payload(), Any, Hub memory_graph_suggest structured-output request wiring., test_suggest_request_includes_structured_options()
 
 ### Community 668 - "Community 668"
+Cohesion: 0.31
+Nodes (5): _atlas_emission(), _atlas_pressure_receipt(), Newest global receipt for another node must not appear on atlas latest., test_latest_chain_shape(), test_latest_chain_skips_non_matching_global_receipt()
+
+### Community 669 - "Community 669"
 Cohesion: 0.33
 Nodes (5): _candidate(), _sample_dispatch_frame(), test_latest_includes_status_summary_counts(), test_latest_returns_frame(), test_latest_status_summary_all_zero_on_empty_frame()
 
-### Community 669 - "Community 669"
+### Community 670 - "Community 670"
 Cohesion: 0.42
 Nodes (6): _atlas_field_state(), _fake_engine_with_field(), test_field_capability_llm_inference(), test_field_latest_not_found(), test_field_latest_returns_parsed_state(), test_field_node_atlas_returns_vector_and_capabilities()
 
-### Community 670 - "Community 670"
+### Community 671 - "Community 671"
 Cohesion: 0.33
 Nodes (4): _DummyBus, _DummyStore, test_get_stats_returns_tracker_snapshot(), test_handler_mapping_includes_get_stats()
 
-### Community 671 - "Community 671"
+### Community 672 - "Community 672"
 Cohesion: 0.39
 Nodes (8): client(), _mind_prep(), _projection_with_item(), TestClient, test_health_ok(), test_mind_run_deterministic_ok(), test_mind_run_emits_shadow_synthesis_from_projection_items_without_authority(), test_mind_run_surfaces_cognitive_projection_seen_without_shadow_when_no_items()
 
-### Community 672 - "Community 672"
+### Community 673 - "Community 673"
 Cohesion: 0.22
 Nodes (9): orion-ollama-host docker-compose (GPU runtime, port 11434, healthcheck, model volume), orion-ollama-host: wrapper around official Ollama container, auto-pulls model on startup, exposes port 11434, orion-ollama-host dependencies (pydantic, pydantic-settings, PyYAML, requests), orion-pageindex docker-compose (port 8360, PageIndex build args, journal_entry_index table wiring), orion-pageindex: standalone journals PageIndex service (corpora rebuild/status/query API for journals and chat_episodes), orion-pageindex dependencies (fastapi, uvicorn, pydantic, psycopg2-binary, SQLAlchemy, pytest), orion-rag docker-compose (bus request/reply channels, VECTOR_DB_URL, EMBEDDING_MODEL), orion-rag: retrieval-augmented generation orchestrator, enriches queries with vector-db context before delegating to LLM host (+1 more)
 
-### Community 673 - "Community 673"
+### Community 674 - "Community 674"
 Cohesion: 0.33
 Nodes (8): callsyne_room_message(), health(), lifespan(), _normalize_signature(), Any, FastAPI, Request, _verify_webhook_hmac_signature()
 
-### Community 674 - "Community 674"
+### Community 675 - "Community 675"
 Cohesion: 0.25
 Nodes (9): orion-sql-db docker-compose.yml (Postgres 15 + pgAdmin), mem_limit/autovacuum tuning to prevent TOAST-vacuum OOM host freeze (16g cap, bounded vacuum memory), orion-sql-db: PostgreSQL database + pgAdmin client, orion-state-journaler docker-compose.yml, orion-state-journaler requirements.txt, orion-state-journaler: Spark/equilibrium snapshot rollup journaler to Postgres, orion-state-service docker-compose.yml, orion-state-service README (+1 more)
 
-### Community 675 - "Community 675"
-Cohesion: 0.31
-Nodes (8): build_journal_entry_index_select(), Any, datetime, Select, Session, query_journal_entry_index(), _tokens(), test_simple_filtered_retrieval_sql_shape()
-
 ### Community 676 - "Community 676"
-Cohesion: 0.31
-Nodes (5): _drain_grammar_tasks(), _grammar_payload(), _metacog_payload(), Regression tests for sql-writer bus consumer stall (grammar INSERT hang blocking, test_grammar_persist_is_non_blocking_and_allows_next_envelope()
+Cohesion: 0.42
+Nodes (7): _node(), test_brain_frame_tick_assembles_and_persists(), test_brain_frame_tick_has_no_phantom_or_mislabeled_lanes(), test_brain_frame_tick_skips_when_disabled(), test_lane_health_remaps_cursor_names_to_friendly_keys(), test_route_grammar_lane_remaps_to_friendly_key(), _worker()
 
 ### Community 677 - "Community 677"
+Cohesion: 0.42
+Nodes (8): _projection(), Unit tests for the self-observability store writers (curiosity + dwell)., _signal(), _store_with_conn(), test_save_coalition_dwell_inactive_when_zero_ticks(), test_save_coalition_dwell_row_shape_and_prune(), test_save_curiosity_candidates_empty_persists_heartbeat(), test_save_curiosity_candidates_inserts_json_array_and_prunes()
+
+### Community 678 - "Community 678"
 Cohesion: 0.53
 Nodes (8): _ok_result_json(), _req(), _settings(), test_empty_base_url_fails_open(), test_http_500_fails_open(), test_ok_returns_result(), test_oversized_body_fails_open(), test_timeout_fails_open()
 
-### Community 678 - "Community 678"
+### Community 679 - "Community 679"
 Cohesion: 0.64
 Nodes (8): _allowed_schemas(), _get_cached(), list_columns(), list_schemas(), list_tables(), Any, _set_cached(), table_fingerprint()
 
-### Community 679 - "Community 679"
+### Community 680 - "Community 680"
 Cohesion: 0.36
 Nodes (7): BaseSettings, Settings, _clear_transition_env(), MonkeyPatch, test_settings_reads_legacy_skip_enabled_alias(), test_settings_reads_legacy_skip_max_sec_alias(), test_settings_refresh_ttl_default_zero()
 
-### Community 680 - "Community 680"
+### Community 681 - "Community 681"
+Cohesion: 0.31
+Nodes (7): now_utc(), PublishResult, BaseModel, datetime, RunCacheEntry, RunRequest, world_pulse_run()
+
+### Community 682 - "Community 682"
 Cohesion: 0.42
 Nodes (8): _built_state(), _live_shaped_field(), test_context_channels_not_unresolved(), test_dimension_evidence_is_dimension_specific(), test_pressure_channels_in_unresolved_pressures(), test_stabilized_but_loaded_label(), test_stabilizers_in_stabilizing_factors(), test_stabilizers_not_in_unresolved_pressures()
 
-### Community 681 - "Community 681"
+### Community 683 - "Community 683"
 Cohesion: 0.25
 Nodes (8): Endogenous Drive Origination Design (Step 1 spec), Internal Economy Scarcity Allocation Design (Step 4 spec), Phase 2: Spark ConceptProfile Graph Read Model, Phase 3A: Shadow Rollout for Spark ConceptProfile Repository, Phase 3B: Parity Evidence and Cutover-Readiness Model, Phase 4: ConceptProfile Runtime Cutover (concept_induction_pass), Phase 0: Spark Concept Profile Repository Seam, Autonomy Origination Measurement Gate (scripts/analysis/README.md)
 
-### Community 682 - "Community 682"
+### Community 684 - "Community 684"
 Cohesion: 0.25
 Nodes (8): Tailscale auth key placeholder file (empty), Admin SSH authorized_keys policy, Script: orion-bootstrap.sh, Orion Node Bootstrap README (Ubuntu 24.04), Requirement: docker-compose.repo SSH URL, Requirement: Tailscale auth key (env or file), Script: verify-agent.sh, Script: verify-gpu.sh
 
-### Community 683 - "Community 683"
+### Community 685 - "Community 685"
 Cohesion: 0.36
 Nodes (7): fetch_attended_target_ids(), open_readonly_connection(), datetime, Kill-criterion eval: attention-bound proposal target diversity (P5).  `inspect_a, Open a psycopg2 connection and force a read-only session.      Returns None on a, Return the target_id of every inspect_attended_target candidate whose     parent, run()
 
-### Community 684 - "Community 684"
+### Community 686 - "Community 686"
 Cohesion: 0.25
 Nodes (8): enum, ExecutiveControl, Generative, MemoryAccess, MetaCognition, Perception, SelfModification, Transform
 
-### Community 685 - "Community 685"
-Cohesion: 0.36
-Nodes (6): join_openai_message_content(), Any, Normalize OpenAI-compatible message.content (str or part list) to plain text., Tests for join_openai_message_content helper., test_join_list_content_skips_reasoning_parts(), test_join_string_content()
+### Community 687 - "Community 687"
+Cohesion: 0.50
+Nodes (7): card_qualifies_for_crystallizer(), emit_memory_card_active_for_crystallizer(), Notify crystallizer when an active card has high-salience priority., _card(), test_card_qualifies_only_active_high_salience(), test_emit_publishes_qualifying_card(), test_emit_skips_non_qualifying_card()
 
-### Community 686 - "Community 686"
+### Community 688 - "Community 688"
 Cohesion: 0.57
 Nodes (7): detect_contradictions(), detect_duplicates(), DetectionResult, _jaccard(), merge_detection(), _normalize_text(), _token_set()
 
-### Community 687 - "Community 687"
-Cohesion: 0.50
-Nodes (7): insert_link(), list_links(), neighborhood(), _normalize_uuid(), Any, Pool, Return crystallization link neighborhood (not Graphiti).
-
-### Community 688 - "Community 688"
+### Community 689 - "Community 689"
 Cohesion: 0.32
 Nodes (7): ChatResultPayload, EnrichedChat, BaseModel, Standardized payload for LLM generation results., Enriched metadata for a chat message (tags, summary, embeddings pointer)., Minimal payload capturing a raw chat exchange., RawChat
 
-### Community 689 - "Community 689"
+### Community 690 - "Community 690"
 Cohesion: 0.25
 Nodes (8): Composition status taxonomy: COMPOSED/SHADOW/DUPLICATE/REHEARSAL, inner_state_registry.py: registry of all self-state signals, Rationale: registry built after signal duplication/dead-end rediscovered 5x by grep-archaeology, SelfStateV1 (Layer 6: the mood), Canonical phi: _phi_from_self_state() / _get_phi_stats(), orion-equilibrium-service heartbeat trigger, OrionTissue: fallback-only tensor (cold-start/outage path), Rationale: spark_engine.py/integration.py/strategies.py deleted (zero production consumers, third φ implementation)
 
@@ -4069,152 +4070,152 @@ Cohesion: 0.39
 Nodes (6): add_test(), smoke_all_notifications.sh script, SKIP_COMPOSE, start_stack(), usage(), wait_for_health()
 
 ### Community 693 - "Community 693"
+Cohesion: 0.39
+Nodes (4): PromptContext, PromptFactory, Any, Turns (AgentConfig + PromptContext) into a messages[] list.      This is where φ
+
+### Community 694 - "Community 694"
+Cohesion: 0.29
+Nodes (6): PromptContext, PromptFactory, Any, Shared context for building prompts for any agent.     Keeps council logic DRY,, Responsible for turning (AgentConfig + PromptContext) into LLM message lists., Single entrypoint: build a messages[] list for an LLM from agent + context.
+
+### Community 695 - "Community 695"
 Cohesion: 0.57
 Nodes (7): _load_app(), MonkeyPatch, Path, test_health(), test_health_proposal_review_block_parent_writable_before_first_write(), test_health_proposal_review_block_store_configured(), test_health_proposal_review_block_store_missing()
 
-### Community 694 - "Community 694"
+### Community 696 - "Community 696"
+Cohesion: 0.43
+Nodes (7): _should_prepare_brain_reply_context(), test_chat_kids_story_skips_heavy_brain_reply_context_prep(), test_chat_quick_skips_heavy_brain_reply_context_prep(), test_introspect_spark_skips_heavy_brain_reply_context_prep(), test_memory_graph_suggest_skips_heavy_brain_reply_context_prep(), test_non_runtime_brain_step_keeps_context_prep_enabled(), test_runtime_skill_skips_chat_stance_autonomy_context_prep()
+
+### Community 697 - "Community 697"
 Cohesion: 0.32
 Nodes (7): _ensure_cortex_exec_paths(), _purge_app_modules_if_wrong_service(), pytest_sessionstart(), Make the top-level ``app`` package resolve to orion-cortex-exec.      In a multi, Avoid importing full spaCy when tests only need app.router (pulls autonomy -> co, Service .env often sets large LLM_CHAT_* dev budgets; unit tests expect canonica, _stub_spacy_for_router_imports()
 
-### Community 695 - "Community 695"
+### Community 698 - "Community 698"
+Cohesion: 0.36
+Nodes (7): _avg(), fetch_recent_sql_fragments(), Fragment, Returns fragments from:       - collapse_mirror (timestamp is string → cast to t, Input columns:       - gpu (JSON): {"latest_file":"...", "gpus":[             {", _summarize_biometrics(), _to_float()
+
+### Community 699 - "Community 699"
 Cohesion: 0.36
 Nodes (7): build_region(), Deterministic region ID from scope + kind + sorted node URIs., stable_region_id(), test_region_builder_different_nodes_different_id(), test_region_builder_produces_valid_region(), test_region_builder_stable_id_idempotent(), test_region_builder_trust_tier_inherits_lowest()
 
-### Community 696 - "Community 696"
+### Community 700 - "Community 700"
+Cohesion: 0.36
+Nodes (6): Any, Server-side AI Town tab HTML fragments for Hub index render., render_aitown_tab_blocks(), _Settings, test_hub_aitown_tab_hidden_when_disabled(), test_hub_aitown_tab_rendered_when_enabled()
+
+### Community 701 - "Community 701"
 Cohesion: 0.32
 Nodes (7): api_llm_routes(), _base_url(), fetch_routes(), Any, ClientTimeout, Hub client for LLM gateway GET /routes catalog., _timeout()
 
-### Community 697 - "Community 697"
-Cohesion: 0.29
-Nodes (7): _chat_turn_trace_linkage(), Canonical correlation linkage for chat turn metadata (Runtime Trace Nexus §5.8)., Correlation ID propagation tests (Runtime Trace Nexus §5.8 gate).  Manual stagin, Hub must expose the same corr id used for cortex + trace APIs (spec §5.8)., HTTP chat must expose trace_linkage canonical id, not cortex-only id (§5.8)., test_chat_response_metadata_includes_canonical_correlation_id(), test_trace_linkage_canonical_preferred_over_cortex_result_id()
-
-### Community 698 - "Community 698"
-Cohesion: 0.43
-Nodes (7): build_mutation_store_from_env(), build_parser(), _default_profile_payload(), main(), ArgumentParser, _resolve_control_plane_postgres_url(), seed_recall_canary_profile()
-
-### Community 699 - "Community 699"
+### Community 702 - "Community 702"
 Cohesion: 0.54
 Nodes (7): _coerce(), _engine(), frames_range(), frames_tail(), Any, Read-only Self-brain API: realtime tail + playback range + window bounds.  Reads, window()
 
-### Community 700 - "Community 700"
+### Community 703 - "Community 703"
 Cohesion: 0.29
 Nodes (5): _ensure_hub_scripts_import_path(), hub_client(), test_complete_goal_success_when_enabled(), test_dismiss_goal_success_when_enabled(), test_promote_goal_success_when_enabled()
 
-### Community 701 - "Community 701"
-Cohesion: 0.36
-Nodes (7): client(), MonkeyPatch, Path, TestClient, FCC model labels API for agent-claude mode., test_fcc_model_labels_disabled_by_default(), test_fcc_model_labels_reads_fixture_env()
-
-### Community 702 - "Community 702"
+### Community 704 - "Community 704"
 Cohesion: 0.43
 Nodes (7): _denver_env(), _extract_format_hub_local_time_source(), Behavioral regression test for `formatHubLocalTime` in app.js.  Bug: orion-notif, Pull the real `formatHubLocalTime` (and its helpers) straight out of app.js., _run_node_denver(), test_naive_utc_created_at_renders_correct_denver_day_and_time(), test_offset_suffixed_value_is_not_double_converted()
 
-### Community 703 - "Community 703"
+### Community 705 - "Community 705"
 Cohesion: 0.32
 Nodes (4): _bridge_suggest_block(), _memory_suggest_block(), test_app_js_wires_memory_graph_bridge_handlers(), test_memory_js_listens_for_bridge_import_event()
 
-### Community 704 - "Community 704"
+### Community 706 - "Bus Channels: Substrate Tier Telemetry"
 Cohesion: 0.25
 Nodes (4): mindRunsModal must not live under #scheduleModal.hidden or it never paints., Bare `global` is undefined in browsers and aborts DOMContentLoaded before tab wi, test_app_js_lane_api_uses_global_this_not_node_global(), test_mind_runs_modal_is_sibling_of_schedule_modal_not_nested()
 
-### Community 705 - "Community 705"
+### Community 707 - "Community 707"
 Cohesion: 0.36
 Nodes (3): _FakeCortexClient, _Store, test_handle_chat_request_injects_session_presence()
 
-### Community 706 - "Bus Channels: Substrate Tier Telemetry"
+### Community 708 - "Community 708"
 Cohesion: 0.36
 Nodes (4): _FakeBus, test_api_chat_response_feedback_publishes_valid_payload(), test_api_chat_response_feedback_rejects_invalid_payload(), test_feedback_downvote_emits_pressure_event_telemetry()
 
-### Community 707 - "Community 707"
+### Community 709 - "Community 709"
 Cohesion: 0.32
 Nodes (3): _fake_engine(), _frame(), test_tail_returns_ascending_and_200()
 
-### Community 708 - "Community 708"
+### Community 710 - "Community 710"
 Cohesion: 0.25
 Nodes (4): Regression guard: the cancel request must key off the per-connection id     capt, The Stop button must be shown for every WS send path that starts a     server-ca, test_app_js_shows_stop_button_on_every_turn_kind_send(), test_app_js_stop_request_uses_connection_id_not_session_id()
 
-### Community 709 - "Community 709"
+### Community 711 - "Community 711"
 Cohesion: 0.29
 Nodes (8): orion-mesh-guardian docker compose deployment (port 7161, mounts /repo ro + docker.sock, NOTIFY_BASE_URL, equilibrium snapshot), orion-mesh-guardian: detects half-dead bus consumers on chat critical path, publishes Hub Pending Attention cards via notify, optional auto-remediation via docker compose, orion-mesh-guardian Python dependencies (fastapi, pydantic, httpx, pyyaml, redis, loguru, requests), orion-notify-digest docker compose deployment (port 7150, shared postgres with notify, drift alert env), orion-notify-digest: builds daily summary of notification activity, sends via orion-notify, integrates Topic Foundry topics/drift alerts, orion-notify docker compose deployment (port 7140, SMTP env, in-app channel, escalation poll), orion-notify: minimal notification host centralizing email delivery, attention requests, chat messages, recipient preferences, escalation, orion-notify Python dependencies (fastapi, requests, pyyaml, loguru, redis, httpx)
 
-### Community 710 - "Community 710"
+### Community 712 - "Community 712"
+Cohesion: 0.68
+Nodes (7): MonkeyPatch, Path, _reload_service_modules(), test_queue_full_deadletters(), test_retrying_write_deadletters_on_total_failure(), test_retrying_write_no_retry_on_http_400(), test_retrying_write_succeeds_after_oserror()
+
+### Community 713 - "Community 713"
 Cohesion: 0.43
 Nodes (6): classify_intent_v1(), IntentClassification, BaseModel, resolve_profile_for_intent(), test_biographical_intent(), test_fallback_profile()
 
-### Community 711 - "Community 711"
+### Community 714 - "Community 714"
 Cohesion: 0.32
 Nodes (4): RDF chat-turn recall must honor the profile time window.  The graph stores no us, _run_window(), test_windowing_drops_out_of_window_and_stamps_kept(), test_windowing_noop_when_since_minutes_non_positive()
 
-### Community 712 - "Community 712"
-Cohesion: 0.46
-Nodes (6): _mock_post(), MonkeyPatch, RDF-backed recall fragments must score by real recency, not a frozen UUID sort., test_rdf_chatturn_fragments_score_by_recency(), test_rdf_fragment_ordering_uses_timestamp_not_uri(), test_rdf_graphtri_fragments_score_by_recency()
+### Community 715 - "Community 715"
+Cohesion: 0.54
+Nodes (7): _make_worker(), Unit tests for the Phase 2 deviation-probe logging hook (2026-07-12, measurement, _state(), test_log_deviation_probe_carries_state_across_ticks(), test_log_deviation_probe_disabled_via_settings_does_not_log(), test_log_deviation_probe_logs_impulses_and_confidence(), test_log_deviation_probe_never_raises_on_gate_failure()
 
-### Community 713 - "Community 713"
+### Community 716 - "Community 716"
 Cohesion: 0.25
 Nodes (8): orion-social-memory docker-compose.yml, orion-social-memory README, orion:chat:social:stored (social-memory input channel), orion-social-memory requirements.txt, orion-social-memory: relational continuity synthesizer for social-room turns, orion-social-room-bridge docker-compose.yml, orion-social-room-bridge requirements.txt, orion-social-room-bridge: social platform bridge (Callsyne/Hub)
 
-### Community 714 - "Community 714"
-Cohesion: 0.32
-Nodes (3): ConnectionManager, Any, WebSocket
-
-### Community 715 - "Community 715"
+### Community 717 - "Community 717"
 Cohesion: 0.43
 Nodes (6): _load_settings_module(), test_evidence_index_wiring_exists_in_settings_env_compose_bus_and_registry(), test_feedback_wiring_exists_in_settings_env_and_compose(), test_journal_index_wiring_exists_in_settings_env_compose_bus_and_registry(), test_markdown_adapter_channel_wiring_exists_in_settings_env_compose_bus_and_registry(), test_parsed_document_channel_wiring_exists_in_settings_env_compose_bus_and_registry()
 
-### Community 716 - "Community 716"
-Cohesion: 0.68
-Nodes (7): _candidate(), _decision(), _self_state(), test_envelope_includes_refs(), test_envelope_includes_verb_mode_source_dry_run(), test_envelope_no_field_state_or_prompts(), test_envelope_read_only_constraints()
+### Community 718 - "Community 718"
+Cohesion: 0.54
+Nodes (7): _make_worker(), _sample_closure(), test_handle_post_turn_closure_bus_message_decodes_envelope(), test_handle_post_turn_closure_message_invokes_handler(), test_worker_handle_post_turn_closure_skips_when_flag_disabled(), test_worker_handle_post_turn_closure_skips_when_surprise_resolved(), test_worker_handle_post_turn_closure_writes_prediction_error_when_unresolved()
 
-### Community 717 - "Community 717"
+### Community 719 - "Community 719"
+Cohesion: 0.32
+Nodes (4): _broadcast(), Phase D — episode + motif grounding (read-only). Refs are capped, degrade to emp, test_tick_attaches_grounding_when_flag_on(), test_tick_no_grounding_when_flag_off()
+
+### Community 720 - "Community 720"
 Cohesion: 0.52
 Nodes (6): BackgroundTasks, compare_runs(), enrich_run_endpoint(), get_run_endpoint(), UUID, fetch_run()
 
-### Community 718 - "Community 718"
+### Community 721 - "Community 721"
 Cohesion: 0.38
 Nodes (7): Bus channel orion-exec:request:LLMGatewayService (LLM gateway intake), OrionBusAsync class (orion.core.bus.async_service.OrionBusAsync) used to publish/subscribe on Redis bus, orion-llm-gateway manual smoke tests: bus chat/exec_step envelopes, ollama vs vllm backend selection, orion-memory-consolidation docker compose deployment (port 8635, consolidation/crystallizer/concept-relation env), orion-mind router profiles: default (route_kind brain, chat_general, advisory) and conservative (route_kind no_chat, mandatory), orion-mind docker compose deployment: semantic/appraisal/stance LLM synthesis routes, evidence limits, LLM gateway intake channel, orion-mind Python dependencies (fastapi, pydantic, pyyaml, redis)
 
-### Community 719 - "Community 719"
+### Community 722 - "Community 722"
 Cohesion: 0.33
 Nodes (7): config/autonomy/capability_policy.v1.yaml — policy config gating which autonomy capabilities may auto-execute per cycle, by side-effect class, required goal status, required drive origins/signal kinds, and per-cycle budget, capability journal.compose.episode — write side-effect, auto_execute true, requires goal status 'proposed', predictive drive origin, no required signal kinds, budget 1/cycle, capability recall.query.readonly — readonly side-effect, auto_execute true, requires goal status 'proposed', predictive drive origin, world_coverage_gap signal, budget 2/cycle (P4 addition, mirrors web.fetch.readonly's gate), capability web.fetch.readonly — readonly side-effect, auto_execute true, requires goal status 'proposed', predictive drive origin, world_coverage_gap signal, budget 2/cycle, capability web.fetch.write — external side-effect, auto_execute false, requires goal status 'planned', budget 0/cycle (blocked from autonomous execution), capability world_pulse.run — readonly side-effect, auto_execute true, requires no goal status, no drive origin gating, budget 1/cycle, Readonly capabilities (recall.query.readonly, P4): ConceptWorker is the sole production call site for maybe_execute_substrate_act_after_metabolism, which gates a Firecrawl fetch and a new inline RecallService RPC under config/autonomy/capability_policy.v1.yaml per cycle, trying recall first so a successful recall leaves that cycle's fetch budget unconsumed; degrades to a no-op if recall_bus/recall_source kwargs aren't wired
 
-### Community 720 - "Community 720"
+### Community 723 - "Community 723"
 Cohesion: 0.43
 Nodes (4): is_excluded(), print_failed_logs(), up_all_services.sh script, up_one()
 
-### Community 721 - "Community 721"
+### Community 724 - "Community 724"
 Cohesion: 0.29
 Nodes (7): Channel "orion:dream:compaction-delta" (kind=event, schema=MemoryCompactionDeltaV1) producers=[orion-dream] consumers=[none], Channel "orion:dream:log" (kind=event, schema=DreamResultV1) producers=[orion-cortex-exec] consumers=[orion-sql-writer, orion-dream], Channel "orion:dream:trigger" (kind=event, schema=DreamTriggerPayload) producers=[orion-dream] consumers=[orion-cortex-orch], Schema: DreamResultV1, Schema: DreamTriggerPayload, Schema: MemoryCompactionDeltaV1, Service: orion-dream
 
-### Community 722 - "Community 722"
+### Community 725 - "Community 725"
 Cohesion: 0.29
 Nodes (7): Channel "orion:evidence:index:upsert" (kind=event, schema=EvidenceUnitV1) producers=[orion-sql-writer, *] consumers=[orion-evidence-index, orion-sql-writer, *], Channel "orion:evidence:markdown:ingest" (kind=event, schema=MarkdownSpecIngestV1) producers=[*] consumers=[orion-sql-writer, orion-evidence-index], Channel "orion:evidence:parsed:ingest" (kind=event, schema=ParsedDocumentIngestV1) producers=[*] consumers=[orion-sql-writer, orion-evidence-index], Schema: EvidenceUnitV1, Schema: MarkdownSpecIngestV1, Schema: ParsedDocumentIngestV1, Service: orion-evidence-index
 
-### Community 723 - "Community 723"
+### Community 726 - "Community 726"
 Cohesion: 0.29
 Nodes (7): Channel "orion:graph:compression:events" (kind=event, schema=GraphCompressionRegionMaterializedV1) producers=[orion-graph-compression] consumers=[*], Channel "orion:graph:compression:stale" (kind=event, schema=CompressionStalenessMarkV1) producers=[orion-rdf-writer, orion-graph-compression] consumers=[orion-graph-compression], Channel "orion:substrate:mutation:pressure" (kind=event, schema=MutationPressureEvidenceV1) producers=[orion-graph-compression] consumers=[none], Schema: CompressionStalenessMarkV1, Schema: GraphCompressionRegionMaterializedV1, Schema: MutationPressureEvidenceV1, Service: orion-graph-compression
 
-### Community 724 - "Community 724"
+### Community 727 - "Community 727"
 Cohesion: 0.29
 Nodes (7): orion-rdf-writer (bus → triples → RDF store service), orion-recall (memory retrieval / MemoryBundleV1 fusion service), orion-rdf-writer docker-compose.yml, orion-rdf-writer requirements.txt, orion-recall docker-compose.yml, orion-recall README.md, orion-recall requirements.txt
 
-### Community 725 - "Community 725"
-Cohesion: 0.43
-Nodes (5): GraphDeltaPlanV1, main(), _status(), build_graph_delta(), _escape_rdf_literal()
-
-### Community 726 - "Community 726"
-Cohesion: 0.38
-Nodes (4): _Node, End-to-end: a repeatedly-selected stuck loop must lose the coalition on     the, test_broadcast_history_tracks_selection(), test_rumination_lock_breaks_on_produced_path()
-
-### Community 727 - "Community 727"
+### Community 728 - "Community 728"
 Cohesion: 0.43
 Nodes (5): fail(), _health_curl(), PYTHONPATH, run_pytest(), smoke_memory_cognition_loop_e2e.sh script
 
-### Community 728 - "Community 728"
+### Community 729 - "Community 729"
 Cohesion: 0.33
 Nodes (7): Generated Juniper Feld join description, town_cards.yaml (cast source of truth), Juniper Feld (AI Town human player character card), Orion (AI Town character card), orion-ai-town docker-compose.yml, orion-ai-town README, orion-ai-town service (AI Town mesh wrapper)
-
-### Community 730 - "Community 730"
-Cohesion: 0.43
-Nodes (6): Skip journal PageIndex for compose paths that would self-loop on journal_entry_i, _skip_journal_pageindex_for_automated_trigger(), test_manual_collapse_not_skipped(), test_skips_metacog_digest(), test_skips_notify_summary(), test_skips_scheduler_daily()
 
 ### Community 732 - "Community 732"
 Cohesion: 0.52
@@ -4228,73 +4229,73 @@ Nodes (7): orion-cortex-orch Python Dependencies, orion-dream Docker Compose Ser
 Cohesion: 0.38
 Nodes (4): label_to_claude_model_id(), Map FCC env key labels to stable Claude tier model ids for claude CLI --model., test_label_to_tier_model_ids(), test_unknown_label_raises()
 
-### Community 735 - "Community 735"
-Cohesion: 0.29
-Nodes (4): Hub Skill Runner: exact catalogue prompt -> concrete skill verb (direct exec, no, Guards Hub Skill Runner catalogue against drift from templates/index.html., 23 operator catalogue skills (excludes placeholder, workflows, and free-text row, test_skill_runner_catalogue_entry_count_matches_non_workflow_options()
-
-### Community 737 - "Community 737"
+### Community 736 - "Community 736"
 Cohesion: 0.43
 Nodes (4): _Store, test_inject_session_presence_fills_empty_client_dict_from_store(), test_inject_session_presence_preserves_client_payload(), test_inject_session_presence_uses_store_when_payload_missing()
 
-### Community 738 - "Community 738"
+### Community 737 - "Community 737"
 Cohesion: 0.43
 Nodes (4): _fake_engine_with_frame(), _sample_attention_frame(), test_attention_latest_not_found(), test_attention_latest_returns_frame()
 
-### Community 739 - "Community 739"
+### Community 738 - "Community 738"
 Cohesion: 0.43
 Nodes (4): _fake_engine_with_frame(), _sample_policy_frame(), test_policy_latest_not_found(), test_policy_latest_returns_frame()
 
-### Community 740 - "Community 740"
+### Community 739 - "Community 739"
 Cohesion: 0.43
 Nodes (4): _fake_engine_with_frame(), _sample_proposal_frame(), test_proposals_latest_not_found(), test_proposals_latest_returns_frame()
 
-### Community 741 - "Community 741"
+### Community 740 - "Community 740"
 Cohesion: 0.43
 Nodes (6): MonkeyPatch, Mid-turn send raising WebSocketDisconnect must still cancel (not only poller)., test_cancel_in_flight_turn_agent_claude(), test_cancel_in_flight_turn_orion_publishes(), test_run_awaitable_cancel_on_websocket_disconnect_exception(), test_run_awaitable_cancel_on_ws_disconnect()
 
-### Community 742 - "Community 742"
+### Community 741 - "Community 741"
 Cohesion: 0.33
 Nodes (6): _load_env_key(), RDF_STORE_PASS, RDF_STORE_QUERY_URL, RDF_STORE_UPDATE_URL, RDF_STORE_USER, fuseki_prune_retention.sh script
 
-### Community 743 - "Community 743"
+### Community 742 - "Community 742"
 Cohesion: 0.38
 Nodes (3): _ensure_jena(), _run_tdbcompact(), fuseki_tdb_compact.sh script
 
-### Community 745 - "Community 745"
-Cohesion: 0.57
-Nodes (6): build_state_response(), get_security_state(), get_security_state_root(), Any, set_security_state(), set_security_state_root()
-
-### Community 746 - "Community 746"
+### Community 744 - "Community 744"
 Cohesion: 0.29
 Nodes (3): ``ORGAN_REGISTRY`` integrity (phase-2 causal DAG contract)., DFS from each organ must not revisit nodes on the stack (no cycles)., test_registry_acyclic()
 
-### Community 747 - "Community 747"
+### Community 745 - "Community 745"
+Cohesion: 0.38
+Nodes (6): Part A.4 verification: does `journal_entries` (the raw append-only SQL table, `a, `JournalEntryWriteV1.model_dump()` now includes `trigger_kind`, but     `Journal, Real end-to-end proof: `_write_row` against an in-memory sqlite     `journal_ent, test_journal_entries_table_has_no_trigger_kind_column(), test_write_row_silently_drops_trigger_kind_for_journal_entries_table(), _write_with_trigger_kind()
+
+### Community 746 - "Community 746"
 Cohesion: 0.33
 Nodes (4): client(), _make_row(), Regression test: the ack must actually set attention_acked_at/ack_type/     ack_, test_attention_ack_persists_fields_on_notify_requests_row()
 
-### Community 749 - "Community 749"
+### Community 748 - "Community 748"
 Cohesion: 0.33
 Nodes (3): _load_sql_writer_channel_kinds(), Ensure every subscribed bus kind has a sql-writer persistence path (prevents sil, test_subscribed_catalog_kinds_are_routable_or_explicitly_special()
 
-### Community 750 - "Community 750"
+### Community 749 - "Community 749"
 Cohesion: 0.33
 Nodes (7): vllm-host (docker-compose service, GPU-backed vLLM runtime), orion-vllm-host Python dependencies (pydantic, pydantic-settings, pyyaml), voip-endpoint (docker-compose service, Asterisk/SIP host-networked), orion-voip-endpoint Python dependencies (fastapi, redis, pydantic), whisper-tts (docker-compose service, GPU TTS/STT), Orion Whisper TTS README (TTS/STT bus contracts, Coqui XTTS-v2, Whisper), orion-whisper-tts Python dependencies (TTS, openai-whisper, transformers pin)
 
-### Community 751 - "Community 751"
+### Community 750 - "Community 750"
 Cohesion: 0.38
 Nodes (3): _load_settings_module(), test_tts_settings_xtts_defaults(), test_whisper_tts_timeout_settings_defaults()
 
-### Community 752 - "Community 752"
+### Community 751 - "Community 751"
 Cohesion: 0.43
 Nodes (6): _channel_entry(), Bus catalog coverage for orion-execution-dispatch-runtime as a cortex-exec produ, recall.query.readonly (P4): the autonomy tick issues an inline recall RPC     fr, test_concept_induction_is_recall_service_request_producer(), test_execution_dispatch_runtime_is_action_outcome_producer(), test_execution_dispatch_runtime_is_background_exec_request_producer()
 
-### Community 754 - "Community 754"
+### Community 753 - "Community 753"
 Cohesion: 0.57
 Nodes (6): _import_app_module(), _purge_module(), Path, test_deep_graph_verb_profile_binding(), test_rdf_adapter_builds_neighbor_query(), test_rdf_enabled_for_deep_graph_profile()
 
-### Community 755 - "Community 755"
+### Community 754 - "Community 754"
 Cohesion: 0.33
 Nodes (5): description, $id, $schema, title, type
+
+### Community 755 - "Community 755"
+Cohesion: 0.33
+Nodes (6): description, services, description, items, minItems, type
 
 ### Community 756 - "Community 756"
 Cohesion: 0.33
@@ -4313,48 +4314,48 @@ Cohesion: 0.40
 Nodes (5): BaseModel, Standardized memory fragment returned by Recall service., Request to recall memory from various sources (Vector, SQL, RDF)., RecallRequest, RecallResult
 
 ### Community 760 - "Community 760"
-Cohesion: 0.47
-Nodes (4): build_introspection_context(), Any, test_introspection_parity_for_primary_workflow_metadata(), test_introspection_context_preserves_workflow_identity_and_personality_metadata()
-
-### Community 761 - "Community 761"
 Cohesion: 0.33
 Nodes (6): orion-meta-tags service, orion-notify-digest service, Spark organ (salience, change, concept formation), orion-spark-concept-induction service, orion-spark-introspector service, orion-topic-foundry service
 
-### Community 762 - "Community 762"
+### Community 761 - "Community 761"
 Cohesion: 0.47
 Nodes (4): check_beta_key(), print_env_file(), PYTHONPATH, context_exec_beta_gate.sh script
 
-### Community 764 - "Community 764"
+### Community 763 - "Community 763"
 Cohesion: 0.73
 Nodes (5): _count_triples(), _export_batch(), _import_batch(), main(), _request()
 
-### Community 765 - "Community 765"
+### Community 764 - "Community 764"
 Cohesion: 0.33
 Nodes (5): ACTIONS_DAILY_RUN_ONCE_DATE, NOTIFY_API_TOKEN, NOTIFY_BASE_URL, ORION_BUS_URL, smoke_actions_daily.sh script
 
-### Community 766 - "Community 766"
+### Community 765 - "Community 765"
 Cohesion: 0.53
 Nodes (4): main(), run_fake_mode(), run_real_mode(), smoke_vision_caption_provenance.sh script
 
-### Community 767 - "Community 767"
+### Community 766 - "Community 766"
 Cohesion: 0.53
 Nodes (5): _load_compose(), _parse_env_example(), Guards the fix for the ephemeral-/tmp cursor durability gap.  `services/orion-ac, test_compose_mounts_volume_covering_state_paths(), test_env_example_store_paths_not_under_tmp()
 
-### Community 770 - "Community 770"
+### Community 769 - "Community 769"
 Cohesion: 0.33
 Nodes (6): FieldAttentionFrameV1 (substrate_attention_frames), FieldStateV1 (substrate_field_state), orion-attention-runtime service, orion-field-digester service (referenced upstream writer), orion-notify service (referenced alert sink), orion-athena-sql-db / orion-sql-db (referenced Postgres)
+
+### Community 770 - "Community 770"
+Cohesion: 0.33
+Nodes (4): Config, BaseSettings, Orion Collapse Mirror settings.     No DB or Chroma dependencies — event-driven, Settings
 
 ### Community 771 - "Community 771"
 Cohesion: 0.40
 Nodes (5): health(), latest(), lifespan(), Any, FastAPI
 
 ### Community 772 - "Community 772"
-Cohesion: 0.47
-Nodes (4): filter_world_context_capsule(), Any, test_filter_world_context_capsule_fail_open_missing(), test_filter_world_context_capsule_filters_expired_and_low_confidence()
-
-### Community 773 - "Community 773"
 Cohesion: 0.33
 Nodes (5): ORION_ACTIONS_TAILSCALE_PATH, ORION_CONTAINER_TAILSCALE_BIN, ORION_HOST_TAILSCALE_BIN, ORION_HOST_TAILSCALE_RUN, up-with-tailscale.sh script
+
+### Community 773 - "Community 773"
+Cohesion: 0.60
+Nodes (5): test_idle_wander_does_not_refire_after_non_actuated_outcome(), test_idle_wander_emits_when_idle(), test_idle_wander_off_when_zero(), test_idle_wander_skips_within_window(), _worker()
 
 ### Community 774 - "Community 774"
 Cohesion: 0.33
@@ -4370,19 +4371,23 @@ Nodes (3): Triple, Fetches triples from the substrate graph using bounded SPARQL
 
 ### Community 778 - "Community 778"
 Cohesion: 0.47
-Nodes (5): attention_latest(), _engine(), _load_latest_attention_frame(), Any, Read-only debug API for substrate field attention frames.
+Nodes (5): _engine(), feedback_latest(), _load_latest_feedback_frame(), Any, Read-only debug API for substrate feedback frames.
 
 ### Community 779 - "Community 779"
 Cohesion: 0.53
 Nodes (4): MonkeyPatch, _request(), test_aitown_proxy_disabled_returns_404(), test_aitown_proxy_forwards_path()
 
-### Community 781 - "Community 781"
+### Community 780 - "Community 780"
 Cohesion: 0.67
 Nodes (5): MonkeyPatch, _request(), test_knowledge_forge_alias_routes_forward_expected_paths(), test_knowledge_forge_proxy_requires_base_url(), test_knowledge_forge_proxy_returns_controlled_http_error()
 
-### Community 786 - "Community 786"
+### Community 785 - "Community 785"
 Cohesion: 0.53
 Nodes (4): MonkeyPatch, _request(), test_world_pulse_alias_routes_forward_expected_paths(), test_world_pulse_proxy_returns_controlled_http_error()
+
+### Community 786 - "Community 786"
+Cohesion: 0.53
+Nodes (5): EmbeddingsBody, ExecStepPayload, ExecutionEnvelope, GenerateBody, BaseModel
 
 ### Community 787 - "Community 787"
 Cohesion: 0.73
@@ -4400,17 +4405,21 @@ Nodes (5): health(), latest(), lifespan(), Any, FastAPI
 Cohesion: 0.40
 Nodes (5): health(), latest(), lifespan(), Any, FastAPI
 
+### Community 791 - "Community 791"
+Cohesion: 0.47
+Nodes (5): _compression_profile(), When both RDF and compression are enabled, both produce candidates., test_compression_backend_called_when_enabled(), test_compression_backend_does_not_suppress_rdf_backend(), test_compression_backend_returns_empty_when_disabled()
+
 ### Community 793 - "Community 793"
 Cohesion: 0.33
 Nodes (4): Config, BaseSettings, Helper to parse the subscription channels from env var., Settings
 
 ### Community 794 - "Community 794"
-Cohesion: 0.40
-Nodes (3): _active_doc_text(), Assert context-exec proposal ledger smoke scripts use durable storage defaults., test_proposal_review_doc_active_examples_use_durable_storage()
+Cohesion: 0.60
+Nodes (5): _source(), test_html_adapter_filters_to_allowed_domains_and_paths(), test_manual_adapter_enforces_domains(), test_rss_adapter_parses_fixture(), test_sitemap_adapter_bounds_child_sitemaps()
 
 ### Community 795 - "Community 795"
-Cohesion: 0.33
-Nodes (3): seed-v2 keeps encoder input dims stable when HTTP traj is dark., test_execution_trajectory_stale_runs_excluded(), test_seed_v2_emits_cognitive_slots_when_trajectory_absent()
+Cohesion: 0.40
+Nodes (3): _active_doc_text(), Assert context-exec proposal ledger smoke scripts use durable storage defaults., test_proposal_review_doc_active_examples_use_durable_storage()
 
 ### Community 796 - "Community 796"
 Cohesion: 0.47
@@ -4452,49 +4461,45 @@ Nodes (5): Self Concept Induce, Self Concept Reflect, Recall Profile: self.factu
 Cohesion: 0.50
 Nodes (5): Chat Discussion Window Journaling Workflow, Journal Dispatch Registry (trigger_kind -> policy, fail-closed), Orion Journaler Service Boundaries and Semantics, JournalEntryWriteV1.trigger_kind Propagation, chat.continuity.v1 Recall Profile (Recent sql_chat Only)
 
-### Community 807 - "Community 807"
+### Community 808 - "Community 808"
 Cohesion: 0.40
 Nodes (5): orion-security-watcher (Guard: vision presence/alert debounce service), orion-security-watcher index.html template, orion-security-watcher docker-compose.yml, orion-security-watcher README.md, orion-security-watcher requirements.txt
 
-### Community 808 - "Community 808"
+### Community 809 - "Community 809"
 Cohesion: 0.40
 Nodes (5): Rationale: concept_induction_pass stayed a bounded reader; missing runtime behavior was autonomous triggering, ConceptInductionTrigger contract (source_kind, subjects, trigger_reason, ...), Bounded trigger loop in ConceptWorker.handle_envelope(), Graph mapping shape (SparkConceptProfile/Subject/Concept/Cluster/StateEstimate RDF nodes), Rationale: graph write additive/isolated, LocalProfileStore stays source of truth
 
-### Community 809 - "Community 809"
+### Community 810 - "Community 810"
 Cohesion: 0.70
 Nodes (4): _ensure_sys_path_stdlib_safe(), main(), Path, _repo_root()
 
-### Community 811 - "Community 811"
+### Community 812 - "Community 812"
 Cohesion: 0.60
 Nodes (3): fail(), pass(), smoke_active_verbs.sh script
 
-### Community 812 - "Community 812"
+### Community 813 - "Community 813"
 Cohesion: 0.60
 Nodes (4): _headers(), main(), _print_step(), Any
 
-### Community 813 - "Community 813"
+### Community 814 - "Community 814"
 Cohesion: 0.70
 Nodes (3): fail(), need_cmd(), verify-bound-capability-live.sh script
 
-### Community 814 - "Community 814"
+### Community 815 - "Community 815"
 Cohesion: 0.40
 Nodes (3): Config, BaseSettings, Settings
 
-### Community 815 - "Community 815"
+### Community 816 - "Community 816"
 Cohesion: 0.60
 Nodes (4): ensure_orion_cortex_exec_app(), _purge_app_tree(), Side-effect: put ``services/orion-cortex-exec`` first and drop a foreign ``app``, _strip_other_service_paths()
 
-### Community 816 - "Community 816"
+### Community 817 - "Community 817"
 Cohesion: 0.70
 Nodes (4): _load_executor_module(), test_metacog_trigger_lineage_chat_turn_overrides_trigger_kind(), test_metacog_trigger_lineage_passes_baseline_from_trigger_payload(), test_metacog_trigger_lineage_passes_dense_from_trigger_payload()
 
-### Community 818 - "Community 818"
+### Community 819 - "Community 819"
 Cohesion: 0.80
 Nodes (4): _base_ctx(), _render(), test_prompts_render_with_situation_fragment_scenarios(), test_prompts_render_without_situation_fragment()
-
-### Community 819 - "Community 819"
-Cohesion: 0.60
-Nodes (4): client(), TestClient, test_ready_200_when_consumer_ready(), test_ready_503_when_intake_bus_not_connected()
 
 ### Community 820 - "Community 820"
 Cohesion: 0.60
@@ -4532,195 +4537,199 @@ Nodes (4): orion-memory-consolidation ships only asyncpg; the crystallization   
 Cohesion: 0.60
 Nodes (4): ensure_orion_mind_app(), _purge_app_tree(), Side-effect: put ``services/orion-mind`` first and drop a foreign ``app`` packag, _strip_other_service_paths()
 
-### Community 838 - "Community 838"
+### Community 837 - "Community 837"
 Cohesion: 0.60
 Nodes (4): Post-fetch SQL chat windowing drops stale sql_timeline/sql_chat rows., _run_window(), test_sql_windowing_drops_out_of_window_uuid_rows(), test_sql_windowing_keeps_recent_rows_with_real_ts_when_id_not_uuid()
 
-### Community 839 - "Community 839"
+### Community 838 - "Community 838"
 Cohesion: 0.70
 Nodes (4): _fake_process(), _sign(), test_webhook_accepts_valid_hmac_when_secret_configured(), test_webhook_rejects_invalid_hmac_when_secret_configured()
 
 ### Community 840 - "Community 840"
-Cohesion: 0.60
-Nodes (4): _drive_state_ready(), Regression: world-pulse curiosity-followup reuse wiring in bus_worker.  Covers t, test_curiosity_followup_reused_skips_live_fetch(), _world_pulse_envelope_with_followup()
-
-### Community 842 - "Community 842"
 Cohesion: 0.40
 Nodes (5): orion-sql-writer docker-compose.yml, orion-sql-writer README, action.outcome.emit.v1 persistence (action_outcomes table, idempotent upsert on action_id), orion-sql-writer requirements.txt, orion-sql-writer: durable bus-to-Postgres persistence consumer
 
-### Community 844 - "Community 844"
-Cohesion: 0.50
-Nodes (4): _emitted_at(), datetime, Return an aware UTC emitted_at so naive/aware comparisons never crash., Materialize the window ending at ``now``. Never raises.
-
-### Community 845 - "Community 845"
+### Community 842 - "Community 842"
 Cohesion: 0.60
 Nodes (4): _ensure_thought_paths(), pytest_configure(), Ensure orion-thought ``app`` resolves to this service during tests., _thought_service_isolation()
 
-### Community 846 - "Community 846"
+### Community 843 - "Community 843"
 Cohesion: 0.70
 Nodes (4): _render(), test_block_absent_without_coloring(), test_block_does_not_introduce_output_keys(), test_block_present_with_coloring()
 
-### Community 847 - "Community 847"
+### Community 844 - "Community 844"
 Cohesion: 0.50
 Nodes (4): _heuristic_gate_score(), Bounded lightweight score used by tests and fallback heuristics., test_heuristic_gate_score_bounds(), test_heuristic_gate_score_prefers_longer_text()
 
-### Community 848 - "Community 848"
+### Community 845 - "Community 845"
+Cohesion: 0.70
+Nodes (4): _load_profiles(), test_caption_frame_routes_to_vlm_caption(), test_vlm_caption_kind_is_caption_frame(), test_vlm_vqa_untouched()
+
+### Community 846 - "Community 846"
 Cohesion: 0.60
 Nodes (4): _load_real_registry(), Thin regression guard, not a topic classifier.      Asserts that none of the sou, test_nasa_news_is_not_tagged_hardware_compute_gpu(), test_no_known_off_topic_source_tagged_hardware_compute_gpu()
 
-### Community 849 - "Community 849"
+### Community 847 - "Community 847"
 Cohesion: 0.70
 Nodes (4): _run_node(), test_agent_trace_helpers_gate_group_and_timeline(), test_agent_trace_helpers_gate_message_level_debug_sections(), test_live_agent_step_anchors_to_conversation_not_body()
 
-### Community 851 - "Community 851"
+### Community 850 - "Community 850"
 Cohesion: 0.60
 Nodes (4): _import_top_levels(), Memory-graph core stays deterministic: no LLM vendor SDKs or bus client imports., test_json_extract_has_no_nonstdlib_imports(), test_memory_graph_core_modules_have_no_llm_vendor_or_bus_imports()
 
-### Community 853 - "Community 853"
+### Community 852 - "Community 852"
 Cohesion: 0.60
 Nodes (3): AST, test_retina_has_no_detector_imports(), _walk_imports()
 
-### Community 854 - "Community 854"
+### Community 853 - "Community 853"
 Cohesion: 0.60
 Nodes (4): main(), Quick (fast) only: send probe1, wait for reply, immediately send probe2, wait ag, _run_fast_two_turns(), _run_one()
 
+### Community 854 - "Community 854"
+Cohesion: 0.50
+Nodes (4): Collapse Mirror split invariant (Strict/Juniper vs Metacog/Orion; rationale: metacog mirrors must never hit Juniper's triage/enrichment pipeline by default), Metacog/Spark Surgical Patch Tracker, Oríon identity + response-policy profile, actions.respond_to_juniper_collapse_mirror.v1 verb
+
 ### Community 855 - "Community 855"
 Cohesion: 0.50
-Nodes (4): description, minimum, type, max_recursion_depth
+Nodes (4): description, minimum, type, order
 
 ### Community 856 - "Community 856"
 Cohesion: 0.50
-Nodes (4): safety_rules, description, items, type
+Nodes (4): description, minItems, type, plan
 
 ### Community 857 - "Community 857"
-Cohesion: 0.67
-Nodes (4): Evaluate, Fact Extraction, Goal Formulation, Memory graph suggest (brain draft JSON)
+Cohesion: 0.50
+Nodes (4): timeout_ms, description, minimum, type
 
 ### Community 858 - "Community 858"
 Cohesion: 0.67
-Nodes (4): Source Delta Review: smoke-003, POST /v1/ideation/run API (proposal-only Claude-backed review), Knowledge Forge Ideation Review v1 spec (markdown), spec:knowledge-forge-ideation-review-v1 (YAML contract)
+Nodes (4): Evaluate, Fact Extraction, Goal Formulation, Memory graph suggest (brain draft JSON)
 
 ### Community 859 - "Community 859"
+Cohesion: 0.67
+Nodes (4): Source Delta Review: smoke-003, POST /v1/ideation/run API (proposal-only Claude-backed review), Knowledge Forge Ideation Review v1 spec (markdown), spec:knowledge-forge-ideation-review-v1 (YAML contract)
+
+### Community 860 - "Community 860"
 Cohesion: 0.83
 Nodes (3): attach_llm_uncertainty_to_collapse_payload(), test_attach_llm_uncertainty_noop_when_missing(), test_attach_llm_uncertainty_preserves_existing_telemetry()
 
-### Community 860 - "Community 860"
+### Community 861 - "Community 861"
 Cohesion: 0.50
 Nodes (3): BaseModel, Standard request to write data to the SQL database., SqlWriteRequest
 
-### Community 861 - "Community 861"
+### Community 862 - "Community 862"
 Cohesion: 0.50
 Nodes (4): orion-self-experiments (typed self-experiment registry + context-exec dispatcher), orion-self-experiments docker-compose.yml, orion-self-experiments README.md, orion-self-experiments requirements.txt
 
-### Community 862 - "Community 862"
+### Community 863 - "Community 863"
 Cohesion: 0.67
 Nodes (3): main(), parse_args(), Namespace
 
-### Community 863 - "Community 863"
+### Community 864 - "Community 864"
 Cohesion: 0.50
 Nodes (3): puppeteer, dependencies, puppeteer
 
-### Community 864 - "Community 864"
+### Community 865 - "Community 865"
 Cohesion: 0.83
 Nodes (3): main(), _max_profile_ctx_size(), _read_env_int()
 
-### Community 866 - "Community 866"
+### Community 867 - "Community 867"
 Cohesion: 0.83
 Nodes (3): check_truth(), grammar_production_truth.sh script, validate_truth_json()
 
-### Community 867 - "Community 867"
+### Community 868 - "Community 868"
 Cohesion: 0.50
 Nodes (3): ORION_KNOWLEDGE_ROOT, PYTHONPATH, orion-knowledge-forge.sh script
 
-### Community 868 - "Community 868"
+### Community 869 - "Community 869"
 Cohesion: 0.83
 Nodes (3): _ensure_test_runtime_deps(), _has_import(), main()
 
-### Community 869 - "Community 869"
+### Community 870 - "Community 870"
 Cohesion: 0.83
 Nodes (3): fail(), pass(), smoke_council_debug.sh script
 
-### Community 873 - "Community 873"
+### Community 874 - "Community 874"
 Cohesion: 0.83
 Nodes (3): _ensure_platform_system(), _load_executor_module(), main()
 
-### Community 874 - "Community 874"
+### Community 875 - "Community 875"
 Cohesion: 0.83
 Nodes (3): psql_run(), smoke_orion_bus_transport_full_stack.sh script, usage()
 
-### Community 875 - "Community 875"
+### Community 876 - "Community 876"
 Cohesion: 0.83
 Nodes (3): _ensure_platform_system(), _load_module(), main()
 
-### Community 876 - "Community 876"
+### Community 877 - "Community 877"
 Cohesion: 0.83
 Nodes (3): require_jq(), run_train(), smoke_topic_foundry_bertopic.sh script
 
-### Community 877 - "Community 877"
+### Community 878 - "Community 878"
 Cohesion: 0.83
 Nodes (3): curl_api(), require_cmd(), smoke_topic_foundry_remote.sh script
 
-### Community 882 - "Community 882"
+### Community 883 - "Community 883"
 Cohesion: 0.67
 Nodes (3): _dream_service_isolation(), _ensure_dream_paths(), Ensure orion-dream ``app`` resolves to this service during evals.
 
-### Community 883 - "Community 883"
+### Community 884 - "Community 884"
 Cohesion: 0.67
 Nodes (3): _dream_service_isolation(), _ensure_dream_paths(), Ensure orion-dream ``app`` resolves to this service during tests.
 
-### Community 884 - "Community 884"
+### Community 885 - "Community 885"
 Cohesion: 0.67
 Nodes (3): _load_embodiment_settings(), Regression: town speech must not default to legacy cortex intake., test_speech_defaults_use_chat_lane_and_skip_unified()
 
-### Community 885 - "Community 885"
+### Community 886 - "Community 886"
 Cohesion: 0.50
 Nodes (3): FCC_OPEN_BROWSER, LOG_FILE, entrypoint.sh script
 
-### Community 886 - "Community 886"
+### Community 887 - "Community 887"
 Cohesion: 0.67
 Nodes (3): get_settings(), BaseSettings, Settings
 
-### Community 887 - "Community 887"
+### Community 888 - "Community 888"
 Cohesion: 0.83
 Nodes (3): _make_region(), test_writer_builds_sparql_update_targeting_compressions_graph(), test_writer_includes_summary_literal()
 
-### Community 888 - "Community 888"
+### Community 889 - "Community 889"
 Cohesion: 0.50
 Nodes (3): Config, BaseSettings, Settings
-
-### Community 889 - "Community 889"
-Cohesion: 0.67
-Nodes (3): _ensure_governor_paths(), _governor_service_isolation(), Ensure orion-harness-governor ``app`` resolves to this service during tests.
 
 ### Community 890 - "Community 890"
 Cohesion: 0.67
-Nodes (3): main(), Live smoke: Hub agent-claude WS streams claude_step + final llm_response.  Usage, run()
+Nodes (3): _ensure_governor_paths(), _governor_service_isolation(), Ensure orion-harness-governor ``app`` resolves to this service during tests.
 
 ### Community 891 - "Community 891"
 Cohesion: 0.67
-Nodes (3): main(), Gate 2 live proof: drive the Hub chat WS in agent mode and assert live step fram, run()
+Nodes (3): main(), Live smoke: Hub agent-claude WS streams claude_step + final llm_response.  Usage, run()
 
 ### Community 892 - "Community 892"
+Cohesion: 0.67
+Nodes (3): main(), Gate 2 live proof: drive the Hub chat WS in agent mode and assert live step fram, run()
+
+### Community 893 - "Community 893"
 Cohesion: 0.83
 Nodes (3): activatePanel(), deactivatePanel(), styleTabButton()
 
-### Community 898 - "Community 898"
+### Community 899 - "Community 899"
 Cohesion: 0.83
 Nodes (3): run_infer(), run_server_boot(), validate_llamacpp_upgrade.sh script
 
-### Community 899 - "Community 899"
+### Community 900 - "Community 900"
 Cohesion: 0.50
 Nodes (3): Config, BaseSettings, Settings
 
-### Community 900 - "Community 900"
+### Community 901 - "Community 901"
 Cohesion: 0.50
 Nodes (4): orion-policy-runtime docker-compose (port 8120, SUBSTRATE_POLICY_PATH, POLICY_POLL_INTERVAL_SEC), orion-policy-runtime: Layer 8 substrate service evaluating ProposalFrameV1 against SubstratePolicyV1, persists PolicyDecisionFrameV1 (policy is not execution), substrate_policy_decision_frames table (PolicyDecisionFrameV1 records), orion-policy-runtime dependencies (fastapi, sqlalchemy, psycopg2-binary, PyYAML)
 
-### Community 901 - "Community 901"
+### Community 902 - "Community 902"
 Cohesion: 0.83
 Nodes (3): fail(), pass(), smoke.sh script
 
-### Community 902 - "Community 902"
+### Community 903 - "Community 903"
 Cohesion: 0.67
 Nodes (3): main(), Eval: honest inner-state headline is responsive and never floored.  Run: python, _raw()
 
@@ -4772,87 +4781,83 @@ Nodes (3): Mesh Node: prometheus (observability), Capability: memory, Topology N
 Cohesion: 0.67
 Nodes (3): orion-sql-writer-tests CI workflow, Memory-graph / SHACL validation dependency (rdflib+pyshacl), requirements-dev.txt (repo-wide dev/test deps)
 
-### Community 923 - "Community 923"
-Cohesion: 0.67
-Nodes (3): Channel "orion:feedback:frame" (kind=event, schema=FeedbackFrameV1) producers=[orion-feedback-runtime] consumers=[orion-spark-concept-induction], Schema: FeedbackFrameV1, Service: orion-feedback-runtime
-
-### Community 925 - "Community 925"
+### Community 924 - "Community 924"
 Cohesion: 0.67
 Nodes (3): description, type, description
 
-### Community 926 - "Community 926"
+### Community 925 - "Community 925"
 Cohesion: 0.67
 Nodes (3): description, type, name
 
-### Community 927 - "Community 927"
+### Community 926 - "Community 926"
 Cohesion: 0.67
 Nodes (3): description, type, prompt_template
 
-### Community 928 - "Community 928"
+### Community 927 - "Community 927"
 Cohesion: 0.67
 Nodes (3): Assess Mesh Presence, Assess Runtime State, Assess Storage Health
 
-### Community 929 - "Community 929"
+### Community 928 - "Community 928"
 Cohesion: 0.67
 Nodes (3): Dream Cycle, Dream Preprocess, Dream Simple
 
-### Community 930 - "Community 930"
+### Community 929 - "Community 929"
 Cohesion: 1.00
 Nodes (3): Finalize Response, Generate Code Scaffold, GitHub Compactor Digest
 
-### Community 932 - "Community 932"
+### Community 931 - "Community 931"
 Cohesion: 0.67
 Nodes (3): spec:substrate-tier-telemetry-v1, Substrate Tier Telemetry (wiki concept page), Forge Log
 
-### Community 933 - "Community 933"
+### Community 932 - "Community 932"
 Cohesion: 0.67
 Nodes (3): assist.light.v1 Recall Profile (Latency Lane, No Vector), chat.general.v1 Recall Profile (UX Continuity / Lightweight), Orion Recall Profiles Overview (Multi-Backend Ensemble Policy)
 
-### Community 934 - "Community 934"
+### Community 933 - "Community 933"
 Cohesion: 0.67
 Nodes (3): graph.compressions.global.v1 recall profile, graph.compressions.local.v1 recall profile, graph.compressions.v1 recall profile (unified)
 
-### Community 936 - "Community 936"
+### Community 935 - "Community 935"
 Cohesion: 1.00
 Nodes (3): Autonomous Event-Driven Concept Induction Trigger Loop note, Phase 1: Spark ConceptProfile Graph Materialization note, orion/spark README
 
-### Community 953 - "Community 953"
+### Community 952 - "Community 952"
 Cohesion: 0.67
 Nodes (3): NarrativeUngrounded, Exception, Raised when the LLM's reply is malformed, cites nothing real, or cites     a fac
 
-### Community 989 - "Community 989"
+### Community 988 - "Community 988"
 Cohesion: 0.67
 Nodes (3): orion-fcc Docker Compose Service, orion-fcc Service (Anthropic-compatible FCC proxy), orion-fcc Python Dependencies (free-claude-code)
 
-### Community 990 - "Community 990"
+### Community 989 - "Community 989"
 Cohesion: 0.67
 Nodes (3): orion-feedback-runtime Docker Compose Service, orion-feedback-runtime Service (Layer 10), orion-feedback-runtime Python Dependencies
 
-### Community 1000 - "Community 1000"
+### Community 999 - "Community 999"
 Cohesion: 0.67
 Nodes (3): Orion Knowledge Forge service contract (CLAUDE.md), orion-knowledge-forge Docker Compose, orion-knowledge-forge Python dependencies
 
-### Community 1001 - "Community 1001"
+### Community 1000 - "Community 1000"
 Cohesion: 0.67
 Nodes (3): orion-meta-tags docker compose deployment (bus enabled, triage/tagged channels, health check, startup delay), orion-meta-tags: LLM-based enrichment of collapse events (entities, sentiment, tags) via orion:collapse:triage -> orion:tags:enriched, orion-meta-tags Python dependencies (fastapi, spacy, sentence-transformers, pydantic, redis)
 
-### Community 1003 - "Community 1003"
+### Community 1002 - "Community 1002"
 Cohesion: 0.67
 Nodes (3): orion-notify policy rules (quiet hours, recipient groups, event-kind/severity routing, throttling), orion-notify service (notification policy owner), orion-notify-digest dependencies (fastapi, uvicorn, pydantic, SQLAlchemy, requests, redis, loguru)
 
-### Community 1004 - "Community 1004"
+### Community 1003 - "Community 1003"
 Cohesion: 0.67
 Nodes (3): orion-rdf-store docker-compose (orion-athena-fuseki container, port 3030, JVM_ARGS, FUSEKI_DATA_DIR bind mount), orion-rdf-store: operator/deployment stack for Orion's primary RDF datastore (Apache Jena Fuseki); not a Python service, no app/settings.py/requirements.txt, orion-rdf-writer: constructs the Knowledge Graph by converting incoming bus events into RDF triples via RdfStoreClient (graphdb/fuseki/generic/rdf4j backends)
 
-### Community 1014 - "Community 1014"
+### Community 1013 - "Community 1013"
 Cohesion: 0.67
 Nodes (3): Golden phi + node attribution (trained encoder overrides phi_now coherence/energy/novelty), Spark train/evals README (offline phi-encoder health reports), eval_phi_encoder_health.py (recon/residual-after-headline-fit collapse gate)
 
-### Community 1021 - "Community 1021"
+### Community 1020 - "Community 1020"
 Cohesion: 0.67
 Nodes (3): orion-world-pulse (docker-compose service, Firecrawl-backed curiosity fetch), orion-world-pulse Python dependencies (fastapi, requests, redis, pytest), sample_section.html test fixture (HTML link extraction, internal vs external hrefs)
 
-### Community 1022 - "Community 1022"
+### Community 1021 - "Community 1021"
 Cohesion: 0.67
 Nodes (3): claim:test:bad-ref (disputed claim fixture with dangling references), claim:does:not:exist (dangling depends_on reference, no fixture defines it), source:missing:0001 (dangling source_refs reference, no fixture defines it)
 


### PR DESCRIPTION
## Summary

- Documents `graphify prs --worktrees`/`--conflicts` and the `save-result`/`reflect` work-memory pattern in `CLAUDE.md`, alongside the `graphify claude install` output (CLAUDE.md section + `.claude/settings.json` PreToolUse nudge hooks) that ran unintentionally earlier this session -- reviewed the hook-guard source directly (always fails open, additionalContext only, never blocks), kept and committed properly since the resulting shape matched what the actual design goal was.
- MCP server mode explicitly considered and NOT adopted -- flagged in-doc so it isn't silently re-proposed. Persistent per-session tool-schema context cost wasn't worth it over the nudge approach already running.
- Merges the live `conjourney` Postgres schema (179 tables, verified via direct `psql` query first) into the *same* `graph.json` as the code/docs graph -- not a separate one -- so `query`/`path`/`explain` can trace from code straight through to the tables it reads/writes.

## Why merged, not a separate graph

Discussed directly: the value of doing this at all is the code-to-table tracing, which only works if it's one graph.

## Notable

- `graphify extract --postgres` runs a *full* corpus re-extraction by default (would have re-triggered the whole AST+semantic pipeline on 4000+ files just to add 180 nodes). Called `introspect_postgres()` directly and merged the fragment via `build_merge` instead -- same incremental pattern used twice already this session for `--update` runs.
- Two missing optional dependencies (`psycopg`, `tree_sitter_sql`) had to be installed into graphify's own tool environment. The second one fails *silently* (0 nodes, 0 edges, no error) rather than raising -- worth knowing if this ever needs to be re-run somewhere fresh.
- All 180 new nodes landed in one Louvain community that had inherited a stale label from a previous community reshuffle -- relabeled to match its actual contents rather than left wrong.

## Test plan

- [x] Raw Postgres query verified directly (179 tables) before touching graphify at all
- [x] Introspection re-verified after installing missing deps (180 nodes, 183 edges -- matches table count)
- [x] Graph health check clean after merge (no dangling/missing endpoints, no self-loops)
- [x] Mislabeled community caught by direct node-overlap check, not assumed, and fixed

Final graph: 31,566 nodes (+180), 93,689 edges (+183), 1,418 communities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)