### PR TITLE
fix(reverie): verdict-aware narration + refractory theme-key mismatch

### DIFF
--- a/docs/superpowers/pr-reports/2026-07-14-reverie-verdict-aware-narration-pr.md
+++ b/docs/superpowers/pr-reports/2026-07-14-reverie-verdict-aware-narration-pr.md
@@ -1,0 +1,106 @@
+# PR report — reverie verdict-aware narration + refractory theme-key fix
+
+PR: https://github.com/junebug-junie/Orion-Sapienform/pull/1055
+Branch: `fix/reverie-verdict-aware-narration`
+Status: **DONE**
+
+## Summary
+
+Two compounding bugs meant reverie could confidently narrate urgency about an
+open loop a human had already resolved or dismissed via the Hub:
+
+1. `chain.py`'s `theme_key_for()` keyed refractory suppression as
+   `"loop:<id>"` — a format only that function ever wrote or read.
+   `attention_loops_store.py`'s `suppress_loop()` (called on a human's
+   Resolve/Dismiss action) and `attention_salience_trace.theme_key` both use
+   the bare loop id. The two never matched, so a closed loop's
+   chain-refractory suppression silently never took effect. **Live-broken in
+   prod** — `ORION_REVERIE_CHAIN_ENABLED=true` is the live config.
+2. Even with suppression working, reverie's narration prompt had no
+   visibility into `attention_loop_outcome` verdicts at all — `OpenLoopV1`
+   carries no outcome field, and that table was read only by the offline
+   weight-refit script and Hub display routes.
+
+This is changeset 1 of 2 from `docs/superpowers/specs/2026-07-14-reverie-narration-continuity-design.md`
+(chain narration continuity — prior-step memory, next_focus wiring,
+confidence/dwell framing — is changeset 2, not in this patch).
+
+## Outcome moved
+
+A human resolving/dismissing an attention loop in the Hub now actually
+suppresses reverie chains from re-igniting on it. Reverie's narration is
+grounded in recorded human verdicts instead of confabulating urgency about
+already-closed loops.
+
+## Root-cause discovery
+
+Found while implementing the spec's changeset 1 (narration-only
+verdict-awareness): reading `attention_loops_store.py` to design the outcome
+lookup surfaced that a `suppress_loop()` mechanism already existed and was
+*intended* to solve this exact problem end-to-end (Resolve → refractory
+suppression → chain skips it) — it was just silently broken by a key-format
+mismatch, not missing as a feature. Fixing that mismatch was folded into this
+changeset since it's the same root problem class, thin, and directly in scope.
+
+## Review findings fixed
+
+Ran the `code-review` skill (level: high, 8 finder angles via subagents,
+1-vote verify) against the diff. Fixed:
+
+- **Row-shaping outside try/except**: `load_recent_loop_outcomes`'s docstring
+  promised "never raises," but only the DB round-trip was guarded — a
+  malformed row shape would propagate. Widened the try to cover shaping.
+- **`age_days: None` could reach the prompt**: when `created_at` wasn't a
+  usable datetime, the LLM could see a literal null and narrate "closed None
+  days ago." Now the key is omitted rather than null.
+- **Blocking sync DB call in the async event loop**: the new
+  `load_recent_loop_outcomes` call had no `asyncio.to_thread` offload, unlike
+  `chain.py`'s established convention for blocking DB/HTTP calls on this
+  shared event loop. Wrapped it.
+- **Prompt block rendered unconditionally**: the `ALREADY-SETTLED LOOPS`
+  instruction appeared on every tick with any open loops, not just when a
+  loop actually had a verdict. Gated on a new deterministic
+  `has_settled_loops` flag.
+- **No coverage of actual narration behavior**: original tests only checked
+  context-dict shape, not what the model is actually told — a misworded or
+  dropped instruction would have passed every test. Added a golden-prompt
+  test rendering the real Jinja template.
+- **Deploy-boundary orphaned rows** (found independently by 3 of the 8
+  review angles): the theme-key format change has no backfill for rows
+  already written under the old prefixed key. Added an idempotent one-time
+  SQL backfill.
+
+Not fixed, accepted and documented in the PR: `resonance_monitor.py`'s
+in-memory tracked-theme set (built from orion-notify's pending-reason
+strings) can emit one spurious "recovered" notification for a loop actively
+paging at the exact deploy instant — self-heals on the next tick, judged not
+worth code for a single cosmetic notification.
+
+## Tests run
+
+```text
+pytest services/orion-thought/tests services/orion-thought/evals -q   → 162 passed
+pytest orion/reverie/ -q                                              → 46 passed
+pytest services/orion-hub/tests/test_reverie_observability_section.py -q → 8 passed
+pytest services/orion-cortex-exec/tests/test_chat_stance_reverie_glimpse_projection.py -q → 11 passed
+pytest services/orion-dream/tests/test_rem_compaction.py -q           → 15 passed
+git diff --check                                                      → clean
+```
+
+## Restart required
+
+```bash
+psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_reverie_theme_key_bare_id_backfill.sql
+
+docker compose \
+  --env-file .env \
+  --env-file services/orion-thought/.env \
+  -f services/orion-thought/docker-compose.yml \
+  up -d --build
+```
+
+## Next
+
+Changeset 2 (`feat/reverie-chain-continuity`: #2 prior-step memory, #3
+next_focus, #6 salience margin, #7 dwell framing) is spec'd and pinned for
+after this lands and is verified live.

--- a/docs/superpowers/specs/2026-07-14-reverie-narration-continuity-design.md
+++ b/docs/superpowers/specs/2026-07-14-reverie-narration-continuity-design.md
@@ -1,0 +1,291 @@
+# Reverie narration continuity — design spec
+
+Status: DESIGN, not implemented. Ground truth verified live 2026-07-14 against
+`main` (post `37e97b92`, the open-loop recency fix).
+
+Scope decided by Juniper: build #1, #2, #3, #6, #7 below. Pin #4 (cross-chain
+theme memory) and #5 (deterministic narrative-stability trace) for later.
+Confirmed: reverie is live in prod. Confirmed: the intended shape is **a
+conscious stream when chained, episodic when standalone** — i.e. continuity is
+scoped to the chain, not injected into every lone tick.
+
+## Arsonist summary
+
+Reverie's per-tick discipline (grounding, `is_hollow()`, deterministic
+salience) is solid and unchanged by this spec. The actual gap: every tick,
+chained or not, rebuilds its prompt from nothing but the live broadcast — no
+tick knows what a prior tick said, whether the thing it's narrating was
+already resolved by a human, or how strong the evidence for its own claim
+actually is. This patch closes those five gaps without touching the
+deterministic substrate selection path (`attention_broadcast.py`,
+`scoring.py`) and without letting the LLM steer its own future attention —
+both of which stay exactly as they are today.
+
+## Current architecture
+
+- `services/orion-thought/app/reverie.py:322-463` (`run_reverie_once`) — one
+  tick: read live broadcast → `build_reverie_context()` → LLM narrates →
+  `parse_reverie_payload()` stamps hollow/salience deterministically →
+  publish + `persist_reverie_thought()`.
+- `services/orion-thought/app/chain.py:186-300` (`run_reverie_chain`) — runs
+  up to `max_steps` (default 4, `ORION_REVERIE_CHAIN_MAX_STEPS`) calls to
+  `run_reverie_once` **in one process invocation**, each stamped with
+  `chain_context=(chain_id, index)`. `chain_context` only labels the
+  *output* — it is never read back into the *input* of the next step.
+  `ema_summary` (`chain.py:260`) is a fixed bookkeeping string, not narrative
+  content.
+- `services/orion-thought/app/store.py` — persistence is write-heavy,
+  read-thin. The only reads that exist today are theme/timestamp pairs for
+  the resonance detector (`load_recent_chain_theme_events`,
+  `load_recent_resonance_alerts`) — no function anywhere reads a prior
+  thought's `interpretation` text back.
+- `orion/schemas/reverie.py:72-73` — `SpontaneousThoughtV1.next_focus` /
+  `.drift` exist on the schema, are never requested by the prompt
+  (`reverie_narrate.j2` only requires `interpretation` + `evidence_refs`),
+  and are never read anywhere else. `settings.py:85`
+  (`ORION_REVERIE_DRIFT_TEMP`) is a matching dead config knob — declared,
+  never read.
+- `attention_loop_outcome` (verdicts: resolved/dismissed/etc, written by
+  `services/orion-hub/scripts/attention_loops_store.py`) is consumed today
+  only by `scripts/refit_salience_weights.py` (offline) and Hub display
+  routes — never by live selection, never by reverie.
+- `OpenLoopV1` (`orion/schemas/attention_frame.py:61-89`) already carries
+  `salience_features: dict`, `salience: float`, `dwell_ticks` (on the
+  broadcast) — real quantitative signal the prompt template currently
+  either omits or passes raw for the LLM to eyeball.
+- `services/orion-hub/scripts/substrate_observability_routes.py:112-140`
+  (`_reverie_section`) already loads the full `thought_json` per row but
+  explicitly whitelists only `salience`, `interpretation`,
+  `attended_node_ids`, `selected_open_loop_id` — `next_focus`/`drift` are
+  fetched and silently dropped.
+
+## Missing questions
+
+Resolved by Juniper this session:
+- Stream vs episodic → **both**: stream inside a chain, episodic for
+  standalone ticks. Standalone (`chain_context=None`) ticks get none of the
+  new continuity behavior — this is load-bearing, see Acceptance checks.
+- Live in prod → yes. Ship #1 (correctness fix) independently of the rest;
+  don't gate it behind the larger continuity patch.
+
+Still open, low-stakes enough not to block a first patch, flagged for
+implementation-time judgment:
+- Does `_reverie_section` need `next_focus`/`drift` surfaced for this patch
+  to satisfy §0A's "producer needs a consumer" bar, or is the eval/test
+  suite itself sufficient consumer? Recommend doing the one-line Hub addition
+  anyway — it's cheap and it's real UI/debug surface, not busywork.
+- `ORION_REVERIE_DRIFT_TEMP`: keep as a still-dead knob, wire it to actually
+  vary generation temperature per chain step, or delete it? Recommend
+  **delete** — it's orthogonal to narration continuity and reintroducing
+  temperature scheduling later is its own thin patch if ever wanted.
+
+## Proposed schema / API changes
+
+No breaking changes to `SpontaneousThoughtV1` — `next_focus`/`drift` already
+exist; this patch makes them real by giving them a producer (prompt asks for
+them, chain-mode only) and a consumer (next chain step's prompt + Hub panel).
+
+New functions:
+
+```python
+# services/orion-thought/app/store.py
+def load_recent_loop_outcomes(loop_ids: list[str]) -> dict[str, dict]:
+    """Most recent attention_loop_outcome verdict per loop_id. Best-effort,
+    never raises, returns {} on any miss — mirrors every other reader in this
+    module. Direct DSN query (no orion.substrate import), same pattern as
+    persist_reverie_thought."""
+```
+
+New pure functions (deterministic, unit-testable, no I/O — §4 split):
+
+```python
+# services/orion-thought/app/reverie.py (or orion/reverie/framing.py if it
+# grows; start colocated, split out only if it earns it)
+def salience_margin(selected: float, runner_up: float | None) -> float: ...
+def dwell_framing(dwell_ticks: int, stability_score: float) -> str: ...
+```
+
+`build_reverie_context()` signature grows additive-only kwargs:
+
+```python
+def build_reverie_context(
+    broadcast: AttentionBroadcastProjectionV1,
+    *,
+    concern_cards: list[ConcernCardV1] | None = None,
+    loop_outcomes: dict[str, dict] | None = None,      # #1
+    prior_thoughts: list[str] | None = None,            # #2, chain-mode only
+    next_focus_hint: str | None = None,                 # #3, chain-mode only
+) -> dict[str, Any]:
+```
+
+All four new kwargs default to `None`/absent — a standalone tick
+(`chain_context=None`) never populates `prior_thoughts` or
+`next_focus_hint`, and `loop_outcomes` is populated for *every* tick
+(chained or not — verdict-awareness is a correctness fix, not a continuity
+feature, so it applies everywhere).
+
+Prompt template additions (`orion/cognition/prompts/reverie_narrate.j2`,
+non-`concern_cards` branch only — `#1/#6/#7` also apply to the semantic-lift
+branch for outcomes, see note below):
+
+- Per-loop outcome line when `loop_outcomes` has an entry for that id:
+  `"- id: {{ loop.id }} | ALREADY VERDICTED: {{ loop.outcome.verdict }}
+  ({{ loop.outcome.note }}, {{ loop.outcome.age_days }}d ago) — narrate as
+  settled, not as an open struggle."`
+- New `CONTINUITY` block, only rendered when `prior_thoughts` is non-empty:
+  the last 2 verbatim interpretations, framed as "what you already said —
+  do not repeat; extend, narrow, or reconsider."
+- New line when `next_focus_hint` is set: `"Last step you said you wanted to
+  focus next on: {{ next_focus_hint }}."` — framed as a hint, not a
+  directive; the coalition data below is still the only thing you may
+  narrate.
+- `salience_margin` and `dwell_framing` rendered as plain pre-computed
+  sentences in the `SOURCE` section (not raw numbers) — e.g. `"This loop
+  edged out the next-best candidate by a narrow margin (0.04) — hedge your
+  certainty accordingly."` / `"This has been the winning focus for 6
+  consecutive ticks."`
+- `REQUIRED JSON FIELDS`, chain-mode only (i.e. `chain_context is not None`
+  and `index < max_steps - 1`): add optional `next_focus` (1 sentence, what
+  to turn to next) and `drift` (1 phrase, how this step's focus differs from
+  the last). Not required on the final step of a chain or on standalone
+  ticks — there is no "next" to point to.
+
+Note on `concern_cards` branch: `#1` (outcomes) and `#6`/`#7` (margin/dwell
+framing) are orthogonal to whether semantic lift is active and should apply
+there too if `open_loops`/`coalition_projection` data is available in that
+branch's context. `#2`/`#3` (chain continuity) stay reverie-branch-only for
+this patch — concern-card chains are not in scope; revisit if that combo
+ever ships.
+
+`run_reverie_once()` grows two optional kwargs threaded straight into
+`build_reverie_context`: `prior_thoughts` and `next_focus_hint`. Nothing
+else in its signature changes.
+
+`chain.py::run_reverie_chain()` — no new persisted state, no new schema.
+The loop already accumulates `thought_ids`/`ema` per step; add two
+in-memory accumulators scoped to the single `run_reverie_chain` call:
+
+```python
+prior_texts: list[str] = []
+last_next_focus: str | None = None
+
+for index in range(max(1, max_steps)):
+    thought = await step_fn(chain_id, index, prior_texts[-2:], last_next_focus)
+    ...
+    if thought is not None:
+        prior_texts.append(thought.interpretation)
+        last_next_focus = thought.next_focus
+```
+
+`StepFn` type widens to `Callable[[str, int, list[str], str | None],
+Awaitable[SpontaneousThoughtV1 | None]]`; `chain.py::_step` passes those
+straight through to `run_reverie_once`. **In-memory only** — no DB read
+needed for chain-local continuity, since a chain fully completes inside one
+`run_reverie_chain` call today. (This is the thing that makes #2 cheaper
+than originally scoped in the brainstorm — no `load_chain_thoughts` store
+function needed.)
+
+`services/orion-hub/scripts/substrate_observability_routes.py:130-138`
+(`_reverie_section`) — add `next_focus`/`drift` to the per-row dict already
+being built from `payload` (both already present in `thought_json`, this is
+a two-line addition, no new query).
+
+## Files likely to touch
+
+- `services/orion-thought/app/reverie.py` — `build_reverie_context`,
+  `_open_loops_for_prompt`, `run_reverie_once`, new `salience_margin`/
+  `dwell_framing` pure functions.
+- `services/orion-thought/app/chain.py` — `run_reverie_chain` (in-memory
+  accumulators), `_step`, `StepFn` type.
+- `services/orion-thought/app/store.py` — new `load_recent_loop_outcomes`.
+- `orion/cognition/prompts/reverie_narrate.j2` — outcome lines, CONTINUITY
+  block, next_focus hint line, margin/dwell framing sentences, conditional
+  `next_focus`/`drift` in REQUIRED JSON FIELDS.
+- `orion/schemas/reverie.py` — doc-comment update only (next_focus/drift
+  are no longer aspirational).
+- `services/orion-thought/app/settings.py` — remove
+  `ORION_REVERIE_DRIFT_TEMP` (dead knob; see Missing questions).
+- `services/orion-hub/scripts/substrate_observability_routes.py` —
+  surface `next_focus`/`drift` in `_reverie_section`.
+- Tests: `services/orion-thought/tests/test_reverie_spontaneous_thought.py`,
+  `test_reverie_chain.py`, `services/orion-thought/evals/
+  test_reverie_hollow_guard_eval.py`, `orion/reverie/evals/
+  test_reverie_semantic_quality_eval.py` — new cases per Acceptance checks
+  below. New unit test file for `salience_margin`/`dwell_framing` (pure,
+  no fixtures needed).
+- `.env_example` — remove `ORION_REVERIE_DRIFT_TEMP` if deleted; no new env
+  keys (outcome lookup uses the existing `POSTGRES_URI` pattern already in
+  `store.py`).
+
+## Non-goals
+
+- No change to `attention_broadcast.py` / `scoring.py` / live coalition
+  selection. Verdict-awareness (#1) is narration-only — a human-closed loop
+  can still win selection; it just won't be narrated as urgent. Suppressing
+  it from selection entirely is a separate, bigger substrate-contract patch,
+  not in scope here.
+- No cross-chain or cross-tick memory (#4, pinned). A new chain on a
+  recurring theme has no idea it's happened before. Left for later.
+- No deterministic narrative-stability/repetition trace (#5, pinned). #2's
+  anti-repetition guarantee is prompt-instruction only in this patch, not
+  measured. This is the biggest accepted risk in this spec — see Tensions.
+- No LLM-driven override of *which* loop/coalition gets selected. The hard
+  version of #3 (next_focus steering selection) needs §0A proposal mode and
+  is explicitly out of scope.
+- No change to standalone (non-chain) tick behavior beyond #1 and #6/#7 —
+  episodic ticks stay memoryless of prior ticks, by design (confirmed).
+- No concern-card-branch chain continuity (see note above).
+
+## Acceptance checks
+
+1. Given a broadcast whose selected loop has a persisted
+   `attention_loop_outcome` row, `build_reverie_context()`'s rendered prompt
+   contains that verdict text; a thought generated against a mocked
+   "resolved" verdict does not describe the loop as an open struggle in a
+   golden-prompt test.
+2. Given a 2+ step chain, step index 1's context contains step 0's
+   `interpretation` text verbatim (capped at last 2); step 0's context
+   contains no `CONTINUITY` block (nothing prior).
+3. Given step 0 emits `next_focus="X"`, step 1's prompt contains the literal
+   hint line referencing `X`.
+4. `salience_margin`/`dwell_framing` are pure functions with unit tests
+   covering: near-tie margin, landslide margin, `runner_up=None` (single
+   loop), zero dwell, high dwell.
+5. **Regression guarantee**: standalone `run_reverie_once(bus)` calls
+   (`chain_context=None`, no `prior_thoughts`/`next_focus_hint` passed)
+   produce **byte-identical** `build_reverie_context()` output to today,
+   except for the new `loop_outcomes` framing (#1 applies everywhere) and
+   `salience_margin`/`dwell_framing` (#6/#7 apply everywhere). No
+   `CONTINUITY` block, no `next_focus` hint line, ever, outside a chain.
+6. `is_hollow()` / grounding discipline unchanged: a thought whose only
+   "evidence" is continuity text or a next_focus hint (not a real coalition
+   id) is still correctly marked hollow — continuity content must never
+   become a grounding backdoor. New explicit regression test for this.
+7. Chain-mode `REQUIRED JSON FIELDS` correctly omit `next_focus`/`drift` on
+   the final step of a chain (nothing to point to).
+8. Full existing suites green:
+   `pytest services/orion-thought/tests -q`,
+   `pytest services/orion-thought/evals -q`,
+   `pytest orion/reverie/tests orion/reverie/evals -q`.
+
+## Recommended next patch
+
+Two changesets, not one — they don't share a dependency and #1 is the
+correctness fix that's been live-broken the longest:
+
+1. **`fix/reverie-verdict-aware-narration`** — #1 alone. Smallest possible
+   diff: `load_recent_loop_outcomes`, wire into `build_reverie_context` +
+   `_open_loops_for_prompt`, one prompt block. Ships independent of
+   everything else below.
+2. **`feat/reverie-chain-continuity`** — #2 + #3 + #6 + #7 together, since
+   they land in the same call sites (`build_reverie_context`, `chain.py`'s
+   step loop, the prompt template) and are easier to review and eval as one
+   coherent "chain narration" changeset than three separate diffs touching
+   the same three files. Ship after #1 is merged and verified live (so a
+   confabulation regression in the bigger patch isn't confused with the
+   verdict-awareness fix).
+
+Both changesets are thin per §0A: no new service, no new abstraction layer,
+additive-only kwargs, in-memory (not DB-backed) chain continuity, and every
+new schema field this patch touches (`next_focus`/`drift`) gets both a real
+producer and a real consumer in the same changeset.

--- a/orion/cognition/prompts/reverie_narrate.j2
+++ b/orion/cognition/prompts/reverie_narrate.j2
@@ -40,6 +40,15 @@ SOURCE (bounded internal input — the current winning coalition)
 - open_loops: {{ open_loops }}
 {% endif %}
 
+ALREADY-SETTLED LOOPS (read this before you narrate urgency)
+- Some entries in open_loops carry an "outcome" field: {"verdict": "resolved" |
+  "dismissed" | "decayed_unattended", "note": "...", "age_days": N}. That verdict
+  was recorded by a human closing this loop — it is ground truth, not a guess.
+- If the loop you are about to narrate has an "outcome", you MUST describe it as
+  settled, past-tense, closed N days ago — never as an open struggle, an active
+  strain, or something "requiring sustained attention". It is still showing up in
+  the coalition because of scoring, not because it is actually still live.
+
 GROUNDING DISCIPLINE (the anti-hollow rule — this is the whole point)
 - There is no user question anchoring you, so you must anchor yourself.
 - interpretation MUST be about THESE coalition ids — what recurs, what strains,

--- a/orion/cognition/prompts/reverie_narrate.j2
+++ b/orion/cognition/prompts/reverie_narrate.j2
@@ -40,14 +40,18 @@ SOURCE (bounded internal input — the current winning coalition)
 - open_loops: {{ open_loops }}
 {% endif %}
 
+{% if has_settled_loops %}
 ALREADY-SETTLED LOOPS (read this before you narrate urgency)
-- Some entries in open_loops carry an "outcome" field: {"verdict": "resolved" |
-  "dismissed" | "decayed_unattended", "note": "...", "age_days": N}. That verdict
-  was recorded by a human closing this loop — it is ground truth, not a guess.
-- If the loop you are about to narrate has an "outcome", you MUST describe it as
-  settled, past-tense, closed N days ago — never as an open struggle, an active
-  strain, or something "requiring sustained attention". It is still showing up in
-  the coalition because of scoring, not because it is actually still live.
+- Some entries above carry an "outcome" field: {"verdict": "resolved" |
+  "dismissed" | "decayed_unattended", "note": "...", "age_days": N (may be
+  absent)}. That verdict was recorded by a human closing this loop — it is
+  ground truth, not a guess.
+- If the loop you are about to narrate has an "outcome", you MUST describe it
+  as settled, past-tense — closed N days ago if age_days is present, otherwise
+  just "already closed" — never as an open struggle, an active strain, or
+  something "requiring sustained attention". It is still showing up in the
+  coalition because of scoring, not because it is actually still live.
+{% endif %}
 
 GROUNDING DISCIPLINE (the anti-hollow rule — this is the whole point)
 - There is no user question anchoring you, so you must anchor yourself.

--- a/services/orion-sql-db/manual_migration_reverie_theme_key_bare_id_backfill.sql
+++ b/services/orion-sql-db/manual_migration_reverie_theme_key_bare_id_backfill.sql
@@ -1,0 +1,37 @@
+-- One-time backfill for the reverie theme_key format fix (fix/reverie-verdict-
+-- aware-narration). chain.theme_key_for() used to prefix a loop-selected
+-- theme_key as "loop:<id>" -- a format only that function ever wrote or read,
+-- so it never matched attention_loops_store.suppress_loop()'s (orion-hub)
+-- bare-id convention, silently breaking refractory suppression on a human's
+-- Resolve/Dismiss action. The code now emits the bare id everywhere; this
+-- backfill re-keys rows written before that deploy so in-flight refractory
+-- suppression windows and resonance recurrence history survive the rollout
+-- instead of being orphaned under the old prefixed key.
+--
+-- Idempotent: safe to run more than once (WHERE theme_key LIKE 'loop:%' matches
+-- nothing on a second run). Apply once, any time at or after deploying
+-- fix/reverie-verdict-aware-narration.
+-- Apply: psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_reverie_theme_key_bare_id_backfill.sql
+
+-- substrate_reverie_refractory: theme_key is the primary key, so re-key via
+-- upsert-then-delete rather than a plain UPDATE, in case a post-deploy chain
+-- already wrote a bare-id row for the same loop (keep whichever suppression
+-- window extends furthest into the future -- the more protective one).
+insert into substrate_reverie_refractory (theme_key, suppressed_until, updated_at)
+select substring(theme_key from 6), suppressed_until, updated_at
+from substrate_reverie_refractory
+where theme_key like 'loop:%'
+on conflict (theme_key) do update
+    set suppressed_until = greatest(
+            substrate_reverie_refractory.suppressed_until,
+            excluded.suppressed_until
+        ),
+        updated_at = now();
+
+delete from substrate_reverie_refractory where theme_key like 'loop:%';
+
+-- substrate_reverie_chain: theme_key is a plain column (chain_id is the primary
+-- key), so a direct rename is safe -- no uniqueness constraint to collide with.
+update substrate_reverie_chain
+set theme_key = substring(theme_key from 6)
+where theme_key like 'loop:%';

--- a/services/orion-thought/app/chain.py
+++ b/services/orion-thought/app/chain.py
@@ -85,11 +85,21 @@ class DbRefractoryStore:
 
 
 def theme_key_for(coalition: Any) -> str:
-    """Deterministic theme key for a coalition — the unit refractory acts on."""
+    """Deterministic theme key for a coalition — the unit refractory acts on.
+
+    A loop-selected theme key is the *bare* loop id — deliberately matching
+    `attention_salience_trace.theme_key` and `attention_loops_store.suppress_loop`
+    (both orion-hub), which already write/read this same
+    `substrate_reverie_refractory` table keyed by bare loop id. A chain must see
+    the refractory suppression a human's Resolve/Dismiss action in the Hub just
+    wrote, or a closed loop keeps re-igniting chains indefinitely. (Previously
+    prefixed `loop:...` — a format only this function ever wrote or read, so it
+    silently never matched the Hub's suppression writes.)
+    """
     if coalition is None:
         return "unknown"
     if getattr(coalition, "selected_open_loop_id", None):
-        return f"loop:{coalition.selected_open_loop_id}"
+        return str(coalition.selected_open_loop_id)
     attended = sorted(getattr(coalition, "attended_node_ids", []) or [])
     if attended:
         return "nodes:" + ",".join(attended)

--- a/services/orion-thought/app/reverie.py
+++ b/services/orion-thought/app/reverie.py
@@ -41,7 +41,7 @@ from orion.schemas.thought import CoalitionSnapshotV1
 from .bus_listener import extract_stance_react_payload
 from .cortex_client import CortexExecClient
 from .settings import settings
-from .store import persist_reverie_thought, persist_salience_trace
+from .store import load_recent_loop_outcomes, persist_reverie_thought, persist_salience_trace
 
 logger = logging.getLogger("orion-thought.reverie")
 
@@ -194,22 +194,32 @@ def build_salience_trace(
     )
 
 
-def _open_loops_for_prompt(broadcast: AttentionBroadcastProjectionV1) -> list[dict[str, Any]]:
-    return [
-        {
+def _open_loops_for_prompt(
+    broadcast: AttentionBroadcastProjectionV1,
+    *,
+    loop_outcomes: dict[str, dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    outcomes = loop_outcomes or {}
+    entries = []
+    for loop in broadcast.frame.open_loops:
+        entry: dict[str, Any] = {
             "id": loop.id,
             "description": loop.description,
             "why_it_matters": loop.why_it_matters,
             "target_type": loop.target_type,
         }
-        for loop in broadcast.frame.open_loops
-    ]
+        outcome = outcomes.get(loop.id)
+        if outcome:
+            entry["outcome"] = outcome
+        entries.append(entry)
+    return entries
 
 
 def build_reverie_context(
     broadcast: AttentionBroadcastProjectionV1,
     *,
     concern_cards: list[ConcernCardV1] | None = None,
+    loop_outcomes: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if concern_cards:
         coalition_refs = coalition_audit_refs(broadcast)
@@ -234,7 +244,7 @@ def build_reverie_context(
             "coalition_stability_score": broadcast.coalition_stability_score,
             "dwell_ticks": broadcast.dwell_ticks,
         },
-        "open_loops": _open_loops_for_prompt(broadcast),
+        "open_loops": _open_loops_for_prompt(broadcast, loop_outcomes=loop_outcomes),
         "metadata": {"mode": "reverie", "llm_profile": "brain"},
     }
 
@@ -244,6 +254,7 @@ def build_reverie_plan_request(
     *,
     correlation_id: str,
     concern_cards: list[ConcernCardV1] | None = None,
+    loop_outcomes: dict[str, dict[str, Any]] | None = None,
 ) -> PlanExecutionRequest:
     use_lift = settings.reverie_semantic_lift_enabled and bool(concern_cards)
     mode = "metacog" if use_lift else "brain"
@@ -262,7 +273,9 @@ def build_reverie_plan_request(
             trigger_source=settings.service_name,
             extra=extra,
         ),
-        context=build_reverie_context(broadcast, concern_cards=concern_cards),
+        context=build_reverie_context(
+            broadcast, concern_cards=concern_cards, loop_outcomes=loop_outcomes
+        ),
     )
 
 
@@ -364,10 +377,16 @@ async def run_reverie_once(
         ),
     )
     try:
+        loop_outcomes: dict[str, dict[str, Any]] | None = None
+        if not (settings.reverie_semantic_lift_enabled and concern_cards):
+            loop_outcomes = load_recent_loop_outcomes(
+                [loop.id for loop in broadcast.frame.open_loops]
+            )
         plan_request = build_reverie_plan_request(
             broadcast,
             correlation_id=correlation_id,
             concern_cards=concern_cards,
+            loop_outcomes=loop_outcomes,
         )
         exec_result = await client.execute_plan(
             source=_source(),

--- a/services/orion-thought/app/reverie.py
+++ b/services/orion-thought/app/reverie.py
@@ -232,6 +232,7 @@ def build_reverie_context(
             "llm_route": "metacog",
             "options": {"llm_lane": "background", "allow_chat_fallback": False},
         }
+    open_loops = _open_loops_for_prompt(broadcast, loop_outcomes=loop_outcomes)
     return {
         "user_message": None,  # the defining difference from stance_react
         "coalition_projection": {
@@ -244,7 +245,8 @@ def build_reverie_context(
             "coalition_stability_score": broadcast.coalition_stability_score,
             "dwell_ticks": broadcast.dwell_ticks,
         },
-        "open_loops": _open_loops_for_prompt(broadcast, loop_outcomes=loop_outcomes),
+        "open_loops": open_loops,
+        "has_settled_loops": any("outcome" in loop for loop in open_loops),
         "metadata": {"mode": "reverie", "llm_profile": "brain"},
     }
 
@@ -379,8 +381,12 @@ async def run_reverie_once(
     try:
         loop_outcomes: dict[str, dict[str, Any]] | None = None
         if not (settings.reverie_semantic_lift_enabled and concern_cards):
-            loop_outcomes = load_recent_loop_outcomes(
-                [loop.id for loop in broadcast.frame.open_loops]
+            # Offloaded to a thread: a blocking DB round-trip here must not stall
+            # this coroutine's shared event loop (same rationale as chain.py's
+            # asyncio.to_thread use around its own blocking DB/HTTP calls).
+            loop_outcomes = await asyncio.to_thread(
+                load_recent_loop_outcomes,
+                [loop.id for loop in broadcast.frame.open_loops],
             )
         plan_request = build_reverie_plan_request(
             broadcast,

--- a/services/orion-thought/app/store.py
+++ b/services/orion-thought/app/store.py
@@ -328,7 +328,8 @@ def load_recent_loop_outcomes(loop_ids: list[str]) -> dict[str, dict[str, Any]]:
 
     Returns {loop_id: {"verdict": str, "note": str, "age_days": int}} — age is
     computed here (deterministic code), not left for the prompt/LLM to infer from
-    a raw timestamp.
+    a raw timestamp. `age_days` is omitted (never `None`) when `created_at` can't
+    be read, so the prompt never has to render a null age.
     """
     ids = [str(i) for i in (loop_ids or []) if i]
     if not ids:
@@ -347,24 +348,23 @@ def load_recent_loop_outcomes(loop_ids: list[str]) -> dict[str, dict[str, Any]]:
         ).bindparams(bindparam("ids", expanding=True))
         with engine.connect() as conn:
             rows = conn.execute(stmt, {"ids": ids}).mappings().all()
+
+        now = datetime.now(timezone.utc)
+        out: dict[str, dict[str, Any]] = {}
+        for r in rows:
+            entry: dict[str, Any] = {
+                "verdict": str(r.get("verdict") or ""),
+                "note": str(r.get("note") or ""),
+            }
+            created = r.get("created_at")
+            if isinstance(created, datetime):
+                c = created if created.tzinfo else created.replace(tzinfo=timezone.utc)
+                entry["age_days"] = max(0, int((now - c).total_seconds() // 86400))
+            out[str(r["loop_id"])] = entry
+        return out
     except Exception as exc:
         logger.debug("loop outcome load failed ids=%s err=%s", ids, exc)
         return {}
-
-    now = datetime.now(timezone.utc)
-    out: dict[str, dict[str, Any]] = {}
-    for r in rows:
-        created = r.get("created_at")
-        age_days = None
-        if isinstance(created, datetime):
-            c = created if created.tzinfo else created.replace(tzinfo=timezone.utc)
-            age_days = max(0, int((now - c).total_seconds() // 86400))
-        out[str(r["loop_id"])] = {
-            "verdict": str(r.get("verdict") or ""),
-            "note": str(r.get("note") or ""),
-            "age_days": age_days,
-        }
-    return out
 
 
 def reverie_refractory_suppress(theme_key: str, until) -> bool:

--- a/services/orion-thought/app/store.py
+++ b/services/orion-thought/app/store.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import TYPE_CHECKING
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
 
 logger = logging.getLogger("orion-thought.store")
 
@@ -314,6 +315,56 @@ def reverie_refractory_is_suppressed(theme_key: str, now) -> bool:
         return until is not None and until > now
     except Exception:
         return False
+
+
+def load_recent_loop_outcomes(loop_ids: list[str]) -> dict[str, dict[str, Any]]:
+    """Most recent `attention_loop_outcome` verdict per loop_id (orion-hub table,
+    written by a human's Resolve/Dismiss action; read directly, no orion-hub import).
+
+    Read-only, best-effort — returns {} on any miss or empty input, so a lookup
+    failure never breaks a reverie tick. Keyed by the *bare* loop id, matching
+    `attention_loops_store.suppress_loop`'s write format (see `chain.theme_key_for`
+    for the sibling refractory-key fix this mirrors).
+
+    Returns {loop_id: {"verdict": str, "note": str, "age_days": int}} — age is
+    computed here (deterministic code), not left for the prompt/LLM to infer from
+    a raw timestamp.
+    """
+    ids = [str(i) for i in (loop_ids or []) if i]
+    if not ids:
+        return {}
+    try:
+        from sqlalchemy import bindparam, text
+
+        engine = _get_engine()
+        stmt = text(
+            """
+            SELECT DISTINCT ON (loop_id) loop_id, verdict, note, created_at
+            FROM attention_loop_outcome
+            WHERE loop_id IN :ids
+            ORDER BY loop_id, created_at DESC
+            """
+        ).bindparams(bindparam("ids", expanding=True))
+        with engine.connect() as conn:
+            rows = conn.execute(stmt, {"ids": ids}).mappings().all()
+    except Exception as exc:
+        logger.debug("loop outcome load failed ids=%s err=%s", ids, exc)
+        return {}
+
+    now = datetime.now(timezone.utc)
+    out: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        created = r.get("created_at")
+        age_days = None
+        if isinstance(created, datetime):
+            c = created if created.tzinfo else created.replace(tzinfo=timezone.utc)
+            age_days = max(0, int((now - c).total_seconds() // 86400))
+        out[str(r["loop_id"])] = {
+            "verdict": str(r.get("verdict") or ""),
+            "note": str(r.get("note") or ""),
+            "age_days": age_days,
+        }
+    return out
 
 
 def reverie_refractory_suppress(theme_key: str, until) -> bool:

--- a/services/orion-thought/tests/test_reverie_chain.py
+++ b/services/orion-thought/tests/test_reverie_chain.py
@@ -49,7 +49,9 @@ def _step_always(salience=0.8):
 
 def test_theme_key_prefers_selected_loop():
     from app import chain
-    assert chain.theme_key_for(_thought().coalition) == "loop:ol-1"
+    # Bare loop id — must match attention_loops_store.suppress_loop's key format
+    # (orion-hub) so a human's Resolve/Dismiss action actually suppresses this chain.
+    assert chain.theme_key_for(_thought().coalition) == "ol-1"
 
 
 def test_theme_key_none_is_unknown():
@@ -106,7 +108,7 @@ async def test_chain_none_when_no_coalition():
 async def test_chain_suppressed_by_refractory():
     from app import chain
     store = chain.InMemoryRefractoryStore()
-    store.suppress("loop:ol-1", NOW + timedelta(seconds=600))
+    store.suppress("ol-1", NOW + timedelta(seconds=600))
     c = await chain.run_reverie_chain(
         AsyncMock(), step_fn=_step_always(), refractory_store=store,
         broadcast_reader=_broadcast, publish=False, now_fn=lambda: NOW,
@@ -122,7 +124,7 @@ async def test_chain_suppresses_theme_after_completion():
         AsyncMock(), step_fn=_step_always(), refractory_store=store,
         broadcast_reader=_broadcast, max_steps=2, refractory_sec=900, publish=False, now_fn=lambda: NOW,
     )
-    assert store.is_suppressed("loop:ol-1", NOW) is True
+    assert store.is_suppressed("ol-1", NOW) is True
 
 
 @pytest.mark.asyncio

--- a/services/orion-thought/tests/test_reverie_narrate_prompt_outcomes.py
+++ b/services/orion-thought/tests/test_reverie_narrate_prompt_outcomes.py
@@ -1,0 +1,65 @@
+"""Golden-prompt coverage for verdict-aware narration (fix/reverie-verdict-
+aware-narration). Renders the real reverie_narrate.j2 through build_reverie_context
+so the actual prompt text the LLM sees is exercised, not just the context dict
+shape -- the point of the fix is what gets said to the model, not just what data
+reaches it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from jinja2 import Environment
+
+from orion.schemas.attention_frame import AttentionBroadcastProjectionV1, AttentionFrameV1, OpenLoopV1
+
+_PROMPT = (
+    Path(__file__).resolve().parents[3] / "orion" / "cognition" / "prompts" / "reverie_narrate.j2"
+)
+
+
+def _render(**ctx) -> str:
+    template = Environment().from_string(_PROMPT.read_text())
+    return template.render(**ctx)
+
+
+def _broadcast(loops=(("ol-1", {}),)):
+    return AttentionBroadcastProjectionV1(
+        frame=AttentionFrameV1(open_loops=[OpenLoopV1(id=oid, description="d", **s) for oid, s in loops]),
+        attended_node_ids=["n-1"],
+        selected_open_loop_id=loops[0][0] if loops else None,
+    )
+
+
+def test_no_outcome_block_when_no_loop_has_a_verdict():
+    from app import reverie
+
+    ctx = reverie.build_reverie_context(_broadcast())
+    out = _render(**ctx)
+    assert "ALREADY-SETTLED LOOPS" not in out
+
+
+def test_outcome_block_present_and_instructs_settled_framing():
+    from app import reverie
+
+    ctx = reverie.build_reverie_context(
+        _broadcast(),
+        loop_outcomes={"ol-1": {"verdict": "resolved", "note": "fixed the flakiness", "age_days": 4}},
+    )
+    out = _render(**ctx)
+    assert "ALREADY-SETTLED LOOPS" in out
+    assert "settled" in out
+    assert "never as an open struggle" in out
+    # the actual verdict data must reach the model, not just the instruction text
+    assert "resolved" in out
+    assert "fixed the flakiness" in out
+
+
+def test_outcome_block_absent_when_open_loops_is_empty():
+    """Regression: the settled-loops instruction must not render when there is
+    nothing in open_loops to apply it to (it used to render unconditionally)."""
+    from app import reverie
+
+    ctx = reverie.build_reverie_context(_broadcast(loops=()))
+    out = _render(**ctx)
+    assert "ALREADY-SETTLED LOOPS" not in out
+    assert "open_loops:" not in out

--- a/services/orion-thought/tests/test_reverie_spontaneous_thought.py
+++ b/services/orion-thought/tests/test_reverie_spontaneous_thought.py
@@ -7,6 +7,7 @@ cognition.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
 import pytest
@@ -118,6 +119,76 @@ def test_derive_salience_fallback_to_stability():
     assert reverie.derive_salience(bcast) == pytest.approx(0.33)
 
 
+# --- verdict-aware narration: outcome threading into the prompt context -------
+
+def test_open_loops_for_prompt_includes_outcome_when_present():
+    from app import reverie
+
+    entries = reverie._open_loops_for_prompt(
+        _broadcast(loops=(("ol-1", {}), ("ol-2", {}))),
+        loop_outcomes={"ol-1": {"verdict": "resolved", "note": "n", "age_days": 3}},
+    )
+    by_id = {e["id"]: e for e in entries}
+    assert by_id["ol-1"]["outcome"] == {"verdict": "resolved", "note": "n", "age_days": 3}
+    assert "outcome" not in by_id["ol-2"]
+
+
+def test_open_loops_for_prompt_omits_outcome_when_none_given():
+    from app import reverie
+
+    entries = reverie._open_loops_for_prompt(_broadcast())
+    assert all("outcome" not in e for e in entries)
+
+
+def test_build_reverie_context_threads_loop_outcomes_into_open_loops():
+    from app import reverie
+
+    ctx = reverie.build_reverie_context(
+        _broadcast(),
+        loop_outcomes={"ol-1": {"verdict": "dismissed", "note": "", "age_days": 1}},
+    )
+    assert ctx["open_loops"][0]["outcome"]["verdict"] == "dismissed"
+
+
+def test_build_reverie_context_concern_cards_branch_ignores_loop_outcomes():
+    """Semantic-lift branch has no open_loops in context at all — outcomes must
+    not be silently expected there; this changeset scopes them to the base
+    coalition-narration branch only."""
+    from app import reverie
+    from orion.schemas.reverie import ConcernCardV1
+
+    card = ConcernCardV1(card_id="c1", coalition_ref="harness_closure:x", human_text="t" * 40)
+    ctx = reverie.build_reverie_context(
+        _broadcast(), concern_cards=[card],
+        loop_outcomes={"ol-1": {"verdict": "resolved", "note": "", "age_days": 1}},
+    )
+    assert "open_loops" not in ctx
+
+
+@pytest.mark.asyncio
+async def test_tick_fetches_and_threads_loop_outcomes(monkeypatch):
+    """The tick must look up outcomes for the live broadcast's loops and pass
+    them through to the plan request context the LLM actually sees."""
+    from app import reverie
+
+    monkeypatch.setattr(
+        reverie, "load_recent_loop_outcomes",
+        lambda ids: {"ol-1": {"verdict": "resolved", "note": "closed", "age_days": 2}},
+    )
+    bus = AsyncMock()
+    cortex = AsyncMock()
+    cortex.execute_plan = AsyncMock(return_value={
+        "final_text": json.dumps({"interpretation": GROUNDED_TEXT, "evidence_refs": ["ol-1"]}),
+    })
+    result = await reverie.run_reverie_once(
+        bus, broadcast_reader=lambda: _broadcast(), cortex_client=cortex,
+    )
+    assert result is not None
+    plan_request = cortex.execute_plan.call_args.kwargs["req"]
+    open_loops = plan_request.context["open_loops"]
+    assert open_loops[0]["outcome"]["verdict"] == "resolved"
+
+
 def test_parse_reverie_payload_marks_unanchored_hollow():
     from app import reverie
 
@@ -194,6 +265,61 @@ def test_persist_never_raises_on_bad_db(monkeypatch):
     t = SpontaneousThoughtV1(thought_id="t", correlation_id="c", coalition=_coalition(),
                              interpretation=GROUNDED_TEXT, evidence_refs=["ol-1"]).marked_hollow()
     assert store.persist_reverie_thought(t) is False  # returned, not raised
+
+
+# --- verdict-aware narration: loop outcome lookup ------------------------------
+
+def test_load_recent_loop_outcomes_empty_ids_short_circuits(monkeypatch):
+    from app import store
+
+    def boom():
+        raise AssertionError("must not touch the DB for an empty id list")
+
+    monkeypatch.setattr(store, "_get_engine", boom)
+    assert store.load_recent_loop_outcomes([]) == {}
+
+
+def test_load_recent_loop_outcomes_never_raises_on_bad_db(monkeypatch):
+    from app import store
+
+    monkeypatch.setattr(store, "_engine", None)
+    monkeypatch.setattr(store, "_database_url", lambda: "postgresql://x:x@127.0.0.1:1/nope")
+    assert store.load_recent_loop_outcomes(["ol-1"]) == {}  # returned, not raised
+
+
+def test_load_recent_loop_outcomes_shapes_rows(monkeypatch):
+    from app import store
+
+    # A bit over 6 days old, to stay clear of the floor-division boundary.
+    created = datetime.now(timezone.utc) - timedelta(days=6, hours=1)
+
+    class _Result:
+        def mappings(self):
+            return self
+
+        def all(self):
+            return [
+                {"loop_id": "ol-1", "verdict": "resolved", "note": "fixed it",
+                 "created_at": created},
+            ]
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def execute(self, *a, **k):
+            return _Result()
+
+    class _Engine:
+        def connect(self):
+            return _Conn()
+
+    monkeypatch.setattr(store, "_get_engine", lambda: _Engine())
+    out = store.load_recent_loop_outcomes(["ol-1", "ol-2"])
+    assert out == {"ol-1": {"verdict": "resolved", "note": "fixed it", "age_days": 6}}
 
 
 @pytest.mark.asyncio

--- a/services/orion-thought/tests/test_reverie_spontaneous_thought.py
+++ b/services/orion-thought/tests/test_reverie_spontaneous_thought.py
@@ -322,6 +322,89 @@ def test_load_recent_loop_outcomes_shapes_rows(monkeypatch):
     assert out == {"ol-1": {"verdict": "resolved", "note": "fixed it", "age_days": 6}}
 
 
+def test_load_recent_loop_outcomes_omits_age_days_when_unreadable(monkeypatch):
+    """A row with no usable created_at must never surface age_days: None into the
+    prompt — the key is omitted rather than emitting a null the LLM could echo
+    literally (e.g. "closed None days ago")."""
+    from app import store
+
+    class _Result:
+        def mappings(self):
+            return self
+
+        def all(self):
+            return [{"loop_id": "ol-1", "verdict": "dismissed", "note": "",
+                      "created_at": None}]
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def execute(self, *a, **k):
+            return _Result()
+
+    class _Engine:
+        def connect(self):
+            return _Conn()
+
+    monkeypatch.setattr(store, "_get_engine", lambda: _Engine())
+    out = store.load_recent_loop_outcomes(["ol-1"])
+    assert "age_days" not in out["ol-1"]
+    assert out["ol-1"]["verdict"] == "dismissed"
+
+
+def test_load_recent_loop_outcomes_never_raises_on_bad_row_shape(monkeypatch):
+    """The 'never raises' guarantee must hold for row-shaping failures too, not
+    just for the DB round-trip -- a malformed/renamed column must degrade to {}
+    rather than propagate out of a function whose whole contract is best-effort."""
+    from app import store
+
+    class _Result:
+        def mappings(self):
+            return self
+
+        def all(self):
+            return [{"loop_id": "ol-1"}]  # missing verdict/note/created_at entirely
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def execute(self, *a, **k):
+            return _Result()
+
+    class _Engine:
+        def connect(self):
+            return _Conn()
+
+    monkeypatch.setattr(store, "_get_engine", lambda: _Engine())
+    # dict.get on a plain dict row never raises for a missing key, so force the
+    # failure via a row object whose .get() raises -- the point under test is
+    # that the shaping loop is inside the try/except, not that this exact input
+    # is realistic.
+    class _BoomRow(dict):
+        def get(self, *a, **k):
+            raise KeyError("simulated malformed row")
+
+    class _BoomResult:
+        def mappings(self):
+            return self
+
+        def all(self):
+            return [_BoomRow(loop_id="ol-1")]
+
+    monkeypatch.setattr(
+        _Conn, "execute", lambda self, *a, **k: _BoomResult()
+    )
+    assert store.load_recent_loop_outcomes(["ol-1"]) == {}  # returned, not raised
+
+
 @pytest.mark.asyncio
 async def test_tick_drops_hollow_thought():
     from app import reverie


### PR DESCRIPTION
## Summary

- Reverie could confidently narrate urgency about an open loop a human had already resolved or dismissed via the Hub, for two independent, compounding reasons.
- **Bug 1**: `chain.py`'s `theme_key_for()` keyed refractory suppression as `"loop:<id>"`, a format only that function ever wrote or read. `attention_loops_store.py`'s `suppress_loop()` (called on a human's Resolve/Dismiss action) and `attention_salience_trace.theme_key` both use the bare loop id. The two never matched — a closed loop's chain-refractory suppression silently never took effect, so chains kept re-igniting on it indefinitely. **This is live-broken in prod today** (`ORION_REVERIE_CHAIN_ENABLED=true` is the live config).
- **Bug 2**: even with suppression working, reverie's narration prompt had no way to say a loop was already verdicted — `OpenLoopV1` carries no outcome field, and `attention_loop_outcome` (the verdict table) was read only by the offline weight-refit script and Hub display routes, never by reverie.
- Fixes both: `theme_key_for()` now emits the bare loop id (matches the Hub's existing convention); a new `store.load_recent_loop_outcomes()` looks up recent verdicts for the current coalition's loops and threads them into the prompt context, with an explicit instruction to narrate a verdicted loop as settled, not as an open struggle.
- A one-time backfill migration re-keys any `substrate_reverie_refractory` / `substrate_reverie_chain` rows written under the old `"loop:<id>"` format before this deploy, so in-flight suppression windows and resonance recurrence history survive the rollout.

## Outcome moved

A human resolving/dismissing an attention loop in the Hub now actually suppresses reverie chains from re-igniting on it (previously silently a no-op), and reverie's narration is grounded in recorded human verdicts instead of confabulating urgency about closed loops.

## Current architecture

`services/orion-thought/app/reverie.py::run_reverie_once` builds every tick's LLM prompt from nothing but the live broadcast — no visibility into whether a loop had already been closed by a human. `chain.py::theme_key_for` computed a refractory-suppression key with a `"loop:"` prefix that no other reader or writer in the codebase used (confirmed via full-repo grep — the Hub's `suppress_loop`/`attention_salience_trace` write/read the bare loop id).

## Architecture touched

`services/orion-thought` (reverie.py, chain.py, store.py), the shared `orion/cognition/prompts/reverie_narrate.j2` prompt, and a manual SQL backfill in `services/orion-sql-db`. No bus/schema contract changes (no new channels, no schema field additions — `next_focus`/`drift` etc. are untouched, out of scope for this changeset).

## Files changed

- `services/orion-thought/app/chain.py`: `theme_key_for()` now returns the bare loop id instead of `"loop:<id>"`, matching the Hub's existing refractory-suppression key convention.
- `services/orion-thought/app/store.py`: new `load_recent_loop_outcomes(loop_ids)` — best-effort direct-DSN read of `attention_loop_outcome`, keyed by bare loop id, returns `{loop_id: {verdict, note, age_days?}}`.
- `services/orion-thought/app/reverie.py`: threads `loop_outcomes` through `build_reverie_context` / `_open_loops_for_prompt` / `build_reverie_plan_request`; `run_reverie_once` fetches outcomes (offloaded via `asyncio.to_thread`) for every tick except the semantic-lift/concern-cards branch (which has no `open_loops` in its context); `build_reverie_context` now also emits a deterministic `has_settled_loops` flag.
- `orion/cognition/prompts/reverie_narrate.j2`: new `ALREADY-SETTLED LOOPS` instruction block, gated on `has_settled_loops` so it only appears when a loop in the current coalition actually carries a verdict.
- `services/orion-sql-db/manual_migration_reverie_theme_key_bare_id_backfill.sql`: one-time, idempotent backfill re-keying pre-deploy `"loop:<id>"` rows in `substrate_reverie_refractory` and `substrate_reverie_chain`.
- Tests: `services/orion-thought/tests/test_reverie_chain.py` (updated 3 assertions to the new bare-id format), `test_reverie_spontaneous_thought.py` (new coverage for `load_recent_loop_outcomes` — empty input, bad DB, row shaping, age omission, never-raises on bad row shape — plus context-threading and a full tick-level test), and a new `test_reverie_narrate_prompt_outcomes.py` rendering the real Jinja template (golden-prompt style) to verify the actual instruction text the model sees.

## Schema / bus / API changes

None. No channels, no schema fields added/removed/renamed. `build_reverie_context`'s returned dict gains two new keys (`open_loops[i].outcome`, `has_settled_loops`) in the non-concern-cards branch only — purely additive, no existing consumer reads an exhaustive key set there.

## Env/config changes

None. No `.env_example` changes; no env sync needed.

## Tests run

```text
PYTHONPATH=<worktree>:<worktree>/services/orion-thought python -m pytest services/orion-thought/tests services/orion-thought/evals -q
162 passed

PYTHONPATH=<worktree> python -m pytest orion/reverie/ -q
46 passed

PYTHONPATH=<worktree>:<worktree>/services/orion-hub python -m pytest services/orion-hub/tests/test_reverie_observability_section.py -q
8 passed

PYTHONPATH=<worktree>:<worktree>/services/orion-cortex-exec python -m pytest services/orion-cortex-exec/tests/test_chat_stance_reverie_glimpse_projection.py -q
11 passed

PYTHONPATH=<worktree>:<worktree>/services/orion-dream python -m pytest services/orion-dream/tests/test_rem_compaction.py -q
15 passed

git diff --check
clean
```

## Evals run

`services/orion-thought/evals/test_reverie_hollow_guard_eval.py` and `orion/reverie/evals/test_reverie_semantic_quality_eval.py` (existing suites, unmodified, still green — see Tests run above, they run in the same `pytest evals -q` invocation). No new eval harness added; the review-flagged gap between "context-shape tests" and "actual narration behavior" was closed with a golden-prompt template-render test (`test_reverie_narrate_prompt_outcomes.py`) rather than a full LLM eval, since no live model call is exercised anywhere else in this test tier either.

## Docker/build/smoke checks

Not run — no runtime/config/dependency/port changes; this is a pure application-code + prompt + one manual SQL fix with no Docker-relevant surface. `check_schema_registry.py` / `check_bus_channels.py` referenced in AGENTS.md §17 don't exist in this repo under those names (verified); no equivalent local script applies since no schema/channel changed.

## Review findings fixed

Ran the `code-review` skill (level: high, 8 finder angles) against the diff in a subagent, deduped/verified candidates directly. Findings:

- Finding: `load_recent_loop_outcomes`'s row-shaping loop ran outside the `try/except`, so the function's own "never raises" contract only covered DB-connect failures, not a malformed row shape.
  - Fix: widened the `try` to cover shaping too, matching every sibling reader in `store.py`.
  - Evidence: new `test_load_recent_loop_outcomes_never_raises_on_bad_row_shape` (injects a row whose `.get()` raises; asserts `{}` returned, not raised).
- Finding: `age_days` could surface as `None` into the prompt when `created_at` wasn't a usable datetime, risking literal "closed None days ago" narration.
  - Fix: `age_days` is now omitted from the outcome dict entirely when unreadable, and the prompt instruction was reworded to handle its absence.
  - Evidence: new `test_load_recent_loop_outcomes_omits_age_days_when_unreadable`.
- Finding: the new `load_recent_loop_outcomes` call was a blocking sync DB round-trip inside `async def run_reverie_once` with no thread offload, unlike `chain.py`'s established `asyncio.to_thread` convention for blocking DB/HTTP calls sharing this service's event loop.
  - Fix: wrapped the call in `asyncio.to_thread`.
  - Evidence: `services/orion-thought/app/reverie.py` diff; existing tick-level tests still pass (mocked sync callable works transparently through `to_thread`).
- Finding: the `ALREADY-SETTLED LOOPS` prompt block rendered unconditionally whenever `open_loops` was non-empty, even when no loop actually had a verdict — unnecessary prompt bulk on the vast majority of ticks.
  - Fix: gated on a new deterministic `has_settled_loops` flag computed in `build_reverie_context` (not left to a Jinja `selectattr` filter).
  - Evidence: `test_no_outcome_block_when_no_loop_has_a_verdict` / `test_outcome_block_present_and_instructs_settled_framing` / `test_outcome_block_absent_when_open_loops_is_empty` in the new golden-prompt test file.
- Finding: only context-dict shape was tested; nothing exercised the actual rendered prompt text the model receives — a misworded or silently-dropped instruction would pass every test in the original patch.
  - Fix: added `test_reverie_narrate_prompt_outcomes.py`, rendering the real `reverie_narrate.j2` through `build_reverie_context` and asserting on the rendered text.
  - Evidence: 3 new passing tests in that file.
- Finding (3 independent review angles converged on this): the `theme_key_for()` format change has no backfill for rows already written under the old `"loop:<id>"` key — in-flight refractory suppression and resonance recurrence history would be silently orphaned at the deploy boundary.
  - Fix: added `manual_migration_reverie_theme_key_bare_id_backfill.sql`, an idempotent one-time re-key (upsert-then-delete for the PK-constrained refractory table, plain update for the chain table).
  - Evidence: migration file follows this repo's existing `manual_migration_*.sql` convention exactly (see `manual_migration_substrate_reverie_refractory.sql` for the pattern matched).

Not fixed, accepted and documented: `resonance_monitor.py`'s in-memory tracked-theme set (reconstructed from orion-notify's pending-reason strings) can hold a stale `"loop:<id>"` key for a loop that was actively paging at the exact moment of deploy, missing the next sample under the new bare-id key and firing one spurious "recovered" notification before re-tracking it under the correct key on a later tick. Narrow, one-time, self-healing, and orion-notify's pending-reason state isn't something a SQL backfill on orion-thought's own tables can reach — judged not worth additional code for a single cosmetic notification during the deploy window.

## Restart required

```bash
# 1. Run the backfill once, any time at or after deploying this branch:
psql "$POSTGRES_URI" -f services/orion-sql-db/manual_migration_reverie_theme_key_bare_id_backfill.sql

# 2. Restart orion-thought so the code change takes effect:
docker compose \
  --env-file .env \
  --env-file services/orion-thought/.env \
  -f services/orion-thought/docker-compose.yml \
  up -d --build
```

## Risks / concerns

- Severity: low
- Concern: `resonance_monitor.py`'s orion-notify-string-derived tracked-theme set can emit one spurious "recovered" notification at the exact deploy boundary for a loop that was actively paging (see "Not fixed" note above).
- Mitigation: self-heals on the next tick once a new sample lands under the corrected bare-id key; no data loss, no incorrect suppression — worst case is one misleading notification.

- Severity: low
- Concern: `orion-thought`'s `store.py` now reads a table (`attention_loop_outcome`) owned/written by `orion-hub`, via raw SQL rather than a documented shared API.
- Mitigation: this coupling direction already exists in reverse today (`orion-hub`'s `_reverie_section` already reads `orion-thought`'s `substrate_reverie_thought` table directly) — same established pattern, not a new architectural precedent. Flagged in the design doc (`docs/superpowers/specs/2026-07-14-reverie-narration-continuity-design.md`) as a known, accepted boundary for this thin patch.

## PR link

(filled in by `gh pr create` below)