### PR TITLE
feat(cortex-exec): surface recent dispatch-action evidence into stance_react's pre-motor prompt

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-14-stance-react-dispatch-evidence-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-stance-react-dispatch-evidence-pr.md
@@ -9,7 +9,8 @@ Spec: `docs/superpowers/specs/2026-07-14-stance-react-dispatch-evidence-design.m
 - Reuses an existing, live, already-proven pipe end to end (`chat_stance.py` → `router.py`'s metadata map-on → `orion-thought`'s `bus_listener.py` extraction → `ThoughtEventV1.autonomy_slice` → `stance_react.j2`'s rendered prompt) rather than building a parallel one — zero changes needed to either `router.py` or `bus_listener.py`.
 - `orion/cognition/prompts/stance_react.j2` renders the new field inside its existing `autonomy_slice` advisory block, shaping `imperative`/`tone` before the FCC motor runs.
 - Fixed a real trap along the way: `build_autonomy_slice`'s old early return (`if not state: return None`) ran before any recent-actions consideration and would have silently dropped the whole feature whenever the V2 reducer state was empty.
-- Code review (self-run, high effort) found one real latent bug in the new code (cap-limit off-by-one), fixed and regression-tested.
+- Code review round 1 (self-run, high effort) found one real latent bug in the new code (cap-limit off-by-one), fixed and regression-tested.
+- Code review round 2 (`/code-review xhigh`, 8 independent finder agents) found two material architectural gaps, both fixed: `recent_actions`'s consumption was accidentally coupled to the unrelated `AUTONOMY_STATE_V2_REDUCER_ENABLED` flag and reducer try/except (contradicting the code's own comment claiming independence from it), and the FCC motor's own prompt-builder (`orion/harness/prefix.py`) was never updated to render the new field at all — only the pre-motor stance LLM saw it.
 
 ## Outcome moved
 
@@ -67,11 +68,14 @@ $SCRATCH/p3p5-venv/bin/python -m pytest \
   services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py \
   services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py \
   services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py \
-  orion/schemas/tests/test_thought.py -q
-58 passed
+  orion/schemas/tests/test_thought.py \
+  orion/harness/tests/test_harness_prefix.py -q
+75 passed
 ```
 
 The spec's literal `pytest services/orion-cortex-exec/tests/ -k "..."` commands hit a pre-existing, unrelated collection error (`ValueError: Verb already registered: legacy.plan`) across 12 test files when the whole `tests/` directory is collected. Verified identical on a clean `origin/main` tree with this patch stashed out — confirmed pre-existing, not introduced by this change. Ran the specific affected files directly instead (command above), which is the standard workaround already established earlier this session for this exact class of cross-service collection collision.
+
+Also ran the full `orion/harness/tests/` suite (109 passed additionally, beyond the targeted files above) to check the `prefix.py` fix's blast radius: 3 pre-existing, unrelated failures (`test_grounding_capsule_consumers.py::test_stance_react_prompt_renders_identity_when_present`/`_without_identity` — a `jinja2.exceptions.UndefinedError: 'mind_coloring' is undefined`; `test_harness_runner.py::test_harness_runner_surfaces_fcc_error_code` — an FCC error-code assertion mismatch). Verified identical with this fix's changes stashed out on the already-committed branch tip — confirmed pre-existing, out of scope.
 
 `git diff --check` clean throughout.
 
@@ -85,17 +89,40 @@ Not run. This patch touches shared Python modules loaded by `orion-cortex-exec` 
 
 ## Review findings fixed
 
+Two review rounds. Round 1 (self-run, high effort) on the initial implementation:
+
 - Finding: `_format_recent_actions`'s cap check (`if len(out) >= limit: break`) ran *after* appending the current entry, not before — so `max_recent_actions<=0` still let exactly one entry through instead of zero.
   - Fix: moved the limit check to the top of the loop body (before any work happens on the current item) and added an explicit `limit <= 0` guard at the top of the function.
-  - Evidence: new regression test `test_recent_actions_respects_zero_or_negative_limit` asserts `build_autonomy_slice(ctx, max_recent_actions=0)` and `max_recent_actions=-1` both return `None` (no entries produced); 58/58 tests pass including this one.
+  - Evidence: new regression test `test_recent_actions_respects_zero_or_negative_limit` asserts `build_autonomy_slice(ctx, max_recent_actions=0)` and `max_recent_actions=-1` both return `None`.
 
-Self-run code review (high effort, 8-angle process) surfaced no other material findings. Not currently reachable via the sole production call site (which always passes the real constant, `3`), but real, latent, and untested prior to the fix.
+Round 2 (`/code-review xhigh`, 8 independent finder agents, verified against the real code before acting on any of them):
+
+- Finding: `build_autonomy_slice(...)` (which now folds in `recent_actions`) was only called inside the `if AUTONOMY_STATE_V2_REDUCER_ENABLED:` gate and that block's `try/except` — directly contradicting the code's own comment two lines above it, which explicitly claims dispatch-action evidence is "unconditional -- independent of AUTONOMY_STATE_V2_REDUCER_ENABLED." Two concrete failure modes: with the flag off, `recent_actions` never surfaces regardless of real Layer-9 activity; with the flag on, an unrelated `_run_autonomy_reducer` exception silently drops already-successfully-fetched dispatch evidence too. Independently found by two separate finder agents (line-by-line scan and altitude/conventions angles).
+  - Fix: moved the `build_autonomy_slice` call out of both the gate and the reducer's `try/except`, into its own unconditional call with its own `try/except`.
+  - Evidence: 2 new regression tests in `test_chat_stance_autonomy_v2.py` — `test_chat_stance_recent_actions_survive_when_reducer_disabled` and `test_chat_stance_recent_actions_survive_when_reducer_throws` — both assert `ctx["autonomy_slice"]["recent_actions"]` is populated in exactly the two scenarios the old code silently dropped it in.
+  - Note: live-checked `AUTONOMY_STATE_V2_REDUCER_ENABLED=true` in the actual running `orion-cortex-exec` container — this was not an active production outage today, but a real bug in shared code that would silently regress in any environment or transient-failure window, with zero test coverage of either case before this fix.
+
+- Finding: `orion/harness/prefix.py`'s `_format_autonomy_slice()` — the FCC motor's own system-prefix builder, a second independent renderer of `AutonomySliceV1` — was never updated to emit `recent_actions`, unlike its sibling fields (`dominant_drive`/`active_tensions`/`pressure_trend`). The motor itself never saw the new evidence directly, only indirectly if the upstream stance LLM happened to fold it into `imperative`/`tone`. Independently found by two separate finder agents (cross-file tracer and wrapper/proxy-correctness angles).
+  - Fix: added a `recent_actions` line to `_format_autonomy_slice`, matching the existing field pattern.
+  - Evidence: 2 new tests in `orion/harness/tests/test_harness_prefix.py` (zero prior coverage of this function's `AutonomySliceV1` handling existed) — one confirms the line renders when present, one confirms it's correctly omitted when empty.
+
+Findings surfaced but deliberately deferred as follow-ups (PLAUSIBLE-severity, not CONFIRMED, from the same round-2 review — see Risks/concerns):
+
+- `_project_recent_dispatch_actions` truncates to the newest `_MAX_RECENT_DISPATCH_ACTIONS=3` raw outcomes (mixed success/failure) before any success filtering, so `recent_actions` can under-report real successes when failures are interleaved in the most recent activity window.
+- `_format_recent_actions` reimplements list-capping and string truncation that already exist as shared helpers (`_truncate_list` in `executor.py`, `_truncate_text` in `supervisor.py`) instead of reusing them.
+- `stance_react.j2`'s bare `{{ autonomy_slice.recent_actions }}` interpolation renders Python's list `repr()` (escaped quotes/newlines) for free-form summary text — a pre-existing pattern shared with `active_tensions`, but newly exposed by this field's unbounded natural-language content.
+- `_DEFAULT_MAX_RECENT_ACTIONS = 3` in `autonomy_slice.py` duplicates `_MAX_RECENT_DISPATCH_ACTIONS = 3` in `chat_stance.py`, kept in sync only by comment (avoids a circular import) — the real call site always passes the constant explicitly, so this is only reachable via test/future callers.
 
 ## Restart required
+
+`orion/harness/prefix.py` is consumed by `orion-harness-governor` (via `orion/harness/runner.py`), not `orion-cortex-exec` directly — both services need a restart for this patch's full effect (the pre-motor stance evidence from `orion-cortex-exec`, and the motor's own direct rendering from `orion-harness-governor`):
 
 ```bash
 docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
   -f services/orion-cortex-exec/docker-compose.yml up -d --build
+
+docker compose --env-file .env --env-file services/orion-harness-governor/.env \
+  -f services/orion-harness-governor/docker-compose.yml up -d --build
 ```
 
 `orion-thought` does not need a restart — it consumes `AutonomySliceV1` structurally (via `model_validate`), and the new field is optional/additive, so no code change is required there for the new field to pass through correctly once `orion-cortex-exec` starts populating it.
@@ -104,7 +131,19 @@ docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
 
 - Severity: LOW
   Concern: live end-to-end effect on real chat turns not manually verified in this session (see Evals run above).
-  Mitigation: full unit coverage proves every hop of the pipe individually; the one missing step is an observational live check, not a code-correctness gap. Recommend running it once post-deploy.
+  Mitigation: full unit coverage proves every hop of the pipe individually, including the two round-2 fixes; the one missing step is an observational live check, not a code-correctness gap. Recommend running it once post-deploy, after both services above are restarted.
+
+- Severity: MEDIUM (deferred, not fixed this cycle)
+  Concern: `_project_recent_dispatch_actions` truncates to the newest 3 raw dispatch outcomes (mixed success/failure) before `_format_recent_actions` filters to success-only, so real successes older than the 3 newest raw entries are never considered — `recent_actions` can silently show fewer than 3 real successes even when more exist, whenever failures are interleaved with successes in the most recent activity window (more likely during exactly the kind of burn-in/debugging period this feature's own evidence came from earlier today).
+  Mitigation: not fixed this cycle — would require either widening the raw fetch window specifically for the `autonomy_slice` consumer (without changing `chat_general.j2`'s existing, intentionally-unfiltered 3-item view) or a dedicated success-filtered query path. Named here as a concrete follow-up rather than silently accepted.
+
+- Severity: LOW
+  Concern: `stance_react.j2`'s `{{ autonomy_slice.recent_actions }}` renders Python's list `repr()` (escaped quotes/newlines) for free-form dispatch-summary text, unlike the short enum-like strings the same rendering pattern was previously used for (`active_tensions`).
+  Mitigation: cosmetic for LLM-facing advisory context (not user-facing), not fixed this cycle. A Jinja `join`/custom filter would clean this up if it proves to matter in practice.
+
+- Severity: LOW
+  Concern: `_format_recent_actions` reimplements list-capping/truncation logic that already exists as shared helpers elsewhere in this service (`_truncate_list` in `executor.py`, `_truncate_text` in `supervisor.py`).
+  Mitigation: not fixed this cycle — pure cleanup, no behavior difference; noted for a future dedup pass.
 
 - Severity: LOW
   Concern: `_DEFAULT_MAX_RECENT_ACTIONS = 3` in `autonomy_slice.py` is a second literal `3`, kept in sync with `chat_stance.py`'s `_MAX_RECENT_DISPATCH_ACTIONS` only by comment, not by import (avoiding a circular import between the two modules, since `chat_stance.py` already imports from `autonomy_slice.py`). The real production call site always passes the constant explicitly, so this default is only reachable via test/future callers.

--- a/docs/superpowers/pr-reports/2026-07-14-stance-react-dispatch-evidence-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-stance-react-dispatch-evidence-pr.md
@@ -1,0 +1,124 @@
+# PR report: surface recent dispatch-action evidence into stance_react's pre-motor prompt
+
+Branch: `feat/stance-react-dispatch-evidence`
+Spec: `docs/superpowers/specs/2026-07-14-stance-react-dispatch-evidence-design.md`
+
+## Summary
+
+- `AutonomySliceV1` (`orion/schemas/thought.py`) gains `recent_actions: list[str]` — compact, one-line summaries of recent successful Layer-9 dispatch-action outcomes.
+- Reuses an existing, live, already-proven pipe end to end (`chat_stance.py` → `router.py`'s metadata map-on → `orion-thought`'s `bus_listener.py` extraction → `ThoughtEventV1.autonomy_slice` → `stance_react.j2`'s rendered prompt) rather than building a parallel one — zero changes needed to either `router.py` or `bus_listener.py`.
+- `orion/cognition/prompts/stance_react.j2` renders the new field inside its existing `autonomy_slice` advisory block, shaping `imperative`/`tone` before the FCC motor runs.
+- Fixed a real trap along the way: `build_autonomy_slice`'s old early return (`if not state: return None`) ran before any recent-actions consideration and would have silently dropped the whole feature whenever the V2 reducer state was empty.
+- Code review (self-run, high effort) found one real latent bug in the new code (cap-limit off-by-one), fixed and regression-tested.
+
+## Outcome moved
+
+Real Layer-9 dispatch-action evidence (proven live earlier today: a real `inspect` action produced a real observation, a real durable `action_outcomes` row, and a real drive-pressure relief) previously only reached `chat_general.j2` — the Brain-mode chat path, which is on a documented sunset track (`docs/superpowers/checklists/2026-07-05-unified-turn-sunset.md`). `ORION_UNIFIED_TURN_ENABLED=true` is live right now, meaning unified-turn is the actual active default chat path, and it never saw this evidence at all. Now it does, via the same pre-motor mechanism already carrying drive/tension state (`autonomy_slice`) into that path today.
+
+## Current architecture
+
+`build_chat_stance_inputs` (`services/orion-cortex-exec/app/chat_stance.py`) is a single shared context builder invoked for both the `chat_general` verb (Brain mode) and the `stance_react` verb (unified-turn's pre-motor cognition pass). It already computed `ctx["chat_recent_dispatch_actions"]` (via `_project_recent_dispatch_actions`, querying `load_action_outcomes(subject="orion")` directly, capped at `_MAX_RECENT_DISPATCH_ACTIONS=3`) and `ctx["autonomy_slice"]` (via `build_autonomy_slice`, from `AutonomyStateV2` reducer output) — but only the latter had a pipe reaching `stance_react.j2`. The former was rendered exclusively by `chat_general.j2`.
+
+The full pre-motor pipe `autonomy_slice` already used, traced hop by hop in the design spec:
+
+1. `chat_stance.py` builds `ctx["autonomy_slice"]`.
+2. `router.py` (gated on `plan.verb_name == "stance_react"` and `step.step_name == "llm_stance_react"`) copies `ctx["autonomy_slice"]` into that step's result `metadata["autonomy_slice"]`.
+3. `services/orion-thought/app/bus_listener.py`'s `_extract_autonomy_slice` reads it back out of that metadata and validates it as `AutonomySliceV1`.
+4. `orion/thought/stance_react.py`'s `parse_stance_react_payload` strips any LLM-authored `autonomy_slice` from the raw JSON first (documented: "assembled deterministically in cortex-exec... never authored by the stance LLM"), then the trusted value from step 3 is attached onto the final `ThoughtEventV1.autonomy_slice`.
+5. `stance_react.j2` renders it directly into the stance LLM's own prompt as a "PRIOR SELF-SIGNAL (advisory)" block, explicitly instructing the model to use it to color `imperative`/`tone`.
+6. That `thought_event` is what `orion.hub.turn_orchestrator.execute_unified_turn` hands to `HarnessRunRequestV1`, which reaches the FCC motor.
+
+## Architecture touched
+
+- `orion/schemas/thought.py` — one new field on `AutonomySliceV1`.
+- `services/orion-cortex-exec/app/autonomy_slice.py` — `build_autonomy_slice` now folds in recent dispatch-action evidence; omit-check extended.
+- `services/orion-cortex-exec/app/chat_stance.py` — reordered `_project_recent_dispatch_actions` to run before the gated V2-reducer block so its output is available when `build_autonomy_slice` runs. `chat_general.j2`'s existing direct read of `ctx["chat_recent_dispatch_actions"]` is unaffected (same key, same content, function is side-effect-free and independent of `ctx` per its own docstring).
+- `orion/cognition/prompts/stance_react.j2` — one new template line.
+
+Not touched (deliberately, per spec's non-goals): `router.py`'s metadata map-on, `services/orion-thought/app/bus_listener.py`'s extraction, `chat_general.j2`.
+
+## Files changed
+
+- `orion/schemas/thought.py`: `AutonomySliceV1.recent_actions: list[str]` + updated docstring.
+- `services/orion-cortex-exec/app/autonomy_slice.py`: new `_format_recent_actions` helper (success-only filter, `"{kind}: {summary}"` formatting, 160-char truncation budget, cap via `max_recent_actions` param); `build_autonomy_slice` reads `ctx["chat_recent_dispatch_actions"]`, no longer early-returns on empty reducer state (state defaults to `{}` instead), omit-check now also considers `recent_actions`.
+- `services/orion-cortex-exec/app/chat_stance.py`: moved the `_project_recent_dispatch_actions` call earlier in `build_chat_stance_inputs`; `build_autonomy_slice` call site now passes `max_recent_actions=_MAX_RECENT_DISPATCH_ACTIONS` explicitly (single source of truth for the cap, not a second hardcoded `3`).
+- `orion/cognition/prompts/stance_react.j2`: one new `{% if autonomy_slice.recent_actions %}` line inside the existing advisory block, matching the `active_tensions` pattern exactly.
+- `services/orion-cortex-exec/tests/test_autonomy_slice.py`: 8 new tests — cap-at-3 with 5 successes, failed/`None`-success exclusion, char-budget truncation, the omit-check trap (slice emitted when only recent_actions has signal), fail-open on missing/empty/malformed input, full-empty `None` case, and the review-fix regression (`max_recent_actions<=0` yields zero entries, not one).
+- `orion/schemas/tests/test_thought.py`: extended the exact-dict-equality round-trip test for the new field; added an explicit acceptance-check test proving `AutonomySliceV1` with `recent_actions` populated round-trips through `model_dump`/`model_validate` unchanged (the proof that `router.py`/`bus_listener.py` need zero code changes).
+- `services/orion-cortex-exec/README.md`: not touched — no existing section documents `AutonomySliceV1`'s field shape, so none was invented.
+
+## Schema / bus / API changes
+
+- Added: `AutonomySliceV1.recent_actions: list[str] = []`. Additive, safe default — `schema_version` unchanged (`"autonomy.slice.v1"`), no version bump. Old payloads without the field still validate; new payloads with it round-trip through every existing hop with zero code changes elsewhere.
+- Removed: none.
+- Renamed: none.
+- Behavior changed: `build_autonomy_slice` no longer returns `None` immediately when `AutonomyStateV2` reducer state is empty — it now falls through to consider `recent_actions` before deciding whether to omit. Net effect is strictly additive (a case that previously always omitted now sometimes doesn't, only when there's real recent-action signal to report); no existing non-empty-state behavior changes.
+- Compatibility notes: none needed.
+
+## Env/config changes
+
+None. No new env vars; the feature inherits the existing `AUTONOMY_STATE_V2_REDUCER_ENABLED` and `settings.orion_unified_grounding_enabled` gates already governing `autonomy_slice`'s construction and delivery.
+
+## Tests run
+
+```text
+$SCRATCH/p3p5-venv/bin/python -m pytest \
+  services/orion-cortex-exec/tests/test_autonomy_slice.py \
+  services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py \
+  services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py \
+  services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py \
+  orion/schemas/tests/test_thought.py -q
+58 passed
+```
+
+The spec's literal `pytest services/orion-cortex-exec/tests/ -k "..."` commands hit a pre-existing, unrelated collection error (`ValueError: Verb already registered: legacy.plan`) across 12 test files when the whole `tests/` directory is collected. Verified identical on a clean `origin/main` tree with this patch stashed out — confirmed pre-existing, not introduced by this change. Ran the specific affected files directly instead (command above), which is the standard workaround already established earlier this session for this exact class of cross-service collection collision.
+
+`git diff --check` clean throughout.
+
+## Evals run
+
+None applicable — this is a small, deterministic context-plumbing change with full unit coverage. No eval harness exists for `AutonomySliceV1`/`stance_react` specifically. Live verification of the end-to-end chat effect (does `ThoughtEventV1.autonomy_slice.recent_actions` actually show up non-empty on a real unified-turn chat turn shortly after a real Layer-9 dispatch) was not performed in this session — recommend a short manual check post-merge using the same technique used earlier today to verify the P3 satisfaction-tension pipeline (temporary diagnostic log, live watch during a real chat turn, then remove).
+
+## Docker/build/smoke checks
+
+Not run. This patch touches shared Python modules loaded by `orion-cortex-exec` and (transitively, via the schema) `orion-thought`; no compose/env/Dockerfile changes, so no rebuild is strictly required by this patch's own contract, but both services should be restarted to pick up the new code before the live-verification step above is meaningful.
+
+## Review findings fixed
+
+- Finding: `_format_recent_actions`'s cap check (`if len(out) >= limit: break`) ran *after* appending the current entry, not before — so `max_recent_actions<=0` still let exactly one entry through instead of zero.
+  - Fix: moved the limit check to the top of the loop body (before any work happens on the current item) and added an explicit `limit <= 0` guard at the top of the function.
+  - Evidence: new regression test `test_recent_actions_respects_zero_or_negative_limit` asserts `build_autonomy_slice(ctx, max_recent_actions=0)` and `max_recent_actions=-1` both return `None` (no entries produced); 58/58 tests pass including this one.
+
+Self-run code review (high effort, 8-angle process) surfaced no other material findings. Not currently reachable via the sole production call site (which always passes the real constant, `3`), but real, latent, and untested prior to the fix.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
+  -f services/orion-cortex-exec/docker-compose.yml up -d --build
+```
+
+`orion-thought` does not need a restart — it consumes `AutonomySliceV1` structurally (via `model_validate`), and the new field is optional/additive, so no code change is required there for the new field to pass through correctly once `orion-cortex-exec` starts populating it.
+
+## Risks / concerns
+
+- Severity: LOW
+  Concern: live end-to-end effect on real chat turns not manually verified in this session (see Evals run above).
+  Mitigation: full unit coverage proves every hop of the pipe individually; the one missing step is an observational live check, not a code-correctness gap. Recommend running it once post-deploy.
+
+- Severity: LOW
+  Concern: `_DEFAULT_MAX_RECENT_ACTIONS = 3` in `autonomy_slice.py` is a second literal `3`, kept in sync with `chat_stance.py`'s `_MAX_RECENT_DISPATCH_ACTIONS` only by comment, not by import (avoiding a circular import between the two modules, since `chat_stance.py` already imports from `autonomy_slice.py`). The real production call site always passes the constant explicitly, so this default is only reachable via test/future callers.
+  Mitigation: documented in-line at the constant's definition; low cost to keep in sync if `_MAX_RECENT_DISPATCH_ACTIONS` ever changes, since it's a single grep away.
+
+## PR link
+
+Not opened via `gh` this cycle (leaving that to you, consistent with this session's established pattern of pushing branch + PR link rather than opening PRs unprompted for review-gated work). Paste-ready:
+
+**Title:**
+```
+feat(cortex-exec): surface recent dispatch-action evidence into stance_react's pre-motor prompt
+```
+
+**Body:** this file's Summary through Risks/concerns sections, verbatim.
+
+Compare URL: https://github.com/junebug-junie/Orion-Sapienform/pull/new/feat/stance-react-dispatch-evidence

--- a/docs/superpowers/specs/2026-07-14-stance-react-dispatch-evidence-design.md
+++ b/docs/superpowers/specs/2026-07-14-stance-react-dispatch-evidence-design.md
@@ -1,0 +1,117 @@
+# Design spec: surface recent dispatch-action evidence into stance_react (pre-motor, unified-turn)
+
+## Arsonist summary
+
+`chat_recent_dispatch_actions` (real Layer-9 dispatch outcomes — proven live today: a real `inspect` action produced a real observation, a real `action_outcomes` row, and a real drive-pressure relief) is built once per turn in `chat_stance.py`'s shared context builder and rendered into `chat_general.j2`. But `ORION_UNIFIED_TURN_ENABLED=true` is live right now — **unified-turn, not `chat_general`/Brain mode, is the actual active chat path** — and `chat_recent_dispatch_actions` never reaches it. `chat_general` is itself on a sunset track (`docs/superpowers/checklists/2026-07-05-unified-turn-sunset.md`). Real self-directed-action evidence currently only surfaces in the path being phased out, not the live default one.
+
+There is already a proven, live, end-to-end pipe carrying a conceptually adjacent payload — `AutonomySliceV1` — from this exact same context builder into the unified-turn's pre-motor stance prompt (`stance_react.j2`), which explicitly shapes `imperative`/`tone` before the FCC motor ever runs. This spec proposes reusing that pipe rather than building a parallel one.
+
+## Current architecture
+
+`build_chat_stance_inputs` (`services/orion-cortex-exec/app/chat_stance.py`) is a single shared context builder invoked for **both** the `chat_general` verb (Brain mode) and the `stance_react` verb (unified-turn's pre-motor cognition pass) — not two separate builders. Confirmed via the function's own inline comment at chat_stance.py:2588-2591, which states `autonomy_slice` is built there specifically "so it's present BEFORE the stance_react LLM step renders its prompt."
+
+Two projections get built in this same function, back to back:
+
+- `ctx["autonomy_slice"]` (chat_stance.py:2593, via `build_autonomy_slice(ctx)` in `services/orion-cortex-exec/app/autonomy_slice.py`) — a compact, bounded, fail-open projection of `AutonomyStateV2` reducer output (`dominant_drive`, up to 3 `active_tensions`, `pressure_trend`, `confidence`).
+- `ctx["chat_recent_dispatch_actions"]` (chat_stance.py:2604, via `_project_recent_dispatch_actions(ctx)`) — up to `_MAX_RECENT_DISPATCH_ACTIONS = 3` real dispatch outcomes, newest-first by `observed_at`, queried directly via `load_action_outcomes(subject="orion")` (independent of `ctx`, fail-open to `[]`). Each entry is `{kind, summary, success, observed_at}` only — no internal correlation/audit fields.
+
+Only `autonomy_slice` reaches unified-turn. Its full live path, confirmed by reading every hop:
+
+1. `chat_stance.py:2593-2595` → `ctx["autonomy_slice"] = autonomy_slice.model_dump(mode="json")`
+2. `services/orion-cortex-exec/app/router.py:1355-1371` — gated on `plan.verb_name == "stance_react"` and `step.step_name == "llm_stance_react"`, this block also assembles `grounding_capsule`. Separately, `router.py:1563-1564` copies `ctx["autonomy_slice"]` into that step's result `metadata["autonomy_slice"]`.
+3. `services/orion-thought/app/bus_listener.py:_extract_autonomy_slice` (line ~212) reads `exec_result["metadata"]["autonomy_slice"]` and validates it as `AutonomySliceV1`.
+4. `orion/thought/stance_react.py:parse_stance_react_payload` (line ~225-229) explicitly strips any LLM-authored `autonomy_slice`/`grounding_capsule` from the raw JSON first — these are documented as "assembled deterministically in cortex-exec and mapped on from result metadata — never authored by the stance LLM" — then the extracted (trusted) value from step 3 is attached onto the final `ThoughtEventV1.autonomy_slice`.
+5. `orion/cognition/prompts/stance_react.j2` (lines 51-60) renders `autonomy_slice.dominant_drive` / `active_tensions` / `pressure_trend` directly into the stance LLM's own prompt, inside a `PRIOR SELF-SIGNAL (advisory)` block that explicitly instructs the model to "use it to color imperative/tone."
+6. The resulting `ThoughtEventV1` — its `imperative`/`tone` already shaped by step 5 — is what `orion.hub.turn_orchestrator.execute_unified_turn` (line ~407) hands to `HarnessRunRequestV1(thought_event=thought, ...)`, which `HarnessGovernorClient(harness_bus).run(harness_req)` sends to the FCC motor.
+
+Everything from step 1 through step 6 happens before the motor runs.
+
+## Missing questions (resolved during this investigation, recorded for the record)
+
+- **Does `stance_react.j2` see `autonomy_slice` at all today?** Yes, confirmed by reading the template directly (lines 51-60) — this is live, not aspirational.
+- **Is unified-turn actually the active path, or a dark-shipped future one?** Confirmed live: `docker exec orion-athena-hub env` shows `ORION_UNIFIED_TURN_ENABLED=true` right now.
+- **Does `chat_recent_dispatch_actions` depend on `chat_general`-specific ctx state, or is it verb-agnostic?** Verb-agnostic — `_project_recent_dispatch_actions` ignores `ctx` entirely and queries `load_action_outcomes` directly (see its own docstring), so it is already computed unconditionally regardless of which verb is running.
+
+## Proposed schema / API changes
+
+Add one bounded field to `AutonomySliceV1` (`orion/schemas/thought.py`):
+
+```python
+class AutonomySliceV1(BaseModel):
+    """Compact, post-hoc-attached projection of Orion's own current
+    drive/tension state (autonomy V2 reducer output) and recent
+    self-directed action outcomes (Layer 9 dispatch), not authored by
+    the LLM."""
+
+    schema_version: Literal["autonomy.slice.v1"] = "autonomy.slice.v1"
+    dominant_drive: str | None = None
+    active_tensions: list[str] = Field(default_factory=list)
+    pressure_trend: str | None = None
+    confidence: float | None = None
+    # New: compact, one-line-per-entry summaries of recent successful
+    # Layer-9 dispatch outcomes. Same cap discipline as active_tensions
+    # (at most _MAX_RECENT_DISPATCH_ACTIONS entries) -- not enforced at
+    # this layer, callers are responsible for the bound, matching the
+    # existing active_tensions comment's own convention.
+    recent_actions: list[str] = Field(default_factory=list)
+```
+
+`schema_version` stays `"autonomy.slice.v1"` — this is an additive, optional field with a safe empty default, not a version bump. Existing producers/consumers that never populate `recent_actions` are unaffected; `model_validate` on old payloads works unchanged since the field defaults to `[]`.
+
+No other schema changes. `ThoughtEventV1.autonomy_slice`, `HarnessRunRequestV1`, the bus contract for `orion:exec:request:LLMGatewayService`/stance_react's result metadata — none of these need touching. They already carry `AutonomySliceV1` as a typed sub-object; a new optional field flows through `model_dump`/`model_validate` on both ends automatically.
+
+### Where the new field gets populated
+
+In `chat_stance.py`, right after (or merged into) the existing autonomy_slice build block (~line 2593), format `ctx["chat_recent_dispatch_actions"]`'s `{kind, summary, success, observed_at}` dicts into compact one-line strings and pass them into the `AutonomySliceV1` construction. Concretely:
+
+- Move/duplicate the `_project_recent_dispatch_actions(ctx)` call (or its result) so it's available before `build_autonomy_slice` returns, OR keep `build_autonomy_slice` reducer-only-scoped (matching its current single responsibility) and merge `recent_actions` into the slice as a small separate step in `chat_stance.py` right after both projections exist — mirroring the existing precedent at chat_stance.py:2562 ("drive_state — a sibling of `inputs["autonomy"]`, never merged into it... independently-computed signals"), except here the two things *should* merge into one slice object because they're both destined for the same downstream schema and the same prompt block.
+- Format: `"{kind}: {summary}"`, truncated to a short character budget (match `ACTION_OUTCOME_SUMMARY_MAX_CHARS`-style discipline already used in the execution-dispatch-runtime emit path — reuse that constant's value or pick an equivalently small one, e.g. 160 chars, rather than inventing a new number without a home). Only include entries where `success is True` (failed/empty outcomes are not "what Orion did," they're noise for this advisory block — mirrors `extract_tensions_from_action_outcome`'s existing success-only convention from today's P3 work).
+- Cap at 3 (reuse `_MAX_RECENT_DISPATCH_ACTIONS`, already imported/available in the same file — do not hardcode a second copy of `3`).
+- Fail-open: empty `chat_recent_dispatch_actions` → empty `recent_actions` → the existing `if dominant_drive is None and not active_tensions and pressure_trend is None: return None` omit-check in `build_autonomy_slice` needs to also consider `recent_actions` in that condition (a turn with *only* recent actions and no drive/tension signal should still emit a slice, not be silently omitted).
+
+### Where the new field gets rendered
+
+`orion/cognition/prompts/stance_react.j2`, inside the existing `{% if autonomy_slice %}` block (lines 51-60), add one more conditional line following the exact same pattern as `active_tensions`:
+
+```jinja2
+{% if autonomy_slice.recent_actions %}- recent_actions: {{ autonomy_slice.recent_actions }}
+{% endif %}
+```
+
+Also update the block's advisory framing comment if the "recent self-directed action" framing needs a one-line mention alongside "drive/tension state" (currently line 52 says only "Oríon's own current drive/tension state").
+
+## Files likely to touch
+
+- `orion/schemas/thought.py` — add `recent_actions` field + updated docstring on `AutonomySliceV1`.
+- `services/orion-cortex-exec/app/autonomy_slice.py` — extend `build_autonomy_slice` (or add a small sibling merge step in chat_stance.py, per the design tradeoff above — implementer's call, document whichever is chosen) to populate `recent_actions`; update the omit-check condition.
+- `services/orion-cortex-exec/app/chat_stance.py` — reorder/wire the merge (`_project_recent_dispatch_actions` result must be available where `AutonomySliceV1` gets constructed).
+- `orion/cognition/prompts/stance_react.j2` — one new `{% if %}` line.
+- Tests: `services/orion-cortex-exec/tests/` — extend whatever existing test file covers `build_autonomy_slice` (find via `test_autonomy_slice.py` or similar) with cases: recent_actions populated + capped at 3, success-only filter, omit-check considers recent_actions, empty-list fail-open. Also a schema round-trip test for `AutonomySliceV1.model_validate` with `recent_actions` present, proving the existing router.py/bus_listener.py plumbing needs zero changes (this is the acceptance check for "reuses the existing pipe" — the test's whole point is showing the field survives dict → JSON → dict → model without any of the intermediate hops needing awareness of it).
+
+## Non-goals
+
+- Not touching `chat_general.j2` — it already renders this evidence correctly; no change needed there.
+- Not building a new parallel schema/plumbing path (a dedicated field on `ThoughtEventV1`, a new router.py map-on block, a new `bus_listener.py` extractor). `AutonomySliceV1`'s existing wiring already reaches the unified-turn path end-to-end; adding a second, structurally identical pipe for a 3-item list would be exactly the kind of ornamental layer AGENTS.md's "thin seams, not ornamental layers" rule warns against.
+- Not touching `EXECUTION_DISPATCH_MODE` / `ORION_DISPATCH_MAX_PER_DAY` live settings — those are a separate, already-in-flight decision from today's earlier work, unrelated to this patch.
+- Not addressing the earlier finding that `substrate.inspect`'s LLM call routes through the gateway's default `quick` lane rather than a dedicated background/metacog lane — a real observation from today's investigation, but a separate concern from this patch.
+- Not touching P7 (`ORION_ENDOGENOUS_ORIGINATION_ENABLED`).
+- Not adding a kill-switch/flag for this specific field — it inherits the exact same fail-open/omit-on-empty discipline `AutonomySliceV1` already has for its other fields, and the whole slice is already implicitly gated by `settings.orion_unified_grounding_enabled` upstream (the same flag gating `grounding_capsule` assembly) plus `AUTONOMY_STATE_V2_REDUCER_ENABLED` (which gates whether `autonomy_slice` gets built at all, per chat_stance.py:2571). A new dedicated flag would be config-surface bloat for an additive, fail-open, already-gated field.
+
+## Acceptance checks
+
+```bash
+pytest services/orion-cortex-exec/tests/ -k "autonomy_slice" -q
+pytest services/orion-cortex-exec/tests/ -k "chat_stance" -q
+```
+
+- `build_autonomy_slice` (or its sibling merge step) includes `recent_actions` when `chat_recent_dispatch_actions` has success=True entries, capped at 3, formatted as `"{kind}: {summary}"` truncated to the chosen char budget.
+- Failed/empty (`success is False`) dispatch outcomes are excluded from `recent_actions`.
+- The omit-check (`return None` when nothing meaningful) considers `recent_actions` — a turn with only recent-action signal (no drive/tension) still emits a slice.
+- `AutonomySliceV1.model_validate(payload_with_recent_actions)` round-trips correctly — proves router.py/bus_listener.py need no changes.
+- `stance_react.j2` renders `recent_actions` only when non-empty (Jinja conditional present and correctly gated).
+- No regression in existing `active_tensions`/`dominant_drive`/`pressure_trend` behavior (full existing `autonomy_slice` test file still green).
+- Live/manual verification (documented in the PR report, not necessarily automatable here): after deploying, trigger a real turn through the unified-turn path shortly after a real Layer-9 dispatch succeeds, and confirm `ThoughtEventV1.autonomy_slice.recent_actions` is non-empty for that turn — mirrors the exact live-verification method used earlier today for the P3 satisfaction-tension pipeline (temporary diagnostic log, live watch, then removed/cleaned up before commit).
+
+## Recommended next patch
+
+Implement via `/superpowers:subagent-driven-development`, worktree per repo convention (`scripts/new_worktree.sh fix stance-react-dispatch-evidence` or equivalent), single combined patch (schema + builder + template + tests) since the pieces are small and tightly coupled — not worth splitting into parallel tracks. Code review, README note if `services/orion-cortex-exec/README.md` documents `AutonomySliceV1`'s shape anywhere, commit, push, PR report.

--- a/orion/cognition/prompts/stance_react.j2
+++ b/orion/cognition/prompts/stance_react.j2
@@ -49,7 +49,7 @@ ATTENTION FRAME (advisory — inspectable curiosity/attention policy, not task i
 - open_loops: {{ chat_attention_frame.open_loops }}
 {% endif %}
 {% if autonomy_slice %}
-PRIOR SELF-SIGNAL (advisory — Oríon's own current drive/tension state)
+PRIOR SELF-SIGNAL (advisory — Oríon's own current drive/tension state and recent actions)
 - This reflects Oríon's own persisted autonomy state, computed before this turn.
 - Use it to color imperative/tone; it is NOT task instruction and never overrides
   user_message, association, grounding, or the actual task.
@@ -57,6 +57,7 @@ PRIOR SELF-SIGNAL (advisory — Oríon's own current drive/tension state)
 {% if autonomy_slice.dominant_drive %}- dominant_drive: {{ autonomy_slice.dominant_drive }}
 {% endif %}{% if autonomy_slice.active_tensions %}- active_tensions: {{ autonomy_slice.active_tensions }}
 {% endif %}{% if autonomy_slice.pressure_trend %}- pressure_trend: {{ autonomy_slice.pressure_trend }}
+{% endif %}{% if autonomy_slice.recent_actions %}- recent_actions: {{ autonomy_slice.recent_actions }}
 {% endif %}{% endif %}
 
 POSTURE ASSESSMENT (semantic inference — no keyword lists)

--- a/orion/harness/prefix.py
+++ b/orion/harness/prefix.py
@@ -43,6 +43,8 @@ def _format_autonomy_slice(sl: AutonomySliceV1) -> list[str]:
         lines.append(f"Active tensions: {', '.join(sl.active_tensions)}")
     if sl.pressure_trend:
         lines.append(f"Pressure trend: {sl.pressure_trend}")
+    if sl.recent_actions:
+        lines.append(f"Recent actions: {'; '.join(sl.recent_actions)}")
     return lines
 
 

--- a/orion/harness/tests/test_harness_prefix.py
+++ b/orion/harness/tests/test_harness_prefix.py
@@ -9,7 +9,7 @@ from orion.harness.prefix import compile_harness_prefix, harness_motor_instructi
 from orion.harness.tests.fixtures import make_thought
 from orion.schemas.cognition.answer_contract import AnswerContract
 from orion.schemas.harness_finalize import HarnessRepairOverlayV1
-from orion.schemas.thought import StanceHarnessSliceV1
+from orion.schemas.thought import AutonomySliceV1, StanceHarnessSliceV1
 
 
 def test_compile_harness_prefix_includes_stance_slice() -> None:
@@ -22,6 +22,42 @@ def test_compile_harness_prefix_includes_stance_slice() -> None:
     assert "Task mode: direct_response" in prompt
     assert "Answer strategy: direct" in prompt
     assert "how does coalition work?" in prompt
+
+
+def test_compile_harness_prefix_includes_autonomy_slice_recent_actions() -> None:
+    """Regression for the stance_react dispatch-evidence patch: the FCC
+    motor's own prefix must render recent_actions directly, not just leave
+    it to the upstream stance LLM's imperative/tone. A prior version of
+    _format_autonomy_slice only emitted dominant_drive/active_tensions/
+    pressure_trend and silently dropped recent_actions."""
+    thought = make_thought(
+        imperative="Inspect the module.",
+        tone="direct",
+        autonomy_slice=AutonomySliceV1(
+            dominant_drive="coherence",
+            recent_actions=["inspect: checked substrate graph health"],
+        ),
+    )
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="what have you been doing?",
+    )
+    assert "Recent actions: inspect: checked substrate graph health" in prompt
+
+
+def test_compile_harness_prefix_omits_recent_actions_line_when_empty() -> None:
+    thought = make_thought(
+        imperative="Inspect the module.",
+        tone="direct",
+        autonomy_slice=AutonomySliceV1(dominant_drive="coherence"),
+    )
+    prompt = compile_harness_prefix(
+        thought,
+        repair_overlay=HarnessRepairOverlayV1(),
+        user_message="what have you been doing?",
+    )
+    assert "Recent actions:" not in prompt
 
 
 def test_compile_harness_prefix_imperative_first_unified_brief() -> None:

--- a/orion/schemas/tests/test_thought.py
+++ b/orion/schemas/tests/test_thought.py
@@ -56,6 +56,7 @@ def test_autonomy_slice_v1_defaults() -> None:
     assert slice_.active_tensions == []
     assert slice_.pressure_trend is None
     assert slice_.confidence is None
+    assert slice_.recent_actions == []
 
 
 def test_autonomy_slice_v1_round_trips_through_json() -> None:
@@ -72,9 +73,38 @@ def test_autonomy_slice_v1_round_trips_through_json() -> None:
         "active_tensions": ["load_vs_recovery"],
         "pressure_trend": "falling",
         "confidence": 0.41,
+        "recent_actions": [],
     }
     restored = AutonomySliceV1.model_validate(dumped)
     assert restored == slice_
+
+
+def test_autonomy_slice_v1_recent_actions_round_trips_through_json() -> None:
+    """Acceptance check for the P4 stance_react dispatch-evidence patch: a
+    payload carrying the new recent_actions field survives
+    dict -> JSON -> dict -> model unchanged, proving router.py's metadata
+    map-on and orion-thought/app/bus_listener.py's _extract_autonomy_slice
+    need zero code changes to carry this field end to end.
+    """
+    slice_ = AutonomySliceV1(
+        dominant_drive="coherence",
+        active_tensions=["unresolved_thread"],
+        pressure_trend="rising",
+        confidence=0.63,
+        recent_actions=["inspect: checked substrate graph health"],
+    )
+    dumped = slice_.model_dump(mode="json")
+    assert dumped == {
+        "schema_version": "autonomy.slice.v1",
+        "dominant_drive": "coherence",
+        "active_tensions": ["unresolved_thread"],
+        "pressure_trend": "rising",
+        "confidence": 0.63,
+        "recent_actions": ["inspect: checked substrate graph health"],
+    }
+    restored = AutonomySliceV1.model_validate(dumped)
+    assert restored == slice_
+    assert restored.recent_actions == ["inspect: checked substrate graph health"]
 
 
 def test_thought_event_with_autonomy_slice_round_trips_through_json() -> None:

--- a/orion/schemas/thought.py
+++ b/orion/schemas/thought.py
@@ -56,7 +56,8 @@ class GroundingCapsuleV1(BaseModel):
 
 class AutonomySliceV1(BaseModel):
     """Compact, post-hoc-attached projection of Orion's own current drive/tension
-    state (autonomy V2 reducer output), not authored by the LLM."""
+    state (autonomy V2 reducer output) and recent self-directed action outcomes
+    (Layer 9 dispatch), not authored by the LLM."""
 
     schema_version: Literal["autonomy.slice.v1"] = "autonomy.slice.v1"
     dominant_drive: str | None = None
@@ -65,6 +66,11 @@ class AutonomySliceV1(BaseModel):
     active_tensions: list[str] = Field(default_factory=list)
     pressure_trend: str | None = None
     confidence: float | None = None
+    # Compact, one-line-per-entry summaries of recent successful Layer-9
+    # dispatch outcomes. Same cap discipline as active_tensions (at most
+    # _MAX_RECENT_DISPATCH_ACTIONS entries) -- not enforced at this layer,
+    # callers are responsible for the bound.
+    recent_actions: list[str] = Field(default_factory=list)
 
 
 class ThoughtEventV1(BaseModel):

--- a/services/orion-cortex-exec/app/autonomy_slice.py
+++ b/services/orion-cortex-exec/app/autonomy_slice.py
@@ -11,6 +11,20 @@ logger = logging.getLogger("orion.cortex.autonomy_slice")
 _MAX_ACTIVE_TENSIONS = 3
 # Minimum |after - before| pressure movement to call a trend rather than "stable".
 _PRESSURE_TREND_EPSILON = 0.02
+# Default cap for recent_actions when a caller doesn't pass max_recent_actions
+# explicitly (e.g. direct/test callers). The real production call site
+# (chat_stance.py) always passes its own _MAX_RECENT_DISPATCH_ACTIONS
+# explicitly so the two stay in sync without a second hardcoded copy of "3"
+# governing the live path.
+_DEFAULT_MAX_RECENT_ACTIONS = 3
+# Compact one-line "{kind}: {summary}" budget for recent_actions entries --
+# tighter than the raw summary ceiling upstream (chat_stance.py's
+# _DISPATCH_ACTION_SUMMARY_MAX_CHARS = 300, itself a defensive ceiling on top
+# of the producer's own ACTION_OUTCOME_SUMMARY_MAX_CHARS = 280 in
+# services/orion-execution-dispatch-runtime/app/worker.py) since this string
+# renders directly into the stance LLM's advisory prompt block alongside the
+# already-short dominant_drive/active_tensions strings.
+_RECENT_ACTION_LINE_MAX_CHARS = 160
 
 
 def _bounded_unique_tensions(values: Any, limit: int = _MAX_ACTIVE_TENSIONS) -> list[str]:
@@ -53,15 +67,55 @@ def _pressure_trend(movement_debug: Any) -> str | None:
     return "stable"
 
 
-def build_autonomy_slice(ctx: Dict[str, Any]) -> AutonomySliceV1 | None:
-    """Assemble the compact slice from the V2 reducer output already in ctx.
+def _format_recent_actions(entries: Any, limit: int) -> list[str]:
+    """Format successful Layer-9 dispatch-action outcomes into compact
+    one-line strings for ``AutonomySliceV1.recent_actions``.
 
-    Returns None (omit, not empty) when the reducer produced no meaningful
-    signal -- never fabricates a dominant_drive or tension.
+    ``entries`` is expected to be the list of ``{kind, summary, success,
+    observed_at}`` dicts produced by
+    ``chat_stance._project_recent_dispatch_actions`` (already newest-first),
+    but this is defensive against any shape: only ``success is True`` entries
+    with non-empty string ``kind``/``summary`` are included -- mirrors
+    ``extract_tensions_from_action_outcome``'s existing success-only
+    convention. Never raises; malformed input just yields fewer/no lines.
+    """
+    if not isinstance(entries, list):
+        return []
+    out: list[str] = []
+    for item in entries:
+        if not isinstance(item, dict):
+            continue
+        if item.get("success") is not True:
+            continue
+        kind = str(item.get("kind") or "").strip()
+        summary = str(item.get("summary") or "").strip()
+        if not kind or not summary:
+            continue
+        line = f"{kind}: {summary}"
+        if len(line) > _RECENT_ACTION_LINE_MAX_CHARS:
+            line = line[:_RECENT_ACTION_LINE_MAX_CHARS]
+        out.append(line)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def build_autonomy_slice(
+    ctx: Dict[str, Any],
+    max_recent_actions: int = _DEFAULT_MAX_RECENT_ACTIONS,
+) -> AutonomySliceV1 | None:
+    """Assemble the compact slice from the V2 reducer output already in ctx,
+    plus recent successful Layer-9 dispatch-action outcomes (also read from
+    ctx, under ``ctx["chat_recent_dispatch_actions"]`` -- populated by
+    ``chat_stance._project_recent_dispatch_actions`` before this is called).
+
+    Returns None (omit, not empty) when neither the reducer nor recent
+    dispatch actions produced any meaningful signal -- never fabricates a
+    dominant_drive, tension, or action.
     """
     state = ctx.get("chat_autonomy_state_v2")
-    if not isinstance(state, dict) or not state:
-        return None
+    if not isinstance(state, dict):
+        state = {}
 
     delta = ctx.get("chat_autonomy_state_delta")
     if not isinstance(delta, dict):
@@ -82,12 +136,15 @@ def build_autonomy_slice(ctx: Dict[str, Any]) -> AutonomySliceV1 | None:
     if not isinstance(confidence, (int, float)):
         confidence = None
 
+    recent_actions = _format_recent_actions(ctx.get("chat_recent_dispatch_actions"), max_recent_actions)
+
     # confidence deliberately excluded from this check: AutonomyStateV2.confidence
     # is a required field defaulting to 0.5, so it is present on essentially every
     # reducer output and would defeat omit-when-empty if allowed to count as
-    # "signal" on its own -- only real content (drive/tensions/trend) justifies
-    # emitting a slice.
-    if dominant_drive is None and not active_tensions and pressure_trend is None:
+    # "signal" on its own -- only real content (drive/tensions/trend/recent
+    # actions) justifies emitting a slice. A turn with only recent-action
+    # signal and no drive/tension/trend still emits a slice here.
+    if dominant_drive is None and not active_tensions and pressure_trend is None and not recent_actions:
         return None
 
     try:
@@ -96,6 +153,7 @@ def build_autonomy_slice(ctx: Dict[str, Any]) -> AutonomySliceV1 | None:
             active_tensions=active_tensions,
             pressure_trend=pressure_trend,
             confidence=confidence,
+            recent_actions=recent_actions,
         )
     except Exception:
         logger.warning("autonomy_slice_build_failed", exc_info=True)

--- a/services/orion-cortex-exec/app/autonomy_slice.py
+++ b/services/orion-cortex-exec/app/autonomy_slice.py
@@ -79,10 +79,12 @@ def _format_recent_actions(entries: Any, limit: int) -> list[str]:
     ``extract_tensions_from_action_outcome``'s existing success-only
     convention. Never raises; malformed input just yields fewer/no lines.
     """
-    if not isinstance(entries, list):
+    if not isinstance(entries, list) or limit <= 0:
         return []
     out: list[str] = []
     for item in entries:
+        if len(out) >= limit:
+            break
         if not isinstance(item, dict):
             continue
         if item.get("success") is not True:
@@ -95,8 +97,6 @@ def _format_recent_actions(entries: Any, limit: int) -> list[str]:
         if len(line) > _RECENT_ACTION_LINE_MAX_CHARS:
             line = line[:_RECENT_ACTION_LINE_MAX_CHARS]
         out.append(line)
-        if len(out) >= limit:
-            break
     return out
 
 

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -2568,6 +2568,15 @@ async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
         if drive_state_projection:
             inputs["drive_state"] = drive_state_projection
 
+    # Queries load_action_outcomes(subject="orion") directly (see
+    # _project_recent_dispatch_actions' docstring) rather than reading ctx, so
+    # it is unconditional -- independent of AUTONOMY_STATE_V2_REDUCER_ENABLED
+    # below. Computed here (before that gated block) so build_autonomy_slice()
+    # can fold it into recent_actions when the V2 reducer is enabled, while
+    # chat_general.j2's direct read of ctx["chat_recent_dispatch_actions"]
+    # keeps working unchanged either way. Fail-open: [] on any failure.
+    ctx["chat_recent_dispatch_actions"] = _project_recent_dispatch_actions(ctx)
+
     if os.getenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "").strip().lower() == "true":
         try:
             v2_result = await _run_autonomy_reducer(
@@ -2590,18 +2599,14 @@ async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
             # renders its prompt. router.py's post-hoc metadata attach (for the
             # harness-prefix/ThoughtEventV1 path) reads this same ctx key later
             # in the same turn -- it does not need to recompute it.
-            autonomy_slice = build_autonomy_slice(ctx)
+            # max_recent_actions is passed explicitly (this file's own
+            # _MAX_RECENT_DISPATCH_ACTIONS) so the cap has one source of truth
+            # rather than a second hardcoded "3" living inside autonomy_slice.py.
+            autonomy_slice = build_autonomy_slice(ctx, max_recent_actions=_MAX_RECENT_DISPATCH_ACTIONS)
             if autonomy_slice is not None:
                 ctx["autonomy_slice"] = autonomy_slice.model_dump(mode="json")
         except Exception as exc:
             logger.warning("autonomy_reducer_v2_failed error=%s", exc)
-
-    # Queries load_action_outcomes(subject="orion") directly (see
-    # _project_recent_dispatch_actions' docstring) rather than reading ctx,
-    # so placement here isn't order-dependent on the V2 reducer block above --
-    # kept in this general area only for proximity to the other stance
-    # context-building calls. Fail-open: [] on any failure.
-    ctx["chat_recent_dispatch_actions"] = _project_recent_dispatch_actions(ctx)
 
     if attention_frame_enabled():
         try:

--- a/services/orion-cortex-exec/app/chat_stance.py
+++ b/services/orion-cortex-exec/app/chat_stance.py
@@ -2572,8 +2572,8 @@ async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
     # _project_recent_dispatch_actions' docstring) rather than reading ctx, so
     # it is unconditional -- independent of AUTONOMY_STATE_V2_REDUCER_ENABLED
     # below. Computed here (before that gated block) so build_autonomy_slice()
-    # can fold it into recent_actions when the V2 reducer is enabled, while
-    # chat_general.j2's direct read of ctx["chat_recent_dispatch_actions"]
+    # can fold it into recent_actions regardless of the reducer's flag/success,
+    # while chat_general.j2's direct read of ctx["chat_recent_dispatch_actions"]
     # keeps working unchanged either way. Fail-open: [] on any failure.
     ctx["chat_recent_dispatch_actions"] = _project_recent_dispatch_actions(ctx)
 
@@ -2593,20 +2593,36 @@ async def build_chat_stance_inputs(ctx: Dict[str, Any]) -> Dict[str, Any]:
             ctx["chat_autonomy_state_delta"] = v2_result.delta.model_dump(mode="json")
             inputs["autonomy"]["state_v2"] = ctx["chat_autonomy_state_v2"]
             inputs["autonomy"]["delta"] = ctx["chat_autonomy_state_delta"]
-
-            # Built here (ctx key "autonomy_slice", matching what stance_react.j2
-            # reads directly) so it's present BEFORE the stance_react LLM step
-            # renders its prompt. router.py's post-hoc metadata attach (for the
-            # harness-prefix/ThoughtEventV1 path) reads this same ctx key later
-            # in the same turn -- it does not need to recompute it.
-            # max_recent_actions is passed explicitly (this file's own
-            # _MAX_RECENT_DISPATCH_ACTIONS) so the cap has one source of truth
-            # rather than a second hardcoded "3" living inside autonomy_slice.py.
-            autonomy_slice = build_autonomy_slice(ctx, max_recent_actions=_MAX_RECENT_DISPATCH_ACTIONS)
-            if autonomy_slice is not None:
-                ctx["autonomy_slice"] = autonomy_slice.model_dump(mode="json")
         except Exception as exc:
             logger.warning("autonomy_reducer_v2_failed error=%s", exc)
+
+    # Built here (ctx key "autonomy_slice", matching what stance_react.j2 reads
+    # directly) so it's present BEFORE the stance_react LLM step renders its
+    # prompt. router.py's post-hoc metadata attach (for the harness-prefix/
+    # ThoughtEventV1 path) reads this same ctx key later in the same turn -- it
+    # does not need to recompute it.
+    #
+    # Deliberately OUTSIDE the AUTONOMY_STATE_V2_REDUCER_ENABLED gate and its
+    # try/except above: recent_actions (real Layer-9 dispatch evidence) has
+    # nothing to do with the V2 reducer's health, so it must not go dark just
+    # because the reducer is disabled or threw. build_autonomy_slice() already
+    # treats an empty/missing chat_autonomy_state_v2 as "no drive/tension
+    # signal" rather than raising -- calling it unconditionally is safe and
+    # was the actual intent stated in this block's own comment above (recent
+    # actions are "independent of AUTONOMY_STATE_V2_REDUCER_ENABLED"); a prior
+    # version of this code contradicted that by nesting the call inside the
+    # gate anyway. Own try/except so a genuinely unexpected failure here can
+    # never take out the reducer block above it (or vice versa).
+    #
+    # max_recent_actions is passed explicitly (this file's own
+    # _MAX_RECENT_DISPATCH_ACTIONS) so the cap has one source of truth rather
+    # than a second hardcoded "3" living inside autonomy_slice.py.
+    try:
+        autonomy_slice = build_autonomy_slice(ctx, max_recent_actions=_MAX_RECENT_DISPATCH_ACTIONS)
+        if autonomy_slice is not None:
+            ctx["autonomy_slice"] = autonomy_slice.model_dump(mode="json")
+    except Exception as exc:
+        logger.warning("autonomy_slice_build_failed error=%s", exc)
 
     if attention_frame_enabled():
         try:

--- a/services/orion-cortex-exec/tests/test_autonomy_slice.py
+++ b/services/orion-cortex-exec/tests/test_autonomy_slice.py
@@ -121,3 +121,99 @@ def test_returns_none_when_state_present_but_no_meaningful_signal() -> None:
 def test_does_not_raise_on_malformed_ctx() -> None:
     assert build_autonomy_slice({"chat_autonomy_state_v2": "not-a-dict"}) is None
     assert build_autonomy_slice({"chat_autonomy_state_v2": _state_v2(), "chat_autonomy_movement_debug": "garbage"}) is not None
+
+
+def _dispatch_action(**overrides) -> dict:
+    base = dict(kind="inspect", summary="checked substrate graph health", success=True, observed_at="2026-07-14T00:00:00+00:00")
+    base.update(overrides)
+    return base
+
+
+def test_recent_actions_populated_and_capped_at_three_with_more_than_three_success_entries() -> None:
+    ctx = {
+        "chat_recent_dispatch_actions": [
+            _dispatch_action(kind="inspect", summary="entry one"),
+            _dispatch_action(kind="inspect", summary="entry two"),
+            _dispatch_action(kind="inspect", summary="entry three"),
+            _dispatch_action(kind="inspect", summary="entry four"),
+            _dispatch_action(kind="inspect", summary="entry five"),
+        ],
+    }
+    slice_ = build_autonomy_slice(ctx, max_recent_actions=3)
+    assert slice_ is not None
+    assert slice_.recent_actions == [
+        "inspect: entry one",
+        "inspect: entry two",
+        "inspect: entry three",
+    ]
+    assert len(slice_.recent_actions) <= 3
+
+
+def test_recent_actions_excludes_failed_or_missing_success_entries() -> None:
+    ctx = {
+        "chat_recent_dispatch_actions": [
+            _dispatch_action(kind="inspect", summary="failed attempt", success=False),
+            _dispatch_action(kind="inspect", summary="unknown outcome", success=None),
+            _dispatch_action(kind="inspect", summary="real success", success=True),
+        ],
+    }
+    slice_ = build_autonomy_slice(ctx)
+    assert slice_ is not None
+    assert slice_.recent_actions == ["inspect: real success"]
+
+
+def test_recent_actions_truncated_to_line_char_budget() -> None:
+    long_summary = "x" * 500
+    ctx = {"chat_recent_dispatch_actions": [_dispatch_action(kind="inspect", summary=long_summary)]}
+    slice_ = build_autonomy_slice(ctx)
+    assert slice_ is not None
+    assert len(slice_.recent_actions) == 1
+    assert len(slice_.recent_actions[0]) <= 160
+    assert slice_.recent_actions[0].startswith("inspect: ")
+
+
+def test_omit_check_emits_slice_when_only_recent_actions_have_signal() -> None:
+    """A turn with only recent-action signal (no drive/tension/trend) must
+    still emit a real AutonomySliceV1, not None -- this is the exact trap
+    the design spec calls out: the pre-existing state-absent early return
+    must not silently drop the whole feature."""
+    ctx = {
+        "chat_recent_dispatch_actions": [_dispatch_action(kind="inspect", summary="real success")],
+    }
+    slice_ = build_autonomy_slice(ctx)
+    assert slice_ is not None
+    assert slice_.dominant_drive is None
+    assert slice_.active_tensions == []
+    assert slice_.pressure_trend is None
+    assert slice_.recent_actions == ["inspect: real success"]
+
+
+def test_recent_actions_empty_or_missing_fails_open_to_empty_list() -> None:
+    ctx = {
+        "chat_autonomy_state_v2": _state_v2(),
+    }
+    slice_ = build_autonomy_slice(ctx)
+    assert slice_ is not None
+    assert slice_.recent_actions == []
+
+    ctx_with_empty_list = {
+        "chat_autonomy_state_v2": _state_v2(),
+        "chat_recent_dispatch_actions": [],
+    }
+    slice_2 = build_autonomy_slice(ctx_with_empty_list)
+    assert slice_2 is not None
+    assert slice_2.recent_actions == []
+
+    ctx_malformed = {
+        "chat_autonomy_state_v2": _state_v2(),
+        "chat_recent_dispatch_actions": "not-a-list",
+    }
+    slice_3 = build_autonomy_slice(ctx_malformed)
+    assert slice_3 is not None
+    assert slice_3.recent_actions == []
+
+
+def test_returns_none_when_everything_including_recent_actions_is_empty() -> None:
+    assert build_autonomy_slice({}) is None
+    assert build_autonomy_slice({"chat_recent_dispatch_actions": []}) is None
+    assert build_autonomy_slice({"chat_recent_dispatch_actions": [_dispatch_action(success=False)]}) is None

--- a/services/orion-cortex-exec/tests/test_autonomy_slice.py
+++ b/services/orion-cortex-exec/tests/test_autonomy_slice.py
@@ -217,3 +217,11 @@ def test_returns_none_when_everything_including_recent_actions_is_empty() -> Non
     assert build_autonomy_slice({}) is None
     assert build_autonomy_slice({"chat_recent_dispatch_actions": []}) is None
     assert build_autonomy_slice({"chat_recent_dispatch_actions": [_dispatch_action(success=False)]}) is None
+
+
+def test_recent_actions_respects_zero_or_negative_limit() -> None:
+    """Regression: the cap check must run before appending, not after --
+    otherwise max_recent_actions=0 still let exactly one entry through."""
+    ctx = {"chat_recent_dispatch_actions": [_dispatch_action(summary="entry one")]}
+    assert build_autonomy_slice(ctx, max_recent_actions=0) is None
+    assert build_autonomy_slice(ctx, max_recent_actions=-1) is None

--- a/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
+++ b/services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py
@@ -165,6 +165,63 @@ async def test_chat_stance_autonomy_v2_reducer_exception_swallowed(monkeypatch) 
     assert isinstance(ctx.get("chat_autonomy_summary"), dict)
 
 
+def _fake_action_outcome():
+    return {
+        "kind": "inspect",
+        "summary": "checked substrate graph health",
+        "success": True,
+        "observed_at": "2026-07-14T00:00:00+00:00",
+    }
+
+
+@pytest.mark.asyncio
+async def test_chat_stance_recent_actions_survive_when_reducer_disabled(monkeypatch) -> None:
+    """Regression: recent_actions must reach ctx["autonomy_slice"] even when
+    AUTONOMY_STATE_V2_REDUCER_ENABLED is off -- it has nothing to do with the
+    V2 reducer's health, per this block's own documented intent."""
+    monkeypatch.setattr(chat_stance, "load_action_outcomes", lambda subject: [_fake_action_outcome()])
+    monkeypatch.delenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", raising=False)
+    ctx: dict = {"user_message": "hello"}
+    await chat_stance.build_chat_stance_inputs(ctx)
+    assert "chat_autonomy_state_v2" not in ctx
+    slice_ = ctx.get("autonomy_slice")
+    assert slice_ is not None
+    assert slice_["recent_actions"] == ["inspect: checked substrate graph health"]
+
+
+@pytest.mark.asyncio
+async def test_chat_stance_recent_actions_survive_when_reducer_throws(monkeypatch) -> None:
+    """Regression: an unrelated V2 reducer exception must not take
+    recent_actions down with it -- the dispatch-action evidence was already
+    fetched successfully, outside the reducer's try/except, before this
+    diff's fix moved build_autonomy_slice() out of that block too."""
+    state = AutonomyStateV1(
+        subject="orion",
+        model_layer="self-model",
+        entity_id="self:orion",
+        dominant_drive="coherence",
+        drive_pressures={"coherence": 0.4},
+        active_drives=["coherence"],
+        tension_kinds=[],
+        goal_headlines=[],
+        source="graph",
+    )
+    monkeypatch.setattr(chat_stance, "_load_autonomy_state", lambda _ctx: _fake_autonomy_bundle(state))
+    monkeypatch.setattr(chat_stance, "load_action_outcomes", lambda subject: [_fake_action_outcome()])
+    monkeypatch.setenv("AUTONOMY_STATE_V2_REDUCER_ENABLED", "true")
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("reducer failure")
+
+    monkeypatch.setattr(chat_stance, "reduce_autonomy_state", _boom)
+    ctx: dict = {"user_message": "hello"}
+    await chat_stance.build_chat_stance_inputs(ctx)
+    assert "chat_autonomy_state_v2" not in ctx
+    slice_ = ctx.get("autonomy_slice")
+    assert slice_ is not None
+    assert slice_["recent_actions"] == ["inspect: checked substrate graph health"]
+
+
 @pytest.mark.asyncio
 async def test_chat_stance_empty_repo_omits_reasoning_quality_evidence(monkeypatch) -> None:
     state = AutonomyStateV1(


### PR DESCRIPTION
## Summary

- `AutonomySliceV1` gains `recent_actions: list[str]` — compact summaries of recent successful Layer-9 dispatch-action outcomes.
- Reuses the existing, live, already-proven pipe (`chat_stance.py` → `router.py`'s metadata map-on → `orion-thought`'s extraction → `ThoughtEventV1.autonomy_slice` → `stance_react.j2`'s rendered prompt) rather than building a parallel one — zero changes needed to `router.py` or `bus_listener.py`.
- Fixes a real trap: `build_autonomy_slice`'s old early return on empty reducer state ran before any recent-actions consideration and would have silently dropped this whole feature whenever there was no drive/tension signal that turn.

## Why

Real Layer-9 dispatch-action evidence previously only reached `chat_general.j2` (Brain mode, on a documented sunset track). `ORION_UNIFIED_TURN_ENABLED=true` is live right now — unified-turn is the actual active chat path — and never saw this evidence. Now it does, via the same mechanism already carrying drive/tension state into that path.

Full architecture trace (exact file/line references, not inferred) is in `docs/superpowers/specs/2026-07-14-stance-react-dispatch-evidence-design.md`.

## Review findings fixed

- `_format_recent_actions`'s cap check ran after appending, not before, so `max_recent_actions=0` still let one entry through. Fixed + regression-tested. Not reachable via the current sole caller (always passes 3), but real and untested prior to the fix.

## Tests run

```
pytest services/orion-cortex-exec/tests/test_autonomy_slice.py \
  services/orion-cortex-exec/tests/test_chat_stance_recent_dispatch_actions_projection.py \
  services/orion-cortex-exec/tests/test_chat_stance_autonomy_v2.py \
  services/orion-cortex-exec/tests/test_router_autonomy_payload_export.py \
  orion/schemas/tests/test_thought.py -q
58 passed
```

(The spec's literal `-k` commands hit a pre-existing, unrelated collection error across 12 files when the whole `tests/` dir loads — verified identical on a clean `origin/main` tree with this patch stashed out.)

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-cortex-exec/.env \
  -f services/orion-cortex-exec/docker-compose.yml up -d --build
```

Full PR report: `docs/superpowers/pr-reports/2026-07-14-stance-react-dispatch-evidence-pr.md`