### PR TITLE
Fix/attention loop recency never decays

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-14-attention-loop-recency-never-decays-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-attention-loop-recency-never-decays-pr.md
@@ -1,0 +1,99 @@
+## Summary
+
+- Fixes a real, live, confirmed production bug: `orion/substrate/attention/salience.py`'s `_recency()` implements a genuine half-life decay (~6h) but was permanently returning `1.0` for every open loop, forever, because the one piece of state it needs (`SalienceHistory.first_seen_at`) was never populated by its only real caller.
+- **Found via a hand-verification of axis-4** (self-model fidelity — see `docs/superpowers/specs/2026-07-14-inner-state-signal-framework-working-doc.md`), not a code audit: a live reverie thought confidently narrated "the coalition is fixated on unresolved transport node anomalies... a struggle to stabilize... requires sustained attention" about `open-loop-9d84d08cddf5`. Checking that claim against real Postgres data found the loop had already been verdicted `resolved` (2026-07-08) and `dismissed` (2026-07-10) in `attention_loop_outcome`, yet was still winning selection on 2026-07-14 with `salience_features` byte-identical, field for field, to the 2026-07-10 snapshot.
+- Two fixes: (1) a new `_first_selected_at` dict in `attention_broadcast.py`, threaded into `_current_history()`, same lifecycle as the existing `_recent_selected_counts` (paired eviction); (2) `build_open_loops()` never received a `now` parameter at all — always defaulted to real wall-clock time internally, decoupled from the frame's own `generated_at`, which also made recency impossible to test deterministically. Now threaded through from `build_substrate_attention_frame`'s single resolved `now`.
+- 6 new/updated tests. Code review (2 angles) found 2 real test-hygiene gaps — both fixed.
+
+## Outcome moved
+
+`_recency()`'s existing, correctly-implemented decay math now actually runs. A loop that's been stale for days will correctly stop being artificially treated as "maximally fresh" in the salience competition.
+
+## Current architecture
+
+`orion/substrate/attention_broadcast.py` runs the "rung 3" continuous workspace competition over the substrate graph (`build_substrate_attention_frame` → `build_open_loops` → `select_actions`, then `broadcast_projection_from_frame` records the winner). `orion/substrate/attention/salience.py`'s `compute_features()` computes 7 features per loop (`evidence_strength`, `evidence_breadth`, `recurrence`, `recency`, `novelty_vs_known`, `dwell`, `habituation`), combined via a linear weighted sum (`LinearSalienceCombiner`, seed weights: `evidence_strength=0.30`, `novelty_vs_known=0.20`, `habituation=-0.35`, others smaller). Before this patch: `recency` was structurally dead — `_current_history()` (the only producer of `SalienceHistory` for this path) never set `first_seen_at`, so `_recency()`'s `first is None` branch fired every time, returning `1.0` unconditionally.
+
+## Architecture touched
+
+`orion/substrate/attention_broadcast.py`, `orion/substrate/attention/scoring.py` (both live production modules, `orion-substrate-runtime`), plus 3 test files. No schema change (`SalienceHistory.first_seen_at` already existed — added this session, unused until now). No other service, no `.env`/compose changes.
+
+## Files changed
+
+- `orion/substrate/attention_broadcast.py`: `_first_selected_at: dict[str, datetime]` (new module state, mirrors `_recent_selected_counts`'s exact lifecycle including eviction), `_record_selection()` now accepts `now`, `_current_history()` now populates `first_seen_at`. `build_substrate_attention_frame` resolves `now` once (`resolved_now`) and reuses it for both `build_open_loops(now=resolved_now)` and `AttentionFrameV1.generated_at`.
+- `orion/substrate/attention/scoring.py`: `build_open_loops()` gained `now: datetime | None = None`, threaded into `compute_salience(..., now=now)`.
+- `orion/substrate/tests/test_attention_broadcast_recency.py` (new): 4 tests — first selection stays fresh (unchanged behavior), recency decays after real simulated time passes (the core regression test), recency matches the live incident's actual scale (near-zero after 5 simulated days), eviction stays paired between the two dicts.
+- `orion/substrate/tests/test_scoring_salience_wiring.py`: 1 new test — direct, wall-clock-independent proof that `now` reaches the recency calculation (constructs `SalienceHistory` + two fixed, widely-separated `now` values, asserts the exact half-life relationship, no dependency on real execution time).
+- `orion/substrate/tests/test_broadcast_habituation.py`, `orion/substrate/tests/test_attention_broadcast_dwell.py`: fixture fixes (see Review findings below).
+
+## Schema / bus / API changes
+
+None. `SalienceHistory.first_seen_at` and `build_open_loops`'s new `now` parameter are both purely additive with safe defaults (`{}` / `None`) — no existing caller's behavior changes unless it opts in.
+
+## Env/config changes
+
+None.
+
+## Tests run
+
+```text
+.venv/bin/python -m pytest \
+  orion/substrate/tests/test_attention_broadcast_dwell.py \
+  orion/substrate/tests/test_attention_broadcast.py \
+  orion/substrate/tests/test_scoring_salience_wiring.py \
+  orion/substrate/tests/test_salience_combiner.py \
+  orion/substrate/tests/test_salience_schema.py \
+  orion/substrate/tests/test_attention_salience_contracts.py \
+  orion/substrate/tests/test_salience_discrimination_eval.py \
+  orion/substrate/tests/test_refit_salience_stub.py \
+  orion/substrate/tests/test_attention_broadcast_recency.py \
+  orion/substrate/tests/test_broadcast_habituation.py \
+  tests/test_attention_frame_schemas.py \
+  tests/test_attention_frame_builder.py -q
+=> 63 passed
+
+PYTHONPATH=services/orion-cortex-exec:. .venv/bin/python -m pytest \
+  services/orion-cortex-exec/tests/test_attention_frame.py -q
+=> 9 passed (the chat-turn-scoped sibling path, confirmed unaffected)
+```
+
+## Evals run
+
+None applicable — no eval harness exists for `orion/substrate/attention/`. The live diagnostic query used to find and confirm this bug (comparing a live reverie thought's claim against `attention_loop_outcome`/`substrate_attention_frames`/`substrate_attention_broadcast_projection` in Postgres) is the closest thing to an eval here — informal, by hand, not automated. Worth noting as a real gap: this class of bug (a dead feature silently pinned at its default) would benefit from a periodic live check, not just this one-off catch. Not building that here — out of proportionate scope for this fix.
+
+## Docker/build/smoke checks
+
+Not run this session. This is a code-only fix inside `orion-substrate-runtime`'s existing Python path — picked up on next rebuild/restart, no config/dependency changes to validate separately.
+
+## Review findings fixed
+
+2-angle code review run against the diff (correctness/wiring, cross-file/conventions):
+
+- Finding (correctness angle): `orion/substrate/tests/test_broadcast_habituation.py` (a pre-existing test file, not touched by the original patch) has an autouse fixture that resets `_recent_selected_counts` but never the new `_first_selected_at` — this file runs WITH habituation enabled (`monkeypatch.setenv(...HABITUATION_ENABLED, "true")`), so `_current_history()` is genuinely live there and the new dict gets populated by real test execution, creating a real state-leak risk between this file's own tests.
+  - Fix: added `_first_selected_at.clear()` to both setup and teardown.
+  - Evidence: `orion/substrate/tests/test_broadcast_habituation.py`'s fixture, both tests still pass (`test_broadcast_history_tracks_selection`, `test_rumination_lock_breaks_on_produced_path`).
+- Finding (cross-file angle): `orion/substrate/tests/test_attention_broadcast_dwell.py`'s fixture also never reset `_recent_selected_counts`/`_first_selected_at` — currently harmless (habituation is off in that file's tests, so `_current_history()` is never consulted), but a real order-dependent flake risk if that ever changes or if test execution is ever randomized/parallelized.
+  - Fix: added both to setup and teardown, for consistency and defensiveness.
+- Finding (correctness angle): the `now`-threading fix in `scoring.py` only had incidental test coverage (detection depended on real-clock proximity to a hardcoded test constant, not a direct assertion on `now` reaching the calculation).
+  - Fix: added `test_build_open_loops_now_param_reaches_recency_calculation` — fully deterministic, zero dependency on real execution time, asserts the exact half-life relationship between two fixed, widely-separated `now` values.
+- Noted, not fixed (confirmed out of scope, not a regression): `orion/substrate/attention_frame.py`'s `build_attention_frame` (the chat-turn-scoped sibling to the fixed broadcast path) never passes `history=`/`now=` to `build_open_loops` at all — it has no persistent habituation state of its own, so recency is always `1.0` there too, by the same mechanical path. Confirmed this is `SalienceHistory`'s own documented intent ("Phase 1 shadow behavior... the broadcast producer fills it in Phase 3") — this patch is exactly that Phase-3 broadcast-producer wiring, scoped to the path that has real persistent state. Not a regression introduced or left behind by this patch.
+- Noted, not resolved (real open question, flagged for awareness): `test_broadcast_habituation.py::test_rumination_lock_breaks_on_produced_path` proves the resonance/inhibition-of-return safety valve *can* work in a focused 15-tick unit test (a stuck loop does eventually lose to a competitor). Why that safety valve didn't save the live incident (`open-loop-9d84d08cddf5` won for 9+ minutes straight in production) wasn't fully root-caused this session — plausible candidates include service-restart-driven habituation-memory resets (both `_recent_selected_counts` and the new `_first_selected_at` are in-memory only, wiped on every `orion-substrate-runtime` restart) or the competing candidates never having comparable evidence_strength regardless of habituation penalty. This fix (recency) is real and correct on its own regardless of that open question, but it may not be the sole explanation for the specific incident depth observed.
+
+## Restart required
+
+```bash
+docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
+  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
+```
+Not run this session.
+
+## Risks / concerns
+
+- Severity: low
+- Concern: `_first_selected_at` is in-memory only (matches `_recent_selected_counts`'s existing, already-accepted behavior) — resets on every service restart, meaning recency briefly "forgets" real history across a restart. Consistent with existing habituation-memory behavior, not a new limitation this patch introduces.
+- Severity: low
+- Concern: the "why didn't resonance save us" open question above — this fix addresses a real, confirmed bug, but may not be the complete explanation for the specific 9+-minute incident depth. Worth a follow-up investigation if the same class of stuck-coalition behavior recurs after this deploys.
+
+## PR link
+
+`gh` is unauthenticated in this environment — open manually at:
+https://github.com/junebug-junie/Orion-Sapienform/pull/new/fix/attention-loop-recency-never-decays

--- a/orion/substrate/attention/scoring.py
+++ b/orion/substrate/attention/scoring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from typing import Any
 
 from orion.schemas.attention_frame import AttentionSignalV1, OpenLoopV1
@@ -78,6 +79,7 @@ def build_open_loops(
     stale_thread_active: bool,
     max_open: int,
     history: "SalienceHistory | None" = None,
+    now: datetime | None = None,
 ) -> list[OpenLoopV1]:
     user_text = compact(ctx.get("user_message") or ctx.get("raw_user_text") or "", 600)
     known = known_blob(inputs, ctx)
@@ -127,7 +129,7 @@ def build_open_loops(
         # traces are real even when the v2 flag is off. score_loop decides whether
         # to consume this value or the legacy weighted sum.
         loop_history = history or SalienceHistory()
-        sal, feats = compute_salience(loop=loop, signals=[signal], history=loop_history)
+        sal, feats = compute_salience(loop=loop, signals=[signal], history=loop_history, now=now)
         loop = loop.model_copy(update={"salience": sal, "salience_features": feats.model_dump(mode="json")})
         loops.append(loop)
     return loops

--- a/orion/substrate/attention_broadcast.py
+++ b/orion/substrate/attention_broadcast.py
@@ -47,6 +47,18 @@ _transition_history: deque[dict[str, Any]] = deque(maxlen=10)
 
 # Recent selected-loop counts for habituation (inhibition-of-return). Capped.
 _recent_selected_counts: dict[str, int] = {}
+# First real-clock moment each loop_id was ever selected. Feeds
+# salience._recency()'s half-life decay -- previously never wired up here,
+# so history.first_seen_at was always an empty dict and _recency() always
+# hit its "never seen before" branch and returned 1.0 unconditionally,
+# forever, for every loop (found live 2026-07-14: a loop verdicted
+# "resolved" on 07-08 and "dismissed" on 07-10 was still winning selection
+# on 07-14 with byte-identical salience_features to the 07-10 snapshot,
+# including recency=1.0). Same in-memory-only, capped-dict lifecycle as
+# _recent_selected_counts -- resets on service restart, consistent with
+# that field's existing, already-accepted behavior; not attempting to add
+# cross-restart persistence here, out of scope for this fix.
+_first_selected_at: dict[str, datetime] = {}
 _MAX_TRACKED_THEMES = 64
 
 # A theme selected at least this many times is "resonating" (stuck) — engage
@@ -54,13 +66,15 @@ _MAX_TRACKED_THEMES = 64
 _RESONANCE_MIN_COUNT = 3
 
 
-def _record_selection(loop_id: str | None) -> None:
+def _record_selection(loop_id: str | None, *, now: datetime | None = None) -> None:
     if not loop_id:
         return
     _recent_selected_counts[loop_id] = _recent_selected_counts.get(loop_id, 0) + 1
+    _first_selected_at.setdefault(loop_id, now or datetime.now(timezone.utc))
     if len(_recent_selected_counts) > _MAX_TRACKED_THEMES:
         drop = min(_recent_selected_counts, key=_recent_selected_counts.get)
         _recent_selected_counts.pop(drop, None)
+        _first_selected_at.pop(drop, None)
 
 
 def _current_history(resonance_theme_keys: set[str] | None = None) -> "SalienceHistory":
@@ -77,6 +91,7 @@ def _current_history(resonance_theme_keys: set[str] | None = None) -> "SalienceH
         dwell_ticks=_dwell_ticks,
         recent_theme_counts=dict(_recent_selected_counts),
         resonance_theme_keys=set(resonance_theme_keys),
+        first_seen_at=dict(_first_selected_at),
     )
 
 
@@ -163,6 +178,14 @@ def build_substrate_attention_frame(
     from orion.substrate.attention.salience import habituation_enabled
 
     lineage = list(belief_lineage or [])
+    # Resolve once, reuse everywhere below -- previously build_open_loops()
+    # (and therefore compute_salience()/_recency()) never received `now` at
+    # all and always defaulted to real wall-clock execution time internally,
+    # decoupled from this frame's own generated_at. Harmless in production
+    # (both were "real now" anyway) but meant recency could never be tested
+    # deterministically, and masked the real bug this patch fixes (see
+    # _first_selected_at above) during development.
+    resolved_now = now or datetime.now(timezone.utc)
     signals = substrate_pressure_signals(nodes, min_salience=min_salience, limit=max_signals)
     merged = merge_signals(signals, limit=max_open * 3)
     history = _current_history() if habituation_enabled() else None
@@ -176,6 +199,7 @@ def build_substrate_attention_frame(
         stale_thread_active=False,
         max_open=max_open,
         history=history,
+        now=resolved_now,
     )
     actions, selected, suppressions, deferred = select_actions(
         open_loops=open_loops,
@@ -186,7 +210,7 @@ def build_substrate_attention_frame(
         stale_thread_active=False,
     )
     frame = AttentionFrameV1(
-        generated_at=now or datetime.now(timezone.utc),
+        generated_at=resolved_now,
         open_loops=open_loops,
         live_unknowns=[loop.description for loop in open_loops if not loop.already_known],
         candidate_actions=actions,
@@ -322,7 +346,9 @@ def broadcast_projection_from_frame(frame: AttentionFrameV1) -> AttentionBroadca
     else:
         stability_score = 0.3
 
-    _record_selection(selected.open_loop_id if selected is not None else None)
+    _record_selection(
+        selected.open_loop_id if selected is not None else None, now=frame.generated_at
+    )
 
     return AttentionBroadcastProjectionV1(
         generated_at=frame.generated_at,

--- a/orion/substrate/tests/test_attention_broadcast_dwell.py
+++ b/orion/substrate/tests/test_attention_broadcast_dwell.py
@@ -22,11 +22,15 @@ def _reset_broadcast_globals():
     attention_broadcast._current_active_coalition = None
     attention_broadcast._dwell_ticks = 0
     attention_broadcast._transition_history.clear()
+    attention_broadcast._recent_selected_counts.clear()
+    attention_broadcast._first_selected_at.clear()
     yield
     attention_broadcast._coalition_history.clear()
     attention_broadcast._current_active_coalition = None
     attention_broadcast._dwell_ticks = 0
     attention_broadcast._transition_history.clear()
+    attention_broadcast._recent_selected_counts.clear()
+    attention_broadcast._first_selected_at.clear()
 
 
 def _node(node_id: str, label: str, pressure: float = 0.9) -> SimpleNamespace:

--- a/orion/substrate/tests/test_attention_broadcast_recency.py
+++ b/orion/substrate/tests/test_attention_broadcast_recency.py
@@ -1,0 +1,119 @@
+"""Regression tests for open-loop recency actually decaying over real time.
+
+Found live 2026-07-14: a loop verdicted "resolved" on 2026-07-08 and
+"dismissed" on 2026-07-10 was still winning attention-broadcast selection on
+2026-07-14, with salience_features byte-identical to the 2026-07-10 snapshot
+-- including recency=1.0, four days after the loop was last touched.
+Root cause: SalienceHistory.first_seen_at (consumed by
+orion.substrate.attention.salience._recency()'s half-life decay) was never
+populated by attention_broadcast.py's _current_history(), so _recency()
+always hit its "never seen before -> maximally fresh" branch and returned
+1.0 unconditionally, for every loop, forever.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import orion.substrate.attention_broadcast as attention_broadcast
+from orion.substrate.attention_broadcast import (
+    broadcast_projection_from_frame,
+    build_substrate_attention_frame,
+)
+
+_NOW = datetime(2026, 7, 14, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _reset_broadcast_globals(monkeypatch: pytest.MonkeyPatch):
+    # Matches the live deployment (.env: ORION_ATTENTION_HABITUATION_ENABLED=true)
+    # -- _current_history() (and therefore first_seen_at/_recency()) is only
+    # ever consulted when this flag is on; build_substrate_attention_frame
+    # passes history=None otherwise, bypassing the fix entirely. Without this,
+    # these tests would pass even with the original bug reintroduced.
+    monkeypatch.setenv("ORION_ATTENTION_HABITUATION_ENABLED", "true")
+    attention_broadcast._coalition_history.clear()
+    attention_broadcast._current_active_coalition = None
+    attention_broadcast._dwell_ticks = 0
+    attention_broadcast._transition_history.clear()
+    attention_broadcast._recent_selected_counts.clear()
+    attention_broadcast._first_selected_at.clear()
+    yield
+    attention_broadcast._coalition_history.clear()
+    attention_broadcast._current_active_coalition = None
+    attention_broadcast._dwell_ticks = 0
+    attention_broadcast._transition_history.clear()
+    attention_broadcast._recent_selected_counts.clear()
+    attention_broadcast._first_selected_at.clear()
+
+
+def _node(node_id: str, label: str, pressure: float = 0.9) -> SimpleNamespace:
+    return SimpleNamespace(
+        node_id=node_id,
+        label=label,
+        metadata={"dynamic_pressure": pressure},
+        signals=SimpleNamespace(confidence=0.8),
+    )
+
+
+def _tick(nodes: list, *, now: datetime):
+    frame = build_substrate_attention_frame(nodes=nodes, now=now)
+    return broadcast_projection_from_frame(frame)
+
+
+def _winning_loop_recency(projection) -> float:
+    loop_id = projection.selected_open_loop_id
+    assert loop_id is not None, "expected a winning loop to check recency on"
+    loop = next(loop for loop in projection.frame.open_loops if loop.id == loop_id)
+    assert loop.salience_features is not None
+    features = loop.salience_features
+    return features["recency"] if isinstance(features, dict) else features.recency
+
+
+def test_first_selection_is_maximally_fresh():
+    """Unchanged behavior: a loop selected for the first time is fresh (1.0)."""
+    nodes = [_node("node:hot", "unresolved contradiction")]
+    projection = _tick(nodes, now=_NOW)
+    assert _winning_loop_recency(projection) == pytest.approx(1.0)
+
+
+def test_recency_actually_decays_after_real_time_passes():
+    """The bug: recency stayed 1.0 forever because first_seen_at was never
+    recorded. First tick establishes first_seen_at; a much later tick on the
+    SAME loop must show decayed recency, not another 1.0."""
+    nodes = [_node("node:hot", "unresolved contradiction")]
+    first = _tick(nodes, now=_NOW)
+    assert _winning_loop_recency(first) == pytest.approx(1.0)
+
+    # 6 hours later == one half-life (see salience._recency's docstring).
+    later = _tick(nodes, now=_NOW + timedelta(hours=6))
+    recency = _winning_loop_recency(later)
+    assert recency < 1.0, (
+        f"recency did not decay after 6 real hours -- got {recency}, "
+        "first_seen_at wiring regressed"
+    )
+    assert recency == pytest.approx(0.5, abs=0.01)
+
+
+def test_recency_matches_live_incident_scale():
+    """The exact live-incident shape: a loop still winning ~4-6 real days
+    after it was first seen must show recency near zero, not 1.0."""
+    nodes = [_node("node:hot", "unresolved contradiction")]
+    _tick(nodes, now=_NOW)
+    much_later = _tick(nodes, now=_NOW + timedelta(days=5))
+    recency = _winning_loop_recency(much_later)
+    assert recency < 0.01, f"expected near-zero recency after 5 days, got {recency}"
+
+
+def test_first_selected_at_evicted_alongside_recent_selected_counts():
+    """_first_selected_at must not grow unboundedly independent of the
+    existing _recent_selected_counts cap -- eviction stays paired."""
+    for i in range(attention_broadcast._MAX_TRACKED_THEMES + 5):
+        nodes = [_node(f"node:{i}", f"focus {i}", pressure=0.9)]
+        _tick(nodes, now=_NOW + timedelta(seconds=i))
+    assert len(attention_broadcast._first_selected_at) <= attention_broadcast._MAX_TRACKED_THEMES
+    assert set(attention_broadcast._first_selected_at) <= set(
+        attention_broadcast._recent_selected_counts
+    )

--- a/orion/substrate/tests/test_broadcast_habituation.py
+++ b/orion/substrate/tests/test_broadcast_habituation.py
@@ -15,12 +15,14 @@ class _Node:
 @pytest.fixture(autouse=True)
 def _reset_broadcast_state():
     ab._recent_selected_counts.clear()
+    ab._first_selected_at.clear()
     ab._dwell_ticks = 0
     ab._coalition_history.clear()
     ab._current_active_coalition = None
     ab._transition_history.clear()
     yield
     ab._recent_selected_counts.clear()
+    ab._first_selected_at.clear()
     ab._dwell_ticks = 0
     ab._coalition_history.clear()
     ab._current_active_coalition = None

--- a/orion/substrate/tests/test_scoring_salience_wiring.py
+++ b/orion/substrate/tests/test_scoring_salience_wiring.py
@@ -1,5 +1,10 @@
+from datetime import datetime, timezone
+
+import pytest
+
 import orion.substrate.attention.salience as salience_mod
 from orion.schemas.attention_frame import AttentionSignalV1
+from orion.substrate.attention.salience import SalienceHistory
 from orion.substrate.attention.scoring import build_open_loops, score_loop
 
 
@@ -46,3 +51,40 @@ def test_score_loop_legacy_when_v2_off(monkeypatch):
     loop = loops[0]
     assert score_loop(loop) >= 0.0
     assert salience_mod.salience_v2_enabled() is False
+
+
+def test_build_open_loops_now_param_reaches_recency_calculation():
+    """Direct, wall-clock-independent proof that build_open_loops()'s `now`
+    parameter actually reaches compute_salience()/compute_features() instead
+    of being silently dropped (found missing entirely until this patch --
+    see orion/substrate/attention_broadcast.py's _first_selected_at comment
+    for the live incident this was part of). Two widely-separated fixed
+    `now` values against the SAME first_seen_at must produce different
+    recency -- if `now` were ignored and compute_features fell back to real
+    datetime.now(), both calls would (almost certainly) still differ from
+    each other by real elapsed test-runtime, but neither would show the
+    exact, deterministic half-life relationship asserted here."""
+    from orion.substrate.attention.common import compact, stable_id
+
+    first_seen = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    phrase = compact("the reactor plan", 120)
+    loop_id = stable_id("open-loop", phrase.lower())
+    history = SalienceHistory(first_seen_at={loop_id: first_seen})
+
+    fresh = build_open_loops(
+        signals=_ctx_signals(), ctx={"user_message": "the reactor plan"}, inputs={},
+        belief_lineage=[], direct_turn=False, generic_reversal=False,
+        stale_thread_active=False, max_open=5,
+        history=history, now=first_seen,
+    )[0]
+    six_hours_later = build_open_loops(
+        signals=_ctx_signals(), ctx={"user_message": "the reactor plan"}, inputs={},
+        belief_lineage=[], direct_turn=False, generic_reversal=False,
+        stale_thread_active=False, max_open=5,
+        history=history, now=first_seen.replace(hour=6),
+    )[0]
+
+    assert fresh.id == loop_id == six_hours_later.id
+    assert fresh.salience_features["recency"] == 1.0
+    # One half-life (see salience._recency's docstring: half-life ~6h).
+    assert six_hours_later.salience_features["recency"] == pytest.approx(0.5, abs=0.01)


### PR DESCRIPTION
## Summary

- Fixes a real, live, confirmed production bug: `orion/substrate/attention/salience.py`'s `_recency()` implements a genuine half-life decay (~6h) but was permanently returning `1.0` for every open loop, forever, because the one piece of state it needs (`SalienceHistory.first_seen_at`) was never populated by its only real caller.
- **Found via a hand-verification of axis-4** (self-model fidelity — see `docs/superpowers/specs/2026-07-14-inner-state-signal-framework-working-doc.md`), not a code audit: a live reverie thought confidently narrated "the coalition is fixated on unresolved transport node anomalies... a struggle to stabilize... requires sustained attention" about `open-loop-9d84d08cddf5`. Checking that claim against real Postgres data found the loop had already been verdicted `resolved` (2026-07-08) and `dismissed` (2026-07-10) in `attention_loop_outcome`, yet was still winning selection on 2026-07-14 with `salience_features` byte-identical, field for field, to the 2026-07-10 snapshot.
- Two fixes: (1) a new `_first_selected_at` dict in `attention_broadcast.py`, threaded into `_current_history()`, same lifecycle as the existing `_recent_selected_counts` (paired eviction); (2) `build_open_loops()` never received a `now` parameter at all — always defaulted to real wall-clock time internally, decoupled from the frame's own `generated_at`, which also made recency impossible to test deterministically. Now threaded through from `build_substrate_attention_frame`'s single resolved `now`.
- 6 new/updated tests. Code review (2 angles) found 2 real test-hygiene gaps — both fixed.

## Outcome moved

`_recency()`'s existing, correctly-implemented decay math now actually runs. A loop that's been stale for days will correctly stop being artificially treated as "maximally fresh" in the salience competition.

## Current architecture

`orion/substrate/attention_broadcast.py` runs the "rung 3" continuous workspace competition over the substrate graph (`build_substrate_attention_frame` → `build_open_loops` → `select_actions`, then `broadcast_projection_from_frame` records the winner). `orion/substrate/attention/salience.py`'s `compute_features()` computes 7 features per loop (`evidence_strength`, `evidence_breadth`, `recurrence`, `recency`, `novelty_vs_known`, `dwell`, `habituation`), combined via a linear weighted sum (`LinearSalienceCombiner`, seed weights: `evidence_strength=0.30`, `novelty_vs_known=0.20`, `habituation=-0.35`, others smaller). Before this patch: `recency` was structurally dead — `_current_history()` (the only producer of `SalienceHistory` for this path) never set `first_seen_at`, so `_recency()`'s `first is None` branch fired every time, returning `1.0` unconditionally.

## Architecture touched

`orion/substrate/attention_broadcast.py`, `orion/substrate/attention/scoring.py` (both live production modules, `orion-substrate-runtime`), plus 3 test files. No schema change (`SalienceHistory.first_seen_at` already existed — added this session, unused until now). No other service, no `.env`/compose changes.

## Files changed

- `orion/substrate/attention_broadcast.py`: `_first_selected_at: dict[str, datetime]` (new module state, mirrors `_recent_selected_counts`'s exact lifecycle including eviction), `_record_selection()` now accepts `now`, `_current_history()` now populates `first_seen_at`. `build_substrate_attention_frame` resolves `now` once (`resolved_now`) and reuses it for both `build_open_loops(now=resolved_now)` and `AttentionFrameV1.generated_at`.
- `orion/substrate/attention/scoring.py`: `build_open_loops()` gained `now: datetime | None = None`, threaded into `compute_salience(..., now=now)`.
- `orion/substrate/tests/test_attention_broadcast_recency.py` (new): 4 tests — first selection stays fresh (unchanged behavior), recency decays after real simulated time passes (the core regression test), recency matches the live incident's actual scale (near-zero after 5 simulated days), eviction stays paired between the two dicts.
- `orion/substrate/tests/test_scoring_salience_wiring.py`: 1 new test — direct, wall-clock-independent proof that `now` reaches the recency calculation (constructs `SalienceHistory` + two fixed, widely-separated `now` values, asserts the exact half-life relationship, no dependency on real execution time).
- `orion/substrate/tests/test_broadcast_habituation.py`, `orion/substrate/tests/test_attention_broadcast_dwell.py`: fixture fixes (see Review findings below).

## Schema / bus / API changes

None. `SalienceHistory.first_seen_at` and `build_open_loops`'s new `now` parameter are both purely additive with safe defaults (`{}` / `None`) — no existing caller's behavior changes unless it opts in.

## Env/config changes

None.

## Tests run

```text
.venv/bin/python -m pytest \
  orion/substrate/tests/test_attention_broadcast_dwell.py \
  orion/substrate/tests/test_attention_broadcast.py \
  orion/substrate/tests/test_scoring_salience_wiring.py \
  orion/substrate/tests/test_salience_combiner.py \
  orion/substrate/tests/test_salience_schema.py \
  orion/substrate/tests/test_attention_salience_contracts.py \
  orion/substrate/tests/test_salience_discrimination_eval.py \
  orion/substrate/tests/test_refit_salience_stub.py \
  orion/substrate/tests/test_attention_broadcast_recency.py \
  orion/substrate/tests/test_broadcast_habituation.py \
  tests/test_attention_frame_schemas.py \
  tests/test_attention_frame_builder.py -q
=> 63 passed

PYTHONPATH=services/orion-cortex-exec:. .venv/bin/python -m pytest \
  services/orion-cortex-exec/tests/test_attention_frame.py -q
=> 9 passed (the chat-turn-scoped sibling path, confirmed unaffected)
```

## Evals run

None applicable — no eval harness exists for `orion/substrate/attention/`. The live diagnostic query used to find and confirm this bug (comparing a live reverie thought's claim against `attention_loop_outcome`/`substrate_attention_frames`/`substrate_attention_broadcast_projection` in Postgres) is the closest thing to an eval here — informal, by hand, not automated. Worth noting as a real gap: this class of bug (a dead feature silently pinned at its default) would benefit from a periodic live check, not just this one-off catch. Not building that here — out of proportionate scope for this fix.

## Docker/build/smoke checks

Not run this session. This is a code-only fix inside `orion-substrate-runtime`'s existing Python path — picked up on next rebuild/restart, no config/dependency changes to validate separately.

## Review findings fixed

2-angle code review run against the diff (correctness/wiring, cross-file/conventions):

- Finding (correctness angle): `orion/substrate/tests/test_broadcast_habituation.py` (a pre-existing test file, not touched by the original patch) has an autouse fixture that resets `_recent_selected_counts` but never the new `_first_selected_at` — this file runs WITH habituation enabled (`monkeypatch.setenv(...HABITUATION_ENABLED, "true")`), so `_current_history()` is genuinely live there and the new dict gets populated by real test execution, creating a real state-leak risk between this file's own tests.
  - Fix: added `_first_selected_at.clear()` to both setup and teardown.
  - Evidence: `orion/substrate/tests/test_broadcast_habituation.py`'s fixture, both tests still pass (`test_broadcast_history_tracks_selection`, `test_rumination_lock_breaks_on_produced_path`).
- Finding (cross-file angle): `orion/substrate/tests/test_attention_broadcast_dwell.py`'s fixture also never reset `_recent_selected_counts`/`_first_selected_at` — currently harmless (habituation is off in that file's tests, so `_current_history()` is never consulted), but a real order-dependent flake risk if that ever changes or if test execution is ever randomized/parallelized.
  - Fix: added both to setup and teardown, for consistency and defensiveness.
- Finding (correctness angle): the `now`-threading fix in `scoring.py` only had incidental test coverage (detection depended on real-clock proximity to a hardcoded test constant, not a direct assertion on `now` reaching the calculation).
  - Fix: added `test_build_open_loops_now_param_reaches_recency_calculation` — fully deterministic, zero dependency on real execution time, asserts the exact half-life relationship between two fixed, widely-separated `now` values.
- Noted, not fixed (confirmed out of scope, not a regression): `orion/substrate/attention_frame.py`'s `build_attention_frame` (the chat-turn-scoped sibling to the fixed broadcast path) never passes `history=`/`now=` to `build_open_loops` at all — it has no persistent habituation state of its own, so recency is always `1.0` there too, by the same mechanical path. Confirmed this is `SalienceHistory`'s own documented intent ("Phase 1 shadow behavior... the broadcast producer fills it in Phase 3") — this patch is exactly that Phase-3 broadcast-producer wiring, scoped to the path that has real persistent state. Not a regression introduced or left behind by this patch.
- Noted, not resolved (real open question, flagged for awareness): `test_broadcast_habituation.py::test_rumination_lock_breaks_on_produced_path` proves the resonance/inhibition-of-return safety valve *can* work in a focused 15-tick unit test (a stuck loop does eventually lose to a competitor). Why that safety valve didn't save the live incident (`open-loop-9d84d08cddf5` won for 9+ minutes straight in production) wasn't fully root-caused this session — plausible candidates include service-restart-driven habituation-memory resets (both `_recent_selected_counts` and the new `_first_selected_at` are in-memory only, wiped on every `orion-substrate-runtime` restart) or the competing candidates never having comparable evidence_strength regardless of habituation penalty. This fix (recency) is real and correct on its own regardless of that open question, but it may not be the sole explanation for the specific incident depth observed.

## Restart required

```bash
docker compose --env-file .env --env-file services/orion-substrate-runtime/.env \
  -f services/orion-substrate-runtime/docker-compose.yml up -d --build
```
Not run this session.

## Risks / concerns

- Severity: low
- Concern: `_first_selected_at` is in-memory only (matches `_recent_selected_counts`'s existing, already-accepted behavior) — resets on every service restart, meaning recency briefly "forgets" real history across a restart. Consistent with existing habituation-memory behavior, not a new limitation this patch introduces.
- Severity: low
- Concern: the "why didn't resonance save us" open question above — this fix addresses a real, confirmed bug, but may not be the complete explanation for the specific 9+-minute incident depth. Worth a follow-up investigation if the same class of stuck-coalition behavior recurs after this deploys.
