### PR TITLE
feat: block destructive git commands in the shared checkout via PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,10 @@
           {
             "type": "command",
             "command": "/home/athena/.local/bin/graphify hook-guard search"
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/destructive_git_guard.py\""
           }
         ]
       },

--- a/docs/superpowers/pr-reports/2026-07-14-destructive-git-guard-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-destructive-git-guard-pr.md
@@ -1,0 +1,117 @@
+# PR report: block destructive git commands in the shared checkout via PreToolUse hook
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1041
+Branch: `feat/destructive-git-op-guard`
+
+## Summary
+
+- Adds `scripts/hooks/destructive_git_guard.py`, a Claude Code `PreToolUse` hook that blocks `git clean -f*`, `git reset --hard`, and `git checkout`/`git switch --force` from running against the shared/primary checkout of this repo.
+- Wires it into `.claude/settings.json` alongside the existing `graphify hook-guard search` entry (same "Bash" matcher).
+- Reuses the same git-dir/git-common-dir shared-checkout detection as `scripts/git_hooks/pre-commit` and `scripts/safe_docker_build.sh`; both got a comment update pointing at this third implementation.
+- 57 tests in `tests/scripts/test_destructive_git_guard.py`, including a regression test for every bug found in review.
+
+## Outcome moved
+
+`git clean -fd`/`git reset --hard` destroy uncommitted files *before* any commit happens, so the existing `pre-commit` hook (which only gates `git commit`) can't help — the damage is already done. This closes that specific gap: it's the same incident class that already happened once this session (a concurrent session's presumed `git clean -fd` wiped `graphify-out/` extras and a spec doc from the shared checkout mid-session, discovered via reflog/timestamp investigation, not caused by this work).
+
+## Current architecture
+
+Before this PR: `scripts/git_hooks/pre-commit` blocked commits from the shared checkout; `scripts/safe_docker_build.sh` was a convention-based wrapper for `docker compose`. Neither covers destructive git operations that never reach a commit.
+
+## Architecture touched
+
+- `.claude/settings.json` — new PreToolUse hook entry.
+- `scripts/hooks/destructive_git_guard.py` — new.
+- `scripts/git_hooks/pre-commit`, `scripts/safe_docker_build.sh` — comment-only, point at the new third implementation of the shared-detection logic.
+- `tests/scripts/test_destructive_git_guard.py` — new.
+
+## Files changed
+
+- `scripts/hooks/destructive_git_guard.py`: new PreToolUse hook script.
+- `.claude/settings.json`: wires the hook into the existing "Bash" matcher.
+- `tests/scripts/test_destructive_git_guard.py`: 57 tests, including a named regression test per confirmed review finding.
+- `scripts/git_hooks/pre-commit`, `scripts/safe_docker_build.sh`: comment updates only (cross-reference the third detection implementation).
+
+## Schema / bus / API changes
+
+None. Pure tooling, no bus/schema/env surface touched.
+
+## Env/config changes
+
+None. No `.env_example` changes; nothing to sync.
+
+## Tests run
+
+```
+/mnt/scripts/Orion-Sapienform/orion_dev/bin/pytest tests/scripts/test_destructive_git_guard.py -q
+57 passed in 1.53s
+```
+
+Note: `pyproject.toml`'s `norecursedirs = ["scripts", ...]` matches directory *basename*, so it also silently excludes `tests/scripts/` from bare `pytest`/`pytest tests -q` discovery (confirmed via `--collect-only`: 0 matches under default testpaths, full collection with the explicit path). This is a **pre-existing, repo-wide gap** — two sibling files (`test_orion_proposal_cli.py`, `test_sync_local_env_from_example.py`) already live there and are always invoked by explicit path in prior PR reports, never bare `pytest`. Flagging as a follow-up, not fixing in this PR since it would affect unrelated test suites.
+
+## Evals run
+
+None. This is a Claude Code hook script, not a `services/<name>` component with its own eval harness — no existing eval harness applies. The 57 tests include full end-to-end coverage (real subprocess over stdin/stdout, real git repos with actual worktrees, no mocks).
+
+## Docker/build/smoke checks
+
+Not applicable — no runtime/service/Docker surface touched.
+
+## Live verification (not just tests)
+
+Two live end-to-end tests were run with explicit Juniper approval via AskUserQuestion (the command itself, `git reset --hard HEAD`, is a genuine no-op against an unmoved HEAD in a clean tree, but AGENTS.md requires explicit approval for it regardless):
+
+1. Temporarily wired the hook into the live shared checkout's `.claude/settings.json`, dispatched a fresh subagent to run `git reset --hard HEAD` there. **Blocked** — the subagent received the exact `permissionDecisionReason` the hook emits, the command never executed, confirmed via `git status` before/after. Wiring reverted after the test.
+2. Confirmed `$CLAUDE_PROJECT_DIR` (used in the committed hook command so it works from any clone/machine) resolves correctly at hook-invocation time, via a non-destructive diagnostic hook writing to a log file — `/mnt/scripts/Orion-Sapienform` in all three firings, including from a dispatched subagent.
+
+A third test (compound command tripping both the graphify hook and this one simultaneously, to confirm the deny still wins) was attempted but the dispatched subagent correctly declined to run a `git reset --hard` on a relayed "the user already approved this" claim from the orchestrating session, since agent-relayed approval isn't verifiable consent. That refusal is correct behavior, not a bug — this specific residual question (does Claude Code's harness honor a deny from the second of two hooks under one matcher when both produce output) is therefore **UNVERIFIED**, left as a documented low-severity gap rather than pushed further through relay.
+
+## Review findings fixed
+
+Ran the `code-review` skill at high effort (8 parallel finder angles, live-reproduced where possible). 10 findings reported, all fixed via a full rewrite of the core detection logic (the bugs shared one root cause: parsing the whole command string instead of walking statements in order while tracking directory state):
+
+- **Finding**: Escape hatch searched the entire command string unscoped/unanchored — matched inside a shell comment (`# ORION_ALLOW_SHARED_CHECKOUT_WRITE=1`, never actually sets the env var) or an unrelated later statement, silently authorizing a real destructive command.
+  - **Fix**: `_escape_hatch_set` now only matches a genuine leading env-assignment prefix on the *same* statement as the destructive command.
+  - **Evidence**: `test_evaluate_escape_hatch_scoped_to_its_own_statement`, `test_escape_hatch_trailing_is_not_a_bypass`.
+- **Finding**: `_resolve_target_dir` only handled a single leading `cd`; `echo x && cd ../shared && git reset --hard` (an ordinary two-hop chain) bypassed directory resolution entirely.
+  - **Fix**: `_evaluate` now walks statements left-to-right tracking a running current directory across every `cd` statement.
+  - **Evidence**: `test_evaluate_multi_hop_cd_bug`, `test_evaluate_sequential_cd_statements`.
+- **Finding**: `git reset --hard` regex used `.*` without `re.DOTALL`, so a bash line-continuation (`git reset \` + newline + `--hard`) evaded detection.
+  - **Fix**: added `re.DOTALL` to `_GIT_RESET_HARD`.
+  - **Evidence**: `test_evaluate_line_continuation_reset_hard`.
+- **Finding**: `-C <dir>`/`cd` extraction scanned the whole raw string unanchored, so decoy text in an earlier statement (e.g. inside an echoed string) could hijack directory resolution.
+  - **Fix**: extraction now scoped per-statement, using quote-stripped text for pattern matching and the original text (aligned by offset) for real path values.
+  - **Evidence**: `test_evaluate_decoy_dash_c_in_earlier_statement_no_longer_hijacks`.
+- **Finding**: Detection was quoting-unaware — a commit message merely mentioning "git reset --hard" as text was misidentified as the command itself.
+  - **Fix**: added `_strip_quoted`, applied before statement-splitting and pattern matching.
+  - **Evidence**: `test_evaluate_quoted_mention_is_not_a_false_positive`.
+- **Finding**: `_is_shared_checkout` used `os.path.realpath` (resolves symlinks) while the two existing shell hooks use logical `cd && pwd` (does not) — the "mirrored" implementations weren't actually equivalent for symlinked paths.
+  - **Fix**: switched to `os.path.normpath`, matching logical-pwd semantics.
+- **Finding**: `git checkout -f`/`git switch -f` (equally destroy uncommitted tracked-file changes) weren't detected, and unlike `push --force`/`branch -D` (explicitly commented as out-of-scope), this wasn't documented as intentional.
+  - **Fix**: added detection for both; documented `switch -C`/`checkout -B` (force-create-branch variants) as a remaining, disclosed gap.
+  - **Evidence**: `test_evaluate_checkout_force_blocked`, `test_evaluate_switch_force_blocked`.
+- **Finding**: `_is_shared_checkout`'s fail-open behavior on git-subprocess error/timeout wasn't listed in the module's own "Known gaps" docstring.
+  - **Fix**: documented explicitly.
+- **Finding**: `tests/scripts/` silently excluded from bare `pytest` via `norecursedirs` basename matching.
+  - **Fix**: not fixed in this PR (pre-existing, repo-wide, affects unrelated suites) — documented above under Tests run, PR report uses the explicit path.
+- **Finding** (architecture-contradiction, most serious): a same-day prior PR report (`docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md`) explicitly evaluated and *rejected* "PreToolUse hook as enforcement," quoting Juniper directly ("I don't want to be beholden to developing with a paid subscription"), scoping PreToolUse hooks to disclosure-only and calling a vendor-neutral git-level wrapper the real, not-yet-built enforcement layer. This PR ships `permissionDecision: deny` — real enforcement — reversing that without initially reconciling it.
+  - **Resolution**: surfaced directly to Juniper before proceeding (not fixed silently). Decision: keep this as real enforcement now; the vendor-neutral wrapper is deferred, not abandoned — next up once agent worktree-discipline noncompliance (why agents end up in the shared checkout at all) is addressed directly. Documented in the module docstring's "Deliberately scoped to Claude Code" section and in this PR report so the tradeoff is visible, not silent.
+
+Two additional review angles (efficiency, simplification) suggested minor perf/style nits (precompile regexes, merge two `git rev-parse` calls into one) — the rewrite incorporates the regex-precompilation and single merged `git rev-parse --git-dir --git-common-dir` call naturally; the rest were not separately chased given diminishing returns relative to the correctness fixes above.
+
+## Restart required
+
+```text
+No restart required. .claude/settings.json is read per-session; a new Claude Code session (or subagent) picks up the new hook automatically once this branch is merged to main.
+```
+
+## Risks / concerns
+
+- **Severity: Medium.** This hook only protects Claude Code sessions that load this repo's `.claude/settings.json` — a different AI tool, a plain terminal, or a human typing the command directly is unprotected. Documented explicitly in the module docstring and this report; not fixed here by design (see architecture-contradiction finding above). Next step: build the vendor-neutral git-level wrapper, deferred until after agent worktree-discipline noncompliance is addressed.
+- **Severity: Low.** Comments (`# ...`) aren't stripped before statement-splitting; a `&&`/`;`/`|` after a `#` on the same line can cause an incorrect statement split. Errs toward over-blocking (a harmless command misread as two statements), not under-blocking.
+- **Severity: Low.** Variable expansion (`$VAR`, `$(...)`) isn't performed; a `cd "$VAR"` resolves to the literal string, which fails the "is this a real directory" check and so fails open (allowed).
+- **Severity: Low.** The "two hooks fire simultaneously on a compound command" interaction is unverified end-to-end (see Live verification above) — believed safe (each hook's deny should be evaluated independently) but not proven live in this session.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1041

--- a/scripts/git_hooks/pre-commit
+++ b/scripts/git_hooks/pre-commit
@@ -46,7 +46,11 @@ fi
 # git copies this hook file verbatim into .git/hooks/, so it must stay a
 # single self-contained file with no runtime dependency on this repo's
 # scripts/ directory being reachable. If you fix a bug here, fix it there
-# too.
+# too. A THIRD, Python reimplementation of this same detection (not a
+# byte-for-byte copy, but the same git-dir/git-common-dir comparison) lives
+# in scripts/hooks/destructive_git_guard.py's _is_shared_checkout() -- if
+# you fix a bug in the detection logic itself (not shell-specific plumbing),
+# check whether it applies there too.
 _GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
 _COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
 IS_SHARED_CHECKOUT=0

--- a/scripts/hooks/destructive_git_guard.py
+++ b/scripts/hooks/destructive_git_guard.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""orion-git-safety-guard: PreToolUse hook that blocks destructive git
+commands (git clean -f*, git reset --hard, git checkout/switch --force)
+from running against the shared/primary checkout of this repo.
+
+Companion to scripts/git_hooks/pre-commit, which only gates `git commit`.
+That hook cannot help here: these commands destroy uncommitted files
+*before* any commit happens, so a commit-time gate is too late -- the
+damage is already done. This hook gates at tool-call time instead, using
+Claude Code's PreToolUse block contract (see AGENTS.md section 2, "Clean
+git and worktree rules").
+
+Deliberately scoped to Claude Code, not vendor-neutral: unlike `git
+commit`, git has no hook point at all for `clean`/`reset`/`checkout`, so
+there is no equivalent of scripts/git_hooks/pre-commit for these commands
+-- the only way to get the same tool-independent guarantee is to
+intercept the `git` binary itself (e.g. a PATH-shadowing wrapper), which
+is a materially bigger change than this file. That wrapper is deferred,
+not abandoned -- it's next up once the underlying question of *why*
+agents end up in the shared checkout at all (worktree-discipline
+noncompliance) is addressed; this hook is a real, live block in the
+meantime, not just a placeholder.
+
+Escape hatch: ORION_ALLOW_SHARED_CHECKOUT_WRITE=1, same as the commit
+hook -- either set in the hook process's own environment, or as a leading
+env-var assignment on the SAME statement as the destructive command
+(e.g. `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git reset --hard`), matching
+how a real shell scopes an inline assignment to the one command it
+prefixes.
+
+Known gaps (disclosed, not silent):
+  - Shell comments (`# ...`) are not stripped. A `&&`/`;`/`|` appearing
+    after a `#` on the same line can cause an incorrect statement split.
+    This errs toward over-blocking (a harmless command misread as two
+    statements), not under-blocking.
+  - Quote-stripping (used so quoted text like a commit message can't be
+    mistaken for a real git invocation or an inline escape-hatch
+    assignment) is a balanced-quote heuristic, not a real shell
+    tokenizer -- it does not handle escaped quotes or nesting.
+  - Variable expansion ($VAR, $(...), backticks) is not performed. A `cd
+    "$VAR"` or `git -C "$VAR"` resolves to the literal string, which
+    almost always fails the "is this a real directory" check and so
+    fails OPEN (allowed), not closed.
+  - `_is_shared_checkout` fails open (allows) on any git-subprocess
+    error, non-zero exit, or its 5s timeout.
+  - `git push --force`/`--force-with-lease` and `git branch -D` are
+    intentionally out of scope -- push affects the remote regardless of
+    which checkout runs it (not a "shared checkout" problem specifically)
+    and git itself already refuses to delete a branch checked out in
+    another worktree.
+  - `git switch -C` / `git checkout -B` (force-create-and-reset branch
+    variants) are not detected; only the `-f`/`--force` forms of
+    checkout/switch are.
+  - This hook only fires for Claude Code sessions that load this repo's
+    .claude/settings.json. A different tool, a plain terminal, or a human
+    typing the command directly is unprotected -- see the "Deliberately
+    scoped" note above.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+_STATEMENT_SPLIT = re.compile(r"&&|;|\|")
+_QUOTED = re.compile(r"'[^']*'|\"[^\"]*\"")
+_FORCE_FLAG_RE = re.compile(r"(?:^|\s)-[a-zA-Z]*f[a-zA-Z]*(?:\s|$)")
+_DRYRUN_FLAG_RE = re.compile(r"(?:^|\s)-[a-zA-Z]*n[a-zA-Z]*(?:\s|$)")
+_CD_STATEMENT = re.compile(r'^cd\s+(["\']?)([^"\']+)\1\s*$')
+_GIT_DASH_C = re.compile(r'\bgit\s+-C\s+(["\']?)([^"\'\s]+)\1')
+_GIT_CLEAN = re.compile(r"\bgit\b(?:\s+-C\s+\S+)?\s+clean\b")
+_GIT_RESET_HARD = re.compile(r"\bgit\b(?:\s+-C\s+\S+)?\s+reset\b.*--hard\b", re.DOTALL)
+_GIT_CHECKOUT = re.compile(r"\bgit\b(?:\s+-C\s+\S+)?\s+checkout\b")
+_GIT_SWITCH = re.compile(r"\bgit\b(?:\s+-C\s+\S+)?\s+switch\b")
+# Matches ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 only as a leading env-var
+# assignment on the statement (optionally after other VAR=val assignments),
+# mirroring real shell scoping of an inline prefix assignment.
+_ESCAPE_HATCH_PREFIX = re.compile(
+    r"^(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*ORION_ALLOW_SHARED_CHECKOUT_WRITE=1(?:\s|$)"
+)
+
+
+def _strip_quoted(s: str) -> str:
+    """Blank out single/double-quoted spans (same length, so positions are
+    preserved) so text inside a commit message, echoed string, etc. can't
+    be mistaken for a real git invocation, a directory override, or an
+    inline escape-hatch assignment. A best-effort heuristic, not a shell
+    tokenizer -- see the module docstring's Known gaps."""
+    return _QUOTED.sub(lambda m: " " * len(m.group(0)), s)
+
+
+def _split_statements(command: str) -> list[tuple[str, str]]:
+    """Splits on &&/;/| using a quote-stripped view (so a quoted string
+    containing one of those characters, e.g. a commit message, doesn't
+    create a bogus statement boundary), then returns (original, stripped)
+    pairs aligned by identical character offsets -- the stripped view is
+    used for pattern matching, the original for extracting real path
+    values out of quoted arguments."""
+    masked = _strip_quoted(command)
+    spans: list[tuple[str, str]] = []
+    pos = 0
+    for m in _STATEMENT_SPLIT.finditer(masked):
+        spans.append((command[pos:m.start()], masked[pos:m.start()]))
+        pos = m.end()
+    spans.append((command[pos:], masked[pos:]))
+    return [(o.strip(), s.strip()) for o, s in spans if s.strip()]
+
+
+def _statement_is_destructive(statement: str) -> str | None:
+    """`statement` must already be quote-stripped."""
+    if _GIT_CLEAN.search(statement):
+        is_dry_run = _DRYRUN_FLAG_RE.search(statement) or "--dry-run" in statement
+        is_forced = _FORCE_FLAG_RE.search(statement) or "--force" in statement
+        # git clean treats -n as authoritative even combined with -f:
+        # nothing is deleted, so a dry-run preview is not destructive.
+        if is_forced and not is_dry_run:
+            return "git clean (force flag, no dry-run)"
+    if _GIT_RESET_HARD.search(statement):
+        return "git reset --hard"
+    if _GIT_CHECKOUT.search(statement) or _GIT_SWITCH.search(statement):
+        is_forced = _FORCE_FLAG_RE.search(statement) or "--force" in statement
+        if is_forced:
+            kind = "checkout" if _GIT_CHECKOUT.search(statement) else "switch"
+            return f"git {kind} (force flag)"
+    return None
+
+
+def _resolve(base: str, path: str) -> str:
+    path = os.path.expanduser(path)
+    if not os.path.isabs(path):
+        path = os.path.join(base, path)
+    return os.path.normpath(path)
+
+
+def _is_shared_checkout(target_dir: str) -> bool:
+    """Mirrors the detection in scripts/git_hooks/pre-commit and
+    scripts/safe_docker_build.sh: the primary checkout's --git-dir IS the
+    --git-common-dir; a linked worktree's differs. Uses normpath (not
+    realpath) so symlinks are treated the same way the shell hooks' logical
+    `cd ... && pwd` treats them -- i.e. not resolved."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", target_dir, "rev-parse", "--git-dir", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return False
+    if proc.returncode != 0:
+        return False
+    lines = proc.stdout.splitlines()
+    if len(lines) != 2:
+        return False
+    git_dir_raw, common_dir_raw = lines
+    gd = os.path.normpath(os.path.join(target_dir, git_dir_raw.strip()))
+    cd = os.path.normpath(os.path.join(target_dir, common_dir_raw.strip()))
+    return gd == cd
+
+
+def _escape_hatch_set(statement: str) -> bool:
+    if os.environ.get("ORION_ALLOW_SHARED_CHECKOUT_WRITE") == "1":
+        return True
+    return bool(_ESCAPE_HATCH_PREFIX.match(statement))
+
+
+def _evaluate(cwd: str, command: str) -> tuple[str, str] | None:
+    """Walks statements left-to-right, tracking a running current directory
+    across `cd <path>` statements (so `cd a && cd b && git reset --hard`
+    resolves correctly, not just a single leading cd). Returns
+    (reason, target_dir) for the first destructive statement that targets
+    the shared checkout and isn't escape-hatched, else None."""
+    current_dir = cwd
+    for original, statement in _split_statements(command):
+        cd_match = _CD_STATEMENT.match(original)
+        if cd_match:
+            current_dir = _resolve(current_dir, cd_match.group(2).strip())
+            continue
+
+        reason = _statement_is_destructive(statement)
+        if reason is None:
+            continue
+
+        dash_c = _GIT_DASH_C.search(original)
+        target_dir = (
+            _resolve(current_dir, dash_c.group(2).strip()) if dash_c else current_dir
+        )
+
+        if not _is_shared_checkout(target_dir):
+            continue
+        if _escape_hatch_set(statement):
+            continue
+        return reason, target_dir
+    return None
+
+
+def main() -> None:
+    try:
+        payload = json.loads(sys.stdin.buffer.read().decode("utf-8", "replace"))
+    except Exception:
+        return
+    if not isinstance(payload, dict):
+        return
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return
+    command = str(tool_input.get("command") or "")
+    if not command.strip():
+        return
+
+    cwd = str(payload.get("cwd") or os.getcwd())
+    result = _evaluate(cwd, command)
+    if result is None:
+        return
+    reason, target_dir = result
+
+    decision = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"[git-safety] Blocked: {reason} in the shared/primary checkout "
+                f"({target_dir}). This repo's policy is worktrees-only for "
+                f"writing/building/running code -- concurrent sessions have "
+                f"silently destroyed each other's uncommitted work this way "
+                f"before. Redo this in a worktree instead: "
+                f"git worktree add ../Orion-Sapienform-<name> -b <type>/<name>. "
+                f"If this is genuinely intentional, prefix the command with "
+                f"ORION_ALLOW_SHARED_CHECKOUT_WRITE=1."
+            ),
+        }
+    }
+    sys.stdout.write(json.dumps(decision, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/safe_docker_build.sh
+++ b/scripts/safe_docker_build.sh
@@ -32,7 +32,10 @@ set -e
 # NOTE: this detection block is intentionally byte-for-byte duplicated in
 # scripts/git_hooks/pre-commit rather than sourced from a shared file --
 # that file gets copied verbatim by git into .git/hooks/ and must stay
-# self-contained. If you fix a bug here, fix it there too.
+# self-contained. If you fix a bug here, fix it there too. A THIRD, Python
+# reimplementation of this same detection lives in
+# scripts/hooks/destructive_git_guard.py's _is_shared_checkout() -- if you
+# fix a bug in the detection logic itself, check whether it applies there.
 _GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
 _COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
 IS_SHARED_CHECKOUT=0

--- a/tests/scripts/test_destructive_git_guard.py
+++ b/tests/scripts/test_destructive_git_guard.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "hooks"))
+
+from destructive_git_guard import (  # noqa: E402
+    _escape_hatch_set,
+    _evaluate,
+    _is_shared_checkout,
+    _resolve,
+    _statement_is_destructive,
+    _strip_quoted,
+    main,
+)
+
+
+# --- _statement_is_destructive ------------------------------------------------
+
+@pytest.mark.parametrize(
+    "statement,expect_blocked",
+    [
+        ("git clean -fd", True),
+        ("git clean -f", True),
+        ("git clean --force -d", True),
+        ("git clean -nfd", False),  # -n (dry-run) is authoritative over -f
+        ("git clean --dry-run --force", False),
+        ("git clean -n", False),
+        ("git status", False),
+        ("git reset --hard", True),
+        ("git reset --hard HEAD~1", True),
+        ("git reset --hard origin/main", True),
+        ("git reset --soft HEAD~1", False),
+        ("git reset --mixed", False),
+        ("echo hello", False),
+        ("git -C /some/dir clean -fd", True),
+        ("git -C /some/dir reset --hard", True),
+        ("git checkout -f", True),
+        ("git checkout --force main", True),
+        ("git checkout main", False),
+        ("git checkout -- some/file", False),
+        ("git switch -f other", True),
+        ("git switch --force other", True),
+        ("git switch other", False),
+        ("git push --force", False),  # intentionally out of scope, see PR report
+        ("git branch -D foo", False),  # intentionally out of scope, see PR report
+        # line-continuation: `git reset \` + newline + `--hard` is a single
+        # real command in bash. .* without DOTALL used to miss this.
+        ("git reset \\\n  --hard", True),
+    ],
+)
+def test_statement_is_destructive(statement: str, expect_blocked: bool) -> None:
+    result = _statement_is_destructive(statement)
+    assert (result is not None) == expect_blocked, f"{statement!r} -> {result!r}"
+
+
+# --- _strip_quoted -------------------------------------------------------------
+
+def test_strip_quoted_blanks_double_quotes_same_length() -> None:
+    s = 'git commit -m "git reset --hard is dangerous"'
+    stripped = _strip_quoted(s)
+    assert "reset" not in stripped
+    assert len(stripped) == len(s)
+
+
+def test_strip_quoted_blanks_single_quotes() -> None:
+    s = "echo 'git clean -fd'"
+    stripped = _strip_quoted(s)
+    assert "clean" not in stripped
+
+
+def test_strip_quoted_leaves_unquoted_text() -> None:
+    s = "git reset --hard"
+    assert _strip_quoted(s) == s
+
+
+# --- _resolve --------------------------------------------------------------
+
+def test_resolve_relative_against_base() -> None:
+    assert _resolve("/repo", "../other") == "/other"
+
+
+def test_resolve_absolute_ignores_base() -> None:
+    assert _resolve("/repo", "/elsewhere") == "/elsewhere"
+
+
+def test_resolve_dot_is_base() -> None:
+    assert _resolve("/repo", ".") == "/repo"
+
+
+# --- _escape_hatch_set -------------------------------------------------------
+
+def test_escape_hatch_leading_prefix() -> None:
+    assert _escape_hatch_set("ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git reset --hard")
+
+
+def test_escape_hatch_with_other_leading_assignments() -> None:
+    assert _escape_hatch_set("FOO=bar ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git reset --hard")
+
+
+def test_escape_hatch_not_set() -> None:
+    assert not _escape_hatch_set("git reset --hard")
+
+
+def test_escape_hatch_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORION_ALLOW_SHARED_CHECKOUT_WRITE", "1")
+    assert _escape_hatch_set("git reset --hard")
+
+
+def test_escape_hatch_trailing_is_not_a_bypass() -> None:
+    """Regression: the token must be a genuine leading prefix of the
+    statement, not appear anywhere in it (e.g. after the real command, or
+    in a shell comment) -- a real shell never scopes an inline assignment
+    that way."""
+    assert not _escape_hatch_set("git reset --hard ORION_ALLOW_SHARED_CHECKOUT_WRITE=1")
+    assert not _escape_hatch_set("git reset --hard # ORION_ALLOW_SHARED_CHECKOUT_WRITE=1")
+
+
+# --- _is_shared_checkout (real git repos, no mocks) --------------------------
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+
+
+@pytest.fixture
+def repo_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    _git("init", "-q", cwd=primary)
+    _git("config", "user.email", "test@example.com", cwd=primary)
+    _git("config", "user.name", "Test", cwd=primary)
+    (primary / "f.txt").write_text("x", encoding="utf-8")
+    _git("add", "f.txt", cwd=primary)
+    _git("commit", "-q", "-m", "init", cwd=primary)
+    linked = tmp_path / "linked"
+    _git("worktree", "add", "-q", str(linked), "-b", "feat/x", cwd=primary)
+    return primary, linked
+
+
+def test_is_shared_checkout_true_for_primary(repo_with_worktree: tuple[Path, Path]) -> None:
+    primary, _ = repo_with_worktree
+    assert _is_shared_checkout(str(primary)) is True
+
+
+def test_is_shared_checkout_false_for_linked_worktree(
+    repo_with_worktree: tuple[Path, Path]
+) -> None:
+    _, linked = repo_with_worktree
+    assert _is_shared_checkout(str(linked)) is False
+
+
+def test_is_shared_checkout_false_outside_any_repo(tmp_path: Path) -> None:
+    outside = tmp_path / "not-a-repo"
+    outside.mkdir()
+    assert _is_shared_checkout(str(outside)) is False
+
+
+# --- _evaluate: the regression tests for every review-confirmed bug ----------
+
+def test_evaluate_blocks_simple_case(repo_with_worktree: tuple[Path, Path]) -> None:
+    primary, _ = repo_with_worktree
+    assert _evaluate(str(primary), "git reset --hard") is not None
+
+
+def test_evaluate_allows_in_worktree(repo_with_worktree: tuple[Path, Path]) -> None:
+    _, linked = repo_with_worktree
+    assert _evaluate(str(linked), "git reset --hard") is None
+
+
+def test_evaluate_multi_hop_cd_bug(repo_with_worktree: tuple[Path, Path]) -> None:
+    """Regression: a cd that isn't the first token used to be invisible to
+    directory resolution entirely."""
+    primary, linked = repo_with_worktree
+    command = f"echo starting && cd {primary} && git reset --hard"
+    result = _evaluate(str(linked), command)
+    assert result is not None
+    assert result[1] == str(primary)
+
+
+def test_evaluate_sequential_cd_statements(repo_with_worktree: tuple[Path, Path]) -> None:
+    primary, linked = repo_with_worktree
+    command = f"cd {linked} && cd {primary} && git reset --hard"
+    result = _evaluate("/nonexistent-start", command)
+    assert result is not None
+    assert result[1] == str(primary)
+
+
+def test_evaluate_decoy_dash_c_in_earlier_statement_no_longer_hijacks(
+    repo_with_worktree: tuple[Path, Path]
+) -> None:
+    """Regression: a `-C <dir>` substring inside an earlier, unrelated
+    statement used to be picked up by a whole-string search and hijack
+    directory resolution for a later, unrelated destructive statement."""
+    primary, _ = repo_with_worktree
+    command = 'echo "see git -C /tmp/decoy note" && git reset --hard'
+    result = _evaluate(str(primary), command)
+    assert result is not None
+    assert result[1] == str(primary)
+
+
+def test_evaluate_quoted_mention_is_not_a_false_positive(
+    repo_with_worktree: tuple[Path, Path]
+) -> None:
+    """Regression: a commit message that merely mentions the destructive
+    command as text used to be misidentified as the command itself."""
+    primary, _ = repo_with_worktree
+    command = 'git commit -m "docs: explain why git reset --hard is dangerous"'
+    assert _evaluate(str(primary), command) is None
+
+
+def test_evaluate_escape_hatch_scoped_to_its_own_statement(
+    repo_with_worktree: tuple[Path, Path]
+) -> None:
+    """Regression: the escape hatch used to be searched across the whole
+    command string, so it could authorize an earlier, unrelated destructive
+    statement in the same chain."""
+    primary, _ = repo_with_worktree
+    command = "git clean -fd; ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 echo hi"
+    result = _evaluate(str(primary), command)
+    assert result is not None
+    assert result[0].startswith("git clean")
+
+
+def test_evaluate_escape_hatch_on_correct_statement_allows(
+    repo_with_worktree: tuple[Path, Path]
+) -> None:
+    primary, _ = repo_with_worktree
+    command = "ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git reset --hard"
+    assert _evaluate(str(primary), command) is None
+
+
+def test_evaluate_checkout_force_blocked(repo_with_worktree: tuple[Path, Path]) -> None:
+    primary, _ = repo_with_worktree
+    assert _evaluate(str(primary), "git checkout -f main") is not None
+
+
+def test_evaluate_switch_force_blocked(repo_with_worktree: tuple[Path, Path]) -> None:
+    primary, _ = repo_with_worktree
+    assert _evaluate(str(primary), "git switch --force other") is not None
+
+
+def test_evaluate_dash_c_with_prior_cd(repo_with_worktree: tuple[Path, Path]) -> None:
+    """`git -C .` after a `cd` should resolve relative to the updated
+    current directory, not the hook's original cwd."""
+    primary, linked = repo_with_worktree
+    command = f"cd {linked} && git -C . reset --hard"
+    result = _evaluate("/nonexistent-start", command)
+    assert result is None  # linked worktree, not shared
+
+
+def test_evaluate_line_continuation_reset_hard(repo_with_worktree: tuple[Path, Path]) -> None:
+    primary, _ = repo_with_worktree
+    assert _evaluate(str(primary), "git reset \\\n  --hard") is not None
+
+
+# --- main() end-to-end, real subprocess over stdin/stdout --------------------
+
+def _run_main(payload: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "hooks" / "destructive_git_guard.py")],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_main_blocks_reset_hard_in_primary(repo_with_worktree: tuple[Path, Path]) -> None:
+    primary, _ = repo_with_worktree
+    proc = _run_main({"cwd": str(primary), "tool_input": {"command": "git reset --hard"}})
+    decision = json.loads(proc.stdout)
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "git-safety" in decision["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_main_allows_reset_hard_in_worktree(repo_with_worktree: tuple[Path, Path]) -> None:
+    _, linked = repo_with_worktree
+    proc = _run_main({"cwd": str(linked), "tool_input": {"command": "git reset --hard"}})
+    assert proc.stdout == ""
+
+
+def test_main_allows_with_escape_hatch(repo_with_worktree: tuple[Path, Path]) -> None:
+    primary, _ = repo_with_worktree
+    proc = _run_main(
+        {
+            "cwd": str(primary),
+            "tool_input": {
+                "command": "ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git reset --hard"
+            },
+        }
+    )
+    assert proc.stdout == ""
+
+
+def test_main_allows_non_destructive_command(repo_with_worktree: tuple[Path, Path]) -> None:
+    primary, _ = repo_with_worktree
+    proc = _run_main({"cwd": str(primary), "tool_input": {"command": "git status"}})
+    assert proc.stdout == ""
+
+
+def test_main_ignores_malformed_input() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "hooks" / "destructive_git_guard.py")],
+        input="not json",
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.stdout == ""
+    assert proc.returncode == 0
+
+
+def test_main_ignores_missing_tool_input() -> None:
+    proc = _run_main({"cwd": "/repo"})
+    assert proc.stdout == ""
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary

- Adds `scripts/hooks/destructive_git_guard.py`, a Claude Code `PreToolUse` hook that blocks `git clean -f*`, `git reset --hard`, and `git checkout`/`git switch --force` from running against the shared/primary checkout of this repo.
- Wires it into `.claude/settings.json` alongside the existing `graphify hook-guard search` entry (same "Bash" matcher).
- Reuses the same git-dir/git-common-dir shared-checkout detection as `scripts/git_hooks/pre-commit` and `scripts/safe_docker_build.sh`; both got a comment update pointing at this third implementation.
- 57 tests in `tests/scripts/test_destructive_git_guard.py`, including a regression test for every bug found in review (see below).

## Outcome moved

`git clean -fd`/`git reset --hard` destroy uncommitted files *before* any commit happens, so the existing `pre-commit` hook (which only gates `git commit`) can't help — the damage is already done. This closes that specific gap: it's the same incident class that already happened once this session (a concurrent session's presumed `git clean -fd` wiped `graphify-out/` extras and a spec doc from the shared checkout mid-session, discovered via reflog/timestamp investigation, not caused by this work).

## Current architecture

Before this PR: `scripts/git_hooks/pre-commit` blocked commits from the shared checkout; `scripts/safe_docker_build.sh` was a convention-based wrapper for `docker compose`. Neither covers destructive git operations that never reach a commit.

## Architecture touched

- `.claude/settings.json` — new PreToolUse hook entry.
- `scripts/hooks/destructive_git_guard.py` — new.
- `scripts/git_hooks/pre-commit`, `scripts/safe_docker_build.sh` — comment-only, point at the new third implementation of the shared-detection logic.
- `tests/scripts/test_destructive_git_guard.py` — new.

## Files changed

- `scripts/hooks/destructive_git_guard.py`: new PreToolUse hook script.
- `.claude/settings.json`: wires the hook into the existing "Bash" matcher.
- `tests/scripts/test_destructive_git_guard.py`: 57 tests, including a named regression test per confirmed review finding.
- `scripts/git_hooks/pre-commit`, `scripts/safe_docker_build.sh`: comment updates only (cross-reference the third detection implementation).

## Schema / bus / API changes

None. Pure tooling, no bus/schema/env surface touched.

## Env/config changes

None. No `.env_example` changes; nothing to sync.

## Tests run

```
/mnt/scripts/Orion-Sapienform/orion_dev/bin/pytest tests/scripts/test_destructive_git_guard.py -q
57 passed in 1.53s
```

Note: `pyproject.toml`'s `norecursedirs = ["scripts", ...]` matches directory *basename*, so it also silently excludes `tests/scripts/` from bare `pytest`/`pytest tests -q` discovery (confirmed via `--collect-only`: 0 matches under default testpaths, full collection with the explicit path). This is a **pre-existing, repo-wide gap** — two sibling files (`test_orion_proposal_cli.py`, `test_sync_local_env_from_example.py`) already live there and are always invoked by explicit path in prior PR reports, never bare `pytest`. Flagging as a follow-up, not fixing in this PR since it would affect unrelated test suites.

## Evals run

None. This is a Claude Code hook script, not a `services/<name>` component with its own eval harness — no existing eval harness applies. The 57 tests include full end-to-end coverage (real subprocess over stdin/stdout, real git repos with actual worktrees, no mocks).

## Docker/build/smoke checks

Not applicable — no runtime/service/Docker surface touched.

## Live verification (not just tests)

Two live end-to-end tests were run with explicit Juniper approval via AskUserQuestion (the command itself, `git reset --hard HEAD`, is a genuine no-op against an unmoved HEAD in a clean tree, but AGENTS.md requires explicit approval for it regardless):

1. Temporarily wired the hook into the live shared checkout's `.claude/settings.json`, dispatched a fresh subagent to run `git reset --hard HEAD` there. **Blocked** — the subagent received the exact `permissionDecisionReason` the hook emits, the command never executed, confirmed via `git status` before/after. Wiring reverted after the test.
2. Confirmed `$CLAUDE_PROJECT_DIR` (used in the committed hook command so it works from any clone/machine) resolves correctly at hook-invocation time, via a non-destructive diagnostic hook writing to a log file — `/mnt/scripts/Orion-Sapienform` in all three firings, including from a dispatched subagent.

A third test (compound command tripping both the graphify hook and this one simultaneously, to confirm the deny still wins) was attempted but the dispatched subagent correctly declined to run a `git reset --hard` on a relayed "the user already approved this" claim from the orchestrating session, since agent-relayed approval isn't verifiable consent. That refusal is correct behavior, not a bug — this specific residual question (does Claude Code's harness honor a deny from the second of two hooks under one matcher when both produce output) is therefore **UNVERIFIED**, left as a documented low-severity gap rather than pushed further through relay.

## Review findings fixed

Ran the `code-review` skill at high effort (8 parallel finder angles, live-reproduced where possible). 10 findings reported, all fixed via a full rewrite of the core detection logic (the bugs shared one root cause: parsing the whole command string instead of walking statements in order while tracking directory state):

- **Finding**: Escape hatch searched the entire command string unscoped/unanchored — matched inside a shell comment (`# ORION_ALLOW_SHARED_CHECKOUT_WRITE=1`, never actually sets the env var) or an unrelated later statement, silently authorizing a real destructive command.
  - **Fix**: `_escape_hatch_set` now only matches a genuine leading env-assignment prefix on the *same* statement as the destructive command.
  - **Evidence**: `test_evaluate_escape_hatch_scoped_to_its_own_statement`, `test_escape_hatch_trailing_is_not_a_bypass`.
- **Finding**: `_resolve_target_dir` only handled a single leading `cd`; `echo x && cd ../shared && git reset --hard` (an ordinary two-hop chain) bypassed directory resolution entirely.
  - **Fix**: `_evaluate` now walks statements left-to-right tracking a running current directory across every `cd` statement.
  - **Evidence**: `test_evaluate_multi_hop_cd_bug`, `test_evaluate_sequential_cd_statements`.
- **Finding**: `git reset --hard` regex used `.*` without `re.DOTALL`, so a bash line-continuation (`git reset \` + newline + `--hard`) evaded detection.
  - **Fix**: added `re.DOTALL` to `_GIT_RESET_HARD`.
  - **Evidence**: `test_evaluate_line_continuation_reset_hard`.
- **Finding**: `-C <dir>`/`cd` extraction scanned the whole raw string unanchored, so decoy text in an earlier statement (e.g. inside an echoed string) could hijack directory resolution.
  - **Fix**: extraction now scoped per-statement, using quote-stripped text for pattern matching and the original text (aligned by offset) for real path values.
  - **Evidence**: `test_evaluate_decoy_dash_c_in_earlier_statement_no_longer_hijacks`.
- **Finding**: Detection was quoting-unaware — a commit message merely mentioning "git reset --hard" as text was misidentified as the command itself.
  - **Fix**: added `_strip_quoted`, applied before statement-splitting and pattern matching.
  - **Evidence**: `test_evaluate_quoted_mention_is_not_a_false_positive`.
- **Finding**: `_is_shared_checkout` used `os.path.realpath` (resolves symlinks) while the two existing shell hooks use logical `cd && pwd` (does not) — the "mirrored" implementations weren't actually equivalent for symlinked paths.
  - **Fix**: switched to `os.path.normpath`, matching logical-pwd semantics.
- **Finding**: `git checkout -f`/`git switch -f` (equally destroy uncommitted tracked-file changes) weren't detected, and unlike `push --force`/`branch -D` (explicitly commented as out-of-scope), this wasn't documented as intentional.
  - **Fix**: added detection for both; documented `switch -C`/`checkout -B` (force-create-branch variants) as a remaining, disclosed gap.
  - **Evidence**: `test_evaluate_checkout_force_blocked`, `test_evaluate_switch_force_blocked`.
- **Finding**: `_is_shared_checkout`'s fail-open behavior on git-subprocess error/timeout wasn't listed in the module's own "Known gaps" docstring.
  - **Fix**: documented explicitly.
- **Finding**: `tests/scripts/` silently excluded from bare `pytest` via `norecursedirs` basename matching.
  - **Fix**: not fixed in this PR (pre-existing, repo-wide, affects unrelated suites) — documented above under Tests run, PR report uses the explicit path.
- **Finding** (architecture-contradiction, most serious): a same-day prior PR report (`docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md`) explicitly evaluated and *rejected* "PreToolUse hook as enforcement," quoting Juniper directly ("I don't want to be beholden to developing with a paid subscription"), scoping PreToolUse hooks to disclosure-only and calling a vendor-neutral git-level wrapper the real, not-yet-built enforcement layer. This PR ships `permissionDecision: deny` — real enforcement — reversing that without initially reconciling it.
  - **Resolution**: surfaced directly to Juniper before proceeding (not fixed silently). Decision: keep this as real enforcement now; the vendor-neutral wrapper is deferred, not abandoned — next up once agent worktree-discipline noncompliance (why agents end up in the shared checkout at all) is addressed directly. Documented in the module docstring's "Deliberately scoped to Claude Code" section and in this PR report so the tradeoff is visible, not silent.

Two additional review angles (efficiency, simplification) suggested minor perf/style nits (precompile regexes, merge two `git rev-parse` calls into one) — the rewrite incorporates the regex-precompilation and single merged `git rev-parse --git-dir --git-common-dir` call naturally; the rest were not separately chased given diminishing returns relative to the correctness fixes above.

## Restart required

```text
No restart required. .claude/settings.json is read per-session; a new Claude Code session (or subagent) picks up the new hook automatically once this branch is merged to main.
```

## Risks / concerns

- **Severity: Medium.** This hook only protects Claude Code sessions that load this repo's `.claude/settings.json` — a different AI tool, a plain terminal, or a human typing the command directly is unprotected. Documented explicitly in the module docstring and this report; not fixed here by design (see architecture-contradiction finding above).
- **Severity: Low.** Comments (`# ...`) aren't stripped before statement-splitting; a `&&`/`;`/`|` after a `#` on the same line can cause an incorrect statement split. Errs toward over-blocking (a harmless command misread as two statements), not under-blocking.
- **Severity: Low.** Variable expansion (`$VAR`, `$(...)`) isn't performed; a `cd "$VAR"` resolves to the literal string, which fails the "is this a real directory" check and so fails open (allowed).
- **Severity: Low.** The "two hooks fire simultaneously on a compound command" interaction is unverified end-to-end (see Live verification above) — believed safe (each hook's deny should be evaluated independently) but not proven live in this session.

## PR link

https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/destructive-git-op-guard