### PR TITLE
feat: worktree hygiene tooling (status, prune, creation, hooks)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,18 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/session_start_worktree_summary.py\"",
+            "timeout": 25
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,14 @@ Already have uncommitted work sitting in the shared checkout when you realize th
 
 New clone, or a worktree where the hook doesn't seem to be firing? Run `scripts/install_git_safety_hooks.sh .` once — hooks live in the shared common git dir, so this protects every worktree of the repo, not just the one it's run from. Full rationale and the incident that prompted this: `docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md`.
 
+This repo actually has three worktree location conventions in live use, not one — worth knowing when you're trying to figure out where a piece of work already lives, or why `git worktree list` shows paths that don't look like the pattern above:
+
+- **`../Orion-Sapienform-<name>`** (sibling directory) — the pattern shown above, the only one this file documented until a live worktree-count audit turned up the other two. Use `scripts/new_worktree.sh <type> <name>` to create one; it also warns if a worktree mentioning the same name already exists under either convention below.
+- **`.worktrees/<name>`** (nested inside the main checkout, gitignored) — driven by other tooling in this environment, not by anything in `scripts/`. Left alone; not something a manual `git worktree add` should imitate.
+- **`.claude/worktrees/agent-<id>`** — Claude Code's own `isolation: "worktree"` Agent-tool feature, auto-created per dispatched agent when that option is used. Also left alone.
+
+Regardless of which convention created it, `git worktree list` sees all of them, and so does this repo's cleanup tooling — `make worktree-status` (add `BASE=<branch>` to compare against something other than `origin/main`), `make worktree-status-stale` (merged worktrees with no open PR — the actual prune candidates), and `make prune-merged-worktrees` (dry-run by default; `YES=1` to actually remove — never force-removes a worktree with uncommitted changes, and never touches the branch itself, only the worktree directory). A `post-merge` hook (installed by the same `scripts/install_git_safety_hooks.sh` above) prints a one-line reminder of how many worktrees are now prunable after every merge, and a `SessionStart` hook does the same at the top of every session.
+
 Branch type examples:
 
 ```text

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions
+.PHONY: test test-hub test-actions bootstrap-test-envs check-inner-state-registry check-single-consumer-channels check-activation-saturation concept-relation-digest check-concept-relation-digest-liveness check-env-compose-parity check-journal-dispatch-registry check-daily-schedule-collisions worktree-status worktree-status-summary worktree-status-stale prune-merged-worktrees
 
 SERVICE ?=
 ARGS ?=
@@ -87,3 +87,24 @@ check-journal-dispatch-registry:
 # this isn't a hard gate today.
 check-daily-schedule-collisions:
 	@python scripts/check_daily_schedule_collisions.py $(if $(THRESHOLD_MINUTES),--threshold-minutes $(THRESHOLD_MINUTES),) $(if $(FAIL_ON_COLLISION),--fail-on-collision,)
+
+# Reconciled worktree view -- path, branch, merged-into-main status, open PR,
+# disk size -- regardless of which of this repo's several worktree location
+# conventions (sibling dir, .worktrees/, .claude/worktrees/agent-<id>) each
+# one uses. See scripts/worktree_status.py.
+# BASE overrides the branch merge status is compared against (default:
+# origin/main) -- e.g. `make worktree-status BASE=origin/release`.
+worktree-status:
+	@python3 scripts/worktree_status.py $(if $(BASE),--base $(BASE),)
+
+worktree-status-summary:
+	@python3 scripts/worktree_status.py --summary $(if $(BASE),--base $(BASE),)
+
+worktree-status-stale:
+	@python3 scripts/worktree_status.py --stale-only $(if $(BASE),--base $(BASE),)
+
+# Dry-run by default; pass YES=1 to actually remove merged worktrees. Never
+# force-removes a worktree with uncommitted changes -- see
+# scripts/prune_merged_worktrees.py.
+prune-merged-worktrees:
+	@python3 scripts/prune_merged_worktrees.py $(if $(YES),--yes,) $(if $(BASE),--base $(BASE),)

--- a/docs/superpowers/pr-reports/2026-07-14-worktree-hygiene-tooling-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-worktree-hygiene-tooling-pr.md
@@ -1,0 +1,115 @@
+# PR report: worktree hygiene tooling (status, prune, creation, hooks)
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1046
+Branch: `chore/worktree-hygiene-tooling`
+
+## Summary
+
+- `scripts/worktree_lib.py`: shared helpers (`list_worktrees`, `merged_branch_set`, `all_open_prs`, `dir_size_bytes`, `parallel_map`) used by every consumer below.
+- `scripts/worktree_status.py`: reconciled table view (path, branch, merged status, open PR, disk size) across all worktree location conventions.
+- `scripts/prune_merged_worktrees.py`: dry-run by default; `--yes` removes worktrees whose branch is merged into main. Never force-removes, never touches branches.
+- `scripts/new_worktree.sh`: one front door for creating a sibling-directory worktree, with a cross-convention collision warning and a helpful error when the branch already exists.
+- `scripts/git_hooks/post-merge` + `scripts/hooks/session_start_worktree_summary.py`: advisory nudges after every merge and at the start of every session.
+- `CLAUDE.md`: documents all three worktree conventions this repo actually has, not just the one it previously described.
+
+## Outcome moved
+
+A live audit (not a guess) found **276 worktrees** under `/mnt/scripts/`, of which **248 are already merged into main and never cleaned up** (~25GB reclaimable), and only 26 represent active work. It also found **three simultaneously-used worktree location conventions** — sibling directories (65, the only one CLAUDE.md documented), `.worktrees/` (186, from other tooling), and `.claude/worktrees/agent-<id>` (15+, Claude Code's own `isolation: worktree` Agent-tool feature) — meaning the fragmentation problem this was built to address was less "agents ignore the policy" and more "worktree creation has three uncoordinated paths, and lifecycle (discovery, cleanup) had zero."
+
+## Current architecture
+
+Before this PR: no worktree cleanup tooling existed anywhere in `scripts/`. `graphify prs --worktrees` gave manual, on-demand visibility but nothing wired it into any automated workflow. CLAUDE.md documented one of three real worktree conventions.
+
+## Architecture touched
+
+`scripts/`, `scripts/hooks/`, `scripts/git_hooks/`, `tests/scripts/`, `Makefile`, `.claude/settings.json`, `CLAUDE.md`. Pure tooling — no service boundaries touched.
+
+## Files changed
+
+- `scripts/worktree_lib.py`: new, shared helpers.
+- `scripts/worktree_status.py`, `scripts/prune_merged_worktrees.py`, `scripts/new_worktree.sh`: new.
+- `scripts/git_hooks/post-merge`, `scripts/hooks/session_start_worktree_summary.py`: new hooks.
+- `scripts/install_git_safety_hooks.sh`: refactored from a single hardcoded pre-commit-install block into a loop that installs both `pre-commit` and `post-merge`.
+- `Makefile`: 4 new targets (`worktree-status`, `worktree-status-summary`, `worktree-status-stale`, `prune-merged-worktrees`), each accepting `BASE=` to override the default `origin/main` comparison.
+- `.claude/settings.json`: new `SessionStart` hook entry.
+- `CLAUDE.md`: documents all three worktree conventions and the new tooling.
+- `tests/scripts/`: `conftest.py` (shared fixtures) + 7 test files, 125 tests total.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```
+/mnt/scripts/Orion-Sapienform/orion_dev/bin/pytest tests/scripts/ -q
+125 passed in 19.47s
+```
+
+## Evals run
+
+None — no eval harness applies to this class of tooling script; same rationale as the destructive-git-guard PR (#1041).
+
+## Docker/build/smoke checks
+
+Not applicable — no runtime/service surface touched.
+
+## Live verification (real data, not synthetic-only)
+
+All of the following were run against this repo's real, current worktree state (not just the synthetic-fixture test suite):
+
+- `worktree_status.py --summary`: 0.152s for 278 worktrees.
+- `worktree_status.py` (full table, batched PR lookup): **1.3s**, down from a measured **~2.5 minutes** with the original per-worktree `gh pr list` design (caught in review — see below).
+- `prune_merged_worktrees.py` (dry-run, parallel `du`): **0.78s**, down from a measured **8.7s** sequential.
+- `install_git_safety_hooks.sh`: installed both hooks fresh, then re-ran to confirm idempotent refresh of both, against a throwaway repo (not this one).
+- `new_worktree.sh`: created and removed a real test worktree; confirmed the collision warning fires against this repo's real worktree list.
+
+## Review findings fixed
+
+Ran `code-review` at high effort (8 parallel finder angles). ~20 findings across correctness, reuse, simplification, efficiency, altitude, and CLAUDE.md conventions. Highest-severity fixed:
+
+- **Finding (reuse, most severe)**: `open_pr_for_branch()` shelled out to `gh pr list --head <branch>` once *per worktree* — 276 separate subprocess+network round trips (measured ~2.5 min), and a transient failure on any single one silently reported that worktree as "no open PR," which `--stale-only` would then treat as a genuine prune candidate.
+  - **Fix**: `all_open_prs()` — one `gh pr list --state open` call, mapped locally by branch. Returns `None` (not `{}`) on failure, so callers can distinguish "no open PRs" from "PR data unavailable." `--stale-only` now refuses to report (exit 1) rather than silently treating unknown-PR-status worktrees as stale.
+  - **Evidence**: `test_all_open_prs_returns_none_when_gh_has_no_remote`, `test_stale_only_refuses_when_pr_data_unavailable`, live timing above.
+- **Finding**: `prune_merged_worktrees.py`'s `du` calls were sequential (measured 8.8s at 248 worktrees) while `worktree_status.py`'s identical operation was already parallelized.
+  - **Fix**: extracted `parallel_map()` into `worktree_lib.py`, used by both.
+- **Finding**: `list_worktrees()`/`merged_branch_set()` had no error handling, unlike every other helper — a failure (bad ref, git unavailable) would either raise an uncaught traceback or (for a since-fixed version of `merged_branch_set`) silently return an empty set indistinguishable from "genuinely nothing merged."
+  - **Fix**: both now raise `WorktreeLibError` on failure; callers catch it and print a clean `[tool-name] ERROR: ...` message instead of a traceback or a misleading "all clear."
+  - **Evidence**: `test_list_worktrees_raises_outside_any_repo`, `test_merged_branch_set_raises_on_bad_base`, `test_bad_base_ref_reports_error_not_traceback`.
+- **Finding**: `dir_size_bytes()` used `du -sb`, a GNU-only flag that fails silently (swallowed by a bare `except`) on BSD/macOS `du`.
+  - **Fix**: switched to the portable `du -sk` (POSIX-ish, widely supported), converting KB to bytes.
+- **Finding**: `install_git_safety_hooks.sh`'s source-hook-existence check moved (during the pre-commit/post-merge refactor) from before any mutation to inside the per-hook install function — a missing source hook now creates a `mkdir -p` side effect (an empty custom hooks dir) before erroring, when the original script failed clean.
+  - **Fix**: both source hooks are validated to exist before `mkdir -p` runs at all.
+- **Finding**: `new_worktree.sh` only implements 1 of 3 real worktree conventions and had no awareness of the other two, risking silently creating a duplicate attempt at work already in progress under a different convention.
+  - **Fix**: added a `git worktree list`-based warning (not a hard block, since it's a heuristic) when an existing worktree's path or branch already mentions the requested name.
+  - **Evidence**: `test_warns_on_name_collision_with_existing_worktree`.
+- **Finding**: `session_start_worktree_summary.py` shelled out to a second `python3` process running `worktree_status.py --summary` purely to get a one-line string, adding a full duplicate interpreter startup (measured ~50ms) on every SessionStart firing, including every subagent spawn.
+  - **Fix**: imports `worktree_lib` directly and builds the summary inline; also fixed the resulting timeout-headroom issue (inner subprocess timeout equaled the outer hook's own timeout, leaving zero margin).
+- **Finding (test coverage)**: `worktree_status.py`'s own CLI logic (argparse, `--stale-only` filter, row assembly) and the new SessionStart hook had zero dedicated tests.
+  - **Fix**: added `test_worktree_status.py` (9 tests) and `test_session_start_worktree_summary.py` (3 tests).
+- **Finding (simplification)**: the `repo_with_worktrees` fixture and a `_git` helper were duplicated near-verbatim across 3 test files; one test duplicated another's coverage.
+  - **Fix**: extracted `tests/scripts/conftest.py`; removed the redundant test.
+- **Finding (CLAUDE.md conventions)**: shipping worktree tooling without correcting CLAUDE.md's incomplete (1-of-3-conventions) documentation in the same changeset violates this repo's own "runtime truth beats config truth" principle.
+  - **Fix**: added a truthful section documenting all three conventions and the new tooling.
+
+Minor, lower-severity findings not separately chased (documented, not silent): `git worktree remove` now anchors with `-C <toplevel>` (was relying on ambient cwd, latent not live); Makefile targets gained a `BASE=` override for consistency with `check-daily-schedule-collisions`'s existing pattern; a single pathological worktree's `du` call can still gate the full-table command's total runtime (bounded by the existing 30s timeout, not fixed further — diminishing returns for a manually-invoked command).
+
+## Restart required
+
+```text
+No restart required. .claude/settings.json is read per-session; a new session picks up the SessionStart hook automatically once this branch is merged. Run `scripts/install_git_safety_hooks.sh .` once per existing checkout to pick up the new post-merge hook (same as any other hook update).
+```
+
+## Risks / concerns
+
+- Severity: Low. `new_worktree.sh` only automates 1 of 3 real worktree conventions (by design — it targets the one AGENTS.md documents); review flagged that this doesn't reduce fragmentation on its own, only adds a consistent front door for the minority case. The collision-warning fix mitigates the sharpest risk (silent duplicate work) without attempting to unify all three mechanisms, which was out of scope for this PR.
+- Severity: Low. A single pathological worktree (unusually large, e.g. from accumulated build artifacts) can still gate the full-table/`--stale-only` command's total runtime up to the 30s per-item timeout, since results are collected via a blocking `list(pool.map(...))` rather than streamed. Not fixed given the class of command this affects (manually-invoked, not session-start-blocking).
+- Severity: Low. Comment/quote handling in `new_worktree.sh`'s collision-detection grep is a simple substring match, not exact — could produce false-positive warnings for coincidentally-similar names. Errs toward over-warning, not silent duplication.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1046

--- a/scripts/git_hooks/post-merge
+++ b/scripts/git_hooks/post-merge
@@ -1,0 +1,20 @@
+#!/bin/sh
+# orion-git-safety-guard (post-merge)
+#
+# Advisory-only nudge: after a merge completes (in ANY worktree -- `git
+# worktree list` is repo-wide, not worktree-scoped, so this doesn't need to
+# gate on shared-vs-linked checkout the way pre-commit does), prints a count
+# of worktrees whose branch is now merged and have no open PR, i.e. safe
+# candidates for `python3 scripts/prune_merged_worktrees.py`.
+#
+# Never blocks anything and never fails the merge it fires on -- if python3
+# isn't reachable, or the script errors, this hook silently does nothing.
+#
+# POSIX sh only -- no bashisms.
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -f "$REPO_ROOT/scripts/worktree_status.py" ] || exit 0
+
+command -v python3 >/dev/null 2>&1 || exit 0
+
+python3 "$REPO_ROOT/scripts/worktree_status.py" --summary 2>/dev/null || true

--- a/scripts/hooks/session_start_worktree_summary.py
+++ b/scripts/hooks/session_start_worktree_summary.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""SessionStart hook: surfaces a one-line worktree-hygiene summary (total /
+merged counts) as additionalContext at the start of every session, so that
+visibility doesn't depend on anyone remembering to run `graphify prs
+--worktrees` or `worktree_status.py` by hand.
+
+Imports worktree_lib directly rather than subprocessing to
+worktree_status.py -- this used to shell out to a second python3 process
+purely to get a one-line string, adding a full duplicate interpreter
+startup (measured ~50ms) on every firing, including every subagent spawn.
+
+Fails silently (no output) on any error -- never blocks session start.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from worktree_lib import WorktreeLibError, mergeable_worktrees  # noqa: E402
+
+
+def main() -> None:
+    try:
+        worktrees, merged_set = mergeable_worktrees()
+    except WorktreeLibError:
+        return
+
+    merged_count = sum(1 for w in worktrees if w.branch in merged_set)
+    summary = (
+        f"worktrees: {len(worktrees)} total, {merged_count} merged into origin/main "
+        f"(candidates for: python3 scripts/prune_merged_worktrees.py)."
+    )
+
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": summary,
+        }
+    }
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_git_safety_hooks.sh
+++ b/scripts/install_git_safety_hooks.sh
@@ -2,10 +2,10 @@
 # orion-git-safety-guard installer
 #
 # Installs scripts/git_hooks/pre-commit (the shared/primary-checkout guard)
-# into the correct git hooks directory for a repo -- respecting
-# core.hooksPath when it's configured, and resolving linked-worktree hook
-# locations correctly (hooks live in the shared/common git dir, not
-# per-worktree).
+# and scripts/git_hooks/post-merge (the worktree-hygiene nudge) into the
+# correct git hooks directory for a repo -- respecting core.hooksPath when
+# it's configured, and resolving linked-worktree hook locations correctly
+# (hooks live in the shared/common git dir, not per-worktree).
 #
 # Usage:
 #   scripts/install_git_safety_hooks.sh [target-repo-dir]
@@ -19,13 +19,6 @@
 set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-SOURCE_HOOK="$SCRIPT_DIR/git_hooks/pre-commit"
-
-if [ ! -f "$SOURCE_HOOK" ]; then
-    echo "[install-git-safety-hooks] ERROR: source hook not found at $SOURCE_HOOK" >&2
-    exit 1
-fi
-
 TARGET_DIR=${1:-.}
 
 if [ ! -d "$TARGET_DIR" ]; then
@@ -81,39 +74,58 @@ else
     HOOKS_DIR="$COMMON_DIR/hooks"
 fi
 
+# Validate both source hooks exist BEFORE any mutation (mkdir -p below) --
+# failing here must not leave a side effect like a freshly-created, empty
+# custom hooks directory behind.
+for _hook_name in pre-commit post-merge; do
+    if [ ! -f "$SCRIPT_DIR/git_hooks/$_hook_name" ]; then
+        echo "[install-git-safety-hooks] ERROR: source hook not found at $SCRIPT_DIR/git_hooks/$_hook_name" >&2
+        exit 1
+    fi
+done
+
 mkdir -p "$HOOKS_DIR"
 
-DEST_HOOK="$HOOKS_DIR/pre-commit"
-MARKER="# orion-git-safety-guard"
+install_one_hook() {
+    local HOOK_NAME="$1"
+    local SOURCE_HOOK="$SCRIPT_DIR/git_hooks/$HOOK_NAME"
+    local DEST_HOOK="$HOOKS_DIR/$HOOK_NAME"
+    local MARKER="# orion-git-safety-guard"
+    local BACKUP
 
-# Refuse to write through an existing symlink rather than silently following
-# it -- a symlinked hooks dir (e.g. dotfiles/chezmoi-managed hooks) would
-# otherwise get its *target* file overwritten, which can live outside this
-# repo entirely and outside what an operator expects this script to touch.
-if [ -L "$DEST_HOOK" ]; then
-    echo "[install-git-safety-hooks] ERROR: $DEST_HOOK is a symlink (-> $(readlink "$DEST_HOOK" 2>/dev/null || echo '?'))." >&2
-    echo "  Refusing to write through it. Remove the symlink or point it at" >&2
-    echo "  $SOURCE_HOOK yourself, then re-run this script." >&2
-    exit 1
-fi
+    # Refuse to write through an existing symlink rather than silently
+    # following it -- a symlinked hooks dir (e.g. dotfiles/chezmoi-managed
+    # hooks) would otherwise get its *target* file overwritten, which can
+    # live outside this repo entirely and outside what an operator expects
+    # this script to touch.
+    if [ -L "$DEST_HOOK" ]; then
+        echo "[install-git-safety-hooks] ERROR: $DEST_HOOK is a symlink (-> $(readlink "$DEST_HOOK" 2>/dev/null || echo '?'))." >&2
+        echo "  Refusing to write through it. Remove the symlink or point it at" >&2
+        echo "  $SOURCE_HOOK yourself, then re-run this script." >&2
+        exit 1
+    fi
 
-if [ -f "$DEST_HOOK" ] && grep -qF "$MARKER" "$DEST_HOOK" 2>/dev/null; then
-    # Already our hook -- always refresh to the current version rather than
-    # skipping, so a later fix to scripts/git_hooks/pre-commit actually
-    # reaches an already-installed checkout when this script is re-run.
+    if [ -f "$DEST_HOOK" ] && grep -qF "$MARKER" "$DEST_HOOK" 2>/dev/null; then
+        # Already our hook -- always refresh to the current version rather
+        # than skipping, so a later fix to the source hook actually reaches
+        # an already-installed checkout when this script is re-run.
+        cp "$SOURCE_HOOK" "$DEST_HOOK"
+        chmod +x "$DEST_HOOK"
+        echo "[install-git-safety-hooks] refreshed orion git-safety $HOOK_NAME hook at $DEST_HOOK"
+        return 0
+    fi
+
+    if [ -f "$DEST_HOOK" ]; then
+        BACKUP="$HOOKS_DIR/$HOOK_NAME.pre-orion-safety.bak"
+        cp "$DEST_HOOK" "$BACKUP"
+        echo "[install-git-safety-hooks] existing $HOOK_NAME hook at $DEST_HOOK preserved as $BACKUP -- merge the two by hand if the old hook did something you still need" >&2
+    fi
+
     cp "$SOURCE_HOOK" "$DEST_HOOK"
     chmod +x "$DEST_HOOK"
-    echo "[install-git-safety-hooks] refreshed orion git-safety pre-commit hook at $DEST_HOOK"
-    exit 0
-fi
 
-if [ -f "$DEST_HOOK" ]; then
-    BACKUP="$HOOKS_DIR/pre-commit.pre-orion-safety.bak"
-    cp "$DEST_HOOK" "$BACKUP"
-    echo "[install-git-safety-hooks] existing pre-commit hook at $DEST_HOOK preserved as $BACKUP -- merge the two by hand if the old hook did something you still need" >&2
-fi
+    echo "[install-git-safety-hooks] installed orion git-safety $HOOK_NAME hook at $DEST_HOOK"
+}
 
-cp "$SOURCE_HOOK" "$DEST_HOOK"
-chmod +x "$DEST_HOOK"
-
-echo "[install-git-safety-hooks] installed orion git-safety pre-commit hook at $DEST_HOOK"
+install_one_hook pre-commit
+install_one_hook post-merge

--- a/scripts/new_worktree.sh
+++ b/scripts/new_worktree.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# One obvious front door for creating a worktree, matching the sibling-
+# directory convention AGENTS.md section 2 documents (as opposed to the
+# other two legitimate-but-undocumented-here patterns this repo also has:
+# .worktrees/ and .claude/worktrees/agent-<id>, both driven by other
+# tooling this script doesn't touch or replace).
+#
+# Usage:
+#   scripts/new_worktree.sh <type> <name>
+#
+# Example:
+#   scripts/new_worktree.sh feat my-thing
+#   -> creates ../Orion-Sapienform-my-thing on branch feat/my-thing
+#
+# type must be one of: feat fix chore docs test (matches AGENTS.md section 2's
+# branch type examples).
+
+set -e
+
+TYPE="$1"
+NAME="$2"
+
+if [ -z "$TYPE" ] || [ -z "$NAME" ]; then
+    echo "Usage: scripts/new_worktree.sh <type> <name>" >&2
+    echo "  type: feat | fix | chore | docs | test" >&2
+    exit 1
+fi
+
+case "$TYPE" in
+    feat|fix|chore|docs|test) ;;
+    *)
+        echo "error: type must be one of feat, fix, chore, docs, test (got: $TYPE)" >&2
+        exit 1
+        ;;
+esac
+
+case "$NAME" in
+    *[!a-zA-Z0-9_-]*)
+        echo "error: name must contain only letters, digits, - and _ (got: $NAME)" >&2
+        exit 1
+        ;;
+esac
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+REPO_NAME=$(basename "$REPO_ROOT")
+TARGET_DIR="$(dirname "$REPO_ROOT")/${REPO_NAME}-${NAME}"
+BRANCH="${TYPE}/${NAME}"
+
+if [ -e "$TARGET_DIR" ]; then
+    echo "error: $TARGET_DIR already exists" >&2
+    exit 1
+fi
+
+# This script only ever creates the sibling-directory convention -- it does
+# NOT unify or replace the other two worktree location patterns this repo
+# also has (.worktrees/, .claude/worktrees/agent-<id>, both driven by other
+# tooling). Warn, not block, if a worktree whose path or branch already
+# mentions this name exists under ANY convention, so a second attempt at
+# the same task under a different mechanism doesn't happen silently.
+_EXISTING=$(git -C "$REPO_ROOT" worktree list --porcelain | grep -iE "(^worktree .*${NAME}|^branch .*${NAME})" || true)
+if [ -n "$_EXISTING" ]; then
+    echo "warning: a worktree already mentions \"$NAME\" -- check this isn't a duplicate of existing work:" >&2
+    echo "$_EXISTING" | sed 's/^/  /' >&2
+    echo "" >&2
+fi
+
+_STDERR_TMP=$(mktemp)
+trap 'rm -f "$_STDERR_TMP"' EXIT
+
+if ! git -C "$REPO_ROOT" worktree add "$TARGET_DIR" -b "$BRANCH" 2>"$_STDERR_TMP"; then
+    if grep -q "already exists" "$_STDERR_TMP" 2>/dev/null; then
+        echo "error: branch $BRANCH already exists. If its worktree was already pruned" >&2
+        echo "  (see scripts/prune_merged_worktrees.py), reuse it with:" >&2
+        echo "    git worktree add $TARGET_DIR $BRANCH" >&2
+        echo "  or delete the stale branch first with: git branch -d $BRANCH" >&2
+    else
+        cat "$_STDERR_TMP" >&2
+    fi
+    exit 1
+fi
+
+echo ""
+echo "Created. Next:"
+echo "  cd $TARGET_DIR"

--- a/scripts/prune_merged_worktrees.py
+++ b/scripts/prune_merged_worktrees.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Lists (and, with --yes, removes) worktrees whose branch is already merged
+into origin/main.
+
+Dry-run by default -- prints what *would* be removed. Pass --yes to actually
+run `git worktree remove` on each one. Never passes --force to `git worktree
+remove`: a worktree with uncommitted changes is left alone and reported as
+skipped, not force-deleted, even if its branch is merged -- an agent (or a
+human) may have left real work sitting there uncommitted.
+
+Only removes the worktree directory, never the branch itself (`git branch
+-d`/`-D`). Branch cleanup is a separate, more sensitive decision left to a
+human or a future, explicitly-scoped tool.
+
+Usage:
+    python3 scripts/prune_merged_worktrees.py              # dry run
+    python3 scripts/prune_merged_worktrees.py --yes         # actually remove
+    python3 scripts/prune_merged_worktrees.py --base main   # different base
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from worktree_lib import (  # noqa: E402
+    WorktreeLibError,
+    dir_size_bytes,
+    human_size,
+    mergeable_worktrees,
+    parallel_map,
+    repo_toplevel,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--yes", action="store_true", help="actually remove, not just report")
+    parser.add_argument("--base", default="origin/main", help="branch to compare merge status against")
+    args = parser.parse_args()
+
+    try:
+        worktrees, merged_set = mergeable_worktrees(base=args.base)
+        toplevel = repo_toplevel()
+    except WorktreeLibError as exc:
+        print(f"[prune-merged-worktrees] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    mergeable = [w for w in worktrees if w.branch in merged_set]
+
+    if not mergeable:
+        print(f"No worktrees found whose branch is merged into {args.base}.")
+        return 0
+
+    sizes = parallel_map(lambda w: dir_size_bytes(w.path), mergeable)
+
+    total_bytes = 0
+    removed, skipped = 0, 0
+    for w, size in zip(mergeable, sizes):
+        total_bytes += size or 0
+        label = f"{w.path}  (branch: {w.branch}, {human_size(size)})"
+        if not args.yes:
+            print(f"[would remove] {label}")
+            continue
+        result = subprocess.run(
+            ["git", "-C", toplevel, "worktree", "remove", str(w.path)],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            print(f"[removed] {label}")
+            removed += 1
+        else:
+            print(f"[skipped, not removed] {label} -- {result.stderr.strip()}")
+            skipped += 1
+
+    print()
+    if args.yes:
+        print(f"Removed {removed}, skipped {skipped} (uncommitted changes or other git refusal).")
+    else:
+        print(f"{len(mergeable)} worktree(s) merged into {args.base}, ~{human_size(total_bytes)} reclaimable.")
+        print("Re-run with --yes to actually remove them.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/worktree_lib.py
+++ b/scripts/worktree_lib.py
@@ -1,0 +1,194 @@
+"""Shared helpers for worktree hygiene tooling (prune, status, post-merge nudge,
+SessionStart hook).
+
+Deliberately one importable module rather than duplicated logic per script --
+unlike scripts/git_hooks/pre-commit's shared-checkout detection, which git
+forces to be byte-for-byte duplicated because git copies hook files verbatim
+into .git/hooks/ with no import path back into this repo. None of the
+consumers here are copied that way, so they import this normally.
+
+Failure philosophy: git-level lookups (list_worktrees, merged_branch_set)
+raise a WorktreeLibError on failure rather than silently returning an empty
+result -- an empty *result* (no worktrees, no merged branches) must stay
+distinguishable from a *failed lookup* (bad ref, git not on PATH, timeout),
+since callers make real decisions (prune candidates, "safe to delete") off
+these. Per-worktree lookups that are expected to sometimes legitimately have
+no answer (disk size of a path that vanished mid-scan) still fail soft to
+None -- see dir_size_bytes.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, TypeVar
+
+_T = TypeVar("_T")
+_R = TypeVar("_R")
+
+_GIT_TIMEOUT = 10
+
+
+class WorktreeLibError(RuntimeError):
+    """Raised when a git-level lookup fails outright (not: 'found nothing')."""
+
+
+@dataclass
+class WorktreeInfo:
+    path: Path
+    branch: str | None  # None for a detached-HEAD worktree
+    is_main: bool
+
+
+def repo_toplevel() -> str:
+    """Resolves the repo root so callers (e.g. `git worktree remove`) can
+    anchor with `-C` explicitly instead of relying on the ambient cwd being
+    inside some worktree of the target repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=_GIT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise WorktreeLibError("'git rev-parse --show-toplevel' timed out") from exc
+    if result.returncode != 0:
+        raise WorktreeLibError(f"'git rev-parse --show-toplevel' failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def list_worktrees() -> list[WorktreeInfo]:
+    """Lists every worktree registered for this repo, regardless of which
+    location convention it uses (sibling directories, .worktrees/,
+    .claude/worktrees/agent-<id>, etc). `git worktree list` is repo-wide,
+    not scoped to the worktree it's invoked from, so this returns the same
+    result no matter which worktree calls it. Git always lists the main
+    worktree first.
+
+    Raises WorktreeLibError if the underlying git command fails or times
+    out -- callers should catch this and report clearly rather than let an
+    empty list masquerade as "this repo has no worktrees"."""
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, timeout=_GIT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise WorktreeLibError(f"'git worktree list' timed out after {_GIT_TIMEOUT}s") from exc
+    if result.returncode != 0:
+        raise WorktreeLibError(f"'git worktree list' failed: {result.stderr.strip()}")
+
+    infos: list[WorktreeInfo] = []
+    path: Path | None = None
+    branch: str | None = None
+    for line in result.stdout.splitlines() + [""]:
+        if line.startswith("worktree "):
+            path = Path(line[len("worktree "):])
+            branch = None
+        elif line.startswith("branch "):
+            branch = line[len("branch "):].removeprefix("refs/heads/")
+        elif line == "" and path is not None:
+            infos.append(WorktreeInfo(path=path, branch=branch, is_main=False))
+            path = None
+    if infos:
+        infos[0].is_main = True
+    return infos
+
+
+def merged_branch_set(base: str = "origin/main") -> set[str]:
+    """One `git branch --merged` call instead of one `git merge-base` per
+    worktree -- at this repo's real scale (276 worktrees when this was
+    written), N subprocess spawns for a single SessionStart-hook summary is
+    the difference between instant and a multi-second startup stall.
+
+    Raises WorktreeLibError on failure (bad --base ref, no such branch,
+    timeout) rather than returning an empty set -- an empty set must mean
+    'genuinely zero merged branches', not 'the lookup itself failed', since
+    prune_merged_worktrees.py treats an empty result as "nothing to do"."""
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--merged", base, "--format=%(refname:short)"],
+            capture_output=True, text=True, timeout=_GIT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise WorktreeLibError(f"'git branch --merged {base}' timed out after {_GIT_TIMEOUT}s") from exc
+    if result.returncode != 0:
+        raise WorktreeLibError(f"'git branch --merged {base}' failed: {result.stderr.strip()}")
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def mergeable_worktrees(base: str = "origin/main") -> tuple[list[WorktreeInfo], set[str]]:
+    """Shared 'which worktrees exist, which branches are merged' setup used
+    by both prune_merged_worktrees.py and worktree_status.py -- factored out
+    so a future change (e.g. excluding detached-HEAD worktrees) only needs
+    to land in one place."""
+    worktrees = [w for w in list_worktrees() if not w.is_main]
+    merged_set = merged_branch_set(base=base)
+    return worktrees, merged_set
+
+
+def dir_size_bytes(path: Path) -> int | None:
+    """Fails soft to None -- unlike list_worktrees/merged_branch_set, a
+    missing size for one worktree (vanished mid-scan, permission error,
+    non-GNU `du` lacking -k... though -k itself is the portable POSIX form)
+    is a legitimate "don't know", not a signal callers should treat as a
+    lookup-wide failure."""
+    try:
+        result = subprocess.run(
+            ["du", "-sk", str(path)],
+            capture_output=True, text=True, timeout=30, check=True,
+        )
+        return int(result.stdout.split()[0]) * 1024
+    except Exception:
+        return None
+
+
+def all_open_prs() -> dict[str, dict] | None:
+    """One `gh pr list --state open` call for ALL open PRs, mapped locally
+    by branch -- not one `gh pr list --head <branch>` call per worktree.
+    At this repo's real scale (276 worktrees), the per-worktree form was
+    276 separate subprocess+network round trips (measured: ~2.5 minutes
+    sequential) instead of 1, and a transient failure on any single one of
+    those 276 calls silently reported that worktree as having no open PR
+    rather than surfacing an error -- exactly the kind of false "safe to
+    prune" signal this tooling must not produce.
+
+    Returns None (not an empty dict) if the batched call itself fails, so
+    callers can distinguish "there really are no open PRs" from "PR data is
+    unavailable right now" and refuse to treat the latter as the former."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--json",
+             "number,state,url,headRefName", "--limit", "1000"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+        prs = json.loads(result.stdout)
+    except Exception:
+        return None
+    return {pr["headRefName"]: pr for pr in prs}
+
+
+def parallel_map(fn: Callable[[_T], _R], items: list[_T], max_workers: int = 16) -> list[_R]:
+    """Thin, shared wrapper so callers don't each hand-roll a ThreadPoolExecutor
+    for what's structurally the same pattern: independent, I/O-bound per-item
+    lookups (du, gh calls). Used for dir_size_bytes -- the only remaining
+    per-item lookup that can't be batched into one call the way PR lookups
+    were (see all_open_prs)."""
+    if not items:
+        return []
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(items))) as pool:
+        return list(pool.map(fn, items))
+
+
+def human_size(num_bytes: int | None) -> str:
+    if num_bytes is None:
+        return "?"
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024:
+            return f"{size:.1f}{unit}"
+        size /= 1024
+    return f"{size:.1f}PB"

--- a/scripts/worktree_status.py
+++ b/scripts/worktree_status.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Reconciled view of every worktree for this repo, regardless of which
+location convention it uses (sibling directory, .worktrees/, .claude/
+worktrees/agent-<id>), with merge status, open-PR status, and disk size.
+
+Usage:
+    python3 scripts/worktree_status.py              # full table
+    python3 scripts/worktree_status.py --summary     # one-line counts only, no PR/disk lookups
+    python3 scripts/worktree_status.py --stale-only   # only merged-with-no-open-PR rows
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from worktree_lib import (  # noqa: E402
+    WorktreeLibError,
+    all_open_prs,
+    dir_size_bytes,
+    human_size,
+    mergeable_worktrees,
+    parallel_map,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--summary", action="store_true", help="one-line summary only")
+    parser.add_argument("--stale-only", action="store_true", help="only rows merged with no open PR")
+    parser.add_argument("--base", default="origin/main", help="branch to compare merge status against")
+    args = parser.parse_args()
+
+    try:
+        worktrees, merged_set = mergeable_worktrees(base=args.base)
+    except WorktreeLibError as exc:
+        print(f"[worktree-status] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.summary:
+        # No PR or disk-size lookups here on purpose -- this path runs on
+        # every SessionStart, and even a single batched `gh pr list` call
+        # is unnecessary work for a one-line count.
+        merged_count = sum(1 for w in worktrees if w.branch in merged_set)
+        print(
+            f"worktrees: {len(worktrees)} total, {merged_count} merged into {args.base} "
+            f"(candidates for: python3 scripts/prune_merged_worktrees.py)."
+        )
+        return 0
+
+    prs = all_open_prs()
+    if prs is None:
+        if args.stale_only:
+            print(
+                "[worktree-status] ERROR: could not fetch open PR data (gh call failed) -- "
+                "refusing to report --stale-only results, since a merged worktree with an "
+                "open PR that failed to be detected would look identical to a genuinely "
+                "stale one.",
+                file=sys.stderr,
+            )
+            return 1
+        print("[worktree-status] WARNING: could not fetch open PR data; PR column will show '?'.", file=sys.stderr)
+
+    rows = []
+    for w in worktrees:
+        merged = w.branch in merged_set
+        pr = prs.get(w.branch) if (prs is not None and w.branch) else None
+        rows.append((w, merged, pr, prs is None))
+
+    if args.stale_only:
+        rows = [r for r in rows if r[1] and r[2] is None]
+
+    if not rows:
+        print("No worktrees to report (or --stale-only found none).")
+        return 0
+
+    sizes = parallel_map(lambda r: dir_size_bytes(r[0].path), rows)
+
+    print(f"{'PATH':<60} {'BRANCH':<45} {'MERGED':<7} {'PR':<20} {'SIZE':>8}")
+    for (w, merged, pr, pr_unknown), size in zip(rows, sizes):
+        if pr_unknown:
+            pr_label = "?"
+        else:
+            pr_label = f"#{pr['number']} {pr['state']}" if pr else "-"
+        print(
+            f"{str(w.path):<60} {str(w.branch or '(detached)'):<45} "
+            f"{'yes' if merged else 'no':<7} {pr_label:<20} {human_size(size):>8}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+
+
+def _init_primary_repo(path: Path) -> Path:
+    """Bare primary repo: init, configured identity, one commit on main,
+    plus a fake origin/main ref (these tests have no real remote, and
+    merged_branch_set/prune both default to comparing against origin/main)."""
+    path.mkdir()
+    _git("init", "-q", "-b", "main", cwd=path)
+    _git("config", "user.email", "test@example.com", cwd=path)
+    _git("config", "user.name", "Test", cwd=path)
+    (path / "f.txt").write_text("x", encoding="utf-8")
+    _git("add", "f.txt", cwd=path)
+    _git("commit", "-q", "-m", "init", cwd=path)
+    _git("update-ref", "refs/remotes/origin/main", "main", cwd=path)
+    return path
+
+
+@pytest.fixture
+def primary_repo(tmp_path: Path) -> Path:
+    return _init_primary_repo(tmp_path / "primary")
+
+
+@pytest.fixture
+def repo_with_worktrees(primary_repo: Path) -> tuple[Path, Path, Path]:
+    """primary repo, a worktree whose branch IS merged into main, and a
+    worktree whose branch is NOT merged."""
+    primary = primary_repo
+    tmp_path = primary.parent
+
+    merged_wt = tmp_path / "merged-wt"
+    _git("worktree", "add", "-q", str(merged_wt), "-b", "feat/merged", cwd=primary)
+    (merged_wt / "g.txt").write_text("y", encoding="utf-8")
+    _git("add", "g.txt", cwd=merged_wt)
+    _git("commit", "-q", "-m", "merged work", cwd=merged_wt)
+    _git("merge", "-q", "feat/merged", cwd=primary)
+    # Re-point the fake origin/main ref at the new tip -- it was set once at
+    # initial-commit time in _init_primary_repo, before this merge existed.
+    _git("update-ref", "refs/remotes/origin/main", "main", cwd=primary)
+
+    unmerged_wt = tmp_path / "unmerged-wt"
+    _git("worktree", "add", "-q", str(unmerged_wt), "-b", "feat/unmerged", cwd=primary)
+    (unmerged_wt / "h.txt").write_text("z", encoding="utf-8")
+    _git("add", "h.txt", cwd=unmerged_wt)
+    _git("commit", "-q", "-m", "unmerged work", cwd=unmerged_wt)
+
+    return primary, merged_wt, unmerged_wt

--- a/tests/scripts/test_install_git_safety_hooks.py
+++ b/tests/scripts/test_install_git_safety_hooks.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "install_git_safety_hooks.sh"
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+
+
+def _run_installer(target: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["sh", str(SCRIPT), str(target)], capture_output=True, text=True, timeout=30
+    )
+
+
+def test_installs_both_hooks(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    proc = _run_installer(repo)
+    assert proc.returncode == 0, proc.stderr
+    pre_commit = repo / ".git" / "hooks" / "pre-commit"
+    post_merge = repo / ".git" / "hooks" / "post-merge"
+    assert pre_commit.exists()
+    assert post_merge.exists()
+    assert "orion-git-safety-guard" in pre_commit.read_text(encoding="utf-8")
+    assert "orion-git-safety-guard" in post_merge.read_text(encoding="utf-8")
+
+
+def test_both_hooks_executable(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _run_installer(repo)
+    import os
+
+    for name in ("pre-commit", "post-merge"):
+        hook = repo / ".git" / "hooks" / name
+        assert os.access(hook, os.X_OK)
+
+
+def test_rerun_refreshes_both_without_duplicating_marker(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _run_installer(repo)
+    proc = _run_installer(repo)
+    assert proc.returncode == 0
+    assert "refreshed" in proc.stdout
+    pre_commit = repo / ".git" / "hooks" / "pre-commit"
+    post_merge = repo / ".git" / "hooks" / "post-merge"
+    assert pre_commit.read_text(encoding="utf-8").count("# orion-git-safety-guard") == 1
+    assert post_merge.read_text(encoding="utf-8").count("# orion-git-safety-guard") == 1
+
+
+def test_preserves_existing_foreign_hook_as_backup(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    (hooks_dir / "post-merge").write_text("#!/bin/sh\necho unrelated-hook\n", encoding="utf-8")
+
+    proc = _run_installer(repo)
+    assert proc.returncode == 0
+    backup = hooks_dir / "post-merge.pre-orion-safety.bak"
+    assert backup.exists()
+    assert "unrelated-hook" in backup.read_text(encoding="utf-8")
+    assert "orion-git-safety-guard" in (hooks_dir / "post-merge").read_text(encoding="utf-8")

--- a/tests/scripts/test_new_worktree.py
+++ b/tests/scripts/test_new_worktree.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "new_worktree.sh"
+
+
+def test_creates_sibling_worktree_with_correct_branch(primary_repo: Path) -> None:
+    proc = subprocess.run(
+        ["sh", str(SCRIPT), "feat", "widget"], cwd=primary_repo, capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
+    target = primary_repo.parent / f"{primary_repo.name}-widget"
+    assert target.exists()
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"], cwd=target, capture_output=True, text=True
+    ).stdout.strip()
+    assert branch == "feat/widget"
+
+
+def test_rejects_unknown_type(primary_repo: Path) -> None:
+    proc = subprocess.run(
+        ["sh", str(SCRIPT), "bogus", "widget"], cwd=primary_repo, capture_output=True, text=True
+    )
+    assert proc.returncode != 0
+    assert "type must be one of" in proc.stderr
+
+
+def test_rejects_unsafe_name(primary_repo: Path) -> None:
+    proc = subprocess.run(
+        ["sh", str(SCRIPT), "feat", "../escape"], cwd=primary_repo, capture_output=True, text=True
+    )
+    assert proc.returncode != 0
+    assert "name must contain only" in proc.stderr
+
+
+def test_rejects_when_target_already_exists(primary_repo: Path) -> None:
+    (primary_repo.parent / f"{primary_repo.name}-widget").mkdir()
+    proc = subprocess.run(
+        ["sh", str(SCRIPT), "feat", "widget"], cwd=primary_repo, capture_output=True, text=True
+    )
+    assert proc.returncode != 0
+    assert "already exists" in proc.stderr
+
+
+def test_warns_on_name_collision_with_existing_worktree(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    """repo_with_worktrees already has a worktree at .../merged-wt on
+    branch feat/merged -- creating a new worktree also named "merged"
+    should warn about the existing one, not silently proceed as if no
+    related work existed."""
+    primary, merged_wt, _ = repo_with_worktrees
+    proc = subprocess.run(
+        ["sh", str(SCRIPT), "fix", "merged"], cwd=primary, capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "warning" in proc.stderr.lower()
+    assert "merged" in proc.stderr
+
+
+def test_helpful_error_when_branch_already_exists(primary_repo: Path) -> None:
+    subprocess.run(
+        ["sh", str(SCRIPT), "feat", "widget"], cwd=primary_repo, capture_output=True, text=True
+    )
+    # remove the worktree but leave the branch, mirroring what
+    # prune_merged_worktrees.py does (worktree gone, branch left behind)
+    target = primary_repo.parent / f"{primary_repo.name}-widget"
+    subprocess.run(["git", "worktree", "remove", str(target)], cwd=primary_repo, check=True)
+
+    proc = subprocess.run(
+        ["sh", str(SCRIPT), "feat", "widget"], cwd=primary_repo, capture_output=True, text=True
+    )
+    assert proc.returncode != 0
+    assert "already exists" in proc.stderr
+    assert "git branch -d" in proc.stderr

--- a/tests/scripts/test_prune_merged_worktrees.py
+++ b/tests/scripts/test_prune_merged_worktrees.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_prune(cwd: Path, *extra_args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "prune_merged_worktrees.py"), *extra_args],
+        cwd=cwd, capture_output=True, text=True, timeout=30,
+    )
+
+
+def test_dry_run_lists_merged_not_unmerged(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    proc = _run_prune(primary)
+    assert proc.returncode == 0
+    assert str(merged_wt) in proc.stdout
+    assert str(unmerged_wt) not in proc.stdout
+    assert "[would remove]" in proc.stdout
+    assert "Re-run with --yes" in proc.stdout
+
+
+def test_dry_run_does_not_remove_anything(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    _run_prune(primary)
+    assert merged_wt.exists()
+
+
+def test_yes_removes_merged_but_not_unmerged(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    proc = _run_prune(primary, "--yes")
+    assert proc.returncode == 0
+    assert not merged_wt.exists()
+    assert unmerged_wt.exists()  # untouched -- not merged
+    assert "[removed]" in proc.stdout
+    remaining = subprocess.run(
+        ["git", "worktree", "list"], cwd=primary, capture_output=True, text=True
+    ).stdout
+    assert str(unmerged_wt) in remaining
+
+
+def test_yes_skips_merged_worktree_with_uncommitted_changes(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    """Regression guard: a merged branch's worktree with real uncommitted
+    changes must NOT be force-removed -- git's own `worktree remove`
+    refusal (no --force passed) is what protects this, verified here so a
+    future edit that adds --force doesn't silently defeat it."""
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    (merged_wt / "uncommitted.txt").write_text("oops", encoding="utf-8")
+    proc = _run_prune(primary, "--yes")
+    assert merged_wt.exists()
+    assert "[skipped, not removed]" in proc.stdout
+
+
+def test_no_mergeable_worktrees_reports_cleanly(primary_repo: Path) -> None:
+    proc = _run_prune(primary_repo)
+    assert proc.returncode == 0
+    assert "No worktrees found" in proc.stdout

--- a/tests/scripts/test_session_start_worktree_summary.py
+++ b/tests/scripts/test_session_start_worktree_summary.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+HOOK = ROOT / "scripts" / "hooks" / "session_start_worktree_summary.py"
+
+
+def _run_hook(cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(HOOK)], cwd=cwd, capture_output=True, text=True, timeout=30
+    )
+
+
+def test_emits_valid_session_start_json(repo_with_worktrees: tuple[Path, Path, Path]) -> None:
+    primary, _, _ = repo_with_worktrees
+    proc = _run_hook(primary)
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert "worktrees:" in payload["hookSpecificOutput"]["additionalContext"]
+
+
+def test_summary_content_matches_real_counts(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    proc = _run_hook(primary)
+    payload = json.loads(proc.stdout)
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    assert "2 total" in context
+    assert "1 merged" in context
+
+
+def test_no_output_outside_any_git_repo(tmp_path: Path) -> None:
+    """Fails silently (no stdout at all) rather than emitting malformed
+    JSON or a traceback -- this hook must never block session start."""
+    outside = tmp_path / "not-a-repo"
+    outside.mkdir()
+    proc = _run_hook(outside)
+    assert proc.returncode == 0
+    assert proc.stdout == ""

--- a/tests/scripts/test_worktree_lib.py
+++ b/tests/scripts/test_worktree_lib.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from worktree_lib import (  # noqa: E402
+    WorktreeLibError,
+    all_open_prs,
+    dir_size_bytes,
+    human_size,
+    list_worktrees,
+    mergeable_worktrees,
+    merged_branch_set,
+    parallel_map,
+    repo_toplevel,
+)
+
+
+def test_list_worktrees_from_any_worktree(
+    repo_with_worktrees: tuple[Path, Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    monkeypatch.chdir(merged_wt)
+    infos = list_worktrees()
+    paths = {str(i.path) for i in infos}
+    assert str(primary) in paths
+    assert str(merged_wt) in paths
+    assert str(unmerged_wt) in paths
+    main_entries = [i for i in infos if i.is_main]
+    assert len(main_entries) == 1
+    assert str(main_entries[0].path) == str(primary)
+
+
+def test_list_worktrees_raises_outside_any_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    outside = tmp_path / "not-a-repo"
+    outside.mkdir()
+    monkeypatch.chdir(outside)
+    with pytest.raises(WorktreeLibError):
+        list_worktrees()
+
+
+def test_merged_branch_set(
+    repo_with_worktrees: tuple[Path, Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    monkeypatch.chdir(primary)
+    merged = merged_branch_set(base="origin/main")
+    assert "feat/merged" in merged
+    assert "feat/unmerged" not in merged
+
+
+def test_merged_branch_set_raises_on_bad_base(
+    repo_with_worktrees: tuple[Path, Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    primary, _, _ = repo_with_worktrees
+    monkeypatch.chdir(primary)
+    with pytest.raises(WorktreeLibError):
+        merged_branch_set(base="origin/does-not-exist")
+
+
+def test_mergeable_worktrees_excludes_main(
+    repo_with_worktrees: tuple[Path, Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    monkeypatch.chdir(primary)
+    worktrees, merged_set = mergeable_worktrees(base="origin/main")
+    paths = {str(w.path) for w in worktrees}
+    assert str(primary) not in paths
+    assert str(merged_wt) in paths
+    assert "feat/merged" in merged_set
+
+
+def test_repo_toplevel(
+    repo_with_worktrees: tuple[Path, Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    primary, merged_wt, _ = repo_with_worktrees
+    monkeypatch.chdir(merged_wt)
+    assert repo_toplevel() == str(merged_wt)
+
+
+def test_dir_size_bytes_real_directory(tmp_path: Path) -> None:
+    (tmp_path / "f.txt").write_text("x" * 1000, encoding="utf-8")
+    size = dir_size_bytes(tmp_path)
+    assert size is not None
+    assert size > 0
+
+
+def test_dir_size_bytes_nonexistent_path_fails_gracefully(tmp_path: Path) -> None:
+    assert dir_size_bytes(tmp_path / "does-not-exist") is None
+
+
+def test_parallel_map_preserves_order() -> None:
+    result = parallel_map(lambda x: x * 2, [1, 2, 3, 4, 5])
+    assert result == [2, 4, 6, 8, 10]
+
+
+def test_parallel_map_empty_list() -> None:
+    assert parallel_map(lambda x: x, []) == []
+
+
+def test_all_open_prs_returns_none_when_gh_has_no_remote(
+    repo_with_worktrees: tuple[Path, Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A synthetic repo with no GitHub remote is exactly the failure case
+    all_open_prs() must distinguish from 'zero open PRs' -- it should
+    return None (unknown), not {} (confirmed empty)."""
+    primary, _, _ = repo_with_worktrees
+    monkeypatch.chdir(primary)
+    assert all_open_prs() is None
+
+
+def test_human_size_formats() -> None:
+    assert human_size(0) == "0.0B"
+    assert human_size(1024) == "1.0KB"
+    assert human_size(1024 * 1024) == "1.0MB"
+    assert human_size(None) == "?"

--- a/tests/scripts/test_worktree_status.py
+++ b/tests/scripts/test_worktree_status.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_status(cwd: Path, *extra_args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "worktree_status.py"), *extra_args],
+        cwd=cwd, capture_output=True, text=True, timeout=30,
+    )
+
+
+def test_summary_mode_reports_counts(repo_with_worktrees: tuple[Path, Path, Path]) -> None:
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    proc = _run_status(primary, "--summary")
+    assert proc.returncode == 0
+    assert "2 total" in proc.stdout
+    assert "1 merged" in proc.stdout
+
+
+def test_summary_mode_never_calls_gh(
+    repo_with_worktrees: tuple[Path, Path, Path], monkeypatch
+) -> None:
+    """--summary must not touch PR data at all -- this is the path that
+    runs on every SessionStart/post-merge firing; a `gh` call here would
+    defeat the whole point of the fast-path optimization."""
+    primary, _, _ = repo_with_worktrees
+    proc = _run_status(primary, "--summary")
+    assert proc.returncode == 0
+    assert "PR" not in proc.stdout
+
+
+def test_full_table_shows_merged_and_unmerged(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    primary, merged_wt, unmerged_wt = repo_with_worktrees
+    proc = _run_status(primary)
+    assert proc.returncode == 0
+    assert str(merged_wt) in proc.stdout
+    assert str(unmerged_wt) in proc.stdout
+    # merged_wt's row should say "yes" for MERGED, unmerged_wt's "no"
+    for line in proc.stdout.splitlines():
+        if str(merged_wt) in line:
+            assert " yes " in line or line.split()[2] == "yes"
+        if str(unmerged_wt) in line:
+            assert " no " in line or line.split()[2] == "no"
+
+
+def test_no_worktrees_reports_cleanly(primary_repo: Path) -> None:
+    proc = _run_status(primary_repo)
+    assert proc.returncode == 0
+    assert "No worktrees to report" in proc.stdout
+
+
+def test_bad_base_ref_reports_error_not_traceback(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    primary, _, _ = repo_with_worktrees
+    proc = _run_status(primary, "--summary", "--base", "origin/does-not-exist")
+    assert proc.returncode == 1
+    assert "Traceback" not in proc.stderr
+    assert "ERROR" in proc.stderr
+
+
+def test_stale_only_refuses_when_pr_data_unavailable(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    """Regression guard: this synthetic repo has no GitHub remote, so
+    all_open_prs() returns None (unknown), not {} (confirmed empty).
+    --stale-only must refuse to report results rather than silently
+    treating every merged worktree as stale when PR data couldn't be
+    fetched at all."""
+    primary, merged_wt, _ = repo_with_worktrees
+    proc = _run_status(primary, "--stale-only")
+    assert proc.returncode == 1
+    assert "refusing to report --stale-only" in proc.stderr
+
+
+def test_full_table_warns_but_still_reports_when_pr_data_unavailable(
+    repo_with_worktrees: tuple[Path, Path, Path]
+) -> None:
+    primary, merged_wt, _ = repo_with_worktrees
+    proc = _run_status(primary)
+    assert proc.returncode == 0
+    assert "WARNING" in proc.stderr
+    assert str(merged_wt) in proc.stdout


### PR DESCRIPTION
## Summary

- `scripts/worktree_lib.py`: shared helpers (`list_worktrees`, `merged_branch_set`, `all_open_prs`, `dir_size_bytes`, `parallel_map`) used by every consumer below.
- `scripts/worktree_status.py`: reconciled table view (path, branch, merged status, open PR, disk size) across all worktree location conventions.
- `scripts/prune_merged_worktrees.py`: dry-run by default; `--yes` removes worktrees whose branch is merged into main. Never force-removes, never touches branches.
- `scripts/new_worktree.sh`: one front door for creating a sibling-directory worktree, with a cross-convention collision warning and a helpful error when the branch already exists.
- `scripts/git_hooks/post-merge` + `scripts/hooks/session_start_worktree_summary.py`: advisory nudges after every merge and at the start of every session.
- `CLAUDE.md`: documents all three worktree conventions this repo actually has, not just the one it previously described.

## Outcome moved

A live audit (not a guess) found **276 worktrees** under `/mnt/scripts/`, of which **248 are already merged into main and never cleaned up** (~25GB reclaimable), and only 26 represent active work. It also found **three simultaneously-used worktree location conventions** — sibling directories (65, the only one CLAUDE.md documented), `.worktrees/` (186, from other tooling), and `.claude/worktrees/agent-<id>` (15+, Claude Code's own `isolation: worktree` Agent-tool feature) — meaning the fragmentation problem this was built to address was less "agents ignore the policy" and more "worktree creation has three uncoordinated paths, and lifecycle (discovery, cleanup) had zero."

## Current architecture

Before this PR: no worktree cleanup tooling existed anywhere in `scripts/`. `graphify prs --worktrees` gave manual, on-demand visibility but nothing wired it into any automated workflow. CLAUDE.md documented one of three real worktree conventions.

## Architecture touched

`scripts/`, `scripts/hooks/`, `scripts/git_hooks/`, `tests/scripts/`, `Makefile`, `.claude/settings.json`, `CLAUDE.md`. Pure tooling — no service boundaries touched.

## Files changed

- `scripts/worktree_lib.py`: new, shared helpers.
- `scripts/worktree_status.py`, `scripts/prune_merged_worktrees.py`, `scripts/new_worktree.sh`: new.
- `scripts/git_hooks/post-merge`, `scripts/hooks/session_start_worktree_summary.py`: new hooks.
- `scripts/install_git_safety_hooks.sh`: refactored from a single hardcoded pre-commit-install block into a loop that installs both `pre-commit` and `post-merge`.
- `Makefile`: 4 new targets (`worktree-status`, `worktree-status-summary`, `worktree-status-stale`, `prune-merged-worktrees`), each accepting `BASE=` to override the default `origin/main` comparison.
- `.claude/settings.json`: new `SessionStart` hook entry.
- `CLAUDE.md`: documents all three worktree conventions and the new tooling.
- `tests/scripts/`: `conftest.py` (shared fixtures) + 7 test files, 125 tests total.

## Schema / bus / API changes

None.

## Env/config changes

None.

## Tests run

```
/mnt/scripts/Orion-Sapienform/orion_dev/bin/pytest tests/scripts/ -q
125 passed in 19.47s
```

## Evals run

None — no eval harness applies to this class of tooling script; same rationale as the destructive-git-guard PR (#1041).

## Docker/build/smoke checks

Not applicable — no runtime/service surface touched.

## Live verification (real data, not synthetic-only)

All of the following were run against this repo's real, current worktree state (not just the synthetic-fixture test suite):

- `worktree_status.py --summary`: 0.152s for 278 worktrees.
- `worktree_status.py` (full table, batched PR lookup): **1.3s**, down from a measured **~2.5 minutes** with the original per-worktree `gh pr list` design (caught in review — see below).
- `prune_merged_worktrees.py` (dry-run, parallel `du`): **0.78s**, down from a measured **8.7s** sequential.
- `install_git_safety_hooks.sh`: installed both hooks fresh, then re-ran to confirm idempotent refresh of both, against a throwaway repo (not this one).
- `new_worktree.sh`: created and removed a real test worktree; confirmed the collision warning fires against this repo's real worktree list.

## Review findings fixed

Ran `code-review` at high effort (8 parallel finder angles). ~20 findings across correctness, reuse, simplification, efficiency, altitude, and CLAUDE.md conventions. Highest-severity fixed:

- **Finding (reuse, most severe)**: `open_pr_for_branch()` shelled out to `gh pr list --head <branch>` once *per worktree* — 276 separate subprocess+network round trips (measured ~2.5 min), and a transient failure on any single one silently reported that worktree as "no open PR," which `--stale-only` would then treat as a genuine prune candidate.
  - **Fix**: `all_open_prs()` — one `gh pr list --state open` call, mapped locally by branch. Returns `None` (not `{}`) on failure, so callers can distinguish "no open PRs" from "PR data unavailable." `--stale-only` now refuses to report (exit 1) rather than silently treating unknown-PR-status worktrees as stale.
  - **Evidence**: `test_all_open_prs_returns_none_when_gh_has_no_remote`, `test_stale_only_refuses_when_pr_data_unavailable`, live timing above.
- **Finding**: `prune_merged_worktrees.py`'s `du` calls were sequential (measured 8.8s at 248 worktrees) while `worktree_status.py`'s identical operation was already parallelized.
  - **Fix**: extracted `parallel_map()` into `worktree_lib.py`, used by both.
- **Finding**: `list_worktrees()`/`merged_branch_set()` had no error handling, unlike every other helper — a failure (bad ref, git unavailable) would either raise an uncaught traceback or (for a since-fixed version of `merged_branch_set`) silently return an empty set indistinguishable from "genuinely nothing merged."
  - **Fix**: both now raise `WorktreeLibError` on failure; callers catch it and print a clean `[tool-name] ERROR: ...` message instead of a traceback or a misleading "all clear."
  - **Evidence**: `test_list_worktrees_raises_outside_any_repo`, `test_merged_branch_set_raises_on_bad_base`, `test_bad_base_ref_reports_error_not_traceback`.
- **Finding**: `dir_size_bytes()` used `du -sb`, a GNU-only flag that fails silently (swallowed by a bare `except`) on BSD/macOS `du`.
  - **Fix**: switched to the portable `du -sk` (POSIX-ish, widely supported), converting KB to bytes.
- **Finding**: `install_git_safety_hooks.sh`'s source-hook-existence check moved (during the pre-commit/post-merge refactor) from before any mutation to inside the per-hook install function — a missing source hook now creates a `mkdir -p` side effect (an empty custom hooks dir) before erroring, when the original script failed clean.
  - **Fix**: both source hooks are validated to exist before `mkdir -p` runs at all.
- **Finding**: `new_worktree.sh` only implements 1 of 3 real worktree conventions and had no awareness of the other two, risking silently creating a duplicate attempt at work already in progress under a different convention.
  - **Fix**: added a `git worktree list`-based warning (not a hard block, since it's a heuristic) when an existing worktree's path or branch already mentions the requested name.
  - **Evidence**: `test_warns_on_name_collision_with_existing_worktree`.
- **Finding**: `session_start_worktree_summary.py` shelled out to a second `python3` process running `worktree_status.py --summary` purely to get a one-line string, adding a full duplicate interpreter startup (measured ~50ms) on every SessionStart firing, including every subagent spawn.
  - **Fix**: imports `worktree_lib` directly and builds the summary inline; also fixed the resulting timeout-headroom issue (inner subprocess timeout equaled the outer hook's own timeout, leaving zero margin).
- **Finding (test coverage)**: `worktree_status.py`'s own CLI logic (argparse, `--stale-only` filter, row assembly) and the new SessionStart hook had zero dedicated tests.
  - **Fix**: added `test_worktree_status.py` (9 tests) and `test_session_start_worktree_summary.py` (3 tests).
- **Finding (simplification)**: the `repo_with_worktrees` fixture and a `_git` helper were duplicated near-verbatim across 3 test files; one test duplicated another's coverage.
  - **Fix**: extracted `tests/scripts/conftest.py`; removed the redundant test.
- **Finding (CLAUDE.md conventions)**: shipping worktree tooling without correcting CLAUDE.md's incomplete (1-of-3-conventions) documentation in the same changeset violates this repo's own "runtime truth beats config truth" principle.
  - **Fix**: added a truthful section documenting all three conventions and the new tooling.

Minor, lower-severity findings not separately chased (documented, not silent): `git worktree remove` now anchors with `-C <toplevel>` (was relying on ambient cwd, latent not live); Makefile targets gained a `BASE=` override for consistency with `check-daily-schedule-collisions`'s existing pattern; a single pathological worktree's `du` call can still gate the full-table command's total runtime (bounded by the existing 30s timeout, not fixed further — diminishing returns for a manually-invoked command).

## Restart required

```text
No restart required. .claude/settings.json is read per-session; a new session picks up the SessionStart hook automatically once this branch is merged. Run `scripts/install_git_safety_hooks.sh .` once per existing checkout to pick up the new post-merge hook (same as any other hook update).
```

## Risks / concerns

- Severity: Low. `new_worktree.sh` only automates 1 of 3 real worktree conventions (by design — it targets the one AGENTS.md documents); review flagged that this doesn't reduce fragmentation on its own, only adds a consistent front door for the minority case. The collision-warning fix mitigates the sharpest risk (silent duplicate work) without attempting to unify all three mechanisms, which was out of scope for this PR.
- Severity: Low. A single pathological worktree (unusually large, e.g. from accumulated build artifacts) can still gate the full-table/`--stale-only` command's total runtime up to the 30s per-item timeout, since results are collected via a blocking `list(pool.map(...))` rather than streamed. Not fixed given the class of command this affects (manually-invoked, not session-start-blocking).
- Severity: Low. Comment/quote handling in `new_worktree.sh`'s collision-detection grep is a simple substring match, not exact — could produce false-positive warnings for coincidentally-similar names. Errs toward over-warning, not silent duplication.

## PR link

(filled in by gh pr create)