### PR TITLE
chore(concept-induction): observability logs for action-outcome tension extraction

### DIFF
--- a/orion/spark/concept_induction/bus_worker.py
+++ b/orion/spark/concept_induction/bus_worker.py
@@ -688,11 +688,20 @@ class ConceptWorker:
         except Exception:
             logger.warning("action_outcome_parse_failed kind=%s", env.kind)
             return []
-        return extract_tensions_from_action_outcome(
+        logger.info(
+            "action_outcome_received source=%s kind=%s action_id=%s success=%s",
+            source_name, outcome.kind, outcome.action_id, outcome.success,
+        )
+        result = extract_tensions_from_action_outcome(
             envelope=env,
             intake_channel=intake_channel,
             outcome=outcome,
         )
+        logger.info(
+            "action_outcome_tensions_extracted count=%d drive_impacts=%s",
+            len(result), [t.drive_impacts for t in result],
+        )
+        return result
 
     def _parse_signal(self, env: BaseEnvelope) -> Optional[OrionSignalV1]:
         try:


### PR DESCRIPTION
## Summary

Added while live-verifying P3's satisfaction-tension pipeline for the first time ever (P1's real send was DOA until PR #1039 fixed it earlier today). `_tensions_from_action_outcome` had no success-path logging, only a warning on parse failure, so confirming the pipeline actually fires required a temporary debug patch and a live watch.

Kept two low-noise permanent INFO lines: what action outcome came in, what tension it produced. Dropped a third, more verbose top-level diagnostic that was only useful for this session's debugging.

## Live verification

A real `inspect` dispatch's outcome produced exactly the expected tension: `drive_impacts={'coherence': -0.1}` — confirming the full P1 (real send) → P2 (outcome emit) → P3 (satisfaction relief) chain works end-to-end for the first time.

## Tests run

```
pytest orion/spark/concept_induction/tests/test_action_outcome_tensions.py -q
7 passed
```