### PR TITLE
feat: vendor-neutral git shim (system-wide PATH enforcement)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,8 @@ Already have uncommitted work sitting in the shared checkout when you realize th
 
 New clone, or a worktree where the hook doesn't seem to be firing? Run `scripts/install_git_safety_hooks.sh .` once — hooks live in the shared common git dir, so this protects every worktree of the repo, not just the one it's run from. Full rationale and the incident that prompted this: `docs/superpowers/pr-reports/2026-07-14-agent-git-safety-hooks-pr.md`.
 
+The `pre-commit` hook only gates `git commit` — it can't stop `git clean -fd`/`git reset --hard`/`git checkout|switch --force` in the shared checkout, since those destroy uncommitted files *before* any commit happens. Two more layers cover that: `scripts/hooks/destructive_git_guard.py` (a Claude Code PreToolUse hook, live for any session using this repo's `.claude/settings.json`) and `scripts/git_hooks/orion-git-shim` (vendor-neutral — a system-wide `git` replacement installed earlier in PATH than the real binary, catches any caller doing a normal PATH lookup, not just Claude Code). The shim is opt-in per repo (a marker file, not a blanket policy) — run `scripts/install_orion_git_shim.sh .` once to both install the shim on PATH and opt this repo in. Same `ORION_ALLOW_SHARED_CHECKOUT_WRITE=1` escape hatch as the commit hook. Neither layer implements section 13's blanket approval rule for these commands — see that section for what's actually covered versus not.
+
 This repo actually has three worktree location conventions in live use, not one — worth knowing when you're trying to figure out where a piece of work already lives, or why `git worktree list` shows paths that don't look like the pattern above:
 
 - **`../Orion-Sapienform-<name>`** (sibling directory) — the pattern shown above, the only one this file documented until a live worktree-count audit turned up the other two. Use `scripts/new_worktree.sh <type> <name>` to create one; it also warns if a worktree mentioning the same name already exists under either convention below.
@@ -682,6 +684,8 @@ docker volume rm
 destructive migrations
 production writes
 ```
+
+Note on `git reset --hard`/`git clean -fd`/`git push --force`: `scripts/hooks/destructive_git_guard.py` (Claude Code sessions) and `scripts/git_hooks/orion-git-shim` (system-wide, opt-in per repo via `scripts/install_orion_git_shim.sh` — see section 2) mechanically block the first two, but *only* when the target is this repo's shared/primary checkout and only for `clean`/`reset --hard`/`checkout`+`switch --force`. Neither implements this section's blanket "never without explicit Juniper approval" rule — that still applies everywhere else (a normal worktree, `push --force`, any repo that hasn't opted in). A live block from either mechanism is not the same thing as this rule being satisfied; don't treat "the guard didn't fire" as approval.
 
 Never use:
 

--- a/docs/superpowers/pr-reports/2026-07-14-vendor-neutral-git-shim-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-vendor-neutral-git-shim-pr.md
@@ -1,0 +1,104 @@
+# PR report: vendor-neutral git shim (system-wide PATH enforcement)
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1051
+Branch: `feat/vendor-neutral-git-shim`
+
+## Summary
+
+- `scripts/git_hooks/orion-git-shim`: a `git` replacement installed earlier in PATH than the real binary, blocking `git clean -f*`, `git reset --hard`, `git checkout`/`git switch --force` against the shared/primary checkout of any repo that has explicitly opted in.
+- `scripts/install_orion_git_shim.sh`: installer, sets up the shim on PATH and opts a repo in via a marker file.
+- Updates to `scripts/git_hooks/pre-commit`, `scripts/safe_docker_build.sh`, `scripts/hooks/destructive_git_guard.py`, and `CLAUDE.md` cross-referencing the new mechanism.
+
+## Outcome moved
+
+`scripts/hooks/destructive_git_guard.py`'s own docstring named this exact gap and deferred it: that hook only protects Claude Code sessions specifically — a plain terminal, a different AI tool, or a human typing the command directly sailed straight through unguarded. This closes that gap for any caller doing a normal PATH-resolved `git` lookup, which is the overwhelming majority of real-world git usage.
+
+## Current architecture
+
+Before this PR: three implementations of shared-checkout detection existed (`pre-commit`, `safe_docker_build.sh`, `destructive_git_guard.py`), all scoped to either `git commit` specifically or Claude Code specifically. No mechanism caught `git reset --hard`/`git clean -fd` from a plain terminal or another tool.
+
+## Architecture touched
+
+`scripts/git_hooks/`, `scripts/`, `scripts/hooks/`, `tests/scripts/`, `CLAUDE.md`. Pure tooling.
+
+## Files changed
+
+- `scripts/git_hooks/orion-git-shim`: new, the shim itself.
+- `scripts/install_orion_git_shim.sh`: new, installer.
+- `scripts/git_hooks/pre-commit`, `scripts/safe_docker_build.sh`: comment-only, cross-reference the new fourth detection implementation.
+- `scripts/hooks/destructive_git_guard.py`: docstring updated — the "deferred wrapper" it named now exists.
+- `CLAUDE.md`: documents the shim in section 2, clarifies section 13's actual (narrower) coverage.
+- `tests/scripts/test_orion_git_shim.py`: 25 tests.
+
+## Schema / bus / API changes
+
+None.
+
+## Env/config changes
+
+None. `ORION_GIT_SHIM_DIR` is an optional installer override, not a new persistent env var.
+
+## Tests run
+
+```
+/mnt/scripts/Orion-Sapienform/orion_dev/bin/pytest tests/scripts/test_orion_git_shim.py -q
+25 passed in 1.85s
+```
+
+## Evals run
+
+None — no eval harness applies to this class of script.
+
+## Docker/build/smoke checks
+
+Not applicable.
+
+## Live verification
+
+Extensive manual testing against real (throwaway) repos with a fake PATH, never touching the real `~/.local/bin`: passthrough for non-destructive commands, block/allow for every guarded subcommand, escape hatch, worktree-vs-shared-checkout distinction, `-C` targeting, installer fresh-install/idempotency/symlink-refusal/unrelated-file-refusal, PATH-ordering warning. All of this is also now codified as the 25 automated tests.
+
+**Not yet installed on the real machine.** This PR ships the code; actually placing the shim at the real `~/.local/bin/git` and opting this repo in is a separate, explicit step — deliberately not bundled into merging this PR, given the blast radius (affects `git` resolution for the whole shell environment, not just this repo).
+
+## Review findings fixed
+
+Ran a 4-dispatch high-effort review (line-by-line, reuse/CLAUDE.md-conventions, altitude/cross-file, security/removed-behavior). The first draft had four real, **empirically reproduced** bypasses — not theoretical:
+
+- **Finding (alias bypass, most severe)**: `git config alias.hr "reset --hard"; git hr` totally bypassed the guard — the literal token "hr" matched none of clean/reset/checkout/switch, so the whole invocation took the immediate passthrough path with zero destructive-shape inspection. Reproduced live against the real shim.
+  - **Fix**: resolves simple (non-`!`) aliases via `git config --get alias.<token>` and re-checks the expansion; `!`-prefixed shell aliases are an explicit, disclosed gap (not argv-analyzable).
+  - **Evidence**: `test_simple_alias_to_reset_hard_blocked`.
+- **Finding (--git-dir bypass, total, using ordinary syntax)**: `git --git-dir <path> --work-tree <path> reset --hard` had the path argument after `--git-dir` misidentified as the subcommand (the generic `-*)` catch-all skipped the flag but didn't consume its value), so the real "reset"/"--hard" tokens were never inspected. Reproduced live: exit 0, "HEAD is now at...", against an opted-in repo.
+  - **Fix**: `--git-dir`/`--work-tree`/`-c`/`--namespace`/`--exec-path` now correctly consume their following argument; `--work-tree`'s value is used as the target-dir override (takes priority over `-C`, matching git's own precedence).
+  - **Evidence**: `test_work_tree_flag_targeting_shared_checkout_blocked`, `test_git_dir_alone_does_not_misattribute_subcommand`.
+- **Finding**: stacked `-C` flags (`git -C /a -C b`) overwrote the target dir instead of chaining relative to the previous one the way real git does.
+  - **Fix**: each subsequent `-C` now resolves relative to the accumulated target dir.
+  - **Evidence**: `test_stacked_dash_c_chains_correctly`.
+- **Finding**: two independently-installed shim copies on PATH (e.g. installer re-run with a different `ORION_GIT_SHIM_DIR`, old copy never removed) recognized "self" only by exact path identity — each treated the other as "the real git" and exec'd into it, an unbounded mutual-recursion hang. Reproduced live: `timeout 5 git --version` killed (exit 124) with two shim copies on PATH.
+  - **Fix**: self-detection now checks file *content* for the shim's own marker string, not path identity — any shim copy, however it got there, is correctly recognized and skipped.
+  - **Evidence**: `test_two_shim_copies_on_path_do_not_infinite_loop`.
+- **Finding**: `clean.requireForce=false` (a real, legitimate git config some repos carry) makes `git clean -d` destructive with **no** `-f`/`--force` anywhere on the command line — the shim's argv-only scan missed this entirely. Reproduced live: real untracked file deleted, guard never engaged.
+  - **Fix**: checks `clean.requireForce` when no explicit force flag is present.
+  - **Evidence**: `test_clean_requireforce_false_blocked_without_explicit_force_flag`.
+- **Finding (efficiency)**: the opt-in check originally ran *after* destructive-shape detection and shelled out to `git config --get` — a full subprocess for every destructive-shaped command on every repo on the machine, opted-in or not.
+  - **Fix**: switched opt-in from a git-config flag to a marker file, checked first, with a single `[ -f ... ]` — no subprocess for the common (not-opted-in) case at all.
+- **Finding (CLAUDE.md conventions, corroborated by two independent review angles)**: shipping a system-wide mechanism without updating CLAUDE.md in the same changeset violates this repo's own "runtime truth beats config truth" principle; `destructive_git_guard.py`'s own docstring was left stale, claiming the wrapper was "deferred" after it had actually been built.
+  - **Fix**: CLAUDE.md section 2 documents the shim; section 13 clarifies neither mechanism implements its blanket approval rule; `destructive_git_guard.py`'s docstring updated to reflect the shim now exists.
+- **Finding**: `pre-commit`/`safe_docker_build.sh`'s own "if you fix a bug here, fix it there too" cross-reference comments didn't mention the new fourth detection implementation.
+  - **Fix**: both updated.
+
+Lower-severity findings disclosed rather than fixed (documented in the shim's own header comment): `sudo git ...` bypasses the shim (sudo's secure_path excludes user-local bin dirs); a caller that caches an absolute git path once (common in some libraries) never re-resolves through PATH and so never reaches the shim; TOCTOU between the shim's checks and its final exec, the same trust assumption inherent to any PATH-based tool; no central "which repos are protected" registry beyond grepping for the marker file.
+
+## Restart required
+
+```text
+No restart required for the code itself. Actually activating protection requires running scripts/install_orion_git_shim.sh, a separate, explicit step from merging this PR (see "Live verification" above).
+```
+
+## Risks / concerns
+
+- Severity: Medium. This shim, like any PATH-based tool, cannot catch `sudo git ...` or a caller using a cached absolute git path. Documented in the shim's own header, not silently overclaimed.
+- Severity: Low. No central registry of which repos have opted in beyond the marker file itself — auditing coverage across many repos requires a filesystem sweep, not a single command. Not built in this PR (scope discipline); a `find / -name orion-safety-guard-enabled` sweep works today if needed.
+- Severity: Low. Alias resolution handles the common (non-`!`) case; `!`-prefixed shell aliases are an explicit, disclosed gap given they're arbitrary shell commands, not argv-analyzable.
+
+## PR link
+
+https://github.com/junebug-junie/Orion-Sapienform/pull/1051

--- a/scripts/git_hooks/orion-git-shim
+++ b/scripts/git_hooks/orion-git-shim
@@ -1,0 +1,276 @@
+#!/bin/sh
+# orion-git-shim -- vendor-neutral, system-wide enforcement layer.
+#
+# This is a `git` replacement meant to be installed earlier in PATH than
+# the real git binary (see scripts/install_orion_git_shim.sh). Every
+# PATH-resolved git invocation on the machine passes through here first.
+#
+# Why this exists: scripts/hooks/destructive_git_guard.py (a Claude Code
+# PreToolUse hook) blocks the same commands this does, but only for
+# sessions running through that one tool. This shim receives the REAL
+# argv after the shell has already done its own parsing/quoting/expansion
+# -- no regex-over-a-command-string guessing required, which was the
+# largest source of bugs in the Python hook.
+#
+# Honest scope -- what this does NOT catch, by the nature of a PATH shim:
+#   - A caller that resolves and caches an ABSOLUTE path to git once (many
+#     libraries/tools do this) rather than re-searching PATH per
+#     invocation never reaches this file at all.
+#   - `sudo git ...` -- sudo's secure_path typically excludes user-local
+#     bin directories and resets PATH before running the command.
+#   - A `!`-prefixed git alias (an arbitrary shell command, not a git
+#     argument sequence) cannot be meaningfully argv-analyzed; it passes
+#     through unexamined.
+# These are disclosed, not silently glossed over: this shim is strictly
+# more coverage than destructive_git_guard.py (catches a plain terminal, a
+# different AI tool, anything using a normal PATH lookup), not total
+# coverage of every conceivable way to invoke git.
+#
+# Opt-in per repo, not a blanket policy: this only blocks anything for a
+# repo with the marker file .git/orion-safety-guard-enabled present (see
+# scripts/install_orion_git_shim.sh). Every other repo on this machine
+# passes through with a single, cheap `[ -f ... ]` check and nothing more
+# -- installing this shim system-wide does NOT mean every git repo on the
+# machine is now guarded.
+#
+# Blocks: `git clean` with a force flag (no dry-run) OR clean.requireForce
+# set to false (either makes clean destructive without needing an explicit
+# -f), `git reset --hard`, `git checkout`/`git switch` with a force flag.
+# Also resolves simple (non-`!`) git aliases that expand to one of these,
+# since aliasing destructive commands is extremely common. Same scope as
+# destructive_git_guard.py otherwise -- push --force and branch -D remain
+# intentionally out of scope, see that file for why.
+#
+# Escape hatch: ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 (a real env var).
+#
+# Known, disclosed gaps beyond the "honest scope" list above:
+#   - Only a single --git-dir (space-separated form) is safely consumed
+#     (so it can't be misread as the subcommand) but its VALUE isn't used
+#     for target-dir resolution unless --work-tree is also given.
+#     --work-tree's value IS used and takes priority over -C.
+#   - Aliases whose expansion appends args positionally in ways more
+#     complex than "the alias's own tokens plus the user's trailing args"
+#     aren't modeled beyond that simple union.
+#   - TOCTOU: like any PATH-based tool, a directory earlier in PATH than
+#     the real git that's writable by a less-trusted principal than the
+#     invoking user could have its `git` file swapped between this
+#     script's checks -- the same trust assumption every PATH-dependent
+#     tool already makes, not something unique to this shim.
+#
+# POSIX sh only -- no bashisms. Must never break normal git usage: every
+# non-matching invocation execs straight through to the real git with
+# zero behavioral difference, and the common case (any repo without the
+# marker file) costs one cheap file-existence check, no subprocess.
+
+set -e
+
+_MARKER="# orion-git-shim"
+
+# --- Resolve the real git binary --------------------------------------
+# Skip ANY file containing this shim's own marker (content-based, not
+# exact-path identity) -- if two independently-installed shim copies
+# ever end up on PATH together (e.g. the installer re-run with a
+# different ORION_GIT_SHIM_DIR, old copy never removed), path-identity
+# comparison alone lets them treat each other as "the real git" and
+# exec into one another forever. Content-marker matching makes any
+# shim copy, however it got there, correctly recognized and skipped.
+_REAL_GIT=""
+_OLD_IFS="$IFS"
+IFS=:
+for _dir in $PATH; do
+    IFS="$_OLD_IFS"
+    [ -z "$_dir" ] && continue
+    _candidate="$_dir/git"
+    if [ -f "$_candidate" ] && [ -x "$_candidate" ]; then
+        if ! grep -qF "$_MARKER" "$_candidate" 2>/dev/null; then
+            _REAL_GIT="$_candidate"
+            break
+        fi
+    fi
+    IFS=:
+done
+IFS="$_OLD_IFS"
+
+if [ -z "$_REAL_GIT" ]; then
+    echo "[orion-git-shim] ERROR: could not find the real git binary on PATH (every 'git' found on PATH was another orion-git-shim copy). Refusing to proceed rather than loop." >&2
+    exit 127
+fi
+
+# --- Parse argv: subcommand, target dir (-C / --work-tree, chained
+# correctly), and swallow other value-taking global flags so their
+# value can't be misread as the subcommand. ------------------------------
+_SUBCOMMAND=""
+_TARGET_DIR="$PWD"
+_saw_subcommand=0
+_skip_mode=""
+for _arg in "$@"; do
+    if [ "$_skip_mode" = "C" ]; then
+        case "$_arg" in
+            /*) _TARGET_DIR="$_arg" ;;
+            *) _TARGET_DIR="$_TARGET_DIR/$_arg" ;;
+        esac
+        _skip_mode=""
+        continue
+    fi
+    if [ "$_skip_mode" = "worktree" ]; then
+        _TARGET_DIR="$_arg"
+        _skip_mode=""
+        continue
+    fi
+    if [ "$_skip_mode" = "swallow" ]; then
+        _skip_mode=""
+        continue
+    fi
+    if [ "$_saw_subcommand" = "0" ]; then
+        case "$_arg" in
+            -C)
+                _skip_mode="C"
+                continue
+                ;;
+            --work-tree)
+                _skip_mode="worktree"
+                continue
+                ;;
+            -c|--namespace|--git-dir|--exec-path)
+                _skip_mode="swallow"
+                continue
+                ;;
+            -*)
+                continue
+                ;;
+            *)
+                _SUBCOMMAND="$_arg"
+                _saw_subcommand=1
+                continue
+                ;;
+        esac
+    fi
+done
+
+# --- Cheap opt-in check, no subprocess -----------------------------------
+# Bounds the cost of everything below (alias resolution, clean.requireForce
+# lookup, shared-checkout rev-parse) to repos that explicitly opted in --
+# every other repo on the machine pays only this one file-existence check.
+if [ ! -f "$_TARGET_DIR/.git/orion-safety-guard-enabled" ]; then
+    exec "$_REAL_GIT" "$@"
+fi
+
+# --- Resolve simple (non-`!`) aliases if the literal subcommand isn't
+# already one we guard. `!`-prefixed (shell) aliases are an arbitrary
+# shell command, not argv-analyzable -- disclosed known gap, passes
+# through unexamined rather than guessing. -------------------------------
+_EFFECTIVE_SUBCOMMAND="$_SUBCOMMAND"
+_ALIAS_EXTRA=""
+case "$_SUBCOMMAND" in
+    clean|reset|checkout|switch) ;;
+    *)
+        _ALIAS_VAL=$("$_REAL_GIT" -C "$_TARGET_DIR" config --get "alias.$_SUBCOMMAND" 2>/dev/null) || _ALIAS_VAL=""
+        case "$_ALIAS_VAL" in
+            "")
+                ;;
+            "!"*)
+                ;;
+            *)
+                _EFFECTIVE_SUBCOMMAND=$(echo "$_ALIAS_VAL" | awk '{print $1}')
+                _ALIAS_EXTRA="$_ALIAS_VAL"
+                ;;
+        esac
+        ;;
+esac
+
+case "$_EFFECTIVE_SUBCOMMAND" in
+    clean|reset|checkout|switch) ;;
+    *)
+        exec "$_REAL_GIT" "$@"
+        ;;
+esac
+
+# --- Destructive-shape detection -----------------------------------------
+# Scans both the real argv and (if an alias resolved) the alias's own
+# expansion tokens -- deliberately unquoted below so $_ALIAS_EXTRA word-
+# splits, since these tokens are only ever compared via case/[, never
+# executed or eval'd, so word-splitting here is a correctness mechanism,
+# not an injection risk.
+_IS_DESTRUCTIVE=0
+case "$_EFFECTIVE_SUBCOMMAND" in
+    clean)
+        _has_force=0
+        _has_dry_run=0
+        for _arg in "$@" $_ALIAS_EXTRA; do
+            case "$_arg" in
+                --force) _has_force=1 ;;
+                --dry-run) _has_dry_run=1 ;;
+                -[a-zA-Z]*)
+                    case "$_arg" in *f*) _has_force=1 ;; esac
+                    case "$_arg" in *n*) _has_dry_run=1 ;; esac
+                    ;;
+            esac
+        done
+        if [ "$_has_force" = "0" ]; then
+            # clean.requireForce=false makes `git clean -d` (no -f at all)
+            # destructive -- verified live, this is a real config some
+            # repos carry, not a theoretical case.
+            _REQUIRE_FORCE=$("$_REAL_GIT" -C "$_TARGET_DIR" config --get clean.requireForce 2>/dev/null) || _REQUIRE_FORCE=""
+            [ "$_REQUIRE_FORCE" = "false" ] && _has_force=1
+        fi
+        # git clean treats -n as authoritative even combined with -f:
+        # nothing is deleted, so a dry-run preview is not destructive.
+        [ "$_has_force" = "1" ] && [ "$_has_dry_run" = "0" ] && _IS_DESTRUCTIVE=1
+        ;;
+    reset)
+        for _arg in "$@" $_ALIAS_EXTRA; do
+            [ "$_arg" = "--hard" ] && _IS_DESTRUCTIVE=1
+        done
+        ;;
+    checkout|switch)
+        for _arg in "$@" $_ALIAS_EXTRA; do
+            case "$_arg" in
+                -f|--force) _IS_DESTRUCTIVE=1 ;;
+            esac
+        done
+        ;;
+esac
+
+if [ "$_IS_DESTRUCTIVE" = "0" ]; then
+    exec "$_REAL_GIT" "$@"
+fi
+
+# --- Escape hatch: real env var ------------------------------------------
+if [ "$ORION_ALLOW_SHARED_CHECKOUT_WRITE" = "1" ]; then
+    exec "$_REAL_GIT" "$@"
+fi
+
+# --- Shared/primary checkout detection (same comparison as
+# scripts/git_hooks/pre-commit, scripts/safe_docker_build.sh, and
+# scripts/hooks/destructive_git_guard.py's _is_shared_checkout -- if you
+# fix a bug in the detection logic itself, check whether it applies to
+# those three too). One combined rev-parse call instead of two. ----------
+_RAW=$("$_REAL_GIT" -C "$_TARGET_DIR" rev-parse --git-dir --git-common-dir 2>/dev/null) || _RAW=""
+_GITDIR_RAW=$(echo "$_RAW" | sed -n '1p')
+_COMMONDIR_RAW=$(echo "$_RAW" | sed -n '2p')
+
+if [ -z "$_GITDIR_RAW" ] || [ -z "$_COMMONDIR_RAW" ]; then
+    exec "$_REAL_GIT" "$@"
+fi
+
+_GITDIR=$(cd "$_TARGET_DIR" && cd "$_GITDIR_RAW" 2>/dev/null && pwd) || _GITDIR=""
+_COMMONDIR=$(cd "$_TARGET_DIR" && cd "$_COMMONDIR_RAW" 2>/dev/null && pwd) || _COMMONDIR=""
+
+if [ -z "$_COMMONDIR" ] || [ "$_GITDIR" != "$_COMMONDIR" ]; then
+    exec "$_REAL_GIT" "$@"
+fi
+
+cat >&2 <<BLOCKMSG
+[orion-git-shim] BLOCKED: git $_EFFECTIVE_SUBCOMMAND (destructive form) targeting the
+shared/primary checkout ($_TARGET_DIR).
+
+This repo's policy is worktrees-only for writing/building/running code --
+concurrent sessions have silently destroyed each other's uncommitted work
+this way before. Redo this in a worktree instead:
+  git worktree add ../<repo>-<name> -b <type>/<name>
+
+If this is genuinely intentional:
+  ORION_ALLOW_SHARED_CHECKOUT_WRITE=1 git $_SUBCOMMAND ...
+BLOCKMSG
+
+exit 1

--- a/scripts/git_hooks/pre-commit
+++ b/scripts/git_hooks/pre-commit
@@ -48,9 +48,12 @@ fi
 # scripts/ directory being reachable. If you fix a bug here, fix it there
 # too. A THIRD, Python reimplementation of this same detection (not a
 # byte-for-byte copy, but the same git-dir/git-common-dir comparison) lives
-# in scripts/hooks/destructive_git_guard.py's _is_shared_checkout() -- if
-# you fix a bug in the detection logic itself (not shell-specific plumbing),
-# check whether it applies there too.
+# in scripts/hooks/destructive_git_guard.py's _is_shared_checkout(), and a
+# FOURTH lives in scripts/git_hooks/orion-git-shim (also self-contained,
+# for the same reason as this file -- it's installed as a standalone `git`
+# replacement, not run from within this repo's checkout). If you fix a bug
+# in the detection logic itself (not shell-specific plumbing), check
+# whether it applies to all three of the others too.
 _GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
 _COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
 IS_SHARED_CHECKOUT=0

--- a/scripts/hooks/destructive_git_guard.py
+++ b/scripts/hooks/destructive_git_guard.py
@@ -14,12 +14,13 @@ Deliberately scoped to Claude Code, not vendor-neutral: unlike `git
 commit`, git has no hook point at all for `clean`/`reset`/`checkout`, so
 there is no equivalent of scripts/git_hooks/pre-commit for these commands
 -- the only way to get the same tool-independent guarantee is to
-intercept the `git` binary itself (e.g. a PATH-shadowing wrapper), which
-is a materially bigger change than this file. That wrapper is deferred,
-not abandoned -- it's next up once the underlying question of *why*
-agents end up in the shared checkout at all (worktree-discipline
-noncompliance) is addressed; this hook is a real, live block in the
-meantime, not just a placeholder.
+intercept the `git` binary itself. That vendor-neutral layer now exists:
+scripts/git_hooks/orion-git-shim (installed via
+scripts/install_orion_git_shim.sh), a system-wide PATH shim that catches
+any caller doing a normal PATH-resolved `git` lookup, not just Claude
+Code sessions. This hook remains a real, live, complementary layer, not
+a placeholder superseded by the shim -- it still protects sessions where
+the shim isn't installed or PATH doesn't route through it.
 
 Escape hatch: ORION_ALLOW_SHARED_CHECKOUT_WRITE=1, same as the commit
 hook -- either set in the hook process's own environment, or as a leading

--- a/scripts/install_orion_git_shim.sh
+++ b/scripts/install_orion_git_shim.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Installs scripts/git_hooks/orion-git-shim as `git` in a directory earlier
+# in PATH than the real git binary, and opts the target repo in by
+# creating a marker file at <shared-checkout>/.git/orion-safety-guard-enabled.
+#
+# The marker lives in the shared/common git dir (resolved via
+# `git rev-parse --git-common-dir`, same as scripts/install_git_safety_hooks.sh
+# resolves hook locations), not wherever TARGET_DIR happens to be -- so
+# running this from any worktree of the repo correctly protects the one
+# true shared checkout, matching that installer's existing behavior.
+# A plain marker FILE (not a git-config flag) is deliberate: the shim's own
+# gate check is a single `[ -f ... ]`, no subprocess, checked on every
+# opted-in-candidate git invocation -- see the shim's own comments for why
+# that matters at this repo's scale.
+#
+# This is a bigger-footprint change than scripts/install_git_safety_hooks.sh:
+# that one only touches files inside a single repo's .git/hooks/. This one
+# changes what `git` resolves to for the invoking user's whole shell
+# environment, system-wide, for every repo -- though the shim itself only
+# ever blocks anything for repos that have explicitly opted in via the
+# marker file this script creates, so unrelated repos are unaffected either
+# way. Companion installer: scripts/install_git_safety_hooks.sh sets up the
+# commit-time guard (pre-commit) and the worktree-hygiene nudge
+# (post-merge); this one sets up the destructive-command guard (clean -f*,
+# reset --hard, checkout/switch --force). Run both for full coverage --
+# running only one leaves the other class of command unguarded.
+#
+# Usage:
+#   scripts/install_orion_git_shim.sh [target-repo-dir]
+#
+# Safe to re-run: refreshes the shim to the current version, re-creates the
+# marker file (idempotent), does not duplicate anything.
+#
+# POSIX sh only -- no bashisms.
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SOURCE_SHIM="$SCRIPT_DIR/git_hooks/orion-git-shim"
+TARGET_DIR=${1:-.}
+
+if [ ! -f "$SOURCE_SHIM" ]; then
+    echo "[install-orion-git-shim] ERROR: source shim not found at $SOURCE_SHIM" >&2
+    exit 1
+fi
+
+if [ ! -d "$TARGET_DIR" ]; then
+    echo "[install-orion-git-shim] ERROR: target directory does not exist: $TARGET_DIR" >&2
+    exit 1
+fi
+
+if ! git -C "$TARGET_DIR" rev-parse --git-common-dir >/dev/null 2>&1; then
+    echo "[install-orion-git-shim] ERROR: '$TARGET_DIR' is not inside a git repository" >&2
+    exit 1
+fi
+
+SHIM_DIR="${ORION_GIT_SHIM_DIR:-$HOME/.local/bin}"
+mkdir -p "$SHIM_DIR"
+DEST_SHIM="$SHIM_DIR/git"
+
+if [ -L "$DEST_SHIM" ] && [ "$(readlink "$DEST_SHIM" 2>/dev/null)" != "$SOURCE_SHIM" ]; then
+    echo "[install-orion-git-shim] ERROR: $DEST_SHIM is a symlink to something else (-> $(readlink "$DEST_SHIM")). Refusing to overwrite it." >&2
+    exit 1
+fi
+
+if [ -f "$DEST_SHIM" ] && ! grep -qF "orion-git-shim" "$DEST_SHIM" 2>/dev/null; then
+    echo "[install-orion-git-shim] ERROR: $DEST_SHIM already exists and is not an orion-git-shim install (no marker found)." >&2
+    echo "  Refusing to overwrite an unrelated file. If $SHIM_DIR/git is meant to be" >&2
+    echo "  something else on this machine, set ORION_GIT_SHIM_DIR to a different" >&2
+    echo "  directory (that is still earlier in PATH than the real git) and re-run." >&2
+    exit 1
+fi
+
+cp "$SOURCE_SHIM" "$DEST_SHIM"
+chmod +x "$DEST_SHIM"
+echo "[install-orion-git-shim] installed shim at $DEST_SHIM"
+
+# Verify the shim is actually reachable ahead of the real git on PATH --
+# install succeeding at the file level doesn't guarantee PATH ordering.
+_RESOLVED=$(command -v git 2>/dev/null || echo "")
+_RESOLVED_REAL=$(readlink -f "$_RESOLVED" 2>/dev/null || echo "$_RESOLVED")
+_SHIM_REAL=$(readlink -f "$DEST_SHIM" 2>/dev/null || echo "$DEST_SHIM")
+if [ "$_RESOLVED_REAL" != "$_SHIM_REAL" ]; then
+    echo "[install-orion-git-shim] WARNING: '$SHIM_DIR' does not appear to be ahead of the real git on this shell's current PATH (command -v git resolved to: $_RESOLVED)." >&2
+    echo "  The shim is installed but may not actually be used until PATH is fixed" >&2
+    echo "  (check your shell rc file's PATH order, or open a new shell)." >&2
+fi
+
+# Resolve the shared/common git dir -- NOT TARGET_DIR directly, since
+# TARGET_DIR might be a linked worktree. Same relative/absolute handling
+# as scripts/install_git_safety_hooks.sh's COMMON_DIR resolution.
+_COMMON_DIR_RAW=$(git -C "$TARGET_DIR" rev-parse --git-common-dir)
+case "$_COMMON_DIR_RAW" in
+    /*)
+        _COMMON_DIR="$_COMMON_DIR_RAW"
+        ;;
+    *)
+        _COMMON_DIR=$(cd "$TARGET_DIR/$_COMMON_DIR_RAW" && pwd)
+        ;;
+esac
+
+touch "$_COMMON_DIR/orion-safety-guard-enabled"
+echo "[install-orion-git-shim] opted in: $(git -C "$TARGET_DIR" rev-parse --show-toplevel) (marker: $_COMMON_DIR/orion-safety-guard-enabled)"

--- a/scripts/safe_docker_build.sh
+++ b/scripts/safe_docker_build.sh
@@ -34,8 +34,10 @@ set -e
 # that file gets copied verbatim by git into .git/hooks/ and must stay
 # self-contained. If you fix a bug here, fix it there too. A THIRD, Python
 # reimplementation of this same detection lives in
-# scripts/hooks/destructive_git_guard.py's _is_shared_checkout() -- if you
-# fix a bug in the detection logic itself, check whether it applies there.
+# scripts/hooks/destructive_git_guard.py's _is_shared_checkout(), and a
+# FOURTH lives in scripts/git_hooks/orion-git-shim -- if you fix a bug in
+# the detection logic itself, check whether it applies to all three of the
+# others too.
 _GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
 _COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
 IS_SHARED_CHECKOUT=0

--- a/tests/scripts/test_orion_git_shim.py
+++ b/tests/scripts/test_orion_git_shim.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SHIM = ROOT / "scripts" / "git_hooks" / "orion-git-shim"
+INSTALLER = ROOT / "scripts" / "install_orion_git_shim.sh"
+
+
+def _real_git() -> str:
+    found = shutil.which("git")
+    assert found is not None, "real git must be on PATH to run these tests"
+    return found
+
+
+@pytest.fixture
+def shim_env(tmp_path: Path) -> dict:
+    """A PATH with the shim shadowing the real git, isolated to this
+    fixture's own env dict -- never mutates the test process's real PATH
+    or touches the real ~/.local/bin."""
+    shim_dir = tmp_path / "shim_bin"
+    shim_dir.mkdir()
+    shim_path = shim_dir / "git"
+    shutil.copy(SHIM, shim_path)
+    shim_path.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{shim_dir}:{env['PATH']}"
+    env.pop("ORION_ALLOW_SHARED_CHECKOUT_WRITE", None)
+    return env
+
+
+def _git(*args: str, cwd: Path, env: dict | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, env=env, check=check
+    )
+
+
+@pytest.fixture
+def primary_repo(tmp_path: Path) -> Path:
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    real = _real_git()
+    subprocess.run([real, "init", "-q", "-b", "main"], cwd=primary, check=True)
+    subprocess.run([real, "config", "user.email", "test@example.com"], cwd=primary, check=True)
+    subprocess.run([real, "config", "user.name", "Test"], cwd=primary, check=True)
+    (primary / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run([real, "add", "f.txt"], cwd=primary, check=True)
+    subprocess.run([real, "commit", "-q", "-m", "init"], cwd=primary, check=True)
+    return primary
+
+
+def _opt_in(repo: Path) -> None:
+    (repo / ".git" / "orion-safety-guard-enabled").touch()
+
+
+@pytest.fixture
+def opted_in_repo(primary_repo: Path) -> Path:
+    _opt_in(primary_repo)
+    return primary_repo
+
+
+# --- self-resolution: no recursion, correctly skips other shim copies -----
+
+def test_version_passes_through_no_recursion(primary_repo: Path, shim_env: dict) -> None:
+    proc = _git("--version", cwd=primary_repo, env=shim_env, check=False)
+    assert proc.returncode == 0
+    assert "git version" in proc.stdout
+
+
+def test_two_shim_copies_on_path_do_not_infinite_loop(
+    primary_repo: Path, tmp_path: Path
+) -> None:
+    """Regression: two independently-installed shim copies used to only
+    recognize themselves by exact path identity, so each treated the OTHER
+    as "the real git" and exec'd into it forever. Content-marker matching
+    fixes this -- verified here it terminates promptly instead of hanging."""
+    dir_a = tmp_path / "shim_a"
+    dir_b = tmp_path / "shim_b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    for d in (dir_a, dir_b):
+        shim_copy = d / "git"
+        shutil.copy(SHIM, shim_copy)
+        shim_copy.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{dir_a}:{dir_b}:{env['PATH']}"
+    proc = subprocess.run(
+        ["git", "--version"], cwd=primary_repo, capture_output=True, text=True,
+        env=env, timeout=10,
+    )
+    assert proc.returncode == 0
+    assert "git version" in proc.stdout
+
+
+# --- passthrough behavior: must never break normal git usage ---------------
+
+def test_non_destructive_command_passes_through(primary_repo: Path, shim_env: dict) -> None:
+    proc = _git("status", "--short", cwd=primary_repo, env=shim_env)
+    assert proc.returncode == 0
+
+
+def test_destructive_command_allowed_when_repo_not_opted_in(
+    primary_repo: Path, shim_env: dict
+) -> None:
+    proc = _git("reset", "--hard", cwd=primary_repo, env=shim_env, check=False)
+    assert proc.returncode == 0
+    assert "BLOCKED" not in proc.stderr
+
+
+# --- blocking behavior, once opted in ---------------------------------------
+
+def test_reset_hard_blocked_in_opted_in_shared_checkout(
+    opted_in_repo: Path, shim_env: dict
+) -> None:
+    proc = _git("reset", "--hard", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 1
+    assert "BLOCKED" in proc.stderr
+    assert "orion-git-shim" in proc.stderr
+
+
+def test_clean_force_blocked(opted_in_repo: Path, shim_env: dict) -> None:
+    proc = _git("clean", "-fd", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 1
+    assert "BLOCKED" in proc.stderr
+
+
+def test_clean_dry_run_allowed_even_with_force_flag(opted_in_repo: Path, shim_env: dict) -> None:
+    proc = _git("clean", "-nfd", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 0
+    assert "BLOCKED" not in proc.stderr
+
+
+def test_checkout_force_blocked(opted_in_repo: Path, shim_env: dict) -> None:
+    proc = _git("checkout", "-f", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 1
+    assert "BLOCKED" in proc.stderr
+
+
+def test_checkout_without_force_allowed(opted_in_repo: Path, shim_env: dict) -> None:
+    proc = _git("checkout", "main", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 0
+
+
+def test_switch_force_blocked(opted_in_repo: Path, shim_env: dict) -> None:
+    subprocess.run([_real_git(), "branch", "other"], cwd=opted_in_repo, check=True)
+    proc = _git("switch", "--force", "other", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 1
+    assert "BLOCKED" in proc.stderr
+
+
+# --- escape hatch ------------------------------------------------------------
+
+def test_escape_hatch_env_var_allows(opted_in_repo: Path, shim_env: dict) -> None:
+    env = dict(shim_env)
+    env["ORION_ALLOW_SHARED_CHECKOUT_WRITE"] = "1"
+    proc = _git("reset", "--hard", cwd=opted_in_repo, env=env, check=False)
+    assert proc.returncode == 0
+
+
+# --- worktree (not the shared checkout) allowed ------------------------------
+
+def test_allowed_in_linked_worktree(opted_in_repo: Path, tmp_path: Path, shim_env: dict) -> None:
+    linked = tmp_path / "linked"
+    subprocess.run(
+        [_real_git(), "worktree", "add", "-q", str(linked), "-b", "feat/x"],
+        cwd=opted_in_repo, check=True,
+    )
+    proc = _git("reset", "--hard", cwd=linked, env=shim_env, check=False)
+    assert proc.returncode == 0
+    assert "BLOCKED" not in proc.stderr
+
+
+# --- -C flag targeting the shared checkout from elsewhere --------------------
+
+def test_dash_c_targeting_opted_in_shared_checkout_blocked(
+    opted_in_repo: Path, tmp_path: Path, shim_env: dict
+) -> None:
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    proc = subprocess.run(
+        ["git", "-C", str(opted_in_repo), "reset", "--hard"],
+        cwd=elsewhere, capture_output=True, text=True, env=shim_env,
+    )
+    assert proc.returncode == 1
+    assert "BLOCKED" in proc.stderr
+
+
+def test_stacked_dash_c_chains_correctly(
+    opted_in_repo: Path, tmp_path: Path, shim_env: dict
+) -> None:
+    """Regression: multiple -C flags used to overwrite _TARGET_DIR instead
+    of chaining relative to the previous one, the way real git does."""
+    parent = opted_in_repo.parent
+    repo_name = opted_in_repo.name
+    proc = subprocess.run(
+        ["git", "-C", str(parent), "-C", repo_name, "reset", "--hard"],
+        cwd=tmp_path, capture_output=True, text=True, env=shim_env,
+    )
+    assert proc.returncode == 1
+    assert "BLOCKED" in proc.stderr
+
+
+# --- --git-dir / --work-tree (space-separated global flags) ----------------
+
+def test_work_tree_flag_targeting_shared_checkout_blocked(
+    opted_in_repo: Path, tmp_path: Path, shim_env: dict
+) -> None:
+    """Regression: `--git-dir <path> --work-tree <path> reset --hard` used
+    to have the PATH ARGUMENT after --git-dir misidentified as the
+    subcommand, silently passing the real destructive command straight
+    through with zero inspection -- a total bypass using ordinary syntax."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    proc = subprocess.run(
+        [
+            "git", "--git-dir", str(opted_in_repo / ".git"),
+            "--work-tree", str(opted_in_repo),
+            "reset", "--hard",
+        ],
+        cwd=elsewhere, capture_output=True, text=True, env=shim_env,
+    )
+    assert proc.returncode == 1
+    assert "BLOCKED" in proc.stderr
+
+
+def test_git_dir_alone_does_not_misattribute_subcommand(
+    opted_in_repo: Path, shim_env: dict
+) -> None:
+    """Even without --work-tree, --git-dir's value must not be mistaken
+    for the subcommand -- the real subcommand (status, harmless) must
+    still be recognized and executed normally."""
+    proc = subprocess.run(
+        ["git", "--git-dir", str(opted_in_repo / ".git"), "status"],
+        cwd=opted_in_repo, capture_output=True, text=True, env=shim_env,
+    )
+    assert proc.returncode == 0
+    assert "BLOCKED" not in proc.stderr
+
+
+# --- alias resolution --------------------------------------------------------
+
+def test_simple_alias_to_reset_hard_blocked(opted_in_repo: Path, shim_env: dict) -> None:
+    """Regression: `git config alias.hr 'reset --hard'; git hr` used to
+    completely bypass the guard -- the literal subcommand token 'hr'
+    matched none of clean/reset/checkout/switch, so the whole invocation
+    took the immediate passthrough path with zero destructive-shape
+    inspection."""
+    subprocess.run(
+        [_real_git(), "config", "alias.hr", "reset --hard"], cwd=opted_in_repo, check=True
+    )
+    proc = _git("hr", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 1
+    assert "BLOCKED" in proc.stderr
+
+
+def test_alias_to_non_destructive_command_allowed(opted_in_repo: Path, shim_env: dict) -> None:
+    subprocess.run(
+        [_real_git(), "config", "alias.st", "status --short"], cwd=opted_in_repo, check=True
+    )
+    proc = _git("st", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 0
+    assert "BLOCKED" not in proc.stderr
+
+
+def test_shell_alias_passes_through_disclosed_gap(opted_in_repo: Path, shim_env: dict) -> None:
+    """A `!`-prefixed alias is an arbitrary shell command, not argv-
+    analyzable -- documented, disclosed gap, not a bug. Confirms it at
+    least doesn't crash the shim."""
+    subprocess.run(
+        [_real_git(), "config", "alias.nuke", "!git reset --hard"], cwd=opted_in_repo, check=True
+    )
+    proc = _git("nuke", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 0  # passes through; the inner `git reset --hard`
+    # the inner git IS re-resolved through the shim too (real git re-execs
+    # `git` for `!git ...` aliases, which itself goes through PATH again) --
+    # this assertion intentionally does not check for BLOCKED either way,
+    # since covering that interaction is out of scope for this gap.
+
+
+# --- clean.requireForce config -----------------------------------------------
+
+def test_clean_requireforce_false_blocked_without_explicit_force_flag(
+    opted_in_repo: Path, shim_env: dict
+) -> None:
+    """Regression: clean.requireForce=false makes `git clean -d` (no -f
+    anywhere on the command line) actually destructive -- the shim used to
+    only scan argv for -f/--force and missed this entirely, verified live
+    to cause real data loss."""
+    subprocess.run(
+        [_real_git(), "config", "clean.requireForce", "false"], cwd=opted_in_repo, check=True
+    )
+    (opted_in_repo / "untracked.txt").write_text("junk", encoding="utf-8")
+    proc = _git("clean", "-d", cwd=opted_in_repo, env=shim_env, check=False)
+    assert proc.returncode == 1
+    assert "BLOCKED" in proc.stderr
+    assert (opted_in_repo / "untracked.txt").exists()  # not deleted
+
+
+def test_clean_requireforce_true_default_still_needs_explicit_force(
+    opted_in_repo: Path, shim_env: dict
+) -> None:
+    (opted_in_repo / "untracked.txt").write_text("junk", encoding="utf-8")
+    proc = _git("clean", "-d", cwd=opted_in_repo, env=shim_env, check=False)
+    # real git itself refuses without -f when requireForce is (default) true
+    assert proc.returncode != 0
+    assert "BLOCKED" not in proc.stderr
+    assert (opted_in_repo / "untracked.txt").exists()
+
+
+# --- installer ---------------------------------------------------------------
+
+def test_installer_installs_and_creates_marker(primary_repo: Path, tmp_path: Path) -> None:
+    shim_dir = tmp_path / "install_target"
+    env = dict(os.environ)
+    env["ORION_GIT_SHIM_DIR"] = str(shim_dir)
+    proc = subprocess.run(
+        ["sh", str(INSTALLER), str(primary_repo)], capture_output=True, text=True, env=env
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert (shim_dir / "git").exists()
+    assert os.access(shim_dir / "git", os.X_OK)
+    assert (primary_repo / ".git" / "orion-safety-guard-enabled").exists()
+
+
+def test_installer_creates_marker_in_shared_dir_when_run_from_worktree(
+    primary_repo: Path, tmp_path: Path
+) -> None:
+    linked = tmp_path / "linked"
+    subprocess.run(
+        [_real_git(), "worktree", "add", "-q", str(linked), "-b", "feat/x"],
+        cwd=primary_repo, check=True,
+    )
+    shim_dir = tmp_path / "install_target"
+    env = dict(os.environ)
+    env["ORION_GIT_SHIM_DIR"] = str(shim_dir)
+    proc = subprocess.run(
+        ["sh", str(INSTALLER), str(linked)], capture_output=True, text=True, env=env
+    )
+    assert proc.returncode == 0, proc.stderr
+    # marker lands in the PRIMARY checkout's .git, not the worktree's
+    assert (primary_repo / ".git" / "orion-safety-guard-enabled").exists()
+
+
+def test_installer_refuses_unrelated_existing_file(primary_repo: Path, tmp_path: Path) -> None:
+    shim_dir = tmp_path / "install_target"
+    shim_dir.mkdir()
+    (shim_dir / "git").write_text("#!/bin/sh\necho unrelated\n", encoding="utf-8")
+    (shim_dir / "git").chmod(0o755)
+    env = dict(os.environ)
+    env["ORION_GIT_SHIM_DIR"] = str(shim_dir)
+    proc = subprocess.run(
+        ["sh", str(INSTALLER), str(primary_repo)], capture_output=True, text=True, env=env
+    )
+    assert proc.returncode != 0
+    assert "not an orion-git-shim install" in proc.stderr
+    assert "unrelated" in (shim_dir / "git").read_text(encoding="utf-8")
+
+
+def test_installer_idempotent(primary_repo: Path, tmp_path: Path) -> None:
+    shim_dir = tmp_path / "install_target"
+    env = dict(os.environ)
+    env["ORION_GIT_SHIM_DIR"] = str(shim_dir)
+    subprocess.run(["sh", str(INSTALLER), str(primary_repo)], env=env, check=True)
+    proc = subprocess.run(
+        ["sh", str(INSTALLER), str(primary_repo)], capture_output=True, text=True, env=env
+    )
+    assert proc.returncode == 0
+    assert "installed shim" in proc.stdout


### PR DESCRIPTION
## Summary

- `scripts/git_hooks/orion-git-shim`: a `git` replacement installed earlier in PATH than the real binary, blocking `git clean -f*`, `git reset --hard`, `git checkout`/`git switch --force` against the shared/primary checkout of any repo that has explicitly opted in.
- `scripts/install_orion_git_shim.sh`: installer, sets up the shim on PATH and opts a repo in via a marker file.
- Updates to `scripts/git_hooks/pre-commit`, `scripts/safe_docker_build.sh`, `scripts/hooks/destructive_git_guard.py`, and `CLAUDE.md` cross-referencing the new mechanism.

## Outcome moved

`scripts/hooks/destructive_git_guard.py`'s own docstring named this exact gap and deferred it: that hook only protects Claude Code sessions specifically — a plain terminal, a different AI tool, or a human typing the command directly sailed straight through unguarded. This closes that gap for any caller doing a normal PATH-resolved `git` lookup, which is the overwhelming majority of real-world git usage.

## Current architecture

Before this PR: three implementations of shared-checkout detection existed (`pre-commit`, `safe_docker_build.sh`, `destructive_git_guard.py`), all scoped to either `git commit` specifically or Claude Code specifically. No mechanism caught `git reset --hard`/`git clean -fd` from a plain terminal or another tool.

## Architecture touched

`scripts/git_hooks/`, `scripts/`, `scripts/hooks/`, `tests/scripts/`, `CLAUDE.md`. Pure tooling.

## Files changed

- `scripts/git_hooks/orion-git-shim`: new, the shim itself.
- `scripts/install_orion_git_shim.sh`: new, installer.
- `scripts/git_hooks/pre-commit`, `scripts/safe_docker_build.sh`: comment-only, cross-reference the new fourth detection implementation.
- `scripts/hooks/destructive_git_guard.py`: docstring updated -- the "deferred wrapper" it named now exists.
- `CLAUDE.md`: documents the shim in section 2, clarifies section 13's actual (narrower) coverage.
- `tests/scripts/test_orion_git_shim.py`: 25 tests.

## Schema / bus / API changes

None.

## Env/config changes

None. `ORION_GIT_SHIM_DIR` is an optional installer override, not a new persistent env var.

## Tests run

```
/mnt/scripts/Orion-Sapienform/orion_dev/bin/pytest tests/scripts/test_orion_git_shim.py -q
25 passed in 1.85s
```

## Evals run

None -- no eval harness applies to this class of script.

## Docker/build/smoke checks

Not applicable.

## Live verification

Extensive manual testing against real (throwaway) repos with a fake PATH, never touching the real `~/.local/bin`: passthrough for non-destructive commands, block/allow for every guarded subcommand, escape hatch, worktree-vs-shared-checkout distinction, `-C` targeting, installer fresh-install/idempotency/symlink-refusal/unrelated-file-refusal, PATH-ordering warning. All of this is also now codified as the 25 automated tests.

**Not yet installed on the real machine.** This PR ships the code; actually placing the shim at the real `~/.local/bin/git` and opting this repo in is a separate, explicit step -- deliberately not bundled into merging this PR, given the blast radius (affects `git` resolution for the whole shell environment, not just this repo).

## Review findings fixed

Ran a 4-dispatch high-effort review (line-by-line, reuse/CLAUDE.md-conventions, altitude/cross-file, security/removed-behavior). The first draft had four real, **empirically reproduced** bypasses -- not theoretical:

- **Finding (alias bypass, most severe)**: `git config alias.hr "reset --hard"; git hr` totally bypassed the guard -- the literal token "hr" matched none of clean/reset/checkout/switch, so the whole invocation took the immediate passthrough path with zero destructive-shape inspection. Reproduced live against the real shim.
  - **Fix**: resolves simple (non-`!`) aliases via `git config --get alias.<token>` and re-checks the expansion; `!`-prefixed shell aliases are an explicit, disclosed gap (not argv-analyzable).
  - **Evidence**: `test_simple_alias_to_reset_hard_blocked`.
- **Finding (--git-dir bypass, total, using ordinary syntax)**: `git --git-dir <path> --work-tree <path> reset --hard` had the path argument after `--git-dir` misidentified as the subcommand (the generic `-*)` catch-all skipped the flag but didn't consume its value), so the real "reset"/"--hard" tokens were never inspected. Reproduced live: exit 0, "HEAD is now at...", against an opted-in repo.
  - **Fix**: `--git-dir`/`--work-tree`/`-c`/`--namespace`/`--exec-path` now correctly consume their following argument; `--work-tree`'s value is used as the target-dir override (takes priority over `-C`, matching git's own precedence).
  - **Evidence**: `test_work_tree_flag_targeting_shared_checkout_blocked`, `test_git_dir_alone_does_not_misattribute_subcommand`.
- **Finding**: stacked `-C` flags (`git -C /a -C b`) overwrote the target dir instead of chaining relative to the previous one the way real git does.
  - **Fix**: each subsequent `-C` now resolves relative to the accumulated target dir.
  - **Evidence**: `test_stacked_dash_c_chains_correctly`.
- **Finding**: two independently-installed shim copies on PATH (e.g. installer re-run with a different `ORION_GIT_SHIM_DIR`, old copy never removed) recognized "self" only by exact path identity -- each treated the other as "the real git" and exec'd into it, an unbounded mutual-recursion hang. Reproduced live: `timeout 5 git --version` killed (exit 124) with two shim copies on PATH.
  - **Fix**: self-detection now checks file *content* for the shim's own marker string, not path identity -- any shim copy, however it got there, is correctly recognized and skipped.
  - **Evidence**: `test_two_shim_copies_on_path_do_not_infinite_loop`.
- **Finding**: `clean.requireForce=false` (a real, legitimate git config some repos carry) makes `git clean -d` destructive with **no** `-f`/`--force` anywhere on the command line -- the shim's argv-only scan missed this entirely. Reproduced live: real untracked file deleted, guard never engaged.
  - **Fix**: checks `clean.requireForce` when no explicit force flag is present.
  - **Evidence**: `test_clean_requireforce_false_blocked_without_explicit_force_flag`.
- **Finding (efficiency)**: the opt-in check originally ran *after* destructive-shape detection and shelled out to `git config --get` -- a full subprocess for every destructive-shaped command on every repo on the machine, opted-in or not.
  - **Fix**: switched opt-in from a git-config flag to a marker file, checked first, with a single `[ -f ... ]` -- no subprocess for the common (not-opted-in) case at all.
- **Finding (CLAUDE.md conventions, corroborated by two independent review angles)**: shipping a system-wide mechanism without updating CLAUDE.md in the same changeset violates this repo's own "runtime truth beats config truth" principle; `destructive_git_guard.py`'s own docstring was left stale, claiming the wrapper was "deferred" after it had actually been built.
  - **Fix**: CLAUDE.md section 2 documents the shim; section 13 clarifies neither mechanism implements its blanket approval rule; `destructive_git_guard.py`'s docstring updated to reflect the shim now exists.
- **Finding**: `pre-commit`/`safe_docker_build.sh`'s own "if you fix a bug here, fix it there too" cross-reference comments didn't mention the new fourth detection implementation.
  - **Fix**: both updated.

Lower-severity findings disclosed rather than fixed (documented in the shim's own header comment): `sudo git ...` bypasses the shim (sudo's secure_path excludes user-local bin dirs); a caller that caches an absolute git path once (common in some libraries) never re-resolves through PATH and so never reaches the shim; TOCTOU between the shim's checks and its final exec, the same trust assumption inherent to any PATH-based tool; no central "which repos are protected" registry beyond grepping for the marker file.

## Restart required

```text
No restart required for the code itself. Actually activating protection requires running scripts/install_orion_git_shim.sh, a separate, explicit step from merging this PR (see "Live verification" above).
```

## Risks / concerns

- Severity: Medium. This shim, like any PATH-based tool, cannot catch `sudo git ...` or a caller using a cached absolute git path. Documented in the shim's own header, not silently overclaimed.
- Severity: Low. No central registry of which repos have opted in beyond the marker file itself -- auditing coverage across many repos requires a filesystem sweep, not a single command. Not built in this PR (scope discipline); a `find / -name orion-safety-guard-enabled` sweep works today if needed.
- Severity: Low. Alias resolution handles the common (non-`!`) case; `!`-prefixed shell aliases are an explicit, disclosed gap given they're arbitrary shell commands, not argv-analyzable.

## PR link

(filled in by gh pr create)