### PR TITLE
Docs/grammar atom wall clock spec

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-14-cortex-exec-grammar-atom-wall-clock-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-cortex-exec-grammar-atom-wall-clock-pr.md
@@ -1,17 +1,44 @@
 ## Summary
 
 - Fixes a real, live-confirmed bug: every atom inside one `orion-cortex-exec`
-  execution trace shared a single flush-time timestamp, so intra-trace timing
-  in the `grammar_events` Postgres corpus was fake (median intra-trace
-  duration across 35,994 real traces was 0.00s). `CortexExecGrammarCollector`
-  now captures a real wall-clock moment per atom (`_put_atom()`) and threads
-  it into each event's `observed_at` field.
-- `emitted_at` deliberately stays the shared flush-time value — it was never
-  wrong (every event genuinely is published to the bus in the same flush
-  batch); this mirrors the pre-existing, already-correct `trace_started`/
-  `trace_ended` pattern rather than inventing a new convention.
+  execution trace shared a single timestamp on `GrammarEventV1.observed_at`
+  (captured once at trace-START, not "flush time" — see the correction note
+  below), so intra-trace timing in the `grammar_events` Postgres corpus was
+  fake. `CortexExecGrammarCollector` now captures a real wall-clock moment
+  per atom (`_put_atom()`) and threads it into each event's `observed_at`
+  field. `emitted_at` deliberately stays the shared flush-time value — it
+  was never wrong (every event genuinely is published to the bus in the same
+  flush batch).
+- **Second round, following a `/code-review max` pass on the already-pushed
+  first round** (see "Review findings fixed" below) — the first round's fix
+  was correct but incomplete: it made `grammar_events.observed_at` real, but
+  two adjacent, already-live consumers still showed fake timing:
+  - `GrammarAtomV1.time_range` (an existing schema field, wired through by
+    `orion/grammar/ledger.py` to persisted `grammar_atoms.time_start/time_end`
+    and served by the live Grammar Atlas API) was never populated by this
+    producer. `_put_atom()` now stamps it, from the same captured moment as
+    `_atom_observed_at`.
+  - `grammar_traces.started_at`/`ended_at` (same Atlas API) were derived
+    from `event.emitted_at` (`orion/grammar/ledger.py`), not `observed_at` —
+    so trace-level duration stayed fake even after the first round.
+    `trace_ended.observed_at` now reflects the real last-recorded-atom
+    time (was hardcoded to trace-start, identical to `trace_started`'s).
+    `orion/grammar/ledger.py::_upsert_trace()` now prefers `observed_at`
+    over `emitted_at` (via the already-existing `_created_at()` helper),
+    safely for every grammar-event producer, not just cortex-exec.
+- Also corrected: the first round's own "live-confirmed" evidence
+  (`max(emitted_at)-min(emitted_at) = 0.00s`) was measured against the
+  wrong field — `emitted_at` was never the buggy one. Re-verified live
+  directly against `observed_at` (the actually-fixed field): also 0.0000s
+  median pre-fix, so the underlying bug claim holds, but the field name/
+  mechanism description in the source comment, spec, and this report were
+  imprecise and are now corrected throughout.
+- Test-file cleanup: removed an unnecessary `datetime` subclass in the
+  fake-clock test helper (a plain callable works identically, verified
+  empirically), removed its dead unused return value, and strengthened one
+  test that previously passed trivially even if the whole fix were reverted.
 - Design spec: `docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md`.
-- 5 new regression tests; 8-angle code review found zero correctness bugs.
+- 10 new/updated regression tests total across both rounds.
 - Confirmed (not speculated) that `HarnessGrammarCollector`
   (`orion/harness/grammar_emit.py`) has the identical bug — tracked as a
   follow-up, explicitly out of scope for this patch.
@@ -20,50 +47,66 @@
 
 `grammar_events` (5M+ real rows, 679K from `orion-cortex-exec` alone) is the
 strongest raw-cognitive-signal substrate identified this session for a future
-felt-state/trajectory corpus. This patch makes its intra-trace timing real,
-which was a hard blocker for building anything on top of it that needs actual
-event ordering/timing within an execution, not just across executions.
+felt-state/trajectory corpus. This patch makes its intra-trace timing real —
+both at the event level (`observed_at`) and at the two adjacent already-live
+consumer surfaces (`grammar_atoms.time_start/time_end`, `grammar_traces.
+started_at/ended_at`) that the first round missed.
 
 ## Current architecture
 
 Before this patch: `CortexExecGrammarCollector.record_*` methods (9 total)
 built `GrammarAtomV1` objects as pure data with no timestamp capture, stored
 in `self._atoms`. `build_cortex_exec_grammar_events()` ran once at trace end,
-computing a single flush-time value used for every atom/edge event's
-`observed_at`.
+using one shared trace-start value for every atom/edge event's `observed_at`,
+and hardcoding `trace_ended.observed_at` to the same trace-start value.
+`orion/grammar/ledger.py::_upsert_trace()` derived `grammar_traces.started_at`/
+`ended_at` from `emitted_at` unconditionally.
 
 ## Architecture touched
 
-`services/orion-cortex-exec/app/grammar_emit.py` only. No schema change
-(`orion/schemas/grammar.py` untouched — `GrammarEventV1.observed_at` already
-existed, just was populated wrong). No other service, no `.env`/compose/
-registry changes.
+`services/orion-cortex-exec/app/grammar_emit.py` (producer fix, both rounds),
+`orion/grammar/ledger.py` (shared package — `_upsert_trace()` now prefers
+`observed_at`, benefits every grammar-event producer, safe fallback to
+`emitted_at` for producers without real `observed_at` yet, no regression for
+them). No schema change (`orion/schemas/grammar.py` untouched —
+`GrammarEventV1.observed_at` and `GrammarAtomV1.time_range` both already
+existed, just were populated wrong/not at all). No env/compose/registry
+changes.
 
 ## Files changed
 
 - `services/orion-cortex-exec/app/grammar_emit.py`: `_atom_observed_at: dict[str, datetime]`
-  added to `CortexExecGrammarCollector`, keyed by `atom.atom_id` (not the
-  internal `_atoms` string key, so edge lookups — which reference `atom_id`
-  — can use it directly). Populated in `_put_atom()`. Three `record_*`
-  methods (`record_step_started`/`completed`/`failed`) switched from direct
-  `self._atoms[key] = atom` to `self._put_atom(key, atom)` so all 9 emitters
-  now route through the same capture point. `build_cortex_exec_grammar_events()`'s
-  atom and edge loops use the real per-atom/per-edge-target timestamp for
-  `observed_at` only.
-- `services/orion-cortex-exec/tests/test_exec_grammar_emit.py`: 5 new tests
-  — distinct real `observed_at` per atom in recording order, `emitted_at`
-  stays uniformly shared, edge `observed_at` matches its target atom's real
-  time, and a defensive fallback test for an atom that bypasses `_put_atom`.
-- `docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md`
-  (new): full design spec, corrected during implementation (see Review
-  findings below) and updated post-review with the confirmed harness sibling
-  bug.
+  on `CortexExecGrammarCollector`, keyed by `atom.atom_id`, populated in
+  `_put_atom()` — which now also stamps `atom.time_range = TimeRangeV1(start=now, end=now)`
+  from the same captured moment. All 9 `record_*` methods route through
+  `_put_atom()`. `build_cortex_exec_grammar_events()`'s atom/edge loops use
+  the real per-atom/per-edge-target timestamp for `observed_at` only;
+  `trace_ended.observed_at` now derives from `max(_atom_observed_at.values())`
+  (falls back to trace-start for a zero-atom trace). Source comments
+  corrected to accurately describe trace-start vs. flush-time.
+- `orion/grammar/ledger.py`: `_upsert_trace()` now computes `trace_ts = _created_at(event)`
+  (reusing the existing helper, which already prefers `observed_at` over
+  `emitted_at` over `now()`) instead of hardcoding `event.emitted_at` for
+  both `started_at` and `ended_at`.
+- `services/orion-cortex-exec/tests/test_exec_grammar_emit.py`: fake-clock
+  helper simplified (`SimpleNamespace` instead of a `datetime` subclass,
+  dead return value removed); `test_edge_observed_at_matches_target_atom_real_timestamp`
+  strengthened with a direct inequality check against the old shared
+  constant (previously only checked internal self-consistency, which passes
+  even fully reverted); 3 new tests for `time_range` population and real
+  `trace_ended` behavior (including the zero-atom fallback path).
+- `orion/grammar/tests/test_ledger.py`: 2 new tests for `_upsert_trace()`
+  preferring `observed_at`, with an explicit fallback-to-`emitted_at` test
+  for producers without real `observed_at`.
+- `docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md`:
+  corrected mechanism description (trace-start vs. flush-time), corrected
+  live evidence (now cites the right field), confirmed harness sibling bug.
 
 ## Schema / bus / API changes
 
-None. `GrammarEventV1`/`GrammarAtomV1` (`orion/schemas/grammar.py`) untouched
-— this patch only changes which values get written into an already-existing
-field.
+None. `GrammarEventV1.observed_at` and `GrammarAtomV1.time_range`
+(`orion/schemas/grammar.py`) both pre-existed — this patch only changes
+which values get written into already-existing fields.
 
 ## Env/config changes
 
@@ -73,69 +116,125 @@ None.
 
 ```text
 .venv/bin/python -m pytest services/orion-cortex-exec/tests/test_exec_grammar_emit.py services/orion-cortex-exec/tests/test_exec_grammar_publish_fail_open.py -q
-=> 13 passed
+=> 16 passed
+
+PYTHONPATH=services/orion-sql-writer:. .venv/bin/python -m pytest orion/grammar/tests/test_ledger.py -q
+=> 5 passed
+
+PYTHONPATH=services/orion-sql-writer:. .venv/bin/python -m pytest services/orion-sql-writer/tests/test_grammar_ledger_sql_shape.py -q
+=> 1 passed
+
+PYTHONPATH=services/orion-sql-writer:. .venv/bin/python -m pytest services/orion-sql-writer/tests/test_grammar_ledger_integration.py -q
+=> 3 errors, all psycopg2.OperationalError connecting to localhost:5432 (the
+   live DB in this environment is on port 55432, not 5432) -- a pre-existing
+   environment/fixture-config issue, not caused by this patch. The one
+   non-DB-dependent test in the sibling file (test_grammar_ledger_sql_shape.py)
+   passes.
 
 .venv/bin/python -m pytest services/orion-cortex-exec/tests -q
 => 12 pre-existing collection errors ("Verb already registered"), confirmed
    identical on a clean main checkout (verified via a fresh clone) --
-   unrelated to this patch, a pre-existing test-isolation issue when the
-   whole tests/ directory collects together.
+   unrelated to this patch.
 ```
 
 ## Evals run
 
-None applicable — bug fix + tests, no model/training component. The real
-"eval" is the live check below.
+None applicable. `services/orion-cortex-exec/` has no `evals/` directory at
+all (confirmed via directory listing) — no eval harness exists for this
+service. Per CLAUDE.md section 11, flagging this explicitly rather than
+silently: no eval harness added here (out of proportionate scope for a bug
+fix), no follow-up issue filed yet — worth doing if/when this service gets
+non-trivial cognition-relevant logic beyond grammar-event bookkeeping.
 
 ## Docker/build/smoke checks
 
-Not deployed this session. No runtime/config changes — a code-only fix
-inside `orion-cortex-exec`'s existing Python path, picked up on next
-container rebuild/restart.
+Not run this session (no Docker access exercised). This patch changes
+runtime behavior (what gets computed and persisted at execution time) but
+not deployment topology (no env, port, volume, or dependency changes) — no
+`docker compose build`/`config` check was run to validate the container
+image itself; that layer is **UNVERIFIED**, distinct from the code-level
+test coverage above, which is real and passing. Restart commands below are
+required to actually pick up the change; the restart itself will be the
+first real verification at that layer.
 
 ## Review findings fixed
 
-8-angle code review run against the diff (correctness x3, reuse,
-simplification, efficiency, altitude, CLAUDE.md conventions). 7 of 8 angles
-returned zero findings. The altitude angle found one real, actionable gap —
-not a bug in this diff, but a spec-accuracy issue:
+**Round 1** (8-angle review before initial push): 7 of 8 angles returned zero
+findings. The altitude angle found the confirmed `HarnessGrammarCollector`
+sibling bug (see Risks/concerns) and a spec-accuracy gap, both fixed in the
+spec doc.
 
-- Finding (altitude angle): the spec's "Missing questions" section framed
-  "do sibling collectors share this bug?" as an open question, when direct
-  code reading during review confirmed `HarnessGrammarCollector`
-  (`orion/harness/grammar_emit.py:92-94,400-417`) has the **identical** bug
-  — not even the old flush-time-only mitigation cortex-exec had, its
-  `_put_atom` never captures any timestamp at all.
-  - Fix: spec updated to state this as confirmed, not speculative; tracked
-    as a near-term follow-up in project memory
-    (`project_grammar_collector_shared_timestamp_bug_siblings`), explicitly
-    out of scope for this patch (no shared base class exists across the
-    three sibling collectors to generalize into without a separate
-    cross-service architecture decision).
-  - Evidence: `docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md`'s
-    "Missing questions" section, corrected post-review.
+**Round 2** (`/code-review max`, 10 angles + verify + sweep, run against the
+already-pushed round 1 diff): 6 of 10 angles returned zero findings
+(removed-behavior, cross-file, language-pitfall, wrapper/proxy, reuse,
+efficiency). 4 angles found real, fixed issues:
 
-Two low-severity nits from the simplification angle (parallel `_atoms`/
-`_atom_observed_at` dicts keyed differently; the `.get(id, observed_at)`
-fallback inlined twice rather than a helper) were explicitly assessed as
-"a wash" / not worth the abstraction for two call sites — not changed.
+- Finding (altitude angle, CONFIRMED): `orion/grammar/ledger.py`'s
+  `grammar_traces.started_at`/`ended_at` derive from `emitted_at`, still
+  fake after round 1's fix.
+  - Fix: `_upsert_trace()` now prefers `observed_at` via the existing
+    `_created_at()` helper; `trace_ended.observed_at` now reflects real
+    last-atom time instead of trace-start.
+  - Evidence: `test_trace_started_prefers_observed_at_over_emitted_at`,
+    `test_trace_ended_observed_at_reflects_last_atom_not_trace_start`.
+- Finding (altitude angle, CONFIRMED): `GrammarAtomV1.time_range` (existing
+  field, wired to persisted columns and a live API) never populated.
+  - Fix: `_put_atom()` now sets `atom.time_range` from the same captured
+    timestamp as `_atom_observed_at`.
+  - Evidence: `test_atom_time_range_populated_with_real_timestamp`.
+- Finding (conventions angle, CONFIRMED): source comment, spec, and PR
+  report described the pre-fix bug as "flush-time" and cited
+  `max(emitted_at)-min(emitted_at)=0.00s` as proof — `emitted_at` was never
+  the buggy field; the actually-fixed field (`observed_at`) was captured at
+  trace-start, not flush-time.
+  - Fix: comments/spec/this report corrected; re-verified live directly
+    against `observed_at` (also 0.0000s median pre-fix on real data,
+    confirming the underlying claim while fixing the mechanism description).
+- Finding (test-quality angle, CONFIRMED):
+  `test_edge_observed_at_matches_target_atom_real_timestamp` passed
+  trivially even with the whole fix reverted (only checked internal
+  self-consistency).
+  - Fix: added a direct inequality assertion against the old shared
+    constant.
+- Finding (simplification angle, CONFIRMED, x2): unnecessary `datetime`
+  subclass in the test fake-clock helper (verified empirically that a plain
+  callable works identically); dead unused return value on the same helper.
+  - Fix: both removed.
+- Finding (conventions angle, PLAUSIBLE): PR report's Docker section
+  self-contradicted its own Summary; evals-gap not disclosed.
+  - Fix: both sections rewritten above.
+- Finding (correctness angle, PLAUSIBLE, not fixed): a backward wall-clock
+  step (NTP correction) between two `_put_atom()` calls in the same trace
+  could theoretically produce non-monotonic `observed_at` ordering.
+  - Disposition: not fixed — low realistic likelihood, low blast radius for
+    a training-data/observability corpus (not a safety-critical path),
+    added guard complexity not proportionate. Noted here for the record.
 
 ## Restart required
 
-```text
-No restart required this session (not deployed). Once merged, orion-cortex-exec
-needs a normal rebuild/restart to pick up the code change:
+```bash
 docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
   -f services/orion-cortex-exec/docker-compose.yml up -d --build
 ```
+Also restart `orion-sql-writer` (reads `orion/grammar/ledger.py`, a shared
+module, so its running container needs the updated code too):
+```bash
+docker compose --env-file .env --env-file services/orion-sql-writer/.env \
+  -f services/orion-sql-writer/docker-compose.yml up -d --build
+```
+Neither run this session — not deployed.
 
 ## Risks / concerns
 
 - Severity: low
-- Concern: `HarnessGrammarCollector` has the same bug, confirmed, not fixed here.
-- Mitigation: tracked explicitly in project memory as a near-term follow-up,
-  not silently deferred; documented in the spec doc's corrected "Missing
-  questions" section.
+- Concern: `HarnessGrammarCollector` has the same event-level bug, confirmed,
+  not fixed here; its `GrammarAtomV1.time_range` is presumably also
+  unpopulated (not independently re-checked this round).
+- Mitigation: tracked explicitly in project memory as a near-term follow-up.
+- Severity: very low
+- Concern: theoretical backward-clock non-monotonicity (see Review findings).
+- Mitigation: accepted as-is, disproportionate to guard against for this
+  corpus's actual use case.
 
 ## PR link
 

--- a/docs/superpowers/pr-reports/2026-07-14-cortex-exec-grammar-atom-wall-clock-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-cortex-exec-grammar-atom-wall-clock-pr.md
@@ -1,0 +1,143 @@
+## Summary
+
+- Fixes a real, live-confirmed bug: every atom inside one `orion-cortex-exec`
+  execution trace shared a single flush-time timestamp, so intra-trace timing
+  in the `grammar_events` Postgres corpus was fake (median intra-trace
+  duration across 35,994 real traces was 0.00s). `CortexExecGrammarCollector`
+  now captures a real wall-clock moment per atom (`_put_atom()`) and threads
+  it into each event's `observed_at` field.
+- `emitted_at` deliberately stays the shared flush-time value — it was never
+  wrong (every event genuinely is published to the bus in the same flush
+  batch); this mirrors the pre-existing, already-correct `trace_started`/
+  `trace_ended` pattern rather than inventing a new convention.
+- Design spec: `docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md`.
+- 5 new regression tests; 8-angle code review found zero correctness bugs.
+- Confirmed (not speculated) that `HarnessGrammarCollector`
+  (`orion/harness/grammar_emit.py`) has the identical bug — tracked as a
+  follow-up, explicitly out of scope for this patch.
+
+## Outcome moved
+
+`grammar_events` (5M+ real rows, 679K from `orion-cortex-exec` alone) is the
+strongest raw-cognitive-signal substrate identified this session for a future
+felt-state/trajectory corpus. This patch makes its intra-trace timing real,
+which was a hard blocker for building anything on top of it that needs actual
+event ordering/timing within an execution, not just across executions.
+
+## Current architecture
+
+Before this patch: `CortexExecGrammarCollector.record_*` methods (9 total)
+built `GrammarAtomV1` objects as pure data with no timestamp capture, stored
+in `self._atoms`. `build_cortex_exec_grammar_events()` ran once at trace end,
+computing a single flush-time value used for every atom/edge event's
+`observed_at`.
+
+## Architecture touched
+
+`services/orion-cortex-exec/app/grammar_emit.py` only. No schema change
+(`orion/schemas/grammar.py` untouched — `GrammarEventV1.observed_at` already
+existed, just was populated wrong). No other service, no `.env`/compose/
+registry changes.
+
+## Files changed
+
+- `services/orion-cortex-exec/app/grammar_emit.py`: `_atom_observed_at: dict[str, datetime]`
+  added to `CortexExecGrammarCollector`, keyed by `atom.atom_id` (not the
+  internal `_atoms` string key, so edge lookups — which reference `atom_id`
+  — can use it directly). Populated in `_put_atom()`. Three `record_*`
+  methods (`record_step_started`/`completed`/`failed`) switched from direct
+  `self._atoms[key] = atom` to `self._put_atom(key, atom)` so all 9 emitters
+  now route through the same capture point. `build_cortex_exec_grammar_events()`'s
+  atom and edge loops use the real per-atom/per-edge-target timestamp for
+  `observed_at` only.
+- `services/orion-cortex-exec/tests/test_exec_grammar_emit.py`: 5 new tests
+  — distinct real `observed_at` per atom in recording order, `emitted_at`
+  stays uniformly shared, edge `observed_at` matches its target atom's real
+  time, and a defensive fallback test for an atom that bypasses `_put_atom`.
+- `docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md`
+  (new): full design spec, corrected during implementation (see Review
+  findings below) and updated post-review with the confirmed harness sibling
+  bug.
+
+## Schema / bus / API changes
+
+None. `GrammarEventV1`/`GrammarAtomV1` (`orion/schemas/grammar.py`) untouched
+— this patch only changes which values get written into an already-existing
+field.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+.venv/bin/python -m pytest services/orion-cortex-exec/tests/test_exec_grammar_emit.py services/orion-cortex-exec/tests/test_exec_grammar_publish_fail_open.py -q
+=> 13 passed
+
+.venv/bin/python -m pytest services/orion-cortex-exec/tests -q
+=> 12 pre-existing collection errors ("Verb already registered"), confirmed
+   identical on a clean main checkout (verified via a fresh clone) --
+   unrelated to this patch, a pre-existing test-isolation issue when the
+   whole tests/ directory collects together.
+```
+
+## Evals run
+
+None applicable — bug fix + tests, no model/training component. The real
+"eval" is the live check below.
+
+## Docker/build/smoke checks
+
+Not deployed this session. No runtime/config changes — a code-only fix
+inside `orion-cortex-exec`'s existing Python path, picked up on next
+container rebuild/restart.
+
+## Review findings fixed
+
+8-angle code review run against the diff (correctness x3, reuse,
+simplification, efficiency, altitude, CLAUDE.md conventions). 7 of 8 angles
+returned zero findings. The altitude angle found one real, actionable gap —
+not a bug in this diff, but a spec-accuracy issue:
+
+- Finding (altitude angle): the spec's "Missing questions" section framed
+  "do sibling collectors share this bug?" as an open question, when direct
+  code reading during review confirmed `HarnessGrammarCollector`
+  (`orion/harness/grammar_emit.py:92-94,400-417`) has the **identical** bug
+  — not even the old flush-time-only mitigation cortex-exec had, its
+  `_put_atom` never captures any timestamp at all.
+  - Fix: spec updated to state this as confirmed, not speculative; tracked
+    as a near-term follow-up in project memory
+    (`project_grammar_collector_shared_timestamp_bug_siblings`), explicitly
+    out of scope for this patch (no shared base class exists across the
+    three sibling collectors to generalize into without a separate
+    cross-service architecture decision).
+  - Evidence: `docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md`'s
+    "Missing questions" section, corrected post-review.
+
+Two low-severity nits from the simplification angle (parallel `_atoms`/
+`_atom_observed_at` dicts keyed differently; the `.get(id, observed_at)`
+fallback inlined twice rather than a helper) were explicitly assessed as
+"a wash" / not worth the abstraction for two call sites — not changed.
+
+## Restart required
+
+```text
+No restart required this session (not deployed). Once merged, orion-cortex-exec
+needs a normal rebuild/restart to pick up the code change:
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml up -d --build
+```
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `HarnessGrammarCollector` has the same bug, confirmed, not fixed here.
+- Mitigation: tracked explicitly in project memory as a near-term follow-up,
+  not silently deferred; documented in the spec doc's corrected "Missing
+  questions" section.
+
+## PR link
+
+`gh` is unauthenticated in this environment — open manually at:
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/docs/grammar-atom-wall-clock-spec

--- a/docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md
+++ b/docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md
@@ -10,14 +10,27 @@ trace start/end pairs), causally chained via `parent_event_id`/`root_event_id`,
 semantically labeled (`atom_type`, `semantic_role`, `salience`, `confidence`).
 This is the strongest raw-cognitive-signal substrate found this session —
 categorically richer than anything built from hardware telemetry today. But
-every atom inside one execution trace currently shares a single flush-time
-timestamp: querying real data, median intra-trace duration (`max(emitted_at) -
-min(emitted_at)` per `trace_id`) across 35,994 real cortex-exec traces is
-**0.00 seconds**. The timing is fake. Real per-step timing already exists in
-memory during execution (`executor.py`'s `t0 = time.time()` / `latency_ms`
-pattern, confirmed at `executor.py:2394` and 9 other call sites) — it's
-measured, then thrown away before it reaches the grammar-event record. This
-spec fixes that, and only that.
+every atom inside one execution trace currently shares a single
+`GrammarEventV1.observed_at` value, captured once at trace-**START**
+(`collector.observed_at`, set at collector construction) — **not** "flush
+time" as an earlier draft of this spec claimed. `emitted_at` is the separate,
+genuinely-flush-time field, and it was never buggy (every event in a trace
+really is published to the bus in the same flush batch). Correction, found
+during a `/code-review max` pass on the first round's already-pushed fix: the
+original live-evidence query below measured `emitted_at`, not `observed_at`
+— the wrong field for this claim, even though the underlying "timing is
+fake" conclusion happens to still be correct for the right field too
+(re-verified directly, see below). Querying real data, median intra-trace
+duration (`max(observed_at) - min(observed_at)` per `trace_id`) across real
+cortex-exec traces is **0.0000 seconds**, confirmed live against the actual
+field this spec fixes. The timing is fake. Real per-step timing already
+exists in memory during execution (`executor.py`'s `t0 = time.time()` /
+`latency_ms` pattern, confirmed at `executor.py:2394` and 9 other call
+sites) — it's measured, then thrown away before it reaches the grammar-event
+record. This spec fixes that, plus two adjacent already-live consumers
+(`GrammarAtomV1.time_range`, `grammar_traces.started_at`/`ended_at` via
+`orion/grammar/ledger.py`) found to have the same symptom for a different
+reason, discovered in the same review pass.
 
 ## Current architecture
 

--- a/docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md
+++ b/docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md
@@ -1,0 +1,175 @@
+# cortex-exec grammar-atom real wall-clock timing — spec
+
+Status: design only, nothing in this document is implemented.
+
+## Arsonist summary
+
+`grammar_events` (Postgres, `orion-sql-writer`) holds 5,067,616 real rows across
+30 days — 679,059 from `orion-cortex-exec` alone (293K atoms, 259K edges, 63K
+trace start/end pairs), causally chained via `parent_event_id`/`root_event_id`,
+semantically labeled (`atom_type`, `semantic_role`, `salience`, `confidence`).
+This is the strongest raw-cognitive-signal substrate found this session —
+categorically richer than anything built from hardware telemetry today. But
+every atom inside one execution trace currently shares a single flush-time
+timestamp: querying real data, median intra-trace duration (`max(emitted_at) -
+min(emitted_at)` per `trace_id`) across 35,994 real cortex-exec traces is
+**0.00 seconds**. The timing is fake. Real per-step timing already exists in
+memory during execution (`executor.py`'s `t0 = time.time()` / `latency_ms`
+pattern, confirmed at `executor.py:2394` and 9 other call sites) — it's
+measured, then thrown away before it reaches the grammar-event record. This
+spec fixes that, and only that.
+
+## Current architecture
+
+- `orion/schemas/grammar.py`: `GrammarAtomV1` (`:91-109`) has **no timestamp
+  field at all**. `GrammarEventV1` (`:176-197`) wraps an atom and already has
+  `emitted_at: datetime` (required) and `observed_at: datetime | None`.
+- `services/orion-cortex-exec/app/grammar_emit.py`:
+  - `CortexExecGrammarCollector` (dataclass, `:47-58`) is instantiated once per
+    plan-execution trace, at real trace-start time
+    (`new_cortex_exec_collector()`, `observed_at=datetime.now(timezone.utc)`
+    at `:476`).
+  - Its `record_step_started`/`record_step_completed`/`record_step_failed`/
+    `record_result_assembled`/`record_request_received`/`record_plan_started`/
+    `record_recall_gate_observed`/`record_result_emitted` methods (`:185-360`
+    roughly) build `GrammarAtomV1` objects as pure data and store them in
+    `self._atoms: dict[str, GrammarAtomV1]`, keyed by a stable string. **None
+    of these methods call `datetime.now()` or capture any timing.**
+  - `record_step_completed` (`:226-258`) receives `latency_ms: int | None` as
+    a parameter — a real duration, already measured by the caller — but it
+    only ever lands in the atom's free-text `summary` string
+    (`f"...latency_ms={latency_ms or 0}..."`), never a structured field.
+  - `build_cortex_exec_grammar_events()` (`:483-570`) runs once, at the end of
+    the trace: computes a single `emitted_at = datetime.now(timezone.utc)`
+    (`:487`) and wraps every accumulated atom into a `GrammarEventV1` using
+    that SAME `emitted_at`/`observed_at` pair for all of them (loop at
+    `:506-523`). Only `trace_ended` gets its own fresh `datetime.now()`
+    (`:558`) — everything else in between, i.e. all the real step-level
+    activity, is flush-time-identical.
+- `services/orion-cortex-exec/app/executor.py`: real per-step timing already
+  exists here — `latency_ms=int((time.time() - t0) * 1000)` appears at 10
+  call sites (`:2394,2419,2619,2727,2760,2775,2788,4332,4487,4503`), meaning
+  `t0 = time.time()` is captured at real step-start moments elsewhere in this
+  file. This is the source of truth `record_step_completed`'s `latency_ms`
+  parameter already draws from.
+
+## Missing questions
+
+- Exact call sites where `t0` itself gets set, and whether threading the real
+  `t0`-based start time through to `record_step_started` (in addition to
+  `record_step_completed` already getting `latency_ms`) is worth the extra
+  plumbing versus just capturing a fresh `datetime.now(timezone.utc)` at each
+  `record_*` call. The gap between "the executor's real event" and "the
+  `record_*` call synchronously following it" should be sub-millisecond
+  either way — a fresh capture at the `record_*` site is almost certainly
+  precise enough and is far less invasive (no `executor.py` changes needed).
+  Default position below: fresh capture, not threaded `t0`. Revisit only if
+  the acceptance checks show a real discrepancy.
+- ~~Do the sibling grammar-event producers... share this exact
+  flush-batching pattern?~~ **Resolved during code review (2026-07-14),
+  confirmed not hypothetical**: `HarnessGrammarCollector`
+  (`orion/harness/grammar_emit.py:92-94,400-417`) has the identical bug —
+  its `_put_atom` never captures a timestamp at all, and
+  `build_harness_grammar_events` wraps every atom with one
+  collector-construction-time `observed_at`. Given harness governs the
+  unified-turn motor path (real LLM/tool-step latencies, same stakes as
+  cortex-exec), this is a real, confirmed, near-term follow-up, not a maybe.
+  `BusTransportGrammarCollector` (`services/orion-bus/app/grammar_emit.py:295-309`)
+  has the same code shape but lower practical stakes (its atoms span one
+  observer tick, plausibly genuinely sub-millisecond). Still out of scope
+  for THIS patch — no shared base class exists to generalize into without
+  first making an undiscussed cross-service architecture decision (these
+  three collectors are independently duplicated peer code across service
+  boundaries, not one mechanism with a special case bolted on) — but no
+  longer an open question, and harness specifically should be scheduled as
+  a near-term follow-up patch, not left indefinitely deferred.
+- Existing test coverage for `grammar_emit.py` — needs to be located and read
+  before writing the acceptance-check tests below, so new tests don't
+  duplicate or fight existing ones asserting on the (currently fake) shared
+  timestamp behavior.
+
+## Proposed schema / API changes
+
+**No `orion/schemas/grammar.py` change.** `GrammarEventV1.emitted_at`/
+`observed_at` already exist as per-event fields — they are simply populated
+with one broadcast value today instead of real per-atom values. This is
+smaller blast radius than the version of this idea first floated in-session
+(adding a field to `GrammarAtomV1`) — no schema migration, no backward-compat
+concern for existing rows, nothing new to add to a registry.
+
+Concrete changes, all inside `services/orion-cortex-exec/app/grammar_emit.py`:
+
+1. `CortexExecGrammarCollector`: add
+   `_atom_observed_at: dict[str, datetime] = field(default_factory=dict)`,
+   parallel to the existing `_atoms` dict, keyed identically.
+2. Every `record_*` method: add one line at the point the atom is stored —
+   `self._atom_observed_at[key] = datetime.now(timezone.utc)`.
+3. `build_cortex_exec_grammar_events()`'s atom-wrapping loop (`:506-523`):
+   set **`observed_at` only** to `collector._atom_observed_at.get(atom.atom_id,
+   observed_at)` for each atom's event — keep `emitted_at` as the shared
+   flush-time value, unchanged. Refined during implementation: `emitted_at`
+   was never actually wrong — every event genuinely is published to the bus
+   in the same flush batch, so a shared `emitted_at` is honest. `observed_at`
+   is the field meant to carry "when did this really happen," and that's the
+   one that was broken (silently defaulting to the same flush-time value).
+   This mirrors the existing, already-correct `trace_started` pattern
+   (`emitted_at`=flush time, `observed_at`=real trace-start) rather than
+   inventing a new convention. Key by `atom.atom_id` (not the internal
+   `_atoms` string key) so edge lookups, which reference `atom_id`, can use
+   the same dict directly.
+4. `edge_emitted` events (`:525-552`): same `observed_at`-only treatment,
+   using the **target** atom's (`to_atom_id`) real captured time — an edge
+   semantically becomes true when its second endpoint happens.
+5. `trace_started`/`trace_ended`: unchanged — already correctly distinct
+   (trace-start and flush-completion moments respectively).
+
+## Files likely to touch
+
+- `services/orion-cortex-exec/app/grammar_emit.py` — all real work.
+- `services/orion-cortex-exec/tests/` (exact file TBD, see missing questions)
+  — likely needs new/updated assertions; existing tests may currently assert
+  the shared-timestamp behavior and need correcting, not just extending.
+- Nothing else. No `orion/schemas/`, no other service, no `.env`/compose/
+  registry changes. Contained entirely within `orion-cortex-exec`.
+
+## Non-goals
+
+- Not touching the other grammar-event producers (hub/biometrics/route/
+  transport-loop) in this patch.
+- Not building the actual trajectory corpus/model over `grammar_events` yet —
+  this patch only makes the underlying timing real; extracting/windowing a
+  corpus from it is separate, future work.
+- Not changing `edge_emitted`'s `evidence_event_ids`/`relation_type`
+  semantics beyond the timestamp fix.
+- **Explicitly out of scope but tracked, not forgotten** (see
+  `project_biometrics_channel_defects_to_fix` in this session's memory):
+  the `expected_offline_suppression` one-way-ratchet bug, the three
+  folded-into-`strain` dead channels (`thermal_pressure`/`memory_pressure`/
+  `disk_pressure`), and the `cpu_pressure`/`gpu_pressure` accumulator
+  oscillation on the non-cognitive/biometrics side of this same roadmap.
+
+## Acceptance checks
+
+- Unit test: run a synthetic multi-step plan through the collector, assert
+  distinct `record_*` calls produce events with strictly increasing (or at
+  minimum non-identical) `emitted_at` values — not one shared timestamp.
+- Unit test: assert ordering — `trace_started.emitted_at <=
+  atom_emitted[0].emitted_at <= ... <= trace_ended.emitted_at`.
+- Unit test: `edge_emitted` events use their target atom's real timestamp,
+  not the trace-start fallback, for any edge whose target atom was actually
+  recorded (fallback path only exercised for a genuinely missing key).
+- Live check (post-deploy): query real `grammar_events` for `orion-cortex-exec`
+  traces with `created_at` after deploy, confirm `max(observed_at) -
+  min(observed_at)` per `trace_id` is now nonzero and plausible (roughly
+  matching real step latencies visible in the atom's own `summary` text, not
+  0.00s and not absurdly large). `emitted_at` is expected to stay 0-spread —
+  that's correct, unchanged, honest flush-time behavior, not a regression.
+- Full existing `services/orion-cortex-exec/tests` suite still passes.
+
+## Recommended next patch
+
+Implement exactly the "Proposed schema / API changes" section, scoped to
+`services/orion-cortex-exec/app/grammar_emit.py` and its test file only.
+Resolve the `t0`-threading missing question by defaulting to a fresh
+`datetime.now(timezone.utc)` capture at each `record_*` call site unless the
+acceptance checks reveal a real precision problem.

--- a/orion/grammar/ledger.py
+++ b/orion/grammar/ledger.py
@@ -49,13 +49,22 @@ def _upsert_trace(session: Any, event: GrammarEventV1) -> None:
     trace_type = _trace_type_from_event(event)
     root_event_id = event.root_event_id or event.event_id
     table = GrammarTraceSQL.__table__
+    # started_at/ended_at prefer event.observed_at (real occurrence time,
+    # via _created_at()'s existing fallback chain) over event.emitted_at
+    # (bus-publish time -- always uniform across one flush batch, by
+    # design, never a meaningful trace-duration signal). Found by review
+    # 2026-07-14: producers whose observed_at is itself accurate per-atom
+    # (see services/orion-cortex-exec/app/grammar_emit.py) now get a real
+    # started_at/ended_at spread here too; producers that don't yet have
+    # accurate observed_at are no worse off than before.
+    trace_ts = _created_at(event)
     values = {
         "trace_id": event.trace_id,
         "trace_type": trace_type,
         "session_id": event.session_id,
         "turn_id": event.turn_id,
         "root_event_id": root_event_id,
-        "started_at": event.emitted_at,
+        "started_at": trace_ts,
         "ended_at": None,
         "status": "open",
         "summary": None,
@@ -69,14 +78,14 @@ def _upsert_trace(session: Any, event: GrammarEventV1) -> None:
                 "session_id": event.session_id,
                 "turn_id": event.turn_id,
                 "root_event_id": root_event_id,
-                "started_at": event.emitted_at,
+                "started_at": trace_ts,
                 "status": "open",
             },
         )
     elif event.event_kind == "trace_ended":
         stmt = pg_insert(table).values(**values).on_conflict_do_update(
             index_elements=["trace_id"],
-            set_={"status": "closed", "ended_at": event.emitted_at},
+            set_={"status": "closed", "ended_at": trace_ts},
         )
     else:
         stmt = pg_insert(table).values(**values).on_conflict_do_nothing(

--- a/orion/grammar/tests/test_ledger.py
+++ b/orion/grammar/tests/test_ledger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-from orion.grammar.ledger import apply_grammar_event, apply_grammar_trace_batch
+from orion.grammar.ledger import _upsert_trace, apply_grammar_event, apply_grammar_trace_batch
 from orion.schemas.grammar import GrammarAtomV1, GrammarEventV1, GrammarProvenanceV1
 
 
@@ -60,3 +60,54 @@ def test_trace_batch_dedupes_existing_event_ids() -> None:
 
     session.execute.return_value.fetchall.return_value = [("evt:1",)]
     assert apply_grammar_event(session, event) is True
+
+
+def test_trace_started_prefers_observed_at_over_emitted_at() -> None:
+    """started_at/ended_at should reflect real occurrence time (observed_at,
+    via _created_at()'s existing fallback chain) not bus-publish time
+    (emitted_at, uniform across one flush batch by design -- never a
+    meaningful trace-duration signal). Found by review 2026-07-14: this was
+    previously hardcoded to emitted_at, which is why grammar_traces.started_at/
+    ended_at collapsed to zero duration even for producers with real
+    per-atom observed_at."""
+    session = MagicMock()
+    emitted = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    observed = datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc)
+    event = GrammarEventV1(
+        event_id="evt:1",
+        event_kind="trace_started",
+        trace_id="trace:t1",
+        emitted_at=emitted,
+        observed_at=observed,
+        provenance=GrammarProvenanceV1(source_service="test"),
+    )
+
+    _upsert_trace(session, event)
+
+    stmt = session.execute.call_args[0][0]
+    params = stmt.compile().params
+    assert params["started_at"] == observed
+    assert params["started_at"] != emitted
+
+
+def test_trace_started_falls_back_to_emitted_at_when_observed_at_missing() -> None:
+    """Producers that don't populate observed_at (or haven't been fixed to
+    populate it accurately yet) must not regress -- _created_at()'s existing
+    fallback chain (observed_at or emitted_at or now()) already handles
+    this; this test locks that behavior in for _upsert_trace specifically."""
+    session = MagicMock()
+    emitted = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    event = GrammarEventV1(
+        event_id="evt:1",
+        event_kind="trace_started",
+        trace_id="trace:t1",
+        emitted_at=emitted,
+        observed_at=None,
+        provenance=GrammarProvenanceV1(source_service="test"),
+    )
+
+    _upsert_trace(session, event)
+
+    stmt = session.execute.call_args[0][0]
+    params = stmt.compile().params
+    assert params["started_at"] == emitted

--- a/services/orion-cortex-exec/app/grammar_emit.py
+++ b/services/orion-cortex-exec/app/grammar_emit.py
@@ -54,6 +54,14 @@ class CortexExecGrammarCollector:
     turn_id: str | None = None
     trace_lane: str | None = None
     _atoms: dict[str, GrammarAtomV1] = field(default_factory=dict)
+    # Real wall-clock moment each atom was actually recorded, keyed by
+    # atom_id (not the internal `_atoms` string key) so edge lookups
+    # (which reference atom_id, not that key) can use it directly too.
+    # Populated by _put_atom() -- see 2026-07-14-cortex-exec-grammar-atom-
+    # wall-clock-spec.md. Before this, every atom in a trace shared one
+    # flush-time timestamp (confirmed live: median intra-trace duration
+    # across 35,994 real traces was 0.00s).
+    _atom_observed_at: dict[str, datetime] = field(default_factory=dict)
     _edge_specs: list[tuple[str, str, str]] = field(default_factory=list)
     _last_completed_atom_id: str | None = None
 
@@ -76,6 +84,7 @@ class CortexExecGrammarCollector:
 
     def _put_atom(self, key: str, atom: GrammarAtomV1) -> None:
         self._atoms[key] = atom
+        self._atom_observed_at[atom.atom_id] = datetime.now(timezone.utc)
 
     def record_request_received(self, *, req: PlanExecutionRequest, mode: str) -> None:
         verb = req.plan.verb_name or "unknown"
@@ -209,7 +218,7 @@ class CortexExecGrammarCollector:
             source_event_id=f"{self.correlation_id}:{order}",
             payload_ref=ref,
         )
-        self._atoms[key] = atom
+        self._put_atom(key, atom)
         if self._last_completed_atom_id:
             self._edge_specs.append(
                 (self._last_completed_atom_id, atom.atom_id, "temporal_successor")
@@ -251,7 +260,7 @@ class CortexExecGrammarCollector:
             source_event_id=f"{self.correlation_id}:{order}",
             payload_ref=ref,
         )
-        self._atoms[key] = atom
+        self._put_atom(key, atom)
         started = self._atoms.get(started_key)
         if started:
             self._edge_specs.append((started.atom_id, atom.atom_id, "derived_from"))
@@ -274,7 +283,7 @@ class CortexExecGrammarCollector:
             source_event_id=f"{self.correlation_id}:{order}",
             payload_ref=ref,
         )
-        self._atoms[key] = atom
+        self._put_atom(key, atom)
         started = self._atoms.get(started_key)
         if started:
             self._edge_specs.append((started.atom_id, atom.atom_id, "derived_from"))
@@ -504,12 +513,19 @@ def build_cortex_exec_grammar_events(
     events: list[GrammarEventV1] = [root]
 
     for atom in collector._atoms.values():
+        # observed_at = real wall-clock moment the atom was actually recorded
+        # (captured in _put_atom()), not the single flush-time value every
+        # atom in a trace previously shared. Falls back to trace-start
+        # observed_at only if an atom somehow bypassed _put_atom(). emitted_at
+        # stays the shared flush-time value -- that one was never wrong, every
+        # event genuinely was published to the bus in the same flush batch.
+        atom_ts = collector._atom_observed_at.get(atom.atom_id, observed_at)
         events.append(
             _event(
                 event_kind="atom_emitted",
                 trace_id=trace_id,
                 emitted_at=emitted_at,
-                observed_at=observed_at,
+                observed_at=atom_ts,
                 provenance=provenance,
                 atom=atom,
                 parent_event_id=root_id,
@@ -533,12 +549,15 @@ def build_cortex_exec_grammar_events(
             salience=0.7,
             evidence_event_ids=[collector.correlation_id],
         )
+        # observed_at = real moment the target atom happened; emitted_at
+        # stays the shared flush-time value, same reasoning as atom_emitted above.
+        edge_ts = collector._atom_observed_at.get(to_atom_id, observed_at)
         events.append(
             _event(
                 event_kind="edge_emitted",
                 trace_id=trace_id,
                 emitted_at=emitted_at,
-                observed_at=observed_at,
+                observed_at=edge_ts,
                 provenance=provenance,
                 edge=edge,
                 parent_event_id=root_id,

--- a/services/orion-cortex-exec/app/grammar_emit.py
+++ b/services/orion-cortex-exec/app/grammar_emit.py
@@ -13,6 +13,7 @@ from orion.schemas.grammar import (
     GrammarEdgeV1,
     GrammarEventV1,
     GrammarProvenanceV1,
+    TimeRangeV1,
 )
 from orion.substrate.execution_loop.ids import cortex_exec_trace_id
 
@@ -58,9 +59,14 @@ class CortexExecGrammarCollector:
     # atom_id (not the internal `_atoms` string key) so edge lookups
     # (which reference atom_id, not that key) can use it directly too.
     # Populated by _put_atom() -- see 2026-07-14-cortex-exec-grammar-atom-
-    # wall-clock-spec.md. Before this, every atom in a trace shared one
-    # flush-time timestamp (confirmed live: median intra-trace duration
-    # across 35,994 real traces was 0.00s).
+    # wall-clock-spec.md. Before this, every GrammarEventV1's observed_at
+    # in a trace was the same value captured once at TRACE-START (collector
+    # construction, not flush time -- emitted_at is the separate,
+    # legitimately-shared flush-time value, unaffected by this field).
+    # Re-verified live directly against observed_at (not just emitted_at,
+    # the field an earlier draft of this fix's evidence mistakenly queried):
+    # median intra-trace observed_at spread across real pre-fix
+    # orion-cortex-exec traces is 0.0000s.
     _atom_observed_at: dict[str, datetime] = field(default_factory=dict)
     _edge_specs: list[tuple[str, str, str]] = field(default_factory=list)
     _last_completed_atom_id: str | None = None
@@ -83,8 +89,17 @@ class CortexExecGrammarCollector:
         return f"{self.trace_id}:{key}"
 
     def _put_atom(self, key: str, atom: GrammarAtomV1) -> None:
+        now = datetime.now(timezone.utc)
+        # Also stamp the atom's own time_range (GrammarAtomV1.time_range,
+        # orion/schemas/grammar.py) -- previously never populated by this
+        # producer, so orion/grammar/ledger.py's atom-row persistence
+        # (grammar_atoms.time_start/time_end) and the Grammar Atlas API
+        # that reads it stayed null even after observed_at was fixed on
+        # the sibling GrammarEventV1 envelope. Same source timestamp as
+        # _atom_observed_at, set together so the two can never drift.
+        atom.time_range = TimeRangeV1(start=now, end=now)
         self._atoms[key] = atom
-        self._atom_observed_at[atom.atom_id] = datetime.now(timezone.utc)
+        self._atom_observed_at[atom.atom_id] = now
 
     def record_request_received(self, *, req: PlanExecutionRequest, mode: str) -> None:
         verb = req.plan.verb_name or "unknown"
@@ -514,11 +529,13 @@ def build_cortex_exec_grammar_events(
 
     for atom in collector._atoms.values():
         # observed_at = real wall-clock moment the atom was actually recorded
-        # (captured in _put_atom()), not the single flush-time value every
-        # atom in a trace previously shared. Falls back to trace-start
-        # observed_at only if an atom somehow bypassed _put_atom(). emitted_at
-        # stays the shared flush-time value -- that one was never wrong, every
-        # event genuinely was published to the bus in the same flush batch.
+        # (captured in _put_atom()), not the single trace-START value every
+        # atom in a trace previously shared (collector.observed_at, set once
+        # at collector construction -- not "flush time", that's the separate
+        # emitted_at local below). Falls back to trace-start observed_at only
+        # if an atom somehow bypassed _put_atom(). emitted_at stays the
+        # shared flush-time value -- that one was never wrong, every event
+        # genuinely was published to the bus in the same flush batch.
         atom_ts = collector._atom_observed_at.get(atom.atom_id, observed_at)
         events.append(
             _event(
@@ -570,12 +587,20 @@ def build_cortex_exec_grammar_events(
             )
         )
 
+    # Real trace-end moment = the last atom actually recorded, not
+    # collector.observed_at (trace-START, which trace_ended previously
+    # reused, making trace_started/trace_ended's observed_at identical --
+    # the exact "grammar_traces.started_at/ended_at collapse to zero
+    # duration" symptom found downstream in orion/grammar/ledger.py).
+    # Falls back to trace-start observed_at only for a trace with zero
+    # recorded atoms (e.g. failed before any record_*() call).
+    trace_ended_at = max(collector._atom_observed_at.values(), default=observed_at)
     events.append(
         _event(
             event_kind="trace_ended",
             trace_id=trace_id,
             emitted_at=datetime.now(timezone.utc),
-            observed_at=observed_at,
+            observed_at=trace_ended_at,
             provenance=provenance,
             parent_event_id=root_id,
             root_event_id=root_id,

--- a/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
+++ b/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import get_args
 
 import pytest
@@ -305,3 +305,122 @@ def test_atom_types_are_allowed_literals() -> None:
     for event in build_cortex_exec_grammar_events(collector):
         if event.atom:
             assert event.atom.atom_type in allowed
+
+
+def _install_fake_clock(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Patch app.grammar_emit's datetime.now() to return strictly increasing,
+    deterministic timestamps -- one tick per call -- so tests can assert real
+    ordering/distinctness without depending on wall-clock speed."""
+    import app.grammar_emit as ge
+
+    counter = {"n": 0}
+    base = datetime(2026, 5, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # noqa: ANN001 -- matches datetime.now's signature
+            counter["n"] += 1
+            return base + timedelta(milliseconds=counter["n"])
+
+    monkeypatch.setattr(ge, "datetime", _FakeDatetime)
+    return counter
+
+
+def _record_two_step_trace(collector: CortexExecGrammarCollector) -> None:
+    req = _minimal_plan(steps=2)
+    collector.record_request_received(req=req, mode="brain")
+    collector.record_plan_started(req=req, depth=None, step_count=2)
+    collector.record_recall_gate_observed(run_recall=False, profile="p", reason="r")
+    for i in (1, 2):
+        collector.record_step_started(
+            order=i, step_name=f"step_{i}", verb_name="chat_general", services=["LLMGatewayService"]
+        )
+        collector.record_step_completed(
+            order=i, step_name=f"step_{i}", latency_ms=10, result_service_keys=["LLMGatewayService"]
+        )
+    collector.record_result_assembled(
+        status="success", final_text_present=True, reasoning_present=False, thinking_source="none"
+    )
+    collector.record_result_emitted(reply_present=True, status="success")
+
+
+def test_atoms_get_distinct_real_observed_at_not_shared_flush_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before this fix: every atom in a trace shared one flush-time
+    timestamp (confirmed live: median intra-trace duration across 35,994
+    real cortex-exec traces was 0.00s). Each record_*() call must now stamp
+    its own real observed_at, in recording order."""
+    _install_fake_clock(monkeypatch)
+    collector = CortexExecGrammarCollector(
+        node_name=NODE, correlation_id=CORR, code_version="0.2.0", observed_at=FIXED_OBS,
+    )
+    _record_two_step_trace(collector)
+
+    events = build_cortex_exec_grammar_events(collector)
+    atom_events = [e for e in events if e.atom is not None]
+    observed_ats = [e.observed_at for e in atom_events]
+
+    assert len(set(observed_ats)) == len(observed_ats), (
+        f"expected distinct observed_at per atom, got duplicates: {observed_ats}"
+    )
+    assert observed_ats == sorted(observed_ats), "expected observed_at in recording order"
+
+
+def test_emitted_at_stays_shared_flush_time_across_all_atoms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """emitted_at was never wrong -- every event in a trace genuinely is
+    published to the bus in the same flush batch. Only observed_at (real
+    occurrence time) should change; emitted_at stays uniform, same as the
+    pre-existing trace_started/trace_ended behavior."""
+    _install_fake_clock(monkeypatch)
+    collector = CortexExecGrammarCollector(
+        node_name=NODE, correlation_id=CORR, code_version="0.2.0", observed_at=FIXED_OBS,
+    )
+    _record_two_step_trace(collector)
+
+    events = build_cortex_exec_grammar_events(collector)
+    atom_events = [e for e in events if e.atom is not None]
+    emitted_ats = {e.emitted_at for e in atom_events}
+    assert len(emitted_ats) == 1, f"expected one shared emitted_at, got {emitted_ats}"
+
+
+def test_edge_observed_at_matches_target_atom_real_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_clock(monkeypatch)
+    collector = CortexExecGrammarCollector(
+        node_name=NODE, correlation_id=CORR, code_version="0.2.0", observed_at=FIXED_OBS,
+    )
+    _record_two_step_trace(collector)
+
+    events = build_cortex_exec_grammar_events(collector)
+    atom_observed_at = {e.atom.atom_id: e.observed_at for e in events if e.atom is not None}
+    edge_events = [e for e in events if e.edge is not None]
+    assert edge_events, "expected at least one edge in a two-step trace"
+    for edge_event in edge_events:
+        target_id = edge_event.edge.to_atom_id
+        assert target_id in atom_observed_at
+        assert edge_event.observed_at == atom_observed_at[target_id]
+
+
+def test_atom_missing_from_observed_at_map_falls_back_to_trace_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive fallback: if an atom somehow bypassed _put_atom() and has no
+    captured observed_at, use the collector's trace-start observed_at rather
+    than crashing or emitting None."""
+    _install_fake_clock(monkeypatch)
+    collector = CortexExecGrammarCollector(
+        node_name=NODE, correlation_id=CORR, code_version="0.2.0", observed_at=FIXED_OBS,
+    )
+    req = _minimal_plan(steps=1)
+    collector.record_request_received(req=req, mode="brain")
+    # Simulate a bypass: drop the captured timestamp for one real atom.
+    missing_atom_id = next(iter(collector._atoms.values())).atom_id
+    del collector._atom_observed_at[missing_atom_id]
+
+    events = build_cortex_exec_grammar_events(collector)
+    atom_event = next(e for e in events if e.atom is not None and e.atom.atom_id == missing_atom_id)
+    assert atom_event.observed_at == FIXED_OBS

--- a/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
+++ b/services/orion-cortex-exec/tests/test_exec_grammar_emit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from typing import get_args
 
 import pytest
@@ -307,23 +308,23 @@ def test_atom_types_are_allowed_literals() -> None:
             assert event.atom.atom_type in allowed
 
 
-def _install_fake_clock(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+def _install_fake_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     """Patch app.grammar_emit's datetime.now() to return strictly increasing,
     deterministic timestamps -- one tick per call -- so tests can assert real
-    ordering/distinctness without depending on wall-clock speed."""
+    ordering/distinctness without depending on wall-clock speed. A plain
+    SimpleNamespace stand-in, not a datetime subclass: grammar_emit.py never
+    constructs datetime(...) directly (only .now()), so nothing here needs
+    to preserve isinstance/type identity with the real datetime class."""
     import app.grammar_emit as ge
 
     counter = {"n": 0}
     base = datetime(2026, 5, 24, 12, 0, 0, tzinfo=timezone.utc)
 
-    class _FakeDatetime(datetime):
-        @classmethod
-        def now(cls, tz=None):  # noqa: ANN001 -- matches datetime.now's signature
-            counter["n"] += 1
-            return base + timedelta(milliseconds=counter["n"])
+    def _fake_now(tz: object = None) -> datetime:
+        counter["n"] += 1
+        return base + timedelta(milliseconds=counter["n"])
 
-    monkeypatch.setattr(ge, "datetime", _FakeDatetime)
-    return counter
+    monkeypatch.setattr(ge, "datetime", SimpleNamespace(now=_fake_now))
 
 
 def _record_two_step_trace(collector: CortexExecGrammarCollector) -> None:
@@ -403,6 +404,12 @@ def test_edge_observed_at_matches_target_atom_real_timestamp(
         target_id = edge_event.edge.to_atom_id
         assert target_id in atom_observed_at
         assert edge_event.observed_at == atom_observed_at[target_id]
+        # Self-consistency alone (edge == its own target atom) passes
+        # trivially even if the whole per-atom fix were reverted back to
+        # one shared value -- also assert against the pre-fix shared
+        # constant (trace-start observed_at) directly, so a revert fails
+        # this test too, not just its distinctness-focused sibling above.
+        assert edge_event.observed_at != FIXED_OBS
 
 
 def test_atom_missing_from_observed_at_map_falls_back_to_trace_start(
@@ -424,3 +431,67 @@ def test_atom_missing_from_observed_at_map_falls_back_to_trace_start(
     events = build_cortex_exec_grammar_events(collector)
     atom_event = next(e for e in events if e.atom is not None and e.atom.atom_id == missing_atom_id)
     assert atom_event.observed_at == FIXED_OBS
+
+
+def test_atom_time_range_populated_with_real_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GrammarAtomV1.time_range (orion/schemas/grammar.py) previously stayed
+    None for every cortex-exec atom -- orion/grammar/ledger.py wires it
+    through to persisted grammar_atoms.time_start/time_end, read by the live
+    Grammar Atlas API, so this was a second place the same 'timing is fake'
+    symptom survived even after observed_at was fixed on the sibling
+    GrammarEventV1 envelope. _put_atom() must now stamp it too, from the
+    same captured moment as _atom_observed_at."""
+    _install_fake_clock(monkeypatch)
+    collector = CortexExecGrammarCollector(
+        node_name=NODE, correlation_id=CORR, code_version="0.2.0", observed_at=FIXED_OBS,
+    )
+    _record_two_step_trace(collector)
+
+    events = build_cortex_exec_grammar_events(collector)
+    atom_events = [e for e in events if e.atom is not None]
+    assert atom_events
+    for event in atom_events:
+        assert event.atom.time_range is not None
+        assert event.atom.time_range.start == event.observed_at
+        assert event.atom.time_range.end == event.observed_at
+
+
+def test_trace_ended_observed_at_reflects_last_atom_not_trace_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before this fix: trace_ended.observed_at reused collector.observed_at
+    (trace-START time), identical to trace_started's -- the exact mechanism
+    behind orion/grammar/ledger.py's grammar_traces.started_at/ended_at
+    collapsing to zero duration. trace_ended must now reflect the real last
+    recorded atom's timestamp."""
+    _install_fake_clock(monkeypatch)
+    collector = CortexExecGrammarCollector(
+        node_name=NODE, correlation_id=CORR, code_version="0.2.0", observed_at=FIXED_OBS,
+    )
+    _record_two_step_trace(collector)
+
+    events = build_cortex_exec_grammar_events(collector)
+    trace_started = next(e for e in events if e.event_kind == "trace_started")
+    trace_ended = next(e for e in events if e.event_kind == "trace_ended")
+    atom_events = [e for e in events if e.atom is not None]
+
+    assert trace_started.observed_at == FIXED_OBS
+    assert trace_ended.observed_at != trace_started.observed_at
+    assert trace_ended.observed_at == max(e.observed_at for e in atom_events)
+
+
+def test_trace_ended_falls_back_to_trace_start_with_zero_atoms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A trace that fails before any record_*() call has no atoms to derive
+    a real end time from -- trace_ended must fall back to trace-start
+    observed_at rather than raising (max() on an empty sequence)."""
+    _install_fake_clock(monkeypatch)
+    collector = CortexExecGrammarCollector(
+        node_name=NODE, correlation_id=CORR, code_version="0.2.0", observed_at=FIXED_OBS,
+    )
+    events = build_cortex_exec_grammar_events(collector)
+    trace_ended = next(e for e in events if e.event_kind == "trace_ended")
+    assert trace_ended.observed_at == FIXED_OBS


### PR DESCRIPTION
## Summary

- Fixes a real, live-confirmed bug: every atom inside one `orion-cortex-exec`
  execution trace shared a single timestamp on `GrammarEventV1.observed_at`
  (captured once at trace-START, not "flush time" — see the correction note
  below), so intra-trace timing in the `grammar_events` Postgres corpus was
  fake. `CortexExecGrammarCollector` now captures a real wall-clock moment
  per atom (`_put_atom()`) and threads it into each event's `observed_at`
  field. `emitted_at` deliberately stays the shared flush-time value — it
  was never wrong (every event genuinely is published to the bus in the same
  flush batch).
- **Second round, following a `/code-review max` pass on the already-pushed
  first round** (see "Review findings fixed" below) — the first round's fix
  was correct but incomplete: it made `grammar_events.observed_at` real, but
  two adjacent, already-live consumers still showed fake timing:
  - `GrammarAtomV1.time_range` (an existing schema field, wired through by
    `orion/grammar/ledger.py` to persisted `grammar_atoms.time_start/time_end`
    and served by the live Grammar Atlas API) was never populated by this
    producer. `_put_atom()` now stamps it, from the same captured moment as
    `_atom_observed_at`.
  - `grammar_traces.started_at`/`ended_at` (same Atlas API) were derived
    from `event.emitted_at` (`orion/grammar/ledger.py`), not `observed_at` —
    so trace-level duration stayed fake even after the first round.
    `trace_ended.observed_at` now reflects the real last-recorded-atom
    time (was hardcoded to trace-start, identical to `trace_started`'s).
    `orion/grammar/ledger.py::_upsert_trace()` now prefers `observed_at`
    over `emitted_at` (via the already-existing `_created_at()` helper),
    safely for every grammar-event producer, not just cortex-exec.
- Also corrected: the first round's own "live-confirmed" evidence
  (`max(emitted_at)-min(emitted_at) = 0.00s`) was measured against the
  wrong field — `emitted_at` was never the buggy one. Re-verified live
  directly against `observed_at` (the actually-fixed field): also 0.0000s
  median pre-fix, so the underlying bug claim holds, but the field name/
  mechanism description in the source comment, spec, and this report were
  imprecise and are now corrected throughout.
- Test-file cleanup: removed an unnecessary `datetime` subclass in the
  fake-clock test helper (a plain callable works identically, verified
  empirically), removed its dead unused return value, and strengthened one
  test that previously passed trivially even if the whole fix were reverted.
- Design spec: `docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md`.
- 10 new/updated regression tests total across both rounds.
- Confirmed (not speculated) that `HarnessGrammarCollector`
  (`orion/harness/grammar_emit.py`) has the identical bug — tracked as a
  follow-up, explicitly out of scope for this patch.

## Outcome moved

`grammar_events` (5M+ real rows, 679K from `orion-cortex-exec` alone) is the
strongest raw-cognitive-signal substrate identified this session for a future
felt-state/trajectory corpus. This patch makes its intra-trace timing real —
both at the event level (`observed_at`) and at the two adjacent already-live
consumer surfaces (`grammar_atoms.time_start/time_end`, `grammar_traces.
started_at/ended_at`) that the first round missed.

## Current architecture

Before this patch: `CortexExecGrammarCollector.record_*` methods (9 total)
built `GrammarAtomV1` objects as pure data with no timestamp capture, stored
in `self._atoms`. `build_cortex_exec_grammar_events()` ran once at trace end,
using one shared trace-start value for every atom/edge event's `observed_at`,
and hardcoding `trace_ended.observed_at` to the same trace-start value.
`orion/grammar/ledger.py::_upsert_trace()` derived `grammar_traces.started_at`/
`ended_at` from `emitted_at` unconditionally.

## Architecture touched

`services/orion-cortex-exec/app/grammar_emit.py` (producer fix, both rounds),
`orion/grammar/ledger.py` (shared package — `_upsert_trace()` now prefers
`observed_at`, benefits every grammar-event producer, safe fallback to
`emitted_at` for producers without real `observed_at` yet, no regression for
them). No schema change (`orion/schemas/grammar.py` untouched —
`GrammarEventV1.observed_at` and `GrammarAtomV1.time_range` both already
existed, just were populated wrong/not at all). No env/compose/registry
changes.

## Files changed

- `services/orion-cortex-exec/app/grammar_emit.py`: `_atom_observed_at: dict[str, datetime]`
  on `CortexExecGrammarCollector`, keyed by `atom.atom_id`, populated in
  `_put_atom()` — which now also stamps `atom.time_range = TimeRangeV1(start=now, end=now)`
  from the same captured moment. All 9 `record_*` methods route through
  `_put_atom()`. `build_cortex_exec_grammar_events()`'s atom/edge loops use
  the real per-atom/per-edge-target timestamp for `observed_at` only;
  `trace_ended.observed_at` now derives from `max(_atom_observed_at.values())`
  (falls back to trace-start for a zero-atom trace). Source comments
  corrected to accurately describe trace-start vs. flush-time.
- `orion/grammar/ledger.py`: `_upsert_trace()` now computes `trace_ts = _created_at(event)`
  (reusing the existing helper, which already prefers `observed_at` over
  `emitted_at` over `now()`) instead of hardcoding `event.emitted_at` for
  both `started_at` and `ended_at`.
- `services/orion-cortex-exec/tests/test_exec_grammar_emit.py`: fake-clock
  helper simplified (`SimpleNamespace` instead of a `datetime` subclass,
  dead return value removed); `test_edge_observed_at_matches_target_atom_real_timestamp`
  strengthened with a direct inequality check against the old shared
  constant (previously only checked internal self-consistency, which passes
  even fully reverted); 3 new tests for `time_range` population and real
  `trace_ended` behavior (including the zero-atom fallback path).
- `orion/grammar/tests/test_ledger.py`: 2 new tests for `_upsert_trace()`
  preferring `observed_at`, with an explicit fallback-to-`emitted_at` test
  for producers without real `observed_at`.
- `docs/superpowers/specs/2026-07-14-cortex-exec-grammar-atom-wall-clock-spec.md`:
  corrected mechanism description (trace-start vs. flush-time), corrected
  live evidence (now cites the right field), confirmed harness sibling bug.

## Schema / bus / API changes

None. `GrammarEventV1.observed_at` and `GrammarAtomV1.time_range`
(`orion/schemas/grammar.py`) both pre-existed — this patch only changes
which values get written into already-existing fields.

## Env/config changes

None.

## Tests run

```text
.venv/bin/python -m pytest services/orion-cortex-exec/tests/test_exec_grammar_emit.py services/orion-cortex-exec/tests/test_exec_grammar_publish_fail_open.py -q
=> 16 passed

PYTHONPATH=services/orion-sql-writer:. .venv/bin/python -m pytest orion/grammar/tests/test_ledger.py -q
=> 5 passed

PYTHONPATH=services/orion-sql-writer:. .venv/bin/python -m pytest services/orion-sql-writer/tests/test_grammar_ledger_sql_shape.py -q
=> 1 passed

PYTHONPATH=services/orion-sql-writer:. .venv/bin/python -m pytest services/orion-sql-writer/tests/test_grammar_ledger_integration.py -q
=> 3 errors, all psycopg2.OperationalError connecting to localhost:5432 (the
   live DB in this environment is on port 55432, not 5432) -- a pre-existing
   environment/fixture-config issue, not caused by this patch. The one
   non-DB-dependent test in the sibling file (test_grammar_ledger_sql_shape.py)
   passes.

.venv/bin/python -m pytest services/orion-cortex-exec/tests -q
=> 12 pre-existing collection errors ("Verb already registered"), confirmed
   identical on a clean main checkout (verified via a fresh clone) --
   unrelated to this patch.
```

## Evals run

None applicable. `services/orion-cortex-exec/` has no `evals/` directory at
all (confirmed via directory listing) — no eval harness exists for this
service. Per CLAUDE.md section 11, flagging this explicitly rather than
silently: no eval harness added here (out of proportionate scope for a bug
fix), no follow-up issue filed yet — worth doing if/when this service gets
non-trivial cognition-relevant logic beyond grammar-event bookkeeping.

## Docker/build/smoke checks

Not run this session (no Docker access exercised). This patch changes
runtime behavior (what gets computed and persisted at execution time) but
not deployment topology (no env, port, volume, or dependency changes) — no
`docker compose build`/`config` check was run to validate the container
image itself; that layer is **UNVERIFIED**, distinct from the code-level
test coverage above, which is real and passing. Restart commands below are
required to actually pick up the change; the restart itself will be the
first real verification at that layer.

## Review findings fixed

**Round 1** (8-angle review before initial push): 7 of 8 angles returned zero
findings. The altitude angle found the confirmed `HarnessGrammarCollector`
sibling bug (see Risks/concerns) and a spec-accuracy gap, both fixed in the
spec doc.

**Round 2** (`/code-review max`, 10 angles + verify + sweep, run against the
already-pushed round 1 diff): 6 of 10 angles returned zero findings
(removed-behavior, cross-file, language-pitfall, wrapper/proxy, reuse,
efficiency). 4 angles found real, fixed issues:

- Finding (altitude angle, CONFIRMED): `orion/grammar/ledger.py`'s
  `grammar_traces.started_at`/`ended_at` derive from `emitted_at`, still
  fake after round 1's fix.
  - Fix: `_upsert_trace()` now prefers `observed_at` via the existing
    `_created_at()` helper; `trace_ended.observed_at` now reflects real
    last-atom time instead of trace-start.
  - Evidence: `test_trace_started_prefers_observed_at_over_emitted_at`,
    `test_trace_ended_observed_at_reflects_last_atom_not_trace_start`.
- Finding (altitude angle, CONFIRMED): `GrammarAtomV1.time_range` (existing
  field, wired to persisted columns and a live API) never populated.
  - Fix: `_put_atom()` now sets `atom.time_range` from the same captured
    timestamp as `_atom_observed_at`.
  - Evidence: `test_atom_time_range_populated_with_real_timestamp`.
- Finding (conventions angle, CONFIRMED): source comment, spec, and PR
  report described the pre-fix bug as "flush-time" and cited
  `max(emitted_at)-min(emitted_at)=0.00s` as proof — `emitted_at` was never
  the buggy field; the actually-fixed field (`observed_at`) was captured at
  trace-start, not flush-time.
  - Fix: comments/spec/this report corrected; re-verified live directly
    against `observed_at` (also 0.0000s median pre-fix on real data,
    confirming the underlying claim while fixing the mechanism description).
- Finding (test-quality angle, CONFIRMED):
  `test_edge_observed_at_matches_target_atom_real_timestamp` passed
  trivially even with the whole fix reverted (only checked internal
  self-consistency).
  - Fix: added a direct inequality assertion against the old shared
    constant.
- Finding (simplification angle, CONFIRMED, x2): unnecessary `datetime`
  subclass in the test fake-clock helper (verified empirically that a plain
  callable works identically); dead unused return value on the same helper.
  - Fix: both removed.
- Finding (conventions angle, PLAUSIBLE): PR report's Docker section
  self-contradicted its own Summary; evals-gap not disclosed.
  - Fix: both sections rewritten above.
- Finding (correctness angle, PLAUSIBLE, not fixed): a backward wall-clock
  step (NTP correction) between two `_put_atom()` calls in the same trace
  could theoretically produce non-monotonic `observed_at` ordering.
  - Disposition: not fixed — low realistic likelihood, low blast radius for
    a training-data/observability corpus (not a safety-critical path),
    added guard complexity not proportionate. Noted here for the record.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml up -d --build
```
Also restart `orion-sql-writer` (reads `orion/grammar/ledger.py`, a shared
module, so its running container needs the updated code too):
```bash
docker compose --env-file .env --env-file services/orion-sql-writer/.env \
  -f services/orion-sql-writer/docker-compose.yml up -d --build
```
Neither run this session — not deployed.

## Risks / concerns

- Severity: low
- Concern: `HarnessGrammarCollector` has the same event-level bug, confirmed,
  not fixed here; its `GrammarAtomV1.time_range` is presumably also
  unpopulated (not independently re-checked this round).
- Mitigation: tracked explicitly in project memory as a near-term follow-up.
- Severity: very low
- Concern: theoretical backward-clock non-monotonicity (see Review findings).
- Mitigation: accepted as-is, disproportionate to guard against for this
  corpus's actual use case.
